### PR TITLE
scripts: twister: Fix Unit Tests on Windows systems

### DIFF
--- a/scripts/tests/twister/test_jobserver.py
+++ b/scripts/tests/twister/test_jobserver.py
@@ -14,15 +14,13 @@ import sys
 
 from contextlib import nullcontext
 from errno import ENOENT
-from fcntl import F_GETFL
 from selectors import EVENT_READ
 
-from twisterlib.jobserver import (
-    JobHandle,
-    JobClient,
-    GNUMakeJobClient,
-    GNUMakeJobServer
-)
+# Job server only works on Linux for now.
+pytestmark = pytest.mark.skipif(sys.platform != 'linux', reason='JobServer only works on Linux.')
+if sys.platform == 'linux':
+    from twisterlib.jobserver import GNUMakeJobClient, GNUMakeJobServer, JobClient, JobHandle
+    from fcntl import F_GETFL
 
 
 def test_jobhandle(capfd):
@@ -95,7 +93,6 @@ TESTDATA_2 = [
     (False, 4),
     (True, 16),
 ]
-
 
 @pytest.mark.parametrize(
     'inheritable, internal_jobs',
@@ -281,6 +278,7 @@ def test_gnumakejobclient_from_environ(
     else:
         gmjc_init_mock.assert_called_once_with(*expected_args,
                                                **expected_kwargs)
+
 
 
 def test_gnumakejobclient_get_job():

--- a/scripts/tests/twister/test_testsuite.py
+++ b/scripts/tests/twister/test_testsuite.py
@@ -213,26 +213,41 @@ def test_scan_file(test_data, test_file, class_env, expected: ScanPathResult):
     assert result == expected
 
 
-TESTDATA_3 = [
-    (
-        'nt',
-        {'access': mmap.ACCESS_READ}
-    ),
-    (
-        'posix',
-        {
-            'flags': mmap.MAP_PRIVATE,
-            'prot': mmap.PROT_READ,
-            'offset': 0
-        }
+# Generate testcases depending on available mmap attributes
+TESTIDS_3 = []
+TESTDATA_3 = []
+
+try:
+    TESTDATA_3.append(
+        (
+            'nt',
+            {'access': mmap.ACCESS_READ}
+        )
     )
-]
+    TESTIDS_3.append('windows')
+except AttributeError:
+    pass
+
+try:
+    TESTDATA_3.append(
+        (
+            'posix',
+            {
+                'flags': mmap.MAP_PRIVATE,
+                'prot': mmap.PROT_READ,
+                'offset': 0
+            }
+        )
+    )
+    TESTIDS_3.append('linux')
+except AttributeError:
+    pass
 
 
 @pytest.mark.parametrize(
     'os_name, expected',
     TESTDATA_3,
-    ids=['windows', 'linux']
+    ids=TESTIDS_3
 )
 def test_scan_file_mmap(os_name, expected):
     class TestException(Exception):


### PR DESCRIPTION
Unit tests currently are not runnable on Windows systems, failing on two testfiles: test_jobserver.py and test_testsuite.py.

This commit removes code dependency on Windows-unavailable elements on Windows systems via skipping the offending tests.

This step is necessary in order to have Twister on Windows automatic verification.