### PR TITLE
west.yaml: update hal_stm32 modules to supports the stm32h7RS serie

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -234,7 +234,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 366c5c909fbcecf94f32411887132024f61b0bcd
+      revision: 54724a815d23b7f518fa88eb5fb7e991109e191b
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Update revision reference for the hal_stm32 with the new stm32h7RS mcu from STMIcroelectronics.

use the latest hal_stm32 module which includes the sm32h7rs serie : 54724a815d23b7f518fa88eb5fb7e991109e191b
