### PR TITLE
boards: croxel_cx1825: disable CDC-ACM logging by default

### DIFF
--- a/boards/croxel/croxel_cx1825/Kconfig.defconfig
+++ b/boards/croxel/croxel_cx1825/Kconfig.defconfig
@@ -6,4 +6,13 @@ if BOARD_CROXEL_CX1825
 config BT_CTLR
 	default BT
 
+if LOG
+
+# Logger cannot use itself to log
+choice USB_CDC_ACM_LOG_LEVEL_CHOICE
+	default USB_CDC_ACM_LOG_LEVEL_OFF
+endchoice
+
+endif # LOG
+
 endif # BOARD_CROXEL_CX1825


### PR DESCRIPTION
Disable this explicitly as done for other boards using a USB console by default, prevents a build warning: