### PR TITLE
scripts: west: commands: build: add --shield argument for specifying shields

### DIFF
--- a/scripts/list_shields.py
+++ b/scripts/list_shields.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2024 Vestas Wind Systems A/S
+# Copyright (c) 2020 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+#
+# This is shared code between the build system's 'shields' target
+# and the 'west shields' extension command. If you change it, make
+# sure to test both ways it can be used.
+#
+# (It's done this way to keep west optional, making it possible to run
+# 'ninja shields' in a build directory without west installed.)
+#
+
+@dataclass(frozen=True)
+class Shield:
+    name: str
+    dir: Path
+
+def shield_key(shield):
+    return shield.name
+
+def find_shields(args):
+    ret = []
+
+    for root in args.board_roots:
+        for shields in find_shields_in(root):
+            ret.append(shields)
+
+    return sorted(ret, key=shield_key)
+
+def find_shields_in(root):
+    shields = root / 'boards' / 'shields'
+    ret = []
+
+    for maybe_shield in (shields).iterdir():
+        if not maybe_shield.is_dir():
+            continue
+        for maybe_kconfig in maybe_shield.iterdir():
+            if maybe_kconfig.name == 'Kconfig.shield':
+                for maybe_overlay in maybe_shield.iterdir():
+                    file_name = maybe_overlay.name
+                    if file_name.endswith('.overlay'):
+                        shield_name = file_name[:-len('.overlay')]
+                        ret.append(Shield(shield_name, maybe_shield))
+
+    return sorted(ret, key=shield_key)
+
+def parse_args():
+    parser = argparse.ArgumentParser(allow_abbrev=False)
+    add_args(parser)
+    return parser.parse_args()
+
+def add_args(parser):
+    # Remember to update west-completion.bash if you add or remove
+    # flags
+    parser.add_argument("--board-root", dest='board_roots', default=[],
+                        type=Path, action='append',
+                        help='add a board root, may be given more than once')
+
+def dump_shields(shields):
+    for shield in shields:
+        print(f'  {shield.name}')
+
+if __name__ == '__main__':
+    dump_shields(find_shields(parse_args()))

--- a/scripts/west-commands.yml
+++ b/scripts/west-commands.yml
@@ -10,6 +10,11 @@ west-commands:
       - name: boards
         class: Boards
         help: display information about supported boards
+  - file: scripts/west_commands/shields.py
+    commands:
+      - name: shields
+        class: Shields
+        help: display list of supported shields
   - file: scripts/west_commands/build.py
     commands:
       - name: build

--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -24,7 +24,7 @@ SYSBUILD_PROJ_DIR = pathlib.Path(__file__).resolve().parent.parent.parent \
 
 BUILD_USAGE = '''\
 west build [-h] [-b BOARD[@REV]]] [-d BUILD_DIR]
-           [-S SNIPPET]
+           [-S SNIPPET] [--shield SHIELD]
            [-t TARGET] [-p {auto, always, never}] [-c] [--cmake-only]
            [-n] [-o BUILD_OPT] [-f]
            [--sysbuild | --no-sysbuild] [--domain DOMAIN]
@@ -143,6 +143,13 @@ class Build(Forceable):
                            Do not use this option with manually specified
                            -DSNIPPET... cmake arguments: the results are
                            undefined''')
+        group.add_argument('--shield', dest='shields', metavar='SHIELD',
+                           action='append', default=[],
+                           help='''add the argument to SHIELD; may be given
+                           multiple times. Forces CMake to run again if given.
+                           Do not use this option with manually specified
+                           -DSHIELD... cmake arguments: the results are
+                           undefined''')
 
         group = parser.add_mutually_exclusive_group()
         group.add_argument('--sysbuild', action='store_true',
@@ -215,7 +222,8 @@ class Build(Forceable):
             else:
                 self._update_cache()
                 if (self.args.cmake or self.args.cmake_opts or
-                        self.args.cmake_only or self.args.snippets):
+                        self.args.cmake_only or self.args.snippets or
+                        self.args.shields):
                     self.run_cmake = True
         else:
             self.run_cmake = True
@@ -553,6 +561,8 @@ class Build(Forceable):
             cmake_opts.extend(self.args.cmake_opts)
         if self.args.snippets:
             cmake_opts.append(f'-DSNIPPET={";".join(self.args.snippets)}')
+        if self.args.shields:
+            cmake_opts.append(f'-DSHIELD={";".join(self.args.shields)}')
 
         user_args = config_get('cmake-args', None)
         if user_args:

--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -24,6 +24,7 @@ SYSBUILD_PROJ_DIR = pathlib.Path(__file__).resolve().parent.parent.parent \
 
 BUILD_USAGE = '''\
 west build [-h] [-b BOARD[@REV]]] [-d BUILD_DIR]
+           [-S SNIPPET]
            [-t TARGET] [-p {auto, always, never}] [-c] [--cmake-only]
            [-n] [-o BUILD_OPT] [-f]
            [--sysbuild | --no-sysbuild] [--domain DOMAIN]
@@ -135,7 +136,7 @@ class Build(Forceable):
         group.add_argument('-n', '--just-print', '--dry-run', '--recon',
                             dest='dry_run', action='store_true',
                             help="just print build commands; don't run them")
-        group.add_argument('-S', '--snippet', dest='snippets',
+        group.add_argument('-S', '--snippet', dest='snippets', metavar='SNIPPET',
                            action='append', default=[],
                            help='''add the argument to SNIPPET; may be given
                            multiple times. Forces CMake to run again if given.

--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -276,7 +276,7 @@ class Build(Forceable):
             if remainder:
                 self.args.cmake_opts = remainder
         except IndexError:
-            return
+            pass
 
     def _parse_test_item(self, test_item):
         found_test_metadata = False

--- a/scripts/west_commands/completion/west-completion.bash
+++ b/scripts/west_commands/completion/west-completion.bash
@@ -702,6 +702,7 @@ __comp_west_build()
 
 	local special_opts="
 		--board -b
+		--snippet -S
 		--pristine -p
 	"
 

--- a/scripts/west_commands/completion/west-completion.bash
+++ b/scripts/west_commands/completion/west-completion.bash
@@ -401,6 +401,11 @@ __set_comp_west_boards()
 	__set_comp ${boards[@]}
 }
 
+__set_comp_west_shields()
+{
+	__set_comp "$(__west_x shields "$@")"
+}
+
 __comp_west_west()
 {
 	case "$prev" in
@@ -734,6 +739,7 @@ __comp_west_build()
 	local special_opts="
 		--board -b
 		--snippet -S
+		--shield
 		--pristine -p
 	"
 
@@ -752,6 +758,10 @@ __comp_west_build()
 	case "$prev" in
 		--board|-b)
 			__set_comp_west_boards
+			return
+			;;
+		--shield)
+			__set_comp_west_shields
 			return
 			;;
 		--pristine|-p)

--- a/scripts/west_commands/completion/west-completion.bash
+++ b/scripts/west_commands/completion/west-completion.bash
@@ -689,6 +689,37 @@ __comp_west_boards()
 	esac
 }
 
+__comp_west_shields()
+{
+	local other_opts="
+		--format -f
+		--name -n
+	"
+
+	local dir_opts="
+		--board-root
+	"
+
+	all_opts="$dir_opts $other_opts"
+
+	case "$prev" in
+		$(__west_to_extglob "$other_opts") )
+			# We don't know how to autocomplete these.
+			return
+			;;
+		$(__west_to_extglob "$dir_opts") )
+			__set_comp_dirs
+			return
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			__set_comp $all_opts
+			;;
+	esac
+}
+
 __comp_west_build()
 {
 	local bool_opts="
@@ -1124,6 +1155,7 @@ __comp_west()
 	local zephyr_ext_cmds=(
 		completion
 		boards
+		shields
 		build
 		sign
 		flash

--- a/scripts/west_commands/shields.py
+++ b/scripts/west_commands/shields.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2024 Vestas Wind Systems A/S
+# Copyright (c) 2019 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import os
+from pathlib import Path
+import re
+import sys
+import textwrap
+
+from west import log
+from west.commands import WestCommand
+
+from zephyr_ext_common import ZEPHYR_BASE
+
+sys.path.append(os.fspath(Path(__file__).parent.parent))
+import list_shields
+import zephyr_module
+
+class Shields(WestCommand):
+
+    def __init__(self):
+        super().__init__(
+            'shields',
+            # Keep this in sync with the string in west-commands.yml.
+            'display list of supported shield',
+            'Display supported shields',
+            accepts_unknown_args=False)
+
+    def do_add_parser(self, parser_adder):
+        default_fmt = '{name}'
+        parser = parser_adder.add_parser(
+            self.name,
+            help=self.help,
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            description=self.description,
+            epilog=textwrap.dedent(f'''\
+            FORMAT STRINGS
+            --------------
+
+            Shields are listed using a Python 3 format string. Arguments
+            to the format string are accessed by name.
+
+            The default format string is:
+
+            "{default_fmt}"
+
+            The following arguments are available:
+
+            - name: shield name
+            - dir: directory that contains the shield definition
+            '''))
+
+        # Remember to update west-completion.bash if you add or remove
+        # flags
+        parser.add_argument('-f', '--format', default=default_fmt,
+                            help='''Format string to use to list each shield;
+                                    see FORMAT STRINGS below.''')
+        parser.add_argument('-n', '--name', dest='name_re',
+                            help='''a regular expression; only shields whose
+                            names match NAME_RE will be listed''')
+        list_shields.add_args(parser)
+
+        return parser
+
+    def do_run(self, args, _):
+        if args.name_re is not None:
+            name_re = re.compile(args.name_re)
+        else:
+            name_re = None
+
+        modules_board_roots = [ZEPHYR_BASE]
+
+        for module in zephyr_module.parse_modules(ZEPHYR_BASE, self.manifest):
+            board_root = module.meta.get('build', {}).get('settings', {}).get('board_root')
+            if board_root is not None:
+                modules_board_roots.append(Path(module.project) / board_root)
+
+        args.board_roots += modules_board_roots
+
+        for shield in list_shields.find_shields(args):
+            if name_re is not None and not name_re.search(shield.name):
+                continue
+            log.inf(args.format.format(name=shield.name, dir=shield.dir))


### PR DESCRIPTION
This patch series adds support for doing `west build -b ... --shield foo` instead of having to do `west build -b ... -- -DSHIELD=foo`. It contains the following additions:
- scripts: west: build: add snippet argument to usage output (missing, identified while adding support for --shield).
- scripts: west: completion: bash: add snippet arguments to build command (missing, identified while adding support for --shield).
- scripts: list_shields: add script for listing the supported shields.
- scripts: west: commands: shields: add cmd for listing supported shields.
- scripts: west: commands: completion: bash: add "west shields" completion.
- scripts: west: commands: build: add arguments for specifying shields.
- scripts: west: commands: completion: bash: support shield arguments.

If this is accepted, a couple of follow-up PRs could:
- Refactor `cmake/modules/shields.cmake` to use `scripts/list_shields.py`.
- Change `doc/_extensions/zephyr/application.py` to recommend using `--shield|-i` in generated west command documentation.