### PR TITLE
manifest: Update nRF hw models to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -300,7 +300,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 4447a22aea5e791c9bd18e7d71cc092623ddd2bb
+      revision: 6c389b9b5fa0a079cd4502e69d375da4c0c289b7
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: da78aea63159771956fe0c9263f2e6985b66e9d5


### PR DESCRIPTION
Update the HW models module to:
6c389b9b5fa0a079cd4502e69d375da4c0c289b7

Including the following:
* 6c389b9 PPI (52): Connect CCM TASK_RATEOVERRIDE
* 2056253 CCM: Change TASK RATEOVERRIDE warning to info