### PR TITLE
samples: Bluetooth: Audio: Add missing board/conf

### DIFF
--- a/samples/bluetooth/broadcast_audio_sink/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/samples/bluetooth/broadcast_audio_sink/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -1,0 +1,3 @@
+# Use USB Audio as audio sink
+CONFIG_USE_USB_AUDIO_OUTPUT=y
+CONFIG_USB_DEVICE_PRODUCT="USB Broadcast Sink"

--- a/samples/bluetooth/broadcast_audio_sink/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/bluetooth/broadcast_audio_sink/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,15 @@
+zephyr_udc0: &usbd {
+	compatible = "nordic,nrf-usbd";
+	status = "okay";
+
+	hs_0: hs_0 {
+		compatible = "usb-audio-hs";
+		mic-feature-mute;
+		mic-channel-l;
+		mic-channel-r;
+
+		hp-feature-mute;
+		hp-channel-l;
+		hp-channel-r;
+	};
+};

--- a/samples/bluetooth/broadcast_audio_source/boards/nrf5340dk_nrf5340_cpuapp.conf
+++ b/samples/bluetooth/broadcast_audio_source/boards/nrf5340dk_nrf5340_cpuapp.conf
@@ -1,0 +1,3 @@
+# Use USB Audio as audio source
+CONFIG_USE_USB_AUDIO_INPUT=y
+CONFIG_USB_DEVICE_PRODUCT="Zephyr Broadcast Source"

--- a/samples/bluetooth/broadcast_audio_source/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/bluetooth/broadcast_audio_source/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,15 @@
+zephyr_udc0: &usbd {
+	compatible = "nordic,nrf-usbd";
+	status = "okay";
+
+	hs_0: hs_0 {
+		compatible = "usb-audio-hs";
+		mic-feature-mute;
+		mic-channel-l;
+		mic-channel-r;
+
+		hp-feature-mute;
+		hp-channel-l;
+		hp-channel-r;
+	};
+};

--- a/samples/bluetooth/unicast_audio_client/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
+++ b/samples/bluetooth/unicast_audio_client/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
@@ -4,3 +4,10 @@ CONFIG_LIBLC3=y
 # The LC3 codec uses a large amount of stack. This app runs the codec in the work-queue, hence
 # inctease stack size for that thread.
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
+
+CONFIG_BT_BUF_EVT_RX_SIZE=255
+CONFIG_BT_BUF_ACL_RX_SIZE=255
+CONFIG_BT_BUF_ACL_TX_SIZE=251
+CONFIG_BT_BUF_CMD_TX_SIZE=255
+
+CONFIG_BT_TINYCRYPT_ECC=y

--- a/samples/bluetooth/unicast_audio_server/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
+++ b/samples/bluetooth/unicast_audio_server/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf
@@ -4,3 +4,10 @@ CONFIG_LIBLC3=y
 # The LC3 codec uses a large amount of stack. This app runs the codec in the work-queue, hence
 # inctease stack size for that thread.
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
+
+CONFIG_BT_BUF_EVT_RX_SIZE=255
+CONFIG_BT_BUF_ACL_RX_SIZE=255
+CONFIG_BT_BUF_ACL_TX_SIZE=251
+CONFIG_BT_BUF_CMD_TX_SIZE=255
+
+CONFIG_BT_TINYCRYPT_ECC=y

--- a/tests/bluetooth/shell/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/tests/bluetooth/shell/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,15 @@
+zephyr_udc0: &usbd {
+	compatible = "nordic,nrf-usbd";
+	status = "okay";
+
+	hs_0: hs_0 {
+		compatible = "usb-audio-hs";
+		mic-feature-mute;
+		mic-channel-l;
+		mic-channel-r;
+
+		hp-feature-mute;
+		hp-channel-l;
+		hp-channel-r;
+	};
+};


### PR DESCRIPTION
Add missing configuration files for the nRF5340DK
and missing configuration values for the unicast
samples w.r.t. buffer sizes and encryption.