### PR TITLE
twister: Refactor 'recording' feature and enable it for Ztest and Pytest

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -5,7 +5,6 @@
 # Copyright 2022 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-import csv
 import logging
 import math
 import os
@@ -97,22 +96,6 @@ class Handler:
                          self.instance.platform.timeout_multiplier *
                          self.options.timeout_multiplier)
 
-    def record(self, harness):
-        if harness.recording:
-            if self.instance.recording is None:
-                self.instance.recording = harness.recording.copy()
-            else:
-                self.instance.recording.extend(harness.recording)
-
-            filename = os.path.join(self.build_dir, "recording.csv")
-            with open(filename, "at") as csvfile:
-                cw = csv.DictWriter(csvfile,
-                                    fieldnames = harness.recording[0].keys(),
-                                    lineterminator = os.linesep,
-                                    quoting = csv.QUOTE_NONNUMERIC)
-                cw.writeheader()
-                cw.writerows(harness.recording)
-
     def terminate(self, proc):
         terminate_process(proc)
         self.terminated = True
@@ -165,7 +148,7 @@ class Handler:
                 for tc in self.instance.testcases:
                     tc.status = "failed"
 
-        self.record(harness)
+        self.instance.record(harness.recording)
 
 
 class BinaryHandler(Handler):

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -91,8 +91,18 @@ class Harness:
         """
         return self.id
 
+    def parse_record(self, line) -> re.Match:
+        match = None
+        if self.record_pattern:
+            match = self.record_pattern.search(line)
+            if match:
+                self.recording.append({ k:v.strip() for k,v in match.groupdict(default="").items() })
+        return match
+    #
 
     def process_test(self, line):
+
+        self.parse_record(line)
 
         runid_match = re.search(self.run_id_pattern, line)
         if runid_match:
@@ -250,11 +260,6 @@ class Console(Harness):
             self.capture_coverage = True
         elif self.GCOV_END in line:
             self.capture_coverage = False
-
-        if self.record_pattern:
-            match = self.record_pattern.search(line)
-            if match:
-                self.recording.append({ k:v.strip() for k,v in match.groupdict(default="").items() })
 
         self.process_test(line)
         # Reset the resulting test state to 'failed' when not all of the patterns were

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -10,6 +10,7 @@ import random
 import logging
 import shutil
 import glob
+import csv
 
 from twisterlib.testsuite import TestCase, TestSuite
 from twisterlib.platform import Platform
@@ -72,6 +73,22 @@ class TestInstance:
         self.init_cases()
         self.filters = []
         self.filter_type = None
+
+    def record(self, recording, fname_csv="recording.csv"):
+        if recording:
+            if self.recording is None:
+                self.recording = recording.copy()
+            else:
+                self.recording.extend(recording)
+
+            filename = os.path.join(self.build_dir, fname_csv)
+            with open(filename, "wt") as csvfile:
+                cw = csv.DictWriter(csvfile,
+                                    fieldnames = self.recording[0].keys(),
+                                    lineterminator = os.linesep,
+                                    quoting = csv.QUOTE_NONNUMERIC)
+                cw.writeheader()
+                cw.writerows(self.recording)
 
     def add_filter(self, reason, filter_type):
         self.filters.append({'type': filter_type, 'reason': reason })

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -129,6 +129,7 @@ def test_handler_final_handle_actions(mocked_instance):
     harness.detected_suite_names = mock.Mock()
     harness.matched_run_id = False
     harness.run_id_exists = True
+    harness.recording = mock.Mock()
 
     handler_time = mock.Mock()
 
@@ -142,6 +143,8 @@ def test_handler_final_handle_actions(mocked_instance):
 
     handler.instance.reason = 'This reason shan\'t be changed.'
     handler._final_handle_actions(harness, handler_time)
+
+    instance.assert_has_calls([mock.call.record(harness.recording)])
 
     assert handler.instance.reason == 'This reason shan\'t be changed.'
 
@@ -202,42 +205,6 @@ def test_handler_missing_suite_name(mocked_instance):
     assert all(
         testcase.status == 'failed' for testcase in handler.instance.testcases
     )
-
-
-def test_handler_record(mocked_instance):
-    instance = mocked_instance
-    instance.testcases = [mock.Mock()]
-
-    handler = Handler(instance)
-
-    harness = twisterlib.harness.Harness()
-    harness.recording = [ {'field_1':  'recording_1_1', 'field_2': 'recording_1_2'},
-                          {'field_1':  'recording_2_1', 'field_2': 'recording_2_2'}
-                        ]
-
-    with mock.patch(
-        'builtins.open',
-        mock.mock_open(read_data='')
-    ) as mock_file, \
-        mock.patch(
-        'csv.DictWriter.writerow',
-        mock.Mock()
-    ) as mock_writeheader, \
-        mock.patch(
-        'csv.DictWriter.writerows',
-        mock.Mock()
-    ) as mock_writerows:
-        handler.record(harness)
-
-    print(mock_file.mock_calls)
-
-    mock_file.assert_called_with(
-        os.path.join(instance.build_dir, 'recording.csv'),
-        'at'
-    )
-
-    mock_writeheader.assert_has_calls([mock.call({ k:k for k in harness.recording[0].keys()})])
-    mock_writerows.assert_has_calls([mock.call(harness.recording)])
 
 
 def test_handler_terminate(mocked_instance):

--- a/scripts/tests/twister/test_harness.py
+++ b/scripts/tests/twister/test_harness.py
@@ -44,6 +44,32 @@ def process_logs(harness, logs):
         harness.handle(line)
 
 
+TEST_DATA_RECORDING = [
+                ([''], "^START:(?P<foo>.*):END", []),
+                (['START:bar:STOP'], "^START:(?P<foo>.*):END", []),
+                (['START:bar:END'], "^START:(?P<foo>.*):END", [{'foo':'bar'}]),
+                (['START:bar:baz:END'], "^START:(?P<foo>.*):(?P<boo>.*):END", [{'foo':'bar', 'boo':'baz'}]),
+                (['START:bar:baz:END','START:may:jun:END'], "^START:(?P<foo>.*):(?P<boo>.*):END",
+                 [{'foo':'bar', 'boo':'baz'}, {'foo':'may', 'boo':'jun'}]),
+                      ]
+@pytest.mark.parametrize(
+    "lines, pattern, expected_records",
+    TEST_DATA_RECORDING,
+    ids=["empty", "no match", "match 1 field", "match 2 fields", "match 2 records"]
+)
+def test_harness_parse_record(lines, pattern, expected_records):
+    harness = Harness()
+    harness.record = { 'regex': pattern }
+    harness.record_pattern = re.compile(pattern)
+
+    assert not harness.recording
+
+    for line in lines:
+        harness.parse_record(line)
+
+    assert harness.recording == expected_records
+
+
 TEST_DATA_1 = [('RunID: 12345', False, False, False, None, True),
                 ('PROJECT EXECUTION SUCCESSFUL', False, False, False, 'passed', False),
                 ('PROJECT EXECUTION SUCCESSFUL', True, False, False, 'failed', False),
@@ -63,6 +89,7 @@ def test_harness_process_test(line, fault, fail_on_fault, cap_cov, exp_stat, exp
     harness.state = None
     harness.fault = fault
     harness.fail_on_fault = fail_on_fault
+    mock.patch.object(Harness, 'parse_record', return_value=None)
 
     #Act
     harness.process_test(line)
@@ -71,6 +98,7 @@ def test_harness_process_test(line, fault, fail_on_fault, cap_cov, exp_stat, exp
     assert harness.matched_run_id == exp_id
     assert harness.state == exp_stat
     assert harness.capture_coverage == cap_cov
+    assert harness.recording == []
 
 
 def test_robot_configure(tmp_path):

--- a/scripts/tests/twister/test_testinstance.py
+++ b/scripts/tests/twister/test_testinstance.py
@@ -227,6 +227,37 @@ def test_testinstance_init(all_testsuites_dict, class_testplan, platforms_list, 
 
 
 @pytest.mark.parametrize('testinstance', [{'testsuite_kind': 'sample'}], indirect=True)
+def test_testinstance_record(testinstance):
+    testinstance.testcases = [mock.Mock()]
+    recording = [ {'field_1':  'recording_1_1', 'field_2': 'recording_1_2'},
+                  {'field_1':  'recording_2_1', 'field_2': 'recording_2_2'}
+                ]
+    with mock.patch(
+        'builtins.open',
+        mock.mock_open(read_data='')
+    ) as mock_file, \
+        mock.patch(
+        'csv.DictWriter.writerow',
+        mock.Mock()
+    ) as mock_writeheader, \
+        mock.patch(
+        'csv.DictWriter.writerows',
+        mock.Mock()
+    ) as mock_writerows:
+        testinstance.record(recording)
+
+    print(mock_file.mock_calls)
+
+    mock_file.assert_called_with(
+        os.path.join(testinstance.build_dir, 'recording.csv'),
+        'wt'
+    )
+
+    mock_writeheader.assert_has_calls([mock.call({ k:k for k in recording[0]})])
+    mock_writerows.assert_has_calls([mock.call(recording)])
+
+
+@pytest.mark.parametrize('testinstance', [{'testsuite_kind': 'sample'}], indirect=True)
 def test_testinstance_add_filter(testinstance):
     reason = 'dummy reason'
     filter_type = 'dummy type'


### PR DESCRIPTION
Refactor Twister `recording` feature moving it from `Handler` class to `TestInstance` class and enable for other `Harness` child
classes other than `Console`, e.g. `Ztest`.

Extend `Pytest` Harness to support `recording` feature to parse test log by a regular expression and collect as records the same
way as `Console` Harness does.