### PR TITLE
Bluetooth: Mesh: Shell: Update DFD start bool parse

### DIFF
--- a/subsys/bluetooth/mesh/shell/dfd.c
+++ b/subsys/bluetooth/mesh/shell/dfd.c
@@ -223,7 +223,7 @@ static int cmd_dfd_start(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	if (argc > 4) {
-		params.apply = strcmp(argv[4], "true") ? false : true;
+		params.apply = shell_strtobool(argv[4], 0, &err);
 	} else {
 		params.apply = true;
 	}


### PR DESCRIPTION
Changes the parsing of boolean input parameter "PolicyApply" to DFD start command to use shell boolean parse library.