### PR TITLE
net: http_server: Send chunked response correctly

### DIFF
--- a/subsys/net/lib/http/http_server_http1.c
+++ b/subsys/net/lib/http/http_server_http1.c
@@ -96,13 +96,13 @@ static int handle_http1_static_resource(
 			   sizeof("xxxx") +				\
 			   sizeof("\r\n")];				\
 	snprintk(http_response, sizeof(http_response),			\
-		 _template "\r\n",					\
+		 _template,						\
 		 "Content-Type: ",					\
 		 _content_type == NULL ?				\
 		 "text/html" : _content_type);				\
 	ret = http_server_sendall(client, http_response,		\
 				  strnlen(http_response,		\
-					  sizeof(_template) - 1));	\
+					  sizeof(http_response) - 1));	\
 	ret; })
 
 static int dynamic_get_req(struct http_resource_detail_dynamic *dynamic_detail,


### PR DESCRIPTION
The chunked response was not sent properly. There were extra "\r\n" before the chunk lenght and the length of the string to be sent was calculated incorrectly.

Fixes #72887