### PR TITLE
nRF54L15bsim: Include RADIO support

### DIFF
--- a/boards/native/nrf_bsim/doc/nrf54l15bsim.rst
+++ b/boards/native/nrf_bsim/doc/nrf54l15bsim.rst
@@ -31,8 +31,9 @@ on the simulated nRF54L15 SOC.
 
 .. warning::
 
-   This target is experimental, and does not yet include models of the RADIO peripheral,
-   so the BLE and 802.15.4 stacks cannot be run on it yet.
+   This target is experimental, and even though it includes models of the RADIO, it does not yet
+   include models of the AAR, CCM, ECB or CLOCK peripherals, so the BLE and 802.15.4 stacks cannot
+   be run on it yet.
 
 This boards include models of some of the nRF54L15 SOC peripherals:
 
@@ -41,6 +42,7 @@ This boards include models of some of the nRF54L15 SOC peripherals:
 * FICR (Factory Information Configuration Registers)
 * GRTC (Global Real-time Counter)
 * PPIB (PPI Bridge)
+* RADIO
 * RRAMC (Resistive RAM Controller)
 * RTC (Real Time Counter)
 * TEMP (Temperature sensor)

--- a/boards/native/nrf_bsim/nrf54l15bsim_nrf54l15_cpuapp.dts
+++ b/boards/native/nrf_bsim/nrf54l15bsim_nrf54l15_cpuapp.dts
@@ -33,7 +33,6 @@
 			/delete-node/ mailbox@0;
 			/delete-node/ interrupt-controller@f0000000;
 			/delete-node/ gpio@50400;
-			/delete-node/ radio@8a000;
 			/delete-node/ i2c@c6000;
 			/delete-node/ spi@c6000;
 			/delete-node/ uart@c6000;
@@ -94,4 +93,9 @@
 
 &temp {
 	status = "okay";
+};
+
+&radio {
+	/* This feature is not yet supported by the RADIO model */
+	/delete-property/ dfe-supported;
 };

--- a/west.yml
+++ b/west.yml
@@ -300,7 +300,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 36b12714a5ed32450d907c89bb118f6280da3483
+      revision: 53635212495e4575955fc717369be4362126456a
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: da78aea63159771956fe0c9263f2e6985b66e9d5


### PR DESCRIPTION
* manifest: Update nRF hw models to latest which include the RADIO peripheral for the nrf54
* boards nrf54l15bsim//cpuapp: Don't remove RADIO in DT
* boards nrf54l15bsim: Update docs as we now have RADIO
