### PR TITLE
pm: Don't use deprecated function

### DIFF
--- a/arch/arc/core/isr_wrapper.S
+++ b/arch/arc/core/isr_wrapper.S
@@ -26,7 +26,7 @@ GTEXT(_isr_wrapper)
 GTEXT(_isr_demux)
 
 #if defined(CONFIG_PM)
-GTEXT(z_pm_save_idle_exit)
+GTEXT(pm_system_resume)
 #endif
 
 /*
@@ -253,7 +253,7 @@ rirq_path:
 
 	st 0, [r1, _kernel_offset_to_idle] /* zero idle duration */
 	PUSHR blink
-	jl z_pm_save_idle_exit
+	jl pm_system_resume
 	POPR blink
 
 _skip_pm_save_idle_exit:

--- a/arch/arm/core/cortex_a_r/isr_wrapper.S
+++ b/arch/arm/core/cortex_a_r/isr_wrapper.S
@@ -156,7 +156,7 @@ _vfp_not_enabled:
 	 * idle, this ensures that the calculation and programming of the
 	 * device for the next timer deadline is not interrupted.  For
 	 * non-tickless idle, this ensures that the clearing of the kernel idle
-	 * state is not interrupted.  In each case, z_pm_save_idle_exit
+	 * state is not interrupted.  In each case, pm_system_resume
 	 * is called with interrupts disabled.
 	 */
 
@@ -170,7 +170,7 @@ _vfp_not_enabled:
 	movs r1, #0
 	/* clear kernel idle state */
 	str r1, [r2, #_kernel_offset_to_idle]
-	bl z_pm_save_idle_exit
+	bl pm_system_resume
 _idle_state_cleared:
 
 #endif /* CONFIG_PM */
@@ -269,7 +269,7 @@ SECTION_FUNC(TEXT, _isr_wrapper)
 	 * idle, this ensures that the calculation and programming of the
 	 * device for the next timer deadline is not interrupted.  For
 	 * non-tickless idle, this ensures that the clearing of the kernel idle
-	 * state is not interrupted.  In each case, z_pm_save_idle_exit
+	 * state is not interrupted.  In each case, pm_system_resume
 	 * is called with interrupts disabled.
 	 */
 
@@ -283,7 +283,7 @@ SECTION_FUNC(TEXT, _isr_wrapper)
 	movs r1, #0
 	/* clear kernel idle state */
 	str r1, [r2, #_kernel_offset_to_idle]
-	bl z_pm_save_idle_exit
+	bl pm_system_resume
 _idle_state_cleared:
 #endif /* CONFIG_PM */
 

--- a/arch/x86/core/ia32/intstub.S
+++ b/arch/x86/core/ia32/intstub.S
@@ -33,7 +33,7 @@
 	GTEXT(arch_swap)
 
 #ifdef CONFIG_PM
-	GTEXT(z_pm_save_idle_exit)
+	GTEXT(pm_system_resume)
 #endif
 
 /**
@@ -314,13 +314,13 @@ handle_idle:
 	movl	$0, _kernel_offset_to_idle(%ecx)
 
 	/*
-	 * Beware that a timer driver's z_pm_save_idle_exit() implementation might
+	 * Beware that a timer driver's pm_system_resume() implementation might
 	 * expect that interrupts are disabled when invoked.  This ensures that
 	 * the calculation and programming of the device for the next timer
 	 * deadline is not interrupted.
 	 */
 
-	call	z_pm_save_idle_exit
+	call	pm_system_resume
 	popl	%edx
 	popl	%eax
 	jmp	alreadyOnIntStack


### PR DESCRIPTION
Use pm_system_resume instead of z_pm_save_idle_exit
