### PR TITLE
Bluetooth: audio: tests: Switch to one-time adv

### DIFF
--- a/tests/bsim/bluetooth/audio/src/bap_scan_delegator_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_scan_delegator_test.c
@@ -680,7 +680,7 @@ static int common_init(void)
 	bt_bap_scan_delegator_register_cb(&scan_delegator_cb);
 	bt_le_per_adv_sync_cb_register(&pa_sync_cb);
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, AD_SIZE, NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, AD_SIZE, NULL, 0);
 	if (err) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return err;

--- a/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
@@ -616,7 +616,7 @@ static void init(void)
 			bt_cap_stream_ops_register(&unicast_streams[i], &unicast_stream_ops);
 		}
 
-		err = bt_le_adv_start(BT_LE_ADV_CONN, cap_acceptor_ad,
+		err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, cap_acceptor_ad,
 				      ARRAY_SIZE(cap_acceptor_ad), NULL, 0);
 		if (err != 0) {
 			FAIL("Advertising failed to start (err %d)\n", err);

--- a/tests/bsim/bluetooth/audio/src/csip_notify_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/csip_notify_server_test.c
@@ -66,7 +66,7 @@ static void test_main(void)
 	}
 
 	printk("Start Advertising\n");
-	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;
@@ -107,7 +107,7 @@ static void test_main(void)
 	}
 
 	printk("Start Advertising\n");
-	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/audio/src/csip_set_member_test.c
+++ b/tests/bsim/bluetooth/audio/src/csip_set_member_test.c
@@ -70,7 +70,7 @@ static void bt_ready(int err)
 		return;
 	}
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 	}

--- a/tests/bsim/bluetooth/audio/src/gmap_ugt_test.c
+++ b/tests/bsim/bluetooth/audio/src/gmap_ugt_test.c
@@ -416,8 +416,8 @@ static void test_main(void)
 		return;
 	}
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN, gmap_acceptor_ad, ARRAY_SIZE(gmap_acceptor_ad),
-			      NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, gmap_acceptor_ad,
+			      ARRAY_SIZE(gmap_acceptor_ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/audio/src/has_test.c
+++ b/tests/bsim/bluetooth/audio/src/has_test.c
@@ -31,6 +31,19 @@ static const struct bt_has_preset_ops preset_ops = {
 	.select = preset_select,
 };
 
+static void start_adv(void)
+{
+	int err;
+
+	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, AD_SIZE, NULL, 0);
+	if (err) {
+		FAIL("Advertising failed to start (err %d)\n", err);
+		return;
+	}
+
+	LOG_DBG("Advertising successfully started");
+}
+
 static void test_common(void)
 {
 	struct bt_has_features_param has_param = {0};
@@ -46,13 +59,7 @@ static void test_common(void)
 
 	LOG_DBG("Bluetooth initialized");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, AD_SIZE, NULL, 0);
-	if (err) {
-		FAIL("Advertising failed to start (err %d)\n", err);
-		return;
-	}
-
-	LOG_DBG("Advertising successfully started");
+	start_adv();
 
 	has_param.type = BT_HAS_HEARING_AID_TYPE_BINAURAL;
 	has_param.preset_sync_support = true;
@@ -115,6 +122,7 @@ static void test_offline_behavior(void)
 
 	WAIT_FOR_FLAG(flag_connected);
 	WAIT_FOR_UNSET_FLAG(flag_connected);
+	start_adv();
 
 	preset_param.index = test_preset_index_3;
 	preset_param.properties = test_preset_properties;

--- a/tests/bsim/bluetooth/audio/src/ias_test.c
+++ b/tests/bsim/bluetooth/audio/src/ias_test.c
@@ -58,7 +58,7 @@ static void test_main(void)
 		return;
 	}
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, AD_SIZE, NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, AD_SIZE, NULL, 0);
 	if (err) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/audio/src/mcs_test.c
+++ b/tests/bsim/bluetooth/audio/src/mcs_test.c
@@ -12,17 +12,11 @@
 
 extern enum bst_result_t bst_result;
 
-/* Callback after Bluetoot initialization attempt */
-static void bt_ready(int err)
+static void start_adv(void)
 {
-	if (err) {
-		FAIL("Bluetooth init failed (err %d)\n", err);
-		return;
-	}
+	int err;
 
-	printk("Bluetooth initialized\n");
-
-	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, AD_SIZE, NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, AD_SIZE, NULL, 0);
 	if (err) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;
@@ -45,15 +39,20 @@ static void test_main(void)
 	}
 
 	/* Initialize Bluetooth, get connected */
-	err = bt_enable(bt_ready);
+	err = bt_enable(NULL);
 	if (err) {
 		FAIL("Bluetooth init failed (err %d)\n", err);
 		return;
 	}
-
-	WAIT_FOR_FLAG(flag_connected);
+	printk("Bluetooth initialized\n");
 
 	PASS("MCS passed\n");
+
+	while (1) {
+		start_adv();
+		WAIT_FOR_FLAG(flag_connected);
+		WAIT_FOR_UNSET_FLAG(flag_connected);
+	}
 }
 
 static const struct bst_test_instance test_mcs[] = {

--- a/tests/bsim/bluetooth/audio/src/media_controller_test.c
+++ b/tests/bsim/bluetooth/audio/src/media_controller_test.c
@@ -1647,7 +1647,7 @@ void test_media_controller_remote_player(void)
 	initialize_bluetooth();
 	initialize_media();
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, AD_SIZE, NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, AD_SIZE, NULL, 0);
 	if (err) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 	}

--- a/tests/bsim/bluetooth/audio/src/micp_mic_dev_test.c
+++ b/tests/bsim/bluetooth/audio/src/micp_mic_dev_test.c
@@ -420,7 +420,7 @@ static void test_main(void)
 
 	printk("MICP initialized\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, AD_SIZE, NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, AD_SIZE, NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/audio/src/pacs_notify_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/pacs_notify_server_test.c
@@ -176,7 +176,7 @@ static void test_main(void)
 	}
 
 	LOG_DBG("Start Advertising");
-	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)", err);
 		return;
@@ -210,7 +210,7 @@ static void test_main(void)
 	trigger_notifications();
 
 	LOG_DBG("Start Advertising");
-	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)", err);
 		return;
@@ -227,7 +227,7 @@ static void test_main(void)
 	}
 
 	LOG_DBG("Start Advertising");
-	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)", err);
 		return;
@@ -261,7 +261,7 @@ static void test_main(void)
 	}
 
 	LOG_DBG("Start Advertising");
-	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)", err);
 		return;

--- a/tests/bsim/bluetooth/audio/src/tbs_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/tbs_client_test.c
@@ -494,7 +494,7 @@ static void test_main(void)
 
 	printk("Audio Server: Bluetooth discovered\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, AD_SIZE, NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, AD_SIZE, NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/audio/src/vcp_vol_rend_test.c
+++ b/tests/bsim/bluetooth/audio/src/vcp_vol_rend_test.c
@@ -1032,7 +1032,7 @@ static void test_main(void)
 
 	printk("VCP initialized\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, AD_SIZE, NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, AD_SIZE, NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;


### PR DESCRIPTION
This patch removes all uses of the adv auto-resume feature in the audio bsim tests, and instead makes all adv starts explicit.

The auto-resume feature is planned for deprecation. And, explicit starting of adv makes what happens in the test more explicit as well.