### PR TITLE
MAINTAINERS: add hostlink channel driver sources to Synopsys Platforms entry

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3172,6 +3172,8 @@ Synopsys Platforms:
     - scripts/west_commands/tests/test_mdb.py
     - scripts/west_commands/runners/nsim.py
     - cmake/emu/nsim.cmake
+    - drivers/serial/uart_hostlink.c
+    - drivers/serial/Kconfig.hostlink
   labels:
     - "platform: Synopsys"
 


### PR DESCRIPTION
Virtual UART over ARC hostlink channel driver is used on Synopsys platforms and maintained by Synopsys.