### PR TITLE
soc: nordic: nrf54h: Retrigger TASK_FREQ_CHANGE

### DIFF
--- a/soc/nordic/nrf54h/soc.c
+++ b/soc/nordic/nrf54h/soc.c
@@ -72,6 +72,8 @@ static int trim_hsfll(void)
 	nrf_hsfll_trim_set(hsfll, &trim);
 
 	nrf_hsfll_task_trigger(hsfll, NRF_HSFLL_TASK_FREQ_CHANGE);
+	/* HSFLL task frequency change needs to be triggered twice to take effect.*/
+	nrf_hsfll_task_trigger(hsfll, NRF_HSFLL_TASK_FREQ_CHANGE);
 
 	LOG_DBG("NRF_HSFLL->TRIM.VSUP = %d", hsfll->TRIM.VSUP);
 	LOG_DBG("NRF_HSFLL->TRIM.COARSE = %d", hsfll->TRIM.COARSE);


### PR DESCRIPTION
A single trigger of the TASK_FREQ_CHANGE task might not be enough, so trigger twice to make sure the frequency gets updated.