### PR TITLE
dts: esp32_devkitc_wroom: Add led0 node

### DIFF
--- a/boards/espressif/esp32_devkitc_wroom/esp32_devkitc_wroom_procpu.dts
+++ b/boards/espressif/esp32_devkitc_wroom/esp32_devkitc_wroom_procpu.dts
@@ -18,6 +18,7 @@
 		uart-0 = &uart0;
 		i2c-0 = &i2c0;
 		sw0 = &button0;
+		led0 = &led0;
 		watchdog0 = &wdt0;
 	};
 
@@ -29,6 +30,14 @@
 			zephyr,code = <INPUT_KEY_0>;
 		};
 	};
+
+	leds {
+        compatible = "gpio-leds";
+        led0: led_0 {
+            gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
+            label = "LED 0";
+        };
+    };
 
 	chosen {
 		zephyr,sram = &sram0;


### PR DESCRIPTION
blinky sample fails to build for esp32_devkitc_wroom due to missing led0 DT node. Add it to the device tree.