### PR TITLE
drivers: ethernet: stm32 eth hal driver align PTP Config Status

### DIFF
--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -1823,7 +1823,7 @@ static int ptp_stm32_init(const struct device *port)
 
 #if defined(CONFIG_ETH_STM32_HAL_API_V2)
 	/* Set PTP Configuration done */
-	heth->IsPtpConfigured = HAL_ETH_PTP_CONFIGURATED;
+	heth->IsPtpConfigured = ETH_STM32_PTP_CONFIGURED;
 #endif
 
 	return 0;

--- a/drivers/ethernet/eth_stm32_hal_priv.h
+++ b/drivers/ethernet/eth_stm32_hal_priv.h
@@ -9,6 +9,15 @@
 #include <zephyr/kernel.h>
 #include <zephyr/types.h>
 
+/* Naming of the  ETH PTP Config Status changes depending on the stm32 serie */
+#if defined(CONFIG_SOC_SERIES_STM32F7X) || defined(CONFIG_SOC_SERIES_STM32F4X)
+#define ETH_STM32_PTP_CONFIGURED HAL_ETH_PTP_CONFIGURATED
+#define ETH_STM32_PTP_NOT_CONFIGURED HAL_ETH_PTP_NOT_CONFIGURATED
+#else
+#define ETH_STM32_PTP_CONFIGURED HAL_ETH_PTP_CONFIGURED
+#define ETH_STM32_PTP_NOT_CONFIGURED HAL_ETH_PTP_NOT_CONFIGURED
+#endif /* stm32F7x or sm32F4x */
+
 #define ST_OUI_B0 0x00
 #define ST_OUI_B1 0x80
 #define ST_OUI_B2 0xE1

--- a/samples/net/gptp/sample.yaml
+++ b/samples/net/gptp/sample.yaml
@@ -17,6 +17,7 @@ tests:
       - native_sim/native/64
       - nucleo_f767zi
       - nucleo_h743zi
+      - nucleo_h753zi
       - nucleo_h745zi_q/stm32h745xx/m7
     depends_on: eth
     integration_platforms:


### PR DESCRIPTION
Align the name of the ETH PTP Config Status values depending on the stm32HAL serie for the ones with CONFIG_ETH_STM32_HAL_API_V2, to be either

- HAL_ETH_PTP_NOT_CONFIGURATED/HAL_ETH_PTP_CONFIGURATED  for the stm32F7x or stm32F4x
- HAL_ETH_PTP_NOT_CONFIGURED/HAL_ETH_PTP_CONFIGURED  for other series

This will fix the build error on nucleo_h753zi 
$ west build -p auto -b nucleo_h753zi samples/net/gptp/
```
./drivers/ethernet/eth_stm32_hal.c:1826:33: error: 'HAL_ETH_PTP_CONFIGURATED' undeclared (first use in this function); did you mean 'HAL_ETH_PTP_CONFIGURED'?
 1826 |         heth->IsPtpConfigured = HAL_ETH_PTP_CONFIGURATED;
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~
      |                                 HAL_ETH_PTP_CONFIGURED

```