### PR TITLE
added necessary DT_DRV_COMPAT #define in akm09918 sensor decoder

### DIFF
--- a/drivers/sensor/asahi_kasei/akm09918c/akm09918c_decoder.c
+++ b/drivers/sensor/asahi_kasei/akm09918c/akm09918c_decoder.c
@@ -5,6 +5,8 @@
 
 #include "akm09918c.h"
 
+#define DT_DRV_COMPAT asahi_kasei_akm09918c
+
 static int akm09918c_decoder_get_frame_count(const uint8_t *buffer,
 					     struct sensor_chan_spec chan_spec,
 					     uint16_t *frame_count)


### PR DESCRIPTION
The sensor decoder api was not available in fact that there was a define missing which links the decoder api to the DT. This PR should fix this issue.