### PR TITLE
boards: nxp: imx93_evk: remove deprecated CAN controller properties

### DIFF
--- a/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.dts
+++ b/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.dts
@@ -159,8 +159,6 @@
 &flexcan2 {
 	pinctrl-0 = <&flexcan2_default>;
 	pinctrl-names = "default";
-	bus-speed = <125000>;
-	bus-speed-data = <1000000>;
 	phys = <&can_phy0>;
 	status = "okay";
 };


### PR DESCRIPTION
Remove the deprecated CAN controller properties "bus-speed" and "bus-speed-data" and rely on the Kconfig defaults.