### PR TITLE
samples: basic: blinky_pwm: add testing base on console output

### DIFF
--- a/samples/basic/blinky_pwm/sample.yaml
+++ b/samples/basic/blinky_pwm/sample.yaml
@@ -7,4 +7,13 @@ tests:
       - drivers
       - pwm
     depends_on: pwm
-    harness: led
+    harness: console
+    harness_config:
+      type: multi_line
+      ordered: true
+      regex:
+        - "PWM-based blinky"
+        - "Calibrating for channel [0-9]+"
+        - "Done calibrating; maximum/minimum periods [0-9]+/[0-9]+ nsec"
+        - "Using period [0-9]+"
+        - "Using period [0-9]+"

--- a/samples/basic/blinky_pwm/src/main.c
+++ b/samples/basic/blinky_pwm/src/main.c
@@ -63,6 +63,7 @@ int main(void)
 			printk("Error %d: failed to set pulse width\n", ret);
 			return 0;
 		}
+		printk("Using period %d\n", period);
 
 		period = dir ? (period * 2U) : (period / 2U);
 		if (period > max_period) {


### PR DESCRIPTION
Extend automated testing on HW by veryfing console output.