### PR TITLE
tests: i2c: i2c_target_api: fix b_u585i_iot02a test

### DIFF
--- a/tests/drivers/i2c/i2c_target_api/boards/b_u585i_iot02a.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/b_u585i_iot02a.overlay
@@ -10,6 +10,8 @@
  * Short Pin PB9 to PH5, and PB8 to PH4, for the test to pass.
  */
 
+/delete-node/ &eeprom0;
+
 &i2c1 {
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";


### PR DESCRIPTION
The b_u585i_iot02a platform already has an 'eeprom0' node in the default devicetree. Delete the default node so that the overlay can define the nodes needed for the test.

This fixes test which seems to have been broken as result of following commit e69d5d83d3aec5e7fce88a1dd1181086405b392f
