### PR TITLE
sys: util: Add sizeof_field() macro

### DIFF
--- a/drivers/gpio/gpio_gecko.c
+++ b/drivers/gpio/gpio_gecko.c
@@ -9,6 +9,7 @@
 #include <errno.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/irq.h>
+#include <zephyr/sys/util.h>
 #include <soc.h>
 #include <em_gpio.h>
 #ifdef CONFIG_SOC_GECKO_DEV_INIT
@@ -63,9 +64,8 @@
 #define GECKO_GPIO_MODEH(pin, mode) (mode << ((pin - 8) * 4))
 
 
-#define member_size(type, member) sizeof(((type *)0)->member)
-#define NUMBER_OF_PORTS (member_size(GPIO_TypeDef, P) / \
-			 member_size(GPIO_TypeDef, P[0]))
+#define NUMBER_OF_PORTS (SIZEOF_FIELD(GPIO_TypeDef, P) / \
+			 SIZEOF_FIELD(GPIO_TypeDef, P[0]))
 
 struct gpio_gecko_common_config {
 };

--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -272,6 +272,16 @@ extern "C" {
 	})
 
 /**
+ * @brief Report the size of a struct field in bytes.
+ *
+ * @param type The structure containing the field of interest.
+ * @param member The field to return the size of.
+ *
+ * @return The field size.
+ */
+#define SIZEOF_FIELD(type, member) sizeof((((type *)0)->member))
+
+/**
  * @brief Concatenate input arguments
  *
  * Concatenate provided tokens into a combined token during the preprocessor pass.

--- a/tests/unit/util/main.c
+++ b/tests/unit/util/main.c
@@ -803,4 +803,19 @@ ZTEST(util, test_CONCAT)
 	zassert_equal(CONCAT(CAT_PART1, CONCAT(CAT_PART2, CAT_PART3)), 123);
 }
 
+ZTEST(util, test_SIZEOF_FIELD)
+{
+	struct test_t {
+		uint32_t a;
+		uint8_t b;
+		uint8_t c[17];
+		int16_t d;
+	};
+
+	BUILD_ASSERT(SIZEOF_FIELD(struct test_t, a) == 4, "The a member is 4-byte wide.");
+	BUILD_ASSERT(SIZEOF_FIELD(struct test_t, b) == 1, "The b member is 1-byte wide.");
+	BUILD_ASSERT(SIZEOF_FIELD(struct test_t, c) == 17, "The c member is 17-byte wide.");
+	BUILD_ASSERT(SIZEOF_FIELD(struct test_t, d) == 2, "The d member is 2-byte wide.");
+}
+
 ZTEST_SUITE(util, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
This macro allows to know the size of a struct member at compile time. Its implementation is taken from the Linux kernel linux/stddef.h.