### PR TITLE
soc: nuvoton: npcx: npcx9: Move non-soc Kconfig to right file

### DIFF
--- a/soc/nuvoton/npcx/npcx9/Kconfig
+++ b/soc/nuvoton/npcx/npcx9/Kconfig
@@ -11,3 +11,11 @@ config SOC_SERIES_NPCX9
 	select CPU_HAS_ARM_MPU
 	select SOC_FAMILY_NPCX
 	select HAS_PM
+
+config NPCX_VCC1_RST_HANG_WORKAROUND
+	bool
+	depends on SOC_NPCX9M7FB
+	default y
+	help
+	  Workaround the issue "Possible Hang-Up After VCC1_RST Reset"
+	  in the npcx9m7fb SoC errata.

--- a/soc/nuvoton/npcx/npcx9/Kconfig.soc
+++ b/soc/nuvoton/npcx/npcx9/Kconfig.soc
@@ -48,11 +48,3 @@ config SOC
 	default "npcx9m7f" if SOC_NPCX9M7F
 	default "npcx9m7fb" if SOC_NPCX9M7FB
 	default "npcx9mfp" if SOC_NPCX9MFP
-
-config NPCX_VCC1_RST_HANG_WORKAROUND
-	bool
-	depends on SOC_NPCX9M7FB
-	default y
-	help
-	  Workaround the issue "Possible Hang-Up After VCC1_RST Reset"
-	  in the npcx9m7fb SoC errata.


### PR DESCRIPTION
Moves a non-SoC Kconfig to the normal Kconfig file, as this symbol has nothing to do with the SoC selection itself