### PR TITLE
drives: pinctrl: ITE: Add a property configure pin current strength

### DIFF
--- a/drivers/pinctrl/pinctrl_ite_it8xxx2.c
+++ b/drivers/pinctrl/pinctrl_ite_it8xxx2.c
@@ -20,6 +20,8 @@ LOG_MODULE_REGISTER(pinctrl_ite_it8xxx2, LOG_LEVEL_ERR);
 struct pinctrl_it8xxx2_gpio {
 	/* gpio port control register (byte mapping to pin) */
 	uint8_t *reg_gpcr;
+	/* port driving select control */
+	uint8_t *reg_pdsc;
 	/* function 3 general control register */
 	uintptr_t func3_gcr[GPIO_GROUP_MEMBERS];
 	/* function 3 enable mask */
@@ -74,6 +76,7 @@ static int pinctrl_it8xxx2_set(const pinctrl_soc_pin_t *pins)
 	uint8_t pin = pins->pin;
 	volatile uint8_t *reg_gpcr = (uint8_t *)gpio->reg_gpcr + pin;
 	volatile uint8_t *reg_volt_sel = (uint8_t *)(gpio->volt_sel[pin]);
+	volatile uint8_t *reg_pdsc = (uint8_t *)gpio->reg_pdsc;
 
 	/* Setting pull-up or pull-down. */
 	switch (IT8XXX2_DT_PINCFG_PUPDR(pincfg)) {
@@ -123,6 +126,18 @@ static int pinctrl_it8xxx2_set(const pinctrl_soc_pin_t *pins)
 	if (IT8XXX2_DT_PINCFG_IMPEDANCE(pincfg)) {
 		*reg_gpcr |= (GPCR_PORT_PIN_MODE_PULLUP |
 			      GPCR_PORT_PIN_MODE_PULLDOWN);
+	}
+
+	/* Driving current selection. */
+	if (reg_pdsc != NULL &&
+		IT8XXX2_DT_PINCFG_DRIVE_CURRENT(pincfg) != IT8XXX2_DRIVE_DEFAULT) {
+		if (IT8XXX2_DT_PINCFG_DRIVE_CURRENT(pincfg) & IT8XXX2_PDSCX_MASK) {
+			/* Driving current selects low. */
+			*reg_pdsc |= BIT(pin);
+		} else {
+			/* Driving current selects high. */
+			*reg_pdsc &= ~BIT(pin);
+		}
 	}
 
 	return 0;
@@ -366,6 +381,7 @@ static int pinctrl_it8xxx2_init(const struct device *dev)
 	COND_CODE_1(DT_INST_PROP(inst, gpio_group),                                    \
 		(.gpio = {                                                             \
 			 .reg_gpcr = (uint8_t *)DT_INST_REG_ADDR_BY_IDX(inst, 0),      \
+			 .reg_pdsc = (uint8_t *)DT_INST_REG_ADDR_BY_IDX(inst, 1),      \
 			 .func3_gcr = DT_INST_PROP(inst, func3_gcr),                   \
 			 .func3_en_mask = DT_INST_PROP(inst, func3_en_mask),           \
 			 .func3_ext = DT_INST_PROP_OR(inst, func3_ext, {0}),           \

--- a/dts/bindings/pinctrl/ite,it8xxx2-pinctrl.yaml
+++ b/dts/bindings/pinctrl/ite,it8xxx2-pinctrl.yaml
@@ -96,3 +96,16 @@ child-binding:
       enum:
         - "3v3"
         - "1v8"
+
+    drive-strength:
+      type: string
+      description: |
+          We can configure this property to drive a high or low current selection.
+          If this property is not configured, it is the default setting.
+          According to the SPEC, the default drive current selection varies from
+          different pins.
+          Define the high level 0b: 8mA
+                     low  level 1b: 4mA or 2mA
+      enum:
+        - "high"
+        - "low"

--- a/dts/riscv/ite/it81xx2.dtsi
+++ b/dts/riscv/ite/it81xx2.dtsi
@@ -61,7 +61,8 @@
 
 		pinctrla: pinctrl@f01610 {
 			compatible = "ite,it8xxx2-pinctrl-func";
-			reg = <0x00f01610 8>;   /* GPCR */
+			reg = <0x00f01610 8     /* GPCR */
+			       NO_FUNC    1>;
 			func3-gcr =     <NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC
 					 0xf02032 0xf02032 0xf016f0 0xf016f0>;
 			func3-en-mask = <0        0        0        0
@@ -80,7 +81,8 @@
 
 		pinctrlb: pinctrl@f01618 {
 			compatible = "ite,it8xxx2-pinctrl-func";
-			reg = <0x00f01618 8>;   /* GPCR */
+			reg = <0x00f01618 8     /* GPCR */
+			       NO_FUNC    1>;
 			func3-gcr =     <0xf016f5 0xf016f5 NO_FUNC NO_FUNC
 					 NO_FUNC  NO_FUNC  NO_FUNC 0xf01600>;
 			func3-en-mask = <0x01     0x02     0       0
@@ -99,7 +101,8 @@
 
 		pinctrlc: pinctrl@f01620 {
 			compatible = "ite,it8xxx2-pinctrl-func";
-			reg = <0x00f01620 8>;   /* GPCR */
+			reg = <0x00f01620 8     /* GPCR */
+			       NO_FUNC    1>;
 			func3-gcr =     <NO_FUNC NO_FUNC  NO_FUNC 0xf016f0
 					 NO_FUNC 0xf016f0 NO_FUNC 0xf016f3>;
 			func3-en-mask = <0       0        0       0x10
@@ -118,7 +121,8 @@
 
 		pinctrld: pinctrl@f01628 {
 			compatible = "ite,it8xxx2-pinctrl-func";
-			reg = <0x00f01628 8>;   /* GPCR */
+			reg = <0x00f01628 8     /* GPCR */
+			       NO_FUNC    1>;
 			func3-gcr =     <NO_FUNC NO_FUNC  NO_FUNC NO_FUNC
 					 NO_FUNC 0xf016f0 NO_FUNC NO_FUNC>;
 			func3-en-mask = <0       0        0       0
@@ -137,7 +141,8 @@
 
 		pinctrle: pinctrl@f01630 {
 			compatible = "ite,it8xxx2-pinctrl-func";
-			reg = <0x00f01630 8>;   /* GPCR */
+			reg = <0x00f01630 8     /* GPCR */
+			       NO_FUNC    1>;
 			func3-gcr =     <0xf02032 NO_FUNC  NO_FUNC NO_FUNC
 					 NO_FUNC  0xf016f0 NO_FUNC 0xf02032>;
 			func3-en-mask = <0x01     0        0       0
@@ -156,7 +161,8 @@
 
 		pinctrlf: pinctrl@f01638 {
 			compatible = "ite,it8xxx2-pinctrl-func";
-			reg = <0x00f01638 8>;   /* GPCR */
+			reg = <0x00f01638 8     /* GPCR */
+			       NO_FUNC    1>;
 			func3-gcr =     <NO_FUNC NO_FUNC 0xf016f0 0xf016f0
 					 NO_FUNC NO_FUNC 0xf016f1 0xf016f1>;
 			func3-en-mask = <0       0       0x02     0x02
@@ -175,7 +181,8 @@
 
 		pinctrlg: pinctrl@f01640 {
 			compatible = "ite,it8xxx2-pinctrl-func";
-			reg = <0x00f01640 8>;   /* GPCR */
+			reg = <0x00f01640 8     /* GPCR */
+			       NO_FUNC    1>;
 			func3-gcr =     <0xf016f0 0xf016f0 0xf016f0 NO_FUNC
 					 NO_FUNC  NO_FUNC  0xf016f0 NO_FUNC>;
 			func3-en-mask = <0x20     0x08     0x10     0
@@ -194,7 +201,8 @@
 
 		pinctrlh: pinctrl@f01648 {
 			compatible = "ite,it8xxx2-pinctrl-func";
-			reg = <0x00f01648 8>;   /* GPCR */
+			reg = <0x00f01648 8     /* GPCR */
+			       NO_FUNC    1>;
 			func3-gcr =     <NO_FUNC 0xf016f1 0xf016f1 NO_FUNC
 					 NO_FUNC 0xf016f5 0xf016f5 NO_FUNC>;
 			func3-en-mask = <0       0x20     0x20     0
@@ -217,7 +225,8 @@
 
 		pinctrli: pinctrl@f01650 {
 			compatible = "ite,it8xxx2-pinctrl-func";
-			reg = <0x00f01650 8>;   /* GPCR */
+			reg = <0x00f01650 8     /* GPCR */
+			       NO_FUNC    1>;
 			func3-gcr =     <NO_FUNC NO_FUNC  NO_FUNC  NO_FUNC
 					 NO_FUNC 0xf016f0 0xf016f0 0xf016f0>;
 			func3-en-mask = <0       0        0        0
@@ -236,7 +245,8 @@
 
 		pinctrlj: pinctrl@f01658 {
 			compatible = "ite,it8xxx2-pinctrl-func";
-			reg = <0x00f01658 8>;   /* GPCR */
+			reg = <0x00f01658 8     /* GPCR */
+			       NO_FUNC    1>;
 			func3-gcr =     <0xf016f4 NO_FUNC  0xf016f4 0xf016f4
 					 0xf016f0 0xf016f0 NO_FUNC  NO_FUNC>;
 			func3-en-mask = <0x01     0        0x01     0x02
@@ -255,7 +265,8 @@
 
 		pinctrlk: pinctrl@f01690 {
 			compatible = "ite,it8xxx2-pinctrl-func";
-			reg = <0x00f01690 8>;   /* GPCR */
+			reg = <0x00f01690 8     /* GPCR */
+			       NO_FUNC    1>;
 			func3-gcr =     <NO_FUNC NO_FUNC NO_FUNC NO_FUNC
 					 NO_FUNC NO_FUNC NO_FUNC NO_FUNC>;
 			func3-en-mask = <0       0       0       0
@@ -274,7 +285,8 @@
 
 		pinctrll: pinctrl@f01698 {
 			compatible = "ite,it8xxx2-pinctrl-func";
-			reg = <0x00f01698 8>;   /* GPCR */
+			reg = <0x00f01698 8     /* GPCR */
+			       NO_FUNC    1>;
 			func3-gcr =     <NO_FUNC NO_FUNC NO_FUNC NO_FUNC
 					 NO_FUNC NO_FUNC NO_FUNC NO_FUNC>;
 			func3-en-mask = <0       0       0       0
@@ -293,7 +305,8 @@
 
 		pinctrlm: pinctrl@f016a0 {
 			compatible = "ite,it8xxx2-pinctrl-func";
-			reg = <0x00f016a0 8>;   /* GPCR */
+			reg = <0x00f016a0 8     /* GPCR */
+			       NO_FUNC    1>;
 			func3-gcr =     <NO_FUNC NO_FUNC NO_FUNC NO_FUNC
 					 NO_FUNC NO_FUNC NO_FUNC NO_FUNC>;
 			func3-en-mask = <0       0       0       0

--- a/dts/riscv/ite/it82xx2.dtsi
+++ b/dts/riscv/ite/it82xx2.dtsi
@@ -447,7 +447,8 @@
 
 		pinctrla: pinctrl@f01660 {
 			compatible = "ite,it8xxx2-pinctrl-func";
-			reg = <0x00f01660 8>;   /* GPCR */
+			reg = <0x00f01660 8     /* GPCR */
+			       0x00f03e30 1>;   /* PDSCA */
 			func3-gcr =     <NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC
 					 0xf02032 0xf02032 0xf03e10 0xf03e10>;
 			func3-en-mask = <0        0        0        0
@@ -466,7 +467,8 @@
 
 		pinctrlb: pinctrl@f01668 {
 			compatible = "ite,it8xxx2-pinctrl-func";
-			reg = <0x00f01668 8>;   /* GPCR */
+			reg = <0x00f01668 8     /* GPCR */
+			       0x00f03e31 1>;   /* PDSCB */
 			func3-gcr =     <0xf03e15 0xf03e15 0xf03e11 NO_FUNC
 					 NO_FUNC  0xf03e11 NO_FUNC  NO_FUNC>;
 			func3-en-mask = <0x01     0x02     0x20     0
@@ -489,7 +491,8 @@
 
 		pinctrlc: pinctrl@f01670 {
 			compatible = "ite,it8xxx2-pinctrl-func";
-			reg = <0x00f01670 8>;   /* GPCR */
+			reg = <0x00f01670 8     /* GPCR */
+			       0x00f03e32 1>;   /* PDSCC */
 			func3-gcr =     <NO_FUNC NO_FUNC  NO_FUNC 0xf03e10
 					 NO_FUNC 0xf03e10 NO_FUNC 0xf03e13>;
 			func3-en-mask = <0       0        0       0x10
@@ -508,7 +511,8 @@
 
 		pinctrld: pinctrl@f01678 {
 			compatible = "ite,it8xxx2-pinctrl-func";
-			reg = <0x00f01678 8>;   /* GPCR */
+			reg = <0x00f01678 8     /* GPCR */
+			       0x00f03e33 1>;   /* PDSCD */
 			func3-gcr =     <NO_FUNC  NO_FUNC  NO_FUNC NO_FUNC
 					 NO_FUNC  0xf03e10 NO_FUNC NO_FUNC>;
 			func3-en-mask = <0        0        0       0
@@ -527,7 +531,8 @@
 
 		pinctrle: pinctrl@f01680 {
 			compatible = "ite,it8xxx2-pinctrl-func";
-			reg = <0x00f01680 8>;   /* GPCR */
+			reg = <0x00f01680 8     /* GPCR */
+			       0x00f03e34 1>;   /* PDSCE */
 			func3-gcr =     <NO_FUNC  0xf03e16 0xf03e16 NO_FUNC
 					 NO_FUNC  0xf03e10 NO_FUNC  NO_FUNC >;
 			func3-en-mask = <0        0x20     0x20     0
@@ -550,7 +555,8 @@
 
 		pinctrlf: pinctrl@f01688 {
 			compatible = "ite,it8xxx2-pinctrl-func";
-			reg = <0x00f01688 8>;   /* GPCR */
+			reg = <0x00f01688 8     /* GPCR */
+			       0x00f03e35 1>;   /* PDSCF */
 			func3-gcr =     <0xf03e15 0xf03e15 0xf03e10 0xf03e10
 					 NO_FUNC  NO_FUNC  0xf03e11 NO_FUNC>;
 			func3-en-mask = <0x04     0x08     0x02     0x02
@@ -569,7 +575,8 @@
 
 		pinctrlg: pinctrl@f01690 {
 			compatible = "ite,it8xxx2-pinctrl-func";
-			reg = <0x00f01690 8>;   /* GPCR */
+			reg = <0x00f01690 8     /* GPCR */
+			       0x00f03e36 1>;   /* PDSCG */
 			func3-gcr =     <0xf03e10 0xf03e10 0xf03e10 NO_FUNC
 					 NO_FUNC  NO_FUNC  0xf03e10 NO_FUNC>;
 			func3-en-mask = <0x20     0x08     0x10     0
@@ -588,7 +595,8 @@
 
 		pinctrlh: pinctrl@f01698 {
 			compatible = "ite,it8xxx2-pinctrl-func";
-			reg = <0x00f01698 8>;   /* GPCR */
+			reg = <0x00f01698 8     /* GPCR */
+			       0x00f03e37 1>;   /* PDSCH */
 			func3-gcr =     <NO_FUNC 0xf03e11 0xf03e11 NO_FUNC
 					 NO_FUNC 0        0        NO_FUNC>;
 			func3-en-mask = <0       0x20     0x20     0
@@ -607,7 +615,8 @@
 
 		pinctrli: pinctrl@f016a0 {
 			compatible = "ite,it8xxx2-pinctrl-func";
-			reg = <0x00f016a0 8>;   /* GPCR */
+			reg = <0x00f016a0 8     /* GPCR */
+			       NO_FUNC    1>;
 			func3-gcr =     <NO_FUNC NO_FUNC  NO_FUNC  NO_FUNC
 					 NO_FUNC 0xf03e10 0xf03e10 0xf03e10>;
 			func3-en-mask = <0       0        0        0
@@ -626,7 +635,8 @@
 
 		pinctrlj: pinctrl@f016a8 {
 			compatible = "ite,it8xxx2-pinctrl-func";
-			reg = <0x00f016a8 8>;   /* GPCR */
+			reg = <0x00f016a8 8     /* GPCR */
+			       0x00f03e39 1>;   /* PDSCJ */
 			func3-gcr =     <0xf03e14 NO_FUNC  0xf03e14 0xf03e14
 					 0xf03e10 0xf03e10 NO_FUNC  NO_FUNC>;
 			func3-en-mask = <0x01     0        0x01     0x02
@@ -645,7 +655,8 @@
 
 		pinctrlk: pinctrl@f016b0 {
 			compatible = "ite,it8xxx2-pinctrl-func";
-			reg = <0x00f016b0 8>;   /* GPCR */
+			reg = <0x00f016b0 8     /* GPCR */
+			       0x00f03e3A 1>;   /* PDSCK */
 			func3-gcr =     <NO_FUNC NO_FUNC NO_FUNC NO_FUNC
 					 NO_FUNC NO_FUNC NO_FUNC NO_FUNC>;
 			func3-en-mask = <0       0       0       0
@@ -664,7 +675,8 @@
 
 		pinctrll: pinctrl@f016b8 {
 			compatible = "ite,it8xxx2-pinctrl-func";
-			reg = <0x00f016b8 8>;   /* GPCR */
+			reg = <0x00f016b8 8     /* GPCR */
+			       0x00f03e3B 1>;   /* PDSCL */
 			func3-gcr =     <NO_FUNC NO_FUNC NO_FUNC NO_FUNC
 					 NO_FUNC NO_FUNC NO_FUNC NO_FUNC>;
 			func3-en-mask = <0       0       0       0
@@ -683,7 +695,8 @@
 
 		pinctrlm: pinctrl@f016c0 {
 			compatible = "ite,it8xxx2-pinctrl-func";
-			reg = <0x00f016c0 8>;   /* GPCR */
+			reg = <0x00f016c0 8     /* GPCR */
+			       NO_FUNC    1>;
 			func3-gcr =     <NO_FUNC NO_FUNC NO_FUNC NO_FUNC
 					 NO_FUNC NO_FUNC NO_FUNC NO_FUNC>;
 			func3-en-mask = <0       0       0       0

--- a/soc/ite/ec/common/pinctrl_soc.h
+++ b/soc/ite/ec/common/pinctrl_soc.h
@@ -42,6 +42,8 @@ typedef struct pinctrl_soc_pin pinctrl_soc_pin_t;
  *    Pin voltage selection     [ 8 ]
  *    Pin input enable config   [ 12 ]
  *    Pin push-pull/open-drain  [ 16 ]
+ *    Pin drive current high/low[ 20 ]
+ *    Pin drive current default [ 21 ]
  */
 #define IT8XXX2_HIGH_IMPEDANCE     0x1U
 #define IT8XXX2_PULL_PIN_DEFAULT   0x0U
@@ -52,6 +54,8 @@ typedef struct pinctrl_soc_pin pinctrl_soc_pin_t;
 #define IT8XXX2_INPUT_ENABLE       0x1U
 #define IT8XXX2_PUSH_PULL          0x0U
 #define IT8XXX2_OPEN_DRAIN         0x1U
+#define IT8XXX2_DRIVE_STRENGTH     0x1U
+#define IT8XXX2_DRIVE_DEFAULT      0x2U
 
 /* Pin tri-state mode. */
 #define IT8XXX2_IMPEDANCE_SHIFT    0U
@@ -69,6 +73,9 @@ typedef struct pinctrl_soc_pin pinctrl_soc_pin_t;
 /* Pin push-pull/open-drain mode */
 #define IT8XXX2_PP_OD_SHIFT        16U
 #define IT8XXX2_PP_OD_MASK         BIT_MASK(1)
+/* Pin driving select control */
+#define IT8XXX2_PDSCX_SHIFT        20U
+#define IT8XXX2_PDSCX_MASK         BIT_MASK(2)
 
 /**
  * @brief Utility macro to obtain configuration of tri-state.
@@ -107,6 +114,12 @@ typedef struct pinctrl_soc_pin pinctrl_soc_pin_t;
 	(((__mode) >> IT8XXX2_PP_OD_SHIFT) & IT8XXX2_PP_OD_MASK)
 
 /**
+ * @brief Utility macro to obtain configuration of driving current selection.
+ */
+#define IT8XXX2_DT_PINCFG_DRIVE_CURRENT(__mode) \
+	(((__mode) >> IT8XXX2_PDSCX_SHIFT) & IT8XXX2_PDSCX_MASK)
+
+/**
  * @brief Utility macro to initialize pincfg field in #pinctrl_pin_t.
  *
  * @param node_id Node identifier.
@@ -125,7 +138,10 @@ typedef struct pinctrl_soc_pin pinctrl_soc_pin_t;
 	 ((IT8XXX2_INPUT_ENABLE * DT_PROP(node_id, input_enable))              \
 	 << IT8XXX2_INPUT_SHIFT) |                                             \
 	 ((IT8XXX2_OPEN_DRAIN * DT_PROP(node_id, drive_open_drain))            \
-	 << IT8XXX2_PP_OD_SHIFT))
+	 << IT8XXX2_PP_OD_SHIFT) |                                             \
+	 ((IT8XXX2_DRIVE_STRENGTH *                                            \
+	 DT_ENUM_IDX_OR(node_id, drive_strength, IT8XXX2_DRIVE_DEFAULT))       \
+	 << IT8XXX2_PDSCX_SHIFT))
 
 /**
  * @brief Utility macro to initialize pinctrls of pinmuxs field in #pinctrl_pin_t.


### PR DESCRIPTION
Add the property of drive-strength to drive a high or low current selection. If this property is not configured, it is the default
setting. According to the SPEC, the default drive current selection varies from different pins.
Define the high level 0b: 8mA
                  low  level 1b: 4mA or 2mA