### PR TITLE
Use sky13317 antenna switch in Beagleconnect freedom

### DIFF
--- a/boards/beagle/beagleconnect_freedom/beagleconnect_freedom-pinctrl.dtsi
+++ b/boards/beagle/beagleconnect_freedom/beagleconnect_freedom-pinctrl.dtsi
@@ -81,14 +81,18 @@
 	/* On-board antenna pinmux states */
 	board_ant_tx_pa_off: board_ant_tx_pa_off {
 		pinmux = <29 IOC_PORT_GPIO>;
+		bias-disable;
 	};
 	board_ant_tx_pa_on: board_ant_tx_pa_on {
 		pinmux = <29 IOC_PORT_RFC_GPO3>;
+		bias-disable;
 	};
 	board_ant_subg_off: board_ant_subg_off {
 		pinmux = <30 IOC_PORT_GPIO>;
+		bias-disable;
 	};
 	board_ant_subg_on: board_ant_subg_on {
 		pinmux = <30 IOC_PORT_RFC_GPO0>;
+		bias-disable;
 	};
 };

--- a/boards/beagle/beagleconnect_freedom/beagleconnect_freedom.dts
+++ b/boards/beagle/beagleconnect_freedom/beagleconnect_freedom.dts
@@ -42,17 +42,32 @@
 		};
 	};
 
+	/**
+	 * The BeagleConnect Freedom has an on-board antenna switch (SKY13317-373LF) used to select
+	 * the appropriate RF signal port based on the currently-used PHY.
+	 *
+	 * Truth table:
+	 *
+	 * Path         DIO29 DIO30
+	 * ===========  ===== =====
+	 * Off          0     0
+	 * Sub-1 GHz    0     1     // DIO30 mux to IOC_PORT_RFC_GPO0 for auto
+	 * 20 dBm TX    1     0     // DIO29 mux to IOC_PORT_RFC_GPO3 for auto
+	 */
+	antenna_mux0: antenna_mux0 {
+		compatible = "skyworks,sky13317";
+		status = "okay";
+		gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>, <&gpio0 30 GPIO_ACTIVE_HIGH>;
+		pinctrl-0 = <&board_ant_tx_pa_off &board_ant_subg_off>;
+		pinctrl-1 = <&board_ant_tx_pa_off &board_ant_subg_on>;
+		pinctrl-2 = <&board_ant_tx_pa_on &board_ant_subg_on>;
+		pinctrl-names = "default", "ant_subg", "ant_subg_pa";
+	};
+
 	leds: leds {
 		compatible = "gpio-leds";
 		led0: led_0 {
 			gpios = <&gpio0 18 GPIO_ACTIVE_HIGH>; // 2.4GHz TX/RX
-		};
-
-		/* U.FL connector switch */
-		rf_sw: rf_sw {
-			gpios =
-				<&gpio0 29 GPIO_ACTIVE_HIGH>, // SubG TX +20dB
-				<&gpio0 30 GPIO_ACTIVE_HIGH>; // SubG TX/RX 0dB
 		};
 	};
 

--- a/boards/beagle/beagleconnect_freedom/board_antenna.c
+++ b/boards/beagle/beagleconnect_freedom/board_antenna.c
@@ -1,9 +1,9 @@
-/* SPDX-License-Identifier: Apache-2.0
- *
+/*
  * Copyright (c) 2021 Florin Stancu
  * Copyright (c) 2021 Jason Kridner, BeagleBoard.org Foundation
  * Copyright (c) 2024 Ayush Singh <ayush@beagleboard.org>
  *
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 /*
@@ -33,14 +33,13 @@ static int board_antenna_init(const struct device *dev);
 static void board_cc13xx_rf_callback(RF_Handle client, RF_GlobalEvent events, void *arg);
 
 const RFCC26XX_HWAttrsV2 RFCC26XX_hwAttrs = {
-	.hwiPriority        = INT_PRI_LEVEL7,
-	.swiPriority        = 0,
+	.hwiPriority = INT_PRI_LEVEL7,
+	.swiPriority = 0,
 	.xoscHfAlwaysNeeded = true,
 	/* RF driver callback for custom antenna switching */
 	.globalCallback = board_cc13xx_rf_callback,
 	/* Subscribe to events */
-	.globalEventMask = (RF_GlobalEventRadioSetup |
-			RF_GlobalEventRadioPowerDown),
+	.globalEventMask = (RF_GlobalEventRadioSetup | RF_GlobalEventRadioPowerDown),
 };
 
 PINCTRL_DT_INST_DEFINE(0);
@@ -73,7 +72,7 @@ static int board_antenna_init(const struct device *dev)
  */
 static void board_cc13xx_rf_callback(RF_Handle client, RF_GlobalEvent events, void *arg)
 {
-	bool    sub1GHz   = false;
+	bool sub1GHz = false;
 	uint8_t loDivider = 0;
 	int i;
 
@@ -84,17 +83,17 @@ static void board_cc13xx_rf_callback(RF_Handle client, RF_GlobalEvent events, vo
 
 	if (events & RF_GlobalEventRadioSetup) {
 		/* Decode the current PA configuration. */
-		RF_TxPowerTable_PAType paType = (RF_TxPowerTable_PAType)
-			RF_getTxPower(client).paType;
+		RF_TxPowerTable_PAType paType =
+			(RF_TxPowerTable_PAType)RF_getTxPower(client).paType;
 		/* Decode the generic argument as a setup command. */
 		RF_RadioSetup *setupCommand = (RF_RadioSetup *)arg;
 
 		switch (setupCommand->common.commandNo) {
-		case (CMD_RADIO_SETUP):
-		case (CMD_BLE5_RADIO_SETUP):
+		case CMD_RADIO_SETUP:
+		case CMD_BLE5_RADIO_SETUP:
 			loDivider = RF_LODIVIDER_MASK & setupCommand->common.loDivider;
 			break;
-		case (CMD_PROP_RADIO_DIV_SETUP):
+		case CMD_PROP_RADIO_DIV_SETUP:
 			loDivider = RF_LODIVIDER_MASK & setupCommand->prop_div.loDivider;
 			break;
 		default:

--- a/boards/ti/cc1352p1_launchxl/board_antenna.c
+++ b/boards/ti/cc1352p1_launchxl/board_antenna.c
@@ -30,39 +30,31 @@
 #define BOARD_ANT_GPIO_PA    1
 #define BOARD_ANT_GPIO_SUBG  2
 
-#define ANTENNA_MUX DT_NODELABEL(antenna_mux0)
-
 static int board_antenna_init(const struct device *dev);
-static void board_cc13xx_rf_callback(RF_Handle client, RF_GlobalEvent events,
-		void *arg);
+static void board_cc13xx_rf_callback(RF_Handle client, RF_GlobalEvent events, void *arg);
 
 const RFCC26XX_HWAttrsV2 RFCC26XX_hwAttrs = {
-	.hwiPriority        = INT_PRI_LEVEL7,
-	.swiPriority        = 0,
+	.hwiPriority = INT_PRI_LEVEL7,
+	.swiPriority = 0,
 	.xoscHfAlwaysNeeded = true,
 	/* RF driver callback for custom antenna switching */
 	.globalCallback = board_cc13xx_rf_callback,
 	/* Subscribe to events */
-	.globalEventMask = (RF_GlobalEventRadioSetup |
-			RF_GlobalEventRadioPowerDown),
+	.globalEventMask = (RF_GlobalEventRadioSetup | RF_GlobalEventRadioPowerDown),
 };
 
 PINCTRL_DT_INST_DEFINE(0);
-DEVICE_DT_INST_DEFINE(0, board_antenna_init, NULL, NULL, NULL,
-					  POST_KERNEL, CONFIG_BOARD_ANTENNA_INIT_PRIO, NULL);
+DEVICE_DT_INST_DEFINE(0, board_antenna_init, NULL, NULL, NULL, POST_KERNEL,
+		      CONFIG_BOARD_ANTENNA_INIT_PRIO, NULL);
 
 static const struct pinctrl_dev_config *ant_pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0);
 static const struct gpio_dt_spec ant_gpios[] = {
-	GPIO_DT_SPEC_GET_BY_IDX_OR(ANTENNA_MUX, gpios, BOARD_ANT_GPIO_24G, {0}),
-	GPIO_DT_SPEC_GET_BY_IDX_OR(ANTENNA_MUX, gpios, BOARD_ANT_GPIO_PA, {0}),
-	GPIO_DT_SPEC_GET_BY_IDX_OR(ANTENNA_MUX, gpios, BOARD_ANT_GPIO_SUBG, {0}),
-};
-
+	DT_FOREACH_PROP_ELEM_SEP(DT_NODELABEL(antenna_mux0), gpios, GPIO_DT_SPEC_GET_BY_IDX, (,))};
 
 /**
  * Antenna switch GPIO init routine.
  */
-int board_antenna_init(const struct device *dev)
+static int board_antenna_init(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 	int i;
@@ -79,9 +71,9 @@ int board_antenna_init(const struct device *dev)
 /**
  * Custom TI RFCC26XX callback for switching the on-board antenna mux on radio setup.
  */
-void board_cc13xx_rf_callback(RF_Handle client, RF_GlobalEvent events, void *arg)
+static void board_cc13xx_rf_callback(RF_Handle client, RF_GlobalEvent events, void *arg)
 {
-	bool    sub1GHz   = false;
+	bool sub1GHz = false;
 	uint8_t loDivider = 0;
 	int i;
 
@@ -92,8 +84,8 @@ void board_cc13xx_rf_callback(RF_Handle client, RF_GlobalEvent events, void *arg
 
 	if (events & RF_GlobalEventRadioSetup) {
 		/* Decode the current PA configuration. */
-		RF_TxPowerTable_PAType paType = (RF_TxPowerTable_PAType)
-			RF_getTxPower(client).paType;
+		RF_TxPowerTable_PAType paType =
+			(RF_TxPowerTable_PAType)RF_getTxPower(client).paType;
 		/* Decode the generic argument as a setup command. */
 		RF_RadioSetup *setupCommand = (RF_RadioSetup *)arg;
 

--- a/dts/bindings/misc/skyworks,sky13317.yaml
+++ b/dts/bindings/misc/skyworks,sky13317.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) 2022 Stancu Florin
+# Copyright (c) 2024 Ayush Singh, BeagleBoard.org Foundation
 # SPDX-License-Identifier: Apache-2.0
 
 description: Skyworks SKY13317 pHEMT GaAs SP3T Antenna Switch
@@ -11,4 +12,6 @@ properties:
   gpios:
     type: phandle-array
     required: true
-    description: Antenna mux control pins
+    description: Antenna mux control pins. Length 1-3
+  pinctrl-0:
+    required: true


### PR DESCRIPTION
- Use antenna switch sky13317 instead of hack
- Base the board_antenna file on cc1352p1_launchxl/board_antenna.c
- This is a continuation of #72332 , #71403 , but also takes in account that only 2 of the 3 switch pins are connected in beagleconnect freedom.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/71285