### PR TITLE
sd: sd_ops: remove additional unlock call within card_read()

### DIFF
--- a/subsys/sd/sd_ops.c
+++ b/subsys/sd/sd_ops.c
@@ -535,7 +535,6 @@ static int card_read(struct sd_card *card, uint8_t *rbuf, uint32_t start_block, 
 	ret = sdmmc_wait_ready(card);
 	if (ret) {
 		LOG_ERR("Card did not return to ready state");
-		k_mutex_unlock(&card->lock);
 		return -ETIMEDOUT;
 	}
 	return 0;


### PR DESCRIPTION
SD ops card_read() implementation does not need to unlock mutex, as this is managed by the calling function card_write_blocks. Remove this stray k_mutex_unlock() call.

Fixes #72287