### PR TITLE
arch: arm64: Original Early Mem Functions Option

### DIFF
--- a/arch/arm64/core/Kconfig
+++ b/arch/arm64/core/Kconfig
@@ -171,6 +171,14 @@ config ARM64_FALLBACK_ON_RESERVED_CORES
 	  then that core will be skipped and the next core in the device tree
 	  will be used.
 
+config ARM64_ENABLE_ORIGINAL_EARLY_MEM_FUNCTIONS
+	bool "To enable original early memset and memcpy functions"
+	help
+	  By default the ARM64 z_early_memset and z_early_memcpy functions
+	  are overridden with simple byte by byte non optimized functions.
+	  Enabling this option will remove the overridden functions and use
+	  the original optimized memset and memcpy functions.
+
 config ARM64_STACK_PROTECTION
 	bool
 	default y if HW_STACK_PROTECTION

--- a/arch/arm64/core/prep_c.c
+++ b/arch/arm64/core/prep_c.c
@@ -21,6 +21,7 @@ extern void z_arm64_mm_init(bool is_primary_core);
 
 __weak void z_arm64_mm_init(bool is_primary_core) { }
 
+#ifndef CONFIG_ARM64_ENABLE_ORIGINAL_EARLY_MEM_FUNCTIONS
 /*
  * These simple memset/memcpy alternatives are necessary as the optimized
  * ones depend on the MMU to be active (see commit c5b898743a20).
@@ -43,6 +44,7 @@ void z_early_memcpy(void *dst, const void *src, size_t n)
 		*d++ = *s++;
 	}
 }
+#endif
 
 /**
  *


### PR DESCRIPTION
Provide the option to remove the default overriding byte by byte ARM64 z_early_memset and z_early_memcpy functions and use the original optimized memset/memcpy functions.