### PR TITLE
dts: bindings: can: rename bus-speed/bus-speed-data properties

### DIFF
--- a/doc/hardware/peripherals/can/shell.rst
+++ b/doc/hardware/peripherals/can/shell.rst
@@ -101,7 +101,7 @@ stopping the processing of CAN frames.
 .. note::
    The CAN controller mode and timing can only be changed while the CAN controller is stopped, which
    is the initial setting upon boot-up. The initial CAN controller mode is set to ``normal`` and the
-   initial timing is set according to the ``bus-speed``, ``sample-point``, ``bus-speed-data``, and
+   initial timing is set according to the ``bitrate``, ``sample-point``, ``bitrate-data``, and
    ``sample-point-data`` :ref:`devicetree` properties.
 
 Timing

--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -239,8 +239,9 @@ Controller Area Network (CAN)
 =============================
 
 * Removed the following deprecated CAN controller devicetree properties. Out-of-tree boards using
-  these properties need to switch to using the ``bus-speed``, ``sample-point``, ``bus-speed-data``,
-  and ``sample-point-data`` devicetree properties for specifying the initial CAN bitrate:
+  these properties can switch to using the ``bitrate``, ``sample-point``, ``bitrate-data``, and
+  ``sample-point-data`` devicetree properties (or rely on :kconfig:option:`CAN_DEFAULT_BITRATE` and
+  :kconfig:option:`CAN_DEFAULT_BITRATE_DATA`) for specifying the initial CAN bitrate:
 
   * ``sjw``
   * ``prop-seg``
@@ -250,6 +251,9 @@ Controller Area Network (CAN)
   * ``prop-seg-data``
   * ``phase-seg1-data``
   * ``phase-seg1-data``
+
+  The ``bus-speed`` and ``bus-speed-data`` CAN controller devicetree properties have been
+  deprecated.
 
   (:github:`68714`)
 

--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -214,6 +214,8 @@ Drivers and Sensors
   * Updated the CAN timing functions to take the minimum supported bitrate into consideration when
     validating the bitrate.
   * Made the ``sample-point`` and ``sample-point-data`` devicetree properties optional.
+  * Renamed the ``bus_speed`` and ``bus_speed_data`` fields of :c:struct:`can_driver_config` to
+    ``bitrate`` and ``bitrate_data``.
 
 * Charger
 

--- a/drivers/can/Kconfig
+++ b/drivers/can/Kconfig
@@ -28,7 +28,7 @@ config CAN_DEFAULT_BITRATE
 	default 125000
 	help
 	  Default initial CAN bitrate in bits/s. This can be overridden per CAN controller using the
-	  "bus-speed" devicetree property.
+	  "bitrate" devicetree property.
 
 config CAN_DEFAULT_BITRATE_DATA
 	int "Default CAN data phase bitrate"
@@ -36,7 +36,7 @@ config CAN_DEFAULT_BITRATE_DATA
 	depends on CAN_FD_MODE
 	help
 	  Default initial CAN data phase bitrate in bits/s. This can be overridden per CAN controller
-	  using the "bus-speed-data" devicetree property.
+	  using the "bitrate-data" devicetree property.
 
 config CAN_SHELL
 	bool "CAN shell"

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -1458,7 +1458,7 @@ int can_mcan_init(const struct device *dev)
 		return err;
 	}
 
-	err = can_calc_timing(dev, &timing, config->common.bus_speed,
+	err = can_calc_timing(dev, &timing, config->common.bitrate,
 			      config->common.sample_point);
 	if (err == -EINVAL) {
 		LOG_ERR("Can't find timing for given param");
@@ -1469,7 +1469,7 @@ int can_mcan_init(const struct device *dev)
 		timing.phase_seg2);
 	LOG_DBG("Sample-point err : %d", err);
 #ifdef CONFIG_CAN_FD_MODE
-	err = can_calc_timing_data(dev, &timing_data, config->common.bus_speed_data,
+	err = can_calc_timing_data(dev, &timing_data, config->common.bitrate_data,
 				   config->common.sample_point_data);
 	if (err == -EINVAL) {
 		LOG_ERR("Can't find timing for given dataphase param");

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -972,7 +972,7 @@ static int mcp2515_init(const struct device *dev)
 	(void)memset(dev_data->filter, 0, sizeof(dev_data->filter));
 	dev_data->old_state = CAN_STATE_ERROR_ACTIVE;
 
-	ret = can_calc_timing(dev, &timing, dev_cfg->common.bus_speed,
+	ret = can_calc_timing(dev, &timing, dev_cfg->common.bitrate,
 			      dev_cfg->common.sample_point);
 	if (ret == -EINVAL) {
 		LOG_ERR("Can't find timing for given param");

--- a/drivers/can/can_mcp251xfd.c
+++ b/drivers/can/can_mcp251xfd.c
@@ -1576,7 +1576,7 @@ static int mcp251xfd_init(const struct device *dev)
 		goto done;
 	}
 
-	ret = can_calc_timing(dev, &timing, dev_cfg->common.bus_speed,
+	ret = can_calc_timing(dev, &timing, dev_cfg->common.bitrate,
 			      dev_cfg->common.sample_point);
 	if (ret < 0) {
 		LOG_ERR("Can't find timing for given param");
@@ -1588,7 +1588,7 @@ static int mcp251xfd_init(const struct device *dev)
 	LOG_DBG("Sample-point err : %d", ret);
 
 #if defined(CONFIG_CAN_FD_MODE)
-	ret = can_calc_timing_data(dev, &timing_data, dev_cfg->common.bus_speed_data,
+	ret = can_calc_timing_data(dev, &timing_data, dev_cfg->common.bitrate_data,
 				   dev_cfg->common.sample_point_data);
 	if (ret < 0) {
 		LOG_ERR("Can't find data timing for given param");

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -1139,7 +1139,7 @@ static int mcux_flexcan_init(const struct device *dev)
 	k_sem_init(&data->tx_allocs_sem, MCUX_FLEXCAN_MAX_TX,
 		   MCUX_FLEXCAN_MAX_TX);
 
-	err = can_calc_timing(dev, &data->timing, config->common.bus_speed,
+	err = can_calc_timing(dev, &data->timing, config->common.bitrate,
 			      config->common.sample_point);
 	if (err == -EINVAL) {
 		LOG_ERR("Can't find timing for given param");
@@ -1160,7 +1160,7 @@ static int mcux_flexcan_init(const struct device *dev)
 #ifdef CONFIG_CAN_MCUX_FLEXCAN_FD
 	if (config->flexcan_fd) {
 		err = can_calc_timing_data(dev, &data->timing_data,
-					   config->common.bus_speed_data,
+					   config->common.bitrate_data,
 					   config->common.sample_point_data);
 		if (err == -EINVAL) {
 			LOG_ERR("Can't find timing for given param");

--- a/drivers/can/can_nxp_s32_canxl.c
+++ b/drivers/can/can_nxp_s32_canxl.c
@@ -931,7 +931,7 @@ static int can_nxp_s32_init(const struct device *dev)
 	IP_MC_RGM->PRST_0[0].PRST_0 &=
 		~(MC_RGM_PRST_0_PERIPH_16_RST_MASK | MC_RGM_PRST_0_PERIPH_24_RST_MASK);
 
-	err = can_calc_timing(dev, &data->timing, config->common.bus_speed,
+	err = can_calc_timing(dev, &data->timing, config->common.bitrate,
 			      config->common.sample_point);
 	if (err == -EINVAL) {
 		LOG_ERR("Can't find timing for given param");
@@ -942,11 +942,11 @@ static int can_nxp_s32_init(const struct device *dev)
 		LOG_WRN("Sample-point error : %d", err);
 	}
 
-	LOG_DBG("Setting CAN bitrate %d:", config->common.bus_speed);
+	LOG_DBG("Setting CAN bitrate %d:", config->common.bitrate);
 	nxp_s32_zcan_timing_to_canxl_timing(&data->timing, &config->can_cfg->bitrate);
 
 #ifdef CAN_NXP_S32_FD_MODE
-	err = can_calc_timing_data(dev, &data->timing_data, config->common.bus_speed_data,
+	err = can_calc_timing_data(dev, &data->timing_data, config->common.bitrate_data,
 				   config->common.sample_point_data);
 	if (err == -EINVAL) {
 		LOG_ERR("Can't find timing data for given param");
@@ -957,7 +957,7 @@ static int can_nxp_s32_init(const struct device *dev)
 		LOG_WRN("Sample-point-data err : %d", err);
 	}
 
-	LOG_DBG("Setting CAN FD bitrate %d:", config->common.bus_speed_data);
+	LOG_DBG("Setting CAN FD bitrate %d:", config->common.bitrate_data);
 	nxp_s32_zcan_timing_to_canxl_timing(&data->timing_data, &config->can_cfg->Fd_bitrate);
 #endif
 

--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -1075,7 +1075,7 @@ static int can_rcar_init(const struct device *dev)
 		return ret;
 	}
 
-	ret = can_calc_timing(dev, &timing, config->common.bus_speed,
+	ret = can_calc_timing(dev, &timing, config->common.bitrate,
 			      config->common.sample_point);
 	if (ret == -EINVAL) {
 		LOG_ERR("Can't find timing for given param");

--- a/drivers/can/can_sja1000.c
+++ b/drivers/can/can_sja1000.c
@@ -781,7 +781,7 @@ int can_sja1000_init(const struct device *dev)
 	can_sja1000_write_reg(dev, CAN_SJA1000_AMR2, 0xFF);
 	can_sja1000_write_reg(dev, CAN_SJA1000_AMR3, 0xFF);
 
-	err = can_calc_timing(dev, &timing, config->common.bus_speed,
+	err = can_calc_timing(dev, &timing, config->common.bitrate,
 			      config->common.sample_point);
 	if (err == -EINVAL) {
 		LOG_ERR("bitrate/sample point cannot be met (err %d)", err);

--- a/drivers/can/can_stm32_bxcan.c
+++ b/drivers/can/can_stm32_bxcan.c
@@ -659,7 +659,7 @@ static int can_stm32_init(const struct device *dev)
 	/* Enable automatic bus-off recovery */
 	can->MCR |= CAN_MCR_ABOM;
 
-	ret = can_calc_timing(dev, &timing, cfg->common.bus_speed,
+	ret = can_calc_timing(dev, &timing, cfg->common.bitrate,
 			      cfg->common.sample_point);
 	if (ret == -EINVAL) {
 		LOG_ERR("Can't find timing for given param");

--- a/drivers/can/can_xmc4xxx.c
+++ b/drivers/can/can_xmc4xxx.c
@@ -869,7 +869,7 @@ static int can_xmc4xxx_init(const struct device *dev)
 	}
 #endif
 
-	ret = can_calc_timing(dev, &timing, dev_cfg->common.bus_speed,
+	ret = can_calc_timing(dev, &timing, dev_cfg->common.bitrate,
 			      dev_cfg->common.sample_point);
 	if (ret < 0) {
 		return ret;

--- a/dts/bindings/can/can-controller.yaml
+++ b/dts/bindings/can/can-controller.yaml
@@ -5,6 +5,14 @@ include: base.yaml
 properties:
   bus-speed:
     type: int
+    deprecated: true
+    description: |
+      Deprecated. This property has been renamed to bitrate.
+
+      Initial bitrate in bit/s. If this is unset, the initial bitrate is set to
+      CONFIG_CAN_DEFAULT_BITRATE.
+  bitrate:
+    type: int
     description: |
       Initial bitrate in bit/s. If this is unset, the initial bitrate is set to
       CONFIG_CAN_DEFAULT_BITRATE.

--- a/dts/bindings/can/can-fd-controller.yaml
+++ b/dts/bindings/can/can-fd-controller.yaml
@@ -5,6 +5,14 @@ include: can-controller.yaml
 properties:
   bus-speed-data:
     type: int
+    deprecated: true
+    description: |
+      Deprecated. This property has been renamed to bitrate-data.
+
+      Initial data phase bitrate in bit/s.  If this is unset, the initial data phase bitrate is set
+      to CONFIG_CAN_DEFAULT_BITRATE_DATA.
+  bitrate-data:
+    type: int
     description: |
       Initial data phase bitrate in bit/s.  If this is unset, the initial data phase bitrate is set
       to CONFIG_CAN_DEFAULT_BITRATE_DATA.

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -374,11 +374,12 @@ struct can_driver_config {
 		.phy = DEVICE_DT_GET_OR_NULL(DT_PHANDLE(node_id, phys)),			\
 		.min_bitrate = DT_CAN_TRANSCEIVER_MIN_BITRATE(node_id, _min_bitrate),		\
 		.max_bitrate = DT_CAN_TRANSCEIVER_MAX_BITRATE(node_id, _max_bitrate),		\
-		.bus_speed = DT_PROP_OR(node_id, bus_speed, CONFIG_CAN_DEFAULT_BITRATE),	\
+		.bus_speed = DT_PROP_OR(node_id, bitrate,					\
+			DT_PROP_OR(node_id, bus_speed, CONFIG_CAN_DEFAULT_BITRATE)),            \
 		.sample_point = DT_PROP_OR(node_id, sample_point, 0),				\
 		IF_ENABLED(CONFIG_CAN_FD_MODE,							\
-			(.bus_speed_data = DT_PROP_OR(node_id, bus_speed_data,			\
-						      CONFIG_CAN_DEFAULT_BITRATE_DATA),		\
+			(.bus_speed_data = DT_PROP_OR(node_id, bitrate_data,                    \
+			 DT_PROP_OR(node_id, bus_speed_data, CONFIG_CAN_DEFAULT_BITRATE_DATA)), \
 			 .sample_point_data = DT_PROP_OR(node_id, sample_point_data, 0),))	\
 	}
 

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -351,14 +351,14 @@ struct can_driver_config {
 	/** The maximum bitrate supported by the CAN controller/transceiver combination. */
 	uint32_t max_bitrate;
 	/** Initial CAN classic/CAN FD arbitration phase bitrate. */
-	uint32_t bus_speed;
+	uint32_t bitrate;
 	/** Initial CAN classic/CAN FD arbitration phase sample point in permille. */
 	uint16_t sample_point;
 #ifdef CONFIG_CAN_FD_MODE
 	/** Initial CAN FD data phase sample point in permille. */
 	uint16_t sample_point_data;
 	/** Initial CAN FD data phase bitrate. */
-	uint32_t bus_speed_data;
+	uint32_t bitrate_data;
 #endif /* CONFIG_CAN_FD_MODE */
 };
 
@@ -374,11 +374,11 @@ struct can_driver_config {
 		.phy = DEVICE_DT_GET_OR_NULL(DT_PHANDLE(node_id, phys)),			\
 		.min_bitrate = DT_CAN_TRANSCEIVER_MIN_BITRATE(node_id, _min_bitrate),		\
 		.max_bitrate = DT_CAN_TRANSCEIVER_MAX_BITRATE(node_id, _max_bitrate),		\
-		.bus_speed = DT_PROP_OR(node_id, bitrate,					\
+		.bitrate = DT_PROP_OR(node_id, bitrate,						\
 			DT_PROP_OR(node_id, bus_speed, CONFIG_CAN_DEFAULT_BITRATE)),            \
 		.sample_point = DT_PROP_OR(node_id, sample_point, 0),				\
 		IF_ENABLED(CONFIG_CAN_FD_MODE,							\
-			(.bus_speed_data = DT_PROP_OR(node_id, bitrate_data,                    \
+			(.bitrate_data = DT_PROP_OR(node_id, bitrate_data,                      \
 			 DT_PROP_OR(node_id, bus_speed_data, CONFIG_CAN_DEFAULT_BITRATE_DATA)), \
 			 .sample_point_data = DT_PROP_OR(node_id, sample_point_data, 0),))	\
 	}

--- a/samples/modules/canopennode/src/main.c
+++ b/samples/modules/canopennode/src/main.c
@@ -15,8 +15,9 @@
 LOG_MODULE_REGISTER(app);
 
 #define CAN_INTERFACE DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus))
-#define CAN_BITRATE (DT_PROP_OR(DT_CHOSEN(zephyr_canbus), bus_speed, \
-				CONFIG_CAN_DEFAULT_BITRATE) / 1000)
+#define CAN_BITRATE (DT_PROP_OR(DT_CHOSEN(zephyr_canbus), bitrate, \
+					  DT_PROP_OR(DT_CHOSEN(zephyr_canbus), bus_speed, \
+						     CONFIG_CAN_DEFAULT_BITRATE)) / 1000)
 
 static struct gpio_dt_spec led_green_gpio = GPIO_DT_SPEC_GET_OR(
 		DT_ALIAS(green_led), gpios, {0});

--- a/tests/drivers/can/host/README.rst
+++ b/tests/drivers/can/host/README.rst
@@ -22,7 +22,7 @@ The Zephyr end of the CAN fixture can be configured as follows:
 * The CAN controller to be used is set using the ``zephyr,canbus`` chosen devicetree node.
 * The CAN bitrates are set using :kconfig:option:`CONFIG_CAN_DEFAULT_BITRATE` and
   :kconfig:option:`CONFIG_CAN_DEFAULT_BITRATE_DATA`, but can be overridden on a board level using
-  the ``bus-speed`` and ``bus-speed-data`` CAN controller devicetree properties if needed. Default
+  the ``bitrate`` and ``bitrate-data`` CAN controller devicetree properties if needed. Default
   bitrates are 125 kbits/s for the arbitration phase/CAN classic and 1 Mbit/s for the CAN FD data
   phase when using bitrate switching (BRS).
 


### PR DESCRIPTION
Deprecate the CAN controller bus-speed/bus-speed-data properties and rename them to bitrate/bitrate-data to match the terminology used in other CAN devicetree properties and the CAN subsystem API. Rename the "bus_speed" and "bus_speed_data" fields of `struct can_driver_config` to "bitrate" and "bitrate_data" to match the corresponding devicetree properties and the terminology used in the rest of the CAN subsystem API.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>