### PR TITLE
llext: add a multi-file test case

### DIFF
--- a/tests/subsys/llext/simple/CMakeLists.txt
+++ b/tests/subsys/llext/simple/CMakeLists.txt
@@ -35,6 +35,16 @@ foreach(ext_name ${ext_names})
   generate_inc_file_for_target(app ${ext_bin} ${ext_inc})
 endforeach()
 
+if(NOT CONFIG_LLEXT_TYPE_ELF_OBJECT)
+  add_llext_target(multi_file_ext
+    OUTPUT  ${ZEPHYR_BINARY_DIR}/multi_file.llext
+    SOURCES ${PROJECT_SOURCE_DIR}/src/multi_file_ext1.c ${PROJECT_SOURCE_DIR}/src/multi_file_ext2.c
+  )
+  generate_inc_file_for_target(app ${ZEPHYR_BINARY_DIR}/multi_file.llext
+    ${ZEPHYR_BINARY_DIR}/include/generated/multi_file.inc
+  )
+endif()
+
 # Add a dummy custom processing command to test add_llext_command
 get_target_property(proc_in_file hello_world_ext lib_output)
 get_target_property(proc_out_file hello_world_ext pkg_input)

--- a/tests/subsys/llext/simple/src/multi_file_ext1.c
+++ b/tests/subsys/llext/simple/src/multi_file_ext1.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * This code demonstrates multi-file object and function linking support.
+ */
+
+#include <stdint.h>
+#include <zephyr/llext/symbol.h>
+#include <zephyr/kernel.h>
+
+/* Test non-static global object relocation */
+int number = 0x42;
+extern int ext_number;
+int ext_sum_fn(int arg);
+
+void test_entry(void)
+{
+	printk("initial: local %d plus external %d equals %d\n",
+	       number, ext_number, ext_sum_fn(ext_number));
+	number ^= ext_number;
+	ext_number ^= number;
+	number ^= ext_number;
+	printk("updated: local %d plus external %d equals %d\n",
+	       number, ext_number, ext_sum_fn(ext_number));
+}
+LL_EXTENSION_SYMBOL(test_entry);

--- a/tests/subsys/llext/simple/src/multi_file_ext2.c
+++ b/tests/subsys/llext/simple/src/multi_file_ext2.c
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* File 2 of the multi-file linking test */
+
+extern int number;
+int ext_number = 0x18;
+
+int ext_sum_fn(int arg)
+{
+	return arg + number;
+}

--- a/tests/subsys/llext/simple/src/test_llext_simple.c
+++ b/tests/subsys/llext/simple/src/test_llext_simple.c
@@ -230,6 +230,13 @@ static LLEXT_CONST uint8_t threads_kernel_objects_ext[] __aligned(4) = {
 LLEXT_LOAD_UNLOAD(threads_kernel_objects, true, threads_objects_perm_setup)
 #endif
 
+#ifndef CONFIG_LLEXT_TYPE_ELF_OBJECT
+static LLEXT_CONST uint8_t multi_file_ext[] __aligned(4) = {
+	#include "multi_file.inc"
+};
+LLEXT_LOAD_UNLOAD(multi_file, true, NULL)
+#endif
+
 
 /*
  * Ensure that EXPORT_SYMBOL does indeed provide a symbol and a valid address


### PR DESCRIPTION
Add a case, testing building an llext from multiple files, calling functions and accessing data across files.