### PR TITLE
drivers: dma: intel_adsp_hda: change L1 exit defaults

### DIFF
--- a/drivers/dma/Kconfig.intel_adsp_hda
+++ b/drivers/dma/Kconfig.intel_adsp_hda
@@ -45,6 +45,7 @@ config DMA_INTEL_ADSP_HDA
 config DMA_INTEL_ADSP_HDA_TIMING_L1_EXIT
 	bool "Intel ADSP HDA Host L1 Exit Interrupt"
 	default y if SOC_INTEL_ACE15_MTPM
+	default y if SOC_INTEL_ACE20_LNL
 	depends on DMA_INTEL_ADSP_HDA_HOST_IN || DMA_INTEL_ADSP_HDA_HOST_OUT
 	help
 	  Intel ADSP HDA Host Interrupt for L1 exit.


### PR DESCRIPTION
DMA_INTEL_ADSP_HDA_TIMING_L1_EXIT should be set by default for both Intel ACE15 and ACE20 platforms.