### PR TITLE
pm: device_runtime: Add API to flush a pending operation

### DIFF
--- a/include/zephyr/pm/device_runtime.h
+++ b/include/zephyr/pm/device_runtime.h
@@ -170,6 +170,22 @@ bool pm_device_runtime_is_enabled(const struct device *dev);
  */
 int pm_device_runtime_usage(const struct device *dev);
 
+/**
+ * @brief Flush the device runtime PM state.
+ *
+ * This function will flush any pending async operation in a
+ * device. It is intended to be called during system suspend to ensure
+ * that the device is in a consistent state.
+ *
+ * @param dev Device instance.
+ *
+ * @retval 0 If it succeeds.
+ * @retval -EINVAL If the device does not have any pending operation.
+ * @retval -EALREADY If device is already suspended.
+ * @retval -errno Other negative errno, result of the action callback.
+ */
+int pm_device_runtime_flush(const struct device *dev);
+
 #else
 
 static inline int pm_device_runtime_auto_enable(const struct device *dev)
@@ -220,6 +236,12 @@ static inline int pm_device_runtime_usage(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 	return -ENOSYS;
+}
+
+static inline int pm_device_runtime_flush(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+	return 0;
 }
 
 #endif

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -576,3 +576,33 @@ int pm_device_runtime_usage(const struct device *dev)
 
 	return usage;
 }
+
+int pm_device_runtime_flush(const struct device *dev)
+{
+	struct pm_device *pm = dev->pm;
+	int ret = 0;
+
+	if (!pm_device_runtime_is_enabled(dev)) {
+		return -ENOTSUP;
+	}
+
+	(void)k_sem_take(&pm->lock, K_FOREVER);
+
+	if (pm->base.state == PM_DEVICE_STATE_SUSPENDED) {
+		ret = -EALREADY;
+		goto unlock;
+	}
+
+	if ((pm->base.state == PM_DEVICE_STATE_SUSPENDING) &&
+	    ((k_work_cancel_delayable(&pm->work) & K_WORK_RUNNING) == 0)) {
+		ret = pm->base.action_cb(pm->dev, PM_DEVICE_ACTION_SUSPEND);
+		pm->base.state = PM_DEVICE_STATE_SUSPENDED;
+	} else {
+		ret = -EINVAL;
+	}
+
+ unlock:
+	k_sem_give(&pm->lock);
+
+	return ret;
+}

--- a/tests/subsys/pm/device_runtime_api/src/main.c
+++ b/tests/subsys/pm/device_runtime_api/src/main.c
@@ -245,6 +245,31 @@ ZTEST(device_runtime_api, test_api)
 		/* Now it should be already suspended */
 		(void)pm_device_state_get(test_dev, &state);
 		zassert_equal(state, PM_DEVICE_STATE_SUSPENDED);
+
+		/* Test if flushing an async operation triggers
+		 * the device pm action immediately.
+		 */
+		ret = pm_device_runtime_get(test_dev);
+		zassert_equal(ret, 0);
+
+		/* A device that is active cannot be flushed */
+		ret = pm_device_runtime_flush(test_dev);
+		zassert_equal(ret, -EINVAL);
+
+		ret = pm_device_runtime_put_async(test_dev, K_MSEC(100));
+
+		(void)pm_device_state_get(test_dev, &state);
+		zassert_equal(state, PM_DEVICE_STATE_SUSPENDING);
+
+		ret = pm_device_runtime_flush(test_dev);
+		zassert_equal(ret, 0);
+
+		(void)pm_device_state_get(test_dev, &state);
+		zassert_equal(state, PM_DEVICE_STATE_SUSPENDED);
+
+		/* A device already suspended should not trigger any action */
+		ret = pm_device_runtime_flush(test_dev);
+		zassert_equal(ret, -EALREADY);
 	}
 
 	/* Put operation should fail due the state be locked. */


### PR DESCRIPTION
Add a new API to flush an async operation that is still pending.
That is particular useful for when the SoC is suspending and the device needs to be suspended.

