### PR TITLE
Bluetooth: Host: Map HCI cmd disallowed to errno 

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -340,6 +340,8 @@ int bt_hci_cmd_send_sync(uint16_t opcode, struct net_buf *buf,
 			return -ENOMEM;
 		case BT_HCI_ERR_INVALID_PARAM:
 			return -EINVAL;
+		case BT_HCI_ERR_CMD_DISALLOWED:
+			return -EACCES;
 		default:
 			return -EIO;
 		}

--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -141,6 +141,15 @@ static int set_random_address(const bt_addr_t *addr)
 
 	err = bt_hci_cmd_send_sync(BT_HCI_OP_LE_SET_RANDOM_ADDRESS, buf, NULL);
 	if (err) {
+		if (err == -EACCES) {
+			/* If we are here we probably tried to set a random
+			 * address while a legacy advertising, scanning or
+			 * initiating is enabled, this is illegal.
+			 *
+			 * See Core Spec @ Vol 4, Part E 7.8.4
+			 */
+			LOG_WRN("cmd disallowed");
+		}
 		return err;
 	}
 

--- a/tests/bluetooth/df/connection_cte_req/src/test_cte_req_enable.c
+++ b/tests/bluetooth/df/connection_cte_req/src/test_cte_req_enable.c
@@ -97,7 +97,7 @@ ZTEST(test_hci_set_conn_cte_rx_params_with_conn_set,
 	int err;
 
 	err = send_conn_cte_req_enable(g_conn_handle, &g_data, true);
-	zassert_equal(err, -EIO,
+	zassert_equal(err, -EACCES,
 		      "Unexpected error value for CTE request enable before set rx params");
 }
 
@@ -109,7 +109,7 @@ ZTEST(test_hci_set_conn_cte_rx_params_with_rx_param_set,
 	g_data.cte_request_interval = REQUEST_INTERVAL_TOO_LOW;
 
 	err = send_conn_cte_req_enable(g_conn_handle, &g_data, true);
-	zassert_equal(err, -EIO,
+	zassert_equal(err, -EACCES,
 		      "Unexpected error value for CTE request enable with too short request"
 		      " interval");
 }

--- a/tests/bluetooth/df/connectionless_cte_tx/src/test_set_cl_cte_tx_enable.c
+++ b/tests/bluetooth/df/connectionless_cte_tx/src/test_set_cl_cte_tx_enable.c
@@ -71,7 +71,7 @@ ZTEST(test_set_cl_cte_tx_enable, test_set_cl_cte_tx_enable_cte_params_not_set)
 
 	/* test logic */
 	err = send_set_cl_cte_tx_enable(g_adv->handle, g_adv->flags, true);
-	zassert_equal(err, -EIO, "Unexpected error value for enable CTE before "
+	zassert_equal(err, -EACCES, "Unexpected error value for enable CTE before "
 		      "CTE params set");
 
 	/* clean up */
@@ -90,7 +90,7 @@ ZTEST(test_set_cl_cte_tx_enable, test_set_cl_cte_tx_enable_per_adv_coded_phy)
 
 	/* test logic */
 	err = send_set_cl_cte_tx_enable(g_adv->handle, g_adv->flags, true);
-	zassert_equal(err, -EIO, "Unexpected error value for enable CTE for "
+	zassert_equal(err, -EACCES, "Unexpected error value for enable CTE for "
 		      "coded PHY");
 
 	/* clean up */
@@ -151,7 +151,7 @@ ZTEST(test_set_cl_cte_tx_enable, test_set_cl_cte_tx_disable_when_no_CTE_enabled)
 
 	/* test logic */
 	err = send_set_cl_cte_tx_enable(g_adv->handle, g_adv->flags, false);
-	zassert_equal(err,  -EIO, "Unexpected error value for disable CTE "
+	zassert_equal(err,  -EACCES, "Unexpected error value for disable CTE "
 		      "before CTE enable");
 
 	/* clean up */


### PR DESCRIPTION
Map the `BT_HCI_ERR_CMD_DISALLOWED` HCI error to `-EACCES`.