### PR TITLE
Add CRC-24

### DIFF
--- a/lib/crc/CMakeLists.txt
+++ b/lib/crc/CMakeLists.txt
@@ -3,6 +3,7 @@
 zephyr_sources_ifdef(CONFIG_CRC
   crc32c_sw.c
   crc32_sw.c
+  crc24_sw.c
   crc16_sw.c
   crc8_sw.c
   crc7_sw.c

--- a/lib/crc/crc24_sw.c
+++ b/lib/crc/crc24_sw.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2024 BayLibre.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/sys/crc.h>
+
+#define CRC24_PGP_POLY 0x01864cfbU
+
+uint32_t crc24_pgp(const uint8_t *data, size_t len)
+{
+	return crc24_pgp_update(CRC24_PGP_INITIAL_VALUE, data, len) & CRC24_FINAL_VALUE_MASK;
+}
+
+/* CRC-24 implementation from the section 6.1 of the RFC 4880 */
+uint32_t crc24_pgp_update(uint32_t crc, const uint8_t *data, size_t len)
+{
+	int i;
+
+	while (len--) {
+		crc ^= (*data++) << 16;
+		for (i = 0; i < 8; i++) {
+			crc <<= 1;
+			if (crc & 0x01000000)
+				crc ^= CRC24_PGP_POLY;
+		}
+	}
+
+	return crc;
+}

--- a/lib/crc/crc_shell.c
+++ b/lib/crc/crc_shell.c
@@ -28,6 +28,7 @@ static const char *const crc_types[] = {
 	[CRC16_ANSI] = "16_ansi",
 	[CRC16_CCITT] = "16_ccitt",
 	[CRC16_ITU_T] = "16_itu_t",
+	[CRC24_PGP] = "24_pgp",
 	[CRC32_C] = "32_c",
 	[CRC32_IEEE] = "32_ieee",
 };

--- a/tests/unit/crc/main.c
+++ b/tests/unit/crc/main.c
@@ -11,6 +11,7 @@
 #include "../../../lib/crc/crc32_sw.c"
 #include "../../../lib/crc/crc32c_sw.c"
 #include "../../../lib/crc/crc7_sw.c"
+#include "../../../lib/crc/crc24_sw.c"
 
 ZTEST(crc, test_crc32c)
 {
@@ -48,6 +49,22 @@ ZTEST(crc, test_crc32_ieee)
 	zassert_equal(crc32_ieee(test1, sizeof(test1)), 0xD3D99E8B);
 	zassert_equal(crc32_ieee(test2, sizeof(test2)), 0xCBF43926);
 	zassert_equal(crc32_ieee(test3, sizeof(test3)), 0x20089AA4);
+}
+
+ZTEST(crc, test_crc24_pgp)
+{
+	uint8_t test1[] = { 'A' };
+	uint8_t test2[] = { '1', '2', '3', '4', '5', '6', '7', '8', '9' };
+	uint8_t test3[] = { 'Z', 'e', 'p', 'h', 'y', 'r' };
+
+	zassert_equal(crc24_pgp(test1, sizeof(test1)), 0x00FE86FA);
+	zassert_equal(crc24_pgp(test2, sizeof(test2)), 0x0021CF02);
+	zassert_equal(crc24_pgp(test3, sizeof(test3)), 0x004662E9);
+
+	/* Compute a CRC in several steps */
+	zassert_equal(crc24_pgp_update(CRC24_PGP_INITIAL_VALUE, test2, 3), 0x0009DF67);
+	zassert_equal(crc24_pgp_update(0x0009DF67, test2 + 3, 2), 0x00BA353A);
+	zassert_equal(crc24_pgp_update(0x00BA353A, test2 + 5, 4), 0x0021CF02);
 }
 
 ZTEST(crc, test_crc16)


### PR DESCRIPTION
Add CRC-24 to the CRC library and also add unit tests.
The CRC-24 implementation is based on the RFC 4880 section 6.1.