### PR TITLE
Bluetooth: BAP: Remove err from recv_state_removed callback

### DIFF
--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -73,6 +73,12 @@ Architectures
 
 Bluetooth
 *********
+* Audio
+
+  * Removed ``err`` from :c:struct:`bt_bap_broadcast_assistant_cb.recv_state_removed` as it was
+    redundant.
+
+* Host
 
   * Added Nordic UART Service (NUS), enabled by the :kconfig:option:`CONFIG_BT_ZEPHYR_NUS`.
     This Service exposes the ability to declare multiple instances of the GATT service,

--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -2101,11 +2101,9 @@ struct bt_bap_broadcast_assistant_cb {
 	 * @brief Callback function for when a receive state is removed.
 	 *
 	 * @param conn     The connection to the Broadcast Audio Scan Service server.
-	 * @param err      Error value. 0 on success, GATT error on fail.
 	 * @param src_id   The receive state.
 	 */
-	void (*recv_state_removed)(struct bt_conn *conn, int err,
-				   uint8_t src_id);
+	void (*recv_state_removed)(struct bt_conn *conn, uint8_t src_id);
 
 	/**
 	 * @brief Callback function for bt_bap_broadcast_assistant_scan_start().

--- a/subsys/bluetooth/audio/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/bap_broadcast_assistant.c
@@ -118,15 +118,14 @@ static void bap_broadcast_assistant_recv_state_changed(
 	}
 }
 
-static void bap_broadcast_assistant_recv_state_removed(struct bt_conn *conn, int err,
-						       uint8_t src_id)
+static void bap_broadcast_assistant_recv_state_removed(struct bt_conn *conn, uint8_t src_id)
 {
 	struct bt_bap_broadcast_assistant_cb *listener, *next;
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&broadcast_assistant_cbs,
 					  listener, next, _node) {
 		if (listener->recv_state_removed) {
-			listener->recv_state_removed(conn, err, src_id);
+			listener->recv_state_removed(conn, src_id);
 		}
 	}
 }
@@ -442,8 +441,8 @@ static uint8_t notify_handler(struct bt_conn *conn,
 		}
 	} else {
 		broadcast_assistant.recv_states[index].past_avail = false;
-		bap_broadcast_assistant_recv_state_removed(conn, 0,
-					broadcast_assistant.recv_states[index].src_id);
+		bap_broadcast_assistant_recv_state_removed(
+			conn, broadcast_assistant.recv_states[index].src_id);
 	}
 
 	return BT_GATT_ITER_CONTINUE;

--- a/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
@@ -215,16 +215,9 @@ static void bap_broadcast_assistant_recv_state_cb(
 	}
 }
 
-static void bap_broadcast_assistant_recv_state_removed_cb(struct bt_conn *conn,
-							  int err,
-							  uint8_t src_id)
+static void bap_broadcast_assistant_recv_state_removed_cb(struct bt_conn *conn, uint8_t src_id)
 {
-	if (err != 0) {
-		shell_error(ctx_shell, "BASS recv state removed failed (%d)",
-			    err);
-	} else {
-		shell_print(ctx_shell, "BASS recv state %u removed", src_id);
-	}
+	shell_print(ctx_shell, "BASS recv state %u removed", src_id);
 }
 
 static void bap_broadcast_assistant_scan_start_cb(struct bt_conn *conn, int err)

--- a/tests/bluetooth/tester/src/btp_bap_broadcast.c
+++ b/tests/bluetooth/tester/src/btp_bap_broadcast.c
@@ -1266,10 +1266,9 @@ static void bap_broadcast_assistant_recv_state_cb(struct bt_conn *conn, int err,
 	btp_send_broadcast_receive_state_ev(conn, state);
 }
 
-static void bap_broadcast_assistant_recv_state_removed_cb(struct bt_conn *conn, int err,
-							  uint8_t src_id)
+static void bap_broadcast_assistant_recv_state_removed_cb(struct bt_conn *conn, uint8_t src_id)
 {
-	LOG_DBG("err: %d", err);
+	LOG_DBG("");
 }
 
 static void bap_broadcast_assistant_scan_start_cb(struct bt_conn *conn, int err)

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_assistant_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_assistant_test.c
@@ -155,14 +155,8 @@ static void bap_broadcast_assistant_recv_state_cb(
 	SET_FLAG(flag_recv_state_updated);
 }
 
-static void bap_broadcast_assistant_recv_state_removed_cb(struct bt_conn *conn, int err,
-					      uint8_t src_id)
+static void bap_broadcast_assistant_recv_state_removed_cb(struct bt_conn *conn, uint8_t src_id)
 {
-	if (err != 0) {
-		FAIL("BASS recv state removed failed (%d)\n", err);
-		return;
-	}
-
 	printk("BASS recv state %u removed\n", src_id);
 	SET_FLAG(flag_cb_called);
 


### PR DESCRIPTION
The callback is only ever called when we received a notification from the BASS server that the receive state is removed, which cannot contain an error code.
Thus it does not make sense for the callback to have an error code.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/69527