### PR TITLE
Revert "drivers/console/xtensa_sim_console: force `\r\n` byte sequence"

### DIFF
--- a/drivers/console/xtensa_sim_console.c
+++ b/drivers/console/xtensa_sim_console.c
@@ -25,14 +25,6 @@ int arch_printk_char_out(int c)
 	register int ret_err __asm__ ("a3");
 
 	buf[0] = (char)c;
-
-	if (buf[0] == '\n') {
-		buf[1] = buf[0];
-		buf[0] = '\r';
-		a3++;
-		a5++;
-	}
-
 	__asm__ volatile ("simcall"
 				: "=a" (ret_val), "=a" (ret_err)
 				: "a" (a2), "a" (a3), "a" (a4), "a" (a5)


### PR DESCRIPTION
This reverts commit 99aa65c72532315a614871648034af83cd29e442.

With this change, various simulators fail with no output with this
change.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
