### PR TITLE
vcnl36825t: allow "force"-mode only if low-power mode is inactive

### DIFF
--- a/drivers/sensor/vishay/vcnl36825t/vcnl36825t.c
+++ b/drivers/sensor/vishay/vcnl36825t/vcnl36825t.c
@@ -454,6 +454,9 @@ static const struct sensor_driver_api vcnl36825t_driver_api = {
 		DT_INST_PROP(inst, low_power) || (DT_INST_PROP(inst, measurement_period) <=        \
 						  VCNL36825T_PS_PERIOD_VALUE_MAX_MS),              \
 		"measurement-period must be less/equal 80 ms with deactivated low-power mode");    \
+	BUILD_ASSERT(!DT_INST_PROP(inst, low_power) || (DT_INST_ENUM_IDX(inst, operation_mode) ==  \
+							VCNL36825T_OPERATION_MODE_AUTO),           \
+		     "operation-mode \"force\" only available if low-power mode deactivated");     \
 	static struct vcnl36825t_data vcnl36825t_data_##inst;                                      \
 	static const struct vcnl36825t_config vcnl36825t_config_##inst = {                         \
 		.i2c = I2C_DT_SPEC_INST_GET(inst),                                                 \

--- a/dts/bindings/sensor/vishay,vcnl36825t.yaml
+++ b/dts/bindings/sensor/vishay,vcnl36825t.yaml
@@ -21,6 +21,8 @@ properties:
 
       Defaults to sensor reset value.
 
+      Note: "force"-mode only available if low-power mode inactive.
+
   measurement-period:
     type: int
     default: 40


### PR DESCRIPTION
The behavior of "force"-mode as described in the datasheet cannot be achieved if low-power mode is enabled. After triggering a sampling, the sensor will not sample again for the period specified in `measurement-time`.

This came by surprise when I got always the same 3 successive values when using both "force"-mode as well as "low-power"-mode. Using the "auto"-mode solved this issue. Further checks revealed that the (wrong) behavior is consistent when activating both "force"- and "low-power"-mode.