### PR TITLE
driver: uart: native: fix stop_bits/databits mix

### DIFF
--- a/drivers/serial/uart_native_tty.c
+++ b/drivers/serial/uart_native_tty.c
@@ -90,7 +90,7 @@ static int native_tty_conv_to_bottom_cfg(struct native_tty_bottom_cfg *bottom_cf
 		return -ENOTSUP;
 	}
 
-	switch (cfg->data_bits) {
+	switch (cfg->stop_bits) {
 	case UART_CFG_STOP_BITS_1:
 		bottom_cfg->stop_bits = NTB_STOP_BITS_1;
 		break;

--- a/drivers/serial/uart_native_tty_bottom.c
+++ b/drivers/serial/uart_native_tty_bottom.c
@@ -144,7 +144,7 @@ static inline void native_tty_stop_bits_set(struct termios *ter,
  * @brief Set the number of data bits in the termios structure
  *
  * @param ter
- * @param stop_bits
+ * @param data_bits
  *
  */
 static inline void native_tty_data_bits_set(struct termios *ter,


### PR DESCRIPTION
Correct a trivial bug and doxygen documentation error in which data_bits was missused instead of stop_bits.

Salvage from #69101 two trivial fixes