### PR TITLE
driver: watchdog: npcx: support longer watchdog timeout

### DIFF
--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -286,6 +286,16 @@ regulator
   has been removed, users should remove this property from their devicetree if it is present.
   (:github:`70642`)
 
+Watchdog
+========
+
+* The ``nuvoton,npcx-watchdog`` driver has been changed to extend the max timeout period.
+  The time of one watchdog count varies with the different pre-scalar settings.
+  Removed :kconfig:option:`CONFIG_WDT_NPCX_DELAY_CYCLES` because it is no longer suitable to
+  set the leading warning time.
+  Instead, added the :kconfig:option:`CONFIG_WDT_NPCX_WARNING_LEADING_TIME_MS` to set
+  the leading warning time in milliseconds.
+
 Bluetooth
 *********
 

--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -265,6 +265,11 @@ Drivers and Sensors
 
 * W1
 
+* Watchdog
+
+  * Added :kconfig:option:`CONFIG_WDT_NPCX_WARNING_LEADING_TIME_MS` to set the leading warning time
+    in milliseconds. Removed no longer used :kconfig:option:`CONFIG_WDT_NPCX_DELAY_CYCLES`.
+
 * Wi-Fi
 
   * Added support for configuring RTS threshold. With this, users can set the RTS threshold value or

--- a/drivers/watchdog/Kconfig.npcx
+++ b/drivers/watchdog/Kconfig.npcx
@@ -12,12 +12,11 @@ config WDT_NPCX
 	  processors.
 	  Say y if you wish to use watchdog on NPCX MCU.
 
-config WDT_NPCX_DELAY_CYCLES
-	int "Number of delay cycles before generating watchdog event/signal"
+config WDT_NPCX_WARNING_LEADING_TIME_MS
+	int "Milliseconds before generating watchdog event/signal"
 	depends on WDT_NPCX
-	range 1 255
-	default 10
+	default 500
 	help
 	  This option defines the window in which a watchdog event must be
-	  handled, in units of 31ms. After this time window, the watchdog reset
-	  triggers immediately.
+	  handled. After this time window, the watchdog reset triggers
+	  immediately.


### PR DESCRIPTION
In the current driver, the longest time of the watchdog timeout is ~8 seconds because the pre-scalar is fixed at 32 (WDCP=5).
This commit removes this limitation by dynamically calculating the pre-scalar according to the watchdog timeout setting from the API.