### PR TITLE
sd: fix frequency and timing selection logic

### DIFF
--- a/drivers/sdhc/rcar_mmc.c
+++ b/drivers/sdhc/rcar_mmc.c
@@ -28,15 +28,6 @@ LOG_MODULE_REGISTER(rcar_mmc, CONFIG_LOG_DEFAULT_LEVEL);
 #define MMC_POLL_FLAGS_TIMEOUT_US 100000
 #define MMC_POLL_FLAGS_ONE_CYCLE_TIMEOUT_US 1
 #define MMC_BUS_CLOCK_FREQ 800000000
-/*
- * SD/MMC clock for Gen3/Gen4 R-car boards can't be equal to 208 MHz,
- * but we can run SDR104 on lower frequencies:
- *    "SDR104: UHS-I 1.8V signaling, Frequency up to 208 MHz"
- * so according to SD card standard it is possible to use lower frequencies,
- * and we need to pass check of frequency in sdmmc in order to use sdr104 mode.
- * This is the reason why it is needed this correction.
- */
-#define MMC_MAX_FREQ_CORRECTION 8000000
 
 #ifdef CONFIG_RCAR_MMC_DMA_SUPPORT
 #define ALIGN_BUF_DMA __aligned(CONFIG_SDHC_BUFFER_ALIGNMENT)
@@ -1941,7 +1932,7 @@ static void rcar_mmc_init_host_props(const struct device *dev)
 
 	/* Note: init only properties that are used for mmc/sdhc */
 
-	props->f_max = cfg->max_frequency + MMC_MAX_FREQ_CORRECTION;
+	props->f_max = cfg->max_frequency;
 	/*
 	 * note: actually, it's possible to get lower frequency
 	 *       if we use divider from cpg too

--- a/include/zephyr/sd/sd_spec.h
+++ b/include/zephyr/sd/sd_spec.h
@@ -12,6 +12,7 @@
 #define ZEPHYR_SUBSYS_SD_SPEC_H_
 
 #include <stdint.h>
+#include <zephyr/sys/util.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -368,7 +369,7 @@ enum sd_group_num {
 
 /* Maximum data rate possible for SD high speed cards */
 enum hs_max_data_rate {
-	HS_MAX_DTR = 50000000,
+	HS_MAX_DTR = MHZ(50),
 };
 
 /**
@@ -411,16 +412,16 @@ enum sd_timing_mode {
  * Controls the SD host controller clock speed on the SD bus.
  */
 enum sdhc_clock_speed {
-	SDMMC_CLOCK_400KHZ = 400000U,
-	SD_CLOCK_25MHZ = 25000000U,
-	SD_CLOCK_50MHZ = 50000000U,
-	SD_CLOCK_100MHZ = 100000000U,
-	SD_CLOCK_208MHZ = 208000000U,
-	MMC_CLOCK_26MHZ = 26000000U,
-	MMC_CLOCK_52MHZ = 52000000U,
-	MMC_CLOCK_DDR52 = 52000000U,
-	MMC_CLOCK_HS200 = 200000000U,
-	MMC_CLOCK_HS400 = 200000000U, /* Same clock freq as HS200, just DDR */
+	SDMMC_CLOCK_400KHZ = KHZ(400),
+	SD_CLOCK_25MHZ = MHZ(25),
+	SD_CLOCK_50MHZ = MHZ(50),
+	SD_CLOCK_100MHZ = MHZ(100),
+	SD_CLOCK_208MHZ = MHZ(208),
+	MMC_CLOCK_26MHZ = MHZ(26),
+	MMC_CLOCK_52MHZ = MHZ(52),
+	MMC_CLOCK_DDR52 = MHZ(52),
+	MMC_CLOCK_HS200 = MHZ(200),
+	MMC_CLOCK_HS400 = MHZ(200), /* Same clock freq as HS200, just DDR */
 };
 
 /**

--- a/include/zephyr/sd/sd_spec.h
+++ b/include/zephyr/sd/sd_spec.h
@@ -369,6 +369,7 @@ enum sd_group_num {
 
 /* Maximum data rate possible for SD high speed cards */
 enum hs_max_data_rate {
+	HS_UNSUPPORTED = 0,
 	HS_MAX_DTR = MHZ(50),
 };
 

--- a/include/zephyr/sd/sd_spec.h
+++ b/include/zephyr/sd/sd_spec.h
@@ -373,6 +373,16 @@ enum hs_max_data_rate {
 	HS_MAX_DTR = MHZ(50),
 };
 
+/* Maximum data rate possible for SD uhs cards */
+enum uhs_max_data_rate {
+	UHS_UNSUPPORTED = 0,
+	UHS_SDR12_MAX_DTR = MHZ(25),
+	UHS_SDR25_MAX_DTR = MHZ(50),
+	UHS_SDR50_MAX_DTR = MHZ(100),
+	UHS_SDR104_MAX_DTR = MHZ(208),
+	UHS_DDR50_MAX_DTR = MHZ(50),
+};
+
 /**
  * @brief SD bus speed support bit flags
  *
@@ -494,7 +504,7 @@ enum sd_driver_strength {
  */
 struct sd_switch_caps {
 	enum hs_max_data_rate hs_max_dtr;
-	enum sdhc_clock_speed uhs_max_dtr;
+	enum uhs_max_data_rate uhs_max_dtr;
 	enum sd_bus_speed bus_speed;
 	enum sd_driver_type sd_drv_type;
 	enum sd_current_limit sd_current_limit;

--- a/include/zephyr/sd/sd_spec.h
+++ b/include/zephyr/sd/sd_spec.h
@@ -381,6 +381,7 @@ enum hs_max_data_rate {
  */
 enum sd_bus_speed {
 	UHS_SDR12_BUS_SPEED = BIT(0),
+	DEFAULT_BUS_SPEED = BIT(0),
 	HIGH_SPEED_BUS_SPEED = BIT(1),
 	UHS_SDR25_BUS_SPEED = BIT(1),
 	UHS_SDR50_BUS_SPEED = BIT(2),
@@ -395,10 +396,14 @@ enum sd_bus_speed {
  * controller to identify timing of card.
  */
 enum sd_timing_mode {
+	SD_TIMING_DEFAULT = 0U,
+	/*!< Default Mode */
 	SD_TIMING_SDR12 = 0U,
-	/*!< Default mode & SDR12 */
+	/*!< SDR12 mode */
+	SD_TIMING_HIGH_SPEED = 1U,
+	/*!< High speed mode */
 	SD_TIMING_SDR25 = 1U,
-	/*!< High speed mode & SDR25 */
+	/*!< SDR25 mode */
 	SD_TIMING_SDR50 = 2U,
 	/*!< SDR50 mode*/
 	SD_TIMING_SDR104 = 3U,

--- a/subsys/sd/sdio.c
+++ b/subsys/sd/sdio.c
@@ -450,23 +450,23 @@ static int sdio_set_bus_width(struct sd_card *card, enum sdhc_bus_width width)
 static inline void sdio_select_bus_speed(struct sd_card *card)
 {
 	if (card->host_props.host_caps.sdr104_support &&
-		(card->cccr_flags & SDIO_SUPPORT_SDR104) &&
-		(card->host_props.f_max >= SD_CLOCK_208MHZ)) {
+		(card->cccr_flags & SDIO_SUPPORT_SDR104)) {
 		card->card_speed = SD_TIMING_SDR104;
+		card->switch_caps.uhs_max_dtr = UHS_SDR104_MAX_DTR;
 	} else if (card->host_props.host_caps.ddr50_support &&
-		(card->cccr_flags & SDIO_SUPPORT_DDR50) &&
-		(card->host_props.f_max >= SD_CLOCK_50MHZ)) {
+		(card->cccr_flags & SDIO_SUPPORT_DDR50)) {
 		card->card_speed = SD_TIMING_DDR50;
+		card->switch_caps.uhs_max_dtr = UHS_DDR50_MAX_DTR;
 	} else if (card->host_props.host_caps.sdr50_support &&
-		(card->cccr_flags & SDIO_SUPPORT_SDR50) &&
-		(card->host_props.f_max >= SD_CLOCK_100MHZ)) {
+		(card->cccr_flags & SDIO_SUPPORT_SDR50)) {
 		card->card_speed = SD_TIMING_SDR50;
+		card->switch_caps.uhs_max_dtr = UHS_SDR50_MAX_DTR;
 	} else if (card->host_props.host_caps.high_spd_support &&
-		(card->switch_caps.bus_speed & SDIO_SUPPORT_HS) &&
-		(card->host_props.f_max >= SD_CLOCK_50MHZ)) {
-		card->card_speed = SD_TIMING_SDR25;
+		(card->cccr_flags & SDIO_SUPPORT_HS)) {
+		card->card_speed = SD_TIMING_HIGH_SPEED;
+		card->switch_caps.hs_max_dtr = HS_MAX_DTR;
 	} else {
-		card->card_speed = SD_TIMING_SDR12;
+		card->card_speed = SD_TIMING_DEFAULT;
 	}
 }
 
@@ -474,34 +474,35 @@ static inline void sdio_select_bus_speed(struct sd_card *card)
 static int sdio_set_bus_speed(struct sd_card *card)
 {
 	int ret, timing, retries = CONFIG_SD_RETRY_COUNT;
+	uint32_t bus_clock;
 	uint8_t speed_reg, target_speed;
 
 	switch (card->card_speed) {
 	/* Set bus clock speed */
 	case SD_TIMING_SDR104:
-		card->switch_caps.uhs_max_dtr = SD_CLOCK_208MHZ;
+		bus_clock = MIN(card->host_props.f_max, card->switch_caps.uhs_max_dtr);
 		target_speed = SDIO_CCCR_SPEED_SDR104;
 		timing = SDHC_TIMING_SDR104;
 		break;
 	case SD_TIMING_DDR50:
-		card->switch_caps.uhs_max_dtr = SD_CLOCK_50MHZ;
+		bus_clock = MIN(card->host_props.f_max, card->switch_caps.uhs_max_dtr);
 		target_speed = SDIO_CCCR_SPEED_DDR50;
 		timing = SDHC_TIMING_DDR50;
 		break;
 	case SD_TIMING_SDR50:
-		card->switch_caps.uhs_max_dtr = SD_CLOCK_100MHZ;
+		bus_clock = MIN(card->host_props.f_max, card->switch_caps.uhs_max_dtr);
 		target_speed = SDIO_CCCR_SPEED_SDR50;
 		timing = SDHC_TIMING_SDR50;
 		break;
-	case SD_TIMING_SDR25:
-		card->switch_caps.uhs_max_dtr = SD_CLOCK_50MHZ;
+	case SD_TIMING_HIGH_SPEED:
+		bus_clock = MIN(card->host_props.f_max, card->switch_caps.hs_max_dtr);
 		target_speed = SDIO_CCCR_SPEED_SDR25;
-		timing = SDHC_TIMING_SDR25;
+		timing = SDHC_TIMING_HS;
 		break;
-	case SD_TIMING_SDR12:
-		card->switch_caps.uhs_max_dtr = SD_CLOCK_25MHZ;
+	case SD_TIMING_DEFAULT:
+		bus_clock = MIN(card->host_props.f_max, MHZ(25));
 		target_speed = SDIO_CCCR_SPEED_SDR12;
-		timing = SDHC_TIMING_SDR12;
+		timing = SDHC_TIMING_LEGACY;
 		break;
 	default:
 		/* No need to change bus speed */
@@ -530,7 +531,7 @@ static int sdio_set_bus_speed(struct sd_card *card)
 	} else {
 		/* Set card bus clock and timing */
 		card->bus_io.timing = timing;
-		card->bus_io.clock = card->switch_caps.uhs_max_dtr;
+		card->bus_io.clock = bus_clock;
 		LOG_DBG("Setting bus clock to: %d", card->bus_io.clock);
 		ret = sdhc_set_io(card->sdhc, &card->bus_io);
 		if (ret) {

--- a/tests/subsys/sd/sdmmc/src/main.c
+++ b/tests/subsys/sd/sdmmc/src/main.c
@@ -200,23 +200,41 @@ ZTEST(sd_stack, test_card_config)
 	zassert_equal(card.status, CARD_INITIALIZED, "Card status is not OK");
 	switch (card.card_speed) {
 	case SD_TIMING_SDR12:
-		TC_PRINT("Card timing: SDR12\n");
+		if (card.flags & SD_1800MV_FLAG) {
+			TC_PRINT("Card timing: SDR12\n");
+		} else {
+			/* Card uses non UHS mode timing */
+			TC_PRINT("Card timing: Legacy\n");
+		}
 		break;
 	case SD_TIMING_SDR25:
-		TC_PRINT("Card timing: SDR25\n");
+		if (card.flags & SD_1800MV_FLAG) {
+			TC_PRINT("Card timing: SDR25\n");
+		} else {
+			/* Card uses non UHS mode timing */
+			TC_PRINT("Card timing: High Speed\n");
+		}
 		break;
 	case SD_TIMING_SDR50:
 		TC_PRINT("Card timing: SDR50\n");
+		zassert_true(card.flags & SD_1800MV_FLAG,
+			     "Card must support UHS mode for this timing");
 		break;
 	case SD_TIMING_SDR104:
 		TC_PRINT("Card timing: SDR104\n");
+		zassert_true(card.flags & SD_1800MV_FLAG,
+			     "Card must support UHS mode for this timing");
 		break;
 	case SD_TIMING_DDR50:
 		TC_PRINT("Card timing: DDR50\n");
+		zassert_true(card.flags & SD_1800MV_FLAG,
+			     "Card must support UHS mode for this timing");
 		break;
 	default:
 		zassert_unreachable("Card timing is not known value");
 	}
+	zassert_not_equal(card.bus_io.clock, 0, "Bus should have nonzero clock");
+	TC_PRINT("Bus Frequency: %d Hz\n", card.bus_io.clock);
 	switch (card.type) {
 	case CARD_SDIO:
 		TC_PRINT("Card type: SDIO\n");


### PR DESCRIPTION
SDMMC framework frequency and timing selection logic has several
longstanding issues, including:
- requiring that SD hosts support the maximum frequency possible for a
given UHS mode in order to apply that timing
- selecting SDHC_TIMING_SDR25 for high speed mode, when SDHC_TIMING_HS
would be correct

Rework the frequency and timing selection logic within the SD framework
to resolve these issues.

Fixes #52589
Fixes #67943

This PR also includes a similar rework for the frequency selection logic in the SDIO framework, as the same issue exists there