### PR TITLE
llext: xtensa: add support for the xt-clang toolchain

### DIFF
--- a/cmake/compiler/xt-clang/target.cmake
+++ b/cmake/compiler/xt-clang/target.cmake
@@ -1,3 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
 
 include(${ZEPHYR_BASE}/cmake/compiler/xcc/target.cmake)
+
+# Flags not supported by llext linker
+# (regexps are supported and match whole word)
+set(LLEXT_REMOVE_FLAGS
+  -fno-pic
+  -fno-pie
+  -ffunction-sections
+  -fdata-sections
+  -g.*
+  -Os
+  -mcpu=.*
+)
+
+# Flags to be added to llext code compilation
+set(LLEXT_APPEND_FLAGS
+  -fPIC
+  -nostdlib
+  -nodefaultlibs
+)

--- a/cmake/linker/xt-ld/linker_flags.cmake
+++ b/cmake/linker/xt-ld/linker_flags.cmake
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+set_property(TARGET linker PROPERTY partial_linking "-r")

--- a/scripts/tests/twister/test_testplan.py
+++ b/scripts/tests/twister/test_testplan.py
@@ -110,7 +110,7 @@ TESTDATA_PART1 = [
     ("None", "None", "env", ['BSIM_OUT_PATH', 'demo_env'], "Environment (BSIM_OUT_PATH, demo_env) not satisfied"),
     ("build_on_all", True, None, None, "Platform is excluded on command line."),
     ("build_on_all", True, "level", "foobar", "Unknown test level 'foobar'"),
-    (None, None, "supported_toolchains", ['gcc'], "Not supported by the toolchain"),
+    (None, None, "supported_toolchains", ['gcc', 'xcc', 'xt-clang'], "Not supported by the toolchain"),
 ]
 
 


### PR DESCRIPTION
To build LLEXT images using the xt-clang toolchain from Cadence linker flags have to be set similar to other toolchains. Add the missing cmake files.