### PR TITLE
Renesas: Smartbond: DMA DT does not use dma-cells

### DIFF
--- a/drivers/dma/dma_smartbond.c
+++ b/drivers/dma/dma_smartbond.c
@@ -343,6 +343,7 @@ static bool dma_channel_update_dreq_mode(enum dma_channel_direction direction,
 		DMA_CTRL_REG_SET_FIELD(DREQ_MODE, *dma_ctrl_reg, DREQ_MODE_SW);
 		break;
 	case PERIPHERAL_TO_MEMORY:
+	case MEMORY_TO_PERIPHERAL:
 	case PERIPHERAL_TO_PERIPHERAL:
 		/* DMA channels starts by peripheral DMA req */
 		DMA_CTRL_REG_SET_FIELD(DREQ_MODE, *dma_ctrl_reg, DREQ_MODE_HW);

--- a/dts/arm/renesas/smartbond/da1469x.dtsi
+++ b/dts/arm/renesas/smartbond/da1469x.dtsi
@@ -386,7 +386,7 @@
 			status = "disabled";
 			dma-channels = <8>;
 			block-count = <1>;
-			#dma-cells = <0>;
+			#dma-cells = <2>;
 		};
 
 		memc: qspic2@34000000 {

--- a/dts/bindings/dma/renesas,smartbond-dma.yaml
+++ b/dts/bindings/dma/renesas,smartbond-dma.yaml
@@ -19,3 +19,14 @@ properties:
     type: int
     const: 1
     description: Number of block counts supported
+
+  "#dma-cells":
+    const: 2
+
+# - #dma-cells : Must be <2>.
+# channel: dma channel to be reserved
+# config: peripheral's dma request line. Valid values are defined in dt-bindings/dma/dma_smartbond.h
+
+dma-cells:
+  - channel
+  - config

--- a/include/zephyr/dt-bindings/dma/dma_smartbond.h
+++ b/include/zephyr/dt-bindings/dma/dma_smartbond.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef DMA_SMARTBOND_H_
+#define DMA_SMARTBOND_H_
+
+/**
+ * @brief Vendror-specific DMA peripheral triggering sources.
+ *
+ * A valid triggering source should be provided when DMA
+ * is configured for peripheral to peripheral or memory to peripheral
+ * transactions.
+ */
+#define DMA_SMARTBOND_TRIG_MUX_SPI		0x0
+#define DMA_SMARTBOND_TRIG_MUX_SPI2		0x1
+#define DMA_SMARTBOND_TRIG_MUX_UART		0x2
+#define DMA_SMARTBOND_TRIG_MUX_UART2		0x3
+#define DMA_SMARTBOND_TRIG_MUX_I2C		0x4
+#define DMA_SMARTBOND_TRIG_MUX_I2C2		0x5
+#define DMA_SMARTBOND_TRIG_MUX_USB		0x6
+#define DMA_SMARTBOND_TRIG_MUX_UART3		0x7
+#define DMA_SMARTBOND_TRIG_MUX_PCM		0x8
+#define DMA_SMARTBOND_TRIG_MUX_SRC		0x9
+#define DMA_SMARTBOND_TRIG_MUX_GPADC		0xC
+#define DMA_SMARTBOND_TRIG_MUX_SDADC		0xD
+#define DMA_SMARTBOND_TRIG_MUX_NONE		0xF
+
+#endif /* DMA_SMARTBOND_H_ */


### PR DESCRIPTION
This PR should fix  #73803. 