### PR TITLE
boards: shields: adafruit_2_8_tft_touch_v2: fix RW612 board overlay

### DIFF
--- a/boards/shields/adafruit_2_8_tft_touch_v2/boards/rd_rw612_bga.overlay
+++ b/boards/shields/adafruit_2_8_tft_touch_v2/boards/rd_rw612_bga.overlay
@@ -16,6 +16,7 @@
 	 * directly and does not require the MIPI DBI SPI node
 	 */
 	/delete-node/ mipi_dbi;
+	/delete-node/ adafruit_2_8_tft_touch_v2_mipi_dbi;
 };
 
 &lcdic {


### PR DESCRIPTION
RW612 board overlay should remove the MIPI DBI nodes defined at the board and at the shield level, because the LCDIC peripheral on this SOC can support the MIPI DBI protocol directly without the emulated Zephyr driver.