### PR TITLE
soc: stm32: soc.h: Undefine conflicting and unsued PAGESIZE

### DIFF
--- a/soc/st/stm32/stm32c0x/soc.h
+++ b/soc/st/stm32/stm32c0x/soc.h
@@ -21,6 +21,9 @@
 
 #include <stm32c0xx.h>
 
+/* PAGESIZE is defined by HAL legacy headers, but conflict with POSIX */
+#undef PAGESIZE
+
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32C0_SOC_H_ */

--- a/soc/st/stm32/stm32f0x/soc.h
+++ b/soc/st/stm32/stm32f0x/soc.h
@@ -22,6 +22,9 @@
 
 #include <stm32f0xx.h>
 
+/* PAGESIZE is defined by HAL legacy headers, but conflict with POSIX */
+#undef PAGESIZE
+
 /* The STM32 HAL headers define these, but they conflict with the Zephyr can.h */
 #undef CAN_MODE_NORMAL
 #undef CAN_MODE_LOOPBACK

--- a/soc/st/stm32/stm32f1x/soc.h
+++ b/soc/st/stm32/stm32f1x/soc.h
@@ -22,6 +22,9 @@
 
 #include <stm32f1xx.h>
 
+/* PAGESIZE is defined by HAL legacy headers, but conflict with POSIX */
+#undef PAGESIZE
+
 /* The STM32 HAL headers define these, but they conflict with the Zephyr can.h */
 #undef CAN_MODE_NORMAL
 #undef CAN_MODE_LOOPBACK

--- a/soc/st/stm32/stm32f2x/soc.h
+++ b/soc/st/stm32/stm32f2x/soc.h
@@ -21,6 +21,9 @@
 
 #include <stm32f2xx.h>
 
+/* PAGESIZE is defined by HAL legacy headers, but conflict with POSIX */
+#undef PAGESIZE
+
 /* The STM32 HAL headers define these, but they conflict with the Zephyr can.h */
 #undef CAN_MODE_NORMAL
 #undef CAN_MODE_LOOPBACK

--- a/soc/st/stm32/stm32f3x/soc.h
+++ b/soc/st/stm32/stm32f3x/soc.h
@@ -23,6 +23,9 @@
 
 #include <stm32f3xx.h>
 
+/* PAGESIZE is defined by HAL legacy headers, but conflict with POSIX */
+#undef PAGESIZE
+
 /* The STM32 HAL headers define these, but they conflict with the Zephyr can.h */
 #undef CAN_MODE_NORMAL
 #undef CAN_MODE_LOOPBACK

--- a/soc/st/stm32/stm32f4x/soc.h
+++ b/soc/st/stm32/stm32f4x/soc.h
@@ -22,6 +22,9 @@
 
 #include <stm32f4xx.h>
 
+/* PAGESIZE is defined by HAL legacy headers, but conflict with POSIX */
+#undef PAGESIZE
+
 /* The STM32 HAL headers define these, but they conflict with the Zephyr can.h */
 #undef CAN_MODE_NORMAL
 #undef CAN_MODE_LOOPBACK

--- a/soc/st/stm32/stm32f7x/soc.h
+++ b/soc/st/stm32/stm32f7x/soc.h
@@ -21,6 +21,9 @@
 
 #include <stm32f7xx.h>
 
+/* PAGESIZE is defined by HAL legacy headers, but conflict with POSIX */
+#undef PAGESIZE
+
 /* The STM32 HAL headers define these, but they conflict with the Zephyr can.h */
 #undef CAN_MODE_NORMAL
 #undef CAN_MODE_LOOPBACK

--- a/soc/st/stm32/stm32g0x/soc.h
+++ b/soc/st/stm32/stm32g0x/soc.h
@@ -22,6 +22,9 @@
 
 #include <stm32g0xx.h>
 
+/* PAGESIZE is defined by HAL legacy headers, but conflict with POSIX */
+#undef PAGESIZE
+
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32G0_SOC_H_ */

--- a/soc/st/stm32/stm32g4x/soc.h
+++ b/soc/st/stm32/stm32g4x/soc.h
@@ -21,6 +21,9 @@
 
 #include <stm32g4xx.h>
 
+/* PAGESIZE is defined by HAL legacy headers, but conflict with POSIX */
+#undef PAGESIZE
+
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32G4_SOC_H_ */

--- a/soc/st/stm32/stm32h5x/soc.h
+++ b/soc/st/stm32/stm32h5x/soc.h
@@ -17,6 +17,9 @@
 
 #include <stm32h5xx.h>
 
+/* PAGESIZE is defined by HAL legacy headers, but conflict with POSIX */
+#undef PAGESIZE
+
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32H5_SOC_H_ */

--- a/soc/st/stm32/stm32h7x/soc.h
+++ b/soc/st/stm32/stm32h7x/soc.h
@@ -11,6 +11,9 @@
 
 #include <stm32h7xx.h>
 
+/* PAGESIZE is defined by HAL legacy headers, but conflict with POSIX */
+#undef PAGESIZE
+
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32H7_SOC_H7_ */

--- a/soc/st/stm32/stm32l0x/soc.h
+++ b/soc/st/stm32/stm32l0x/soc.h
@@ -21,6 +21,9 @@
 
 #include <stm32l0xx.h>
 
+/* PAGESIZE is defined by HAL legacy headers, but conflict with POSIX */
+#undef PAGESIZE
+
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32L0_SOC_H_ */

--- a/soc/st/stm32/stm32l1x/soc.h
+++ b/soc/st/stm32/stm32l1x/soc.h
@@ -21,6 +21,9 @@
 
 #include <stm32l1xx.h>
 
+/* PAGESIZE is defined by HAL legacy headers, but conflict with POSIX */
+#undef PAGESIZE
+
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32L1_SOC_H_ */

--- a/soc/st/stm32/stm32l4x/soc.h
+++ b/soc/st/stm32/stm32l4x/soc.h
@@ -23,6 +23,9 @@
 
 #include <stm32l4xx.h>
 
+/* PAGESIZE is defined by HAL legacy headers, but conflict with POSIX */
+#undef PAGESIZE
+
 /* The STM32 HAL headers define these, but they conflict with the Zephyr can.h */
 #undef CAN_MODE_NORMAL
 #undef CAN_MODE_LOOPBACK

--- a/soc/st/stm32/stm32l5x/soc.h
+++ b/soc/st/stm32/stm32l5x/soc.h
@@ -21,6 +21,9 @@
 
 #include <stm32l5xx.h>
 
+/* PAGESIZE is defined by HAL legacy headers, but conflict with POSIX */
+#undef PAGESIZE
+
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32L5_SOC_H_ */

--- a/soc/st/stm32/stm32mp1x/soc.h
+++ b/soc/st/stm32/stm32mp1x/soc.h
@@ -21,6 +21,9 @@
 
 #include <stm32mp1xx.h>
 
+/* PAGESIZE is defined by HAL legacy headers, but conflict with POSIX */
+#undef PAGESIZE
+
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32MP1SOC_H_ */

--- a/soc/st/stm32/stm32u5x/soc.h
+++ b/soc/st/stm32/stm32u5x/soc.h
@@ -17,6 +17,9 @@
 
 #include <stm32u5xx.h>
 
+/* PAGESIZE is defined by HAL legacy headers, but conflict with POSIX */
+#undef PAGESIZE
+
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32U5_SOC_H_ */

--- a/soc/st/stm32/stm32wbax/soc.h
+++ b/soc/st/stm32/stm32wbax/soc.h
@@ -17,6 +17,9 @@
 
 #include <stm32wbaxx.h>
 
+/* PAGESIZE is defined by HAL legacy headers, but conflict with POSIX */
+#undef PAGESIZE
+
 /* function exported to the soc power.c */
 int stm32wba_init(void);
 

--- a/soc/st/stm32/stm32wbx/soc.h
+++ b/soc/st/stm32/stm32wbx/soc.h
@@ -21,6 +21,9 @@
 
 #include <stm32wbxx.h>
 
+/* PAGESIZE is defined by HAL legacy headers, but conflict with POSIX */
+#undef PAGESIZE
+
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32WBX_SOC_H_ */

--- a/soc/st/stm32/stm32wlx/soc.h
+++ b/soc/st/stm32/stm32wlx/soc.h
@@ -21,6 +21,9 @@
 
 #include <stm32wlxx.h>
 
+/* PAGESIZE is defined by HAL legacy headers, but conflict with POSIX */
+#undef PAGESIZE
+
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _STM32WL_SOC_H_ */


### PR DESCRIPTION
The PAGESIZE definition is typically used in POSIX systems as a measure of virtual memory granularity.
Problem is that it is also defined in STM32Cube HAL legacy headers as #define PAGESIZE FLASH_PAGE_SIZE
but not used otherwise.

Undefine this HAL definition to allow safe use of POSIX definition.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/70136