### PR TITLE
Add official support for the ST M24 I2C EEPROM series

### DIFF
--- a/boards/shields/x_nucleo_eeprma2/x_nucleo_eeprma2.overlay
+++ b/boards/shields/x_nucleo_eeprma2/x_nucleo_eeprma2.overlay
@@ -20,7 +20,7 @@
 
 	eeprom0_x_nucleo_eeprma2: eeprom@54 {
 		/* M24C02-FMC6TG aka U1 (2 kbit eeprom in DFN8 package) */
-		compatible = "st,m24c02", "st,m24xxx", "atmel,at24";
+		compatible = "st,m24xxx";
 		reg = <0x54>;
 		size = <256>;
 		pagesize = <16>;
@@ -33,7 +33,7 @@
 
 	eeprom1_x_nucleo_eeprma2: eeprom@55 {
 		/* M24256-DFDW6TP aka U2 (256 kbit eeprom in TSSOP package) */
-		compatible = "st,m24256", "st,m24xxx", "atmel,at24";
+		compatible = "st,m24xxx";
 		reg = <0x55>;
 		size = <DT_SIZE_K(32)>;
 		pagesize = <64>;
@@ -46,7 +46,7 @@
 
 	eeprom2_x_nucleo_eeprma2: eeprom@56 {
 		/* M24M01-DFMN6TP aka U3 (1 Mbit eeprom in SO8N package) */
-		compatible = "st,m24m01", "st,m24xxx", "atmel,at24";
+		compatible = "st,m24xxx";
 		reg = <0x56>;
 		size = <DT_SIZE_K(128)>;
 		pagesize = <256>;

--- a/drivers/eeprom/Kconfig
+++ b/drivers/eeprom/Kconfig
@@ -36,12 +36,6 @@ config EEPROM_SHELL_BUFFER_SIZE
 	  Size of the buffer used for EEPROM read/write commands in
 	  the EEPROM shell.
 
-config EEPROM_AT2X
-	bool
-	help
-	  Enable support for Atmel AT2x (and compatible) I2C/SPI
-	  EEPROMs.
-
 config EEPROM_AT2X_EMUL
 	bool "Emulate an Atmel AT24 I2C chip"
 	depends on EMUL
@@ -51,54 +45,13 @@ config EEPROM_AT2X_EMUL
 	  At present it only supports 8-bit addressing. The size of the EEPROM
 	  is given by the 'size' property. See the binding for further details.
 
-config EEPROM_AT24
-	bool "I2C EEPROMs compatible with Atmel's AT24 family"
-	default y
-	depends on DT_HAS_ATMEL_AT24_ENABLED
-	select I2C
-	select EEPROM_AT2X
-	help
-	  Enable support for I2C EEPROMs compatible with Atmel's AT24 family.
-
-	  There are multiple vendors manufacturing I2C EEPROMs compatible with
-	  the programming model of the Atmel AT24.
-
-	  Examples of compatible EEPROM families:
-	  - Microchip AT24xxx
-	  - ST M24xxx
-
-config EEPROM_AT25
-	bool "SPI EEPROMs compatibile with Atmel's AT25 family"
-	default y
-	depends on DT_HAS_ATMEL_AT25_ENABLED
-	select SPI
-	select EEPROM_AT2X
-	help
-	  Enable support for SPI EEPROMs compatible with Atmel's AT25 family.
-
-	  There are multiple vendors manufacturing SPI EEPROMs compatible with
-	  the programming model of the Atmel AT25.
-
-	  Examples of compatible EEPROM families:
-	  - Microchip AT25xxx
-	  - ST M95xxx
-
-config EEPROM_AT2X_INIT_PRIORITY
-	int "AT2X EEPROM init priority"
-	default 80
-	depends on EEPROM_AT2X
-	help
-	  AT2X EEPROM driver device initialization priority.
-
-	  The EEPROM is connected to I2C or SPI bus an has to be initialized
-	  after I2C/SPI driver.
-
 source "drivers/eeprom/Kconfig.lpc11u6x"
 source "drivers/eeprom/Kconfig.stm32"
 source "drivers/eeprom/Kconfig.eeprom_emu"
 source "drivers/eeprom/Kconfig.tmp116"
 source "drivers/eeprom/Kconfig.xec"
 source "drivers/eeprom/Kconfig.mb85rcxx"
+source "drivers/eeprom/Kconfig.at2x"
 
 config EEPROM_SIMULATOR
 	bool "Simulated EEPROM driver"

--- a/drivers/eeprom/Kconfig.at2x
+++ b/drivers/eeprom/Kconfig.at2x
@@ -1,0 +1,63 @@
+# Copyright (c) 2019 Vestas Wind Systems A/S
+# Copyright (c) 2024 SILA Embedded Solutions GmbH
+# SPDX-License-Identifier: Apache-2.0
+
+config EEPROM_AT2X
+	bool
+	help
+	  Enable support for Atmel AT2x (and compatible) I2C/SPI
+	  EEPROMs.
+
+config EEPROM_AT2X_I2C
+	bool "I2C EEPROMs compatible with Atmel's AT24 family"
+	select I2C
+	select EEPROM_AT2X
+	help
+	  Enable support for I2C EEPROMs compatible with Atmel's AT24 family.
+
+	  There are multiple vendors manufacturing I2C EEPROMs compatible with
+	  the programming model of the Atmel AT24.
+
+	  Examples of compatible EEPROM families:
+	  - Microchip AT24xxx
+	  - ST M24xxx
+
+config EEPROM_AT2X_SPI
+	bool "SPI EEPROMs compatible with Atmel's AT25 family"
+	select SPI
+	select EEPROM_AT2X
+	help
+	  Enable support for SPI EEPROMs compatible with Atmel's AT25 family.
+
+	  There are multiple vendors manufacturing SPI EEPROMs compatible with
+	  the programming model of the Atmel AT25.
+
+	  Examples of compatible EEPROM families:
+	  - Microchip AT25xxx
+	  - ST M95xxx
+
+config EEPROM_AT24
+	bool "Atmel AT24 I2C EEPROM support"
+	default y
+	depends on DT_HAS_ATMEL_AT24_ENABLED
+	select EEPROM_AT2X_I2C
+	help
+	  Enable support for Atmel AT24 I2C EEPROMs.
+
+config EEPROM_AT25
+	bool "Atmel AT25 SPI EEPROM support"
+	default y
+	depends on DT_HAS_ATMEL_AT25_ENABLED
+	select EEPROM_AT2X_SPI
+	help
+	  Enable support for Atmel AT25 SPI EEPROMs.
+
+config EEPROM_AT2X_INIT_PRIORITY
+	int "AT2X EEPROM init priority"
+	default 80
+	depends on EEPROM_AT2X
+	help
+	  AT2X EEPROM driver device initialization priority.
+
+	  The EEPROM is connected to I2C or SPI bus and has to be initialized
+	  after I2C/SPI driver.

--- a/drivers/eeprom/Kconfig.at2x
+++ b/drivers/eeprom/Kconfig.at2x
@@ -52,6 +52,14 @@ config EEPROM_AT25
 	help
 	  Enable support for Atmel AT25 SPI EEPROMs.
 
+config EEPROM_M24
+	bool "ST M24 I2C EEPROM support"
+	default y
+	depends on DT_HAS_ST_M24XXX_ENABLED
+	select EEPROM_AT2X_I2C
+	help
+	  Enable support for ST M24 I2C EEPROMs.
+
 config EEPROM_AT2X_INIT_PRIORITY
 	int "AT2X EEPROM init priority"
 	default 80

--- a/dts/bindings/mtd/st,m24xxx.yaml
+++ b/dts/bindings/mtd/st,m24xxx.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2024 SILA Embedded Solutions GmbH
+# SPDX-License-Identifier: Apache-2.0
+
+description: ST M24xxx I2C EEPROM
+
+compatible: "st,m24xxx"
+
+include: ["atmel,at24.yaml"]

--- a/tests/drivers/build_all/eeprom/app.overlay
+++ b/tests/drivers/build_all/eeprom/app.overlay
@@ -65,6 +65,18 @@
 					read-only;
 				};
 			};
+
+			test_i2c_m24m02_a125: m24m02_a125@3 {
+				compatible = "st,m24xxx";
+				status = "okay";
+				reg = <0x3>;
+				size = <262144>;
+				pagesize = <256>;
+				address-width = <16>;
+				timeout = <5>;
+				wp-gpios = <&test_gpio 0 0>;
+				/* read-only; */
+			};
 		};
 
 		test_spi: spi@33334444 {


### PR DESCRIPTION
It is already with the existing implementation of the AT24 possible to use an EEPROM from the ST M24 series, although it is not very well documented (see #73064 and #69021). To avoid this confusion I have generalized the driver for the AT24 and AT25 so that it can be reused for other compatibles and added specific bindings for the ST M24 I2C automotive series.
With this approach it is rather clear which ICs are supported by which driver, and it can be easily extended for other compatible ICs.