### PR TITLE
boards: renesas: da1469x_dk_pro: Update SPI pins

### DIFF
--- a/boards/renesas/da1469x_dk_pro/da1469x_dk_pro-pinctrl.dtsi
+++ b/boards/renesas/da1469x_dk_pro/da1469x_dk_pro-pinctrl.dtsi
@@ -64,12 +64,12 @@
 
 	spi_controller: spi_controller {
 		group1 {
-			pinmux = <SMARTBOND_PINMUX(SPI_CLK, 0, 22)>,
-				<SMARTBOND_PINMUX(SPI_DO, 0, 23)>;
+			pinmux = <SMARTBOND_PINMUX(SPI_CLK, 0, 21)>,
+				 <SMARTBOND_PINMUX(SPI_DO, 0, 26)>;
 			output-enable;
 		};
 		group2 {
-			pinmux = <SMARTBOND_PINMUX(SPI_DI, 0, 25)>;
+			pinmux = <SMARTBOND_PINMUX(SPI_DI, 0, 24)>;
 			input-enable;
 		};
 	};


### PR DESCRIPTION
Two pins assigned to SPI controller (P0_22,P0_23) are dedicated to XTAL32K which is present on devkit.

For this reason SPI function are re-assigned to pins available on optional header MikorBUS 1 to match configuration of SPI2 which is routed to MikorBUS 2 header.

Alternatively SPI could be routed to Arduino header (also not populated by default) but since SPI2 matched MikorBUS#2 SPI can match MikorBUS#1

Other pins from J3 or J4 connectors could also be chosen but for now removing conflict with XTAL32 seems to be priority.