### PR TITLE
drivers: serial: esp32: Fix next buffer release on rx disable

### DIFF
--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -879,7 +879,7 @@ static int uart_esp32_async_rx_disable(const struct device *dev)
 	/*Release next buffer*/
 	if (data->async.rx_next_len) {
 		evt.type = UART_RX_BUF_RELEASED;
-		evt.data.rx_buf.buf = data->async.rx_buf;
+		evt.data.rx_buf.buf = data->async.rx_next_buf;
 		if (data->async.cb) {
 			data->async.cb(dev, &evt, data->async.user_data);
 		}


### PR DESCRIPTION
When releasing a next buffer on an async rx disable event, the current buffer is passed to the callback instead of the next buffer. This PR sets the event data rx buffer as the next buffer.