### PR TITLE
Update tcpserversink sample

### DIFF
--- a/samples/subsys/video/tcpserversink/README.rst
+++ b/samples/subsys/video/tcpserversink/README.rst
@@ -29,12 +29,13 @@ interface. Ethernet cable must be connected to RJ45 connector.
 Building and Running
 ********************
 
-For :ref:`mimxrt1064_evk`, build this sample application with the following commands:
+For :ref:`mimxrt1064_evk`, the sample can be built with the following command.
+If a mt9m114 camera shield is missing, video software generator will be used instead.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/subsys/video/tcpserversink
    :board: mimxrt1064_evk
-   :shield: dvp_fpc24_mt9m114
+   :shield: [dvp_fpc24_mt9m114]
    :goals: build
    :compact:
 
@@ -58,6 +59,7 @@ Example with gstreamer:
 	! videoconvert \
         ! fpsdisplaysink sync=false
 
+For video software generator, the default resolution should be width=320 and height=160.
 
 References
 **********

--- a/samples/subsys/video/tcpserversink/README.rst
+++ b/samples/subsys/video/tcpserversink/README.rst
@@ -34,6 +34,7 @@ For :ref:`mimxrt1064_evk`, build this sample application with the following comm
 .. zephyr-app-commands::
    :zephyr-app: samples/subsys/video/tcpserversink
    :board: mimxrt1064_evk
+   :shield: dvp_fpc24_mt9m114
    :goals: build
    :compact:
 

--- a/samples/subsys/video/tcpserversink/README.rst
+++ b/samples/subsys/video/tcpserversink/README.rst
@@ -42,7 +42,7 @@ Sample Output
 
 .. code-block:: console
 
-    Video device detected, format: RGBP 640x480
+    Video device detected, format: RGBP 480x272
     TCP: Waiting for client...
 
 Then from a peer on the same network you can connect and grab frames.
@@ -52,7 +52,7 @@ Example with gstreamer:
 .. code-block:: console
 
     gst-launch-1.0 tcpclientsrc host=192.0.2.1 port=5000 \
-        ! videoparse format=rgb16 width=640 height=480 \
+        ! videoparse format=rgb16 width=480 height=272 \
         ! queue \
 	! videoconvert \
         ! fpsdisplaysink sync=false

--- a/samples/subsys/video/tcpserversink/sample.yaml
+++ b/samples/subsys/video/tcpserversink/sample.yaml
@@ -2,14 +2,18 @@ sample:
   name: Video TCP server sink
 tests:
   sample.video.tcpserversink:
+    filter: dt_chosen_enabled("zephyr,camera")
     build_only: true
     tags:
       - video
       - net
       - socket
+      - shield
     platform_allow: mimxrt1064_evk
     depends_on:
       - video
       - netif
     integration_platforms:
       - mimxrt1064_evk
+    extra_args:
+      - platform:mimxrt1064_evk:SHIELD=dvp_fpc24_mt9m114

--- a/samples/subsys/video/tcpserversink/sample.yaml
+++ b/samples/subsys/video/tcpserversink/sample.yaml
@@ -2,7 +2,6 @@ sample:
   name: Video TCP server sink
 tests:
   sample.video.tcpserversink:
-    filter: dt_chosen_enabled("zephyr,camera")
     build_only: true
     tags:
       - video

--- a/samples/subsys/video/tcpserversink/src/main.c
+++ b/samples/subsys/video/tcpserversink/src/main.c
@@ -15,7 +15,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main);
 
-#define MY_PORT 5000
+#define MY_PORT          5000
 #define MAX_CLIENT_QUEUE 1
 
 static ssize_t sendall(int sock, const void *buf, size_t len)
@@ -78,10 +78,9 @@ int main(void)
 		return 0;
 	}
 
-	printk("Video device detected, format: %c%c%c%c %ux%u\n",
-	       (char)fmt.pixelformat, (char)(fmt.pixelformat >> 8),
-	       (char)(fmt.pixelformat >> 16), (char)(fmt.pixelformat >> 24),
-	       fmt.width, fmt.height);
+	printk("Video device detected, format: %c%c%c%c %ux%u\n", (char)fmt.pixelformat,
+	       (char)(fmt.pixelformat >> 8), (char)(fmt.pixelformat >> 16),
+	       (char)(fmt.pixelformat >> 24), fmt.width, fmt.height);
 
 	/* Alloc Buffers */
 	for (i = 0; i < ARRAY_SIZE(buffers); i++) {
@@ -96,8 +95,7 @@ int main(void)
 	do {
 		printk("TCP: Waiting for client...\n");
 
-		client = accept(sock, (struct sockaddr *)&client_addr,
-				&client_addr_len);
+		client = accept(sock, (struct sockaddr *)&client_addr, &client_addr_len);
 		if (client < 0) {
 			printk("Failed to accept: %d\n", errno);
 			return 0;
@@ -121,8 +119,7 @@ int main(void)
 		/* Capture loop */
 		i = 0;
 		do {
-			ret = video_dequeue(video, VIDEO_EP_OUT, &vbuf,
-					    K_FOREVER);
+			ret = video_dequeue(video, VIDEO_EP_OUT, &vbuf, K_FOREVER);
 			if (ret) {
 				LOG_ERR("Unable to dequeue video buf");
 				return 0;
@@ -149,8 +146,7 @@ int main(void)
 
 		/* Flush remaining buffers */
 		do {
-			ret = video_dequeue(video, VIDEO_EP_OUT,
-					    &vbuf, K_NO_WAIT);
+			ret = video_dequeue(video, VIDEO_EP_OUT, &vbuf, K_NO_WAIT);
 		} while (!ret);
 
 	} while (1);

--- a/samples/subsys/video/tcpserversink/src/main.c
+++ b/samples/subsys/video/tcpserversink/src/main.c
@@ -125,7 +125,7 @@ int main(void)
 				return 0;
 			}
 
-			printk("\rSending frame %d", i++);
+			printk("\rSending frame %d\n", i++);
 
 			/* Send video buffer to TCP client */
 			ret = sendall(client, vbuf->buffer, vbuf->bytesused);

--- a/samples/subsys/video/tcpserversink/src/main.c
+++ b/samples/subsys/video/tcpserversink/src/main.c
@@ -15,6 +15,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main);
 
+#define VIDEO_DEV_SW     "VIDEO_SW_GENERATOR"
 #define MY_PORT          5000
 #define MAX_CLIENT_QUEUE 1
 
@@ -40,8 +41,21 @@ int main(void)
 	struct video_buffer *buffers[2], *vbuf;
 	int i, ret, sock, client;
 	struct video_format fmt;
+#if DT_HAS_CHOSEN(zephyr_camera)
 	const struct device *const video = DEVICE_DT_GET(DT_CHOSEN(zephyr_camera));
 
+	if (!device_is_ready(video)) {
+		LOG_ERR("%s: video device not ready.", video->name);
+		return 0;
+	}
+#else
+	const struct device *const video = device_get_binding(VIDEO_DEV_SW);
+
+	if (video == NULL) {
+		LOG_ERR("%s: video device not found or failed to initialized.", VIDEO_DEV_SW);
+		return 0;
+	}
+#endif
 	/* Prepare Network */
 	(void)memset(&addr, 0, sizeof(addr));
 	addr.sin_family = AF_INET;
@@ -64,11 +78,6 @@ int main(void)
 	if (ret < 0) {
 		LOG_ERR("Failed to listen on TCP socket: %d", errno);
 		close(sock);
-		return 0;
-	}
-
-	if (!device_is_ready(video)) {
-		LOG_ERR("%s: device not ready.\n", video->name);
 		return 0;
 	}
 

--- a/samples/subsys/video/tcpserversink/src/main.c
+++ b/samples/subsys/video/tcpserversink/src/main.c
@@ -40,7 +40,7 @@ int main(void)
 	struct video_buffer *buffers[2], *vbuf;
 	int i, ret, sock, client;
 	struct video_format fmt;
-	const struct device *const video = DEVICE_DT_GET_ANY(nxp_imx_csi);
+	const struct device *const video = DEVICE_DT_GET(DT_CHOSEN(zephyr_camera));
 
 	/* Prepare Network */
 	(void)memset(&addr, 0, sizeof(addr));


### PR DESCRIPTION
Initially, the sample should not rely on the fact that the NXP CSI node is always enabled and if this is required, sample.yaml should have `filter: dt_compat_enabled("nxp,imx-csi")`.

As https://github.com/zephyrproject-rtos/zephyr/pull/72435 is now merged and as pointed out by https://github.com/zephyrproject-rtos/zephyr/pull/73604, update this sample to reflect the new shield.

Some minor improvements are also made such as adding support for video software generator.