### PR TITLE
dts: gd: fix uart4 irq wrong

### DIFF
--- a/dts/arm/gd/gd32f4xx/gd32f4xx.dtsi
+++ b/dts/arm/gd/gd32f4xx/gd32f4xx.dtsi
@@ -107,7 +107,7 @@
 		uart4: usart@40005000 {
 			compatible = "gd,gd32-usart";
 			reg = <0x40005000 0x400>;
-			interrupts = <52 0>;
+			interrupts = <53 0>;
 			clocks = <&cctl GD32_CLOCK_UART4>;
 			resets = <&rctl GD32_RESET_UART4>;
 			status = "disabled";


### PR DESCRIPTION
Fix irq number wrong of uart4 in dts.

Reference doc(Page 163): <https://www.gigadevice.com.cn/Public/Uploads/uploadfile/files/20240407/GD32F4xx_User_Manual_Rev3.0.pdf>