### PR TITLE
codespace: add support for GitHub codespace

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/base:debian",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/home/vscode/zephyrproject/zephyr,type=bind",
+  "workspaceFolder": "/home/vscode/zephyrproject/zephyr",
+  "onCreateCommand": "bash -i /home/vscode/zephyrproject/zephyr/.devcontainer/setup.sh",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "C_Cpp.default.compileCommands": "/home/vscode/zephyrproject/zephyr/build/compile_commands.json",
+        "devicetree.zephyr": "/home/vscode/zephyrproject/zephyr",
+        "extensions.ignoreRecommendations": true
+      },
+      "extensions": [
+        "ms-vscode.cpptools",
+        "nordic-semiconductor.nrf-devicetree",
+        "nordic-semiconductor.nrf-kconfig",
+        "editorconfig.editorconfig"
+      ]
+    }
+  }
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+#
+# Copyright (c) 2024 Yong Cong Sin <yongcong.sin@gmail.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Configurations
+## Zephyr SDK version
+SDK_VERSION=0.16.8
+## Install Directory
+INSTALL_DIR="/opt"
+## Python Virtual Env
+VENV_DIR="$INSTALL_DIR/.venv"
+
+# The owner of dir created in `devcontainer.json` is `root`,
+# change it to $USER:$USER here so that we can modify it.
+sudo chown -R $USER:$USER ~/zephyrproject
+
+# Install dependencies
+# https://docs.zephyrproject.org/latest/develop/getting_started/index.html#install-dependencies
+sudo apt update -y && sudo apt upgrade -y
+
+TMP_DIR=`mktemp -d`
+if [[ ! "$TMP_DIR" || ! -d "$TMP_DIR" ]]; then
+  echo "Could not create temp dir"
+  exit 1
+fi
+
+cd "$TMP_DIR"
+wget https://apt.kitware.com/kitware-archive.sh
+sudo bash kitware-archive.sh
+
+sudo apt install -y --no-install-recommends git cmake ninja-build gperf \
+  ccache dfu-util device-tree-compiler wget \
+  python3-dev python3-pip python3-setuptools python3-tk python3-wheel python3-venv xz-utils file \
+  make gcc gcc-multilib g++-multilib libsdl2-dev libmagic1
+
+# Install the Zephyr SDK
+# https://docs.zephyrproject.org/latest/develop/getting_started/index.html#install-the-zephyr-sdk
+wget "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${SDK_VERSION}/zephyr-sdk-${SDK_VERSION}_linux-x86_64.tar.xz"
+wget -O - "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${SDK_VERSION}/sha256.sum | shasum --check --ignore-missing"
+sudo mkdir -p $INSTALL_DIR
+sudo chown -R $USER:$USER $INSTALL_DIR
+tar xvf "zephyr-sdk-${SDK_VERSION}_linux-x86_64.tar.xz" -C $INSTALL_DIR
+cd "$INSTALL_DIR/zephyr-sdk-${SDK_VERSION}"
+./setup.sh -t all -h -c
+
+# Cleanup
+rm -rf $TMP_DIR
+sudo apt-get clean -y && \
+	sudo apt-get autoremove --purge -y && \
+	sudo rm -rf /var/lib/apt/lists/*
+
+# Create west config file so that we dont have to `west init`
+mkdir -p ~/zephyrproject/.west
+echo "[manifest]" >> ~/zephyrproject/.west/config
+echo "path = zephyr" >> ~/zephyrproject/.west/config
+echo "file = west.yml" >> ~/zephyrproject/.west/config
+echo "" >> ~/zephyrproject/.west/config
+echo "[zephyr]" >> ~/zephyrproject/.west/config
+echo "base = zephyr" >> ~/zephyrproject/.west/config
+echo "" >> ~/zephyrproject/.west/config
+echo "[build]" >> ~/zephyrproject/.west/config
+echo "cmake-args = -DCMAKE_EXPORT_COMPILE_COMMANDS=ON" >> ~/zephyrproject/.west/config
+
+# Get Zephyr and install Python dependencies
+# https://docs.zephyrproject.org/latest/develop/getting_started/index.html#get-zephyr-and-install-python-dependencies
+python3 -m venv $VENV_DIR
+source $VENV_DIR/bin/activate
+
+pip install west
+cd ~/zephyrproject
+source ~/zephyrproject/zephyr/zephyr-env.sh
+west update
+west zephyr-export
+pip install -r ~/zephyrproject/zephyr/scripts/requirements.txt
+
+west completion bash > $INSTALL_DIR/west-completion.bash
+source $INSTALL_DIR/west-completion.bash
+
+echo "source ${INSTALL_DIR}/west-completion.bash" >> ~/.bashrc
+echo "source ${VENV_DIR}/bin/activate" >> ~/.bashrc
+echo "source ~/zephyrproject/zephyr/zephyr-env.sh" >> ~/.bashrc
+
+cd ~/zephyrproject/zephyr
+history -c

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,9 @@ Getting Started
 ***************
 
 Welcome to Zephyr! See the `Introduction to Zephyr`_ for a high-level overview,
-and the documentation's `Getting Started Guide`_ to start developing.
+and the documentation's `Getting Started Guide`_ to start developing. Alternatively,
+you can try out Zephyr by creating a GitHub codespace without any installation; see
+`Create GitHub codespace`_ for details.
 
 .. start_include_here
 

--- a/doc/develop/codespace/index.rst
+++ b/doc/develop/codespace/index.rst
@@ -1,0 +1,95 @@
+.. _github_codespace:
+
+Developing with GitHub Codespace
+################################
+
+`GitHub codespace <https://github.com/features/codespaces>`_ is a development environment that's
+hosted in the cloud. By leveraging _free*_ hours provided by GitHub, it allows users to get started
+or get something done with Zephyr on any device that has a modern web browser and has access to the
+internet.
+
+   .. note::
+
+      Read more about GitHub codespace billing `here <https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces>`_.
+
+When creating a codespace from a Zephyr repository, a custom devcontainer image will be built
+on the fly following the
+`Getting Started Guide <https://docs.zephyrproject.org/latest/develop/getting_started/index.html>`_,
+this process is expected to take quite a few minutes.
+
+Once everything is installed, you will be presented with a Visual Studio Code (VSCode) web interface, with some
+extensions configured and is ready to build firmware.
+
+It is also possible to connect to GitHub codespace from VSCode. This might be advantageous
+for users on company computers that restricts the installation of unapproved software. For example, this
+setup allows users to develop with `Renode <https://renode.io/>`_, or compile applications for
+:ref:`native_sim<native_sim>` on a Mac.
+
+
+.. _limitations:
+
+Limitations
+***********
+
+* USB access is not supported in GitHub codespace, and therefore any operations
+  (i.e. firmware programming and debugging) that requires USB will not work.
+
+.. _additional_configs:
+
+Additional Configurations
+*************************
+
+This section documents the configuration of some VSCode extensions that could be
+handy in developing with Zephyr.
+
+.. _config_checkpatch:
+
+Checkpatch
+==========
+
+Zephyr CI uses the checkpatch script to validate if the patch submitted conforms to our
+coding guidelines, user can run the script by executing it in the terminal. Alternatively,
+we can make use of VSCode and view the violation directly in the editor. To do that, download
+the extension `here <https://marketplace.visualstudio.com/items?itemName=idanp.checkpatch>`_,
+then apply the following configurations (copied from
+`here <https://github.com/zephyrproject-rtos/zephyr/blob/main/.checkpatch.conf>`_)
+to the setting.
+
+.. code-block:: json
+
+   {
+      "checkpatch.checkpatchPath": "/home/vscode/zephyrproject/zephyr/scripts/checkpatch.pl",
+      "checkpatch.checkpatchArgs": [
+      "--emacs",
+      "--summary-file",
+      "--show-types",
+      "--max-line-length=100",
+      "--min-conf-desc-length=1",
+      "--typedefsfile=/home/vscode/zephyrproject/zephyr/scripts/checkpatch/typedefsfile",
+      "--ignore BRACES",
+      "--ignore PRINTK_WITHOUT_KERN_LEVEL",
+      "--ignore SPLIT_STRING",
+      "--ignore VOLATILE",
+      "--ignore CONFIG_EXPERIMENTAL",
+      "--ignore PREFER_KERNEL_TYPES",
+      "--ignore PREFER_SECTION",
+      "--ignore AVOID_EXTERNS",
+      "--ignore NETWORKING_BLOCK_COMMENT_STYLE",
+      "--ignore DATE_TIME",
+      "--ignore MINMAX",
+      "--ignore CONST_STRUCT",
+      "--ignore FILE_PATH_CHANGES",
+      "--ignore SPDX_LICENSE_TAG",
+      "--ignore C99_COMMENT_TOLERANCE",
+      "--ignore REPEATED_WORD",
+      "--ignore UNDOCUMENTED_DT_STRING",
+      "--ignore DT_SPLIT_BINDING_PATCH",
+      "--ignore DT_SCHEMA_BINDING_PATCH",
+      "--ignore TRAILING_SEMICOLON",
+      "--ignore COMPLEX_MACRO",
+      "--ignore MULTISTATEMENT_MACRO_USE_DO_WHILE",
+      "--ignore ENOSYS",
+      "--ignore IS_ENABLED_CONFIG",
+      "--ignore EXPORT_SYMBOL"
+      ]
+   }

--- a/doc/develop/index.rst
+++ b/doc/develop/index.rst
@@ -8,6 +8,7 @@ Developing with Zephyr
 
    getting_started/index.rst
    beyond-GSG.rst
+   codespace/index.rst
    env_vars.rst
    application/index.rst
    debug/index.rst


### PR DESCRIPTION
Build a custom devcontainer image following the [Zephyr Getting Started Guide](https://docs.zephyrproject.org/latest/develop/getting_started/index.html), this allows users to get started or get something done on any device that has a modern web browser and has access to the internet (i.e. Tablets, Smartphones), by leveraging _free*_ hours provided by GitHub:

> ![Screenshot 2024-06-03 at 12 32 54 PM](https://github.com/zephyrproject-rtos/zephyr/assets/1563974/b5a0bad0-d9c7-4940-b5e6-bd7a8664a628)

> [!NOTE]
> Read more about billing [here](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces).

To get started, just press the `+` or the big green button:

> <img width="422" alt="Screenshot 2024-06-03 at 12 43 24 PM" src="https://github.com/zephyrproject-rtos/zephyr/assets/1563974/55b5bb77-e224-4a4f-9465-0f37cc98456e">

The initialization of codespace will take just a couple of minutes, you can see what it is doing by pressing the `View logs` button:

> <img width="862" alt="Screenshot 2024-06-03 at 12 35 33 PM" src="https://github.com/zephyrproject-rtos/zephyr/assets/1563974/007f3d48-189e-430d-b7ee-093c0bf1e95a">

If the `setup.sh` ran everything successfully (occasionally, it might not, like some of the Python packages fails to install during init), user will be presented with a Visual Studio Code web interface (GitHub codespace), with checkpatch and intellisense properly configured and is ready to build firmware:

> ![Screenshot 2024-06-03 at 12 01 15 PM](https://github.com/zephyrproject-rtos/zephyr/assets/1563974/e3ce49db-9c1f-4cf0-b97b-79ec625402c4)
> <img width="1439" alt="Screenshot 2024-06-03 at 12 03 29 PM" src="https://github.com/zephyrproject-rtos/zephyr/assets/1563974/7e82eb6c-b7aa-4f89-b53b-785fc11b288c">

Ideally we should be able to use [ZephyrProject CI docker image](https://hub.docker.com/r/zephyrprojectrtos/zephyr-build), but codespace takes forever to pull the containers 🙁 We can also prebuild the codespace image but that option will incur storage cost to the org (zephyrproject).

## How to test?

Go to https://github.com/ycsin/zephyr/tree/pr/codespace

Press the `+` or the big green button:

> <img width="422" alt="Screenshot 2024-06-03 at 12 43 24 PM" src="https://github.com/zephyrproject-rtos/zephyr/assets/1563974/55b5bb77-e224-4a4f-9465-0f37cc98456e">