### PR TITLE
Bluetooth: controller: Add BT_CTLR_HCI Kconfig option

### DIFF
--- a/subsys/bluetooth/controller/CMakeLists.txt
+++ b/subsys/bluetooth/controller/CMakeLists.txt
@@ -21,6 +21,10 @@ zephyr_library_sources(
   ll_sw/ll_addr.c
   ll_sw/ull.c
   ll_sw/lll_common.c
+  )
+
+zephyr_library_sources_ifdef(
+  CONFIG_BT_CTLR_HCI
   hci/hci_driver.c
   hci/hci.c
   )

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -124,6 +124,14 @@ config BT_LL_SW_SPLIT
 
 endchoice
 
+config BT_CTLR_HCI
+	bool "Host Controller Interface (HCI)"
+	default y
+	help
+	  Enable the Host Controller interface (HCI) in the Controller.
+	  This should almost always be enabled, except in a few special
+	  cases, like for unit testing.
+
 comment "BLE Controller configuration"
 
 config BT_CTLR_CRYPTO
@@ -137,7 +145,7 @@ config BT_CTLR_CRYPTO
 config BT_CTLR_HCI_VS_BUILD_INFO
 	string "Zephyr HCI VS Build Info string"
 	default ""
-	depends on BT_HCI_VS
+	depends on BT_CTLR_HCI && BT_HCI_VS
 	help
 	  User-defined string that will be returned by the Zephyr VS Read Build
 	  Information command after the Zephyr version and build time. When
@@ -988,6 +996,7 @@ config BT_CTLR_SMI_TX_SETTING
 
 config BT_CTLR_HCI_CODEC_AND_DELAY_INFO
 	bool "Codecs and controller delay information commands"
+	depends on BT_CTLR_HCI
 	help
 	  Enable HCI commands to read information about supported
 	  codecs, codec capabilities, and controller delay.

--- a/subsys/testsuite/boards/unit_testing/unit_testing/Kconfig.defconfig
+++ b/subsys/testsuite/boards/unit_testing/unit_testing/Kconfig.defconfig
@@ -6,3 +6,8 @@
 choice BT_HCI_BUS_TYPE
 	default BT_NO_DRIVER
 endchoice
+
+# Controller HCI support requires e.g. devicetree, which isn't available
+# for unit tests.
+config BT_CTLR_HCI
+	default n


### PR DESCRIPTION
Add a new option to split off the building of the HCI layer of the controller. This layer is not needed by the controller unit tests, and becomes problematic with the planned change to use devicetree for HCI drivers (causing CI failures in #72323).