### PR TITLE
board: mimx93_evk_a55: disable gpio expander by default (fix issue 72619)

### DIFF
--- a/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.dts
+++ b/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.dts
@@ -119,6 +119,7 @@
 				line-name = "exp_sel";
 				output-low;
 			};
+			status = "disabled";
 		};
 	};
 };


### PR DESCRIPTION
This commit is to fix some GPIO test case build issue:
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/72619

In fact, the issue is introduce by expander GPIO PR:
https://github.com/zephyrproject-rtos/zephyr/pull/69330
It is used to add GPIO expander support,  in that PR, dts node layout is:
```
   lpi2c {
            MFD driver {
                    gpio driver {
                    }
            }
    }
```
The initial idea is to disable all these node by default in order to keep
a minimal default image, but that PR only disabled lpi2c and MFD
driver node, but enabled gpio driver node, so gpio driver will report
building error as it depends on expander and i2c which are disabled, so
this fix is to disable gpio node.  If we want to use expander gpio, we
need to enable i2c, expander and gpio nodes simultaneously.

Some GPIO test cases have been enabled on i.mx93 EVK board by enabling
onchip GPIO controller in the overlay, for example:
tests/drivers/gpio/gpio_basic_api/boards/imx93_evk_mimx9352_a55.overlay