### PR TITLE
scripts: twister: add option to force using sysbuild for every testsuite

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -713,6 +713,11 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
     )
 
     parser.add_argument(
+        "--force-sysbuild", action="store_true",
+        help="""Use to enforce usage of sysbuild for every test suite"""
+    )
+
+    parser.add_argument(
         "-X", "--fixture", action="append", default=[],
         help="Specify a fixture that a board might support.")
 

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -547,6 +547,8 @@ class TestPlan:
                     for name in parsed_data.scenarios.keys():
                         suite_dict = parsed_data.get_scenario(name)
                         suite = TestSuite(root, suite_path, name, data=suite_dict, detailed_test_id=self.options.detailed_test_id)
+                        if self.options.force_sysbuild:
+                            suite.sysbuild = True
                         suite.add_subcases(suite_dict, subcases, ztest_suite_names)
                         if testsuite_filter:
                             scenario = os.path.basename(suite.name)


### PR DESCRIPTION
CLI option which force to use sysbuild.

The usecase:
Enable testing with twister for 'companion' cores, which needs luncher to start.
E.g. Luncher is executed at Application core and FLPR core executes test/sample.
Usage with west:
`west build -b nrf54l15pdk/nrf54l15/cpuflpr . --sysbuild -- -DSB_CONFIG_VPR_LAUNCHER=y`

Usage with twister:
`python ./zephyr/scripts/twister --ninja  --jobs 1 -T zephyr/samples/basic --platform nrf54l15pdk/nrf54l15/cpuflpr --device-testing --device-serial /dev/ttyACM0 --extra-args SB_CONFIG_VPR_LAUNCHER=y --west-flash --force-sysbuild`