### PR TITLE
tests: bsim: Enable asserts by default

### DIFF
--- a/tests/bsim/bluetooth/host/gatt/authorization/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/gatt/authorization/src/gatt_client_test.c
@@ -60,7 +60,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	UNSET_FLAG(flag_is_connected);
 }
 
-BT_CONN_CB_DEFINE(conn_callbacks) = {
+static struct bt_conn_cb conn_callbacks = {
 	.connected = connected,
 	.disconnected = disconnected,
 };
@@ -296,6 +296,8 @@ static void gatt_interact(uint16_t handle)
 static void test_main(void)
 {
 	int err;
+
+	bt_conn_cb_register(&conn_callbacks);
 
 	err = bt_enable(NULL);
 	if (err != 0) {

--- a/tests/bsim/bluetooth/host/gatt/authorization/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/gatt/authorization/src/gatt_server_test.c
@@ -45,7 +45,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	g_conn = NULL;
 }
 
-BT_CONN_CB_DEFINE(conn_callbacks) = {
+static struct bt_conn_cb conn_callbacks = {
 	.connected = connected,
 	.disconnected = disconnected,
 };
@@ -330,6 +330,8 @@ static void test_main(void)
 		FAIL("Registering GATT authorization callbacks failed (err %d)\n", err);
 		return;
 	}
+
+	bt_conn_cb_register(&conn_callbacks);
 
 	err = bt_enable(NULL);
 	if (err != 0) {

--- a/tests/bsim/bluetooth/host/gatt/general/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/gatt/general/src/gatt_client_test.c
@@ -74,7 +74,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_
 	}
 }
 
-BT_CONN_CB_DEFINE(conn_callbacks) = {
+static struct bt_conn_cb conn_callbacks = {
 	.connected = connected,
 	.disconnected = disconnected,
 	.security_changed = security_changed,
@@ -350,6 +350,8 @@ static void gatt_read(uint16_t handle, uint8_t expect_att_err)
 static void test_main(void)
 {
 	int err;
+
+	bt_conn_cb_register(&conn_callbacks);
 
 	err = bt_enable(NULL);
 	if (err != 0) {

--- a/tests/bsim/bluetooth/host/gatt/general/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/gatt/general/src/gatt_server_test.c
@@ -47,7 +47,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	UNSET_FLAG(flag_is_connected);
 }
 
-BT_CONN_CB_DEFINE(conn_callbacks) = {
+static struct bt_conn_cb conn_callbacks = {
 	.connected = connected,
 	.disconnected = disconnected,
 };
@@ -150,6 +150,8 @@ static void test_main(void)
 	const struct bt_data ad[] = {
 		BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR))
 	};
+
+	bt_conn_cb_register(&conn_callbacks);
 
 	err = bt_enable(NULL);
 	if (err != 0) {

--- a/tests/bsim/compile.source
+++ b/tests/bsim/compile.source
@@ -23,7 +23,7 @@ function _compile(){
   local conf_overlay="${conf_overlay:-""}"
 
   default_cmake_args=(-DCONFIG_COVERAGE=y -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-    -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y)
+    -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y -DCONFIG_ASSERT=y)
   local cmake_args=(${cmake_args:-"${default_cmake_args[@]}"})
   local cmake_extra_args="${cmake_extra_args:-""}"
   local ninja_args="${ninja_args:-""}"


### PR DESCRIPTION
Asserts should always be enabled in test builds.