### PR TITLE
arch: make `EXCEPTION_STACK_TRACE` depends on `ARCH_HAS_STACK_TRACE`

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -666,6 +666,12 @@ config ARCH_SUPPORTS_MEM_MAPPED_STACKS
 	help
 	  Select when the architecture supports memory mapped stacks.
 
+config ARCH_HAS_STACK_TRACE
+	bool
+	help
+	  Enabled when the conditions are met for the architecture to
+	  support stack trace.
+
 #
 # Other architecture related options
 #

--- a/arch/arm64/core/Kconfig
+++ b/arch/arm64/core/Kconfig
@@ -115,6 +115,10 @@ config CMSIS_V2_THREAD_DYNAMIC_STACK_SIZE
 config IPM_CONSOLE_STACK_SIZE
 	default 2048
 
+config ARCH_HAS_STACK_TRACE
+	default y
+	depends on ARM64_ENABLE_FRAME_POINTER
+
 config AARCH64_IMAGE_HEADER
 	bool "Add image header"
 	default y if ARM_MMU || ARM_MPU

--- a/arch/arm64/core/fatal.c
+++ b/arch/arm64/core/fatal.c
@@ -194,7 +194,7 @@ static void esf_dump(const z_arch_esf_t *esf)
 	LOG_ERR("x18: 0x%016llx  lr:  0x%016llx", esf->x18, esf->lr);
 }
 
-#ifdef CONFIG_ARM64_ENABLE_FRAME_POINTER
+#ifdef CONFIG_EXCEPTION_STACK_TRACE
 static void esf_unwind(const z_arch_esf_t *esf)
 {
 	/*
@@ -354,9 +354,9 @@ void z_arm64_fatal_error(unsigned int reason, z_arch_esf_t *esf)
 		esf_dump(esf);
 	}
 
-#ifdef CONFIG_ARM64_ENABLE_FRAME_POINTER
+#ifdef CONFIG_EXCEPTION_STACK_TRACE
 	esf_unwind(esf);
-#endif /* CONFIG_ARM64_ENABLE_FRAME_POINTER */
+#endif /* CONFIG_EXCEPTION_STACK_TRACE */
 #endif /* CONFIG_EXCEPTION_DEBUG */
 
 	z_fatal_error(reason, esf);

--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -50,11 +50,12 @@ config RISCV_ENABLE_FRAME_POINTER
 config RISCV_EXCEPTION_STACK_TRACE
 	bool
 	default y
+	select DEPRECATED
+	depends on !ARCH_HAS_STACK_TRACE
 	depends on RISCV_ENABLE_FRAME_POINTER
-	depends on EXCEPTION_STACK_TRACE
 	imply THREAD_STACK_INFO
 	help
-	  Internal config to enable runtime stack traces on fatal exceptions.
+	  [DEPRECATED] Internal config to enable runtime stack traces on fatal exceptions.
 
 menu "RISCV Processor Options"
 
@@ -390,6 +391,11 @@ config GEN_IRQ_VECTOR_TABLE
 
 config ARCH_HAS_SINGLE_THREAD_SUPPORT
 	default y if !SMP
+
+config ARCH_HAS_STACK_TRACE
+	default y
+	depends on RISCV_ENABLE_FRAME_POINTER
+	imply THREAD_STACK_INFO
 
 rsource "Kconfig.isa"
 

--- a/arch/riscv/core/fatal.c
+++ b/arch/riscv/core/fatal.c
@@ -28,7 +28,7 @@ static const struct z_exc_handle exceptions[] = {
  #define NO_REG "                "
 #endif
 
-#ifdef CONFIG_RISCV_EXCEPTION_STACK_TRACE
+#ifdef CONFIG_EXCEPTION_STACK_TRACE
 #define MAX_STACK_FRAMES 8
 
 struct stackframe {
@@ -103,7 +103,7 @@ static void unwind_stack(const z_arch_esf_t *esf)
 
 	LOG_ERR("");
 }
-#endif /* CONFIG_RISCV_EXCEPTION_STACK_TRACE */
+#endif /* CONFIG_EXCEPTION_STACK_TRACE */
 
 FUNC_NORETURN void z_riscv_fatal_error(unsigned int reason,
 				       const z_arch_esf_t *esf)
@@ -167,9 +167,9 @@ FUNC_NORETURN void z_riscv_fatal_error_csf(unsigned int reason, const z_arch_esf
 		LOG_ERR("");
 	}
 
-#ifdef CONFIG_RISCV_EXCEPTION_STACK_TRACE
+#ifdef CONFIG_EXCEPTION_STACK_TRACE
 		unwind_stack(esf);
-#endif /* CONFIG_RISCV_EXCEPTION_STACK_TRACE */
+#endif /* CONFIG_EXCEPTION_STACK_TRACE */
 
 #endif /* CONFIG_EXCEPTION_DEBUG */
 	z_fatal_error(reason, esf);

--- a/arch/x86/core/Kconfig.ia32
+++ b/arch/x86/core/Kconfig.ia32
@@ -166,9 +166,10 @@ endmenu
 config X86_EXCEPTION_STACK_TRACE
 	bool
 	default y
-	depends on EXCEPTION_STACK_TRACE
+	select DEPRECATED
+	depends on !ARCH_HAS_STACK_TRACE
 	help
-	  Internal config to enable runtime stack traces on fatal exceptions.
+	  [DEPRECATED] Internal config to enable runtime stack traces on fatal exceptions.
 
 config X86_USE_THREAD_LOCAL_STORAGE
 	bool
@@ -192,5 +193,9 @@ config X86_RUNTIME_IRQ_STATS
 	  Add irq runtime statistics to allow runtime profiling irq performance
 	  data with Host tools, enable this and implement platform dependent API
 	  runtime_irq_stats().
+
+config ARCH_HAS_STACK_TRACE
+	default y
+	depends on !OMIT_FRAME_POINTER
 
 endif # !X86_64

--- a/arch/x86/core/Kconfig.intel64
+++ b/arch/x86/core/Kconfig.intel64
@@ -32,10 +32,11 @@ config X86_EXCEPTION_STACK_SIZE
 config X86_EXCEPTION_STACK_TRACE
 	bool
 	default y
-	depends on EXCEPTION_STACK_TRACE
+	select DEPRECATED
+	depends on !ARCH_HAS_STACK_TRACE
 	depends on NO_OPTIMIZATIONS
 	help
-	  Internal config to enable runtime stack traces on fatal exceptions.
+	  [DEPRECATED] Internal config to enable runtime stack traces on fatal exceptions.
 
 config SCHED_IPI_VECTOR
 	int "IDT vector to use for scheduler IPI"
@@ -87,5 +88,10 @@ config X86_USERSPACE
 	 This option enables APIs to drop a thread's privileges down to ring 3,
 	 supporting user-level threads that are protected from each other and
 	 from crashing the kernel.
+
+config ARCH_HAS_STACK_TRACE
+	default y
+	depends on NO_OPTIMIZATIONS
+	depends on !OMIT_FRAME_POINTER
 
 endif # X86_64

--- a/arch/x86/core/fatal.c
+++ b/arch/x86/core/fatal.c
@@ -131,7 +131,7 @@ static inline uintptr_t esf_get_code(const z_arch_esf_t *esf)
 #endif
 }
 
-#if defined(CONFIG_X86_EXCEPTION_STACK_TRACE)
+#if defined(CONFIG_EXCEPTION_STACK_TRACE)
 struct stack_frame {
 	uintptr_t next;
 	uintptr_t ret_addr;
@@ -186,7 +186,7 @@ static void unwind_stack(uintptr_t base_ptr, uint16_t cs)
 		base_ptr = frame->next;
 	}
 }
-#endif /* CONFIG_X86_EXCEPTION_STACK_TRACE */
+#endif /* CONFIG_EXCEPTION_STACK_TRACE */
 
 static inline uintptr_t get_cr3(const z_arch_esf_t *esf)
 {
@@ -226,11 +226,11 @@ static void dump_regs(const z_arch_esf_t *esf)
 	LOG_ERR("RSP: 0x%016lx RFLAGS: 0x%016lx CS: 0x%04lx CR3: 0x%016lx",
 		esf->rsp, esf->rflags, esf->cs & 0xFFFFU, get_cr3(esf));
 
-#ifdef CONFIG_X86_EXCEPTION_STACK_TRACE
+#ifdef CONFIG_EXCEPTION_STACK_TRACE
 	LOG_ERR("call trace:");
 #endif
 	LOG_ERR("RIP: 0x%016lx", esf->rip);
-#ifdef CONFIG_X86_EXCEPTION_STACK_TRACE
+#ifdef CONFIG_EXCEPTION_STACK_TRACE
 	unwind_stack(esf->rbp, esf->cs);
 #endif
 }
@@ -245,11 +245,11 @@ static void dump_regs(const z_arch_esf_t *esf)
 	LOG_ERR("EFLAGS: 0x%08x CS: 0x%04x CR3: 0x%08lx", esf->eflags,
 		esf->cs & 0xFFFFU, get_cr3(esf));
 
-#ifdef CONFIG_X86_EXCEPTION_STACK_TRACE
+#ifdef CONFIG_EXCEPTION_STACK_TRACE
 	LOG_ERR("call trace:");
 #endif
 	LOG_ERR("EIP: 0x%08x", esf->eip);
-#ifdef CONFIG_X86_EXCEPTION_STACK_TRACE
+#ifdef CONFIG_EXCEPTION_STACK_TRACE
 	unwind_stack(esf->ebp, esf->cs);
 #endif
 }

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -371,9 +371,9 @@ config DEBUG_INFO
 config EXCEPTION_STACK_TRACE
 	bool "Attempt to print stack traces upon exceptions"
 	default y
+	depends on ARCH_HAS_STACK_TRACE
 	depends on PRINTK
 	depends on DEBUG_INFO
-	depends on !OMIT_FRAME_POINTER
 	help
 	  If the architecture fatal handling code supports it, attempt to
 	  print a stack trace of function memory addresses when an


### PR DESCRIPTION
Create an intermediary `CONFIG_ARCH_HAS_STACK_TRACE` that is enabled by architectures based on arch-specific conditions and have the `CONFIG_EXCEPTION_STACK_TRACE` depends on that.

Then, update all occurances of
- `CONFIG_RISCV_EXCEPTION_STACK_TRACE` &
- `CONFIG_x86_EXCEPTION_STACK_TRACE`

The dependencies of `arm64` is a little different, it depends on `CONFIG_ARM64_ENABLE_FRAME_POINTER` to imply that the stack trace is enabled, update that to `CONFIG_EXCEPTION_STACK_TRACE` as well.