### PR TITLE
device: Remove z_device_is_ready

### DIFF
--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -732,22 +732,6 @@ size_t z_device_get_all_static(const struct device **devices);
 /**
  * @brief Verify that a device is ready for use.
  *
- * This is the implementation underlying device_is_ready(), without the overhead
- * of a syscall wrapper.
- *
- * @param dev pointer to the device in question.
- *
- * @retval true If the device is ready for use.
- * @retval false If the device is not ready for use or if a NULL device pointer
- * is passed as argument.
- *
- * @see device_is_ready()
- */
-bool z_device_is_ready(const struct device *dev);
-
-/**
- * @brief Verify that a device is ready for use.
- *
  * Indicates whether the provided device pointer is for a device known to be
  * in a state where it can be used with its standard API.
  *
@@ -762,11 +746,6 @@ bool z_device_is_ready(const struct device *dev);
  * is passed as argument.
  */
 __syscall bool device_is_ready(const struct device *dev);
-
-static inline bool z_impl_device_is_ready(const struct device *dev)
-{
-	return z_device_is_ready(dev);
-}
 
 /**
  * @brief Initialize a device.

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -40,13 +40,13 @@ const struct device *z_impl_device_get_binding(const char *name)
 	 * performed. Reserve string comparisons for a fallback.
 	 */
 	STRUCT_SECTION_FOREACH(device, dev) {
-		if (z_device_is_ready(dev) && (dev->name == name)) {
+		if (z_impl_device_is_ready(dev) && (dev->name == name)) {
 			return dev;
 		}
 	}
 
 	STRUCT_SECTION_FOREACH(device, dev) {
-		if (z_device_is_ready(dev) && (strcmp(name, dev->name) == 0)) {
+		if (z_impl_device_is_ready(dev) && (strcmp(name, dev->name) == 0)) {
 			return dev;
 		}
 	}
@@ -87,7 +87,7 @@ size_t z_device_get_all_static(struct device const **devices)
 	return cnt;
 }
 
-bool z_device_is_ready(const struct device *dev)
+bool z_impl_device_is_ready(const struct device *dev)
 {
 	/*
 	 * if an invalid device pointer is passed as argument, this call


### PR DESCRIPTION
This duplicates the functionality of device_is_ready.