### PR TITLE
manifest: Update hal_nxp for the commit "drivers: elcdif: Fix register writting issue in SetPixelFormat"

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -193,7 +193,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 57d844b03ea545aa702ae99d9777481709ba8aa4
+      revision: 4745707801a8828004046b3ce2e60ed60487b5e3
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Update NXP hal to point to the following commit:

"drivers: elcdif: Fix register writting issue in SetPixelFormat".

The corresponding hal PR is https://github.com/zephyrproject-rtos/hal_nxp/pull/383 