### PR TITLE
Modify NXP's CSI driver to support both rt11xx and rt10xx

### DIFF
--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -638,6 +638,9 @@ void video_buffer_release(struct video_buffer *buf);
 /** YUYV pixel format */
 #define VIDEO_PIX_FMT_YUYV video_fourcc('Y', 'U', 'Y', 'V') /* 16  Y0-Cb0 Y1-Cr0 */
 
+/** XYUV32 pixel format */
+#define VIDEO_PIX_FMT_XYUV32 video_fourcc('X', 'Y', 'U', 'V') /* 32  XYUV-8-8-8-8 */
+
 /**
  *
  * @}


### PR DESCRIPTION
This PR modify the NXP's CSI driver to support both rt11xx and rt10xx. This depends on [this PR](https://github.com/zephyrproject-rtos/zephyr/pull/71859)
It is split from https://github.com/zephyrproject-rtos/zephyr/pull/69810 as required by @loicpoulain to ease the review process.
It already got reviewed by @danieldegrasse.

The PR depends on https://github.com/zephyrproject-rtos/zephyr/pull/71859