### PR TITLE
twister: fix serial connection for flash_before

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
@@ -85,6 +85,13 @@ def pytest_addoption(parser: pytest.Parser):
         help='Script for controlling pseudoterminal.'
     )
     twister_harness_group.addoption(
+        '--flash-before',
+        type=bool,
+        help='Flash device before attaching to serial port'
+             'This is useful for devices that share the same port for programming'
+             'and serial console, or use soft-USB, where flash must come first.'
+    )
+    twister_harness_group.addoption(
         '--west-flash-extra-args',
         help='Extend parameters for west flash. '
              'E.g. --west-flash-extra-args="--board-id=foobar,--erase" '

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/twister_harness_config.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/twister_harness_config.py
@@ -26,6 +26,7 @@ class DeviceConfig:
     id: str = ''
     product: str = ''
     serial_pty: str = ''
+    flash_before: bool = False
     west_flash_extra_args: list[str] = field(default_factory=list, repr=False)
     name: str = ''
     pre_script: Path | None = None
@@ -62,6 +63,7 @@ class TwisterHarnessConfig:
             id=config.option.device_id,
             product=config.option.device_product,
             serial_pty=config.option.device_serial_pty,
+            flash_before=bool(config.option.flash_before),
             west_flash_extra_args=west_flash_extra_args,
             pre_script=_cast_to_path(config.option.pre_script),
             post_script=_cast_to_path(config.option.post_script),

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -178,7 +178,7 @@ Artificially long but functional example:
     parser.add_argument("--flash-before", action="store_true", default=False,
                         help="""Flash device before attaching to serial port.
                         This is useful for devices that share the same port for programming
-                        and serial console, where flash must come first.
+                        and serial console, or use soft-USB, where flash must come first.
                         """)
 
     test_or_build.add_argument(

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -408,6 +408,9 @@ class Pytest(Harness):
         if hardware.post_script:
             command.append(f'--post-script={hardware.post_script}')
 
+        if hardware.flash_before:
+            command.append(f'--flash-before={hardware.flash_before}')
+
         return command
 
     def run_command(self, cmd, timeout):


### PR DESCRIPTION
The --flash-before flag allows devices to be flashed before the serial connection is established. However, the implementation was incomplete and only worked if the port address already existed at the start of the run. This is incompatible with devices that implement the USB in software (eg: USB-CDC).

This commit fixes the implementation to delay setting up the connection until after the device is flashed, and to retry the connection for two seconds after flashing to give the device time to enumerate as a USB device.

I considered making a separate twister flag for this behavior, to be used in conjunction with --flash-before. But on further consideration I think this is exactly the behavior originally envisioned, where there is no attempt whatsoever to connect to the serial port until after the firmware being tested has been flashed to the device.

This builds on the work of @LucasTambor in #66534 and addresses some of the issues I saw @JPHutchins discussing in https://github.com/zephyrproject-rtos/zephyr/pull/57660#issuecomment-1545167109.