### PR TITLE
MAINTAINERS: Add overlay-le-audio.conf to Bluetooth Audio

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -446,6 +446,7 @@ Bluetooth Audio:
     - tests/bluetooth/audio/
     - tests/bsim/bluetooth/audio/
     - tests/bluetooth/shell/audio.conf
+    - tests/bluetooth/tester/overlay-le-audio.conf
     - doc/connectivity/bluetooth/api/audio/
     - samples/bluetooth/broadcast_audio*/
     - samples/bluetooth/hap*/


### PR DESCRIPTION
Add the overlay-le-audio.conf overlay for the BT tester to the Bluetooth Audio group, so that changes to that file will notify the right people.