### PR TITLE
Fix network documentation coverage

### DIFF
--- a/include/zephyr/net/buf.h
+++ b/include/zephyr/net/buf.h
@@ -1017,10 +1017,10 @@ struct net_buf {
 	/** Where the buffer should go when freed up. */
 	uint8_t pool_id;
 
-	/* Size of user data on this buffer */
+	/** Size of user data on this buffer */
 	uint8_t user_data_size;
 
-	/* Union for convenience access to the net_buf_simple members, also
+	/** Union for convenience access to the net_buf_simple members, also
 	 * preserving the old API.
 	 */
 	union {
@@ -1042,12 +1042,16 @@ struct net_buf {
 			uint8_t *__buf;
 		};
 
+		/** @cond INTERNAL_HIDDEN */
 		struct net_buf_simple b;
+		/** @endcond */
 	};
 
 	/** System metadata for this buffer. */
 	uint8_t user_data[] __net_buf_align;
 };
+
+/** @cond INTERNAL_HIDDEN */
 
 struct net_buf_data_cb {
 	uint8_t * __must_check (*alloc)(struct net_buf *buf, size_t *size,
@@ -1062,6 +1066,8 @@ struct net_buf_data_alloc {
 	size_t max_alloc_size;
 };
 
+/** @endcond */
+
 /**
  * @brief Network buffer pool representation.
  *
@@ -1071,7 +1077,7 @@ struct net_buf_pool {
 	/** LIFO to place the buffer into when free */
 	struct k_lifo free;
 
-	/* to prevent concurrent access/modifications */
+	/** To prevent concurrent access/modifications */
 	struct k_spinlock lock;
 
 	/** Number of buffers in pool */
@@ -1080,7 +1086,7 @@ struct net_buf_pool {
 	/** Number of uninitialized buffers */
 	uint16_t uninit_count;
 
-	/* Size of user data allocated to this pool */
+	/** Size of user data allocated to this pool */
 	uint8_t user_data_size;
 
 #if defined(CONFIG_NET_BUF_POOL_USAGE)
@@ -1172,12 +1178,14 @@ extern const struct net_buf_data_alloc net_buf_heap_alloc;
 					 _net_buf_##_name, _count, _ud_size, \
 					 _destroy)
 
+/** @cond INTERNAL_HIDDEN */
+
 struct net_buf_pool_fixed {
 	uint8_t *data_pool;
 };
 
-/** @cond INTERNAL_HIDDEN */
 extern const struct net_buf_data_cb net_buf_fixed_cb;
+
 /** @endcond */
 
 /**

--- a/include/zephyr/net/canbus.h
+++ b/include/zephyr/net/canbus.h
@@ -4,8 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_NET_CAN_H_
-#define ZEPHYR_INCLUDE_NET_CAN_H_
+/** @file
+ *  @brief CAN bus socket API definitions.
+ */
+
+#ifndef ZEPHYR_INCLUDE_NET_CANBUS_H_
+#define ZEPHYR_INCLUDE_NET_CANBUS_H_
 
 #include <zephyr/types.h>
 #include <zephyr/net/net_ip.h>
@@ -52,4 +56,4 @@ BUILD_ASSERT(offsetof(struct canbus_api, iface_api) == 0);
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_NET_CAN_H_ */
+#endif /* ZEPHYR_INCLUDE_NET_CANBUS_H_ */

--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -82,11 +82,15 @@ enum coap_method {
 	COAP_METHOD_IPATCH = 7,  /**< IPATCH */
 };
 
+/** @cond INTERNAL_HIDDEN */
+
 #define COAP_REQUEST_MASK 0x07
 
 #define COAP_VERSION_1 1U
 
 #define COAP_OBSERVE_MAX_AGE 0xFFFFFF
+
+/** @endcond */
 
 /**
  * @brief CoAP packets may be of one of these types.
@@ -193,9 +197,13 @@ enum coap_response_code {
 						COAP_MAKE_RESPONSE_CODE(5, 5)
 };
 
+/** @cond INTERNAL_HIDDEN */
+
 #define COAP_CODE_EMPTY (0)
 
 #define COAP_TOKEN_MAX_LEN 8UL
+
+/** @endcond */
 
 /**
  * @brief Set of Content-Format option values for CoAP.
@@ -214,10 +222,14 @@ enum coap_content_format {
 	COAP_CONTENT_FORMAT_APP_CBOR = 60               /**< application/cbor */
 };
 
+/** @cond INTERNAL_HIDDEN */
+
 /* block option helper */
 #define GET_BLOCK_NUM(v)        ((v) >> 4)
 #define GET_BLOCK_SIZE(v)       (((v) & 0x7))
 #define GET_MORE(v)             (!!((v) & 0x08))
+
+/** @endcond */
 
 struct coap_observer;
 struct coap_packet;
@@ -251,10 +263,15 @@ typedef void (*coap_notify_t)(struct coap_resource *resource,
 struct coap_resource {
 	/** Which function to be called for each CoAP method */
 	coap_method_t get, post, put, del, fetch, patch, ipatch;
+	/** Notify function to call */
 	coap_notify_t notify;
+	/** Resource path */
 	const char * const *path;
+	/** User specific opaque data */
 	void *user_data;
+	/** List of resource observers */
 	sys_slist_t observers;
+	/** Resource age */
 	int age;
 };
 
@@ -262,9 +279,13 @@ struct coap_resource {
  * @brief Represents a remote device that is observing a local resource.
  */
 struct coap_observer {
+	/** Observer list node */
 	sys_snode_t list;
+	/** Observer connection end point information */
 	struct sockaddr addr;
+	/** Observer token */
 	uint8_t token[8];
+	/** Extended token length */
 	uint8_t tkl;
 };
 
@@ -344,11 +365,17 @@ struct coap_pending {
  * also used when observing resources.
  */
 struct coap_reply {
+	/** CoAP reply callback */
 	coap_reply_t reply;
+	/** User specific opaque data */
 	void *user_data;
+	/** Reply age */
 	int age;
+	/** Reply id */
 	uint16_t id;
+	/** Reply token */
 	uint8_t token[8];
+	/** Extended token length */
 	uint8_t tkl;
 };
 
@@ -721,8 +748,11 @@ static inline enum coap_block_size coap_bytes_to_block_size(uint16_t bytes)
  * @brief Represents the current state of a block-wise transaction.
  */
 struct coap_block_context {
+	/** Total size of the block-wise transaction */
 	size_t total_size;
+	/** Current size of the block-wise transaction */
 	size_t current;
+	/** Block size */
 	enum coap_block_size block_size;
 };
 

--- a/include/zephyr/net/coap_client.h
+++ b/include/zephyr/net/coap_client.h
@@ -22,7 +22,7 @@
 #include <zephyr/net/coap.h>
 #include <zephyr/kernel.h>
 
-
+/** Maximum size of a CoAP message */
 #define MAX_COAP_MSG_LEN (CONFIG_COAP_CLIENT_MESSAGE_HEADER_SIZE + \
 			  CONFIG_COAP_CLIENT_MESSAGE_SIZE)
 
@@ -67,12 +67,17 @@ struct coap_client_request {
  * @brief Representation of extra options for the CoAP client request
  */
 struct coap_client_option {
+	/** Option code */
 	uint16_t code;
 #if defined(CONFIG_COAP_EXTENDED_OPTIONS_LEN)
+	/** Option len */
 	uint16_t len;
+	/** Buffer for the length */
 	uint8_t value[CONFIG_COAP_EXTENDED_OPTIONS_LEN_VALUE];
 #else
+	/** Option len */
 	uint8_t len;
+	/** Buffer for the length */
 	uint8_t value[12];
 #endif
 };

--- a/include/zephyr/net/coap_link_format.h
+++ b/include/zephyr/net/coap_link_format.h
@@ -70,7 +70,9 @@ int coap_well_known_core_get_len(struct coap_resource *resources,
  * to a valid coap_core_metadata structure.
  */
 struct coap_core_metadata {
+	/** List of attributes to add */
 	const char * const *attributes;
+	/** User specific data */
 	void *user_data;
 };
 

--- a/include/zephyr/net/coap_mgmt.h
+++ b/include/zephyr/net/coap_mgmt.h
@@ -38,8 +38,6 @@ struct coap_service;
 struct coap_resource;
 struct coap_observer;
 
-/** @endcond */
-
 enum net_event_coap_cmd {
 	/* Service events */
 	NET_EVENT_COAP_CMD_SERVICE_STARTED = 1,
@@ -48,6 +46,8 @@ enum net_event_coap_cmd {
 	NET_EVENT_COAP_CMD_OBSERVER_ADDED,
 	NET_EVENT_COAP_CMD_OBSERVER_REMOVED,
 };
+
+/** @endcond */
 
 /**
  * @brief coap_mgmt event raised when a service has started
@@ -77,7 +77,7 @@ enum net_event_coap_cmd {
  * @brief CoAP Service event structure.
  */
 struct net_event_coap_service {
-	/* The CoAP service for which the event is emitted */
+	/** The CoAP service for which the event is emitted */
 	const struct coap_service *service;
 };
 
@@ -85,9 +85,9 @@ struct net_event_coap_service {
  * @brief CoAP Observer event structure.
  */
 struct net_event_coap_observer {
-	/* The CoAP resource for which the event is emitted */
+	/** The CoAP resource for which the event is emitted */
 	struct coap_resource *resource;
-	/* The observer that is added/removed */
+	/** The observer that is added/removed */
 	struct coap_observer *observer;
 };
 

--- a/include/zephyr/net/conn_mgr_connectivity.h
+++ b/include/zephyr/net/conn_mgr_connectivity.h
@@ -41,12 +41,12 @@ extern "C" {
 						 NET_MGMT_EVENT_BIT)
 #define _NET_MGMT_CONN_IF_EVENT			(NET_MGMT_IFACE_BIT | _NET_MGMT_CONN_BASE)
 
-/** @endcond */
-
 enum net_event_conn_cmd {
 	NET_EVENT_CONN_CMD_IF_TIMEOUT = 1,
 	NET_EVENT_CONN_CMD_IF_FATAL_ERROR,
 };
+
+/** @endcond */
 
 /**
  * @brief net_mgmt event raised when a connection attempt times out

--- a/include/zephyr/net/conn_mgr_monitor.h
+++ b/include/zephyr/net/conn_mgr_monitor.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief API for monitoring network connections and interfaces.
+ */
+
 #ifndef ZEPHYR_INCLUDE_CONN_MGR_H_
 #define ZEPHYR_INCLUDE_CONN_MGR_H_
 

--- a/include/zephyr/net/dhcpv4.h
+++ b/include/zephyr/net/dhcpv4.h
@@ -54,14 +54,14 @@ enum net_dhcpv4_state {
  * within corresponding changes to net_dhcpv4_msg_type_name.
  */
 enum net_dhcpv4_msg_type {
-	NET_DHCPV4_MSG_TYPE_DISCOVER	= 1,
-	NET_DHCPV4_MSG_TYPE_OFFER	= 2,
-	NET_DHCPV4_MSG_TYPE_REQUEST	= 3,
-	NET_DHCPV4_MSG_TYPE_DECLINE	= 4,
-	NET_DHCPV4_MSG_TYPE_ACK		= 5,
-	NET_DHCPV4_MSG_TYPE_NAK		= 6,
-	NET_DHCPV4_MSG_TYPE_RELEASE	= 7,
-	NET_DHCPV4_MSG_TYPE_INFORM	= 8,
+	NET_DHCPV4_MSG_TYPE_DISCOVER	= 1, /**< Discover message */
+	NET_DHCPV4_MSG_TYPE_OFFER	= 2, /**< Offer message */
+	NET_DHCPV4_MSG_TYPE_REQUEST	= 3, /**< Request message */
+	NET_DHCPV4_MSG_TYPE_DECLINE	= 4, /**< Decline message */
+	NET_DHCPV4_MSG_TYPE_ACK		= 5, /**< Acknowledge message */
+	NET_DHCPV4_MSG_TYPE_NAK		= 6, /**< Negative acknowledge message */
+	NET_DHCPV4_MSG_TYPE_RELEASE	= 7, /**< Release message */
+	NET_DHCPV4_MSG_TYPE_INFORM	= 8, /**< Inform message */
 };
 
 struct net_dhcpv4_option_callback;

--- a/include/zephyr/net/dns_resolve.h
+++ b/include/zephyr/net/dns_resolve.h
@@ -88,9 +88,13 @@ enum dns_query_type {
  * Address info struct is passed to callback that gets all the results.
  */
 struct dns_addrinfo {
+	/** IP address information */
 	struct sockaddr ai_addr;
+	/** Length of the ai_addr field */
 	socklen_t       ai_addrlen;
-	uint8_t            ai_family;
+	/** Address family of the address information */
+	uint8_t         ai_family;
+	/** Canonical name of the address */
 	char            ai_canonname[DNS_MAX_NAME_SIZE + 1];
 };
 
@@ -157,16 +161,21 @@ typedef void (*dns_resolve_cb_t)(enum dns_resolve_status status,
 				 struct dns_addrinfo *info,
 				 void *user_data);
 
+/** @cond INTERNAL_HIDDEN */
+
 enum dns_resolve_context_state {
 	DNS_RESOLVE_CONTEXT_ACTIVE,
 	DNS_RESOLVE_CONTEXT_DEACTIVATING,
 	DNS_RESOLVE_CONTEXT_INACTIVE,
 };
 
+/** @endcond */
+
 /**
  * DNS resolve context structure.
  */
 struct dns_resolve_context {
+	/** List of configured DNS servers */
 	struct {
 		/** DNS server information */
 		struct sockaddr dns_server;

--- a/include/zephyr/net/dsa.h
+++ b/include/zephyr/net/dsa.h
@@ -21,6 +21,8 @@
  * @{
  */
 
+/** @cond INTERNAL_HIDDEN */
+
 #define NET_DSA_PORT_MAX_COUNT 8
 #define DSA_STATUS_PERIOD_MS K_MSEC(1000)
 
@@ -33,6 +35,8 @@
 #else
 #define DSA_TAG_SIZE 0
 #endif
+
+/** @endcond */
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/net/dummy.h
+++ b/include/zephyr/net/dummy.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/** @file
+ * @brief Dummy layer 2
+ *
+ * This is not to be included by the application.
+ */
 
 #ifndef ZEPHYR_INCLUDE_NET_DUMMY_H_
 #define ZEPHYR_INCLUDE_NET_DUMMY_H_
@@ -22,6 +27,7 @@ extern "C" {
  * @{
  */
 
+/** Dummy L2 API operations. */
 struct dummy_api {
 	/**
 	 * The net_if_api must be placed in first position in this

--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -20,11 +20,7 @@
 
 #include <zephyr/net/net_ip.h>
 #include <zephyr/net/net_pkt.h>
-
-#if defined(CONFIG_NET_LLDP)
 #include <zephyr/net/lldp.h>
-#endif
-
 #include <zephyr/sys/util.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/ethernet_vlan.h>
@@ -49,13 +45,14 @@ extern "C" {
  * @{
  */
 
-#define NET_ETH_ADDR_LEN		6U
+#define NET_ETH_ADDR_LEN		6U /**< Ethernet MAC address length */
+
+/** Ethernet address */
+struct net_eth_addr {
+	uint8_t addr[NET_ETH_ADDR_LEN]; /**< Buffer storing the address */
+};
 
 /** @cond INTERNAL_HIDDEN */
-
-struct net_eth_addr {
-	uint8_t addr[NET_ETH_ADDR_LEN];
-};
 
 #define NET_ETH_HDR(pkt) ((struct net_eth_hdr *)net_pkt_data(pkt))
 
@@ -108,8 +105,12 @@ struct net_eth_addr {
 #define ETH_P_HDLC	NET_ETH_PTYPE_HDLC
 #endif
 
-#define NET_ETH_MINIMAL_FRAME_SIZE	60
-#define NET_ETH_MTU			1500
+/** @endcond */
+
+#define NET_ETH_MINIMAL_FRAME_SIZE	60   /**< Minimum Ethernet frame size */
+#define NET_ETH_MTU			1500 /**< Ethernet MTU size */
+
+/** @cond INTERNAL_HIDDEN */
 
 #if defined(CONFIG_NET_VLAN)
 #define _NET_ETH_MAX_HDR_SIZE		(sizeof(struct net_eth_vlan_hdr))
@@ -134,7 +135,7 @@ struct net_eth_addr {
 
 /** @endcond */
 
-/** Ethernet hardware capabilities */
+/** @brief Ethernet hardware capabilities */
 enum ethernet_hw_caps {
 	/** TX Checksum offloading supported for all of IPv4, UDP, TCP */
 	ETHERNET_HW_TX_CHKSUM_OFFLOAD	= BIT(0),
@@ -181,8 +182,10 @@ enum ethernet_hw_caps {
 	/** VLAN Tag stripping */
 	ETHERNET_HW_VLAN_TAG_STRIP	= BIT(14),
 
-	/** DSA switch */
-	ETHERNET_DSA_SLAVE_PORT	= BIT(15),
+	/** DSA switch slave port */
+	ETHERNET_DSA_SLAVE_PORT		= BIT(15),
+
+	/** DSA switch master port */
 	ETHERNET_DSA_MASTER_PORT	= BIT(16),
 
 	/** IEEE 802.1Qbv (scheduled traffic) supported */
@@ -230,11 +233,14 @@ enum ethernet_t1s_param_type {
 };
 
 /** @endcond */
+
+/** Ethernet T1S specific parameters */
 struct ethernet_t1s_param {
 	/** Type of T1S parameter */
 	enum ethernet_t1s_param_type type;
 	union {
-		/* PLCA is the Physical Layer (PHY) Collision
+		/**
+		 * PLCA is the Physical Layer (PHY) Collision
 		 * Avoidance technique employed with multidrop
 		 * 10Base-T1S standard.
 		 *
@@ -273,6 +279,7 @@ struct ethernet_t1s_param {
 	};
 };
 
+/** Ethernet Qav specific parameters */
 struct ethernet_qav_param {
 	/** ID of the priority queue to use */
 	int queue_id;
@@ -314,6 +321,7 @@ enum ethernet_gate_state_operation {
 
 /** @endcond */
 
+/** Ethernet Qbv specific parameters */
 struct ethernet_qbv_param {
 	/** Port id */
 	int port_id;
@@ -325,6 +333,7 @@ struct ethernet_qbv_param {
 		/** True if Qbv is enabled or not */
 		bool enabled;
 
+		/** Gate control information */
 		struct {
 			/** True = open, False = closed */
 			bool gate_status[NET_TC_TX_COUNT];
@@ -342,7 +351,8 @@ struct ethernet_qbv_param {
 		/** Number of entries in gate control list */
 		uint32_t gate_control_list_len;
 
-		/* The time values are set in one go when type is set to
+		/**
+		 * The time values are set in one go when type is set to
 		 * ETHERNET_QBV_PARAM_TYPE_TIME
 		 */
 		struct {
@@ -378,6 +388,7 @@ enum ethernet_qbu_preempt_status {
 
 /** @endcond */
 
+/** Ethernet Qbu specific parameters */
 struct ethernet_qbu_param {
 	/** Port id */
 	int port_id;
@@ -390,8 +401,7 @@ struct ethernet_qbu_param {
 		/** Release advance (nanoseconds) */
 		uint32_t release_advance;
 
-		/** sequence of framePreemptionAdminStatus values.
-		 */
+		/** sequence of framePreemptionAdminStatus values */
 		enum ethernet_qbu_preempt_status
 				frame_preempt_statuses[NET_TC_TX_COUNT];
 
@@ -401,13 +411,13 @@ struct ethernet_qbu_param {
 		/** Link partner status (from Qbr) */
 		bool link_partner_status;
 
-		/** Additional fragment size (from Qbr). The minimum non-final
+		/**
+		 * Additional fragment size (from Qbr). The minimum non-final
 		 * fragment size is (additional_fragment_size + 1) * 64 octets
 		 */
 		uint8_t additional_fragment_size : 2;
 	};
 };
-
 
 /** @cond INTERNAL_HIDDEN */
 
@@ -427,7 +437,7 @@ enum ethernet_if_types {
 	L2_ETH_IF_TYPE_WIFI,
 } __packed;
 
-
+/** Ethernet filter description */
 struct ethernet_filter {
 	/** Type of filter */
 	enum ethernet_filter_type type;
@@ -445,6 +455,7 @@ enum ethernet_txtime_param_type {
 
 /** @endcond */
 
+/** Ethernet TXTIME specific parameters */
 struct ethernet_txtime_param {
 	/** Type of TXTIME parameter */
 	enum ethernet_txtime_param_type type;
@@ -455,6 +466,7 @@ struct ethernet_txtime_param {
 };
 
 /** @cond INTERNAL_HIDDEN */
+
 struct ethernet_config {
 	union {
 		bool auto_negotiation;
@@ -482,8 +494,10 @@ struct ethernet_config {
 		struct ethernet_filter filter;
 	};
 };
+
 /** @endcond */
 
+/** Ethernet L2 API operations. */
 struct ethernet_api {
 	/**
 	 * The net_if_api must be placed in first position in this
@@ -491,11 +505,11 @@ struct ethernet_api {
 	 */
 	struct net_if_api iface_api;
 
-#if defined(CONFIG_NET_STATISTICS_ETHERNET)
 	/** Collect optional ethernet specific statistics. This pointer
 	 * should be set by driver if statistics needs to be collected
 	 * for that driver.
 	 */
+#if defined(CONFIG_NET_STATISTICS_ETHERNET)
 	struct net_stats_eth *(*get_stats)(const struct device *dev);
 #endif
 
@@ -518,18 +532,18 @@ struct ethernet_api {
 			  enum ethernet_config_type type,
 			  struct ethernet_config *config);
 
-#if defined(CONFIG_NET_VLAN)
 	/** The IP stack will call this function when a VLAN tag is enabled
 	 * or disabled. If enable is set to true, then the VLAN tag was added,
 	 * if it is false then the tag was removed. The driver can utilize
 	 * this information if needed.
 	 */
+#if defined(CONFIG_NET_VLAN)
 	int (*vlan_setup)(const struct device *dev, struct net_if *iface,
 			  uint16_t tag, bool enable);
 #endif /* CONFIG_NET_VLAN */
 
-#if defined(CONFIG_PTP_CLOCK)
 	/** Return ptp_clock device that is tied to this ethernet device */
+#if defined(CONFIG_PTP_CLOCK)
 	const struct device *(*get_ptp_clock)(const struct device *dev);
 #endif /* CONFIG_PTP_CLOCK */
 
@@ -537,12 +551,13 @@ struct ethernet_api {
 	int (*send)(const struct device *dev, struct net_pkt *pkt);
 };
 
+/** @cond INTERNAL_HIDDEN */
+
 /* Make sure that the network interface API is properly setup inside
  * Ethernet API struct (it is the first one).
  */
 BUILD_ASSERT(offsetof(struct ethernet_api, iface_api) == 0);
 
-/** @cond INTERNAL_HIDDEN */
 struct net_eth_hdr {
 	struct net_eth_addr dst;
 	struct net_eth_addr src;
@@ -567,7 +582,7 @@ struct ethernet_vlan {
 
 /** @endcond */
 
-#if defined(CONFIG_NET_LLDP)
+/** Ethernet LLDP specific parameters */
 struct ethernet_lldp {
 	/** Used for track timers */
 	sys_snode_t node;
@@ -593,7 +608,8 @@ struct ethernet_lldp {
 	/** LLDP RX callback function */
 	net_lldp_recv_cb_t cb;
 };
-#endif /* CONFIG_NET_LLDP */
+
+/** @cond INTERNAL_HIDDEN */
 
 enum ethernet_flags {
 	ETH_CARRIER_UP,
@@ -671,8 +687,6 @@ struct ethernet_context {
  */
 void ethernet_init(struct net_if *iface);
 
-/** @cond INTERNAL_HIDDEN */
-
 #define ETHERNET_L2_CTX_TYPE	struct ethernet_context
 
 /* Separate header for VLAN as some of device interfaces might not
@@ -688,7 +702,15 @@ struct net_eth_vlan_hdr {
 	uint16_t type;
 } __packed;
 
+/** @endcond */
 
+/**
+ * @brief Check if the Ethernet MAC address is a broadcast address.
+ *
+ * @param addr A valid pointer to a Ethernet MAC address.
+ *
+ * @return true if address is a broadcast address, false if not
+ */
 static inline bool net_eth_is_addr_broadcast(struct net_eth_addr *addr)
 {
 	if (addr->addr[0] == 0xff &&
@@ -703,6 +725,13 @@ static inline bool net_eth_is_addr_broadcast(struct net_eth_addr *addr)
 	return false;
 }
 
+/**
+ * @brief Check if the Ethernet MAC address is unspecified.
+ *
+ * @param addr A valid pointer to a Ethernet MAC address.
+ *
+ * @return true if address is unspecified, false if not
+ */
 static inline bool net_eth_is_addr_unspecified(struct net_eth_addr *addr)
 {
 	if (addr->addr[0] == 0x00 &&
@@ -717,6 +746,13 @@ static inline bool net_eth_is_addr_unspecified(struct net_eth_addr *addr)
 	return false;
 }
 
+/**
+ * @brief Check if the Ethernet MAC address is a multicast address.
+ *
+ * @param addr A valid pointer to a Ethernet MAC address.
+ *
+ * @return true if address is a multicast address, false if not
+ */
 static inline bool net_eth_is_addr_multicast(struct net_eth_addr *addr)
 {
 #if defined(CONFIG_NET_IPV6)
@@ -737,16 +773,37 @@ static inline bool net_eth_is_addr_multicast(struct net_eth_addr *addr)
 	return false;
 }
 
+/**
+ * @brief Check if the Ethernet MAC address is a group address.
+ *
+ * @param addr A valid pointer to a Ethernet MAC address.
+ *
+ * @return true if address is a group address, false if not
+ */
 static inline bool net_eth_is_addr_group(struct net_eth_addr *addr)
 {
 	return addr->addr[0] & 0x01;
 }
 
+/**
+ * @brief Check if the Ethernet MAC address is valid.
+ *
+ * @param addr A valid pointer to a Ethernet MAC address.
+ *
+ * @return true if address is valid, false if not
+ */
 static inline bool net_eth_is_addr_valid(struct net_eth_addr *addr)
 {
 	return !net_eth_is_addr_unspecified(addr) && !net_eth_is_addr_group(addr);
 }
 
+/**
+ * @brief Check if the Ethernet MAC address is a LLDP multicast address.
+ *
+ * @param addr A valid pointer to a Ethernet MAC address.
+ *
+ * @return true if address is a LLDP multicast address, false if not
+ */
 static inline bool net_eth_is_addr_lldp_multicast(struct net_eth_addr *addr)
 {
 #if defined(CONFIG_NET_GPTP) || defined(CONFIG_NET_LLDP)
@@ -758,11 +815,20 @@ static inline bool net_eth_is_addr_lldp_multicast(struct net_eth_addr *addr)
 	    addr->addr[5] == 0x0e) {
 		return true;
 	}
+#else
+	ARG_UNUSED(addr);
 #endif
 
 	return false;
 }
 
+/**
+ * @brief Check if the Ethernet MAC address is a PTP multicast address.
+ *
+ * @param addr A valid pointer to a Ethernet MAC address.
+ *
+ * @return true if address is a PTP multicast address, false if not
+ */
 static inline bool net_eth_is_addr_ptp_multicast(struct net_eth_addr *addr)
 {
 #if defined(CONFIG_NET_GPTP)
@@ -774,14 +840,19 @@ static inline bool net_eth_is_addr_ptp_multicast(struct net_eth_addr *addr)
 	    addr->addr[5] == 0x00) {
 		return true;
 	}
+#else
+	ARG_UNUSED(addr);
 #endif
 
 	return false;
 }
 
+/**
+ * @brief Return Ethernet broadcast address.
+ *
+ * @return Ethernet broadcast address.
+ */
 const struct net_eth_addr *net_eth_broadcast_addr(void);
-
-/** @endcond */
 
 /**
  * @brief Convert IPv4 multicast address to Ethernet address.
@@ -989,6 +1060,8 @@ static inline bool net_eth_is_vlan_interface(struct net_if *iface)
 }
 #endif
 
+/** @cond INTERNAL_HIDDEN */
+
 #if !defined(CONFIG_ETH_DRIVER_RAW_MODE)
 
 #define Z_ETH_NET_DEVICE_INIT_INSTANCE(node_id, dev_id, name, instance,	\
@@ -1016,6 +1089,8 @@ static inline bool net_eth_is_vlan_interface(struct net_if *iface)
 	Z_ETH_NET_DEVICE_INIT_INSTANCE(node_id, dev_id, name, 0,	\
 				       init_fn, pm, data, config, prio,	\
 				       api, mtu)
+
+/** @endcond */
 
 /**
  * @brief Create an Ethernet network interface and bind it to network device.

--- a/include/zephyr/net/ethernet_bridge.h
+++ b/include/zephyr/net/ethernet_bridge.h
@@ -56,6 +56,8 @@ struct eth_bridge {
 	STRUCT_SECTION_ITERABLE(eth_bridge, name) = \
 		ETH_BRIDGE_INITIALIZER(name)
 
+/** @cond INTERNAL_HIDDEN */
+
 struct eth_bridge_iface_context {
 	sys_snode_t node;
 	struct eth_bridge *instance;
@@ -66,6 +68,8 @@ struct eth_bridge_listener {
 	sys_snode_t node;
 	struct k_fifo pkt_queue;
 };
+
+/** @endcond */
 
 /**
  * @brief Add an Ethernet network interface to a bridge

--- a/include/zephyr/net/gptp.h
+++ b/include/zephyr/net/gptp.h
@@ -130,6 +130,7 @@ struct gptp_port_identity {
 	uint16_t port_number;
 } __packed;
 
+/** gPTP message flags */
 struct gptp_flags {
 	union {
 		/** Byte access. */
@@ -140,6 +141,7 @@ struct gptp_flags {
 	};
 } __packed;
 
+/** gPTP message header */
 struct gptp_hdr {
 	/** Type of the message. */
 	uint8_t message_type:4;

--- a/include/zephyr/net/hostname.h
+++ b/include/zephyr/net/hostname.h
@@ -28,16 +28,21 @@ extern "C" {
 	    (sizeof(CONFIG_NET_HOSTNAME) - 1 +                                                     \
 	     (IS_ENABLED(CONFIG_NET_HOSTNAME_UNIQUE) ? sizeof("0011223344556677") - 1 : 0)))
 #else
+/** Maximum hostname length */
 #define NET_HOSTNAME_MAX_LEN                                                                       \
 	(sizeof(CONFIG_NET_HOSTNAME) - 1 +                                                         \
 	 (IS_ENABLED(CONFIG_NET_HOSTNAME_UNIQUE) ? sizeof("0011223344556677") - 1 : 0))
 #endif
+
+/** @cond INTERNAL_HIDDEN */
 
 #if defined(CONFIG_NET_HOSTNAME_ENABLE)
 #define NET_HOSTNAME_SIZE NET_HOSTNAME_MAX_LEN + 1
 #else
 #define NET_HOSTNAME_SIZE 1
 #endif
+
+/** @endcond */
 
 /**
  * @brief Get the device hostname

--- a/include/zephyr/net/http/client.h
+++ b/include/zephyr/net/http/client.h
@@ -30,6 +30,8 @@
 extern "C" {
 #endif
 
+/** @cond INTERNAL_HIDDEN */
+
 #if !defined(HTTP_CRLF)
 #define HTTP_CRLF "\r\n"
 #endif
@@ -38,10 +40,12 @@ extern "C" {
 #define HTTP_STATUS_STR_SIZE	32
 #endif
 
-/* Is there more data to come */
+/** @endcond */
+
+/** Is there more data to come */
 enum http_final_call {
-	HTTP_DATA_MORE = 0,
-	HTTP_DATA_FINAL = 1,
+	HTTP_DATA_MORE = 0,  /**< More data will come */
+	HTTP_DATA_FINAL = 1, /**< End of data */
 };
 
 struct http_request;
@@ -174,7 +178,7 @@ struct http_response {
 	 */
 	size_t processed;
 
-	/* https://tools.ietf.org/html/rfc7230#section-3.1.2
+	/** See https://tools.ietf.org/html/rfc7230#section-3.1.2 for more information.
 	 * The status-code element is a 3-digit integer code
 	 *
 	 * The reason-phrase element exists for the sole
@@ -193,9 +197,9 @@ struct http_response {
 	 */
 	uint16_t http_status_code;
 
-	uint8_t cl_present : 1;
-	uint8_t body_found : 1;
-	uint8_t message_complete : 1;
+	uint8_t cl_present : 1;       /**< Is Content-Length field present */
+	uint8_t body_found : 1;       /**< Is message body found */
+	uint8_t message_complete : 1; /**< Is HTTP message parsing complete */
 };
 
 /** HTTP client internal data that the application should not touch

--- a/include/zephyr/net/http/frame.h
+++ b/include/zephyr/net/http/frame.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief HTTP2 frame information.
+ */
+
 #ifndef ZEPHYR_INCLUDE_NET_HTTP_SERVER_FRAME_H_
 #define ZEPHYR_INCLUDE_NET_HTTP_SERVER_FRAME_H_
 
@@ -13,18 +18,31 @@
 extern "C" {
 #endif
 
+/** HTTP2 frame types */
 enum http_frame_type {
+	/** Data frame */
 	HTTP_SERVER_DATA_FRAME = 0x00,
+	/** Headers frame */
 	HTTP_SERVER_HEADERS_FRAME = 0x01,
+	/** Priority frame */
 	HTTP_SERVER_PRIORITY_FRAME = 0x02,
+	/** Reset stream frame */
 	HTTP_SERVER_RST_STREAM_FRAME = 0x03,
+	/** Settings frame */
 	HTTP_SERVER_SETTINGS_FRAME = 0x04,
+	/** Push promise frame */
 	HTTP_SERVER_PUSH_PROMISE_FRAME = 0x05,
+	/** Ping frame */
 	HTTP_SERVER_PING_FRAME = 0x06,
+	/** Goaway frame */
 	HTTP_SERVER_GOAWAY_FRAME = 0x07,
+	/** Window update frame */
 	HTTP_SERVER_WINDOW_UPDATE_FRAME = 0x08,
+	/** Continuation frame */
 	HTTP_SERVER_CONTINUATION_FRAME = 0x09
 };
+
+/** @cond INTERNAL_HIDDEN */
 
 #define HTTP_SERVER_HPACK_METHOD 0
 #define HTTP_SERVER_HPACK_PATH   1
@@ -39,17 +57,27 @@ enum http_frame_type {
 #define HTTP_SERVER_FRAME_FLAGS_OFFSET     4
 #define HTTP_SERVER_FRAME_STREAM_ID_OFFSET 5
 
+/** @endcond */
+
+/** HTTP2 settings field */
 struct http_settings_field {
-	uint16_t id;
-	uint32_t value;
+	uint16_t id;    /**< Field id */
+	uint32_t value; /**< Field value */
 } __packed;
 
+/** @brief HTTP2 settings */
 enum http_settings {
+	/** Header table size */
 	HTTP_SETTINGS_HEADER_TABLE_SIZE = 1,
+	/** Enable push */
 	HTTP_SETTINGS_ENABLE_PUSH = 2,
+	/** Maximum number of concurrent streams */
 	HTTP_SETTINGS_MAX_CONCURRENT_STREAMS = 3,
+	/** Initial window size */
 	HTTP_SETTINGS_INITIAL_WINDOW_SIZE = 4,
+	/** Max frame size */
 	HTTP_SETTINGS_MAX_FRAME_SIZE = 5,
+	/** Max header list size */
 	HTTP_SETTINGS_MAX_HEADER_LIST_SIZE = 6,
 };
 

--- a/include/zephyr/net/http/hpack.h
+++ b/include/zephyr/net/http/hpack.h
@@ -26,6 +26,8 @@
 extern "C" {
 #endif
 
+/** @cond INTERNAL_HIDDEN */
+
 enum http_hpack_static_key {
 	HTTP_SERVER_HPACK_INVALID = 0,
 	HTTP_SERVER_HPACK_AUTHORITY = 1,
@@ -100,6 +102,8 @@ enum http_hpack_static_key {
 #define HTTP_SERVER_HUFFMAN_DECODE_BUFFER_SIZE 0
 #endif
 
+/** @endcond */
+
 /** HTTP2 header field with decoding buffer. */
 struct http_hpack_header_buf {
 	/** A pointer to the decoded header field name. */
@@ -121,6 +125,8 @@ struct http_hpack_header_buf {
 	size_t datalen;
 };
 
+/** @cond INTERNAL_HIDDEN */
+
 int http_hpack_huffman_decode(const uint8_t *encoded_buf, size_t encoded_len,
 			      uint8_t *buf, size_t buflen);
 int http_hpack_huffman_encode(const uint8_t *str, size_t str_len,
@@ -129,6 +135,8 @@ int http_hpack_decode_header(const uint8_t *buf, size_t datalen,
 			     struct http_hpack_header_buf *header);
 int http_hpack_encode_header(uint8_t *buf, size_t buflen,
 			     struct http_hpack_header_buf *header);
+
+/** @endcond */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/net/http/method.h
+++ b/include/zephyr/net/http/method.h
@@ -58,7 +58,9 @@ enum http_method {
 	HTTP_LINK = 31, /**< LINK */
 	HTTP_UNLINK = 32, /**< UNLINK */
 
+	/** @cond INTERNAL_HIDDEN */
 	HTTP_METHOD_END_VALUE /* keep this the last value */
+	/** @endcond */
 };
 
 #ifdef __cplusplus

--- a/include/zephyr/net/http/server.h
+++ b/include/zephyr/net/http/server.h
@@ -9,7 +9,10 @@
 #define ZEPHYR_INCLUDE_NET_HTTP_SERVER_H_
 
 /**
+ * @file server.h
+ *
  * @brief HTTP server API
+ *
  * @defgroup http_server HTTP server API
  * @ingroup networking
  * @{
@@ -196,12 +199,28 @@ BUILD_ASSERT(offsetof(struct http_resource_detail_dynamic, common) == 0);
 typedef int (*http_resource_websocket_cb_t)(int ws_socket,
 					    void *user_data);
 
+/** @brief Representation of a websocket server resource */
 struct http_resource_detail_websocket {
+	/** Common resource details. */
 	struct http_resource_detail common;
+
+	/** Websocket socket value */
 	int ws_sock;
+
+	/** Resource callback used by the server to interact with the
+	 *  application.
+	 */
 	http_resource_websocket_cb_t cb;
+
+	/** Data buffer used to exchanged data between server and the,
+	 *  application.
+	 */
 	uint8_t *data_buffer;
+
+	/** Length of the data in the data buffer. */
 	size_t data_buffer_len;
+
+	/** A pointer to the user data registered by the application.  */
 	void *user_data;
 };
 
@@ -335,8 +354,10 @@ struct http_client_ctx {
 	 */
 	struct k_work_delayable inactivity_timer;
 
-	/* Websocket security key. */
+/** @cond INTERNAL_HIDDEN */
+	/** Websocket security key. */
 	IF_ENABLED(CONFIG_WEBSOCKET, (uint8_t ws_sec_key[HTTP_SERVER_WS_MAX_SEC_KEY_LEN]));
+/** @endcond */
 
 	/** Flag indicating that headers were sent in the reply. */
 	bool headers_sent : 1;

--- a/include/zephyr/net/http/service.h
+++ b/include/zephyr/net/http/service.h
@@ -8,7 +8,10 @@
 #define ZEPHYR_INCLUDE_NET_HTTP_SERVICE_H_
 
 /**
+ * @file service.h
+ *
  * @brief HTTP service API
+ *
  * @defgroup http_service HTTP service API
  * @ingroup networking
  * @{
@@ -25,8 +28,11 @@
 extern "C" {
 #endif
 
+/** HTTP resource description */
 struct http_resource_desc {
+	/** Resource name */
 	const char *resource;
+	/** Detail associated with this resource */
 	void *detail;
 };
 
@@ -53,6 +59,8 @@ struct http_resource_desc {
 		.resource = _resource,                                                             \
 		.detail = (void *)(_detail),                                                       \
 	}
+
+/** @cond INTERNAL_HIDDEN */
 
 struct http_service_desc {
 	const char *host;
@@ -85,6 +93,8 @@ struct http_service_desc {
 			    (.sec_tag_list_size = COND_CODE_0(NUM_VA_ARGS_LESS_1(__VA_ARGS__), (0),\
 					     (GET_ARG_N(1, GET_ARGS_LESS_N(1, __VA_ARGS__))))), ())\
 	}
+
+/** @endcond */
 
 /**
  * @brief Define an HTTP service without static resources.
@@ -207,7 +217,7 @@ struct http_service_desc {
 /**
  * @brief Iterate over all HTTP services.
  *
- * @param _it Name of iterator (of type @ref http_service_desc)
+ * @param _it Name of http_service_desc iterator
  */
 #define HTTP_SERVICE_FOREACH(_it) STRUCT_SECTION_FOREACH(http_service_desc, _it)
 

--- a/include/zephyr/net/icmp.h
+++ b/include/zephyr/net/icmp.h
@@ -6,10 +6,11 @@
 
 /** @file icmp.h
  *
+ * @brief ICMP sending and receiving.
+ *
  * @defgroup icmp Send and receive IPv4 or IPv6 ICMP Echo Request messages.
  * @ingroup networking
  * @{
- * @brief ICMP sending and receiving.
  */
 
 #ifndef ZEPHYR_INCLUDE_NET_ICMP_H_
@@ -27,10 +28,10 @@
 extern "C" {
 #endif
 
-#define NET_ICMPV4_ECHO_REQUEST 8
-#define NET_ICMPV4_ECHO_REPLY   0
-#define NET_ICMPV6_ECHO_REQUEST 128
-#define NET_ICMPV6_ECHO_REPLY   129
+#define NET_ICMPV4_ECHO_REQUEST 8    /**< ICMPv4 Echo-Request */
+#define NET_ICMPV4_ECHO_REPLY   0    /**< ICMPv4 Echo-Reply */
+#define NET_ICMPV6_ECHO_REQUEST 128  /**< ICMPv6 Echo-Request */
+#define NET_ICMPV6_ECHO_REPLY   129  /**< ICMPv6 Echo-Reply */
 
 struct net_icmp_ctx;
 struct net_icmp_ip_hdr;
@@ -136,7 +137,7 @@ struct net_icmp_ping_params {
 	/** Network packet priority. */
 	int priority;
 
-	/* Arbitrary payload data that will be included in the Echo Reply
+	/** Arbitrary payload data that will be included in the Echo Reply
 	 * verbatim. May be NULL.
 	 */
 	const void *data;

--- a/include/zephyr/net/ieee802154.h
+++ b/include/zephyr/net/ieee802154.h
@@ -241,10 +241,11 @@ struct ieee802154_security_ctx {
 	/** INTERNAL_HIDDEN @endcond */
 };
 
+/** @brief IEEE 802.15.4 device role */
 enum ieee802154_device_role {
-	IEEE802154_DEVICE_ROLE_ENDDEVICE,
-	IEEE802154_DEVICE_ROLE_COORDINATOR,
-	IEEE802154_DEVICE_ROLE_PAN_COORDINATOR,
+	IEEE802154_DEVICE_ROLE_ENDDEVICE,       /**< End device */
+	IEEE802154_DEVICE_ROLE_COORDINATOR,     /**< Coordinator */
+	IEEE802154_DEVICE_ROLE_PAN_COORDINATOR, /**< PAN coordinator */
 };
 
 /** IEEE 802.15.4 L2 context. */

--- a/include/zephyr/net/ieee802154_ie.h
+++ b/include/zephyr/net/ieee802154_ie.h
@@ -40,8 +40,8 @@
  * @details See sections 7.4.2.1 and 7.4.3.1.
  */
 enum ieee802154_ie_type {
-	IEEE802154_IE_TYPE_HEADER = 0x0,
-	IEEE802154_IE_TYPE_PAYLOAD,
+	IEEE802154_IE_TYPE_HEADER = 0x0, /**< Header type */
+	IEEE802154_IE_TYPE_PAYLOAD,      /**< Payload type */
 };
 
 /**
@@ -51,13 +51,13 @@ enum ieee802154_ie_type {
  * are implemented.
  */
 enum ieee802154_header_ie_element_id {
-	IEEE802154_HEADER_IE_ELEMENT_ID_VENDOR_SPECIFIC_IE = 0x00,
-	IEEE802154_HEADER_IE_ELEMENT_ID_CSL_IE = 0x1a,
-	IEEE802154_HEADER_IE_ELEMENT_ID_RIT_IE = 0x1b,
-	IEEE802154_HEADER_IE_ELEMENT_ID_RENDEZVOUS_TIME_IE = 0x1d,
-	IEEE802154_HEADER_IE_ELEMENT_ID_TIME_CORRECTION_IE = 0x1e,
-	IEEE802154_HEADER_IE_ELEMENT_ID_HEADER_TERMINATION_1 = 0x7e,
-	IEEE802154_HEADER_IE_ELEMENT_ID_HEADER_TERMINATION_2 = 0x7f,
+	IEEE802154_HEADER_IE_ELEMENT_ID_VENDOR_SPECIFIC_IE = 0x00,   /**< Vendor specific IE */
+	IEEE802154_HEADER_IE_ELEMENT_ID_CSL_IE = 0x1a,	             /**< CSL IE */
+	IEEE802154_HEADER_IE_ELEMENT_ID_RIT_IE = 0x1b,               /**< RIT IE */
+	IEEE802154_HEADER_IE_ELEMENT_ID_RENDEZVOUS_TIME_IE = 0x1d,   /**< Rendezvous time IE */
+	IEEE802154_HEADER_IE_ELEMENT_ID_TIME_CORRECTION_IE = 0x1e,   /**< Time correction IE */
+	IEEE802154_HEADER_IE_ELEMENT_ID_HEADER_TERMINATION_1 = 0x7e, /**< Header termination 1 */
+	IEEE802154_HEADER_IE_ELEMENT_ID_HEADER_TERMINATION_2 = 0x7f, /**< Header termination 2 */
 	/* partial list, add additional ids as needed */
 };
 
@@ -67,36 +67,40 @@ enum ieee802154_header_ie_element_id {
 
 /** @brief Vendor Specific Header IE, see section 7.4.2.3. */
 struct ieee802154_header_ie_vendor_specific {
+	/** Vendor OUI */
 	uint8_t vendor_oui[IEEE802154_VENDOR_SPECIFIC_IE_OUI_LEN];
+	/** Vendor specific information */
 	uint8_t *vendor_specific_info;
 } __packed;
 
 /** @brief Full CSL IE, see section 7.4.2.3. */
 struct ieee802154_header_ie_csl_full {
-	uint16_t csl_phase;
-	uint16_t csl_period;
-	uint16_t csl_rendezvous_time;
+	uint16_t csl_phase;           /**< CSL phase */
+	uint16_t csl_period;          /**< CSL period */
+	uint16_t csl_rendezvous_time; /**< Rendezvous time */
 } __packed;
 
 /** @brief Reduced CSL IE, see section 7.4.2.3. */
 struct ieee802154_header_ie_csl_reduced {
-	uint16_t csl_phase;
-	uint16_t csl_period;
+	uint16_t csl_phase;  /**< CSL phase */
+	uint16_t csl_period; /**< CSL period */
 } __packed;
 
 /** @brief Generic CSL IE, see section 7.4.2.3. */
 struct ieee802154_header_ie_csl {
 	union {
+		/** CSL full information */
 		struct ieee802154_header_ie_csl_full full;
+		/** CSL reduced information */
 		struct ieee802154_header_ie_csl_reduced reduced;
 	};
 } __packed;
 
 /** @brief RIT IE, see section 7.4.2.4. */
 struct ieee802154_header_ie_rit {
-	uint8_t time_to_first_listen;
-	uint8_t number_of_repeat_listen;
-	uint16_t repeat_listen_interval;
+	uint8_t time_to_first_listen;    /**< Time to First Listen */
+	uint8_t number_of_repeat_listen; /**< Number of Repeat Listen */
+	uint16_t repeat_listen_interval; /**< Repeat listen interval */
 } __packed;
 
 /**
@@ -104,8 +108,8 @@ struct ieee802154_header_ie_rit {
  * (macCslInterval is nonzero).
  */
 struct ieee802154_header_ie_rendezvous_time_full {
-	uint16_t rendezvous_time;
-	uint16_t wakeup_interval;
+	uint16_t rendezvous_time; /**< Rendezvous time */
+	uint16_t wakeup_interval; /**< Wakeup interval */
 } __packed;
 
 /**
@@ -113,21 +117,25 @@ struct ieee802154_header_ie_rendezvous_time_full {
  * (macCslInterval is zero).
  */
 struct ieee802154_header_ie_rendezvous_time_reduced {
-	uint16_t rendezvous_time;
+	uint16_t rendezvous_time; /**< Rendezvous time */
 } __packed;
 
 /** @brief Rendezvous Time IE, see section 7.4.2.6. */
 struct ieee802154_header_ie_rendezvous_time {
 	union {
+		/** Rendezvous time full information */
 		struct ieee802154_header_ie_rendezvous_time_full full;
+		/** Rendezvous time reduced information */
 		struct ieee802154_header_ie_rendezvous_time_reduced reduced;
 	};
 } __packed;
 
 /** @brief Time Correction IE, see section 7.4.2.7. */
 struct ieee802154_header_ie_time_correction {
-	uint16_t time_sync_info;
+	uint16_t time_sync_info;  /**< Time synchronization information */
 } __packed;
+
+/** @cond INTERNAL_HIDDEN */
 
 /* @brief Generic Header IE, see section 7.4.2.1. */
 struct ieee802154_header_ie {
@@ -151,6 +159,8 @@ struct ieee802154_header_ie {
 		/* add additional supported header IEs here */
 	} content;
 } __packed;
+
+/** INTERNAL_HIDDEN @endcond */
 
 /** @brief The header IE's header length (2 bytes). */
 #define IEEE802154_HEADER_IE_HEADER_LENGTH sizeof(uint16_t)

--- a/include/zephyr/net/ieee802154_mgmt.h
+++ b/include/zephyr/net/ieee802154_mgmt.h
@@ -322,8 +322,8 @@ struct ieee802154_req_params {
 
 	/** Result address */
 	union {
-		uint16_t short_addr;			  /* in CPU byte order */
-		uint8_t addr[IEEE802154_MAX_ADDR_LENGTH]; /* in big endian */
+		uint16_t short_addr;			  /**< in CPU byte order */
+		uint8_t addr[IEEE802154_MAX_ADDR_LENGTH]; /**< in big endian */
 	};
 
 	/** length of address */
@@ -339,13 +339,13 @@ struct ieee802154_req_params {
  * see tables 9-9 and 9-10 in section 9.5.
  */
 struct ieee802154_security_params {
-	uint8_t key[16];      /* secKeyDescriptor.secKey */
-	uint8_t key_len;      /* a key length of 16 bytes is mandatory for standards conformance */
-	uint8_t key_mode : 2; /* secKeyIdMode */
-	uint8_t level : 3;    /* Used instead of a frame-specific SecurityLevel parameter when
+	uint8_t key[16];      /**< secKeyDescriptor.secKey */
+	uint8_t key_len;      /**< Key length of 16 bytes is mandatory for standards conformance */
+	uint8_t key_mode : 2; /**< secKeyIdMode */
+	uint8_t level : 3;    /**< Used instead of a frame-specific SecurityLevel parameter when
 			       * constructing the auxiliary security header
 			       */
-	uint8_t _unused : 3;
+	uint8_t _unused : 3;  /**< unused value (ignore) */
 };
 
 #ifdef __cplusplus

--- a/include/zephyr/net/ieee802154_radio.h
+++ b/include/zephyr/net/ieee802154_radio.h
@@ -233,8 +233,8 @@ enum ieee802154_phy_channel_page {
  * ieee802154_phy_supported_channels.
  */
 struct ieee802154_phy_channel_range {
-	uint16_t from_channel;
-	uint16_t to_channel;
+	uint16_t from_channel; /**< From channel range */
+	uint16_t to_channel;   /**< To channel range */
 };
 
 /**
@@ -533,11 +533,11 @@ enum ieee802154_hw_caps {
 
 /** Filter type, see @ref ieee802154_radio_api::filter */
 enum ieee802154_filter_type {
-	IEEE802154_FILTER_TYPE_IEEE_ADDR,
-	IEEE802154_FILTER_TYPE_SHORT_ADDR,
-	IEEE802154_FILTER_TYPE_PAN_ID,
-	IEEE802154_FILTER_TYPE_SRC_IEEE_ADDR,
-	IEEE802154_FILTER_TYPE_SRC_SHORT_ADDR,
+	IEEE802154_FILTER_TYPE_IEEE_ADDR,      /**< Address type filter */
+	IEEE802154_FILTER_TYPE_SHORT_ADDR,     /**< Short address type filter */
+	IEEE802154_FILTER_TYPE_PAN_ID,         /**< PAN id type filter */
+	IEEE802154_FILTER_TYPE_SRC_IEEE_ADDR,  /**< Source address type filter */
+	IEEE802154_FILTER_TYPE_SRC_SHORT_ADDR, /**< Source short address type filter */
 };
 
 /** Driver events, see @ref IEEE802154_CONFIG_EVENT_HANDLER */
@@ -1125,15 +1125,15 @@ struct ieee802154_config {
 	union {
 		/** see @ref IEEE802154_CONFIG_AUTO_ACK_FPB */
 		struct {
-			bool enabled;
-			enum ieee802154_fpb_mode mode;
+			bool enabled;                  /**< Is auto ACK FPB enabled */
+			enum ieee802154_fpb_mode mode; /**< Auto ACK FPB mode */
 		} auto_ack_fpb;
 
 		/** see @ref IEEE802154_CONFIG_ACK_FPB */
 		struct {
-			uint8_t *addr; /* in little endian for both, short and extended address */
-			bool extended;
-			bool enabled;
+			uint8_t *addr; /**< little endian for both short and extended address */
+			bool extended; /**< Is extended address */
+			bool enabled;  /**< Is enabled */
 		} ack_fpb;
 
 		/** see @ref IEEE802154_CONFIG_PAN_COORDINATOR */
@@ -1194,6 +1194,9 @@ struct ieee802154_config {
 			 */
 			net_time_t duration;
 
+			/**
+			 * Used channel
+			 */
 			uint8_t channel;
 		} rx_slot;
 

--- a/include/zephyr/net/ieee802154_radio_openthread.h
+++ b/include/zephyr/net/ieee802154_radio_openthread.h
@@ -25,6 +25,7 @@ enum ieee802154_openthread_hw_caps {
 	IEEE802154_OPENTHREAD_HW_MULTIPLE_CCA = BIT(IEEE802154_HW_CAPS_BITS_PRIV_START),
 };
 
+/** @brief TX mode */
 enum ieee802154_openthread_tx_mode {
 	/**
 	 * The @ref IEEE802154_OPENTHREAD_TX_MODE_TXTIME_MULTIPLE_CCA mode allows to send
@@ -93,6 +94,7 @@ enum ieee802154_openthread_config_type {
 /** OpenThread specific configuration data of ieee802154 driver. */
 struct ieee802154_openthread_config {
 	union {
+		/** Common configuration */
 		struct ieee802154_config common;
 
 		/** ``IEEE802154_OPENTHREAD_CONFIG_MAX_EXTRA_CCA_ATTEMPTS``
@@ -134,6 +136,7 @@ enum ieee802154_openthread_attr {
  */
 struct ieee802154_openthread_attr_value {
 	union {
+		/** Common attribute value */
 		struct ieee802154_attr_value common;
 
 		/** @brief Attribute value for @ref IEEE802154_OPENTHREAD_ATTR_T_RECCA */

--- a/include/zephyr/net/igmp.h
+++ b/include/zephyr/net/igmp.h
@@ -27,10 +27,11 @@
 extern "C" {
 #endif
 
+/** IGMP parameters */
 struct igmp_param {
-	struct in_addr *source_list; /* List of sources to include or exclude */
-	size_t sources_len;          /* Length of source list */
-	bool include;                /* Source list filter type */
+	struct in_addr *source_list; /**< List of sources to include or exclude */
+	size_t sources_len;          /**< Length of source list */
+	bool include;                /**< Source list filter type */
 };
 
 /**

--- a/include/zephyr/net/ipv4_autoconf.h
+++ b/include/zephyr/net/ipv4_autoconf.h
@@ -13,12 +13,14 @@
 
 /** Current state of IPv4 Autoconfiguration */
 enum net_ipv4_autoconf_state {
-	NET_IPV4_AUTOCONF_INIT,
-	NET_IPV4_AUTOCONF_PROBE,
-	NET_IPV4_AUTOCONF_ANNOUNCE,
-	NET_IPV4_AUTOCONF_ASSIGNED,
-	NET_IPV4_AUTOCONF_RENEW,
+	NET_IPV4_AUTOCONF_INIT,     /**< Initialization state */
+	NET_IPV4_AUTOCONF_PROBE,    /**< Probing state */
+	NET_IPV4_AUTOCONF_ANNOUNCE, /**< Announce state */
+	NET_IPV4_AUTOCONF_ASSIGNED, /**< Assigned state */
+	NET_IPV4_AUTOCONF_RENEW,    /**< Renew state */
 };
+
+/** @cond INTERNAL_HIDDEN */
 
 /**
  * @brief Initialize IPv4 auto configuration engine.
@@ -28,5 +30,7 @@ void net_ipv4_autoconf_init(void);
 #else
 #define net_ipv4_autoconf_init(...)
 #endif
+
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_NET_IPV4_AUTOCONF_H_ */

--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -7,11 +7,6 @@
 
 /** @file lwm2m.h
  *
- * @defgroup lwm2m_api LwM2M high-level API
- * @since 1.9
- * @version 0.8.0
- * @ingroup networking
- * @{
  * @brief LwM2M high-level API
  *
  * @details
@@ -21,6 +16,12 @@
  *
  * @note For more information refer to Technical Specification
  * OMA-TS-LightweightM2M_Core-V1_1_1-20190617-A
+ *
+ * @defgroup lwm2m_api LwM2M high-level API
+ * @since 1.9
+ * @version 0.8.0
+ * @ingroup networking
+ * @{
  */
 
 #ifndef ZEPHYR_INCLUDE_NET_LWM2M_H_
@@ -283,7 +284,9 @@ struct lwm2m_ctx {
 struct lwm2m_time_series_elem {
 	/** Cached data Unix timestamp */
 	time_t t;
+	/** Element value */
 	union {
+		/** @cond INTERNAL_HIDDEN */
 		uint8_t u8;
 		uint16_t u16;
 		uint32_t u32;
@@ -295,6 +298,7 @@ struct lwm2m_time_series_elem {
 		time_t time;
 		double f;
 		bool b;
+		/** @endcond */
 	};
 };
 
@@ -2144,21 +2148,37 @@ void lwm2m_acknowledge(struct lwm2m_ctx *client_ctx);
  * lwm2m_rd_client_start()
  */
 enum lwm2m_rd_client_event {
+	/** Invalid event */
 	LWM2M_RD_CLIENT_EVENT_NONE,
+	/** Bootstrap registration failure */
 	LWM2M_RD_CLIENT_EVENT_BOOTSTRAP_REG_FAILURE,
+	/** Bootstrap registration complete */
 	LWM2M_RD_CLIENT_EVENT_BOOTSTRAP_REG_COMPLETE,
+	/** Bootstrap transfer complete */
 	LWM2M_RD_CLIENT_EVENT_BOOTSTRAP_TRANSFER_COMPLETE,
+	/** Registration failure */
 	LWM2M_RD_CLIENT_EVENT_REGISTRATION_FAILURE,
+	/** Registration complete */
 	LWM2M_RD_CLIENT_EVENT_REGISTRATION_COMPLETE,
+	/** Registration timeout */
 	LWM2M_RD_CLIENT_EVENT_REG_TIMEOUT,
+	/** Registration update complete */
 	LWM2M_RD_CLIENT_EVENT_REG_UPDATE_COMPLETE,
+	/** De-registration failure */
 	LWM2M_RD_CLIENT_EVENT_DEREGISTER_FAILURE,
+	/** Disconnected */
 	LWM2M_RD_CLIENT_EVENT_DISCONNECT,
+	/** Queue mode RX off */
 	LWM2M_RD_CLIENT_EVENT_QUEUE_MODE_RX_OFF,
+	/** Engine suspended */
 	LWM2M_RD_CLIENT_EVENT_ENGINE_SUSPENDED,
+	/** Network error */
 	LWM2M_RD_CLIENT_EVENT_NETWORK_ERROR,
+	/** Registration update */
 	LWM2M_RD_CLIENT_EVENT_REG_UPDATE,
+	/** De-register */
 	LWM2M_RD_CLIENT_EVENT_DEREGISTER,
+	/** Server disabled */
 	LWM2M_RD_CLIENT_EVENT_SERVER_DISABLED,
 };
 
@@ -2270,9 +2290,9 @@ char *lwm2m_path_log_buf(char *buf, struct lwm2m_obj_path *path);
  * lwm2m_send_cb()
  */
 enum lwm2m_send_status {
-	LWM2M_SEND_STATUS_SUCCESS,
-	LWM2M_SEND_STATUS_FAILURE,
-	LWM2M_SEND_STATUS_TIMEOUT,
+	LWM2M_SEND_STATUS_SUCCESS,  /**< Succeed */
+	LWM2M_SEND_STATUS_FAILURE,  /**< Failure */
+	LWM2M_SEND_STATUS_TIMEOUT,  /**< Timeout */
 };
 
 /**

--- a/include/zephyr/net/lwm2m_path.h
+++ b/include/zephyr/net/lwm2m_path.h
@@ -8,7 +8,10 @@
 #define ZEPHYR_INCLUDE_NET_LWM2M_PATH_H_
 
 /**
+ * @file lwm2m.h
+ *
  * @brief LwM2M path helper macros
+ *
  * @defgroup lwm2m_path_helpers LwM2M path helper macros
  * @ingroup lwm2m_api
  * @{

--- a/include/zephyr/net/mdio.h
+++ b/include/zephyr/net/mdio.h
@@ -110,7 +110,7 @@ enum mdio_opcode {
 #define MDIO_AN_T1_ADV_M		0x0203U
 /** BASE-T1 Auto-negotiation advertisement register [47:32] */
 #define MDIO_AN_T1_ADV_H		0x0204U
-/* BASE-T1 PMA/PMD control register */
+/** BASE-T1 PMA/PMD control register */
 #define MDIO_PMA_PMD_BT1_CTRL		0x0834U
 
 /* BASE-T1 Auto-negotiation Control register */
@@ -152,9 +152,9 @@ enum mdio_opcode {
 #define MDIO_AN_T1_ADV_M_MST		BIT(4)
 
 /* BASE-T1 Auto-negotiation Advertisement register [47:32] */
-/* 10BASE-T1L High Level Transmit Operating Mode Request */
+/** 10BASE-T1L High Level Transmit Operating Mode Request */
 #define MDIO_AN_T1_ADV_H_10L_TX_HI_REQ	BIT(12)
-/* 10BASE-T1L High Level Transmit Operating Mode Ability */
+/** 10BASE-T1L High Level Transmit Operating Mode Ability */
 #define MDIO_AN_T1_ADV_H_10L_TX_HI	BIT(13)
 
 /* BASE-T1 PMA/PMD control register */

--- a/include/zephyr/net/mii.h
+++ b/include/zephyr/net/mii.h
@@ -131,8 +131,9 @@
 #define MII_ADVERTISE_10_FULL      (1 << 6)
 /** try for 10 Mb/s half duplex support */
 #define MII_ADVERTISE_10_HALF      (1 << 5)
-/** Selector Field */
+/** Selector Field Mask */
 #define MII_ADVERTISE_SEL_MASK     (0x1F << 0)
+/** Selector Field */
 #define MII_ADVERTISE_SEL_IEEE_802_3   0x01
 
 /* 1000BASE-T Control Register bit definitions */
@@ -141,6 +142,7 @@
 /** try for 1000BASE-T half duplex support */
 #define MII_ADVERTISE_1000_HALF    (1 << 8)
 
+/** Advertise all speeds */
 #define MII_ADVERTISE_ALL (MII_ADVERTISE_10_HALF | MII_ADVERTISE_10_FULL |\
 			   MII_ADVERTISE_100_HALF | MII_ADVERTISE_100_FULL |\
 			   MII_ADVERTISE_SEL_IEEE_802_3)

--- a/include/zephyr/net/mqtt.h
+++ b/include/zephyr/net/mqtt.h
@@ -6,16 +6,17 @@
 
 /** @file mqtt.h
  *
- * @defgroup mqtt_socket MQTT Client library
- * @since 1.14
- * @version 0.8.0
- * @ingroup networking
- * @{
  * @brief MQTT Client Implementation
  *
  * @note The implementation assumes TCP module is enabled.
  *
  * @note By default the implementation uses MQTT version 3.1.1.
+ *
+ * @defgroup mqtt_socket MQTT Client library
+ * @since 1.14
+ * @version 0.8.0
+ * @ingroup networking
+ * @{
  */
 
 #ifndef ZEPHYR_INCLUDE_NET_MQTT_H_
@@ -417,15 +418,16 @@ struct mqtt_transport {
 	 */
 	enum mqtt_transport_type type;
 
+	/** Use either unsecured TCP or secured TLS transport */
 	union {
-		/* TCP socket transport for MQTT */
+		/** TCP socket transport for MQTT */
 		struct {
 			/** Socket descriptor. */
 			int sock;
 		} tcp;
 
 #if defined(CONFIG_MQTT_LIB_TLS)
-		/* TLS socket transport for MQTT */
+		/** TLS socket transport for MQTT */
 		struct {
 			/** Socket descriptor. */
 			int sock;
@@ -559,7 +561,7 @@ struct mqtt_client {
 	 */
 	uint8_t clean_session : 1;
 
-	/* Userdata */
+	/** User specific opaque data */
 	void *user_data;
 };
 

--- a/include/zephyr/net/mqtt_sn.h
+++ b/include/zephyr/net/mqtt_sn.h
@@ -6,15 +6,15 @@
 
 /** @file mqtt_sn.h
  *
- * @defgroup mqtt_sn_socket MQTT-SN Client library
- * @ingroup networking
- * @{
  * @brief MQTT-SN Client Implementation
  *
  * @details
  * MQTT-SN Client's Application interface is defined in this header.
  * Targets protocol version 1.2.
  *
+ * @defgroup mqtt_sn_socket MQTT-SN Client library
+ * @ingroup networking
+ * @{
  */
 
 #ifndef ZEPHYR_INCLUDE_NET_MQTT_SN_H_

--- a/include/zephyr/net/net_context.h
+++ b/include/zephyr/net/net_context.h
@@ -35,6 +35,8 @@ extern "C" {
 /** Is this context used or not */
 #define NET_CONTEXT_IN_USE BIT(0)
 
+/** @cond INTERNAL_HIDDEN */
+
 /** State of the context (bits 1 & 2 in the flags) */
 enum net_context_state {
 	NET_CONTEXT_IDLE = 0,
@@ -45,6 +47,8 @@ enum net_context_state {
 	NET_CONTEXT_CONNECTED = 2,
 	NET_CONTEXT_LISTENING = 3,
 };
+
+/** @endcond */
 
 /**
  * The address family, connection type and IP protocol are
@@ -65,7 +69,7 @@ enum net_context_state {
 /** Is the socket closing / closed */
 #define NET_CONTEXT_CLOSING_SOCK  BIT(10)
 
-/* Context is bound to a specific interface */
+/** Context is bound to a specific interface */
 #define NET_CONTEXT_BOUND_TO_IFACE BIT(11)
 
 struct net_context;
@@ -478,8 +482,12 @@ static inline void net_context_set_closing(struct net_context *context,
 	}
 }
 
+/** @cond INTERNAL_HIDDEN */
+
 #define NET_CONTEXT_STATE_SHIFT 1
 #define NET_CONTEXT_STATE_MASK 0x03
+
+/** @endcond */
 
 /**
  * @brief Get state for this network context.
@@ -1258,24 +1266,25 @@ int net_context_recv(struct net_context *context,
 int net_context_update_recv_wnd(struct net_context *context,
 				int32_t delta);
 
+/** @brief Network context options. These map to BSD socket option values. */
 enum net_context_option {
-	NET_OPT_PRIORITY          = 1,
-	NET_OPT_TXTIME            = 2,
-	NET_OPT_SOCKS5            = 3,
-	NET_OPT_RCVTIMEO          = 4,
-	NET_OPT_SNDTIMEO          = 5,
-	NET_OPT_RCVBUF            = 6,
-	NET_OPT_SNDBUF            = 7,
-	NET_OPT_DSCP_ECN          = 8,
-	NET_OPT_REUSEADDR         = 9,
-	NET_OPT_REUSEPORT         = 10,
-	NET_OPT_IPV6_V6ONLY       = 11,
-	NET_OPT_RECV_PKTINFO      = 12,
-	NET_OPT_MCAST_TTL         = 13,
-	NET_OPT_MCAST_HOP_LIMIT   = 14,
-	NET_OPT_UNICAST_HOP_LIMIT = 15,
-	NET_OPT_TTL               = 16,
-	NET_OPT_ADDR_PREFERENCES  = 17,
+	NET_OPT_PRIORITY          = 1,  /**< Context priority */
+	NET_OPT_TXTIME            = 2,  /**< TX time */
+	NET_OPT_SOCKS5            = 3,  /**< SOCKS5 */
+	NET_OPT_RCVTIMEO          = 4,  /**< Receive timeout */
+	NET_OPT_SNDTIMEO          = 5,  /**< Send timeout */
+	NET_OPT_RCVBUF            = 6,  /**< Receive buffer */
+	NET_OPT_SNDBUF            = 7,  /**< Send buffer */
+	NET_OPT_DSCP_ECN          = 8,  /**< DSCP ECN */
+	NET_OPT_REUSEADDR         = 9,  /**< Re-use address */
+	NET_OPT_REUSEPORT         = 10, /**< Re-use port */
+	NET_OPT_IPV6_V6ONLY       = 11, /**< Share IPv4 and IPv6 port space */
+	NET_OPT_RECV_PKTINFO      = 12, /**< Receive packet information */
+	NET_OPT_MCAST_TTL         = 13, /**< IPv4 multicast TTL */
+	NET_OPT_MCAST_HOP_LIMIT   = 14, /**< IPv6 multicast hop limit */
+	NET_OPT_UNICAST_HOP_LIMIT = 15, /**< IPv6 unicast hop limit */
+	NET_OPT_TTL               = 16, /**< IPv4 unicast TTL */
+	NET_OPT_ADDR_PREFERENCES  = 17, /**< IPv6 address preference */
 };
 
 /**

--- a/include/zephyr/net/net_event.h
+++ b/include/zephyr/net/net_event.h
@@ -41,18 +41,6 @@ enum net_event_if_cmd {
 	NET_EVENT_IF_CMD_ADMIN_UP,
 };
 
-#define NET_EVENT_IF_DOWN				\
-	(_NET_EVENT_IF_BASE | NET_EVENT_IF_CMD_DOWN)
-
-#define NET_EVENT_IF_UP					\
-	(_NET_EVENT_IF_BASE | NET_EVENT_IF_CMD_UP)
-
-#define NET_EVENT_IF_ADMIN_DOWN				\
-	(_NET_EVENT_IF_BASE | NET_EVENT_IF_CMD_ADMIN_DOWN)
-
-#define NET_EVENT_IF_ADMIN_UP				\
-	(_NET_EVENT_IF_BASE | NET_EVENT_IF_CMD_ADMIN_UP)
-
 /* IPv6 Events */
 #define _NET_IPV6_LAYER		NET_MGMT_LAYER_L3
 #define _NET_IPV6_CORE_CODE	0x060
@@ -88,78 +76,6 @@ enum net_event_ipv6_cmd {
 	NET_EVENT_IPV6_CMD_PE_FILTER_DEL,
 };
 
-#define NET_EVENT_IPV6_ADDR_ADD					\
-	(_NET_EVENT_IPV6_BASE | NET_EVENT_IPV6_CMD_ADDR_ADD)
-
-#define NET_EVENT_IPV6_ADDR_DEL					\
-	(_NET_EVENT_IPV6_BASE |	NET_EVENT_IPV6_CMD_ADDR_DEL)
-
-#define NET_EVENT_IPV6_MADDR_ADD				\
-	(_NET_EVENT_IPV6_BASE |	NET_EVENT_IPV6_CMD_MADDR_ADD)
-
-#define NET_EVENT_IPV6_MADDR_DEL				\
-	(_NET_EVENT_IPV6_BASE | NET_EVENT_IPV6_CMD_MADDR_DEL)
-
-#define NET_EVENT_IPV6_PREFIX_ADD				\
-	(_NET_EVENT_IPV6_BASE |	NET_EVENT_IPV6_CMD_PREFIX_ADD)
-
-#define NET_EVENT_IPV6_PREFIX_DEL				\
-	(_NET_EVENT_IPV6_BASE |	NET_EVENT_IPV6_CMD_PREFIX_DEL)
-
-#define NET_EVENT_IPV6_MCAST_JOIN				\
-	(_NET_EVENT_IPV6_BASE |	NET_EVENT_IPV6_CMD_MCAST_JOIN)
-
-#define NET_EVENT_IPV6_MCAST_LEAVE				\
-	(_NET_EVENT_IPV6_BASE |	NET_EVENT_IPV6_CMD_MCAST_LEAVE)
-
-#define NET_EVENT_IPV6_ROUTER_ADD				\
-	(_NET_EVENT_IPV6_BASE | NET_EVENT_IPV6_CMD_ROUTER_ADD)
-
-#define NET_EVENT_IPV6_ROUTER_DEL				\
-	(_NET_EVENT_IPV6_BASE | NET_EVENT_IPV6_CMD_ROUTER_DEL)
-
-#define NET_EVENT_IPV6_ROUTE_ADD				\
-	(_NET_EVENT_IPV6_BASE | NET_EVENT_IPV6_CMD_ROUTE_ADD)
-
-#define NET_EVENT_IPV6_ROUTE_DEL				\
-	(_NET_EVENT_IPV6_BASE | NET_EVENT_IPV6_CMD_ROUTE_DEL)
-
-#define NET_EVENT_IPV6_DAD_SUCCEED				\
-	(_NET_EVENT_IPV6_BASE | NET_EVENT_IPV6_CMD_DAD_SUCCEED)
-
-#define NET_EVENT_IPV6_DAD_FAILED				\
-	(_NET_EVENT_IPV6_BASE | NET_EVENT_IPV6_CMD_DAD_FAILED)
-
-#define NET_EVENT_IPV6_NBR_ADD					\
-	(_NET_EVENT_IPV6_BASE | NET_EVENT_IPV6_CMD_NBR_ADD)
-
-#define NET_EVENT_IPV6_NBR_DEL					\
-	(_NET_EVENT_IPV6_BASE | NET_EVENT_IPV6_CMD_NBR_DEL)
-
-#define NET_EVENT_IPV6_DHCP_START				\
-	(_NET_EVENT_IPV6_BASE |	NET_EVENT_IPV6_CMD_DHCP_START)
-
-#define NET_EVENT_IPV6_DHCP_BOUND				\
-	(_NET_EVENT_IPV6_BASE |	NET_EVENT_IPV6_CMD_DHCP_BOUND)
-
-#define NET_EVENT_IPV6_DHCP_STOP				\
-	(_NET_EVENT_IPV6_BASE |	NET_EVENT_IPV6_CMD_DHCP_STOP)
-
-#define NET_EVENT_IPV6_ADDR_DEPRECATED				\
-	(_NET_EVENT_IPV6_BASE | NET_EVENT_IPV6_CMD_ADDR_DEPRECATED)
-
-#define NET_EVENT_IPV6_PE_ENABLED				\
-	(_NET_EVENT_IPV6_BASE | NET_EVENT_IPV6_CMD_PE_ENABLED)
-
-#define NET_EVENT_IPV6_PE_DISABLED				\
-	(_NET_EVENT_IPV6_BASE | NET_EVENT_IPV6_CMD_PE_DISABLED)
-
-#define NET_EVENT_IPV6_PE_FILTER_ADD				\
-	(_NET_EVENT_IPV6_BASE | NET_EVENT_IPV6_CMD_PE_FILTER_ADD)
-
-#define NET_EVENT_IPV6_PE_FILTER_DEL				\
-	(_NET_EVENT_IPV6_BASE | NET_EVENT_IPV6_CMD_PE_FILTER_DEL)
-
 /* IPv4 Events*/
 #define _NET_IPV4_LAYER		NET_MGMT_LAYER_L3
 #define _NET_IPV4_CORE_CODE	0x004
@@ -182,40 +98,6 @@ enum net_event_ipv4_cmd {
 	NET_EVENT_IPV4_CMD_MCAST_LEAVE,
 };
 
-#define NET_EVENT_IPV4_ADDR_ADD					\
-	(_NET_EVENT_IPV4_BASE | NET_EVENT_IPV4_CMD_ADDR_ADD)
-
-#define NET_EVENT_IPV4_ADDR_DEL					\
-	(_NET_EVENT_IPV4_BASE |	NET_EVENT_IPV4_CMD_ADDR_DEL)
-
-#define NET_EVENT_IPV4_MADDR_ADD				\
-	(_NET_EVENT_IPV4_BASE |	NET_EVENT_IPV4_CMD_MADDR_ADD)
-
-#define NET_EVENT_IPV4_MADDR_DEL				\
-	(_NET_EVENT_IPV4_BASE | NET_EVENT_IPV4_CMD_MADDR_DEL)
-
-#define NET_EVENT_IPV4_ROUTER_ADD				\
-	(_NET_EVENT_IPV4_BASE |	NET_EVENT_IPV4_CMD_ROUTER_ADD)
-
-#define NET_EVENT_IPV4_ROUTER_DEL				\
-	(_NET_EVENT_IPV4_BASE |	NET_EVENT_IPV4_CMD_ROUTER_DEL)
-
-#define NET_EVENT_IPV4_DHCP_START				\
-	(_NET_EVENT_IPV4_BASE |	NET_EVENT_IPV4_CMD_DHCP_START)
-
-#define NET_EVENT_IPV4_DHCP_BOUND				\
-	(_NET_EVENT_IPV4_BASE |	NET_EVENT_IPV4_CMD_DHCP_BOUND)
-
-#define NET_EVENT_IPV4_DHCP_STOP				\
-	(_NET_EVENT_IPV4_BASE |	NET_EVENT_IPV4_CMD_DHCP_STOP)
-
-#define NET_EVENT_IPV4_MCAST_JOIN				\
-	(_NET_EVENT_IPV4_BASE |	NET_EVENT_IPV4_CMD_MCAST_JOIN)
-
-#define NET_EVENT_IPV4_MCAST_LEAVE				\
-	(_NET_EVENT_IPV4_BASE |	NET_EVENT_IPV4_CMD_MCAST_LEAVE)
-
-
 /* L4 network events */
 #define _NET_L4_LAYER		NET_MGMT_LAYER_L4
 #define _NET_L4_CORE_CODE	0x114
@@ -234,28 +116,198 @@ enum net_event_l4_cmd {
 	NET_EVENT_L4_CMD_CAPTURE_STOPPED,
 };
 
-#define NET_EVENT_L4_CONNECTED				\
+/** @endcond */
+
+/** Event emitted when the network interface goes down. */
+#define NET_EVENT_IF_DOWN					\
+	(_NET_EVENT_IF_BASE | NET_EVENT_IF_CMD_DOWN)
+
+/** Event emitted when the network interface goes up. */
+#define NET_EVENT_IF_UP						\
+	(_NET_EVENT_IF_BASE | NET_EVENT_IF_CMD_UP)
+
+/** Event emitted when the network interface is taken down manually. */
+#define NET_EVENT_IF_ADMIN_DOWN					\
+	(_NET_EVENT_IF_BASE | NET_EVENT_IF_CMD_ADMIN_DOWN)
+
+/** Event emitted when the network interface goes up manually. */
+#define NET_EVENT_IF_ADMIN_UP					\
+	(_NET_EVENT_IF_BASE | NET_EVENT_IF_CMD_ADMIN_UP)
+
+/** Event emitted when an IPv6 address is added to the system. */
+#define NET_EVENT_IPV6_ADDR_ADD					\
+	(_NET_EVENT_IPV6_BASE | NET_EVENT_IPV6_CMD_ADDR_ADD)
+
+/** Event emitted when an IPv6 address is removed from the system. */
+#define NET_EVENT_IPV6_ADDR_DEL					\
+	(_NET_EVENT_IPV6_BASE |	NET_EVENT_IPV6_CMD_ADDR_DEL)
+
+/** Event emitted when an IPv6 multicast address is added to the system. */
+#define NET_EVENT_IPV6_MADDR_ADD				\
+	(_NET_EVENT_IPV6_BASE |	NET_EVENT_IPV6_CMD_MADDR_ADD)
+
+/** Event emitted when an IPv6 multicast address is removed from the system. */
+#define NET_EVENT_IPV6_MADDR_DEL				\
+	(_NET_EVENT_IPV6_BASE | NET_EVENT_IPV6_CMD_MADDR_DEL)
+
+/** Event emitted when an IPv6 prefix is added to the system. */
+#define NET_EVENT_IPV6_PREFIX_ADD				\
+	(_NET_EVENT_IPV6_BASE |	NET_EVENT_IPV6_CMD_PREFIX_ADD)
+
+/** Event emitted when an IPv6 prefix is removed from the system. */
+#define NET_EVENT_IPV6_PREFIX_DEL				\
+	(_NET_EVENT_IPV6_BASE |	NET_EVENT_IPV6_CMD_PREFIX_DEL)
+
+/** Event emitted when an IPv6 multicast group is joined. */
+#define NET_EVENT_IPV6_MCAST_JOIN				\
+	(_NET_EVENT_IPV6_BASE |	NET_EVENT_IPV6_CMD_MCAST_JOIN)
+
+/** Event emitted when an IPv6 multicast group is left. */
+#define NET_EVENT_IPV6_MCAST_LEAVE				\
+	(_NET_EVENT_IPV6_BASE |	NET_EVENT_IPV6_CMD_MCAST_LEAVE)
+
+/** Event emitted when an IPv6 router is added to the system. */
+#define NET_EVENT_IPV6_ROUTER_ADD				\
+	(_NET_EVENT_IPV6_BASE | NET_EVENT_IPV6_CMD_ROUTER_ADD)
+
+/** Event emitted when an IPv6 router is removed from the system. */
+#define NET_EVENT_IPV6_ROUTER_DEL				\
+	(_NET_EVENT_IPV6_BASE | NET_EVENT_IPV6_CMD_ROUTER_DEL)
+
+/** Event emitted when an IPv6 route is added to the system. */
+#define NET_EVENT_IPV6_ROUTE_ADD				\
+	(_NET_EVENT_IPV6_BASE | NET_EVENT_IPV6_CMD_ROUTE_ADD)
+
+/** Event emitted when an IPv6 route is removed from the system. */
+#define NET_EVENT_IPV6_ROUTE_DEL				\
+	(_NET_EVENT_IPV6_BASE | NET_EVENT_IPV6_CMD_ROUTE_DEL)
+
+/** Event emitted when an IPv6 duplicate address detection succeeds. */
+#define NET_EVENT_IPV6_DAD_SUCCEED				\
+	(_NET_EVENT_IPV6_BASE | NET_EVENT_IPV6_CMD_DAD_SUCCEED)
+
+/** Event emitted when an IPv6 duplicate address detection fails. */
+#define NET_EVENT_IPV6_DAD_FAILED				\
+	(_NET_EVENT_IPV6_BASE | NET_EVENT_IPV6_CMD_DAD_FAILED)
+
+/** Event emitted when an IPv6 neighbor is added to the system. */
+#define NET_EVENT_IPV6_NBR_ADD					\
+	(_NET_EVENT_IPV6_BASE | NET_EVENT_IPV6_CMD_NBR_ADD)
+
+/** Event emitted when an IPv6 neighbor is removed from the system. */
+#define NET_EVENT_IPV6_NBR_DEL					\
+	(_NET_EVENT_IPV6_BASE | NET_EVENT_IPV6_CMD_NBR_DEL)
+
+/** Event emitted when an IPv6 DHCP client starts. */
+#define NET_EVENT_IPV6_DHCP_START				\
+	(_NET_EVENT_IPV6_BASE |	NET_EVENT_IPV6_CMD_DHCP_START)
+
+/** Event emitted when an IPv6 DHCP client address is bound. */
+#define NET_EVENT_IPV6_DHCP_BOUND				\
+	(_NET_EVENT_IPV6_BASE |	NET_EVENT_IPV6_CMD_DHCP_BOUND)
+
+/** Event emitted when an IPv6 DHCP client is stopped. */
+#define NET_EVENT_IPV6_DHCP_STOP				\
+	(_NET_EVENT_IPV6_BASE |	NET_EVENT_IPV6_CMD_DHCP_STOP)
+
+/** IPv6 address is deprecated. */
+#define NET_EVENT_IPV6_ADDR_DEPRECATED				\
+	(_NET_EVENT_IPV6_BASE | NET_EVENT_IPV6_CMD_ADDR_DEPRECATED)
+
+/** IPv6 Privacy extension is enabled. */
+#define NET_EVENT_IPV6_PE_ENABLED				\
+	(_NET_EVENT_IPV6_BASE | NET_EVENT_IPV6_CMD_PE_ENABLED)
+
+/** IPv6 Privacy extension is disabled. */
+#define NET_EVENT_IPV6_PE_DISABLED				\
+	(_NET_EVENT_IPV6_BASE | NET_EVENT_IPV6_CMD_PE_DISABLED)
+
+/** IPv6 Privacy extension filter is added. */
+#define NET_EVENT_IPV6_PE_FILTER_ADD				\
+	(_NET_EVENT_IPV6_BASE | NET_EVENT_IPV6_CMD_PE_FILTER_ADD)
+
+/** IPv6 Privacy extension filter is removed. */
+#define NET_EVENT_IPV6_PE_FILTER_DEL				\
+	(_NET_EVENT_IPV6_BASE | NET_EVENT_IPV6_CMD_PE_FILTER_DEL)
+
+/** Event emitted when an IPv4 address is added to the system. */
+#define NET_EVENT_IPV4_ADDR_ADD					\
+	(_NET_EVENT_IPV4_BASE | NET_EVENT_IPV4_CMD_ADDR_ADD)
+
+/** Event emitted when an IPv4 address is removed from the system. */
+#define NET_EVENT_IPV4_ADDR_DEL					\
+	(_NET_EVENT_IPV4_BASE |	NET_EVENT_IPV4_CMD_ADDR_DEL)
+
+/** Event emitted when an IPv4 multicast address is added to the system. */
+#define NET_EVENT_IPV4_MADDR_ADD				\
+	(_NET_EVENT_IPV4_BASE |	NET_EVENT_IPV4_CMD_MADDR_ADD)
+
+/** Event emitted when an IPv4 multicast address is removed from the system. */
+#define NET_EVENT_IPV4_MADDR_DEL				\
+	(_NET_EVENT_IPV4_BASE | NET_EVENT_IPV4_CMD_MADDR_DEL)
+
+/** Event emitted when an IPv4 router is added to the system. */
+#define NET_EVENT_IPV4_ROUTER_ADD				\
+	(_NET_EVENT_IPV4_BASE |	NET_EVENT_IPV4_CMD_ROUTER_ADD)
+
+/** Event emitted when an IPv4 router is removed from the system. */
+#define NET_EVENT_IPV4_ROUTER_DEL				\
+	(_NET_EVENT_IPV4_BASE |	NET_EVENT_IPV4_CMD_ROUTER_DEL)
+
+/** Event emitted when an IPv4 DHCP client is started. */
+#define NET_EVENT_IPV4_DHCP_START				\
+	(_NET_EVENT_IPV4_BASE |	NET_EVENT_IPV4_CMD_DHCP_START)
+
+/** Event emitted when an IPv4 DHCP client address is bound. */
+#define NET_EVENT_IPV4_DHCP_BOUND				\
+	(_NET_EVENT_IPV4_BASE |	NET_EVENT_IPV4_CMD_DHCP_BOUND)
+
+/** Event emitted when an IPv4 DHCP client is stopped. */
+#define NET_EVENT_IPV4_DHCP_STOP				\
+	(_NET_EVENT_IPV4_BASE |	NET_EVENT_IPV4_CMD_DHCP_STOP)
+
+/** Event emitted when an IPv4 multicast group is joined. */
+#define NET_EVENT_IPV4_MCAST_JOIN				\
+	(_NET_EVENT_IPV4_BASE |	NET_EVENT_IPV4_CMD_MCAST_JOIN)
+
+/** Event emitted when an IPv4 multicast group is left. */
+#define NET_EVENT_IPV4_MCAST_LEAVE				\
+	(_NET_EVENT_IPV4_BASE |	NET_EVENT_IPV4_CMD_MCAST_LEAVE)
+
+/** Event emitted when the system is considered to be connected.
+ * The connected in this context means that the network interface is up,
+ * and the interface has either IPv4 or IPv6 address assigned to it.
+ */
+#define NET_EVENT_L4_CONNECTED					\
 	(_NET_EVENT_L4_BASE | NET_EVENT_L4_CMD_CONNECTED)
 
+/** Event emitted when the system is no longer connected.
+ * Typically this means that network connectivity is lost either by
+ * the network interface is going down, or the interface has no longer
+ * an IP address etc.
+ */
 #define NET_EVENT_L4_DISCONNECTED			\
 	(_NET_EVENT_L4_BASE | NET_EVENT_L4_CMD_DISCONNECTED)
 
+/** Event emitted when a DNS server is added to the system. */
 #define NET_EVENT_DNS_SERVER_ADD			\
 	(_NET_EVENT_L4_BASE | NET_EVENT_L4_CMD_DNS_SERVER_ADD)
 
+/** Event emitted when a DNS server is removed from the system. */
 #define NET_EVENT_DNS_SERVER_DEL			\
 	(_NET_EVENT_L4_BASE | NET_EVENT_L4_CMD_DNS_SERVER_DEL)
 
+/** Event emitted when the system hostname is changed. */
 #define NET_EVENT_HOSTNAME_CHANGED			\
 	(_NET_EVENT_L4_BASE | NET_EVENT_L4_CMD_HOSTNAME_CHANGED)
 
+/** Network packet capture is started. */
 #define NET_EVENT_CAPTURE_STARTED			\
 	(_NET_EVENT_L4_BASE | NET_EVENT_L4_CMD_CAPTURE_STARTED)
 
+/** Network packet capture is stopped. */
 #define NET_EVENT_CAPTURE_STOPPED			\
 	(_NET_EVENT_L4_BASE | NET_EVENT_L4_CMD_CAPTURE_STOPPED)
-
-/** @endcond */
 
 /**
  * @brief Network Management event information structure
@@ -268,6 +320,7 @@ enum net_event_l4_cmd {
  * information.
  */
 struct net_event_ipv6_addr {
+	/** IPv6 address related to this event */
 	struct in6_addr addr;
 };
 
@@ -281,8 +334,10 @@ struct net_event_ipv6_addr {
  * @note: idx will be '-1' in case of NET_EVENT_IPV6_NBR_DEL event.
  */
 struct net_event_ipv6_nbr {
+	/** Neighbor IPv6 address */
 	struct in6_addr addr;
-	int idx; /* NBR index*/
+	/** Neighbor index in cache */
+	int idx;
 };
 
 /**
@@ -294,8 +349,11 @@ struct net_event_ipv6_nbr {
  * information.
  */
 struct net_event_ipv6_route {
+	/** IPv6 address of the next hop */
 	struct in6_addr nexthop;
-	struct in6_addr addr; /* addr/prefix */
+	/** IPv6 address or prefix of the route */
+	struct in6_addr addr;
+	/** IPv6 prefix length */
 	uint8_t prefix_len;
 };
 
@@ -308,8 +366,11 @@ struct net_event_ipv6_route {
  * information.
  */
 struct net_event_ipv6_prefix {
-	struct in6_addr addr; /* prefix */
+	/** IPv6 prefix */
+	struct in6_addr addr;
+	/** IPv6 prefix length */
 	uint8_t len;
+	/** IPv6 prefix lifetime in seconds */
 	uint32_t lifetime;
 };
 
@@ -320,6 +381,7 @@ struct net_event_ipv6_prefix {
  * information.
  */
 struct net_event_l4_hostname {
+	/** New hostname */
 	char hostname[NET_HOSTNAME_SIZE];
 };
 
@@ -334,7 +396,9 @@ struct net_event_l4_hostname {
  * This is only available if CONFIG_NET_IPV6_PE_FILTER_PREFIX_COUNT is >0.
  */
 struct net_event_ipv6_pe_filter {
+	/** IPv6 address of privacy extension filter */
 	struct in6_addr prefix;
+	/** IPv6 filter deny or allow list */
 	bool is_deny_list;
 };
 

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -263,15 +263,15 @@ enum net_if_flag {
 /** @endcond */
 };
 
-/** Network interface operational status (RFC 2863). */
+/** @brief Network interface operational status (RFC 2863). */
 enum net_if_oper_state {
-	NET_IF_OPER_UNKNOWN,
-	NET_IF_OPER_NOTPRESENT,
-	NET_IF_OPER_DOWN,
-	NET_IF_OPER_LOWERLAYERDOWN,
-	NET_IF_OPER_TESTING,
-	NET_IF_OPER_DORMANT,
-	NET_IF_OPER_UP,
+	NET_IF_OPER_UNKNOWN,        /**< Initial (unknown) value */
+	NET_IF_OPER_NOTPRESENT,     /**< Hardware missing */
+	NET_IF_OPER_DOWN,           /**< Interface is down */
+	NET_IF_OPER_LOWERLAYERDOWN, /**< Lower layer interface is down */
+	NET_IF_OPER_TESTING,        /**< Training mode */
+	NET_IF_OPER_DORMANT,        /**< Waiting external action */
+	NET_IF_OPER_UP,             /**< Interface is up */
 } __packed;
 
 #if defined(CONFIG_NET_OFFLOAD)
@@ -290,6 +290,7 @@ struct net_offload;
 #endif
 /* @endcond */
 
+/** IPv6 configuration */
 struct net_if_ipv6 {
 	/** Unicast IP addresses */
 	struct net_if_addr unicast[NET_IF_MAX_IPV6_ADDR];
@@ -336,6 +337,7 @@ struct net_if_ipv6 {
 };
 
 #if defined(CONFIG_NET_DHCPV6) && defined(CONFIG_NET_NATIVE_IPV6)
+/** DHCPv6 configuration */
 struct net_if_dhcpv6 {
 	/** Used for timer list. */
 	sys_snode_t node;
@@ -420,6 +422,7 @@ struct net_if_addr_ipv4 {
 	struct in_addr netmask;
 };
 
+/** IPv4 configuration */
 struct net_if_ipv4 {
 	/** Unicast IP addresses */
 	struct net_if_addr_ipv4 unicast[NET_IF_MAX_IPV4_ADDR];
@@ -633,7 +636,7 @@ struct net_if_dev {
 	/** Interface's private L2 data pointer */
 	void *l2_data;
 
-	/* For internal use */
+	/** For internal use */
 	ATOMIC_DEFINE(flags, NET_IF_NUM_FLAGS);
 
 	/** The hardware link address */
@@ -689,7 +692,10 @@ struct net_if {
 	int tx_pending;
 #endif
 
+	/** Mutex protecting this network interface instance */
 	struct k_mutex lock;
+
+	/** Mutex used when sending data */
 	struct k_mutex tx_lock;
 
 	/** Network interface specific flags */
@@ -698,13 +704,16 @@ struct net_if {
 	 */
 	uint8_t pe_enabled : 1;
 
-	/* If PE is enabled, then this tells whether public addresses
+	/** If PE is enabled, then this tells whether public addresses
 	 * are preferred over temporary ones for this interface.
 	 */
 	uint8_t pe_prefer_public : 1;
 
+	/** Unused bit flags (ignore) */
 	uint8_t _unused : 6;
 };
+
+/** @cond INTERNAL_HIDDEN */
 
 static inline void net_if_lock(struct net_if *iface)
 {
@@ -744,6 +753,8 @@ static inline void net_if_tx_unlock(struct net_if *iface)
 
 	k_mutex_unlock(&iface->tx_lock);
 }
+
+/** @endcond */
 
 /**
  * @brief Set a value in network interface flags
@@ -1820,6 +1831,8 @@ uint8_t net_if_ipv6_get_hop_limit(struct net_if *iface);
  */
 void net_if_ipv6_set_hop_limit(struct net_if *iface, uint8_t hop_limit);
 
+/** @cond INTERNAL_HIDDEN */
+
 /* The old hop limit setter function is deprecated because the naming
  * of it was incorrect. The API name was missing "_if_" so this function
  * should not be used.
@@ -1830,6 +1843,8 @@ static inline void net_ipv6_set_hop_limit(struct net_if *iface,
 {
 	net_if_ipv6_set_hop_limit(iface, hop_limit);
 }
+
+/** @endcond */
 
 /**
  * @brief Get IPv6 multicast hop limit specified for a given interface. This is the

--- a/include/zephyr/net/net_ip.h
+++ b/include/zephyr/net/net_ip.h
@@ -138,26 +138,26 @@ enum net_sock_type {
 /** IPv6 address struct */
 struct in6_addr {
 	union {
-		uint8_t s6_addr[16];
-		uint16_t s6_addr16[8]; /* In big endian */
-		uint32_t s6_addr32[4]; /* In big endian */
+		uint8_t s6_addr[16];   /**< IPv6 address buffer */
+		uint16_t s6_addr16[8]; /**< In big endian */
+		uint32_t s6_addr32[4]; /**< In big endian */
 	};
 };
 
-/* Binary size of the IPv6 address */
+/** Binary size of the IPv6 address */
 #define NET_IPV6_ADDR_SIZE 16
 
 /** IPv4 address struct */
 struct in_addr {
 	union {
-		uint8_t s4_addr[4];
-		uint16_t s4_addr16[2]; /* In big endian */
-		uint32_t s4_addr32[1]; /* In big endian */
-		uint32_t s_addr; /* In big endian, for POSIX compatibility. */
+		uint8_t s4_addr[4];    /**< IPv4 address buffer */
+		uint16_t s4_addr16[2]; /**< In big endian */
+		uint32_t s4_addr32[1]; /**< In big endian */
+		uint32_t s_addr; /**< In big endian, for POSIX compatibility. */
 	};
 };
 
-/* Binary size of the IPv4 address */
+/** Binary size of the IPv4 address */
 #define NET_IPV4_ADDR_SIZE 4
 
 /** Socket address family type */
@@ -176,51 +176,56 @@ typedef size_t socklen_t;
 
 /** Socket address struct for IPv6. */
 struct sockaddr_in6 {
-	sa_family_t		sin6_family;   /* AF_INET6               */
-	uint16_t		sin6_port;     /* Port number            */
-	struct in6_addr		sin6_addr;     /* IPv6 address           */
-	uint8_t			sin6_scope_id; /* interfaces for a scope */
-};
-
-struct sockaddr_in6_ptr {
-	sa_family_t		sin6_family;   /* AF_INET6               */
-	uint16_t		sin6_port;     /* Port number            */
-	struct in6_addr		*sin6_addr;    /* IPv6 address           */
-	uint8_t			sin6_scope_id; /* interfaces for a scope */
+	sa_family_t		sin6_family;   /**< AF_INET6               */
+	uint16_t		sin6_port;     /**< Port number            */
+	struct in6_addr		sin6_addr;     /**< IPv6 address           */
+	uint8_t			sin6_scope_id; /**< Interfaces for a scope */
 };
 
 /** Socket address struct for IPv4. */
 struct sockaddr_in {
-	sa_family_t		sin_family;    /* AF_INET      */
-	uint16_t		sin_port;      /* Port number  */
-	struct in_addr		sin_addr;      /* IPv4 address */
-};
-
-struct sockaddr_in_ptr {
-	sa_family_t		sin_family;    /* AF_INET      */
-	uint16_t		sin_port;      /* Port number  */
-	struct in_addr		*sin_addr;     /* IPv4 address */
+	sa_family_t		sin_family;    /**< AF_INET      */
+	uint16_t		sin_port;      /**< Port number  */
+	struct in_addr		sin_addr;      /**< IPv4 address */
 };
 
 /** Socket address struct for packet socket. */
 struct sockaddr_ll {
-	sa_family_t sll_family;   /* Always AF_PACKET                   */
-	uint16_t    sll_protocol; /* Physical-layer protocol            */
-	int         sll_ifindex;  /* Interface number                   */
-	uint16_t    sll_hatype;   /* ARP hardware type                  */
-	uint8_t     sll_pkttype;  /* Packet type                        */
-	uint8_t     sll_halen;    /* Length of address                  */
-	uint8_t     sll_addr[8];  /* Physical-layer address, big endian */
+	sa_family_t sll_family;   /**< Always AF_PACKET                   */
+	uint16_t    sll_protocol; /**< Physical-layer protocol            */
+	int         sll_ifindex;  /**< Interface number                   */
+	uint16_t    sll_hatype;   /**< ARP hardware type                  */
+	uint8_t     sll_pkttype;  /**< Packet type                        */
+	uint8_t     sll_halen;    /**< Length of address                  */
+	uint8_t     sll_addr[8];  /**< Physical-layer address, big endian */
 };
 
+/** @cond INTERNAL_HIDDEN */
+
+/** Socket address struct for IPv6 where address is a pointer */
+struct sockaddr_in6_ptr {
+	sa_family_t		sin6_family;   /**< AF_INET6               */
+	uint16_t		sin6_port;     /**< Port number            */
+	struct in6_addr		*sin6_addr;    /**< IPv6 address           */
+	uint8_t			sin6_scope_id; /**< interfaces for a scope */
+};
+
+/** Socket address struct for IPv4 where address is a pointer */
+struct sockaddr_in_ptr {
+	sa_family_t		sin_family;    /**< AF_INET      */
+	uint16_t		sin_port;      /**< Port number  */
+	struct in_addr		*sin_addr;     /**< IPv4 address */
+};
+
+/** Socket address struct for packet socket where address is a pointer */
 struct sockaddr_ll_ptr {
-	sa_family_t sll_family;   /* Always AF_PACKET                   */
-	uint16_t    sll_protocol; /* Physical-layer protocol            */
-	int         sll_ifindex;  /* Interface number                   */
-	uint16_t    sll_hatype;   /* ARP hardware type                  */
-	uint8_t     sll_pkttype;  /* Packet type                        */
-	uint8_t     sll_halen;    /* Length of address                  */
-	uint8_t     *sll_addr;    /* Physical-layer address, big endian */
+	sa_family_t sll_family;   /**< Always AF_PACKET                   */
+	uint16_t    sll_protocol; /**< Physical-layer protocol            */
+	int         sll_ifindex;  /**< Interface number                   */
+	uint16_t    sll_hatype;   /**< ARP hardware type                  */
+	uint8_t     sll_pkttype;  /**< Packet type                        */
+	uint8_t     sll_halen;    /**< Length of address                  */
+	uint8_t     *sll_addr;    /**< Physical-layer address, big endian */
 };
 
 struct sockaddr_can_ptr {
@@ -228,30 +233,36 @@ struct sockaddr_can_ptr {
 	int         can_ifindex;
 };
 
+/** @endcond */
+
 #if !defined(HAVE_IOVEC)
+/** IO vector array element */
 struct iovec {
-	void  *iov_base;
-	size_t iov_len;
+	void  *iov_base; /**< Pointer to data */
+	size_t iov_len;  /**< Length of the data */
 };
 #endif
 
+/** Message struct */
 struct msghdr {
-	void         *msg_name;       /* optional socket address, big endian */
-	socklen_t     msg_namelen;    /* size of socket address */
-	struct iovec *msg_iov;        /* scatter/gather array */
-	size_t        msg_iovlen;     /* number of elements in msg_iov */
-	void         *msg_control;    /* ancillary data */
-	size_t        msg_controllen; /* ancillary data buffer len */
-	int           msg_flags;      /* flags on received message */
+	void         *msg_name;       /**< Optional socket address, big endian */
+	socklen_t     msg_namelen;    /**< Size of socket address */
+	struct iovec *msg_iov;        /**< Scatter/gather array */
+	size_t        msg_iovlen;     /**< Number of elements in msg_iov */
+	void         *msg_control;    /**< Ancillary data */
+	size_t        msg_controllen; /**< Ancillary data buffer len */
+	int           msg_flags;      /**< Flags on received message */
 };
 
+/** Control message ancillary data */
 struct cmsghdr {
-	socklen_t cmsg_len;    /* Number of bytes, including header */
-	int       cmsg_level;  /* Originating protocol */
-	int       cmsg_type;   /* Protocol-specific type */
-	/* Flexible array member to force alignment of cmsghdr */
-	z_max_align_t cmsg_data[];
+	socklen_t cmsg_len;    /**< Number of bytes, including header */
+	int       cmsg_level;  /**< Originating protocol */
+	int       cmsg_type;   /**< Protocol-specific type */
+	z_max_align_t cmsg_data[]; /**< Flexible array member to force alignment of cmsghdr */
 };
+
+/** @cond INTERNAL_HIDDEN */
 
 /* Alignment for headers and data. These are arch specific but define
  * them here atm if not found alredy.
@@ -263,13 +274,24 @@ struct cmsghdr {
 #define ALIGN_D(x) ROUND_UP(x, __alignof__(z_max_align_t))
 #endif
 
+/** @endcond */
+
 #if !defined(CMSG_FIRSTHDR)
+/**
+ * Returns a pointer to the first cmsghdr in the ancillary data buffer
+ * associated with the passed msghdr.  It returns NULL if there isn't
+ * enough space for a cmsghdr in the buffer.
+ */
 #define CMSG_FIRSTHDR(msghdr)					\
 	((msghdr)->msg_controllen >= sizeof(struct cmsghdr) ?	\
 	 (struct cmsghdr *)((msghdr)->msg_control) : NULL)
 #endif
 
 #if !defined(CMSG_NXTHDR)
+/**
+ * Returns the next valid cmsghdr after the passed cmsghdr. It returns NULL
+ * when there isn't enough space left in the buffer.
+ */
 #define CMSG_NXTHDR(msghdr, cmsg)					 \
 	(((cmsg) == NULL) ? CMSG_FIRSTHDR(msghdr) :			 \
 	 (((uint8_t *)(cmsg) + ALIGN_H((cmsg)->cmsg_len) +		 \
@@ -281,14 +303,30 @@ struct cmsghdr {
 #endif
 
 #if !defined(CMSG_DATA)
+/**
+ * Returns a pointer to the data portion of a cmsghdr.  The pointer returned
+ * cannot be assumed to be suitably aligned for accessing arbitrary payload
+ * data types. Applications should not cast it to a pointer type matching
+ * the payload, but should instead use memcpy(3) to copy data to or from a
+ * suitably declared object.
+ */
 #define CMSG_DATA(cmsg) ((uint8_t *)(cmsg) + ALIGN_D(sizeof(struct cmsghdr)))
 #endif
 
 #if !defined(CMSG_SPACE)
+/**
+ * Returns the number of bytes an ancillary element with payload of the passed
+ * data length occupies.
+ */
 #define CMSG_SPACE(length) (ALIGN_D(sizeof(struct cmsghdr)) + ALIGN_H(length))
 #endif
 
 #if !defined(CMSG_LEN)
+/**
+ * Returns the value to store in the cmsg_len member of the cmsghdr structure,
+ * taking into account any necessary alignment.
+ * It takes the data length as an argument.
+ */
 #define CMSG_LEN(length) (ALIGN_D(sizeof(struct cmsghdr)) + length)
 #endif
 
@@ -345,8 +383,10 @@ struct cmsghdr {
 
 /** Generic sockaddr struct. Must be cast to proper type. */
 struct sockaddr {
-	sa_family_t sa_family;
+	sa_family_t sa_family; /**< Address family */
+/** @cond INTERNAL_HIDDEN */
 	char data[NET_SOCKADDR_MAX_SIZE - sizeof(sa_family_t)];
+/** @endcond */
 };
 
 /** @cond INTERNAL_HIDDEN */
@@ -376,15 +416,30 @@ struct net_addr {
 	};
 };
 
-#define IN6ADDR_ANY_INIT { { { 0, 0, 0, 0, 0, 0, 0, 0, 0, \
-				0, 0, 0, 0, 0, 0, 0 } } }
-#define IN6ADDR_LOOPBACK_INIT { { { 0, 0, 0, 0, 0, 0, 0, \
-				0, 0, 0, 0, 0, 0, 0, 0, 1 } } }
-
+/** A pointer to IPv6 any address (all values zero) */
 extern const struct in6_addr in6addr_any;
+
+/** A pointer to IPv6 loopback address (::1) */
 extern const struct in6_addr in6addr_loopback;
 
 /** @endcond */
+
+/** IPv6 address initializer */
+#define IN6ADDR_ANY_INIT { { { 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+				0, 0, 0, 0, 0, 0, 0 } } }
+
+/** IPv6 loopback address initializer */
+#define IN6ADDR_LOOPBACK_INIT { { { 0, 0, 0, 0, 0, 0, 0, \
+				0, 0, 0, 0, 0, 0, 0, 0, 1 } } }
+
+/** IPv4 any address */
+#define INADDR_ANY 0
+
+/** IPv4 address initializer */
+#define INADDR_ANY_INIT { { { INADDR_ANY } } }
+
+/** IPv6 loopback address initializer */
+#define INADDR_LOOPBACK_INIT  { { { 127, 0, 0, 1 } } }
 
 /** Max length of the IPv4 address as a string. Defined by POSIX. */
 #define INET_ADDRSTRLEN 16
@@ -399,13 +454,9 @@ extern const struct in6_addr in6addr_loopback;
 #define NET_IPV6_ADDR_LEN sizeof("xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx")
 #define NET_IPV4_ADDR_LEN sizeof("xxx.xxx.xxx.xxx")
 
-#define INADDR_ANY 0
-#define INADDR_ANY_INIT { { { INADDR_ANY } } }
-
-#define INADDR_LOOPBACK_INIT  { { { 127, 0, 0, 1 } } }
-
 /** @endcond */
 
+/** @brief IP Maximum Transfer Unit */
 enum net_ip_mtu {
 	/** IPv6 MTU length. We must be able to receive this size IPv6 packet
 	 * without fragmentation.
@@ -422,7 +473,7 @@ enum net_ip_mtu {
 	NET_IPV4_MTU = 576,
 };
 
-/** Network packet priority settings described in IEEE 802.1Q Annex I.1 */
+/** @brief Network packet priority settings described in IEEE 802.1Q Annex I.1 */
 enum net_priority {
 	NET_PRIORITY_BK = 1, /**< Background (lowest)                */
 	NET_PRIORITY_BE = 0, /**< Best effort (default)              */
@@ -434,9 +485,9 @@ enum net_priority {
 	NET_PRIORITY_NC = 7  /**< Network control (highest)          */
 } __packed;
 
-#define NET_MAX_PRIORITIES 8 /* How many priority values there are */
+#define NET_MAX_PRIORITIES 8 /**< How many priority values there are */
 
-/** IPv6/IPv4 network connection tuple */
+/** @brief IPv6/IPv4 network connection tuple */
 struct net_tuple {
 	struct net_addr *remote_addr;  /**< IPv6/IPv4 remote address */
 	struct net_addr *local_addr;   /**< IPv6/IPv4 local address  */
@@ -445,7 +496,7 @@ struct net_tuple {
 	enum net_ip_protocol ip_proto; /**< IP protocol              */
 };
 
-/** What is the current state of the network address */
+/** @brief What is the current state of the network address */
 enum net_addr_state {
 	NET_ADDR_ANY_STATE = -1, /**< Default (invalid) address type */
 	NET_ADDR_TENTATIVE = 0,  /**< Tentative address              */
@@ -453,7 +504,7 @@ enum net_addr_state {
 	NET_ADDR_DEPRECATED,     /**< Deprecated address             */
 } __packed;
 
-/** How the network address is assigned to network interface */
+/** @brief How the network address is assigned to network interface */
 enum net_addr_type {
 	/** Default value. This is not a valid value. */
 	NET_ADDR_ANY = 0,

--- a/include/zephyr/net/net_mgmt.h
+++ b/include/zephyr/net/net_mgmt.h
@@ -90,14 +90,33 @@ typedef int (*net_mgmt_request_handler_t)(uint32_t mgmt_request,
 					  struct net_if *iface,
 					  void *data, size_t len);
 
+/**
+ * @brief Generate a network management event.
+ *
+ * @param _mgmt_request Management event identifier
+ * @param _iface Network interface
+ * @param _data Any additional data for the event
+ * @param _len Length of the additional data.
+ */
 #define net_mgmt(_mgmt_request, _iface, _data, _len)			\
 	net_mgmt_##_mgmt_request(_mgmt_request, _iface, _data, _len)
 
+/**
+ * @brief Declare a request handler function for the given network event.
+ *
+ * @param _mgmt_request Management event identifier
+ */
 #define NET_MGMT_DEFINE_REQUEST_HANDLER(_mgmt_request)			\
 	extern int net_mgmt_##_mgmt_request(uint32_t mgmt_request,	\
 					    struct net_if *iface,	\
 					    void *data, size_t len)
 
+/**
+ * @brief Create a request handler function for the given network event.
+ *
+ * @param _mgmt_request Management event identifier
+ * @param _func Function for handling this event
+ */
 #define NET_MGMT_REGISTER_REQUEST_HANDLER(_mgmt_request, _func)	\
 	FUNC_ALIAS(_func, net_mgmt_##_mgmt_request, int)
 
@@ -258,7 +277,7 @@ void net_mgmt_del_event_callback(struct net_mgmt_event_callback *cb);
  * @param mgmt_event The actual network event code to notify
  * @param iface a valid pointer on a struct net_if if only the event is
  *        based on an iface. NULL otherwise.
- * @param info a valid pointer on the information you want to pass along
+ * @param info A valid pointer on the information you want to pass along
  *        with the event. NULL otherwise. Note the data pointed there is
  *        normalized by the related event.
  * @param length size of the data pointed by info pointer.
@@ -266,10 +285,20 @@ void net_mgmt_del_event_callback(struct net_mgmt_event_callback *cb);
  * Note: info and length are disabled if CONFIG_NET_MGMT_EVENT_INFO
  *       is not defined.
  */
-#ifdef CONFIG_NET_MGMT_EVENT
+#if defined(CONFIG_NET_MGMT_EVENT)
 void net_mgmt_event_notify_with_info(uint32_t mgmt_event, struct net_if *iface,
 				     const void *info, size_t length);
+#else
+#define net_mgmt_event_notify_with_info(...)
+#endif
 
+/**
+ * @brief Used by the system to notify an event without any additional information.
+ * @param mgmt_event The actual network event code to notify
+ * @param iface A valid pointer on a struct net_if if only the event is
+ *        based on an iface. NULL otherwise.
+ */
+#if defined(CONFIG_NET_MGMT_EVENT)
 static inline void net_mgmt_event_notify(uint32_t mgmt_event,
 					 struct net_if *iface)
 {
@@ -277,7 +306,6 @@ static inline void net_mgmt_event_notify(uint32_t mgmt_event,
 }
 #else
 #define net_mgmt_event_notify(...)
-#define net_mgmt_event_notify_with_info(...)
 #endif
 
 /**

--- a/include/zephyr/net/net_pkt.h
+++ b/include/zephyr/net/net_pkt.h
@@ -46,6 +46,8 @@ extern "C" {
 
 struct net_context;
 
+/** @cond INTERNAL_HIDDEN */
+
 /* buffer cursor used in net_pkt */
 struct net_pkt_cursor {
 	/** Current net_buf pointer by the cursor */
@@ -53,6 +55,8 @@ struct net_pkt_cursor {
 	/** Current position in the data buffer of the net_buf */
 	uint8_t *pos;
 };
+
+/** @endcond */
 
 /**
  * @brief Network packet.
@@ -72,8 +76,8 @@ struct net_pkt {
 
 	/** buffer holding the packet */
 	union {
-		struct net_buf *frags;
-		struct net_buf *buffer;
+		struct net_buf *frags;   /**< buffer fragment */
+		struct net_buf *buffer;  /**< alias to a buffer fragment */
 	};
 
 	/** Internal buffer iterator used for reading/writing */
@@ -1401,8 +1405,12 @@ static inline void net_pkt_set_remote_address(struct net_pkt *pkt,
 #define NET_PKT_SLAB_DEFINE(name, count)				\
 	K_MEM_SLAB_DEFINE(name, sizeof(struct net_pkt), count, 4)
 
+/** @cond INTERNAL_HIDDEN */
+
 /* Backward compatibility macro */
 #define NET_PKT_TX_SLAB_DEFINE(name, count) NET_PKT_SLAB_DEFINE(name, count)
+
+/** @endcond */
 
 /**
  * @brief Create a data fragment net_buf pool
@@ -1855,9 +1863,13 @@ struct net_pkt *net_pkt_rx_alloc(k_timeout_t timeout);
 struct net_pkt *net_pkt_alloc_on_iface(struct net_if *iface,
 				       k_timeout_t timeout);
 
+/** @cond INTERNAL_HIDDEN */
+
 /* Same as above but specifically for RX packet */
 struct net_pkt *net_pkt_rx_alloc_on_iface(struct net_if *iface,
 					  k_timeout_t timeout);
+/** @endcond */
+
 #endif
 
 /**
@@ -1918,12 +1930,17 @@ struct net_pkt *net_pkt_alloc_with_buffer(struct net_if *iface,
 					  enum net_ip_protocol proto,
 					  k_timeout_t timeout);
 
+/** @cond INTERNAL_HIDDEN */
+
 /* Same as above but specifically for RX packet */
 struct net_pkt *net_pkt_rx_alloc_with_buffer(struct net_if *iface,
 					     size_t size,
 					     sa_family_t family,
 					     enum net_ip_protocol proto,
 					     k_timeout_t timeout);
+
+/** @endcond */
+
 #endif
 
 /**
@@ -2140,7 +2157,18 @@ struct net_pkt *net_pkt_shallow_clone(struct net_pkt *pkt,
  */
 int net_pkt_read(struct net_pkt *pkt, void *data, size_t length);
 
-/* Read uint8_t data data a net_pkt */
+/**
+ * @brief Read a byte (uint8_t) from a net_pkt
+ *
+ * @details net_pkt's cursor should be properly initialized and,
+ *          if needed, positioned using net_pkt_skip.
+ *          Cursor position will be updated after the operation.
+ *
+ * @param pkt  The network packet from where to read
+ * @param data The destination uint8_t where to copy the data
+ *
+ * @return 0 on success, negative errno code otherwise.
+ */
 static inline int net_pkt_read_u8(struct net_pkt *pkt, uint8_t *data)
 {
 	return net_pkt_read(pkt, data, 1);
@@ -2203,13 +2231,35 @@ int net_pkt_read_be32(struct net_pkt *pkt, uint32_t *data);
  */
 int net_pkt_write(struct net_pkt *pkt, const void *data, size_t length);
 
-/* Write uint8_t data into a net_pkt. */
+/**
+ * @brief Write a byte (uint8_t) data to a net_pkt
+ *
+ * @details net_pkt's cursor should be properly initialized and,
+ *          if needed, positioned using net_pkt_skip.
+ *          Cursor position will be updated after the operation.
+ *
+ * @param pkt  The network packet from where to read
+ * @param data The uint8_t value to write
+ *
+ * @return 0 on success, negative errno code otherwise.
+ */
 static inline int net_pkt_write_u8(struct net_pkt *pkt, uint8_t data)
 {
 	return net_pkt_write(pkt, &data, sizeof(uint8_t));
 }
 
-/* Write uint16_t big endian data into a net_pkt. */
+/**
+ * @brief Write a uint16_t big endian data to a net_pkt
+ *
+ * @details net_pkt's cursor should be properly initialized and,
+ *          if needed, positioned using net_pkt_skip.
+ *          Cursor position will be updated after the operation.
+ *
+ * @param pkt  The network packet from where to read
+ * @param data The uint16_t value in host byte order to write
+ *
+ * @return 0 on success, negative errno code otherwise.
+ */
 static inline int net_pkt_write_be16(struct net_pkt *pkt, uint16_t data)
 {
 	uint16_t data_be16 = htons(data);
@@ -2217,7 +2267,18 @@ static inline int net_pkt_write_be16(struct net_pkt *pkt, uint16_t data)
 	return net_pkt_write(pkt, &data_be16, sizeof(uint16_t));
 }
 
-/* Write uint32_t big endian data into a net_pkt. */
+/**
+ * @brief Write a uint32_t big endian data to a net_pkt
+ *
+ * @details net_pkt's cursor should be properly initialized and,
+ *          if needed, positioned using net_pkt_skip.
+ *          Cursor position will be updated after the operation.
+ *
+ * @param pkt  The network packet from where to read
+ * @param data The uint32_t value in host byte order to write
+ *
+ * @return 0 on success, negative errno code otherwise.
+ */
 static inline int net_pkt_write_be32(struct net_pkt *pkt, uint32_t data)
 {
 	uint32_t data_be32 = htonl(data);
@@ -2225,7 +2286,18 @@ static inline int net_pkt_write_be32(struct net_pkt *pkt, uint32_t data)
 	return net_pkt_write(pkt, &data_be32, sizeof(uint32_t));
 }
 
-/* Write uint32_t little endian data into a net_pkt. */
+/**
+ * @brief Write a uint32_t little endian data to a net_pkt
+ *
+ * @details net_pkt's cursor should be properly initialized and,
+ *          if needed, positioned using net_pkt_skip.
+ *          Cursor position will be updated after the operation.
+ *
+ * @param pkt  The network packet from where to read
+ * @param data The uint32_t value in host byte order to write
+ *
+ * @return 0 on success, negative errno code otherwise.
+ */
 static inline int net_pkt_write_le32(struct net_pkt *pkt, uint32_t data)
 {
 	uint32_t data_le32 = sys_cpu_to_le32(data);
@@ -2233,7 +2305,18 @@ static inline int net_pkt_write_le32(struct net_pkt *pkt, uint32_t data)
 	return net_pkt_write(pkt, &data_le32, sizeof(uint32_t));
 }
 
-/* Write uint16_t little endian data into a net_pkt. */
+/**
+ * @brief Write a uint16_t little endian data to a net_pkt
+ *
+ * @details net_pkt's cursor should be properly initialized and,
+ *          if needed, positioned using net_pkt_skip.
+ *          Cursor position will be updated after the operation.
+ *
+ * @param pkt  The network packet from where to read
+ * @param data The uint16_t value in host byte order to write
+ *
+ * @return 0 on success, negative errno code otherwise.
+ */
 static inline int net_pkt_write_le16(struct net_pkt *pkt, uint16_t data)
 {
 	uint16_t data_le16 = sys_cpu_to_le16(data);
@@ -2311,6 +2394,8 @@ bool net_pkt_is_contiguous(struct net_pkt *pkt, size_t size);
  */
 size_t net_pkt_get_contiguous_len(struct net_pkt *pkt);
 
+/** @cond INTERNAL_HIDDEN */
+
 struct net_pkt_data_access {
 #if !defined(CONFIG_NET_HEADERS_ALWAYS_CONTIGUOUS)
 	void *data;
@@ -2342,6 +2427,8 @@ struct net_pkt_data_access {
 	}
 
 #endif /* CONFIG_NET_HEADERS_ALWAYS_CONTIGUOUS */
+
+/** @endcond */
 
 /**
  * @brief Get data from a network packet in a contiguous way

--- a/include/zephyr/net/net_pkt_filter.h
+++ b/include/zephyr/net/net_pkt_filter.h
@@ -46,7 +46,7 @@ struct npf_test {
 
 /** @brief filter rule structure */
 struct npf_rule {
-	sys_snode_t node;
+	sys_snode_t node;               /**< Slist rule list node */
 	enum net_verdict result;	/**< result if all tests pass */
 	uint32_t nb_tests;		/**< number of tests for this rule */
 	struct npf_test *tests[];	/**< pointers to @ref npf_test instances */
@@ -59,8 +59,8 @@ extern struct npf_rule npf_default_drop;
 
 /** @brief rule set for a given test location */
 struct npf_rule_list {
-	sys_slist_t rule_head;
-	struct k_spinlock lock;
+	sys_slist_t rule_head;   /**< List head */
+	struct k_spinlock lock;  /**< Lock protecting the list access */
 };
 
 /** @brief  rule list applied to outgoing packets */
@@ -107,6 +107,8 @@ bool npf_remove_rule(struct npf_rule_list *rules, struct npf_rule *rule);
  */
 bool npf_remove_all_rules(struct npf_rule_list *rules);
 
+/** @cond INTERNAL_HIDDEN */
+
 /* convenience shortcuts */
 #define npf_insert_send_rule(rule) npf_insert_rule(&npf_send_rules, rule)
 #define npf_insert_recv_rule(rule) npf_insert_rule(&npf_recv_rules, rule)
@@ -137,6 +139,8 @@ bool npf_remove_all_rules(struct npf_rule_list *rules);
 #define npf_remove_ipv6_recv_rule(rule) npf_remove_rule(&npf_ipv6_recv_rules, rule)
 #define npf_remove_all_ipv6_recv_rules() npf_remove_all_rules(&npf_ipv6_recv_rules)
 #endif /* CONFIG_NET_PKT_FILTER_IPV6_HOOK */
+
+/** @endcond */
 
 /**
  * @brief Statically define one packet filter rule

--- a/include/zephyr/net/net_stats.h
+++ b/include/zephyr/net/net_stats.h
@@ -186,8 +186,13 @@ struct net_stats_udp {
  * @brief IPv6 neighbor discovery statistics
  */
 struct net_stats_ipv6_nd {
+	/** Number of dropped IPv6 neighbor discovery packets. */
 	net_stats_t drop;
+
+	/** Number of received IPv6 neighbor discovery packets. */
 	net_stats_t recv;
+
+	/** Number of sent IPv6 neighbor discovery packets. */
 	net_stats_t sent;
 };
 
@@ -195,13 +200,13 @@ struct net_stats_ipv6_nd {
  * @brief IPv6 multicast listener daemon statistics
  */
 struct net_stats_ipv6_mld {
-	/** Number of received IPv6 MLD queries */
+	/** Number of received IPv6 MLD queries. */
 	net_stats_t recv;
 
-	/** Number of sent IPv6 MLD reports */
+	/** Number of sent IPv6 MLD reports. */
 	net_stats_t sent;
 
-	/** Number of dropped IPv6 MLD packets */
+	/** Number of dropped IPv6 MLD packets. */
 	net_stats_t drop;
 };
 
@@ -223,7 +228,10 @@ struct net_stats_ipv4_igmp {
  * @brief Network packet transfer times for calculating average TX time
  */
 struct net_stats_tx_time {
+	/** Sum of network packet transfer times. */
 	uint64_t sum;
+
+	/** Number of network packets transferred. */
 	net_stats_t count;
 };
 
@@ -231,9 +239,14 @@ struct net_stats_tx_time {
  * @brief Network packet receive times for calculating average RX time
  */
 struct net_stats_rx_time {
+	/** Sum of network packet receive times. */
 	uint64_t sum;
+
+	/** Number of network packets received. */
 	net_stats_t count;
 };
+
+/** @cond INTERNAL_HIDDEN */
 
 #if NET_TC_TX_COUNT == 0
 #define NET_TC_TX_STATS_COUNT 1
@@ -247,29 +260,43 @@ struct net_stats_rx_time {
 #define NET_TC_RX_STATS_COUNT NET_TC_RX_COUNT
 #endif
 
+/** @endcond */
+
 /**
  * @brief Traffic class statistics
  */
 struct net_stats_tc {
+	/** TX statistics for each traffic class */
 	struct {
+		/** Helper for calculating average TX time statistics */
 		struct net_stats_tx_time tx_time;
 #if defined(CONFIG_NET_PKT_TXTIME_STATS_DETAIL)
+		/** Detailed TX time statistics inside network stack */
 		struct net_stats_tx_time
 				tx_time_detail[NET_PKT_DETAIL_STATS_COUNT];
 #endif
+		/** Number of packets sent for this traffic class */
 		net_stats_t pkts;
+		/** Number of bytes sent for this traffic class */
 		net_stats_t bytes;
+		/** Priority of this traffic class */
 		uint8_t priority;
 	} sent[NET_TC_TX_STATS_COUNT];
 
+	/** RX statistics for each traffic class */
 	struct {
+		/** Helper for calculating average RX time statistics */
 		struct net_stats_rx_time rx_time;
 #if defined(CONFIG_NET_PKT_RXTIME_STATS_DETAIL)
+		/** Detailed RX time statistics inside network stack */
 		struct net_stats_rx_time
 				rx_time_detail[NET_PKT_DETAIL_STATS_COUNT];
 #endif
+		/** Number of packets received for this traffic class */
 		net_stats_t pkts;
+		/** Number of bytes received for this traffic class */
 		net_stats_t bytes;
+		/** Priority of this traffic class */
 		uint8_t priority;
 	} recv[NET_TC_RX_STATS_COUNT];
 };
@@ -279,9 +306,13 @@ struct net_stats_tc {
  * @brief Power management statistics
  */
 struct net_stats_pm {
+	/** Total suspend time */
 	uint64_t overall_suspend_time;
+	/** How many times we were suspended */
 	net_stats_t suspend_count;
+	/** How long the last suspend took */
 	uint32_t last_suspend_time;
+	/** Network interface last suspend start time */
 	uint32_t start_time;
 };
 
@@ -367,6 +398,7 @@ struct net_stats {
 #endif
 
 #if defined(CONFIG_NET_STATISTICS_POWER_MANAGEMENT)
+	/** Power management statistics */
 	struct net_stats_pm pm;
 #endif
 };
@@ -375,26 +407,61 @@ struct net_stats {
  * @brief Ethernet error statistics
  */
 struct net_stats_eth_errors {
+	/** Number of RX length errors */
 	net_stats_t rx_length_errors;
+
+	/** Number of RX overrun errors */
 	net_stats_t rx_over_errors;
+
+	/** Number of RX CRC errors */
 	net_stats_t rx_crc_errors;
+
+	/** Number of RX frame errors */
 	net_stats_t rx_frame_errors;
+
+	/** Number of RX net_pkt allocation errors */
 	net_stats_t rx_no_buffer_count;
+
+	/** Number of RX missed errors */
 	net_stats_t rx_missed_errors;
+
+	/** Number of RX long length errors */
 	net_stats_t rx_long_length_errors;
+
+	/** Number of RX short length errors */
 	net_stats_t rx_short_length_errors;
+
+	/** Number of RX buffer align errors */
 	net_stats_t rx_align_errors;
+
+	/** Number of RX DMA failed errors */
 	net_stats_t rx_dma_failed;
+
+	/** Number of RX net_buf allocation errors */
 	net_stats_t rx_buf_alloc_failed;
 
+	/** Number of TX aborted errors */
 	net_stats_t tx_aborted_errors;
+
+	/** Number of TX carrier errors */
 	net_stats_t tx_carrier_errors;
+
+	/** Number of TX FIFO errors */
 	net_stats_t tx_fifo_errors;
+
+	/** Number of TX heartbeat errors */
 	net_stats_t tx_heartbeat_errors;
+
+	/** Number of TX window errors */
 	net_stats_t tx_window_errors;
+
+	/** Number of TX DMA failed errors */
 	net_stats_t tx_dma_failed;
 
+	/** Number of uncorrected ECC errors */
 	net_stats_t uncorr_ecc_errors;
+
+	/** Number of corrected ECC errors */
 	net_stats_t corr_ecc_errors;
 };
 
@@ -402,9 +469,16 @@ struct net_stats_eth_errors {
  * @brief Ethernet flow control statistics
  */
 struct net_stats_eth_flow {
+	/** Number of RX XON flow control */
 	net_stats_t rx_flow_control_xon;
+
+	/** Number of RX XOFF flow control */
 	net_stats_t rx_flow_control_xoff;
+
+	/** Number of TX XON flow control */
 	net_stats_t tx_flow_control_xon;
+
+	/** Number of TX XOFF flow control */
 	net_stats_t tx_flow_control_xoff;
 };
 
@@ -412,7 +486,10 @@ struct net_stats_eth_flow {
  * @brief Ethernet checksum statistics
  */
 struct net_stats_eth_csum {
+	/** Number of good RX checksum offloading */
 	net_stats_t rx_csum_offload_good;
+
+	/** Number of failed RX checksum offloading */
 	net_stats_t rx_csum_offload_errors;
 };
 
@@ -420,8 +497,13 @@ struct net_stats_eth_csum {
  * @brief Ethernet hardware timestamp statistics
  */
 struct net_stats_eth_hw_timestamp {
+	/** Number of RX hardware timestamp cleared */
 	net_stats_t rx_hwtstamp_cleared;
+
+	/** Number of RX hardware timestamp timeout */
 	net_stats_t tx_hwtstamp_timeouts;
+
+	/** Number of RX hardware timestamp skipped */
 	net_stats_t tx_hwtstamp_skipped;
 };
 
@@ -430,8 +512,8 @@ struct net_stats_eth_hw_timestamp {
  * @brief Ethernet vendor specific statistics
  */
 struct net_stats_eth_vendor {
-	const char * const key;
-	uint32_t value;
+	const char * const key; /**< Key name of vendor statistics */
+	uint32_t value;         /**< Value of the statistics key */
 };
 #endif
 
@@ -439,20 +521,48 @@ struct net_stats_eth_vendor {
  * @brief All Ethernet specific statistics
  */
 struct net_stats_eth {
+	/** Total number of bytes received and sent */
 	struct net_stats_bytes bytes;
+
+	/** Total number of packets received and sent */
 	struct net_stats_pkts pkts;
+
+	/** Total number of broadcast packets received and sent */
 	struct net_stats_pkts broadcast;
+
+	/** Total number of multicast packets received and sent */
 	struct net_stats_pkts multicast;
+
+	/** Total number of errors in RX and TX */
 	struct net_stats_pkts errors;
+
+	/** Total number of errors in RX and TX */
 	struct net_stats_eth_errors error_details;
+
+	/** Total number of flow control errors in RX and TX */
 	struct net_stats_eth_flow flow_control;
+
+	/** Total number of checksum errors in RX and TX */
 	struct net_stats_eth_csum csum;
+
+	/** Total number of hardware timestamp errors in RX and TX */
 	struct net_stats_eth_hw_timestamp hw_timestamp;
+
+	/** Total number of collisions */
 	net_stats_t collisions;
+
+	/** Total number of dropped TX packets */
 	net_stats_t tx_dropped;
+
+	/** Total number of TX timeout errors */
 	net_stats_t tx_timeout_count;
+
+	/** Total number of TX queue restarts */
 	net_stats_t tx_restart_queue;
+
+	/** Total number of RX unknown protocol packets */
 	net_stats_t unknown_protocol;
+
 #ifdef CONFIG_NET_STATISTICS_ETHERNET_VENDOR
 	/** Array is terminated with an entry containing a NULL key */
 	struct net_stats_eth_vendor *vendor;
@@ -463,7 +573,10 @@ struct net_stats_eth {
  * @brief All PPP specific statistics
  */
 struct net_stats_ppp {
+	/** Total number of bytes received and sent */
 	struct net_stats_bytes bytes;
+
+	/** Total number of packets received and sent */
 	struct net_stats_pkts pkts;
 
 	/** Number of received and dropped PPP frames. */
@@ -488,17 +601,32 @@ struct net_stats_sta_mgmt {
  * @brief All Wi-Fi specific statistics
  */
 struct net_stats_wifi {
+	/** Total number of beacon errors */
 	struct net_stats_sta_mgmt sta_mgmt;
+
+	/** Total number of bytes received and sent */
 	struct net_stats_bytes bytes;
+
+	/** Total number of packets received and sent */
 	struct net_stats_pkts pkts;
+
+	/** Total number of broadcast packets received and sent */
 	struct net_stats_pkts broadcast;
+
+	/** Total number of multicast packets received and sent */
 	struct net_stats_pkts multicast;
+
+	/** Total number of errors in RX and TX */
 	struct net_stats_pkts errors;
+
+	/** Total number of unicast packets received and sent */
 	struct net_stats_pkts unicast;
 };
 
 #if defined(CONFIG_NET_STATISTICS_USER_API)
 /* Management part definitions */
+
+/** @cond INTERNAL_HIDDEN */
 
 #define _NET_STATS_LAYER	NET_MGMT_LAYER_L3
 #define _NET_STATS_CODE		0x101
@@ -522,96 +650,133 @@ enum net_request_stats_cmd {
 	NET_REQUEST_STATS_CMD_GET_WIFI,
 };
 
+/** @endcond */
+
+/** Request all network statistics */
 #define NET_REQUEST_STATS_GET_ALL				\
 	(_NET_STATS_BASE | NET_REQUEST_STATS_CMD_GET_ALL)
 
-NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_STATS_GET_ALL);
-
+/** Request all processing error statistics */
 #define NET_REQUEST_STATS_GET_PROCESSING_ERROR				\
 	(_NET_STATS_BASE | NET_REQUEST_STATS_CMD_GET_PROCESSING_ERROR)
 
-NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_STATS_GET_PROCESSING_ERROR);
-
+/** Request number of received and sent bytes */
 #define NET_REQUEST_STATS_GET_BYTES				\
 	(_NET_STATS_BASE | NET_REQUEST_STATS_CMD_GET_BYTES)
 
-NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_STATS_GET_BYTES);
-
+/** Request IP error statistics */
 #define NET_REQUEST_STATS_GET_IP_ERRORS				\
 	(_NET_STATS_BASE | NET_REQUEST_STATS_CMD_GET_IP_ERRORS)
 
+/** @cond INTERNAL_HIDDEN */
+
+NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_STATS_GET_ALL);
+NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_STATS_GET_PROCESSING_ERROR);
+NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_STATS_GET_BYTES);
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_STATS_GET_IP_ERRORS);
 
+/** @endcond */
+
 #if defined(CONFIG_NET_STATISTICS_IPV4)
+/** Request IPv4 statistics */
 #define NET_REQUEST_STATS_GET_IPV4				\
 	(_NET_STATS_BASE | NET_REQUEST_STATS_CMD_GET_IPV4)
 
+/** @cond INTERNAL_HIDDEN */
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_STATS_GET_IPV4);
+/** @endcond */
 #endif /* CONFIG_NET_STATISTICS_IPV4 */
 
 #if defined(CONFIG_NET_STATISTICS_IPV6)
+/** Request IPv6 statistics */
 #define NET_REQUEST_STATS_GET_IPV6				\
 	(_NET_STATS_BASE | NET_REQUEST_STATS_CMD_GET_IPV6)
 
+/** @cond INTERNAL_HIDDEN */
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_STATS_GET_IPV6);
+/** @endcond */
 #endif /* CONFIG_NET_STATISTICS_IPV6 */
 
 #if defined(CONFIG_NET_STATISTICS_IPV6_ND)
+/** Request IPv6 neighbor discovery statistics */
 #define NET_REQUEST_STATS_GET_IPV6_ND				\
 	(_NET_STATS_BASE | NET_REQUEST_STATS_CMD_GET_IPV6_ND)
 
+/** @cond INTERNAL_HIDDEN */
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_STATS_GET_IPV6_ND);
+/** @endcond */
 #endif /* CONFIG_NET_STATISTICS_IPV6_ND */
 
 #if defined(CONFIG_NET_STATISTICS_ICMP)
+/** Request ICMPv4 and ICMPv6 statistics */
 #define NET_REQUEST_STATS_GET_ICMP				\
 	(_NET_STATS_BASE | NET_REQUEST_STATS_CMD_GET_ICMP)
 
+/** @cond INTERNAL_HIDDEN */
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_STATS_GET_ICMP);
+/** @endcond */
 #endif /* CONFIG_NET_STATISTICS_ICMP */
 
 #if defined(CONFIG_NET_STATISTICS_UDP)
+/** Request UDP statistics */
 #define NET_REQUEST_STATS_GET_UDP				\
 	(_NET_STATS_BASE | NET_REQUEST_STATS_CMD_GET_UDP)
 
+/** @cond INTERNAL_HIDDEN */
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_STATS_GET_UDP);
+/** @endcond */
 #endif /* CONFIG_NET_STATISTICS_UDP */
 
 #if defined(CONFIG_NET_STATISTICS_TCP)
+/** Request TCP statistics */
 #define NET_REQUEST_STATS_GET_TCP				\
 	(_NET_STATS_BASE | NET_REQUEST_STATS_CMD_GET_TCP)
 
+/** @cond INTERNAL_HIDDEN */
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_STATS_GET_TCP);
+/** @endcond */
 #endif /* CONFIG_NET_STATISTICS_TCP */
 
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
+/** Request Ethernet statistics */
 #define NET_REQUEST_STATS_GET_ETHERNET				\
 	(_NET_STATS_BASE | NET_REQUEST_STATS_CMD_GET_ETHERNET)
 
+/** @cond INTERNAL_HIDDEN */
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_STATS_GET_ETHERNET);
+/** @endcond */
 #endif /* CONFIG_NET_STATISTICS_ETHERNET */
 
 #if defined(CONFIG_NET_STATISTICS_PPP)
+/** Request PPP statistics */
 #define NET_REQUEST_STATS_GET_PPP				\
 	(_NET_STATS_BASE | NET_REQUEST_STATS_CMD_GET_PPP)
 
+/** @cond INTERNAL_HIDDEN */
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_STATS_GET_PPP);
+/** @endcond */
 #endif /* CONFIG_NET_STATISTICS_PPP */
 
 #endif /* CONFIG_NET_STATISTICS_USER_API */
 
 #if defined(CONFIG_NET_STATISTICS_POWER_MANAGEMENT)
+/** Request network power management statistics */
 #define NET_REQUEST_STATS_GET_PM				\
 	(_NET_STATS_BASE | NET_REQUEST_STATS_CMD_GET_PM)
 
+/** @cond INTERNAL_HIDDEN */
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_STATS_GET_PM);
+/** @endcond */
 #endif /* CONFIG_NET_STATISTICS_POWER_MANAGEMENT */
 
 #if defined(CONFIG_NET_STATISTICS_WIFI)
+/** Request Wi-Fi statistics */
 #define NET_REQUEST_STATS_GET_WIFI				\
 	(_NET_STATS_BASE | NET_REQUEST_STATS_CMD_GET_WIFI)
 
+/** @cond INTERNAL_HIDDEN */
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_STATS_GET_WIFI);
+/** @endcond */
 #endif /* CONFIG_NET_STATISTICS_WIFI */
 
 /**

--- a/include/zephyr/net/net_timeout.h
+++ b/include/zephyr/net/net_timeout.h
@@ -61,12 +61,13 @@ struct net_timeout {
 	 */
 	sys_snode_t node;
 
-	/* Time at which the timer was last set.
+	/** Time at which the timer was last set.
 	 *
-	 * This usually corresponds to the low 32 bits of k_uptime_get(). */
+	 * This usually corresponds to the low 32 bits of k_uptime_get().
+	 */
 	uint32_t timer_start;
 
-	/* Portion of remaining timeout that does not exceed
+	/** Portion of remaining timeout that does not exceed
 	 * NET_TIMEOUT_MAX_VALUE.
 	 *
 	 * This value is updated in parallel with timer_start and wrap_counter
@@ -74,7 +75,7 @@ struct net_timeout {
 	 */
 	uint32_t timer_timeout;
 
-	/* Timer wrap count.
+	/** Timer wrap count.
 	 *
 	 * This tracks multiples of NET_TIMEOUT_MAX_VALUE milliseconds that
 	 * have yet to pass.  It is also updated along with timer_start and

--- a/include/zephyr/net/offloaded_netdev.h
+++ b/include/zephyr/net/offloaded_netdev.h
@@ -58,7 +58,7 @@ struct offloaded_if_api {
 	/** Enable or disable the device (in response to admin state change) */
 	int (*enable)(const struct net_if *iface, bool state);
 
-	/* Types of offloaded net device */
+	/** Types of offloaded net device */
 	enum offloaded_net_if_types (*get_type)(void);
 };
 

--- a/include/zephyr/net/openthread.h
+++ b/include/zephyr/net/openthread.h
@@ -199,7 +199,11 @@ int openthread_api_mutex_try_lock(struct openthread_context *ot_context);
  */
 void openthread_api_mutex_unlock(struct openthread_context *ot_context);
 
+/** @cond INTERNAL_HIDDEN */
+
 #define OPENTHREAD_L2_CTX_TYPE struct openthread_context
+
+/** @endcond */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/net/phy.h
+++ b/include/zephyr/net/phy.h
@@ -42,8 +42,31 @@ enum phy_link_speed {
 	LINK_FULL_1000BASE_T		= BIT(5),
 };
 
+/**
+ * @brief Check if phy link is full duplex.
+ *
+ * @param x Link capabilities
+ *
+ * @return True if link is full duplex, false if not.
+ */
 #define PHY_LINK_IS_FULL_DUPLEX(x)	(x & (BIT(1) | BIT(3) | BIT(5)))
+
+/**
+ * @brief Check if phy link speed is 1 Gbit/sec.
+ *
+ * @param x Link capabilities
+ *
+ * @return True if link is 1 Gbit/sec, false if not.
+ */
 #define PHY_LINK_IS_SPEED_1000M(x)	(x & (BIT(4) | BIT(5)))
+
+/**
+ * @brief Check if phy link speed is 100 Mbit/sec.
+ *
+ * @param x Link capabilities
+ *
+ * @return True if link is 1 Mbit/sec, false if not.
+ */
 #define PHY_LINK_IS_SPEED_100M(x)	(x & (BIT(2) | BIT(3)))
 
 /** @brief Link state */

--- a/include/zephyr/net/ppp.h
+++ b/include/zephyr/net/ppp.h
@@ -4,6 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief PPP (Point-to-Point Protocol)
+ */
 
 #ifndef ZEPHYR_INCLUDE_NET_PPP_H_
 #define ZEPHYR_INCLUDE_NET_PPP_H_
@@ -103,6 +107,8 @@ enum ppp_phase {
 	PPP_TERMINATE,
 };
 
+/** @cond INTERNAL_HIDDEN */
+
 /**
  * PPP states, RFC 1661 ch. 4.2
  */
@@ -136,10 +142,13 @@ enum ppp_packet_type {
 	PPP_DISCARD_REQ    = 11
 };
 
+/** @endcond */
+
 /**
  * LCP option types from RFC 1661 ch. 6
  */
 enum lcp_option_type {
+	/** Reserved option value (do not use) */
 	LCP_OPTION_RESERVED = 0,
 
 	/** Maximum-Receive-Unit */
@@ -168,6 +177,7 @@ enum lcp_option_type {
  * IPCP option types from RFC 1332
  */
 enum ipcp_option_type {
+	/** Reserved IPCP option value (do not use) */
 	IPCP_OPTION_RESERVED = 0,
 
 	/** IP Addresses */
@@ -198,6 +208,7 @@ enum ipcp_option_type {
  * IPV6CP option types from RFC 5072
  */
 enum ipv6cp_option_type {
+	/** Reserved IPV6CP option value (do not use) */
 	IPV6CP_OPTION_RESERVED = 0,
 
 	/** Interface identifier */
@@ -225,6 +236,7 @@ struct ppp_fsm {
 	/** Timeout timer */
 	struct k_work_delayable timer;
 
+	/** FSM callbacks */
 	struct {
 		/** Acknowledge Configuration Information */
 		int (*config_info_ack)(struct ppp_fsm *fsm,
@@ -284,6 +296,7 @@ struct ppp_fsm {
 						    struct net_pkt *pkt);
 	} cb;
 
+	/** My options */
 	struct {
 		/** Options information */
 		const struct ppp_my_option_info *info;
@@ -329,6 +342,8 @@ struct ppp_fsm {
 	uint8_t ack_received : 1;
 };
 
+/** @cond INTERNAL_HIDDEN */
+
 #define PPP_MY_OPTION_ACKED	BIT(0)
 #define PPP_MY_OPTION_REJECTED	BIT(1)
 
@@ -336,6 +351,16 @@ struct ppp_my_option_data {
 	uint32_t flags;
 };
 
+#define IPCP_NUM_MY_OPTIONS	3
+#define IPV6CP_NUM_MY_OPTIONS	1
+
+enum ppp_flags {
+	PPP_CARRIER_UP,
+};
+
+/** @endcond */
+
+/** Link control protocol options */
 struct lcp_options {
 	/** Magic number */
 	uint32_t magic;
@@ -354,24 +379,22 @@ struct lcp_options {
 #define LCP_NUM_MY_OPTIONS	1
 #endif
 
+/** IPv4 control protocol options */
 struct ipcp_options {
 	/** IPv4 address */
 	struct in_addr address;
+
+	/** Primary DNS server address */
 	struct in_addr dns1_address;
+
+	/** Secondary DNS server address */
 	struct in_addr dns2_address;
 };
 
-#define IPCP_NUM_MY_OPTIONS	3
-
+/** IPv6 control protocol options */
 struct ipv6cp_options {
 	/** Interface identifier */
 	uint8_t iid[PPP_INTERFACE_IDENTIFIER_LEN];
-};
-
-#define IPV6CP_NUM_MY_OPTIONS	1
-
-enum ppp_flags {
-	PPP_CARRIER_UP,
 };
 
 /** PPP L2 context specific to certain network interface */
@@ -384,6 +407,7 @@ struct ppp_context {
 	/** PPP startup worker. */
 	struct k_work_delayable startup;
 
+	/** LCP options */
 	struct {
 		/** Finite state machine for LCP */
 		struct ppp_fsm fsm;
@@ -402,6 +426,7 @@ struct ppp_context {
 	} lcp;
 
 #if defined(CONFIG_NET_IPV4)
+	/** ICMP options */
 	struct {
 		/** Finite state machine for IPCP */
 		struct ppp_fsm fsm;
@@ -418,6 +443,7 @@ struct ppp_context {
 #endif
 
 #if defined(CONFIG_NET_IPV6)
+	/** IPV6CP options */
 	struct {
 		/** Finite state machine for IPV6CP */
 		struct ppp_fsm fsm;
@@ -434,6 +460,7 @@ struct ppp_context {
 #endif
 
 #if defined(CONFIG_NET_L2_PPP_PAP)
+	/** PAP options */
 	struct {
 		/** Finite state machine for PAP */
 		struct ppp_fsm fsm;
@@ -441,7 +468,9 @@ struct ppp_context {
 #endif
 
 #if defined(CONFIG_NET_SHELL)
+	/** Network shell PPP command internal data */
 	struct {
+		/** Ping command internal data */
 		struct {
 			/** Callback to be called when Echo-Reply is received.
 			 */
@@ -544,21 +573,25 @@ enum net_event_ppp_cmd {
 	NET_EVENT_PPP_CMD_PHASE_DEAD,
 };
 
-#define NET_EVENT_PPP_CARRIER_ON					\
-	(_NET_PPP_EVENT | NET_EVENT_PPP_CMD_CARRIER_ON)
-
-#define NET_EVENT_PPP_CARRIER_OFF					\
-	(_NET_PPP_EVENT | NET_EVENT_PPP_CMD_CARRIER_OFF)
-
-#define NET_EVENT_PPP_PHASE_RUNNING					\
-	(_NET_PPP_EVENT | NET_EVENT_PPP_CMD_PHASE_RUNNING)
-
-#define NET_EVENT_PPP_PHASE_DEAD					\
-	(_NET_PPP_EVENT | NET_EVENT_PPP_CMD_PHASE_DEAD)
-
 struct net_if;
 
 /** @endcond */
+
+/** Event emitted when PPP carrier is on */
+#define NET_EVENT_PPP_CARRIER_ON					\
+	(_NET_PPP_EVENT | NET_EVENT_PPP_CMD_CARRIER_ON)
+
+/** Event emitted when PPP carrier is off */
+#define NET_EVENT_PPP_CARRIER_OFF					\
+	(_NET_PPP_EVENT | NET_EVENT_PPP_CMD_CARRIER_OFF)
+
+/** Event emitted when PPP goes into running phase */
+#define NET_EVENT_PPP_PHASE_RUNNING					\
+	(_NET_PPP_EVENT | NET_EVENT_PPP_CMD_PHASE_RUNNING)
+
+/** Event emitted when PPP goes into dead phase */
+#define NET_EVENT_PPP_PHASE_DEAD					\
+	(_NET_PPP_EVENT | NET_EVENT_PPP_CMD_PHASE_DEAD)
 
 /**
  * @brief Raise CARRIER_ON event when PPP is connected.

--- a/include/zephyr/net/ptp_time.h
+++ b/include/zephyr/net/ptp_time.h
@@ -109,6 +109,8 @@ extern "C" {
 struct net_ptp_time {
 	/** Seconds encoded on 48 bits. */
 	union {
+
+/** @cond INTERNAL_HIDDEN */
 		struct {
 #ifdef CONFIG_LITTLE_ENDIAN
 			uint32_t low;
@@ -120,6 +122,9 @@ struct net_ptp_time {
 			uint32_t low;
 #endif
 		} _sec;
+/** @endcond */
+
+		/** Second value. */
 		uint64_t second;
 	};
 
@@ -147,6 +152,8 @@ struct net_ptp_time {
 struct net_ptp_extended_time {
 	/** Seconds encoded on 48 bits. */
 	union {
+
+/** @cond INTERNAL_HIDDEN */
 		struct {
 #ifdef CONFIG_LITTLE_ENDIAN
 			uint32_t low;
@@ -158,11 +165,16 @@ struct net_ptp_extended_time {
 			uint32_t low;
 #endif
 		} _sec;
+/** @endcond */
+
+		/** Second value. */
 		uint64_t second;
 	};
 
 	/** Fractional nanoseconds on 48 bits. */
 	union {
+
+/** @cond INTERNAL_HIDDEN */
 		struct {
 #ifdef CONFIG_LITTLE_ENDIAN
 			uint32_t low;
@@ -174,6 +186,9 @@ struct net_ptp_extended_time {
 			uint32_t low;
 #endif
 		} _fns;
+/** @endcond */
+
+		/** Fractional nanoseconds value. */
 		uint64_t fract_nsecond;
 	};
 } __packed;

--- a/include/zephyr/net/sntp.h
+++ b/include/zephyr/net/sntp.h
@@ -5,6 +5,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief SNTP (Simple Network Time Protocol)
+ */
+
 #ifndef ZEPHYR_INCLUDE_NET_SNTP_H_
 #define ZEPHYR_INCLUDE_NET_SNTP_H_
 
@@ -23,21 +28,24 @@ extern "C" {
 
 /** Time as returned by SNTP API, fractional seconds since 1 Jan 1970 */
 struct sntp_time {
-	uint64_t seconds;
-	uint32_t fraction;
+	uint64_t seconds;        /**< Second value */
+	uint32_t fraction;       /**< Fractional seconds value */
 #if defined(CONFIG_SNTP_UNCERTAINTY)
-	uint64_t uptime_us;
-	uint32_t uncertainty_us;
+	uint64_t uptime_us;      /**< Uptime in microseconds */
+	uint32_t uncertainty_us; /**< Uncertainty in microseconds */
 #endif
 };
 
 /** SNTP context */
 struct sntp_ctx {
+
+/** @cond INTERNAL_HIDDEN */
 	struct {
 		struct zsock_pollfd fds[1];
 		int nfds;
 		int fd;
 	} sock;
+/** @endcond */
 
 	/** Timestamp when the request was sent from client to server.
 	 *  This is used to check if the originated timestamp in the server

--- a/include/zephyr/net/socket.h
+++ b/include/zephyr/net/socket.h
@@ -562,6 +562,8 @@ static inline ssize_t zsock_recv(int sock, void *buf, size_t max_len,
  */
 __syscall int zsock_fcntl_impl(int sock, int cmd, int flags);
 
+/** @cond INTERNAL_HIDDEN */
+
 /*
  * Need this wrapper because newer GCC versions got too smart and "typecheck"
  * even macros.
@@ -578,6 +580,8 @@ static inline int zsock_fcntl_wrapper(int sock, int cmd, ...)
 }
 
 #define zsock_fcntl zsock_fcntl_wrapper
+
+/** @endcond */
 
 /**
  * @brief Control underlying socket parameters
@@ -598,6 +602,8 @@ static inline int zsock_fcntl_wrapper(int sock, int cmd, ...)
  */
 __syscall int zsock_ioctl_impl(int sock, unsigned long request, va_list ap);
 
+/** @cond INTERNAL_HIDDEN */
+
 static inline int zsock_ioctl_wrapper(int sock, unsigned long request, ...)
 {
 	int ret;
@@ -611,6 +617,8 @@ static inline int zsock_ioctl_wrapper(int sock, unsigned long request, ...)
 }
 
 #define zsock_ioctl zsock_ioctl_wrapper
+
+/** @endcond */
 
 /**
  * @brief Efficiently poll multiple sockets for events

--- a/include/zephyr/net/socket_net_mgmt.h
+++ b/include/zephyr/net/socket_net_mgmt.h
@@ -29,12 +29,16 @@ extern "C" {
  * @{
  */
 
+/** @cond INTERNAL_HIDDEN */
+
 /* Protocols of the protocol family PF_NET_MGMT */
 #define NET_MGMT_EVENT_PROTO 0x01
 
 /* Socket NET_MGMT options */
 #define SOL_NET_MGMT_BASE 100
 #define SOL_NET_MGMT_RAW (SOL_NET_MGMT_BASE + 1)
+
+/** @endcond */
 
 /**
  * struct sockaddr_nm - The sockaddr structure for NET_MGMT sockets

--- a/include/zephyr/net/socket_offload.h
+++ b/include/zephyr/net/socket_offload.h
@@ -26,9 +26,11 @@ extern "C" {
  * POSIX socket API standard for arguments, return values and setting of errno.
  */
 struct socket_dns_offload {
+	/** DNS getaddrinfo offloaded implementation API */
 	int (*getaddrinfo)(const char *node, const char *service,
 			   const struct zsock_addrinfo *hints,
 			   struct zsock_addrinfo **res);
+	/** DNS freeaddrinfo offloaded implementation API */
 	void (*freeaddrinfo)(struct zsock_addrinfo *res);
 };
 
@@ -39,11 +41,15 @@ struct socket_dns_offload {
  */
 void socket_offload_dns_register(const struct socket_dns_offload *ops);
 
+/** @cond INTERNAL_HIDDEN */
+
 int socket_offload_getaddrinfo(const char *node, const char *service,
 			       const struct zsock_addrinfo *hints,
 			       struct zsock_addrinfo **res);
 
 void socket_offload_freeaddrinfo(struct zsock_addrinfo *res);
+
+/** @endcond */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/net/socket_select.h
+++ b/include/zephyr/net/socket_select.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/** @file socket_select.h
+ *
+ * @brief BSD select support functions.
+ */
+
 #ifndef ZEPHYR_INCLUDE_NET_SOCKET_SELECT_H_
 #define ZEPHYR_INCLUDE_NET_SOCKET_SELECT_H_
 
@@ -21,10 +26,13 @@
 extern "C" {
 #endif
 
+/** @cond INTERNAL_HIDDEN */
+
 typedef struct zsock_fd_set {
 	uint32_t bitset[(CONFIG_POSIX_MAX_FDS + 31) / 32];
 } zsock_fd_set;
 
+/** @endcond */
 
 /**
  * @brief Legacy function to poll multiple sockets for events
@@ -106,6 +114,8 @@ void ZSOCK_FD_CLR(int fd, zsock_fd_set *set);
  */
 void ZSOCK_FD_SET(int fd, zsock_fd_set *set);
 
+/** @cond INTERNAL_HIDDEN */
+
 #ifdef CONFIG_NET_SOCKETS_POSIX_NAMES
 
 #define fd_set zsock_fd_set
@@ -139,6 +149,8 @@ static inline void FD_SET(int fd, zsock_fd_set *set)
 }
 
 #endif /* CONFIG_NET_SOCKETS_POSIX_NAMES */
+
+/** @endcond */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/net/socket_service.h
+++ b/include/zephyr/net/socket_service.h
@@ -75,6 +75,8 @@ struct net_socket_service_desc {
 	int *idx;
 };
 
+/** @cond INTERNAL_HIDDEN */
+
 #define __z_net_socket_svc_get_name(_svc_id) __z_net_socket_service_##_svc_id
 #define __z_net_socket_svc_get_idx(_svc_id) __z_net_socket_service_idx_##_svc_id
 #define __z_net_socket_svc_get_owner __FILE__ ":" STRINGIFY(__LINE__)
@@ -109,6 +111,8 @@ extern void net_socket_service_callback(struct k_work *work);
 		.pev_len = (_count),					\
 		.idx = &__z_net_socket_svc_get_idx(_name),		\
 	}
+
+/** @endcond */
 
 /**
  * @brief Statically define a network socket service.

--- a/include/zephyr/net/socket_types.h
+++ b/include/zephyr/net/socket_types.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief socket types definitionis
+ */
+
 #ifndef ZEPHYR_INCLUDE_NET_SOCKET_TYPES_H_
 #define ZEPHYR_INCLUDE_NET_SOCKET_TYPES_H_
 
@@ -16,6 +21,7 @@
 
 #include <zephyr/types.h>
 
+/** @cond INTERNAL_HIDDEN */
 
 #ifdef CONFIG_NEWLIB_LIBC
 
@@ -51,6 +57,8 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+/** @endcond */
 
 /**
  * @}

--- a/include/zephyr/net/socketcan.h
+++ b/include/zephyr/net/socketcan.h
@@ -28,8 +28,10 @@ extern "C" {
  * @{
  */
 
-/* Protocols of the protocol family PF_CAN */
+/** Protocols of the protocol family PF_CAN */
 #define CAN_RAW 1
+
+/** @cond INTERNAL_HIDDEN */
 
 /* SocketCAN options */
 #define SOL_CAN_BASE 100
@@ -39,28 +41,35 @@ enum {
 	CAN_RAW_FILTER = 1,
 };
 
+/** @endcond */
+
 /* SocketCAN MTU size compatible with Linux */
 #ifdef CONFIG_CAN_FD_MODE
+/** SocketCAN max data length */
 #define SOCKETCAN_MAX_DLEN 64U
+/** CAN FD frame MTU */
 #define CANFD_MTU (sizeof(struct socketcan_frame))
+/** CAN frame MTU */
 #define CAN_MTU (CANFD_MTU - 56U)
 #else /* CONFIG_CAN_FD_MODE */
+/** SocketCAN max data length */
 #define SOCKETCAN_MAX_DLEN 8U
+/** CAN frame MTU */
 #define CAN_MTU (sizeof(struct socketcan_frame))
 #endif /* !CONFIG_CAN_FD_MODE */
 
 /* CAN FD specific flags from Linux Kernel (include/uapi/linux/can.h) */
-#define CANFD_BRS 0x01 /* bit rate switch (second bitrate for payload data) */
-#define CANFD_ESI 0x02 /* error state indicator of the transmitting node */
-#define CANFD_FDF 0x04 /* mark CAN FD for dual use of struct canfd_frame */
+#define CANFD_BRS 0x01 /**< Bit rate switch (second bitrate for payload data) */
+#define CANFD_ESI 0x02 /**< Error state indicator of the transmitting node */
+#define CANFD_FDF 0x04 /**< Mark CAN FD for dual use of struct canfd_frame */
 
 /**
  * struct sockaddr_can - The sockaddr structure for CAN sockets
  *
  */
 struct sockaddr_can {
-	sa_family_t can_family;
-	int         can_ifindex;
+	sa_family_t can_family;   /**< Address family */
+	int         can_ifindex;  /**< SocketCAN network interface index */
 };
 
 /**

--- a/include/zephyr/net/socketutils.h
+++ b/include/zephyr/net/socketutils.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Socket utility functions.
+ */
+
 #ifndef ZEPHYR_INCLUDE_NET_SOCKETUTILS_H_
 #define ZEPHYR_INCLUDE_NET_SOCKETUTILS_H_
 

--- a/include/zephyr/net/tftp.h
+++ b/include/zephyr/net/tftp.h
@@ -6,10 +6,11 @@
 
 /** @file tftp.h
  *
+ * @brief TFTP Client Implementation
+ *
  * @defgroup tftp_client TFTP Client library
  * @ingroup networking
  * @{
- * @brief TFTP Client Implementation
  */
 
 #ifndef ZEPHYR_INCLUDE_NET_TFTP_H_

--- a/include/zephyr/net/trickle.h
+++ b/include/zephyr/net/trickle.h
@@ -60,11 +60,11 @@ struct net_trickle {
 	uint8_t k;		/**< Redundancy constant */
 	uint8_t c;		/**< Consistency counter */
 
-	bool double_to;
+	bool double_to;         /**< Flag telling if the internval is doubled */
 
-	struct k_work_delayable timer;
+	struct k_work_delayable timer; /**< Internal timer struct */
 	net_trickle_cb_t cb;	/**< Callback to be called when timer expires */
-	void *user_data;
+	void *user_data;        /**< User specific opaque data */
 };
 
 /** @cond INTERNAL_HIDDEN */

--- a/include/zephyr/net/virtual.h
+++ b/include/zephyr/net/virtual.h
@@ -81,6 +81,7 @@ struct virtual_interface_config {
 #endif
 /** @endcond */
 
+/** Virtual L2 API operations. */
 struct virtual_interface_api {
 	/**
 	 * The net_if_api must be placed in first position in this

--- a/include/zephyr/net/websocket.h
+++ b/include/zephyr/net/websocket.h
@@ -38,13 +38,14 @@ extern "C" {
 #define WEBSOCKET_FLAG_PING   0x00000010 /**< Ping message       */
 #define WEBSOCKET_FLAG_PONG   0x00000020 /**< Pong message       */
 
+/** @brief Websocket option codes */
 enum websocket_opcode  {
-	WEBSOCKET_OPCODE_CONTINUE     = 0x00,
-	WEBSOCKET_OPCODE_DATA_TEXT    = 0x01,
-	WEBSOCKET_OPCODE_DATA_BINARY  = 0x02,
-	WEBSOCKET_OPCODE_CLOSE        = 0x08,
-	WEBSOCKET_OPCODE_PING         = 0x09,
-	WEBSOCKET_OPCODE_PONG         = 0x0A,
+	WEBSOCKET_OPCODE_CONTINUE     = 0x00, /**< Message continues */
+	WEBSOCKET_OPCODE_DATA_TEXT    = 0x01, /**< Textual data */
+	WEBSOCKET_OPCODE_DATA_BINARY  = 0x02, /**< Binary data */
+	WEBSOCKET_OPCODE_CLOSE        = 0x08, /**< Closing connection */
+	WEBSOCKET_OPCODE_PING         = 0x09, /**< Ping message */
+	WEBSOCKET_OPCODE_PONG         = 0x0A, /**< Pong message */
 };
 
 /**
@@ -212,6 +213,8 @@ int websocket_register(int http_sock, uint8_t *recv_buf, size_t recv_buf_len);
  */
 int websocket_unregister(int ws_sock);
 
+/** @cond INTERNAL_HIDDEN */
+
 #if defined(CONFIG_WEBSOCKET_CLIENT)
 void websocket_init(void);
 #else
@@ -219,6 +222,8 @@ static inline void websocket_init(void)
 {
 }
 #endif
+
+/** @endcond */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/net/wifi.h
+++ b/include/zephyr/net/wifi.h
@@ -22,16 +22,21 @@
 
 #include <zephyr/sys/util.h>  /* for ARRAY_SIZE */
 
+/** Length of the country code string */
 #define WIFI_COUNTRY_CODE_LEN 2
+
+/** @cond INTERNAL_HIDDEN */
 
 #define WIFI_LISTEN_INTERVAL_MIN 0
 #define WIFI_LISTEN_INTERVAL_MAX 65535
+
+/** @endcond */
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/** IEEE 802.11 security types. */
+/** @brief IEEE 802.11 security types. */
 enum wifi_security_type {
 	/** No security. */
 	WIFI_SECURITY_TYPE_NONE = 0,
@@ -52,15 +57,17 @@ enum wifi_security_type {
 	/** WPA/WPA2/WPA3 PSK security. */
 	WIFI_SECURITY_TYPE_WPA_AUTO_PERSONAL,
 
+/** @cond INTERNAL_HIDDEN */
 	__WIFI_SECURITY_TYPE_AFTER_LAST,
 	WIFI_SECURITY_TYPE_MAX = __WIFI_SECURITY_TYPE_AFTER_LAST - 1,
 	WIFI_SECURITY_TYPE_UNKNOWN
+/** @endcond */
 };
 
 /** Helper function to get user-friendly security type name. */
 const char *wifi_security_txt(enum wifi_security_type security);
 
-/** IEEE 802.11w - Management frame protection. */
+/** @brief IEEE 802.11w - Management frame protection. */
 enum wifi_mfp_options {
 	/** MFP disabled. */
 	WIFI_MFP_DISABLE = 0,
@@ -69,9 +76,11 @@ enum wifi_mfp_options {
 	/** MFP required. */
 	WIFI_MFP_REQUIRED,
 
+/** @cond INTERNAL_HIDDEN */
 	__WIFI_MFP_AFTER_LAST,
 	WIFI_MFP_MAX = __WIFI_MFP_AFTER_LAST - 1,
 	WIFI_MFP_UNKNOWN
+/** @endcond */
 };
 
 /** Helper function to get user-friendly MFP name.*/
@@ -99,17 +108,25 @@ enum wifi_frequency_bands {
 /** Helper function to get user-friendly frequency band name. */
 const char *wifi_band_txt(enum wifi_frequency_bands band);
 
+/** Max SSID length */
 #define WIFI_SSID_MAX_LEN 32
+/** Minimum PSK length */
 #define WIFI_PSK_MIN_LEN 8
+/** Maximum PSK length */
 #define WIFI_PSK_MAX_LEN 64
+/** Max SAW password length */
 #define WIFI_SAE_PSWD_MAX_LEN 128
+/** MAC address length */
 #define WIFI_MAC_ADDR_LEN 6
 
+/** Minimum channel number */
 #define WIFI_CHANNEL_MIN 1
+/** Maximum channel number */
 #define WIFI_CHANNEL_MAX 233
+/** Any channel number */
 #define WIFI_CHANNEL_ANY 255
 
-/** Wi-Fi interface states.
+/** @brief Wi-Fi interface states.
  *
  * Based on https://w1.fi/wpa_supplicant/devel/defs_8h.html#a4aeb27c1e4abd046df3064ea9756f0bc
  */
@@ -135,9 +152,11 @@ enum wifi_iface_state {
 	/** All authentication completed, ready to pass data. */
 	WIFI_STATE_COMPLETED,
 
+/** @cond INTERNAL_HIDDEN */
 	__WIFI_STATE_AFTER_LAST,
 	WIFI_STATE_MAX = __WIFI_STATE_AFTER_LAST - 1,
 	WIFI_STATE_UNKNOWN
+/** @endcond */
 };
 
 /* We rely on the strict order of the enum values, so, let's check it */
@@ -155,7 +174,7 @@ BUILD_ASSERT(WIFI_STATE_DISCONNECTED < WIFI_STATE_INTERFACE_DISABLED &&
 /** Helper function to get user-friendly interface state name. */
 const char *wifi_state_txt(enum wifi_iface_state state);
 
-/** Wi-Fi interface modes.
+/** @brief Wi-Fi interface modes.
  *
  * Based on https://w1.fi/wpa_supplicant/devel/defs_8h.html#a4aeb27c1e4abd046df3064ea9756f0bc
  */
@@ -173,15 +192,17 @@ enum wifi_iface_mode {
 	/** 802.11s Mesh mode. */
 	WIFI_MODE_MESH = 5,
 
+/** @cond INTERNAL_HIDDEN */
 	__WIFI_MODE_AFTER_LAST,
 	WIFI_MODE_MAX = __WIFI_MODE_AFTER_LAST - 1,
 	WIFI_MODE_UNKNOWN
+/** @endcond */
 };
 
 /** Helper function to get user-friendly interface mode name. */
 const char *wifi_mode_txt(enum wifi_iface_mode mode);
 
-/** Wi-Fi link operating modes
+/** @brief Wi-Fi link operating modes
  *
  * As per https://en.wikipedia.org/wiki/Wi-Fi#Versions_and_generations.
  */
@@ -205,15 +226,17 @@ enum wifi_link_mode {
 	/** 802.11be. */
 	WIFI_7,
 
+/** @cond INTERNAL_HIDDEN */
 	__WIFI_LINK_MODE_AFTER_LAST,
 	WIFI_LINK_MODE_MAX = __WIFI_LINK_MODE_AFTER_LAST - 1,
 	WIFI_LINK_MODE_UNKNOWN
+/** @endcond */
 };
 
 /** Helper function to get user-friendly link mode name. */
 const char *wifi_link_mode_txt(enum wifi_link_mode link_mode);
 
-/** Wi-Fi scanning types. */
+/** @brief Wi-Fi scanning types. */
 enum wifi_scan_type {
 	/** Active scanning (default). */
 	WIFI_SCAN_TYPE_ACTIVE = 0,
@@ -221,7 +244,7 @@ enum wifi_scan_type {
 	WIFI_SCAN_TYPE_PASSIVE,
 };
 
-/** Wi-Fi power save states. */
+/** @brief Wi-Fi power save states. */
 enum wifi_ps {
 	/** Power save disabled. */
 	WIFI_PS_DISABLED = 0,
@@ -232,7 +255,7 @@ enum wifi_ps {
 /** Helper function to get user-friendly ps name. */
 const char *wifi_ps_txt(enum wifi_ps ps_name);
 
-/** Wi-Fi power save modes. */
+/** @brief Wi-Fi power save modes. */
 enum wifi_ps_mode {
 	/** Legacy power save mode. */
 	WIFI_PS_MODE_LEGACY = 0,
@@ -246,11 +269,12 @@ enum wifi_ps_mode {
 /** Helper function to get user-friendly ps mode name. */
 const char *wifi_ps_mode_txt(enum wifi_ps_mode ps_mode);
 
-/* Interface index Min and Max values */
+/** Network interface index min value */
 #define WIFI_INTERFACE_INDEX_MIN 1
+/** Network interface index max value */
 #define WIFI_INTERFACE_INDEX_MAX 255
 
-/** Wifi operational mode */
+/** @brief Wifi operational mode */
 enum wifi_operational_modes {
 	/** STA mode setting enable */
 	WIFI_STA_MODE = BIT(0),
@@ -266,7 +290,7 @@ enum wifi_operational_modes {
 	WIFI_SOFTAP_MODE = BIT(5),
 };
 
-/** Mode filter settings */
+/** @brief Mode filter settings */
 enum wifi_filter {
 	/** Support management, data and control packet sniffing */
 	WIFI_PACKET_FILTER_ALL = BIT(0),
@@ -278,7 +302,7 @@ enum wifi_filter {
 	WIFI_PACKET_FILTER_CTRL = BIT(3),
 };
 
-/** Wi-Fi Target Wake Time (TWT) operations. */
+/** @brief Wi-Fi Target Wake Time (TWT) operations. */
 enum wifi_twt_operation {
 	/** TWT setup operation */
 	WIFI_TWT_SETUP = 0,
@@ -289,7 +313,7 @@ enum wifi_twt_operation {
 /** Helper function to get user-friendly twt operation name. */
 const char *wifi_twt_operation_txt(enum wifi_twt_operation twt_operation);
 
-/** Wi-Fi Target Wake Time (TWT) negotiation types. */
+/** @brief Wi-Fi Target Wake Time (TWT) negotiation types. */
 enum wifi_twt_negotiation_type {
 	/** TWT individual negotiation */
 	WIFI_TWT_INDIVIDUAL = 0,
@@ -302,7 +326,7 @@ enum wifi_twt_negotiation_type {
 /** Helper function to get user-friendly twt negotiation type name. */
 const char *wifi_twt_negotiation_type_txt(enum wifi_twt_negotiation_type twt_negotiation);
 
-/** Wi-Fi Target Wake Time (TWT) setup commands. */
+/** @brief Wi-Fi Target Wake Time (TWT) setup commands. */
 enum wifi_twt_setup_cmd {
 	/** TWT setup request */
 	WIFI_TWT_SETUP_CMD_REQUEST = 0,
@@ -325,7 +349,7 @@ enum wifi_twt_setup_cmd {
 /** Helper function to get user-friendly twt setup cmd name. */
 const char *wifi_twt_setup_cmd_txt(enum wifi_twt_setup_cmd twt_setup);
 
-/** Wi-Fi Target Wake Time (TWT) negotiation status. */
+/** @brief Wi-Fi Target Wake Time (TWT) negotiation status. */
 enum wifi_twt_setup_resp_status {
 	/** TWT response received for TWT request */
 	WIFI_TWT_RESP_RECEIVED = 0,
@@ -333,7 +357,7 @@ enum wifi_twt_setup_resp_status {
 	WIFI_TWT_RESP_NOT_RECEIVED,
 };
 
-/** Target Wake Time (TWT) error codes. */
+/** @brief Target Wake Time (TWT) error codes. */
 enum wifi_twt_fail_reason {
 	/** Unspecified error */
 	WIFI_TWT_FAIL_UNSPECIFIED,
@@ -359,7 +383,7 @@ enum wifi_twt_fail_reason {
 	WIFI_TWT_FAIL_FLOW_ALREADY_EXISTS,
 };
 
-/** Wi-Fi Target Wake Time (TWT) teradown status. */
+/** @brief Wi-Fi Target Wake Time (TWT) teradown status. */
 enum wifi_twt_teardown_status {
 	/** TWT teardown success */
 	WIFI_TWT_TEARDOWN_SUCCESS = 0,
@@ -400,7 +424,7 @@ static inline const char *wifi_twt_get_err_code_str(int16_t err_no)
 	return "<unknown>";
 }
 
-/** Wi-Fi power save parameters. */
+/** @brief Wi-Fi power save parameters. */
 enum wifi_ps_param_type {
 	/** Power save state. */
 	WIFI_PS_PARAM_STATE,
@@ -414,7 +438,7 @@ enum wifi_ps_param_type {
 	WIFI_PS_PARAM_TIMEOUT,
 };
 
-/** Wi-Fi power save modes. */
+/** @brief Wi-Fi power save modes. */
 enum wifi_ps_wakeup_mode {
 	/** DTIM based wakeup. */
 	WIFI_PS_WAKEUP_MODE_DTIM = 0,
@@ -425,7 +449,7 @@ enum wifi_ps_wakeup_mode {
 /** Helper function to get user-friendly ps wakeup mode name. */
 const char *wifi_ps_wakeup_mode_txt(enum wifi_ps_wakeup_mode ps_wakeup_mode);
 
-/** Wi-Fi power save error codes. */
+/** @brief Wi-Fi power save error codes. */
 enum wifi_config_ps_param_fail_reason {
 	/** Unspecified error */
 	WIFI_PS_PARAM_FAIL_UNSPECIFIED,

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -28,6 +28,8 @@ extern "C" {
 
 /* Management part definitions */
 
+/** @cond INTERNAL_HIDDEN */
+
 #define _NET_WIFI_LAYER	NET_MGMT_LAYER_L2
 #define _NET_WIFI_CODE	0x156
 #define _NET_WIFI_BASE	(NET_MGMT_IFACE_BIT |			\
@@ -50,7 +52,9 @@ extern "C" {
 #define WIFI_MGMT_BAND_STR_SIZE_MAX 8
 #define WIFI_MGMT_SCAN_MAX_BSS_CNT 65535
 
-/** Wi-Fi management commands */
+/** @endcond */
+
+/** @brief Wi-Fi management commands */
 enum net_request_wifi_cmd {
 	/** Scan for Wi-Fi networks */
 	NET_REQUEST_WIFI_CMD_SCAN = 1,
@@ -84,88 +88,109 @@ enum net_request_wifi_cmd {
 	NET_REQUEST_WIFI_CMD_VERSION,
 	/** Set RTS threshold */
 	NET_REQUEST_WIFI_CMD_RTS_THRESHOLD,
+
+/** @cond INTERNAL_HIDDEN */
 	NET_REQUEST_WIFI_CMD_MAX
+/** @endcond */
 };
 
+/** Request a Wi-Fi scan */
 #define NET_REQUEST_WIFI_SCAN					\
 	(_NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_SCAN)
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_SCAN);
 
+/** Request a Wi-Fi connect */
 #define NET_REQUEST_WIFI_CONNECT				\
 	(_NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_CONNECT)
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_CONNECT);
 
+/** Request a Wi-Fi disconnect */
 #define NET_REQUEST_WIFI_DISCONNECT				\
 	(_NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_DISCONNECT)
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_DISCONNECT);
 
+/** Request a Wi-Fi access point enable */
 #define NET_REQUEST_WIFI_AP_ENABLE				\
 	(_NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_AP_ENABLE)
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_AP_ENABLE);
 
+/** Request a Wi-Fi access point disable */
 #define NET_REQUEST_WIFI_AP_DISABLE				\
 	(_NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_AP_DISABLE)
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_AP_DISABLE);
 
+/** Request a Wi-Fi network interface status */
 #define NET_REQUEST_WIFI_IFACE_STATUS				\
 	(_NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_IFACE_STATUS)
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_IFACE_STATUS);
 
-#define NET_REQUEST_WIFI_PS				\
+/** Request a Wi-Fi power save */
+#define NET_REQUEST_WIFI_PS					\
 	(_NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_PS)
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_PS);
 
-#define NET_REQUEST_WIFI_TWT			\
+/** Request a Wi-Fi TWT */
+#define NET_REQUEST_WIFI_TWT					\
 	(_NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_TWT)
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_TWT);
 
+/** Request a Wi-Fi power save configuration */
 #define NET_REQUEST_WIFI_PS_CONFIG				\
 	(_NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_PS_CONFIG)
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_PS_CONFIG);
+
+/** Request a Wi-Fi regulatory domain */
 #define NET_REQUEST_WIFI_REG_DOMAIN				\
 	(_NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_REG_DOMAIN)
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_REG_DOMAIN);
 
-#define NET_REQUEST_WIFI_MODE				\
+/** Request current Wi-Fi mode */
+#define NET_REQUEST_WIFI_MODE					\
 	(_NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_MODE)
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_MODE);
 
-#define NET_REQUEST_WIFI_PACKET_FILTER			\
+/** Request Wi-Fi packet filter */
+#define NET_REQUEST_WIFI_PACKET_FILTER				\
 	(_NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_PACKET_FILTER)
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_PACKET_FILTER);
 
-#define NET_REQUEST_WIFI_CHANNEL			\
+/** Request a Wi-Fi channel */
+#define NET_REQUEST_WIFI_CHANNEL				\
 	(_NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_CHANNEL)
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_CHANNEL);
 
+/** Request a Wi-Fi access point to disconnect a station */
 #define NET_REQUEST_WIFI_AP_STA_DISCONNECT			\
 	(_NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_AP_STA_DISCONNECT)
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_AP_STA_DISCONNECT);
 
-#define NET_REQUEST_WIFI_VERSION			\
+/** Request a Wi-Fi version */
+#define NET_REQUEST_WIFI_VERSION				\
 	(_NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_VERSION)
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_VERSION);
 
-#define NET_REQUEST_WIFI_RTS_THRESHOLD			\
+/** Request a Wi-Fi RTS threashold */
+#define NET_REQUEST_WIFI_RTS_THRESHOLD				\
 	(_NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_RTS_THRESHOLD)
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_RTS_THRESHOLD);
-/** Wi-Fi management events */
+
+/** @brief Wi-Fi management events */
 enum net_event_wifi_cmd {
 	/** Scan results available */
 	NET_EVENT_WIFI_CMD_SCAN_RESULT = 1,
@@ -197,46 +222,59 @@ enum net_event_wifi_cmd {
 	NET_EVENT_WIFI_CMD_AP_STA_DISCONNECTED,
 };
 
+/** Event emitted for Wi-Fi scan result */
 #define NET_EVENT_WIFI_SCAN_RESULT				\
 	(_NET_WIFI_EVENT | NET_EVENT_WIFI_CMD_SCAN_RESULT)
 
+/** Event emitted when Wi-Fi scan is done */
 #define NET_EVENT_WIFI_SCAN_DONE				\
 	(_NET_WIFI_EVENT | NET_EVENT_WIFI_CMD_SCAN_DONE)
 
+/** Event emitted for Wi-Fi connect result */
 #define NET_EVENT_WIFI_CONNECT_RESULT				\
 	(_NET_WIFI_EVENT | NET_EVENT_WIFI_CMD_CONNECT_RESULT)
 
+/** Event emitted for Wi-Fi disconnect result */
 #define NET_EVENT_WIFI_DISCONNECT_RESULT			\
 	(_NET_WIFI_EVENT | NET_EVENT_WIFI_CMD_DISCONNECT_RESULT)
 
-#define NET_EVENT_WIFI_IFACE_STATUS						\
+/** Event emitted for Wi-Fi network interface status */
+#define NET_EVENT_WIFI_IFACE_STATUS				\
 	(_NET_WIFI_EVENT | NET_EVENT_WIFI_CMD_IFACE_STATUS)
 
+/** Event emitted for Wi-Fi TWT information */
 #define NET_EVENT_WIFI_TWT					\
 	(_NET_WIFI_EVENT | NET_EVENT_WIFI_CMD_TWT)
 
+/** Event emitted for Wi-Fi TWT sleep state */
 #define NET_EVENT_WIFI_TWT_SLEEP_STATE				\
 	(_NET_WIFI_EVENT | NET_EVENT_WIFI_CMD_TWT_SLEEP_STATE)
 
+/** Event emitted for Wi-Fi raw scan result */
 #define NET_EVENT_WIFI_RAW_SCAN_RESULT                          \
 	(_NET_WIFI_EVENT | NET_EVENT_WIFI_CMD_RAW_SCAN_RESULT)
 
+/** Event emitted Wi-Fi disconnect is completed */
 #define NET_EVENT_WIFI_DISCONNECT_COMPLETE			\
 	(_NET_WIFI_EVENT | NET_EVENT_WIFI_CMD_DISCONNECT_COMPLETE)
 
+/** Event emitted for Wi-Fi access point enable result */
 #define NET_EVENT_WIFI_AP_ENABLE_RESULT				\
 	(_NET_WIFI_EVENT | NET_EVENT_WIFI_CMD_AP_ENABLE_RESULT)
 
+/** Event emitted for Wi-Fi access point disable result */
 #define NET_EVENT_WIFI_AP_DISABLE_RESULT			\
 	(_NET_WIFI_EVENT | NET_EVENT_WIFI_CMD_AP_DISABLE_RESULT)
 
+/** Event emitted when Wi-Fi station is connected in AP mode */
 #define NET_EVENT_WIFI_AP_STA_CONNECTED				\
 	(_NET_WIFI_EVENT | NET_EVENT_WIFI_CMD_AP_STA_CONNECTED)
 
+/** Event emitted Wi-Fi station is disconnected from AP */
 #define NET_EVENT_WIFI_AP_STA_DISCONNECTED			\
 	(_NET_WIFI_EVENT | NET_EVENT_WIFI_CMD_AP_STA_DISCONNECTED)
 
-/** Wi-Fi version */
+/** @brief Wi-Fi version */
 struct wifi_version {
 	/** Driver version */
 	const char *drv_version;
@@ -306,7 +344,7 @@ struct wifi_scan_params {
 	struct wifi_band_channel band_chan[WIFI_MGMT_SCAN_CHAN_MAX_MANUAL];
 };
 
-/** Wi-Fi scan result, each result is provided to the net_mgmt_event_callback
+/** @brief Wi-Fi scan result, each result is provided to the net_mgmt_event_callback
  * via its info attribute (see net_mgmt.h)
  */
 struct wifi_scan_result {
@@ -330,7 +368,7 @@ struct wifi_scan_result {
 	uint8_t mac_length;
 };
 
-/** Wi-Fi connect request parameters */
+/** @brief Wi-Fi connect request parameters */
 struct wifi_connect_req_params {
 	/** SSID */
 	const uint8_t *ssid;
@@ -358,7 +396,7 @@ struct wifi_connect_req_params {
 	int timeout;
 };
 
-/** Wi-Fi connect result codes. To be overlaid on top of \ref wifi_status
+/** @brief Wi-Fi connect result codes. To be overlaid on top of \ref wifi_status
  * in the connect result event for detailed status.
  */
 enum wifi_conn_status {
@@ -385,7 +423,7 @@ enum wifi_conn_status {
 	WIFI_STATUS_DISCONN_FIRST_STATUS = WIFI_STATUS_CONN_LAST_STATUS,
 };
 
-/** Wi-Fi disconnect reason codes. To be overlaid on top of \ref wifi_status
+/** @brief Wi-Fi disconnect reason codes. To be overlaid on top of \ref wifi_status
  * in the disconnect result event for detailed reason.
  */
 enum wifi_disconn_reason {
@@ -399,7 +437,7 @@ enum wifi_disconn_reason {
 	WIFI_REASON_DISCONN_INACTIVITY,
 };
 
-/** Wi-Fi AP mode result codes. To be overlaid on top of \ref wifi_status
+/** @brief Wi-Fi AP mode result codes. To be overlaid on top of \ref wifi_status
  * in the AP mode enable or disable result event for detailed status.
  */
 enum wifi_ap_status {
@@ -421,17 +459,21 @@ enum wifi_ap_status {
 	WIFI_STATUS_AP_OP_NOT_PERMITTED,
 };
 
-/** Generic Wi-Fi status for commands and events */
+/** @brief Generic Wi-Fi status for commands and events */
 struct wifi_status {
 	union {
+		/** Status value */
 		int status;
+		/** Connection status */
 		enum wifi_conn_status conn_status;
+		/** Disconnection reason status */
 		enum wifi_disconn_reason disconn_reason;
+		/** Access point status */
 		enum wifi_ap_status ap_status;
 	};
 };
 
-/** Wi-Fi interface status */
+/** @brief Wi-Fi interface status */
 struct wifi_iface_status {
 	/** Interface state, see enum wifi_iface_state */
 	int state;
@@ -463,11 +505,11 @@ struct wifi_iface_status {
 	bool twt_capable;
 };
 
-/** Wi-Fi power save parameters */
+/** @brief Wi-Fi power save parameters */
 struct wifi_ps_params {
-	/* Power save state */
+	/** Power save state */
 	enum wifi_ps enabled;
-	/* Listen interval */
+	/** Listen interval */
 	unsigned short listen_interval;
 	/** Wi-Fi power save wakeup mode */
 	enum wifi_ps_wakeup_mode wakeup_mode;
@@ -488,7 +530,7 @@ struct wifi_ps_params {
 	enum wifi_config_ps_param_fail_reason fail_reason;
 };
 
-/** Wi-Fi TWT parameters */
+/** @brief Wi-Fi TWT parameters */
 struct wifi_twt_params {
 	/** TWT operation, see enum wifi_twt_operation */
 	enum wifi_twt_operation operation;
@@ -519,7 +561,7 @@ struct wifi_twt_params {
 			bool announce;
 			/** Wake up time */
 			uint32_t twt_wake_interval;
-			/* Wake ahead notification is sent earlier than
+			/** Wake ahead notification is sent earlier than
 			 * TWT Service period (SP) start based on this duration.
 			 * This should give applications ample time to
 			 * prepare the data before TWT SP starts.
@@ -536,6 +578,8 @@ struct wifi_twt_params {
 	enum wifi_twt_fail_reason fail_reason;
 };
 
+/** @cond INTERNAL_HIDDEN */
+
 /* Flow ID is only 3 bits */
 #define WIFI_MAX_TWT_FLOWS 8
 #define WIFI_MAX_TWT_INTERVAL_US (LONG_MAX - 1)
@@ -543,7 +587,9 @@ struct wifi_twt_params {
 #define WIFI_MAX_TWT_WAKE_INTERVAL_US 262144
 #define WIFI_MAX_TWT_WAKE_AHEAD_DURATION_US (LONG_MAX - 1)
 
-/** Wi-Fi TWT flow information */
+/** @endcond */
+
+/** @brief Wi-Fi TWT flow information */
 struct wifi_twt_flow_info {
 	/** Interval = Wake up time + Sleeping time */
 	uint64_t  twt_interval;
@@ -563,11 +609,11 @@ struct wifi_twt_flow_info {
 	bool announce;
 	/** Wake up time */
 	uint32_t twt_wake_interval;
-	/* wake ahead duration */
+	/** Wake ahead duration */
 	uint32_t twt_wake_ahead_duration;
 };
 
-/** Wi-Fi power save configuration */
+/** @brief Wi-Fi power save configuration */
 struct wifi_ps_config {
 	/** Number of TWT flows */
 	char num_twt_flows;
@@ -577,7 +623,7 @@ struct wifi_ps_config {
 	struct wifi_ps_params ps_params;
 };
 
-/** Generic get/set operation for any command*/
+/** @brief Generic get/set operation for any command*/
 enum wifi_mgmt_op {
 	/** Get operation */
 	WIFI_MGMT_GET = 0,
@@ -585,9 +631,10 @@ enum wifi_mgmt_op {
 	WIFI_MGMT_SET = 1,
 };
 
+/** Max regulatory channel number */
 #define MAX_REG_CHAN_NUM  42
 
-/** Per-channel regulatory attributes */
+/** @brief Per-channel regulatory attributes */
 struct wifi_reg_chan_info {
 	/** Center frequency in MHz */
 	unsigned short center_frequency;
@@ -601,9 +648,9 @@ struct wifi_reg_chan_info {
 	unsigned short dfs:1;
 } __packed;
 
-/** Regulatory domain information or configuration */
+/** @brief Regulatory domain information or configuration */
 struct wifi_reg_domain {
-	/* Regulatory domain operation */
+	/** Regulatory domain operation */
 	enum wifi_mgmt_op oper;
 	/** Ignore all other regulatory hints over this one */
 	bool force;
@@ -615,7 +662,7 @@ struct wifi_reg_domain {
 	struct wifi_reg_chan_info *chan_info;
 };
 
-/** Wi-Fi TWT sleep states */
+/** @brief Wi-Fi TWT sleep states */
 enum wifi_twt_sleep_state {
 	/** TWT sleep state: sleeping */
 	WIFI_TWT_STATE_SLEEP = 0,
@@ -624,7 +671,7 @@ enum wifi_twt_sleep_state {
 };
 
 #if defined(CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS) || defined(__DOXYGEN__)
-/** Wi-Fi raw scan result */
+/** @brief Wi-Fi raw scan result */
 struct wifi_raw_scan_result {
 	/** RSSI */
 	int8_t rssi;
@@ -637,7 +684,7 @@ struct wifi_raw_scan_result {
 };
 #endif /* CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS */
 
-/** AP mode - connected STA details */
+/** @brief AP mode - connected STA details */
 struct wifi_ap_sta_info {
 	/** Link mode, see enum wifi_link_mode */
 	enum wifi_link_mode link_mode;
@@ -648,6 +695,8 @@ struct wifi_ap_sta_info {
 	/** is TWT capable ? */
 	bool twt_capable;
 };
+
+/** @cond INTERNAL_HIDDEN */
 
 /* for use in max info size calculations */
 union wifi_mgmt_events {
@@ -661,7 +710,9 @@ union wifi_mgmt_events {
 	struct wifi_ap_sta_info ap_sta_info;
 };
 
-/** Wi-Fi mode setup */
+/** @endcond */
+
+/** @brief Wi-Fi mode setup */
 struct wifi_mode_info {
 	/** Mode setting for a specific mode of operation */
 	uint8_t mode;
@@ -671,7 +722,7 @@ struct wifi_mode_info {
 	enum wifi_mgmt_op oper;
 };
 
-/** Wi-Fi filter setting for monitor, prmoiscuous, TX-injection modes */
+/** @brief Wi-Fi filter setting for monitor, prmoiscuous, TX-injection modes */
 struct wifi_filter_info {
 	/** Filter setting */
 	uint8_t filter;
@@ -683,7 +734,7 @@ struct wifi_filter_info {
 	enum wifi_mgmt_op oper;
 };
 
-/** Wi-Fi channel setting for monitor and TX-injection modes */
+/** @brief Wi-Fi channel setting for monitor and TX-injection modes */
 struct wifi_channel_info {
 	/** Channel value to set */
 	uint16_t channel;

--- a/include/zephyr/net/wifi_nm.h
+++ b/include/zephyr/net/wifi_nm.h
@@ -42,6 +42,8 @@ struct wifi_nm_instance {
 	struct net_if *mgd_ifaces[CONFIG_WIFI_NM_MAX_MANAGED_INTERFACES];
 };
 
+/** @cond INTERNAL_HIDDEN */
+
 #define WIFI_NM_NAME(name) wifi_nm_##name
 
 #define DEFINE_WIFI_NM_INSTANCE(_name, _ops)		\
@@ -50,6 +52,8 @@ struct wifi_nm_instance {
 		.ops = _ops,				\
 		.mgd_ifaces = { NULL },		\
 	}
+
+/** @endcond */
 
 /**
  * @brief Get a Network manager instance for a given name

--- a/include/zephyr/net/wifi_utils.h
+++ b/include/zephyr/net/wifi_utils.h
@@ -28,7 +28,10 @@ extern "C" {
  * @{
  */
 
+/** Maximum length of the band specification string */
 #define WIFI_UTILS_MAX_BAND_STR_LEN 3
+
+/** Maximum length of the channel specification string */
 #define WIFI_UTILS_MAX_CHAN_STR_LEN 4
 
 /**

--- a/include/zephyr/net/zperf.h
+++ b/include/zephyr/net/zperf.h
@@ -24,6 +24,8 @@
 extern "C" {
 #endif
 
+/** @cond INTERNAL_HIDDEN */
+
 enum zperf_status {
 	ZPERF_SESSION_STARTED,
 	ZPERF_SESSION_PERIODIC_RESULT,
@@ -51,17 +53,20 @@ struct zperf_download_params {
 	char if_name[IFNAMSIZ];
 };
 
+/** @endcond */
+
+/** Performance results */
 struct zperf_results {
-	uint32_t nb_packets_sent;
-	uint32_t nb_packets_rcvd;
-	uint32_t nb_packets_lost;
-	uint32_t nb_packets_outorder;
-	uint64_t total_len;
-	uint64_t time_in_us;
-	uint32_t jitter_in_us;
-	uint64_t client_time_in_us;
-	uint32_t packet_size;
-	uint32_t nb_packets_errors;
+	uint32_t nb_packets_sent;     /**< Number of packets sent */
+	uint32_t nb_packets_rcvd;     /**< Number of packets received */
+	uint32_t nb_packets_lost;     /**< Number of packets lost */
+	uint32_t nb_packets_outorder; /**< Number of packets out of order */
+	uint64_t total_len;           /**< Total length of the transferred data */
+	uint64_t time_in_us;          /**< Total time of the transfer in microseconds */
+	uint32_t jitter_in_us;        /**< Jitter in microseconds */
+	uint64_t client_time_in_us;   /**< Client connection time in microseconds */
+	uint32_t packet_size;         /**< Packet size */
+	uint32_t nb_packets_errors;   /**< Number of packet errors */
 };
 
 /**


### PR DESCRIPTION
This should improve network documentation coverage percentage.
So I added missing doxygen comments when applicable or hide internal documentation which does not need to be documented.
There are lot of commits, but most of them are very small. Each header file changed is placed in its own commit for easier revert / fix if needed.
