### PR TITLE
Bluetooth: Controller: Fix BIS target_event truncated to 8 bits

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -5998,7 +5998,7 @@ int hci_iso_handle(struct net_buf *buf, struct net_buf **evt)
 						   ISO_INT_UNIT_US));
 
 #else /* !CONFIG_BT_CTLR_ISOAL_PSN_IGNORE */
-		uint8_t target_event;
+		uint64_t target_event;
 		uint8_t event_offset;
 
 		/* Determine the target event and the first event offset after


### PR DESCRIPTION
The target_event value is up to 39-bits but was put into a uint8_t