### PR TITLE
doc: project roles: reviewer and assignee clarification

### DIFF
--- a/doc/contribute/contributor_expectations.rst
+++ b/doc/contribute/contributor_expectations.rst
@@ -276,6 +276,9 @@ Reviewer Expectations
     #. PRs assigned to the reviewer as the area maintainer.
     #. All other PRs.
 
+- Reviewers shall strive to advance the PR to a mergeable state with their
+  feedback and engagement with the PR author.
+
 - Try to provide feedback on the entire PR in one shot. This provides the
   contributor an opportunity to address all comments in the next PR update.
 
@@ -304,6 +307,11 @@ Reviewer Expectations
   "Request Changes" option is used. Requested changes shall be in the scope of
   the PR in question and following the contribution and style guidelines of the
   project.
+
+- Reviewers shall not close a PR due to technical or structural disagreement.
+  If requested changes cannot be resolved within the review process, the
+  :ref:`pr_technical_escalation` path shall be used for any potential resolution
+  path, which may include closing the PR.
 
 .. _Code of Conduct: https://github.com/zephyrproject-rtos/zephyr/blob/main/CODE_OF_CONDUCT.md
 

--- a/doc/project/project_roles.rst
+++ b/doc/project/project_roles.rst
@@ -159,6 +159,7 @@ Assignees are set either automatically based on the code being changed or set
 by the other Maintainers, the Release Engineering team can set an assignee when
 the latter is not possible.
 
+* Responsibility to drive the pull request to a mergeable state
 * Right to dismiss stale and unrelated reviews or reviews not following
   :ref:`expectations <reviewer-expectations>` from reviewers and seek reviews
   from additional maintainers, developers and contributors
@@ -166,7 +167,6 @@ the latter is not possible.
   requested are addressed
 * Responsibility to re-assign a pull request if they are the original submitter
   of the code
-* Responsibility to drive the pull request to a mergeable state
 * Solicit approvals from maintainers of the subsystems affected
 * Responsibility to drive the :ref:`pr_technical_escalation` process
 


### PR DESCRIPTION
Clarification of reviewer expectations and role. Emphasis on clarifying when a PR can be closed.

Highlighting reviewers and assignee objective to guide PR to a mergeable state, if possible.