### PR TITLE
kernel: removed redundant casts

### DIFF
--- a/kernel/device.c
+++ b/kernel/device.c
@@ -59,7 +59,7 @@ static inline const struct device *z_vrfy_device_get_binding(const char *name)
 {
 	char name_copy[Z_DEVICE_MAX_NAME_LEN];
 
-	if (k_usermode_string_copy(name_copy, (char *)name, sizeof(name_copy))
+	if (k_usermode_string_copy(name_copy, name, sizeof(name_copy))
 	    != 0) {
 		return NULL;
 	}

--- a/kernel/include/mmu.h
+++ b/kernel/include/mmu.h
@@ -26,7 +26,7 @@
  * core kernel.
  */
 #define Z_PHYS_RAM_START	((uintptr_t)CONFIG_SRAM_BASE_ADDRESS)
-#define Z_PHYS_RAM_SIZE		((size_t)KB(CONFIG_SRAM_SIZE))
+#define Z_PHYS_RAM_SIZE		(KB(CONFIG_SRAM_SIZE))
 #define Z_PHYS_RAM_END		(Z_PHYS_RAM_START + Z_PHYS_RAM_SIZE)
 #define Z_NUM_PAGE_FRAMES	(Z_PHYS_RAM_SIZE / (size_t)CONFIG_MMU_PAGE_SIZE)
 

--- a/kernel/pipes.c
+++ b/kernel/pipes.c
@@ -519,9 +519,9 @@ int z_vrfy_k_pipe_put(struct k_pipe *pipe, const void *data,
 {
 	K_OOPS(K_SYSCALL_OBJ(pipe, K_OBJ_PIPE));
 	K_OOPS(K_SYSCALL_MEMORY_WRITE(bytes_written, sizeof(*bytes_written)));
-	K_OOPS(K_SYSCALL_MEMORY_READ((void *)data, bytes_to_write));
+	K_OOPS(K_SYSCALL_MEMORY_READ(data, bytes_to_write));
 
-	return z_impl_k_pipe_put((struct k_pipe *)pipe, data,
+	return z_impl_k_pipe_put(pipe, data,
 				 bytes_to_write, bytes_written, min_xfer,
 				 timeout);
 }
@@ -727,9 +727,9 @@ int z_vrfy_k_pipe_get(struct k_pipe *pipe, void *data, size_t bytes_to_read,
 {
 	K_OOPS(K_SYSCALL_OBJ(pipe, K_OBJ_PIPE));
 	K_OOPS(K_SYSCALL_MEMORY_WRITE(bytes_read, sizeof(*bytes_read)));
-	K_OOPS(K_SYSCALL_MEMORY_WRITE((void *)data, bytes_to_read));
+	K_OOPS(K_SYSCALL_MEMORY_WRITE(data, bytes_to_read));
 
-	return z_impl_k_pipe_get((struct k_pipe *)pipe, (void *)data,
+	return z_impl_k_pipe_get(pipe, data,
 				bytes_to_read, bytes_read, min_xfer,
 				timeout);
 }

--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -189,7 +189,7 @@ void z_impl_k_sem_reset(struct k_sem *sem)
 static inline int z_vrfy_k_sem_take(struct k_sem *sem, k_timeout_t timeout)
 {
 	K_OOPS(K_SYSCALL_OBJ(sem, K_OBJ_SEM));
-	return z_impl_k_sem_take((struct k_sem *)sem, timeout);
+	return z_impl_k_sem_take(sem, timeout);
 }
 #include <syscalls/k_sem_take_mrsh.c>
 

--- a/kernel/stack.c
+++ b/kernel/stack.c
@@ -51,7 +51,7 @@ int32_t z_impl_k_stack_alloc_init(struct k_stack *stack, uint32_t num_entries)
 	if (buffer != NULL) {
 		k_stack_init(stack, buffer, num_entries);
 		stack->flags = K_STACK_FLAG_ALLOC;
-		ret = (int32_t)0;
+		ret = 0;
 	} else {
 		ret = -ENOMEM;
 	}

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -174,7 +174,7 @@ static inline int z_vrfy_k_thread_name_set(struct k_thread *thread, const char *
 	 * the current z_vrfy / z_impl split does not provide a
 	 * means of doing so.
 	 */
-	if (k_usermode_string_copy(name, (char *)str, sizeof(name)) != 0) {
+	if (k_usermode_string_copy(name, str, sizeof(name)) != 0) {
 		return -EFAULT;
 	}
 

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -221,7 +221,7 @@ static size_t obj_align_get(enum k_objects otype)
 	return ret;
 }
 
-static struct dyn_obj *dyn_object_find(void *obj)
+static struct dyn_obj *dyn_object_find(const void *obj)
 {
 	struct dyn_obj *node;
 	k_spinlock_key_t key;
@@ -490,7 +490,7 @@ struct k_object *k_object_find(const void *obj)
 		 * 11.8 but is justified since we know dynamic objects
 		 * were not declared with a const qualifier.
 		 */
-		dyn = dyn_object_find((void *)obj);
+		dyn = dyn_object_find(obj);
 		if (dyn != NULL) {
 			ret = &dyn->kobj;
 		}

--- a/kernel/userspace_handler.c
+++ b/kernel/userspace_handler.c
@@ -70,9 +70,8 @@ static inline void z_vrfy_k_object_release(const void *object)
 {
 	struct k_object *ko;
 
-	ko = validate_any_object((void *)object);
-	K_OOPS(K_SYSCALL_VERIFY_MSG(ko != NULL, "object %p access denied",
-				    (void *)object));
+	ko = validate_any_object(object);
+	K_OOPS(K_SYSCALL_VERIFY_MSG(ko != NULL, "object %p access denied", object));
 	k_thread_perms_clear(ko, _current);
 }
 #include <syscalls/k_object_release_mrsh.c>


### PR DESCRIPTION
Removed redundant casts and  and modified parameter types to receive a const pointer when a non-const pointer is not needed

This corresponds to following misra coding guideline:

> A cast shall not remove any const or volatile qualification from the type pointed to by a pointer

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/f953e929d842c7654957c0e41dd10d44c4c9f5b8