### PR TITLE
boards: nxp: mixmxrt1170_evk: Separate i2c6 from csi pin muxing

### DIFF
--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk-pinctrl.dtsi
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk-pinctrl.dtsi
@@ -23,7 +23,10 @@
 			bias-pull-up;
 			slew-rate = "fast";
 		};
-		group2 {
+	};
+
+	pinmux_lpi2c6: pinmux_lpi2c6 {
+		group0 {
 			pinmux = <&iomuxc_lpsr_gpio_lpsr_07_lpi2c6_scl>,
 				<&iomuxc_lpsr_gpio_lpsr_06_lpi2c6_sda>;
 			drive-strength = "high";

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
@@ -130,6 +130,11 @@
 	pinctrl-names = "default";
 };
 
+&lpi2c6 {
+	pinctrl-0 = <&pinmux_lpi2c6>;
+	pinctrl-names = "default";
+};
+
 &flexcan3 {
 	pinctrl-0 = <&pinmux_flexcan3>;
 	pinctrl-names = "default";


### PR DESCRIPTION
Pin muxing for i2c6 and csi should be separated as i2c is initialized before csi. Otherwise, i2c6 bus device will not be ready when the camera sensor on this bus initializes.

This is split from https://github.com/zephyrproject-rtos/zephyr/pull/69810 to ease the review process, and already got reviews.