### PR TITLE
doc: modbus: Update docs to work with latest PyModbus

### DIFF
--- a/samples/subsys/modbus/rtu_server/README.rst
+++ b/samples/subsys/modbus/rtu_server/README.rst
@@ -150,4 +150,4 @@ To read holding registers use FC03 command (read_holding_registers).
    }
 
 .. _`joy-it RS-485 shield for Arduino`: https://joy-it.net/en/products/ARD-RS485
-.. _`PyModbus`: https://github.com/riptideio/pymodbus
+.. _`PyModbus`: https://github.com/pymodbus-dev/pymodbus

--- a/samples/subsys/modbus/rtu_server/README.rst
+++ b/samples/subsys/modbus/rtu_server/README.rst
@@ -85,7 +85,7 @@ For example, to set LED0 on use FC01 command (write_coil).
 
 .. code-block:: console
 
-   > client.write_coil address=0 value=1 unit=1
+   > client.write_coil address=0 value=1 slave=1
 
 Client should confirm successful communication and LED0 should light.
 
@@ -100,13 +100,13 @@ To set LED0 off but LED1 and LED2 on use FC15 command (write_coils).
 
 .. code-block:: console
 
-   > client.write_coils address=0 values=0,1,1 unit=1
+   > client.write_coils address=0 values=0,1,1 slave=1
 
 To read LED0, LED1, LED2 state FC05 command (read_coils) can be used.
 
 .. code-block:: console
 
-   > client.read_coils address=0 count=3 unit=1
+   > client.read_coils address=0 count=3 slave=1
    {
        "bits": [
            false,
@@ -128,19 +128,19 @@ To write single holding registers use FC06 command (write_register),
 
 .. code-block:: console
 
-   > client.write_register address=0 value=42 unit=1
+   > client.write_register address=0 value=42 slave=1
 
 or FC16 command (write_registers).
 
 .. code-block:: console
 
-   > client.write_registers address=0 values=42,42,42 unit=1
+   > client.write_registers address=0 values=42,42,42 slave=1
 
 To read holding registers use FC03 command (read_holding_registers).
 
 .. code-block:: console
 
-   > client.read_holding_registers address=0 count=3 unit=1
+   > client.read_holding_registers address=0 count=3 slave=1
    {
        "registers": [
            42,

--- a/samples/subsys/modbus/tcp_gateway/README.rst
+++ b/samples/subsys/modbus/tcp_gateway/README.rst
@@ -54,7 +54,7 @@ For example, to set LED0 on use FC01 command (write_coil).
 .. code-block:: console
 
    > client.connect
-   > client.write_coil address=0 value=1 unit=1
+   > client.write_coil address=0 value=1 slave=1
 
 Client should confirm successful communication and LED0 should light.
 
@@ -69,13 +69,13 @@ To set LED0 off but LED1 and LED2 on use FC15 command (write_coils).
 
 .. code-block:: console
 
-   > client.write_coils address=0 values=0,1,1 unit=1
+   > client.write_coils address=0 values=0,1,1 slave=1
 
 To read LED0, LED1, LED2 state FC05 command (read_coils) can be used.
 
 .. code-block:: console
 
-   > client.read_coils address=0 count=3 unit=1
+   > client.read_coils address=0 count=3 slave=1
    {
        "bits": [
            false,
@@ -97,19 +97,19 @@ To write single holding registers use FC06 command (write_register),
 
 .. code-block:: console
 
-   > client.write_register address=0 value=42 unit=1
+   > client.write_register address=0 value=42 slave=1
 
 or FC16 command (write_registers).
 
 .. code-block:: console
 
-   > client.write_registers address=0 values=42,42,42 unit=1
+   > client.write_registers address=0 values=42,42,42 slave=1
 
 To read holding registers use FC03 command (read_holding_registers).
 
 .. code-block:: console
 
-   > client.read_holding_registers address=0 count=3 unit=1
+   > client.read_holding_registers address=0 count=3 slave=1
    {
        "registers": [
            42,

--- a/samples/subsys/modbus/tcp_gateway/README.rst
+++ b/samples/subsys/modbus/tcp_gateway/README.rst
@@ -118,4 +118,4 @@ To read holding registers use FC03 command (read_holding_registers).
        ]
    }
 
-.. _`PyModbus`: https://github.com/riptideio/pymodbus
+.. _`PyModbus`: https://github.com/pymodbus-dev/pymodbus

--- a/samples/subsys/modbus/tcp_server/README.rst
+++ b/samples/subsys/modbus/tcp_server/README.rst
@@ -50,7 +50,7 @@ For example, to set LED0 on use FC01 command (write_coil).
 .. code-block:: console
 
    > client.connect
-   > client.write_coil address=0 value=1 unit=1
+   > client.write_coil address=0 value=1 slave=1
 
 Client should confirm successful communication and LED0 should light.
 
@@ -65,13 +65,13 @@ To set LED0 off but LED1 and LED2 on use FC15 command (write_coils).
 
 .. code-block:: console
 
-   > client.write_coils address=0 values=0,1,1 unit=1
+   > client.write_coils address=0 values=0,1,1 slave=1
 
 To read LED0, LED1, LED2 state FC05 command (read_coils) can be used.
 
 .. code-block:: console
 
-   > client.read_coils address=0 count=3 unit=1
+   > client.read_coils address=0 count=3 slave=1
    {
        "bits": [
            false,
@@ -93,19 +93,19 @@ To write single holding registers use FC06 command (write_register),
 
 .. code-block:: console
 
-   > client.write_register address=0 value=42 unit=1
+   > client.write_register address=0 value=42 slave=1
 
 or FC16 command (write_registers).
 
 .. code-block:: console
 
-   > client.write_registers address=0 values=42,42,42 unit=1
+   > client.write_registers address=0 values=42,42,42 slave=1
 
 To read holding registers use FC03 command (read_holding_registers).
 
 .. code-block:: console
 
-   > client.read_holding_registers address=0 count=3 unit=1
+   > client.read_holding_registers address=0 count=3 slave=1
    {
        "registers": [
            42,

--- a/samples/subsys/modbus/tcp_server/README.rst
+++ b/samples/subsys/modbus/tcp_server/README.rst
@@ -114,4 +114,4 @@ To read holding registers use FC03 command (read_holding_registers).
        ]
    }
 
-.. _`PyModbus`: https://github.com/riptideio/pymodbus
+.. _`PyModbus`: https://github.com/pymodbus-dev/pymodbus


### PR DESCRIPTION
The [PyModbus](https://github.com/pymodbus-dev/pymodbus) project changed the `unit=` parameter to `slave=` in the
v3.3.0 release (see https://pymodbus.readthedocs.io/en/latest/source/api_changes.html#api-changes-3-3-0)

As a result, the examples in the docs end up being interpreted incorrectly as broadcast messages on newer versions of PyModbus:

```
> client.write_coil address=0 value=1 unit=1
{
    "message": "Broadcast message, ignoring errors!!!"
}
```

This PR changes all instances of the `unit=` parameter in the docs to `slave=` which results in the correct responses:

```
> client.write_coil address=0 value=1 slave=1
{
    "address": 0,
    "value": true
}
```

This PR also updates the PyModbus GitHub project URL.