### PR TITLE
boards: st: stm32h745i_disco: fix CAN phy devicetree representation

### DIFF
--- a/boards/st/stm32h745i_disco/stm32h745i_disco_stm32h745xx_m7.dts
+++ b/boards/st/stm32h745i_disco/stm32h745i_disco_stm32h745xx_m7.dts
@@ -33,18 +33,6 @@
 		};
 	};
 
-	transceiver0: can-phy0 {
-		compatible = "microchip,mcp2562fd", "can-transceiver-gpio";
-		max-bitrate = <5000000>;
-		#phy-cells = <0>;
-	};
-
-	transceiver1: can-phy1 {
-		compatible = "microchip,mcp2562fd", "can-transceiver-gpio";
-		max-bitrate = <5000000>;
-		#phy-cells = <0>;
-	};
-
 	/* RM0455 - 23.6 External device address mapping */
 	sdram2: sdram@d0000000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
@@ -218,7 +206,10 @@
 	bus-speed-data = <1000000>;
 	sample-point = <875>;
 	sample-point-data = <875>;
-	phys = <&transceiver0>;
+
+	can-transceiver {
+		max-bitrate = <5000000>;
+	};
 };
 
 &fdcan2 {
@@ -229,7 +220,10 @@
 	bus-speed-data = <1000000>;
 	sample-point = <875>;
 	sample-point-data = <875>;
-	phys = <&transceiver1>;
+
+	can-transceiver {
+		max-bitrate = <5000000>;
+	};
 };
 
 &fmc {

--- a/drivers/can/transceiver/can_transceiver_gpio.c
+++ b/drivers/can/transceiver/can_transceiver_gpio.c
@@ -120,6 +120,11 @@ static const struct can_transceiver_driver_api can_transceiver_gpio_driver_api =
 		   (.name##_gpio = GPIO_DT_SPEC_INST_GET(inst, name##_gpios),))
 
 #define CAN_TRANSCEIVER_GPIO_INIT(inst)					\
+	BUILD_ASSERT(DT_INST_NODE_HAS_PROP(inst, enable_gpios) ||	\
+		     DT_INST_NODE_HAS_PROP(inst, standby_gpios),	\
+		     "Missing GPIO property on "			\
+		     DT_NODE_FULL_NAME(DT_DRV_INST(inst)));		\
+									\
 	static const struct can_transceiver_gpio_config	can_transceiver_gpio_config_##inst = { \
 		CAN_TRANSCEIVER_GPIO_COND(inst, enable)			\
 		CAN_TRANSCEIVER_GPIO_COND(inst, standby)		\


### PR DESCRIPTION
On this board, the CAN transceivers are not GPIO controlled, but passive, and should not be represented by the "can-transceiver-gpio" compatible (as this leads to driver compilation warnings due to missing GPIO properties).

Fixes: c8faa1e3809854e83bc7abe9d33737a5047d9125