### PR TITLE
doc: update migration guide and release notes for PRs #71827 and #72243

### DIFF
--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -90,17 +90,26 @@ Mbed TLS
 * TLS 1.2, RSA, AES, DES, and all the hash algorithms except SHA-256
   (SHA-224, SHA-384, SHA-512, MD5 and SHA-1) are not enabled by default anymore.
   Their respective Kconfig options now need to be explicitly enabled to be able to use them.
-* The Kconfig options previously named `CONFIG_MBEDTLS_MAC_*_ENABLED` have been renamed.
-  The `_MAC` and `_ENABLED` parts have been removed from their names.
+  (:github:`72078`)
+* The Kconfig options previously named ``CONFIG_MBEDTLS_MAC_*_ENABLED`` have been renamed.
+  The ``_MAC`` and ``_ENABLED`` parts have been removed from their names. (:github:`73267`)
 * The :kconfig:option:`CONFIG_MBEDTLS_HASH_ALL_ENABLED` Kconfig option has been fixed to actually
   enable all the available hash algorithms. Previously, it used to only enable the SHA-2 ones.
-* The `CONFIG_MBEDTLS_HASH_SHA*_ENABLED` Kconfig options have been removed. They were duplicates
-  of other Kconfig options which are now named `CONFIG_MBEDTLS_SHA*`.
-* The `CONFIG_MBEDTLS_MAC_ALL_ENABLED` Kconfig option has been removed. Its equivalent is the
+  (:github:`73267`)
+* The ``CONFIG_MBEDTLS_HASH_SHA*_ENABLED`` Kconfig options have been removed. They were duplicates
+  of other Kconfig options which are now named ``CONFIG_MBEDTLS_SHA*``. (:github:`73267`)
+* The ``CONFIG_MBEDTLS_MAC_ALL_ENABLED`` Kconfig option has been removed. Its equivalent is the
   combination of :kconfig:option:`CONFIG_MBEDTLS_HASH_ALL_ENABLED` and :kconfig:option:`CONFIG_MBEDTLS_CMAC`.
+  (:github:`73267`)
 * The Kconfig options ``CONFIG_MBEDTLS_MAC_MD4_ENABLED``, ``CONFIG_MBEDTLS_CIPHER_ARC4_ENABLED``
   and ``CONFIG_MBEDTLS_CIPHER_BLOWFISH_ENABLED`` were removed because they are no more supported
   in Mbed TLS. (:github:`73222`)
+* When there is any PSA crypto provider available in the system
+  (i.e. :kconfig:option:`CONFIG_MBEDTLS_PSA_CRYPTO_CLIENT` is set), desired PSA crypto
+  features must be explicitly enabled using proper ``CONFIG_PSA_WANT_*``. (:github:`72243`)
+* TLS/X509/PK/MD modules will use PSA crypto APIs instead of legacy ones as soon
+  as there is any PSA crypto provider available in the system
+  (i.e. :kconfig:option:`CONFIG_MBEDTLS_PSA_CRYPTO_CLIENT` is set). (:github:`72243`)
 
 MCUboot
 =======
@@ -555,6 +564,12 @@ Networking
   socket calls. Linux expects the protocol field to be ``htons(ETH_P_ALL)`` if it is desired
   to receive all the network packets. See details in
   https://www.man7.org/linux/man-pages/man7/packet.7.html documentation. (:github:`73338`)
+
+* TCP now uses SHA-256 instead of MD5 for ISN generation. The crypto support for
+  this hash computation was also changed from Mbed TLS to PSA APIs. This was achieved
+  by making :kconfig:option:`CONFIG_NET_TCP_ISN_RFC6528` depend on
+  :kconfig:option:`PSA_WANT_ALG_SHA_256` instead of legacy ``CONFIG_MBEDTLS_*``
+  features. (:github:`71827`)
 
 Other Subsystems
 ****************

--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -424,6 +424,11 @@ Networking
 
   * Removed IPSP support. ``CONFIG_NET_L2_BT`` does not exist anymore.
 
+* TCP:
+
+  * ISN generation now uses SHA-256 instead of MD5. Moreover it now relies on PSA APIs
+    instead of legacy Mbed TLS functions for hash computation.
+
 USB
 ***
 
@@ -478,6 +483,14 @@ Libraries / Subsystems
 
   * Mbed TLS was updated to 3.6.0. Release notes can be found at:
     https://github.com/Mbed-TLS/mbedtls/releases/tag/v3.6.0
+  * When any PSA crypto provider is available in the system
+    (:kconfig:option:`CONFIG_MBEDTLS_PSA_CRYPTO_CLIENT` is enabled), desired PSA features
+    must now be explicitly selected through ``CONFIG_PSA_WANT_xxx`` symbols.
+  * Choice symbols :kconfig:option:`CONFIG_MBEDTLS_PSA_CRYPTO_LEGACY_RNG` and
+    :kconfig:option:`CONFIG_MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG` were added in order
+    to allow the user to specify how Mbed TLS PSA crypto core should generate random numbers.
+    The former option, which is the default, relies on legacy entropy and CTR_DRBG/HMAC_DRBG
+    modules, while the latter relies on CSPRNG drivers.
 
 * Random
 


### PR DESCRIPTION
This PR just updates `migration-guide` and `release-notes` documents for following already merged PRs:

- #71827 
- #72243 