### PR TITLE
drivers: sensor: adxl362: fix temperature conversion

### DIFF
--- a/drivers/sensor/adi/adxl362/adxl362.c
+++ b/drivers/sensor/adi/adxl362/adxl362.c
@@ -561,7 +561,8 @@ static void adxl362_accel_convert(struct sensor_value *val, int accel,
 static void adxl362_temp_convert(struct sensor_value *val, int temp)
 {
 	/* See sensitivity and bias specifications in table 1 of datasheet */
-	int milli_c = (temp - ADXL362_TEMP_BIAS_LSB) * ADXL362_TEMP_MC_PER_LSB;
+	int milli_c = (temp - ADXL362_TEMP_BIAS_LSB) * ADXL362_TEMP_MC_PER_LSB +
+		      (ADXL362_TEMP_BIAS_TEST_CONDITION * 1000);
 
 	val->val1 = milli_c / 1000;
 	val->val2 = (milli_c % 1000) * 1000;

--- a/drivers/sensor/adi/adxl362/adxl362.h
+++ b/drivers/sensor/adi/adxl362/adxl362.h
@@ -169,6 +169,7 @@
 /* ADXL362 temperature sensor specifications */
 #define ADXL362_TEMP_MC_PER_LSB 65
 #define ADXL362_TEMP_BIAS_LSB 350
+#define ADXL362_TEMP_BIAS_TEST_CONDITION 25
 
 struct adxl362_config {
 	struct spi_dt_spec bus;


### PR DESCRIPTION
It was missing the test condition for the temperature sensor.