### PR TITLE
ARCMWDT: Turn off picolibc support

### DIFF
--- a/cmake/toolchain/arcmwdt/Kconfig.defconfig
+++ b/cmake/toolchain/arcmwdt/Kconfig.defconfig
@@ -1,0 +1,5 @@
+# Copyright (c) 2024 Synopsys
+# SPDX-License-Identifier: Apache-2.0
+
+config PICOLIBC_SUPPORTED
+	default n


### PR DESCRIPTION
MetaWare toolchain doesn't support building Zephyr with Picolibc module. This PR fixes biuld process by turning off picolibc support on compiler side.