### PR TITLE
i2c: Add RTIO-compatible driver for nRFx TWI

### DIFF
--- a/drivers/i2c/CMakeLists.txt
+++ b/drivers/i2c/CMakeLists.txt
@@ -29,7 +29,16 @@ else()
 endif()
 
 zephyr_library_sources_ifdef(CONFIG_I2C_EMUL		i2c_emul.c)
-zephyr_library_sources_ifdef(CONFIG_I2C_NRFX_TWI	i2c_nrfx_twi.c)
+
+if(CONFIG_I2C_RTIO)
+  zephyr_library_sources_ifdef(CONFIG_I2C_NRFX_TWI
+	i2c_nrfx_twi_rtio.c
+	i2c_nrfx_twi_common.c
+	)
+else()
+  zephyr_library_sources_ifdef(CONFIG_I2C_NRFX_TWI	i2c_nrfx_twi.c)
+endif()
+
 zephyr_library_sources_ifdef(CONFIG_I2C_NRFX_TWIM	i2c_nrfx_twim.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_SAM_TWI		i2c_sam_twi.c)
 

--- a/drivers/i2c/CMakeLists.txt
+++ b/drivers/i2c/CMakeLists.txt
@@ -36,7 +36,10 @@ if(CONFIG_I2C_RTIO)
 	i2c_nrfx_twi_common.c
 	)
 else()
-  zephyr_library_sources_ifdef(CONFIG_I2C_NRFX_TWI	i2c_nrfx_twi.c)
+  zephyr_library_sources_ifdef(CONFIG_I2C_NRFX_TWI
+	i2c_nrfx_twi.c
+	i2c_nrfx_twi_common.c
+	)
 endif()
 
 zephyr_library_sources_ifdef(CONFIG_I2C_NRFX_TWIM	i2c_nrfx_twim.c)

--- a/drivers/i2c/Kconfig.nrfx
+++ b/drivers/i2c/Kconfig.nrfx
@@ -17,6 +17,7 @@ if I2C_NRFX
 config I2C_NRFX_TWI
 	def_bool y
 	depends on DT_HAS_NORDIC_NRF_TWI_ENABLED
+	select HAS_I2C_RTIO
 	select NRFX_TWI0 if HAS_HW_NRF_TWI0
 	select NRFX_TWI1 if HAS_HW_NRF_TWI1
 

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -11,6 +11,7 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <soc.h>
 #include <nrfx_twi.h>
+#include "i2c_nrfx_twi_common.h"
 
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>
@@ -23,19 +24,19 @@ LOG_MODULE_REGISTER(i2c_nrfx_twi, CONFIG_I2C_LOG_LEVEL);
 #endif
 
 struct i2c_nrfx_twi_data {
+	uint32_t dev_config;
 	struct k_sem transfer_sync;
 	struct k_sem completion_sync;
 	volatile nrfx_err_t res;
-	uint32_t dev_config;
 };
 
-struct i2c_nrfx_twi_config {
-	nrfx_twi_t twi;
-	nrfx_twi_config_t config;
-	const struct pinctrl_dev_config *pcfg;
-};
-
-static int i2c_nrfx_twi_recover_bus(const struct device *dev);
+/* Enforce dev_config matches the same offset as the common structure,
+ * otherwise common API won't be compatible with i2c_nrfx_twi.
+ */
+BUILD_ASSERT(
+	offsetof(struct i2c_nrfx_twi_data, dev_config) ==
+	offsetof(struct i2c_nrfx_twi_common_data, dev_config)
+);
 
 static int i2c_nrfx_twi_transfer(const struct device *dev,
 				 struct i2c_msg *msgs,
@@ -53,58 +54,15 @@ static int i2c_nrfx_twi_transfer(const struct device *dev,
 	nrfx_twi_enable(&config->twi);
 
 	for (size_t i = 0; i < num_msgs; i++) {
-		if (I2C_MSG_ADDR_10_BITS & msgs[i].flags) {
-			ret = -ENOTSUP;
+		bool more_msgs = ((i < (num_msgs - 1)) &&
+				  !(msgs[i + 1].flags & I2C_MSG_RESTART));
+
+		ret = i2c_nrfx_twi_msg_transfer(dev, msgs[i].flags,
+						msgs[i].buf,
+						msgs[i].len, addr,
+						more_msgs);
+		if (ret) {
 			break;
-		}
-
-		nrfx_twi_xfer_desc_t cur_xfer = {
-			.p_primary_buf  = msgs[i].buf,
-			.primary_length = msgs[i].len,
-			.address	= addr,
-			.type		= (msgs[i].flags & I2C_MSG_READ) ?
-					  NRFX_TWI_XFER_RX : NRFX_TWI_XFER_TX
-		};
-		uint32_t xfer_flags = 0;
-		nrfx_err_t res;
-
-		/* In case the STOP condition is not supposed to appear after
-		 * the current message, check what is requested further:
-		 */
-		if (!(msgs[i].flags & I2C_MSG_STOP)) {
-			/* - if the transfer consists of more messages
-			 *   and the I2C repeated START is not requested
-			 *   to appear before the next message, suspend
-			 *   the transfer after the current message,
-			 *   so that it can be resumed with the next one,
-			 *   resulting in the two messages merged into
-			 *   a continuous transfer on the bus
-			 */
-			if ((i < (num_msgs - 1)) &&
-			    !(msgs[i + 1].flags & I2C_MSG_RESTART)) {
-				xfer_flags |= NRFX_TWI_FLAG_SUSPEND;
-			/* - otherwise, just finish the transfer without
-			 *   generating the STOP condition, unless the current
-			 *   message is an RX request, for which such feature
-			 *   is not supported
-			 */
-			} else if (msgs[i].flags & I2C_MSG_READ) {
-				ret = -ENOTSUP;
-				break;
-			} else {
-				xfer_flags |= NRFX_TWI_FLAG_TX_NO_STOP;
-			}
-		}
-
-		res = nrfx_twi_xfer(&config->twi, &cur_xfer, xfer_flags);
-		if (res != NRFX_SUCCESS) {
-			if (res == NRFX_ERROR_BUSY) {
-				ret = -EBUSY;
-				break;
-			} else {
-				ret = -EIO;
-				break;
-			}
 		}
 
 		ret = k_sem_take(&data->completion_sync,
@@ -132,8 +90,7 @@ static int i2c_nrfx_twi_transfer(const struct device *dev,
 			break;
 		}
 
-		res = data->res;
-		if (res != NRFX_SUCCESS) {
+		if (data->res != NRFX_SUCCESS) {
 			ret = -EIO;
 			break;
 		}
@@ -147,7 +104,8 @@ static int i2c_nrfx_twi_transfer(const struct device *dev,
 
 static void event_handler(nrfx_twi_evt_t const *p_event, void *p_context)
 {
-	struct i2c_nrfx_twi_data *dev_data = p_context;
+	const struct device *dev = p_context;
+	struct i2c_nrfx_twi_data *dev_data = (struct i2c_nrfx_twi_data *)dev->data;
 
 	switch (p_event->type) {
 	case NRFX_TWI_EVT_DONE:
@@ -167,114 +125,11 @@ static void event_handler(nrfx_twi_evt_t const *p_event, void *p_context)
 	k_sem_give(&dev_data->completion_sync);
 }
 
-static int i2c_nrfx_twi_configure(const struct device *dev,
-				  uint32_t dev_config)
-{
-	const struct i2c_nrfx_twi_config *config = dev->config;
-	struct i2c_nrfx_twi_data *data = dev->data;
-	nrfx_twi_t const *inst = &config->twi;
-
-	if (I2C_ADDR_10_BITS & dev_config) {
-		return -EINVAL;
-	}
-
-	switch (I2C_SPEED_GET(dev_config)) {
-	case I2C_SPEED_STANDARD:
-		nrf_twi_frequency_set(inst->p_twi, NRF_TWI_FREQ_100K);
-		break;
-	case I2C_SPEED_FAST:
-		nrf_twi_frequency_set(inst->p_twi, NRF_TWI_FREQ_400K);
-		break;
-	default:
-		LOG_ERR("unsupported speed");
-		return -EINVAL;
-	}
-	data->dev_config = dev_config;
-
-	return 0;
-}
-
-static int i2c_nrfx_twi_recover_bus(const struct device *dev)
-{
-	const struct i2c_nrfx_twi_config *config = dev->config;
-	uint32_t scl_pin;
-	uint32_t sda_pin;
-	nrfx_err_t err;
-
-	scl_pin = nrf_twi_scl_pin_get(config->twi.p_twi);
-	sda_pin = nrf_twi_sda_pin_get(config->twi.p_twi);
-
-	err = nrfx_twi_bus_recover(scl_pin, sda_pin);
-	return (err == NRFX_SUCCESS ? 0 : -EBUSY);
-}
-
 static const struct i2c_driver_api i2c_nrfx_twi_driver_api = {
 	.configure   = i2c_nrfx_twi_configure,
 	.transfer    = i2c_nrfx_twi_transfer,
 	.recover_bus = i2c_nrfx_twi_recover_bus,
 };
-
-static int init_twi(const struct device *dev)
-{
-	const struct i2c_nrfx_twi_config *config = dev->config;
-	struct i2c_nrfx_twi_data *dev_data = dev->data;
-	nrfx_err_t result = nrfx_twi_init(&config->twi, &config->config,
-					  event_handler, dev_data);
-	if (result != NRFX_SUCCESS) {
-		LOG_ERR("Failed to initialize device: %s",
-			    dev->name);
-		return -EBUSY;
-	}
-
-	return 0;
-}
-
-#ifdef CONFIG_PM_DEVICE
-static int twi_nrfx_pm_action(const struct device *dev,
-			      enum pm_device_action action)
-{
-	const struct i2c_nrfx_twi_config *config = dev->config;
-	struct i2c_nrfx_twi_data *data = dev->data;
-	int ret = 0;
-
-	switch (action) {
-	case PM_DEVICE_ACTION_RESUME:
-		ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
-		if (ret < 0) {
-			return ret;
-		}
-		init_twi(dev);
-		if (data->dev_config) {
-			i2c_nrfx_twi_configure(dev, data->dev_config);
-		}
-		break;
-
-	case PM_DEVICE_ACTION_SUSPEND:
-		nrfx_twi_uninit(&config->twi);
-
-		ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_SLEEP);
-		if (ret < 0) {
-			return ret;
-		}
-		break;
-
-	default:
-		ret = -ENOTSUP;
-	}
-
-	return ret;
-}
-#endif /* CONFIG_PM_DEVICE */
-
-#define I2C_NRFX_TWI_INVALID_FREQUENCY  ((nrf_twi_frequency_t)-1)
-#define I2C_NRFX_TWI_FREQUENCY(bitrate)					       \
-	 (bitrate == I2C_BITRATE_STANDARD ? NRF_TWI_FREQ_100K		       \
-	: bitrate == 250000               ? NRF_TWI_FREQ_250K		       \
-	: bitrate == I2C_BITRATE_FAST     ? NRF_TWI_FREQ_400K		       \
-					  : I2C_NRFX_TWI_INVALID_FREQUENCY)
-#define I2C(idx) DT_NODELABEL(i2c##idx)
-#define I2C_FREQUENCY(idx)						       \
-	I2C_NRFX_TWI_FREQUENCY(DT_PROP(I2C(idx), clock_frequency))
 
 #define I2C_NRFX_TWI_DEVICE(idx)					       \
 	NRF_DT_CHECK_NODE_HAS_PINCTRL_SLEEP(I2C(idx));			       \
@@ -291,7 +146,7 @@ static int twi_nrfx_pm_action(const struct device *dev,
 		if (err < 0) {						       \
 			return err;					       \
 		}							       \
-		return init_twi(dev);					       \
+		return i2c_nrfx_twi_init(dev);				       \
 	}								       \
 	static struct i2c_nrfx_twi_data twi_##idx##_data = {		       \
 		.transfer_sync = Z_SEM_INITIALIZER(                            \
@@ -307,6 +162,7 @@ static int twi_nrfx_pm_action(const struct device *dev,
 			.skip_psel_cfg = true,				       \
 			.frequency = I2C_FREQUENCY(idx),		       \
 		},							       \
+		.event_handler = event_handler,				       \
 		.pcfg = PINCTRL_DT_DEV_CONFIG_GET(I2C(idx)),		       \
 	};								       \
 	PM_DEVICE_DT_DEFINE(I2C(idx), twi_nrfx_pm_action);		       \

--- a/drivers/i2c/i2c_nrfx_twi_common.c
+++ b/drivers/i2c/i2c_nrfx_twi_common.c
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2024, Croxel Inc
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/pinctrl.h>
+#include <nrfx_twi.h>
+#include "i2c_nrfx_twi_common.h"
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(i2c_nrfx_twi);
+
+int i2c_nrfx_twi_init(const struct device *dev)
+{
+	const struct i2c_nrfx_twi_config *config = dev->config;
+	nrfx_err_t result = nrfx_twi_init(&config->twi, &config->config,
+					  config->event_handler, (void *)dev);
+	if (result != NRFX_SUCCESS) {
+		LOG_ERR("Failed to initialize device: %s",
+			    dev->name);
+		return -EBUSY;
+	}
+
+	return 0;
+}
+
+int i2c_nrfx_twi_configure(const struct device *dev, uint32_t dev_config)
+{
+	const struct i2c_nrfx_twi_config *config = dev->config;
+	struct i2c_nrfx_twi_common_data *data = dev->data;
+	nrfx_twi_t const *inst = &config->twi;
+
+	if (I2C_ADDR_10_BITS & dev_config) {
+		return -EINVAL;
+	}
+
+	switch (I2C_SPEED_GET(dev_config)) {
+	case I2C_SPEED_STANDARD:
+		nrf_twi_frequency_set(inst->p_twi, NRF_TWI_FREQ_100K);
+		break;
+	case I2C_SPEED_FAST:
+		nrf_twi_frequency_set(inst->p_twi, NRF_TWI_FREQ_400K);
+		break;
+	default:
+		LOG_ERR("unsupported speed");
+		return -EINVAL;
+	}
+	data->dev_config = dev_config;
+
+	return 0;
+}
+
+int i2c_nrfx_twi_recover_bus(const struct device *dev)
+{
+	const struct i2c_nrfx_twi_config *config = dev->config;
+	uint32_t scl_pin;
+	uint32_t sda_pin;
+	nrfx_err_t err;
+
+	scl_pin = nrf_twi_scl_pin_get(config->twi.p_twi);
+	sda_pin = nrf_twi_sda_pin_get(config->twi.p_twi);
+
+	err = nrfx_twi_bus_recover(scl_pin, sda_pin);
+	return (err == NRFX_SUCCESS ? 0 : -EBUSY);
+}
+
+int i2c_nrfx_twi_msg_transfer(const struct device *dev, uint8_t flags,
+			      uint8_t *buf, size_t buf_len,
+			      uint16_t i2c_addr, bool more_msgs)
+{
+	const struct i2c_nrfx_twi_config *config = dev->config;
+	int ret = 0;
+	uint32_t xfer_flags = 0;
+	nrfx_err_t res;
+	nrfx_twi_xfer_desc_t cur_xfer = {
+		.p_primary_buf = buf,
+		.primary_length = buf_len,
+		.address = i2c_addr,
+		.type = (flags & I2C_MSG_READ) ?
+			 NRFX_TWI_XFER_RX : NRFX_TWI_XFER_TX,
+	};
+
+	if (flags & I2C_MSG_ADDR_10_BITS) {
+		LOG_ERR("10-bit I2C Addr devices not supported");
+		ret = -ENOTSUP;
+	} else if (!(flags & I2C_MSG_STOP)) {
+		/* - if the transfer consists of more messages
+		 *   and the I2C repeated START is not requested
+		 *   to appear before the next message, suspend
+		 *   the transfer after the current message,
+		 *   so that it can be resumed with the next one,
+		 *   resulting in the two messages merged into
+		 *   a continuous transfer on the bus
+		 */
+		if (more_msgs) {
+			xfer_flags |= NRFX_TWI_FLAG_SUSPEND;
+		/* - otherwise, just finish the transfer without
+		 *   generating the STOP condition, unless the current
+		 *   message is an RX request, for which such feature
+		 *   is not supported
+		 */
+		} else if (flags & I2C_MSG_READ) {
+			ret = -ENOTSUP;
+		} else {
+			xfer_flags |= NRFX_TWI_FLAG_TX_NO_STOP;
+		}
+	}
+
+	if (!ret) {
+		res = nrfx_twi_xfer(&config->twi, &cur_xfer, xfer_flags);
+		switch (res) {
+		case NRFX_SUCCESS:
+			break;
+		case NRFX_ERROR_BUSY:
+			ret = -EBUSY;
+			break;
+		default:
+			ret = -EIO;
+			break;
+		}
+	}
+
+	return ret;
+}
+
+#ifdef CONFIG_PM_DEVICE
+int twi_nrfx_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	const struct i2c_nrfx_twi_config *config = dev->config;
+	struct i2c_nrfx_twi_common_data *data = dev->data;
+	int ret = 0;
+
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
+		ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+		if (ret < 0) {
+			return ret;
+		}
+		i2c_nrfx_twi_init(dev);
+		if (data->dev_config) {
+			i2c_nrfx_twi_configure(dev, data->dev_config);
+		}
+		break;
+
+	case PM_DEVICE_ACTION_SUSPEND:
+		nrfx_twi_uninit(&config->twi);
+
+		ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_SLEEP);
+		if (ret < 0) {
+			return ret;
+		}
+		break;
+
+	default:
+		ret = -ENOTSUP;
+	}
+
+	return ret;
+}
+#endif /* CONFIG_PM_DEVICE */

--- a/drivers/i2c/i2c_nrfx_twi_common.h
+++ b/drivers/i2c/i2c_nrfx_twi_common.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2024, Croxel Inc
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_I2C_I2C_NRFX_TWI_COMMON_H_
+#define ZEPHYR_DRIVERS_I2C_I2C_NRFX_TWI_COMMON_H_
+
+#include <zephyr/pm/device.h>
+#include <nrfx_twi.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define I2C_NRFX_TWI_INVALID_FREQUENCY  ((nrf_twi_frequency_t)-1)
+#define I2C_NRFX_TWI_FREQUENCY(bitrate)					       \
+	 (bitrate == I2C_BITRATE_STANDARD ? NRF_TWI_FREQ_100K		       \
+	: bitrate == 250000               ? NRF_TWI_FREQ_250K		       \
+	: bitrate == I2C_BITRATE_FAST     ? NRF_TWI_FREQ_400K		       \
+					  : I2C_NRFX_TWI_INVALID_FREQUENCY)
+#define I2C(idx) DT_NODELABEL(i2c##idx)
+#define I2C_FREQUENCY(idx)						       \
+	I2C_NRFX_TWI_FREQUENCY(DT_PROP(I2C(idx), clock_frequency))
+
+struct i2c_nrfx_twi_common_data {
+	uint32_t dev_config;
+};
+
+struct i2c_nrfx_twi_config {
+	nrfx_twi_t twi;
+	nrfx_twi_config_t config;
+	nrfx_twi_evt_handler_t event_handler;
+	const struct pinctrl_dev_config *pcfg;
+};
+
+static inline nrfx_err_t i2c_nrfx_twi_get_evt_result(nrfx_twi_evt_t const *p_event)
+{
+	switch (p_event->type) {
+	case NRFX_TWI_EVT_DONE:
+		return NRFX_SUCCESS;
+	case NRFX_TWI_EVT_ADDRESS_NACK:
+		return NRFX_ERROR_DRV_TWI_ERR_ANACK;
+	case NRFX_TWI_EVT_DATA_NACK:
+		return NRFX_ERROR_DRV_TWI_ERR_DNACK;
+	default:
+		return NRFX_ERROR_INTERNAL;
+	}
+}
+
+int i2c_nrfx_twi_init(const struct device *dev);
+int i2c_nrfx_twi_configure(const struct device *dev, uint32_t dev_config);
+int i2c_nrfx_twi_recover_bus(const struct device *dev);
+int i2c_nrfx_twi_msg_transfer(const struct device *dev, uint8_t flags,
+			      uint8_t *buf, size_t buf_len,
+			      uint16_t i2c_addr, bool more_msgs);
+
+#ifdef CONFIG_PM_DEVICE
+int twi_nrfx_pm_action(const struct device *dev, enum pm_device_action action);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_DRIVERS_I2C_I2C_NRFX_TWI_COMMON_H_ */

--- a/drivers/i2c/i2c_nrfx_twi_rtio.c
+++ b/drivers/i2c/i2c_nrfx_twi_rtio.c
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2018, Nordic Semiconductor ASA
+ * Copyright (c) 2024, Croxel Inc
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/i2c/rtio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/drivers/pinctrl.h>
+#include <soc.h>
+#include <nrfx_twi.h>
+#include "i2c_nrfx_twi_common.h"
+
+#include <zephyr/logging/log.h>
+#include <zephyr/irq.h>
+LOG_MODULE_REGISTER(i2c_nrfx_twi, CONFIG_I2C_LOG_LEVEL);
+
+struct i2c_nrfx_twi_rtio_data {
+	uint32_t dev_config;
+	bool twi_enabled;
+	struct i2c_rtio *ctx;
+};
+
+/* Enforce dev_config matches the same offset as the common structure,
+ * otherwise common API won't be compatible with i2c_nrfx_twi_rtio.
+ */
+BUILD_ASSERT(
+	offsetof(struct i2c_nrfx_twi_rtio_data, dev_config) ==
+	offsetof(struct i2c_nrfx_twi_common_data, dev_config)
+);
+
+static void i2c_nrfx_twi_complete(const struct device *dev, int status);
+
+static bool i2c_nrfx_twi_msg_start(const struct device *dev, uint8_t flags,
+				   uint8_t *buf, size_t buf_len, uint16_t i2c_addr)
+{
+	const struct i2c_nrfx_twi_config *config = dev->config;
+	struct i2c_nrfx_twi_rtio_data *const dev_data = dev->data;
+	struct i2c_rtio *ctx = dev_data->ctx;
+	int ret = 0;
+
+	/** Enabling while already enabled ends up in a failed assertion: skip it. */
+	if (!dev_data->twi_enabled) {
+		nrfx_twi_enable(&config->twi);
+		dev_data->twi_enabled = true;
+	}
+
+	ret = i2c_nrfx_twi_msg_transfer(dev, flags, buf, buf_len, i2c_addr, false);
+	if (ret != 0) {
+		nrfx_twi_disable(&config->twi);
+		dev_data->twi_enabled = false;
+
+		return i2c_rtio_complete(ctx, ret);
+	}
+
+	return false;
+}
+
+static bool i2c_nrfx_twi_start(const struct device *dev)
+{
+	struct i2c_nrfx_twi_rtio_data *const dev_data = dev->data;
+	struct i2c_rtio *ctx = dev_data->ctx;
+	struct rtio_sqe *sqe = &ctx->txn_curr->sqe;
+	struct i2c_dt_spec *dt_spec = sqe->iodev->data;
+
+	switch (sqe->op) {
+	case RTIO_OP_RX:
+		return i2c_nrfx_twi_msg_start(dev, I2C_MSG_READ | sqe->iodev_flags,
+					sqe->buf, sqe->buf_len, dt_spec->addr);
+	case RTIO_OP_TINY_TX:
+		return i2c_nrfx_twi_msg_start(dev, I2C_MSG_WRITE | sqe->iodev_flags,
+					sqe->tiny_buf, sqe->tiny_buf_len, dt_spec->addr);
+	case RTIO_OP_TX:
+		return i2c_nrfx_twi_msg_start(dev, I2C_MSG_WRITE | sqe->iodev_flags,
+					sqe->buf, sqe->buf_len, dt_spec->addr);
+	case RTIO_OP_I2C_CONFIGURE:
+		(void)i2c_nrfx_twi_configure(dev, sqe->i2c_config);
+		return false;
+	case RTIO_OP_I2C_RECOVER:
+		(void)i2c_rtio_recover(ctx);
+		return false;
+	default:
+		LOG_ERR("Invalid op code %d for submission %p\n", sqe->op, (void *)sqe);
+		return i2c_rtio_complete(ctx, -EINVAL);
+	}
+}
+
+static void i2c_nrfx_twi_complete(const struct device *dev, int status)
+{
+	/** Finalize if there are no more pending xfers */
+	const struct i2c_nrfx_twi_config *config = dev->config;
+	struct i2c_nrfx_twi_rtio_data *data = dev->data;
+	struct i2c_rtio *const ctx = data->ctx;
+
+	if (i2c_rtio_complete(ctx, status)) {
+		(void)i2c_nrfx_twi_start(dev);
+	} else {
+		nrfx_twi_disable(&config->twi);
+		data->twi_enabled = false;
+	}
+}
+
+static int i2c_nrfx_twi_transfer(const struct device *dev,
+				 struct i2c_msg *msgs,
+				 uint8_t num_msgs, uint16_t addr)
+{
+	struct i2c_rtio *const ctx = ((struct i2c_nrfx_twi_rtio_data *)
+		dev->data)->ctx;
+
+	return i2c_rtio_transfer(ctx, msgs, num_msgs, addr);
+}
+
+static void event_handler(nrfx_twi_evt_t const *p_event, void *p_context)
+{
+	const struct device *dev = p_context;
+	int status = 0;
+
+	if (i2c_nrfx_twi_get_evt_result(p_event) != NRFX_SUCCESS) {
+		status = -EIO;
+	}
+
+	i2c_nrfx_twi_complete(dev, status);
+}
+
+static void i2c_nrfx_twi_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_seq)
+{
+	struct i2c_nrfx_twi_rtio_data *data = dev->data;
+	struct i2c_rtio *const ctx = data->ctx;
+
+	if (i2c_rtio_submit(ctx, iodev_seq)) {
+		(void)i2c_nrfx_twi_start(dev);
+	}
+}
+
+static const struct i2c_driver_api i2c_nrfx_twi_driver_api = {
+	.configure   = i2c_nrfx_twi_configure,
+	.transfer    = i2c_nrfx_twi_transfer,
+	.recover_bus = i2c_nrfx_twi_recover_bus,
+	.iodev_submit = i2c_nrfx_twi_submit,
+};
+
+#define I2C_NRFX_TWI_RTIO_DEVICE(idx)					       \
+	NRF_DT_CHECK_NODE_HAS_PINCTRL_SLEEP(I2C(idx));			       \
+	BUILD_ASSERT(I2C_FREQUENCY(idx)	!=				       \
+		     I2C_NRFX_TWI_INVALID_FREQUENCY,			       \
+		     "Wrong I2C " #idx " frequency setting in dts");	       \
+	static int twi_##idx##_init(const struct device *dev)		       \
+	{								       \
+		IRQ_CONNECT(DT_IRQN(I2C(idx)), DT_IRQ(I2C(idx), priority),     \
+			    nrfx_isr, nrfx_twi_##idx##_irq_handler, 0);	       \
+		const struct i2c_nrfx_twi_config *config = dev->config;	       \
+		const struct i2c_nrfx_twi_rtio_data *dev_data = dev->data;     \
+		int err = pinctrl_apply_state(config->pcfg,		       \
+					      PINCTRL_STATE_DEFAULT);	       \
+		if (err < 0) {						       \
+			return err;					       \
+		}							       \
+		i2c_rtio_init(dev_data->ctx, dev);			       \
+		return i2c_nrfx_twi_init(dev);				       \
+	}								       \
+	I2C_RTIO_DEFINE(_i2c##idx##_twi_rtio,				       \
+			DT_INST_PROP_OR(n, sq_size, CONFIG_I2C_RTIO_SQ_SIZE),  \
+			DT_INST_PROP_OR(n, cq_size, CONFIG_I2C_RTIO_CQ_SIZE)); \
+	static struct i2c_nrfx_twi_rtio_data twi_##idx##_data = {	       \
+		.ctx = &_i2c##idx##_twi_rtio,				       \
+	};								       \
+	PINCTRL_DT_DEFINE(I2C(idx));					       \
+	static const struct i2c_nrfx_twi_config twi_##idx##z_config = {	       \
+		.twi = NRFX_TWI_INSTANCE(idx),				       \
+		.config = {						       \
+			.skip_gpio_cfg = true,				       \
+			.skip_psel_cfg = true,				       \
+			.frequency = I2C_FREQUENCY(idx),		       \
+		},							       \
+		.event_handler = event_handler,				       \
+		.pcfg = PINCTRL_DT_DEV_CONFIG_GET(I2C(idx)),		       \
+	};								       \
+	PM_DEVICE_DT_DEFINE(I2C(idx), twi_nrfx_pm_action);		       \
+	I2C_DEVICE_DT_DEFINE(I2C(idx),					       \
+		      twi_##idx##_init,					       \
+		      PM_DEVICE_DT_GET(I2C(idx)),			       \
+		      &twi_##idx##_data,				       \
+		      &twi_##idx##z_config,				       \
+		      POST_KERNEL,					       \
+		      CONFIG_I2C_INIT_PRIORITY,				       \
+		      &i2c_nrfx_twi_driver_api)
+
+#ifdef CONFIG_HAS_HW_NRF_TWI0
+I2C_NRFX_TWI_RTIO_DEVICE(0);
+#endif
+
+#ifdef CONFIG_HAS_HW_NRF_TWI1
+I2C_NRFX_TWI_RTIO_DEVICE(1);
+#endif

--- a/tests/drivers/i2c/i2c_ram/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/i2c/i2c_ram/boards/nrf52840dk_nrf52840.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2023 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		i2c-ram = &arduino_i2c;
+	};
+};


### PR DESCRIPTION
### Description
- Add first version of nrfx_twi_rtio.c, the RTIO-compatible driver for nrfx devices.
- Add overlay to make the i2c_ram test compatible with nRF52840DK, the board used to develop and test against.

### Testing
- Build command: `west build -b nrf52840dk/nrf52840 tests/drivers/i2c/i2c_ram -- -DCONFIG_I2C_RTIO=y`
- Output:
``` console
*** Booting Zephyr OS build v3.6.0-3653-gf246797ccd33 ***
Running TESTSUITE i2c_ram
===================================================================
START - test_ram_rtio
submitting write from thread 0x20000250 addr 7
 PASS - test_ram_rtio in 0.007 seconds
===================================================================
START - test_ram_rtio_isr
timer submitting write, addr e
timer checking write result, submitting read
read command complete
read data complete
 PASS - test_ram_rtio_isr in 0.015 seconds
===================================================================
START - test_ram_transfer
ram using i2c_transfer from thread 0x20000250 addr 15
 PASS - test_ram_transfer in 0.008 seconds
===================================================================
START - test_ram_write_read
ram using i2c_write and i2c_write_read from thread 0x20000250 addr 1c
 PASS - test_ram_write_read in 0.009 seconds
===================================================================
TESTSUITE i2c_ram succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [i2c_ram]: pass = 4, fail = 0, skip = 0, total = 4 duration = 0.039 seconds
 - PASS - [i2c_ram.test_ram_rtio] duration = 0.007 seconds
 - PASS - [i2c_ram.test_ram_rtio_isr] duration = 0.015 seconds
 - PASS - [i2c_ram.test_ram_transfer] duration = 0.008 seconds
 - PASS - [i2c_ram.test_ram_write_read] duration = 0.009 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```