### PR TITLE
driver: eSPI: npcx: enable the Serial Port (Host UART) support

### DIFF
--- a/drivers/espi/host_subs_npcx.c
+++ b/drivers/espi/host_subs_npcx.c
@@ -191,6 +191,7 @@ struct host_sub_npcx_data host_sub_data;
 #define NPCX_C2H_TRANSACTION_TIMEOUT_US 200
 
 /* Logical Device Number Assignments */
+#define EC_CFG_LDN_SP    0x03
 #define EC_CFG_LDN_MOUSE 0x05
 #define EC_CFG_LDN_KBC   0x06
 #define EC_CFG_LDN_SHM   0x0F
@@ -205,6 +206,13 @@ struct host_sub_npcx_data host_sub_data;
 #define EC_CFG_IDX_DATA_IO_ADDR_H  0x62
 #define EC_CFG_IDX_DATA_IO_ADDR_L  0x63
 
+/* LDN Activation Enable */
+#define EC_CFG_IDX_CTRL_LDN_ENABLE 0x01
+
+/* Index of SuperI/O Control and Configuration Registers */
+#define EC_CFG_IDX_SUPERIO_SIOCF9      0x29
+#define EC_CFG_IDX_SUPERIO_SIOCF9_CKEN 2
+
 /* Index of Special Logical Device Configuration (Shared Memory Module) */
 #define EC_CFG_IDX_SHM_CFG             0xF1
 #define EC_CFG_IDX_SHM_WND1_ADDR_0     0xF4
@@ -216,6 +224,11 @@ struct host_sub_npcx_data host_sub_data;
 #define EC_CFG_IDX_SHM_WND2_ADDR_2     0xFA
 #define EC_CFG_IDX_SHM_WND2_ADDR_3     0xFB
 #define EC_CFG_IDX_SHM_DP80_ADDR_RANGE 0xFD
+
+/* Index of Special Logical Device Configuration (Serial Port/Host UART) */
+#define EC_CFG_IDX_SP_CFG              0xF0
+/* Enable selection of bank 2 and 3 for the Serial Port */
+#define EC_CFG_IDX_SP_CFG_BK_SL_ENABLE 7
 
 /* Host sub-device local inline functions */
 static inline uint8_t host_shd_mem_wnd_size_sl(uint32_t size)
@@ -995,10 +1008,10 @@ void npcx_host_init_subs_host_domain(void)
 		 * modules by setting bit 0 in its Control (index is 0x30) reg.
 		 */
 		host_c2h_write_io_cfg_reg(EC_CFG_IDX_LDN, EC_CFG_LDN_KBC);
-		host_c2h_write_io_cfg_reg(EC_CFG_IDX_CTRL, 0x01);
+		host_c2h_write_io_cfg_reg(EC_CFG_IDX_CTRL, EC_CFG_IDX_CTRL_LDN_ENABLE);
 
 		host_c2h_write_io_cfg_reg(EC_CFG_IDX_LDN, EC_CFG_LDN_MOUSE);
-		host_c2h_write_io_cfg_reg(EC_CFG_IDX_CTRL, 0x01);
+		host_c2h_write_io_cfg_reg(EC_CFG_IDX_CTRL, EC_CFG_IDX_CTRL_LDN_ENABLE);
 	}
 
 	if (IS_ENABLED(CONFIG_ESPI_PERIPHERAL_HOST_IO)) {
@@ -1007,7 +1020,7 @@ void npcx_host_init_subs_host_domain(void)
 		 * module by setting bit 0 in its Control (index is 0x30) reg.
 		 */
 		host_c2h_write_io_cfg_reg(EC_CFG_IDX_LDN, EC_CFG_LDN_ACPI);
-		host_c2h_write_io_cfg_reg(EC_CFG_IDX_CTRL, 0x01);
+		host_c2h_write_io_cfg_reg(EC_CFG_IDX_CTRL, EC_CFG_IDX_CTRL_LDN_ENABLE);
 	}
 
 	if (IS_ENABLED(CONFIG_ESPI_PERIPHERAL_EC_HOST_CMD) ||
@@ -1028,7 +1041,7 @@ void npcx_host_init_subs_host_domain(void)
 		 (CONFIG_ESPI_PERIPHERAL_HOST_CMD_DATA_PORT_NUM + 4) & 0xff);
 #endif
 		/* Enable 'Host Command' io port (PM Channel 2) */
-		host_c2h_write_io_cfg_reg(EC_CFG_IDX_CTRL, 0x01);
+		host_c2h_write_io_cfg_reg(EC_CFG_IDX_CTRL, EC_CFG_IDX_CTRL_LDN_ENABLE);
 
 		/* Select 'Shared Memory' bank which LDN are 0x0F */
 		host_c2h_write_io_cfg_reg(EC_CFG_IDX_LDN, EC_CFG_LDN_SHM);
@@ -1053,8 +1066,23 @@ void npcx_host_init_subs_host_domain(void)
 			host_c2h_write_io_cfg_reg(EC_CFG_IDX_SHM_DP80_ADDR_RANGE, 0x0f);
 		}
 	/* Enable SHM direct memory access */
-	host_c2h_write_io_cfg_reg(EC_CFG_IDX_CTRL, 0x01);
+	host_c2h_write_io_cfg_reg(EC_CFG_IDX_CTRL, EC_CFG_IDX_CTRL_LDN_ENABLE);
 	}
+
+	if (IS_ENABLED(CONFIG_ESPI_PERIPHERAL_UART)) {
+		/* Select Serial Port banks which LDN are 0x03. */
+		host_c2h_write_io_cfg_reg(EC_CFG_IDX_LDN, EC_CFG_LDN_SP);
+		/* Enable SIO_CLK */
+		host_c2h_write_io_cfg_reg(EC_CFG_IDX_SUPERIO_SIOCF9,
+					  host_c2h_read_io_cfg_reg(EC_CFG_IDX_SUPERIO_SIOCF9) |
+						  BIT(EC_CFG_IDX_SUPERIO_SIOCF9_CKEN));
+		/* Enable Bank Select */
+		host_c2h_write_io_cfg_reg(EC_CFG_IDX_SP_CFG,
+					  host_c2h_read_io_cfg_reg(EC_CFG_IDX_SP_CFG) |
+						  BIT(EC_CFG_IDX_SP_CFG_BK_SL_ENABLE));
+		host_c2h_write_io_cfg_reg(EC_CFG_IDX_CTRL, EC_CFG_IDX_CTRL_LDN_ENABLE);
+	}
+
 	LOG_DBG("Hos sub-modules configurations are done!");
 }
 

--- a/dts/arm/nuvoton/npcx/npcx4/npcx4-pinctrl.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx4/npcx4-pinctrl.dtsi
@@ -30,6 +30,22 @@
 		dev-ctl = <0x0 6 1 0x01>;
 	};
 
+	/omit-if-no-ref/ sio_clk_sel_96m: devctl3-sio-clk_sel-96m {
+		dev-ctl = <0x4 6 2 0x00>;
+	};
+
+	/omit-if-no-ref/ sio_clk_sel_100: devctl3-sio-clk_sel-100m {
+		dev-ctl = <0x4 6 2 0x01>;
+	};
+
+	/omit-if-no-ref/ sio_clk_sel_120m: devctl3-sio-clk_sel-120m {
+		dev-ctl = <0x4 6 2 0x02>;
+	};
+
+	/omit-if-no-ref/ sio_clk_sel_90m: devctl3-sio-clk_sel-90m {
+		dev-ctl = <0x4 6 2 0x03>;
+	};
+
 	/* Prebuild nodes for peripheral device's pin-muxing and pad properties */
 	/* Flash Interface Unit (FIU) */
 	/omit-if-no-ref/ fiu_ext_io0_io1_clk_cs_gpa4_96_a2_a0: periph-fiu-ext {

--- a/dts/arm/nuvoton/npcx/npcx7/npcx7-pinctrl.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx7/npcx7-pinctrl.dtsi
@@ -22,6 +22,14 @@
 		dev-ctl = <0x0 6 1 0x01>;
 	};
 
+	/omit-if-no-ref/ sio_full_ck48: devctl4-sio-full-ck48 {
+		dev-ctl = <0x6 3 1 0x00>;
+	};
+
+	/omit-if-no-ref/ sio_full_ck50: devctl4-sio-full-ck50 {
+		dev-ctl = <0x6 3 1 0x01>;
+	};
+
 	/* Prebuild nodes for peripheral device's pin-muxing and pad properties */
 	/* Flash Interface Unit (FIU) */
 	/omit-if-no-ref/ fiu_ext_io0_io1_clk_cs_gpa4_96_a2_a0: periph-fiu-ext {

--- a/dts/arm/nuvoton/npcx/npcx9/npcx9-pinctrl.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx9/npcx9-pinctrl.dtsi
@@ -23,6 +23,14 @@
 		dev-ctl = <0x0 6 1 0x01>;
 	};
 
+	/omit-if-no-ref/ sio_full_ck48: devctl4-sio-full-ck48 {
+		dev-ctl = <0x6 3 1 0x00>;
+	};
+
+	/omit-if-no-ref/ sio_full_ck50: devctl4-sio-full-ck50 {
+		dev-ctl = <0x6 3 1 0x01>;
+	};
+
 	/* Prebuild nodes for peripheral device's pin-muxing and pad properties */
 	/* Flash Interface Unit (FIU) */
 	/omit-if-no-ref/ fiu_ext_io0_io1_clk_cs_gpa4_96_a2_a0: periph-fiu-ext {


### PR DESCRIPTION
This PR contains:
1. pinctrl nodes required for the Serial Port device ctrl.
2. enable the Serial Port LDN (03h) and SIO clock if CONFIG_ESPI_PERIPHERAL_UART=y.