### PR TITLE
boards: steval_stwinbx1: Remove adc support from board's yaml

### DIFF
--- a/boards/st/steval_stwinbx1/steval_stwinbx1.yaml
+++ b/boards/st/steval_stwinbx1/steval_stwinbx1.yaml
@@ -8,7 +8,6 @@ toolchain:
 ram: 786
 flash: 2048
 supported:
-  - adc
   - counter
   - gpio
   - pwm


### PR DESCRIPTION
Leftover from review.

Fixes #73078