### PR TITLE
drivers: memc: memc_mcux_flexspi: Fix support for multi-device mode

### DIFF
--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -52,8 +52,10 @@ enum {
 	READ_STATUS_REG,
 	ERASE_CHIP,
 	READ_JESD216,
+	/* Entries after this should be for scratch commands */
+	FLEXSPI_INSTR_PROG_END,
 	/* Used for temporary commands during initialization */
-	SCRATCH_CMD,
+	SCRATCH_CMD = FLEXSPI_INSTR_PROG_END,
 	SCRATCH_CMD2,
 	/* Must be last entry */
 	FLEXSPI_INSTR_END,
@@ -1014,7 +1016,7 @@ _program_lut:
 	 */
 	ret = memc_flexspi_set_device_config(&data->controller, &data->config,
 					(uint32_t *)flexspi_lut,
-					FLEXSPI_INSTR_END * MEMC_FLEXSPI_CMD_PER_SEQ,
+					FLEXSPI_INSTR_PROG_END * MEMC_FLEXSPI_CMD_PER_SEQ,
 					data->port);
 	if (ret < 0) {
 		return ret;

--- a/drivers/memc/Kconfig.mcux
+++ b/drivers/memc/Kconfig.mcux
@@ -40,6 +40,16 @@ config MEMC_MCUX_FLEXSPI_INIT_PRIORITY
 	  MEMC_MCUX_FLEXSPI_INIT_PRIORITY < FLASH_INIT_PRIORITY <
 	  MEMC_INIT_PRIORITY
 
+config MEMC_MCUX_FLEXSPI_INIT_XIP
+	bool "Initialize FLEXSPI when using device for XIP"
+	help
+	  Initialize the FLEXSPI device even when using it for XIP. If this
+	  Kconfig is enabled, the user must ensure that the pin control
+	  state used does not reconfigure the pins used to interface with
+	  the flash device used for XIP, and that the configuration settings
+	  used for the FLEXSPI are compatible with those needed for XIP from
+	  the flash device.
+
 config MEMC_MCUX_FLEXSPI
 	bool
 	select PINCTRL

--- a/drivers/memc/Kconfig.mcux
+++ b/drivers/memc/Kconfig.mcux
@@ -30,6 +30,16 @@ config MEMC_MCUX_FLEXSPI_IS66WVQ8M4
 	depends on DT_HAS_NXP_IMX_FLEXSPI_IS66WVQ8M4_ENABLED
 	select MEMC_MCUX_FLEXSPI
 
+config MEMC_MCUX_FLEXSPI_INIT_PRIORITY
+	int "MCUX FLEXSPI MEMC driver initialization priority"
+	default MEMC_INIT_PRIORITY
+	help
+	  Initialization priority for FlexSPI MEMC driver. In cases where the
+	  flash driver must initialize before the MEMC RAM driver,
+	  initialization priorities can be set such that
+	  MEMC_MCUX_FLEXSPI_INIT_PRIORITY < FLASH_INIT_PRIORITY <
+	  MEMC_INIT_PRIORITY
+
 config MEMC_MCUX_FLEXSPI
 	bool
 	select PINCTRL

--- a/drivers/memc/memc_mcux_flexspi.c
+++ b/drivers/memc/memc_mcux_flexspi.c
@@ -424,7 +424,7 @@ static int memc_flexspi_pm_action(const struct device *dev, enum pm_device_actio
 			      &memc_flexspi_data_##n,			\
 			      NULL,					\
 			      POST_KERNEL,				\
-			      CONFIG_MEMC_INIT_PRIORITY,	\
+			      CONFIG_MEMC_MCUX_FLEXSPI_INIT_PRIORITY,	\
 			      NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(MEMC_FLEXSPI)

--- a/drivers/memc/memc_mcux_flexspi.h
+++ b/drivers/memc/memc_mcux_flexspi.h
@@ -57,7 +57,7 @@ int memc_flexspi_update_clock(const struct device *dev,
  * @param dev: FlexSPI device
  * @param device_config: External device configuration.
  * @param lut_array: Lookup table of FlexSPI flash commands for device
- * @param lut_count: number of command entries (16 bytes each) in LUT
+ * @param lut_count: number of LUT entries (4 bytes each) in lut array
  * @param port: FlexSPI port to use for this external device
  * @return 0 on success, negative value on failure
  */

--- a/drivers/memc/memc_mcux_flexspi_is66wvq8m4.c
+++ b/drivers/memc/memc_mcux_flexspi_is66wvq8m4.c
@@ -169,8 +169,6 @@ static int memc_flexspi_is66wvq8m4_init(const struct device *dev)
 		return -EINVAL;
 	}
 
-	memc_flexspi_reset(data->controller);
-
 	if (memc_flexspi_is66wvq8m4_get_vendor_id(dev, &vendor_id)) {
 		LOG_ERR("Could not read vendor id");
 		return -EIO;

--- a/samples/drivers/memc/boards/rd_rw612_bga.conf
+++ b/samples/drivers/memc/boards/rd_rw612_bga.conf
@@ -1,5 +1,22 @@
 # Copyright 2023 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-# RW is configured to execute from code ram, so use rom loader to load image
-CONFIG_NXP_RW_ROM_RAMLOADER=y
+# In order to safely access the PSRAM on port B of the RW FlexSPI peripheral,
+# the QSPI flash on port A must be configured by the application. Otherwise,
+# the PSRAM configuration will overwrite the LUT entries for the QSPI flash,
+# and the application will no longer be able to XIP from the flash.
+# To make sure the QSPI flash is configured, enable flash drivers.
+CONFIG_FLASH=y
+
+# Initialization priorities are critical here. The FlexSPI MEMC driver must
+# initialize first. Then, the QSPI flash driver must initialize to program
+# the LUT table for port A. Finally, the PSRAM driver can initialize and
+# program the LUT table for port B
+CONFIG_MEMC_MCUX_FLEXSPI_INIT_PRIORITY=0
+CONFIG_FLASH_INIT_PRIORITY=50
+CONFIG_MEMC_INIT_PRIORITY=60
+
+# This board has the PSRAM attached to the same FLEXSPI device as the flash
+# chip used for XIP, so we must explicitly enable the FLEXSPI MEMC driver
+# to reconfigure the flash device it is executing from
+CONFIG_MEMC_MCUX_FLEXSPI_INIT_XIP=y

--- a/samples/drivers/memc/boards/rd_rw612_bga.overlay
+++ b/samples/drivers/memc/boards/rd_rw612_bga.overlay
@@ -5,10 +5,6 @@
  */
 
 / {
-	chosen {
-		zephyr,flash = &sram_code;
-	};
-
 	aliases {
 		sram-ext = &is66wvq8m4;
 	};
@@ -16,4 +12,31 @@
 
 &is66wvq8m4 {
 	status = "okay";
+};
+
+&pinctrl {
+	pinmux_flexspi_safe: pinmux-flexspi-safe {
+		group0 {
+			pinmux = <IO_MUX_QUAD_SPI_PSRAM_IO35
+				IO_MUX_QUAD_SPI_PSRAM_IO36
+				IO_MUX_QUAD_SPI_PSRAM_IO38
+				IO_MUX_QUAD_SPI_PSRAM_IO39
+				IO_MUX_QUAD_SPI_PSRAM_IO40
+				IO_MUX_QUAD_SPI_PSRAM_IO41>;
+			slew-rate = "normal";
+		};
+
+		group1 {
+			pinmux = <IO_MUX_QUAD_SPI_PSRAM_IO37>;
+			slew-rate = "normal";
+			bias-pull-down;
+		};
+	};
+};
+
+/* Override pin control state to use one that only changes the PSRAM pin
+ * configuration
+ */
+&flexspi {
+	pinctrl-0 = <&pinmux_flexspi_safe>;
 };

--- a/soc/nxp/rw/flexspi_clock_setup.c
+++ b/soc/nxp/rw/flexspi_clock_setup.c
@@ -43,7 +43,7 @@ int __ramfunc flexspi_clock_set_freq(uint32_t clock_name, uint32_t rate)
 	FLEXSPI_Enable(FLEXSPI, false);
 
 	set_flexspi_clock(FLEXSPI, (CLKCTL0->FLEXSPIFCLKSEL &
-			CLKCTL0_FLEXSPIFCLKDIV_DIV_MASK), (divider + 1));
+			CLKCTL0_FLEXSPIFCLKSEL_SEL_MASK), (divider + 1));
 
 
 	FLEXSPI_Enable(FLEXSPI, true);


### PR DESCRIPTION
Fix support for using multiple devices attached to the FLEXSPI simultaneously. 

The RD-RW612 BGA board has one FLEXSPI controller, with a PSRAM and QSPI device attached. In order to verify this support functions as expected, enable executing in place from the attached QSPI chip (on port A), while reading and writing from the attached PSRAM chip (on port B) within the MEMC driver sample.