### PR TITLE
soc: microchip: mec: Add new HAL based MEC5 family chips

### DIFF
--- a/modules/Kconfig.microchip
+++ b/modules/Kconfig.microchip
@@ -7,3 +7,6 @@ config HAS_MEC_HAL
 
 config HAS_MPFS_HAL
 	bool "Microchip MPFS HAL drivers support"
+
+config HAS_MEC5_HAL
+	bool "Microchip MEC5 HAL drivers support"

--- a/soc/microchip/mec/Kconfig
+++ b/soc/microchip/mec/Kconfig
@@ -8,6 +8,7 @@ if SOC_FAMILY_MICROCHIP_MEC
 
 menuconfig MCHP_MEC_UNSIGNED_HEADER
 	bool "Create an unsigned output binary with MCHP MEC binary header"
+	depends on SOC_SERIES_MEC172X
 	help
 	  On Microchip MEC series chip, the ROM code loads firmware image from flash
 	  to RAM using a TAG to locate a Header which specifies the location and
@@ -210,6 +211,54 @@ config MCHP_HEADER_VERBOSE_OUTPUT
 
 endif # MCHP_MEC_UNSIGNED_HEADER
 
+# Common debug configuration
+choice
+	prompt "MEC debug interface general configuration"
+	default SOC_MEC_DEBUG_AND_TRACING
+	depends on SOC_SERIES_MEC174X || SOC_SERIES_MEC175X || SOC_SERIES_MECH172X
+	help
+	  Select Debug SoC interface support for MEC SoC family
+
+	config SOC_MEC_DEBUG_DISABLED
+		bool "Disable debug support"
+		help
+		  Debug port is disabled, JTAG/SWD cannot be enabled. JTAG_RST#
+		  pin is ignored. All other JTAG pins can be used as GPIOs
+		  or other non-JTAG alternate functions.
+
+	config SOC_MEC_DEBUG_WITHOUT_TRACING
+		bool "Debug support via Serial wire debug"
+		help
+		  JTAG port in SWD mode.
+
+	config SOC_MEC_DEBUG_AND_TRACING
+		bool "Debug support via Serial wire debug with tracing enabled"
+		help
+		  JTAG port is enabled in SWD mode.
+endchoice
+
+choice
+	prompt "MEC debug interface trace configuration"
+	default SOC_MEC_DEBUG_AND_SWV_TRACING
+	depends on SOC_MEC_DEBUG_AND_TRACING
+	help
+	  Select tracing mode for debug interface
+
+	config SOC_MEC_DEBUG_AND_ETM_TRACING
+		bool "Debug support via Serial wire debug"
+		help
+		  JTAG port in SWD mode and ETM as tracing method.
+		  ETM re-assigns 5 pins for clock and 4-bit data bus.
+		  Check data sheet for functions shared with ETM.
+
+	config SOC_MEC_DEBUG_AND_SWV_TRACING
+		bool "debug support via Serial Wire Debug and Viewer"
+		help
+		  JTAG port in SWD mode and SWV as tracing method.
+		  Check data sheet for functions shared with SWD and SWV pins.
+endchoice
+
+# common processor clock divider configuration
 config SOC_MEC_PROC_CLK_DIV
 	int "PROC_CLK_DIV"
 	default 1

--- a/soc/microchip/mec/common/CMakeLists.txt
+++ b/soc/microchip/mec/common/CMakeLists.txt
@@ -4,6 +4,9 @@ zephyr_include_directories(.)
 zephyr_library_sources_ifdef(CONFIG_SOC_SERIES_MEC172X
   soc_i2c.c
 )
+zephyr_library_sources_ifdef(CONFIG_HAS_MEC5_HAL
+  soc_cmn_init.c
+)
 
 if (DEFINED CONFIG_MCHP_HEADER_VERBOSE_OUTPUT)
     set(MCHP_HEADER_VERBOSE_OPTION "-v")

--- a/soc/microchip/mec/common/soc_cmn_init.c
+++ b/soc/microchip/mec/common/soc_cmn_init.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+#include <soc.h>
+#include <mec_ecia_api.h>
+#include <mec_ecs_api.h>
+
+static void mec5_soc_init_debug_interface(void)
+{
+#if defined(CONFIG_SOC_MEC_DEBUG_DISABLED)
+	mec_ecs_etm_pins(ECS_ETM_PINS_DISABLE);
+	mec_ecs_debug_port(MEC_DEBUG_MODE_DISABLE);
+#else
+#if defined(SOC_MEC_DEBUG_WITHOUT_TRACING)
+	mec_ecs_etm_pins(ECS_ETM_PINS_DISABLE);
+	mec_ecs_debug_port(MEC_DEBUG_MODE_SWD);
+#elif defined(SOC_MEC_DEBUG_AND_TRACING)
+#if defined(SOC_MEC_DEBUG_AND_ETM_TRACING)
+	mec_ecs_etm_pins(ECS_ETM_PINS_DISABLE);
+	mec_ecs_debug_port(MEC_DEBUG_MODE_SWD_SWV);
+#elif defined(CONFIG_SOC_MEC_DEBUG_AND_ETM_TRACING)
+	mec_ecs_debug_port(MEC_DEBUG_MODE_SWD);
+	mec_ecs_etm_pins(ECS_ETM_PINS_ENABLE);
+#endif
+#endif
+#endif
+}
+
+int mec5_soc_common_init(void)
+{
+	mec5_soc_init_debug_interface();
+	mec_ecia_init(MEC5_ECIA_DIRECT_BITMAP, 1, 0);
+
+	return 0;
+}

--- a/soc/microchip/mec/common/soc_cmn_init.h
+++ b/soc/microchip/mec/common/soc_cmn_init.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2024 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __MEC5_SOC_CMN_INIT_H
+#define __MEC5_SOC_CMN_INIT_H
+
+#ifndef _ASMLANGUAGE
+
+int mec5_soc_common_init(void);
+
+#endif
+
+#endif

--- a/soc/microchip/mec/mec174x/CMakeLists.txt
+++ b/soc/microchip/mec/mec174x/CMakeLists.txt
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2024, Microchip Technology Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+zephyr_include_directories(${ZEPHYR_BASE}/drivers)
+zephyr_sources(soc.c)
+zephyr_include_directories(.)
+
+set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")

--- a/soc/microchip/mec/mec174x/Kconfig
+++ b/soc/microchip/mec/mec174x/Kconfig
@@ -1,0 +1,21 @@
+# Microchip MEC174X MCU core series
+
+# Copyright (c) 2024 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC_SERIES_MEC174X
+	select ARM
+	select CPU_CORTEX_M4
+	select CPU_CORTEX_M_HAS_DWT
+	select CPU_HAS_FPU
+	select CPU_HAS_ARM_MPU
+	select HAS_SWO
+	select HAS_MEC5_HAL
+	select HAS_PM
+
+if SOC_SERIES_MEC174X
+
+config RTOS_TIMER
+	bool "MEC174x RTOS Timer(32KHz) as kernel timer"
+
+endif # SOC_SERIES_MEC174X

--- a/soc/microchip/mec/mec174x/Kconfig.defconfig.mec1743qlj
+++ b/soc/microchip/mec/mec174x/Kconfig.defconfig.mec1743qlj
@@ -1,0 +1,16 @@
+# Copyright (c) 2024 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Microchip MEC1743QLJ MCU using MEC5 HAL
+# Q = 480KB total SRAM
+# LJ = 176 pin package
+
+if SOC_MEC1743_QLJ
+
+config GPIO
+	default y
+
+config PINCTRL
+	default y
+
+endif # SOC_MEC1743_QLJ

--- a/soc/microchip/mec/mec174x/Kconfig.defconfig.mec1743qsz
+++ b/soc/microchip/mec/mec174x/Kconfig.defconfig.mec1743qsz
@@ -1,0 +1,16 @@
+# Copyright (c) 2024 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Microchip MEC1743QSZ MCU using MEC5 HAL
+# Q = 480KB total SRAM
+# SZ = 144 pin package
+
+if SOC_MEC1743_QSZ
+
+config GPIO
+	default y
+
+config PINCTRL
+	default y
+
+endif # SOC_MEC1743_QSZ

--- a/soc/microchip/mec/mec174x/Kconfig.defconfig.series
+++ b/soc/microchip/mec/mec174x/Kconfig.defconfig.series
@@ -1,0 +1,19 @@
+# Copyright (c) 2024 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Microchip MEC174x MCU series configuration options
+
+if SOC_SERIES_MEC174X
+
+config NUM_IRQS
+	# must be >= the highest interrupt number used
+	# - include the UART interrupts
+	# All NVIC external sources.
+	default 194
+
+rsource "Kconfig.defconfig.mec174*"
+
+config CORTEX_M_SYSTICK
+	depends on !RTOS_TIMER
+
+endif # SOC_SERIES_MEC174X

--- a/soc/microchip/mec/mec174x/Kconfig.soc
+++ b/soc/microchip/mec/mec174x/Kconfig.soc
@@ -1,0 +1,25 @@
+# Copyright (c) 2024 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Microchip MEC174x MCU core series
+
+config SOC_SERIES_MEC174X
+	bool
+	select SOC_FAMILY_MICROCHIP_MEC
+	help
+	  Enable support for Microchip MEC Cortex-M4F MCU series
+
+config SOC_SERIES
+	default "mec174x" if SOC_SERIES_MEC174X
+
+config SOC_MEC1743_QLJ
+	bool
+	select SOC_SERIES_MEC174X
+
+config SOC_MEC1743_QSZ
+	bool
+	select SOC_SERIES_MEC174X
+
+config SOC
+	default "mec1743_qlj" if SOC_MEC1743_QLJ
+	default "mec1743_qsz" if SOC_MEC1743_QSZ

--- a/soc/microchip/mec/mec174x/soc.c
+++ b/soc/microchip/mec/mec174x/soc.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+#include <soc.h>
+#include <soc_cmn_init.h>
+
+static int soc_init(void)
+{
+	mec5_soc_common_init();
+	return 0;
+}
+
+/* Enabling HW debug and initializing the MEC interrupt aggregator should be done
+ * before driver are loaded to not overwrite driver interrupt configuration.
+ * Use early initialization category called soon after Zephyr z_cstart and before
+ * Zephyr starts making driver initialization calls.
+ */
+SYS_INIT(soc_init, EARLY, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/soc/microchip/mec/mec174x/soc.h
+++ b/soc/microchip/mec/mec174x/soc.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __MEC5_SOC_H
+#define __MEC5_SOC_H
+
+#define SYSCLK_DEFAULT_IOSC_HZ MHZ(96)
+
+#ifndef _ASMLANGUAGE
+
+#include "device_mec5.h"
+
+/* common SoC API */
+#include "soc_dt.h"
+#include "soc_espi_channels.h"
+#include "soc_gpio.h"
+#include "soc_pcr.h"
+#include "soc_pins.h"
+
+#endif
+
+#endif

--- a/soc/microchip/mec/mec175x/CMakeLists.txt
+++ b/soc/microchip/mec/mec175x/CMakeLists.txt
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2024, Microchip Technology Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+zephyr_include_directories(${ZEPHYR_BASE}/drivers)
+zephyr_sources(soc.c)
+zephyr_include_directories(.)
+
+set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")

--- a/soc/microchip/mec/mec175x/Kconfig
+++ b/soc/microchip/mec/mec175x/Kconfig
@@ -1,0 +1,21 @@
+# Microchip MEC175X MCU core series
+
+# Copyright (c) 2024 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC_SERIES_MEC175X
+	select ARM
+	select CPU_CORTEX_M4
+	select CPU_CORTEX_M_HAS_DWT
+	select CPU_HAS_FPU
+	select CPU_HAS_ARM_MPU
+	select HAS_SWO
+	select HAS_MEC5_HAL
+	select HAS_PM
+
+if SOC_SERIES_MEC175X
+
+config RTOS_TIMER
+	bool "MEC175x RTOS Timer(32KHz) as kernel timer"
+
+endif # SOC_SERIES_MEC175X

--- a/soc/microchip/mec/mec175x/Kconfig.defconfig.mec1753qlj
+++ b/soc/microchip/mec/mec175x/Kconfig.defconfig.mec1753qlj
@@ -1,0 +1,16 @@
+# Copyright (c) 2024 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Microchip MEC1753QLJ MCU using MEC5 HAL
+# Q = 480KB total SRAM
+# LJ = 176 pin package
+
+if SOC_MEC1753_QLJ
+
+config GPIO
+	default y
+
+config PINCTRL
+	default y
+
+endif # SOC_MEC1753_QLJ

--- a/soc/microchip/mec/mec175x/Kconfig.defconfig.mec1753qsz
+++ b/soc/microchip/mec/mec175x/Kconfig.defconfig.mec1753qsz
@@ -1,0 +1,16 @@
+# Copyright (c) 2024 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Microchip MEC1743QSZ MCU using MEC5 HAL
+# Q = 480KB total SRAM
+# SZ = 144 pin package
+
+if SOC_MEC1743_QSZ
+
+config GPIO
+	default y
+
+config PINCTRL
+	default y
+
+endif # SOC_MEC1743_QSZ

--- a/soc/microchip/mec/mec175x/Kconfig.defconfig.series
+++ b/soc/microchip/mec/mec175x/Kconfig.defconfig.series
@@ -1,0 +1,19 @@
+# Copyright (c) 2024 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Microchip MEC175x MCU series configuration options
+
+if SOC_SERIES_MEC175X
+
+config NUM_IRQS
+	# must be >= the highest interrupt number used
+	# - include the UART interrupts
+	# All NVIC external sources.
+	default 198
+
+rsource "Kconfig.defconfig.mec175*"
+
+config CORTEX_M_SYSTICK
+	depends on !RTOS_TIMER
+
+endif # SOC_SERIES_MEC175X

--- a/soc/microchip/mec/mec175x/Kconfig.soc
+++ b/soc/microchip/mec/mec175x/Kconfig.soc
@@ -1,0 +1,25 @@
+# Copyright (c) 2024 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Microchip MEC175x MCU core series
+
+config SOC_SERIES_MEC175X
+	bool
+	select SOC_FAMILY_MICROCHIP_MEC
+	help
+	  Enable support for Microchip MEC Cortex-M4F MCU series
+
+config SOC_SERIES
+	default "mec175x" if SOC_SERIES_MEC175X
+
+config SOC_MEC1753_QLJ
+	bool
+	select SOC_SERIES_MEC175X
+
+config SOC_MEC1753_QSZ
+	bool
+	select SOC_SERIES_MEC175X
+
+config SOC
+	default "mec1753_qlj" if SOC_MEC1753_QLJ
+	default "mec1753_qsz" if SOC_MEC1753_QSZ

--- a/soc/microchip/mec/mec175x/soc.c
+++ b/soc/microchip/mec/mec175x/soc.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+#include <soc.h>
+#include <soc_cmn_init.h>
+
+static int soc_init(void)
+{
+	mec5_soc_common_init();
+	return 0;
+}
+
+/* Enabling HW debug and initializing the MEC interrupt aggregator should be done
+ * before driver are loaded to not overwrite driver interrupt configuration.
+ * Use early initialization category called soon after Zephyr z_cstart and before
+ * Zephyr starts making driver initialization calls.
+ */
+SYS_INIT(soc_init, EARLY, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/soc/microchip/mec/mec175x/soc.h
+++ b/soc/microchip/mec/mec175x/soc.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __MEC5_SOC_H
+#define __MEC5_SOC_H
+
+#define SYSCLK_DEFAULT_IOSC_HZ MHZ(96)
+
+#ifndef _ASMLANGUAGE
+
+#include "device_mec5.h"
+
+/* common SoC API */
+#include "soc_dt.h"
+#include "soc_espi_channels.h"
+#include "soc_gpio.h"
+#include "soc_pcr.h"
+#include "soc_pins.h"
+
+#endif
+
+#endif

--- a/soc/microchip/mec/mech172x/CMakeLists.txt
+++ b/soc/microchip/mec/mech172x/CMakeLists.txt
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2024, Microchip Technology Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+zephyr_include_directories(${ZEPHYR_BASE}/drivers)
+zephyr_sources(soc.c)
+zephyr_include_directories(.)
+
+set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")

--- a/soc/microchip/mec/mech172x/Kconfig
+++ b/soc/microchip/mec/mech172x/Kconfig
@@ -1,0 +1,21 @@
+# Microchip MECH172X MCU core series using MEC5 HAL and DTSI
+
+# Copyright (c) 2024 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC_SERIES_MECH172X
+	select ARM
+	select CPU_CORTEX_M4
+	select CPU_CORTEX_M_HAS_DWT
+	select CPU_HAS_FPU
+	select CPU_HAS_ARM_MPU
+	select HAS_SWO
+	select HAS_MEC5_HAL
+	select HAS_PM
+
+if SOC_SERIES_MECH172X
+
+config RTOS_TIMER
+	bool "MECH172x RTOS Timer(32KHz) as kernel timer"
+
+endif # SOC_SERIES_MECH172X

--- a/soc/microchip/mec/mech172x/Kconfig.defconfig.mech1723nlj
+++ b/soc/microchip/mec/mech172x/Kconfig.defconfig.mech1723nlj
@@ -1,0 +1,16 @@
+# Copyright (c) 2024 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Microchip MECH1723N-LJ MCU using MEC5 HAL
+# N = 416KB total SRAM
+# LJ = 176 pin package
+
+if SOC_MECH1723_NLJ
+
+config GPIO
+	default y
+
+config PINCTRL
+	default y
+
+endif # SOC_MECH1723_NLJ

--- a/soc/microchip/mec/mech172x/Kconfig.defconfig.mech1723nsz
+++ b/soc/microchip/mec/mech172x/Kconfig.defconfig.mech1723nsz
@@ -1,0 +1,16 @@
+# Copyright (c) 2024 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Microchip MECH1723N-SZ MCU using MEC5 HAL
+# N = 416KB total SRAM
+# SZ = 144 pin package
+
+if SOC_MECH1723_NSZ
+
+config GPIO
+	default y
+
+config PINCTRL
+	default y
+
+endif # SOC_MECH1723_NSZ

--- a/soc/microchip/mec/mech172x/Kconfig.defconfig.series
+++ b/soc/microchip/mec/mech172x/Kconfig.defconfig.series
@@ -1,0 +1,19 @@
+# Copyright (c) 2024 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Microchip MECH172x MCU series configuration options
+
+if SOC_SERIES_MECH172X
+
+config NUM_IRQS
+	# must be >= the highest interrupt number used
+	# - include the UART interrupts
+	# All NVIC external sources.
+	default 181
+
+rsource "Kconfig.defconfig.mech172*"
+
+config CORTEX_M_SYSTICK
+	depends on !RTOS_TIMER
+
+endif # SOC_SERIES_MECH172X

--- a/soc/microchip/mec/mech172x/Kconfig.soc
+++ b/soc/microchip/mec/mech172x/Kconfig.soc
@@ -1,0 +1,25 @@
+# Copyright (c) 2024 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Microchip MECH172x MCU core series
+
+config SOC_SERIES_MECH172X
+	bool
+	select SOC_FAMILY_MICROCHIP_MEC
+	help
+	  Enable support for Microchip MEC Cortex-M4F MCU series
+
+config SOC_SERIES
+	default "mech172x" if SOC_SERIES_MECH172X
+
+config SOC_MECH1723_NLJ
+	bool
+	select SOC_SERIES_MECH172X
+
+config SOC_MECH1723_NSZ
+	bool
+	select SOC_SERIES_MECH172X
+
+config SOC
+	default "mech1723_nlj" if SOC_MECH1723_NLJ
+	default "mech1723_nsz" if SOC_MECH1723_NSZ

--- a/soc/microchip/mec/mech172x/soc.c
+++ b/soc/microchip/mec/mech172x/soc.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+#include <soc.h>
+#include <soc_cmn_init.h>
+
+static int soc_init(void)
+{
+	mec5_soc_common_init();
+	return 0;
+}
+
+/* Enabling HW debug and initializing the MEC interrupt aggregator should be done
+ * before driver are loaded to not overwrite driver interrupt configuration.
+ * Use early initialization category called soon after Zephyr z_cstart and before
+ * Zephyr starts making driver initialization calls.
+ */
+SYS_INIT(soc_init, EARLY, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/soc/microchip/mec/mech172x/soc.h
+++ b/soc/microchip/mec/mech172x/soc.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __MEC5_SOC_H
+#define __MEC5_SOC_H
+
+#define SYSCLK_DEFAULT_IOSC_HZ MHZ(96)
+
+#ifndef _ASMLANGUAGE
+
+#include "device_mec5.h"
+
+/* common SoC API */
+#include "soc_dt.h"
+#include "soc_espi_channels.h"
+#include "soc_gpio.h"
+#include "soc_pcr.h"
+#include "soc_pins.h"
+
+#endif
+
+#endif

--- a/soc/microchip/mec/soc.yml
+++ b/soc/microchip/mec/soc.yml
@@ -8,3 +8,15 @@ family:
     socs:
     - name: mec172x_nsz
     - name: mec172x_nlj
+  - name: mec174x
+    socs:
+    - name: mec1743_qlj
+    - name: mec1743_qsz
+  - name: mec175x
+    socs:
+    - name: mec1753_qlj
+    - name: mec1753_qsz
+  - name: mech172x
+    socs:
+    - name: mech1723_nlj
+    - name: mech1723_nsz


### PR DESCRIPTION
Add new Microchip MEC chips using the new MEC5 HAL and add a HAL version of a legacy chip named MECH172x.
The new HAL (header and peripheral C code support):
New: MEC174x and MEC175x
Old: MEC172x named as MECH172x.
This PR does not affect customers using the legacy, non-HAL MEC172x.
