### PR TITLE
subsys: llext: add _POSIX_C_SOURCE definition

### DIFF
--- a/subsys/llext/CMakeLists.txt
+++ b/subsys/llext/CMakeLists.txt
@@ -1,5 +1,7 @@
 if(CONFIG_LLEXT)
   zephyr_library()
+  # For strnlen()
+  zephyr_library_compile_definitions(-D_POSIX_C_SOURCE=200809L)
   zephyr_library_sources(llext.c llext_export.c buf_loader.c)
   zephyr_library_sources_ifdef(CONFIG_LLEXT_SHELL shell.c)
 endif()


### PR DESCRIPTION
Fix implicit-function-declaration warning while building the llext shell, see extract of build log below while building for a nucleo board:

```
/home/ubuntu/zephyrproject/zephyr/subsys/llext/shell.c: In function 'cmd_llext_load_hex':
/home/ubuntu/zephyrproject/zephyr/subsys/llext/shell.c:124:26: warning: implicit declaration of function 'strnlen'; did you mean 'strlen'? [-Wimplicit-function-declaration]
  124 |         size_t hex_len = strnlen(argv[2], CONFIG_LLEXT_SHELL_MAX_SIZE*2+1);
      |                          ^~~~~~~
      |                          strlen
```