### PR TITLE
drivers: spi: fix async slave API documentation

### DIFF
--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -169,13 +169,13 @@ static inline int spi_context_wait_for_completion(struct spi_context *ctx)
 			return -ETIMEDOUT;
 		}
 		status = ctx->sync_status;
-	}
 
 #ifdef CONFIG_SPI_SLAVE
-	if (spi_context_is_slave(ctx) && !status) {
-		return ctx->recv_frames;
-	}
+		if (spi_context_is_slave(ctx) && !status) {
+			status = ctx->recv_frames;
+		}
 #endif /* CONFIG_SPI_SLAVE */
+	}
 
 	return status;
 }

--- a/drivers/spi/spi_dw.c
+++ b/drivers/spi/spi_dw.c
@@ -442,12 +442,6 @@ static int transceive(const struct device *dev,
 
 	ret = spi_context_wait_for_completion(&spi->ctx);
 
-#ifdef CONFIG_SPI_SLAVE
-	if (spi_context_is_slave(&spi->ctx) && !ret) {
-		ret = spi->ctx.recv_frames;
-	}
-#endif /* CONFIG_SPI_SLAVE */
-
 out:
 	spi_context_release(&spi->ctx, ret);
 

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -778,7 +778,7 @@ static inline int spi_transceive_dt(const struct spi_dt_spec *spec,
  * @param rx_bufs Buffer array where data to be read will be written to.
  *
  * @retval frames Positive number of frames received in slave mode.
- * @retval 0 If successful.
+ * @retval 0 If successful in master mode.
  * @retval -errno Negative errno code on failure.
  */
 static inline int spi_read(const struct device *dev,
@@ -871,8 +871,7 @@ static inline int spi_write_dt(const struct spi_dt_spec *spec,
  *        successfully or not).
  * @param userdata Userdata passed to callback
  *
- * @retval frames Positive number of frames received in slave mode.
- * @retval 0 If successful in master mode.
+ * @retval 0 If successful.
  * @retval -errno Negative errno code on failure.
  */
 static inline int spi_transceive_cb(const struct device *dev,
@@ -915,8 +914,7 @@ void z_spi_transfer_signal_cb(const struct device *dev, int result, void *userda
  *        notify the end of the transaction, and whether it went
  *        successfully or not).
  *
- * @retval frames Positive number of frames received in slave mode.
- * @retval 0 If successful in master mode.
+ * @retval 0 If successful.
  * @retval -errno Negative errno code on failure.
  */
 static inline int spi_transceive_signal(const struct device *dev,
@@ -966,7 +964,6 @@ __deprecated static inline int spi_transceive_async(const struct device *dev,
  *        notify the end of the transaction, and whether it went
  *        successfully or not).
  *
- * @retval frames Positive number of frames received in slave mode.
  * @retval 0 If successful
  * @retval -errno Negative errno code on failure.
  */


### PR DESCRIPTION
It is not possible to return the number of received frames for an asynchronous transfer in slave mode. The number of received frames is only known once the transfer got completed.
Return 0 if the transfer was started successful and a negative error code if the transfer could not start.