### PR TITLE
drivers: sensor: add sht21, htu21d driver

### DIFF
--- a/drivers/sensor/silabs/si7006/Kconfig
+++ b/drivers/sensor/silabs/si7006/Kconfig
@@ -2,9 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config SI7006
-	bool "Si7006 Temperature and Humidity Sensor"
+	bool "SHT21, Si7006, and HTU21D Humidity and Temperature Sensors"
 	default y
-	depends on DT_HAS_SILABS_SI7006_ENABLED
+	depends on DT_HAS_SILABS_SI7006_ENABLED || DT_HAS_SENSIRION_SHT21_ENABLED
 	select I2C
 	help
-	  Enable I2C-based driver for Si7006 Temperature and Humidity Sensor.
+	  Enable I2C-based driver for several humidity and temperature sensors
+	  compatible with the Sensirion SHT21, such as the Silicon Labs
+	  Si7006/13/20/21 and Measurement Specialties HTU21D

--- a/drivers/sensor/silabs/si7006/si7006.c
+++ b/drivers/sensor/silabs/si7006/si7006.c
@@ -36,16 +36,15 @@ static int si7006_get_humidity(const struct device *dev)
 	struct si7006_data *si_data = dev->data;
 	const struct si7006_config *config = dev->config;
 	int retval;
-	uint8_t hum[2];
+	uint16_t hum;
 
-	retval = i2c_burst_read_dt(&config->i2c,
-				   SI7006_MEAS_REL_HUMIDITY_MASTER_MODE, hum,
-				   sizeof(hum));
+	retval = i2c_burst_read_dt(&config->i2c, SI7006_MEAS_REL_HUMIDITY_MASTER_MODE,
+				   (uint8_t *)&hum, sizeof(hum));
 
 	if (retval == 0) {
-		si_data->humidity = (hum[0] << 8) | hum[1];
+		si_data->humidity = sys_be16_to_cpu(hum) & ~3;
 	} else {
-		LOG_ERR("read register err");
+		LOG_ERR("read register err: %d", retval);
 	}
 
 	return retval;
@@ -64,16 +63,16 @@ static int si7006_get_temperature(const struct device *dev)
 {
 	struct si7006_data *si_data = dev->data;
 	const struct si7006_config *config = dev->config;
-	uint8_t temp[2];
+	uint16_t temp;
 	int retval;
 
-	retval = i2c_burst_read_dt(&config->i2c, config->read_temp_cmd, temp,
-				   sizeof(temp));
+	retval = i2c_burst_read_dt(&config->i2c, config->read_temp_cmd,
+				   (uint8_t *)&temp, sizeof(temp));
 
 	if (retval == 0) {
-		si_data->temperature = (temp[0] << 8) | temp[1];
+		si_data->temperature = sys_be16_to_cpu(temp) & ~3;
 	} else {
-		LOG_ERR("read register err");
+		LOG_ERR("read register err: %d", retval);
 	}
 
 	return retval;

--- a/drivers/sensor/silabs/si7006/si7006.c
+++ b/drivers/sensor/silabs/si7006/si7006.c
@@ -5,16 +5,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/device.h>
+#include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/kernel.h>
-#include <zephyr/device.h>
-#include <zephyr/init.h>
-#include <string.h>
 #include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/__assert.h>
-#include <zephyr/drivers/i2c.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include "si7006.h"
 #include <zephyr/logging/log.h>
 

--- a/drivers/sensor/silabs/si7006/si7006.c
+++ b/drivers/sensor/silabs/si7006/si7006.c
@@ -22,7 +22,6 @@
 LOG_MODULE_REGISTER(si7006, CONFIG_SENSOR_LOG_LEVEL);
 
 struct si7006_data {
-	const struct device *i2c_dev;
 	uint16_t temperature;
 	uint16_t humidity;
 };

--- a/drivers/sensor/silabs/si7006/si7006.c
+++ b/drivers/sensor/silabs/si7006/si7006.c
@@ -23,7 +23,7 @@ struct si7006_data {
 
 struct si7006_config {
 	struct i2c_dt_spec i2c;
-	/** Use "read temp" vs "read old temp" command, the latter only with SiLabs sensors. */
+	/* Use "read temp" vs "read old temp" command, the latter only with SiLabs sensors. */
 	uint8_t read_temp_cmd;
 };
 
@@ -59,7 +59,6 @@ static int si7006_get_humidity(const struct device *dev)
  *
  * @return int 0 on success
  */
-
 static int si7006_get_temperature(const struct device *dev)
 {
 	struct si7006_data *si_data = dev->data;
@@ -178,7 +177,6 @@ static const struct sensor_driver_api si7006_api = {
  *
  * @return 0 for success
  */
-
 static int si7006_init(const struct device *dev)
 {
 	const struct si7006_config *config = dev->config;
@@ -193,17 +191,23 @@ static int si7006_init(const struct device *dev)
 	return 0;
 }
 
-#define SI7006_DEFINE(inst, temp_cmd)							\
-	static struct si7006_data si7006_data_##inst;					\
+#define SI7006_DEFINE(inst, name, temp_cmd)						\
+	static struct si7006_data si7006_data_##name##_##inst;				\
 											\
-	static const struct si7006_config si7006_config_##inst = {			\
-		.i2c = I2C_DT_SPEC_GET(inst),						\
+	static const struct si7006_config si7006_config_##name##_##inst = {		\
+		.i2c = I2C_DT_SPEC_INST_GET(inst),					\
 		.read_temp_cmd = temp_cmd,						\
 	};										\
 											\
-	SENSOR_DEVICE_DT_DEFINE(inst, si7006_init, NULL,				\
-				&si7006_data_##inst, &si7006_config_##inst,		\
-				POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &si7006_api); \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, si7006_init, NULL,				\
+				     &si7006_data_##name##_##inst,			\
+				     &si7006_config_##name##_##inst,			\
+				     POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,		\
+				     &si7006_api);
 
-DT_FOREACH_STATUS_OKAY_VARGS(silabs_si7006, SI7006_DEFINE, SI7006_READ_OLD_TEMP);
-DT_FOREACH_STATUS_OKAY_VARGS(sensirion_sht21, SI7006_DEFINE, SI7006_MEAS_TEMP_MASTER_MODE);
+#define DT_DRV_COMPAT silabs_si7006
+DT_INST_FOREACH_STATUS_OKAY_VARGS(SI7006_DEFINE, DT_DRV_COMPAT, SI7006_READ_OLD_TEMP);
+
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT sensirion_sht21
+DT_INST_FOREACH_STATUS_OKAY_VARGS(SI7006_DEFINE, DT_DRV_COMPAT, SI7006_MEAS_TEMP_MASTER_MODE);

--- a/drivers/sensor/silabs/si7006/si7006.c
+++ b/drivers/sensor/silabs/si7006/si7006.c
@@ -10,6 +10,7 @@
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/util.h>
 #include "si7006.h"
 #include <zephyr/logging/log.h>
 
@@ -108,25 +109,58 @@ static int si7006_channel_get(const struct device *dev,
 	struct si7006_data *si_data = dev->data;
 
 	if (chan == SENSOR_CHAN_AMBIENT_TEMP) {
+		/* Raw formula: (temp * 175.72) / 65536 - 46.85
+		 * To use integer math, scale the 175.72 factor by 128 and move the offset to
+		 * inside the division.  This gives us:
+		 *
+		 * (temp * 175.72 * 128 - 46.86 * 128 * 65536) / (65536 * 128)
+		 * The constants can be calculated now:
+		 * (temp * 22492 - 393006285) / 2^23
+		 *
+		 * There is a very small amount of round-off error in the factor of 22492.  To
+		 * compenstate, a constant of 5246 is used to center the error about 0, thus
+		 * reducing the overall MSE.
+		 */
 
-		int32_t temp_ucelcius = (((17572 * (int32_t)si_data->temperature)
-					/ 65536) - 4685) * 10000;
+		/* Temperature value times two to the 23rd power, i.e. temp_23 = temp << 23 */
+		const int32_t temp_23 = si_data->temperature * 22492 - (393006285 - 5246);
+		/* Integer component of temperature */
+		int32_t temp_int = temp_23 >> 23;
+		/* Fractional component of temperature */
+		int32_t temp_frac = temp_23 & BIT_MASK(23);
 
-		val->val1 = temp_ucelcius / 1000000;
-		val->val2 = temp_ucelcius % 1000000;
+		/* Deal with the split twos-complement / BCD format oddness with negatives */
+		if (temp_23 < 0) {
+			temp_int += 1;
+			temp_frac -= BIT(23);
+		}
+		val->val1 = temp_int;
+		/* Remove a constant factor of 64 from (temp_frac * 1000000) >> 23 */
+		val->val2 = (temp_frac * 15625ULL) >> 17;
 
-		LOG_DBG("temperature = val1:%d, val2:%d", val->val1, val->val2);
+		LOG_DBG("temperature %u = val1:%d, val2:%d", si_data->temperature,
+			val->val1, val->val2);
 
 		return 0;
 	} else if (chan == SENSOR_CHAN_HUMIDITY) {
+		/* Humidity times two to the 16th power.  Offset of -6 not applied yet. */
+		const uint32_t rh_16 = si_data->humidity * 125U;
+		/* Integer component of humidity */
+		const int16_t rh_int = rh_16 >> 16;
+		/* Fraction component of humidity */
+		const uint16_t rh_frac = rh_16 & BIT_MASK(16);
 
-		int32_t relative_humidity = (((125 * (int32_t)si_data->humidity)
-					    / 65536) - 6) * 1000000;
+		val->val1 = rh_int - 6; /* Apply offset now */
+		/* Remove a constant factor of 64 from (rh_frac * 1000000) >> 16 */
+		val->val2 = (rh_frac * 15625) >> 10;
 
-		val->val1 = relative_humidity / 1000000;
-		val->val2 = relative_humidity % 1000000;
+		/* Deal with the split twos-complement / BCD format oddness with negatives */
+		if (val->val1 < 0) {
+			val->val1 += 1;
+			val->val2 -= 1000000;
+		}
 
-		LOG_DBG("humidity = val1:%d, val2:%d", val->val1, val->val2);
+		LOG_DBG("humidity %u = val1:%d, val2:%d", si_data->humidity, val->val1, val->val2);
 
 		return 0;
 	} else {

--- a/dts/bindings/sensor/sensirion,sht21.yaml
+++ b/dts/bindings/sensor/sensirion,sht21.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2023, Trent Piepho <tpiepho@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Sensirion SHT21 Humidity and Temperature Sensor
+
+  This is compatible with the Measurement Specialties HUT21D, "meas,htu21d".
+
+  For the Silicon Labs Si7006/13/20/21 series, use the "silabs,si7006"
+  compatible for slightly altered operation.
+
+compatible: "sensirion,sht21"
+
+include: [sensor-device.yaml, i2c-device.yaml]

--- a/dts/bindings/sensor/silabs,si7006.yaml
+++ b/dts/bindings/sensor/silabs,si7006.yaml
@@ -1,8 +1,14 @@
 # Copyright (c) 2019, Electronut Labs
+# Copyright (c) 2023, Trent Piepho <tpiepho@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-description: Si7006 temperature and humidity sensor
+description: |
+  Silicon Labs Si7006 Humidity and Temperature Sensor
+
+  This is compatible with a range of Silicon Labs sensors, such as the Si7013,
+  Si7020, and Si7021.  This binding will use a slightly different (better)
+  command to read temperature from the "sensirion,sht21" binding.
 
 compatible: "silabs,si7006"
 
-include: [sensor-device.yaml, i2c-device.yaml]
+include: sensirion,sht21.yaml

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -1055,3 +1055,8 @@ test_i2c_shtc1: shtc1@8e {
 	measure-mode = "low-power";
 	clock-stretching;
 };
+
+test_i2c_sht21@90 {
+	compatible = "sensirion,sht21";
+	reg = <0x90>;
+};


### PR DESCRIPTION
Add SHT21 and HTU21D support.
This comes from https://github.com/zephyrproject-rtos/zephyr/pull/56227, I rebased it on mainline.  I decided to do this because the other pull request was left pending. I personally tested the driver for the sht2x sensor and it worked correctly. 