### PR TITLE
tests: llext: exclude apollo4 platform

### DIFF
--- a/tests/subsys/llext/simple/testcase.yaml
+++ b/tests/subsys/llext/simple/testcase.yaml
@@ -4,6 +4,8 @@ common:
     - arm
     - xtensa
   platform_exclude:
+    - apollo4p_evb
+    - apollo4p_blue_kxr_evb
     - numaker_pfm_m487 # See #63167
     - qemu_cortex_r5 # unsupported relocations
 


### PR DESCRIPTION
Exclude the Apollo4 platform from LLEXT tests for now, as they currently break CI due to #72775.
Fast-tracking a commit by @mathieuchopstm from #72358 as it applies to many outstanding LLEXT PRs.