### PR TITLE
boards: thingy53: define ADC channel for battery

### DIFF
--- a/boards/nordic/thingy53/thingy53_nrf5340_common.dtsi
+++ b/boards/nordic/thingy53/thingy53_nrf5340_common.dtsi
@@ -88,7 +88,7 @@
 		regulator-boot-on;
 	};
 
-	vbatt {
+	vbatt: vbatt {
 		compatible = "voltage-divider";
 		io-channels = <&adc 2>;
 		output-ohms = <180000>;
@@ -155,7 +155,19 @@
 };
 
 &adc {
+	#address-cells = <1>;
+	#size-cells = <0>;
 	status = "okay";
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,vref-mv = <600>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+		zephyr,input-positive = <NRF_SAADC_AIN2>;
+	};
 };
 
 &gpiote {


### PR DESCRIPTION
Define the ADC channel for battery monitoring so that `voltage-divider` driver works.