### PR TITLE
samples: bluetooth: Enable PM on rd_rw612_bga

### DIFF
--- a/samples/bluetooth/central_ht/boards/rd_rw612_bga.conf
+++ b/samples/bluetooth/central_ht/boards/rd_rw612_bga.conf
@@ -1,0 +1,1 @@
+CONFIG_PM=y

--- a/samples/bluetooth/peripheral_ht/boards/rd_rw612_bga.conf
+++ b/samples/bluetooth/peripheral_ht/boards/rd_rw612_bga.conf
@@ -1,0 +1,1 @@
+CONFIG_PM=y


### PR DESCRIPTION
Enable power management by default for rd_rw612_bga on peripheral_ht and central_ht samples