### PR TITLE
boards: shields: Introduce the M5Stick Roverc shield

### DIFF
--- a/boards/shields/m5stack_roverc/Kconfig.shield
+++ b/boards/shields/m5stack_roverc/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright (c) 2024 Julien Vermillard <julien@vermillard.com>
+# SPDX-License-Identifier: Apache-2.0
+
+config SHIELD_M5STACK_ROVERC
+	def_bool $(shields_list_contains,m5stack_roverc)

--- a/boards/shields/m5stack_roverc/boards/m5stickc_plus_procpu.overlay
+++ b/boards/shields/m5stack_roverc/boards/m5stickc_plus_procpu.overlay
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024 Julien Vermillard <julien@vermillard.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/{
+       aliases {
+		i2c-1 = &i2c1;
+       };
+};
+
+&pinctrl {
+       i2c1_default: i2c1_default {
+               group1 {
+                       pinmux = <I2C1_SDA_GPIO0>,
+                                <I2C1_SCL_GPIO26>;
+                       bias-pull-up;
+                       drive-open-drain;
+                       output-high;
+               };
+       };
+};
+
+&i2c1 {
+       status = "okay";
+       clock-frequency = <I2C_BITRATE_STANDARD>;
+       sda-gpios = <&gpio0 0 GPIO_OPEN_DRAIN>;
+       scl-gpios = <&gpio0 26 GPIO_OPEN_DRAIN>;
+       pinctrl-0 = <&i2c1_default>;
+       scl-timeout-us = <0>;
+       pinctrl-names = "default";
+
+       rover: rover@38 {
+              compatible = "i2c-device";
+              reg = <0x38>;
+              status = "okay";
+       };
+};

--- a/boards/shields/m5stack_roverc/doc/index.rst
+++ b/boards/shields/m5stack_roverc/doc/index.rst
@@ -1,0 +1,22 @@
+.. _m5stack_roverc:
+
+M5Stack roverc
+##############
+
+Overview
+********
+The M5Stack Roverc is a programmable Mecanum wheel omnidirectional mobile robot base.
+Compatible with M5StickC/M5StickC PLUS.
+
+Requirements
+************
+
+This shield can only be used with the `m5stick_cplus` board.
+
+References
+**********
+
+.. target-notes::
+
+.. M5Stack roverc website:
+   https://shop.m5stack.com/products/roverc-prow-o-m5stickc

--- a/boards/shields/m5stack_roverc/m5stack_roverc.overlay
+++ b/boards/shields/m5stack_roverc/m5stack_roverc.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2024 Julien Vermillard <julien@vermillard.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * This file is intentionally empty.
+ */


### PR DESCRIPTION
This hat or shield is an I2C device, so some pin on the m5stick_cplus must be reconfigured to be used as the second I2C bus to be able to send commands to the rover.