### PR TITLE
Bluetooth: CSIP: Make set_member_by_conn a public function

### DIFF
--- a/include/zephyr/bluetooth/audio/csip.h
+++ b/include/zephyr/bluetooth/audio/csip.h
@@ -315,6 +315,21 @@ typedef void (*bt_csip_set_coordinator_discover_cb)(
 int bt_csip_set_coordinator_discover(struct bt_conn *conn);
 
 /**
+ * @brief Get the set member from a connection pointer
+ *
+ * Get the Coordinated Set Identification Profile Set Coordinator pointer from a connection pointer.
+ * Only Set Coordinators that have been initiated via bt_csip_set_coordinator_discover() can be
+ * retrieved.
+ *
+ * @param conn     Connection pointer.
+ *
+ * @retval Pointer to a Coordinated Set Identification Profile Set Coordinator instance
+ * @retval NULL if @p conn is NULL or if the connection has not done discovery yet
+ */
+struct bt_csip_set_coordinator_set_member *
+bt_csip_set_coordinator_set_member_by_conn(const struct bt_conn *conn);
+
+/**
  * @typedef bt_csip_set_coordinator_lock_set_cb
  * @brief Callback for locking a set across one or more devices
  *

--- a/subsys/bluetooth/audio/cap_common.c
+++ b/subsys/bluetooth/audio/cap_common.c
@@ -340,7 +340,7 @@ static uint8_t bt_cap_common_discover_included_cb(struct bt_conn *conn,
 			}
 		} else {
 			const struct bt_csip_set_coordinator_set_member *member =
-				bt_csip_set_coordinator_csis_member_by_conn(conn);
+				bt_csip_set_coordinator_set_member_by_conn(conn);
 
 			LOG_DBG("Found CAS with CSIS");
 

--- a/subsys/bluetooth/audio/csip_internal.h
+++ b/subsys/bluetooth/audio/csip_internal.h
@@ -46,7 +46,5 @@ struct bt_csip_set_coordinator_svc_inst {
 	struct bt_csip_set_coordinator_set_info *set_info;
 };
 
-struct bt_csip_set_coordinator_csis_inst *bt_csip_set_coordinator_csis_inst_by_handle(
-	struct bt_conn *conn, uint16_t start_handle);
-struct bt_csip_set_coordinator_set_member *
-bt_csip_set_coordinator_csis_member_by_conn(struct bt_conn *conn);
+struct bt_csip_set_coordinator_csis_inst *
+bt_csip_set_coordinator_csis_inst_by_handle(struct bt_conn *conn, uint16_t start_handle);

--- a/subsys/bluetooth/audio/csip_set_coordinator.c
+++ b/subsys/bluetooth/audio/csip_set_coordinator.c
@@ -1419,7 +1419,7 @@ struct bt_csip_set_coordinator_csis_inst *bt_csip_set_coordinator_csis_inst_by_h
 }
 
 struct bt_csip_set_coordinator_set_member *
-bt_csip_set_coordinator_csis_member_by_conn(struct bt_conn *conn)
+bt_csip_set_coordinator_set_member_by_conn(const struct bt_conn *conn)
 {
 	struct bt_csip_set_coordinator_inst *client;
 
@@ -1430,8 +1430,11 @@ bt_csip_set_coordinator_csis_member_by_conn(struct bt_conn *conn)
 	}
 
 	client = &client_insts[bt_conn_index(conn)];
+	if (client->conn == conn) {
+		return &client->set_member;
+	}
 
-	return &client->set_member;
+	return NULL;
 }
 
 /*************************** PUBLIC FUNCTIONS ***************************/

--- a/tests/bluetooth/audio/cap_commander/uut/csip.c
+++ b/tests/bluetooth/audio/cap_commander/uut/csip.c
@@ -53,7 +53,7 @@ int bt_csip_set_coordinator_discover(struct bt_conn *conn)
 }
 
 struct bt_csip_set_coordinator_set_member *
-bt_csip_set_coordinator_csis_member_by_conn(struct bt_conn *conn)
+bt_csip_set_coordinator_set_member_by_conn(const struct bt_conn *conn)
 {
 	if (conn == NULL) {
 		return NULL;


### PR DESCRIPTION
The function is useful for application to lookup set members from bt_conn pointers, e.g. when iterating on connected devices.