### PR TITLE
net: arp: Unref the packet it if is already in queue

### DIFF
--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -408,6 +408,7 @@ struct net_pkt *net_arp_prepare(struct net_pkt *pkt,
 			if (!net_pkt_ipv4_auto(pkt) &&
 			    k_queue_unique_append(&entry->pending_queue._queue,
 						  net_pkt_ref(pkt))) {
+				net_pkt_unref(pkt);
 				k_mutex_unlock(&arp_mutex);
 				return NULL;
 			}


### PR DESCRIPTION
If the net_pkt to be sent is already in the queue, we return NULL to the caller. But we have already managed to ref the net_pkt so we need to unref it here in order to avoid net_pkt leak.

Fixes #73112