### PR TITLE
Add RW61x monolithic build support on BLE applications

### DIFF
--- a/boards/nxp/rd_rw612_bga/Kconfig.defconfig
+++ b/boards/nxp/rd_rw612_bga/Kconfig.defconfig
@@ -5,6 +5,9 @@
 
 if BOARD_RD_RW612_BGA
 
+config FLASH_LOAD_SIZE
+	default 0x400000 if !BOOTLOADER_MCUBOOT && !NXP_MONOLITHIC_BT
+
 if LVGL
 
 # Enable DMA for LCDIC

--- a/boards/nxp/rd_rw612_bga/doc/index.rst
+++ b/boards/nxp/rd_rw612_bga/doc/index.rst
@@ -66,12 +66,24 @@ Supported Features
 | PM        | on-chip    | power management; uses SoC Power  |
 |           |            | Modes 1 and 2                     |
 +-----------+------------+-----------------------------------+
+| BLE       | on-chip    | Bluetooth                         |
++-----------+------------+-----------------------------------+
 
 The default configuration can be found in the defconfig file:
 
    :zephyr_file:`boards/nxp/rd_rw612_bga/rd_rw612_bga_defconfig/`
 
 Other hardware features are not currently supported
+
+Fetch Binary Blobs
+******************
+
+To support Bluetooth, rd_rw612_bga requires fetching binary blobs, which can be
+achieved by running the following command:
+
+.. code-block:: console
+
+   west blobs fetch hal_nxp
 
 Programming and Debugging
 *************************
@@ -134,6 +146,26 @@ should see the following message in the terminal:
    ***** Booting Zephyr OS zephyr-v3.6.0 *****
    Hello World! rd_rw612_bga
 
+Bluetooth
+=========
+
+BLE functionality requires to fetch binary blobs, so make sure to follow
+the ``Fetch Binary Blobs`` section first.
+
+Those binary blobs can be used in two different ways, depending if :kconfig:option:`CONFIG_NXP_MONOLITHIC_BT`
+is enabled or not:
+
+- :kconfig:option:`CONFIG_NXP_MONOLITHIC_BT` is enabled (default):
+
+The required binary blob will be linked with the application image directly, forming
+one single monolithic image.
+The user has nothing else to do other than flashing the application to the board.
+
+- :kconfig:option:`CONFIG_NXP_MONOLITHIC_BT` is disabled:
+
+In this case, the BLE blob won't be linked with the application, so the user needs to manually
+flash the BLE binary blob to the board at the address ``0x18540000``.
+The binary blob will be located here: ``<zephyr workspace>/modules/hal/nxp/zephyr/blobs/rw61x/rw61x_sb_ble_a2.bin``
 
 Resources
 =========

--- a/modules/Kconfig.mcux
+++ b/modules/Kconfig.mcux
@@ -375,6 +375,12 @@ config NXP_FW_LOADER
 	   The firmware loader is used to load firmwares to embedded tranceivers.
 	   It is needed to enable connectivity features.
 
+config NXP_MONOLITHIC_BT
+	bool "BT firmware monolithic build"
+	help
+	   If enabled, the BT firmware used by the device will be linked with the
+	   application directly.
+
 config NXP_RF_IMU
 	bool "Include RF_IMU adapter for intercore messaging"
 	select EVENTS

--- a/samples/bluetooth/central_ht/sample.yaml
+++ b/samples/bluetooth/central_ht/sample.yaml
@@ -8,8 +8,13 @@ tests:
       - qemu_x86
       - nrf51dk/nrf51822
       - nrf52dk/nrf52832
-      - rd_rw612_bga
     tags: bluetooth
     integration_platforms:
       - qemu_cortex_m3
+  sample.bluetooth.central_ht.nxp:
+    # Disabling monolithic since CI environment doesn't use blobs
+    harness: bluetooth
+    platform_allow:
       - rd_rw612_bga
+    extra_configs:
+      - CONFIG_NXP_MONOLITHIC_BT=n

--- a/samples/bluetooth/peripheral_ht/sample.yaml
+++ b/samples/bluetooth/peripheral_ht/sample.yaml
@@ -9,11 +9,9 @@ tests:
       - qemu_x86
       - nrf51dk/nrf51822
       - nrf52dk/nrf52832
-      - rd_rw612_bga
     tags: bluetooth
     integration_platforms:
       - qemu_cortex_m3
-      - rd_rw612_bga
   sample.bluetooth.peripheral_ht.frdm_kw41z_shield:
     harness: bluetooth
     platform_allow:
@@ -25,3 +23,10 @@ tests:
     extra_args: SHIELD=frdm_kw41z
     integration_platforms:
       - mimxrt1020_evk
+  sample.bluetooth.peripheral_ht.nxp:
+    # Disabling monolithic since CI environment doesn't use blobs
+    harness: bluetooth
+    platform_allow:
+      - rd_rw612_bga
+    extra_configs:
+      - CONFIG_NXP_MONOLITHIC_BT=n

--- a/soc/nxp/rw/CMakeLists.txt
+++ b/soc/nxp/rw/CMakeLists.txt
@@ -18,4 +18,6 @@ set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/li
 
 zephyr_include_directories(.)
 
+zephyr_linker_sources(RODATA firmwares.ld)
+
 zephyr_linker_sources(RAM_SECTIONS sections.ld)

--- a/soc/nxp/rw/Kconfig.defconfig
+++ b/soc/nxp/rw/Kconfig.defconfig
@@ -109,6 +109,9 @@ config HEAP_MEM_POOL_SIZE
 
 endif # BT
 
+config NXP_MONOLITHIC_BT
+	default y if BT
+
 config NXP_FW_LOADER
 	default y if (BT || WIFI)
 

--- a/soc/nxp/rw/firmwares.ld
+++ b/soc/nxp/rw/firmwares.ld
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#if defined(CONFIG_NXP_MONOLITHIC_BT)
+. = ALIGN(4);
+KEEP(*(.fw_cpu2_ble))
+#endif

--- a/tests/bluetooth/tester/testcase.yaml
+++ b/tests/bluetooth/tester/testcase.yaml
@@ -6,9 +6,16 @@ tests:
       - native_posix
       - native_sim
       - nrf52840dk/nrf52840
-      - rd_rw612_bga
     tags: bluetooth
     harness: bluetooth
+  bluetooth.general.tester.nxp:
+    # Disabling monolithic since CI environment doesn't use blobs
+    build_only: true
+    harness: bluetooth
+    platform_allow:
+      - rd_rw612_bga
+    extra_configs:
+      - CONFIG_NXP_MONOLITHIC_BT=n
   bluetooth.general.tester_le_audio:
     build_only: true
     platform_allow:

--- a/west.yml
+++ b/west.yml
@@ -193,7 +193,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 5e84f1d2173e3c5057725d76f9dad6bfabad0b5f
+      revision: 88a7d079eed470ecc94010784931823a85ac3b39
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
The feature allows to link the binary blobs with BLE applications during the build, forming
one single monolithic image that can be flashed directly to the board.