### PR TITLE
drivers: counter: sam: Add qdec as tc special mode

### DIFF
--- a/boards/atmel/sam/sam_e70_xplained/sam_e70_xplained-common.dtsi
+++ b/boards/atmel/sam/sam_e70_xplained/sam_e70_xplained-common.dtsi
@@ -210,3 +210,31 @@ zephyr_udc0: &usbhs {
 		max-bitrate = <5000000>;
 	};
 };
+
+&tc0 {
+	qdec0: qdec {
+		pinctrl-0 = <&qdec0_default>;
+		pinctrl-names = "default";
+	};
+};
+
+&tc1 {
+	qdec1: qdec {
+		pinctrl-0 = <&qdec1_default>;
+		pinctrl-names = "default";
+	};
+};
+
+&tc2 {
+	qdec2: qdec {
+		pinctrl-0 = <&qdec2_default>;
+		pinctrl-names = "default";
+	};
+};
+
+&tc3 {
+	qdec3: qdec {
+		pinctrl-0 = <&qdec3_default>;
+		pinctrl-names = "default";
+	};
+};

--- a/boards/atmel/sam/sam_e70_xplained/sam_e70_xplained-pinctrl.dtsi
+++ b/boards/atmel/sam/sam_e70_xplained/sam_e70_xplained-pinctrl.dtsi
@@ -76,28 +76,28 @@
 		};
 	};
 
-	tc0_qdec_default: tc0_qdec_default {
+	qdec0_default: qdec0_default {
 		group1 {
 			pinmux = <PA0B_TC0_TIOA0>,
 				 <PA1B_TC0_TIOB0>;
 		};
 	};
 
-	tc1_qdec_default: tc1_qdec_default {
+	qdec1_default: qdec1_default {
 		group1 {
 			pinmux = <PC23B_TC1_TIOA3>,
 				 <PC24B_TC1_TIOB3>;
 		};
 	};
 
-	tc2_qdec_default: tc2_qdec_default {
+	qdec2_default: qdec2_default {
 		group1 {
 			pinmux = <PC5B_TC2_TIOA6>,
 				 <PC6B_TC2_TIOB6>;
 		};
 	};
 
-	tc3_qdec_default: tc3_qdec_default {
+	qdec3_default: qdec3_default {
 		group1 {
 			pinmux = <PE0B_TC3_TIOA9>,
 				 <PE1B_TC3_TIOB9>;

--- a/boards/atmel/sam/sam_e70_xplained/sam_e70_xplained_same70q21.dts
+++ b/boards/atmel/sam/sam_e70_xplained/sam_e70_xplained_same70q21.dts
@@ -15,35 +15,3 @@
 	model = "Atmel SAM E70 Xplained board";
 	compatible = "atmel,sam_e70_xplained", "atmel,same70q21", "atmel,same70";
 };
-
-&tc0 {
-	status = "okay";
-	compatible = "atmel,sam-tc-qdec";
-
-	pinctrl-0 = <&tc0_qdec_default>;
-	pinctrl-names = "default";
-};
-
-&tc1 {
-	status = "disabled";
-	compatible = "atmel,sam-tc-qdec";
-
-	pinctrl-0 = <&tc1_qdec_default>;
-	pinctrl-names = "default";
-};
-
-&tc2 {
-	status = "disabled";
-	compatible = "atmel,sam-tc-qdec";
-
-	pinctrl-0 = <&tc2_qdec_default>;
-	pinctrl-names = "default";
-};
-
-&tc3 {
-	status = "disabled";
-	compatible = "atmel,sam-tc-qdec";
-
-	pinctrl-0 = <&tc3_qdec_default>;
-	pinctrl-names = "default";
-};

--- a/drivers/sensor/qdec_sam/qdec_sam.c
+++ b/drivers/sensor/qdec_sam/qdec_sam.c
@@ -125,9 +125,9 @@ static const struct sensor_driver_api qdec_sam_driver_api = {
 #define QDEC_SAM_INIT(n)						\
 	PINCTRL_DT_INST_DEFINE(n);					\
 	static const struct qdec_sam_dev_cfg qdec##n##_sam_config = {	\
-		.regs = (Tc *)DT_INST_REG_ADDR(n),			\
+		.regs = (Tc *)DT_REG_ADDR(DT_INST_PARENT(n)),		\
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),		\
-		.clock_cfg = SAM_DT_INST_CLOCKS_PMC_CFG(n),		\
+		.clock_cfg = SAM_DT_CLOCKS_PMC_CFG(DT_INST_PARENT(n)),	\
 	};								\
 									\
 	static struct qdec_sam_dev_data qdec##n##_sam_data;		\

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -354,6 +354,11 @@
 				 <&pmc PMC_TYPE_PERIPHERAL 24>,
 				 <&pmc PMC_TYPE_PERIPHERAL 25>;
 			status = "disabled";
+
+			qdec {
+				compatible = "atmel,sam-tc-qdec";
+				status = "disabled";
+			};
 		};
 
 		tc1: tc@40010000 {
@@ -366,6 +371,11 @@
 				 <&pmc PMC_TYPE_PERIPHERAL 27>,
 				 <&pmc PMC_TYPE_PERIPHERAL 28>;
 			status = "disabled";
+
+			qdec {
+				compatible = "atmel,sam-tc-qdec";
+				status = "disabled";
+			};
 		};
 
 		tc2: tc@40014000 {
@@ -378,6 +388,11 @@
 				 <&pmc PMC_TYPE_PERIPHERAL 48>,
 				 <&pmc PMC_TYPE_PERIPHERAL 49>;
 			status = "disabled";
+
+			qdec {
+				compatible = "atmel,sam-tc-qdec";
+				status = "disabled";
+			};
 		};
 
 		tc3: tc@40054000 {
@@ -390,6 +405,11 @@
 				 <&pmc PMC_TYPE_PERIPHERAL 51>,
 				 <&pmc PMC_TYPE_PERIPHERAL 52>;
 			status = "disabled";
+
+			qdec {
+				compatible = "atmel,sam-tc-qdec";
+				status = "disabled";
+			};
 		};
 
 		trng: random@40070000 {

--- a/dts/bindings/sensor/atmel,sam-tc-qdec.yaml
+++ b/dts/bindings/sensor/atmel,sam-tc-qdec.yaml
@@ -1,19 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
-description: Atmel SAM Timer Counter (TC) QDEC node
+description: Atmel SAM Timer Counter (TC) QDEC mode
 
 compatible: "atmel,sam-tc-qdec"
 
 include:
   - name: sensor-device.yaml
   - name: pinctrl-device.yaml
-
-properties:
-  reg:
-    required: true
-
-  interrupts:
-    required: true
-
-  clocks:
-    required: true

--- a/samples/sensor/qdec/boards/sam_e70_xplained_same70q21.overlay
+++ b/samples/sensor/qdec/boards/sam_e70_xplained_same70q21.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024 Gerson Fernando Budke <nandojve@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		qdec0 = &qdec0;
+	};
+};
+
+&qdec0 {
+	status = "okay";
+};

--- a/samples/sensor/qdec/boards/sam_e70_xplained_same70q21b.overlay
+++ b/samples/sensor/qdec/boards/sam_e70_xplained_same70q21b.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024 Gerson Fernando Budke <nandojve@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		qdec0 = &qdec0;
+	};
+};
+
+&qdec0 {
+	status = "okay";
+};

--- a/samples/sensor/qdec/sample.yaml
+++ b/samples/sensor/qdec/sample.yaml
@@ -4,10 +4,17 @@ sample:
 common:
   tags: sensors
   timeout: 5
-  harness: console
 
 tests:
   sample.sensor.qdec_sensor:
+    filter: dt_alias_exists("qdec0")
+
+  sample.sensor.sam_qdec_sensor:
+    platform_allow:
+      - sam_e70_xplained/same70q21
+      - sam_e70_xplained/same70q21b
+
+  sample.sensor.st_qdec_sensor:
     platform_allow: nucleo_f401re
     harness_config:
       fixture: fixture_mech_encoder

--- a/west.yml
+++ b/west.yml
@@ -152,7 +152,7 @@ manifest:
       groups:
         - hal
     - name: hal_atmel
-      revision: d6221e73d76a4a31d802e0657342fcbda77e21ae
+      revision: 56d60ebc909ad065bf6554cee73487969857614b
       path: modules/hal/atmel
       groups:
         - hal


### PR DESCRIPTION
The current atmel,sam-tc-qdec sensor implementation shared the timer counter node. This create issues when users wants define both modes. The current proposal changes the qdec dedinition to be a child of tc and refactor all the chain of definitions.

Fixes #71312