### PR TITLE
Fix/smartbond timer counter test build fails

### DIFF
--- a/drivers/counter/counter_smartbond_timer.c
+++ b/drivers/counter/counter_smartbond_timer.c
@@ -105,6 +105,8 @@ static uint8_t counter_smartbond_pdc_trigger_get(const struct device *dev)
 		return MCU_PDC_TRIGGER_TIMER3;
 	case (uint32_t)TIMER4:
 		return MCU_PDC_TRIGGER_TIMER4;
+	default:
+		return 0;
 	}
 }
 

--- a/soc/renesas/smartbond/da1469x/Kconfig.defconfig
+++ b/soc/renesas/smartbond/da1469x/Kconfig.defconfig
@@ -4,7 +4,7 @@
 if SOC_SERIES_DA1469X
 
 config SMARTBOND_TIMER
-	default y if PM
+	default y if PM && !$(dt_nodelabel_enabled,timer2)
 
 config CORTEX_M_SYSTICK
 	default n if SMARTBOND_TIMER


### PR DESCRIPTION
This PR is a hotfix and may not be the ideal.

Fixes #73685

I'm not sure why, but setting CONFIG_SMARTBOND_TIMER=n in a .conf or on command line is not able to disable the Kconfig. The only way I could get it to disable was by changing that default case in the Kconfig.defconfig as seen in the PR.