### PR TITLE
nordic nrf-timer: Expose max frequency as DT property and use it in nrf counter driver

### DIFF
--- a/drivers/counter/counter_nrfx_timer.c
+++ b/drivers/counter/counter_nrfx_timer.c
@@ -417,6 +417,14 @@ static const struct counter_driver_api counter_nrfx_driver_api = {
 			    irq_handler, DEVICE_DT_INST_GET(idx), 0))		\
 	)
 
+#if !defined(CONFIG_SOC_SERIES_BSIM_NRFXX)
+#define CHECK_MAX_FREQ(idx)									\
+		BUILD_ASSERT(DT_INST_PROP(idx, max_frequency) ==				\
+			NRF_TIMER_BASE_FREQUENCY_GET((NRF_TIMER_Type *)DT_INST_REG_ADDR(idx)))
+#else
+#define CHECK_MAX_FREQ(idx)
+#endif
+
 #define COUNTER_NRFX_TIMER_DEVICE(idx)								\
 	BUILD_ASSERT(DT_INST_PROP(idx, prescaler) <=						\
 			TIMER_PRESCALER_PRESCALER_Msk,						\
@@ -455,6 +463,7 @@ static const struct counter_driver_api counter_nrfx_driver_api = {
 		.timer = (NRF_TIMER_Type *)DT_INST_REG_ADDR(idx),				\
 		LOG_INSTANCE_PTR_INIT(log, LOG_MODULE_NAME, idx)				\
 	};											\
+	CHECK_MAX_FREQ(idx);									\
 	DEVICE_DT_INST_DEFINE(idx,								\
 			    counter_##idx##_init,						\
 			    NULL,								\

--- a/drivers/counter/counter_nrfx_timer.c
+++ b/drivers/counter/counter_nrfx_timer.c
@@ -15,8 +15,6 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME, LOG_LEVEL);
 
 #define DT_DRV_COMPAT nordic_nrf_timer
 
-#define TIMER_CLOCK(timer_instance) NRF_TIMER_BASE_FREQUENCY_GET(timer_instance)
-
 #define CC_TO_ID(cc_num) (cc_num - 2)
 
 #define ID_TO_CC(idx) (nrf_timer_cc_channel_t)(idx + 2)
@@ -448,7 +446,7 @@ static const struct counter_driver_api counter_nrfx_driver_api = {
 	static MAYBE_CONST_CONFIG struct counter_nrfx_config nrfx_counter_##idx##_config = {	\
 		.info = {									\
 			.max_top_value = (uint32_t)BIT64_MASK(DT_INST_PROP(idx, max_bit_width)),\
-			.freq = TIMER_CLOCK((NRF_TIMER_Type *)DT_INST_REG_ADDR(idx)) /		\
+			.freq = DT_INST_PROP(idx, max_frequency) /				\
 				BIT(DT_INST_PROP(idx, prescaler)),				\
 			.flags = COUNTER_CONFIG_INFO_COUNT_UP,					\
 			.channels = CC_TO_ID(DT_INST_PROP(idx, cc_num)),			\

--- a/dts/bindings/timer/nordic,nrf-timer.yaml
+++ b/dts/bindings/timer/nordic,nrf-timer.yaml
@@ -24,10 +24,20 @@ properties:
   interrupts:
     required: true
 
+  max-frequency:
+    type: int
+    default: 16000000
+    description: |
+        Maximum timer frequency in Hz.
+
+        The default value is 16MHz which was the maximum frequency for all nRF TIMER peripherals
+        up to the nRF54 series, and still remains the most typical maximum frequency for nRF54
+        TIMERs.
+
   prescaler:
     type: int
     required: true
-    description: Prescaler value determines frequency (base_frequency/2^prescaler)
+    description: Prescaler value determines frequency (max-frequency/2^prescaler)
 
   zli:
     type: boolean

--- a/dts/common/nordic/nrf54h20.dtsi
+++ b/dts/common/nordic/nrf54h20.dtsi
@@ -217,6 +217,7 @@
 				cc-num = <8>;
 				interrupts = <40 NRF_DEFAULT_IRQ_PRIORITY>;
 				max-bit-width = <32>;
+				max-frequency = <DT_FREQ_M(32)>;
 				prescaler = <0>;
 			};
 
@@ -227,6 +228,7 @@
 				cc-num = <8>;
 				interrupts = <41 NRF_DEFAULT_IRQ_PRIORITY>;
 				max-bit-width = <32>;
+				max-frequency = <DT_FREQ_M(32)>;
 				prescaler = <0>;
 			};
 
@@ -237,6 +239,7 @@
 				cc-num = <8>;
 				interrupts = <42 NRF_DEFAULT_IRQ_PRIORITY>;
 				max-bit-width = <32>;
+				max-frequency = <DT_FREQ_M(32)>;
 				prescaler = <0>;
 			};
 
@@ -356,6 +359,7 @@
 				cc-num = <6>;
 				interrupts = <226 NRF_DEFAULT_IRQ_PRIORITY>;
 				max-bit-width = <32>;
+				max-frequency = <DT_FREQ_M(320)>;
 				prescaler = <0>;
 			};
 
@@ -366,6 +370,7 @@
 				cc-num = <6>;
 				interrupts = <227 NRF_DEFAULT_IRQ_PRIORITY>;
 				max-bit-width = <32>;
+				max-frequency = <DT_FREQ_M(320)>;
 				prescaler = <0>;
 			};
 

--- a/dts/common/nordic/nrf54l15.dtsi
+++ b/dts/common/nordic/nrf54l15.dtsi
@@ -212,6 +212,7 @@
 				cc-num = <6>;
 				max-bit-width = <32>;
 				interrupts = <85 NRF_DEFAULT_IRQ_PRIORITY>;
+				max-frequency = <DT_FREQ_M(128)>;
 				prescaler = <0>;
 			};
 
@@ -228,6 +229,7 @@
 				cc-num = <8>;
 				max-bit-width = <32>;
 				interrupts = <133 NRF_DEFAULT_IRQ_PRIORITY>;
+				max-frequency = <DT_FREQ_M(32)>;
 				prescaler = <0>;
 			};
 


### PR DESCRIPTION
The counter driver needs to know what is the maximum counting frequency of each timer peripheral.
Let's add it to its DT, and let's use it in the driver directly instead of relaying on the HAL working it out.