### PR TITLE
boards: nxp: frdm_k22f: fix the flash size value

### DIFF
--- a/boards/nxp/frdm_k22f/doc/index.rst
+++ b/boards/nxp/frdm_k22f/doc/index.rst
@@ -26,7 +26,7 @@ MCUs.
 Hardware
 ********
 
-- MK22FN512VLH12 (120 MHz, 1 MB flash memory, 256 KB RAM, low-power,
+- MK22FN512VLH12 (120 MHz, 512 KB flash memory, 128 KB RAM, low-power,
   crystal-less USB, and 64 pin Low profile Quad Flat Package (LQFP))
 - Dual role USB interface with micro-B USB connector
 - RGB LED

--- a/boards/nxp/frdm_k22f/frdm_k22f.dts
+++ b/boards/nxp/frdm_k22f/frdm_k22f.dts
@@ -1,12 +1,13 @@
 /*
  * Copyright (c) 2018 Prevas A/S
+ * Copyright 2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 /dts-v1/;
 
-#include <nxp/nxp_k2x.dtsi>
+#include <nxp/nxp_k22fn512.dtsi>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include "frdm_k22f-pinctrl.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>

--- a/dts/arm/nxp/nxp_k22fn512.dtsi
+++ b/dts/arm/nxp/nxp_k22fn512.dtsi
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <nxp/nxp_k2x.dtsi>
+
+&flash0 {
+	reg = <0 DT_SIZE_K(512)>;
+};


### PR DESCRIPTION
- The MK22FN512VLH12 chip, installed on frdm_k22f, has 512 KB of Program Flash and 128KB SRAM according to the K22P121M120SF7RM.pdf manual (page 55).
- Fix the flash size to 512KB (was 1MB).
- Add nxp_k22fn512.dtsi with correct flash size value.