### PR TITLE
boards: nordic: nrf54h20dk: Add counter to the supported peripherals

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.yaml
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.yaml
@@ -12,6 +12,7 @@ toolchain:
 ram: 256
 flash: 512
 supported:
+  - counter
   - gpio
   - pwm
   - spi

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.yaml
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.yaml
@@ -12,6 +12,7 @@ toolchain:
 ram: 192
 flash: 256
 supported:
+  - counter
   - gpio
   - pwm
   - spi


### PR DESCRIPTION
Enable Twister tests for the counter driver for:
- nrf54h20/cpuapp;
- nrf54h20/cpurad.