### PR TITLE
boards: nxp: mimxrt10xx: fix non-optimal sector distribution

### DIFF
--- a/boards/nxp/mimxrt1010_evk/mimxrt1010_evk.dts
+++ b/boards/nxp/mimxrt1010_evk/mimxrt1010_evk.dts
@@ -105,19 +105,22 @@ arduino_serial: &lpuart1 {};
 			#size-cells = <1>;
 			boot_partition: partition@0 {
 				label = "mcuboot";
-				reg = <0x00000000 DT_SIZE_K(64)>;
+				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			slot0_partition: partition@10000 {
+			/* The MCUBoot swap-move algorithm uses the last 3 sectors
+			 * of the primary slot0 for swap status and move.
+			 */
+			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00010000 DT_SIZE_M(7)>;
+				reg = <0x00020000 (DT_SIZE_M(7) + DT_SIZE_K(12))>;
 			};
-			slot1_partition: partition@710000 {
+			slot1_partition: partition@723000 {
 				label = "image-1";
-				reg = <0x00710000 DT_SIZE_M(7)>;
+				reg = <0x00723000 DT_SIZE_M(7)>;
 			};
-			storage_partition: partition@E10000 {
+			storage_partition: partition@E23000 {
 				label = "storage";
-				reg = <0x00E10000 DT_SIZE_K(1984)>;
+				reg = <0x00E23000 (DT_SIZE_M(2) - DT_SIZE_K(140))>;
 			};
 		};
 	};

--- a/boards/nxp/mimxrt1015_evk/mimxrt1015_evk.dts
+++ b/boards/nxp/mimxrt1015_evk/mimxrt1015_evk.dts
@@ -102,19 +102,22 @@ arduino_serial: &lpuart4 {
 			#size-cells = <1>;
 			boot_partition: partition@0 {
 				label = "mcuboot";
-				reg = <0x00000000 DT_SIZE_K(64)>;
+				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			slot0_partition: partition@10000 {
+			/* The MCUBoot swap-move algorithm uses the last 3 sectors
+			 * of the primary slot0 for swap status and move.
+			 */
+			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00010000 DT_SIZE_M(7)>;
+				reg = <0x00020000 (DT_SIZE_M(7) + DT_SIZE_K(12))>;
 			};
-			slot1_partition: partition@710000 {
+			slot1_partition: partition@723000 {
 				label = "image-1";
-				reg = <0x00710000 DT_SIZE_M(7)>;
+				reg = <0x00723000 DT_SIZE_M(7)>;
 			};
-			storage_partition: partition@E10000 {
+			storage_partition: partition@E23000 {
 				label = "storage";
-				reg = <0x00E10000 DT_SIZE_K(1984)>;
+				reg = <0x00E23000 (DT_SIZE_M(2) - DT_SIZE_K(140))>;
 			};
 		};
 	};

--- a/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -107,25 +107,24 @@ arduino_serial: &lpuart2 {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
-
 			boot_partition: partition@0 {
 				label = "mcuboot";
-				reg = <0x00000000 DT_SIZE_K(64)>;
+				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			/* Note slot 0 has one additional sector,
-			 * this is intended for use with the swap move algorithm
+			/* The MCUBoot swap-move algorithm uses the last 2 sectors
+			 * of the primary slot0 for swap status and move.
 			 */
-			slot0_partition: partition@10000 {
+			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00010000 (DT_SIZE_M(3) + DT_SIZE_K(4))>;
+				reg = <0x00020000 (DT_SIZE_M(3) + DT_SIZE_K(8))>;
 			};
-			slot1_partition: partition@311000 {
+			slot1_partition: partition@322000 {
 				label = "image-1";
-				reg = <0x00311000 DT_SIZE_M(3)>;
+				reg = <0x00322000 DT_SIZE_M(3)>;
 			};
-			storage_partition: partition@611000 {
+			storage_partition: partition@622000 {
 				label = "storage";
-				reg = <0x00611000 DT_SIZE_K(1980)>;
+				reg = <0x00622000 (DT_SIZE_M(2) - DT_SIZE_K(136))>;
 			};
 		};
 	};

--- a/boards/nxp/mimxrt1024_evk/mimxrt1024_evk.dts
+++ b/boards/nxp/mimxrt1024_evk/mimxrt1024_evk.dts
@@ -100,25 +100,24 @@ arduino_serial: &lpuart2 {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
-
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 DT_SIZE_K(64)>;
+			reg = <0x00000000 DT_SIZE_K(128)>;
 		};
-		/* Note slot 0 has one additional sector,
-		 * this is intended for use with the swap move algorithm
+		/* The MCUBoot swap-move algorithm uses the last 2 sectors
+		 * of the primary slot0 for swap status and move.
 		 */
-		slot0_partition: partition@10000 {
+		slot0_partition: partition@20000 {
 			label = "image-0";
-			reg = <0x00010000 DT_SIZE_K(1924)>;
+			reg = <0x00020000 (DT_SIZE_K(1920) + DT_SIZE_K(8))>;
 		};
-		slot1_partition: partition@1f1000 {
+		slot1_partition: partition@202000 {
 			label = "image-1";
-			reg = <0x001F1000 DT_SIZE_K(1920)>;
+			reg = <0x00202000 DT_SIZE_K(1920)>;
 		};
-		storage_partition: partition@3d1000 {
+		storage_partition: partition@3E2000 {
 			label = "storage";
-			reg = <0x003D1000 DT_SIZE_K(188)>;
+			reg = <0x003E2000 DT_SIZE_K(120)>;
 		};
 	};
 };

--- a/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.dts
+++ b/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.dts
@@ -103,19 +103,22 @@
 			#size-cells = <1>;
 			boot_partition: partition@0 {
 				label = "mcuboot";
-				reg = <0x00000000 DT_SIZE_K(64)>;
+				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			slot0_partition: partition@10000 {
+			/* The MCUBoot swap-move algorithm uses the last 2 sectors
+			 * of the primary slot0 for swap status and move.
+			 */
+			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00010000 DT_SIZE_M(3)>;
+				reg = <0x00020000 (DT_SIZE_M(3) + DT_SIZE_K(8))>;
 			};
-			slot1_partition: partition@310000 {
+			slot1_partition: partition@322000 {
 				label = "image-1";
-				reg = <0x00310000 DT_SIZE_M(3)>;
+				reg = <0x00322000 DT_SIZE_M(3)>;
 			};
-			storage_partition: partition@610000 {
+			storage_partition: partition@622000 {
 				label = "storage";
-				reg = <0x00610000 DT_SIZE_K(1984)>;
+				reg = <0x00622000 (DT_SIZE_M(2) - DT_SIZE_K(136))>;
 			};
 		};
 	};

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_hyperflash.overlay
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_hyperflash.overlay
@@ -46,25 +46,24 @@
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
-
 			boot_partition: partition@0 {
 				label = "mcuboot";
-				reg = <0x00000000 DT_SIZE_K(256)>;
+				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			/* Note slot 0 has one additional sector,
-			 * this is intended for use with the swap move algorithm
+			/* The MCUBoot swap-move algorithm uses the last 14 sectors
+			 * of the primary slot0 for swap status and move.
 			 */
-			slot0_partition: partition@40000 {
+			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00040000 (DT_SIZE_M(3) + DT_SIZE_K(4))>;
+				reg = <0x00020000 (DT_SIZE_M(3) + DT_SIZE_K(56))>;
 			};
-			slot1_partition: partition@341000 {
+			slot1_partition: partition@32E000 {
 				label = "image-1";
-				reg = <0x00341000 DT_SIZE_M(3)>;
+				reg = <0x0032E000 DT_SIZE_M(3)>;
 			};
-			storage_partition: partition@641000 {
+			storage_partition: partition@62E000 {
 				label = "storage";
-				reg = <0x00641000 (DT_SIZE_M(57) + DT_SIZE_K(764))>;
+				reg = <0x0062E000 (DT_SIZE_M(58) - DT_SIZE_K(184))>;
 			};
 		};
 	};

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_qspi.overlay
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_qspi.overlay
@@ -27,30 +27,28 @@
 		jedec-id = [9d 70 17];
 		erase-block-size = <4096>;
 		write-block-size = <1>;
-
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
-
 			boot_partition: partition@0 {
 				label = "mcuboot";
-				reg = <0x00000000 DT_SIZE_K(64)>;
+				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			/* Note slot 0 has one additional sector,
-			 * this is intended for use with the swap move algorithm
+			/* The MCUBoot swap-move algorithm uses the last 2 sectors
+			 * of the primary slot0 for swap status and move.
 			 */
-			slot0_partition: partition@10000 {
+			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00010000 (DT_SIZE_M(3) + DT_SIZE_K(4))>;
+				reg = <0x00020000 (DT_SIZE_M(3) + DT_SIZE_K(8))>;
 			};
-			slot1_partition: partition@311000 {
+			slot1_partition: partition@322000 {
 				label = "image-1";
-				reg = <0x00311000 DT_SIZE_M(3)>;
+				reg = <0x00322000 DT_SIZE_M(3)>;
 			};
-			storage_partition: partition@611000 {
+			storage_partition: partition@622000 {
 				label = "storage";
-				reg = <0x00611000 DT_SIZE_K(1980)>;
+				reg = <0x00622000 (DT_SIZE_M(2) - DT_SIZE_K(136))>;
 			};
 		};
 	};

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_hyperflash.overlay
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_hyperflash.overlay
@@ -44,25 +44,24 @@
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
-
 			boot_partition: partition@0 {
 				label = "mcuboot";
-				reg = <0x00000000 DT_SIZE_K(256)>;
+				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			/* Note slot 0 has one additional sector,
-			 * this is intended for use with the swap move algorithm
+			/* The MCUBoot swap-move algorithm uses the last 14 sectors
+			 * of the primary slot0 for swap status and move.
 			 */
-			slot0_partition: partition@40000 {
+			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00040000 (DT_SIZE_M(3) + DT_SIZE_K(4))>;
+				reg = <0x00020000 (DT_SIZE_M(3) + DT_SIZE_K(56))>;
 			};
-			slot1_partition: partition@341000 {
+			slot1_partition: partition@32E000 {
 				label = "image-1";
-				reg = <0x00341000 DT_SIZE_M(3)>;
+				reg = <0x0032E000 DT_SIZE_M(3)>;
 			};
-			storage_partition: partition@641000 {
+			storage_partition: partition@62E000 {
 				label = "storage";
-				reg = <0x00641000 (DT_SIZE_M(57) + DT_SIZE_K(764))>;
+				reg = <0x0062E000 (DT_SIZE_M(58) - DT_SIZE_K(184))>;
 			};
 		};
 	};

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi.overlay
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi.overlay
@@ -34,25 +34,24 @@
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
-
 			boot_partition: partition@0 {
 				label = "mcuboot";
-				reg = <0x00000000 DT_SIZE_K(64)>;
+				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			/* Note slot 0 has one additional sector,
-			 * this is intended for use with the swap move algorithm
+			/* The MCUBoot swap-move algorithm uses the last 2 sectors
+			 * of the primary slot0 for swap status and move.
 			 */
-			slot0_partition: partition@10000 {
+			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00010000 (DT_SIZE_M(3) + DT_SIZE_K(4))>;
+				reg = <0x00020000 (DT_SIZE_M(3) + DT_SIZE_K(8))>;
 			};
-			slot1_partition: partition@311000 {
+			slot1_partition: partition@322000 {
 				label = "image-1";
-				reg = <0x00311000 DT_SIZE_M(3)>;
+				reg = <0x00322000 DT_SIZE_M(3)>;
 			};
-			storage_partition: partition@611000 {
+			storage_partition: partition@622000 {
 				label = "storage";
-				reg = <0x00611000 DT_SIZE_K(1980)>;
+				reg = <0x00622000 (DT_SIZE_M(2) - DT_SIZE_K(136))>;
 			};
 		};
 	};

--- a/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6.dts
+++ b/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6.dts
@@ -206,22 +206,24 @@
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
-
 			boot_partition: partition@0 {
 				label = "mcuboot";
-				reg = <0x00000000 DT_SIZE_K(256)>;
+				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			slot0_partition: partition@40000 {
+			/* The MCUBoot swap-move algorithm uses the last 14 sectors
+			 * of the primary slot0 for swap status and move.
+			 */
+			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00040000 DT_SIZE_M(3)>;
+				reg = <0x00020000 (DT_SIZE_M(3) + DT_SIZE_K(56))>;
 			};
-			slot1_partition: partition@340000 {
+			slot1_partition: partition@32E000 {
 				label = "image-1";
-				reg = <0x00340000 DT_SIZE_M(3)>;
+				reg = <0x0032E000 DT_SIZE_M(3)>;
 			};
-			storage_partition: partition@640000 {
+			storage_partition: partition@62E000 {
 				label = "storage";
-				reg = <0x00640000 (DT_SIZE_M(557) + DT_SIZE_K(768))>;
+				reg = <0x0062E000 (DT_SIZE_M(58) - DT_SIZE_K(184))>;
 			};
 		};
 	};

--- a/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -202,22 +202,22 @@ arduino_i2c: &lpi2c1 {};
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
-
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 DT_SIZE_K(64)>;
+			reg = <0x00000000 DT_SIZE_K(128)>;
 		};
-		/* Note slot 0 has one additional sector,
-		 * this is intended for use with the swap move algorithm
+		/* The MCUBoot swap-move algorithm uses the last 2 sectors
+		 * of the primary slot0 for swap status and move.
 		 */
-		slot0_partition: partition@10000 {
+		slot0_partition: partition@20000 {
 			label = "image-0";
-			reg = <0x00010000 DT_SIZE_K(2016)>;
+			reg = <0x00020000 (DT_SIZE_K(1980) + DT_SIZE_K(8))>;
 		};
-		slot1_partition: partition@208000 {
+		slot1_partition: partition@211000 {
 			label = "image-1";
-			reg = <0x00208000 DT_SIZE_K(2012)>;
+			reg = <0x00211000 DT_SIZE_K(1980)>;
 		};
+		/* The storage partition is located in is25wp064 */
 	};
 };
 


### PR DESCRIPTION
- Optimize slot sizes for MCUBoot swap move algorithm for mimxrt1010/15/20/24/40/50/60/64 boards.
- Save up to 64 wasted sectors.
- Use DT_SIZE_K/M macros for slot sizes.
- Fix partition size errors.
- Limit mcuboot max size to 128KB (was 256KB).