### PR TITLE
ci: doc-build: Install pyserial

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -111,6 +111,7 @@ jobs:
         pip3 install west==${WEST_VERSION}
         pip3 install cmake==${CMAKE_VERSION}
         pip3 install coverxygen
+        pip3 install pyserial
 
     - name: west setup
       run: |
@@ -228,6 +229,7 @@ jobs:
         pip3 install -r doc/requirements.txt
         pip3 install west==${WEST_VERSION}
         pip3 install cmake==${CMAKE_VERSION}
+        pip3 install pyserial
 
     - name: west setup
       run: |


### PR DESCRIPTION
Since 7eaca455faf6ff8d9a92c4392da281dab08d0c2b, pyserial is required for building docs.