### PR TITLE
net: http: client: mark as unstable

### DIFF
--- a/include/zephyr/net/http/client.h
+++ b/include/zephyr/net/http/client.h
@@ -16,6 +16,8 @@
 /**
  * @brief HTTP client API
  * @defgroup http_client HTTP client API
+ * @since 2.1
+ * @version 0.2.0
  * @ingroup networking
  * @{
  */

--- a/subsys/net/lib/http/Kconfig
+++ b/subsys/net/lib/http/Kconfig
@@ -23,10 +23,9 @@ config HTTP_PARSER_STRICT
 	  This option enables the strict parsing option
 
 config HTTP_CLIENT
-	bool "HTTP client API [EXPERIMENTAL]"
+	bool "HTTP client API"
 	select HTTP_PARSER
 	select HTTP_PARSER_URL
-	select EXPERIMENTAL
 	help
 	  HTTP client API
 


### PR DESCRIPTION
As the http client currently has two applications that are using it (websocket and hawkBit) its API should be set as unstable. As described [here](https://docs.zephyrproject.org/latest/develop/api/api_lifecycle.html).