### PR TITLE
drivers/sensor: lps25hb: Fix int32 overflow in the val2 part

### DIFF
--- a/drivers/sensor/st/lps25hb/lps25hb.c
+++ b/drivers/sensor/st/lps25hb/lps25hb.c
@@ -69,9 +69,14 @@ static int lps25hb_sample_fetch(const struct device *dev,
 static inline void lps25hb_press_convert(struct sensor_value *val,
 					 int32_t raw_val)
 {
-	/* val = raw_val / 40960 */
+	/* Pressure sensitivity is 4096 LSB/hPa */
+	/* Also convert hPa into kPa */
 	val->val1 = raw_val / 40960;
-	val->val2 = ((int32_t)raw_val * 1000000 / 40960) % 1000000;
+
+	/* For the decimal part use (3125 / 128) as a factor instead of
+	 * (1000000 / 40960) to avoid int32 overflow
+	 */
+	val->val2 = (raw_val % 40960) * 3125 / 128;
 }
 
 static inline void lps25hb_temp_convert(struct sensor_value *val,


### PR DESCRIPTION
The val2 calculation was done using (1000000 / 40960) as multiplying factor, which was sometimes leading to a int32 overflow. So, let's use the equivalent (but smaller) (3125 / 128).

Fix #46615
Mimic what already done in #38090 (c3050a5aa)
