### PR TITLE
samples: drivers: adc_sequence: Fix expected console output regex

### DIFF
--- a/samples/drivers/adc/adc_sequence/sample.yaml
+++ b/samples/drivers/adc/adc_sequence/sample.yaml
@@ -16,6 +16,6 @@ tests:
     harness_config:
       type: multi_line
       regex:
-        - "ADC sequence reading\\[\\d+\\]:"
+        - "ADC sequence reading \\[\\d+\\]:"
         - "- .+, channel \\d+, \\d+ sequence samples:"
         - "- - \\d+ (= \\d+mV)|(\\(value in mV not available\\))"


### PR DESCRIPTION
Add a missing space in the regular expression that defines the expected console output so that it matches what the sample actually produces.

Fixes #71988.