### PR TITLE
boards: frdm_mcxn947: Fix MCUBoot support.

### DIFF
--- a/boards/nxp/frdm_mcxn947/Kconfig.defconfig
+++ b/boards/nxp/frdm_mcxn947/Kconfig.defconfig
@@ -14,4 +14,11 @@ config MAIN_STACK_SIZE
 
 endif
 
+if BOOTLOADER_MCUBOOT
+choice MCUBOOT_BOOTLOADER_MODE
+	# Board only supports MCUBoot via "upgrade only" method:
+	default MCUBOOT_BOOTLOADER_MODE_OVERWRITE_ONLY
+endchoice
+endif #BOOTLOADER_MCUBOOT
+
 endif

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
@@ -96,16 +96,16 @@
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
 		};
-		/* Note slot 0 has one additional sector,
-		 * this is intended for use with the swap move algorithm
+		/* For the MCUBoot "upgrade only" method,
+		 * the slot sizes must be equal.
 		 */
 		slot0_partition: partition@10000 {
 			label = "image-0";
 			reg = <0x00010000 DT_SIZE_K(992)>;
 		};
-		slot1_partition: partition@100000 {
+		slot1_partition: partition@108000 {
 			label = "image-1";
-			reg = <0x00108000 DT_SIZE_K(984)>;
+			reg = <0x00108000 DT_SIZE_K(992)>;
 		};
 		/* storage_partition is placed in WINBOND flash memory*/
 	};


### PR DESCRIPTION
- Set MCUBoot "upgrade only" method, as the program size is 128B (>32B).
- Set slot sizes to the same value, required by the MCUBoot "upgrade only" method.