### PR TITLE
drivers: sensor: Place API into iterable section

### DIFF
--- a/drivers/sensor/a01nyub/a01nyub.c
+++ b/drivers/sensor/a01nyub/a01nyub.c
@@ -114,7 +114,7 @@ static int a01nyub_sample_fetch(const struct device *dev, enum sensor_channel ch
 	return -ENOTSUP;
 }
 
-static const struct sensor_driver_api a01nyub_api_funcs = {
+static DEVICE_API(sensor, a01nyub_api_funcs) = {
 	.sample_fetch = a01nyub_sample_fetch,
 	.channel_get = a01nyub_channel_get,
 };

--- a/drivers/sensor/adi/adltc2990/adltc2990.c
+++ b/drivers/sensor/adi/adltc2990/adltc2990.c
@@ -505,7 +505,7 @@ static int adltc2990_channel_get(const struct device *dev, enum sensor_channel c
 	return 0;
 }
 
-static const struct sensor_driver_api adltc2990_driver_api = {
+static DEVICE_API(sensor, adltc2990_driver_api) = {
 	.sample_fetch = adltc2990_sample_fetch,
 	.channel_get = adltc2990_channel_get,
 };

--- a/drivers/sensor/adi/adt7310/adt7310.c
+++ b/drivers/sensor/adi/adt7310/adt7310.c
@@ -276,7 +276,7 @@ static int adt7310_init(const struct device *dev)
 	return ret;
 }
 
-static const struct sensor_driver_api adt7310_driver_api = {
+static DEVICE_API(sensor, adt7310_driver_api) = {
 	.attr_set = adt7310_attr_set,
 	.sample_fetch = adt7310_sample_fetch,
 	.channel_get  = adt7310_channel_get,

--- a/drivers/sensor/adi/adt7420/adt7420.c
+++ b/drivers/sensor/adi/adt7420/adt7420.c
@@ -144,7 +144,7 @@ static int adt7420_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api adt7420_driver_api = {
+static DEVICE_API(sensor, adt7420_driver_api) = {
 	.attr_set = adt7420_attr_set,
 	.sample_fetch = adt7420_sample_fetch,
 	.channel_get = adt7420_channel_get,

--- a/drivers/sensor/adi/adxl345/adxl345.c
+++ b/drivers/sensor/adi/adxl345/adxl345.c
@@ -383,7 +383,7 @@ static int adxl345_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api adxl345_api_funcs = {
+static DEVICE_API(sensor, adxl345_api_funcs) = {
 	.attr_set = adxl345_attr_set,
 	.sample_fetch = adxl345_sample_fetch,
 	.channel_get = adxl345_channel_get,

--- a/drivers/sensor/adi/adxl362/adxl362.c
+++ b/drivers/sensor/adi/adxl362/adxl362.c
@@ -654,7 +654,7 @@ static int adxl362_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api adxl362_api_funcs = {
+static DEVICE_API(sensor, adxl362_api_funcs) = {
 	.attr_set     = adxl362_attr_set,
 	.sample_fetch = adxl362_sample_fetch,
 	.channel_get  = adxl362_channel_get,

--- a/drivers/sensor/adi/adxl367/adxl367.c
+++ b/drivers/sensor/adi/adxl367/adxl367.c
@@ -940,7 +940,7 @@ static int adxl367_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api adxl367_api_funcs = {
+static DEVICE_API(sensor, adxl367_api_funcs) = {
 	.attr_set     = adxl367_attr_set,
 	.sample_fetch = adxl367_sample_fetch,
 	.channel_get  = adxl367_channel_get,

--- a/drivers/sensor/adi/adxl372/adxl372.c
+++ b/drivers/sensor/adi/adxl372/adxl372.c
@@ -692,7 +692,7 @@ static int adxl372_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api adxl372_api_funcs = {
+static DEVICE_API(sensor, adxl372_api_funcs) = {
 	.attr_set = adxl372_attr_set,
 	.sample_fetch = adxl372_sample_fetch,
 	.channel_get = adxl372_channel_get,

--- a/drivers/sensor/amd_sb_tsi/sb_tsi.c
+++ b/drivers/sensor/amd_sb_tsi/sb_tsi.c
@@ -76,7 +76,7 @@ static int sb_tsi_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api sb_tsi_driver_api = {
+static DEVICE_API(sensor, sb_tsi_driver_api) = {
 	.sample_fetch = sb_tsi_sample_fetch,
 	.channel_get = sb_tsi_channel_get,
 };

--- a/drivers/sensor/amg88xx/amg88xx.c
+++ b/drivers/sensor/amg88xx/amg88xx.c
@@ -127,7 +127,7 @@ int amg88xx_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api amg88xx_driver_api = {
+static DEVICE_API(sensor, amg88xx_driver_api) = {
 #ifdef CONFIG_AMG88XX_TRIGGER
 	.attr_set = amg88xx_attr_set,
 	.trigger_set = amg88xx_trigger_set,

--- a/drivers/sensor/ams/ams_as5600/ams_as5600.c
+++ b/drivers/sensor/ams/ams_as5600/ams_as5600.c
@@ -81,7 +81,7 @@ static int as5600_initialize(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api as5600_driver_api = {
+static DEVICE_API(sensor, as5600_driver_api) = {
 	.sample_fetch = as5600_fetch,
 	.channel_get = as5600_get,
 };

--- a/drivers/sensor/ams/ams_iAQcore/iAQcore.c
+++ b/drivers/sensor/ams/ams_iAQcore/iAQcore.c
@@ -93,7 +93,7 @@ static int iaqcore_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api iaq_core_driver_api = {
+static DEVICE_API(sensor, iaq_core_driver_api) = {
 	.sample_fetch = iaqcore_sample_fetch,
 	.channel_get = iaqcore_channel_get,
 };

--- a/drivers/sensor/ams/ccs811/ccs811.c
+++ b/drivers/sensor/ams/ccs811/ccs811.c
@@ -304,7 +304,7 @@ static int ccs811_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api ccs811_driver_api = {
+static DEVICE_API(sensor, ccs811_driver_api) = {
 #ifdef CONFIG_CCS811_TRIGGER
 	.attr_set = ccs811_attr_set,
 	.trigger_set = ccs811_trigger_set,

--- a/drivers/sensor/ams/ens210/ens210.c
+++ b/drivers/sensor/ams/ens210/ens210.c
@@ -260,7 +260,7 @@ static int ens210_wait_boot(const struct device *dev)
 	return -EIO;
 }
 
-static const struct sensor_driver_api en210_driver_api = {
+static DEVICE_API(sensor, en210_driver_api) = {
 	.sample_fetch = ens210_sample_fetch,
 	.channel_get = ens210_channel_get,
 };

--- a/drivers/sensor/ams/tcs3400/tcs3400.c
+++ b/drivers/sensor/ams/tcs3400/tcs3400.c
@@ -241,7 +241,7 @@ static int tcs3400_sensor_setup(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api tcs3400_api = {
+static DEVICE_API(sensor, tcs3400_api) = {
 	.sample_fetch = tcs3400_sample_fetch,
 	.channel_get = tcs3400_channel_get,
 	.attr_set = tcs3400_attr_set,

--- a/drivers/sensor/ams/tmd2620/tmd2620.c
+++ b/drivers/sensor/ams/tmd2620/tmd2620.c
@@ -387,7 +387,7 @@ static int tmd2620_pm_action(const struct device *dev, enum pm_device_action act
 }
 #endif
 
-static const struct sensor_driver_api tmd2620_driver_api = {
+static DEVICE_API(sensor, tmd2620_driver_api) = {
 	.sample_fetch = tmd2620_sample_fetch,
 	.channel_get = tmd2620_channel_get,
 #ifdef CONFIG_TMD2620_TRIGGER

--- a/drivers/sensor/ams/tsl2540/tsl2540.c
+++ b/drivers/sensor/ams/tsl2540/tsl2540.c
@@ -335,7 +335,7 @@ static int tsl2540_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api tsl2540_driver_api = {
+static DEVICE_API(sensor, tsl2540_driver_api) = {
 	.sample_fetch = tsl2540_sample_fetch,
 	.channel_get = tsl2540_channel_get,
 	.attr_set = tsl2540_attr_set,

--- a/drivers/sensor/ams/tsl2561/tsl2561.c
+++ b/drivers/sensor/ams/tsl2561/tsl2561.c
@@ -245,7 +245,7 @@ static int tsl2561_channel_get(const struct device *dev, enum sensor_channel cha
 	return 0;
 }
 
-static const struct sensor_driver_api tsl2561_driver_api = {
+static DEVICE_API(sensor, tsl2561_driver_api) = {
 	.sample_fetch = tsl2561_sample_fetch,
 	.channel_get = tsl2561_channel_get
 };

--- a/drivers/sensor/ams/tsl2591/tsl2591.c
+++ b/drivers/sensor/ams/tsl2591/tsl2591.c
@@ -477,7 +477,7 @@ static int tsl2591_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api tsl2591_driver_api = {
+static DEVICE_API(sensor, tsl2591_driver_api) = {
 #ifdef CONFIG_TSL2591_TRIGGER
 	.trigger_set = tsl2591_trigger_set,
 #endif

--- a/drivers/sensor/aosong/ags10/ags10.c
+++ b/drivers/sensor/aosong/ags10/ags10.c
@@ -118,8 +118,10 @@ static int ags10_init(const struct device *dev)
 	return ret;
 }
 
-static const struct sensor_driver_api ags10_api = {.sample_fetch = ags10_sample_fetch,
-						   .channel_get = ags10_channel_get};
+static DEVICE_API(sensor, ags10_api) = {
+	.sample_fetch = ags10_sample_fetch,
+	.channel_get = ags10_channel_get,
+};
 
 #define AGS10_INIT(n)                                                                              \
 	static struct ags10_data ags10_data_##n;                                                   \

--- a/drivers/sensor/aosong/dht/dht.c
+++ b/drivers/sensor/aosong/dht/dht.c
@@ -230,7 +230,7 @@ static int dht_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api dht_api = {
+static DEVICE_API(sensor, dht_api) = {
 	.sample_fetch = &dht_sample_fetch,
 	.channel_get = &dht_channel_get,
 };

--- a/drivers/sensor/aosong/dht20/dht20.c
+++ b/drivers/sensor/aosong/dht20/dht20.c
@@ -307,8 +307,10 @@ static int dht20_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api dht20_driver_api = {.sample_fetch = dht20_sample_fetch,
-							  .channel_get = dht20_channel_get};
+static DEVICE_API(sensor, dht20_driver_api) = {
+	.sample_fetch = dht20_sample_fetch,
+	.channel_get = dht20_channel_get,
+};
 
 #define DT_DRV_COMPAT aosong_dht20
 #if DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT)

--- a/drivers/sensor/apds9253/apds9253.c
+++ b/drivers/sensor/apds9253/apds9253.c
@@ -226,7 +226,7 @@ static int apds9253_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api apds9253_driver_api = {
+static DEVICE_API(sensor, apds9253_driver_api) = {
 	.sample_fetch = &apds9253_sample_fetch,
 	.channel_get = &apds9253_channel_get,
 };

--- a/drivers/sensor/apds9306/apds9306.c
+++ b/drivers/sensor/apds9306/apds9306.c
@@ -348,7 +348,7 @@ static int apds9306_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api apds9306_driver_api = {
+static DEVICE_API(sensor, apds9306_driver_api) = {
 	.attr_set = apds9306_attr_set,
 	.attr_get = apds9306_attr_get,
 	.sample_fetch = apds9306_sample_fetch,

--- a/drivers/sensor/apds9960/apds9960.c
+++ b/drivers/sensor/apds9960/apds9960.c
@@ -466,7 +466,7 @@ static int apds9960_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api apds9960_driver_api = {
+static DEVICE_API(sensor, apds9960_driver_api) = {
 	.sample_fetch = &apds9960_sample_fetch,
 	.channel_get = &apds9960_channel_get,
 #ifdef CONFIG_APDS9960_TRIGGER

--- a/drivers/sensor/asahi_kasei/ak8975/ak8975.c
+++ b/drivers/sensor/asahi_kasei/ak8975/ak8975.c
@@ -86,7 +86,7 @@ static int ak8975_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api ak8975_driver_api = {
+static DEVICE_API(sensor, ak8975_driver_api) = {
 	.sample_fetch = ak8975_sample_fetch,
 	.channel_get = ak8975_channel_get,
 };

--- a/drivers/sensor/asahi_kasei/akm09918c/akm09918c.c
+++ b/drivers/sensor/asahi_kasei/akm09918c/akm09918c.c
@@ -237,7 +237,7 @@ static int akm09918c_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api akm09918c_driver_api = {
+static DEVICE_API(sensor, akm09918c_driver_api) = {
 	.sample_fetch = akm09918c_sample_fetch,
 	.channel_get = akm09918c_channel_get,
 	.attr_get = akm09918c_attr_get,

--- a/drivers/sensor/bosch/bma280/bma280.c
+++ b/drivers/sensor/bosch/bma280/bma280.c
@@ -106,7 +106,7 @@ static int bma280_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api bma280_driver_api = {
+static DEVICE_API(sensor, bma280_driver_api) = {
 #if CONFIG_BMA280_TRIGGER
 	.attr_set = bma280_attr_set,
 	.trigger_set = bma280_trigger_set,

--- a/drivers/sensor/bosch/bma4xx/bma4xx.c
+++ b/drivers/sensor/bosch/bma4xx/bma4xx.c
@@ -683,7 +683,7 @@ static int bma4xx_get_decoder(const struct device *dev, const struct sensor_deco
  * Sensor driver API
  */
 
-static const struct sensor_driver_api bma4xx_driver_api = {
+static DEVICE_API(sensor, bma4xx_driver_api) = {
 	.attr_set = bma4xx_attr_set,
 	.submit = bma4xx_submit,
 	.get_decoder = bma4xx_get_decoder,

--- a/drivers/sensor/bosch/bmc150_magn/bmc150_magn.c
+++ b/drivers/sensor/bosch/bmc150_magn/bmc150_magn.c
@@ -464,7 +464,7 @@ static int bmc150_magn_attr_set(const struct device *dev,
 }
 #endif
 
-static const struct sensor_driver_api bmc150_magn_api_funcs = {
+static DEVICE_API(sensor, bmc150_magn_api_funcs) = {
 #if defined(BMC150_MAGN_SET_ATTR)
 	.attr_set = bmc150_magn_attr_set,
 #endif

--- a/drivers/sensor/bosch/bme280/bme280.c
+++ b/drivers/sensor/bosch/bme280/bme280.c
@@ -254,7 +254,7 @@ static int bme280_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api bme280_api_funcs = {
+static DEVICE_API(sensor, bme280_api_funcs) = {
 	.sample_fetch = bme280_sample_fetch,
 	.channel_get = bme280_channel_get,
 #ifdef CONFIG_SENSOR_ASYNC_API

--- a/drivers/sensor/bosch/bme680/bme680.c
+++ b/drivers/sensor/bosch/bme680/bme680.c
@@ -478,7 +478,7 @@ static int bme680_init(const struct device *dev)
 	return pm_device_driver_init(dev, bme680_pm_control);
 }
 
-static const struct sensor_driver_api bme680_api_funcs = {
+static DEVICE_API(sensor, bme680_api_funcs) = {
 	.sample_fetch = bme680_sample_fetch,
 	.channel_get = bme680_channel_get,
 };

--- a/drivers/sensor/bosch/bmg160/bmg160.c
+++ b/drivers/sensor/bosch/bmg160/bmg160.c
@@ -272,7 +272,7 @@ static int bmg160_channel_get(const struct device *dev,
 	}
 }
 
-static const struct sensor_driver_api bmg160_api = {
+static DEVICE_API(sensor, bmg160_api) = {
 	.attr_set = bmg160_attr_set,
 #ifdef CONFIG_BMG160_TRIGGER
 	.trigger_set = bmg160_trigger_set,

--- a/drivers/sensor/bosch/bmi08x/bmi08x_accel.c
+++ b/drivers/sensor/bosch/bmi08x/bmi08x_accel.c
@@ -536,7 +536,7 @@ static int bmi08x_accel_pm_action(const struct device *dev, enum pm_device_actio
 }
 #endif /* CONFIG_PM_DEVICE */
 
-static const struct sensor_driver_api bmi08x_api = {
+static DEVICE_API(sensor, bmi08x_api) = {
 	.attr_set = bmi08x_attr_set,
 #ifdef CONFIG_BMI08X_ACCEL_TRIGGER
 	.trigger_set = bmi08x_trigger_set_acc,

--- a/drivers/sensor/bosch/bmi08x/bmi08x_gyro.c
+++ b/drivers/sensor/bosch/bmi08x/bmi08x_gyro.c
@@ -348,7 +348,7 @@ static int bmi08x_gyro_pm_action(const struct device *dev, enum pm_device_action
 }
 #endif /* CONFIG_PM_DEVICE */
 
-static const struct sensor_driver_api bmi08x_api = {
+static DEVICE_API(sensor, bmi08x_api) = {
 	.attr_set = bmi08x_attr_set,
 #ifdef CONFIG_BMI08X_GYRO_TRIGGER
 	.trigger_set = bmi08x_trigger_set_gyr,

--- a/drivers/sensor/bosch/bmi160/bmi160.c
+++ b/drivers/sensor/bosch/bmi160/bmi160.c
@@ -1009,7 +1009,7 @@ static int bmi160_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api bmi160_api = {
+static DEVICE_API(sensor, bmi160_api) = {
 	.attr_set = bmi160_attr_set,
 	.attr_get = bmi160_attr_get,
 #ifdef CONFIG_BMI160_TRIGGER

--- a/drivers/sensor/bosch/bmi270/bmi270.c
+++ b/drivers/sensor/bosch/bmi270/bmi270.c
@@ -769,7 +769,7 @@ static int bmi270_init(const struct device *dev)
 	return ret;
 }
 
-static const struct sensor_driver_api bmi270_driver_api = {
+static DEVICE_API(sensor, bmi270_driver_api) = {
 	.sample_fetch = bmi270_sample_fetch,
 	.channel_get = bmi270_channel_get,
 	.attr_set = bmi270_attr_set,

--- a/drivers/sensor/bosch/bmi323/bmi323.c
+++ b/drivers/sensor/bosch/bmi323/bmi323.c
@@ -1106,7 +1106,7 @@ static int bosch_bmi323_driver_api_channel_get(const struct device *dev, enum se
 	return ret;
 }
 
-static const struct sensor_driver_api bosch_bmi323_api = {
+static DEVICE_API(sensor, bosch_bmi323_api) = {
 	.attr_set = bosch_bmi323_driver_api_attr_set,
 	.attr_get = bosch_bmi323_driver_api_attr_get,
 	.trigger_set = bosch_bmi323_driver_api_trigger_set,

--- a/drivers/sensor/bosch/bmm150/bmm150.c
+++ b/drivers/sensor/bosch/bmm150/bmm150.c
@@ -489,7 +489,7 @@ static int bmm150_attr_set(const struct device *dev,
 }
 #endif
 
-static const struct sensor_driver_api bmm150_api_funcs = {
+static DEVICE_API(sensor, bmm150_api_funcs) = {
 #if defined(BMM150_SET_ATTR_REP)
 	.attr_set = bmm150_attr_set,
 #endif

--- a/drivers/sensor/bosch/bmp180/bmp180.c
+++ b/drivers/sensor/bosch/bmp180/bmp180.c
@@ -417,7 +417,7 @@ static int bmp180_pm_action(const struct device *dev,
 }
 #endif /* CONFIG_PM_DEVICE */
 
-static const struct sensor_driver_api bmp180_api = {
+static DEVICE_API(sensor, bmp180_api) = {
 	.attr_set = bmp180_attr_set,
 	.sample_fetch = bmp180_sample_fetch,
 	.channel_get = bmp180_channel_get,

--- a/drivers/sensor/bosch/bmp388/bmp388.c
+++ b/drivers/sensor/bosch/bmp388/bmp388.c
@@ -458,7 +458,7 @@ static int bmp388_pm_action(const struct device *dev,
 }
 #endif /* CONFIG_PM_DEVICE */
 
-static const struct sensor_driver_api bmp388_api = {
+static DEVICE_API(sensor, bmp388_api) = {
 	.attr_set = bmp388_attr_set,
 #ifdef CONFIG_BMP388_TRIGGER
 	.trigger_set = bmp388_trigger_set,

--- a/drivers/sensor/bosch/bmp581/bmp581.c
+++ b/drivers/sensor/bosch/bmp581/bmp581.c
@@ -540,9 +540,11 @@ static int bmp581_init(const struct device *dev)
 	return ret;
 }
 
-static const struct sensor_driver_api bmp581_driver_api = {.sample_fetch = bmp581_sample_fetch,
-							   .channel_get = bmp581_channel_get,
-							   .attr_set = bmp581_attr_set};
+static DEVICE_API(sensor, bmp581_driver_api) = {
+	.sample_fetch = bmp581_sample_fetch,
+	.channel_get = bmp581_channel_get,
+	.attr_set = bmp581_attr_set,
+};
 
 #define BMP581_CONFIG(i)                                                                           \
 	static const struct bmp581_config bmp581_config_##i = {                                    \

--- a/drivers/sensor/current_amp/current_amp.c
+++ b/drivers/sensor/current_amp/current_amp.c
@@ -71,7 +71,7 @@ static int get(const struct device *dev, enum sensor_channel chan, struct sensor
 	return 0;
 }
 
-static const struct sensor_driver_api current_api = {
+static DEVICE_API(sensor, current_api) = {
 	.sample_fetch = fetch,
 	.channel_get = get,
 };

--- a/drivers/sensor/ene_tach_kb1200/tach_ene_kb1200.c
+++ b/drivers/sensor/ene_tach_kb1200/tach_ene_kb1200.c
@@ -122,7 +122,7 @@ static int tach_kb1200_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api tach_kb1200_driver_api = {
+static DEVICE_API(sensor, tach_kb1200_driver_api) = {
 	.sample_fetch = tach_kb1200_sample_fetch,
 	.channel_get = tach_kb1200_channel_get,
 };

--- a/drivers/sensor/ens160/ens160.c
+++ b/drivers/sensor/ens160/ens160.c
@@ -175,7 +175,7 @@ static int ens160_attr_set(const struct device *dev, enum sensor_channel chan,
 	return ret;
 }
 
-static const struct sensor_driver_api ens160_driver_api = {
+static DEVICE_API(sensor, ens160_driver_api) = {
 	.sample_fetch = ens160_sample_fetch,
 	.channel_get = ens160_channel_get,
 	.attr_set = ens160_attr_set,

--- a/drivers/sensor/espressif/esp32_temp/esp32_temp.c
+++ b/drivers/sensor/espressif/esp32_temp/esp32_temp.c
@@ -61,7 +61,7 @@ static int esp32_temp_channel_get(const struct device *dev, enum sensor_channel 
 	return sensor_value_from_double(val, data->temp_out);
 }
 
-static const struct sensor_driver_api esp32_temp_driver_api = {
+static DEVICE_API(sensor, esp32_temp_driver_api) = {
 	.sample_fetch = esp32_temp_sample_fetch,
 	.channel_get = esp32_temp_channel_get,
 };

--- a/drivers/sensor/espressif/pcnt_esp32/pcnt_esp32.c
+++ b/drivers/sensor/espressif/pcnt_esp32/pcnt_esp32.c
@@ -357,7 +357,7 @@ static int pcnt_esp32_trigger_set(const struct device *dev, const struct sensor_
 }
 #endif /* CONFIG_PCNT_ESP32_TRIGGER */
 
-static const struct sensor_driver_api pcnt_esp32_api = {
+static DEVICE_API(sensor, pcnt_esp32_api) = {
 	.sample_fetch = pcnt_esp32_sample_fetch,
 	.channel_get = pcnt_esp32_channel_get,
 	.attr_set = pcnt_esp32_attr_set,

--- a/drivers/sensor/explorir_m/explorir_m.c
+++ b/drivers/sensor/explorir_m/explorir_m.c
@@ -327,7 +327,7 @@ static int explorir_m_channel_get(const struct device *dev, enum sensor_channel 
 	return 0;
 }
 
-static const struct sensor_driver_api explorir_m_api_funcs = {
+static DEVICE_API(sensor, explorir_m_api_funcs) = {
 	.attr_set = explorir_m_attr_set,
 	.attr_get = explorir_m_attr_get,
 	.sample_fetch = explorir_m_sample_fetch,

--- a/drivers/sensor/f75303/f75303.c
+++ b/drivers/sensor/f75303/f75303.c
@@ -143,7 +143,7 @@ static int f75303_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api f75303_driver_api = {
+static DEVICE_API(sensor, f75303_driver_api) = {
 	.sample_fetch = f75303_sample_fetch,
 	.channel_get = f75303_channel_get,
 };

--- a/drivers/sensor/fcx_mldx5/fcx_mldx5.c
+++ b/drivers/sensor/fcx_mldx5/fcx_mldx5.c
@@ -417,7 +417,7 @@ static int fcx_mldx5_channel_get(const struct device *dev, enum sensor_channel c
 	return 0;
 }
 
-static const struct sensor_driver_api fcx_mldx5_api_funcs = {
+static DEVICE_API(sensor, fcx_mldx5_api_funcs) = {
 	.attr_get = fcx_mldx5_attr_get,
 	.sample_fetch = fcx_mldx5_sample_fetch,
 	.channel_get = fcx_mldx5_channel_get,

--- a/drivers/sensor/grow_r502a/grow_r502a.c
+++ b/drivers/sensor/grow_r502a/grow_r502a.c
@@ -1168,7 +1168,7 @@ static int grow_r502a_init(const struct device *dev)
 	return fps_init(dev);
 }
 
-static const struct sensor_driver_api grow_r502a_api = {
+static DEVICE_API(sensor, grow_r502a_api) = {
 	.sample_fetch = grow_r502a_sample_fetch,
 	.channel_get = grow_r502a_channel_get,
 	.attr_set = grow_r502a_attr_set,

--- a/drivers/sensor/hc_sr04/hc_sr04.c
+++ b/drivers/sensor/hc_sr04/hc_sr04.c
@@ -165,7 +165,7 @@ static int hcsr04_channel_get(const struct device *dev, enum sensor_channel chan
 	return sensor_value_from_milli(val, distance_mm);
 }
 
-static const struct sensor_driver_api hcsr04_driver_api = {
+static DEVICE_API(sensor, hcsr04_driver_api) = {
 	.sample_fetch = hcsr04_sample_fetch,
 	.channel_get = hcsr04_channel_get
 };

--- a/drivers/sensor/honeywell/hmc5883l/hmc5883l.c
+++ b/drivers/sensor/honeywell/hmc5883l/hmc5883l.c
@@ -78,7 +78,7 @@ static int hmc5883l_sample_fetch(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api hmc5883l_driver_api = {
+static DEVICE_API(sensor, hmc5883l_driver_api) = {
 #if CONFIG_HMC5883L_TRIGGER
 	.trigger_set = hmc5883l_trigger_set,
 #endif

--- a/drivers/sensor/honeywell/mpr/mpr.c
+++ b/drivers/sensor/honeywell/mpr/mpr.c
@@ -127,7 +127,7 @@ static int mpr_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api mpr_api_funcs = {
+static DEVICE_API(sensor, mpr_api_funcs) = {
 	.sample_fetch = mpr_sample_fetch,
 	.channel_get = mpr_channel_get,
 };

--- a/drivers/sensor/honeywell/sm351lt/sm351lt.c
+++ b/drivers/sensor/honeywell/sm351lt/sm351lt.c
@@ -177,7 +177,7 @@ static int sm351lt_attr_get(const struct device *dev,
 }
 #endif
 
-static const struct sensor_driver_api sm351lt_api_funcs = {
+static DEVICE_API(sensor, sm351lt_api_funcs) = {
 	.sample_fetch = sm351lt_sample_fetch,
 	.channel_get = sm351lt_channel_get,
 #if CONFIG_SM351LT_TRIGGER

--- a/drivers/sensor/hp206c/hp206c.c
+++ b/drivers/sensor/hp206c/hp206c.c
@@ -275,7 +275,7 @@ static int hp206c_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api hp206c_api = {
+static DEVICE_API(sensor, hp206c_api) = {
 	.attr_set = hp206c_attr_set,
 	.sample_fetch = hp206c_adc_acquire,
 	.channel_get = hp206c_channel_get,

--- a/drivers/sensor/infineon/dps310/dps310.c
+++ b/drivers/sensor/infineon/dps310/dps310.c
@@ -709,7 +709,7 @@ static int dps310_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api dps310_api_funcs = {
+static DEVICE_API(sensor, dps310_api_funcs) = {
 	.sample_fetch = dps310_sample_fetch,
 	.channel_get = dps310_channel_get,
 };

--- a/drivers/sensor/infineon/tle9104/tle9104_diagnostics.c
+++ b/drivers/sensor/infineon/tle9104/tle9104_diagnostics.c
@@ -64,7 +64,7 @@ static int tle9104_diagnostics_channel_get(const struct device *dev, enum sensor
 	}
 }
 
-static const struct sensor_driver_api tle9104_diagnostics_driver_api = {
+static DEVICE_API(sensor, tle9104_diagnostics_driver_api) = {
 	.sample_fetch = tle9104_diagnostics_sample_fetch,
 	.channel_get = tle9104_diagnostics_channel_get,
 };

--- a/drivers/sensor/infineon/xmc4xxx_temp/xmc4xxx_temp.c
+++ b/drivers/sensor/infineon/xmc4xxx_temp/xmc4xxx_temp.c
@@ -57,7 +57,7 @@ static int xmc4xxx_temp_channel_get(const struct device *dev, enum sensor_channe
 	return sensor_value_from_double(val, data->temp_out);
 }
 
-static const struct sensor_driver_api xmc4xxx_temp_driver_api = {
+static DEVICE_API(sensor, xmc4xxx_temp_driver_api) = {
 	.sample_fetch = xmc4xxx_temp_sample_fetch,
 	.channel_get = xmc4xxx_temp_channel_get,
 };

--- a/drivers/sensor/ist8310/ist8310.c
+++ b/drivers/sensor/ist8310/ist8310.c
@@ -98,7 +98,7 @@ static int ist8310_channel_get(const struct device *dev, enum sensor_channel cha
 	return 0;
 }
 
-static const struct sensor_driver_api ist8310_api_funcs = {
+static DEVICE_API(sensor, ist8310_api_funcs) = {
 	.sample_fetch = ist8310_sample_fetch,
 	.channel_get = ist8310_channel_get,
 };

--- a/drivers/sensor/ite/ite_tach_it8xxx2/tach_ite_it8xxx2.c
+++ b/drivers/sensor/ite/ite_tach_it8xxx2/tach_ite_it8xxx2.c
@@ -213,7 +213,7 @@ static int tach_it8xxx2_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api tach_it8xxx2_driver_api = {
+static DEVICE_API(sensor, tach_it8xxx2_driver_api) = {
 	.sample_fetch = tach_it8xxx2_sample_fetch,
 	.channel_get = tach_it8xxx2_channel_get,
 };

--- a/drivers/sensor/ite/ite_vcmp_it8xxx2/vcmp_ite_it8xxx2.c
+++ b/drivers/sensor/ite/ite_vcmp_it8xxx2/vcmp_ite_it8xxx2.c
@@ -352,7 +352,7 @@ static int vcmp_it8xxx2_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api vcmp_ite_it8xxx2_api = {
+static DEVICE_API(sensor, vcmp_ite_it8xxx2_api) = {
 	.attr_set = vcmp_ite_it8xxx2_attr_set,
 	.trigger_set = vcmp_ite_it8xxx2_trigger_set,
 	.channel_get = vcmp_it8xxx2_channel_get,

--- a/drivers/sensor/jedec/jc42/jc42.c
+++ b/drivers/sensor/jedec/jc42/jc42.c
@@ -89,7 +89,7 @@ static int jc42_channel_get(const struct device *dev, enum sensor_channel chan,
 	return 0;
 }
 
-static const struct sensor_driver_api jc42_api_funcs = {
+static DEVICE_API(sensor, jc42_api_funcs) = {
 	.sample_fetch = jc42_sample_fetch,
 	.channel_get = jc42_channel_get,
 #ifdef CONFIG_JC42_TRIGGER

--- a/drivers/sensor/lm35/lm35.c
+++ b/drivers/sensor/lm35/lm35.c
@@ -65,7 +65,7 @@ static int lm35_channel_get(const struct device *dev, enum sensor_channel chan,
 	return 0;
 }
 
-static const struct sensor_driver_api lm35_driver_api = {
+static DEVICE_API(sensor, lm35_driver_api) = {
 	.sample_fetch = lm35_sample_fetch,
 	.channel_get = lm35_channel_get,
 };

--- a/drivers/sensor/lm75/lm75.c
+++ b/drivers/sensor/lm75/lm75.c
@@ -306,7 +306,7 @@ static int lm75_channel_get(const struct device *dev, enum sensor_channel chan,
 	}
 }
 
-static const struct sensor_driver_api lm75_driver_api = {
+static DEVICE_API(sensor, lm75_driver_api) = {
 	.attr_set = lm75_attr_set,
 	.attr_get = lm75_attr_get,
 #if LM75_TRIGGER_SUPPORT

--- a/drivers/sensor/lm77/lm77.c
+++ b/drivers/sensor/lm77/lm77.c
@@ -298,7 +298,7 @@ static int lm77_channel_get(const struct device *dev, enum sensor_channel chan,
 	return 0;
 }
 
-static const struct sensor_driver_api lm77_driver_api = {
+static DEVICE_API(sensor, lm77_driver_api) = {
 	.attr_set = lm77_attr_set,
 	.attr_get = lm77_attr_get,
 #if LM77_TRIGGER_SUPPORT

--- a/drivers/sensor/ltrf216a/ltrf216a.c
+++ b/drivers/sensor/ltrf216a/ltrf216a.c
@@ -135,7 +135,7 @@ static int ltrf216a_channel_get(const struct device *dev, enum sensor_channel ch
 	return 0;
 }
 
-static const struct sensor_driver_api ltrf216a_driver_api = {
+static DEVICE_API(sensor, ltrf216a_driver_api) = {
 	.sample_fetch = ltrf216a_sample_fetch,
 	.channel_get = ltrf216a_channel_get,
 };

--- a/drivers/sensor/maxim/ds18b20/ds18b20.c
+++ b/drivers/sensor/maxim/ds18b20/ds18b20.c
@@ -310,7 +310,7 @@ int ds18b20_attr_set(const struct device *dev, enum sensor_channel chan,
 	return 0;
 }
 
-static const struct sensor_driver_api ds18b20_driver_api = {
+static DEVICE_API(sensor, ds18b20_driver_api) = {
 	.attr_set = ds18b20_attr_set,
 	.sample_fetch = ds18b20_sample_fetch,
 	.channel_get = ds18b20_channel_get,

--- a/drivers/sensor/maxim/max17055/max17055.c
+++ b/drivers/sensor/maxim/max17055/max17055.c
@@ -469,7 +469,7 @@ static int max17055_gauge_init(const struct device *dev)
 	return max17055_reg_write(dev, STATUS, tmp);
 }
 
-static const struct sensor_driver_api max17055_battery_driver_api = {
+static DEVICE_API(sensor, max17055_battery_driver_api) = {
 	.sample_fetch = max17055_sample_fetch,
 	.channel_get = max17055_channel_get,
 };

--- a/drivers/sensor/maxim/max17262/max17262.c
+++ b/drivers/sensor/maxim/max17262/max17262.c
@@ -363,7 +363,7 @@ static int max17262_gauge_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api max17262_battery_driver_api = {
+static DEVICE_API(sensor, max17262_battery_driver_api) = {
 	.sample_fetch = max17262_sample_fetch,
 	.channel_get = max17262_channel_get,
 };

--- a/drivers/sensor/maxim/max30101/max30101.c
+++ b/drivers/sensor/maxim/max30101/max30101.c
@@ -88,7 +88,7 @@ static int max30101_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api max30101_driver_api = {
+static DEVICE_API(sensor, max30101_driver_api) = {
 	.sample_fetch = max30101_sample_fetch,
 	.channel_get = max30101_channel_get,
 };

--- a/drivers/sensor/maxim/max31790/max31790_fan_fault.c
+++ b/drivers/sensor/maxim/max31790/max31790_fan_fault.c
@@ -49,7 +49,7 @@ static int max31790_fan_fault_channel_get(const struct device *dev, enum sensor_
 	return 0;
 }
 
-static const struct sensor_driver_api max31790_fan_fault_api = {
+static DEVICE_API(sensor, max31790_fan_fault_api) = {
 	.sample_fetch = max31790_fan_fault_sample_fetch,
 	.channel_get = max31790_fan_fault_channel_get,
 };

--- a/drivers/sensor/maxim/max31790/max31790_fan_speed.c
+++ b/drivers/sensor/maxim/max31790/max31790_fan_speed.c
@@ -105,7 +105,7 @@ static int max31790_fan_speed_channel_get(const struct device *dev, enum sensor_
 	return 0;
 }
 
-static const struct sensor_driver_api max31790_fan_speed_api = {
+static DEVICE_API(sensor, max31790_fan_speed_api) = {
 	.sample_fetch = max31790_fan_speed_sample_fetch,
 	.channel_get = max31790_fan_speed_channel_get,
 };

--- a/drivers/sensor/maxim/max31855/max31855.c
+++ b/drivers/sensor/maxim/max31855/max31855.c
@@ -103,7 +103,7 @@ static int max31855_channel_get(const struct device *dev, enum sensor_channel ch
 	return 0;
 }
 
-static const struct sensor_driver_api max31855_api = {
+static DEVICE_API(sensor, max31855_api) = {
 	.sample_fetch = max31855_sample_fetch,
 	.channel_get = max31855_channel_get,
 };

--- a/drivers/sensor/maxim/max31865/max31865.c
+++ b/drivers/sensor/maxim/max31865/max31865.c
@@ -302,7 +302,7 @@ static int max31865_attr_set(const struct device *dev, enum sensor_channel chan,
 	}
 }
 
-static const struct sensor_driver_api max31865_api_funcs = {
+static DEVICE_API(sensor, max31865_api_funcs) = {
 	.sample_fetch = max31865_sample_fetch,
 	.channel_get = max31865_channel_get,
 	.attr_set = max31865_attr_set,

--- a/drivers/sensor/maxim/max31875/max31875.c
+++ b/drivers/sensor/maxim/max31875/max31875.c
@@ -237,7 +237,7 @@ static int max31875_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api max31875_driver_api = {
+static DEVICE_API(sensor, max31875_driver_api) = {
 	.attr_set = max31875_attr_set,
 	.sample_fetch = max31875_sample_fetch,
 	.channel_get = max31875_channel_get,

--- a/drivers/sensor/maxim/max44009/max44009.c
+++ b/drivers/sensor/maxim/max44009/max44009.c
@@ -165,7 +165,7 @@ static int max44009_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api max44009_driver_api = {
+static DEVICE_API(sensor, max44009_driver_api) = {
 	.attr_set = max44009_attr_set,
 	.sample_fetch = max44009_sample_fetch,
 	.channel_get = max44009_channel_get,

--- a/drivers/sensor/maxim/max6675/max6675.c
+++ b/drivers/sensor/maxim/max6675/max6675.c
@@ -82,7 +82,7 @@ static int max6675_channel_get(const struct device *dev, enum sensor_channel cha
 	return 0;
 }
 
-static const struct sensor_driver_api max6675_api = {
+static DEVICE_API(sensor, max6675_api) = {
 	.sample_fetch = &max6675_sample_fetch,
 	.channel_get = &max6675_channel_get,
 };

--- a/drivers/sensor/meas/ms5607/ms5607.c
+++ b/drivers/sensor/meas/ms5607/ms5607.c
@@ -310,7 +310,7 @@ static int ms5607_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api ms5607_api_funcs = {
+static DEVICE_API(sensor, ms5607_api_funcs) = {
 	.attr_set = ms5607_attr_set,
 	.sample_fetch = ms5607_sample_fetch,
 	.channel_get = ms5607_channel_get,

--- a/drivers/sensor/meas/ms5837/ms5837.c
+++ b/drivers/sensor/meas/ms5837/ms5837.c
@@ -263,7 +263,7 @@ static int ms5837_attr_set(const struct device *dev, enum sensor_channel chan,
 	return -ENOTSUP;
 }
 
-static const struct sensor_driver_api ms5837_api_funcs = {
+static DEVICE_API(sensor, ms5837_api_funcs) = {
 	.attr_set = ms5837_attr_set,
 	.sample_fetch = ms5837_sample_fetch,
 	.channel_get = ms5837_channel_get,

--- a/drivers/sensor/memsic/mc3419/mc3419.c
+++ b/drivers/sensor/memsic/mc3419/mc3419.c
@@ -285,7 +285,7 @@ static int mc3419_init(const struct device *dev)
 	return ret;
 }
 
-static const struct sensor_driver_api mc3419_api = {
+static DEVICE_API(sensor, mc3419_api) = {
 	.attr_set = mc3419_attr_set,
 #if defined(CONFIG_MC3419_TRIGGER)
 	.trigger_set = mc3419_trigger_set,

--- a/drivers/sensor/memsic/mmc56x3/mmc56x3.c
+++ b/drivers/sensor/memsic/mmc56x3/mmc56x3.c
@@ -439,7 +439,7 @@ static int mmc56x3_attr_get(const struct device *dev, enum sensor_channel chan,
 	return ret;
 }
 
-static const struct sensor_driver_api mmc56x3_api_funcs = {
+static DEVICE_API(sensor, mmc56x3_api_funcs) = {
 	.sample_fetch = mmc56x3_sample_fetch,
 	.channel_get = mmc56x3_channel_get,
 	.attr_get = mmc56x3_attr_get,

--- a/drivers/sensor/mhz19b/mhz19b.c
+++ b/drivers/sensor/mhz19b/mhz19b.c
@@ -247,7 +247,7 @@ static int mhz19b_sample_fetch(const struct device *dev, enum sensor_channel cha
 	return -ENOTSUP;
 }
 
-static const struct sensor_driver_api mhz19b_api_funcs = {
+static DEVICE_API(sensor, mhz19b_api_funcs) = {
 	.attr_set = mhz19b_attr_set,
 	.attr_get = mhz19b_attr_get,
 	.sample_fetch = mhz19b_sample_fetch,

--- a/drivers/sensor/microchip/mchp_tach_xec/tach_mchp_xec.c
+++ b/drivers/sensor/microchip/mchp_tach_xec/tach_mchp_xec.c
@@ -177,7 +177,7 @@ static int tach_xec_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api tach_xec_driver_api = {
+static DEVICE_API(sensor, tach_xec_driver_api) = {
 	.sample_fetch = tach_xec_sample_fetch,
 	.channel_get = tach_xec_channel_get,
 };

--- a/drivers/sensor/microchip/mcp9600/mcp9600.c
+++ b/drivers/sensor/microchip/mcp9600/mcp9600.c
@@ -104,7 +104,7 @@ static int mcp9600_channel_get(const struct device *dev, enum sensor_channel cha
 	return 0;
 }
 
-static const struct sensor_driver_api mcp9600_api = {
+static DEVICE_API(sensor, mcp9600_api) = {
 	.sample_fetch = mcp9600_sample_fetch,
 	.channel_get = mcp9600_channel_get,
 };

--- a/drivers/sensor/microchip/mcp970x/mcp970x.c
+++ b/drivers/sensor/microchip/mcp970x/mcp970x.c
@@ -91,7 +91,7 @@ static int get(const struct device *dev, enum sensor_channel chan, struct sensor
 	return 0;
 }
 
-static const struct sensor_driver_api mcp970x_api = {
+static DEVICE_API(sensor, mcp970x_api) = {
 	.sample_fetch = fetch,
 	.channel_get = get,
 };

--- a/drivers/sensor/microchip/tcn75a/tcn75a.c
+++ b/drivers/sensor/microchip/tcn75a/tcn75a.c
@@ -63,7 +63,7 @@ static int tcn75a_channel_get(const struct device *dev, enum sensor_channel chan
 	return 0;
 }
 
-static const struct sensor_driver_api tcn75a_api = {
+static DEVICE_API(sensor, tcn75a_api) = {
 	.sample_fetch = &tcn75a_sample_fetch,
 	.channel_get = &tcn75a_channel_get,
 #ifdef CONFIG_TCN75A_TRIGGER

--- a/drivers/sensor/nct75/nct75.c
+++ b/drivers/sensor/nct75/nct75.c
@@ -80,7 +80,7 @@ static int nct75_channel_get(const struct device *dev, enum sensor_channel chan,
 	return 0;
 }
 
-static const struct sensor_driver_api nct75_api = {
+static DEVICE_API(sensor, nct75_api) = {
 	.sample_fetch = nct75_sample_fetch,
 	.channel_get = nct75_channel_get,
 };

--- a/drivers/sensor/nordic/npm1300_charger/npm1300_charger.c
+++ b/drivers/sensor/nordic/npm1300_charger/npm1300_charger.c
@@ -661,7 +661,7 @@ int npm1300_charger_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api npm1300_charger_battery_driver_api = {
+static DEVICE_API(sensor, npm1300_charger_battery_driver_api) = {
 	.sample_fetch = npm1300_charger_sample_fetch,
 	.channel_get = npm1300_charger_channel_get,
 	.attr_set = npm1300_charger_attr_set,

--- a/drivers/sensor/nordic/qdec_nrfx/qdec_nrfx.c
+++ b/drivers/sensor/nordic/qdec_nrfx/qdec_nrfx.c
@@ -186,7 +186,7 @@ static void qdec_nrfx_gpio_ctrl(const struct device *dev, bool enable)
 	}
 }
 
-static const struct sensor_driver_api qdec_nrfx_driver_api = {
+static DEVICE_API(sensor, qdec_nrfx_driver_api) = {
 	.sample_fetch = qdec_nrfx_sample_fetch,
 	.channel_get  = qdec_nrfx_channel_get,
 	.trigger_set  = qdec_nrfx_trigger_set,

--- a/drivers/sensor/nordic/temp/temp_nrf5.c
+++ b/drivers/sensor/nordic/temp/temp_nrf5.c
@@ -104,7 +104,7 @@ static void temp_nrf5_isr(const void *arg)
 	k_sem_give(&data->device_sync_sem);
 }
 
-static const struct sensor_driver_api temp_nrf5_driver_api = {
+static DEVICE_API(sensor, temp_nrf5_driver_api) = {
 	.sample_fetch = temp_nrf5_sample_fetch,
 	.channel_get = temp_nrf5_channel_get,
 };

--- a/drivers/sensor/nordic/temp/temp_nrfs.c
+++ b/drivers/sensor/nordic/temp/temp_nrfs.c
@@ -281,7 +281,7 @@ static int temp_nrfs_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api temp_nrfs_drv_api = {
+static DEVICE_API(sensor, temp_nrfs_drv_api) = {
 #ifdef CONFIG_TEMP_NRFS_TRIGGER
 	.attr_set = api_sensor_attr_set,
 	.trigger_set = api_sensor_trigger_set,

--- a/drivers/sensor/ntc_thermistor/ntc_thermistor.c
+++ b/drivers/sensor/ntc_thermistor/ntc_thermistor.c
@@ -87,7 +87,7 @@ static int ntc_thermistor_channel_get(const struct device *dev, enum sensor_chan
 	return 0;
 }
 
-static const struct sensor_driver_api ntc_thermistor_driver_api = {
+static DEVICE_API(sensor, ntc_thermistor_driver_api) = {
 	.sample_fetch = ntc_thermistor_sample_fetch,
 	.channel_get = ntc_thermistor_channel_get,
 };

--- a/drivers/sensor/nuvoton/nuvoton_adc_cmp_npcx/adc_cmp_npcx.c
+++ b/drivers/sensor/nuvoton/nuvoton_adc_cmp_npcx/adc_cmp_npcx.c
@@ -243,7 +243,7 @@ static int adc_cmp_npcx_channel_get(const struct device *dev,
 	return -ENOTSUP;
 }
 
-static const struct sensor_driver_api adc_cmp_npcx_api = {
+static DEVICE_API(sensor, adc_cmp_npcx_api) = {
 	.attr_set = adc_cmp_npcx_attr_set,
 	.attr_get = adc_cmp_npcx_attr_get,
 	.trigger_set = adc_cmp_npcx_trigger_set,

--- a/drivers/sensor/nuvoton/nuvoton_tach_npcx/tach_nuvoton_npcx.c
+++ b/drivers/sensor/nuvoton/nuvoton_tach_npcx/tach_nuvoton_npcx.c
@@ -363,7 +363,7 @@ static int tach_npcx_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api tach_npcx_driver_api = {
+static DEVICE_API(sensor, tach_npcx_driver_api) = {
 	.sample_fetch = tach_npcx_sample_fetch,
 	.channel_get = tach_npcx_channel_get,
 };

--- a/drivers/sensor/nxp/fxas21002/fxas21002.c
+++ b/drivers/sensor/nxp/fxas21002/fxas21002.c
@@ -437,7 +437,7 @@ static int fxas21002_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api fxas21002_driver_api = {
+static DEVICE_API(sensor, fxas21002_driver_api) = {
 	.sample_fetch = fxas21002_sample_fetch,
 	.channel_get = fxas21002_channel_get,
 #if CONFIG_FXAS21002_TRIGGER

--- a/drivers/sensor/nxp/fxls8974/fxls8974.c
+++ b/drivers/sensor/nxp/fxls8974/fxls8974.c
@@ -580,7 +580,7 @@ static int fxls8974_init(const struct device *dev)
 		return 0;
 }
 
-static const struct sensor_driver_api fxls8974_driver_api = {
+static DEVICE_API(sensor, fxls8974_driver_api) = {
 		.sample_fetch = fxls8974_sample_fetch,
 		.channel_get = fxls8974_channel_get,
 		.attr_set = fxls8974_attr_set,

--- a/drivers/sensor/nxp/fxos8700/fxos8700.c
+++ b/drivers/sensor/nxp/fxos8700/fxos8700.c
@@ -656,7 +656,7 @@ static int fxos8700_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api fxos8700_driver_api = {
+static DEVICE_API(sensor, fxos8700_driver_api) = {
 	.sample_fetch = fxos8700_sample_fetch,
 	.channel_get = fxos8700_channel_get,
 	.attr_set = fxos8700_attr_set,

--- a/drivers/sensor/nxp/mcux_acmp/mcux_acmp.c
+++ b/drivers/sensor/nxp/mcux_acmp/mcux_acmp.c
@@ -520,7 +520,7 @@ static int mcux_acmp_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api mcux_acmp_driver_api = {
+static DEVICE_API(sensor, mcux_acmp_driver_api) = {
 	.attr_set = mcux_acmp_attr_set,
 	.attr_get = mcux_acmp_attr_get,
 #ifdef CONFIG_SENSOR_MCUX_ACMP_TRIGGER

--- a/drivers/sensor/nxp/mcux_lpcmp/mcux_lpcmp.c
+++ b/drivers/sensor/nxp/mcux_lpcmp/mcux_lpcmp.c
@@ -398,7 +398,7 @@ static int mcux_lpcmp_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api mcux_lpcmp_driver_api = {
+static DEVICE_API(sensor, mcux_lpcmp_driver_api) = {
 	.attr_set = mcux_lpcmp_attr_set,
 	.attr_get = mcux_lpcmp_attr_get,
 #ifdef CONFIG_MCUX_LPCMP_TRIGGER

--- a/drivers/sensor/nxp/nxp_kinetis_temp/temp_kinetis.c
+++ b/drivers/sensor/nxp/nxp_kinetis_temp/temp_kinetis.c
@@ -131,7 +131,7 @@ static int temp_kinetis_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api temp_kinetis_driver_api = {
+static DEVICE_API(sensor, temp_kinetis_driver_api) = {
 	.sample_fetch = temp_kinetis_sample_fetch,
 	.channel_get = temp_kinetis_channel_get,
 };

--- a/drivers/sensor/nxp/nxp_tempmon/nxp_tempmon.c
+++ b/drivers/sensor/nxp/nxp_tempmon/nxp_tempmon.c
@@ -72,7 +72,7 @@ static int nxp_tempmon_channel_get(const struct device *dev, enum sensor_channel
 	return sensor_value_from_double(val, temp);
 }
 
-static const struct sensor_driver_api nxp_tempmon_driver_api = {
+static DEVICE_API(sensor, nxp_tempmon_driver_api) = {
 	.sample_fetch = nxp_tempmon_sample_fetch,
 	.channel_get = nxp_tempmon_channel_get,
 };

--- a/drivers/sensor/nxp/p3t1755/p3t1755.c
+++ b/drivers/sensor/nxp/p3t1755/p3t1755.c
@@ -147,7 +147,7 @@ static int p3t1755_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api p3t1755_driver_api = {
+static DEVICE_API(sensor, p3t1755_driver_api) = {
 	.sample_fetch = p3t1755_sample_fetch,
 	.channel_get = p3t1755_channel_get,
 };

--- a/drivers/sensor/nxp/qdec_mcux/qdec_mcux.c
+++ b/drivers/sensor/nxp/qdec_mcux/qdec_mcux.c
@@ -124,7 +124,7 @@ static int qdec_mcux_ch_get(const struct device *dev, enum sensor_channel ch,
 	return 0;
 }
 
-static const struct sensor_driver_api qdec_mcux_api = {
+static DEVICE_API(sensor, qdec_mcux_api) = {
 	.attr_set = &qdec_mcux_attr_set,
 	.attr_get = &qdec_mcux_attr_get,
 	.sample_fetch = &qdec_mcux_fetch,

--- a/drivers/sensor/nxp/qdec_nxp_s32/qdec_nxp_s32.c
+++ b/drivers/sensor/nxp/qdec_nxp_s32/qdec_nxp_s32.c
@@ -123,7 +123,7 @@ static int qdec_s32_ch_get(const struct device *dev, enum sensor_channel ch,
 	return 0;
 }
 
-static const struct sensor_driver_api qdec_s32_api = {
+static DEVICE_API(sensor, qdec_s32_api) = {
 	.sample_fetch = &qdec_s32_fetch,
 	.channel_get = &qdec_s32_ch_get,
 };

--- a/drivers/sensor/pms7003/pms7003.c
+++ b/drivers/sensor/pms7003/pms7003.c
@@ -167,7 +167,7 @@ static int pms7003_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api pms7003_api = {
+static DEVICE_API(sensor, pms7003_api) = {
 	.sample_fetch = &pms7003_sample_fetch,
 	.channel_get = &pms7003_channel_get,
 };

--- a/drivers/sensor/qdec_sam/qdec_sam.c
+++ b/drivers/sensor/qdec_sam/qdec_sam.c
@@ -117,7 +117,7 @@ static int qdec_sam_initialize(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api qdec_sam_driver_api = {
+static DEVICE_API(sensor, qdec_sam_driver_api) = {
 	.sample_fetch = qdec_sam_fetch,
 	.channel_get = qdec_sam_get,
 };

--- a/drivers/sensor/renesas/hs300x/hs300x.c
+++ b/drivers/sensor/renesas/hs300x/hs300x.c
@@ -150,8 +150,10 @@ static int hs300x_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api hs300x_driver_api = {.sample_fetch = hs300x_sample_fetch,
-							   .channel_get = hs300x_channel_get};
+static DEVICE_API(sensor, hs300x_driver_api) = {
+	.sample_fetch = hs300x_sample_fetch,
+	.channel_get = hs300x_channel_get,
+};
 
 #define DEFINE_HS300X(n)                                                                           \
 	static struct hs300x_data hs300x_data_##n;                                                 \

--- a/drivers/sensor/renesas/isl29035/isl29035.c
+++ b/drivers/sensor/renesas/isl29035/isl29035.c
@@ -65,7 +65,7 @@ static int isl29035_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api isl29035_api = {
+static DEVICE_API(sensor, isl29035_api) = {
 #if CONFIG_ISL29035_TRIGGER
 	.attr_set = &isl29035_attr_set,
 	.trigger_set = &isl29035_trigger_set,

--- a/drivers/sensor/rohm/bd8lb600fs/bd8lb600fs_diagnostics.c
+++ b/drivers/sensor/rohm/bd8lb600fs/bd8lb600fs_diagnostics.c
@@ -45,7 +45,7 @@ static int bd8lb600fs_diagnostics_channel_get(const struct device *dev, enum sen
 	}
 }
 
-static const struct sensor_driver_api bd8lb600fs_diagnostics_driver_api = {
+static DEVICE_API(sensor, bd8lb600fs_diagnostics_driver_api) = {
 	.sample_fetch = bd8lb600fs_diagnostics_sample_fetch,
 	.channel_get = bd8lb600fs_diagnostics_channel_get,
 };

--- a/drivers/sensor/rohm/bh1750/bh1750.c
+++ b/drivers/sensor/rohm/bh1750/bh1750.c
@@ -187,7 +187,7 @@ static int bh1750_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api bh1750_driver_api = {
+static DEVICE_API(sensor, bh1750_driver_api) = {
 	.sample_fetch = bh1750_sample_fetch,
 	.channel_get = bh1750_channel_get
 };

--- a/drivers/sensor/rpi_pico_temp/rpi_pico_temp.c
+++ b/drivers/sensor/rpi_pico_temp/rpi_pico_temp.c
@@ -82,7 +82,7 @@ static int rpi_pico_temp_channel_get(const struct device *dev, enum sensor_chann
 	return 0;
 }
 
-static const struct sensor_driver_api rpi_pico_temp_driver_api = {
+static DEVICE_API(sensor, rpi_pico_temp_driver_api) = {
 	.sample_fetch = rpi_pico_temp_sample_fetch,
 	.channel_get = rpi_pico_temp_channel_get,
 };

--- a/drivers/sensor/s11059/s11059.c
+++ b/drivers/sensor/s11059/s11059.c
@@ -290,7 +290,7 @@ static int s11059_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api s11059_driver_api = {
+static DEVICE_API(sensor, s11059_driver_api) = {
 	.sample_fetch = s11059_sample_fetch,
 	.channel_get = s11059_channel_get,
 };

--- a/drivers/sensor/sbs_gauge/sbs_gauge.c
+++ b/drivers/sensor/sbs_gauge/sbs_gauge.c
@@ -272,7 +272,7 @@ static int sbs_gauge_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api sbs_gauge_driver_api = {
+static DEVICE_API(sensor, sbs_gauge_driver_api) = {
 	.sample_fetch = sbs_gauge_sample_fetch,
 	.channel_get = sbs_gauge_channel_get,
 };

--- a/drivers/sensor/seeed/grove/light_sensor.c
+++ b/drivers/sensor/seeed/grove/light_sensor.c
@@ -78,7 +78,7 @@ static int gls_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api gls_api = {
+static DEVICE_API(sensor, gls_api) = {
 	.sample_fetch = &gls_sample_fetch,
 	.channel_get = &gls_channel_get,
 };

--- a/drivers/sensor/seeed/grove/temperature_sensor.c
+++ b/drivers/sensor/seeed/grove/temperature_sensor.c
@@ -80,7 +80,7 @@ static int gts_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api gts_api = {
+static DEVICE_API(sensor, gts_api) = {
 	.sample_fetch = &gts_sample_fetch,
 	.channel_get = &gts_channel_get,
 };

--- a/drivers/sensor/seeed/hm330x/hm330x.c
+++ b/drivers/sensor/seeed/hm330x/hm330x.c
@@ -84,7 +84,7 @@ static int hm330x_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api hm330x_driver_api = {
+static DEVICE_API(sensor, hm330x_driver_api) = {
 	.sample_fetch = hm330x_sample_fetch,
 	.channel_get = hm330x_channel_get
 };

--- a/drivers/sensor/sensirion/scd4x/scd4x.c
+++ b/drivers/sensor/sensirion/scd4x/scd4x.c
@@ -881,7 +881,7 @@ static int scd4x_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api scd4x_api_funcs = {
+static DEVICE_API(sensor, scd4x_api_funcs) = {
 	.sample_fetch = scd4x_sample_fetch,
 	.channel_get = scd4x_channel_get,
 	.attr_set = scd4x_attr_set,

--- a/drivers/sensor/sensirion/sgp40/sgp40.c
+++ b/drivers/sensor/sensirion/sgp40/sgp40.c
@@ -242,7 +242,7 @@ static int sgp40_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api sgp40_api = {
+static DEVICE_API(sensor, sgp40_api) = {
 	.sample_fetch = sgp40_sample_fetch,
 	.channel_get = sgp40_channel_get,
 	.attr_set = sgp40_attr_set,

--- a/drivers/sensor/sensirion/sht3xd/sht3xd.c
+++ b/drivers/sensor/sensirion/sht3xd/sht3xd.c
@@ -156,7 +156,7 @@ static int sht3xd_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api sht3xd_driver_api = {
+static DEVICE_API(sensor, sht3xd_driver_api) = {
 #ifdef CONFIG_SHT3XD_TRIGGER
 	.attr_set = sht3xd_attr_set,
 	.trigger_set = sht3xd_trigger_set,

--- a/drivers/sensor/sensirion/sht4x/sht4x.c
+++ b/drivers/sensor/sensirion/sht4x/sht4x.c
@@ -202,7 +202,7 @@ static int sht4x_init(const struct device *dev)
 }
 
 
-static const struct sensor_driver_api sht4x_api = {
+static DEVICE_API(sensor, sht4x_api) = {
 	.sample_fetch = sht4x_sample_fetch,
 	.channel_get = sht4x_channel_get,
 	.attr_set = sht4x_attr_set,

--- a/drivers/sensor/sensirion/shtcx/shtcx.c
+++ b/drivers/sensor/sensirion/shtcx/shtcx.c
@@ -183,7 +183,7 @@ static int shtcx_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api shtcx_driver_api = {
+static DEVICE_API(sensor, shtcx_driver_api) = {
 	.sample_fetch = shtcx_sample_fetch,
 	.channel_get = shtcx_channel_get,
 };

--- a/drivers/sensor/sensirion/sts4x/sts4x.c
+++ b/drivers/sensor/sensirion/sts4x/sts4x.c
@@ -150,7 +150,7 @@ static int sts4x_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api sts4x_api_funcs = {
+static DEVICE_API(sensor, sts4x_api_funcs) = {
 	.sample_fetch = sts4x_sample_fetch,
 	.channel_get = sts4x_channel_get,
 };

--- a/drivers/sensor/sensor_shell.c
+++ b/drivers/sensor/sensor_shell.c
@@ -169,6 +169,11 @@ static int find_sensor_trigger_device(const struct device *sensor)
 	return -1;
 }
 
+static bool sensor_device_check(const struct device *dev)
+{
+	return DEVICE_API_IS(sensor, dev);
+}
+
 /* Forward declaration */
 static void data_ready_trigger_handler(const struct device *sensor,
 				       const struct sensor_trigger *trigger);
@@ -544,8 +549,8 @@ static int cmd_get_sensor(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	dev = device_get_binding(argv[1]);
-	if (dev == NULL) {
-		shell_error(sh, "Device unknown (%s)", argv[1]);
+	if (dev == NULL || !sensor_device_check(dev)) {
+		shell_error(sh, "Sensor device unknown (%s)", argv[1]);
 		k_mutex_unlock(&cmd_get_mutex);
 		return -ENODEV;
 	}
@@ -613,8 +618,8 @@ static int cmd_sensor_attr_set(const struct shell *shell_ptr, size_t argc, char 
 	int rc;
 
 	dev = device_get_binding(argv[1]);
-	if (dev == NULL) {
-		shell_error(shell_ptr, "Device unknown (%s)", argv[1]);
+	if (dev == NULL || !sensor_device_check(dev)) {
+		shell_error(shell_ptr, "Sensor device unknown (%s)", argv[1]);
 		return -ENODEV;
 	}
 
@@ -697,8 +702,8 @@ static int cmd_sensor_attr_get(const struct shell *shell_ptr, size_t argc, char 
 	const struct device *dev;
 
 	dev = device_get_binding(argv[1]);
-	if (dev == NULL) {
-		shell_error(shell_ptr, "Device unknown (%s)", argv[1]);
+	if (dev == NULL || !sensor_device_check(dev)) {
+		shell_error(shell_ptr, "Sensor device unknown (%s)", argv[1]);
 		return -ENODEV;
 	}
 
@@ -848,7 +853,7 @@ SHELL_DYNAMIC_CMD_CREATE(dsub_device_name, device_name_get);
 
 static void device_name_get(size_t idx, struct shell_static_entry *entry)
 {
-	const struct device *dev = shell_device_lookup(idx, NULL);
+	const struct device *dev = shell_device_filter(idx, sensor_device_check);
 
 	current_cmd_ctx = CTX_GET;
 	entry->syntax = (dev != NULL) ? dev->name : NULL;
@@ -1047,8 +1052,8 @@ static int cmd_trig_sensor(const struct shell *sh, size_t argc, char **argv)
 
 	/* Parse device name */
 	dev = device_get_binding(argv[1]);
-	if (dev == NULL) {
-		shell_error(sh, "Device unknown (%s)", argv[1]);
+	if (dev == NULL || !sensor_device_check(dev)) {
+		shell_error(sh, "Sensor device unknown (%s)", argv[1]);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/silabs/si7006/si7006.c
+++ b/drivers/sensor/silabs/si7006/si7006.c
@@ -172,7 +172,7 @@ static int si7006_channel_get(const struct device *dev,
 	}
 }
 
-static const struct sensor_driver_api si7006_api = {
+static DEVICE_API(sensor, si7006_api) = {
 	.sample_fetch = &si7006_sample_fetch,
 	.channel_get = &si7006_channel_get,
 };

--- a/drivers/sensor/silabs/si7055/si7055.c
+++ b/drivers/sensor/silabs/si7055/si7055.c
@@ -119,7 +119,7 @@ static int si7055_channel_get(const struct device *dev,
 	}
 }
 
-static const struct sensor_driver_api si7055_api = {
+static DEVICE_API(sensor, si7055_api) = {
 	.sample_fetch = &si7055_sample_fetch,
 	.channel_get = &si7055_channel_get,
 };

--- a/drivers/sensor/silabs/si7060/si7060.c
+++ b/drivers/sensor/silabs/si7060/si7060.c
@@ -92,7 +92,7 @@ static int si7060_channel_get(const struct device *dev,
 	}
 }
 
-static const struct sensor_driver_api si7060_api = {
+static DEVICE_API(sensor, si7060_api) = {
 	.sample_fetch = &si7060_sample_fetch,
 	.channel_get = &si7060_channel_get,
 };

--- a/drivers/sensor/silabs/si7210/si7210.c
+++ b/drivers/sensor/silabs/si7210/si7210.c
@@ -421,7 +421,7 @@ static int si7210_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api si7210_api_funcs = {
+static DEVICE_API(sensor, si7210_api_funcs) = {
 	.sample_fetch = si7210_sample_fetch,
 	.channel_get = si7210_channel_get,
 };

--- a/drivers/sensor/st/hts221/hts221.c
+++ b/drivers/sensor/st/hts221/hts221.c
@@ -114,7 +114,7 @@ static int hts221_read_conversion_data(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api hts221_driver_api = {
+static DEVICE_API(sensor, hts221_driver_api) = {
 #ifdef CONFIG_HTS221_TRIGGER
 	.trigger_set = hts221_trigger_set,
 #endif

--- a/drivers/sensor/st/i3g4250d/i3g4250d.c
+++ b/drivers/sensor/st/i3g4250d/i3g4250d.c
@@ -158,7 +158,7 @@ static int i3g4250d_attr_set(const struct device *dev, enum sensor_channel chan,
 	return -ENOTSUP;
 }
 
-static const struct sensor_driver_api i3g4250d_driver_api = {
+static DEVICE_API(sensor, i3g4250d_driver_api) = {
 	.attr_set = i3g4250d_attr_set,
 	.sample_fetch = i3g4250d_sample_fetch,
 	.channel_get = i3g4250d_channel_get,

--- a/drivers/sensor/st/iis2dh/iis2dh.c
+++ b/drivers/sensor/st/iis2dh/iis2dh.c
@@ -219,7 +219,7 @@ static int iis2dh_sample_fetch(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api iis2dh_driver_api = {
+static DEVICE_API(sensor, iis2dh_driver_api) = {
 	.attr_set = iis2dh_attr_set,
 #if CONFIG_IIS2DH_TRIGGER
 	.trigger_set = iis2dh_trigger_set,

--- a/drivers/sensor/st/iis2dlpc/iis2dlpc.c
+++ b/drivers/sensor/st/iis2dlpc/iis2dlpc.c
@@ -250,7 +250,7 @@ static int iis2dlpc_sample_fetch(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api iis2dlpc_driver_api = {
+static DEVICE_API(sensor, iis2dlpc_driver_api) = {
 	.attr_set = iis2dlpc_attr_set,
 #if CONFIG_IIS2DLPC_TRIGGER
 	.trigger_set = iis2dlpc_trigger_set,

--- a/drivers/sensor/st/iis2iclx/iis2iclx.c
+++ b/drivers/sensor/st/iis2iclx/iis2iclx.c
@@ -517,7 +517,7 @@ static int iis2iclx_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api iis2iclx_driver_api = {
+static DEVICE_API(sensor, iis2iclx_driver_api) = {
 	.attr_set = iis2iclx_attr_set,
 #if CONFIG_IIS2ICLX_TRIGGER
 	.trigger_set = iis2iclx_trigger_set,

--- a/drivers/sensor/st/iis2mdc/iis2mdc.c
+++ b/drivers/sensor/st/iis2mdc/iis2mdc.c
@@ -234,7 +234,7 @@ static int iis2mdc_sample_fetch(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api iis2mdc_driver_api = {
+static DEVICE_API(sensor, iis2mdc_driver_api) = {
 	.attr_set = iis2mdc_attr_set,
 #if CONFIG_IIS2MDC_TRIGGER
 	.trigger_set = iis2mdc_trigger_set,

--- a/drivers/sensor/st/iis328dq/iis328dq.c
+++ b/drivers/sensor/st/iis328dq/iis328dq.c
@@ -293,7 +293,7 @@ static int iis328dq_sample_fetch(const struct device *dev, enum sensor_channel c
 	return 0;
 }
 
-static const struct sensor_driver_api iis328dq_driver_api = {
+static DEVICE_API(sensor, iis328dq_driver_api) = {
 	.attr_set = iis328dq_attr_set,
 #if CONFIG_IIS328DQ_TRIGGER
 	.trigger_set = iis328dq_trigger_set,

--- a/drivers/sensor/st/iis3dhhc/iis3dhhc.c
+++ b/drivers/sensor/st/iis3dhhc/iis3dhhc.c
@@ -141,7 +141,7 @@ static int iis3dhhc_attr_set(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api iis3dhhc_api_funcs = {
+static DEVICE_API(sensor, iis3dhhc_api_funcs) = {
 	.attr_set = iis3dhhc_attr_set,
 	.sample_fetch = iis3dhhc_sample_fetch,
 	.channel_get = iis3dhhc_channel_get,

--- a/drivers/sensor/st/ism330dhcx/ism330dhcx.c
+++ b/drivers/sensor/st/ism330dhcx/ism330dhcx.c
@@ -677,7 +677,7 @@ static int ism330dhcx_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api ism330dhcx_api_funcs = {
+static DEVICE_API(sensor, ism330dhcx_api_funcs) = {
 	.attr_set = ism330dhcx_attr_set,
 #if CONFIG_ISM330DHCX_TRIGGER
 	.trigger_set = ism330dhcx_trigger_set,

--- a/drivers/sensor/st/lis2de12/lis2de12.c
+++ b/drivers/sensor/st/lis2de12/lis2de12.c
@@ -303,7 +303,7 @@ static int lis2de12_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api lis2de12_driver_api = {
+static DEVICE_API(sensor, lis2de12_driver_api) = {
 	.attr_set = lis2de12_attr_set,
 #if CONFIG_LIS2DE12_TRIGGER
 	.trigger_set = lis2de12_trigger_set,

--- a/drivers/sensor/st/lis2dh/lis2dh.c
+++ b/drivers/sensor/st/lis2dh/lis2dh.c
@@ -320,7 +320,7 @@ static int lis2dh_attr_set(const struct device *dev, enum sensor_channel chan,
 	return 0;
 }
 
-static const struct sensor_driver_api lis2dh_driver_api = {
+static DEVICE_API(sensor, lis2dh_driver_api) = {
 	.attr_set = lis2dh_attr_set,
 #if CONFIG_LIS2DH_TRIGGER
 	.trigger_set = lis2dh_trigger_set,

--- a/drivers/sensor/st/lis2ds12/lis2ds12.c
+++ b/drivers/sensor/st/lis2ds12/lis2ds12.c
@@ -258,7 +258,7 @@ static int lis2ds12_channel_get(const struct device *dev,
 	return lis2ds12_get_channel(chan, val, data, data->gain);
 }
 
-static const struct sensor_driver_api lis2ds12_driver_api = {
+static DEVICE_API(sensor, lis2ds12_driver_api) = {
 	.attr_set = lis2ds12_attr_set,
 #if defined(CONFIG_LIS2DS12_TRIGGER)
 	.trigger_set = lis2ds12_trigger_set,

--- a/drivers/sensor/st/lis2du12/lis2du12.c
+++ b/drivers/sensor/st/lis2du12/lis2du12.c
@@ -304,7 +304,7 @@ static int lis2du12_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api lis2du12_driver_api = {
+static DEVICE_API(sensor, lis2du12_driver_api) = {
 	.attr_set = lis2du12_attr_set,
 #if CONFIG_LIS2DU12_TRIGGER
 	.trigger_set = lis2du12_trigger_set,

--- a/drivers/sensor/st/lis2dux12/lis2dux12.c
+++ b/drivers/sensor/st/lis2dux12/lis2dux12.c
@@ -298,7 +298,7 @@ static int lis2dux12_channel_get(const struct device *dev, enum sensor_channel c
 	return lis2dux12_get_channel(chan, val, data, data->gain);
 }
 
-static const struct sensor_driver_api lis2dux12_driver_api = {
+static DEVICE_API(sensor, lis2dux12_driver_api) = {
 	.attr_set = lis2dux12_attr_set,
 #if defined(CONFIG_LIS2DUX12_TRIGGER)
 	.trigger_set = lis2dux12_trigger_set,

--- a/drivers/sensor/st/lis2dw12/lis2dw12.c
+++ b/drivers/sensor/st/lis2dw12/lis2dw12.c
@@ -428,7 +428,7 @@ static int lis2dw12_sample_fetch(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api lis2dw12_driver_api = {
+static DEVICE_API(sensor, lis2dw12_driver_api) = {
 	.attr_set = lis2dw12_attr_set,
 #if CONFIG_LIS2DW12_TRIGGER
 	.trigger_set = lis2dw12_trigger_set,

--- a/drivers/sensor/st/lis2mdl/lis2mdl.c
+++ b/drivers/sensor/st/lis2mdl/lis2mdl.c
@@ -310,7 +310,7 @@ static int lis2mdl_sample_fetch(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api lis2mdl_driver_api = {
+static DEVICE_API(sensor, lis2mdl_driver_api) = {
 	.attr_set = lis2mdl_attr_set,
 #if CONFIG_LIS2MDL_TRIGGER
 	.trigger_set = lis2mdl_trigger_set,

--- a/drivers/sensor/st/lis3mdl/lis3mdl.c
+++ b/drivers/sensor/st/lis3mdl/lis3mdl.c
@@ -94,7 +94,7 @@ int lis3mdl_sample_fetch(const struct device *dev, enum sensor_channel chan)
 	return 0;
 }
 
-static const struct sensor_driver_api lis3mdl_driver_api = {
+static DEVICE_API(sensor, lis3mdl_driver_api) = {
 #if CONFIG_LIS3MDL_TRIGGER
 	.trigger_set = lis3mdl_trigger_set,
 #endif

--- a/drivers/sensor/st/lps22hb/lps22hb.c
+++ b/drivers/sensor/st/lps22hb/lps22hb.c
@@ -88,7 +88,7 @@ static int lps22hb_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api lps22hb_api_funcs = {
+static DEVICE_API(sensor, lps22hb_api_funcs) = {
 	.sample_fetch = lps22hb_sample_fetch,
 	.channel_get = lps22hb_channel_get,
 };

--- a/drivers/sensor/st/lps22hh/lps22hh.c
+++ b/drivers/sensor/st/lps22hh/lps22hh.c
@@ -169,7 +169,7 @@ static int lps22hh_attr_set(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api lps22hh_driver_api = {
+static DEVICE_API(sensor, lps22hh_driver_api) = {
 	.attr_set = lps22hh_attr_set,
 	.sample_fetch = lps22hh_sample_fetch,
 	.channel_get = lps22hh_channel_get,

--- a/drivers/sensor/st/lps25hb/lps25hb.c
+++ b/drivers/sensor/st/lps25hb/lps25hb.c
@@ -107,7 +107,7 @@ static int lps25hb_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api lps25hb_api_funcs = {
+static DEVICE_API(sensor, lps25hb_api_funcs) = {
 	.sample_fetch = lps25hb_sample_fetch,
 	.channel_get = lps25hb_channel_get,
 };

--- a/drivers/sensor/st/lps2xdf/lps2xdf.c
+++ b/drivers/sensor/st/lps2xdf/lps2xdf.c
@@ -141,7 +141,7 @@ static int lps2xdf_sample_fetch(const struct device *dev, enum sensor_channel ch
 	return chip_api->sample_fetch(dev, chan);
 }
 
-static const struct sensor_driver_api lps2xdf_driver_api = {
+static DEVICE_API(sensor, lps2xdf_driver_api) = {
 	.attr_set = lps2xdf_attr_set,
 	.sample_fetch = lps2xdf_sample_fetch,
 	.channel_get = lps2xdf_channel_get,

--- a/drivers/sensor/st/lsm303dlhc_magn/lsm303dlhc_magn.c
+++ b/drivers/sensor/st/lsm303dlhc_magn/lsm303dlhc_magn.c
@@ -89,7 +89,7 @@ static int lsm303dlhc_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api lsm303dlhc_magn_driver_api = {
+static DEVICE_API(sensor, lsm303dlhc_magn_driver_api) = {
 	.sample_fetch = lsm303dlhc_sample_fetch,
 	.channel_get = lsm303dlhc_channel_get,
 };

--- a/drivers/sensor/st/lsm6ds0/lsm6ds0.c
+++ b/drivers/sensor/st/lsm6ds0/lsm6ds0.c
@@ -384,7 +384,7 @@ static int lsm6ds0_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api lsm6ds0_api_funcs = {
+static DEVICE_API(sensor, lsm6ds0_api_funcs) = {
 	.sample_fetch = lsm6ds0_sample_fetch,
 	.channel_get = lsm6ds0_channel_get,
 };

--- a/drivers/sensor/st/lsm6dsl/lsm6dsl.c
+++ b/drivers/sensor/st/lsm6dsl/lsm6dsl.c
@@ -699,7 +699,7 @@ static int lsm6dsl_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api lsm6dsl_driver_api = {
+static DEVICE_API(sensor, lsm6dsl_driver_api) = {
 	.attr_set = lsm6dsl_attr_set,
 #if CONFIG_LSM6DSL_TRIGGER
 	.trigger_set = lsm6dsl_trigger_set,

--- a/drivers/sensor/st/lsm6dso/lsm6dso.c
+++ b/drivers/sensor/st/lsm6dso/lsm6dso.c
@@ -694,7 +694,7 @@ static int lsm6dso_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api lsm6dso_driver_api = {
+static DEVICE_API(sensor, lsm6dso_driver_api) = {
 	.attr_set = lsm6dso_attr_set,
 #if CONFIG_LSM6DSO_TRIGGER
 	.trigger_set = lsm6dso_trigger_set,

--- a/drivers/sensor/st/lsm6dso16is/lsm6dso16is.c
+++ b/drivers/sensor/st/lsm6dso16is/lsm6dso16is.c
@@ -725,7 +725,7 @@ static int lsm6dso16is_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api lsm6dso16is_driver_api = {
+static DEVICE_API(sensor, lsm6dso16is_driver_api) = {
 	.attr_set = lsm6dso16is_attr_set,
 #if CONFIG_LSM6DSO16IS_TRIGGER
 	.trigger_set = lsm6dso16is_trigger_set,

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.c
@@ -928,7 +928,7 @@ static int lsm6dsv16x_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api lsm6dsv16x_driver_api = {
+static DEVICE_API(sensor, lsm6dsv16x_driver_api) = {
 	.attr_set = lsm6dsv16x_attr_set,
 	.attr_get = lsm6dsv16x_attr_get,
 #if CONFIG_LSM6DSV16X_TRIGGER

--- a/drivers/sensor/st/lsm9ds0_gyro/lsm9ds0_gyro.c
+++ b/drivers/sensor/st/lsm9ds0_gyro/lsm9ds0_gyro.c
@@ -243,7 +243,7 @@ static int lsm9ds0_gyro_attr_set(const struct device *dev,
 }
 #endif
 
-static const struct sensor_driver_api lsm9ds0_gyro_api_funcs = {
+static DEVICE_API(sensor, lsm9ds0_gyro_api_funcs) = {
 	.sample_fetch = lsm9ds0_gyro_sample_fetch,
 	.channel_get = lsm9ds0_gyro_channel_get,
 #if defined(LSM9DS0_GYRO_SET_ATTR)

--- a/drivers/sensor/st/lsm9ds0_mfd/lsm9ds0_mfd.c
+++ b/drivers/sensor/st/lsm9ds0_mfd/lsm9ds0_mfd.c
@@ -634,7 +634,7 @@ static int lsm9ds0_mfd_attr_set(const struct device *dev,
 }
 #endif
 
-static const struct sensor_driver_api lsm9ds0_mfd_api_funcs = {
+static DEVICE_API(sensor, lsm9ds0_mfd_api_funcs) = {
 	.sample_fetch = lsm9ds0_mfd_sample_fetch,
 	.channel_get = lsm9ds0_mfd_channel_get,
 #if defined(LSM9DS0_MFD_ATTR_SET)

--- a/drivers/sensor/st/lsm9ds1/lsm9ds1.c
+++ b/drivers/sensor/st/lsm9ds1/lsm9ds1.c
@@ -557,7 +557,7 @@ static int lsm9ds1_channel_get(const struct device *dev, enum sensor_channel cha
 	return 0;
 }
 
-static const struct sensor_driver_api lsm9ds1_api_funcs = {
+static DEVICE_API(sensor, lsm9ds1_api_funcs) = {
 	.sample_fetch = lsm9ds1_sample_fetch,
 	.channel_get = lsm9ds1_channel_get,
 	.attr_set = lsm9ds1_attr_set,

--- a/drivers/sensor/st/qdec_stm32/qdec_stm32.c
+++ b/drivers/sensor/st/qdec_stm32/qdec_stm32.c
@@ -136,7 +136,7 @@ static int qdec_stm32_initialize(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api qdec_stm32_driver_api = {
+static DEVICE_API(sensor, qdec_stm32_driver_api) = {
 	.sample_fetch = qdec_stm32_fetch,
 	.channel_get = qdec_stm32_get,
 };

--- a/drivers/sensor/st/stm32_digi_temp/stm32_digi_temp.c
+++ b/drivers/sensor/st/stm32_digi_temp/stm32_digi_temp.c
@@ -257,7 +257,7 @@ static int stm32_digi_temp_pm_action(const struct device *dev, enum pm_device_ac
 }
 #endif /* CONFIG_PM_DEVICE */
 
-static const struct sensor_driver_api stm32_digi_temp_driver_api = {
+static DEVICE_API(sensor, stm32_digi_temp_driver_api) = {
 	.sample_fetch = stm32_digi_temp_sample_fetch,
 	.channel_get = stm32_digi_temp_channel_get,
 };

--- a/drivers/sensor/st/stm32_temp/stm32_temp.c
+++ b/drivers/sensor/st/stm32_temp/stm32_temp.c
@@ -254,7 +254,7 @@ static int stm32_temp_channel_get(const struct device *dev, enum sensor_channel 
 	return sensor_value_from_float(val, temp);
 }
 
-static const struct sensor_driver_api stm32_temp_driver_api = {
+static DEVICE_API(sensor, stm32_temp_driver_api) = {
 	.sample_fetch = stm32_temp_sample_fetch,
 	.channel_get = stm32_temp_channel_get,
 };

--- a/drivers/sensor/st/stm32_vbat/stm32_vbat.c
+++ b/drivers/sensor/st/stm32_vbat/stm32_vbat.c
@@ -92,7 +92,7 @@ static int stm32_vbat_channel_get(const struct device *dev, enum sensor_channel 
 	return sensor_value_from_milli(val, voltage);
 }
 
-static const struct sensor_driver_api stm32_vbat_driver_api = {
+static DEVICE_API(sensor, stm32_vbat_driver_api) = {
 	.sample_fetch = stm32_vbat_sample_fetch,
 	.channel_get = stm32_vbat_channel_get,
 };

--- a/drivers/sensor/st/stm32_vref/stm32_vref.c
+++ b/drivers/sensor/st/stm32_vref/stm32_vref.c
@@ -121,7 +121,7 @@ static int stm32_vref_channel_get(const struct device *dev, enum sensor_channel 
 	return sensor_value_from_milli(val, vref);
 }
 
-static const struct sensor_driver_api stm32_vref_driver_api = {
+static DEVICE_API(sensor, stm32_vref_driver_api) = {
 	.sample_fetch = stm32_vref_sample_fetch,
 	.channel_get = stm32_vref_channel_get,
 };

--- a/drivers/sensor/st/stts22h/stts22h.c
+++ b/drivers/sensor/st/stts22h/stts22h.c
@@ -127,7 +127,7 @@ static int stts22h_attr_set(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api stts22h_api_funcs = {
+static DEVICE_API(sensor, stts22h_api_funcs) = {
 	.attr_set = stts22h_attr_set,
 	.sample_fetch = stts22h_sample_fetch,
 	.channel_get = stts22h_channel_get,

--- a/drivers/sensor/st/stts751/stts751.c
+++ b/drivers/sensor/st/stts751/stts751.c
@@ -131,7 +131,7 @@ static int stts751_attr_set(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api stts751_api_funcs = {
+static DEVICE_API(sensor, stts751_api_funcs) = {
 	.attr_set = stts751_attr_set,
 	.sample_fetch = stts751_sample_fetch,
 	.channel_get = stts751_channel_get,

--- a/drivers/sensor/st/vl53l0x/vl53l0x.c
+++ b/drivers/sensor/st/vl53l0x/vl53l0x.c
@@ -295,7 +295,7 @@ static int vl53l0x_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api vl53l0x_api_funcs = {
+static DEVICE_API(sensor, vl53l0x_api_funcs) = {
 	.sample_fetch = vl53l0x_sample_fetch,
 	.channel_get = vl53l0x_channel_get,
 };

--- a/drivers/sensor/st/vl53l1x/vl53l1.c
+++ b/drivers/sensor/st/vl53l1x/vl53l1.c
@@ -408,7 +408,7 @@ static int vl53l1x_attr_set(const struct device *dev,
 	return ret;
 }
 
-static const struct sensor_driver_api vl53l1x_api_funcs = {
+static DEVICE_API(sensor, vl53l1x_api_funcs) = {
 	.sample_fetch = vl53l1x_sample_fetch,
 	.channel_get = vl53l1x_channel_get,
 	.attr_get = vl53l1x_attr_get,

--- a/drivers/sensor/sx9500/sx9500.c
+++ b/drivers/sensor/sx9500/sx9500.c
@@ -75,7 +75,7 @@ static int sx9500_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api sx9500_api_funcs = {
+static DEVICE_API(sensor, sx9500_api_funcs) = {
 	.sample_fetch = sx9500_sample_fetch,
 	.channel_get = sx9500_channel_get,
 #ifdef CONFIG_SX9500_TRIGGER

--- a/drivers/sensor/tdk/icm42605/icm42605.c
+++ b/drivers/sensor/tdk/icm42605/icm42605.c
@@ -415,7 +415,7 @@ static int icm42605_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api icm42605_driver_api = {
+static DEVICE_API(sensor, icm42605_driver_api) = {
 #ifdef CONFIG_ICM42605_TRIGGER
 	.trigger_set = icm42605_trigger_set,
 #endif

--- a/drivers/sensor/tdk/icm42670/icm42670.c
+++ b/drivers/sensor/tdk/icm42670/icm42670.c
@@ -677,7 +677,7 @@ void icm42670_unlock(const struct device *dev)
 
 #endif
 
-static const struct sensor_driver_api icm42670_driver_api = {
+static DEVICE_API(sensor, icm42670_driver_api) = {
 #ifdef CONFIG_ICM42670_TRIGGER
 	.trigger_set = icm42670_trigger_set,
 #endif

--- a/drivers/sensor/tdk/icm42688/icm42688.c
+++ b/drivers/sensor/tdk/icm42688/icm42688.c
@@ -233,7 +233,7 @@ static int icm42688_attr_get(const struct device *dev, enum sensor_channel chan,
 	return res;
 }
 
-static const struct sensor_driver_api icm42688_driver_api = {
+static DEVICE_API(sensor, icm42688_driver_api) = {
 	.sample_fetch = icm42688_sample_fetch,
 	.channel_get = icm42688_channel_get,
 	.attr_set = icm42688_attr_set,

--- a/drivers/sensor/tdk/icp10125/icp10125.c
+++ b/drivers/sensor/tdk/icp10125/icp10125.c
@@ -303,7 +303,7 @@ static int icp10125_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api icp10125_api_funcs = {
+static DEVICE_API(sensor, icp10125_api_funcs) = {
 	.sample_fetch = icp10125_sample_fetch,
 	.channel_get = icp10125_channel_get,
 };

--- a/drivers/sensor/tdk/mpu6050/mpu6050.c
+++ b/drivers/sensor/tdk/mpu6050/mpu6050.c
@@ -141,7 +141,7 @@ static int mpu6050_sample_fetch(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api mpu6050_driver_api = {
+static DEVICE_API(sensor, mpu6050_driver_api) = {
 #if CONFIG_MPU6050_TRIGGER
 	.trigger_set = mpu6050_trigger_set,
 #endif

--- a/drivers/sensor/tdk/mpu9250/mpu9250.c
+++ b/drivers/sensor/tdk/mpu9250/mpu9250.c
@@ -220,7 +220,7 @@ static int mpu9250_sample_fetch(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api mpu9250_driver_api = {
+static DEVICE_API(sensor, mpu9250_driver_api) = {
 #if CONFIG_MPU9250_TRIGGER
 	.trigger_set = mpu9250_trigger_set,
 #endif

--- a/drivers/sensor/th02/th02.c
+++ b/drivers/sensor/th02/th02.c
@@ -121,7 +121,7 @@ static int th02_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api th02_driver_api = {
+static DEVICE_API(sensor, th02_driver_api) = {
 	.sample_fetch = th02_sample_fetch,
 	.channel_get = th02_channel_get,
 };

--- a/drivers/sensor/ti/bq274xx/bq274xx.c
+++ b/drivers/sensor/ti/bq274xx/bq274xx.c
@@ -843,7 +843,7 @@ static int bq274xx_pm_action(const struct device *dev,
 }
 #endif /* CONFIG_BQ274XX_PM */
 
-static const struct sensor_driver_api bq274xx_battery_driver_api = {
+static DEVICE_API(sensor, bq274xx_battery_driver_api) = {
 	.sample_fetch = bq274xx_sample_fetch,
 	.channel_get = bq274xx_channel_get,
 #ifdef CONFIG_BQ274XX_TRIGGER

--- a/drivers/sensor/ti/fdc2x1x/fdc2x1x.c
+++ b/drivers/sensor/ti/fdc2x1x/fdc2x1x.c
@@ -718,7 +718,7 @@ static int fdc2x1x_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api fdc2x1x_api_funcs = {
+static DEVICE_API(sensor, fdc2x1x_api_funcs) = {
 	.attr_set = fdc2x1x_attr_set,
 	.sample_fetch = fdc2x1x_sample_fetch,
 	.channel_get = fdc2x1x_channel_get,

--- a/drivers/sensor/ti/ina219/ina219.c
+++ b/drivers/sensor/ti/ina219/ina219.c
@@ -276,7 +276,7 @@ static int ina219_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api ina219_api = {
+static DEVICE_API(sensor, ina219_api) = {
 	.sample_fetch = ina219_sample_fetch,
 	.channel_get = ina219_channel_get,
 };

--- a/drivers/sensor/ti/ina226/ina226.c
+++ b/drivers/sensor/ti/ina226/ina226.c
@@ -303,7 +303,7 @@ static int ina226_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api ina226_driver_api = {
+static DEVICE_API(sensor, ina226_driver_api) = {
 	.attr_set = ina226_attr_set,
 	.attr_get = ina226_attr_get,
 	.sample_fetch = ina226_sample_fetch,

--- a/drivers/sensor/ti/ina23x/ina230.c
+++ b/drivers/sensor/ti/ina23x/ina230.c
@@ -229,7 +229,7 @@ static int ina230_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api ina230_driver_api = {
+static DEVICE_API(sensor, ina230_driver_api) = {
 	.attr_set = ina230_attr_set,
 	.attr_get = ina230_attr_get,
 #ifdef CONFIG_INA230_TRIGGER

--- a/drivers/sensor/ti/ina23x/ina237.c
+++ b/drivers/sensor/ti/ina23x/ina237.c
@@ -388,7 +388,7 @@ static int ina237_trigger_set(const struct device *dev, const struct sensor_trig
 	return 0;
 }
 
-static const struct sensor_driver_api ina237_driver_api = {
+static DEVICE_API(sensor, ina237_driver_api) = {
 	.attr_set = ina237_attr_set,
 	.attr_get = ina237_attr_get,
 	.trigger_set = ina237_trigger_set,

--- a/drivers/sensor/ti/ina3221/ina3221.c
+++ b/drivers/sensor/ti/ina3221/ina3221.c
@@ -267,7 +267,7 @@ static int ina3221_attr_set(const struct device *dev, enum sensor_channel chan,
 	return 0;
 }
 
-static const struct sensor_driver_api ina3221_api = {
+static DEVICE_API(sensor, ina3221_api) = {
 	.sample_fetch = ina3221_sample_fetch,
 	.channel_get = ina3221_channel_get,
 	.attr_set = ina3221_attr_set,

--- a/drivers/sensor/ti/lm95234/lm95234.c
+++ b/drivers/sensor/ti/lm95234/lm95234.c
@@ -204,7 +204,7 @@ static int lm95234_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api lm95234_driver_api = {
+static DEVICE_API(sensor, lm95234_driver_api) = {
 	.sample_fetch = lm95234_sample_fetch,
 	.channel_get = lm95234_channel_get,
 };

--- a/drivers/sensor/ti/opt3001/opt3001.c
+++ b/drivers/sensor/ti/opt3001/opt3001.c
@@ -107,7 +107,7 @@ static int opt3001_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api opt3001_driver_api = {
+static DEVICE_API(sensor, opt3001_driver_api) = {
 	.sample_fetch = opt3001_sample_fetch,
 	.channel_get = opt3001_channel_get,
 };

--- a/drivers/sensor/ti/ti_hdc/ti_hdc.c
+++ b/drivers/sensor/ti/ti_hdc/ti_hdc.c
@@ -100,7 +100,7 @@ static int ti_hdc_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api ti_hdc_driver_api = {
+static DEVICE_API(sensor, ti_hdc_driver_api) = {
 	.sample_fetch = ti_hdc_sample_fetch,
 	.channel_get = ti_hdc_channel_get,
 };

--- a/drivers/sensor/ti/ti_hdc20xx/ti_hdc20xx.c
+++ b/drivers/sensor/ti/ti_hdc20xx/ti_hdc20xx.c
@@ -134,7 +134,7 @@ static int ti_hdc20xx_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api ti_hdc20xx_api_funcs = {
+static DEVICE_API(sensor, ti_hdc20xx_api_funcs) = {
 	.sample_fetch = ti_hdc20xx_sample_fetch,
 	.channel_get = ti_hdc20xx_channel_get,
 };

--- a/drivers/sensor/ti/tmag5170/tmag5170.c
+++ b/drivers/sensor/ti/tmag5170/tmag5170.c
@@ -517,7 +517,7 @@ static int tmag5170_pm_action(const struct device *dev,
 }
 #endif /* CONFIG_PM_DEVICE */
 
-static const struct sensor_driver_api tmag5170_driver_api = {
+static DEVICE_API(sensor, tmag5170_driver_api) = {
 	.sample_fetch = tmag5170_sample_fetch,
 	.channel_get = tmag5170_channel_get,
 #if defined(CONFIG_TMAG5170_TRIGGER)

--- a/drivers/sensor/ti/tmag5273/tmag5273.c
+++ b/drivers/sensor/ti/tmag5273/tmag5273.c
@@ -1189,7 +1189,7 @@ static int tmag5273_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api tmag5273_driver_api = {
+static DEVICE_API(sensor, tmag5273_driver_api) = {
 	.attr_set = tmag5273_attr_set,
 	.attr_get = tmag5273_attr_get,
 	.sample_fetch = tmag5273_sample_fetch,

--- a/drivers/sensor/ti/tmp007/tmp007.c
+++ b/drivers/sensor/ti/tmp007/tmp007.c
@@ -95,7 +95,7 @@ static int tmp007_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api tmp007_driver_api = {
+static DEVICE_API(sensor, tmp007_driver_api) = {
 #ifdef CONFIG_TMP007_TRIGGER
 	.attr_set = tmp007_attr_set,
 	.trigger_set = tmp007_trigger_set,

--- a/drivers/sensor/ti/tmp1075/tmp1075.c
+++ b/drivers/sensor/ti/tmp1075/tmp1075.c
@@ -151,7 +151,7 @@ static int tmp1075_channel_get(const struct device *dev, enum sensor_channel cha
 	return 0;
 }
 
-static const struct sensor_driver_api tmp1075_driver_api = {
+static DEVICE_API(sensor, tmp1075_driver_api) = {
 	.attr_set = tmp1075_attr_set,
 	.attr_get = tmp1075_attr_get,
 	.sample_fetch = tmp1075_sample_fetch,

--- a/drivers/sensor/ti/tmp108/tmp108.c
+++ b/drivers/sensor/ti/tmp108/tmp108.c
@@ -309,7 +309,7 @@ static int tmp108_attr_set(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api tmp108_driver_api = {
+static DEVICE_API(sensor, tmp108_driver_api) = {
 	.attr_set = tmp108_attr_set,
 	.attr_get = tmp108_attr_get,
 	.sample_fetch = tmp108_sample_fetch,

--- a/drivers/sensor/ti/tmp112/tmp112.c
+++ b/drivers/sensor/ti/tmp112/tmp112.c
@@ -178,7 +178,7 @@ static int tmp112_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api tmp112_driver_api = {
+static DEVICE_API(sensor, tmp112_driver_api) = {
 	.attr_set = tmp112_attr_set,
 	.sample_fetch = tmp112_sample_fetch,
 	.channel_get = tmp112_channel_get,

--- a/drivers/sensor/ti/tmp114/tmp114.c
+++ b/drivers/sensor/ti/tmp114/tmp114.c
@@ -197,7 +197,7 @@ static int tmp114_attr_set(const struct device *dev,
 	}
 }
 
-static const struct sensor_driver_api tmp114_driver_api = {
+static DEVICE_API(sensor, tmp114_driver_api) = {
 	.attr_get = tmp114_attr_get,
 	.attr_set = tmp114_attr_set,
 	.sample_fetch = tmp114_sample_fetch,

--- a/drivers/sensor/ti/tmp116/tmp116.c
+++ b/drivers/sensor/ti/tmp116/tmp116.c
@@ -334,7 +334,7 @@ static int tmp116_attr_get(const struct device *dev, enum sensor_channel chan,
 	return 0;
 }
 
-static const struct sensor_driver_api tmp116_driver_api = {
+static DEVICE_API(sensor, tmp116_driver_api) = {
 	.attr_set = tmp116_attr_set,
 	.attr_get = tmp116_attr_get,
 	.sample_fetch = tmp116_sample_fetch,

--- a/drivers/sensor/tsic_xx6/tsic_xx6.c
+++ b/drivers/sensor/tsic_xx6/tsic_xx6.c
@@ -211,8 +211,10 @@ static int tsic_xx6_channel_get(const struct device *dev, enum sensor_channel ch
 	return 0;
 }
 
-static const struct sensor_driver_api tsic_xx6_driver_api = {.sample_fetch = tsic_xx6_sample_fetch,
-							     .channel_get = tsic_xx6_channel_get};
+static DEVICE_API(sensor, tsic_xx6_driver_api) = {
+	.sample_fetch = tsic_xx6_sample_fetch,
+	.channel_get = tsic_xx6_channel_get,
+};
 
 static int tsic_xx6_get_frame_cycles(const struct tsic_xx6_config *config, uint64_t *frame_cycles)
 {

--- a/drivers/sensor/veaa_x_3/veaa_x_3.c
+++ b/drivers/sensor/veaa_x_3/veaa_x_3.c
@@ -144,7 +144,7 @@ static int veaa_x_3_channel_get(const struct device *dev, enum sensor_channel ch
 	return 0;
 }
 
-static const struct sensor_driver_api veaa_x_3_api_funcs = {
+static DEVICE_API(sensor, veaa_x_3_api_funcs) = {
 	.attr_set = veaa_x_3_attr_set,
 	.attr_get = veaa_x_3_attr_get,
 	.sample_fetch = veaa_x_3_sample_fetch,

--- a/drivers/sensor/vishay/vcnl36825t/vcnl36825t.c
+++ b/drivers/sensor/vishay/vcnl36825t/vcnl36825t.c
@@ -533,7 +533,7 @@ static int vcnl36825t_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api vcnl36825t_driver_api = {
+static DEVICE_API(sensor, vcnl36825t_driver_api) = {
 	.sample_fetch = vcnl36825t_sample_fetch,
 	.channel_get = vcnl36825t_channel_get,
 	.attr_set = vcnl36825t_attr_set,

--- a/drivers/sensor/vishay/vcnl4040/vcnl4040.c
+++ b/drivers/sensor/vishay/vcnl4040/vcnl4040.c
@@ -291,7 +291,7 @@ static int vcnl4040_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api vcnl4040_driver_api = {
+static DEVICE_API(sensor, vcnl4040_driver_api) = {
 	.sample_fetch = vcnl4040_sample_fetch,
 	.channel_get = vcnl4040_channel_get,
 #ifdef CONFIG_VCNL4040_TRIGGER

--- a/drivers/sensor/vishay/veml7700/veml7700.c
+++ b/drivers/sensor/vishay/veml7700/veml7700.c
@@ -585,10 +585,12 @@ static int veml7700_init(const struct device *dev)
 	return 0;
 }
 
-static const struct sensor_driver_api veml7700_api = {.sample_fetch = veml7700_sample_fetch,
-						      .channel_get = veml7700_channel_get,
-						      .attr_set = veml7700_attr_set,
-						      .attr_get = veml7700_attr_get};
+static DEVICE_API(sensor, veml7700_api) = {
+	.sample_fetch = veml7700_sample_fetch,
+	.channel_get = veml7700_channel_get,
+	.attr_set = veml7700_attr_set,
+	.attr_get = veml7700_attr_get,
+};
 
 #define VEML7700_INIT(n)                                                                           \
 	static struct veml7700_data veml7700_data_##n;                                             \

--- a/drivers/sensor/voltage_divider/voltage.c
+++ b/drivers/sensor/voltage_divider/voltage.c
@@ -87,7 +87,7 @@ static int get(const struct device *dev, enum sensor_channel chan, struct sensor
 	return ret;
 }
 
-static const struct sensor_driver_api voltage_api = {
+static DEVICE_API(sensor, voltage_api) = {
 	.sample_fetch = fetch,
 	.channel_get = get,
 };

--- a/drivers/sensor/wsen/wsen_hids_2525020210002/wsen_hids_2525020210002.c
+++ b/drivers/sensor/wsen/wsen_hids_2525020210002/wsen_hids_2525020210002.c
@@ -183,7 +183,7 @@ static int hids_2525020210002_attr_get(const struct device *dev, enum sensor_cha
 	return 0;
 }
 
-static const struct sensor_driver_api hids_2525020210002_driver_api = {
+static DEVICE_API(sensor, hids_2525020210002_driver_api) = {
 	.attr_set = hids_2525020210002_attr_set,
 	.attr_get = hids_2525020210002_attr_get,
 	.sample_fetch = hids_2525020210002_sample_fetch,

--- a/samples/sensor/sensor_shell/src/fake_sensor.c
+++ b/samples/sensor/sensor_shell/src/fake_sensor.c
@@ -81,7 +81,7 @@ static int trigger_set(const struct device *dev, const struct sensor_trigger *tr
 	return 0;
 }
 
-static const struct sensor_driver_api api = {
+static DEVICE_API(sensor, api) = {
 	.attr_get = attr_get,
 	.attr_set = attr_set,
 	.sample_fetch = sample_fetch,

--- a/subsys/sensing/sensor/hinge_angle/hinge_angle.c
+++ b/subsys/sensing/sensor/hinge_angle/hinge_angle.c
@@ -91,7 +91,7 @@ static void hinge_submit(const struct device *dev,
 	}
 }
 
-static const struct sensor_driver_api hinge_api = {
+static DEVICE_API(sensor, hinge_api) = {
 	.attr_set = hinge_attr_set,
 	.submit = hinge_submit,
 };

--- a/subsys/sensing/sensor/phy_3d_sensor/phy_3d_sensor.c
+++ b/subsys/sensing/sensor/phy_3d_sensor/phy_3d_sensor.c
@@ -209,7 +209,7 @@ static void phy_3d_sensor_submit(const struct device *dev,
 	return;
 }
 
-static const struct sensor_driver_api phy_3d_sensor_api = {
+static DEVICE_API(sensor, phy_3d_sensor_api) = {
 	.attr_set = phy_3d_sensor_attr_set,
 	.submit = phy_3d_sensor_submit,
 };

--- a/tests/drivers/clock_control/nrf_clock_calibration/src/mock_temp_nrf5.c
+++ b/tests/drivers/clock_control/nrf_clock_calibration/src/mock_temp_nrf5.c
@@ -34,7 +34,7 @@ static int mock_temp_nrf5_channel_get(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api mock_temp_nrf5_driver_api = {
+static DEVICE_API(sensor, mock_temp_nrf5_driver_api) = {
 	.sample_fetch = mock_temp_nrf5_sample_fetch,
 	.channel_get = mock_temp_nrf5_channel_get,
 };

--- a/tests/drivers/sensor/generic/src/dummy_sensor.c
+++ b/tests/drivers/sensor/generic/src/dummy_sensor.c
@@ -161,7 +161,7 @@ int dummy_sensor_trigger_set(const struct device *dev,
 	return 0;
 }
 
-static const struct sensor_driver_api dummy_sensor_api = {
+static DEVICE_API(sensor, dummy_sensor_api) = {
 	.sample_fetch = &dummy_sensor_sample_fetch,
 	.channel_get = &dummy_sensor_channel_get,
 	.attr_set = dummy_sensor_attr_set,
@@ -169,7 +169,7 @@ static const struct sensor_driver_api dummy_sensor_api = {
 	.trigger_set = dummy_sensor_trigger_set,
 };
 
-static const struct sensor_driver_api dummy_sensor_no_trig_api = {
+static DEVICE_API(sensor, dummy_sensor_no_trig_api) = {
 	.sample_fetch = &dummy_sensor_sample_fetch,
 	.channel_get = &dummy_sensor_channel_get,
 	.attr_set = NULL,


### PR DESCRIPTION
Move all sensor driver api structs into an iterable section.

Depends on #71773