### PR TITLE
tests: net: ipv6: Fix RA test

### DIFF
--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -756,6 +756,8 @@ static void ra_message(void)
 ZTEST(net_ipv6, test_rs_ra_message)
 {
 	rs_message();
+	/* Small delay to let the net stack process the generated RA message. */
+	k_sleep(K_MSEC(10));
 	ra_message();
 }
 


### PR DESCRIPTION
Due to recent changes, as simple k_yield() is not enough on some platforms (nRF platforms for example), as the entropy subsystem is now used because of PE, which may block, causing context switch before entire RA message is processed.

Fix this by adding small delay before checking if RA was processed properly.

Fixes #72518