### PR TITLE
drivers: sensor: stm32_vbat / vref: get rid of floating point computation

### DIFF
--- a/drivers/sensor/st/stm32_vbat/stm32_vbat.c
+++ b/drivers/sensor/st/stm32_vbat/stm32_vbat.c
@@ -77,18 +77,16 @@ static int stm32_vbat_channel_get(const struct device *dev, enum sensor_channel 
 {
 	struct stm32_vbat_data *data = dev->data;
 	const struct stm32_vbat_config *cfg = dev->config;
-	float voltage;
+	int32_t voltage;
 
 	if (chan != SENSOR_CHAN_VOLTAGE) {
 		return -ENOTSUP;
 	}
 
-	/* Sensor value in millivolts */
-	voltage = data->raw * adc_ref_internal(data->adc) / 0x0FFF;
-	/* considering the vbat input through a resistor bridge */
-	voltage = voltage * cfg->ratio / 1000; /* value of SENSOR_CHAN_VOLTAGE in Volt */
+	/* Sensor value in millivolts considering the vbat input through a resistor bridge */
+	voltage = data->raw * adc_ref_internal(data->adc) * cfg->ratio / 0x0FFF;
 
-	return sensor_value_from_double(val, voltage);
+	return sensor_value_from_milli(val, voltage);
 }
 
 static const struct sensor_driver_api stm32_vbat_driver_api = {

--- a/drivers/sensor/st/stm32_vref/stm32_vref.c
+++ b/drivers/sensor/st/stm32_vref/stm32_vref.c
@@ -81,7 +81,7 @@ static int stm32_vref_channel_get(const struct device *dev, enum sensor_channel 
 {
 	struct stm32_vref_data *data = dev->data;
 	const struct stm32_vref_config *cfg = dev->config;
-	float vref;
+	int32_t vref;
 
 	if (chan != SENSOR_CHAN_VOLTAGE) {
 		return -ENOTSUP;
@@ -112,14 +112,12 @@ static int stm32_vref_channel_get(const struct device *dev, enum sensor_channel 
 #else
 	vref = cfg->cal_mv * (*cfg->cal_addr) / data->raw;
 #endif /* CONFIG_SOC_SERIES_STM32H5X */
-	/* millivolt to volt */
-	vref /= 1000;
 
 #if defined(CONFIG_SOC_SERIES_STM32H5X)
 	LL_ICACHE_Enable();
 #endif /* CONFIG_SOC_SERIES_STM32H5X */
 
-	return sensor_value_from_double(val, vref);
+	return sensor_value_from_milli(val, vref);
 }
 
 static const struct sensor_driver_api stm32_vref_driver_api = {


### PR DESCRIPTION
The goal is to use less flash, especially by removing the need to include support FP code on FPU-less MCUs.