### PR TITLE
pcie: Remove deprecated functions

### DIFF
--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -38,6 +38,8 @@ Removed APIs in this release
  * The Bluetooth subsystem specific debug symbols are removed. They have been replaced with the
    Zephyr logging ones.
 
+ * Removed deprecated ``pcie_probe`` and ``pcie_bdf_lookup`` functions from the PCIe APIs.
+
 Deprecated in this release
 ==========================
 

--- a/drivers/pcie/host/pcie.c
+++ b/drivers/pcie/host/pcie.c
@@ -368,40 +368,6 @@ void pcie_irq_enable(pcie_bdf_t bdf, unsigned int irq)
 	irq_enable(irq);
 }
 
-struct lookup_data {
-	pcie_bdf_t bdf;
-	pcie_id_t id;
-};
-
-static bool lookup_cb(pcie_bdf_t bdf, pcie_id_t id, void *cb_data)
-{
-	struct lookup_data *data = cb_data;
-
-	if (id == data->id) {
-		data->bdf = bdf;
-		return false;
-	}
-
-	return true;
-}
-
-pcie_bdf_t pcie_bdf_lookup(pcie_id_t id)
-{
-	struct lookup_data data = {
-		.bdf = PCIE_BDF_NONE,
-		.id = id,
-	};
-	struct pcie_scan_opt opt = {
-		.cb = lookup_cb,
-		.cb_data = &data,
-		.flags = (PCIE_SCAN_RECURSIVE | PCIE_SCAN_CB_ALL),
-	};
-
-	pcie_scan(&opt);
-
-	return data.bdf;
-}
-
 static bool scan_flag(const struct pcie_scan_opt *opt, uint32_t flag)
 {
 	return ((opt->flags & flag) != 0U);

--- a/drivers/pcie/host/pcie.c
+++ b/drivers/pcie/host/pcie.c
@@ -37,23 +37,6 @@ static bool prt_en;
 
 /* functions documented in drivers/pcie/pcie.h */
 
-bool pcie_probe(pcie_bdf_t bdf, pcie_id_t id)
-{
-	uint32_t data;
-
-	data = pcie_conf_read(bdf, PCIE_CONF_ID);
-
-	if (!PCIE_ID_IS_VALID(data)) {
-		return false;
-	}
-
-	if (id == PCIE_ID_NONE) {
-		return true;
-	}
-
-	return (id == data);
-}
-
 void pcie_set_cmd(pcie_bdf_t bdf, uint32_t bits, bool on)
 {
 	uint32_t cmdstat;

--- a/include/zephyr/drivers/pcie/pcie.h
+++ b/include/zephyr/drivers/pcie/pcie.h
@@ -159,20 +159,6 @@ struct pcie_bar {
  */
 
 /**
- * @brief Look up the BDF based on PCI(e) vendor & device ID
- *
- * This function is used to look up the BDF for a device given its
- * vendor and device ID.
- *
- * @deprecated
- * @see DEVICE_PCIE_DECLARE
- *
- * @param id PCI(e) vendor & device ID encoded using PCIE_ID()
- * @return The BDF for the device, or PCIE_BDF_NONE if it was not found
- */
-__deprecated extern pcie_bdf_t pcie_bdf_lookup(pcie_id_t id);
-
-/**
  * @brief Read a 32-bit word from an endpoint's configuration space.
  *
  * This function is exported by the arch/SoC/board code.

--- a/include/zephyr/drivers/pcie/pcie.h
+++ b/include/zephyr/drivers/pcie/pcie.h
@@ -236,18 +236,6 @@ struct pcie_scan_opt {
 int pcie_scan(const struct pcie_scan_opt *opt);
 
 /**
- * @brief Probe for the presence of a PCI(e) endpoint.
- *
- * @deprecated
- * @see DEVICE_PCIE_DECLARE
- *
- * @param bdf the endpoint to probe
- * @param id the endpoint ID to expect, or PCIE_ID_NONE for "any device"
- * @return true if the device is present, false otherwise
- */
-__deprecated extern bool pcie_probe(pcie_bdf_t bdf, pcie_id_t id);
-
-/**
  * @brief Get the MBAR at a specific BAR index
  * @param bdf the PCI(e) endpoint
  * @param bar_index 0-based BAR index

--- a/tests/drivers/smbus/smbus_emul/src/smbus.c
+++ b/tests/drivers/smbus/smbus_emul/src/smbus.c
@@ -49,7 +49,6 @@ static void mock_conf_write(pcie_bdf_t bdf, unsigned int reg, uint32_t data)
 
 #define CONFIG_SMBUS_INTEL_PCH_ACCESS_IO
 #define device_map(a, b, c, d)
-#define pcie_probe(bdf, id)	1
 #define pcie_set_cmd(a, b, c)
 
 #define SMBUS_EMUL	"smbus_emul"


### PR DESCRIPTION
`pcie_probe()` and `pcie_bdf_lookup()` where deprecated before Zephyr 3.3. Time to remove them.