### PR TITLE
twister: tests: kernel: timer_behavior: Extend with stats recording

### DIFF
--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -504,15 +504,54 @@ harness_config: <harness configuration options>
         The regular expression with named subgroups to match data fields
         at the test's output lines where the test provides some custom data
         for further analysis. These records will be written into the build
-        directory 'recording.csv' file as well as 'recording' property
-        of the test suite object in 'twister.json'.
+        directory ``recording.csv`` file as well as ``recording`` property
+        of the test suite object in ``twister.json``.
 
-        For example, to extract three data fields 'metric', 'cycles', 'nanoseconds':
+        For example, to extract three data fields ``metric``, ``cycles``,
+        ``nanoseconds``:
 
         .. code-block:: yaml
 
           record:
             regex: "(?P<metric>.*):(?P<cycles>.*) cycles, (?P<nanoseconds>.*) ns"
+
+      as_json: <list of regex subgroup names> (optional)
+        Data fields, extracted by the regular expression into named subgroups,
+        which will be additionally parsed as JSON encoded strings and written
+        into ``twister.json`` as nested ``recording`` object properties.
+        The corresponding ``recording.csv`` columns will contain strings as-is.
+
+        Using this option, a test log can convey layered data structures
+        passed from the test image for further analysis with summary results,
+        traces, statistics, etc.
+
+        For example, this configuration:
+
+        .. code-block:: yaml
+
+          record:
+            regex: "RECORD:(?P<type>.*):DATA:(?P<metrics>.*)"
+            as_json: [metrics]
+
+        when matched to a test log string:
+
+        .. code-block:: none
+
+          RECORD:jitter_drift:DATA:{"rollovers":0, "mean_us":1000.0}
+
+        will be reported in ``twister.json`` as:
+
+        .. code-block:: json
+
+          "recording":[
+              {
+                   "type":"jitter_drift",
+                   "metrics":{
+                       "rollovers":0,
+                       "mean_us":1000.0
+                   }
+              }
+          ]
 
     fixture: <expression>
         Specify a test case dependency on an external device(e.g., sensor),

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -13,6 +13,7 @@ import logging
 import threading
 import time
 import shutil
+import json
 
 from twisterlib.error import ConfigurationError
 from twisterlib.environment import ZEPHYR_BASE, PYTEST_PLUGIN_INSTALLED
@@ -56,6 +57,7 @@ class Harness:
         self.next_pattern = 0
         self.record = None
         self.record_pattern = None
+        self.record_as_json = None
         self.recording = []
         self.ztest = False
         self.detected_suite_names = []
@@ -81,6 +83,7 @@ class Harness:
             self.record = config.get('record', {})
             if self.record:
                 self.record_pattern = re.compile(self.record.get("regex", ""))
+                self.record_as_json = self.record.get("as_json")
 
     def build(self):
         pass
@@ -91,12 +94,27 @@ class Harness:
         """
         return self.id
 
+    def translate_record(self, record: dict) -> dict:
+        if self.record_as_json:
+            for k in self.record_as_json:
+                if not k in record:
+                    continue
+                try:
+                    record[k] = json.loads(record[k]) if record[k] else {}
+                except json.JSONDecodeError as parse_error:
+                    logger.warning(f"HARNESS:{self.__class__.__name__}: recording JSON failed:"
+                                   f" {parse_error} for '{k}':'{record[k]}'")
+                    # Don't set the Harness state to failed for recordings.
+                    record[k] = { 'ERROR': { 'msg': str(parse_error), 'doc': record[k] } }
+        return record
+
     def parse_record(self, line) -> re.Match:
         match = None
         if self.record_pattern:
             match = self.record_pattern.search(line)
             if match:
-                self.recording.append({ k:v.strip() for k,v in match.groupdict(default="").items() })
+                rec = self.translate_record({ k:v.strip() for k,v in match.groupdict(default="").items() })
+                self.recording.append(rec)
         return match
     #
 

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -354,11 +354,11 @@ class Pytest(Harness):
         if pytest_dut_scope:
             command.append(f'--dut-scope={pytest_dut_scope}')
 
-        if handler.options.verbose > 1:
-            command.extend([
-                '--log-cli-level=DEBUG',
-                '--log-cli-format=%(levelname)s: %(message)s'
-            ])
+        # Always pass output from the pytest test and the test image up to Twister log.
+        command.extend([
+            '--log-cli-level=DEBUG',
+            '--log-cli-format=%(levelname)s: %(message)s'
+        ])
 
         if handler.type_str == 'device':
             command.extend(

--- a/scripts/schemas/twister/testsuite-schema.yaml
+++ b/scripts/schemas/twister/testsuite-schema.yaml
@@ -130,6 +130,11 @@ schema;scenario-schema:
             "regex":
               type: str
               required: true
+            "as_json":
+              type: seq
+              required: false
+              sequence:
+                - type: str
         "bsim_exe_name":
           type: str
           required: false

--- a/tests/kernel/timer/timer_behavior/README
+++ b/tests/kernel/timer/timer_behavior/README
@@ -28,12 +28,12 @@ External tool interface
 In order to get data from the external tool, the test expects a Python module,
 named on testcase.yaml, with the following interface:
 
-    run(seconds: float, options: str) -> {}
+    run(seconds: float, options: str) -> {}, int
 
 The `seconds` parameter defines for how long the data collection is expected
 to run; `options` is a string defined on testcase.yaml with options known to
-the external tool helper module. It should return a dictionary with the
-following statistics, in seconds:
+the external tool helper module. It should return a tuple with a dictionary
+for the following time statistics, in seconds:
 
     'mean':         Mean time of each period
     'stddev':       Standard deviation from the mean time
@@ -41,6 +41,8 @@ following statistics, in seconds:
     'min':          Minimum period registered
     'max':          Maximum period registered
     'total_time':   Total time, between first and last period.
+
+and an integer value of how many data values are collected for the statistics.
 
 Note that the collection may need to go a bit after the "seconds" parameter,
 to account for expected drift in the test and between the DUT and the external

--- a/tests/kernel/timer/timer_behavior/pytest/saleae_logic2.py
+++ b/tests/kernel/timer/timer_behavior/pytest/saleae_logic2.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Intel Corporation
+# Copyright (c) 2023-2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -62,7 +62,7 @@ def do_analysis(output_dir):
     total_time = data[-1]
 
     return {'mean': mean, 'stddev': std, 'var': var, 'min': minimum,
-            'max': maximum, 'total_time': total_time}
+            'max': maximum, 'total_time': total_time}, len(diff)
 
 
 # options should be a string of the format:

--- a/tests/kernel/timer/timer_behavior/pytest/test_timer.py
+++ b/tests/kernel/timer/timer_behavior/pytest/test_timer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Intel Corporation
+# Copyright (c) 2023-2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -11,7 +11,7 @@ from twister_harness import DeviceAdapter
 logger = logging.getLogger(__name__)
 
 
-def do_analysys(test, stats, config, sys_clock_hw_cycles_per_sec):
+def do_analysys(test, stats, stats_count, config, sys_clock_hw_cycles_per_sec):
     logger.info('====================================================')
     logger.info(f'periodic timer behaviour using {test} mechanism:')
 
@@ -52,6 +52,29 @@ def do_analysys(test, stats, config, sys_clock_hw_cycles_per_sec):
     logger.info(f'real drift:     {time_diff * 1_000_000:.6f} us')
     logger.info('====================================================')
 
+    logger.info('RECORD: {'
+                f'"testcase":"jitter_drift_timer"'
+                f', "mechanism":"{test}_external", "stats_count": {stats_count}, ' +
+                ', '.join(['"{}_us":{:.6f}'.format(k, v * 1_000_000) for k,v in stats.items()]) +
+                f', "expected_total_time_us":{seconds * 1_000_000:.6f}'
+                f', "expected_total_drift_us":{seconds * max_drift_ppm:.6f}'
+                f', "total_drift_us": {time_diff * 1_000_000:.6f}'
+                f', "min_bound_us":{min_bound * 1_000_000:.6f}'
+                f', "max_bound_us":{max_bound * 1_000_000:.6f}'
+                f', "expected_period_cycles":{expected_period:.0f}'
+                f', "sys_clock_hw_cycles_per_sec":{sys_clock_hw_cycles_per_sec}, ' +
+                ', '.join(['"CONFIG_{}":{}'.format(k, str(config[k]).rstrip()) for k in [
+                                            'SYS_CLOCK_HW_CYCLES_PER_SEC',
+                                            'SYS_CLOCK_TICKS_PER_SEC',
+                                            'TIMER_TEST_PERIOD',
+                                            'TIMER_TEST_SAMPLES',
+                                            'TIMER_TEST_MAX_STDDEV',
+                                            'TIMER_EXTERNAL_TEST_PERIOD_MAX_DRIFT_PPM',
+                                            'TIMER_EXTERNAL_TEST_MAX_DRIFT_PPM'
+                                                                                 ]
+                          ]) + '}'
+              )
+
     assert stats['stddev'] < max_stddev
     assert stats['min'] >= min_bound
     assert stats['max'] <= max_bound
@@ -73,5 +96,6 @@ def test_flash(dut: DeviceAdapter, tool, tool_options, config,
     tests = ["builtin", "startdelay"]
     for test in tests:
         wait_sync_point(dut, test)
-        stats = tool.run(seconds, tool_options)
-        do_analysys(test, stats, config, sys_clock_hw_cycles_per_sec)
+        stats, stats_count = tool.run(seconds, tool_options)
+        assert stats_count
+        do_analysys(test, stats, stats_count, config, sys_clock_hw_cycles_per_sec)

--- a/tests/kernel/timer/timer_behavior/pytest/test_timer.py
+++ b/tests/kernel/timer/timer_behavior/pytest/test_timer.py
@@ -11,7 +11,7 @@ from twister_harness import DeviceAdapter
 logger = logging.getLogger(__name__)
 
 
-def do_analysys(test, stats, stats_count, config, sys_clock_hw_cycles_per_sec):
+def do_analysis(test, stats, stats_count, config, sys_clock_hw_cycles_per_sec):
     logger.info('====================================================')
     logger.info(f'periodic timer behaviour using {test} mechanism:')
 
@@ -98,7 +98,7 @@ def test_flash(dut: DeviceAdapter, tool, tool_options, config,
         wait_sync_point(dut, test)
         stats, stats_count = tool.run(seconds, tool_options)
         assert stats_count
-        do_analysys(test, stats, stats_count, config, sys_clock_hw_cycles_per_sec)
+        do_analysis(test, stats, stats_count, config, sys_clock_hw_cycles_per_sec)
 
     # Let the running test's image output to be fully captured from device.
     dut.readlines()

--- a/tests/kernel/timer/timer_behavior/pytest/test_timer.py
+++ b/tests/kernel/timer/timer_behavior/pytest/test_timer.py
@@ -99,3 +99,6 @@ def test_flash(dut: DeviceAdapter, tool, tool_options, config,
         stats, stats_count = tool.run(seconds, tool_options)
         assert stats_count
         do_analysys(test, stats, stats_count, config, sys_clock_hw_cycles_per_sec)
+
+    # Let the running test's image output to be fully captured from device.
+    dut.readlines()

--- a/tests/kernel/timer/timer_behavior/src/jitter_drift.c
+++ b/tests/kernel/timer/timer_behavior/src/jitter_drift.c
@@ -126,7 +126,7 @@ static double cycles_to_us(uint64_t cycles)
 /**
  * @brief Test a timers jitter and drift over time
  */
-static void do_test_using(void (*sample_collection_fn)(void))
+static void do_test_using(void (*sample_collection_fn)(void), const char *mechanism)
 {
 	k_timeout_t actual_timeout = K_USEC(CONFIG_TIMER_TEST_PERIOD);
 	uint64_t expected_duration = (uint64_t)actual_timeout.ticks * CONFIG_TIMER_TEST_SAMPLES;
@@ -262,6 +262,51 @@ static void do_test_using(void (*sample_collection_fn)(void))
 		 periodic_start, periodic_end, actual_time_us, expected_time_us,
 		 expected_time_drift_us, time_diff_us);
 
+	/* Record the stats gathered as a JSON object including related CONFIG_* params. */
+	TC_PRINT("RECORD: {"
+		 "\"testcase\":\"jitter_drift_timer\", \"mechanism\":\"%s\""
+		 ", \"stats_count\":%d, \"rollovers\":%d"
+		 ", \"mean_us\":%.6f, \"mean_cycles\":%.0f"
+		 ", \"stddev_us\":%.6f, \"stddev_cycles\":%.0f"
+		 ", \"var_us\":%.6f, \"var_cycles\":%.0f"
+		 ", \"min_us\":%.6f, \"min_cycles\":%llu"
+		 ", \"max_us\":%.6f, \"max_cycles\":%llu"
+		 ", \"timer_start_cycle\": %llu, \"timer_end_cycle\": %llu"
+		 ", \"total_time_us\":%.6f"
+		 ", \"expected_total_time_us\":%.6f"
+		 ", \"expected_total_drift_us\":%.6f"
+		 ", \"total_drift_us\":%.6f"
+		 ", \"expected_period_cycles\":%.0f"
+		 ", \"expected_period_drift_us\":%.6f"
+		 ", \"sys_clock_hw_cycles_per_sec\":%d"
+		 ", \"CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC\":%d"
+		 ", \"CONFIG_SYS_CLOCK_TICKS_PER_SEC\":%d"
+		 ", \"CONFIG_TIMER_TEST_PERIOD\":%d"
+		 ", \"CONFIG_TIMER_TEST_SAMPLES\":%d"
+		 ", \"CONFIG_TIMER_TEST_MAX_STDDEV\":%d"
+		 "}\n",
+		 mechanism,
+		 CONFIG_TIMER_TEST_SAMPLES - periodic_rollovers, periodic_rollovers,
+		 mean_us, mean_cyc,
+		 stddev_us, stddev_cyc,
+		 variance_us, variance_cyc,
+		 min_us, min_cyc,
+		 max_us, max_cyc,
+		 periodic_start, periodic_end,
+		 actual_time_us,
+		 expected_time_us,
+		 expected_time_drift_us,
+		 time_diff_us,
+		 expected_period,
+		 expected_period_drift,
+		 sys_clock_hw_cycles_per_sec(),
+		 CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC,
+		 CONFIG_SYS_CLOCK_TICKS_PER_SEC,
+		 CONFIG_TIMER_TEST_PERIOD,
+		 CONFIG_TIMER_TEST_SAMPLES,
+		 CONFIG_TIMER_TEST_MAX_STDDEV
+		 );
+
 	/* Validate the maximum/minimum timer period is off by no more than 10% */
 	double test_period = (double)CONFIG_TIMER_TEST_PERIOD;
 	double period_max_drift_percentage =
@@ -300,7 +345,7 @@ ZTEST(timer_jitter_drift, test_jitter_drift_timer_period)
 	k_sleep(K_SECONDS(CONFIG_TIMER_EXTERNAL_TEST_SYNC_DELAY));
 	gpio_pin_configure_dt(&timer_out, GPIO_OUTPUT_LOW);
 #endif
-	do_test_using(collect_timer_period_time_samples);
+	do_test_using(collect_timer_period_time_samples, "builtin");
 }
 
 ZTEST(timer_jitter_drift, test_jitter_drift_timer_startdelay)
@@ -314,7 +359,7 @@ ZTEST(timer_jitter_drift, test_jitter_drift_timer_startdelay)
 	k_sleep(K_SECONDS(CONFIG_TIMER_EXTERNAL_TEST_SYNC_DELAY));
 	gpio_pin_configure_dt(&timer_out, GPIO_OUTPUT_LOW);
 #endif
-	do_test_using(collect_timer_startdelay_time_samples);
+	do_test_using(collect_timer_startdelay_time_samples, "startdelay");
 }
 
 ZTEST_SUITE(timer_jitter_drift, NULL, NULL, NULL, NULL, NULL);

--- a/tests/kernel/timer/timer_behavior/src/tick_timer_train.c
+++ b/tests/kernel/timer/timer_behavior/src/tick_timer_train.c
@@ -136,6 +136,23 @@ ZTEST(timer_tick_train, test_one_tick_timer_train)
 			 timers[i].late_callbacks,
 			 (1000 * timers[i].late_callbacks + MAX_CALLBACKS/2) / MAX_CALLBACKS / 10,
 			 (1000 * timers[i].late_callbacks + MAX_CALLBACKS/2) / MAX_CALLBACKS % 10);
+		/* Record the stats gathered as a JSON object including related CONFIG_* params. */
+		TC_PRINT("RECORD: {"
+			 "\"testcase\":\"one_tick_timer_train\""
+			 ", \"timer\":%d, \"max_delta_cycles\":%u, \"max_delta_us\":%u"
+			 ", \"late_callbacks\":%u"
+			 ", \"perfect_delta_cycles\":%u, \"perfect_delta_us\":%u"
+			 ", \"train_time_ms\":%u, \"busy_loops\":%u"
+			 ", \"timers\":%u, \"expected_callbacks\":%u, \"expected_time_ms\":%u"
+			 ", \"CONFIG_SYS_CLOCK_TICKS_PER_SEC\":%u"
+			 "}\n",
+			 i, timers[i].max_delta, k_cyc_to_us_near32(timers[i].max_delta),
+			 timers[i].late_callbacks,
+			 k_ticks_to_cyc_floor32(TIMERS), k_ticks_to_us_near32(TIMERS),
+			 delta_time, busy_loops,
+			 TIMERS, MAX_CALLBACKS, max_time,
+			 CONFIG_SYS_CLOCK_TICKS_PER_SEC
+			 );
 		max_delta = timers[i].max_delta > max_delta ? timers[i].max_delta : max_delta;
 		k_timer_stop(&timers[i].tm);
 	}

--- a/tests/kernel/timer/timer_behavior/testcase.yaml
+++ b/tests/kernel/timer/timer_behavior/testcase.yaml
@@ -8,6 +8,10 @@ tests:
       - mcu
     simulation_exclude:
       - renode
+    harness_config:
+      record:
+        regex: "RECORD:(?P<metrics>.*)"
+        as_json: ['metrics']
   kernel.timer.timer_behavior_external:
     filter: dt_compat_enabled("test-kernel-timer-behavior-external")
     harness: pytest

--- a/tests/kernel/timer/timer_behavior/testcase.yaml
+++ b/tests/kernel/timer/timer_behavior/testcase.yaml
@@ -19,6 +19,9 @@ tests:
       pytest_args: ['--tool', 'saleae_logic2', '--tool-options',
                     'address=127.0.0.1,port=10430,channel=1,sample-rate=6_250_000,threshold-volts=3.3']
       fixture: gpio_timerout
+      record:
+        regex: "RECORD:(?P<metrics>.*)"
+        as_json: ['metrics']
     extra_configs:
       - CONFIG_TIMER_EXTERNAL_TEST=y
       - CONFIG_BOOT_DELAY=5000


### PR DESCRIPTION
Extend `kernel/timer/timer_behavior` test suite with additional logging of the tests statistics gathered for timer drift, variance,
etc. as JSON-formatted records to ease data collection and analysis.

These log records will be processed by the Twister Harness recording feature which captures and parses timer statistics from the log output, then composes it into twister.json and recording.csv files.

The Twister Harness recording feature, as well as Twister Pytest Harness, are also improved to facilitate this change, improve logging, and in general, to allow data fields, extracted from the log by a regular expression, to be treated as a semi-structured JSON data.