### PR TITLE
cmake: linker_script: Fix using deferred init with `CMAKE_LINKER_GENERATOR`

### DIFF
--- a/cmake/linker_script/common/common-rom.cmake
+++ b/cmake/linker_script/common/common-rom.cmake
@@ -8,6 +8,9 @@ zephyr_linker_section_obj_level(SECTION init LEVEL POST_KERNEL)
 zephyr_linker_section_obj_level(SECTION init LEVEL APPLICATION)
 zephyr_linker_section_obj_level(SECTION init LEVEL SMP)
 
+zephyr_linker_section(NAME deferred_init_list KVMA RAM_REGION GROUP RODATA_REGION)
+zephyr_linker_section_configure(SECTION deferred_init_list INPUT ".z_deferred_init*" KEEP SORT NAME)
+
 zephyr_iterable_section(NAME device NUMERIC KVMA RAM_REGION GROUP RODATA_REGION SUBALIGN CONFIG_LINKER_ITERABLE_SUBALIGN)
 
 if(CONFIG_GEN_SW_ISR_TABLE AND NOT CONFIG_DYNAMIC_INTERRUPTS)

--- a/tests/kernel/device/testcase.yaml
+++ b/tests/kernel/device/testcase.yaml
@@ -1,28 +1,32 @@
 common:
   tags:
     - device
+    - kernel
     - userspace
-  integration_platforms:
-    - native_sim
 tests:
   kernel.device:
-    tags:
-      - kernel
-      - device
+    integration_platforms:
+      - native_sim
     platform_exclude: xenvm
   kernel.device.minimallibc:
+    integration_platforms:
+      - native_sim
     filter: CONFIG_MINIMAL_LIBC_SUPPORTED
     tags:
-      - kernel
-      - device
       - libc
     extra_configs:
       - CONFIG_MINIMAL_LIBC=y
     platform_exclude: xenvm
   kernel.device.pm:
-    tags:
-      - kernel
-      - device
+    integration_platforms:
+      - native_sim
     platform_exclude: mec15xxevb_assy6853 xenvm
     extra_configs:
       - CONFIG_PM_DEVICE=y
+  kernel.device.linker_generator:
+    platform_allow:
+      - qemu_cortex_m3
+    tags:
+      - linker_generator
+    extra_configs:
+      - CONFIG_CMAKE_LINKER_GENERATOR=y


### PR DESCRIPTION
The section for deferred devices was missing for `CMAKE_LINKER_GENERATOR`.

Issue shown here:
```shell
$ west build -p -b qemu_cortex_m3 tests/kernel/device -- -DCONFIG_CMAKE_LINKER_GENERATOR=y
# ...
/opt/zephyr-sdk-0.16.5-1/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/../../../../arm-zephyr-eabi/bin/ld.bfd: zephyr/kernel/libkernel.a(init.c.obj): in function `z_impl_device_init':
/home/pdgendt/dev/zephyr-main/zephyr/kernel/init.c:388: undefined reference to `__deferred_init_list_start'
/opt/zephyr-sdk-0.16.5-1/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/../../../../arm-zephyr-eabi/bin/ld.bfd: /home/pdgendt/dev/zephyr-main/zephyr/kernel/init.c:388: undefined reference to `__deferred_init_list_end'
```

Regression introduced by #67335