### PR TITLE
drivers: added missing parenthesis

### DIFF
--- a/drivers/interrupt_controller/intc_system_apic.c
+++ b/drivers/interrupt_controller/intc_system_apic.c
@@ -19,7 +19,7 @@
 #include <zephyr/irq.h>
 #include <zephyr/linker/sections.h>
 
-#define IS_IOAPIC_IRQ(irq)  (irq < z_loapic_irq_base())
+#define IS_IOAPIC_IRQ(irq)  ((irq) < z_loapic_irq_base())
 #define HARDWARE_IRQ_LIMIT ((z_loapic_irq_base() + LOAPIC_IRQ_COUNT) - 1)
 
 /**


### PR DESCRIPTION
Added missing parentheses around macro argument expansion.

This corresponds to following coding guideline:

> Expressions resulting from the expansion of macro parameters shall be enclosed in parentheses

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/3c1d1a11e97c1306d85977140905b22ab7f8b31e