### PR TITLE
dts: arm: nuvoton: add wdt node of numaker m2l31x

### DIFF
--- a/dts/arm/nuvoton/m2l31x.dtsi
+++ b/dts/arm/nuvoton/m2l31x.dtsi
@@ -386,6 +386,14 @@
 			bosch,mram-cfg = <0x0 12 10 3 3 3 3 3>;
 			status = "disabled";
 		};
+
+		wwdt: watchdog@40096000 {
+			compatible = "nuvoton,numaker-wwdt";
+			reg = <0x40096000 0x10>;
+			interrupts = <9 0>;
+			clocks = <&pcc NUMAKER_WWDT_MODULE NUMAKER_CLK_CLKSEL1_WWDTSEL_LIRC 0>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/tests/drivers/watchdog/wdt_basic_api/boards/numaker_m2l31ki.overlay
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/numaker_m2l31ki.overlay
@@ -1,0 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+&wwdt {
+	status = "okay";
+};


### PR DESCRIPTION
This PR is to add watchdog node of numaker m2l31x dtsi and enable watchdog of numaker_m2l31ki board for wdt-basic-api test.

Pass wdt-basic-api test as:
```
Running TESTSUITE wdt_basic_test_suite
===================================================================
START - test_wdt
Testcase: test_wdt_no_callback
Waiting to restart MCU
Running TESTSUITE wdt_basic_test_suite
===================================================================
START - test_wdt
Testcase: test_wdt_no_callback
Testcase passed
Testcase: test_wdt_callback_1
Waiting to restart MCU
Running TESTSUITE wdt_basic_test_suite
===================================================================
START - test_wdt
Testcase: test_wdt_callback_1
Testcase passed
Testcase: test_wdt_bad_window_max
E: window.max should be non-zero
 PASS - test_wdt in 0.011 seconds
===================================================================
TESTSUITE wdt_basic_test_suite succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [wdt_basic_test_suite]: pass = 1, fail = 0, skip = 0, total = 1 duration = 0.011 seconds
 - PASS - [wdt_basic_test_suite.test_wdt] duration = 0.011 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```
