### PR TITLE
Bluetooth: Tester: Adjust bap ext adv options

### DIFF
--- a/tests/bluetooth/tester/src/btp_bap_broadcast.c
+++ b/tests/bluetooth/tester/src/btp_bap_broadcast.c
@@ -360,7 +360,7 @@ uint8_t btp_bap_broadcast_source_setup(const void *cmd, uint16_t cmd_len,
 
 	err = tester_gap_padv_configure(BT_LE_PER_ADV_PARAM(BT_GAP_PER_ADV_FAST_INT_MIN_2,
 							    BT_GAP_PER_ADV_FAST_INT_MAX_2,
-							    BT_LE_PER_ADV_OPT_USE_TX_POWER));
+							    BT_LE_PER_ADV_OPT_NONE));
 	if (err != 0) {
 		LOG_DBG("Failed to configure periodic advertising: %d", err);
 

--- a/tests/bluetooth/tester/src/btp_cap.c
+++ b/tests/bluetooth/tester/src/btp_cap.c
@@ -569,7 +569,7 @@ static int cap_broadcast_source_adv_setup(struct btp_bap_broadcast_local_source 
 
 	err = tester_gap_padv_configure(BT_LE_PER_ADV_PARAM(BT_GAP_PER_ADV_FAST_INT_MIN_2,
 							    BT_GAP_PER_ADV_FAST_INT_MAX_2,
-							    BT_LE_PER_ADV_OPT_USE_TX_POWER));
+							    BT_LE_PER_ADV_OPT_NONE));
 	if (err != 0) {
 		LOG_DBG("Failed to configure periodic advertising: %d", err);
 


### PR DESCRIPTION
This change removes the BT_LE_PER_ADV_OPT_USE_TX_POWER option for extended advertisement in BLE Audio PTS tests.

The Broadcaster setup options was hardcoded to include the BT_LE_PER_ADV_OPT_USE_TX_POWER option. This causes incompabilities for any controller not support it, and since the option is not required for the audio tests it should not be used here.