### PR TITLE
drivers: tmag5273: remove unneccessary check

### DIFF
--- a/drivers/sensor/ti/tmag5273/tmag5273.c
+++ b/drivers/sensor/ti/tmag5273/tmag5273.c
@@ -102,17 +102,17 @@ static int tmag5273_reset_device_status(const struct device *dev)
 /**
  * @brief checks for DIAG_FAIL errors and reads out the DEVICE_STATUS register if necessary
  *
- * Prints a human readable representation to the log, if \c CONFIG_LOG is activated.
- *
- * @param drv_cfg[in] driver instance configuration
- * @param device_status[out] DEVICE_STATUS register if DIAG_FAIL is set
+ * @param[in] drv_cfg driver instance configuration
+ * @param[out] device_status DEVICE_STATUS register if DIAG_FAIL is set
  *
  * @retval 0 on success
- * @retval "!= 0" on error (see @ref i2c_reg_read_byte for error codes)
+ * @retval "!= 0" on error
+ *                  - \c -EIO on any set error device status bit
+ *                  - see @ref i2c_reg_read_byte for error codes
  *
  * @note
- * If tmag5273_config.ignore_diag_fail is se
- *   -  \a device_status will be always set to \c 0,
+ * If tmag5273_config.ignore_diag_fail is set
+ *   - \a device_status will be always set to \c 0,
  *   - the function always returns \c 0.
  */
 static int tmag5273_check_device_status(const struct tmag5273_config *drv_cfg,

--- a/drivers/sensor/ti/tmag5273/tmag5273.c
+++ b/drivers/sensor/ti/tmag5273/tmag5273.c
@@ -144,23 +144,23 @@ static int tmag5273_check_device_status(const struct tmag5273_config *drv_cfg,
 	}
 
 	if ((*device_status & TMAG5273_VCC_UV_ER_MSK) == TMAG5273_VCC_UV_ERR) {
-		LOG_WRN("VCC undervoltage detected");
+		LOG_ERR("VCC under voltage detected");
 	}
 #ifdef CONFIG_CRC
 	if (drv_cfg->crc_enabled &&
 	    ((*device_status & TMAG5273_OTP_CRC_ER_MSK) == TMAG5273_OTP_CRC_ERR)) {
-		LOG_WRN("OTP CRC error detected");
+		LOG_ERR("OTP CRC error detected");
 	}
 #endif
 	if ((*device_status & TMAG5273_INT_ER_MSK) == TMAG5273_INT_ERR) {
-		LOG_WRN("INT pin error detected");
+		LOG_ERR("INT pin error detected");
 	}
 
 	if ((*device_status & TMAG5273_OSC_ER_MSK) == TMAG5273_OSC_ERR) {
-		LOG_WRN("Oscillator error detected");
+		LOG_ERR("Oscillator error detected");
 	}
 
-	return 0;
+	return -EIO;
 }
 
 /**
@@ -689,11 +689,6 @@ static int tmag5273_sample_fetch(const struct device *dev, enum sensor_channel c
 		return retval;
 	}
 
-	if ((i2c_buffer[TMAG5273_REG_CONV_STATUS - TMAG5273_REG_RESULT_BEGIN] &
-	     TMAG5273_DIAG_STATUS_MSK) == TMAG5273_DIAG_FAIL) {
-		return -EIO;
-	}
-
 	bool all_channels = (chan == SENSOR_CHAN_ALL);
 	bool all_xyz = all_channels || (chan == SENSOR_CHAN_MAGN_XYZ);
 	bool all_angle_magnitude = all_channels || ((int)chan == TMAG5273_CHAN_ANGLE_MAGNITUDE);
@@ -1118,7 +1113,7 @@ static int tmag5273_init(const struct device *dev)
 		return -EINVAL;
 	}
 
-	tmag5273_check_device_status(drv_cfg, &regdata);
+	(void)tmag5273_check_device_status(drv_cfg, &regdata);
 
 	retval = tmag5273_reset_device_status(dev);
 	if (retval < 0) {


### PR DESCRIPTION
If an immediate return on error is used, an additional result check in `sample_fetch` can be neglected. This doesn't change the behavior, as for the fetch routine additionally checked for an unset `TMAG5273_DIAG_FAIL`.