### PR TITLE
drivers: sensor: fix PM Implementation for LM75 temperature sensor

### DIFF
--- a/drivers/sensor/lm75/lm75.c
+++ b/drivers/sensor/lm75/lm75.c
@@ -64,12 +64,10 @@ static int lm75_sample_fetch(const struct device *dev,
 {
 	struct lm75_data *data = dev->data;
 	const struct lm75_config *cfg = dev->config;
-	enum pm_device_state pm_state;
 	int ret;
 
-	(void)pm_device_state_get(dev, &pm_state);
-	if (pm_state != PM_DEVICE_STATE_ACTIVE) {
-		ret = -EIO;
+	ret = pm_device_runtime_get(dev);
+	if (ret < 0) {
 		return ret;
 	}
 
@@ -83,6 +81,7 @@ static int lm75_sample_fetch(const struct device *dev,
 		break;
 	}
 
+	pm_device_runtime_put(dev);
 	return ret;
 }
 


### PR DESCRIPTION
the PM get and put operations were missing, this lead to the driver returning -EIO when CONFIG_PM_DEVICE_RUNTIME was enabled. Fix was tested and works on a nRF52840-DK.
@MaureenHelm @alexanderwachter @gmarull

Note: Interestingly, with older Zephyr versions this seems to be not an issue, only in the recent versions the missing operations lead to the described bug. I dont know why though.