### PR TITLE
shell: add shell backend for audio DSP using shared memory window

### DIFF
--- a/include/zephyr/shell/shell_adsp_memory_window.h
+++ b/include/zephyr/shell/shell_adsp_memory_window.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SHELL_ADSP_MEMORY_WINDOW_H__
+#define SHELL_ADSP_MEMORY_WINDOW_H__
+
+#include <zephyr/kernel.h>
+#include <zephyr/shell/shell.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern const struct shell_transport_api shell_adsp_memory_window_transport_api;
+
+struct sys_winstream;
+
+/** Memwindow based shell transport. */
+struct shell_adsp_memory_window {
+	/** Handler function registered by shell. */
+	shell_transport_handler_t shell_handler;
+
+	struct k_timer timer;
+
+	/** Context registered by shell. */
+	void *shell_context;
+
+	/** Receive winstream object */
+	struct sys_winstream *ws_rx;
+
+	/** Transmit winstream object */
+	struct sys_winstream *ws_tx;
+
+	/** Last read sequence number */
+	uint32_t read_seqno;
+};
+
+#define SHELL_ADSP_MEMORY_WINDOW_DEFINE(_name)				\
+	static struct shell_adsp_memory_window _name##_shell_adsp_memory_window;\
+	struct shell_transport _name = {					\
+		.api = &shell_adsp_memory_window_transport_api,		\
+		.ctx = (struct shell_memwindow *)&_name##_shell_adsp_memory_window,	\
+	}
+
+/**
+ * @brief This function provides pointer to shell ADSP memory window backend instance.
+ *
+ * Function returns pointer to the shell ADSP memory window instance. This instance can be
+ * next used with shell_execute_cmd function in order to test commands behavior.
+ *
+ * @returns Pointer to the shell instance.
+ */
+const struct shell *shell_backend_adsp_memory_window_get_ptr(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SHELL_ADSP_MEMORY_WINDOW_H__ */

--- a/soc/intel/intel_adsp/common/include/adsp_debug_window.h
+++ b/soc/intel/intel_adsp/common/include/adsp_debug_window.h
@@ -43,6 +43,7 @@
 
 /* debug window slots usage */
 #define ADSP_DW_SLOT_NUM_TRACE		1
+#define ADSP_DW_SLOT_NUM_SHELL		0
 
 /* debug log slot types */
 #define ADSP_DW_SLOT_UNUSED		0x00000000
@@ -51,6 +52,7 @@
 #define ADSP_DW_SLOT_GDB_STUB		0x42444700
 #define ADSP_DW_SLOT_TELEMETRY		0x4c455400
 #define ADSP_DW_SLOT_TRACE		0x54524143
+#define ADSP_DW_SLOT_SHELL		0x73686c6c
 #define ADSP_DW_SLOT_BROKEN		0x44414544
 
  /* for debug and critical types */

--- a/soc/intel/intel_adsp/tools/cavstool.py
+++ b/soc/intel/intel_adsp/tools/cavstool.py
@@ -11,6 +11,7 @@ import subprocess
 import ctypes
 import mmap
 import argparse
+import pty
 
 start_output = True
 
@@ -25,7 +26,7 @@ HUGEPAGE_FILE = "/dev/hugepages/cavs-fw-dma.tmp."
 #
 # Window 0 is the FW_STATUS area, and 4k after that the IPC "outbox"
 # Window 1 is the IPC "inbox" (host-writable memory, just 384 bytes currently)
-# Window 2 is debug, divided into multiple slots, unused by this script
+# Window 2 is used for debug slots (Zephyr shell is one user)
 # Window 3 is winstream-formatted log output
 
 WINDOW_BASE = 0x80000
@@ -33,6 +34,11 @@ WINDOW_STRIDE = 0x20000
 
 WINDOW_BASE_ACE = 0x180000
 WINDOW_STRIDE_ACE = 0x8000
+
+DEBUG_SLOT_SIZE = 4096
+DEBUG_SLOT_SHELL = 0
+SHELL_RX_SIZE = 256
+SHELL_MAX_VALID_SLOT_SIZE = 16777216
 
 # pylint: disable=duplicate-code
 
@@ -648,24 +654,29 @@ def winstream_offset():
 # This SHOULD be just "mem[start:start+length]", but slicing an mmap
 # array seems to be unreliable on one of my machines (python 3.6.9 on
 # Ubuntu 18.04).  Read out bytes individually.
-def win_read(start, length):
+def win_read(base, start, length):
     try:
-        return b''.join(bar4_mmap[winstream_offset() + x].to_bytes(1, 'little')
+        return b''.join(bar4_mmap[base + x].to_bytes(1, 'little')
                         for x in range(start, start + length))
     except IndexError as ie:
         # A FW in a bad state may cause winstream garbage
-        log.error("IndexError in bar4_mmap[%d + %d]", winstream_offset(), start)
+        log.error("IndexError in bar4_mmap[%d + %d]", base, start)
         log.error("bar4_mmap.size()=%d", bar4_mmap.size())
         raise ie
 
-def win_hdr():
-    return struct.unpack("<IIII", win_read(0, 16))
+def win_hdr(base):
+    return struct.unpack("<IIII", win_read(base, 0, 16))
 
 # Python implementation of the same algorithm in sys_winstream_read(),
 # see there for details.
-def winstream_read(last_seq):
+def winstream_read(base, last_seq):
     while True:
-        (wlen, start, end, seq) = win_hdr()
+        (wlen, start, end, seq) = win_hdr(base)
+        if wlen > SHELL_MAX_VALID_SLOT_SIZE:
+            log.debug("DSP powered off at winstream_read")
+            return (seq, "")
+        if wlen == 0:
+            return (seq, "")
         if last_seq == 0:
             last_seq = seq if args.no_history else (seq - ((end - start) % wlen))
         if seq == last_seq or start == end:
@@ -675,15 +686,87 @@ def winstream_read(last_seq):
             return (seq, "")
         copy = (end - behind) % wlen
         suffix = min(behind, wlen - copy)
-        result = win_read(16 + copy, suffix)
+        result = win_read(base, 16 + copy, suffix)
         if suffix < behind:
-            result += win_read(16, behind - suffix)
-        (wlen, start1, end, seq1) = win_hdr()
+            result += win_read(base, 16, behind - suffix)
+        (wlen, start1, end, seq1) = win_hdr(base)
         if start1 == start and seq1 == seq:
             # Best effort attempt at decoding, replacing unusable characters
             # Found to be useful when it really goes wrong
             return (seq, result.decode("utf-8", "replace"))
 
+def idx_mod(wlen, idx):
+    if idx >= wlen:
+        return idx - wlen
+    return idx
+
+def idx_sub(wlen, a, b):
+    return idx_mod(wlen, a + (wlen - b))
+
+# Python implementation of the same algorithm in sys_winstream_write(),
+# see there for details.
+def winstream_write(base, msg):
+    (wlen, start, end, seq) = win_hdr(base)
+    if wlen > SHELL_MAX_VALID_SLOT_SIZE:
+        log.debug("DSP powered off at winstream_write")
+        return
+    if wlen == 0:
+        return
+    lenmsg = len(msg)
+    lenmsg0 = lenmsg
+    if len(msg) > wlen + 1:
+        start = end
+        lenmsg = wlen - 1
+    lenmsg = min(lenmsg, wlen)
+    if seq != 0:
+        avail = (wlen - 1) - idx_sub(wlen, end, start)
+        if lenmsg > avail:
+            start = idx_mod(wlen, start + (lenmsg - avail))
+    if lenmsg < lenmsg0:
+        start = end
+        drop = lenmsg0 - lenmsg
+        msg = msg[drop : lenmsg - drop]
+    suffix = min(lenmsg, wlen - end)
+    for c in range(0, suffix):
+        bar4_mmap[base + 16 + end + c] = msg[c]
+    if lenmsg > suffix:
+        for c in range(0, lenmsg - suffix):
+            bar4_mmap[base + 16 + c] = msg[suffix + c]
+    end = idx_mod(wlen, end + lenmsg)
+    seq += lenmsg0
+    # write back updated fields as 32bit writes
+    update_hdr = struct.pack("<III", start, end, seq)
+    dst = base + 4 # skip wlen
+    for c in range(0, 3):
+        src = c * 4
+        bar4_mmap[dst : dst + 4] = update_hdr[src : src + 4]
+        dst += 4
+
+def debug_offset():
+    ( base, stride ) = adsp_mem_window_config()
+    return base + stride * 2
+
+def shell_base_offset():
+    return debug_offset() + DEBUG_SLOT_SIZE * (1 + DEBUG_SLOT_SHELL)
+
+def read_from_shell_memwindow_winstream(last_seq):
+    offset = shell_base_offset() + SHELL_RX_SIZE
+    (last_seq, output) = winstream_read(offset, last_seq)
+    if output:
+        os.write(shell_client_port, output.encode("utf-8"))
+    return last_seq
+
+def write_to_shell_memwindow_winstream():
+    msg = os.read(shell_client_port, 1)
+    if len(msg) > 0:
+        winstream_write(shell_base_offset(), msg)
+
+def create_shell_pty():
+    global shell_client_port
+    (shell_client_port, user_port) = pty.openpty()
+    name = os.ttyname(user_port)
+    log.info(f"shell PTY at: {name}")
+    asyncio.get_event_loop().add_reader(shell_client_port, write_to_shell_memwindow_winstream)
 
 async def ipc_delay_done():
     await asyncio.sleep(0.1)
@@ -865,12 +948,18 @@ async def main():
         if not args.quiet:
             sys.stdout.write("--\n")
 
+    if args.shell_pty:
+        create_shell_pty()
+
     hda_streams = dict()
 
     last_seq = 0
+    last_seq_shell = 0
     while start_output is True:
         await asyncio.sleep(0.03)
-        (last_seq, output) = winstream_read(last_seq)
+        if args.shell_pty:
+            last_seq_shell = read_from_shell_memwindow_winstream(last_seq_shell)
+        (last_seq, output) = winstream_read(winstream_offset(), last_seq)
         if output:
             sys.stdout.write(output)
             sys.stdout.flush()
@@ -885,6 +974,8 @@ ap.add_argument("-v", "--verbose", action="store_true",
                 help="More loader output, DEBUG logging level")
 ap.add_argument("-l", "--log-only", action="store_true",
                 help="Don't load firmware, just show log output")
+ap.add_argument("-p", "--shell-pty", action="store_true",
+                help="Create a Zephyr shell pty if enabled in firmware")
 ap.add_argument("-n", "--no-history", action="store_true",
                 help="No current log buffer at start, just new output")
 ap.add_argument("fw_file", nargs="?", help="Firmware file")

--- a/subsys/shell/backends/CMakeLists.txt
+++ b/subsys/shell/backends/CMakeLists.txt
@@ -29,3 +29,8 @@ zephyr_sources_ifdef(
   CONFIG_SHELL_BACKEND_RPMSG
   shell_rpmsg.c
 )
+
+zephyr_sources_ifdef(
+  CONFIG_SHELL_BACKEND_ADSP_MEMORY_WINDOW
+  shell_adsp_memory_window.c
+)

--- a/subsys/shell/backends/Kconfig.backends
+++ b/subsys/shell/backends/Kconfig.backends
@@ -625,4 +625,29 @@ config SHELL_DUMMY_INIT_LOG_LEVEL
 
 endif # SHELL_BACKEND_DUMMY
 
+config SHELL_BACKEND_ADSP_MEMORY_WINDOW
+	bool "Shell backend implemented over mapped memory window."
+	depends on SOC_FAMILY_INTEL_ADSP
+	help
+	  Enable ADSP memory window backend which can be used to execute commands
+	  from remote host processor that has access to the same memory window.
+
+if SHELL_BACKEND_ADSP_MEMORY_WINDOW
+
+config SHELL_BACKEND_ADSP_MEMORY_WINDOW_PROMPT
+	string "Displayed prompt name"
+	default "~$ "
+	help
+	  Displayed prompt name for ADSP memory window backend. If prompt is set,
+	  the shell will send two newlines during initialization.
+
+config SHELL_BACKEND_ADSP_MEMORY_WINDOW_POLL_INTERVAL
+	int "Poll interval (in microseconds)"
+	default 100
+	help
+	  This option can be used to modify the poll interval the backend uses
+	  to check for new commands.
+
+endif # SHELL_BACKEND_ADSP_MEMORY_WINDOW
+
 endif # SHELL_BACKENDS

--- a/subsys/shell/backends/shell_adsp_memory_window.c
+++ b/subsys/shell/backends/shell_adsp_memory_window.c
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/shell/shell_adsp_memory_window.h>
+#include <zephyr/sys/winstream.h>
+#include <zephyr/logging/log.h>
+
+#include <adsp_memory.h>
+#include <adsp_debug_window.h>
+
+SHELL_ADSP_MEMORY_WINDOW_DEFINE(shell_transport_adsp_memory_window);
+SHELL_DEFINE(shell_adsp_memory_window, CONFIG_SHELL_BACKEND_ADSP_MEMORY_WINDOW_PROMPT,
+	     &shell_transport_adsp_memory_window, 256, 0, SHELL_FLAG_OLF_CRLF);
+
+LOG_MODULE_REGISTER(shell_adsp_memory_window);
+
+#define RX_WINDOW_SIZE		256
+#define POLL_INTERVAL		K_MSEC(CONFIG_SHELL_BACKEND_ADSP_MEMORY_WINDOW_POLL_INTERVAL)
+
+BUILD_ASSERT(RX_WINDOW_SIZE < ADSP_DW_SLOT_SIZE);
+
+struct adsp_debug_slot_shell {
+	uint8_t rx_window[RX_WINDOW_SIZE];
+	uint8_t tx_window[ADSP_DW_SLOT_SIZE - RX_WINDOW_SIZE];
+} __packed;
+
+static void timer_handler(struct k_timer *timer)
+{
+	const struct shell_adsp_memory_window *sh_adsp_mw = k_timer_user_data_get(timer);
+
+	__ASSERT_NO_MSG(sh_adsp_mw->shell_handler && sh_adsp_mw->shell_context);
+
+	sh_adsp_mw->shell_handler(SHELL_TRANSPORT_EVT_RX_RDY,
+				    sh_adsp_mw->shell_context);
+}
+
+static int init(const struct shell_transport *transport,
+		const void *config,
+		shell_transport_handler_t evt_handler,
+		void *context)
+{
+	struct shell_adsp_memory_window *sh_adsp_mw =
+		(struct shell_adsp_memory_window *)transport->ctx;
+	struct adsp_debug_slot_shell *dw_slot;
+
+	if (ADSP_DW->descs[ADSP_DW_SLOT_NUM_SHELL].type &&
+	    (ADSP_DW->descs[ADSP_DW_SLOT_NUM_SHELL].type !=
+		    ADSP_DW_SLOT_SHELL)) {
+		LOG_WRN("Possible conflict with debug window slot for shell, key %#x\n",
+			ADSP_DW->descs[ADSP_DW_SLOT_NUM_SHELL].type);
+	}
+
+	ADSP_DW->descs[ADSP_DW_SLOT_NUM_SHELL].type = ADSP_DW->descs[ADSP_DW_SLOT_NUM_SHELL].type;
+
+	sh_adsp_mw->shell_handler = evt_handler;
+	sh_adsp_mw->shell_context = context;
+
+	dw_slot = (struct adsp_debug_slot_shell *)ADSP_DW->slots[ADSP_DW_SLOT_NUM_SHELL];
+
+	sh_adsp_mw->ws_rx = sys_winstream_init(&dw_slot->rx_window[0], sizeof(dw_slot->rx_window));
+	sh_adsp_mw->ws_tx = sys_winstream_init(&dw_slot->tx_window[0], sizeof(dw_slot->tx_window));
+
+	LOG_DBG("shell with ADSP debug window rx/tx %u/%u\n",
+		sizeof(dw_slot->rx_window), sizeof(dw_slot->tx_window));
+
+	k_timer_init(&sh_adsp_mw->timer, timer_handler, NULL);
+	k_timer_user_data_set(&sh_adsp_mw->timer, (void *)sh_adsp_mw);
+	k_timer_start(&sh_adsp_mw->timer, POLL_INTERVAL, POLL_INTERVAL);
+
+	return 0;
+}
+
+static int uninit(const struct shell_transport *transport)
+{
+	struct shell_adsp_memory_window *sh_adsp_mw =
+		(struct shell_adsp_memory_window *)transport->ctx;
+
+	k_timer_stop(&sh_adsp_mw->timer);
+
+	return 0;
+}
+
+static int enable(const struct shell_transport *transport, bool blocking)
+{
+	return 0;
+}
+
+static int write(const struct shell_transport *transport,
+		 const void *data, size_t length, size_t *cnt)
+{
+	struct shell_adsp_memory_window *sh_adsp_mw =
+		(struct shell_adsp_memory_window *)transport->ctx;
+
+	sys_winstream_write(sh_adsp_mw->ws_tx, data, length);
+	*cnt = length;
+
+	return 0;
+}
+
+static int read(const struct shell_transport *transport,
+		void *data, size_t length, size_t *cnt)
+{
+	struct shell_adsp_memory_window *sh_adsp_mw =
+		(struct shell_adsp_memory_window *)transport->ctx;
+	uint32_t res;
+
+	res = sys_winstream_read(sh_adsp_mw->ws_rx, &sh_adsp_mw->read_seqno, data, length);
+	*cnt = res;
+
+	return 0;
+}
+
+const struct shell_transport_api shell_adsp_memory_window_transport_api = {
+	.init = init,
+	.uninit = uninit,
+	.enable = enable,
+	.write = write,
+	.read = read
+};
+
+static int enable_shell_adsp_memory_window(void)
+{
+	bool log_backend = true;
+	uint32_t level = CONFIG_LOG_MAX_LEVEL;
+	static const struct shell_backend_config_flags cfg_flags =
+		SHELL_DEFAULT_BACKEND_CONFIG_FLAGS;
+
+	shell_init(&shell_adsp_memory_window, NULL, cfg_flags, log_backend, level);
+
+	return 0;
+}
+SYS_INIT(enable_shell_adsp_memory_window, POST_KERNEL, 0);
+
+const struct shell *shell_backend_adsp_memory_window_get_ptr(void)
+{
+	return &shell_adsp_memory_window;
+}


### PR DESCRIPTION
Shell backend for Intel ADSPs that uses Zephyr winstream as memory streaming protocol. Another two patches to add support to cavstool/acetool tools to use the shell from host.

Some notes on design rationale:
- debug slot number is hardcoded on purpose so that writing a client that can wait for DSP to boot up (or resume from suspend) is possible/easier
- con of above is that currently "mtrace" log backend needs to be disabled when shell backend is enabled -- should be pragmatic as one can route the logs to the shell output
- cavstool.py pty code based on example from @nklayman 's https://github.com/zephyrproject-rtos/zephyr/pull/49077
- cavstool.py and acetool.py code is still duplicated, this PR adds duplicated changes. we have a lot of CI/developer usage that assume a single file can be deployed, so I think it's better to keep these separate (and standalone) until we can unify to a single python script that can handle all targets (IOW carving out justt the shell code to a separate common py file, doesn't make a lot of sense)