### PR TITLE
manifest: Update hal_microchip for new MEC5 HAL

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -178,7 +178,7 @@ manifest:
       groups:
         - hal
     - name: hal_microchip
-      revision: 68575aa28cd33c68b3b8d66f510d15746c57fdb5
+      revision: 1279561ea9b71c5f572d3d52708b7b445a383662
       path: modules/hal/microchip
       groups:
         - hal


### PR DESCRIPTION
Microchip external HAL repository has been updated with the MEC5 HAL for new chips. MEC5 is a full HAL with chip headers, C peripheral code, and PINCTRL DTSI files. MEC5 is meant for MEC174x, MEC175x, and also include support for the older MEC172x named as MECH172x. NOTE: legacy MEC172x in the currest zephyr tree is not affected.