### PR TITLE
Bluetooth samples: Fix broadcast source device name

### DIFF
--- a/samples/bluetooth/broadcast_audio_source/src/main.c
+++ b/samples/bluetooth/broadcast_audio_source/src/main.c
@@ -432,10 +432,6 @@ static int setup_broadcast_source(struct bt_bap_broadcast_source **source)
 	return 0;
 }
 
-static const struct bt_data ad[] = {
-	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
-};
-
 int main(void)
 {
 	struct bt_le_ext_adv *adv;
@@ -493,7 +489,7 @@ int main(void)
 		NET_BUF_SIMPLE_DEFINE(ad_buf,
 				      BT_UUID_SIZE_16 + BT_AUDIO_BROADCAST_ID_SIZE);
 		NET_BUF_SIMPLE_DEFINE(base_buf, 128);
-		struct bt_data ext_ad;
+		struct bt_data ext_ad[2];
 		struct bt_data per_ad;
 		uint32_t broadcast_id;
 
@@ -502,12 +498,6 @@ int main(void)
 		if (err != 0) {
 			printk("Unable to create extended advertising set: %d\n",
 			       err);
-			return 0;
-		}
-
-		err = bt_le_ext_adv_set_data(adv, ad, ARRAY_SIZE(ad), NULL, 0);
-		if (err) {
-			printk("Failed to set advertising data (err %d)\n", err);
 			return 0;
 		}
 
@@ -535,10 +525,12 @@ int main(void)
 		/* Setup extended advertising data */
 		net_buf_simple_add_le16(&ad_buf, BT_UUID_BROADCAST_AUDIO_VAL);
 		net_buf_simple_add_le24(&ad_buf, broadcast_id);
-		ext_ad.type = BT_DATA_SVC_DATA16;
-		ext_ad.data_len = ad_buf.len;
-		ext_ad.data = ad_buf.data;
-		err = bt_le_ext_adv_set_data(adv, &ext_ad, 1, NULL, 0);
+		ext_ad[0].type = BT_DATA_SVC_DATA16;
+		ext_ad[0].data_len = ad_buf.len;
+		ext_ad[0].data = ad_buf.data;
+		ext_ad[1] = (struct bt_data)BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME,
+						    sizeof(CONFIG_BT_DEVICE_NAME) - 1);
+		err = bt_le_ext_adv_set_data(adv, ext_ad, 2, NULL, 0);
 		if (err != 0) {
 			printk("Failed to set extended advertising data: %d\n",
 			       err);


### PR DESCRIPTION
The device name explicitly added in the advertising data.