### PR TITLE
Bluetooth: Remove useless field `init_credits`

### DIFF
--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -335,6 +335,10 @@ Bluetooth Host
 
   (:github:`71686`)
 
+* The field :code:`init_credits` in :c:type:`bt_l2cap_le_endpoint` has been removed as it was no
+  longer used in Zephyr 3.4.0 and later. Any references to this field should be removed. No further
+  action is needed.
+
 Networking
 **********
 

--- a/include/zephyr/bluetooth/l2cap.h
+++ b/include/zephyr/bluetooth/l2cap.h
@@ -157,8 +157,6 @@ struct bt_l2cap_le_endpoint {
 	uint16_t				mtu;
 	/** Endpoint Maximum PDU payload Size */
 	uint16_t				mps;
-	/** Endpoint initial credits */
-	uint16_t				init_credits;
 	/** Endpoint credits */
 	atomic_t			credits;
 };


### PR DESCRIPTION
Remove `bt_l2cap_le_endpoint.init_credits` that has zero uses and is just taking up RAM for no reason.