### PR TITLE
scripts: requirements: run-tests: add python-can

### DIFF
--- a/scripts/requirements-run-test.txt
+++ b/scripts/requirements-run-test.txt
@@ -17,3 +17,6 @@ psutil
 
 # Artifacts package creation
 bz
+
+# used for CAN <=> host testing
+python-can>=4.3.0


### PR DESCRIPTION
Add python-can dependency for the newly introduced tests/drivers/can/host test suite.