### PR TITLE
logging: cmsis: prevent wundef warnings

### DIFF
--- a/include/zephyr/logging/log_core.h
+++ b/include/zephyr/logging/log_core.h
@@ -197,7 +197,7 @@ static inline char z_log_minimal_level_to_char(int level)
  * emitted instead. String check may increase compilation time so it is not
  * always performed (could significantly increase CI time).
  */
-#if CONFIG_LOG_FMT_STRING_VALIDATE
+#if defined(CONFIG_LOG_FMT_STRING_VALIDATE) && CONFIG_LOG_FMT_STRING_VALIDATE
 #define LOG_STRING_WARNING(_mode, _src, ...) \
 	    Z_LOG_MSG_CREATE(UTIL_NOT(IS_ENABLED(CONFIG_USERSPACE)), _mode, \
 			     Z_LOG_LOCAL_DOMAIN_ID, _src, LOG_LEVEL_ERR, NULL, 0, \

--- a/include/zephyr/logging/log_core.h
+++ b/include/zephyr/logging/log_core.h
@@ -197,7 +197,7 @@ static inline char z_log_minimal_level_to_char(int level)
  * emitted instead. String check may increase compilation time so it is not
  * always performed (could significantly increase CI time).
  */
-#if defined(CONFIG_LOG_FMT_STRING_VALIDATE) && CONFIG_LOG_FMT_STRING_VALIDATE
+#ifdef CONFIG_LOG_FMT_STRING_VALIDATE
 #define LOG_STRING_WARNING(_mode, _src, ...) \
 	    Z_LOG_MSG_CREATE(UTIL_NOT(IS_ENABLED(CONFIG_USERSPACE)), _mode, \
 			     Z_LOG_LOCAL_DOMAIN_ID, _src, LOG_LEVEL_ERR, NULL, 0, \

--- a/modules/cmsis/cmsis_core_m.h
+++ b/modules/cmsis/cmsis_core_m.h
@@ -52,19 +52,19 @@
 #error "__DSP_PRESENT and CONFIG_ARMV8_M_DSP are not set to the same value"
 #endif
 
-#if  __ICACHE_PRESENT != CONFIG_CPU_HAS_ICACHE
+#if  defined(__ICACHE_PRESENT) && (__ICACHE_PRESENT != CONFIG_CPU_HAS_ICACHE)
 #error "__ICACHE_PRESENT and CONFIG_CPU_HAS_ICACHE are not set to the same value"
 #endif
 
-#if __DCACHE_PRESENT != CONFIG_CPU_HAS_DCACHE
+#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT != CONFIG_CPU_HAS_DCACHE)
 #error "__DCACHE_PRESENT and CONFIG_CPU_HAS_DCACHE are not set to the same value"
 #endif
 
-#if __MVE_PRESENT != CONFIG_ARMV8_1_M_MVEI
+#if defined(__MVE_PRESENT) && (__MVE_PRESENT != CONFIG_ARMV8_1_M_MVEI)
 #error "__MVE_PRESENT and CONFIG_ARMV8_1_M_MVEI are not set to the same value"
 #endif
 
-#if __SAUREGION_PRESENT != CONFIG_CPU_HAS_ARM_SAU
+#if defined(__SAUREGION_PRESENT) && (__SAUREGION_PRESENT != CONFIG_CPU_HAS_ARM_SAU)
 #error "__SAUREGION_PRESENT and CONFIG_CPU_HAS_ARM_SAU are not set to the same value"
 #endif
 


### PR DESCRIPTION
If -Werror is used compilation fails due to wundef warning.