### PR TITLE
scripts: set_assignees.py: No trivial label for single-line changes

### DIFF
--- a/scripts/set_assignees.py
+++ b/scripts/set_assignees.py
@@ -70,15 +70,12 @@ def process_pr(gh, maintainer_file, number):
     all_areas = set()
     fn = list(pr.get_files())
 
-    manifest_change = False
     for changed_file in fn:
         if changed_file.filename in ['west.yml','submanifests/optional.yaml']:
-            manifest_change = True
             break
 
-    # one liner PRs should be trivial
-    if pr.commits == 1 and (pr.additions <= 1 and pr.deletions <= 1) and not manifest_change:
-        labels = {'Trivial'}
+    if pr.commits == 1 and (pr.additions <= 1 and pr.deletions <= 1):
+        labels = {'size: XS'}
 
     if len(fn) > 500:
         log(f"Too many files changed ({len(fn)}), skipping....")


### PR DESCRIPTION
The description of the "Trivial" label states:
"Changes that can be reviewed by anyone, i.e. doc changes, minor build system tweaks, etc.".

Just because a change only affects a single line of code, it does not mean that it is a trivial change. It may have difficult to understand implications which require approval of the responsible maintainer.

As it is hard to detect by a bot which change is actually trivial, remove the automatic labeling and leave it to the creator of the PR or reviewers to decide.

As an example, see PR #73460, which removed a single line that was not trivial.