### PR TITLE
tests/posix/env: set CONFIG_PICOLIBC=y

### DIFF
--- a/tests/posix/env/prj.conf
+++ b/tests/posix/env/prj.conf
@@ -1,3 +1,6 @@
 CONFIG_ZTEST=y
 CONFIG_POSIX_ENV=y
+# Let's explicitly choose PICOLIBC, so it is used if supported even if it would not have been the
+# default (otherwise native targets default to the host C library)
+CONFIG_PICOLIBC=y
 CONFIG_COMMON_LIBC_MALLOC=y


### PR DESCRIPTION
Chosing by default in the prj.conf
PICOLIBC ensures we also use an embedded
libC even when built for a native target
and even if we dont set POSIX_API.

This ensures the test will build and pass
properly when built with default configuration
from command line without using the test yaml.

This change does not affect the build result
for other targets as those defaulted already
to PICOLIBC.