### PR TITLE
arch: arm: cortex_a_r: Improve support for big endian

### DIFF
--- a/arch/arm/CMakeLists.txt
+++ b/arch/arm/CMakeLists.txt
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set_property(GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT elf32-littlearm)
+if(CONFIG_BIG_ENDIAN)
+  set_property(GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT elf32-bigarm)
+else()
+  set_property(GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT elf32-littlearm)
+endif()
 
 add_subdirectory(core)

--- a/arch/arm/core/cortex_a_r/thread.c
+++ b/arch/arm/core/cortex_a_r/thread.c
@@ -95,6 +95,10 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	iframe->a4 = (uint32_t)p3;
 
 	iframe->xpsr = A_BIT | MODE_SYS;
+#if defined(CONFIG_BIG_ENDIAN)
+	iframe->xpsr |= E_BIT;
+#endif /* CONFIG_BIG_ENDIAN */
+
 #if defined(CONFIG_COMPILER_ISA_THUMB2)
 	iframe->xpsr |= T_BIT;
 #endif /* CONFIG_COMPILER_ISA_THUMB2 */

--- a/include/zephyr/arch/arm/cortex_a_r/cpu.h
+++ b/include/zephyr/arch/arm/cortex_a_r/cpu.h
@@ -26,6 +26,7 @@
 #define MODE_SYS	0x1f
 #define MODE_MASK	0x1f
 
+#define E_BIT	(1 << 9)
 #define A_BIT	(1 << 8)
 #define I_BIT	(1 << 7)
 #define F_BIT	(1 << 6)


### PR DESCRIPTION
This enables support for big endian Cortex A/R devices. The pull request consists of two changes:
* Set `PROPERTY_OUTPUT_FORMAT` to `elf32-bigarm` when `CONFIG_BIG_ENDIAN=y`
* Set the endianness bit of the `CPSR` register, ensuring that the CPU stays in big endian mode when switching to the main thread. Without this, data accesses used the wrong endianness, causing a (very big) headache.

The `CPSR` issue was the only problem I noticed when porting the `TMS570LS1224` big endian Cortex R4F SoC. With this fixed, it seems to work completely fine. My setup is available at https://github.com/OrbitNTNU/zephyr-hw if that is relevant.