### PR TITLE
tests: Made pointer parameters explicitely const where non-const pointer parameters are not needed

### DIFF
--- a/tests/kernel/device/src/mmio.c
+++ b/tests/kernel/device/src/mmio.c
@@ -60,7 +60,7 @@ DEVICE_DEFINE(foo0, "foo0", foo_single_init, NULL,
  */
 ZTEST(device, test_mmio_single)
 {
-	struct z_device_mmio_rom *rom;
+	const struct z_device_mmio_rom *rom;
 	const struct device *dev = device_get_binding("foo0");
 	mm_reg_t regs;
 


### PR DESCRIPTION
modified parameter types to receive a const pointer when a non-const pointer is not needed

This corresponds to following misra coding guideline:

> A cast shall not remove any const or volatile qualification from the type pointed to by a pointer

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/f953e929d842c7654957c0e41dd10d44c4c9f5b8