### PR TITLE
riscv: Align _isr_wrapper to 64 bytes for CLIC

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -379,6 +379,7 @@ config ARCH_IRQ_VECTOR_TABLE_ALIGN
 
 config RISCV_TRAP_HANDLER_ALIGNMENT
 	int "Alignment of RISC-V trap handler in bytes"
+	default 64 if RISCV_HAS_CLIC
 	default 4
 	help
 	  This value configures the alignment of RISC-V trap handling

--- a/soc/common/riscv-privileged/vector.S
+++ b/soc/common/riscv-privileged/vector.S
@@ -33,7 +33,7 @@ SECTION_FUNC(vectors, __start)
 	 *
 	 * CLIC vectored mode uses mtvec exclusively for exception handling and
 	 * mtvec.base must be aligned to 64 bytes (this is done using
-	 * CONFIG_ARCH_SW_ISR_TABLE_ALIGN)
+	 * CONFIG_RISCV_TRAP_HANDLER_ALIGNMENT)
 	 */
 	la t0, _isr_wrapper
 	addi t0, t0, 0x03 /* Enable CLIC vectored mode by setting LSB */


### PR DESCRIPTION
The CLIC requires that mtvec.base is aligned to 64 bytes. _isr_wrapper is used as mtvec.base, so align it to 64 bytes.