### PR TITLE
Bluetooth: Controller: Add parameter to ISOALs sdu_write

### DIFF
--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -256,9 +256,12 @@ isoal_status_t sink_sdu_emit_hci(const struct isoal_sink             *sink_ctx,
 }
 
 isoal_status_t sink_sdu_write_hci(void *dbuf,
+				  const size_t sdu_written,
 				  const uint8_t *pdu_payload,
 				  const size_t consume_len)
 {
+	ARG_UNUSED(sdu_written);
+
 	struct net_buf *buf = (struct net_buf *) dbuf;
 
 	LL_ASSERT(buf);

--- a/subsys/bluetooth/controller/ll_sw/isoal.c
+++ b/subsys/bluetooth/controller/ll_sw/isoal.c
@@ -694,6 +694,7 @@ static isoal_status_t isoal_rx_append_to_sdu(struct isoal_sink *sink,
 			const struct isoal_sink_session *session = &sink->session;
 
 			err |= session->sdu_write(sdu->contents.dbuf,
+						  sp->sdu_written,
 						  pdu_payload,
 						  consume_len);
 			pdu_payload += consume_len;

--- a/subsys/bluetooth/controller/ll_sw/isoal.h
+++ b/subsys/bluetooth/controller/ll_sw/isoal.h
@@ -242,6 +242,8 @@ typedef isoal_status_t (*isoal_sink_sdu_emit_cb)(
 typedef isoal_status_t (*isoal_sink_sdu_write_cb)(
 	/*!< [in]  Destination buffer */
 	void          *dbuf,
+	/*!< [in]  Number of bytes already written to this SDU */
+	const size_t sdu_written,
 	/*!< [in]  Source data */
 	const uint8_t *pdu_payload,
 	/*!< [in]  Number of bytes to be copied */
@@ -450,6 +452,7 @@ isoal_status_t sink_sdu_emit_hci(const struct isoal_sink             *sink_ctx,
 				 const struct isoal_emitted_sdu_frag *sdu_frag,
 				 const struct isoal_emitted_sdu      *sdu);
 isoal_status_t sink_sdu_write_hci(void *dbuf,
+				  const size_t sdu_written,
 				  const uint8_t *pdu_payload,
 				  const size_t consume_len);
 

--- a/tests/bsim/bluetooth/ll/bis/src/main.c
+++ b/tests/bsim/bluetooth/ll/bis/src/main.c
@@ -124,10 +124,11 @@ static isoal_status_t test_sink_sdu_emit(const struct isoal_sink             *si
 }
 
 static isoal_status_t test_sink_sdu_write(void *dbuf,
+					  const size_t sdu_written,
 					  const uint8_t *pdu_payload,
 					  const size_t consume_len)
 {
-	memcpy(dbuf, pdu_payload, consume_len);
+	memcpy((uint8_t *)dbuf + sdu_written, pdu_payload, consume_len);
 
 	return ISOAL_STATUS_OK;
 }


### PR DESCRIPTION
For vendor datapaths that do not use a netbuffer to write SDUs into, the callee of sdu_write currently has to keep track itself of how much data has been written to the current SDU; This is wasteful since ISOAL already keeps track of that. Add an sdu_written parameter to the callback to inform the callee how much has been written to the current SDU already so the callee can write using the correct offset