### PR TITLE
dts: bindings: can: loopback/native linux: these CAN drivers support CAN FD

### DIFF
--- a/dts/bindings/can/zephyr,can-loopback.yaml
+++ b/dts/bindings/can/zephyr,can-loopback.yaml
@@ -5,4 +5,4 @@ description: Zephyr emulated CAN loopback controller
 
 compatible: "zephyr,can-loopback"
 
-include: can-controller.yaml
+include: can-fd-controller.yaml

--- a/dts/bindings/can/zephyr,native-linux-can.yaml
+++ b/dts/bindings/can/zephyr,native-linux-can.yaml
@@ -5,7 +5,7 @@ description: Zephyr CAN driver using Linux SocketCAN
 
 compatible: "zephyr,native-linux-can"
 
-include: can-controller.yaml
+include: can-fd-controller.yaml
 
 properties:
   host-interface:


### PR DESCRIPTION
The CAN loopback and native Linux drivers supports CAN FD. Change the bindings to reflect this. No functional changes.
