### PR TITLE
testsuite: coverage: support coverage information across reboots

### DIFF
--- a/lib/os/reboot.c
+++ b/lib/os/reboot.c
@@ -9,11 +9,16 @@
 #include <zephyr/sys/reboot.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
+#include <zephyr/debug/gcov.h>
 
 extern void sys_arch_reboot(int type);
 
 FUNC_NORETURN void sys_reboot(int type)
 {
+#ifdef CONFIG_COVERAGE_DUMP
+	gcov_coverage_dump();
+#endif /* CONFIG_COVERAGE_DUMP */
+
 	(void)irq_lock();
 
 	/* Disable caches to ensure all data is flushed */

--- a/subsys/testsuite/coverage/coverage.c
+++ b/subsys/testsuite/coverage/coverage.c
@@ -261,7 +261,9 @@ void gcov_coverage_dump(void)
 	struct gcov_info *gcov_list_first = gcov_info_head;
 	struct gcov_info *gcov_list = gcov_info_head;
 
-	k_sched_lock();
+	if (!k_is_in_isr()) {
+		k_sched_lock();
+	}
 	printk("\nGCOV_COVERAGE_DUMP_START");
 	while (gcov_list) {
 
@@ -290,7 +292,9 @@ void gcov_coverage_dump(void)
 	}
 coverage_dump_end:
 	printk("\nGCOV_COVERAGE_DUMP_END\n");
-	k_sched_unlock();
+	if (!k_is_in_isr()) {
+		k_sched_unlock();
+	}
 	return;
 }
 


### PR DESCRIPTION
Add support for generating code coverage information across reboots in a test run.
Rebooting during tests is a useful pattern for validating reboot/exception handling.
As a valid test pattern, it is also desirable that the coverage information contains all code the test run.

Without this PR, the gcov dump only occurs once at the end of the test execution, and only contains coverage information from the last "boot". This obviously excludes any exception handlers or reboot logic.

With this PR, coverage is accurately calculated:
![image](https://github.com/zephyrproject-rtos/zephyr/assets/8476715/46280e4b-ad2f-423f-9566-fb7b4ba946b3)

The runtime cost of searching the logs for additional dumps is functionally 0 as under normal operation the single gcov dump is the last item in the logs.