### PR TITLE
drivers: ethernet: stm32: Remove support for deprecated API

### DIFF
--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -24,17 +24,17 @@ choice ETH_STM32_HAL_API_VERSION
 	prompt "STM32Cube HAL Ethernet version"
 
 config ETH_STM32_HAL_API_V2
-	bool "Use new HAL driver"
+	bool "Use official STM32Cube HAL driver"
 	depends on SOC_SERIES_STM32H7X || SOC_SERIES_STM32H5X || SOC_SERIES_STM32F4X || SOC_SERIES_STM32F7X
 	help
-	  Use the new HAL driver instead of the legacy one.
+	  Use the official STM32Cube HAL driver instead of the legacy one.
 
 config ETH_STM32_HAL_API_V1
-	bool "Use legacy HAL driver"
-	depends on !SOC_SERIES_STM32H5X
-	select DEPRECATED if SOC_SERIES_STM32H7X || SOC_SERIES_STM32F4X || SOC_SERIES_STM32F7X
+	bool "Use legacy STM32Cube HAL driver"
+	depends on SOC_SERIES_STM32F1X || SOC_SERIES_STM32F2X
 	help
-	  Driver version based on legacy HAL version. Deprecated unless using STM32F2 series.
+	  Driver version based on legacy HAL version as the current official API version.
+	  Available only for STM32F1 and STM32F2 SoC series.
 
 endchoice
 


### PR DESCRIPTION
STM32Cube Ethernet API V2 support has been introduced in Zephyr release V3.3.

Fully remove support for the deprecated API version on impacted series (F4, F7, H7)