### PR TITLE
boards: fixed SPI DTS bug for nrf5340_audio_dk board

### DIFF
--- a/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_cpuapp_common.dtsi
+++ b/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_cpuapp_common.dtsi
@@ -193,7 +193,7 @@ arduino_spi: &spi4 {
 	pinctrl-names = "default", "sleep";
 	sdhc0: sdhc@1 {
 		compatible = "zephyr,sdhc-spi-slot";
-		reg = <0>;
+		reg = <1>;
 		status = "okay";
 		sdmmc {
 			compatible = "zephyr,sdmmc-disk";
@@ -205,7 +205,7 @@ arduino_spi: &spi4 {
 
 	cs47l63: cs47l63@2 {
 		compatible = "cirrus,cs47l63";
-		reg = <1>;
+		reg = <2>;
 		spi-max-frequency = <8000000>;
 		irq-gpios = <&gpio0 19 GPIO_ACTIVE_LOW>;
 		reset-gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;


### PR DESCRIPTION
This fixes the SPI DTS bug on the nrf5340_audio_dk board
which was introduced by https://github.com/zephyrproject-rtos/zephyr/commit/b8978e9efecd60ea2d3468c0e70ab4a0affacb0b:
unit address and first address in 'reg' (0x0) don't match
for /soc/peripheral@50000000/spi@a000/sdhc@1
unit address and first address in 'reg' (0x1) don't match
for /soc/peripheral@50000000/spi@a000/cs47l63@2