### PR TITLE
twister: allow using west-flash with 'erase'

### DIFF
--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -501,16 +501,10 @@ class FilterBuilder(CMake):
         if self.testsuite.sysbuild and self.env.options.device_testing:
             # Verify that twister's arguments support sysbuild.
             # Twister sysbuild flashing currently only works with west, so
-            # --west-flash must be passed. Additionally, erasing the DUT
-            # before each test with --west-flash=--erase will inherently not
-            # work with sysbuild.
+            # --west-flash must be passed.
             if self.env.options.west_flash is None:
                 logger.warning("Sysbuild test will be skipped. " +
                     "West must be used for flashing.")
-                return {os.path.join(self.platform.name, self.testsuite.name): True}
-            elif "--erase" in self.env.options.west_flash:
-                logger.warning("Sysbuild test will be skipped, " +
-                    "--erase is not supported with --west-flash")
                 return {os.path.join(self.platform.name, self.testsuite.name): True}
 
         if self.testsuite and self.testsuite.filter:

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -555,20 +555,6 @@ TESTDATA_3 = [
         {os.path.join('other', 'dummy.testsuite.name'): True}
     ),
     (
-        'other', ['other'], True,
-        False, ['--erase'], True,
-        'Dummy parse results', True,
-        None,
-        None,
-        {},
-        {},
-        None,
-        b'dummy edt pickle contents',
-        ['Sysbuild test will be skipped,' \
-         ' --erase is not supported with --west-flash'],
-        {os.path.join('other', 'dummy.testsuite.name'): True}
-    ),
-    (
         'other', ['other'], False,
         True, None, False,
         'Dummy parse results', True,
@@ -651,7 +637,7 @@ TESTDATA_3 = [
     ' expected_logs, expected_return',
     TESTDATA_3,
     ids=['unit testing', 'domain', 'kconfig', 'no cache',
-         'no west options', 'erase west flash option', 'no edt',
+         'no west options', 'no edt',
          'parse result', 'no parse result', 'no testsuite filter', 'parse err']
 )
 def test_filterbuilder_parse_generated(


### PR DESCRIPTION
Using `erase` with west-flash was blocked as it was messing with sysbuild. With #69748 the issue is fixed, hence 'erase' is no longer blocked. Remove obsolete twister test