### PR TITLE
mqtt: doc: remove Unicode "fullwidth left parenthesis" from code comment

### DIFF
--- a/include/zephyr/shell/shell_mqtt.h
+++ b/include/zephyr/shell/shell_mqtt.h
@@ -120,7 +120,7 @@ struct shell_mqtt {
 const struct shell *shell_backend_mqtt_get_ptr(void);
 
 /**
- * @brief Function to define the device ID （devid) for which the shell mqtt backend uses as a
+ * @brief Function to define the device ID (devid) for which the shell mqtt backend uses as a
  * client ID when it connects to the broker. It will publish its output to devid_tx and subscribe
  * to devid_rx for input .
  *


### PR DESCRIPTION
Fix Doxygen comment for shell_mqtt_get_devid which contained a funky Unicode char (U+FF08, `（`) for a left parenthesis that can cause issues with some documentation tools.