### PR TITLE
lib: avoided increments/decrements with side effects

### DIFF
--- a/lib/crc/crc16_sw.c
+++ b/lib/crc/crc16_sw.c
@@ -54,7 +54,8 @@ uint16_t crc16_ccitt(uint16_t seed, const uint8_t *src, size_t len)
 	for (; len > 0; len--) {
 		uint8_t e, f;
 
-		e = seed ^ *src++;
+		e = seed ^ *src;
+		++src;
 		f = e ^ (e << 4);
 		seed = (seed >> 8) ^ ((uint16_t)f << 8) ^ ((uint16_t)f << 3) ^ ((uint16_t)f >> 4);
 	}
@@ -66,7 +67,8 @@ uint16_t crc16_itu_t(uint16_t seed, const uint8_t *src, size_t len)
 {
 	for (; len > 0; len--) {
 		seed = (seed >> 8U) | (seed << 8U);
-		seed ^= *src++;
+		seed ^= *src;
+		++src;
 		seed ^= (seed & 0xffU) >> 4U;
 		seed ^= seed << 12U;
 		seed ^= (seed & 0xffU) << 5U;

--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -515,7 +515,8 @@ static inline const char *extract_specifier(struct conversion *conv,
 {
 	bool unsupported = false;
 
-	conv->specifier = *sp++;
+	conv->specifier = *sp;
+	++sp;
 
 	switch (conv->specifier) {
 	case SINT_CONV_CASES:
@@ -652,7 +653,8 @@ static inline const char *extract_conversion(struct conversion *conv,
 	 */
 	++sp;
 	if (*sp == '%') {
-		conv->specifier = *sp++;
+		conv->specifier = *sp;
+		++sp;
 		return sp;
 	}
 
@@ -797,7 +799,8 @@ static char *encode_uint(uint_value_type value,
 	do {
 		unsigned int lsv = (unsigned int)(value % radix);
 
-		*--bp = (lsv <= 9) ? ('0' + lsv)
+		--bp;
+		*bp = (lsv <= 9) ? ('0' + lsv)
 			: upcase ? ('A' + lsv - 10) : ('a' + lsv - 10);
 		value /= radix;
 	} while ((value != 0) && (bps < bp));
@@ -906,23 +909,27 @@ static char *encode_float(double value,
 	if (expo == BIT_MASK(EXPONENT_BITS)) {
 		if (fract == 0) {
 			if (isupper((unsigned char)c) != 0) {
-				*buf++ = 'I';
-				*buf++ = 'N';
-				*buf++ = 'F';
+				buf[0] = 'I';
+				buf[1] = 'N';
+				buf[2] = 'F';
+				buf += 3;
 			} else {
-				*buf++ = 'i';
-				*buf++ = 'n';
-				*buf++ = 'f';
+				buf[0] = 'i';
+				buf[1] = 'n';
+				buf[2] = 'f';
+				buf += 3;
 			}
 		} else {
 			if (isupper((unsigned char)c) != 0) {
-				*buf++ = 'N';
-				*buf++ = 'A';
-				*buf++ = 'N';
+				buf[0] = 'N';
+				buf[1] = 'A';
+				buf[2] = 'N';
+				buf += 3;
 			} else {
-				*buf++ = 'n';
-				*buf++ = 'a';
-				*buf++ = 'n';
+				buf[0] = 'n';
+				buf[1] = 'a';
+				buf[2] = 'n';
+				buf += 3;
 			}
 		}
 
@@ -942,8 +949,9 @@ static char *encode_float(double value,
 	if (IS_ENABLED(CONFIG_CBPRINTF_FP_A_SUPPORT)
 	    && (IS_ENABLED(CONFIG_CBPRINTF_FP_ALWAYS_A)
 		|| conv->specifier_a)) {
-		*buf++ = '0';
-		*buf++ = 'x';
+		buf[0] = '0';
+		buf[1] = 'x';
+		buf += 2;
 
 		/* Remove the offset from the exponent, and store the
 		 * non-fractional value.  Subnormals require increasing the
@@ -951,10 +959,12 @@ static char *encode_float(double value,
 		 */
 		expo -= 1023;
 		if (is_subnormal) {
-			*buf++ = '0';
+			*buf = '0';
+			++buf;
 			++expo;
 		} else {
-			*buf++ = '1';
+			*buf = '1';
+			++buf;
 		}
 
 		/* If we didn't get precision from a %a specification then we
@@ -990,7 +1000,8 @@ static char *encode_float(double value,
 		bool require_dp = ((fract != 0) || conv->flag_hash);
 
 		if (require_dp || (precision != 0)) {
-			*buf++ = '.';
+			*buf = '.';
+			++buf;
 		}
 
 		/* Get the fractional value as a hexadecimal string, using x
@@ -1010,12 +1021,15 @@ static char *encode_float(double value,
 		 * point.
 		 */
 		while ((spe - sp) < FRACTION_HEX) {
-			*--sp = '0';
+			--sp;
+			*sp = '0';
 		}
 
 		/* Append the leading significant "digits". */
 		while ((sp < spe) && (precision > 0)) {
-			*buf++ = *sp++;
+			*buf = *sp;
+			++buf;
+			++sp;
 			--precision;
 		}
 
@@ -1028,11 +1042,14 @@ static char *encode_float(double value,
 			}
 		}
 
-		*buf++ = 'p';
+		*buf = 'p';
+		++buf;
 		if (expo >= 0) {
-			*buf++ = '+';
+			*buf = '+';
+			++buf;
 		} else {
-			*buf++ = '-';
+			*buf = '-';
+			++buf;
 			expo = -expo;
 		}
 
@@ -1040,7 +1057,9 @@ static char *encode_float(double value,
 		sp = encode_uint(expo, &aconv, buf, spe);
 
 		while (sp < spe) {
-			*buf++ = *sp++;
+			*buf = *sp;
+			++buf;
+			++sp;
 		}
 
 		*bpe = buf;
@@ -1174,7 +1193,8 @@ static char *encode_float(double value,
 		if (decexp > 0) {
 			/* Emit the digits above the decimal point. */
 			while ((decexp > 0) && (digit_count > 0)) {
-				*buf++ = _get_digit(&fract, &digit_count);
+				*buf = _get_digit(&fract, &digit_count);
+				++buf;
 				decexp--;
 			}
 
@@ -1182,14 +1202,16 @@ static char *encode_float(double value,
 
 			decexp = 0;
 		} else {
-			*buf++ = '0';
+			*buf = '0';
+			++buf;
 		}
 
 		/* Emit the decimal point only if required by the alternative
 		 * format, or if more digits are to follow.
 		 */
 		if (conv->flag_hash || (precision > 0)) {
-			*buf++ = '.';
+			*buf = '.';
+			++buf;
 		}
 
 		if ((decexp < 0) && (precision > 0)) {
@@ -1214,12 +1236,14 @@ static char *encode_float(double value,
 		 * format, or if more digits are to follow.
 		 */
 		if (conv->flag_hash || (precision > 0)) {
-			*buf++ = '.';
+			*buf = '.';
+			++buf;
 		}
 	}
 
 	while ((precision > 0) && (digit_count > 0)) {
-		*buf++ = _get_digit(&fract, &digit_count);
+		*buf = _get_digit(&fract, &digit_count);
+		++buf;
 		precision--;
 	}
 
@@ -1227,32 +1251,37 @@ static char *encode_float(double value,
 
 	if (prune_zero) {
 		conv->pad0_pre_exp = 0;
-		while (*--buf == '0') {
-			;
-		}
+		do {
+			--buf;
+		} while (*buf == '0');
 		if (*buf != '.') {
-			buf++;
+			++buf;
 		}
 	}
 
 	/* Emit the explicit exponent, if format requires it. */
 	if ((c == 'e') || (c == 'E')) {
-		*buf++ = c;
+		*buf = c;
+		++buf;
 		if (decexp < 0) {
 			decexp = -decexp;
-			*buf++ = '-';
+			*buf = '-';
+			++buf;
 		} else {
-			*buf++ = '+';
+			*buf = '+';
+			++buf;
 		}
 
 		/* At most 3 digits to the decimal.  Spit them out. */
 		if (decexp >= 100) {
-			*buf++ = (decexp / 100) + '0';
+			*buf = (decexp / 100) + '0';
+			++buf;
 			decexp %= 100;
 		}
 
-		*buf++ = (decexp / 10) + '0';
-		*buf++ = (decexp % 10) + '0';
+		buf[0] = (decexp / 10) + '0';
+		buf[1] = (decexp % 10) + '0';
+		buf += 2;
 	}
 
 	/* Cache whether there's padding required */
@@ -1324,7 +1353,8 @@ static int outs(cbprintf_cb out,
 	size_t count = 0;
 
 	while ((sp < ep) || ((ep == NULL) && *sp)) {
-		int rc = out((int)*sp++, ctx);
+		int rc = out((int)*sp, ctx);
+		++sp;
 
 		if (rc < 0) {
 			return rc;
@@ -1374,7 +1404,8 @@ int z_cbvprintf_impl(cbprintf_cb out, void *ctx, const char *fp,
 
 	while (*fp != 0) {
 		if (*fp != '%') {
-			OUTC(*fp++);
+			OUTC(*fp);
+			++fp;
 			continue;
 		}
 
@@ -1782,11 +1813,13 @@ int z_cbvprintf_impl(cbprintf_cb out, void *ctx, const char *fp,
 			if (conv->specifier_a) {
 				/* Only padding is pre_exp */
 				while (*cp != 'p') {
-					OUTC(*cp++);
+					OUTC(*cp);
+					++cp;
 				}
 			} else {
 				while (isdigit((unsigned char)*cp) != 0) {
-					OUTC(*cp++);
+					OUTC(*cp);
+					++cp;
 				}
 
 				pad_len = conv->pad0_value;
@@ -1797,7 +1830,8 @@ int z_cbvprintf_impl(cbprintf_cb out, void *ctx, const char *fp,
 				}
 
 				if (*cp == '.') {
-					OUTC(*cp++);
+					OUTC(*cp);
+					++cp;
 					/* Remaining padding is
 					 * post-dp.
 					 */
@@ -1806,7 +1840,8 @@ int z_cbvprintf_impl(cbprintf_cb out, void *ctx, const char *fp,
 					}
 				}
 				while (isdigit((unsigned char)*cp) != 0) {
-					OUTC(*cp++);
+					OUTC(*cp);
+					++cp;
 				}
 			}
 

--- a/lib/os/cbprintf_packaged.c
+++ b/lib/os/cbprintf_packaged.c
@@ -335,7 +335,8 @@ int cbvprintf_package(void *packaged, size_t len, uint32_t flags,
 	 * reason for the post-decrement on fmt as it will be incremented
 	 * prior to the next (actually first) round of that loop.
 	 */
-	s = fmt--;
+	s = fmt;
+	--fmt;
 	align = VA_STACK_ALIGN(char *);
 	size = sizeof(char *);
 	goto process_string;
@@ -766,7 +767,8 @@ process_string:
 				return -ENOSPC;
 			}
 			/* store the pointer position prefix */
-			*buf++ = pos;
+			*buf = pos;
+			++buf;
 		}
 	}
 
@@ -794,7 +796,8 @@ process_string:
 			return -ENOSPC;
 		}
 		/* store the pointer position prefix */
-		*buf++ = str_ptr_pos[i];
+		*buf = str_ptr_pos[i];
+		++buf;
 		/* copy the string with its terminating '\0' */
 		memcpy(buf, (uint8_t *)s, size);
 		buf += size;
@@ -851,7 +854,8 @@ int cbpprintf_external(cbprintf_cb out,
 	 */
 	for (i = 0; i < s_nbr; i++) {
 		/* Locate pointer location for this string */
-		s_idx = *(uint8_t *)s++;
+		s_idx = *(uint8_t *)s;
+		++s;
 		ps = (char **)(buf + s_idx * sizeof(int));
 		/* update the pointer with current string location */
 		*ps = s;

--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -97,7 +97,8 @@ static int buf_char_out(int c, void *ctx_p)
 {
 	struct buf_out_context *ctx = ctx_p;
 
-	ctx->buf[ctx->buf_count++] = c;
+	ctx->buf[ctx->buf_count] = c;
+	++ctx->buf_count;
 	if (ctx->buf_count == CONFIG_PRINTK_BUFFER_SIZE) {
 		buf_flush(ctx);
 	}
@@ -226,15 +227,16 @@ struct str_context {
 static int str_out(int c, struct str_context *ctx)
 {
 	if ((ctx->str == NULL) || (ctx->count >= ctx->max)) {
-		ctx->count++;
+		++ctx->count;
 		return c;
 	}
 
 	if (ctx->count == (ctx->max - 1)) {
-		ctx->str[ctx->count++] = '\0';
+		ctx->str[ctx->count] = '\0';
 	} else {
-		ctx->str[ctx->count++] = c;
+		ctx->str[ctx->count] = c;
 	}
+	++ctx->count;
 
 	return c;
 }

--- a/lib/utils/rb.c
+++ b/lib/utils/rb.c
@@ -81,14 +81,16 @@ static int find_and_stack(struct rbtree *tree, struct rbnode *node,
 {
 	int sz = 0;
 
-	stack[sz++] = tree->root;
+	stack[sz] = tree->root;
+	++sz;
 
 	while (stack[sz - 1] != node) {
 		uint8_t side = tree->lessthan_fn(node, stack[sz - 1]) ? 0U : 1U;
 		struct rbnode *ch = get_child(stack[sz - 1], side);
 
 		if (ch != NULL) {
-			stack[sz++] = ch;
+			stack[sz] = ch;
+			++sz;
 		} else {
 			break;
 		}
@@ -241,7 +243,8 @@ void rb_insert(struct rbtree *tree, struct rbnode *node)
 	set_child(parent, side, node);
 	set_color(node, RED);
 
-	stack[stacksz++] = node;
+	stack[stacksz] = node;
+	++stacksz;
 	fix_extra_red(stack, stacksz);
 
 	if (stacksz > tree->max_depth) {
@@ -287,7 +290,8 @@ static void fix_missing_black(struct rbnode **stack, int stacksz,
 			rotate(stack, stacksz);
 			set_color(parent, RED);
 			set_color(sib, BLACK);
-			stack[stacksz++] = n;
+			stack[stacksz] = n;
+			++stacksz;
 
 			parent = stack[stacksz - 2];
 			sib = get_child(parent, (n_side == 0U) ? 1U : 0U);
@@ -333,7 +337,8 @@ static void fix_missing_black(struct rbnode **stack, int stacksz,
 			inner = get_child(sib, n_side);
 
 			stack[stacksz - 1] = sib;
-			stack[stacksz++] = inner;
+			stack[stacksz] = inner;
+			++stacksz;
 			rotate(stack, stacksz);
 			set_color(sib, RED);
 			set_color(inner, BLACK);
@@ -390,10 +395,12 @@ void rb_remove(struct rbtree *tree, struct rbnode *node)
 		struct rbnode *node2 = get_child(node, 0U);
 
 		hiparent = (stacksz > 1) ? stack[stacksz - 2] : NULL;
-		stack[stacksz++] = node2;
+		stack[stacksz] = node2;
+		++stacksz;
 		while (get_child(node2, 1U) != NULL) {
 			node2 = get_child(node2, 1U);
-			stack[stacksz++] = node2;
+			stack[stacksz] = node2;
+			++stacksz;
 		}
 
 		loparent = stack[stacksz - 2];


### PR DESCRIPTION
Avoided increments/decrements with side effects.

This corresponds to following coding guideline:

> A full expression containing an increment (++) or decrement (–) operator should have no other potential side effects other than that caused by the increment or decrement operator

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/671153b94dd5af207423fd8aaf4caf2f6c4d19c3