### PR TITLE
soc: nrf54h: use word accesses to SPI_DW peripheral

### DIFF
--- a/soc/nordic/nrf54h/Kconfig.defconfig
+++ b/soc/nordic/nrf54h/Kconfig.defconfig
@@ -36,4 +36,7 @@ endif # RISCV
 config SPI_DW_HSSI
 	default y if SPI_DW
 
+config SPI_DW_ACCESS_WORD_ONLY
+	default y if SPI_DW
+
 endif # SOC_SERIES_NRF54HX


### PR DESCRIPTION
The nRF54H20 EXMIF peripheral requires word accesses. Doing accesses of byte or half-word sizes results in bus fault.