### PR TITLE
boards: st: stm32c0116_dk defines the select pin with zephyr,code

### DIFF
--- a/boards/st/stm32c0116_dk/stm32c0116_dk.dts
+++ b/boards/st/stm32c0116_dk/stm32c0116_dk.dts
@@ -53,7 +53,7 @@
 
 		select_key {
 			press-thresholds-mv = <0>;
-			zephyr,code = <INPUT_KEY_SELECT>;
+			zephyr,code = <INPUT_KEY_ENTER>;
 		};
 
 		left_key {


### PR DESCRIPTION
Define the select_key with the correct zephyr,code which is <INPUT_KEY_ENTER>

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/73599
