### PR TITLE
QEMU: Fix issue 72191

### DIFF
--- a/boards/qemu/x86/board.cmake
+++ b/boards/qemu/x86/board.cmake
@@ -71,7 +71,7 @@ set(QEMU_FLAGS_${ARCH}
   )
 
 if(NOT CONFIG_ACPI)
-  list(APPEND QEMU_FLAGS_${ARCH} -no-acpi)
+  list(APPEND QEMU_FLAGS_${ARCH} -machine acpi=off)
 endif()
 
 # TODO: Support debug


### PR DESCRIPTION
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/72191 by replacing `-no-acpi` with `-machine acpi=off`

Appears to still work with QEMU pre 9.0.0