### PR TITLE
kernel: banner: Add option to clear screen on boot

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -467,6 +467,12 @@ config BOOT_DELAY
 	  achieved by waiting for DCD on the serial port--however, not
 	  all serial ports have DCD.
 
+config BOOT_CLEAR_SCREEN
+	bool "Clear screen"
+	help
+	  Use this option to clear the screen before printing anything else.
+	  Using a VT100 enabled terminal on the client side is required for this to work.
+
 config THREAD_MONITOR
 	bool "Thread monitoring"
 	help

--- a/kernel/banner.c
+++ b/kernel/banner.c
@@ -31,6 +31,15 @@ void boot_banner(void)
 	k_busy_wait(CONFIG_BOOT_DELAY * USEC_PER_MSEC);
 #endif /* defined(CONFIG_BOOT_DELAY) && (CONFIG_BOOT_DELAY > 0) */
 
+#if defined(CONFIG_BOOT_CLEAR_SCREEN)
+	 /* \x1b[ = escape sequence
+	  * 3J = erase scrollback
+	  * 2J = erase screen
+	  * H = move cursor to top left
+	  */
+	printk("\x1b[3J\x1b[2J\x1b[H");
+#endif /* CONFIG_BOOT_CLEAR_SCREEN */
+
 #ifdef CONFIG_BOOT_BANNER
 	printk("*** " CONFIG_BOOT_BANNER_STRING " " BANNER_VERSION BANNER_POSTFIX " ***\n");
 #endif /* CONFIG_BOOT_BANNER */


### PR DESCRIPTION
On each reboot, this option causes the serial output to start top-left on the users terminal, simplifying (human) parsing.

In case the idea is not rejected immediately, I'm willing to figure out some kind of testing. Please give me a heads up in case there is a particular reason why no `banner.c` tests exist yet.