### PR TITLE
drivers: watchdog: Allow WDT_DISABLE_AT_BOOT only when supported

### DIFF
--- a/drivers/watchdog/Kconfig
+++ b/drivers/watchdog/Kconfig
@@ -11,8 +11,12 @@ menuconfig WATCHDOG
 
 if WATCHDOG
 
+config HAS_WDT_DISABLE_AT_BOOT
+	bool
+
 config WDT_DISABLE_AT_BOOT
 	bool "Disable at boot"
+	depends on HAS_WDT_DISABLE_AT_BOOT
 	help
 	  Disable watchdog at Zephyr system startup.
 

--- a/drivers/watchdog/Kconfig.andes_atcwdt200
+++ b/drivers/watchdog/Kconfig.andes_atcwdt200
@@ -9,6 +9,7 @@ config WDT_ANDES_ATCWDT200
 	bool "Andes Watchdog driver"
 	default y
 	depends on DT_HAS_ANDESTECH_ATCWDT200_ENABLED
+	select HAS_WDT_DISABLE_AT_BOOT
 	select COUNTER
 	help
 	  Enable driver for the Andes Watchdog driver.

--- a/drivers/watchdog/Kconfig.cc13xx_cc26xx
+++ b/drivers/watchdog/Kconfig.cc13xx_cc26xx
@@ -5,6 +5,7 @@ config WDT_CC13XX_CC26XX
 	bool "Watchdog Driver for CC13xx / CC26xx family of MCUs"
 	default y
 	depends on DT_HAS_TI_CC13XX_CC26XX_WATCHDOG_ENABLED
+	select HAS_WDT_DISABLE_AT_BOOT
 	help
 	  Enable watchdog for CC13xx / CC26xx family of MCUs
 

--- a/drivers/watchdog/Kconfig.cc32xx
+++ b/drivers/watchdog/Kconfig.cc32xx
@@ -5,6 +5,7 @@ config WDT_CC32XX
 	bool "Watchdog Driver for cc32xx family of MCUs"
 	default y
 	depends on DT_HAS_TI_CC32XX_WATCHDOG_ENABLED
+	select HAS_WDT_DISABLE_AT_BOOT
 	help
 	  Watchdog for cc32xx family of MCUs
 

--- a/drivers/watchdog/Kconfig.dw
+++ b/drivers/watchdog/Kconfig.dw
@@ -7,5 +7,6 @@ config WDT_DW
 	bool "Synopsys DesignWare Watchdog driver"
 	default y
 	depends on DT_HAS_SNPS_DESIGNWARE_WATCHDOG_ENABLED
+	select HAS_WDT_DISABLE_AT_BOOT
 	help
 	  Synopsys DesignWare Watchdog driver.

--- a/drivers/watchdog/Kconfig.ene
+++ b/drivers/watchdog/Kconfig.ene
@@ -5,5 +5,6 @@ config WDT_ENE_KB1200
 	bool "ENE KB1200 watchdog driver"
 	default y
 	depends on DT_HAS_ENE_KB1200_WATCHDOG_ENABLED
+	select HAS_WDT_DISABLE_AT_BOOT
 	help
 	  This option enables the KB1200 watchdog driver.

--- a/drivers/watchdog/Kconfig.esp32
+++ b/drivers/watchdog/Kconfig.esp32
@@ -7,5 +7,6 @@ config WDT_ESP32
 	bool "ESP32 Watchdog (WDT) Driver"
 	default y
 	depends on DT_HAS_ESPRESSIF_ESP32_WATCHDOG_ENABLED
+	select HAS_WDT_DISABLE_AT_BOOT
 	help
 	  Enable WDT driver for ESP32.

--- a/drivers/watchdog/Kconfig.gd32
+++ b/drivers/watchdog/Kconfig.gd32
@@ -5,6 +5,7 @@ config FWDGT_GD32
 	bool "GD32 Free watchdog timer (FWDGT) driver"
 	default y
 	depends on DT_HAS_GD_GD32_FWDGT_ENABLED
+	select HAS_WDT_DISABLE_AT_BOOT
 	select USE_GD32_FWDGT
 	help
 	  Enable the Free watchdog timer (FWDGT) driver for GD32 SoCs.

--- a/drivers/watchdog/Kconfig.gecko
+++ b/drivers/watchdog/Kconfig.gecko
@@ -9,7 +9,7 @@ config WDT_GECKO
 	bool "Gecko series Watchdog (WDOG) Driver"
 	default y
 	depends on DT_HAS_SILABS_GECKO_WDOG_ENABLED
+	select HAS_WDT_DISABLE_AT_BOOT
 	select SOC_GECKO_WDOG
-	default y
 	help
 	  Enable WDOG driver for Silicon Labs Gecko MCUs.

--- a/drivers/watchdog/Kconfig.it8xxx2
+++ b/drivers/watchdog/Kconfig.it8xxx2
@@ -5,6 +5,7 @@ config WDT_ITE_IT8XXX2
 	bool "ITE it8xxx2 Watchdog Timer (WDT) driver"
 	default y
 	depends on DT_HAS_ITE_IT8XXX2_WATCHDOG_ENABLED
+	select HAS_WDT_DISABLE_AT_BOOT
 	help
 	  This option enables the Watchdog Timer driver for ITE it8xxx2.
 	  This driver supports only one channel that id is 0 and 16-bits

--- a/drivers/watchdog/Kconfig.npcx
+++ b/drivers/watchdog/Kconfig.npcx
@@ -7,6 +7,7 @@ config WDT_NPCX
 	bool "Nuvoton NPCX embedded controller (EC) Watchdog Timer driver"
 	default y
 	depends on DT_HAS_NUVOTON_NPCX_WATCHDOG_ENABLED
+	select HAS_WDT_DISABLE_AT_BOOT
 	help
 	  This option enables the Watchdog Timer driver for NPCX family of
 	  processors.

--- a/drivers/watchdog/Kconfig.rpi_pico
+++ b/drivers/watchdog/Kconfig.rpi_pico
@@ -5,6 +5,7 @@ config WDT_RPI_PICO
 	bool "Raspberry Pi Pico Watchdog driver"
 	default y
 	depends on DT_HAS_RASPBERRYPI_PICO_WATCHDOG_ENABLED
+	select HAS_WDT_DISABLE_AT_BOOT
 
 config WDT_RPI_PICO_INITIAL_TIMEOUT
 	int "Default watchdog timeout in us"

--- a/drivers/watchdog/Kconfig.sam
+++ b/drivers/watchdog/Kconfig.sam
@@ -7,5 +7,6 @@ config WDT_SAM
 	bool "Atmel SAM MCU Family Watchdog (WDT) Driver"
 	default y
 	depends on DT_HAS_ATMEL_SAM_WATCHDOG_ENABLED
+	select HAS_WDT_DISABLE_AT_BOOT
 	help
 	  Enable WDT driver for Atmel SAM MCUs.

--- a/drivers/watchdog/Kconfig.sam0
+++ b/drivers/watchdog/Kconfig.sam0
@@ -7,5 +7,6 @@ config WDT_SAM0
 	bool "Atmel SAM0 series Watchdog (WDT) Driver"
 	default y
 	depends on DT_HAS_ATMEL_SAM0_WATCHDOG_ENABLED
+	select HAS_WDT_DISABLE_AT_BOOT
 	help
 	  Enable WDT driver for Atmel SAM0 MCUs.

--- a/drivers/watchdog/Kconfig.sifive
+++ b/drivers/watchdog/Kconfig.sifive
@@ -7,5 +7,6 @@ config WDT_SIFIVE
 	bool "SiFive Watchdog (WDT) Driver"
 	default y
 	depends on DT_HAS_SIFIVE_WDT_ENABLED
+	select HAS_WDT_DISABLE_AT_BOOT
 	help
 	  This option enables WDT driver for SiFive Freedom.

--- a/drivers/watchdog/Kconfig.smartbond
+++ b/drivers/watchdog/Kconfig.smartbond
@@ -7,6 +7,7 @@ config WDT_SMARTBOND
 	bool "Watchdog Driver for Smartbond family of MCUs"
 	default y
 	depends on DT_HAS_RENESAS_SMARTBOND_WATCHDOG_ENABLED
+	select HAS_WDT_DISABLE_AT_BOOT
 	help
 	  Enable watchdog driver for Smartbond line of MCUs
 

--- a/drivers/watchdog/Kconfig.stm32
+++ b/drivers/watchdog/Kconfig.stm32
@@ -9,6 +9,7 @@ config IWDG_STM32
 	bool "Independent Watchdog (IWDG) Driver for STM32 family of MCUs"
 	default y
 	depends on DT_HAS_ST_STM32_WATCHDOG_ENABLED
+	select HAS_WDT_DISABLE_AT_BOOT
 	help
 	  Enable IWDG driver for STM32 line of MCUs
 

--- a/drivers/watchdog/Kconfig.tco
+++ b/drivers/watchdog/Kconfig.tco
@@ -7,5 +7,6 @@ config WDT_TCO
 	bool "Intel TCO Watchdog driver"
 	default y
 	depends on DT_HAS_INTEL_TCO_WDT_ENABLED
+	select HAS_WDT_DISABLE_AT_BOOT
 	help
 	  Enable support for Intel TCO WDT driver.

--- a/drivers/watchdog/Kconfig.xec
+++ b/drivers/watchdog/Kconfig.xec
@@ -7,5 +7,6 @@ config WDT_XEC
 	bool "Microchip XEC series Watchdog Timer (WDT) driver"
 	default y
 	depends on DT_HAS_MICROCHIP_XEC_WATCHDOG_ENABLED
+	select HAS_WDT_DISABLE_AT_BOOT
 	help
 	  Enable WDT driver for Microchip XEC MCU series.

--- a/drivers/watchdog/Kconfig.xmc4xxx
+++ b/drivers/watchdog/Kconfig.xmc4xxx
@@ -7,6 +7,7 @@ config WDT_XMC4XXX
 	bool "Infineon XMC4xxx MCU Family Watchdog (WDT) Driver"
 	default y
 	depends on DT_HAS_INFINEON_XMC4XXX_WATCHDOG_ENABLED
+	select HAS_WDT_DISABLE_AT_BOOT
 	help
 	  Enable WDT driver for Infineon XMC4xxx MCUs.
 


### PR DESCRIPTION
Introduce a hidden Kconfig option named HAS_WDT_DISABLE_AT_BOOT and allow users to enable WDT_DISABLE_AT_BOOT only when that hidden option is selected by a watchdog driver, i.e. disabling at boot is supported.
Select this new hidden option for all existing watchdog drivers that refer to WDT_DISABLE_AT_BOOT.