### PR TITLE
Fixes small typo in log_backend_fs.c

### DIFF
--- a/subsys/logging/backends/log_backend_fs.c
+++ b/subsys/logging/backends/log_backend_fs.c
@@ -35,7 +35,7 @@ static int get_log_file_id(struct fs_dirent *ent);
 static uint32_t log_format_current = CONFIG_LOG_BACKEND_FS_OUTPUT_DEFAULT;
 #endif
 
-static int check_log_volumen_available(void)
+static int check_log_volume_available(void)
 {
 	int index = 0;
 	char const *name;
@@ -152,7 +152,7 @@ int write_log_to_file(uint8_t *data, size_t length, void *ctx)
 	struct fs_file_t *f = &fs_file;
 
 	if (backend_state == BACKEND_FS_NOT_INITIALIZED) {
-		if (check_log_volumen_available()) {
+		if (check_log_volume_available()) {
 			return length;
 		}
 		rc = create_log_dir(CONFIG_LOG_BACKEND_FS_DIR);


### PR DESCRIPTION
Came across what seemed to be a typo in log_backend_fs.c and just wanted to push a fix. 