### PR TITLE
net: lwm2m: Fix pull-context on queue mode

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -681,8 +681,8 @@ static int socket_recv_message(struct lwm2m_ctx *client_ctx)
 	static struct sockaddr from_addr;
 
 	from_addr_len = sizeof(from_addr);
-	len = zsock_recvfrom(client_ctx->sock_fd, in_buf, sizeof(in_buf) - 1, 0, &from_addr,
-			     &from_addr_len);
+	len = zsock_recvfrom(client_ctx->sock_fd, in_buf, sizeof(in_buf) - 1, ZSOCK_MSG_DONTWAIT,
+			     &from_addr, &from_addr_len);
 
 	if (len < 0) {
 		if (errno == EAGAIN || errno == EWOULDBLOCK) {


### PR DESCRIPTION
Two issues fixed:
When pull-context is created, it does not have to wake up the RD client context. Ignore the EPERM warning.

When new pull-context creates a new socket, sometimes socket-loop gets to recvfrom() before we have set O_NONBLOCK on the socket. So use ZSOCK_MSG_DONTWAIT on zsock_recvfrom() so it does not block the socket loop.

Fixes #71450

@laurin  Please review.
