### PR TITLE
drivers: spi: remove deprecated functions

### DIFF
--- a/doc/develop/api/terminology.rst
+++ b/doc/develop/api/terminology.rst
@@ -184,7 +184,7 @@ Explanation
 Be aware that **async** is orthogonal to context-switching.  Some APIs
 may provide completion information through a callback, but may suspend
 while waiting for the resource necessary to initiate the operation; an
-example is :c:func:`spi_transceive_async`.
+example is :c:func:`spi_transceive_signal`.
 
 If a function is both **no-wait** and **async** then selecting the
 no-wait path only guarantees that the function will not sleep.  It does

--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -65,6 +65,9 @@ Deprecated in this release
  * SPI
 
   * Deprecated :c:func:`spi_is_ready` API function has been removed.
+  * Deprecated :c:func:`spi_transceive_async` API function has been removed.
+  * Deprecated :c:func:`spi_read_async` API function has been removed.
+  * Deprecated :c:func:`spi_write_async` API function has been removed.
 
 Architectures
 *************

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -615,7 +615,7 @@ typedef void (*spi_callback_t)(const struct device *dev, int result, void *data)
 /**
  * @typedef spi_api_io
  * @brief Callback API for asynchronous I/O
- * See spi_transceive_async() for argument descriptions
+ * See spi_transceive_signal() for argument descriptions
  */
 typedef int (*spi_api_io_async)(const struct device *dev,
 				const struct spi_config *config,
@@ -933,20 +933,6 @@ static inline int spi_transceive_signal(const struct device *dev,
 }
 
 /**
- * @brief Alias for spi_transceive_signal for backwards compatibility
- *
- * @deprecated Use @ref spi_transceive_signal instead.
- */
-__deprecated static inline int spi_transceive_async(const struct device *dev,
-				       const struct spi_config *config,
-				       const struct spi_buf_set *tx_bufs,
-				       const struct spi_buf_set *rx_bufs,
-				       struct k_poll_signal *sig)
-{
-	return spi_transceive_signal(dev, config, tx_bufs, rx_bufs, sig);
-}
-
-/**
  * @brief Read the specified amount of data from the SPI driver.
  *
  * @note This function is asynchronous.
@@ -979,24 +965,11 @@ static inline int spi_read_signal(const struct device *dev,
 }
 
 /**
- * @brief Alias for spi_read_signal for backwards compatibility
- *
- * @deprecated Use @ref spi_read_signal instead.
- */
-__deprecated static inline int spi_read_async(const struct device *dev,
-				 const struct spi_config *config,
-				 const struct spi_buf_set *rx_bufs,
-				 struct k_poll_signal *sig)
-{
-	return spi_read_signal(dev, config, rx_bufs, sig);
-}
-
-/**
  * @brief Write the specified amount of data from the SPI driver.
  *
  * @note This function is asynchronous.
  *
- * @note This function is a helper function calling spi_transceive_async.
+ * @note This function is a helper function calling spi_transceive_signal.
  *
  * @note This function is available only if @kconfig{CONFIG_SPI_ASYNC}
  * and @kconfig{CONFIG_POLL} are selected.
@@ -1020,19 +993,6 @@ static inline int spi_write_signal(const struct device *dev,
 				  struct k_poll_signal *sig)
 {
 	return spi_transceive_signal(dev, config, tx_bufs, NULL, sig);
-}
-
-/**
- * @brief Alias for spi_write_signal for backwards compatibility
- *
- * @deprecated Use @ref spi_write_signal instead.
- */
-__deprecated static inline int spi_write_async(const struct device *dev,
-				 const struct spi_config *config,
-				 const struct spi_buf_set *tx_bufs,
-				 struct k_poll_signal *sig)
-{
-	return spi_write_signal(dev, config, tx_bufs, sig);
 }
 
 #endif /* CONFIG_POLL */


### PR DESCRIPTION
`spi_transceive_async`, `spi_read_async` and `spi_write_async` are deprecated since v3.2.

This is the second round of cleaning the spi header from deprecated functions.