### PR TITLE
Rcar sd mmc fixes

### DIFF
--- a/boards/renesas/rcar_h3ulcb/rcar_h3ulcb_r8a77951_a57-pinctrl.dtsi
+++ b/boards/renesas/rcar_h3ulcb/rcar_h3ulcb_r8a77951_a57-pinctrl.dtsi
@@ -17,42 +17,52 @@
 
 	emmc2_clk: emmc2_clk {
 		pin = <PIN_SD2_CLK FUNC_SD2_CLK>;
+		power-source = <PIN_VOLTAGE_1P8V>;
 	};
 
 	emmc2_cmd: emmc2_cmd {
 		pin = <PIN_SD2_CMD FUNC_SD2_CMD>;
+		power-source = <PIN_VOLTAGE_1P8V>;
 	};
 
 	emmc2_data0: emmc2_data0 {
 		pin = <PIN_SD2_DATA0 FUNC_SD2_DAT0>;
+		power-source = <PIN_VOLTAGE_1P8V>;
 	};
 
 	emmc2_data1: emmc2_data1 {
 		pin = <PIN_SD2_DATA1 FUNC_SD2_DAT1>;
+		power-source = <PIN_VOLTAGE_1P8V>;
 	};
 
 	emmc2_data2: emmc2_data2 {
 		pin = <PIN_SD2_DATA2 FUNC_SD2_DAT2>;
+		power-source = <PIN_VOLTAGE_1P8V>;
 	};
 
 	emmc2_data3: emmc2_data3 {
 		pin = <PIN_SD2_DATA3 FUNC_SD2_DAT3>;
+		power-source = <PIN_VOLTAGE_1P8V>;
 	};
 
 	emmc2_data4: emmc2_data4 {
 		pin = <PIN_SD1_DATA0 FUNC_SD2_DAT4>;
+		power-source = <PIN_VOLTAGE_1P8V>;
 	};
 
 	emmc2_data5: emmc2_data5 {
 		pin = <PIN_SD1_DATA1 FUNC_SD2_DAT5>;
+		power-source = <PIN_VOLTAGE_1P8V>;
 	};
 
 	emmc2_data6: emmc2_data6 {
 		pin = <PIN_SD1_DATA2 FUNC_SD2_DAT6>;
+		power-source = <PIN_VOLTAGE_1P8V>;
 	};
 
 	emmc2_data7: emmc2_data7 {
 		pin = <PIN_SD1_DATA3 FUNC_SD2_DAT7>;
+		power-source = <PIN_VOLTAGE_1P8V>;
 	};
 
 	emmc2_ds: emmc2_ds {

--- a/boards/renesas/rcar_h3ulcb/rcar_h3ulcb_r8a77951_a57-pinctrl.dtsi
+++ b/boards/renesas/rcar_h3ulcb/rcar_h3ulcb_r8a77951_a57-pinctrl.dtsi
@@ -15,6 +15,78 @@
 		pin = <PIN_RX2_A FUNC_RX2_A>;
 	};
 
+	sd0_clk: sd0_clk {
+		pin = <PIN_SD0_CLK FUNC_SD0_CLK>;
+		power-source = <PIN_VOLTAGE_3P3V>;
+	};
+
+	sd0_cmd: sd0_cmd {
+		pin = <PIN_SD0_CMD FUNC_SD0_CMD>;
+		power-source = <PIN_VOLTAGE_3P3V>;
+	};
+
+	sd0_data0: sd0_data0 {
+		pin = <PIN_SD0_DATA0 FUNC_SD0_DAT0>;
+		power-source = <PIN_VOLTAGE_3P3V>;
+	};
+
+	sd0_data1: sd0_data1 {
+		pin = <PIN_SD0_DATA1 FUNC_SD0_DAT1>;
+		power-source = <PIN_VOLTAGE_3P3V>;
+	};
+
+	sd0_data2: sd0_data2 {
+		pin = <PIN_SD0_DATA2 FUNC_SD0_DAT2>;
+		power-source = <PIN_VOLTAGE_3P3V>;
+	};
+
+	sd0_data3: sd0_data3 {
+		pin = <PIN_SD0_DATA3 FUNC_SD0_DAT3>;
+		power-source = <PIN_VOLTAGE_3P3V>;
+	};
+
+	sd0_clk_uhs: sd0_clk_uhs {
+		pin = <PIN_SD0_CLK FUNC_SD0_CLK>;
+		power-source = <PIN_VOLTAGE_1P8V>;
+	};
+
+	sd0_cmd_uhs: sd0_cmd_uhs {
+		pin = <PIN_SD0_CMD FUNC_SD0_CMD>;
+		power-source = <PIN_VOLTAGE_1P8V>;
+	};
+
+	sd0_data0_uhs: sd0_data0_uhs {
+		pin = <PIN_SD0_DATA0 FUNC_SD0_DAT0>;
+		power-source = <PIN_VOLTAGE_1P8V>;
+	};
+
+	sd0_data1_uhs: sd0_data1_uhs {
+		pin = <PIN_SD0_DATA1 FUNC_SD0_DAT1>;
+		power-source = <PIN_VOLTAGE_1P8V>;
+	};
+
+	sd0_data2_uhs: sd0_data2_uhs {
+		pin = <PIN_SD0_DATA2 FUNC_SD0_DAT2>;
+		power-source = <PIN_VOLTAGE_1P8V>;
+	};
+
+	sd0_data3_uhs: sd0_data3_uhs {
+		pin = <PIN_SD0_DATA3 FUNC_SD0_DAT3>;
+		power-source = <PIN_VOLTAGE_1P8V>;
+	};
+
+	/* note: CD pin is fixed at 3.3V */
+	sd0_cd: sd0_cd {
+		pin = <PIN_SD0_CD FUNC_SD0_CD>;
+		power-source = <PIN_VOLTAGE_3P3V>;
+	};
+
+	/* note: WP pin is fixed at 3.3V */
+	sd0_wp: sd0_wp {
+		pin = <PIN_SD0_WP FUNC_SD0_WP>;
+		power-source = <PIN_VOLTAGE_3P3V>;
+	};
+
 	emmc2_clk: emmc2_clk {
 		pin = <PIN_SD2_CLK FUNC_SD2_CLK>;
 		power-source = <PIN_VOLTAGE_1P8V>;

--- a/boards/renesas/rcar_h3ulcb/rcar_h3ulcb_r8a77951_a57.dts
+++ b/boards/renesas/rcar_h3ulcb/rcar_h3ulcb_r8a77951_a57.dts
@@ -8,6 +8,7 @@
 /dts-v1/;
 #include <mem.h>
 #include <arm64/renesas/r8a77951.dtsi>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 #include "rcar_h3ulcb_r8a77951_a57-pinctrl.dtsi"
 
 / {
@@ -28,6 +29,52 @@
 	aliases {
 		sdhc0 = &emmc2;
 	};
+
+	vcc_sd0: regulator-vcc-sd0 {
+		compatible = "regulator-fixed";
+
+		regulator-name = "SD0 Vcc";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+
+		enable-gpios = <&gpio5 2 GPIO_ACTIVE_HIGH>;
+	};
+
+	vccq_sd0: regulator-vccq-sd0 {
+		compatible = "regulator-gpio";
+
+		regulator-name = "SD0 VccQ";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <3300000>;
+
+		gpios = <&gpio5 1 GPIO_ACTIVE_HIGH>;
+		states = <3300000 1>, <1800000 0>;
+
+		regulator-always-on;
+	};
+};
+
+&gpio5 {
+	status = "okay";
+};
+
+&sd0 {
+	pinctrl-0 = <&sd0_clk &sd0_cmd &sd0_cd &sd0_wp
+		     &sd0_data0 &sd0_data1 &sd0_data2 &sd0_data3>;
+	pinctrl-1 = <&sd0_clk_uhs &sd0_cmd_uhs &sd0_cd &sd0_wp
+		     &sd0_data0_uhs &sd0_data1_uhs &sd0_data2_uhs &sd0_data3_uhs>;
+	pinctrl-names = "default", "uhs";
+	disk {
+		compatible = "zephyr,sdmmc-disk";
+		status = "okay";
+	};
+
+	vmmc-supply = <&vcc_sd0>;
+	vqmmc-supply = <&vccq_sd0>;
+
+	bus-width = <4>;
+	mmc-sdr104-support;
+	status = "okay";
 };
 
 &scif2 {

--- a/boards/renesas/rcar_salvator_xs/rcar_salvator_xs-pinctrl.dtsi
+++ b/boards/renesas/rcar_salvator_xs/rcar_salvator_xs-pinctrl.dtsi
@@ -17,42 +17,52 @@
 
 	emmc2_clk: emmc2_clk {
 		pin = <PIN_SD2_CLK FUNC_SD2_CLK>;
+		power-source = <PIN_VOLTAGE_1P8V>;
 	};
 
 	emmc2_cmd: emmc2_cmd {
 		pin = <PIN_SD2_CMD FUNC_SD2_CMD>;
+		power-source = <PIN_VOLTAGE_1P8V>;
 	};
 
 	emmc2_data0: emmc2_data0 {
 		pin = <PIN_SD2_DATA0 FUNC_SD2_DAT0>;
+		power-source = <PIN_VOLTAGE_1P8V>;
 	};
 
 	emmc2_data1: emmc2_data1 {
 		pin = <PIN_SD2_DATA1 FUNC_SD2_DAT1>;
+		power-source = <PIN_VOLTAGE_1P8V>;
 	};
 
 	emmc2_data2: emmc2_data2 {
 		pin = <PIN_SD2_DATA2 FUNC_SD2_DAT2>;
+		power-source = <PIN_VOLTAGE_1P8V>;
 	};
 
 	emmc2_data3: emmc2_data3 {
 		pin = <PIN_SD2_DATA3 FUNC_SD2_DAT3>;
+		power-source = <PIN_VOLTAGE_1P8V>;
 	};
 
 	emmc2_data4: emmc2_data4 {
 		pin = <PIN_SD1_DATA0 FUNC_SD2_DAT4>;
+		power-source = <PIN_VOLTAGE_1P8V>;
 	};
 
 	emmc2_data5: emmc2_data5 {
 		pin = <PIN_SD1_DATA1 FUNC_SD2_DAT5>;
+		power-source = <PIN_VOLTAGE_1P8V>;
 	};
 
 	emmc2_data6: emmc2_data6 {
 		pin = <PIN_SD1_DATA2 FUNC_SD2_DAT6>;
+		power-source = <PIN_VOLTAGE_1P8V>;
 	};
 
 	emmc2_data7: emmc2_data7 {
 		pin = <PIN_SD1_DATA3 FUNC_SD2_DAT7>;
+		power-source = <PIN_VOLTAGE_1P8V>;
 	};
 
 	emmc2_ds: emmc2_ds {

--- a/boards/renesas/rcar_spider_s4/rcar_spider_s4_r8a779f0_a55-pinctrl.dtsi
+++ b/boards/renesas/rcar_spider_s4/rcar_spider_s4_r8a779f0_a55-pinctrl.dtsi
@@ -14,4 +14,58 @@
 	hscif0_data_rx_default: hscif0_data_rx_default {
 		pin = <PIN_HRX0 FUNC_HRX0>;
 	};
+
+	mmc_clk: mmc_clk {
+		pin = <PIN_MMC_SD_CLK FUNC_MMC_SD_CLK>;
+		power-source = <PIN_VOLTAGE_1P8V>;
+	};
+
+	mmc_cmd: mmc_cmd {
+		pin = <PIN_MMC_SD_CMD FUNC_MMC_SD_CMD>;
+		power-source = <PIN_VOLTAGE_1P8V>;
+	};
+
+	mmc_data0: mmc_data0 {
+		pin = <PIN_MMC_SD_D0 FUNC_MMC_SD_D0>;
+		power-source = <PIN_VOLTAGE_1P8V>;
+	};
+
+	mmc_data1: mmc_data1 {
+		pin = <PIN_MMC_SD_D1 FUNC_MMC_SD_D1>;
+		power-source = <PIN_VOLTAGE_1P8V>;
+	};
+
+	mmc_data2: mmc_data2 {
+		pin = <PIN_MMC_SD_D2 FUNC_MMC_SD_D2>;
+		power-source = <PIN_VOLTAGE_1P8V>;
+	};
+
+	mmc_data3: mmc_data3 {
+		pin = <PIN_MMC_SD_D3 FUNC_MMC_SD_D3>;
+		power-source = <PIN_VOLTAGE_1P8V>;
+	};
+
+	mmc_data4: mmc_data4 {
+		pin = <PIN_MMC_D4 FUNC_MMC_D4>;
+		power-source = <PIN_VOLTAGE_1P8V>;
+	};
+
+	mmc_data5: mmc_data5 {
+		pin = <PIN_MMC_D5 FUNC_MMC_D5>;
+		power-source = <PIN_VOLTAGE_1P8V>;
+	};
+
+	mmc_data6: mmc_data6 {
+		pin = <PIN_MMC_D6 FUNC_MMC_D6>;
+		power-source = <PIN_VOLTAGE_1P8V>;
+	};
+
+	mmc_data7: mmc_data7 {
+		pin = <PIN_MMC_D7 FUNC_MMC_D7>;
+		power-source = <PIN_VOLTAGE_1P8V>;
+	};
+
+	mmc_ds: mmc_ds {
+		pin = <PIN_MMC_DS FUNC_MMC_DS>;
+	};
 };

--- a/boards/renesas/rcar_spider_s4/rcar_spider_s4_r8a779f0_a55.dts
+++ b/boards/renesas/rcar_spider_s4/rcar_spider_s4_r8a779f0_a55.dts
@@ -30,3 +30,22 @@
 	current-speed = <1843200>;
 	status = "okay";
 };
+
+&mmc0 {
+	pinctrl-0 = <&mmc_clk &mmc_cmd &mmc_ds
+		&mmc_data0 &mmc_data1 &mmc_data2 &mmc_data3
+		&mmc_data4 &mmc_data5 &mmc_data6 &mmc_data7>;
+	pinctrl-1 = <&mmc_clk &mmc_cmd &mmc_ds
+		&mmc_data0 &mmc_data1 &mmc_data2 &mmc_data3
+		&mmc_data4 &mmc_data5 &mmc_data6 &mmc_data7>;
+	pinctrl-names = "default", "uhs";
+	disk {
+		compatible = "zephyr,mmc-disk";
+		status = "okay";
+	};
+	bus-width = <8>;
+	mmc-hs200-1_8v;
+	mmc-hs400-1_8v;
+	non-removable;
+	status = "okay";
+};

--- a/tests/subsys/sd/sdmmc/boards/rcar_h3ulcb_r8a77951_a57.overlay
+++ b/tests/subsys/sd/sdmmc/boards/rcar_h3ulcb_r8a77951_a57.overlay
@@ -1,0 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/ {
+	aliases {
+		sdhc0 = &sd0;
+	};
+};


### PR DESCRIPTION
Set power-source property for MMC pins for h3ulcb (CA57) and Salvator-XS boards.
Add MMC node to DTS and describe MMC pins for R-Car Spider S4 (CA55).
Add SD node to DTS and describe SD pins for h3ulcb (CA57).
Add overlay file for testing `tests/subsys/sd/sdmmc` on h3ulcb (CA57) board.