### PR TITLE
ztest: Add macros for comparing strings

### DIFF
--- a/subsys/testsuite/ztest/include/zephyr/ztest_assert.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest_assert.h
@@ -390,6 +390,16 @@ static inline bool z_zexpect(bool cond, const char *default_msg, const char *fil
 	zassert(memcmp(buf, exp, size) == 0, #buf " not equal to " #exp, ##__VA_ARGS__)
 
 /**
+ * @brief Assert that 2 strings have the same contents
+ *
+ * @param s1 The first string
+ * @param s2 The second string
+ * @param ... Optional message and variables to print if the expectation fails
+ */
+#define zassert_str_equal(s1, s2, ...)                                                     \
+	zassert(strcmp(s1, s2) == 0, #s1 " not equal to " #s2, ##__VA_ARGS__)
+
+/**
  * @}
  */
 
@@ -558,6 +568,16 @@ static inline bool z_zexpect(bool cond, const char *default_msg, const char *fil
 	zassume(memcmp(buf, exp, size) == 0, #buf " not equal to " #exp, ##__VA_ARGS__)
 
 /**
+ * @brief Assumes that 2 strings have the same contents
+ *
+ * @param s1 The first string
+ * @param s2 The second string
+ * @param ... Optional message and variables to print if the expectation fails
+ */
+#define zassume_str_equal(s1, s2, ...)                                                     \
+	zassume(strcmp(s1, s2) == 0, #s1 " not equal to " #s2, ##__VA_ARGS__)
+
+/**
  * @}
  */
 
@@ -690,6 +710,17 @@ static inline bool z_zexpect(bool cond, const char *default_msg, const char *fil
  */
 #define zexpect_mem_equal(buf, exp, size, ...)                                                     \
 	zexpect(memcmp(buf, exp, size) == 0, #buf " not equal to " #exp, ##__VA_ARGS__)
+
+/**
+ * @brief Expect that 2 strings have the same contents, otherwise mark test as failed but
+ * continue its execution.
+ *
+ * @param s1 The first string
+ * @param s2 The second string
+ * @param ... Optional message and variables to print if the expectation fails
+ */
+#define zexpect_str_equal(s1, s2, ...)                                                     \
+	zexpect(strcmp(s1, s2) == 0, #s1 " not equal to " #s2, ##__VA_ARGS__)
 
 /**
  * @}

--- a/tests/ztest/base/src/main.c
+++ b/tests/ztest/base/src/main.c
@@ -36,6 +36,23 @@ ZTEST(framework_tests, test_assert_mem_equal)
 	zassert_mem_equal(actual, expected, sizeof(expected), NULL);
 }
 
+ZTEST(framework_tests, test_assert_str_equal)
+{
+	const char *s1 = "asdf";
+	const char s2[] = {'a', 's', 'd', 'f', '\0'};
+
+	zassert_str_equal(s1, s2);
+}
+
+ZTEST_EXPECT_FAIL(framework_tests, test_assert_str_equal_fail);
+ZTEST(framework_tests, test_assert_str_equal_fail)
+{
+	const char *s1 = "asdf";
+	const char s2[] = {'a', 's', 'd', 'f', 'q', '\0'};
+
+	zassert_str_equal(s1, s2);
+}
+
 ZTEST_EXPECT_SKIP(framework_tests, test_skip_config);
 ZTEST(framework_tests, test_skip_config)
 {

--- a/tests/ztest/zexpect/src/main.c
+++ b/tests/ztest/zexpect/src/main.c
@@ -172,3 +172,20 @@ ZTEST(expect, test_fail_expect_between_inclusive)
 	zexpect_between_inclusive(5, 0, 4);
 	zexpect_between_inclusive(5, 6, 10);
 }
+
+ZTEST(expect, test_expect_str_equal)
+{
+	const char *s1 = "asdf";
+	const char s2[] = {'a', 's', 'd', 'f', '\0'};
+
+	zexpect_str_equal(s1, s2);
+}
+
+ZTEST_EXPECT_FAIL(expect, test_expect_str_equal_fail);
+ZTEST(expect, test_expect_str_equal_fail)
+{
+	const char *s1 = "asdf";
+	const char s2[] = {'a', 's', 'd', 'f', 'q', '\0'};
+
+	zexpect_str_equal(s1, s2);
+}


### PR DESCRIPTION
These macros allows us to compare strings in a simpler way.