### PR TITLE
maintainers: litex: migrate from codeowners to maintainers.yml

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -151,7 +151,6 @@
 /drivers/*/*sam4l*                        @nandojve
 /drivers/*/*cc13xx_cc26xx*                @bwitherspoon
 /drivers/*/*gd32*                         @nandojve
-/drivers/*/*litex*                        @mateusz-holenko @kgugala @pgielda
 /drivers/*/*mcux*                         @mmahadevan108 @dleach02
 /drivers/*/*stm32*                        @erwango @ABOSTM @FRASTM
 /drivers/*/*native_posix*                 @aescolar @daor-oti
@@ -211,7 +210,6 @@
 /drivers/entropy/*b91*                    @andy-liu-telink
 /drivers/entropy/*bt_hci*                 @JordanYates
 /drivers/entropy/*rv32m1*                 @dleach02
-/drivers/entropy/*litex*                  @mateusz-holenko @kgugala @pgielda
 /drivers/ethernet/*dwmac*                 @npitre
 /drivers/ethernet/*stm32*                 @Nukersson @lochej
 /drivers/ethernet/*w5500*                 @parthitce
@@ -257,7 +255,6 @@
 /drivers/i2c/i2c_test.c                   @mbolivar-ampere
 /drivers/i2c/*rcar*                       @aaillet
 /drivers/i2c/*kb1200*                     @ene-steven
-/drivers/i2s/*litex*                      @mateusz-holenko @kgugala @pgielda
 /drivers/i2s/i2s_ll_stm32*                @avisconti
 /drivers/i2s/*nrfx*                       @anangl
 /drivers/i3c/i3c_cdns.c                   @XenuIsWatching
@@ -449,7 +446,6 @@
 /dts/riscv/ite/                           @ite
 /dts/riscv/microchip/microchip-miv.dtsi   @galak
 /dts/riscv/openisa/rv32m1*                @dleach02
-/dts/riscv/riscv32-litex-vexriscv.dtsi    @mateusz-holenko @kgugala @pgielda
 /dts/riscv/starfive/                      @rajnesh-kanwal @pfarwsi
 /dts/riscv/andes/andes_v5*                @cwshu @kevinwang821020 @jimmyzhe
 /dts/riscv/niosv/                         @sweeaun
@@ -484,8 +480,6 @@
 /dts/bindings/*/st*                       @erwango
 /dts/bindings/sensor/ams*                 @alexanderwachter
 /dts/bindings/*/sifive*                   @mateusz-holenko @kgugala @pgielda
-/dts/bindings/*/litex*                    @mateusz-holenko @kgugala @pgielda
-/dts/bindings/*/vexriscv*                 @mateusz-holenko @kgugala @pgielda
 /dts/bindings/*/andes*                    @cwshu @kevinwang821020 @jimmyzhe
 /dts/bindings/*/neorv32*                  @henrikbrixandersen
 /dts/bindings/*/*lan91c111*               @sgrrzhf

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3717,6 +3717,29 @@ Infineon Platforms:
     Infineon SOCs, dts files and related drivers. Infineon Proto, Pioneer, Eval and Relax
     boards.
 
+LiteX Platforms:
+  status: maintained
+  maintainers:
+    - tgorochowik
+    - kgugala
+    - fkokosinski
+  collaborators:
+    - mateusz-holenko
+    - maass-hamburg
+  files:
+    - boards/enjoydigital/litex_vexriscv/
+    - drivers/*/*litex*
+    - drivers/spi/spi_litespi*
+    - drivers/*/Kconfig.litex
+    - dts/bindings/*/litex*
+    - dts/riscv/riscv32-litex-vexriscv.dtsi
+    - include/zephyr/drivers/*/*litex*
+    - samples/boards/litex/
+    - samples/drivers/*litex/
+    - soc/litex/
+  labels:
+    - "platform: LiteX"
+
 Panasonic Platforms:
   status: maintained
   maintainers:

--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -36,6 +36,9 @@ Boards
   ``SOC_IT81302CX``, ``SOC_IT82002AW``, ``SOC_IT82202AX``, ``SOC_IT82302AX``.
   And, rename the ``SOC_SERIES_ITE_IT8XXX2`` to ``SOC_SERIES_IT8XXX2``. (:github:`71680`)
 
+* LiteX: Renamed the ``compatible`` of the LiteX VexRiscV interrupt controller node from
+  ``vexriscv-intc0`` to :dtcompatible:`litex,vexriscv-intc0`. (:github:`73211`)
+
 Modules
 *******
 

--- a/drivers/interrupt_controller/Kconfig
+++ b/drivers/interrupt_controller/Kconfig
@@ -26,7 +26,7 @@ config SWERV_PIC
 config VEXRISCV_LITEX_IRQ
 	bool "VexRiscv LiteX Interrupt controller"
 	default y
-	depends on DT_HAS_VEXRISCV_INTC0_ENABLED
+	depends on DT_HAS_LITEX_VEXRISCV_INTC0_ENABLED
 	help
 	  IRQ implementation for LiteX VexRiscv
 

--- a/drivers/interrupt_controller/intc_vexriscv_litex.c
+++ b/drivers/interrupt_controller/intc_vexriscv_litex.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT vexriscv_intc0
+#define DT_DRV_COMPAT litex_vexriscv_intc0
 
 #include <zephyr/kernel.h>
 #include <zephyr/arch/cpu.h>

--- a/dts/bindings/interrupt-controller/litex,vexriscv-intc0.yaml
+++ b/dts/bindings/interrupt-controller/litex,vexriscv-intc0.yaml
@@ -3,7 +3,7 @@
 
 description: LiteX VexRiscV interrupt controller
 
-compatible: "vexriscv-intc0"
+compatible: "litex,vexriscv-intc0"
 
 include: [interrupt-controller.yaml, base.yaml]
 

--- a/dts/riscv/riscv32-litex-vexriscv.dtsi
+++ b/dts/riscv/riscv32-litex-vexriscv.dtsi
@@ -33,7 +33,7 @@
 		compatible = "litex,vexriscv";
 		ranges;
 		intc0: interrupt-controller@bc0 {
-			compatible = "vexriscv-intc0";
+			compatible = "litex,vexriscv-intc0";
 			#address-cells = <0>;
 			#interrupt-cells = <2>;
 			interrupt-controller;


### PR DESCRIPTION
- add the `litex` prefix to the litex interrupt controller
- migrate the liteX codeowners to maintainers.yml
- add myself as collaborator to LiteX