### PR TITLE
MAINTAINERS: update Synopsys platform entry

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3154,6 +3154,9 @@ Synopsys Platforms:
     - soc/snps/
     - boards/snps/
     - samples/boards/arc_secure_services/
+    - scripts/west_commands/runners/mdb.py
+    - scripts/west_commands/tests/test_mdb.py
+    - scripts/west_commands/runners/nsim.py
   labels:
     - "platform: Synopsys"
 

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3157,6 +3157,7 @@ Synopsys Platforms:
     - scripts/west_commands/runners/mdb.py
     - scripts/west_commands/tests/test_mdb.py
     - scripts/west_commands/runners/nsim.py
+    - cmake/emu/nsim.cmake
   labels:
     - "platform: Synopsys"
 

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3150,7 +3150,6 @@ Synopsys Platforms:
   collaborators:
     - abrodkin
     - evgeniy-paltsev
-    - IRISZZW
   files:
     - soc/snps/
     - boards/snps/


### PR DESCRIPTION
 - Remove IRISZZW from collaborators as he no longer works for Synopsys
 - Add mdb & nsim west runners files as parts of Synopsys platform
 - Add nsim cmake support file as parts of Synopsys platform