### PR TITLE
doc: kernel: Tweak pipes documentation

### DIFF
--- a/doc/kernel/services/data_passing/pipes.rst
+++ b/doc/kernel/services/data_passing/pipes.rst
@@ -231,7 +231,7 @@ Configuration Options
 
 Related configuration options:
 
-* CONFIG_PIPES
+* :kconfig:option:`CONFIG_PIPES`
 
 API Reference
 *************

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -704,6 +704,9 @@ config PIPES
 	  allows a thread to send a byte stream to another thread. Pipes can
 	  be used to synchronously transfer chunks of data in whole or in part.
 
+	  Note that setting this option slightly increases the size of the
+	  thread structure.
+
 config KERNEL_MEM_POOL
 	bool "Use Kernel Memory Pool"
 	default y


### PR DESCRIPTION
Updates the pipes documentation to provide a link to the CONFIG_PIPES Kconfig option instead of merely just listing it. This brings the pipes documentation into alignment with other kernel service documentation (such as polling and events) whose features require a Kconfig option to be enabled before the feature can be used.

Fixes #73419