### PR TITLE
drivers: display: elcdif: Modify interruption enablement

### DIFF
--- a/drivers/display/Kconfig.mcux_elcdif
+++ b/drivers/display/Kconfig.mcux_elcdif
@@ -53,6 +53,18 @@ config MCUX_ELCDIF_PXP
 	  display_write is called with a framebuffer equal in size to the
 	  display.
 
+config MCUX_ELCDIF_LP
+	bool "ELCDIF low power"
+	help
+	  This option, when enabled, will enable CUR_FRAME_DONE_IRQ at the display
+	  write function and disable it at the interruption handler for each new frame.
+	  Disabling the interrupt when no new frame needs to be sent gives the CPU the
+	  possibility to enter low-power mode, thus saving energy.
+	  This option, when disabled, CUR_FRAME_DONE_IRQ will be enabled only
+	  once at initialization. This option should be disabled when the application's
+	  frame rate is close to the display's refresh rate to avoid introducing
+	  additional latency caused by frequently enabling and disabling CUR_FRAME_DONE_IRQ.
+
 if MCUX_ELCDIF_PXP
 
 choice MCUX_ELCDIF_PXP_ROTATE_DIRECTION

--- a/drivers/display/display_mcux_elcdif.c
+++ b/drivers/display/display_mcux_elcdif.c
@@ -203,8 +203,10 @@ static int mcux_elcdif_write(const struct device *dev, const uint16_t x, const u
 	/* Update index of active framebuffer */
 	dev_data->next_idx = (dev_data->next_idx + 1) % CONFIG_MCUX_ELCDIF_FB_NUM;
 #endif
-	/* Enable frame buffer completion interrupt */
-	ELCDIF_EnableInterrupts(config->base, kELCDIF_CurFrameDoneInterruptEnable);
+
+	if (IS_ENABLED(CONFIG_MCUX_ELCDIF_LP)) {
+		ELCDIF_EnableInterrupts(config->base, kELCDIF_CurFrameDoneInterruptEnable);
+	}
 	/* Wait for frame send to complete */
 	k_sem_take(&dev_data->sem, K_FOREVER);
 	return ret;
@@ -297,10 +299,11 @@ static void mcux_elcdif_isr(const struct device *dev)
 	status = ELCDIF_GetInterruptStatus(config->base);
 	ELCDIF_ClearInterruptStatus(config->base, status);
 	if (config->base->CUR_BUF == ((uint32_t)dev_data->active_fb)) {
-		/* Disable frame completion interrupt, post to
-		 * sem to notify that frame send is complete.
-		 */
-		ELCDIF_DisableInterrupts(config->base, kELCDIF_CurFrameDoneInterruptEnable);
+		if (IS_ENABLED(CONFIG_MCUX_ELCDIF_LP)) {
+			/* Disable frame completion interrupt if Low power mode is activated*/
+			ELCDIF_DisableInterrupts(config->base, kELCDIF_CurFrameDoneInterruptEnable);
+		}
+		/* Post to sem to notify that frame display is complete.*/
 		k_sem_give(&dev_data->sem);
 	}
 }
@@ -338,6 +341,9 @@ static int mcux_elcdif_init(const struct device *dev)
 	dev_data->active_fb = dev_data->fb[0];
 
 	ELCDIF_RgbModeInit(config->base, &dev_data->rgb_mode);
+	if (!IS_ENABLED(CONFIG_MCUX_ELCDIF_LP)) {
+		ELCDIF_EnableInterrupts(config->base, kELCDIF_CurFrameDoneInterruptEnable);
+	}
 	ELCDIF_RgbModeStart(config->base);
 
 	return 0;


### PR DESCRIPTION
The elcdif interruption is enabled in the write function and disabled in the IRQ handler for each frame update. Frequently toggling the CurFrameDoneInterruptEnable can result in unnecessary delay.

Fix it by only enabling the interruption at the init function.