### PR TITLE
samples: drivers: spi_flash: Add nRF54H20DK support

### DIFF
--- a/samples/drivers/spi_flash/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/drivers/spi_flash/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&mx25uw63 {
+	status = "okay";
+};
+
+
+/ {
+	aliases {
+		spi-flash0 = &mx25uw63;
+	};
+};


### PR DESCRIPTION
Verified on nRF54H20DK, useful for testing external flash access.