### PR TITLE
libc/picolibc: Support Picolibc for toolchains without bundled Picolibc

### DIFF
--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -43,7 +43,6 @@ config NEWLIB_LIBC_SUPPORTED
 config PICOLIBC_SUPPORTED
 	bool
 	depends on !NATIVE_APPLICATION
-	depends on ("$(TOOLCHAIN_HAS_PICOLIBC)" = "y") || (NATIVE_LIBRARY)
 	depends on !REQUIRES_FULL_LIBCPP || ("$(TOOLCHAIN_HAS_PICOLIBC)" = "y")
 	default y
 	select FULL_LIBC_SUPPORTED


### PR DESCRIPTION
Allow Picolibc to get build from module, if the toolchain does not include a bundled picolibc. This should always be possible, except for native applications and if libcpp is required.

We initially encountered this problem using `gnuarmemb` toolchain but it's also reproducible with `llvm`:

    ZEPHYR_TOOLCHAIN_VARIANT=llvm ./scripts/twister -T tests/kernel/common -p qemu_x86 -t picolibc -v
