### PR TITLE
drivers: flash: stm32 ospi adapt lines on writes

### DIFF
--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -1442,36 +1442,37 @@ static int flash_stm32_ospi_write(const struct device *dev, off_t addr,
 	/* using 32bits address also in SPI/STR mode */
 	cmd_pp.Instruction = dev_data->write_opcode;
 
-	if (dev_cfg->data_mode != OSPI_OPI_MODE) {
-		switch (cmd_pp.Instruction) {
-		case SPI_NOR_CMD_PP_4B:
-			__fallthrough;
-		case SPI_NOR_CMD_PP: {
-			cmd_pp.InstructionMode = HAL_OSPI_INSTRUCTION_1_LINE;
-			cmd_pp.AddressMode = HAL_OSPI_ADDRESS_1_LINE;
-			cmd_pp.DataMode = HAL_OSPI_DATA_1_LINE;
-			break;
-		}
-		case SPI_NOR_CMD_PP_1_1_4_4B:
-			__fallthrough;
-		case SPI_NOR_CMD_PP_1_1_4: {
-			cmd_pp.InstructionMode = HAL_OSPI_INSTRUCTION_1_LINE;
-			cmd_pp.AddressMode = HAL_OSPI_ADDRESS_1_LINE;
-			cmd_pp.DataMode = HAL_OSPI_DATA_4_LINES;
-			break;
-		}
-		case SPI_NOR_CMD_PP_1_4_4_4B:
-			__fallthrough;
-		case SPI_NOR_CMD_PP_1_4_4: {
-			cmd_pp.InstructionMode = HAL_OSPI_INSTRUCTION_1_LINE;
-			cmd_pp.AddressMode = HAL_OSPI_ADDRESS_4_LINES;
-			cmd_pp.DataMode = HAL_OSPI_DATA_4_LINES;
-			break;
-		}
-		default:
-			/* use the mode from ospi_prepare_cmd */
-			break;
-		}
+	/* Adapt lines based on write_opcode */
+	switch (cmd_pp.Instruction) {
+	case SPI_NOR_CMD_PP_4B:
+		__fallthrough;
+	case SPI_NOR_CMD_PP:
+		cmd_pp.InstructionMode = HAL_OSPI_INSTRUCTION_1_LINE;
+		cmd_pp.AddressMode = HAL_OSPI_ADDRESS_1_LINE;
+		cmd_pp.DataMode = HAL_OSPI_DATA_1_LINE;
+		break;
+	case SPI_NOR_CMD_PP_1_1_2:
+		cmd_pp.InstructionMode = HAL_OSPI_INSTRUCTION_1_LINE;
+		cmd_pp.AddressMode = HAL_OSPI_ADDRESS_1_LINE;
+		cmd_pp.DataMode = HAL_OSPI_DATA_2_LINES;
+		break;
+	case SPI_NOR_CMD_PP_1_1_4_4B:
+		__fallthrough;
+	case SPI_NOR_CMD_PP_1_1_4:
+		cmd_pp.InstructionMode = HAL_OSPI_INSTRUCTION_1_LINE;
+		cmd_pp.AddressMode = HAL_OSPI_ADDRESS_1_LINE;
+		cmd_pp.DataMode = HAL_OSPI_DATA_4_LINES;
+		break;
+	case SPI_NOR_CMD_PP_1_4_4_4B:
+		__fallthrough;
+	case SPI_NOR_CMD_PP_1_4_4:
+		cmd_pp.InstructionMode = HAL_OSPI_INSTRUCTION_1_LINE;
+		cmd_pp.AddressMode = HAL_OSPI_ADDRESS_4_LINES;
+		cmd_pp.DataMode = HAL_OSPI_DATA_4_LINES;
+		break;
+	default:
+		/* Use lines based on data mode set in ospi_prepare_cmd */
+		break;
 	}
 
 	cmd_pp.Address = addr;


### PR DESCRIPTION
Correct used lines based on write opcode regardless of the data mode. The write opcode is set during init for all modes and can be overwritten in DT.

Simplify the switch, allow usage of different PP opcodes in OPI mode, and add `PP_1_1_2`.