### PR TITLE
Bluetooth: Audio: Shell: Fix build errors for USB=n

### DIFF
--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -3778,7 +3778,7 @@ static void start_sine_stream_cb(struct shell_stream *sh_stream, void *user_data
 		if (err != 0) {
 			shell_error(sh, "Failed to init LC3 %d for stream %p", err, bap_stream);
 
-			return -ENOEXEC;
+			return;
 		}
 
 		sh_stream->tx.active = true;
@@ -3791,7 +3791,6 @@ static void start_sine_stream_cb(struct shell_stream *sh_stream, void *user_data
 static int cmd_start_sine(const struct shell *sh, size_t argc, char *argv[])
 {
 	bool start_all = false;
-	int err;
 
 	if (argc > 1) {
 		if (strcmp(argv[1], "all") == 0) {
@@ -3804,11 +3803,11 @@ static int cmd_start_sine(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	if (start_all) {
-		bap_foreach_stream(start_sine_stream_cb, sh);
+		bap_foreach_stream(start_sine_stream_cb, (void *)sh);
 	} else {
 		struct shell_stream *sh_stream = shell_stream_from_bap_stream(default_stream);
 
-		start_sine_stream_cb(sh_stream, sh);
+		start_sine_stream_cb(sh_stream, (void *)sh);
 	}
 
 	return 0;
@@ -3817,8 +3816,7 @@ static int cmd_start_sine(const struct shell *sh, size_t argc, char *argv[])
 static void stop_sine_stream_cb(struct shell_stream *sh_stream, void *user_data)
 {
 	if (sh_stream->is_tx) {
-		struct bt_bap_stream *bap_stream =
-			bap_stream_from_shell_stream(&unicast_streams[i]);
+		struct bt_bap_stream *bap_stream = bap_stream_from_shell_stream(sh_stream);
 		const struct shell *sh = user_data;
 
 		shell_print(sh, "Stopped transmitting on stream %p", bap_stream);
@@ -3842,11 +3840,11 @@ static int cmd_stop_sine(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	if (stop_all) {
-		bap_foreach_stream(stop_sine_stream_cb, sh);
+		bap_foreach_stream(stop_sine_stream_cb, (void *)sh);
 	} else {
 		struct shell_stream *sh_stream = shell_stream_from_bap_stream(default_stream);
 
-		stop_sine_stream_cb(sh_stream, sh)
+		stop_sine_stream_cb(sh_stream, (void *)sh);
 	}
 
 	return 0;

--- a/tests/bluetooth/shell/boards/native_posix.conf
+++ b/tests/bluetooth/shell/boards/native_posix.conf
@@ -11,6 +11,3 @@ CONFIG_SYS_CLOCK_TICKS_PER_SEC=500
 # For LC3 the following configs are needed
 CONFIG_FPU=y
 CONFIG_LIBLC3=y
-# The LC3 codec uses a large amount of stack. This app runs the codec in the work-queue, hence
-# inctease stack size for that thread.
-CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096

--- a/tests/bluetooth/shell/boards/native_sim.conf
+++ b/tests/bluetooth/shell/boards/native_sim.conf
@@ -11,6 +11,3 @@ CONFIG_SYS_CLOCK_TICKS_PER_SEC=500
 # For LC3 the following configs are needed
 CONFIG_FPU=y
 CONFIG_LIBLC3=y
-# The LC3 codec uses a large amount of stack. This app runs the codec in the work-queue, hence
-# inctease stack size for that thread.
-CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096

--- a/tests/bluetooth/shell/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
+++ b/tests/bluetooth/shell/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
@@ -1,10 +1,13 @@
 # For LC3 the following configs are needed
 CONFIG_FPU=y
 CONFIG_LIBLC3=y
+
+# For USB audio the following configs are needed
 CONFIG_RING_BUFFER=y
 CONFIG_USB_DEVICE_STACK=y
 CONFIG_USB_DEVICE_AUDIO=y
 CONFIG_USB_DEVICE_PRODUCT="Zephyr Shell USB"
+
 # The LC3 codec uses a large amount of stack. This app runs the codec in the work-queue, hence
 # inctease stack size for that thread.
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=5120

--- a/tests/bluetooth/shell/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
+++ b/tests/bluetooth/shell/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
@@ -8,7 +8,5 @@ CONFIG_USB_DEVICE_STACK=y
 CONFIG_USB_DEVICE_AUDIO=y
 CONFIG_USB_DEVICE_PRODUCT="Zephyr Shell USB"
 
-# The LC3 codec uses a large amount of stack. This app runs the codec in the work-queue, hence
-# inctease stack size for that thread.
-CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=5120
+# Enable encryption in the host
 CONFIG_BT_TINYCRYPT_ECC=y

--- a/tests/bluetooth/shell/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/tests/bluetooth/shell/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -1,6 +1,14 @@
 # For LC3 the following configs are needed
 CONFIG_FPU=y
 CONFIG_LIBLC3=y
+
+# For USB audio the following configs are needed
+CONFIG_RING_BUFFER=y
+CONFIG_USB_DEVICE_STACK=y
+CONFIG_USB_DEVICE_AUDIO=y
+CONFIG_USB_DEVICE_PRODUCT="Zephyr Shell USB"
+
 # The LC3 codec uses a large amount of stack. This app runs the codec in the work-queue, hence
 # inctease stack size for that thread.
-CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=5120
+CONFIG_BT_TINYCRYPT_ECC=y

--- a/tests/bluetooth/shell/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/tests/bluetooth/shell/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -8,7 +8,5 @@ CONFIG_USB_DEVICE_STACK=y
 CONFIG_USB_DEVICE_AUDIO=y
 CONFIG_USB_DEVICE_PRODUCT="Zephyr Shell USB"
 
-# The LC3 codec uses a large amount of stack. This app runs the codec in the work-queue, hence
-# inctease stack size for that thread.
-CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=5120
+# Enable encryption in the host
 CONFIG_BT_TINYCRYPT_ECC=y

--- a/tests/bluetooth/shell/testcase.yaml
+++ b/tests/bluetooth/shell/testcase.yaml
@@ -353,14 +353,24 @@ tests:
   bluetooth.audio_shell.no_lc3:
     extra_args: CONF_FILE="audio.conf"
     build_only: true
-    platform_allow: native_posix
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340_audio_dk/nrf5340/cpuapp
+    integration_platforms:
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340_audio_dk/nrf5340/cpuapp
     extra_configs:
       - CONFIG_FPU=n
       - CONFIG_LIBLC3=n
   bluetooth.audio_shell.no_usb:
     extra_args: CONF_FILE="audio.conf"
     build_only: true
-    platform_allow: native_posix
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340_audio_dk/nrf5340/cpuapp
+    integration_platforms:
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340_audio_dk/nrf5340/cpuapp
     extra_configs:
       - CONFIG_RING_BUFFER=n
       - CONFIG_USB_DEVICE_STACK=n


### PR DESCRIPTION
When CONFIG_USB_DEVICE_STACK=n then the sine wave
generator was enabled, which caused build errors.

This commit fixes those errors and also adds the
nRF5340 as a build target for the USB tests.