### PR TITLE
lib: libc: make char subtractions compliant with coding guidelines

### DIFF
--- a/lib/libc/minimal/source/stdlib/strtol.c
+++ b/lib/libc/minimal/source/stdlib/strtol.c
@@ -96,9 +96,9 @@ long strtol(const char *nptr, char **endptr, register int base)
 	cutoff /= (unsigned long)base;
 	for (acc = 0, any = 0;; c = *s++) {
 		if (isdigit((unsigned char)c) != 0) {
-			c -= '0';
+			c = (char)c - '0';
 		} else if (isalpha((unsigned char)c) != 0) {
-			c -= isupper((unsigned char)c) != 0 ? 'A' - 10 : 'a' - 10;
+			c = (char)c - (isupper(c) != 0 ? 'A' : 'a') + 10;
 		} else {
 			break;
 		}

--- a/lib/libc/minimal/source/stdlib/strtoul.c
+++ b/lib/libc/minimal/source/stdlib/strtoul.c
@@ -76,9 +76,9 @@ unsigned long strtoul(const char *nptr, char **endptr, register int base)
 	cutlim = (unsigned long)ULONG_MAX % (unsigned long)base;
 	for (acc = 0, any = 0;; c = *s++) {
 		if (isdigit((unsigned char)c) != 0) {
-			c -= '0';
+			c = (char)c - '0';
 		} else if (isalpha((unsigned char)c) != 0) {
-			c -= isupper((unsigned char)c) != 0 ? 'A' - 10 : 'a' - 10;
+			c = (char)c - (isupper(c) != 0 ? 'A' : 'a') + 10;
 		} else {
 			break;
 		}


### PR DESCRIPTION
Use the compliant form char - integer instead of the non-compliant one integer - char.

This corresponds to following coding guideline:

> Expressions of essentially character type shall not be used inappropriately in addition and subtraction operations

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/63afaf742a412e67270155b06a661a43e669ec6d