### PR TITLE
drivers: wifi: esp_at: add mode for autoconnecting to wifi

### DIFF
--- a/drivers/wifi/esp_at/esp.h
+++ b/drivers/wifi/esp_at/esp.h
@@ -206,10 +206,11 @@ struct esp_socket {
 };
 
 enum esp_data_flag {
-	EDF_STA_CONNECTING = BIT(1),
-	EDF_STA_CONNECTED  = BIT(2),
-	EDF_STA_LOCK       = BIT(3),
-	EDF_AP_ENABLED     = BIT(4),
+	EDF_STA_CONNECTING		= BIT(1),
+	EDF_STA_CONNECTED		= BIT(2),
+	EDF_STA_LOCK			= BIT(3),
+	EDF_AP_ENABLED			= BIT(4),
+	EDF_STA_AUTOCONN_ENABLED	= BIT(6),
 };
 
 /* driver data */


### PR DESCRIPTION
Add mode for autoconnecting to wifi via NET_REQUEST_WIFI_MODE. By using this mode a user can make the ESP_AT firmware autoconnect to previously configured wifi stored in flash.