### PR TITLE
ARM64: early memset/memcpy optimizations and fixes

### DIFF
--- a/arch/arm64/core/CMakeLists.txt
+++ b/arch/arm64/core/CMakeLists.txt
@@ -4,6 +4,7 @@ zephyr_library()
 
 zephyr_library_sources(
   cpu_idle.S
+  early_mem_funcs.S
   fatal.c
   irq_init.c
   irq_manage.c

--- a/arch/arm64/core/early_mem_funcs.S
+++ b/arch/arm64/core/early_mem_funcs.S
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) BayLibre SAS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/toolchain.h>
+#include <zephyr/linker/sections.h>
+
+_ASM_FILE_PROLOGUE
+
+/*
+ * These simple memset and memcpy alternatives are necessary as the optimized
+ * ones depend on the MMU to be active (see commit c5b898743a20).
+ *
+ * Furthermore, we can't implement those in C as the compiler is just too
+ * smart for its own good and replaces our simple loops into direct calls
+ * to memset or memcpy on its own.
+ */
+
+/* void z_early_memset(void *dst, int c, size_t n) */
+GTEXT(z_early_memset)
+SECTION_FUNC(TEXT, z_early_memset)
+
+	/* is dst pointer 8-bytes aligned? */
+	tst	x0, #0x7
+	b.ne	2f
+
+	/* at least 8 bytes to set? */
+	cmp	x2, #8
+	b.lo	2f
+
+	/* spread the byte value across whole 64 bits */
+	and	x8, x1, #0xff
+        mov	x9, #0x0101010101010101
+	mul	x8, x8, x9
+
+1:	/* 8 bytes at a time */
+	sub	x2, x2, #8
+	cmp	x2, #7
+	str	x8, [x0], #8
+	b.hi	1b
+
+2:	/* at least one byte to set? */
+	cbz	x2, 4f
+
+3:	/* one byte at a time */
+	subs	x2, x2, #1
+	strb	w8, [x0], #1
+	b.ne	3b
+
+4:	ret
+
+/* void z_early_memcpy(void *dst, const void *src, size_t n) */
+GTEXT(z_early_memcpy)
+SECTION_FUNC(TEXT, z_early_memcpy)
+
+	/* are dst and src pointers 8-bytes aligned? */
+	orr	x8, x1, x0
+	tst	x8, #0x7
+	b.ne	2f
+
+	/* at least 8 bytes to copy? */
+	cmp	x2, #8
+	b.lo	2f
+
+1:	/* 8 bytes at a time */
+	ldr	x8, [x1], #8
+	sub	x2, x2, #8
+	cmp	x2, #7
+	str	x8, [x0], #8
+	b.hi	1b
+
+2:	/* at least one byte to copy? */
+	cbz	x2, 4f
+
+3:	/* one byte at a time */
+	ldrb	w8, [x1], #1
+	subs	x2, x2, #1
+	strb	w8, [x0], #1
+	b.ne	3b
+
+4:	ret

--- a/arch/arm64/core/prep_c.c
+++ b/arch/arm64/core/prep_c.c
@@ -21,58 +21,6 @@ extern void z_arm64_mm_init(bool is_primary_core);
 
 __weak void z_arm64_mm_init(bool is_primary_core) { }
 
-/*
- * These simple memset/memcpy alternatives are necessary as the optimized
- * ones depend on the MMU to be active (see commit c5b898743a20).
- */
-void z_early_memset(void *dst, int c, size_t n)
-{
-	if (((uintptr_t)dst & (sizeof(uint64_t) - 1)) == 0) {
-		/* speed-up if 64-bit aligned which should be the default */
-		uint64_t *d8 = dst;
-		uint64_t c8 = (uint8_t)c;
-
-		c8 |= c8 << 8;
-		c8 |= c8 << 16;
-		c8 |= c8 << 32;
-
-		while (n >= 8) {
-			*d8++ = c8;
-			n -= 8;
-		}
-		dst = d8;
-	}
-
-	uint8_t *d = dst;
-
-	while (n--) {
-		*d++ = c;
-	}
-}
-
-void z_early_memcpy(void *dst, const void *src, size_t n)
-{
-	if ((((uintptr_t)dst | (uintptr_t)src) & (sizeof(uint64_t) - 1)) == 0) {
-		/* speed-up if 64-bit aligned which should be the default */
-		uint64_t *d8 = dst;
-		const uint64_t *s8 = src;
-
-		while (n >= 8) {
-			*d8++ = *s8++;
-			n -= 8;
-		}
-		dst = d8;
-		src = s8;
-	}
-
-	uint8_t *d = dst;
-	const uint8_t *s = src;
-
-	while (n--) {
-		*d++ = *s++;
-	}
-}
-
 /**
  *
  * @brief Prepare to and run C code


### PR DESCRIPTION
This provides a straight forward speed-up to the early memset/memcpy
functions given that:

- MMU and cache are not yet enabled, and

- early memset/memcpy are for data sections which are most likely
  64-bits aligned.

Then I looked at the resulting assembly to notice that the compiler simply
replaced half of the C code with a direct call to memset which defeats the
purpose entirely. So I moved those functions to assembly code instead.

I still kept the optimized C code in a separate commit for reference.
