### PR TITLE
Fix stm32wl i2c driver LPM

### DIFF
--- a/drivers/i2c/i2c_ll_stm32.h
+++ b/drivers/i2c/i2c_ll_stm32.h
@@ -56,6 +56,9 @@ struct i2c_stm32_data {
 #endif
 	struct k_sem bus_mutex;
 	uint32_t dev_config;
+#if defined(CONFIG_SOC_SERIES_STM32WLX)
+	uint32_t i2c_clock;
+#endif
 #ifdef CONFIG_I2C_STM32_V1
 	uint16_t slave_address;
 #endif


### PR DESCRIPTION
# Description
This PR introduce a fix for this issue :https://github.com/zephyrproject-rtos/zephyr/issues/37414 by adding a timing reinitialization  when PM resume

## Type of change
- Bug fix

# Test steps

- Choose a i2c sensor sample (Choose the one you have). For example `samples/sensor/bme280`.
- Add `CONFIG_PM=y `
- Build for the `nucleo_wl55jc`
- Check that the sample work well with and without `CONFIG_PM`