### PR TITLE
manifest: Update NXP HAL mcux to SDK 2.15.100 RT1180 support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -193,7 +193,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: abc66979c77421fb3a140ce2e4e6ea7165cdbe8f
+      revision: pull/391/head
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Adding RT1180 support and assorted updates