### PR TITLE
ztest: Remove include of syscalls/ztest_test.h

### DIFF
--- a/subsys/testsuite/ztest/include/zephyr/ztest_test.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest_test.h
@@ -576,8 +576,4 @@ __syscall void sys_clock_tick_set(uint64_t tick);
 }
 #endif
 
-#ifndef ZTEST_UNITTEST
-#include <syscalls/ztest_test.h>
-#endif
-
 #endif /* ZEPHYR_TESTSUITE_ZTEST_TEST_H_ */


### PR DESCRIPTION
There is no such file in Zephyr.