### PR TITLE
dts: bindings: Update Nordic owned memory bindings

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-memory_map.dtsi
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-memory_map.dtsi
@@ -11,9 +11,7 @@
 			compatible = "nordic,owned-memory";
 			reg = <0x2f010000 DT_SIZE_K(260)>;
 			status = "disabled";
-			perm-read;
-			perm-write;
-			perm-secure;
+			nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RWS>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			ranges = <0x0 0x2f010000 0x41000>;
@@ -35,9 +33,7 @@
 			compatible = "nordic,owned-memory";
 			reg = <0x2f051000 DT_SIZE_K(4)>;
 			status = "disabled";
-			perm-read;
-			perm-write;
-			perm-secure;
+			nordic,access = <NRF_OWNER_ID_RADIOCORE NRF_PERM_RWS>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			ranges = <0x0 0x2f051000 0x1000>;
@@ -55,9 +51,7 @@
 			compatible = "nordic,owned-memory";
 			reg = <0x2f0be000 DT_SIZE_K(4)>;
 			status = "disabled";
-			perm-read;
-			perm-write;
-			perm-secure;
+			nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RWS>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			ranges = <0x0 0x2f0be000 0x1000>;
@@ -72,8 +66,8 @@
 			compatible = "nordic,owned-memory";
 			reg = <0x2f0bf000 DT_SIZE_K(4)>;
 			status = "disabled";
-			perm-read;
-			perm-write;
+			nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RW>,
+					<NRF_OWNER_ID_RADIOCORE NRF_PERM_RW>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			ranges = <0x0 0x2f0bf000 0x1000>;
@@ -111,16 +105,15 @@
 		};
 
 		/*
-		 * NOTE: perm-execute is not required as FLPR has a direct
-		 * bridge with RAM21, bypassing MPC.
+		 * NOTE: FLPR has a direct bridge with RAM21 that bypasses MPC.
+		 * This means that when this region is marked as non-executable,
+		 * only FLPR can execute code from it.
 		 */
 		ram21_region: memory@2f890000 {
 			compatible = "nordic,owned-memory";
 			status = "disabled";
 			reg = <0x2f890000 DT_SIZE_K(64)>;
-			perm-read;
-			perm-write;
-			perm-secure;
+			nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RWS>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			ranges = <0x0 0x2f890000 0x10000>;
@@ -151,9 +144,7 @@
 			compatible = "nordic,owned-memory";
 			reg = <0x2fc00000 DT_SIZE_K(64)>;
 			status = "disabled";
-			perm-read;
-			perm-write;
-			perm-execute;
+			nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RWX>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			ranges = <0x0 0x2fc00000 0x10000>;
@@ -172,29 +163,27 @@
 		};
 
 		shared_ram3x_region: memory@2fc12000 {
-			compatible = "nordic,owned-memory";
 			reg = <0x2fc12000 DT_SIZE_K(8)>;
-			status = "disabled";
-			perm-read;
-			perm-write;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			ranges = <0x0 0x2fc12000 0x2000>;
 
-			cpuapp_dma_region: memory@e80 {
-				compatible = "zephyr,memory-region";
-				reg = <0xe80 DT_SIZE_K(3)>;
+			cpuapp_dma_region: memory@0 {
+				compatible = "nordic,owned-memory", "zephyr,memory-region";
+				reg = <0x0 DT_SIZE_K(4)>;
 				status = "disabled";
 				#memory-region-cells = <0>;
+				nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RW>;
 				zephyr,memory-region = "DMA_RAM3x_APP";
 				zephyr,memory-attr = <( DT_MEM_DMA )>;
 			};
 
-			cpurad_dma_region: memory@1a80 {
-				compatible = "zephyr,memory-region";
-				reg = <0x1a80 0x480>;
+			cpurad_dma_region: memory@1000 {
+				compatible = "nordic,owned-memory", "zephyr,memory-region";
+				reg = <0x1000 DT_SIZE_K(1)>;
 				status = "disabled";
 				#memory-region-cells = <0>;
+				nordic,access = <NRF_OWNER_ID_RADIOCORE NRF_PERM_RW>;
 				zephyr,memory-region = "DMA_RAM3x_RAD";
 				zephyr,memory-attr = <( DT_MEM_DMA )>;
 			};
@@ -206,9 +195,7 @@
 	cpurad_rx_partitions: cpurad-rx-partitions {
 		compatible = "nordic,owned-partitions", "fixed-partitions";
 		status = "disabled";
-		perm-read;
-		perm-execute;
-		perm-secure;
+		nordic,access = <NRF_OWNER_ID_RADIOCORE NRF_PERM_RXS>;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
@@ -220,9 +207,7 @@
 	cpuapp_rx_partitions: cpuapp-rx-partitions {
 		compatible = "nordic,owned-partitions", "fixed-partitions";
 		status = "disabled";
-		perm-read;
-		perm-execute;
-		perm-secure;
+		nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RXS>;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
@@ -242,9 +227,7 @@
 	cpuapp_rw_partitions: cpuapp-rw-partitions {
 		compatible = "nordic,owned-partitions", "fixed-partitions";
 		status = "disabled";
-		perm-read;
-		perm-write;
-		perm-secure;
+		nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RWS>;
 		#address-cells = <1>;
 		#size-cells = <1>;
 

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-memory_map.dtsi
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-memory_map.dtsi
@@ -81,27 +81,20 @@
 			};
 		};
 
-		shared_ram20_region: memory@2f88f000 {
-			reg = <0x2f88f000 DT_SIZE_K(4)>;
-			#address-cells = <1>;
-			#size-cells = <1>;
-			ranges = <0x0 0x2f88f000 0x1000>;
+		cpuapp_cpusys_ipc_shm: memory@2f88fce0 {
+			reg = <0x2f88fce0 0x80>;
+		};
 
-			cpuapp_cpusys_ipc_shm: memory@ce0 {
-				reg = <0xce0 0x80>;
-			};
+		cpusys_cpuapp_ipc_shm: memory@2f88fd60 {
+			reg = <0x2f88fd60 0x80>;
+		};
 
-			cpusys_cpuapp_ipc_shm: memory@d60 {
-				reg = <0xd60 0x80>;
-			};
+		cpurad_cpusys_ipc_shm: memory@2f88fe00 {
+			reg = <0x2f88fe00 0x80>;
+		};
 
-			cpurad_cpusys_ipc_shm: memory@e00 {
-				reg = <0xe00 0x80>;
-			};
-
-			cpusys_cpurad_ipc_shm: memory@e80 {
-				reg = <0xe80 0x80>;
-			};
+		cpusys_cpurad_ipc_shm: memory@2f88fe80 {
+			reg = <0x2f88fe80 0x80>;
 		};
 
 		/*
@@ -162,31 +155,24 @@
 			};
 		};
 
-		shared_ram3x_region: memory@2fc12000 {
-			reg = <0x2fc12000 DT_SIZE_K(8)>;
-			#address-cells = <1>;
-			#size-cells = <1>;
-			ranges = <0x0 0x2fc12000 0x2000>;
+		cpuapp_dma_region: memory@2fc12000 {
+			compatible = "nordic,owned-memory", "zephyr,memory-region";
+			reg = <0x2fc12000 DT_SIZE_K(4)>;
+			status = "disabled";
+			#memory-region-cells = <0>;
+			nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RW>;
+			zephyr,memory-region = "DMA_RAM3x_APP";
+			zephyr,memory-attr = <( DT_MEM_DMA )>;
+		};
 
-			cpuapp_dma_region: memory@0 {
-				compatible = "nordic,owned-memory", "zephyr,memory-region";
-				reg = <0x0 DT_SIZE_K(4)>;
-				status = "disabled";
-				#memory-region-cells = <0>;
-				nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RW>;
-				zephyr,memory-region = "DMA_RAM3x_APP";
-				zephyr,memory-attr = <( DT_MEM_DMA )>;
-			};
-
-			cpurad_dma_region: memory@1000 {
-				compatible = "nordic,owned-memory", "zephyr,memory-region";
-				reg = <0x1000 DT_SIZE_K(1)>;
-				status = "disabled";
-				#memory-region-cells = <0>;
-				nordic,access = <NRF_OWNER_ID_RADIOCORE NRF_PERM_RW>;
-				zephyr,memory-region = "DMA_RAM3x_RAD";
-				zephyr,memory-attr = <( DT_MEM_DMA )>;
-			};
+		cpurad_dma_region: memory@2fc13000 {
+			compatible = "nordic,owned-memory", "zephyr,memory-region";
+			reg = <0x2fc13000 DT_SIZE_K(1)>;
+			status = "disabled";
+			#memory-region-cells = <0>;
+			nordic,access = <NRF_OWNER_ID_RADIOCORE NRF_PERM_RW>;
+			zephyr,memory-region = "DMA_RAM3x_RAD";
+			zephyr,memory-attr = <( DT_MEM_DMA )>;
 		};
 	};
 };

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -116,14 +116,6 @@
 	status = "okay";
 };
 
-&cpuapp_cpurad_ram0x_region {
-	status = "okay";
-};
-
-&shared_ram3x_region {
-	status = "okay";
-};
-
 &ram21_region {
 	status = "okay";
 };

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
@@ -34,10 +34,6 @@
 	};
 };
 
-&shared_ram3x_region {
-	status = "okay";
-};
-
 &cpuapp_cpurad_ram0x_region {
 	status = "okay";
 };

--- a/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280-memory_map.dtsi
+++ b/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280-memory_map.dtsi
@@ -98,27 +98,20 @@
 			};
 		};
 
-		shared_ram20_region: memory@2f88f000 {
-			reg = <0x2f88f000 DT_SIZE_K(4)>;
-			#address-cells = <1>;
-			#size-cells = <1>;
-			ranges = <0x0 0x2f88f000 0x1000>;
+		cpuapp_cpusys_ipc_shm: memory@2f88fce0 {
+			reg = <0x2f88fce0 0x80>;
+		};
 
-			cpuapp_cpusys_ipc_shm: memory@ce0 {
-				reg = <0xce0 0x80>;
-			};
+		cpusys_cpuapp_ipc_shm: memory@2f88fd60 {
+			reg = <0x2f88fd60 0x80>;
+		};
 
-			cpusys_cpuapp_ipc_shm: memory@d60 {
-				reg = <0xd60 0x80>;
-			};
+		cpurad_cpusys_ipc_shm: memory@2f88fe00 {
+			reg = <0x2f88fe00 0x80>;
+		};
 
-			cpurad_cpusys_ipc_shm: memory@e00 {
-				reg = <0xe00 0x80>;
-			};
-
-			cpusys_cpurad_ipc_shm: memory@e80 {
-				reg = <0xe80 0x80>;
-			};
+		cpusys_cpurad_ipc_shm: memory@2f88fe80 {
+			reg = <0x2f88fe80 0x80>;
 		};
 
 		ram21_region: memory@2f890000 {
@@ -162,31 +155,24 @@
 			};
 		};
 
-		shared_ram3x_region: memory@2fc06000 {
-			reg = <0x2fc06000 DT_SIZE_K(8)>;
-			#address-cells = <1>;
-			#size-cells = <1>;
-			ranges = <0x0 0x2fc06000 0x4000>;
+		cpuapp_dma_region: memory@2fc06000 {
+			compatible = "nordic,owned-memory", "zephyr,memory-region";
+			reg = <0x2fc06000 DT_SIZE_K(4)>;
+			status = "disabled";
+			#memory-region-cells = <0>;
+			nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RW>;
+			zephyr,memory-region = "DMA_RAM3x_APP";
+			zephyr,memory-attr = <( DT_MEM_DMA )>;
+		};
 
-			cpuapp_dma_region: memory@0 {
-				compatible = "nordic,owned-memory", "zephyr,memory-region";
-				reg = <0x0 DT_SIZE_K(4)>;
-				status = "disabled";
-				#memory-region-cells = <0>;
-				nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RW>;
-				zephyr,memory-region = "DMA_RAM3x_APP";
-				zephyr,memory-attr = <( DT_MEM_DMA )>;
-			};
-
-			cpurad_dma_region: memory@1000 {
-				compatible = "nordic,owned-memory", "zephyr,memory-region";
-				reg = <0x1000 DT_SIZE_K(1)>;
-				status = "disabled";
-				#memory-region-cells = <0>;
-				nordic,access = <NRF_OWNER_ID_RADIOCORE NRF_PERM_RW>;
-				zephyr,memory-region = "DMA_RAM3x_RAD";
-				zephyr,memory-attr = <( DT_MEM_DMA )>;
-			};
+		cpurad_dma_region: memory@2fc07000 {
+			compatible = "nordic,owned-memory", "zephyr,memory-region";
+			reg = <0x2fc07000 DT_SIZE_K(1)>;
+			status = "disabled";
+			#memory-region-cells = <0>;
+			nordic,access = <NRF_OWNER_ID_RADIOCORE NRF_PERM_RW>;
+			zephyr,memory-region = "DMA_RAM3x_RAD";
+			zephyr,memory-attr = <( DT_MEM_DMA )>;
 		};
 	};
 };

--- a/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280-memory_map.dtsi
+++ b/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280-memory_map.dtsi
@@ -15,9 +15,7 @@
 			compatible = "nordic,owned-memory";
 			reg = <0x2f011000 DT_SIZE_K(4)>;
 			status = "disabled";
-			perm-read;
-			perm-write;
-			perm-secure;
+			nordic,access = <NRF_OWNER_ID_RADIOCORE NRF_PERM_RWS>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			ranges = <0x0 0x2f011000 0x1000>;
@@ -35,9 +33,7 @@
 			compatible = "nordic,owned-memory";
 			reg = <0x2f012000 DT_SIZE_K(516)>;
 			status = "disabled";
-			perm-read;
-			perm-write;
-			perm-secure;
+			nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RWS>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			ranges = <0x0 0x2f012000 0x81000>;
@@ -59,8 +55,8 @@
 			compatible = "nordic,owned-memory";
 			reg = <0x2f0cf000 DT_SIZE_K(4)>;
 			status = "disabled";
-			perm-read;
-			perm-write;
+			nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RW>,
+					<NRF_OWNER_ID_RADIOCORE NRF_PERM_RW>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			ranges = <0x0 0x2f0cf000 0x1000>;
@@ -75,8 +71,11 @@
 		};
 
 		cpuapp_cpucell_ram0x_region: memory@2f0d0000 {
+			compatible = "nordic,owned-memory";
 			reg = <0x2f0d0000 DT_SIZE_K(36)>;
 			status = "disabled";
+			nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RW>,
+					<NRF_OWNER_ID_CELL NRF_PERM_RW>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			ranges = <0x0 0x2f0d0000 0x9000>;
@@ -97,31 +96,6 @@
 			cpucell_cpuapp_ipc_shm_heap: memory@5000 {
 				reg = <0x5000 0x4000>;
 			};
-		};
-
-		/* Shared memory ownership.
-		 * TODO:
-		 * remove these two after https://github.com/zephyrproject-rtos/zephyr/pull/72273
-		 * and let cpuapp_cpucell_ram0x_region use the `access` binding to describe
-		 * the shared memory ownership.
-		 */
-
-		cpuapp_cpucell_ipc_shm: memory@2 {
-			compatible = "nordic,owned-memory";
-			reg = <0x2f0d0000 DT_SIZE_K(36)>;
-			owner-id = <2>;
-			perm-read;
-			perm-write;
-			status = "disabled";
-		};
-
-		cpucell_cpuapp_ipc_shm: memory@4 {
-			compatible = "nordic,owned-memory";
-			reg = <0x2f0d0000 DT_SIZE_K(36)>;
-			owner-id = <4>;
-			perm-read;
-			perm-write;
-			status = "disabled";
 		};
 
 		shared_ram20_region: memory@2f88f000 {
@@ -151,9 +125,7 @@
 			compatible = "nordic,owned-memory";
 			status = "disabled";
 			reg = <0x2f890000 DT_SIZE_K(32)>;
-			perm-read;
-			perm-write;
-			perm-secure;
+			nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RWS>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			ranges = <0x0 0x2f890000 0x8000>;
@@ -172,9 +144,7 @@
 			compatible = "nordic,owned-memory";
 			reg = <0x2fc00000 DT_SIZE_K(24)>;
 			status = "disabled";
-			perm-read;
-			perm-write;
-			perm-execute;
+			nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RWX>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			ranges = <0x0 0x2fc00000 0x6000>;
@@ -193,29 +163,27 @@
 		};
 
 		shared_ram3x_region: memory@2fc06000 {
-			compatible = "nordic,owned-memory";
 			reg = <0x2fc06000 DT_SIZE_K(8)>;
-			status = "disabled";
-			perm-read;
-			perm-write;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			ranges = <0x0 0x2fc06000 0x4000>;
 
 			cpuapp_dma_region: memory@0 {
-				compatible = "zephyr,memory-region";
+				compatible = "nordic,owned-memory", "zephyr,memory-region";
 				reg = <0x0 DT_SIZE_K(4)>;
 				status = "disabled";
 				#memory-region-cells = <0>;
+				nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RW>;
 				zephyr,memory-region = "DMA_RAM3x_APP";
 				zephyr,memory-attr = <( DT_MEM_DMA )>;
 			};
 
 			cpurad_dma_region: memory@1000 {
-				compatible = "zephyr,memory-region";
-				reg = <0x1000 0x80>;
+				compatible = "nordic,owned-memory", "zephyr,memory-region";
+				reg = <0x1000 DT_SIZE_K(1)>;
 				status = "disabled";
 				#memory-region-cells = <0>;
+				nordic,access = <NRF_OWNER_ID_RADIOCORE NRF_PERM_RW>;
 				zephyr,memory-region = "DMA_RAM3x_RAD";
 				zephyr,memory-attr = <( DT_MEM_DMA )>;
 			};
@@ -227,9 +195,7 @@
 	cpurad_rx_partitions: cpurad-rx-partitions {
 		compatible = "nordic,owned-partitions", "fixed-partitions";
 		status = "disabled";
-		perm-read;
-		perm-execute;
-		perm-secure;
+		nordic,access = <NRF_OWNER_ID_RADIOCORE NRF_PERM_RXS>;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
@@ -241,9 +207,7 @@
 	cpuapp_rx_partitions: cpuapp-rx-partitions {
 		compatible = "nordic,owned-partitions", "fixed-partitions";
 		status = "disabled";
-		perm-read;
-		perm-execute;
-		perm-secure;
+		nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RXS>;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
@@ -259,9 +223,7 @@
 	cpuapp_rw_partitions: cpuapp-rw-partitions {
 		compatible = "nordic,owned-partitions", "fixed-partitions";
 		status = "disabled";
-		perm-read;
-		perm-write;
-		perm-secure;
+		nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RWS>;
 		#address-cells = <1>;
 		#size-cells = <1>;
 

--- a/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280_cpuapp.dts
+++ b/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280_cpuapp.dts
@@ -114,19 +114,7 @@
 	status = "okay";
 };
 
-&cpuapp_cpurad_ram0x_region {
-	status = "okay";
-};
-
-&cpuapp_cpucell_ipc_shm {
-	status = "okay";
-};
-
-&cpucell_cpuapp_ipc_shm {
-	status = "okay";
-};
-
-&shared_ram3x_region {
+&cpuapp_cpucell_ram0x_region {
 	status = "okay";
 };
 

--- a/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280_cpurad.dts
+++ b/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280_cpurad.dts
@@ -35,10 +35,6 @@
 	};
 };
 
-&shared_ram3x_region {
-	status = "okay";
-};
-
 &cpuapp_cpurad_ram0x_region {
 	status = "okay";
 };

--- a/dts/bindings/mtd/nordic,owned-partitions.yaml
+++ b/dts/bindings/mtd/nordic,owned-partitions.yaml
@@ -24,8 +24,7 @@ description: |
 
         rx-partitions {
             compatible = "nordic,owned-partitions";
-            perm-read;
-            perm-execute;
+            nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RX>;
             #address-cells = <1>;
             #size-cells = <1>;
 
@@ -37,8 +36,7 @@ description: |
 
         rw-partitions {
             compatible = "nordic,owned-partitions";
-            perm-read;
-            perm-write;
+            nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RW>;
             #address-cells = <1>;
             #size-cells = <1>;
 

--- a/dts/bindings/reserved-memory/nordic,owned-memory.yaml
+++ b/dts/bindings/reserved-memory/nordic,owned-memory.yaml
@@ -8,17 +8,64 @@ description: |
   will be recorded in the UICR of the compiled domain. Memory ownership and
   access is then configured for the domain at boot time, based on the UICR.
 
+  Example:
+
+    reserved-memory {
+        memory@2fc00000 {
+            compatible = "nordic,owned-memory";
+            reg = <0x2fc00000 0x1000>;
+            status = "okay";
+            nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_R>,
+                            <NRF_OWNER_ID_RADIOCORE NRF_PERM_W>;
+        };
+    };
+
+  A single local domain can request a memory region to be reserved on behalf of
+  multiple access owners. A single memory region shall be reserved by at most
+  one domain, by setting status "okay" on the associated node. For example, if
+  the region defined above is enabled by Application on behalf of Radiocore,
+  then the Radiocore's devicetree must set status "disabled" on that node.
+
+  Each of the different owners may have a different set of permissions granted,
+  as also shown above.
+
+  Note: one domain can also reserve memory for another domain and not itself.
+  Whichever domain has status "okay" set on the node does not need to be listed
+  as one of the access owners.
+
 compatible: "nordic,owned-memory"
 
-include: base.yaml
+include: [base.yaml, "zephyr,memory-common.yaml"]
 
 properties:
   reg:
     required: true
 
+  nordic,access:
+    type: array
+    description: |
+      Array of (owner-id, permission-flags) pairs, where:
+
+      - Owner ID represents the domain that will have access to this memory.
+        Valid values can be found in dts/common/nordic/<soc>.dtsi,
+        where they are defined as NRF_OWNER_ID_*
+
+      - Permissions are encoded as a 32-bit bitfield, using the flags found in
+        include/zephyr/dt-bindings/reserved-memory/nordic-owned-memory.h,
+        where they are defined as NRF_PERM_*
+
+        The same file defines all possible permission flag combinations.
+        For example, one can use:
+          <NRF_OWNER_ID_APPLICATION NRF_PERM_RWX>
+
+        as a shorthand for:
+          <NRF_OWNER_ID_APPLICATION (NRF_PERM_R | NRF_PERM_W | NRF_PERM_X)>
+
   owner-id:
     type: int
+    deprecated: true
     description: |
+      Deprecated, applies only if 'nordic,access' is not defined.
       Owner ID of the domain that will own this memory region. If not defined,
       the ownership will default to the domain being compiled.
 
@@ -27,20 +74,35 @@ properties:
 
   perm-read:
     type: boolean
-    description: Owner has read access to the region.
+    deprecated: true
+    description: |
+      Deprecated, applies only if 'nordic,access' is not defined.
+      Owner has read access to the region.
 
   perm-write:
     type: boolean
-    description: Owner has write access to the region.
+    deprecated: true
+    description: |
+      Deprecated, applies only if 'nordic,access' is not defined.
+      Owner has write access to the region.
 
   perm-execute:
     type: boolean
-    description: Owner can execute code from the region.
+    deprecated: true
+    description: |
+      Deprecated, applies only if 'nordic,access' is not defined.
+      Owner can execute code from the region.
 
   perm-secure:
     type: boolean
-    description: Owner has secure-only access to the region.
+    deprecated: true
+    description: |
+      Deprecated, applies only if 'nordic,access' is not defined.
+      Owner has secure-only access to the region.
 
   non-secure-callable:
     type: boolean
-    description: Memory region is used for non-secure-callable code.
+    deprecated: true
+    description: |
+      Deprecated, applies only if 'nordic,access' is not defined.
+      Memory region is used for non-secure-callable code.

--- a/dts/common/nordic/nrf54h20.dtsi
+++ b/dts/common/nordic/nrf54h20.dtsi
@@ -11,6 +11,7 @@
 #include <zephyr/dt-bindings/misc/nordic-domain-id-nrf54h20.h>
 #include <zephyr/dt-bindings/misc/nordic-owner-id-nrf54h20.h>
 #include <zephyr/dt-bindings/misc/nordic-tddconf.h>
+#include <zephyr/dt-bindings/reserved-memory/nordic-owned-memory.h>
 
 /delete-node/ &sw_pwm;
 

--- a/dts/common/nordic/nrf9280.dtsi
+++ b/dts/common/nordic/nrf9280.dtsi
@@ -10,6 +10,7 @@
 #include <zephyr/dt-bindings/misc/nordic-nrf-ficr-nrf9230-engb.h>
 #include <zephyr/dt-bindings/misc/nordic-domain-id-nrf9230.h>
 #include <zephyr/dt-bindings/misc/nordic-owner-id-nrf9230.h>
+#include <zephyr/dt-bindings/reserved-memory/nordic-owned-memory.h>
 
 /delete-node/ &sw_pwm;
 

--- a/include/zephyr/dt-bindings/reserved-memory/nordic-owned-memory.h
+++ b/include/zephyr/dt-bindings/reserved-memory/nordic-owned-memory.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_RESERVED_MEMORY_NORDIC_OWNED_MEMORY_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_RESERVED_MEMORY_NORDIC_OWNED_MEMORY_H_
+
+#include <zephyr/dt-bindings/dt-util.h>
+
+/**
+ * @name Basic memory permission flags.
+ * @{
+ */
+
+/** Readable. */
+#define NRF_PERM_R BIT(0)
+/** Writable. */
+#define NRF_PERM_W BIT(1)
+/** Executable. */
+#define NRF_PERM_X BIT(2)
+/** Secure-only. */
+#define NRF_PERM_S BIT(3)
+/** Non-secure-callable. */
+#define NRF_PERM_NSC BIT(4)
+
+/**
+ * @}
+ */
+
+/**
+ * @name Memory permission flag combinations.
+ * @note NRF_PERM_NSC overrides all other flags, so it is not included here.
+ * @{
+ */
+
+#define NRF_PERM_RW   (NRF_PERM_R | NRF_PERM_W)
+#define NRF_PERM_RX   (NRF_PERM_R | NRF_PERM_X)
+#define NRF_PERM_RS   (NRF_PERM_R | NRF_PERM_S)
+#define NRF_PERM_WX   (NRF_PERM_W | NRF_PERM_X)
+#define NRF_PERM_WS   (NRF_PERM_W | NRF_PERM_S)
+#define NRF_PERM_XS   (NRF_PERM_X | NRF_PERM_S)
+#define NRF_PERM_RWX  (NRF_PERM_R | NRF_PERM_W | NRF_PERM_X)
+#define NRF_PERM_RWS  (NRF_PERM_R | NRF_PERM_W | NRF_PERM_S)
+#define NRF_PERM_RXS  (NRF_PERM_R | NRF_PERM_X | NRF_PERM_S)
+#define NRF_PERM_WXS  (NRF_PERM_W | NRF_PERM_X | NRF_PERM_S)
+#define NRF_PERM_RWXS (NRF_PERM_R | NRF_PERM_W | NRF_PERM_X | NRF_PERM_S)
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_RESERVED_MEMORY_NORDIC_OWNED_MEMORY_H_ */

--- a/tests/arch/common/ramfunc/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/arch/common/ramfunc/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -4,5 +4,5 @@
  */
 
 &cpuapp_ram0x_region {
-	perm-execute;
+	nordic,access = <NRF_OWNER_ID_APPLICATION NRF_PERM_RWXS>;
 };

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_cpurad.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_cpurad.overlay
@@ -5,11 +5,6 @@
  */
 #include "nrf54h20dk_nrf54h20_common.dtsi"
 
-/* Increase dma region to fit dmm heap. */
-&cpurad_dma_region {
-	reg = <0x1e80 0x100>;
-};
-
 &spi130 {
 	memory-regions = <&cpurad_dma_region>;
 };

--- a/tests/drivers/spi/spi_error_cases/boards/nrf54h20dk_nrf54h20_cpuppr_launcher.overlay
+++ b/tests/drivers/spi/spi_error_cases/boards/nrf54h20dk_nrf54h20_cpuppr_launcher.overlay
@@ -14,10 +14,6 @@
 	interrupt-parent = <&cpuppr_clic>;
 };
 
-&shared_ram3x_region {
-	status = "okay";
-};
-
 &gpio0 {
 	status = "reserved";
 };

--- a/tests/drivers/uart/uart_mix_fifo_poll/boards/nrf54h20dk_nrf54h20_cpurad.overlay
+++ b/tests/drivers/uart/uart_mix_fifo_poll/boards/nrf54h20dk_nrf54h20_cpurad.overlay
@@ -2,11 +2,6 @@
 
 #include "nrf54h20dk_nrf54h20_common.dtsi"
 
-&cpurad_dma_region {
-	/* Default space is not enough. */
-	reg = <0x1e80 0x100>;
-};
-
 &dut {
 	memory-regions = <&cpurad_dma_region>;
 };


### PR DESCRIPTION
This concerns both `nordic,owned-memory` and `nordic,owned-partitions`.

Introduce a property named `nordic,access`, which is meant to replace
the `owner-id` and `perm-*` properties. It allows for describing how
multiple domains should access a single memory region, possibly with
different permissions per owner, but without having to create more than
one DT node for this purpose.

This change is also motivated by updated memory protection requirements
on the nRF54H20, which mandate that a given memory region must only be
reserved by one domain, even if multiple domains can have access to it.
This restriction is now described in the binding itself.