### PR TITLE
usb: device_next: Properly store enumeration speed

### DIFF
--- a/subsys/usb/device_next/usbd_core.c
+++ b/subsys/usb/device_next/usbd_core.c
@@ -120,6 +120,7 @@ static int event_handler_bus_reset(struct usbd_contex *const uds_ctx)
 	switch (udc_speed) {
 	case UDC_BUS_SPEED_HS:
 		uds_ctx->status.speed = USBD_SPEED_HS;
+		break;
 	default:
 		uds_ctx->status.speed = USBD_SPEED_FS;
 	}


### PR DESCRIPTION
Add missing break inside switch statement to allow UDC context to indicate that current operating speed is High-Speed. Due to missing break statement, the stack always assumed Full-Speed.