### PR TITLE
MAINTAINERS: Add ubieda as a sensor driver collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1820,6 +1820,7 @@ Release Notes:
     - teburd
     - yperess
     - tristan-google
+    - ubieda
   files:
     - drivers/sensor/
     - include/zephyr/drivers/sensor.h


### PR DESCRIPTION
Following suggestion from the Dev-WG Meeting, adding myself as collaborator on the Sensor Drivers.