### PR TITLE
modules: lvgl: lvgl_fs: Free file on close

### DIFF
--- a/modules/lvgl/lvgl_fs.c
+++ b/modules/lvgl/lvgl_fs.c
@@ -88,6 +88,7 @@ static lv_fs_res_t lvgl_fs_close(struct _lv_fs_drv_t *drv, void *file)
 	int err;
 
 	err = fs_close((struct fs_file_t *)file);
+	LV_MEM_CUSTOM_FREE(file);
 	return errno_to_lv_fs_res(err);
 }
 


### PR DESCRIPTION
Add missing call to LV_MEM_CUSTOM_FREE when closing a file to prevent memory from leaking.

Resolves issue #73148.

I checked the LVGL repository for a reference implementation if it's indeed expected behavior that the close operation deallocates the file struct and this little-fs driver does the same thing:
[https://github.com/lvgl/lvgl/pull/5562/files#diff-cfb0a29e9176c1b2d437ed93288081d5840419f8983c61d80e0371d9777e93acR91](https://github.com/lvgl/lvgl/pull/5562/files#diff-cfb0a29e9176c1b2d437ed93288081d5840419f8983c61d80e0371d9777e93acR91)