### PR TITLE
boards: andestech: Add missing supported drivers to board yaml

### DIFF
--- a/boards/andestech/adp_xc7k_ae350/adp_xc7k_ae350.yaml
+++ b/boards/andestech/adp_xc7k_ae350/adp_xc7k_ae350.yaml
@@ -16,6 +16,9 @@ supported:
   - mbox
   - flash
   - dma
+  - led
+  - syscon
+  - hwinfo
 testing:
   ignore_tags:
     - bluetooth


### PR DESCRIPTION
Add some supported drivers to adp_xc7k_ae350.yaml

Signed-off-by: Wei-Tai Lee [wtlee@andestech.com](mailto:wtlee@andestech.com)