### PR TITLE
tests: drivers: build_all: gpio: fix imx93_evk/mimx9352/a55

### DIFF
--- a/tests/drivers/build_all/gpio/boards/imx93_evk_mimx9352_a55.overlay
+++ b/tests/drivers/build_all/gpio/boards/imx93_evk_mimx9352_a55.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024 Meta Platforms
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&lpi2c2 {
+	status = "okay";
+};
+
+&mfd0 {
+	status = "okay";
+};
+
+&gpio_exp0 {
+	status = "okay";
+};


### PR DESCRIPTION
The `imx93_evk/mimx9352/a55` board needs a few things enabled to build the gpio test. Add an overlay to enable the required nodes.

Fixes #72619