### PR TITLE
cmake: set big-endian flags to TOOLCHAIN_*_FLAGS

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -178,8 +178,9 @@ config BIG_ENDIAN
 	  Little-endian architecture is the default and should leave this option
 	  unselected.  This option is selected by arch/$ARCH/Kconfig,
 	  soc/**/Kconfig, or boards/**/Kconfig and the user should generally avoid
-	  modifying it.  The option is used to select linker script OUTPUT_FORMAT
-	  and command line option for gen_isr_tables.py.
+	  modifying it.  The option is used to select linker script OUTPUT_FORMAT,
+	  the toolchain flags (TOOLCHAIN_C_FLAGS, TOOLCHAIN_LD_FLAGS), and command
+	  line option for gen_isr_tables.py.
 
 config LITTLE_ENDIAN
 	# Hidden Kconfig option representing the default little-endian architecture

--- a/cmake/compiler/gcc/target_arm.cmake
+++ b/cmake/compiler/gcc/target_arm.cmake
@@ -10,6 +10,11 @@ endif()
 
 list(APPEND ARM_C_FLAGS -mabi=aapcs)
 
+if(CONFIG_BIG_ENDIAN)
+  list(APPEND TOOLCHAIN_C_FLAGS -mbig-endian)
+  list(APPEND TOOLCHAIN_LD_FLAGS -mbig-endian)
+endif()
+
 if(CONFIG_FPU)
   list(APPEND ARM_C_FLAGS   -mfpu=${GCC_M_FPU})
 


### PR DESCRIPTION
This PR is related to https://github.com/zephyrproject-rtos/sdk-ng/pull/765