### PR TITLE
kernel: avoided increments/decrements with side effects

### DIFF
--- a/kernel/include/priority_q.h
+++ b/kernel/include/priority_q.h
@@ -79,7 +79,8 @@ static ALWAYS_INLINE void z_priq_rb_add(struct _priq_rb *pq, struct k_thread *th
 {
 	struct k_thread *t;
 
-	thread->base.order_key = pq->next_order_key++;
+	thread->base.order_key = pq->next_order_key;
+	++pq->next_order_key;
 
 	/* Renumber at wraparound.  This is tiny code, and in practice
 	 * will almost never be hit on real systems.  BUT on very
@@ -89,7 +90,8 @@ static ALWAYS_INLINE void z_priq_rb_add(struct _priq_rb *pq, struct k_thread *th
 	 */
 	if (!pq->next_order_key) {
 		RB_FOR_EACH_CONTAINER(&pq->tree, t, base.qnode_rb) {
-			t->base.order_key = pq->next_order_key++;
+			t->base.order_key = pq->next_order_key;
+			++pq->next_order_key;
 		}
 	}
 

--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -46,7 +46,8 @@ void k_free(void *ptr)
 
 	if (ptr != NULL) {
 		heap_ref = ptr;
-		ptr = --heap_ref;
+		--heap_ref;
+		ptr = heap_ref;
 
 		SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_heap_sys, k_free, *heap_ref, heap_ref);
 


### PR DESCRIPTION
Avoided increments/decrements with side effects.


This corresponds to following coding guideline:
> A full expression containing an increment (++) or decrement (–) operator should have no other potential side effects other than that caused by the increment or decrement operator

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/671153b94dd5af207423fd8aaf4caf2f6c4d19c3