### PR TITLE
dts: litex: add node label for cpu

### DIFF
--- a/dts/riscv/riscv32-litex-vexriscv.dtsi
+++ b/dts/riscv/riscv32-litex-vexriscv.dtsi
@@ -18,7 +18,7 @@
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
-		cpu@0 {
+		cpu0: cpu@0 {
 			clock-frequency = <100000000>;
 			compatible = "litex,vexriscv-standard", "riscv";
 			device_type = "cpu";


### PR DESCRIPTION
This adds a node label for the litex cpu.