### PR TITLE
MAINTAINERS: add orphaned RISC-V boards back to the RISC-V area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3449,6 +3449,20 @@ Microchip MEC Platforms:
   labels:
     - "platform: Microchip MEC"
 
+Microchip RISC-V Platforms:
+  status: maintained
+  maintainers:
+    - fkokosinski
+    - kgugala
+    - tgorochowik
+  files:
+    - boards/microchip/m2gl025_miv/
+    - boards/microchip/mpfs_icicle/
+    - dts/riscv/microchip/
+    - soc/microchip/miv/
+  labels:
+    - "platform: Microchip RISC-V"
+
 Microchip SAM Platforms:
   status: maintained
   maintainers:

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2903,6 +2903,8 @@ RISCV arch:
     - ycsin
   files:
     - arch/riscv/
+    - boards/enjoydigital/litex_vexriscv/
+    - boards/lowrisc/opentitan_earlgrey/
     - boards/qemu/riscv*/
     - boards/sifive/
     - boards/sparkfun/red_v_things_plus/


### PR DESCRIPTION
This PR restores the pre-HWMv2 status of RISC-V boards being covered by the RISC-V area of maintenance, by adding the following orphaned boards back to the area:
* `litex_vexriscv`
* `opentitan_earlgrey`
* `m2gl025_miv`
* `mpfs_icicle`

An example of an affected PR can be found here: https://github.com/zephyrproject-rtos/zephyr/pull/72569.