### PR TITLE
MAINTAINERS: add pdgendt as ethernet collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1250,6 +1250,7 @@ Release Notes:
   collaborators:
     - decsny
     - lmajewski
+    - pdgendt
   files:
     - drivers/ethernet/
     - include/zephyr/dt-bindings/ethernet/


### PR DESCRIPTION
Propose to help out for ethernet driver subsystem.