### PR TITLE
tests: drivers: counter: counter_nrf_rtc: Run test on nrf54h20

### DIFF
--- a/tests/drivers/counter/counter_nrf_rtc/fixed_top/testcase.yaml
+++ b/tests/drivers/counter/counter_nrf_rtc/fixed_top/testcase.yaml
@@ -7,3 +7,5 @@ tests:
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52_bsim
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54h20dk/nrf54h20/cpurad


### PR DESCRIPTION
Add nrf54h20dk to platform allow list.
Overlay for tht target was already added.