### PR TITLE
tests: drivers: dma: loop transfer: Improve debuggability

### DIFF
--- a/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
+++ b/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
@@ -28,6 +28,9 @@
 #include <zephyr/pm/device.h>
 #include <zephyr/ztest.h>
 
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(test_dma_loop, CONFIG_DMA_LOG_LEVEL);
+
 /* in millisecond */
 #define SLEEPTIME 250
 
@@ -167,6 +170,8 @@ static int test_loop(const struct device *dma)
 	for (int i = 0; i < TRANSFER_LOOPS; i++) {
 		TC_PRINT("RX data Loop %d\n", i);
 		if (memcmp(tx_data, rx_data[i], CONFIG_DMA_LOOP_TRANSFER_SIZE)) {
+			LOG_HEXDUMP_ERR(tx_data, CONFIG_DMA_LOOP_TRANSFER_SIZE, "TX");
+			LOG_HEXDUMP_ERR(rx_data[i], CONFIG_DMA_LOOP_TRANSFER_SIZE, "RX");
 			return TC_FAIL;
 		}
 	}
@@ -311,6 +316,8 @@ static int test_loop_suspend_resume(const struct device *dma)
 	for (int i = 0; i < TRANSFER_LOOPS; i++) {
 		TC_PRINT("RX data Loop %d\n", i);
 		if (memcmp(tx_data, rx_data[i], CONFIG_DMA_LOOP_TRANSFER_SIZE)) {
+			LOG_HEXDUMP_ERR(tx_data, CONFIG_DMA_LOOP_TRANSFER_SIZE, "TX");
+			LOG_HEXDUMP_ERR(rx_data[i], CONFIG_DMA_LOOP_TRANSFER_SIZE, "RX");
 			return TC_FAIL;
 		}
 	}
@@ -449,6 +456,8 @@ static int test_loop_repeated_start_stop(const struct device *dma)
 	for (int i = 0; i < TRANSFER_LOOPS; i++) {
 		TC_PRINT("RX data Loop %d\n", i);
 		if (memcmp(tx_data, rx_data[i], CONFIG_DMA_LOOP_TRANSFER_SIZE)) {
+			LOG_HEXDUMP_ERR(tx_data, CONFIG_DMA_LOOP_TRANSFER_SIZE, "TX");
+			LOG_HEXDUMP_ERR(rx_data[i], CONFIG_DMA_LOOP_TRANSFER_SIZE, "RX");
 			return TC_FAIL;
 		}
 	}


### PR DESCRIPTION
By printing the content of mismatching buffers, debugging gets simplified.