### PR TITLE
debug: coredump: fix multiple definitions

### DIFF
--- a/include/zephyr/debug/coredump.h
+++ b/include/zephyr/debug/coredump.h
@@ -229,34 +229,34 @@ int coredump_cmd(enum coredump_cmd_id cmd_id, void *arg);
 
 #else
 
-void coredump(unsigned int reason, const z_arch_esf_t *esf,
-	      struct k_thread *thread)
+static inline void coredump(unsigned int reason, const z_arch_esf_t *esf,
+			    struct k_thread *thread)
 {
 	ARG_UNUSED(reason);
 	ARG_UNUSED(esf);
 	ARG_UNUSED(thread);
 }
 
-void coredump_memory_dump(uintptr_t start_addr, uintptr_t end_addr)
+static inline void coredump_memory_dump(uintptr_t start_addr, uintptr_t end_addr)
 {
 	ARG_UNUSED(start_addr);
 	ARG_UNUSED(end_addr);
 }
 
-void coredump_buffer_output(uint8_t *buf, size_t buflen)
+static inline void coredump_buffer_output(uint8_t *buf, size_t buflen)
 {
 	ARG_UNUSED(buf);
 	ARG_UNUSED(buflen);
 }
 
-int coredump_query(enum coredump_query_id query_id, void *arg)
+static inline int coredump_query(enum coredump_query_id query_id, void *arg)
 {
 	ARG_UNUSED(query_id);
 	ARG_UNUSED(arg);
 	return -ENOTSUP;
 }
 
-int coredump_cmd(enum coredump_cmd_id query_id, void *arg)
+static inline int coredump_cmd(enum coredump_cmd_id query_id, void *arg)
 {
 	ARG_UNUSED(query_id);
 	ARG_UNUSED(arg);


### PR DESCRIPTION
When compiling with CONFIG_DEBUG_COREDUMP=n and including <zephyr/debug/coredump.h> from any file, linking fails with a multiple definitions error. Define the functions in the header file as static inline.