### PR TITLE
drivers: eth: stm32: fix typo in Kconfig

### DIFF
--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -30,7 +30,7 @@ config ETH_STM32_HAL_API_V2
 	  Use the new HAL driver instead of the legacy one.
 
 config ETH_STM32_HAL_API_V1
-	bool "Use new HAL driver"
+	bool "Use legacy HAL driver"
 	depends on !SOC_SERIES_STM32H5X
 	select DEPRECATED if SOC_SERIES_STM32H7X || SOC_SERIES_STM32F4X || SOC_SERIES_STM32F7X
 	help


### PR DESCRIPTION
For the choice ETH_STM32_HAL_API_VERSION, both options ETH_STM32_HAL_API_V2 and ETH_STM32_HAL_API_V1 had the same prompt "Use new HAL driver". This commit fixes the prompt for the legacy driver.