### PR TITLE
dts: nordic: nrf54h20: Fix exmif node definition

### DIFF
--- a/dts/common/nordic/nrf54h20.dtsi
+++ b/dts/common/nordic/nrf54h20.dtsi
@@ -341,7 +341,7 @@
 			};
 
 			exmif: spi@95000 {
-				compatible = "nordic,nrf-exmif", "snps,designware-spi";
+				compatible = "nordic,nrf-exmif";
 				#address-cells = <1>;
 				#size-cells = <0>;
 				reg = <0x95000 0x500 0x95500 0xb00>;


### PR DESCRIPTION
Remove the "snps,designware-spi" compatible from the EXMIF node in nRF54H20i, as the spi_dw driver cannot be used for this peripheral without Nordic-specific modifications that are not present upstream. An attempt to do so (just setting CONFIG_SPI=y will cause that, as the driver initialization function will be executed then) results in a bus fault.

Fixes #72657.