### PR TITLE
doc: Bluetooth: Mesh: fix :c:enum: used in lieu of :c:enumerator:

### DIFF
--- a/doc/connectivity/bluetooth/api/mesh/dfu.rst
+++ b/doc/connectivity/bluetooth/api/mesh/dfu.rst
@@ -201,17 +201,17 @@ DFU. Depending on the availability of the Remote Provisioning Server model on th
 the device may either boot up unprovisioned after applying the new firmware or require to be
 re-provisioned. The complete list of available options is defined in :c:enum:`bt_mesh_dfu_effect`:
 
-:c:enum:`BT_MESH_DFU_EFFECT_NONE`
+:c:enumerator:`BT_MESH_DFU_EFFECT_NONE`
    The device stays provisioned after the new firmware is programmed. This effect is chosen if the
    composition data of the new firmware doesn't change.
-:c:enum:`BT_MESH_DFU_EFFECT_COMP_CHANGE_NO_RPR`
+:c:enumerator:`BT_MESH_DFU_EFFECT_COMP_CHANGE_NO_RPR`
    This effect is chosen when the composition data changes and the device doesn't support the remote
    provisioning. The new composition data takes place only after re-provisioning.
-:c:enum:`BT_MESH_DFU_EFFECT_COMP_CHANGE`
+:c:enumerator:`BT_MESH_DFU_EFFECT_COMP_CHANGE`
    This effect is chosen when the composition data changes and the device supports the remote
    provisioning. In this case, the device stays provisioned and the new composition data takes place
    after re-provisioning using the Remote Provisioning models.
-:c:enum:`BT_MESH_DFU_EFFECT_UNPROV`
+:c:enumerator:`BT_MESH_DFU_EFFECT_UNPROV`
   This effect is chosen if the composition data in the new firmware changes, the device doesn't
   support the remote provisioning, and the new composition data takes effect after applying the
   firmware.
@@ -219,7 +219,7 @@ re-provisioned. The complete list of available options is defined in :c:enum:`bt
 When the Target node receives the Firmware Update Firmware Metadata Check message, the Firmware
 Update Server model calls the :c:member:`bt_mesh_dfu_srv_cb.check` callback, the application can
 then process the metadata and provide the effect value. If the effect is
-:c:enum:`BT_MESH_DFU_EFFECT_COMP_CHANGE`, the application must call functions
+:c:enumerator:`BT_MESH_DFU_EFFECT_COMP_CHANGE`, the application must call functions
 :c:func:`bt_mesh_comp_change_prepare` and :c:func:`bt_mesh_models_metadata_change_prepare` to
 prepare the Composition Data Page and Models Metadata Page contents before applying the new
 firmware image. See :ref:`bluetooth_mesh_dfu_srv_comp_data_and_models_metadata` for more


### PR DESCRIPTION
While Breathe seems to not care and creates hyperlinks either way, the proper role to mention a C enumerator is :c:enumerator:. :c:enum: is to be used to refer to the enum itself.