### PR TITLE
Fix cbprintf package warning

### DIFF
--- a/drivers/usb/device/usb_dc_rpi_pico.c
+++ b/drivers/usb/device/usb_dc_rpi_pico.c
@@ -787,7 +787,7 @@ int usb_dc_ep_read_wait(uint8_t ep, uint8_t *data,
 	}
 
 	LOG_DBG("ep 0x%02x, %u bytes, %u+%u, %p", ep, max_data_len, ep_state->read_offset,
-		read_count, data);
+		read_count, (void *)data);
 
 	if (data) {
 		read_count = MIN(read_count, max_data_len);

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -884,7 +884,7 @@ int usb_dc_ep_read_wait(uint8_t ep, uint8_t *data, uint32_t max_data_len,
 	read_count = ep_state->read_count;
 
 	LOG_DBG("ep 0x%02x, %u bytes, %u+%u, %p", ep, max_data_len,
-		ep_state->read_offset, read_count, data);
+		ep_state->read_offset, read_count, (void *)data);
 
 	if (!USB_EP_DIR_IS_OUT(ep)) { /* check if OUT ep */
 		LOG_ERR("Wrong endpoint direction: 0x%02x", ep);

--- a/subsys/usb/device/usb_descriptor.c
+++ b/subsys/usb/device/usb_descriptor.c
@@ -169,7 +169,7 @@ static void ascii7_to_utf16le(void *descriptor)
 	uint8_t *buf = (uint8_t *)&str_descr->bString;
 
 	LOG_DBG("idx_max %d, ascii_idx_max %d, buf %p",
-		idx_max, ascii_idx_max, buf);
+		idx_max, ascii_idx_max, (void *)buf);
 
 	for (int i = idx_max; i >= 0; i -= 2) {
 		LOG_DBG("char %c : %x, idx %d -> %d",


### PR DESCRIPTION
While working with usb-stack from zephyr there may following warnings from `` package occur:

```log
<wrn> cbprintf_package: (unsigned) char * used for %p argument. It's recommended to cast it to void * because it may cause misbehavior in certain configurations. String:"%s: ep 0x%02x, %u bytes, %u+%u, %p" argument:5
````

and

```log
<wrn> cbprintf_package: (unsigned) char * used for %p argument. It's recommended to cast it to void * because it may cause misbehavior in certain configurations. String:"%s: ep 0x%02x, %u bytes, %u+%u, %p" argument:5
````

This PR shall fix this kind of warnings.

A small tipps on behaviour reproduction if you not see this behaviour directly:
 - `CONFIG_LOG_BUFFER_SIZE` may be increasd to 32768
 - use `-C` option in case of minicom to redirect your log output to separate .log file
 - search in redirected .log file for strings outputted by warnings from above
