### PR TITLE
doc: describe Kconfig tracking symbol

### DIFF
--- a/doc/build/kconfig/setting.rst
+++ b/doc/build/kconfig/setting.rst
@@ -198,6 +198,55 @@ configuration that gets modified when making changes in the :ref:`interactive
 configuration interfaces <menuconfig>`.
 
 
+Tracking Kconfig symbols
+************************
+
+It is possible to create Kconfig symbols which takes the default value of
+another Kconfig symbol.
+
+This is valuable when you want a symbol specific to an application or subsystem
+but do not want to rely directly on the common symbol. For example, you might
+want to decouple the settings so they can be independently configured, or to
+ensure you always have a locally named setting, even if the external setting name changes.
+is later changed.
+
+For example, consider the common ``FOO_STRING`` setting where a subsystem wants
+to have a ``SUB_FOO_STRING`` but still allow for customization.
+
+This can be done like this:
+
+.. code-block:: kconfig
+
+    config FOO_STRING
+            string "Foo"
+            default "foo"
+
+    config SUB_FOO_STRING
+            string "Sub-foo"
+            default FOO_STRING
+
+This ensures that the default value of ``SUB_FOO_STRING`` is identical to
+``FOO_STRING`` while still allows users to configure both settings
+independently.
+
+It is also possible to make ``SUB_FOO_STRING`` invisible and thereby keep the
+two symbols in sync, unless the value of the tracking symbol is changed in a
+:file:`defconfig` file.
+
+.. code-block:: kconfig
+
+    config FOO_STRING
+            string "Foo"
+            default "foo"
+
+    config SUB_FOO_STRING
+            string
+            default FOO_STRING
+            help
+              Hidden symbol which follows FOO_STRING
+              Can be changed through *.defconfig files.
+
+
 Configuring invisible Kconfig symbols
 *************************************
 


### PR DESCRIPTION
Fixes: #73132

Add a subsection on tracking Kconfig symbols whose default values is obtained from another Kconfig symbol.