### PR TITLE
net: ipv6: scope checking function fix

### DIFF
--- a/include/zephyr/net/net_ip.h
+++ b/include/zephyr/net/net_ip.h
@@ -1122,7 +1122,7 @@ static inline bool net_ipv6_is_addr_solicited_node(const struct in6_addr *addr)
 static inline bool net_ipv6_is_addr_mcast_scope(const struct in6_addr *addr,
 						int scope)
 {
-	return (addr->s6_addr[0] == 0xff) && (addr->s6_addr[1] == scope);
+	return (addr->s6_addr[0] == 0xff) && ((addr->s6_addr[1] & 0xF) == scope);
 }
 
 /**


### PR DESCRIPTION
Change the implementation of net_ipv6_is_addr_mcast_scope() inline function that let us check if a given IPv6 address has a specified scope. Previously, it was comparing the whole byte including flags of a multicast address. It meant, that while checking for a specific scope a one was also checking the flags. Even in Zephyr's net stack there are checks for a IPv6 link local scope that are failing for addresses that are not marked as "well known" (when least significant bit of the flags is set).