### PR TITLE
drivers: spi_bitbang: Fix timing in SPI bitbang driver

### DIFF
--- a/drivers/spi/spi_bitbang.c
+++ b/drivers/spi/spi_bitbang.c
@@ -177,21 +177,21 @@ static int spi_bitbang_transceive(const struct device *dev,
 
 			k_busy_wait(wait_us);
 
-			/* first clock edge */
-			gpio_pin_set_dt(&info->clk_gpio, !clock_state);
-
 			if (!loop && do_read && !cpha) {
 				b = gpio_pin_get_dt(miso);
 			}
 
-			k_busy_wait(wait_us);
+			/* first (leading) clock edge */
+			gpio_pin_set_dt(&info->clk_gpio, !clock_state);
 
-			/* second clock edge */
-			gpio_pin_set_dt(&info->clk_gpio, clock_state);
+			k_busy_wait(wait_us);
 
 			if (!loop && do_read && cpha) {
 				b = gpio_pin_get_dt(miso);
 			}
+
+			/* second (trailing) clock edge */
+			gpio_pin_set_dt(&info->clk_gpio, clock_state);
 
 			if (loop) {
 				b = d;


### PR DESCRIPTION
Fix timing in SPI bitbang driver.
The issue occurs with CPHA=1 when the input data is changed immediately after the clock shift on the last bit of the read. Because we read the input bit after changing the clock, this bit becomes invalid.
Instead of doing wait, clock-change, read. Do wait, read, clock-change.