### PR TITLE
doc: dts: Add missing ABNF macros for child num

### DIFF
--- a/doc/build/dts/macros.bnf
+++ b/doc/build/dts/macros.bnf
@@ -73,6 +73,9 @@ node-macro =/ %s"DT_N" path-id %s"_P_" prop-id %s"_FOREACH_PROP_ELEM"
 node-macro =/ %s"DT_N" path-id %s"_P_" prop-id %s"_FOREACH_PROP_ELEM_SEP"
 node-macro =/ %s"DT_N" path-id %s"_P_" prop-id %s"_FOREACH_PROP_ELEM_VARGS"
 node-macro =/ %s"DT_N" path-id %s"_P_" prop-id %s"_FOREACH_PROP_ELEM_SEP_VARGS"
+; These are used by DT_CHILD_NUM and DT_CHILD_NUM_STATUS_OKAY macros
+node-macro =/ %s"DT_N" path-id %s"_CHILD_NUM"
+node-macro =/ %s"DT_N" path-id %s"_CHILD_NUM_STATUS_OKAY"
 ; These are used internally by DT_FOREACH_CHILD, which iterates over
 ; each child node.
 node-macro =/ %s"DT_N" path-id %s"_FOREACH_CHILD"


### PR DESCRIPTION
Commit 5871ff010b4d2b27e4a27d7580a2b912f1044cb8
added support for generated DT macros to get the number of child nodes of a node, but we forgot to update
the documentation of the augmented Backus–Naur form of the DT macros to reflect this addition.