### PR TITLE
boards: nrf54h20dk: Drop shared_ram20_region's compatible

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-memory_map.dtsi
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-memory_map.dtsi
@@ -70,11 +70,7 @@
 		};
 
 		shared_ram20_region: memory@2f88f000 {
-			compatible = "nordic,owned-memory";
 			reg = <0x2f88f000 DT_SIZE_K(4)>;
-			status = "okay";
-			perm-read;
-			perm-write;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			ranges = <0x0 0x2f88f000 0x1000>;


### PR DESCRIPTION
Access to this region should no longer be requested via UICR, because it will be statically reserved by secure domain firmware.