### PR TITLE
boards: imx93_evk: fix flexcan driver dts change

### DIFF
--- a/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.dts
+++ b/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.dts
@@ -159,8 +159,8 @@
 &flexcan2 {
 	pinctrl-0 = <&flexcan2_default>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
+	bitrate = <125000>;
+	bitrate-data = <1000000>;
 	phys = <&can_phy0>;
 	status = "okay";
 };


### PR DESCRIPTION
Fixes breaking DTS changes brought in from #73654.