### PR TITLE
drivers: udc_dwc2: Submit reset after chirp sequence

### DIFF
--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -865,13 +865,13 @@ static void udc_dwc2_isr_handler(const struct device *dev)
 			sys_write32(USB_DWC2_GINTSTS_USBRST, gintsts_reg);
 			dwc2_on_bus_reset(dev);
 			LOG_DBG("USB Reset interrupt");
-			udc_submit_event(dev, UDC_EVT_RESET, 0);
 		}
 
 		if (int_status & USB_DWC2_GINTSTS_ENUMDONE) {
 			/* Clear and handle Enumeration Done interrupt. */
 			sys_write32(USB_DWC2_GINTSTS_ENUMDONE, gintsts_reg);
 			dwc2_handle_enumdone(dev);
+			udc_submit_event(dev, UDC_EVT_RESET, 0);
 		}
 
 		if (int_status & USB_DWC2_GINTSTS_USBSUSP) {


### PR DESCRIPTION
DWC USB 2.0 HS OTG Controller sets USB Reset interrupt after Reset signalling starts, but before the High-Speed Detection Handshake. This allows software to perform most of the reset handling even before the connection speed is known. The device controller indicates High-Speed Detection Handshake result is available in DSTS register by setting Enumeration Done interrupt.

USB stack expects that the connection speed is known immediately after UDC_EVT_RESET is submitted. Due to this expectation, it is important to submit UDC_EVT_RESET only after Enumeration Done interrupt to prevent the USB stack from reading (and storing) actual device speed before it is known.