### PR TITLE
samples: nrfx_prs: Fix pin assignment on nRF5340 DK

### DIFF
--- a/samples/boards/nrf/nrfx_prs/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/boards/nrf/nrfx_prs/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,20 +1,20 @@
 &pinctrl {
 	spi1_default_alt: spi1_default_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 0, 6)>,
-				<NRF_PSEL(SPIM_MOSI, 0, 7)>;
+			psels = <NRF_PSEL(SPIM_SCK, 0, 25)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 6)>;
 		};
 		group2 {
-			psels = <NRF_PSEL(SPIM_MISO, 0, 25)>;
+			psels = <NRF_PSEL(SPIM_MISO, 0, 7)>;
 			bias-pull-down;
 		};
 	};
 
 	spi1_sleep_alt: spi1_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 0, 6)>,
-				<NRF_PSEL(SPIM_MOSI, 0, 7)>,
-				<NRF_PSEL(SPIM_MISO, 0, 25)>;
+			psels = <NRF_PSEL(SPIM_SCK, 0, 25)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 6)>,
+				<NRF_PSEL(SPIM_MISO, 0, 7)>;
 			low-power-enable;
 		};
 	};


### PR DESCRIPTION
Pins P0.06 and P0.07 are shorted on nRF5340 DKs prepared for on-target tests because that is required for UART tests. That causes background SPIM transfers in this sample to fail because SPIM is not able to drive its SCK line configured as P0.06. Rearrange then the pins used in this sample, so that SCK is not on a pin involved in a GPIO loopback.

Fixes #72920.