### PR TITLE
net: lib: coap_client: observe-related fixes

### DIFF
--- a/include/zephyr/net/coap_client.h
+++ b/include/zephyr/net/coap_client.h
@@ -91,6 +91,10 @@ struct coap_client_internal_request {
 	struct coap_client_request coap_request;
 	struct coap_packet request;
 	uint8_t request_tag[COAP_TOKEN_MAX_LEN];
+
+	/* For GETs with observe option set */
+	bool is_observe;
+	int last_response_id;
 };
 
 struct coap_client {
@@ -141,9 +145,8 @@ int coap_client_req(struct coap_client *client, int sock, const struct sockaddr 
 /**
  * @brief Cancel all current requests.
  *
- * This is intended for canceling long-running requests (e.g. GETs with the OBSERVE option set,
- * or a block transfer) which have gone stale for some reason. It is also intended for responding
- * to network connectivity issues.
+ * This is intended for canceling long-running requests (e.g. GETs with the OBSERVE option set)
+ * which has gone stale for some reason.
  *
  * @param client Client instance.
  */


### PR DESCRIPTION
An earlier pull request implementing observe support was merged too hastily. It had a few issues:

1. The predicate for whether a request should be marked not ongoing was wrong (it checked ret != 0 instead of ret < 0)
2. Without observes in mind, MID-based deduplication is not a required feature. Deduplication was handled implicitly - the exchange would get dropped after the first response anyway, so duplicate responses would not get matched to anything. But with observes, there are several responses in an exchange. This commit adds this.
3. Using coap_request_is_observe(&internal_req->request) in the response handler requires the whole request to stay in scope for the lifetime of the observation, which I observed was not always the case. Adding an is_observe bool to the internal struct improved stability significantly.

With these fixes, GETs with observe option works very well.