### PR TITLE
bluetooth: hci_nxp: move vendor specific setup to its dedicated place

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -112,6 +112,7 @@ config BT_DA1469X
 
 config BT_NXP
 	bool "NXP HCI driver"
+	select BT_HCI_SETUP
 	help
 	  NXP HCI bluetooth interface
 

--- a/drivers/bluetooth/hci/hci_nxp.c
+++ b/drivers/bluetooth/hci/hci_nxp.c
@@ -312,7 +312,18 @@ static int bt_nxp_open(void)
 			LOG_ERR("HCI open failed");
 			break;
 		}
+	} while (false);
 
+	return ret;
+}
+
+int bt_nxp_setup(const struct bt_hci_setup_params *params)
+{
+	ARG_UNUSED(params);
+
+	int ret;
+
+	do {
 #if CONFIG_HCI_NXP_SET_CAL_DATA
 		ret = bt_nxp_set_calibration_data();
 		if (ret < 0) {
@@ -345,7 +356,7 @@ static int bt_nxp_open(void)
 			LOG_ERR("Failed to configure controller autosleep");
 			break;
 		}
-#endif
+#endif /* CONFIG_HCI_NXP_ENABLE_AUTO_SLEEP */
 	} while (false);
 
 	return ret;
@@ -373,6 +384,7 @@ static int bt_nxp_close(void)
 static const struct bt_hci_driver drv = {
 	.name = "BT NXP",
 	.open = bt_nxp_open,
+	.setup = bt_nxp_setup,
 	.close = bt_nxp_close,
 	.send = bt_nxp_send,
 	.bus = BT_HCI_DRIVER_BUS_IPM,


### PR DESCRIPTION
Some vendor specific setup was done inside
the open() HCI function, those should be
inside setup() function instead.