### PR TITLE
posix: re-introduce PTHREAD_RWLOCK_INITIALIZER

### DIFF
--- a/include/zephyr/posix/pthread.h
+++ b/include/zephyr/posix/pthread.h
@@ -153,7 +153,7 @@ int pthread_condattr_setclock(pthread_condattr_t *att, clockid_t clock_id);
  *
  * Initialize a rwlock with the default rwlock attributes.
  */
-#define POSIX_RWLOCK_INITIALIZER (-1)
+#define PTHREAD_RWLOCK_INITIALIZER (-1)
 
 /*
  *  Mutex attributes - type

--- a/lib/posix/options/rwlock.c
+++ b/lib/posix/options/rwlock.c
@@ -86,7 +86,7 @@ struct posix_rwlock *to_posix_rwlock(pthread_rwlock_t *rwlock)
 	size_t bit;
 	struct posix_rwlock *rwl;
 
-	if (*rwlock != POSIX_RWLOCK_INITIALIZER) {
+	if (*rwlock != PTHREAD_RWLOCK_INITIALIZER) {
 		return get_posix_rwlock(*rwlock);
 	}
 
@@ -116,7 +116,7 @@ int pthread_rwlock_init(pthread_rwlock_t *rwlock,
 	struct posix_rwlock *rwl;
 
 	ARG_UNUSED(attr);
-	*rwlock = POSIX_RWLOCK_INITIALIZER;
+	*rwlock = PTHREAD_RWLOCK_INITIALIZER;
 
 	rwl = to_posix_rwlock(rwlock);
 	if (rwl == NULL) {


### PR DESCRIPTION
Rename the POSIX_RWLOCK_INITIALIZER back to PTHREAD_RWLOCK_INITIALIZER. This was changed in 70e2b02c8e1, but PTHREAD_RWLOCK_INITIALIZER is the standard name used by external libraries.

Change it back to restore compatibility.