### PR TITLE
sd: sd_ops: take card lock when issuing IOCTL command

### DIFF
--- a/subsys/sd/sd_ops.c
+++ b/subsys/sd/sd_ops.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 NXP
+ * Copyright 2022,2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -774,6 +774,13 @@ int card_write_blocks(struct sd_card *card, const uint8_t *wbuf, uint32_t start_
 /* IO Control handler for SD MMC */
 int card_ioctl(struct sd_card *card, uint8_t cmd, void *buf)
 {
+	int ret;
+
+	ret = k_mutex_lock(&card->lock, K_MSEC(CONFIG_SD_DATA_TIMEOUT));
+	if (ret) {
+		LOG_WRN("Could not get SD card mutex");
+		return ret;
+	}
 	switch (cmd) {
 	case DISK_IOCTL_GET_SECTOR_COUNT:
 		(*(uint32_t *)buf) = card->block_count;
@@ -787,9 +794,10 @@ int card_ioctl(struct sd_card *card, uint8_t cmd, void *buf)
 		 * Note that SD stack does not support enabling caching, so
 		 * cache flush is not required here
 		 */
-		return sdmmc_wait_ready(card);
+		ret = sdmmc_wait_ready(card);
 	default:
-		return -ENOTSUP;
+		ret = -ENOTSUP;
 	}
-	return 0;
+	k_mutex_unlock(&card->lock);
+	return ret;
 }


### PR DESCRIPTION
Take card lock when running IOCTL command, to avoid race conditions that could occur within the lower SDHC transfer implementations (as these will be called by sdmmc_wait_ready)

Fixes #72368