### PR TITLE
ci: codecov: Fix merged coverage report path

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -222,9 +222,8 @@ jobs:
         if: always()
         uses: codecov/codecov-action@v4
         with:
-          directory: ./coverage/reports
           env_vars: OS,PYTHON
           fail_ci_if_error: false
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: merged.xml
+          files: coverage/reports/merged.xml


### PR DESCRIPTION
This commit updates the codecov workflow to specify the full coverage report file path under `files` because codecov-action v4 does not correctly process the `directory` parameter.