### PR TITLE
net: if: Fix potential unaligned word access

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -3549,7 +3549,7 @@ static bool ipv4_is_broadcast_address(struct net_if *iface,
 		bcast.s_addr = ipv4->unicast[i].ipv4.address.in_addr.s_addr |
 			       ~ipv4->unicast[i].netmask.s_addr;
 
-		if (bcast.s_addr == addr->s_addr) {
+		if (bcast.s_addr == UNALIGNED_GET(&addr->s_addr)) {
 			ret = true;
 			goto out;
 		}


### PR DESCRIPTION
Hi All,

This MR fixes unaligned access exception that happens due to an unaligned address read from RX net_buf.

Let me know if you have any suggestions on this MR.

Best,
Taras