### PR TITLE
samples: modules: canopennode: make sample configurations depend on nvs

### DIFF
--- a/samples/modules/canopennode/sample.yaml
+++ b/samples/modules/canopennode/sample.yaml
@@ -15,15 +15,10 @@ common:
       - "(.*)CANopen stack initialized"
 tests:
   sample.modules.canopennode:
-    filter: dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions")
-      and dt_chosen_enabled("zephyr,flash-controller") and CONFIG_FLASH_HAS_DRIVER_ENABLED
-    platform_exclude:
-      - nucleo_h723zg
-      - nucleo_h743zi
-      - nucleo_h745zi_q/stm32h745xx/m7
-      - nucleo_h753zi
+    depends_on: nvs
   sample.modules.canopennode.program_download:
     sysbuild: true
+    depends_on: nvs
     platform_allow:
       - frdm_k64f
       - twr_ke18f


### PR DESCRIPTION
Make two of the CANopenNode sample configurations depend on "nvs" instead of trying to establish a local rule for which boards have the needed functionality.