### PR TITLE
drivers: sensor: rtio: use catch-remaining for decoding

### DIFF
--- a/drivers/sensor/default_rtio_sensor.c
+++ b/drivers/sensor/default_rtio_sensor.c
@@ -323,6 +323,10 @@ int sensor_natively_supported_channel_size_info(struct sensor_chan_spec channel,
 	__ASSERT_NO_MSG(base_size != NULL);
 	__ASSERT_NO_MSG(frame_size != NULL);
 
+	if (((int)channel.chan_type < 0) || channel.chan_type >= (SENSOR_CHAN_ALL)) {
+		return -ENOTSUP;
+	}
+
 	switch (channel.chan_type) {
 	case SENSOR_CHAN_ACCEL_X:
 	case SENSOR_CHAN_ACCEL_Y:
@@ -342,49 +346,6 @@ int sensor_natively_supported_channel_size_info(struct sensor_chan_spec channel,
 		*base_size = sizeof(struct sensor_three_axis_data);
 		*frame_size = sizeof(struct sensor_three_axis_sample_data);
 		return 0;
-	case SENSOR_CHAN_DIE_TEMP:
-	case SENSOR_CHAN_AMBIENT_TEMP:
-	case SENSOR_CHAN_PRESS:
-	case SENSOR_CHAN_HUMIDITY:
-	case SENSOR_CHAN_LIGHT:
-	case SENSOR_CHAN_IR:
-	case SENSOR_CHAN_RED:
-	case SENSOR_CHAN_GREEN:
-	case SENSOR_CHAN_BLUE:
-	case SENSOR_CHAN_ALTITUDE:
-	case SENSOR_CHAN_PM_1_0:
-	case SENSOR_CHAN_PM_2_5:
-	case SENSOR_CHAN_PM_10:
-	case SENSOR_CHAN_DISTANCE:
-	case SENSOR_CHAN_CO2:
-	case SENSOR_CHAN_VOC:
-	case SENSOR_CHAN_GAS_RES:
-	case SENSOR_CHAN_VOLTAGE:
-	case SENSOR_CHAN_CURRENT:
-	case SENSOR_CHAN_POWER:
-	case SENSOR_CHAN_RESISTANCE:
-	case SENSOR_CHAN_ROTATION:
-	case SENSOR_CHAN_RPM:
-	case SENSOR_CHAN_GAUGE_VOLTAGE:
-	case SENSOR_CHAN_GAUGE_AVG_CURRENT:
-	case SENSOR_CHAN_GAUGE_STDBY_CURRENT:
-	case SENSOR_CHAN_GAUGE_MAX_LOAD_CURRENT:
-	case SENSOR_CHAN_GAUGE_TEMP:
-	case SENSOR_CHAN_GAUGE_STATE_OF_CHARGE:
-	case SENSOR_CHAN_GAUGE_FULL_CHARGE_CAPACITY:
-	case SENSOR_CHAN_GAUGE_REMAINING_CHARGE_CAPACITY:
-	case SENSOR_CHAN_GAUGE_NOM_AVAIL_CAPACITY:
-	case SENSOR_CHAN_GAUGE_FULL_AVAIL_CAPACITY:
-	case SENSOR_CHAN_GAUGE_AVG_POWER:
-	case SENSOR_CHAN_GAUGE_STATE_OF_HEALTH:
-	case SENSOR_CHAN_GAUGE_TIME_TO_EMPTY:
-	case SENSOR_CHAN_GAUGE_TIME_TO_FULL:
-	case SENSOR_CHAN_GAUGE_DESIGN_VOLTAGE:
-	case SENSOR_CHAN_GAUGE_DESIRED_VOLTAGE:
-	case SENSOR_CHAN_GAUGE_DESIRED_CHARGING_CURRENT:
-		*base_size = sizeof(struct sensor_q31_data);
-		*frame_size = sizeof(struct sensor_q31_sample_data);
-		return 0;
 	case SENSOR_CHAN_PROX:
 		*base_size = sizeof(struct sensor_byte_data);
 		*frame_size = sizeof(struct sensor_byte_sample_data);
@@ -394,7 +355,9 @@ int sensor_natively_supported_channel_size_info(struct sensor_chan_spec channel,
 		*frame_size = sizeof(struct sensor_uint64_sample_data);
 		return 0;
 	default:
-		return -ENOTSUP;
+		*base_size = sizeof(struct sensor_q31_data);
+		*frame_size = sizeof(struct sensor_q31_sample_data);
+		return 0;
 	}
 }
 
@@ -485,6 +448,10 @@ static int decode(const uint8_t *buffer, struct sensor_chan_spec chan_spec,
 		return -EINVAL;
 	}
 
+	if (((int)chan_spec.chan_type < 0) || chan_spec.chan_type >= (SENSOR_CHAN_ALL)) {
+		return 0;
+	}
+
 	/* Check for 3d channel mappings */
 	switch (chan_spec.chan_type) {
 	case SENSOR_CHAN_ACCEL_X:
@@ -518,49 +485,8 @@ static int decode(const uint8_t *buffer, struct sensor_chan_spec chan_spec,
 					  SENSOR_CHAN_POS_DY, SENSOR_CHAN_POS_DZ,
 					  chan_spec.chan_idx);
 		break;
-	case SENSOR_CHAN_DIE_TEMP:
-	case SENSOR_CHAN_AMBIENT_TEMP:
-	case SENSOR_CHAN_PRESS:
-	case SENSOR_CHAN_HUMIDITY:
-	case SENSOR_CHAN_LIGHT:
-	case SENSOR_CHAN_IR:
-	case SENSOR_CHAN_RED:
-	case SENSOR_CHAN_GREEN:
-	case SENSOR_CHAN_BLUE:
-	case SENSOR_CHAN_ALTITUDE:
-	case SENSOR_CHAN_PM_1_0:
-	case SENSOR_CHAN_PM_2_5:
-	case SENSOR_CHAN_PM_10:
-	case SENSOR_CHAN_DISTANCE:
-	case SENSOR_CHAN_CO2:
-	case SENSOR_CHAN_VOC:
-	case SENSOR_CHAN_GAS_RES:
-	case SENSOR_CHAN_VOLTAGE:
-	case SENSOR_CHAN_CURRENT:
-	case SENSOR_CHAN_POWER:
-	case SENSOR_CHAN_RESISTANCE:
-	case SENSOR_CHAN_ROTATION:
-	case SENSOR_CHAN_RPM:
-	case SENSOR_CHAN_GAUGE_VOLTAGE:
-	case SENSOR_CHAN_GAUGE_AVG_CURRENT:
-	case SENSOR_CHAN_GAUGE_STDBY_CURRENT:
-	case SENSOR_CHAN_GAUGE_MAX_LOAD_CURRENT:
-	case SENSOR_CHAN_GAUGE_TEMP:
-	case SENSOR_CHAN_GAUGE_STATE_OF_CHARGE:
-	case SENSOR_CHAN_GAUGE_FULL_CHARGE_CAPACITY:
-	case SENSOR_CHAN_GAUGE_REMAINING_CHARGE_CAPACITY:
-	case SENSOR_CHAN_GAUGE_NOM_AVAIL_CAPACITY:
-	case SENSOR_CHAN_GAUGE_FULL_AVAIL_CAPACITY:
-	case SENSOR_CHAN_GAUGE_AVG_POWER:
-	case SENSOR_CHAN_GAUGE_STATE_OF_HEALTH:
-	case SENSOR_CHAN_GAUGE_TIME_TO_EMPTY:
-	case SENSOR_CHAN_GAUGE_TIME_TO_FULL:
-	case SENSOR_CHAN_GAUGE_DESIGN_VOLTAGE:
-	case SENSOR_CHAN_GAUGE_DESIRED_VOLTAGE:
-	case SENSOR_CHAN_GAUGE_DESIRED_CHARGING_CURRENT:
-		count = decode_q31(header, q, data_out, chan_spec);
-		break;
 	default:
+		count = decode_q31(header, q, data_out, chan_spec);
 		break;
 	}
 	if (count > 0) {


### PR DESCRIPTION
As new channels are added to the `enum sensor_channel`, some of the newer channel aren't updated in the whitelist of rtio decoder.

Instead of specifying every channel in the list, do:
1. Verify that the `channel` is valid
2. cherry-pick the channels that require special handling, i.e.
   1. `three_axis_data`
   2. `byte_data`
   3. `uint64_data`
3. handle the remaining `channel` in the default case as
   `q31_data`

to make sure that all channels are handled.

___


before:

```
uart:~$ sensor get sensor@0 32
[870:26:48.134,000] <inf> fake_sensor: [sample_fetch] dev: 0x8000e2b8, chan: 59
[870:26:48.134,000] <inf> fake_sensor: [channel_get] dev: 0x8000e2b8, chan: 32
```

after:

```
uart:~$ sensor get sensor@0 32
channel idx=32 (null) shift=6 num_samples=1 value=9220133425350000000ns (32.000000)
[870:26:48.134,000] <inf> fake_sensor: [sample_fetch] dev: 0x8000e290, chan: 59
[870:26:48.134,000] <inf> fake_sensor: [channel_get] dev: 0x8000e290, chan: 32
```

