### PR TITLE
usb: device_next: wait for device to resume after remote wakeup signal

### DIFF
--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -226,6 +226,8 @@ struct usbd_contex {
 	const char *name;
 	/** Access mutex */
 	struct k_mutex mutex;
+	/** Remote wakeup semaphore */
+	struct k_sem rwup_sem;
 	/** Pointer to UDC device */
 	const struct device *dev;
 	/** Notification message recipient callback */

--- a/subsys/usb/device_next/class/usbd_cdc_acm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_acm.c
@@ -490,10 +490,14 @@ static int cdc_acm_send_notification(const struct device *dev,
 
 	net_buf_add_mem(buf, &notification, sizeof(struct cdc_acm_notification));
 	ret = usbd_ep_enqueue(c_data, buf);
-	/* FIXME: support for sync transfers */
+	if (ret) {
+		net_buf_unref(buf);
+		return ret;
+	}
+
 	k_sem_take(&data->notif_sem, K_FOREVER);
 
-	return ret;
+	return 0;
 }
 
 /*

--- a/subsys/usb/device_next/class/usbd_cdc_ecm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ecm.c
@@ -28,7 +28,6 @@ LOG_MODULE_REGISTER(cdc_ecm, CONFIG_USBD_CDC_ECM_LOG_LEVEL);
 enum {
 	CDC_ECM_IFACE_UP,
 	CDC_ECM_CLASS_ENABLED,
-	CDC_ECM_CLASS_SUSPENDED,
 	CDC_ECM_OUT_ENGAGED,
 };
 
@@ -334,11 +333,6 @@ static int cdc_ecm_send_notification(const struct device *dev,
 		return 0;
 	}
 
-	if (atomic_test_bit(&data->state, CDC_ECM_CLASS_SUSPENDED)) {
-		LOG_INF("USB device is suspended (FIXME)");
-		return 0;
-	}
-
 	ep = cdc_ecm_get_int_in(c_data);
 	buf = usbd_ep_buf_alloc(c_data, ep, sizeof(struct cdc_ecm_notification));
 	if (buf == NULL) {
@@ -401,24 +395,21 @@ static void usbd_cdc_ecm_disable(struct usbd_class_data *const c_data)
 		net_if_carrier_off(data->iface);
 	}
 
-	atomic_clear_bit(&data->state, CDC_ECM_CLASS_SUSPENDED);
 	LOG_INF("Configuration disabled");
 }
 
 static void usbd_cdc_ecm_suspended(struct usbd_class_data *const c_data)
 {
 	const struct device *dev = usbd_class_get_private(c_data);
-	struct cdc_ecm_eth_data *data = dev->data;
 
-	atomic_set_bit(&data->state, CDC_ECM_CLASS_SUSPENDED);
+	LOG_DBG("CDC ECM device %s suspended", dev->name);
 }
 
 static void usbd_cdc_ecm_resumed(struct usbd_class_data *const c_data)
 {
 	const struct device *dev = usbd_class_get_private(c_data);
-	struct cdc_ecm_eth_data *data = dev->data;
 
-	atomic_clear_bit(&data->state, CDC_ECM_CLASS_SUSPENDED);
+	LOG_DBG("CDC ECM device %s resumed", dev->name);
 }
 
 static int usbd_cdc_ecm_ctd(struct usbd_class_data *const c_data,

--- a/subsys/usb/device_next/usbd_core.c
+++ b/subsys/usb/device_next/usbd_core.c
@@ -204,6 +204,8 @@ int usbd_device_init_core(struct usbd_contex *const uds_ctx)
 {
 	int ret;
 
+	k_sem_init(&uds_ctx->rwup_sem, 0, 1);
+
 	ret = udc_init(uds_ctx->dev, usbd_event_carrier);
 	if (ret != 0) {
 		LOG_ERR("Failed to init device driver");

--- a/subsys/usb/device_next/usbd_device.h
+++ b/subsys/usb/device_next/usbd_device.h
@@ -93,6 +93,9 @@ static inline void usbd_status_suspended(struct usbd_contex *const uds_ctx,
 					 const bool value)
 {
 	uds_ctx->status.suspended = value;
+	if (!value) {
+		k_sem_give(&uds_ctx->rwup_sem);
+	}
 }
 
 /**

--- a/subsys/usb/device_next/usbd_endpoint.c
+++ b/subsys/usb/device_next/usbd_endpoint.c
@@ -125,7 +125,12 @@ int usbd_ep_enqueue(const struct usbd_class_data *const c_data,
 
 	if (USB_EP_DIR_IS_IN(bi->ep)) {
 		if (usbd_is_suspended(uds_ctx)) {
-			return -EPERM;
+			int ret;
+
+			ret = usbd_wakeup_request(uds_ctx);
+			if (ret != 0) {
+				return ret;
+			}
 		}
 	}
 


### PR DESCRIPTION
After the remote wake-up signal, wait a short time for the device to resume.
If device is suspended, try to signal remote wakeup before buffer enqueue.