### PR TITLE
drivers: pinctrl: support digital-path-disable for Numaker

### DIFF
--- a/drivers/pinctrl/pinctrl_numaker.c
+++ b/drivers/pinctrl/pinctrl_numaker.c
@@ -16,7 +16,9 @@
 #define GPIO_SIZE   DT_REG_SIZE(DT_NODELABEL(gpioa))
 
 #define SLEWCTL_PIN_SHIFT(pin_idx)	((pin_idx) * 2)
-#define SLEWCTL_MASK(pin_idx)	(3 << SLEWCTL_PIN_SHIFT(pin_idx))
+#define SLEWCTL_MASK(pin_idx)		(3 << SLEWCTL_PIN_SHIFT(pin_idx))
+#define DINOFF_PIN_SHIFT(pin_idx)	(pin_idx + GPIO_DINOFF_DINOFF0_Pos)
+#define DINOFF_MASK(pin_idx)		(1 << DINOFF_PIN_SHIFT(pin_idx))
 
 static void gpio_configure(const pinctrl_soc_pin_t *pin, uint8_t port_idx, uint8_t pin_idx)
 {
@@ -28,7 +30,8 @@ static void gpio_configure(const pinctrl_soc_pin_t *pin, uint8_t port_idx, uint8
 		      ((pin->schmitt_enable ? 1 : 0) << pin_idx);
 	port->SLEWCTL = (port->SLEWCTL & ~SLEWCTL_MASK(pin_idx)) |
 			(pin->slew_rate << SLEWCTL_PIN_SHIFT(pin_idx));
-
+	port->DINOFF = (port->DINOFF & ~DINOFF_MASK(pin_idx)) |
+		       ((pin->digital_disable ? 1 : 0) << DINOFF_PIN_SHIFT(pin_idx));
 }
 /**
  * Configure pin multi-function

--- a/dts/bindings/pinctrl/nuvoton,numaker-pinctrl.yaml
+++ b/dts/bindings/pinctrl/nuvoton,numaker-pinctrl.yaml
@@ -83,3 +83,6 @@ child-binding:
           Set the speed of a pin. This setting effectively limits the
           slew rate of the output signal. Hardware default configuration is low.
           Fast slew rate could support fast speed pins, like as SPI CLK up to 50MHz.
+      digital-path-disable:
+        type: boolean
+        description: disable digital path on a pin.

--- a/soc/nuvoton/numaker/common/pinctrl_soc.h
+++ b/soc/nuvoton/numaker/common/pinctrl_soc.h
@@ -25,6 +25,7 @@ typedef struct pinctrl_soc_pin_t {
 	uint32_t open_drain: 1;
 	uint32_t schmitt_enable: 1;
 	uint32_t slew_rate: 2;
+	uint32_t digital_disable: 1;
 } pinctrl_soc_pin_t;
 
 #define Z_PINCTRL_STATE_PIN_INIT(node_id, prop, idx)						\
@@ -33,6 +34,7 @@ typedef struct pinctrl_soc_pin_t {
 		.open_drain = DT_PROP(node_id, drive_open_drain),				\
 		.schmitt_enable = DT_PROP(node_id, input_schmitt_enable),			\
 		.slew_rate = DT_ENUM_IDX(node_id, slew_rate),					\
+		.digital_disable = DT_PROP(node_id, digital_path_disable),			\
 	},
 
 #define Z_PINCTRL_STATE_PINS_INIT(node_id, prop)						\


### PR DESCRIPTION
This PR is to add the new property digital-path-disable for Nuvoton numaker pinctrl driver.
Test result of adc_api & gpio_basic_api on both of numaker_m2l31ki & numaker_pfm_m467 board as: (PASS)

```
------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [adc_basic]: pass = 6, fail = 0, skip = 0, total = 6 duration = 0.532 seconds
 - PASS - [adc_basic.test_adc_asynchronous_call] duration = 0.006 seconds
 - PASS - [adc_basic.test_adc_invalid_request] duration = 0.013 seconds
 - PASS - [adc_basic.test_adc_repeated_samplings] duration = 0.091 seconds
 - PASS - [adc_basic.test_adc_sample_one_channel] duration = 0.007 seconds
 - PASS - [adc_basic.test_adc_sample_two_channels] duration = 0.007 seconds
 - PASS - [adc_basic.test_adc_sample_with_interval] duration = 0.408 seconds

------ TESTSUITE SUMMARY END ------

===================================================================

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [after_flash_gpio_config_trigger]: pass = 2, fail = 0, skip = 0, total = 2 duration = 0.022 seconds
 - PASS - [after_flash_gpio_config_trigger.test_gpio_config_trigger] duration = 0.011 seconds
 - PASS - [after_flash_gpio_config_trigger.test_gpio_config_twice_trigger] duration = 0.011 seconds

SUITE PASS - 100.00% [gpio_port]: pass = 1, fail = 0, skip = 0, total = 1 duration = 0.034 seconds
 - PASS - [gpio_port.test_gpio_port] duration = 0.034 seconds

SUITE PASS - 100.00% [gpio_port_cb_mgmt]: pass = 3, fail = 0, skip = 0, total = 3 duration = 9.718 seconds
 - PASS - [gpio_port_cb_mgmt.test_gpio_callback_add_remove] duration = 3.605 seconds
 - PASS - [gpio_port_cb_mgmt.test_gpio_callback_enable_disable] duration = 3.607 seconds
 - PASS - [gpio_port_cb_mgmt.test_gpio_callback_self_remove] duration = 2.506 seconds

SUITE PASS - 100.00% [gpio_port_cb_vari]: pass = 1, fail = 0, skip = 0, total = 1 duration = 9.943 seconds
 - PASS - [gpio_port_cb_vari.test_gpio_callback_variants] duration = 9.943 seconds

------ TESTSUITE SUMMARY END ------
```