### PR TITLE
soc: intel_ish: Make ISH support APIC timer with TSC time source.

### DIFF
--- a/boards/intel/ish/Kconfig.defconfig
+++ b/boards/intel/ish/Kconfig.defconfig
@@ -9,4 +9,5 @@ config TEST_EXTRA_STACK_SIZE
 endif # TEST
 
 config SYS_CLOCK_TICKS_PER_SEC
-	default 2048 if HPET_TIMER # HPET is 32768 HZ
+	default 2048 if HPET_TIMER # HPET timer's frequency is 32768 HZ
+	default 2000 if APIC_TIMER_TSC # APIC timer's frequency is 19.2 MHZ or 100 MHZ

--- a/soc/intel/intel_ish/Kconfig.defconfig
+++ b/soc/intel/intel_ish/Kconfig.defconfig
@@ -8,6 +8,8 @@ if SOC_FAMILY_INTEL_ISH
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 32768 if HPET_TIMER
+	default 96000000 if APIC_TIMER_TSC && SOC_INTEL_ISH_5_4_1
+	default 100000000 if APIC_TIMER_TSC && !SOC_INTEL_ISH_5_4_1
 
 config X86_VERY_EARLY_CONSOLE
 	default n
@@ -20,6 +22,21 @@ config SRAM_OFFSET
 # (e.g. without BIOS, ACPI, CMOS, etc.).
 config X86_PC_COMPATIBLE
 	default n
+
+if APIC_TIMER_TSC
+
+config DYNAMIC_INTERRUPTS
+	default y
+
+if SOC_INTEL_ISH_5_4_1
+
+config APIC_TIMER_TSC_N
+	default 1280
+
+config APIC_TIMER_TSC_M
+	default 256
+endif
+endif
 
 rsource "*/Kconfig.defconfig.series"
 


### PR DESCRIPTION
This commit enables ISH boards to use APIC timer with TSC time source as
their system timer by replacing CONFIG_HPET with CONFIG_APIC_TIMER_TSC.