### PR TITLE
CAN-MCAN line 1 ISR - add more debug information

### DIFF
--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -802,6 +802,14 @@ void can_mcan_line_1_isr(const struct device *dev)
 		return;
 	}
 
+	if ((ir & CAN_MCAN_IR_PEA) != 0U) {
+		LOG_DBG("Protocol error in arbitration phase: ir: 0x%x", ir);
+	}
+
+	if ((ir & CAN_MCAN_IR_PED) != 0U) {
+		LOG_DBG("Protocol error in data phase: ir: 0x%x", ir);
+	}
+
 	while ((ir & events) != 0U) {
 		err = can_mcan_write_reg(dev, CAN_MCAN_IR, events & ir);
 		if (err != 0) {


### PR DESCRIPTION
In some cases CAN-Bus communication may be disturbed by other parts of SoC. For example USB may disturb CAN communication if electircal wiring of the board is not done properly or the system is in development stage.
This change adds debug-prints s.t. CAN-Bus protocol errors in arbitration or data phases can be
detected while in CAN-Bus ISR.

In my case I am getting 16 ISR calls with 16 same CAN messages as soon as I enable USB and CAN on my nucleo_h745zi_q board with waveshare-can-rs485 shield. Currently I am investigating the problem. But it shall work, cause there are plenty of STM32 designs with CAN and USB enabled.
