### PR TITLE
Manifest update: hal_microchip MEC5 v0.2

### DIFF
--- a/soc/microchip/mec/common/soc_cmn_init.c
+++ b/soc/microchip/mec/common/soc_cmn_init.c
@@ -15,18 +15,18 @@ static void mec5_soc_init_debug_interface(void)
 {
 #if defined(CONFIG_SOC_MEC_DEBUG_DISABLED)
 	mec_ecs_etm_pins(ECS_ETM_PINS_DISABLE);
-	mec_ecs_debug_port(MEC_DEBUG_MODE_DISABLE);
+	mec_hal_ecs_debug_port(MEC_DEBUG_MODE_DISABLE);
 #else
 #if defined(SOC_MEC_DEBUG_WITHOUT_TRACING)
 	mec_ecs_etm_pins(ECS_ETM_PINS_DISABLE);
-	mec_ecs_debug_port(MEC_DEBUG_MODE_SWD);
+	mec_hal_ecs_debug_port(MEC_DEBUG_MODE_SWD);
 #elif defined(SOC_MEC_DEBUG_AND_TRACING)
 #if defined(SOC_MEC_DEBUG_AND_ETM_TRACING)
 	mec_ecs_etm_pins(ECS_ETM_PINS_DISABLE);
-	mec_ecs_debug_port(MEC_DEBUG_MODE_SWD_SWV);
+	mec_hal_ecs_debug_port(MEC_DEBUG_MODE_SWD_SWV);
 #elif defined(CONFIG_SOC_MEC_DEBUG_AND_ETM_TRACING)
 	mec_ecs_debug_port(MEC_DEBUG_MODE_SWD);
-	mec_ecs_etm_pins(ECS_ETM_PINS_ENABLE);
+	mec_hal_ecs_etm_pins(ECS_ETM_PINS_ENABLE);
 #endif
 #endif
 #endif
@@ -35,7 +35,7 @@ static void mec5_soc_init_debug_interface(void)
 int mec5_soc_common_init(void)
 {
 	mec5_soc_init_debug_interface();
-	mec_ecia_init(MEC5_ECIA_DIRECT_BITMAP, 1, 0);
+	mec_hal_ecia_init(MEC5_ECIA_DIRECT_BITMAP, 1, 0);
 
 	return 0;
 }

--- a/west.yml
+++ b/west.yml
@@ -183,7 +183,7 @@ manifest:
       groups:
         - hal
     - name: hal_microchip
-      revision: 1279561ea9b71c5f572d3d52708b7b445a383662
+      revision: 71eba057c0cb7fc11b6f33eb40a82f1ebe2c571c
       path: modules/hal/microchip
       groups:
         - hal


### PR DESCRIPTION
Microchip HAL MEC5 has been updated to v0.2 due to standardization of HAL API and register define names to prevent clashes with external symbols. The PR also contains a small commit to update the small number of HAL API calls in the common SoC initialization code.