### PR TITLE
drivers: can: support for numaker m2l31x

### DIFF
--- a/boards/nuvoton/numaker_m2l31ki/numaker_m2l31ki_defconfig
+++ b/boards/nuvoton/numaker_m2l31ki/numaker_m2l31ki_defconfig
@@ -21,3 +21,6 @@ CONFIG_UART_CONSOLE=y
 
 # Enable RMC
 CONFIG_FLASH=y
+
+# m2l31x has 4 MPU regions and can't afford to enable CONFIG_USERSPACE
+CONFIG_USERSPACE=n

--- a/drivers/can/Kconfig.numaker
+++ b/drivers/can/Kconfig.numaker
@@ -8,6 +8,6 @@ config CAN_NUMAKER
 	default y
 	select CAN_MCAN
 	depends on DT_HAS_NUVOTON_NUMAKER_CANFD_ENABLED
-	depends on SOC_SERIES_M46X
+	depends on SOC_SERIES_M46X || SOC_SERIES_M2L31X
 	help
 	  Enables Nuvoton NuMaker CAN FD driver, using Bosch M_CAN

--- a/dts/arm/nuvoton/m2l31x.dtsi
+++ b/dts/arm/nuvoton/m2l31x.dtsi
@@ -358,6 +358,34 @@
 			#pwm-cells = <3>;
 			status = "disabled";
 		};
+
+		canfd0: canfd@40020000 {
+			compatible = "nuvoton,numaker-canfd";
+			reg = <0x40020000 0x200>, <0x40020200 0x1800>;
+			reg-names = "m_can", "message_ram";
+			interrupts = <112 0>, <113 0>;
+			interrupt-names = "int0", "int1";
+			resets = <&rst NUMAKER_CANFD0_RST>;
+			clocks = <&pcc NUMAKER_CANFD0_MODULE
+				  NUMAKER_CLK_CLKSEL0_CANFD0SEL_HCLK
+				  NUMAKER_CLK_CLKDIV5_CANFD0(1)>;
+			bosch,mram-cfg = <0x0 12 10 3 3 3 3 3>;
+			status = "disabled";
+		};
+
+		canfd1: canfd@40024000 {
+			compatible = "nuvoton,numaker-canfd";
+			reg = <0x40024000 0x200>, <0x40024200 0x1800>;
+			reg-names = "m_can", "message_ram";
+			interrupts = <114 0>, <115 0>;
+			interrupt-names = "int0", "int1";
+			resets = <&rst NUMAKER_CANFD1_RST>;
+			clocks = <&pcc NUMAKER_CANFD1_MODULE
+				  NUMAKER_CLK_CLKSEL0_CANFD1SEL_HCLK
+				  NUMAKER_CLK_CLKDIV5_CANFD1(1)>;
+			bosch,mram-cfg = <0x0 12 10 3 3 3 3 3>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/tests/drivers/can/api/boards/numaker_m2l31ki.overlay
+++ b/tests/drivers/can/api/boards/numaker_m2l31ki.overlay
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/ {
+	chosen {
+		zephyr,canbus = &canfd0;
+	};
+};
+
+&pinctrl {
+	/* CAN TX/RX --> UNO D3/D2 */
+	canfd0_default: canfd0_default {
+		group0 {
+			pinmux = <PC5MFP_CANFD0_TXD>,
+				 <PC4MFP_CANFD0_RXD>;
+		};
+	};
+};
+
+&canfd0 {
+	pinctrl-0 = <&canfd0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};


### PR DESCRIPTION
This PR is to add support for the CAN-FD driver of Nuvoton NuMaker M2L31X series and includes the configuration of the numaker_m2l31ki board for can-api test.

Pass can-api test as:
```
------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [can_classic]: pass = 43, fail = 0, skip = 2, total = 45 duration = 0.523 seconds
SUITE PASS - 100.00% [can_stats]: pass = 1, fail = 0, skip = 0, total = 1 duration = 0.001 seconds
SUITE SKIP -   0.00% [can_transceiver]: pass = 0, fail = 0, skip = 1, total = 1 duration = 0.000 seconds
SUITE PASS - 100.00% [can_utilities]: pass = 3, fail = 0, skip = 0, total = 3 duration = 0.003 seconds
SUITE PASS - 100.00% [canfd]: pass = 12, fail = 0, skip = 0, total = 12 duration = 0.017 seconds
------ TESTSUITE SUMMARY END ------
```