### PR TITLE
twister: footprint: Add optional detailed JSON report on symbols

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -386,6 +386,18 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
              "using additional build option `--target footprint`.")
 
     footprint_group.add_argument(
+        "--footprint-report",
+        nargs="?",
+        default=None,
+        choices=['all', 'ROM', 'RAM'],
+        const="all",
+        help="Select which memory area symbols' data to collect as 'footprint' property "
+             "of each test suite built, and report in 'twister_footprint.json' together "
+             "with the relevant execution metadata the same way as in `twister.json`. "
+             "Implies '--create-rom-ram-report' to generate the footprint data files. "
+             "No value means '%(const)s'. Default: %(default)s""")
+
+    footprint_group.add_argument(
         "--enable-size-report",
         action="store_true",
         help="Collect and report ROM/RAM section sizes for each test image built.")
@@ -789,6 +801,9 @@ def parse_arguments(parser, args, options = None, on_init=True):
 
     if options.last_metrics or options.compare_report:
         options.enable_size_report = True
+
+    if options.footprint_report:
+        options.create_rom_ram_report = True
 
     if options.aggressive_no_clean:
         options.no_clean = True

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -764,6 +764,8 @@ class ProjectBuilder(FilterBuilder):
             'build.log',
             'device.log',
             'recording.csv',
+            'rom.json',
+            'ram.json',
             # below ones are needed to make --test-only work as well
             'Makefile',
             'CMakeCache.txt',


### PR DESCRIPTION
An alternative implementation to #72131 

New Twister option `--footprint-report` is introduced to collect and report detailed memory footprint results (for symbols) as an additional JSON file. By default, the new option is disabled.

The new option implies and extends `--create-rom-ram-report`, so currently there are three choices: 'ROM', 'RAM', and 'all' to select which memory areas data report additionally as `twister_footprint.json`.
In case of a custom report name, or per-platform report mode, it is always composed with the rightmost `_footprint.json` suffix.

The additional detailed JSON report has similar structure as `twister.json` and compelements it, also having a reduced set of the testsuite properties:
- instead of `testcases` list it contains `footprint` object with `rom.json` and `ram.json` artifacts embedded;
- other properites are limited to represent the context of the testsuite build execution, thus to allow further data processing consistently and independently from the `twister.json`;
- 'filtered' test instances are not included into the footprint report.