### PR TITLE
drivers: spi: fix the bug for atcspi200

### DIFF
--- a/drivers/spi/spi_andes_atcspi200.c
+++ b/drivers/spi/spi_andes_atcspi200.c
@@ -23,7 +23,6 @@ typedef void (*atcspi200_cfg_func_t)(void);
 struct stream {
 	const struct device *dma_dev;
 	uint32_t channel;
-	uint32_t block_idx;
 	struct dma_config dma_cfg;
 	struct dma_block_config dma_blk_cfg;
 	struct dma_block_config chain_block[MAX_CHAIN_SIZE];
@@ -38,6 +37,7 @@ struct spi_atcspi200_data {
 	uint32_t tx_fifo_size;
 	uint32_t rx_fifo_size;
 	int tx_cnt;
+	int rx_cnt;
 	size_t chunk_len;
 	bool busy;
 #ifdef CONFIG_ANDES_SPI_DMA_MODE
@@ -124,7 +124,8 @@ static int spi_transfer(const struct device *dev)
 		return -EINVAL;
 	}
 
-	data->tx_cnt = 0;
+	data->tx_cnt = data->chunk_len;
+	data->rx_cnt = data->chunk_len;
 
 	if (!spi_context_rx_on(ctx)) {
 		tctrl = (TRNS_MODE_WRITE_ONLY << TCTRL_TRNS_MODE_OFFSET) |
@@ -255,13 +256,12 @@ static inline void dma_rx_callback(const struct device *dev, void *user_data,
 {
 	const struct device *spi_dev = (struct device *)user_data;
 	struct spi_atcspi200_data *data = spi_dev->data;
-	struct spi_context *ctx = &data->ctx;
 	int error;
 
 	dma_stop(data->dma_rx.dma_dev, data->dma_rx.channel);
 	spi_rx_dma_disable(spi_dev);
 
-	if (spi_context_rx_on(ctx)) {
+	if (data->rx_cnt) {
 		if (spi_dma_rx_load(spi_dev) != 0) {
 			return;
 		}
@@ -276,13 +276,12 @@ static inline void dma_tx_callback(const struct device *dev, void *user_data,
 {
 	const struct device *spi_dev = (struct device *)user_data;
 	struct spi_atcspi200_data *data = spi_dev->data;
-	struct spi_context *ctx = &data->ctx;
 	int error;
 
 	dma_stop(data->dma_tx.dma_dev, data->dma_tx.channel);
 	spi_tx_dma_disable(spi_dev);
 
-	if (spi_context_tx_on(ctx)) {
+	if (data->tx_cnt) {
 		if (spi_dma_tx_load(spi_dev) != 0) {
 			return;
 		}
@@ -303,103 +302,90 @@ static int spi_dma_tx_load(const struct device *dev)
 	const struct spi_atcspi200_cfg * const cfg = dev->config;
 	struct spi_atcspi200_data *data = dev->data;
 	struct spi_context *ctx = &data->ctx;
-	int remain_len, ret, dfs;
+	int ret, dfs;
 
 	/* prepare the block for this TX DMA channel */
 	memset(&data->dma_tx.dma_blk_cfg, 0, sizeof(struct dma_block_config));
-
-	if (ctx->current_tx->len > data->chunk_len) {
-		data->dma_tx.dma_blk_cfg.block_size = data->chunk_len /
-					data->dma_tx.dma_cfg.dest_data_size;
-	} else {
-		data->dma_tx.dma_blk_cfg.block_size = ctx->current_tx->len /
-					data->dma_tx.dma_cfg.dest_data_size;
-	}
+	dfs = SPI_WORD_SIZE_GET(ctx->config->operation) >> 3;
 
 	/* tx direction has memory as source and periph as dest. */
-	if (ctx->current_tx->buf == NULL) {
+	if (ctx->tx_buf == NULL && ctx->tx_count == 0) {
 		dummy_rx_tx_buffer = 0;
+		data->dma_tx.dma_blk_cfg.block_size = data->tx_cnt;
 		/* if tx buff is null, then sends NOP on the line. */
 		data->dma_tx.dma_blk_cfg.source_address = (uintptr_t)&dummy_rx_tx_buffer;
 		data->dma_tx.dma_blk_cfg.source_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
+		data->tx_cnt = 0;
 	} else {
-		data->dma_tx.dma_blk_cfg.source_address = (uintptr_t)ctx->current_tx->buf;
-		if (data->dma_tx.src_addr_increment) {
+		data->dma_tx.dma_blk_cfg.block_size = ctx->current_tx->len /
+						data->dma_tx.dma_cfg.dest_data_size;
+		if (ctx->current_tx->buf != NULL) {
+			data->dma_tx.dma_blk_cfg.source_address = (uintptr_t)ctx->current_tx->buf;
 			data->dma_tx.dma_blk_cfg.source_addr_adj = DMA_ADDR_ADJ_INCREMENT;
 		} else {
+			dummy_rx_tx_buffer = 0;
+			data->dma_tx.dma_blk_cfg.source_address = (uintptr_t)&dummy_rx_tx_buffer;
 			data->dma_tx.dma_blk_cfg.source_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
 		}
+		data->tx_cnt -= ctx->current_tx->len;
+		spi_context_update_tx(ctx, dfs, ctx->current_tx->len);
 	}
-
-	dfs = SPI_WORD_SIZE_GET(ctx->config->operation) >> 3;
-	remain_len = data->chunk_len - ctx->current_tx->len;
-	spi_context_update_tx(ctx, dfs, ctx->current_tx->len);
 
 	data->dma_tx.dma_blk_cfg.dest_address = (uint32_t)SPI_DATA(cfg->base);
-	/* fifo mode NOT USED there */
-	if (data->dma_tx.dst_addr_increment) {
-		data->dma_tx.dma_blk_cfg.dest_addr_adj = DMA_ADDR_ADJ_INCREMENT;
-	} else {
-		data->dma_tx.dma_blk_cfg.dest_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
-	}
+	data->dma_tx.dma_blk_cfg.dest_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
 
 	/* direction is given by the DT */
+	data->dma_tx.dma_cfg.block_count = 1;
 	data->dma_tx.dma_cfg.head_block = &data->dma_tx.dma_blk_cfg;
 	data->dma_tx.dma_cfg.head_block->next_block = NULL;
 	/* give the client dev as arg, as the callback comes from the dma */
 	data->dma_tx.dma_cfg.user_data = (void *)dev;
 
 	if (data->dma_tx.dma_cfg.source_chaining_en) {
-		data->dma_tx.dma_cfg.block_count = ctx->tx_count;
 		data->dma_tx.dma_cfg.dma_callback = NULL;
-		data->dma_tx.block_idx = 0;
 		struct dma_block_config *blk_cfg = &data->dma_tx.dma_blk_cfg;
-		const struct spi_buf *current_tx = ctx->current_tx;
 
-		while (remain_len > 0) {
+		while (data->tx_cnt > 0) {
 			struct dma_block_config *next_blk_cfg;
 
-			next_blk_cfg = &data->dma_tx.chain_block[data->dma_tx.block_idx];
-			data->dma_tx.block_idx += 1;
-
+			next_blk_cfg =
+				&data->dma_tx.chain_block[data->dma_tx.dma_cfg.block_count - 1];
+			data->dma_tx.dma_cfg.block_count += 1;
 			blk_cfg->next_block = next_blk_cfg;
-			current_tx = ctx->current_tx;
-
-			next_blk_cfg->block_size = current_tx->len /
-						data->dma_tx.dma_cfg.dest_data_size;
 
 			/* tx direction has memory as source and periph as dest. */
-			if (current_tx->buf == NULL) {
+			if (ctx->tx_buf == NULL && ctx->tx_count == 0) {
 				dummy_rx_tx_buffer = 0;
+				next_blk_cfg->block_size = data->tx_cnt;
 				/* if tx buff is null, then sends NOP on the line. */
 				next_blk_cfg->source_address = (uintptr_t)&dummy_rx_tx_buffer;
 				next_blk_cfg->source_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
+				data->tx_cnt = 0;
 			} else {
-				next_blk_cfg->source_address = (uintptr_t)current_tx->buf;
-				if (data->dma_tx.src_addr_increment) {
+				next_blk_cfg->block_size = ctx->current_tx->len /
+							data->dma_tx.dma_cfg.dest_data_size;
+				if (ctx->current_tx->buf != NULL) {
+					next_blk_cfg->source_address =
+								(uintptr_t)ctx->current_tx->buf;
 					next_blk_cfg->source_addr_adj = DMA_ADDR_ADJ_INCREMENT;
 				} else {
+					next_blk_cfg->source_address =
+								(uintptr_t)&dummy_rx_tx_buffer;
 					next_blk_cfg->source_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
 				}
+				data->tx_cnt -= ctx->current_tx->len;
+				spi_context_update_tx(ctx, dfs, ctx->current_tx->len);
 			}
 
 			next_blk_cfg->dest_address = (uint32_t)SPI_DATA(cfg->base);
-			/* fifo mode NOT USED there */
-			if (data->dma_tx.dst_addr_increment) {
-				next_blk_cfg->dest_addr_adj = DMA_ADDR_ADJ_INCREMENT;
-			} else {
-				next_blk_cfg->dest_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
-			}
+			next_blk_cfg->dest_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
 
 			blk_cfg = next_blk_cfg;
 			next_blk_cfg->next_block = NULL;
-			remain_len -= ctx->current_tx->len;
-			spi_context_update_tx(ctx, dfs, ctx->current_tx->len);
 		}
 
 	} else {
 		data->dma_tx.dma_blk_cfg.next_block = NULL;
-		data->dma_tx.dma_cfg.block_count = 1;
 		data->dma_tx.dma_cfg.dma_callback = dma_tx_callback;
 	}
 
@@ -408,7 +394,7 @@ static int spi_dma_tx_load(const struct device *dev)
 			&data->dma_tx.dma_cfg);
 	/* the channel is the actual stream from 0 */
 	if (ret != 0) {
-		data->dma_tx.block_idx = 0;
+		data->dma_tx.dma_cfg.block_count = 0;
 		data->dma_tx.dma_blk_cfg.next_block = NULL;
 		return ret;
 	}
@@ -421,94 +407,83 @@ static int spi_dma_rx_load(const struct device *dev)
 	const struct spi_atcspi200_cfg * const cfg = dev->config;
 	struct spi_atcspi200_data *data = dev->data;
 	struct spi_context *ctx = &data->ctx;
-	int remain_len, ret, dfs;
+	int ret, dfs;
 
 	/* prepare the block for this RX DMA channel */
 	memset(&data->dma_rx.dma_blk_cfg, 0, sizeof(struct dma_block_config));
-
-	if (ctx->current_rx->len > data->chunk_len) {
-		data->dma_rx.dma_blk_cfg.block_size = data->chunk_len /
-					data->dma_rx.dma_cfg.dest_data_size;
-	} else {
-		data->dma_rx.dma_blk_cfg.block_size = ctx->current_rx->len /
-					data->dma_rx.dma_cfg.dest_data_size;
-	}
+	dfs = SPI_WORD_SIZE_GET(ctx->config->operation) >> 3;
 
 	/* rx direction has periph as source and mem as dest. */
-	if (ctx->current_rx->buf == NULL) {
+	if (ctx->rx_buf == NULL && ctx->rx_count == 0) {
+		data->dma_rx.dma_blk_cfg.block_size = data->rx_cnt;
 		/* if rx buff is null, then write data to dummy address. */
 		data->dma_rx.dma_blk_cfg.dest_address = (uintptr_t)&dummy_rx_tx_buffer;
 		data->dma_rx.dma_blk_cfg.dest_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
+		data->rx_cnt = 0;
 	} else {
-		data->dma_rx.dma_blk_cfg.dest_address = (uintptr_t)ctx->current_rx->buf;
-		if (data->dma_rx.dst_addr_increment) {
+		data->dma_rx.dma_blk_cfg.block_size = ctx->current_rx->len /
+					data->dma_rx.dma_cfg.dest_data_size;
+		if (ctx->current_rx->buf != NULL) {
+			data->dma_rx.dma_blk_cfg.dest_address = (uintptr_t)ctx->current_rx->buf;
 			data->dma_rx.dma_blk_cfg.dest_addr_adj = DMA_ADDR_ADJ_INCREMENT;
 		} else {
+			data->dma_rx.dma_blk_cfg.dest_address = (uintptr_t)&dummy_rx_tx_buffer;
 			data->dma_rx.dma_blk_cfg.dest_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
 		}
+		data->rx_cnt -= ctx->current_rx->len;
+		spi_context_update_rx(ctx, dfs, ctx->current_rx->len);
 	}
-
-	dfs = SPI_WORD_SIZE_GET(ctx->config->operation) >> 3;
-	remain_len = data->chunk_len - ctx->current_rx->len;
-	spi_context_update_rx(ctx, dfs, ctx->current_rx->len);
 
 	data->dma_rx.dma_blk_cfg.source_address = (uint32_t)SPI_DATA(cfg->base);
+	data->dma_rx.dma_blk_cfg.source_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
 
-	if (data->dma_rx.src_addr_increment) {
-		data->dma_rx.dma_blk_cfg.source_addr_adj = DMA_ADDR_ADJ_INCREMENT;
-	} else {
-		data->dma_rx.dma_blk_cfg.source_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
-	}
-
+	data->dma_rx.dma_cfg.block_count = 1;
 	data->dma_rx.dma_cfg.head_block = &data->dma_rx.dma_blk_cfg;
 	data->dma_rx.dma_cfg.head_block->next_block = NULL;
 	data->dma_rx.dma_cfg.user_data = (void *)dev;
 
 	if (data->dma_rx.dma_cfg.source_chaining_en) {
-		data->dma_rx.dma_cfg.block_count = ctx->rx_count;
 		data->dma_rx.dma_cfg.dma_callback = NULL;
-		data->dma_rx.block_idx = 0;
 		struct dma_block_config *blk_cfg = &data->dma_rx.dma_blk_cfg;
-		const struct spi_buf *current_rx = ctx->current_rx;
 
-		while (remain_len > 0) {
+		while (data->rx_cnt > 0) {
 			struct dma_block_config *next_blk_cfg;
 
-			next_blk_cfg = &data->dma_rx.chain_block[data->dma_rx.block_idx];
-			data->dma_rx.block_idx += 1;
-
+			next_blk_cfg =
+				&data->dma_rx.chain_block[data->dma_rx.dma_cfg.block_count - 1];
+			data->dma_rx.dma_cfg.block_count += 1;
 			blk_cfg->next_block = next_blk_cfg;
-			current_rx = ctx->current_rx;
-
-			next_blk_cfg->block_size = current_rx->len /
-						data->dma_rx.dma_cfg.dest_data_size;
 
 			/* rx direction has periph as source and mem as dest. */
-			if (current_rx->buf == NULL) {
+			if (ctx->rx_buf == NULL && ctx->rx_count == 0) {
+				next_blk_cfg->block_size = data->rx_cnt;
 				/* if rx buff is null, then write data to dummy address. */
 				next_blk_cfg->dest_address = (uintptr_t)&dummy_rx_tx_buffer;
 				next_blk_cfg->dest_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
+				data->rx_cnt = 0;
 			} else {
-				next_blk_cfg->dest_address = (uintptr_t)current_rx->buf;
-				if (data->dma_rx.dst_addr_increment) {
+				next_blk_cfg->block_size = ctx->current_rx->len /
+							data->dma_rx.dma_cfg.dest_data_size;
+
+				if (ctx->current_rx->buf != NULL) {
+					next_blk_cfg->dest_address =
+								(uintptr_t)ctx->current_rx->buf;
 					next_blk_cfg->dest_addr_adj = DMA_ADDR_ADJ_INCREMENT;
 				} else {
+					next_blk_cfg->dest_address =
+								(uintptr_t)&dummy_rx_tx_buffer;
 					next_blk_cfg->dest_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
 				}
+
+				data->rx_cnt -= ctx->current_rx->len;
+				spi_context_update_rx(ctx, dfs, ctx->current_rx->len);
 			}
 
 			next_blk_cfg->source_address = (uint32_t)SPI_DATA(cfg->base);
-
-			if (data->dma_rx.src_addr_increment) {
-				next_blk_cfg->source_addr_adj = DMA_ADDR_ADJ_INCREMENT;
-			} else {
-				next_blk_cfg->source_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
-			}
+			next_blk_cfg->source_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
 
 			blk_cfg = next_blk_cfg;
 			next_blk_cfg->next_block = NULL;
-			remain_len -= ctx->current_rx->len;
-			spi_context_update_rx(ctx, dfs, ctx->current_rx->len);
 		}
 	} else {
 		data->dma_rx.dma_blk_cfg.next_block = NULL;
@@ -521,7 +496,7 @@ static int spi_dma_rx_load(const struct device *dev)
 			&data->dma_rx.dma_cfg);
 	/* the channel is the actual stream from 0 */
 	if (ret != 0) {
-		data->dma_rx.block_idx = 0;
+		data->dma_rx.dma_cfg.block_count = 0;
 		data->dma_rx.dma_blk_cfg.next_block = NULL;
 		return ret;
 	}
@@ -541,6 +516,9 @@ static int spi_transfer_dma(const struct device *dev)
 	if (data_len > MAX_TRANSFER_CNT) {
 		return -EINVAL;
 	}
+
+	data->tx_cnt = data->chunk_len;
+	data->rx_cnt = data->chunk_len;
 
 	if (!spi_context_rx_on(ctx)) {
 		tctrl = (TRNS_MODE_WRITE_ONLY << TCTRL_TRNS_MODE_OFFSET) |
@@ -630,7 +608,7 @@ static int transceive(const struct device *dev,
 			size_t rx_len = spi_context_total_rx_len(ctx);
 			size_t tx_len = spi_context_total_tx_len(ctx);
 
-			chunk_len = MIN(rx_len, tx_len);
+			chunk_len = MAX(rx_len, tx_len);
 		}
 
 		data->chunk_len = chunk_len;
@@ -737,7 +715,7 @@ int spi_atcspi200_init(const struct device *dev)
 	return 0;
 }
 
-static const struct spi_driver_api spi_atcspi200_api = {
+static struct spi_driver_api spi_atcspi200_api = {
 	.transceive = spi_atcspi200_transceive,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = spi_atcspi200_transceive_async,
@@ -769,14 +747,6 @@ static void spi_atcspi200_irq_handler(void *arg)
 
 		for (i = tx_num; i > 0; i--) {
 
-			if (data->tx_cnt >= data->chunk_len) {
-				/* Have already sent a chunk of data, so stop
-				 * sending data!
-				 */
-				sys_clear_bits(SPI_INTEN(cfg->base), IEN_TX_FIFO_MSK);
-				break;
-			}
-
 			if (spi_context_tx_buf_on(ctx)) {
 
 				switch (dfs) {
@@ -790,16 +760,21 @@ static void spi_atcspi200_irq_handler(void *arg)
 
 			} else if (spi_context_tx_on(ctx)) {
 				tx_data = 0;
-			} else {
-				sys_clear_bits(SPI_INTEN(cfg->base), IEN_TX_FIFO_MSK);
-				break;
 			}
 
 			sys_write32(tx_data, SPI_DATA(cfg->base));
 
 			spi_context_update_tx(ctx, dfs, 1);
 
-			data->tx_cnt++;
+			data->tx_cnt--;
+
+			if (data->tx_cnt == 0) {
+				/* Have already sent a chunk of data, so stop
+				 * sending data!
+				 */
+				sys_clear_bits(SPI_INTEN(cfg->base), IEN_TX_FIFO_MSK);
+				break;
+			}
 		}
 		sys_write32(INTST_TX_FIFO_INT_MSK, SPI_INTST(cfg->base));
 
@@ -823,8 +798,16 @@ static void spi_atcspi200_irq_handler(void *arg)
 					break;
 				}
 
-			} else if (!spi_context_rx_on(ctx)) {
+			}
+
+			data->rx_cnt--;
+
+			if (data->rx_cnt == 0) {
+				/* Have already sent a chunk of data, so stop
+				 * sending data!
+				 */
 				sys_clear_bits(SPI_INTEN(cfg->base), IEN_RX_FIFO_MSK);
+				break;
 			}
 
 			spi_context_update_rx(ctx, dfs, 1);
@@ -845,7 +828,7 @@ static void spi_atcspi200_irq_handler(void *arg)
 
 			spi_tx_dma_disable(dev);
 			dma_stop(data->dma_tx.dma_dev, data->dma_tx.channel);
-			data->dma_tx.block_idx = 0;
+			data->dma_tx.dma_cfg.block_count = 0;
 			data->dma_tx.dma_blk_cfg.next_block = NULL;
 		}
 
@@ -853,7 +836,7 @@ static void spi_atcspi200_irq_handler(void *arg)
 
 			spi_rx_dma_disable(dev);
 			dma_stop(data->dma_rx.dma_dev, data->dma_rx.channel);
-			data->dma_rx.block_idx = 0;
+			data->dma_rx.dma_cfg.block_count = 0;
 			data->dma_rx.dma_blk_cfg.next_block = NULL;
 		}
 #endif /* CONFIG_ANDES_SPI_DMA_MODE */
@@ -887,7 +870,7 @@ static void spi_atcspi200_irq_handler(void *arg)
 		.channel_direction = ANDES_DMA_CONFIG_DIRECTION(		\
 				     DMA_CHANNEL_CONFIG(index, dir)),		\
 		.complete_callback_en = 0,					\
-		.error_callback_dis = 0,					\
+		.error_callback_en = 0,						\
 		.source_data_size =						\
 			ANDES_DMA_CONFIG_##src_dev##_DATA_SIZE(			\
 					DMA_CHANNEL_CONFIG(index, dir)		\


### PR DESCRIPTION
Fixe the bug in some corner case when spi using dma scatter transfer mode.
Mainly to modify the error in the calculation of the block count and the size contained when the lengths of tx and rx are not equal.
This change has been verified on the adp_xc7k/ae350 board.