### PR TITLE
kernel: Predicate _cpus_active on CONFIG_PM

### DIFF
--- a/kernel/init.c
+++ b/kernel/init.c
@@ -46,8 +46,9 @@ BUILD_ASSERT(CONFIG_MP_NUM_CPUS == CONFIG_MP_MAX_NUM_CPUS,
 __pinned_bss
 struct z_kernel _kernel;
 
-__pinned_bss
-atomic_t _cpus_active;
+#ifdef CONFIG_PM
+__pinned_bss atomic_t _cpus_active;
+#endif
 
 /* init/main and idle threads */
 K_THREAD_PINNED_STACK_DEFINE(z_main_stack, CONFIG_MAIN_STACK_SIZE);
@@ -512,11 +513,13 @@ void z_init_cpu(int id)
 		CONFIG_SCHED_THREAD_USAGE_AUTO_ENABLE;
 #endif
 
+#ifdef CONFIG_PM
 	/*
 	 * Increment number of CPUs active. The pm subsystem
 	 * will keep track of this from here.
 	 */
 	atomic_inc(&_cpus_active);
+#endif
 
 #ifdef CONFIG_OBJ_CORE_SYSTEM
 	k_obj_core_init_and_link(K_OBJ_CORE(&_kernel.cpus[id]), &obj_type_cpu);


### PR DESCRIPTION
This value isn't used outside of the PM subsystem, so don't build it.

More important than the four bytes of .bss was the use of an atomic_inc().  Some platforms are forced to use
CONFIG_ATOMIC_OPERATIONS_C (but in almost all cases are single-core devices that won't use atomics at runtime).  There, this turns into a function call that pulls in the whole atomics implementation.