### PR TITLE
west: Regex based version finding in OpenOCD runner

### DIFF
--- a/scripts/west_commands/runners/intel_cyclonev.py
+++ b/scripts/west_commands/runners/intel_cyclonev.py
@@ -194,13 +194,14 @@ class IntelCycloneVBinaryRunner(ZephyrBinaryRunner):
         out = self.check_output([self.openocd_cmd[0], '--version'],
                                 stderr=subprocess.STDOUT).decode()
 
-        return out.split('\n')[0]
+        version_match = re.search(r"Open On-Chip Debugger (\d+.\d+.\d+)", out)
+        version = version_match.group(1).split('.')
+
+        return [self.to_num(i) for i in version]
 
     def supports_thread_info(self):
         # Zephyr rtos was introduced after 0.11.0
-        version_str = self.read_version().split(' ')[3]
-        version = version_str.split('.')
-        (major, minor, rev) = [self.to_num(i) for i in version]
+        (major, minor, rev) = self.read_version()
         return (major, minor, rev) > (0, 11, 0)
 
     def do_run(self, command, **kwargs):

--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -203,13 +203,14 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
         out = self.check_output([self.openocd_cmd[0], '--version'],
                                 stderr=subprocess.STDOUT).decode()
 
-        return out.split('\n')[0]
+        version_match = re.search(r"Open On-Chip Debugger (\d+.\d+.\d+)", out)
+        version = version_match.group(1).split('.')
+
+        return [self.to_num(i) for i in version]
 
     def supports_thread_info(self):
         # Zephyr rtos was introduced after 0.11.0
-        version_str = self.read_version().split(' ')[3]
-        version = version_str.split('.')
-        (major, minor, rev) = [self.to_num(i) for i in version]
+        (major, minor, rev) = self.read_version()
         return (major, minor, rev) > (0, 11, 0)
 
     def do_run(self, command, **kwargs):


### PR DESCRIPTION
Previous OpenOCD version finding would fail when additional tokens were prepended to the 'openocd --version' output, as happens with some third- party OpenOCD repackages (xPack for one).

Fixes: #71955