### PR TITLE
logging: log_output: Prevent redundant flush with zero-length data

### DIFF
--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -152,11 +152,11 @@ static void buffer_write(log_output_func_t outf, uint8_t *buf, size_t len,
 {
 	int processed;
 
-	do {
+	while (len != 0) {
 		processed = outf(buf, len, ctx);
 		len -= processed;
 		buf += processed;
-	} while (len != 0);
+	}
 }
 
 


### PR DESCRIPTION
There's such a case captured. When log immediate mode is enabled, each log message is output per character. However, "log_output_flush()" function is still called with zero data length at the end of "log_output_process()". Better to make "log_output_flush()" returns immediatley if buffer data length is zero.