### PR TITLE
soc: renesas: smartbond: Fix exiting from suspend state

### DIFF
--- a/soc/renesas/smartbond/da1469x/power.c
+++ b/soc/renesas/smartbond/da1469x/power.c
@@ -39,6 +39,10 @@ void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 {
 	ARG_UNUSED(state);
 	ARG_UNUSED(substate_id);
+
+	if (state == PM_STATE_STANDBY) {
+		__enable_irq();
+	}
 }
 
 static int renesas_da1469x_pm_init(void)


### PR DESCRIPTION
We need to enable irqs that were disabled when entering suspend state.