### PR TITLE
[Backport v3.5-branch] drivers: can: shell: fully initialize frame before sending and use correct DLC in output

### DIFF
--- a/drivers/can/can_shell.c
+++ b/drivers/can/can_shell.c
@@ -665,7 +665,7 @@ static int cmd_can_send(const struct shell *sh, size_t argc, char **argv)
 		    (frame.flags & CAN_FRAME_RTR) != 0 ? 1 : 0,
 		    (frame.flags & CAN_FRAME_FDF) != 0 ? 1 : 0,
 		    (frame.flags & CAN_FRAME_BRS) != 0 ? 1 : 0,
-		    can_dlc_to_bytes(frame.dlc));
+		    frame.dlc);
 
 	err = can_send(dev, &frame, K_NO_WAIT, can_shell_tx_callback, UINT_TO_POINTER(frame_no));
 	if (err != 0) {

--- a/drivers/can/can_shell.c
+++ b/drivers/can/can_shell.c
@@ -560,7 +560,7 @@ static int cmd_can_send(const struct shell *sh, size_t argc, char **argv)
 	const struct device *dev = device_get_binding(argv[1]);
 	static unsigned int frame_counter;
 	unsigned int frame_no;
-	struct can_frame frame;
+	struct can_frame frame = { 0 };
 	uint32_t max_id;
 	int argidx = 2;
 	uint32_t val;


### PR DESCRIPTION
Backport 6a070ee165fe39b2fcbfd365102165ab362dce2f~2..6a070ee165fe39b2fcbfd365102165ab362dce2f from #73310

Fixes: #73310
Fixes: #73314