### PR TITLE
kernel: added missing parenthesis

### DIFF
--- a/include/zephyr/spinlock.h
+++ b/include/zephyr/spinlock.h
@@ -437,7 +437,7 @@ static ALWAYS_INLINE void z_spin_onexit(__maybe_unused k_spinlock_key_t *k)
  */
 #define K_SPINLOCK(lck)                                                                            \
 	for (k_spinlock_key_t __i K_SPINLOCK_ONEXIT = {}, __key = k_spin_lock(lck); !__i.key;      \
-	     k_spin_unlock(lck, __key), __i.key = 1)
+	     k_spin_unlock((lck), __key), __i.key = 1)
 
 /** @} */
 

--- a/kernel/include/mmu.h
+++ b/kernel/include/mmu.h
@@ -47,8 +47,8 @@
  * been remapped or paged out. Never use this unless you know exactly what you
  * are doing.
  */
-#define Z_BOOT_VIRT_TO_PHYS(virt) ((uintptr_t)(((uint8_t *)virt) - Z_VM_OFFSET))
-#define Z_BOOT_PHYS_TO_VIRT(phys) ((uint8_t *)(((uintptr_t)phys) + Z_VM_OFFSET))
+#define Z_BOOT_VIRT_TO_PHYS(virt) ((uintptr_t)(((uint8_t *)(virt)) - Z_VM_OFFSET))
+#define Z_BOOT_PHYS_TO_VIRT(phys) ((uint8_t *)(((uintptr_t)(phys)) + Z_VM_OFFSET))
 
 #ifdef CONFIG_ARCH_MAPS_ALL_RAM
 #define Z_FREE_VM_START	Z_BOOT_PHYS_TO_VIRT(Z_PHYS_RAM_END)
@@ -253,9 +253,9 @@ void z_page_frames_dump(void);
 
 /* Convenience macro for iterating over all page frames */
 #define Z_PAGE_FRAME_FOREACH(_phys, _pageframe) \
-	for (_phys = Z_PHYS_RAM_START, _pageframe = z_page_frames; \
-	     _phys < Z_PHYS_RAM_END; \
-	     _phys += CONFIG_MMU_PAGE_SIZE, _pageframe++)
+	for ((_phys) = Z_PHYS_RAM_START, (_pageframe) = z_page_frames; \
+	     (_phys) < Z_PHYS_RAM_END; \
+	     (_phys) += CONFIG_MMU_PAGE_SIZE, (_pageframe)++)
 
 #ifdef CONFIG_DEMAND_PAGING
 /* We reserve a virtual page as a scratch area for page-ins/outs at the end

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -133,12 +133,12 @@ void z_page_frames_dump(void)
 /* LCOV_EXCL_STOP */
 
 #define VIRT_FOREACH(_base, _size, _pos) \
-	for (_pos = _base; \
-	     _pos < ((uint8_t *)_base + _size); _pos += CONFIG_MMU_PAGE_SIZE)
+	for ((_pos) = (_base); \
+	     (_pos) < ((uint8_t *)(_base) + (_size)); (_pos) += CONFIG_MMU_PAGE_SIZE)
 
 #define PHYS_FOREACH(_base, _size, _pos) \
-	for (_pos = _base; \
-	     _pos < ((uintptr_t)_base + _size); _pos += CONFIG_MMU_PAGE_SIZE)
+	for ((_pos) = (_base); \
+	     (_pos) < ((uintptr_t)(_base) + (_size)); (_pos) += CONFIG_MMU_PAGE_SIZE)
 
 
 /*


### PR DESCRIPTION
Added missing parentheses around macro argument expansion.

This corresponds to following coding guideline:

> Expressions resulting from the expansion of macro parameters shall be enclosed in parentheses

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/3c1d1a11e97c1306d85977140905b22ab7f8b31e