### PR TITLE
soc: stm32: Enable full range of ART acceleration

### DIFF
--- a/soc/st/stm32/stm32c0x/soc.c
+++ b/soc/st/stm32/stm32c0x/soc.c
@@ -14,6 +14,8 @@
 #include <zephyr/linker/linker-defs.h>
 #include <string.h>
 
+#include <stm32_ll_system.h>
+
 #include <cmsis_core.h>
 
 /**
@@ -26,6 +28,10 @@
  */
 static int stm32c0_init(void)
 {
+	/* Enable ART Accelerator I-cache and prefetch */
+	LL_FLASH_EnableInstCache();
+	LL_FLASH_EnablePrefetch();
+
 	/* Update CMSIS SystemCoreClock variable (HCLK) */
 	/* At reset, system core clock is set to 48 MHz from HSI */
 	SystemCoreClock = 48000000;

--- a/soc/st/stm32/stm32f0x/soc.c
+++ b/soc/st/stm32/stm32f0x/soc.c
@@ -67,6 +67,9 @@ void relocate_vector_table(void)
  */
 static int stm32f0_init(void)
 {
+	/* Enable ART Accelerator prefetch */
+	LL_FLASH_EnablePrefetch();
+
 	/* Update CMSIS SystemCoreClock variable (HCLK) */
 	/* At reset, system core clock is set to 8 MHz from HSI */
 	SystemCoreClock = 8000000;

--- a/soc/st/stm32/stm32f1x/soc.c
+++ b/soc/st/stm32/stm32f1x/soc.c
@@ -12,6 +12,8 @@
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 
+#include <stm32_ll_system.h>
+
 #include <cmsis_core.h>
 
 /**
@@ -24,6 +26,11 @@
  */
 static int stm32f1_init(void)
 {
+#ifdef FLASH_ACR_PRFTBE
+	/* Enable ART Accelerator prefetch */
+	LL_FLASH_EnablePrefetch();
+#endif
+
 	/* Update CMSIS SystemCoreClock variable (HCLK) */
 	/* At reset, system core clock is set to 8 MHz from HSI */
 	SystemCoreClock = 8000000;

--- a/soc/st/stm32/stm32f2x/soc.c
+++ b/soc/st/stm32/stm32f2x/soc.c
@@ -29,9 +29,10 @@
  */
 static int stm32f2_init(void)
 {
-	/* Enable ART Flash cache accelerator for both Instruction and Data */
+	/* Enable ART Flash I/D-cache accelerator and prefetch */
 	LL_FLASH_EnableInstCache();
 	LL_FLASH_EnableDataCache();
+	LL_FLASH_EnablePrefetch();
 
 	/* Update CMSIS SystemCoreClock variable (HCLK) */
 	/* At reset, system core clock is set to 16 MHz from HSI */

--- a/soc/st/stm32/stm32f3x/soc.c
+++ b/soc/st/stm32/stm32f3x/soc.c
@@ -25,6 +25,9 @@
  */
 static int stm32f3_init(void)
 {
+	/* Enable ART Accelerator prefetch */
+	LL_FLASH_EnablePrefetch();
+
 	/* Update CMSIS SystemCoreClock variable (HCLK) */
 	/* At reset, system core clock is set to 8 MHz from HSI */
 	SystemCoreClock = 8000000;

--- a/soc/st/stm32/stm32f4x/soc.c
+++ b/soc/st/stm32/stm32f4x/soc.c
@@ -26,7 +26,8 @@
  */
 static int st_stm32f4_init(void)
 {
-	/* Enable ART Flash cache accelerator for both instruction and data */
+	/* Enable ART Flash I/D-cache and prefetch */
+	LL_FLASH_EnablePrefetch();
 	LL_FLASH_EnableInstCache();
 	LL_FLASH_EnableDataCache();
 

--- a/soc/st/stm32/stm32f7x/soc.c
+++ b/soc/st/stm32/stm32f7x/soc.c
@@ -28,8 +28,9 @@
  */
 static int st_stm32f7_init(void)
 {
-	/* Enable ART Flash cache accelerator */
+	/* Enable ART Flash cache accelerator and prefetch */
 	LL_FLASH_EnableART();
+	LL_FLASH_EnablePrefetch();
 
 	sys_cache_instr_enable();
 	sys_cache_data_enable();

--- a/soc/st/stm32/stm32g4x/soc.c
+++ b/soc/st/stm32/stm32g4x/soc.c
@@ -30,6 +30,11 @@
  */
 static int stm32g4_init(void)
 {
+	/* Enable ART Accelerator I/D-cache and prefetch */
+	LL_FLASH_EnableInstCache();
+	LL_FLASH_EnableDataCache();
+	LL_FLASH_EnablePrefetch();
+
 	/* Update CMSIS SystemCoreClock variable (HCLK) */
 	/* At reset, system core clock is set to 16 MHz from HSI */
 	SystemCoreClock = 16000000;

--- a/soc/st/stm32/stm32l0x/soc.c
+++ b/soc/st/stm32/stm32l0x/soc.c
@@ -14,6 +14,7 @@
 #include <zephyr/linker/linker-defs.h>
 #include <string.h>
 #include <stm32_ll_bus.h>
+#include <stm32_ll_system.h>
 
 #include <cmsis_core.h>
 
@@ -27,6 +28,9 @@
  */
 static int stm32l0_init(void)
 {
+	/* Enable ART accelerator prefetch */
+	LL_FLASH_EnablePrefetch();
+
 	/* Update CMSIS SystemCoreClock variable (HCLK) */
 	/* At reset, system core clock is set to 2.1 MHz from MSI */
 	SystemCoreClock = 2097152;

--- a/soc/st/stm32/stm32l1x/soc.c
+++ b/soc/st/stm32/stm32l1x/soc.c
@@ -15,6 +15,7 @@
 #include <string.h>
 #include <stm32_ll_bus.h>
 #include <stm32_ll_pwr.h>
+#include <stm32_ll_system.h>
 
 #include <cmsis_core.h>
 
@@ -28,6 +29,9 @@
  */
 static int stm32l1_init(void)
 {
+	/* Enable ART accelerator prefetch */
+	LL_FLASH_EnablePrefetch();
+
 	/* Update CMSIS SystemCoreClock variable (HCLK) */
 	/* At reset, system core clock is set to 2.1 MHz from MSI */
 	SystemCoreClock = 2097000;

--- a/soc/st/stm32/stm32wbx/soc.c
+++ b/soc/st/stm32/stm32wbx/soc.c
@@ -13,6 +13,8 @@
 #include <zephyr/init.h>
 #include <zephyr/logging/log.h>
 
+#include <stm32_ll_system.h>
+
 #include <cmsis_core.h>
 
 #define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
@@ -28,6 +30,11 @@ LOG_MODULE_REGISTER(soc);
  */
 static int stm32wb_init(void)
 {
+	/* Enable the ART Accelerator I-cache, D-cache and prefetch */
+	LL_FLASH_EnableInstCache();
+	LL_FLASH_EnableDataCache();
+	LL_FLASH_EnablePrefetch();
+
 	/* Update CMSIS SystemCoreClock variable (HCLK) */
 	/* At reset, system core clock is set to 4 MHz from MSI */
 	SystemCoreClock = 4000000;

--- a/soc/st/stm32/stm32wlx/soc.c
+++ b/soc/st/stm32/stm32wlx/soc.c
@@ -32,9 +32,10 @@ LOG_MODULE_REGISTER(soc);
  */
 static int stm32wl_init(void)
 {
-	/* Enable CPU data and instruction cache */
+	/* Enable CPU data and instruction cache and prefetch */
 	LL_FLASH_EnableInstCache();
 	LL_FLASH_EnableDataCache();
+	LL_FLASH_EnablePrefetch();
 
 	/* Update CMSIS SystemCoreClock variable (HCLK) */
 	/* At reset, system core clock is set to 4 MHz from MSI */


### PR DESCRIPTION
When not done already and available, enable
 - ART I-cache
 - ART D-cache
 - ART prefetch

Fixes #71417