### PR TITLE
soc: nxp: imxrt11xx: support configuration of ARM PLL

### DIFF
--- a/boards/nxp/mimxrt1160_evk/mimxrt1160_evk.dtsi
+++ b/boards/nxp/mimxrt1160_evk/mimxrt1160_evk.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include "mimxrt1160_evk-pinctrl.dtsi"
+#include <nxp/nxp_rt1160.dtsi>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include "mimxrt1170_evk-pinctrl.dtsi"
+#include <nxp/nxp_rt1170.dtsi>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {

--- a/boards/nxp/vmu_rt1170/vmu_rt1170.dtsi
+++ b/boards/nxp/vmu_rt1170/vmu_rt1170.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include "vmu_rt1170-pinctrl.dtsi"
+#include <nxp/nxp_rt1170.dtsi>
 
 / {
 	aliases {

--- a/dts/arm/nxp/nxp_rt1160.dtsi
+++ b/dts/arm/nxp/nxp_rt1160.dtsi
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Configure ARM PLL to 600MHz */
+&arm_pll {
+	clock-mult = <100>;
+	clock-div = <4>;
+};

--- a/dts/arm/nxp/nxp_rt1170.dtsi
+++ b/dts/arm/nxp/nxp_rt1170.dtsi
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Configure ARM PLL to 996MHz */
+&arm_pll {
+	clock-mult = <83>;
+	clock-div = <2>;
+};

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -169,6 +169,18 @@
 			reg = <0x40cc0000 0x4000>;
 
 			#clock-cells = <3>;
+
+			/*
+			 * ARM PLL is an integer PLL, with an input clock
+			 * of 24MHz. The PLL features a loop divider and
+			 * post divider. The output frequency is calculated
+			 * as Fout = 24MHz * (clock-mult / clock-div)
+			 */
+			arm_pll: arm-pll {
+				compatible = "fixed-factor-clock";
+				#clock-cells = <0>;
+			};
+
 		};
 
 		gpio1: gpio@4012c000 {

--- a/soc/nxp/imxrt/imxrt11xx/soc.c
+++ b/soc/nxp/imxrt/imxrt11xx/soc.c
@@ -55,22 +55,30 @@
 #endif
 
 #ifdef CONFIG_INIT_ARM_PLL
-static const clock_arm_pll_config_t armPllConfig = {
-#if defined(CONFIG_SOC_MIMXRT1176_CM4) || defined(CONFIG_SOC_MIMXRT1176_CM7)
-	/* resulting frequency: 24 * (166/(2* 2)) = 984MHz */
-	/* Post divider, 0 - DIV by 2, 1 - DIV by 4, 2 - DIV by 8, 3 - DIV by 1 */
-	.postDivider = kCLOCK_PllPostDiv2,
-	/* PLL Loop divider, Fout = Fin * ( loopDivider / ( 2 * postDivider ) ) */
-	.loopDivider = 166,
-#elif defined(CONFIG_SOC_MIMXRT1166_CM4) || defined(CONFIG_SOC_MIMXRT1166_CM7)
-	/* resulting frequency: 24 * (200/(2 * 4)) = 600MHz */
-	/* Post divider, 0 - DIV by 2, 1 - DIV by 4, 2 - DIV by 8, 3 - DIV by 1 */
-	.postDivider = kCLOCK_PllPostDiv4,
-	/* PLL Loop divider, Fout = Fin * ( loopDivider / ( 2 * postDivider ) ) */
-	.loopDivider = 200,
+
+#if defined(CONFIG_SOC_MIMXRT1176)
+#define DEFAULT_LOOPDIV 83
+#define DEFAULT_POSTDIV 2
+#elif defined(CONFIG_SOC_MIMXRT1166)
+#define DEFAULT_LOOPDIV 100
+#define DEFAULT_POSTDIV 4
 #else
-	#error "Unknown SOC, no pll configuration defined"
+/*
+ * Check that the ARM PLL has a multiplier and divider set
+ */
+BUILD_ASSERT(DT_NODE_HAS_PROP(DT_NODELABEL(arm_pll), clock_mult),
+			      "ARM PLL must have clock-mult property");
+BUILD_ASSERT(DT_NODE_HAS_PROP(DT_NODELABEL(arm_pll), clock_div),
+			      "ARM PLL must have clock-div property");
 #endif
+
+
+static const clock_arm_pll_config_t armPllConfig = {
+	.postDivider = CONCAT(kCLOCK_PllPostDiv,
+			      DT_PROP_OR(DT_NODELABEL(arm_pll), clock_div,
+			      DEFAULT_POSTDIV)),
+	.loopDivider = DT_PROP_OR(DT_NODELABEL(arm_pll), clock_mult,
+				  DEFAULT_LOOPDIV) * 2,
 };
 #endif
 


### PR DESCRIPTION
Add support for configuration of the ARM PLL on the iMXRT1170/1160 series SOCs. This PLL is used to generate the M7 core frequency, and is an integer pll. Provide default configurations for the RT1160 and RT1170 targeting 600MHz and 1GHz respectively.