### PR TITLE
docs/services/device_mgmt/smp_groups/image_management: fix off

### DIFF
--- a/doc/services/device_mgmt/smp_groups/smp_group_1.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_1.rst
@@ -391,7 +391,7 @@ where:
     :align: center
 
     +------------------+-------------------------------------------------------------------------+
-    | "off"            | offset of last successfully written byte of update.                     |
+    | "off"            | Portion of the upload that has been completed, in 8-bit bytes.          |
     +------------------+-------------------------------------------------------------------------+
     | "match"          | indicates if the uploaded data successfully matches the provided SHA256 |
     |                  | hash or not, only sent in the final packet if                           |

--- a/doc/services/device_mgmt/smp_groups/smp_group_1.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_1.rst
@@ -295,7 +295,7 @@ where:
     +-----------+--------------------------------------------------------------------------------+
     | "len"     | optional length of an image. Must appear when "off" is 0.                      |
     +-----------+--------------------------------------------------------------------------------+
-    | "off"     | offset of image chunk the request carries.                                     |
+    | "off"     | offset of the next expected chunk of application image.                        |
     +-----------+--------------------------------------------------------------------------------+
     | "sha"     | SHA256 hash of an upload; this is used to identify an upload session (e.g. to  |
     |           | allow MCUmgr to continue a broken session), and for image verification         |


### PR DESCRIPTION
The "off" field is not the the last written byte, instead it is the offset of the next byte to be sent.