### PR TITLE
Bluetooth: Host: Fix connection establishment upon RPA timeout

### DIFF
--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -606,7 +606,6 @@ static void le_update_private_addr(void)
 	}
 #endif
 	if (IS_ENABLED(CONFIG_BT_CENTRAL) &&
-	    IS_ENABLED(CONFIG_BT_FILTER_ACCEPT_LIST) &&
 	    atomic_test_bit(bt_dev.flags, BT_DEV_INITIATING)) {
 		/* Canceled initiating procedure will be restarted by
 		 * connection complete event.

--- a/tests/bsim/bluetooth/host/privacy/central/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/privacy/central/CMakeLists.txt
@@ -5,6 +5,12 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bsim_test_rpa_central)
 
+add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/common/testlib testlib)
+target_link_libraries(app PRIVATE testlib)
+
+add_subdirectory(${ZEPHYR_BASE}/tests/bsim/babblekit babblekit)
+target_link_libraries(app PRIVATE babblekit)
+
 target_sources(app PRIVATE
 	src/bs_bt_utils.c
 	src/tester.c

--- a/tests/bsim/bluetooth/host/privacy/central/prj.conf
+++ b/tests/bsim/bluetooth/host/privacy/central/prj.conf
@@ -11,3 +11,8 @@ CONFIG_BT_RPA_TIMEOUT=10
 CONFIG_BT_CTLR_ADV_SET=2
 CONFIG_BT_CTLR_SCAN_REQ_NOTIFY=y
 CONFIG_BT_SCAN_WITH_IDENTITY=y
+
+# Enable the possibility to set the RPA such that the RPA
+# refreshes before the connection attempt has completed
+CONFIG_BT_RPA_TIMEOUT_DYNAMIC=y
+CONFIG_BT_CREATE_CONN_TIMEOUT=10

--- a/tests/bsim/bluetooth/host/privacy/central/src/dut.c
+++ b/tests/bsim/bluetooth/host/privacy/central/src/dut.c
@@ -12,6 +12,10 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/bluetooth.h>
 
+#include <babblekit/testcase.h>
+#include <testlib/conn.h>
+#include <testlib/scan.h>
+
 void start_scanning(void)
 {
 	int err;
@@ -43,6 +47,72 @@ void dut_procedure(void)
 	start_scanning();
 
 	/* Nothing to do */
+
+	PASS("PASS\n");
+}
+
+void dut_procedure_connect_short_rpa_timeout(void)
+{
+	backchannel_init(1);
+
+	const uint16_t rpa_timeout_s = 1;
+
+	int err;
+	bt_addr_le_t peer = {};
+	struct bt_conn *conn = NULL;
+
+	/* Enable bluetooth */
+	err = bt_enable(NULL);
+	TEST_ASSERT(!err, "Failed to enable bluetooth (err %d)");
+
+	/* Central to use a short RPA timeout */
+	err = bt_le_set_rpa_timeout(rpa_timeout_s);
+	TEST_ASSERT(!err, "Failed to set RPA timeout (err %d)", err);
+
+	err = bt_testlib_scan_find_name(&peer, CONFIG_BT_DEVICE_NAME);
+	TEST_ASSERT(!err, "Failed to start scan (err %d)", err);
+
+	/* Indicate to the peer device that we have found the advertiser. */
+	backchannel_sync_send();
+
+	/* Create a connection using that address */
+	err = bt_testlib_connect(&peer, &conn);
+	TEST_ASSERT(!err, "Failed to initiate connection (err %d)", err);
+
+	PASS("PASS\n");
+}
+
+void dut_procedure_connect_timeout(void)
+{
+	const uint16_t rpa_timeout_s = 1;
+
+	int err;
+	bt_addr_le_t peer = {.type = BT_ADDR_LE_RANDOM, .a = {.val = {1, 2, 3, 4, 5, 6}}};
+	struct bt_conn *conn = NULL;
+
+	/* Enable bluetooth */
+	err = bt_enable(NULL);
+	TEST_ASSERT(!err, "Failed to enable bluetooth (err %d)", err);
+
+	/* Central to use a short RPA timeout */
+	err = bt_le_set_rpa_timeout(rpa_timeout_s);
+	TEST_ASSERT(!err, "Failed to set RPA timeout (err %d)", err);
+
+	int64_t old_time = k_uptime_get();
+
+	/* Create a connection using that address */
+	err = bt_testlib_connect(&peer, &conn);
+	TEST_ASSERT(err == BT_HCI_ERR_UNKNOWN_CONN_ID,
+		    "Expected connection establishment to time out (err %d)", err);
+
+	int64_t new_time = k_uptime_get();
+	int64_t time_diff_ms = new_time - old_time;
+	int64_t expected_conn_timeout_ms = CONFIG_BT_CREATE_CONN_TIMEOUT * 1000;
+	int64_t diff_to_expected_ms = abs(time_diff_ms - expected_conn_timeout_ms);
+
+	printk("Connection creation timed out after %d ms\n", time_diff_ms);
+	TEST_ASSERT(diff_to_expected_ms < 0.1 * expected_conn_timeout_ms,
+		    "Connection timeout not within 10 \%% of expected timeout");
 
 	PASS("PASS\n");
 }

--- a/tests/bsim/bluetooth/host/privacy/central/src/main.c
+++ b/tests/bsim/bluetooth/host/privacy/central/src/main.c
@@ -8,20 +8,50 @@
 #include "bstests.h"
 
 void tester_procedure(void);
+void tester_procedure_periph_delayed_start_of_conn_adv(void);
 void dut_procedure(void);
+void dut_procedure_connect_short_rpa_timeout(void);
+void dut_procedure_connect_timeout(void);
 
 static const struct bst_test_instance test_to_add[] = {
 	{
 		.test_id = "central",
+		.test_descr = "Central performs active scanning using RPA",
 		.test_post_init_f = test_init,
 		.test_tick_f = test_tick,
 		.test_main_f = dut_procedure,
 	},
 	{
+		.test_id = "central_connect_short_rpa_timeout",
+		.test_descr = "Central connects to a peripheral using a short RPA timeout",
+		.test_post_init_f = test_init,
+		.test_tick_f = test_tick,
+		.test_main_f = dut_procedure_connect_short_rpa_timeout,
+	},
+	{
+		.test_id = "central_connect_fails_with_short_rpa_timeout",
+		.test_descr = "Central connects to a peripheral using a short RPA timeout"
+			      " but expects connection establishment to time out.",
+		.test_post_init_f = test_init,
+		.test_tick_f = test_tick,
+		.test_main_f = dut_procedure_connect_timeout,
+	},
+	{
 		.test_id = "peripheral",
+		.test_descr = "Performs scannable advertising, validates that the scanner"
+			      " RPA address refreshes",
 		.test_post_init_f = test_init,
 		.test_tick_f = test_tick,
 		.test_main_f = tester_procedure,
+	},
+	{
+		.test_id = "periph_delayed_start_of_conn_adv",
+		.test_descr = "Performs connectable advertising. "
+			      "The advertiser is stopped for 10 seconds when instructed by the DUT"
+			      " to allow it to run the initiator for longer than its RPA timeout.",
+		.test_post_init_f = test_init,
+		.test_tick_f = test_tick,
+		.test_main_f = tester_procedure_periph_delayed_start_of_conn_adv,
 	},
 	BSTEST_END_MARKER,
 };

--- a/tests/bsim/bluetooth/host/privacy/central/test_scripts/run_test_short_conn_timeout.sh
+++ b/tests/bsim/bluetooth/host/privacy/central/test_scripts/run_test_short_conn_timeout.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Copyright 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+set -eu
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+EXECUTE_TIMEOUT=100
+verbosity_level=2
+
+# Test that connection establishment times out when RPA
+# timeout is shorter than the connection establishment timeout
+simulation_id="test_central_connect_fails_with_short_rpa_timeout"
+
+central_exe="${BSIM_OUT_PATH}/bin/bs_${BOARD_TS}_$(guess_test_long_name)_prj_conf"
+
+cd ${BSIM_OUT_PATH}/bin
+
+Execute "$central_exe" \
+    -v=${verbosity_level} -s=${simulation_id} -d=0 \
+    -testid=central_connect_fails_with_short_rpa_timeout -RealEncryption=1
+
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
+    -D=1 -sim_length=60e6 $@
+
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/privacy/central/test_scripts/run_test_short_rpa_timeout.sh
+++ b/tests/bsim/bluetooth/host/privacy/central/test_scripts/run_test_short_rpa_timeout.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Copyright 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+set -eu
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+EXECUTE_TIMEOUT=100
+verbosity_level=2
+
+# Test connection establishment when the RPA times out before
+# we expect the connection to be established
+simulation_id="test_central_connect_short_rpa_timeout"
+
+central_exe="${BSIM_OUT_PATH}/bin/bs_${BOARD_TS}_$(guess_test_long_name)_prj_conf"
+peripheral_exe="${central_exe}"
+
+cd ${BSIM_OUT_PATH}/bin
+
+Execute "$central_exe" \
+    -v=${verbosity_level} -s=${simulation_id} -d=0 \
+    -testid=central_connect_short_rpa_timeout -RealEncryption=1
+
+Execute "$peripheral_exe" \
+    -v=${verbosity_level} -s=${simulation_id} -d=1 \
+    -testid=periph_delayed_start_of_conn_adv -RealEncryption=1
+
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
+    -D=2 -sim_length=60e6 $@
+
+wait_for_background_jobs


### PR DESCRIPTION
Before this commit, the following bugs were present:
- When `CONFIG_BT_FILTER_ACCEPT_LIST` was set, connection establishment was cancelled upon RPA timeout. This required the application to restart the initiator every RPA timeout.
- When `CONFIG_BT_FILTER_ACCEPT_LIST` was not set, the RPA was not updated while the initiator was running.

This commit unifies the RPA timeout handling for both these cases. Upon RPA timeout the initiator is cancelled and restarted when the controller raises the LE Connection Complete event. The workqueue state is checked when restarting the initiator to prevent it being restarted when the timeout is hit.

Corresponding test cases have been added to ensure that this feature works.