### PR TITLE
scripts: twisterlib: handlers: early QEMU timeout

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -879,6 +879,9 @@ class QEMUHandler(Handler):
 
         while True:
             this_timeout = int((timeout_time - time.time()) * 1000)
+            if timeout_extended:
+                # Quit early after timeout extension if no more data is being received
+                this_timeout = min(this_timeout, 1000)
             if this_timeout < 0 or not p.poll(this_timeout):
                 try:
                     if pid and this_timeout > 0:


### PR DESCRIPTION
Terminate QEMU earlier if the test finishes and no output data is received for 1 second. This new timeout operates in parallel with the global test timeout.

For coverage testing, this can reduce the time spent running individual tests by up to 29 seconds, while still giving the full 30 extra seconds to dump gcov data if needed.

Should reduce the duration of long CI runs like this:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/9036499613/job/24833501514
```
 INFO    - 1199/1790 mps2/an385                tests/kernel/mbox/mbox_usage/kernel.mailbox.usage  PASSED (qemu 31.285s)
INFO    - 1200/1790 mps2/an385                tests/kernel/mem_slab/mslab_concept/kernel.memory_slabs.concept PASSED (qemu 31.112s)
INFO    - 1201/1790 mps2/an385                tests/kernel/fifo/fifo_timeout/kernel.fifo.timeout PASSED (qemu 31.556s)
INFO    - 1202/1790 mps2/an385                tests/kernel/fifo/fifo_usage/kernel.fifo.usage     PASSED (qemu 31.445s)
INFO    - 1203/1790 mps2/an385                tests/kernel/mem_slab/mslab_threadsafe/kernel.memory_slabs.threadsafe PASSED (qemu 31.318s)
```
