### PR TITLE
xtensa: mmu: MMU re-initialization API

### DIFF
--- a/arch/xtensa/core/ptables.c
+++ b/arch/xtensa/core/ptables.c
@@ -327,6 +327,24 @@ void xtensa_mmu_init(void)
 	arch_xtensa_mmu_post_init(_current_cpu->id == 0);
 }
 
+void xtensa_mmu_reinit(void)
+{
+	/* First initialize the hardware */
+	xtensa_init_paging(xtensa_kernel_ptables);
+
+#ifdef CONFIG_USERSPACE
+	struct k_thread *thread = _current_cpu->current;
+	struct arch_mem_domain *domain =
+			&(thread->mem_domain_info.mem_domain->arch);
+
+
+	/* Set the page table for current context */
+	xtensa_set_paging(domain->asid, domain->ptables);
+#endif /* CONFIG_USERSPACE */
+
+	arch_xtensa_mmu_post_init(_current_cpu->id == 0);
+}
+
 #ifdef CONFIG_ARCH_HAS_RESERVED_PAGE_FRAMES
 /* Zephyr's linker scripts for Xtensa usually puts
  * something before z_mapped_start (aka .text),

--- a/include/zephyr/arch/xtensa/xtensa_mmu.h
+++ b/include/zephyr/arch/xtensa/xtensa_mmu.h
@@ -124,6 +124,16 @@ extern int xtensa_soc_mmu_ranges_num;
 void xtensa_mmu_init(void);
 
 /**
+ * @brief Re-initialize hardware MMU.
+ *
+ * This configures the MMU hardware when the cpu lost context and has
+ * re-started.
+ *
+ * It assumes that the page table is already created and accessible in memory.
+ */
+void xtensa_mmu_reinit(void);
+
+/**
  * @brief Tell other processors to flush TLBs.
  *
  * This sends IPI to other processors to telling them to


### PR DESCRIPTION
With power managment is enabled, depending on the SoC power state used when idle, the MMU may lose context and may need to be re-initialized. When re-initializing the MMU, we must not re-create the page table because it may overwrite changes done during the execution, but we still need to set the asid and page table for the current context.