### PR TITLE
tests: boot: Add nrf54l15pdk to platform_allow list in with_mcumgr tests

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4551,7 +4551,7 @@ West:
     - nordicjm
   files:
     - modules/Kconfig.mcuboot
-    - tests/boot/test_mcuboot/
+    - tests/boot/
   labels:
     - "area: MCUBoot"
 

--- a/tests/boot/with_mcumgr/testcase.yaml
+++ b/tests/boot/with_mcumgr/testcase.yaml
@@ -3,6 +3,7 @@ common:
   platform_allow:
     - nrf52840dk/nrf52840
     - nrf5340dk/nrf5340/cpuapp
+    - nrf54l15pdk/nrf54l15/cpuapp
     - nrf9160dk/nrf9160
   integration_platforms:
     - nrf52840dk/nrf52840


### PR DESCRIPTION
Extend platform_allow list for with_mcumgr tests with nRF54L board.
Added new board to run tests on nightly regression.
Also extended area in maintainer list.