### PR TITLE
Bluetooth: Host: Test RPA update on time-limited scanning

### DIFF
--- a/tests/bsim/bluetooth/host/privacy/central/src/main.c
+++ b/tests/bsim/bluetooth/host/privacy/central/src/main.c
@@ -10,6 +10,7 @@
 void tester_procedure(void);
 void tester_procedure_periph_delayed_start_of_conn_adv(void);
 void dut_procedure(void);
+void dut_procedure_with_scan_timeout(void);
 void dut_procedure_connect_short_rpa_timeout(void);
 void dut_procedure_connect_timeout(void);
 
@@ -20,6 +21,13 @@ static const struct bst_test_instance test_to_add[] = {
 		.test_pre_init_f = test_init,
 		.test_tick_f = test_tick,
 		.test_main_f = dut_procedure,
+	},
+	{
+		.test_id = "central_scan_with_timeout",
+		.test_descr = "Central performs active scanning using RPA",
+		.test_pre_init_f = test_init,
+		.test_tick_f = test_tick,
+		.test_main_f = dut_procedure_with_scan_timeout,
 	},
 	{
 		.test_id = "central_connect_short_rpa_timeout",

--- a/tests/bsim/bluetooth/host/privacy/central/test_scripts/run_test_scan_timeout.sh
+++ b/tests/bsim/bluetooth/host/privacy/central/test_scripts/run_test_scan_timeout.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Copyright 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+set -eu
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+EXECUTE_TIMEOUT=100
+verbosity_level=2
+
+# Test that RPA refresh works even if scan timeout is non-zero
+simulation_id="test_scan_timeout"
+
+central_exe="${BSIM_OUT_PATH}/bin/bs_${BOARD_TS}_$(guess_test_long_name)_prj_conf"
+peripheral_exe="${central_exe}"
+
+cd ${BSIM_OUT_PATH}/bin
+
+Execute "$central_exe" \
+    -v=${verbosity_level} -s=${simulation_id} -d=0 \
+    -testid=central_scan_with_timeout -RealEncryption=1
+
+Execute "$peripheral_exe" \
+    -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral -RealEncryption=1
+
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
+    -D=2 -sim_length=120e6 $@
+
+wait_for_background_jobs


### PR DESCRIPTION
Add a test where the application chooses to set a scan timeout greater than the RPA timeout.

Previously we were lacking test coverage for time-limited scanning.

(Currently this test is failing - the RPA is never updated)