### PR TITLE
tests/kernel/context: Detect spurious wakes during timeout check

### DIFF
--- a/tests/kernel/context/src/main.c
+++ b/tests/kernel/context/src/main.c
@@ -245,6 +245,9 @@ static void _test_kernel_cpu_idle(int atomic)
 				k_cpu_idle();
 			}
 		} while ((idle_loops++ < CONFIG_MAX_IDLE_WAKES) && (idle_timer_done == false));
+		zassert_true(idle_timer_done,
+			     "The CPU was waken spuriously too many times (%d > %d)",
+			     idle_loops, CONFIG_MAX_IDLE_WAKES);
 		dt = k_uptime_ticks() - t0;
 		zassert_true(abs((int32_t) (dt - dur)) <= slop,
 			     "Inaccurate wakeup, idled for %d ticks, expected %d",


### PR DESCRIPTION
This test checks that a timer timeout keeps the CPU sleeping for the right amount of time.
How this was done though, a system timer driver which wakes the kernel spuriously a bit before the
correct deadline would not be detected, even though it should.

Let's fix this, ensuring the timer callback has been called when we check the wake time in inside the expected range.
