### PR TITLE
drivers: lpuart: Fix async configure

### DIFF
--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -714,10 +714,9 @@ static int mcux_lpuart_callback_set(const struct device *dev, uart_callback_t ca
 	data->callback = NULL;
 	data->cb_data = NULL;
 	data->api_type = LPUART_ASYNC;
-	return mcux_lpuart_configure_async(dev);
-#else
-	return 0;
 #endif
+
+	return mcux_lpuart_configure_async(dev);
 }
 
 static int mcux_lpuart_tx(const struct device *dev, const uint8_t *buf, size_t len,


### PR DESCRIPTION
Fix async configure function not being called
when the irq driven api is not used, which
both causes a build warning and would not
work at runtime.

Fixes #72308 