### PR TITLE
Bluetooth: BAP: Fix conn checks for bcast assistant notifications

### DIFF
--- a/subsys/bluetooth/audio/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/bap_broadcast_assistant.c
@@ -344,6 +344,10 @@ static void long_bap_read(struct bt_conn *conn, uint16_t handle)
 
 	LOG_DBG("conn %p busy %u", conn, broadcast_assistant.busy);
 
+	if (conn == NULL) {
+		return; /* noop */
+	}
+
 	if (broadcast_assistant.busy) {
 		/* If the client is busy reading or writing something else, reschedule the
 		 * long read.
@@ -403,6 +407,11 @@ static uint8_t notify_handler(struct bt_conn *conn,
 		return BT_GATT_ITER_STOP;
 	}
 
+	if (conn == NULL) {
+		/* Indicates that the CCC has been removed - no-op */
+		return BT_GATT_ITER_CONTINUE;
+	}
+
 	LOG_HEXDUMP_DBG(data, length, "Receive state notification:");
 
 	index = lookup_index_by_handle(handle);
@@ -414,16 +423,10 @@ static uint8_t notify_handler(struct bt_conn *conn,
 
 	if (length != 0) {
 		const uint8_t att_ntf_header_size = 3; /* opcode (1) + handle (2) */
-		uint16_t max_ntf_size;
+		const uint16_t max_ntf_size = bt_gatt_get_mtu(conn) - att_ntf_header_size;
 
 		/* Cancel any pending long reads containing now obsolete information */
 		(void)k_work_cancel_delayable(&broadcast_assistant.bap_read_work);
-
-		if (conn != NULL) {
-			max_ntf_size = bt_gatt_get_mtu(conn) - att_ntf_header_size;
-		} else {
-			max_ntf_size = MIN(BT_L2CAP_RX_MTU, BT_L2CAP_TX_MTU) - att_ntf_header_size;
-		}
 
 		if (length == max_ntf_size) {
 			/* TODO: if we are busy we should not overwrite the long_read_handle,


### PR DESCRIPTION
The notify handle in the BAP broadcast assistant did not handle conn == NULL properly, and neither did delayed_bap_read_handler.

Add better NULL checks, which also fixes a coverity issue.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/69136