### PR TITLE
pinctrl: st: add remap pa11 and pa12 support to C0 series

### DIFF
--- a/boards/st/stm32c0116_dk/doc/index.rst
+++ b/boards/st/stm32c0116_dk/doc/index.rst
@@ -97,8 +97,8 @@ Default Zephyr Peripheral Mapping:
 
 The STM32C0116 Discovery board is configured as follows:
 
-- UART_2 TX/RX : PA2/PA3 (ST-Link Virtual Port Com)
-- UART_1 TX/RX : PA9/PA10
+- UART_2 TX/RX : PA2/PA3
+- UART_1 TX/RX : PA9/PA10 (ST-Link Virtual Port Com)
 - PWM_1_CH3 : PB6
 - ADC1_CH8 : PA8
 - LD3 : PB6

--- a/boards/st/stm32c0116_dk/stm32c0116_dk.dts
+++ b/boards/st/stm32c0116_dk/stm32c0116_dk.dts
@@ -13,8 +13,8 @@
 	compatible = "st,stm32c011f6-dk";
 
 	chosen {
-		zephyr,console = &usart2;
-		zephyr,shell-uart = &usart2;
+		zephyr,console = &usart1;
+		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};
@@ -63,6 +63,11 @@
 	clock-frequency = <DT_FREQ_M(48)>;
 	ahb-prescaler = <1>;
 	apb1-prescaler = <1>;
+};
+
+&pinctrl {
+	remap-pa11;
+	remap-pa12;
 };
 
 &usart1 {

--- a/drivers/pinctrl/pinctrl_stm32.c
+++ b/drivers/pinctrl/pinctrl_stm32.c
@@ -80,8 +80,8 @@ int stm32_pinmux_init_remap(void)
 
 #if REMAP_PA11 || REMAP_PA12
 
-#if !defined(CONFIG_SOC_SERIES_STM32G0X)
-#error "Pin remap property available only on STM32G0 SoC series"
+#if !defined(CONFIG_SOC_SERIES_STM32G0X) && !defined(CONFIG_SOC_SERIES_STM32C0X)
+#error "Pin remap property available only on STM32G0 and STM32C0 SoC series"
 #endif
 
 	LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_SYSCFG);

--- a/dts/bindings/pinctrl/st,stm32-pinctrl.yaml
+++ b/dts/bindings/pinctrl/st,stm32-pinctrl.yaml
@@ -20,12 +20,12 @@ properties:
   remap-pa11:
     type: boolean
     description: Remaps the PA11 pin to operate as PA9 pin.
-      Use of this property is restricted to STM32G0 SoCs.
+      Use of this property is restricted to STM32G0 and STM32C0 SoCs.
 
   remap-pa12:
     type: boolean
     description: Remaps the PA12 pin to operate as PA10 pin.
-      Use of this property is restricted to STM32G0 SoCs.
+      Use of this property is restricted to STM32G0 and STM32C0 SoCs.
 
   remap-pa11-pa12:
     type: boolean


### PR DESCRIPTION
STM32C0 series implement PA11 and PA12 remap to redirect PA9 and PA10 functions into them.

This implementation is already done for STM32G0 series : only add support for STM32C0 series.
Add remap support on stm32c0116_dk board to make VCP working

Note for me: avoid upgrading embedded STLink to JLink for board support implementation next time :)

fixes #72301