### PR TITLE
llext: handle all sections automatically

### DIFF
--- a/include/zephyr/llext/loader.h
+++ b/include/zephyr/llext/loader.h
@@ -68,9 +68,6 @@ struct llext_loader {
 	 */
 	void *(*peek)(struct llext_loader *ldr, size_t pos);
 
-	/** Total calculated .data size for relocatable extensions */
-	size_t prog_data_size;
-
 	/** @cond ignore */
 	elf_ehdr_t hdr;
 	elf_shdr_t sects[LLEXT_MEM_COUNT];


### PR DESCRIPTION
Currently LLEXT only links .text, .data, .rodata, .bss and .exported_sym sections, but objects can have custom sections, which must be linked too. This patch groups sections by their flags: it so far assumes only one executable section .text, but all read-only and all writable data sections are grouped in two pseudo-segments. So that now we store .text, .bss, RODATA and DATA. This assumes that all such read-only and writable sections are grouped together during (partial) linking.

This is a replacement of #73274 which I... have apparently closed by accident