### PR TITLE
NXP LPC55S16 combine srams

### DIFF
--- a/boards/nxp/lpcxpresso55s16/lpcxpresso55s16.dts
+++ b/boards/nxp/lpcxpresso55s16/lpcxpresso55s16.dts
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Henrik Brix Andersen <henrik@brixandersen.dk>
+ * Copyright 2024, NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -12,6 +13,15 @@
 / {
 	model = "NXP LPCXpresso55S16 board";
 	compatible = "nxp,lpc55xxx", "nxp,lpc";
+};
+
+/*
+ * Default for this board is to allocate SRAM0-2 for data.  But the
+ * application can have an application specific device tree to
+ * allocate the SRAMs differently.
+ */
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(64)>;
 };
 
 zephyr_udc0: &usbhs {

--- a/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
@@ -36,13 +36,15 @@
 	#size-cells = <1>;
 
 	sramx: memory@4000000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x4000000 DT_SIZE_K(16)>;
+		zephyr,memory-region = "SRAMX";
 	};
 
 	sram0: memory@20000000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x20000000 DT_SIZE_K(32)>;
+		zephyr,memory-region = "SRAM0";
 	};
 
 	sram1: memory@20008000 {


### PR DESCRIPTION
Combines SRAMs 0-2, increasing the default SRAM size to 64KB for apps.

Example app and more details using these SRAM arrays provided at [Example leveraging all the SRAM in NXP LPC5500 devices](https://github.com/zephyrproject-rtos/zephyr/discussions/73539).