### PR TITLE
west: twister: Fix default options setup

### DIFF
--- a/scripts/west_commands/twister_cmd.py
+++ b/scripts/west_commands/twister_cmd.py
@@ -56,8 +56,9 @@ class Twister(WestCommand):
             "args: {} remainder: {}".format(args, remainder), level=log.VERBOSE_EXTREME
         )
 
-        options = self._parse_arguments(args=remainder, options=args)
-        ret = main(options)
+        options = parse_arguments(self.parser, args=remainder, options=args)
+        default_options = parse_arguments(self.parser, args=[], on_init=False)
+        ret = main(options, default_options)
         sys.exit(ret)
 
     def _parse_arguments(self, args, options):


### PR DESCRIPTION
Fix missing change to run Twister with default options setup.

Should be implemented together with #72399