### PR TITLE
tests: mcuboot: add boot_request_upgrade() return value check

### DIFF
--- a/tests/boot/test_mcuboot/src/main.c
+++ b/tests/boot/test_mcuboot/src/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 NXP
+ * Copyright 2022-2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,10 +11,16 @@
 /* Main entry point */
 int main(void)
 {
+	int err;
+
 	printk("Launching primary slot application on %s\n", CONFIG_BOARD);
 	/* Perform a permanent swap of MCUBoot application */
-	boot_request_upgrade(1);
-	printk("Secondary application ready for swap, rebooting\n");
-	sys_reboot(SYS_REBOOT_COLD);
+	err = boot_request_upgrade(BOOT_UPGRADE_PERMANENT);
+	if (err) {
+		printk("Failed to request upgrade: %d", err);
+	} else {
+		printk("Secondary application ready for swap, rebooting\n");
+		sys_reboot(SYS_REBOOT_COLD);
+	}
 	return 0;
 }


### PR DESCRIPTION
- Adds boot_request_upgrade() return value check.
- Avoid repeating resets if the upgrade request fails.