### PR TITLE
include: dt-bindings: gpio: fix GPIO_INT_WAKEUP flag value

### DIFF
--- a/include/zephyr/dt-bindings/gpio/gpio.h
+++ b/include/zephyr/dt-bindings/gpio/gpio.h
@@ -81,9 +81,10 @@
 
 /* Note: Bits 15 downto 8 are reserved for SoC specific flags. */
 
-/** Configures GPIO interrupt to wakeup the system from low power mode.
+/**
+ * Configures GPIO interrupt to wakeup the system from low power mode.
  */
-#define GPIO_INT_WAKEUP         (1u << 28)
+#define GPIO_INT_WAKEUP         (1 << 28)
 
 /**
  * @}


### PR DESCRIPTION
`1u` causes devicetree parsing error when `GPIO_INT_WAKEUP` flag is used in a `gpios` property.

```
parse error: expected ')', not '<unknown token>'
```