### PR TITLE
drivers: nxp_enet: Disable hw accel with IPV6

### DIFF
--- a/drivers/ethernet/nxp_enet/Kconfig
+++ b/drivers/ethernet/nxp_enet/Kconfig
@@ -48,6 +48,7 @@ config ETH_NXP_ENET_USE_DTCM_FOR_DMA_BUFFER
 config ETH_NXP_ENET_HW_ACCELERATION
 	bool "Hardware acceleration"
 	default y
+	depends on !NET_IPV6
 	help
 	  Enable hardware acceleration for the following:
 	  - IPv4, UDP and TCP checksum (both Rx and Tx)


### PR DESCRIPTION
As far as I can tell it appears that the hardware does not support acceleration of ICMPV6 checksums. For now, the easiest way to fix the runtime failure of IPV6 is just to disable the hardware acceleration if IPV6 is expected to be used.

Fixes #73518