### PR TITLE
 drivers: sensor: nxp: kinetis: temp: fix memset() length

### DIFF
--- a/drivers/sensor/nxp/nxp_kinetis_temp/Kconfig
+++ b/drivers/sensor/nxp/nxp_kinetis_temp/Kconfig
@@ -7,7 +7,8 @@ config TEMP_KINETIS
 	bool "NXP Kinetis Temperature Sensor"
 	default y
 	depends on DT_HAS_NXP_KINETIS_TEMPERATURE_ENABLED
-	depends on (ADC && SOC_FAMILY_KINETIS)
+	depends on SOC_FAMILY_KINETIS
+	select ADC
 	help
 	  Enable driver for NXP Kinetis temperature sensor.
 

--- a/drivers/sensor/nxp/nxp_kinetis_temp/temp_kinetis.c
+++ b/drivers/sensor/nxp/nxp_kinetis_temp/temp_kinetis.c
@@ -159,7 +159,7 @@ static int temp_kinetis_init(const struct device *dev)
 		},
 	};
 
-	memset(&data->buffer, 0, ARRAY_SIZE(data->buffer));
+	memset(&data->buffer, 0, sizeof(data->buffer));
 
 	if (!device_is_ready(config->adc)) {
 		LOG_ERR("ADC device is not ready");


### PR DESCRIPTION
Use the correct buffer size when calling memset(). 

Fixes: #73093
