### PR TITLE
samples: drivers: watchdog: Run sample on nrf54h20

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -39,6 +39,7 @@
 		sw2 = &button2;
 		sw3 = &button3;
 		ipc-to-cpusys = &cpuapp_cpusys_ipc;
+		watchdog0 = &wdt010;
 	};
 
 	buttons {

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.yaml
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.yaml
@@ -15,4 +15,3 @@ supported:
   - gpio
   - pwm
   - spi
-  - watchdog

--- a/samples/drivers/watchdog/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/drivers/watchdog/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2024 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&wdt010 {
+	status = "okay";
+};

--- a/samples/drivers/watchdog/boards/nrf54l15pdk_nrf54l15_cpuflpr.overlay
+++ b/samples/drivers/watchdog/boards/nrf54l15pdk_nrf54l15_cpuflpr.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2024 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&wdt30 {
+	status = "okay";
+};

--- a/samples/drivers/watchdog/boards/nrf54l15pdk_nrf54l15_cpuflpr_xip.overlay
+++ b/samples/drivers/watchdog/boards/nrf54l15pdk_nrf54l15_cpuflpr_xip.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2024 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&wdt30 {
+	status = "okay";
+};


### PR DESCRIPTION
Add overlay that enables selected WDT instance on
nrf54h20 Application core.