### PR TITLE
tests: lwm2m: Allow server address to be changed

### DIFF
--- a/tests/net/lib/lwm2m/interop/testcase.yaml
+++ b/tests/net/lib/lwm2m/interop/testcase.yaml
@@ -5,7 +5,6 @@ tests:
     slow: true
     harness_config:
       pytest_dut_scope: module
-      pytest_args: []
     integration_platforms:
       - native_sim
     platform_allow:


### PR DESCRIPTION
Allow changing the target server address on interoperability tests.
This allows running same testcases against public Leshan instance. It is a first requirement to run same tests on a real HW.

## Example

```
twister -p native_sim -c -vv --inline-logs -S -T $ZEPHYR_BASE/tests/net/lib/lwm2m/interop --pytest-args='--passwd=salasana' --pytest-args='-k=1_1_int_102' --pytest-args='--leshan_addr=leshan.eclipseprojects.io' --pytest-args='--leshan_rest_api=https://leshan.eclipseprojects.io/api' --pytest-args='--leshan_bootstrap_rest_api=https://leshan.eclipseprojects.io/bs/api'
```
