### PR TITLE
modules: lvgl: fix pointer input for normal orientation

### DIFF
--- a/modules/lvgl/input/lvgl_pointer_input.c
+++ b/modules/lvgl/input/lvgl_pointer_input.c
@@ -89,6 +89,7 @@ static void lvgl_pointer_process_event(const struct device *dev, struct input_ev
 	case DISPLAY_ORIENTATION_NORMAL:
 		point->x = tmp_point.x;
 		point->y = tmp_point.y;
+		break;
 	case DISPLAY_ORIENTATION_ROTATED_90:
 		point->x = tmp_point.y;
 		point->y = cap->y_resolution - tmp_point.x;


### PR DESCRIPTION
After #73300 the input for normal orientation doesn't function as expected.

The issue is that the `DISPLAY_ORIENTATION_NORMAL` is treated as `DISPLAY_ORIENTATION_ROTATED_90`.

This PR adds the missing `break` statement.