### PR TITLE
Bluetooth: Add support for Path Loss Monitoring feature

### DIFF
--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -675,6 +675,26 @@ struct bt_hci_cp_le_set_tx_power_report_enable {
 	uint8_t  remote_enable;
 } __packed;
 
+struct bt_hci_cp_le_set_path_loss_reporting_parameters {
+	uint16_t handle;
+	uint8_t  high_threshold;
+	uint8_t  high_hysteresis;
+	uint8_t  low_threshold;
+	uint8_t  low_hysteresis;
+	uint16_t min_time_spent;
+} __packed;
+
+struct bt_hci_cp_le_set_path_loss_reporting_enable {
+	uint16_t handle;
+	uint8_t  enable;
+} __packed;
+
+#define BT_HCI_OP_LE_SET_PATH_LOSS_REPORTING_PARAMETERS BT_OP(BT_OGF_LE, 0x0078) /* 0x2078 */
+
+#define BT_HCI_LE_PATH_LOSS_REPORTING_DISABLE       0x00
+#define BT_HCI_LE_PATH_LOSS_REPORTING_ENABLE        0x01
+#define BT_HCI_OP_LE_SET_PATH_LOSS_REPORTING_ENABLE BT_OP(BT_OGF_LE, 0x0079) /* 0x2079 */
+
 #define BT_HCI_CTL_TO_HOST_FLOW_DISABLE         0x00
 #define BT_HCI_CTL_TO_HOST_FLOW_ENABLE          0x01
 #define BT_HCI_OP_SET_CTL_TO_HOST_FLOW          BT_OP(BT_OGF_BASEBAND, 0x0031) /* 0x0c31 */
@@ -3018,6 +3038,18 @@ struct bt_hci_evt_le_req_peer_sca_complete {
 	uint8_t  status;
 	uint16_t handle;
 	uint8_t  sca;
+} __packed;
+
+#define	BT_HCI_LE_ZONE_ENTERED_LOW      0x0
+#define	BT_HCI_LE_ZONE_ENTERED_MIDDLE   0x1
+#define	BT_HCI_LE_ZONE_ENTERED_HIGH     0x2
+#define	BT_HCI_LE_PATH_LOSS_UNAVAILABLE 0xFF
+
+#define BT_HCI_EVT_LE_PATH_LOSS_THRESHOLD                   0x20
+struct bt_hci_evt_le_path_loss_threshold {
+	uint16_t handle;
+	uint8_t  current_path_loss;
+	uint8_t  zone_entered;
 } __packed;
 
 /** Reason for Transmit power reporting.

--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -174,6 +174,13 @@ config BT_TRANSMIT_POWER_CONTROL
 	  Enable support for LE Power Control Request feature that is defined in the
 	  Bluetooth Core specification, Version 5.4 | Vol 6, Part B, Section 4.6.31.
 
+config BT_PATH_LOSS_MONITORING
+	bool "LE Path Loss Monitoring"
+	depends on !BT_CTLR || BT_CTLR_LE_PATH_LOSS_MONITORING_SUPPORT
+	help
+	  Enable support for LE Path Loss Monitoring feature that is defined in the
+	  Bluetooth Core specification, Version 5.4 | Vol 6, Part B, Section 4.6.32.
+
 endif # BT_CONN
 
 rsource "Kconfig.iso"

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -104,6 +104,10 @@ config BT_CTLR_READ_ISO_LINK_QUALITY_SUPPORT
 config BT_CTLR_LE_POWER_CONTROL_SUPPORT
 	bool
 
+config BT_CTLR_LE_PATH_LOSS_MONITORING_SUPPORT
+	depends on BT_CTLR_LE_POWER_CONTROL_SUPPORT
+	bool
+
 config BT_CTLR
 	bool "Bluetooth Controller"
 	help
@@ -549,6 +553,14 @@ config BT_CTLR_LE_POWER_CONTROL
 	help
 	  Enable support for LE Power Control Request feature that is defined in the
 	  Bluetooth Core specification, Version 5.4 | Vol 6, Part B, Section 4.6.31.
+
+config BT_CTLR_LE_PATH_LOSS_MONITORING
+	bool "LE Path Loss Monitoring Feature"
+	depends on BT_CTLR_LE_PATH_LOSS_MONITORING_SUPPORT
+	default y if BT_PATH_LOSS_MONITORING
+	help
+	  Enable support for LE Path Loss Monitoring feature that is defined in the
+	  Bluetooth Core specification, Version 5.4 | Vol 6, Part B, Section 4.6.32.
 
 endif # BT_CONN
 

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2884,6 +2884,65 @@ int bt_conn_le_get_tx_power_level(struct bt_conn *conn,
 	return err;
 }
 
+#if defined(CONFIG_BT_PATH_LOSS_MONITORING)
+void notify_path_loss_threshold_report(struct bt_conn *conn,
+				       struct bt_conn_le_path_loss_threshold_report report)
+{
+	for (struct bt_conn_cb *cb = callback_list; cb; cb = cb->_next) {
+		if (cb->path_loss_threshold_report) {
+			cb->path_loss_threshold_report(conn, &report);
+		}
+	}
+
+	STRUCT_SECTION_FOREACH(bt_conn_cb, cb)
+	{
+		if (cb->path_loss_threshold_report) {
+			cb->path_loss_threshold_report(conn, &report);
+		}
+	}
+}
+
+int bt_conn_le_set_path_loss_mon_param(struct bt_conn *conn,
+				       const struct bt_conn_le_path_loss_reporting_param *params)
+{
+	struct bt_hci_cp_le_set_path_loss_reporting_parameters *cp;
+	struct net_buf *buf;
+
+	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_PATH_LOSS_REPORTING_PARAMETERS, sizeof(*cp));
+	if (!buf) {
+		return -ENOBUFS;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+	cp->handle = sys_cpu_to_le16(conn->handle);
+	cp->high_threshold = params->high_threshold;
+	cp->high_hysteresis = params->high_hysteresis;
+	cp->low_threshold = params->low_threshold;
+	cp->low_hysteresis = params->low_hysteresis;
+	cp->min_time_spent = sys_cpu_to_le16(params->min_time_spent);
+
+	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_SET_PATH_LOSS_REPORTING_PARAMETERS, buf, NULL);
+}
+
+int bt_conn_le_set_path_loss_mon_enable(struct bt_conn *conn, bool reporting_enable)
+{
+	struct bt_hci_cp_le_set_path_loss_reporting_enable *cp;
+	struct net_buf *buf;
+
+	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_PATH_LOSS_REPORTING_ENABLE, sizeof(*cp));
+	if (!buf) {
+		return -ENOBUFS;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+	cp->handle = sys_cpu_to_le16(conn->handle);
+	cp->enable = reporting_enable ? BT_HCI_LE_PATH_LOSS_REPORTING_ENABLE :
+			BT_HCI_LE_PATH_LOSS_REPORTING_DISABLE;
+
+	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_SET_PATH_LOSS_REPORTING_ENABLE, buf, NULL);
+}
+#endif /* CONFIG_BT_PATH_LOSS_MONITORING */
+
 int bt_conn_le_param_update(struct bt_conn *conn,
 			    const struct bt_le_conn_param *param)
 {

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -408,6 +408,9 @@ bool le_param_req(struct bt_conn *conn, struct bt_le_conn_param *param);
 void notify_tx_power_report(struct bt_conn *conn,
 			    struct bt_conn_le_tx_power_report report);
 
+void notify_path_loss_threshold_report(struct bt_conn *conn,
+				       struct bt_conn_le_path_loss_threshold_report report);
+
 #if defined(CONFIG_BT_SMP)
 /* If role specific LTK is present */
 bool bt_conn_ltk_present(const struct bt_conn *conn);

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2502,6 +2502,42 @@ void bt_hci_le_transmit_power_report(struct net_buf *buf)
 }
 #endif /* CONFIG_BT_TRANSMIT_POWER_CONTROL */
 
+#if defined(CONFIG_BT_PATH_LOSS_MONITORING)
+void bt_hci_le_path_loss_threshold_event(struct net_buf *buf)
+{
+	struct bt_hci_evt_le_path_loss_threshold *evt;
+	struct bt_conn_le_path_loss_threshold_report report;
+	struct bt_conn *conn;
+
+	evt = net_buf_pull_mem(buf, sizeof(*evt));
+
+	if (evt->zone_entered > BT_CONN_LE_PATH_LOSS_ZONE_ENTERED_HIGH) {
+		LOG_ERR("Invalid zone %u in bt_hci_evt_le_path_loss_threshold",
+			evt->zone_entered);
+		return;
+	}
+
+	conn = bt_conn_lookup_handle(sys_le16_to_cpu(evt->handle), BT_CONN_TYPE_LE);
+	if (!conn) {
+		LOG_ERR("Unknown conn handle 0x%04X for path loss threshold report",
+		       sys_le16_to_cpu(evt->handle));
+		return;
+	}
+
+	if (evt->current_path_loss == BT_HCI_LE_PATH_LOSS_UNAVAILABLE) {
+		report.zone = BT_CONN_LE_PATH_LOSS_ZONE_UNAVAILABLE;
+		report.path_loss = BT_HCI_LE_PATH_LOSS_UNAVAILABLE;
+	} else {
+		report.zone = evt->zone_entered;
+		report.path_loss = evt->current_path_loss;
+	}
+
+	notify_path_loss_threshold_report(conn, report);
+
+	bt_conn_unref(conn);
+}
+#endif /* CONFIG_BT_PATH_LOSS_MONITORING */
+
 static const struct event_handler vs_events[] = {
 #if defined(CONFIG_BT_DF_VS_CL_IQ_REPORT_16_BITS_IQ_SAMPLES)
 	EVENT_HANDLER(BT_HCI_EVT_VS_LE_CONNECTIONLESS_IQ_REPORT,
@@ -2651,6 +2687,10 @@ static const struct event_handler meta_events[] = {
 	EVENT_HANDLER(BT_HCI_EVT_LE_TRANSMIT_POWER_REPORT, bt_hci_le_transmit_power_report,
 		      sizeof(struct bt_hci_evt_le_transmit_power_report)),
 #endif /* CONFIG_BT_TRANSMIT_POWER_CONTROL */
+#if defined(CONFIG_BT_PATH_LOSS_MONITORING)
+	EVENT_HANDLER(BT_HCI_EVT_LE_PATH_LOSS_THRESHOLD, bt_hci_le_path_loss_threshold_event,
+		      sizeof(struct bt_hci_evt_le_path_loss_threshold)),
+#endif /* CONFIG_BT_PATH_LOSS_MONITORING */
 #if defined(CONFIG_BT_PER_ADV_SYNC_RSP)
 	EVENT_HANDLER(BT_HCI_EVT_LE_PER_ADVERTISING_REPORT_V2, bt_hci_le_per_adv_report_v2,
 		      sizeof(struct bt_hci_evt_le_per_advertising_report_v2)),
@@ -3243,6 +3283,10 @@ static int le_set_event_mask(void)
 		}
 		if (IS_ENABLED(CONFIG_BT_TRANSMIT_POWER_CONTROL)) {
 			mask |= BT_EVT_MASK_LE_TRANSMIT_POWER_REPORTING;
+		}
+
+		if (IS_ENABLED(CONFIG_BT_PATH_LOSS_MONITORING)) {
+			mask |= BT_EVT_MASK_LE_PATH_LOSS_THRESHOLD;
 		}
 	}
 

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -189,6 +189,24 @@ static const char *enabled2str(bool enabled)
 
 #endif /* CONFIG_BT_TRANSMIT_POWER_CONTROL */
 
+#if defined(CONFIG_BT_PATH_LOSS_MONITORING)
+static const char *plm_report_zone_str(enum bt_conn_le_path_loss_zone zone)
+{
+	switch (zone) {
+	case BT_CONN_LE_PATH_LOSS_ZONE_ENTERED_LOW:
+		return "Entered low zone";
+	case BT_CONN_LE_PATH_LOSS_ZONE_ENTERED_MIDDLE:
+		return "Entered middle zone";
+	case BT_CONN_LE_PATH_LOSS_ZONE_ENTERED_HIGH:
+		return "Entered high zone";
+	case BT_CONN_LE_PATH_LOSS_ZONE_UNAVAILABLE:
+		return "Path loss unavailable";
+	default:
+		return "Unknown";
+	}
+}
+#endif /* CONFIG_BT_PATH_LOSS_MONITORING */
+
 #if defined(CONFIG_BT_CENTRAL)
 static int cmd_scan_off(const struct shell *sh);
 static int cmd_connect_le(const struct shell *sh, size_t argc, char *argv[]);
@@ -955,6 +973,14 @@ void tx_power_report(struct bt_conn *conn,
 }
 #endif
 
+#if defined(CONFIG_BT_PATH_LOSS_MONITORING)
+void path_loss_threshold_report(struct bt_conn *conn,
+				const struct bt_conn_le_path_loss_threshold_report *report)
+{
+	shell_print(ctx_shell, "Path Loss Threshold event: Zone: %s, Path loss dbm: %d",
+		    plm_report_zone_str(report->zone), report->path_loss);
+}
+#endif
 
 static struct bt_conn_cb conn_callbacks = {
 	.connected = connected,
@@ -978,6 +1004,9 @@ static struct bt_conn_cb conn_callbacks = {
 #endif
 #if defined(CONFIG_BT_TRANSMIT_POWER_CONTROL)
 	.tx_power_report = tx_power_report,
+#endif
+#if defined(CONFIG_BT_PATH_LOSS_MONITORING)
+	.path_loss_threshold_report = path_loss_threshold_report,
 #endif
 };
 #endif /* CONFIG_BT_CONN */
@@ -2929,6 +2958,70 @@ static int cmd_set_power_report_enable(const struct shell *sh, size_t argc, char
 
 #endif
 
+#if defined(CONFIG_BT_PATH_LOSS_MONITORING)
+static int cmd_set_path_loss_reporting_parameters(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err = 0;
+
+	if (default_conn == NULL) {
+		shell_error(sh, "Conn handle error, at least one connection is required.");
+		return -ENOEXEC;
+	}
+
+	for (size_t argn = 1; argn < argc; argn++) {
+		(void)shell_strtoul(argv[argn], 10, &err);
+
+		if (err) {
+			shell_help(sh);
+			shell_error(sh, "Could not parse input number %d", argn);
+			return SHELL_CMD_HELP_PRINTED;
+		}
+	}
+
+	const struct bt_conn_le_path_loss_reporting_param params = {
+		.high_threshold = shell_strtoul(argv[1], 10, &err),
+		.high_hysteresis = shell_strtoul(argv[2], 10, &err),
+		.low_threshold = shell_strtoul(argv[3], 10, &err),
+		.low_hysteresis = shell_strtoul(argv[4], 10, &err),
+		.min_time_spent = shell_strtoul(argv[5], 10, &err),
+	};
+
+	err = bt_conn_le_set_path_loss_mon_param(default_conn, &params);
+	if (err) {
+		shell_error(sh, "bt_conn_le_set_path_loss_mon_param returned error %d", err);
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
+
+static int cmd_set_path_loss_reporting_enable(const struct shell *sh, size_t argc, char *argv[])
+{
+	bool enable;
+	int err = 0;
+
+	if (default_conn == NULL) {
+		shell_error(sh, "Conn handle error, at least one connection is required.");
+		return -ENOEXEC;
+	}
+
+	enable = shell_strtobool(argv[1], 10, &err);
+	if (err) {
+		shell_help(sh);
+		return SHELL_CMD_HELP_PRINTED;
+	}
+
+	err = bt_conn_le_set_path_loss_mon_enable(default_conn, enable);
+
+	if (err) {
+		shell_error(sh, "bt_conn_le_set_path_loss_mon_enable returned error %d", err);
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
+#endif
+
 
 #if defined(CONFIG_BT_CONN)
 #if defined(CONFIG_BT_CENTRAL)
@@ -4618,6 +4711,13 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
 	SHELL_CMD_ARG(read-remote-tx-power, NULL, HELP_NONE, cmd_read_remote_tx_power, 2, 0),
 	SHELL_CMD_ARG(read-local-tx-power, NULL, HELP_NONE, cmd_read_local_tx_power, 2, 0),
 	SHELL_CMD_ARG(set-power-report-enable, NULL, HELP_NONE, cmd_set_power_report_enable, 3, 0),
+#endif
+#if defined(CONFIG_BT_PATH_LOSS_MONITORING)
+	SHELL_CMD_ARG(path-loss-monitoring-set-params, NULL,
+		      "<high threshold> <high hysteresis> <low threshold> <low hysteresis> <min time spent>",
+		      cmd_set_path_loss_reporting_parameters, 6, 0),
+	SHELL_CMD_ARG(path-loss-monitoring-enable, NULL, "<enable: true, false>",
+		      cmd_set_path_loss_reporting_enable, 2, 0),
 #endif
 #if defined(CONFIG_BT_BROADCASTER)
 	SHELL_CMD_ARG(advertise, NULL,


### PR DESCRIPTION
This commit adds host support for the Path Loss Monitoring feature see Bluetooth Core specification, Version 5.4, Vol 6, Part B, Section 4.6.32.

Limited logic is required, just adding a wrapper around the HCI command for ease of use.

Add new zone - BT_CONN_LE_PATH_LOSS_UNAVAILABLE, to convert 0xFF path loss to a useful zone.

Add new Kconfigs and functionality to the bt shell.