### PR TITLE
drivers: counter: stm32_rtc: fix clk disable for WBAX

### DIFF
--- a/drivers/counter/counter_ll_stm32_rtc.c
+++ b/drivers/counter/counter_ll_stm32_rtc.c
@@ -191,7 +191,7 @@ static int rtc_stm32_start(const struct device *dev)
 
 	/* Enable RTC bus clock */
 	if (clock_control_on(clk, (clock_control_subsys_t) &cfg->pclken[0]) != 0) {
-		LOG_ERR("clock op failed\n");
+		LOG_ERR("RTC clock enabling failed\n");
 		return -EIO;
 	}
 #else
@@ -212,9 +212,9 @@ static int rtc_stm32_stop(const struct device *dev)
 	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	const struct rtc_stm32_config *cfg = dev->config;
 
-	/* Enable RTC bus clock */
-	if (clock_control_on(clk, (clock_control_subsys_t) &cfg->pclken[0]) != 0) {
-		LOG_ERR("clock op failed\n");
+	/* Disable RTC bus clock */
+	if (clock_control_off(clk, (clock_control_subsys_t) &cfg->pclken[0]) != 0) {
+		LOG_ERR("RTC clock disabling failed\n");
 		return -EIO;
 	}
 #else


### PR DESCRIPTION
Inside `rtc_stm32_stop()`, `clock_control_on()` was called instead of `clock_control_off()` for STM32WBAX series.