### PR TITLE
drivers/timer/arm_arch_timer: properly fix cycles overflow with GDB stub

### DIFF
--- a/drivers/timer/arm_arch_timer.c
+++ b/drivers/timer/arm_arch_timer.c
@@ -22,14 +22,11 @@ static uint32_t cyc_per_tick;
 
 #if defined(CONFIG_GDBSTUB)
 /* When interactively debugging, the cycle diff can overflow 32-bit variable */
-#define TO_CYCLE_DIFF(x) (x)
+#define cycle_diff_t uint64_t
 #else
-/* Convert to 32-bit for fast division */
-#define TO_CYCLE_DIFF(x) ((cycle_diff_t)(x))
-#endif
-
 /* the unsigned long cast limits divisors to native CPU register width */
 #define cycle_diff_t unsigned long
+#endif
 
 static struct k_spinlock lock;
 static uint64_t last_cycle;
@@ -66,7 +63,7 @@ static void arm_arch_timer_compare_isr(const void *arg)
 
 	uint64_t curr_cycle = arm_arch_timer_count();
 	uint64_t delta_cycles = curr_cycle - last_cycle;
-	uint32_t delta_ticks = TO_CYCLE_DIFF(delta_cycles) / CYC_PER_TICK;
+	uint32_t delta_ticks = (cycle_diff_t)delta_cycles / CYC_PER_TICK;
 
 	last_cycle += (cycle_diff_t)delta_ticks * CYC_PER_TICK;
 	last_tick += delta_ticks;


### PR DESCRIPTION
In commit 606825551203 ("drivers/timer/arm_arch_timer: Fix cycles
overflow with GDB stub") an extra TO_CYCLE_DIFF() macro was introduced
to bypass the cycle_diff_t type cast in some cases.

The actual fix consists in defining that type properly in the first
place. That's the very reason why such type was abstracted.

Signed-off-by: Nicolas Pitre <npitre@baylibre.com>
