### PR TITLE
MAINTAINERS: Add audio_samples to Bluetooth Audio

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -442,6 +442,7 @@ Bluetooth Audio:
     - include/zephyr/bluetooth/audio/
     - tests/bluetooth/audio/
     - tests/bsim/bluetooth/audio/
+    - tests/bsim/bluetooth/audio_samples/
     - tests/bluetooth/shell/audio.conf
     - tests/bluetooth/tester/overlay-le-audio.conf
     - doc/connectivity/bluetooth/api/audio/


### PR DESCRIPTION
Add the tests/bsim/bluetooth/audio_samples/ directory to the Bluetooth Audio group.