### PR TITLE
lib: utils: avoid Boolean-to-integer type casts

### DIFF
--- a/lib/utils/timeutil.c
+++ b/lib/utils/timeutil.c
@@ -148,7 +148,7 @@ int timeutil_sync_ref_from_local(const struct timeutil_sync_state *tsp,
 			rv = -ERANGE;
 		} else {
 			*refp = ref_abs;
-			rv = (int)(tsp->skew != 1.0f);
+			rv = (tsp->skew != 1.0f) ? 1 : 0;
 		}
 	}
 
@@ -175,7 +175,7 @@ int timeutil_sync_local_from_ref(const struct timeutil_sync_state *tsp,
 				    + (int64_t)local_delta;
 
 		*localp = local_abs;
-		rv = (int)(tsp->skew != 1.0f);
+		rv = (tsp->skew != 1.0f) ? 1 : 0;
 	}
 
 	return rv;


### PR DESCRIPTION
Avoid casting expression to an inappropriate essential type.

This corresponds to following coding guideline:

> The value of an expression should not be cast to an inappropriate essential type

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/7eadb9c5eb347da53dd453bd23eb6a91d4375ebb