### PR TITLE
bluetooth: host: conn: Fix assertion failure in wait_for_tx_work

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -383,17 +383,12 @@ static void wait_for_tx_work(struct bt_conn *conn)
 #if defined(CONFIG_BT_CONN_TX)
 	LOG_DBG("conn %p", conn);
 
-	if (IS_ENABLED(CONFIG_BT_RECV_WORKQ_SYS)) {
+	if (IS_ENABLED(CONFIG_BT_RECV_WORKQ_SYS) ||
+	    k_current_get() == k_work_queue_thread_get(&k_sys_work_q)) {
 		tx_notify(conn);
 	} else {
 		struct k_work_sync sync;
 		int err;
-
-		/* API docs mention undefined behavior if syncing on work item
-		 * from wq execution context.
-		 */
-		__ASSERT_NO_MSG(k_current_get() !=
-				k_work_queue_thread_get(&k_sys_work_q));
 
 		err = k_work_submit(&conn->tx_complete_work);
 		__ASSERT(err >= 0, "couldn't submit (err %d)", err);


### PR DESCRIPTION
Calling bt_disable in system workqueue context while BLE connected may lead to calling wait_for_tx_work in this context. Fix check in code to avoid assertion failure.