### PR TITLE
drivers: display: gc9x01: convert to MIPI DBI API

### DIFF
--- a/boards/shields/seeed_xiao_round_display/seeed_xiao_round_display.overlay
+++ b/boards/shields/seeed_xiao_round_display/seeed_xiao_round_display.overlay
@@ -27,6 +27,26 @@
 	aliases {
 		rtc = &pcf8563_xiao_round_display;
 	};
+
+	xiao_round_display_mipi_dbi {
+		compatible = "zephyr,mipi-dbi-spi";
+		spi-dev = <&xiao_spi>;
+		dc-gpios = <&xiao_d 3 GPIO_ACTIVE_HIGH>;
+		write-only;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		gc9a01_xiao_round_display: gc9a01@0 {
+			status = "okay";
+			compatible = "galaxycore,gc9x01x";
+			reg = <0>;
+			mipi-max-frequency = <DT_FREQ_M(100)>;
+			pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+			width = <240>;
+			height = <240>;
+			display-inversion;
+		};
+	};
 };
 
 &xiao_adc {
@@ -61,18 +81,6 @@
 &xiao_spi {
 	status = "okay";
 	cs-gpios = <&xiao_d 1 GPIO_ACTIVE_LOW>, <&xiao_d 2 GPIO_ACTIVE_LOW>;
-
-	gc9a01_xiao_round_display: gc9a01@0 {
-		status = "okay";
-		compatible = "galaxycore,gc9x01x";
-		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(100)>;
-		cmd-data-gpios = <&xiao_d 3 GPIO_ACTIVE_HIGH>;
-		pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
-		width = <240>;
-		height = <240>;
-		display-inversion;
-	};
 
 	sdhc_xiao_round_display: sdhc@1 {
 		compatible = "zephyr,sdhc-spi-slot";

--- a/boards/waveshare/esp32s3_touch_lcd_1_28/esp32s3_touch_lcd_1_28_esp32s3_procpu.dts
+++ b/boards/waveshare/esp32s3_touch_lcd_1_28/esp32s3_touch_lcd_1_28_esp32s3_procpu.dts
@@ -56,6 +56,28 @@
 			pwms = <&ledc0 0 PWM_HZ(250) PWM_POLARITY_NORMAL>;
 		};
 	};
+
+	/* MIPI DBI */
+	mipi_dbi {
+		compatible = "zephyr,mipi-dbi-spi";
+		spi-dev = <&spi2>;
+		dc-gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+		write-only;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		gc9a01: gc9a01@0 {
+			status = "okay";
+			compatible = "galaxycore,gc9x01x";
+			reg = <0>;
+			mipi-max-frequency = <100000000>;
+			pixel-format = <PANEL_PIXEL_FORMAT_RGB_888>;
+			display-inversion;
+			width = <240>;
+			height = <240>;
+		};
+	};
 };
 
 &flash0 {
@@ -146,19 +168,6 @@
 	pinctrl-0 = <&spim2_default>;
 	pinctrl-names = "default";
 	cs-gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
-
-	gc9a01: gc9a01@0 {
-		status = "okay";
-		compatible = "galaxycore,gc9x01x";
-		reg = <0>;
-		spi-max-frequency = <100000000>;
-		cmd-data-gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
-		reset-gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
-		pixel-format = <PANEL_PIXEL_FORMAT_RGB_888>;
-		display-inversion;
-		width = <240>;
-		height = <240>;
-	};
 };
 
 &trng0 {

--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -312,6 +312,50 @@ Controller Area Network (CAN)
 Display
 =======
 
+* GC9X01 based displays now use the MIPI DBI driver class. These displays
+  must now be declared within a MIPI DBI driver wrapper device, which will
+  manage interfacing with the display. (:github:`73686`)
+  For an example, see below:
+
+  .. code-block:: devicetree
+
+    /* Legacy GC9X01 display definition */
+    &spi0 {
+        gc9a01: gc9a01@0 {
+            status = "okay";
+            compatible = "galaxycore,gc9x01x";
+            reg = <0>;
+            spi-max-frequency = <100000000>;
+            cmd-data-gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
+            reset-gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+            ...
+        };
+    };
+
+    /* New display definition with MIPI DBI device */
+
+    #include <zephyr/dt-bindings/mipi_dbi/mipi_dbi.h>
+
+    ...
+
+    mipi_dbi {
+        compatible = "zephyr,mipi-dbi-spi";
+        dc-gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
+        reset-gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+        spi-dev = <&spi0>;
+        #address-cells = <1>;
+        #size-cells = <0>;
+
+        gc9a01: gc9a01@0 {
+            status = "okay";
+            compatible = "galaxycore,gc9x01x";
+            reg = <0>;
+            mipi-max-frequency = <100000000>;
+            ...
+        };
+    };
+
+
 * ST7735R based displays now use the MIPI DBI driver class. These displays
   must now be declared within a MIPI DBI driver wrapper device, which will
   manage interfacing with the display. Note that the `cmd-data-gpios` pin has

--- a/drivers/display/Kconfig.gc9x01x
+++ b/drivers/display/Kconfig.gc9x01x
@@ -5,6 +5,6 @@ config GC9X01X
 	bool "GC9X01X display driver"
 	default y
 	depends on DT_HAS_GALAXYCORE_GC9X01X_ENABLED
-	select SPI
+	select MIPI_DBI
 	help
 	  Enable driver for GC9X01X display driver.

--- a/dts/bindings/display/galaxycore,gc9x01x.yaml
+++ b/dts/bindings/display/galaxycore,gc9x01x.yaml
@@ -29,23 +29,9 @@ description: |
 
 compatible: "galaxycore,gc9x01x"
 
-include: [spi-device.yaml, display-controller.yaml, lcd-controller.yaml]
+include: [mipi-dbi-spi-device.yaml, display-controller.yaml, lcd-controller.yaml]
 
 properties:
-  reset-gpios:
-    type: phandle-array
-    description: |
-      RESET pin of the GC9X01X.
-      If connected directly the MCU pin should be configured
-      as active low.
-
-  cmd-data-gpios:
-    type: phandle-array
-    required: true
-    description: |
-      Data/Command pin of the GC9X01X is to be configured
-      high(1) for data, low(0) for command.
-
   orientation:
     type: string
     default: "normal"

--- a/tests/drivers/build_all/display/app.overlay
+++ b/tests/drivers/build_all/display/app.overlay
@@ -125,6 +125,16 @@
 					tcon = <0x22>;
 				};
 			};
+
+			test_spi_gc9x01x: gc9x01x@6 {
+				compatible = "galaxycore,gc9x01x";
+				reg = <6>;
+				mipi-max-frequency = <100000000>;
+				pixel-format = <16>;
+
+				width = <240>;
+				height = <240>;
+			};
 		};
 
 
@@ -136,21 +146,12 @@
 			status = "okay";
 			clock-frequency = <2000000>;
 
-			/* one entry for every devices at spi.dtsi */
+			/* one entry for every device. Note that this must
+			 * include MIPI DBI devices as well.
+			 */
 			cs-gpios = <&test_gpio 0 0 &test_gpio 0 1 &test_gpio 0 2
-				&test_gpio 0 3 &test_gpio 0 4 &test_gpio 0 5>;
-
-			test_spi_gc9x01x: gc9x01x@1 {
-				compatible = "galaxycore,gc9x01x";
-				reg = <1>;
-				spi-max-frequency = <100000000>;
-				cmd-data-gpios = <&test_gpio 1 0>;
-				reset-gpios = <&test_gpio 2 0>;
-				pixel-format = <16>;
-
-				width = <240>;
-				height = <240>;
-			};
+				&test_gpio 0 3 &test_gpio 0 4 &test_gpio 0 5
+				&test_gpio 0 6>;
 
 			test_led_strip_0: lpd8806@2 {
 				compatible = "greeled,lpd8806";

--- a/tests/drivers/build_all/display/app.overlay
+++ b/tests/drivers/build_all/display/app.overlay
@@ -153,9 +153,9 @@
 				&test_gpio 0 3 &test_gpio 0 4 &test_gpio 0 5
 				&test_gpio 0 6>;
 
-			test_led_strip_0: lpd8806@2 {
+			test_led_strip_0: lpd8806@0 {
 				compatible = "greeled,lpd8806";
-				reg = <2>;
+				reg = <0>;
 				spi-max-frequency = <2000000>;
 				chain-length = <1>;
 				color-mapping = <LED_COLOR_ID_RED
@@ -163,9 +163,9 @@
 						 LED_COLOR_ID_BLUE>;
 			};
 
-			test_led_strip_1: ws2812_spi@3 {
+			test_led_strip_1: ws2812_spi@1 {
 				compatible = "worldsemi,ws2812-spi";
-				reg = <3>;
+				reg = <1>;
 				spi-max-frequency = <2000000>;
 				spi-one-frame = <1>;
 				spi-zero-frame = <1>;


### PR DESCRIPTION
Convert galaxycore GC9X01 to MIPI DBI API. In tree boards and tests
using this display have also had their devicetrees updated to use the
new MIPI DBI SPI emulated device.
