### PR TITLE
usb: device_next: initialize BOS device caps number

### DIFF
--- a/subsys/usb/device_next/usbd_ch9.c
+++ b/subsys/usb/device_next/usbd_ch9.c
@@ -704,6 +704,7 @@ static void desc_fill_bos_root(struct usbd_contex *const uds_ctx,
 	root->bLength = sizeof(struct usb_bos_descriptor);
 	root->bDescriptorType = USB_DESC_BOS;
 	root->wTotalLength = root->bLength;
+	root->bNumDeviceCaps = 0;
 
 	SYS_DLIST_FOR_EACH_CONTAINER(&uds_ctx->descriptors, desc_nd, node) {
 		if (desc_nd->bDescriptorType == USB_DESC_BOS) {


### PR DESCRIPTION
Explicitly initialize bNumDeviceCaps to 0 because the bos descriptor is stored on stack.

Fixes: b0d7d70834ab ("usb: device_next: add initial BOS support")
Coverity-CID: 368798