### PR TITLE
drivers: nsos: support getsockopt(), setsockopt() and FIONREAD

### DIFF
--- a/drivers/net/nsos.h
+++ b/drivers/net/nsos.h
@@ -126,6 +126,10 @@ int nsos_adapt_sendto(int fd, const void *buf, size_t len, int flags,
 int nsos_adapt_sendmsg(int fd, const struct nsos_mid_msghdr *msg_mid, int flags);
 int nsos_adapt_recvfrom(int fd, void *buf, size_t len, int flags,
 			struct nsos_mid_sockaddr *addr, size_t *addrlen);
+int nsos_adapt_getsockopt(int fd, int level, int optname,
+			  void *optval, size_t *optlen);
+int nsos_adapt_setsockopt(int fd, int level, int optname,
+			  const void *optval, size_t optlen);
 
 void nsos_adapt_poll_add(struct nsos_mid_pollfd *pollfd);
 void nsos_adapt_poll_remove(struct nsos_mid_pollfd *pollfd);

--- a/drivers/net/nsos.h
+++ b/drivers/net/nsos.h
@@ -138,6 +138,8 @@ void nsos_adapt_poll_update(struct nsos_mid_pollfd *pollfd);
 int nsos_adapt_fcntl_getfl(int fd);
 int nsos_adapt_fcntl_setfl(int fd, int flags);
 
+int nsos_adapt_fionread(int fd, int *avail);
+
 int nsos_adapt_getaddrinfo(const char *node, const char *service,
 			   const struct nsos_mid_addrinfo *hints,
 			   struct nsos_mid_addrinfo **res,

--- a/drivers/net/nsos_adapt.c
+++ b/drivers/net/nsos_adapt.c
@@ -16,6 +16,7 @@
 #include <fcntl.h>
 #include <netdb.h>
 #include <netinet/in.h>
+#include <netinet/tcp.h>
 #include <poll.h>
 #include <stdlib.h>
 #include <string.h>
@@ -624,6 +625,22 @@ int nsos_adapt_getsockopt(int fd, int nsos_mid_level, int nsos_mid_optname,
 			return nsos_adapt_getsockopt_int(fd, SOL_SOCKET, SO_KEEPALIVE,
 							 nsos_mid_optval, nsos_mid_optlen);
 		}
+
+	case NSOS_MID_IPPROTO_TCP:
+		switch (nsos_mid_optname) {
+		case NSOS_MID_TCP_NODELAY:
+			return nsos_adapt_getsockopt_int(fd, IPPROTO_TCP, TCP_NODELAY,
+							 nsos_mid_optval, nsos_mid_optlen);
+		case NSOS_MID_TCP_KEEPIDLE:
+			return nsos_adapt_getsockopt_int(fd, IPPROTO_TCP, TCP_KEEPIDLE,
+							 nsos_mid_optval, nsos_mid_optlen);
+		case NSOS_MID_TCP_KEEPINTVL:
+			return nsos_adapt_getsockopt_int(fd, IPPROTO_TCP, TCP_KEEPINTVL,
+							 nsos_mid_optval, nsos_mid_optlen);
+		case NSOS_MID_TCP_KEEPCNT:
+			return nsos_adapt_getsockopt_int(fd, IPPROTO_TCP, TCP_KEEPCNT,
+							 nsos_mid_optval, nsos_mid_optlen);
+		}
 	}
 
 	return -NSOS_MID_EOPNOTSUPP;
@@ -685,6 +702,22 @@ int nsos_adapt_setsockopt(int fd, int nsos_mid_level, int nsos_mid_optname,
 							 nsos_mid_optval, nsos_mid_optlen);
 		case NSOS_MID_SO_KEEPALIVE:
 			return nsos_adapt_setsockopt_int(fd, SOL_SOCKET, SO_KEEPALIVE,
+							 nsos_mid_optval, nsos_mid_optlen);
+		}
+
+	case NSOS_MID_IPPROTO_TCP:
+		switch (nsos_mid_optname) {
+		case NSOS_MID_TCP_NODELAY:
+			return nsos_adapt_setsockopt_int(fd, IPPROTO_TCP, TCP_NODELAY,
+							 nsos_mid_optval, nsos_mid_optlen);
+		case NSOS_MID_TCP_KEEPIDLE:
+			return nsos_adapt_setsockopt_int(fd, IPPROTO_TCP, TCP_KEEPIDLE,
+							 nsos_mid_optval, nsos_mid_optlen);
+		case NSOS_MID_TCP_KEEPINTVL:
+			return nsos_adapt_setsockopt_int(fd, IPPROTO_TCP, TCP_KEEPINTVL,
+							 nsos_mid_optval, nsos_mid_optlen);
+		case NSOS_MID_TCP_KEEPCNT:
+			return nsos_adapt_setsockopt_int(fd, IPPROTO_TCP, TCP_KEEPCNT,
 							 nsos_mid_optval, nsos_mid_optlen);
 		}
 	}

--- a/drivers/net/nsos_adapt.c
+++ b/drivers/net/nsos_adapt.c
@@ -651,6 +651,22 @@ int nsos_adapt_setsockopt(int fd, int nsos_mid_level, int nsos_mid_optname,
 			return nsos_adapt_setsockopt_int(fd, SOL_SOCKET, SO_PRIORITY,
 							 nsos_mid_optval, nsos_mid_optlen);
 
+		case NSOS_MID_SO_RCVTIMEO: {
+			const struct nsos_mid_timeval *nsos_mid_tv = nsos_mid_optval;
+			struct timeval tv = {
+				.tv_sec = nsos_mid_tv->tv_sec,
+				.tv_usec = nsos_mid_tv->tv_usec,
+			};
+			int ret;
+
+			ret = setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO,
+					 &tv, sizeof(tv));
+			if (ret < 0) {
+				return -errno_to_nsos_mid(errno);
+			}
+
+			return 0;
+		}
 		case NSOS_MID_SO_RCVBUF:
 			return nsos_adapt_setsockopt_int(fd, SOL_SOCKET, SO_RCVBUF,
 							 nsos_mid_optval, nsos_mid_optlen);

--- a/drivers/net/nsos_adapt.c
+++ b/drivers/net/nsos_adapt.c
@@ -641,6 +641,13 @@ int nsos_adapt_getsockopt(int fd, int nsos_mid_level, int nsos_mid_optname,
 			return nsos_adapt_getsockopt_int(fd, IPPROTO_TCP, TCP_KEEPCNT,
 							 nsos_mid_optval, nsos_mid_optlen);
 		}
+
+	case NSOS_MID_IPPROTO_IPV6:
+		switch (nsos_mid_optname) {
+		case NSOS_MID_IPV6_V6ONLY:
+			return nsos_adapt_getsockopt_int(fd, IPPROTO_IPV6, IPV6_V6ONLY,
+							 nsos_mid_optval, nsos_mid_optlen);
+		}
 	}
 
 	return -NSOS_MID_EOPNOTSUPP;
@@ -718,6 +725,13 @@ int nsos_adapt_setsockopt(int fd, int nsos_mid_level, int nsos_mid_optname,
 							 nsos_mid_optval, nsos_mid_optlen);
 		case NSOS_MID_TCP_KEEPCNT:
 			return nsos_adapt_setsockopt_int(fd, IPPROTO_TCP, TCP_KEEPCNT,
+							 nsos_mid_optval, nsos_mid_optlen);
+		}
+
+	case NSOS_MID_IPPROTO_IPV6:
+		switch (nsos_mid_optname) {
+		case NSOS_MID_IPV6_V6ONLY:
+			return nsos_adapt_setsockopt_int(fd, IPPROTO_IPV6, IPV6_V6ONLY,
 							 nsos_mid_optval, nsos_mid_optlen);
 		}
 	}

--- a/drivers/net/nsos_adapt.c
+++ b/drivers/net/nsos_adapt.c
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/epoll.h>
+#include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
@@ -932,6 +933,18 @@ int nsos_adapt_fcntl_setfl(int fd, int flags)
 	int ret;
 
 	ret = fcntl(fd, F_SETFL, fl_from_nsos_mid(flags));
+	if (ret < 0) {
+		return -errno_to_nsos_mid(errno);
+	}
+
+	return 0;
+}
+
+int nsos_adapt_fionread(int fd, int *avail)
+{
+	int ret;
+
+	ret = ioctl(fd, FIONREAD, avail);
 	if (ret < 0) {
 		return -errno_to_nsos_mid(errno);
 	}

--- a/drivers/net/nsos_adapt.c
+++ b/drivers/net/nsos_adapt.c
@@ -10,6 +10,8 @@
  * Linux (bottom) side of NSOS (Native Simulator Offloaded Sockets).
  */
 
+#define _DEFAULT_SOURCE
+
 #include <errno.h>
 #include <fcntl.h>
 #include <netdb.h>
@@ -25,6 +27,7 @@
 #include "nsos_errno.h"
 #include "nsos_fcntl.h"
 #include "nsos_netdb.h"
+#include "nsos_socket.h"
 
 #include "board_soc.h"
 #include "irq_ctrl.h"
@@ -509,6 +512,167 @@ int nsos_adapt_recvfrom(int fd, void *buf, size_t len, int flags,
 	}
 
 	return ret;
+}
+
+static int nsos_adapt_getsockopt_int(int fd, int level, int optname,
+				     void *optval, size_t *nsos_mid_optlen)
+{
+	socklen_t optlen = *nsos_mid_optlen;
+	int ret;
+
+	ret = getsockopt(fd, level, optname, optval, &optlen);
+	if (ret < 0) {
+		return -errno_to_nsos_mid(errno);
+	}
+
+	*nsos_mid_optlen = optlen;
+
+	return 0;
+}
+
+int nsos_adapt_getsockopt(int fd, int nsos_mid_level, int nsos_mid_optname,
+			  void *nsos_mid_optval, size_t *nsos_mid_optlen)
+{
+	switch (nsos_mid_level) {
+	case NSOS_MID_SOL_SOCKET:
+		switch (nsos_mid_optname) {
+		case NSOS_MID_SO_ERROR: {
+			int err;
+			socklen_t optlen = sizeof(err);
+			int ret;
+
+			ret = getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &optlen);
+			if (ret < 0) {
+				return -errno_to_nsos_mid(errno);
+			}
+
+			*(int *)nsos_mid_optval = errno_to_nsos_mid(err);
+
+			return 0;
+		}
+		case NSOS_MID_SO_TYPE: {
+			int type;
+			socklen_t optlen = sizeof(type);
+			int ret;
+			int err;
+
+			ret = getsockopt(fd, SOL_SOCKET, SO_TYPE, &type, &optlen);
+			if (ret < 0) {
+				return -errno_to_nsos_mid(errno);
+			}
+
+			err = socket_type_to_nsos_mid(type, nsos_mid_optval);
+			if (err) {
+				return err;
+			}
+
+			return 0;
+		}
+		case NSOS_MID_SO_PROTOCOL: {
+			int proto;
+			socklen_t optlen = sizeof(proto);
+			int ret;
+			int err;
+
+			ret = getsockopt(fd, SOL_SOCKET, SO_PROTOCOL, &proto, &optlen);
+			if (ret < 0) {
+				return -errno_to_nsos_mid(errno);
+			}
+
+			err = socket_proto_to_nsos_mid(proto, nsos_mid_optval);
+			if (err) {
+				return err;
+			}
+
+			return 0;
+		}
+		case NSOS_MID_SO_DOMAIN: {
+			int family;
+			socklen_t optlen = sizeof(family);
+			int ret;
+			int err;
+
+			ret = getsockopt(fd, SOL_SOCKET, SO_DOMAIN, &family, &optlen);
+			if (ret < 0) {
+				return -errno_to_nsos_mid(errno);
+			}
+
+			err = socket_family_to_nsos_mid(family, nsos_mid_optval);
+			if (err) {
+				return err;
+			}
+
+			return 0;
+		}
+		case NSOS_MID_SO_RCVBUF:
+			return nsos_adapt_getsockopt_int(fd, SOL_SOCKET, SO_RCVBUF,
+							 nsos_mid_optval, nsos_mid_optlen);
+		case NSOS_MID_SO_SNDBUF:
+			return nsos_adapt_getsockopt_int(fd, SOL_SOCKET, SO_SNDBUF,
+							 nsos_mid_optval, nsos_mid_optlen);
+		case NSOS_MID_SO_REUSEADDR:
+			return nsos_adapt_getsockopt_int(fd, SOL_SOCKET, SO_REUSEADDR,
+							 nsos_mid_optval, nsos_mid_optlen);
+		case NSOS_MID_SO_REUSEPORT:
+			return nsos_adapt_getsockopt_int(fd, SOL_SOCKET, SO_REUSEPORT,
+							 nsos_mid_optval, nsos_mid_optlen);
+		case NSOS_MID_SO_LINGER:
+			return nsos_adapt_getsockopt_int(fd, SOL_SOCKET, SO_LINGER,
+							 nsos_mid_optval, nsos_mid_optlen);
+		case NSOS_MID_SO_KEEPALIVE:
+			return nsos_adapt_getsockopt_int(fd, SOL_SOCKET, SO_KEEPALIVE,
+							 nsos_mid_optval, nsos_mid_optlen);
+		}
+	}
+
+	return -NSOS_MID_EOPNOTSUPP;
+}
+
+static int nsos_adapt_setsockopt_int(int fd, int level, int optname,
+				     const void *optval, size_t optlen)
+{
+	int ret;
+
+	ret = setsockopt(fd, level, optname, optval, optlen);
+	if (ret < 0) {
+		return -errno_to_nsos_mid(errno);
+	}
+
+	return 0;
+}
+
+int nsos_adapt_setsockopt(int fd, int nsos_mid_level, int nsos_mid_optname,
+			  const void *nsos_mid_optval, size_t nsos_mid_optlen)
+{
+	switch (nsos_mid_level) {
+	case NSOS_MID_SOL_SOCKET:
+		switch (nsos_mid_optname) {
+		case NSOS_MID_SO_PRIORITY:
+			return nsos_adapt_setsockopt_int(fd, SOL_SOCKET, SO_PRIORITY,
+							 nsos_mid_optval, nsos_mid_optlen);
+
+		case NSOS_MID_SO_RCVBUF:
+			return nsos_adapt_setsockopt_int(fd, SOL_SOCKET, SO_RCVBUF,
+							 nsos_mid_optval, nsos_mid_optlen);
+		case NSOS_MID_SO_SNDBUF:
+			return nsos_adapt_setsockopt_int(fd, SOL_SOCKET, SO_SNDBUF,
+							 nsos_mid_optval, nsos_mid_optlen);
+		case NSOS_MID_SO_REUSEADDR:
+			return nsos_adapt_setsockopt_int(fd, SOL_SOCKET, SO_REUSEADDR,
+							 nsos_mid_optval, nsos_mid_optlen);
+		case NSOS_MID_SO_REUSEPORT:
+			return nsos_adapt_setsockopt_int(fd, SOL_SOCKET, SO_REUSEPORT,
+							 nsos_mid_optval, nsos_mid_optlen);
+		case NSOS_MID_SO_LINGER:
+			return nsos_adapt_setsockopt_int(fd, SOL_SOCKET, SO_LINGER,
+							 nsos_mid_optval, nsos_mid_optlen);
+		case NSOS_MID_SO_KEEPALIVE:
+			return nsos_adapt_setsockopt_int(fd, SOL_SOCKET, SO_KEEPALIVE,
+							 nsos_mid_optval, nsos_mid_optlen);
+		}
+	}
+
+	return -NSOS_MID_EOPNOTSUPP;
 }
 
 #define MAP_POLL_EPOLL(_event_from, _event_to)	\

--- a/drivers/net/nsos_socket.h
+++ b/drivers/net/nsos_socket.h
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2024 Marcin Niestroj
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __DRIVERS_NET_NSOS_SOCKET_H__
+#define __DRIVERS_NET_NSOS_SOCKET_H__
+
+/**
+ * @name Socket level options (NSOS_MID_SOL_SOCKET)
+ * @{
+ */
+/** Socket-level option */
+#define NSOS_MID_SOL_SOCKET 1
+
+/* Socket options for NSOS_MID_SOL_SOCKET level */
+
+/** Recording debugging information (ignored, for compatibility) */
+#define NSOS_MID_SO_DEBUG 1
+/** address reuse */
+#define NSOS_MID_SO_REUSEADDR 2
+/** Type of the socket */
+#define NSOS_MID_SO_TYPE 3
+/** Async error */
+#define NSOS_MID_SO_ERROR 4
+/** Bypass normal routing and send directly to host (ignored, for compatibility) */
+#define NSOS_MID_SO_DONTROUTE 5
+/** Transmission of broadcast messages is supported (ignored, for compatibility) */
+#define NSOS_MID_SO_BROADCAST 6
+
+/** Size of socket send buffer */
+#define NSOS_MID_SO_SNDBUF 7
+/** Size of socket recv buffer */
+#define NSOS_MID_SO_RCVBUF 8
+
+/** Enable sending keep-alive messages on connections */
+#define NSOS_MID_SO_KEEPALIVE 9
+/** Place out-of-band data into receive stream (ignored, for compatibility) */
+#define NSOS_MID_SO_OOBINLINE 10
+/** Socket priority */
+#define NSOS_MID_SO_PRIORITY 12
+/** Socket lingers on close (ignored, for compatibility) */
+#define NSOS_MID_SO_LINGER 13
+/** Allow multiple sockets to reuse a single port */
+#define NSOS_MID_SO_REUSEPORT 15
+
+/** Receive low watermark (ignored, for compatibility) */
+#define NSOS_MID_SO_RCVLOWAT 18
+/** Send low watermark (ignored, for compatibility) */
+#define NSOS_MID_SO_SNDLOWAT 19
+
+/**
+ * Receive timeout
+ * Applies to receive functions like recv(), but not to connect()
+ */
+#define NSOS_MID_SO_RCVTIMEO 20
+/** Send timeout */
+#define NSOS_MID_SO_SNDTIMEO 21
+
+/** Bind a socket to an interface */
+#define NSOS_MID_SO_BINDTODEVICE	25
+
+/** Socket accepts incoming connections (ignored, for compatibility) */
+#define NSOS_MID_SO_ACCEPTCONN 30
+
+/** Timestamp TX packets */
+#define NSOS_MID_SO_TIMESTAMPING 37
+/** Protocol used with the socket */
+#define NSOS_MID_SO_PROTOCOL 38
+
+/** Domain used with SOCKET */
+#define NSOS_MID_SO_DOMAIN 39
+
+/** Enable SOCKS5 for Socket */
+#define NSOS_MID_SO_SOCKS5 60
+
+/** Socket TX time (when the data should be sent) */
+#define NSOS_MID_SO_TXTIME 61
+
+/** @} */
+
+#endif /* __DRIVERS_NET_NSOS_SOCKET_H__ */

--- a/drivers/net/nsos_socket.h
+++ b/drivers/net/nsos_socket.h
@@ -103,4 +103,32 @@ struct nsos_mid_timeval {
 
 /** @} */
 
+/**
+ * @name IPv6 level options (NSOS_MID_IPPROTO_IPV6)
+ * @{
+ */
+/* Socket options for NSOS_MID_IPPROTO_IPV6 level */
+/** Set the unicast hop limit for the socket. */
+#define NSOS_MID_IPV6_UNICAST_HOPS	16
+
+/** Set the multicast hop limit for the socket. */
+#define NSOS_MID_IPV6_MULTICAST_HOPS 18
+
+/** Join IPv6 multicast group. */
+#define NSOS_MID_IPV6_ADD_MEMBERSHIP 20
+
+/** Leave IPv6 multicast group. */
+#define NSOS_MID_IPV6_DROP_MEMBERSHIP 21
+
+/** Don't support IPv4 access */
+#define NSOS_MID_IPV6_V6ONLY 26
+
+/** Pass an IPV6_RECVPKTINFO ancillary message that contains a
+ *  in6_pktinfo structure that supplies some information about the
+ *  incoming packet. See RFC 3542.
+ */
+#define NSOS_MID_IPV6_RECVPKTINFO 49
+
+/** @} */
+
 #endif /* __DRIVERS_NET_NSOS_SOCKET_H__ */

--- a/drivers/net/nsos_socket.h
+++ b/drivers/net/nsos_socket.h
@@ -87,4 +87,20 @@ struct nsos_mid_timeval {
 
 /** @} */
 
+/**
+ * @name TCP level options (NSOS_MID_IPPROTO_TCP)
+ * @{
+ */
+/* Socket options for NSOS_MID_IPPROTO_TCP level */
+/** Disable TCP buffering (ignored, for compatibility) */
+#define NSOS_MID_TCP_NODELAY 1
+/** Start keepalives after this period (seconds) */
+#define NSOS_MID_TCP_KEEPIDLE 2
+/** Interval between keepalives (seconds) */
+#define NSOS_MID_TCP_KEEPINTVL 3
+/** Number of keepalives before dropping connection */
+#define NSOS_MID_TCP_KEEPCNT 4
+
+/** @} */
+
 #endif /* __DRIVERS_NET_NSOS_SOCKET_H__ */

--- a/drivers/net/nsos_socket.h
+++ b/drivers/net/nsos_socket.h
@@ -7,6 +7,8 @@
 #ifndef __DRIVERS_NET_NSOS_SOCKET_H__
 #define __DRIVERS_NET_NSOS_SOCKET_H__
 
+#include <stdint.h>
+
 /**
  * @name Socket level options (NSOS_MID_SOL_SOCKET)
  * @{
@@ -77,6 +79,11 @@
 
 /** Socket TX time (when the data should be sent) */
 #define NSOS_MID_SO_TXTIME 61
+
+struct nsos_mid_timeval {
+	int64_t tv_sec;
+	int64_t tv_usec;
+};
 
 /** @} */
 

--- a/drivers/net/nsos_sockets.c
+++ b/drivers/net/nsos_sockets.c
@@ -1024,6 +1024,26 @@ static int nsos_getsockopt(void *obj, int level, int optname,
 						   NSOS_MID_SOL_SOCKET, NSOS_MID_SO_KEEPALIVE,
 						   optval, optlen);
 		}
+
+	case IPPROTO_TCP:
+		switch (optname) {
+		case TCP_NODELAY:
+			return nsos_getsockopt_int(sock,
+						   NSOS_MID_IPPROTO_TCP, NSOS_MID_TCP_NODELAY,
+						   optval, optlen);
+		case TCP_KEEPIDLE:
+			return nsos_getsockopt_int(sock,
+						   NSOS_MID_IPPROTO_TCP, NSOS_MID_TCP_KEEPIDLE,
+						   optval, optlen);
+		case TCP_KEEPINTVL:
+			return nsos_getsockopt_int(sock,
+						   NSOS_MID_IPPROTO_TCP, NSOS_MID_TCP_KEEPINTVL,
+						   optval, optlen);
+		case TCP_KEEPCNT:
+			return nsos_getsockopt_int(sock,
+						   NSOS_MID_IPPROTO_TCP, NSOS_MID_TCP_KEEPCNT,
+						   optval, optlen);
+		}
 	}
 
 	errno = EOPNOTSUPP;
@@ -1131,6 +1151,26 @@ static int nsos_setsockopt(void *obj, int level, int optname,
 		case SO_KEEPALIVE:
 			return nsos_setsockopt_int(sock,
 						   NSOS_MID_SOL_SOCKET, NSOS_MID_SO_KEEPALIVE,
+						   optval, optlen);
+		}
+
+	case IPPROTO_TCP:
+		switch (optname) {
+		case TCP_NODELAY:
+			return nsos_setsockopt_int(sock,
+						   NSOS_MID_IPPROTO_TCP, NSOS_MID_TCP_NODELAY,
+						   optval, optlen);
+		case TCP_KEEPIDLE:
+			return nsos_setsockopt_int(sock,
+						   NSOS_MID_IPPROTO_TCP, NSOS_MID_TCP_KEEPIDLE,
+						   optval, optlen);
+		case TCP_KEEPINTVL:
+			return nsos_setsockopt_int(sock,
+						   NSOS_MID_IPPROTO_TCP, NSOS_MID_TCP_KEEPINTVL,
+						   optval, optlen);
+		case TCP_KEEPCNT:
+			return nsos_setsockopt_int(sock,
+						   NSOS_MID_IPPROTO_TCP, NSOS_MID_TCP_KEEPCNT,
 						   optval, optlen);
 		}
 	}

--- a/drivers/net/nsos_sockets.c
+++ b/drivers/net/nsos_sockets.c
@@ -1044,6 +1044,14 @@ static int nsos_getsockopt(void *obj, int level, int optname,
 						   NSOS_MID_IPPROTO_TCP, NSOS_MID_TCP_KEEPCNT,
 						   optval, optlen);
 		}
+
+	case IPPROTO_IPV6:
+		switch (optname) {
+		case IPV6_V6ONLY:
+			return nsos_getsockopt_int(sock,
+						   NSOS_MID_IPPROTO_IPV6, NSOS_MID_IPV6_V6ONLY,
+						   optval, optlen);
+		}
 	}
 
 	errno = EOPNOTSUPP;
@@ -1171,6 +1179,14 @@ static int nsos_setsockopt(void *obj, int level, int optname,
 		case TCP_KEEPCNT:
 			return nsos_setsockopt_int(sock,
 						   NSOS_MID_IPPROTO_TCP, NSOS_MID_TCP_KEEPCNT,
+						   optval, optlen);
+		}
+
+	case IPPROTO_IPV6:
+		switch (optname) {
+		case IPV6_V6ONLY:
+			return nsos_setsockopt_int(sock,
+						   NSOS_MID_IPPROTO_IPV6, NSOS_MID_IPV6_V6ONLY,
 						   optval, optlen);
 		}
 	}

--- a/drivers/net/nsos_sockets.c
+++ b/drivers/net/nsos_sockets.c
@@ -371,6 +371,15 @@ static int nsos_ioctl(void *obj, unsigned int request, va_list args)
 
 		return -errno_from_nsos_mid(-ret);
 	}
+
+	case ZFD_IOCTL_FIONREAD: {
+		int *avail = va_arg(args, int *);
+		int ret;
+
+		ret = nsos_adapt_fionread(sock->pollfd.fd, avail);
+
+		return -errno_from_nsos_mid(-ret);
+	}
 	}
 
 	return -EINVAL;

--- a/samples/net/sockets/echo_server/src/tcp.c
+++ b/samples/net/sockets/echo_server/src/tcp.c
@@ -101,11 +101,19 @@ static int start_tcp_proto(struct data *data,
 	}
 #endif
 
-	/* Prefer IPv6 temporary addresses */
 	if (bind_addr->sa_family == AF_INET6) {
+		/* Prefer IPv6 temporary addresses */
 		optval = IPV6_PREFER_SRC_PUBLIC;
 		(void)setsockopt(data->tcp.sock, IPPROTO_IPV6,
 				 IPV6_ADDR_PREFERENCES,
+				 &optval, sizeof(optval));
+
+		/*
+		 * Bind only to IPv6 without mapping to IPv4, since we bind to
+		 * IPv4 using another socket
+		 */
+		optval = 1;
+		(void)setsockopt(data->tcp.sock, IPPROTO_IPV6, IPV6_V6ONLY,
 				 &optval, sizeof(optval));
 	}
 

--- a/samples/net/sockets/echo_server/src/udp.c
+++ b/samples/net/sockets/echo_server/src/udp.c
@@ -78,11 +78,19 @@ static int start_udp_proto(struct data *data, struct sockaddr *bind_addr,
 	}
 #endif
 
-	/* Prefer IPv6 temporary addresses */
 	if (bind_addr->sa_family == AF_INET6) {
+		/* Prefer IPv6 temporary addresses */
 		optval = IPV6_PREFER_SRC_PUBLIC;
 		(void)setsockopt(data->tcp.sock, IPPROTO_IPV6,
 				 IPV6_ADDR_PREFERENCES,
+				 &optval, sizeof(optval));
+
+		/*
+		 * Bind only to IPv6 without mapping to IPv4, since we bind to
+		 * IPv4 using another socket
+		 */
+		optval = 1;
+		(void)setsockopt(data->tcp.sock, IPPROTO_IPV6, IPV6_V6ONLY,
 				 &optval, sizeof(optval));
 	}
 

--- a/tests/net/socket/udp/src/main.c
+++ b/tests/net/socket/udp/src/main.c
@@ -343,7 +343,7 @@ ZTEST(net_socket_udp, test_07_so_priority)
 			      sizeof(optval));
 	zassert_equal(rv, 0, "setsockopt failed (%d)", errno);
 
-	optval = 8;
+	optval = 6;
 	rv = zsock_setsockopt(sock2, SOL_SOCKET, SO_PRIORITY, &optval,
 			      sizeof(optval));
 	zassert_equal(rv, 0, "setsockopt failed");


### PR DESCRIPTION
Add initial support for `getsockopt()`, `setsockopt()` and `ioctl(FIONREAD)` APIs.

This increases percentage of passed tests in `tests/net/socket/udp/` from 39.29% to 67.88%.

Fixes: #71243