### PR TITLE
include: storage: flash_map: _NODE macros

### DIFF
--- a/include/zephyr/storage/flash_map.h
+++ b/include/zephyr/storage/flash_map.h
@@ -302,6 +302,15 @@ uint8_t flash_area_erased_val(const struct flash_area *fa);
 #define FIXED_PARTITION_OFFSET(label) DT_REG_ADDR(DT_NODELABEL(label))
 
 /**
+ * Get fixed-partition offset from DTS node
+ *
+ * @param node DTS node of a partition
+ *
+ * @return fixed-partition offset, as defined for the partition in DTS.
+ */
+#define FIXED_PARTITION_NODE_OFFSET(node) DT_REG_ADDR(node)
+
+/**
  * Get fixed-partition size for DTS node label
  *
  * @param label DTS node label
@@ -309,6 +318,15 @@ uint8_t flash_area_erased_val(const struct flash_area *fa);
  * @return fixed-partition offset, as defined for the partition in DTS.
  */
 #define FIXED_PARTITION_SIZE(label) DT_REG_SIZE(DT_NODELABEL(label))
+
+/**
+ * Get fixed-partition size for DTS node
+ *
+ * @param node DTS node of a partition
+ *
+ * @return fixed-partition size, as defined for the partition in DTS.
+ */
+#define FIXED_PARTITION_NODE_SIZE(node) DT_REG_SIZE(node)
 
 /**
  * Get device pointer for device the area/partition resides on
@@ -329,6 +347,16 @@ uint8_t flash_area_erased_val(const struct flash_area *fa);
  */
 #define FIXED_PARTITION_DEVICE(label) \
 	DEVICE_DT_GET(DT_MTD_FROM_FIXED_PARTITION(DT_NODELABEL(label)))
+
+/**
+ * Get device pointer for device the area/partition resides on
+ *
+ * @param node DTS node of a partition
+ *
+ * @return Pointer to a device.
+ */
+#define FIXED_PARTITION_NODE_DEVICE(node) \
+	DEVICE_DT_GET(DT_MTD_FROM_FIXED_PARTITION(node))
 
 #ifdef __cplusplus
 }

--- a/tests/subsys/storage/flash_map/src/main.c
+++ b/tests/subsys/storage/flash_map/src/main.c
@@ -13,6 +13,7 @@
 #define SLOT1_PARTITION		slot1_partition
 #define SLOT1_PARTITION_ID	FIXED_PARTITION_ID(SLOT1_PARTITION)
 #define SLOT1_PARTITION_DEV	FIXED_PARTITION_DEVICE(SLOT1_PARTITION)
+#define SLOT1_PARTITION_NODE	DT_NODELABEL(SLOT1_PARTITION)
 
 extern int flash_map_entries;
 struct flash_sector fs_sectors[256];
@@ -188,6 +189,17 @@ ZTEST(flash_map, test_flash_area_erased_val)
 		      "value different than the flash erase value");
 
 	flash_area_close(fa);
+}
+
+ZTEST(flash_map, test_fixed_partition_node_macros)
+{
+	/* Test against changes in API */
+	zassert_equal(FIXED_PARTITION_NODE_OFFSET(SLOT1_PARTITION_NODE),
+		DT_REG_ADDR(SLOT1_PARTITION_NODE));
+	zassert_equal(FIXED_PARTITION_NODE_SIZE(SLOT1_PARTITION_NODE),
+		DT_REG_SIZE(SLOT1_PARTITION_NODE));
+	zassert_equal(FIXED_PARTITION_NODE_DEVICE(SLOT1_PARTITION_NODE),
+		DEVICE_DT_GET(DT_MTD_FROM_FIXED_PARTITION(SLOT1_PARTITION_NODE)));
 }
 
 ZTEST_SUITE(flash_map, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
adds size, offset and divice access macros that are operating with nodes as an argumet.