### PR TITLE
Allow disabling the nRF5340 network CPU by protocol drivers

### DIFF
--- a/boards/lairdconnect/bl5340_dvk/bl5340_dvk_nrf5340_cpunet_reset.c
+++ b/boards/lairdconnect/bl5340_dvk/bl5340_dvk_nrf5340_cpunet_reset.c
@@ -10,7 +10,7 @@
 #include <zephyr/logging/log.h>
 
 #include <soc.h>
-#include <nrf53_cpunet_mgmt.h>
+#include <hal/nrf_reset.h>
 
 LOG_MODULE_REGISTER(bl5340_dvk_cpuapp, CONFIG_LOG_DEFAULT_LEVEL);
 
@@ -50,7 +50,7 @@ static int remoteproc_mgr_boot(void)
 	 */
 
 	/* Release the Network MCU, 'Release force off signal' */
-	nrf53_cpunet_enable(true);
+	nrf_reset_network_force_off(NRF_RESET, false);
 
 	LOG_DBG("Network MCU released.");
 #endif /* !CONFIG_TRUSTED_EXECUTION_SECURE */

--- a/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_cpunet_reset.c
+++ b/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_cpunet_reset.c
@@ -9,7 +9,7 @@
 #include <zephyr/logging/log.h>
 
 #include <soc.h>
-#include <nrf53_cpunet_mgmt.h>
+#include <hal/nrf_reset.h>
 #include <hal/nrf_gpiote.h>
 
 LOG_MODULE_REGISTER(nrf5340_audio_dk_nrf5340_cpuapp, CONFIG_LOG_DEFAULT_LEVEL);
@@ -71,7 +71,7 @@ static int remoteproc_mgr_boot(void)
 	 */
 
 	/* Release the Network MCU, 'Release force off signal' */
-	nrf53_cpunet_enable(true);
+	nrf_reset_network_force_off(NRF_RESET, false);
 
 	LOG_DBG("Network MCU released.");
 #endif /* !CONFIG_TRUSTED_EXECUTION_SECURE */

--- a/boards/nordic/nrf5340dk/nrf5340_cpunet_reset.c
+++ b/boards/nordic/nrf5340dk/nrf5340_cpunet_reset.c
@@ -9,7 +9,7 @@
 #include <zephyr/logging/log.h>
 
 #include <soc.h>
-#include <nrf53_cpunet_mgmt.h>
+#include <hal/nrf_reset.h>
 
 LOG_MODULE_REGISTER(nrf5340dk_nrf5340_cpuapp, CONFIG_LOG_DEFAULT_LEVEL);
 
@@ -49,7 +49,7 @@ static int remoteproc_mgr_boot(void)
 	 */
 
 	/* Release the Network MCU, 'Release force off signal' */
-	nrf53_cpunet_enable(true);
+	nrf_reset_network_force_off(NRF_RESET, false);
 
 	LOG_DBG("Network MCU released.");
 #endif /* !CONFIG_TRUSTED_EXECUTION_SECURE */

--- a/boards/nordic/thingy53/board.c
+++ b/boards/nordic/thingy53/board.c
@@ -8,7 +8,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <soc.h>
-#include <nrf53_cpunet_mgmt.h>
+#include <hal/nrf_reset.h>
 
 LOG_MODULE_REGISTER(thingy53_board_init);
 
@@ -52,7 +52,7 @@ static void enable_cpunet(void)
 	 */
 
 	/* Release the Network MCU, 'Release force off signal' */
-	nrf53_cpunet_enable(true);
+	nrf_reset_network_force_off(NRF_RESET, false);
 
 	LOG_DBG("Network MCU released.");
 #endif /* !CONFIG_TRUSTED_EXECUTION_SECURE */

--- a/boards/panasonic/pan1783/pan1783_nrf5340_cpunet_reset.c
+++ b/boards/panasonic/pan1783/pan1783_nrf5340_cpunet_reset.c
@@ -9,7 +9,7 @@
 #include <zephyr/logging/log.h>
 
 #include <soc.h>
-#include <nrf53_cpunet_mgmt.h>
+#include <hal/nrf_reset.h>
 
 #if defined(CONFIG_BOARD_PAN1783_EVB_NRF5340_CPUAPP)
 LOG_MODULE_REGISTER(pan1783_evb_cpuapp, CONFIG_LOG_DEFAULT_LEVEL);
@@ -42,7 +42,7 @@ static int remoteproc_mgr_boot(void)
 	remoteproc_mgr_config();
 
 	/* Release the Network MCU, 'Release force off signal' */
-	nrf53_cpunet_enable(true);
+	nrf_reset_network_force_off(NRF_RESET, false);
 
 	LOG_DBG("Network MCU released.");
 

--- a/boards/raytac/mdbt53_db_40/raytac_mdbt53_db_40_nrf5340_cpunet_reset.c
+++ b/boards/raytac/mdbt53_db_40/raytac_mdbt53_db_40_nrf5340_cpunet_reset.c
@@ -10,7 +10,7 @@
 #include <zephyr/logging/log.h>
 
 #include <soc.h>
-#include <nrf53_cpunet_mgmt.h>
+#include <hal/nrf_reset.h>
 
 LOG_MODULE_REGISTER(raytac_mdbt53_db_40_nrf5340_cpuapp, CONFIG_LOG_DEFAULT_LEVEL);
 
@@ -50,7 +50,7 @@ static int remoteproc_mgr_boot(const struct device *dev)
 	 */
 
 	/* Release the Network MCU, 'Release force off signal' */
-	nrf53_cpunet_enable(true);
+	nrf_reset_network_force_off(NRF_RESET, false);
 
 	LOG_DBG("Network MCU released.");
 #endif /* !CONFIG_TRUSTED_EXECUTION_SECURE */

--- a/boards/raytac/mdbt53v_db_40/raytac_mdbt53v_db_40_nrf5340_cpunet_reset.c
+++ b/boards/raytac/mdbt53v_db_40/raytac_mdbt53v_db_40_nrf5340_cpunet_reset.c
@@ -49,7 +49,7 @@ static int remoteproc_mgr_boot(const struct device *dev)
 	 */
 
 	/* Release the Network MCU, 'Release force off signal' */
-	nrf53_cpunet_enable(true);
+	nrf_reset_network_force_off(NRF_RESET, false);
 
 	LOG_DBG("Network MCU released.");
 #endif /* !CONFIG_TRUSTED_EXECUTION_SECURE */

--- a/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_spinel_backend_ipc.c
+++ b/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_spinel_backend_ipc.c
@@ -15,6 +15,10 @@
 #include "../../spinel_base/spinel.h"
 #include "../../src/include/nrf_802154_spinel.h"
 
+#if defined(CONFIG_SOC_NRF5340_CPUAPP)
+#include <nrf53_cpunet_mgmt.h>
+#endif
+
 #define LOG_LEVEL LOG_LEVEL_INFO
 #define LOG_MODULE_NAME spinel_ipc_backend
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
@@ -49,6 +53,10 @@ nrf_802154_ser_err_t nrf_802154_backend_init(void)
 	const struct device *const ipc_instance =
 		DEVICE_DT_GET(DT_CHOSEN(nordic_802154_spinel_ipc));
 	int err;
+
+#if defined(CONFIG_SOC_NRF5340_CPUAPP)
+	nrf53_cpunet_enable(true);
+#endif
 
 	err = ipc_service_open_instance(ipc_instance);
 	if (err < 0 && err != -EALREADY) {


### PR DESCRIPTION
Changes introduced in https://github.com/zephyrproject-rtos/zephyr/pull/71337 caused radio protocol drivers to be unable to turn off the network CPU in longer periods of inactivity. This PR attempts to fix that while keeping the sharing mechanism in place and functional.