### PR TITLE
drivers: i2c: bitbang: add get_config

### DIFF
--- a/drivers/i2c/i2c_bitbang.c
+++ b/drivers/i2c/i2c_bitbang.c
@@ -60,6 +60,19 @@ int i2c_bitbang_configure(struct i2c_bitbang *context, uint32_t dev_config)
 		return -ENOTSUP;
 	}
 
+	context->dev_config = dev_config;
+
+	return 0;
+}
+
+int i2c_bitbang_get_config(struct i2c_bitbang *context, uint32_t *config)
+{
+	if (context->dev_config == 0) {
+		return -EIO;
+	}
+
+	*config = context->dev_config;
+
 	return 0;
 }
 

--- a/drivers/i2c/i2c_bitbang.h
+++ b/drivers/i2c/i2c_bitbang.h
@@ -28,7 +28,8 @@ struct i2c_bitbang_io {
 struct i2c_bitbang {
 	const struct i2c_bitbang_io	*io;
 	void				*io_context;
-	uint32_t				delays[2];
+	uint32_t			delays[2];
+	uint32_t			dev_config;
 };
 
 /**
@@ -47,6 +48,12 @@ void i2c_bitbang_init(struct i2c_bitbang *bitbang,
  * in struct i2c_driver_api.
  */
 int i2c_bitbang_configure(struct i2c_bitbang *bitbang, uint32_t dev_config);
+
+/**
+ * Implementation of the functionality required by the 'get_config' function
+ * in struct i2c_driver_api.
+ */
+int i2c_bitbang_get_config(struct i2c_bitbang *context, uint32_t *config);
 
 /**
  * Implementation of the functionality required by the 'recover_bus'

--- a/drivers/i2c/i2c_gpio.c
+++ b/drivers/i2c/i2c_gpio.c
@@ -93,6 +93,23 @@ static int i2c_gpio_configure(const struct device *dev, uint32_t dev_config)
 	return rc;
 }
 
+static int i2c_gpio_get_config(const struct device *dev, uint32_t *config)
+{
+	struct i2c_gpio_context *context = dev->data;
+	int rc;
+
+	k_mutex_lock(&context->mutex, K_FOREVER);
+
+	rc = i2c_bitbang_get_config(&context->bitbang, config);
+	if (rc < 0) {
+		LOG_ERR("I2C controller not configured: %d", rc);
+	}
+
+	k_mutex_unlock(&context->mutex);
+
+	return rc;
+}
+
 static int i2c_gpio_transfer(const struct device *dev, struct i2c_msg *msgs,
 				uint8_t num_msgs, uint16_t slave_address)
 {
@@ -125,6 +142,7 @@ static int i2c_gpio_recover_bus(const struct device *dev)
 
 static const struct i2c_driver_api api = {
 	.configure = i2c_gpio_configure,
+	.get_config = i2c_gpio_get_config,
 	.transfer = i2c_gpio_transfer,
 	.recover_bus = i2c_gpio_recover_bus,
 };

--- a/drivers/i2c/i2c_litex.c
+++ b/drivers/i2c/i2c_litex.c
@@ -114,6 +114,13 @@ static int i2c_litex_configure(const struct device *dev, uint32_t dev_config)
 	return i2c_bitbang_configure(bitbang, dev_config);
 }
 
+static int i2c_litex_get_config(const struct device *dev, uint32_t *config)
+{
+	struct i2c_bitbang *bitbang = GET_I2C_BITBANG(dev);
+
+	return i2c_bitbang_get_config(bitbang, config);
+}
+
 static int i2c_litex_transfer(const struct device *dev,  struct i2c_msg *msgs,
 			      uint8_t num_msgs, uint16_t addr)
 {
@@ -122,9 +129,18 @@ static int i2c_litex_transfer(const struct device *dev,  struct i2c_msg *msgs,
 	return i2c_bitbang_transfer(bitbang, msgs, num_msgs, addr);
 }
 
+static int i2c_litex_recover_bus(const struct device *dev)
+{
+	struct i2c_bitbang *bitbang = GET_I2C_BITBANG(dev);
+
+	return i2c_bitbang_recover_bus(bitbang);
+}
+
 static const struct i2c_driver_api i2c_litex_driver_api = {
 	.configure = i2c_litex_configure,
+	.get_config = i2c_litex_get_config,
 	.transfer = i2c_litex_transfer,
+	.recover_bus = i2c_litex_recover_bus,
 };
 
 /* Device Instantiation */

--- a/drivers/i2c/i2c_sbcon.c
+++ b/drivers/i2c/i2c_sbcon.c
@@ -17,6 +17,11 @@
 #include <zephyr/device.h>
 #include <errno.h>
 #include <zephyr/drivers/i2c.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(i2c_sbcon, CONFIG_I2C_LOG_LEVEL);
+
+#include "i2c-priv.h"
 #include "i2c_bitbang.h"
 
 /* SBCon hardware registers layout */
@@ -35,6 +40,7 @@ struct sbcon {
 /* Driver config */
 struct i2c_sbcon_config {
 	struct sbcon *sbcon;		/* Address of hardware registers */
+	uint32_t bitrate;		/* I2C bus speed in Hz */
 };
 
 /* Driver instance data */
@@ -118,10 +124,17 @@ static int i2c_sbcon_init(const struct device *dev)
 {
 	struct i2c_sbcon_context *context = dev->data;
 	const struct i2c_sbcon_config *config = dev->config;
+	int ret;
 
 	i2c_bitbang_init(&context->bitbang, &io_fns, config->sbcon);
 
-	return 0;
+	ret = i2c_bitbang_configure(&context->bitbang,
+				    I2C_MODE_CONTROLLER | i2c_map_dt_bitrate(config->bitrate));
+	if (ret != 0) {
+		LOG_ERR("failed to configure I2C bitbang: %d", ret);
+	}
+
+	return ret;
 }
 
 #define	DEFINE_I2C_SBCON(_num)						\
@@ -129,7 +142,8 @@ static int i2c_sbcon_init(const struct device *dev)
 static struct i2c_sbcon_context i2c_sbcon_dev_data_##_num;		\
 									\
 static const struct i2c_sbcon_config i2c_sbcon_dev_cfg_##_num = {	\
-	.sbcon		= (void *)DT_INST_REG_ADDR(_num), \
+	.sbcon		= (void *)DT_INST_REG_ADDR(_num),		\
+	.bitrate	= DT_INST_PROP(_num, clock_frequency),		\
 };									\
 									\
 I2C_DEVICE_DT_INST_DEFINE(_num,						\

--- a/drivers/i2c/i2c_sbcon.c
+++ b/drivers/i2c/i2c_sbcon.c
@@ -84,6 +84,13 @@ static int i2c_sbcon_configure(const struct device *dev, uint32_t dev_config)
 	return i2c_bitbang_configure(&context->bitbang, dev_config);
 }
 
+static int i2c_sbcon_get_config(const struct device *dev, uint32_t *config)
+{
+	struct i2c_sbcon_context *context = dev->data;
+
+	return i2c_bitbang_get_config(&context->bitbang, config);
+}
+
 static int i2c_sbcon_transfer(const struct device *dev, struct i2c_msg *msgs,
 				uint8_t num_msgs, uint16_t slave_address)
 {
@@ -93,9 +100,18 @@ static int i2c_sbcon_transfer(const struct device *dev, struct i2c_msg *msgs,
 							slave_address);
 }
 
+static int i2c_sbcon_recover_bus(const struct device *dev)
+{
+	struct i2c_sbcon_context *context = dev->data;
+
+	return i2c_bitbang_recover_bus(&context->bitbang);
+}
+
 static const struct i2c_driver_api api = {
 	.configure = i2c_sbcon_configure,
+	.get_config = i2c_sbcon_get_config,
 	.transfer = i2c_sbcon_transfer,
+	.recover_bus = i2c_sbcon_recover_bus,
 };
 
 static int i2c_sbcon_init(const struct device *dev)

--- a/dts/bindings/i2c/litex,i2c.yaml
+++ b/dts/bindings/i2c/litex,i2c.yaml
@@ -13,3 +13,6 @@ include: i2c-controller.yaml
 properties:
   reg:
     required: true
+
+  clock-frequency:
+    required: true

--- a/dts/riscv/riscv32-litex-vexriscv.dtsi
+++ b/dts/riscv/riscv32-litex-vexriscv.dtsi
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+ #include <zephyr/dt-bindings/i2c/i2c.h>
+
 / {
 	#address-cells = <1>;
 	#size-cells = <1>;
@@ -161,6 +163,7 @@
 			compatible = "litex,i2c";
 			reg = <0xe0005000 0x4 0xe0005004 0x4>;
 			reg-names = "write", "read";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";


### PR DESCRIPTION
- implement get_config of the i2c api for the bitbang lib.
- add get_config of the i2c api to the i2c gpio driver.
- add get_config and recover_bus of the i2c api to the i2c sbcom driver.
- use the frequency of the device tree for the litex and sbcon i2c driver.
- add get_config and recover_bus of the i2c api to the litex i2c driver.