### PR TITLE
drivers: watchdog: Add support for Apollo3 SoCs watchdog

### DIFF
--- a/boards/ambiq/apollo3_evb/apollo3_evb.dts
+++ b/boards/ambiq/apollo3_evb/apollo3_evb.dts
@@ -91,6 +91,10 @@
 	status = "okay";
 };
 
+&wdt0 {
+	status = "okay";
+};
+
 &gpio0_31 {
 	status = "okay";
 };

--- a/boards/ambiq/apollo3_evb/apollo3_evb.yaml
+++ b/boards/ambiq/apollo3_evb/apollo3_evb.yaml
@@ -9,6 +9,7 @@ toolchain:
   - gnuarmemb
 supported:
   - uart
+  - watchdog
   - gpio
 testing:
   ignore_tags:

--- a/boards/ambiq/apollo3p_evb/apollo3p_evb.dts
+++ b/boards/ambiq/apollo3p_evb/apollo3p_evb.dts
@@ -91,6 +91,10 @@
 	status = "okay";
 };
 
+&wdt0 {
+	status = "okay";
+};
+
 &gpio0_31 {
 	status = "okay";
 };

--- a/boards/ambiq/apollo3p_evb/apollo3p_evb.yaml
+++ b/boards/ambiq/apollo3p_evb/apollo3p_evb.yaml
@@ -9,6 +9,7 @@ toolchain:
   - gnuarmemb
 supported:
   - uart
+  - watchdog
   - gpio
 testing:
   ignore_tags:

--- a/drivers/watchdog/wdt_ambiq.c
+++ b/drivers/watchdog/wdt_ambiq.c
@@ -35,10 +35,13 @@ static void wdt_ambiq_isr(void *arg)
 	const struct device *dev = (const struct device *)arg;
 	struct wdt_ambiq_data *data = dev->data;
 
+#if defined(CONFIG_SOC_SERIES_APOLLO3X)
+	am_hal_wdt_int_clear();
+#else
 	uint32_t status;
-
 	am_hal_wdt_interrupt_status_get(AM_HAL_WDT_MCU, &status, false);
 	am_hal_wdt_interrupt_clear(AM_HAL_WDT_MCU, status);
+#endif
 
 	if (data->callback) {
 		data->callback(dev, 0);
@@ -51,6 +54,25 @@ static int wdt_ambiq_setup(const struct device *dev, uint8_t options)
 	struct wdt_ambiq_data *data = dev->data;
 	am_hal_wdt_config_t cfg;
 
+#if defined(CONFIG_SOC_SERIES_APOLLO3X)
+	uint32_t ui32ClockSource = AM_HAL_WDT_LFRC_CLK_DEFAULT;
+
+	if (dev_cfg->clk_freq == 128) {
+		ui32ClockSource = AM_HAL_WDT_LFRC_CLK_128HZ;
+	} else if (dev_cfg->clk_freq == 16) {
+		ui32ClockSource = AM_HAL_WDT_LFRC_CLK_16HZ;
+	} else if (dev_cfg->clk_freq == 1) {
+		ui32ClockSource = AM_HAL_WDT_LFRC_CLK_1HZ;
+	}
+	cfg.ui32Config = ui32ClockSource | _VAL2FLD(WDT_CFG_RESEN, data->reset) |
+			 AM_HAL_WDT_ENABLE_INTERRUPT;
+	cfg.ui16InterruptCount = data->timeout;
+	cfg.ui16ResetCount = data->timeout;
+	am_hal_clkgen_control(AM_HAL_CLKGEN_CONTROL_LFRC_START, 0);
+	am_hal_wdt_init(&cfg);
+	am_hal_wdt_int_enable();
+	am_hal_wdt_start();
+#else
 	if (dev_cfg->clk_freq == 128) {
 		cfg.eClockSource = AM_HAL_WDT_128HZ;
 	} else if (dev_cfg->clk_freq == 16) {
@@ -68,7 +90,7 @@ static int wdt_ambiq_setup(const struct device *dev, uint8_t options)
 	am_hal_wdt_config(AM_HAL_WDT_MCU, &cfg);
 	am_hal_wdt_interrupt_enable(AM_HAL_WDT_MCU, AM_HAL_WDT_INTERRUPT_MCU);
 	am_hal_wdt_start(AM_HAL_WDT_MCU, false);
-
+#endif
 	return 0;
 }
 
@@ -76,8 +98,11 @@ static int wdt_ambiq_disable(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 
+#if defined(CONFIG_SOC_SERIES_APOLLO3X)
+	am_hal_wdt_halt();
+#else
 	am_hal_wdt_stop(AM_HAL_WDT_MCU);
-
+#endif
 	return 0;
 }
 
@@ -114,7 +139,11 @@ static int wdt_ambiq_feed(const struct device *dev, int channel_id)
 	ARG_UNUSED(dev);
 	ARG_UNUSED(channel_id);
 
+#if defined(CONFIG_SOC_SERIES_APOLLO3X)
+	am_hal_wdt_restart();
+#else
 	am_hal_wdt_restart(AM_HAL_WDT_MCU);
+#endif
 	LOG_DBG("Fed the watchdog");
 
 	return 0;


### PR DESCRIPTION
This commit adds support for the watchdog which
can be found in Apollo3 SoCs