### PR TITLE
arch: x86: avoided increments/decrements with side effects

### DIFF
--- a/arch/x86/zefi/printf.h
+++ b/arch/x86/zefi/printf.h
@@ -45,14 +45,18 @@ static void prdec(struct _pfr *r, long v)
 	char digs[11 * sizeof(long)/4];
 	int i = sizeof(digs) - 1;
 
-	digs[i--] = 0;
+	digs[i] = 0;
+	--i;
 	while (v || i == 9) {
-		digs[i--] = '0' + (v % 10);
+		digs[i] = '0' + (v % 10);
+		--i;
 		v /= 10;
 	}
 
-	while (digs[++i] != '\0') {
+	++i;
+	while (digs[i] != '\0') {
 		pc(r, digs[i]);
+		++i;
 	}
 }
 
@@ -101,8 +105,10 @@ static int vpf(struct _pfr *r, const char *f, va_list ap)
 		case 's': {
 			char *s = va_arg(ap, char *);
 
-			while (*s != '\0')
-				pc(r, *s++);
+			while (*s != '\0') {
+				pc(r, *s);
+				++s;
+			}
 			break;
 		}
 		case 'p':

--- a/arch/x86/zefi/zefi.c
+++ b/arch/x86/zefi/zefi.c
@@ -56,7 +56,8 @@ static void efi_putchar(int c)
 		efi_putchar('\r');
 	}
 
-	efibuf[n++] = c;
+	efibuf[n] = c;
+	++n;
 
 	if (c == '\n' || n == PUTCHAR_BUFSZ) {
 		efibuf[n] = 0U;


### PR DESCRIPTION
Avoided increments/decrements with side effects.
Avoided more than one increment/decrement in for-loop.

This corresponds to following coding guideline:

> A full expression containing an increment (++) or decrement (–) operator should have no other potential side effects other than that caused by the increment or decrement operator

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/671153b94dd5af207423fd8aaf4caf2f6c4d19c3