### PR TITLE
arch/xtensa: Add automatic vector linkage generation

### DIFF
--- a/arch/xtensa/core/CMakeLists.txt
+++ b/arch/xtensa/core/CMakeLists.txt
@@ -103,3 +103,11 @@ add_custom_command(
 
 add_custom_target(xtensa_handlers_h DEPENDS ${HANDLERS}.h)
 add_dependencies(zephyr_interface xtensa_handlers_h)
+
+# Auto-generate interrupt vector entry
+set(VECS_LD ${CMAKE_BINARY_DIR}/zephyr/include/generated/xtensa_vectors.ld)
+add_custom_command(OUTPUT ${VECS_LD} DEPENDS ${CORE_ISA_DM}
+  COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/gen_vectors.py
+          ${CORE_ISA_DM} > ${VECS_LD})
+add_custom_target(xtensa_vectors_ld DEPENDS ${VECS_LD})
+add_dependencies(zephyr_interface xtensa_vectors_ld)

--- a/arch/xtensa/core/gen_vectors.py
+++ b/arch/xtensa/core/gen_vectors.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# Copyright 2023 The ChromiumOS Authors
+# SPDX-License-Identifier: Apache-2.0
+import sys
+import re
+
+# Xtensa Vector Table linker generator
+#
+# Takes a pre-processed (gcc -dM) core-isa.h file as its first
+# argument, and emits a GNU linker section declartion which will
+# correctly load the exception vectors and literals as long as their
+# code is declared using standard conventions (see below).
+#
+# The section name will be ".z_xtensa_vectors", and a symbol
+# "z_xtensa_vecbase" is emitted containing a valid value for the
+# VECBASE SR at runtime.
+#
+# Obviously, this requires that XCHAL_HAVE_VECBASE=1.  A similar trick
+# could be played to load vectors at fixed addresses on hardware that
+# lacks VECBASE, but the core-isa.h interface is inexplicably
+# different.
+#
+# Because the "standard conventions" (which descend from somewhere in
+# Cadence) are not documented anywhere and just end up cut and pasted
+# between devices, here's an attempt at a specification:
+#
+# + The six register window exception vectors are defined with offsets
+#   internal to their assembly code.  They are linked in a single
+#   section named ".WindowVectors.text".
+#
+# + The "kernel", "user" and "double exception" vectors are emitted in
+#   sections named ".KernelExceptionVector.text",
+#   "UserExceptionVector.text" and "DoubleExceptionVector.text"
+#   respectively.
+#
+# + XEA2 interrupt vectors are in sections named
+#   ".Level<n>InterruptVector.text", except (!) for ones which are
+#   given special names.  The "debug" and "NMI" interrupts (if they
+#   exist) are technically implemented as standard interrupt vectors
+#   (of a platform-dependent level), but the code for them is emitted
+#   in ".DebugExceptionVector.text" and ".NMIExceptionVector.text",
+#   and not a section corresponding to their interrupt level.
+#
+# + Any unused bytes at the end of a vector are made available as
+#   storage for immediate values used by the following vector (Xtensa
+#   can only back-reference immediates for MOVI/L32R instructions) as
+#   a "<name>Vector.literal" section.  Note that there is no guarantee
+#   of how much space is available, it depends on the previous
+#   vector's code size.  Zephyr code has historically not used this
+#   space, as support in existing linker scripts is inconsistent.  But
+#   it's exposed here.
+
+coreisa = sys.argv[1]
+
+debug_level = 0
+
+# Translation for the core-isa.h vs. linker section naming conventions
+sect_names = { "DOUBLEEXC" : "DoubleException",
+               "KERNEL" : "KernelException",
+               "NMI" : "NMIException",
+               "USER" : "UserException" }
+
+offsets = {}
+
+with open(coreisa) as infile:
+    for line in infile.readlines():
+        m = re.match(r"^#define\s+XCHAL_([^ ]+)_VECOFS\s*(.*)", line.rstrip())
+        if m:
+            (sym, val) = (m.group(1), m.group(2))
+            if sym == "WINDOW_OF4":
+                # This must be the start of the section
+                assert eval(val) == 0
+            elif sym.startswith("WINDOW"):
+                # Ignore the other window exceptions, they're internally sorted
+                pass
+            elif sym == "RESET":
+                # Ignore, not actually part of the vector table
+                pass
+            elif sym == "DEBUG":
+                # This one is a recursive macro that doesn't expand,
+                # so handle manually
+                m = re.match(r"XCHAL_INTLEVEL(\d+)_VECOFS", val)
+                if not m:
+                    print(f"no intlevel match for debug val {val}")
+                assert m
+                debug_level = eval(m.group(1))
+            else:
+                if val == "XCHAL_NMI_VECOFS":
+                    # This gets recursively defined in the other
+                    # direction, so ignore the INTLEVEL
+                    pass
+                else:
+                    addr = eval(val)
+                    m = re.match(r"^INTLEVEL(\d+)", sym)
+                    if m:
+                        offsets[f"Level{m.group(1)}Interrupt"] = addr
+                    else:
+                        offsets[sect_names[sym]] = addr
+
+if debug_level > 0:
+    old = f"Level{debug_level}Interrupt"
+    offsets[f"DebugException"] = offsets[old]
+    del offsets[old]
+
+sects = list(offsets)
+sects.sort(key=lambda s: offsets[s])
+
+print("/* Automatically Generated Code - Do Not Edit */")
+print("/* See arch/xtensa/core/gen_vector.py */")
+print("")
+
+# The 1k alignment is experimental, the docs on the Relocatable Vector
+# Option doesn't specify an alignment at all, but writes to the
+# bottom bits don't take...
+print( "  .z_xtensa_vectors : ALIGN(1024) {")
+print( "    z_xtensa_vecbase = .;")
+print(f"    KEEP(*(.WindowVectors.text));")
+for s in sects:
+    print(f"    KEEP(*(.{s}Vector.literal));")
+    print( "    . = 0x%3.3x;" % (offsets[s]))
+    print(f"    KEEP(*(.{s}Vector.text));")
+print("  }")

--- a/soc/cdns/dc233c/include/xtensa-dc233c.ld
+++ b/soc/cdns/dc233c/include/xtensa-dc233c.ld
@@ -45,25 +45,7 @@
 
 MEMORY
 {
-  sram0_0_seg  : org = 0x00002000, len = 0x178
-  sram0_1_seg  : org = 0x00002178, len = 0x8
-  sram0_2_seg  : org = 0x00002180, len = 0x38
-  sram0_3_seg  : org = 0x000021B8, len = 0x8
-  sram0_4_seg  : org = 0x000021C0, len = 0x38
-  sram0_5_seg  : org = 0x000021F8, len = 0x8
-  sram0_6_seg  : org = 0x00002200, len = 0x38
-  sram0_7_seg  : org = 0x00002238, len = 0x8
-  sram0_8_seg  : org = 0x00002240, len = 0x38
-  sram0_9_seg  : org = 0x00002278, len = 0x8
-  sram0_10_seg : org = 0x00002280, len = 0x38
-  sram0_11_seg : org = 0x000022B8, len = 0x8
-  sram0_12_seg : org = 0x000022C0, len = 0x38
-  sram0_13_seg : org = 0x000022F8, len = 0x8
-  sram0_14_seg : org = 0x00002300, len = 0x38
-  sram0_15_seg : org = 0x00002338, len = 0x8
-  sram0_16_seg : org = 0x00002340, len = 0x38
-  sram0_17_seg : org = 0x00002378, len = 0x48
-  sram0_18_seg : org = 0x000023C0, len = 0x40
+  vectors : org = 0x00002000, len = 0x2400
 #ifdef CONFIG_XTENSA_MMU
   vec_helpers  : org = 0x00002400, len = (PHYS_RAM_ADDR - 0x00002400)
 #endif
@@ -87,26 +69,7 @@ MEMORY
 
 PHDRS
 {
-  sram0_0_phdr PT_LOAD;
-  sram0_1_phdr PT_LOAD;
-  sram0_2_phdr PT_LOAD;
-  sram0_3_phdr PT_LOAD;
-  sram0_4_phdr PT_LOAD;
-  sram0_5_phdr PT_LOAD;
-  sram0_6_phdr PT_LOAD;
-  sram0_7_phdr PT_LOAD;
-  sram0_8_phdr PT_LOAD;
-  sram0_9_phdr PT_LOAD;
-  sram0_10_phdr PT_LOAD;
-  sram0_11_phdr PT_LOAD;
-  sram0_12_phdr PT_LOAD;
-  sram0_13_phdr PT_LOAD;
-  sram0_14_phdr PT_LOAD;
-  sram0_15_phdr PT_LOAD;
-  sram0_16_phdr PT_LOAD;
-  sram0_17_phdr PT_LOAD;
-  sram0_18_phdr PT_LOAD;
-
+  vectors_phdr PT_LOAD;
 #ifdef CONFIG_XTENSA_MMU
   vec_helpers_phdr PT_LOAD;
 #endif
@@ -154,138 +117,9 @@ SECTIONS
 #include <zephyr/linker/intlist.ld>
 #endif
 
-  .WindowVectors.text : ALIGN(4)
-  {
-    _WindowVectors_text_start = ABSOLUTE(.);
-    KEEP (*(.WindowVectors.text))
-    _WindowVectors_text_end = ABSOLUTE(.);
-  } >sram0_0_seg :sram0_0_phdr
-
-  .Level2InterruptVector.literal : ALIGN(4)
-  {
-    _Level2InterruptVector_literal_start = ABSOLUTE(.);
-    *(.Level2InterruptVector.literal)
-    _Level2InterruptVector_literal_end = ABSOLUTE(.);
-  } >sram0_1_seg :sram0_1_phdr
-
-  .Level2InterruptVector.text : ALIGN(4)
-  {
-    _Level2InterruptVector_text_start = ABSOLUTE(.);
-    KEEP (*(.Level2InterruptVector.text))
-    _Level2InterruptVector_text_end = ABSOLUTE(.);
-  } >sram0_2_seg :sram0_2_phdr
-
-  .Level3InterruptVector.literal : ALIGN(4)
-  {
-    _Level3InterruptVector_literal_start = ABSOLUTE(.);
-    *(.Level3InterruptVector.literal)
-    _Level3InterruptVector_literal_end = ABSOLUTE(.);
-  } >sram0_3_seg :sram0_3_phdr
-
-  .Level3InterruptVector.text : ALIGN(4)
-  {
-    _Level3InterruptVector_text_start = ABSOLUTE(.);
-    KEEP (*(.Level3InterruptVector.text))
-    _Level3InterruptVector_text_end = ABSOLUTE(.);
-  } >sram0_4_seg :sram0_4_phdr
-
-  .Level4InterruptVector.literal : ALIGN(4)
-  {
-    _Level4InterruptVector_literal_start = ABSOLUTE(.);
-    *(.Level4InterruptVector.literal)
-    _Level4InterruptVector_literal_end = ABSOLUTE(.);
-  } >sram0_5_seg :sram0_5_phdr
-
-  .Level4InterruptVector.text : ALIGN(4)
-  {
-    _Level4InterruptVector_text_start = ABSOLUTE(.);
-    KEEP (*(.Level4InterruptVector.text))
-    _Level4InterruptVector_text_end = ABSOLUTE(.);
-  } >sram0_6_seg :sram0_6_phdr
-
-  .Level5InterruptVector.literal : ALIGN(4)
-  {
-    _Level5InterruptVector_literal_start = ABSOLUTE(.);
-    *(.Level5InterruptVector.literal)
-    _Level5InterruptVector_literal_end = ABSOLUTE(.);
-  } >sram0_7_seg :sram0_7_phdr
-
-  .Level5InterruptVector.text : ALIGN(4)
-  {
-    _Level5InterruptVector_text_start = ABSOLUTE(.);
-    KEEP (*(.Level5InterruptVector.text))
-    _Level5InterruptVector_text_end = ABSOLUTE(.);
-  } >sram0_8_seg :sram0_8_phdr
-
-  .DebugExceptionVector.literal : ALIGN(4)
-  {
-    _DebugExceptionVector_literal_start = ABSOLUTE(.);
-    *(.DebugExceptionVector.literal)
-    _DebugExceptionVector_literal_end = ABSOLUTE(.);
-  } >sram0_9_seg :sram0_9_phdr
-
-  .DebugExceptionVector.text : ALIGN(4)
-  {
-    _DebugExceptionVector_text_start = ABSOLUTE(.);
-    KEEP (*(.DebugExceptionVector.text))
-    _DebugExceptionVector_text_end = ABSOLUTE(.);
-  } >sram0_10_seg :sram0_10_phdr
-
-  .NMIExceptionVector.literal : ALIGN(4)
-  {
-    _NMIExceptionVector_literal_start = ABSOLUTE(.);
-    *(.NMIExceptionVector.literal)
-    _NMIExceptionVector_literal_end = ABSOLUTE(.);
-  } >sram0_11_seg :sram0_11_phdr
-
-  .NMIExceptionVector.text : ALIGN(4)
-  {
-    _NMIExceptionVector_text_start = ABSOLUTE(.);
-    KEEP (*(.NMIExceptionVector.text))
-    _NMIExceptionVector_text_end = ABSOLUTE(.);
-  } >sram0_12_seg :sram0_12_phdr
-
-  .KernelExceptionVector.literal : ALIGN(4)
-  {
-    _KernelExceptionVector_literal_start = ABSOLUTE(.);
-    *(.KernelExceptionVector.literal)
-    _KernelExceptionVector_literal_end = ABSOLUTE(.);
-  } >sram0_13_seg :sram0_13_phdr
-
-  .KernelExceptionVector.text : ALIGN(4)
-  {
-    _KernelExceptionVector_text_start = ABSOLUTE(.);
-    KEEP (*(.KernelExceptionVector.text))
-    _KernelExceptionVector_text_end = ABSOLUTE(.);
-  } >sram0_14_seg :sram0_14_phdr
-
-  .UserExceptionVector.literal : ALIGN(4)
-  {
-    _UserExceptionVector_literal_start = ABSOLUTE(.);
-    *(.UserExceptionVector.literal)
-    _UserExceptionVector_literal_end = ABSOLUTE(.);
-  } >sram0_15_seg :sram0_15_phdr
-
-  .UserExceptionVector.text : ALIGN(4)
-  {
-    _UserExceptionVector_text_start = ABSOLUTE(.);
-    KEEP (*(.UserExceptionVector.text))
-    _UserExceptionVector_text_end = ABSOLUTE(.);
-  } >sram0_16_seg :sram0_16_phdr
-
-  .DoubleExceptionVector.literal : ALIGN(4)
-  {
-    _DoubleExceptionVector_literal_start = ABSOLUTE(.);
-    *(.DoubleExceptionVector.literal)
-    _DoubleExceptionVector_literal_end = ABSOLUTE(.);
-  } >sram0_17_seg :sram0_17_phdr
-
-  .DoubleExceptionVector.text : ALIGN(4)
-  {
-    _DoubleExceptionVector_text_start = ABSOLUTE(.);
-    KEEP (*(.DoubleExceptionVector.text))
-    _DoubleExceptionVector_text_end = ABSOLUTE(.);
-  } >sram0_18_seg :sram0_18_phdr
+/* Auto-generated vector linkage, to "vectors" memory region */
+#include <xtensa_vectors.ld>
+ >vectors :vectors_phdr
 
 #define LIB_OBJ_FUNC_IN_SECT(library, obj_file, func)		\
 	*##library##:##obj_file##(.literal.##func .text.##func)	\


### PR DESCRIPTION
Existing solutions for linking the Xtensa vector table are a cut-and-paste mess of inherited code, with more than a dozen special sections that need to be linked into many special MEMORY{} regions.

Accept the existing convention used by C/asm code, but automatically detect the needed offsets for the platform from core-isa.h (it can share the preprocessing with gen_zsr.py) and emit a file that can be included in lieu of all the existing boilerplate. 