### PR TITLE
net: zperf: Add periodic reporting for upload

### DIFF
--- a/include/zephyr/net/zperf.h
+++ b/include/zephyr/net/zperf.h
@@ -26,6 +26,7 @@ extern "C" {
 
 enum zperf_status {
 	ZPERF_SESSION_STARTED,
+	ZPERF_SESSION_PERIODIC_RESULT,
 	ZPERF_SESSION_FINISHED,
 	ZPERF_SESSION_ERROR
 } __packed;
@@ -40,6 +41,7 @@ struct zperf_upload_params {
 		uint8_t tos;
 		int tcp_nodelay;
 		int priority;
+		uint32_t report_interval_ms;
 	} options;
 };
 

--- a/subsys/net/lib/zperf/zperf_common.c
+++ b/subsys/net/lib/zperf/zperf_common.c
@@ -110,7 +110,7 @@ int zperf_get_ipv4_addr(char *host, struct in_addr *addr)
 }
 
 int zperf_prepare_upload_sock(const struct sockaddr *peer_addr, uint8_t tos,
-			      int priority, int proto)
+			      int priority, int tcp_nodelay, int proto)
 {
 	socklen_t addrlen = peer_addr->sa_family == AF_INET6 ?
 			    sizeof(struct sockaddr_in6) :
@@ -187,6 +187,14 @@ int zperf_prepare_upload_sock(const struct sockaddr *peer_addr, uint8_t tos,
 			NET_WARN("Failed to set SOL_SOCKET - SO_PRIORITY socket option.");
 			return -EINVAL;
 		}
+	}
+
+	if (proto == IPPROTO_TCP && tcp_nodelay &&
+	    zsock_setsockopt(sock, IPPROTO_TCP, TCP_NODELAY,
+			     &tcp_nodelay,
+			     sizeof(tcp_nodelay)) != 0) {
+		NET_WARN("Failed to set IPPROTO_TCP - TCP_NODELAY socket option.");
+		return -EINVAL;
 	}
 
 	ret = zsock_connect(sock, peer_addr, addrlen);

--- a/subsys/net/lib/zperf/zperf_internal.h
+++ b/subsys/net/lib/zperf/zperf_internal.h
@@ -104,7 +104,7 @@ struct sockaddr_in *zperf_get_sin(void);
 extern void connect_ap(char *ssid);
 
 int zperf_prepare_upload_sock(const struct sockaddr *peer_addr, uint8_t tos,
-			      int priority, int proto);
+			      int priority, int tcp_nodelay, int proto);
 
 uint32_t zperf_packet_duration(uint32_t packet_size, uint32_t rate_in_kbps);
 

--- a/subsys/net/lib/zperf/zperf_shell.c
+++ b/subsys/net/lib/zperf/zperf_shell.c
@@ -361,6 +361,9 @@ static void udp_session_cb(enum zperf_status status,
 	case ZPERF_SESSION_ERROR:
 		shell_fprintf(sh, SHELL_ERROR, "UDP session error.\n");
 		break;
+
+	default:
+		break;
 	}
 }
 
@@ -476,7 +479,7 @@ static void shell_udp_upload_print_stats(const struct shell *sh,
 					 struct zperf_results *results)
 {
 	if (IS_ENABLED(CONFIG_NET_UDP)) {
-		unsigned int rate_in_kbps, client_rate_in_kbps;
+		uint64_t rate_in_kbps, client_rate_in_kbps;
 
 		shell_fprintf(sh, SHELL_NORMAL, "-\nUpload completed!\n");
 
@@ -540,7 +543,7 @@ static void shell_tcp_upload_print_stats(const struct shell *sh,
 					 struct zperf_results *results)
 {
 	if (IS_ENABLED(CONFIG_NET_TCP)) {
-		unsigned int client_rate_in_kbps;
+		uint64_t client_rate_in_kbps;
 
 		shell_fprintf(sh, SHELL_NORMAL, "-\nUpload completed!\n");
 
@@ -569,6 +572,37 @@ static void shell_tcp_upload_print_stats(const struct shell *sh,
 	}
 }
 
+static void shell_tcp_upload_print_periodic(const struct shell *sh,
+					    struct zperf_results *results)
+{
+	if (IS_ENABLED(CONFIG_NET_TCP)) {
+		uint64_t client_rate_in_kbps;
+
+		if (results->client_time_in_us != 0U) {
+			client_rate_in_kbps = (uint32_t)
+				(((uint64_t)results->nb_packets_sent *
+				  (uint64_t)results->packet_size * (uint64_t)8 *
+				  (uint64_t)USEC_PER_SEC) /
+				 (results->client_time_in_us * 1000U));
+		} else {
+			client_rate_in_kbps = 0U;
+		}
+
+		shell_fprintf(sh, SHELL_NORMAL, "Duration: ");
+		print_number_64(sh, results->client_time_in_us,
+			     TIME_US, TIME_US_UNIT);
+		shell_fprintf(sh, SHELL_NORMAL, " | ");
+		shell_fprintf(sh, SHELL_NORMAL, "Packets: %6u | ",
+			      results->nb_packets_sent);
+		shell_fprintf(sh, SHELL_NORMAL,
+			      "Errors: %6u | ",
+			      results->nb_packets_errors);
+		shell_fprintf(sh, SHELL_NORMAL, "Rate: ");
+		print_number(sh, client_rate_in_kbps, KBPS, KBPS_UNIT);
+		shell_fprintf(sh, SHELL_NORMAL, "\n");
+	}
+}
+
 static void udp_upload_cb(enum zperf_status status,
 			  struct zperf_results *result,
 			  void *user_data)
@@ -587,6 +621,9 @@ static void udp_upload_cb(enum zperf_status status,
 	case ZPERF_SESSION_ERROR:
 		shell_fprintf(sh, SHELL_ERROR, "UDP upload failed\n");
 		break;
+
+	default:
+		break;
 	}
 }
 
@@ -598,6 +635,10 @@ static void tcp_upload_cb(enum zperf_status status,
 
 	switch (status) {
 	case ZPERF_SESSION_STARTED:
+		break;
+
+	case ZPERF_SESSION_PERIODIC_RESULT:
+		shell_tcp_upload_print_periodic(sh, result);
 		break;
 
 	case ZPERF_SESSION_FINISHED: {
@@ -866,6 +907,24 @@ static int shell_cmd_upload(const struct shell *sh, size_t argc,
 			opt_cnt += 2;
 			break;
 
+		case 'i':
+			int seconds = parse_arg(&i, argc, argv);
+
+			if (is_udp) {
+				shell_fprintf(sh, SHELL_WARNING,
+					      "UDP does not support -i option\n");
+				return -ENOEXEC;
+			}
+			if (seconds < 0 || seconds > UINT16_MAX) {
+				shell_fprintf(sh, SHELL_WARNING,
+					      "Parse error: %s\n", argv[i]);
+				return -ENOEXEC;
+			}
+
+			param.options.report_interval_ms = seconds * MSEC_PER_SEC;
+			opt_cnt += 2;
+			break;
+
 		default:
 			shell_fprintf(sh, SHELL_WARNING,
 				      "Unrecognized argument: %s\n", argv[i]);
@@ -1081,6 +1140,24 @@ static int shell_cmd_upload2(const struct shell *sh, size_t argc,
 			opt_cnt += 2;
 			break;
 
+		case 'i':
+			int seconds = parse_arg(&i, argc, argv);
+
+			if (is_udp) {
+				shell_fprintf(sh, SHELL_WARNING,
+					      "UDP does not support -i option\n");
+				return -ENOEXEC;
+			}
+			if (seconds < 0 || seconds > UINT16_MAX) {
+				shell_fprintf(sh, SHELL_WARNING,
+					      "Parse error: %s\n", argv[i]);
+				return -ENOEXEC;
+			}
+
+			param.options.report_interval_ms = seconds * MSEC_PER_SEC;
+			opt_cnt += 2;
+			break;
+
 		default:
 			shell_fprintf(sh, SHELL_WARNING,
 				      "Unrecognized argument: %s\n", argv[i]);
@@ -1250,6 +1327,9 @@ static void tcp_session_cb(enum zperf_status status,
 	case ZPERF_SESSION_ERROR:
 		shell_fprintf(sh, SHELL_ERROR, "TCP session error.\n");
 		break;
+
+	default:
+		break;
 	}
 }
 
@@ -1390,6 +1470,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(zperf_cmd_tcp,
 		  "Available options:\n"
 		  "-S tos: Specify IPv4/6 type of service\n"
 		  "-a: Asynchronous call (shell will not block for the upload)\n"
+		  "-i sec: Periodic reporting interval in seconds (async only)\n"
 		  "-n: Disable Nagle's algorithm\n"
 #ifdef CONFIG_NET_CONTEXT_PRIORITY
 		  "-p: Specify custom packet priority\n"
@@ -1409,12 +1490,13 @@ SHELL_STATIC_SUBCMD_SET_CREATE(zperf_cmd_tcp,
 		  "Available options:\n"
 		  "-S tos: Specify IPv4/6 type of service\n"
 		  "-a: Asynchronous call (shell will not block for the upload)\n"
+		  "-i sec: Periodic reporting interval in seconds (async only)\n"
+		  "-n: Disable Nagle's algorithm\n"
 #ifdef CONFIG_NET_CONTEXT_PRIORITY
 		  "-p: Specify custom packet priority\n"
 #endif /* CONFIG_NET_CONTEXT_PRIORITY */
 		  "Example: tcp upload2 v6 1 1K\n"
 		  "Example: tcp upload2 v4\n"
-		  "-n: Disable Nagle's algorithm\n"
 #if defined(CONFIG_NET_IPV6) && defined(MY_IP6ADDR_SET)
 		  "Default IPv6 address is " MY_IP6ADDR
 		  ", destination [" DST_IP6ADDR "]:" DEF_PORT_STR "\n"

--- a/subsys/net/lib/zperf/zperf_tcp_uploader.c
+++ b/subsys/net/lib/zperf/zperf_tcp_uploader.c
@@ -133,17 +133,10 @@ int zperf_tcp_upload(const struct zperf_upload_params *param,
 	}
 
 	sock = zperf_prepare_upload_sock(&param->peer_addr, param->options.tos,
-					 param->options.priority, IPPROTO_TCP);
+					 param->options.priority, param->options.tcp_nodelay,
+					 IPPROTO_TCP);
 	if (sock < 0) {
 		return sock;
-	}
-
-	if (param->options.tcp_nodelay &&
-	    zsock_setsockopt(sock, IPPROTO_TCP, TCP_NODELAY,
-			     &param->options.tcp_nodelay,
-			     sizeof(param->options.tcp_nodelay)) != 0) {
-		NET_WARN("Failed to set IPPROTO_TCP - TCP_NODELAY socket option.");
-		return -EINVAL;
 	}
 
 	ret = tcp_upload(sock, param->duration_ms, param->packet_size, result);

--- a/subsys/net/lib/zperf/zperf_tcp_uploader.c
+++ b/subsys/net/lib/zperf/zperf_tcp_uploader.c
@@ -150,20 +150,72 @@ static void tcp_upload_async_work(struct k_work *work)
 {
 	struct zperf_async_upload_context *upload_ctx =
 		CONTAINER_OF(work, struct zperf_async_upload_context, work);
-	struct zperf_results result;
+	struct zperf_results result = { 0 };
 	int ret;
+	struct zperf_upload_params param = upload_ctx->param;
+	int sock;
 
 	upload_ctx->callback(ZPERF_SESSION_STARTED, NULL,
 			     upload_ctx->user_data);
 
-	ret = zperf_tcp_upload(&upload_ctx->param, &result);
-	if (ret < 0) {
+	sock = zperf_prepare_upload_sock(&param.peer_addr, param.options.tos,
+					 param.options.priority, param.options.tcp_nodelay,
+					 IPPROTO_TCP);
+
+	if (sock < 0) {
 		upload_ctx->callback(ZPERF_SESSION_ERROR, NULL,
 				     upload_ctx->user_data);
-	} else {
-		upload_ctx->callback(ZPERF_SESSION_FINISHED, &result,
-				     upload_ctx->user_data);
+		return;
 	}
+
+	if (param.options.report_interval_ms > 0) {
+		uint32_t report_interval = param.options.report_interval_ms;
+		uint32_t duration = param.duration_ms;
+
+		/* Compute how many upload rounds will be executed and the duration
+		 * of the last round when total duration isn't divisible by interval
+		 */
+		uint32_t rounds = (duration + report_interval - 1) / report_interval;
+		uint32_t last_round_duration = duration - ((rounds - 1) * report_interval);
+
+		struct zperf_results periodic_result;
+
+		for (; rounds > 0; rounds--) {
+			uint32_t round_duration;
+
+			if (rounds == 1) {
+				round_duration = last_round_duration;
+			} else {
+				round_duration = report_interval;
+			}
+			ret = tcp_upload(sock, round_duration, param.packet_size, &periodic_result);
+			if (ret < 0) {
+				upload_ctx->callback(ZPERF_SESSION_ERROR, NULL,
+						     upload_ctx->user_data);
+				return;
+			}
+			upload_ctx->callback(ZPERF_SESSION_PERIODIC_RESULT, &periodic_result,
+					     upload_ctx->user_data);
+
+			result.nb_packets_sent += periodic_result.nb_packets_sent;
+			result.client_time_in_us += periodic_result.client_time_in_us;
+			result.nb_packets_errors += periodic_result.nb_packets_errors;
+		}
+
+		result.packet_size = periodic_result.packet_size;
+
+	} else {
+		ret = tcp_upload(sock, param.duration_ms, param.packet_size, &result);
+		if (ret < 0) {
+			upload_ctx->callback(ZPERF_SESSION_ERROR, NULL,
+					     upload_ctx->user_data);
+			return;
+		}
+	}
+
+	upload_ctx->callback(ZPERF_SESSION_FINISHED, &result,
+			     upload_ctx->user_data);
+	zsock_close(sock);
 }
 
 int zperf_tcp_upload_async(const struct zperf_upload_params *param,

--- a/subsys/net/lib/zperf/zperf_udp_uploader.c
+++ b/subsys/net/lib/zperf/zperf_udp_uploader.c
@@ -305,7 +305,7 @@ int zperf_udp_upload(const struct zperf_upload_params *param,
 	}
 
 	sock = zperf_prepare_upload_sock(&param->peer_addr, param->options.tos,
-					 param->options.priority, IPPROTO_UDP);
+					 param->options.priority, 0, IPPROTO_UDP);
 	if (sock < 0) {
 		return sock;
 	}


### PR DESCRIPTION
Add option (-i) for zperf tcp upload that will enable periodic result reporting. This is useful for monitoring performance swings during a longer session.

Example zperf shell usage:
```
uart:~$ zperf tcp upload -a -i 2 192.0.2.2 5001 10
Remote port is 5001
Connecting to 192.0.2.2
Duration:       10.00 s
Packet size:    256 bytes
Rate:           10 kbps
Starting...
Duration: 2.00 s | Packets:  11051 | Errors:      0 | Rate: 11.31 Mbps
Duration: 2.00 s | Packets:  11072 | Errors:      0 | Rate: 11.33 Mbps
Duration: 2.00 s | Packets:  11059 | Errors:      0 | Rate: 11.32 Mbps
Duration: 2.00 s | Packets:  11057 | Errors:      0 | Rate: 11.31 Mbps
Duration: 2.00 s | Packets:  11051 | Errors:      0 | Rate: 11.31 Mbps
-
Upload completed!
Duration:       10.00 s
Num packets:    55290
Num errors:     0 (retry or fail)
Rate:           11.32 Mbps
uart:~$ 
```