### PR TITLE
Implement non-standard pthread_tryjoin and pthread_timedjoin.

### DIFF
--- a/include/zephyr/posix/pthread.h
+++ b/include/zephyr/posix/pthread.h
@@ -429,6 +429,8 @@ int pthread_attr_setinheritsched(pthread_attr_t *attr, int inheritsched);
 int pthread_once(pthread_once_t *once, void (*initFunc)(void));
 #endif
 FUNC_NORETURN void pthread_exit(void *retval);
+int pthread_timedjoin_np(pthread_t thread, void **status, const struct timespec *abstime);
+int pthread_tryjoin_np(pthread_t thread, void **status);
 int pthread_join(pthread_t thread, void **status);
 int pthread_cancel(pthread_t pthread);
 int pthread_detach(pthread_t thread);

--- a/tests/posix/common/src/pthread.c
+++ b/tests/posix/common/src/pthread.c
@@ -143,6 +143,14 @@ static void *thread_top_exec(void *p1)
 	return NULL;
 }
 
+static void *timedjoin_thread(void *p1)
+{
+	int sleep_duration_ms = POINTER_TO_INT(p1);
+
+	usleep(USEC_PER_MSEC * sleep_duration_ms);
+	return NULL;
+}
+
 static int bounce_test_done(void)
 {
 	int i;
@@ -369,6 +377,69 @@ ZTEST(pthread, test_pthread_termination)
 	/* TESTPOINT: Try canceling a terminated thread */
 	ret = pthread_cancel(newthread[0]);
 	zassert_equal(ret, ESRCH, "cancelled a terminated thread!");
+}
+
+ZTEST(pthread, test_pthread_tryjoin)
+{
+	pthread_t th = {0};
+	int sleep_duration_ms = 200;
+	void *retval;
+
+	/* Creating a thread that exits after 200ms*/
+	zassert_ok(pthread_create(&th, NULL, timedjoin_thread, INT_TO_POINTER(sleep_duration_ms)));
+
+	/* Attempting to join, when thread is still running, should fail */
+	usleep(USEC_PER_MSEC * sleep_duration_ms / 2);
+	zassert_equal(pthread_tryjoin_np(th, &retval), EBUSY);
+
+	/* Sleep so thread will exit */
+	usleep(USEC_PER_MSEC * sleep_duration_ms);
+
+	/* Attempting to join without blocking should succeed now */
+	zassert_ok(pthread_tryjoin_np(th, &retval));
+}
+
+ZTEST(pthread, test_pthread_timedjoin)
+{
+	pthread_t th = {0};
+	int sleep_duration_ms = 200;
+	void *ret;
+	struct timespec not_done;
+	struct timespec done;
+	struct timespec invalid[] = {
+		[0] = {.tv_sec = -1},
+		[1] = {.tv_nsec = -1},
+		[2] = {.tv_nsec = NSEC_PER_SEC},
+	};
+
+	/* setup timespecs when the thread is still running and when it is done */
+	clock_gettime(CLOCK_MONOTONIC, &not_done);
+	clock_gettime(CLOCK_MONOTONIC, &done);
+	not_done.tv_nsec += sleep_duration_ms / 2 * NSEC_PER_MSEC;
+	done.tv_nsec += sleep_duration_ms * 1.5 * NSEC_PER_MSEC;
+	while (not_done.tv_nsec >= NSEC_PER_SEC) {
+		not_done.tv_sec++;
+		not_done.tv_nsec -= NSEC_PER_SEC;
+	}
+	while (done.tv_nsec >= NSEC_PER_SEC) {
+		done.tv_sec++;
+		done.tv_nsec -= NSEC_PER_SEC;
+	}
+
+	/* Creating a thread that exits after 200ms*/
+	zassert_ok(pthread_create(&th, NULL, timedjoin_thread, INT_TO_POINTER(sleep_duration_ms)));
+
+	/* pthread_timedjoin-np must return -EINVAL for invalid struct timespecs */
+	zassert_equal(pthread_timedjoin_np(th, &ret, NULL), EINVAL);
+	for (size_t i = 0; i < ARRAY_SIZE(invalid); ++i) {
+		zassert_equal(pthread_timedjoin_np(th, &ret, &invalid[i]), EINVAL);
+	}
+
+	/* Attempting to join with a timeout, when the thread is still running should fail */
+	zassert_equal(pthread_timedjoin_np(th, &ret, &not_done), ETIMEDOUT);
+
+	/* Attempting to join with a timeout, when the thread is done, should succeed */
+	zassert_ok(pthread_timedjoin_np(th, &ret, &done));
 }
 
 static void *create_thread1(void *p1)


### PR DESCRIPTION
Implement the non-standard facilities for joining pthreads.

## Open Questions
- [x] naming `_np` for non-standard as gnu does?
- [x] test allowed to sleep 300 ms?
- [x] use maximum value of `time_t` to represent `forever` in the timespec, which is the correct/portable makro?
- [x] convert `timespec` to `timeout` -> handle overflow?

This is my first PR, so let me know, if something formal is wrong. @cfriedt please let me know your opinion on this.