### PR TITLE
drivers: apic_timer: move to periodic mode

### DIFF
--- a/boards/intel/adl/Kconfig.defconfig
+++ b/boards/intel/adl/Kconfig.defconfig
@@ -16,6 +16,8 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 if APIC_TIMER
 config APIC_TIMER_IRQ
 	default 24
+endif
+if APIC_TIMER_TSC
 config APIC_TIMER_TSC_M
 	default 3
 config APIC_TIMER_TSC_N

--- a/boards/intel/ehl/Kconfig.defconfig
+++ b/boards/intel/ehl/Kconfig.defconfig
@@ -27,6 +27,8 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 if APIC_TIMER
 config APIC_TIMER_IRQ
 	default 24
+endif
+if APIC_TIMER_TSC
 config APIC_TIMER_TSC_M
 	default 3
 config APIC_TIMER_TSC_N

--- a/boards/intel/rpl/Kconfig.defconfig
+++ b/boards/intel/rpl/Kconfig.defconfig
@@ -17,6 +17,8 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 if APIC_TIMER
 config APIC_TIMER_IRQ
 	default 24
+endif
+if APIC_TIMER_TSC
 config APIC_TIMER_TSC_M
 	default 3
 config APIC_TIMER_TSC_N

--- a/boards/up-bridge-the-gap/up_squared/Kconfig.defconfig
+++ b/boards/up-bridge-the-gap/up_squared/Kconfig.defconfig
@@ -18,6 +18,8 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 if APIC_TIMER
 config APIC_TIMER_IRQ
 	default 24
+endif
+if APIC_TIMER_TSC
 config APIC_TIMER_TSC_M
 	default 3
 config APIC_TIMER_TSC_N

--- a/boards/up-bridge-the-gap/up_squared_pro_7000/Kconfig.defconfig
+++ b/boards/up-bridge-the-gap/up_squared_pro_7000/Kconfig.defconfig
@@ -19,6 +19,8 @@ if APIC_TIMER
 
 config APIC_TIMER_IRQ
 	default 24
+endif
+if APIC_TIMER_TSC
 config APIC_TIMER_TSC_M
 	default 3
 config APIC_TIMER_TSC_N

--- a/drivers/timer/CMakeLists.txt
+++ b/drivers/timer/CMakeLists.txt
@@ -6,6 +6,7 @@ zephyr_library_sources_ifdef(CONFIG_ALTERA_AVALON_TIMER altera_avalon_timer_hal.
 zephyr_library_sources_ifdef(CONFIG_AMBIQ_STIMER_TIMER ambiq_stimer.c)
 zephyr_library_sources_ifdef(CONFIG_APIC_TIMER apic_timer.c)
 zephyr_library_sources_ifdef(CONFIG_APIC_TSC_DEADLINE_TIMER apic_tsc.c)
+zephyr_library_sources_ifdef(CONFIG_APIC_TIMER_TSC apic_tsc.c)
 zephyr_library_sources_ifdef(CONFIG_ARCV2_TIMER arcv2_timer0.c)
 zephyr_library_sources_ifdef(CONFIG_ARM_ARCH_TIMER arm_arch_timer.c)
 zephyr_library_sources_ifdef(CONFIG_INTEL_ADSP_TIMER intel_adsp_timer.c)

--- a/drivers/timer/Kconfig.x86
+++ b/drivers/timer/Kconfig.x86
@@ -51,6 +51,19 @@ config APIC_TSC_DEADLINE_TIMER
 	  choice for any x86 device with invariant TSC and TSC
 	  deadline capability.
 
+config APIC_TIMER_TSC
+	bool "Local APIC timer using TSC time source"
+	depends on !SMP
+	select LOAPIC
+	select TICKLESS_CAPABLE
+	select TIMER_HAS_64BIT_CYCLE_COUNTER
+	help
+	  If your CPU supports invariant TSC but no TSC deadline capability
+	  then this choice will rely on the TSC as time source and the
+	  local APIC in one-shot mode as the timeout event source.
+	  You must know the ratio of the TSC frequency to the local APIC
+	  timer frequency.
+
 endchoice
 
 if APIC_TIMER
@@ -66,14 +79,7 @@ config APIC_TIMER_IRQ
 	  user-configurable and almost certainly should be managed via
 	  a different mechanism.
 
-config APIC_TIMER_TSC
-	bool "Use invariant TSC for sys_clock_cycle_get_32()"
-	select TIMER_HAS_64BIT_CYCLE_COUNTER
-	help
-	  If your CPU supports invariant TSC, and you know the ratio of the
-	  TSC frequency to CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC (the local APIC
-	  timer frequency), then enable this for a much faster and more
-	  accurate sys_clock_cycle_get_32().
+endif # APIC_TIMER
 
 if APIC_TIMER_TSC
 
@@ -87,11 +93,9 @@ config APIC_TIMER_TSC_M
 
 endif # APIC_TIMER_TSC
 
-endif # APIC_TIMER
-
 config APIC_TIMER_IRQ_PRIORITY
 	int "Local APIC timer interrupt priority"
-	depends on APIC_TIMER || APIC_TSC_DEADLINE_TIMER
+	depends on APIC_TIMER || APIC_TSC_DEADLINE_TIMER || APIC_TIMER_TSC
 	default 4
 	help
 	  This option specifies the interrupt priority used by the

--- a/drivers/timer/Kconfig.x86
+++ b/drivers/timer/Kconfig.x86
@@ -26,10 +26,10 @@ config HPET_TIMER
 config APIC_TIMER
 	bool "Local APIC timer"
 	select LOAPIC
-	select TICKLESS_CAPABLE
+	select TIMER_HAS_64BIT_CYCLE_COUNTER
 	select SYSTEM_CLOCK_LOCK_FREE_COUNT
 	help
-	  Use the x86 local APIC in one-shot mode as the system time
+	  Use the x86 local APIC in periodic mode as the system time
 	  source.  NOTE: this probably isn't what you want except on
 	  older or idiosyncratic hardware (or environments like qemu
 	  without complete APIC emulation).  Modern hardware will work

--- a/drivers/timer/apic_tsc.c
+++ b/drivers/timer/apic_tsc.c
@@ -16,8 +16,37 @@
 #define IA32_TSC_DEADLINE_MSR 0x6e0
 #define IA32_TSC_ADJUST_MSR   0x03b
 
-#define CYC_PER_TICK (CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC \
-		      / (uint64_t) CONFIG_SYS_CLOCK_TICKS_PER_SEC)
+#define CYC_PER_TICK (uint32_t)(CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC \
+				/ CONFIG_SYS_CLOCK_TICKS_PER_SEC)
+
+/* the unsigned long cast limits divisors to native CPU register width */
+#define cycle_diff_t unsigned long
+#define CYCLE_DIFF_MAX (~(cycle_diff_t)0)
+
+/*
+ * We have two constraints on the maximum number of cycles we can wait for.
+ *
+ * 1) sys_clock_announce() accepts at most INT32_MAX ticks.
+ *
+ * 2) The number of cycles between two reports must fit in a cycle_diff_t
+ *    variable before converting it to ticks.
+ *
+ * Then:
+ *
+ * 3) Pick the smallest between (1) and (2).
+ *
+ * 4) Take into account some room for the unavoidable IRQ servicing latency.
+ *    Let's use 3/4 of the max range.
+ *
+ * Finally let's add the LSB value to the result so to clear out a bunch of
+ * consecutive set bits coming from the original max values to produce a
+ * nicer literal for assembly generation.
+ */
+#define CYCLES_MAX_1	((uint64_t)INT32_MAX * (uint64_t)CYC_PER_TICK)
+#define CYCLES_MAX_2	((uint64_t)CYCLE_DIFF_MAX)
+#define CYCLES_MAX_3	MIN(CYCLES_MAX_1, CYCLES_MAX_2)
+#define CYCLES_MAX_4	(CYCLES_MAX_3 / 2 + CYCLES_MAX_3 / 4)
+#define CYCLES_MAX	(CYCLES_MAX_4 + LSB_GET(CYCLES_MAX_4))
 
 struct apic_timer_lvt {
 	uint8_t vector   : 8;
@@ -28,7 +57,9 @@ struct apic_timer_lvt {
 };
 
 static struct k_spinlock lock;
-static uint64_t last_announce;
+static uint64_t last_cycle;
+static uint64_t last_tick;
+static uint32_t last_elapsed;
 static union { uint32_t val; struct apic_timer_lvt lvt; } lvt_reg;
 
 static ALWAYS_INLINE uint64_t rdtsc(void)
@@ -39,21 +70,6 @@ static ALWAYS_INLINE uint64_t rdtsc(void)
 	return lo + (((uint64_t)hi) << 32);
 }
 
-static void isr(const void *arg)
-{
-	ARG_UNUSED(arg);
-	k_spinlock_key_t key = k_spin_lock(&lock);
-	uint32_t ticks = (rdtsc() - last_announce) / CYC_PER_TICK;
-
-	last_announce += ticks * CYC_PER_TICK;
-	k_spin_unlock(&lock, key);
-	sys_clock_announce(ticks);
-
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		sys_clock_set_timeout(1, false);
-	}
-}
-
 static inline void wrmsr(int32_t msr, uint64_t val)
 {
 	uint32_t hi = (uint32_t) (val >> 32);
@@ -62,18 +78,50 @@ static inline void wrmsr(int32_t msr, uint64_t val)
 	__asm__ volatile("wrmsr" :: "d"(hi), "a"(lo), "c"(msr));
 }
 
+static void isr(const void *arg)
+{
+	ARG_UNUSED(arg);
+
+	k_spinlock_key_t key = k_spin_lock(&lock);
+	uint64_t curr_cycle = rdtsc();
+	uint64_t delta_cycles = curr_cycle - last_cycle;
+	uint32_t delta_ticks = (cycle_diff_t)delta_cycles / CYC_PER_TICK;
+
+	last_cycle += (cycle_diff_t)delta_ticks * CYC_PER_TICK;
+	last_tick += delta_ticks;
+	last_elapsed = 0;
+
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		uint64_t next_cycle = last_cycle + CYC_PER_TICK;
+
+		wrmsr(IA32_TSC_DEADLINE_MSR, next_cycle);
+	}
+
+	k_spin_unlock(&lock, key);
+	sys_clock_announce(delta_ticks);
+}
+
 void sys_clock_set_timeout(int32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
-	uint64_t now = rdtsc();
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
+
 	k_spinlock_key_t key = k_spin_lock(&lock);
-	uint64_t expires = now + (MAX(ticks - 1, 0) * CYC_PER_TICK);
+	uint64_t next_cycle;
 
-	expires = last_announce + (((expires - last_announce + CYC_PER_TICK - 1)
-				    / CYC_PER_TICK) * CYC_PER_TICK);
+	if (ticks == K_TICKS_FOREVER) {
+		next_cycle = last_cycle + CYCLES_MAX;
+	} else {
+		next_cycle = (last_tick + last_elapsed + ticks) * CYC_PER_TICK;
+		if ((next_cycle - last_cycle) > CYCLES_MAX) {
+			next_cycle = last_cycle + CYCLES_MAX;
+		}
+	}
 
-	/* The second condition is to catch the wraparound.
+	/*
 	 * Interpreted strictly, the IA SDM description of the
 	 * TSC_DEADLINE MSR implies that it will trigger an immediate
 	 * interrupt if we try to set an expiration across the 64 bit
@@ -81,21 +129,28 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	 * real hardware it requires more than a century of uptime,
 	 * but this is cheap and safe.
 	 */
-	if ((ticks == K_TICKS_FOREVER) || (expires < last_announce)) {
-		expires = UINT64_MAX;
+	if (next_cycle < last_cycle) {
+		next_cycle = UINT64_MAX;
 	}
+	wrmsr(IA32_TSC_DEADLINE_MSR, next_cycle);
 
-	wrmsr(IA32_TSC_DEADLINE_MSR, expires);
 	k_spin_unlock(&lock, key);
 }
 
 uint32_t sys_clock_elapsed(void)
 {
-	k_spinlock_key_t key = k_spin_lock(&lock);
-	uint32_t ret = (rdtsc() - last_announce) / CYC_PER_TICK;
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return 0;
+	}
 
+	k_spinlock_key_t key = k_spin_lock(&lock);
+	uint64_t curr_cycle = rdtsc();
+	uint64_t delta_cycles = curr_cycle - last_cycle;
+	uint32_t delta_ticks = (cycle_diff_t)delta_cycles / CYC_PER_TICK;
+
+	last_elapsed = delta_ticks;
 	k_spin_unlock(&lock, key);
-	return ret;
+	return delta_ticks;
 }
 
 uint32_t sys_clock_cycle_get_32(void)
@@ -190,12 +245,12 @@ static int sys_clock_driver_init(void)
 	 */
 	__asm__ volatile("mfence" ::: "memory");
 
-	last_announce = rdtsc();
-	irq_enable(timer_irq());
-
+	last_tick = rdtsc() / CYC_PER_TICK;
+	last_cycle = last_tick * CYC_PER_TICK;
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		sys_clock_set_timeout(1, false);
+		wrmsr(IA32_TSC_DEADLINE_MSR, last_cycle + CYC_PER_TICK);
 	}
+	irq_enable(timer_irq());
 
 	return 0;
 }

--- a/soc/intel/apollo_lake/Kconfig.defconfig
+++ b/soc/intel/apollo_lake/Kconfig.defconfig
@@ -14,9 +14,6 @@ if APIC_TIMER
 config APIC_TIMER_IRQ
 	default 24
 
-config APIC_TIMER_TSC
-	default y
-
 endif # APIC_TIMER
 
 config X86_DYNAMIC_IRQ_STUBS


### PR DESCRIPTION
This driver is impossible to make time-accurate using single-shot
mode. Time accuracy may be obtained only by using periodic mode, meaning
it is not tickless capable either. Let's simplify the code by only
supporting periodic mode and strip out the TSC stuff. Any hardware with
TSC capability should use the apic_tsc driver instead.

There is apparently some hardware out there with a TSC but without the
ability to set a deadline comparator. In such case it would be much
cleaner to add the ability to use the APIC ICR in one-shot mode as a 
fallback IRQ source to the apic_tsc driver instead of relying on the 
apic_timer driver.
