### PR TITLE
samples: Bluetooth: hci_vs_scan_req: Build for BT_LL_SW_SPLIT only

### DIFF
--- a/samples/bluetooth/hci_vs_scan_req/sample.yaml
+++ b/samples/bluetooth/hci_vs_scan_req/sample.yaml
@@ -5,8 +5,8 @@ tests:
     harness: bluetooth
     platform_allow:
       - nrf52dk/nrf52832
-      - qemu_cortex_m3
-      - qemu_x86
-    tags: bluetooth
     integration_platforms:
-      - qemu_cortex_m3
+      - nrf52dk/nrf52832
+    extra_configs:
+      - CONFIG_BT_LL_SW_SPLIT=y
+    tags: bluetooth


### PR DESCRIPTION
Build the vendor specific sample hci_vs_scan_req for BT_LL_SW_SPLIT variant of the Controller only.