### PR TITLE
tests: Bluetooth: CAP: Add missing CSIP function

### DIFF
--- a/tests/bluetooth/audio/cap_commander/uut/csip.c
+++ b/tests/bluetooth/audio/cap_commander/uut/csip.c
@@ -52,6 +52,16 @@ int bt_csip_set_coordinator_discover(struct bt_conn *conn)
 	return 0;
 }
 
+struct bt_csip_set_coordinator_set_member *
+bt_csip_set_coordinator_csis_member_by_conn(struct bt_conn *conn)
+{
+	if (conn == NULL) {
+		return NULL;
+	}
+
+	return &member;
+}
+
 void mock_bt_csip_init(void)
 {
 }


### PR DESCRIPTION
The bt_csip_set_coordinator_csis_member_by_conn function was seemingly missing, causing the CAP unit tests to not build.