### PR TITLE
doc: mcumgr: fix mixed up occurrences of :c:enum: and :c:enumerator:

### DIFF
--- a/doc/services/device_mgmt/mcumgr_callbacks.rst
+++ b/doc/services/device_mgmt/mcumgr_callbacks.rst
@@ -192,7 +192,7 @@ the file should be allowed or not, note that this requires that
 :kconfig:option:`CONFIG_MCUMGR_GRP_FS_FILE_ACCESS_HOOK` be enabled to receive
 this callback.
 Two types of errors can be returned, the ``rc`` parameter can be set to an
-:c:enumerator:`mcumgr_err_t` error code and :c:enumerator:`MGMT_CB_ERROR_RC`
+:c:enum:`mcumgr_err_t` error code and :c:enumerator:`MGMT_CB_ERROR_RC`
 can be returned, or a group error code (introduced with version 2 of the MCUmgr
 protocol) can be set by setting the ``group`` value to the group and ``rc``
 value to the group error code and returning :c:enumerator:`MGMT_CB_ERROR_ERR`.
@@ -330,4 +330,3 @@ API Reference
 *************
 
 .. doxygengroup:: mcumgr_callback_api
-    :inner:

--- a/doc/services/device_mgmt/mcumgr_handlers.rst
+++ b/doc/services/device_mgmt/mcumgr_handlers.rst
@@ -52,8 +52,8 @@ responses (which have unique error codes per group as opposed to the legacy SMP 
 responses that return a :c:enum:`mcumgr_err_t` - there should always be an OK error code with the
 value 0 and an unknown error code with the value 1. The above example then adds an error code of
 ``not wanted`` with value 2. In addition, the group ID is set to be
-:c:enum:`MGMT_GROUP_ID_PERUSER`, which is the start group ID for user-defined groups, note that
-group IDs need to be unique so other custom groups should use different values, a central index
+:c:enumerator:`MGMT_GROUP_ID_PERUSER`, which is the start group ID for user-defined groups, note
+that group IDs need to be unique so other custom groups should use different values, a central index
 header file (as upstream Zephyr has) can be used to distribute group IDs more easily.
 
 Initial header <grp_name>_mgmt_callbacks.h
@@ -70,7 +70,7 @@ file would look similar to:
 This sets up a single event which application (or module) code can register for to receive a
 callback when the function handler is executed, which allows the flow of the handler to be
 changed (i.e. to return an error instead of continuing). The event group ID is set to
-:c:enum:`MGMT_EVT_GRP_USER_CUSTOM_START`, which is the start event ID for user-defined groups,
+:c:enumerator:`MGMT_EVT_GRP_USER_CUSTOM_START`, which is the start event ID for user-defined groups,
 note that event IDs need to be unique so other custom groups should use different values, a
 central index header file (as upstream Zephyr has) can be used to distribute event IDs more
 easily.

--- a/doc/services/device_mgmt/smp_groups/smp_group_0.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_0.rst
@@ -563,7 +563,7 @@ System reset request header fields:
     +--------+--------------+----------------+
 
 Normally the command sends an empty CBOR map as data, but if a previous reset
-attempt has responded with "rc" equal to :c:enum:`MGMT_ERR_EBUSY` then the
+attempt has responded with "rc" equal to :c:enumerator:`MGMT_ERR_EBUSY` then the
 following map may be sent to force a reset:
 
 .. code-block:: none

--- a/doc/services/device_mgmt/smp_groups/smp_group_1.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_1.rst
@@ -204,7 +204,7 @@ where:
     |                  | using SMP version 1 or for SMP errors when using SMP version 2.         |
     +------------------+-------------------------------------------------------------------------+
     | "rsn"            | optional string that clarifies reason for an error; specifically useful |
-    |                  | when ``rc`` is :c:enum:`MGMT_ERR_EUNKNOWN`.                             |
+    |                  | when ``rc`` is :c:enumerator:`MGMT_ERR_EUNKNOWN`.                       |
     +------------------+-------------------------------------------------------------------------+
 
 .. note::
@@ -407,7 +407,7 @@ where:
     |                  | using SMP version 1 or for SMP errors when using SMP version 2.         |
     +------------------+-------------------------------------------------------------------------+
     | "rsn"            | optional string that clarifies reason for an error; specifically useful |
-    |                  | when ``rc`` is :c:enum:`MGMT_ERR_EUNKNOWN`.                             |
+    |                  | when ``rc`` is :c:enumerator:`MGMT_ERR_EUNKNOWN`.                       |
     +------------------+-------------------------------------------------------------------------+
 
 The "off" field is only included in responses to successfully processed requests;
@@ -509,10 +509,10 @@ where:
     |                  | using SMP version 1 or for SMP errors when using SMP version 2.         |
     +------------------+-------------------------------------------------------------------------+
     | "rsn"            | optional string that clarifies reason for an error; specifically useful |
-    |                  | when ``rc`` is :c:enum:`MGMT_ERR_EUNKNOWN`.                             |
+    |                  | when ``rc`` is :c:enumerator:`MGMT_ERR_EUNKNOWN`.                       |
     +------------------+-------------------------------------------------------------------------+
 
 .. note::
     Response from Zephyr running device may have "rc" value of
-    :c:enum:`MGMT_ERR_EBADSTATE`, which means that the secondary
+    :c:enumerator:`MGMT_ERR_EBADSTATE`, which means that the secondary
     image has been marked for next boot already and may not be erased.

--- a/doc/services/device_mgmt/smp_groups/smp_group_3.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_3.rst
@@ -542,5 +542,5 @@ There is a settings access MCUmgr callback available (see :ref:`mcumgr_callbacks
 callbacks) which allows for applications/modules to know when settings management commands are
 used and, optionally, block access (for example through the use of a security mechanism). This
 callback can be enabled with :kconfig:option:`CONFIG_MCUMGR_GRP_SETTINGS_ACCESS_HOOK`, registered
-with the event :c:enum:`MGMT_EVT_OP_SETTINGS_MGMT_ACCESS`, whereby the supplied callback data is
-:c:struct:`settings_mgmt_access`.
+with the event :c:enumerator:`MGMT_EVT_OP_SETTINGS_MGMT_ACCESS`, whereby the supplied callback data
+is :c:struct:`settings_mgmt_access`.

--- a/doc/services/device_mgmt/smp_groups/smp_group_8.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_8.rst
@@ -47,7 +47,7 @@ requests or even be removed.
     However, if the Kconfig option
     :kconfig:option:`CONFIG_MCUMGR_GRP_FS_FILE_ACCESS_HOOK` is enabled, then an
     application can register a callback handler for
-    :c:enum:`MGMT_EVT_OP_FS_MGMT_FILE_ACCESS` (see
+    :c:enumerator:`MGMT_EVT_OP_FS_MGMT_FILE_ACCESS` (see
     :ref:`MCUmgr callbacks <mcumgr_callbacks>`), which allows for allowing or
     declining access to reading/writing a particular file, or for rewriting the
     path supplied by the client.
@@ -185,7 +185,7 @@ change between requests or even be removed.
     However, if the Kconfig option
     :kconfig:option:`CONFIG_MCUMGR_GRP_FS_FILE_ACCESS_HOOK` is enabled, then an
     application can register a callback handler for
-    :c:enum:`MGMT_EVT_OP_FS_MGMT_FILE_ACCESS` (see
+    :c:enumerator:`MGMT_EVT_OP_FS_MGMT_FILE_ACCESS` (see
     :ref:`MCUmgr callbacks <mcumgr_callbacks>`), which allows for allowing or
     declining access to reading/writing a particular file, or for rewriting the
     path supplied by the client.


### PR DESCRIPTION
While Breathe seems to not care and creates hyperlinks either way, the proper role to mention a C enumerator is `:c:enumerator:`. `:c:enum:` is to be used to refer to the enum itself.