### PR TITLE
Exclude native_posix for samples which set EVENTFD

### DIFF
--- a/samples/net/dns_resolve/sample.yaml
+++ b/samples/net/dns_resolve/sample.yaml
@@ -1,6 +1,9 @@
 common:
   harness: net
   depends_on: netif
+  platform_exclude:
+    - native_posix
+    - native_posix/native/64
   tags:
     - net
     - dns

--- a/samples/net/sockets/big_http_download/sample.yaml
+++ b/samples/net/sockets/big_http_download/sample.yaml
@@ -9,6 +9,9 @@ common:
   tags:
     - net
     - socket
+  platform_exclude:
+    - native_posix
+    - native_posix/native/64
 tests:
   sample.net.sockets.big_http_download:
     extra_configs:

--- a/samples/net/sockets/http_get/sample.yaml
+++ b/samples/net/sockets/http_get/sample.yaml
@@ -15,6 +15,8 @@ tests:
     platform_exclude:
       - cc3220sf_launchxl
       - cc3235sf_launchxl
+      - native_posix
+      - native_posix/native/64
     extra_configs:
       - CONFIG_POSIX_API=y
   sample.net.sockets.http_get.offload.simplelink:

--- a/samples/posix/gettimeofday/sample.yaml
+++ b/samples/posix/gettimeofday/sample.yaml
@@ -4,6 +4,9 @@ sample:
 common:
   filter: ( CONFIG_FULL_LIBC_SUPPORTED and not CONFIG_NATIVE_LIBC
     and not CONFIG_SOC_FAMILY_INTEL_ADSP )
+  platform_exclude:
+    - native_posix
+    - native_posix/native/64
   harness: net
   min_ram: 32
   min_flash: 96


### PR DESCRIPTION
Due to kconfig dependencies, these samples set EVENTFD (and some also POSIX_API, and other options) which
depends on !NATIVE_APPLICATION, which when building for native_posix results in kconfig warnings when they
are forced to n, and therefore a twister build failure.

As native_posix is a native_application, let's exclude it from the test to prevent this combination from happening in CI.

Fixes #73434