### PR TITLE
nrf54l15bsim: Add RRAM

### DIFF
--- a/boards/native/nrf_bsim/doc/nrf54l15bsim.rst
+++ b/boards/native/nrf_bsim/doc/nrf54l15bsim.rst
@@ -38,18 +38,21 @@ This boards include models of some of the nRF54L15 SOC peripherals:
 
 * DPPI (Distributed Programmable Peripheral Interconnect)
 * EGU (Event Generator Unit)
+* FICR (Factory Information Configuration Registers)
 * GRTC (Global Real-time Counter)
 * PPIB (PPI Bridge)
+* RRAMC (Resistive RAM Controller)
 * RTC (Real Time Counter)
 * TEMP (Temperature sensor)
 * TIMER
+* UICR (User Information Configuration Registers)
 
 and will use the same drivers as the nrf54l15pdk targets for these.
 For more information on what is modeled to which level of detail,
 check the `HW models implementation status`_.
 
-Note that unlike a real nrf54l15 device, the nrf54l15bsim boards have unlimited RAM and flash for
-code.
+Note that unlike a real nrf54l15 device, the nrf54l15bsim boards have unlimited RAM, and code does
+not occupy their RRAM.
 
 .. _BabbleSim:
    https://BabbleSim.github.io

--- a/boards/native/nrf_bsim/nrf54l15bsim_nrf54l15_cpuapp.dts
+++ b/boards/native/nrf_bsim/nrf54l15bsim_nrf54l15_cpuapp.dts
@@ -15,6 +15,8 @@
 
 	chosen {
 		zephyr,entropy = &rng;
+		zephyr,flash-controller = &rram_controller;
+		zephyr,flash = &cpuapp_rram;
 	};
 
 	/delete-node/ cpus;
@@ -22,8 +24,6 @@
 	/delete-node/ sw-pwm;
 
 	soc {
-		/delete-node/ uicr@ffd000;
-		/delete-node/ ficr@ffc000;
 		/delete-node/ memory@20000000;
 		/delete-node/ memory@2002f000;
 		peripheral@50000000 {
@@ -62,7 +62,6 @@
 			/delete-node/ gpiote@10c000;
 			/delete-node/ clock@10e000;
 		};
-		/delete-node/ rram-controller@5004b000;
 		/delete-node/ spu@50003000;
 		/delete-node/ gpiote@5000d000;
 		/delete-node/ crypto@50844000;
@@ -79,6 +78,18 @@
 	/* Channels 7-11 reserved for Zero Latency IRQs, 3-4 for FLPR */
 	child-owned-channels = <3 4 7 8 9 10 11>;
 	status = "okay";
+};
+
+&cpuapp_rram {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		storage_partition: partition@0 {
+			label = "storage";
+			reg = <0x0 DT_SIZE_K(500)>;
+		};
+	};
 };
 
 &temp {

--- a/drivers/flash/soc_flash_nrf_rram.c
+++ b/drivers/flash/soc_flash_nrf_rram.c
@@ -41,7 +41,11 @@ LOG_MODULE_REGISTER(flash_nrf_rram, CONFIG_FLASH_LOG_LEVEL);
 
 #define RRAM DT_INST(0, soc_nv_flash)
 
+#if defined(CONFIG_SOC_SERIES_BSIM_NRFXX)
+#define RRAM_START NRF_RRAM_BASE_ADDR
+#else
 #define RRAM_START DT_REG_ADDR(RRAM)
+#endif
 #define RRAM_SIZE  DT_REG_SIZE(RRAM)
 
 #define PAGE_SIZE  DT_PROP(RRAM, erase_block_size)

--- a/west.yml
+++ b/west.yml
@@ -295,7 +295,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 5d638052c9fe1ef3bd7638067354eba4d3f2fa78
+      revision: 36b12714a5ed32450d907c89bb118f6280da3483
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: da78aea63159771956fe0c9263f2e6985b66e9d5


### PR DESCRIPTION
Add support for the RRAM in the simulated nRF54L15:

* manifest: Update nRF hw models to latest
* drivers/flash/ nrf RRAM: Support simulated targets
* boards nrf54l15bsim: Update docs with RRAMC, FICR and UICR mention
* boards nrf54l15bsim: Enable RRAMC and add storage partition

Note: The RRAMC models are very simple, and too forgiving to be of much use for testing the RRAM driver itself.
The aim is to enable the Zephyr "flash" RRAM driver to run as in the real HW, so all functionality that depends on it can be used.
