### PR TITLE
MAINTAINERS: add doc/safety to documentation area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -852,6 +852,7 @@ Documentation:
     - doc/project/
     - doc/releases/
     - doc/security/
+    - doc/safety/
     - README.rst
     - doc/substitutions.txt
     - doc/images/Zephyr-Kite-in-tree.png


### PR DESCRIPTION
Add the missing doc/safety path to the area documentation.