### PR TITLE
Bluetooth: samples: hci_ipc: Fix incorrect NULL pointer check

### DIFF
--- a/samples/bluetooth/hci_ipc/src/main.c
+++ b/samples/bluetooth/hci_ipc/src/main.c
@@ -294,7 +294,7 @@ void bt_ctlr_assert_handle(char *file, uint32_t line)
 		struct net_buf *buf;
 
 		buf = hci_vs_err_assert(file, line);
-		if (buf == NULL) {
+		if (buf != NULL) {
 			/* Send the event over ipc */
 			hci_ipc_send(buf, HCI_FATAL_ERR_MSG);
 		} else {


### PR DESCRIPTION
The condition was the inverse of what it should have been, leading to an inevitable NULL pointer dereference later.