### PR TITLE
tests: kernel: timer: Fix failing tests for custom k_busy_wait()

### DIFF
--- a/tests/kernel/timer/timer_api/Kconfig
+++ b/tests/kernel/timer/timer_api/Kconfig
@@ -4,4 +4,7 @@
 config SYS_CLOCK_TICKS_PER_SEC
 	default 16384 if NRF_RTC_TIMER && TICKLESS_KERNEL
 
+config ASSERT_VERBOSE
+	default n if SOC_NRF54H20_CPUPPR
+
 source "Kconfig.zephyr"

--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -28,15 +28,22 @@ struct timer_data {
  */
 #define INEXACT_MS_CONVERT ((CONFIG_SYS_CLOCK_TICKS_PER_SEC % MSEC_PER_SEC) != 0)
 
-#if CONFIG_NRF_RTC_TIMER
-/* On Nordic SOCs one or both of the tick and busy-wait clocks may
- * derive from sources that have slews that sum to +/- 13%.
+#if CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT && CONFIG_NRF_RTC_TIMER
+/* On Nordic SOCs using RTC_TIMER as the system timer and custom k_busy_wait() implementation,
+ * one or both of the tick and busy-wait clocks may derive from sources that have slews that
+ * sum to +/- 13%.
  */
 #define BUSY_TICK_SLEW_PPM 130000U
+#elif CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT && CONFIG_NRF_GRTC_TIMER
+/* On Nordic SOCs using GRTC_TIMER as the system timer and custom k_busy_wait() implementation,
+ * one or both of the tick and busy-wait clocks may derive from sources that have slews that
+ * sum to +/- 2%.
+ */
+#define BUSY_TICK_SLEW_PPM 20000U
 #else
-/* On other platforms assume the clocks are perfectly aligned. */
+/* In other cases assume the clocks are perfectly aligned. */
 #define BUSY_TICK_SLEW_PPM 0U
-#endif
+#endif /* CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT && CONFIG_NRF_RTC_TIMER */
 #define PPM_DIVISOR 1000000U
 
 /* If the tick clock is faster or slower than the busywait clock the

--- a/tests/kernel/timer/timer_behavior/testcase.yaml
+++ b/tests/kernel/timer/timer_behavior/testcase.yaml
@@ -12,6 +12,8 @@ tests:
       record:
         regex: "RECORD:(?P<metrics>.*)"
         as_json: ['metrics']
+    platform_exclude:
+      - nrf54h20dk/nrf54h20/cpuppr
   kernel.timer.timer_behavior_external:
     filter: dt_compat_enabled("test-kernel-timer-behavior-external")
     harness: pytest


### PR DESCRIPTION
This commit provides an additional threshold value for comparison when a custom k_busy_wait() implementation is chosen.