### PR TITLE
boards: nxp: frdm_mcxn947: enable USDHC0

### DIFF
--- a/boards/nxp/frdm_mcxn947/Kconfig.defconfig
+++ b/boards/nxp/frdm_mcxn947/Kconfig.defconfig
@@ -6,4 +6,12 @@ if BOARD_FRDM_MCXN947
 config NET_L2_ETHERNET
 	default y if NETWORKING
 
+if SD_STACK
+
+# SD stack requires larger main stack size
+config MAIN_STACK_SIZE
+	default 1536
+
+endif
+
 endif

--- a/boards/nxp/frdm_mcxn947/board.c
+++ b/boards/nxp/frdm_mcxn947/board.c
@@ -192,6 +192,11 @@ static int frdm_mcxn947_init(void)
 	CLOCK_AttachClk(kPLL0_to_CTIMER4);
 #endif
 
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(usdhc0), okay)
+	CLOCK_SetClkDiv(kCLOCK_DivUSdhcClk, 1u);
+	CLOCK_AttachClk(kFRO_HF_to_USDHC);
+#endif
+
 #if CONFIG_FLASH_MCUX_FLEXSPI_NOR
 	/* We downclock the FlexSPI to 50MHz, it will be set to the
 	 * optimum speed supported by the Flash device during FLEXSPI

--- a/boards/nxp/frdm_mcxn947/doc/index.rst
+++ b/boards/nxp/frdm_mcxn947/doc/index.rst
@@ -82,6 +82,8 @@ The FRDM-MCXN947 board configuration supports the following hardware features:
 +-----------+------------+-------------------------------------+
 | CTIMER    | on-chip    | counter                             |
 +-----------+------------+-------------------------------------+
+| USDHC     | on-chip    | sdhc                                |
++-----------+------------+-------------------------------------+
 
 Targets available
 ==================

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947-pinctrl.dtsi
@@ -129,4 +129,23 @@
 		};
 	};
 
+	pinmux_usdhc0: pinmux_usdhc0 {
+		group0 {
+			pinmux = <SDHC0_CMD_PIO2_5>,
+			       <SDHC0_D0_PIO2_3>,
+			       <SDHC0_D1_PIO2_2>,
+			       <SDHC0_D2_PIO2_7>,
+			       <SDHC0_D3_PIO2_6>;
+			slew-rate = "fast";
+			drive-strength = "low";
+			bias-pull-up;
+			input-enable;
+		};
+		group1 {
+			pinmux = <SDHC0_CLK_PIO2_4>;
+			slew-rate = "fast";
+			drive-strength = "low";
+			input-enable;
+		};
+	};
 };

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
@@ -14,6 +14,7 @@
 		led2 = &blue_led;
 		sw0 = &user_button_2;
 		sw1 = &user_button_3;
+		sdhc0 = &usdhc0;
 	};
 
 	leds {
@@ -172,4 +173,13 @@
 &flexpwm1_pwm0 {
 	pinctrl-0 = <&pinmux_flexpwm1_pwm0>;
 	pinctrl-names = "default";
+};
+
+&usdhc0 {
+	pinctrl-0 = <&pinmux_usdhc0>;
+	pinctrl-1 = <&pinmux_usdhc0>;
+	pinctrl-2 = <&pinmux_usdhc0>;
+	cd-gpios = <&gpio2 1 GPIO_ACTIVE_LOW>;
+	pinctrl-names = "default", "slow", "med";
+	no-1-8-v;
 };

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.dts
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.dts
@@ -58,6 +58,10 @@
 	status = "okay";
 };
 
+&gpio2 {
+	status = "okay";
+};
+
 &green_led {
 	status = "okay";
 };
@@ -140,4 +144,12 @@
 
 &ctimer0 {
 	status = "okay";
+};
+
+&usdhc0 {
+	status = "okay";
+	sdmmc {
+		compatible = "zephyr,sdmmc-disk";
+		status = "okay";
+	};
 };

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.yaml
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.yaml
@@ -23,4 +23,5 @@ supported:
   - watchdog
   - pwm
   - counter
+  - sdhc
 vendor: nxp

--- a/drivers/sdhc/imx_usdhc.c
+++ b/drivers/sdhc/imx_usdhc.c
@@ -282,21 +282,6 @@ static int imx_usdhc_reset(const struct device *dev)
 	return USDHC_Reset(cfg->base, kUSDHC_ResetAll, 100U) == true ? 0 : -ETIMEDOUT;
 }
 
-/* Wait for USDHC to gate clock when it is disabled */
-static inline void imx_usdhc_wait_clock_gate(USDHC_Type *base)
-{
-	uint32_t timeout = 1000;
-
-	while (timeout--) {
-		if (base->PRES_STATE & USDHC_PRES_STATE_SDOFF_MASK) {
-			break;
-		}
-	}
-	if (timeout == 0) {
-		LOG_WRN("SD clock did not gate in time");
-	}
-}
-
 /*
  * Set SDHC io properties
  */

--- a/drivers/sdhc/imx_usdhc.c
+++ b/drivers/sdhc/imx_usdhc.c
@@ -159,6 +159,14 @@ static void card_detect_gpio_cb(const struct device *port,
 	}
 }
 
+static void imx_usdhc_select_1_8v(USDHC_Type *base, bool enable_1_8v)
+{
+#if !(defined(FSL_FEATURE_USDHC_HAS_NO_VOLTAGE_SELECT) && \
+	(FSL_FEATURE_USDHC_HAS_NO_VOLTAGE_SELECT))
+	UDSHC_SelectVoltage(base, enable_1_8v);
+#endif
+}
+
 
 static int imx_usdhc_dat3_pull(const struct usdhc_config *cfg, bool pullup)
 {
@@ -256,7 +264,7 @@ static int imx_usdhc_reset(const struct device *dev)
 {
 	const struct usdhc_config *cfg = dev->config;
 	/* Switch to default I/O voltage of 3.3V */
-	UDSHC_SelectVoltage(cfg->base, false);
+	imx_usdhc_select_1_8v(cfg->base, false);
 	USDHC_EnableDDRMode(cfg->base, false, 0U);
 #if defined(FSL_FEATURE_USDHC_HAS_SDR50_MODE) && (FSL_FEATURE_USDHC_HAS_SDR50_MODE)
 	USDHC_EnableStandardTuning(cfg->base, 0, 0, false);
@@ -353,7 +361,7 @@ static int imx_usdhc_set_io(const struct device *dev, struct sdhc_io *ios)
 		switch (ios->signal_voltage) {
 		case SD_VOL_3_3_V:
 		case SD_VOL_3_0_V:
-			UDSHC_SelectVoltage(cfg->base, false);
+			imx_usdhc_select_1_8v(cfg->base, false);
 			break;
 		case SD_VOL_1_8_V:
 			/**
@@ -367,7 +375,7 @@ static int imx_usdhc_set_io(const struct device *dev, struct sdhc_io *ios)
 			 * 10 ms, then allow it to be gated again.
 			 */
 			/* Switch to 1.8V */
-			UDSHC_SelectVoltage(cfg->base, true);
+			imx_usdhc_select_1_8v(cfg->base, true);
 			/* Wait 10 ms- clock will be gated during this period */
 			k_msleep(10);
 			/* Force the clock on */

--- a/drivers/sdhc/imx_usdhc.c
+++ b/drivers/sdhc/imx_usdhc.c
@@ -279,7 +279,7 @@ static int imx_usdhc_reset(const struct device *dev)
 #endif
 
 	/* Reset data/command/tuning circuit */
-	return USDHC_Reset(cfg->base, kUSDHC_ResetAll, 100U) == true ? 0 : -ETIMEDOUT;
+	return USDHC_Reset(cfg->base, kUSDHC_ResetAll, 1000U) == true ? 0 : -ETIMEDOUT;
 }
 
 /*

--- a/dts/arm/nxp/nxp_mcxn94x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn94x_common.dtsi
@@ -786,6 +786,16 @@
 		input = <0>;
 		prescale = <0>;
 	};
+
+	usdhc0: usdhc@109000 {
+		compatible = "nxp,imx-usdhc";
+		reg = <0x109000 0x1000>;
+		interrupts = <61 0>;
+		status = "disabled";
+		clocks = <&syscon MCUX_USDHC1_CLK>;
+		max-bus-freq = <52000000>;
+		min-bus-freq = <400000>;
+	};
 };
 
 &systick {


### PR DESCRIPTION
Enable support for USDHC0 sd host controller on FRDM_MCXN947. This support was verified with `tests/subsys/sd/sdmmc`, and `tests/subsys/sd/sdio`