### PR TITLE
drivers: display: st7789v: convert to MIPI DBI API

### DIFF
--- a/boards/m5stack/m5stack_atoms3/m5stack_atoms3_procpu.dts
+++ b/boards/m5stack/m5stack_atoms3/m5stack_atoms3_procpu.dts
@@ -9,6 +9,7 @@
 #include "m5stack_atoms3-pinctrl.dtsi"
 #include "grove_connectors.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/mipi_dbi/mipi_dbi.h>
 
 / {
 	model = "M5Stack AtomS3 PROCPU";
@@ -46,6 +47,45 @@
 		regulator-name = "lcd_backlight_enable";
 		enable-gpios = <&gpio0 16 GPIO_ACTIVE_HIGH>;
 		regulator-boot-on;
+	};
+
+	mipi_dbi {
+		compatible = "zephyr,mipi-dbi-spi";
+		spi-dev = <&spi2>;
+		dc-gpios = <&gpio1 1 GPIO_ACTIVE_HIGH>;	     /* G33 */
+		reset-gpios = <&gpio1 2 GPIO_ACTIVE_LOW>;    /* G34 */
+		write-only;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		st7789v: st7789v@0 {
+			compatible = "sitronix,st7789v";
+			reg = <0>;
+			mipi-max-frequency = <27000000>;
+
+			width = <128>;
+			height = <128>;
+			x-offset = <2>;
+			y-offset = <1>;
+
+			vcom = <0x28>;
+			gctrl = <0x35>;
+			vrhs = <0x10>;
+			vdvs = <0x20>;
+			mdac = <0x00>;
+			gamma = <0x01>;
+			colmod = <0x55>;
+			lcm = <0x0c>;
+			porch-param = [0c 0c 00 33 33];
+			cmd2en-param = [5a 69 02 00];
+			pwctrl1-param = [a4 a1];
+			pvgam-param = [d0 00 02 07 0a 28 32 44 42 06 0e 12 14 17];
+			nvgam-param = [d0 00 02 07 0a 28 31 54 47 0e 1c 17 1b 1e];
+			ram-param = [00 E0];
+			rgb-param = [40 02 14];
+			mipi-mode = <MIPI_DBI_MODE_SPI_4WIRE>;
+		};
+
 	};
 
 };
@@ -91,36 +131,6 @@
 	status = "okay";
 	pinctrl-0 = <&spim2_default>;
 	pinctrl-names = "default";
-
-	st7789v: st7789v@0 {
-		compatible = "sitronix,st7789v";
-		reg = <0>;
-		spi-max-frequency = <27000000>;
-		cmd-data-gpios = <&gpio1 1 GPIO_ACTIVE_LOW>; /* G33 */
-		reset-gpios = <&gpio1 2 GPIO_ACTIVE_LOW>;    /* G34 */
-
-		width = <128>;
-		height = <128>;
-		x-offset = <2>;
-		y-offset = <1>;
-
-		vcom = <0x28>;
-		gctrl = <0x35>;
-		vrhs = <0x10>;
-		vdvs = <0x20>;
-		mdac = <0x00>;
-		gamma = <0x01>;
-		colmod = <0x55>;
-		lcm = <0x0c>;
-		porch-param = [0c 0c 00 33 33];
-		cmd2en-param = [5a 69 02 00];
-		pwctrl1-param = [a4 a1];
-		pvgam-param = [d0 00 02 07 0a 28 32 44 42 06 0e 12 14 17];
-		nvgam-param = [d0 00 02 07 0a 28 31 54 47 0e 1c 17 1b 1e];
-		ram-param = [00 E0];
-		rgb-param = [40 02 14];
-	};
-
 };
 
 &gpio0 {

--- a/boards/m5stack/m5stickc_plus/m5stickc_plus_procpu.dts
+++ b/boards/m5stack/m5stickc_plus/m5stickc_plus_procpu.dts
@@ -9,6 +9,7 @@
 #include "m5stickc_plus-pinctrl.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/regulator/axp192.h>
+#include <zephyr/dt-bindings/mipi_dbi/mipi_dbi.h>
 
 / {
 	model = "M5StickC Plus PROCPU";
@@ -56,6 +57,44 @@
 			label = "User button 1";
 			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
 			zephyr,code = <INPUT_KEY_1>;
+		};
+	};
+
+	mipi_dbi {
+		compatible = "zephyr,mipi-dbi-spi";
+		spi-dev = <&spi3>;
+		dc-gpios = <&gpio0 23 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
+		write-only;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		st7789v: st7789v@0 {
+			compatible = "sitronix,st7789v";
+			reg = <0>;
+			mipi-max-frequency = <20000000>;
+
+			width = <135>;
+			height = <240>;
+			x-offset = <53>;
+			y-offset = <40>;
+
+			vcom = <0x28>;
+			gctrl = <0x35>;
+			vrhs = <0x10>;
+			vdvs = <0x20>;
+			mdac = <0x00>;
+			gamma = <0x01>;
+			colmod = <0x55>;
+			lcm = <0x2c>;
+			porch-param = [0c 0c 00 33 33];
+			cmd2en-param = [5a 69 02 00];
+			pwctrl1-param = [a4 a1];
+			pvgam-param = [d0 00 02 07 0a 28 32 44 42 06 0e 12 14 17];
+			nvgam-param = [d0 00 02 07 0a 28 31 54 47 0e 1c 17 1b 1e];
+			ram-param = [00 F0];
+			rgb-param = [40 02 14];
+			mipi-mode = <MIPI_DBI_MODE_SPI_4WIRE>;
 		};
 	};
 };
@@ -152,34 +191,6 @@
 	status = "okay";
 	pinctrl-0 = <&spim3_default>;
 	pinctrl-names = "default";
-	st7789v: st7789v@0 {
-		compatible = "sitronix,st7789v";
-		reg = <0>;
-		spi-max-frequency = <20000000>;
-		cmd-data-gpios = <&gpio0 23 GPIO_ACTIVE_LOW>;
-		reset-gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
-
-		width = <135>;
-		height = <240>;
-		x-offset = <53>;
-		y-offset = <40>;
-
-		vcom = <0x28>;
-		gctrl = <0x35>;
-		vrhs = <0x10>;
-		vdvs = <0x20>;
-		mdac = <0x00>;
-		gamma = <0x01>;
-		colmod = <0x55>;
-		lcm = <0x2c>;
-		porch-param = [0c 0c 00 33 33];
-		cmd2en-param = [5a 69 02 00];
-		pwctrl1-param = [a4 a1];
-		pvgam-param = [d0 00 02 07 0a 28 32 44 42 06 0e 12 14 17];
-		nvgam-param = [d0 00 02 07 0a 28 31 54 47 0e 1c 17 1b 1e];
-		ram-param = [00 F0];
-		rgb-param = [40 02 14];
-	};
 };
 
 &timer0 {

--- a/boards/pine64/pinetime_devkit0/pinetime_devkit0.dts
+++ b/boards/pine64/pinetime_devkit0/pinetime_devkit0.dts
@@ -12,6 +12,7 @@
 #include <nordic/nrf52832_qfaa.dtsi>
 #include "pinetime_devkit0-pinctrl.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/mipi_dbi/mipi_dbi.h>
 
 / {
 	model = "Pine64 PineTime DevKit0";
@@ -76,6 +77,42 @@
 		io-channels = <&adc 7>;
 		output-ohms = <1000000>;
 		full-ohms = <(1000000 + 1000000)>;
+	};
+
+	mipi_dbi {
+		compatible = "zephyr,mipi-dbi-spi";
+		spi-dev = <&spi1>;
+		dc-gpios = <&gpio0 18 GPIO_ACTIVE_HIGH>;	/* DET */
+		reset-gpios = <&gpio0 26 GPIO_ACTIVE_LOW>;	/* RESX reset */
+		write-only;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		/* Sitronix ST7789V LCD */
+		st7789v: st7789v@1 {
+			compatible = "sitronix,st7789v";
+			reg = <1>;
+			mipi-max-frequency = <8000000>; /* 8MHz */
+			width = <240>;
+			height = <240>;
+			x-offset = <0>;
+			y-offset = <0>;
+			vcom = <0x19>;
+			gctrl = <0x35>;
+			vrhs = <0x12>;
+			vdvs = <0x20>;
+			mdac = <0x00>;
+			gamma = <0x01>;
+			colmod = <0x05>;
+			lcm = <0x2c>;
+			porch-param = [0c 0c 00 33 33];
+			cmd2en-param = [5a 69 02 01];
+			pwctrl1-param = [a4 a1];
+			pvgam-param = [D0 04 0D 11 13 2B 3F 54 4C 18 0D 0B 1F 23];
+			nvgam-param = [D0 04 0C 11 13 2C 3F 44 51 2F 1F 1F 20 23];
+			ram-param = [00 F0];
+			rgb-param = [CD 08 14];
+			mipi-mode = <MIPI_DBI_MODE_SPI_4WIRE>;
+		};
 	};
 };
 
@@ -177,34 +214,6 @@
 				reg = <0x00300000 0x00100000>;
 			};
 		};
-	};
-
-	/* Sitronix ST7789V LCD */
-	st7789v: st7789v@1 {
-		compatible = "sitronix,st7789v";
-		reg = <1>;
-		spi-max-frequency = <8000000>; /* 8MHz */
-		cmd-data-gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;	/* DET */
-		reset-gpios = <&gpio0 26 GPIO_ACTIVE_LOW>;	/* RESX reset */
-		width = <240>;
-		height = <240>;
-		x-offset = <0>;
-		y-offset = <0>;
-		vcom = <0x19>;
-		gctrl = <0x35>;
-		vrhs = <0x12>;
-		vdvs = <0x20>;
-		mdac = <0x00>;
-		gamma = <0x01>;
-		colmod = <0x05>;
-		lcm = <0x2c>;
-		porch-param = [0c 0c 00 33 33];
-		cmd2en-param = [5a 69 02 01];
-		pwctrl1-param = [a4 a1];
-		pvgam-param = [D0 04 0D 11 13 2B 3F 54 4C 18 0D 0B 1F 23];
-		nvgam-param = [D0 04 0C 11 13 2C 3F 44 51 2F 1F 1F 20 23];
-		ram-param = [00 F0];
-		rgb-param = [CD 08 14];
 	};
 };
 

--- a/boards/shields/st7789v_generic/st7789v_tl019fqv01.overlay
+++ b/boards/shields/st7789v_generic/st7789v_tl019fqv01.overlay
@@ -3,41 +3,51 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <zephyr/dt-bindings/mipi_dbi/mipi_dbi.h>
 
 / {
 	chosen {
 		zephyr,display = &st7789v_st7789v_tl019fqv01;
+	};
+
+	mipi_dbi_st7789v_tl019fqv01 {
+		compatible = "zephyr,mipi-dbi-spi";
+		spi-dev = <&arduino_spi>;
+		dc-gpios = <&arduino_header 15 GPIO_ACTIVE_HIGH>;	/* D9 */
+		reset-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>;	/* D8 */
+		write-only;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		st7789v_st7789v_tl019fqv01: st7789v@0 {
+			compatible = "sitronix,st7789v";
+			mipi-max-frequency = <20000000>;
+			reg = <0>;
+			width = <320>;
+			height = <170>;
+			x-offset = <0>;
+			y-offset = <35>;
+			vcom = <0x2b>;
+			gctrl = <0x35>;
+			vrhs = <0x0f>;
+			vdvs = <0x20>;
+			mdac = <0x60>;
+			gamma = <0x01>;
+			colmod = <0x55>;
+			lcm = <0x2c>;
+			porch-param = [0c 0c 00 33 33];
+			cmd2en-param = [5a 69 02 01];
+			pwctrl1-param = [52 a1];
+			pvgam-param = [D0 00 02 07 0B 1A 31 54 40 29 12 12 12 17];
+			nvgam-param = [D0 00 02 07 05 15 2D 44 44 1C 18 16 1C 1D];
+			ram-param = [00 F8];
+			rgb-param = [CD 08 14];
+			mipi-mode = <MIPI_DBI_MODE_SPI_4WIRE>;
+		};
 	};
 };
 
 &arduino_spi {
 	status = "okay";
 	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;	/* D10 */
-
-	st7789v_st7789v_tl019fqv01: st7789v@0 {
-		compatible = "sitronix,st7789v";
-		spi-max-frequency = <20000000>;
-		reg = <0>;
-		cmd-data-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>;	/* D9 */
-		reset-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>;	/* D8 */
-		width = <320>;
-		height = <170>;
-		x-offset = <0>;
-		y-offset = <35>;
-		vcom = <0x2b>;
-		gctrl = <0x35>;
-		vrhs = <0x0f>;
-		vdvs = <0x20>;
-		mdac = <0x60>;
-		gamma = <0x01>;
-		colmod = <0x55>;
-		lcm = <0x2c>;
-		porch-param = [0c 0c 00 33 33];
-		cmd2en-param = [5a 69 02 01];
-		pwctrl1-param = [52 a1];
-		pvgam-param = [D0 00 02 07 0B 1A 31 54 40 29 12 12 12 17];
-		nvgam-param = [D0 00 02 07 05 15 2D 44 44 1C 18 16 1C 1D];
-		ram-param = [00 F8];
-		rgb-param = [CD 08 14];
-	};
 };

--- a/boards/shields/st7789v_generic/st7789v_waveshare_240x240.overlay
+++ b/boards/shields/st7789v_generic/st7789v_waveshare_240x240.overlay
@@ -5,40 +5,51 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/mipi_dbi/mipi_dbi.h>
+
 / {
 	chosen {
 		zephyr,display = &st7789v_st7789v_waveshare_240x240;
+	};
+
+	mipi_dbi_st7789v_waveshare_240x240 {
+		compatible = "zephyr,mipi-dbi-spi";
+		spi-dev = <&arduino_spi>;
+		dc-gpios = <&arduino_header 15 GPIO_ACTIVE_HIGH>;	/* D9 */
+		reset-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>;	/* D8 */
+		write-only;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		st7789v_st7789v_waveshare_240x240: st7789v@0 {
+			compatible = "sitronix,st7789v";
+			mipi-max-frequency = <20000000>;
+			reg = <0>;
+			width = <240>;
+			height = <240>;
+			x-offset = <0>;
+			y-offset = <0>;
+			vcom = <0x19>;
+			gctrl = <0x35>;
+			vrhs = <0x12>;
+			vdvs = <0x20>;
+			mdac = <0x00>;
+			gamma = <0x01>;
+			colmod = <0x05>;
+			lcm = <0x2c>;
+			porch-param = [0c 0c 00 33 33];
+			cmd2en-param = [5a 69 02 01];
+			pwctrl1-param = [a4 a1];
+			pvgam-param = [D0 04 0D 11 13 2B 3F 54 4C 18 0D 0B 1F 23];
+			nvgam-param = [D0 04 0C 11 13 2C 3F 44 51 2F 1F 1F 20 23];
+			ram-param = [00 F0];
+			rgb-param = [CD 08 14];
+			mipi-mode = <MIPI_DBI_MODE_SPI_4WIRE>;
+		};
 	};
 };
 
 &arduino_spi {
 	status = "okay";
 	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>;	/* D10 */
-
-	st7789v_st7789v_waveshare_240x240: st7789v@0 {
-		compatible = "sitronix,st7789v";
-		spi-max-frequency = <20000000>;
-		reg = <0>;
-		cmd-data-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>;	/* D9 */
-		reset-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>;	/* D8 */
-		width = <240>;
-		height = <240>;
-		x-offset = <0>;
-		y-offset = <0>;
-		vcom = <0x19>;
-		gctrl = <0x35>;
-		vrhs = <0x12>;
-		vdvs = <0x20>;
-		mdac = <0x00>;
-		gamma = <0x01>;
-		colmod = <0x05>;
-		lcm = <0x2c>;
-		porch-param = [0c 0c 00 33 33];
-		cmd2en-param = [5a 69 02 01];
-		pwctrl1-param = [a4 a1];
-		pvgam-param = [D0 04 0D 11 13 2B 3F 54 4C 18 0D 0B 1F 23];
-		nvgam-param = [D0 04 0C 11 13 2C 3F 44 51 2F 1F 1F 20 23];
-		ram-param = [00 F0];
-		rgb-param = [CD 08 14];
-	};
 };

--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -317,6 +317,50 @@ Display
         };
     };
 
+
+* ST7789V based displays now use the MIPI DBI driver class. These displays
+  must now be declared within a MIPI DBI driver wrapper device, which will
+  manage interfacing with the display. (:github:`73750`) Note that the
+  `cmd-data-gpios` pin has changed polarity with this update, to align better
+  with the new `dc-gpios` name. For an example, see below:
+
+  .. code-block:: devicetree
+
+    /* Legacy ST7789V display definition */
+    &spi0 {
+        st7789: st7789@0 {
+            compatible = "sitronix,st7789v";
+            reg = <0>;
+            spi-max-frequency = <32000000>;
+            reset-gpios = <&gpio0 6 GPIO_ACTIVE_LOW>;
+            cmd-data-gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+            ...
+        };
+    };
+
+    /* New display definition with MIPI DBI device */
+
+    #include <zephyr/dt-bindings/mipi_dbi/mipi_dbi.h>
+
+    ...
+
+    mipi_dbi {
+        compatible = "zephyr,mipi-dbi-spi";
+        reset-gpios = <&gpio0 6 GPIO_ACTIVE_LOW>;
+        dc-gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
+        spi-dev = <&spi0>;
+        #address-cells = <1>;
+        #size-cells = <0>;
+
+        st7789: st7789@0 {
+            compatible = "sitronix,st7789v";
+            reg = <0>;
+            mipi-max-frequency = <32000000>;
+            mipi-mode = <MIPI_DBI_MODE_SPI_4WIRE>;
+            ...
+        };
+    };
+
 Enhanced Serial Peripheral Interface (eSPI)
 ===========================================
 

--- a/drivers/display/Kconfig.st7789v
+++ b/drivers/display/Kconfig.st7789v
@@ -7,7 +7,7 @@ menuconfig ST7789V
 	bool "ST7789V display driver"
 	default y
 	depends on DT_HAS_SITRONIX_ST7789V_ENABLED
-	select SPI
+	select MIPI_DBI
 	help
 	  Enable driver for ST7789V display driver.
 

--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -14,8 +14,7 @@
 #include "display_st7789v.h"
 
 #include <zephyr/device.h>
-#include <zephyr/drivers/spi.h>
-#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/mipi_dbi.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/drivers/display.h>
@@ -25,9 +24,8 @@
 LOG_MODULE_REGISTER(display_st7789v);
 
 struct st7789v_config {
-	struct spi_dt_spec bus;
-	struct gpio_dt_spec cmd_data_gpio;
-	struct gpio_dt_spec reset_gpio;
+	const struct device *mipi_dbi;
+	const struct mipi_dbi_config dbi_config;
 	uint8_t vcom;
 	uint8_t gctrl;
 	bool vdv_vrh_enable;
@@ -73,38 +71,9 @@ static void st7789v_transmit(const struct device *dev, uint8_t cmd,
 			     uint8_t *tx_data, size_t tx_count)
 {
 	const struct st7789v_config *config = dev->config;
-	uint16_t data = cmd;
 
-	struct spi_buf tx_buf = { .buf = &cmd, .len = 1 };
-	struct spi_buf_set tx_bufs = { .buffers = &tx_buf, .count = 1 };
-
-	if (config->cmd_data_gpio.port != NULL) {
-		if (cmd != ST7789V_CMD_NONE) {
-			gpio_pin_set_dt(&config->cmd_data_gpio, 1);
-			spi_write_dt(&config->bus, &tx_bufs);
-		}
-
-		if (tx_data != NULL) {
-			tx_buf.buf = tx_data;
-			tx_buf.len = tx_count;
-			gpio_pin_set_dt(&config->cmd_data_gpio, 0);
-			spi_write_dt(&config->bus, &tx_bufs);
-		}
-	} else {
-		tx_buf.buf = &data;
-		tx_buf.len = 2;
-
-		if (cmd != ST7789V_CMD_NONE) {
-			spi_write_dt(&config->bus, &tx_bufs);
-		}
-
-		if (tx_data != NULL) {
-			for (size_t index = 0; index < tx_count; ++index) {
-				data = 0x0100 | tx_data[index];
-				spi_write_dt(&config->bus, &tx_bufs);
-			}
-		}
-	}
+	mipi_dbi_command_write(config->mipi_dbi, &config->dbi_config, cmd,
+			       tx_data, tx_count);
 }
 
 static void st7789v_exit_sleep(const struct device *dev)
@@ -115,18 +84,19 @@ static void st7789v_exit_sleep(const struct device *dev)
 
 static void st7789v_reset_display(const struct device *dev)
 {
+	const struct st7789v_config *config = dev->config;
+	int ret;
+
 	LOG_DBG("Resetting display");
 
-	const struct st7789v_config *config = dev->config;
-	if (config->reset_gpio.port != NULL) {
-		k_sleep(K_MSEC(1));
-		gpio_pin_set_dt(&config->reset_gpio, 1);
-		k_sleep(K_MSEC(6));
-		gpio_pin_set_dt(&config->reset_gpio, 0);
-		k_sleep(K_MSEC(20));
-	} else {
+	k_sleep(K_MSEC(1));
+	ret = mipi_dbi_reset(config->mipi_dbi, 6);
+	if (ret == -ENOTSUP) {
+		/* Send software reset command */
 		st7789v_transmit(dev, ST7789V_CMD_SW_RESET, NULL, 0);
 		k_sleep(K_MSEC(5));
+	} else {
+		k_sleep(K_MSEC(20));
 	}
 }
 
@@ -166,9 +136,12 @@ static int st7789v_write(const struct device *dev,
 			 const struct display_buffer_descriptor *desc,
 			 const void *buf)
 {
+	const struct st7789v_config *config = dev->config;
+	struct display_buffer_descriptor mipi_desc;
 	const uint8_t *write_data_start = (uint8_t *) buf;
 	uint16_t nbr_of_writes;
 	uint16_t write_h;
+	enum display_pixel_format pixfmt;
 
 	__ASSERT(desc->width <= desc->pitch, "Pitch is smaller then width");
 	__ASSERT((desc->pitch * ST7789V_PIXEL_SIZE * desc->height) <= desc->buf_size,
@@ -181,15 +154,31 @@ static int st7789v_write(const struct device *dev,
 	if (desc->pitch > desc->width) {
 		write_h = 1U;
 		nbr_of_writes = desc->height;
+		mipi_desc.height = 1;
+		mipi_desc.buf_size = desc->pitch * ST7789V_PIXEL_SIZE;
 	} else {
 		write_h = desc->height;
 		nbr_of_writes = 1U;
+		mipi_desc.height = desc->height;
+		mipi_desc.buf_size = desc->width * write_h * ST7789V_PIXEL_SIZE;
+	}
+	if (IS_ENABLED(CONFIG_ST7789V_RGB565)) {
+		pixfmt = PIXEL_FORMAT_RGB_565;
+	} else {
+		pixfmt = PIXEL_FORMAT_RGB_888;
 	}
 
+	mipi_desc.width = desc->width;
+	/* Per MIPI API, pitch must always match width */
+	mipi_desc.pitch = desc->width;
+
+	/* Send RAMWR command */
+	st7789v_transmit(dev, ST7789V_CMD_RAMWR, NULL, 0);
+
 	for (uint16_t write_cnt = 0U; write_cnt < nbr_of_writes; ++write_cnt) {
-		st7789v_transmit(dev, write_cnt == 0U ? ST7789V_CMD_RAMWR : ST7789V_CMD_NONE,
-				(void *) write_data_start,
-				desc->width * ST7789V_PIXEL_SIZE * write_h);
+		mipi_dbi_write_display(config->mipi_dbi, &config->dbi_config,
+				       write_data_start, &mipi_desc, pixfmt);
+
 		write_data_start += (desc->pitch * ST7789V_PIXEL_SIZE);
 	}
 
@@ -326,33 +315,9 @@ static int st7789v_init(const struct device *dev)
 {
 	const struct st7789v_config *config = dev->config;
 
-	if (!spi_is_ready_dt(&config->bus)) {
-		LOG_ERR("SPI device not ready");
+	if (!device_is_ready(config->mipi_dbi)) {
+		LOG_ERR("MIPI DBI device not ready");
 		return -ENODEV;
-	}
-
-	if (config->reset_gpio.port != NULL) {
-		if (!gpio_is_ready_dt(&config->reset_gpio)) {
-			LOG_ERR("Reset GPIO device not ready");
-			return -ENODEV;
-		}
-
-		if (gpio_pin_configure_dt(&config->reset_gpio, GPIO_OUTPUT_INACTIVE)) {
-			LOG_ERR("Couldn't configure reset pin");
-			return -EIO;
-		}
-	}
-
-	if (config->cmd_data_gpio.port != NULL) {
-		if (!gpio_is_ready_dt(&config->cmd_data_gpio)) {
-			LOG_ERR("CMD/DATA GPIO device not ready");
-			return -ENODEV;
-		}
-
-		if (gpio_pin_configure_dt(&config->cmd_data_gpio, GPIO_OUTPUT)) {
-			LOG_ERR("Couldn't configure CMD/DATA pin");
-			return -EIO;
-		}
 	}
 
 	st7789v_reset_display(dev);
@@ -398,14 +363,14 @@ static const struct display_driver_api st7789v_api = {
 };
 
 #define ST7789V_WORD_SIZE(inst)								\
-	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, cmd_data_gpios), (8), (9))
-
+	((DT_INST_PROP(inst, mipi_mode) == MIPI_DBI_MODE_SPI_4WIRE) ?                   \
+	SPI_WORD_SET(8) : SPI_WORD_SET(9))
 #define ST7789V_INIT(inst)								\
 	static const struct st7789v_config st7789v_config_ ## inst = {			\
-		.bus = SPI_DT_SPEC_INST_GET(inst, SPI_OP_MODE_MASTER |			\
-					    SPI_WORD_SET(ST7789V_WORD_SIZE(inst)), 0),	\
-		.cmd_data_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, cmd_data_gpios, {}),	\
-		.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, reset_gpios, {}),		\
+		.mipi_dbi = DEVICE_DT_GET(DT_INST_PARENT(inst)),                        \
+		.dbi_config = MIPI_DBI_CONFIG_DT_INST(inst,                             \
+						      ST7789V_WORD_SIZE(inst) |         \
+						      SPI_OP_MODE_MASTER, 0),           \
 		.vcom = DT_INST_PROP(inst, vcom),					\
 		.gctrl = DT_INST_PROP(inst, gctrl),					\
 		.vdv_vrh_enable = (DT_INST_NODE_HAS_PROP(inst, vrhs)			\

--- a/drivers/display/display_st7789v.h
+++ b/drivers/display/display_st7789v.h
@@ -68,6 +68,4 @@
 #define ST7789V_CMD_PVGAMCTRL			0xe0
 #define ST7789V_CMD_NVGAMCTRL			0xe1
 
-#define ST7789V_CMD_NONE			0xff
-
 #endif

--- a/dts/bindings/display/sitronix,st7789v.yaml
+++ b/dts/bindings/display/sitronix,st7789v.yaml
@@ -6,29 +6,9 @@ description: ST7789V 320x240 display controller
 
 compatible: "sitronix,st7789v"
 
-include: [spi-device.yaml, display-controller.yaml]
+include: [mipi-dbi-spi-device.yaml, display-controller.yaml]
 
 properties:
-  reset-gpios:
-    type: phandle-array
-    description: |
-      RESET pin.
-
-      The RESET pin of ST7789V is active low.
-      If connected directly the MCU pin should be configured
-      as active low.
-
-  cmd-data-gpios:
-    type: phandle-array
-    description: |
-      D/CX pin. If configured, 4-lines serial interface is used, otherwise
-      3-lines serial interface is used and a D/CX bit (9-bit) is added to
-      the protocol.
-
-      The D/CX pin of ST7789V is active low (transmission command byte).
-      If connected directly the MCU pin should be configured
-      as active low.
-
   x-offset:
     type: int
     required: true
@@ -115,3 +95,6 @@ properties:
     type: uint8-array
     required: true
     description: RGB Interface Control Parameter
+
+  mipi-mode:
+    required: true

--- a/tests/drivers/build_all/display/app.overlay
+++ b/tests/drivers/build_all/display/app.overlay
@@ -70,6 +70,34 @@
 				width = <160>;
 				height = <128>;
 			};
+
+			st7789v: st7789v@3 {
+				compatible = "sitronix,st7789v";
+				reg = <3>;
+				mipi-max-frequency = <25000000>;
+
+				width = <128>;
+				height = <128>;
+				/* Arbiratry values */
+				x-offset = <0>;
+				y-offset = <0>;
+				vcom = <0x28>;
+				gctrl = <0x35>;
+				vrhs = <0x10>;
+				vdvs = <0x20>;
+				mdac = <0x00>;
+				gamma = <0x01>;
+				colmod = <0x55>;
+				lcm = <0x0c>;
+				porch-param = [0c 0c 00 33 33];
+				cmd2en-param = [5a 69 02 00];
+				pwctrl1-param = [a4 a1];
+				pvgam-param = [d0 00 02 07 0a 28 32 44 42 06 0e 12 14 17];
+				nvgam-param = [d0 00 02 07 0a 28 31 54 47 0e 1c 17 1b 1e];
+				ram-param = [00 E0];
+				rgb-param = [40 02 14];
+				mipi-mode = <MIPI_DBI_MODE_SPI_4WIRE>;
+			};
 		};
 
 
@@ -82,7 +110,8 @@
 			clock-frequency = <2000000>;
 
 			/* one entry for every devices at spi.dtsi */
-			cs-gpios = <&test_gpio 0 0 &test_gpio 0 1 &test_gpio 0 2>;
+			cs-gpios = <&test_gpio 0 0 &test_gpio 0 1 &test_gpio 0 2
+				&test_gpio 0 3>;
 
 			test_spi_gc9x01x: gc9x01x@1 {
 				compatible = "galaxycore,gc9x01x";


### PR DESCRIPTION
Convert ST7789V display driver to use MIPI DBI API. Update in tree boards to use the new devicetree syntax needed to enable
this display with the MIPI DBI API.
