### PR TITLE
MAINTAINERS: add arc qemu to Synopsys platform entry

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3153,6 +3153,7 @@ Synopsys Platforms:
   files:
     - soc/snps/
     - boards/snps/
+    - boards/qemu/arc/
     - samples/boards/arc_secure_services/
     - scripts/west_commands/runners/mdb.py
     - scripts/west_commands/tests/test_mdb.py


### PR DESCRIPTION
The ARC QEMU boards are maintained by Synopsys, so let's add boards/qemu/arc to Synopsys platform entry