### PR TITLE
doc: mem_mgmt: Add missing definition for mem_mgmt doxygen group

### DIFF
--- a/doc/_doxygen/groups.dox
+++ b/doc/_doxygen/groups.dox
@@ -73,4 +73,9 @@
 @{
 @}
 
+@brief Memory Management APIs
+@defgroup mem_mgmt Memory Management APIs
+@{
+@}
+
 */


### PR DESCRIPTION
Avoid warning and properly list memory management APIs in Doxygen documentation by actually declaring the mem_mgmt doxygen group

FWIW there is already a "Memory Management" API group listed under OS Services (see https://docs.zephyrproject.org/latest/doxygen/html/group__memory__management.html) so I wonder if there should be some consolidation at some point?