### PR TITLE
boards: infineon: cyw20829m2evk_02: Remove the incorrect flash node

### DIFF
--- a/boards/infineon/cyw920829m2evk_02/cyw920829m2evk_02.dts
+++ b/boards/infineon/cyw920829m2evk_02/cyw920829m2evk_02.dts
@@ -71,8 +71,7 @@ uart2: &scb2 {
 	status = "okay";
 };
 
-&flash_controller {
-
+/ {
 	flash0: flash@60000000 {
 		compatible = "soc-nv-flash";
 		reg = <0x60000000 DT_SIZE_K(512)>;

--- a/dts/arm/infineon/cat1b/cyw20829/cyw20829.dtsi
+++ b/dts/arm/infineon/cat1b/cyw20829/cyw20829.dtsi
@@ -19,13 +19,6 @@
 		};
 	};
 
-	flash_controller: flash_controller@40250000 {
-		compatible = "infineon,cat1-flash-controller";
-		reg = <0x40250000 0x10000>;
-		#address-cells = <1>;
-		#size-cells = <1>;
-	};
-
 	sram0: memory@20000000 {
 		compatible = "mmio-sram";
 		reg = <0x20000000 0x3DC00>;


### PR DESCRIPTION
Delete the incorrect node declaration for flash-controller 
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/73525