### PR TITLE
doc: scripts: devicetree_rest: normalize binding URLs

### DIFF
--- a/doc/_scripts/gen_devicetree_rest.py
+++ b/doc/_scripts/gen_devicetree_rest.py
@@ -797,8 +797,10 @@ def binding_filename(binding):
         raise ValueError(f'binding path has no {dts_bindings}: {binding.path}')
 
     # Cut past dts/bindings, strip off the extension (.yaml or .yml), and
-    # replace with .rst.
-    return os.path.splitext(as_posix[idx + len(dts_bindings):])[0] + '.rst'
+    # replace with .rst, and convert vendor separator ',' to '_'.
+    return (
+        os.path.splitext(as_posix[idx + len(dts_bindings):])[0] + '.rst'
+    ).replace(",", "_")
 
 def binding_ref_target(binding):
     # Return the sphinx ':ref:' target name for a binding.


### PR DESCRIPTION
Most bindings contain a ',' (vendor separator), but since it is a reserved character for URLs, we end up having it converted to '%2C', e.g.

```
.../serial/altr%2Cjtag-uart.html
               ^^^
```

This patch converts it to '_', so that we won't have escaped characters in the URLs, e.g.

```
.../serial/altr_jtag-uart.html
```