### PR TITLE
Extend sys/bitarray API with set-bit counting, xor, nth-bit-set

### DIFF
--- a/include/zephyr/sys/bitarray.h
+++ b/include/zephyr/sys/bitarray.h
@@ -169,6 +169,23 @@ int sys_bitarray_alloc(sys_bitarray_t *bitarray, size_t num_bits,
 		       size_t *offset);
 
 /**
+ * Count bits set in a bit array region
+ *
+ * This counts the number of bits set (@p count) in a
+ * region (@p offset, @p num_bits).
+ *
+ * @param[in]  bitarray Bitarray struct
+ * @param[in]  num_bits Number of bits to check, must be larger than 0
+ * @param[in]  offset   Starting bit position
+ * @param[out] count    Number of bits set in the region if successful
+ *
+ * @retval 0       Operation successful
+ * @retval -EINVAL Invalid argument (e.g. out-of-bounds access, trying to count 0 bits, etc.)
+ */
+int sys_bitarray_popcount_region(sys_bitarray_t *bitarray, size_t num_bits, size_t offset,
+				 size_t *count);
+
+/**
  * Free bits in a bit array
  *
  * This marks the number of bits (@p num_bits) starting from @p offset

--- a/include/zephyr/sys/bitarray.h
+++ b/include/zephyr/sys/bitarray.h
@@ -168,6 +168,22 @@ int sys_bitarray_test_and_clear_bit(sys_bitarray_t *bitarray, size_t bit, int *p
 int sys_bitarray_alloc(sys_bitarray_t *bitarray, size_t num_bits,
 		       size_t *offset);
 
+/*
+ * Calculates the bit-wise XOR of two bitarrays in a region.
+ * The result is stored in the first bitarray passed in (@p dst).
+ * Both bitarrays must be of the same size.
+ *
+ * @param dst      Bitarray struct
+ * @param other    Bitarray struct
+ * @param num_bits Number of bits in the region, must be larger than 0
+ * @param offset   Starting bit location
+ *
+ * @retval 0       Operation successful
+ * @retval -EINVAL Invalid argument (e.g. out-of-bounds access, mismatching bitarrays, trying to xor
+ * 0 bits, etc.)
+ */
+int sys_bitarray_xor(sys_bitarray_t *dst, sys_bitarray_t *other, size_t num_bits, size_t offset);
+
 /**
  * Count bits set in a bit array region
  *

--- a/include/zephyr/sys/bitarray.h
+++ b/include/zephyr/sys/bitarray.h
@@ -185,6 +185,28 @@ int sys_bitarray_alloc(sys_bitarray_t *bitarray, size_t num_bits,
 int sys_bitarray_xor(sys_bitarray_t *dst, sys_bitarray_t *other, size_t num_bits, size_t offset);
 
 /**
+ * Find nth bit set in region
+ *
+ * This counts the number of bits set (@p count) in a
+ * region (@p offset, @p num_bits) and returns the index (@p found_at)
+ * of the nth set bit, if it exists, as long with a zero return value.
+ *
+ * If it does not exist, @p found_at is not updated and the method returns
+ *
+ * @param[in]  bitarray Bitarray struct
+ * @param[in]  n        Nth bit set to look for
+ * @param[in]  num_bits Number of bits to check, must be larger than 0
+ * @param[in]  offset   Starting bit position
+ * @param[out] found_at Index of the nth bit set, if found
+ *
+ * @retval 0       Operation successful
+ * @retval 1       Nth bit set was not found in region
+ * @retval -EINVAL Invalid argument (e.g. out-of-bounds access, trying to count 0 bits, etc.)
+ */
+int sys_bitarray_find_nth_set(sys_bitarray_t *bitarray, size_t n, size_t num_bits, size_t offset,
+			      size_t *found_at);
+
+/**
  * Count bits set in a bit array region
  *
  * This counts the number of bits set (@p count) in a

--- a/tests/kernel/common/src/bitarray.c
+++ b/tests/kernel/common/src/bitarray.c
@@ -617,6 +617,149 @@ ZTEST(bitarray, test_bitarray_popcount_region)
 		      ret);
 }
 
+ZTEST(bitarray, test_bitarray_xor)
+{
+	int ret;
+
+	/* Bitarrays have embedded spinlocks and can't on the stack. */
+	if (IS_ENABLED(CONFIG_KERNEL_COHERENCE)) {
+		ztest_test_skip();
+	}
+
+	SYS_BITARRAY_DEFINE(ba, 128);
+	SYS_BITARRAY_DEFINE(bb, 128);
+	SYS_BITARRAY_DEFINE(bc, 129);
+
+	printk("Testing bit array region xor spanning single bundle\n");
+
+	/* Pre-populate the bits */
+	ba.bundles[0] = 0x80001001;
+	ba.bundles[1] = 0x10000008;
+	ba.bundles[2] = 0xFFFFFFFF;
+	ba.bundles[3] = 0x00000000;
+
+	bb.bundles[0] = 0x80010001;
+	bb.bundles[1] = 0x10000008;
+	bb.bundles[2] = 0xFFFFFFFF;
+	bb.bundles[3] = 0x00000000;
+
+	ret = sys_bitarray_xor(&ba, &bb, 32, 0);
+	zassert_equal(ret, 0, "sys_bitarray_xor() returned unexpected value: %d", ret);
+	zassert_equal(ba.bundles[0], 0x00011000, "sys_bitarray_xor() result unexpected: %x",
+		      ba.bundles[0]);
+	zassert_equal(bb.bundles[0], 0x80010001, "sys_bitarray_xor() result unexpected: %x",
+		      bb.bundles[0]);
+
+	zassert_equal(ba.bundles[1], 0x10000008, "sys_bitarray_xor() result unexpected: %x",
+		      ba.bundles[1]);
+	zassert_equal(bb.bundles[1], 0x10000008, "sys_bitarray_xor() result unexpected: %x",
+		      bb.bundles[1]);
+
+	zassert_equal(ba.bundles[2], 0xFFFFFFFF, "sys_bitarray_xor() result unexpected: %x",
+		      ba.bundles[2]);
+	zassert_equal(bb.bundles[2], 0xFFFFFFFF, "sys_bitarray_xor() result unexpected: %x",
+		      bb.bundles[2]);
+
+	zassert_equal(ba.bundles[3], 0x00000000, "sys_bitarray_xor() result unexpected: %x",
+		      ba.bundles[3]);
+	zassert_equal(bb.bundles[3], 0x00000000, "sys_bitarray_xor() result unexpected: %x",
+		      bb.bundles[3]);
+
+	/* Pre-populate the bits */
+	ba.bundles[0] = 0x80001001;
+	ba.bundles[1] = 0x10000008;
+	ba.bundles[2] = 0xFFFFFFFF;
+	ba.bundles[3] = 0x00000000;
+
+	bb.bundles[0] = 0x80010001;
+	bb.bundles[1] = 0x10000008;
+	bb.bundles[2] = 0xFFFFFFFF;
+	bb.bundles[3] = 0x00000000;
+
+	ret = sys_bitarray_xor(&ba, &bb, 16, 0);
+	zassert_equal(ret, 0, "sys_bitarray_xor() returned unexpected value: %d", ret);
+	zassert_equal(ba.bundles[0], 0x80001000, "sys_bitarray_xor() result unexpected: %x",
+		      ba.bundles[0]);
+	zassert_equal(bb.bundles[0], 0x80010001, "sys_bitarray_xor() result unexpected: %x",
+		      bb.bundles[0]);
+
+	/* Pre-populate the bits */
+	ba.bundles[0] = 0x80001001;
+	ba.bundles[1] = 0x10000008;
+	ba.bundles[2] = 0xFFFFFFFF;
+	ba.bundles[3] = 0x00000000;
+
+	bb.bundles[0] = 0x80010001;
+	bb.bundles[1] = 0x10000008;
+	bb.bundles[2] = 0xFFFFFFFF;
+	bb.bundles[3] = 0x00000000;
+
+	ret = sys_bitarray_xor(&ba, &bb, 16, 16);
+	zassert_equal(ret, 0, "sys_bitarray_xor() returned unexpected value: %d", ret);
+	zassert_equal(ba.bundles[0], 0x00011001, "sys_bitarray_xor() result unexpected: %x",
+		      ba.bundles[0]);
+	zassert_equal(bb.bundles[0], 0x80010001, "sys_bitarray_xor() result unexpected: %x",
+		      bb.bundles[0]);
+
+	printk("Testing bit array region xor spanning multiple bundles\n");
+
+	/* Pre-populate the bits */
+	ba.bundles[0] = 0x00000000;
+	ba.bundles[1] = 0xFFFFFFFF;
+	ba.bundles[2] = 0xFFFFFFFF;
+	ba.bundles[3] = 0xFFFFFFFF;
+
+	bb.bundles[0] = 0x00000000;
+	bb.bundles[1] = 0xFFFFFFFF;
+	bb.bundles[2] = 0xFFFFFFFF;
+	bb.bundles[3] = 0xFFFFFFFF;
+
+	ret = sys_bitarray_xor(&ba, &bb, 32*3 - 2, 32 + 1);
+	zassert_equal(ret, 0, "sys_bitarray_xor() returned unexpected value: %d", ret);
+	zassert_equal(ba.bundles[0], 0x00000000, "sys_bitarray_xor() result unexpected: %x",
+		      ba.bundles[0]);
+	zassert_equal(ba.bundles[1], 0x00000001, "sys_bitarray_xor() result unexpected: %x",
+		      ba.bundles[1]);
+	zassert_equal(ba.bundles[2], 0x00000000, "sys_bitarray_xor() result unexpected: %x",
+		      ba.bundles[2]);
+	zassert_equal(ba.bundles[3], 0x80000000, "sys_bitarray_xor() result unexpected: %x",
+		      ba.bundles[3]);
+
+	printk("Testing error cases\n");
+	/* Pre-populate the bits */
+	ba.bundles[0] = 0x00000000;
+	ba.bundles[1] = 0x00000000;
+	ba.bundles[2] = 0x00000000;
+	ba.bundles[3] = 0x00000000;
+
+	bb.bundles[0] = 0x00000000;
+	bb.bundles[1] = 0x00000000;
+	bb.bundles[2] = 0x00000000;
+	bb.bundles[3] = 0x00000000;
+
+	bc.bundles[0] = 0x00000000;
+	bc.bundles[1] = 0x00000000;
+	bc.bundles[2] = 0x00000000;
+	bc.bundles[3] = 0x00000000;
+	bc.bundles[4] = 0x00000000;
+
+	ret = sys_bitarray_xor(&ba, &bb, 32, 0);
+	zassert_equal(ret, 0, "sys_bitarray_xor() returned unexpected value: %d", ret);
+	ret = sys_bitarray_xor(&ba, &bc, 32, 0);
+	zassert_equal(ret, -EINVAL, "sys_bitarray_xor() returned unexpected value: %d", ret);
+	ret = sys_bitarray_xor(&bc, &ba, 32, 0);
+	zassert_equal(ret, -EINVAL, "sys_bitarray_xor() returned unexpected value: %d", ret);
+
+	ret = sys_bitarray_xor(&ba, &bb, 128, 0);
+	zassert_equal(ret, 0, "sys_bitarray_xor() returned unexpected value: %d", ret);
+	ret = sys_bitarray_xor(&ba, &bb, 128, 1);
+	zassert_equal(ret, -EINVAL, "sys_bitarray_xor() returned unexpected value: %d", ret);
+	ret = sys_bitarray_xor(&ba, &bb, 129, 0);
+	zassert_equal(ret, -EINVAL, "sys_bitarray_xor() returned unexpected value: %d", ret);
+	ret = sys_bitarray_xor(&ba, &bb, 0, 0);
+	zassert_equal(ret, -EINVAL, "sys_bitarray_xor() returned unexpected value: %d", ret);
+}
+
 ZTEST(bitarray, test_bitarray_region_set_clear)
 {
 	int ret;


### PR DESCRIPTION
Hello there!

I am currently working on integrating a memory-optimized forward error correction algorithm for LoRaWAN "natively" in Zephyr instead of relying on the external module that is currently being used.

For that, I need some more bitarray methods than are currently available.
In order to make review more enjoyable, I have added the three additional methods I need in this first PR and will then follow up with a second PR adding the new forward error correction algorithm that uses them.

This is my first Zephyr contribution and I am very much looking forward to your feedback.
Thanks for having a look!