### PR TITLE
Add Truncate flag to fs_open - Implementation and unit tests

### DIFF
--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -402,6 +402,9 @@ Libraries / Subsystems
     :kconfig:option:`CONFIG_FS_FATFS_MKFS` Kconfig option. This option is enabled by default if
     :kconfig:option:`CONFIG_FILE_SYSTEM_MKFS` is set.
 
+  * FS: It is now possible to truncate a file while opening using :c:func:`fs_open`
+    and by passing ``FS_O_TRUNC`` flag.
+
 * POSIX API
 
 * LoRa/LoRaWAN

--- a/include/zephyr/fs/fs.h
+++ b/include/zephyr/fs/fs.h
@@ -160,8 +160,11 @@ struct fs_statvfs {
 #define FS_O_CREATE     0x10
 /** Open/create file for append */
 #define FS_O_APPEND     0x20
+/** Truncate the file while opening */
+#define FS_O_TRUNC      0x40
 /** Bitmask for open/create flags */
-#define FS_O_FLAGS_MASK 0x30
+#define FS_O_FLAGS_MASK 0x70
+
 
 /** Bitmask for open flags */
 #define FS_O_MASK       (FS_O_MODE_MASK | FS_O_FLAGS_MASK)
@@ -268,6 +271,7 @@ static inline void fs_dir_t_init(struct fs_dir_t *zdp)
  *   - @c FS_O_RDWR open for read/write (<tt>FS_O_READ | FS_O_WRITE</tt>)
  *   - @c FS_O_CREATE create file if it does not exist
  *   - @c FS_O_APPEND move to end of file before each write
+ *   - @c FS_O_TRUNC truncate the file
  *
  * @warning If @p flags are set to 0 the function will open file, if it exists
  *          and is accessible, but you will have no read/write access to it.
@@ -284,6 +288,7 @@ static inline void fs_dir_t_init(struct fs_dir_t *zdp)
  *	   FS_MOUNT_FLAG_READ_ONLY flag;
  * @retval -ENOENT when the file does not exist at the path;
  * @retval -ENOTSUP when not implemented by underlying file system driver;
+ * @retval -EACCES when trying to truncate a file without opening it for write.
  * @retval <0 an other negative errno code, depending on a file system back-end.
  */
 int fs_open(struct fs_file_t *zfp, const char *file_name, fs_mode_t flags);

--- a/subsys/fs/fs.c
+++ b/subsys/fs/fs.c
@@ -134,6 +134,7 @@ int fs_open(struct fs_file_t *zfp, const char *file_name, fs_mode_t flags)
 {
 	struct fs_mount_t *mp;
 	int rc = -EINVAL;
+	bool truncate_file = false;
 
 	if ((file_name == NULL) ||
 			(strlen(file_name) <= 1) || (file_name[0] != '/')) {
@@ -160,12 +161,35 @@ int fs_open(struct fs_file_t *zfp, const char *file_name, fs_mode_t flags)
 		return -ENOTSUP;
 	}
 
+	if ((flags & FS_O_TRUNC) != 0) {
+		if ((flags & FS_O_WRITE) == 0) {
+			/** Truncate not allowed when file is not opened for write */
+			LOG_ERR("file should be opened for write to truncate!!");
+			return -EACCES;
+		}
+		CHECKIF(mp->fs->truncate == NULL) {
+			LOG_ERR("file truncation not supported!!");
+			return -ENOTSUP;
+		}
+		truncate_file = true;
+	}
+
 	zfp->mp = mp;
 	rc = mp->fs->open(zfp, file_name, flags);
 	if (rc < 0) {
 		LOG_ERR("file open error (%d)", rc);
 		zfp->mp = NULL;
 		return rc;
+	}
+
+	if (truncate_file) {
+		/* Truncate the opened file to 0 length */
+		rc = mp->fs->truncate(zfp, 0);
+		if (rc < 0) {
+			LOG_ERR("file truncation failed (%d)", rc);
+			zfp->mp = NULL;
+			return rc;
+		}
 	}
 
 	/* Copy flags to zfp for use with other fs_ API calls */


### PR DESCRIPTION
### Introduction:
------------------

This PR is supporting the implementations of posix functions like fread (https://github.com/zephyrproject-rtos/zephyr/issues/66940), fopen.

According to ISO-C standard, 'w*' mode passed to fopen should create a new file or else truncate the contents of the existing file. While implementing fopen, I found that it was a bit unclean to convert posix flags into zfs flags. ZFS supports posix equivalents for e.g: 'r' => FS_O_READ. It would be easier to implement ISO-C's fopen behavior if ZFS natively supports truncate flag and truncates during the file open stage.

------------------
### Considerations:
------------------

I considered two approaches here:

1. Create a flag for truncate in fs and make changes to fs_open method to also call truncate when this flag is passed (its possible that an underlying fs might have not yet implemented the truncate method)
(Or)
2. Directly handle truncation at fopen level. On a side note we can have a flag for truncate like FS_O_TRUNC as well but this would only make sense if option 1 is picked.

The first option made sense to me as there can be client usecases where a file needs to be truncated during opening regardless of the fs. So after having a chat with @cfriedt , making this PR without having an issue attached.

Other Considerations:
1. Write flag has to be passed alongside truncate, otherwise the open operation fails with Access denied.
2. If truncate operation is not defined for an fs, it fails with Operation unsupported error with a log. Maybe this can be handled in a better way by just recreating the file? 

------------------
### Implementation
------------------

1. Added support for new flag.
2. Added truncate operation within fs_open based on flags.
3. Added unit tests that run flag related tests on common fs.
4. Clang formatted the modified segments (Although when I ran it on the file, I could see a lot more changes throughout the file - maybe a refactor PR is needed?)

------------------
### Testing
------------------

Ran filesystem related tests which is relevant to this patch:

```
./scripts/twister -i -T tests/subsys/fs --tag filesystem
```

No failures found. Relying on CI for extensive testing.
