### PR TITLE
cmake: Set C compile features early for modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,6 +219,26 @@ if(CONFIG_LTO)
   add_link_options($<TARGET_PROPERTY:linker,lto_arguments>)
 endif()
 
+if(CONFIG_STD_C23)
+  set(CSTD c2x)
+elseif(CONFIG_STD_C17)
+  set(CSTD c17)
+elseif(CONFIG_STD_C11)
+  set(CSTD c11)
+elseif(CONFIG_STD_C99)
+  set(CSTD c99)
+elseif(CONFIG_STD_C90)
+  set(CSTD c90)
+else()
+  message(FATAL_ERROR "Unreachable code. Expected C standard to have been chosen.")
+endif()
+
+if(CONFIG_GNU_C_EXTENSIONS)
+  string(REPLACE "c" "gnu" CSTD "${CSTD}")
+endif()
+
+list(APPEND CMAKE_C_COMPILE_FEATURES ${compile_features_${CSTD}})
+
 # @Intent: Obtain compiler specific flags related to C++ that are not influenced by kconfig
 zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:$<TARGET_PROPERTY:compiler-cpp,required>>)
 
@@ -956,35 +976,19 @@ if(CONFIG_USERSPACE)
   set(PROCESS_GPERF ${ZEPHYR_BASE}/scripts/build/process_gperf.py)
 endif()
 
-get_property(CSTD GLOBAL PROPERTY CSTD)
-if(NOT DEFINED CSTD)
-  if(CONFIG_STD_C23)
-    set(CSTD c2x)
-  elseif(CONFIG_STD_C17)
-    set(CSTD c17)
-  elseif(CONFIG_STD_C11)
-    set(CSTD c11)
-  elseif(CONFIG_STD_C99)
-    set(CSTD c99)
-  elseif(CONFIG_STD_C90)
-    set(CSTD c90)
-  else()
-    message(FATAL_ERROR "Unreachable code. Expected C standard to have been chosen.")
-  endif()
-
-  if(CONFIG_GNU_C_EXTENSIONS)
-    string(REPLACE "c" "gnu" CSTD "${CSTD}")
-  endif()
-else()
+get_property(GLOBAL_CSTD GLOBAL PROPERTY CSTD)
+if(DEFINED GLOBAL_CSTD)
   message(DEPRECATION
     "Global CSTD property is deprecated, see Kconfig.zephyr for C Standard options.")
+  set(CSTD ${GLOBAL_CSTD})
+  list(APPEND CMAKE_C_COMPILE_FEATURES ${compile_features_${CSTD}})
 endif()
 
 # @Intent: Obtain compiler specific flag for specifying the c standard
 zephyr_compile_options(
   $<$<COMPILE_LANGUAGE:C>:$<TARGET_PROPERTY:compiler,cstd>${CSTD}>
 )
-set(CMAKE_C_COMPILE_FEATURES ${compile_features_${CSTD}} PARENT_SCOPE)
+set(CMAKE_C_COMPILE_FEATURES ${CMAKE_C_COMPILE_FEATURES} PARENT_SCOPE)
 
 # @Intent: Configure linker scripts, i.e. generate linker scripts with variables substituted
 toolchain_ld_configure_files()


### PR DESCRIPTION
If modules require C compiler features, these need to be set before calling `add_subdirectory`.

Fixes #72411