### PR TITLE
net: wifi_mgmt: add hostap DPP support

### DIFF
--- a/modules/hostap/src/supp_api.h
+++ b/modules/hostap/src/supp_api.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023 Nordic Semiconductor ASA
+ * Copyright 2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -165,4 +166,14 @@ int supplicant_ap_sta_disconnect(const struct device *dev,
 				 const uint8_t *mac_addr);
 
 #endif /* CONFIG_AP */
+
+/**
+ * @brief Dispatch DPP operations
+ *
+ * @param dev Wi-Fi interface name to use
+ * @param dpp_params DPP action enum and params in string
+ * @return 0 for OK; -1 for ERROR
+ */
+int supplicant_dpp_dispatch(const struct device *dev,
+			    struct wifi_dpp_params *params);
 #endif /* ZEPHYR_SUPP_MGMT_H */

--- a/modules/hostap/src/supp_main.c
+++ b/modules/hostap/src/supp_main.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023 Nordic Semiconductor ASA.
+ * Copyright 2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -64,6 +65,7 @@ static const struct wifi_mgmt_ops mgmt_ops = {
 	.ap_disable = supplicant_ap_disable,
 	.ap_sta_disconnect = supplicant_ap_sta_disconnect,
 #endif /* CONFIG_AP */
+	.dpp_dispatch = supplicant_dpp_dispatch,
 };
 
 DEFINE_WIFI_NM_INSTANCE(wifi_supplicant, &mgmt_ops);

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2016 Intel Corporation.
+ * Copyright 2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -773,6 +774,22 @@ static int wifi_set_rts_threshold(uint32_t mgmt_request, struct net_if *iface,
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_RTS_THRESHOLD, wifi_set_rts_threshold);
+
+static int wifi_dpp(uint32_t mgmt_request, struct net_if *iface,
+		    void *data, size_t len)
+{
+	const struct device *dev = net_if_get_device(iface);
+	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_api(iface);
+	struct wifi_dpp_params *params = data;
+
+	if (wifi_mgmt_api == NULL || wifi_mgmt_api->dpp_dispatch == NULL) {
+		return -ENOTSUP;
+	}
+
+	return wifi_mgmt_api->dpp_dispatch(dev, params);
+}
+
+NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_DPP, wifi_dpp);
 
 #ifdef CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS
 void wifi_mgmt_raise_raw_scan_result_event(struct net_if *iface,

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018 Intel Corporation
+ * Copyright 2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -1934,6 +1935,408 @@ static int cmd_wifi_version(const struct shell *sh, size_t argc, char *argv[])
 	return 0;
 }
 
+static int parse_dpp_args_auth_init(const struct shell *sh, size_t argc, char *argv[],
+				    struct wifi_dpp_params *params)
+{
+	int opt;
+	int opt_index = 0;
+	struct getopt_state *state;
+	static struct option long_options[] = {{"peer", required_argument, 0, 'p'},
+					       {"role", required_argument, 0, 'r'},
+					       {"configurator", required_argument, 0, 'c'},
+					       {"mode", required_argument, 0, 'm'},
+					       {"ssid", required_argument, 0, 's'},
+					       {0, 0, 0, 0}};
+	int ret = 0;
+
+	while ((opt = getopt_long(argc, argv, "p:r:c:m:s:",
+		long_options, &opt_index)) != -1) {
+		state = getopt_state_get();
+		switch (opt) {
+		case 'p':
+			params->auth_init.peer = shell_strtol(optarg, 10, &ret);
+			break;
+		case 'r':
+			params->auth_init.role = shell_strtol(optarg, 10, &ret);
+			break;
+		case 'c':
+			params->auth_init.configurator = shell_strtol(optarg, 10, &ret);
+			break;
+		case 'm':
+			params->auth_init.conf = shell_strtol(optarg, 10, &ret);
+			break;
+		case 's':
+			strncpy(params->auth_init.ssid, optarg, WIFI_SSID_MAX_LEN);
+			break;
+		default:
+			PR_ERROR("Invalid option %c\n", optopt);
+			return -EINVAL;
+		}
+
+		if (ret) {
+			PR_ERROR("Invalid argument %d ret %d\n", opt_index, ret);
+			return -EINVAL;
+		}
+	}
+
+	return 0;
+}
+
+static int parse_dpp_args_chirp(const struct shell *sh, size_t argc, char *argv[],
+				struct wifi_dpp_params *params)
+{
+	int opt;
+	int opt_index = 0;
+	struct getopt_state *state;
+	static struct option long_options[] = {{"own", required_argument, 0, 'i'},
+					       {"freq", required_argument, 0, 'f'},
+					       {0, 0, 0, 0}};
+	int ret = 0;
+
+	while ((opt = getopt_long(argc, argv, "i:f:",
+		long_options, &opt_index)) != -1) {
+		state = getopt_state_get();
+		switch (opt) {
+		case 'i':
+			params->chirp.id = shell_strtol(optarg, 10, &ret);
+			break;
+		case 'f':
+			params->chirp.freq = shell_strtol(optarg, 10, &ret);
+			break;
+		default:
+			PR_ERROR("Invalid option %c\n", optopt);
+			return -EINVAL;
+		}
+
+		if (ret) {
+			PR_ERROR("Invalid argument %d ret %d\n", opt_index, ret);
+			return -EINVAL;
+		}
+	}
+
+	return 0;
+}
+
+static int parse_dpp_args_listen(const struct shell *sh, size_t argc, char *argv[],
+				 struct wifi_dpp_params *params)
+{
+	int opt;
+	int opt_index = 0;
+	struct getopt_state *state;
+	static struct option long_options[] = {{"role", required_argument, 0, 'r'},
+					       {"freq", required_argument, 0, 'f'},
+					       {0, 0, 0, 0}};
+	int ret = 0;
+
+	while ((opt = getopt_long(argc, argv, "r:f:",
+		long_options, &opt_index)) != -1) {
+		state = getopt_state_get();
+		switch (opt) {
+		case 'r':
+			params->listen.role = shell_strtol(optarg, 10, &ret);
+			break;
+		case 'f':
+			params->listen.freq = shell_strtol(optarg, 10, &ret);
+			break;
+		default:
+			PR_ERROR("Invalid option %c\n", optopt);
+			return -EINVAL;
+		}
+
+		if (ret) {
+			PR_ERROR("Invalid argument %d ret %d\n", opt_index, ret);
+			return -EINVAL;
+		}
+	}
+
+	return 0;
+}
+
+static int parse_dpp_args_btstrap_gen(const struct shell *sh, size_t argc, char *argv[],
+				      struct wifi_dpp_params *params)
+{
+	int opt;
+	int opt_index = 0;
+	struct getopt_state *state;
+	static struct option long_options[] = {{"type", required_argument, 0, 't'},
+					       {"opclass", required_argument, 0, 'o'},
+					       {"channel", required_argument, 0, 'h'},
+					       {"mac", required_argument, 0, 'a'},
+					       {0, 0, 0, 0}};
+	int ret = 0;
+
+	while ((opt = getopt_long(argc, argv, "t:o:h:a:",
+		long_options, &opt_index)) != -1) {
+		state = getopt_state_get();
+		switch (opt) {
+		case 't':
+			params->bootstrap_gen.type = shell_strtol(optarg, 10, &ret);
+			break;
+		case 'o':
+			params->bootstrap_gen.op_class = shell_strtol(optarg, 10, &ret);
+			break;
+		case 'h':
+			params->bootstrap_gen.chan = shell_strtol(optarg, 10, &ret);
+			break;
+		case 'a':
+			ret = net_bytes_from_str(params->bootstrap_gen.mac,
+						 WIFI_MAC_ADDR_LEN, optarg);
+			break;
+		default:
+			PR_ERROR("Invalid option %c\n", optopt);
+			return -EINVAL;
+		}
+
+		if (ret) {
+			PR_ERROR("Invalid argument %d ret %d\n", opt_index, ret);
+			return -EINVAL;
+		}
+	}
+
+	/* DPP bootstrap type currently only support qr_code */
+	if (params->bootstrap_gen.type == 0) {
+		params->bootstrap_gen.type = WIFI_DPP_BOOTSTRAP_TYPE_QRCODE;
+	}
+
+	if (params->bootstrap_gen.type != WIFI_DPP_BOOTSTRAP_TYPE_QRCODE) {
+		PR_ERROR("DPP bootstrap type currently only support qr_code\n");
+		return -ENOTSUP;
+	}
+
+	/* operating class should be set alongside with channel */
+	if ((params->bootstrap_gen.op_class && !params->bootstrap_gen.chan) ||
+	    (!params->bootstrap_gen.op_class && params->bootstrap_gen.chan)) {
+		PR_ERROR("Operating class should be set alongside with channel\n");
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int parse_dpp_args_set_config_param(const struct shell *sh, size_t argc, char *argv[],
+					   struct wifi_dpp_params *params)
+{
+	int opt;
+	int opt_index = 0;
+	struct getopt_state *state;
+	static struct option long_options[] = {{"configurator", required_argument, 0, 'c'},
+					       {"mode", required_argument, 0, 'm'},
+					       {"ssid", required_argument, 0, 's'},
+					       {0, 0, 0, 0}};
+	int ret = 0;
+
+	while ((opt = getopt_long(argc, argv, "p:r:c:m:s:",
+		long_options, &opt_index)) != -1) {
+		state = getopt_state_get();
+		switch (opt) {
+		case 'c':
+			params->configurator_set.configurator = shell_strtol(optarg, 10, &ret);
+			break;
+		case 'm':
+			params->configurator_set.conf = shell_strtol(optarg, 10, &ret);
+			break;
+		case 's':
+			strncpy(params->configurator_set.ssid, optarg, WIFI_SSID_MAX_LEN);
+			break;
+		default:
+			PR_ERROR("Invalid option %c\n", optopt);
+			return -EINVAL;
+		}
+
+		if (ret) {
+			PR_ERROR("Invalid argument %d ret %d\n", opt_index, ret);
+			return -EINVAL;
+		}
+	}
+
+	return 0;
+}
+
+static int cmd_wifi_dpp_configurator_add(const struct shell *sh, size_t argc, char *argv[])
+{
+	struct net_if *iface = net_if_get_first_wifi();
+	struct wifi_dpp_params params = {0};
+
+	params.action = WIFI_DPP_CONFIGURATOR_ADD;
+
+	if (net_mgmt(NET_REQUEST_WIFI_DPP, iface, &params, sizeof(params))) {
+		PR_WARNING("Failed to request DPP action\n");
+		return -ENOEXEC;
+	}
+	return 0;
+}
+
+static int cmd_wifi_dpp_auth_init(const struct shell *sh, size_t argc, char *argv[])
+{
+	int ret;
+	struct net_if *iface = net_if_get_first_wifi();
+	struct wifi_dpp_params params = {0};
+
+	params.action = WIFI_DPP_AUTH_INIT;
+
+	ret = parse_dpp_args_auth_init(sh, argc, argv, &params);
+	if (ret) {
+		PR_ERROR("parse DPP args fail\n");
+		return -EINVAL;
+	}
+
+	if (net_mgmt(NET_REQUEST_WIFI_DPP, iface, &params, sizeof(params))) {
+		PR_WARNING("Failed to request DPP action\n");
+		return -ENOEXEC;
+	}
+	return 0;
+}
+
+static int cmd_wifi_dpp_qr_code(const struct shell *sh, size_t argc, char *argv[])
+{
+	struct net_if *iface = net_if_get_first_wifi();
+	struct wifi_dpp_params params = {0};
+
+	params.action = WIFI_DPP_QR_CODE;
+
+	if (argc >= 2) {
+		strncpy(params.dpp_qr_code, argv[1], WIFI_DPP_QRCODE_MAX_LEN);
+	}
+
+	if (net_mgmt(NET_REQUEST_WIFI_DPP, iface, &params, sizeof(params))) {
+		PR_WARNING("Failed to request DPP action\n");
+		return -ENOEXEC;
+	}
+	return 0;
+}
+
+static int cmd_wifi_dpp_chirp(const struct shell *sh, size_t argc, char *argv[])
+{
+	int ret;
+	struct net_if *iface = net_if_get_first_wifi();
+	struct wifi_dpp_params params = {0};
+
+	params.action = WIFI_DPP_CHIRP;
+
+	ret = parse_dpp_args_chirp(sh, argc, argv, &params);
+	if (ret) {
+		PR_ERROR("parse DPP args fail\n");
+		return -EINVAL;
+	}
+
+	if (net_mgmt(NET_REQUEST_WIFI_DPP, iface, &params, sizeof(params))) {
+		PR_WARNING("Failed to request DPP action\n");
+		return -ENOEXEC;
+	}
+	return 0;
+}
+
+static int cmd_wifi_dpp_listen(const struct shell *sh, size_t argc, char *argv[])
+{
+	int ret;
+	struct net_if *iface = net_if_get_first_wifi();
+	struct wifi_dpp_params params = {0};
+
+	params.action = WIFI_DPP_LISTEN;
+
+	ret = parse_dpp_args_listen(sh, argc, argv, &params);
+	if (ret) {
+		PR_ERROR("parse DPP args fail\n");
+		return -EINVAL;
+	}
+
+	if (net_mgmt(NET_REQUEST_WIFI_DPP, iface, &params, sizeof(params))) {
+		PR_WARNING("Failed to request DPP action\n");
+		return -ENOEXEC;
+	}
+	return 0;
+}
+
+static int cmd_wifi_dpp_btstrap_gen(const struct shell *sh, size_t argc, char *argv[])
+{
+	int ret;
+	struct net_if *iface = net_if_get_first_wifi();
+	struct wifi_dpp_params params = {0};
+
+	params.action = WIFI_DPP_BOOTSTRAP_GEN;
+
+	ret = parse_dpp_args_btstrap_gen(sh, argc, argv, &params);
+	if (ret) {
+		PR_ERROR("parse DPP args fail\n");
+		return -EINVAL;
+	}
+
+	if (net_mgmt(NET_REQUEST_WIFI_DPP, iface, &params, sizeof(params))) {
+		PR_WARNING("Failed to request DPP action\n");
+		return -ENOEXEC;
+	}
+	return 0;
+}
+
+static int cmd_wifi_dpp_btstrap_get_uri(const struct shell *sh, size_t argc, char *argv[])
+{
+	int ret = 0;
+	struct net_if *iface = net_if_get_first_wifi();
+	struct wifi_dpp_params params = {0};
+
+	params.action = WIFI_DPP_BOOTSTRAP_GET_URI;
+
+	if (argc >= 2) {
+		params.id = shell_strtol(argv[1], 10, &ret);
+	}
+
+	if (ret) {
+		PR_ERROR("parse DPP args fail\n");
+		return -EINVAL;
+	}
+
+	if (net_mgmt(NET_REQUEST_WIFI_DPP, iface, &params, sizeof(params))) {
+		PR_WARNING("Failed to request DPP action\n");
+		return -ENOEXEC;
+	}
+	return 0;
+}
+
+static int cmd_wifi_dpp_configurator_set(const struct shell *sh, size_t argc, char *argv[])
+{
+	int ret;
+	struct net_if *iface = net_if_get_first_wifi();
+	struct wifi_dpp_params params = {0};
+
+	params.action = WIFI_DPP_SET_CONF_PARAM;
+
+	ret = parse_dpp_args_set_config_param(sh, argc, argv, &params);
+	if (ret) {
+		PR_ERROR("parse DPP args fail\n");
+		return -EINVAL;
+	}
+
+	if (net_mgmt(NET_REQUEST_WIFI_DPP, iface, &params, sizeof(params))) {
+		PR_WARNING("Failed to request DPP action\n");
+		return -ENOEXEC;
+	}
+	return 0;
+}
+
+static int cmd_wifi_dpp_resp_timeout_set(const struct shell *sh, size_t argc, char *argv[])
+{
+	int ret = 0;
+	struct net_if *iface = net_if_get_first_wifi();
+	struct wifi_dpp_params params = {0};
+
+	params.action = WIFI_DPP_SET_WAIT_RESP_TIME;
+
+	if (argc >= 2) {
+		params.dpp_resp_wait_time = shell_strtol(argv[1], 10, &ret);
+	}
+
+	if (ret) {
+		PR_ERROR("parse DPP args fail");
+		return -EINVAL;
+	}
+
+	if (net_mgmt(NET_REQUEST_WIFI_DPP, iface, &params, sizeof(params))) {
+		PR_WARNING("Failed to request DPP action\n");
+		return -ENOEXEC;
+	}
+	return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(wifi_cmd_ap,
 	SHELL_CMD_ARG(disable, NULL,
 		  "Disable Access Point mode.\n",
@@ -1993,6 +2396,59 @@ SHELL_STATIC_SUBCMD_SET_CREATE(wifi_twt_ops,
 	SHELL_CMD_ARG(teardown_all, NULL, " Teardown all TWT flows.\n",
 		cmd_wifi_twt_teardown_all,
 		1, 0),
+	SHELL_SUBCMD_SET_END
+);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	wifi_cmd_dpp,
+	SHELL_CMD_ARG(configurator_add, NULL,
+		      " Add DPP configurator\n",
+		      cmd_wifi_dpp_configurator_add, 1, 0),
+	SHELL_CMD_ARG(auth_init, NULL,
+		      "DPP start auth request:\n"
+		      "-p --peer <peer_bootstrap_id>\n"
+		      "[-r --role <1/2>]: DPP role default 1. 1: configurator, 2: enrollee\n"
+		      "Optional args for configurator:\n"
+		      "[-c --configurator <configurator_id>]\n"
+		      "[-m --mode <1/2>]: Peer mode. 1: STA, 2: AP\n"
+		      "[-s --ssid <SSID>]: SSID\n",
+		      cmd_wifi_dpp_auth_init, 3, 8),
+	SHELL_CMD_ARG(qr_code, NULL,
+		      " Input QR code:\n"
+		      "<qr_code_string>\n",
+		      cmd_wifi_dpp_qr_code, 2, 0),
+	SHELL_CMD_ARG(chirp, NULL,
+		      " DPP chirp:\n"
+		      "-i --own <own_bootstrap_id>\n"
+		      "-f --freq <listen_freq>\n",
+		      cmd_wifi_dpp_chirp, 5, 0),
+	SHELL_CMD_ARG(listen, NULL,
+		      " DPP listen:\n"
+		      "-f --freq <listen_freq>\n"
+		      "-r --role <1/2>: DPP role. 1: configurator, 2: enrollee\n",
+		      cmd_wifi_dpp_listen, 5, 0),
+	SHELL_CMD_ARG(btstrap_gen, NULL,
+		      " DPP bootstrap generate:\n"
+		      "[-t --type <1/2/3>]: Bootstrap type. 1: qr_code, 2: pkex, 3: nfc."
+		      " Currently only support qr_code\n"
+		      "[-o --opclass <operating_class>]\n"
+		      "[-h --channel <channel>]\n"
+		      "[-a --mac <mac_addr>]\n",
+		      cmd_wifi_dpp_btstrap_gen, 1, 8),
+	SHELL_CMD_ARG(btstrap_get_uri, NULL,
+		      " Get DPP bootstrap uri by id:\n"
+		      "<bootstrap_id>\n",
+		      cmd_wifi_dpp_btstrap_get_uri, 2, 0),
+	SHELL_CMD_ARG(configurator_set, NULL,
+		      " Set DPP configurator parameters:\n"
+		      "-c --configurator <configurator_id>\n"
+		      "[-m --mode <1/2>]: Peer mode. 1: STA, 2: AP\n"
+		      "[-s --ssid <SSID>]: SSID\n",
+		      cmd_wifi_dpp_configurator_set, 3, 4),
+	SHELL_CMD_ARG(resp_timeout_set, NULL,
+		      " Set DPP RX response wait timeout ms:\n"
+		      "<timeout_ms>\n",
+		      cmd_wifi_dpp_resp_timeout_set, 2, 0),
 	SHELL_SUBCMD_SET_END
 );
 
@@ -2123,6 +2579,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(wifi_commands,
 		     cmd_wifi_set_rts_threshold,
 		     2,
 		     0),
+	SHELL_CMD(dpp, &wifi_cmd_dpp, "DPP actions\n", NULL),
 	SHELL_SUBCMD_SET_END
 );
 


### PR DESCRIPTION
Add wifi l2 mgmt dpp handlers.
Add wifi subcommand dpp to call l2 mgmt dpp handlers.

DPP shell commands body is the same as wpa_cli commands but with different prefix "wifi dpp". eg.
"wifi dpp dpp_auth_init peer=1 role=enrollee"

DPP shell command handler will parse user args to params in enum and send l2 mgmt dpp requests.
DPP l2 handlers will parse params to hostap wpa_cli format args and send wpa_cli commands to hostap.