### PR TITLE
gpio: gpio_mcux_igpio: switch to using DT_INST_IRQN_BY_IDX

### DIFF
--- a/drivers/gpio/gpio_mcux_igpio.c
+++ b/drivers/gpio/gpio_mcux_igpio.c
@@ -367,12 +367,12 @@ static const struct gpio_driver_api mcux_igpio_driver_api = {
 
 #define MCUX_IGPIO_IRQ_INIT(n, i)					\
 	do {								\
-		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(n, i, irq),		\
+		IRQ_CONNECT(DT_INST_IRQN_BY_IDX(n, i),			\
 			    DT_INST_IRQ_BY_IDX(n, i, priority),		\
 			    mcux_igpio_port_isr,			\
 			    DEVICE_DT_INST_GET(n), 0);			\
 									\
-		irq_enable(DT_INST_IRQ_BY_IDX(n, i, irq));		\
+		irq_enable(DT_INST_IRQN_BY_IDX(n, i));			\
 	} while (false)
 
 #define MCUX_IGPIO_INIT(n)						\


### PR DESCRIPTION
After #63289, multi-level interrupts are now encoded using macro magic. This means that using the generic DT_INST_IRQ_BY_IDX() to fetch the INTID is no longer an option as the queried INTID will be the one specified through the node's `interrupts` properties. To fix this, switch to using DT_INST_IRQN_BY_IDX() which will return the correctly encoded INTID.