### PR TITLE
drivers: counter: Kconfig.mcux_lptmr: change Kconfig description string

### DIFF
--- a/drivers/counter/Kconfig.mcux_lptmr
+++ b/drivers/counter/Kconfig.mcux_lptmr
@@ -12,7 +12,7 @@ config COUNTER_MCUX_LPTMR
 	  Enable support for the MCUX Low Power Timer (LPTMR).
 
 config COUNTER_MCUX_KINETIS_LPTMR
-	bool "Deprecated DT compatible"
+	bool "Legacy MCUX LPTMR driver [DEPRECATED]"
 	default y
 	depends on DT_HAS_NXP_KINETIS_LPTMR_ENABLED
 	select DEPRECATED


### PR DESCRIPTION
Update Kconfig description string for the deprecated MCUX LPTMR Kconfig to be more descriptive, for users browsing Kconfigs using menuconfig or other tools