### PR TITLE
boards stm32h747i_disco: Add missing mdio node

### DIFF
--- a/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m7.dts
+++ b/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m7.dts
@@ -130,15 +130,25 @@
 	 */
 	status = "okay";
 	pinctrl-0 = <&eth_ref_clk_pa1
-		     &eth_mdio_pa2
 		     &eth_crs_dv_pa7
-		     &eth_mdc_pc1
 		     &eth_rxd0_pc4
 		     &eth_rxd1_pc5
 		     &eth_tx_en_pg11
 		     &eth_txd0_pg13
 		     &eth_txd1_pg12>;
 	pinctrl-names = "default";
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
+	pinctrl-names = "default";
+
+	ethernet-phy@0 {
+		compatible = "ethernet-phy";
+		reg = <0x00>;
+		status = "okay";
+	};
 };
 
 &rng {


### PR DESCRIPTION
Akin to the changes in
ab29ee5e0b3e07afdca308255487703d940ced32
Add missing mdio node for
stm32h747i_disco/stm32h747i_disco_stm32h747xx_m7

Without this, samples/net/sockets/echo_server
fails to build in this board.

Fixes: #72433
Related to #71012