### PR TITLE
usb: device: allow uneven SN to be obtained from HWINFO

### DIFF
--- a/subsys/usb/device/usb_descriptor.c
+++ b/subsys/usb/device/usb_descriptor.c
@@ -347,12 +347,11 @@ static void usb_fix_ascii_sn_string_descriptor(struct usb_sn_descriptor *sn)
 	default_sn_len = strlen(CONFIG_USB_DEVICE_SN);
 
 	if (runtime_sn_len != default_sn_len) {
-		LOG_ERR("the new SN descriptor doesn't have the same "
+		LOG_WRN("the new SN descriptor doesn't have the same "
 			"length as CONFIG_USB_DEVICE_SN");
-		return;
 	}
 
-	memcpy(sn->bString, runtime_sn, runtime_sn_len);
+	memcpy(sn->bString, runtime_sn, MIN(runtime_sn_len, default_sn_len));
 }
 
 static void usb_desc_update_mps0(struct usb_device_descriptor *const desc)


### PR DESCRIPTION
If the length of the string literal reserved for the serial number descriptor is odd, the string is not used because its length is always even and therefore one character longer. Fix this by using the shortest length for the copy.

Fixes: #69585