### PR TITLE
flash: spi_nor: automatically handle device runtime PM (remove `IDLE_IN_DPD`)

### DIFF
--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -113,6 +113,11 @@ Other Subsystems
 Flash map
 =========
 
+ * ``CONFIG_SPI_NOR_IDLE_IN_DPD`` has been removed from the :kconfig:option:`CONFIG_SPI_NOR`
+   driver. An enhanced version of this functionality can be obtained by enabling
+   :ref:`pm-device-runtime` on the device (Tunable with
+   :kconfig:option:`CONFIG_SPI_NOR_ACTIVE_DWELL_MS`).
+
 hawkBit
 =======
 

--- a/drivers/flash/Kconfig.nor
+++ b/drivers/flash/Kconfig.nor
@@ -78,4 +78,15 @@ config SPI_NOR_FLASH_LAYOUT_PAGE_SIZE
 	  (32768), the sector size (4096), or any non-zero multiple of the
 	  sector size.
 
+config SPI_NOR_ACTIVE_DWELL_MS
+	int "Dwell period (ms) after last use to stay in active mode"
+	depends on PM_DEVICE_RUNTIME
+	default 10
+	help
+	  Flash accesses commonly occur in bursts, where entering and exiting DPD
+	  mode between each access adds significantly to the total operation time.
+	  This option controls how long to remain in active mode after each API
+	  call, eliminating the active->idle->active transition sequence if another
+	  transaction occurs before the dwell period expires.
+
 endif # SPI_NOR

--- a/drivers/flash/Kconfig.nor
+++ b/drivers/flash/Kconfig.nor
@@ -78,16 +78,4 @@ config SPI_NOR_FLASH_LAYOUT_PAGE_SIZE
 	  (32768), the sector size (4096), or any non-zero multiple of the
 	  sector size.
 
-config SPI_NOR_IDLE_IN_DPD
-	bool "Use Deep Power-Down mode when flash is not being accessed."
-	help
-	  Where supported deep power-down mode can reduce current draw
-	  to as little as 0.1% of standby current.  However it takes
-	  some milliseconds to enter and exit from this mode.
-
-	  Select this option for applications where device power
-	  management is not enabled, the flash remains inactive for
-	  long periods, and when used the impact of waiting for mode
-	  enter and exit delays is acceptable.
-
 endif # SPI_NOR

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -557,16 +557,24 @@ static int exit_dpd(const struct device *const dev)
 /* Everything necessary to acquire owning access to the device. */
 static void acquire_device(const struct device *dev)
 {
+	const struct spi_nor_config *cfg = dev->config;
+
 	if (IS_ENABLED(CONFIG_MULTITHREADING)) {
 		struct spi_nor_data *const driver_data = dev->data;
 
 		k_sem_take(&driver_data->sem, K_FOREVER);
 	}
+
+	(void)pm_device_runtime_get(cfg->spi.bus);
 }
 
 /* Everything necessary to release access to the device. */
 static void release_device(const struct device *dev)
 {
+	const struct spi_nor_config *cfg = dev->config;
+
+	(void)pm_device_runtime_put(cfg->spi.bus);
+
 	if (IS_ENABLED(CONFIG_MULTITHREADING)) {
 		struct spi_nor_data *const driver_data = dev->data;
 

--- a/samples/drivers/spi_flash/sample.yaml
+++ b/samples/drivers/spi_flash/sample.yaml
@@ -20,13 +20,3 @@ tests:
         - "Attempting to write 4 bytes"
         - "Data read matches data written. Good!!"
     depends_on: spi
-  sample.drivers.spi.flash_dpd:
-    tags:
-      - spi
-      - flash
-    filter: dt_compat_enabled("jedec,spi-nor")
-    platform_exclude: hifive_unmatched
-    build_only: true
-    extra_configs:
-      - CONFIG_SPI_NOR_IDLE_IN_DPD=y
-    depends_on: spi


### PR DESCRIPTION
Automatically handle device runtime PM for all flash API calls. Asynchronously release the device after a small delay to minimise power state transitions under multiple sequential API calls (e.g. NVS).

Remove `SPI_NOR_IDLE_IN_DPD` to simplify the possible transition states in the `spi_nor` driver. This option was originally added 5 years ago when device runtime PM was in a much less mature state.

I do not believe having a separate power management implementation for this one in-tree driver is in the interests of the project.

The behaviour of `SPI_NOR_IDLE_IN_DPD` leads to extremly suboptimal behaviour in use cases where multiple small reads are performed sequentially, see #69588.

Removal of this option does not break the behaviour of any existing applications, only increases current consumption in idle by ~10uA until device runtime PM is enabled.