### PR TITLE
Revert "shell: backends: uart: avoid unnecessary TX IRQs"

### DIFF
--- a/subsys/shell/backends/shell_uart.c
+++ b/subsys/shell/backends/shell_uart.c
@@ -166,8 +166,7 @@ static void dtr_timer_handler(struct k_timer *timer)
 
 static void uart_tx_handle(const struct device *dev, struct shell_uart_int_driven *sh_uart)
 {
-	uint32_t avail;
-	uint32_t written;
+	uint32_t len;
 	const uint8_t *data;
 
 	if (!uart_dtr_check(dev)) {
@@ -177,22 +176,16 @@ static void uart_tx_handle(const struct device *dev, struct shell_uart_int_drive
 		return;
 	}
 
-	do {
-		avail = ring_buf_get_claim(&sh_uart->tx_ringbuf, (uint8_t **)&data,
-					sh_uart->tx_ringbuf.size);
-		if (avail) {
-			int err;
+	len = ring_buf_get_claim(&sh_uart->tx_ringbuf, (uint8_t **)&data,
+				 sh_uart->tx_ringbuf.size);
+	if (len) {
+		int err;
 
-			written = uart_fifo_fill(dev, data, avail);
-			err = ring_buf_get_finish(&sh_uart->tx_ringbuf, written);
-			__ASSERT_NO_MSG(err == 0);
-			ARG_UNUSED(err);
-		} else {
-			written = 0;
-		}
-	} while (avail && written);
-
-	if (avail == 0) {
+		len = uart_fifo_fill(dev, data, len);
+		err = ring_buf_get_finish(&sh_uart->tx_ringbuf, len);
+		__ASSERT_NO_MSG(err == 0);
+		ARG_UNUSED(err);
+	} else {
 		uart_irq_tx_disable(dev);
 		sh_uart->tx_busy = 0;
 	}


### PR DESCRIPTION
This reverts commit d2e5eeb51d3364585c2fec13d5f44784e06da53e.

PR zephyrproject-rtos/zephyr#71172 is causing the bug reported on issue zephyrproject-rtos/zephyr#72598.