### PR TITLE
bluetooth: rfcomm: fix issue of sending buf invalid

### DIFF
--- a/include/zephyr/bluetooth/classic/rfcomm.h
+++ b/include/zephyr/bluetooth/classic/rfcomm.h
@@ -66,10 +66,9 @@ struct bt_rfcomm_dlc_ops {
 	/** DLC sent callback
 	 *
 	 *  @param dlc The dlc which has sent data.
-	 *  @param buf Buffer containing data has been sent.
 	 *  @param err Sent result.
 	 */
-	void (*sent)(struct bt_rfcomm_dlc *dlc, struct net_buf *buf, int err);
+	void (*sent)(struct bt_rfcomm_dlc *dlc, int err);
 };
 
 /** @brief Role of RFCOMM session and dlc. Used only by internal APIs

--- a/subsys/bluetooth/host/classic/hfp_ag.c
+++ b/subsys/bluetooth/host/classic/hfp_ag.c
@@ -459,7 +459,7 @@ static int bt_hfp_ag_bac_handler(struct bt_hfp_ag *ag, struct net_buf *buf)
 {
 	uint32_t codec;
 	uint32_t codec_ids = 0U;
-	int err;
+	int err = 0;
 
 	if (!is_char(buf, '=')) {
 		return -ENOTSUP;

--- a/subsys/bluetooth/host/classic/hfp_ag_internal.h
+++ b/subsys/bluetooth/host/classic/hfp_ag_internal.h
@@ -23,6 +23,7 @@ enum {
 	BT_HFP_AG_CODEC_CONN,    /* Codec connection is ongoing */
 	BT_HFP_AG_CODEC_CHANGED, /* Codec Id Changed */
 	BT_HFP_AG_TX_ONGOING,    /* TX is ongoing */
+	BT_HFP_AG_CREATING_SCO,  /* SCO is creating */
 
 	/* Total number of flags - must be at the end of the enum */
 	BT_HFP_AG_NUM_FLAGS,

--- a/subsys/bluetooth/host/classic/hfp_ag_internal.h
+++ b/subsys/bluetooth/host/classic/hfp_ag_internal.h
@@ -22,6 +22,7 @@ enum {
 	BT_HFP_AG_INCOMING_CALL, /* Incoming call */
 	BT_HFP_AG_CODEC_CONN,    /* Codec connection is ongoing */
 	BT_HFP_AG_CODEC_CHANGED, /* Codec Id Changed */
+	BT_HFP_AG_TX_ONGOING,    /* TX is ongoing */
 
 	/* Total number of flags - must be at the end of the enum */
 	BT_HFP_AG_NUM_FLAGS,
@@ -115,6 +116,9 @@ struct bt_hfp_ag {
 
 	/* Critical locker */
 	struct k_sem lock;
+
+	/* TX work */
+	struct k_work_delayable tx_work;
 };
 
 /* Active */

--- a/subsys/bluetooth/host/classic/hfp_hf.c
+++ b/subsys/bluetooth/host/classic/hfp_hf.c
@@ -711,9 +711,9 @@ static void hfp_hf_recv(struct bt_rfcomm_dlc *dlc, struct net_buf *buf)
 	}
 }
 
-static void hfp_hf_sent(struct bt_rfcomm_dlc *dlc, struct net_buf *buf, int err)
+static void hfp_hf_sent(struct bt_rfcomm_dlc *dlc, int err)
 {
-	LOG_DBG("DLC %p sent cb buf %p (err %d)", dlc, buf, err);
+	LOG_DBG("DLC %p sent cb (err %d)", dlc, err);
 }
 
 static int bt_hfp_hf_accept(struct bt_conn *conn, struct bt_rfcomm_dlc **dlc)

--- a/subsys/bluetooth/host/classic/rfcomm.c
+++ b/subsys/bluetooth/host/classic/rfcomm.c
@@ -50,18 +50,6 @@ LOG_MODULE_REGISTER(bt_rfcomm);
 #define SESSION_RTX(_w) CONTAINER_OF(k_work_delayable_from_work(_w), \
 				     struct bt_rfcomm_session, rtx_work)
 
-struct bt_rfcomm_tx {
-	sys_snode_t node;
-	struct bt_rfcomm_dlc *dlc;
-	struct net_buf *buf;
-};
-
-#define rfcomm_tx_data(buf) ((struct bt_rfcomm_tx **)net_buf_user_data(buf))
-
-static struct bt_rfcomm_tx rfcomm_tx[CONFIG_BT_RFCOMM_TX_MAX];
-
-static K_FIFO_DEFINE(rfcomm_tx_free);
-
 static struct bt_rfcomm_server *servers;
 
 /* Pool for dummy buffers to wake up the tx threads */
@@ -553,70 +541,22 @@ static void rfcomm_check_fc(struct bt_rfcomm_dlc *dlc)
 	k_sem_give(&dlc->tx_credits);
 }
 
-static struct bt_rfcomm_tx *bt_rfcomm_tx_alloc(void)
+static void bt_rfcomm_tx_destroy(struct bt_rfcomm_dlc *dlc, struct net_buf *buf)
 {
-	/* The TX context always get freed in the system workqueue,
-	 * so if we're in the same workqueue but there are no immediate
-	 * contexts available, there's no chance we'll get one by waiting.
-	 */
-	if (k_current_get() == &k_sys_work_q.thread) {
-		return k_fifo_get(&rfcomm_tx_free, K_NO_WAIT);
-	}
-
-	if (IS_ENABLED(CONFIG_BT_RFCOMM_LOG_LEVEL_DBG)) {
-		struct bt_rfcomm_tx *tx = k_fifo_get(&rfcomm_tx_free, K_NO_WAIT);
-
-		if (tx) {
-			return tx;
-		}
-
-		LOG_WRN("Unable to get an immediate free bt_rfcomm_tx");
-	}
-
-	return k_fifo_get(&rfcomm_tx_free, K_FOREVER);
-}
-
-static void bt_rfcomm_tx_free(struct bt_rfcomm_tx *tx)
-{
-	LOG_DBG("Free tx buffer %p", tx);
-
-	tx->buf = NULL;
-	tx->dlc = NULL;
-	k_fifo_put(&rfcomm_tx_free, tx);
-}
-
-static void bt_rfcomm_tx_destroy(struct net_buf *buf)
-{
-	struct bt_rfcomm_tx *tx;
-	struct bt_rfcomm_dlc *dlc;
-	struct net_buf *tx_buf;
-
-	LOG_DBG("buf %p", buf);
+	LOG_DBG("dlc %p, buf %p", dlc, buf);
 
 	if ((buf == NULL) || (buf->len == 0)) {
 		return;
 	}
 
-	tx = *rfcomm_tx_data(buf);
-	tx_buf = tx->buf;
-	dlc = tx->dlc;
-
-	bt_rfcomm_tx_free(tx);
-
-	if (tx_buf != buf) {
-		LOG_ERR("Tx buf %p and buf %p are inconsistent", tx_buf, buf);
-	}
-
 	if (dlc && dlc->ops && dlc->ops->sent) {
-		dlc->ops->sent(dlc, tx_buf, -ESHUTDOWN);
+		dlc->ops->sent(dlc, -ESHUTDOWN);
 	}
 }
 
 static void rfcomm_sent(struct bt_conn *conn, void *user_data, int err)
 {
-	struct bt_rfcomm_tx *tx;
 	struct bt_rfcomm_dlc *dlc;
-	struct net_buf *tx_buf;
 
 	LOG_DBG("conn %p", conn);
 
@@ -624,15 +564,10 @@ static void rfcomm_sent(struct bt_conn *conn, void *user_data, int err)
 		return;
 	}
 
-	tx = user_data;
-
-	tx_buf = tx->buf;
-	dlc = tx->dlc;
-
-	bt_rfcomm_tx_free(tx);
+	dlc = (struct bt_rfcomm_dlc *)user_data;
 
 	if (dlc && dlc->ops && dlc->ops->sent) {
-		dlc->ops->sent(dlc, tx_buf, err);
+		dlc->ops->sent(dlc, err);
 	}
 }
 
@@ -641,7 +576,6 @@ static void rfcomm_dlc_tx_thread(void *p1, void *p2, void *p3)
 	struct bt_rfcomm_dlc *dlc = p1;
 	k_timeout_t timeout = K_FOREVER;
 	struct net_buf *buf;
-	struct bt_rfcomm_tx *tx;
 
 	LOG_DBG("Started for dlc %p", dlc);
 
@@ -655,7 +589,7 @@ static void rfcomm_dlc_tx_thread(void *p1, void *p2, void *p3)
 		     dlc->state != BT_RFCOMM_STATE_USER_DISCONNECT) ||
 		    !buf || !buf->len) {
 			if (buf) {
-				bt_rfcomm_tx_destroy(buf);
+				bt_rfcomm_tx_destroy(dlc, buf);
 				net_buf_unref(buf);
 			}
 			break;
@@ -664,17 +598,15 @@ static void rfcomm_dlc_tx_thread(void *p1, void *p2, void *p3)
 		rfcomm_check_fc(dlc);
 		if (dlc->state != BT_RFCOMM_STATE_CONNECTED &&
 		    dlc->state != BT_RFCOMM_STATE_USER_DISCONNECT) {
-			bt_rfcomm_tx_destroy(buf);
+			bt_rfcomm_tx_destroy(dlc, buf);
 			net_buf_unref(buf);
 			break;
 		}
 
-		tx = *rfcomm_tx_data(buf);
-
-		if (rfcomm_send_cb(dlc->session, buf, rfcomm_sent, tx) < 0) {
+		if (rfcomm_send_cb(dlc->session, buf, rfcomm_sent, dlc) < 0) {
 			/* This fails only if channel is disconnected */
 			dlc->state = BT_RFCOMM_STATE_DISCONNECTED;
-			bt_rfcomm_tx_destroy(buf);
+			bt_rfcomm_tx_destroy(dlc, buf);
 			break;
 		}
 
@@ -687,7 +619,7 @@ static void rfcomm_dlc_tx_thread(void *p1, void *p2, void *p3)
 
 	/* Give back any allocated buffers */
 	while ((buf = net_buf_get(&dlc->tx_queue, K_NO_WAIT))) {
-		bt_rfcomm_tx_destroy(buf);
+		bt_rfcomm_tx_destroy(dlc, buf);
 		net_buf_unref(buf);
 	}
 
@@ -1519,7 +1451,6 @@ static void rfcomm_handle_data(struct bt_rfcomm_session *session,
 
 int bt_rfcomm_dlc_send(struct bt_rfcomm_dlc *dlc, struct net_buf *buf)
 {
-	struct bt_rfcomm_tx *tx;
 	uint8_t fcs, cr;
 
 	if (!buf) {
@@ -1535,19 +1466,6 @@ int bt_rfcomm_dlc_send(struct bt_rfcomm_dlc *dlc, struct net_buf *buf)
 	if (buf->len > dlc->mtu) {
 		return -EMSGSIZE;
 	}
-
-	tx = bt_rfcomm_tx_alloc();
-	if (tx == NULL) {
-		LOG_ERR("No tx buffer");
-		return -ENOBUFS;
-	}
-
-	LOG_DBG("TX buffer %p", tx);
-
-	tx->dlc = dlc;
-	tx->buf = buf;
-
-	*rfcomm_tx_data(buf) = tx;
 
 	/* length */
 	if (buf->len > BT_RFCOMM_MAX_LEN_8) {
@@ -1846,7 +1764,6 @@ static int rfcomm_accept(struct bt_conn *conn, struct bt_l2cap_server *server,
 
 void bt_rfcomm_init(void)
 {
-	int i;
 	static struct bt_l2cap_server server = {
 		.psm       = BT_L2CAP_PSM_RFCOMM,
 		.accept    = rfcomm_accept,
@@ -1854,10 +1771,4 @@ void bt_rfcomm_init(void)
 	};
 
 	bt_l2cap_br_server_register(&server);
-
-	k_fifo_init(&rfcomm_tx_free);
-
-	for (i = 0; i < ARRAY_SIZE(rfcomm_tx); i++) {
-		k_fifo_put(&rfcomm_tx_free, &rfcomm_tx[i]);
-	}
 }

--- a/subsys/bluetooth/host/classic/rfcomm.c
+++ b/subsys/bluetooth/host/classic/rfcomm.c
@@ -610,10 +610,6 @@ static void bt_rfcomm_tx_destroy(struct net_buf *buf)
 	if (dlc && dlc->ops && dlc->ops->sent) {
 		dlc->ops->sent(dlc, tx_buf, -ESHUTDOWN);
 	}
-
-	if (tx_buf != NULL) {
-		net_buf_unref(tx_buf);
-	}
 }
 
 static void rfcomm_sent(struct bt_conn *conn, void *user_data, int err)
@@ -637,10 +633,6 @@ static void rfcomm_sent(struct bt_conn *conn, void *user_data, int err)
 
 	if (dlc && dlc->ops && dlc->ops->sent) {
 		dlc->ops->sent(dlc, tx_buf, err);
-	}
-
-	if (tx_buf != NULL) {
-		net_buf_unref(tx_buf);
 	}
 }
 
@@ -1553,7 +1545,7 @@ int bt_rfcomm_dlc_send(struct bt_rfcomm_dlc *dlc, struct net_buf *buf)
 	LOG_DBG("TX buffer %p", tx);
 
 	tx->dlc = dlc;
-	tx->buf = net_buf_ref(buf);
+	tx->buf = buf;
 
 	*rfcomm_tx_data(buf) = tx;
 


### PR DESCRIPTION
There is a change (commit no.: 93d0eac834) that if the `ref` of sending buf is not 1, the error code `-EINVAL` will be returned from bt_conn_send_cb.

It causes the RFCOMM functionality cannot work properly.

Remove the ref operation from the buf to be sent to fix the issue.

Due to the sending buf cannot be referred by sending layer.
It is unsafe to use `buf` identification for a transmission, because the buf may have been newly transmitted when the
sent callback is triggered.

Now instead, when the send completion callback is received, the upper layer is notified that a transfer is completed.
If multiple bufs are sent at the same time, there is no guarantee which buf is completed when the sent callback triggered. Therefore, it is recommended that the caller transfers the next data block after the previous transfer is completed.

HFP AG: Due to the sent callback of RFCOMM is changed, the sending buf need to be primed waiting for the previous one to be completed. Add a worker for this purpose.

HFP Unit: Due to the parameter `buf` has been removed by rfcomm, update the prototype of channel sent callback hfp_hf_sent.


