### PR TITLE
Add a shield for DVP FPC 24-pins mt9m114 camera modules

### DIFF
--- a/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -342,3 +342,7 @@ zephyr_udc0: &usb1 {
 	pinctrl-0 = <&pinmux_swo>;
 	pinctrl-names = "default";
 };
+
+dvp_fpc24_i2c: &lpi2c1 {};
+
+dvp_fpc24_interface: &csi {};

--- a/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -149,18 +149,6 @@ arduino_i2c: &lpi2c1 {};
 	pinctrl-0 = <&pinmux_lpi2c1>;
 	pinctrl-names = "default";
 
-	mt9m114: mt9m114@48 {
-		compatible = "aptina,mt9m114";
-		reg = <0x48>;
-		status = "okay";
-
-		port {
-			mt9m114_ep_out: endpoint {
-				remote-endpoint = <&csi_ep_in>;
-			};
-		};
-	};
-
 	ft5336: ft5336@38 {
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
@@ -271,16 +259,8 @@ zephyr_udc0: &usb1 {
 };
 
 &csi {
-	status = "okay";
-	source = <&mt9m114>;
 	pinctrl-0 = <&pinmux_csi>;
 	pinctrl-names = "default";
-
-	port {
-		csi_ep_in: endpoint {
-			remote-endpoint = <&mt9m114_ep_out>;
-		};
-	};
 };
 
 &flexpwm2_pwm3 {

--- a/boards/shields/dvp_fpc24_mt9m114/Kconfig.shield
+++ b/boards/shields/dvp_fpc24_mt9m114/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright 2024 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+config SHIELD_DVP_FPC24_MT9M114
+	def_bool $(shields_list_contains,DVP_FPC24_MT9M114)

--- a/boards/shields/dvp_fpc24_mt9m114/boards/mimxrt1064_evk.overlay
+++ b/boards/shields/dvp_fpc24_mt9m114/boards/mimxrt1064_evk.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&dvp_fpc24_interface {
+	source = <&mt9m114>;
+};

--- a/boards/shields/dvp_fpc24_mt9m114/doc/index.rst
+++ b/boards/shields/dvp_fpc24_mt9m114/doc/index.rst
@@ -1,0 +1,92 @@
+.. _dvp_fpc24_mt9m114:
+
+DVP FPC-24 MT9M114 Camera Module
+################################
+
+Overview
+********
+
+This shield supports mt9m114 camera modules which use a 24-pin FPC connector and a DVP
+(Digital Video Port), aka parallel interface. These camera modules are compatible and provided
+together with the i.MX RT1050, RT1060 and RT1064 EVKs as specified here `Camera iMXRT`_.
+
+Pins assignment of the DVP FPC-24 MT9M114 camera module
+=======================================================
+
++-------------------+--------------+
+| FPC Connector Pin | Function     |
++===================+==============+
+| 1                 | NC           |
++-------------------+--------------+
+| 2                 | AGND         |
++-------------------+--------------+
+| 3                 | SDA          |
++-------------------+--------------+
+| 4                 | AVDD         |
++-------------------+--------------+
+| 5                 | SCL          |
++-------------------+--------------+
+| 6                 | Reset        |
++-------------------+--------------+
+| 7                 | Vsync        |
++-------------------+--------------+
+| 8                 | Powerdown    |
++-------------------+--------------+
+| 9                 | Hsync        |
++-------------------+--------------+
+| 10                | DVDD         |
++-------------------+--------------+
+| 11                | DOVDD        |
++-------------------+--------------+
+| 12                | Data 9       |
++-------------------+--------------+
+| 13                | Master Clock |
++-------------------+--------------+
+| 14                | Data 8       |
++-------------------+--------------+
+| 15                | DGND         |
++-------------------+--------------+
+| 16                | Data 7       |
++-------------------+--------------+
+| 17                | Pixel Clock  |
++-------------------+--------------+
+| 18                | Data 6       |
++-------------------+--------------+
+| 19                | Data 2       |
++-------------------+--------------+
+| 20                | Data 5       |
++-------------------+--------------+
+| 21                | Data 3       |
++-------------------+--------------+
+| 22                | Data 4       |
++-------------------+--------------+
+| 23                | Data 1       |
++-------------------+--------------+
+| 24                | Data 0       |
++-------------------+--------------+
+
+
+Requirements
+************
+
+This shield can only be used with a board which provides a configuration for a 24-pins FPC
+connector with DVP (parallel) interface, such as the i.MX RT1050, RT1060, RT1064 EVKs.
+
+Programming
+***********
+
+Set ``-DSHIELD=dvp_fpc24_mt9m114`` when you invoke ``west build``. For example:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/subsys/video/capture
+   :board: mimxrt1064_evk
+   :shield: dvp_fpc24_mt9m114
+   :goals: build
+
+References
+**********
+
+.. target-notes::
+
+.. _Camera iMXRT:
+   https://community.nxp.com/t5/i-MX-RT-Knowledge-Base/Connecting-camera-and-LCD-to-i-MX-RT-EVKs/ta-p/1122183

--- a/boards/shields/dvp_fpc24_mt9m114/dvp_fpc24_mt9m114.overlay
+++ b/boards/shields/dvp_fpc24_mt9m114/dvp_fpc24_mt9m114.overlay
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/{
+	chosen {
+		zephyr,camera = &dvp_fpc24_interface;
+	};
+};
+
+&dvp_fpc24_i2c {
+	mt9m114: mt9m114@48 {
+		compatible = "aptina,mt9m114";
+		reg = <0x48>;
+
+		port {
+			mt9m114_ep_out: endpoint {
+				remote-endpoint = <&dfi_ep_in>;
+			};
+		};
+	};
+};
+
+&dvp_fpc24_interface {
+	status = "okay";
+
+	port {
+		dfi_ep_in: endpoint {
+			remote-endpoint = <&mt9m114_ep_out>;
+		};
+	};
+};


### PR DESCRIPTION
This PR adds a shield for DVP FPC 24-pins mt9m114 camera modules which are upported across NXP's i.MX RT10xx series.

It is split from https://github.com/zephyrproject-rtos/zephyr/pull/69810 to ease the review process.

It already got reviewed by @danieldegrasse.