### PR TITLE
samples: sensor: Enable bme280 sensor using I2C driver

### DIFF
--- a/samples/sensor/bme280/boards/esp32_devkitc_wroom_procpu.overlay
+++ b/samples/sensor/bme280/boards/esp32_devkitc_wroom_procpu.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&i2c0 {
+	bme280@76 {
+		compatible = "bosch,bme280";
+		reg = <0x76>;
+		status = "okay";
+	};
+};


### PR DESCRIPTION
Added overlay to enable bme280 sensor
using i2c on esp32_devkitc_wroom board.