### PR TITLE
Add `DISK_IOCTL_CTRL_DEINIT` and `DISK_IOCTL_CTRL_INIT` macros to de-initialize and initialize a disk device

### DIFF
--- a/drivers/disk/flashdisk.c
+++ b/drivers/disk/flashdisk.c
@@ -405,6 +405,8 @@ static int disk_flash_access_ioctl(struct disk_info *disk, uint8_t cmd, void *bu
 		*(uint32_t *)buff = ctx->page_size / ctx->sector_size;
 		k_mutex_unlock(&ctx->lock);
 		return 0;
+	case DISK_IOCTL_CTRL_INIT:
+		return disk_flash_access_init(disk);
 	default:
 		break;
 	}

--- a/drivers/disk/flashdisk.c
+++ b/drivers/disk/flashdisk.c
@@ -389,6 +389,7 @@ static int disk_flash_access_ioctl(struct disk_info *disk, uint8_t cmd, void *bu
 	ctx = CONTAINER_OF(disk, struct flashdisk_data, info);
 
 	switch (cmd) {
+	case DISK_IOCTL_CTRL_DEINIT:
 	case DISK_IOCTL_CTRL_SYNC:
 		k_mutex_lock(&ctx->lock, K_FOREVER);
 		rc = flashdisk_cache_commit(ctx);

--- a/drivers/disk/loopback_disk.c
+++ b/drivers/disk/loopback_disk.c
@@ -107,6 +107,7 @@ static int loopback_disk_access_ioctl(struct disk_info *disk, uint8_t cmd, void 
 		*(uint32_t *)buff = LOOPBACK_SECTOR_SIZE;
 		return 0;
 	}
+	case DISK_IOCTL_CTRL_DEINIT:
 	case DISK_IOCTL_CTRL_SYNC:
 		return fs_sync(&ctx->file);
 	case DISK_IOCTL_CTRL_INIT:

--- a/drivers/disk/loopback_disk.c
+++ b/drivers/disk/loopback_disk.c
@@ -22,10 +22,6 @@ static inline struct loopback_disk_access *get_ctx(struct disk_info *info)
 	return CONTAINER_OF(info, struct loopback_disk_access, info);
 }
 
-static int loopback_disk_access_init(struct disk_info *disk)
-{
-	return 0;
-}
 static int loopback_disk_access_status(struct disk_info *disk)
 {
 	return DISK_STATUS_OK;
@@ -113,9 +109,15 @@ static int loopback_disk_access_ioctl(struct disk_info *disk, uint8_t cmd, void 
 	}
 	case DISK_IOCTL_CTRL_SYNC:
 		return fs_sync(&ctx->file);
+	case DISK_IOCTL_CTRL_INIT:
+		return 0;
 	default:
 		return -ENOTSUP;
 	}
+}
+static int loopback_disk_access_init(struct disk_info *disk)
+{
+	return loopback_disk_access_ioctl(disk, DISK_IOCTL_CTRL_INIT, NULL);
 }
 
 static const struct disk_operations loopback_disk_operations = {

--- a/drivers/disk/mmc_subsys.c
+++ b/drivers/disk/mmc_subsys.c
@@ -85,6 +85,13 @@ static int disk_mmc_access_ioctl(struct disk_info *disk, uint8_t cmd, void *buf)
 	switch (cmd) {
 	case DISK_IOCTL_CTRL_INIT:
 		return disk_mmc_access_init(disk);
+	case DISK_IOCTL_CTRL_DEINIT:
+		mmc_ioctl(&data->card, DISK_IOCTL_CTRL_SYNC, NULL);
+		/* sd_init() will toggle power to MMC, so we can just mark
+		 * disk as uninitialized
+		 */
+		data->status = SD_UNINIT;
+		return 0;
 	default:
 		return mmc_ioctl(&data->card, cmd, buf);
 	}

--- a/drivers/disk/mmc_subsys.c
+++ b/drivers/disk/mmc_subsys.c
@@ -38,11 +38,6 @@ static int disk_mmc_access_init(struct disk_info *disk)
 	struct mmc_data *data = dev->data;
 	int ret;
 
-	if (data->status == SD_OK) {
-		/* Called twice, don't reinit */
-		return 0;
-	}
-
 	ret = sd_init(cfg->host_controller, &data->card);
 	if (ret) {
 		data->status = SD_ERROR;

--- a/drivers/disk/mmc_subsys.c
+++ b/drivers/disk/mmc_subsys.c
@@ -82,7 +82,14 @@ static int disk_mmc_access_ioctl(struct disk_info *disk, uint8_t cmd, void *buf)
 	const struct device *dev = disk->dev;
 	struct mmc_data *data = dev->data;
 
-	return mmc_ioctl(&data->card, cmd, buf);
+	switch (cmd) {
+	case DISK_IOCTL_CTRL_INIT:
+		return disk_mmc_access_init(disk);
+	default:
+		return mmc_ioctl(&data->card, cmd, buf);
+	}
+
+	return 0;
 }
 
 static const struct disk_operations mmc_disk_ops = {

--- a/drivers/disk/nvme/nvme_disk.c
+++ b/drivers/disk/nvme/nvme_disk.c
@@ -178,6 +178,7 @@ static int nvme_disk_ioctl(struct disk_info *disk, uint8_t cmd, void *buff)
 		*(uint32_t *)buff = nvme_namespace_get_sector_size(ns);
 
 		break;
+	case DISK_IOCTL_CTRL_DEINIT:
 	case DISK_IOCTL_CTRL_SYNC:
 		ret = nvme_disk_flush(ns);
 		break;

--- a/drivers/disk/nvme/nvme_disk.c
+++ b/drivers/disk/nvme/nvme_disk.c
@@ -11,11 +11,6 @@ LOG_MODULE_DECLARE(nvme, CONFIG_NVME_LOG_LEVEL);
 
 #include "nvme.h"
 
-static int nvme_disk_init(struct disk_info *disk)
-{
-	return 0;
-}
-
 static int nvme_disk_status(struct disk_info *disk)
 {
 	return 0;
@@ -186,12 +181,20 @@ static int nvme_disk_ioctl(struct disk_info *disk, uint8_t cmd, void *buff)
 	case DISK_IOCTL_CTRL_SYNC:
 		ret = nvme_disk_flush(ns);
 		break;
+	case DISK_IOCTL_CTRL_INIT:
+		ret = 0;
+		break;
 	default:
 		ret = -EINVAL;
 	}
 
 	nvme_unlock(disk->dev);
 	return ret;
+}
+
+static int nvme_disk_init(struct disk_info *disk)
+{
+	return nvme_disk_ioctl(disk, DISK_IOCTL_CTRL_INIT, NULL);
 }
 
 static const struct disk_operations nvme_disk_ops = {

--- a/drivers/disk/ramdisk.c
+++ b/drivers/disk/ramdisk.c
@@ -94,6 +94,7 @@ static int disk_ram_access_ioctl(struct disk_info *disk, uint8_t cmd, void *buff
 		*(uint32_t *)buff  = 1U;
 		break;
 	case DISK_IOCTL_CTRL_INIT:
+	case DISK_IOCTL_CTRL_DEINIT:
 		break;
 	default:
 		return -EINVAL;

--- a/drivers/disk/ramdisk.c
+++ b/drivers/disk/ramdisk.c
@@ -41,11 +41,6 @@ static int disk_ram_access_status(struct disk_info *disk)
 	return DISK_STATUS_OK;
 }
 
-static int disk_ram_access_init(struct disk_info *disk)
-{
-	return 0;
-}
-
 static int disk_ram_access_read(struct disk_info *disk, uint8_t *buff,
 				uint32_t sector, uint32_t count)
 {
@@ -98,11 +93,18 @@ static int disk_ram_access_ioctl(struct disk_info *disk, uint8_t cmd, void *buff
 	case DISK_IOCTL_GET_ERASE_BLOCK_SZ:
 		*(uint32_t *)buff  = 1U;
 		break;
+	case DISK_IOCTL_CTRL_INIT:
+		break;
 	default:
 		return -EINVAL;
 	}
 
 	return 0;
+}
+
+static int disk_ram_access_init(struct disk_info *disk)
+{
+	return disk_ram_access_ioctl(disk, DISK_IOCTL_CTRL_INIT, NULL);
 }
 
 static int disk_ram_init(const struct device *dev)

--- a/drivers/disk/sdmmc_stm32.c
+++ b/drivers/disk/sdmmc_stm32.c
@@ -265,10 +265,6 @@ static int stm32_sdmmc_access_init(struct disk_info *disk)
 	struct stm32_sdmmc_priv *priv = dev->data;
 	int err;
 
-	if (priv->status == DISK_STATUS_OK) {
-		return 0;
-	}
-
 	if (priv->status == DISK_STATUS_NOMEDIA) {
 		return -ENODEV;
 	}

--- a/drivers/disk/sdmmc_stm32.c
+++ b/drivers/disk/sdmmc_stm32.c
@@ -307,14 +307,18 @@ static int stm32_sdmmc_access_init(struct disk_info *disk)
 	return 0;
 }
 
-#if !defined(CONFIG_SDMMC_STM32_EMMC)
-static void stm32_sdmmc_access_deinit(struct stm32_sdmmc_priv *priv)
+static int stm32_sdmmc_access_deinit(struct stm32_sdmmc_priv *priv)
 {
+#if defined(CONFIG_SDMMC_STM32_EMMC)
+	HAL_MMC_DeInit(&priv->hsd);
+#else
 	HAL_SD_DeInit(&priv->hsd);
 
 	stm32_sdmmc_clock_disable(priv);
-}
 #endif
+	priv->status = DISK_STATUS_UNINIT;
+	return 0;
+}
 
 static int stm32_sdmmc_access_status(struct disk_info *disk)
 {
@@ -483,6 +487,8 @@ static int stm32_sdmmc_access_ioctl(struct disk_info *disk, uint8_t cmd,
 		break;
 	case DISK_IOCTL_CTRL_INIT:
 		return stm32_sdmmc_access_init(disk);
+	case DISK_IOCTL_CTRL_DEINIT:
+		return stm32_sdmmc_access_deinit(priv);
 	default:
 		return -EINVAL;
 	}

--- a/drivers/disk/sdmmc_stm32.c
+++ b/drivers/disk/sdmmc_stm32.c
@@ -481,6 +481,8 @@ static int stm32_sdmmc_access_ioctl(struct disk_info *disk, uint8_t cmd,
 	case DISK_IOCTL_CTRL_SYNC:
 		/* we use a blocking API, so nothing to do for sync */
 		break;
+	case DISK_IOCTL_CTRL_INIT:
+		return stm32_sdmmc_access_init(disk);
 	default:
 		return -EINVAL;
 	}

--- a/drivers/disk/sdmmc_subsys.c
+++ b/drivers/disk/sdmmc_subsys.c
@@ -37,11 +37,6 @@ static int disk_sdmmc_access_init(struct disk_info *disk)
 	struct sdmmc_data *data = dev->data;
 	int ret;
 
-	if (data->status == SD_OK) {
-		/* Called twice, don't reinit */
-		return 0;
-	}
-
 	if (!sd_is_card_present(cfg->host_controller)) {
 		return DISK_STATUS_NOMEDIA;
 	}

--- a/drivers/disk/sdmmc_subsys.c
+++ b/drivers/disk/sdmmc_subsys.c
@@ -89,7 +89,13 @@ static int disk_sdmmc_access_ioctl(struct disk_info *disk, uint8_t cmd, void *bu
 	const struct device *dev = disk->dev;
 	struct sdmmc_data *data = dev->data;
 
-	return sdmmc_ioctl(&data->card, cmd, buf);
+	case DISK_IOCTL_CTRL_INIT:
+		return disk_sdmmc_access_init(disk);
+	default:
+		return sdmmc_ioctl(&data->card, cmd, buf);
+	}
+
+	return 0;
 }
 
 static const struct disk_operations sdmmc_disk_ops = {

--- a/drivers/disk/sdmmc_subsys.c
+++ b/drivers/disk/sdmmc_subsys.c
@@ -89,8 +89,16 @@ static int disk_sdmmc_access_ioctl(struct disk_info *disk, uint8_t cmd, void *bu
 	const struct device *dev = disk->dev;
 	struct sdmmc_data *data = dev->data;
 
+	switch (cmd) {
 	case DISK_IOCTL_CTRL_INIT:
 		return disk_sdmmc_access_init(disk);
+	case DISK_IOCTL_CTRL_DEINIT:
+		sdmmc_ioctl(&data->card, DISK_IOCTL_CTRL_SYNC, NULL);
+		/* sd_init() will toggle power to SDMMC, so we can just mark
+		 * disk as uninitialized
+		 */
+		data->status = SD_UNINIT;
+		return 0;
 	default:
 		return sdmmc_ioctl(&data->card, cmd, buf);
 	}

--- a/include/zephyr/drivers/disk.h
+++ b/include/zephyr/drivers/disk.h
@@ -55,6 +55,18 @@ extern "C" {
  * device
  */
 #define DISK_IOCTL_CTRL_INIT			6
+/** Deinitialize the disk. This IOCTL can be used to de-initialize the disk,
+ * enabling it to be removed from the system if the disk is hot-pluggable.
+ * Disk usage is reference counted, so for a given disk the
+ * `DISK_IOCTL_CTRL_DEINIT` IOCTL must be issued as many times as the
+ * `DISK_IOCTL_CTRL_INIT` IOCTL was issued in order to de-initialize it.
+ *
+ * This macro optionally accepts a pointer to a boolean as the `buf` parameter,
+ * which if true indicates the disk should be forcibly stopped, ignoring all
+ * reference counts. The disk driver must report success if a forced stop is
+ * requested, but this operation is inherently unsafe.
+ */
+#define DISK_IOCTL_CTRL_DEINIT			7
 
 /**
  * @brief Possible return bitmasks for disk_status()

--- a/include/zephyr/drivers/disk.h
+++ b/include/zephyr/drivers/disk.h
@@ -49,6 +49,12 @@ extern "C" {
 #define DISK_IOCTL_GET_ERASE_BLOCK_SZ		4
 /** Commit any cached read/writes to disk */
 #define DISK_IOCTL_CTRL_SYNC			5
+/** Initialize the disk. This IOCTL must be issued before the disk can be
+ * used for I/O. It is reference counted, so only the first successful
+ * invocation of this macro on an uninitialized disk will initialize the IO
+ * device
+ */
+#define DISK_IOCTL_CTRL_INIT			6
 
 /**
  * @brief Possible return bitmasks for disk_status()

--- a/include/zephyr/drivers/disk.h
+++ b/include/zephyr/drivers/disk.h
@@ -77,6 +77,8 @@ struct disk_info {
 	const struct disk_operations *ops;
 	/** Device associated to this disk */
 	const struct device *dev;
+	/** Internally used disk reference count */
+	uint16_t refcnt;
 };
 
 /**

--- a/include/zephyr/storage/disk_access.h
+++ b/include/zephyr/storage/disk_access.h
@@ -44,7 +44,8 @@ extern "C" {
  * @ref disk_access_ioctl with the IOCTL @ref DISK_IOCTL_CTRL_INIT.
  *
  * Disk initialization is reference counted, so only the first successful call
- * to initialize a uninitialized disk will actually initialize the disk
+ * to initialize a uninitialized (or previously de-initialized) disk will
+ * actually initialize the disk
  *
  * @param[in] pdrv          Disk name
  *

--- a/include/zephyr/storage/disk_access.h
+++ b/include/zephyr/storage/disk_access.h
@@ -41,6 +41,9 @@ extern "C" {
  * This call is made by the consumer before doing any IO calls so that the
  * disk or the backing device can do any initialization.
  *
+ * Disk initialization is reference counted, so only the first successful call
+ * to initialize a uninitialized disk will actually initialize the disk
+ *
  * @param[in] pdrv          Disk name
  *
  * @return 0 on success, negative errno code on fail

--- a/include/zephyr/storage/disk_access.h
+++ b/include/zephyr/storage/disk_access.h
@@ -39,7 +39,9 @@ extern "C" {
  * @brief perform any initialization
  *
  * This call is made by the consumer before doing any IO calls so that the
- * disk or the backing device can do any initialization.
+ * disk or the backing device can do any initialization. Although still
+ * supported for legacy compatibility, users should instead call
+ * @ref disk_access_ioctl with the IOCTL @ref DISK_IOCTL_CTRL_INIT.
  *
  * Disk initialization is reference counted, so only the first successful call
  * to initialize a uninitialized disk will actually initialize the disk

--- a/modules/fatfs/zfs_diskio.c
+++ b/modules/fatfs/zfs_diskio.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018-2021 Zephyr contributors
  * Copyright (c) 2022 Nordic Semiconductor ASA
+ * Copyright 2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -12,6 +13,7 @@
  */
 #include <ff.h>
 #include <diskio.h>	/* FatFs lower layer API */
+#include <zfs_diskio.h> /* Zephyr specific FatFS API */
 #include <zephyr/storage/disk_access.h>
 
 static const char * const pdrv_str[] = {FF_VOLUME_STRS};
@@ -31,13 +33,9 @@ DSTATUS disk_status(BYTE pdrv)
 /* Initialize a Drive */
 DSTATUS disk_initialize(BYTE pdrv)
 {
-	__ASSERT(pdrv < ARRAY_SIZE(pdrv_str), "pdrv out-of-range\n");
+	uint8_t param = DISK_IOCTL_POWER_ON;
 
-	if (disk_access_init(pdrv_str[pdrv]) != 0) {
-		return STA_NOINIT;
-	} else {
-		return RES_OK;
-	}
+	return disk_ioctl(pdrv, CTRL_POWER, &param);
 }
 
 /* Read Sector(s) */
@@ -106,6 +104,27 @@ DRESULT disk_ioctl(BYTE pdrv, BYTE cmd, void *buff)
 		if (disk_access_ioctl(pdrv_str[pdrv],
 				DISK_IOCTL_GET_ERASE_BLOCK_SZ, buff) != 0) {
 			ret = RES_ERROR;
+		}
+		break;
+
+	/* Optional IOCTL command used by Zephyr fs_unmount implementation,
+	 * not called by FATFS
+	 */
+	case CTRL_POWER:
+		if (((*(uint8_t *)buff)) == DISK_IOCTL_POWER_OFF) {
+			/* Power disk off */
+			if (disk_access_ioctl(pdrv_str[pdrv],
+					      DISK_IOCTL_CTRL_DEINIT,
+					      NULL) != 0) {
+				ret = RES_ERROR;
+			}
+		} else {
+			/* Power disk on */
+			if (disk_access_ioctl(pdrv_str[pdrv],
+					      DISK_IOCTL_CTRL_INIT,
+					      NULL) != 0) {
+				ret = STA_NOINIT;
+			}
 		}
 		break;
 

--- a/modules/fatfs/zfs_diskio.h
+++ b/modules/fatfs/zfs_diskio.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_MODULES_FATFS_ZFS_DISKIO_H_
+#define ZEPHYR_MODULES_FATFS_ZFS_DISKIO_H_
+/*
+ * Header file for Zephyr specific portions of the FatFS disk interface.
+ * These APIs are internal to Zephyr's FatFS VFS implementation
+ */
+
+/*
+ * Values that can be passed to buffer pointer used by disk_ioctl() when
+ * sending CTRL_POWER IOCTL
+ */
+#define DISK_IOCTL_POWER_OFF 0x0
+#define DISK_IOCTL_POWER_ON 0x1
+
+
+#endif /* ZEPHYR_MODULES_FATFS_ZFS_DISKIO_H_ */


### PR DESCRIPTION
## Introduction

This is relatively simple change to the disk access API- it introduces two new IOCTL command codes:
- `DISK_IOCTL_CTRL_INIT`: initialize the disk, functionally equivalent to calling `disk_access_init`
- `DISK_IOCTL_CTRL_DEINIT`: de-initialize the disk. After this point the disk can be reinitialized via `disk_access_ioctl(disk, DISK_IOCTL_CTRL_INIT, NULL)` (or via `disk_access_init`)

### Problem description

Currently there is no way to explicitly de-initialize a disk device. This causes issues for devices like SD cards, which are inherently hot-pluggable. Moreover, some applications may wish to power off the SD card device when not using it (which would require first de-initializing it). Providing a method to do so via the disk access API allows users to realize additional power savings, or safely remove a hot-pluggable device such as an SD card from their board

### Dependencies

In order to make use of this API effectively, `fs_unmount` implementations for filesystems must be updated to take advantage of the new IOCTL calls. I have already made these changes for the FATFS filesystem implementation within this PR, but other filesystem implementations will need to be changed in order to use this feature

### Concerns and Unresolved Questions

The introduction of `DISK_IOCTL_CTRL_INIT` makes the `disk_access_init` API call redundant. However, given that the disk access API is stable I think that this redundancy does not clear the bar for a stable API change. If we'd like to do so, the primary benefit would be one less field in the API structure for each disk driver.

The other concern I have is if we need to provide a method for users to explicitly request a disk *not* be unmounted when calling `fs_unmount`. I think it is ok if `fs_unmount` implicitly de-initializes a disk device, since from what I can tell we do not support multiple partitions being present on one disk device (so if a filesystem is unmounted the disk should be de-initialized as well). However, this may not always be the case in the future.