### PR TITLE
boards: st: stm32h745i_disco: Fix arduino connector description

### DIFF
--- a/boards/st/stm32h745i_disco/arduino_r3_connector.dtsi
+++ b/boards/st/stm32h745i_disco/arduino_r3_connector.dtsi
@@ -37,6 +37,6 @@
 };
 
 
-arduino_i2c: &i2c1 {};
-
+arduino_i2c: &i2c4 {};
+arduino_spi: &spi2 {};
 arduino_serial: &usart1 {};


### PR DESCRIPTION
Arduino connector on this board had 2 issues:
- missing spi reference
- wrong i2c reference

This commit fixes both.