### PR TITLE
boards nrf_bsim: Add NVIC_GetEnableIRQ()

### DIFF
--- a/boards/native/nrf_bsim/common/cmsis/cmsis.c
+++ b/boards/native/nrf_bsim/common/cmsis/cmsis.c
@@ -35,6 +35,11 @@ void NVIC_EnableIRQ(IRQn_Type IRQn)
 	hw_irq_ctrl_enable_irq(CONFIG_NATIVE_SIMULATOR_MCU_N, IRQn);
 }
 
+uint32_t NVIC_GetEnableIRQ(IRQn_Type IRQn)
+{
+	return hw_irq_ctrl_is_irq_enabled(CONFIG_NATIVE_SIMULATOR_MCU_N, IRQn);
+}
+
 void NVIC_SetPriority(IRQn_Type IRQn, uint32_t priority)
 {
 	hw_irq_ctrl_prio_set(CONFIG_NATIVE_SIMULATOR_MCU_N, IRQn, priority);


### PR DESCRIPTION
Provide a replacement for CMSIS' NVIC_GetEnableIRQ() as some applications use it.