### PR TITLE
dts: bindings: gpio: remove unused reg property from emul driver

### DIFF
--- a/boards/native/native_sim/native_sim.dts
+++ b/boards/native/native_sim/native_sim.dts
@@ -161,10 +161,9 @@
 		compatible = "zephyr,native-posix-counter";
 	};
 
-	gpio0: gpio@800 {
+	gpio0: gpio_emul {
 		status = "okay";
 		compatible = "zephyr,gpio-emul";
-		reg = <0x800 0x4>;
 		rising-edge;
 		falling-edge;
 		high-level;

--- a/dts/bindings/gpio/zephyr,gpio-emul.yaml
+++ b/dts/bindings/gpio/zephyr,gpio-emul.yaml
@@ -8,9 +8,6 @@ compatible: "zephyr,gpio-emul"
 include: [gpio-controller.yaml, base.yaml]
 
 properties:
-  reg:
-    required: true
-
   rising-edge:
     description: Enables support for rising edge interrupt detection
     type: boolean


### PR DESCRIPTION
The gpio-emul driver does not actually require any reg property, since it is not in the physical memory map of any device. So let's remove that property from the bindings.