### PR TITLE
Enable tests/posix/env in native targets

### DIFF
--- a/tests/posix/env/testcase.yaml
+++ b/tests/posix/env/testcase.yaml
@@ -1,7 +1,5 @@
 common:
   filter: not CONFIG_NATIVE_LIBC
-  arch_exclude:
-    - posix
   integration_platforms:
     - qemu_riscv64
   tags: posix


### PR DESCRIPTION
    tests/posix/env: Remove arch posix filter
    
    This test runs fine in "native" targets
    based on the toolchain and C library filtering.
    As there is no need to exclude this architecture,
    let's remove the exclusion to improve coverage.
