### PR TITLE
net: l2: ethernet: arp: Fix ARP probe target HW address matching

### DIFF
--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -726,6 +726,27 @@ static inline bool net_eth_is_addr_broadcast(struct net_eth_addr *addr)
 }
 
 /**
+ * @brief Check if the Ethernet MAC address is a all zeroes address.
+ *
+ * @param addr A valid pointer to an Ethernet MAC address.
+ *
+ * @return true if address is an all zeroes address, false if not
+ */
+static inline bool net_eth_is_addr_all_zeroes(struct net_eth_addr *addr)
+{
+	if (addr->addr[0] == 0x00 &&
+	    addr->addr[1] == 0x00 &&
+	    addr->addr[2] == 0x00 &&
+	    addr->addr[3] == 0x00 &&
+	    addr->addr[4] == 0x00 &&
+	    addr->addr[5] == 0x00) {
+		return true;
+	}
+
+	return false;
+}
+
+/**
  * @brief Check if the Ethernet MAC address is unspecified.
  *
  * @param addr A valid pointer to a Ethernet MAC address.

--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -791,14 +791,11 @@ enum net_verdict net_arp_input(struct net_pkt *pkt,
 		}
 
 		if (IS_ENABLED(CONFIG_NET_ARP_GRATUITOUS)) {
-			if (memcmp(&eth_hdr->dst,
-				   net_eth_broadcast_addr(),
-				   sizeof(struct net_eth_addr)) == 0 &&
-			    memcmp(&arp_hdr->dst_hwaddr,
-				   net_eth_broadcast_addr(),
-				   sizeof(struct net_eth_addr)) == 0 &&
-			    memcmp(&arp_hdr->dst_ipaddr, &arp_hdr->src_ipaddr,
-				   sizeof(struct in_addr)) == 0) {
+			if (net_eth_is_addr_broadcast(&eth_hdr->dst) &&
+			    (net_eth_is_addr_broadcast(&arp_hdr->dst_hwaddr) ||
+			     net_eth_is_addr_all_zeroes(&arp_hdr->dst_hwaddr)) &&
+			    net_ipv4_addr_cmp_raw(arp_hdr->dst_ipaddr,
+						  arp_hdr->src_ipaddr)) {
 				/* If the IP address is in our cache,
 				 * then update it here.
 				 */


### PR DESCRIPTION
According to RFC3927 and RFC5227, an ARP probe target HW address should be set to all-zeroes:

"The 'target hardware address' field is ignored and SHOULD be set to all zeroes."

Hence, we should allow the ARP probes to have all-zeroes target HW address as well.

Fixes #73038