### PR TITLE
samples: net: http_server: add link to HTTP Server doc page

### DIFF
--- a/samples/net/sockets/http_server/README.rst
+++ b/samples/net/sockets/http_server/README.rst
@@ -7,7 +7,7 @@
 Overview
 --------
 
-This sample application demonstrates the use of the ``http_server`` library.
+This sample application demonstrates the use of the :ref:`http_server_interface` library.
 This library provides high-level functions to simplify and abstract server implementation.
 The server supports the HTTP/1.1 protocol which can also be upgraded to HTTP/2,
 it also support native HTTP/2 protocol without upgrading.


### PR DESCRIPTION
Improve navigability in the documentation by adding a link to the main HTTP Server documentation page to the HTTP Server sample.