### PR TITLE
scripts/ci/pylintrc: Disable consider-using-enumerate

### DIFF
--- a/scripts/ci/pylintrc
+++ b/scripts/ci/pylintrc
@@ -67,7 +67,6 @@ enable=
     singleton-comparison,
     misplaced-comparison-constant,
     unidiomatic-typecheck,
-    consider-using-enumerate,
     consider-iterating-dictionary,
     bad-classmethod-argument,
     bad-mcs-method-argument,


### PR DESCRIPTION
This "convention" report ("C0200: Consider using enumerate instead of iterating with range and len") is overbroad.  It wants to detect the case of code that is looping over an iterable by index but is also extracting the item itself by index; enumerate() gives you both, so it's preferred.

But sometimes that's just an artifact, and the index is being used symmetrically to index into two arrays, for example it wants to turn this fairly obvious and idiomatic array copy construction:

    for i in range(len(input)):
        output[i + offset] = input[i]

Into this, which is asymettric, and obscures the clarity of what's happening (you'll not it also involves more bytes of code, not fewer!):

    for i, elem in enumerate(input):
        output[i + offset] = elem

Turn it off, as it's otherwise blocking CI on clean idiomatic code.