### PR TITLE
Fixing flash_fill chunk calculation and typos

### DIFF
--- a/drivers/flash/Kconfig
+++ b/drivers/flash/Kconfig
@@ -20,7 +20,7 @@ config FLASH_HAS_EX_OP
 config FLASH_HAS_EXPLICIT_ERASE
 	bool
 	help
-	  Device has does not do erase-on-write (erase-on-program, auto-erase
+	  Device does not do erase-on-write (erase-on-program, auto-erase
 	  on write) and requires explicit erase procedure to be programmed
 	  with random value, in place where it has already been programmed with
 	  some other value, as program can only change bits from erased-value
@@ -128,7 +128,7 @@ config FLASH_SHELL_BUFFER_SIZE
 endif # FLASH_SHELL
 
 config FLASH_FILL_BUFFER_SIZE
-	int "Buffer size of flash_fill funciton"
+	int "Buffer size of flash_fill function"
 	default 32
 	help
 	  Size of a buffer used by flash_fill function to fill a device with
@@ -138,7 +138,7 @@ config FLASH_FILL_BUFFER_SIZE
 	  be written to a device, and alignment of write offset.
 	  Even if device does not have such requirement, filling device by
 	  single bytes is not efficient.
-	  Value selected here should be multiply of the largest write-block-size
+	  Value selected here should be a multiple of the largest write-block-size
 	  among all the memory devices used in system.
 
 if FLASH_HAS_PAGE_LAYOUT

--- a/drivers/flash/flash_util.c
+++ b/drivers/flash/flash_util.c
@@ -48,7 +48,7 @@ int z_impl_flash_fill(const struct device *dev, uint8_t val, off_t offset,
 	memset(filler, val, sizeof(filler));
 
 	while (stored < size) {
-		size_t chunk = MIN(sizeof(filler), size);
+		size_t chunk = MIN(sizeof(filler), size - stored);
 
 		rc = api->write(dev, offset + stored, filler, chunk);
 		if (rc < 0) {

--- a/include/zephyr/drivers/flash.h
+++ b/include/zephyr/drivers/flash.h
@@ -57,10 +57,12 @@ struct flash_pages_layout {
  * through a runtime.
  */
 struct flash_parameters {
+	/** Minimal write alignment and size */
 	const size_t write_block_size;
-	/* Device capabilities. Only drivers are supposed to set the
-	 * capabilities directly, users need to call the FLASH_CAPS_
-	 * macros on pointer to flash_parameters to get capabilities.
+
+	/** @cond INTERNAL_HIDDEN */
+	/* User code should call flash_params_get_ functions on flash_parameters
+	 * to get capabilities, rather than accessing object contents directly.
 	 */
 	struct {
 		/* Device has no explicit erase, so it either erases on
@@ -70,7 +72,9 @@ struct flash_parameters {
 		 */
 		bool no_explicit_erase: 1;
 	} caps;
-	uint8_t erase_value; /* Byte value of erased flash */
+	/** @endcond */
+	/** Value the device is filled in erased areas */
+	uint8_t erase_value;
 };
 
 /** Set for ordinary Flash where erase is needed before write of random data */
@@ -324,7 +328,7 @@ __syscall int flash_fill(const struct device *dev, uint8_t val, off_t offset, si
  *  If device is explicit erase type device or device driver provides erase
  *  callback, the callback of the device is called, in which it behaves
  *  the same way as flash_erase.
- *  If a device is does not require explicit erase, either because
+ *  If a device does not require explicit erase, either because
  *  it has no erase at all or has auto-erase/erase-on-write,
  *  and does not provide erase callback then erase is emulated by
  *  leveling selected device memory area with erase_value assigned to


### PR DESCRIPTION
Two commits: flash_fill chunk calculation bug and typos.

### Rationale for 3.7.0 milestone

Please consider the PR for 3.7.0 release as it, aside for cosmetic fixes of documentation, provides fix for flash_fill where there is probable range overrun on write.