### PR TITLE
riscv: linker: try to use name of register 

### DIFF
--- a/doc/build/dts/macros.bnf
+++ b/doc/build/dts/macros.bnf
@@ -35,6 +35,7 @@ node-macro =/ %s"DT_N" path-id %s"_REG_IDX_" DIGIT
               %s"_VAL_" ( %s"ADDRESS" / %s"SIZE")
 node-macro =/ %s"DT_N" path-id %s"_REG_NAME_" dt-name
               %s"_VAL_" ( %s"ADDRESS" / %s"SIZE")
+node-macro =/ %s"DT_N" path-id %s"_REG_NAME_" dt-name "_EXISTS"
 ; The interrupts property is also special.
 node-macro =/ %s"DT_N" path-id %s"_IRQ_NUM"
 node-macro =/ %s"DT_N" path-id %s"_IRQ_LEVEL"

--- a/include/zephyr/arch/riscv/common/linker.ld
+++ b/include/zephyr/arch/riscv/common/linker.ld
@@ -55,13 +55,18 @@
 
 #elif DT_NODE_HAS_COMPAT(DT_CHOSEN(zephyr_flash), jedec_spi_nor)
 /* For jedec,spi-nor we expect the spi controller to memory map the flash
- * and for that mapping to be the second register property of the spi
- * controller.
+ * and for that mapping to be on the register with the name flash_mmap and if a register with that
+ * name doesn't exists, we expect it to be in the second register property of the spi controller.
  */
 #define SPI_CTRL DT_PARENT(DT_CHOSEN(zephyr_flash))
-#define ROM_BASE (DT_REG_ADDR_BY_IDX(SPI_CTRL, 1) + FLASH_LOAD_OFFSET)
+#define FLASH_MMAP_NAME flash_mmap
+#define ROM_BASE                                                                                   \
+	(DT_REG_ADDR_BY_NAME_OR(SPI_CTRL, FLASH_MMAP_NAME, DT_REG_ADDR_BY_IDX(SPI_CTRL, 1)) +      \
+	 FLASH_LOAD_OFFSET)
 #ifndef ROM_SIZE
-#define ROM_SIZE (DT_REG_SIZE_BY_IDX(SPI_CTRL, 1) - ROM_END_OFFSET)
+#define ROM_SIZE                                                                                   \
+	(DT_REG_SIZE_BY_NAME_OR(SPI_CTRL, FLASH_MMAP_NAME, DT_REG_SIZE_BY_IDX(SPI_CTRL, 1)) -      \
+	 ROM_END_OFFSET)
 #endif
 
 #else /* Use Kconfig to cover the remaining cases */

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -29,7 +29,7 @@
  * @brief devicetree.h API
  * @defgroup devicetree Devicetree
  * @since 2.2
- * @version 1.0.0
+ * @version 1.1.0
  * @{
  * @}
  */
@@ -2203,6 +2203,20 @@
 	IS_ENABLED(DT_CAT4(node_id, _REG_IDX_, idx, _EXISTS))
 
 /**
+ * @brief Is @p name a valid register block name?
+ *
+ * If this returns 1, then DT_REG_ADDR_BY_NAME(node_id, name) or
+ * DT_REG_SIZE_BY_NAME(node_id, name) are valid.
+ * If it returns 0, it is an error to use those macros with name @p name.
+ * @param node_id node identifier
+ * @param name name to check
+ * @return 1 if @p name is a valid register block name,
+ *         0 otherwise.
+ */
+#define DT_REG_HAS_NAME(node_id, name) \
+	IS_ENABLED(DT_CAT4(node_id, _REG_NAME_, name, _EXISTS))
+
+/**
  * @brief Get the base address of the register block at index @p idx
  * @param node_id node identifier
  * @param idx index of the register whose address to return
@@ -2265,6 +2279,18 @@
 	DT_CAT4(node_id, _REG_NAME_, name, _VAL_ADDRESS)
 
 /**
+ * @brief Like DT_REG_ADDR_BY_NAME(), but with a fallback to @p default_value
+ * @param node_id node identifier
+ * @param name lowercase-and-underscores register specifier name
+ * @param default_value a fallback value to expand to
+ * @return address of the register block specified by name if present,
+ *         @p default_value otherwise
+ */
+#define DT_REG_ADDR_BY_NAME_OR(node_id, name, default_value) \
+	COND_CODE_1(DT_REG_HAS_NAME(node_id, name), \
+		    (DT_REG_ADDR_BY_NAME(node_id, name)), (default_value))
+
+/**
  * @brief 64-bit version of DT_REG_ADDR_BY_NAME()
  *
  * This macro version adds the appropriate suffix for 64-bit unsigned
@@ -2287,6 +2313,19 @@
  */
 #define DT_REG_SIZE_BY_NAME(node_id, name) \
 	DT_CAT4(node_id, _REG_NAME_, name, _VAL_SIZE)
+
+/**
+ * @brief Like DT_REG_SIZE_BY_NAME(), but with a fallback to @p default_value
+ * @param node_id node identifier
+ * @param name lowercase-and-underscores register specifier name
+ * @param default_value a fallback value to expand to
+ * @return size of the register block specified by name if present,
+ *         @p default_value otherwise
+ */
+#define DT_REG_SIZE_BY_NAME_OR(node_id, name, default_value) \
+	COND_CODE_1(DT_REG_HAS_NAME(node_id, name), \
+		    (DT_REG_SIZE_BY_NAME(node_id, name)), (default_value))
+
 
 /**
  * @}
@@ -3916,6 +3955,15 @@
 #define DT_INST_REG_HAS_IDX(inst, idx) DT_REG_HAS_IDX(DT_DRV_INST(inst), idx)
 
 /**
+ * @brief is @p name a valid register block name on a `DT_DRV_COMPAT` instance?
+ * @param inst instance number
+ * @param name name to check
+ * @return 1 if @p name is a valid register block name,
+ *         0 otherwise.
+ */
+#define DT_INST_REG_HAS_NAME(inst, name) DT_REG_HAS_NAME(DT_DRV_INST(inst), name)
+
+/**
  * @brief Get a `DT_DRV_COMPAT` instance's idx-th register block's address
  * @param inst instance number
  * @param idx index of the register whose address to return
@@ -3942,6 +3990,17 @@
 	DT_REG_ADDR_BY_NAME(DT_DRV_INST(inst), name)
 
 /**
+ * @brief Like DT_INST_REG_ADDR_BY_NAME(), but with a fallback to @p default_value
+ * @param inst instance number
+ * @param name lowercase-and-underscores register specifier name
+ * @param default_value a fallback value to expand to
+ * @return address of the register block specified by name if present,
+ *         @p default_value otherwise
+ */
+#define DT_INST_REG_ADDR_BY_NAME_OR(inst, name, default_value) \
+	DT_REG_ADDR_BY_NAME_OR(DT_DRV_INST(inst), name, default_value)
+
+/**
  * @brief 64-bit version of DT_INST_REG_ADDR_BY_NAME()
  *
  * This macro version adds the appropriate suffix for 64-bit unsigned
@@ -3964,6 +4023,17 @@
  */
 #define DT_INST_REG_SIZE_BY_NAME(inst, name) \
 	DT_REG_SIZE_BY_NAME(DT_DRV_INST(inst), name)
+
+/**
+ * @brief Like DT_INST_REG_SIZE_BY_NAME(), but with a fallback to @p default_value
+ * @param inst instance number
+ * @param name lowercase-and-underscores register specifier name
+ * @param default_value a fallback value to expand to
+ * @return size of the register block specified by name if present,
+ *         @p default_value otherwise
+ */
+#define DT_INST_REG_SIZE_BY_NAME_OR(inst, name, default_value) \
+	DT_REG_SIZE_BY_NAME_OR(DT_DRV_INST(inst), name, default_value)
 
 /**
  * @brief Get a `DT_DRV_COMPAT`'s (only) register block address

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -416,6 +416,7 @@ def write_regs(node):
             idx_vals.append((idx_macro,
                              f"{reg.addr} /* {hex(reg.addr)} */"))
             if reg.name:
+                name_vals.append((f"{path_id}_REG_NAME_{reg.name}_EXISTS", 1))
                 name_macro = f"{path_id}_REG_NAME_{reg.name}_VAL_ADDRESS"
                 name_vals.append((name_macro, f"DT_{idx_macro}"))
 

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -540,6 +540,11 @@ ZTEST(devicetree_api, test_reg)
 	zassert_true(DT_REG_HAS_IDX(TEST_ABCD1234, 1), "");
 	zassert_false(DT_REG_HAS_IDX(TEST_ABCD1234, 2), "");
 
+	/* DT_REG_HAS_NAME */
+	zassert_true(DT_REG_HAS_NAME(TEST_ABCD1234, one), "");
+	zassert_true(DT_REG_HAS_NAME(TEST_ABCD1234, two), "");
+	zassert_false(DT_REG_HAS_NAME(TEST_ABCD1234, three), "");
+
 	/* DT_REG_ADDR_BY_IDX */
 	zassert_equal(DT_REG_ADDR_BY_IDX(TEST_ABCD1234, 0), 0xabcd1234, "");
 	zassert_equal(DT_REG_ADDR_BY_IDX(TEST_ABCD1234, 1), 0x98765432, "");
@@ -561,6 +566,11 @@ ZTEST(devicetree_api, test_reg)
 	zassert_equal(DT_REG_ADDR_BY_NAME(TEST_ABCD1234, one), 0xabcd1234, "");
 	zassert_equal(DT_REG_ADDR_BY_NAME(TEST_ABCD1234, two), 0x98765432, "");
 
+	/* DT_REG_ADDR_BY_NAME_OR */
+	zassert_equal(DT_REG_ADDR_BY_NAME_OR(TEST_ABCD1234, one, 0x10), 0xabcd1234, "");
+	zassert_equal(DT_REG_ADDR_BY_NAME_OR(TEST_ABCD1234, two, 0x11), 0x98765432, "");
+	zassert_equal(DT_REG_ADDR_BY_NAME_OR(TEST_ABCD1234, three, 0x12), 0x12, "");
+
 	/* DT_REG_ADDR_BY_NAME_U64 */
 	zassert_equal(DT_REG_ADDR_BY_NAME_U64(TEST_ABCD1234, one), 0xabcd1234, "");
 	zassert_equal(DT_REG_ADDR_BY_NAME_U64(TEST_ABCD1234, two), 0x98765432, "");
@@ -569,6 +579,11 @@ ZTEST(devicetree_api, test_reg)
 	zassert_equal(DT_REG_SIZE_BY_NAME(TEST_ABCD1234, one), 0x500, "");
 	zassert_equal(DT_REG_SIZE_BY_NAME(TEST_ABCD1234, two), 0xff, "");
 
+	/* DT_REG_SIZE_BY_NAME_OR */
+	zassert_equal(DT_REG_SIZE_BY_NAME_OR(TEST_ABCD1234, one, 0x10), 0x500, "");
+	zassert_equal(DT_REG_SIZE_BY_NAME_OR(TEST_ABCD1234, two, 0x11), 0xff, "");
+	zassert_equal(DT_REG_SIZE_BY_NAME_OR(TEST_ABCD1234, three, 0x12), 0x12, "");
+
 	/* DT_INST */
 	zassert_equal(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT), 1, "");
 
@@ -576,6 +591,11 @@ ZTEST(devicetree_api, test_reg)
 	zassert_true(DT_INST_REG_HAS_IDX(0, 0), "");
 	zassert_true(DT_INST_REG_HAS_IDX(0, 1), "");
 	zassert_false(DT_INST_REG_HAS_IDX(0, 2), "");
+
+	/* DT_INST_REG_HAS_NAME */
+	zassert_true(DT_INST_REG_HAS_NAME(0, first), "");
+	zassert_true(DT_INST_REG_HAS_NAME(0, second), "");
+	zassert_false(DT_INST_REG_HAS_NAME(0, third), "");
 
 	/* DT_INST_REG_ADDR_BY_IDX */
 	zassert_equal(DT_INST_REG_ADDR_BY_IDX(0, 0), 0x9999aaaa, "");
@@ -598,6 +618,11 @@ ZTEST(devicetree_api, test_reg)
 	zassert_equal(DT_INST_REG_ADDR_BY_NAME(0, first), 0x9999aaaa, "");
 	zassert_equal(DT_INST_REG_ADDR_BY_NAME(0, second), 0xbbbbcccc, "");
 
+	/* DT_INST_REG_ADDR_BY_NAME_OR */
+	zassert_equal(DT_INST_REG_ADDR_BY_NAME_OR(0, first, 0x10), 0x9999aaaa, "");
+	zassert_equal(DT_INST_REG_ADDR_BY_NAME_OR(0, second, 0x11), 0xbbbbcccc, "");
+	zassert_equal(DT_INST_REG_SIZE_BY_NAME_OR(0, third, 0x12), 0x12, "");
+
 	/* DT_INST_REG_ADDR_BY_NAME_U64 */
 	zassert_equal(DT_INST_REG_ADDR_BY_NAME_U64(0, first), 0x9999aaaa, "");
 	zassert_equal(DT_INST_REG_ADDR_BY_NAME_U64(0, second), 0xbbbbcccc, "");
@@ -605,6 +630,11 @@ ZTEST(devicetree_api, test_reg)
 	/* DT_INST_REG_SIZE_BY_NAME */
 	zassert_equal(DT_INST_REG_SIZE_BY_NAME(0, first), 0x1000, "");
 	zassert_equal(DT_INST_REG_SIZE_BY_NAME(0, second), 0x3f, "");
+
+	/* DT_REG_SIZE_BY_NAME_OR */
+	zassert_equal(DT_INST_REG_SIZE_BY_NAME_OR(0, first, 0x10), 0x1000, "");
+	zassert_equal(DT_INST_REG_SIZE_BY_NAME_OR(0, second, 0x11), 0x3f, "");
+	zassert_equal(DT_INST_REG_SIZE_BY_NAME_OR(0, third, 0x12), 0x12, "");
 }
 
 #undef DT_DRV_COMPAT


### PR DESCRIPTION
Instead of always using the second register the SPI controller for memory mapping the jedec,spi-nor flash, use the name of the register. As a fallback, if the a register with that name doesn't exists use the second register.

To be able to add this functionality, this PR also adds DT_REG_HAS_NAME, DT_REG_ADDR_BY_NAME_OR, DT_REG_SIZE_BY_NAME_OR, DT_INST_REG_HAS_NAME, DT_INST_REG_SIZE_BY_NAME_OR and DT_INST_REG_ADDR_BY_NAME_OR. (That is also needed for https://github.com/zephyrproject-rtos/zephyr/pull/73446)