### PR TITLE
snippets: cdc-acm-console: Redirect Shell target to USB

### DIFF
--- a/snippets/cdc-acm-console/cdc-acm-console.overlay
+++ b/snippets/cdc-acm-console/cdc-acm-console.overlay
@@ -7,6 +7,7 @@
 / {
 	chosen {
 		zephyr,console = &snippet_cdc_acm_console_uart;
+		zephyr,shell-uart = &snippet_cdc_acm_console_uart;
 	};
 };
 


### PR DESCRIPTION
To easily enable Shell over USB. Tested with:
```
west build -b nrf52840dk/nrf52840 \
           -S cdc-acm-console` \
           samples/subsys/shell/shell_module
```

Adding this functionality per suggestion brought up on https://github.com/zephyrproject-rtos/zephyr/pull/71904#discussion_r1579507231