### PR TITLE
lorawan: make possible to send empty frames

### DIFF
--- a/subsys/lorawan/lorawan.c
+++ b/subsys/lorawan/lorawan.c
@@ -595,7 +595,7 @@ int lorawan_send(uint8_t port, uint8_t *data, uint8_t len,
 	int ret = 0;
 	bool empty_frame = false;
 
-	if (data == NULL) {
+	if (data == NULL && len > 0) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Empty frames are allowed by the LoRaWAN protocol and are actually useful to open new RX slots or flush MAC commands in stack. Therefore allow the data pointer to be `NULL` if `len` is 0.

Note that I am not even sure we want to have this check. It seems in other subsystems, it is the responsibility of the caller to ensure the data pointer is not NULL.