### PR TITLE
docs: bitarray: fix missing method documentation

### DIFF
--- a/include/zephyr/sys/bitarray.h
+++ b/include/zephyr/sys/bitarray.h
@@ -168,7 +168,7 @@ int sys_bitarray_test_and_clear_bit(sys_bitarray_t *bitarray, size_t bit, int *p
 int sys_bitarray_alloc(sys_bitarray_t *bitarray, size_t num_bits,
 		       size_t *offset);
 
-/*
+/**
  * Calculates the bit-wise XOR of two bitarrays in a region.
  * The result is stored in the first bitarray passed in (@p dst).
  * Both bitarrays must be of the same size.


### PR DESCRIPTION
for method `sys_bitarray_xor` that was added recently in #72901.

I messed up by forgetting to add the double asterisk for doxyen 🙈 
Noticed this when checking https://docs.zephyrproject.org/apidoc/latest/group__bitarray__apis.html#ga195f100be66d9392c8a5e917ad9f8cea