### PR TITLE
boards: nxp: rt1064: remove display definition, use RK043* Rocktech panel shields

### DIFF
--- a/boards/nxp/mimxrt1064_evk/Kconfig.defconfig
+++ b/boards/nxp/mimxrt1064_evk/Kconfig.defconfig
@@ -11,16 +11,6 @@ config DEVICE_CONFIGURATION_DATA
 config NXP_IMX_EXTERNAL_SDRAM
 	default y
 
-config INPUT
-	default y if LVGL
-
-if INPUT
-
-config INPUT_FT5336_INTERRUPT
-	default y
-
-endif # INPUT
-
 if NETWORKING
 
 config NET_L2_ETHERNET
@@ -34,19 +24,5 @@ config ETH_MCUX_PHY_RESET
 endif # ETH_MCUX
 
 endif # NETWORKING
-
-if LVGL
-
-config LV_Z_VDB_SIZE
-	default 16
-
-config LV_DPI_DEF
-	default 128
-
-choice LV_COLOR_DEPTH
-	default LV_COLOR_DEPTH_16
-endchoice
-
-endif # LVGL
 
 endif # BOARD_MIMXRT1064_EVK

--- a/boards/nxp/mimxrt1064_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1064_evk/doc/index.rst
@@ -111,7 +111,9 @@ configuration supports the following hardware features:
 +-----------+------------+-------------------------------------+
 | SYSTICK   | on-chip    | systick                             |
 +-----------+------------+-------------------------------------+
-| DISPLAY   | on-chip    | display                             |
+| DISPLAY   | on-chip    | eLCDIF. Tested with                 |
+|           |            | :ref:`rk043fn02h_ct`, and           |
+|           |            | :ref:`rk043fn66hs_ctg` shields      |
 +-----------+------------+-------------------------------------+
 | VIDEO     | on-chip    | video, using CSI                    |
 +-----------+------------+-------------------------------------+

--- a/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -8,7 +8,6 @@
 
 #include <nxp/nxp_rt1064.dtsi>
 #include "mimxrt1064_evk-pinctrl.dtsi"
-#include <zephyr/dt-bindings/display/panel.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -40,6 +39,33 @@
 		/* Micron MT48LC16M16A2B4-6AIT:G */
 		device_type = "memory";
 		reg = <0x80000000 DT_SIZE_M(32)>;
+	};
+
+	/*
+	 * This node describes the GPIO pins of the parallel FPC interface,
+	 * This interface is standard to several NXP EVKs, and is used with
+	 * several parallel LCD displays (available as zephyr shields)
+	 */
+	nxp_parallel_lcd_connector: parallel-connector {
+		compatible = "nxp,parallel-lcd-connector";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map =	<0  0 &gpio2 31 0>;	/* Pin 1, BL+ */
+	};
+
+	/*
+	 * This node describes the GPIO pins of the I2C display FPC interface,
+	 * This interface is standard to several NXP EVKs, and is used with
+	 * several parallel LCD displays (available as zephyr shields)
+	 */
+	nxp_i2c_touch_fpc: i2c-touch-connector {
+		compatible = "nxp,i2c-tsc-fpc";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map =	<1  0 &gpio1 2 0>,	/* Pin 2, LCD touch RST */
+				<2  0 &gpio1 11 0>;	/* Pin 3, LCD touch INT */
 	};
 
 	leds {
@@ -100,48 +126,16 @@
 			   <20 0 &gpio1 17 0>,	/* D14 */
 			   <21 0 &gpio1 16 0>;	/* D15 */
 	};
-
-	panel {
-		compatible = "rocktech,rk043fn02h-ct";
-		port {
-			lcd_panel_in: endpoint {
-				remote-endpoint = <&lcd_panel_out>;
-			};
-		};
-	};
 };
 
-arduino_i2c: &lpi2c1 {};
+nxp_touch_i2c: &lpi2c1 {};
 
-&lcdif {
-	status = "okay";
-	width = <480>;
-	height = <272>;
-	display-timings {
-		compatible = "zephyr,panel-timing";
-		hsync-len = <41>;
-		hfront-porch = <4>;
-		hback-porch = <8>;
-		vsync-len = <10>;
-		vfront-porch = <4>;
-		vback-porch = <2>;
-		de-active= <1>;
-		pixelclk-active = <1>;
-		hsync-active = <0>;
-		vsync-active = <0>;
-		clock-frequency = <9210240>;
-	};
-	pixel-format = <PANEL_PIXEL_FORMAT_BGR_565>;
-	data-bus-width = "16-bit";
+zephyr_lcdif: &lcdif {
 	pinctrl-0 = <&pinmux_lcdif>;
 	pinctrl-names = "default";
-	backlight-gpios = <&gpio2 31 GPIO_ACTIVE_HIGH>;
-	port {
-		lcd_panel_out: endpoint {
-			remote-endpoint = <&lcd_panel_in>;
-		};
-	};
 };
+
+nxp_parallel_i2c: &lpi2c1 {};
 
 &lpi2c1 {
 	status = "okay";

--- a/samples/drivers/display/sample.yaml
+++ b/samples/drivers/display/sample.yaml
@@ -171,6 +171,7 @@ tests:
       fixture: fixture_display
   sample.display.rk043fn66hs_ctg:
     platform_allow:
+      - mimxrt1064_evk
       - mimxrt1060_evk
       - mimxrt1050_evk
     tags: display
@@ -180,6 +181,7 @@ tests:
       fixture: fixture_display
   sample.display.rk043fn02h_ct:
     platform_allow:
+      - mimxrt1064_evk
       - mimxrt1060_evk
       - mimxrt1050_evk
     tags: display

--- a/samples/subsys/display/lvgl/sample.yaml
+++ b/samples/subsys/display/lvgl/sample.yaml
@@ -72,6 +72,7 @@ tests:
       - gui
   samples.subsys.display.lvgl.rk043fn66hs_ctg:
     platform_allow:
+      - mimxrt1064_evk
       - mimxrt1060_evk
       - mimxrt1050_evk
     tags: display
@@ -81,6 +82,7 @@ tests:
       fixture: fixture_display
   samples.subsys.display.lvgl.rk043fn02h_ct:
     platform_allow:
+      - mimxrt1064_evk
       - mimxrt1060_evk
       - mimxrt1050_evk
     tags: display


### PR DESCRIPTION
Remove display definition from RT1064 EVK board, and use RK043* display shields as these shields support the FPC connector present on the EVK. Add RT1064 to testcases for these shields.

~Depends on https://github.com/zephyrproject-rtos/zephyr/pull/72174~