### PR TITLE
dt-bindings: pinctrl: pinctrl_gecko: fix misleading GECKO_FUN_MSK mask value

### DIFF
--- a/include/zephyr/dt-bindings/pinctrl/gecko-pinctrl-s1.h
+++ b/include/zephyr/dt-bindings/pinctrl/gecko-pinctrl-s1.h
@@ -26,7 +26,7 @@
 /** Position of the function field. */
 #define GECKO_FUN_POS 24U
 /** Mask for the function field. */
-#define GECKO_FUN_MSK 0xFFFU
+#define GECKO_FUN_MSK 0xFFU
 
 /** Position of the pin field. */
 #define GECKO_PIN_POS 0U

--- a/include/zephyr/dt-bindings/pinctrl/gecko-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/gecko-pinctrl.h
@@ -26,7 +26,7 @@
 /** Position of the function field. */
 #define GECKO_FUN_POS 24U
 /** Mask for the function field. */
-#define GECKO_FUN_MSK 0xFFFU
+#define GECKO_FUN_MSK 0xFFU
 
 /** Position of the pin field. */
 #define GECKO_PIN_POS 0U


### PR DESCRIPTION
In the 32-bit bitfield pinctrl, the bits from b31 to b24 are representing the PIN function. [link to comment](https://github.com/zephyrproject-rtos/zephyr/blob/7abb9d7593b7f4d727fa1fa6440a6d87f612f99a/include/zephyr/dt-bindings/pinctrl/gecko-pinctrl.h#L10). The correct mask value then must be 0xFFu.