### PR TITLE
soc: esp32c3: fix TLS flash addressing

### DIFF
--- a/soc/espressif/esp32c3/default.ld
+++ b/soc/espressif/esp32c3/default.ld
@@ -786,6 +786,12 @@ SECTIONS
   .flash.rodata_end : ALIGN(0x10)
   {
     . = ALIGN(4);
+
+     /* create explicit symbol for __tdata_start so that it is loaded
+      * into proper DROM region atributted by AT keyword below
+      */
+    __tdata_start = ADDR(tdata);
+
     _rodata_reserved_end = ABSOLUTE(.);
     _image_rodata_end = ABSOLUTE(.);
   } GROUP_DATA_LINK_IN(RODATA_REGION, ROMABLE_REGION)


### PR DESCRIPTION
When TLS is used, `__tdata_start` is PROVIDED by
"thread-local-storage.ld" using absolute address, which makes it land in wrong flash address. This causes risc-v startup code to fail during memcpy/memset.

This PR overrides `__tdata_start` to use ADDR, which will make sure it is placed in DROM region due to AT keyword.

Fixes #69708