### PR TITLE
toolchain: llvm: Allow TLS when using llvm targeting arm

### DIFF
--- a/cmake/toolchain/llvm/Kconfig
+++ b/cmake/toolchain/llvm/Kconfig
@@ -19,7 +19,7 @@ config LLVM_USE_LLD
 endchoice
 
 config TOOLCHAIN_LLVM_SUPPORTS_THREAD_LOCAL_STORAGE
-	depends on RISCV
+	depends on RISCV || ARM
 	def_bool y
 	select TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
 


### PR DESCRIPTION
TLS for Arm targets seems to be well supported in clang/lld, so mark it as supported by the toolchain.

For testing, I ran twister locally using llvm targeting the qemu_cortex_m3 board as below and did not see any regressions:

`west twister -c -W -p qemu_cortex_m3 -x=CONFIG_LLVM_USE_LLD=y -x=CONFIG_COMPILER_RT_RTLIB=y`