### PR TITLE
kernel: Relax loop in z_smp_global_lock()

### DIFF
--- a/kernel/smp.c
+++ b/kernel/smp.c
@@ -60,6 +60,7 @@ unsigned int z_smp_global_lock(void)
 
 	if (!_current->base.global_lock_count) {
 		while (!atomic_cas(&global_lock, 0, 1)) {
+			arch_spin_relax();
 		}
 	}
 


### PR DESCRIPTION
Updates z_smp_global_lock() to follow the pattern used in spinlocks to relax the loop between atomic_cas() attempts.