### PR TITLE
kernel: docs: correct sys_heap_aligned_realloc

### DIFF
--- a/include/zephyr/sys/sys_heap.h
+++ b/include/zephyr/sys/sys_heap.h
@@ -162,11 +162,6 @@ void sys_heap_free(struct sys_heap *heap, void *mem);
  * new block fails, then NULL will be returned and the old block will
  * not be freed or modified.
  *
- * @note The return of a NULL on failure is a different behavior than
- * POSIX realloc(), which specifies that the original pointer will be
- * returned (i.e. it is not possible to safely detect realloc()
- * failure in POSIX, but it is here).
- *
  * @param heap Heap from which to allocate
  * @param ptr Original pointer returned from a previous allocation
  * @param align Alignment in bytes, must be a power of two


### PR DESCRIPTION
correct doc of sys_heap_aligned_realloc().

According to https://pubs.opengroup.org/onlinepubs/9699919799/functions/realloc.html returning `NULL` on failiure is POSIX behavior of `realloc()`.