### PR TITLE
Bluetooth: Deprecate adv auto-resume

### DIFF
--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -311,6 +311,78 @@ Bluetooth Classic
 Bluetooth Host
 ==============
 
+Automatic advertiser resumption is deprecated
+---------------------------------------------
+
+.. note::
+
+   This deprecation is compiler-checked. If you get no warnings,
+   you should not be affected.
+
+Deprecated symbols:
+   * :c:enumerator:`BT_LE_ADV_OPT_CONNECTABLE`
+   * :c:enumerator:`BT_LE_ADV_OPT_ONE_TIME`
+   * :c:macro:`BT_LE_ADV_CONN`
+
+New symbols:
+   * :c:enumerator:`BT_LE_ADV_OPT_CONN`
+   * :c:macro:`BT_LE_ADV_CONN_FAST_1`
+   * :c:macro:`BT_LE_ADV_CONN_FAST_2`
+
+:c:enumerator:`BT_LE_ADV_OPT_CONNECTABLE` is a combined
+instruction to make the advertiser connectable and to enable
+automatic resumption. To disable the automatic resumption, use
+:c:enumerator:`BT_LE_ADV_OPT_CONN`.
+
+Extended Advertising API with shorthands
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Extended Advertising API ``bt_le_ext_adv_*`` implicitly assumes
+:c:enumerator:`BT_LE_ADV_OPT_ONE_TIME` and never automatically
+resume advertising. Therefore, the following search/replace can
+be applied without thinking:
+
+Replace all
+
+.. code-block:: diff
+
+   -bt_le_ext_adv_create(BT_LE_ADV_CONN, ...)
+   +bt_le_ext_adv_create(BT_LE_ADV_FAST_2, ...)
+
+.. code-block:: diff
+
+   -bt_le_ext_adv_update_param(..., BT_LE_ADV_CONN)
+   +bt_le_ext_adv_update_param(..., BT_LE_ADV_FAST_2)
+
+Extended Advertising API with custom parameters
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You may have uses of :c:enumerator:`BT_LE_ADV_OPT_CONNECTABLE`
+in assignments to a :c:struct:`bt_le_adv_param`. If your struct
+is never passed to :c:func:`bt_le_adv_start`, you should:
+
+* replace :c:enumerator:`BT_LE_ADV_OPT_CONNECTABLE` with
+  :c:enumerator:`BT_LE_ADV_OPT_CONN`.
+* remove :c:enumerator:`BT_LE_ADV_OPT_ONE_TIME`.
+
+Legacy Advertising API not using automatic resumption
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Any calls to :c:func:`bt_le_adv_start` that use the combination
+:c:enumerator:`BT_LE_ADV_OPT_CONNECTABLE` and
+:c:enumerator:`BT_LE_ADV_OPT_ONE_TIME` should have that
+combination replaced with :c:enumerator:`BT_LE_ADV_OPT_CONN`.
+
+Legacy Advertising API using automatic resumption
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For this case, the application has to take over the
+responsibility of restarting the advertiser.
+
+Refer to the extended advertising sample for an example
+implementation of advertiser restarting. The same technique can
+be used for legacy advertising.
+
 Bluetooth Crypto
 ================
 

--- a/samples/bluetooth/direct_adv/src/main.c
+++ b/samples/bluetooth/direct_adv/src/main.c
@@ -128,7 +128,7 @@ static void bt_ready(void)
 		adv_param.options |= BT_LE_ADV_OPT_DIR_ADDR_RPA;
 		err = bt_le_adv_start(&adv_param, NULL, 0, NULL, 0);
 	} else {
-		err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), NULL, 0);
+		err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
 	}
 
 	if (err) {

--- a/samples/bluetooth/direction_finding_peripheral/src/main.c
+++ b/samples/bluetooth/direction_finding_peripheral/src/main.c
@@ -100,7 +100,7 @@ static void bt_ready(void)
 
 	printk("Bluetooth initialized\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return;

--- a/samples/bluetooth/eddystone/src/main.c
+++ b/samples/bluetooth/eddystone/src/main.c
@@ -431,7 +431,7 @@ static int eds_slot_restart(struct eds_slot *slot, uint8_t type)
 			addr = oob.addr;
 		}
 
-		err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), NULL, 0);
+		err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
 	} else {
 		size_t count = 1;
 
@@ -634,7 +634,7 @@ static void bt_ready(int err)
 	printk("Bluetooth initialized\n");
 
 	/* Start advertising */
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return;

--- a/samples/bluetooth/encrypted_advertising/peripheral/src/peripheral_ead.c
+++ b/samples/bluetooth/encrypted_advertising/peripheral/src/peripheral_ead.c
@@ -128,21 +128,10 @@ static bool rpa_expired_cb(struct bt_le_ext_adv *adv)
 static int create_adv(struct bt_le_ext_adv **adv)
 {
 	int err;
-	struct bt_le_adv_param params;
-
-	memset(&params, 0, sizeof(struct bt_le_adv_param));
-
-	params.options |= BT_LE_ADV_OPT_CONNECTABLE;
-	params.options |= BT_LE_ADV_OPT_EXT_ADV;
-
-	params.id = BT_ID_DEFAULT;
-	params.sid = 0;
-	params.interval_min = BT_GAP_ADV_FAST_INT_MIN_2;
-	params.interval_max = BT_GAP_ADV_FAST_INT_MAX_2;
 
 	adv_cb.rpa_expired = rpa_expired_cb;
 
-	err = bt_le_ext_adv_create(&params, &adv_cb, adv);
+	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_CONN, &adv_cb, adv);
 	if (err) {
 		LOG_ERR("Failed to create advertiser (%d)", err);
 		return -1;

--- a/samples/bluetooth/hci_pwr_ctrl/src/main.c
+++ b/samples/bluetooth/hci_pwr_ctrl/src/main.c
@@ -43,7 +43,7 @@ static K_THREAD_STACK_DEFINE(pwr_thread_stack, 512);
 static const int8_t txpower[DEVICE_BEACON_TXPOWER_NUM] = {4, 0, -3, -8,
 							  -15, -18, -23, -30};
 static const struct bt_le_adv_param *param =
-	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE | BT_LE_ADV_OPT_ONE_TIME, 0x0020, 0x0020, NULL);
+	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONN, 0x0020, 0x0020, NULL);
 
 static void read_conn_rssi(uint16_t handle, int8_t *rssi)
 {

--- a/samples/bluetooth/iso_connected_benchmark/src/main.c
+++ b/samples/bluetooth/iso_connected_benchmark/src/main.c
@@ -1279,10 +1279,7 @@ static int run_peripheral(void)
 	}
 
 	LOG_INF("Starting advertising");
-	err = bt_le_adv_start(
-		BT_LE_ADV_PARAM(BT_LE_ADV_OPT_ONE_TIME | BT_LE_ADV_OPT_CONNECTABLE,
-				BT_GAP_ADV_FAST_INT_MIN_2, BT_GAP_ADV_FAST_INT_MAX_2, NULL),
-		NULL, 0, sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, NULL, 0, sd, ARRAY_SIZE(sd));
 	if (err != 0) {
 		LOG_ERR("Advertising failed to start: %d", err);
 		return err;

--- a/samples/bluetooth/iso_peripheral/src/main.c
+++ b/samples/bluetooth/iso_peripheral/src/main.c
@@ -177,7 +177,7 @@ int main(void)
 		return 0;
 	}
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return 0;

--- a/samples/bluetooth/mtu_update/peripheral/src/peripheral_mtu_update.c
+++ b/samples/bluetooth/mtu_update/peripheral/src/peripheral_mtu_update.c
@@ -91,7 +91,7 @@ void run_peripheral_sample(uint8_t *notify_data, size_t notify_data_size, uint16
 	struct bt_gatt_attr *notify_crch =
 		bt_gatt_find_by_uuid(mtu_test.attrs, 0xffff, &notify_characteristic_uuid.uuid);
 
-	bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, adv_ad_data, ARRAY_SIZE(adv_ad_data), NULL, 0);
+	bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, adv_ad_data, ARRAY_SIZE(adv_ad_data), NULL, 0);
 
 	bool infinite = seconds == 0;
 

--- a/samples/bluetooth/periodic_sync_rsp/src/main.c
+++ b/samples/bluetooth/periodic_sync_rsp/src/main.c
@@ -231,10 +231,7 @@ int main(void)
 	}
 
 	do {
-		err = bt_le_adv_start(
-			BT_LE_ADV_PARAM(BT_LE_ADV_OPT_ONE_TIME | BT_LE_ADV_OPT_CONNECTABLE,
-					BT_GAP_ADV_FAST_INT_MIN_2, BT_GAP_ADV_FAST_INT_MAX_2, NULL),
-			ad, ARRAY_SIZE(ad), NULL, 0);
+		err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
 		if (err && err != -EALREADY) {
 			printk("Advertising failed to start (err %d)\n", err);
 

--- a/samples/bluetooth/peripheral/src/main.c
+++ b/samples/bluetooth/peripheral/src/main.c
@@ -290,7 +290,7 @@ static void bt_ready(void)
 		settings_load();
 	}
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return;

--- a/samples/bluetooth/peripheral_accept_list/src/main.c
+++ b/samples/bluetooth/peripheral_accept_list/src/main.c
@@ -121,7 +121,7 @@ static void bt_ready(void)
 	bond_count = 0;
 	bt_foreach_bond(BT_ID_DEFAULT, add_bonded_addr_to_filter_list, NULL);
 
-	adv_param = *BT_LE_ADV_CONN_ONE_TIME;
+	adv_param = *BT_LE_ADV_CONN_FAST_1;
 
 	/* If we have got at least one bond, activate the filter */
 	if (bond_count) {

--- a/samples/bluetooth/peripheral_csc/src/main.c
+++ b/samples/bluetooth/peripheral_csc/src/main.c
@@ -379,7 +379,7 @@ static void bt_ready(void)
 
 	printk("Bluetooth initialized\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return;

--- a/samples/bluetooth/peripheral_dis/src/main.c
+++ b/samples/bluetooth/peripheral_dis/src/main.c
@@ -100,7 +100,7 @@ int main(void)
 
 	printk("Bluetooth initialized\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return 0;

--- a/samples/bluetooth/peripheral_esp/src/main.c
+++ b/samples/bluetooth/peripheral_esp/src/main.c
@@ -421,7 +421,7 @@ static void bt_ready(void)
 
 	printk("Bluetooth initialized\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return;

--- a/samples/bluetooth/peripheral_gatt_write/src/peripheral_gatt_write.c
+++ b/samples/bluetooth/peripheral_gatt_write/src/peripheral_gatt_write.c
@@ -67,7 +67,7 @@ uint32_t peripheral_gatt_write(uint32_t count)
 	(void)bt_conn_auth_cb_register(&auth_callbacks);
 #endif /* CONFIG_BT_SMP */
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return 0U;

--- a/samples/bluetooth/peripheral_hids/src/main.c
+++ b/samples/bluetooth/peripheral_hids/src/main.c
@@ -100,7 +100,7 @@ static void bt_ready(int err)
 		settings_load();
 	}
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return;

--- a/samples/bluetooth/peripheral_hr/src/main.c
+++ b/samples/bluetooth/peripheral_hr/src/main.c
@@ -204,7 +204,7 @@ int main(void)
 
 #if !defined(CONFIG_BT_EXT_ADV)
 	printk("Starting Legacy Advertising (connectable and scannable)\n");
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return 0;
@@ -215,9 +215,7 @@ int main(void)
 		.id = BT_ID_DEFAULT,
 		.sid = 0U,
 		.secondary_max_skip = 0U,
-		.options = (BT_LE_ADV_OPT_EXT_ADV |
-			    BT_LE_ADV_OPT_CONNECTABLE |
-			    BT_LE_ADV_OPT_CODED),
+		.options = (BT_LE_ADV_OPT_EXT_ADV | BT_LE_ADV_OPT_CONN | BT_LE_ADV_OPT_CODED),
 		.interval_min = BT_GAP_ADV_FAST_INT_MIN_2,
 		.interval_max = BT_GAP_ADV_FAST_INT_MAX_2,
 		.peer = NULL,
@@ -283,7 +281,7 @@ int main(void)
 		} else if (atomic_test_and_clear_bit(state, STATE_DISCONNECTED)) {
 #if !defined(CONFIG_BT_EXT_ADV)
 			printk("Starting Legacy Advertising (connectable and scannable)\n");
-			err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), sd,
+			err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), sd,
 					      ARRAY_SIZE(sd));
 			if (err) {
 				printk("Advertising failed to start (err %d)\n", err);

--- a/samples/bluetooth/peripheral_ht/src/main.c
+++ b/samples/bluetooth/peripheral_ht/src/main.c
@@ -62,7 +62,7 @@ static void bt_ready(void)
 
 	hts_init();
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return;

--- a/samples/bluetooth/peripheral_identity/src/peripheral_identity.c
+++ b/samples/bluetooth/peripheral_identity/src/peripheral_identity.c
@@ -33,8 +33,7 @@ static void adv_start(struct k_work *work)
 		.id = BT_ID_DEFAULT,
 		.sid = 0,
 		.secondary_max_skip = 0,
-		.options = (BT_LE_ADV_OPT_CONNECTABLE |
-			    BT_LE_ADV_OPT_ONE_TIME),
+		.options = BT_LE_ADV_OPT_CONN,
 		.interval_min = 0x0020, /* 20 ms */
 		.interval_max = 0x0020, /* 20 ms */
 		.peer = NULL,

--- a/samples/bluetooth/peripheral_nus/src/main.c
+++ b/samples/bluetooth/peripheral_nus/src/main.c
@@ -61,7 +61,7 @@ int main(void)
 		return err;
 	}
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		printk("Failed to start advertising: %d\n", err);
 		return err;

--- a/samples/bluetooth/peripheral_ots/src/main.c
+++ b/samples/bluetooth/peripheral_ots/src/main.c
@@ -335,7 +335,7 @@ int main(void)
 		return 0;
 	}
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return 0;

--- a/samples/bluetooth/peripheral_past/src/main.c
+++ b/samples/bluetooth/peripheral_past/src/main.c
@@ -147,7 +147,7 @@ int main(void)
 		return 0;
 	}
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, NULL, 0, sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, NULL, 0, sd, ARRAY_SIZE(sd));
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return 0;

--- a/samples/bluetooth/peripheral_sc_only/src/main.c
+++ b/samples/bluetooth/peripheral_sc_only/src/main.c
@@ -145,7 +145,7 @@ int main(void)
 	bt_conn_auth_cb_register(&auth_cb_display);
 	bt_conn_auth_info_cb_register(&auth_cb_info);
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return 0;

--- a/samples/bluetooth/st_ble_sensor/src/main.c
+++ b/samples/bluetooth/st_ble_sensor/src/main.c
@@ -142,7 +142,7 @@ static void bt_ready(int err)
 	}
 	LOG_INF("Bluetooth initialized");
 	/* Start advertising */
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err) {
 		LOG_ERR("Advertising failed to start (err %d)", err);
 		return;

--- a/samples/boards/bbc/microbit/pong/src/ble.c
+++ b/samples/boards/bbc/microbit/pong/src/ble.c
@@ -471,7 +471,7 @@ static void ble_timeout(struct k_work *work)
 		k_work_reschedule(&ble_work, K_NO_WAIT);
 		break;
 	case BLE_ADV_START:
-		err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), sd,
+		err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), sd,
 				      ARRAY_SIZE(sd));
 		if (err) {
 			printk("Advertising failed to start (err %d)\n", err);

--- a/samples/boards/phytec/reel_board/mesh_badge/src/main.c
+++ b/samples/boards/phytec/reel_board/mesh_badge/src/main.c
@@ -181,7 +181,7 @@ static void bt_ready(int err)
 
 	if (!mesh_is_initialized()) {
 		/* Start advertising */
-		err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), sd,
+		err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), sd,
 				      ARRAY_SIZE(sd));
 		if (err) {
 			printk("Advertising failed to start (err %d)\n", err);

--- a/samples/subsys/logging/ble_backend/src/main.c
+++ b/samples/subsys/logging/ble_backend/src/main.c
@@ -26,7 +26,7 @@ static void start_adv(void)
 {
 	int err;
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		LOG_ERR("Advertising failed to start (err %d)", err);
 		return;

--- a/samples/subsys/mgmt/mcumgr/smp_svr/src/bluetooth.c
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/src/bluetooth.c
@@ -30,7 +30,7 @@ static void advertise(struct k_work *work)
 {
 	int rc;
 
-	rc = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
+	rc = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (rc) {
 		LOG_ERR("Advertising failed to start (rc %d)", rc);
 		return;

--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -392,7 +392,7 @@ static bool valid_adv_ext_param(const struct bt_le_adv_param *param)
 	    BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features)) {
 		if (param->peer &&
 		    !(param->options & BT_LE_ADV_OPT_EXT_ADV) &&
-		    !(param->options & BT_LE_ADV_OPT_CONNECTABLE)) {
+		    !(param->options & _BT_LE_ADV_OPT_CONNECTABLE)) {
 			/* Cannot do directed non-connectable advertising
 			 * without extended advertising.
 			 */
@@ -441,7 +441,7 @@ static bool valid_adv_ext_param(const struct bt_le_adv_param *param)
 		return false;
 	}
 
-	if (!(param->options & BT_LE_ADV_OPT_CONNECTABLE)) {
+	if (!(param->options & _BT_LE_ADV_OPT_CONNECTABLE)) {
 		/*
 		 * BT Core 4.2 [Vol 2, Part E, 7.8.5]
 		 * The Advertising_Interval_Min and Advertising_Interval_Max
@@ -484,7 +484,7 @@ static bool valid_adv_param(const struct bt_le_adv_param *param)
 		return false;
 	}
 
-	if (param->peer && !(param->options & BT_LE_ADV_OPT_CONNECTABLE)) {
+	if (param->peer && !(param->options & _BT_LE_ADV_OPT_CONNECTABLE)) {
 		return false;
 	}
 
@@ -1020,7 +1020,7 @@ int bt_le_adv_start_legacy(struct bt_le_ext_adv *adv,
 
 	name_type = get_adv_name_type_param(param);
 
-	if (param->options & BT_LE_ADV_OPT_CONNECTABLE) {
+	if (param->options & _BT_LE_ADV_OPT_CONNECTABLE) {
 		if (dir_adv) {
 			if (param->options & BT_LE_ADV_OPT_DIR_MODE_LOW_DUTY) {
 				set_param.type = BT_HCI_ADV_DIRECT_IND_LOW_DUTY;
@@ -1062,11 +1062,11 @@ int bt_le_adv_start_legacy(struct bt_le_ext_adv *adv,
 	}
 
 	if (IS_ENABLED(CONFIG_BT_PERIPHERAL) &&
-	    (param->options & BT_LE_ADV_OPT_CONNECTABLE)) {
+	    (param->options & _BT_LE_ADV_OPT_CONNECTABLE)) {
 		err = le_adv_start_add_conn(adv, &conn);
 		if (err) {
 			if (err == -ENOMEM && !dir_adv &&
-			    !(param->options & BT_LE_ADV_OPT_ONE_TIME)) {
+			    !(param->options & _BT_LE_ADV_OPT_ONE_TIME)) {
 				goto set_adv_state;
 			}
 
@@ -1096,7 +1096,7 @@ int bt_le_adv_start_legacy(struct bt_le_ext_adv *adv,
 
 set_adv_state:
 	atomic_set_bit_to(adv->flags, BT_ADV_PERSIST, !dir_adv &&
-			  !(param->options & BT_LE_ADV_OPT_ONE_TIME));
+			  !(param->options & _BT_LE_ADV_OPT_ONE_TIME));
 
 	atomic_set_bit_to(adv->flags, BT_ADV_INCLUDE_NAME_AD,
 			  name_type == ADV_NAME_TYPE_AD);
@@ -1105,7 +1105,7 @@ set_adv_state:
 			  name_type == ADV_NAME_TYPE_SD);
 
 	atomic_set_bit_to(adv->flags, BT_ADV_CONNECTABLE,
-			  param->options & BT_LE_ADV_OPT_CONNECTABLE);
+			  param->options & _BT_LE_ADV_OPT_CONNECTABLE);
 
 	atomic_set_bit_to(adv->flags, BT_ADV_SCANNABLE, scannable);
 
@@ -1187,7 +1187,7 @@ static int le_ext_adv_param_set(struct bt_le_ext_adv *adv,
 		cp->scan_req_notify_enable = BT_HCI_LE_ADV_SCAN_REQ_ENABLE;
 	}
 
-	if (param->options & BT_LE_ADV_OPT_CONNECTABLE) {
+	if (param->options & _BT_LE_ADV_OPT_CONNECTABLE) {
 		props |= BT_HCI_LE_ADV_PROP_CONN;
 		if (!dir_adv && !(param->options & BT_LE_ADV_OPT_EXT_ADV)) {
 			/* When using non-extended adv packets then undirected
@@ -1252,7 +1252,7 @@ static int le_ext_adv_param_set(struct bt_le_ext_adv *adv,
 			  name_type == ADV_NAME_TYPE_SD);
 
 	atomic_set_bit_to(adv->flags, BT_ADV_CONNECTABLE,
-			  param->options & BT_LE_ADV_OPT_CONNECTABLE);
+			  param->options & _BT_LE_ADV_OPT_CONNECTABLE);
 
 	atomic_set_bit_to(adv->flags, BT_ADV_SCANNABLE, scannable);
 
@@ -1312,11 +1312,11 @@ int bt_le_adv_start_ext(struct bt_le_ext_adv *adv,
 	}
 
 	if (IS_ENABLED(CONFIG_BT_PERIPHERAL) &&
-	    (param->options & BT_LE_ADV_OPT_CONNECTABLE)) {
+	    (param->options & _BT_LE_ADV_OPT_CONNECTABLE)) {
 		err = le_adv_start_add_conn(adv, &conn);
 		if (err) {
 			if (err == -ENOMEM && !dir_adv &&
-			    !(param->options & BT_LE_ADV_OPT_ONE_TIME)) {
+			    !(param->options & _BT_LE_ADV_OPT_ONE_TIME)) {
 				goto set_adv_state;
 			}
 
@@ -1347,7 +1347,7 @@ int bt_le_adv_start_ext(struct bt_le_ext_adv *adv,
 set_adv_state:
 	/* Flag always set to false by le_ext_adv_param_set */
 	atomic_set_bit_to(adv->flags, BT_ADV_PERSIST, !dir_adv &&
-			  !(param->options & BT_LE_ADV_OPT_ONE_TIME));
+			  !(param->options & _BT_LE_ADV_OPT_ONE_TIME));
 
 	return 0;
 }
@@ -1459,11 +1459,11 @@ static uint32_t adv_get_options(const struct bt_le_ext_adv *adv)
 	uint32_t options = 0;
 
 	if (!atomic_test_bit(adv->flags, BT_ADV_PERSIST)) {
-		options |= BT_LE_ADV_OPT_ONE_TIME;
+		options |= _BT_LE_ADV_OPT_ONE_TIME;
 	}
 
 	if (atomic_test_bit(adv->flags, BT_ADV_CONNECTABLE)) {
-		options |= BT_LE_ADV_OPT_CONNECTABLE;
+		options |= _BT_LE_ADV_OPT_CONNECTABLE;
 	}
 
 	if (atomic_test_bit(adv->flags, BT_ADV_USE_IDENTITY)) {
@@ -1596,7 +1596,7 @@ int bt_le_ext_adv_update_param(struct bt_le_ext_adv *adv,
 		/* If params for per adv has been set, do not allow setting
 		 * connectable, scanable or use legacy adv
 		 */
-		if (param->options & BT_LE_ADV_OPT_CONNECTABLE ||
+		if (param->options & _BT_LE_ADV_OPT_CONNECTABLE ||
 		    param->options & BT_LE_ADV_OPT_SCANNABLE ||
 		    !(param->options & BT_LE_ADV_OPT_EXT_ADV) ||
 		    param->options & BT_LE_ADV_OPT_ANONYMOUS) {

--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -792,7 +792,7 @@ bool bt_id_adv_random_addr_check(const struct bt_le_adv_param *param)
 		 * Explicitly stop it here.
 		 */
 
-		if (!(param->options & BT_LE_ADV_OPT_CONNECTABLE) &&
+		if (!(param->options & _BT_LE_ADV_OPT_CONNECTABLE) &&
 		     (param->options & BT_LE_ADV_OPT_USE_IDENTITY)) {
 			/* Attempt to set non-connectable NRPA */
 			return false;
@@ -1870,7 +1870,7 @@ int bt_id_set_adv_own_addr(struct bt_le_ext_adv *adv, uint32_t options,
 		return 0;
 	}
 
-	if (options & BT_LE_ADV_OPT_CONNECTABLE) {
+	if (options & _BT_LE_ADV_OPT_CONNECTABLE) {
 		if (dir_adv && (options & BT_LE_ADV_OPT_DIR_ADDR_RPA) &&
 		    !BT_FEAT_LE_PRIVACY(bt_dev.le.features)) {
 			return -ENOTSUP;

--- a/subsys/bluetooth/host/shell/bt.c
+++ b/subsys/bluetooth/host/shell/bt.c
@@ -2003,7 +2003,7 @@ static int cmd_advertise(const struct shell *sh, size_t argc, char *argv[])
 	param.interval_max = BT_GAP_ADV_FAST_INT_MAX_2;
 
 	if (!strcmp(argv[1], "on")) {
-		param.options = BT_LE_ADV_OPT_CONNECTABLE;
+		param.options = BT_LE_ADV_OPT_CONN;
 	} else if (!strcmp(argv[1], "nconn")) {
 		param.options = 0U;
 	} else {
@@ -2033,8 +2033,6 @@ static int cmd_advertise(const struct shell *sh, size_t argc, char *argv[])
 		} else if (!strcmp(arg, "name-ad")) {
 			name_ad = true;
 			name_sd = false;
-		} else if (!strcmp(arg, "one-time")) {
-			param.options |= BT_LE_ADV_OPT_ONE_TIME;
 		} else if (!strcmp(arg, "disable-37")) {
 			param.options |= BT_LE_ADV_OPT_DISABLE_CHAN_37;
 		} else if (!strcmp(arg, "disable-38")) {
@@ -2058,7 +2056,7 @@ static int cmd_advertise(const struct shell *sh, size_t argc, char *argv[])
 
 	atomic_clear(adv_opt);
 	atomic_set_bit_to(adv_opt, SHELL_ADV_OPT_CONNECTABLE,
-			  (param.options & BT_LE_ADV_OPT_CONNECTABLE) > 0);
+			  (param.options & BT_LE_ADV_OPT_CONN) > 0);
 	atomic_set_bit_to(adv_opt, SHELL_ADV_OPT_DISCOVERABLE, discoverable);
 	atomic_set_bit_to(adv_opt, SHELL_ADV_OPT_APPEARANCE, appearance);
 
@@ -2143,10 +2141,10 @@ static bool adv_param_parse(size_t argc, char *argv[],
 	memset(param, 0, sizeof(struct bt_le_adv_param));
 
 	if (!strcmp(argv[1], "conn-scan")) {
-		param->options |= BT_LE_ADV_OPT_CONNECTABLE;
+		param->options |= BT_LE_ADV_OPT_CONN;
 		param->options |= BT_LE_ADV_OPT_SCANNABLE;
 	} else if (!strcmp(argv[1], "conn-nscan")) {
-		param->options |= BT_LE_ADV_OPT_CONNECTABLE;
+		param->options |= BT_LE_ADV_OPT_CONN;
 	} else if (!strcmp(argv[1], "nconn-scan")) {
 		param->options |= BT_LE_ADV_OPT_SCANNABLE;
 	} else if (!strcmp(argv[1], "nconn-nscan")) {
@@ -2245,7 +2243,7 @@ static int cmd_adv_create(const struct shell *sh, size_t argc, char *argv[])
 
 	atomic_clear(adv_set_opt[adv_index]);
 	atomic_set_bit_to(adv_set_opt[adv_index], SHELL_ADV_OPT_CONNECTABLE,
-			  (param.options & BT_LE_ADV_OPT_CONNECTABLE) > 0);
+			  (param.options & BT_LE_ADV_OPT_CONN) > 0);
 	atomic_set_bit_to(adv_set_opt[adv_index], SHELL_ADV_OPT_EXT_ADV,
 			  (param.options & BT_LE_ADV_OPT_EXT_ADV) > 0);
 
@@ -4977,7 +4975,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
 	SHELL_CMD_ARG(advertise, NULL,
 		      "<type: off, on, nconn> [mode: discov, non_discov] "
 		      "[filter-accept-list: fal, fal-scan, fal-conn] [identity] [no-name] "
-		      "[one-time] [name-ad] [appearance] "
+		      "[name-ad] [appearance] "
 		      "[disable-37] [disable-38] [disable-39]",
 		      cmd_advertise, 2, 8),
 #if defined(CONFIG_BT_PERIPHERAL)

--- a/subsys/bluetooth/mesh/pb_gatt_srv.c
+++ b/subsys/bluetooth/mesh/pb_gatt_srv.c
@@ -34,8 +34,7 @@
 LOG_MODULE_REGISTER(bt_mesh_pb_gatt_srv);
 
 #define ADV_OPT_PROV                                                           \
-	(BT_LE_ADV_OPT_CONNECTABLE | BT_LE_ADV_OPT_SCANNABLE |                 \
-	 BT_LE_ADV_OPT_ONE_TIME | ADV_OPT_USE_IDENTITY)
+	(BT_LE_ADV_OPT_CONN | BT_LE_ADV_OPT_SCANNABLE | ADV_OPT_USE_IDENTITY)
 
 #define FAST_ADV_TIME (60LL * MSEC_PER_SEC)
 

--- a/subsys/bluetooth/mesh/proxy_srv.c
+++ b/subsys/bluetooth/mesh/proxy_srv.c
@@ -48,8 +48,7 @@ LOG_MODULE_REGISTER(bt_mesh_gatt);
 			       BT_LE_ADV_OPT_USE_IDENTITY : (private) ? BT_LE_ADV_OPT_USE_NRPA : 0)
 
 #define ADV_OPT_PROXY(private)                                                                     \
-	(BT_LE_ADV_OPT_CONNECTABLE | BT_LE_ADV_OPT_SCANNABLE | ADV_OPT_ADDR(private) |             \
-	 BT_LE_ADV_OPT_ONE_TIME)
+	(BT_LE_ADV_OPT_CONN | BT_LE_ADV_OPT_SCANNABLE | ADV_OPT_ADDR(private))
 
 static void proxy_send_beacons(struct k_work *work);
 static int proxy_send(struct bt_conn *conn,

--- a/subsys/bluetooth/services/nus/bt_nus_auto_start_bt.c
+++ b/subsys/bluetooth/services/nus/bt_nus_auto_start_bt.c
@@ -27,7 +27,7 @@ static int bt_nus_auto_start(void)
 	err = bt_enable(NULL);
 	__ASSERT_NO_MSG(!err);
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	__ASSERT_NO_MSG(!err);
 
 	return 0;

--- a/tests/bluetooth/common/testlib/src/adv.c
+++ b/tests/bluetooth/common/testlib/src/adv.c
@@ -50,7 +50,7 @@ int bt_testlib_adv_conn(struct bt_conn **conn, int id, const char *name)
 	param.id = id;
 	param.interval_min = BT_GAP_ADV_FAST_INT_MIN_1;
 	param.interval_max = BT_GAP_ADV_FAST_INT_MAX_1;
-	param.options |= BT_LE_ADV_OPT_CONNECTABLE;
+	param.options |= BT_LE_ADV_OPT_CONN;
 
 	k_condvar_init(&ctx.done);
 

--- a/tests/bluetooth/host/id/bt_id_adv_random_addr_check/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_adv_random_addr_check/src/main.c
@@ -154,7 +154,7 @@ ZTEST(bt_id_adv_random_addr_check, test_check_returns_false_advertise_with_local
 
 	atomic_set_bit(bt_dev.flags, BT_DEV_SCANNING);
 
-	adv_param.options &= ~BT_LE_ADV_OPT_CONNECTABLE;
+	adv_param.options &= ~BT_LE_ADV_OPT_CONN;
 	adv_param.options |= BT_LE_ADV_OPT_USE_IDENTITY;
 	bt_dev.id_addr[BT_ID_DEFAULT].type = BT_ADDR_LE_RANDOM;
 

--- a/tests/bluetooth/host/id/bt_id_set_adv_own_addr/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_set_adv_own_addr/src/main.c
@@ -34,7 +34,7 @@ ZTEST_SUITE(bt_id_set_adv_own_addr, NULL, NULL, NULL, NULL, NULL);
  *  privacy is enabled and 'BT_LE_ADV_OPT_USE_IDENTITY' options bit isn't set.
  *
  *  Constraints:
- *   - Options 'BT_LE_ADV_OPT_CONNECTABLE' bit is set
+ *   - Options 'BT_LE_ADV_OPT_CONN' bit is set
  *   - Options 'BT_LE_ADV_OPT_USE_IDENTITY' bit isn't set
  *   - 'CONFIG_BT_PRIVACY' is enabled
  *   - bt_id_set_adv_private_addr() succeeds and returns 0
@@ -53,7 +53,7 @@ ZTEST(bt_id_set_adv_own_addr, test_bt_id_set_adv_private_addr_succeeds_adv_conne
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_PRIVACY);
 
-	options |= BT_LE_ADV_OPT_CONNECTABLE;
+	options |= BT_LE_ADV_OPT_CONN;
 
 	/* This will cause bt_id_set_adv_private_addr() to return 0 */
 	atomic_set_bit(bt_dev.flags, BT_DEV_RPA_VALID);
@@ -82,7 +82,7 @@ ZTEST(bt_id_set_adv_own_addr, test_bt_id_set_adv_private_addr_succeeds_adv_conne
  *  bt_id_set_adv_random_addr() if privacy isn't enabled.
  *
  *  Constraints:
- *   - Options 'BT_LE_ADV_OPT_CONNECTABLE' bit is set
+ *   - Options 'BT_LE_ADV_OPT_CONN' bit is set
  *   - 'CONFIG_BT_PRIVACY' isn't enabled
  *   - bt_id_set_adv_random_addr() succeeds and returns 0
  *
@@ -102,7 +102,7 @@ ZTEST(bt_id_set_adv_own_addr, test_bt_id_set_adv_random_addr_succeeds_adv_connec
 	/* If 'CONFIG_BT_EXT_ADV' is defined, it changes bt_id_set_adv_random_addr() behaviour */
 	Z_TEST_SKIP_IFDEF(CONFIG_BT_EXT_ADV);
 
-	options |= BT_LE_ADV_OPT_CONNECTABLE;
+	options |= BT_LE_ADV_OPT_CONN;
 
 	adv.id = 0;
 	bt_addr_le_copy(&bt_dev.id_addr[adv.id], BT_RPA_LE_ADDR);
@@ -132,12 +132,12 @@ ZTEST(bt_id_set_adv_own_addr, test_bt_id_set_adv_random_addr_succeeds_adv_connec
 /*
  *  Test setting the advertising private address with a static random address through
  *  bt_id_set_adv_random_addr() when device isn't advertising as a connectable device (i.e.
- *  BT_LE_ADV_OPT_CONNECTABLE bit in options isn't set) and the advertisement is using the device
+ *  BT_LE_ADV_OPT_CONN bit in options isn't set) and the advertisement is using the device
  *  identity (i.e. BT_LE_ADV_OPT_USE_IDENTITY bit is set in options).
  *
  *  Constraints:
  *   - Options 'BT_LE_ADV_OPT_USE_IDENTITY' bit is set
- *   - Options 'BT_LE_ADV_OPT_CONNECTABLE' bit isn't set
+ *   - Options 'BT_LE_ADV_OPT_CONN' bit isn't set
  *   - bt_id_set_adv_random_addr() succeeds and returns 0
  *
  *  Expected behaviour:
@@ -156,7 +156,7 @@ ZTEST(bt_id_set_adv_own_addr, test_bt_id_set_adv_random_addr_succeeds_not_connec
 	Z_TEST_SKIP_IFDEF(CONFIG_BT_EXT_ADV);
 
 	options |= BT_LE_ADV_OPT_USE_IDENTITY;
-	options &= ~BT_LE_ADV_OPT_CONNECTABLE;
+	options &= ~BT_LE_ADV_OPT_CONN;
 
 	adv.id = 0;
 	bt_addr_le_copy(&bt_dev.id_addr[adv.id], BT_RPA_LE_ADDR);
@@ -178,7 +178,7 @@ ZTEST(bt_id_set_adv_own_addr, test_bt_id_set_adv_random_addr_succeeds_not_connec
  *  'BT_LE_ADV_OPT_USE_IDENTITY' and 'BT_LE_ADV_OPT_USE_IDENTITY' options bits aren't set.
  *
  *  Constraints:
- *   - Options 'BT_LE_ADV_OPT_CONNECTABLE' bit isn't set
+ *   - Options 'BT_LE_ADV_OPT_CONN' bit isn't set
  *   - Options 'BT_LE_ADV_OPT_USE_IDENTITY' bit isn't set
  *   - bt_id_set_adv_random_addr() succeeds and returns 0
  *
@@ -196,7 +196,7 @@ ZTEST(bt_id_set_adv_own_addr, test_bt_id_set_adv_private_addr_succeeds_not_conne
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_EXT_ADV);
 
-	options &= ~BT_LE_ADV_OPT_CONNECTABLE;
+	options &= ~BT_LE_ADV_OPT_CONN;
 	options &= ~BT_LE_ADV_OPT_USE_IDENTITY;
 
 	/* This will cause bt_id_set_adv_private_addr() to return 0 */
@@ -216,7 +216,7 @@ ZTEST(bt_id_set_adv_own_addr, test_bt_id_set_adv_private_addr_succeeds_not_conne
  *  before updating the device advertising address and then re-enable it after the update is done.
  *
  *  Constraints:
- *   - Options 'BT_LE_ADV_OPT_CONNECTABLE' bit isn't set
+ *   - Options 'BT_LE_ADV_OPT_CONN' bit isn't set
  *   - Options 'BT_LE_ADV_OPT_USE_IDENTITY' bit isn't set
  *
  *  Expected behaviour:
@@ -233,7 +233,7 @@ ZTEST(bt_id_set_adv_own_addr, test_observer_scanning_re_enabled_after_updating_a
 	Z_TEST_SKIP_IFDEF(CONFIG_BT_EXT_ADV);
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_OBSERVER);
 
-	options &= ~BT_LE_ADV_OPT_CONNECTABLE;
+	options &= ~BT_LE_ADV_OPT_CONN;
 	options &= ~BT_LE_ADV_OPT_USE_IDENTITY;
 
 	/* Set device scanning active flag */

--- a/tests/bluetooth/host/id/bt_id_set_adv_own_addr/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_id_set_adv_own_addr/src/test_suite_invalid_inputs.c
@@ -58,7 +58,7 @@ ZTEST(bt_id_set_adv_own_addr_invalid_inputs, test_null_address_type_reference)
  *  Constraints:
  *   - Directed advertising flag is set
  *   - 'BT_LE_FEAT_BIT_PRIVACY' bit isn't set
- *   - Options 'BT_LE_ADV_OPT_CONNECTABLE' bit is set
+ *   - Options 'BT_LE_ADV_OPT_CONN' bit is set
  *   - Options 'BT_LE_ADV_OPT_DIR_ADDR_RPA' bit is set
  *
  *  Expected behaviour:
@@ -71,7 +71,7 @@ ZTEST(bt_id_set_adv_own_addr_invalid_inputs, test_dir_adv_with_rpa_no_privacy)
 	struct bt_le_ext_adv adv = {0};
 	uint8_t own_addr_type = BT_ADDR_LE_ANONYMOUS;
 
-	options |= BT_LE_ADV_OPT_CONNECTABLE;
+	options |= BT_LE_ADV_OPT_CONN;
 	options |= BT_LE_ADV_OPT_DIR_ADDR_RPA;
 
 	bt_dev.le.features[(BT_LE_FEAT_BIT_PRIVACY) >> 3] &= ~BIT((BT_LE_FEAT_BIT_PRIVACY)&7);
@@ -87,7 +87,7 @@ ZTEST(bt_id_set_adv_own_addr_invalid_inputs, test_dir_adv_with_rpa_no_privacy)
  *  Operation fails if bt_id_set_adv_private_addr() failed and a negative error code is returned.
  *
  *  Constraints:
- *   - Options 'BT_LE_ADV_OPT_CONNECTABLE' bit is set
+ *   - Options 'BT_LE_ADV_OPT_CONN' bit is set
  *   - Options 'BT_LE_ADV_OPT_USE_IDENTITY' bit isn't set
  *   - 'CONFIG_BT_PRIVACY' is enabled
  *   - bt_id_set_adv_private_addr() fails and returns a negative error code (failure)
@@ -104,7 +104,7 @@ ZTEST(bt_id_set_adv_own_addr_invalid_inputs, test_bt_id_set_adv_private_addr_fai
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_PRIVACY);
 
-	options |= BT_LE_ADV_OPT_CONNECTABLE;
+	options |= BT_LE_ADV_OPT_CONN;
 
 	err = bt_id_set_adv_own_addr(&adv, options, true, &own_addr_type);
 
@@ -119,7 +119,7 @@ ZTEST(bt_id_set_adv_own_addr_invalid_inputs, test_bt_id_set_adv_private_addr_fai
  *  Operation fails if bt_id_set_adv_random_addr() failed and a negative error code is returned.
  *
  *  Constraints:
- *   - Options 'BT_LE_ADV_OPT_CONNECTABLE' bit is set
+ *   - Options 'BT_LE_ADV_OPT_CONN' bit is set
  *   - 'CONFIG_BT_PRIVACY' isn't enabled
  *   - bt_id_set_adv_random_addr() fails and returns a negative error code (failure)
  *
@@ -137,7 +137,7 @@ ZTEST(bt_id_set_adv_own_addr_invalid_inputs, test_bt_id_set_adv_random_addr_fail
 	/* If 'CONFIG_BT_EXT_ADV' is defined, it changes bt_id_set_adv_random_addr() behaviour */
 	Z_TEST_SKIP_IFDEF(CONFIG_BT_EXT_ADV);
 
-	options |= BT_LE_ADV_OPT_CONNECTABLE;
+	options |= BT_LE_ADV_OPT_CONN;
 
 	adv.id = 0;
 	bt_addr_le_copy(&bt_dev.id_addr[adv.id], BT_RPA_LE_ADDR);
@@ -152,14 +152,14 @@ ZTEST(bt_id_set_adv_own_addr_invalid_inputs, test_bt_id_set_adv_random_addr_fail
 /*
  *  Test setting the advertising private address with a static random address through
  *  bt_id_set_adv_random_addr() when device isn't advertising as a connectable device (i.e.
- *  BT_LE_ADV_OPT_CONNECTABLE bit in options isn't set) and the advertisement is using the device
+ *  BT_LE_ADV_OPT_CONN bit in options isn't set) and the advertisement is using the device
  *  identity (i.e. BT_LE_ADV_OPT_USE_IDENTITY bit is set in options).
  *
  *  Operation fails if bt_id_set_adv_random_addr() failed and a negative error code is returned.
  *
  *  Constraints:
  *   - Options 'BT_LE_ADV_OPT_USE_IDENTITY' bit is set
- *   - Options 'BT_LE_ADV_OPT_CONNECTABLE' bit isn't set
+ *   - Options 'BT_LE_ADV_OPT_CONN' bit isn't set
  *   - bt_id_set_adv_random_addr() fails and returns a negative error code (failure)
  *
  *  Expected behaviour:
@@ -176,7 +176,7 @@ ZTEST(bt_id_set_adv_own_addr_invalid_inputs, test_bt_id_set_adv_random_addr_fail
 	Z_TEST_SKIP_IFDEF(CONFIG_BT_EXT_ADV);
 
 	options |= BT_LE_ADV_OPT_USE_IDENTITY;
-	options &= ~BT_LE_ADV_OPT_CONNECTABLE;
+	options &= ~BT_LE_ADV_OPT_CONN;
 
 	adv.id = 0;
 	bt_addr_le_copy(&bt_dev.id_addr[adv.id], BT_RPA_LE_ADDR);
@@ -192,7 +192,7 @@ ZTEST(bt_id_set_adv_own_addr_invalid_inputs, test_bt_id_set_adv_random_addr_fail
  *  Operation fails if bt_id_set_adv_private_addr() failed and a negative error code is returned.
  *
  *  Constraints:
- *   - Options 'BT_LE_ADV_OPT_CONNECTABLE' bit isn't set
+ *   - Options 'BT_LE_ADV_OPT_CONN' bit isn't set
  *   - Options 'BT_LE_ADV_OPT_USE_IDENTITY' bit isn't set
  *   - bt_id_set_adv_private_addr() fails and returns a negative error code (failure)
  *
@@ -206,7 +206,7 @@ ZTEST(bt_id_set_adv_own_addr_invalid_inputs, test_bt_id_set_adv_private_addr_fai
 	struct bt_le_ext_adv adv = {0};
 	uint8_t own_addr_type = BT_ADDR_LE_ANONYMOUS;
 
-	options &= ~BT_LE_ADV_OPT_CONNECTABLE;
+	options &= ~BT_LE_ADV_OPT_CONN;
 	options &= ~BT_LE_ADV_OPT_USE_IDENTITY;
 
 	/* This will cause bt_id_set_adv_private_addr() to return a negative error code */

--- a/tests/bluetooth/shell/src/main.c
+++ b/tests/bluetooth/shell/src/main.c
@@ -53,7 +53,7 @@ static int cmd_hrs_simulate(const struct shell *sh,
 		if (!hrs_registered && IS_ENABLED(CONFIG_BT_BROADCASTER)) {
 			shell_print(sh, "Registering HRS Service");
 			hrs_registered = true;
-			err = bt_le_adv_start(BT_LE_ADV_CONN, ad,
+			err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad,
 					      ARRAY_SIZE(ad), NULL, 0);
 			if (err) {
 				shell_error(sh, "Advertising failed to start"

--- a/tests/bluetooth/tester/src/btp_gap.c
+++ b/tests/bluetooth/tester/src/btp_gap.c
@@ -615,7 +615,7 @@ int tester_gap_create_adv_instance(struct bt_le_adv_param *param, uint8_t own_ad
 	}
 
 	if (atomic_test_bit(&current_settings, BTP_GAP_SETTINGS_CONNECTABLE)) {
-		param->options |= BT_LE_ADV_OPT_CONNECTABLE;
+		param->options |= BT_LE_ADV_OPT_CONN;
 
 		if (filter_list_in_use) {
 			param->options |= BT_LE_ADV_OPT_FILTER_CONN;
@@ -681,10 +681,8 @@ static uint8_t start_advertising(const void *cmd, uint16_t cmd_len,
 {
 	const struct btp_gap_start_advertising_cmd *cp = cmd;
 	struct btp_gap_start_advertising_rp *rp = rsp;
-	struct bt_le_adv_param param = BT_LE_ADV_PARAM_INIT(BT_LE_ADV_OPT_ONE_TIME,
-							    BT_GAP_ADV_FAST_INT_MIN_2,
-							    BT_GAP_ADV_FAST_INT_MAX_2,
-							    NULL);
+	struct bt_le_adv_param param =
+		BT_LE_ADV_PARAM_INIT(0, BT_GAP_ADV_FAST_INT_MIN_2, BT_GAP_ADV_FAST_INT_MAX_2, NULL);
 	uint8_t own_addr_type;
 	uint32_t duration;
 	uint8_t adv_len;
@@ -1436,10 +1434,8 @@ static struct bt_le_per_adv_sync_cb pa_sync_cb = {
 int tester_gap_padv_configure(const struct bt_le_per_adv_param *param)
 {
 	int err;
-	struct bt_le_adv_param ext_adv_param = BT_LE_ADV_PARAM_INIT(BT_LE_ADV_OPT_ONE_TIME,
-								    param->interval_min,
-								    param->interval_max,
-								    NULL);
+	struct bt_le_adv_param ext_adv_param =
+		BT_LE_ADV_PARAM_INIT(0, param->interval_min, param->interval_max, NULL);
 
 	if (ext_adv == NULL) {
 		current_settings = BIT(BTP_GAP_SETTINGS_DISCOVERABLE) |

--- a/tests/bsim/bluetooth/audio/src/bap_scan_delegator_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_scan_delegator_test.c
@@ -693,7 +693,7 @@ static int common_init(void)
 
 	bt_le_per_adv_sync_cb_register(&pa_sync_cb);
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, AD_SIZE, NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, AD_SIZE, NULL, 0);
 	if (err) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return err;

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
@@ -602,8 +602,8 @@ static void test_main_acl_disconnect(void)
 	 */
 	for (size_t i = 0U; i < ARRAY_SIZE(dummy_ext_adv); i++) {
 		const struct bt_le_adv_param param = BT_LE_ADV_PARAM_INIT(
-			(BT_LE_ADV_OPT_EXT_ADV | BT_LE_ADV_OPT_CONNECTABLE),
-			BT_GAP_ADV_SLOW_INT_MAX, BT_GAP_ADV_SLOW_INT_MAX, NULL);
+			(BT_LE_ADV_OPT_EXT_ADV | BT_LE_ADV_OPT_CONN), BT_GAP_ADV_SLOW_INT_MAX,
+			BT_GAP_ADV_SLOW_INT_MAX, NULL);
 		int err;
 
 		err = bt_le_ext_adv_create(&param, NULL, &dummy_ext_adv[i]);

--- a/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
@@ -638,7 +638,7 @@ void test_start_adv(void)
 	struct bt_le_ext_adv *ext_adv;
 
 	/* Create a connectable non-scannable advertising set */
-	err = bt_le_ext_adv_create(BT_LE_ADV_CONN_ONE_TIME, NULL, &ext_adv);
+	err = bt_le_ext_adv_create(BT_LE_ADV_CONN_FAST_1, NULL, &ext_adv);
 	if (err != 0) {
 		FAIL("Failed to create advertising set (err %d)\n", err);
 
@@ -752,7 +752,7 @@ static void init(void)
 			bt_cap_stream_ops_register(&unicast_streams[i], &unicast_stream_ops);
 		}
 
-		err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, cap_acceptor_ad,
+		err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, cap_acceptor_ad,
 				      ARRAY_SIZE(cap_acceptor_ad), NULL, 0);
 		if (err != 0) {
 			FAIL("Advertising failed to start (err %d)\n", err);

--- a/tests/bsim/bluetooth/audio/src/csip_notify_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/csip_notify_server_test.c
@@ -78,7 +78,7 @@ static void test_main(void)
 	}
 
 	printk("Start Advertising\n");
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;
@@ -119,7 +119,7 @@ static void test_main(void)
 	}
 
 	printk("Start Advertising\n");
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/audio/src/csip_set_member_test.c
+++ b/tests/bsim/bluetooth/audio/src/csip_set_member_test.c
@@ -80,7 +80,7 @@ static void bt_ready(int err)
 		return;
 	}
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 	}

--- a/tests/bsim/bluetooth/audio/src/gmap_ugt_test.c
+++ b/tests/bsim/bluetooth/audio/src/gmap_ugt_test.c
@@ -445,8 +445,8 @@ static void test_main(void)
 		return;
 	}
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, gmap_acceptor_ad,
-			      ARRAY_SIZE(gmap_acceptor_ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, gmap_acceptor_ad, ARRAY_SIZE(gmap_acceptor_ad),
+			      NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/audio/src/has_test.c
+++ b/tests/bsim/bluetooth/audio/src/has_test.c
@@ -43,7 +43,7 @@ static void start_adv(void)
 {
 	int err;
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, AD_SIZE, NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, AD_SIZE, NULL, 0);
 	if (err) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/audio/src/ias_test.c
+++ b/tests/bsim/bluetooth/audio/src/ias_test.c
@@ -58,7 +58,7 @@ static void test_main(void)
 		return;
 	}
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, AD_SIZE, NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, AD_SIZE, NULL, 0);
 	if (err) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/audio/src/mcs_test.c
+++ b/tests/bsim/bluetooth/audio/src/mcs_test.c
@@ -20,7 +20,7 @@ static void start_adv(void)
 {
 	int err;
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, AD_SIZE, NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, AD_SIZE, NULL, 0);
 	if (err) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/audio/src/media_controller_test.c
+++ b/tests/bsim/bluetooth/audio/src/media_controller_test.c
@@ -1655,7 +1655,7 @@ void test_media_controller_remote_player(void)
 	initialize_bluetooth();
 	initialize_media();
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, AD_SIZE, NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, AD_SIZE, NULL, 0);
 	if (err) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 	}

--- a/tests/bsim/bluetooth/audio/src/micp_mic_dev_test.c
+++ b/tests/bsim/bluetooth/audio/src/micp_mic_dev_test.c
@@ -432,7 +432,7 @@ static void test_main(void)
 
 	printk("MICP initialized\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, AD_SIZE, NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, AD_SIZE, NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/audio/src/pacs_notify_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/pacs_notify_server_test.c
@@ -191,7 +191,7 @@ static void test_main(void)
 	}
 
 	LOG_DBG("Start Advertising");
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)", err);
 		return;
@@ -225,7 +225,7 @@ static void test_main(void)
 	trigger_notifications();
 
 	LOG_DBG("Start Advertising");
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)", err);
 		return;
@@ -242,7 +242,7 @@ static void test_main(void)
 	}
 
 	LOG_DBG("Start Advertising");
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)", err);
 		return;
@@ -276,7 +276,7 @@ static void test_main(void)
 	}
 
 	LOG_DBG("Start Advertising");
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)", err);
 		return;

--- a/tests/bsim/bluetooth/audio/src/tbs_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/tbs_client_test.c
@@ -503,7 +503,7 @@ static void test_main(void)
 
 	printk("Audio Server: Bluetooth discovered\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, AD_SIZE, NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, AD_SIZE, NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/audio/src/vcp_vol_rend_test.c
+++ b/tests/bsim/bluetooth/audio/src/vcp_vol_rend_test.c
@@ -1044,7 +1044,7 @@ static void test_main(void)
 
 	printk("VCP initialized\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, AD_SIZE, NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, AD_SIZE, NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/host/adv/encrypted/css_sample_data/src/peripheral.c
+++ b/tests/bsim/bluetooth/host/adv/encrypted/css_sample_data/src/peripheral.c
@@ -15,7 +15,7 @@ static void create_adv(struct bt_le_ext_adv **adv)
 
 	memset(&params, 0, sizeof(struct bt_le_adv_param));
 
-	params.options |= BT_LE_ADV_OPT_CONNECTABLE;
+	params.options |= BT_LE_ADV_OPT_CONN;
 	params.options |= BT_LE_ADV_OPT_EXT_ADV;
 
 	params.id = BT_ID_DEFAULT;

--- a/tests/bsim/bluetooth/host/att/eatt/src/common.c
+++ b/tests/bsim/bluetooth/host/att/eatt/src/common.c
@@ -140,7 +140,7 @@ void peripheral_setup_and_connect(void)
 		FAIL("Can't enable Bluetooth (err %d)\n", err);
 	}
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 	}

--- a/tests/bsim/bluetooth/host/att/eatt_notif/src/server_test.c
+++ b/tests/bsim/bluetooth/host/att/eatt_notif/src/server_test.c
@@ -189,7 +189,7 @@ static void test_main(void)
 
 	printk("Bluetooth initialized\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/host/att/pipeline/dut/src/main.c
+++ b/tests/bsim/bluetooth/host/att/pipeline/dut/src/main.c
@@ -121,11 +121,6 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 	}
 }
 
-/* In your area */
-#define ADV_PARAM_SINGLE BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE | BT_LE_ADV_OPT_ONE_TIME, \
-					 BT_GAP_ADV_FAST_INT_MIN_2,	\
-					 BT_GAP_ADV_FAST_INT_MAX_2, NULL)
-
 static strucc bt_conn *connecc(void)
 {
 	int err;
@@ -133,7 +128,7 @@ static strucc bt_conn *connecc(void)
 
 	UNSET_FLAG(is_connected);
 
-	err = bt_le_adv_start(ADV_PARAM_SINGLE, NULL, 0, NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, NULL, 0, NULL, 0);
 	ASSERT(!err, "Adving failed to start (err %d)\n", err);
 
 	LOG_DBG(" wait connecc...");

--- a/tests/bsim/bluetooth/host/central/src/dummy_peripheral.c
+++ b/tests/bsim/bluetooth/host/central/src/dummy_peripheral.c
@@ -41,7 +41,7 @@ static void test_peripheral_dummy(void)
 	err = bt_enable(NULL);
 	TEST_ASSERT(err == 0, "Can't enable Bluetooth (err %d)", err);
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
 	TEST_ASSERT(err == 0, "Advertising failed to start (err %d)", err);
 
 	err = k_sem_take(&sem_connected, K_FOREVER);

--- a/tests/bsim/bluetooth/host/gatt/authorization/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/gatt/authorization/src/gatt_server_test.c
@@ -341,7 +341,7 @@ static void test_main(void)
 
 	printk("Bluetooth initialized\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/host/gatt/caching/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/gatt/caching/src/gatt_server_test.c
@@ -101,7 +101,7 @@ static void test_main_common(bool connect_eatt)
 
 	printk("Bluetooth initialized\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 

--- a/tests/bsim/bluetooth/host/gatt/ccc_store/src/peripheral.c
+++ b/tests/bsim/bluetooth/host/gatt/ccc_store/src/peripheral.c
@@ -58,18 +58,8 @@ BT_GATT_SERVICE_DEFINE(dummy_svc, BT_GATT_PRIMARY_SERVICE(&dummy_service),
 static void create_adv(struct bt_le_ext_adv **adv)
 {
 	int err;
-	struct bt_le_adv_param params;
 
-	memset(&params, 0, sizeof(struct bt_le_adv_param));
-
-	params.options |= BT_LE_ADV_OPT_CONNECTABLE;
-
-	params.id = BT_ID_DEFAULT;
-	params.sid = 0;
-	params.interval_min = BT_GAP_ADV_FAST_INT_MIN_2;
-	params.interval_max = BT_GAP_ADV_FAST_INT_MAX_2;
-
-	err = bt_le_ext_adv_create(&params, NULL, adv);
+	err = bt_le_ext_adv_create(BT_LE_ADV_CONN_FAST_1, NULL, adv);
 	if (err) {
 		FAIL("Failed to create advertiser (%d)\n", err);
 	}

--- a/tests/bsim/bluetooth/host/gatt/general/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/gatt/general/src/gatt_server_test.c
@@ -161,7 +161,7 @@ static void test_main(void)
 
 	printk("Bluetooth initialized\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/host/gatt/notify/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/gatt/notify/src/gatt_server_test.c
@@ -183,7 +183,7 @@ static void setup(void)
 
 	printk("Bluetooth initialized\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/host/gatt/notify_multiple/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/gatt/notify_multiple/src/gatt_server_test.c
@@ -145,7 +145,7 @@ static void test_main(void)
 
 	printk("Bluetooth initialized\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/host/gatt/sc_indicate/src/bs_bt_utils.c
+++ b/tests/bsim/bluetooth/host/gatt/sc_indicate/src/bs_bt_utils.c
@@ -129,7 +129,7 @@ void create_adv(struct bt_le_ext_adv **adv)
 	int err;
 	struct bt_le_adv_param params = {};
 
-	params.options |= BT_LE_ADV_OPT_CONNECTABLE;
+	params.options |= BT_LE_ADV_OPT_CONN;
 	params.options |= BT_LE_ADV_OPT_EXT_ADV;
 
 	params.id = BT_ID_DEFAULT;

--- a/tests/bsim/bluetooth/host/gatt/settings/src/utils.c
+++ b/tests/bsim/bluetooth/host/gatt/settings/src/utils.c
@@ -121,8 +121,7 @@ void advertise_connectable(void)
 
 	param.interval_min = 0x0020;
 	param.interval_max = 0x4000;
-	param.options |= BT_LE_ADV_OPT_ONE_TIME;
-	param.options |= BT_LE_ADV_OPT_CONNECTABLE;
+	param.options |= BT_LE_ADV_OPT_CONN;
 
 	err = bt_le_adv_start(&param, NULL, 0, NULL, 0);
 	__ASSERT(err == 0, "Advertising failed to start (err %d)\n", err);

--- a/tests/bsim/bluetooth/host/iso/cis/src/cis_peripheral.c
+++ b/tests/bsim/bluetooth/host/iso/cis/src/cis_peripheral.c
@@ -143,7 +143,7 @@ static void adv_connect(void)
 {
 	int err;
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 

--- a/tests/bsim/bluetooth/host/l2cap/credits/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/credits/src/main.c
@@ -210,11 +210,6 @@ static void disconnect_device(struct bt_conn *conn, void *data)
 	WAIT_FOR_FLAG_UNSET(is_connected);
 }
 
-#define BT_LE_ADV_CONN_OT BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE | \
-					  BT_LE_ADV_OPT_ONE_TIME,	\
-					  BT_GAP_ADV_FAST_INT_MIN_2, \
-					  BT_GAP_ADV_FAST_INT_MAX_2, NULL)
-
 static void test_peripheral_main(void)
 {
 	LOG_DBG("*L2CAP CREDITS Peripheral started*");
@@ -233,7 +228,7 @@ static void test_peripheral_main(void)
 
 	LOG_DBG("Peripheral Bluetooth initialized.");
 	LOG_DBG("Connectable advertising...");
-	err = bt_le_adv_start(BT_LE_ADV_CONN_OT, NULL, 0, NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, NULL, 0, NULL, 0);
 	if (err) {
 		FAIL("Advertising failed to start (err %d)", err);
 		return;

--- a/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/src/main.c
@@ -227,10 +227,6 @@ static void disconnect_device(struct bt_conn *conn, void *data)
 	WAIT_FOR_FLAG_UNSET(is_connected);
 }
 
-#define BT_LE_ADV_CONN_OT                                                                          \
-	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE | BT_LE_ADV_OPT_ONE_TIME,                        \
-			BT_GAP_ADV_FAST_INT_MIN_2, BT_GAP_ADV_FAST_INT_MAX_2, NULL)
-
 static void test_peripheral_main(void)
 {
 	int err;
@@ -251,7 +247,7 @@ static void test_peripheral_main(void)
 
 	LOG_DBG("Peripheral Bluetooth initialized.");
 	LOG_DBG("Connectable advertising...");
-	err = bt_le_adv_start(BT_LE_ADV_CONN_OT, NULL, 0, NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, NULL, 0, NULL, 0);
 	if (err) {
 		FAIL("Advertising failed to start (err %d)", err);
 		return;

--- a/tests/bsim/bluetooth/host/l2cap/general/src/main_l2cap_ecred.c
+++ b/tests/bsim/bluetooth/host/l2cap/general/src/main_l2cap_ecred.c
@@ -449,7 +449,7 @@ static void test_peripheral_main(void)
 
 	LOG_DBG("Peripheral Bluetooth initialized.");
 	LOG_DBG("Connectable advertising...");
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err) {
 		FAIL("Advertising failed to start (err %d)", err);
 		return;

--- a/tests/bsim/bluetooth/host/l2cap/many_conns/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/many_conns/src/main.c
@@ -235,11 +235,6 @@ static void disconnect_device(struct bt_conn *conn, void *data)
 	WAIT_FOR_FLAG_UNSET(is_connected);
 }
 
-#define BT_LE_ADV_CONN_OT BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE | \
-					  BT_LE_ADV_OPT_ONE_TIME,	\
-					  BT_GAP_ADV_FAST_INT_MIN_2, \
-					  BT_GAP_ADV_FAST_INT_MAX_2, NULL)
-
 static void test_peripheral_main(void)
 {
 	LOG_DBG("L2CAP CONN LATENCY Peripheral started*");
@@ -255,7 +250,7 @@ static void test_peripheral_main(void)
 
 	LOG_DBG("Peripheral Bluetooth initialized.");
 	LOG_DBG("Connectable advertising...");
-	err = bt_le_adv_start(BT_LE_ADV_CONN_OT, NULL, 0, NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, NULL, 0, NULL, 0);
 	ASSERT(!err, "Advertising failed to start (err %d)", err);
 
 	LOG_DBG("Advertising started.");

--- a/tests/bsim/bluetooth/host/l2cap/multilink_peripheral/src/dut.c
+++ b/tests/bsim/bluetooth/host/l2cap/multilink_peripheral/src/dut.c
@@ -251,7 +251,7 @@ static void start_advertising(void)
 
 	LOG_DBG("starting advertiser");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
 	TEST_ASSERT(!err, "Advertising failed to start (err %d)", err);
 }
 

--- a/tests/bsim/bluetooth/host/l2cap/send_on_connect/src/main_l2cap_send_on_connect.c
+++ b/tests/bsim/bluetooth/host/l2cap/send_on_connect/src/main_l2cap_send_on_connect.c
@@ -187,7 +187,7 @@ static void test_peripheral_main(void)
 
 	register_l2cap_server();
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/host/l2cap/stress/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/stress/src/main.c
@@ -293,11 +293,6 @@ static void disconnect_device(struct bt_conn *conn, void *data)
 	WAIT_FOR_FLAG_UNSET(is_connected);
 }
 
-#define BT_LE_ADV_CONN_OT BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE | \
-					  BT_LE_ADV_OPT_ONE_TIME,	\
-					  BT_GAP_ADV_FAST_INT_MIN_2, \
-					  BT_GAP_ADV_FAST_INT_MAX_2, NULL)
-
 static void test_peripheral_main(void)
 {
 	LOG_DBG("*L2CAP STRESS Peripheral started*");
@@ -316,7 +311,7 @@ static void test_peripheral_main(void)
 
 	LOG_DBG("Peripheral Bluetooth initialized.");
 	LOG_DBG("Connectable advertising...");
-	err = bt_le_adv_start(BT_LE_ADV_CONN_OT, NULL, 0, NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, NULL, 0, NULL, 0);
 	if (err) {
 		FAIL("Advertising failed to start (err %d)", err);
 		return;

--- a/tests/bsim/bluetooth/host/l2cap/userdata/src/main_l2cap_userdata.c
+++ b/tests/bsim/bluetooth/host/l2cap/userdata/src/main_l2cap_userdata.c
@@ -175,7 +175,7 @@ static void test_peripheral_main(void)
 		return;
 	}
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/host/misc/conn_stress/peripheral/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/conn_stress/peripheral/src/main.c
@@ -400,7 +400,7 @@ void test_peripheral_main(void)
 	sprintf(name, "per-%d", get_device_nbr());
 	bt_set_name(name);
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, NULL, 0, NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, NULL, 0, NULL, 0);
 	if (err) {
 		LOG_ERR("Advertising failed to start (err %d)", err);
 		__ASSERT_NO_MSG(err);

--- a/tests/bsim/bluetooth/host/misc/disable/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/misc/disable/src/gatt_server_test.c
@@ -144,7 +144,7 @@ static void test_main(void)
 
 		printk("Bluetooth initialized\n");
 
-		err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), NULL, 0);
+		err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
 		if (err != 0) {
 			FAIL("Advertising failed to start (err %d)\n", err);
 			return;

--- a/tests/bsim/bluetooth/host/misc/hfc/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/hfc/src/main.c
@@ -106,10 +106,6 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 	}
 }
 
-#define ADV_PARAM_SINGLE BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE | BT_LE_ADV_OPT_ONE_TIME, \
-					 BT_GAP_ADV_FAST_INT_MIN_2,	\
-					 BT_GAP_ADV_FAST_INT_MAX_2, NULL)
-
 static struct bt_conn *connect_as_peripheral(void)
 {
 	int err;
@@ -117,7 +113,7 @@ static struct bt_conn *connect_as_peripheral(void)
 
 	UNSET_FLAG(is_connected);
 
-	err = bt_le_adv_start(ADV_PARAM_SINGLE, NULL, 0, NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, NULL, 0, NULL, 0);
 	ASSERT(!err, "Adving failed to start (err %d)\n", err);
 
 	LOG_DBG("advertising");

--- a/tests/bsim/bluetooth/host/misc/unregister_conn_cb/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/unregister_conn_cb/src/main.c
@@ -123,7 +123,7 @@ static void start_adv(void)
 	const struct bt_data ad[] = {
 		BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR))};
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN_ONE_TIME, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err != 0) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;

--- a/tests/bsim/bluetooth/host/privacy/central/src/tester.c
+++ b/tests/bsim/bluetooth/host/privacy/central/src/tester.c
@@ -141,9 +141,8 @@ void tester_procedure_periph_delayed_start_of_conn_adv(void)
 
 	int err;
 	struct bt_le_adv_param params =
-		BT_LE_ADV_PARAM_INIT(BT_LE_ADV_OPT_CONNECTABLE | BT_LE_ADV_OPT_USE_IDENTITY,
-				     BT_GAP_ADV_FAST_INT_MIN_2,
-				     BT_GAP_ADV_FAST_INT_MAX_2, NULL);
+		BT_LE_ADV_PARAM_INIT(BT_LE_ADV_OPT_CONN | BT_LE_ADV_OPT_USE_IDENTITY,
+				     BT_GAP_ADV_FAST_INT_MIN_2, BT_GAP_ADV_FAST_INT_MAX_2, NULL);
 	struct bt_data ad;
 	struct bt_le_ext_adv *adv;
 

--- a/tests/bsim/bluetooth/host/privacy/device/src/test_undirected_peripheral.c
+++ b/tests/bsim/bluetooth/host/privacy/device/src/test_undirected_peripheral.c
@@ -166,7 +166,7 @@ static void create_adv(struct bt_le_ext_adv **adv)
 
 	memset(&params, 0, sizeof(struct bt_le_adv_param));
 
-	params.options |= BT_LE_ADV_OPT_CONNECTABLE;
+	params.options |= BT_LE_ADV_OPT_CONN;
 
 	params.id = BT_ID_DEFAULT;
 	params.sid = 0;
@@ -191,11 +191,11 @@ static void update_adv_params(struct bt_le_ext_adv *adv, enum adv_param_t adv_pa
 	memset(&params, 0, sizeof(struct bt_le_adv_param));
 
 	if (adv_params == CONN_SCAN) {
-		params.options |= BT_LE_ADV_OPT_CONNECTABLE;
+		params.options |= BT_LE_ADV_OPT_CONN;
 		params.options |= BT_LE_ADV_OPT_SCANNABLE;
 		LOG_DBG("Advertiser params: CONN_SCAN");
 	} else if (adv_params == CONN_NSCAN) {
-		params.options |= BT_LE_ADV_OPT_CONNECTABLE;
+		params.options |= BT_LE_ADV_OPT_CONN;
 		LOG_DBG("Advertiser params: CONN_NSCAN");
 	} else if (adv_params == NCONN_SCAN) {
 		params.options |= BT_LE_ADV_OPT_SCANNABLE;

--- a/tests/bsim/bluetooth/host/privacy/legacy/src/dut.c
+++ b/tests/bsim/bluetooth/host/privacy/legacy/src/dut.c
@@ -42,10 +42,8 @@ void start_advertising(uint32_t options)
 {
 	int err;
 
-	struct bt_le_adv_param param = BT_LE_ADV_PARAM_INIT(BT_LE_ADV_OPT_ONE_TIME,
-							    BT_GAP_ADV_FAST_INT_MIN_2,
-							    BT_GAP_ADV_FAST_INT_MAX_2,
-							    NULL);
+	struct bt_le_adv_param param =
+		BT_LE_ADV_PARAM_INIT(0, BT_GAP_ADV_FAST_INT_MIN_2, BT_GAP_ADV_FAST_INT_MAX_2, NULL);
 	param.options |= options;
 
 	err = bt_le_adv_start(&param, ad, ARRAY_SIZE(ad), NULL, 0);
@@ -82,7 +80,7 @@ void dut_procedure(void)
 	generate_new_rpa();
 
 	LOG_DBG("start adv with identity");
-	start_advertising(BT_LE_ADV_OPT_CONNECTABLE | BT_LE_ADV_OPT_USE_IDENTITY);
+	start_advertising(BT_LE_ADV_OPT_CONN | BT_LE_ADV_OPT_USE_IDENTITY);
 
 	/* wait for the tester to validate we're using our identity address */
 	LOG_DBG("wait for validation by tester");
@@ -94,7 +92,7 @@ void dut_procedure(void)
 	}
 
 	LOG_DBG("start adv with RPA");
-	start_advertising(BT_LE_ADV_OPT_CONNECTABLE);
+	start_advertising(BT_LE_ADV_OPT_CONN);
 
 	/* Test pass verdict is decided by the tester */
 	PASS("DUT done\n");

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/src/bs_bt_utils.c
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/src/bs_bt_utils.c
@@ -163,8 +163,7 @@ void advertise_connectable(int id, bt_addr_le_t *directed_dst)
 	param.id = id;
 	param.interval_min = 0x0020;
 	param.interval_max = 0x4000;
-	param.options |= BT_LE_ADV_OPT_ONE_TIME;
-	param.options |= BT_LE_ADV_OPT_CONNECTABLE;
+	param.options |= BT_LE_ADV_OPT_CONN;
 
 	if (directed_dst) {
 		param.options |= BT_LE_ADV_OPT_DIR_ADDR_RPA;

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_denied/src/bs_bt_utils.c
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_denied/src/bs_bt_utils.c
@@ -163,8 +163,7 @@ void advertise_connectable(int id, bt_addr_le_t *directed_dst)
 	param.id = id;
 	param.interval_min = 0x0020;
 	param.interval_max = 0x4000;
-	param.options |= BT_LE_ADV_OPT_ONE_TIME;
-	param.options |= BT_LE_ADV_OPT_CONNECTABLE;
+	param.options |= BT_LE_ADV_OPT_CONN;
 
 	if (directed_dst) {
 		param.options |= BT_LE_ADV_OPT_DIR_ADDR_RPA;

--- a/tests/bsim/bluetooth/host/security/bond_per_connection/src/bs_bt_utils.c
+++ b/tests/bsim/bluetooth/host/security/bond_per_connection/src/bs_bt_utils.c
@@ -184,8 +184,7 @@ void advertise_connectable(int id, bt_addr_le_t *directed_dst)
 	param.id = id;
 	param.interval_min = 0x0020;
 	param.interval_max = 0x4000;
-	param.options |= BT_LE_ADV_OPT_ONE_TIME;
-	param.options |= BT_LE_ADV_OPT_CONNECTABLE;
+	param.options |= BT_LE_ADV_OPT_CONN;
 
 	if (directed_dst) {
 		param.options |= BT_LE_ADV_OPT_DIR_ADDR_RPA;

--- a/tests/bsim/bluetooth/host/security/ccc_update/src/peripheral.c
+++ b/tests/bsim/bluetooth/host/security/ccc_update/src/peripheral.c
@@ -63,7 +63,7 @@ static void create_adv(struct bt_le_ext_adv **adv)
 
 	memset(&params, 0, sizeof(struct bt_le_adv_param));
 
-	params.options |= BT_LE_ADV_OPT_CONNECTABLE;
+	params.options |= BT_LE_ADV_OPT_CONN;
 
 	params.id = BT_ID_DEFAULT;
 	params.sid = 0;

--- a/tests/bsim/bluetooth/host/security/id_addr_update/peripheral/src/utils.c
+++ b/tests/bsim/bluetooth/host/security/id_addr_update/peripheral/src/utils.c
@@ -153,8 +153,7 @@ void advertise_connectable(int id)
 	param.id = id;
 	param.interval_min = 0x0020;
 	param.interval_max = 0x4000;
-	param.options |= BT_LE_ADV_OPT_ONE_TIME;
-	param.options |= BT_LE_ADV_OPT_CONNECTABLE;
+	param.options |= BT_LE_ADV_OPT_CONN;
 
 	err = bt_le_adv_start(&param, NULL, 0, NULL, 0);
 	ASSERT(!err, "Advertising failed to start (err %d)\n", err);

--- a/tests/bsim/bluetooth/host/security/security_changed_callback/src/bs_bt_utils.c
+++ b/tests/bsim/bluetooth/host/security/security_changed_callback/src/bs_bt_utils.c
@@ -175,8 +175,7 @@ void advertise_connectable(int id, bt_addr_le_t *directed_dst)
 	param.id = id;
 	param.interval_min = 0x0020;
 	param.interval_max = 0x4000;
-	param.options |= BT_LE_ADV_OPT_ONE_TIME;
-	param.options |= BT_LE_ADV_OPT_CONNECTABLE;
+	param.options |= BT_LE_ADV_OPT_CONN;
 
 	if (directed_dst) {
 		param.options |= BT_LE_ADV_OPT_DIR_ADDR_RPA;

--- a/tests/bsim/bluetooth/ll/advx/src/main.c
+++ b/tests/bsim/bluetooth/ll/advx/src/main.c
@@ -185,7 +185,7 @@ static void test_advx_main(void)
 	printk("success.\n");
 
 	printk("Connectable advertising...");
-	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_2, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return;
@@ -401,7 +401,7 @@ static void test_advx_main(void)
 	k_sleep(K_MSEC(1000));
 
 	printk("Create connectable advertising set...");
-	err = bt_le_ext_adv_create(BT_LE_ADV_CONN, &adv_callbacks, &adv);
+	err = bt_le_ext_adv_create(BT_LE_ADV_CONN_FAST_2, &adv_callbacks, &adv);
 	if (err) {
 		goto exit;
 	}
@@ -654,7 +654,7 @@ static void test_advx_main(void)
 		}
 	};
 	const struct bt_le_adv_param adv_param = {
-		.options = BT_LE_ADV_OPT_CONNECTABLE,
+		.options = BT_LE_ADV_OPT_CONN,
 		.peer = &direct_addr,
 	};
 	err = bt_le_adv_start(&adv_param, NULL, 0, NULL, 0);

--- a/tests/bsim/bluetooth/ll/cis/src/main.c
+++ b/tests/bsim/bluetooth/ll/cis/src/main.c
@@ -75,18 +75,12 @@ static bt_addr_le_t peer_addr;
 	BT_LE_CONN_PARAM(CONN_INTERVAL_MIN, CONN_INTERVAL_MAX, 0U, CONN_TIMEOUT)
 
 #if defined(CONFIG_TEST_USE_LEGACY_ADVERTISING)
-#define BT_LE_ADV_CONN_CUSTOM BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE | \
-					      BT_LE_ADV_OPT_ONE_TIME, \
-					      ADV_INTERVAL_MIN, \
-					      ADV_INTERVAL_MAX, \
-					      NULL)
+#define BT_LE_ADV_CONN_CUSTOM                                                                      \
+	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONN, ADV_INTERVAL_MIN, ADV_INTERVAL_MAX, NULL)
 #else /* !CONFIG_TEST_USE_LEGACY_ADVERTISING */
-#define BT_LE_ADV_CONN_CUSTOM BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE | \
-					      BT_LE_ADV_OPT_EXT_ADV | \
-					      BT_LE_ADV_OPT_ONE_TIME, \
-					      ADV_INTERVAL_MIN, \
-					      ADV_INTERVAL_MAX, \
-					      NULL)
+#define BT_LE_ADV_CONN_CUSTOM                                                                      \
+	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONN | BT_LE_ADV_OPT_EXT_ADV, ADV_INTERVAL_MIN,              \
+			ADV_INTERVAL_MAX, NULL)
 #endif /* !CONFIG_TEST_USE_LEGACY_ADVERTISING */
 
 #define SEQ_NUM_MAX 1000U

--- a/tests/bsim/bluetooth/ll/conn/src/test_connect2.c
+++ b/tests/bsim/bluetooth/ll/conn/src/test_connect2.c
@@ -122,9 +122,27 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	}
 }
 
+static int start_advertising(void)
+{
+	int err;
+
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
+	if (err) {
+		printk("Advertising failed to start (err %d)\n", err);
+	}
+
+	return err;
+}
+
+static void recycled(void)
+{
+	start_advertising();
+}
+
 static struct bt_conn_cb conn_callbacks = {
 	.connected = connected,
 	.disconnected = disconnected,
+	.recycled = recycled,
 };
 
 static void bt_ready(void)
@@ -133,13 +151,17 @@ static void bt_ready(void)
 
 	printk("Peripheral Bluetooth initialized\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err) {
 		FAIL("Advertising failed to start (err %d)\n", err);
 		return;
 	}
 
-	printk("Advertising successfully started\n");
+	err = start_advertising();
+
+	if (!err) {
+		printk("Advertising successfully started\n");
+	}
 }
 
 static void bas_notify(void)

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/main.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/main.c
@@ -46,6 +46,21 @@ static const struct bt_data sd[] = {
 
 static int service_set;
 
+static int start_advertising(void)
+{
+	int err;
+
+	err = bt_le_adv_start(BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONN | BT_LE_ADV_OPT_USE_IDENTITY,
+					      BT_GAP_ADV_FAST_INT_MIN_1, BT_GAP_ADV_FAST_INT_MAX_1,
+					      NULL),
+			      ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
+	if (err) {
+		printk("Advertising failed to start (err %d)\n", err);
+	}
+
+	return err;
+}
+
 static void connected(struct bt_conn *conn, uint8_t err)
 {
 	if (err) {
@@ -58,6 +73,11 @@ static void connected(struct bt_conn *conn, uint8_t err)
 static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	printk("Disconnected (reason 0x%02x)\n", reason);
+}
+
+static void recycled(void)
+{
+	start_advertising();
 }
 
 static void security_changed(struct bt_conn *conn, bt_security_t level,
@@ -73,6 +93,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.connected = connected,
 	.disconnected = disconnected,
+	.recycled = recycled,
 	.security_changed = security_changed,
 };
 
@@ -226,14 +247,11 @@ static void bt_ready(int err)
 		settings_load();
 	}
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), sd,
-			      ARRAY_SIZE(sd));
-	if (err) {
-		printk("Advertising failed to start (err %d)\n", err);
-		return;
-	}
+	err = start_advertising();
 
-	printk("Advertising successfully started\n");
+	if (!err) {
+		printk("Advertising successfully started\n");
+	}
 }
 
 static void auth_passkey_display(struct bt_conn *conn, unsigned int passkey)

--- a/tests/bsim/bluetooth/samples/battery_service/src/peripheral_test.c
+++ b/tests/bsim/bluetooth/samples/battery_service/src/peripheral_test.c
@@ -101,7 +101,7 @@ static void bt_ready(void)
 
 	LOG_DBG("Peripheral Bluetooth initialized\n");
 
-	err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad), NULL, 0);
+	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), NULL, 0);
 	if (err) {
 		TEST_FAIL("Advertising failed to start (err %d)\n", err);
 		return;


### PR DESCRIPTION
The host-based adv auto-resume function has both a problematic implementation and disagreement in the community around how it should behave. See the issue linked resolved below for details.

This patch makes the deprecation visible to the user. The user will be better served by a auto-resume tailored their applications use case, based on more primitive host API like `conn_cb.recycled`, which has obvious behavior that is unlikely to change.

Resolves: https://github.com/zephyrproject-rtos/zephyr/issues/72567