### PR TITLE
CI: Fix coverage analysis for qemu and native_sim

### DIFF
--- a/scripts/ci/coverage/coverage_analysis.py
+++ b/scripts/ci/coverage/coverage_analysis.py
@@ -15,8 +15,8 @@ class Json_report:
 
     simulators = [
         'unit_testing',
-        'native',
-        'qemu',
+        'native_sim',
+        'qemu_x86',
         'mps2/an385'
     ]
 


### PR DESCRIPTION
With changes done in a1cdf276101656ebfb0f3274b5771005f7ca5c78 we were not getting coverage data from qemu and native_sim.

It fixes the issue putting the full simulator name in the simulator list.