### PR TITLE
samples: video: tcpserversink: fix build regression

### DIFF
--- a/samples/subsys/video/tcpserversink/src/main.c
+++ b/samples/subsys/video/tcpserversink/src/main.c
@@ -40,7 +40,7 @@ int main(void)
 	struct video_buffer *buffers[2], *vbuf;
 	int i, ret, sock, client;
 	struct video_format fmt;
-	const struct device *const video = DEVICE_DT_GET_ONE(nxp_imx_csi);
+	const struct device *const video = DEVICE_DT_GET_ANY(nxp_imx_csi);
 
 	/* Prepare Network */
 	(void)memset(&addr, 0, sizeof(addr));


### PR DESCRIPTION
The `nxp,imx-csi` node seems to be indirectly disabled in dts in commit cf4495b196051d7cf634421eb79c26210162f4be which caused a [build failure](https://github.com/zephyrproject-rtos/zephyr/actions/runs/9329767331/job/25682654042?pr=73047) / regression in CI, impacting the `main` branch.

Use `DEVICE_DT_GET_ANY()` instead of `DEVICE_DT_GET_ONE()`, since the latter requires a DT node present, while the former does not and returns `NULL` if no such compat exists with status "okay".

Testing done:
```shell
west build -p  -b mimxrt1064_evk samples/subsys/video/tcpserversink/
```