### PR TITLE
samples: tfm: Remove old 'tfm' tag & update relevant boards

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3877,7 +3877,7 @@ TF-M Integration:
   labels:
     - "area: TF-M"
   tests:
-    - tfm
+    - trusted-firmware-m
 
 
 "Toolchain Integration":

--- a/boards/arm/mps2/mps2_an521_cpu0_ns.yaml
+++ b/boards/arm/mps2/mps2_an521_cpu0_ns.yaml
@@ -14,6 +14,5 @@ testing:
   only_tags:
     - arm
     - kernel
-    - tfm
     - userspace
     - trusted-firmware-m

--- a/boards/arm/mps3/mps3_an547_ns.yaml
+++ b/boards/arm/mps3/mps3_an547_ns.yaml
@@ -18,4 +18,4 @@ toolchain:
 testing:
   default: true
   only_tags:
-    - tfm
+    - trusted-firmware-m

--- a/tests/arch/arm/arm_thread_swap_tz/testcase.yaml
+++ b/tests/arch/arm/arm_thread_swap_tz/testcase.yaml
@@ -3,7 +3,7 @@ common:
   tags:
     - arm
     - fpu
-    - tfm
+    - trusted-firmware-m
   arch_allow: arm
 tests:
   arch.arm.swap.tz:

--- a/tests/net/lib/tls_credentials/testcase.yaml
+++ b/tests/net/lib/tls_credentials/testcase.yaml
@@ -10,5 +10,4 @@ tests:
     tags:
       - net
       - tls
-      - tfm
       - trusted-firmware-m


### PR DESCRIPTION
The 'tfm' tag was removed from the samples in in 7c80473e0a06851f826f4018af348d04ae57e401 but it remained in use in other parts of the project.
This change brings back consistency through out the project.