### PR TITLE
drivers: timer: nrf_grtc_timer: Fix for random system hangs

### DIFF
--- a/drivers/timer/nrf_grtc_timer.c
+++ b/drivers/timer/nrf_grtc_timer.c
@@ -184,6 +184,11 @@ static void sys_clock_timeout_handler(int32_t id, uint64_t cc_val, void *p_conte
 	ARG_UNUSED(id);
 	ARG_UNUSED(p_context);
 	uint64_t dticks;
+	uint64_t now = counter();
+
+	if (unlikely(now < cc_val)) {
+		return;
+	}
 
 	dticks = counter_sub(cc_val, last_count) / CYC_PER_TICK;
 


### PR DESCRIPTION
d599e2b6705eb removed early return from sys_clock_timeout_handler if current counter value is less than cc_val. It seems that this return is needed as after the removal some stress tests which were using system timers heavily started to hang.

Fixes #73003.