### PR TITLE
Utils: Implement `navigation_bearing()` API

### DIFF
--- a/lib/utils/CMakeLists.txt
+++ b/lib/utils/CMakeLists.txt
@@ -15,6 +15,8 @@ zephyr_sources_ifdef(CONFIG_NOTIFY notify.c)
 
 zephyr_sources_ifdef(CONFIG_JSON_LIBRARY json.c)
 
+zephyr_sources_ifdef(CONFIG_NAVIGATION navigation.c)
+
 zephyr_sources_ifdef(CONFIG_RING_BUFFER ring_buffer.c)
 
 zephyr_sources_ifdef(CONFIG_UTF8 utf8.c)

--- a/lib/utils/Kconfig
+++ b/lib/utils/Kconfig
@@ -58,3 +58,6 @@ config UTF8
 	  handle UTF-8 encoded strings.
 
 endmenu
+
+config NAVIGATION
+	bool "Navigation utilities"

--- a/lib/utils/navigation.c
+++ b/lib/utils/navigation.c
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2024 Bjarki Arge Andreasen
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/data/navigation.h>
+
+#define NAV_BEARING_MAX   360000
+#define NAV_BEARING_MIN   0
+#define NAV_LATITUDE_MAX  90000000000
+#define NAV_LATITUDE_MIN  -90000000000
+#define NAV_LONGITUDE_MAX 180000000000
+#define NAV_LONGITUDE_MIN -180000000000
+
+/*
+ * Input: 1/65535
+ * Output: millidegrees
+ * Mathematic notation: (0.861 * x)
+ * Accuracy: +-73 millidegrees for input range [0 .. 13107]
+ */
+static uint16_t nav_atan_linear(uint16_t x)
+{
+	uint32_t a;
+
+	a = x;
+	a <<= 16;
+	a /= 76116;
+	return a;
+}
+
+/*
+ * Input: 1/65535
+ * Output: millidegrees
+ * Mathematic notation: (0.6995 * x) + ((0.00000429 * x) * (65535 - x)) - 880
+ * Accuracy: +-86 millidegrees for input range [13107 .. 65535]
+ *
+ * Inspired by IEEE SIGNAL PROCESSING MAGAZINE, May 2006, page 109, equation 7
+ */
+static uint16_t nav_atan_poly(uint16_t x)
+{
+	uint32_t a;
+	uint32_t b;
+
+	a = x;
+	a <<= 16;
+	a /= 93690;
+
+	b = x;
+	b <<= 16;
+	b /= 233100;
+	b *= 65535 - x;
+	b >>= 16;
+
+	return a + b - 880;
+}
+
+/*
+ * Input: 1/65535
+ * Output: millidegrees
+ * Accuracy: +-86 millidegrees
+ */
+static uint16_t nav_atan(uint16_t x)
+{
+	if (x == 0) {
+		return 0;
+	}
+
+	if (x < 13108) {
+		return nav_atan_linear(x);
+	}
+
+	if (x < 65535) {
+		return nav_atan_poly(x);
+	}
+
+	return 45000;
+}
+
+static uint8_t nav_atan2_quadrant(const int64_t *y, const int64_t *x)
+{
+	if (*y >= 0) {
+		if (*x >= 0) {
+			return 0;
+		}
+
+		return 1;
+	}
+
+	if (*x < 0) {
+		return 2;
+	}
+
+	return 3;
+}
+
+static void nav_atan2_abs(int64_t *x)
+{
+	*x = *x < 0 ? -(*x) : *x;
+}
+
+static bool nav_atan2_swap(int64_t *y, int64_t *x)
+{
+	int64_t cache;
+
+	if (*y < *x) {
+		cache = *x;
+		*x = *y;
+		*y = cache;
+		return true;
+	}
+
+	return false;
+}
+
+static void nav_atan2_quantize(int64_t *y, int64_t *x)
+{
+	if (*y == 0) {
+		return;
+	}
+
+	while (*y >= 4294967296) {
+		*x >>= 1;
+		*y >>= 1;
+	}
+
+	while (*y < 2147483648) {
+		*x <<= 1;
+		*y <<= 1;
+	}
+}
+
+static uint16_t nav_atan2_divide(const int64_t *y, const int64_t *x)
+{
+	uint32_t numerator;
+	uint32_t denominator;
+
+	numerator = (uint32_t)*x;
+	denominator = (uint32_t)*y;
+
+	if (numerator == denominator) {
+		return UINT16_MAX;
+	}
+
+	denominator >>= 16;
+
+	if (denominator == 0) {
+		return UINT16_MAX;
+	}
+
+	return numerator / denominator;
+}
+
+static uint32_t nav_atan2_translate(uint16_t angle, uint8_t quadrant, bool swapped)
+{
+	uint32_t udeg;
+
+	udeg = 90000;
+	udeg *= quadrant;
+
+	if (quadrant % 2) {
+		udeg += swapped ? 90000 - angle : angle;
+	} else {
+		udeg += swapped ? angle : 90000 - angle;
+	}
+
+	return udeg;
+}
+
+static uint32_t nav_atan2(int64_t x, int64_t y)
+{
+	uint8_t quadrant;
+	bool swapped;
+	uint16_t angle;
+
+	quadrant = nav_atan2_quadrant(&x, &y);
+	nav_atan2_abs(&x);
+	nav_atan2_abs(&y);
+	swapped = nav_atan2_swap(&x, &y);
+	nav_atan2_quantize(&x, &y);
+	angle = nav_atan2_divide(&x, &y);
+	angle = nav_atan(angle);
+	return nav_atan2_translate(angle, quadrant, swapped);
+}
+
+static void nav_delta_latitude(int64_t *delta, const int64_t *to, const int64_t *from)
+{
+	*delta = *to - *from;
+}
+
+static void nav_delta_longitude(int64_t *delta, const int64_t *to, const int64_t *from)
+{
+	/* Longitudes wrap at +-180 degrees */
+	if ((*to >= NAV_LATITUDE_MAX) && (*from <= NAV_LATITUDE_MIN)) {
+		*delta = (*to - NAV_LONGITUDE_MAX) - (*from + NAV_LONGITUDE_MAX);
+	} else if ((*to <= NAV_LATITUDE_MIN) && (*from >= NAV_LATITUDE_MAX)) {
+		*delta = (*to + NAV_LONGITUDE_MAX) - (*from - NAV_LONGITUDE_MAX);
+	} else {
+		*delta = *to - *from;
+	}
+}
+
+static bool nav_validate_data(const struct navigation_data *data)
+{
+	return (data->latitude <= NAV_LATITUDE_MAX) &&
+	       (data->latitude >= NAV_LATITUDE_MIN) &&
+	       (data->longitude <= NAV_LONGITUDE_MAX) &&
+	       (data->longitude >= NAV_LONGITUDE_MIN);
+}
+
+int navigation_bearing(uint32_t *bearing, const struct navigation_data *from,
+		       const struct navigation_data *to)
+{
+	int64_t latitude;
+	int64_t longitude;
+
+	if (!nav_validate_data(from) || !nav_validate_data(to)) {
+		return -EINVAL;
+	}
+
+	nav_delta_latitude(&latitude, &to->latitude, &from->latitude);
+	nav_delta_longitude(&longitude, &to->longitude, &from->longitude);
+	*bearing = nav_atan2(longitude, latitude);
+	return 0;
+}

--- a/tests/lib/navigation/CMakeLists.txt
+++ b/tests/lib/navigation/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright 2024 Bjarki Arge Andreasen
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(navigation)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/lib/navigation/prj.conf
+++ b/tests/lib/navigation/prj.conf
@@ -1,0 +1,5 @@
+# Copyright 2024 Bjarki Arge Andreasen
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+CONFIG_NAVIGATION=y

--- a/tests/lib/navigation/src/test_bearing.c
+++ b/tests/lib/navigation/src/test_bearing.c
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2024 Bjarki Arge Andreasen
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+#include <zephyr/data/navigation.h>
+
+struct test_sample {
+	int64_t from_latitude;
+	int64_t from_longitude;
+	int64_t to_latitude;
+	int64_t to_longitude;
+	uint32_t bearing;
+};
+
+static struct navigation_data from_nav_data;
+static struct navigation_data to_nav_data;
+
+static const struct test_sample samples[] = {
+	{
+		.from_latitude = 0,
+		.from_longitude = 0,
+		.to_latitude = 0,
+		.to_longitude = 90000000000,
+		.bearing = 90000,
+	},
+	{
+		.from_latitude = 0,
+		.from_longitude = 180000000000,
+		.to_latitude = 0,
+		.to_longitude = -90000000000,
+		.bearing = 90000,
+	},
+	{
+		.from_latitude = 0,
+		.from_longitude = 0,
+		.to_latitude = 44999999999,
+		.to_longitude = 77942286340,
+		.bearing = 60000,
+	},
+	{
+		.from_latitude = 0,
+		.from_longitude = 180000000000,
+		.to_latitude = 44999999999,
+		.to_longitude = -102057713660,
+		.bearing = 60000,
+	},
+	{
+		.from_latitude = 0,
+		.from_longitude = 0,
+		.to_latitude = 77942286340,
+		.to_longitude = 45000000000,
+		.bearing = 30000,
+	},
+	{
+		.from_latitude = 0,
+		.from_longitude = 180000000000,
+		.to_latitude = 77942286340,
+		.to_longitude = -135000000000,
+		.bearing = 30000,
+	},
+	{
+		.from_latitude = 0,
+		.from_longitude = 0,
+		.to_latitude = 90000000000,
+		.to_longitude = 0,
+		.bearing = 0,
+	},
+	{
+		.from_latitude = 0,
+		.from_longitude = 180000000000,
+		.to_latitude = 90000000000,
+		.to_longitude = 180000000000,
+		.bearing = 0,
+	},
+	{
+		.from_latitude = 0,
+		.from_longitude = 0,
+		.to_latitude = 77942286340,
+		.to_longitude = -44999999999,
+		.bearing = 330001,
+	},
+	{
+		.from_latitude = 0,
+		.from_longitude = 180000000000,
+		.to_latitude = 77942286340,
+		.to_longitude = 135000000001,
+		.bearing = 330001,
+	},
+	{
+		.from_latitude = 0,
+		.from_longitude = 0,
+		.to_latitude = 45000000000,
+		.to_longitude = -77942286340,
+		.bearing = 300001,
+	},
+	{
+		.from_latitude = 0,
+		.from_longitude = 180000000000,
+		.to_latitude = 45000000000,
+		.to_longitude = 102057713660,
+		.bearing = 300001,
+	},
+	{
+		.from_latitude = 0,
+		.from_longitude = 0,
+		.to_latitude = 0,
+		.to_longitude = -90000000000,
+		.bearing = 270000,
+	},
+	{
+		.from_latitude = 0,
+		.from_longitude = 180000000000,
+		.to_latitude = 0,
+		.to_longitude = 90000000000,
+		.bearing = 270000,
+	},
+	{
+		.from_latitude = 0,
+		.from_longitude = 0,
+		.to_latitude = -44999999999,
+		.to_longitude = -77942286340,
+		.bearing = 240001,
+	},
+	{
+		.from_latitude = 0,
+		.from_longitude = 180000000000,
+		.to_latitude = -44999999999,
+		.to_longitude = 102057713660,
+		.bearing = 240001,
+	},
+	{
+		.from_latitude = 0,
+		.from_longitude = 0,
+		.to_latitude = -77942286340,
+		.to_longitude = -45000000000,
+		.bearing = 210001,
+	},
+	{
+		.from_latitude = 0,
+		.from_longitude = 180000000000,
+		.to_latitude = -77942286340,
+		.to_longitude = 135000000000,
+		.bearing = 210001,
+	},
+	{
+		.from_latitude = 0,
+		.from_longitude = 0,
+		.to_latitude = -90000000000,
+		.to_longitude = 0,
+		.bearing = 180000,
+	},
+	{
+		.from_latitude = 0,
+		.from_longitude = 180000000000,
+		.to_latitude = -90000000000,
+		.to_longitude = 180000000000,
+		.bearing = 180000,
+	},
+	{
+		.from_latitude = 0,
+		.from_longitude = 0,
+		.to_latitude = -77942286340,
+		.to_longitude = 44999999999,
+		.bearing = 150000,
+	},
+	{
+		.from_latitude = 0,
+		.from_longitude = 180000000000,
+		.to_latitude = -77942286340,
+		.to_longitude = -135000000001,
+		.bearing = 150000,
+	},
+	{
+		.from_latitude = 0,
+		.from_longitude = 0,
+		.to_latitude = -45000000000,
+		.to_longitude = 77942286340,
+		.bearing = 120000,
+	},
+	{
+		.from_latitude = 0,
+		.from_longitude = 180000000000,
+		.to_latitude = -45000000000,
+		.to_longitude = -102057713660,
+		.bearing = 120000,
+	},
+};
+
+static void set_nav_data(const struct test_sample *sample)
+{
+	from_nav_data.latitude = sample->from_latitude;
+	from_nav_data.longitude = sample->from_longitude;
+	to_nav_data.latitude = sample->to_latitude;
+	to_nav_data.longitude = sample->to_longitude;
+}
+
+static bool validate_bearing(uint32_t est, uint32_t real)
+{
+	int64_t error;
+
+	error = real;
+	error -= est;
+	PRINT("est: %u, real: %u, error: %lli\n", est, real, error);
+
+	if (real < 180000 || est < 180000) {
+		est += 180000;
+		real += 180000;
+	}
+
+	if (est < (real - 5000)) {
+		return false;
+	}
+
+	if (est > (real + 5000)) {
+		return false;
+	}
+
+	return true;
+}
+
+ZTEST(navigation, test_bearing)
+{
+	uint32_t bearing;
+
+	for (size_t i = 0; i < ARRAY_SIZE(samples); i++) {
+		set_nav_data(&samples[i]);
+		zassert_ok(navigation_bearing(&bearing, &from_nav_data, &to_nav_data));
+		zassert_true(validate_bearing(bearing, samples[i].bearing));
+	}
+}

--- a/tests/lib/navigation/src/test_suite.c
+++ b/tests/lib/navigation/src/test_suite.c
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2024 Bjarki Arge Andreasen
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+
+ZTEST_SUITE(navigation, NULL, NULL, NULL, NULL, NULL);

--- a/tests/lib/navigation/testcase.yaml
+++ b/tests/lib/navigation/testcase.yaml
@@ -1,0 +1,7 @@
+# Copyright 2024 Bjarki Arge Andreasen
+# SPDX-License-Identifier: Apache-2.0
+
+tests:
+  lib.navigation:
+    tags:
+      - navigation


### PR DESCRIPTION
Implement `navigation_bearing()` API of the `navigation.h ` utilities.

The implementation uses a native fixed-point `atan` approximation which is accurate to within 0.1 degrees from 0 to 1 (0 to 65535), which is all that is needed for determining the bearing :)

The bearing is stored in millidegrees, from 0 to 360000. An error of 83 is 0.083 degrees :)
```
Running TESTSUITE navigation
===================================================================
START - test_bearing
est: 90000, real: 90000, error: 0
est: 90000, real: 90000, error: 0
est: 59918, real: 60000, error: 82
est: 59918, real: 60000, error: 82
est: 30082, real: 30000, error: -82
est: 30082, real: 30000, error: -82
est: 0, real: 0, error: 0
est: 0, real: 0, error: 0
est: 329918, real: 330001, error: 83
est: 329918, real: 330001, error: 83
est: 300082, real: 300001, error: -81
est: 300082, real: 300001, error: -81
est: 270000, real: 270000, error: 0
est: 270000, real: 270000, error: 0
est: 239918, real: 240001, error: 83
est: 239918, real: 240001, error: 83
est: 210082, real: 210001, error: -81
est: 210082, real: 210001, error: -81
est: 180000, real: 180000, error: 0
est: 180000, real: 180000, error: 0
est: 149918, real: 150000, error: 82
est: 149918, real: 150000, error: 82
est: 120082, real: 120000, error: -82
est: 120082, real: 120000, error: -82
 PASS - test_bearing in 0.000 seconds
===================================================================
TESTSUITE navigation succeeded
```