### PR TITLE
lib: heap: Enable asserts by default

### DIFF
--- a/lib/heap/Kconfig
+++ b/lib/heap/Kconfig
@@ -6,6 +6,7 @@ menu "Heap and Memory Allocation"
 
 config SYS_HEAP_VALIDATE
 	bool "Internal heap validity checking"
+	depends on ASSERT
 	help
 	  The sys_heap implementation is instrumented for extensive
 	  internal validation.  Leave this off by default, unless


### PR DESCRIPTION
There is no point in having heap validation enabled but without asserts, as nothing is reported to the user.

Auto enable of assert will help use catch heap corruptions.