### PR TITLE
intel_adsp/ace: pm: Let secondary cores be powered off

### DIFF
--- a/soc/intel/intel_adsp/ace/power.c
+++ b/soc/intel/intel_adsp/ace/power.c
@@ -200,6 +200,12 @@ void power_gate_entry(uint32_t core_id)
 		 * from power gaiting.
 		 */
 		z_xt_ints_on(ALL_USED_INT_LEVELS_MASK);
+	} else {
+		/* Secondary cores are supposed to be started manually. Lets
+		 * them just be powered off.
+		 */
+		DSPCS.capctl[core_id].ctl &= ~DSPCS_CTL_SPA;
+		soc_cpu_power_down(core_id);
 	}
 
 	soc_cpus_active[core_id] = false;

--- a/soc/intel/intel_adsp/ace/power.c
+++ b/soc/intel/intel_adsp/ace/power.c
@@ -182,7 +182,7 @@ static ALWAYS_INLINE void _restore_core_context(void)
 }
 
 void dsp_restore_vector(void);
-void mp_resume_entry(void);
+void z_mp_entry(void);
 
 void power_gate_entry(uint32_t core_id)
 {
@@ -222,13 +222,14 @@ void power_gate_entry(uint32_t core_id)
 
 static void __used power_gate_exit(void)
 {
-	cpu_early_init();
 	sys_cache_data_flush_and_invd_all();
-	_restore_core_context();
 
-	/* Secondary core is resumed by set_dx */
+	/* Secondary core is resumed manually and have a fresh start */
 	if (arch_proc_id()) {
-		mp_resume_entry();
+		z_mp_entry();
+	} else {
+		cpu_early_init();
+		_restore_core_context();
 	}
 }
 

--- a/soc/intel/intel_adsp/common/multiprocessing.c
+++ b/soc/intel/intel_adsp/common/multiprocessing.c
@@ -96,7 +96,7 @@ __asm__(".section .text.z_soc_mp_asm_entry, \"x\" \n\t"
 #undef NOP32
 #undef NOP4
 
-static __imr void __used z_mp_entry(void)
+__imr void __used z_mp_entry(void)
 {
 	cpu_early_init();
 	/* Set up the CPU pointer. */


### PR DESCRIPTION
Secondary cores are only power gated when the applcation forces SOFT_OFF state and it is assumed that these cores will powered off, since the arey are restarted manually from the appllication.

The initialization path (when starting a cpu) assumes that the cpu is powered off.