### PR TITLE
dts: flatten video's device tree endpoints definition

### DIFF
--- a/boards/madmachine/mm_swiftio/mm_swiftio.dts
+++ b/boards/madmachine/mm_swiftio/mm_swiftio.dts
@@ -113,7 +113,7 @@
 
 		reset-gpios = <&gpio2 20 GPIO_ACTIVE_HIGH>;
 
-		port {
+		ports {
 			ov7725_ep_out: endpoint {
 				remote-endpoint = <&csi_ep_in>;
 			};
@@ -196,7 +196,7 @@
 	pinctrl-0 = <&pinmux_csi>;
 	pinctrl-names = "default";
 
-	port {
+	ports {
 		csi_ep_in: endpoint {
 			remote-endpoint = <&ov7725_ep_out>;
 		};

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -92,7 +92,7 @@
 
 	panel {
 		compatible = "rocktech,rk043fn02h-ct";
-		port {
+		ports {
 			lcd_panel_in: endpoint {
 				remote-endpoint = <&lcd_panel_out>;
 			};
@@ -135,7 +135,7 @@ arduino_serial: &lpuart3 {
 	pinctrl-0 = <&pinmux_lcdif>;
 	pinctrl-names = "default";
 	backlight-gpios = <&gpio2 31 GPIO_ACTIVE_HIGH>;
-	port {
+	ports {
 		lcd_panel_out: endpoint {
 			remote-endpoint = <&lcd_panel_in>;
 		};

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -99,7 +99,7 @@
 
 	panel {
 		compatible = "rocktech,rk043fn02h-ct";
-		port {
+		ports {
 			lcd_panel_in: endpoint {
 				remote-endpoint = <&lcd_panel_out>;
 			};
@@ -137,7 +137,7 @@ arduino_serial: &lpuart3 {
 	pinctrl-0 = <&pinmux_lcdif>;
 	pinctrl-names = "default";
 	backlight-gpios = <&gpio2 31 GPIO_ACTIVE_HIGH>;
-	port {
+	ports {
 		lcd_panel_out: endpoint {
 			remote-endpoint = <&lcd_panel_in>;
 		};

--- a/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -103,7 +103,7 @@
 
 	panel {
 		compatible = "rocktech,rk043fn02h-ct";
-		port {
+		ports {
 			lcd_panel_in: endpoint {
 				remote-endpoint = <&lcd_panel_out>;
 			};
@@ -136,7 +136,7 @@ arduino_i2c: &lpi2c1 {};
 	pinctrl-0 = <&pinmux_lcdif>;
 	pinctrl-names = "default";
 	backlight-gpios = <&gpio2 31 GPIO_ACTIVE_HIGH>;
-	port {
+	ports {
 		lcd_panel_out: endpoint {
 			remote-endpoint = <&lcd_panel_in>;
 		};
@@ -154,7 +154,7 @@ arduino_i2c: &lpi2c1 {};
 		reg = <0x48>;
 		status = "okay";
 
-		port {
+		ports {
 			mt9m114_ep_out: endpoint {
 				remote-endpoint = <&csi_ep_in>;
 			};
@@ -276,7 +276,7 @@ zephyr_udc0: &usb1 {
 	pinctrl-0 = <&pinmux_csi>;
 	pinctrl-names = "default";
 
-	port {
+	ports {
 		csi_ep_in: endpoint {
 			remote-endpoint = <&mt9m114_ep_out>;
 		};

--- a/dts/bindings/video/st,stm32-dcmi.yaml
+++ b/dts/bindings/video/st,stm32-dcmi.yaml
@@ -24,7 +24,7 @@ description: |
               STM32_DMA_MEM_INC | STM32_DMA_PERIPH_8BITS | STM32_DMA_MEM_32BITS |
               STM32_DMA_PRIORITY_HIGH) STM32_DMA_FIFO_1_4>;
 
-      port {
+      ports {
         dcmi_ep_in: endpoint {
           remote-endpoint = <&ov2640_ep_out>;
         };


### PR DESCRIPTION
This is part of a series of proposals for incremental changes for the Video API:
- https://github.com/zephyrproject-rtos/zephyr/issues/72959

## Summary:

Remove `port@0` from video devicetree and only keep `endpoint@0`

Before:
- `videodev { ports { port@0 { endpoint@0 { remote-endpoint; }; }; }; };`
- `videodev { port { endpoint { remote-endpoint; }; }; };`

After:
- `videodev { ports { endpoint@0 { remote-endpoint; }; }; };`

## Details:

Currently, remote-endpoint is not used (#72311). This allows us to move definitions without breaking anything.

In Linux, the [`ports{};` block](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/boot/dts/freescale/imx8mp-tqma8mpql-mba8mpxl-lvds-g133han01.dtso#n25) allows to have `#address-cells` in `ports{}` applied to `port@0{}; port@1{}; ...` only, and not i.e. [`display-timings`](https://github.com/zephyrproject-rtos/zephyr/blob/main/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts#L120-L143).

Complex configurations are still possible with this scheme:

	videodev@10380000 {
		ports {
			#address-cells = <1>;
			#size-cells = <0>;

			port@0 {
				reg = <0>;
				#address-cells = <1>;
				#size-cells = <0>;

				endpoint@0 {
					reg = <0>;
					remote-endpoint = <&other>;
				};

				endpoint@1 {
					reg = <1>;
					remote-endpoint = <&other>;
				};
			};

			port@1 {
				reg = <1>;
				#address-cells = <1>;
				#size-cells = <0>;

				endpoint@0 {
					reg = <0>;
					remote-endpoint = <&other>;
				};
			};
		};
	};

Is turned into something like this:

	videodev@10380000 {
		ports {
			#address-cells = <2>;
			#size-cells = <0>;

			endpoint@00 {
				reg = <0 0>;
				data-lanes = <0 1 2 3>;
				remote-endpoint = <&other>;
			};

			endpoint@01 {
				reg = <0 1>;
				data-lanes = <4 5 6 7>;
				remote-endpoint = <&other>;
			};

			endpoint@10 {
				reg = <1 0>;
				data-lanes = <0 1 2 3>;
				remote-endpoint = <&other>;
			};
		};
	};

This prevents to apply devicetree properties to an entire port, affecting each of its endpoint, but in the Linux source, this was only used once, in imx8mp-tqma8mpql-mba8mpxl-lvds-g133han01.dtso:

## References

Reviewing a few contexts where remote-endpoint are invoked in Linux (audio, mipi, hdmi, usb) and have extra properties (outside `reg`, `#address-cells =`, `#size-cells` and nested blocks):

```
cd Linux
find . -name '*.dts*' -exec grep -C10 'remote-endpoint' {} +
```

several in endpoint:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/boot/dts/allwinner/sun50i-a64-amarula-relic.dts

several in endpoint:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/boot/dts/allwinner/sun50i-a64-pinetab.dts

`link-frequencies` in endpoint:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/boot/dts/mediatek/mt8186-corsola.dtsi

`data-lanes` in endpoint:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/boot/dts/mediatek/mt8186-corsola-steelix.dtsi

`data-lanes` in endoint:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/boot/dts/mediatek/mt8195-cherry.dtsi

`dai-format` in endpoint:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/boot/dts/nvidia/tegra234-p3737-0000.dtsi

`convert-rate` in endoint:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/boot/dts/nvidia/tegra194-p3509-0000.dtsi

`data-lanes` in endpoint:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/boot/dts/rockchip/px30-evb.dts

several in endpoint:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/boot/dts/renesas/hihope-rzg2-ex-aistarvision-mipi-adapter-2.1.dtsi

several in endpoint:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/boot/dts/renesas/r8a774c0-ek874-mipi-2.1.dts

several in endpoint:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/boot/dts/renesas/rz-smarc-cru-csi-ov5645.dtsi

sevral in endpoint:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/boot/dts/renesas/draak.dtsi

several in endpoint:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/boot/dts/qcom/qrb5165-rb5-vision-mezzanine.dts

several in endpoint:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/boot/dts/qcom/sdm850-lenovo-yoga-c630.dts

`data-lanes` in endpoint:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/boot/dts/qcom/sdm845-cheza.dtsi

`data-lanes` in endpoint:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/boot/dts/qcom/sc7180-trogdor-wormdingler.dtsi

`data-lanes` in endpoint:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/boot/dts/qcom/sm8350-hdk.dts

`data-lanes` in endpoint:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/boot/dts/freescale/imx8mm-evk.dtsi

several in endpoints:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/boot/dts/freescale/imx8mm-venice-gw72xx-0x-imx219.dtso

**`dual-lvds-odd-pixels` in port:**
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/boot/dts/freescale/imx8mp-tqma8mpql-mba8mpxl-lvds-g133han01.dtso

**`dual-lvds-even-pixels` in port:**
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/boot/dts/freescale/imx8mp-tqma8mpql-mba8mpxl-lvds-g133han01.dtso

several in endpoint:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/boot/dts/freescale/imx8mm-beacon-baseboard.dtsi

`data-lanes` in endpoint:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/boot/dts/freescale/imx8mp-evk.dts

`bus-width` in endpoint:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm/boot/dts/renesas/r8a7791-koelsch.dts

`arm,pl11x,tft-r0g0b0-pads` in endpoint:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm/boot/dts/arm/arm-realview-eb.dtsi

several in endpoint:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm/boot/dts/st/stm32mp157c-ev1.dts

several in endpoint:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm/boot/dts/st/stm32429i-eval.dts

several in endpoint:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm/boot/dts/ti/omap/omap3-n900.dts
