### PR TITLE
Drop extern attr from functions

### DIFF
--- a/include/zephyr/app_memory/mem_domain.h
+++ b/include/zephyr/app_memory/mem_domain.h
@@ -126,7 +126,7 @@ struct k_mem_partition;
  * @retval -EINVAL if invalid parameters supplied
  * @retval -ENOMEM if insufficient memory
  */
-extern int k_mem_domain_init(struct k_mem_domain *domain, uint8_t num_parts,
+int k_mem_domain_init(struct k_mem_domain *domain, uint8_t num_parts,
 			     struct k_mem_partition *parts[]);
 
 /**
@@ -156,7 +156,7 @@ extern int k_mem_domain_init(struct k_mem_domain *domain, uint8_t num_parts,
  * @retval -EINVAL if invalid parameters supplied
  * @retval -ENOSPC if no free partition slots available
  */
-extern int k_mem_domain_add_partition(struct k_mem_domain *domain,
+int k_mem_domain_add_partition(struct k_mem_domain *domain,
 				      struct k_mem_partition *part);
 
 /**
@@ -171,7 +171,7 @@ extern int k_mem_domain_add_partition(struct k_mem_domain *domain,
  * @retval -EINVAL if invalid parameters supplied
  * @retval -ENOENT if no matching partition found
  */
-extern int k_mem_domain_remove_partition(struct k_mem_domain *domain,
+int k_mem_domain_remove_partition(struct k_mem_domain *domain,
 					 struct k_mem_partition *part);
 
 /**
@@ -185,7 +185,7 @@ extern int k_mem_domain_remove_partition(struct k_mem_domain *domain,
  *
  * @return 0 if successful, fails otherwise.
  */
-extern int k_mem_domain_add_thread(struct k_mem_domain *domain,
+int k_mem_domain_add_thread(struct k_mem_domain *domain,
 				   k_tid_t thread);
 
 #ifdef __cplusplus

--- a/include/zephyr/arch/x86/arch.h
+++ b/include/zephyr/arch/x86/arch.h
@@ -244,10 +244,10 @@ extern "C" {
 
 #ifndef _ASMLANGUAGE
 
-extern void arch_irq_enable(unsigned int irq);
-extern void arch_irq_disable(unsigned int irq);
+void arch_irq_enable(unsigned int irq);
+void arch_irq_disable(unsigned int irq);
 
-extern uint32_t sys_clock_cycle_get_32(void);
+uint32_t sys_clock_cycle_get_32(void);
 
 __pinned_func
 static inline uint32_t arch_k_cycle_get_32(void)
@@ -255,7 +255,7 @@ static inline uint32_t arch_k_cycle_get_32(void)
 	return sys_clock_cycle_get_32();
 }
 
-extern uint64_t sys_clock_cycle_get_64(void);
+uint64_t sys_clock_cycle_get_64(void);
 
 __pinned_func
 static inline uint64_t arch_k_cycle_get_64(void)

--- a/include/zephyr/arch/x86/ia32/arch.h
+++ b/include/zephyr/arch/x86/ia32/arch.h
@@ -266,8 +266,8 @@ static inline void arch_irq_direct_pm(void)
  * tracing/tracing.h cannot be included here due to circular dependency
  */
 #if defined(CONFIG_TRACING)
-extern void sys_trace_isr_enter(void);
-extern void sys_trace_isr_exit(void);
+void sys_trace_isr_enter(void);
+void sys_trace_isr_exit(void);
 #endif
 
 static inline void arch_isr_direct_header(void)
@@ -287,7 +287,7 @@ static inline void arch_isr_direct_header(void)
  *	  cannot be referenced from a public header, so we move it to an
  *	  external function.
  */
-extern void arch_isr_direct_footer_swap(unsigned int key);
+void arch_isr_direct_footer_swap(unsigned int key);
 
 static inline void arch_isr_direct_footer(int swap)
 {

--- a/include/zephyr/arch/x86/multiboot.h
+++ b/include/zephyr/arch/x86/multiboot.h
@@ -40,7 +40,7 @@ extern struct multiboot_info multiboot_info;
 
 #ifdef CONFIG_MULTIBOOT_INFO
 
-extern void z_multiboot_init(struct multiboot_info *info_pa);
+void z_multiboot_init(struct multiboot_info *info_pa);
 
 #else
 

--- a/include/zephyr/arch/xtensa/arch.h
+++ b/include/zephyr/arch/xtensa/arch.h
@@ -79,7 +79,7 @@ struct arch_mem_domain {
  *
  * @param reason_p Reason for exception.
  */
-extern void xtensa_arch_except(int reason_p);
+void xtensa_arch_except(int reason_p);
 
 /**
  * @brief Generate kernel oops.
@@ -89,7 +89,7 @@ extern void xtensa_arch_except(int reason_p);
  * @param reason_p Reason for exception.
  * @param ssf Stack pointer.
  */
-extern void xtensa_arch_kernel_oops(int reason_p, void *ssf);
+void xtensa_arch_kernel_oops(int reason_p, void *ssf);
 
 #ifdef CONFIG_USERSPACE
 
@@ -117,7 +117,7 @@ __syscall void xtensa_user_fault(unsigned int reason);
 #include <syscalls/arch.h>
 
 /* internal routine documented in C file, needed by IRQ_CONNECT() macro */
-extern void z_irq_priority_set(uint32_t irq, uint32_t prio, uint32_t flags);
+void z_irq_priority_set(uint32_t irq, uint32_t prio, uint32_t flags);
 
 #define ARCH_IRQ_CONNECT(irq_p, priority_p, isr_p, isr_param_p, flags_p) \
 	{ \
@@ -237,7 +237,7 @@ static inline bool arch_mem_coherent(void *ptr)
  * @param is_core0 True if this is called while executing on
  *                 CPU core #0.
  */
-extern void arch_xtensa_mmu_post_init(bool is_core0);
+void arch_xtensa_mmu_post_init(bool is_core0);
 #endif
 
 #ifdef __cplusplus

--- a/include/zephyr/arch/xtensa/irq.h
+++ b/include/zephyr/arch/xtensa/irq.h
@@ -160,7 +160,7 @@ static ALWAYS_INLINE bool arch_irq_unlocked(unsigned int key)
  *
  * @return True if interrupt is enabled, false otherwise.
  */
-extern int xtensa_irq_is_enabled(unsigned int irq);
+int xtensa_irq_is_enabled(unsigned int irq);
 
 #include <zephyr/irq.h>
 

--- a/include/zephyr/drivers/interrupt_controller/loapic.h
+++ b/include/zephyr/drivers/interrupt_controller/loapic.h
@@ -60,11 +60,11 @@ extern "C" {
 
 DEVICE_MMIO_TOPLEVEL_DECLARE(LOAPIC_REGS_STR);
 
-extern uint32_t z_loapic_irq_base(void);
-extern void z_loapic_enable(unsigned char cpu_number);
-extern void z_loapic_int_vec_set(unsigned int irq, unsigned int vector);
-extern void z_loapic_irq_enable(unsigned int irq);
-extern void z_loapic_irq_disable(unsigned int irq);
+uint32_t z_loapic_irq_base(void);
+void z_loapic_enable(unsigned char cpu_number);
+void z_loapic_int_vec_set(unsigned int irq, unsigned int vector);
+void z_loapic_irq_enable(unsigned int irq);
+void z_loapic_irq_disable(unsigned int irq);
 
 /**
  * @brief Read 64-bit value from the local APIC in x2APIC mode.

--- a/include/zephyr/drivers/timer/system_timer.h
+++ b/include/zephyr/drivers/timer/system_timer.h
@@ -70,7 +70,7 @@ extern "C" {
  * @param idle Hint to the driver that the system is about to enter
  *        the idle state immediately after setting the timeout
  */
-extern void sys_clock_set_timeout(int32_t ticks, bool idle);
+void sys_clock_set_timeout(int32_t ticks, bool idle);
 
 /**
  * @brief Timer idle exit notification
@@ -84,7 +84,7 @@ extern void sys_clock_set_timeout(int32_t ticks, bool idle);
  * This is allowed for compatibility, but not recommended.  The kernel
  * will figure that out on its own.
  */
-extern void sys_clock_idle_exit(void);
+void sys_clock_idle_exit(void);
 
 /**
  * @brief Announce time progress to the kernel
@@ -97,7 +97,7 @@ extern void sys_clock_idle_exit(void);
  *
  * @param ticks Elapsed time, in ticks
  */
-extern void sys_clock_announce(int32_t ticks);
+void sys_clock_announce(int32_t ticks);
 
 /**
  * @brief Ticks elapsed since last sys_clock_announce() call
@@ -107,7 +107,7 @@ extern void sys_clock_announce(int32_t ticks);
  * this with appropriate locking, the driver needs only provide an
  * instantaneous answer.
  */
-extern uint32_t sys_clock_elapsed(void);
+uint32_t sys_clock_elapsed(void);
 
 /**
  * @brief Disable system timer.
@@ -116,7 +116,7 @@ extern uint32_t sys_clock_elapsed(void);
  * The config @kconfig{CONFIG_SYSTEM_TIMER_HAS_DISABLE_SUPPORT} can be used to
  * check if the system timer has the capability of being disabled.
  */
-extern void sys_clock_disable(void);
+void sys_clock_disable(void);
 
 /**
  * @brief Hardware cycle counter


### PR DESCRIPTION
By default function declarations are considered extern. There is no need to explicitly using this attribute.