### PR TITLE
Synchronise documentations with the project file structure.

### DIFF
--- a/arch/arm/core/cortex_m/irq_manage.c
+++ b/arch/arm/core/cortex_m/irq_manage.c
@@ -122,7 +122,7 @@ void _arch_isr_direct_pm(void)
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
 	/* Lock all interrupts. irq_lock() will on this CPU only disable those
 	 * lower than BASEPRI, which is not what we want. See comments in
-	 * arch/arm/core/isr_wrapper.S
+	 * arch/arm/core/cortex_m/isr_wrapper.c
 	 */
 	__asm__ volatile("cpsid i" : : : "memory");
 #else

--- a/doc/develop/optimizations/tools.rst
+++ b/doc/develop/optimizations/tools.rst
@@ -229,32 +229,32 @@ as in the following example.
 
 Pahole will generate something similar to the output below in the console::
 
-    /* Used at: zephyr/isr_tables.c */
-    /* <80> ../include/sw_isr_table.h:30 */
-    struct _isr_table_entry {
-            void *                     arg;                  /*     0     4 */
-            void                       (*isr)(void *);       /*     4     4 */
+    /* Used at: [...]/build/zephyr/kobject_hash.c */
+    /* <375> [...]/zephyr/include/zephyr/sys/dlist.h:37 */
+    union {
+            struct _dnode *            head;               /*     0     4 */
+            struct _dnode *            next;               /*     0     4 */
+    };
+    /* Used at: [...]/build/zephyr/kobject_hash.c */
+    /* <397> [...]/zephyr/include/zephyr/sys/dlist.h:36 */
+    struct _dnode {
+            union {
+                    struct _dnode *    head;                 /*     0     4 */
+                    struct _dnode *    next;                 /*     0     4 */
+            };                                               /*     0     4 */
+            union {
+                    struct _dnode *    tail;                 /*     4     4 */
+                    struct _dnode *    prev;                 /*     4     4 */
+            };                                               /*     4     4 */
 
             /* size: 8, cachelines: 1, members: 2 */
             /* last cacheline: 8 bytes */
     };
-    /* Used at: zephyr/isr_tables.c */
-    /* <eb> ../include/arch/arm/aarch32/cortex_m/mpu/arm_mpu_v7m.h:134 */
-    struct arm_mpu_region_attr {
-            uint32_t                   rasr;                 /*     0     4 */
-
-            /* size: 4, cachelines: 1, members: 1 */
-            /* last cacheline: 4 bytes */
-    };
-    /* Used at: zephyr/isr_tables.c */
-    /* <112> ../include/arch/arm/aarch32/cortex_m/mpu/arm_mpu.h:24 */
-    struct arm_mpu_region {
-            uint32_t                   base;                 /*     0     4 */
-            const char  *              name;                 /*     4     4 */
-            arm_mpu_region_attr_t      attr;                 /*     8     4 */
-
-            /* size: 12, cachelines: 1, members: 3 */
-            /* last cacheline: 12 bytes */
+    /* Used at: [...]/build/zephyr/kobject_hash.c */
+    /* <3b7> [...]/zephyr/include/zephyr/sys/dlist.h:41 */
+    union {
+            struct _dnode *            tail;               /*     0     4 */
+            struct _dnode *            prev;               /*     0     4 */
     };
     ...
     ...

--- a/doc/hardware/arch/arm_cortex_m.rst
+++ b/doc/hardware/arch/arm_cortex_m.rst
@@ -169,7 +169,7 @@ PendSV exception return sequence restores the new thread's caller-saved register
 return address, as part of unstacking the exception stack frame.
 
 The implementation of the context-switch mechanism is present in
-:file:`arch/arm/core/swap_helper.S`.
+:file:`arch/arm/core/cortex_m/swap_helper.S`.
 
 Stack limit checking (Arm v8-M)
 -------------------------------
@@ -262,7 +262,7 @@ interrupt. If the ZLI feature is enabled in Mainline Cortex-M builds (see
 * Regular HW interrupts are assigned priority levels lower than SVC.
 
 The priority level configuration in Cortex-M is implemented in
-:file:`include/arch/arm/exception.h`.
+:file:`include/zephyr/arch/arm/cortex_m/exception.h`.
 
 Locking and unlocking IRQs
 --------------------------
@@ -337,7 +337,7 @@ CPU Idling
 
 The Cortex-M architecture port implements both k_cpu_idle()
 and k_cpu_atomic_idle(). The implementation is present in
-:file:`arch/arm/core/cpu_idle.S`.
+:file:`arch/arm/core/cortex_m/cpu_idle.c`.
 
 In both implementations, the processor
 will attempt to put the core to low power mode.
@@ -444,7 +444,7 @@ are programmed during system boot.
   ``zephyr,memory-attr`` defining the MPU permissions for the memory region.
   See the next section for more details.
 
-The above MPU regions are defined in :file:`soc/arm/common/cortex_m/arm_mpu_regions.c`.
+The above MPU regions are defined in :file:`arch/arm/core/mpu/arm_mpu_regions.c`.
 Alternative MPU configurations are allowed by enabling :kconfig:option:`CONFIG_CPU_HAS_CUSTOM_FIXED_SOC_MPU_REGIONS`.
 When enabled, this option signifies that the Cortex-M SoC will define and
 configure its own fixed MPU regions in the SoC definition.
@@ -618,7 +618,7 @@ Linking Cortex-M applications
 *****************************
 
 Most Cortex-M platforms make use of the default Cortex-M
-GCC linker script in :file:`include/arch/arm/cortex-m/scripts/linked.ld`,
+GCC linker script in :file:`include/zephyr/arch/arm/cortex_m/scripts/linker.ld`,
 although it is possible for platforms to use a custom linker
 script as well.
 


### PR DESCRIPTION
Some files haves been renamed/moved in the project while their reference in comments & documentation have not been updated.

This fixes (at least some of) those discrepancies.