### PR TITLE
maintainers: ite: edit included files

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3627,7 +3627,7 @@ ITE Platforms:
     - drivers/sensor/ite/
     - drivers/*/*it8xxx2*.c
     - drivers/*/*_ite_*
-    - dts/bindings/*/*ite*
+    - dts/bindings/*/ite*
     - dts/riscv/ite/
     - soc/ite/
   labels:


### PR DESCRIPTION
Only include dts bindings, which start with `ite`, instead of all containing it.

So, it won't mach files, that contain `litex` or `ilitek`.