### PR TITLE
net: conn: fix supplicant l2 recv unexpected frame

### DIFF
--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -581,13 +581,22 @@ static bool conn_are_endpoints_valid(struct net_pkt *pkt, uint8_t family,
 static enum net_verdict conn_raw_socket(struct net_pkt *pkt,
 					struct net_conn *conn, uint8_t proto)
 {
-	if (proto == ETH_P_ALL) {
-		enum net_sock_type type = net_context_get_type(conn->context);
+	enum net_sock_type type = net_context_get_type(conn->context);
 
+	if (proto == ETH_P_ALL) {
 		if ((type == SOCK_DGRAM && !net_pkt_is_l2_processed(pkt)) ||
 		    (type == SOCK_RAW && net_pkt_is_l2_processed(pkt))) {
 			return NET_CONTINUE;
 		}
+	}
+
+	/*
+	 * After l2 processed only deliver protocol matched pkt,
+	 * unless the connetion protocol is all packets
+	 */
+	if (type == SOCK_DGRAM && net_pkt_is_l2_processed(pkt) &&
+	    conn->proto != ETH_P_ALL && conn->proto != net_pkt_ll_proto_type(pkt)) {
+		return NET_CONTINUE;
 	}
 
 	if (!(conn->flags & NET_CONN_LOCAL_ADDR_SET)) {

--- a/tests/net/socket/af_packet/src/main.c
+++ b/tests/net/socket/af_packet/src/main.c
@@ -328,7 +328,7 @@ ZTEST(socket_packet, test_packet_sockets_dgram)
 
 	memset(&dst, 0, sizeof(dst));
 	dst.sll_family = AF_PACKET;
-	dst.sll_protocol = htons(ETH_P_IP);
+	dst.sll_protocol = htons(ETH_P_TSN);
 	memcpy(dst.sll_addr, lladdr1, sizeof(lladdr1));
 
 	ret = zsock_sendto(sock2, data_to_send, sizeof(data_to_send), 0,


### PR DESCRIPTION
Supplicant create AF_PACKET proto ETH_P_PAE socket but receive other frames like ICMP and UDP and causes following issues.
1. When frame len exceeds MTU, net_pkt_clone cannot clone pkt. Thus dropped it and print warning log.
2. It will lower throughput performance as every packet is cloned.

Fix it by conn_raw_socket does not deliver pkts protocol not macted, after l2 processed, unless conn is raw.