### PR TITLE
tests: Bluetooth: "fix" resume2 bsim test

### DIFF
--- a/tests/bsim/bluetooth/host/adv/resume2/dut/prj.conf
+++ b/tests/bsim/bluetooth/host/adv/resume2/dut/prj.conf
@@ -20,3 +20,6 @@ CONFIG_BT_GAP_AUTO_UPDATE_CONN_PARAMS=n
 
 CONFIG_BT_MAX_CONN=3
 CONFIG_BT_ID_MAX=1
+
+# This test encodes Zephyr Link-layer specific behavior.
+CONFIG_BT_LL_SW_SPLIT=y


### PR DESCRIPTION
This test assumes that the link-layer will have the same amount of peripheral slots as central slots.

Force the usage of the Zephyr Link Layer for this one test.

E.g. nCentrals == nPeripherals == BT_MAX_CONN

This might not be true for other controllers:
In nordic's case, the Softdevice Controller takes BT_MAX_CONN as the total number of slots, peripherals + centrals.
In that case, nCentrals = BT_MAX_CONN - 1, nPeripherals = 1.

That test is not designed for this case.