### PR TITLE
Bluetooth: CAP: Add reference to the set member for CAP discover

### DIFF
--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -304,6 +304,11 @@ Bluetooth Audio
   :kconfig:option:`CONFIG_BT_ISO_PERIPHERAL` are not longer `select`ed automatically when
   enabling :kconfig:option:`CONFIG_BT_BAP_UNICAST_SERVER`, and these must now be set explicitly
   in the project configuration file. (:github:`71993`)
+* The discover callback functions :code:`bt_cap_initiator_cb.unicast_discovery_complete`` and
+  :code:`bt_cap_commander_cb.discovery_complete`` for CAP now contain an additional parameter for
+  the set member.
+  This needs to be added to all instances of CAP discovery callback functions defined.
+  (:github:`72797`)
 
 Bluetooth Classic
 =================

--- a/include/zephyr/bluetooth/audio/cap.h
+++ b/include/zephyr/bluetooth/audio/cap.h
@@ -63,14 +63,16 @@ struct bt_cap_initiator_cb {
 	 * @param conn      The connection pointer supplied to
 	 *                  bt_cap_initiator_unicast_discover().
 	 * @param err       0 if Common Audio Service was found else -ENODATA.
+	 * @param member    Pointer to the set member. NULL if err != 0.
 	 * @param csis_inst The Coordinated Set Identification Service if
 	 *                  Common Audio Service was found and includes a
 	 *                  Coordinated Set Identification Service.
 	 *                  NULL on error or if remote device does not include
-	 *                  Coordinated Set Identification Service.
+	 *                  Coordinated Set Identification Service. NULL if err != 0.
 	 */
 	void (*unicast_discovery_complete)(
 		struct bt_conn *conn, int err,
+		const struct bt_csip_set_coordinator_set_member *member,
 		const struct bt_csip_set_coordinator_csis_inst *csis_inst);
 
 	/**
@@ -676,13 +678,15 @@ struct bt_cap_commander_cb {
 	 * @param conn      The connection pointer supplied to
 	 *                  bt_cap_initiator_unicast_discover().
 	 * @param err       0 if Common Audio Service was found else -ENODATA.
+	 * @param member    Pointer to the set member. NULL if err != 0.
 	 * @param csis_inst The Coordinated Set Identification Service if
 	 *                  Common Audio Service was found and includes a
 	 *                  Coordinated Set Identification Service.
 	 *                  NULL on error or if remote device does not include
-	 *                  Coordinated Set Identification Service.
+	 *                  Coordinated Set Identification Service. NULL if err != 0.
 	 */
 	void (*discovery_complete)(struct bt_conn *conn, int err,
+				   const struct bt_csip_set_coordinator_set_member *member,
 				   const struct bt_csip_set_coordinator_csis_inst *csis_inst);
 
 #if defined(CONFIG_BT_VCP_VOL_CTLR)

--- a/samples/bluetooth/tmap_central/src/cap_initiator.c
+++ b/samples/bluetooth/tmap_central/src/cap_initiator.c
@@ -98,6 +98,7 @@ static struct bt_bap_lc3_preset unicast_preset_48_2_1 =
 					 BT_AUDIO_CONTEXT_TYPE_MEDIA);
 
 static void cap_discovery_complete_cb(struct bt_conn *conn, int err,
+				      const struct bt_csip_set_coordinator_set_member *member,
 				      const struct bt_csip_set_coordinator_csis_inst *csis_inst)
 {
 	if (err != 0) {

--- a/subsys/bluetooth/audio/cap_commander.c
+++ b/subsys/bluetooth/audio/cap_commander.c
@@ -65,10 +65,11 @@ int bt_cap_commander_unregister_cb(const struct bt_cap_commander_cb *cb)
 
 static void
 cap_commander_discover_complete(struct bt_conn *conn, int err,
+				const struct bt_csip_set_coordinator_set_member *member,
 				const struct bt_csip_set_coordinator_csis_inst *csis_inst)
 {
 	if (cap_cb && cap_cb->discovery_complete) {
-		cap_cb->discovery_complete(conn, err, csis_inst);
+		cap_cb->discovery_complete(conn, err, member, csis_inst);
 	}
 }
 

--- a/subsys/bluetooth/audio/cap_initiator.c
+++ b/subsys/bluetooth/audio/cap_initiator.c
@@ -315,10 +315,11 @@ int bt_cap_initiator_broadcast_get_base(struct bt_cap_broadcast_source *broadcas
 
 static void
 bt_cap_initiator_discover_complete(struct bt_conn *conn, int err,
+				   const struct bt_csip_set_coordinator_set_member *member,
 				   const struct bt_csip_set_coordinator_csis_inst *csis_inst)
 {
 	if (cap_cb && cap_cb->unicast_discovery_complete) {
-		cap_cb->unicast_discovery_complete(conn, err, csis_inst);
+		cap_cb->unicast_discovery_complete(conn, err, member, csis_inst);
 	}
 }
 

--- a/subsys/bluetooth/audio/cap_internal.h
+++ b/subsys/bluetooth/audio/cap_internal.h
@@ -118,7 +118,8 @@ struct bt_cap_commander_proc_param {
 };
 
 typedef void (*bt_cap_common_discover_func_t)(
-	struct bt_conn *conn, int err, const struct bt_csip_set_coordinator_csis_inst *csis_inst);
+	struct bt_conn *conn, int err, const struct bt_csip_set_coordinator_set_member *member,
+	const struct bt_csip_set_coordinator_csis_inst *csis_inst);
 
 struct bt_cap_common_proc_param {
 	union {

--- a/subsys/bluetooth/audio/csip_internal.h
+++ b/subsys/bluetooth/audio/csip_internal.h
@@ -48,3 +48,5 @@ struct bt_csip_set_coordinator_svc_inst {
 
 struct bt_csip_set_coordinator_csis_inst *bt_csip_set_coordinator_csis_inst_by_handle(
 	struct bt_conn *conn, uint16_t start_handle);
+struct bt_csip_set_coordinator_set_member *
+bt_csip_set_coordinator_csis_member_by_conn(struct bt_conn *conn);

--- a/subsys/bluetooth/audio/csip_set_coordinator.c
+++ b/subsys/bluetooth/audio/csip_set_coordinator.c
@@ -1418,6 +1418,22 @@ struct bt_csip_set_coordinator_csis_inst *bt_csip_set_coordinator_csis_inst_by_h
 	return NULL;
 }
 
+struct bt_csip_set_coordinator_set_member *
+bt_csip_set_coordinator_csis_member_by_conn(struct bt_conn *conn)
+{
+	struct bt_csip_set_coordinator_inst *client;
+
+	CHECKIF(conn == NULL) {
+		LOG_DBG("conn is NULL");
+
+		return NULL;
+	}
+
+	client = &client_insts[bt_conn_index(conn)];
+
+	return &client->set_member;
+}
+
 /*************************** PUBLIC FUNCTIONS ***************************/
 int bt_csip_set_coordinator_register_cb(struct bt_csip_set_coordinator_cb *cb)
 {

--- a/subsys/bluetooth/audio/shell/cap_commander.c
+++ b/subsys/bluetooth/audio/shell/cap_commander.c
@@ -19,6 +19,7 @@
 #include "audio.h"
 
 static void cap_discover_cb(struct bt_conn *conn, int err,
+			    const struct bt_csip_set_coordinator_set_member *member,
 			    const struct bt_csip_set_coordinator_csis_inst *csis_inst)
 {
 	if (err != 0) {

--- a/subsys/bluetooth/audio/shell/cap_initiator.c
+++ b/subsys/bluetooth/audio/shell/cap_initiator.c
@@ -25,6 +25,7 @@
 #define CAP_UNICAST_CLIENT_STREAM_COUNT ARRAY_SIZE(unicast_streams)
 
 static void cap_discover_cb(struct bt_conn *conn, int err,
+			    const struct bt_csip_set_coordinator_set_member *member,
 			    const struct bt_csip_set_coordinator_csis_inst *csis_inst)
 {
 	if (err != 0) {

--- a/tests/bluetooth/audio/mocks/include/cap_commander.h
+++ b/tests/bluetooth/audio/mocks/include/cap_commander.h
@@ -16,6 +16,7 @@ void mock_cap_commander_init(void);
 void mock_cap_commander_cleanup(void);
 
 DECLARE_FAKE_VOID_FUNC(mock_cap_commander_discovery_complete_cb, struct bt_conn *, int,
+		       const struct bt_csip_set_coordinator_set_member *,
 		       const struct bt_csip_set_coordinator_csis_inst *);
 DECLARE_FAKE_VOID_FUNC(mock_cap_commander_volume_changed_cb, struct bt_conn *, int);
 DECLARE_FAKE_VOID_FUNC(mock_cap_commander_volume_mute_changed_cb, struct bt_conn *, int);

--- a/tests/bluetooth/audio/mocks/src/cap_commander.c
+++ b/tests/bluetooth/audio/mocks/src/cap_commander.c
@@ -18,6 +18,7 @@
 	FAKE(mock_cap_commander_microphone_gain_changed_cb)
 
 DEFINE_FAKE_VOID_FUNC(mock_cap_commander_discovery_complete_cb, struct bt_conn *, int,
+		      const struct bt_csip_set_coordinator_set_member *,
 		      const struct bt_csip_set_coordinator_csis_inst *);
 
 DEFINE_FAKE_VOID_FUNC(mock_cap_commander_volume_changed_cb, struct bt_conn *, int);

--- a/tests/bluetooth/tester/src/btp_cap.c
+++ b/tests/bluetooth/tester/src/btp_cap.c
@@ -50,6 +50,7 @@ static void btp_send_discovery_completed_ev(struct bt_conn *conn, uint8_t status
 }
 
 static void cap_discovery_complete_cb(struct bt_conn *conn, int err,
+				      const struct bt_csip_set_coordinator_set_member *member,
 				      const struct bt_csip_set_coordinator_csis_inst *csis_inst)
 {
 	LOG_DBG("");

--- a/tests/bsim/bluetooth/audio/src/cap_commander_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_commander_test.c
@@ -36,6 +36,7 @@ CREATE_FLAG(flag_microphone_mute_changed);
 CREATE_FLAG(flag_microphone_gain_changed);
 
 static void cap_discovery_complete_cb(struct bt_conn *conn, int err,
+				      const struct bt_csip_set_coordinator_set_member *member,
 				      const struct bt_csip_set_coordinator_csis_inst *csis_inst)
 {
 	if (err != 0) {

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
@@ -185,6 +185,7 @@ static struct bt_bap_stream_ops unicast_stream_ops = {
 };
 
 static void cap_discovery_complete_cb(struct bt_conn *conn, int err,
+				      const struct bt_csip_set_coordinator_set_member *member,
 				      const struct bt_csip_set_coordinator_csis_inst *csis_inst)
 {
 	if (err != 0) {

--- a/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
+++ b/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
@@ -263,6 +263,7 @@ static struct bt_bap_stream_ops stream_ops = {
 };
 
 static void cap_discovery_complete_cb(struct bt_conn *conn, int err,
+				      const struct bt_csip_set_coordinator_set_member *member,
 				      const struct bt_csip_set_coordinator_csis_inst *csis_inst)
 {
 	if (err != 0) {


### PR DESCRIPTION
Since the CSIP API expects a set member struct for nearly all functionality, the reference to the full set member (along with the CAS specific CSIS) should be given to the application.