### PR TITLE
drivers: clock_control: nrf_auxpll: add lock timeout

### DIFF
--- a/drivers/clock_control/clock_control_nrf_auxpll.c
+++ b/drivers/clock_control/clock_control_nrf_auxpll.c
@@ -5,16 +5,23 @@
 
 #define DT_DRV_COMPAT nordic_nrf_auxpll
 
+#include <errno.h>
 #include <stdint.h>
 
 #include <zephyr/arch/cpu.h>
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>
 
 #include <hal/nrf_auxpll.h>
+
+/* maximum lock time in ms, >10x time observed experimentally */
+#define AUXPLL_LOCK_TIME_MAX_MS  20
+/* lock wait step in ms*/
+#define AUXPLL_LOCK_WAIT_STEP_MS 1
 
 struct clock_control_nrf_auxpll_config {
 	NRF_AUXPLL_Type *auxpll;
@@ -28,15 +35,22 @@ struct clock_control_nrf_auxpll_config {
 static int clock_control_nrf_auxpll_on(const struct device *dev, clock_control_subsys_t sys)
 {
 	const struct clock_control_nrf_auxpll_config *config = dev->config;
+	bool locked;
+	unsigned int wait = 0U;
 
 	ARG_UNUSED(sys);
 
 	nrf_auxpll_task_trigger(config->auxpll, NRF_AUXPLL_TASK_START);
 
-	while (!nrf_auxpll_mode_locked_check(config->auxpll)) {
-	}
+	do {
+		locked = nrf_auxpll_mode_locked_check(config->auxpll);
+		if (!locked) {
+			k_msleep(AUXPLL_LOCK_WAIT_STEP_MS);
+			wait += AUXPLL_LOCK_WAIT_STEP_MS;
+		}
+	} while (wait < AUXPLL_LOCK_TIME_MAX_MS && !locked);
 
-	return 0;
+	return locked ? 0 : -ETIMEDOUT;
 }
 
 static int clock_control_nrf_auxpll_off(const struct device *dev, clock_control_subsys_t sys)


### PR DESCRIPTION
This patch adds a timeout to the clock_control_on() implementation. The reason for this timeout is to prevent system freezes when the PLL is configured incorrectly, or, if BICR is wrong. The locking time of the AUXPLL is <30us, however, when it starts it also starts other dependencies which take much longer to become ready. The locking time has been experimentally measured to be around 2ms, so a 10x bound has been added.