### PR TITLE
usb: device_next: CDC ACM: Process TX on configuration enable

### DIFF
--- a/subsys/usb/device_next/class/usbd_cdc_acm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_acm.c
@@ -268,7 +268,13 @@ static void usbd_cdc_acm_enable(struct usbd_class_data *const c_data)
 	}
 
 	if (atomic_test_bit(&data->state, CDC_ACM_IRQ_TX_ENABLED)) {
-		/* TODO */
+		if (ring_buf_is_empty(data->tx_fifo.rb)) {
+			/* Raise TX ready interrupt */
+			cdc_acm_work_submit(&data->irq_cb_work);
+		} else {
+			/* Queue pending TX data on IN endpoint */
+			cdc_acm_work_submit(&data->tx_fifo_work);
+		}
 	}
 }
 


### PR DESCRIPTION
If CDC ACM uart side has TX enabled when the configuration gets enabled, depending on fifo state following has to happen:
  * if the fifo is empty - trigger TX ready interrupt
  * if the fifo is not empty - queue TX data on IN endpoint