### PR TITLE
Websocket closing fixes

### DIFF
--- a/include/zephyr/net/websocket.h
+++ b/include/zephyr/net/websocket.h
@@ -201,6 +201,17 @@ int websocket_disconnect(int ws_sock);
  */
 int websocket_register(int http_sock, uint8_t *recv_buf, size_t recv_buf_len);
 
+/**
+ * @brief Unregister a websocket. This is called when we no longer need
+ *        the underlaying "real" socket. This will close first the websocket
+ *        and then the original socket.
+ *
+ * @param ws_sock Websocket connection socket.
+ *
+ * @return <0 if error, 0 the websocket connection is now fully closed
+ */
+int websocket_unregister(int ws_sock);
+
 #if defined(CONFIG_WEBSOCKET_CLIENT)
 void websocket_init(void);
 #else

--- a/samples/net/sockets/http_server/src/ws.c
+++ b/samples/net/sockets/http_server/src/ws.c
@@ -12,6 +12,7 @@
 #include <zephyr/net/http/service.h>
 #include <zephyr/net/net_ip.h>
 #include <zephyr/net/socket.h>
+#include <zephyr/net/websocket.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(net_http_server_sample, LOG_LEVEL_DBG);
@@ -173,7 +174,7 @@ static void ws_handler(void *ptr1, void *ptr2, void *ptr3)
 
 	*in_use = false;
 
-	(void)close(client);
+	(void)websocket_unregister(client);
 
 	cfg->sock = -1;
 }

--- a/subsys/net/lib/websocket/websocket.c
+++ b/subsys/net/lib/websocket/websocket.c
@@ -1193,6 +1193,58 @@ out:
 	return ret;
 }
 
+static struct websocket_context *websocket_search(int sock)
+{
+	struct websocket_context *ctx = NULL;
+	int i;
+
+	k_sem_take(&contexts_lock, K_FOREVER);
+
+	for (i = 0; i < ARRAY_SIZE(contexts); i++) {
+		if (!websocket_context_is_used(&contexts[i])) {
+			continue;
+		}
+
+		if (contexts[i].sock != sock) {
+			continue;
+		}
+
+		ctx = &contexts[i];
+		break;
+	}
+
+	k_sem_give(&contexts_lock);
+
+	return ctx;
+}
+
+int websocket_unregister(int sock)
+{
+	struct websocket_context *ctx;
+
+	if (sock < 0) {
+		return -EINVAL;
+	}
+
+	ctx = websocket_search(sock);
+	if (ctx == NULL) {
+		NET_DBG("[%p] Real socket for websocket sock %d not found!", ctx, sock);
+		return -ENOENT;
+	}
+
+	if (ctx->real_sock < 0) {
+		return -EALREADY;
+	}
+
+	(void)zsock_close(sock);
+	(void)zsock_close(ctx->real_sock);
+
+	ctx->real_sock = -1;
+	ctx->sock = -1;
+
+	return 0;
+}
+
 static const struct socket_op_vtable websocket_fd_op_vtable = {
 	.fd_vtable = {
 		.read = websocket_read_vmeth,

--- a/subsys/net/lib/websocket/websocket.c
+++ b/subsys/net/lib/websocket/websocket.c
@@ -441,10 +441,15 @@ static int websocket_close_vmeth(void *obj)
 
 	ret = websocket_interal_disconnect(ctx);
 	if (ret < 0) {
-		NET_DBG("[%p] Cannot close (%d)", obj, ret);
+		/* Ignore error if we are not connected */
+		if (ret != -ENOTCONN) {
+			NET_DBG("[%p] Cannot close (%d)", obj, ret);
 
-		errno = -ret;
-		return -1;
+			errno = -ret;
+			return -1;
+		}
+
+		ret = 0;
 	}
 
 	return ret;


### PR DESCRIPTION
Doing a normal close for a websocket does not close the underlying real socket. If we do not have fd for the real socket, then it is not possible to fully close a websocket connection. As we are allocating a websocket using `websocket_register()` in HTTP server use case, create a `websocket_unregister()` that will close both the real socket and the websocket socket.
