### PR TITLE
drivers: clock: stm32f1,f3: fix adc prescaler

### DIFF
--- a/boards/st/nucleo_f103rb/nucleo_f103rb.dts
+++ b/boards/st/nucleo_f103rb/nucleo_f103rb.dts
@@ -69,6 +69,7 @@
 	ahb-prescaler = <1>;
 	apb1-prescaler = <2>;
 	apb2-prescaler = <1>;
+	adc-prescaler = <2>;
 };
 
 &usart1 {

--- a/boards/st/nucleo_f303k8/nucleo_f303k8.dts
+++ b/boards/st/nucleo_f303k8/nucleo_f303k8.dts
@@ -63,6 +63,7 @@
 	ahb-prescaler = <1>;
 	apb1-prescaler = <2>;
 	apb2-prescaler = <1>;
+	adc12-prescaler = <0>;
 };
 
 &timers2 {

--- a/boards/st/nucleo_f303re/nucleo_f303re.dts
+++ b/boards/st/nucleo_f303re/nucleo_f303re.dts
@@ -69,6 +69,8 @@
 	ahb-prescaler = <1>;
 	apb1-prescaler = <2>;
 	apb2-prescaler = <1>;
+	adc12-prescaler = <0>;
+	adc34-prescaler = <0>;
 };
 
 &usart2 {

--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -35,6 +35,28 @@
 #define apb2_prescaler(v) fn_apb2_prescaler(v)
 #endif
 
+#if defined(RCC_CFGR_ADCPRE)
+#define z_adc12_prescaler(v) LL_RCC_ADC_CLKSRC_PCLK2_DIV_ ## v
+#define adc12_prescaler(v) z_adc12_prescaler(v)
+#elif defined(RCC_CFGR2_ADC1PRES)
+#define z_adc12_prescaler(v) \
+	COND_CODE_1(IS_EQ(v, 0), \
+		    LL_RCC_ADC1_CLKSRC_HCLK, \
+		    LL_RCC_ADC1_CLKSRC_PLL_DIV_ ## v)
+#define adc12_prescaler(v) z_adc12_prescaler(v)
+#else
+#define z_adc12_prescaler(v) \
+	COND_CODE_1(IS_EQ(v, 0), \
+		    (LL_RCC_ADC12_CLKSRC_HCLK), \
+		    (LL_RCC_ADC12_CLKSRC_PLL_DIV_ ## v))
+#define adc12_prescaler(v) z_adc12_prescaler(v)
+#define z_adc34_prescaler(v) \
+	COND_CODE_1(IS_EQ(v, 0), \
+		    (LL_RCC_ADC34_CLKSRC_HCLK), \
+		    (LL_RCC_ADC34_CLKSRC_PLL_DIV_ ## v))
+#define adc34_prescaler(v) z_adc34_prescaler(v)
+#endif
+
 #if DT_NODE_HAS_PROP(DT_NODELABEL(rcc), ahb4_prescaler)
 #define RCC_CALC_FLASH_FREQ __LL_RCC_CALC_HCLK4_FREQ
 #define GET_CURRENT_FLASH_PRESCALER LL_RCC_GetAHB4Prescaler
@@ -813,13 +835,13 @@ int stm32_clock_control_init(const struct device *dev)
 	LL_RCC_SetAHB4Prescaler(ahb_prescaler(STM32_AHB4_PRESCALER));
 #endif
 #if DT_NODE_HAS_PROP(DT_NODELABEL(rcc), adc_prescaler)
-	LL_RCC_SetADCClockSource(adc_prescaler(STM32_ADC_PRESCALER));
+	LL_RCC_SetADCClockSource(adc12_prescaler(STM32_ADC_PRESCALER));
 #endif
 #if DT_NODE_HAS_PROP(DT_NODELABEL(rcc), adc12_prescaler)
-	LL_RCC_SetADCClockSource(adc_prescaler(STM32_ADC12_PRESCALER));
+	LL_RCC_SetADCClockSource(adc12_prescaler(STM32_ADC12_PRESCALER));
 #endif
 #if DT_NODE_HAS_PROP(DT_NODELABEL(rcc), adc34_prescaler)
-	LL_RCC_SetADCClockSource(adc_prescaler(STM32_ADC34_PRESCALER));
+	LL_RCC_SetADCClockSource(adc34_prescaler(STM32_ADC34_PRESCALER));
 #endif
 
 	/* configure MCO1/MCO2 based on Kconfig */

--- a/drivers/clock_control/clock_stm32f0_f3.c
+++ b/drivers/clock_control/clock_stm32f0_f3.c
@@ -15,28 +15,6 @@
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include "clock_stm32_ll_common.h"
 
-#if defined(RCC_CFGR_ADCPRE)
-#define z_adc_prescaler(v) LL_RCC_ADC_CLKSRC_PCLK2_DIV_ ## v
-#define adc_prescaler(v) z_adc_prescaler(v)
-#elif defined(RCC_CFGR2_ADC1PRES)
-#define z_adc12_prescaler(v) \
-	COND_CODE_1(IS_EQ(v, 0), \
-		    LL_RCC_ADC1_CLKSRC_HCLK, \
-		    LL_RCC_ADC1_CLKSRC_PLL_DIV_ ## v)
-#define adc12_prescaler(v) z_adc12_prescaler(v)
-#else
-#define z_adc12_prescaler(v) \
-	COND_CODE_1(IS_EQ(v, 0), \
-		    LL_RCC_ADC12_CLKSRC_HCLK, \
-		    LL_RCC_ADC12_CLKSRC_PLL_DIV_ ## v)
-#define adc12_prescaler(v) z_adc12_prescaler(v)
-#define z_adc34_prescaler(v) \
-	COND_CODE_1(IS_EQ(v, 0), \
-		    LL_RCC_ADC34_CLKSRC_HCLK, \
-		    LL_RCC_ADC34_CLKSRC_PLL_DIV_ ## v)
-#define adc34_prescaler(v) z_adc34_prescaler(v)
-#endif
-
 #if defined(STM32_PLL_ENABLED)
 
 /**

--- a/drivers/clock_control/clock_stm32f1.c
+++ b/drivers/clock_control/clock_stm32f1.c
@@ -21,9 +21,6 @@
 #define STM32_USB_PRE_ENABLED	RCC_CFGR_OTGFSPRE
 #endif
 
-#define z_adc_prescaler(v) LL_RCC_ADC_CLKSRC_PCLK2_DIV_ ## v
-#define adc_prescaler(v) z_adc_prescaler(v)
-
 #if defined(STM32_PLL_ENABLED)
 
 /*

--- a/dts/bindings/clock/st,stm32f3-rcc.yaml
+++ b/dts/bindings/clock/st,stm32f3-rcc.yaml
@@ -31,6 +31,7 @@ properties:
         ADC 1 and 2 prescaler
         - 0: Disables the clock so the ADC can use AHB clock (synchronous mode)
         - Other values n: The ADC can use the PLL clock divided by n
+        On STM32F37x, only 2/4/6/8 are allowed.
 
   adc34-prescaler:
     type: int


### PR DESCRIPTION
Fix a compilation error occurring when a prescaler was set for ADC on F1 and F3 family.

Fixes #73375