### PR TITLE
boards: remove test feature usb_cdc

### DIFF
--- a/boards/adafruit/feather/adafruit_feather_nrf52840.yaml
+++ b/boards/adafruit/feather/adafruit_feather_nrf52840.yaml
@@ -9,7 +9,6 @@ toolchain:
 supported:
   - adc
   - usb_device
-  - usb_cdc
   - ble
   - watchdog
   - counter

--- a/boards/adafruit/itsybitsy/adafruit_itsybitsy_nrf52840.yaml
+++ b/boards/adafruit/itsybitsy/adafruit_itsybitsy_nrf52840.yaml
@@ -16,7 +16,6 @@ supported:
   - i2c
   - pwm
   - spi
-  - usb_cdc
   - usb_device
   - watchdog
 vendor: adafruit

--- a/boards/arduino/giga_r1/arduino_giga_r1_stm32h747xx_m7.yaml
+++ b/boards/arduino/giga_r1/arduino_giga_r1_stm32h747xx_m7.yaml
@@ -14,6 +14,5 @@ supported:
   - arduino_spi
   - spi
   - memc
-  - usb_cdc
   - usb_device
 vendor: arduino

--- a/boards/arduino/nano_33_ble/arduino_nano_33_ble.yaml
+++ b/boards/arduino/nano_33_ble/arduino_nano_33_ble.yaml
@@ -14,7 +14,6 @@ supported:
   - serial
   - spi
   - uart
-  - usb_cdc
   - usb_device
   - watchdog
 vendor: arduino

--- a/boards/arduino/nano_33_ble/arduino_nano_33_ble_nrf52840_sense.yaml
+++ b/boards/arduino/nano_33_ble/arduino_nano_33_ble_nrf52840_sense.yaml
@@ -14,7 +14,6 @@ supported:
   - serial
   - spi
   - uart
-  - usb_cdc
   - usb_device
   - watchdog
 vendor: arduino

--- a/boards/atmel/sam0/samd21_xpro/samd21_xpro.yaml
+++ b/boards/atmel/sam0/samd21_xpro/samd21_xpro.yaml
@@ -20,7 +20,6 @@ supported:
   - pwm
   - spi
   - uart
-  - usb_cdc
   - usb_device
   - watchdog
 vendor: atmel

--- a/boards/atmel/sam0/saml21_xpro/saml21_xpro.yaml
+++ b/boards/atmel/sam0/saml21_xpro/saml21_xpro.yaml
@@ -20,7 +20,6 @@ supported:
   - pwm
   - spi
   - uart
-  - usb_cdc
   - usb_device
   - watchdog
 vendor: atmel

--- a/boards/atmel/sam0/samr34_xpro/samr34_xpro.yaml
+++ b/boards/atmel/sam0/samr34_xpro/samr34_xpro.yaml
@@ -20,7 +20,6 @@ supported:
   - pwm
   - spi
   - uart
-  - usb_cdc
   - usb_device
   - watchdog
 vendor: atmel

--- a/boards/lairdconnect/bl5340_dvk/bl5340_dvk_nrf5340_cpuapp.yaml
+++ b/boards/lairdconnect/bl5340_dvk/bl5340_dvk_nrf5340_cpuapp.yaml
@@ -16,7 +16,6 @@ supported:
   - qspi
   - spi
   - uart
-  - usb_cdc
   - usb_device
   - watchdog
 vendor: lairdconnect

--- a/boards/lairdconnect/bl5340_dvk/bl5340_dvk_nrf5340_cpuapp_ns.yaml
+++ b/boards/lairdconnect/bl5340_dvk/bl5340_dvk_nrf5340_cpuapp_ns.yaml
@@ -15,7 +15,6 @@ supported:
   - pwm
   - spi
   - uart
-  - usb_cdc
   - usb_device
   - watchdog
 vendor: lairdconnect

--- a/boards/lairdconnect/bl654_usb/bl654_usb.yaml
+++ b/boards/lairdconnect/bl654_usb/bl654_usb.yaml
@@ -8,7 +8,6 @@ toolchain:
   - xtools
 supported:
   - usb_device
-  - usb_cdc
   - ble
   - pwm
   - watchdog

--- a/boards/lairdconnect/pinnacle_100_dvk/pinnacle_100_dvk.yaml
+++ b/boards/lairdconnect/pinnacle_100_dvk/pinnacle_100_dvk.yaml
@@ -16,7 +16,6 @@ supported:
   - i2c
   - pwm
   - spi
-  - usb_cdc
   - usb_device
   - watchdog
   - netif:modem

--- a/boards/makerdiary/nrf52840_mdk_usb_dongle/nrf52840_mdk_usb_dongle.yaml
+++ b/boards/makerdiary/nrf52840_mdk_usb_dongle/nrf52840_mdk_usb_dongle.yaml
@@ -10,7 +10,6 @@ toolchain:
   - xtools
 supported:
   - usb_device
-  - usb_cdc
   - ble
   - watchdog
   - counter

--- a/boards/nordic/nrf21540dk/nrf21540dk_nrf52840.yaml
+++ b/boards/nordic/nrf21540dk/nrf21540dk_nrf52840.yaml
@@ -18,7 +18,6 @@ supported:
   - i2c
   - pwm
   - spi
-  - usb_cdc
   - usb_device
   - watchdog
   - netif:openthread

--- a/boards/nordic/nrf52840dk/nrf52840dk_nrf52840.yaml
+++ b/boards/nordic/nrf52840dk/nrf52840dk_nrf52840.yaml
@@ -21,7 +21,6 @@ supported:
   - i2s
   - pwm
   - spi
-  - usb_cdc
   - usb_device
   - watchdog
   - netif:openthread

--- a/boards/nordic/nrf52840dongle/nrf52840dongle_nrf52840.yaml
+++ b/boards/nordic/nrf52840dongle/nrf52840dongle_nrf52840.yaml
@@ -11,7 +11,6 @@ toolchain:
 supported:
   - adc
   - usb_device
-  - usb_cdc
   - ble
   - pwm
   - spi

--- a/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_cpuapp.yaml
+++ b/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_cpuapp.yaml
@@ -19,6 +19,5 @@ supported:
   - i2c
   - pwm
   - watchdog
-  - usb_cdc
   - usb_device
 vendor: nordic

--- a/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_cpuapp_ns.yaml
+++ b/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_cpuapp_ns.yaml
@@ -14,6 +14,5 @@ supported:
   - spi
   - pwm
   - watchdog
-  - usb_cdc
   - usb_device
 vendor: nordic

--- a/boards/nordic/nrf5340dk/nrf5340dk_nrf5340_cpuapp.yaml
+++ b/boards/nordic/nrf5340dk/nrf5340dk_nrf5340_cpuapp.yaml
@@ -14,7 +14,6 @@ supported:
   - i2s
   - pwm
   - watchdog
-  - usb_cdc
   - usb_device
   - netif:openthread
   - gpio

--- a/boards/nordic/nrf5340dk/nrf5340dk_nrf5340_cpuapp_ns.yaml
+++ b/boards/nordic/nrf5340dk/nrf5340dk_nrf5340_cpuapp_ns.yaml
@@ -12,7 +12,6 @@ supported:
   - i2c
   - pwm
   - watchdog
-  - usb_cdc
   - usb_device
   - netif:openthread
   - gpio

--- a/boards/nordic/thingy53/thingy53_nrf5340_cpuapp.yaml
+++ b/boards/nordic/thingy53/thingy53_nrf5340_cpuapp.yaml
@@ -13,7 +13,6 @@ supported:
   - i2c
   - pwm
   - watchdog
-  - usb_cdc
   - usb_device
   - netif:openthread
 vendor: nordic

--- a/boards/nordic/thingy53/thingy53_nrf5340_cpuapp_ns.yaml
+++ b/boards/nordic/thingy53/thingy53_nrf5340_cpuapp_ns.yaml
@@ -13,7 +13,6 @@ supported:
   - i2c
   - pwm
   - watchdog
-  - usb_cdc
   - usb_device
   - netif:openthread
 vendor: nordic

--- a/boards/panasonic/pan1770_evb/pan1770_evb.yaml
+++ b/boards/panasonic/pan1770_evb/pan1770_evb.yaml
@@ -25,7 +25,6 @@ supported:
   - i2s
   - pwm
   - spi
-  - usb_cdc
   - usb_device
   - watchdog
   - netif:openthread

--- a/boards/panasonic/pan1780_evb/pan1780_evb.yaml
+++ b/boards/panasonic/pan1780_evb/pan1780_evb.yaml
@@ -25,7 +25,6 @@ supported:
   - i2s
   - pwm
   - spi
-  - usb_cdc
   - usb_device
   - watchdog
   - netif:openthread

--- a/boards/panasonic/pan1783/pan1783_evb_nrf5340_cpuapp.yaml
+++ b/boards/panasonic/pan1783/pan1783_evb_nrf5340_cpuapp.yaml
@@ -14,7 +14,6 @@ supported:
   - i2s
   - pwm
   - watchdog
-  - usb_cdc
   - usb_device
   - netif:openthread
   - gpio

--- a/boards/panasonic/pan1783/pan1783a_evb_nrf5340_cpuapp.yaml
+++ b/boards/panasonic/pan1783/pan1783a_evb_nrf5340_cpuapp.yaml
@@ -14,7 +14,6 @@ supported:
   - i2s
   - pwm
   - watchdog
-  - usb_cdc
   - usb_device
   - netif:openthread
   - gpio

--- a/boards/panasonic/pan1783/pan1783a_pa_evb_nrf5340_cpuapp.yaml
+++ b/boards/panasonic/pan1783/pan1783a_pa_evb_nrf5340_cpuapp.yaml
@@ -14,7 +14,6 @@ supported:
   - i2s
   - pwm
   - watchdog
-  - usb_cdc
   - usb_device
   - netif:openthread
   - gpio

--- a/boards/phytec/reel_board/reel_board_1.yaml
+++ b/boards/phytec/reel_board/reel_board_1.yaml
@@ -13,7 +13,6 @@ supported:
   - spi
   - gpio
   - usb_device
-  - usb_cdc
   - ble
   - pwm
   - arduino_i2c

--- a/boards/phytec/reel_board/reel_board_nrf52840_2.yaml
+++ b/boards/phytec/reel_board/reel_board_nrf52840_2.yaml
@@ -13,7 +13,6 @@ supported:
   - spi
   - gpio
   - usb_device
-  - usb_cdc
   - ble
   - pwm
   - arduino_i2c

--- a/boards/rak/rak4631/rak4631_nrf52840.yaml
+++ b/boards/rak/rak4631/rak4631_nrf52840.yaml
@@ -15,7 +15,6 @@ supported:
   - gpio
   - i2c
   - pwm
-  - usb_cdc
   - usb_device
   - watchdog
   - lora

--- a/boards/rak/rak5010/rak5010_nrf52840.yaml
+++ b/boards/rak/rak5010/rak5010_nrf52840.yaml
@@ -15,7 +15,6 @@ supported:
   - gpio
   - i2c
   - pwm
-  - usb_cdc
   - usb_device
   - watchdog
 vendor: rak

--- a/boards/raytac/mdbt50q_db_33/raytac_mdbt50q_db_33_nrf52833.yaml
+++ b/boards/raytac/mdbt50q_db_33/raytac_mdbt50q_db_33_nrf52833.yaml
@@ -21,7 +21,6 @@ supported:
   - ieee802154
   - pwm
   - spi
-  - usb_cdc
   - usb_device
   - watchdog
   - netif:openthread

--- a/boards/raytac/mdbt50q_db_40/raytac_mdbt50q_db_40_nrf52840.yaml
+++ b/boards/raytac/mdbt50q_db_40/raytac_mdbt50q_db_40_nrf52840.yaml
@@ -23,7 +23,6 @@ supported:
   - ieee802154
   - pwm
   - spi
-  - usb_cdc
   - usb_device
   - watchdog
   - netif:openthread

--- a/boards/raytac/mdbt53_db_40/raytac_mdbt53_db_40_nrf5340_cpuapp.yaml
+++ b/boards/raytac/mdbt53_db_40/raytac_mdbt53_db_40_nrf5340_cpuapp.yaml
@@ -17,6 +17,5 @@ supported:
   - spi
   - uart
   - watchdog
-  - usb_cdc
   - usb_device
   - netif:openthread

--- a/boards/raytac/mdbt53_db_40/raytac_mdbt53_db_40_nrf5340_cpuapp_ns.yaml
+++ b/boards/raytac/mdbt53_db_40/raytac_mdbt53_db_40_nrf5340_cpuapp_ns.yaml
@@ -15,7 +15,6 @@ supported:
   - watchdog
   - spi
   - uart
-  - usb_cdc
   - usb_device
   - netif:openthread
   - gpio

--- a/boards/seeed/wio_terminal/wio_terminal.yaml
+++ b/boards/seeed/wio_terminal/wio_terminal.yaml
@@ -16,7 +16,6 @@ supported:
   - i2c
   - pwm
   - spi
-  - usb_cdc
   - usb_device
   - watchdog
 vendor: seeed

--- a/boards/seeed/xiao_ble/xiao_ble.yaml
+++ b/boards/seeed/xiao_ble/xiao_ble.yaml
@@ -17,7 +17,6 @@ supported:
   - i2s
   - pwm
   - spi
-  - usb_cdc
   - usb_device
   - watchdog
   - netif:openthread

--- a/boards/seeed/xiao_ble/xiao_ble_nrf52840_sense.yaml
+++ b/boards/seeed/xiao_ble/xiao_ble_nrf52840_sense.yaml
@@ -17,7 +17,6 @@ supported:
   - i2s
   - pwm
   - spi
-  - usb_cdc
   - usb_device
   - watchdog
   - netif:openthread

--- a/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m7.yaml
+++ b/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m7.yaml
@@ -17,6 +17,5 @@ supported:
   - i2c
   - pwm
   - netif:eth
-  - usb_cdc
   - usb_device
 vendor: st

--- a/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m7.yaml
+++ b/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m7.yaml
@@ -16,6 +16,5 @@ supported:
   - netif:eth
   - qspi
   - memc
-  - usb_cdc
   - usb_device
 vendor: st

--- a/boards/u-blox/ubx_bmd340eval/ubx_bmd340eval_nrf52840.yaml
+++ b/boards/u-blox/ubx_bmd340eval/ubx_bmd340eval_nrf52840.yaml
@@ -20,7 +20,6 @@ supported:
   - pwm
   - spi
   - qspi
-  - usb_cdc
   - usb_device
   - watchdog
   - netif:openthread

--- a/boards/u-blox/ubx_bmd345eval/ubx_bmd345eval_nrf52840.yaml
+++ b/boards/u-blox/ubx_bmd345eval/ubx_bmd345eval_nrf52840.yaml
@@ -19,7 +19,6 @@ supported:
   - pwm
   - spi
   - qspi
-  - usb_cdc
   - usb_device
   - watchdog
   - netif:openthread

--- a/boards/u-blox/ubx_bmd380eval/ubx_bmd380eval_nrf52840.yaml
+++ b/boards/u-blox/ubx_bmd380eval/ubx_bmd380eval_nrf52840.yaml
@@ -17,7 +17,6 @@ supported:
   - pwm
   - spi
   - qspi
-  - usb_cdc
   - usb_device
   - watchdog
   - netif:openthread

--- a/boards/u-blox/ubx_evkninab3/ubx_evkninab3_nrf52840.yaml
+++ b/boards/u-blox/ubx_evkninab3/ubx_evkninab3_nrf52840.yaml
@@ -18,7 +18,6 @@ supported:
   - i2c
   - pwm
   - spi
-  - usb_cdc
   - usb_device
   - watchdog
   - netif:openthread

--- a/samples/subsys/usb/console/sample.yaml
+++ b/samples/subsys/usb/console/sample.yaml
@@ -4,7 +4,6 @@ tests:
   sample.usb.console:
     depends_on:
       - usb_device
-      - usb_cdc
     tags: usb
     harness: console
     harness_config:


### PR DESCRIPTION
This test feature is not required and was only used as a dependency in the usb/console example. It is redundant since the sample already depends on usb_device.