### PR TITLE
soc: riscv: litex: add reboot

### DIFF
--- a/boards/enjoydigital/litex_vexriscv/litex_vexriscv.dts
+++ b/boards/enjoydigital/litex_vexriscv/litex_vexriscv.dts
@@ -23,6 +23,10 @@
 	};
 };
 
+&ctrl0 {
+	status = "okay";
+};
+
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;

--- a/dts/bindings/riscv/litex,soc-controller.yaml
+++ b/dts/bindings/riscv/litex,soc-controller.yaml
@@ -1,0 +1,12 @@
+# Copyright 2024 Vogl Electronic GmbH
+# SPDX-License-Identifier: Apache-2.0
+
+description: LiteX SoC Controller driver
+
+compatible: "litex,soc-controller"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true

--- a/dts/riscv/riscv32-litex-vexriscv.dtsi
+++ b/dts/riscv/riscv32-litex-vexriscv.dtsi
@@ -32,6 +32,15 @@
 		#size-cells = <1>;
 		compatible = "litex,vexriscv";
 		ranges;
+		ctrl0: soc_controller@e0000000 {
+			compatible = "litex,soc-controller";
+			reg = <0xe0000000 0x4
+				0xe0000004 0x4
+				0xe0000008 0x4>;
+			reg-names = "reset",
+				"scratch",
+				"bus_errors";
+		};
 		intc0: interrupt-controller@bc0 {
 			compatible = "vexriscv-intc0";
 			#address-cells = <0>;

--- a/soc/litex/litex_vexriscv/CMakeLists.txt
+++ b/soc/litex/litex_vexriscv/CMakeLists.txt
@@ -9,6 +9,8 @@ zephyr_sources(
     ${ZEPHYR_BASE}/soc/common/riscv-privileged/vector.S
 )
 
+zephyr_sources_ifdef(CONFIG_REBOOT reboot.c)
+
 zephyr_include_directories(.)
 
 set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/riscv/common/linker.ld CACHE INTERNAL "")

--- a/soc/litex/litex_vexriscv/Kconfig.defconfig
+++ b/soc/litex/litex_vexriscv/Kconfig.defconfig
@@ -9,4 +9,8 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config NUM_IRQS
 	default 12
 
+config REBOOT
+	depends on DT_HAS_LITEX_SOC_CONTROLLER_ENABLED
+	default y
+
 endif # SOC_LITEX_VEXRISCV

--- a/soc/litex/litex_vexriscv/reboot.c
+++ b/soc/litex/litex_vexriscv/reboot.c
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2024 Vogl Electronic GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#define DT_DRV_COMPAT litex_soc_controller
+
+#include <zephyr/kernel.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/sys/reboot.h>
+#include <soc.h>
+
+#define LITEX_CTRL_RESET DT_INST_REG_ADDR_BY_NAME(0, reset)
+
+void sys_arch_reboot(int type)
+{
+	ARG_UNUSED(type);
+	/* SoC Reset on BIT(0)*/
+	litex_write8(BIT(0), LITEX_CTRL_RESET);
+}


### PR DESCRIPTION
this makes it possible to reboot a litex SoC through our zephyr api.

Related PR on litex: https://github.com/enjoy-digital/litex/pull/1961 

For reference: rebooting the litex SoC is already implemented in linux https://github.com/torvalds/linux/blob/master/drivers/soc/litex/litex_soc_ctrl.c