### PR TITLE
arch: arm64: fatal: limit max number of stack traces

### DIFF
--- a/arch/arm64/core/fatal.c
+++ b/arch/arm64/core/fatal.c
@@ -223,7 +223,7 @@ static void esf_unwind(const z_arch_esf_t *esf)
 	uint64_t lr;
 
 	LOG_ERR("");
-	while (fp != NULL) {
+	for (int i = 0; (fp != NULL) && (i < CONFIG_EXCEPTION_STACK_TRACE_MAX_FRAMES); i++) {
 		lr = fp[1];
 #ifdef CONFIG_SYMTAB
 		uint32_t offset = 0;


### PR DESCRIPTION
In some cases, the `fp` will never be `NULL` and the stack unwinding can go on and on forever, limit the max depth so that this will not happen.

Repro/test with:

```
west build -b qemu_cortex_a53 -p auto -t run \
  -T zephyr/tests/kernel/mem_protect/userspace/kernel.memory_protection.userspace -- \
    -DCONFIG_OVERRIDE_FRAME_POINTER_DEFAULT=y \
    -DCONFIG_OMIT_FRAME_POINTER=n
```