### PR TITLE
Bluetooth: Audio: Add fallbacks codec functions that have an implied value (per the BAP spec)

### DIFF
--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -534,6 +534,10 @@ Bluetooth Audio
   :c:func:`bt_audio_codec_cap_get_supported_audio_chan_counts`.
   To maintain existing behavior set the parameter to ``false``. (:github:`72090`)
 
+* Added ``fallback_to_default`` parameter to
+  :c:func:`bt_audio_codec_cap_get_max_codec_frames_per_sdu`.
+  To maintain existing behavior set the parameter to ``false``. (:github:`72090`)
+
 Bluetooth Classic
 =================
 

--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -538,6 +538,10 @@ Bluetooth Audio
   :c:func:`bt_audio_codec_cap_get_max_codec_frames_per_sdu`.
   To maintain existing behavior set the parameter to ``false``. (:github:`72090`)
 
+* Added ``fallback_to_default`` parameter to
+  :c:func:`bt_audio_codec_cfg_meta_get_pref_context`.
+  To maintain existing behavior set the parameter to ``false``. (:github:`72090`)
+
 Bluetooth Classic
 =================
 

--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -527,6 +527,9 @@ Bluetooth Audio
 * All occurrences of ``set_sirk`` have been changed to just ``sirk`` as the ``s`` in ``sirk`` stands
   for set. (:github:`73413`)
 
+* Added ``fallback_to_default`` parameter to :c:func:`bt_audio_codec_cfg_get_chan_allocation`.
+  To maintain existing behavior set the parameter to ``false``. (:github:`72090`)
+
 Bluetooth Classic
 =================
 

--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -530,6 +530,10 @@ Bluetooth Audio
 * Added ``fallback_to_default`` parameter to :c:func:`bt_audio_codec_cfg_get_chan_allocation`.
   To maintain existing behavior set the parameter to ``false``. (:github:`72090`)
 
+* Added ``fallback_to_default`` parameter to
+  :c:func:`bt_audio_codec_cap_get_supported_audio_chan_counts`.
+  To maintain existing behavior set the parameter to ``false``. (:github:`72090`)
+
 Bluetooth Classic
 =================
 

--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -1178,18 +1178,23 @@ int bt_audio_codec_cfg_meta_set_val(struct bt_audio_codec_cfg *codec_cfg,
  */
 int bt_audio_codec_cfg_meta_unset_val(struct bt_audio_codec_cfg *codec_cfg,
 				      enum bt_audio_metadata_type type);
-/** @brief Extract preferred contexts
+/**
+ * @brief Extract preferred contexts
  *
- *  See @ref BT_AUDIO_METADATA_TYPE_PREF_CONTEXT for more information about this value.
+ * See @ref BT_AUDIO_METADATA_TYPE_PREF_CONTEXT for more information about this value.
  *
- *  @param codec_cfg The codec data to search in.
+ * @param codec_cfg The codec data to search in.
+ * @param fallback_to_default If true this function will provide the default value of
+ *        @ref BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED if the type is not found when @p codec_cfg.id is
+ *        @ref BT_HCI_CODING_FORMAT_LC3.
  *
  *  @retval The preferred context type if positive or 0
  *  @retval -EINVAL if arguments are invalid
  *  @retval -ENODATA if not found
  *  @retval -EBADMSG if found value has invalid size
  */
-int bt_audio_codec_cfg_meta_get_pref_context(const struct bt_audio_codec_cfg *codec_cfg);
+int bt_audio_codec_cfg_meta_get_pref_context(const struct bt_audio_codec_cfg *codec_cfg,
+					     bool fallback_to_default);
 
 /**
  * @brief Set the preferred context of a codec configuration metadata.

--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -986,24 +986,29 @@ int bt_audio_codec_cfg_get_frame_dur(const struct bt_audio_codec_cfg *codec_cfg)
 int bt_audio_codec_cfg_set_frame_dur(struct bt_audio_codec_cfg *codec_cfg,
 				     enum bt_audio_codec_cfg_frame_dur frame_dur);
 
-/** @brief Extract channel allocation from BT codec config
+/**
+ * @brief Extract channel allocation from BT codec config
  *
- *  The value returned is a bit field representing one or more audio locations as
- *  specified by @ref bt_audio_location
- *  Shall match one or more of the bits set in BT_PAC_SNK_LOC/BT_PAC_SRC_LOC.
+ * The value returned is a bit field representing one or more audio locations as
+ * specified by @ref bt_audio_location
+ * Shall match one or more of the bits set in BT_PAC_SNK_LOC/BT_PAC_SRC_LOC.
  *
- *  Up to the configured @ref BT_AUDIO_CODEC_CAP_TYPE_CHAN_COUNT number of channels can be present.
+ * Up to the configured @ref BT_AUDIO_CODEC_CAP_TYPE_CHAN_COUNT number of channels can be present.
  *
- *  @param codec_cfg The codec configuration to extract data from.
- *  @param chan_allocation Pointer to the variable to store the extracted value in.
+ * @param codec_cfg The codec configuration to extract data from.
+ * @param chan_allocation Pointer to the variable to store the extracted value in.
+ * @param fallback_to_default If true this function will provide the default value of
+ *        @ref BT_AUDIO_LOCATION_MONO_AUDIO if the type is not found when @p codec_cfg.id is @ref
+ *        BT_HCI_CODING_FORMAT_LC3.
  *
- *  @retval 0 if value is found and stored in the pointer provided
- *  @retval -EINVAL if arguments are invalid
- *  @retval -ENODATA if not found
- *  @retval -EBADMSG if found value has invalid size or value
+ * @retval 0 if value is found and stored in the pointer provided
+ * @retval -EINVAL if arguments are invalid
+ * @retval -ENODATA if not found
+ * @retval -EBADMSG if found value has invalid size or value
  */
 int bt_audio_codec_cfg_get_chan_allocation(const struct bt_audio_codec_cfg *codec_cfg,
-					   enum bt_audio_location *chan_allocation);
+					   enum bt_audio_location *chan_allocation,
+					   bool fallback_to_default);
 
 /**
  * @brief Set the channel allocation of a codec configuration.
@@ -1051,26 +1056,25 @@ int bt_audio_codec_cfg_get_octets_per_frame(const struct bt_audio_codec_cfg *cod
 int bt_audio_codec_cfg_set_octets_per_frame(struct bt_audio_codec_cfg *codec_cfg,
 					    uint16_t octets_per_frame);
 
-/** @brief Extract number of audio frame blocks in each SDU from BT codec config
+/**
+ * @brief Extract number of audio frame blocks in each SDU from BT codec config
  *
- *  The overall SDU size will be octets_per_frame * frame_blocks_per_sdu * number-of-channels.
+ * The overall SDU size will be octets_per_frame * frame_blocks_per_sdu * number-of-channels.
  *
- *  If this value is not present a default value of 1 shall be used.
+ * If this value is not present a default value of 1 shall be used.
  *
- *  A frame block is one or more frames that represents data for the same period of time but
- *  for different channels. If the stream have two audio channels and this value is two
- *  there will be four frames in the SDU.
+ * A frame block is one or more frames that represents data for the same period of time but
+ * for different channels. If the stream have two audio channels and this value is two
+ * there will be four frames in the SDU.
  *
- *  @param codec_cfg The codec configuration to extract data from.
- *  @param fallback_to_default If true this function will return the default value of 1
- *         if the type is not found. In this case the function will only fail if a NULL
- *         pointer is provided.
+ * @param codec_cfg The codec configuration to extract data from.
+ * @param fallback_to_default If true this function will return the default value of 1
+ *         if the type is not found when @p codec_cfg.id is @ref BT_HCI_CODING_FORMAT_LC3.
  *
- *  @retval The count of codec frames in each SDU if value is found else of @p fallback_to_default
- *          is true then the value 1 is returned if frames per sdu is not found.
- *  @retval -EINVAL if arguments are invalid
- *  @retval -ENODATA if not found
- *  @retval -EBADMSG if found value has invalid size or value
+ * @retval The count of codec frame blocks in each SDU.
+ * @retval -EINVAL if arguments are invalid
+ * @retval -ENODATA if not found
+ * @retval -EBADMSG if found value has invalid size or value
  */
 int bt_audio_codec_cfg_get_frame_blocks_per_sdu(const struct bt_audio_codec_cfg *codec_cfg,
 						bool fallback_to_default);

--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -1585,13 +1585,16 @@ int bt_audio_codec_cap_set_frame_dur(struct bt_audio_codec_cap *codec_cap,
  * @brief Extract the frequency from a codec capability.
  *
  * @param codec_cap The codec capabilities to extract data from.
+ * @param fallback_to_default If true this function will provide the default value of 1
+ *        if the type is not found when @p codec_cap.id is @ref BT_HCI_CODING_FORMAT_LC3.
  *
- * @retval Bitfield of supported channel counts if 0 or positive
+ * @retval Number of supported channel counts if 0 or positive
  * @retval -EINVAL if arguments are invalid
  * @retval -ENODATA if not found
  * @retval -EBADMSG if found value has invalid size or value
  */
-int bt_audio_codec_cap_get_supported_audio_chan_counts(const struct bt_audio_codec_cap *codec_cap);
+int bt_audio_codec_cap_get_supported_audio_chan_counts(const struct bt_audio_codec_cap *codec_cap,
+						       bool fallback_to_default);
 
 /**
  * @brief Set the channel count of a codec capability.

--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -1642,13 +1642,16 @@ int bt_audio_codec_cap_set_octets_per_frame(
  * @brief Extract the maximum codec frames per SDU from a codec capability.
  *
  * @param codec_cap The codec capabilities to extract data from.
+ * @param fallback_to_default If true this function will provide the default value of 1
+ *        if the type is not found when @p codec_cap.id is @ref BT_HCI_CODING_FORMAT_LC3.
  *
  * @retval Maximum number of codec frames per SDU supported
  * @retval -EINVAL if arguments are invalid
  * @retval -ENODATA if not found
  * @retval -EBADMSG if found value has invalid size or value
  */
-int bt_audio_codec_cap_get_max_codec_frames_per_sdu(const struct bt_audio_codec_cap *codec_cap);
+int bt_audio_codec_cap_get_max_codec_frames_per_sdu(const struct bt_audio_codec_cap *codec_cap,
+						    bool fallback_to_default);
 
 /**
  * @brief Set the maximum codec frames per SDU of a codec capability.

--- a/samples/bluetooth/bap_broadcast_sink/src/main.c
+++ b/samples/bluetooth/bap_broadcast_sink/src/main.c
@@ -345,7 +345,7 @@ static int lc3_enable(struct broadcast_sink_stream *sink_stream)
 	}
 
 	ret = bt_audio_codec_cfg_get_chan_allocation(sink_stream->stream.codec_cfg,
-						     &sink_stream->chan_allocation);
+						     &sink_stream->chan_allocation, true);
 	if (ret != 0) {
 		printk("Error: Channel allocation not set, invalid configuration for LC3");
 		return ret;
@@ -622,18 +622,11 @@ static bool find_valid_bis_cb(const struct bt_bap_base_subgroup_bis *bis,
 		return true;
 	}
 
-	err = bt_audio_codec_cfg_get_chan_allocation(&codec_cfg, &chan_allocation);
+	err = bt_audio_codec_cfg_get_chan_allocation(&codec_cfg, &chan_allocation, true);
 	if (err != 0) {
 		printk("Could not find channel allocation for BIS: %d\n", err);
 
-		/* Absence of channel allocation is implicitly mono as per the BAP spec */
-		if (CONFIG_TARGET_BROADCAST_CHANNEL == BT_AUDIO_LOCATION_MONO_AUDIO) {
-			data->bis[0].index = bis->index;
-			data->bis[0].chan_allocation = chan_allocation;
-			data->cnt = 1;
-
-			return false;
-		} else if (err == -ENODATA && strlen(CONFIG_TARGET_BROADCAST_NAME) > 0U) {
+		if (err == -ENODATA && strlen(CONFIG_TARGET_BROADCAST_NAME) > 0U) {
 			/* Accept no channel allocation data available
 			 * if TARGET_BROADCAST_NAME defined. Use current index.
 			 */
@@ -742,7 +735,7 @@ static bool find_valid_bis_in_subgroup_cb(const struct bt_bap_base_subgroup *sub
 		return true;
 	}
 
-	err = bt_audio_codec_cfg_get_chan_allocation(&codec_cfg, &chan_allocation);
+	err = bt_audio_codec_cfg_get_chan_allocation(&codec_cfg, &chan_allocation, false);
 	if (err != 0) {
 		printk("Could not find subgroup channel allocation: %d - Looking in the BISes\n",
 		       err);

--- a/samples/bluetooth/bap_unicast_client/src/stream_lc3.c
+++ b/samples/bluetooth/bap_unicast_client/src/stream_lc3.c
@@ -105,7 +105,7 @@ static int extract_lc3_config(struct tx_stream *stream)
 		return ret;
 	}
 
-	ret = bt_audio_codec_cfg_get_chan_allocation(codec_cfg, &lc3_tx->chan_allocation);
+	ret = bt_audio_codec_cfg_get_chan_allocation(codec_cfg, &lc3_tx->chan_allocation, false);
 	if (ret != 0) {
 		LOG_DBG("Could not get channel allocation: %d", ret);
 		lc3_tx->chan_allocation = BT_AUDIO_LOCATION_MONO_AUDIO;

--- a/samples/bluetooth/bap_unicast_server/src/main.c
+++ b/samples/bluetooth/bap_unicast_server/src/main.c
@@ -154,7 +154,8 @@ static void print_codec_cfg(const struct bt_audio_codec_cfg *codec_cfg)
 			       bt_audio_codec_cfg_frame_dur_to_frame_dur_us(ret));
 		}
 
-		if (bt_audio_codec_cfg_get_chan_allocation(codec_cfg, &chan_allocation) == 0) {
+		ret = bt_audio_codec_cfg_get_chan_allocation(codec_cfg, &chan_allocation, false);
+		if (ret == 0) {
 			printk("  Channel allocation: 0x%x\n", chan_allocation);
 		}
 

--- a/samples/bluetooth/hap_ha/src/bap_unicast_sr.c
+++ b/samples/bluetooth/hap_ha/src/bap_unicast_sr.c
@@ -93,7 +93,8 @@ static void print_codec_cfg(const struct bt_audio_codec_cfg *codec_cfg)
 			       bt_audio_codec_cfg_frame_dur_to_frame_dur_us(ret));
 		}
 
-		if (bt_audio_codec_cfg_get_chan_allocation(codec_cfg, &chan_allocation) == 0) {
+		ret = bt_audio_codec_cfg_get_chan_allocation(codec_cfg, &chan_allocation, false);
+		if (ret == 0) {
 			printk("  Channel allocation: 0x%x\n", chan_allocation);
 		}
 

--- a/samples/bluetooth/tmap_peripheral/src/bap_unicast_sr.c
+++ b/samples/bluetooth/tmap_peripheral/src/bap_unicast_sr.c
@@ -82,7 +82,8 @@ static void print_codec_cfg(const struct bt_audio_codec_cfg *codec_cfg)
 			       bt_audio_codec_cfg_frame_dur_to_frame_dur_us(ret));
 		}
 
-		if (bt_audio_codec_cfg_get_chan_allocation(codec_cfg, &chan_allocation) == 0) {
+		ret = bt_audio_codec_cfg_get_chan_allocation(codec_cfg, &chan_allocation, false);
+		if (ret == 0) {
 			printk("  Channel allocation: 0x%x\n", chan_allocation);
 		}
 

--- a/subsys/bluetooth/audio/codec.c
+++ b/subsys/bluetooth/audio/codec.c
@@ -1192,14 +1192,23 @@ int bt_audio_codec_cfg_meta_unset_val(struct bt_audio_codec_cfg *codec_cfg,
 	return ret;
 }
 
-int bt_audio_codec_cfg_meta_get_pref_context(const struct bt_audio_codec_cfg *codec_cfg)
+int bt_audio_codec_cfg_meta_get_pref_context(const struct bt_audio_codec_cfg *codec_cfg,
+					     bool fallback_to_default)
 {
+	int ret;
+
 	CHECKIF(codec_cfg == NULL) {
 		LOG_DBG("codec_cfg is NULL");
 		return -EINVAL;
 	}
 
-	return codec_meta_get_pref_context(codec_cfg->meta, codec_cfg->meta_len);
+	ret = codec_meta_get_pref_context(codec_cfg->meta, codec_cfg->meta_len);
+
+	if (ret == -ENODATA && fallback_to_default && codec_cfg->id == BT_HCI_CODING_FORMAT_LC3) {
+		return BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED;
+	}
+
+	return ret;
 }
 
 int bt_audio_codec_cfg_meta_set_pref_context(struct bt_audio_codec_cfg *codec_cfg,

--- a/subsys/bluetooth/audio/codec.c
+++ b/subsys/bluetooth/audio/codec.c
@@ -2112,7 +2112,8 @@ int bt_audio_codec_cap_set_octets_per_frame(
 					  codec_frame_le32, sizeof(codec_frame_le32));
 }
 
-int bt_audio_codec_cap_get_max_codec_frames_per_sdu(const struct bt_audio_codec_cap *codec_cap)
+int bt_audio_codec_cap_get_max_codec_frames_per_sdu(const struct bt_audio_codec_cap *codec_cap,
+						    bool fallback_to_default)
 {
 	const uint8_t *data;
 	uint8_t data_len;
@@ -2125,6 +2126,10 @@ int bt_audio_codec_cap_get_max_codec_frames_per_sdu(const struct bt_audio_codec_
 	data_len =
 		bt_audio_codec_cap_get_val(codec_cap, BT_AUDIO_CODEC_CAP_TYPE_FRAME_COUNT, &data);
 	if (data == NULL) {
+		if (fallback_to_default && codec_cap->id == BT_HCI_CODING_FORMAT_LC3) {
+			return 1;
+		}
+
 		return -ENODATA;
 	}
 

--- a/subsys/bluetooth/audio/codec.c
+++ b/subsys/bluetooth/audio/codec.c
@@ -2004,7 +2004,8 @@ int bt_audio_codec_cap_set_frame_dur(struct bt_audio_codec_cap *codec_cap,
 					  &frame_dur_u8, sizeof(frame_dur_u8));
 }
 
-int bt_audio_codec_cap_get_supported_audio_chan_counts(const struct bt_audio_codec_cap *codec_cap)
+int bt_audio_codec_cap_get_supported_audio_chan_counts(const struct bt_audio_codec_cap *codec_cap,
+						       bool fallback_to_default)
 {
 	const uint8_t *data;
 	uint8_t data_len;
@@ -2016,6 +2017,10 @@ int bt_audio_codec_cap_get_supported_audio_chan_counts(const struct bt_audio_cod
 
 	data_len = bt_audio_codec_cap_get_val(codec_cap, BT_AUDIO_CODEC_CAP_TYPE_CHAN_COUNT, &data);
 	if (data == NULL) {
+		if (fallback_to_default && codec_cap->id == BT_HCI_CODING_FORMAT_LC3) {
+			return 1;
+		}
+
 		return -ENODATA;
 	}
 

--- a/subsys/bluetooth/audio/codec.c
+++ b/subsys/bluetooth/audio/codec.c
@@ -467,7 +467,8 @@ int bt_audio_codec_cfg_set_frame_dur(struct bt_audio_codec_cfg *codec_cfg,
 }
 
 int bt_audio_codec_cfg_get_chan_allocation(const struct bt_audio_codec_cfg *codec_cfg,
-					   enum bt_audio_location *chan_allocation)
+					   enum bt_audio_location *chan_allocation,
+					   bool fallback_to_default)
 {
 	const uint8_t *data;
 	uint8_t data_len;
@@ -486,6 +487,12 @@ int bt_audio_codec_cfg_get_chan_allocation(const struct bt_audio_codec_cfg *code
 	data_len =
 		bt_audio_codec_cfg_get_val(codec_cfg, BT_AUDIO_CODEC_CFG_CHAN_ALLOC, &data);
 	if (data == NULL) {
+		if (fallback_to_default && codec_cfg->id == BT_HCI_CODING_FORMAT_LC3) {
+			*chan_allocation = BT_AUDIO_LOCATION_MONO_AUDIO;
+
+			return 0;
+		}
+
 		return -ENODATA;
 	}
 
@@ -564,7 +571,7 @@ int bt_audio_codec_cfg_get_frame_blocks_per_sdu(const struct bt_audio_codec_cfg 
 	data_len = bt_audio_codec_cfg_get_val(codec_cfg,
 					      BT_AUDIO_CODEC_CFG_FRAME_BLKS_PER_SDU, &data);
 	if (data == NULL) {
-		if (fallback_to_default) {
+		if (fallback_to_default && codec_cfg->id == BT_HCI_CODING_FORMAT_LC3) {
 			return 1;
 		}
 

--- a/subsys/bluetooth/audio/shell/audio.h
+++ b/subsys/bluetooth/audio/shell/audio.h
@@ -675,7 +675,7 @@ static inline void print_codec_cap(const struct shell *sh, size_t indent,
 						  (enum bt_audio_codec_cap_frame_dur)ret);
 		}
 
-		ret = bt_audio_codec_cap_get_supported_audio_chan_counts(codec_cap);
+		ret = bt_audio_codec_cap_get_supported_audio_chan_counts(codec_cap, true);
 		if (ret >= 0) {
 			print_codec_cap_chan_count(sh, indent,
 						   (enum bt_audio_codec_cap_chan_count)ret);

--- a/subsys/bluetooth/audio/shell/audio.h
+++ b/subsys/bluetooth/audio/shell/audio.h
@@ -950,7 +950,7 @@ static inline void print_codec_cfg(const struct shell *sh, size_t indent,
 		const uint8_t *data;
 		int ret;
 
-		ret = bt_audio_codec_cfg_meta_get_pref_context(codec_cfg);
+		ret = bt_audio_codec_cfg_meta_get_pref_context(codec_cfg, true);
 		if (ret >= 0) {
 			print_codec_meta_pref_context(sh, indent, (enum bt_audio_context)ret);
 		}

--- a/subsys/bluetooth/audio/shell/audio.h
+++ b/subsys/bluetooth/audio/shell/audio.h
@@ -912,8 +912,8 @@ static inline void print_codec_cfg(const struct shell *sh, size_t indent,
 						  (enum bt_audio_codec_cfg_frame_dur)ret);
 		}
 
-		ret = bt_audio_codec_cfg_get_chan_allocation(codec_cfg, &chan_allocation);
-		if (ret >= 0) {
+		ret = bt_audio_codec_cfg_get_chan_allocation(codec_cfg, &chan_allocation, false);
+		if (ret == 0) {
 			print_codec_cfg_chan_allocation(sh, indent, chan_allocation);
 		}
 

--- a/subsys/bluetooth/audio/shell/audio.h
+++ b/subsys/bluetooth/audio/shell/audio.h
@@ -686,7 +686,7 @@ static inline void print_codec_cap(const struct shell *sh, size_t indent,
 			print_codec_cap_octets_per_codec_frame(sh, indent, &codec_frame);
 		}
 
-		ret = bt_audio_codec_cap_get_max_codec_frames_per_sdu(codec_cap);
+		ret = bt_audio_codec_cap_get_max_codec_frames_per_sdu(codec_cap, true);
 		if (ret >= 0) {
 			print_codec_cap_max_codec_frames_per_sdu(sh, indent, (uint8_t)ret);
 		}

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -2901,8 +2901,8 @@ static void stream_started_cb(struct bt_bap_stream *bap_stream)
 			sh_stream->lc3_frame_duration_us = 0U;
 		}
 
-		ret = bt_audio_codec_cfg_get_chan_allocation(codec_cfg,
-							     &sh_stream->lc3_chan_allocation);
+		ret = bt_audio_codec_cfg_get_chan_allocation(
+			codec_cfg, &sh_stream->lc3_chan_allocation, false);
 		if (ret == 0) {
 			sh_stream->lc3_chan_cnt =
 				bt_audio_get_chan_count(sh_stream->lc3_chan_allocation);

--- a/subsys/bluetooth/audio/shell/cap_initiator.c
+++ b/subsys/bluetooth/audio/shell/cap_initiator.c
@@ -10,6 +10,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
 
@@ -719,7 +720,7 @@ static int set_codec_config(const struct shell *sh, struct shell_stream *sh_stre
 		return 0;
 	}
 
-	err = bt_audio_codec_cfg_get_chan_allocation(&sh_stream->codec_cfg, &chan_alloc);
+	err = bt_audio_codec_cfg_get_chan_allocation(&sh_stream->codec_cfg, &chan_alloc, false);
 	if (err != 0) {
 		if (err == -ENODATA) {
 			chan_alloc = BT_AUDIO_LOCATION_MONO_AUDIO;

--- a/tests/bluetooth/audio/codec/src/main.c
+++ b/tests/bluetooth/audio/codec/src/main.c
@@ -1124,8 +1124,47 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_get_supported_audio_chan_c
 
 	int ret;
 
-	ret = bt_audio_codec_cap_get_supported_audio_chan_counts(&codec_cap);
+	ret = bt_audio_codec_cap_get_supported_audio_chan_counts(&codec_cap, false);
 	zassert_equal(ret, 2, "Unexpected return value %d", ret);
+}
+
+ZTEST(audio_codec_test_suite,
+	test_bt_audio_codec_cap_get_supported_audio_chan_counts_lc3_fallback_true)
+{
+	struct bt_audio_codec_cap codec_cap = {.id = BT_HCI_CODING_FORMAT_LC3};
+	int err;
+
+	err = bt_audio_codec_cap_get_supported_audio_chan_counts(&codec_cap, true);
+	zassert_equal(err, 1, "unexpected error %d", err);
+}
+
+ZTEST(audio_codec_test_suite,
+	test_bt_audio_codec_cap_get_supported_audio_chan_counts_lc3_fallback_false)
+{
+	struct bt_audio_codec_cap codec_cap = {.id = BT_HCI_CODING_FORMAT_LC3};
+	int err;
+
+	err = bt_audio_codec_cap_get_supported_audio_chan_counts(&codec_cap, false);
+	zassert_equal(err, -ENODATA, "unexpected error %d", err);
+}
+
+ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_get_supported_audio_chan_counts_fallback_true)
+{
+	struct bt_audio_codec_cap codec_cap = {0};
+	int err;
+
+	err = bt_audio_codec_cap_get_supported_audio_chan_counts(&codec_cap, true);
+	zassert_equal(err, -ENODATA, "unexpected error %d", err);
+}
+
+ZTEST(audio_codec_test_suite,
+	test_bt_audio_codec_cap_get_supported_audio_chan_counts_fallback_false)
+{
+	struct bt_audio_codec_cap codec_cap = {0};
+	int err;
+
+	err = bt_audio_codec_cap_get_supported_audio_chan_counts(&codec_cap, true);
+	zassert_equal(err, -ENODATA, "unexpected error %d", err);
 }
 
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_set_supported_audio_chan_counts)
@@ -1137,14 +1176,14 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_set_supported_audio_chan_c
 
 	int ret;
 
-	ret = bt_audio_codec_cap_get_supported_audio_chan_counts(&codec_cap);
+	ret = bt_audio_codec_cap_get_supported_audio_chan_counts(&codec_cap, false);
 	zassert_equal(ret, 1, "Unexpected return value %d", ret);
 
-	ret = bt_audio_codec_cap_set_frame_dur(&codec_cap,
-					       BT_AUDIO_CODEC_CAP_CHAN_COUNT_SUPPORT(2));
+	ret = bt_audio_codec_cap_set_supported_audio_chan_counts(
+		&codec_cap, BT_AUDIO_CODEC_CAP_CHAN_COUNT_SUPPORT(2));
 	zassert_true(ret > 0, "Unexpected return value %d", ret);
 
-	ret = bt_audio_codec_cap_get_frame_dur(&codec_cap);
+	ret = bt_audio_codec_cap_get_supported_audio_chan_counts(&codec_cap, false);
 	zassert_equal(ret, 2, "Unexpected return value %d", ret);
 }
 

--- a/tests/bluetooth/audio/codec/src/main.c
+++ b/tests/bluetooth/audio/codec/src/main.c
@@ -1243,8 +1243,46 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_get_max_codec_frames_per_s
 
 	int ret;
 
-	ret = bt_audio_codec_cap_get_max_codec_frames_per_sdu(&codec_cap);
+	ret = bt_audio_codec_cap_get_max_codec_frames_per_sdu(&codec_cap, false);
 	zassert_equal(ret, 2, "Unexpected return value %d", ret);
+}
+
+ZTEST(audio_codec_test_suite,
+	test_bt_audio_codec_cap_get_max_codec_frames_per_sdu_lc3_fallback_true)
+{
+	struct bt_audio_codec_cap codec_cap = {.id = BT_HCI_CODING_FORMAT_LC3};
+	int err;
+
+	err = bt_audio_codec_cap_get_max_codec_frames_per_sdu(&codec_cap, true);
+	zassert_equal(err, 1, "unexpected error %d", err);
+}
+
+ZTEST(audio_codec_test_suite,
+	test_bt_audio_codec_cap_get_max_codec_frames_per_sdu_lc3_fallback_false)
+{
+	struct bt_audio_codec_cap codec_cap = {.id = BT_HCI_CODING_FORMAT_LC3};
+	int err;
+
+	err = bt_audio_codec_cap_get_max_codec_frames_per_sdu(&codec_cap, false);
+	zassert_equal(err, -ENODATA, "unexpected error %d", err);
+}
+
+ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_get_max_codec_frames_per_sdu_fallback_true)
+{
+	struct bt_audio_codec_cap codec_cap = {0};
+	int err;
+
+	err = bt_audio_codec_cap_get_max_codec_frames_per_sdu(&codec_cap, true);
+	zassert_equal(err, -ENODATA, "unexpected error %d", err);
+}
+
+ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_get_max_codec_frames_per_sdu_fallback_false)
+{
+	struct bt_audio_codec_cap codec_cap = {0};
+	int err;
+
+	err = bt_audio_codec_cap_get_max_codec_frames_per_sdu(&codec_cap, true);
+	zassert_equal(err, -ENODATA, "unexpected error %d", err);
 }
 
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_set_max_codec_frames_per_sdu)
@@ -1256,13 +1294,13 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_set_max_codec_frames_per_s
 
 	int ret;
 
-	ret = bt_audio_codec_cap_get_max_codec_frames_per_sdu(&codec_cap);
+	ret = bt_audio_codec_cap_get_max_codec_frames_per_sdu(&codec_cap, false);
 	zassert_equal(ret, 2, "Unexpected return value %d", ret);
 
 	ret = bt_audio_codec_cap_set_max_codec_frames_per_sdu(&codec_cap, 4U);
 	zassert_true(ret > 0, "Unexpected return value %d", ret);
 
-	ret = bt_audio_codec_cap_get_max_codec_frames_per_sdu(&codec_cap);
+	ret = bt_audio_codec_cap_get_max_codec_frames_per_sdu(&codec_cap, false);
 	zassert_equal(ret, 4, "Unexpected return value %d", ret);
 }
 

--- a/tests/bluetooth/audio/codec/src/main.c
+++ b/tests/bluetooth/audio/codec/src/main.c
@@ -7,14 +7,18 @@
  */
 
 #include <errno.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap_lc3_preset.h>
+#include <zephyr/bluetooth/audio/lc3.h>
+#include <zephyr/bluetooth/byteorder.h>
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/fff.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/util.h>
 
 #include <ztest_test.h>
 #include <ztest_assert.h>
@@ -975,7 +979,7 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_get_val)
 	const uint8_t *data;
 	int ret;
 
-	ret = bt_audio_codec_cap_get_val(&codec_cap, BT_AUDIO_CODEC_CFG_FREQ, &data);
+	ret = bt_audio_codec_cap_get_val(&codec_cap, BT_AUDIO_CODEC_CAP_TYPE_FREQ, &data);
 	zassert_equal(ret, sizeof(expected_data), "Unexpected return value %d", ret);
 	zassert_equal(data[0], expected_data, "Unexpected return value %d", ret);
 }
@@ -992,15 +996,15 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_set_val)
 	const uint8_t *data;
 	int ret;
 
-	ret = bt_audio_codec_cap_get_val(&codec_cap, BT_AUDIO_CODEC_CFG_FREQ, &data);
+	ret = bt_audio_codec_cap_get_val(&codec_cap, BT_AUDIO_CODEC_CAP_TYPE_FREQ, &data);
 	zassert_equal(ret, sizeof(expected_data), "Unexpected return value %d", ret);
 	zassert_equal(data[0], expected_data, "Unexpected return value %d", ret);
 
-	ret = bt_audio_codec_cap_set_val(&codec_cap, BT_AUDIO_CODEC_CFG_FREQ,
+	ret = bt_audio_codec_cap_set_val(&codec_cap, BT_AUDIO_CODEC_CAP_TYPE_FREQ,
 					 &new_expected_data, sizeof(new_expected_data));
 	zassert_true(ret > 0, "Unexpected return value %d", ret);
 
-	ret = bt_audio_codec_cap_get_val(&codec_cap, BT_AUDIO_CODEC_CFG_FREQ, &data);
+	ret = bt_audio_codec_cap_get_val(&codec_cap, BT_AUDIO_CODEC_CAP_TYPE_FREQ, &data);
 	zassert_equal(ret, sizeof(new_expected_data), "Unexpected return value %d", ret);
 	zassert_equal(data[0], new_expected_data, "Unexpected data value %u", data[0]);
 }
@@ -1013,14 +1017,14 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_set_val_new)
 	const uint8_t *data;
 	int ret;
 
-	ret = bt_audio_codec_cap_get_val(&codec_cap, BT_AUDIO_CODEC_CFG_FREQ, &data);
+	ret = bt_audio_codec_cap_get_val(&codec_cap, BT_AUDIO_CODEC_CAP_TYPE_FREQ, &data);
 	zassert_equal(ret, -ENODATA, "Unexpected return value %d", ret);
 
-	ret = bt_audio_codec_cap_set_val(&codec_cap, BT_AUDIO_CODEC_CFG_FREQ,
+	ret = bt_audio_codec_cap_set_val(&codec_cap, BT_AUDIO_CODEC_CAP_TYPE_FREQ,
 					 &new_expected_data, sizeof(new_expected_data));
 	zassert_true(ret > 0, "Unexpected return value %d", ret);
 
-	ret = bt_audio_codec_cap_get_val(&codec_cap, BT_AUDIO_CODEC_CFG_FREQ, &data);
+	ret = bt_audio_codec_cap_get_val(&codec_cap, BT_AUDIO_CODEC_CAP_TYPE_FREQ, &data);
 	zassert_equal(ret, sizeof(new_expected_data), "Unexpected return value %d", ret);
 	zassert_equal(data[0], new_expected_data, "Unexpected return value %d", ret);
 }

--- a/tests/bluetooth/audio/codec/src/main.c
+++ b/tests/bluetooth/audio/codec/src/main.c
@@ -503,8 +503,44 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_pref_context)
 							BT_BYTES_LIST_LE16(ctx))});
 	int ret;
 
-	ret = bt_audio_codec_cfg_meta_get_pref_context(&codec_cfg);
+	ret = bt_audio_codec_cfg_meta_get_pref_context(&codec_cfg, false);
 	zassert_equal(ret, 0x0005, "unexpected return value %d", ret);
+}
+
+ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_pref_context_lc3_fallback_true)
+{
+	struct bt_audio_codec_cfg codec_cfg = {.id = BT_HCI_CODING_FORMAT_LC3};
+	int err;
+
+	err = bt_audio_codec_cfg_meta_get_pref_context(&codec_cfg, true);
+	zassert_equal(err, BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED, "unexpected error %d", err);
+}
+
+ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_pref_context_lc3_fallback_false)
+{
+	struct bt_audio_codec_cfg codec_cfg = {.id = BT_HCI_CODING_FORMAT_LC3};
+	int err;
+
+	err = bt_audio_codec_cfg_meta_get_pref_context(&codec_cfg, false);
+	zassert_equal(err, -ENODATA, "unexpected error %d", err);
+}
+
+ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_pref_context_fallback_true)
+{
+	struct bt_audio_codec_cfg codec_cfg = {0};
+	int err;
+
+	err = bt_audio_codec_cfg_meta_get_pref_context(&codec_cfg, true);
+	zassert_equal(err, -ENODATA, "unexpected error %d", err);
+}
+
+ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_pref_context_fallback_false)
+{
+	struct bt_audio_codec_cfg codec_cfg = {0};
+	int err;
+
+	err = bt_audio_codec_cfg_meta_get_pref_context(&codec_cfg, true);
+	zassert_equal(err, -ENODATA, "unexpected error %d", err);
 }
 
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_pref_context)
@@ -518,13 +554,13 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_pref_context)
 							BT_BYTES_LIST_LE16(ctx))});
 	int ret;
 
-	ret = bt_audio_codec_cfg_meta_get_pref_context(&codec_cfg);
+	ret = bt_audio_codec_cfg_meta_get_pref_context(&codec_cfg, false);
 	zassert_equal(ret, 0x0005, "Unexpected return value %d", ret);
 
 	ret = bt_audio_codec_cfg_meta_set_pref_context(&codec_cfg, new_ctx);
 	zassert_true(ret > 0, "Unexpected return value %d", ret);
 
-	ret = bt_audio_codec_cfg_meta_get_pref_context(&codec_cfg);
+	ret = bt_audio_codec_cfg_meta_get_pref_context(&codec_cfg, false);
 	zassert_equal(ret, 0x0100, "Unexpected return value %d", ret);
 }
 

--- a/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
@@ -77,7 +77,8 @@ static void print_codec_cfg(const struct bt_audio_codec_cfg *codec_cfg)
 				bt_audio_codec_cfg_frame_dur_to_frame_dur_us(ret));
 		}
 
-		if (bt_audio_codec_cfg_get_chan_allocation(codec_cfg, &chan_allocation) == 0) {
+		ret = bt_audio_codec_cfg_get_chan_allocation(codec_cfg, &chan_allocation, false);
+		if (ret == 0) {
 			LOG_DBG("  Channel allocation: 0x%x", chan_allocation);
 		}
 
@@ -282,7 +283,7 @@ static int validate_codec_parameters(const struct bt_audio_codec_cfg *codec_cfg)
 	int ret;
 
 	chan_allocation_err =
-		bt_audio_codec_cfg_get_chan_allocation(codec_cfg, &chan_allocation);
+		bt_audio_codec_cfg_get_chan_allocation(codec_cfg, &chan_allocation, false);
 	octets_per_frame = bt_audio_codec_cfg_get_octets_per_frame(codec_cfg);
 	frames_per_sdu = bt_audio_codec_cfg_get_frame_blocks_per_sdu(codec_cfg, true);
 

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
@@ -134,7 +134,7 @@ static bool valid_base_subgroup(const struct bt_bap_base_subgroup *subgroup)
 		return false;
 	}
 
-	ret = bt_audio_codec_cfg_get_chan_allocation(&codec_cfg, &chan_allocation);
+	ret = bt_audio_codec_cfg_get_chan_allocation(&codec_cfg, &chan_allocation, false);
 	if (ret == 0) {
 		chan_cnt = bt_audio_get_chan_count(chan_allocation);
 	} else {
@@ -444,7 +444,7 @@ static void validate_stream_codec_cfg(const struct bt_bap_stream *stream)
 	/* The broadcast source sets the channel allocation in the BIS to
 	 * BT_AUDIO_LOCATION_FRONT_LEFT
 	 */
-	ret = bt_audio_codec_cfg_get_chan_allocation(codec_cfg, &chan_allocation);
+	ret = bt_audio_codec_cfg_get_chan_allocation(codec_cfg, &chan_allocation, false);
 	if (ret == 0) {
 		if (chan_allocation != BT_AUDIO_LOCATION_FRONT_LEFT) {
 			FAIL("Unexpected channel allocation: 0x%08X", chan_allocation);


### PR DESCRIPTION
BAP specifies that several of the codec config and codec capability values have an implied value if not explicitly set. 

fixes https://github.com/zephyrproject-rtos/zephyr/issues/71597#