### PR TITLE
tests: drivers: uart: Add nrf54l15/cpuflpr overlays to test scope

### DIFF
--- a/tests/drivers/uart/uart_async_api/boards/nrf54l15pdk_nrf54l15_cpuflpr.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/nrf54l15pdk_nrf54l15_cpuflpr.overlay
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	uart21_default: uart21_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 10)>,
+				<NRF_PSEL(UART_RX, 1, 11)>;
+		};
+	};
+
+	uart21_sleep: uart21_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 10)>,
+				<NRF_PSEL(UART_RX, 1, 11)>;
+			low-power-enable;
+		};
+	};
+};
+
+dut: &uart21 {
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&uart21_default>;
+	pinctrl-1 = <&uart21_sleep>;
+	pinctrl-names = "default", "sleep";
+};

--- a/tests/drivers/uart/uart_elementary/boards/nrf54l15pdk_nrf54l15_cpuflpr.overlay
+++ b/tests/drivers/uart/uart_elementary/boards/nrf54l15pdk_nrf54l15_cpuflpr.overlay
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+&pinctrl {
+	uart21_default: uart21_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 10)>,
+				<NRF_PSEL(UART_RX, 1, 11)>,
+				<NRF_PSEL(UART_RTS, 1, 8)>,
+				<NRF_PSEL(UART_CTS, 1, 9)>;
+		};
+	};
+
+	uart21_sleep: uart21_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 10)>,
+				<NRF_PSEL(UART_RX, 1, 11)>,
+				<NRF_PSEL(UART_RTS, 1, 8)>,
+				<NRF_PSEL(UART_CTS, 1, 9)>;
+			low-power-enable;
+		};
+	};
+};
+
+dut: &uart21 {
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&uart21_default>;
+	pinctrl-1 = <&uart21_sleep>;
+	pinctrl-names = "default", "sleep";
+	hw-flow-control;
+};

--- a/tests/drivers/uart/uart_elementary/boards/nrf54l15pdk_nrf54l15_cpuflpr_dual_uart.overlay
+++ b/tests/drivers/uart/uart_elementary/boards/nrf54l15pdk_nrf54l15_cpuflpr_dual_uart.overlay
@@ -1,0 +1,51 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+&pinctrl {
+	uart21_default: uart21_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 10)>,
+				<NRF_PSEL(UART_RX, 1, 8)>;
+				bias-pull-up;
+		};
+	};
+
+	uart21_sleep: uart21_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 10)>,
+				<NRF_PSEL(UART_RX, 1, 8)>;
+			low-power-enable;
+		};
+	};
+
+	uart22_default: uart22_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 9)>,
+				<NRF_PSEL(UART_RX, 1, 11)>;
+				bias-pull-up;
+		};
+	};
+
+	uart22_sleep: uart22_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 1, 9)>,
+				<NRF_PSEL(UART_RX, 1, 11)>;
+			low-power-enable;
+		};
+	};
+};
+
+dut: &uart21 {
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&uart21_default>;
+	pinctrl-1 = <&uart21_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+dut_aux: &uart22 {
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&uart22_default>;
+	pinctrl-1 = <&uart22_sleep>;
+	pinctrl-names = "default", "sleep";
+};

--- a/tests/drivers/uart/uart_elementary/testcase.yaml
+++ b/tests/drivers/uart/uart_elementary/testcase.yaml
@@ -10,6 +10,7 @@ tests:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54l15pdk/nrf54l15/cpuapp
+      - nrf54l15pdk/nrf54l15/cpuflpr
       - nrf5340dk/nrf5340/cpuapp
   drivers.uart.uart_elementary_dual_nrf54h:
     filter: CONFIG_SERIAL_SUPPORT_INTERRUPT
@@ -38,6 +39,21 @@ tests:
     platform_allow:
       - nrf54l15pdk/nrf54l15/cpuapp
     extra_args: DTC_OVERLAY_FILE="boards/nrf54l15pdk_nrf54l15_cpuapp_dual_uart.overlay"
+    extra_configs:
+      - CONFIG_DUAL_UART_TEST=y
+      - CONFIG_SETUP_MISMATCH_TEST=y
+  drivers.uart.uart_elementary_dual_nrf54l_cpuflpr:
+    filter: CONFIG_SERIAL_SUPPORT_INTERRUPT
+    platform_allow:
+      - nrf54l15pdk/nrf54l15/cpuflpr
+    extra_args: DTC_OVERLAY_FILE="boards/nrf54l15pdk_nrf54l15_cpuflpr_dual_uart.overlay"
+    extra_configs:
+      - CONFIG_DUAL_UART_TEST=y
+  drivers.uart.uart_elementary_dual_setup_mismatch_nrf54l_cpuflpr:
+    filter: CONFIG_SERIAL_SUPPORT_INTERRUPT
+    platform_allow:
+      - nrf54l15pdk/nrf54l15/cpuflpr
+    extra_args: DTC_OVERLAY_FILE="boards/nrf54l15pdk_nrf54l15_cpuflpr_dual_uart.overlay"
     extra_configs:
       - CONFIG_DUAL_UART_TEST=y
       - CONFIG_SETUP_MISMATCH_TEST=y


### PR DESCRIPTION
Adding a separate overlay for nrf54l15 flpr is required because running tests on console uart fails.