### PR TITLE
boards: nrf54l15pdk_nrf54l15_cpuapp: Twister yaml for PDK 0.2.1

### DIFF
--- a/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15_cpuapp.yaml
+++ b/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15_cpuapp.yaml
@@ -10,7 +10,7 @@ toolchain:
   - xtools
   - zephyr
 ram: 188
-flash: 324
+flash: 1428
 supported:
   - adc
   - counter

--- a/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15_cpuapp_0_2_1.yaml
+++ b/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15_cpuapp_0_2_1.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+identifier: nrf54l15pdk@0.2.1/nrf54l15/cpuapp
+name: nRF54l15-PDK-nRF54l15-Application
+type: mcu
+arch: arm
+toolchain:
+  - gnuarmemb
+  - xtools
+  - zephyr
+ram: 188
+flash: 1428
+supported:
+  - adc
+  - counter
+  - gpio
+  - i2c
+  - pwm
+  - spi
+  - watchdog
+  - i2s


### PR DESCRIPTION
PR adds twister yaml for nrf54l15pdk_nrf54l15_cpuapp rev 0.2.1. The file is needed to support PDK 0.2.1 in tests.
PR also fixes flash size used in the nrf54l15pdk_nrf54l15_cpuapp.yaml.