### PR TITLE
drivers/console/xtensa_sim_console: force `\r\n` byte sequence for newline

### DIFF
--- a/drivers/console/xtensa_sim_console.c
+++ b/drivers/console/xtensa_sim_console.c
@@ -25,6 +25,14 @@ int arch_printk_char_out(int c)
 	register int ret_err __asm__ ("a3");
 
 	buf[0] = (char)c;
+
+	if (buf[0] == '\n') {
+		buf[1] = buf[0];
+		buf[0] = '\r';
+		a3++;
+		a5++;
+	}
+
 	__asm__ volatile ("simcall"
 				: "=a" (ret_val), "=a" (ret_err)
 				: "a" (a2), "a" (a3), "a" (a4), "a" (a5)


### PR DESCRIPTION
Force `\r\n` byte sequence for newline for the Xtensa simulator console driver. This effectively mirrors the behavior of the UART console driver.