### PR TITLE
boards: nxp: mimxrt1010: Fix alignment instruction on FlexSPI

### DIFF
--- a/boards/nxp/mimxrt1010_evk/init.c
+++ b/boards/nxp/mimxrt1010_evk/init.c
@@ -7,7 +7,7 @@
 
 void SystemInitHook(void)
 {
-#if DT_SAME_NODE(DT_NODELABEL(flexspi), DT_PARENT(DT_CHOSEN(flash)))
+#if CONFIG_FLASH_MCUX_FLEXSPI_XIP
 	/* AT25SF128A SPI Flash on the RT1010-EVK requires special alignment
 	 * considerations, so set the READADDROPT bit in the FlexSPI so it
 	 * will fetch more data than each AHB burst requires to meet alignment


### PR DESCRIPTION
### Description
Instruction not getting executed since #69264 (HWMv2 Porting).

This fixes `tests/drivers/i2c/i2c_ram` when built with `CONFIG_I2C_RTIO=y`. Which was failing due to strange alignment issues upon initialization, which matches with the descritption of `SystemInitHook()`:
> Without this, the FlexSPI will return corrupted data during early boot, causing a hardfault. This can also be resolved by enabling the instruction cache in very early boot.