### PR TITLE
kernel: banner: Allow for external boot banner

### DIFF
--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -116,6 +116,11 @@ Build system and Infrastructure
     choice to select the C Standard version. Additionally subsystems can select a minimum
     required C Standard version, with for example :kconfig:option:`CONFIG_REQUIRES_STD_C11`.
 
+  * Added external boot banner feature which allows for applications/modules to have a custom boot
+    banner implementation which can be enabled with
+    :kconfig:option:`CONFIG_BOOT_BANNER_EXTERNAL_IMPLEMENTATION` with function
+    :c:func:`boot_banner`.
+
 Drivers and Sensors
 *******************
 

--- a/include/zephyr/kernel/banner.h
+++ b/include/zephyr/kernel/banner.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020 Intel Corporation
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_KERNEL_BANNER_H
+#define ZEPHYR_INCLUDE_KERNEL_BANNER_H
+
+/**
+ * @brief Boot banner API
+ * @ingroup kernel_apis
+ * @defgroup boot_banner_api Boot banner API
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Output boot banner
+ *
+ * Output boot banner at device boot-up. This should output the boot banner using e.g. `printk`
+ * calls, if @kconfig{CONFIG_BOOT_BANNER_EXTERNAL_IMPLEMENTATION} is enabled then this function
+ * should be implemented in application/module code.
+ */
+void boot_banner(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_KERNEL_BANNER_H */

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -49,7 +49,6 @@ add_compile_options($<TARGET_PROPERTY:compiler,warning_shadow_variables>)
 
 list(APPEND kernel_files
   main_weak.c
-  banner.c
   busy_wait.c
   device.c
   errno.c
@@ -60,6 +59,12 @@ list(APPEND kernel_files
   float.c
   version.c
   )
+
+if(CONFIG_BOOT_BANNER AND NOT CONFIG_BOOT_BANNER_EXTERNAL_IMPLEMENTATION)
+list(APPEND kernel_files
+  banner.c
+  )
+endif()
 
 if(CONFIG_SCHED_CPU_MASK)
 list(APPEND kernel_files

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -446,9 +446,18 @@ config BOOT_BANNER
 	help
 	  This option outputs a banner to the console device during boot up.
 
+config BOOT_BANNER_EXTERNAL_IMPLEMENTATION
+	bool
+	depends on BOOT_BANNER
+	help
+	  Use an external boot banner implementation, this allows external applications/modules
+	  to implement their own boot banner, see `include/zephyr/kernel/banner.h` for function
+	  definition.
+
 config BOOT_BANNER_STRING
 	string "Boot banner string"
 	depends on BOOT_BANNER
+	depends on !BOOT_BANNER_EXTERNAL_IMPLEMENTATION
 	default "Booting Zephyr OS build"
 	help
 	  Use this option to set the boot banner.

--- a/kernel/banner.c
+++ b/kernel/banner.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
+#include <zephyr/kernel/banner.h>
 #include <zephyr/init.h>
 #include <zephyr/device.h>
 #include <version.h>

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -13,6 +13,7 @@
 
 #include <offsets_short.h>
 #include <zephyr/kernel.h>
+#include <zephyr/kernel/banner.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/debug/stack.h>
 #include <zephyr/random/random.h>
@@ -397,9 +398,6 @@ static inline int z_vrfy_device_init(const struct device *dev)
 #include <syscalls/device_init_mrsh.c>
 #endif
 
-extern void boot_banner(void);
-
-
 /**
  * @brief Mainline for kernel's background thread
  *
@@ -427,7 +425,10 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 #if defined(CONFIG_STACK_POINTER_RANDOM) && (CONFIG_STACK_POINTER_RANDOM != 0)
 	z_stack_adjust_initialized = 1;
 #endif /* CONFIG_STACK_POINTER_RANDOM */
+
+#if defined(CONFIG_BOOT_BANNER)
 	boot_banner();
+#endif /* CONFIG_BOOT_BANNER */
 
 #if defined(CONFIG_CPP)
 	void z_cpp_init_static(void);

--- a/west.yml
+++ b/west.yml
@@ -23,6 +23,8 @@ manifest:
       url-base: https://github.com/zephyrproject-rtos
     - name: babblesim
       url-base: https://github.com/BabbleSim
+    - name: nordicjm
+      url-base: https://github.com/nordicjm
 
   group-filter: [-babblesim, -optional]
 
@@ -282,7 +284,8 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: d4394c2f9b76e0a7b758441cea3a8ceb896f66c8
+      revision: 3240371dd0db9eaad942fc8af89f65561dfb346f
+      remote: nordicjm
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
    Adds a new Kconfig CONFIG_BOOT_BANNER_EXTERNAL_IMPLEMENTATION which
    allows for applications/modules to implement their own boot banner

Also includes fix for MCUboot

### Background:

MCUboot has had a custom boot banner added which replaces the zephyr one to include information on the MCUboot build, with a normal zephyr build this works fine due to the linker dropping the original function and using the one that MCUboot has, but with llext enabled in the build, the build fails because the function is defined multiple times. This resolves the issue by making the zephyr one weak which allows for applications to replace it with an alternative implementation

- [x] Release notes addition