### PR TITLE
drivers: video: Introduce macro to deal with endpoints

### DIFF
--- a/dts/bindings/test/vnd,video.yaml
+++ b/dts/bindings/test/vnd,video.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2024 tinyVision.ai Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test Video device
+
+compatible: "vnd,video"
+
+child-binding:
+  child-binding:
+    include: video-interfaces.yaml

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -3792,6 +3792,70 @@
  */
 
 /**
+ * @defgroup devicetree-generic-endpoint Endpoint helpers
+ * @ingroup devicetree
+ * @{
+ */
+
+/**
+ * @brief Get the remote endpoint node connected to a local endpoint.
+ *
+ * Devices can be interconnected through ports and endpoints.
+ *
+ * Example devicetree overlay:
+ *
+ * @code{.dts}
+ *	&source {
+ *		port {
+ *			source_out: endpoint {
+ *				remote-endpoint-label = "sink_in";
+ *				source-property = <1>;
+ *			};
+ *		};
+ *	};
+ *
+ *	&sink {
+ *		port {
+ *			sink_in: endpoint {
+ *				remote-endpoint-label = "source_out";
+ *				sink-property = <2>;
+ *			};
+ *		};
+ *	};
+ * @endcode
+ *
+ * @c DT_REMOTE_ENDPOINT(endpoint_node) permits to access the other endpoint
+ * connected to @c endpoint_node.
+ *
+ * Example usage: starting from the sink, access the source endpoint connected
+ * to the @c sink_in endpoint:
+ *
+ * @code{.c}
+ *	DT_PROP(DT_REMOTE_ENDPOINT(DT_NODELABEL(sink_in)), source_property)
+ * @endcode
+ *
+ * Example usage, starting from the source, to access the sink endpoint
+ * connected to the @c source_out endpoint:
+ *
+ * @code{.c}
+ *	DT_PROP(DT_REMOTE_ENDPOINT(DT_NODELABEL(source_out)), sink_property)
+ * @endcode
+ *
+ * @note Once circular phandle references are supported in Zephyr devicetree,
+ *       @c remote-endpoint-label (string) may be changed into
+ *       @c remote-endpoint (phandle).
+ *
+ * @param node The local endpoint node to use.
+ *
+ * @return The remote endpoint node connected to @p node.
+ */
+#define DT_REMOTE_ENDPOINT(node) DT_NODELABEL(DT_STRING_TOKEN(node, remote_endpoint_label))
+
+/**
+ * @}
+ */
+
+/**
  * @defgroup devicetree-inst Instance-based devicetree APIs
  * @ingroup devicetree
  * @{

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -506,6 +506,26 @@
 			status = "okay";
 		};
 
+		test_video_source: video_source {
+			compatible = "vnd,video";
+
+			port {
+				test_video_source_out: endpoint {
+					remote-endpoint-label = "test_video_sink_in";
+				};
+			};
+		};
+
+		test_video_sink: video_sink {
+			compatible = "vnd,video";
+
+			port {
+				test_video_sink_in: endpoint {
+					remote-endpoint-label = "test_video_source_out";
+				};
+			};
+		};
+
 		test_pwm1: pwm@55551111 {
 			compatible = "vnd,pwm";
 			#pwm-cells = <3>;

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -76,6 +76,9 @@
 #define TEST_DMA_CTLR_1 DT_NODELABEL(test_dma1)
 #define TEST_DMA_CTLR_2 DT_NODELABEL(test_dma2)
 
+#define TEST_VIDEO_SOURCE_OUT DT_NODELABEL(test_video_source_out)
+#define TEST_VIDEO_SINK_IN    DT_NODELABEL(test_video_sink_in)
+
 #define TEST_IO_CHANNEL_CTLR_1 DT_NODELABEL(test_adc_1)
 #define TEST_IO_CHANNEL_CTLR_2 DT_NODELABEL(test_adc_2)
 
@@ -1276,6 +1279,19 @@ ZTEST(devicetree_api, test_dma)
 	zassert_true(DT_INST_DMAS_HAS_IDX(0, 1), "");
 	zassert_false(DT_DMAS_HAS_IDX(TEST_TEMP, 2), "");
 	zassert_false(DT_INST_DMAS_HAS_IDX(0, 2), "");
+}
+
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT vnd_video_device
+ZTEST(devicetree_api, test_video)
+{
+	/* DT_REMOTE_ENDPOINT(source) */
+	zassert_true(DT_SAME_NODE(DT_REMOTE_ENDPOINT(TEST_VIDEO_SOURCE_OUT),
+				  TEST_VIDEO_SINK_IN), "");
+
+	/* DT_REMOTE_ENDPOINT(sink) */
+	zassert_true(DT_SAME_NODE(DT_REMOTE_ENDPOINT(TEST_VIDEO_SINK_IN),
+				  TEST_VIDEO_SOURCE_OUT), "");
 }
 
 #undef DT_DRV_COMPAT


### PR DESCRIPTION
This is part of a series of proposals for incremental changes for the Video API:
- https://github.com/zephyrproject-rtos/zephyr/issues/72959

This depends on:
- #72950 (not anymore)
- https://github.com/zephyrproject-rtos/zephyr/pull/74415

It introduces some way to point at devicetree objects and use them in the API.
It assumes that endpoint numbers can be passed where `enum video_endpoint_id ep` is present through the API.

Example:

```dts
vid0: videodev@10380000 {
	ports {
		#address-cells = <2>;
		#size-cells = <0>;

		vid0port0in: endpoint@0000 {
			reg = <0 0>;
			data-lanes = <0 1 2 3>;
			remote-endpoint = <&other>;
		};

		vid0port0out: endpoint@0001 {
			reg = <0 1>;
			data-lanes = <4 5 6 7>;
			remote-endpoint = <&other>;
		};

		vid0port1in: endpoint@0100 {
			reg = <1 0>;
			data-lanes = <0 1 2 3>;
			remote-endpoint = <&other>;
		};
	};
};
```

It is then possible to refer `vid0port0out` like this:

```
video_set_signal(DEVICE_DT_GET(DT_NODELABEL(vid0)), VIDEO_DT_ENDPOINT_ID(vid0port0out));
```