### PR TITLE
Bluetooth: Host: Allow conn create timeout longer than RPA timeout

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -688,7 +688,6 @@ config BT_MAX_PAIRED
 config BT_CREATE_CONN_TIMEOUT
 	int "Timeout for pending LE Create Connection command in seconds"
 	default 3
-	range 1 BT_RPA_TIMEOUT if BT_PRIVACY && (BT_RPA_TIMEOUT < 655)
 	range 1 655
 
 config BT_CONN_PARAM_UPDATE_TIMEOUT

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2975,20 +2975,6 @@ static void bt_conn_set_param_le(struct bt_conn *conn,
 	conn->le.timeout = param->timeout;
 }
 
-static bool create_param_validate(const struct bt_conn_le_create_param *param)
-{
-#if defined(CONFIG_BT_PRIVACY)
-	/* Initiation timeout cannot be greater than the RPA timeout */
-	const uint32_t timeout_max = (MSEC_PER_SEC / 10) * bt_dev.rpa_timeout;
-
-	if (param->timeout > timeout_max) {
-		return false;
-	}
-#endif
-
-	return true;
-}
-
 static void create_param_setup(const struct bt_conn_le_create_param *param)
 {
 	bt_dev.create_param = *param;
@@ -3168,10 +3154,6 @@ int bt_conn_le_create(const bt_addr_le_t *peer, const struct bt_conn_le_create_p
 	err = conn_le_create_common_checks(peer, conn_param);
 	if (err) {
 		return err;
-	}
-
-	if (!create_param_validate(create_param)) {
-		return -EINVAL;
 	}
 
 	conn = conn_le_create_helper(peer, conn_param);


### PR DESCRIPTION
https://github.com/zephyrproject-rtos/zephyr/pull/72674 fixed a bug where this configuration did not work.

Now that this configuration is tested, we should mark it as supported.

The timeout check that was present in the code before was useless and was not working because the check was run before a default timeout of 0 was converted to a timeout.