### PR TITLE
kernel: banner: fix disabling boot banner

### DIFF
--- a/kernel/banner.c
+++ b/kernel/banner.c
@@ -27,7 +27,9 @@
 void boot_banner(void)
 {
 #if defined(CONFIG_BOOT_DELAY) && (CONFIG_BOOT_DELAY > 0)
+#ifdef CONFIG_BOOT_BANNER
 	printk("***** delaying boot " DELAY_STR "ms (per build configuration) *****\n");
+#endif /* CONFIG_BOOT_BANNER */
 	k_busy_wait(CONFIG_BOOT_DELAY * USEC_PER_MSEC);
 #endif /* defined(CONFIG_BOOT_DELAY) && (CONFIG_BOOT_DELAY > 0) */
 


### PR DESCRIPTION
When the CONFIG_BOOT_BANNER flag is set to "n", but CONFIG_BOOT_DELAY is enabled, there is a delay message printed at boot time. This allows for the whole boot banner to be disabled.