### PR TITLE
arch: avoid mixing types

### DIFF
--- a/arch/x86/core/early_serial.c
+++ b/arch/x86/core/early_serial.c
@@ -62,12 +62,12 @@ static mm_reg_t mmio;
 #define FCR_FIFO    BIT(0)  /* enable XMIT and RCVR FIFO */
 #define FCR_RCVRCLR BIT(1)  /* clear RCVR FIFO           */
 #define FCR_XMITCLR BIT(2)  /* clear XMIT FIFO           */
-#define FCR_FIFO_1  0       /* 1 byte in RCVR FIFO       */
+#define FCR_FIFO_1  0x00U   /* 1 byte in RCVR FIFO       */
 
 static bool early_serial_init_done;
 static uint32_t suppressed_chars;
 
-static void serout(int c)
+static void serout(uint8_t c)
 {
 	while ((IN(REG_LSR) & LSR_THRE) == 0) {
 	}
@@ -82,9 +82,9 @@ int arch_printk_char_out(int c)
 	}
 
 	if (c == '\n') {
-		serout('\r');
+		serout((uint8_t)'\r');
 	}
-	serout(c);
+	serout((uint8_t)c);
 	return c;
 }
 
@@ -104,8 +104,8 @@ void z_x86_early_serial_init(void)
 
 	OUT(REG_IER, IER_DISABLE);     /* Disable interrupts */
 	OUT(REG_LCR, LCR_DLAB_SELECT); /* DLAB select */
-	OUT(REG_BRDL, 1);              /* Baud divisor = 1 */
-	OUT(REG_BRDH, 0);
+	OUT(REG_BRDL, 1U);              /* Baud divisor = 1 */
+	OUT(REG_BRDH, 0U);
 	OUT(REG_LCR, LCR_8N1);         /* LCR = 8n1 + DLAB off */
 	OUT(REG_MCR, MCR_DTR | MCR_RTS);
 

--- a/arch/x86/core/intel64/cpu.c
+++ b/arch/x86/core/intel64/cpu.c
@@ -142,7 +142,7 @@ void arch_cpu_start(int cpu_num, k_thread_stack_t *stack, int sz,
 		    arch_cpustart_t fn, void *arg)
 {
 #if CONFIG_MP_MAX_NUM_CPUS > 1
-	uint8_t vector = ((unsigned long) x86_ap_start) >> 12;
+	uint8_t vector = (uint8_t)(((uintptr_t)x86_ap_start) >> 12);
 	uint8_t apic_id;
 
 	IF_ENABLED(CONFIG_ACPI, ({
@@ -156,8 +156,8 @@ void arch_cpu_start(int cpu_num, k_thread_stack_t *stack, int sz,
 
 	apic_id = x86_cpu_loapics[cpu_num];
 
-	x86_cpuboot[cpu_num].sp = (uint64_t) K_KERNEL_STACK_BUFFER(stack) + sz;
-	x86_cpuboot[cpu_num].stack_size = sz;
+	x86_cpuboot[cpu_num].sp = (uint64_t) K_KERNEL_STACK_BUFFER(stack) + (size_t)sz;
+	x86_cpuboot[cpu_num].stack_size = (size_t)sz;
 	x86_cpuboot[cpu_num].fn = fn;
 	x86_cpuboot[cpu_num].arg = arg;
 

--- a/arch/x86/core/intel64/fatal.c
+++ b/arch/x86/core/intel64/fatal.c
@@ -48,6 +48,6 @@ void arch_syscall_oops(void *ssf_ptr)
 
 	LOG_ERR("Bad system call from RIP 0x%lx", ssf->rip);
 
-	z_x86_fatal_error(K_ERR_KERNEL_OOPS, NULL);
+	z_x86_fatal_error((unsigned int)K_ERR_KERNEL_OOPS, NULL);
 }
 #endif /* CONFIG_USERSPACE */

--- a/arch/x86/core/intel64/thread.c
+++ b/arch/x86/core/intel64/thread.c
@@ -49,17 +49,17 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 #endif
 	iframe = Z_STACK_PTR_TO_FRAME(struct x86_initial_frame, stack_ptr);
 	iframe->rip = 0U;
-	thread->callee_saved.rsp = (long) iframe;
-	thread->callee_saved.rip = (long) switch_entry;
+	thread->callee_saved.rsp = (uint64_t) iframe;
+	thread->callee_saved.rip = (uint64_t) switch_entry;
 	thread->callee_saved.rflags = EFLAGS_INITIAL;
 
 	/* Parameters to entry point, which is populated in
 	 * thread->callee_saved.rip
 	 */
-	thread->arch.rdi = (long) entry;
-	thread->arch.rsi = (long) p1;
-	thread->arch.rdx = (long) p2;
-	thread->arch.rcx = (long) p3;
+	thread->arch.rdi = (uint64_t) entry;
+	thread->arch.rsi = (uint64_t) p1;
+	thread->arch.rdx = (uint64_t) p2;
+	thread->arch.rcx = (uint64_t) p3;
 
 	x86_sse_init(thread);
 

--- a/arch/x86/zefi/zefi.c
+++ b/arch/x86/zefi/zefi.c
@@ -143,7 +143,7 @@ uintptr_t __abi efi_entry(void *img_handle, struct efi_system_table *sys_tab)
 
 	efi_prepare_boot_arg();
 
-	for (size_t i = 0; i < sizeof(zefi_zsegs)/sizeof(zefi_zsegs[0]); i++) {
+	for (size_t i = 0; i < ARRAY_SIZE(zefi_zsegs); i++) {
 		uint32_t bytes = zefi_zsegs[i].sz;
 		uint8_t *dst = (uint8_t *)zefi_zsegs[i].addr;
 
@@ -153,7 +153,7 @@ uintptr_t __abi efi_entry(void *img_handle, struct efi_system_table *sys_tab)
 		}
 	}
 
-	for (size_t i = 0; i < sizeof(zefi_dsegs)/sizeof(zefi_dsegs[0]); i++) {
+	for (size_t i = 0; i < ARRAY_SIZE(zefi_zsegs); i++) {
 		uint32_t bytes = zefi_dsegs[i].sz;
 		uint32_t off = zefi_dsegs[i].off;
 		uint8_t *dst = (uint8_t *)zefi_dsegs[i].addr;


### PR DESCRIPTION
Fixed some occurrences of mixing up types in arch

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/d03fa8d8e9d90f104e5dadafea0f773a67862659