### PR TITLE
drivers: nsos: fcntl: prefer Zephyr-specific macros over libc

### DIFF
--- a/drivers/net/nsos_fcntl.c
+++ b/drivers/net/nsos_fcntl.c
@@ -16,7 +16,14 @@
  * symbols.
  */
 
+/*
+ * When building for Zephyr, use Zephyr specific fcntl definitions.
+ */
+#ifdef __ZEPHYR__
+#include <zephyr/posix/fcntl.h>
+#else
 #include <fcntl.h>
+#endif
 
 #include "nsos_errno.h"
 #include "nsos_fcntl.h"


### PR DESCRIPTION
Definitions of fcntl flags are different between native libc and Zephyr. In
order to correctly map those values to the host, include Zephyr's `fcntl.h`
header, instead of the one bundled with libc.