### PR TITLE
boards: st: remove "- sdhc" tag from supported list

### DIFF
--- a/boards/olimex/olimexino_stm32/olimexino_stm32.yaml
+++ b/boards/olimex/olimexino_stm32/olimexino_stm32.yaml
@@ -11,7 +11,6 @@ supported:
   - gpio
   - i2c
   - pwm
-  - sdhc
   - spi
   - usb_device
   - watchdog

--- a/boards/st/stm32f746g_disco/stm32f746g_disco.yaml
+++ b/boards/st/stm32f746g_disco/stm32f746g_disco.yaml
@@ -16,7 +16,6 @@ supported:
   - gpio
   - pwm
   - counter
-  - sdhc
   - usb_device
   - display
   - memc

--- a/boards/st/stm32f7508_dk/stm32f7508_dk.yaml
+++ b/boards/st/stm32f7508_dk/stm32f7508_dk.yaml
@@ -19,7 +19,6 @@ supported:
   - gpio
   - pwm
   - counter
-  - sdhc
   - usb_device
   - display
   - memc

--- a/boards/st/stm32h573i_dk/stm32h573i_dk.yaml
+++ b/boards/st/stm32h573i_dk/stm32h573i_dk.yaml
@@ -24,6 +24,5 @@ supported:
   - usb_device
   - usb
   - i2c
-  - sdhc
   - rtc
 vendor: st

--- a/boards/st/stm32l496g_disco/stm32l496g_disco.yaml
+++ b/boards/st/stm32l496g_disco/stm32l496g_disco.yaml
@@ -15,7 +15,6 @@ supported:
   - spi
   - gpio
   - counter
-  - sdhc
   - adc
   - qspi
 vendor: st

--- a/boards/st/stm32l4r9i_disco/stm32l4r9i_disco.yaml
+++ b/boards/st/stm32l4r9i_disco/stm32l4r9i_disco.yaml
@@ -18,7 +18,6 @@ supported:
   - i2c
   - pwm
   - rtc
-  - sdhc
   - spi
   - uart
   - usb

--- a/boards/st/stm32l562e_dk/stm32l562e_dk.yaml
+++ b/boards/st/stm32l562e_dk/stm32l562e_dk.yaml
@@ -19,7 +19,6 @@ supported:
   - dma
   - usart
   - arduino_spi
-  - sdhc
   - usb
   - usb_device
   - nvs

--- a/boards/st/stm32l562e_dk/stm32l562e_dk_stm32l562xx_ns.yaml
+++ b/boards/st/stm32l562e_dk/stm32l562e_dk_stm32l562xx_ns.yaml
@@ -13,7 +13,6 @@ supported:
   - dac
   - spi
   - arduino_spi
-  - sdhc
   - usb
   - usb_device
 ram: 192

--- a/boards/weact/mini_stm32h743/mini_stm32h743.yaml
+++ b/boards/weact/mini_stm32h743/mini_stm32h743.yaml
@@ -15,6 +15,5 @@ supported:
   - backup_sram
   - watchdog
   - usb
-  - sdhc
   - qspi
 vendor: weact

--- a/tests/drivers/disk/disk_access/testcase.yaml
+++ b/tests/drivers/disk/disk_access/testcase.yaml
@@ -34,3 +34,5 @@ tests:
     platform_allow:
       - native_sim/native/64
       - native_sim
+  drivers.disk.stm32_sdhc:
+    filter: dt_compat_enabled("st,stm32-sdmmc")


### PR DESCRIPTION
SDHC twister tag indicates that the board supports an SD host controller
driver. Since the ST SDMMC support is provided directly via a disk
driver, SDHC tests are not supported on ST boards. Drop this tag in
order to avoid twister failures running the SDHC tests on these
platforms.

In order to ensure these boards still receive testing, add an STM32 specific testcase for disk access to the `tests/drivers/disk/disk_access` testcase.yaml
