### PR TITLE
modules: hal_nordic: dvfs: added callback when scaling done

### DIFF
--- a/modules/hal_nordic/nrfs/dvfs/Kconfig
+++ b/modules/hal_nordic/nrfs/dvfs/Kconfig
@@ -26,6 +26,11 @@ config NRFS_LOCAL_DOMAIN_DOWNSCALE_SAFETY_TIMEOUT_US
 	default 1000000 if (NRFS_LOCAL_DOMAIN_DVFS_TEST || LOG)
 	default 1500
 
+config NRFS_LOCAL_DOMAIN_DOWNSCALE_FINISH_DELAY_TIMEOUT_US
+	int "Additional delay to let secdom finish dowscale procedure in us"
+	range 1 10000000
+	default 1000
+
 config NRFS_LOCAL_DOMAIN_DVFS_HANDLER_TASK_STACK_SIZE
 	int "Stack size used for DVFS handling task"
 	range 256 2048

--- a/modules/hal_nordic/nrfs/dvfs/ld_dvfs_handler.h
+++ b/modules/hal_nordic/nrfs/dvfs/ld_dvfs_handler.h
@@ -17,7 +17,7 @@ extern "C" {
  * @brief Function to request LD frequency change.
  *
  * @param frequency requested frequency setting from enum dvfs_frequency_setting.
- * @return EBUSY                  Frequency change in progress.
+ * @return EBUSY                  Frequency change request pending.
  * @return EAGAIN                 DVFS init in progress.
  * @return ENXIO                  Not supported frequency settings.
  * @return NRFS_SUCCESS           Request sent successfully.
@@ -25,6 +25,20 @@ extern "C" {
  * @return NRFS_ERR_IPC           Backend returned error during request sending.
  */
 int32_t dvfs_service_handler_change_freq_setting(enum dvfs_frequency_setting freq_setting);
+
+/**
+ * @brief Type to use as callback function in dvfs service
+ *
+ * @param new_setting applied frequency setting
+ */
+typedef void (*dvfs_service_handler_callback)(enum dvfs_frequency_setting new_setting);
+
+/**
+ * @brief Register callback function which will be called when new dvfs frequency is applied.
+ *
+ * @param clb dvfs_service_handler_callback to register
+ */
+void dvfs_service_handler_register_freq_setting_applied_callback(dvfs_service_handler_callback clb);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
User can assign callback function to local domain dvfs handler and get notification when scaling process is finished for particular domain.
Reworked usage of DVFS_SERV_HDL_FREQ_CHANGE_IN_PROGRESS_BIT_POS which was not initialized properly.