### PR TITLE
boards: nxp: vmu_rt1170: fix dummy cycle value in flash configuration

### DIFF
--- a/boards/nxp/vmu_rt1170/flexspi_nor_config.c
+++ b/boards/nxp/vmu_rt1170/flexspi_nor_config.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019, MADMACHINE LIMITED
+ * Copyright 2024 NXP
  *
  * refer to hal_nxp board file
  *
@@ -101,7 +102,7 @@ const struct flexspi_nor_config_t g_flash_fast_config = {
 			[0 + 0] = FLEXSPI_LUT_SEQ(CMD_DDR, FLEXSPI_8PAD,
 				0xEE, CMD_DDR, FLEXSPI_8PAD, 0x11),
 			[0 + 1] = FLEXSPI_LUT_SEQ(RADDR_DDR, FLEXSPI_8PAD,
-				0x20, DUMMY_DDR, FLEXSPI_8PAD, 0x04),
+				0x20, DUMMY_DDR, FLEXSPI_8PAD, 0x28),
 			[0 + 2] = FLEXSPI_LUT_SEQ(READ_DDR, FLEXSPI_8PAD,
 				0x04, STOP, FLEXSPI_1PAD, 0x00),
 


### PR DESCRIPTION
The VMURT1170 board configures the FLEXSPI to run at 200MHz serial clock in DDR mode, via the flash configuration block passed to the ROM API. Per the datasheet of the MX25UM51345G flash present on the board, 20 dummy cycles are required before reading data in OPI DTR mode. Correct the dummy cycle value used for read commands to 0x28 (40 DDR dummy cycles, equivalent to 20 dummy cycles of the clock) to resolve this issue.