### PR TITLE
board: mimxrt1160_evk: linkserver support

### DIFF
--- a/boards/nxp/mimxrt1160_evk/board.cmake
+++ b/boards/nxp/mimxrt1160_evk/board.cmake
@@ -7,6 +7,7 @@
 if(CONFIG_SOC_MIMXRT1166_CM7 OR CONFIG_SECOND_CORE_MCUX)
 board_runner_args(pyocd "--target=mimxrt1160_cm7")
 board_runner_args(jlink "--device=MIMXRT1166xxx6_M7" "--reset-after-load")
+board_runner_args(linkserver  "--device=MIMXRT1166xxxxx:MIMXRT1160-EVK")
 elseif(CONFIG_SOC_MIMXRT1166_CM4)
 board_runner_args(pyocd "--target=mimxrt1160_cm4")
 # Note: Please use JLINK above V7.50 (Only support run cm4 image when debugging due to default boot core on board is cm7 core)
@@ -14,4 +15,5 @@ board_runner_args(jlink "--device=MIMXRT1166xxx6_M4")
 endif()
 
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/linkserver.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/nxp/mimxrt1160_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1160_evk/doc/index.rst
@@ -267,10 +267,8 @@ however the :ref:`pyocd-debug-host-tools` do not yet support programming the
 external flashes on this board so you must reconfigure the board for one of the
 following debug probes instead.
 
-.. _Using J-Link RT1160:
-
 Using J-Link
----------------------------------
+------------
 
 Install the :ref:`jlink-debug-host-tools` and make sure they are in your search
 path.
@@ -278,6 +276,16 @@ path.
 There are two options: the onboard debug circuit can be updated with Segger
 J-Link firmware, or :ref:`jlink-external-debug-probe` can be attached to the
 EVK. See `Using J-Link with MIMXRT1160-EVK or MIMXRT1170-EVK`_ for more details.
+
+Using LinkServer
+----------------
+
+Install the :ref:`linkserver-debug-host-tools` and make sure they are in your
+search path.  LinkServer works with the default CMSIS-DAP firmware included in
+the on-board debugger.
+
+Linkserver is the default runner. You may also se the ``-r linkserver`` option
+with West to use the LinkServer runner.
 
 Configuring a Console
 =====================


### PR DESCRIPTION
add linkserver support for mimxrt1160_evk

as when I run `pyocd list -t`, there is no mimxrt1160_evk support

```
 mimxrt1010                NXP                      MIMXRT1011xxxxx                         builtin  
  mimxrt1015                NXP                      MIMXRT1015xxxxx                         builtin  
  mimxrt1020                NXP                      MIMXRT1021xxxxx                         builtin  
  mimxrt1024                NXP                      MIMXRT1024xxxxx                         builtin  
  mimxrt1050                NXP                      MIMXRT1052xxxxB_hyperflash              builtin  
  mimxrt1050_hyperflash     NXP                      MIMXRT1052xxxxB_hyperflash              builtin  
  mimxrt1050_quadspi        NXP                      MIMXRT1052xxxxB_quadspi                 builtin  
  mimxrt1060                NXP                      MIMXRT1062xxxxA                         builtin  
  mimxrt1064                NXP                      MIMXRT1064xxxxA                         builtin  
  mimxrt1170_cm4            NXP                      MIMXRT1176xxxxx_CM4                     builtin  
  mimxrt1170_cm7            NXP                      MIMXRT1176xxxxx_CM7                     builtin  
```

for pyocd need install a cmsis-dap pack to support