### PR TITLE
net: ppp: Optimize memory allocation

### DIFF
--- a/drivers/net/ppp.c
+++ b/drivers/net/ppp.c
@@ -326,7 +326,7 @@ static int ppp_save_byte(struct ppp_driver_context *ppp, uint8_t byte)
 	 */
 	if (ppp->available == 1) {
 		ret = net_pkt_alloc_buffer(ppp->pkt,
-					   CONFIG_NET_BUF_DATA_SIZE,
+					   CONFIG_NET_BUF_DATA_SIZE + ppp->available,
 					   AF_UNSPEC, K_NO_WAIT);
 		if (ret < 0) {
 			LOG_ERR("[%p] cannot allocate new data buffer", ppp);


### PR DESCRIPTION
net_pkt_alloc_buffer() deducts the free space from the requested number of bytes.

As ppp_save_byte() calls net_pkt_alloc_buffer() when the packet has one byte available still, this causes all but the first net_buf in the packet to be of size CONFIG_NET_BUF_DATA_SIZE - 1.

Consequences:
 - With CONFIG_NET_BUF_FIXED_DATA_SIZE enabled, one byte per net_buf gets wasted.
 - CONFIG_NET_BUF_DATA_SIZE has typically an even, likely even a power of two value. Using exactly one byte less per buffer causes operations that require aligned memory (e.g. DMA) to become inefficient or to not work at all.