### PR TITLE
codeowners: add sensor veaa-x-3

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -333,6 +333,7 @@
 /drivers/sensor/qdec_stm32/               @valeriosetti
 /drivers/sensor/rpi_pico_temp/            @soburi
 /drivers/sensor/st*/                      @avisconti
+/drivers/sensor/veaa_x_3/                 @jeppenodgaard @MaureenHelm
 /drivers/sensor/ene_tack_kb1200/          @ene-steven
 /drivers/serial/*b91*                     @andy-liu-telink
 /drivers/serial/uart_altera_jtag.c        @nashif @gohshunjing


### PR DESCRIPTION
Add @jeppenodgaard and @MaureenHelm as veaa-x-3 codeowners.