### PR TITLE
scripts: fixed the code generator to obtain congruent parameter names

### DIFF
--- a/scripts/build/gen_syscalls.py
+++ b/scripts/build/gen_syscalls.py
@@ -113,13 +113,13 @@ extern "C" {{
 
 handler_template = """
 extern uintptr_t z_hdlr_%s(uintptr_t arg1, uintptr_t arg2, uintptr_t arg3,
-                uintptr_t arg4, uintptr_t arg5, uintptr_t arg6, void *ssf);
+                uintptr_t arg4, uintptr_t arg5, uintptr_t %s, void *ssf);
 """
 
 weak_template = """
 __weak ALIAS_OF(handler_no_syscall)
 uintptr_t %s(uintptr_t arg1, uintptr_t arg2, uintptr_t arg3,
-         uintptr_t arg4, uintptr_t arg5, uintptr_t arg6, void *ssf);
+         uintptr_t arg4, uintptr_t arg5, uintptr_t %s, void *ssf);
 """
 
 # defines a macro wrapper which supersedes the syscall when used
@@ -301,13 +301,13 @@ def wrapper_defs(func_name, func_type, args, fn):
 
     return wrap
 
-# Returns an expression for the specified (zero-indexed!) marshalled
-# parameter to a syscall, with handling for a final "more" parameter.
+# Returns an expression for the specified marshalled parameter
+# to a syscall, with handling for a final "more" parameter.
 def mrsh_rval(mrsh_num, total):
-    if mrsh_num < 5 or total <= 6:
+    if mrsh_num < 6 or total <= 6:
         return "arg%d" % mrsh_num
     else:
-        return "(((uintptr_t *)more)[%d])" % (mrsh_num - 5)
+        return "(((const uintptr_t *)more)[%d])" % (mrsh_num - 6)
 
 def marshall_defs(func_name, func_type, args):
     mrsh_name = "z_mrsh_" + func_name
@@ -326,30 +326,30 @@ def marshall_defs(func_name, func_type, args):
     decl_arglist = ", ".join([" ".join(argrec) for argrec in args])
     mrsh = "extern %s z_vrfy_%s(%s);\n" % (func_type, func_name, decl_arglist)
 
-    mrsh += "uintptr_t %s(uintptr_t arg0, uintptr_t arg1, uintptr_t arg2,\n" % mrsh_name
+    mrsh += "uintptr_t %s(uintptr_t arg1, uintptr_t arg2, uintptr_t arg3,\n" % mrsh_name
     if nmrsh <= 6:
-        mrsh += "\t\t" + "uintptr_t arg3, uintptr_t arg4, uintptr_t arg5, void *ssf)\n"
+        mrsh += "\t\t" + "uintptr_t arg4, uintptr_t arg5, uintptr_t arg6, void *ssf)\n"
     else:
-        mrsh += "\t\t" + "uintptr_t arg3, uintptr_t arg4, void *more, void *ssf)\n"
+        mrsh += "\t\t" + "uintptr_t arg4, uintptr_t arg5, uintptr_t more, void *ssf)\n"
     mrsh += "{\n"
     mrsh += "\t" + "_current->syscall_frame = ssf;\n"
 
-    for unused_arg in range(nmrsh, 6):
+    for unused_arg in range(nmrsh + 1, 7):
         mrsh += "\t(void) arg%d;\t/* unused */\n" % unused_arg
 
     if nmrsh > 6:
-        mrsh += ("\tK_OOPS(K_SYSCALL_MEMORY_READ(more, "
+        mrsh += ("\tK_OOPS(K_SYSCALL_MEMORY_READ((const uintptr_t *)more, "
                  + str(nmrsh - 5) + " * sizeof(uintptr_t)));\n")
 
     argnum = 0
     for i, (argtype, split) in enumerate(vrfy_parms):
         mrsh += "\t%s parm%d;\n" % (union_decl(argtype, split), i)
         if split:
-            mrsh += "\t" + "parm%d.split.lo = %s;\n" % (i, mrsh_rval(argnum, nmrsh))
+            mrsh += "\t" + "parm%d.split.lo = %s;\n" % (i + 1, mrsh_rval(argnum, nmrsh))
             argnum += 1
-            mrsh += "\t" + "parm%d.split.hi = %s;\n" % (i, mrsh_rval(argnum, nmrsh))
+            mrsh += "\t" + "parm%d.split.hi = %s;\n" % (i + 1, mrsh_rval(argnum, nmrsh))
         else:
-            mrsh += "\t" + "parm%d.x = %s;\n" % (i, mrsh_rval(argnum, nmrsh))
+            mrsh += "\t" + "parm%d.x = %s;\n" % (i + 1, mrsh_rval(argnum, nmrsh))
         argnum += 1
 
     # Finally, invoke the verify function
@@ -364,7 +364,7 @@ def marshall_defs(func_name, func_type, args):
         mrsh += "\t" + "%s ret = %s;\n" % (func_type, vrfy_call)
 
         if need_split(func_type):
-            ptr = "((uint64_t *)%s)" % mrsh_rval(nmrsh - 1, nmrsh)
+            ptr = "((uint64_t *)%s)" % mrsh_rval(nmrsh, nmrsh)
             mrsh += "\t" + "K_OOPS(K_SYSCALL_MEMORY_WRITE(%s, 8));\n" % ptr
             mrsh += "\t" + "*%s = ret;\n" % ptr
             mrsh += "\t" + "_current->syscall_frame = NULL;\n"
@@ -375,7 +375,7 @@ def marshall_defs(func_name, func_type, args):
 
     mrsh += "}\n"
 
-    return mrsh, mrsh_name
+    return mrsh, mrsh_name, nmrsh
 
 def analyze_fn(match_group, fn):
     func, args = match_group
@@ -394,13 +394,13 @@ def analyze_fn(match_group, fn):
     sys_id = "K_SYSCALL_" + func_name.upper()
 
     marshaller = None
-    marshaller, handler = marshall_defs(func_name, func_type, args)
+    marshaller, handler, nmrsh = marshall_defs(func_name, func_type, args)
     invocation = wrapper_defs(func_name, func_type, args, fn)
 
     # Entry in _k_syscall_table
     table_entry = "[%s] = %s" % (sys_id, handler)
 
-    return (handler, invocation, marshaller, sys_id, table_entry)
+    return (handler, invocation, marshaller, sys_id, table_entry, nmrsh)
 
 def parse_args():
     global args
@@ -446,9 +446,10 @@ def main():
     handlers = []
     emit_list = []
     exported = []
+    arg_numbers = []
 
     for match_group, fn, to_emit in syscalls:
-        handler, inv, mrsh, sys_id, entry = analyze_fn(match_group, fn)
+        handler, inv, mrsh, sys_id, entry, nmrsh = analyze_fn(match_group, fn)
 
         if fn not in invocations:
             invocations[fn] = []
@@ -461,6 +462,7 @@ def main():
             table_entries.append(entry)
             emit_list.append(handler)
             exported.append(handler.replace("z_mrsh_", "z_impl_"))
+            arg_numbers.append(nmrsh)
         else:
             ids_not_emit.append(sys_id)
 
@@ -472,8 +474,9 @@ def main():
     with open(args.syscall_dispatch, "w") as fp:
         table_entries.append("[K_SYSCALL_BAD] = handler_bad_syscall")
 
-        weak_defines = "".join([weak_template % name
-                                for name in handlers
+        weak_defines = "".join([weak_template % (name,
+                                "arg6" if nmrsh <= 6 else "more")
+                                for (name, nmrsh) in zip(handlers, arg_numbers)
                                 if not name in noweak and name in emit_list])
 
         # The "noweak" ones just get a regular declaration


### PR DESCRIPTION
fixed the code generator to obtain congruent parameter names

This corresponds to following misra coding guideline:

> All declarations of an object or function shall use the same names and type qualifiers

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

original Commits:
https://github.com/zephyrproject-rtos/zephyr/commit/7b6cdcbed7706a69b11b87af9a560848916e7056
https://github.com/zephyrproject-rtos/zephyr/commit/878d4338bb71ea506ec05d7caabbf7c4bc49fa20