### PR TITLE
Introduce CP9314 B1 silicon and HW I2C lock support

### DIFF
--- a/drivers/regulator/regulator_cp9314.c
+++ b/drivers/regulator/regulator_cp9314.c
@@ -520,7 +520,6 @@ static int regulator_cp9314_init(const struct device *dev)
 
 	switch (value) {
 	case CP9314_CHIP_REV_B0:
-		LOG_INF("Found CP9314 REV:0x%x\n", value);
 		ret = regulator_cp9314_b0_init(dev);
 		if (ret < 0) {
 			return ret;
@@ -530,6 +529,8 @@ static int regulator_cp9314_init(const struct device *dev)
 		LOG_ERR("Invalid CP9314 REV:0x%x\n", value);
 		return -ENOTSUP;
 	}
+
+	LOG_INF("Found CP9314 REV:0x%x\n", value);
 
 	ret = regulator_cp9314_otp_init(dev);
 	if (ret < 0) {

--- a/drivers/regulator/regulator_cp9314.c
+++ b/drivers/regulator/regulator_cp9314.c
@@ -530,7 +530,7 @@ static int regulator_cp9314_init(const struct device *dev)
 		return -ENOTSUP;
 	}
 
-	LOG_INF("Found CP9314 REV:0x%x\n", value);
+	LOG_DBG("Found CP9314 REV:0x%x\n", value);
 
 	ret = regulator_cp9314_otp_init(dev);
 	if (ret < 0) {

--- a/drivers/regulator/regulator_cp9314.c
+++ b/drivers/regulator/regulator_cp9314.c
@@ -119,6 +119,7 @@ LOG_MODULE_REGISTER(CP9314, CONFIG_REGULATOR_LOG_LEVEL);
 #define CP9314_REG_BC_STS_C  0x62
 #define CP9314_CHIP_REV_MASK GENMASK(7, 4)
 #define CP9314_CHIP_REV_B0   0x1
+#define CP9314_CHIP_REV_B1   0x3
 
 #define CP9314_REG_FORCE_SC_MISC 0x69
 #define CP9314_FORCE_CSI_EN      BIT(0)
@@ -524,6 +525,8 @@ static int regulator_cp9314_init(const struct device *dev)
 		if (ret < 0) {
 			return ret;
 		}
+		break;
+	case CP9314_CHIP_REV_B1:
 		break;
 	default:
 		LOG_ERR("Invalid CP9314 REV:0x%x\n", value);

--- a/drivers/regulator/regulator_cp9314.c
+++ b/drivers/regulator/regulator_cp9314.c
@@ -118,7 +118,7 @@ LOG_MODULE_REGISTER(CP9314, CONFIG_REGULATOR_LOG_LEVEL);
 
 #define CP9314_REG_BC_STS_C  0x62
 #define CP9314_CHIP_REV_MASK GENMASK(7, 4)
-#define CP9314_CHIP_REV_B0   0x10
+#define CP9314_CHIP_REV_B0   0x1
 
 #define CP9314_REG_FORCE_SC_MISC 0x69
 #define CP9314_FORCE_CSI_EN      BIT(0)
@@ -516,7 +516,7 @@ static int regulator_cp9314_init(const struct device *dev)
 		return ret;
 	}
 
-	value &= CP9314_CHIP_REV_MASK;
+	value = FIELD_GET(CP9314_CHIP_REV_MASK, value);
 
 	switch (value) {
 	case CP9314_CHIP_REV_B0:

--- a/dts/bindings/regulator/cirrus,cp9314.yaml
+++ b/dts/bindings/regulator/cirrus,cp9314.yaml
@@ -39,3 +39,9 @@ properties:
     description: |
       Desired switched capacitor ratio set at initialization. This entry will overwrite
       the selection set by the PROG resistor.
+
+  cirrus,hw-i2c-lock:
+    type: boolean
+    description: |
+      Indicate if the hardware write lock was enabled via the resistor value applied to
+      PGPIO2.


### PR DESCRIPTION
These changes introduce support for the B1 revision of CP9314 and its new hardware I2C write lock feature. This feature protects the CP9314 from spurious writes to the control port when not in use.

Additionally, this PR drops support for the B0 revision that does not include the I2C write lock mechanism. Instances of CP9314 that do not contain the write lock mechanism are not recommended for host-controlled applications.