### PR TITLE
boards: esp32: don't enable spiram for mcuboot

### DIFF
--- a/boards/espressif/esp32_ethernet_kit/Kconfig.defconfig
+++ b/boards/espressif/esp32_ethernet_kit/Kconfig.defconfig
@@ -6,7 +6,7 @@
 if BOARD_ESP32_ETHERNET_KIT_ESP32_PROCPU
 
 config ESP_SPIRAM
-	default y
+	default y if !MCUBOOT
 
 choice SPIRAM_TYPE
 	default SPIRAM_TYPE_ESPPSRAM64

--- a/boards/hardkernel/odroid_go/Kconfig.defconfig
+++ b/boards/hardkernel/odroid_go/Kconfig.defconfig
@@ -12,7 +12,7 @@ config SPI
 	default y if DISK_DRIVER_SDMMC
 
 config ESP_SPIRAM
-	default y
+	default y if !MCUBOOT
 
 choice SPIRAM_TYPE
 	default SPIRAM_TYPE_ESPPSRAM64


### PR DESCRIPTION
Don't enable ESP_SPIRAM for mcuboot.

The condition in `soc/espressif/common/Kconfig.spiram` is overwritten by the `Kconfig.defconfig` in the boards directory.