### PR TITLE
drivers: nsos: minor fixes and improvements

### DIFF
--- a/drivers/net/nsos_adapt.c
+++ b/drivers/net/nsos_adapt.c
@@ -752,6 +752,7 @@ static int nsos_poll_to_epoll_events(int events_from)
 	MAP_POLL_EPOLL(POLLIN, EPOLLIN);
 	MAP_POLL_EPOLL(POLLOUT, EPOLLOUT);
 	MAP_POLL_EPOLL(POLLERR, EPOLLERR);
+	MAP_POLL_EPOLL(POLLHUP, EPOLLHUP);
 
 	return events_to;
 }
@@ -763,6 +764,7 @@ static int nsos_epoll_to_poll_events(int events_from)
 	MAP_POLL_EPOLL(EPOLLIN, POLLIN);
 	MAP_POLL_EPOLL(EPOLLOUT, POLLOUT);
 	MAP_POLL_EPOLL(EPOLLERR, POLLERR);
+	MAP_POLL_EPOLL(EPOLLHUP, POLLHUP);
 
 	return events_to;
 }

--- a/drivers/net/nsos_sockets.c
+++ b/drivers/net/nsos_sockets.c
@@ -265,8 +265,7 @@ static int nsos_poll_prepare(struct nsos_socket *sock, struct zsock_pollfd *pfd,
 	sock->pollfd.cb = pollcb;
 
 	if (*pev == pev_end) {
-		errno = ENOMEM;
-		return -1;
+		return -ENOMEM;
 	}
 
 	k_poll_signal_init(&sock->poll);

--- a/drivers/net/nsos_sockets.c
+++ b/drivers/net/nsos_sockets.c
@@ -624,6 +624,7 @@ static int nsos_accept(void *obj, struct sockaddr *addr, socklen_t *addrlen)
 
 	zephyr_fd = z_reserve_fd();
 	if (zephyr_fd < 0) {
+		errno = -zephyr_fd;
 		goto close_adapt_fd;
 	}
 

--- a/drivers/net/nsos_sockets.c
+++ b/drivers/net/nsos_sockets.c
@@ -708,7 +708,7 @@ static ssize_t nsos_sendmsg(void *obj, const struct msghdr *msg, int flags)
 
 	msg_iov = k_calloc(msg->msg_iovlen, sizeof(*msg_iov));
 	if (!msg_iov) {
-		ret = -ENOMEM;
+		ret = -NSOS_MID_ENOMEM;
 		goto return_ret;
 	}
 


### PR DESCRIPTION
* propagate `POLLHUP` from host's `epoll()`
* fix `nsos_sendmsg()` error code
* set `errno` on failed `z_reserve_fd()`
* fix `ENOMEM` return from `ZFD_IOCTL_POLL_PREPARE`