### PR TITLE
drivers: sensors: sensor_shell: fix hang & crash

### DIFF
--- a/drivers/sensor/default_rtio_sensor.c
+++ b/drivers/sensor/default_rtio_sensor.c
@@ -304,6 +304,9 @@ static int get_frame_count(const uint8_t *buffer, struct sensor_chan_spec channe
 	case SENSOR_CHAN_MAGN_XYZ:
 		channel.chan_type = SENSOR_CHAN_MAGN_X;
 		break;
+	case SENSOR_CHAN_POS_DXYZ:
+		channel.chan_type = SENSOR_CHAN_POS_DX;
+		break;
 	default:
 		break;
 	}
@@ -343,6 +346,7 @@ int sensor_natively_supported_channel_size_info(struct sensor_chan_spec channel,
 	case SENSOR_CHAN_POS_DX:
 	case SENSOR_CHAN_POS_DY:
 	case SENSOR_CHAN_POS_DZ:
+	case SENSOR_CHAN_POS_DXYZ:
 		*base_size = sizeof(struct sensor_three_axis_data);
 		*frame_size = sizeof(struct sensor_three_axis_sample_data);
 		return 0;
@@ -481,6 +485,7 @@ static int decode(const uint8_t *buffer, struct sensor_chan_spec chan_spec,
 	case SENSOR_CHAN_POS_DX:
 	case SENSOR_CHAN_POS_DY:
 	case SENSOR_CHAN_POS_DZ:
+	case SENSOR_CHAN_POS_DXYZ:
 		count = decode_three_axis(header, q, data_out, SENSOR_CHAN_POS_DX,
 					  SENSOR_CHAN_POS_DY, SENSOR_CHAN_POS_DZ,
 					  chan_spec.chan_idx);

--- a/drivers/sensor/sensor_shell.c
+++ b/drivers/sensor/sensor_shell.c
@@ -78,6 +78,7 @@ static const char *sensor_channel_name[SENSOR_CHAN_COMMON_COUNT] = {
 	[SENSOR_CHAN_VOC] = "voc",
 	[SENSOR_CHAN_GAS_RES] = "gas_resistance",
 	[SENSOR_CHAN_VOLTAGE] = "voltage",
+	[SENSOR_CHAN_VSHUNT] = "vshunt",
 	[SENSOR_CHAN_CURRENT] = "current",
 	[SENSOR_CHAN_POWER] = "power",
 	[SENSOR_CHAN_RESISTANCE] = "resistance",

--- a/drivers/sensor/sensor_shell.c
+++ b/drivers/sensor/sensor_shell.c
@@ -984,8 +984,7 @@ static void data_ready_trigger_handler(const struct device *sensor,
 			continue;
 		}
 		/* Skip 3 axis channels */
-		if (i == SENSOR_CHAN_ACCEL_XYZ || i == SENSOR_CHAN_GYRO_XYZ ||
-		    i == SENSOR_CHAN_MAGN_XYZ) {
+		if (SENSOR_CHANNEL_3_AXIS(i)) {
 			continue;
 		}
 

--- a/drivers/sensor/sensor_shell.c
+++ b/drivers/sensor/sensor_shell.c
@@ -86,6 +86,7 @@ static const char *sensor_channel_name[SENSOR_CHAN_COMMON_COUNT] = {
 	[SENSOR_CHAN_POS_DX] = "pos_dx",
 	[SENSOR_CHAN_POS_DY] = "pos_dy",
 	[SENSOR_CHAN_POS_DZ] = "pos_dz",
+	[SENSOR_CHAN_POS_DXYZ] = "pos_dxyz",
 	[SENSOR_CHAN_RPM] = "rpm",
 	[SENSOR_CHAN_GAUGE_VOLTAGE] = "gauge_voltage",
 	[SENSOR_CHAN_GAUGE_AVG_CURRENT] = "gauge_avg_current",
@@ -364,6 +365,7 @@ void sensor_shell_processing_callback(int result, uint8_t *buf, uint32_t buf_len
 		case SENSOR_CHAN_MAGN_X:
 		case SENSOR_CHAN_MAGN_Y:
 		case SENSOR_CHAN_MAGN_Z:
+		case SENSOR_CHAN_POS_DX:
 		case SENSOR_CHAN_POS_DY:
 		case SENSOR_CHAN_POS_DZ:
 			continue;
@@ -392,7 +394,7 @@ void sensor_shell_processing_callback(int result, uint8_t *buf, uint32_t buf_len
 				case SENSOR_CHAN_ACCEL_XYZ:
 				case SENSOR_CHAN_GYRO_XYZ:
 				case SENSOR_CHAN_MAGN_XYZ:
-				case SENSOR_CHAN_POS_DX: {
+				case SENSOR_CHAN_POS_DXYZ: {
 					struct sensor_three_axis_data *data =
 						(struct sensor_three_axis_data *)decoded_buffer;
 
@@ -446,7 +448,7 @@ void sensor_shell_processing_callback(int result, uint8_t *buf, uint32_t buf_len
 			case SENSOR_CHAN_ACCEL_XYZ:
 			case SENSOR_CHAN_GYRO_XYZ:
 			case SENSOR_CHAN_MAGN_XYZ:
-			case SENSOR_CHAN_POS_DX: {
+			case SENSOR_CHAN_POS_DXYZ: {
 				struct sensor_three_axis_data *data =
 					(struct sensor_three_axis_data *)decoded_buffer;
 

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -150,6 +150,8 @@ enum sensor_channel {
 	SENSOR_CHAN_POS_DY,
 	/** Position change on the Z axis, in points. */
 	SENSOR_CHAN_POS_DZ,
+	/** Position change on the X, Y and Z axis, in points. */
+	SENSOR_CHAN_POS_DXYZ,
 
 	/** Revolutions per minute, in RPM. */
 	SENSOR_CHAN_RPM,
@@ -929,12 +931,12 @@ struct __attribute__((__packed__)) sensor_data_generic_header {
  *
  * @param[in] chan The channel to check
  * @retval true if @p chan is any of @ref SENSOR_CHAN_ACCEL_XYZ, @ref SENSOR_CHAN_GYRO_XYZ, or
- *         @ref SENSOR_CHAN_MAGN_XYZ
+ *         @ref SENSOR_CHAN_MAGN_XYZ, or @ref SENSOR_CHAN_POS_DXYZ
  * @retval false otherwise
  */
 #define SENSOR_CHANNEL_3_AXIS(chan)                                                                \
 	((chan) == SENSOR_CHAN_ACCEL_XYZ || (chan) == SENSOR_CHAN_GYRO_XYZ ||                      \
-	 (chan) == SENSOR_CHAN_MAGN_XYZ)
+	 (chan) == SENSOR_CHAN_MAGN_XYZ || (chan) == SENSOR_CHAN_POS_DXYZ)
 
 /**
  * @brief Get the sensor's decoder API

--- a/include/zephyr/drivers/sensor_data_types.h
+++ b/include/zephyr/drivers/sensor_data_types.h
@@ -47,6 +47,7 @@ struct sensor_data_header {
  * - :c:enum:`SENSOR_CHAN_POS_DX`
  * - :c:enum:`SENSOR_CHAN_POS_DY`
  * - :c:enum:`SENSOR_CHAN_POS_DZ`
+ * - :c:enum:`SENSOR_CHAN_POS_DXYZ`
  */
 struct sensor_three_axis_data {
 	struct sensor_data_header header;

--- a/samples/sensor/sensor_shell/pytest/test_sensor_shell.py
+++ b/samples/sensor/sensor_shell/pytest/test_sensor_shell.py
@@ -25,12 +25,12 @@ def test_sensor_shell_get(shell: Shell):
     assert any(['channel type=31(voltage)' in line for line in lines]), 'expected response not found'
 
     lines = shell.exec_command('sensor get sensor@1 53')
-    assert any(['channel type=53(gauge_time_to_empty)' in line for line in lines]), 'expected response not found'
+    assert any(['channel type=53(gauge_state_of_health)' in line for line in lines]), 'expected response not found'
 
     # Channel should be the last one before 'all' (because 'all' doesn't print anything) so that the
     # for-loop in `parse_named_int()` will go through everything
     lines = shell.exec_command('sensor get sensor@0 gauge_desired_charging_current')
-    assert any(['channel type=58(gauge_desired_charging_current)' in line for line in lines]), 'expected response not found'
+    assert any(['channel type=59(gauge_desired_charging_current)' in line for line in lines]), 'expected response not found'
 
     logger.info('response is valid')
 
@@ -42,7 +42,7 @@ def test_sensor_shell_attr_get(shell: Shell):
     assert any(['sensor@0(channel=co2, attr=sampling_frequency)' in line for line in lines]), 'expected response not found'
 
     lines = shell.exec_command('sensor attr_get sensor@1 53 3')
-    assert any(['sensor@1(channel=gauge_time_to_empty, attr=slope_th)' in line for line in lines]), 'expected response not found'
+    assert any(['sensor@1(channel=gauge_state_of_health, attr=slope_th)' in line for line in lines]), 'expected response not found'
 
     logger.info('response is valid')
 
@@ -55,7 +55,7 @@ def test_sensor_shell_attr_set(shell: Shell):
     assert any([expected_line in line for line in lines]), 'expected response not found'
 
     lines = shell.exec_command('sensor attr_set sensor@1 53 3 1')
-    expected_line = 'sensor@1 channel=gauge_time_to_empty, attr=slope_th set to value=1'
+    expected_line = 'sensor@1 channel=gauge_state_of_health, attr=slope_th set to value=1'
     assert any([expected_line in line for line in lines]), 'expected response not found'
 
     logger.info('response is valid')

--- a/samples/sensor/sensor_shell/pytest/test_sensor_shell.py
+++ b/samples/sensor/sensor_shell/pytest/test_sensor_shell.py
@@ -27,6 +27,11 @@ def test_sensor_shell_get(shell: Shell):
     lines = shell.exec_command('sensor get sensor@1 53')
     assert any(['channel type=53(gauge_time_to_empty)' in line for line in lines]), 'expected response not found'
 
+    # Channel should be the last one before 'all' (because 'all' doesn't print anything) so that the
+    # for-loop in `parse_named_int()` will go through everything
+    lines = shell.exec_command('sensor get sensor@0 gauge_desired_charging_current')
+    assert any(['channel type=58(gauge_desired_charging_current)' in line for line in lines]), 'expected response not found'
+
     logger.info('response is valid')
 
 

--- a/samples/sensor/sensor_shell/src/fake_sensor.c
+++ b/samples/sensor/sensor_shell/src/fake_sensor.c
@@ -56,6 +56,8 @@ static int channel_get(const struct device *dev, enum sensor_channel chan, struc
 	case SENSOR_CHAN_GYRO_XYZ:
 		__fallthrough;
 	case SENSOR_CHAN_MAGN_XYZ:
+		__fallthrough;
+	case SENSOR_CHAN_POS_DXYZ:
 		for (int i = 0; i < 3; i++, val++) {
 			val->val1 = chan;
 			val->val2 = 1;


### PR DESCRIPTION
Currently, getting any channel >= `SENSOR_CHAN_VSHUNT` would result in a `NULL` pointer deref:

```
uart:~$ sensor get sensor@0 32
channel idx=32 (null) shift=6 num_samples=1 value=9220133425350000000ns (32.000000)
uart:~$ sensor get sensor@0 current
[870:26:48.134,000] <err> os: 
[870:26:48.134,000] <err> os:  mcause: 5, Load access fault
[870:26:48.134,000] <err> os:   mtval: 0
[870:26:48.134,000] <err> os:      a0: 0000000080016b36    t0: 000000008000dfc0
[870:26:48.134,000] <err> os:      a1: 0000000000000000    t1: 0000000000000039
[870:26:48.134,000] <err> os:      a2: 0000000000000063    t2: 0000000000000000
[870:26:48.134,000] <err> os:      a3: 0000000000000076    t3: 000000000000000c
[870:26:48.134,000] <err> os:      a4: 0000000080016b37    t4: 0000000000000020
[870:26:48.134,000] <err> os:      a5: 0000000000000063    t5: aaaaaaaaaaaaaaaa
[870:26:48.134,000] <err> os:      a6: 000000000000000a    t6: aaaaaaaaaaaaaaaa
[870:26:48.134,000] <err> os:      a7: 0000000080016b36
[870:26:48.134,000] <err> os:      sp: 0000000080019870
[870:26:48.134,000] <err> os:      ra: 0000000080008b86
[870:26:48.134,000] <err> os:    mepc: 000000008000ddd2
[870:26:48.134,000] <err> os: mstatus: 0000000a00001880
[870:26:48.134,000] <err> os: 
[870:26:48.134,000] <err> os: >>> ZEPHYR FATAL ERROR 0: CPU exception on CPU 0
[870:26:48.134,000] <err> os: Current thread: 0x80016688 (shell_uart)
[870:26:48.144,000] <err> os: Halting system
```

and using a non-sensor device in the command will cause a hang:

```
uart:~$ sensor get sensor@0 ambient_temp 
channel idx=13 ambient_temp shift=11 num_samples=1 value=9220133425350000000ns (1234.005677)
uart:~$ sensor get uart@10000000 ambient_temp
<hang>
```

This PR fixes that:

```
uart:~$ sensor get sensor@0 current
channel idx=33 current shift=6 num_samples=1 value=9220133425350000000ns (33.999999)
uart:~$ sensor get sensor@0 ambient_temp
channel idx=13 ambient_temp shift=11 num_samples=1 value=9220133425350000000ns (1234.005677)
uart:~$ sensor get uart@10000000 ambient_temp
Device is not a sensor (uart@10000000)
uart:~$ sensor attr_get uart@10000000 ambient_temp
Device is not a sensor (uart@10000000)
uart:~$ sensor attr_set uart@10000000 ambient_temp
Device is not a sensor (uart@10000000)
uart:~$ sensor attr_set uart@10000000 sampling_frequency
Device is not a sensor (uart@10000000)
uart:~$ 
```

Fixes #72838