### PR TITLE
Add rw61 power management support

### DIFF
--- a/boards/nxp/rd_rw612_bga/doc/index.rst
+++ b/boards/nxp/rd_rw612_bga/doc/index.rst
@@ -61,7 +61,11 @@ Supported Features
 +-----------+------------+-----------------------------------+
 | MRT       | on-chip    | counter                           |
 +-----------+------------+-----------------------------------+
-
+| OS_TIMER  | on-chip    | os timer                          |
++-----------+------------+-----------------------------------+
+| PM        | on-chip    | power management; uses SoC Power  |
+|           |            | Modes 1 and 2                     |
++-----------+------------+-----------------------------------+
 
 The default configuration can be found in the defconfig file:
 

--- a/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
+++ b/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
@@ -254,3 +254,13 @@ zephyr_udc0: &usb_otg {
 &dac0 {
 	status = "okay";
 };
+
+/* OS Timer is the wakeup source for PM mode 2 */
+&os_timer {
+	status = "okay";
+	wakeup-source;
+};
+
+&systick {
+	status = "disabled";
+};

--- a/dts/arm/nxp/nxp_rw6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rw6xx_common.dtsi
@@ -19,6 +19,7 @@
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
+		cpu-power-states = <&idle &suspend>;
 
 		cpu0: cpu@0 {
 			compatible = "arm,cortex-m33f";
@@ -29,6 +30,28 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";
 				reg = <0xe000ed90 0x40>;
+			};
+		};
+
+		power-states {
+			/* Idle mode maps to Power Mode 1 */
+			idle: idle {
+				compatible = "zephyr,power-state";
+				power-state-name = "runtime-idle";
+				min-residency-us = <0>;
+				exit-latency-us = <0>;
+			};
+			/* Suspend mode maps to Power Mode 2 */
+			suspend: suspend {
+				compatible = "nxp,pdcfg-power", "zephyr,power-state";
+				power-state-name = "suspend-to-idle";
+				min-residency-us = <500>;
+				exit-latency-us = <120>;
+				deep-sleep-config = <0x180000>,
+							<0x0>,
+							<0x4>,
+							<0x100>,
+							<0x0>;
 			};
 		};
 	};

--- a/dts/arm/nxp/nxp_rw6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rw6xx_common.dtsi
@@ -362,7 +362,6 @@
 		};
 	};
 
-
 	gau {
 		ranges = <>;
 		#address-cells = <1>;
@@ -391,6 +390,13 @@
 			status = "disabled";
 			#io-channel-cells = <0>;
 		};
+	};
+
+	os_timer: timers@13b000 {
+		compatible = "nxp,os-timer";
+		reg = <0x13b000 0x1000>;
+		interrupts = <41 0>;
+		status = "disabled";
 	};
 };
 

--- a/soc/nxp/rw/CMakeLists.txt
+++ b/soc/nxp/rw/CMakeLists.txt
@@ -7,6 +7,10 @@ zephyr_sources(
   flexspi_clock_setup.c
   )
 
+zephyr_sources_ifdef(CONFIG_PM
+  power.c
+  )
+
 zephyr_linker_sources_ifdef(CONFIG_NXP_RW6XX_BOOT_HEADER
   ROM_START SORT_KEY 0 boot_header.ld)
 

--- a/soc/nxp/rw/Kconfig
+++ b/soc/nxp/rw/Kconfig
@@ -17,6 +17,7 @@ config SOC_SERIES_RW6XX
 	select HAS_MCUX_FLEXCOMM
 	select INIT_SYS_PLL
 	select HAS_MCUX_CACHE
+	select HAS_PM
 
 if SOC_SERIES_RW6XX
 

--- a/soc/nxp/rw/Kconfig.defconfig
+++ b/soc/nxp/rw/Kconfig.defconfig
@@ -9,6 +9,13 @@ config ROM_START_OFFSET
 
 config NUM_IRQS
 	default 129
+if MCUX_OS_TIMER
+
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default 1000000
+
+endif # MCUX_OS_TIMER
+
 if CORTEX_M_SYSTICK
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC

--- a/soc/nxp/rw/power.c
+++ b/soc/nxp/rw/power.c
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/kernel.h>
+#include <zephyr/pm/pm.h>
+#include <zephyr/init.h>
+
+#include "fsl_power.h"
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
+
+/* Active mode */
+#define POWER_MODE0		0
+/* Idle mode */
+#define POWER_MODE1		1
+/* Standby mode */
+#define POWER_MODE2		2
+/* Sleep mode */
+#define POWER_MODE3		3
+/* Deep Sleep mode */
+#define POWER_MODE4		4
+
+#define NODE_ID DT_INST(0, nxp_pdcfg_power)
+
+power_sleep_config_t slp_cfg;
+
+/* Invoke Low Power/System Off specific Tasks */
+__weak void pm_state_set(enum pm_state state, uint8_t substate_id)
+{
+	ARG_UNUSED(substate_id);
+
+	/* Set PRIMASK */
+	__disable_irq();
+	/* Set BASEPRI to 0 */
+	irq_unlock(0);
+
+	switch (state) {
+	case PM_STATE_RUNTIME_IDLE:
+		POWER_SetSleepMode(POWER_MODE1);
+		__WFI();
+		break;
+	case PM_STATE_SUSPEND_TO_IDLE:
+		POWER_EnterPowerMode(POWER_MODE2, &slp_cfg);
+		break;
+	default:
+		LOG_DBG("Unsupported power state %u", state);
+		break;
+	}
+}
+
+/* Handle SOC specific activity after Low Power Mode Exit */
+__weak void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
+{
+	ARG_UNUSED(state);
+	ARG_UNUSED(substate_id);
+
+	/* Clear PRIMASK */
+	__enable_irq();
+}
+
+static int nxp_rw6xx_power_init(void)
+{
+	uint32_t suspend_sleepconfig[5] = DT_PROP_OR(NODE_ID, deep_sleep_config, {});
+
+	slp_cfg.pm2MemPuCfg = suspend_sleepconfig[0];
+	slp_cfg.pm2AnaPuCfg = suspend_sleepconfig[1];
+	slp_cfg.clkGate = suspend_sleepconfig[2];
+	slp_cfg.memPdCfg = suspend_sleepconfig[3];
+	slp_cfg.pm3BuckCfg = suspend_sleepconfig[4];
+
+	return 0;
+}
+
+SYS_INIT(nxp_rw6xx_power_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/soc/nxp/rw/soc.c
+++ b/soc/nxp/rw/soc.c
@@ -138,6 +138,10 @@ __ramfunc void clock_init(void)
 	/* Call function set_flexspi_clock() to set flexspi clock source to aux0_pll_clk in XIP. */
 	set_flexspi_clock(FLEXSPI, 2U, 2U);
 
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(os_timer), nxp_os_timer, okay)
+	CLOCK_AttachClk(kLPOSC_to_OSTIMER_CLK);
+#endif
+
 #if (DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(wwdt), nxp_lpc_wwdt, okay))
 	CLOCK_AttachClk(kLPOSC_to_WDT0_CLK);
 #else

--- a/soc/nxp/rw/soc.h
+++ b/soc/nxp/rw/soc.h
@@ -9,12 +9,18 @@
 #ifndef _ASMLANGUAGE
 #include <zephyr/sys/util.h>
 #include <fsl_common.h>
+#include "fsl_power.h"
 
 /* Add include for DTS generated information */
 #include <zephyr/devicetree.h>
 
 #endif /* !_ASMLANGUAGE */
 
+/* Wrapper Function to deal with SDK differences in power API */
+static inline void EnableDeepSleepIRQ(IRQn_Type irq)
+{
+	POWER_EnableWakeup(irq);
+}
 
 #ifdef CONFIG_MEMC
 int flexspi_clock_set_freq(uint32_t clock_name, uint32_t rate);

--- a/tests/subsys/pm/power_mgmt_soc/testcase.yaml
+++ b/tests/subsys/pm/power_mgmt_soc/testcase.yaml
@@ -10,6 +10,7 @@ tests:
       - nucleo_l476rg
       - twr_ke18f
       - mimxrt595_evk/mimxrt595s/cm33
+      - rd_rw612_bga
     tags: pm
     integration_platforms:
       - mec15xxevb_assy6853


### PR DESCRIPTION
Switch the system timer to use OS Timer.
Added SoC Power Management support for RW61X. This PR supports Power Modes 1 and 2.

Tested with OS Timer wakeup using the test `zephyr/tests/subsys/pm/power_mgmt_soc`