### PR TITLE
samples: net: http_get: fix typo in sections names in sample.yaml

### DIFF
--- a/samples/net/sockets/http_get/sample.yaml
+++ b/samples/net/sockets/http_get/sample.yaml
@@ -27,7 +27,7 @@ tests:
       - socket
       - offload
       - simplelink
-  sample.get.sockets.http_get.nsos.http:
+  sample.net.sockets.http_get.nsos.http:
     harness: console
     harness_config:
       type: multi_line
@@ -40,7 +40,7 @@ tests:
       - native_sim
       - native_sim/native/64
     extra_args: OVERLAY_CONFIG="overlay-nsos.conf"
-  sample.get.sockets.http_get.nsos.https:
+  sample.net.sockets.http_get.nsos.https:
     harness: console
     harness_config:
       type: multi_line


### PR DESCRIPTION
Just do: `s/sample.get/sample.net/`.