### PR TITLE
tests: drivers: dma: loop transfer: Avoid fake pass

### DIFF
--- a/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
+++ b/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
@@ -254,7 +254,8 @@ static int test_loop_suspend_resume(const struct device *dma)
 			done = 1;
 			TC_PRINT("suspend not supported\n");
 			dma_stop(dma, chan_id);
-			return TC_PASS;
+			ztest_test_skip();
+			return TC_SKIP;
 		}
 		tc = transfer_count;
 		irq_unlock(irq_key);


### PR DESCRIPTION
When the needed functionality is not available, its test should be skipped, not passed.