### PR TITLE
[Backport v2.7-branch]  drivers: sensor: nxp: kinetis: temp: fix memset() length

### DIFF
--- a/drivers/sensor/nxp_kinetis_temp/temp_kinetis.c
+++ b/drivers/sensor/nxp_kinetis_temp/temp_kinetis.c
@@ -159,7 +159,7 @@ static int temp_kinetis_init(const struct device *dev)
 		},
 	};
 
-	memset(&data->buffer, 0, ARRAY_SIZE(data->buffer));
+	memset(&data->buffer, 0, sizeof(data->buffer));
 
 	if (!device_is_ready(config->adc)) {
 		LOG_ERR("ADC device is not ready");


### PR DESCRIPTION
Backport 59402fd82ef07634e580b2e85f600b2f4897235a from #73094.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/73093
Fixes: #73104