### PR TITLE
drivers: adc: Place API into iterable section

### DIFF
--- a/doc/kernel/drivers/index.rst
+++ b/doc/kernel/drivers/index.rst
@@ -61,6 +61,8 @@ High-level calls accessed through device-specific APIs, such as
 :file:`i2c.h` or :file:`spi.h`, are usually intended as synchronous. Thus,
 these calls should be blocking.
 
+.. _device_driver_api:
+
 Driver APIs
 ***********
 

--- a/doc/releases/migration-guide-4.1.rst
+++ b/doc/releases/migration-guide-4.1.rst
@@ -57,6 +57,13 @@ LVGL
 Device Drivers and Devicetree
 *****************************
 
+* Device driver APIs are placed into iterable sections (:github:`71773`) to allow for runtime
+  checking. See :ref:`device_driver_api` for more details.
+  The :c:macro:`DEVICE_API()` macro should be used by out-of-tree driver implementations for
+  the following driver classes:
+
+    * :c:struct:`adc_driver_api`
+
 Controller Area Network (CAN)
 =============================
 

--- a/drivers/adc/adc_ad559x.c
+++ b/drivers/adc/adc_ad559x.c
@@ -297,7 +297,7 @@ static int adc_ad559x_init(const struct device *dev)
 #endif
 
 #define ADC_AD559X_DRIVER_API(inst)                                                                \
-	static const struct adc_driver_api adc_ad559x_api##inst = {                                \
+	static DEVICE_API(adc, adc_ad559x_api##inst) = {                                           \
 		.channel_setup = adc_ad559x_channel_setup,                                         \
 		.read = adc_ad559x_read,                                                           \
 		.ref_internal = AD559X_ADC_VREF_MV * (1 + DT_INST_PROP(inst, double_input_range)), \

--- a/drivers/adc/adc_ads1112.c
+++ b/drivers/adc/adc_ads1112.c
@@ -379,7 +379,7 @@ static int ads1112_init(const struct device *dev)
 	return rc;
 }
 
-static const struct adc_driver_api api = {
+static DEVICE_API(adc, api) = {
 	.channel_setup = ads1112_channel_setup,
 	.read = ads1112_read,
 	.ref_internal = ADS1112_REF_INTERNAL,

--- a/drivers/adc/adc_ads1119.c
+++ b/drivers/adc/adc_ads1119.c
@@ -481,7 +481,7 @@ static int ads1119_init(const struct device *dev)
 	return rc;
 }
 
-static const struct adc_driver_api api = {
+static DEVICE_API(adc, api) = {
 	.channel_setup = ads1119_channel_setup,
 	.read = ads1119_read,
 	.ref_internal = ADS1119_REF_INTERNAL,

--- a/drivers/adc/adc_ads114s0x.c
+++ b/drivers/adc/adc_ads114s0x.c
@@ -1472,7 +1472,7 @@ static int ads114s0x_init(const struct device *dev)
 	return result;
 }
 
-static const struct adc_driver_api api = {
+static DEVICE_API(adc, api) = {
 	.channel_setup = ads114s0x_channel_setup,
 	.read = ads114s0x_read,
 	.ref_internal = ADS114S0X_REF_INTERNAL,

--- a/drivers/adc/adc_ads1x1x.c
+++ b/drivers/adc/adc_ads1x1x.c
@@ -786,7 +786,7 @@ static int ads1x1x_init(const struct device *dev)
 	return 0;
 }
 
-static const struct adc_driver_api ads1x1x_api = {
+static DEVICE_API(adc, ads1x1x_api) = {
 	.channel_setup = ads1x1x_channel_setup,
 	.read = ads1x1x_read,
 	.ref_internal = 2048,

--- a/drivers/adc/adc_ads7052.c
+++ b/drivers/adc/adc_ads7052.c
@@ -284,7 +284,7 @@ static int adc_ads7052_init(const struct device *dev)
 	return 0;
 }
 
-static const struct adc_driver_api ads7052_api = {
+static DEVICE_API(adc, ads7052_api) = {
 	.channel_setup = adc_ads7052_channel_setup,
 	.read = adc_ads7052_read,
 #ifdef CONFIG_ADC_ASYNC

--- a/drivers/adc/adc_ambiq.c
+++ b/drivers/adc/adc_ambiq.c
@@ -386,7 +386,7 @@ static int adc_ambiq_pm_action(const struct device *dev, enum pm_device_action a
 
 #ifdef CONFIG_ADC_ASYNC
 #define ADC_AMBIQ_DRIVER_API(n)                                                                    \
-	static const struct adc_driver_api adc_ambiq_driver_api_##n = {                            \
+	static DEVICE_API(adc, adc_ambiq_driver_api_##n) = {                                       \
 		.channel_setup = adc_ambiq_channel_setup,                                          \
 		.read = adc_ambiq_read,                                                            \
 		.read_async = adc_ambiq_read_async,                                                \
@@ -394,7 +394,7 @@ static int adc_ambiq_pm_action(const struct device *dev, enum pm_device_action a
 	};
 #else
 #define ADC_AMBIQ_DRIVER_API(n)                                                                    \
-	static const struct adc_driver_api adc_ambiq_driver_api_##n = {                            \
+	static DEVICE_API(adc, adc_ambiq_driver_api_##n) = {                                       \
 		.channel_setup = adc_ambiq_channel_setup,                                          \
 		.read = adc_ambiq_read,                                                            \
 		.ref_internal = DT_INST_PROP(n, internal_vref_mv),                                 \

--- a/drivers/adc/adc_b91.c
+++ b/drivers/adc/adc_b91.c
@@ -452,7 +452,7 @@ static const struct b91_adc_cfg cfg_0 = {
 	.vref_internal_mv = DT_INST_PROP(0, vref_internal_mv),
 };
 
-static const struct adc_driver_api adc_b91_driver_api = {
+static DEVICE_API(adc, adc_b91_driver_api) = {
 	.channel_setup = adc_b91_channel_setup,
 	.read = adc_b91_read,
 #ifdef CONFIG_ADC_ASYNC

--- a/drivers/adc/adc_cc13xx_cc26xx.c
+++ b/drivers/adc/adc_cc13xx_cc26xx.c
@@ -274,7 +274,7 @@ static void adc_cc13xx_cc26xx_isr(const struct device *dev)
 	adc_context_on_sampling_done(&data->ctx, dev);
 }
 
-static const struct adc_driver_api cc13xx_cc26xx_driver_api = {
+static DEVICE_API(adc, cc13xx_cc26xx_driver_api) = {
 	.channel_setup = adc_cc13xx_cc26xx_channel_setup,
 	.read = adc_cc13xx_cc26xx_read,
 #ifdef CONFIG_ADC_ASYNC

--- a/drivers/adc/adc_cc32xx.c
+++ b/drivers/adc/adc_cc32xx.c
@@ -279,7 +279,7 @@ static void adc_cc32xx_isr_ch3(const struct device *dev)
 	adc_cc32xx_isr(dev, 3);
 }
 
-static const struct adc_driver_api cc32xx_driver_api = {
+static DEVICE_API(adc, cc32xx_driver_api) = {
 	.channel_setup = adc_cc32xx_channel_setup,
 	.read = adc_cc32xx_read,
 #ifdef CONFIG_ADC_ASYNC

--- a/drivers/adc/adc_emul.c
+++ b/drivers/adc/adc_emul.c
@@ -546,7 +546,7 @@ static int adc_emul_init(const struct device *dev)
 }
 
 #define ADC_EMUL_INIT(_num)						\
-	static const struct adc_driver_api adc_emul_api_##_num = {	\
+	static DEVICE_API(adc, adc_emul_api_##_num) = {			\
 		.channel_setup = adc_emul_channel_setup,		\
 		.read = adc_emul_read,					\
 		.ref_internal = DT_INST_PROP(_num, ref_internal_mv),	\

--- a/drivers/adc/adc_emul.c
+++ b/drivers/adc/adc_emul.c
@@ -155,7 +155,6 @@ int adc_emul_value_func_set(const struct device *dev, unsigned int chan,
 int adc_emul_ref_voltage_set(const struct device *dev, enum adc_reference ref,
 			     uint16_t value)
 {
-	struct adc_driver_api *api = (struct adc_driver_api *)dev->api;
 	struct adc_emul_data *data = dev->data;
 	int err = 0;
 
@@ -167,7 +166,6 @@ int adc_emul_ref_voltage_set(const struct device *dev, enum adc_reference ref,
 		break;
 	case ADC_REF_INTERNAL:
 		data->ref_int = value;
-		api->ref_internal = value;
 		break;
 	case ADC_REF_EXTERNAL0:
 		data->ref_ext0 = value;
@@ -548,7 +546,7 @@ static int adc_emul_init(const struct device *dev)
 }
 
 #define ADC_EMUL_INIT(_num)						\
-	static struct adc_driver_api adc_emul_api_##_num = {		\
+	static const struct adc_driver_api adc_emul_api_##_num = {	\
 		.channel_setup = adc_emul_channel_setup,		\
 		.read = adc_emul_read,					\
 		.ref_internal = DT_INST_PROP(_num, ref_internal_mv),	\

--- a/drivers/adc/adc_ene_kb1200.c
+++ b/drivers/adc/adc_ene_kb1200.c
@@ -212,7 +212,7 @@ static void adc_context_update_buffer_pointer(struct adc_context *ctx, bool repe
 	}
 }
 
-struct adc_driver_api adc_kb1200_api = {
+static DEVICE_API(adc, adc_kb1200_api) = {
 	.channel_setup = adc_kb1200_channel_setup,
 	.read = adc_kb1200_read,
 	.ref_internal = ADC_VREF_ANALOG,

--- a/drivers/adc/adc_esp32.c
+++ b/drivers/adc/adc_esp32.c
@@ -706,7 +706,7 @@ static int adc_esp32_init(const struct device *dev)
 	return 0;
 }
 
-static const struct adc_driver_api api_esp32_driver_api = {
+static DEVICE_API(adc, api_esp32_driver_api) = {
 	.channel_setup = adc_esp32_channel_setup,
 	.read          = adc_esp32_read,
 #ifdef CONFIG_ADC_ASYNC

--- a/drivers/adc/adc_gd32.c
+++ b/drivers/adc/adc_gd32.c
@@ -356,7 +356,7 @@ static int adc_gd32_read_async(const struct device *dev,
 }
 #endif /* CONFIG_ADC_ASYNC */
 
-static struct adc_driver_api adc_gd32_driver_api = {
+static DEVICE_API(adc, adc_gd32_driver_api) = {
 	.channel_setup = adc_gd32_channel_setup,
 	.read = adc_gd32_read,
 #ifdef CONFIG_ADC_ASYNC

--- a/drivers/adc/adc_gecko.c
+++ b/drivers/adc/adc_gecko.c
@@ -280,7 +280,7 @@ static int adc_gecko_init(const struct device *dev)
 	return 0;
 }
 
-static const struct adc_driver_api api_gecko_adc_driver_api = {
+static DEVICE_API(adc, api_gecko_adc_driver_api) = {
 	.channel_setup = adc_gecko_channel_setup,
 	.read = adc_gecko_read,
 };

--- a/drivers/adc/adc_ifx_cat1.c
+++ b/drivers/adc/adc_ifx_cat1.c
@@ -266,7 +266,7 @@ static int ifx_cat1_adc_init(const struct device *dev)
 	return 0;
 }
 
-static const struct adc_driver_api adc_cat1_driver_api = {
+static DEVICE_API(adc, adc_cat1_driver_api) = {
 	.channel_setup = ifx_cat1_adc_channel_setup,
 	.read = ifx_cat1_adc_read,
 	#ifdef CONFIG_ADC_ASYNC

--- a/drivers/adc/adc_ite_it8xxx2.c
+++ b/drivers/adc/adc_ite_it8xxx2.c
@@ -387,7 +387,7 @@ static void adc_it8xxx2_isr(const struct device *dev)
 	k_sem_give(&data->sem);
 }
 
-static const struct adc_driver_api api_it8xxx2_driver_api = {
+static DEVICE_API(adc, api_it8xxx2_driver_api) = {
 	.channel_setup = adc_it8xxx2_channel_setup,
 	.read = adc_it8xxx2_read,
 #ifdef CONFIG_ADC_ASYNC

--- a/drivers/adc/adc_lmp90xxx.c
+++ b/drivers/adc/adc_lmp90xxx.c
@@ -1036,7 +1036,7 @@ static int lmp90xxx_init(const struct device *dev)
 	return 0;
 }
 
-static const struct adc_driver_api lmp90xxx_adc_api = {
+static DEVICE_API(adc, lmp90xxx_adc_api) = {
 	.channel_setup = lmp90xxx_adc_channel_setup,
 	.read = lmp90xxx_adc_read,
 #ifdef CONFIG_ADC_ASYNC

--- a/drivers/adc/adc_ltc2451.c
+++ b/drivers/adc/adc_ltc2451.c
@@ -87,7 +87,7 @@ static int ltc2451_init(const struct device *dev)
 	return ltc2451_set_conversion_speed(dev, config->conversion_speed);
 }
 
-static const struct adc_driver_api ltc2451_api = {
+static DEVICE_API(adc, ltc2451_api) = {
 	.channel_setup = ltc2451_channel_setup,
 	.read = ltc2451_read_latest_conversion,
 };

--- a/drivers/adc/adc_max11102_17.c
+++ b/drivers/adc/adc_max11102_17.c
@@ -389,7 +389,7 @@ static int max11102_17_init(const struct device *dev)
 	return result;
 }
 
-static const struct adc_driver_api api = {
+static DEVICE_API(adc, api) = {
 	.channel_setup = max11102_17_channel_setup,
 	.read = max11102_17_read,
 	.ref_internal = 0,

--- a/drivers/adc/adc_max1125x.c
+++ b/drivers/adc/adc_max1125x.c
@@ -765,7 +765,7 @@ static int max1125x_init(const struct device *dev)
 	return 0;
 }
 
-static const struct adc_driver_api max1125x_api = {
+static DEVICE_API(adc, max1125x_api) = {
 	.channel_setup = max1125x_channel_setup,
 	.read = max1125x_read,
 	.ref_internal = 2048,

--- a/drivers/adc/adc_max32.c
+++ b/drivers/adc/adc_max32.c
@@ -296,7 +296,7 @@ static void adc_max32_isr(const struct device *dev)
 	}
 }
 
-static const struct adc_driver_api adc_max32_driver_api = {
+static DEVICE_API(adc, adc_max32_driver_api) = {
 	.channel_setup = adc_max32_channel_setup,
 	.read = adc_max32_read,
 #ifdef CONFIG_ADC_ASYNC

--- a/drivers/adc/adc_mchp_xec.c
+++ b/drivers/adc/adc_mchp_xec.c
@@ -397,7 +397,7 @@ static int adc_xec_pm_action(const struct device *dev, enum pm_device_action act
 }
 #endif /* CONFIG_PM_DEVICE */
 
-struct adc_driver_api adc_xec_api = {
+static DEVICE_API(adc, adc_xec_api) = {
 	.channel_setup = adc_xec_channel_setup,
 	.read = adc_xec_read,
 #if defined(CONFIG_ADC_ASYNC)

--- a/drivers/adc/adc_mcp320x.c
+++ b/drivers/adc/adc_mcp320x.c
@@ -297,7 +297,7 @@ static int mcp320x_init(const struct device *dev)
 	return 0;
 }
 
-static const struct adc_driver_api mcp320x_adc_api = {
+static DEVICE_API(adc, mcp320x_adc_api) = {
 	.channel_setup = mcp320x_channel_setup,
 	.read = mcp320x_read,
 #ifdef CONFIG_ADC_ASYNC

--- a/drivers/adc/adc_mcux_12b1msps_sar.c
+++ b/drivers/adc/adc_mcux_12b1msps_sar.c
@@ -262,7 +262,7 @@ static int mcux_12b1msps_sar_adc_init(const struct device *dev)
 	return 0;
 }
 
-static const struct adc_driver_api mcux_12b1msps_sar_adc_driver_api = {
+static DEVICE_API(adc, mcux_12b1msps_sar_adc_driver_api) = {
 	.channel_setup = mcux_12b1msps_sar_adc_channel_setup,
 	.read = mcux_12b1msps_sar_adc_read,
 #ifdef CONFIG_ADC_ASYNC

--- a/drivers/adc/adc_mcux_adc12.c
+++ b/drivers/adc/adc_mcux_adc12.c
@@ -269,7 +269,7 @@ static int mcux_adc12_init(const struct device *dev)
 				 (kADC12_ReferenceVoltageSourceVref))
 
 #define ADC12_MCUX_DRIVER_API(n)				\
-	static const struct adc_driver_api mcux_adc12_driver_api_##n = {	\
+	static DEVICE_API(adc, mcux_adc12_driver_api_##n) = {	\
 		.channel_setup = mcux_adc12_channel_setup,	\
 		.read = mcux_adc12_read,	\
 		IF_ENABLED(CONFIG_ADC_ASYNC, (.read_async = mcux_adc12_read_async,))	\

--- a/drivers/adc/adc_mcux_adc16.c
+++ b/drivers/adc/adc_mcux_adc16.c
@@ -432,7 +432,7 @@ static int mcux_adc16_init(const struct device *dev)
 	return 0;
 }
 
-static const struct adc_driver_api mcux_adc16_driver_api = {
+static DEVICE_API(adc, mcux_adc16_driver_api) = {
 	.channel_setup = mcux_adc16_channel_setup,
 	.read = mcux_adc16_read,
 #ifdef CONFIG_ADC_ASYNC

--- a/drivers/adc/adc_mcux_gau_adc.c
+++ b/drivers/adc/adc_mcux_gau_adc.c
@@ -351,7 +351,7 @@ static int mcux_gau_adc_init(const struct device *dev)
 	return 0;
 }
 
-static const struct adc_driver_api mcux_gau_adc_driver_api = {
+static DEVICE_API(adc, mcux_gau_adc_driver_api) = {
 	.channel_setup = mcux_gau_adc_channel_setup,
 	.read = mcux_gau_adc_read,
 #ifdef CONFIG_ADC_ASYNC

--- a/drivers/adc/adc_mcux_lpadc.c
+++ b/drivers/adc/adc_mcux_lpadc.c
@@ -543,7 +543,7 @@ static int mcux_lpadc_init(const struct device *dev)
 	return 0;
 }
 
-static const struct adc_driver_api mcux_lpadc_driver_api = {
+static DEVICE_API(adc, mcux_lpadc_driver_api) = {
 	.channel_setup = mcux_lpadc_channel_setup,
 	.read = mcux_lpadc_read,
 #ifdef CONFIG_ADC_ASYNC

--- a/drivers/adc/adc_npcx.c
+++ b/drivers/adc/adc_npcx.c
@@ -841,7 +841,7 @@ static int adc_npcx_init(const struct device *dev)
 		irq_enable(DT_INST_IRQN(n));					\
 	}									\
 										\
-	static const struct adc_driver_api adc_npcx_driver_api_##n = {		\
+	static DEVICE_API(adc, adc_npcx_driver_api_##n) = {			\
 		.channel_setup = adc_npcx_channel_setup,			\
 		.read = adc_npcx_read,						\
 		.ref_internal = DT_INST_PROP(n, vref_mv),			\

--- a/drivers/adc/adc_nrfx_adc.c
+++ b/drivers/adc/adc_nrfx_adc.c
@@ -281,7 +281,7 @@ static int init_adc(const struct device *dev)
 	return 0;
 }
 
-static const struct adc_driver_api adc_nrfx_driver_api = {
+static DEVICE_API(adc, adc_nrfx_driver_api) = {
 	.channel_setup = adc_nrfx_channel_setup,
 	.read          = adc_nrfx_read,
 #ifdef CONFIG_ADC_ASYNC

--- a/drivers/adc/adc_nrfx_saadc.c
+++ b/drivers/adc/adc_nrfx_saadc.c
@@ -661,7 +661,7 @@ static int init_saadc(const struct device *dev)
 	return 0;
 }
 
-static const struct adc_driver_api adc_nrfx_driver_api = {
+static DEVICE_API(adc, adc_nrfx_driver_api) = {
 	.channel_setup = adc_nrfx_channel_setup,
 	.read          = adc_nrfx_read,
 #ifdef CONFIG_ADC_ASYNC

--- a/drivers/adc/adc_numaker.c
+++ b/drivers/adc/adc_numaker.c
@@ -301,7 +301,7 @@ static int adc_numaker_read_async(const struct device *dev,
 }
 #endif
 
-static const struct adc_driver_api adc_numaker_driver_api = {
+static DEVICE_API(adc, adc_numaker_driver_api) = {
 	.channel_setup = adc_numaker_channel_setup,
 	.read = adc_numaker_read,
 #ifdef CONFIG_ADC_ASYNC

--- a/drivers/adc/adc_nxp_s32_adc_sar.c
+++ b/drivers/adc/adc_nxp_s32_adc_sar.c
@@ -334,7 +334,7 @@ static void adc_nxp_s32_isr(const struct device *dev)
 }
 
 #define ADC_NXP_S32_DRIVER_API(n)						\
-	static const struct adc_driver_api adc_nxp_s32_driver_api_##n = {	\
+	static DEVICE_API(adc, adc_nxp_s32_driver_api_##n) = {			\
 		.channel_setup = adc_nxp_s32_channel_setup,			\
 		.read = adc_nxp_s32_read,					\
 		IF_ENABLED(CONFIG_ADC_ASYNC, (.read_async = adc_nxp_s32_read_async,))\

--- a/drivers/adc/adc_renesas_ra.c
+++ b/drivers/adc/adc_renesas_ra.c
@@ -342,7 +342,7 @@ const adc_extended_cfg_t g_adc_cfg_extend = {
 #define ADC_RA_INIT(idx)                                                                           \
 	IRQ_CONFIGURE_FUNC(idx)                                                                    \
 	PINCTRL_DT_INST_DEFINE(idx);                                                               \
-	static struct adc_driver_api adc_ra_api_##idx = {                                          \
+	static DEVICE_API(adc, adc_ra_api_##idx) = {                                               \
 		.channel_setup = adc_ra_channel_setup,                                             \
 		.read = adc_ra_read,                                                               \
 		.ref_internal = DT_INST_PROP(idx, vref_mv),                                        \

--- a/drivers/adc/adc_rpi_pico.c
+++ b/drivers/adc/adc_rpi_pico.c
@@ -354,7 +354,7 @@ static int adc_rpi_init(const struct device *dev)
 #define ADC_RPI_INIT(idx)                                                                          \
 	IRQ_CONFIGURE_FUNC(idx)                                                                    \
 	PINCTRL_DT_INST_DEFINE(idx);                                                               \
-	static struct adc_driver_api adc_rpi_api_##idx = {                                         \
+	static DEVICE_API(adc, adc_rpi_api_##idx) = {                                              \
 		.channel_setup = adc_rpi_channel_setup,                                            \
 		.read = adc_rpi_read,                                                              \
 		.ref_internal = DT_INST_PROP(idx, vref_mv),                                        \

--- a/drivers/adc/adc_sam.c
+++ b/drivers/adc/adc_sam.c
@@ -376,7 +376,7 @@ static int adc_sam_read_async(const struct device *dev,
 }
 #endif
 
-static const struct adc_driver_api adc_sam_api = {
+static DEVICE_API(adc, adc_sam_api) = {
 	.channel_setup = adc_sam_channel_setup,
 	.read = adc_sam_read,
 #ifdef CONFIG_ADC_ASYNC

--- a/drivers/adc/adc_sam0.c
+++ b/drivers/adc/adc_sam0.c
@@ -503,7 +503,7 @@ static int adc_sam0_read_async(const struct device *dev,
 }
 #endif
 
-static const struct adc_driver_api adc_sam0_api = {
+static DEVICE_API(adc, adc_sam0_api) = {
 	.channel_setup = adc_sam0_channel_setup,
 	.read = adc_sam0_read,
 	.ref_internal = 1000U,			/* Fixed 1.0 V reference */

--- a/drivers/adc/adc_sam_afec.c
+++ b/drivers/adc/adc_sam_afec.c
@@ -331,7 +331,7 @@ static int adc_sam_read_async(const struct device *dev,
 }
 #endif
 
-static const struct adc_driver_api adc_sam_api = {
+static DEVICE_API(adc, adc_sam_api) = {
 	.channel_setup = adc_sam_channel_setup,
 	.read = adc_sam_read,
 #ifdef CONFIG_ADC_ASYNC

--- a/drivers/adc/adc_smartbond_gpadc.c
+++ b/drivers/adc/adc_smartbond_gpadc.c
@@ -389,7 +389,7 @@ static int adc_smartbond_init(const struct device *dev)
 	return ret;
 }
 
-static const struct adc_driver_api adc_smartbond_driver_api = {
+static DEVICE_API(adc, adc_smartbond_driver_api) = {
 	.channel_setup = adc_smartbond_channel_setup,
 	.read          = adc_smartbond_read,
 #ifdef CONFIG_ADC_ASYNC

--- a/drivers/adc/adc_smartbond_sdadc.c
+++ b/drivers/adc/adc_smartbond_sdadc.c
@@ -393,7 +393,7 @@ static int sdadc_smartbond_init(const struct device *dev)
 	return ret;
 }
 
-static const struct adc_driver_api sdadc_smartbond_driver_api = {
+static DEVICE_API(adc, sdadc_smartbond_driver_api) = {
 	.channel_setup = sdadc_smartbond_channel_setup,
 	.read          = sdadc_smartbond_read,
 #ifdef CONFIG_ADC_ASYNC

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -1727,7 +1727,7 @@ static int adc_stm32_pm_action(const struct device *dev,
 }
 #endif /* CONFIG_PM_DEVICE */
 
-static const struct adc_driver_api api_stm32_driver_api = {
+static DEVICE_API(adc, api_stm32_driver_api) = {
 	.channel_setup = adc_stm32_channel_setup,
 	.read = adc_stm32_read,
 #ifdef CONFIG_ADC_ASYNC

--- a/drivers/adc/adc_stm32wb0.c
+++ b/drivers/adc/adc_stm32wb0.c
@@ -1056,7 +1056,7 @@ int adc_stm32wb0_read_async(const struct device *dev,
 }
 #endif /* CONFIG_ADC_ASYNC */
 
-static const struct adc_driver_api api_stm32wb0_driver_api = {
+static DEVICE_API(adc, api_stm32wb0_driver_api) = {
 	.channel_setup = adc_stm32wb0_channel_setup,
 	.read = adc_stm32wb0_read,
 #if defined(CONFIG_ADC_ASYNC)

--- a/drivers/adc/adc_test.c
+++ b/drivers/adc/adc_test.c
@@ -37,7 +37,7 @@ static int vnd_adc_read_async(const struct device *dev,
 }
 #endif
 
-static const struct adc_driver_api vnd_adc_api = {
+static DEVICE_API(adc, vnd_adc_api) = {
 	.channel_setup = vnd_adc_channel_setup,
 	.read = vnd_adc_read,
 #ifdef CONFIG_ADC_ASYNC

--- a/drivers/adc/adc_tla2021.c
+++ b/drivers/adc/adc_tla2021.c
@@ -295,7 +295,7 @@ static int tla2021_init(const struct device *dev)
 	return 0;
 }
 
-static const struct adc_driver_api tla2021_driver_api = {
+static DEVICE_API(adc, tla2021_driver_api) = {
 	.channel_setup = tla2021_channel_setup,
 	.read = tla2021_read,
 	.ref_internal = 4096,

--- a/drivers/adc/adc_vf610.c
+++ b/drivers/adc/adc_vf610.c
@@ -233,7 +233,7 @@ static int vf610_adc_init(const struct device *dev)
 	return 0;
 }
 
-static const struct adc_driver_api vf610_adc_driver_api = {
+static DEVICE_API(adc, vf610_adc_driver_api) = {
 	.channel_setup = vf610_adc_channel_setup,
 	.read = vf610_adc_read,
 #ifdef CONFIG_ADC_ASYNC

--- a/drivers/adc/adc_xmc4xxx.c
+++ b/drivers/adc/adc_xmc4xxx.c
@@ -300,7 +300,7 @@ static int adc_xmc4xxx_init(const struct device *dev)
 	return 0;
 }
 
-static const struct adc_driver_api api_xmc4xxx_driver_api = {
+static DEVICE_API(adc, api_xmc4xxx_driver_api) = {
 	.channel_setup = adc_xmc4xxx_channel_setup,
 	.read = adc_xmc4xxx_read,
 #ifdef CONFIG_ADC_ASYNC

--- a/drivers/adc/iadc_gecko.c
+++ b/drivers/adc/iadc_gecko.c
@@ -453,7 +453,7 @@ static int adc_gecko_init(const struct device *dev)
 	return 0;
 }
 
-static const struct adc_driver_api api_gecko_adc_driver_api = {
+static DEVICE_API(adc, api_gecko_adc_driver_api) = {
 	.channel_setup = adc_gecko_channel_setup,
 	.read = adc_gecko_read,
 #ifdef CONFIG_ADC_ASYNC

--- a/include/zephyr/drivers/adc.h
+++ b/include/zephyr/drivers/adc.h
@@ -726,10 +726,7 @@ __syscall int adc_channel_setup(const struct device *dev,
 static inline int z_impl_adc_channel_setup(const struct device *dev,
 					   const struct adc_channel_cfg *channel_cfg)
 {
-	const struct adc_driver_api *api =
-				(const struct adc_driver_api *)dev->api;
-
-	return api->channel_setup(dev, channel_cfg);
+	return DEVICE_API_GET(adc, dev)->channel_setup(dev, channel_cfg);
 }
 
 /**
@@ -777,10 +774,7 @@ __syscall int adc_read(const struct device *dev,
 static inline int z_impl_adc_read(const struct device *dev,
 				  const struct adc_sequence *sequence)
 {
-	const struct adc_driver_api *api =
-				(const struct adc_driver_api *)dev->api;
-
-	return api->read(dev, sequence);
+	return DEVICE_API_GET(adc, dev)->read(dev, sequence);
 }
 
 /**
@@ -828,10 +822,7 @@ static inline int z_impl_adc_read_async(const struct device *dev,
 					const struct adc_sequence *sequence,
 					struct k_poll_signal *async)
 {
-	const struct adc_driver_api *api =
-				(const struct adc_driver_api *)dev->api;
-
-	return api->read_async(dev, sequence, async);
+	return DEVICE_API_GET(adc, dev)->read_async(dev, sequence, async);
 }
 #endif /* CONFIG_ADC_ASYNC */
 
@@ -846,10 +837,7 @@ static inline int z_impl_adc_read_async(const struct device *dev,
  */
 static inline uint16_t adc_ref_internal(const struct device *dev)
 {
-	const struct adc_driver_api *api =
-				(const struct adc_driver_api *)dev->api;
-
-	return api->ref_internal;
+	return DEVICE_API_GET(adc, dev)->ref_internal;
 }
 
 /**

--- a/tests/drivers/build_all/adc/testcase.yaml
+++ b/tests/drivers/build_all/adc/testcase.yaml
@@ -39,3 +39,9 @@ tests:
     platform_allow: mec15xxevb_assy6853
   drivers.adc.test.build:
     platform_allow: qemu_cortex_m3
+  drivers.adc.linker_generator.build:
+    platform_allow: qemu_cortex_m3
+    tags:
+      - linker_generator
+    extra_configs:
+      - CONFIG_CMAKE_LINKER_GENERATOR=y


### PR DESCRIPTION
Move all adc driver api structs into an iterable section.

Depends on #71773