### PR TITLE
boards: st: nucleo_wba55cg: add 'zephyr,bt-c2h-uart'

### DIFF
--- a/boards/st/nucleo_wba55cg/nucleo_wba55cg.dts
+++ b/boards/st/nucleo_wba55cg/nucleo_wba55cg.dts
@@ -19,6 +19,7 @@
 	#size-cells = <1>;
 
 	chosen {
+		zephyr,bt-c2h-uart = &usart1;
 		zephyr,console = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;


### PR DESCRIPTION
Include `zephyr,bt-c2h-uart` in `chosen` node to make it possible to use HCI raw mode over UART. This was tested on real board with `hci_uart` sample, with Linux machine as a host (kernel 6.8, BlueZ 5.75).