### PR TITLE
doc: releases: Enforce linking to Pull Requests in migration guide

### DIFF
--- a/doc/releases/index.rst
+++ b/doc/releases/index.rst
@@ -103,6 +103,10 @@ in the migration guide. This includes:
 - Anything else that can affect the compilation or runtime behavior of an
   existing application
 
+Each entry in the migration guide must include a brief explanation of the change
+as well as refer to the Pull Request that introduced it, in order for the user
+to be able to understand the context of the change.
+
 .. toctree::
    :maxdepth: 1
    :glob:

--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -20,7 +20,7 @@ Build System
 
 * Completely overhauled the way SoCs and boards are defined. This requires all
   out-of-tree SoCs and boards to be ported to the new model. See the
-  :ref:`hw_model_v2` for more detailed information.
+  :ref:`hw_model_v2` for more detailed information. (:github:`69607`)
 
 Kernel
 ******
@@ -29,12 +29,12 @@ Boards
 ******
 
 * Reordered D1 and D0 in the `pro_micro` connector gpio-map for SparkFun Pro Micro RP2040 to match
-  original Pro Micro definition. Out-of-tree shields must be updated to reflect this change.
+  original Pro Micro definition. Out-of-tree shields must be updated to reflect this change. (:github:`69994`)
 * ITE: Rename all SoC variant Kconfig options, e.g., ``CONFIG_SOC_IT82202_AX`` is renamed to
   ``CONFIG_SOC_IT82202AX``.
   All symbols are renamed as follows: ``SOC_IT81202BX``, ``SOC_IT81202CX``, ``SOC_IT81302BX``,
   ``SOC_IT81302CX``, ``SOC_IT82002AW``, ``SOC_IT82202AX``, ``SOC_IT82302AX``.
-  And, rename the ``SOC_SERIES_ITE_IT8XXX2`` to ``SOC_SERIES_IT8XXX2``.
+  And, rename the ``SOC_SERIES_ITE_IT8XXX2`` to ``SOC_SERIES_IT8XXX2``. (:github:`71680`)
 
 Modules
 *******
@@ -54,7 +54,7 @@ Device Drivers and Devicetree
   compatible :dtcompatible:`nxp,pit-channel` and configure as below.
   The :kconfig:option:`CONFIG_COUNTER_MCUX_PIT` has also been renamed to
   :kconfig:option:`CONFIG_COUNTER_NXP_PIT` with regards to the renaming
-  of the binding for the pit.
+  of the binding for the pit. (:github:`66336`)
   example:
 
   .. code-block:: devicetree
@@ -81,8 +81,8 @@ Device Drivers and Devicetree
   in DT, which also comes with a different version driver. Alternatively,
   the Ethernet node can be deleted and redefined as the old binding to use
   the deprecated legacy driver. The primary advantage of the new binding
-  is to be able to abstract an arbitrary phy through the mdio API. Example
-  of a basic board level ENET DT definition:
+  is to be able to abstract an arbitrary phy through the mdio API. (:github:`70400`)
+  Example of a basic board level ENET DT definition:
 
   .. code-block:: devicetree
 
@@ -106,7 +106,7 @@ Device Drivers and Devicetree
         };
     };
 
-* Some of the driver API structs have been rename to have the required ``_driver_api`` suffix.
+* Some of the driver API structs have been rename to have the required ``_driver_api`` suffix. (:github:`72182`)
   The following types have been renamed:
 
   * ``emul_sensor_backend_api`` to :c:struct:`emul_sensor_driver_api`
@@ -114,8 +114,8 @@ Device Drivers and Devicetree
   * ``usbc_ppc_drv`` to :c:struct:`usbc_ppc_driver_api`
 
 * The driver for :dtcompatible:`maxim,max31790` got split up into a MFD and an
-  actual PWM driver. Previously, an instance of this device could have been
-  defined like this:
+  actual PWM driver. (:github:`68433`)
+  Previously, an instance of this device could have been defined like this:
 
   .. code-block:: devicetree
 
@@ -154,10 +154,10 @@ Charger
 =======
 
 * Dropped ``constant-charge-current-max-microamp`` property in ``charger_max20335`` driver because
-  it did not reflect real chip functionality.
+  it did not reflect real chip functionality. (:github:`69910`)
 
 * Added enum key to ``constant-charge-voltage-max-microvolt`` property in ``maxim,max20335-charger``
-  binding to indicate invalid devicetree values at build time.
+  binding to indicate invalid devicetree values at build time. (:github:`69910`)
 
 Controller Area Network (CAN)
 =============================
@@ -175,7 +175,9 @@ Controller Area Network (CAN)
   * ``phase-seg1-data``
   * ``phase-seg1-data``
 
-* Support for manual bus-off recovery was reworked:
+  (:github:`68714`)
+
+* Support for manual bus-off recovery was reworked (:github:`69460`):
 
   * Automatic bus recovery will always be enabled upon driver initialization regardless of Kconfig
     options. Since CAN controllers are initialized in "stopped" state, no unwanted bus-off recovery
@@ -198,14 +200,15 @@ Display
 
 Enhanced Serial Peripheral Interface (eSPI)
 ===========================================
-  * The macros ``ESPI_SLAVE_TO_MASTER`` and ``ESPI_MASTER_TO_SLAVE`` were renamed to
-    ``ESPI_TARGET_TO_CONTROLLER`` and ``ESPI_CONTROLLER_TO_TARGET`` respectively to reflect
-    the new terminology in eSPI 1.5 specification.
-  * The enum values ``ESPI_VWIRE_SIGNAL_SLV_BOOT_STS``, ``ESPI_VWIRE_SIGNAL_SLV_BOOT_DONE`` and
-    all ``ESPI_VWIRE_SIGNAL_SLV_GPIO_<NUMBER>`` signals were renamed to
-    ``ESPI_VWIRE_SIGNAL_TARGET_BOOT_STS``, ``ESPI_VWIRE_SIGNAL_TARGET_BOOT_DONE`` and
-    ``ESPI_VWIRE_SIGNAL_TARGET_GPIO_<NUMBER>`` respectively to reflect the new terminology
-    in eSPI 1.5 specification.
+
+* The macros ``ESPI_SLAVE_TO_MASTER`` and ``ESPI_MASTER_TO_SLAVE`` were renamed to
+  ``ESPI_TARGET_TO_CONTROLLER`` and ``ESPI_CONTROLLER_TO_TARGET`` respectively to reflect
+  the new terminology in eSPI 1.5 specification.
+  The enum values ``ESPI_VWIRE_SIGNAL_SLV_BOOT_STS``, ``ESPI_VWIRE_SIGNAL_SLV_BOOT_DONE`` and
+  all ``ESPI_VWIRE_SIGNAL_SLV_GPIO_<NUMBER>`` signals were renamed to
+  ``ESPI_VWIRE_SIGNAL_TARGET_BOOT_STS``, ``ESPI_VWIRE_SIGNAL_TARGET_BOOT_DONE`` and
+  ``ESPI_VWIRE_SIGNAL_TARGET_GPIO_<NUMBER>`` respectively to reflect the new terminology
+  in eSPI 1.5 specification. (:github:`68492`)
 
 Flash
 =====
@@ -219,7 +222,7 @@ GNSS
 * Basic power management support has been added to the ``gnss-nmea-generic`` driver.
   If ``CONFIG_PM_DEVICE=y`` the driver is now initialized in suspended mode and the
   application needs to call :c:func:`pm_device_action_run` with :c:macro:`PM_DEVICE_ACTION_RESUME`
-  to start up the driver.
+  to start up the driver. (:github:`71774`)
 
 Input
 =====
@@ -228,11 +231,11 @@ Input
   relative to the raw ADC values, similarly to min and max. The data structures
   and properties have been renamed to reflect that (from ``out-deadzone`` to
   ``in-deadzone``) and when migrating to the new definition the value should be
-  scaled accordingly.
+  scaled accordingly. (:github:`70377`)
 
 * The ``holtek,ht16k33-keyscan`` driver has been converted to use the
   :ref:`input` subsystem, callbacks have to be migrated to use the input APIs,
-  :dtcompatible:`zephyr,kscan-input` can be used for backward compatibility.
+  :dtcompatible:`zephyr,kscan-input` can be used for backward compatibility. (:github:`69875`)
 
 Interrupt Controller
 ====================
@@ -241,7 +244,7 @@ LED Strip
 =========
 
 * The property ``in-gpios`` defined in :dtcompatible:`worldsemi,ws2812-gpio` has been
-  renamed to ``gpios``.
+  renamed to ``gpios``. (:github:`68514`)
 
 Sensors
 =======
@@ -266,10 +269,10 @@ Bluetooth Mesh
 * The model metadata pointer declaration of :c:struct:`bt_mesh_model` has been changed
   to a single ``const *`` and redundant metadata pointer from :c:struct:`bt_mesh_health_srv`
   is removed. Consequently, :code:`BT_MESH_MODEL_HEALTH_SRV` definition is changed
-  to use variable argument notation. (:github:`71281`). Now, when your implementation
+  to use variable argument notation. Now, when your implementation
   supports :kconfig:option:`CONFIG_BT_MESH_LARGE_COMP_DATA_SRV` and when you need to
   specify metadata for Health Server model, simply pass metadata as the last argument
-  to the :code:`BT_MESH_MODEL_HEALTH_SRV` macro, otherwise omit the last argument.
+  to the :code:`BT_MESH_MODEL_HEALTH_SRV` macro, otherwise omit the last argument. (:github:`71281`)
 
 Bluetooth Audio
 ===============
@@ -318,8 +321,7 @@ Networking
 
 * The zperf zperf_results struct is changed to support 64 bits transferred bytes (total_len)
   and test duration (time_in_us and client_time_in_us), instead of 32 bits. This will make
-  the long-duration zperf test show with correct throughput result.
-  (:github:`69500`)
+  the long-duration zperf test show with correct throughput result. (:github:`69500`)
 
 * Each IPv4 address assigned to a network interface has an IPv4 netmask
   tied to it instead of being set for the whole interface.
@@ -359,10 +361,9 @@ Other Subsystems
 hawkBit
 =======
 
-  * :kconfig:option:`CONFIG_HAWKBIT_PORT` is now an int instead of a string.
-
-  * :kconfig:option:`CONFIG_SETTINGS` needs to be enabled to use hawkBit, as it now uses the
-    settings subsystem to store the hawkBit configuration.
+* :kconfig:option:`CONFIG_HAWKBIT_PORT` is now an int instead of a string.
+  :kconfig:option:`CONFIG_SETTINGS` needs to be enabled to use hawkBit, as it now uses the
+  settings subsystem to store the hawkBit configuration. (:github:`68806`)
 
 LoRaWAN
 =======
@@ -374,7 +375,7 @@ Modem
 =====
 
 * The ``CONFIG_MODEM_CHAT_LOG_BUFFER`` Kconfig option was
-  renamed to :kconfig:option:`MODEM_CHAT_LOG_BUFFER_SIZE`.
+  renamed to :kconfig:option:`CONFIG_MODEM_CHAT_LOG_BUFFER_SIZE`. (:github:`70405`)
 
 Shell
 =====
@@ -396,19 +397,19 @@ Userspace
 Architectures
 *************
 
-* Function :c:func:`arch_start_cpu` has been renamed to :c:func:`arch_cpu_start`.
+* Function :c:func:`arch_start_cpu` has been renamed to :c:func:`arch_cpu_start`. (:github:`64987`)
 
 * x86
 
   * Kconfigs ``CONFIG_DISABLE_SSBD`` and ``CONFIG_ENABLE_EXTENDED_IBRS``
     are deprecated. Use :kconfig:option:`CONFIG_X86_DISABLE_SSBD` and
-    :kconfig:option:`CONFIG_X86_ENABLE_EXTENDED_IBRS` instead.
+    :kconfig:option:`CONFIG_X86_ENABLE_EXTENDED_IBRS` instead. (:github:`69690`)
 
 * POSIX arch:
 
   * LLVM fuzzing support has been refactored. A test application now needs to provide its own
     ``LLVMFuzzerTestOneInput()`` hook instead of relying on a board provided one. Check
-    ``samples/subsys/debug/fuzz/`` for an example.
+    ``samples/subsys/debug/fuzz/`` for an example. (:github:`71378`)
 
 Xtensa
 ======


### PR DESCRIPTION
    In order to provide additional context and information to Zephyr users,
    ensure that each entry in the migration guide contains a link to the
    GitHub Pull Request that introduced the corresponding change.