### PR TITLE
clang-format: add array-for-each to correct formatting issues

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -32,6 +32,8 @@ ColumnLimit: 100
 ConstructorInitializerIndentWidth: 8
 ContinuationIndentWidth: 8
 ForEachMacros:
+  - 'ARRAY_FOR_EACH'
+  - 'ARRAY_FOR_EACH_PTR'
   - 'FOR_EACH'
   - 'FOR_EACH_FIXED_ARG'
   - 'FOR_EACH_IDX'


### PR DESCRIPTION
The ARRAY_FOR_EACH() and ARRAY_FOR_EACH_PTR() macros were not formatting correctly in vs code (and I would guess other editors).

Add an entry to .clang-format so that the opening brace is on the same line as the macros added in 42335036b7ee0d896a22102ea9d822f624aefa0a.