### PR TITLE
tests: drivers: uart: uart_async_api: enable support for lpcxpresso55s69

### DIFF
--- a/boards/nxp/lpcxpresso55s69/lpcxpresso55s69.dtsi
+++ b/boards/nxp/lpcxpresso55s69/lpcxpresso55s69.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NXP
+ * Copyright 2019,2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -107,8 +107,6 @@
 &flexcomm0 {
 	compatible = "nxp,lpc-usart";
 	current-speed = <115200>;
-	dmas = <&dma0 4>, <&dma0 5>;
-	dma-names = "rx", "tx";
 };
 
 &flash0 {

--- a/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0.dts
+++ b/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NXP
+ * Copyright 2019,2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -125,8 +125,6 @@
 
 &hs_lspi {
 	status = "okay";
-	dmas = <&dma0 2>, <&dma0 3>;
-	dma-names = "rx", "tx";
 	cs-gpios = <&gpio1 1 GPIO_ACTIVE_LOW>;
 };
 
@@ -179,8 +177,6 @@ i2s0: &flexcomm6 {
 	compatible = "nxp,lpc-i2s";
 	#address-cells = <1>;
 	#size-cells = <0>;
-	dmas = <&dma0 16>;
-	dma-names = "rx";
 };
 
 /* I2S transmit channel */
@@ -189,8 +185,6 @@ i2s1: &flexcomm7 {
 	compatible = "nxp,lpc-i2s";
 	#address-cells = <1>;
 	#size-cells = <0>;
-	dmas = <&dma0 19>;
-	dma-names = "tx";
 };
 
 &sc_timer {

--- a/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0_ns.dts
+++ b/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0_ns.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NXP
+ * Copyright 2019,2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -85,8 +85,6 @@
 
 &hs_lspi {
 	status = "okay";
-	dmas = <&dma0 2>, <&dma0 3>;
-	dma-names = "rx", "tx";
 };
 
 &wwdt0 {

--- a/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
@@ -229,6 +229,8 @@
 		interrupts = <14 0>;
 		clocks = <&syscon MCUX_FLEXCOMM0_CLK>;
 		resets = <&reset NXP_SYSCON_RESET(1, 11)>;
+		dmas = <&dma0 4>, <&dma0 5>;
+		dma-names = "rx", "tx";
 		status = "disabled";
 	};
 
@@ -238,6 +240,8 @@
 		interrupts = <15 0>;
 		clocks = <&syscon MCUX_FLEXCOMM1_CLK>;
 		resets = <&reset NXP_SYSCON_RESET(1, 12)>;
+		dmas = <&dma0 6 &dma0 7>;
+		dma-names = "rx", "tx";
 		status = "disabled";
 	};
 
@@ -247,6 +251,8 @@
 		interrupts = <16 0>;
 		clocks = <&syscon MCUX_FLEXCOMM2_CLK>;
 		resets = <&reset NXP_SYSCON_RESET(1, 13)>;
+		dmas = <&dma0 10 &dma0 11>;
+		dma-names = "rx", "tx";
 		status = "disabled";
 	};
 
@@ -256,6 +262,8 @@
 		interrupts = <17 0>;
 		clocks = <&syscon MCUX_FLEXCOMM3_CLK>;
 		resets = <&reset NXP_SYSCON_RESET(1, 14)>;
+		dmas = <&dma0 8 &dma0 9>;
+		dma-names = "rx", "tx";
 		status = "disabled";
 	};
 
@@ -265,6 +273,8 @@
 		interrupts = <18 0>;
 		clocks = <&syscon MCUX_FLEXCOMM4_CLK>;
 		resets = <&reset NXP_SYSCON_RESET(1, 15)>;
+		dmas = <&dma0 12 &dma0 13>;
+		dma-names = "rx", "tx";
 		status = "disabled";
 	};
 
@@ -274,6 +284,8 @@
 		interrupts = <19 0>;
 		clocks = <&syscon MCUX_FLEXCOMM5_CLK>;
 		resets = <&reset NXP_SYSCON_RESET(1, 16)>;
+		dmas = <&dma0 14 &dma0 15>;
+		dma-names = "rx", "tx";
 		status = "disabled";
 	};
 
@@ -283,6 +295,8 @@
 		interrupts = <20 0>;
 		clocks = <&syscon MCUX_FLEXCOMM6_CLK>;
 		resets = <&reset NXP_SYSCON_RESET(1, 17)>;
+		dmas = <&dma0 16 &dma0 17>;
+		dma-names = "rx", "tx";
 		status = "disabled";
 	};
 
@@ -292,6 +306,8 @@
 		interrupts = <21 0>;
 		clocks = <&syscon MCUX_FLEXCOMM7_CLK>;
 		resets = <&reset NXP_SYSCON_RESET(1, 18)>;
+		dmas = <&dma0 18 &dma0 19>;
+		dma-names = "rx", "tx";
 		status = "disabled";
 	};
 
@@ -315,6 +331,8 @@
 		interrupts = <59 0>;
 		clocks = <&syscon MCUX_HS_SPI_CLK>;
 		resets = <&reset NXP_SYSCON_RESET(2, 28)>;
+		dmas = <&dma0 2 &dma0 3>;
+		dma-names = "rx", "tx";
 		status = "disabled";
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/tests/drivers/uart/uart_async_api/boards/lpcxpresso55s69_lpc55s69_cpu0.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/lpcxpresso55s69_lpc55s69_cpu0.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Short P18.13 and P18.15 to loopback Flexcomm2 RX/TX for this test */
+dut: &flexcomm2 {
+	status = "okay";
+};


### PR DESCRIPTION
Enable support for running uart async API test on LPCXpresso55s69 EVK. This PR also moves the DMA channel definitions for the LPC55S6x to the SOC level, as the definitions are not board specific