### PR TITLE
Bluetooth: ISO: Upgrade from experimental to unstable

### DIFF
--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -14,6 +14,10 @@
 /**
  * @brief Isochronous channels (ISO)
  * @defgroup bt_iso Isochronous channels (ISO)
+ *
+ * @since 2.3
+ * @version 0.8.0
+ *
  * @ingroup bluetooth
  * @{
  */

--- a/subsys/bluetooth/Kconfig.iso
+++ b/subsys/bluetooth/Kconfig.iso
@@ -25,21 +25,19 @@ config BT_ISO_UNICAST
 	  Isochronous channels.
 
 config BT_ISO_PERIPHERAL
-	bool "Bluetooth Isochronous Channel Unicast Peripheral Support [EXPERIMENTAL]"
+	bool "Bluetooth Isochronous Channel Unicast Peripheral Support"
 	depends on !BT_CTLR || BT_CTLR_PERIPHERAL_ISO_SUPPORT
 	select BT_PERIPHERAL
 	select BT_ISO_UNICAST
-	select EXPERIMENTAL
 	help
 	  This option enables support for Bluetooth Unicast
 	  Isochronous channels for the peripheral role.
 
 config BT_ISO_CENTRAL
-	bool "Bluetooth Isochronous Channel Unicast Central Support [EXPERIMENTAL]"
+	bool "Bluetooth Isochronous Channel Unicast Central Support"
 	depends on !BT_CTLR || BT_CTLR_CENTRAL_ISO_SUPPORT
 	select BT_CENTRAL
 	select BT_ISO_UNICAST
-	select EXPERIMENTAL
 	help
 	  This option enables support for Bluetooth Broadcast
 	  Isochronous channels for the central role.
@@ -50,24 +48,22 @@ config BT_ISO_BROADCAST
 	select BT_EXT_ADV
 
 config BT_ISO_BROADCASTER
-	bool "Bluetooth Isochronous Broadcaster Support [EXPERIMENTAL]"
+	bool "Bluetooth Isochronous Broadcaster Support"
 	depends on !BT_CTLR || BT_CTLR_ADV_ISO_SUPPORT
 	select BT_ISO_BROADCAST
 	select BT_ISO_TX
 	select BT_BROADCASTER
 	select BT_PER_ADV
-	select EXPERIMENTAL
 	help
 	  This option enables support for the Bluetooth Isochronous Broadcaster.
 
 config BT_ISO_SYNC_RECEIVER
-	bool "Bluetooth Isochronous Synchronized Receiver Support [EXPERIMENTAL]"
+	bool "Bluetooth Isochronous Synchronized Receiver Support"
 	depends on !BT_CTLR || BT_CTLR_SYNC_ISO_SUPPORT
 	select BT_ISO_BROADCAST
 	select BT_ISO_RX
 	select BT_OBSERVER
 	select BT_PER_ADV_SYNC
-	select EXPERIMENTAL
 	help
 	  This option enables support for the Bluetooth Isochronous
 	  Synchronized Receiver.


### PR DESCRIPTION
The ISO API and implementation have existed in Zephyr for several years, and while not fully qualified, stable or tested yet, it's not experimental anymore (and have not been for a long time).

This commit removes any references to it being experimental and instead defines it as unstable by setting the version to
> 0.1.0. 0.8.0 is being used as the initial version, as that
is what other unstable modules was defined to have as their initial version if they were not stable (>= 1.0.0).