### PR TITLE
samples: boards: nrf: nrfx_prs: extend regex to test default task

### DIFF
--- a/samples/boards/nrf/nrfx_prs/sample.yaml
+++ b/samples/boards/nrf/nrfx_prs/sample.yaml
@@ -17,3 +17,8 @@ tests:
         - "nrfx PRS example on .*"
         - "-> press \".*\" to trigger a transfer"
         - "-> press \".*\" to switch the type of peripheral"
+        - "Switched to SPIM"
+        - "-- Background transfer on \".*\" --"
+        - "Tx: 4E 6F 72 64 69 63 20 53 65 6D 69 63 6F 6E 64 75 63 74 6F 72 00"
+        - "Rx:"
+        - "-- Background transfer on \".*\" --"


### PR DESCRIPTION
Verifies that at least SPIM is initialized properly.