### PR TITLE
dts/arm/st: wl: change cpu0 compatible to arm,cortex-m4

### DIFF
--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -29,7 +29,7 @@
 
 		cpu0: cpu@0 {
 			device_type = "cpu";
-			compatible = "arm,cortex-m4f";
+			compatible = "arm,cortex-m4";
 			reg = <0>;
 			cpu-power-states = <&stop0 &stop1 &stop2>;
 		};


### PR DESCRIPTION
The STM32WL SoC has a Cortex M4 CPU without FPU. Change the cpu0 compatible string accordingly.