### PR TITLE
codeowner: add adc driver max1125x

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -168,6 +168,7 @@
 /drivers/adc/*max11102_17*                @benediktibk
 /drivers/adc/*kb1200*                     @ene-steven
 /drivers/adc/adc_ad559x.c                 @bbilas
+/drivers/adc/*adc_max1125x*               @mustafaabdullahk
 /drivers/audio/*nrfx*                     @anangl
 /drivers/auxdisplay/*pt6314*              @xingrz
 /drivers/auxdisplay/*                      @thedjnK


### PR DESCRIPTION
Add missing @mustafaabdullahk as max1125x codeowners.

related pr: https://github.com/zephyrproject-rtos/zephyr/pull/58153

Signed-off-by: Mustafa Abdullah Kus <mustafa.kus@sparsetechnology.com>