### PR TITLE
samples: sensors: nucleo_f756zg added to die_temp_polling

### DIFF
--- a/samples/sensor/die_temp_polling/boards/nucleo_f756zg.overlay
+++ b/samples/sensor/die_temp_polling/boards/nucleo_f756zg.overlay
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2024 Noah Pendleton
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		die-temp0 = &die_temp;
+	};
+};
+
+&die_temp {
+	status = "okay";
+};
+
+&adc1 {
+	pinctrl-0 = <&adc1_in0_pa0>;
+	pinctrl-names = "default";
+	st,adc-prescaler = <4>;
+	status = "okay";
+};


### PR DESCRIPTION
Added board overlay file to permit internal temperature sensor testing:

- `nucleo_f756zg`

Signed-off-by: Noah Pendleton <noah.pendleton@gmail.com>
