### PR TITLE
drivers: eeprom: atmel,at2x: improve devicetree bindings + Kconfig descriptions

### DIFF
--- a/boards/intel/socfpga_std/cyclonev_socdk/cyclonev_socdk.dts
+++ b/boards/intel/socfpga_std/cyclonev_socdk/cyclonev_socdk.dts
@@ -63,7 +63,7 @@
 			status = "okay";
 
 			eeprom: eeprom@51 {
-				compatible = "atmel,at24";
+				compatible = "microchip,at24lc32a", "atmel,at24";
 				status = "okay";
 				reg = <0x51>;
 				size = <4096>;

--- a/boards/lairdconnect/bl5340_dvk/bl5340_dvk_nrf5340_cpuapp_common.dtsi
+++ b/boards/lairdconnect/bl5340_dvk/bl5340_dvk_nrf5340_cpuapp_common.dtsi
@@ -152,7 +152,7 @@
 	pinctrl-1 = <&i2c1_sleep>;
 	pinctrl-names = "default", "sleep";
 	at24c256@50 {
-		compatible = "atmel,at24";
+		compatible = "atmel,at24c256", "atmel,at24";
 		reg = <0x50>;
 		size = <32768>;
 		pagesize = <64>;

--- a/boards/shields/lmp90100_evb/lmp90100_evb.overlay
+++ b/boards/shields/lmp90100_evb/lmp90100_evb.overlay
@@ -32,7 +32,7 @@
 	status = "okay";
 
 	eeprom0_lmp90100_evb: eeprom@57 {
-		compatible = "atmel,at24";
+		compatible = "atmel,at24c02", "atmel,at24";
 		reg = <0x57>;
 		size = <256>;
 		pagesize = <8>;

--- a/boards/shields/x_nucleo_eeprma2/x_nucleo_eeprma2.overlay
+++ b/boards/shields/x_nucleo_eeprma2/x_nucleo_eeprma2.overlay
@@ -20,7 +20,7 @@
 
 	eeprom0_x_nucleo_eeprma2: eeprom@54 {
 		/* M24C02-FMC6TG aka U1 (2 kbit eeprom in DFN8 package) */
-		compatible = "st,m24xxx", "atmel,at24";
+		compatible = "st,m24c02", "st,m24xxx", "atmel,at24";
 		reg = <0x54>;
 		size = <256>;
 		pagesize = <16>;
@@ -33,7 +33,7 @@
 
 	eeprom1_x_nucleo_eeprma2: eeprom@55 {
 		/* M24256-DFDW6TP aka U2 (256 kbit eeprom in TSSOP package) */
-		compatible = "st,m24xxx", "atmel,at24";
+		compatible = "st,m24256", "st,m24xxx", "atmel,at24";
 		reg = <0x55>;
 		size = <DT_SIZE_K(32)>;
 		pagesize = <64>;
@@ -46,7 +46,7 @@
 
 	eeprom2_x_nucleo_eeprma2: eeprom@56 {
 		/* M24M01-DFMN6TP aka U3 (1 Mbit eeprom in SO8N package) */
-		compatible = "st,m24xxx", "atmel,at24";
+		compatible = "st,m24m01", "st,m24xxx", "atmel,at24";
 		reg = <0x56>;
 		size = <DT_SIZE_K(128)>;
 		pagesize = <256>;
@@ -82,7 +82,7 @@
 
 	eeprom4_x_nucleo_eeprma2: eeprom_m95040@0 {
 		/* M95040-RMC6TG aka U5 (4 kbit eeprom in DFN8 package) */
-		compatible = "st,m95xxx", "atmel,at25";
+		compatible = "st,m95040", "st,m95xxx", "atmel,at25";
 		reg = <0x00>;
 		size = <512>;
 		pagesize = <16>;
@@ -96,7 +96,7 @@
 
 	eeprom5_x_nucleo_eeprma2: eeprom_m95256@1 {
 		/* M95256-DFDW6TP aka U6 (256 kbit eeprom in TSSOP package) */
-		compatible = "st,m95xxx", "atmel,at25";
+		compatible = "st,m95256", "st,m95xxx", "atmel,at25";
 		reg = <0x01>;
 		size = <DT_SIZE_K(32)>;
 		pagesize = <64>;
@@ -110,7 +110,7 @@
 
 	eeprom6_x_nucleo_eeprma2: eeprom_m95m04@2 {
 		/* M95M04-DRMN6TP aka U7 (4 Mbit eeprom in SON8 package) */
-		compatible = "st,m95xxx", "atmel,at25";
+		compatible = "st,m95m04", "st,m95xxx", "atmel,at25";
 		reg = <0x02>;
 		size = <DT_SIZE_K(512)>;
 		pagesize = <512>;

--- a/drivers/eeprom/Kconfig
+++ b/drivers/eeprom/Kconfig
@@ -64,22 +64,36 @@ config EMUL_EEPROM_AT2X
 	  [DEPRECATED] Select EEPROM_AT2X_EMUL instead.
 
 config EEPROM_AT24
-	bool "Atmel AT24 (and compatible) I2C EEPROM support"
+	bool "I2C EEPROMs compatible with Atmel's AT24 family"
 	default y
 	depends on DT_HAS_ATMEL_AT24_ENABLED
 	select I2C
 	select EEPROM_AT2X
 	help
-	  Enable support for Atmel AT24 (and compatible) I2C EEPROMs.
+	  Enable support for I2C EEPROMs compatible with Atmel's AT24 family.
+
+	  There are multiple vendors manufacturing I2C EEPROMs compatible with
+	  the programming model of the Atmel AT24.
+
+	  Examples of compatible EEPROM families:
+	  - Microchip AT24xxx
+	  - ST M24xxx
 
 config EEPROM_AT25
-	bool "Atmel AT25 (and compatible) SPI EEPROM support"
+	bool "SPI EEPROMs compatibile with Atmel's AT25 family"
 	default y
 	depends on DT_HAS_ATMEL_AT25_ENABLED
 	select SPI
 	select EEPROM_AT2X
 	help
-	  Enable support for Atmel AT25 (and compatible) SPI EEPROMs.
+	  Enable support for SPI EEPROMs compatible with Atmel's AT25 family.
+
+	  There are multiple vendors manufacturing SPI EEPROMs compatible with
+	  the programming model of the Atmel AT25.
+
+	  Examples of compatible EEPROM families:
+	  - Microchip AT25xxx
+	  - ST M95xxx
 
 config EEPROM_AT2X_INIT_PRIORITY
 	int "AT2X EEPROM init priority"

--- a/dts/bindings/mtd/atmel,at24.yaml
+++ b/dts/bindings/mtd/atmel,at24.yaml
@@ -2,7 +2,36 @@
 # Copyright (c) 2018, Nordic Semiconductor
 # SPDX-License-Identifier: Apache-2.0
 
-description: Atmel AT24 (or compatible) I2C EEPROM
+description: |
+  I2C EEPROMs compatible with Atmel's AT24 family
+
+  There are multiple vendors manufacturing I2C EEPROMs compatible with the programming model of the
+  Atmel AT24.
+
+  Examples of compatible EEPROM families:
+  - Microchip AT24xxx
+  - ST M24xxx
+
+  Each of these can be represented by a set of common parameters (EEPROM size, page size, address
+  width, and timeout) available from the datasheet of the specific EEPROM. The compatible string for
+  these can list the specific EEPROM vendor and model along with the vendor EEPROM family as long as
+  the least-specific compatible entry is "atmel,at24".
+
+  Example devicetree node describing a ST M24M01 EEPROM on the i2c0 bus:
+
+    &i2c0 {
+      status = "okay";
+      clock-frequency = <I2C_BITRATE_FAST>;
+
+      eeprom@56 {
+        compatible = "st,m24m01", "st,m24xxx", "atmel,at24";
+        reg = <0x56>;
+        size = <DT_SIZE_K(128)>;
+        pagesize = <256>;
+        address-width = <16>;
+        timeout = <5>;
+     };
+   };
 
 compatible: "atmel,at24"
 

--- a/dts/bindings/mtd/atmel,at25.yaml
+++ b/dts/bindings/mtd/atmel,at25.yaml
@@ -1,7 +1,36 @@
 # Copyright (c) 2019 Vestas Wind Systems A/S
 # SPDX-License-Identifier: Apache-2.0
 
-description: Atmel AT25 (or compatible) SPI EEPROM
+description: |
+  SPI EEPROMs compatible with Atmel's AT25 family
+
+  There are multiple vendors manufacturing SPI EEPROMs compatible with the programming model of the
+  Atmel AT25.
+
+  Examples of compatible EEPROM families:
+  - Microchip AT25xxx
+  - ST M95xxx
+
+  Each of these can be represented by a set of common parameters (EEPROM size, page size, address
+  width, and timeout) available from the datasheet of the specific EEPROM. The compatible string for
+  these can list the specific EEPROM vendor and model along with the vendor EEPROM family as long as
+  the least-specific compatible entry is "atmel,at25".
+
+  Example devicetree node describing a ST M95256 EEPROM on the spi0 bus:
+
+    &spi0 {
+      status = "okay";
+
+      eeprom@1 {
+        compatible = "st,m95256", "st,m95xxx", "atmel,at25";
+        reg = <0x1>;
+        size = <DT_SIZE_K(32)>;
+        pagesize = <64>;
+        address-width = <16>;
+        spi-max-frequency = <DT_FREQ_M(20)>;
+        timeout = <5>;
+      };
+   };
 
 compatible: "atmel,at25"
 


### PR DESCRIPTION
Improve the devicetree binding and Kconfig descriptions for the atmel,at24 and atmel,at25 EEPROM compatibles. These compatibles work for a number of different EEPROM families manufactured by vendors other than Atmel.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>