### PR TITLE
net: ipv6: mld: change contents of MLDv2 reports 

### DIFF
--- a/subsys/net/ip/ipv6_mld.c
+++ b/subsys/net/ip/ipv6_mld.c
@@ -234,7 +234,7 @@ int net_ipv6_mld_join(struct net_if *iface, const struct in6_addr *addr)
 		return -ENETDOWN;
 	}
 
-	ret = net_ipv6_mld_send_single(iface, addr, NET_IPV6_MLDv2_MODE_IS_EXCLUDE);
+	ret = net_ipv6_mld_send_single(iface, addr, NET_IPV6_MLDv2_CHANGE_TO_EXCLUDE_MODE);
 	if (ret < 0) {
 		return ret;
 	}
@@ -268,7 +268,7 @@ int net_ipv6_mld_leave(struct net_if *iface, const struct in6_addr *addr)
 		return 0;
 	}
 
-	ret = net_ipv6_mld_send_single(iface, addr, NET_IPV6_MLDv2_MODE_IS_INCLUDE);
+	ret = net_ipv6_mld_send_single(iface, addr, NET_IPV6_MLDv2_CHANGE_TO_INCLUDE_MODE);
 	if (ret < 0) {
 		return ret;
 	}

--- a/subsys/net/ip/route.c
+++ b/subsys/net/ip/route.c
@@ -805,8 +805,8 @@ static void propagate_mld_event(struct net_route_entry_mcast *route, bool route_
 	/* Apply only for complete addresses */
 	if (route->prefix_len == 128) {
 		mld_event.addr = &route->group;
-		mld_event.mode = route_added ? NET_IPV6_MLDv2_MODE_IS_EXCLUDE :
-					       NET_IPV6_MLDv2_MODE_IS_INCLUDE;
+		mld_event.mode = route_added ? NET_IPV6_MLDv2_CHANGE_TO_EXCLUDE_MODE :
+					       NET_IPV6_MLDv2_CHANGE_TO_INCLUDE_MODE;
 
 		net_if_foreach(send_mld_event, &mld_event);
 	}

--- a/tests/net/mld/src/main.c
+++ b/tests/net/mld/src/main.c
@@ -708,7 +708,7 @@ static void add_mcast_route_and_verify(struct net_if *iface, struct in6_addr *ad
 	zassert_ok(k_sem_take(&wait_data, K_MSEC(WAIT_TIME)), "Timeout while waiting for a report");
 
 	zassert_equal(info->records_count, 1, "Invalid number of reported addresses");
-	zassert_equal(info->records[0].record_type, NET_IPV6_MLDv2_MODE_IS_EXCLUDE,
+	zassert_equal(info->records[0].record_type, NET_IPV6_MLDv2_CHANGE_TO_EXCLUDE_MODE,
 		      "Invalid MLDv2 record type");
 	zassert_mem_equal(&info->records[0].mcast_addr, addr,
 			  sizeof(struct in6_addr), "Invalid reported address");
@@ -731,7 +731,7 @@ static void del_mcast_route_and_verify(struct net_if *iface, struct in6_addr *ad
 	zassert_ok(k_sem_take(&wait_data, K_MSEC(WAIT_TIME)), "Timeout while waiting for a report");
 
 	zassert_equal(info->records_count, 1, "Invalid number of reported addresses");
-	zassert_equal(info->records[0].record_type, NET_IPV6_MLDv2_MODE_IS_INCLUDE,
+	zassert_equal(info->records[0].record_type, NET_IPV6_MLDv2_CHANGE_TO_INCLUDE_MODE,
 		      "Invalid MLDv2 record type");
 	zassert_mem_equal(&info->records[0].mcast_addr, addr,
 			  sizeof(struct in6_addr), "Invalid reported address");


### PR DESCRIPTION
This PR introduces 3 commits:
1. Removal of unnecessary addition of unspecified IPv6 address to "sources" part
2. Change of mode codes in order to provide an actual information (transition vs current state)
3. Alignment of tests