### PR TITLE
DNM: drivers: counter: clock fixes and add imx7d GPT driver

### DIFF
--- a/boards/toradex/colibri_imx7d/colibri_imx7d_mcimx7d_m4.yaml
+++ b/boards/toradex/colibri_imx7d/colibri_imx7d_mcimx7d_m4.yaml
@@ -20,4 +20,5 @@ testing:
     - bluetooth
 supported:
   - pwm
+  - counter
 vendor: nxp

--- a/drivers/counter/CMakeLists.txt
+++ b/drivers/counter/CMakeLists.txt
@@ -50,3 +50,4 @@ zephyr_library_sources_ifdef(CONFIG_COUNTER_SNPS_DW             counter_dw_timer
 zephyr_library_sources_ifdef(CONFIG_COUNTER_SHELL               counter_timer_shell.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_TIMER_RPI_PICO      counter_rpi_pico_timer.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_NXP_MRT             counter_nxp_mrt.c)
+zephyr_library_sources_ifdef(CONFIG_COUNTER_GPT_IMX             counter_imx7d_gpt.c)

--- a/drivers/counter/Kconfig
+++ b/drivers/counter/Kconfig
@@ -98,4 +98,6 @@ source "drivers/counter/Kconfig.rpi_pico"
 
 source "drivers/counter/Kconfig.nxp_mrt"
 
+source "drivers/counter/Kconfig.imx7d_gpt"
+
 endif # COUNTER

--- a/drivers/counter/Kconfig.imx7d_gpt
+++ b/drivers/counter/Kconfig.imx7d_gpt
@@ -1,0 +1,17 @@
+# Copyright (c) 2024 MAKEEN Energy A/S
+# SPDX-License-Identifier: Apache-2.0
+
+
+config GPT_IMX
+	bool "i.MX GPT Driver"
+	default y
+	depends on $(dt_compat_enabled,$(DT_COMPAT_NXP_IMX7D_GPT))
+	help
+	  Enable support for i.MX ftm driver.
+
+config COUNTER_GPT_IMX
+	bool "IMX GPT driver"
+	default y
+	depends on GPT_IMX
+	help
+	  Enable support for Flexible Timer (FTM) driver.

--- a/drivers/counter/counter_imx7d_gpt.c
+++ b/drivers/counter/counter_imx7d_gpt.c
@@ -1,0 +1,439 @@
+/*
+ * Copyright (c) 2024, MAKEEN Energy A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT nxp_imx7d_gpt
+
+#include <zephyr/drivers/counter.h>
+#include <zephyr/irq.h>
+#include <gpt.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/barrier.h>
+
+#define GUARD_PERIOD 1200
+
+/* bit indicating if an alarm is expecting to be enabled at the next overflow */
+#define IMX_GPT_OVF_DELAYED 0x01
+/* bit set when an alarm was rescheduled after an overflow */
+#define IMX_GPT_OVF_PROCESSED 0x02
+
+LOG_MODULE_REGISTER(imx7d_gpt, CONFIG_COUNTER_LOG_LEVEL);
+
+struct imx_gpt_config {
+	/* info must be first element */
+	struct counter_config_info info;
+	GPT_Type *base;
+	uint8_t clock_source;
+};
+
+struct imx_gpt_alarm_cfg {
+	struct counter_alarm_cfg alarm_cfg;
+	uint8_t ovf_state;
+};
+
+struct imx_gpt_data {
+	counter_top_callback_t top_callback;
+	void *top_user_data;
+	struct imx_gpt_alarm_cfg alarm_cfgs[3];
+};
+
+static int imx_gpt_start(const struct device *dev)
+{
+	const struct imx_gpt_config *config = dev->config;
+	unsigned int key;
+
+	key = irq_lock();
+	GPT_Enable(config->base);
+	irq_unlock(key);
+	LOG_DBG("GPT start counter: %u SR: %x CR: %x\n",
+		GPT_ReadCounter(config->base), config->base->SR, config->base->CR);
+	return 0;
+}
+
+static int imx_gpt_stop(const struct device *dev)
+{
+	const struct imx_gpt_config *config = dev->config;
+	unsigned int key;
+
+	key = irq_lock();
+	GPT_Disable(config->base);
+	irq_unlock(key);
+	LOG_DBG("GPT stop counter: %u SR: %x CR: %x\n",
+		GPT_ReadCounter(config->base), config->base->SR, config->base->CR);
+	return 0;
+}
+
+static int imx_gpt_get_value(const struct device *dev, uint32_t *ticks)
+{
+	const struct imx_gpt_config *config = dev->config;
+
+	*ticks = GPT_ReadCounter(config->base);
+	return 0;
+}
+
+static int imx_gpt_set_alarm(const struct device *dev, uint8_t chan_id,
+			      const struct counter_alarm_cfg *alarm_cfg)
+{
+	const struct imx_gpt_config *config = dev->config;
+	struct imx_gpt_data *data = dev->data;
+	unsigned int key;
+
+	uint32_t current = GPT_ReadCounter(config->base);
+	uint32_t ticks = alarm_cfg->ticks;
+
+	struct counter_alarm_cfg *alarm_data = NULL;
+	struct imx_gpt_alarm_cfg *ext_alarm_data = NULL;
+
+	if (chan_id > config->info.channels) {
+		LOG_ERR("Invalid channel id");
+		return -EINVAL;
+	}
+
+	ext_alarm_data = &data->alarm_cfgs[chan_id];
+	alarm_data = &ext_alarm_data->alarm_cfg;
+
+	/* tick delay too long */
+	if ((alarm_cfg->flags & COUNTER_ALARM_CFG_ABSOLUTE) == 0 &&
+	   alarm_cfg->ticks >= config->info.max_top_value) {
+		LOG_ERR("Error setting max %d / %d\n",
+				alarm_cfg->ticks, config->info.max_top_value);
+		return -EINVAL;
+	}
+
+	if (alarm_data->callback) {
+		return -EBUSY;
+	}
+
+	if ((alarm_cfg->flags & COUNTER_ALARM_CFG_ABSOLUTE) == 0) {
+		ticks += current;
+		ticks &= config->info.max_top_value;
+	}
+
+	/* it is not garanteed that we can match the TOP value, so match -1 tick from the TOP */
+	/* Ticks can only match if they are bellow the MAX top */
+	if (ticks > config->info.max_top_value) {
+		LOG_ERR("Error ticks max %d / %d\n", alarm_cfg->ticks, config->info.max_top_value);
+		return -EINVAL;
+	}
+
+	alarm_data->callback = alarm_cfg->callback;
+	alarm_data->user_data = alarm_cfg->user_data;
+	alarm_data->ticks = ticks;
+	alarm_data->flags = alarm_cfg->flags;
+
+	key = irq_lock();
+	GPT_SetOutputCompareValue(config->base, chan_id, ticks);
+	GPT_SetIntCmd(config->base, (1U<<chan_id), true);
+	irq_unlock(key);
+	LOG_DBG("GPT Set alarm [%d]: %u / %u IR:%x SR:%x CR:%x\n",
+			chan_id, current, ticks, config->base->IR,
+			config->base->SR, config->base->CR);
+
+
+	return 0;
+}
+
+static int imx_gpt_cancel_alarm(const struct device *dev, uint8_t chan_id)
+{
+	const struct imx_gpt_config *config = dev->config;
+	struct imx_gpt_data *data = dev->data;
+	struct counter_alarm_cfg *alarm_data = NULL;
+	struct imx_gpt_alarm_cfg *ext_alarm_data = NULL;
+	unsigned int key;
+
+	if (chan_id > config->info.channels) {
+		LOG_ERR("Invalid channel id");
+		return -EINVAL;
+	}
+
+	ext_alarm_data = &data->alarm_cfgs[chan_id];
+	alarm_data = &ext_alarm_data->alarm_cfg;
+
+	key = irq_lock();
+	GPT_SetIntCmd(config->base, (1UL<<chan_id), false);
+	alarm_data->callback = NULL;
+	irq_unlock(key);
+	return 0;
+}
+
+static uint32_t imx_gpt_get_pending_int(const struct device *dev)
+{
+	const struct imx_gpt_config *config = dev->config;
+
+	return	GPT_GetStatusFlag(config->base, (
+					gptStatusFlagOutputCompare1 |
+					gptStatusFlagOutputCompare2 |
+					gptStatusFlagOutputCompare3 |
+					gptStatusFlagRollOver));
+}
+
+void imx_gpt_isr(const struct device *dev)
+{
+	const struct imx_gpt_config *config = dev->config;
+	struct imx_gpt_data *data = dev->data;
+	unsigned int key = irq_lock();
+
+	uint32_t current = GPT_ReadCounter(config->base);
+	uint32_t status;
+	uint32_t int_enable = (config->base->IR) & 0x3F;
+
+	status =  imx_gpt_get_pending_int(dev);
+
+	GPT_ClearStatusFlag(config->base, status);
+	barrier_dsync_fence_full();
+
+	if ((status & gptStatusFlagRollOver) && (int_enable & gptStatusFlagRollOver)) {
+
+		if (data->top_callback) {
+			data->top_callback(dev, data->top_user_data);
+		}
+
+
+		/* on overflow, all compare are triggered */
+		uint32_t status_save = status;
+
+		status = 0;
+
+		for (uint8_t chan_id = 0; chan_id < config->info.channels; chan_id++) {
+			uint8_t channel_flag = (1UL<<chan_id);
+			struct imx_gpt_alarm_cfg *ext_alarm_data =  &data->alarm_cfgs[chan_id];
+			struct counter_alarm_cfg *alarm_data = &ext_alarm_data->alarm_cfg;
+
+			/* if channel is enabled and it was matching for the 0 count  */
+			if ((status & channel_flag) != 0 && (int_enable & channel_flag) != 0
+				&& GPT_GetOutputCompareValue(config->base, chan_id) == 0
+				&& alarm_data->callback) {
+				status |= channel_flag;
+			}
+		}
+		/* Return here to clear the flags at overflow and */
+		/* let the compare channel trigger again */
+		LOG_DBG("GPT top: IR:%x SR:%x/%x/%x\n",
+			config->base->IR, config->base->SR, status, status_save);
+	}
+
+	for (uint8_t chan_id = 0; chan_id < config->info.channels; chan_id++) {
+		uint8_t channel_flag = (1UL<<chan_id);
+		struct imx_gpt_alarm_cfg *ext_alarm_data = &data->alarm_cfgs[chan_id];
+		struct counter_alarm_cfg *alarm_data = &ext_alarm_data->alarm_cfg;
+
+		if ((status & channel_flag) &&
+			(int_enable & channel_flag) &&
+			alarm_data->callback) {
+
+			GPT_SetIntCmd(config->base, channel_flag, false);
+
+			counter_alarm_callback_t alarm_cb = alarm_data->callback;
+
+			alarm_data->callback = NULL;
+			alarm_cb(dev, chan_id, current, alarm_data->user_data);
+			LOG_DBG("GPT alarm: IR:%x SR:%x/%x\n",
+				config->base->IR, config->base->SR, status);
+		}
+	}
+
+	irq_unlock(key);
+}
+
+static int imx_gpt_set_top_value(const struct device *dev,
+				  const struct counter_top_cfg *cfg)
+{
+	const struct imx_gpt_config *config = dev->config;
+	struct imx_gpt_data *data = dev->data;
+	unsigned int key;
+	int res = 0;
+
+	if (cfg->ticks != config->info.max_top_value) {
+		LOG_ERR("Wrap can only be set to 0x%x",
+			config->info.max_top_value);
+		res = -ENOTSUP;
+	}
+
+	data->top_callback = cfg->callback;
+	data->top_user_data = cfg->user_data;
+
+	key = irq_lock();
+	/* Always enable */
+	GPT_SetIntCmd(config->base, gptStatusFlagRollOver, true);
+
+	/* set_top_value resets the counter as per flags in Zephyr API */
+	if ((cfg->flags & COUNTER_TOP_CFG_DONT_RESET) == 0) {
+		/* IMX GPT resets if ENMOD in GPT->CR is 1 */
+		GPT_Disable(config->base);
+		GPT_Enable(config->base);
+	}
+	irq_unlock(key);
+
+	return res;
+}
+
+static uint32_t imx_gpt_get_top_value(const struct device *dev)
+{
+	const struct imx_gpt_config *config = dev->config;
+
+	return config->info.max_top_value;
+}
+
+static uint32_t imx_gpt_get_frequency(const struct device *dev)
+{
+	const struct imx_gpt_config *config = dev->config;
+
+	uint32_t clock_freq = get_gpt_clock_freq_soc(config->base);
+	/* when using OSC source we must divide to make sure */
+	/* the counting frequency is at maximum 1/2 of Periph clock */
+	uint32_t osc_prescaler = 1;
+
+	uint32_t clock_freq_pre = (clock_freq / (osc_prescaler+1));
+
+	uint32_t prescaler = (clock_freq_pre / config->info.freq) - 1;
+
+	uint32_t gpt_freq = clock_freq_pre / (prescaler+1);
+
+	return gpt_freq;
+}
+
+static int imx_gpt_init(const struct device *dev)
+{
+	const struct imx_gpt_config *config = dev->config;
+	struct imx_gpt_data *data = dev->data;
+	gpt_init_config_t gptConfig;
+	unsigned int key;
+	uint32_t clock_freq;
+
+	clock_freq = get_gpt_clock_freq_soc(config->base);
+
+	/* when using OSC source we must divide to make sure */
+	/* the counting frequency is at maximum 1/2 of Periph clock */
+	/* See IMX7DRM */
+	uint32_t osc_prescaler = 1;
+
+	uint32_t clock_freq_pre = (clock_freq / (osc_prescaler+1));
+
+	if (clock_freq_pre % config->info.freq) {
+		LOG_ERR("Cannot Adjust GPT freq to %u\n", config->info.freq);
+		LOG_ERR("clock src is %u\n", clock_freq_pre);
+		return -EINVAL;
+	}
+
+	data->top_callback = NULL;
+	data->top_user_data = NULL;
+
+	/* Reference manual sequence page 4064*/
+	/*!< true: FreeRun mode, false: Restart mode. */
+	gptConfig.freeRun = true;
+	/*!< GPT enabled in wait mode. */
+	gptConfig.waitEnable = true;
+	/*!< GPT enabled in stop mode. */
+	gptConfig.stopEnable = true;
+	/*!< GPT enabled in doze mode. */
+	gptConfig.dozeEnable = true;
+	/*!< GPT enabled in debug mode. */
+	gptConfig.dbgEnable = false;
+	/*!< true: counter reset to 0 when enabled, false: counter retain its value when enabled. */
+	gptConfig.enableMode = true;
+
+
+	uint32_t prescaler = (clock_freq_pre / config->info.freq) - 1;
+	uint32_t gpt_freq = clock_freq_pre / (prescaler+1);
+
+	LOG_DBG("GPT srcclock: %u gpt_freq: %u clock_source:%u\n",
+			clock_freq_pre, config->info.freq, config->clock_source);
+
+	key = irq_lock();
+	GPT_Init(config->base, &gptConfig);
+
+	GPT_SetClockSource(config->base, config->clock_source);
+
+	GPT_ClearStatusFlag(config->base,
+		gptStatusFlagOutputCompare1 |
+		gptStatusFlagOutputCompare2 |
+		gptStatusFlagOutputCompare3 |
+		gptStatusFlagInputCapture1 |
+		gptStatusFlagInputCapture2 |
+		gptStatusFlagRollOver);
+
+	GPT_SetIntCmd(config->base,
+		gptStatusFlagOutputCompare1 |
+		gptStatusFlagOutputCompare2 |
+		gptStatusFlagOutputCompare3 |
+		gptStatusFlagInputCapture1 |
+		gptStatusFlagInputCapture2 |
+		gptStatusFlagRollOver, false);
+
+
+
+	GPT_SetOutputOperationMode(config->base,
+			gptOutputCompareChannel1, gptOutputOperationDisconnected);
+	GPT_SetOutputOperationMode(config->base,
+			gptOutputCompareChannel2, gptOutputOperationDisconnected);
+	GPT_SetOutputOperationMode(config->base,
+			gptOutputCompareChannel3, gptOutputOperationDisconnected);
+
+	GPT_SetOscPrescaler(config->base, osc_prescaler);
+	GPT_SetPrescaler(config->base, prescaler);
+
+	LOG_DBG("GPT oscprescaler: %u prescaler: %u cntFreq:%u CR:%u IR:%u\n",
+	GPT_GetOscPrescaler(config->base),
+	GPT_GetPrescaler(config->base),
+	 gpt_freq,
+	 config->base->CR, config->base->IR);
+
+
+	/* enable by default */
+	GPT_SetIntCmd(config->base, gptStatusFlagRollOver, true);
+
+	irq_unlock(key);
+
+	return 0;
+}
+
+static const struct counter_driver_api imx_gpt_driver_api = {
+	.start = imx_gpt_start,
+	.stop = imx_gpt_stop,
+	.get_value = imx_gpt_get_value,
+	.set_alarm = imx_gpt_set_alarm,
+	.cancel_alarm = imx_gpt_cancel_alarm,
+	.set_top_value = imx_gpt_set_top_value,
+	.get_pending_int = imx_gpt_get_pending_int,
+	.get_top_value = imx_gpt_get_top_value,
+	.get_freq = imx_gpt_get_frequency,
+	/* .set_guard_period = imx_gpt_set_guard_period, */
+	/* .get_guard_period = imx_gpt_get_guard_period, */
+};
+
+#define GPT_DEVICE_INIT_IMX7D(n)						\
+	static struct imx_gpt_data imx_gpt_data_ ## n = {0};		\
+									\
+	static const struct imx_gpt_config imx_gpt_config_ ## n = {	\
+		.base = (void *)DT_INST_REG_ADDR(n),			\
+		.clock_source = gptClockSourceOsc, \
+		.info = {						\
+			.max_top_value = UINT32_MAX,			\
+			.freq = DT_INST_PROP(n, gptfreq),           \
+			.channels = 3,					\
+			.flags = COUNTER_CONFIG_INFO_COUNT_UP,		\
+		},							\
+	};								\
+									\
+	static int imx_gpt_## n ##_init(const struct device *dev);	\
+	DEVICE_DT_INST_DEFINE(n,					\
+			    imx_gpt_## n ##_init,			\
+			    NULL,					\
+			    &imx_gpt_data_ ## n,			\
+			    &imx_gpt_config_ ## n,			\
+			    POST_KERNEL,				\
+			    CONFIG_COUNTER_INIT_PRIORITY,		\
+			    &imx_gpt_driver_api);			\
+									\
+	static int imx_gpt_## n ##_init(const struct device *dev)	\
+	{								\
+		IRQ_CONNECT(DT_INST_IRQN(n),				\
+			    DT_INST_IRQ(n, priority),			\
+			    imx_gpt_isr, DEVICE_DT_INST_GET(n), 0);	\
+		irq_enable(DT_INST_IRQN(n));				\
+		return imx_gpt_init(dev);				\
+	}								\
+
+DT_INST_FOREACH_STATUS_OKAY(GPT_DEVICE_INIT_IMX7D)

--- a/dts/arm/nxp/nxp_imx7d_m4.dtsi
+++ b/dts/arm/nxp/nxp_imx7d_m4.dtsi
@@ -365,6 +365,55 @@
 			status = "disabled";
 			#pwm-cells = <2>;
 		};
+
+		gpt1: gpt@302d0000 {
+			compatible = "nxp,imx7d-gpt";
+			reg = <0x302d0000 0x10000>;
+			interrupts = <55 0>;
+			gptfreq = <12000000>;
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+						RDC_DOMAIN_PERM_RW)|\
+				RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+						RDC_DOMAIN_PERM_RW))>;
+			status = "disabled";
+		};
+
+		gpt2: gpt@302e0000 {
+			compatible = "nxp,imx7d-gpt";
+			reg = <0x302e0000 0x10000>;
+			interrupts = <54 0>;
+			gptfreq = <12000000>;
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+						RDC_DOMAIN_PERM_RW)|\
+				RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+						RDC_DOMAIN_PERM_RW))>;
+			status = "disabled";
+		};
+
+		gpt3: gpt@302f0000 {
+			compatible = "nxp,imx7d-gpt";
+			reg = <0x302f0000 0x10000>;
+			interrupts = <53 0>;
+			gptfreq = <12000000>;
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+						RDC_DOMAIN_PERM_RW)|\
+				RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+						RDC_DOMAIN_PERM_RW))>;
+			status = "disabled";
+		};
+
+		gpt4: gpt@30300000 {
+			compatible = "nxp,imx7d-gpt";
+			reg = <0x30300000 0x10000>;
+			interrupts = <52 0>;
+			gptfreq = <12000000>;
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+						RDC_DOMAIN_PERM_RW)|\
+				RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+						RDC_DOMAIN_PERM_RW))>;
+			status = "disabled";
+		};
+
 	};
 };
 

--- a/dts/bindings/arm/nxp,imx7d-ccm.yaml
+++ b/dts/bindings/arm/nxp,imx7d-ccm.yaml
@@ -1,0 +1,25 @@
+# Copyright (c) 2024 MAKEEN Energy A/S
+# SPDX-License-Identifier: Apache-2.0
+
+description: NXP IMX7D CCM Prescalers definitons
+
+properties:
+
+  ccm-pre:
+    type: int
+    default: 0
+    enum:
+      - 0
+      - 1
+      - 2
+      - 3
+      - 4
+      - 5
+      - 6
+      - 7
+    description: CCM Pre divider value (0-7, divider=n+1)
+
+  ccm-post:
+    type: int
+    default: 0
+    description: Post divider value (0-63, divider=n+1)

--- a/dts/bindings/counter/nxp,imx7d-gpt.yaml
+++ b/dts/bindings/counter/nxp,imx7d-gpt.yaml
@@ -1,0 +1,25 @@
+# Copyright (c) 2024, MAKEEN Energy A/S
+# SPDX-License-Identifier: Apache-2.0
+
+description: NXP IMX7D General-Purpose Timer (GPT)
+
+compatible: "nxp,imx7d-gpt"
+
+include: [base.yaml, pinctrl-device.yaml, "nxp,imx7d-ccm.yaml"]
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true
+
+  gptfreq:
+    type: int
+    required: true
+    description: gpt frequencies
+
+  rdc:
+    type: int
+    required: true
+    description: Set the RDC permission for this peripheral

--- a/include/zephyr/dt-bindings/clock/nxp_imx7d_ccm.h
+++ b/include/zephyr/dt-bindings/clock/nxp_imx7d_ccm.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2024, MAKEEN Energy A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_IMX7D_CCM_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_IMX7D_CCM_H_
+
+/* Pre and Post dividers for the root CCM */
+#define CCM_DT_ROOT_PRE(nodelabel) DT_PROP(DT_NODELABEL(nodelabel), ccm_pre)
+#define CCM_DT_ROOT_POST(nodelabel) DT_PROP(DT_NODELABEL(nodelabel), ccm_post)
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_IMX7D_CCM_H_ */

--- a/samples/drivers/counter/alarm/boards/colibri_imx7d_mcimx7d_m4.overlay
+++ b/samples/drivers/counter/alarm/boards/colibri_imx7d_mcimx7d_m4.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2024 MAKEEN Energy A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&gpt2 {
+	status = "okay";
+};

--- a/samples/drivers/counter/alarm/src/main.c
+++ b/samples/drivers/counter/alarm/src/main.c
@@ -53,6 +53,8 @@ struct counter_alarm_cfg alarm_cfg;
 #define TIMER DT_NODELABEL(timer0)
 #elif defined(CONFIG_COUNTER_TIMER_RPI_PICO)
 #define TIMER DT_NODELABEL(timer)
+#elif defined(CONFIG_COUNTER_GPT_IMX)
+#define TIMER DT_NODELABEL(gpt2)
 #endif
 
 static void test_counter_interrupt_fn(const struct device *counter_dev,

--- a/soc/nxp/imx/imx7d/Kconfig.defconfig.mcimx7d_m4
+++ b/soc/nxp/imx/imx7d/Kconfig.defconfig.mcimx7d_m4
@@ -6,7 +6,7 @@
 if SOC_MCIMX7D_M4
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	default 200000000
+	default 240000000
 
 config GPIO
 	default y

--- a/soc/nxp/imx/imx7d/soc.c
+++ b/soc/nxp/imx/imx7d/soc.c
@@ -70,6 +70,17 @@ static void nxp_mcimx7_gpio_config(void)
 	CCM_ControlGate(CCM, ccmCcgrGateGpio2, ccmClockNeededRunWait);
 #endif
 
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(gpio3), okay)
+	RDC_SetPdapAccess(RDC, rdcPdapGpio3, RDC_DT_VAL(gpio3), false, false);
+	/* Enable gpio clock gate */
+	CCM_ControlGate(CCM, ccmCcgrGateGpio3, ccmClockNeededRunWait);
+#endif
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(gpio4), okay)
+	RDC_SetPdapAccess(RDC, rdcPdapGpio4, RDC_DT_VAL(gpio4), false, false);
+	/* Enable gpio clock gate */
+	CCM_ControlGate(CCM, ccmCcgrGateGpio4, ccmClockNeededRunWait);
+#endif
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(gpio7), okay)
 	RDC_SetPdapAccess(RDC, rdcPdapGpio7, RDC_DT_VAL(gpio7), false, false);
@@ -97,6 +108,51 @@ static void nxp_mcimx7_uart_config(void)
 	 * So we need UART clock all the time
 	 */
 	CCM_ControlGate(CCM, ccmCcgrGateUart2, ccmClockNeededAll);
+#endif
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(uart3), okay)
+	/* We need to grasp board uart exclusively */
+	RDC_SetPdapAccess(RDC, rdcPdapUart3, RDC_DT_VAL(uart3), false, false);
+	/* Select clock derived from OSC clock(24M) */
+	CCM_UpdateRoot(CCM, ccmRootUart3, ccmRootmuxUartOsc24m, 0, 0);
+	/* Enable uart clock */
+	CCM_EnableRoot(CCM, ccmRootUart3);
+	/*
+	 * IC Limitation
+	 * M4 stop will cause A7 UART lose functionality
+	 * So we need UART clock all the time
+	 */
+	CCM_ControlGate(CCM, ccmCcgrGateUart3, ccmClockNeededAll);
+#endif
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(uart4), okay)
+	/* We need to grasp board uart exclusively */
+	RDC_SetPdapAccess(RDC, rdcPdapUart4, RDC_DT_VAL(uart4), false, false);
+	/* Select clock derived from OSC clock(24M) */
+	CCM_UpdateRoot(CCM, ccmRootUart4, ccmRootmuxUartOsc24m, 0, 0);
+	/* Enable uart clock */
+	CCM_EnableRoot(CCM, ccmRootUart4);
+	/*
+	 * IC Limitation
+	 * M4 stop will cause A7 UART lose functionality
+	 * So we need UART clock all the time
+	 */
+	CCM_ControlGate(CCM, ccmCcgrGateUart4, ccmClockNeededAll);
+#endif
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(uart5), okay)
+	/* We need to grasp board uart exclusively */
+	RDC_SetPdapAccess(RDC, rdcPdapUart5, RDC_DT_VAL(uart5), false, false);
+	/* Select clock derived from OSC clock(24M) */
+	CCM_UpdateRoot(CCM, ccmRootUart5, ccmRootmuxUartOsc24m, 0, 0);
+	/* Enable uart clock */
+	CCM_EnableRoot(CCM, ccmRootUart5);
+	/*
+	 * IC Limitation
+	 * M4 stop will cause A7 UART lose functionality
+	 * So we need UART clock all the time
+	 */
+	CCM_ControlGate(CCM, ccmCcgrGateUart5, ccmClockNeededAll);
 #endif
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(uart6), okay)

--- a/soc/nxp/imx/imx7d/soc.c
+++ b/soc/nxp/imx/imx7d/soc.c
@@ -7,6 +7,7 @@
 #include <zephyr/init.h>
 #include <soc.h>
 #include <zephyr/dt-bindings/rdc/imx_rdc.h>
+#include <zephyr/dt-bindings/clock/nxp_imx7d_ccm.h>
 #include <zephyr/devicetree.h>
 #include "wdog_imx.h"
 
@@ -267,6 +268,60 @@ static void nxp_mcimx7_pwm_config(void)
 }
 #endif /* CONFIG_PWM_IMX */
 
+#ifdef CONFIG_GPT_IMX
+static void nxp_mcimx7_gpt_config(void)
+{
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(gpt1), okay)
+	/* We need to grasp board ftm exclusively */
+	RDC_SetPdapAccess(RDC, rdcPdapGpt1, RDC_DT_VAL(gpt1), false, false);
+	/* Select clock derived from OSC clock(24M) */
+	CCM_DisableRoot(CCM, ccmRootGpt1);
+	CCM_UpdateRoot(CCM, ccmRootGpt1, ccmRootmuxGptOsc24m,
+					CCM_DT_ROOT_PRE(gpt1), CCM_DT_ROOT_POST(gpt1));
+	/* Enable pwm clock */
+	CCM_EnableRoot(CCM, ccmRootGpt1);
+	CCM_ControlGate(CCM, ccmCcgrGateGpt1, ccmClockNeededRunWait);
+#endif
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(gpt2), okay)
+	/* We need to grasp board ftm exclusively */
+	RDC_SetPdapAccess(RDC, rdcPdapGpt2, RDC_DT_VAL(gpt2), false, false);
+	/* Select clock derived from OSC clock(24M) */
+	CCM_DisableRoot(CCM, ccmRootGpt2);
+	CCM_UpdateRoot(CCM, ccmRootGpt2, ccmRootmuxGptOsc24m,
+					CCM_DT_ROOT_PRE(gpt2), CCM_DT_ROOT_POST(gpt2));
+	/* Enable pwm clock */
+	CCM_EnableRoot(CCM, ccmRootGpt2);
+	CCM_ControlGate(CCM, ccmCcgrGateGpt2, ccmClockNeededRunWait);
+#endif
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(gpt3), okay)
+	/* We need to grasp board ftm exclusively */
+	RDC_SetPdapAccess(RDC, rdcPdapGpt3, RDC_DT_VAL(gpt3), false, false);
+	/* Select clock derived from OSC clock(24M) */
+	CCM_DisableRoot(CCM, ccmRootGpt3);
+	CCM_UpdateRoot(CCM, ccmRootGpt3, ccmRootmuxGptOsc24m,
+					CCM_DT_ROOT_PRE(gpt3), CCM_DT_ROOT_POST(gpt3));
+	/* Enable pwm clock */
+	CCM_EnableRoot(CCM, ccmRootGpt3);
+	CCM_ControlGate(CCM, ccmCcgrGateGpt3, ccmClockNeededRunWait);
+#endif
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(gpt4), okay)
+	/* We need to grasp board ftm exclusively */
+	RDC_SetPdapAccess(RDC, rdcPdapGpt4, RDC_DT_VAL(gpt4), false, false);
+	/* Select clock derived from OSC clock(24M) */
+	CCM_DisableRoot(CCM, ccmRootGpt4);
+	CCM_UpdateRoot(CCM, ccmRootGpt4, ccmRootmuxGptOsc24m,
+					CCM_DT_ROOT_PRE(gpt4), CCM_DT_ROOT_POST(gpt4));
+	/* Enable pwm clock */
+	CCM_EnableRoot(CCM, ccmRootGpt4);
+	CCM_ControlGate(CCM, ccmCcgrGateGpt4, ccmClockNeededRunWait);
+#endif
+}
+#endif /* CONFIG_GPT_IMX */
+
 #ifdef CONFIG_IPM_IMX
 static void nxp_mcimx7_mu_config(void)
 {
@@ -302,6 +357,10 @@ static int nxp_mcimx7_init(void)
 #ifdef CONFIG_PWM_IMX
 	nxp_mcimx7_pwm_config();
 #endif /* CONFIG_PWM_IMX */
+
+#ifdef CONFIG_GPT_IMX
+	nxp_mcimx7_gpt_config();
+#endif /* CONFIG_GPT_IMX */
 
 #ifdef CONFIG_IPM_IMX
 	nxp_mcimx7_mu_config();

--- a/soc/nxp/imx/imx7d/soc_clk_freq.c
+++ b/soc/nxp/imx/imx7d/soc_clk_freq.c
@@ -50,3 +50,46 @@ uint32_t get_pwm_clock_freq(PWM_Type *base)
 	return hz / (pre + 1) / (post + 1);
 }
 #endif /* CONFIG_PWM_IMX */
+
+#ifdef CONFIG_GPT_IMX
+uint32_t get_gpt_clock_freq_soc(GPT_Type *base)
+{
+	uint32_t root;
+	uint32_t hz = 0;
+	uint32_t pre = 0, post = 0;
+
+	switch ((uint32_t)base) {
+	case GPT1_BASE:
+		root = CCM_GetRootMux(CCM, ccmRootGpt1);
+		CCM_GetRootDivider(CCM, ccmRootGpt1, &pre, &post);
+		break;
+	case GPT2_BASE:
+		root = CCM_GetRootMux(CCM, ccmRootGpt2);
+		CCM_GetRootDivider(CCM, ccmRootGpt2, &pre, &post);
+		break;
+	case GPT3_BASE:
+		root = CCM_GetRootMux(CCM, ccmRootGpt3);
+		CCM_GetRootDivider(CCM, ccmRootGpt3, &pre, &post);
+		break;
+	case GPT4_BASE:
+		root = CCM_GetRootMux(CCM, ccmRootGpt4);
+		CCM_GetRootDivider(CCM, ccmRootGpt4, &pre, &post);
+		break;
+	default:
+		return 0;
+	}
+
+	switch (root) {
+	case ccmRootmuxGptOsc24m:
+		hz = 24000000U;
+		break;
+	case ccmRootmuxGptSysPllPfd0:
+		hz = CCM_ANALOG_GetPfdFreq(CCM_ANALOG, ccmAnalogPfd0Frac);
+		break;
+	default:
+		return 0;
+	}
+
+	return hz / (pre + 1) / (post + 1);
+}
+#endif /* CONFIG_GPT_IMX */

--- a/soc/nxp/imx/imx7d/soc_clk_freq.h
+++ b/soc/nxp/imx/imx7d/soc_clk_freq.h
@@ -7,6 +7,7 @@
 #ifndef __SOC_CLOCK_FREQ_H__
 #define __SOC_CLOCK_FREQ_H__
 
+#include <soc.h>
 #include "device_imx.h"
 #include <zephyr/types.h>
 
@@ -23,6 +24,16 @@ extern "C" {
  */
 uint32_t get_pwm_clock_freq(PWM_Type *base);
 #endif /* CONFIG_PWM_IMX */
+
+#ifdef CONFIG_GPT_IMX
+/*!
+ * @brief Get clock frequency applies to the GPT module
+ *
+ * @param base GPT base pointer.
+ * @return clock frequency (in HZ) applies to the GPT module
+ */
+uint32_t get_gpt_clock_freq_soc(GPT_Type *base);
+#endif /* CONFIG_GPT_IMX */
 
 #if defined(__cplusplus)
 }

--- a/tests/drivers/counter/counter_basic_api/Kconfig
+++ b/tests/drivers/counter/counter_basic_api/Kconfig
@@ -1,12 +1,6 @@
-# Config for counter alarm sample
-
-# Copyright (c) 2019 Nordic Semiconductor ASA
 # Copyright (c) 2024 MAKEEN Energy A/S
 # SPDX-License-Identifier: Apache-2.0
 
-config COUNTER_SAM0_TC32
-	bool
-	default y if BOARD_ATSAMD20_XPRO
 
 #Use ROMSTART_RELOCATION_ROM if booting the image using Linux RPROC
 #If using U-boot disable it and use the bin file instead.
@@ -15,6 +9,5 @@ config ROMSTART_RELOCATION_ROM
 
 config BUILD_OUTPUT_BIN
 	default n if ROMSTART_RELOCATION_ROM
-
 
 source "Kconfig.zephyr"

--- a/tests/drivers/counter/counter_basic_api/boards/colibri_imx7d_mcimx7d_m4.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/colibri_imx7d_mcimx7d_m4.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2024 MAKEEN Energy A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Test software is too big to fit on TCM, use OCRAM to build */
+/ {
+	chosen {
+		zephyr,flash = &ocram_code;
+	};
+};
+
+&gpt2 {
+	status = "okay";
+};

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -57,6 +57,7 @@ static const struct device *const devices[] = {
 	DEVS_FOR_DT_COMPAT(microchip_xec_timer)
 	DEVS_FOR_DT_COMPAT(nxp_imx_epit)
 	DEVS_FOR_DT_COMPAT(nxp_imx_gpt)
+	DEVS_FOR_DT_COMPAT(nxp_imx7d_gpt)
 #ifdef CONFIG_COUNTER_MCUX_TPM
 	DEVS_FOR_DT_COMPAT(nxp_tpm_timer)
 #endif


### PR DESCRIPTION
This PR adds support for the GPT (General Purpose Timer) of IMX7D SOCs to be used with the Counter API.

It fixes missing and erroneous declarations of clock settings for uarts and gpios for the imx7d soc.
It means correctly setting the Core clock to 240MHz instead of 200MHz and activating the clock gates.

Then it adds the driver to the test-suite by enabling compilation for the Toradex colibri_imx7d board.

In order to work, this PR needs an update from **hal_nxp** to add the gpt.c driver to the CMakeList:

**hal_nxp/imx/drivers/CMakeLists.txt**
```
zephyr_include_directories(.)

if(CONFIG_SOC_MCIMX7D_M4)
zephyr_library_sources(
  ccm_imx7d.c
  ccm_analog_imx7d.c
)
endif()

if(CONFIG_SOC_MCIMX6X_M4)
zephyr_library_sources(
  ccm_imx6sx.c
  ccm_analog_imx6sx.c
)
zephyr_library_sources_ifdef(CONFIG_ADC_VF610   adc_imx6sx.c)
endif()

zephyr_library_sources_ifdef(CONFIG_COUNTER_IMX_EPIT	epit.c)
zephyr_library_sources_ifdef(CONFIG_GPIO_IMX		gpio_imx.c)
zephyr_library_sources_ifdef(CONFIG_I2C_IMX		i2c_imx.c)
zephyr_library_sources_ifdef(CONFIG_IPM_IMX		mu_imx.c)
zephyr_library_sources_ifdef(CONFIG_UART_IMX		uart_imx.c)
zephyr_library_sources_ifdef(CONFIG_GPT_IMX		gpt.c)

```