### PR TITLE
boards: arm: stm32h750b_dk: add support for display (fixed)

### DIFF
--- a/boards/arm/stm32h750b_dk/Kconfig.defconfig
+++ b/boards/arm/stm32h750b_dk/Kconfig.defconfig
@@ -1,0 +1,20 @@
+# STM32H750B DK board configuration
+
+# Copyright (c) 2023 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_STM32H750B_DK
+
+config BOARD
+	default "stm32h750b_dk"
+
+if DISPLAY
+
+# MEMC needs to be enabled in order to store
+# display buffer to external SDRAM connected to FMC
+config MEMC
+	default y
+
+endif # DISPLAY
+
+endif # BOARD_STM32H750B_DK

--- a/boards/st/stm32h750b_dk/Kconfig.stm32h750b_dk
+++ b/boards/st/stm32h750b_dk/Kconfig.stm32h750b_dk
@@ -3,3 +3,12 @@
 
 config BOARD_STM32H750B_DK
 	select SOC_STM32H750XX
+
+if DISPLAY
+
+# MEMC needs to be enabled in order to store
+# display buffer to external SDRAM connected to FMC
+config MEMC
+	default y
+
+endif # DISPLAY

--- a/boards/st/stm32h750b_dk/board.cmake
+++ b/boards/st/stm32h750b_dk/board.cmake
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 board_runner_args(jlink "--device=STM32H735IG" "--speed=4000")
 board_runner_args(openocd --target-handle=_CHIPNAME.cpu0)
 
+include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/stm32h750b_dk/stm32h750b_dk.dts
+++ b/boards/st/stm32h750b_dk/stm32h750b_dk.dts
@@ -19,6 +19,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,flash-controller = &mt25ql512ab1;
+		zephyr,display = &ltdc;
 	};
 
 	sdram2: sdram@d0000000 {
@@ -68,12 +69,61 @@
 	status = "okay";
 };
 
+&ltdc {
+	pinctrl-0 = <&ltdc_r0_pi15 &ltdc_r1_pj0 &ltdc_r2_pj1 &ltdc_r3_ph9
+		&ltdc_r4_pj3 &ltdc_r5_pj4 &ltdc_r6_pj5 &ltdc_r7_pj6
+		&ltdc_g0_pj7 &ltdc_g1_pj8 &ltdc_g2_pj9 &ltdc_g3_pj10
+		&ltdc_g4_pj11 &ltdc_g5_pi0 &ltdc_g6_pi1 &ltdc_g7_pk2
+		&ltdc_b0_pj12 &ltdc_b1_pj13 &ltdc_b2_pj14 &ltdc_b3_pj15
+		&ltdc_b4_pk3 &ltdc_b5_pk4 &ltdc_b6_pk5 &ltdc_b7_pk6
+		&ltdc_de_pk7 &ltdc_clk_pi14 &ltdc_hsync_pi12 &ltdc_vsync_pi9>;
+	pinctrl-names = "default";
+
+	disp-on-gpios = <&gpiod 7 GPIO_ACTIVE_HIGH>;
+
+	ext-sdram = <&sdram2>;
+	status = "okay";
+
+	clocks = <&rcc STM32_CLOCK_BUS_APB3 0x00000008>,
+		<&rcc STM32_SRC_PLL3_R NO_SEL>;
+
+	width = <480>;
+	height = <272>;
+	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+	display-timings {
+		compatible = "zephyr,panel-timing";
+		de-active = <0>;
+		pixelclk-active = <0>;
+		hsync-active = <0>;
+		vsync-active = <0>;
+		hsync-len = <1>;
+		vsync-len = <10>;
+		hback-porch = <43>;
+		vback-porch = <12>;
+		hfront-porch = <8>;
+		vfront-porch = <4>;
+	};
+	def-back-color-red = <0xFF>;
+	def-back-color-green = <0xFF>;
+	def-back-color-blue = <0xFF>;
+};
+
 &pll {
 	div-m = <5>;
 	mul-n = <192>;
 	div-p = <2>;
 	div-q = <4>;
 	div-r = <4>;
+	clocks = <&clk_hse>;
+	status = "okay";
+};
+
+&pll3 {
+	div-m = <5>;
+	mul-n = <192>;
+	div-p = <2>;
+	div-q = <20>;
+	div-r = <99>;
 	clocks = <&clk_hse>;
 	status = "okay";
 };
@@ -114,13 +164,13 @@
 		status = "okay";
 
 		partitions {
-			   compatible = "fixed-partitions";
-			   #address-cells = <1>;
-			   #size-cells = <1>;
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
 
-			   partition@0 {
-			       reg = <0x0 DT_SIZE_M(64)>;
-			   };
+			partition@0 {
+				reg = <0x0 DT_SIZE_M(64)>;
+			};
 		};
 	};
 


### PR DESCRIPTION
Add support for display on stm32h750b_dk. samples/drivers/display is compiling and flashing correctly now.  Previous PR is here: https://github.com/zephyrproject-rtos/zephyr/pull/67245 but, I can't reopen it.

Contains patch by [pcornu](https://github.com/pcornu), also tested by [ajarmouni-st](https://github.com/ajarmouni-st)

