### PR TITLE
dts: bindings: serial: nrf-uart: current-speed shall be required

### DIFF
--- a/dts/bindings/serial/nordic,nrf-uart-common.yaml
+++ b/dts/bindings/serial/nordic,nrf-uart-common.yaml
@@ -17,6 +17,7 @@ properties:
       if CONFIG_PINCTRL is enabled).
 
   current-speed:
+    required: true
     description: |
       Initial baud rate setting for UART. Only a fixed set of baud
       rates are selectable on these devices.


### PR DESCRIPTION
Adding required flag to the current-speed as without this driver does not compile.