### PR TITLE
drivers: counter: Add support for Apollo3 SoCs counter

### DIFF
--- a/boards/ambiq/apollo3_evb/apollo3_evb.dts
+++ b/boards/ambiq/apollo3_evb/apollo3_evb.dts
@@ -103,6 +103,38 @@
 	status = "okay";
 };
 
+&counter0 {
+	status = "okay";
+};
+
+&counter1 {
+	status = "okay";
+};
+
+&counter2 {
+	status = "okay";
+};
+
+&counter3 {
+	status = "okay";
+};
+
+&counter4 {
+	status = "okay";
+};
+
+&counter5 {
+	status = "okay";
+};
+
+&counter6 {
+	status = "okay";
+};
+
+&counter7 {
+	status = "okay";
+};
+
 &gpio0_31 {
 	status = "okay";
 };

--- a/boards/ambiq/apollo3_evb/apollo3_evb.yaml
+++ b/boards/ambiq/apollo3_evb/apollo3_evb.yaml
@@ -10,6 +10,7 @@ toolchain:
 supported:
   - uart
   - watchdog
+  - counter
   - gpio
   - i2c
 testing:

--- a/boards/ambiq/apollo3p_evb/apollo3p_evb.dts
+++ b/boards/ambiq/apollo3p_evb/apollo3p_evb.dts
@@ -103,6 +103,38 @@
 	status = "okay";
 };
 
+&counter0 {
+	status = "okay";
+};
+
+&counter1 {
+	status = "okay";
+};
+
+&counter2 {
+	status = "okay";
+};
+
+&counter3 {
+	status = "okay";
+};
+
+&counter4 {
+	status = "okay";
+};
+
+&counter5 {
+	status = "okay";
+};
+
+&counter6 {
+	status = "okay";
+};
+
+&counter7 {
+	status = "okay";
+};
+
 &gpio0_31 {
 	status = "okay";
 };

--- a/boards/ambiq/apollo3p_evb/apollo3p_evb.yaml
+++ b/boards/ambiq/apollo3p_evb/apollo3p_evb.yaml
@@ -10,6 +10,7 @@ toolchain:
 supported:
   - uart
   - watchdog
+  - counter
   - gpio
   - i2c
 testing:

--- a/drivers/counter/counter_ambiq_timer.c
+++ b/drivers/counter/counter_ambiq_timer.c
@@ -18,10 +18,11 @@ LOG_MODULE_REGISTER(ambiq_counter, CONFIG_COUNTER_LOG_LEVEL);
 
 static void counter_ambiq_isr(void *arg);
 
-#define TIMER_IRQ (DT_INST_IRQN(0))
-
 struct counter_ambiq_config {
 	struct counter_config_info counter_info;
+	uint32_t instance;
+	uint32_t clk_src;
+	void (*irq_config_func)(void);
 };
 
 struct counter_ambiq_data {
@@ -31,33 +32,76 @@ struct counter_ambiq_data {
 
 static struct k_spinlock lock;
 
+#if defined(CONFIG_SOC_SERIES_APOLLO3X)
+static void counter_irq_config_func(void)
+{
+	/* Apollo3 counters share the same irq number, connect to counter0 once when init and handle
+	 * different banks in counter_ambiq_isr
+	 */
+	static bool global_irq_init = true;
+
+	if (!global_irq_init) {
+		return;
+	}
+
+	global_irq_init = false;
+
+	/* Shared irq config default to ctimer0. */
+	NVIC_ClearPendingIRQ(CTIMER_IRQn);
+	IRQ_CONNECT(CTIMER_IRQn, DT_INST_IRQ(0, priority), counter_ambiq_isr, DEVICE_DT_INST_GET(0),
+		    0);
+	irq_enable(CTIMER_IRQn);
+};
+#endif
+
 static int counter_ambiq_init(const struct device *dev)
 {
+	k_spinlock_key_t key = k_spin_lock(&lock);
+	const struct counter_ambiq_config *cfg = dev->config;
+
+#if defined(CONFIG_SOC_SERIES_APOLLO3X)
+	/* Timer configuration */
+	am_hal_ctimer_config_t sContTimer;
+	/* Create 32-bit timer */
+	sContTimer.ui32Link = 1;
+	/* Set up TimerA. */
+	sContTimer.ui32TimerAConfig = (AM_HAL_CTIMER_FN_REPEAT | AM_HAL_CTIMER_INT_ENABLE |
+				       (cfg->clk_src << CTIMER_CTRL0_TMRA0CLK_Pos));
+	/* Set up TimerB. */
+	sContTimer.ui32TimerBConfig = 0;
+
+	am_hal_clkgen_control(AM_HAL_CLKGEN_CONTROL_SYSCLK_MAX, 0);
+
+	am_hal_ctimer_clear(cfg->instance, AM_HAL_CTIMER_BOTH);
+	am_hal_ctimer_config(cfg->instance, &sContTimer);
+	counter_irq_config_func();
+#else
 	am_hal_timer_config_t tc;
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
-
 	am_hal_timer_default_config_set(&tc);
-	tc.eInputClock = AM_HAL_TIMER_CLOCK_HFRC_DIV16;
+	tc.eInputClock = cfg->clk_src;
 	tc.eFunction = AM_HAL_TIMER_FN_UPCOUNT;
 	tc.ui32PatternLimit = 0;
 
-	am_hal_timer_config(0, &tc);
+	am_hal_timer_config(cfg->instance, &tc);
+	cfg->irq_config_func();
+#endif
 
 	k_spin_unlock(&lock, key);
-
-	NVIC_ClearPendingIRQ(TIMER_IRQ);
-	IRQ_CONNECT(TIMER_IRQ, 0, counter_ambiq_isr, DEVICE_DT_INST_GET(0), 0);
-	irq_enable(TIMER_IRQ);
 
 	return 0;
 }
 
 static int counter_ambiq_start(const struct device *dev)
 {
+	const struct counter_ambiq_config *cfg = dev->config;
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
-	am_hal_timer_start(0);
+#if defined(CONFIG_SOC_SERIES_APOLLO3X)
+	am_hal_ctimer_start(cfg->instance, AM_HAL_CTIMER_TIMERA);
+#else
+	am_hal_timer_start(cfg->instance);
+#endif
 
 	k_spin_unlock(&lock, key);
 
@@ -66,9 +110,15 @@ static int counter_ambiq_start(const struct device *dev)
 
 static int counter_ambiq_stop(const struct device *dev)
 {
+	const struct counter_ambiq_config *cfg = dev->config;
+
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
-	am_hal_timer_stop(0);
+#if defined(CONFIG_SOC_SERIES_APOLLO3X)
+	am_hal_ctimer_stop(cfg->instance, AM_HAL_CTIMER_BOTH);
+#else
+	am_hal_timer_stop(cfg->instance);
+#endif
 
 	k_spin_unlock(&lock, key);
 
@@ -77,9 +127,16 @@ static int counter_ambiq_stop(const struct device *dev)
 
 static int counter_ambiq_get_value(const struct device *dev, uint32_t *ticks)
 {
+	const struct counter_ambiq_config *cfg = dev->config;
+
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
-	*ticks = am_hal_timer_read(0);
+#if defined(CONFIG_SOC_SERIES_APOLLO3X)
+	*ticks = (am_hal_ctimer_read(cfg->instance, AM_HAL_CTIMER_TIMERA)) |
+		 (am_hal_ctimer_read(cfg->instance, AM_HAL_CTIMER_TIMERB) << 16);
+#else
+	*ticks = am_hal_timer_read(cfg->instance);
+#endif
 
 	k_spin_unlock(&lock, key);
 
@@ -91,21 +148,34 @@ static int counter_ambiq_set_alarm(const struct device *dev, uint8_t chan_id,
 {
 	ARG_UNUSED(chan_id);
 	struct counter_ambiq_data *data = dev->data;
+	const struct counter_ambiq_config *cfg = dev->config;
 	uint32_t now;
 
 	counter_ambiq_get_value(dev, &now);
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
-	/* Enable interrupt, due to counter_ambiq_cancel_alarm() disables it*/
-	am_hal_timer_interrupt_clear(AM_HAL_TIMER_MASK(0, AM_HAL_TIMER_COMPARE1));
-	am_hal_timer_interrupt_enable(AM_HAL_TIMER_MASK(0, AM_HAL_TIMER_COMPARE1));
+#if defined(CONFIG_SOC_SERIES_APOLLO3X)
+	am_hal_ctimer_int_clear(AM_HAL_CTIMER_INT_TIMERA0C0);
+	am_hal_ctimer_int_enable(AM_HAL_CTIMER_INT_TIMERA0C0);
 
 	if ((alarm_cfg->flags & COUNTER_ALARM_CFG_ABSOLUTE) == 0) {
-		am_hal_timer_compare1_set(0, now + alarm_cfg->ticks);
+		am_hal_ctimer_compare_set(cfg->instance, AM_HAL_CTIMER_BOTH, 0,
+					  now + alarm_cfg->ticks);
 	} else {
-		am_hal_timer_compare1_set(0, alarm_cfg->ticks);
+		am_hal_ctimer_compare_set(cfg->instance, AM_HAL_CTIMER_BOTH, 0, alarm_cfg->ticks);
 	}
+#else
+	/* Enable interrupt, due to counter_ambiq_cancel_alarm() disables it*/
+	am_hal_timer_interrupt_clear(AM_HAL_TIMER_MASK(cfg->instance, AM_HAL_TIMER_COMPARE1));
+	am_hal_timer_interrupt_enable(AM_HAL_TIMER_MASK(cfg->instance, AM_HAL_TIMER_COMPARE1));
+
+	if ((alarm_cfg->flags & COUNTER_ALARM_CFG_ABSOLUTE) == 0) {
+		am_hal_timer_compare1_set(cfg->instance, now + alarm_cfg->ticks);
+	} else {
+		am_hal_timer_compare1_set(cfg->instance, alarm_cfg->ticks);
+	}
+#endif
 
 	data->user_data = alarm_cfg->user_data;
 	data->callback = alarm_cfg->callback;
@@ -118,12 +188,19 @@ static int counter_ambiq_set_alarm(const struct device *dev, uint8_t chan_id,
 static int counter_ambiq_cancel_alarm(const struct device *dev, uint8_t chan_id)
 {
 	ARG_UNUSED(chan_id);
-
+	const struct counter_ambiq_config *cfg = dev->config;
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
-	am_hal_timer_interrupt_disable(AM_HAL_TIMER_MASK(0, AM_HAL_TIMER_COMPARE1));
+#if defined(CONFIG_SOC_SERIES_APOLLO3X)
+	am_hal_ctimer_int_disable(AM_HAL_CTIMER_INT_TIMERA0C0);
 	/* Reset the compare register */
-	am_hal_timer_compare1_set(0, 0);
+	am_hal_ctimer_compare_set(cfg->instance, AM_HAL_CTIMER_BOTH, 0, 0);
+#else
+	am_hal_timer_interrupt_disable(AM_HAL_TIMER_MASK(cfg->instance, AM_HAL_TIMER_COMPARE1));
+	/* Reset the compare register */
+	am_hal_timer_compare1_set(cfg->instance, 0);
+#endif
+
 	k_spin_unlock(&lock, key);
 
 	return 0;
@@ -163,33 +240,71 @@ static const struct counter_driver_api counter_api = {
 	.get_top_value = counter_ambiq_get_top_value,
 };
 
+#define APOLLO3_HANDLE_SHARED_TIMER_IRQ(n)                                                         \
+	static const struct device *const dev_##n = DEVICE_DT_INST_GET(n);                         \
+	struct counter_ambiq_data *const data_##n = dev_##n->data;                                 \
+	uint32_t status_##n = CTIMERn(n)->INTSTAT;                                                 \
+	status_##n &= CTIMERn(n)->INTEN;                                                           \
+	if (status_##n) {                                                                          \
+		CTIMERn(n)->INTCLR = AM_HAL_CTIMER_INT_TIMERA0C0;                                  \
+		counter_ambiq_get_value(dev_##n, &now);                                            \
+		if (data_##n->callback) {                                                          \
+			data_##n->callback(dev_##n, 0, now, data_##n->user_data);                  \
+		}                                                                                  \
+	}
+
 static void counter_ambiq_isr(void *arg)
 {
-	const struct device *dev = (const struct device *)arg;
-	struct counter_ambiq_data *data = dev->data;
 	uint32_t now = 0;
 
-	am_hal_timer_interrupt_clear(AM_HAL_TIMER_MASK(0, AM_HAL_TIMER_COMPARE1));
+#if defined(CONFIG_SOC_SERIES_APOLLO3X)
+	ARG_UNUSED(arg);
+
+	DT_INST_FOREACH_STATUS_OKAY(APOLLO3_HANDLE_SHARED_TIMER_IRQ)
+#else
+	const struct device *dev = (const struct device *)arg;
+	struct counter_ambiq_data *data = dev->data;
+	const struct counter_ambiq_config *cfg = dev->config;
+
+	am_hal_timer_interrupt_clear(AM_HAL_TIMER_MASK(cfg->instance, AM_HAL_TIMER_COMPARE1));
 	counter_ambiq_get_value(dev, &now);
 
 	if (data->callback) {
 		data->callback(dev, 0, now, data->user_data);
 	}
+#endif
 }
 
+#if defined(CONFIG_SOC_SERIES_APOLLO3X)
+/* Apollo3 counters share the same irq number, connect irq here will cause build error, so we
+ * leave this function blank here and do it in counter_irq_config_func
+ */
+#define AMBIQ_COUNTER_CONFIG_FUNC(idx) static void counter_irq_config_func_##idx(void){};
+#else
+#define AMBIQ_COUNTER_CONFIG_FUNC(idx)                                                             \
+	static void counter_irq_config_func_##idx(void)                                            \
+	{                                                                                          \
+		NVIC_ClearPendingIRQ(DT_INST_IRQN(idx));                                           \
+		IRQ_CONNECT(DT_INST_IRQN(idx), DT_INST_IRQ(idx, priority), counter_ambiq_isr,      \
+			    DEVICE_DT_INST_GET(idx), 0);                                           \
+		irq_enable(DT_INST_IRQN(idx));                                                     \
+	};
+#endif
+
 #define AMBIQ_COUNTER_INIT(idx)                                                                    \
-                                                                                                   \
+	static void counter_irq_config_func_##idx(void);                                           \
 	static struct counter_ambiq_data counter_data_##idx;                                       \
-                                                                                                   \
 	static const struct counter_ambiq_config counter_config_##idx = {                          \
+		.instance = (DT_INST_REG_ADDR(idx) - DT_INST_REG_ADDR(0)) / DT_INST_REG_SIZE(idx), \
+		.clk_src = DT_INST_PROP(idx, clk_source),                                          \
 		.counter_info = {.max_top_value = UINT32_MAX,                                      \
-				 .freq = 6000000,                                                  \
+				 .freq = DT_INST_PROP(idx, clock_frequency),                       \
 				 .flags = COUNTER_CONFIG_INFO_COUNT_UP,                            \
 				 .channels = 1},                                                   \
+		.irq_config_func = counter_irq_config_func_##idx,                                  \
 	};                                                                                         \
-                                                                                                   \
+	AMBIQ_COUNTER_CONFIG_FUNC(idx)                                                             \
 	DEVICE_DT_INST_DEFINE(idx, counter_ambiq_init, NULL, &counter_data_##idx,                  \
 			      &counter_config_##idx, PRE_KERNEL_1, CONFIG_COUNTER_INIT_PRIORITY,   \
 			      &counter_api);
-
 DT_INST_FOREACH_STATUS_OKAY(AMBIQ_COUNTER_INIT);

--- a/dts/arm/ambiq/ambiq_apollo3_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo3_blue.dtsi
@@ -70,8 +70,73 @@
 
 		counter0: counter@40008000 {
 			compatible = "ambiq,counter";
-			reg = <0x40008000 0x80>;
+			reg = <0x40008000 0x20>;
 			interrupts = <14 0>;
+			clock-frequency = <DT_FREQ_M(3)>;
+			clk-source = <2>;
+			status = "disabled";
+		};
+
+		counter1: counter@40008020 {
+			compatible = "ambiq,counter";
+			reg = <0x40008020 0x20>;
+			interrupts = <14 0>;
+			clock-frequency = <DT_FREQ_M(3)>;
+			clk-source = <2>;
+			status = "disabled";
+		};
+
+		counter2: counter@40008040 {
+			compatible = "ambiq,counter";
+			reg = <0x40008040 0x20>;
+			interrupts = <14 0>;
+			clock-frequency = <DT_FREQ_M(3)>;
+			clk-source = <2>;
+			status = "disabled";
+		};
+
+		counter3: counter@40008060 {
+			compatible = "ambiq,counter";
+			reg = <0x40008060 0x20>;
+			interrupts = <14 0>;
+			clock-frequency = <DT_FREQ_M(3)>;
+			clk-source = <2>;
+			status = "disabled";
+		};
+
+		counter4: counter@40008080 {
+			compatible = "ambiq,counter";
+			reg = <0x40008080 0x20>;
+			interrupts = <14 0>;
+			clock-frequency = <DT_FREQ_M(3)>;
+			clk-source = <2>;
+			status = "disabled";
+		};
+
+		counter5: counter@400080a0 {
+			compatible = "ambiq,counter";
+			reg = <0x400080A0 0x20>;
+			interrupts = <14 0>;
+			clock-frequency = <DT_FREQ_M(3)>;
+			clk-source = <2>;
+			status = "disabled";
+		};
+
+		counter6: counter@400080c0 {
+			compatible = "ambiq,counter";
+			reg = <0x400080C0 0x20>;
+			interrupts = <14 0>;
+			clock-frequency = <DT_FREQ_M(3)>;
+			clk-source = <2>;
+			status = "disabled";
+		};
+
+		counter7: counter@400080e0 {
+			compatible = "ambiq,counter";
+			reg = <0x400080E0 0x20>;
+			interrupts = <14 0>;
+			clock-frequency = <DT_FREQ_M(3)>;
+			clk-source = <2>;
 			status = "disabled";
 		};
 

--- a/dts/arm/ambiq/ambiq_apollo3p_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo3p_blue.dtsi
@@ -70,8 +70,73 @@
 
 		counter0: counter@40008000 {
 			compatible = "ambiq,counter";
-			reg = <0x40008000 0x80>;
+			reg = <0x40008000 0x20>;
 			interrupts = <14 0>;
+			clock-frequency = <DT_FREQ_M(3)>;
+			clk-source = <2>;
+			status = "disabled";
+		};
+
+		counter1: counter@40008020 {
+			compatible = "ambiq,counter";
+			reg = <0x40008020 0x20>;
+			interrupts = <14 0>;
+			clock-frequency = <DT_FREQ_M(3)>;
+			clk-source = <2>;
+			status = "disabled";
+		};
+
+		counter2: counter@40008040 {
+			compatible = "ambiq,counter";
+			reg = <0x40008040 0x20>;
+			interrupts = <14 0>;
+			clock-frequency = <DT_FREQ_M(3)>;
+			clk-source = <2>;
+			status = "disabled";
+		};
+
+		counter3: counter@40008060 {
+			compatible = "ambiq,counter";
+			reg = <0x40008060 0x20>;
+			interrupts = <14 0>;
+			clock-frequency = <DT_FREQ_M(3)>;
+			clk-source = <2>;
+			status = "disabled";
+		};
+
+		counter4: counter@40008080 {
+			compatible = "ambiq,counter";
+			reg = <0x40008080 0x20>;
+			interrupts = <14 0>;
+			clock-frequency = <DT_FREQ_M(3)>;
+			clk-source = <2>;
+			status = "disabled";
+		};
+
+		counter5: counter@400080a0 {
+			compatible = "ambiq,counter";
+			reg = <0x400080A0 0x20>;
+			interrupts = <14 0>;
+			clock-frequency = <DT_FREQ_M(3)>;
+			clk-source = <2>;
+			status = "disabled";
+		};
+
+		counter6: counter@400080c0 {
+			compatible = "ambiq,counter";
+			reg = <0x400080C0 0x20>;
+			interrupts = <14 0>;
+			clock-frequency = <DT_FREQ_M(3)>;
+			clk-source = <2>;
+			status = "disabled";
+		};
+
+		counter7: counter@400080e0 {
+			compatible = "ambiq,counter";
+			reg = <0x400080E0 0x20>;
+			interrupts = <14 0>;
+			clock-frequency = <DT_FREQ_M(3)>;
+			clk-source = <2>;
 			status = "disabled";
 		};
 

--- a/dts/arm/ambiq/ambiq_apollo4p.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo4p.dtsi
@@ -96,10 +96,12 @@
 			status = "okay";
 		};
 
-		counter0: counter@40008000 {
+		counter0: counter@40008200 {
 			compatible = "ambiq,counter";
-			reg = <0x40008000 0x80>;
+			reg = <0x40008200 0x20>;
 			interrupts = <67 0>;
+			clock-frequency = <DT_FREQ_M(6)>;
+			clk-source = <1>;
 			status = "disabled";
 		};
 

--- a/dts/arm/ambiq/ambiq_apollo4p_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo4p_blue.dtsi
@@ -78,10 +78,12 @@
 			status = "okay";
 		};
 
-		counter0: counter@40008000 {
+		counter0: counter@40008200 {
 			compatible = "ambiq,counter";
-			reg = <0x40008000 0x80>;
+			reg = <0x40008200 0x20>;
 			interrupts = <67 0>;
+			clock-frequency = <DT_FREQ_M(6)>;
+			clk-source = <1>;
 			status = "disabled";
 		};
 

--- a/dts/bindings/counter/ambiq,counter.yaml
+++ b/dts/bindings/counter/ambiq,counter.yaml
@@ -13,3 +13,13 @@ properties:
 
   interrupts:
     required: true
+
+  clock-frequency:
+    type: int
+    required: true
+    description: Counter clock frequency
+
+  clk-source:
+    type: int
+    required: true
+    description: Counter clock source


### PR DESCRIPTION
This commit adds support for the counter which
can be found in Apollo3 SoCs