### PR TITLE
tracing: add missing calls for k_wakeup/k_thread_user_mode_enter

### DIFF
--- a/subsys/tracing/ctf/ctf_top.c
+++ b/subsys/tracing/ctf/ctf_top.c
@@ -33,6 +33,25 @@ void sys_trace_k_thread_switched_out(void)
 	ctf_top_thread_switched_out((uint32_t)(uintptr_t)thread, name);
 }
 
+void sys_trace_k_thread_user_mode_enter(void)
+{
+	struct k_thread *thread;
+	ctf_bounded_string_t name = { "unknown" };
+
+	thread = k_sched_current_thread_query();
+	_get_thread_name(thread, &name);
+	ctf_top_thread_user_mode_enter((uint32_t)(uintptr_t)thread, name);
+}
+
+void sys_trace_k_thread_wakeup(struct k_thread *thread)
+{
+	ctf_bounded_string_t name = { "unknown" };
+
+	_get_thread_name(thread, &name);
+	ctf_top_thread_wakeup((uint32_t)(uintptr_t)thread, name);
+}
+
+
 void sys_trace_k_thread_switched_in(void)
 {
 	struct k_thread *thread;

--- a/subsys/tracing/ctf/ctf_top.h
+++ b/subsys/tracing/ctf/ctf_top.h
@@ -102,7 +102,9 @@ typedef enum {
 	CTF_EVENT_TIMER_STOP = 0x30,
 	CTF_EVENT_TIMER_STATUS_SYNC_ENTER = 0x31,
 	CTF_EVENT_TIMER_STATUS_SYNC_BLOCKING = 0x32,
-	CTF_EVENT_TIMER_STATUS_SYNC_EXIT = 0x33
+	CTF_EVENT_TIMER_STATUS_SYNC_EXIT = 0x33,
+	CTF_EVENT_THREAD_USER_MODE_ENTER = 0x34,
+	CTF_EVENT_THREAD_WAKEUP = 0x35,
 
 } ctf_event_t;
 
@@ -186,6 +188,19 @@ static inline void ctf_top_thread_name_set(uint32_t thread_id,
 {
 	CTF_EVENT(CTF_LITERAL(uint8_t, CTF_EVENT_THREAD_NAME_SET), thread_id,
 		  name);
+}
+
+
+static inline void ctf_top_thread_user_mode_enter(uint32_t thread_id, ctf_bounded_string_t name)
+{
+	CTF_EVENT(CTF_LITERAL(uint8_t, CTF_EVENT_THREAD_USER_MODE_ENTER),
+		  thread_id, name);
+}
+
+static inline void ctf_top_thread_wakeup(uint32_t thread_id, ctf_bounded_string_t name)
+{
+	CTF_EVENT(CTF_LITERAL(uint8_t, CTF_EVENT_THREAD_WAKEUP),
+		  thread_id, name);
 }
 
 static inline void ctf_top_isr_enter(void)

--- a/subsys/tracing/ctf/tracing_ctf.h
+++ b/subsys/tracing/ctf/tracing_ctf.h
@@ -25,7 +25,7 @@ extern "C" {
 	sys_trace_k_thread_create(new_thread, stack_size, prio)
 
 #define sys_port_trace_k_thread_user_mode_enter()                              \
-	sys_trace_k_thread_user_mode_enter(entry, p1, p2, p3)
+	sys_trace_k_thread_user_mode_enter()
 
 #define sys_port_trace_k_thread_heap_assign(thread, heap)
 #define sys_port_trace_k_thread_join_enter(thread, timeout)
@@ -372,8 +372,7 @@ void sys_trace_k_thread_foreach_unlocked_exit(k_thread_user_cb_t user_cb,
 					      void *user_data);
 void sys_trace_k_thread_create(struct k_thread *new_thread, size_t stack_size,
 			       int prio);
-void sys_trace_k_thread_user_mode_enter(k_thread_entry_t entry, void *p1,
-					void *p2, void *p3);
+void sys_trace_k_thread_user_mode_enter(void);
 void sys_trace_k_thread_heap_assign(struct k_thread *thread,
 				    struct k_heap *heap);
 void sys_trace_k_thread_join_blocking(struct k_thread *thread,

--- a/subsys/tracing/ctf/tsdl/metadata
+++ b/subsys/tracing/ctf/tsdl/metadata
@@ -310,3 +310,21 @@ event {
 		uint32_t result;
 	};
 };
+
+event {
+	name = user_mode_enter;
+	id = 0x34;
+	fields := struct {
+		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
+	};
+};
+
+event {
+	name = thread_wakeup;
+	id = 0x35;
+	fields := struct {
+		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
+	};
+};


### PR DESCRIPTION
Add missing hooks for k_wakeup/k_thread_user_mode_enter to CTF backend.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
