### PR TITLE
Bluetooth: CAP: Fix check for volume_mute_changed callback

### DIFF
--- a/subsys/bluetooth/audio/cap_commander.c
+++ b/subsys/bluetooth/audio/cap_commander.c
@@ -410,7 +410,7 @@ static void cap_commander_proc_complete(void)
 		}
 		break;
 	case BT_CAP_COMMON_PROC_TYPE_VOLUME_MUTE_CHANGE:
-		if (cap_cb->volume_changed != NULL) {
+		if (cap_cb->volume_mute_changed != NULL) {
 			cap_cb->volume_mute_changed(failed_conn, err);
 		}
 		break;


### PR DESCRIPTION
The callback was guarded by a wrong check.