### PR TITLE
subsys: task_wdt: Feed hardware watchdog only when its started

### DIFF
--- a/subsys/task_wdt/task_wdt.c
+++ b/subsys/task_wdt/task_wdt.c
@@ -79,7 +79,7 @@ static void schedule_next_timeout(int64_t current_ticks)
 	k_timer_start(&timer, K_TIMEOUT_ABS_TICKS(next_timeout), K_FOREVER);
 
 #ifdef CONFIG_TASK_WDT_HW_FALLBACK
-	if (hw_wdt_dev) {
+	if (hw_wdt_started) {
 		wdt_feed(hw_wdt_dev, hw_wdt_channel);
 	}
 #endif


### PR DESCRIPTION
Previously the schedule_next_timeout() function was feeding the hardware watchdog irrespective of whether or not it was started. This is now fixed.

Fixes #70478