### PR TITLE
assert: Expand to (void)test when asserts are disabled

### DIFF
--- a/include/zephyr/sys/__assert.h
+++ b/include/zephyr/sys/__assert.h
@@ -137,15 +137,15 @@ void assert_post_action(const char *file, unsigned int line);
 #warning "__ASSERT() statements are ENABLED"
 #endif
 #else
-#define __ASSERT(test, fmt, ...) { }
+#define __ASSERT(test, fmt, ...) {(void)(test)}
 #define __ASSERT_EVAL(expr1, expr2, test, fmt, ...) expr1
-#define __ASSERT_NO_MSG(test) { }
+#define __ASSERT_NO_MSG(test) {(void)(test)}
 #define __ASSERT_POST_ACTION() { }
 #endif
 #else
-#define __ASSERT(test, fmt, ...) { }
+#define __ASSERT(test, fmt, ...) {(void)(test)}
 #define __ASSERT_EVAL(expr1, expr2, test, fmt, ...) expr1
-#define __ASSERT_NO_MSG(test) { }
+#define __ASSERT_NO_MSG(test) {(void)(test)}
 #define __ASSERT_POST_ACTION() { }
 #endif
 


### PR DESCRIPTION
If a convenience variable is used for `test`, then compilers will raise an "unused variable" warning when asserts are disabled.

The alternative is guarding that variable behind an ifdef, or using __ASSERT_EVAL() which both hinder readability. We have enough ifdefs as it is.

E.g. this code will raise a warning:
```c
static void lower_data_ready(struct bt_l2cap_br_chan *br_chan)
{
	struct bt_conn *conn = br_chan->chan.conn;
	sys_snode_t *s = sys_slist_get(&conn->l2cap_data_ready);

	__ASSERT_NO_MSG(s == &br_chan->_pdu_ready);
```