### PR TITLE
twister: hardwaremap: avoid exceptions when generating hardware map

### DIFF
--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -288,8 +288,11 @@ class HardwareMap:
             def readlink(link):
                 return str((by_id / link).resolve())
 
-            persistent_map = {readlink(link): str(link)
-                              for link in by_id.iterdir()}
+            if by_id.exists():
+                persistent_map = {readlink(link): str(link)
+                                  for link in by_id.iterdir()}
+            else:
+                persistent_map = {}
         else:
             persistent_map = {}
 

--- a/scripts/tests/twister/test_hardwaremap.py
+++ b/scripts/tests/twister/test_hardwaremap.py
@@ -383,6 +383,9 @@ def test_hardwaremap_scan(
             Path(path / 'basic-file2-link')
         ]
 
+    def mock_exists(path):
+        return True
+
     mocked_hm.manufacturer = ['dummy manufacturer', 'Texas Instruments']
     mocked_hm.runner_mapping = {
         'dummy runner': ['product[0-9]+',],
@@ -433,7 +436,9 @@ def test_hardwaremap_scan(
          mock.patch('twisterlib.hardwaremap.Path.resolve',
                     autospec=True, side_effect=mock_resolve), \
          mock.patch('twisterlib.hardwaremap.Path.iterdir',
-                    autospec=True, side_effect=mock_iterdir):
+                    autospec=True, side_effect=mock_iterdir), \
+         mock.patch('twisterlib.hardwaremap.Path.exists',
+                    autospec=True, side_effect=mock_exists):
         mocked_hm.scan(persistent)
 
     assert sorted([d.__repr__() for d in mocked_hm.detected]) == \


### PR DESCRIPTION
Avoid exceptions when generating persistent hardware maps on Linux with no devices available.