### PR TITLE
bluetooth: audio: add bt_audio_get_chan_count

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -631,6 +631,15 @@ struct bt_audio_codec_cfg {
 int bt_audio_data_parse(const uint8_t ltv[], size_t size,
 			bool (*func)(struct bt_data *data, void *user_data), void *user_data);
 
+/**
+ * @brief Function to get the number of channels from the channel allocation
+ *
+ * @param chan_allocation The channel allocation
+ *
+ * @return The number of channels
+ */
+uint8_t bt_audio_get_chan_count(enum bt_audio_location chan_allocation);
+
 /** @brief Audio Capability type */
 enum bt_audio_dir {
 	BT_AUDIO_DIR_SINK = 0x01,

--- a/subsys/bluetooth/audio/audio.c
+++ b/subsys/bluetooth/audio/audio.c
@@ -67,6 +67,26 @@ int bt_audio_data_parse(const uint8_t ltv[], size_t size,
 	return 0;
 }
 
+uint8_t bt_audio_get_chan_count(enum bt_audio_location chan_allocation)
+{
+	if (chan_allocation == BT_AUDIO_LOCATION_MONO_AUDIO) {
+		return 1;
+	}
+
+#ifdef POPCOUNT
+	return POPCOUNT(chan_allocation);
+#else
+	uint8_t cnt = 0U;
+
+	while (chan_allocation != 0U) {
+		cnt += chan_allocation & 1U;
+		chan_allocation >>= 1U;
+	}
+
+	return cnt;
+#endif
+}
+
 #if defined(CONFIG_BT_CONN)
 
 static uint8_t bt_audio_security_check(const struct bt_conn *conn)

--- a/subsys/bluetooth/audio/shell/audio.h
+++ b/subsys/bluetooth/audio/shell/audio.h
@@ -220,22 +220,6 @@ int cap_ac_unicast(const struct shell *sh, const struct bap_unicast_ac_param *pa
 #endif /* CONFIG_BT_BAP_UNICAST_CLIENT */
 #endif /* CONFIG_BT_BAP_UNICAST */
 
-static inline uint8_t get_chan_cnt(enum bt_audio_location chan_allocation)
-{
-	uint8_t cnt = 0U;
-
-	if (chan_allocation == BT_AUDIO_LOCATION_MONO_AUDIO) {
-		return 1;
-	}
-
-	while (chan_allocation != 0) {
-		cnt += chan_allocation & 1U;
-		chan_allocation >>= 1;
-	}
-
-	return cnt;
-}
-
 static inline void print_qos(const struct shell *sh, const struct bt_audio_codec_qos *qos)
 {
 #if defined(CONFIG_BT_BAP_BROADCAST_SOURCE) || defined(CONFIG_BT_BAP_UNICAST)

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -2855,7 +2855,8 @@ static void stream_started_cb(struct bt_bap_stream *bap_stream)
 		ret = bt_audio_codec_cfg_get_chan_allocation(codec_cfg,
 							     &sh_stream->lc3_chan_allocation);
 		if (ret == 0) {
-			sh_stream->lc3_chan_cnt = get_chan_cnt(sh_stream->lc3_chan_allocation);
+			sh_stream->lc3_chan_cnt =
+				bt_audio_get_chan_count(sh_stream->lc3_chan_allocation);
 		} else {
 			shell_error(ctx_shell, "Could not get channel allocation: %d", ret);
 			sh_stream->lc3_chan_allocation = BT_AUDIO_LOCATION_MONO_AUDIO;

--- a/subsys/bluetooth/audio/shell/bap_usb.c
+++ b/subsys/bluetooth/audio/shell/bap_usb.c
@@ -214,7 +214,7 @@ int bap_usb_add_frame_to_usb(enum bt_audio_location chan_allocation, const int16
 		return -EINVAL;
 	}
 
-	if (get_chan_cnt(chan_allocation) != 1) {
+	if (bt_audio_get_chan_count(chan_allocation) != 1) {
 		LOG_DBG("Invalid channel allocation %d", chan_allocation);
 
 		return -EINVAL;

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
@@ -66,18 +66,6 @@ static K_SEM_DEFINE(sem_stopped, 0U, ARRAY_SIZE(streams));
 static const uint32_t bis_index_mask = BIT_MASK(ARRAY_SIZE(streams) + 1U);
 static uint32_t bis_index_bitfield;
 
-static uint8_t count_bits(enum bt_audio_location chan_allocation)
-{
-	uint8_t cnt = 0U;
-
-	while (chan_allocation != 0) {
-		cnt += chan_allocation & 1U;
-		chan_allocation >>= 1;
-	}
-
-	return cnt;
-}
-
 static bool valid_base_subgroup(const struct bt_bap_base_subgroup *subgroup)
 {
 	struct bt_audio_codec_cfg codec_cfg = {0};
@@ -128,7 +116,7 @@ static bool valid_base_subgroup(const struct bt_bap_base_subgroup *subgroup)
 
 	ret = bt_audio_codec_cfg_get_chan_allocation(&codec_cfg, &chan_allocation);
 	if (ret == 0) {
-		chan_cnt = count_bits(chan_allocation);
+		chan_cnt = bt_audio_get_chan_count(chan_allocation);
 	} else {
 		printk("Could not get subgroup channel allocation: %d\n", ret);
 		/* Channel allocation is an optional field, and omitting it implicitly means mono */
@@ -444,7 +432,7 @@ static void validate_stream_codec_cfg(const struct bt_bap_stream *stream)
 			return;
 		}
 
-		chan_cnt = count_bits(chan_allocation);
+		chan_cnt = bt_audio_get_chan_count(chan_allocation);
 	} else {
 		FAIL("Could not get subgroup channel allocation: %d\n", ret);
 


### PR DESCRIPTION
Implement a function bt_audio_get_chan_count that takes an enum bt_audio_location and returns the number of channels in that value.