### PR TITLE
samples: sensors: nucleo_h7a3zi_q added to die_temp_polling

### DIFF
--- a/samples/sensor/die_temp_polling/boards/nucleo_h7a3zi_q.overlay
+++ b/samples/sensor/die_temp_polling/boards/nucleo_h7a3zi_q.overlay
@@ -1,0 +1,17 @@
+/ {
+	aliases {
+		die-temp0 = &die_temp;
+	};
+};
+
+&die_temp {
+	status = "okay";
+};
+
+&adc2 {
+	pinctrl-0 = <&adc2_inp0_pc2_c>;
+	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
+	status = "okay";
+};


### PR DESCRIPTION
Added board overlay file to permit internal temperature sensor testing:
    - `nucleo_h7a3zi_q`

Signed-off-by: Noah Pendleton <noah.pendleton@gmail.com>
