### PR TITLE
soc: intel: adsp: tgl: ace: Set correct virtual memory size

### DIFF
--- a/soc/intel/intel_adsp/ace/Kconfig.defconfig.series
+++ b/soc/intel/intel_adsp/ace/Kconfig.defconfig.series
@@ -74,6 +74,13 @@ config XTENSA_NUM_SPIN_RELAX_NOPS
 
 endif # XTENSA_MORE_SPIN_RELAX_NOPS
 
+if KERNEL_VM_SUPPORT
+
+config KERNEL_VM_SIZE
+	default 0xfe0000
+
+endif
+
 rsource "Kconfig.defconfig.ace*"
 
 endif # SOC_SERIES_INTEL_ADSP_ACE

--- a/soc/intel/intel_adsp/cavs/Kconfig.defconfig.cavs_v25
+++ b/soc/intel/intel_adsp/cavs/Kconfig.defconfig.cavs_v25
@@ -46,7 +46,7 @@ config CAVS_ISR_TBL_OFFSET
 if KERNEL_VM_SUPPORT
 
 config KERNEL_VM_SIZE
-	default 0x800000
+	default 0xfe0000
 
 endif
 


### PR DESCRIPTION
Corrected virtual memory size to match the range supported by the Translation Lookup Buffer. The TLB size is 16 MB, however the first 128 KB is dedicated to LPSRAM and bypasses the TLB. This was taken into account in KERNEL_VM_BASE, so KERNEL_VM_SIZE was reduced accordingly.