### PR TITLE
tests: drivers: gpio: gpio_basic_api: Add nrf54h20dk overlays

### DIFF
--- a/modules/hal_nordic/nrfx/nrfx_glue.h
+++ b/modules/hal_nordic/nrfx/nrfx_glue.h
@@ -334,6 +334,9 @@ void nrfx_busy_wait(uint32_t usec_to_wait);
 				   NRFX_PPI_GROUPS_USED_BY_802154_DRV | \
 				   NRFX_PPI_GROUPS_USED_BY_MPSL)
 
+/** @brief Bitmask that defines GPIOTE130 channels reserved for use outside of the nrfx library. */
+#define NRFX_GPIOTE130_CHANNELS_USED ~NRFX_CONFIG_MASK_DT(DT_NODELABEL(gpiote130), owned_channels)
+
 #if defined(CONFIG_BT_CTLR)
 /*
  * The enabled Bluetooth controller subsystem is responsible for providing

--- a/tests/drivers/gpio/gpio_basic_api/boards/nrf54h20dk_nrf54h20_common.dtsi
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nrf54h20dk_nrf54h20_common.dtsi
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/ {
+	resources {
+		compatible = "test-gpio-basic-api";
+		out-gpios = <&gpio0 6 0>;
+		in-gpios = <&gpio0 7 0>;
+	};
+};
+
+&gpio0 {
+	status = "okay";
+	sense-edge-mask = <0x60>;
+};
+
+&gpiote130 {
+	status = "okay";
+	owned-channels = < 0 1 >;
+};

--- a/tests/drivers/gpio/gpio_basic_api/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "nrf54h20dk_nrf54h20_common.dtsi"

--- a/tests/drivers/gpio/gpio_basic_api/boards/nrf54h20dk_nrf54h20_cpurad.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nrf54h20dk_nrf54h20_cpurad.overlay
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "nrf54h20dk_nrf54h20_common.dtsi"


### PR DESCRIPTION
Add overlays for nrf54h20dk_nrf54h20 cpuapp and cpurad.