### PR TITLE
subsys: net_buf: Make net_buf_unref thread safety.

### DIFF
--- a/include/zephyr/net/buf.h
+++ b/include/zephyr/net/buf.h
@@ -1008,17 +1008,24 @@ struct net_buf {
 	/** Fragments associated with this buffer. */
 	struct net_buf *frags;
 
-	/** Reference count. */
-	uint8_t ref;
+	/** Union for convenience preserving the old API. */
+	union {
+		struct {
+			/** Reference count. */
+			uint8_t ref;
 
-	/** Bit-field of buffer flags. */
-	uint8_t flags;
+			/** Bit-field of buffer flags. */
+			uint8_t flags;
 
-	/** Where the buffer should go when freed up. */
-	uint8_t pool_id;
+			/** Where the buffer should go when freed up. */
+			uint8_t pool_id;
 
-	/** Size of user data on this buffer */
-	uint8_t user_data_size;
+			/* Size of user data on this buffer */
+			uint8_t user_data_size;
+		};
+
+		atomic_t atomic;
+	};
 
 	/** Union for convenience access to the net_buf_simple members, also
 	 * preserving the old API.

--- a/tests/net/buf/src/main.c
+++ b/tests/net/buf/src/main.c
@@ -252,7 +252,6 @@ ZTEST(net_buf_tests, test_net_buf_4)
 
 		if ((i % 2) && next) {
 			net_buf_frag_del(frag, next);
-			net_buf_unref(next);
 			removed++;
 		} else {
 			frag = next;
@@ -276,7 +275,6 @@ ZTEST(net_buf_tests, test_net_buf_4)
 		struct net_buf *frag2 = buf->frags;
 
 		net_buf_frag_del(buf, frag2);
-		net_buf_unref(frag2);
 		removed++;
 	}
 


### PR DESCRIPTION
Current `buf->ref` not thread safely, there are race conditions in some scenarios.

For example, in Bluetooth applications, net_buf is used extensively. Although the Bluetooth host stack is a Coop thread, which can avoid competition, but the thread where the application's main function is located is not necessarily a Coop thread, which will cause a race condition.

The following is a test code to verify what may happen:

```C
static void thread1(void *p1, void *p2, void *p3)
{
 while (1)
 {
   pthread_mutex_lock(&mutex);
   pthread_cond_wait(&cond, &mutex);
   if (--ref > 0) {
     printf("%s ref %d\n", k_current_get()->name, ref);
   } else {
     k_fifo_put(&fifo, &node);
   }
   printf("%s ref %d\n", k_current_get()->name, ref);
   pthread_mutex_unlock(&mutex);
 }
}
static void thread2(void *p1, void *p2, void *p3)
{
 while (2)
 {
   pthread_mutex_lock(&mutex1);
   pthread_cond_wait(&cond, &mutex1);
   if (--ref > 0) {
     printf("%s ref %d\n", k_current_get()->name, ref);
   } else {
     k_fifo_put(&fifo, &node);
   }
   printf("%s ref %d\n", k_current_get()->name, ref);
   pthread_mutex_unlock(&mutex1);
 }
}
static void thread3(void *p1, void *p2, void *p3)
{
 while (2)
 {
   printf("Start\n");
   ref = 1;
   pthread_cond_broadcast(&cond);
   k_sleep(K_MSEC(10));
   void *a = k_fifo_get(&fifo, K_FOREVER);
   void *b = k_fifo_get(&fifo, K_NO_WAIT);
   printf("%p %p\n", a, b);
 }
}
```

After some repeat test, race condition:

```
Start
h4_rx_thread0 ref 0
h4_rx_thread1 ref 255
h4_rx_thread1 ref 255
0x5558f5f63470 (nil)
Start
h4_rx_thread0 ref 0
h4_rx_thread1 ref 255
h4_rx_thread1 ref 255
0x5558f5f63470 (nil)
Start
h4_rx_thread0 ref 0
h4_rx_thread1 ref 255
h4_rx_thread1 ref 255
0x5558f5f63470 (nil)
Start
h4_rx_thread0 ref 0
h4_rx_thread1 ref 0
0x5558f5f63470 0x5558f5f63470
```