### PR TITLE
twister: Set default coverage platform only when needed

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -782,7 +782,7 @@ def parse_arguments(parser, args, options = None):
     if options.coverage:
         options.enable_coverage = True
 
-    if not options.coverage_platform:
+    if options.enable_coverage and not options.coverage_platform:
         options.coverage_platform = options.platform
 
     if options.coverage_formats:

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -387,8 +387,6 @@ class TestPlan:
             print(" - {}".format(test))
         print("{} total.".format(cnt))
 
-    def config(self):
-        logger.info("coverage platform: {}".format(self.coverage_platform))
 
     # Debug Functions
     @staticmethod

--- a/scripts/tests/twister/test_testplan.py
+++ b/scripts/tests/twister/test_testplan.py
@@ -1058,15 +1058,6 @@ def test_testplan_report_test_list(capfd):
            '10 total.' in out
 
 
-def test_testplan_config(caplog):
-    testplan = TestPlan(env=mock.Mock())
-    testplan.coverage_platform = 'dummy cov'
-
-    testplan.config()
-
-    assert 'coverage platform: dummy cov' in caplog.text
-
-
 def test_testplan_info(capfd):
     TestPlan.info('dummy text')
 


### PR DESCRIPTION
Set `options.coverage_platform` only when running coverage; code cleanup.

Noticed with #72399 that `coverage_platform` was always set to non-default values.