### PR TITLE
soc: pm: ambiq: Add power management support for Apollo3 SoCs

### DIFF
--- a/drivers/i2c/i2c_ambiq.c
+++ b/drivers/i2c/i2c_ambiq.c
@@ -9,6 +9,9 @@
 #include <errno.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/kernel.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/policy.h>
+#include <zephyr/pm/device_runtime.h>
 
 #include <am_mcu_apollo.h>
 
@@ -186,6 +189,14 @@ static int i2c_ambiq_transfer(const struct device *dev, struct i2c_msg *msgs, ui
 		return 0;
 	}
 
+#if defined(CONFIG_PM_DEVICE_RUNTIME)
+	ret = pm_device_runtime_get(dev);
+
+	if (ret < 0) {
+		LOG_ERR("pm_device_runtime_get failed: %d", ret);
+	}
+#endif
+
 	/* Send out messages */
 	k_sem_take(&data->bus_sem, K_FOREVER);
 
@@ -202,6 +213,17 @@ static int i2c_ambiq_transfer(const struct device *dev, struct i2c_msg *msgs, ui
 	}
 
 	k_sem_give(&data->bus_sem);
+
+#if defined(CONFIG_PM_DEVICE_RUNTIME)
+	/* Use async put to avoid useless device suspension/resumption
+	 * when doing consecutive transmission.
+	 */
+	ret = pm_device_runtime_put_async(dev, K_MSEC(2));
+
+	if (ret < 0) {
+		LOG_ERR("pm_device_runtime_put failed: %d", ret);
+	}
+#endif
 
 	return 0;
 }
@@ -258,6 +280,34 @@ static const struct i2c_driver_api i2c_ambiq_driver_api = {
 	.transfer = i2c_ambiq_transfer,
 };
 
+#ifdef CONFIG_PM_DEVICE
+static int i2c_ambiq_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	struct i2c_ambiq_data *data = dev->data;
+	uint32_t ret;
+	am_hal_sysctrl_power_state_e status;
+
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
+		status = AM_HAL_SYSCTRL_WAKE;
+		break;
+	case PM_DEVICE_ACTION_SUSPEND:
+		status = AM_HAL_SYSCTRL_DEEPSLEEP;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	ret = am_hal_iom_power_ctrl(data->IOMHandle, status, true);
+
+	if (ret != AM_HAL_STATUS_SUCCESS) {
+		return -EPERM;
+	} else {
+		return 0;
+	}
+}
+#endif /* CONFIG_PM_DEVICE */
+
 #define AMBIQ_I2C_DEFINE(n)                                                                        \
 	PINCTRL_DT_INST_DEFINE(n);                                                                 \
 	static int pwr_on_ambiq_i2c_##n(void)                                                      \
@@ -286,7 +336,8 @@ static const struct i2c_driver_api i2c_ambiq_driver_api = {
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                         \
 		.irq_config_func = i2c_irq_config_func_##n,                                        \
 		.pwr_func = pwr_on_ambiq_i2c_##n};                                                 \
-	I2C_DEVICE_DT_INST_DEFINE(n, i2c_ambiq_init, NULL, &i2c_ambiq_data##n,                     \
+	PM_DEVICE_DT_INST_DEFINE(n, i2c_ambiq_pm_action);                                          \
+	I2C_DEVICE_DT_INST_DEFINE(n, i2c_ambiq_init, PM_DEVICE_DT_INST_GET(n), &i2c_ambiq_data##n, \
 				  &i2c_ambiq_config##n, POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,     \
 				  &i2c_ambiq_driver_api);
 

--- a/drivers/serial/uart_pl011.c
+++ b/drivers/serial/uart_pl011.c
@@ -33,7 +33,9 @@
 #endif
 
 #include "uart_pl011_registers.h"
+#ifdef CONFIG_SOC_FAMILY_AMBIQ
 #include "uart_pl011_ambiq.h"
+#endif
 #include "uart_pl011_raspberrypi_pico.h"
 
 struct pl011_config {
@@ -647,9 +649,8 @@ void pl011_isr(const struct device *dev)
 			DT_NODE_HAS_COMPAT(DT_INST_CLOCKS_CTLR(n), fixed_clock),        \
 			(DT_INST_PROP_BY_PHANDLE(n, clocks, clock_frequency)), (0)),    \
 	};							\
-								\
 	DEVICE_DT_INST_DEFINE(n, &pl011_init,			\
-			NULL,					\
+			PM_DEVICE_DT_INST_GET(n),					\
 			&pl011_data_port_##n,			\
 			&pl011_cfg_port_##n,			\
 			PRE_KERNEL_1,				\

--- a/drivers/serial/uart_pl011_ambiq.h
+++ b/drivers/serial/uart_pl011_ambiq.h
@@ -9,8 +9,11 @@
 
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/policy.h>
 
 #include "uart_pl011_registers.h"
+#include <am_mcu_apollo.h>
 
 #define PWRCTRL_MAX_WAIT_US 5
 
@@ -50,6 +53,113 @@ static inline int clk_enable_ambiq_uart(const struct device *dev, uint32_t clk)
 	return pl011_ambiq_clk_set(dev, clk);
 }
 
+#ifdef CONFIG_PM_DEVICE
+
+/* Register status record.
+ * The register status will be preserved to this variable before entering sleep mode,
+ * and they will be restored after wake up.
+ */
+typedef struct {
+	bool bValid;
+	uint32_t regILPR;
+	uint32_t regIBRD;
+	uint32_t regFBRD;
+	uint32_t regLCRH;
+	uint32_t regCR;
+	uint32_t regIFLS;
+	uint32_t regIER;
+} uart_register_state_t;
+static uart_register_state_t sRegState[2];
+
+static int uart_ambiq_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	int key;
+
+	/*Uart module number*/
+	uint32_t ui32Module = ((uint32_t)get_uart(dev) == REG_UART_BASEADDR) ? 0 : 1;
+
+	/*Uart Power module*/
+	am_hal_pwrctrl_periph_e eUARTPowerModule =
+		((am_hal_pwrctrl_periph_e)(AM_HAL_PWRCTRL_PERIPH_UART0 + ui32Module));
+
+	/*Uart register status*/
+	uart_register_state_t *pRegisterStatus = &sRegState[ui32Module];
+
+	/* Decode the requested power state and update UART operation accordingly.*/
+	switch (action) {
+
+	/* Turn on the UART. */
+	case PM_DEVICE_ACTION_RESUME:
+
+		/* Make sure we don't try to restore an invalid state.*/
+		if (!pRegisterStatus->bValid) {
+			return -EPERM;
+		}
+
+		/*The resume and suspend actions may be executed back-to-back,
+		 * so we add a busy wait here for stabilization.
+		 */
+		k_busy_wait(100);
+
+		/* Enable power control.*/
+		am_hal_pwrctrl_periph_enable(eUARTPowerModule);
+
+		/* Restore UART registers*/
+		key = irq_lock();
+
+		UARTn(ui32Module)->ILPR = pRegisterStatus->regILPR;
+		UARTn(ui32Module)->IBRD = pRegisterStatus->regIBRD;
+		UARTn(ui32Module)->FBRD = pRegisterStatus->regFBRD;
+		UARTn(ui32Module)->LCRH = pRegisterStatus->regLCRH;
+		UARTn(ui32Module)->CR = pRegisterStatus->regCR;
+		UARTn(ui32Module)->IFLS = pRegisterStatus->regIFLS;
+		UARTn(ui32Module)->IER = pRegisterStatus->regIER;
+		pRegisterStatus->bValid = false;
+
+		irq_unlock(key);
+
+		return 0;
+	case PM_DEVICE_ACTION_SUSPEND:
+
+		while ((get_uart(dev)->fr & PL011_FR_BUSY) != 0)
+			;
+
+		/* Preserve UART registers*/
+		key = irq_lock();
+
+		pRegisterStatus->regILPR = UARTn(ui32Module)->ILPR;
+		pRegisterStatus->regIBRD = UARTn(ui32Module)->IBRD;
+		pRegisterStatus->regFBRD = UARTn(ui32Module)->FBRD;
+		pRegisterStatus->regLCRH = UARTn(ui32Module)->LCRH;
+		pRegisterStatus->regCR = UARTn(ui32Module)->CR;
+		pRegisterStatus->regIFLS = UARTn(ui32Module)->IFLS;
+		pRegisterStatus->regIER = UARTn(ui32Module)->IER;
+		pRegisterStatus->bValid = true;
+
+		irq_unlock(key);
+
+		/* Clear all interrupts before sleeping as having a pending UART
+		 * interrupt burns power.
+		 */
+		UARTn(ui32Module)->IEC = 0xFFFFFFFF;
+
+		/* If the user is going to sleep, certain bits of the CR register
+		 * need to be 0 to be low power and have the UART shut off.
+		 * Since the user either wishes to retain state which takes place
+		 * above or the user does not wish to retain state, it is acceptable
+		 * to set the entire CR register to 0.
+		 */
+		UARTn(ui32Module)->CR = 0;
+
+		/* Disable power control.*/
+		am_hal_pwrctrl_periph_disable(eUARTPowerModule);
+		return 0;
+	default:
+		return -ENOTSUP;
+	}
+}
+#endif /* CONFIG_PM_DEVICE */
+
 /* Problem: writes to power configure register takes some time to take effective.
  * Solution: Check device's power status to ensure that register has taken effective.
  * Note: busy wait is not allowed to use here due to UART is initiated before timer starts.
@@ -57,11 +167,12 @@ static inline int clk_enable_ambiq_uart(const struct device *dev, uint32_t clk)
 #if defined(CONFIG_SOC_SERIES_APOLLO3X)
 #define DEVPWRSTATUS_OFFSET 0x10
 #define HCPA_MASK           0x4
-#define AMBIQ_UART_DEFINE(n)                                                                 \
+#define AMBIQ_UART_DEFINE(n)                                                                       \
+	PM_DEVICE_DT_INST_DEFINE(n, uart_ambiq_pm_action);                                         \
 	static int pwr_on_ambiq_uart_##n(void)                                                     \
 	{                                                                                          \
 		uint32_t addr = DT_REG_ADDR(DT_INST_PHANDLE(n, ambiq_pwrcfg)) +                    \
-				DT_INST_PHA(n, ambiq_pwrcfg, offset);                              \
+				DT_INST_PHA(n, ambiq_pwrcfg, offset);      \
 		uint32_t pwr_status_addr = addr + DEVPWRSTATUS_OFFSET;                             \
 		sys_write32((sys_read32(addr) | DT_INST_PHA(n, ambiq_pwrcfg, mask)), addr);        \
 		while (!(sys_read32(pwr_status_addr) & HCPA_MASK)) {                               \
@@ -78,7 +189,7 @@ static inline int clk_enable_ambiq_uart(const struct device *dev, uint32_t clk)
 	static int pwr_on_ambiq_uart_##n(void)                                                     \
 	{                                                                                          \
 		uint32_t addr = DT_REG_ADDR(DT_INST_PHANDLE(n, ambiq_pwrcfg)) +                    \
-				DT_INST_PHA(n, ambiq_pwrcfg, offset);                              \
+				DT_INST_PHA(n, ambiq_pwrcfg, offset);            \
 		uint32_t pwr_status_addr = addr + DEVPWRSTATUS_OFFSET;                             \
 		sys_write32((sys_read32(addr) | DT_INST_PHA(n, ambiq_pwrcfg, mask)), addr);        \
 		while ((sys_read32(pwr_status_addr) & DT_INST_PHA(n, ambiq_pwrcfg, mask)) !=       \

--- a/drivers/spi/spi_ambiq.c
+++ b/drivers/spi/spi_ambiq.c
@@ -13,6 +13,10 @@ LOG_MODULE_REGISTER(spi_ambiq);
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/policy.h>
+#include <zephyr/pm/device_runtime.h>
+
 #include <stdlib.h>
 #include <errno.h>
 #include "spi_context.h"
@@ -346,8 +350,7 @@ static int spi_ambiq_xfer(const struct device *dev, const struct spi_config *con
 				ret = spi_ambiq_xfer_full_duplex(dev, AM_HAL_IOM_FULLDUPLEX, trans,
 								 cont);
 			} else {
-				ret = spi_ambiq_xfer_half_duplex(dev, AM_HAL_IOM_RX, trans,
-								 cont);
+				ret = spi_ambiq_xfer_half_duplex(dev, AM_HAL_IOM_RX, trans, cont);
 			}
 		} else { /* There's no data to Receive */
 			/* Regard the first tx_buf as cmd if there are more than one buffer */
@@ -379,6 +382,14 @@ static int spi_ambiq_transceive(const struct device *dev, const struct spi_confi
 		return 0;
 	}
 
+#if defined(CONFIG_PM_DEVICE_RUNTIME)
+	ret = pm_device_runtime_get(dev);
+
+	if (ret < 0) {
+		LOG_ERR("pm_device_runtime_get failed: %d", ret);
+	}
+#endif
+
 	/* context setup */
 	spi_context_lock(&data->ctx, false, NULL, NULL, config);
 
@@ -394,6 +405,17 @@ static int spi_ambiq_transceive(const struct device *dev, const struct spi_confi
 	ret = spi_ambiq_xfer(dev, config);
 
 	spi_context_release(&data->ctx, ret);
+
+#if defined(CONFIG_PM_DEVICE_RUNTIME)
+	/* Use async put to avoid useless device suspension/resumption
+	 * when doing consecutive transmission.
+	 */
+	ret = pm_device_runtime_put_async(dev, K_MSEC(2));
+
+	if (ret < 0) {
+		LOG_ERR("pm_device_runtime_put failed: %d", ret);
+	}
+#endif
 
 	return ret;
 }
@@ -455,6 +477,35 @@ end:
 	return ret;
 }
 
+#ifdef CONFIG_PM_DEVICE
+static int spi_ambiq_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	struct spi_ambiq_data *data = dev->data;
+	uint32_t ret;
+	am_hal_sysctrl_power_state_e status;
+
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
+		status = AM_HAL_SYSCTRL_WAKE;
+		break;
+	case PM_DEVICE_ACTION_SUSPEND:
+		status = AM_HAL_SYSCTRL_DEEPSLEEP;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	ret = am_hal_iom_power_ctrl(data->IOMHandle, status, true);
+
+	if (ret != AM_HAL_STATUS_SUCCESS) {
+		LOG_ERR("am_hal_iom_power_ctrl failed: %d", ret);
+		return -EPERM;
+	} else {
+		return 0;
+	}
+}
+#endif /* CONFIG_PM_DEVICE */
+
 #define AMBIQ_SPI_INIT(n)                                                                          \
 	PINCTRL_DT_INST_DEFINE(n);                                                                 \
 	static int pwr_on_ambiq_spi_##n(void)                                                      \
@@ -481,7 +532,9 @@ end:
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                         \
 		.irq_config_func = spi_irq_config_func_##n,                                        \
 		.pwr_func = pwr_on_ambiq_spi_##n};                                                 \
-	DEVICE_DT_INST_DEFINE(n, spi_ambiq_init, NULL, &spi_ambiq_data##n, &spi_ambiq_config##n,   \
-			      POST_KERNEL, CONFIG_SPI_INIT_PRIORITY, &spi_ambiq_driver_api);
+	PM_DEVICE_DT_INST_DEFINE(n, spi_ambiq_pm_action);                                          \
+	DEVICE_DT_INST_DEFINE(n, spi_ambiq_init, PM_DEVICE_DT_INST_GET(n), &spi_ambiq_data##n,     \
+			      &spi_ambiq_config##n, POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,         \
+			      &spi_ambiq_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(AMBIQ_SPI_INIT)

--- a/dts/arm/ambiq/ambiq_apollo3_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo3_blue.dtsi
@@ -249,6 +249,7 @@
 			interrupts = <6 0>;
 			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x2>;
+			zephyr,pm-device-runtime-auto;
 		};
 
 		i2c1: i2c@50005000 {
@@ -258,6 +259,7 @@
 			interrupts = <7 0>;
 			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x4>;
+			zephyr,pm-device-runtime-auto;
 		};
 
 		i2c2: i2c@50006000 {
@@ -267,6 +269,7 @@
 			interrupts = <8 0>;
 			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x8>;
+			zephyr,pm-device-runtime-auto;
 		};
 
 		i2c3: i2c@50007000 {
@@ -276,6 +279,7 @@
 			interrupts = <9 0>;
 			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x10>;
+			zephyr,pm-device-runtime-auto;
 		};
 
 		i2c4: i2c@50008000 {
@@ -285,6 +289,7 @@
 			interrupts = <10 0>;
 			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x20>;
+			zephyr,pm-device-runtime-auto;
 		};
 
 		i2c5: i2c@50009000 {
@@ -294,6 +299,7 @@
 			interrupts = <11 0>;
 			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x40>;
+			zephyr,pm-device-runtime-auto;
 		};
 
 		mspi0: spi@40020000 {

--- a/dts/arm/ambiq/ambiq_apollo3_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo3_blue.dtsi
@@ -195,6 +195,7 @@
 			interrupts = <6 0>;
 			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x2>;
+			zephyr,pm-device-runtime-auto;
 		};
 
 		spi1: spi@50005000 {
@@ -204,6 +205,7 @@
 			interrupts = <7 0>;
 			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x4>;
+			zephyr,pm-device-runtime-auto;
 		};
 
 		spi2: spi@50006000 {
@@ -213,6 +215,7 @@
 			interrupts = <8 0>;
 			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x8>;
+			zephyr,pm-device-runtime-auto;
 		};
 
 		spi3: spi@50007000 {
@@ -222,6 +225,7 @@
 			interrupts = <9 0>;
 			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x10>;
+			zephyr,pm-device-runtime-auto;
 		};
 
 		spi4: spi@50008000 {
@@ -231,6 +235,7 @@
 			interrupts = <10 0>;
 			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x20>;
+			zephyr,pm-device-runtime-auto;
 		};
 
 		spi5: spi@50009000 {
@@ -240,6 +245,7 @@
 			interrupts = <11 0>;
 			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x40>;
+			zephyr,pm-device-runtime-auto;
 		};
 
 		i2c0: i2c@50004000 {

--- a/dts/arm/ambiq/ambiq_apollo3_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo3_blue.dtsi
@@ -174,6 +174,7 @@
 			status = "disabled";
 			clocks = <&uartclk>;
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x80>;
+			zephyr,pm-device-runtime-auto;
 		};
 
 		uart1: uart@4001d000 {
@@ -184,6 +185,7 @@
 			status = "disabled";
 			clocks = <&uartclk>;
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x100>;
+			zephyr,pm-device-runtime-auto;
 		};
 
 		spi0: spi@50004000 {

--- a/dts/arm/ambiq/ambiq_apollo3_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo3_blue.dtsi
@@ -22,6 +22,32 @@
 		cpu0: cpu@0 {
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
+			cpu-power-states = <&idle &suspend_to_ram>;
+		};
+
+		power-states {
+			idle: idle {
+				compatible = "zephyr,power-state";
+				power-state-name = "suspend-to-idle";
+				/* As Apollo3blue datasheet, run_to_sleep and sleep_to_run
+				 * transition time are both lower than 1us, but considering
+				 * the software overhead we set a bigger value.
+				 */
+				min-residency-us = <100>;
+				exit-latency-us = <5>;
+			};
+
+			suspend_to_ram: suspend_to_ram {
+				compatible = "zephyr,power-state";
+				power-state-name = "suspend-to-ram";
+				/* As Apollo3blue datasheet, run_to_deepsleep transition time is
+				 * the software overhead 1us and deepsleep_to_run transition time
+				 * is about 25us,but considering the software overhead, we set
+				 * a bigger value.
+				 */
+				min-residency-us = <2000>;
+				exit-latency-us = <125>;
+			};
 		};
 	};
 

--- a/dts/arm/ambiq/ambiq_apollo3p_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo3p_blue.dtsi
@@ -22,6 +22,32 @@
 		cpu0: cpu@0 {
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
+			cpu-power-states = <&idle &suspend_to_ram>;
+		};
+
+		power-states {
+			idle: idle {
+				compatible = "zephyr,power-state";
+				power-state-name = "suspend-to-idle";
+				/* As Apollo3blueplus datasheet, run_to_sleep and sleep_to_run
+				 * transition time are both lower than 1us, but considering
+				 * the software overhead we set a bigger value.
+				 */
+				min-residency-us = <100>;
+				exit-latency-us = <5>;
+			};
+
+			suspend_to_ram: suspend_to_ram {
+				compatible = "zephyr,power-state";
+				power-state-name = "suspend-to-ram";
+				/* As Apollo3blueplus datasheet, run_to_deepsleep transition time
+				 * is the software overhead 1us and deepsleep_to_run transition
+				 * time is about 25us,but considering the software overhead,
+				 * we set a bigger value.
+				 */
+				min-residency-us = <2000>;
+				exit-latency-us = <125>;
+			};
 		};
 	};
 

--- a/dts/arm/ambiq/ambiq_apollo3p_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo3p_blue.dtsi
@@ -195,6 +195,7 @@
 			interrupts = <6 0>;
 			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x2>;
+			zephyr,pm-device-runtime-auto;
 		};
 
 		spi1: spi@50005000 {
@@ -204,6 +205,7 @@
 			interrupts = <7 0>;
 			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x4>;
+			zephyr,pm-device-runtime-auto;
 		};
 
 		spi2: spi@50006000 {
@@ -213,6 +215,7 @@
 			interrupts = <8 0>;
 			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x8>;
+			zephyr,pm-device-runtime-auto;
 		};
 
 		spi3: spi@50007000 {
@@ -222,6 +225,7 @@
 			interrupts = <9 0>;
 			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x10>;
+			zephyr,pm-device-runtime-auto;
 		};
 
 		spi4: spi@50008000 {
@@ -231,6 +235,7 @@
 			interrupts = <10 0>;
 			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x20>;
+			zephyr,pm-device-runtime-auto;
 		};
 
 		spi5: spi@50009000 {
@@ -240,6 +245,7 @@
 			interrupts = <11 0>;
 			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x40>;
+			zephyr,pm-device-runtime-auto;
 		};
 
 		i2c0: i2c@50004000 {

--- a/dts/arm/ambiq/ambiq_apollo3p_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo3p_blue.dtsi
@@ -174,6 +174,7 @@
 			status = "disabled";
 			clocks = <&uartclk>;
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x80>;
+			zephyr,pm-device-runtime-auto;
 		};
 
 		uart1: uart@4001d000 {
@@ -184,6 +185,7 @@
 			status = "disabled";
 			clocks = <&uartclk>;
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x100>;
+			zephyr,pm-device-runtime-auto;
 		};
 
 		spi0: spi@50004000 {

--- a/dts/arm/ambiq/ambiq_apollo3p_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo3p_blue.dtsi
@@ -249,6 +249,7 @@
 			interrupts = <6 0>;
 			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x2>;
+			zephyr,pm-device-runtime-auto;
 		};
 
 		i2c1: i2c@50005000 {
@@ -258,6 +259,7 @@
 			interrupts = <7 0>;
 			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x4>;
+			zephyr,pm-device-runtime-auto;
 		};
 
 		i2c2: i2c@50006000 {
@@ -267,6 +269,7 @@
 			interrupts = <8 0>;
 			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x8>;
+			zephyr,pm-device-runtime-auto;
 		};
 
 		i2c3: i2c@50007000 {
@@ -276,6 +279,7 @@
 			interrupts = <9 0>;
 			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x10>;
+			zephyr,pm-device-runtime-auto;
 		};
 
 		i2c4: i2c@50008000 {
@@ -285,6 +289,7 @@
 			interrupts = <10 0>;
 			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x20>;
+			zephyr,pm-device-runtime-auto;
 		};
 
 		i2c5: i2c@50009000 {
@@ -294,6 +299,7 @@
 			interrupts = <11 0>;
 			status = "disabled";
 			ambiq,pwrcfg = <&pwrcfg 0x8 0x40>;
+			zephyr,pm-device-runtime-auto;
 		};
 
 		mspi0: spi@50014000 {

--- a/soc/ambiq/apollo3x/CMakeLists.txt
+++ b/soc/ambiq/apollo3x/CMakeLists.txt
@@ -5,5 +5,6 @@
 
 zephyr_sources(soc.c)
 zephyr_include_directories(.)
+zephyr_sources_ifdef(CONFIG_PM power.c)
 
 set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")

--- a/soc/ambiq/apollo3x/Kconfig
+++ b/soc/ambiq/apollo3x/Kconfig
@@ -10,3 +10,4 @@ config SOC_SERIES_APOLLO3X
 	select CPU_HAS_ARM_MPU
 	select HAS_SWO
 	select AMBIQ_HAL
+	select HAS_PM

--- a/soc/ambiq/apollo3x/Kconfig.defconfig
+++ b/soc/ambiq/apollo3x/Kconfig.defconfig
@@ -6,4 +6,18 @@ if SOC_SERIES_APOLLO3X
 
 rsource "Kconfig.defconfig.apollo3*"
 
+config PM
+	default y
+
+config PM_DEVICE
+	default y if PM
+
+config PM_DEVICE_RUNTIME
+	default y if PM_DEVICE
+
+# Need to enlarge the IDLE stack size because the power
+# management operations are executed in the idle task
+config IDLE_STACK_SIZE
+	default 2048 if PM
+
 endif # SOC_SERIES_APOLLO3X

--- a/soc/ambiq/apollo3x/power.c
+++ b/soc/ambiq/apollo3x/power.c
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2024 Ambiq LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <soc.h>
+
+#include <zephyr/drivers/interrupt_controller/gic.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/pm/pm.h>
+#include <zephyr/init.h>
+
+/* ambiq-sdk includes */
+#include <am_mcu_apollo.h>
+
+LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
+
+void pm_state_set(enum pm_state state, uint8_t substate_id)
+{
+	ARG_UNUSED(substate_id);
+
+	__disable_irq();
+	__set_BASEPRI(0);
+
+	switch (state) {
+	case PM_STATE_SUSPEND_TO_IDLE: {
+		/* Put ARM core to normal sleep. */
+		am_hal_sysctrl_sleep(AM_HAL_SYSCTRL_SLEEP_NORMAL);
+		break;
+	}
+	case PM_STATE_SUSPEND_TO_RAM: {
+		/* Put ARM core to deep sleep. */
+		/* Cotex-m: power down, register value preserve.*/
+		/* Cache: power down*/
+		/* Flash: power down*/
+		/* Sram: retention*/
+		am_hal_sysctrl_sleep(AM_HAL_SYSCTRL_SLEEP_DEEP);
+		break;
+	}
+	default: {
+		LOG_DBG("Unsupported power state %u", state);
+		break;
+	}
+	}
+}
+
+void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
+{
+	ARG_UNUSED(substate_id);
+
+	switch (state) {
+	case PM_STATE_SUSPEND_TO_IDLE: {
+		/* Nothing is needed after soc is wake up.*/
+		break;
+	}
+	case PM_STATE_SUSPEND_TO_RAM: {
+		/* Flash, cache, sram automatically switch to active state on wake up,
+		 * Nothing needed for software.
+		 */
+		break;
+	}
+	default: {
+		LOG_DBG("Unsupported power substate-id %u", state);
+		break;
+	}
+	}
+
+	__enable_irq();
+	irq_unlock(0);
+}
+
+static int ambiq_power_init(void)
+{
+	/* Enable flash.
+	 * Currently all flash area is powered on, but we should only enable the used flash area and
+	 * put unused flash in power down mode.
+	 */
+	if (am_hal_pwrctrl_memory_enable(AM_HAL_PWRCTRL_MEM_FLASH_MAX)) {
+		__ASSERT(0, "Failed to enable FLASH!");
+	}
+
+	/* Enable SRAM.
+	 * Currently all SRAM area is powered on, but we should only enable the used ram area and
+	 * put unused ram in power down mode.
+	 */
+	if (am_hal_pwrctrl_memory_enable(AM_HAL_PWRCTRL_MEM_SRAM_MAX)) {
+		__ASSERT(0, "Failed to enable SRAM!");
+	}
+
+	/* For optimal Deep Sleep current, configure cache to be powered-down in deepsleep. */
+	am_hal_pwrctrl_memory_deepsleep_powerdown(AM_HAL_PWRCTRL_MEM_CACHE);
+
+	/* Power off all flash area, when go to deep sleep.*/
+	am_hal_pwrctrl_memory_deepsleep_powerdown(AM_HAL_PWRCTRL_MEM_FLASH_MAX);
+
+	/* Keep the used SRAM area in retention mode. */
+	am_hal_pwrctrl_memory_deepsleep_powerdown(AM_HAL_PWRCTRL_MEM_SRAM_MAX);
+	am_hal_pwrctrl_memory_deepsleep_retain(AM_HAL_PWRCTRL_MEM_SRAM_MAX);
+
+#if defined(CONFIG_SOC_APOLLO3P_BLUE)
+	/*
+	 * If user has enabled AM_HAL_SYSCTRL_DEEPSLEEP_WA in am_hal_sysctrl.h
+	 * this will allow user to acheive lower current draw in deepsleep
+	 */
+	am_hal_sysctrl_control(AM_HAL_SYSCTRL_CONTROL_DEEPSLEEP_MINPWR_EN, 0);
+#endif
+
+	return 0;
+}
+
+SYS_INIT(ambiq_power_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/soc/ambiq/apollo3x/soc.c
+++ b/soc/ambiq/apollo3x/soc.c
@@ -10,6 +10,12 @@
 
 static int arm_apollo3_init(void)
 {
+	/* Set the clock frequency. */
+	am_hal_clkgen_control(AM_HAL_CLKGEN_CONTROL_SYSCLK_MAX, 0);
+
+	/* Enable Flash cache.*/
+	am_hal_cachectrl_config(&am_hal_cachectrl_defaults);
+	am_hal_cachectrl_enable();
 
 	/* Initialize for low power in the power control block */
 	am_hal_pwrctrl_low_power_init();


### PR DESCRIPTION
This commit adds support for the power management for
Apollo3/Apollo3P SoCs, and enables the CONFIG_PM,
CONFIG_PM_DEVICE, CONFIG_PM_DEVICE_RUNTIME by default