### PR TITLE
scripts: ci: test_plan: fix usage with files and tc roots treshold to parameters

### DIFF
--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -24,7 +24,7 @@ if "ZEPHYR_BASE" not in os.environ:
 # however, pylint complains that it doesn't recognized them when used (used-before-assignment).
 zephyr_base = Path(os.environ['ZEPHYR_BASE'])
 repository_path = zephyr_base
-repo_to_scan = zephyr_base
+repo_to_scan = Repo(zephyr_base)
 args = None
 
 
@@ -424,8 +424,8 @@ if __name__ == "__main__":
     errors = 0
     if args.repo_to_scan:
         repository_path = Path(args.repo_to_scan)
-    if args.commits:
         repo_to_scan = Repo(repository_path)
+    if args.commits:
         commit = repo_to_scan.git.diff("--name-only", args.commits)
         files = commit.split("\n")
     elif args.modified_files:

--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -95,7 +95,7 @@ class Tag:
 
 class Filters:
     def __init__(self, modified_files, ignore_path, alt_tags, testsuite_root,
-                 pull_request=False, platforms=[], detailed_test_id=True):
+                 pull_request=False, platforms=[], detailed_test_id=True, tc_roots_th=20):
         self.modified_files = modified_files
         self.testsuite_root = testsuite_root
         self.resolved_files = []
@@ -108,6 +108,7 @@ class Filters:
         self.detailed_test_id = detailed_test_id
         self.ignore_path = ignore_path
         self.tag_cfg_file = alt_tags
+        self.tc_roots_th = tc_roots_th
 
     def process(self):
         self.find_modules()
@@ -288,7 +289,7 @@ class Filters:
         for t in tests:
             _options.extend(["-T", t ])
 
-        if len(tests) > 20:
+        if len(tests) > self.tc_roots_th:
             logging.warning(f"{len(tests)} tests changed, this looks like a global change, skipping test handling, revert to default")
             self.full_twister = True
             return
@@ -392,6 +393,9 @@ def parse_args():
             help="Number of tests per builder")
     parser.add_argument('-n', '--default-matrix', default=10, type=int,
             help="Number of tests per builder")
+    parser.add_argument('--testcase-roots-threshold', default=20, type=int,
+            help="Threshold value for number of modified testcase roots, up to which an optimized scope is still applied."
+                 "When exceeded, full scope will be triggered")
     parser.add_argument('--detailed-test-id', action='store_true',
             help="Include paths to tests' locations in tests' names.")
     parser.add_argument("--no-detailed-test-id", dest='detailed_test_id', action="store_false",
@@ -438,7 +442,8 @@ if __name__ == "__main__":
         print("=========")
 
     f = Filters(files, args.ignore_path, args.alt_tags, args.testsuite_root,
-                args.pull_request, args.platform, args.detailed_test_id)
+                args.pull_request, args.platform, args.detailed_test_id,
+                args.testcase_roots_threshold)
     f.process()
 
     # remove dupes and filtered cases


### PR DESCRIPTION
When modified files list is used instead of commit range, repo object was incorrect.

Allow to provide from CLI, threshold value for number of test case roots
selected for execution base on changed files.
When such threshold will be exceeded, full scope will be executed.