### PR TITLE
samples: drivers: adc: Add nrf54l15 to platform_allow

### DIFF
--- a/samples/drivers/adc/adc_dt/sample.yaml
+++ b/samples/drivers/adc/adc_dt/sample.yaml
@@ -15,6 +15,7 @@ tests:
       - stm32h735g_disco
       - nrf51dk/nrf51822
       - nrf52840dk/nrf52840
+      - nrf54l15pdk/nrf54l15/cpuapp
       - mec172xevb_assy6906
       - gd32f350r_eval
       - gd32f450i_eval

--- a/samples/drivers/adc/adc_sequence/sample.yaml
+++ b/samples/drivers/adc/adc_sequence/sample.yaml
@@ -9,6 +9,7 @@ tests:
       - cy8cproto_063_ble
       - cy8cproto_062_4343w
       - nrf52840dk/nrf52840
+      - nrf54l15pdk/nrf54l15/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
     harness: console


### PR DESCRIPTION
Enable execution of ADC driver tests on nrf54l15.
Overlay file for nrf54l15 already exists.