### PR TITLE
bluetooth: keys_br: Improve bt_foreach_bond

### DIFF
--- a/subsys/bluetooth/host/classic/keys_br.c
+++ b/subsys/bluetooth/host/classic/keys_br.c
@@ -146,6 +146,24 @@ void bt_keys_link_key_store(struct bt_keys_link_key *link_key)
 	}
 }
 
+void bt_foreach_bond_br(void (*func)(const struct bt_bond_info *info, void *user_data),
+			void *user_data)
+{
+	__ASSERT_NO_MSG(func != NULL);
+
+	for (size_t i = 0; i < ARRAY_SIZE(key_pool); i++) {
+		const struct bt_keys_link_key *key = &key_pool[i];
+
+		if (!bt_addr_eq(&key->addr, BT_ADDR_ANY)) {
+			struct bt_bond_info info;
+
+			info.addr.type = BT_ADDR_LE_PUBLIC;
+			bt_addr_copy(&info.addr.a, &key->addr);
+			func(&info, user_data);
+		}
+	}
+}
+
 #if defined(CONFIG_BT_SETTINGS)
 
 static int link_key_set(const char *name, size_t len_rd,

--- a/subsys/bluetooth/host/keys.c
+++ b/subsys/bluetooth/host/keys.c
@@ -169,6 +169,10 @@ void bt_foreach_bond(uint8_t id, void (*func)(const struct bt_bond_info *info,
 			func(&info, user_data);
 		}
 	}
+
+	if (IS_ENABLED(CONFIG_BT_CLASSIC)) {
+		bt_foreach_bond_br(func, user_data);
+	}
 }
 
 void bt_keys_foreach_type(enum bt_keys_type type, void (*func)(struct bt_keys *keys, void *data),

--- a/subsys/bluetooth/host/keys.h
+++ b/subsys/bluetooth/host/keys.h
@@ -215,7 +215,8 @@ struct bt_keys_link_key *bt_keys_find_link_key(const bt_addr_t *addr);
 void bt_keys_link_key_clear(struct bt_keys_link_key *link_key);
 void bt_keys_link_key_clear_addr(const bt_addr_t *addr);
 void bt_keys_link_key_store(struct bt_keys_link_key *link_key);
-
+void bt_foreach_bond_br(void (*func)(const struct bt_bond_info *info, void *user_data),
+			void *user_data);
 
 /* This function is used to signal that the key has been used for paring */
 /* It updates the aging counter and saves it to flash if configuration option */


### PR DESCRIPTION
The BR Keys cannot be scanned by function bt_foreach_bond.

Add function bt_foreach_bond_br for br.

The function bt_foreach_bond_br will be called by bt_foreach_bond if the BR is enabled.