### PR TITLE
boards: st: nucleo_u575zi_q: add USB OTG_FS

### DIFF
--- a/boards/st/nucleo_u575zi_q/doc/index.rst
+++ b/boards/st/nucleo_u575zi_q/doc/index.rst
@@ -167,6 +167,8 @@ The Zephyr nucleo_u575zi_q board configuration supports the following hardware f
 +-----------+------------+-------------------------------------+
 | WATCHDOG  | on-chip    | independent watchdog                |
 +-----------+------------+-------------------------------------+
+| USB FS    | on-chip    | USB Full Speed device               |
++-----------+------------+-------------------------------------+
 | BKP SRAM  | on-chip    | Backup SRAM                         |
 +-----------+------------+-------------------------------------+
 | RNG       | on-chip    | True Random number generator        |

--- a/boards/st/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
+++ b/boards/st/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
@@ -171,6 +171,12 @@
 	status = "okay";
 };
 
+zephyr_udc0: &usbotg_fs {
+	pinctrl-0 = <&usb_otg_fs_dm_pa11 &usb_otg_fs_dp_pa12>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
 &fdcan1 {
 	clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000200>,
 		 <&rcc STM32_SRC_PLL1_Q FDCAN1_SEL(1)>;


### PR DESCRIPTION
Add USB OTG_FS on nucleo_u575zi_q


**Converting this PR https://github.com/zephyrproject-rtos/zephyr/pull/69020 to Hardware model version 2**