### PR TITLE
drivers: ethernet: fix rx used bit not set when high bps ethernet dat…

### DIFF
--- a/drivers/ethernet/eth_xlnx_gem.c
+++ b/drivers/ethernet/eth_xlnx_gem.c
@@ -335,6 +335,10 @@ static void eth_xlnx_gem_isr(const struct device *dev)
 			      (buf_iter * (uint32_t)dev_conf->rx_buffer_size);
 			++bdptr;
 		}
+		bdptr->ctrl = 0; /* BD is owned by the controller */
+		bdptr->addr = ((uint32_t)dev_data->first_rx_buffer +
+		      (buf_iter * (uint32_t)dev_conf->rx_buffer_size)) |
+		      ETH_XLNX_GEM_RXBD_WRAP_BIT;
 		sys_write32(ETH_XLNX_GEM_IXR_RX_USED_BIT,
 			    dev_conf->base_addr + ETH_XLNX_GEM_IER_OFFSET);
 	}

--- a/drivers/ethernet/eth_xlnx_gem.c
+++ b/drivers/ethernet/eth_xlnx_gem.c
@@ -315,11 +315,12 @@ static void eth_xlnx_gem_isr(const struct device *dev)
 	/* DMA Rx buffer used bit not clear error handling */
 
 	if ((reg_val & ETH_XLNX_GEM_IXR_RX_USED_BIT) != 0x00000000U) {
-			reg_val =
-			sys_read32(dev_conf->base_addr +
+		sys_write32(ETH_XLNX_GEM_IXR_RX_USED_BIT,
+			dev_conf->base_addr + ETH_XLNX_GEM_IDR_OFFSET);
+		reg_val = sys_read32(dev_conf->base_addr +
 						ETH_XLNX_GEM_NWCTRL_OFFSET);
-			reg_val |= ETH_XLNX_GEM_NWCTRL_FLUSH_DPRAM_BIT;
-			sys_write32(reg_val, dev_conf->base_addr +
+		reg_val |= ETH_XLNX_GEM_NWCTRL_FLUSH_DPRAM_BIT;
+		sys_write32(reg_val, dev_conf->base_addr +
 						ETH_XLNX_GEM_NWCTRL_OFFSET);
 		struct eth_xlnx_gem_bd *bdptr;
 		uint32_t buf_iter;
@@ -332,6 +333,8 @@ static void eth_xlnx_gem_isr(const struct device *dev)
 			      (buf_iter * (uint32_t)dev_conf->rx_buffer_size);
 			++bdptr;
 		}
+		sys_write32(ETH_XLNX_GEM_IXR_RX_USED_BIT,
+			    dev_conf->base_addr + ETH_XLNX_GEM_IER_OFFSET);
 	}
 
 	/*

--- a/drivers/ethernet/eth_xlnx_gem.c
+++ b/drivers/ethernet/eth_xlnx_gem.c
@@ -317,6 +317,8 @@ static void eth_xlnx_gem_isr(const struct device *dev)
 	if ((reg_val & ETH_XLNX_GEM_IXR_RX_USED_BIT) != 0x00000000U) {
 		sys_write32(ETH_XLNX_GEM_IXR_RX_USED_BIT,
 			dev_conf->base_addr + ETH_XLNX_GEM_IDR_OFFSET);
+		sys_write32(ETH_XLNX_GEM_IXR_RX_USED_BIT,
+			dev_conf->base_addr + ETH_XLNX_GEM_ISR_OFFSET);
 		reg_val = sys_read32(dev_conf->base_addr +
 						ETH_XLNX_GEM_NWCTRL_OFFSET);
 		reg_val |= ETH_XLNX_GEM_NWCTRL_FLUSH_DPRAM_BIT;

--- a/drivers/ethernet/eth_xlnx_gem_priv.h
+++ b/drivers/ethernet/eth_xlnx_gem_priv.h
@@ -209,6 +209,7 @@
 
 /*
  * gem.net_ctrl:
+ * [18]		  Flush the next packet from the external RX DPRAM
  * [15]       Store 1588 receive timestamp in CRC field
  * [12]       Transmit zero quantum pause frame
  * [11]       Transmit pause frame
@@ -222,6 +223,7 @@
  * [02]       Enable receive
  * [01]       Local loopback mode
  */
+#define ETH_XLNX_GEM_NWCTRL_FLUSH_DPRAM_BIT		0x00040000
 #define ETH_XLNX_GEM_NWCTRL_RXTSTAMP_BIT		0x00008000
 #define ETH_XLNX_GEM_NWCTRL_ZEROPAUSETX_BIT		0x00001000
 #define ETH_XLNX_GEM_NWCTRL_PAUSETX_BIT			0x00000800


### PR DESCRIPTION
…a coming in and wrap dma buffer descriptor

recently, I am using zephyr with its Ethernet driver and running on ZynqMP RPU, however, when I doing throughput test I found when high data rate cause the rx dma buffer wrap arround, the rx isr pending handle will not clear the dma buffer.
This scenario can be fixed by flushing the the exist dma buffer packet and re-configure the dma rx buffer.