### PR TITLE
net: lwm2m: Block-Wise response NUM field fix

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -1004,7 +1004,7 @@ static int lwm2m_write_handler_opaque(struct lwm2m_engine_obj_inst *obj_inst,
 				return ret;
 			}
 		}
-		if (msg->in.block_ctx) {
+		if (msg->in.block_ctx && !last_pkt_block) {
 			msg->in.block_ctx->ctx.current += len;
 		}
 	}


### PR DESCRIPTION
When calculating the offset for blockwise writes,
we should not advance the block_ctx->current field past the block boundary.
It causes CoAP layer to reply with the next NUM field instead of the current one being processed.

Fixes regression caused by https://github.com/zephyrproject-rtos/zephyr/pull/72590