### PR TITLE
twister: cleanup how we capture results of handlers

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -856,19 +856,12 @@ class QEMUHandler(Handler):
         os.unlink(fifo_out)
 
     @staticmethod
-    def _thread_update_instance_info(handler, handler_time, out_state):
+    def _thread_update_instance_info(handler, handler_time, status, reason):
         handler.instance.execution_time = handler_time
-        if out_state == "timeout":
-            handler.instance.status = "failed"
-            handler.instance.reason = "Timeout"
-        elif out_state == "failed":
-            handler.instance.status = "failed"
-            handler.instance.reason = "Failed"
-        elif out_state in ['unexpected eof', 'unexpected byte']:
-            handler.instance.status = "failed"
-            handler.instance.reason = out_state
+        handler.instance.status = status
+        if reason:
+            handler.instance.reason = reason
         else:
-            handler.instance.status = out_state
             handler.instance.reason = "Unknown"
 
     @staticmethod
@@ -886,7 +879,8 @@ class QEMUHandler(Handler):
         timeout_time = start_time + timeout
         p = select.poll()
         p.register(in_fp, select.POLLIN)
-        out_state = None
+        _status = None
+        _reason = None
 
         line = ""
         timeout_extended = False
@@ -907,17 +901,19 @@ class QEMUHandler(Handler):
                         # of not enough CPU time scheduled by host for
                         # QEMU process during p.poll(this_timeout)
                         cpu_time = QEMUHandler._get_cpu_time(pid)
-                        if cpu_time < timeout and not out_state:
+                        if cpu_time < timeout and not _status:
                             timeout_time = time.time() + (timeout - cpu_time)
                             continue
                 except psutil.NoSuchProcess:
                     pass
                 except ProcessLookupError:
-                    out_state = "failed"
+                    _status = "failed"
+                    _reason = "Execution error"
                     break
 
-                if not out_state:
-                    out_state = "timeout"
+                if not _status:
+                    _status = "failed"
+                    _reason = "timeout"
                 break
 
             if pid == 0 and os.path.exists(pid_fn):
@@ -927,13 +923,15 @@ class QEMUHandler(Handler):
                 c = in_fp.read(1).decode("utf-8")
             except UnicodeDecodeError:
                 # Test is writing something weird, fail
-                out_state = "unexpected byte"
+                _status = "failed"
+                _reason = "unexpected byte"
                 break
 
             if c == "":
                 # EOF, this shouldn't happen unless QEMU crashes
                 if not ignore_unexpected_eof:
-                    out_state = "unexpected eof"
+                    _status = "failed"
+                    _reason = "unexpected eof"
                 break
             line = line + c
             if c != "\n":
@@ -947,13 +945,14 @@ class QEMUHandler(Handler):
 
             harness.handle(line)
             if harness.state:
-                # if we have registered a fail make sure the state is not
+                # if we have registered a fail make sure the status is not
                 # overridden by a false success message coming from the
                 # testsuite
-                if out_state not in ['failed', 'unexpected eof', 'unexpected byte']:
-                    out_state = harness.state
+                if _status != 'failed':
+                    _status = harness.state
+                    _reason = harness.reason
 
-                # if we get some state, that means test is doing well, we reset
+                # if we get some status, that means test is doing well, we reset
                 # the timeout and wait for 2 more seconds to catch anything
                 # printed late. We wait much longer if code
                 # coverage is enabled since dumping this information can
@@ -967,9 +966,9 @@ class QEMUHandler(Handler):
             line = ""
 
         handler_time = time.time() - start_time
-        logger.debug(f"QEMU ({pid}) complete ({out_state}) after {handler_time} seconds")
+        logger.debug(f"QEMU ({pid}) complete with {_status} ({_reason}) after {handler_time} seconds")
 
-        QEMUHandler._thread_update_instance_info(handler, handler_time, out_state)
+        QEMUHandler._thread_update_instance_info(handler, handler_time, _status, _reason)
 
         QEMUHandler._thread_close_files(fifo_in, fifo_out, pid, out_fp, in_fp, log_out_fp)
 
@@ -1133,19 +1132,12 @@ class QEMUWinHandler(Handler):
                 pass
 
     @staticmethod
-    def _monitor_update_instance_info(handler, handler_time, out_state):
+    def _monitor_update_instance_info(handler, handler_time, status, reason):
         handler.instance.execution_time = handler_time
-        if out_state == "timeout":
-            handler.instance.status = "failed"
-            handler.instance.reason = "Timeout"
-        elif out_state == "failed":
-            handler.instance.status = "failed"
-            handler.instance.reason = "Failed"
-        elif out_state in ['unexpected eof', 'unexpected byte']:
-            handler.instance.status = "failed"
-            handler.instance.reason = out_state
+        handler.instance.status = status
+        if reason:
+            handler.instance.reason = reason
         else:
-            handler.instance.status = out_state
             handler.instance.reason = "Unknown"
 
     def _set_qemu_filenames(self, sysbuild_build_dir):
@@ -1193,7 +1185,8 @@ class QEMUWinHandler(Handler):
     def _monitor_output(self, queue, timeout, logfile, pid_fn, harness, ignore_unexpected_eof=False):
         start_time = time.time()
         timeout_time = start_time + timeout
-        out_state = None
+        _status = None
+        _reason = None
         line = ""
         timeout_extended = False
         self.pid = 0
@@ -1209,17 +1202,19 @@ class QEMUWinHandler(Handler):
                         # of not enough CPU time scheduled by host for
                         # QEMU process during p.poll(this_timeout)
                         cpu_time = self._get_cpu_time(self.pid)
-                        if cpu_time < timeout and not out_state:
+                        if cpu_time < timeout and not _status:
                             timeout_time = time.time() + (timeout - cpu_time)
                             continue
                 except psutil.NoSuchProcess:
                     pass
                 except ProcessLookupError:
-                    out_state = "failed"
+                    _status = "failed"
+                    _reason = "Execution error"
                     break
 
-                if not out_state:
-                    out_state = "timeout"
+                if not _status:
+                    _status = "failed"
+                    _reason = "timeout"
                 break
 
             if self.pid == 0 and os.path.exists(pid_fn):
@@ -1237,13 +1232,15 @@ class QEMUWinHandler(Handler):
                 c = c.decode("utf-8")
             except UnicodeDecodeError:
                 # Test is writing something weird, fail
-                out_state = "unexpected byte"
+                _status = "failed"
+                _reason = "unexpected byte"
                 break
 
             if c == "":
                 # EOF, this shouldn't happen unless QEMU crashes
                 if not ignore_unexpected_eof:
-                    out_state = "unexpected eof"
+                    _status = "failed"
+                    _reason = "unexpected eof"
                 break
             line = line + c
             if c != "\n":
@@ -1260,8 +1257,9 @@ class QEMUWinHandler(Handler):
                 # if we have registered a fail make sure the state is not
                 # overridden by a false success message coming from the
                 # testsuite
-                if out_state not in ['failed', 'unexpected eof', 'unexpected byte']:
-                    out_state = harness.state
+                if _status != 'failed':
+                    _status = harness.state
+                    _reason = harness.reason
 
                 # if we get some state, that means test is doing well, we reset
                 # the timeout and wait for 2 more seconds to catch anything
@@ -1279,8 +1277,8 @@ class QEMUWinHandler(Handler):
         self.stop_thread = True
 
         handler_time = time.time() - start_time
-        logger.debug(f"QEMU ({self.pid}) complete ({out_state}) after {handler_time} seconds")
-        self._monitor_update_instance_info(self, handler_time, out_state)
+        logger.debug(f"QEMU ({self.pid}) complete with {_status} ({_reason}) after {handler_time} seconds")
+        self._monitor_update_instance_info(self, handler_time, _status, _reason)
         self._close_log_file(log_out_fp)
         self._stop_qemu_process(self.pid)
 

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -45,6 +45,7 @@ class Harness:
 
     def __init__(self):
         self.state = None
+        self.reason = None
         self.type = None
         self.regex = []
         self.matches = OrderedDict()
@@ -114,11 +115,13 @@ class Harness:
         if self.RUN_PASSED in line:
             if self.fault:
                 self.state = "failed"
+                self.reason = "Fault detected while running test"
             else:
                 self.state = "passed"
 
         if self.RUN_FAILED in line:
             self.state = "failed"
+            self.reason = "Testsuite failed"
 
         if self.fail_on_fault:
             if self.FAULT == line:
@@ -273,11 +276,13 @@ class Console(Harness):
                          f" {self.next_pattern} of {self.patterns_expected}"
                          f" expected ordered patterns.")
             self.state = "failed"
+            self.reason = "patterns did not match (ordered)"
         if self.state == "passed" and not self.ordered and len(self.matches) < self.patterns_expected:
             logger.error(f"HARNESS:{self.__class__.__name__}: failed with"
                          f" {len(self.matches)} of {self.patterns_expected}"
                          f" expected unordered patterns.")
             self.state = "failed"
+            self.reason = "patterns did not match (unordered)"
 
         tc = self.instance.get_case_or_create(self.get_testcase_name())
         if self.state == "passed":
@@ -679,12 +684,13 @@ class Test(Harness):
         self.process_test(line)
 
         if not self.ztest and self.state:
-            logger.debug(f"not a ztest and no state for  {self.id}")
+            logger.debug(f"not a ztest and no state for {self.id}")
             tc = self.instance.get_case_or_create(self.id)
             if self.state == "passed":
                 tc.status = "passed"
             else:
                 tc.status = "failed"
+                tc.reason = "Test failure"
 
 
 class Ztest(Test):

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -1728,28 +1728,29 @@ def test_qemuhandler_thread_close_files(is_pid, is_lookup_error):
 
 
 TESTDATA_24 = [
-    ('timeout', 'failed', 'Timeout'),
-    ('failed', 'failed', 'Failed'),
-    ('unexpected eof', 'failed', 'unexpected eof'),
-    ('unexpected byte', 'failed', 'unexpected byte'),
-    (None, None, 'Unknown'),
+    ('failed', 'timeout', 'failed', 'timeout'),
+    ('failed', 'Execution error', 'failed', 'Execution error'),
+    ('failed', 'unexpected eof', 'failed', 'unexpected eof'),
+    ('failed', 'unexpected byte', 'failed', 'unexpected byte'),
+    (None, None, None, 'Unknown'),
 ]
 
 @pytest.mark.parametrize(
-    'out_state, expected_status, expected_reason',
+    '_status, _reason, expected_status, expected_reason',
     TESTDATA_24,
     ids=['timeout', 'failed', 'unexpected eof', 'unexpected byte', 'unknown']
 )
 def test_qemuhandler_thread_update_instance_info(
     mocked_instance,
-    out_state,
+    _status,
+    _reason,
     expected_status,
     expected_reason
 ):
     handler = QEMUHandler(mocked_instance, 'build')
     handler_time = 59
 
-    QEMUHandler._thread_update_instance_info(handler, handler_time, out_state)
+    QEMUHandler._thread_update_instance_info(handler, handler_time, _status, _reason)
 
     assert handler.instance.execution_time == handler_time
 
@@ -1765,6 +1766,7 @@ TESTDATA_25 = [
         [None] * 60 + ['success'] * 6,
         1000,
         False,
+        'failed',
         'timeout',
         [mock.call('1\n'), mock.call('1\n')]
     ),
@@ -1776,6 +1778,7 @@ TESTDATA_25 = [
         100,
         False,
         'failed',
+        None,
         [mock.call('1\n'), mock.call('1\n')]
     ),
     (
@@ -1785,6 +1788,7 @@ TESTDATA_25 = [
         ['success'] * 3,
         100,
         False,
+        'failed',
         'unexpected eof',
         []
     ),
@@ -1795,6 +1799,7 @@ TESTDATA_25 = [
         ['success'] * 3,
         100,
         False,
+        'failed',
         'unexpected byte',
         []
     ),
@@ -1806,6 +1811,7 @@ TESTDATA_25 = [
         100,
         False,
         'success',
+        None,
         [mock.call('1\n'), mock.call('2\n'), mock.call('3\n'), mock.call('4\n')]
     ),
     (
@@ -1815,6 +1821,7 @@ TESTDATA_25 = [
         [None] * 3 + ['success'] * 7,
         100,
         False,
+        'failed',
         'timeout',
         [mock.call('1\n'), mock.call('2\n')]
     ),
@@ -1826,13 +1833,14 @@ TESTDATA_25 = [
         (n for n in [100, 100, 10000]),
         True,
         'success',
+        None,
         [mock.call('1\n'), mock.call('2\n'), mock.call('3\n'), mock.call('4\n')]
     ),
 ]
 
 @pytest.mark.parametrize(
     'content, timeout, pid, harness_states, cputime, capture_coverage,' \
-    ' expected_out_state, expected_log_calls',
+    ' expected_status, expected_reason, expected_log_calls',
     TESTDATA_25,
     ids=[
         'timeout',
@@ -1853,7 +1861,8 @@ def test_qemuhandler_thread(
     harness_states,
     cputime,
     capture_coverage,
-    expected_out_state,
+    expected_status,
+    expected_reason,
     expected_log_calls
 ):
     def mock_cputime(pid):
@@ -1930,7 +1939,8 @@ def test_qemuhandler_thread(
     mock_thread_update_instance_info.assert_called_once_with(
         handler,
         mock.ANY,
-        expected_out_state
+        expected_status,
+        mock.ANY
     )
 
     log_fp_mock.write.assert_has_calls(expected_log_calls)

--- a/scripts/tests/twister/test_harness.py
+++ b/scripts/tests/twister/test_harness.py
@@ -464,8 +464,8 @@ TEST_DATA_7 = [("", "Running TESTSUITE suite_name", ['suite_name'], None, True, 
             ("", "PASS - test_example in 0 seconds", [], "passed", True, None),
             ("", "SKIP - test_example in 0 seconds", [], "skipped", True, None),
             ("", "FAIL - test_example in 0 seconds", [], "failed", True, None),
-            ("not a ztest and no state for  test_id", "START - test_testcase", [], "passed", False, "passed"),
-            ("not a ztest and no state for  test_id", "START - test_testcase", [], "failed", False, "failed")]
+            ("not a ztest and no state for test_id", "START - test_testcase", [], "passed", False, "passed"),
+            ("not a ztest and no state for test_id", "START - test_testcase", [], "failed", False, "failed")]
 @pytest.mark.parametrize(
    "exp_out, line, exp_suite_name, exp_status, ztest, state",
    TEST_DATA_7,

--- a/scripts/tests/twister_blackbox/test_report.py
+++ b/scripts/tests/twister_blackbox/test_report.py
@@ -112,7 +112,7 @@ class TestReport:
         (
             os.path.join(TEST_DATA, 'tests', 'one_fail_two_error_one_pass'),
             ['qemu_x86'],
-            [r'one_fail_two_error_one_pass.agnostic.group1.subgroup2 on qemu_x86 FAILED \(Failed\)',
+            [r'one_fail_two_error_one_pass.agnostic.group1.subgroup2 on qemu_x86 FAILED \(.*\)',
             r'one_fail_two_error_one_pass.agnostic.group1.subgroup3 on qemu_x86 ERROR \(Build failure\)',
             r'one_fail_two_error_one_pass.agnostic.group1.subgroup4 on qemu_x86 ERROR \(Build failure\)'],
         )

--- a/scripts/tests/twister_blackbox/test_runner.py
+++ b/scripts/tests/twister_blackbox/test_runner.py
@@ -622,7 +622,7 @@ class TestRunner:
 
 
         assert re.search(
-            r'one_fail_one_pass.agnostic.group1.subgroup2 on qemu_x86 failed \(Failed\)', err)
+            r'one_fail_one_pass.agnostic.group1.subgroup2 on qemu_x86 failed \(.*\)', err)
 
         pass_search = re.search(pass_regex, err, re.MULTILINE)
 


### PR DESCRIPTION
we use reason for a failure to indicate state and then set the status
later and reason for the failure, in case of the failure is taken from
the handler status. Clean this up by setting status and reason coming
from the handler very early, so we do not have to go through replacing
meaning later.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
