### PR TITLE
espi/it8xxx2: enable EC to accept port 81 cycle

### DIFF
--- a/drivers/espi/Kconfig.it8xxx2
+++ b/drivers/espi/Kconfig.it8xxx2
@@ -127,4 +127,19 @@ config ESPI_IT8XXX2_PNPCFG_DEVICE_KBC_MOUSE
 	  With this option enabled, EC will send IRQ12 signal to host when the
 	  KBC mouse output buffer is full.
 
+# On IT8xxx2 series, this configuration option has limitation:
+# Port 80 and 81 I/O cycles share the same interrupt source and there is no
+# status bit to indicate which cycle triggered the interrupt and data registers
+# of these two ports are read only. Hence EC have to read these two data
+# registers at the same time in the ISR.
+# It means that the Host must alwasy write 2 bytes of data to port 80 otherwise
+# port 81 data will not be updated.
+config ESPI_IT8XXX2_PORT_81_CYCLE
+	bool "EC accepts 0x81 I/O cycle from eSPI transaction"
+	depends on ESPI_PERIPHERAL_DEBUG_PORT_80
+	help
+	  With this option enabled, EC will accept 0x81 I/O cycle from the Host.
+	  This allows EC to accept 2 bytes of port 80 data written from the Host.
+	  (e.g. using iotools: iotools io_write16 0x80 0x1234)
+
 endif #ESPI_IT8XXX2

--- a/soc/ite/ec/common/chip_chipregs.h
+++ b/soc/ite/ec/common/chip_chipregs.h
@@ -1661,6 +1661,8 @@ struct gctrl_it8xxx2_regs {
 #define IT8XXX2_GCTRL_ILM0_ENABLE	BIT(0)
 /* Accept Port 80h Cycle */
 #define IT8XXX2_GCTRL_ACP80		BIT(6)
+/* Accept Port 81h Cycle */
+#define IT8XXX2_GCTRL_ACP81		BIT(3)
 /* USB Debug Enable */
 #define IT8XXX2_GCTRL_MCCR_USB_EN	BIT(7)
 /* USB Pad Power-On Enable */


### PR DESCRIPTION
This allows EC to accept 2 bytes of port 80 data written from the Host.