### PR TITLE
boards: nxp: mimxrt1020evk: Fix enet dts

### DIFF
--- a/boards/nxp/mimxrt1020_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1020_evk/doc/index.rst
@@ -106,6 +106,8 @@ already supported, which can also be re-used on this mimxrt1020_evk board:
 | UART      | on-chip    | serial port-polling;                |
 |           |            | serial port-interrupt               |
 +-----------+------------+-------------------------------------+
+| ENET      | on-chip    | ethernet                            |
++-----------+------------+-------------------------------------+
 | USB       | on-chip    | USB device                          |
 +-----------+------------+-------------------------------------+
 | ADC       | on-chip    | adc                                 |

--- a/boards/nxp/mimxrt1020_evk/mimxrt1020_evk-pinctrl.dtsi
+++ b/boards/nxp/mimxrt1020_evk/mimxrt1020_evk-pinctrl.dtsi
@@ -31,21 +31,29 @@
 			input-enable;
 		};
 		group1 {
-			pinmux = <&iomuxc_gpio_ad_b0_04_gpio1_io04>;
-			drive-strength = "r0-5";
-			bias-pull-up;
-			bias-pull-up-value = "100k";
-			slew-rate = "fast";
-			nxp,speed = "100-mhz";
-		};
-		group2 {
 			pinmux = <&iomuxc_gpio_ad_b0_09_enet_rx_data1>,
 				<&iomuxc_gpio_ad_b0_11_enet_rx_en>,
 				<&iomuxc_gpio_ad_b0_14_enet_tx_data0>,
 				<&iomuxc_gpio_ad_b0_15_enet_tx_data1>,
 				<&iomuxc_gpio_ad_b0_13_enet_tx_en>,
-				<&iomuxc_gpio_ad_b0_12_enet_rx_er>,
-				<&iomuxc_gpio_emc_40_enet_mdio>,
+				<&iomuxc_gpio_ad_b0_12_enet_rx_er>;
+			drive-strength = "r0-5";
+			bias-pull-up;
+			bias-pull-up-value = "100k";
+			slew-rate = "fast";
+			nxp,speed = "200-mhz";
+		};
+		group2 {
+			pinmux = <&iomuxc_gpio_ad_b0_10_enet_rx_data0>;
+			drive-strength = "r0-6";
+			slew-rate = "slow";
+			nxp,speed = "100-mhz";
+		};
+	};
+
+	pinmux_enet_mdio: pinmux_enet_mdio {
+		group0 {
+			pinmux = <&iomuxc_gpio_emc_40_enet_mdio>,
 				<&iomuxc_gpio_emc_41_enet_mdc>;
 			drive-strength = "r0-5";
 			bias-pull-up;
@@ -53,7 +61,7 @@
 			slew-rate = "fast";
 			nxp,speed = "200-mhz";
 		};
-		group3 {
+		group1 {
 			pinmux = <&iomuxc_gpio_ad_b1_06_gpio1_io22>;
 			drive-strength = "r0-5";
 			bias-pull-up;
@@ -61,12 +69,18 @@
 			slew-rate = "slow";
 			nxp,speed = "100-mhz";
 		};
-		group4 {
-			pinmux = <&iomuxc_gpio_ad_b0_10_enet_rx_data0>;
-			drive-strength = "r0-6";
-			slew-rate = "slow";
+		group2 {
+			pinmux = <&iomuxc_gpio_ad_b0_04_gpio1_io04>;
+			drive-strength = "r0-5";
+			bias-pull-up;
+			bias-pull-up-value = "100k";
+			slew-rate = "fast";
 			nxp,speed = "100-mhz";
 		};
+	};
+
+	pinmux_ptp: pinmux_ptp {
+		/* Intentionally empty */
 	};
 
 	pinmux_flexcan1: pinmux_flexcan1 {
@@ -173,9 +187,7 @@
 		};
 	};
 
-	/* intentionally left empty */
-	pinmux_ptp: pinmux_ptp {
-	};
+
 
 	pinmux_sai3: pinmux_sai3 {
 		group0 {

--- a/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -131,6 +131,35 @@ arduino_serial: &lpuart2 {
 	};
 };
 
+&enet_mac {
+	status = "okay";
+	pinctrl-0 = <&pinmux_enet>;
+	pinctrl-names = "default";
+	phy-handle = <&phy>;
+	zephyr,random-mac-address;
+	phy-connection-type = "rmii";
+};
+
+&enet_mdio {
+	status = "okay";
+	pinctrl-0 = <&pinmux_enet_mdio>;
+	pinctrl-names = "default";
+	phy: phy@0 {
+		compatible = "microchip,ksz8081";
+		reg = <0>;
+		status = "okay";
+		mc,reset-gpio = <&gpio1 4 GPIO_ACTIVE_HIGH>;
+		mc,interrupt-gpio = <&gpio1 22 GPIO_ACTIVE_HIGH>;
+		mc,interface-type = "rmii";
+	};
+};
+
+&enet_ptp_clock {
+	status = "okay";
+	pinctrl-0 = <&pinmux_ptp>;
+	pinctrl-names = "default";
+};
+
 &lpi2c1 {
 	status = "okay";
 	pinctrl-0 = <&pinmux_lpi2c1>;


### PR DESCRIPTION
Re-enable enet on mimxrt1020 board using the new devicetree. Build and execution of zperf sample on this board is successful.