### PR TITLE
Bluetooth: Controller: Add missing guard for mic_state in ull_conn_iso

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
@@ -470,12 +470,15 @@ void ull_conn_iso_done(struct node_rx_event_done *done)
 			/* CIS was setup and is now expected to be going */
 			if (done->extra.trx_performed_bitmask &
 			    (1U << LL_CIS_IDX_FROM_HANDLE(cis->lll.handle))) {
-				if (done->extra.mic_state == LLL_CONN_MIC_FAIL) {
+				if (false) {
+#if defined(CONFIG_BT_CTLR_LE_ENC)
+				} else if (done->extra.mic_state == LLL_CONN_MIC_FAIL) {
 					/* MIC failure - stop CIS and defer cleanup to after
 					 * teardown.
 					 */
 					ull_conn_iso_cis_stop(cis, NULL,
 							      BT_HCI_ERR_TERM_DUE_TO_MIC_FAIL);
+#endif /* CONFIG_BT_CTLR_LE_ENC */
 				} else {
 					cis->event_expire = 0U;
 				}


### PR DESCRIPTION
The mic_state is a guarded field in event_done_extra where it was accessed outside of its guard.