### PR TITLE
dts: nxp_mcxn94x: fix flash write-block-size

### DIFF
--- a/dts/arm/nxp/nxp_mcxn94x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn94x_common.dtsi
@@ -572,7 +572,8 @@
 			compatible = "soc-nv-flash";
 			reg = <0 DT_SIZE_M(2)>;
 			erase-block-size = <8192>;
-			write-block-size = <16>;
+			/* MCXN94x ROM Flash API supports writing of 128B pages. */
+			write-block-size = <128>;
 		};
 	};
 


### PR DESCRIPTION
- Fix mcxn94x flash write-block-size from 16 to 128.
- Fix flash_program() return error 0x65, that means "Address or length does not meet the required alignment."
- The mcxn94x Flash ROM API flash_program() start address and the length must be 128 bytes-aligned.