### PR TITLE
Do not set reason early as handler code won't replace it

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -778,6 +778,10 @@ class QEMUHandler(Handler):
 
         self.pid_fn = os.path.join(instance.build_dir, "qemu.pid")
 
+        self.stdout_fn = os.path.join(instance.build_dir, "qemu.stdout")
+
+        self.stderr_fn = os.path.join(instance.build_dir, "qemu.stderr")
+
         if instance.testsuite.ignore_qemu_crash:
             self.ignore_qemu_crash = True
             self.ignore_unexpected_eof = True
@@ -1010,7 +1014,7 @@ class QEMUHandler(Handler):
         is_timeout = False
         qemu_pid = None
 
-        with subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=self.build_dir) as proc:
+        with subprocess.Popen(command, stdout=open(self.stdout_fn, "wt"), stderr=open(self.stderr_fn, "wt"), cwd=self.build_dir) as proc:
             logger.debug("Spawning QEMUHandler Thread for %s" % self.name)
 
             try:

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -47,7 +47,7 @@ class TestInstance:
         self.platform: Platform = platform
 
         self.status = None
-        self.reason = "Unknown"
+        self.reason = None
         self.metrics = dict()
         self.handler = None
         self.recording = None


### PR DESCRIPTION
Handler code, for example QemuHandler, will not replace the "instance.reason" if it is already set (checks against None) so if this is set early here, we will not receive the correct error later.