### PR TITLE
doc: update Infocenter links to TechDocs links

### DIFF
--- a/boards/nordic/nrf21540dk/doc/index.rst
+++ b/boards/nordic/nrf21540dk/doc/index.rst
@@ -32,7 +32,7 @@ The CPU provides support for the following devices:
      nRF21540 DK (Credit: Nordic Semiconductor)
 
 More information about the board can be found at the `nRF21540 website`_.
-The `Nordic Semiconductor Infocenter`_ contains the processor's and front end
+`nRF21540 Product Specification`_ contains the processor's and front end
 module's information and the datasheet.
 
 Hardware
@@ -83,7 +83,7 @@ hardware features:
 +-----------+------------+----------------------+
 
 Other hardware features have not been enabled yet for this board.
-See `nRF52840 Product Specification`_ and `Nordic Semiconductor Infocenter`_
+See `nRF52840 Product Specification`_ and `nRF21540 DK Hardware guide`_
 for a complete list of nRF21540 Development Kit board hardware features.
 
 Connections and IOs
@@ -229,8 +229,8 @@ References
 
 .. target-notes::
 
-.. _Nordic Semiconductor Infocenter: https://infocenter.nordicsemi.com
+.. _nRF21540 DK Hardware guide: https://docs.nordicsemi.com/bundle/ug_nrf21540_dk/page/UG/nrf21540_DK/intro.html
 .. _J-Link Software and documentation pack: https://www.segger.com/jlink-software.html
 .. _nRF21540 website: https://www.nordicsemi.com/Products/Low-power-short-range-wireless/nRF21540
-.. _nRF52840 Product Specification: http://infocenter.nordicsemi.com/pdf/nRF52840_PS_v1.0.pdf
-.. _nRF21540 Product Specification: http://infocenter.nordicsemi.com/pdf/nRF21540_PS_v1.0.pdf
+.. _nRF52840 Product Specification: https://docs.nordicsemi.com/bundle/ps_nrf52840/page/keyfeatures_html5.html
+.. _nRF21540 Product Specification: https://docs.nordicsemi.com/bundle/ps_nrf21540/page/keyfeatures_html5.html

--- a/boards/nordic/nrf51dk/doc/index.rst
+++ b/boards/nordic/nrf51dk/doc/index.rst
@@ -29,7 +29,7 @@ Semiconductor nRF51822 ARM Cortex-M0 CPU and the following devices:
      nRF51 DK (Credit: Nordic Semiconductor)
 
 More information about the board can be found at the
-`nRF51 DK website`_. The `Nordic Semiconductor Infocenter`_
+`nRF51 DK website`_. The `nRF51 Development Kit User Guide`_
 contains the processor's information and the datasheet.
 
 
@@ -75,7 +75,7 @@ hardware features:
 +-----------+------------+----------------------+
 
 Other hardware features have not been enabled yet for this board.
-See `nRF51 DK website`_ and `Nordic Semiconductor Infocenter`_
+See `nRF51 DK website`_ and `nRF51 Development Kit User Guide`_
 for a complete list of nRF51 Development Kit board hardware features.
 
 Connections and IOs
@@ -156,4 +156,4 @@ References
 .. target-notes::
 
 .. _nRF51 DK website: https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF51-DK
-.. _Nordic Semiconductor Infocenter: https://infocenter.nordicsemi.com
+.. _nRF51 Development Kit User Guide: https://docs.nordicsemi.com/bundle/nRF51-Series-DK/resource/nRF51_Development_Kit_User_Guide_v1.2.pdf

--- a/boards/nordic/nrf51dongle/doc/index.rst
+++ b/boards/nordic/nrf51dongle/doc/index.rst
@@ -29,7 +29,7 @@ Semiconductor nRF51822 ARM Cortex-M0 CPU and the following devices:
      nRF51 Dongle (Credit: Nordic Semiconductor)
 
 More information about the board can be found at the
-`nRF51 Dongle website`_. The `Nordic Semiconductor Infocenter`_
+`nRF51 Dongle website`_. The `Nordic Semiconductor TechDocs`_
 contains the processor's information and the datasheet.
 
 
@@ -75,7 +75,7 @@ hardware features:
 +-----------+------------+----------------------+
 
 Other hardware features have not been enabled yet for this board.
-See `nRF51 Dongle website`_ and `Nordic Semiconductor Infocenter`_
+See `nRF51 Dongle website`_ and `Nordic Semiconductor TechDocs`_
 for a complete list of nRF51 Dongle hardware features.
 
 Connections and IOs
@@ -141,4 +141,4 @@ References
 .. target-notes::
 
 .. _nRF51 Dongle website: http://www.nordicsemi.com/eng/Products/nRF51-Dongle
-.. _Nordic Semiconductor Infocenter: http://infocenter.nordicsemi.com/
+.. _Nordic Semiconductor TechDocs: https://docs.nordicsemi.com/

--- a/boards/nordic/nrf52833dk/doc/index.rst
+++ b/boards/nordic/nrf52833dk/doc/index.rst
@@ -27,7 +27,7 @@ the following devices:
 * :abbr:`WDT (Watchdog Timer)`
 
 More information about the board can be found at the
-`nRF52833 DK website`_. The `Nordic Semiconductor Infocenter`_
+`nRF52833 DK website`_. `nRF52833 Product Specification`_
 contains the processor's information and the datasheet.
 
 
@@ -80,7 +80,7 @@ hardware features:
 +-----------+------------+----------------------+
 
 Other hardware features have not been enabled yet for this board.
-See `nRF52833 DK website`_ and `Nordic Semiconductor Infocenter`_
+See `nRF52833 DK website`_ and `nRF52833 DK Hardware guide`_
 for a complete list of nRF52833 Development Kit board hardware features.
 
 Connections and IOs
@@ -212,9 +212,9 @@ References
 .. target-notes::
 
 .. _nRF52833 DK website: https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52833-DK
-.. _Nordic Semiconductor Infocenter: https://infocenter.nordicsemi.com
+.. _nRF52833 Product Specification: https://docs.nordicsemi.com/bundle/ps_nrf52833/page/keyfeatures_html5.html
 .. _J-Link Software and documentation pack: https://www.segger.com/jlink-software.html
-.. _nRF52833 Product Specification: https://infocenter.nordicsemi.com/pdf/nRF52833_OPS_v0.7.pdf
+.. _nRF52833 DK Hardware guide: https://docs.nordicsemi.com/bundle/ug_nrf52833_dk/page/UG/dk/intro.html
 
 .. _nrf52833dk_nrf52820:
 

--- a/boards/nordic/nrf52840dk/doc/index.rst
+++ b/boards/nordic/nrf52840dk/doc/index.rst
@@ -32,7 +32,7 @@ Nordic Semiconductor nRF52840 ARM Cortex-M4F CPU and the following devices:
      nRF52840 DK (Credit: Nordic Semiconductor)
 
 More information about the board can be found at the `nRF52840 DK website`_.
-The `Nordic Semiconductor Infocenter`_ contains the processor's information
+`nRF52840 Product Specification`_ contains the processor's information
 and the datasheet.
 
 
@@ -84,7 +84,7 @@ hardware features:
 +-----------+------------+----------------------+
 
 Other hardware features have not been enabled yet for this board.
-See `nRF52840 DK website`_ and `Nordic Semiconductor Infocenter`_
+See `nRF52840 DK website`_ and `nRF52840 DK Hardware guide`_
 for a complete list of nRF52840 Development Kit board hardware features.
 
 Connections and IOs
@@ -244,7 +244,7 @@ References
 .. target-notes::
 
 .. _nRF52840 DK website: https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-DK
-.. _Nordic Semiconductor Infocenter: https://infocenter.nordicsemi.com
+.. _nRF52840 Product Specification: https://docs.nordicsemi.com/bundle/ps_nrf52840/page/keyfeatures_html5.html
+.. _nRF52840 DK Hardware guide: https://docs.nordicsemi.com/bundle/ug_nrf52840_dk/page/UG/dk/intro.html
 .. _J-Link Software and documentation pack: https://www.segger.com/jlink-software.html
-.. _nRF52840 Product Specification: http://infocenter.nordicsemi.com/pdf/nRF52840_PS_v1.0.pdf
 .. _nRF52811 website: https://www.nordicsemi.com/Products/Low-power-short-range-wireless/nRF52811

--- a/boards/nordic/nrf52840dongle/doc/index.rst
+++ b/boards/nordic/nrf52840dongle/doc/index.rst
@@ -31,7 +31,7 @@ Semiconductor nRF52840 ARM Cortex-M4F CPU and the following devices:
      nRF52840 Dongle
 
 More information about the board can be found at the
-`nRF52840 Dongle website`_. The `Nordic Semiconductor Infocenter`_
+`nRF52840 Dongle website`_. The `nRF52840 Dongle guide`_
 contains the processor's information and the datasheet.
 
 
@@ -82,7 +82,7 @@ hardware features:
 +-----------+------------+----------------------+
 
 Other hardware features have not been enabled yet for this board.
-See `nRF52840 Dongle website`_ and `Nordic Semiconductor Infocenter`_
+See `nRF52840 Dongle website`_ and `nRF52840 Dongle Hardware description`_
 for a complete list of nRF52840 Dongle board hardware features.
 
 Connections and IOs
@@ -334,12 +334,12 @@ References
 
 .. _nRF52840 Dongle website:
    https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-Dongle
-.. _Nordic Semiconductor Infocenter:
-   https://infocenter.nordicsemi.com
+.. _nRF52840 Dongle guide: https://docs.nordicsemi.com/bundle/ug_nrf52840_dk/page/UG/dk/intro.html
+.. _nRF52840 Dongle Hardware description: https://docs.nordicsemi.com/bundle/ug_nrf52840_dongle/page/UG/nrf52840_Dongle/hw_description.html
 .. _J-Link Software and documentation pack:
    https://www.segger.com/jlink-software.html
 .. _Nordic Semiconductor USB DFU:
-   https://infocenter.nordicsemi.com/index.jsp?topic=%2Fcom.nordic.infocenter.sdk5.v15.2.0%2Fsdk_app_serial_dfu_bootloader.html
+   https://docs.nordicsemi.com/bundle/sdk_nrf5_v17.1.0/page/sdk_app_serial_dfu_bootloader.html
 .. _nrfutil:
    https://github.com/NordicSemiconductor/pc-nrfutil
 .. _MCUboot:

--- a/boards/nordic/nrf52dk/doc/index.rst
+++ b/boards/nordic/nrf52dk/doc/index.rst
@@ -32,7 +32,7 @@ the following devices:
      nRF52 DK (Credit: Nordic Semiconductor)
 
 More information about the board can be found at the
-`nRF52 DK website`_. The `Nordic Semiconductor Infocenter`_
+`nRF52 DK website`_. `nRF52832 Product Specification`_
 contains the processor's information and the datasheet.
 
 
@@ -82,7 +82,7 @@ hardware features:
 +-----------+------------+----------------------+
 
 Other hardware features have not been enabled yet for this board.
-See `nRF52 DK website`_ and `Nordic Semiconductor Infocenter`_
+See `nRF52 DK website`_ and `nRF52832 Product Specification`_
 for a complete list of nRF52 Development Kit board hardware features.
 
 Connections and IOs
@@ -403,7 +403,7 @@ References
 .. target-notes::
 
 .. _nRF52 DK website: https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52-DK
-.. _Nordic Semiconductor Infocenter: https://infocenter.nordicsemi.com
+.. _nRF52832 Product Specification: https://docs.nordicsemi.com/bundle/ps_nrf52832/page/nrf52832_ps.html
 
 .. _nrf52dk_nrf52805:
 

--- a/boards/nordic/nrf5340_audio_dk/doc/index.rst
+++ b/boards/nordic/nrf5340_audio_dk/doc/index.rst
@@ -35,7 +35,7 @@ The nRF5340 Audio DK comes with the following hardware features:
      :align: center
      :alt: nRF5340 DK
 
-More information about the board can be found at the `nRF5340 Audio DK website`_. The `Nordic Semiconductor Infocenter`_
+More information about the board can be found at the `nRF5340 Audio DK website`_. The `nRF5340 Audio DK hardware guide`_
 contains the processor's information and the datasheet.
 
 nRF5340 SoC
@@ -53,13 +53,13 @@ The ``nrf5340_audio_dk/nrf5340/cpuapp`` build target provides support for the ap
 core on the nRF5340 SoC. The ``nrf5340_audio_dk/nrf5340/cpunet`` build target provides
 support for the network core on the nRF5340 SoC.
 
-The `Nordic Semiconductor Infocenter`_ contains the processor's information and
+The `nRF5340 Audio DK hardware guide`_ contains the processor's information and
 the datasheet.
 
 Supported Features
 ==================
 
-See :ref:`nrf5340dk_nrf5340` and `Nordic Semiconductor Infocenter`_
+See :ref:`nrf5340dk_nrf5340` and `nRF5340 Audio DK hardware guide`_
 for a complete list of nRF5340 Audio DK board hardware features.
 
 
@@ -106,4 +106,4 @@ References
 
 .. _nRF5340 Audio DK website:
    https://www.nordicsemi.com/Products/Development-hardware/nrf5340-audio-dk
-.. _Nordic Semiconductor Infocenter: https://infocenter.nordicsemi.com
+.. _nRF5340 Audio DK hardware guide: https://docs.nordicsemi.com/bundle/ug_nrf5340_audio/page/UG/nrf5340_audio/intro.html

--- a/boards/nordic/nrf5340dk/doc/index.rst
+++ b/boards/nordic/nrf5340dk/doc/index.rst
@@ -48,7 +48,7 @@ nRF5340 SoC provides support for the following devices:
 
 More information about the board can be found at the
 `nRF5340 DK website`_.
-The `Nordic Semiconductor Infocenter`_
+The `nRF5340 DK Product Specification`_
 contains the processor's information and the datasheet.
 
 
@@ -132,7 +132,7 @@ hardware features:
 +-----------+------------+----------------------+
 
 Other hardware features have not been enabled yet for this board.
-See `Nordic Semiconductor Infocenter`_
+See `nRF5340 DK Product Specification`_
 for a complete list of nRF5340 DK board hardware features.
 
 Connections and IOs
@@ -326,5 +326,5 @@ References
    https://developer.arm.com/docs/100690/latest/attribution-units-sau-and-idau
 .. _nRF5340 DK website:
    https://www.nordicsemi.com/Software-and-tools/Development-Kits/nRF5340-DK
-.. _Nordic Semiconductor Infocenter: https://infocenter.nordicsemi.com
+.. _nRF5340 DK Product Specification: https://docs.nordicsemi.com/bundle/ps_nrf5340/page/keyfeatures_html5.html
 .. _Trusted Firmware M: https://www.trustedfirmware.org/projects/tf-m/

--- a/boards/nordic/nrf9131ek/doc/index.rst
+++ b/boards/nordic/nrf9131ek/doc/index.rst
@@ -32,8 +32,8 @@ Cortex-M33F CPU with ARMv8-M Security Extension and the following devices:
 
      nRF9131 EK (Credit: Nordic Semiconductor)
 
-The `Nordic Semiconductor Infocenter`_
-contains the processor's information and the datasheet.
+The `Nordic Semiconductor TechDocs`_ will soon
+contain the processor's information and the datasheet.
 
 
 Hardware
@@ -225,5 +225,5 @@ References
 
 .. _IDAU:
    https://developer.arm.com/docs/100690/latest/attribution-units-sau-and-idau
-.. _Nordic Semiconductor Infocenter: https://infocenter.nordicsemi.com
+.. _Nordic Semiconductor TechDocs: https://docs.nordicsemi.com/
 .. _Trusted Firmware M: https://www.trustedfirmware.org/projects/tf-m/

--- a/boards/nordic/nrf9151dk/doc/index.rst
+++ b/boards/nordic/nrf9151dk/doc/index.rst
@@ -196,5 +196,5 @@ References
 .. _IDAU:
    https://developer.arm.com/docs/100690/latest/attribution-units-sau-and-idau
 .. _nRF9151 website: https://www.nordicsemi.com/Products/nRF9151
-.. _Nordic Semiconductor Infocenter: https://infocenter.nordicsemi.com
+.. _Nordic Semiconductor TechDocs: https://docs.nordicsemi.com/
 .. _Trusted Firmware M: https://www.trustedfirmware.org/projects/tf-m/

--- a/boards/nordic/nrf9160dk/doc/index.rst
+++ b/boards/nordic/nrf9160dk/doc/index.rst
@@ -33,7 +33,7 @@ Cortex-M33F CPU with ARMv8-M Security Extension and the following devices:
      nRF9160 DK (Credit: Nordic Semiconductor)
 
 More information about the board can be found at the
-`nRF9160 DK website`_. The `Nordic Semiconductor Infocenter`_
+`nRF9160 DK website`_. `nRF9160 Product Specification`_
 contains the processor's information and the datasheet.
 
 
@@ -108,7 +108,7 @@ Remember to also enable routing for this additional hardware in the firmware for
 :ref:`nrf9160dk_nrf52840` (see :ref:`nrf9160dk_board_controller_firmware`).
 
 Other hardware features have not been enabled yet for this board.
-See `nRF9160 DK website`_ and `Nordic Semiconductor Infocenter`_
+See `nRF9160 DK website`_ and `nRF9160 Product Specification`_
 for a complete list of nRF9160 DK board hardware features.
 
 Connections and IOs
@@ -282,7 +282,7 @@ SiP.
 
 More information about the board can be found at
 the `Nordic Low power cellular IoT`_ website.
-The `Nordic Semiconductor Infocenter`_
+`nRF52840 Product Specification`_
 contains the processor's information and the datasheet.
 
 
@@ -526,6 +526,7 @@ References
 .. _nRF9160 DK website: https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF9160-DK
 .. _Trusted Firmware M: https://www.trustedfirmware.org/projects/tf-m/
 .. _Nordic Low power cellular IoT: https://www.nordicsemi.com/Products/Low-power-cellular-IoT
-.. _Nordic Semiconductor Infocenter: https://infocenter.nordicsemi.com
+.. _nRF9160 Product Specification: https://docs.nordicsemi.com/bundle/ps_nrf9160/page/nRF9160_html5_keyfeatures.html
+.. _nRF52840 Product Specification: https://docs.nordicsemi.com/bundle/ps_nrf52840/page/keyfeatures_html5.html
 .. _J-Link Software and documentation pack: https://www.segger.com/jlink-software.html
-.. _nRF9160 DK board control section in the nRF9160 DK User Guide: https://infocenter.nordicsemi.com/topic/ug_nrf91_dk/UG/nrf91_DK/board_controller.html
+.. _nRF9160 DK board control section in the nRF9160 DK User Guide: https://docs.nordicsemi.com/bundle/ug_nrf9160_dk/page/UG/nrf91_DK/hw_description/nrf9160_board_controller.html

--- a/boards/nordic/nrf9161dk/doc/index.rst
+++ b/boards/nordic/nrf9161dk/doc/index.rst
@@ -27,7 +27,7 @@ Cortex-M33F CPU with ARMv8-M Security Extension and the following devices:
 * :abbr:`IDAU (Implementation Defined Attribution Unit)`
 
 More information about the board can be found at the
-`nRF9161 DK website`_. The `Nordic Semiconductor Infocenter`_
+`nRF9161 DK website`_. `nRF9161 Product Specification`_
 contains the processor's information and the datasheet.
 
 
@@ -84,7 +84,7 @@ hardware features:
 .. _nrf9161dk_additional_hardware:
 
 Other hardware features have not been enabled yet for this board.
-See `nRF9161 DK website`_ and `Nordic Semiconductor Infocenter`_
+See `nRF9161 DK website`_ and `nRF9161 Product Specification`_
 for a complete list of nRF9161 DK board hardware features.
 
 Connections and IOs
@@ -199,5 +199,5 @@ References
 .. _IDAU:
    https://developer.arm.com/docs/100690/latest/attribution-units-sau-and-idau
 .. _nRF9161 DK website: https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF9161-DK
-.. _Nordic Semiconductor Infocenter: https://infocenter.nordicsemi.com
+.. _nRF9161 Product Specification: https://docs.nordicsemi.com/bundle/ps_nrf9161/page/nRF9161_html5_keyfeatures.html
 .. _Trusted Firmware M: https://www.trustedfirmware.org/projects/tf-m/

--- a/boards/nordic/thingy52/doc/index.rst
+++ b/boards/nordic/thingy52/doc/index.rst
@@ -41,7 +41,7 @@ processor, a set of environmental sensors, a pushbutton, and two RGB LEDs.
      nRF52 Thingy:52 (Credit: Nordic Semiconductor)
 
 More information about the board can be found at the `nRF52 DK website`_. The
-`Nordic Semiconductor Infocenter`_ contains the processor's information and the
+`Nordic Thingy:52 guide`_ contains the processor's information and the
 datasheet.
 
 
@@ -390,4 +390,4 @@ References
 .. target-notes::
 
 .. _nRF52 DK website: https://www.nordicsemi.com/Software-and-Tools/Development-Kits/Nordic-Thingy-52
-.. _Nordic Semiconductor Infocenter: http://infocenter.nordicsemi.com/
+.. _Nordic Thingy:52 guide: https://docs.nordicsemi.com/bundle/ug_thingy52/page/UG/thingy52/intro/frontpage.html

--- a/boards/nordic/thingy53/doc/index.rst
+++ b/boards/nordic/thingy53/doc/index.rst
@@ -22,7 +22,7 @@ The ``thingy53/nrf5340/cpuapp`` build target provides support for the applicatio
 core on the nRF5340 SoC. The ``thingy53/nrf5340/cpunet`` build target provides
 support for the network core on the nRF5340 SoC.
 
-The `Nordic Semiconductor Infocenter`_ contains the processor's information and
+The `Nordic Thingy:53 Hardware guide`_ contains the processor's information and
 the datasheet.
 
 Programming and Debugging
@@ -48,4 +48,4 @@ References
 
 .. target-notes::
 
-.. _Nordic Semiconductor Infocenter: http://infocenter.nordicsemi.com/
+.. _Nordic Thingy:53 Hardware guide: https://docs.nordicsemi.com/bundle/ug_thingy53/page/UG/thingy53/intro/frontpage.html


### PR DESCRIPTION
As the Infocenter will soon be taken offline, updating links to point to TechDocs.