### PR TITLE
boards: nordic: nrf54h20dk: add custom JLink reset scheme

### DIFF
--- a/boards/nordic/nrf54h20dk/board.cmake
+++ b/boards/nordic/nrf54h20dk/board.cmake
@@ -3,13 +3,12 @@
 include(${ZEPHYR_BASE}/boards/common/nrfutil.board.cmake)
 
 if(CONFIG_BOARD_NRF54H20DK_NRF54H20_CPUAPP OR CONFIG_BOARD_NRF54H20DK_NRF54H20_CPURAD)
-  if(CONFIG_BOARD_NRF54H20DK_NRF54H20_CPURAD)
-    set(
-      JLINK_TOOL_OPT
-      "-jlinkscriptfile ${CMAKE_CURRENT_LIST_DIR}/support/nrf54h20_cpurad.JLinkScript"
-    )
+  if(CONFIG_BOARD_NRF54H20DK_NRF54H20_CPUAPP)
+    set(JLINKSCRIPTFILE ${CMAKE_CURRENT_LIST_DIR}/support/nrf54h20_cpuapp.JLinkScript)
+  else()
+    set(JLINKSCRIPTFILE ${CMAKE_CURRENT_LIST_DIR}/support/nrf54h20_cpurad.JLinkScript)
   endif()
 
-  board_runner_args(jlink "--device=CORTEX-M33" "--speed=4000" "--tool-opt=${JLINK_TOOL_OPT}")
+  board_runner_args(jlink "--device=CORTEX-M33" "--speed=4000" "--tool-opt=-jlinkscriptfile ${JLINKSCRIPTFILE}")
   include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 endif()

--- a/boards/nordic/nrf54h20dk/support/nrf54h20_cpuapp.JLinkScript
+++ b/boards/nordic/nrf54h20dk/support/nrf54h20_cpuapp.JLinkScript
@@ -10,21 +10,14 @@ __constant U32 _DEMCR_VC_CORERESET = (1 <<  0);
 __constant U32 _DEMCR_TRCENA       = (1 << 24);
 
 // CPU wait enable register
-__constant U32 _CPUCONF_CPUWAIT_ADDR = 0x5301150C;
-
-int ConfigTargetSettings(void) {
-	JLINK_ExecCommand("CORESIGHT_AddAP = Index=1 Type=AHB-AP");
-	CORESIGHT_IndexAHBAPToUse = 1;
-
-	return 0;
-}
+__constant U32 _CPUCONF_CPUWAIT_ADDR = 0x5201150C;
 
 int ResetTarget(void) {
 	// ADAC reset
 	JLINK_CORESIGHT_WriteDP(2, 0x04000010);
 	JLINK_CORESIGHT_WriteAP(0, 0xA3030000);
 	JLINK_CORESIGHT_WriteAP(0, 0x00000004);
-	JLINK_CORESIGHT_WriteAP(0, 0x01030000);
+	JLINK_CORESIGHT_WriteAP(0, 0x01020000);
 
 	JLINK_SYS_Sleep(100);
 	JLINK_CORESIGHT_ReadAP(2);


### PR DESCRIPTION
A custom reset scheme is required for the nRF54H20 SoC so that debug works out of the box. This magic will eventually be part of JLink.