### PR TITLE
arch: coding guidelines: use bool param when data nature is boolean

### DIFF
--- a/arch/arc/core/mpu/arc_core_mpu.c
+++ b/arch/arc/core/mpu/arc_core_mpu.c
@@ -34,7 +34,7 @@ int arch_mem_domain_max_partitions_get(void)
 /*
  * Validate the given buffer is user accessible or not
  */
-int arch_buffer_validate(const void *addr, size_t size, int write)
+int arch_buffer_validate(const void *addr, size_t size, bool write)
 {
 	return arc_core_mpu_buffer_validate(addr, size, write);
 }

--- a/arch/arc/core/mpu/arc_mpu_common_internal.h
+++ b/arch/arc/core/mpu/arc_mpu_common_internal.h
@@ -207,7 +207,7 @@ int arc_core_mpu_get_max_domain_partition_regions(void)
 /**
  * @brief validate the given buffer is user accessible or not
  */
-int arc_core_mpu_buffer_validate(const void *addr, size_t size, int write)
+int arc_core_mpu_buffer_validate(const void *addr, size_t size, bool write)
 {
 	/*
 	 * For ARC MPU, smaller region number takes priority.

--- a/arch/arc/core/mpu/arc_mpu_v4_internal.h
+++ b/arch/arc/core/mpu/arc_mpu_v4_internal.h
@@ -779,7 +779,7 @@ int arc_core_mpu_get_max_domain_partition_regions(void)
 /**
  * @brief validate the given buffer is user accessible or not
  */
-int arc_core_mpu_buffer_validate(const void *addr, size_t size, int write)
+int arc_core_mpu_buffer_validate(const void *addr, size_t size, bool write)
 {
 	int r_index;
 	int key = arch_irq_lock();

--- a/arch/arm/core/mpu/arm_core_mpu.c
+++ b/arch/arm/core/mpu/arm_core_mpu.c
@@ -338,7 +338,7 @@ int arch_mem_domain_max_partitions_get(void)
 	return ARM_CORE_MPU_MAX_DOMAIN_PARTITIONS_GET(available_regions);
 }
 
-int arch_buffer_validate(const void *addr, size_t size, int write)
+int arch_buffer_validate(const void *addr, size_t size, bool write)
 {
 	return arm_core_mpu_buffer_validate(addr, size, write);
 }

--- a/arch/arm/core/mpu/arm_core_mpu_dev.h
+++ b/arch/arm/core/mpu/arm_core_mpu_dev.h
@@ -261,7 +261,7 @@ int arm_core_mpu_get_max_available_dyn_regions(void);
  *       spans multiple enabled MPU regions (even if these regions all
  *       permit user access).
  */
-int arm_core_mpu_buffer_validate(const void *addr, size_t size, int write);
+int arm_core_mpu_buffer_validate(const void *addr, size_t size, bool write);
 
 #endif /* CONFIG_ARM_MPU */
 

--- a/arch/arm/core/mpu/arm_mpu.c
+++ b/arch/arm/core/mpu/arm_mpu.c
@@ -341,7 +341,7 @@ int arm_core_mpu_get_max_available_dyn_regions(void)
  *
  * Presumes the background mapping is NOT user accessible.
  */
-int arm_core_mpu_buffer_validate(const void *addr, size_t size, int write)
+int arm_core_mpu_buffer_validate(const void *addr, size_t size, bool write)
 {
 	return mpu_buffer_validate(addr, size, write);
 }

--- a/arch/arm/core/mpu/arm_mpu_v7_internal.h
+++ b/arch/arm/core/mpu/arm_mpu_v7_internal.h
@@ -169,7 +169,7 @@ static inline int is_user_accessible_region(uint32_t r_index, int write)
  * This internal function validates whether a given memory buffer
  * is user accessible or not.
  */
-static inline int mpu_buffer_validate(const void *addr, size_t size, int write)
+static inline int mpu_buffer_validate(const void *addr, size_t size, bool write)
 {
 	int32_t r_index;
 	int rc = -EPERM;

--- a/arch/arm/core/mpu/arm_mpu_v8_internal.h
+++ b/arch/arm/core/mpu/arm_mpu_v8_internal.h
@@ -408,7 +408,7 @@ static inline int is_user_accessible_region(uint32_t rnr, int write)
  * This internal function validates whether a given memory buffer
  * is user accessible or not.
  */
-static inline int mpu_buffer_validate(const void *addr, size_t size, int write)
+static inline int mpu_buffer_validate(const void *addr, size_t size, bool write)
 {
 	int32_t rnr;
 	int rc = -EPERM;
@@ -455,7 +455,7 @@ static inline int mpu_buffer_validate(const void *addr, size_t size, int write)
  * in case the fast address range check fails.
  *
  */
-static inline int mpu_buffer_validate(const void *addr, size_t size, int write)
+static inline int mpu_buffer_validate(const void *addr, size_t size, bool write)
 {
 	uint32_t _addr = (uint32_t)addr;
 	uint32_t _size = (uint32_t)size;

--- a/arch/arm/core/mpu/nxp_mpu.c
+++ b/arch/arm/core/mpu/nxp_mpu.c
@@ -602,7 +602,7 @@ static inline int is_user_accessible_region(uint32_t r_index, int write)
 /**
  * @brief validate the given buffer is user accessible or not
  */
-int arm_core_mpu_buffer_validate(const void *addr, size_t size, int write)
+int arm_core_mpu_buffer_validate(const void *addr, size_t size, bool write)
 {
 	uint8_t r_index;
 

--- a/arch/arm64/core/userspace.S
+++ b/arch/arm64/core/userspace.S
@@ -51,7 +51,7 @@ strlen_done:
 	ret
 
 /*
- * int arch_buffer_validate(const void *addr, size_t size, int write)
+ * int arch_buffer_validate(const void *addr, size_t size, bool write)
  */
 
 GTEXT(arch_buffer_validate)

--- a/arch/riscv/core/pmp.c
+++ b/arch/riscv/core/pmp.c
@@ -667,7 +667,7 @@ int arch_mem_domain_thread_remove(struct k_thread *thread)
 	((inner_start) >= (outer_start) && (inner_size) <= (outer_size) && \
 	 ((inner_start) - (outer_start)) <= ((outer_size) - (inner_size)))
 
-int arch_buffer_validate(const void *addr, size_t size, int write)
+int arch_buffer_validate(const void *addr, size_t size, bool write)
 {
 	uintptr_t start = (uintptr_t)addr;
 	int ret = -1;

--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -1432,7 +1432,7 @@ static inline void bcb_fence(void)
 }
 
 __pinned_func
-int arch_buffer_validate(const void *addr, size_t size, int write)
+int arch_buffer_validate(const void *addr, size_t size, bool write)
 {
 	pentry_t *ptables = z_x86_thread_page_tables_get(_current);
 	uint8_t *virt;

--- a/arch/xtensa/core/mpu.c
+++ b/arch/xtensa/core/mpu.c
@@ -969,7 +969,7 @@ out:
 	return ret;
 }
 
-int arch_buffer_validate(const void *addr, size_t size, int write)
+int arch_buffer_validate(const void *addr, size_t size, bool write)
 {
 	uintptr_t aligned_addr;
 	size_t aligned_size, addr_offset;

--- a/arch/xtensa/core/ptables.c
+++ b/arch/xtensa/core/ptables.c
@@ -1044,7 +1044,7 @@ static bool page_validate(uint32_t *ptables, uint32_t page, uint8_t ring, bool w
 	return true;
 }
 
-int arch_buffer_validate(const void *addr, size_t size, int write)
+int arch_buffer_validate(const void *addr, size_t size, bool write)
 {
 	int ret = 0;
 	uint8_t *virt;

--- a/include/zephyr/arch/arc/v2/mpu/arc_core_mpu.h
+++ b/include/zephyr/arch/arc/v2/mpu/arc_core_mpu.h
@@ -88,7 +88,7 @@ void arc_core_mpu_remove_mem_domain(struct k_mem_domain *mem_domain);
 void arc_core_mpu_remove_mem_partition(struct k_mem_domain *domain,
 			uint32_t partition_id);
 int arc_core_mpu_get_max_domain_partition_regions(void);
-int arc_core_mpu_buffer_validate(const void *addr, size_t size, int write);
+int arc_core_mpu_buffer_validate(const void *addr, size_t size, bool write);
 
 #endif
 

--- a/include/zephyr/arch/arch_interface.h
+++ b/include/zephyr/arch/arch_interface.h
@@ -778,12 +778,12 @@ int arch_mem_domain_partition_add(struct k_mem_domain *domain,
  *
  * @param addr start address of the buffer
  * @param size the size of the buffer
- * @param write If non-zero, additionally check if the area is writable.
+ * @param write If true, additionally check if the area is writable.
  *	  Otherwise, just check if the memory can be read.
  *
  * @return nonzero if the permissions don't match.
  */
-int arch_buffer_validate(const void *addr, size_t size, int write);
+int arch_buffer_validate(const void *addr, size_t size, bool write);
 
 /**
  * Get the optimal virtual region alignment to optimize the MMU table layout


### PR DESCRIPTION
converted arch buffer validation param "write" to boolean because this param is used as a boolean in the method.

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/d03fa8d8e9d90f104e5dadafea0f773a67862659