### PR TITLE
include: arch: x86: added missing parenthesis

### DIFF
--- a/include/zephyr/arch/x86/arch.h
+++ b/include/zephyr/arch/x86/arch.h
@@ -219,7 +219,7 @@ static ALWAYS_INLINE int sys_test_and_clear_bit(mem_addr_t addr,
 extern unsigned char _irq_to_interrupt_vector[];
 
 #define Z_IRQ_TO_INTERRUPT_VECTOR(irq) \
-	((unsigned int) _irq_to_interrupt_vector[irq])
+	((unsigned int) _irq_to_interrupt_vector[(irq)])
 
 
 #endif /* _ASMLANGUAGE */


### PR DESCRIPTION
Added missing parentheses around macro argument expansion.

This corresponds to following coding guideline:

> Expressions resulting from the expansion of macro parameters shall be enclosed in parentheses

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/3c1d1a11e97c1306d85977140905b22ab7f8b31e