### PR TITLE
net: lwm2m: On write, use server selected block size

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -2066,6 +2066,10 @@ static int parse_write_op(struct lwm2m_message *msg, uint16_t format)
 			free_block_ctx(block_ctx);
 
 			r = init_block_ctx(&msg->path, &block_ctx);
+			/* If we have already parsed the packet, we can handle the block size
+			 * given by the server.
+			 */
+			block_ctx->ctx.block_size = block_size;
 		}
 
 		if (r < 0) {


### PR DESCRIPTION
When we receive CoAP packets, it is in input buffer that is size of NET_IPV6_MTU.
So in reality, we can handle bigger Block-Wise writes than CONFIG_LWM2M_COAP_BLOCK_SIZE.

So if parsing of CoAP packet has passed, continue
with the same block-size instead of going to default.

While PR https://github.com/zephyrproject-rtos/zephyr/pull/73639 fixed the issue when block-sizes were configured to be the same, one remaining issue was when server was using bigger blocksize. Then the NUM field was not calculated using the same block-size what the packet was send, so it was still off-by-one on certain cases.


