### PR TITLE
arch: x86: added missing parenthesis

### DIFF
--- a/arch/x86/core/early_serial.c
+++ b/arch/x86/core/early_serial.c
@@ -25,8 +25,8 @@
  * together.
  */
 static mm_reg_t mmio;
-#define IN(reg)       (sys_read32(mmio + reg * 4) & 0xff)
-#define OUT(reg, val) sys_write32((val) & 0xff, mmio + reg * 4)
+#define IN(reg)       (sys_read32(mmio + (reg) * 4) & 0xff)
+#define OUT(reg, val) sys_write32((val) & 0xff, mmio + (reg) * 4)
 #elif defined(X86_SOC_EARLY_SERIAL_MMIO8_ADDR)
 /* Still other devices use a MMIO region containing packed byte
  * registers


### PR DESCRIPTION
Added missing parentheses around macro argument expansion.

This corresponds to following coding guideline:

> Expressions resulting from the expansion of macro parameters shall be enclosed in parentheses

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/3c1d1a11e97c1306d85977140905b22ab7f8b31e