### PR TITLE
Drivers: Serial: Refactored [tx/rx]-invert as generic uart properties

### DIFF
--- a/dts/bindings/serial/espressif,esp32-uart.yaml
+++ b/dts/bindings/serial/espressif,esp32-uart.yaml
@@ -2,7 +2,7 @@ description: ESP32 UART
 
 compatible: "espressif,esp32-uart"
 
-include: [uart-controller.yaml, pinctrl-device.yaml]
+include: [uart-controller.yaml, uart-controller-pin-inversion.yaml, pinctrl-device.yaml]
 
 properties:
   reg:
@@ -21,15 +21,3 @@ properties:
       Overrides hw-flow-control if both are set.
       Using this mode, the pin assigned to DTR
       is asserted during transmission.
-
-  tx-invert:
-    type: boolean
-    description: |
-      Invert the binary logic of tx pin. When enabled, physical logic levels are inverted and
-      we use 1=Low, 0=High instead of 1=High, 0=Low.
-
-  rx-invert:
-    type: boolean
-    description: |
-      Invert the binary logic of rx pin. When enabled, physical logic levels are inverted and
-      we use 1=Low, 0=High instead of 1=High, 0=Low.

--- a/dts/bindings/serial/nxp,kinetis-lpuart.yaml
+++ b/dts/bindings/serial/nxp,kinetis-lpuart.yaml
@@ -2,7 +2,7 @@ description: Kinetis LPUART
 
 compatible: "nxp,kinetis-lpuart"
 
-include: [uart-controller.yaml, pinctrl-device.yaml]
+include: [uart-controller.yaml, uart-controller-pin-inversion.yaml, pinctrl-device.yaml]
 
 properties:
   reg:
@@ -22,18 +22,6 @@ properties:
       Using this mode, TX and RX lines are internally connected and
       only TX pin is used afterwards and should be configured.
       RX/TX conflicts must be handled on user side.
-
-  tx-invert:
-    type: boolean
-    description: |
-      Invert the binary logic of tx pin. When enabled, physical logic levels are inverted and
-      we use 1=Low, 0=High instead of 1=High, 0=Low.
-
-  rx-invert:
-    type: boolean
-    description: |
-      Invert the binary logic of rx pin. When enabled, physical logic levels are inverted and
-      we use 1=Low, 0=High instead of 1=High, 0=Low.
 
   nxp,rs485-mode:
     type: boolean

--- a/dts/bindings/serial/st,stm32-uart-base.yaml
+++ b/dts/bindings/serial/st,stm32-uart-base.yaml
@@ -10,6 +10,7 @@ include:
       - clock-frequency
   - name: pinctrl-device.yaml
   - name: reset-device.yaml
+  - name: uart-controller-pin-inversion.yaml
 
 properties:
   reg:
@@ -36,18 +37,6 @@ properties:
     type: boolean
     description:
       Swap the TX and RX pins. Used in case of a cross wired connection.
-
-  tx-invert:
-    type: boolean
-    description: |
-      Invert the binary logic of tx pin. When enabled, physical logic levels are inverted and
-      we use 1=Low, 0=High instead of 1=High, 0=Low.
-
-  rx-invert:
-    type: boolean
-    description: |
-      Invert the binary logic of rx pin. When enabled, physical logic levels are inverted and
-      we use 1=Low, 0=High instead of 1=High, 0=Low.
 
   pinctrl-0:
     required: true

--- a/dts/bindings/serial/uart-controller-pin-inversion.yaml
+++ b/dts/bindings/serial/uart-controller-pin-inversion.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2024 Croxel, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Pin Inversion fields for UART controllers
+
+properties:
+  tx-invert:
+    type: boolean
+    description: |
+      Invert the binary logic of tx pin. When enabled, physical logic levels are inverted and
+      we use 1=Low, 0=High instead of 1=High, 0=Low.
+  rx-invert:
+    type: boolean
+    description: |
+      Invert the binary logic of rx pin. When enabled, physical logic levels are inverted and
+      we use 1=Low, 0=High instead of 1=High, 0=Low.


### PR DESCRIPTION
Initially TX/RX-inverted capability is only supported in STM32 driver, But recently NXP and ESP driver support is also added. With these changes adding support in additional vendors will be easy