### PR TITLE
modules: tf-m: nordic: remove problematic include path

### DIFF
--- a/modules/trusted-firmware-m/nordic/CMakeLists.txt
+++ b/modules/trusted-firmware-m/nordic/CMakeLists.txt
@@ -14,7 +14,6 @@ set(partition_includes
 
 set(board_includes
     ${CMAKE_BINARY_DIR}/../zephyr/misc/generated/syscalls_links/include
-    ${ZEPHYR_BASE}/include
 )
 
 target_include_directories(platform_region_defs

--- a/modules/trusted-firmware-m/nordic/ns/CMakeLists.txt
+++ b/modules/trusted-firmware-m/nordic/ns/CMakeLists.txt
@@ -17,7 +17,6 @@ set(partition_includes
 
 set(board_includes
     ${CMAKE_BINARY_DIR}/../zephyr/misc/generated/syscalls_links/include
-    ${ZEPHYR_BASE}/include
 )
 
 target_include_directories(platform_region_defs


### PR DESCRIPTION
It made the build of `samples/tfm_integration/tfm_psa_test/sample.tfm.psa_test_crypto` break since the update of Mbed TLS to 3.6.0 (#71118), apparently because `${ZEPHYR_BASE}` wasn't set, and the include doesn't seem to be needed.