### PR TITLE
include: linker: common-rom: Remove unused http_resource_desc section

### DIFF
--- a/include/zephyr/linker/common-rom/common-rom-net.ld
+++ b/include/zephyr/linker/common-rom/common-rom-net.ld
@@ -16,7 +16,6 @@
 
 #if defined(CONFIG_HTTP_SERVER)
 	ITERABLE_SECTION_ROM(http_service_desc, Z_LINK_ITERABLE_SUBALIGN)
-	ITERABLE_SECTION_ROM(http_resource_desc, Z_LINK_ITERABLE_SUBALIGN)
 #endif
 
 #if defined(CONFIG_COAP_SERVER)


### PR DESCRIPTION
HTTP resources are assigned a section for each service, so this iterable section isn't used.