### PR TITLE
intel_adsp/ace: power: fix address space annotation for powerdown

### DIFF
--- a/soc/intel/intel_adsp/ace/power.c
+++ b/soc/intel/intel_adsp/ace/power.c
@@ -72,8 +72,8 @@ __imr void power_init(void)
  * (each bit corresponds to one ebb)
  * @param response_to_ipc       flag if ipc response should be send during power down
  */
-extern void power_down(bool disable_lpsram, uint32_t *hpsram_pg_mask,
-			   bool response_to_ipc);
+extern void power_down(bool disable_lpsram, uint32_t __sparse_cache * hpsram_pg_mask,
+		       bool response_to_ipc);
 
 #ifdef CONFIG_ADSP_IMR_CONTEXT_SAVE
 /**


### PR DESCRIPTION
power_down() expects a cached pointer. Fix the sparse annotation to match the implementation (sys_cache_cached_ptr_get() returns a cached pointer so this is correct).

Fixes: f54232e9124d ("intel_adsp/ace: power: Do not re-implement cache func")