### PR TITLE
drivers: sensor: stm32_temp/vbat/vref: ensure the ADC is not suspended

### DIFF
--- a/drivers/sensor/st/stm32_temp/stm32_temp.c
+++ b/drivers/sensor/st/stm32_temp/stm32_temp.c
@@ -10,6 +10,7 @@
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/drivers/adc.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/pm/device_runtime.h>
 #include <stm32_ll_adc.h>
 #if defined(CONFIG_SOC_SERIES_STM32H5X)
 #include <stm32_ll_icache.h>
@@ -74,6 +75,7 @@ static int stm32_temp_sample_fetch(const struct device *dev, enum sensor_channel
 	}
 
 	k_mutex_lock(&data->mutex, K_FOREVER);
+	pm_device_runtime_get(data->adc);
 
 	rc = adc_channel_setup(data->adc, &data->adc_cfg);
 	if (rc) {
@@ -97,6 +99,7 @@ static int stm32_temp_sample_fetch(const struct device *dev, enum sensor_channel
 				       path &= ~LL_ADC_PATH_INTERNAL_TEMPSENSOR);
 
 unlock:
+	pm_device_runtime_put(data->adc);
 	k_mutex_unlock(&data->mutex);
 
 	return rc;

--- a/drivers/sensor/st/stm32_vbat/stm32_vbat.c
+++ b/drivers/sensor/st/stm32_vbat/stm32_vbat.c
@@ -9,6 +9,7 @@
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/drivers/adc.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/pm/device_runtime.h>
 #include <stm32_ll_adc.h>
 
 LOG_MODULE_REGISTER(stm32_vbat, CONFIG_SENSOR_LOG_LEVEL);
@@ -45,6 +46,7 @@ static int stm32_vbat_sample_fetch(const struct device *dev, enum sensor_channel
 	}
 
 	k_mutex_lock(&data->mutex, K_FOREVER);
+	pm_device_runtime_get(data->adc);
 
 	rc = adc_channel_setup(data->adc, &data->adc_cfg);
 
@@ -67,6 +69,7 @@ static int stm32_vbat_sample_fetch(const struct device *dev, enum sensor_channel
 				       path &= ~LL_ADC_PATH_INTERNAL_VBAT);
 
 unlock:
+	pm_device_runtime_put(data->adc);
 	k_mutex_unlock(&data->mutex);
 
 	return rc;

--- a/drivers/sensor/st/stm32_vref/stm32_vref.c
+++ b/drivers/sensor/st/stm32_vref/stm32_vref.c
@@ -11,6 +11,7 @@
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/drivers/adc.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/pm/device_runtime.h>
 #include <stm32_ll_adc.h>
 #if defined(CONFIG_SOC_SERIES_STM32H5X)
 #include <stm32_ll_icache.h>
@@ -45,6 +46,7 @@ static int stm32_vref_sample_fetch(const struct device *dev, enum sensor_channel
 	}
 
 	k_mutex_lock(&data->mutex, K_FOREVER);
+	pm_device_runtime_get(data->adc);
 
 	rc = adc_channel_setup(data->adc, &data->adc_cfg);
 	if (rc) {
@@ -71,6 +73,7 @@ static int stm32_vref_sample_fetch(const struct device *dev, enum sensor_channel
 
 
 unlock:
+	pm_device_runtime_put(data->adc);
 	k_mutex_unlock(&data->mutex);
 
 	return rc;


### PR DESCRIPTION
The STM32 temperature, battery and voltage reference sensors needs to write the ADC common registers to enable the corresponding ADC features. For that we need to ensure that the ADC is not suspended by using the pm_device_runtime_get/put methods.

This is required for the sensors to keep working after PR like #72809.