### PR TITLE
sys: fix implicit conversion uint32 to uint8

### DIFF
--- a/include/zephyr/sys/cbprintf_internal.h
+++ b/include/zephyr/sys/cbprintf_internal.h
@@ -681,7 +681,7 @@ do { \
 		_align_offset += sizeof(int); \
 	} \
 	uint32_t _arg_size = Z_CBPRINTF_ARG_SIZE(_arg); \
-	uint32_t _loc = _idx / sizeof(int); \
+	uint8_t _loc = (uint8_t)(_idx / sizeof(int)); \
 	if (arg_idx < 1 + _fros_cnt) { \
 		if (_ros_pos_en) { \
 			_ros_pos_buf[_ros_pos_idx++] = _loc; \
@@ -700,7 +700,7 @@ do { \
 			} \
 		} else if (_rws_pos_en) { \
 			_rws_buffer[_rws_pos_idx++] = arg_idx - 1; \
-			_rws_buffer[_rws_pos_idx++] = _idx / sizeof(int); \
+			_rws_buffer[_rws_pos_idx++] = (uint8_t)(_idx / sizeof(int)); \
 		} \
 	} \
 	if (_buf && _idx < (int)_max) { \


### PR DESCRIPTION
When running clang-tidy and logging module is used through any of the LOG_ macro, an issue was raised in Z_CBPRINTF_PACK_ARG2 macro.

A uint32_t variable was copied into a _rws_buffer array with an implicit cast (error: implicit conversion loses integer precision: 'uint32_t' (aka 'unsigned int') to 'uint8_t' (aka 'unsigned char')).

Here we are adding an explicit cast to get rid of the implicit conversion error.