### PR TITLE
modules:lvgl: Fix invalid encoder button input events

### DIFF
--- a/modules/lvgl/input/lvgl_encoder_input.c
+++ b/modules/lvgl/input/lvgl_encoder_input.c
@@ -28,6 +28,8 @@ static void lvgl_encoder_process_event(const struct device *dev, struct input_ev
 		data->pending_event.enc_diff = evt->value;
 	} else if (evt->code == cfg->button_input_code) {
 		data->pending_event.state = evt->value ? LV_INDEV_STATE_PR : LV_INDEV_STATE_REL;
+		data->pending_event.enc_diff = 0;
+		data->pending_event.key = LV_KEY_ENTER;
 	} else {
 		LOG_DBG("Ignored input event: %u", evt->code);
 		return;


### PR DESCRIPTION
When the encoder button was pressed, it didn't go into edit mode. This is because in the read_cb function the `key` field was set to 0 instead of `LV_KEY_ENTER`.

When the encoder button was pressed after it was rotated first, LVGL would think that the encoder has rotated again because the `enc_diff` field wasn't cleared.

This clears the enc_diff field, and set the key field to LV_KEY_ENTER for button events.

Fixes zephyrproject-rtos#73529