### PR TITLE
sys: ignore ineffective bitwise and from clang-tidy

### DIFF
--- a/include/zephyr/sys/cbprintf_internal.h
+++ b/include/zephyr/sys/cbprintf_internal.h
@@ -92,6 +92,7 @@ extern "C" {
 #define Z_CBPRINTF_IS_PCHAR(x, flags) \
 	z_cbprintf_cxx_is_pchar(x, (flags) & CBPRINTF_PACKAGE_CONST_CHAR_RO)
 #else
+/* NOLINTBEGIN(misc-redundant-expression) */
 #define Z_CBPRINTF_IS_PCHAR(x, flags) \
 	_Generic((x) + 0, \
 		/* char * */ \
@@ -111,6 +112,7 @@ extern "C" {
 		const volatile wchar_t * : 1, \
 		default : \
 			0)
+/* NOLINTEND(misc-redundant-expression) */
 #endif
 
 /** @brief Check if argument fits in 32 bit word.


### PR DESCRIPTION
This PR follows the issue described in [!64236](https://github.com/zephyrproject-rtos/zephyr/issues/64236)

When running clang-tidy, an 'ineffective bitwise and operation' (type misc-redundant-expression) was detected on Z_CBPRINTF_IS_PCHAR macro.

As this behavior is expected, we are adding comment to ignore this macro for the specific misc-redundant-expression check of clang-tidy