### PR TITLE
drivers: adc: ltc2451: Add ltc2451 default conversion speed

### DIFF
--- a/dts/bindings/adc/lltc,ltc2451.yaml
+++ b/dts/bindings/adc/lltc,ltc2451.yaml
@@ -10,7 +10,11 @@ include: i2c-device.yaml
 properties:
   conversion-speed:
     type: int
+    default: 60
     enum:
       - 30
       - 60
-    description: Set conversion speed in Hz
+    description: |
+      Set conversion speed in Hz
+      Default value corresponds to the default value of the register
+      To specify channel 2 and 4 = 0b001010 = 10


### PR DESCRIPTION
Adds default conversion speed as it isn't a required property