### PR TITLE
boards: waveshare: esp32s3_touch: update appcpu supported peripherals

### DIFF
--- a/boards/waveshare/esp32s3_touch_lcd_1_28/esp32s3_touch_lcd_1_28_esp32s3_appcpu.yaml
+++ b/boards/waveshare/esp32s3_touch_lcd_1_28/esp32s3_touch_lcd_1_28_esp32s3_appcpu.yaml
@@ -5,18 +5,23 @@ arch: xtensa
 toolchain:
   - zephyr
 supported:
-  - gpio
-  - i2c
-  - spi
-  - watchdog
-  - regulator
   - uart
-  - pwm
-  - pinmux
-  - nvs
-  - display
 testing:
   ignore_tags:
     - net
     - bluetooth
+    - flash
+    - cpp
+    - posix
+    - watchdog
+    - logging
+    - kernel
+    - pm
+    - gpio
+    - crypto
+    - eeprom
+    - heap
+    - cmsis_rtos
+    - jwt
+    - zdsp
 vendor: waveshare


### PR DESCRIPTION
esp32s3 contains 2 cpus: procpu and appcpu.
appcpu has very limited peripherals support for now.

This updated esp32s3_touch board to list only support peripherals.