### PR TITLE
docs: Add pytest files to a scope triggering doc-build workflow

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -50,6 +50,8 @@ jobs:
           scripts/dts/
           doc/requirements.txt
           .github/workflows/doc-build.yml
+          scripts/pylib/pytest-twister-harness/src/twister_harness/device/device_adapter.py
+          scripts/pylib/pytest-twister-harness/src/twister_harness/helpers/shell.py
 
   doc-build-html:
     name: "Documentation Build (HTML)"


### PR DESCRIPTION
Those files are used with autoclass to use their docstrings in docs.