### PR TITLE
 drivers: display: ssd16xx: implement display_set_orientation

### DIFF
--- a/drivers/display/ssd16xx.c
+++ b/drivers/display/ssd16xx.c
@@ -453,12 +453,6 @@ static int ssd16xx_set_window(const struct device *dev,
 		return -EINVAL;
 	}
 
-	err = ssd16xx_write_cmd(dev, SSD16XX_CMD_ENTRY_MODE,
-				&data->scan_mode, sizeof(data->scan_mode));
-	if (err < 0) {
-		return err;
-	}
-
 	err = ssd16xx_set_ram_param(dev, x_start, x_end, y_start, y_end);
 	if (err < 0) {
 		return err;
@@ -893,6 +887,11 @@ static int ssd16xx_set_profile(const struct device *dev,
 		if (err < 0) {
 			return err;
 		}
+	}
+
+	err = ssd16xx_write_uint8(dev, SSD16XX_CMD_ENTRY_MODE, data->scan_mode);
+	if (err < 0) {
+		return err;
 	}
 
 	data->profile = type;

--- a/dts/bindings/display/ilitek,ili9xxx-common.yaml
+++ b/dts/bindings/display/ilitek,ili9xxx-common.yaml
@@ -28,6 +28,7 @@ properties:
       - 270
     description:
       Display rotation (CW) in degrees.
+      If not defined, rotation is off by default.
 
   display-inversion:
     type: boolean

--- a/dts/bindings/display/solomon,ssd16xx-common.yaml
+++ b/dts/bindings/display/solomon,ssd16xx-common.yaml
@@ -10,10 +10,6 @@ properties:
     type: uint8-array
     description: Booster soft start values
 
-  orientation-flipped:
-    type: boolean
-    description: Last column address is mapped to first segment
-
   reset-gpios:
     type: phandle-array
     required: true
@@ -48,6 +44,18 @@ properties:
       Display controller can have integrated temperature sensor or
       an external temperature sensor is connected to the controller.
       The value selects which sensor should be used.
+
+  rotation:
+    type: int
+    default: 0
+    enum:
+      - 0
+      - 90
+      - 180
+      - 270
+    description:
+      Display rotation (CW) in degrees.
+      If not defined, rotation is off by default.
 
 child-binding:
   description: |


### PR DESCRIPTION
I chose this approach instead of software rotation because I need it for an ultra low power project.
Rotation in steps of 0, 90, 180, 270 degrees is done by changing
the data entry modes.
This PR removes the orientation-flipped property, as it is redundant.

There's also a performance improvement in a separate commit.

Tested on the reel_board with a 250x122 display (ssd1673 controller)
and a custom PCB with a 200x200 display (ssd1681 controller).
Also tested all orientations with various width/height dts overrides.

To test with the LVGL sample, I had to change some glue code as well, see https://github.com/zephyrproject-rtos/zephyr/pull/73474
