### PR TITLE
doc: security: improve ETSI 303645 table layout

### DIFF
--- a/doc/security/standards/etsi-303645.rst
+++ b/doc/security/standards/etsi-303645.rst
@@ -177,9 +177,13 @@ Provisions Assessment
     * - N/A
       - The provision is not applicable to Zephyr or it is product makers responsibility
 
+.. raw:: latex
+
+    \begin{landscape}
+
 .. list-table:: ETSI 303645 provisions assessment using table B.1
     :header-rows: 1
-    :widths: 17 63 17 63 63
+    :widths: 25 80 15 15 60
 
     * - Provision
       - Description
@@ -729,3 +733,7 @@ Provisions Assessment
       - M C
       - N/A
       -
+
+.. raw:: latex
+
+    \end{landscape}


### PR DESCRIPTION
Improve ETSI 303645 layout both for HTML (use more appropriate column widths) and PDF (use landscape orientation).

PDF:

<img width="1260" alt="image" src="https://github.com/zephyrproject-rtos/zephyr/assets/128251/b8e493cf-dade-4243-9094-4aac5766908d">

HTML:

<img width="882" alt="image" src="https://github.com/zephyrproject-rtos/zephyr/assets/128251/d38da779-f70e-433c-8a7e-d7486db0a6a5">
