### PR TITLE
samples/subsys/shell/shell_module/overlays: revert to the default prompt

### DIFF
--- a/samples/subsys/shell/shell_module/boards/intel_socfpga_agilex5_socdk.conf
+++ b/samples/subsys/shell/shell_module/boards/intel_socfpga_agilex5_socdk.conf
@@ -5,9 +5,6 @@
 CONFIG_HEAP_MEM_POOL_SIZE=16384
 CONFIG_SHELL_STACK_SIZE=8192
 
-# Setting the Shell prompt
-CONFIG_SHELL_PROMPT_UART="agilex5$ "
-
 # Setting the max argc
 CONFIG_SHELL_ARGC_MAX=12
 

--- a/samples/subsys/shell/shell_module/boards/intel_socfpga_agilex_socdk.conf
+++ b/samples/subsys/shell/shell_module/boards/intel_socfpga_agilex_socdk.conf
@@ -5,9 +5,6 @@
 CONFIG_HEAP_MEM_POOL_SIZE=16384
 CONFIG_SHELL_STACK_SIZE=8192
 
-# Setting the Shell prompt
-CONFIG_SHELL_PROMPT_UART="agilex$ "
-
 # Setting the max argc
 CONFIG_SHELL_ARGC_MAX=12
 


### PR DESCRIPTION
I'm running automated tests for all Zephyr targets, recording logs and comparing them against the expected output. These two targets:
* intel_socfpga_agilex_socdk
* intel_socfpga_agilex5_socdk

set their prompt to a custom one without an explanation why. This potentially conflicts with the [configuration](https://github.com/zephyrproject-rtos/zephyr/blob/main/samples/subsys/shell/shell_module/prj_login.conf#L17) in `prj_login.conf`, and is not what the Robot test scenario [expects](https://github.com/zephyrproject-rtos/zephyr/blob/main/samples/subsys/shell/shell_module/shell_module.robot#L11) either.

This PR unifies the expected output of this sample in its default configuration.



