### PR TITLE
boards: nrf54h20dk: Add SUIT storage definition

### DIFF
--- a/dts/common/nordic/nrf54h20.dtsi
+++ b/dts/common/nordic/nrf54h20.dtsi
@@ -74,6 +74,10 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
+		suit_storage_partition: memory@e1eb000 {
+			reg = <0xe1eb000 DT_SIZE_K(24)>;
+		};
+
 		cpurad_uicr_ext: memory@e1ff000 {
 			reg = <0xe1ff000 DT_SIZE_K(2)>;
 		};


### PR DESCRIPTION
Add a definition of SUIT storage, so there will be a common source of the SUIT storage location for both SDFW and scripts generating SUIT storage areas, assigned to local domains.