### PR TITLE
tests: drivers: uart: uart_pm fix 'rxbuf' may be used uninitialized

### DIFF
--- a/tests/drivers/uart/uart_pm/src/main.c
+++ b/tests/drivers/uart/uart_pm/src/main.c
@@ -66,7 +66,7 @@ static void async_callback(const struct device *dev, struct uart_event *evt, voi
 static bool async_verify(const struct device *dev, bool active)
 {
 	char txbuf[] = "test";
-	uint8_t rxbuf[32];
+	uint8_t rxbuf[32] = { 0 };
 	volatile bool tx_done = false;
 	int err;
 


### PR DESCRIPTION
Fix for uart_pm/src/main.c:106:23:
error: 'rxbuf' may be used uninitialized [-Werror=maybe-uninitialized]

string.h:62:10: note: by argument 2 of type 'const void *' to 'memcmp' 
   62 | int      memcmp (const void *, const void *, size_t);
      |          ^~~~~~
tests/drivers/uart/uart_pm/src/main.c:69:17: note: 'rxbuf' declared here
   69 |         uint8_t rxbuf[32];
      |                 ^~~~~