### PR TITLE
drivers: nxp_pit: check if top cb is null

### DIFF
--- a/drivers/counter/counter_nxp_pit.c
+++ b/drivers/counter/counter_nxp_pit.c
@@ -187,7 +187,9 @@ static void nxp_pit_isr(const struct device *dev)
 	flags = PIT_GetStatusFlags(config->base, channel);
 	if (flags) {
 		PIT_ClearStatusFlags(config->base, channel, flags);
-		data->top_callback(dev, data->top_user_data);
+		if (data->top_callback) {
+			data->top_callback(dev, data->top_user_data);
+		}
 	}
 }
 #endif /* DT_NODE_HAS_PROP(DT_COMPAT_GET_ANY_STATUS_OKAY(nxp_pit), interrupts) */


### PR DESCRIPTION
check if top cb is null to avoid hard fault
top cb is allowed to be null in api so this is required

Fixes #72080 