### PR TITLE
doc: Unconditionally enable sphinxcontrib.rsvgconverter

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -174,7 +174,6 @@ add_doc_target(
     -d ${DOCS_DOCTREE_DIR}
     -w ${DOCS_BUILD_DIR}/latex.log
     -t ${DOC_TAG}
-    -t svgconvert
     ${SPHINXOPTS}
     ${SPHINXOPTS_EXTRA}
     ${DOCS_SRC_DIR}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -80,6 +80,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.graphviz",
     "sphinxcontrib.jquery",
+    "sphinxcontrib.rsvgconverter",
     "zephyr.application",
     "zephyr.html_redirects",
     "zephyr.kconfig",
@@ -98,10 +99,6 @@ extensions = [
     "zephyr.domain",
     "zephyr.api_overview",
 ]
-
-# Only use SVG converter when it is really needed, e.g. LaTeX.
-if tags.has("svgconvert"):  # pylint: disable=undefined-variable
-    extensions.append("sphinxcontrib.rsvgconverter")
 
 templates_path = ["_templates"]
 


### PR DESCRIPTION
Sphinx's image conversion logic is smart enough that converters are only kicking in when actually needed. For example, HTML builder indicates it can handle SVG images just fine, so the rsvg converter is not solicited for HTML builds.

This commit proposes to simplify the doc build and configuration by unconditionally enabling sphinxcontrib.rsvgconverter.