### PR TITLE
arch: ensure redeclarations use the same parameter names

### DIFF
--- a/arch/x86/core/ia32/fatal.c
+++ b/arch/x86/core/ia32/fatal.c
@@ -42,18 +42,18 @@ void z_x86_spurious_irq(const z_arch_esf_t *esf)
 }
 
 __pinned_func
-void arch_syscall_oops(void *ssf)
+void arch_syscall_oops(void *ssf_ptr)
 {
-	struct _x86_syscall_stack_frame *ssf_ptr =
-		(struct _x86_syscall_stack_frame *)ssf;
+	struct _x86_syscall_stack_frame *ssf =
+		(struct _x86_syscall_stack_frame *)ssf_ptr;
 	z_arch_esf_t oops = {
-		.eip = ssf_ptr->eip,
-		.cs = ssf_ptr->cs,
-		.eflags = ssf_ptr->eflags
+		.eip = ssf->eip,
+		.cs = ssf->cs,
+		.eflags = ssf->eflags
 	};
 
 	if (oops.cs == USER_CODE_SEG) {
-		oops.esp = ssf_ptr->esp;
+		oops.esp = ssf->esp;
 	}
 
 	z_x86_fatal_error(K_ERR_KERNEL_OOPS, &oops);

--- a/arch/x86/core/intel64/irq.c
+++ b/arch/x86/core/intel64/irq.c
@@ -17,7 +17,7 @@
 
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
-unsigned char _irq_to_interrupt_vector[CONFIG_MAX_IRQ_LINES];
+uint8_t _irq_to_interrupt_vector[CONFIG_MAX_IRQ_LINES];
 #define NR_IRQ_VECTORS (IV_NR_VECTORS - IV_IRQS)  /* # vectors free for IRQs */
 
 void (*x86_irq_funcs[NR_IRQ_VECTORS])(const void *arg);
@@ -100,8 +100,8 @@ void z_x86_irq_connect_on_vector(unsigned int irq,
  */
 
 int arch_irq_connect_dynamic(unsigned int irq, unsigned int priority,
-			     void (*func)(const void *arg),
-			     const void *arg, uint32_t flags)
+		     void (*routine)(const void *parameter),
+			     const void *parameter, uint32_t flags)
 {
 	uint32_t key;
 	int vector;
@@ -124,7 +124,7 @@ int arch_irq_connect_dynamic(unsigned int irq, unsigned int priority,
 #endif /* CONFIG_INTEL_VTD_ICTL */
 
 		z_irq_controller_irq_config(vector, irq, flags);
-		z_x86_irq_connect_on_vector(irq, vector, func, arg);
+		z_x86_irq_connect_on_vector(irq, (uint8_t)vector, routine, parameter, flags);
 	}
 
 	irq_unlock(key);

--- a/include/zephyr/arch/x86/arch.h
+++ b/include/zephyr/arch/x86/arch.h
@@ -216,7 +216,7 @@ static ALWAYS_INLINE int sys_test_and_clear_bit(mem_addr_t addr,
  * at build time and defined via the linker script. On Intel64, it's an array.
  */
 
-extern unsigned char _irq_to_interrupt_vector[];
+extern uint8_t _irq_to_interrupt_vector[CONFIG_MAX_IRQ_LINES];
 
 #define Z_IRQ_TO_INTERRUPT_VECTOR(irq) \
 	((unsigned int) _irq_to_interrupt_vector[irq])


### PR DESCRIPTION
used the same parameter names in every redeclaration

This corresponds to following misra coding guideline:

> All declarations of an object or function shall use the same names and type qualifiers

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

original Commit:
https://github.com/zephyrproject-rtos/zephyr/commit/bdc5f2c7da9b13e042e8ec729f67ccc54e10195a