### PR TITLE
Bluetooth: controller: Implement macros for vendor assert information

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -671,6 +671,16 @@ config BT_CTLR_ASSERT_OVERHEAD_START
 	  otherwise leading to remote supervision timeout and possible missing
 	  local disconnect events.
 
+config BT_CTLR_ASSERT_VENDOR
+	bool "Vendor Defined Assertion Information Handler"
+	help
+	  This option enables a vendor specific sink for the controller assertion
+	  mechanism, where parameter information is provided. This must be defined in
+	  vendor debug HAL interface as \"BT_ASSERT_VND(cond, param1, param2)\", and
+	  will be invoked whenever the controller code encounters an unrecoverable error
+	  with parameter information. Implementation shall include the equivalent of
+	  BT_ASSERT_DIE for halting the kernel.
+
 config BT_CTLR_CENTRAL_SPACING
 	int "Central Connection Spacing"
 	depends on BT_CTLR_SCHED_ADVANCED

--- a/subsys/bluetooth/controller/hal/debug.h
+++ b/subsys/bluetooth/controller/hal/debug.h
@@ -27,6 +27,18 @@ void bt_ctlr_assert_handle(char *file, uint32_t line);
 		BT_ASSERT_MSG(cond, fmt, ##__VA_ARGS__)
 #endif
 
+#if defined(CONFIG_BT_CTLR_ASSERT_VENDOR)
+#define LL_ASSERT_INFO1(cond, param) \
+		BT_ASSERT_VND(cond, param, 0)
+#define LL_ASSERT_INFO2(cond, param1, param2) \
+		BT_ASSERT_VND(cond, param1, param2)
+#else
+#define LL_ASSERT_INFO1(cond, param) \
+		LL_ASSERT_MSG(cond, "param: %u", param)
+#define LL_ASSERT_INFO2(cond, param1, param2) \
+		LL_ASSERT_MSG(cond, "param1: %u param2: %u", param1, param2)
+#endif /* CONFIG_BT_CTLR_ASSERT_VENDOR */
+
 #if defined(CONFIG_BT_CTLR_ASSERT_OVERHEAD_START)
 #define LL_ASSERT_OVERHEAD(overhead) \
 	LL_ASSERT_MSG(false, "%s: Actual EVENT_OVERHEAD_START_US = %u", \

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -2647,7 +2647,7 @@ int ull_adv_aux_stop(struct ll_adv_aux_set *aux)
 
 	err = ull_ticker_stop_with_mark(TICKER_ID_ADV_AUX_BASE + aux_handle,
 					aux, &aux->lll);
-	LL_ASSERT(err == 0 || err == -EALREADY);
+	LL_ASSERT_INFO2(err == 0 || err == -EALREADY, aux_handle, err);
 	if (err) {
 		return err;
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -2022,7 +2022,7 @@ static uint8_t sync_stop(struct ll_adv_sync_set *sync)
 
 	err = ull_ticker_stop_with_mark(TICKER_ID_ADV_SYNC_BASE + sync_handle,
 					sync, &sync->lll);
-	LL_ASSERT(err == 0 || err == -EALREADY);
+	LL_ASSERT_INFO2(err == 0 || err == -EALREADY, sync_handle, err);
 	if (err) {
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1730,7 +1730,7 @@ static inline void disable(uint16_t handle)
 
 	err = ull_ticker_stop_with_mark(TICKER_ID_CONN_BASE + handle,
 					conn, &conn->lll);
-	LL_ASSERT(err == 0 || err == -EALREADY);
+	LL_ASSERT_INFO2(err == 0 || err == -EALREADY, handle, err);
 
 	conn->lll.handle = LLL_HANDLE_INVALID;
 	conn->lll.link_tx_free = NULL;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
@@ -1568,8 +1568,7 @@ static void disable(uint16_t handle)
 
 	err = ull_ticker_stop_with_mark(TICKER_ID_CONN_ISO_BASE + handle,
 					cig, &cig->lll);
-
-	LL_ASSERT(err == 0 || err == -EALREADY);
+	LL_ASSERT_INFO2(err == 0 || err == -EALREADY, handle, err);
 
 	cig->lll.handle = LLL_HANDLE_INVALID;
 	cig->lll.resume_cis = LLL_HANDLE_INVALID;

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -653,7 +653,7 @@ uint8_t ull_scan_disable(uint8_t handle, struct ll_scan_set *scan)
 
 	err = ull_ticker_stop_with_mark(TICKER_ID_SCAN_BASE + handle,
 					scan, &scan->lll);
-	LL_ASSERT(err == 0 || err == -EALREADY);
+	LL_ASSERT_INFO2(err == 0 || err == -EALREADY, handle, err);
 	if (err) {
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -412,7 +412,7 @@ uint8_t ll_sync_terminate(uint16_t handle)
 	/* Stop periodic sync ticker timeouts */
 	err = ull_ticker_stop_with_mark(TICKER_ID_SCAN_SYNC_BASE + handle,
 					sync, &sync->lll);
-	LL_ASSERT(err == 0 || err == -EALREADY);
+	LL_ASSERT_INFO2(err == 0 || err == -EALREADY, handle, err);
 	if (err) {
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
@@ -270,7 +270,7 @@ uint8_t ll_big_sync_terminate(uint8_t big_handle, void **rx)
 
 	err = ull_ticker_stop_with_mark((TICKER_ID_SCAN_SYNC_ISO_BASE +
 					 big_handle), sync_iso, &sync_iso->lll);
-	LL_ASSERT(err == 0 || err == -EALREADY);
+	LL_ASSERT_INFO2(err == 0 || err == -EALREADY, big_handle, err);
 	if (err) {
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
@@ -817,7 +817,7 @@ static void disable(uint8_t sync_idx)
 
 	err = ull_ticker_stop_with_mark(TICKER_ID_SCAN_SYNC_ISO_BASE +
 					sync_idx, sync_iso, &sync_iso->lll);
-	LL_ASSERT(err == 0 || err == -EALREADY);
+	LL_ASSERT_INFO2(err == 0 || err == -EALREADY, sync_idx, err);
 }
 
 static int init_reset(void)


### PR DESCRIPTION
Implement LL_ASSERT_INFO1 and LL_ASSERT_INFO2 for triggering assertions with parameter information provided for vendor core dump.

Adds Kconfig CONFIG_BT_CTLR_ASSERT_VENDOR by which the new LL asserts map to BT_ASSERT_VND macros, which shall be implemented in the debug_vendor_hal.h of the platform. If not enabled, LL_ASSERT_INFO will map to existing BT_ASSERT_MSG with parameters printed.

Add use of LL_ASSERT_INFO2 where ull_ticker_stop_with_mark() result may assert.