### PR TITLE
soc/da1469x: Fix CONFIG_SYS_CLOCK_*_PER_SEC defines

### DIFF
--- a/soc/renesas/smartbond/da1469x/Kconfig.defconfig
+++ b/soc/renesas/smartbond/da1469x/Kconfig.defconfig
@@ -12,12 +12,15 @@ config CORTEX_M_SYSTICK
 config NUM_IRQS
 	default 40
 
+DT_LPCLK_PATH := $(dt_nodelabel_path,lp_clk)
+DT_CLOCK_SRC_PATH := $(dt_node_ph_prop_path,$(DT_LPCLK_PATH),clock-src)
+
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency) if CORTEX_M_SYSTICK
-	default 32768 if SMARTBOND_TIMER
+	default $(dt_node_int_prop_int,$(DT_CLOCK_SRC_PATH),clock-frequency) if SMARTBOND_TIMER
 
 config SYS_CLOCK_TICKS_PER_SEC
-	default 32768 if SMARTBOND_TIMER
+	default $(dt_node_int_prop_int,$(DT_CLOCK_SRC_PATH),clock-frequency) if SMARTBOND_TIMER
 
 config SRAM_VECTOR_TABLE
 	default y


### PR DESCRIPTION
Needs PR #73403 for function "dt_node_ph_prop_path"

The function is used so the following configuration options for DA1469x:

SYS_CLOCK_HW_CYCLES_PER_SEC
SYS_CLOCK_TICKS_PER_SEC

could get their values according to lp_clock node's clock-src property.