### PR TITLE
CI: Fix coverage reporting.

### DIFF
--- a/scripts/ci/coverage/coverage_analysis.py
+++ b/scripts/ci/coverage/coverage_analysis.py
@@ -69,7 +69,8 @@ class Json_report:
                                     break
                             sub_component_name = testcase_name[testcase_name.find('.'):]
                             sub_component_name = sub_component_name[1:]
-                            sub_component_name = sub_component_name[:sub_component_name.find(".")]
+                            if sub_component_name.find(".") > 0:
+                                sub_component_name = sub_component_name[:sub_component_name.find(".")]
                             if known_component_flag is False:
 
                                 sub_component = {


### PR DESCRIPTION
The fix applies to parse_testplan function.
There was a bug while parsing testcase identifier.

For e.g. 
testcase identifier: `bootloader.mcuboot.assert`
testcase identifier: `bootloader.mcuboot`
[component].[sub_component]


Results before fix.
![image](https://github.com/zephyrproject-rtos/zephyr/assets/122030181/3c229806-fbb6-4148-b518-8ba9a2235511)
As it shows, the `mcuboot` was shortened by the last letter because of that line.
```
sub_component_name = sub_component_name[:sub_component_name.find(".")]
```
Because if the `find` function doesn't find the dot, it returns `-1`.
My solution to that problem is to verify if a dot exists in the string before cutting.
```
if sub_component_name.find(".") > 0:
      sub_component_name = sub_component_name[:sub_component_name.find(".")]
```
Results after fix.
![image](https://github.com/zephyrproject-rtos/zephyr/assets/122030181/2b9a746e-2b16-4217-a393-d0c41f1ab4b0)
