### PR TITLE
MAINTAINERS: add nRF platform second maintainer

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3467,11 +3467,11 @@ nRF Platforms:
   status: maintained
   maintainers:
     - anangl
+    - masz-nordic
   collaborators:
     - jaz1-nordic
     - kl-cruz
     - magp-nordic
-    - masz-nordic
     - nika-nordic
   files:
     - boards/nordic/


### PR DESCRIPTION
Add myself as a second maintainer for nRF platform.