### PR TITLE
fs: Fix null pointer exception caused by async fs_unmount

### DIFF
--- a/subsys/fs/fs.c
+++ b/subsys/fs/fs.c
@@ -791,9 +791,6 @@ int fs_unmount(struct fs_mount_t *mp)
 		goto unmount_err;
 	}
 
-	/* clear file system interface */
-	mp->fs = NULL;
-
 	/* remove mount node from the list */
 	sys_dlist_remove(&mp->node);
 	LOG_DBG("fs unmounted from %s", mp->mnt_point);


### PR DESCRIPTION
If fs_unmount is invoked while fs i/o is ongoing then it will cause a NULL pointer exception due to the unchecked and unprotected dereference of the fs pointer.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/73501