### PR TITLE
drivers/sensor: lsm6dsl: use sensor APIs to convert to units

### DIFF
--- a/drivers/sensor/st/lsm6dsl/lsm6dsl.c
+++ b/drivers/sensor/st/lsm6dsl/lsm6dsl.c
@@ -472,14 +472,12 @@ static int lsm6dsl_sample_fetch(const struct device *dev,
 static inline void lsm6dsl_accel_convert(struct sensor_value *val, int raw_val,
 					 float sensitivity)
 {
-	double dval;
+	int64_t dval;
 
-	/* Sensitivity is exposed in mg/LSB */
+	/* Sensitivity is exposed in ug/LSB */
 	/* Convert to m/s^2 */
-	dval = (double)(raw_val) * (double)sensitivity * SENSOR_G_DOUBLE / 1000;
-	val->val1 = (int32_t)dval;
-	val->val2 = (((int32_t)(dval * 1000)) % 1000) * 1000;
-
+	dval = (int64_t)raw_val * sensitivity;
+	sensor_ug_to_ms2(dval, val);
 }
 
 static inline int lsm6dsl_accel_get_channel(enum sensor_channel chan,
@@ -522,13 +520,12 @@ static int lsm6dsl_accel_channel_get(enum sensor_channel chan,
 static inline void lsm6dsl_gyro_convert(struct sensor_value *val, int raw_val,
 					float sensitivity)
 {
-	double dval;
+	int64_t dval;
 
-	/* Sensitivity is exposed in mdps/LSB */
-	/* Convert to rad/s */
-	dval = (double)(raw_val * (double)sensitivity * SENSOR_DEG2RAD_DOUBLE / 1000);
-	val->val1 = (int32_t)dval;
-	val->val2 = (((int32_t)(dval * 1000)) % 1000) * 1000;
+	/* Sensitivity is exposed in udps/LSB */
+	/* So, calculate value in 10 udps unit and then to rad/s */
+	dval = (int64_t)raw_val * sensitivity / 10;
+	sensor_10udegrees_to_rad(dval, val);
 }
 
 static inline int lsm6dsl_gyro_get_channel(enum sensor_channel chan,

--- a/drivers/sensor/st/lsm6dsl/lsm6dsl.h
+++ b/drivers/sensor/st/lsm6dsl/lsm6dsl.h
@@ -553,14 +553,11 @@
 #define LSM6DSL_REG_Z_OFS_USR				0x75
 
 
-/* Accel sensor sensitivity grain is 0.061 mg/LSB */
-#define SENSI_GRAIN_XL				(61LL / 1000.0)
+/* Accel sensor sensitivity grain is 61 ug/LSB */
+#define SENSI_GRAIN_XL				61LL
 
-/* Gyro sensor sensitivity grain is 4.375 mdps/LSB */
-#define SENSI_GRAIN_G				(4375LL / 1000.0)
-#define SENSOR_PI_DOUBLE			(SENSOR_PI / 1000000.0)
-#define SENSOR_DEG2RAD_DOUBLE			(SENSOR_PI_DOUBLE / 180)
-#define SENSOR_G_DOUBLE				(SENSOR_G / 1000000.0)
+/* Gyro sensor sensitivity grain is 4375 udps/LSB */
+#define SENSI_GRAIN_G				4375LL
 
 #if CONFIG_LSM6DSL_ACCEL_FS == 0
 	#define LSM6DSL_ACCEL_FS_RUNTIME 1


### PR DESCRIPTION
Make use of sensor_ug_to_ms2() and sensor_10udegrees_to_rad() APIs to convert from raw values into proper units (i.e. m/s^2 for accel and rad/s for gyro). It also improves measurement precision.

Fixes #63980

Mimic what already done for other sensors in #71223
Replaces: #70718 