### PR TITLE
cmake: Add kconfig options to set compiler warning groups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,24 +377,24 @@ zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:$<TARGET_PROPERTY:compiler-cpp,
 
 # ==========================================================================
 #
-# cmake -DW=... settings
+# cmake -DW=... or COMPILER_WARNINGS_GROUP Kconfig options
 #
 # W=1 - warnings that may be relevant and does not occur too often
 # W=2 - warnings that occur quite often but may still be relevant
 # W=3 - the more obscure warnings, can most likely be ignored
 # ==========================================================================
-# @Intent: Add cmake -DW toolchain supported warnings, if any
-if(W MATCHES "1")
+# @Intent: Add cmake -DW or Kconfig toolchain supported warnings, if any
+if(W MATCHES "1" OR CONFIG_COMPILER_WARNINGS_GROUP1)
   zephyr_compile_options($<$<COMPILE_LANGUAGE:C>:$<TARGET_PROPERTY:compiler,warning_dw_1>>)
   zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:$<TARGET_PROPERTY:compiler-cpp,warning_dw_1>>)
 endif()
 
-if(W MATCHES "2")
+if(W MATCHES "2" OR CONFIG_COMPILER_WARNINGS_GROUP2)
   zephyr_compile_options($<$<COMPILE_LANGUAGE:C>:$<TARGET_PROPERTY:compiler,warning_dw_2>>)
   zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:$<TARGET_PROPERTY:compiler-cpp,warning_dw_2>>)
 endif()
 
-if(W MATCHES "3")
+if(W MATCHES "3" OR CONFIG_COMPILER_WARNINGS_GROUP3)
   zephyr_compile_options($<$<COMPILE_LANGUAGE:C>:$<TARGET_PROPERTY:compiler,warning_dw_3>>)
   zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:$<TARGET_PROPERTY:compiler-cpp,warning_dw_3>>)
 endif()

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -521,10 +521,34 @@ config LTO
 	help
 	  This option enables Link Time Optimization.
 
+menu "Warning options"
+
 config COMPILER_WARNINGS_AS_ERRORS
 	bool "Treat warnings as errors"
 	help
 	  Turn on "warning as error" toolchain flags
+
+config COMPILER_WARNINGS_GROUP1
+	bool "Warnings group 1"
+	help
+	  Enable compiler warnings group 1, similar to passing -W=1 to CMake.
+	  For warnings that may be relevant and does not occur too often.
+
+config COMPILER_WARNINGS_GROUP2
+	bool "Warnings group 2"
+	imply COMPILER_WARNINGS_GROUP1
+	help
+	  Enable compiler warnings group 2, similar to passing -W=2 to CMake.
+	  For warnings that occur quite often but may still be relevant.
+
+config COMPILER_WARNINGS_GROUP3
+	bool "Warnings group 3"
+	imply COMPILER_WARNINGS_GROUP2
+	help
+	  Enable compiler warnings group 3, similar to passing -W=3 to CMake.
+	  For the more obscure warnings, can most likely be ignored.
+
+endmenu
 
 config COMPILER_SAVE_TEMPS
 	bool "Save temporary object files"


### PR DESCRIPTION
Allow users/projects to enable compiler warning groups from the project instead of passing it to build commands.

Ref #72488