### PR TITLE
gitignore: Ignore myresults.xml files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ sanity-out*
 twister-out*
 bsim_out
 bsim_bt_out
+myresults.xml
 tests/RunResults.xml
 scripts/grub
 doc/reference/kconfig/*.rst


### PR DESCRIPTION
These files are created as a result of local babblesim test runs and can be safely ignored.