### PR TITLE
stm32 rtc driver using the stm32 LL_RTC Time Date init functions

### DIFF
--- a/tests/drivers/rtc/rtc_api/testcase.yaml
+++ b/tests/drivers/rtc/rtc_api/testcase.yaml
@@ -9,5 +9,6 @@ tests:
       - api
     filter: dt_alias_exists("rtc")
     depends_on: rtc
+    timeout: 100
     platform_exclude:
       - qemu_x86_64


### PR DESCRIPTION
Use the LL_RTC_TIME_Init and LL_RTC_DATE_Init and 
let the LL functions manage the Enter init mode and the Write Protection of the RTC calendar Registers

Increase the Timeout when executing the tests/drivers/rtc/rtc_api on stm32 targets
This will let test ends correctly when waiting for the alarm flags

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/72888
