### PR TITLE
samples: net: cellular_modem: Fix nRF9160

### DIFF
--- a/samples/net/cellular_modem/boards/nrf9160dk_nrf52840.conf
+++ b/samples/net/cellular_modem/boards/nrf9160dk_nrf52840.conf
@@ -1,4 +1,6 @@
 CONFIG_UART_ASYNC_API=y
+CONFIG_UART_1_ASYNC=y
+CONFIG_UART_1_INTERRUPT_DRIVEN=n
 # Enable HW RX byte counting. This especially matters at higher baud rates.
 CONFIG_UART_1_NRF_HW_ASYNC=y
 CONFIG_UART_1_NRF_HW_ASYNC_TIMER=1

--- a/samples/net/cellular_modem/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/net/cellular_modem/boards/nrf9160dk_nrf9160_ns.conf
@@ -1,4 +1,6 @@
 CONFIG_UART_ASYNC_API=y
+CONFIG_UART_1_ASYNC=y
+CONFIG_UART_1_INTERRUPT_DRIVEN=n
 # Enable HW RX byte counting. This especially matters at higher baud rates.
 CONFIG_UART_1_NRF_HW_ASYNC=y
 CONFIG_UART_1_NRF_HW_ASYNC_TIMER=1


### PR DESCRIPTION
Add missing Kconfigs to nRF9160dk overlays.