### PR TITLE
drivers: dai: sai: write some data into TX FIFO before start

### DIFF
--- a/drivers/dai/nxp/sai/sai.c
+++ b/drivers/dai/nxp/sai/sai.c
@@ -696,7 +696,7 @@ static int sai_trigger_start(const struct device *dev,
 	struct sai_data *data;
 	const struct sai_config *cfg;
 	uint32_t old_state;
-	int ret;
+	int ret, i;
 
 	data = dev->data;
 	cfg = dev->config;
@@ -733,7 +733,12 @@ static int sai_trigger_start(const struct device *dev,
 	SAI_TX_RX_ENABLE_DISABLE_IRQ(dir, data->regmap,
 				     kSAI_FIFOErrorInterruptEnable, true);
 
-	/* TODO: is there a need to write some words to the FIFO to avoid starvation? */
+	/* avoid initial underrun by writing a frame's worth of 0s */
+	if (dir == DAI_DIR_TX) {
+		for (i = 0; i < data->cfg.channels; i++) {
+			SAI_WriteData(UINT_TO_I2S(data->regmap), cfg->tx_dline, 0x0);
+		}
+	}
 
 	/* TODO: for now, only DMA mode is supported */
 	SAI_TX_RX_DMA_ENABLE_DISABLE(dir, data->regmap, true);


### PR DESCRIPTION
While running the following command:

	aplay ... | arecord ...

multiple times, it was discovered that the SAI transmit FIFO goes into underrun. This only happened in the beginning, a few BCLK cycles after unmasking the transmit data line. With the following flow:

	1) Trigger start on RX
		a) Do TX and RX software reset
		b) Enable RX FIFO error interrupt
		c) Enable RX DMA requests
		d) Enable receive data line
		e) Enable transmitter
		f) Enable receiver

	    ..... some time has passed .....

	2) Trigger start on TX
		a) Enable DMA requests
		b) Enable transmit data line

and configuration in mind:

	1) RX is SYNC with TX
	2) TX is ASYNC
	3) Each FSYNC edge is 32-bit wide
	4) Each frame contains 2 32-bit words

this points to the following possibilites:

	1) The transmitter is enabled so close to the
	start of a new frame that even though the DMA requests
	are asserted, the DMAC doesn't have enough time
	to service them until the module goes into underrun
	=> the timing is bad.

	2) The transmitter is enabled somewhat close to
	the start of a new frame such that the DMAC is not
	fast enough to service the module until it goes into
	underrun => DMAC is too slow AND the timing is bad.

Although the exact cause was not pinpointed, this patch aims to fix the problem by writing a frame's worth of 0s in the transmit FIFO. This way, even if we're dealing with scenario 1) or 2), the DMAC has plenty of time to perform the transfer (i.e: a frame), thus avoiding the underrun.