### PR TITLE
Bluetooth: Audio: Get function for bt_audio_codec_qos_pref.

### DIFF
--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -410,6 +410,9 @@ struct bt_bap_ep_info {
 	 *  otherwise NULL
 	 */
 	struct bt_bap_ep *paired_ep;
+
+	/** Pointer to the preferred QoS settings associated with the endpoint */
+	const struct bt_audio_codec_qos_pref *qos_pref;
 };
 
 /**

--- a/subsys/bluetooth/audio/bap_stream.c
+++ b/subsys/bluetooth/audio/bap_stream.c
@@ -118,6 +118,7 @@ int bt_bap_ep_get_info(const struct bt_bap_ep *ep, struct bt_bap_ep_info *info)
 	info->id = ep->status.id;
 	info->state = ep->status.state;
 	info->dir = dir;
+	info->qos_pref = &ep->qos_pref;
 
 	if (ep->iso == NULL) {
 		info->paired_ep = NULL;


### PR DESCRIPTION
Implement get function for bt_audio_codec_qos_pref for BAP endpoints Therefore no need to use the internal header file to get it.

This PR fixes https://github.com/zephyrproject-rtos/zephyr/issues/72359