### PR TITLE
net: lwm2m: efficent cbor record data structure

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_senml_cbor.patch
+++ b/subsys/net/lib/lwm2m/lwm2m_senml_cbor.patch
@@ -1,5 +1,5 @@
 diff --git a/subsys/net/lib/lwm2m/lwm2m_senml_cbor_decode.c b/subsys/net/lib/lwm2m/lwm2m_senml_cbor_decode.c
-index c12f477cce..f41b81275d 100644
+index 8b136cccf0b..ca935f9f60a 100644
 --- a/subsys/net/lib/lwm2m/lwm2m_senml_cbor_decode.c
 +++ b/subsys/net/lib/lwm2m/lwm2m_senml_cbor_decode.c
 @@ -4,7 +4,7 @@
@@ -41,7 +41,7 @@ index c12f477cce..f41b81275d 100644
 	if (!tmp_result) {
 		zcbor_trace_file(state);
 diff --git a/subsys/net/lib/lwm2m/lwm2m_senml_cbor_decode.h b/subsys/net/lib/lwm2m/lwm2m_senml_cbor_decode.h
-index a36f8782c6..b913fb78e9 100644
+index 8060c2cd932..7316e8fb2c6 100644
 --- a/subsys/net/lib/lwm2m/lwm2m_senml_cbor_decode.h
 +++ b/subsys/net/lib/lwm2m/lwm2m_senml_cbor_decode.h
 @@ -4,7 +4,7 @@
@@ -66,7 +66,7 @@ index a36f8782c6..b913fb78e9 100644
 		const uint8_t *payload, size_t payload_len,
 		struct lwm2m_senml *result,
 diff --git a/subsys/net/lib/lwm2m/lwm2m_senml_cbor_encode.c b/subsys/net/lib/lwm2m/lwm2m_senml_cbor_encode.c
-index 94926c531f..5521917853 100644
+index d63baab5bcb..cbeef1b4e18 100644
 --- a/subsys/net/lib/lwm2m/lwm2m_senml_cbor_encode.c
 +++ b/subsys/net/lib/lwm2m/lwm2m_senml_cbor_encode.c
 @@ -4,7 +4,7 @@
@@ -114,7 +114,7 @@ index 94926c531f..5521917853 100644
 	if (!tmp_result) {
 		zcbor_trace_file(state);
 diff --git a/subsys/net/lib/lwm2m/lwm2m_senml_cbor_encode.h b/subsys/net/lib/lwm2m/lwm2m_senml_cbor_encode.h
-index df2f0ac6a1..8fa1eedb2b 100644
+index 8bfba2d834e..fe644015f63 100644
 --- a/subsys/net/lib/lwm2m/lwm2m_senml_cbor_encode.h
 +++ b/subsys/net/lib/lwm2m/lwm2m_senml_cbor_encode.h
 @@ -4,7 +4,7 @@
@@ -139,7 +139,7 @@ index df2f0ac6a1..8fa1eedb2b 100644
 		uint8_t *payload, size_t payload_len,
 		const struct lwm2m_senml *input,
 diff --git a/subsys/net/lib/lwm2m/lwm2m_senml_cbor_types.h b/subsys/net/lib/lwm2m/lwm2m_senml_cbor_types.h
-index 77649036ef..f0a2958072 100644
+index ad1d0bef58d..662329d1680 100644
 --- a/subsys/net/lib/lwm2m/lwm2m_senml_cbor_types.h
 +++ b/subsys/net/lib/lwm2m/lwm2m_senml_cbor_types.h
 @@ -4,7 +4,7 @@
@@ -151,7 +151,7 @@ index 77649036ef..f0a2958072 100644
   * Generated with a --default-max-qty of 99
   */
 
-@@ -20,14 +20,18 @@
+@@ -20,14 +20,17 @@
  extern "C" {
  #endif
 
@@ -163,7 +163,6 @@ index 77649036ef..f0a2958072 100644
 - *  See `zcbor --help` for more information about --default-max-qty
 - */
 -#define DEFAULT_MAX_QTY 99
-+
 +enum lwm2m_senml_cbor_key {
 +	lwm2m_senml_cbor_key_bn = -2,
 +	lwm2m_senml_cbor_key_bt = -3,
@@ -178,7 +177,26 @@ index 77649036ef..f0a2958072 100644
 
  struct record_bn {
 	struct zcbor_string record_bn;
-@@ -118,7 +122,7 @@ struct record {
+@@ -104,21 +107,21 @@ struct record_key_value_pair_m {
+
+ struct record {
+	struct record_bn record_bn;
+-	bool record_bn_present;
+	struct record_bt record_bt;
+-	bool record_bt_present;
+	struct record_n record_n;
+-	bool record_n_present;
+	struct record_t record_t;
+-	bool record_t_present;
+	struct record_union_r record_union;
+-	bool record_union_present;
+	struct record_key_value_pair_m record_key_value_pair_m[5];
+	size_t record_key_value_pair_m_count;
++	bool record_bn_present;
++	bool record_bt_present;
++	bool record_n_present;
++	bool record_t_present;
++	bool record_union_present;
  };
 
  struct lwm2m_senml {

--- a/subsys/net/lib/lwm2m/lwm2m_senml_cbor_types.h
+++ b/subsys/net/lib/lwm2m/lwm2m_senml_cbor_types.h
@@ -107,17 +107,17 @@ struct record_key_value_pair_m {
 
 struct record {
 	struct record_bn record_bn;
-	bool record_bn_present;
 	struct record_bt record_bt;
-	bool record_bt_present;
 	struct record_n record_n;
-	bool record_n_present;
 	struct record_t record_t;
-	bool record_t_present;
 	struct record_union_r record_union;
-	bool record_union_present;
 	struct record_key_value_pair_m record_key_value_pair_m[5];
 	size_t record_key_value_pair_m_count;
+	bool record_bn_present;
+	bool record_bt_present;
+	bool record_n_present;
+	bool record_t_present;
+	bool record_union_present;
 };
 
 struct lwm2m_senml {


### PR DESCRIPTION
The record data structure is better aligned. Each record saves 24 bytes.
For embedded systems it is important to have packed data structures. The RAM saving is quite big if multiple records are used.