### PR TITLE
drivers: udc_dwc2: Fix debug logging bus fault

### DIFF
--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -1168,7 +1168,7 @@ static int udc_dwc2_ep_enable(const struct device *dev,
 
 	for (uint8_t i = 1U; i < priv->ineps; i++) {
 		LOG_DBG("DIEPTXF%u %08x DIEPCTL%u %08x",
-			i, sys_read32((mem_addr_t)base->dieptxf[i - 1U]), i, dxepctl);
+			i, sys_read32((mem_addr_t)&base->dieptxf[i - 1U]), i, dxepctl);
 	}
 
 	return 0;


### PR DESCRIPTION
Pass DIEPTXF address instead of value to sys_read32() to prevent bus fault when debug logging is enabled.