### PR TITLE
sensor: battery voltage -> SoC conversions

### DIFF
--- a/boards/nordic/thingy53/thingy53_nrf5340_common.dtsi
+++ b/boards/nordic/thingy53/thingy53_nrf5340_common.dtsi
@@ -5,6 +5,7 @@
  */
 #include "thingy53_nrf5340_common-pinctrl.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/battery/battery.h>
 
 / {
 	chosen {
@@ -90,6 +91,8 @@
 
 	vbatt {
 		compatible = "voltage-divider";
+		device-chemistry = "lithium-ion-polymer";
+		ocv-capacity-table-0 = <BATTERY_OCV_CURVE_LITHIUM_ION_POLYMER_DEFAULT>;
 		io-channels = <&adc 2>;
 		output-ohms = <180000>;
 		full-ohms = <(1500000 + 180000)>;

--- a/drivers/sensor/voltage_divider/voltage.c
+++ b/drivers/sensor/voltage_divider/voltage.c
@@ -22,67 +22,73 @@ struct voltage_config {
 
 struct voltage_data {
 	struct adc_sequence sequence;
-	uint16_t raw;
+	int32_t voltage_mv;
 };
 
 static int fetch(const struct device *dev, enum sensor_channel chan)
 {
 	const struct voltage_config *config = dev->config;
 	struct voltage_data *data = dev->data;
+	uint16_t adc_raw;
 	int ret;
 
-	if ((chan != SENSOR_CHAN_VOLTAGE) && (chan != SENSOR_CHAN_ALL)) {
+	switch (chan) {
+	case SENSOR_CHAN_VOLTAGE:
+	case SENSOR_CHAN_ALL:
+		break;
+	default:
 		return -ENOTSUP;
 	}
 
+	data->sequence.buffer = &adc_raw;
+	data->sequence.buffer_size = sizeof(adc_raw);
+
+	/* Read the ADC */
 	ret = adc_read(config->voltage.port.dev, &data->sequence);
 	if (ret != 0) {
 		LOG_ERR("adc_read: %d", ret);
 	}
 
-	return ret;
+	if (config->voltage.port.channel_cfg.differential) {
+		data->voltage_mv = (int16_t)adc_raw;
+	} else if (config->voltage.port.resolution < 16) {
+		/* Can be removed when issue #71119 is resolved */
+		data->voltage_mv = (int16_t)adc_raw;
+	} else {
+		data->voltage_mv = adc_raw;
+	}
+
+	/* Convert to a real voltage */
+	ret = adc_raw_to_millivolts_dt(&config->voltage.port, &data->voltage_mv);
+	if (ret != 0) {
+		LOG_ERR("raw_to_mv: %d", ret);
+		return ret;
+	}
+
+	/* Scale according to the voltage divider */
+	(void)voltage_divider_scale_dt(&config->voltage, &data->voltage_mv);
+
+	/* Print the reading and conversion */
+	LOG_DBG("ADC: %d, Voltage: %dmV", adc_raw, data->voltage_mv);
+	return 0;
 }
 
 static int get(const struct device *dev, enum sensor_channel chan, struct sensor_value *val)
 {
 	const struct voltage_config *config = dev->config;
 	struct voltage_data *data = dev->data;
-	int32_t raw_val;
-	int32_t v_mv;
-	int ret;
 
 	__ASSERT_NO_MSG(val != NULL);
 
-	if (chan != SENSOR_CHAN_VOLTAGE) {
+	switch (chan) {
+	case SENSOR_CHAN_VOLTAGE:
+		val->val1 = data->voltage_mv / 1000;
+		val->val2 = (data->voltage_mv * 1000) % 1000000;
+		break;
+	default:
 		return -ENOTSUP;
 	}
-
-	if (config->voltage.port.channel_cfg.differential) {
-		raw_val = (int16_t)data->raw;
-	} else if (config->voltage.port.resolution < 16) {
-		/* Can be removed when issue #71119 is resolved */
-		raw_val = (int16_t)data->raw;
-	} else {
-		raw_val = data->raw;
-	}
-
-	ret = adc_raw_to_millivolts_dt(&config->voltage.port, &raw_val);
-	if (ret != 0) {
-		LOG_ERR("raw_to_mv: %d", ret);
-		return ret;
-	}
-
-	v_mv = raw_val;
-
-	/* Note if full_ohms is not specified then unscaled voltage is returned */
-	(void)voltage_divider_scale_dt(&config->voltage, &v_mv);
-
-	LOG_DBG("%d of %d, %dmV, voltage:%dmV", data->raw,
-		(1 << data->sequence.resolution) - 1, raw_val, v_mv);
-	val->val1 = v_mv / 1000;
-	val->val2 = (v_mv * 1000) % 1000000;
-
-	return ret;
+	return 0;
 }
 
 static const struct sensor_driver_api voltage_api = {
@@ -156,9 +162,6 @@ static int voltage_init(const struct device *dev)
 		LOG_ERR("sequence init: %d", ret);
 		return ret;
 	}
-
-	data->sequence.buffer = &data->raw;
-	data->sequence.buffer_size = sizeof(data->raw);
 
 	return 0;
 }

--- a/dts/bindings/battery/battery.yaml
+++ b/dts/bindings/battery/battery.yaml
@@ -8,6 +8,30 @@ description: |
   linux/Documentation/devicetree/bindings/power/supply/battery.yaml
 
 properties:
+  device-chemistry:
+    type: string
+    description: This describes the chemical technology of the battery.
+      The "lithium-ion" value is a blanket type for all lithium-ion batteries.
+      If the specific chemistry is unknown, this value can be used instead of
+      the precise "lithium-ion-X" options.
+    enum:
+      - "nickel-cadmium"
+      - "nickel-metal-hydride"
+      - "lithium-ion"
+      - "lithium-ion-polymer"
+      - "lithium-ion-iron-phosphate"
+      - "lithium-ion-manganese-oxide"
+
+  ocv-capacity-table-0:
+    type: array
+    description: |
+      An array providing the open circuit voltage (OCV) , which is used to look
+      up battery capacity according to current OCV value. The OCV unit is
+      microvolts.
+
+      Unlike the linux equivalent this array is required to be 11 elements
+      long, representing the voltages for 0-100% charge in 10% steps.
+
   re-charge-voltage-microvolt:
     type: int
     description: limit to automatically start charging again

--- a/dts/bindings/iio/afe/voltage-divider.yaml
+++ b/dts/bindings/iio/afe/voltage-divider.yaml
@@ -7,7 +7,7 @@ description: |
 
 compatible: "voltage-divider"
 
-include: base.yaml
+include: [base.yaml, battery.yaml]
 
 properties:
   io-channels:

--- a/include/zephyr/drivers/sensor/battery.h
+++ b/include/zephyr/drivers/sensor/battery.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2024 Embeint Inc
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_BATTERY_H_
+#define ZEPHYR_INCLUDE_DRIVERS_SENSOR_BATTERY_H_
+
+#include <stdint.h>
+#include <errno.h>
+
+#include <zephyr/devicetree.h>
+#include <zephyr/math/interpolation.h>
+#include <zephyr/sys/util_macro.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief battery API
+ * @defgroup battery_apis battery APIs
+ * @{
+ */
+
+/* Battery chemistry enumeration.
+ * Value names must match those from dts/bindings/battery.yaml
+ */
+enum battery_chemistry {
+	BATTERY_CHEMISTRY_UNKNOWN = 0,
+	BATTERY_CHEMISTRY_NICKEL_CADMIUM,
+	BATTERY_CHEMISTRY_NICKEL_METAL_HYDRIDE,
+	BATTERY_CHEMISTRY_LITHIUM_ION,
+	BATTERY_CHEMISTRY_LITHIUM_ION_POLYMER,
+	BATTERY_CHEMISTRY_LITHIUM_ION_IRON_PHOSPHATE,
+	BATTERY_CHEMISTRY_LITHIUM_ION_MANGANESE_OXIDE,
+};
+
+/* Length of open circuit voltage table */
+#define BATTERY_OCV_TABLE_LEN 11
+
+/**
+ * @brief Get the battery chemistry enum value
+ *
+ * @param node_id node identifier
+ */
+#define BATTERY_CHEMISTRY_DT_GET(node_id)                                                          \
+	UTIL_CAT(BATTERY_CHEMISTRY_, DT_STRING_UPPER_TOKEN_OR(node_id, device_chemistry, UNKNOWN))
+
+/**
+ * @brief Get the OCV curve for a given table
+ *
+ * @param node_id node identifier
+ * @param table table to retrieve
+ */
+#define BATTERY_OCV_TABLE_DT_GET(node_id, table)                                                   \
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, table),                                              \
+		    ({DT_FOREACH_PROP_ELEM_SEP(node_id, table, DT_PROP_BY_IDX, (,))}), ({-1}))
+
+/**
+ * @brief Convert an OCV table and battery voltage to a charge percentage
+ *
+ * @param ocv_table Open circuit voltage curve
+ * @param voltage_uv Battery voltage in microVolts
+ *
+ * @returns Battery state of charge in milliPercent
+ */
+static inline int32_t battery_soc_lookup(const int32_t ocv_table[BATTERY_OCV_TABLE_LEN],
+					 uint32_t voltage_uv)
+{
+	static const int32_t soc_axis[BATTERY_OCV_TABLE_LEN] = {
+		0, 10000, 20000, 30000, 40000, 50000, 60000, 70000, 80000, 90000, 100000};
+
+	/* Convert voltage to SoC */
+	return linear_interpolate(ocv_table, soc_axis, BATTERY_OCV_TABLE_LEN, voltage_uv);
+}
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_BATTERY_H_ */

--- a/include/zephyr/dt-bindings/battery/battery.h
+++ b/include/zephyr/dt-bindings/battery/battery.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 Embeint Inc
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The following open-circuit voltage curves have been extracted from the datasheets of the
+ * listed battery parts. They will not be 100% correct for all batteries of the chemistry,
+ * but should provide a good baseline. These curves will also be affected by ambient temperature
+ * and discharge current.
+ *
+ * Each curve is 11 elements representing the OCV voltage in microvolts for each charge percentage
+ * from 0% to 100% inclusive in 10% increments.
+ */
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_BATTERY_BATTERY_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_BATTERY_BATTERY_H_
+
+/* Panasonic KR-1800SCE */
+#define BATTERY_OCV_CURVE_NICKEL_CADMIUM_DEFAULT                                                   \
+	800000 1175000 1207000 1217000 1221000 1226000 1233000 1245000 1266000 1299000 1366000
+
+/* Panasonic BK-1100FHU */
+#define BATTERY_OCV_CURVE_NICKEL_METAL_HYDRIDE_DEFAULT                                             \
+	1004000 1194000 1231000 1244000 1254000 1257000 1263000 1266000 1274000 1315000 1420000
+
+/* Panasonic NCR18650BF */
+#define BATTERY_OCV_CURVE_LITHIUM_ION_POLYMER_DEFAULT                                              \
+	2502000 3146000 3372000 3449000 3532000 3602000 3680000 3764000 3842000 3936000 4032000
+
+/* Drypower IFR18650 E1600 */
+#define BATTERY_OCV_CURVE_LITHIUM_IRON_PHOSPHATE_DEFAULT                                           \
+	2013000 3068000 3159000 3194000 3210000 3221000 3229000 3246000 3256000 3262000 3348000
+
+/* FDK CR14250SE */
+#define BATTERY_OCV_CURVE_LITHIUM_MANGANESE_DEFAULT                                                \
+	1906000 2444000 2689000 2812000 2882000 2927000 2949000 2955000 2962000 2960000 2985000
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_BATTERY_BATTERY_H_ */

--- a/include/zephyr/math/interpolation.h
+++ b/include/zephyr/math/interpolation.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2024 Embeint Inc
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_ZEPHYR_MATH_INTERPOLATION_H_
+#define ZEPHYR_INCLUDE_ZEPHYR_MATH_INTERPOLATION_H_
+
+#include <stdint.h>
+#include <math.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @file
+ * @brief Provide linear interpolation functions
+ */
+
+/**
+ * @brief Perform a linear interpolation across an arbitrary curve
+ *
+ * @note Result rounding occurs away from 0, e.g:
+ *       1.5 -> 2, -5.5 -> -6
+ *
+ * @param x_axis Ascending list of X co-ordinates for @a y_axis data points
+ * @param y_axis Y co-ordinates for each X data point
+ * @param len Length of the @a x_axis and @a y_axis arrays
+ * @param x X co-ordinate to lookup
+ *
+ * @retval y_axis[0] if x < x_axis[0]
+ * @retval y_axis[len - 1] if x > x_axis[len - 1]
+ * @retval int32_t Linear interpolation between the two nearest @a y_axis values.
+ */
+static inline int32_t linear_interpolate(const int32_t *x_axis, const int32_t *y_axis, uint8_t len,
+					 int32_t x)
+{
+	float rise, run, slope;
+	int32_t x_shifted;
+	uint8_t idx_low = 0;
+
+	/* Handle out of bounds values */
+	if (x <= x_axis[0]) {
+		return y_axis[0];
+	} else if (x >= x_axis[len - 1]) {
+		return y_axis[len - 1];
+	}
+
+	/* Find the lower x axis bucket */
+	while (x >= x_axis[idx_low + 1]) {
+		idx_low++;
+	}
+
+	/* Shift input to origin */
+	x_shifted = x - x_axis[idx_low];
+	if (x_shifted == 0) {
+		return y_axis[idx_low];
+	}
+
+	/* Local slope */
+	rise = y_axis[idx_low + 1] - y_axis[idx_low];
+	run = x_axis[idx_low + 1] - x_axis[idx_low];
+	slope = rise / run;
+
+	/* Apply slope, undo origin shift and round */
+	return roundf(y_axis[idx_low] + (slope * x_shifted));
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_ZEPHYR_MATH_INTERPOLATION_H_ */

--- a/tests/lib/math/interpolation/CMakeLists.txt
+++ b/tests/lib/math/interpolation/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2024 Embeint Inc
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(interpolation)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/lib/math/interpolation/prj.conf
+++ b/tests/lib/math/interpolation/prj.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2024 Embeint Inc
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+# roundf support on Xtensa
+CONFIG_REQUIRES_FULL_LIBC=y

--- a/tests/lib/math/interpolation/src/main.c
+++ b/tests/lib/math/interpolation/src/main.c
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2024 Embeint Inc
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <math.h>
+
+#include <zephyr/ztest.h>
+#include <zephyr/math/interpolation.h>
+
+ZTEST(interpolation, test_interpolation_oob)
+{
+	int32_t x_axis[] = {10, 20, 30, 40, 50};
+	int32_t y_axis[] = {20, 22, 24, 28, 36};
+	uint8_t len = ARRAY_SIZE(x_axis);
+
+	zassert_equal(ARRAY_SIZE(x_axis), ARRAY_SIZE(y_axis));
+
+	zassert_equal(y_axis[0], linear_interpolate(x_axis, y_axis, len, INT32_MIN));
+	zassert_equal(y_axis[0], linear_interpolate(x_axis, y_axis, len, -1));
+	zassert_equal(y_axis[0], linear_interpolate(x_axis, y_axis, len, 0));
+	zassert_equal(y_axis[0], linear_interpolate(x_axis, y_axis, len, x_axis[0] - 1));
+
+	zassert_equal(y_axis[4], linear_interpolate(x_axis, y_axis, len, x_axis[4] + 1));
+	zassert_equal(y_axis[4], linear_interpolate(x_axis, y_axis, len, 100));
+	zassert_equal(y_axis[4], linear_interpolate(x_axis, y_axis, len, INT32_MAX));
+}
+
+ZTEST(interpolation, test_interpolation_on_boundary)
+{
+	int32_t x_axis[] = {10, 20, 30, 40, 50};
+	int32_t y_axis[] = {20, 22, 24, 28, 36};
+	uint8_t len = ARRAY_SIZE(x_axis);
+
+	zassert_equal(ARRAY_SIZE(x_axis), ARRAY_SIZE(y_axis));
+
+	/* Looking up x_axis values should return corresponding y_axis */
+	for (int i = 0; i < ARRAY_SIZE(x_axis); i++) {
+		zassert_equal(y_axis[i], linear_interpolate(x_axis, y_axis, len, x_axis[i]));
+	}
+}
+
+ZTEST(interpolation, test_interpolation_rounding)
+{
+	int32_t y_axis[] = {0, 1, 2};
+	int32_t x_axis[] = {0, 10, 20};
+	uint8_t len = ARRAY_SIZE(x_axis);
+
+	zassert_equal(ARRAY_SIZE(x_axis), ARRAY_SIZE(y_axis));
+
+	/* 0 to 4 -> 0 */
+	for (int i = 0; i < 5; i++) {
+		zassert_equal(0, linear_interpolate(x_axis, y_axis, len, i));
+	}
+	/* 5 to 14 -> 1 */
+	for (int i = 5; i < 15; i++) {
+		zassert_equal(1, linear_interpolate(x_axis, y_axis, len, i));
+	}
+	/* 15 to N -> 2 */
+	for (int i = 15; i <= 20; i++) {
+		zassert_equal(2, linear_interpolate(x_axis, y_axis, len, i));
+	}
+}
+
+ZTEST(interpolation, test_interpolation_simple)
+{
+	int32_t y_axis[] = {0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100};
+	int32_t x_axis[] = {2000, 2100, 2200, 2300, 2400, 2500, 2600, 2700, 2800, 2900, 3000};
+	uint8_t len = ARRAY_SIZE(x_axis);
+	int32_t expected;
+
+	zassert_equal(ARRAY_SIZE(x_axis), ARRAY_SIZE(y_axis));
+
+	/* y = (x - 2000) / 10 */
+	for (int i = x_axis[0]; i <= x_axis[1]; i++) {
+		expected = round((i - 2000.0) / 10.0);
+		zassert_equal(expected, linear_interpolate(x_axis, y_axis, len, i));
+	}
+}
+
+ZTEST(interpolation, test_interpolation_negative_y)
+{
+	int32_t y_axis[] = {-100, -90, -80, -70, -60, -50, -40, -30, -20, -10, 0};
+	int32_t x_axis[] = {2000, 2100, 2200, 2300, 2400, 2500, 2600, 2700, 2800, 2900, 3000};
+	uint8_t len = ARRAY_SIZE(x_axis);
+	int32_t expected;
+
+	zassert_equal(ARRAY_SIZE(x_axis), ARRAY_SIZE(y_axis));
+
+	/* y = ((x - 2000) / 10) - 100 */
+	for (int i = x_axis[0]; i <= x_axis[len - 1]; i++) {
+		expected = round((i - 2000.0) / 10.0 - 100.0);
+		zassert_equal(expected, linear_interpolate(x_axis, y_axis, len, i));
+	}
+}
+
+ZTEST(interpolation, test_interpolation_negative_x)
+{
+	int32_t y_axis[] = {0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100};
+	int32_t x_axis[] = {-3000, -2900, -2800, -2700, -2600, -2500,
+			    -2400, -2300, -2200, -2100, -2000};
+	uint8_t len = ARRAY_SIZE(x_axis);
+	int32_t expected;
+
+	zassert_equal(ARRAY_SIZE(x_axis), ARRAY_SIZE(y_axis));
+
+	/* y = ((x + 3000) / 10) */
+	for (int i = x_axis[0]; i <= x_axis[len - 1]; i++) {
+		expected = round((i + 3000.0) / 10.0);
+		zassert_equal(expected, linear_interpolate(x_axis, y_axis, len, i));
+	}
+}
+
+ZTEST(interpolation, test_interpolation_negative_xy)
+{
+	int32_t y_axis[] = {-100, -90, -80, -70, -60, -50, -40, -30, -20, -10, 0};
+	int32_t x_axis[] = {-3000, -2900, -2800, -2700, -2600, -2500,
+			    -2400, -2300, -2200, -2100, -2000};
+	uint8_t len = ARRAY_SIZE(x_axis);
+	int32_t expected;
+
+	zassert_equal(ARRAY_SIZE(x_axis), ARRAY_SIZE(y_axis));
+
+	/* y = ((x + 3000) / 10) - 100 */
+	for (int i = x_axis[0]; i <= x_axis[len - 1]; i++) {
+		expected = round((i + 3000.0) / 10.0 - 100.0);
+		zassert_equal(expected, linear_interpolate(x_axis, y_axis, len, i));
+	}
+}
+
+ZTEST(interpolation, test_interpolation_piecewise)
+{
+	int32_t y_axis[] = {10, 30, 110, 40, 0};
+	int32_t x_axis[] = {100, 150, 200, 250, 300};
+	uint8_t len = ARRAY_SIZE(x_axis);
+	int32_t expected;
+
+	zassert_equal(ARRAY_SIZE(x_axis), ARRAY_SIZE(y_axis));
+
+	/* First line segment, y = 0.4x - 30 */
+	for (int i = x_axis[0]; i <= x_axis[1]; i++) {
+		expected = round(0.4 * i - 30.0);
+		zassert_equal(expected, linear_interpolate(x_axis, y_axis, len, i));
+	}
+
+	/* Second line segment, y = 1.6x - 210 */
+	for (int i = x_axis[1]; i <= x_axis[2]; i++) {
+		expected = round(1.6 * i - 210.0);
+		zassert_equal(expected, linear_interpolate(x_axis, y_axis, len, i));
+	}
+
+	/* Third line segment, y = 390 - 1.4x */
+	for (int i = x_axis[2]; i <= x_axis[3]; i++) {
+		expected = round(390.0 - 1.4 * i);
+		zassert_equal(expected, linear_interpolate(x_axis, y_axis, len, i));
+	}
+
+	/* Fourth line segment, y = 240 - 0.8x */
+	for (int i = x_axis[3]; i <= x_axis[4]; i++) {
+		expected = round(240.0 - 0.8 * i);
+		zassert_equal(expected, linear_interpolate(x_axis, y_axis, len, i));
+	}
+}
+
+ZTEST_SUITE(interpolation, NULL, NULL, NULL, NULL, NULL);

--- a/tests/lib/math/interpolation/testcase.yaml
+++ b/tests/lib/math/interpolation/testcase.yaml
@@ -1,0 +1,7 @@
+# Copyright (c) 2024 Embeint Inc
+# SPDX-License-Identifier: Apache-2.0
+
+tests:
+  math.interpolation:
+    integration_platforms:
+      - native_sim


### PR DESCRIPTION
Provide a mechanism for sensors that can only measure battery voltage to report a charge percentage through an open circuit voltage lookup table. 5 default tables are provided for different battery chemistries, application specific curves can easily be used instead.

This conversion is added to the voltage-divider driver and configured on the Thingy53 platform.

A custom linear interpolation function is provided to avoid any dependency on CMSIS-DSP.