### PR TITLE
ci: codecov: Add upload token for codecov action

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -220,10 +220,11 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: always()
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           directory: ./coverage/reports
           env_vars: OS,PYTHON
           fail_ci_if_error: false
           verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: merged.xml


### PR DESCRIPTION
This commit adds the token for uploading to codecov.io because codecov now requires a token and rejects any upload requests without one.

It also updates the codecov-action version from v3 to v4, which is required for using a "global upload token."