### PR TITLE
dts: mcxn947: Fix input key error

### DIFF
--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
@@ -6,6 +6,7 @@
 
 #include "frdm_mcxn947-pinctrl.dtsi"
 #include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
 	aliases{
@@ -41,11 +42,13 @@
 		user_button_2: button_0 {
 			label = "User SW2";
 			gpios = <&gpio0 23 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			zephyr,code = <INPUT_KEY_0>;
 			status = "disabled";
 		};
 		user_button_3: button_1 {
 			label = "User SW3";
 			gpios = <&gpio0 6 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+			zephyr,code = <INPUT_KEY_1>;
 			status = "disabled";
 		};
 	};


### PR DESCRIPTION
Fix the compile error when input driver is enabled. Error message:
In file included from zephyr/zephyr/include/zephyr/sys/util_macro.h:34,
                 from zephyr/zephyr/include/zephyr/irq_multilevel.h:15,
                 from zephyr/zephyr/include/zephyr/devicetree.h:20,
                 from zephyr/zephyr/include/zephyr/device.h:12,
                 from zephyr/zephyr/drivers/input/input_gpio_keys.c:9:
zephyr/zephyr/include/zephyr/toolchain/gcc.h:87:36: error: static assertion failed:
"zephyr-code must be specified to use the input-gpio-keys driver"