### PR TITLE
net: http_server: Add support for specifying Content-Type

### DIFF
--- a/include/zephyr/net/http/server.h
+++ b/include/zephyr/net/http/server.h
@@ -74,6 +74,9 @@ struct http_resource_detail {
 
 	/** Content encoding of the resource. */
 	const char *content_encoding;
+
+	/** Content type of the resource. */
+	const char *content_type;
 };
 
 /** @cond INTERNAL_HIDDEN */

--- a/samples/net/sockets/http_server/src/main.c
+++ b/samples/net/sockets/http_server/src/main.c
@@ -31,6 +31,7 @@ struct http_resource_detail_static index_html_gz_resource_detail = {
 			.type = HTTP_RESOURCE_TYPE_STATIC,
 			.bitmask_of_supported_http_methods = BIT(HTTP_GET),
 			.content_encoding = "gzip",
+			.content_type = "text/html",
 		},
 	.static_data = index_html_gz,
 	.static_data_len = sizeof(index_html_gz),


### PR DESCRIPTION
Allow user to specify the Content-Type header field for the HTTP response.
