### PR TITLE
scripts: kconfig: Add integer arithmetic functions

### DIFF
--- a/tests/kconfig/functions/CMakeLists.txt
+++ b/tests/kconfig/functions/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(kconfig_functions)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/kconfig/functions/Kconfig
+++ b/tests/kconfig/functions/Kconfig
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2022 CSIRO
+
+config KCONFIG_ARITHMETRIC_ADD_10
+	int
+	default $(add, 10)
+
+config KCONFIG_ARITHMETRIC_ADD_10_3
+	int
+	default $(add, 10, 3)
+
+config KCONFIG_ARITHMETRIC_ADD_10_3_2
+	int
+	default $(add, 10, 3, 2)
+
+config KCONFIG_ARITHMETRIC_SUB_10
+	int
+	default $(sub, 10)
+
+config KCONFIG_ARITHMETRIC_SUB_10_3
+	int
+	default $(sub, 10, 3)
+
+config KCONFIG_ARITHMETRIC_SUB_10_3_2
+	int
+	default $(sub, 10, 3, 2)
+
+config KCONFIG_ARITHMETRIC_MUL_10
+	int
+	default $(mul, 10)
+
+config KCONFIG_ARITHMETRIC_MUL_10_3
+	int
+	default $(mul, 10, 3)
+
+config KCONFIG_ARITHMETRIC_MUL_10_3_2
+	int
+	default $(mul, 10, 3, 2)
+
+config KCONFIG_ARITHMETRIC_DIV_10
+	int
+	default $(div, 10)
+
+config KCONFIG_ARITHMETRIC_DIV_10_3
+	int
+	default $(div, 10, 3)
+
+config KCONFIG_ARITHMETRIC_DIV_10_3_2
+	int
+	default $(div, 10, 3, 2)
+
+config KCONFIG_ARITHMETRIC_MOD_10
+	int
+	default $(mod, 10)
+
+config KCONFIG_ARITHMETRIC_MOD_10_3
+	int
+	default $(mod, 10, 3)
+
+config KCONFIG_ARITHMETRIC_MOD_10_3_2
+	int
+	default $(mod, 10, 3, 2)
+
+config KCONFIG_ARITHMETRIC_INC_1
+	int
+	default $(inc, 1)
+
+config KCONFIG_ARITHMETRIC_INC_1_1
+	string
+	default "$(inc, 1, 1)"
+
+config KCONFIG_ARITHMETRIC_INC_INC_1_1
+	string
+	default "$(inc, $(inc, 1, 1))"
+
+config KCONFIG_ARITHMETRIC_DEC_1
+	int
+	default $(dec, 1)
+
+config KCONFIG_ARITHMETRIC_DEC_1_1
+	string
+	default "$(dec, 1, 1)"
+
+config KCONFIG_ARITHMETRIC_DEC_DEC_1_1
+	string
+	default "$(dec, $(dec, 1, 1))"
+
+config KCONFIG_ARITHMETRIC_ADD_INC_1_1
+	int
+	default $(add, $(inc, 1, 1))
+
+source "Kconfig.zephyr"

--- a/tests/kconfig/functions/prj.conf
+++ b/tests/kconfig/functions/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/kconfig/functions/src/arithmetric.c
+++ b/tests/kconfig/functions/src/arithmetric.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2024 TOKITA Hiroshi
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <string.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/ztest.h>
+
+ZTEST(test_kconfig_functions_arithmetric, test_expectedvalues)
+{
+	zassert_equal(CONFIG_KCONFIG_ARITHMETRIC_ADD_10, 10);
+	zassert_equal(CONFIG_KCONFIG_ARITHMETRIC_ADD_10_3, 10 + 3);
+	zassert_equal(CONFIG_KCONFIG_ARITHMETRIC_ADD_10_3_2, 10 + 3 + 2);
+	zassert_equal(CONFIG_KCONFIG_ARITHMETRIC_SUB_10, 10);
+	zassert_equal(CONFIG_KCONFIG_ARITHMETRIC_SUB_10_3, 10 - 3);
+	zassert_equal(CONFIG_KCONFIG_ARITHMETRIC_SUB_10_3_2, 10 - 3 - 2);
+	zassert_equal(CONFIG_KCONFIG_ARITHMETRIC_MUL_10, 10);
+	zassert_equal(CONFIG_KCONFIG_ARITHMETRIC_MUL_10_3, 10 * 3);
+	zassert_equal(CONFIG_KCONFIG_ARITHMETRIC_MUL_10_3_2, 10 * 3 * 2);
+	zassert_equal(CONFIG_KCONFIG_ARITHMETRIC_DIV_10, 10);
+	zassert_equal(CONFIG_KCONFIG_ARITHMETRIC_DIV_10_3, 10 / 3);
+	zassert_equal(CONFIG_KCONFIG_ARITHMETRIC_DIV_10_3_2, 10 / 3 / 2);
+	zassert_equal(CONFIG_KCONFIG_ARITHMETRIC_MOD_10, 10);
+	zassert_equal(CONFIG_KCONFIG_ARITHMETRIC_MOD_10_3, 10 % 3);
+	zassert_equal(CONFIG_KCONFIG_ARITHMETRIC_MOD_10_3_2, 10 % 3 % 2);
+	zassert_equal(CONFIG_KCONFIG_ARITHMETRIC_INC_1, 1 + 1);
+	zassert_str_equal(CONFIG_KCONFIG_ARITHMETRIC_INC_1_1, "2,2");
+	zassert_str_equal(CONFIG_KCONFIG_ARITHMETRIC_INC_INC_1_1, "3,3");
+	zassert_equal(CONFIG_KCONFIG_ARITHMETRIC_DEC_1, 1 - 1);
+	zassert_str_equal(CONFIG_KCONFIG_ARITHMETRIC_DEC_1_1, "0,0");
+	zassert_str_equal(CONFIG_KCONFIG_ARITHMETRIC_DEC_DEC_1_1, "-1,-1");
+	zassert_equal(CONFIG_KCONFIG_ARITHMETRIC_ADD_INC_1_1, (1 + 1) + (1 + 1));
+}
+
+ZTEST_SUITE(test_kconfig_functions_arithmetric, NULL, NULL, NULL, NULL, NULL);

--- a/tests/kconfig/functions/testcase.yaml
+++ b/tests/kconfig/functions/testcase.yaml
@@ -1,0 +1,6 @@
+tests:
+  kconfig.functions:
+    tags: kconfig
+    integration_platforms:
+      - native_sim
+      - native_sim/native/64


### PR DESCRIPTION
Added functions for integer arithmetic operations
(add, subtract, multiple, divide, modulo)

---
Usually, calculations between device tree values ​​are performed in a .c file, but there are cases in which we want the calculation to be completed at the time the macro is defined.
In PR #72050, we tried to create a value based on the CPU frequency defined in the device tree and use that as an argument to the `LISTIFY` macro.
But, since the `LISTIFY` macro concatenates values, the argument given to this macro needs to be a number, not a formula.
A similar problem exists with `COND_CODE_1`, where even values ​​that are statically calculable from devicetree values ​​can be difficult to handle.
This Kconfig extension allows arithmetic operations on device tree values and makes it possible to define values ​​calculated from devicetree values ​​as config macros.