### PR TITLE
x86: introduce memory barrier API z_x86_mb()

### DIFF
--- a/arch/x86/core/Kconfig.ia32
+++ b/arch/x86/core/Kconfig.ia32
@@ -179,14 +179,6 @@ config X86_USE_THREAD_LOCAL_STORAGE
 	help
 	  Internal config to enable thread local storage.
 
-config X86_MFENCE_INSTRUCTION_SUPPORTED
-	bool "X86 MFENCE instruction supported"
-	default y
-	depends on CACHE_MANAGEMENT
-	help
-	  Set n to disable the use of MFENCE instruction in arch_dcache_flush()
-	  for X86 CPUs have CLFLUSH instruction but no MFENCE
-
 config X86_RUNTIME_IRQ_STATS
 	bool
 	help

--- a/arch/x86/core/cache.c
+++ b/arch/x86/core/cache.c
@@ -17,6 +17,7 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/cache.h>
 #include <stdbool.h>
+#include <kernel_arch_func.h>
 
 /* Not Write-through bit */
 #define X86_REG_CR0_NW BIT(29)
@@ -102,11 +103,7 @@ int arch_dcache_flush_range(void *start_addr, size_t size)
 				"+m"(*(volatile char *)start));
 	}
 
-#if defined(CONFIG_X86_MFENCE_INSTRUCTION_SUPPORTED)
-	__asm__ volatile("mfence;\n\t":::"memory");
-#else
-	__asm__ volatile("lock; addl $0,-4(%%esp);\n\t":::"memory", "cc");
-#endif
+	z_x86_mb();
 	return 0;
 }
 

--- a/arch/x86/include/kernel_arch_func.h
+++ b/arch/x86/include/kernel_arch_func.h
@@ -108,6 +108,18 @@ void z_x86_irq_connect_on_vector(unsigned int irq,
 				 void (*func)(const void *arg),
 				 const void *arg);
 
+/*
+ * X86 memory barrier to force strict CPU ordering
+ */
+static inline void z_x86_mb(void)
+{
+#if defined(CONFIG_X86_64) || defined(X86_CPU_HAS_SSE2)
+	__asm__ volatile("mfence;\n\t":::"memory");
+#else
+	__asm__ volatile("lock; addl $0,-4(%%esp);\n\t":::"memory", "cc");
+#endif
+}
+
 #endif /* !_ASMLANGUAGE */
 
 #endif /* ZEPHYR_ARCH_X86_INCLUDE_KERNEL_ARCH_FUNC_H_ */

--- a/drivers/timer/CMakeLists.txt
+++ b/drivers/timer/CMakeLists.txt
@@ -36,3 +36,7 @@ zephyr_library_sources_ifdef(CONFIG_XLNX_PSTTC_TIMER xlnx_psttc_timer.c)
 zephyr_library_sources_ifdef(CONFIG_XTENSA_TIMER xtensa_sys_timer.c)
 zephyr_library_sources_ifdef(CONFIG_SMARTBOND_TIMER smartbond_timer.c)
 zephyr_library_sources_ifdef(CONFIG_MTK_ADSP_TIMER mtk_adsp_timer.c)
+
+if(CONFIG_APIC_TSC_DEADLINE_TIMER OR CONFIG_APIC_TIMER_TSC)
+  zephyr_library_include_directories(${ZEPHYR_BASE}/arch/x86/include)
+endif()

--- a/drivers/timer/apic_tsc.c
+++ b/drivers/timer/apic_tsc.c
@@ -12,6 +12,7 @@
 #include <zephyr/spinlock.h>
 #include <zephyr/drivers/interrupt_controller/loapic.h>
 #include <zephyr/irq.h>
+#include <kernel_arch_func.h>
 
 /*
  * This driver is selected when either CONFIG_APIC_TIMER_TSC or
@@ -250,7 +251,7 @@ void smp_timer_init(void)
 	 * configuration write.
 	 */
 	x86_write_loapic(LOAPIC_TIMER, lvt_reg.val);
-	__asm__ volatile("mfence" ::: "memory");
+	z_x86_mb();
 	clear_tsc_adjust();
 	irq_enable(timer_irq());
 }
@@ -306,7 +307,7 @@ static int sys_clock_driver_init(void)
 	 * (i.e. a timeout we're about to set) cannot possibly reorder
 	 * around the initialization we just did.
 	 */
-	__asm__ volatile("mfence" ::: "memory");
+	z_x86_mb();
 
 	last_tick = rdtsc() / CYC_PER_TICK;
 	last_cycle = last_tick * CYC_PER_TICK;


### PR DESCRIPTION
    Implemented with mfence instruction if supported by CPU, x86_64 or ia32
    with SSE2, or fallback to a lock instruction.
    Replace all existing mfence calls with new z_x86_mb() API.
    Remove Kconfig option CONFIG_X86_MFENCE_INSTRUCTION_SUPPORTED.