### PR TITLE
improve `struct z_page_frame` usage

### DIFF
--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -2008,9 +2008,7 @@ static void mark_addr_page_reserved(uintptr_t addr, size_t len)
 			continue;
 		}
 
-		struct z_page_frame *pf = z_phys_to_page_frame(pos);
-
-		pf->flags |= Z_PAGE_FRAME_RESERVED;
+		z_page_frame_set(z_phys_to_page_frame(pos), Z_PAGE_FRAME_RESERVED);
 	}
 }
 

--- a/arch/xtensa/core/ptables.c
+++ b/arch/xtensa/core/ptables.c
@@ -337,15 +337,12 @@ void xtensa_mmu_init(void)
 __weak void arch_reserved_pages_update(void)
 {
 	uintptr_t page;
-	struct z_page_frame *pf;
 	int idx;
 
 	for (page = CONFIG_SRAM_BASE_ADDRESS, idx = 0;
 	     page < (uintptr_t)z_mapped_start;
 	     page += CONFIG_MMU_PAGE_SIZE, idx++) {
-		pf = &z_page_frames[idx];
-
-		pf->flags |= Z_PAGE_FRAME_RESERVED;
+		z_page_frame_set(&z_page_frames[idx], Z_PAGE_FRAME_RESERVED);
 	}
 }
 #endif /* CONFIG_ARCH_HAS_RESERVED_PAGE_FRAMES */

--- a/doc/kernel/memory_management/demand_paging.rst
+++ b/doc/kernel/memory_management/demand_paging.rst
@@ -53,6 +53,10 @@ Page Frame
   addresses. For every page frame, a ``struct z_page_frame`` is instantiated to
   store metadata. Flags for each page frame:
 
+  * ``Z_PAGE_FRAME_FREE`` indicates a page frame is unused and on the list of
+    free page frames. When this flag is set, none of the other flags are
+    meaningful and they must not be modified.
+
   * ``Z_PAGE_FRAME_PINNED`` indicates a page frame is pinned in memory
     and should never be paged out.
 

--- a/include/zephyr/kernel/mm/demand_paging.h
+++ b/include/zephyr/kernel/mm/demand_paging.h
@@ -267,10 +267,10 @@ void k_mem_paging_eviction_init(void);
  * a loaded data page may be selected, in which case its associated page frame
  * will have the Z_PAGE_FRAME_BACKED bit cleared (as it is no longer cached).
  *
- * pf->addr will indicate the virtual address the page is currently mapped to.
- * Large, sparse backing stores which can contain the entire address space
- * may simply generate location tokens purely as a function of pf->addr with no
- * other management necessary.
+ * z_page_frame_to_virt(pf) will indicate the virtual address the page is
+ * currently mapped to. Large, sparse backing stores which can contain the
+ * entire address space may simply generate location tokens purely as a
+ * function of that virtual address with no other management necessary.
  *
  * This function distinguishes whether it was called on behalf of a page
  * fault. A free backing store location must always be reserved in order for

--- a/kernel/include/mmu.h
+++ b/kernel/include/mmu.h
@@ -162,6 +162,16 @@ static inline bool z_page_frame_is_available(struct z_page_frame *page)
 	return page->flags == 0U;
 }
 
+static inline void z_page_frame_set(struct z_page_frame *pf, uint8_t flags)
+{
+	pf->flags |= flags;
+}
+
+static inline void z_page_frame_clear(struct z_page_frame *pf, uint8_t flags)
+{
+	pf->flags &= ~flags;
+}
+
 static inline void z_assert_phys_aligned(uintptr_t phys)
 {
 	__ASSERT(phys % CONFIG_MMU_PAGE_SIZE == 0U,

--- a/soc/intel/intel_socfpga_std/cyclonev/soc.c
+++ b/soc/intel/intel_socfpga_std/cyclonev/soc.c
@@ -31,7 +31,7 @@ void arch_reserved_pages_update(void)
 		}
 		struct z_page_frame *pf = z_phys_to_page_frame(pos);
 
-		pf->flags |= Z_PAGE_FRAME_RESERVED;
+		z_page_frame_set(pf, Z_PAGE_FRAME_RESERVED);
 	}
 }
 

--- a/subsys/demand_paging/backing_store/backing_store_qemu_x86_tiny.c
+++ b/subsys/demand_paging/backing_store/backing_store_qemu_x86_tiny.c
@@ -45,7 +45,7 @@ int k_mem_paging_backing_store_location_get(struct z_page_frame *pf,
 					    bool page_fault)
 {
 	/* Simply returns the virtual address */
-	*location = POINTER_TO_UINT(pf->addr);
+	*location = POINTER_TO_UINT(z_page_frame_to_virt(pf));
 
 	return 0;
 }

--- a/subsys/demand_paging/eviction/nru.c
+++ b/subsys/demand_paging/eviction/nru.c
@@ -36,7 +36,7 @@ static void nru_periodic_update(struct k_timer *timer)
 		}
 
 		/* Clear accessed bit in page tables */
-		(void)arch_page_info_get(pf->addr, NULL, true);
+		(void)arch_page_info_get(z_page_frame_to_virt(pf), NULL, true);
 	}
 
 	irq_unlock(key);
@@ -58,7 +58,7 @@ struct z_page_frame *k_mem_paging_eviction_select(bool *dirty_ptr)
 			continue;
 		}
 
-		flags = arch_page_info_get(pf->addr, NULL, false);
+		flags = arch_page_info_get(z_page_frame_to_virt(pf), NULL, false);
 		accessed = (flags & ARCH_DATA_PAGE_ACCESSED) != 0UL;
 		dirty = (flags & ARCH_DATA_PAGE_DIRTY) != 0UL;
 


### PR DESCRIPTION
There is a nasti `__packed` on `struct z_page_frame` that has to die.
Remove it and make the structure even more compact at the same time.

