### PR TITLE
soc: intel_adsp: tools: fix ace20 fw load flow (+ a cosmetic fix)

### DIFF
--- a/soc/intel/intel_adsp/tools/cavstool.py
+++ b/soc/intel/intel_adsp/tools/cavstool.py
@@ -270,18 +270,18 @@ def map_regs():
     (bar4_mem, bar4_mmap) = bar_map(pcidir, 4)
     dsp = Regs(bar4_mem)
     if adsp_is_ace():
-        dsp.HFDSSCS = 0x1000
-        dsp.HFPWRCTL = 0x1d18
-        dsp.HFPWRSTS = 0x1d1c
+        dsp.HFDSSCS        = 0x1000
+        dsp.HFPWRCTL       = 0x1d18
+        dsp.HFPWRSTS       = 0x1d1c
         dsp.DSP2CXCTL_PRIMARY = 0x178d04
-        dsp.HFIPCXTDR = 0x73200
-        dsp.HFIPCXTDA = 0x73204
-        dsp.HFIPCXIDR = 0x73210
-        dsp.HFIPCXIDA = 0x73214
-        dsp.HFIPCXCTL = 0x73228
-        dsp.HFIPCXTDDY = 0x73300
-        dsp.HFIPCXIDDY = 0x73380
-        dsp.ROM_STATUS = 0x163200 if ace15 else 0x160200
+        dsp.HFIPCXTDR      = 0x73200
+        dsp.HFIPCXTDA      = 0x73204
+        dsp.HFIPCXIDR      = 0x73210
+        dsp.HFIPCXIDA      = 0x73214
+        dsp.HFIPCXCTL      = 0x73228
+        dsp.HFIPCXTDDY     = 0x73300
+        dsp.HFIPCXIDDY     = 0x73380
+        dsp.ROM_STATUS     = 0x163200 if ace15 else 0x160200
         dsp.SRAM_FW_STATUS = WINDOW_BASE_ACE
     else:
         dsp.ADSPCS         = 0x00004

--- a/soc/intel/intel_adsp/tools/cavstool.py
+++ b/soc/intel/intel_adsp/tools/cavstool.py
@@ -281,7 +281,7 @@ def map_regs():
         dsp.HFIPCXCTL = 0x73228
         dsp.HFIPCXTDDY = 0x73300
         dsp.HFIPCXIDDY = 0x73380
-        dsp.ROM_STATUS = 0x163200
+        dsp.ROM_STATUS = 0x163200 if ace15 else 0x160200
         dsp.SRAM_FW_STATUS = WINDOW_BASE_ACE
     else:
         dsp.ADSPCS         = 0x00004


### PR DESCRIPTION
cfa2f99b2119 soc: intel_adsp: tools: align code style in maps_regs()
5282e5b4725c soc: intel_adsp: tools: fix ace20 fw load flow

Use the correct register to read ROM status on intel_adsp_ace20.

Without this this fix, firmware load is successful but
boot takes extra 2 seconds and following warning was emitted:

WARNING:cavs-fw:Load failed?  ROM_STATUS = 0x0

The log-only mode (-l) was not working at all and is fixed
by this commit.

