### PR TITLE
tests: drivers: pwm_api: nrf54h20dk: disable pwm120

### DIFF
--- a/tests/drivers/pwm/pwm_api/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -19,3 +19,7 @@
 	pinctrl-names = "default", "sleep";
 	memory-regions = <&cpuapp_dma_region>;
 };
+
+&pwm120 {
+	status = "disabled";
+};


### PR DESCRIPTION
When PWM120 instance is enabled, it will cause the test to use this instance instead of PWM130.