### PR TITLE
Add USB support for MCX N947

### DIFF
--- a/boards/nxp/frdm_mcxn947/board.c
+++ b/boards/nxp/frdm_mcxn947/board.c
@@ -8,6 +8,15 @@
 #include <fsl_clock.h>
 #include <fsl_spc.h>
 #include <soc.h>
+#if CONFIG_USB_DC_NXP_EHCI
+#include "usb_phy.h"
+#include "usb.h"
+
+/* USB PHY condfiguration */
+#define BOARD_USB_PHY_D_CAL     (0x04U)
+#define BOARD_USB_PHY_TXCAL45DP (0x07U)
+#define BOARD_USB_PHY_TXCAL45DM (0x07U)
+#endif
 
 /* Board xtal frequency in Hz */
 #define BOARD_XTAL0_CLK_HZ                        24000000U
@@ -94,6 +103,8 @@ static int frdm_mcxn947_init(void)
 
 	/* Set AHBCLKDIV divider to value 1 */
 	CLOCK_SetClkDiv(kCLOCK_DivAhbClk, 1U);
+
+	CLOCK_SetupExtClocking(BOARD_XTAL0_CLK_HZ);
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(flexcomm1), okay)
 	CLOCK_SetClkDiv(kCLOCK_DivFlexcom1Clk, 1u);
@@ -213,6 +224,48 @@ static int frdm_mcxn947_init(void)
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(lpadc0), okay)
 	CLOCK_SetClkDiv(kCLOCK_DivAdc0Clk, 1U);
 	CLOCK_AttachClk(kFRO_HF_to_ADC0);
+#endif
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(usb1), okay) && CONFIG_USB_DC_NXP_EHCI
+	usb_phy_config_struct_t usbPhyConfig = {
+		BOARD_USB_PHY_D_CAL, BOARD_USB_PHY_TXCAL45DP, BOARD_USB_PHY_TXCAL45DM,
+	};
+
+	SPC0->ACTIVE_VDELAY = 0x0500;
+	/* Change the power DCDC to 1.8v (By default, DCDC is 1.8V), CORELDO to 1.1v (By default,
+	 * CORELDO is 1.0V)
+	 */
+	SPC0->ACTIVE_CFG &= ~SPC_ACTIVE_CFG_CORELDO_VDD_DS_MASK;
+	SPC0->ACTIVE_CFG |= SPC_ACTIVE_CFG_DCDC_VDD_LVL(0x3) | SPC_ACTIVE_CFG_CORELDO_VDD_LVL(0x3) |
+			    SPC_ACTIVE_CFG_SYSLDO_VDD_DS_MASK | SPC_ACTIVE_CFG_DCDC_VDD_DS(0x2u);
+	/* Wait until it is done */
+	while (SPC0->SC & SPC_SC_BUSY_MASK) {
+	};
+	if (0u == (SCG0->LDOCSR & SCG_LDOCSR_LDOEN_MASK)) {
+		SCG0->TRIM_LOCK = 0x5a5a0001U;
+		SCG0->LDOCSR |= SCG_LDOCSR_LDOEN_MASK;
+		/* wait LDO ready */
+		while (0U == (SCG0->LDOCSR & SCG_LDOCSR_VOUT_OK_MASK)) {
+		};
+	}
+	SYSCON->AHBCLKCTRLSET[2] |= SYSCON_AHBCLKCTRL2_USB_HS_MASK |
+				    SYSCON_AHBCLKCTRL2_USB_HS_PHY_MASK;
+	SCG0->SOSCCFG &= ~(SCG_SOSCCFG_RANGE_MASK | SCG_SOSCCFG_EREFS_MASK);
+	/* xtal = 20 ~ 30MHz */
+	SCG0->SOSCCFG = (1U << SCG_SOSCCFG_RANGE_SHIFT) | (1U << SCG_SOSCCFG_EREFS_SHIFT);
+	SCG0->SOSCCSR |= SCG_SOSCCSR_SOSCEN_MASK;
+	while (1) {
+		if (SCG0->SOSCCSR & SCG_SOSCCSR_SOSCVLD_MASK) {
+			break;
+		}
+	}
+	SYSCON->CLOCK_CTRL |= SYSCON_CLOCK_CTRL_CLKIN_ENA_MASK |
+			      SYSCON_CLOCK_CTRL_CLKIN_ENA_FM_USBH_LPT_MASK;
+	CLOCK_EnableClock(kCLOCK_UsbHs);
+	CLOCK_EnableClock(kCLOCK_UsbHsPhy);
+	CLOCK_EnableUsbhsPhyPllClock(kCLOCK_Usbphy480M, BOARD_XTAL0_CLK_HZ);
+	CLOCK_EnableUsbhsClock();
+	USB_EhciPhyInit(kUSB_ControllerEhci0, BOARD_XTAL0_CLK_HZ, &usbPhyConfig);
 #endif
 
 	/* Set SystemCoreClock variable. */

--- a/boards/nxp/frdm_mcxn947/doc/index.rst
+++ b/boards/nxp/frdm_mcxn947/doc/index.rst
@@ -88,6 +88,8 @@ The FRDM-MCXN947 board configuration supports the following hardware features:
 +-----------+------------+-------------------------------------+
 | ADC       | on-chip    | adc                                 |
 +-----------+------------+-------------------------------------+
+| USBHS     | on-chip    | USB device                          |
++-----------+------------+-------------------------------------+
 
 Targets available
 ==================

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.dts
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.dts
@@ -161,3 +161,7 @@
 &lpadc0 {
 	status = "okay";
 };
+
+zephyr_udc0: &usb1 {
+	status = "okay";
+};

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.yaml
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.yaml
@@ -26,4 +26,5 @@ supported:
   - sdhc
   - regulator
   - adc
+  - usb_device
 vendor: nxp

--- a/drivers/usb/device/usb_dc_mcux.c
+++ b/drivers/usb/device/usb_dc_mcux.c
@@ -89,7 +89,9 @@ BUILD_ASSERT(NUM_INSTS <= 1, "Only one USB device supported");
 #elif DT_NODE_HAS_STATUS(DT_NODELABEL(usbfs), okay)
 #define CONTROLLER_ID	kUSB_ControllerLpcIp3511Fs0
 #endif /* LPC55s69 */
-#elif defined(CONFIG_SOC_SERIES_IMXRT11XX) || defined(CONFIG_SOC_SERIES_IMXRT10XX)
+#elif defined(CONFIG_SOC_SERIES_IMXRT11XX) || \
+	defined(CONFIG_SOC_SERIES_IMXRT10XX) || \
+	defined(CONFIG_SOC_SERIES_MCXNX4X)
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(usb1), okay)
 #define CONTROLLER_ID kUSB_ControllerEhci0
 #elif DT_NODE_HAS_STATUS(DT_NODELABEL(usb2), okay)

--- a/dts/arm/nxp/nxp_mcxn94x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn94x_common.dtsi
@@ -840,6 +840,15 @@
 		#io-channel-cells = <1>;
 		clocks = <&syscon MCUX_LPADC2_CLK>;
 	};
+
+	usb1: usbd@10b000 {
+		compatible = "nxp,ehci";
+		reg = <0x10b000 0x1000>;
+		interrupts = <67 0>;
+		interrupt-names = "usb_otg";
+		num-bidir-endpoints = <8>;
+		status = "disabled";
+	};
 };
 
 &systick {

--- a/soc/nxp/mcx/Kconfig
+++ b/soc/nxp/mcx/Kconfig
@@ -39,4 +39,8 @@ config MFD
 	default y
 	depends on DT_HAS_NXP_LP_FLEXCOMM_ENABLED
 
+choice USB_MCUX_CONTROLLER_TYPE
+	default USB_DC_NXP_EHCI
+endchoice
+
 endif # SOC_FAMILY_NXP_MCX


### PR DESCRIPTION
This uses the old USB framework. We would need to transition to USB Next once the USB driver is merged.