### PR TITLE
debug: coredump: expose COREDUMP_STR strings as public

### DIFF
--- a/include/zephyr/debug/coredump.h
+++ b/include/zephyr/debug/coredump.h
@@ -11,6 +11,19 @@
 #include <stdint.h>
 #include <sys/types.h>
 
+/*
+ * Define COREDUMP_*_STR as public to allow coredump_backend_other to re-use
+ * these strings if necessary
+ */
+#define COREDUMP_BEGIN_STR      "BEGIN#"
+#define COREDUMP_END_STR        "END#"
+#define COREDUMP_ERROR_STR      "ERROR CANNOT DUMP#"
+
+/*
+ * Need to prefix coredump strings to make it easier to parse
+ * as log module adds its own prefixes.
+ */
+#define COREDUMP_PREFIX_STR     "#CD:"
 
 /**
  * @file

--- a/subsys/debug/coredump/coredump_internal.h
+++ b/subsys/debug/coredump/coredump_internal.h
@@ -16,16 +16,6 @@
  * public documentation.
  */
 
-#define COREDUMP_BEGIN_STR	"BEGIN#"
-#define COREDUMP_END_STR	"END#"
-#define COREDUMP_ERROR_STR	"ERROR CANNOT DUMP#"
-
-/*
- * Need to prefix coredump strings to make it easier to parse
- * as log module adds its own prefixes.
- */
-#define COREDUMP_PREFIX_STR	"#CD:"
-
 struct z_coredump_memory_region_t {
 	uintptr_t	start;
 	uintptr_t	end;


### PR DESCRIPTION
This allows a customized coredump_backend_other API to re-use the COREDUMP_*_STR without re-defining the same strings.