### PR TITLE
ARC: nSIM: hs5x: align sys clock with other SMP nSIM configs

### DIFF
--- a/soc/snps/nsim/Kconfig.defconfig.hs5x_smp
+++ b/soc/snps/nsim/Kconfig.defconfig.hs5x_smp
@@ -15,7 +15,7 @@ config NUM_IRQS
 	default 30
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	default 5000000
+	default 1000000
 
 config CACHE_MANAGEMENT
 	default y


### PR DESCRIPTION
Align SYS_CLOCK_HW_CYCLES_PER_SEC with other SMP nSIM configurations (set it to 1000000)

This significantly reduce verification time on HS5x SMP platforms.