### PR TITLE
Fix for issue  #72394 and additional checks for CONFIG_FILE_SYSTEM_MAX_FILE_NAME

### DIFF
--- a/include/zephyr/fs/fs_interface.h
+++ b/include/zephyr/fs/fs_interface.h
@@ -34,7 +34,7 @@ extern "C" {
 #endif
 
 #if !defined(MAX_FILE_NAME) && defined(CONFIG_FILE_SYSTEM_LITTLEFS)
-#define MAX_FILE_NAME 256
+#define MAX_FILE_NAME 255
 #endif
 
 #if !defined(MAX_FILE_NAME) /* filesystem selection */

--- a/include/zephyr/fs/fs_interface.h
+++ b/include/zephyr/fs/fs_interface.h
@@ -13,10 +13,23 @@
 extern "C" {
 #endif
 
-#if defined(CONFIG_FILE_SYSTEM_MAX_FILE_NAME) &&  (CONFIG_FILE_SYSTEM_MAX_FILE_NAME - 0) > 0
+#if defined(CONFIG_FILE_SYSTEM_MAX_FILE_NAME) && (CONFIG_FILE_SYSTEM_MAX_FILE_NAME - 0) > 0
+
+/* No in-tree file system supports name longer than 255 characters */
+#if (CONFIG_FILE_SYSTEM_LITTLEFS || CONFIG_FAT_FILESYSTEM_ELM ||	\
+	CONFIG_FILE_SYSTEM_EXT2) && (CONFIG_FILE_SYSTEM_MAX_FILE_NAME > 255)
+#error "Max allowed CONFIG_FILE_SYSTEM_MAX_FILE_NAME is 255 characters, when any in-tree FS enabled"
+#endif
+
+/* Enabled FAT driver, without LFN, restricts name length to 12 characters */
+#if defined(CONFIG_FAT_FILESYSTEM_ELM) && !(CONFIG_FS_FATFS_LFN) && \
+	(CONFIG_FILE_SYSTEM_MAX_FILE_NAME > 12)
+#error "CONFIG_FILE_SYSTEM_MAX_FILE_NAME can not be > 12 if FAT is enabled without LFN"
+#endif
+
 #define MAX_FILE_NAME CONFIG_FILE_SYSTEM_MAX_FILE_NAME
 
-#else /* CONFIG_FILE_SYSTEM_MAX_FILE_NAME */
+#else
 /* Select from enabled file systems */
 
 #if defined(CONFIG_FAT_FILESYSTEM_ELM)


### PR DESCRIPTION
Two commits: 
  1) Fix for MAX_FILE_NAME defaulting for LittleFS to 256, while max allowed is now 255
  2) improved checks of CONFIG_FILE_SYSTEM_MAX_FILE_NAME


Fixes #72394 