### PR TITLE
Revert "task_wdt: start feeding hardware watchdog immediately after init"

### DIFF
--- a/subsys/task_wdt/task_wdt.c
+++ b/subsys/task_wdt/task_wdt.c
@@ -147,7 +147,6 @@ int task_wdt_init(const struct device *hw_wdt)
 	}
 
 	k_timer_init(&timer, task_wdt_trigger, NULL);
-	schedule_next_timeout(sys_clock_tick_get());
 
 	return 0;
 }


### PR DESCRIPTION
This reverts commit 69307e585dd38ff58107b70fa9396e32807ab954.
The commit would feed the hardware watchdog before it was started. The watchdog is not started until the first task wdt is added.

This fixes issue #70478
