### PR TITLE
kconfig: sca: Add Kconfig for SCA tools

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -48,6 +48,7 @@ source "kernel/Kconfig"
 source "drivers/Kconfig"
 source "lib/Kconfig"
 source "subsys/Kconfig"
+source "cmake/sca/Kconfig"
 
 osource "$(TOOLCHAIN_KCONFIG_DIR)/Kconfig"
 

--- a/cmake/sca/Kconfig
+++ b/cmake/sca/Kconfig
@@ -1,0 +1,8 @@
+# Static Code Analysis (SCA) options
+
+# Copyright (c) 2024 Baumer (www.baumer.com)
+# SPDX-License-Identifier: Apache-2.0
+
+menu "Static Code Analysis (SCA) tools"
+
+endmenu


### PR DESCRIPTION
Add the possibility to use Kconfig for SCA tools.

Sometimes SCA tools can have a different or complex setups to run or outputs to generate.
The implemented cmake sca mechanism right now only allows configuration of the tools by using env variables or passing parameters to the build command. Which makes the integration and configuration seems very hidden and undocumented for everyone else as well. 

The first Kconfig options for a SCA tool would be introduced with https://github.com/zephyrproject-rtos/zephyr/pull/68324