### PR TITLE
drivers: video: introduce semantics for `enum endpoint_id`

### DIFF
--- a/drivers/video/video_mcux_csi.c
+++ b/drivers/video/video_mcux_csi.c
@@ -155,7 +155,7 @@ static int video_mcux_csi_set_fmt(const struct device *dev, enum video_endpoint_
 	status_t ret;
 	struct video_format format = *fmt;
 
-	if (!bpp || ep != VIDEO_EP_OUT) {
+	if (bpp == 0 || (ep != VIDEO_EP_OUT && ep != VIDEO_EP_ALL)) {
 		return -EINVAL;
 	}
 
@@ -198,7 +198,7 @@ static int video_mcux_csi_get_fmt(const struct device *dev, enum video_endpoint_
 {
 	const struct video_mcux_csi_config *config = dev->config;
 
-	if (fmt == NULL || ep != VIDEO_EP_OUT) {
+	if (fmt == NULL || (ep != VIDEO_EP_OUT && ep != VIDEO_EP_ALL)) {
 		return -EINVAL;
 	}
 
@@ -288,7 +288,7 @@ static int video_mcux_csi_enqueue(const struct device *dev, enum video_endpoint_
 	unsigned int to_read;
 	status_t ret;
 
-	if (ep != VIDEO_EP_OUT) {
+	if (ep != VIDEO_EP_OUT && ep != VIDEO_EP_ALL) {
 		return -EINVAL;
 	}
 
@@ -311,7 +311,7 @@ static int video_mcux_csi_dequeue(const struct device *dev, enum video_endpoint_
 {
 	struct video_mcux_csi_data *data = dev->data;
 
-	if (ep != VIDEO_EP_OUT) {
+	if (ep != VIDEO_EP_OUT && ep != VIDEO_EP_ALL) {
 		return -EINVAL;
 	}
 
@@ -355,7 +355,7 @@ static int video_mcux_csi_get_caps(const struct device *dev, enum video_endpoint
 	const struct video_mcux_csi_config *config = dev->config;
 	int err = -ENODEV;
 
-	if (ep != VIDEO_EP_OUT) {
+	if (ep != VIDEO_EP_OUT && ep != VIDEO_EP_ALL) {
 		return -EINVAL;
 	}
 

--- a/drivers/video/video_mcux_mipi_csi2rx.c
+++ b/drivers/video/video_mcux_mipi_csi2rx.c
@@ -132,7 +132,7 @@ static int mipi_csi2rx_get_fmt(const struct device *dev, enum video_endpoint_id 
 {
 	const struct mipi_csi2rx_config *config = dev->config;
 
-	if (fmt == NULL || ep != VIDEO_EP_OUT) {
+	if (fmt == NULL || (ep != VIDEO_EP_OUT && ep != VIDEO_EP_ALL)) {
 		return -EINVAL;
 	}
 
@@ -175,7 +175,7 @@ static int mipi_csi2rx_get_caps(const struct device *dev, enum video_endpoint_id
 {
 	const struct mipi_csi2rx_config *config = dev->config;
 
-	if (ep != VIDEO_EP_OUT) {
+	if (ep != VIDEO_EP_OUT && ep != VIDEO_EP_ALL) {
 		return -EINVAL;
 	}
 

--- a/drivers/video/video_stm32_dcmi.c
+++ b/drivers/video/video_stm32_dcmi.c
@@ -215,7 +215,7 @@ static int video_stm32_dcmi_set_fmt(const struct device *dev,
 	struct video_stm32_dcmi_data *data = dev->data;
 	unsigned int bpp = video_pix_fmt_bpp(fmt->pixelformat);
 
-	if (!bpp || ep != VIDEO_EP_OUT) {
+	if (bpp == 0 || (ep != VIDEO_EP_OUT && ep != VIDEO_EP_ALL)) {
 		return -EINVAL;
 	}
 
@@ -238,7 +238,7 @@ static int video_stm32_dcmi_get_fmt(const struct device *dev,
 	struct video_stm32_dcmi_data *data = dev->data;
 	const struct video_stm32_dcmi_config *config = dev->config;
 
-	if ((fmt == NULL) || (ep != VIDEO_EP_OUT)) {
+	if (fmt == NULL || (ep != VIDEO_EP_OUT && ep != VIDEO_EP_ALL)) {
 		return -EINVAL;
 	}
 
@@ -309,7 +309,7 @@ static int video_stm32_dcmi_enqueue(const struct device *dev,
 {
 	struct video_stm32_dcmi_data *data = dev->data;
 
-	if (ep != VIDEO_EP_OUT) {
+	if (ep != VIDEO_EP_OUT && ep != VIDEO_EP_ALL) {
 		return -EINVAL;
 	}
 
@@ -327,7 +327,7 @@ static int video_stm32_dcmi_dequeue(const struct device *dev,
 {
 	struct video_stm32_dcmi_data *data = dev->data;
 
-	if (ep != VIDEO_EP_OUT) {
+	if (ep != VIDEO_EP_OUT && ep != VIDEO_EP_ALL) {
 		return -EINVAL;
 	}
 
@@ -346,7 +346,7 @@ static int video_stm32_dcmi_get_caps(const struct device *dev,
 	const struct video_stm32_dcmi_config *config = dev->config;
 	int ret = -ENODEV;
 
-	if (ep != VIDEO_EP_OUT) {
+	if (ep != VIDEO_EP_OUT && ep != VIDEO_EP_ALL) {
 		return -EINVAL;
 	}
 

--- a/drivers/video/video_sw_generator.c
+++ b/drivers/video/video_sw_generator.c
@@ -52,7 +52,7 @@ static int video_sw_generator_set_fmt(const struct device *dev, enum video_endpo
 	struct video_sw_generator_data *data = dev->data;
 	int i = 0;
 
-	if (ep != VIDEO_EP_OUT) {
+	if (ep != VIDEO_EP_OUT && ep != VIDEO_EP_ALL) {
 		return -EINVAL;
 	}
 
@@ -79,7 +79,7 @@ static int video_sw_generator_get_fmt(const struct device *dev, enum video_endpo
 {
 	struct video_sw_generator_data *data = dev->data;
 
-	if (ep != VIDEO_EP_OUT) {
+	if (ep != VIDEO_EP_OUT && ep != VIDEO_EP_ALL) {
 		return -EINVAL;
 	}
 
@@ -171,7 +171,7 @@ static int video_sw_generator_enqueue(const struct device *dev, enum video_endpo
 {
 	struct video_sw_generator_data *data = dev->data;
 
-	if (ep != VIDEO_EP_OUT) {
+	if (ep != VIDEO_EP_OUT && ep != VIDEO_EP_ALL) {
 		return -EINVAL;
 	}
 
@@ -185,7 +185,7 @@ static int video_sw_generator_dequeue(const struct device *dev, enum video_endpo
 {
 	struct video_sw_generator_data *data = dev->data;
 
-	if (ep != VIDEO_EP_OUT) {
+	if (ep != VIDEO_EP_OUT && ep != VIDEO_EP_ALL) {
 		return -EINVAL;
 	}
 

--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -124,10 +124,14 @@ struct video_buffer {
  * Identify the video device endpoint.
  */
 enum video_endpoint_id {
-	VIDEO_EP_NONE,
-	VIDEO_EP_ANY,
-	VIDEO_EP_IN,
-	VIDEO_EP_OUT,
+	/** Targets some part of the video device not bound to an endpoint */
+	VIDEO_EP_NONE = -1,
+	/** Targets all input or output endpoints of the device */
+	VIDEO_EP_ALL = -2,
+	/** Targets all input endpoints of the device: those consuming data */
+	VIDEO_EP_IN = -3,
+	/** Targets all output endpoints of the device: those producing data */
+	VIDEO_EP_OUT = -4,
 };
 
 /**
@@ -449,7 +453,7 @@ static inline int video_stream_stop(const struct device *dev)
 	}
 
 	ret = api->stream_stop(dev);
-	video_flush(dev, VIDEO_EP_ANY, true);
+	video_flush(dev, VIDEO_EP_ALL, true);
 
 	return ret;
 }


### PR DESCRIPTION
This is part of a series of proposal for incremental changes for the Video API:
- https://github.com/zephyrproject-rtos/zephyr/issues/72959

This adds slightly new semantics for `endpoint_id`:

- `IN` is not "the main input endpoint" anymore but "each and every input endpoint"
- `OUT` is not "the main output endpoint" anymore but "each and every output endpoint"
- ~~`ANY`~~ `ALL` is not "one endpoint of choice" anymore but "every single endpoint"
- `NONE` is not "does not affect any interface" anymore but "affects something not bound to any interface"
- Other values >= 0 are allowed to specify a particular interface.