### PR TITLE
boards: st: nucleo_wba55cg: define all LEDs/buttons and add MCUboot related LED/button aliases

### DIFF
--- a/boards/st/nucleo_wba55cg/nucleo_wba55cg.dts
+++ b/boards/st/nucleo_wba55cg/nucleo_wba55cg.dts
@@ -29,24 +29,46 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
-		blue_led_1: led_1 {
+		blue_led_1: led_0 {
 			gpios = <&gpiob 4 GPIO_ACTIVE_LOW>;
 			label = "User LD1";
+		};
+		green_led_2: led_1 {
+			gpios = <&gpioa 9 GPIO_ACTIVE_LOW>;
+			label = "User LD2";
+		};
+		red_led_3: led_2 {
+			gpios = <&gpiob 8 GPIO_ACTIVE_LOW>;
+			label = "User LD3";
 		};
 	};
 
 	gpio_keys {
 		compatible = "gpio-keys";
-		user_button: button {
-			label = "User";
-			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
+		user_button_1: button_0 {
+			label = "User B1";
+			gpios = <&gpioc 13 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			zephyr,code = <INPUT_KEY_0>;
+		};
+		user_button_2: button_1 {
+			label = "User B2";
+			gpios = <&gpiob 6 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			zephyr,code = <INPUT_KEY_1>;
+		};
+		user_button_3: button_2 {
+			label = "User B3";
+			gpios = <&gpiob 7 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			zephyr,code = <INPUT_KEY_2>;
 		};
 	};
 
 	aliases {
 		led0 = &blue_led_1;
-		sw0 = &user_button;
+		led1 = &green_led_2;
+		led2 = &red_led_3;
+		sw0 = &user_button_1;
+		sw1 = &user_button_2;
+		sw2 = &user_button_3;
 	};
 };
 

--- a/boards/st/nucleo_wba55cg/nucleo_wba55cg.dts
+++ b/boards/st/nucleo_wba55cg/nucleo_wba55cg.dts
@@ -69,6 +69,8 @@
 		sw0 = &user_button_1;
 		sw1 = &user_button_2;
 		sw2 = &user_button_3;
+		mcuboot-led0 = &blue_led_1;
+		mcuboot-button0 = &user_button_1;
 	};
 };
 

--- a/samples/boards/stm32/power_mgmt/suspend_to_ram/boards/nucleo_wba55cg.overlay
+++ b/samples/boards/stm32/power_mgmt/suspend_to_ram/boards/nucleo_wba55cg.overlay
@@ -31,18 +31,6 @@
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&adc4 8>;
 	};
-
-	leds: leds {
-		compatible = "gpio-leds";
-		red_led_3: led_3 {
-			gpios = <&gpiob 8 GPIO_ACTIVE_LOW>;
-			label = "User LD2";
-		};
-	};
-
-	aliases {
-		led2 = &red_led_3;
-	};
 };
 
 &lptim1 {


### PR DESCRIPTION
This includes the following two commits, focused on LEDs and buttons definitions for `nucleo_wba55cg` board:

- **boards: st: nucleo_wba55cg: define all LEDs and buttons**
This board includes three gpio-connected LEDs and push-buttons. Include all missing defines in board's DTS and while at it, fix existing button definition (missing pull-up enable) and align node names with other boards (e.g. `nucleo_wb55rg`).

   Provided changes were tested on real board with `blinky` and `button` samples.

   Additionally, duplicated LED nodes no longer required were removed from overlay file for this board, in `suspend_to_ram` sample.

- **boards: st: nucleo_wba55cg: add mcuboot-{led0,button0} aliases**
This adds DT aliases for LED and button used in recovery mode of the `MCUboot` bootloader, on the `nucleo_wba55cg` board.