### PR TITLE
ieee802154: ieee802154_cc13xx_cc26xx_subg: Fix tcp timeout

### DIFF
--- a/drivers/ieee802154/ieee802154_cc13xx_cc26xx_subg.c
+++ b/drivers/ieee802154/ieee802154_cc13xx_cc26xx_subg.c
@@ -403,7 +403,11 @@ static void cmd_prop_rx_adv_callback(RF_Handle h, RF_CmdHandle ch,
 	LOG_DBG("ch: %u cmd: %04x st: %04x e: 0x%" PRIx64, ch,
 		op->commandNo, op->status, e);
 
-	if (e & RF_EventRxEntryDone) {
+	/* If PROP_ERROR_RXBUF is returned, then RF_EventRxEntryDone is never
+	 * triggered. So finished buffers need to be cleaned up even on this
+	 * status.
+	 */
+	if (e & RF_EventRxEntryDone || op->status == PROP_ERROR_RXBUF) {
 		drv_rx_done(drv_data);
 	}
 


### PR DESCRIPTION
- If status == PROP_ERROR_RXBUF, that means rx buffer head is not empty. In case of this, RF_EventRxEntryDone is never triggered and thus we enter an infinite loop of nothing happening. Due to this, TCP socket times out.
- To fix this, we need to free rx buffer current head. However, it seems better to free all the elements that are already finished instead of just head.
- Before 128354ae17fb95ec6c61d73b9060f1a274715464, the buffer was reset every time drv_rx_start was called. However, that also seems wrong for a ring buffer. So I am freeing the finished buffers instead.
- Tested on Beagleconnect Freedom.
- Fixes https://github.com/zephyrproject-rtos/zephyr/issues/71191