### PR TITLE
usb: device_next: fix BOS descriptor request

### DIFF
--- a/subsys/usb/device_next/usbd_ch9.c
+++ b/subsys/usb/device_next/usbd_ch9.c
@@ -703,7 +703,7 @@ static void desc_fill_bos_root(struct usbd_contex *const uds_ctx,
 	SYS_DLIST_FOR_EACH_CONTAINER(&uds_ctx->descriptors, desc_nd, node) {
 		if (desc_nd->bDescriptorType == USB_DESC_BOS) {
 			root->wTotalLength += desc_nd->bLength;
-			root->bNumDeviceCaps += desc_nd->bLength;
+			root->bNumDeviceCaps++;
 		}
 	}
 }
@@ -712,9 +712,27 @@ static int sreq_get_desc_bos(struct usbd_contex *const uds_ctx,
 			     struct net_buf *const buf)
 {
 	struct usb_setup_packet *setup = usbd_get_setup_pkt(uds_ctx);
+	struct usb_device_descriptor *dev_dsc;
 	struct usb_bos_descriptor bos;
 	struct usbd_desc_node *desc_nd;
 	size_t len;
+
+	switch (usbd_bus_speed(uds_ctx)) {
+	case USBD_SPEED_FS:
+		dev_dsc = uds_ctx->fs_desc;
+		break;
+	case USBD_SPEED_HS:
+		dev_dsc = uds_ctx->hs_desc;
+		break;
+	default:
+		errno = -ENOTSUP;
+		return 0;
+	}
+
+	if (sys_le16_to_cpu(dev_dsc->bcdUSB) < 0x0201U) {
+		errno = -ENOTSUP;
+		return 0;
+	}
 
 	desc_fill_bos_root(uds_ctx, &bos);
 	len = MIN(net_buf_tailroom(buf), MIN(setup->wLength, bos.wTotalLength));


### PR DESCRIPTION
Return protocol error if bcdUSB is less than 0x0201. Fix typo in number of capabilities.

Fixes: b0d7d70834ab ("usb: device_next: add initial BOS support")