### PR TITLE
Formatting Output: avoided assignment of string literals to non-const char *

### DIFF
--- a/include/zephyr/sys/cbprintf_internal.h
+++ b/include/zephyr/sys/cbprintf_internal.h
@@ -555,8 +555,9 @@ extern "C" {
 #ifdef __cplusplus
 #define Z_CBPRINTF_ARG_SIZE(v) z_cbprintf_cxx_arg_size(v)
 #else
+#define Z_CONSTIFY(v) (_Generic((v), char * : (const char *)(uintptr_t)(v), default : (v)))
 #define Z_CBPRINTF_ARG_SIZE(v) ({\
-	__auto_type __v = (v) + 0; \
+	__auto_type __v = (Z_CONSTIFY(v)) + 0; \
 	/* Static code analysis may complain about unused variable. */ \
 	(void)__v; \
 	size_t __arg_size = _Generic((v), \
@@ -580,7 +581,7 @@ extern "C" {
 #define Z_CBPRINTF_STORE_ARG(buf, arg) do { \
 	if (Z_CBPRINTF_VA_STACK_LL_DBL_MEMCPY) { \
 		/* If required, copy arguments by word to avoid unaligned access.*/ \
-		__auto_type _v = (arg) + 0; \
+		__auto_type _v = (Z_CONSTIFY(arg)) + 0; \
 		double _d = _Generic((arg) + 0, \
 				float : (arg) + 0, \
 				default : \


### PR DESCRIPTION
avoided to assign string literals to non-const char *

This corresponds to following misra coding guideline:

> A string literal shall not be assigned to an object unless the objects type is pointer to const-qualified char.

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

Original commit:
https://github.com/zephyrproject-rtos/zephyr/commit/829f63f93f6edb1907451046af659d18cfc9b2aa


