### PR TITLE
samples/posix/env: Change integration platform

### DIFF
--- a/dts/arm64/broadcom/bcm2712.dtsi
+++ b/dts/arm64/broadcom/bcm2712.dtsi
@@ -73,6 +73,7 @@
 			reg = <0x10 0x7d001000 0x200>;
 			interrupts = <GIC_SPI 121 IRQ_TYPE_LEVEL
 				      IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "irq_121";
 			clocks = <&clk_uart>;
 			status = "disabled";
 		};

--- a/samples/posix/env/sample.yaml
+++ b/samples/posix/env/sample.yaml
@@ -7,7 +7,7 @@ common:
     - native_posix
     - native_posix/native/64
   integration_platforms:
-    - qemu_riscv32
+    - native_sim
   harness: console
   harness_config:
     type: multi_line


### PR DESCRIPTION
There is some instability problems with qemu_riscv32 https://github.com/zephyrproject-rtos/zephyr/issues/72858 which cause this sample test to fail in CI at random. Let's change the integration platform to a reliable one, so this test focuses on the sample and does not produce false test failures due to the platform.

Mitigates: #72858

----

The CI failure ~is~was due to
*  #72866 

=> Sitting this on top of this PR so it's CI can pass:
* #72868 