### PR TITLE
net: capture: fix doxygen parameter names

### DIFF
--- a/include/zephyr/net/capture.h
+++ b/include/zephyr/net/capture.h
@@ -271,7 +271,7 @@ struct net_capture_cooked {
 /**
  * @brief Initialize cooked mode capture context.
  *
- * @param cooked Cooked context struct allocated by user.
+ * @param ctx Cooked context struct allocated by user.
  * @param hatype Link-layer address type
  * @param halen Link-layer address length (maximum is 8 bytes)
  * @param addr Link-layer address
@@ -307,7 +307,7 @@ static inline int net_capture_cooked_setup(struct net_capture_cooked *ctx,
  *        layer packets so that packet boundary is not lost.
  *
  * @param ctx Cooked mode capture context.
- * @param buf Data to capture.
+ * @param data Data to capture.
  * @param len Length of the data.
  * @param type The direction and type of the packet (did we sent it etc).
  * @param ptype Protocol type id. These are the ETH_P_* types set in ethernet.h


### PR DESCRIPTION
Fix parameter names in the doxygen comment to fix warnings when building the docs.

Not detected in the original PR (see #72605)