### PR TITLE
buildsystem: Add an option to compress debug sections

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1792,6 +1792,17 @@ if(CONFIG_BUILD_OUTPUT_STRIPPED)
     )
 endif()
 
+if(CONFIG_BUILD_OUTPUT_COMPRESS_DEBUG_SECTIONS)
+  list(APPEND
+    post_build_commands
+    COMMAND $<TARGET_PROPERTY:bintools,elfconvert_command>
+            $<TARGET_PROPERTY:bintools,elfconvert_flag>
+            $<TARGET_PROPERTY:bintools,elfconvert_flag_compress_debug_sections>
+            $<TARGET_PROPERTY:bintools,elfconvert_flag_infile>${KERNEL_ELF_NAME}
+            $<TARGET_PROPERTY:bintools,elfconvert_flag_final>
+)
+endif()
+
 if(CONFIG_BUILD_OUTPUT_EXE)
   if (NOT CONFIG_NATIVE_LIBRARY)
     list(APPEND

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -784,6 +784,11 @@ config BUILD_OUTPUT_STRIPPED
 	  Build a stripped binary zephyr/zephyr.strip in the build directory.
 	  The name of this file can be customized with CONFIG_KERNEL_BIN_NAME.
 
+config BUILD_OUTPUT_COMPRESS_DEBUG_SECTIONS
+	bool "Compress debug sections in the ELF file"
+	help
+	  Compress debug sections in the ELF file to reduce the file size.
+
 config BUILD_OUTPUT_ADJUST_LMA
 	string
 	help

--- a/cmake/bintools/bintools_template.cmake
+++ b/cmake/bintools/bintools_template.cmake
@@ -66,6 +66,7 @@
 #   elfconvert_flag_final         : Flags that must always be applied last at the elfconvert command
 #   elfconvert_flag_strip_all     : Flag that is used for stripping all symbols when converting
 #   elfconvert_flag_strip_debug   : Flag that is used to strip debug symbols when converting
+#   elfconvert_flag_compress_debug_sections: Flag that is used to compress debug sections when converting
 #   elfconvert_flag_intarget      : Flag for specifying target used for infile
 #   elfconvert_flag_outtarget     : Flag for specifying target to use for converted file.
 #                                   Target value must be one of those listed described by: elfconvert_formats
@@ -141,6 +142,7 @@ set_property(TARGET bintools PROPERTY elfconvert_command ${CMAKE_COMMAND} -E ech
 set_property(TARGET bintools PROPERTY elfconvert_formats "")
 set_property(TARGET bintools PROPERTY elfconvert_flag "")
 set_property(TARGET bintools PROPERTY elfconvert_flag_final "")
+set_property(TARGET bintools PROPERTY elfconvert_flag_compress_debug_sections "")
 set_property(TARGET bintools PROPERTY elfconvert_flag_outtarget "")
 set_property(TARGET bintools PROPERTY elfconvert_flag_section_remove "")
 set_property(TARGET bintools PROPERTY elfconvert_flag_gapfill "")

--- a/cmake/bintools/gnu/target_bintools.cmake
+++ b/cmake/bintools/gnu/target_bintools.cmake
@@ -7,6 +7,7 @@
 #   elfconvert_flag_final         : empty
 #   elfconvert_flag_strip_all     : -S
 #   elfconvert_flag_strip_debug   : -g
+#   elfconvert_flag_compress_debug_sections: --compress-debug-sections
 #   elfconvert_flag_intarget      : --input-target=
 #   elfconvert_flag_outtarget     : --output-target=
 #   elfconvert_flag_section_remove: --remove-section=
@@ -33,6 +34,8 @@ set_property(TARGET bintools PROPERTY elfconvert_flag_final "")
 
 set_property(TARGET bintools PROPERTY elfconvert_flag_strip_all "-S")
 set_property(TARGET bintools PROPERTY elfconvert_flag_strip_debug "-g")
+
+set_property(TARGET bintools PROPERTY elfconvert_flag_compress_debug_sections "--compress-debug-sections")
 
 set_property(TARGET bintools PROPERTY elfconvert_flag_intarget "--input-target=")
 set_property(TARGET bintools PROPERTY elfconvert_flag_outtarget "--output-target=")

--- a/cmake/bintools/llvm/target_bintools.cmake
+++ b/cmake/bintools/llvm/target_bintools.cmake
@@ -7,6 +7,7 @@
 #   elfconvert_flag_final         : empty
 #   elfconvert_flag_strip_all     : -S
 #   elfconvert_flag_strip_debug   : -g
+#   elfconvert_flag_compress_debug_sections: --compress-debug-sections
 #   elfconvert_flag_intarget      : --input-target=
 #   elfconvert_flag_outtarget     : --output-target=
 #   elfconvert_flag_section_remove: --remove-section=
@@ -33,6 +34,8 @@ set_property(TARGET bintools PROPERTY elfconvert_flag_final "")
 
 set_property(TARGET bintools PROPERTY elfconvert_flag_strip_all "-S")
 set_property(TARGET bintools PROPERTY elfconvert_flag_strip_debug "-g")
+
+set_property(TARGET bintools PROPERTY elfconvert_flag_compress_debug_sections "--compress-debug-sections")
 
 set_property(TARGET bintools PROPERTY elfconvert_flag_intarget "--input-target=")
 set_property(TARGET bintools PROPERTY elfconvert_flag_outtarget "--output-target=")


### PR DESCRIPTION
Compressing debug sections can reduce the output
ELF file size substantially.