### PR TITLE
drivers: rtc: rtc_shell: fix milliseconds display

### DIFF
--- a/drivers/rtc/rtc_shell.c
+++ b/drivers/rtc/rtc_shell.c
@@ -210,7 +210,7 @@ static int cmd_get(const struct shell *sh, size_t argc, char **argv)
 		return res;
 	}
 
-	shell_print(sh, "%04d-%02d-%02dT%02d:%02d:%02d:%06d", rtctime.tm_year + 1900,
+	shell_print(sh, "%04d-%02d-%02dT%02d:%02d:%02d.%03d", rtctime.tm_year + 1900,
 		    rtctime.tm_mon + 1, rtctime.tm_mday, rtctime.tm_hour, rtctime.tm_min,
 		    rtctime.tm_sec, rtctime.tm_nsec / 1000000);
 


### PR DESCRIPTION
The RTC shell get command displays the time according to the ISO8601 standard. Fix the milliseconds field to be displayed on 3 digits instead of 6 like if they were microseconds. In addition change the separator between seconds and milliseconds to a dot like specified in the ISO8601 standard.

Before:
2024-06-02T22:33:10:000667

After:
2024-06-02T22:33:10.667