### PR TITLE
cmake/modules/extensions: Fix string list replacement

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -5326,7 +5326,7 @@ function(add_llext_target target_name)
        REPLACE "(.+)" "^\\1$"
        OUTPUT_VARIABLE llext_remove_flags_regexp
   )
-  string(REPLACE ";" "|" llext_remove_flags_regexp "${llext_remove_flags_regexp}")
+  list(JOIN llext_remove_flags_regexp "|" llext_remove_flags_regexp)
   if ("${llext_remove_flags_regexp}" STREQUAL "")
     # an empty regexp would match anything, we actually need the opposite
     # so set it to match empty strings


### PR DESCRIPTION
Changing from `;` to `|` directly doesn't consider for escaped `;` inside a list. Fix suggested by @pillo79.