### PR TITLE
dts: boards: stm32h562: add timers 15, 16 and 17

### DIFF
--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -368,6 +368,69 @@
 			};
 		};
 
+		timers15: timers@40014000 {
+			compatible = "st,stm32-timers";
+			reg = <0x40014000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00010000>;
+			resets = <&rctl STM32_RESET(APB2, 16U)>;
+			interrupts = <71 0>;
+			interrupt-names = "global";
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+		};
+
+		timers16: timers@40014400 {
+			compatible = "st,stm32-timers";
+			reg = <0x40014400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00020000>;
+			resets = <&rctl STM32_RESET(APB2, 17U)>;
+			interrupts = <72 0>;
+			interrupt-names = "global";
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+		};
+
+		timers17: timers@40014800 {
+			compatible = "st,stm32-timers";
+			reg = <0x40014800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00040000>;
+			resets = <&rctl STM32_RESET(APB2, 18U)>;
+			interrupts = <73 0>;
+			interrupt-names = "global";
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+		};
+
 		aes: aes@420c0000 {
 			compatible = "st,stm32-aes";
 			reg = <0x420c0000 0x400>;


### PR DESCRIPTION
Add the remaining timer nodes for stm32h562.

Tested with a Logic Analyzer and `samples/drivers/led_pwm` with added `nucleo_h563zi.overlay`:

```
#include <zephyr/dt-bindings/pwm/stm32_pwm.h>

&timers15 {
	status = "okay";
	st,prescaler = <1000>;

	pwm15: pwm {
		status = "okay";
		pinctrl-0 = <&tim15_ch2_pa3 /* CN10.34 */>;
		pinctrl-names = "default";
	};
};

&timers16 {
	status = "okay";
	st,prescaler = <1000>;

	pwm16: pwm {
		status = "okay";
		pinctrl-0 = <&tim16_ch1n_pb6 /* CN10.14 */>;
		pinctrl-names = "default";
	};
};

&timers17 {
	st,prescaler = <1000>;
	status = "okay";

	pwm17: pwm {
		status = "okay";
		pinctrl-0 = <&tim17_ch1n_pb7 /* CN10.16 */>;
		pinctrl-names = "default";
	};
};

&pwmleds {
	status = "okay";

	pwm_led_1: green_led_1 {
		pwms = <&pwm15 2 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
		label = "green led";
	};

	pwm_led_2: red_led_1 {
		pwms = <&pwm16 1 PWM_MSEC(20)
		        (PWM_POLARITY_NORMAL | STM32_PWM_COMPLEMENTARY)>;
		label = "red led";
	};

	pwm_led_3: blue_led_1 {
		pwms = <&pwm17 1 PWM_MSEC(20)
		        (PWM_POLARITY_NORMAL | STM32_PWM_COMPLEMENTARY)>;
		label = "blue led";
	};
};
```