### PR TITLE
include: drivers: gpio: fix gpio_dt_flags_t overflow

### DIFF
--- a/include/zephyr/dt-bindings/gpio/gpio.h
+++ b/include/zephyr/dt-bindings/gpio/gpio.h
@@ -79,12 +79,12 @@
 
 /** @} */
 
-/* Note: Bits 15 downto 8 are reserved for SoC specific flags. */
-
 /**
  * Configures GPIO interrupt to wakeup the system from low power mode.
  */
-#define GPIO_INT_WAKEUP         (1 << 28)
+#define GPIO_INT_WAKEUP         (1 << 6)
+
+/* Note: Bits 15 downto 8 are reserved for SoC specific flags. */
 
 /**
  * @}


### PR DESCRIPTION
when `GPIO_INT_WAKEUP` flag is used in a DT `gpios` property, the `gpio_dt_flags_t` var that holds the flags overflows.