### PR TITLE
linker: lld: cortex_m: Place .ARM.exidx sections when using lld

### DIFF
--- a/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
@@ -178,7 +178,7 @@ SECTIONS
 	 * section overlap.
 	 */
 	__exidx_start = .;
-#if defined (__GCC_LINKER_CMD__)
+#if defined (__GCC_LINKER_CMD__) || defined (__LLD_LINKER_CMD__)
 	*(.ARM.exidx* gnu.linkonce.armexidx.*)
 #endif
 	__exidx_end = .;


### PR DESCRIPTION
Currently, .ARM.exidx input sections are only handled when building with ld. When building with lld (and depending on the orphan section handling policy configured), a few issues can arise:

  1. lld may produce warnings about the orphan section
  2. lld may place the input .ARM.exidx sections in unexpected ways--it seems lld does place the .ARM.exidx input sections in the expected .ARM.exidx output section, but it places them at the end of the section (after '__exidx_end').

To resolve the possible warning and unexpected placement, explicitly handle .ARM.exidx sections when lld is used.