### PR TITLE
drivers: watchdog: NXP: Fix WDG option handling

### DIFF
--- a/drivers/watchdog/wdt_mcux_imx_wdog.c
+++ b/drivers/watchdog/wdt_mcux_imx_wdog.c
@@ -42,10 +42,10 @@ static int mcux_wdog_setup(const struct device *dev, uint8_t options)
 	}
 
 	data->wdog_config.workMode.enableStop =
-		(options & WDT_OPT_PAUSE_IN_SLEEP) == 0U;
+		(options & WDT_OPT_PAUSE_IN_SLEEP) == WDT_OPT_PAUSE_IN_SLEEP;
 
 	data->wdog_config.workMode.enableDebug =
-		(options & WDT_OPT_PAUSE_HALTED_BY_DBG) == 0U;
+		(options & WDT_OPT_PAUSE_HALTED_BY_DBG) == WDT_OPT_PAUSE_HALTED_BY_DBG;
 
 	WDOG_Init(base, &data->wdog_config);
 	LOG_DBG("Setup the watchdog");

--- a/drivers/watchdog/wdt_mcux_wdog.c
+++ b/drivers/watchdog/wdt_mcux_wdog.c
@@ -43,10 +43,10 @@ static int mcux_wdog_setup(const struct device *dev, uint8_t options)
 	}
 
 	data->wdog_config.workMode.enableStop =
-		(options & WDT_OPT_PAUSE_IN_SLEEP) == 0U;
+		(options & WDT_OPT_PAUSE_IN_SLEEP) == WDT_OPT_PAUSE_IN_SLEEP;
 
 	data->wdog_config.workMode.enableDebug =
-		(options & WDT_OPT_PAUSE_HALTED_BY_DBG) == 0U;
+		(options & WDT_OPT_PAUSE_HALTED_BY_DBG) == WDT_OPT_PAUSE_HALTED_BY_DBG;
 
 	WDOG_Init(base, &data->wdog_config);
 	LOG_DBG("Setup the watchdog");

--- a/drivers/watchdog/wdt_mcux_wdog32.c
+++ b/drivers/watchdog/wdt_mcux_wdog32.c
@@ -51,10 +51,10 @@ static int mcux_wdog32_setup(const struct device *dev, uint8_t options)
 	}
 
 	data->wdog_config.workMode.enableStop =
-		(options & WDT_OPT_PAUSE_IN_SLEEP) == 0U;
+		(options & WDT_OPT_PAUSE_IN_SLEEP) == WDT_OPT_PAUSE_IN_SLEEP;
 
 	data->wdog_config.workMode.enableDebug =
-		(options & WDT_OPT_PAUSE_HALTED_BY_DBG) == 0U;
+		(options & WDT_OPT_PAUSE_HALTED_BY_DBG) == WDT_OPT_PAUSE_HALTED_BY_DBG;
 
 	WDOG32_Init(base, &data->wdog_config);
 	LOG_DBG("Setup the watchdog");


### PR DESCRIPTION
If `enableStop` is true the watchdog is halted in chip stop mode.
If `enableDebug` is true the watchdog is halted in chip debug mode.