### PR TITLE
tests: drivers: Update uart_elementary suite with different configuration

### DIFF
--- a/tests/drivers/uart/uart_elementary/src/main.c
+++ b/tests/drivers/uart/uart_elementary/src/main.c
@@ -233,15 +233,15 @@ ZTEST(uart_elementary, test_uart_dual_port_transmission)
 {
 	int err;
 	struct uart_config test_uart_config = { .baudrate = 115200,
-						.parity = UART_CFG_PARITY_NONE,
-						.stop_bits = UART_CFG_STOP_BITS_1,
+						.parity = UART_CFG_PARITY_EVEN,
+						.stop_bits = UART_CFG_STOP_BITS_2,
 						.data_bits = UART_CFG_DATA_BITS_8,
 						.flow_ctrl = UART_CFG_FLOW_CTRL_NONE };
 
 #if defined(CONFIG_SETUP_MISMATCH_TEST)
 	struct uart_config test_uart_config_aux = { .baudrate = 9600,
-						    .parity = UART_CFG_PARITY_NONE,
-						    .stop_bits = UART_CFG_STOP_BITS_1,
+						    .parity = UART_CFG_PARITY_EVEN,
+						    .stop_bits = UART_CFG_STOP_BITS_2,
 						    .data_bits = UART_CFG_DATA_BITS_8,
 						    .flow_ctrl = UART_CFG_FLOW_CTRL_NONE };
 #endif


### PR DESCRIPTION
…guration

Conigure UART to use 2 stop bits and even parity in 'dual transmission' case to cover more driver code cases.