### PR TITLE
Fix/hostap l2 recv unexpected frame

### DIFF
--- a/tests/net/socket/af_packet/src/main.c
+++ b/tests/net/socket/af_packet/src/main.c
@@ -328,7 +328,7 @@ ZTEST(socket_packet, test_packet_sockets_dgram)
 
 	memset(&dst, 0, sizeof(dst));
 	dst.sll_family = AF_PACKET;
-	dst.sll_protocol = htons(ETH_P_IP);
+	dst.sll_protocol = htons(ETH_P_TSN);
 	memcpy(dst.sll_addr, lladdr1, sizeof(lladdr1));
 
 	ret = zsock_sendto(sock2, data_to_send, sizeof(data_to_send), 0,


### PR DESCRIPTION
net: conn: fix supplicant l2 recv unexpected frame
    
    Supplicant create AF_PACKET proto ETH_P_PAE socket but receive other
    frames like ICMP, UDP and causes following issues.
    1. When frame len exceeds MTU, net_pkt_clone cannot clone pkt.
       Thus dropped it and print warning log.
    2. It will lower throughput performance as every packet is cloned.
    
    Fix it by conn_raw_socket does not deliver pkts protocol not macted,
    after l2 processed, unless conn is all packets.

tests: net: socket: af_packet: fix TSN socket recv IP pkt
    
    test_packet_sockets_dgram create ETH_P_TSN sockets but
    send and recv ETH_P_IP packet.
    
    Fix it by sending ETH_P_TSN packet.