### PR TITLE
net: zperf: Fix upload ping timeout error

### DIFF
--- a/subsys/net/lib/zperf/zperf_shell.c
+++ b/subsys/net/lib/zperf/zperf_shell.c
@@ -685,7 +685,8 @@ static void send_ping(const struct shell *sh,
 		return;
 	}
 
-	memcpy(&dest_addr.sin6_addr, addr, sizeof(struct in6_addr));
+	dest_addr.sin6_family = AF_INET6;
+	net_ipv6_addr_copy_raw((uint8_t *)&dest_addr.sin6_addr, (uint8_t *)addr);
 
 	k_sem_init(&sem_wait, 0, 1);
 


### PR DESCRIPTION
Fixes remote address for ping before upload. This caused the ping in zperf
upload to timeout as shown in the following output:

```
uart:~$ zperf udp upload 2001:db8::2 5001 10 50 1M
Remote port is 5001
Connecting to 2001:db8::2
Duration:       10.00 s
Packet size:    50 bytes
Rate:           1000 kbps
Starting...
ping 2001:db8::2 timeout
Rate:           1.00 Mbps
Packet duration 390 us
```

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/68674