### PR TITLE
drivers: spi: mcux_flexcomm: fix invalid dma config for last tx packets.

### DIFF
--- a/drivers/spi/spi_mcux_flexcomm.c
+++ b/drivers/spi/spi_mcux_flexcomm.c
@@ -400,7 +400,6 @@ static int spi_mcux_dma_tx_load(const struct device *dev, const uint8_t *buf,
 		if (last_packet  &&
 		    ((word_size > 8) ? (len > 2U) : (len > 1U))) {
 			spi_mcux_prepare_txdummy(&data->last_word, last_packet, spi_cfg);
-			blk_cfg->source_gather_en = 1;
 			blk_cfg->source_address = (uint32_t)&data->dummy_tx_buffer;
 			blk_cfg->dest_address = (uint32_t)&base->FIFOWR;
 			blk_cfg->block_size = (word_size > 8) ?
@@ -434,7 +433,6 @@ static int spi_mcux_dma_tx_load(const struct device *dev, const uint8_t *buf,
 		 */
 		if (last_packet  &&
 		    ((word_size > 8) ? (len > 2U) : (len > 1U))) {
-			blk_cfg->source_gather_en = 1;
 			blk_cfg->source_address = (uint32_t)buf;
 			blk_cfg->dest_address = (uint32_t)&base->FIFOWR;
 			blk_cfg->block_size = (word_size > 8) ?


### PR DESCRIPTION
spi tx transfers using dma broke when the dma driver was extended with scatter/gather support.
the spi driver was setting source_gather_en without setting source_gather_interval.
that causes the source address to never be increased.

this commit removes the source_gather_en the spi driver does not use the dma gather support.
