### PR TITLE
tests: test_mcuboot: update test pattern for upgrade mode

### DIFF
--- a/tests/boot/test_mcuboot/testcase.yaml
+++ b/tests/boot/test_mcuboot/testcase.yaml
@@ -7,7 +7,7 @@ common:
       - "I: Starting bootloader"
       - "Launching primary slot application on (.*)"
       - "Secondary application ready for swap, rebooting"
-      - "I: Starting swap using (.*)"
+      - "I: Starting swap using (.*)|I: Image 0 upgrade secondary slot -> primary slot"
       - "Swapped application booted on (.*)"
 tests:
   bootloader.mcuboot:


### PR DESCRIPTION
NXP LPC series flash only supoort upgrade mode, so change the pattern to match this mode

below is the lpcxpresso55s28 log

```
*** Booting MCUboot v2.1.0-rc1-1-gd4394c2f9b76 ***
*** Using Zephyr OS build v3.6.0-3587-g5f9a9ed098d3 ***
I: Starting bootloader
I: Image index: 0, Swap type: none
I: Bootloader chainload address offset: 0x8000
I: Jumping to the first image slot
*** Booting Zephyr OS build v3.6.0-3587-g5f9a9ed098d3 ***
Swapped application booted on lpcxpresso55s28
E*** Booting MCUboot v2.1.0-rc1-1-gd4394c2f9b76 ***
*** Using Zephyr OS build v3.6.0-3587-g5f9a9ed098d3 ***
I: Starting bootloader
I: Image index: 0, Swap type: none
I: Bootloader chainload address offset: 0x8000
I: Jumping to the first image slot
*** Booting Zephyr OS build v3.6.0-3587-g5f9a9ed098d3 ***
Swapped application booted on lpcxpresso55s28
KIK*** Booting MCUboot v2.1.0-rc1-1-gd4394c2f9b76 ***
*** Using Zephyr OS build v3.6.0-3587-g5f9a9ed098d3 ***
I: Starting bootloader
I: Image index: 0, Swap type: none
I: Bootloader chainload address offset: 0x8000
I: Jumping to the first image slot
*** Booting Zephyr OS build v3.6.0-3587-g5f9a9ed098d3 ***
Launching primary slot application on lpcxpresso55s28
Secondary application ready for swap, rebooting*** Booting MCUboot v2.1.0-rc1-1-gd4394c2f9b76 ***
*** Using Zephyr OS build v3.6.0-3587-g5f9a9ed098d3 ***
I: Starting bootloader
I: Image index: 0, Swap type: perm
I: Image 0 upgrade secondary slot -> primary slot
I: Erasing the primary slot
I: Image 0 copying the secondary slot to the primary slot: 0x4400 bytes
I: Bootloader chainload address offset: 0x8000
I: Jumping to the first image slot
*** Booting Zephyr OS build v3.6.0-3587-g5f9a9ed098d3 ***
Swapped application booted on lpcxpresso55s28
```