### PR TITLE
tests/kernel/timer/timer_behavior/pytest: align grpcio version

### DIFF
--- a/tests/kernel/timer/timer_behavior/pytest/requirements-saleae.txt
+++ b/tests/kernel/timer/timer_behavior/pytest/requirements-saleae.txt
@@ -1,2 +1,3 @@
 numpy
+grpcio-tools>=1.63.0
 logic2-automation


### PR DESCRIPTION
Align grpcio version with logic2-automation package fixing its fail on Channel.unary_unary() call with missing _registered_method argument.