### PR TITLE
boards: nxp: rd_rw612_bga: add support for goworld 16880 display module

### DIFF
--- a/boards/nxp/rd_rw612_bga/Kconfig.defconfig
+++ b/boards/nxp/rd_rw612_bga/Kconfig.defconfig
@@ -30,4 +30,8 @@ config LV_Z_FLUSH_THREAD
 
 endif # LVGL
 
+# Enable interrupt support when using FT5336 driver
+config INPUT_FT5336_INTERRUPT
+	default y if INPUT
+
 endif # BOARD_RD_RW612_BGA

--- a/boards/nxp/rd_rw612_bga/dts/goworld_16880_lcm.overlay
+++ b/boards/nxp/rd_rw612_bga/dts/goworld_16880_lcm.overlay
@@ -1,0 +1,91 @@
+#include <zephyr/dt-bindings/spi/spi.h>
+
+/ {
+	chosen {
+		zephyr,display = &st7796s_lcdic;
+	};
+
+	lvgl_pointer {
+		compatible = "zephyr,lvgl-pointer-input";
+		input = <&ft7401>;
+		swap-xy;
+		invert-y;
+	};
+};
+
+&lcdic {
+	status = "okay";
+	nxp,swap-bytes;
+	/*
+	 * Settings to connect this display:
+	 * Populate the following resistors:
+	 * - R125, R123, R12, R124, R15, R243, R239, R236, R233, R286, R246
+	 * Remove the following resistors:
+	 * - R9, R11, R20, R19, R242, R241, R237, R235, R245
+	 * Remove JP30 to disconnect Flexcomm SPI CS
+	 * Display can be connected to Arduino header (J5/J6)
+	 * Pin #  | Signal | Header
+	 * -------------------------------
+	 * 1      | VDD    | J5.8 (+3.3V)
+	 * 2      | RST    | J6.8 (LCD_SPI_RESETN)
+	 * 3      | SDO    | J5.5 (SPI_MISO)
+	 * 4      | CS     | J5.3 (LCD_SPI_SS)
+	 * 5      | SCLK   | J5.6 (LCD_SPI_SCK)
+	 * 6      | GND    | J5.7 (GND)
+	 * 7      | MOSI   | J5.4 (LCD_SPI_SDIO)
+	 * 8      | CD     | J5.1 (LCD_SPI_DC)
+	 * 9      | TE     | J5.2 (LCD_SPI_TE, not enabled)
+	 *
+	 * Pins 10 and 11 correspond to the backlight anode and cathode,
+	 * and must be driven by an external circuit
+	 */
+	st7796s_lcdic: st7796s@0 {
+		compatible = "sitronix,st7796s";
+		status = "okay";
+		reg = <0>;
+		mipi-max-frequency = <23000000>;
+		duplex = <SPI_HALF_DUPLEX>;
+		height = <320>;
+		width = <480>;
+		invert-mode = "1-dot";
+		frmctl1 = [80 10];
+		bpc = [1F 50 00 20];
+		dfc = [8A 07 3B];
+		pwr1 = [80 64];
+		pwr2 = <0x13>;
+		pwr3 = <0xA7>;
+		vcmpctl = <0x09>;
+		doca = [40 8A 00 00 29 19 A5 38];
+		pgc = [F0 06 0B 07 06 05 2E 33 47 3A 17 16 2E 31];
+		ngc = [F0 09 0D 09 08 23 2E 33 46 38 13 13 2C 32];
+		madctl = <0x28>;
+	};
+};
+
+&flexcomm2 {
+	status = "okay";
+	ft7401: ft7401@38 {
+		/*
+		 * Settings to connect this touch controller:
+		 * Populate JP3 and JP50 to connect I2C
+		 * Controller can be connected to Arduino Header (J8/J5)
+		 * Pin #1 | Signal | Header
+		 * -------------------------------
+		 * 1      | VDD    | J8.2 (+3.3V)
+		 * 2      | IOVDD  | J8.4 (+3.3V)
+		 * 3      | SCL    | J5.10 (SCL)
+		 * 4      | SDA    | J5.9 (SDA)
+		 * 5      | INT    | J6.3 (D2)
+		 * 6      | RST    | J6.4 (D3)
+		 * 7      | GND    | J8.6 (GND)
+		 * 8      | GND    | J8.7 (GND)
+		 *
+		 * Note- the actual controller present on this IC is a FT7401,
+		 * but the FT5336 driver in Zephyr supports this IC.
+		 */
+		compatible = "focaltech,ft5336";
+		reg = <0x38>;
+		reset-gpios = <&hsgpio0 15 GPIO_ACTIVE_LOW>;
+		int-gpios = <&hsgpio0 11 GPIO_ACTIVE_HIGH>;
+	};
+};


### PR DESCRIPTION
Add support for the goworld 16880 display module. As this display module only features an FFC cable, it is added as a board overlay for the RW612 BGA. This module uses an ST7796S display controller as well as an FT7401 touch controller (which is managed by the FT5336 input driver)