### PR TITLE
usb: device_next: Update remote wakeup log level

### DIFF
--- a/subsys/usb/device_next/usbd_device.c
+++ b/subsys/usb/device_next/usbd_device.c
@@ -160,7 +160,7 @@ int usbd_wakeup_request(struct usbd_contex *const uds_ctx)
 	}
 
 	if (!uds_ctx->status.rwup || !usbd_is_suspended(uds_ctx)) {
-		LOG_ERR("Remote wakeup feature not enabled or not suspended");
+		LOG_WRN("Remote wakeup feature not enabled or not suspended");
 		ret = -EACCES;
 		goto wakeup_request_error;
 	}


### PR DESCRIPTION
The `Remote wakeup feature not enabled or not suspended` log is not related to an actual error (connected host might not enable USB remote wakeup feature). Use warning log level.