### PR TITLE
boards: nxp: mimxrt1170_evk: Enable video feature

### DIFF
--- a/boards/nxp/mimxrt1170_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1170_evk/doc/index.rst
@@ -168,6 +168,9 @@ RT1170 EVKB (`mimxrt1170_evk@B//cm7/cm4`)
 +-----------+------------+-------------------------------------+-----------------+-----------------+
 | PIT       | on-chip    | pit                                 | Supported (M7)  | Supported (M7)  |
 +-----------+------------+-------------------------------------+-----------------+-----------------+
+| VIDEO     | on-chip    | CSI; MIPI CSI-2 Rx. Tested with     | Supported (M7)  | Supported (M7)  |
+|           |            | :ref:`wuxi_ov5640` shield           |                 |                 |
++-----------+------------+-------------------------------------+-----------------+-----------------+
 
 The default configuration can be found in the defconfig files:
 :zephyr_file:`boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_defconfig`

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7.yaml
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7.yaml
@@ -28,4 +28,5 @@ supported:
   - spi
   - usb_device
   - watchdog
+  - video
 vendor: nxp

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_B.yaml
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_B.yaml
@@ -26,4 +26,5 @@ supported:
   - spi
   - usb_device
   - watchdog
+  - video
 vendor: nxp


### PR DESCRIPTION
Enable video feature on cm7 evk and evkb which are tested with ov5640 camera.

This PR is split from https://github.com/zephyrproject-rtos/zephyr/pull/69810 to ease the review process.
This PR is dependent on https://github.com/zephyrproject-rtos/zephyr/pull/72434 which needs to be merged first.