### PR TITLE
Revert "arch: arm: aarch32: introduce CONFIG_BUILD_ALIGN_LMA"

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -812,15 +812,6 @@ config BUILD_OUTPUT_INFO_HEADER
 	  - VMA address of each segment
 	  - Size of each segment
 
-config BUILD_ALIGN_LMA
-	bool "Align LMA in output image"
-	default y if BUILD_OUTPUT_ADJUST_LMA!=""
-	help
-	  Ensure that the LMA for each section in the output image respects
-	  the alignment requirements of that section. This is required for
-	  some tooling, such as objcopy, to be able to adjust the LMA of the
-	  ELF file.
-
 config APPLICATION_DEFINED_SYSCALL
 	bool "Scan application folder for any syscall definition"
 	help

--- a/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
@@ -217,21 +217,8 @@ SECTIONS
 
 #include <zephyr/linker/cplusplus-rom.ld>
 
-#if defined(CONFIG_BUILD_ALIGN_LMA)
-    /*
-     * Include a padding section here to make sure that the LMA address
-     * of the sections in the RAMABLE_REGION are aligned with those
-     * section's VMA alignment requirements.
-     */
-    SECTION_PROLOGUE(padding_section,,)
-	{
 	__rodata_region_end = .;
 	MPU_ALIGN(__rodata_region_end - ADDR(rom_start));
-	} GROUP_LINK_IN(ROMABLE_REGION)
-#else
-	__rodata_region_end = .;
-	MPU_ALIGN(__rodata_region_end - ADDR(rom_start));
-#endif
 	__rom_region_end = __rom_region_start + . - ADDR(rom_start);
 
     GROUP_END(ROMABLE_REGION)


### PR DESCRIPTION
This reverts commit d8bdddd52f4ced694f5dcb418f7bda9fcd7a7032. This commit was a workaround for an issue with objcopy, where attempting to change the section LMA of an ELF with a different alignment used for the VMA and LMA of that section would fail. A more generic fix has been added to the objcopy utility shipped with Zephyr's sdk-ng with https://github.com/zephyrproject-rtos/sdk-ng/pull/729. Since this fix was mainlined in Zephyr SDK NG 0.16.5, let's revert this unnecessary workaround for the issue.