### PR TITLE
net: lwm2m: Allow setting RD context without starting

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -1708,6 +1708,11 @@ struct lwm2m_ctx *lwm2m_rd_client_ctx(void)
 	return client.ctx;
 }
 
+void lwm2m_rd_client_set_ctx(struct lwm2m_ctx *ctx)
+{
+	client.ctx = ctx;
+}
+
 int lwm2m_rd_client_connection_resume(struct lwm2m_ctx *client_ctx)
 {
 	if (client.ctx != client_ctx) {

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.h
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.h
@@ -66,4 +66,14 @@ struct lwm2m_message *lwm2m_get_ongoing_rd_msg(void);
  */
 int lwm2m_rd_client_server_disabled(uint16_t inst_id);
 
+/**
+ * @brief Set client context for the RD client.
+ *
+ * For testing purposes, it might be required to set the client context
+ * without starting the RD client.
+ *
+ * @param ctx context
+ */
+void lwm2m_rd_client_set_ctx(struct lwm2m_ctx *ctx);
+
 #endif /* LWM2M_RD_CLIENT_H */

--- a/tests/net/lib/lwm2m/interop/src/lwm2m-client.c
+++ b/tests/net/lib/lwm2m/interop/src/lwm2m-client.c
@@ -16,6 +16,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/net/lwm2m.h>
 #include <zephyr/net/socket.h>
+#include "lwm2m_rd_client.h"
 
 #define APP_BANNER "Run LWM2M client"
 
@@ -246,9 +247,11 @@ int main(void)
 
 	client.tls_tag = 1;
 	client.set_socketoptions = set_socketoptions;
+	client.event_cb = rd_client_event;
+	client.observe_cb = observe_cb;
+	client.sock_fd = -1;
 
-	lwm2m_rd_client_start(&client, CONFIG_BOARD, 0, rd_client_event, observe_cb);
-	lwm2m_rd_client_stop(&client, rd_client_event, false);
+	lwm2m_rd_client_set_ctx(&client);
 
 	return 0;
 }


### PR DESCRIPTION
When tests control the LwM2M client entirely through shell, we should be abel to set the RD client context from the application without causing RD client to
start registration.