### PR TITLE
boards: nxp: Fix usage of DT_CHOSEN() macro to get chosen Zephyr Flash

### DIFF
--- a/boards/nxp/mimxrt1010_evk/init.c
+++ b/boards/nxp/mimxrt1010_evk/init.c
@@ -7,7 +7,7 @@
 
 void SystemInitHook(void)
 {
-#if DT_SAME_NODE(DT_NODELABEL(flexspi), DT_PARENT(DT_CHOSEN(flash)))
+#if DT_SAME_NODE(DT_NODELABEL(flexspi), DT_PARENT(DT_CHOSEN(zephyr_flash)))
 	/* AT25SF128A SPI Flash on the RT1010-EVK requires special alignment
 	 * considerations, so set the READADDROPT bit in the FlexSPI so it
 	 * will fetch more data than each AHB burst requires to meet alignment

--- a/soc/nxp/imxrt/imxrt10xx/lpm_rt1064.c
+++ b/soc/nxp/imxrt/imxrt10xx/lpm_rt1064.c
@@ -117,7 +117,7 @@ static void clock_init_usb1_pll(const clock_usb_pll_config_t *config)
 
 static void flexspi_enter_critical(void)
 {
-#if DT_SAME_NODE(DT_NODELABEL(flexspi2), DT_PARENT(DT_CHOSEN(flash)))
+#if DT_SAME_NODE(DT_NODELABEL(flexspi2), DT_PARENT(DT_CHOSEN(zephyr_flash)))
 	/* Wait for flexspi to be inactive, and gate the clock */
 	while (!((FLEXSPI2->STS0 & FLEXSPI_STS0_ARBIDLE_MASK) &&
 			(FLEXSPI2->STS0 & FLEXSPI_STS0_SEQIDLE_MASK))) {
@@ -128,7 +128,7 @@ static void flexspi_enter_critical(void)
 	CCM->CCGR7 &= (~CCM_CCGR7_CG1_MASK);
 #endif
 
-#if DT_SAME_NODE(DT_NODELABEL(flexspi), DT_PARENT(DT_CHOSEN(flash)))
+#if DT_SAME_NODE(DT_NODELABEL(flexspi), DT_PARENT(DT_CHOSEN(zephyr_flash)))
 	/* Wait for flexspi to be inactive, and gate the clock */
 	while (!((FLEXSPI->STS0 & FLEXSPI_STS0_ARBIDLE_MASK) &&
 			(FLEXSPI->STS0 & FLEXSPI_STS0_SEQIDLE_MASK))) {
@@ -142,7 +142,7 @@ static void flexspi_enter_critical(void)
 
 static void flexspi_exit_critical(void)
 {
-#if DT_SAME_NODE(DT_NODELABEL(flexspi2), DT_PARENT(DT_CHOSEN(flash)))
+#if DT_SAME_NODE(DT_NODELABEL(flexspi2), DT_PARENT(DT_CHOSEN(zephyr_flash)))
 	/* Enable clock gate of flexspi2. */
 	CCM->CCGR7 |= (CCM_CCGR7_CG1_MASK);
 
@@ -153,7 +153,7 @@ static void flexspi_exit_critical(void)
 	while (!((FLEXSPI2->STS0 & FLEXSPI_STS0_ARBIDLE_MASK) &&
 		(FLEXSPI2->STS0 & FLEXSPI_STS0_SEQIDLE_MASK))) {
 	}
-#elif DT_SAME_NODE(DT_NODELABEL(flexspi), DT_PARENT(DT_CHOSEN(flash)))
+#elif DT_SAME_NODE(DT_NODELABEL(flexspi), DT_PARENT(DT_CHOSEN(zephyr_flash)))
 	/* Enable clock of flexspi. */
 	CCM->CCGR6 |= CCM_CCGR6_CG5_MASK;
 
@@ -211,11 +211,11 @@ void clock_full_power(void)
 #endif
 
 	/* Set Flexspi divider before increasing frequency of PLL3 PDF0. */
-#if DT_SAME_NODE(DT_NODELABEL(flexspi), DT_PARENT(DT_CHOSEN(flash)))
+#if DT_SAME_NODE(DT_NODELABEL(flexspi), DT_PARENT(DT_CHOSEN(zephyr_flash)))
 	clock_set_div(kCLOCK_FlexspiDiv, flexspi_div);
 	clock_set_mux(kCLOCK_FlexspiMux, 3);
 #endif
-#if DT_SAME_NODE(DT_NODELABEL(flexspi2), DT_PARENT(DT_CHOSEN(flash)))
+#if DT_SAME_NODE(DT_NODELABEL(flexspi2), DT_PARENT(DT_CHOSEN(zephyr_flash)))
 	clock_set_div(kCLOCK_Flexspi2Div, flexspi_div);
 	clock_set_mux(kCLOCK_Flexspi2Mux, 1);
 #endif
@@ -258,12 +258,12 @@ void clock_low_power(void)
 	CCM_ANALOG->PLL_USB1_SET = CCM_ANALOG_PLL_USB1_ENABLE_MASK;
 	CCM_ANALOG->PFD_480_CLR = CCM_ANALOG_PFD_480_PFD0_CLKGATE_MASK;
 	/* Change flexspi to use PLL3 PFD0 with no divisor (24M flexspi clock) */
-#if DT_SAME_NODE(DT_NODELABEL(flexspi), DT_PARENT(DT_CHOSEN(flash)))
+#if DT_SAME_NODE(DT_NODELABEL(flexspi), DT_PARENT(DT_CHOSEN(zephyr_flash)))
 	clock_set_div(kCLOCK_FlexspiDiv, 0);
 	/* FLEXSPI1 mux to PLL3 PFD0 BYPASS */
 	clock_set_mux(kCLOCK_FlexspiMux, 3);
 #endif
-#if DT_SAME_NODE(DT_NODELABEL(flexspi2), DT_PARENT(DT_CHOSEN(flash)))
+#if DT_SAME_NODE(DT_NODELABEL(flexspi2), DT_PARENT(DT_CHOSEN(zephyr_flash)))
 	clock_set_div(kCLOCK_Flexspi2Div, 0);
 	/* FLEXSPI2 mux to PLL3 PFD0 BYPASS */
 	clock_set_mux(kCLOCK_Flexspi2Mux, 1);

--- a/soc/nxp/imxrt/imxrt11xx/soc.c
+++ b/soc/nxp/imxrt/imxrt11xx/soc.c
@@ -527,7 +527,7 @@ static ALWAYS_INLINE void clock_init(void)
 #endif
 #endif
 
-#if !(DT_NODE_HAS_COMPAT(DT_CHOSEN(flash), nxp_imx_flexspi)) && \
+#if !(DT_NODE_HAS_COMPAT(DT_CHOSEN(zephyr_flash), nxp_imx_flexspi)) && \
 	defined(CONFIG_MEMC_MCUX_FLEXSPI) && \
 	DT_NODE_HAS_STATUS(DT_NODELABEL(flexspi), okay)
 	/* Configure FLEXSPI1 using OSC_RC_48M_DIV2 */


### PR DESCRIPTION
### Description
Used multiple places in the tree. The idea is to determine if this node's parent corresponds to a specific node (e.g: flexspi) so that specific configurations can get done. Without the fix, the macro expansions were defaulting to false.

This fixes an issue I was facing at boot (unalignment fault) on `tests/drivers/i2c/i2c_ram` with `CONFIG_I2C_RTIO=y` on `mimxrt1010_evk`, which matches the description of `mimxrt1010_evk/init.c`:

> AT25SF128A SPI Flash on the RT1010-EVK requires special alignment considerations, so set the READADDROPT bit in the FlexSPI so it will fetch more data than each AHB burst requires to meet alignment requirements.

> Without this, the FlexSPI will return corrupted data during early boot, causing a hardfault. This can also be resolved by enabling the instruction cache in very early boot.