### PR TITLE
boards: spike: Add Spike support

### DIFF
--- a/boards/spike/riscv32/Kconfig
+++ b/boards/spike/riscv32/Kconfig
@@ -1,0 +1,4 @@
+# Copyright (c) 2024 Tim-Marek Thomas <thomas@sra.uni-hannover.de>
+# SPDX-License-Identifier: Apache-2.0
+config BOARD_SPIKE_RISCV32
+	select SPIKE_TARGET

--- a/boards/spike/riscv32/Kconfig.spike_riscv32
+++ b/boards/spike/riscv32/Kconfig.spike_riscv32
@@ -1,0 +1,5 @@
+# Copyright (c) 2024 Tim-Marek Thomas <thomas@sra.uni-hannover.de>
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_SPIKE_RISCV32
+	select SOC_SPIKE_VIRT_RISCV32

--- a/boards/spike/riscv32/board.yml
+++ b/boards/spike/riscv32/board.yml
@@ -1,0 +1,5 @@
+board:
+  name: spike_riscv32
+  vendor: spike
+  socs:
+    - name: spike_virt_riscv32

--- a/boards/spike/riscv32/doc/index.rst
+++ b/boards/spike/riscv32/doc/index.rst
@@ -1,0 +1,106 @@
+.. _spike_riscv32:
+
+RISCV32 Emulation (Spike)
+#############
+
+Overview
+********
+The RISCV32 Spike board configuration is used to emulate the RISCV32 architecture.
+
+Programming and Debugging
+*************************
+Applications for the ``spike_riscv32`` board configuration can be built and run in
+the usual way for emulated boards (see :ref:`build_an_application` and
+:ref:`application_run` for more details).
+
+Flashing
+========
+While this board is emulated and you can't "flash" it, you can use this
+configuration to run basic Zephyr applications in the Spike
+emulated environment. For example, with the :zephyr:code-sample:`synchronization` sample:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/synchronization
+   :host-os: unix
+   :board: spike_riscv32
+   :goals: build
+
+This will build an image with the synchronization sample app.
+You can boot it using SPIKE with the following command line:
+
+.. code-block:: console
+
+   isnogud% spike --isa=rv32imac build/zephyr/zephyr.elf
+   warning: tohost and fromhost symbols not in ELF; can't communicate with target
+   *** Booting Zephyr OS build v3.6.0-3379-gea47ef0ac0ef ***
+   thread_a: Hello World from cpu 0 on spike_riscv32!
+   thread_b: Hello World from cpu 0 on spike_riscv32!
+   thread_a: Hello World from cpu 0 on spike_riscv32!
+   thread_b: Hello World from cpu 0 on spike_riscv32!
+   thread_a: Hello World from cpu 0 on spike_riscv32!
+   thread_b: Hello World from cpu 0 on spike_riscv32!
+   thread_a: Hello World from cpu 0 on spike_riscv32!
+   thread_b: Hello World from cpu 0 on spike_riscv32!
+   thread_a: Hello World from cpu 0 on spike_riscv32!
+
+Exit SPIKE by pressing :kbd:`CTRL+C` :kbd:`q`.
+
+Debugging
+=========
+
+If you want to use gdb for debugging you need to add following options to spike:
+
+.. code-block:: console
+
+   isnogud% spike --isa=rv32imac -m0x80000000:0x10000000 --rbb-port=9824 build/zephyr/zephyr.elf
+   Listening for remote bitbang connection on port 9824.
+   warning: tohost and fromhost symbols not in ELF; can't communicate with target
+   *** Booting Zephyr OS build v3.6.0-3379-gea47ef0ac0ef ***
+   thread_a: Hello World from cpu 0 on spike_riscv32!
+   thread_b: Hello World from cpu 0 on spike_riscv32!
+
+Then attach using openocd (an usable openocd configuration is available in the spike README on
+github page):
+
+.. code-block:: console
+
+   isnogud% ./riscv-openocd/src/openocd -f ~/spike.cfg
+   Open On-Chip Debugger 0.12.0+dev-03746-g16db1b77f (2024-04-26-11:14)
+   Licensed under GNU GPL v2
+   For bug reports, read
+      http://openocd.org/doc/doxygen/bugs.html
+   Info : auto-selecting first available session transport "jtag". To override use 'transport select <transport>'.
+   Info : Initializing remote_bitbang driver
+   Info : Connecting to localhost:9824
+   Info : remote_bitbang driver initialized
+   Info : Note: The adapter "remote_bitbang" doesn't support configurable speed
+   Info : JTAG tap: riscv.cpu tap/device found: 0xdeadbeef (mfg: 0x777 (Fabric of Truth Inc), part: 0xeadb, ver: 0xd)
+   Info : [riscv.cpu] datacount=2 progbufsize=2
+   Info : [riscv.cpu] Examined RISC-V core
+   Info : [riscv.cpu]  XLEN=32, misa=0x8000000000141105
+   [riscv.cpu] Target successfully examined.
+   Info : [riscv.cpu] Examination succeed
+   Info : starting gdb server for riscv.cpu on 3333
+   Info : Listening on port 3333 for gdb connections
+   riscv.cpu halted due to debug-request.
+   Info : Listening on port 6666 for tcl connections
+   Info : Listening on port 4444 for telnet connections
+
+And finally connect using gdb:
+
+.. code-block:: console
+
+   (gdb) target extended-remote :3333
+   Remote debugging using :3333
+   arch_irq_unlock (key=8) at /home/edwarf/git/riscv_spike/zephyr-project/zephyr/include/zephyr/arch/riscv/arch.h:259
+   259		__asm__ volatile ("csrs mstatus, %0"
+
+Hint: If you receive errors, that gdb/openocd cannot write into memory, this is due to enabled PMP.
+Either compile Zephyr with PMP disabled, use hardware breakpoints or add ``--dm-sba=32`` to the spike
+commandline, which allows openocd to access the system bus and bypass PMP.
+
+References
+**********
+
+.. Spike github:
+   https://github.com/riscv-software-src/riscv-isa-sim

--- a/boards/spike/riscv32/spike_riscv32.dts
+++ b/boards/spike/riscv32/spike_riscv32.dts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 Tim-Marek Tomas <thomas@sra.uni-hannover.de>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+#include <virt.dtsi>
+
+/ {
+	chosen {
+		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
+		zephyr,sram = &ram0;
+	};
+};
+
+&uart0 {
+	status = "okay";
+};

--- a/boards/spike/riscv32/spike_riscv32.yaml
+++ b/boards/spike/riscv32/spike_riscv32.yaml
@@ -1,0 +1,14 @@
+identifier: spike_riscv32
+name: spike Emulation for RISC-V 32-bit
+type: sim
+arch: riscv
+toolchain:
+  - zephyr
+  - xtools
+supported:
+  - netif
+testing:
+  default: true
+  ignore_tags:
+    - net
+    - bluetooth

--- a/boards/spike/riscv32/spike_riscv32_defconfig
+++ b/boards/spike/riscv32/spike_riscv32_defconfig
@@ -1,0 +1,9 @@
+# Copyright (c) 2024 Tim-Marek Thomas <thomas@sra.uni-hannover.de>
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_CONSOLE=y
+CONFIG_SERIAL=y
+CONFIG_UART_CONSOLE=y
+CONFIG_STACK_SENTINEL=y
+CONFIG_XIP=n
+CONFIG_RISCV_PMP=y

--- a/boards/spike/riscv64/Kconfig
+++ b/boards/spike/riscv64/Kconfig
@@ -1,0 +1,4 @@
+# Copyright (c) 2024 Tim-Marek Thomas <thomas@sra.uni-hannover.de>
+# SPDX-License-Identifier: Apache-2.0
+config BOARD_SPIKE_RISCV64
+	select SPIKE_TARGET

--- a/boards/spike/riscv64/Kconfig.spike_riscv64
+++ b/boards/spike/riscv64/Kconfig.spike_riscv64
@@ -1,0 +1,5 @@
+# Copyright (c) 2024 Tim-Marek Thomas <thomas@sra.uni-hannover.de>
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_SPIKE_RISCV64
+	select SOC_SPIKE_VIRT_RISCV64

--- a/boards/spike/riscv64/board.yml
+++ b/boards/spike/riscv64/board.yml
@@ -1,0 +1,5 @@
+board:
+  name: spike_riscv64
+  vendor: spike
+  socs:
+    - name: spike_virt_riscv64

--- a/boards/spike/riscv64/doc/index.rst
+++ b/boards/spike/riscv64/doc/index.rst
@@ -1,0 +1,106 @@
+.. _spike_riscv64:
+
+RISCV64 Emulation (Spike)
+#############
+
+Overview
+********
+The RISCV64 Spike board configuration is used to emulate the RISCV64 architecture.
+
+Programming and Debugging
+*************************
+Applications for the ``spike_riscv64`` board configuration can be built and run in
+the usual way for emulated boards (see :ref:`build_an_application` and
+:ref:`application_run` for more details).
+
+Flashing
+========
+While this board is emulated and you can't "flash" it, you can use this
+configuration to run basic Zephyr applications in the Spike
+emulated environment. For example, with the :zephyr:code-sample:`synchronization` sample:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/synchronization
+   :host-os: unix
+   :board: spike_riscv64
+   :goals: build
+
+This will build an image with the synchronization sample app.
+You can boot it using SPIKE with the following command line:
+
+.. code-block:: console
+
+   isnogud% spike --isa=rv64imac build/zephyr/zephyr.elf
+   warning: tohost and fromhost symbols not in ELF; can't communicate with target
+   *** Booting Zephyr OS build v3.6.0-3379-gea47ef0ac0ef ***
+   thread_a: Hello World from cpu 0 on spike_riscv64!
+   thread_b: Hello World from cpu 0 on spike_riscv64!
+   thread_a: Hello World from cpu 0 on spike_riscv64!
+   thread_b: Hello World from cpu 0 on spike_riscv64!
+   thread_a: Hello World from cpu 0 on spike_riscv64!
+   thread_b: Hello World from cpu 0 on spike_riscv64!
+   thread_a: Hello World from cpu 0 on spike_riscv64!
+   thread_b: Hello World from cpu 0 on spike_riscv64!
+   thread_a: Hello World from cpu 0 on spike_riscv64!
+
+Exit SPIKE by pressing :kbd:`CTRL+C` :kbd:`q`.
+
+Debugging
+=========
+
+If you want to use gdb for debugging you need to add following options to spike:
+
+.. code-block:: console
+
+   isnogud% spike --isa=rv64imac -m0x80000000:0x10000000 --rbb-port=9824 build/zephyr/zephyr.elf
+   Listening for remote bitbang connection on port 9824.
+   warning: tohost and fromhost symbols not in ELF; can't communicate with target
+   *** Booting Zephyr OS build v3.6.0-3379-gea47ef0ac0ef ***
+   thread_a: Hello World from cpu 0 on spike_riscv64!
+   thread_b: Hello World from cpu 0 on spike_riscv64!
+
+Then attach using openocd (an usable openocd configuration is available in the spike README on
+github page):
+
+.. code-block:: console
+
+   isnogud% ./riscv-openocd/src/openocd -f ~/spike.cfg
+   Open On-Chip Debugger 0.12.0+dev-03746-g16db1b77f (2024-04-26-11:14)
+   Licensed under GNU GPL v2
+   For bug reports, read
+      http://openocd.org/doc/doxygen/bugs.html
+   Info : auto-selecting first available session transport "jtag". To override use 'transport select <transport>'.
+   Info : Initializing remote_bitbang driver
+   Info : Connecting to localhost:9824
+   Info : remote_bitbang driver initialized
+   Info : Note: The adapter "remote_bitbang" doesn't support configurable speed
+   Info : JTAG tap: riscv.cpu tap/device found: 0xdeadbeef (mfg: 0x777 (Fabric of Truth Inc), part: 0xeadb, ver: 0xd)
+   Info : [riscv.cpu] datacount=2 progbufsize=2
+   Info : [riscv.cpu] Examined RISC-V core
+   Info : [riscv.cpu]  XLEN=64, misa=0x8000000000141105
+   [riscv.cpu] Target successfully examined.
+   Info : [riscv.cpu] Examination succeed
+   Info : starting gdb server for riscv.cpu on 3333
+   Info : Listening on port 3333 for gdb connections
+   riscv.cpu halted due to debug-request.
+   Info : Listening on port 6666 for tcl connections
+   Info : Listening on port 4444 for telnet connections
+
+And finally connect using gdb:
+
+.. code-block:: console
+
+   (gdb) target extended-remote :3333
+   Remote debugging using :3333
+   arch_irq_unlock (key=8) at /home/edwarf/git/riscv_spike/zephyr-project/zephyr/include/zephyr/arch/riscv/arch.h:259
+   259		__asm__ volatile ("csrs mstatus, %0"
+
+Hint: If you receive errors, that gdb/openocd cannot write into memory, this is due to enabled PMP.
+Either compile Zephyr with PMP disabled, use hardware breakpoints or add ``--dm-sba=64`` to the spike
+commandline, which allows openocd to access the system bus and bypass PMP.
+
+References
+**********
+
+.. Spike github:
+   https://github.com/riscv-software-src/riscv-isa-sim

--- a/boards/spike/riscv64/spike_riscv64.dts
+++ b/boards/spike/riscv64/spike_riscv64.dts
@@ -1,0 +1,21 @@
+/*
+* Copyright (c) 2024 Tim-Marek Tomas <thomas@sra.uni-hannover.de>
+*
+* SPDX-License-Identifier: Apache-2.0
+*/
+
+/dts-v1/;
+
+#include <virt.dtsi>
+
+/ {
+	chosen {
+		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
+		zephyr,sram = &ram0;
+	};
+};
+
+&uart0 {
+	status = "okay";
+};

--- a/boards/spike/riscv64/spike_riscv64.yaml
+++ b/boards/spike/riscv64/spike_riscv64.yaml
@@ -1,0 +1,14 @@
+identifier: spike_riscv64
+name: spike Emulation for RISC-V 64-bit
+type: sim
+arch: riscv
+toolchain:
+  - zephyr
+  - xtools
+supported:
+  - netif
+testing:
+  default: true
+  ignore_tags:
+    - net
+    - bluetooth

--- a/boards/spike/riscv64/spike_riscv64_defconfig
+++ b/boards/spike/riscv64/spike_riscv64_defconfig
@@ -1,0 +1,9 @@
+# Copyright (c) 2024 Tim-Marek Thomas <thomas@sra.uni-hannover.de>
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_CONSOLE=y
+CONFIG_SERIAL=y
+CONFIG_UART_CONSOLE=y
+CONFIG_STACK_SENTINEL=y
+CONFIG_XIP=n
+CONFIG_RISCV_PMP=y

--- a/soc/spike/CMakeLists.txt
+++ b/soc/spike/CMakeLists.txt
@@ -1,0 +1,3 @@
+# Copyright (c) 2024 Tim-Marek Thomas <thomas@sra.uni-hannover.de>
+# SPDX-License-Identifier: Apache-2.0
+set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/riscv/common/linker.ld CACHE INTERNAL "")

--- a/soc/spike/Kconfig
+++ b/soc/spike/Kconfig
@@ -1,0 +1,17 @@
+# Copyright (c) 2024 Tim-Marek Thomas <thomas@sra.uni-hannover.de>
+# SPDX-License-Identifier: Apache-2.0
+config SOC_FAMILY_SPIKE_VIRT_RISCV
+	select RISCV
+	select RISCV_ISA_EXT_M
+	select RISCV_ISA_EXT_A
+	select RISCV_ISA_EXT_C
+	select ATOMIC_OPERATIONS_BUILTIN
+	select RISCV_PRIVILEGED
+	select RISCV_HAS_PLIC
+	select INCLUDE_RESET_VECTOR
+
+if SOC_FAMILY_SPIKE_VIRT_RISCV
+
+rsource "*/Kconfig"
+
+endif # SOC_FAMILY_SPIKE_VIRT_RISCV

--- a/soc/spike/Kconfig.defconfig
+++ b/soc/spike/Kconfig.defconfig
@@ -1,0 +1,29 @@
+# Copyright (c) 2024 Tim-Marek Thomas <thomas@sra.uni-hannover.de>
+# SPDX-License-Identifier: Apache-2.0
+if SOC_FAMILY_SPIKE_VIRT_RISCV
+
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default 1000000
+
+config RISCV_SOC_INTERRUPT_INIT
+	default y
+
+config RISCV_GP
+	default y
+
+config 2ND_LVL_ISR_TBL_OFFSET
+	default 12
+
+config 2ND_LVL_INTR_00_OFFSET
+	default 11
+
+config MAX_IRQ_PER_AGGREGATOR
+	default 52
+
+config NUM_IRQS
+	default 1035
+
+config PMP_SLOTS
+	default 16
+
+endif # SOC_FAMILY_SPIKE_VIRT_RISCV

--- a/soc/spike/Kconfig.soc
+++ b/soc/spike/Kconfig.soc
@@ -1,0 +1,9 @@
+# Copyright (c) 2024 Tim-Marek Thomas <thomas@sra.uni-hannover.de>
+# SPDX-License-Identifier: Apache-2.0
+config SOC_FAMILY_SPIKE_VIRT_RISCV
+	bool
+
+config SOC_FAMILY
+	default "spike_virt_riscv" if SOC_FAMILY_SPIKE_VIRT_RISCV
+
+rsource "*/Kconfig.soc"

--- a/soc/spike/soc.yml
+++ b/soc/spike/soc.yml
@@ -1,0 +1,5 @@
+family:
+- name: spike_virt_riscv
+  socs:
+  - name: spike_virt_riscv32
+  - name: spike_virt_riscv64

--- a/soc/spike/spike_virt_riscv32/Kconfig
+++ b/soc/spike/spike_virt_riscv32/Kconfig
@@ -1,0 +1,8 @@
+# Copyright (c) 2024 Tim-Marek Thomas <thomas@sra.uni-hannover.de>
+# SPDX-License-Identifier: Apache-2.0
+config SOC_SPIKE_VIRT_RISCV32
+	select 32BIT
+	select CPU_HAS_FPU
+	select RISCV_ISA_RV32I
+	select RISCV_ISA_EXT_ZICSR
+	select RISCV_ISA_EXT_ZIFENCEI

--- a/soc/spike/spike_virt_riscv32/Kconfig.soc
+++ b/soc/spike/spike_virt_riscv32/Kconfig.soc
@@ -1,0 +1,8 @@
+# Copyright (c) 2024 Tim-Marek Thomas <thomas@sra.uni-hannover.de>
+# SPDX-License-Identifier: Apache-2.0
+config SOC_SPIKE_VIRT_RISCV32
+	bool
+	select SOC_FAMILY_SPIKE_VIRT_RISCV
+
+config SOC
+	default "spike_virt_riscv32" if SOC_SPIKE_VIRT_RISCV32

--- a/soc/spike/spike_virt_riscv64/Kconfig
+++ b/soc/spike/spike_virt_riscv64/Kconfig
@@ -1,0 +1,8 @@
+# Copyright (c) 2024 Tim-Marek Thomas <thomas@sra.uni-hannover.de>
+# SPDX-License-Identifier: Apache-2.0
+config SOC_SPIKE_VIRT_RISCV64
+	select 64BIT
+	select CPU_HAS_FPU
+	select RISCV_ISA_RV64I
+	select RISCV_ISA_EXT_ZICSR
+	select RISCV_ISA_EXT_ZIFENCEI

--- a/soc/spike/spike_virt_riscv64/Kconfig.soc
+++ b/soc/spike/spike_virt_riscv64/Kconfig.soc
@@ -1,0 +1,8 @@
+# Copyright (c) 2024 Tim-Marek Thomas <thomas@sra.uni-hannover.de>
+# SPDX-License-Identifier: Apache-2.0
+config SOC_SPIKE_VIRT_RISCV64
+	bool
+	select SOC_FAMILY_SPIKE_VIRT_RISCV
+
+config SOC
+	default "spike_virt_riscv64" if SOC_SPIKE_VIRT_RISCV64


### PR DESCRIPTION
This adds [Spike](https://github.com/riscv-software-src/riscv-isa-sim) as a SoC and Board.
I oriented myself mostly at the QEMU RISC-V support, and the already existing [FreeRTOS demo](https://github.com/FreeRTOS/FreeRTOS/tree/main/FreeRTOS/Demo/RISC-V-spike-htif_GCC).

While this isn't really generally desirable (QEMU is more than sufficient in almost all cases), i needed this for a  work-related project.

I can build the sample applications, run them in Spike, and also use Spikes remote bitbang to connect with a gdb session.

This is still a bit WIP because of a few points:
- The board and SoC definitions are currently not under /others, which is probably a better place.
- For some reason, when i build the documentation locally, the spike board does not appear under the "Supported Boards" page. Also, is there any other way to speed up documentation generation except `make html-fast`? That still takes ages on my laptop :sweat_smile: 
- I did not implement htif support, which can be used to communicate with the host. Might be neat.
- I did not add Spike as a emulator platform, thus `west build -t run` does not work. I detailed how one can run the generated .elf using spike in the docs.
- I dont know if this is generally desirable to be added to the main project. QEMU is, as already mentioned sufficient for almost all use cases, and when i understood it correctly the [SAIL Model](https://github.com/riscv/sail-riscv) of RISC-V is supposed to kind-off supersede Spike?