### PR TITLE
boards: silabs: efr32xg24_dk2601: fix flash partitions labels mismatch

### DIFF
--- a/boards/silabs/efr32xg24_dk2601b/efr32xg24_dk2601b.dts
+++ b/boards/silabs/efr32xg24_dk2601b/efr32xg24_dk2601b.dts
@@ -146,25 +146,25 @@
 
 		/* Reserve 464 kB for the application in slot 0 */
 		slot0_partition: partition@c000 {
-			label = "storage";
+			label = "image-0";
 			reg = <0x0000c000 0x00074000>;
 		};
 
 		/* Reserve 464 kB for the application in slot 1 */
 		slot1_partition: partition@80000 {
-			label = "image-0";
+			label = "image-1";
 			reg = <0x00080000 0x00074000>;
 		};
 
 		/* Reserve 32 kB for the scratch partition */
 		scratch_partition: partition@f4000 {
-			label = "image-1";
+			label = "image-scratch";
 			reg = <0x000f4000 0x00008000>;
 		};
 
 		/* Set 528Kb of storage at the end of the 1024Kb of flash */
 		storage_partition: partition@fc000 {
-			label = "image-scratch";
+			label = "storage";
 			reg = <0x000fc000 0x00084000>;
 		};
 	};


### PR DESCRIPTION
Hello,

This commit fix the label mismatch introduced in PR --> https://github.com/zephyrproject-rtos/zephyr/pull/55092

Regards,
Adrien M.