### PR TITLE
twister: Add means for requiring sysbuild from platform level

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.yaml
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.yaml
@@ -9,6 +9,7 @@ toolchain:
   - gnuarmemb
   - xtools
   - zephyr
+sysbuild: true
 ram: 256
 flash: 296
 supported:

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuppr.yaml
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuppr.yaml
@@ -7,6 +7,7 @@ type: mcu
 arch: riscv
 toolchain:
   - zephyr
+sysbuild: true
 ram: 62
 flash: 62
 supported:

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuppr_xip.yaml
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuppr_xip.yaml
@@ -7,6 +7,7 @@ type: mcu
 arch: riscv
 toolchain:
   - zephyr
+sysbuild: true
 ram: 62
 flash: 64
 supported:

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.yaml
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.yaml
@@ -9,6 +9,7 @@ toolchain:
   - gnuarmemb
   - xtools
   - zephyr
+sysbuild: true
 ram: 192
 flash: 256
 supported:

--- a/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15_cpuapp.yaml
+++ b/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15_cpuapp.yaml
@@ -9,6 +9,7 @@ toolchain:
   - gnuarmemb
   - xtools
   - zephyr
+sysbuild: true
 ram: 188
 flash: 324
 supported:

--- a/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15_cpuflpr.yaml
+++ b/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15_cpuflpr.yaml
@@ -7,6 +7,7 @@ type: mcu
 arch: riscv
 toolchain:
   - zephyr
+sysbuild: true
 ram: 96
 flash: 96
 supported:

--- a/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15_cpuflpr_xip.yaml
+++ b/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15_cpuflpr_xip.yaml
@@ -7,6 +7,7 @@ type: mcu
 arch: riscv
 toolchain:
   - zephyr
+sysbuild: true
 ram: 68
 flash: 96
 supported:

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -153,7 +153,7 @@ class Handler:
         self.instance.record(harness.recording)
 
     def get_default_domain_build_dir(self):
-        if self.instance.testsuite.sysbuild:
+        if self.instance.sysbuild:
             # Load domain yaml to get default domain build directory
             # Note: for targets using QEMU, we assume that the target will
             # have added any additional images to the run target manually

--- a/scripts/pylib/twister/twisterlib/platform.py
+++ b/scripts/pylib/twister/twisterlib/platform.py
@@ -24,6 +24,8 @@ class Platform:
 
         self.name = ""
         self.normalized_name = ""
+        # if sysbuild to be used by default on a given platform
+        self.sysbuild = False
         self.twister = True
         # if no RAM size is specified by the board, take a default of 128K
         self.ram = 128
@@ -56,6 +58,7 @@ class Platform:
 
         self.name = data['identifier']
         self.normalized_name = self.name.replace("/", "_")
+        self.sysbuild = data.get("sysbuild", False)
         self.twister = data.get("twister", True)
         # if no RAM size is specified by the board, take a default of 128K
         self.ram = data.get("ram", 128)

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -335,7 +335,7 @@ class CMake:
             gen_defines_args = ""
 
         warning_command = 'CONFIG_COMPILER_WARNINGS_AS_ERRORS'
-        if self.testsuite.sysbuild:
+        if self.instance.sysbuild:
             warning_command = 'SB_' + warning_command
 
         logger.debug("Running cmake on %s for %s" % (self.source_dir, self.platform.name))
@@ -357,7 +357,7 @@ class CMake:
                 f'-P{canonical_zephyr_base}/cmake/package_helper.cmake',
             ]
 
-        if self.testsuite.sysbuild and not filter_stages:
+        if self.instance.sysbuild and not filter_stages:
             logger.debug("Building %s using sysbuild" % (self.source_dir))
             source_args = [
                 f'-S{canonical_zephyr_base}/share/sysbuild',
@@ -445,7 +445,7 @@ class FilterBuilder(CMake):
         if self.platform.name == "unit_testing":
             return {}
 
-        if self.testsuite.sysbuild and not filter_stages:
+        if self.instance.sysbuild and not filter_stages:
             # Load domain yaml to get default domain build directory
             domain_path = os.path.join(self.build_dir, "domains.yaml")
             domains = Domains.from_file(domain_path)
@@ -498,7 +498,7 @@ class FilterBuilder(CMake):
             filter_data.update(self.defconfig)
         filter_data.update(self.cmake_cache)
 
-        if self.testsuite.sysbuild and self.env.options.device_testing:
+        if self.instance.sysbuild and self.env.options.device_testing:
             # Verify that twister's arguments support sysbuild.
             # Twister sysbuild flashing currently only works with west, so
             # --west-flash must be passed.
@@ -806,7 +806,7 @@ class ProjectBuilder(FilterBuilder):
         files_to_keep = self._get_binaries()
         files_to_keep.append(os.path.join('zephyr', 'runners.yaml'))
 
-        if self.testsuite.sysbuild:
+        if self.instance.sysbuild:
             files_to_keep.append('domains.yaml')
             for domain in self.instance.domains.get_domains():
                 files_to_keep += self._get_artifact_allow_list_for_domain(domain.name)
@@ -846,7 +846,7 @@ class ProjectBuilder(FilterBuilder):
         # Get binaries for a single-domain build
         binaries += self._get_binaries_from_runners()
         # Get binaries in the case of a multiple-domain build
-        if self.testsuite.sysbuild:
+        if self.instance.sysbuild:
             for domain in self.instance.domains.get_domains():
                 binaries += self._get_binaries_from_runners(domain.name)
 

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -67,6 +67,8 @@ class TestInstance:
             self.build_dir = os.path.join(outdir, platform.normalized_name, source_dir_rel, testsuite.name)
         self.run_id = self._get_run_id()
         self.domains = None
+        # Instance need to use sysbuild if a given suite or a platform requires it
+        self.sysbuild = testsuite.sysbuild or platform.sysbuild
 
         self.run = False
         self.testcases: list[TestCase] = []
@@ -335,7 +337,7 @@ class TestInstance:
 
     def get_elf_file(self) -> str:
 
-        if self.testsuite.sysbuild:
+        if self.sysbuild:
             build_dir = self.domains.get_default_domain().build_dir
         else:
             build_dir = self.build_dir

--- a/scripts/schemas/twister/platform-schema.yaml
+++ b/scripts/schemas/twister/platform-schema.yaml
@@ -66,6 +66,8 @@ mapping:
     type: seq
     seq:
       - type: str
+  "sysbuild":
+    type: bool
   "env":
     type: seq
     seq:

--- a/scripts/tests/twister/pytest_integration/test_harness_pytest.py
+++ b/scripts/tests/twister/pytest_integration/test_harness_pytest.py
@@ -19,6 +19,7 @@ def testinstance() -> TestInstance:
     testsuite = TestSuite('.', 'samples/hello', 'unit.test')
     testsuite.harness_config = {}
     testsuite.ignore_faults = False
+    testsuite.sysbuild = False
     platform = Platform()
 
     testinstance = TestInstance(testsuite, platform, 'outdir')

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -445,7 +445,7 @@ def test_binaryhandler_create_command(
     handler.seed = seed
     handler.extra_test_args = extra_args
     handler.build_dir = 'build_dir'
-    handler.instance.testsuite.sysbuild = False
+    handler.instance.sysbuild = False
     handler.platform = SimpleNamespace()
     handler.platform.resc = "file.resc"
     handler.platform.uart = "uart"
@@ -1469,7 +1469,7 @@ def test_qemuhandler_get_default_domain_build_dir(
     from_file_mock = mock.Mock(return_value=domains_mock)
 
     handler = QEMUHandler(mocked_instance, 'build')
-    handler.instance.testsuite.sysbuild = self_sysbuild
+    handler.instance.sysbuild = self_sysbuild
     handler.build_dir = self_build_dir
 
     with mock.patch('domains.Domains.from_file', from_file_mock):

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -42,6 +42,7 @@ def mocked_instance(tmp_path):
     testsuite.source_dir: str = ''
     instance.testsuite = testsuite
     platform = mock.Mock()
+    platform.sysbuild = False
     platform.binaries: List[str] = []
     instance.platform = platform
     build_dir = tmp_path / 'build_dir'
@@ -131,7 +132,7 @@ def test_if_default_binaries_are_taken_properly(project_builder: ProjectBuilder)
         os.path.join('zephyr', 'zephyr.elf'),
         os.path.join('zephyr', 'zephyr.exe'),
     ]
-    project_builder.testsuite.sysbuild = False
+    project_builder.instance.sysbuild = False
     binaries = project_builder._get_binaries()
     assert sorted(binaries) == sorted(default_binaries)
 
@@ -139,7 +140,7 @@ def test_if_default_binaries_are_taken_properly(project_builder: ProjectBuilder)
 def test_if_binaries_from_platform_are_taken_properly(project_builder: ProjectBuilder):
     platform_binaries = ['spi_image.bin']
     project_builder.platform.binaries = platform_binaries
-    project_builder.testsuite.sysbuild = False
+    project_builder.instance.sysbuild = False
     platform_binaries_expected = [os.path.join('zephyr', bin) for bin in platform_binaries]
     binaries = project_builder._get_binaries()
     assert sorted(binaries) == sorted(platform_binaries_expected)
@@ -698,7 +699,6 @@ def test_filterbuilder_parse_generated(
         return mock.Mock()
 
     testsuite_mock = mock.Mock()
-    testsuite_mock.sysbuild = 'sysbuild' if sysbuild else None
     testsuite_mock.name = 'dummy.testsuite.name'
     testsuite_mock.filter = testsuite_filter
     platform_mock = mock.Mock()
@@ -710,6 +710,7 @@ def test_filterbuilder_parse_generated(
     fb = FilterBuilder(testsuite_mock, platform_mock, source_dir, build_dir,
                        mocked_jobserver)
     instance_mock = mock.Mock()
+    instance_mock.sysbuild = 'sysbuild' if sysbuild else None
     fb.instance = instance_mock
     fb.env = mock.Mock()
     fb.env.options = mock.Mock()
@@ -1675,7 +1676,7 @@ def test_projectbuilder_cleanup_device_testing_artifacts(
     bins = [os.path.join('zephyr', 'file.bin')]
 
     instance_mock = mock.Mock()
-    instance_mock.testsuite.sysbuild = False
+    instance_mock.sysbuild = False
     build_dir = os.path.join('build', 'dir')
     instance_mock.build_dir = build_dir
     env_mock = mock.Mock()

--- a/scripts/tests/twister/test_testinstance.py
+++ b/scripts/tests/twister/test_testinstance.py
@@ -597,7 +597,7 @@ def test_testinstance_get_elf_file(caplog, tmp_path, testinstance, sysbuild, exp
     sysbuild_elf2 = zephyr_dir / 'dummy2.elf'
     sysbuild_elf2.write_bytes(b'0')
 
-    testinstance.testsuite.sysbuild = sysbuild
+    testinstance.sysbuild = sysbuild
     testinstance.domains = mock.Mock(
         get_default_domain=mock.Mock(
             return_value=mock.Mock(


### PR DESCRIPTION
Some complex platforms (e.g. nrf54h20) requires sysbuild for all builds. Even simplest hello_world. This PR add option to configure such requirement (sysbuild: true) in platform_name.yaml which is used by twister. It tells twister to use sysbuild always for such target.
The PR also adds "sysbuild: true" to nrf54h20 targets yamls