### PR TITLE
include: sys: added missing parenthesis

### DIFF
--- a/include/zephyr/internal/syscall_handler.h
+++ b/include/zephyr/internal/syscall_handler.h
@@ -431,11 +431,11 @@ int k_usermode_string_copy(char *dst, const char *src, size_t maxlen);
 #define K_SYSCALL_MEMORY(ptr, size, write) \
 	K_SYSCALL_VERIFY_MSG(K_SYSCALL_MEMORY_SIZE_CHECK(ptr, size) \
 			     && !Z_DETECT_POINTER_OVERFLOW(ptr, size) \
-			     && (arch_buffer_validate((void *)ptr, size, write) \
+			     && (arch_buffer_validate((void *)(ptr), (size), (write)) \
 			     == 0), \
 			     "Memory region %p (size %zu) %s access denied", \
 			     (void *)(ptr), (size_t)(size), \
-			     write ? "write" : "read")
+			     (write) ? "write" : "read")
 
 /**
  * @brief Runtime check that a user thread has read permission to a memory area
@@ -541,9 +541,9 @@ static inline int k_object_validation_check(struct k_object *ko,
 
 #define K_SYSCALL_IS_OBJ(ptr, type, init) \
 	K_SYSCALL_VERIFY_MSG(k_object_validation_check(			\
-				     k_object_find((const void *)ptr),	\
-				     (const void *)ptr,			\
-				     type, init) == 0, "access denied")
+				     k_object_find((const void *)(ptr)),	\
+				     (const void *)(ptr),		\
+				     (type), (init)) == 0, "access denied")
 
 /**
  * @brief Runtime check driver object pointer for presence of operation
@@ -562,7 +562,7 @@ static inline int k_object_validation_check(struct k_object *ko,
 #define K_SYSCALL_DRIVER_OP(ptr, api_name, op) \
 	({ \
 		struct api_name *__device__ = (struct api_name *) \
-			((const struct device *)ptr)->api; \
+			((const struct device *)(ptr))->api; \
 		K_SYSCALL_VERIFY_MSG(__device__->op != NULL, \
 				    "Operation %s not defined for driver " \
 				    "instance %p", \

--- a/include/zephyr/sys/bitarray.h
+++ b/include/zephyr/sys/bitarray.h
@@ -59,7 +59,7 @@ typedef struct sys_bitarray sys_bitarray_t;
 		[DIV_ROUND_UP(DIV_ROUND_UP(total_bits, 8),		\
 			       sizeof(uint32_t))] = {0};		\
 	sba_mod sys_bitarray_t name = {					\
-		.num_bits = total_bits,					\
+		.num_bits = (total_bits),				\
 		.num_bundles = DIV_ROUND_UP(				\
 			DIV_ROUND_UP(total_bits, 8), sizeof(uint32_t)),	\
 		.bundles = _sys_bitarray_bundles_##name,		\

--- a/include/zephyr/sys/cbprintf_internal.h
+++ b/include/zephyr/sys/cbprintf_internal.h
@@ -592,26 +592,26 @@ extern "C" {
 		(void)_d; \
 		size_t arg_size = Z_CBPRINTF_ARG_SIZE(arg); \
 		size_t _wsize = arg_size / sizeof(int); \
-		z_cbprintf_wcpy((int *)buf, \
+		z_cbprintf_wcpy((int *)(buf), \
 			      (int *) _Generic((arg) + 0, float : &_d, default : &_v), \
 			      _wsize); \
 	} else { \
 		*_Generic((arg) + 0, \
-			char : (int *)buf, \
-			unsigned char: (int *)buf, \
-			short : (int *)buf, \
-			unsigned short : (int *)buf, \
-			int : (int *)buf, \
-			unsigned int : (unsigned int *)buf, \
-			long : (long *)buf, \
-			unsigned long : (unsigned long *)buf, \
-			long long : (long long *)buf, \
-			unsigned long long : (unsigned long long *)buf, \
-			float : (double *)buf, \
-			double : (double *)buf, \
-			long double : (long double *)buf, \
+			char : (int *)(buf), \
+			unsigned char: (int *)(buf), \
+			short : (int *)(buf), \
+			unsigned short : (int *)(buf), \
+			int : (int *)(buf), \
+			unsigned int : (unsigned int *)(buf), \
+			long : (long *)(buf), \
+			unsigned long : (unsigned long *)(buf), \
+			long long : (long long *)(buf), \
+			unsigned long long : (unsigned long long *)(buf), \
+			float : (double *)(buf), \
+			double : (double *)(buf), \
+			long double : (long double *)(buf), \
 			default : \
-				(const void **)buf) = arg; \
+				(const void **)(buf)) = (arg); \
 	} \
 } while (false)
 #endif
@@ -678,9 +678,9 @@ do { \
 			Z_CBPRINTF_IS_LONGDOUBLE(_arg) && \
 			!IS_ENABLED(CONFIG_CBPRINTF_PACKAGE_LONGDOUBLE)),\
 			"Packaging of long double not enabled in Kconfig."); \
-	while ((_align_offset % Z_CBPRINTF_ALIGNMENT(_arg)) != 0UL) { \
-		_idx += sizeof(int); \
-		_align_offset += sizeof(int); \
+	while (((_align_offset) % Z_CBPRINTF_ALIGNMENT(_arg)) != 0UL) { \
+		(_idx) += sizeof(int); \
+		(_align_offset) += sizeof(int); \
 	} \
 	uint32_t _arg_size = Z_CBPRINTF_ARG_SIZE(_arg); \
 	uint8_t _loc = (uint8_t)(_idx / sizeof(int)); \
@@ -705,11 +705,11 @@ do { \
 			_rws_buffer[_rws_pos_idx++] = (uint8_t)(_idx / sizeof(int)); \
 		} \
 	} \
-	if (_buf && _idx < (int)_max) { \
-		Z_CBPRINTF_STORE_ARG(&_buf[_idx], _arg); \
+	if ((_buf) && (_idx) < (int)(_max)) { \
+		Z_CBPRINTF_STORE_ARG(&(_buf)[(_idx)], _arg); \
 	} \
-	_idx += _arg_size; \
-	_align_offset += _arg_size; \
+	(_idx) += (_arg_size); \
+	(_align_offset) += (_arg_size); \
 } while (false)
 
 /** @brief Package single argument.
@@ -782,9 +782,9 @@ do { \
 	Z_CBPRINTF_SUPPRESS_SIZEOF_ARRAY_DECAY \
 	BUILD_ASSERT(!IS_ENABLED(CONFIG_XTENSA) || \
 		     (IS_ENABLED(CONFIG_XTENSA) && \
-		      !(_align_offset % CBPRINTF_PACKAGE_ALIGNMENT)), \
+		      !((_align_offset) % CBPRINTF_PACKAGE_ALIGNMENT)), \
 			"Xtensa requires aligned package."); \
-	BUILD_ASSERT((_align_offset % sizeof(int)) == 0, \
+	BUILD_ASSERT(((_align_offset) % sizeof(int)) == 0, \
 			"Alignment offset must be multiply of a word."); \
 	IF_ENABLED(CONFIG_CBPRINTF_STATIC_PACKAGE_CHECK_ALIGNMENT, \
 		(__ASSERT(!((uintptr_t)buf & (CBPRINTF_PACKAGE_ALIGNMENT - 1)), \
@@ -793,7 +793,7 @@ do { \
 	bool _ros_pos_en = (_flags) & CBPRINTF_PACKAGE_ADD_RO_STR_POS; \
 	bool _rws_pos_en = (_flags) & CBPRINTF_PACKAGE_ADD_RW_STR_POS; \
 	bool _cros_en = (_flags) & CBPRINTF_PACKAGE_CONST_CHAR_RO; \
-	uint8_t *_pbuf = buf; \
+	uint8_t *_pbuf = (buf); \
 	uint8_t _rws_pos_idx = 0; \
 	uint8_t _ros_pos_idx = 0; \
 	/* Variable holds count of all string pointer arguments. */ \
@@ -810,7 +810,7 @@ do { \
 	size_t _pmax = !is_null_no_warn(buf) ? _inlen : INT32_MAX; \
 	int _pkg_len = 0; \
 	int _total_len = 0; \
-	int _pkg_offset = _align_offset; \
+	int _pkg_offset = (_align_offset); \
 	union cbprintf_package_hdr *_len_loc; \
 	/* If string has rw string arguments CBPRINTF_PACKAGE_ADD_RW_STR_POS is a must. */ \
 	if (_rws_cnt && !((_flags) & CBPRINTF_PACKAGE_ADD_RW_STR_POS)) { \
@@ -819,7 +819,7 @@ do { \
 	} \
 	/* package starts with string address and field with length */ \
 	if (_pmax < sizeof(*_len_loc)) { \
-		_outlen = -ENOSPC; \
+		(_outlen) = -ENOSPC; \
 		break; \
 	} \
 	_len_loc = (union cbprintf_package_hdr *)_pbuf; \
@@ -842,7 +842,7 @@ do { \
 		} \
 	} \
 	/* Store length */ \
-	_outlen = (_total_len > (int)_pmax) ? -ENOSPC : _total_len; \
+	(_outlen) = (_total_len > (int)_pmax) ? -ENOSPC : _total_len; \
 	/* Store length in the header, set number of dumped strings to 0 */ \
 	if (_pbuf != NULL) { \
 		union cbprintf_package_hdr pkg_hdr = { \

--- a/include/zephyr/sys/device_mmio.h
+++ b/include/zephyr/sys/device_mmio.h
@@ -715,7 +715,7 @@ struct z_device_mmio_rom {
 #define DEVICE_MMIO_TOPLEVEL_MAP(name, flags) \
 	device_map(&Z_TOPLEVEL_RAM_NAME(name), \
 		   Z_TOPLEVEL_ROM_NAME(name).phys_addr, \
-		   Z_TOPLEVEL_ROM_NAME(name).size, flags)
+		   Z_TOPLEVEL_ROM_NAME(name).size, (flags))
 #else
 #define DEVICE_MMIO_TOPLEVEL_MAP(name, flags) do { } while (false)
 #endif

--- a/include/zephyr/sys/dlist.h
+++ b/include/zephyr/sys/dlist.h
@@ -116,10 +116,10 @@ typedef struct _dnode sys_dnode_t;
  * @param __dns A sys_dnode_t pointer for the loop to run safely
  */
 #define SYS_DLIST_FOR_EACH_NODE_SAFE(__dl, __dn, __dns)			\
-	for (__dn = sys_dlist_peek_head(__dl),				\
-		     __dns = sys_dlist_peek_next(__dl, __dn);		\
-	     __dn != NULL; __dn = __dns,				\
-		     __dns = sys_dlist_peek_next(__dl, __dn))
+	for ((__dn) = sys_dlist_peek_head(__dl),			\
+		     (__dns) = sys_dlist_peek_next((__dl), (__dn));	\
+	     (__dn) != NULL; (__dn) = (__dns),				\
+		     (__dns) = sys_dlist_peek_next(__dl, __dn))
 
 /**
  * @brief Provide the primitive to resolve the container of a list node
@@ -130,7 +130,7 @@ typedef struct _dnode sys_dnode_t;
  * @param __n The field name of sys_dnode_t within the container struct
  */
 #define SYS_DLIST_CONTAINER(__dn, __cn, __n) \
-	((__dn != NULL) ? CONTAINER_OF(__dn, __typeof__(*__cn), __n) : NULL)
+	(((__dn) != NULL) ? CONTAINER_OF(__dn, __typeof__(*(__cn)), __n) : NULL)
 /**
  * @brief Provide the primitive to peek container of the list head
  *
@@ -149,8 +149,8 @@ typedef struct _dnode sys_dnode_t;
  * @param __n The field name of sys_dnode_t within the container struct
  */
 #define SYS_DLIST_PEEK_NEXT_CONTAINER(__dl, __cn, __n) \
-	((__cn != NULL) ? \
-	 SYS_DLIST_CONTAINER(sys_dlist_peek_next(__dl, &(__cn->__n)),	\
+	(((__cn) != NULL) ? \
+	 SYS_DLIST_CONTAINER(sys_dlist_peek_next((__dl), &((__cn)->__n)),	\
 				      __cn, __n) : NULL)
 
 /**
@@ -168,9 +168,9 @@ typedef struct _dnode sys_dnode_t;
  * @param __n The field name of sys_dnode_t within the container struct
  */
 #define SYS_DLIST_FOR_EACH_CONTAINER(__dl, __cn, __n)			\
-	for (__cn = SYS_DLIST_PEEK_HEAD_CONTAINER(__dl, __cn, __n);     \
-	     __cn != NULL;                                              \
-	     __cn = SYS_DLIST_PEEK_NEXT_CONTAINER(__dl, __cn, __n))
+	for ((__cn) = SYS_DLIST_PEEK_HEAD_CONTAINER(__dl, __cn, __n);     \
+	     (__cn) != NULL;                                              \
+	     (__cn) = SYS_DLIST_PEEK_NEXT_CONTAINER(__dl, __cn, __n))
 
 /**
  * @brief Provide the primitive to safely iterate on a list under a container
@@ -188,10 +188,10 @@ typedef struct _dnode sys_dnode_t;
  * @param __n The field name of sys_dnode_t within the container struct
  */
 #define SYS_DLIST_FOR_EACH_CONTAINER_SAFE(__dl, __cn, __cns, __n)	\
-	for (__cn = SYS_DLIST_PEEK_HEAD_CONTAINER(__dl, __cn, __n),	\
-	     __cns = SYS_DLIST_PEEK_NEXT_CONTAINER(__dl, __cn, __n);    \
-	     __cn != NULL; __cn = __cns,				\
-	     __cns = SYS_DLIST_PEEK_NEXT_CONTAINER(__dl, __cn, __n))
+	for ((__cn) = SYS_DLIST_PEEK_HEAD_CONTAINER(__dl, __cn, __n),	\
+	     (__cns) = SYS_DLIST_PEEK_NEXT_CONTAINER(__dl, __cn, __n);    \
+	     (__cn) != NULL; (__cn) = (__cns),				\
+	     (__cns) = SYS_DLIST_PEEK_NEXT_CONTAINER(__dl, __cn, __n))
 
 /**
  * @brief initialize list to its empty state

--- a/include/zephyr/sys/list_gen.h
+++ b/include/zephyr/sys/list_gen.h
@@ -12,21 +12,21 @@
 #include <zephyr/sys/util.h>
 
 #define Z_GENLIST_FOR_EACH_NODE(__lname, __l, __sn)			\
-	for (__sn = sys_ ## __lname ## _peek_head(__l); __sn != NULL;	\
-	     __sn = sys_ ## __lname ## _peek_next(__sn))
+	for ((__sn) = sys_ ## __lname ## _peek_head(__l); (__sn) != NULL;	\
+	     (__sn) = sys_ ## __lname ## _peek_next(__sn))
 
 
 #define Z_GENLIST_ITERATE_FROM_NODE(__lname, __l, __sn)			\
-	for (__sn = __sn ? sys_ ## __lname ## _peek_next_no_check(__sn)	\
+	for ((__sn) = (__sn) ? sys_ ## __lname ## _peek_next_no_check(__sn)	\
 			 : sys_ ## __lname ## _peek_head(__l);		\
-	     __sn != NULL;						\
-	     __sn = sys_ ## __lname ## _peek_next(__sn))
+	     (__sn) != NULL;						\
+	     (__sn) = sys_ ## __lname ## _peek_next(__sn))
 
 #define Z_GENLIST_FOR_EACH_NODE_SAFE(__lname, __l, __sn, __sns)		\
-	for (__sn = sys_ ## __lname ## _peek_head(__l),			\
-		     __sns = sys_ ## __lname ## _peek_next(__sn);	\
-	     __sn != NULL ; __sn = __sns,				\
-		     __sns = sys_ ## __lname ## _peek_next(__sn))
+	for ((__sn) = sys_ ## __lname ## _peek_head(__l),			\
+		     (__sns) = sys_ ## __lname ## _peek_next(__sn);	\
+	     (__sn) != NULL ; (__sn) = (__sns),				\
+		     (__sns) = sys_ ## __lname ## _peek_next(__sn))
 
 #define Z_GENLIST_CONTAINER(__ln, __cn, __n)				\
 	((__ln) ? CONTAINER_OF((__ln), __typeof__(*(__cn)), __n) : NULL)
@@ -43,16 +43,16 @@
 			__cn, __n) : NULL)
 
 #define Z_GENLIST_FOR_EACH_CONTAINER(__lname, __l, __cn, __n)		\
-	for (__cn = Z_GENLIST_PEEK_HEAD_CONTAINER(__lname, __l, __cn,	\
+	for ((__cn) = Z_GENLIST_PEEK_HEAD_CONTAINER(__lname, __l, __cn,	\
 						  __n);			\
-	     __cn != NULL;						\
-	     __cn = Z_GENLIST_PEEK_NEXT_CONTAINER(__lname, __cn, __n))
+	     (__cn) != NULL;						\
+	     (__cn) = Z_GENLIST_PEEK_NEXT_CONTAINER(__lname, __cn, __n))
 
 #define Z_GENLIST_FOR_EACH_CONTAINER_SAFE(__lname, __l, __cn, __cns, __n)     \
-	for (__cn = Z_GENLIST_PEEK_HEAD_CONTAINER(__lname, __l, __cn, __n),   \
-	     __cns = Z_GENLIST_PEEK_NEXT_CONTAINER(__lname, __cn, __n); \
-	     __cn != NULL; __cn = __cns,				\
-	     __cns = Z_GENLIST_PEEK_NEXT_CONTAINER(__lname, __cn, __n))
+	for ((__cn) = Z_GENLIST_PEEK_HEAD_CONTAINER(__lname, __l, __cn, __n),   \
+	     (__cns) = Z_GENLIST_PEEK_NEXT_CONTAINER(__lname, __cn, __n); \
+	     (__cn) != NULL; (__cn) = (__cns),				\
+	     (__cns) = Z_GENLIST_PEEK_NEXT_CONTAINER(__lname, __cn, __n))
 
 #define Z_GENLIST_IS_EMPTY(__lname)					\
 	static inline bool						\

--- a/include/zephyr/sys/onoff.h
+++ b/include/zephyr/sys/onoff.h
@@ -188,14 +188,14 @@ struct onoff_manager {
  * to an off state. Can be null.
  */
 #define ONOFF_TRANSITIONS_INITIALIZER(_start, _stop, _reset) { \
-		.start = _start,			       \
-		.stop = _stop,				       \
-		.reset = _reset,			       \
+		.start = (_start),			       \
+		.stop = (_stop),			       \
+		.reset = (_reset),			       \
 }
 
 /** @cond INTERNAL_HIDDEN */
 #define ONOFF_MANAGER_INITIALIZER(_transitions) { \
-		.transitions = _transitions,	  \
+		.transitions = (_transitions),	  \
 }
 /** @endcond */
 

--- a/include/zephyr/sys/rb.h
+++ b/include/zephyr/sys/rb.h
@@ -215,7 +215,7 @@ struct rbnode *z_rb_foreach_next(struct rbtree *tree, struct _rb_foreach *f);
  */
 #define RB_FOR_EACH(tree, node) \
 	for (struct _rb_foreach __f = _RB_FOREACH_INIT(tree, node);	\
-	     (node = z_rb_foreach_next(tree, &__f));			\
+	     ((node) = z_rb_foreach_next((tree), &__f));		\
 	     /**/)
 
 /**
@@ -231,7 +231,7 @@ struct rbnode *z_rb_foreach_next(struct rbtree *tree, struct _rb_foreach *f);
 #define RB_FOR_EACH_CONTAINER(tree, node, field)		           \
 	for (struct _rb_foreach __f = _RB_FOREACH_INIT(tree, node);	   \
 			({struct rbnode *n = z_rb_foreach_next(tree, &__f); \
-			 node = n ? CONTAINER_OF(n, __typeof__(*(node)),   \
+			 (node) = n ? CONTAINER_OF(n, __typeof__(*(node)),   \
 					 field) : NULL; (node); }) != NULL;        \
 			 /**/)
 

--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -779,7 +779,7 @@ static inline void mem_xor_128(uint8_t dst[16], const uint8_t src1[16], const ui
 /* This is used in linker scripts so need to avoid type casting there */
 #define KB(x) ((x) << 10)
 #else
-#define KB(x) (((size_t)x) << 10)
+#define KB(x) (((size_t)(x)) << 10)
 #endif
 /** @brief Number of bytes in @p x mebibytes */
 #define MB(x) (KB(x) << 10)


### PR DESCRIPTION
Added missing parentheses around macro argument expansion.

This corresponds to following coding guideline:

> Expressions resulting from the expansion of macro parameters shall be enclosed in parentheses

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/3c1d1a11e97c1306d85977140905b22ab7f8b31e