### PR TITLE
drivers: nxp_enet: Add ability to use fused mac on some platforms

### DIFF
--- a/drivers/ethernet/nxp_enet/eth_nxp_enet.c
+++ b/drivers/ethernet/nxp_enet/eth_nxp_enet.c
@@ -63,7 +63,6 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #elif defined(CONFIG_SOC_SERIES_KINETIS_K6X)
 #define ETH_NXP_ENET_UNIQUE_ID	(SIM->UIDH ^ SIM->UIDMH ^ SIM->UIDML ^ SIM->UIDL)
 #else
-#define ETH_NXP_ENET_UNIQUE_ID 0xFFFFFF
 #error "Unsupported SOC"
 #endif
 
@@ -599,11 +598,13 @@ static void eth_nxp_enet_isr(const struct device *dev)
 	irq_unlock(irq_lock_key);
 }
 
+/* Note this is not universally unique, it just is probably unique on a network */
 static inline void nxp_enet_unique_mac(uint8_t *mac_addr)
 {
 	uint32_t id = ETH_NXP_ENET_UNIQUE_ID;
 
-	mac_addr[0] = FREESCALE_OUI_B0;
+	/* Setting LAA bit because it is not guaranteed universally unique */
+	mac_addr[0] = FREESCALE_OUI_B0 | 0x02;
 	mac_addr[1] = FREESCALE_OUI_B1;
 	mac_addr[2] = FREESCALE_OUI_B2;
 	mac_addr[3] = FIELD_GET(0xFF0000, id);

--- a/dts/bindings/ethernet/nxp,enet-mac.yaml
+++ b/dts/bindings/ethernet/nxp,enet-mac.yaml
@@ -26,6 +26,11 @@ properties:
   nxp,unique-mac:
     type: boolean
     description: |
-      Use unique silicon ID to use UAA MAC.
+      Use part of the unique silicon ID to generate the MAC.
       This property will be overridden if the node has
       zephyr,random-mac-address or local-mac-address also.
+      This option is intended for cases where a very low likelihood
+      that the mac address is the same as another on the network
+      is sufficient, such as, testing, bringup, demos, etc.
+      The first 3 bytes will be the freescale OUI and the next
+      3 bytes will come from the chip's unique ID.

--- a/dts/bindings/ethernet/nxp,enet-mac.yaml
+++ b/dts/bindings/ethernet/nxp,enet-mac.yaml
@@ -34,3 +34,9 @@ properties:
       is sufficient, such as, testing, bringup, demos, etc.
       The first 3 bytes will be the freescale OUI and the next
       3 bytes will come from the chip's unique ID.
+
+  nxp,fused-mac:
+    type: boolean
+    description: |
+      Use the MAC address from fuse shadow register.
+      Not all platforms have a fusable MAC address.

--- a/west.yml
+++ b/west.yml
@@ -198,7 +198,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 88a7d079eed470ecc94010784931823a85ac3b39
+      revision: 5db52e3e3bd6a7ada1f4983e037555d3ff9af028
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Add ability to use fused mac on RT10xx and RT11xx and redocument the nxp,unique-mac property to be more clear of what it is