### PR TITLE
Added sysbuild support for pytest-twister-harness

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/binary_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/binary_adapter.py
@@ -118,7 +118,7 @@ class NativeSimulatorAdapter(BinaryAdapterBase):
 
     def generate_command(self) -> None:
         """Set command to run."""
-        self.command = [str(self.device_config.build_dir / 'zephyr' / 'zephyr.exe')]
+        self.command = [str(self.device_config.app_build_dir / 'zephyr' / 'zephyr.exe')]
 
 
 class UnitSimulatorAdapter(BinaryAdapterBase):
@@ -126,10 +126,10 @@ class UnitSimulatorAdapter(BinaryAdapterBase):
 
     def generate_command(self) -> None:
         """Set command to run."""
-        self.command = [str(self.device_config.build_dir / 'testbinary')]
+        self.command = [str(self.device_config.app_build_dir / 'testbinary')]
 
 
 class CustomSimulatorAdapter(BinaryAdapterBase):
     def generate_command(self) -> None:
         """Set command to run."""
-        self.command = [self.west, 'build', '-d', str(self.device_config.build_dir), '-t', 'run']
+        self.command = [self.west, 'build', '-d', str(self.device_config.app_build_dir), '-t', 'run']

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/qemu_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/qemu_adapter.py
@@ -23,7 +23,7 @@ class QemuAdapter(BinaryAdapterBase):
 
     def generate_command(self) -> None:
         """Set command to run."""
-        self.command = [self.west, 'build', '-d', str(self.device_config.build_dir), '-t', 'run']
+        self.command = [self.west, 'build', '-d', str(self.device_config.app_build_dir), '-t', 'run']
         if 'stdin' in self.process_kwargs:
             self.process_kwargs.pop('stdin')
 

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/helpers/domains_helper.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/helpers/domains_helper.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import os
+import sys
+import logging
+
+from pathlib import Path
+
+ZEPHYR_BASE = os.environ['ZEPHYR_BASE']
+sys.path.insert(0, os.path.join(ZEPHYR_BASE, 'scripts', 'pylib', 'build_helpers'))
+
+from domains import Domains
+
+logger = logging.getLogger(__name__)
+logging.getLogger('pykwalify').setLevel(logging.ERROR)
+
+
+def get_default_domain_name(domains_file: Path | str) -> int:
+    """
+    Get the default domain name from the domains.yaml file
+    """
+    domains = Domains.from_file(domains_file)
+    logger.debug("Loaded sysbuild domain data from %s" % domains_file)
+    return domains.get_default_domain().name

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/twister_harness_config.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/twister_harness_config.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
+from twister_harness.helpers.domains_helper import get_default_domain_name
 
 import pytest
 
@@ -32,6 +33,14 @@ class DeviceConfig:
     pre_script: Path | None = None
     post_script: Path | None = None
     post_flash_script: Path | None = None
+    app_build_dir: Path | None = None
+
+    def __post_init__(self):
+        domains = self.build_dir / 'domains.yaml'
+        if domains.exists():
+            self.app_build_dir = self.build_dir / get_default_domain_name(domains)
+        else:
+            self.app_build_dir = self.build_dir
 
 
 @dataclass

--- a/scripts/pylib/pytest-twister-harness/tests/device/qemu_adapter_test.py
+++ b/scripts/pylib/pytest-twister-harness/tests/device/qemu_adapter_test.py
@@ -27,7 +27,7 @@ def fixture_device_adapter(tmp_path) -> Generator[QemuAdapter, None, None]:
 
 @patch('shutil.which', return_value='west')
 def test_if_generate_command_creates_proper_command(patched_which, device: QemuAdapter):
-    device.device_config.build_dir = Path('build_dir')
+    device.device_config.app_build_dir = Path('build_dir')
     device.generate_command()
     assert device.command == ['west', 'build', '-d', 'build_dir', '-t', 'run']
 

--- a/tests/boot/with_mcumgr/pytest/test_downgrade_prevention.py
+++ b/tests/boot/with_mcumgr/pytest/test_downgrade_prevention.py
@@ -14,7 +14,7 @@ from utils import (
     check_with_shell_command,
     check_with_mcumgr_command,
 )
-from test_upgrade import create_signed_image, PROJECT_NAME
+from test_upgrade import create_signed_image
 
 
 logger = logging.getLogger(__name__)
@@ -34,14 +34,15 @@ def test_downgrade_prevention(dut: DeviceAdapter, shell: Shell, mcumgr: MCUmgr):
     6) Verify that the original application is booted (version 1.1.1)
     """
     origin_version = find_in_config(
-        Path(dut.device_config.build_dir) / PROJECT_NAME / 'zephyr' / '.config',
+        Path(dut.device_config.app_build_dir) / 'zephyr' / '.config',
         'CONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION'
     )
     check_with_shell_command(shell, origin_version)
     assert origin_version != '0.0.0+0'
 
     logger.info('Prepare upgrade image with lower version')
-    image_to_test = create_signed_image(dut.device_config.build_dir, '0.0.0+0')
+    image_to_test = create_signed_image(dut.device_config.build_dir,
+                                        dut.device_config.app_build_dir, '0.0.0+0')
 
     logger.info('Upload image with mcumgr')
     dut.disconnect()

--- a/tests/boot/with_mcumgr/pytest/test_upgrade.py
+++ b/tests/boot/with_mcumgr/pytest/test_upgrade.py
@@ -18,10 +18,9 @@ from utils import (
 )
 
 logger = logging.getLogger(__name__)
-PROJECT_NAME = 'with_mcumgr'
 
 
-def create_signed_image(build_dir: Path, version: str) -> Path:
+def create_signed_image(build_dir: Path, app_build_dir: Path, version: str) -> Path:
     image_to_test = Path(build_dir) / 'test_{}.signed.bin'.format(
         version.replace('.', '_').replace('+', '_'))
     origin_key_file = find_in_config(
@@ -29,7 +28,7 @@ def create_signed_image(build_dir: Path, version: str) -> Path:
         'CONFIG_BOOT_SIGNATURE_KEY_FILE'
     )
     west_sign_with_imgtool(
-        build_dir=Path(build_dir) / PROJECT_NAME,
+        build_dir=Path(app_build_dir),
         output_bin=image_to_test,
         key_file=Path(origin_key_file),
         version=version
@@ -62,7 +61,8 @@ def test_upgrade_with_confirm(dut: DeviceAdapter, shell: Shell, mcumgr: MCUmgr):
     """
     logger.info('Prepare upgrade image')
     new_version = '0.0.2+0'
-    image_to_test = create_signed_image(dut.device_config.build_dir, new_version)
+    image_to_test = create_signed_image(dut.device_config.build_dir,
+                                        dut.device_config.app_build_dir, new_version)
 
     logger.info('Upload image with mcumgr')
     dut.disconnect()
@@ -111,12 +111,13 @@ def test_upgrade_with_revert(dut: DeviceAdapter, shell: Shell, mcumgr: MCUmgr):
     8) Verify that MCUboot reverts update
     """
     origin_version = find_in_config(
-        Path(dut.device_config.build_dir) / PROJECT_NAME / 'zephyr' / '.config',
+        Path(dut.device_config.app_build_dir) / 'zephyr' / '.config',
         'CONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION'
     )
     logger.info('Prepare upgrade image')
     new_version = '0.0.3+0'
-    image_to_test = create_signed_image(dut.device_config.build_dir, new_version)
+    image_to_test = create_signed_image(dut.device_config.build_dir,
+                                        dut.device_config.app_build_dir, new_version)
 
     logger.info('Upload image with mcumgr')
     dut.disconnect()
@@ -178,14 +179,14 @@ def test_upgrade_signature(dut: DeviceAdapter, shell: Shell, mcumgr: MCUmgr, key
         key_file = Path(origin_key_file).parent / key_file
         assert key_file.is_file()
         assert not key_file.samefile(origin_key_file)
-        image_to_test = image_to_test = Path(dut.device_config.build_dir) / 'test_invalid_key.bin'
+        image_to_test = Path(dut.device_config.build_dir) / 'test_invalid_key.bin'
         logger.info('Sign second image with an invalid key')
     else:
-        image_to_test = image_to_test = Path(dut.device_config.build_dir) / 'test_no_key.bin'
+        image_to_test = Path(dut.device_config.build_dir) / 'test_no_key.bin'
         logger.info('Sign second imagewith no key')
 
     west_sign_with_imgtool(
-        build_dir=Path(dut.device_config.build_dir) / PROJECT_NAME,
+        build_dir=Path(dut.device_config.app_build_dir),
         output_bin=image_to_test,
         key_file=key_file,
         version='0.0.3+4'  # must differ from the origin version, if not then hash is not updated


### PR DESCRIPTION
This PR fixes native and qemu when using sysbuild and `pytest-twister-harness`.
To test it, one can enable sysbuild in sample: samples/subsys/testsuite/pytest/shell
(by adding `sysbuild: true`),
then run:
`./scripts/twister -vv -T samples/subsys/testsuite/pytest/shell -p qemu_x86 -p native_sim`

Default domain is read from `domains.yaml` file (same as in twister core), and paths to build directories are updated.

Additionally in that PR I updated `tests/boot/with_mcumgr` testcase, to use updated paths from pytest-twister-harness.

This PR is related to #72100