### PR TITLE
drivers: mcux_lptmr_timer: Fix compat string error

### DIFF
--- a/drivers/counter/Kconfig.mcux_lptmr
+++ b/drivers/counter/Kconfig.mcux_lptmr
@@ -12,7 +12,7 @@ config COUNTER_MCUX_LPTMR
 	  Enable support for the MCUX Low Power Timer (LPTMR).
 
 config COUNTER_MCUX_KINETIS_LPTMR
-	bool "Deprecated DT compatible"
+	bool
 	default y
 	depends on DT_HAS_NXP_KINETIS_LPTMR_ENABLED
 	select DEPRECATED

--- a/drivers/timer/Kconfig.mcux_lptmr
+++ b/drivers/timer/Kconfig.mcux_lptmr
@@ -6,7 +6,8 @@
 config MCUX_LPTMR_TIMER
 	bool "MCUX LPTMR timer"
 	default y
-	depends on DT_HAS_NXP_KINETIS_LPTMR_ENABLED
+	depends on DT_HAS_NXP_KINETIS_LPTMR_ENABLED || \
+		   MCUX_KINETIS_LPTMR
 	depends on !COUNTER_MCUX_LPTMR
 	depends on PM
 	select SYSTEM_TIMER_HAS_DISABLE_SUPPORT
@@ -14,3 +15,13 @@ config MCUX_LPTMR_TIMER
 	  This module implements a kernel device driver for the NXP MCUX Low
 	  Power Timer (LPTMR) and provides the standard "system clock driver"
 	  interfaces.
+
+config MCUX_KINETIS_LPTMR
+	bool
+	default y
+	depends on DT_HAS_NXP_KINETIS_LPTMR_ENABLED
+	select DEPRECATED
+	help
+	  The compatible string "nxp,kinetis-lptmr" should
+	  be swiched to "nxp,lptmr" in DT. The former will
+	  be removed eventually.

--- a/drivers/timer/mcux_lptmr_timer.c
+++ b/drivers/timer/mcux_lptmr_timer.c
@@ -4,7 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/devicetree.h>
+#if DT_HAS_COMPAT_STATUS_OKAY(nxp_kinetis_lptmr)
 #define DT_DRV_COMPAT nxp_kinetis_lptmr
+#else
+#define DT_DRV_COMPAT nxp_lptmr
+#endif
 
 #include <zephyr/init.h>
 #include <zephyr/drivers/timer/system_timer.h>


### PR DESCRIPTION
Fix error due to compatible string changing in DT and forgetting to update this driver with the change.

Fixes #73617