### PR TITLE
Bluetooth: Controller: Fix disabling when LFCLK is still starting

### DIFF
--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -881,10 +881,12 @@ static int hci_driver_open(const struct device *dev, bt_hci_recv_t recv)
 
 static int hci_driver_close(const struct device *dev)
 {
+	int err;
 	struct hci_driver_data *data = dev->data;
 
 	/* Resetting the LL stops all roles */
-	ll_deinit();
+	err = ll_deinit();
+	LL_ASSERT(!err);
 
 	/* Abort prio RX thread */
 	k_thread_abort(&prio_recv_thread_data);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_clock.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_clock.c
@@ -66,6 +66,9 @@ int lll_clock_deinit(void)
 	struct onoff_manager *mgr =
 		z_nrf_clock_control_get_onoff(CLOCK_CONTROL_NRF_SUBSYS_LF);
 
+	/* Cancel any ongoing request */
+	(void)onoff_cancel(mgr, &lf_cli);
+
 	return onoff_release(mgr);
 }
 


### PR DESCRIPTION
This fixes a bug where the stack may get stuck in the
POWER_CLOCK ISR after enabling and disabling the Bluetooth
stack a couple of times. It happens after calling
`onoff_request()` after a failing call to `onoff_release()`.
Then the `lf_cli`s next points to itself, generating a
circular list of clients.

Calling `onoff_release()` may fail if there is an outstanding
request. By calling `onoff_cancel()` we enter a state where
we can safely remove the client.

This was not seen earlier because the return value
from `ll_deinit()` in `hci_driver_close()` was ignored.