### PR TITLE
net: tls_credentials: Add missing base64.h header inclusion

### DIFF
--- a/subsys/net/lib/tls_credentials/tls_credentials_digest_raw.c
+++ b/subsys/net/lib/tls_credentials/tls_credentials_digest_raw.c
@@ -19,6 +19,7 @@
 #if defined(CONFIG_PSA_WANT_ALG_SHA_256) && defined(CONFIG_BASE64)
 
 #include <psa/crypto.h>
+#include <zephyr/sys/base64.h>
 
 int credential_digest_raw(struct tls_credential *credential, void *dest, size_t *len)
 {


### PR DESCRIPTION
base64_encode() was used w/o including the base64.h header. This commit fixes it.