### PR TITLE
drivers: gpio: remove '&' when assigning `gpio_xxx_init` function

### DIFF
--- a/drivers/gpio/gpio_ads114s0x.c
+++ b/drivers/gpio/gpio_ads114s0x.c
@@ -138,7 +138,7 @@ BUILD_ASSERT(CONFIG_GPIO_ADS114S0X_INIT_PRIORITY > CONFIG_ADC_INIT_PRIORITY,
                                                                                                    \
 	static struct gpio_ads114s0x_data gpio_ads114s0x_##id##_data;                              \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(id, &gpio_ads114s0x_init, NULL, &gpio_ads114s0x_##id##_data,         \
+	DEVICE_DT_INST_DEFINE(id, gpio_ads114s0x_init, NULL, &gpio_ads114s0x_##id##_data,          \
 			      &gpio_ads114s0x_##id##_cfg, POST_KERNEL,                             \
 			      CONFIG_GPIO_ADS114S0X_INIT_PRIORITY, &gpio_ads114s0x_api);
 

--- a/drivers/gpio/gpio_ambiq.c
+++ b/drivers/gpio/gpio_ambiq.c
@@ -580,7 +580,7 @@ static const struct gpio_driver_api ambiq_gpio_drv_api = {
 		.irq_num = DT_INST_IRQN(n),                                                        \
 		.cfg_func = ambiq_gpio_cfg_func_##n};                                              \
 	AMBIQ_GPIO_CONFIG_FUNC(n)                                                                  \
-	DEVICE_DT_INST_DEFINE(n, &ambiq_gpio_init, NULL, &ambiq_gpio_data_##n,                     \
+	DEVICE_DT_INST_DEFINE(n, ambiq_gpio_init, NULL, &ambiq_gpio_data_##n,                      \
 			      &ambiq_gpio_config_##n, PRE_KERNEL_1, CONFIG_GPIO_INIT_PRIORITY,     \
 			      &ambiq_gpio_drv_api);
 

--- a/drivers/gpio/gpio_axp192.c
+++ b/drivers/gpio/gpio_axp192.c
@@ -313,7 +313,7 @@ static int gpio_axp192_init(const struct device *dev)
                                                                                                    \
 	static struct gpio_axp192_data gpio_axp192_data##inst;                                     \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(inst, &gpio_axp192_init, NULL, &gpio_axp192_data##inst,              \
+	DEVICE_DT_INST_DEFINE(inst, gpio_axp192_init, NULL, &gpio_axp192_data##inst,               \
 			      &gpio_axp192_config##inst, POST_KERNEL,                              \
 			      CONFIG_GPIO_AXP192_INIT_PRIORITY, &gpio_axp192_api);
 

--- a/drivers/gpio/gpio_cc32xx.c
+++ b/drivers/gpio/gpio_cc32xx.c
@@ -256,7 +256,7 @@ static const struct gpio_driver_api api_funcs = {
 	}
 
 #define GPIO_CC32XX_DEVICE_INIT(n)					     \
-	DEVICE_DT_INST_DEFINE(n, &gpio_cc32xx_a##n##_init,		     \
+	DEVICE_DT_INST_DEFINE(n, gpio_cc32xx_a##n##_init,		     \
 			NULL, &gpio_cc32xx_a##n##_data,			     \
 			&gpio_cc32xx_a##n##_config,			     \
 			POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,		     \

--- a/drivers/gpio/gpio_davinci.c
+++ b/drivers/gpio/gpio_davinci.c
@@ -191,7 +191,7 @@ static int gpio_davinci_init(const struct device *dev)
 	static struct gpio_davinci_data gpio_davinci_##n##_data;		  \
 										  \
 	DEVICE_DT_INST_DEFINE(n,						  \
-		&gpio_davinci_init,						  \
+		gpio_davinci_init,						  \
 		NULL,								  \
 		&gpio_davinci_##n##_data,					  \
 		&gpio_davinci_##n##_config,					  \

--- a/drivers/gpio/gpio_gd32.c
+++ b/drivers/gpio/gpio_gd32.c
@@ -373,7 +373,7 @@ static int gpio_gd32_init(const struct device *port)
 									       \
 	static struct gpio_gd32_data gpio_gd32_data##n;			       \
 									       \
-	DEVICE_DT_INST_DEFINE(n, &gpio_gd32_init, NULL, &gpio_gd32_data##n,    \
+	DEVICE_DT_INST_DEFINE(n, gpio_gd32_init, NULL, &gpio_gd32_data##n,     \
 			      &gpio_gd32_config##n, PRE_KERNEL_1,	       \
 			      CONFIG_GPIO_INIT_PRIORITY, &gpio_gd32_api);
 

--- a/drivers/gpio/gpio_lmp90xxx.c
+++ b/drivers/gpio/gpio_lmp90xxx.c
@@ -161,7 +161,7 @@ BUILD_ASSERT(CONFIG_GPIO_LMP90XXX_INIT_PRIORITY >
 	static struct gpio_lmp90xxx_data gpio_lmp90xxx_##id##_data;	\
 									\
 	DEVICE_DT_INST_DEFINE(id,					\
-			    &gpio_lmp90xxx_init,			\
+			    gpio_lmp90xxx_init,				\
 			    NULL,					\
 			    &gpio_lmp90xxx_##id##_data,			\
 			    &gpio_lmp90xxx_##id##_cfg, POST_KERNEL,	\

--- a/drivers/gpio/gpio_neorv32.c
+++ b/drivers/gpio/gpio_neorv32.c
@@ -221,7 +221,7 @@ static const struct gpio_driver_api neorv32_gpio_driver_api = {
 	};								\
 									\
 	DEVICE_DT_INST_DEFINE(n,					\
-			&neorv32_gpio_init,				\
+			neorv32_gpio_init,				\
 			NULL,						\
 			&neorv32_gpio_##n##_data,			\
 			&neorv32_gpio_##n##_config,			\

--- a/drivers/gpio/gpio_npm1300.c
+++ b/drivers/gpio/gpio_npm1300.c
@@ -222,7 +222,7 @@ static int gpio_npm1300_init(const struct device *dev)
                                                                                                    \
 		static struct gpio_npm1300_data gpio_npm1300_data##n;                              \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(n, &gpio_npm1300_init, NULL, &gpio_npm1300_data##n,                  \
+	DEVICE_DT_INST_DEFINE(n, gpio_npm1300_init, NULL, &gpio_npm1300_data##n,                   \
 			      &gpio_npm1300_config##n, POST_KERNEL,                                \
 			      CONFIG_GPIO_NPM1300_INIT_PRIORITY, &gpio_npm1300_api);
 

--- a/drivers/gpio/gpio_npm6001.c
+++ b/drivers/gpio/gpio_npm6001.c
@@ -223,7 +223,7 @@ static int gpio_npm6001_init(const struct device *dev)
                                                                                \
 	static struct gpio_npm6001_data gpio_npm6001_data##n;                  \
                                                                                \
-	DEVICE_DT_INST_DEFINE(n, &gpio_npm6001_init, NULL,                     \
+	DEVICE_DT_INST_DEFINE(n, gpio_npm6001_init, NULL,                      \
 			      &gpio_npm6001_data##n, &gpio_npm6001_config##n,  \
 			      POST_KERNEL, CONFIG_GPIO_NPM6001_INIT_PRIORITY,  \
 			      &gpio_npm6001_api);

--- a/drivers/gpio/gpio_numaker.c
+++ b/drivers/gpio/gpio_numaker.c
@@ -265,7 +265,7 @@ static void gpio_numaker_isr(const struct device *dev)
 		SYS_LockReg();                                                                     \
 		return err;                                                                        \
 	}                                                                                          \
-	DEVICE_DT_INST_DEFINE(n, &gpio_numaker_init##n, NULL, &gpio_numaker_data##n,               \
+	DEVICE_DT_INST_DEFINE(n, gpio_numaker_init##n, NULL, &gpio_numaker_data##n,                \
 			      &gpio_numaker_config##n, PRE_KERNEL_1, CONFIG_GPIO_INIT_PRIORITY,    \
 			      &gpio_numaker_api);
 

--- a/drivers/gpio/gpio_sedi.c
+++ b/drivers/gpio/gpio_sedi.c
@@ -331,7 +331,7 @@ static int gpio_sedi_init(const struct device *dev)
 	};							       \
 	PM_DEVICE_DEFINE(gpio_##n, gpio_sedi_pm_action);               \
 	DEVICE_DT_INST_DEFINE(n,				       \
-		      &gpio_sedi_init,				       \
+		      gpio_sedi_init,				       \
 		      PM_DEVICE_GET(gpio_##n),		               \
 		      &gpio##n##_data,			               \
 		      &gpio##n##_config,			       \

--- a/drivers/gpio/gpio_xlnx_axi.c
+++ b/drivers/gpio/gpio_xlnx_axi.c
@@ -450,7 +450,7 @@ static const struct gpio_driver_api gpio_xlnx_axi_driver_api = {
 			   irq_enable(DT_INST_IRQN(n));                                            \
 		   }))                                                                             \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(n, &gpio_xlnx_axi_init, NULL, &gpio_xlnx_axi_##n##_data,             \
+	DEVICE_DT_INST_DEFINE(n, gpio_xlnx_axi_init, NULL, &gpio_xlnx_axi_##n##_data,              \
 			      &gpio_xlnx_axi_##n##_config, PRE_KERNEL_1,                           \
 			      CONFIG_GPIO_INIT_PRIORITY, &gpio_xlnx_axi_driver_api);
 


### PR DESCRIPTION
Remove address-of operator ('&') when assigning `gpio_xxx_init` function pointer in `DEVICE_DT_INST_DEFINE` macro.

This change aims to maintain consistency among the drivers in `drivers/gpio`, ensuring that all function pointer assignments follow the same pattern.