### PR TITLE
docs: .gitignore: ignore coverage files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ outdir
 outdir-*
 scripts/basic/fixdep
 scripts/gen_idt/gen_idt
+coverage-report
+doc-coverage.info
 doc/_build
 doc/doxygen
 doc/xml
@@ -52,6 +54,7 @@ venv
 .venv
 .DS_Store
 .clangd
+new.info
 
 # CI output
 compliance.xml


### PR DESCRIPTION
ignore files, that are generated when building the API doc coverage report following the workflow `doc-build-html` in step `build-docs` at  `.github/workflows/doc-build.yml`
