### PR TITLE
llext: add `pre_located` test

### DIFF
--- a/tests/subsys/llext/simple/CMakeLists.txt
+++ b/tests/subsys/llext/simple/CMakeLists.txt
@@ -23,6 +23,10 @@ if(CONFIG_ARM)
   endif()
 endif()
 
+if (CONFIG_LLEXT_TYPE_ELF_RELOCATABLE AND CONFIG_XTENSA)
+    list(APPEND ext_names pre_located)
+endif()
+
 # generate extension targets foreach extension given by 'ext_names'
 foreach(ext_name ${ext_names})
   set(ext_src ${PROJECT_SOURCE_DIR}/src/${ext_name}_ext.c)
@@ -45,12 +49,15 @@ if(NOT CONFIG_LLEXT_TYPE_ELF_OBJECT)
   )
 endif()
 
-# Add a dummy custom processing command to test add_llext_command
-get_target_property(proc_in_file hello_world_ext lib_output)
-get_target_property(proc_out_file hello_world_ext pkg_input)
-add_llext_command(
-  TARGET hello_world_ext
-  POST_BUILD
-  COMMAND echo "dummy patching ${proc_in_file} to create ${proc_out_file}"
-  COMMAND ${CMAKE_COMMAND} -E copy ${proc_in_file} ${proc_out_file}
-)
+if (CONFIG_LLEXT_TYPE_ELF_RELOCATABLE AND CONFIG_XTENSA)
+  # Manually fix the pre_located extension's text address at a multiple of 4
+  get_target_property(pre_located_target pre_located_ext lib_target)
+  get_target_property(pre_located_file pre_located_ext pkg_input)
+  add_llext_command(
+    TARGET pre_located_ext
+    POST_BUILD
+    COMMAND ${CMAKE_C_COMPILER}
+    -Wl,-r -Wl,-Ttext=0xbada110c -nostdlib -nodefaultlibs -nostartfiles
+    $<TARGET_OBJECTS:${pre_located_target}> -o ${pre_located_file}
+  )
+endif()

--- a/tests/subsys/llext/simple/src/pre_located_ext.c
+++ b/tests/subsys/llext/simple/src/pre_located_ext.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2024 Arduino SA.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * This file contains a simple test extension that defines an entry point
+ * in the .text section. The entry point is never called, but the symbol
+ * address is fixed via a linker call and then checked by the test.
+ */
+
+#include <zephyr/llext/symbol.h>
+
+void test_entry(void)
+{
+	/* This function is never called */
+}
+LL_EXTENSION_SYMBOL(test_entry);


### PR DESCRIPTION
This PR introduces a test for the `pre_located` feature added in #72479, by crafting a special extension that is not supposed to be executed but contains a symbol whose address is manually placed via a custom link step.
This also replaces the current dummy `add_llext_command()` step with an actual use case. 