### PR TITLE
LE Audio: Fix issue wth cap_stream for non-ARM builds

### DIFF
--- a/subsys/bluetooth/audio/cap_stream.c
+++ b/subsys/bluetooth/audio/cap_stream.c
@@ -6,6 +6,7 @@
 
 #include <errno.h>
 #include <stddef.h>
+#include <stdbool.h>
 #include <stdint.h>
 
 #include <zephyr/autoconf.h>
@@ -25,9 +26,9 @@
 
 LOG_MODULE_REGISTER(bt_cap_stream, CONFIG_BT_CAP_STREAM_LOG_LEVEL);
 
-static bool is_cap_initiator_unicast(struct bt_bap_stream *bap_stream)
+static bool stream_is_central(struct bt_bap_stream *bap_stream)
 {
-	if (IS_ENABLED(CONFIG_BT_CAP_INITIATOR) && IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT)) {
+	if (IS_ENABLED(CONFIG_BT_CONN)) {
 		struct bt_conn_info info;
 		int err;
 
@@ -55,7 +56,8 @@ static void cap_stream_configured_cb(struct bt_bap_stream *bap_stream,
 
 	LOG_DBG("%p", cap_stream);
 
-	if (is_cap_initiator_unicast(bap_stream)) {
+	if (IS_ENABLED(CONFIG_BT_CAP_INITIATOR) && IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) &&
+	    stream_is_central(bap_stream)) {
 		bt_cap_initiator_codec_configured(cap_stream);
 	}
 
@@ -73,7 +75,8 @@ static void cap_stream_qos_set_cb(struct bt_bap_stream *bap_stream)
 
 	LOG_DBG("%p", cap_stream);
 
-	if (is_cap_initiator_unicast(bap_stream)) {
+	if (IS_ENABLED(CONFIG_BT_CAP_INITIATOR) && IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) &&
+	    stream_is_central(bap_stream)) {
 		bt_cap_initiator_qos_configured(cap_stream);
 	}
 
@@ -91,7 +94,8 @@ static void cap_stream_enabled_cb(struct bt_bap_stream *bap_stream)
 
 	LOG_DBG("%p", cap_stream);
 
-	if (is_cap_initiator_unicast(bap_stream)) {
+	if (IS_ENABLED(CONFIG_BT_CAP_INITIATOR) && IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) &&
+	    stream_is_central(bap_stream)) {
 		bt_cap_initiator_enabled(cap_stream);
 	}
 
@@ -109,7 +113,8 @@ static void cap_stream_metadata_updated_cb(struct bt_bap_stream *bap_stream)
 
 	LOG_DBG("%p", cap_stream);
 
-	if (is_cap_initiator_unicast(bap_stream)) {
+	if (IS_ENABLED(CONFIG_BT_CAP_INITIATOR) && IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) &&
+	    stream_is_central(bap_stream)) {
 		bt_cap_initiator_metadata_updated(cap_stream);
 	}
 
@@ -141,7 +146,7 @@ static void cap_stream_released_cb(struct bt_bap_stream *bap_stream)
 
 	LOG_DBG("%p", cap_stream);
 
-	/* Here we cannot use is_cap_initiator_unicast as bap_stream->conn is NULL, so fall back to
+	/* Here we cannot use stream_is_central as bap_stream->conn is NULL, so fall back to
 	 * a more generic, less accurate check
 	 */
 	if (IS_ENABLED(CONFIG_BT_CAP_INITIATOR) && IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT)) {
@@ -164,7 +169,8 @@ static void cap_stream_started_cb(struct bt_bap_stream *bap_stream)
 
 	LOG_DBG("%p", cap_stream);
 
-	if (is_cap_initiator_unicast(bap_stream)) {
+	if (IS_ENABLED(CONFIG_BT_CAP_INITIATOR) && IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) &&
+	    stream_is_central(bap_stream)) {
 		bt_cap_initiator_started(cap_stream);
 	}
 
@@ -222,7 +228,8 @@ static void cap_stream_connected_cb(struct bt_bap_stream *bap_stream)
 		CONTAINER_OF(bap_stream, struct bt_cap_stream, bap_stream);
 	struct bt_bap_stream_ops *ops = cap_stream->ops;
 
-	if (is_cap_initiator_unicast(bap_stream)) {
+	if (IS_ENABLED(CONFIG_BT_CAP_INITIATOR) && IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) &&
+	    stream_is_central(bap_stream)) {
 		bt_cap_initiator_connected(cap_stream);
 	}
 

--- a/tests/bluetooth/shell/testcase.yaml
+++ b/tests/bluetooth/shell/testcase.yaml
@@ -333,11 +333,25 @@ tests:
     build_only: true
     extra_configs:
       - CONFIG_BT_CAP_ACCEPTOR_SET_MEMBER=n
+  bluetooth.audio_shell.only_cap_acceptor:
+    extra_args: CONF_FILE="audio.conf"
+    build_only: true
+    extra_configs:
+      - CONFIG_BT_BAP_UNICAST_CLIENT=n
+      - CONFIG_BT_CAP_INITIATOR=n
+      - CONFIG_BT_CAP_COMMANDER=n
   bluetooth.audio_shell.no_cap_initiator:
     extra_args: CONF_FILE="audio.conf"
     build_only: true
     extra_configs:
       - CONFIG_BT_CAP_INITIATOR=n
+  bluetooth.audio_shell.only_cap_initiator:
+    extra_args: CONF_FILE="audio.conf"
+    build_only: true
+    extra_configs:
+      - CONFIG_BT_BAP_UNICAST_SERVER=n
+      - CONFIG_BT_CAP_ACCEPTOR=n
+      - CONFIG_BT_CAP_COMMANDER=n
   bluetooth.audio_shell.no_gmap:
     extra_args: CONF_FILE="audio.conf"
     build_only: true
@@ -350,6 +364,14 @@ tests:
     platform_allow: native_posix
     extra_configs:
       - CONFIG_BT_CAP_COMMANDER=n
+  bluetooth.audio_shell.only_cap_commander:
+    extra_args: CONF_FILE="audio.conf"
+    build_only: true
+    platform_allow: native_posix
+    extra_configs:
+      - CONFIG_BT_BAP_UNICAST_CLIENT=n
+      - CONFIG_BT_CAP_ACCEPTOR=n
+      - CONFIG_BT_CAP_INITIATOR=n
   bluetooth.audio_shell.no_lc3:
     extra_args: CONF_FILE="audio.conf"
     build_only: true


### PR DESCRIPTION
The current version of the file and how it used IS_ENABLED seemingly did not work for e.g. the BSIM and native posix builds (https://github.com/zephyrproject-rtos/zephyr/actions/runs/9357616500/job/25825761204?pr=72075). This commit should fix that by using IS_ENABLED directly. 