### PR TITLE
boards: nxp: mimxrt11xx: fix non-optimal sector distribution

### DIFF
--- a/boards/nxp/mimxrt1160_evk/mimxrt1160_evk.dtsi
+++ b/boards/nxp/mimxrt1160_evk/mimxrt1160_evk.dtsi
@@ -91,7 +91,7 @@
 	reg = <0x400cc000 0x4000>, <0x30000000 DT_SIZE_M(16)>;
 	is25wp128: is25wp128@0 {
 		compatible = "nxp,imx-flexspi-nor";
-		size = <134217728>;
+		size = <DT_SIZE_M(16*8)>;
 		reg = <0>;
 		spi-max-frequency = <133000000>;
 		status = "okay";
@@ -103,25 +103,24 @@
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
-
 			boot_partition: partition@0 {
 				label = "mcuboot";
 				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			/* Note slot 0 has one additional sector,
-			 * this is intended for use with the swap move algorithm
+			/* The MCUBoot swap-move algorithm uses the last 3 sectors
+			 * of the primary slot0 for swap status and move.
 			 */
 			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00020000 0x301000>;
+				reg = <0x00020000 (DT_SIZE_M(7) + DT_SIZE_K(12))>;
 			};
-			slot1_partition: partition@321000 {
+			slot1_partition: partition@723000 {
 				label = "image-1";
-				reg = <0x00321000 0x300000>;
+				reg = <0x00723000 DT_SIZE_M(7)>;
 			};
-			storage_partition: partition@621000 {
+			storage_partition: partition@E23000 {
 				label = "storage";
-				reg = <0x00621000 DT_SIZE_K(1984)>;
+				reg = <0x00E23000 (DT_SIZE_M(2) - DT_SIZE_K(140))>;
 			};
 		};
 	};

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
@@ -190,7 +190,7 @@
 	reg = <0x400cc000 0x4000>, <0x30000000 DT_SIZE_M(16)>;
 	is25wp128: is25wp128@0 {
 		compatible = "nxp,imx-flexspi-nor";
-		size = <134217728>;
+		size = <DT_SIZE_M(16*8)>;
 		reg = <0>;
 		spi-max-frequency = <133000000>;
 		status = "okay";
@@ -207,20 +207,20 @@
 				label = "mcuboot";
 				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			/* Note slot 0 has one additional sector,
-			 * this is intended for use with the swap move algorithm
+			/* The MCUBoot swap-move algorithm uses the last 3 sectors
+			 * of the primary slot0 for swap status and move.
 			 */
 			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00020000 0x301000>;
+				reg = <0x00020000 (DT_SIZE_M(7) + DT_SIZE_K(12))>;
 			};
-			slot1_partition: partition@321000 {
+			slot1_partition: partition@723000 {
 				label = "image-1";
-				reg = <0x00321000 0x300000>;
+				reg = <0x00723000 DT_SIZE_M(7)>;
 			};
-			storage_partition: partition@621000 {
+			storage_partition: partition@E23000 {
 				label = "storage";
-				reg = <0x00621000 DT_SIZE_K(1984)>;
+				reg = <0x00E23000 (DT_SIZE_M(2) - DT_SIZE_K(140))>;
 			};
 		};
 	};

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
@@ -22,9 +22,8 @@
 	status = "okay";
 	reg = <0x400cc000 0x4000>, <0x30000000 DT_SIZE_M(64)>;
 	w25q512nw:w25q512nw@0 {
-		/* IS25WP128 flash chip not currently enabled */
 		compatible = "nxp,imx-flexspi-nor";
-		size = <DT_SIZE_M(512)>;
+		size = <DT_SIZE_M(64*8)>;
 		reg = <0>;
 		spi-max-frequency = <133000000>;
 		status = "okay";
@@ -32,10 +31,6 @@
 		erase-block-size = <4096>;
 		write-block-size = <1>;
 
-		/*
-		 * Partitions are present to support dual core operation.
-		 * as flash write is not supported, MCUBoot is not enabled.
-		 */
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
@@ -45,20 +40,20 @@
 				label = "mcuboot";
 				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			/* Note slot 0 has one additional sector,
-			 * this is intended for use with the swap move algorithm
+			/* The MCUBoot swap-move algorithm uses the last 3 sectors
+			 * of the primary slot0 for swap status and move.
 			 */
 			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00020000 0x301000>;
+				reg = <0x00020000 (DT_SIZE_M(7) + DT_SIZE_K(12))>;
 			};
-			slot1_partition: partition@321000 {
+			slot1_partition: partition@723000 {
 				label = "image-1";
-				reg = <0x00321000 0x300000>;
+				reg = <0x00723000 DT_SIZE_M(7)>;
 			};
-			storage_partition: partition@621000 {
+			storage_partition: partition@E23000 {
 				label = "storage";
-				reg = <0x00621000 DT_SIZE_K(1984)>;
+				reg = <0x00E23000 (DT_SIZE_M(50) - DT_SIZE_K(140))>;
 			};
 		};
 	};

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
@@ -7,8 +7,9 @@
 / {
 	chosen {
 		zephyr,flash = &w25q512nw;
-		/delete-property/ zephyr,flash-controller;
-		/delete-property/ zephyr,code-partition;
+		zephyr,flash-controller = &w25q512nw;
+		zephyr,flash = &w25q512nw;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	aliases {
@@ -23,9 +24,8 @@
 	status = "okay";
 	reg = <0x400cc000 0x4000>, <0x30000000 DT_SIZE_M(64)>;
 	w25q512nw:w25q512nw@0 {
-		/* IS25WP128 flash chip not currently enabled */
 		compatible = "nxp,imx-flexspi-nor";
-		size = <DT_SIZE_M(512)>;
+		size = <DT_SIZE_M(64*8)>;
 		reg = <0>;
 		spi-max-frequency = <133000000>;
 		status = "okay";
@@ -33,10 +33,6 @@
 		erase-block-size = <4096>;
 		write-block-size = <1>;
 
-		/*
-		 * Partitions are present to support dual core operation.
-		 * as flash write is not supported, MCUBoot is not enabled.
-		 */
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
@@ -46,20 +42,20 @@
 				label = "mcuboot";
 				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			/* Note slot 0 has one additional sector,
-			 * this is intended for use with the swap move algorithm
+			/* The MCUBoot swap-move algorithm uses the last 3 sectors
+			 * of the primary slot0 for swap status and move.
 			 */
 			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00020000 0x301000>;
+				reg = <0x00020000 (DT_SIZE_M(7) + DT_SIZE_K(12))>;
 			};
-			slot1_partition: partition@321000 {
+			slot1_partition: partition@723000 {
 				label = "image-1";
-				reg = <0x00321000 0x300000>;
+				reg = <0x00723000 DT_SIZE_M(7)>;
 			};
-			storage_partition: partition@621000 {
+			storage_partition: partition@E23000 {
 				label = "storage";
-				reg = <0x00621000 DT_SIZE_K(1984)>;
+				reg = <0x00E23000 (DT_SIZE_M(50) - DT_SIZE_K(140))>;
 			};
 		};
 	};

--- a/boards/nxp/vmu_rt1170/vmu_rt1170.dtsi
+++ b/boards/nxp/vmu_rt1170/vmu_rt1170.dtsi
@@ -177,7 +177,7 @@
 	ahb-prefetch;
 	ahb-read-addr-opt;
 	rx-clock-source = <1>;
-	reg = <0x400cc000 0x4000>, <0x30000000 DT_SIZE_M(16)>;
+	reg = <0x400cc000 0x4000>, <0x30000000 DT_SIZE_M(64)>;
 	mx25um51345g: mx25um51345g@0 {
 		compatible = "nxp,imx-flexspi-mx25um51345g";
 		/* MX25UM51245G is 64MB, 512MBit flash part */
@@ -193,22 +193,24 @@
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
-
 			boot_partition: partition@0 {
 				label = "mcuboot";
 				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
+			/* The MCUBoot swap-move algorithm uses the last 14 sectors
+			 * of the primary slot0 for swap status and move.
+			 */
 			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00020000 DT_SIZE_K(3076)>;
+				reg = <0x00020000 (DT_SIZE_M(3) + DT_SIZE_K(56))>;
 			};
-			slot1_partition: partition@321000 {
+			slot1_partition: partition@32E000 {
 				label = "image-1";
-				reg = <0x00321000 DT_SIZE_K(3072)>;
+				reg = <0x0032E000 DT_SIZE_M(3)>;
 			};
-			storage_partition: partition@621000 {
+			storage_partition: partition@62E000 {
 				label = "storage";
-				reg = <0x00621000 DT_SIZE_M(57)>;
+				reg = <0x0062E000 (DT_SIZE_M(58) - DT_SIZE_K(184))>;
 			};
 		};
 	};


### PR DESCRIPTION
- Optimize slot sizes for MCUBoot swap move algorithm for mimxrt1160/70 boards.
- Use DT_SIZE_K/M macros for slot sizes.
- Limit mcuboot max size to 128KB.