### PR TITLE
Fix handling of VLAN packets with stripped VLAN header

### DIFF
--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -288,6 +288,7 @@ static enum net_verdict ethernet_recv(struct net_if *iface,
 		}
 
 		if (is_vlan_pkt) {
+			net_pkt_set_priority(pkt, net_vlan2priority(net_pkt_vlan_priority(pkt)));
 			net_pkt_set_iface(pkt,
 					  net_eth_get_vlan_iface(iface, net_pkt_vlan_tag(pkt)));
 


### PR DESCRIPTION
This PR fixed the handling of packets with stripped VLAN headers by forwarding also frames to the virtual interface with TCI set by the driver. 

It also sets the priority of a packet based on the PCP field of the VLAN header.

I tested this with my tricore port and an enhanced dwmac driver.