### PR TITLE
sensor: convert ADC `depends on` to `select`

### DIFF
--- a/drivers/input/Kconfig.analog_axis
+++ b/drivers/input/Kconfig.analog_axis
@@ -5,8 +5,8 @@ config INPUT_ANALOG_AXIS
 	bool "ADC based analog axis input driver"
 	default y
 	depends on DT_HAS_ANALOG_AXIS_ENABLED
-	depends on ADC
 	depends on MULTITHREADING
+	select ADC
 	help
 	  ADC based analog axis input driver
 

--- a/drivers/sensor/current_amp/Kconfig
+++ b/drivers/sensor/current_amp/Kconfig
@@ -8,6 +8,6 @@ config CURRENT_AMP
 	bool "Current sense amplifier driver"
 	default y
 	depends on DT_HAS_CURRENT_SENSE_AMPLIFIER_ENABLED
-	depends on ADC
+	select ADC
 	help
 	  Enable current sense amplifier driver.

--- a/drivers/sensor/rpi_pico_temp/Kconfig
+++ b/drivers/sensor/rpi_pico_temp/Kconfig
@@ -7,7 +7,7 @@ config RPI_PICO_TEMP
 	bool "Raspberry Pi Pico CPU Temperature Sensor"
 	default y
 	depends on DT_HAS_RASPBERRYPI_PICO_TEMP_ENABLED
-	depends on ADC
+	select ADC
 
 	help
 	  Enable driver for Raspberry Pi Pico CPU temperature sensor.

--- a/drivers/sensor/seeed/grove/Kconfig
+++ b/drivers/sensor/seeed/grove/Kconfig
@@ -16,7 +16,8 @@ config GROVE_LIGHT_SENSOR
 	bool "The Seeed Grove Light Sensor"
 	default y
 	depends on DT_HAS_SEEED_GROVE_LIGHT_ENABLED
-	depends on ADC && !MINIMAL_LIBC
+	depends on !MINIMAL_LIBC
+	select ADC
 	help
 	  Setting this value will enable driver support for the Grove Light
 	  Sensor.
@@ -25,7 +26,8 @@ config GROVE_TEMPERATURE_SENSOR
 	bool "The Seeed Grove Temperature Sensor"
 	default y
 	depends on DT_HAS_SEEED_GROVE_TEMPERATURE_ENABLED
-	depends on ADC && !MINIMAL_LIBC
+	depends on !MINIMAL_LIBC
+	select ADC
 	help
 	  Setting this value will enable driver support for the Grove
 	  Temperature Sensor.

--- a/drivers/sensor/st/stm32_vbat/Kconfig
+++ b/drivers/sensor/st/stm32_vbat/Kconfig
@@ -7,6 +7,7 @@ config STM32_VBAT
 	bool "STM32 Vbat Sensor"
 	default y
 	depends on DT_HAS_ST_STM32_VBAT_ENABLED
-	depends on ADC && (SOC_FAMILY_STM32 && !SOC_SERIES_STM32F1X)
+	depends on SOC_FAMILY_STM32 && !SOC_SERIES_STM32F1X
+	select ADC
 	help
 	  Enable driver for STM32 Vbat sensor and then also ADC

--- a/drivers/sensor/st/stm32_vref/Kconfig
+++ b/drivers/sensor/st/stm32_vref/Kconfig
@@ -7,6 +7,7 @@ config STM32_VREF
 	bool "STM32 VREF Sensor"
 	default y
 	depends on DT_HAS_ST_STM32_VREF_ENABLED
-	depends on ADC && (SOC_FAMILY_STM32 && !SOC_SERIES_STM32F1X)
+	depends on SOC_FAMILY_STM32 && !SOC_SERIES_STM32F1X
+	select ADC
 	help
 	  Enable driver for STM32 Vref sensor.

--- a/drivers/sensor/voltage_divider/Kconfig
+++ b/drivers/sensor/voltage_divider/Kconfig
@@ -8,6 +8,6 @@ config VOLTAGE_DIVIDER
 	bool "Voltage sensor driver"
 	default y
 	depends on DT_HAS_VOLTAGE_DIVIDER_ENABLED
-	depends on ADC
+	select ADC
 	help
 	  Enable voltage sensor driver.


### PR DESCRIPTION
When a sensor that depends on an ADC is enabled in devicetree, enable the ADC subsystem. ADC is roughly equivalent to a bus for these sensors (the mechanism through which data is transferred), which had the same conversion applied in #48707.

The same benefits apply here, namely removing the need for the following pattern in board `.kconfig` files:
```
configdefault ADC
    default y if SENSOR
```