### PR TITLE
drivers: esp_at: make esp_pull_quoted() to only return -EAGAIN

### DIFF
--- a/drivers/wifi/esp_at/esp.c
+++ b/drivers/wifi/esp_at/esp.c
@@ -256,7 +256,7 @@ MODEM_CMD_DEFINE(on_cmd_cipstamac)
 static int esp_pull_quoted(char **str, char *str_end, char **unquoted)
 {
 	if (**str != '"') {
-		return -EBADMSG;
+		return -EAGAIN;
 	}
 
 	(*str)++;


### PR DESCRIPTION
If no " character is found in buffer by esp_pull_quoted() it returns -EAGAIN which causes a loop that never ends. This is because the buffer dont get filled up with new data so no " chrachter will be found. This commit changes esp_pull_quoted() to only return -EAGAIN, so the buffer can get filled with new data and thus the loop can come to an end.