### PR TITLE
twister: Fix path to binary location for unit_testing board

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -235,6 +235,8 @@ class BinaryHandler(Handler):
             command = [self.generator_cmd, "run_renode_test"]
         elif self.call_make_run:
             command = [self.generator_cmd, "run"]
+        elif self.instance.testsuite.type == "unit":
+            command = [self.binary]
         else:
             binary = os.path.join(self.get_default_domain_build_dir(), "zephyr", "zephyr.exe")
             command = [binary]


### PR DESCRIPTION
PR #72100 broke execution of unit type tests. This commit fixes it by bringing back the "old" logic for selecting a binary path for unit type tests.