### PR TITLE
boards: st: higher sysclock for the stm32h743/h753 nucleo boards

### DIFF
--- a/boards/st/nucleo_h743zi/nucleo_h743zi.dts
+++ b/boards/st/nucleo_h743zi/nucleo_h743zi.dts
@@ -80,10 +80,10 @@
 };
 
 &pll {
-	div-m = <1>;
-	mul-n = <24>;
+	div-m = <2>;
+	mul-n = <240>;
 	div-p = <2>;
-	div-q = <4>;
+	div-q = <2>;
 	div-r = <2>;
 	clocks = <&clk_hse>;
 	status = "okay";
@@ -91,13 +91,13 @@
 
 &rcc {
 	clocks = <&pll>;
-	clock-frequency = <DT_FREQ_M(96)>;
+	clock-frequency = <DT_FREQ_M(480)>;
 	d1cpre = <1>;
-	hpre = <1>;
-	d1ppre = <1>;
-	d2ppre1 = <1>;
-	d2ppre2 = <1>;
-	d3ppre = <1>;
+	hpre = <2>;
+	d1ppre = <2>;
+	d2ppre1 = <2>;
+	d2ppre2 = <2>;
+	d3ppre = <2>;
 };
 
 &usart3 {

--- a/boards/st/nucleo_h753zi/nucleo_h753zi.dts
+++ b/boards/st/nucleo_h753zi/nucleo_h753zi.dts
@@ -77,10 +77,10 @@
 };
 
 &pll {
-	div-m = <1>;
-	mul-n = <24>;
+	div-m = <2>;
+	mul-n = <240>;
 	div-p = <2>;
-	div-q = <4>;
+	div-q = <2>;
 	div-r = <2>;
 	clocks = <&clk_hse>;
 	status = "okay";
@@ -88,13 +88,13 @@
 
 &rcc {
 	clocks = <&pll>;
-	clock-frequency = <DT_FREQ_M(96)>;
+	clock-frequency = <DT_FREQ_M(480)>;
 	d1cpre = <1>;
-	hpre = <1>;
-	d1ppre = <1>;
-	d2ppre1 = <1>;
-	d2ppre2 = <1>;
-	d3ppre = <1>;
+	hpre = <2>;
+	d1ppre = <2>;
+	d2ppre1 = <2>;
+	d2ppre2 = <2>;
+	d3ppre = <2>;
 };
 
 &usart3 {


### PR DESCRIPTION
Configure the DTS to increase the sysclock to its max value 240MHz for the nucleo_h743zi and nucleo_h753zi boards
 The PLL source is HSE is 8MHz clock source from the STLink.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/73536