### PR TITLE
include: logging: added missing parenthesis

### DIFF
--- a/include/zephyr/logging/log.h
+++ b/include/zephyr/logging/log.h
@@ -185,7 +185,7 @@ extern "C" {
  * @param _str    Persistent, raw string.
  */
 #define LOG_HEXDUMP_ERR(_data, _length, _str) \
-	Z_LOG_HEXDUMP(LOG_LEVEL_ERR, _data, _length, _str)
+	Z_LOG_HEXDUMP(LOG_LEVEL_ERR, _data, _length, (_str))
 
 /**
  * @brief Writes a WARNING level message to the log.
@@ -198,7 +198,7 @@ extern "C" {
  * @param _str    Persistent, raw string.
  */
 #define LOG_HEXDUMP_WRN(_data, _length, _str) \
-	Z_LOG_HEXDUMP(LOG_LEVEL_WRN, _data, _length, _str)
+	Z_LOG_HEXDUMP(LOG_LEVEL_WRN, _data, _length, (_str))
 
 /**
  * @brief Writes an INFO level message to the log.
@@ -210,7 +210,7 @@ extern "C" {
  * @param _str    Persistent, raw string.
  */
 #define LOG_HEXDUMP_INF(_data, _length, _str) \
-	Z_LOG_HEXDUMP(LOG_LEVEL_INF, _data, _length, _str)
+	Z_LOG_HEXDUMP(LOG_LEVEL_INF, _data, _length, (_str))
 
 /**
  * @brief Writes a DEBUG level message to the log.
@@ -222,7 +222,7 @@ extern "C" {
  * @param _str    Persistent, raw string.
  */
 #define LOG_HEXDUMP_DBG(_data, _length, _str) \
-	Z_LOG_HEXDUMP(LOG_LEVEL_DBG, _data, _length, _str)
+	Z_LOG_HEXDUMP(LOG_LEVEL_DBG, _data, _length, (_str))
 
 /**
  * @brief Writes an ERROR hexdump message associated with the instance to the
@@ -330,7 +330,7 @@ void z_log_vprintk(const char *fmt, va_list ap);
 	{											\
 		.name = COND_CODE_1(CONFIG_LOG_FMT_SECTION,					\
 				(UTIL_CAT(_name, _str)), (STRINGIFY(_name))),			\
-		.level = _level									\
+		.level = (_level)								\
 	}
 
 #define _LOG_MODULE_DYNAMIC_DATA_CREATE(_name)					\

--- a/include/zephyr/logging/log_core.h
+++ b/include/zephyr/logging/log_core.h
@@ -141,15 +141,15 @@ extern "C" {
 		(Z_LOG_STR_WITH_PREFIX(__VA_ARGS__)), (__VA_ARGS__))
 
 #define Z_LOG_LEVEL_CHECK(_level, _check_level, _default_level) \
-	(_level <= Z_LOG_RESOLVED_LEVEL(_check_level, _default_level))
+	((_level) <= Z_LOG_RESOLVED_LEVEL(_check_level, _default_level))
 
 #define Z_LOG_CONST_LEVEL_CHECK(_level)					    \
 	(IS_ENABLED(CONFIG_LOG) &&					    \
 	(Z_LOG_LEVEL_CHECK(_level, CONFIG_LOG_OVERRIDE_LEVEL, LOG_LEVEL_NONE) \
 	||								    \
 	((IS_ENABLED(CONFIG_LOG_OVERRIDE_LEVEL) == false) &&		    \
-	(_level <= __log_level) &&					    \
-	(_level <= CONFIG_LOG_MAX_LEVEL)				    \
+	((_level) <= __log_level) &&					    \
+	((_level) <= CONFIG_LOG_MAX_LEVEL)				    \
 	)								    \
 	))
 
@@ -257,7 +257,7 @@ static inline char z_log_minimal_level_to_char(int level)
 	} \
 	int _mode; \
 	void *_src = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
-		(void *)_dsource : (void *)_source; \
+		(void *)(_dsource) : (void *)(_source); \
 	bool string_ok; \
 	LOG_POINTERS_VALIDATE(string_ok, __VA_ARGS__); \
 	if (!string_ok) { \
@@ -331,17 +331,17 @@ static inline char z_log_minimal_level_to_char(int level)
 	\
 	if (IS_ENABLED(CONFIG_LOG_MODE_MINIMAL)) { \
 		Z_LOG_TO_PRINTK(_level, "%s", _str); \
-		z_log_minimal_hexdump_print(_level, \
-					    (const char *)_data, _len);\
+		z_log_minimal_hexdump_print((_level), \
+					    (const char *)(_data), (_len));\
 		break; \
 	} \
 	if (!IS_ENABLED(CONFIG_LOG_FRONTEND) && IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) && \
-	    !is_user_context && _level > Z_LOG_RUNTIME_FILTER(filters)) { \
+	    !is_user_context && (_level) > Z_LOG_RUNTIME_FILTER(filters)) { \
 		break; \
 	} \
 	int mode; \
 	void *_src = IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ? \
-		(void *)_dsource : (void *)_source; \
+		(void *)(_dsource) : (void *)(_source); \
 	Z_LOG_MSG_CREATE(UTIL_NOT(IS_ENABLED(CONFIG_USERSPACE)), mode, \
 				  Z_LOG_LOCAL_DOMAIN_ID, _src, _level, \
 			  _data, _len, \
@@ -417,7 +417,7 @@ static inline char z_log_minimal_level_to_char(int level)
  * two other backends are set for ERR, returned level is INF.
  */
 #define Z_LOG_RUNTIME_FILTER(_filter) \
-	LOG_FILTER_SLOT_GET(&_filter, LOG_FILTER_AGGR_SLOT_IDX)
+	LOG_FILTER_SLOT_GET(&(_filter), LOG_FILTER_AGGR_SLOT_IDX)
 
 /** @brief Log level value used to indicate log entry that should not be
  *	   formatted (raw string).

--- a/include/zephyr/logging/log_msg.h
+++ b/include/zephyr/logging/log_msg.h
@@ -150,10 +150,10 @@ enum z_log_msg_mode {
 	.valid = 0, \
 	.busy = 0, \
 	.type = Z_LOG_MSG_LOG, \
-	.domain = _domain_id, \
-	.level = _level, \
-	.package_len = _plen, \
-	.data_len = _dlen, \
+	.domain = (_domain_id), \
+	.level = (_level), \
+	.package_len = (_plen), \
+	.data_len = (_dlen), \
 }
 
 #define Z_LOG_MSG_CBPRINTF_FLAGS(_cstr_cnt) \
@@ -165,11 +165,11 @@ enum z_log_msg_mode {
 #define Z_LOG_MSG_ON_STACK_ALLOC(ptr, len) \
 	long long _ll_buf[DIV_ROUND_UP(len, sizeof(long long))]; \
 	long double _ld_buf[DIV_ROUND_UP(len, sizeof(long double))]; \
-	ptr = (sizeof(long double) == Z_LOG_MSG_ALIGNMENT) ? \
+	(ptr) = (sizeof(long double) == Z_LOG_MSG_ALIGNMENT) ? \
 			(struct log_msg *)_ld_buf : (struct log_msg *)_ll_buf; \
 	if (IS_ENABLED(CONFIG_LOG_TEST_CLEAR_MESSAGE_SPACE)) { \
 		/* During test fill with 0's to simplify message comparison */ \
-		memset(ptr, 0, len); \
+		memset((ptr), 0, (len)); \
 	}
 #else /* Z_LOG_MSG_USE_VLA */
 /* When VLA cannot be used we need to trick compiler a bit and create multiple
@@ -203,7 +203,7 @@ enum z_log_msg_mode {
 	} \
 	if (IS_ENABLED(CONFIG_LOG_TEST_CLEAR_MESSAGE_SPACE)) { \
 		/* During test fill with 0's to simplify message comparison */ \
-		memset(ptr, 0, len); \
+		memset((ptr), 0, (len)); \
 	}
 #endif /* Z_LOG_MSG_USE_VLA */
 
@@ -211,7 +211,7 @@ enum z_log_msg_mode {
 	offsetof(struct log_msg, data)
 
 #define Z_LOG_MSG_LEN(pkg_len, data_len) \
-	(offsetof(struct log_msg, data) + pkg_len + (data_len))
+	(offsetof(struct log_msg, data) + (pkg_len) + (data_len))
 
 #define Z_LOG_MSG_ALIGNED_WLEN(pkg_len, data_len) \
 	DIV_ROUND_UP(ROUND_UP(Z_LOG_MSG_LEN(pkg_len, data_len), \
@@ -351,7 +351,7 @@ do { \
 					   (uint32_t)_plen, _dlen); \
 	LOG_MSG_DBG("creating message on stack: package len: %d, data len: %d\n", \
 			_plen, (int)(_dlen)); \
-	z_log_msg_static_create((void *)_source, _desc, _msg->data, _data); \
+	z_log_msg_static_create((void *)(_source), _desc, _msg->data, (_data)); \
 } while (false)
 
 #ifdef CONFIG_LOG_SPEED
@@ -506,13 +506,13 @@ do { \
 			  _level, _data, _dlen, ...) \
 do {\
 	Z_LOG_MSG_STR_VAR(_fmt, ##__VA_ARGS__) \
-	z_log_msg_runtime_create(_domain_id, (void *)_source, \
-				  _level, (uint8_t *)_data, _dlen,\
+	z_log_msg_runtime_create((_domain_id), (void *)(_source), \
+				  (_level), (uint8_t *)(_data), (_dlen),\
 				  Z_LOG_MSG_CBPRINTF_FLAGS(_cstr_cnt) | \
 				  (IS_ENABLED(CONFIG_LOG_USE_TAGGED_ARGUMENTS) ? \
 				   CBPRINTF_PACKAGE_ARGS_ARE_TAGGED : 0), \
 				  Z_LOG_FMT_RUNTIME_ARGS(_fmt, ##__VA_ARGS__));\
-	_mode = Z_LOG_MSG_MODE_RUNTIME; \
+	(_mode) = Z_LOG_MSG_MODE_RUNTIME; \
 } while (false)
 #else /* CONFIG_LOG_ALWAYS_RUNTIME */
 #define Z_LOG_MSG_CREATE3(_try_0cpy, _mode,  _cstr_cnt, _domain_id, _source,\
@@ -522,11 +522,11 @@ do { \
 	bool has_rw_str = CBPRINTF_MUST_RUNTIME_PACKAGE( \
 					Z_LOG_MSG_CBPRINTF_FLAGS(_cstr_cnt), \
 					__VA_ARGS__); \
-	if (IS_ENABLED(CONFIG_LOG_SPEED) && _try_0cpy && ((_dlen) == 0) && !has_rw_str) {\
+	if (IS_ENABLED(CONFIG_LOG_SPEED) && (_try_0cpy) && ((_dlen) == 0) && !has_rw_str) {\
 		LOG_MSG_DBG("create zero-copy message\n");\
 		Z_LOG_MSG_SIMPLE_CREATE(_cstr_cnt, _domain_id, _source, \
 					_level, Z_LOG_FMT_ARGS(_fmt, ##__VA_ARGS__)); \
-		_mode = Z_LOG_MSG_MODE_ZERO_COPY; \
+		(_mode) = Z_LOG_MSG_MODE_ZERO_COPY; \
 	} else { \
 		IF_ENABLED(UTIL_AND(IS_ENABLED(CONFIG_LOG_SIMPLE_MSG_OPTIMIZE), \
 				    UTIL_AND(UTIL_NOT(_domain_id), UTIL_NOT(_cstr_cnt))), \
@@ -544,9 +544,9 @@ do { \
 		LOG_MSG_DBG("create on stack message\n");\
 		Z_LOG_MSG_STACK_CREATE(_cstr_cnt, _domain_id, _source, _level, _data, \
 					_dlen, Z_LOG_FMT_ARGS(_fmt, ##__VA_ARGS__)); \
-		_mode = Z_LOG_MSG_MODE_FROM_STACK; \
+		(_mode) = Z_LOG_MSG_MODE_FROM_STACK; \
 	} \
-	(void)_mode; \
+	(void)(_mode); \
 } while (false)
 
 #if defined(__cplusplus)


### PR DESCRIPTION
Added missing parentheses around macro argument expansion.

This corresponds to following coding guideline:

> Expressions resulting from the expansion of macro parameters shall be enclosed in parentheses

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/3c1d1a11e97c1306d85977140905b22ab7f8b31e