### PR TITLE
arch: riscv: check esf before calling z_riscv_unwind_stack

### DIFF
--- a/arch/riscv/core/fatal.c
+++ b/arch/riscv/core/fatal.c
@@ -107,7 +107,7 @@ FUNC_NORETURN void z_riscv_fatal_error_csf(unsigned int reason, const z_arch_esf
 		LOG_ERR("");
 	}
 
-	if (IS_ENABLED(CONFIG_RISCV_EXCEPTION_STACK_TRACE)) {
+	if (IS_ENABLED(CONFIG_RISCV_EXCEPTION_STACK_TRACE) && (esf != NULL)) {
 		z_riscv_unwind_stack(esf);
 	}
 

--- a/arch/riscv/core/stacktrace.c
+++ b/arch/riscv/core/stacktrace.c
@@ -88,10 +88,6 @@ void z_riscv_unwind_stack(const z_arch_esf_t *esf)
 	uintptr_t ra;
 	struct stackframe *frame;
 
-	if (esf == NULL) {
-		return;
-	}
-
 	LOG_ERR("call trace:");
 
 	for (int i = 0; (i < MAX_STACK_FRAMES) && (fp != 0U) && in_stack_bound(fp);) {
@@ -120,10 +116,6 @@ void z_riscv_unwind_stack(const z_arch_esf_t *esf)
 	uintptr_t sp = z_riscv_get_sp_before_exc(esf);
 	uintptr_t ra;
 	uintptr_t *ksp = (uintptr_t *)sp;
-
-	if (esf == NULL) {
-		return;
-	}
 
 	LOG_ERR("call trace:");
 

--- a/include/zephyr/internal/syscall_handler.h
+++ b/include/zephyr/internal/syscall_handler.h
@@ -56,7 +56,7 @@ enum _obj_init_check {
  */
 static inline bool k_is_in_user_syscall(void)
 {
-	/* This gets set on entry to the syscall's generasted z_mrsh
+	/* This gets set on entry to the syscall's generated z_mrsh
 	 * function and then cleared on exit. This code path is only
 	 * encountered when a syscall is made from user mode, system
 	 * calls from supervisor mode bypass everything directly to


### PR DESCRIPTION
During a fault in the userspace, the esf pointer from `_current->syscall_frame` can be `NULL`, and could be dereferenced during the variable initialization in the `z_riscv_unwind_stack` function, which leads to `Load access fault`

Make sure that esf is not NULL before calling `z_riscv_unwind_stack` to prevent NULL pointer dereferencing.

This bug is found when working on #73288, and will unblock that PR.