### PR TITLE
broadcom/bcm2712: Fix UART DT

### DIFF
--- a/dts/arm64/broadcom/bcm2712.dtsi
+++ b/dts/arm64/broadcom/bcm2712.dtsi
@@ -73,6 +73,7 @@
 			reg = <0x10 0x7d001000 0x200>;
 			interrupts = <GIC_SPI 121 IRQ_TYPE_LEVEL
 				      IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "irq_121";
 			clocks = <&clk_uart>;
 			status = "disabled";
 		};


### PR DESCRIPTION
Its UART driver needs the interrupt-names property, let's add it.

Fixes: #72866