### PR TITLE
lib: added missing parenthesis

### DIFF
--- a/lib/libc/minimal/source/stdout/fprintf.c
+++ b/lib/libc/minimal/source/stdout/fprintf.c
@@ -10,7 +10,7 @@
 #include <stdio.h>
 #include <zephyr/sys/cbprintf.h>
 
-#define DESC(d) ((void *)d)
+#define DESC(d) ((void *)(d))
 
 int fprintf(FILE *ZRESTRICT stream, const char *ZRESTRICT format, ...)
 {

--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -1364,7 +1364,7 @@ int z_cbvprintf_impl(cbprintf_cb out, void *ctx, const char *fp,
  */
 
 #define OUTS(_sp, _ep) do { \
-	int rc = outs(out, ctx, _sp, _ep); \
+	int rc = outs(out, ctx, (_sp), (_ep)); \
 	\
 	if (rc < 0) {	    \
 		return rc; \

--- a/lib/utils/bitarray.c
+++ b/lib/utils/bitarray.c
@@ -13,7 +13,7 @@
 #include <zephyr/sys/sys_io.h>
 
 /* Number of bits represented by one bundle */
-#define bundle_bitness(ba)	(sizeof(ba->bundles[0]) * 8)
+#define bundle_bitness(ba)	(sizeof((ba)->bundles[0]) * 8)
 
 struct bundle_data {
 	 /* Start and end index of bundles */


### PR DESCRIPTION
Added missing parentheses around macro argument expansion.

This corresponds to following coding guideline:

> Expressions resulting from the expansion of macro parameters shall be enclosed in parentheses

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/3c1d1a11e97c1306d85977140905b22ab7f8b31e