### PR TITLE
drivers: sensor: si7006: fix redundant include in si7006

### DIFF
--- a/drivers/sensor/silabs/si7006/si7006.c
+++ b/drivers/sensor/silabs/si7006/si7006.c
@@ -13,12 +13,11 @@
 #include <string.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/__assert.h>
-#include <zephyr/logging/log.h>
 #include <zephyr/drivers/i2c.h>
-#include <zephyr/logging/log.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include "si7006.h"
+#include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(si7006, CONFIG_SENSOR_LOG_LEVEL);
 


### PR DESCRIPTION
Remove redundant include of `zephyr/logging/log.h` in si7006.c.