### PR TITLE
tests: i2c_ram: Add fixture for i2c_ram testing

### DIFF
--- a/tests/drivers/i2c/i2c_ram/testcase.yaml
+++ b/tests/drivers/i2c/i2c_ram/testcase.yaml
@@ -4,6 +4,9 @@ common:
     - drivers
     - i2c
   filter: dt_alias_exists("i2c-ram")
+  harness: ztest
+  harness_config:
+    fixture: i2c_ram
 tests:
   drivers.i2c.ram:
     depends_on: i2c


### PR DESCRIPTION
i2c_ram expects that a ram-like part is connected to an i2c bus and therefore requires a hardware fixture setup much like spi_loopback.

Adds a fixture that must be designated when running twister tests on a board with -X i2c_ram.

Fixes #73203 