### PR TITLE
drivers: udc_dwc2: handle interrupt IEPINT before the RXFLVL

### DIFF
--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -888,14 +888,14 @@ static void udc_dwc2_isr_handler(const struct device *dev)
 			udc_submit_event(dev, UDC_EVT_RESUME, 0);
 		}
 
-		if (int_status & USB_DWC2_GINTSTS_RXFLVL) {
-			/* Handle RxFIFO Non-Empty interrupt */
-			dwc2_handle_rxflvl(dev);
-		}
-
 		if (int_status & USB_DWC2_GINTSTS_IEPINT) {
 			/* Handle IN Endpoints interrupt */
 			dwc2_handle_iepint(dev);
+		}
+
+		if (int_status & USB_DWC2_GINTSTS_RXFLVL) {
+			/* Handle RxFIFO Non-Empty interrupt */
+			dwc2_handle_rxflvl(dev);
 		}
 
 		if (int_status & USB_DWC2_GINTSTS_OEPINT) {


### PR DESCRIPTION
There could be a situation where both flags are set at the same time, for example we could observe it on a high speed bus processing control request with data stage to host. Handling the RXFLVL interrupt first will result in an incorrect event sequence and a "Cannot determine the next stage" error.