### PR TITLE
tests settings/file: Add missing overlay for native_sim//64

### DIFF
--- a/tests/subsys/settings/file/boards/native_sim_native_64.overlay
+++ b/tests/subsys/settings/file/boards/native_sim_native_64.overlay
@@ -1,0 +1,6 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "native_sim.overlay"


### PR DESCRIPTION
native_sim//64 is one of the allowed platforms
but lacks an overlay which causes the test to fail to build.
Let's fix it.

Otherwise the test fails in CI as shown here: https://github.com/zephyrproject-rtos/zephyr/actions/runs/9240178517/job/25420198984#step:13:3941