### PR TITLE
soc: intel_adsp: ipc: don't call k_sem_init() multiple times

### DIFF
--- a/soc/intel/intel_adsp/common/ipc.c
+++ b/soc/intel/intel_adsp/common/ipc.c
@@ -160,7 +160,7 @@ int intel_adsp_ipc_send_message(const struct device *dev,
 		return -EBUSY;
 	}
 
-	k_sem_init(&devdata->sem, 0, 1);
+	k_sem_reset(&devdata->sem);
 	/* Prevent entering runtime idle state until IPC acknowledgment is received. */
 	pm_policy_state_lock_get(PM_STATE_RUNTIME_IDLE, PM_ALL_SUBSTATES);
 	devdata->tx_ack_pending = true;


### PR DESCRIPTION
k_sem_init() is called for every IPC message sent in intel_adsp_ipc_send_message(). This has not had any side-effects in upstream configurations, but has been linked to a failing run of test_obj_tracking_sanity test case in downstream Zephyr use.

Replace k_sem_init() with k_sem_reset() as this is more appropriate API to reset the semaphore count, and ensure deterministic behaviour in case a thread is waiting on the semaphore at time of reset.

Suggested-by: Peter Mitsis <peter.mitsis@intel.com>