### PR TITLE
net: coap: Block-Wise response NUM field fix

### DIFF
--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -1286,7 +1286,9 @@ int coap_append_block1_option(struct coap_packet *cpkt,
 		SET_NUM(val, ctx->current / bytes);
 	} else {
 		SET_BLOCK_SIZE(val, ctx->block_size);
-		SET_NUM(val, ctx->current / bytes);
+		if (ctx->current > bytes) {
+			SET_NUM(val, (ctx->current - 1) / bytes);
+		}
 	}
 
 	r = coap_append_option_int(cpkt, COAP_OPTION_BLOCK1, val);


### PR DESCRIPTION
In CoAP Block-Wise, as per RFC
    A Block1 Option in control usage in a response (e.g., a 2.xx
    response for a PUT or POST request):
    The NUM field of the Block1 Option indicates what block number
    is being acknowledged.

Change the NUM field calculation on responses, so instead of pointing to beginning of next block (bytes_downloaded/block_size), we should point to current block.

This has been reported internally, but Zephyr issue number does not exist yet.
As of today, Leshan seem to ignore the NUM field from the responses, but AVSystem Coiote does not. So we are broken against Coiote.
