### PR TITLE
tests: drivers: rtc api testing with timeout

### DIFF
--- a/tests/drivers/rtc/rtc_api/testcase.yaml
+++ b/tests/drivers/rtc/rtc_api/testcase.yaml
@@ -9,5 +9,6 @@ tests:
       - api
     filter: dt_alias_exists("rtc")
     depends_on: rtc
+    timeout: 100
     platform_exclude:
       - qemu_x86_64


### PR DESCRIPTION
Add a timeout to the tests/drivers/rtc_api testcase so twister can end properly when running with twister.

The value is set to pass testcase on all stm32 boards: 
   tests/drivers/rtc/rtc_api/drivers.rtc.rtc_api, b_u585i_iot02a
   tests/drivers/rtc/rtc_api/drivers.rtc.rtc_api, disco_l475_iot1
   tests/drivers/rtc/rtc_api/drivers.rtc.rtc_api, nucleo_f091rc
   tests/drivers/rtc/rtc_api/drivers.rtc.rtc_api, nucleo_f207zg
   tests/drivers/rtc/rtc_api/drivers.rtc.rtc_api, nucleo_f401re
   tests/drivers/rtc/rtc_api/drivers.rtc.rtc_api, nucleo_f429zi
   tests/drivers/rtc/rtc_api/drivers.rtc.rtc_api, nucleo_f746zg
   tests/drivers/rtc/rtc_api/drivers.rtc.rtc_api, nucleo_g071rb
   tests/drivers/rtc/rtc_api/drivers.rtc.rtc_api, nucleo_g474re
   tests/drivers/rtc/rtc_api/drivers.rtc.rtc_api, nucleo_h743zi
   tests/drivers/rtc/rtc_api/drivers.rtc.rtc_api, nucleo_l073rz
   tests/drivers/rtc/rtc_api/drivers.rtc.rtc_api, nucleo_wb55rg
   tests/drivers/rtc/rtc_api/drivers.rtc.rtc_api, nucleo_wba55cg
   tests/drivers/rtc/rtc_api/drivers.rtc.rtc_api, nucleo_wl55jc
   tests/drivers/rtc/rtc_api/drivers.rtc.rtc_api, stm32f3_disco
   tests/drivers/rtc/rtc_api/drivers.rtc.rtc_api, stm32h573i_dk