### PR TITLE
usb: dfu: fix detach happening too fast

### DIFF
--- a/subsys/usb/device/class/dfu/usb_dfu.c
+++ b/subsys/usb/device/class/dfu/usb_dfu.c
@@ -427,6 +427,10 @@ static void dfu_timer_work_handler(struct k_work *item)
 				LOG_ERR("usb_dc_detach failed");
 			}
 			dfu_enter_idle();
+
+			/* Wait 1 SOF period to ensure the host notices the deconnection. */
+			k_sleep(K_MSEC(1));
+
 			if (usb_dc_attach()) {
 				LOG_ERR("usb_dc_attach failed");
 			}


### PR DESCRIPTION
In some relatively rare conditions, the DFU detach/attach happens to fast, which cause the host to not notice it. It seems to to be the case for instance on STM32 when no endpoint are being used.

Adding a 1 ms delay (i.e. one SOF period) between the detach and the attach fixes the issue.