### PR TITLE
fs: fcb: correct `FCB_MAX_LEN` boundary check and refactor `fcb_get_len()`

### DIFF
--- a/include/zephyr/fs/fcb.h
+++ b/include/zephyr/fs/fcb.h
@@ -37,7 +37,7 @@ extern "C" {
  * @{
  */
 
-#define FCB_MAX_LEN	(CHAR_MAX | CHAR_MAX << 7) /**< Max length of element */
+#define FCB_MAX_LEN	(0x3fffu) /**< Max length of element (16,383) */
 
 /**
  * @brief FCB entry info structure. This data structure describes the element

--- a/subsys/fs/fcb/fcb.c
+++ b/subsys/fs/fcb/fcb.c
@@ -223,7 +223,7 @@ fcb_put_len(const struct fcb *fcb, uint8_t *buf, uint16_t len)
 	if (len < 0x80) {
 		buf[0] = len ^ ~fcb->f_erase_value;
 		return 1;
-	} else if (len < FCB_MAX_LEN) {
+	} else if (len <= FCB_MAX_LEN) {
 		buf[0] = (len | 0x80) ^ ~fcb->f_erase_value;
 		buf[1] = (len >> 7) ^ ~fcb->f_erase_value;
 		return 2;

--- a/subsys/fs/fcb/fcb.c
+++ b/subsys/fs/fcb/fcb.c
@@ -236,16 +236,21 @@ int
 fcb_get_len(const struct fcb *fcb, uint8_t *buf, uint16_t *len)
 {
 	int rc;
-	if ((buf[0] ^ ~fcb->f_erase_value) & 0x80) {
+	uint8_t buf0_xor;
+	uint8_t buf1_xor;
+
+	buf0_xor = buf[0] ^ ~fcb->f_erase_value;
+	if (buf0_xor & 0x80) {
 		if ((buf[0] == fcb->f_erase_value) &&
 		    (buf[1] == fcb->f_erase_value)) {
 			return -ENOTSUP;
 		}
-		*len = ((buf[0] ^ ~fcb->f_erase_value) & 0x7f) |
-			((uint8_t)(buf[1] ^ ~fcb->f_erase_value) << 7);
+
+		buf1_xor = buf[1] ^ ~fcb->f_erase_value;
+		*len = (uint16_t)((buf0_xor & 0x7f) | ((uint16_t)buf1_xor << 7));
 		rc = 2;
 	} else {
-		*len = (uint8_t)(buf[0] ^ ~fcb->f_erase_value);
+		*len = (uint16_t)(buf0_xor);
 		rc = 1;
 	}
 	return rc;


### PR DESCRIPTION
Two commits in this PR as followings:

- correct `FCB_MAX_LEN` boundary condition
  Fixes #73868
- refactor `fcb_get_len()` for improved readability
