### PR TITLE
samples: net: Exclude native_posix when socket service lib is used

### DIFF
--- a/samples/net/dns_resolve/sample.yaml
+++ b/samples/net/dns_resolve/sample.yaml
@@ -4,6 +4,9 @@ common:
   tags:
     - net
     - dns
+  platform_exclude:
+    - native_posix
+    - native_posix/native/64
 sample:
   description: DNS resolver, mDNS and LLMNR responder
   name: DNS resolver and responder sample application

--- a/samples/net/sockets/big_http_download/sample.yaml
+++ b/samples/net/sockets/big_http_download/sample.yaml
@@ -9,6 +9,9 @@ common:
   tags:
     - net
     - socket
+  platform_exclude:
+    - native_posix
+    - native_posix/native/64
 tests:
   sample.net.sockets.big_http_download:
     extra_configs:

--- a/samples/net/sockets/http_get/sample.yaml
+++ b/samples/net/sockets/http_get/sample.yaml
@@ -8,6 +8,9 @@ common:
   tags:
     - net
     - socket
+  platform_exclude:
+    - native_posix
+    - native_posix/native/64
 tests:
   sample.net.sockets.http_get:
     filter: not CONFIG_NET_SOCKETS_OFFLOAD and not CONFIG_NATIVE_LIBC

--- a/samples/posix/gettimeofday/sample.yaml
+++ b/samples/posix/gettimeofday/sample.yaml
@@ -10,6 +10,9 @@ common:
   tags:
     - posix
     - net
+  platform_exclude:
+    - native_posix
+    - native_posix/native/64
 tests:
   sample.posix.gettimeofday:
     harness: net


### PR DESCRIPTION
Socket service library uses eventfd, which does not work with native_posix platform, hence need to exclude it from samples that now rely on socket services.

Fixes #73434