### PR TITLE
arch/x86: Make irq_offload SMP-safe on x86_64

### DIFF
--- a/tests/kernel/smp_abort/testcase.yaml
+++ b/tests/kernel/smp_abort/testcase.yaml
@@ -1,6 +1,5 @@
 tests:
   kernel.smp_abort:
-    arch_exclude: x86  # Buggy irq_offload(), see #71172
     tags:
       - kernel
       - smp


### PR DESCRIPTION
The irq_offload mechanism was using the same entry of the IDT vector for all CPUs on SMP systems. This caused race conditions when two CPUs were doing irq_offload() calls.

This patch addresses that by adding one indirection layer: the irq_offload() now sets a per CPU entry with the routine and parameter to be run. Then a software interrupt is generated, and a default handler will do the appropriate dispatching.

Finally, test "kernel/smp_abort" is enabled for x86 as it should work now.

Fixes #72172.