### PR TITLE
shell: shell_adsp_memory_window: fix invalid cast in struct init

### DIFF
--- a/include/zephyr/shell/shell_adsp_memory_window.h
+++ b/include/zephyr/shell/shell_adsp_memory_window.h
@@ -42,7 +42,7 @@ struct shell_adsp_memory_window {
 	static struct shell_adsp_memory_window _name##_shell_adsp_memory_window;\
 	struct shell_transport _name = {					\
 		.api = &shell_adsp_memory_window_transport_api,		\
-		.ctx = (struct shell_memwindow *)&_name##_shell_adsp_memory_window,	\
+		.ctx = &_name##_shell_adsp_memory_window,	\
 	}
 
 /**


### PR DESCRIPTION
Fix invalid cast in SHELL_ADSP_MEMORY_WINDOW_DEFINE(). The type used in the cast (struct shell_memwindow) refers to a non-existant type. As the initialized struct field is of type "void *", compiler does not complain about it, so there were no build warning/errors seen.

Reported-by: Jyri Sarha <jyri.sarha@linux.intel.com>