### PR TITLE
mgmt: mcumgr: transport: Add missing net include file

### DIFF
--- a/subsys/mgmt/mcumgr/transport/src/smp_udp.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_udp.c
@@ -14,6 +14,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
 #include <zephyr/net/socket.h>
+#include <zephyr/net/net_if.h>
 #include <zephyr/mgmt/mcumgr/mgmt/mgmt.h>
 #include <zephyr/mgmt/mcumgr/smp/smp.h>
 #include <zephyr/mgmt/mcumgr/transport/smp.h>


### PR DESCRIPTION
Adds a missing network include file which was causing an undefined function build failure, likely caused by a recent change affecting includes in other header files

Fixes #73050