### PR TITLE
twister: Report Kconfig symbols in twister.json

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -621,6 +621,13 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
         """)
 
     parser.add_argument(
+        "--report-kconfig-symbols",
+        action="store_true",
+        help="""Report Kconfig symbols applied on build (listed in `.config` file)
+        in twister.json as `kconfig` property of test suites selected. Default: not reported.
+        """)
+
+    parser.add_argument(
         "--retry-failed", type=int, default=0,
         help="Retry failing tests again, up to the number of times specified.")
 

--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # vim: set syntax=python ts=4 :
 #
-# Copyright (c) 2018 Intel Corporation
+# Copyright (c) 2018-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 import os
@@ -320,6 +320,9 @@ class Reporting:
             if instance.status is not None:
                 suite["execution_time"] =  f"{float(handler_time):.2f}"
             suite["build_time"] =  f"{float(instance.build_time):.2f}"
+
+            if self.env.options.report_kconfig_symbols and instance.defconfig is not None:
+                suite["kconfig"] = instance.defconfig
 
             testcases = []
 

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -49,6 +49,7 @@ class TestInstance:
         self.status = None
         self.reason = "Unknown"
         self.metrics = dict()
+        self.defconfig = None
         self.handler = None
         self.recording = None
         self.outdir = outdir

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -240,9 +240,11 @@ def test_cmake_parse_generated(mocked_jobserver):
     cmake = CMake(testsuite_mock, platform_mock, source_dir, build_dir,
                   mocked_jobserver)
 
+    cmake.instance = mock.Mock()
+
     result = cmake.parse_generated()
 
-    assert cmake.defconfig == {}
+    assert cmake.instance.defconfig == {}
     assert result == {}
 
 
@@ -498,7 +500,7 @@ def test_cmake_run_cmake(
 
 TESTDATA_3 = [
     ('unit_testing', [], False, True, None, True, None, True,
-     None, None, {}, {}, None, None, [], {}),
+     None, None, None, {}, None, None, [], {}),
     (
         'other', [], True,
         True, ['dummy', 'west', 'options'], True,
@@ -534,7 +536,7 @@ TESTDATA_3 = [
         'Dummy parse results', True,
         None,
         os.path.join('build', 'dir', 'zephyr', 'edt.pickle'),
-        {},
+        None,
         {},
         {'ARCH': 'dummy arch', 'PLATFORM': 'other', 'env_dummy': True},
         b'dummy edt pickle contents',
@@ -547,7 +549,7 @@ TESTDATA_3 = [
         'Dummy parse results', True,
         None,
         None,
-        {},
+        None,
         {},
         {},
         None,
@@ -560,7 +562,7 @@ TESTDATA_3 = [
         'Dummy parse results', True,
         None,
         None,
-        {},
+        None,
         {'dummy cache elem': 1},
         {'ARCH': 'dummy arch', 'PLATFORM': 'other', 'env_dummy': True,
          'dummy cache elem': 1},
@@ -574,7 +576,7 @@ TESTDATA_3 = [
         'Dummy parse results', True,
         None,
         os.path.join('build', 'dir', 'zephyr', 'edt.pickle'),
-        {},
+        None,
         {'dummy cache elem': 1},
         {'ARCH': 'dummy arch', 'PLATFORM': 'other', 'env_dummy': True,
          'dummy cache elem': 1},
@@ -588,7 +590,7 @@ TESTDATA_3 = [
         None, True,
         None,
         os.path.join('build', 'dir', 'zephyr', 'edt.pickle'),
-        {},
+        None,
         {'dummy cache elem': 1},
         {'ARCH': 'dummy arch', 'PLATFORM': 'other', 'env_dummy': True,
          'dummy cache elem': 1},
@@ -602,7 +604,7 @@ TESTDATA_3 = [
         'Dummy parse results', False,
         None,
         os.path.join('build', 'dir', 'zephyr', 'edt.pickle'),
-        {},
+        None,
         {'dummy cache elem': 1},
         {'ARCH': 'dummy arch', 'PLATFORM': 'other', 'env_dummy': True,
          'dummy cache elem': 1},
@@ -617,7 +619,7 @@ TESTDATA_3 = [
         SyntaxError, True,
         None,
         os.path.join('build', 'dir', 'zephyr', 'edt.pickle'),
-        {},
+        None,
         {'dummy cache elem': 1},
         {'ARCH': 'dummy arch', 'PLATFORM': 'other', 'env_dummy': True,
          'dummy cache elem': 1},
@@ -711,6 +713,7 @@ def test_filterbuilder_parse_generated(
                        mocked_jobserver)
     instance_mock = mock.Mock()
     fb.instance = instance_mock
+    fb.instance.defconfig = None
     fb.env = mock.Mock()
     fb.env.options = mock.Mock()
     fb.env.options.west_flash = west_flash_options
@@ -738,7 +741,7 @@ def test_filterbuilder_parse_generated(
 
     assert all([log in caplog.text for log in expected_logs])
 
-    assert fb.defconfig == expected_defconfig
+    assert fb.instance.defconfig == expected_defconfig
 
     assert fb.cmake_cache == expected_cmakecache
 
@@ -2237,7 +2240,7 @@ def test_projectbuilder_run(
     pb.options.extra_test_args = ['dummy_arg1', 'dummy_arg2']
     pb.duts = ['another dut']
     pb.options.seed = seed
-    pb.defconfig = defconfig
+    pb.instance.defconfig = defconfig
     pb.parse_generated = mock.Mock()
 
     with mock.patch('twisterlib.runner.HarnessImporter.get_harness',


### PR DESCRIPTION
New Twister command line argument `--report-kconfig-symbols` extends `twister.json` report with Kconfig symbols which were used to build the test suites selected.
The Kconfig additional test's context allows to track code changes in tests (like HWMv2 migration side effects), helps in regressions' triage and coverage analysis.