### PR TITLE
drivers: spi: stm32: Skip pinctrl suspend/resume for subghzspi

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -1238,10 +1238,12 @@ static int spi_stm32_pm_action(const struct device *dev,
 
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
-		/* Set pins to active state */
-		err = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
-		if (err < 0) {
-			return err;
+		if (!spi_stm32_is_subghzspi(dev)) {
+			/* Set pins to active state */
+			err = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+			if (err < 0) {
+				return err;
+			}
 		}
 
 		/* enable clock */
@@ -1255,21 +1257,24 @@ static int spi_stm32_pm_action(const struct device *dev,
 		/* Stop device clock. */
 		err = clock_control_off(clk, (clock_control_subsys_t)&config->pclken[0]);
 		if (err != 0) {
-			LOG_ERR("Could not enable SPI clock");
+			LOG_ERR("Could not disable SPI clock");
 			return err;
 		}
 
-		/* Move pins to sleep state */
-		err = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_SLEEP);
-		if ((err < 0) && (err != -ENOENT)) {
-			/*
-			 * If returning -ENOENT, no pins where defined for sleep mode :
-			 * Do not output on console (might sleep already) when going to sleep,
-			 * "SPI pinctrl sleep state not available"
-			 * and don't block PM suspend.
-			 * Else return the error.
-			 */
-			return err;
+		if (!spi_stm32_is_subghzspi(dev)) {
+			/* Move pins to sleep state */
+			err = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_SLEEP);
+			if ((err < 0) && (err != -ENOENT)) {
+				/*
+				 * If returning -ENOENT, no pins where defined for sleep mode :
+				 * Do not output on console (might sleep already) when going to
+				 * sleep,
+				 * "SPI pinctrl sleep state not available"
+				 * and don't block PM suspend.
+				 * Else return the error.
+				 */
+				return err;
+			}
 		}
 		break;
 	default:


### PR DESCRIPTION
Subghzspi instances cannot have any pinctrl configs. This causes a failure of the power management suspend and resume operations for the subghzspi instance because no "default" pinctrl is found.

Fix that by skipping the pinctrl parts on subghzspi instances.

At the same time fix a copy and paste in the suspend error message.

Fixes: b567a7db83ae