### PR TITLE
Bluetooth: Mesh: Fix PB GATT adv name

### DIFF
--- a/subsys/bluetooth/mesh/pb_gatt_srv.c
+++ b/subsys/bluetooth/mesh/pb_gatt_srv.c
@@ -226,26 +226,27 @@ static size_t gatt_prov_adv_create(struct bt_data prov_sd[2])
 	sys_put_be16(prov->oob_info, prov_svc_data + 18);
 
 	if (!prov->uri) {
-		return 0;
+		goto dev_name;
 	}
 
 	uri_len = strlen(prov->uri);
 	if (uri_len > 29) {
 		/* There's no way to shorten an URI */
 		LOG_WRN("Too long URI to fit advertising packet");
-		return 0;
+		goto dev_name;
 	}
 
-	prov_sd[0].type = BT_DATA_URI;
-	prov_sd[0].data_len = uri_len;
-	prov_sd[0].data = (const uint8_t *)prov->uri;
+	prov_sd[prov_sd_len].type = BT_DATA_URI;
+	prov_sd[prov_sd_len].data_len = uri_len;
+	prov_sd[prov_sd_len].data = (const uint8_t *)prov->uri;
 
 	prov_sd_len += 1;
 
+dev_name:
 #if defined(CONFIG_BT_MESH_PB_GATT_USE_DEVICE_NAME)
-	prov_sd[1].type = BT_DATA_NAME_COMPLETE;
-	prov_sd[1].data_len = sizeof(CONFIG_BT_DEVICE_NAME) - 1;
-	prov_sd[1].data = CONFIG_BT_DEVICE_NAME;
+	prov_sd[prov_sd_len].type = BT_DATA_NAME_COMPLETE;
+	prov_sd[prov_sd_len].data_len = sizeof(CONFIG_BT_DEVICE_NAME) - 1;
+	prov_sd[prov_sd_len].data = CONFIG_BT_DEVICE_NAME;
 
 	prov_sd_len += 1;
 #endif


### PR DESCRIPTION
Fixes issue where PB GATT Server will drop
advertising device name if optional provisioning
URI is not provided.