### PR TITLE
usb: cdc_acm: Additional connection state checks

### DIFF
--- a/subsys/usb/device/class/cdc_acm.c
+++ b/subsys/usb/device/class/cdc_acm.c
@@ -625,13 +625,9 @@ static void cdc_acm_irq_tx_disable(const struct device *dev)
  */
 static int cdc_acm_irq_tx_ready(const struct device *dev)
 {
-	struct cdc_acm_dev_data_t * const dev_data = dev->data;
+	struct cdc_acm_dev_data_t *const data = dev->data;
 
-	if (dev_data->tx_irq_ena && dev_data->tx_ready) {
-		return 1;
-	}
-
-	return 0;
+	return data->tx_irq_ena && data->configured && data->tx_ready && !data->suspended;
 }
 
 /**
@@ -671,13 +667,9 @@ static void cdc_acm_irq_rx_disable(const struct device *dev)
  */
 static int cdc_acm_irq_rx_ready(const struct device *dev)
 {
-	struct cdc_acm_dev_data_t * const dev_data = dev->data;
+	struct cdc_acm_dev_data_t *const data = dev->data;
 
-	if (dev_data->rx_ready) {
-		return 1;
-	}
-
-	return 0;
+	return data->rx_irq_ena && data->rx_ready;
 }
 
 /**
@@ -689,15 +681,7 @@ static int cdc_acm_irq_rx_ready(const struct device *dev)
  */
 static int cdc_acm_irq_is_pending(const struct device *dev)
 {
-	struct cdc_acm_dev_data_t * const dev_data = dev->data;
-
-	if (dev_data->tx_ready && dev_data->tx_irq_ena) {
-		return 1;
-	} else if (dev_data->rx_ready && dev_data->rx_irq_ena) {
-		return 1;
-	} else {
-		return 0;
-	}
+	return cdc_acm_irq_rx_ready(dev) || cdc_acm_irq_tx_ready(dev);
 }
 
 /**

--- a/subsys/usb/device/usb_transfer.c
+++ b/subsys/usb/device/usb_transfer.c
@@ -251,7 +251,8 @@ int usb_transfer(uint8_t ep, uint8_t *data, size_t dlen, unsigned int flags,
 
 	if (flags & USB_TRANS_WRITE) {
 		/* start writing first chunk */
-		k_work_submit_to_queue(&USB_WORK_Q, &trans->work);
+		ret = k_work_submit_to_queue(&USB_WORK_Q, &trans->work);
+		ret = (ret < 0) ? ret : 0;
 	} else {
 		/* ready to read, clear NAK */
 		ret = usb_dc_ep_read_continue(ep);


### PR DESCRIPTION
Issues caused:
- On intense use I had packet losses (below 1 per 1000)
- Restarting the host device or resetting the USB controller caused the usb transfer to get stuck in about 30% of tests
- This includes issue #72786 opened by a collegue

Analysis of issues:
  I found multiple cases causing this isssues with wrong return values on cdc_acm_irq_is_pending(), cdc_acm_irq_tx_ready() etc causing my logic to get stuck

Changes:
- usb_transfer(): k_work_submit_to_queue() return value was ignored -> calling function tx_work_handler() dropped data even though it was
   not put to workqueue
- tx_work_handler() put dev_data->tx_ready to false even if usb_transfer() failed but without the transfer done callback it was never reset to true so TX got stuck
- cdc_acm_irq_tx_ready() did not check configured and suspended states This caused the device to show as ready even though it was not configured after a host reset
- cdc_acm_irq_rx_ready() did not check if irq is enabled
- cdc_acm_irq_is_pending() had the same issues as its just a test on cdc_acm_irq_rx_ready() or cdc_acm_irq_tx_ready() (the description says so, too) -> Replaced it by a call of both functions for a fast and consistent fix

Tests:
- The host reset issue was tested with a Intel NUC with Windows 11 in an endless reset loop, about 2 times per minute, for 12 hours. The issue no longer applies there
- The host reset issue was also tested on a Linux XUbuntu host with a pyusb device reset script. The issue was tested only manually (at 50% success that was good enough) and does not apply any longer
- Data loss was tested with an echo device and a data generating and checking script. It was also tested with a device generating serialized data (counting up).
- Both showed data loss (about 1 byte per GB, in blocks of multiples of 8). For both test cases the issue no longer applied (tested with more than 1 TB of data) Fixes: #72786

Considerations:
- Changes in cdc_acm.c should not have impact on other code. Return values may show an error that was missed before
- Change in usb_transfer.c may influence more devices The new return value should be in an expected range (0 or negative) so I expect it to work with all other components as well