### PR TITLE
west.yml: hal_stm32: Don't include legacy headers anymore

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -229,7 +229,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: ed93098718d5c727d2fac5ef27023a2a14763e32
+      revision: 366c5c909fbcecf94f32411887132024f61b0bcd
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
We're not supposed to rely on symbols provided by these files. In case it is required stm32 zephyr code base should be updated rather than relying on legacy definitions.

Additionally:
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/70136

Note:
See last comment