### PR TITLE
tests: net: lib: http_server: Bump min_ram requirements

### DIFF
--- a/tests/net/lib/http_server/common/testcase.yaml
+++ b/tests/net/lib/http_server/common/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  min_ram: 16
+  min_ram: 40
   tags:
     - net
     - http

--- a/tests/net/lib/http_server/crime/testcase.yaml
+++ b/tests/net/lib/http_server/crime/testcase.yaml
@@ -1,6 +1,6 @@
 common:
   harness: net
-  min_ram: 16
+  min_ram: 60
   tags:
     - http
     - net

--- a/tests/net/lib/http_server/prototype/testcase.yaml
+++ b/tests/net/lib/http_server/prototype/testcase.yaml
@@ -1,6 +1,6 @@
 common:
   harness: net
-  min_ram: 16
+  min_ram: 80
   tags:
     - http
     - net


### PR DESCRIPTION
The values set as a min_ram requirement were far from the actual RAM usage reported during build, make them more realistic.