### PR TITLE
drivers: clock_control: stm32: adding config_regulator_voltage for L0

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -733,6 +733,7 @@ int stm32_clock_control_init(const struct device *dev)
 
 	/* Some clocks would be activated by default */
 	config_enable_default_clocks();
+	config_regulator_voltage(CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC);
 
 #if defined(FLASH_ACR_LATENCY)
 	uint32_t old_flash_freq;
@@ -838,6 +839,7 @@ void HAL_RCC_CSSCallback(void)
 }
 #endif
 
+void __weak config_regulator_voltage(uint32_t hclk_freq) {}
 /**
  * @brief RCC device, note that priority is intentionally set to 1 so
  * that the device init runs just after SOC init

--- a/drivers/clock_control/clock_stm32_ll_common.h
+++ b/drivers/clock_control/clock_stm32_ll_common.h
@@ -49,6 +49,7 @@ void config_pll2(void);
 void config_plli2s(void);
 #endif
 void config_enable_default_clocks(void);
+void config_regulator_voltage(uint32_t hclk_freq);
 
 /* functions exported to the soc power.c */
 int stm32_clock_control_init(const struct device *dev);

--- a/drivers/clock_control/clock_stm32l0_l1.c
+++ b/drivers/clock_control/clock_stm32l0_l1.c
@@ -9,6 +9,7 @@
 #include <soc.h>
 #include <stm32_ll_bus.h>
 #include <stm32_ll_rcc.h>
+#include <stm32_ll_pwr.h>
 #include <stm32_ll_utils.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/sys/util.h>
@@ -82,6 +83,22 @@ uint32_t get_pllout_frequency(void)
 #endif /* defined(STM32_PLL_ENABLED) */
 
 /**
+ * @brief Set up voltage regulator voltage
+ */
+void config_regulator_voltage(uint32_t hclk_freq)
+{
+	if (hclk_freq <= MHZ(4.2)) {
+		LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE3);
+	} else if (hclk_freq <= MHZ(16)) {
+		LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE2);
+	} else {
+		LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE1);
+	}
+	while (LL_PWR_IsActiveFlag_VOS() == 1) {
+	}
+}
+
+/**
  * @brief Activate default clocks
  */
 void config_enable_default_clocks(void)
@@ -92,4 +109,5 @@ void config_enable_default_clocks(void)
 	/* Enable System Configuration Controller clock. */
 	LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_SYSCFG);
 #endif
+	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
 }

--- a/soc/st/stm32/stm32l0x/soc.c
+++ b/soc/st/stm32/stm32l0x/soc.c
@@ -14,8 +14,6 @@
 #include <zephyr/linker/linker-defs.h>
 #include <string.h>
 #include <stm32_ll_bus.h>
-#include <stm32_ll_pwr.h>
-#include <stm32_ll_bus.h>
 
 #include <cmsis_core.h>
 
@@ -32,13 +30,6 @@ static int stm32l0_init(void)
 	/* Update CMSIS SystemCoreClock variable (HCLK) */
 	/* At reset, system core clock is set to 2.1 MHz from MSI */
 	SystemCoreClock = 2097152;
-
-	/* Default Voltage scaling range selection (range2)
-	 * doesn't allow to configure Max frequency
-	 * switch to range1 to match any frequency
-	 */
-	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
-	LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE1);
 
 	/* On STM32L0, there are some hardfault when enabling DBGMCU bit:
 	 * Sleep, Stop or Standby.


### PR DESCRIPTION
STM32 MCU shall set voltage regulator level with respect to set clock frequency to reach optimal power consumption.
Voltage regulator is set prior to clock setting based on configuration from dts/overlay file. Config_regulator_voltage is set as weak in clock_stm32_ll_common - config_regulator_voltage can be extended to other STM32 families without need to rewrite heavily family clock driver, default one can be still used.