### PR TITLE
soc: nordic: Select new nrf54lx compatible kconfig option

### DIFF
--- a/soc/nordic/nrf54l/Kconfig
+++ b/soc/nordic/nrf54l/Kconfig
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config SOC_SERIES_NRF54LX
+	select SOC_COMPATIBLE_NRF54LX
 	select HAS_NRFX
 	select HAS_NORDIC_DRIVERS
 	select HAS_SEGGER_RTT if ZEPHYR_SEGGER_MODULE


### PR DESCRIPTION
Select the newly introduced nrf54lx compatible kconfig option.

This is common both for real HW and for simulated HW, allowing SW to behave appropriately for both.