### PR TITLE
ztest: drivers: can: add imx93_evk to drivers/can/api test

### DIFF
--- a/boards/nxp/imx93_evk/dts/imx93_evk_flexcan2.overlay
+++ b/boards/nxp/imx93_evk/dts/imx93_evk_flexcan2.overlay
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2024 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/{
+	chosen{
+		zephyr,canbus = &flexcan2;
+	};
+};
+
+&gpiohog_exp_sel {
+	status = "okay";
+	output-low;
+};
+
+&can_phy0 {
+	status = "okay";
+};
+
+&flexcan2 {
+	status = "okay";
+};

--- a/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.dts
+++ b/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.dts
@@ -17,7 +17,6 @@
 		zephyr,console = &lpuart2;
 		zephyr,shell-uart = &lpuart2;
 		zephyr,sram = &sram0;
-		zephyr,canbus = &flexcan2;
 	};
 
 	cpus {
@@ -71,7 +70,7 @@
 		max-bitrate = <8000000>;
 		standby-gpios = <&gpio_exp0 8 GPIO_ACTIVE_HIGH>;
 		#phy-cells = <0>;
-		status = "okay";
+		status = "disabled";
 	};
 };
 
@@ -106,11 +105,12 @@
 	pinctrl-names = "default";
 
 	mfd0:adp5585@34 {
+		status = "okay";
 		compatible = "adi,adp5585";
 		reg = <0x34>;
-		status = "okay";
 
 		gpio_exp0: adp5585_gpio {
+			status = "okay";
 			compatible = "adi,adp5585-gpio";
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -128,7 +128,6 @@
 				line-name = "exp_sel";
 				output-low;
 			};
-			status = "disabled";
 		};
 	};
 };
@@ -160,5 +159,5 @@
 	pinctrl-0 = <&flexcan2_default>;
 	pinctrl-names = "default";
 	phys = <&can_phy0>;
-	status = "okay";
+	status = "disabled";
 };

--- a/samples/drivers/can/babbling/boards/imx93_evk_mimx9352_a55.overlay
+++ b/samples/drivers/can/babbling/boards/imx93_evk_mimx9352_a55.overlay
@@ -1,0 +1,1 @@
+#include "imx93_evk_flexcan2.overlay"

--- a/samples/drivers/can/counter/boards/imx93_evk_mimx9352_a55.overlay
+++ b/samples/drivers/can/counter/boards/imx93_evk_mimx9352_a55.overlay
@@ -1,0 +1,1 @@
+#include "imx93_evk_flexcan2.overlay"

--- a/samples/subsys/canbus/isotp/boards/imx93_evk_mimx9352_a55.overlay
+++ b/samples/subsys/canbus/isotp/boards/imx93_evk_mimx9352_a55.overlay
@@ -1,0 +1,1 @@
+#include "imx93_evk_flexcan2.overlay"

--- a/tests/drivers/can/api/boards/imx93_evk_mimx9352_a55.overlay
+++ b/tests/drivers/can/api/boards/imx93_evk_mimx9352_a55.overlay
@@ -1,0 +1,1 @@
+#include "imx93_evk_flexcan2.overlay"

--- a/tests/drivers/can/host/boards/imx93_evk_mimx9352_a55.overlay
+++ b/tests/drivers/can/host/boards/imx93_evk_mimx9352_a55.overlay
@@ -1,0 +1,1 @@
+#include "imx93_evk_flexcan2.overlay"

--- a/tests/drivers/can/timing/boards/imx93_evk_mimx9352_a55.overlay
+++ b/tests/drivers/can/timing/boards/imx93_evk_mimx9352_a55.overlay
@@ -1,0 +1,1 @@
+#include "imx93_evk_flexcan2.overlay"

--- a/tests/subsys/canbus/isotp/conformance/boards/imx93_evk_mimx9352_a55.overlay
+++ b/tests/subsys/canbus/isotp/conformance/boards/imx93_evk_mimx9352_a55.overlay
@@ -1,0 +1,1 @@
+#include "imx93_evk_flexcan2.overlay"

--- a/tests/subsys/canbus/isotp/implementation/boards/imx93_evk_mimx9352_a55.overlay
+++ b/tests/subsys/canbus/isotp/implementation/boards/imx93_evk_mimx9352_a55.overlay
@@ -1,0 +1,1 @@
+#include "imx93_evk_flexcan2.overlay"


### PR DESCRIPTION
Add imx93_evk to drivers/can/api test

Link to issue: #73757