### PR TITLE
tests: drivers: timer: nrf_grtc_timer: add nRF54L15 FLPR to targets

### DIFF
--- a/tests/drivers/timer/nrf_grtc_timer/testcase.yaml
+++ b/tests/drivers/timer/nrf_grtc_timer/testcase.yaml
@@ -3,5 +3,6 @@ tests:
     tags: drivers
     platform_allow:
       - nrf54l15pdk/nrf54l15/cpuapp
+      - nrf54l15pdk/nrf54l15/cpuflpr
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54h20dk/nrf54h20/cpurad


### PR DESCRIPTION
Allow testing FLPR with this testcase.