### PR TITLE
subsys: testsuite: coverage: support resetting counters

### DIFF
--- a/subsys/testsuite/coverage/coverage.c
+++ b/subsys/testsuite/coverage/coverage.c
@@ -259,6 +259,22 @@ void gcov_reset_counts(struct gcov_info *info)
 	}
 }
 
+void gcov_reset_all_counts(void)
+{
+	struct gcov_info *gcov_list = NULL;
+
+	k_sched_lock();
+
+	gcov_list = gcov_get_list_head();
+
+	while (gcov_list) {
+		gcov_reset_counts(gcov_list);
+		gcov_list = gcov_list->next;
+	}
+
+	k_sched_unlock();
+}
+
 void dump_on_console_start(const char *filename)
 {
 	printk("\n%c", FILE_START_INDICATOR);

--- a/subsys/testsuite/coverage/coverage.c
+++ b/subsys/testsuite/coverage/coverage.c
@@ -132,12 +132,12 @@ size_t gcov_calculate_buff_size(struct gcov_info *info)
 }
 
 /**
- * gcov_to_gcda - convert from gcov data set (info) to
+ * gcov_populate_buffer - convert from gcov data set (info) to
  * .gcda file format.
  * This buffer will now have info similar to a regular gcda
  * format.
  */
-size_t gcov_to_gcda(uint8_t *buffer, struct gcov_info *info)
+size_t gcov_populate_buffer(uint8_t *buffer, struct gcov_info *info)
 {
 	struct gcov_fn_info *functions;
 	struct gcov_ctr_info *counters_per_func;
@@ -232,6 +232,33 @@ size_t gcov_to_gcda(uint8_t *buffer, struct gcov_info *info)
 	return buffer_write_position;
 }
 
+void gcov_reset_counts(struct gcov_info *info)
+{
+	struct gcov_fn_info *functions;
+	struct gcov_ctr_info *counters_per_func;
+	uint32_t iter_functions;
+	uint32_t iter_counts;
+	uint32_t iter_counter_values;
+
+	for (iter_functions = 0U;
+		iter_functions < info->n_functions;
+		iter_functions++) {
+
+		functions = info->functions[iter_functions];
+		counters_per_func = functions->ctrs;
+
+		for (iter_counts = 0U;
+			iter_counts < GCOV_COUNTERS;
+			iter_counts++) {
+			for (iter_counter_values = 0U;
+				iter_counter_values < counters_per_func->num;
+				iter_counter_values++) {
+				counters_per_func->values[iter_counter_values] = 0;
+			}
+		}
+	}
+}
+
 void dump_on_console_start(const char *filename)
 {
 	printk("\n%c", FILE_START_INDICATOR);
@@ -274,7 +301,7 @@ void gcov_coverage_dump(void)
 			goto coverage_dump_end;
 		}
 
-		written_size = gcov_to_gcda(buffer, gcov_list);
+		written_size = gcov_populate_buffer(buffer, gcov_list);
 		if (written_size != size) {
 			printk("Write Error on buff\n");
 			goto coverage_dump_end;

--- a/subsys/testsuite/coverage/coverage.h
+++ b/subsys/testsuite/coverage/coverage.h
@@ -124,5 +124,6 @@ struct gcov_info {
 struct gcov_info *gcov_get_list_head(void);
 size_t gcov_populate_buffer(uint8_t *buffer, struct gcov_info *info);
 size_t gcov_calculate_buff_size(struct gcov_info *info);
+void gcov_reset_counts(struct gcov_info *info);
 
 #endif /* _COVERAGE_H_ */

--- a/subsys/testsuite/coverage/coverage.h
+++ b/subsys/testsuite/coverage/coverage.h
@@ -124,6 +124,6 @@ struct gcov_info {
 struct gcov_info *gcov_get_list_head(void);
 size_t gcov_populate_buffer(uint8_t *buffer, struct gcov_info *info);
 size_t gcov_calculate_buff_size(struct gcov_info *info);
-void gcov_reset_counts(struct gcov_info *info);
+void gcov_reset_all_counts(void);
 
 #endif /* _COVERAGE_H_ */

--- a/subsys/testsuite/ztest/CMakeLists.txt
+++ b/subsys/testsuite/ztest/CMakeLists.txt
@@ -7,6 +7,7 @@ zephyr_syscall_header(
 
 zephyr_include_directories(
   ${ZEPHYR_BASE}/subsys/testsuite/include
+  ${ZEPHYR_BASE}/subsys/testsuite/coverage
   ${ZEPHYR_BASE}/subsys/testsuite/ztest/include
   )
 

--- a/subsys/testsuite/ztest/Kconfig
+++ b/subsys/testsuite/ztest/Kconfig
@@ -132,6 +132,16 @@ config ZTEST_VERIFY_RUN_ALL
 	help
 	  This rule will fail the project if not all tests have been run.
 
+
+config ZTEST_COVERAGE_RESET_BEFORE_TESTS
+	bool "Performs coverage counters reset"
+	depends on COVERAGE_GCOV
+	help
+	  This rule will reset gcov counters before running tests. This ensures
+	  that only code lines triggered by test itself are counted in the coverage report
+	  and all the board initialization code and pre-test bootstrap is not counted.
+	  This is useful when, for example, you are testing code that is also executed during bootup.
+
 config ZTEST_SHUFFLE
 	bool "Shuffle the order of tests and suites"
 	select TEST_RANDOM_GENERATOR if !ENTROPY_HAS_DRIVER

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -38,6 +38,10 @@ static bool failed_expectation;
 #define NUM_ITER_PER_TEST  1
 #endif
 
+#ifdef CONFIG_ZTEST_COVERAGE_RESET_BEFORE_TESTS
+#include <coverage.h>
+#endif
+
 /* ZTEST_DMEM and ZTEST_BMEM are used for the application shared memory test  */
 
 /**
@@ -1081,6 +1085,10 @@ int z_impl_ztest_run_test_suites(const void *state, bool shuffle, int suite_iter
 	if (test_status == ZTEST_STATUS_CRITICAL_ERROR) {
 		return count;
 	}
+
+#ifdef CONFIG_ZTEST_COVERAGE_RESET_BEFORE_TESTS
+	gcov_reset_all_counts();
+#endif
 
 #ifdef CONFIG_ZTEST_SHUFFLE
 	struct ztest_suite_node *suites_to_run[ZTEST_SUITE_COUNT];


### PR DESCRIPTION
This continues the work started by Joshua in https://github.com/zephyrproject-rtos/zephyr/pull/65842

Ability to reset gcov counters allows better isolation of tests
coverage. Specifically it allows to:
1. Not include counters for any code that was executed prior running the
   test, which includes all the code executed during the board boot.
2. Run multiple tests without firmware reload by resetting counters
   between each.


I also undo renaming of gcov_populate_buffer to gcvo_to_gcda from bc8b7dd6dd36e0ae6b256353bf967c3568b907a7 as it was actually a bug. The function was only renamed in .c, but not in the corresponding .h. I opted for returning it to original name to avoid breaking the public contract from the header.
