### PR TITLE
twister: handle exceptions when running binaries

### DIFF
--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -2691,6 +2691,7 @@ def test_twisterrunner_execute(caplog):
 
     process_mock = mock.Mock()
     process_mock().join = mock.Mock(side_effect=mock_join)
+    process_mock().exitcode = 0
     pipeline_mock = mock.Mock()
     done_mock = mock.Mock()
 


### PR DESCRIPTION
Deal with binaries not found. Also set default return code to something
other than zero to catch issues and report correct status.

Fixes #72807

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
