### PR TITLE
tests: dma: loop transfer: Modernize zassert usage

### DIFF
--- a/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
+++ b/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
@@ -55,12 +55,10 @@ static void test_transfer(const struct device *dev, uint32_t id)
 		dma_block_cfg.dest_address = (uint32_t)rx_data[transfer_count];
 #endif
 
-		zassert_false(dma_config(dev, id, &dma_cfg),
-					"Not able to config transfer %d",
-					transfer_count + 1);
-		zassert_false(dma_start(dev, id),
-					"Not able to start next transfer %d",
-					transfer_count + 1);
+		zassert_ok(dma_config(dev, id, &dma_cfg), "Not able to config transfer %d",
+			   transfer_count + 1);
+		zassert_ok(dma_start(dev, id), "Not able to start next transfer %d",
+			   transfer_count + 1);
 	}
 }
 


### PR DESCRIPTION
zassert_ok() is a more descriptive way to check for errors.