### PR TITLE
net: lib: dhcpv4: goto INIT on IF down, not RENEWING

### DIFF
--- a/subsys/net/lib/dhcpv4/dhcpv4.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4.c
@@ -1406,7 +1406,7 @@ static void dhcpv4_iface_event_handler(struct net_mgmt_event_callback *cb,
 
 		if (iface->config.dhcpv4.state == NET_DHCPV4_BOUND) {
 			iface->config.dhcpv4.attempts = 0U;
-			iface->config.dhcpv4.state = NET_DHCPV4_RENEWING;
+			iface->config.dhcpv4.state = NET_DHCPV4_INIT;
 			NET_DBG("enter state=%s", net_dhcpv4_state_name(
 					iface->config.dhcpv4.state));
 			/* Remove any bound address as interface is gone */


### PR DESCRIPTION
When the interface goes down, the safest thing to do is to return to the INIT state, as there is no guarantee that any state is preserved upon the interface coming back up again.

This is particularly the case with WiFi. Without this change, I was observing the following pattern, where upon the second connection the networking stack is sending off an ARP request before being assigned an IP address, which is apparently never responded to (As seen by the second ARP request a second later which is acknowledged). This ARP request is triggered by `dhcpv4_send_request` from the `RENEWING` state.

```
> IF UP
[00:00:10.979,919] <inf> wifi_mgmt: Initiating connection to 'xxxxxxxx'
[00:00:17.457,214] <inf> wifi_mgmt: Connection successful
[00:00:17.477,142] <inf> net_dhcpv4: Received: 192.168.20.23
[00:00:17.477,416] <inf> app: Network connected
[00:00:17.478,546] <inf> net_arp: Generating request for 192.168.20.1
[00:00:17.483,459] <inf> net_arp: Received ll 18:F1:45:85:EC:21 for IP 192.168.20.1
[00:00:17.510,803] <inf> app: Starting send
...
> IF DOWN
...
> IF UP
[00:00:32.917,083] <inf> wifi_mgmt: Initiating connection to 'xxxxxxxx'
[00:00:39.345,001] <inf> net_arp: Generating request for 192.168.20.1
[00:00:39.396,514] <inf> wifi_mgmt: Connection successful
[00:00:39.416,900] <inf> net_dhcpv4: Received: 192.168.20.23
[00:00:39.417,205] <inf> app: Network connected
[00:00:39.418,182] <inf> app: Starting send
[00:00:40.426,849] <err> net_pkt: Data buffer (583) allocation failed (context_alloc_pkt:1844)
[00:00:40.426,879] <err> net_ctx: Failed to allocate net_pkt
[00:00:41.346,191] <inf> net_arp: Generating request for 192.168.20.1
[00:00:41.358,856] <inf> net_arp: Received ll 18:F1:45:85:EC:21 for IP 192.168.20.1
...
```