### PR TITLE
requirements: Set min version of pylint to 3

### DIFF
--- a/scripts/requirements-compliance.txt
+++ b/scripts/requirements-compliance.txt
@@ -5,5 +5,5 @@ python-magic
 python-magic-bin; sys_platform == "win32"
 lxml
 junitparser>=2
-pylint
+pylint>=3
 yamllint


### PR DESCRIPTION
PR #72592 made pylint to use json2 output format. However, this format is introduced in pylint v3. This commit adds an appropriate setting in the requirements file.