### PR TITLE
arch: arm: Use voting lock for multi-core boot race condition

### DIFF
--- a/arch/arm/core/cortex_a_r/boot.h
+++ b/arch/arm/core/cortex_a_r/boot.h
@@ -26,5 +26,6 @@ extern void __start(void);
 #define BOOT_PARAM_UDF_SP_OFFSET	16
 #define BOOT_PARAM_SVC_SP_OFFSET	20
 #define BOOT_PARAM_SYS_SP_OFFSET	24
+#define BOOT_PARAM_VOTING_OFFSET	28
 
 #endif /* _BOOT_H_ */

--- a/arch/arm/core/cortex_a_r/macro_priv.inc
+++ b/arch/arm/core/cortex_a_r/macro_priv.inc
@@ -18,6 +18,27 @@
 	ubfx	\rreg0, \rreg0, #0, #24
 .endm
 
+/*
+ * Get CPU logic id by looking up cpu_node_list
+ * returns
+ *   reg0: MPID
+ *   reg1: logic id (0 ~ CONFIG_MP_MAX_NUM_CPUS - 1)
+ * clobbers: reg0, reg1, reg2, reg3
+ */
+.macro get_cpu_logic_id reg0, reg1, reg2, reg3
+	get_cpu_id \reg0
+	ldr	\reg3, =cpu_node_list
+	mov	\reg1, #0
+1:	ldr	\reg2, [\reg3, \reg1, lsl #2]
+	cmp	\reg2, \reg0
+	beq	2f
+	add	\reg1, \reg1, #1
+	cmp	\reg1, #CONFIG_MP_MAX_NUM_CPUS
+	bne	1b
+	b	.
+2:
+.endm
+
 .macro get_cpu rreg0
 	/*
          * Get CPU pointer.

--- a/arch/arm/core/cortex_a_r/reset.S
+++ b/arch/arm/core/cortex_a_r/reset.S
@@ -200,23 +200,62 @@ EL1_Reset_Handler:
 #endif /* CONFIG_DCLS */
 
     ldr r0, =arm_cpu_boot_params
+
 #if CONFIG_MP_MAX_NUM_CPUS > 1
-    get_cpu_id r1
+    /*
+     * This code uses voting locks, like arch/arm64/core/reset.S, to determine primary CPU.
+     */
 
-    ldrex r2, [r0, #BOOT_PARAM_MPID_OFFSET]
-    cmp r2, #-1
-    bne 1f
-    strex r3, r1, [r0, #BOOT_PARAM_MPID_OFFSET]
-    cmp r3, #0
+    /*
+     * Get the "logic" id defined by cpu_node_list statically for voting lock self-identify.
+     * It is worth noting that this is NOT the final logic id (arch_curr_cpu()->id)
+     */
+    get_cpu_logic_id r1, r2, r3, r4 // r1: MPID, r2: logic id
+
+    add r4, r0, #BOOT_PARAM_VOTING_OFFSET
+
+    /* signal our desire to vote */
+    mov r5, #1
+    strb r5, [r4, r2]
+    ldr r3, [r0, #BOOT_PARAM_MPID_OFFSET]
+    cmn r3, #1
+    beq 1f
+
+    /* some core already won, release */
+    mov r7, #0
+    strb r7, [r4, r2]
+    b _secondary_core
+
+    /* suggest current core then release */
+1:  str r1, [r0, #BOOT_PARAM_MPID_OFFSET]
+    strb r7, [r4, r2]
+    dmb
+
+    /* then wait until every core else is done voting */
+    mov r5, #0
+2:  ldrb r3, [r4, r5]
+    tst r3, #255
+    /* wait */
+    bne 2b
+    add r5, r5, #1
+    cmp r5, #CONFIG_MP_MAX_NUM_CPUS
+    bne 2b
+
+    /* check if current core won */
+    dmb
+    ldr r3, [r0, #BOOT_PARAM_MPID_OFFSET]
+    cmp r3, r1
     beq _primary_core
+    /* fallthrough secondary */
 
-1:
-    dmb ld
+    /* loop until our turn comes */
+_secondary_core:
+    dmb
     ldr r2, [r0, #BOOT_PARAM_MPID_OFFSET]
     cmp r1, r2
-    bne 1b
+    bne _secondary_core
 
-    /* we can now move on */
+    /* we can now load our stack pointer values and move on */
     ldr r4, =arch_secondary_cpu_init
     ldr r5, [r0, #BOOT_PARAM_FIQ_SP_OFFSET]
     ldr r6, [r0, #BOOT_PARAM_IRQ_SP_OFFSET]

--- a/arch/arm/core/cortex_a_r/smp.c
+++ b/arch/arm/core/cortex_a_r/smp.c
@@ -50,6 +50,7 @@ struct boot_params {
 	char *udf_sp;
 	char *svc_sp;
 	char *sys_sp;
+	uint8_t voting[CONFIG_MP_MAX_NUM_CPUS];
 	arch_cpustart_t fn;
 	void *arg;
 	int cpu_num;
@@ -63,6 +64,7 @@ BUILD_ASSERT(offsetof(struct boot_params, abt_sp) == BOOT_PARAM_ABT_SP_OFFSET);
 BUILD_ASSERT(offsetof(struct boot_params, udf_sp) == BOOT_PARAM_UDF_SP_OFFSET);
 BUILD_ASSERT(offsetof(struct boot_params, svc_sp) == BOOT_PARAM_SVC_SP_OFFSET);
 BUILD_ASSERT(offsetof(struct boot_params, sys_sp) == BOOT_PARAM_SYS_SP_OFFSET);
+BUILD_ASSERT(offsetof(struct boot_params, voting) == BOOT_PARAM_VOTING_OFFSET);
 
 volatile struct boot_params arm_cpu_boot_params = {
 	.mpid = -1,
@@ -74,7 +76,7 @@ volatile struct boot_params arm_cpu_boot_params = {
 	.sys_sp = (char *)(z_arm_sys_stack + CONFIG_ARMV7_SYS_STACK_SIZE),
 };
 
-static const uint32_t cpu_node_list[] = {
+const uint32_t cpu_node_list[] = {
 	DT_FOREACH_CHILD_STATUS_OKAY_SEP(DT_PATH(cpus), DT_REG_ADDR, (,))};
 
 /* cpu_map saves the maping of core id and mpid */


### PR DESCRIPTION
Port of similar change in arm64 that eliminates exclusive load/store instructions, which may not work when MMU/MPU/cache are disabled.

My previous suggestion was to simply introduce a loop around the ldrex/strex (which would handle the original problem of strex failing, but not the wider issue with using exclusive access this early in boot process). After discussion at [AArch32-R SMP fixes](https://github.com/zephyrproject-rtos/zephyr/pull/65465/commits/333c8566ed4c47c19612f5574863ea7621289a05#diff-da3175d625f6d13072c4f16348168e9b326d011de36fc65724821d3369774628) I followed the advice to use voting locks like arm64.

Verified on Corellium 4-CPU AArch32-R VM, which starts CPU cores in random order and closely in parallel.