### PR TITLE
drivers: ipm: Add IPM over MBOX driver

### DIFF
--- a/drivers/ipm/CMakeLists.txt
+++ b/drivers/ipm/CMakeLists.txt
@@ -15,5 +15,6 @@ zephyr_library_sources_ifdef(CONFIG_IPM_SEDI ipm_sedi.c)
 zephyr_library_sources_ifdef(CONFIG_IPM_IVSHMEM ipm_ivshmem.c)
 zephyr_library_sources_ifdef(CONFIG_ESP32_SOFT_IPM ipm_esp32.c)
 zephyr_library_sources_ifdef(CONFIG_XLNX_IPI ipm_xlnx_ipi.c)
+zephyr_library_sources_ifdef(CONFIG_IPM_MBOX ipm_mbox.c)
 
 zephyr_library_sources_ifdef(CONFIG_USERSPACE   ipm_handlers.c)

--- a/drivers/ipm/Kconfig
+++ b/drivers/ipm/Kconfig
@@ -55,6 +55,14 @@ config XLNX_IPI
 	  Inter Processor Interrupt driver for AMD-Xilinx
 	  platforms such as ZynqMP Ultrascale+.
 
+config IPM_MBOX
+	bool "IPM over MBOX driver"
+	default y
+	depends on DT_HAS_ZEPHYR_MBOX_IPM_ENABLED
+	depends on MBOX
+	help
+	  IPM driver using a MBOX driver as the backend mechanism.
+
 source "drivers/ipm/Kconfig.nrfx"
 source "drivers/ipm/Kconfig.imx"
 source "drivers/ipm/Kconfig.stm32"

--- a/drivers/ipm/ipm_mbox.c
+++ b/drivers/ipm/ipm_mbox.c
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2024 Texas Instruments Incorporated
+ *	Andrew Davis <afd@ti.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT zephyr_mbox_ipm
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/ipm.h>
+#include <zephyr/drivers/mbox.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(ipm_mbox, CONFIG_IPM_LOG_LEVEL);
+
+struct ipm_mbox_data {
+	ipm_callback_t callback;
+	void *user_data;
+};
+
+struct ipm_mbox_config {
+	struct mbox_dt_spec mbox_tx;
+	struct mbox_dt_spec mbox_rx;
+};
+
+static void ipm_mbox_callback(const struct device *mboxdev, mbox_channel_id_t channel_id,
+			      void *user_data, struct mbox_msg *data)
+{
+	const struct device *ipmdev = user_data;
+	struct ipm_mbox_data *ipm_mbox_data = ipmdev->data;
+
+	ipm_mbox_data->callback(ipmdev, ipm_mbox_data->user_data, channel_id, (void *)data->data);
+}
+
+static int ipm_mbox_send(const struct device *ipmdev, int wait, uint32_t id,
+			 const void *data, int size)
+{
+	const struct ipm_mbox_config *config = ipmdev->config;
+
+	struct mbox_msg message = {
+		.data = data,
+		.size = size,
+	};
+
+	return mbox_send_dt(&config->mbox_tx, &message);
+}
+
+static void ipm_mbox_register_callback(const struct device *ipmdev,
+				       ipm_callback_t cb,
+				       void *user_data)
+{
+	struct ipm_mbox_data *data = ipmdev->data;
+
+	data->callback = cb;
+	data->user_data = user_data;
+}
+
+static int ipm_mbox_get_max_data_size(const struct device *ipmdev)
+{
+	const struct ipm_mbox_config *config = ipmdev->config;
+
+	return mbox_mtu_get_dt(&config->mbox_tx);
+}
+
+static uint32_t ipm_mbox_get_max_id(const struct device *ipmdev)
+{
+	const struct ipm_mbox_config *config = ipmdev->config;
+
+	return mbox_max_channels_get_dt(&config->mbox_tx);
+}
+
+static int ipm_mbox_set_enable(const struct device *ipmdev, int enable)
+{
+	const struct ipm_mbox_config *config = ipmdev->config;
+
+	mbox_set_enabled_dt(&config->mbox_rx, enable);
+
+	return 0;
+}
+
+static int ipm_mbox_init(const struct device *ipmdev)
+{
+	const struct ipm_mbox_config *config = ipmdev->config;
+
+	mbox_register_callback_dt(&config->mbox_rx, ipm_mbox_callback, (void *)ipmdev);
+
+	return 0;
+}
+
+static const struct ipm_driver_api ipm_mbox_funcs = {
+	.send = ipm_mbox_send,
+	.register_callback = ipm_mbox_register_callback,
+	.max_data_size_get = ipm_mbox_get_max_data_size,
+	.max_id_val_get = ipm_mbox_get_max_id,
+	.set_enabled = ipm_mbox_set_enable,
+};
+
+#define IPM_MBOX_DEV_DEFINE(n)						\
+	static struct ipm_mbox_data ipm_mbox_data_##n;			\
+	static const struct ipm_mbox_config ipm_mbox_config_##n = {	\
+		.mbox_tx = MBOX_DT_SPEC_INST_GET(n, tx),		\
+		.mbox_rx = MBOX_DT_SPEC_INST_GET(n, rx),		\
+	};								\
+	DEVICE_DT_INST_DEFINE(n,					\
+			      &ipm_mbox_init,				\
+			      NULL,					\
+			      &ipm_mbox_data_##n,			\
+			      &ipm_mbox_config_##n,			\
+			      POST_KERNEL,				\
+			      0,					\
+			      &ipm_mbox_funcs);
+
+DT_INST_FOREACH_STATUS_OKAY(IPM_MBOX_DEV_DEFINE)

--- a/dts/bindings/ipm/zephyr,mbox-ipm.yaml
+++ b/dts/bindings/ipm/zephyr,mbox-ipm.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2024 Texas Instruments Incorporated
+#      Andrew Davis <afd@ti.com>
+# SPDX-License-Identifier: Apache-2.0
+
+description: Inter-Processor-Message to Mailbox adaptor driver
+
+compatible: "zephyr,mbox-ipm"
+
+include: base.yaml
+
+properties:
+  mboxes:
+    description: phandle to the MBOX controller (TX and RX are required)
+    required: true
+
+  mbox-names:
+    description: MBOX channel names (must be called "tx" and "rx")
+    required: true


### PR DESCRIPTION
The Multi-Channel Inter-Processor Mailbox (MBOX) framework can be seen as a more general version of the Inter-Processor Mailbox (IPM) framework. An MBOX driver provides for multiple channels, where IPM provides for only a single channel of communication.

Currently many applications are written to use IPM, while some are now being written to use MBOX. This means if a platform wants to support both types of apps a given it must have a driver for both frameworks. As MBOX is the newer and more generic framework, new drivers are being added for this framework only and older IPM drivers are being migrated to MBOX. This leads to the situation where applications need to be written twice, once for each framework, to run across all platforms.

The solution is to add a gasket driver that exposes the IPM interface while using a MBOX driver in the back-end. This shim driver allows platforms to only need an MBOX driver to support both types of application. This IPM driver can be used when an application only supports IPM but the platform only supports MBOX.

This will allow platforms and applications to be ported over to MBOX independently of each other. Add this driver here.



This avoids issues like we had when adding J721e support that only has MBOX drivers (and we wanted to use the OpenAMP samples which only support IPM #72250). Also helps with cases like this #69680 where platforms need to have both types of drivers instead of just switching over to MBOX fully.