### PR TITLE
arch: common: Removed unnecessary cast

### DIFF
--- a/arch/common/isr_tables.c
+++ b/arch/common/isr_tables.c
@@ -90,7 +90,7 @@ uintptr_t __irq_vector_table _irq_vector_table[IRQ_TABLE_SIZE] = {
 #ifdef CONFIG_GEN_SW_ISR_TABLE
 struct _isr_table_entry __sw_isr_table _sw_isr_table[IRQ_TABLE_SIZE] = {
 	[0 ...(IRQ_TABLE_SIZE - 1)] = {(const void *)0x42,
-				       (void *)&z_irq_spurious},
+				       &z_irq_spurious},
 };
 #endif
 


### PR DESCRIPTION
Removed an unnecessary cast to void * from a function that already had the correct signature. This makes for more portable code as casting between code and data pointers are frowned upon by the C standard.