### PR TITLE
soc: espressif: add misssing external xtal kconfig entry

### DIFF
--- a/soc/espressif/esp32/Kconfig.rtc
+++ b/soc/espressif/esp32/Kconfig.rtc
@@ -74,4 +74,21 @@ config RTC_XTAL_CAL_RETRY
 	  Increase this option if the 32k crystal oscillator
 	  does not start and switches to internal RC.
 
+config ESP_SYSTEM_RTC_EXT_XTAL_BOOTSTRAP_CYCLES
+	int "Bootstrap cycles for external 32kHz crystal"
+	depends on ESP_SYSTEM_RTC_EXT_XTAL
+	default 5
+	range 0 32768
+	help
+	  To reduce the startup time of an external RTC crystal,
+	  we bootstrap it with a 32kHz square wave for a fixed number of cycles.
+	  Setting 0 will disable bootstrapping (if disabled, the crystal may take
+	  longer to start up or fail to oscillate under some conditions).
+
+	  If this value is too high, a faulty crystal may initially start and then fail.
+	  If this value is too low, an otherwise good crystal may not start.
+
+	  To accurately determine if the crystal has started,
+	  set a larger "Number of cycles for RTC_SLOW_CLK calibration" (about 3000).
+
 endif # SOC_SERIES_ESP32

--- a/soc/espressif/esp32c3/Kconfig.rtc
+++ b/soc/espressif/esp32c3/Kconfig.rtc
@@ -47,4 +47,21 @@ config RTC_CLK_CAL_CYCLES
 	    In case more value will help improve the definition of the launch of the crystal.
 	    If the crystal could not start, it will be switched to internal RC.
 
+config ESP_SYSTEM_RTC_EXT_XTAL_BOOTSTRAP_CYCLES
+	int "Bootstrap cycles for external 32kHz crystal"
+	depends on ESP_SYSTEM_RTC_EXT_XTAL
+	default 0
+	range 0 32768
+	help
+	  To reduce the startup time of an external RTC crystal,
+	  we bootstrap it with a 32kHz square wave for a fixed number of cycles.
+	  Setting 0 will disable bootstrapping (if disabled, the crystal may take
+	  longer to start up or fail to oscillate under some conditions).
+
+	  If this value is too high, a faulty crystal may initially start and then fail.
+	  If this value is too low, an otherwise good crystal may not start.
+
+	  To accurately determine if the crystal has started,
+	  set a larger "Number of cycles for RTC_SLOW_CLK calibration" (about 3000).
+
 endif # SOC_SERIES_ESP32C3

--- a/soc/espressif/esp32s2/Kconfig.rtc
+++ b/soc/espressif/esp32s2/Kconfig.rtc
@@ -73,4 +73,21 @@ config RTC_XTAL_CAL_RETRY
 	  Increase this option if the 32k crystal oscillator
 	  does not start and switches to internal RC.
 
+config ESP_SYSTEM_RTC_EXT_XTAL_BOOTSTRAP_CYCLES
+	int "Bootstrap cycles for external 32kHz crystal"
+	depends on ESP_SYSTEM_RTC_EXT_XTAL
+	default 0
+	range 0 32768
+	help
+	  To reduce the startup time of an external RTC crystal,
+	  we bootstrap it with a 32kHz square wave for a fixed number of cycles.
+	  Setting 0 will disable bootstrapping (if disabled, the crystal may take
+	  longer to start up or fail to oscillate under some conditions).
+
+	  If this value is too high, a faulty crystal may initially start and then fail.
+	  If this value is too low, an otherwise good crystal may not start.
+
+	  To accurately determine if the crystal has started,
+	  set a larger "Number of cycles for RTC_SLOW_CLK calibration" (about 3000).
+
 endif # SOC_SERIES_ESP32S2

--- a/soc/espressif/esp32s3/Kconfig.rtc
+++ b/soc/espressif/esp32s3/Kconfig.rtc
@@ -43,4 +43,21 @@ config RTC_CLK_CAL_CYCLES
 	  In case more value will help improve the definition of the launch of the crystal.
 	  If the crystal could not start, it will be switched to internal RC.
 
+config ESP_SYSTEM_RTC_EXT_XTAL_BOOTSTRAP_CYCLES
+	int "Bootstrap cycles for external 32kHz crystal"
+	depends on ESP_SYSTEM_RTC_EXT_XTAL
+	default 0
+	range 0 32768
+	help
+	  To reduce the startup time of an external RTC crystal,
+	  we bootstrap it with a 32kHz square wave for a fixed number of cycles.
+	  Setting 0 will disable bootstrapping (if disabled, the crystal may take
+	  longer to start up or fail to oscillate under some conditions).
+
+	  If this value is too high, a faulty crystal may initially start and then fail.
+	  If this value is too low, an otherwise good crystal may not start.
+
+	  To accurately determine if the crystal has started,
+	  set a larger "Number of cycles for RTC_SLOW_CLK calibration" (about 3000).
+
 endif # SOC_SERIES_ESP32S3


### PR DESCRIPTION
External XTAL usage is missing a Bootstrap Cycle configuration
in Kconfig, causing build to failure when CONFIG_RTC_CLK_SRC_EXT_CRYS
is selected.

Fixes #72190