### PR TITLE
scripts: west_commands:runners: nrf_common: uicr pinreset check

### DIFF
--- a/scripts/west_commands/runners/nrf_common.py
+++ b/scripts/west_commands/runners/nrf_common.py
@@ -371,7 +371,12 @@ class NrfBinaryRunner(ZephyrBinaryRunner):
 
     def reset_target(self):
         if self.family == 'NRF52_FAMILY' and not self.softreset:
-            self.exec_op('pinreset-enable')
+            if self.build_conf.getboolean('CONFIG_GPIO_AS_PINRESET'):
+                self.exec_op('pinreset-enable')
+            else:
+                self.logger.warning('CONFIG_GPIO_AS_PINRESET is not enabled, '
+                                    'using softreset.')
+                self.softreset = True
 
         if self.softreset:
             self.exec_op('reset', option="RESET_SYSTEM")

--- a/scripts/west_commands/tests/test_nrf.py
+++ b/scripts/west_commands/tests/test_nrf.py
@@ -493,6 +493,9 @@ def fix_up_runner_config(test_case, runner_config, tmpdir):
         f.write(f'''
 CONFIG_SOC_SERIES_{test_case.family[:5]}X=y
 ''')
+        f.write('''
+CONFIG_GPIO_AS_PINRESET=y
+''')
     to_replace['build_dir'] = tmpdir
 
     if test_case.family != 'NRF53_FAMILY':


### PR DESCRIPTION
Changes the default behavior of target reset on the nRF52 series if
the reset pin is configured as a GPIO.

If CONFIG_GPIO_AS_PINRESET is not enabled, the default flashing behavior
of 'west flash' would reconfigure UICR with 'pinreset-enable,' making
it unclear why the RESET pin is not acting as a GPIO. This warns the user
of this behavior and switches to 'softreset' instead.

Signed-off-by: Helmut Lord <kellyhlord@gmail.com>
