### PR TITLE
drivers: sam_can: fixed MCAN Register Base Address

### DIFF
--- a/drivers/can/can_sam.c
+++ b/drivers/can/can_sam.c
@@ -25,6 +25,7 @@ struct can_sam_config {
 	const struct atmel_sam_pmc_config clock_cfg;
 	const struct pinctrl_dev_config *pcfg;
 	int divider;
+	mm_reg_t dma_base;
 };
 
 static int can_sam_read_reg(const struct device *dev, uint16_t reg, uint32_t *val)
@@ -101,7 +102,13 @@ static int can_sam_init(const struct device *dev)
 		return ret;
 	}
 
-	ret = can_mcan_configure_mram(dev, 0U, sam_cfg->mram);
+	/* get actual message ram base address */
+	uint32_t mrba = sam_cfg->mram & 0xFFFF0000;
+
+	/* keep lower 16bit; update DMA Base Register */
+	sys_write32(sam_cfg->dma_base, (sys_read32(sam_cfg->dma_base) & 0x0000FFFF) | mrba);
+
+	ret = can_mcan_configure_mram(dev, mrba, sam_cfg->mram);
 	if (ret != 0) {
 		return ret;
 	}
@@ -174,6 +181,7 @@ static void config_can_##inst##_irq(void)                                       
 		.divider = DT_INST_PROP(inst, divider),			\
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),		\
 		.config_irq = config_can_##inst##_irq,			\
+		.dma_base = (mm_reg_t) DT_INST_REG_ADDR_BY_NAME(inst, dma_base) \
 	};								\
 									\
 	static const struct can_mcan_config can_mcan_cfg_##inst =	\

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -439,7 +439,8 @@
 
 		can0: can@40030000 {
 			compatible = "atmel,sam-can";
-			reg = <0x40030000 0x100>;
+			reg = <0x40030000 0x100>, <0x40088110 0x04>;
+			reg-names = "m_can", "dma_base";
 			interrupts = <35 0>, <36 0>;
 			interrupt-names = "int0", "int1";
 			clocks = <&pmc PMC_TYPE_PERIPHERAL 35>;
@@ -450,7 +451,8 @@
 
 		can1: can@40034000 {
 			compatible = "atmel,sam-can";
-			reg = <0x40034000 0x100>;
+			reg = <0x40034000 0x100>, <0x40088114 0x4>;
+			reg-names = "m_can", "dma_base";
 			interrupts = <37 0>, <38 0>;
 			interrupt-names = "int0", "int1";
 			clocks = <&pmc PMC_TYPE_PERIPHERAL 37>;

--- a/dts/bindings/can/atmel,sam-can.yaml
+++ b/dts/bindings/can/atmel,sam-can.yaml
@@ -9,6 +9,15 @@ include:
 properties:
   reg:
     required: true
+    description: |
+      2 reg blocks needed; Register block for the MCAN configuration registers;
+      Register block for the DMA Base Address
+
+  reg-names:
+    type: string-array
+    required: true
+    description: |
+      description of reg blocks
 
   interrupts:
     required: true


### PR DESCRIPTION
Before that fix, the default mrba was used; additionally the offset of "0" to the actual mcan memory location was used. 

Fixes #68472