### PR TITLE
Enhance x86 apic timer driver

### DIFF
--- a/drivers/timer/Kconfig.x86
+++ b/drivers/timer/Kconfig.x86
@@ -68,12 +68,12 @@ config APIC_TIMER_IRQ
 	  a different mechanism.
 
 config APIC_TIMER_TSC
-	bool "Use invariant TSC for sys_clock_cycle_get_32()"
+	bool "Use invariant TSC for Local APIC timer's cycle count"
 	help
 	  If your CPU supports invariant TSC, and you know the ratio of the
 	  TSC frequency to CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC (the local APIC
 	  timer frequency), then enable this for a much faster and more
-	  accurate sys_clock_cycle_get_32().
+	  accurate Local APIC timer's cycle count.
 
 if APIC_TIMER_TSC
 

--- a/drivers/timer/Kconfig.x86
+++ b/drivers/timer/Kconfig.x86
@@ -28,6 +28,7 @@ config APIC_TIMER
 	select LOAPIC
 	select TICKLESS_CAPABLE
 	select SYSTEM_CLOCK_LOCK_FREE_COUNT
+	select TIMER_HAS_64BIT_CYCLE_COUNTER
 	help
 	  Use the x86 local APIC in one-shot mode as the system time
 	  source.  NOTE: this probably isn't what you want except on
@@ -68,7 +69,6 @@ config APIC_TIMER_IRQ
 
 config APIC_TIMER_TSC
 	bool "Use invariant TSC for sys_clock_cycle_get_32()"
-	select TIMER_HAS_64BIT_CYCLE_COUNTER
 	help
 	  If your CPU supports invariant TSC, and you know the ratio of the
 	  TSC frequency to CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC (the local APIC

--- a/drivers/timer/apic_timer.c
+++ b/drivers/timer/apic_timer.c
@@ -192,20 +192,18 @@ uint32_t sys_clock_elapsed(void)
 
 #ifdef CONFIG_APIC_TIMER_TSC
 
-uint32_t sys_clock_cycle_get_32(void)
+uint64_t sys_clock_cycle_get_64(void)
 {
 	uint64_t tsc = z_tsc_read();
-	uint32_t cycles;
 
-	cycles = (tsc * CONFIG_APIC_TIMER_TSC_M) / CONFIG_APIC_TIMER_TSC_N;
-	return cycles;
+	return (tsc * CONFIG_APIC_TIMER_TSC_M) / CONFIG_APIC_TIMER_TSC_N;
 }
 
 #else
 
-uint32_t sys_clock_cycle_get_32(void)
+uint64_t sys_clock_cycle_get_64(void)
 {
-	uint32_t ret;
+	uint64_t ret;
 	uint32_t ccr;
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
@@ -217,6 +215,11 @@ uint32_t sys_clock_cycle_get_32(void)
 }
 
 #endif
+
+uint32_t sys_clock_cycle_get_32(void)
+{
+	return (uint32_t)sys_clock_cycle_get_64();
+}
 
 static int sys_clock_driver_init(void)
 {

--- a/drivers/timer/apic_timer.c
+++ b/drivers/timer/apic_timer.c
@@ -164,7 +164,7 @@ static void isr(const void *arg)
 	cached_icr = MAX_TICKS * CYCLES_PER_TICK;
 	total_cycles += cycles;
 	ticks = (total_cycles - last_announcement) / CYCLES_PER_TICK;
-	last_announcement = total_cycles;
+	last_announcement += ticks * CYCLES_PER_TICK;
 	k_spin_unlock(&lock, key);
 	sys_clock_announce(ticks);
 }


### PR DESCRIPTION
1.  Add 64bit cycle counter support.
2.  Improve accuracy of last_announcement assignment.
3.  Improve TSC mode accuracy by using TSC count