### PR TITLE
sensor: bme680: fix API conformance

### DIFF
--- a/drivers/sensor/bosch/bme680/bme680.c
+++ b/drivers/sensor/bosch/bme680/bme680.c
@@ -23,6 +23,13 @@
 
 LOG_MODULE_REGISTER(bme680, CONFIG_SENSOR_LOG_LEVEL);
 
+struct bme_data_regs {
+	uint8_t pressure[3];
+	uint8_t temperature[3];
+	uint8_t humidity[2];
+	uint8_t padding[3];
+	uint8_t gas[2];
+} __packed;
 
 #if BME680_BUS_SPI
 static inline bool bme680_is_on_spi(const struct device *dev)
@@ -41,7 +48,7 @@ static inline int bme680_bus_check(const struct device *dev)
 }
 
 static inline int bme680_reg_read(const struct device *dev,
-				  uint8_t start, uint8_t *buf, int size)
+				  uint8_t start, void *buf, int size)
 {
 	const struct bme680_config *config = dev->config;
 
@@ -209,12 +216,11 @@ static int bme680_sample_fetch(const struct device *dev,
 			       enum sensor_channel chan)
 {
 	struct bme680_data *data = dev->data;
-	uint8_t buff[BME680_LEN_FIELD] = { 0 };
+	struct bme_data_regs data_regs;
 	uint8_t gas_range;
 	uint32_t adc_temp, adc_press;
 	uint16_t adc_hum, adc_gas_res;
 	uint8_t status;
-	int size = BME680_LEN_FIELD;
 	int cnt = 0;
 	int ret;
 
@@ -235,35 +241,29 @@ static int bme680_sample_fetch(const struct device *dev,
 			return -EAGAIN;
 		}
 		k_sleep(K_MSEC(1));
-		ret = bme680_reg_read(dev, BME680_REG_FIELD0, &status, 1);
+		ret = bme680_reg_read(dev, BME680_REG_MEAS_STATUS, &status, 1);
 		if (ret < 0) {
 			return ret;
 		}
 	} while (!(status & BME680_MSK_NEW_DATA));
 	LOG_DBG("New data after %d ms", cnt);
 
-	ret = bme680_reg_read(dev, BME680_REG_FIELD0, buff, size);
+	ret = bme680_reg_read(dev, BME680_REG_FIELD0, &data_regs, sizeof(data_regs));
 	if (ret < 0) {
 		return ret;
 	}
 
-	data->new_data = true;
-	data->heatr_stab = buff[14] & BME680_MSK_HEATR_STAB;
+	adc_press = sys_get_be24(data_regs.pressure) >> 4;
+	adc_temp = sys_get_be24(data_regs.temperature) >> 4;
+	adc_hum = sys_get_be16(data_regs.humidity);
+	adc_gas_res = sys_get_be16(data_regs.gas) >> 6;
+	data->heatr_stab = data_regs.gas[1] & BME680_MSK_HEATR_STAB;
+	gas_range = data_regs.gas[1] & BME680_MSK_GAS_RANGE;
 
-	adc_press = (uint32_t)(((uint32_t)buff[2] << 12) | ((uint32_t)buff[3] << 4)
-			    | ((uint32_t)buff[4] >> 4));
-	adc_temp = (uint32_t)(((uint32_t)buff[5] << 12) | ((uint32_t)buff[6] << 4)
-			   | ((uint32_t)buff[7] >> 4));
-	adc_hum = (uint16_t)(((uint32_t)buff[8] << 8) | (uint32_t)buff[9]);
-	adc_gas_res = (uint16_t)((uint32_t)buff[13] << 2 | (((uint32_t)buff[14]) >> 6));
-	gas_range = buff[14] & BME680_MSK_GAS_RANGE;
-
-	if (data->new_data) {
-		bme680_calc_temp(data, adc_temp);
-		bme680_calc_press(data, adc_press);
-		bme680_calc_humidity(data, adc_hum);
-		bme680_calc_gas_resistance(data, gas_range, adc_gas_res);
-	}
+	bme680_calc_temp(data, adc_temp);
+	bme680_calc_press(data, adc_press);
+	bme680_calc_humidity(data, adc_hum);
+	bme680_calc_gas_resistance(data, gas_range, adc_gas_res);
 	return 0;
 }
 

--- a/drivers/sensor/bosch/bme680/bme680.h
+++ b/drivers/sensor/bosch/bme680/bme680.h
@@ -57,14 +57,14 @@ struct bme680_config {
 
 #define BME680_CHIP_ID                  0x61
 
-#define BME680_LEN_FIELD                15
 #define BME680_LEN_COEFF_ALL            42
 #define BME680_LEN_COEFF1               23
 #define BME680_LEN_COEFF2               14
 #define BME680_LEN_COEFF3               5
 
 #define BME680_REG_COEFF3               0x00
-#define BME680_REG_FIELD0               0x1d
+#define BME680_REG_MEAS_STATUS          0x1D
+#define BME680_REG_FIELD0               0x1F
 #define BME680_REG_IDAC_HEAT0           0x50
 #define BME680_REG_RES_HEAT0            0x5A
 #define BME680_REG_GAS_WAIT0            0x64
@@ -72,9 +72,9 @@ struct bme680_config {
 #define BME680_REG_CTRL_GAS_0           0x70
 #define BME680_REG_CTRL_GAS_1           0x71
 #define BME680_REG_CTRL_HUM             0x72
+#define BME680_REG_STATUS               0x73
 #define BME680_REG_CTRL_MEAS            0x74
 #define BME680_REG_CONFIG               0x75
-#define BME680_REG_STATUS               0x73
 #define BME680_REG_UNIQUE_ID            0x83
 #define BME680_REG_COEFF1               0x8a
 #define BME680_REG_COEFF2               0xe1
@@ -204,7 +204,6 @@ struct bme680_data {
 	uint32_t calc_gas_resistance;
 
 	/* Additional information */
-	uint8_t new_data;
 	uint8_t heatr_stab;
 
 	/* Carryover between temperature and pressure/humidity compensation. */


### PR DESCRIPTION
`sensor_sample_fetch` is documented to read all of a sensor's active
channels and block until complete. The previous implementation read
the result from the previous call and triggered the next sample.

As a result the first call always failed, and subsequent calls would
return data one sampling period old.

Read less data from the sensor and use standard zephyr functions for
extracting integers from byte arrays.

Data layout derived from the original datasheet, code tested on Thingy53:
![image](https://github.com/zephyrproject-rtos/zephyr/assets/8476715/e700fc01-54a9-4cd7-9b97-6260909ae648)
