### PR TITLE
drivers: sdhc: sdhc_spi: release bus on error, and fix CMD12 failue logic

### DIFF
--- a/drivers/sdhc/sdhc_spi.c
+++ b/drivers/sdhc/sdhc_spi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 NXP
+ * Copyright 2022,2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -143,6 +143,7 @@ static int sdhc_spi_init_card(const struct device *dev)
 	spi_cfg->operation |= SPI_CS_ACTIVE_HIGH;
 	ret = sdhc_spi_rx(config->spi_dev, spi_cfg, data->scratch, 10);
 	if (ret != 0) {
+		spi_release(config->spi_dev, spi_cfg);
 		spi_cfg->operation &= ~SPI_CS_ACTIVE_HIGH;
 		return ret;
 	}
@@ -638,6 +639,8 @@ static int sdhc_spi_request(const struct device *dev,
 		} while ((ret != 0) && (retries-- > 0));
 	}
 	if (ret) {
+		/* Release SPI bus */
+		spi_release(config->spi_dev, dev_data->spi_cfg);
 		return ret;
 	}
 	/* Release SPI bus */


### PR DESCRIPTION
Properly release SPI bus on transmit error within the SDHC SPI driver. In these cases return code is not checked, as we wish to return the error code from the failed transfer to the SD stack.

Fixes #72364

drivers: sdhc: sdhc_spi: rework CMD12 failure logic

Rework CMD12 failure logic for SDHC SPI driver. Previously, the error
code of CMD12 was not checked, so even if CMD12 failed to send the
initial command would be retried. Change this behavior to retry CMD12
until it succeeds. If CMD12 fails, its error code will be propagated to
the caller. Otherwise, the return code from the command being sent by
the caller will be propagated.

Fixes #72365
