### PR TITLE
west: linkserver: fix erase error

### DIFF
--- a/scripts/west_commands/runners/linkserver.py
+++ b/scripts/west_commands/runners/linkserver.py
@@ -164,13 +164,8 @@ class LinkServerBinaryRunner(ZephyrBinaryRunner):
 
     def do_erase(self, **kwargs):
 
-        if self.core is not None:
-            _cmd_core = ":"+self.core
-        else:
-            _cmd_core = ""
-
         linkserver_cmd = ([self.linkserver, "flash"] + ["--probe", str(self.probe)] +
-                          [self.device+_cmd_core] + ["erase"])
+                          [self.device] + ["erase"])
         self.logger.debug("flash erase command = " + str(linkserver_cmd))
         self.check_call(linkserver_cmd)
 


### PR DESCRIPTION
- Fixes linkserver runner "west flash --erase" error: ERRMSG: Exception: Device query can have at most 2 parts (3 found)
- There is no need to specify the core with the flash erase command line.