### PR TITLE
samples: subsys: ipc: ipc_service: keep using remote harness

### DIFF
--- a/samples/subsys/ipc/ipc_service/multi_endpoint/sample.yaml
+++ b/samples/subsys/ipc/ipc_service/multi_endpoint/sample.yaml
@@ -14,6 +14,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
     tags: ipc
     sysbuild: true
+    harness: remote
     extra_args:
       DTC_OVERLAY_FILE=boards/nrf5340dk_nrf5340_cpuapp_icbmsg.overlay
       remote_DTC_OVERLAY_FILE=boards/nrf5340dk_nrf5340_cpunet_icbmsg.overlay


### PR DESCRIPTION
Temporary solution as there is no such harness as remote. However console regex are not defined yet.