### PR TITLE
Remove Breathe from doc infra

### DIFF
--- a/doc/_extensions/zephyr/domain.py
+++ b/doc/_extensions/zephyr/domain.py
@@ -310,7 +310,7 @@ class CustomDoxygenGroupDirective(DoxygenGroupDirective):
         nodes = super().run()
 
         if self.config.zephyr_breathe_insert_related_samples:
-            return [RelatedCodeSamplesNode(id=self.arguments[0]), *nodes]
+            return [*nodes, RelatedCodeSamplesNode(id=self.arguments[0])]
         else:
             return nodes
 

--- a/doc/_extensions/zephyr/domain.py
+++ b/doc/_extensions/zephyr/domain.py
@@ -48,7 +48,6 @@ Roles
 """
 from typing import Any, Dict, Iterator, List, Tuple
 
-from breathe.directives.content_block import DoxygenGroupDirective
 from docutils import nodes
 from docutils.nodes import Node
 from docutils.parsers.rst import Directive, directives
@@ -59,6 +58,7 @@ from sphinx.transforms import SphinxTransform
 from sphinx.transforms.post_transforms import SphinxPostTransform
 from sphinx.util import logging
 from sphinx.util.nodes import NodeMatcher, make_refnode
+from zephyr.doxybridge import DoxygenGroupDirective
 from zephyr.gh_utils import gh_link_get_url
 
 import json
@@ -323,7 +323,7 @@ def setup(app):
     app.add_transform(ConvertCodeSampleNode)
     app.add_post_transform(ProcessRelatedCodeSamplesNode)
 
-    # monkey-patching of Breathe's DoxygenGroupDirective
+    # monkey-patching of the DoxygenGroupDirective
     app.add_directive("doxygengroup", CustomDoxygenGroupDirective, override=True)
 
     return {

--- a/doc/_extensions/zephyr/doxybridge.py
+++ b/doc/_extensions/zephyr/doxybridge.py
@@ -1,0 +1,235 @@
+"""
+Copyright (c) 2021 Nordic Semiconductor ASA
+Copyright (c) 2024 The Linux Foundation
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import os
+from typing import Any, Dict
+
+import concurrent.futures
+
+from docutils import nodes
+
+from sphinx import addnodes
+from sphinx.application import Sphinx
+from sphinx.transforms.post_transforms import SphinxPostTransform
+from sphinx.util import logging
+from sphinx.util.docutils import SphinxDirective
+from sphinx.domains.c import CXRefRole
+
+import doxmlparser
+from doxmlparser.compound import DoxCompoundKind, DoxMemberKind
+
+logger = logging.getLogger(__name__)
+
+
+KIND_D2S = {
+    DoxMemberKind.DEFINE: "macro",
+    DoxMemberKind.VARIABLE: "var",
+    DoxMemberKind.TYPEDEF: "type",
+    DoxMemberKind.ENUM: "enum",
+    DoxMemberKind.FUNCTION: "func",
+}
+
+
+class DoxygenGroupDirective(SphinxDirective):
+    has_content = False
+    required_arguments = 1
+    optional_arguments = 0
+
+    def run(self):
+
+        desc_node = addnodes.desc()
+        desc_node["domain"] = "c"
+        desc_node["objtype"] = "group"
+
+        title_signode = addnodes.desc_signature()
+        group_xref = addnodes.pending_xref(
+            "",
+            refdomain="c",
+            reftype="group",
+            reftarget=self.arguments[0],
+            refwarn=True,
+        )
+        group_xref += nodes.Text(self.arguments[0])
+        title_signode += group_xref
+
+        desc_node.append(title_signode)
+
+        return [desc_node]
+
+
+class DoxygenReferencer(SphinxPostTransform):
+    """Mapping between Doxygen memberdef kind and Sphinx kinds"""
+
+    default_priority = 5
+
+    def run(self, **kwargs: Any) -> None:
+        for node in self.document.traverse(addnodes.pending_xref):
+            if node.get("refdomain") != "c":
+                continue
+
+            reftype = node.get("reftype")
+
+            # "member", "data" and "var" are equivalent as per Sphinx documentation for C domain
+            if reftype in ("member", "data"):
+                reftype = "var"
+
+            entry = self.app.env.doxybridge_cache.get(reftype)
+            if not entry:
+                continue
+
+            reftarget = node.get("reftarget").replace(".", "::").rstrip("()")
+            id = entry.get(reftarget)
+            if not id:
+                if reftype == "func":
+                    # macros are sometimes referenced as functions, so try that
+                    id = self.app.env.doxybridge_cache.get("macro").get(reftarget)
+                    if not id:
+                        continue
+                else:
+                    continue
+
+            if reftype in ("struct", "union", "group"):
+                doxygen_target = f"{id}.html"
+            else:
+                split = id.split("_")
+                doxygen_target = f"{'_'.join(split[:-1])}.html#{split[-1][1:]}"
+
+            doxygen_target = str(self.app.config.doxybridge_dir) + "/html/" + doxygen_target
+
+            doc_dir = os.path.dirname(self.document.get("source"))
+            doc_dest = os.path.join(
+                self.app.outdir,
+                os.path.relpath(doc_dir, self.app.srcdir),
+            )
+            rel_uri = os.path.relpath(doxygen_target, doc_dest)
+
+            refnode = nodes.reference("", "", internal=True, refuri=rel_uri, reftitle="")
+
+            refnode.append(node[0].deepcopy())
+
+            if reftype == "group":
+                refnode["classes"].append("doxygroup")
+                title = self.app.env.doxybridge_group_titles.get(reftarget, "group")
+                refnode[0] = nodes.Text(title)
+
+            node.replace_self([refnode])
+
+
+def parse_members(sectiondef):
+    cache = {}
+
+    for memberdef in sectiondef.get_memberdef():
+        kind = KIND_D2S.get(memberdef.get_kind())
+        if not kind:
+            continue
+
+        id = memberdef.get_id()
+        if memberdef.get_kind() == DoxMemberKind.VARIABLE:
+            name = memberdef.get_qualifiedname() or memberdef.get_name()
+        else:
+            name = memberdef.get_name()
+
+        cache.setdefault(kind, {})[name] = id
+
+        if memberdef.get_kind() == DoxMemberKind.ENUM:
+            for enumvalue in memberdef.get_enumvalue():
+                enumname = enumvalue.get_name()
+                enumid = enumvalue.get_id()
+                cache.setdefault("enumerator", {})[enumname] = enumid
+
+    return cache
+
+
+def parse_sections(compounddef):
+    cache = {}
+
+    for sectiondef in compounddef.get_sectiondef():
+        members = parse_members(sectiondef)
+        for kind, data in members.items():
+            cache.setdefault(kind, {}).update(data)
+
+    return cache
+
+
+def parse_compound(inDirName, baseName) -> Dict:
+    rootObj = doxmlparser.compound.parse(inDirName + "/" + baseName + ".xml", True)
+    cache = {}
+    group_titles = {}
+
+    for compounddef in rootObj.get_compounddef():
+        name = compounddef.get_compoundname()
+        id = compounddef.get_id()
+        kind = None
+        if compounddef.get_kind() == DoxCompoundKind.STRUCT:
+            kind = "struct"
+        elif compounddef.get_kind() == DoxCompoundKind.UNION:
+            kind = "union"
+        elif compounddef.get_kind() == DoxCompoundKind.GROUP:
+            kind = "group"
+            group_titles[name] = compounddef.get_title()
+
+        if kind:
+            cache.setdefault(kind, {})[name] = id
+
+        sections = parse_sections(compounddef)
+        for kind, data in sections.items():
+            cache.setdefault(kind, {}).update(data)
+
+    return cache, group_titles
+
+
+def parse_index(app: Sphinx, inDirName):
+    rootObj = doxmlparser.index.parse(inDirName + "/index.xml", True)
+    compounds = rootObj.get_compound()
+
+    with concurrent.futures.ProcessPoolExecutor() as executor:
+        futures = [
+            executor.submit(parse_compound, inDirName, compound.get_refid())
+            for compound in compounds
+        ]
+        for future in concurrent.futures.as_completed(futures):
+            cache, group_titles = future.result()
+            for kind, data in cache.items():
+                app.env.doxybridge_cache.setdefault(kind, {}).update(data)
+            app.env.doxybridge_group_titles.update(group_titles)
+
+
+def doxygen_parse(app: Sphinx) -> None:
+    if not app.env.doxygen_input_changed:
+        return
+
+    app.env.doxybridge_cache = {
+        "macro": {},
+        "var": {},
+        "type": {},
+        "enum": {},
+        "enumerator": {},
+        "func": {},
+        "union": {},
+        "struct": {},
+        "group": {},
+    }
+
+    app.env.doxybridge_group_titles = {}
+
+    parse_index(app, str(app.config.doxybridge_dir / "xml"))
+
+
+def setup(app: Sphinx) -> Dict[str, Any]:
+    app.add_config_value("doxybridge_dir", None, "env")
+
+    app.add_directive("doxygengroup", DoxygenGroupDirective)
+
+    app.add_role_to_domain("c", "group", CXRefRole())
+
+    app.add_post_transform(DoxygenReferencer)
+    app.connect("builder-inited", doxygen_parse)
+
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -953,3 +953,15 @@ dark-mode-toggle::part(toggleLabel){
   #search-se-menu ul li.selected .fa-check {
     display: inline;
   }
+
+.doxygroup::after {
+    content: 'Doxygen';
+    display: inline-block;
+    background-color: var(--admonition-note-title-background-color);
+    color: var(--admonition-note-title-color);
+    padding: 2px 8px;
+    border-radius: 12px;
+    margin-left: 8px;
+    font-size: 0.875em;
+    font-weight: bold;
+}

--- a/doc/build/dts/api/api.rst
+++ b/doc/build/dts/api/api.rst
@@ -359,7 +359,6 @@ system-wide settings. The :c:func:`DT_CHOSEN()` macro can be used to get a node
 identifier for a chosen node.
 
 .. doxygengroup:: devicetree-generic-chosen
-   :project: Zephyr
 
 Zephyr-specific chosen nodes
 ****************************

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -88,6 +88,7 @@ extensions = [
     "sphinx_sitemap",
     "zephyr.warnings_filter",
     "zephyr.doxyrunner",
+    "zephyr.doxybridge",
     "zephyr.gh_utils",
     "zephyr.manifest_projects_table",
     "notfound.extension",
@@ -247,6 +248,10 @@ doxyrunner_outdir = ZEPHYR_BUILD / "doxygen"
 doxyrunner_fmt = True
 doxyrunner_fmt_vars = {"ZEPHYR_BASE": str(ZEPHYR_BASE), "ZEPHYR_VERSION": version}
 doxyrunner_outdir_var = "DOXY_OUT"
+
+# -- Options for zephyr.doxybridge plugin ---------------------------------
+
+doxybridge_dir = doxyrunner_outdir
 
 # -- Options for html_redirect plugin -------------------------------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -73,7 +73,6 @@ with open(ZEPHYR_BASE / "SDK_VERSION") as f:
 # -- General configuration ------------------------------------------------
 
 extensions = [
-    "breathe",
     "sphinx_rtd_theme",
     "sphinx.ext.todo",
     "sphinx.ext.extlinks",
@@ -248,33 +247,6 @@ doxyrunner_outdir = ZEPHYR_BUILD / "doxygen"
 doxyrunner_fmt = True
 doxyrunner_fmt_vars = {"ZEPHYR_BASE": str(ZEPHYR_BASE), "ZEPHYR_VERSION": version}
 doxyrunner_outdir_var = "DOXY_OUT"
-
-# -- Options for Breathe plugin -------------------------------------------
-
-breathe_projects = {"Zephyr": str(doxyrunner_outdir / "xml")}
-breathe_default_project = "Zephyr"
-breathe_domain_by_extension = {
-    "h": "c",
-    "c": "c",
-}
-breathe_show_enumvalue_initializer = True
-breathe_default_members = ("members", )
-
-cpp_id_attributes = [
-    "__syscall",
-    "__syscall_always_inline",
-    "__deprecated",
-    "__may_alias",
-    "__used",
-    "__unused",
-    "__weak",
-    "__attribute_const__",
-    "__DEPRECATED_MACRO",
-    "FUNC_NORETURN",
-    "__subsystem",
-    "ALWAYS_INLINE",
-]
-c_id_attributes = cpp_id_attributes
 
 # -- Options for html_redirect plugin -------------------------------------
 

--- a/doc/connectivity/bluetooth/api/mesh/blob.rst
+++ b/doc/connectivity/bluetooth/api/mesh/blob.rst
@@ -191,5 +191,3 @@ API reference
 This section contains types and defines common to the BLOB Transfer models.
 
 .. doxygengroup:: bt_mesh_blob
-   :project: Zephyr
-   :members:

--- a/doc/connectivity/bluetooth/api/mesh/blob_cli.rst
+++ b/doc/connectivity/bluetooth/api/mesh/blob_cli.rst
@@ -126,5 +126,3 @@ API reference
 *************
 
 .. doxygengroup:: bt_mesh_blob_cli
-   :project: Zephyr
-   :members:

--- a/doc/connectivity/bluetooth/api/mesh/blob_flash.rst
+++ b/doc/connectivity/bluetooth/api/mesh/blob_flash.rst
@@ -32,4 +32,3 @@ API Reference
 *************
 
 .. doxygengroup:: bt_mesh_blob_io_flash
-   :project: Zephyr

--- a/doc/connectivity/bluetooth/api/mesh/blob_srv.rst
+++ b/doc/connectivity/bluetooth/api/mesh/blob_srv.rst
@@ -96,5 +96,3 @@ API reference
 *************
 
 .. doxygengroup:: bt_mesh_blob_srv
-   :project: Zephyr
-   :members:

--- a/doc/connectivity/bluetooth/api/mesh/dfd_srv.rst
+++ b/doc/connectivity/bluetooth/api/mesh/dfd_srv.rst
@@ -37,5 +37,3 @@ API reference
 *************
 
 .. doxygengroup:: bt_mesh_dfd_srv
-   :project: Zephyr
-   :members:

--- a/doc/connectivity/bluetooth/api/mesh/dfu.rst
+++ b/doc/connectivity/bluetooth/api/mesh/dfu.rst
@@ -371,13 +371,7 @@ API reference
 This section lists the types common to the Device Firmware Update mesh models.
 
 .. doxygengroup:: bt_mesh_dfd
-   :project: Zephyr
-   :members:
 
 .. doxygengroup:: bt_mesh_dfu
-   :project: Zephyr
-   :members:
 
 .. doxygengroup:: bt_mesh_dfu_metadata
-   :project: Zephyr
-   :members:

--- a/doc/connectivity/bluetooth/api/mesh/dfu_cli.rst
+++ b/doc/connectivity/bluetooth/api/mesh/dfu_cli.rst
@@ -12,5 +12,3 @@ API reference
 *************
 
 .. doxygengroup:: bt_mesh_dfu_cli
-   :project: Zephyr
-   :members:

--- a/doc/connectivity/bluetooth/api/mesh/dfu_srv.rst
+++ b/doc/connectivity/bluetooth/api/mesh/dfu_srv.rst
@@ -128,5 +128,3 @@ API reference
 *************
 
 .. doxygengroup:: bt_mesh_dfu_srv
-   :project: Zephyr
-   :members:

--- a/doc/connectivity/bluetooth/api/mesh/lcd_cli.rst
+++ b/doc/connectivity/bluetooth/api/mesh/lcd_cli.rst
@@ -22,5 +22,3 @@ API reference
 *************
 
 .. doxygengroup:: bt_mesh_large_comp_data_cli
-   :project: Zephyr
-   :members:

--- a/doc/connectivity/bluetooth/api/mesh/lcd_srv.rst
+++ b/doc/connectivity/bluetooth/api/mesh/lcd_srv.rst
@@ -35,5 +35,3 @@ API reference
 *************
 
 .. doxygengroup:: bt_mesh_large_comp_data_srv
-   :project: Zephyr
-   :members:

--- a/doc/connectivity/bluetooth/api/mesh/od_cli.rst
+++ b/doc/connectivity/bluetooth/api/mesh/od_cli.rst
@@ -33,5 +33,3 @@ API reference
 *************
 
 .. doxygengroup:: bt_mesh_od_priv_proxy_cli
-   :project: Zephyr
-   :members:

--- a/doc/connectivity/bluetooth/api/mesh/od_srv.rst
+++ b/doc/connectivity/bluetooth/api/mesh/od_srv.rst
@@ -24,5 +24,3 @@ API reference
 *************
 
 .. doxygengroup:: bt_mesh_od_priv_proxy_srv
-   :project: Zephyr
-   :members:

--- a/doc/connectivity/bluetooth/api/mesh/op_agg_cli.rst
+++ b/doc/connectivity/bluetooth/api/mesh/op_agg_cli.rst
@@ -27,5 +27,3 @@ API reference
 *************
 
 .. doxygengroup:: bt_mesh_op_agg_cli
-   :project: Zephyr
-   :members:

--- a/doc/connectivity/bluetooth/api/mesh/op_agg_srv.rst
+++ b/doc/connectivity/bluetooth/api/mesh/op_agg_srv.rst
@@ -28,5 +28,3 @@ API reference
 *************
 
 .. doxygengroup:: bt_mesh_op_agg_srv
-   :project: Zephyr
-   :members:

--- a/doc/connectivity/bluetooth/api/mesh/priv_beacon_cli.rst
+++ b/doc/connectivity/bluetooth/api/mesh/priv_beacon_cli.rst
@@ -31,5 +31,3 @@ API reference
 *************
 
 .. doxygengroup:: bt_mesh_priv_beacon_cli
-   :project: Zephyr
-   :members:

--- a/doc/connectivity/bluetooth/api/mesh/priv_beacon_srv.rst
+++ b/doc/connectivity/bluetooth/api/mesh/priv_beacon_srv.rst
@@ -34,5 +34,3 @@ API reference
 *************
 
 .. doxygengroup:: bt_mesh_priv_beacon_srv
-   :project: Zephyr
-   :members:

--- a/doc/connectivity/bluetooth/api/mesh/rpr_cli.rst
+++ b/doc/connectivity/bluetooth/api/mesh/rpr_cli.rst
@@ -138,5 +138,3 @@ API reference
 *************
 
 .. doxygengroup:: bt_mesh_rpr_cli
-   :project: Zephyr
-   :members:

--- a/doc/connectivity/bluetooth/api/mesh/rpr_srv.rst
+++ b/doc/connectivity/bluetooth/api/mesh/rpr_srv.rst
@@ -34,5 +34,3 @@ API reference
 *************
 
 .. doxygengroup:: bt_mesh_rpr_srv
-   :project: Zephyr
-   :members:

--- a/doc/connectivity/bluetooth/api/mesh/sar_cfg_cli.rst
+++ b/doc/connectivity/bluetooth/api/mesh/sar_cfg_cli.rst
@@ -37,5 +37,3 @@ API reference
 *************
 
 .. doxygengroup:: bt_mesh_sar_cfg_cli
-   :project: Zephyr
-   :members:

--- a/doc/connectivity/bluetooth/api/mesh/sar_cfg_srv.rst
+++ b/doc/connectivity/bluetooth/api/mesh/sar_cfg_srv.rst
@@ -27,5 +27,3 @@ API reference
 *************
 
 .. doxygengroup:: bt_mesh_sar_cfg_srv
-   :project: Zephyr
-   :members:

--- a/doc/connectivity/bluetooth/api/mesh/srpl_cli.rst
+++ b/doc/connectivity/bluetooth/api/mesh/srpl_cli.rst
@@ -31,5 +31,3 @@ API reference
 *************
 
 .. doxygengroup:: bt_mesh_sol_pdu_rpl_cli
-   :project: Zephyr
-   :members:

--- a/doc/connectivity/bluetooth/api/mesh/srpl_srv.rst
+++ b/doc/connectivity/bluetooth/api/mesh/srpl_srv.rst
@@ -30,5 +30,3 @@ API reference
 *************
 
 .. doxygengroup:: bt_mesh_sol_pdu_rpl_srv
-   :project: Zephyr
-   :members:

--- a/doc/hardware/peripherals/mdio.rst
+++ b/doc/hardware/peripherals/mdio.rst
@@ -17,4 +17,3 @@ API Reference
 *************
 
 .. doxygengroup:: mdio_interface
-   :project: Zephyr

--- a/doc/kernel/memory_management/demand_paging.rst
+++ b/doc/kernel/memory_management/demand_paging.rst
@@ -183,16 +183,13 @@ API Reference
 *************
 
 .. doxygengroup:: mem-demand-paging
-   :project: Zephyr
 
 Eviction Algorithm APIs
 =======================
 
 .. doxygengroup:: mem-demand-paging-eviction
-   :project: Zephyr
 
 Backing Store APIs
 ==================
 
 .. doxygengroup:: mem-demand-paging-backing-store
-   :project: Zephyr

--- a/doc/kernel/memory_management/shared_multi_heap.rst
+++ b/doc/kernel/memory_management/shared_multi_heap.rst
@@ -79,4 +79,3 @@ The API does not enforce any attributes, but at least it defines the two most
 common ones: :c:enumerator:`SMH_REG_ATTR_CACHEABLE` and :c:enumerator:`SMH_REG_ATTR_NON_CACHEABLE`.
 
 .. doxygengroup:: shared_multi_heap
-   :project: Zephyr

--- a/doc/kernel/services/other/version.rst
+++ b/doc/kernel/services/other/version.rst
@@ -9,4 +9,3 @@ API Reference
 **************
 
 .. doxygengroup:: version_apis
-   :content-only:

--- a/doc/known-warnings.txt
+++ b/doc/known-warnings.txt
@@ -1,24 +1,2 @@
 # Each line should contain the regular expression of a known Sphinx warning
 # that should be filtered out
-
-# Function and (enum or struct) name
-.*Duplicate C declaration.*\n.*'\.\. c:.*:: flash_img_check'.*
-.*Duplicate C declaration.*\n.*'\.\. c:.*:: fs_statvfs'.*
-.*Duplicate C declaration.*\n.*'\.\. c:.*:: .*dmic_trigger.*'.*
-.*Duplicate C declaration.*\n.*'\.\. c:.*:: dma_config'.*
-.*Duplicate C declaration.*\n.*'\.\. c:.*:: net_if_mcast_monitor'.*
-
-# Struct and typedef name
-.*Duplicate C declaration.*\n.*'\.\. c:.*:: zsock_fd_set'.*
-
-# Function and extern function
-.*Duplicate C declaration.*\n.*'\.\. c:.*:: .*net_if_ipv4_addr_mask_cmp.*'.*
-.*Duplicate C declaration.*\n.*'\.\. c:.*:: .*net_if_ipv4_is_addr_bcast.*'.*
-.*Duplicate C declaration.*\n.*'\.\. c:.*:: .*net_if_ipv4_addr_lookup.*'.*
-.*Duplicate C declaration.*\n.*'\.\. c:.*:: .*net_if_ipv6_addr_lookup.*'.*
-.*Duplicate C declaration.*\n.*'\.\. c:.*:: .*net_if_ipv6_maddr_lookup.*'.*
-
-# Common field names
-.*Duplicate C declaration.*\n.*'\.\. c:.*:: .*struct in_addr.*'.*
-.*Duplicate C declaration.*\n.*'\.\. c:.*:: .*struct in6_addr.*'.*
-.*Duplicate C declaration.*\n.*'\.\. c:.*:: .*struct net_if.*'.*

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,5 @@
 # DOC: used to generate docs
 
-breathe>=4.34
 sphinx
 sphinx_rtd_theme~=2.0
 sphinx-tabs

--- a/samples/drivers/clock_control_litex/README.rst
+++ b/samples/drivers/clock_control_litex/README.rst
@@ -45,12 +45,9 @@ This configuration defines 2 clock outputs: ``clk0`` and ``clk1`` with default f
 Driver Usage
 ************
 
-The driver is interfaced with the :ref:`Clock Control API <clock_control_api>` function ``clock_control_on()`` and a LiteX driver specific structure:
+The driver is interfaced with the :ref:`Clock Control API <clock_control_api>` function ``clock_control_on()`` and a LiteX driver specific structure (:c:struct:`litex_clk_setup`).
 
-.. doxygenstruct:: litex_clk_setup
-   :project: Zephyr
-
-| To change clock parameter it is needed to cast a pointer to structure ``litex_clk_setup`` onto ``clock_control_subsys_t`` and use it with ``clock_control_on()``.
+| To change clock parameter it is needed to cast a pointer to structure :c:struct:`litex_clk_setup` onto :c:type:`clock_control_subsys_t` and use it with :c:func:`clock_control_on()`.
 | This code will try to set on ``clk0`` frequency 50MHz, 90 degrees of phase offset and 75% duty cycle.
 
 .. code-block:: c


### PR DESCRIPTION
📄  Live doc example: https://builds.zephyrproject.io/zephyr/pr/73671/docs/services/input/index.html
___
Following up on some great work from @gmarull a while back (PR #39702), this PR effectively drops Breathe to instead directly link to our Doxygen website.

For people not familiar with Breathe, it's what's allowed us to effectively "embed" Doxygen documentation directly in our main docs.zephyrproject.org documentation. The `.. doxygengroup::` would allow to list the entire contents of a Doxygen group and embed it in a given ReStructuredText page, and mentions to a C object (ex. struct, function, etc.) made using the C domain "roles" (ex. `` :c:struct:`foo` ``, `` :c:func:`bar` ``) would automatically link to the RST page in which the Doxygen group was embedded. This makes for a nice "one stop shop"  experience but doesn't scale well as the project grows.

This PR builds on @gmarull's "doxybridge" extension so that it handles *all* of the C domain roles used in our docs. Also adds support for a basic `.. doxygengroup::` (initially coming from Breathe) directive as it's convenient, for now at least, to have the "API reference" sections of many of our pages still pointing to something useful, as well as list relevant code samples.
The extension now uses Doxygen "official" xml parser (where Gerard was initially using ElementTree).It also parses in parallel, as this is quite a resource extensive, and only parses again when needed on subsequent incremental builds.

A clean "turbo" build of the docs on my M2 takes ~3 minutes, and I am hopeful that OOM errors are also a thing of the past. 

Still to be tested/done:

- [x] PDF build
- [ ] Optionally: Improve the back and forth navigation between Sphinx docs and Doxygen website so that users don't get too confused