### PR TITLE
testsuite: add dependency to `COVERAGE_GCOV_HEAP_SIZE`

### DIFF
--- a/subsys/testsuite/Kconfig
+++ b/subsys/testsuite/Kconfig
@@ -74,6 +74,7 @@ endchoice
 
 config COVERAGE_GCOV_HEAP_SIZE
 	int "Size of heap allocated for gcov coverage data dump"
+	depends on COVERAGE_GCOV
 	default 32768 if X86 || SOC_SERIES_MPS2
 	default 16384
 	help


### PR DESCRIPTION
Add missing dependency on `COVERAGE_GCOV` to prevent the symbol from appearing in every application.