### PR TITLE
soc: nxp: imxrt11xx: Enable clock for lpi2c6

### DIFF
--- a/soc/nxp/imxrt/imxrt11xx/soc.c
+++ b/soc/nxp/imxrt/imxrt11xx/soc.c
@@ -398,6 +398,11 @@ static ALWAYS_INLINE void clock_init(void)
 	rootCfg.mux = kCLOCK_LPI2C5_ClockRoot_MuxOscRc48MDiv2;
 	rootCfg.div = 1;
 	CLOCK_SetRootClock(kCLOCK_Root_Lpi2c5, &rootCfg);
+
+	/* Configure Lpi2c6 using Osc24M */
+	rootCfg.mux = kCLOCK_LPI2C6_ClockRoot_MuxOsc24MOut;
+	rootCfg.div = 12;
+	CLOCK_SetRootClock(kCLOCK_Root_Lpi2c6, &rootCfg);
 #endif
 
 


### PR DESCRIPTION
Enable clock for lpi2c6 on i.MX RT11XX series. This is needed to control the camera sensor on this i2c port.

This is splitted from https://github.com/zephyrproject-rtos/zephyr/pull/71854 as requested by @danieldegrasse 