### PR TITLE
sd: sd_ops: fix DISK_IOCTL_CTRL_SYNC return code

### DIFF
--- a/subsys/sd/sd_ops.c
+++ b/subsys/sd/sd_ops.c
@@ -794,6 +794,7 @@ int card_ioctl(struct sd_card *card, uint8_t cmd, void *buf)
 		 * cache flush is not required here
 		 */
 		ret = sdmmc_wait_ready(card);
+		break;
 	default:
 		ret = -ENOTSUP;
 	}


### PR DESCRIPTION
SD IOCTL handling for DISK_IOCTL_CTRL_SYNC was falling through to the default return statement, and returning an error when disk sync succeeded. Fix this issue by properly breaking in IOCTL handler.