### PR TITLE
include: zephyr: dsp: Inconsistent macro names changed

### DIFF
--- a/include/zephyr/dsp/basicmath.h
+++ b/include/zephyr/dsp/basicmath.h
@@ -8,8 +8,8 @@
  * @brief Public APIs for DSP basicmath
  */
 
-#ifndef INCLUDE_ZEPHYR_DSP_BASICMATH_H_
-#define INCLUDE_ZEPHYR_DSP_BASICMATH_H_
+#ifndef ZEPHYR_INCLUDE_DSP_BASICMATH_H_
+#define ZEPHYR_INCLUDE_DSP_BASICMATH_H_
 
 #include <zephyr/dsp/dsp.h>
 
@@ -929,4 +929,4 @@ DSP_FUNC_SCOPE void zdsp_clip_q7(const DSP_DATA q7_t *src, DSP_DATA q7_t *dst, q
 #include <zephyr/dsp/basicmath_f16.h>
 #endif /* CONFIG_FP16 */
 
-#endif /* INCLUDE_ZEPHYR_DSP_BASICMATH_H_ */
+#endif /* ZEPHYR_INCLUDE_DSP_BASICMATH_H_ */

--- a/include/zephyr/dsp/basicmath_f16.h
+++ b/include/zephyr/dsp/basicmath_f16.h
@@ -8,8 +8,8 @@
  * @brief Public APIs for DSP basicmath for 16 bit floating point
  */
 
-#ifndef INCLUDE_ZEPHYR_DSP_BASICMATH_F16_H_
-#define INCLUDE_ZEPHYR_DSP_BASICMATH_F16_H_
+#ifndef ZEPHYR_INCLUDE_DSP_BASICMATH_F16_H_
+#define ZEPHYR_INCLUDE_DSP_BASICMATH_F16_H_
 
 #ifndef CONFIG_FP16
 #error "Cannot use float16 DSP functionality without CONFIG_FP16 enabled"
@@ -121,4 +121,4 @@ DSP_FUNC_SCOPE void zdsp_clip_f16(const float16_t *src, float16_t *dst, float16_
 }
 #endif
 
-#endif /* INCLUDE_ZEPHYR_DSP_BASICMATH_F16_H_ */
+#endif /* ZEPHYR_INCLUDE_DSP_BASICMATH_F16_H_ */

--- a/include/zephyr/dsp/dsp.h
+++ b/include/zephyr/dsp/dsp.h
@@ -8,8 +8,8 @@
  * @brief Public APIs for Digital Signal Processing (DSP) math.
  */
 
-#ifndef INCLUDE_ZEPHYR_DSP_DSP_H_
-#define INCLUDE_ZEPHYR_DSP_DSP_H_
+#ifndef ZEPHYR_INCLUDE_DSP_DSP_H_
+#define ZEPHYR_INCLUDE_DSP_DSP_H_
 
 #ifdef CONFIG_DSP_BACKEND_HAS_STATIC
 #define DSP_FUNC_SCOPE static
@@ -44,4 +44,4 @@
 
 #include "zdsp_backend.h"
 
-#endif /* INCLUDE_ZEPHYR_DSP_DSP_H_ */
+#endif /* ZEPHYR_INCLUDE_DSP_DSP_H_ */

--- a/include/zephyr/dsp/print_format.h
+++ b/include/zephyr/dsp/print_format.h
@@ -2,8 +2,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_ZEPHYR_DSP_PRINT_FORMAT_H
-#define ZEPHYR_INCLUDE_ZEPHYR_DSP_PRINT_FORMAT_H
+#ifndef ZEPHYR_INCLUDE_DSP_PRINT_FORMAT_H
+#define ZEPHYR_INCLUDE_DSP_PRINT_FORMAT_H
 
 #include <inttypes.h>
 #include <stdlib.h>
@@ -63,4 +63,4 @@ static inline int64_t ___PRIq_arg_shift(int64_t q, int shift)
  * @}
  */
 
-#endif /* ZEPHYR_INCLUDE_ZEPHYR_DSP_PRINT_FORMAT_H */
+#endif /* ZEPHYR_INCLUDE_DSP_PRINT_FORMAT_H */

--- a/include/zephyr/dsp/types.h
+++ b/include/zephyr/dsp/types.h
@@ -2,8 +2,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef INCLUDE_ZEPHYR_DSP_TYPES_H_
-#define INCLUDE_ZEPHYR_DSP_TYPES_H_
+#ifndef ZEPHYR_INCLUDE_DSP_TYPES_H_
+#define ZEPHYR_INCLUDE_DSP_TYPES_H_
 
 #include <stdint.h>
 
@@ -68,4 +68,4 @@ typedef double float64_t;
  * @}
  */
 
-#endif /* INCLUDE_ZEPHYR_DSP_TYPES_H_ */
+#endif /* ZEPHYR_INCLUDE_DSP_TYPES_H_ */


### PR DESCRIPTION
Modified inconsistency between macro name and package path in DSP package