### PR TITLE
sysbuild: support sysbuild/CMakeLists.txt as entry point and support APPLICATION_CONFIG_DIR

### DIFF
--- a/share/sysbuild-package/cmake/SysbuildConfig.cmake
+++ b/share/sysbuild-package/cmake/SysbuildConfig.cmake
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+
+if(Sysbuild_FIND_COMPONENTS)
+  set(Zephyr_FIND_COMPONENTS ${Sysbuild_FIND_COMPONENTS})
+else()
+  set(Zephyr_FIND_COMPONENTS sysbuild_default)
+endif()
+include(${CMAKE_CURRENT_LIST_DIR}/../../zephyr-package/cmake/ZephyrConfig.cmake)
+set(Sysbuild_FOUND True)

--- a/share/sysbuild-package/cmake/SysbuildConfigVersion.cmake
+++ b/share/sysbuild-package/cmake/SysbuildConfigVersion.cmake
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include(${CMAKE_CURRENT_LIST_DIR}/../../zephyr-package/cmake/ZephyrConfigVersion.cmake)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../sysbuild/cmake/modules)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} PARENT_SCOPE)

--- a/share/sysbuild/CMakeLists.txt
+++ b/share/sysbuild/CMakeLists.txt
@@ -12,38 +12,12 @@ endif()
 # If APP_DIR is a relative path, then CMake will adjust to absolute path based
 # on current working dir.
 set(APP_DIR ${APP_DIR} CACHE PATH "Main Application Source Directory")
+set(Sysbuild_DIR ${CMAKE_CURRENT_LIST_DIR}/../sysbuild-package/cmake)
 
-# Add sysbuild/cmake/modules to CMAKE_MODULE_PATH which allows us to integrate
-# sysbuild CMake modules with general Zephyr CMake modules.
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/modules)
-# List of Zephyr and sysbuild CMake modules we need for sysbuild.
-# Note: sysbuild_kconfig will internally load kconfig CMake module.
-set(zephyr_modules extensions
-    sysbuild_extensions python west root zephyr_module boards shields hwm_v2
-    sysbuild_kconfig native_simulator_sb_extensions
-  )
+project(sysbuild_toplevel LANGUAGES)
 
-find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE} COMPONENTS ${zephyr_modules})
-
-project(sysbuild LANGUAGES)
-
-get_filename_component(APP_DIR  ${APP_DIR} ABSOLUTE)
-get_filename_component(app_name ${APP_DIR} NAME)
-set(DEFAULT_IMAGE "${app_name}")
-
-# This is where all Zephyr applications are added to the multi-image build.
-sysbuild_add_subdirectory(images)
-
-get_property(IMAGES GLOBAL PROPERTY sysbuild_images)
-sysbuild_module_call(PRE_CMAKE MODULES ${SYSBUILD_MODULE_NAMES} IMAGES ${IMAGES})
-sysbuild_images_order(IMAGES_CONFIGURATION_ORDER CONFIGURE IMAGES ${IMAGES})
-foreach(image ${IMAGES_CONFIGURATION_ORDER})
-  sysbuild_module_call(PRE_IMAGE_CMAKE MODULES ${SYSBUILD_MODULE_NAMES} IMAGES ${IMAGES} IMAGE ${image})
-  ExternalZephyrProject_Cmake(APPLICATION ${image})
-  sysbuild_module_call(POST_IMAGE_CMAKE MODULES ${SYSBUILD_MODULE_NAMES} IMAGES ${IMAGES} IMAGE ${image})
-endforeach()
-sysbuild_module_call(POST_CMAKE MODULES ${SYSBUILD_MODULE_NAMES} IMAGES ${IMAGES})
-
-sysbuild_module_call(PRE_DOMAINS MODULES ${SYSBUILD_MODULE_NAMES} IMAGES ${IMAGES})
-include(cmake/domains.cmake)
-sysbuild_module_call(POST_DOMAINS MODULES ${SYSBUILD_MODULE_NAMES} IMAGES ${IMAGES})
+if(EXISTS ${APP_DIR}/sysbuild/CMakeLists.txt)
+  add_subdirectory(${APP_DIR}/sysbuild sysbuild/application)
+else()
+  add_subdirectory(template sysbuild/application)
+endif()

--- a/share/sysbuild/cmake/modules/sysbuild_default.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_default.cmake
@@ -1,0 +1,19 @@
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: Apache-2.0
+
+#
+# Sysbuild default list of CMake modules to include in a regular sysbuild session.
+#
+include(extensions)
+include(sysbuild_extensions)
+include(python)
+include(west)
+include(root)
+include(zephyr_module)
+include(boards)
+include(shields)
+include(hwm_v2)
+include(sysbuild_kconfig)
+include(native_simulator_sb_extensions)
+include(sysbuild_images)

--- a/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
@@ -661,7 +661,7 @@ function(sysbuild_add_subdirectory source_dir)
       " (expected at most 2, got ${ARGC})"
     )
   endif()
-  set(binary_dir ${ARGV1})
+  set(binary_dir ${ARGN})
 
   # Update SYSBUILD_CURRENT_SOURCE_DIR in this scope, to support nesting
   # of sysbuild_add_subdirectory() and even regular add_subdirectory().

--- a/share/sysbuild/cmake/modules/sysbuild_images.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_images.cmake
@@ -1,0 +1,27 @@
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# This module is responsible for including images into sysbuild and to call
+# pre and post hooks.
+
+get_filename_component(APP_DIR  ${APP_DIR} ABSOLUTE)
+get_filename_component(app_name ${APP_DIR} NAME)
+set(DEFAULT_IMAGE "${app_name}")
+
+# This is where all Zephyr applications are added to the multi-image build.
+sysbuild_add_subdirectory(${sysbuild_toplevel_SOURCE_DIR}/images sysbuild/images)
+
+get_property(IMAGES GLOBAL PROPERTY sysbuild_images)
+sysbuild_module_call(PRE_CMAKE MODULES ${SYSBUILD_MODULE_NAMES} IMAGES ${IMAGES})
+sysbuild_images_order(IMAGES_CONFIGURATION_ORDER CONFIGURE IMAGES ${IMAGES})
+foreach(image ${IMAGES_CONFIGURATION_ORDER})
+  sysbuild_module_call(PRE_IMAGE_CMAKE MODULES ${SYSBUILD_MODULE_NAMES} IMAGES ${IMAGES} IMAGE ${image})
+  ExternalZephyrProject_Cmake(APPLICATION ${image})
+  sysbuild_module_call(POST_IMAGE_CMAKE MODULES ${SYSBUILD_MODULE_NAMES} IMAGES ${IMAGES} IMAGE ${image})
+endforeach()
+sysbuild_module_call(POST_CMAKE MODULES ${SYSBUILD_MODULE_NAMES} IMAGES ${IMAGES})
+
+sysbuild_module_call(PRE_DOMAINS MODULES ${SYSBUILD_MODULE_NAMES} IMAGES ${IMAGES})
+include(${sysbuild_toplevel_SOURCE_DIR}/cmake/domains.cmake)
+sysbuild_module_call(POST_DOMAINS MODULES ${SYSBUILD_MODULE_NAMES} IMAGES ${IMAGES})

--- a/share/sysbuild/cmake/modules/sysbuild_kconfig.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_kconfig.cmake
@@ -13,13 +13,37 @@ set(EXTRA_KCONFIG_TARGET_COMMAND_FOR_sysbuild_guiconfig
 set(KCONFIG_TARGETS sysbuild_menuconfig sysbuild_guiconfig)
 list(TRANSFORM EXTRA_KCONFIG_TARGETS PREPEND "sysbuild_")
 
+if(DEFINED APPLICATION_CONFIG_DIR AND NOT DEFINED CACHE{APPLICATION_CONFIG_DIR})
+  set(APPLICATION_CONFIG_DIR "${APPLICATION_CONFIG_DIR}" CACHE INTERNAL "Application config dir")
+elseif(DEFINED CACHE{APPLICATION_CONFIG_DIR} AND
+       NOT (APPLICATION_CONFIG_DIR STREQUAL "$CACHE{APPLICATION_CONFIG_DIR}"))
+  message(WARNING
+          "Sysbuild scoped APPLICATION_CONFIG_DIR and cached APPLICATION_CONFIG_DIR differs.\n"
+          "Setting value used internally by Sysbuild (sysbuild scoped):\n"
+	  " - ${APPLICATION_CONFIG_DIR}\n"
+	  "Setting value used by images (cached):\n"
+	  " - $CACHE{APPLICATION_CONFIG_DIR}\n"
+  )
+endif()
+
+# If there is a dedicated SB_APPLICATION_CONFIG_DIR, then create a local
+# scoped APPLICATION_CONFIG_DIR hiding any cache variant.
+# The cache setting is the setting passed to sysbuild image cache files
+if(DEFINED SB_APPLICATION_CONFIG_DIR)
+  set(APPLICATION_CONFIG_DIR ${SB_APPLICATION_CONFIG_DIR})
+elseif(NOT DEFINED APPLICATION_CONFIG_DIR)
+  get_filename_component(APP_DIR  ${APP_DIR} ABSOLUTE)
+  set(APPLICATION_CONFIG_DIR ${APP_DIR})
+endif()
+string(CONFIGURE ${APPLICATION_CONFIG_DIR} APPLICATION_CONFIG_DIR)
+
 if(DEFINED SB_CONF_FILE)
   # SB_CONF_FILE already set so nothing to do.
 elseif(DEFINED ENV{SB_CONF_FILE})
   set(SB_CONF_FILE $ENV{SB_CONF_FILE})
 else()
   # sysbuild.conf is an optional file, because sysbuild is an opt-in feature.
-  zephyr_file(CONF_FILES ${APP_DIR} KCONF SB_CONF_FILE NAMES "sysbuild.conf" SUFFIX ${FILE_SUFFIX})
+  zephyr_file(CONF_FILES ${APPLICATION_CONFIG_DIR} KCONF SB_CONF_FILE NAMES "sysbuild.conf" SUFFIX ${FILE_SUFFIX})
 endif()
 
 if(NOT DEFINED SB_EXTRA_CONF_FILE AND DEFINED SB_OVERLAY_CONFIG)

--- a/share/sysbuild/cmake/modules/sysbuild_kconfig.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_kconfig.cmake
@@ -56,7 +56,7 @@ endif()
 
 # Empty files to make kconfig.py happy.
 file(TOUCH ${CMAKE_CURRENT_BINARY_DIR}/empty.conf)
-set(APPLICATION_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+set(APPLICATION_SOURCE_DIR ${sysbuild_toplevel_SOURCE_DIR})
 set(AUTOCONF_H             ${CMAKE_CURRENT_BINARY_DIR}/autoconf.h)
 set(CONF_FILE              ${SB_CONF_FILE})
 set(EXTRA_CONF_FILE        "${SB_EXTRA_CONF_FILE}")

--- a/share/sysbuild/template/CMakeLists.txt
+++ b/share/sysbuild/template/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Generic sysbuild CMakeLists.txt file used as sysbuild entry point for multi-image builds.
+#
+# Applications which requires custom handling when built using sysbuild may copy this
+# file to the folder `<app-dir>/sysbuild` and use as a template and extend as needed.
+
+find_package(Sysbuild REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+project(sysbuild LANGUAGES)


### PR DESCRIPTION
This PR refactors sysbuild entry code by creating a CMake sysbuild
module for image processing and place sysbuild entry code in a
SysbuildLists.txt file.

The SysbuildLists.txt file will be use as template for applications
which doesn't provide their own entry file.

An application may place a SysbuildLists.txt file at its toplevel
folder. The SysbuildLists.txt file is similar in nature to the
CMakeLists.txt file for the application and allows application
developers to adjust how an application is built with sysbuild.

Also part of this PR is APPLICATION_CONFIG_DIR support in sysbuild.

---------

Additional background info

The name SysbuildLists.txt is proposed as it allows the file to be placed at the sample's top-level folder, next to the CMakeLists.txt.
Also the name reflects the intention of the file.
However, one implication is that the file is included using `include()` statement inside sysbuild, meaning the use of add_subdirectory() must include bin dir, like this:

https://github.com/zephyrproject-rtos/zephyr/blob/1f494ea61a401af32d42264e6b75e9eee1a29dc6/share/sysbuild/SysbuildLists.txt#L10-L12

An alternative to SysbuildLists.txt could be a subfolder, like `<sample>/sysbuild/CMakeLists.txt`, but that makes it less visible as well as less clear of the intention (being entry point for sysbuild).