### PR TITLE
Bluetooth: BAP: Broadcast Source: Update stream codec config data

### DIFF
--- a/subsys/bluetooth/audio/bap_endpoint.h
+++ b/subsys/bluetooth/audio/bap_endpoint.h
@@ -103,8 +103,12 @@ struct bt_bap_broadcast_source {
 	/* The codec specific configured data for each stream in the subgroup */
 	struct bt_audio_broadcast_stream_data stream_data[BROADCAST_STREAM_CNT];
 #endif /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0 */
-
 	uint8_t broadcast_code[BT_AUDIO_BROADCAST_CODE_SIZE];
+
+	/* The complete codec specific configured data for each stream in the subgroup.
+	 * This contains both the subgroup and the BIS-specific data for each stream.
+	 */
+	struct bt_audio_codec_cfg codec_cfg[BROADCAST_STREAM_CNT];
 
 	/* The subgroups containing the streams used to create the broadcast source */
 	sys_slist_t subgroups;

--- a/tests/bluetooth/audio/bap_broadcast_source/src/main.c
+++ b/tests/bluetooth/audio/bap_broadcast_source/src/main.c
@@ -44,7 +44,8 @@ static void bap_broadcast_source_test_suite_fixture_init(
 {
 	const uint8_t bis_cfg_data[] = {
 		BT_AUDIO_CODEC_DATA(BT_AUDIO_CODEC_CFG_CHAN_ALLOC,
-				    BT_AUDIO_LOCATION_FRONT_LEFT | BT_AUDIO_LOCATION_FRONT_RIGHT),
+				    BT_BYTES_LIST_LE32(BT_AUDIO_LOCATION_FRONT_LEFT |
+						       BT_AUDIO_LOCATION_FRONT_RIGHT)),
 	};
 	const size_t streams_per_subgroup = CONFIG_BT_BAP_BROADCAST_SRC_STREAM_COUNT /
 					    CONFIG_BT_BAP_BROADCAST_SRC_SUBGROUP_COUNT;
@@ -228,6 +229,19 @@ ZTEST_F(bap_broadcast_source_test_suite, test_broadcast_source_create_start_send
 		for (size_t j = 0U; j < create_param->params[i].params_count; j++) {
 			struct bt_bap_stream *bap_stream = create_param->params[i].params[j].stream;
 
+			/* verify bap stream started cb stream parameter */
+			zassert_equal(mock_bap_stream_started_cb_fake.arg0_history[i], bap_stream);
+			struct bt_audio_codec_cfg *codec_cfg = bap_stream->codec_cfg;
+			enum bt_audio_location chan_allocation;
+			/* verify subgroup codec data */
+			zassert_equal(bt_audio_codec_cfg_get_freq(codec_cfg),
+				      BT_AUDIO_CODEC_CFG_FREQ_16KHZ);
+			zassert_equal(bt_audio_codec_cfg_get_frame_dur(codec_cfg),
+				      BT_AUDIO_CODEC_CFG_DURATION_10);
+			/* verify bis specific codec data */
+			bt_audio_codec_cfg_get_chan_allocation(codec_cfg, &chan_allocation);
+			zassert_equal(chan_allocation,
+				      BT_AUDIO_LOCATION_FRONT_LEFT | BT_AUDIO_LOCATION_FRONT_RIGHT);
 			/* Since BAP doesn't care about the `buf` we can just provide NULL */
 			err = bt_bap_stream_send(bap_stream, NULL, 0);
 			zassert_equal(0, err,
@@ -1220,6 +1234,8 @@ ZTEST_F(bap_broadcast_source_test_suite, test_broadcast_source_get_id_inval_stat
 	zassert_not_equal(0, err, "Did not fail with deleted broadcast source");
 }
 
+
+
 ZTEST_F(bap_broadcast_source_test_suite, test_broadcast_source_get_base_single_bis)
 {
 	struct bt_bap_broadcast_source_param *create_param = fixture->param;
@@ -1237,8 +1253,8 @@ ZTEST_F(bap_broadcast_source_test_suite, test_broadcast_source_get_base_single_b
 		0x04,                                           /* meta length */
 		0x03, 0x02, 0x01, 0x00,                         /* meta */
 		0x01,                                           /* bis index */
-		0x03,                                           /* bis cc length */
-		0x02, 0x03, 0x03                                /* bis cc length */
+		0x06,                                           /* bis cc length */
+		0x05, 0x03, 0x03, 0x00, 0x00, 0x00              /* bis cc length */
 	};
 
 	NET_BUF_SIMPLE_DEFINE(base_buf, 64);
@@ -1294,8 +1310,8 @@ ZTEST_F(bap_broadcast_source_test_suite, test_broadcast_source_get_base)
 		0x04,                                           /* meta length */
 		0x03, 0x02, 0x01, 0x00,                         /* meta */
 		0x01,                                           /* bis index */
-		0x03,                                           /* bis cc length */
-		0x02, 0x03, 0x03,                               /* bis cc length */
+		0x06,                                           /* bis cc length */
+		0x05, 0x03, 0x03, 0x00, 0x00, 0x00,             /* bis cc length */
 		0x01,                                           /* Subgroup 1: bis count */
 		0x06, 0x00, 0x00, 0x00, 0x00,                   /* LC3 codec_id*/
 		0x10,                                           /* cc length */
@@ -1304,8 +1320,8 @@ ZTEST_F(bap_broadcast_source_test_suite, test_broadcast_source_get_base)
 		0x04,                                           /* meta length */
 		0x03, 0x02, 0x01, 0x00,                         /* meta */
 		0x02,                                           /* bis index */
-		0x03,                                           /* bis cc length */
-		0x02, 0x03, 0x03                                /* bis cc length */
+		0x06,                                           /* bis cc length */
+		0x05, 0x03, 0x03, 0x00, 0x00, 0x00              /* bis cc length */
 	};
 
 	NET_BUF_SIMPLE_DEFINE(base_buf, 128);

--- a/tests/bluetooth/audio/bap_broadcast_source/uut/CMakeLists.txt
+++ b/tests/bluetooth/audio/bap_broadcast_source/uut/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(uut STATIC
   ${ZEPHYR_BASE}/subsys/bluetooth/audio/bap_iso.c
   ${ZEPHYR_BASE}/subsys/bluetooth/audio/bap_stream.c
   ${ZEPHYR_BASE}/subsys/bluetooth/audio/bap_broadcast_source.c
+  ${ZEPHYR_BASE}/subsys/bluetooth/audio/codec.c
   ${ZEPHYR_BASE}/subsys/logging/log_minimal.c
   ${ZEPHYR_BASE}/subsys/net/buf_simple.c
 )

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
@@ -446,7 +446,7 @@ static void validate_stream_codec_cfg(const struct bt_bap_stream *stream)
 	 */
 	ret = bt_audio_codec_cfg_get_chan_allocation(codec_cfg, &chan_allocation);
 	if (ret == 0) {
-		if (chan_allocation != BT_AUDIO_LOCATION_FRONT_LEFT) {
+		if (chan_allocation != BT_AUDIO_LOCATION_FRONT_CENTER) {
 			FAIL("Unexpected channel allocation: 0x%08X", chan_allocation);
 
 			return;


### PR DESCRIPTION
When creating a BAP broadcast source with bt_bap_broadcast_source_create, only the subgroup information is stored in the streams and the remaining BIS specific information is not stored in the stream->codec_cfg, which it should.
Fix is to store bis specific information also in stream codec config.

Fixes #71125 