### PR TITLE
scripts: west_commands: runners: nrfutil: Only flash devkits

### DIFF
--- a/scripts/west_commands/runners/nrfutil.py
+++ b/scripts/west_commands/runners/nrfutil.py
@@ -77,7 +77,7 @@ class NrfUtilBinaryRunner(NrfBinaryRunner):
         for o in out:
             if o['type'] == 'task_end':
                 devs = o['data']['data']['devices']
-        snrs = [dev['serialNumber'] for dev in devs]
+        snrs = [dev['serialNumber'] for dev in devs if dev['traits']['jlink']]
 
         self.logger.debug(f'Found boards: {snrs}')
         return snrs


### PR DESCRIPTION
The nrfutil runner calls "nrfutil --json device list" which outputs information about all connected serial ports. The list includes not only actual boards but also any ttyACM instance. If the ttyACM instance does not have serial number, then the nrfutil runner will fail on matching serial number regexp on NoneType.

Fix the issue by limiting nrfutil runner board output to only devices that have trait devkit set.