### PR TITLE
docs: Move sensor.rst  to sensor/index.rst

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1843,7 +1843,7 @@ Release Notes:
     - dts/bindings/sensor/
     - include/zephyr/drivers/sensor/
     - include/zephyr/dt-bindings/sensor/
-    - doc/hardware/peripherals/sensor.rst
+    - doc/hardware/peripherals/sensor/
     - tests/drivers/build_all/sensor/
   labels:
     - "area: Sensors"

--- a/doc/_scripts/redirects.py
+++ b/doc/_scripts/redirects.py
@@ -143,6 +143,7 @@ REDIRECTS = [
     ('guides/west/workspaces', 'develop/west/workspaces'),
     ('guides/west/zephyr-cmds', 'develop/west/zephyr-cmds'),
     ('guides/zephyr_cmake_package', 'build/zephyr_cmake_package'),
+    ('hardware/peripherals/sensor', 'hardware/peripherals/sensor/index'),
     ('reference/api/api_lifecycle', 'develop/api/api_lifecycle'),
     ('reference/api/index', 'develop/api/index'),
     ('reference/api/overview', 'develop/api/overview'),

--- a/doc/hardware/peripherals/index.rst
+++ b/doc/hardware/peripherals/index.rst
@@ -51,7 +51,7 @@ Peripherals
    reset.rst
    retained_mem.rst
    sdhc.rst
-   sensor.rst
+   sensor/index.rst
    spi.rst
    smbus.rst
    uart.rst

--- a/doc/hardware/peripherals/sensor/index.rst
+++ b/doc/hardware/peripherals/sensor/index.rst
@@ -57,7 +57,7 @@ measures ambient temperature and atmospheric pressure.  Note that
 :c:func:`sensor_sample_fetch` is only called once, as it reads and
 compensates data for both channels.
 
-.. literalinclude:: ../../../samples/sensor/bme280/src/main.c
+.. literalinclude:: ../../../../samples/sensor/bme280/src/main.c
    :language: c
    :lines: 12-
    :linenos:
@@ -217,7 +217,7 @@ interest of saving power. Since the application has direct access to the
 kernel config symbols, no trigger is registered when triggering was disabled
 by the driver's configuration.
 
-.. literalinclude:: ../../../samples/sensor/mcp9808/src/main.c
+.. literalinclude:: ../../../../samples/sensor/mcp9808/src/main.c
    :language: c
    :lines: 12-
    :linenos:


### PR DESCRIPTION
Looking to expand the sensor docs and break out significant sections. First though to move this to a directory to allow for multiple sensor related rst docs.