### PR TITLE
kernel: add `k_uptime_seconds`

### DIFF
--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -71,6 +71,11 @@ Architectures
 
 * Xtensa
 
+Kernel
+******
+
+  * Added :c:func:`k_uptime_seconds` function to simplify `k_uptime_get() / 1000` usage.
+
 Bluetooth
 *********
 

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -1775,6 +1775,19 @@ static inline uint32_t k_uptime_get_32(void)
 }
 
 /**
+ * @brief Get system uptime in seconds.
+ *
+ * This routine returns the elapsed time since the system booted,
+ * in seconds.
+ *
+ * @return Current uptime in seconds.
+ */
+static inline uint32_t k_uptime_seconds(void)
+{
+	return k_ticks_to_sec_floor32(k_uptime_ticks());
+}
+
+/**
  * @brief Get elapsed time.
  *
  * This routine computes the elapsed time between the current system uptime

--- a/include/zephyr/sys/time_units.h
+++ b/include/zephyr/sys/time_units.h
@@ -272,7 +272,8 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * #!/usr/bin/perl -w
  * use strict;
  *
- * my %human = ("ms" => "milliseconds",
+ * my %human = ("sec" => "seconds",
+ *              "ms" => "milliseconds",
  *              "us" => "microseconds",
  *              "ns" => "nanoseconds",
  *              "cyc" => "hardware cycles",
@@ -282,10 +283,10 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  *                    "floor" => "Truncates");
  *
  * sub big { return $_[0] eq "us" || $_[0] eq "ns"; }
- * sub prefix { return $_[0] eq "ms" || $_[0] eq "us" || $_[0] eq "ns"; }
+ * sub prefix { return $_[0] eq "sec" || $_[0] eq "ms" || $_[0] eq "us" || $_[0] eq "ns"; }
  *
- * for my $from_unit ("ms", "us", "ns", "cyc", "ticks") {
- *     for my $to_unit ("ms", "us", "ns", "cyc", "ticks") {
+ * for my $from_unit ("sec", "ms", "us", "ns", "cyc", "ticks") {
+ *     for my $to_unit ("sec", "ms", "us", "ns", "cyc", "ticks") {
  *         next if $from_unit eq $to_unit;
  *         next if prefix($from_unit) && prefix($to_unit);
  *         for my $round ("floor", "near", "ceil") {
@@ -333,12 +334,205 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
 /* Some more concise declarations to simplify the generator script and
  * save bytes below
  */
+#define Z_HZ_sec 1
 #define Z_HZ_ms 1000
 #define Z_HZ_us 1000000
 #define Z_HZ_ns 1000000000
 #define Z_HZ_cyc sys_clock_hw_cycles_per_sec()
 #define Z_HZ_ticks CONFIG_SYS_CLOCK_TICKS_PER_SEC
 #define Z_CCYC (!IS_ENABLED(CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME))
+
+/** @brief Convert seconds to hardware cycles. 32 bits. Truncates.
+ *
+ * Converts time values in seconds to hardware cycles.
+ * Computes result in 32 bit precision.
+ * Truncates to the next lowest output unit.
+ *
+ * @warning Generated. Do not edit. See above.
+ *
+ * @param t Source time in seconds. uint64_t
+ *
+ * @return The converted time value in hardware cycles. uint32_t
+ */
+#define k_sec_to_cyc_floor32(t) \
+	z_tmcvt_32(t, Z_HZ_sec, Z_HZ_cyc, Z_CCYC, false, false)
+
+
+/** @brief Convert seconds to hardware cycles. 64 bits. Truncates.
+ *
+ * Converts time values in seconds to hardware cycles.
+ * Computes result in 64 bit precision.
+ * Truncates to the next lowest output unit.
+ *
+ * @warning Generated. Do not edit. See above.
+ *
+ * @param t Source time in seconds. uint64_t
+ *
+ * @return The converted time value in hardware cycles. uint64_t
+ */
+#define k_sec_to_cyc_floor64(t) \
+	z_tmcvt_64(t, Z_HZ_sec, Z_HZ_cyc, Z_CCYC, false, false)
+
+
+/** @brief Convert seconds to hardware cycles. 32 bits. Round nearest.
+ *
+ * Converts time values in seconds to hardware cycles.
+ * Computes result in 32 bit precision.
+ * Rounds to the nearest output unit.
+ *
+ * @warning Generated. Do not edit. See above.
+ *
+ * @param t Source time in seconds. uint64_t
+ *
+ * @return The converted time value in hardware cycles. uint32_t
+ */
+#define k_sec_to_cyc_near32(t) \
+	z_tmcvt_32(t, Z_HZ_sec, Z_HZ_cyc, Z_CCYC, false, true)
+
+
+/** @brief Convert seconds to hardware cycles. 64 bits. Round nearest.
+ *
+ * Converts time values in seconds to hardware cycles.
+ * Computes result in 64 bit precision.
+ * Rounds to the nearest output unit.
+ *
+ * @warning Generated. Do not edit. See above.
+ *
+ * @param t Source time in seconds. uint64_t
+ *
+ * @return The converted time value in hardware cycles. uint64_t
+ */
+#define k_sec_to_cyc_near64(t) \
+	z_tmcvt_64(t, Z_HZ_sec, Z_HZ_cyc, Z_CCYC, false, true)
+
+
+/** @brief Convert seconds to hardware cycles. 32 bits. Rounds up.
+ *
+ * Converts time values in seconds to hardware cycles.
+ * Computes result in 32 bit precision.
+ * Rounds up to the next highest output unit.
+ *
+ * @warning Generated. Do not edit. See above.
+ *
+ * @param t Source time in seconds. uint64_t
+ *
+ * @return The converted time value in hardware cycles. uint32_t
+ */
+#define k_sec_to_cyc_ceil32(t) \
+	z_tmcvt_32(t, Z_HZ_sec, Z_HZ_cyc, Z_CCYC, true, false)
+
+
+/** @brief Convert seconds to hardware cycles. 64 bits. Rounds up.
+ *
+ * Converts time values in seconds to hardware cycles.
+ * Computes result in 64 bit precision.
+ * Rounds up to the next highest output unit.
+ *
+ * @warning Generated. Do not edit. See above.
+ *
+ * @param t Source time in seconds. uint64_t
+ *
+ * @return The converted time value in hardware cycles. uint64_t
+ */
+#define k_sec_to_cyc_ceil64(t) \
+	z_tmcvt_64(t, Z_HZ_sec, Z_HZ_cyc, Z_CCYC, true, false)
+
+
+/** @brief Convert seconds to ticks. 32 bits. Truncates.
+ *
+ * Converts time values in seconds to ticks.
+ * Computes result in 32 bit precision.
+ * Truncates to the next lowest output unit.
+ *
+ * @warning Generated. Do not edit. See above.
+ *
+ * @param t Source time in seconds. uint64_t
+ *
+ * @return The converted time value in ticks. uint32_t
+ */
+#define k_sec_to_ticks_floor32(t) \
+	z_tmcvt_32(t, Z_HZ_sec, Z_HZ_ticks, true, false, false)
+
+
+/** @brief Convert seconds to ticks. 64 bits. Truncates.
+ *
+ * Converts time values in seconds to ticks.
+ * Computes result in 64 bit precision.
+ * Truncates to the next lowest output unit.
+ *
+ * @warning Generated. Do not edit. See above.
+ *
+ * @param t Source time in seconds. uint64_t
+ *
+ * @return The converted time value in ticks. uint64_t
+ */
+#define k_sec_to_ticks_floor64(t) \
+	z_tmcvt_64(t, Z_HZ_sec, Z_HZ_ticks, true, false, false)
+
+
+/** @brief Convert seconds to ticks. 32 bits. Round nearest.
+ *
+ * Converts time values in seconds to ticks.
+ * Computes result in 32 bit precision.
+ * Rounds to the nearest output unit.
+ *
+ * @warning Generated. Do not edit. See above.
+ *
+ * @param t Source time in seconds. uint64_t
+ *
+ * @return The converted time value in ticks. uint32_t
+ */
+#define k_sec_to_ticks_near32(t) \
+	z_tmcvt_32(t, Z_HZ_sec, Z_HZ_ticks, true, false, true)
+
+
+/** @brief Convert seconds to ticks. 64 bits. Round nearest.
+ *
+ * Converts time values in seconds to ticks.
+ * Computes result in 64 bit precision.
+ * Rounds to the nearest output unit.
+ *
+ * @warning Generated. Do not edit. See above.
+ *
+ * @param t Source time in seconds. uint64_t
+ *
+ * @return The converted time value in ticks. uint64_t
+ */
+#define k_sec_to_ticks_near64(t) \
+	z_tmcvt_64(t, Z_HZ_sec, Z_HZ_ticks, true, false, true)
+
+
+/** @brief Convert seconds to ticks. 32 bits. Rounds up.
+ *
+ * Converts time values in seconds to ticks.
+ * Computes result in 32 bit precision.
+ * Rounds up to the next highest output unit.
+ *
+ * @warning Generated. Do not edit. See above.
+ *
+ * @param t Source time in seconds. uint64_t
+ *
+ * @return The converted time value in ticks. uint32_t
+ */
+#define k_sec_to_ticks_ceil32(t) \
+	z_tmcvt_32(t, Z_HZ_sec, Z_HZ_ticks, true, true, false)
+
+
+/** @brief Convert seconds to ticks. 64 bits. Rounds up.
+ *
+ * Converts time values in seconds to ticks.
+ * Computes result in 64 bit precision.
+ * Rounds up to the next highest output unit.
+ *
+ * @warning Generated. Do not edit. See above.
+ *
+ * @param t Source time in seconds. uint64_t
+ *
+ * @return The converted time value in ticks. uint64_t
+ */
+#define k_sec_to_ticks_ceil64(t) \
+	z_tmcvt_64(t, Z_HZ_sec, Z_HZ_ticks, true, true, false)
+
 
 /** @brief Convert milliseconds to hardware cycles. 32 bits. Truncates.
  *
@@ -916,6 +1110,102 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
 	z_tmcvt_64(t, Z_HZ_ns, Z_HZ_ticks, true, true, false)
 
 
+/** @brief Convert hardware cycles to seconds. 32 bits. Truncates.
+ *
+ * Converts time values in hardware cycles to seconds.
+ * Computes result in 32 bit precision.
+ * Truncates to the next lowest output unit.
+ *
+ * @warning Generated. Do not edit. See above.
+ *
+ * @param t Source time in hardware cycles. uint64_t
+ *
+ * @return The converted time value in seconds. uint32_t
+ */
+#define k_cyc_to_sec_floor32(t) \
+	z_tmcvt_32(t, Z_HZ_cyc, Z_HZ_sec, Z_CCYC, false, false)
+
+
+/** @brief Convert hardware cycles to seconds. 64 bits. Truncates.
+ *
+ * Converts time values in hardware cycles to seconds.
+ * Computes result in 64 bit precision.
+ * Truncates to the next lowest output unit.
+ *
+ * @warning Generated. Do not edit. See above.
+ *
+ * @param t Source time in hardware cycles. uint64_t
+ *
+ * @return The converted time value in seconds. uint64_t
+ */
+#define k_cyc_to_sec_floor64(t) \
+	z_tmcvt_64(t, Z_HZ_cyc, Z_HZ_sec, Z_CCYC, false, false)
+
+
+/** @brief Convert hardware cycles to seconds. 32 bits. Round nearest.
+ *
+ * Converts time values in hardware cycles to seconds.
+ * Computes result in 32 bit precision.
+ * Rounds to the nearest output unit.
+ *
+ * @warning Generated. Do not edit. See above.
+ *
+ * @param t Source time in hardware cycles. uint64_t
+ *
+ * @return The converted time value in seconds. uint32_t
+ */
+#define k_cyc_to_sec_near32(t) \
+	z_tmcvt_32(t, Z_HZ_cyc, Z_HZ_sec, Z_CCYC, false, true)
+
+
+/** @brief Convert hardware cycles to seconds. 64 bits. Round nearest.
+ *
+ * Converts time values in hardware cycles to seconds.
+ * Computes result in 64 bit precision.
+ * Rounds to the nearest output unit.
+ *
+ * @warning Generated. Do not edit. See above.
+ *
+ * @param t Source time in hardware cycles. uint64_t
+ *
+ * @return The converted time value in seconds. uint64_t
+ */
+#define k_cyc_to_sec_near64(t) \
+	z_tmcvt_64(t, Z_HZ_cyc, Z_HZ_sec, Z_CCYC, false, true)
+
+
+/** @brief Convert hardware cycles to seconds. 32 bits. Rounds up.
+ *
+ * Converts time values in hardware cycles to seconds.
+ * Computes result in 32 bit precision.
+ * Rounds up to the next highest output unit.
+ *
+ * @warning Generated. Do not edit. See above.
+ *
+ * @param t Source time in hardware cycles. uint64_t
+ *
+ * @return The converted time value in seconds. uint32_t
+ */
+#define k_cyc_to_sec_ceil32(t) \
+	z_tmcvt_32(t, Z_HZ_cyc, Z_HZ_sec, Z_CCYC, true, false)
+
+
+/** @brief Convert hardware cycles to seconds. 64 bits. Rounds up.
+ *
+ * Converts time values in hardware cycles to seconds.
+ * Computes result in 64 bit precision.
+ * Rounds up to the next highest output unit.
+ *
+ * @warning Generated. Do not edit. See above.
+ *
+ * @param t Source time in hardware cycles. uint64_t
+ *
+ * @return The converted time value in seconds. uint64_t
+ */
+#define k_cyc_to_sec_ceil64(t) \
+	z_tmcvt_64(t, Z_HZ_cyc, Z_HZ_sec, Z_CCYC, true, false)
+
+
 /** @brief Convert hardware cycles to milliseconds. 32 bits. Truncates.
  *
  * Converts time values in hardware cycles to milliseconds.
@@ -1298,6 +1588,102 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  */
 #define k_cyc_to_ticks_ceil64(t) \
 	z_tmcvt_64(t, Z_HZ_cyc, Z_HZ_ticks, Z_CCYC, true, false)
+
+
+/** @brief Convert ticks to seconds. 32 bits. Truncates.
+ *
+ * Converts time values in ticks to seconds.
+ * Computes result in 32 bit precision.
+ * Truncates to the next lowest output unit.
+ *
+ * @warning Generated. Do not edit. See above.
+ *
+ * @param t Source time in ticks. uint64_t
+ *
+ * @return The converted time value in seconds. uint32_t
+ */
+#define k_ticks_to_sec_floor32(t) \
+	z_tmcvt_32(t, Z_HZ_ticks, Z_HZ_sec, true, false, false)
+
+
+/** @brief Convert ticks to seconds. 64 bits. Truncates.
+ *
+ * Converts time values in ticks to seconds.
+ * Computes result in 64 bit precision.
+ * Truncates to the next lowest output unit.
+ *
+ * @warning Generated. Do not edit. See above.
+ *
+ * @param t Source time in ticks. uint64_t
+ *
+ * @return The converted time value in seconds. uint64_t
+ */
+#define k_ticks_to_sec_floor64(t) \
+	z_tmcvt_64(t, Z_HZ_ticks, Z_HZ_sec, true, false, false)
+
+
+/** @brief Convert ticks to seconds. 32 bits. Round nearest.
+ *
+ * Converts time values in ticks to seconds.
+ * Computes result in 32 bit precision.
+ * Rounds to the nearest output unit.
+ *
+ * @warning Generated. Do not edit. See above.
+ *
+ * @param t Source time in ticks. uint64_t
+ *
+ * @return The converted time value in seconds. uint32_t
+ */
+#define k_ticks_to_sec_near32(t) \
+	z_tmcvt_32(t, Z_HZ_ticks, Z_HZ_sec, true, false, true)
+
+
+/** @brief Convert ticks to seconds. 64 bits. Round nearest.
+ *
+ * Converts time values in ticks to seconds.
+ * Computes result in 64 bit precision.
+ * Rounds to the nearest output unit.
+ *
+ * @warning Generated. Do not edit. See above.
+ *
+ * @param t Source time in ticks. uint64_t
+ *
+ * @return The converted time value in seconds. uint64_t
+ */
+#define k_ticks_to_sec_near64(t) \
+	z_tmcvt_64(t, Z_HZ_ticks, Z_HZ_sec, true, false, true)
+
+
+/** @brief Convert ticks to seconds. 32 bits. Rounds up.
+ *
+ * Converts time values in ticks to seconds.
+ * Computes result in 32 bit precision.
+ * Rounds up to the next highest output unit.
+ *
+ * @warning Generated. Do not edit. See above.
+ *
+ * @param t Source time in ticks. uint64_t
+ *
+ * @return The converted time value in seconds. uint32_t
+ */
+#define k_ticks_to_sec_ceil32(t) \
+	z_tmcvt_32(t, Z_HZ_ticks, Z_HZ_sec, true, true, false)
+
+
+/** @brief Convert ticks to seconds. 64 bits. Rounds up.
+ *
+ * Converts time values in ticks to seconds.
+ * Computes result in 64 bit precision.
+ * Rounds up to the next highest output unit.
+ *
+ * @warning Generated. Do not edit. See above.
+ *
+ * @param t Source time in ticks. uint64_t
+ *
+ * @return The converted time value in seconds. uint64_t
+ */
+#define k_ticks_to_sec_ceil64(t) \
+	z_tmcvt_64(t, Z_HZ_ticks, Z_HZ_sec, true, true, false)
 
 
 /** @brief Convert ticks to milliseconds. 32 bits. Truncates.

--- a/include/zephyr/sys/time_units.h
+++ b/include/zephyr/sys/time_units.h
@@ -278,8 +278,8 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  *              "cyc" => "hardware cycles",
  *              "ticks" => "ticks");
  * my %human_round = ("ceil" => "Rounds up",
- *		   "near" => "Round nearest",
- *		   "floor" => "Truncates");
+ *                    "near" => "Round nearest",
+ *                    "floor" => "Truncates");
  *
  * sub big { return $_[0] eq "us" || $_[0] eq "ns"; }
  * sub prefix { return $_[0] eq "ms" || $_[0] eq "us" || $_[0] eq "ns"; }
@@ -301,7 +301,7 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  *
  *                 my $hfrom = $human{$from_unit};
  *                 my $hto = $human{$to_unit};
- *		my $hround = $human_round{$round};
+ *                 my $hround = $human_round{$round};
  *                 print "/", "** \@brief Convert $hfrom to $hto. $ret32 bits. $hround.\n";
  *                 print " *\n";
  *                 print " * Converts time values in $hfrom to $hto.\n";
@@ -314,12 +314,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  *                     print " * Truncates to the next lowest output unit.\n";
  *                 }
  *                 print " *\n";
- *		print " * \@param t Source time in $hfrom. uint64_t\n";
- *		print " *\n";
+ *                 print " * \@warning Generated. Do not edit. See above.\n";
+ *                 print " *\n";
+ *                 print " * \@param t Source time in $hfrom. uint64_t\n";
+ *                 print " *\n";
  *                 print " * \@return The converted time value in $hto. $type\n";
  *                 print " *", "/\n";
- *
- *                 print "/", "* Generated.  Do not edit.  See above. *", "/\n";
  *                 print "#define $sym(t) \\\n";
  *                 print "\tz_tmcvt_$ret32(t, Z_HZ_$from_unit, Z_HZ_$to_unit,";
  *                 print " $const_hz, $rup, $roff)\n";
@@ -346,11 +346,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Truncates to the next lowest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in milliseconds. uint64_t
  *
  * @return The converted time value in hardware cycles. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ms_to_cyc_floor32(t) \
 	z_tmcvt_32(t, Z_HZ_ms, Z_HZ_cyc, Z_CCYC, false, false)
 
@@ -361,11 +362,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Truncates to the next lowest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in milliseconds. uint64_t
  *
  * @return The converted time value in hardware cycles. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ms_to_cyc_floor64(t) \
 	z_tmcvt_64(t, Z_HZ_ms, Z_HZ_cyc, Z_CCYC, false, false)
 
@@ -376,11 +378,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Rounds to the nearest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in milliseconds. uint64_t
  *
  * @return The converted time value in hardware cycles. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ms_to_cyc_near32(t) \
 	z_tmcvt_32(t, Z_HZ_ms, Z_HZ_cyc, Z_CCYC, false, true)
 
@@ -391,11 +394,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Rounds to the nearest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in milliseconds. uint64_t
  *
  * @return The converted time value in hardware cycles. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ms_to_cyc_near64(t) \
 	z_tmcvt_64(t, Z_HZ_ms, Z_HZ_cyc, Z_CCYC, false, true)
 
@@ -406,11 +410,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Rounds up to the next highest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in milliseconds. uint64_t
  *
  * @return The converted time value in hardware cycles. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ms_to_cyc_ceil32(t) \
 	z_tmcvt_32(t, Z_HZ_ms, Z_HZ_cyc, Z_CCYC, true, false)
 
@@ -421,11 +426,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Rounds up to the next highest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in milliseconds. uint64_t
  *
  * @return The converted time value in hardware cycles. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ms_to_cyc_ceil64(t) \
 	z_tmcvt_64(t, Z_HZ_ms, Z_HZ_cyc, Z_CCYC, true, false)
 
@@ -436,11 +442,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Truncates to the next lowest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in milliseconds. uint64_t
  *
  * @return The converted time value in ticks. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ms_to_ticks_floor32(t) \
 	z_tmcvt_32(t, Z_HZ_ms, Z_HZ_ticks, true, false, false)
 
@@ -451,11 +458,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Truncates to the next lowest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in milliseconds. uint64_t
  *
  * @return The converted time value in ticks. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ms_to_ticks_floor64(t) \
 	z_tmcvt_64(t, Z_HZ_ms, Z_HZ_ticks, true, false, false)
 
@@ -466,11 +474,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Rounds to the nearest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in milliseconds. uint64_t
  *
  * @return The converted time value in ticks. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ms_to_ticks_near32(t) \
 	z_tmcvt_32(t, Z_HZ_ms, Z_HZ_ticks, true, false, true)
 
@@ -481,11 +490,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Rounds to the nearest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in milliseconds. uint64_t
  *
  * @return The converted time value in ticks. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ms_to_ticks_near64(t) \
 	z_tmcvt_64(t, Z_HZ_ms, Z_HZ_ticks, true, false, true)
 
@@ -496,11 +506,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Rounds up to the next highest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in milliseconds. uint64_t
  *
  * @return The converted time value in ticks. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ms_to_ticks_ceil32(t) \
 	z_tmcvt_32(t, Z_HZ_ms, Z_HZ_ticks, true, true, false)
 
@@ -511,11 +522,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Rounds up to the next highest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in milliseconds. uint64_t
  *
  * @return The converted time value in ticks. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ms_to_ticks_ceil64(t) \
 	z_tmcvt_64(t, Z_HZ_ms, Z_HZ_ticks, true, true, false)
 
@@ -526,11 +538,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Truncates to the next lowest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in microseconds. uint64_t
  *
  * @return The converted time value in hardware cycles. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_us_to_cyc_floor32(t) \
 	z_tmcvt_32(t, Z_HZ_us, Z_HZ_cyc, Z_CCYC, false, false)
 
@@ -541,11 +554,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Truncates to the next lowest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in microseconds. uint64_t
  *
  * @return The converted time value in hardware cycles. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_us_to_cyc_floor64(t) \
 	z_tmcvt_64(t, Z_HZ_us, Z_HZ_cyc, Z_CCYC, false, false)
 
@@ -556,11 +570,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Rounds to the nearest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in microseconds. uint64_t
  *
  * @return The converted time value in hardware cycles. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_us_to_cyc_near32(t) \
 	z_tmcvt_32(t, Z_HZ_us, Z_HZ_cyc, Z_CCYC, false, true)
 
@@ -571,11 +586,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Rounds to the nearest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in microseconds. uint64_t
  *
  * @return The converted time value in hardware cycles. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_us_to_cyc_near64(t) \
 	z_tmcvt_64(t, Z_HZ_us, Z_HZ_cyc, Z_CCYC, false, true)
 
@@ -586,11 +602,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Rounds up to the next highest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in microseconds. uint64_t
  *
  * @return The converted time value in hardware cycles. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_us_to_cyc_ceil32(t) \
 	z_tmcvt_32(t, Z_HZ_us, Z_HZ_cyc, Z_CCYC, true, false)
 
@@ -601,11 +618,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Rounds up to the next highest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in microseconds. uint64_t
  *
  * @return The converted time value in hardware cycles. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_us_to_cyc_ceil64(t) \
 	z_tmcvt_64(t, Z_HZ_us, Z_HZ_cyc, Z_CCYC, true, false)
 
@@ -616,11 +634,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Truncates to the next lowest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in microseconds. uint64_t
  *
  * @return The converted time value in ticks. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_us_to_ticks_floor32(t) \
 	z_tmcvt_32(t, Z_HZ_us, Z_HZ_ticks, true, false, false)
 
@@ -631,11 +650,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Truncates to the next lowest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in microseconds. uint64_t
  *
  * @return The converted time value in ticks. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_us_to_ticks_floor64(t) \
 	z_tmcvt_64(t, Z_HZ_us, Z_HZ_ticks, true, false, false)
 
@@ -646,11 +666,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Rounds to the nearest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in microseconds. uint64_t
  *
  * @return The converted time value in ticks. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_us_to_ticks_near32(t) \
 	z_tmcvt_32(t, Z_HZ_us, Z_HZ_ticks, true, false, true)
 
@@ -661,11 +682,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Rounds to the nearest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in microseconds. uint64_t
  *
  * @return The converted time value in ticks. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_us_to_ticks_near64(t) \
 	z_tmcvt_64(t, Z_HZ_us, Z_HZ_ticks, true, false, true)
 
@@ -676,11 +698,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Rounds up to the next highest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in microseconds. uint64_t
  *
  * @return The converted time value in ticks. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_us_to_ticks_ceil32(t) \
 	z_tmcvt_32(t, Z_HZ_us, Z_HZ_ticks, true, true, false)
 
@@ -691,11 +714,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Rounds up to the next highest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in microseconds. uint64_t
  *
  * @return The converted time value in ticks. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_us_to_ticks_ceil64(t) \
 	z_tmcvt_64(t, Z_HZ_us, Z_HZ_ticks, true, true, false)
 
@@ -706,11 +730,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Truncates to the next lowest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in nanoseconds. uint64_t
  *
  * @return The converted time value in hardware cycles. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ns_to_cyc_floor32(t) \
 	z_tmcvt_32(t, Z_HZ_ns, Z_HZ_cyc, Z_CCYC, false, false)
 
@@ -721,11 +746,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Truncates to the next lowest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in nanoseconds. uint64_t
  *
  * @return The converted time value in hardware cycles. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ns_to_cyc_floor64(t) \
 	z_tmcvt_64(t, Z_HZ_ns, Z_HZ_cyc, Z_CCYC, false, false)
 
@@ -736,11 +762,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Rounds to the nearest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in nanoseconds. uint64_t
  *
  * @return The converted time value in hardware cycles. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ns_to_cyc_near32(t) \
 	z_tmcvt_32(t, Z_HZ_ns, Z_HZ_cyc, Z_CCYC, false, true)
 
@@ -751,11 +778,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Rounds to the nearest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in nanoseconds. uint64_t
  *
  * @return The converted time value in hardware cycles. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ns_to_cyc_near64(t) \
 	z_tmcvt_64(t, Z_HZ_ns, Z_HZ_cyc, Z_CCYC, false, true)
 
@@ -766,11 +794,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Rounds up to the next highest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in nanoseconds. uint64_t
  *
  * @return The converted time value in hardware cycles. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ns_to_cyc_ceil32(t) \
 	z_tmcvt_32(t, Z_HZ_ns, Z_HZ_cyc, Z_CCYC, true, false)
 
@@ -781,11 +810,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Rounds up to the next highest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in nanoseconds. uint64_t
  *
  * @return The converted time value in hardware cycles. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ns_to_cyc_ceil64(t) \
 	z_tmcvt_64(t, Z_HZ_ns, Z_HZ_cyc, Z_CCYC, true, false)
 
@@ -796,11 +826,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Truncates to the next lowest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in nanoseconds. uint64_t
  *
  * @return The converted time value in ticks. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ns_to_ticks_floor32(t) \
 	z_tmcvt_32(t, Z_HZ_ns, Z_HZ_ticks, true, false, false)
 
@@ -811,11 +842,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Truncates to the next lowest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in nanoseconds. uint64_t
  *
  * @return The converted time value in ticks. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ns_to_ticks_floor64(t) \
 	z_tmcvt_64(t, Z_HZ_ns, Z_HZ_ticks, true, false, false)
 
@@ -826,11 +858,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Rounds to the nearest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in nanoseconds. uint64_t
  *
  * @return The converted time value in ticks. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ns_to_ticks_near32(t) \
 	z_tmcvt_32(t, Z_HZ_ns, Z_HZ_ticks, true, false, true)
 
@@ -841,11 +874,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Rounds to the nearest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in nanoseconds. uint64_t
  *
  * @return The converted time value in ticks. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ns_to_ticks_near64(t) \
 	z_tmcvt_64(t, Z_HZ_ns, Z_HZ_ticks, true, false, true)
 
@@ -856,11 +890,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Rounds up to the next highest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in nanoseconds. uint64_t
  *
  * @return The converted time value in ticks. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ns_to_ticks_ceil32(t) \
 	z_tmcvt_32(t, Z_HZ_ns, Z_HZ_ticks, true, true, false)
 
@@ -871,11 +906,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Rounds up to the next highest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in nanoseconds. uint64_t
  *
  * @return The converted time value in ticks. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ns_to_ticks_ceil64(t) \
 	z_tmcvt_64(t, Z_HZ_ns, Z_HZ_ticks, true, true, false)
 
@@ -886,11 +922,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Truncates to the next lowest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in hardware cycles. uint64_t
  *
  * @return The converted time value in milliseconds. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_cyc_to_ms_floor32(t) \
 	z_tmcvt_32(t, Z_HZ_cyc, Z_HZ_ms, Z_CCYC, false, false)
 
@@ -901,11 +938,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Truncates to the next lowest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in hardware cycles. uint64_t
  *
  * @return The converted time value in milliseconds. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_cyc_to_ms_floor64(t) \
 	z_tmcvt_64(t, Z_HZ_cyc, Z_HZ_ms, Z_CCYC, false, false)
 
@@ -916,11 +954,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Rounds to the nearest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in hardware cycles. uint64_t
  *
  * @return The converted time value in milliseconds. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_cyc_to_ms_near32(t) \
 	z_tmcvt_32(t, Z_HZ_cyc, Z_HZ_ms, Z_CCYC, false, true)
 
@@ -931,11 +970,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Rounds to the nearest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in hardware cycles. uint64_t
  *
  * @return The converted time value in milliseconds. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_cyc_to_ms_near64(t) \
 	z_tmcvt_64(t, Z_HZ_cyc, Z_HZ_ms, Z_CCYC, false, true)
 
@@ -946,11 +986,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Rounds up to the next highest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in hardware cycles. uint64_t
  *
  * @return The converted time value in milliseconds. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_cyc_to_ms_ceil32(t) \
 	z_tmcvt_32(t, Z_HZ_cyc, Z_HZ_ms, Z_CCYC, true, false)
 
@@ -961,11 +1002,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Rounds up to the next highest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in hardware cycles. uint64_t
  *
  * @return The converted time value in milliseconds. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_cyc_to_ms_ceil64(t) \
 	z_tmcvt_64(t, Z_HZ_cyc, Z_HZ_ms, Z_CCYC, true, false)
 
@@ -976,11 +1018,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Truncates to the next lowest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in hardware cycles. uint64_t
  *
  * @return The converted time value in microseconds. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_cyc_to_us_floor32(t) \
 	z_tmcvt_32(t, Z_HZ_cyc, Z_HZ_us, Z_CCYC, false, false)
 
@@ -991,11 +1034,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Truncates to the next lowest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in hardware cycles. uint64_t
  *
  * @return The converted time value in microseconds. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_cyc_to_us_floor64(t) \
 	z_tmcvt_64(t, Z_HZ_cyc, Z_HZ_us, Z_CCYC, false, false)
 
@@ -1006,11 +1050,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Rounds to the nearest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in hardware cycles. uint64_t
  *
  * @return The converted time value in microseconds. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_cyc_to_us_near32(t) \
 	z_tmcvt_32(t, Z_HZ_cyc, Z_HZ_us, Z_CCYC, false, true)
 
@@ -1021,11 +1066,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Rounds to the nearest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in hardware cycles. uint64_t
  *
  * @return The converted time value in microseconds. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_cyc_to_us_near64(t) \
 	z_tmcvt_64(t, Z_HZ_cyc, Z_HZ_us, Z_CCYC, false, true)
 
@@ -1036,11 +1082,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Rounds up to the next highest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in hardware cycles. uint64_t
  *
  * @return The converted time value in microseconds. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_cyc_to_us_ceil32(t) \
 	z_tmcvt_32(t, Z_HZ_cyc, Z_HZ_us, Z_CCYC, true, false)
 
@@ -1051,11 +1098,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Rounds up to the next highest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in hardware cycles. uint64_t
  *
  * @return The converted time value in microseconds. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_cyc_to_us_ceil64(t) \
 	z_tmcvt_64(t, Z_HZ_cyc, Z_HZ_us, Z_CCYC, true, false)
 
@@ -1066,11 +1114,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Truncates to the next lowest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in hardware cycles. uint64_t
  *
  * @return The converted time value in nanoseconds. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_cyc_to_ns_floor32(t) \
 	z_tmcvt_32(t, Z_HZ_cyc, Z_HZ_ns, Z_CCYC, false, false)
 
@@ -1081,11 +1130,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Truncates to the next lowest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in hardware cycles. uint64_t
  *
  * @return The converted time value in nanoseconds. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_cyc_to_ns_floor64(t) \
 	z_tmcvt_64(t, Z_HZ_cyc, Z_HZ_ns, Z_CCYC, false, false)
 
@@ -1096,11 +1146,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Rounds to the nearest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in hardware cycles. uint64_t
  *
  * @return The converted time value in nanoseconds. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_cyc_to_ns_near32(t) \
 	z_tmcvt_32(t, Z_HZ_cyc, Z_HZ_ns, Z_CCYC, false, true)
 
@@ -1111,11 +1162,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Rounds to the nearest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in hardware cycles. uint64_t
  *
  * @return The converted time value in nanoseconds. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_cyc_to_ns_near64(t) \
 	z_tmcvt_64(t, Z_HZ_cyc, Z_HZ_ns, Z_CCYC, false, true)
 
@@ -1126,11 +1178,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Rounds up to the next highest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in hardware cycles. uint64_t
  *
  * @return The converted time value in nanoseconds. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_cyc_to_ns_ceil32(t) \
 	z_tmcvt_32(t, Z_HZ_cyc, Z_HZ_ns, Z_CCYC, true, false)
 
@@ -1141,11 +1194,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Rounds up to the next highest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in hardware cycles. uint64_t
  *
  * @return The converted time value in nanoseconds. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_cyc_to_ns_ceil64(t) \
 	z_tmcvt_64(t, Z_HZ_cyc, Z_HZ_ns, Z_CCYC, true, false)
 
@@ -1156,11 +1210,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Truncates to the next lowest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in hardware cycles. uint64_t
  *
  * @return The converted time value in ticks. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_cyc_to_ticks_floor32(t) \
 	z_tmcvt_32(t, Z_HZ_cyc, Z_HZ_ticks, Z_CCYC, false, false)
 
@@ -1171,11 +1226,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Truncates to the next lowest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in hardware cycles. uint64_t
  *
  * @return The converted time value in ticks. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_cyc_to_ticks_floor64(t) \
 	z_tmcvt_64(t, Z_HZ_cyc, Z_HZ_ticks, Z_CCYC, false, false)
 
@@ -1186,11 +1242,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Rounds to the nearest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in hardware cycles. uint64_t
  *
  * @return The converted time value in ticks. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_cyc_to_ticks_near32(t) \
 	z_tmcvt_32(t, Z_HZ_cyc, Z_HZ_ticks, Z_CCYC, false, true)
 
@@ -1201,11 +1258,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Rounds to the nearest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in hardware cycles. uint64_t
  *
  * @return The converted time value in ticks. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_cyc_to_ticks_near64(t) \
 	z_tmcvt_64(t, Z_HZ_cyc, Z_HZ_ticks, Z_CCYC, false, true)
 
@@ -1216,11 +1274,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Rounds up to the next highest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in hardware cycles. uint64_t
  *
  * @return The converted time value in ticks. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_cyc_to_ticks_ceil32(t) \
 	z_tmcvt_32(t, Z_HZ_cyc, Z_HZ_ticks, Z_CCYC, true, false)
 
@@ -1231,11 +1290,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Rounds up to the next highest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in hardware cycles. uint64_t
  *
  * @return The converted time value in ticks. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_cyc_to_ticks_ceil64(t) \
 	z_tmcvt_64(t, Z_HZ_cyc, Z_HZ_ticks, Z_CCYC, true, false)
 
@@ -1246,11 +1306,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Truncates to the next lowest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in ticks. uint64_t
  *
  * @return The converted time value in milliseconds. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ticks_to_ms_floor32(t) \
 	z_tmcvt_32(t, Z_HZ_ticks, Z_HZ_ms, true, false, false)
 
@@ -1261,11 +1322,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Truncates to the next lowest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in ticks. uint64_t
  *
  * @return The converted time value in milliseconds. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ticks_to_ms_floor64(t) \
 	z_tmcvt_64(t, Z_HZ_ticks, Z_HZ_ms, true, false, false)
 
@@ -1276,11 +1338,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Rounds to the nearest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in ticks. uint64_t
  *
  * @return The converted time value in milliseconds. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ticks_to_ms_near32(t) \
 	z_tmcvt_32(t, Z_HZ_ticks, Z_HZ_ms, true, false, true)
 
@@ -1291,11 +1354,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Rounds to the nearest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in ticks. uint64_t
  *
  * @return The converted time value in milliseconds. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ticks_to_ms_near64(t) \
 	z_tmcvt_64(t, Z_HZ_ticks, Z_HZ_ms, true, false, true)
 
@@ -1306,11 +1370,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Rounds up to the next highest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in ticks. uint64_t
  *
  * @return The converted time value in milliseconds. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ticks_to_ms_ceil32(t) \
 	z_tmcvt_32(t, Z_HZ_ticks, Z_HZ_ms, true, true, false)
 
@@ -1321,11 +1386,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Rounds up to the next highest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in ticks. uint64_t
  *
  * @return The converted time value in milliseconds. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ticks_to_ms_ceil64(t) \
 	z_tmcvt_64(t, Z_HZ_ticks, Z_HZ_ms, true, true, false)
 
@@ -1336,11 +1402,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Truncates to the next lowest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in ticks. uint64_t
  *
  * @return The converted time value in microseconds. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ticks_to_us_floor32(t) \
 	z_tmcvt_32(t, Z_HZ_ticks, Z_HZ_us, true, false, false)
 
@@ -1351,11 +1418,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Truncates to the next lowest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in ticks. uint64_t
  *
  * @return The converted time value in microseconds. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ticks_to_us_floor64(t) \
 	z_tmcvt_64(t, Z_HZ_ticks, Z_HZ_us, true, false, false)
 
@@ -1366,11 +1434,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Rounds to the nearest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in ticks. uint64_t
  *
  * @return The converted time value in microseconds. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ticks_to_us_near32(t) \
 	z_tmcvt_32(t, Z_HZ_ticks, Z_HZ_us, true, false, true)
 
@@ -1381,11 +1450,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Rounds to the nearest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in ticks. uint64_t
  *
  * @return The converted time value in microseconds. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ticks_to_us_near64(t) \
 	z_tmcvt_64(t, Z_HZ_ticks, Z_HZ_us, true, false, true)
 
@@ -1396,11 +1466,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Rounds up to the next highest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in ticks. uint64_t
  *
  * @return The converted time value in microseconds. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ticks_to_us_ceil32(t) \
 	z_tmcvt_32(t, Z_HZ_ticks, Z_HZ_us, true, true, false)
 
@@ -1411,11 +1482,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Rounds up to the next highest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in ticks. uint64_t
  *
  * @return The converted time value in microseconds. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ticks_to_us_ceil64(t) \
 	z_tmcvt_64(t, Z_HZ_ticks, Z_HZ_us, true, true, false)
 
@@ -1426,11 +1498,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Truncates to the next lowest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in ticks. uint64_t
  *
  * @return The converted time value in nanoseconds. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ticks_to_ns_floor32(t) \
 	z_tmcvt_32(t, Z_HZ_ticks, Z_HZ_ns, true, false, false)
 
@@ -1441,11 +1514,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Truncates to the next lowest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in ticks. uint64_t
  *
  * @return The converted time value in nanoseconds. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ticks_to_ns_floor64(t) \
 	z_tmcvt_64(t, Z_HZ_ticks, Z_HZ_ns, true, false, false)
 
@@ -1456,11 +1530,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Rounds to the nearest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in ticks. uint64_t
  *
  * @return The converted time value in nanoseconds. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ticks_to_ns_near32(t) \
 	z_tmcvt_32(t, Z_HZ_ticks, Z_HZ_ns, true, false, true)
 
@@ -1471,11 +1546,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Rounds to the nearest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in ticks. uint64_t
  *
  * @return The converted time value in nanoseconds. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ticks_to_ns_near64(t) \
 	z_tmcvt_64(t, Z_HZ_ticks, Z_HZ_ns, true, false, true)
 
@@ -1486,11 +1562,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Rounds up to the next highest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in ticks. uint64_t
  *
  * @return The converted time value in nanoseconds. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ticks_to_ns_ceil32(t) \
 	z_tmcvt_32(t, Z_HZ_ticks, Z_HZ_ns, true, true, false)
 
@@ -1501,11 +1578,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Rounds up to the next highest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in ticks. uint64_t
  *
  * @return The converted time value in nanoseconds. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ticks_to_ns_ceil64(t) \
 	z_tmcvt_64(t, Z_HZ_ticks, Z_HZ_ns, true, true, false)
 
@@ -1516,11 +1594,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Truncates to the next lowest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in ticks. uint64_t
  *
  * @return The converted time value in hardware cycles. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ticks_to_cyc_floor32(t) \
 	z_tmcvt_32(t, Z_HZ_ticks, Z_HZ_cyc, Z_CCYC, false, false)
 
@@ -1531,11 +1610,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Truncates to the next lowest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in ticks. uint64_t
  *
  * @return The converted time value in hardware cycles. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ticks_to_cyc_floor64(t) \
 	z_tmcvt_64(t, Z_HZ_ticks, Z_HZ_cyc, Z_CCYC, false, false)
 
@@ -1546,11 +1626,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Rounds to the nearest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in ticks. uint64_t
  *
  * @return The converted time value in hardware cycles. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ticks_to_cyc_near32(t) \
 	z_tmcvt_32(t, Z_HZ_ticks, Z_HZ_cyc, Z_CCYC, false, true)
 
@@ -1561,11 +1642,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Rounds to the nearest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in ticks. uint64_t
  *
  * @return The converted time value in hardware cycles. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ticks_to_cyc_near64(t) \
 	z_tmcvt_64(t, Z_HZ_ticks, Z_HZ_cyc, Z_CCYC, false, true)
 
@@ -1576,11 +1658,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 32 bit precision.
  * Rounds up to the next highest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in ticks. uint64_t
  *
  * @return The converted time value in hardware cycles. uint32_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ticks_to_cyc_ceil32(t) \
 	z_tmcvt_32(t, Z_HZ_ticks, Z_HZ_cyc, Z_CCYC, true, false)
 
@@ -1591,11 +1674,12 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
  * Computes result in 64 bit precision.
  * Rounds up to the next highest output unit.
  *
+ * @warning Generated. Do not edit. See above.
+ *
  * @param t Source time in ticks. uint64_t
  *
  * @return The converted time value in hardware cycles. uint64_t
  */
-/* Generated.  Do not edit.  See above. */
 #define k_ticks_to_cyc_ceil64(t) \
 	z_tmcvt_64(t, Z_HZ_ticks, Z_HZ_cyc, Z_CCYC, true, false)
 

--- a/samples/basic/hash_map/src/main.c
+++ b/samples/basic/hash_map/src/main.c
@@ -47,7 +47,7 @@ int main(void)
 
 			LOG_DBG("Inserted %zu", i);
 
-			if (k_uptime_get() / MSEC_PER_SEC > CONFIG_TEST_LIB_HASH_MAP_DURATION_S) {
+			if (k_uptime_seconds() > CONFIG_TEST_LIB_HASH_MAP_DURATION_S) {
 				goto out;
 			}
 		}
@@ -60,7 +60,7 @@ int main(void)
 
 			LOG_DBG("Replaced %zu", i);
 
-			if (k_uptime_get() / MSEC_PER_SEC > CONFIG_TEST_LIB_HASH_MAP_DURATION_S) {
+			if (k_uptime_seconds() > CONFIG_TEST_LIB_HASH_MAP_DURATION_S) {
 				goto out;
 			}
 		}
@@ -72,7 +72,7 @@ int main(void)
 
 			LOG_DBG("Removed %zu", i - 1);
 
-			if (k_uptime_get() / MSEC_PER_SEC > CONFIG_TEST_LIB_HASH_MAP_DURATION_S) {
+			if (k_uptime_seconds() > CONFIG_TEST_LIB_HASH_MAP_DURATION_S) {
 				goto out;
 			}
 		}

--- a/subsys/lorawan/services/clock_sync.c
+++ b/subsys/lorawan/services/clock_sync.c
@@ -71,7 +71,7 @@ static struct clock_sync_context ctx;
  */
 static int clock_sync_serialize_device_time(uint8_t *buf, size_t size)
 {
-	uint32_t device_time = k_uptime_get() / MSEC_PER_SEC + ctx.time_offset;
+	uint32_t device_time = k_uptime_seconds() + ctx.time_offset;
 
 	if (size < sizeof(uint32_t)) {
 		return -ENOSPC;
@@ -221,7 +221,7 @@ int lorawan_clock_sync_get(uint32_t *gps_time)
 	__ASSERT(gps_time != NULL, "gps_time parameter is required");
 
 	if (ctx.synchronized) {
-		*gps_time = (uint32_t)(k_uptime_get() / MSEC_PER_SEC + ctx.time_offset);
+		*gps_time = k_uptime_seconds() + ctx.time_offset;
 		return 0;
 	} else {
 		return -EAGAIN;

--- a/subsys/net/ip/ipv6_pe.c
+++ b/subsys/net/ip/ipv6_pe.c
@@ -193,8 +193,7 @@ static bool ipv6_pe_prefix_update_lifetimes(struct net_if_ipv6 *ipv6,
 			continue;
 		}
 
-		addr_age = (uint32_t)(k_uptime_get() / 1000UL) -
-			ipv6->unicast[i].addr_create_time;
+		addr_age = k_uptime_seconds() - ipv6->unicast[i].addr_create_time;
 		new_age = abs(addr_age) + vlifetime;
 
 		if ((new_age >= TEMP_VALID_LIFETIME) ||
@@ -382,7 +381,7 @@ void net_ipv6_pe_start(struct net_if *iface, const struct in6_addr *prefix,
 	ifaddr->is_temporary = true;
 	ifaddr->addr_preferred_lifetime = preferred_lifetime;
 	ifaddr->addr_timeout = ifaddr->addr_preferred_lifetime - DESYNC_FACTOR(ipv6);
-	ifaddr->addr_create_time = (uint32_t)(k_uptime_get() / 1000UL);
+	ifaddr->addr_create_time = k_uptime_seconds();
 
 	NET_DBG("Lifetime %d desync %d timeout %d preferred %d valid %d",
 		lifetime, DESYNC_FACTOR(ipv6), ifaddr->addr_timeout,
@@ -674,8 +673,7 @@ static void renewal_cb(struct net_if *iface, void *user_data)
 		/* If the address is too old, then generate a new one
 		 * and remove the old address.
 		 */
-		diff = (int32_t)(ipv6->unicast[i].addr_create_time -
-			       ((uint32_t)(k_uptime_get() / 1000UL)));
+		diff = (int32_t)(ipv6->unicast[i].addr_create_time - k_uptime_seconds());
 		diff = abs(diff);
 
 		if (diff < (ipv6->unicast[i].addr_preferred_lifetime -

--- a/subsys/net/lib/lwm2m/ipso_light_control.c
+++ b/subsys/net/lib/lwm2m/ipso_light_control.c
@@ -78,8 +78,7 @@ static void *on_time_read_cb(uint16_t obj_inst_id, uint16_t res_id, uint16_t res
 		}
 
 		if (on_off_value[i]) {
-			on_time_value[i] = (k_uptime_get() / MSEC_PER_SEC) -
-				on_time_offset[i];
+			on_time_value[i] = k_uptime_seconds() - on_time_offset[i];
 		}
 
 		*data_len = sizeof(on_time_value[i]);
@@ -109,8 +108,7 @@ static int on_time_post_write_cb(uint16_t obj_inst_id,
 		}
 
 		if (counter == 0) {
-			on_time_offset[i] =
-				(int32_t)(k_uptime_get() / MSEC_PER_SEC);
+			on_time_offset[i] = k_uptime_seconds();
 		}
 
 		return 0;

--- a/subsys/net/lib/lwm2m/lwm2m_obj_device.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_device.c
@@ -176,7 +176,7 @@ static int reset_error_list_cb(uint16_t obj_inst_id,
 static void *current_time_read_cb(uint16_t obj_inst_id, uint16_t res_id,
 				  uint16_t res_inst_id, size_t *data_len)
 {
-	time_temp = time_offset + (k_uptime_get() / 1000);
+	time_temp = time_offset + k_uptime_seconds();
 	*data_len = sizeof(time_temp);
 
 	return &time_temp;
@@ -195,10 +195,10 @@ static int current_time_post_write_cb(uint16_t obj_inst_id, uint16_t res_id,
 				      bool last_block, size_t total_size)
 {
 	if (data_len == 4U) {
-		time_offset = *(uint32_t *)data - (uint32_t)(k_uptime_get() / 1000);
+		time_offset = *(uint32_t *)data - k_uptime_seconds();
 		return 0;
 	} else if (data_len == 8U) {
-		time_offset = *(time_t *)data - (time_t)(k_uptime_get() / 1000);
+		time_offset = *(time_t *)data - (time_t)k_uptime_seconds();
 		return 0;
 	}
 

--- a/tests/subsys/lorawan/clock_sync/src/main.c
+++ b/tests/subsys/lorawan/clock_sync/src/main.c
@@ -81,7 +81,7 @@ ZTEST(clock_sync, test_app_time)
 
 	device_time = sys_get_le32(req.data + 1);
 	token_req = req.data[5] & 0xF;
-	zassert_within((int)device_time, (int)(k_uptime_get() / 1000), 1);
+	zassert_within((int)device_time, k_uptime_seconds(), 1);
 
 	/* apply a time correction of 1000 seconds */
 	sys_put_le32(1000, ans_data + 1);
@@ -90,7 +90,7 @@ ZTEST(clock_sync, test_app_time)
 	lorawan_emul_send_downlink(CLOCK_SYNC_PORT, false, 0, 0, sizeof(ans_data), ans_data);
 
 	lorawan_clock_sync_get(&gps_time);
-	zassert_within(gps_time, (k_uptime_get() / 1000) + 1000, 1);
+	zassert_within(gps_time, k_uptime_seconds() + 1000, 1);
 }
 
 ZTEST(clock_sync, test_device_app_time_periodicity)


### PR DESCRIPTION
Add a helper function for retrieving the system uptime in seconds without having to do a second division.

Additionally:
 * Cleanup `time_unit.h` doxygen
 * Generate all time conversion functions for seconds unit
 * Convert in-tree usage of `k_uptime_get() / 1000` to new function
