### PR TITLE
Adds backup sram DT node to STM32H56xx

### DIFF
--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -56,6 +56,14 @@
 			};
 		};
 
+		backup_sram: memory@40036400 {
+			compatible = "zephyr,memory-region", "st,stm32-backup-sram";
+			reg = <0x40036400 DT_SIZE_K(4)>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x10000000>;
+			zephyr,memory-region = "BACKUP_SRAM";
+			status = "disabled";
+		};
+
 		lptim3: timers@44004800 {
 			compatible = "st,stm32-lptim";
 			clocks = <&rcc STM32_CLOCK_BUS_APB3 0x1000>;

--- a/samples/boards/stm32/backup_sram/boards/nucleo_h563zi.overlay
+++ b/samples/boards/stm32/backup_sram/boards/nucleo_h563zi.overlay
@@ -1,0 +1,9 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2024 Thorsten Spätling <thorsten.spaetling@vierling.de>
+ */
+
+&backup_sram{
+	status = "okay";
+};


### PR DESCRIPTION
I also added an overlay file for the nucleo_h563zi board to the samples/boards/stm32/backup_sram example.