### PR TITLE
drivers: sensor: stm32_temp: use sensor_value_from_float()

### DIFF
--- a/drivers/sensor/st/stm32_temp/stm32_temp.c
+++ b/drivers/sensor/st/stm32_temp/stm32_temp.c
@@ -149,7 +149,7 @@ static int stm32_temp_channel_get(const struct device *dev, enum sensor_channel 
 	temp += 25;
 #endif
 
-	return sensor_value_from_double(val, temp);
+	return sensor_value_from_float(val, temp);
 }
 
 static const struct sensor_driver_api stm32_temp_driver_api = {


### PR DESCRIPTION
The temperature being computed using a float variable, use sensor_value_from_float() instead of sensor_value_from_double(). This saves some flash.