### PR TITLE
Capture qemu launch stdout and stderr

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -799,6 +799,10 @@ class QEMUHandler(Handler):
 
         self.pid_fn = os.path.join(instance.build_dir, "qemu.pid")
 
+        self.stdout_fn = os.path.join(instance.build_dir, "qemu.stdout")
+
+        self.stderr_fn = os.path.join(instance.build_dir, "qemu.stderr")
+
         if instance.testsuite.ignore_qemu_crash:
             self.ignore_qemu_crash = True
             self.ignore_unexpected_eof = True
@@ -1033,7 +1037,7 @@ class QEMUHandler(Handler):
         is_timeout = False
         qemu_pid = None
 
-        with subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=self.build_dir) as proc:
+        with subprocess.Popen(command, stdout=open(self.stdout_fn, "wt"), stderr=open(self.stderr_fn, "wt"), cwd=self.build_dir) as proc:
             logger.debug("Spawning QEMUHandler Thread for %s" % self.name)
 
             try:


### PR DESCRIPTION
Currently we launch qemu (well, "ninja run" usually) using Popen and request stdout and stderr to be redirected into a pipe. However we never read that pipe so the information is not captured. Instead log directly into files that can be inspected after a failed to to find out why qemu run failed.

Note that this is really only useful in cases where qemu either fails to launch or crashes.

Regular test data is still handled via the qemu fifo.

Fixes #72997 