### PR TITLE
usb: device_next: Fix string descriptors response

### DIFF
--- a/subsys/usb/device_next/usbd_ch9.c
+++ b/subsys/usb/device_next/usbd_ch9.c
@@ -563,6 +563,7 @@ static void string_ascii7_to_utf16le(struct usbd_desc_node *const dn,
 	};
 	uint8_t *ascii7_str;
 	size_t len;
+	size_t i;
 
 	if (dn->str.utype == USBD_DUT_STRING_SERIAL_NUMBER && dn->str.use_hwinfo) {
 		ssize_t hwid_len = get_sn_from_hwid(hwid_sn);
@@ -575,7 +576,7 @@ static void string_ascii7_to_utf16le(struct usbd_desc_node *const dn,
 		head.bLength = sizeof(head) + hwid_len * 2;
 		ascii7_str = hwid_sn;
 	} else {
-		head.bLength = dn->bLength,
+		head.bLength = dn->bLength;
 		ascii7_str = (uint8_t *)dn->ptr;
 	}
 
@@ -588,11 +589,15 @@ static void string_ascii7_to_utf16le(struct usbd_desc_node *const dn,
 	net_buf_add_mem(buf, &head, MIN(len, sizeof(head)));
 	len -= MIN(len, sizeof(head));
 
-	for (size_t i = 0; i < len; i++) {
+	for (i = 0; i < len / 2; i++) {
 		__ASSERT(ascii7_str[i] > 0x1F && ascii7_str[i] < 0x7F,
 			 "Only printable ascii-7 characters are allowed in USB "
 			 "string descriptors");
 		net_buf_add_le16(buf, ascii7_str[i]);
+	}
+
+	if (len & 1) {
+		net_buf_add_u8(buf, ascii7_str[i]);
 	}
 }
 


### PR DESCRIPTION
Commit 2f31ee63b5c5 ("usb: device_next: convert ASCII7 strings to UTF16LE on the fly") made string descriptors respond with twice as much of the actual string data.

Fix the issue by taking into account that USB string descriptor length is already multiplied by two. Additionally, make it possible to return odd number of bytes if host requested so.

Fixes: #73073