### PR TITLE
doc: requirements: Add pyserial

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -15,8 +15,9 @@ sphinx-sitemap
 PyYAML>=6.0
 pykwalify
 
-# Used by pytest-twister-harness plugin
+# Used by pytest-twister-harness plugin (imported by autodoc)
 pytest
+pyserial
 
 # Doxygen doxmlparser
 doxmlparser


### PR DESCRIPTION
Since 7eaca455faf6ff8d9a92c4392da281dab08d0c2b, pyserial is required for building docs because `DeviceAdapter` from the `pytest-twister-harness` plugin, which is imported by autodoc, now depends on it.