### PR TITLE
fs: nvs: Add CRC to protect the data part of the NVS items

### DIFF
--- a/doc/services/storage/nvs/nvs.rst
+++ b/doc/services/storage/nvs/nvs.rst
@@ -19,11 +19,16 @@ combination of these.
 Each element is stored in flash as metadata (8 byte) and data. The metadata is
 written in a table starting from the end of a nvs sector, the data is
 written one after the other from the start of the sector. The metadata consists
-of: id, data offset in sector, data length, part (unused), and a CRC. The CRC is
+of: id, data offset in sector, data length, part (unused), and a CRC. This CRC is
 only calculated over the metadata and only ensures that a write has been
-completed. The actual data of the element is not protected by a CRC. It is
-encouraged to include a CRC as part of the data and to take appropriate
-corrective actions when the data CRC does not match its expected value.
+completed. The actual data of the element can be protected by a different (and optional)
+CRC-32. Use the :kconfig:option:`CONFIG_NVS_DATA_CRC` configuration item to enable
+the data part CRC.
+**Note:** the data CRC is checked only when the whole data of the element is read.
+The data CRC is not checked for a partial read, as it is stored at the end of the
+element data area.
+**Note 2:** enabling the data CRC feature on a previously existing NVS content without
+data CRC will make all existing data invalid.
 
 A write of data to nvs always starts with writing the data, followed by a write
 of the metadata. Data that is written in flash without metadata is ignored

--- a/subsys/fs/nvs/Kconfig
+++ b/subsys/fs/nvs/Kconfig
@@ -29,6 +29,14 @@ config NVS_LOOKUP_CACHE_SIZE
 	  Number of entries in Non-volatile Storage lookup cache.
 	  It is recommended that it be a power of 2.
 
+config NVS_DATA_CRC
+	bool "Non-volatile Storage CRC protection on the data"
+	help
+	  Enable a CRC-32 on the data part of each NVS element.
+	  The ATE CRC is not impacted by this feature and stays the same.
+	  The CRC-32 is transparently stored at the end of the data field,
+	  in the NVS data section, so 4 more bytes are needed per NVS element.
+
 module = NVS
 module-str = nvs
 source "subsys/logging/Kconfig.template.log_config"

--- a/subsys/fs/nvs/nvs_priv.h
+++ b/subsys/fs/nvs/nvs_priv.h
@@ -30,6 +30,15 @@ extern "C" {
 
 #define NVS_LOOKUP_CACHE_NO_ADDR 0xFFFFFFFF
 
+/*
+ * Allow to use the NVS_DATA_CRC_SIZE macro in computations whether data CRC is enabled or not
+ */
+#ifdef CONFIG_NVS_DATA_CRC
+#define NVS_DATA_CRC_SIZE 4 /* CRC-32 size in bytes */
+#else
+#define NVS_DATA_CRC_SIZE 0
+#endif
+
 /* Allocation Table Entry */
 struct nvs_ate {
 	uint16_t id;	/* data id */

--- a/tests/subsys/fs/nvs/src/main.c
+++ b/tests/subsys/fs/nvs/src/main.c
@@ -560,7 +560,8 @@ ZTEST_F(nvs, test_nvs_full_sector)
 				     len);
 		} else {
 			zassert_true(len == sizeof(data_read),
-				     "nvs_read failed: %d", i, len);
+				     "nvs_read #%d failed: len is %zd instead of %zu",
+				     i, len, sizeof(data_read));
 			zassert_equal(data_read, i,
 				      "read unexpected data: %d instead of %d",
 				      data_read, i);
@@ -639,6 +640,9 @@ ZTEST_F(nvs, test_nvs_gc_corrupt_close_ate)
 	uint32_t data;
 	ssize_t len;
 	int err;
+#ifdef CONFIG_NVS_DATA_CRC
+	uint32_t data_crc;
+#endif
 
 	close_ate.id = 0xffff;
 	close_ate.offset = fixture->fs.sector_size - sizeof(struct nvs_ate) * 5;
@@ -648,6 +652,9 @@ ZTEST_F(nvs, test_nvs_gc_corrupt_close_ate)
 	ate.id = 0x1;
 	ate.offset = 0;
 	ate.len = sizeof(data);
+#ifdef CONFIG_NVS_DATA_CRC
+	ate.len += sizeof(data_crc);
+#endif
 	ate.crc8 = crc8_ccitt(0xff, &ate,
 			      offsetof(struct nvs_ate, crc8));
 
@@ -666,6 +673,12 @@ ZTEST_F(nvs, test_nvs_gc_corrupt_close_ate)
 	data = 0xaa55aa55;
 	err = flash_write(fixture->fs.flash_device, fixture->fs.offset, &data, sizeof(data));
 	zassert_true(err == 0,  "flash_write failed: %d", err);
+#ifdef CONFIG_NVS_DATA_CRC
+	data_crc = crc32_ieee((const uint8_t *) &data, sizeof(data));
+	err = flash_write(fixture->fs.flash_device, fixture->fs.offset + sizeof(data), &data_crc,
+			  sizeof(data_crc));
+	zassert_true(err == 0,  "flash_write for data CRC failed: %d", err);
+#endif
 
 	/* Mark sector 1 as closed */
 	err = flash_write(fixture->fs.flash_device,

--- a/tests/subsys/fs/nvs/testcase.yaml
+++ b/tests/subsys/fs/nvs/testcase.yaml
@@ -11,3 +11,15 @@ tests:
       - CONFIG_NVS_LOOKUP_CACHE=y
       - CONFIG_NVS_LOOKUP_CACHE_SIZE=64
     platform_allow: native_sim
+  filesystem.nvs.data_crc:
+    extra_args:
+      - CONFIG_NVS_DATA_CRC=y
+    platform_allow:
+      - native_sim
+      - qemu_x86
+  filesystem.nvs.data_crc_cache:
+    extra_args:
+      - CONFIG_NVS_DATA_CRC=y
+      - CONFIG_NVS_LOOKUP_CACHE=y
+      - CONFIG_NVS_LOOKUP_CACHE_SIZE=64
+    platform_allow: native_sim


### PR DESCRIPTION
Add a CRC-32 to protect the data part of a NVS item.
This CRC is optional and can be enabled with the `CONFIG_NVS_DATA_CRC` configuration item.

Also added a test scenario and updated the NVS documentation to reflect the existence of this CRC.