### PR TITLE
boards: nxp: kinetis: fix non-optimal sector distribution

### DIFF
--- a/boards/nxp/frdm_k22f/frdm_k22f.dts
+++ b/boards/nxp/frdm_k22f/frdm_k22f.dts
@@ -204,23 +204,23 @@ zephyr_udc0: &usbotg {
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x00010000>;
+			reg = <0x00000000 DT_SIZE_K(64)>;
 			read-only;
 		};
-		/* Note slot 0 has one additional sector,
-		 * this is intended for use with the swap move algorithm
+		/* The MCUBoot swap-move algorithm uses the last 3 sectors
+		 * of the primary slot0 for swap status and move.
 		 */
 		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x00010000 0x00028800>;
+			reg = <0x00010000 (DT_SIZE_K(180) + DT_SIZE_K(6))>;
 		};
-		slot1_partition: partition@38800 {
+		slot1_partition: partition@3E800 {
 			label = "image-1";
-			reg = <0x00038800 0x00028000>;
+			reg = <0x0003E800 DT_SIZE_K(180)>;
 		};
-		storage_partition: partition@60800 {
+		storage_partition: partition@6B800 {
 			label = "storage";
-			reg = <0x00060800 0x0001f800>;
+			reg = <0x0006B800 DT_SIZE_K(82)>;
 		};
 
 	};

--- a/boards/nxp/frdm_k64f/frdm_k64f.dts
+++ b/boards/nxp/frdm_k64f/frdm_k64f.dts
@@ -233,23 +233,23 @@ zephyr_udc0: &usbotg {
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x00010000>;
+			reg = <0x00000000 DT_SIZE_K(64)>;
 			read-only;
 		};
-		/* Note slot 0 has one additional sector,
-		 * this is intended for use with the swap move algorithm
+		/* The MCUBoot swap-move algorithm uses the last 2 sectors
+		 * of the primary slot0 for swap status and move.
 		 */
 		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x00010000 0x00069000>;
+			reg = <0x00010000 (DT_SIZE_K(416) + DT_SIZE_K(8))>;
 		};
-		slot1_partition: partition@79000 {
+		slot1_partition: partition@7a000 {
 			label = "image-1";
-			reg = <0x00079000 0x00068000>;
+			reg = <0x0007a000 DT_SIZE_K(416)>;
 		};
-		storage_partition: partition@e1000 {
+		storage_partition: partition@e2000 {
 			label = "storage";
-			reg = <0x000e1000 0x0001f000>;
+			reg = <0x000e2000 DT_SIZE_K(120)>;
 		};
 	};
 };

--- a/boards/nxp/frdm_k82f/frdm_k82f.dts
+++ b/boards/nxp/frdm_k82f/frdm_k82f.dts
@@ -159,14 +159,14 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x0 DT_SIZE_K(48)>;
+			reg = <0x0 DT_SIZE_K(44)>;
 		};
-		/* Note slot 0 has one additional sector,
-		 * this is intended for use with the swap move algorithm
+		/* The MCUBoot swap-move algorithm uses the last 2 sectors
+		 * of the primary slot0 for swap status and move.
 		 */
-		slot0_partition: partition@c000 {
+		slot0_partition: partition@b000 {
 			label = "image-0";
-			reg = <0xc000 DT_SIZE_K(100)>;
+			reg = <0xb000 (DT_SIZE_K(96) + DT_SIZE_K(8))>;
 		};
 		slot1_partition: partition@25000 {
 			label = "image-1";

--- a/boards/nxp/hexiwear/hexiwear_mk64f12.dts
+++ b/boards/nxp/hexiwear/hexiwear_mk64f12.dts
@@ -181,26 +181,25 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
-
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x00010000>;
+			reg = <0x00000000 DT_SIZE_K(64)>;
 			read-only;
 		};
-		/* Note slot 0 has one additional sector,
-		 * this is intended for use with the swap move algorithm
+		/* The MCUBoot swap-move algorithm uses the last 2 sectors
+		 * of the primary slot0 for swap status and move.
 		 */
 		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x00010000 0x00069000>;
+			reg = <0x00010000 (DT_SIZE_K(416) + DT_SIZE_K(8))>;
 		};
-		slot1_partition: partition@79000 {
+		slot1_partition: partition@7a000 {
 			label = "image-1";
-			reg = <0x00079000 0x00068000>;
+			reg = <0x0007a000 DT_SIZE_K(416)>;
 		};
-		storage_partition: partition@e1000 {
+		storage_partition: partition@e2000 {
 			label = "storage";
-			reg = <0x000e1000 0x0001f000>;
+			reg = <0x000e2000 DT_SIZE_K(120)>;
 		};
 	};
 };

--- a/boards/nxp/rddrone_fmuk66/rddrone_fmuk66.dts
+++ b/boards/nxp/rddrone_fmuk66/rddrone_fmuk66.dts
@@ -236,23 +236,23 @@ zephyr_udc0: &usbotg {
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x00010000>;
+			reg = <0x00000000 DT_SIZE_K(64)>;
 			read-only;
 		};
-		/* Note slot 0 has one additional sector,
-		 * this is intended for use with the swap move algorithm
+		/* The MCUBoot swap-move algorithm uses the last 2 sectors
+		 * of the primary slot0 for swap status and move.
 		 */
 		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x00010000 0x000E9000>;
+			reg = <0x00010000 (DT_SIZE_K(928) + DT_SIZE_K(8))>;
 		};
-		slot1_partition: partition@F9000 {
+		slot1_partition: partition@FA000 {
 			label = "image-1";
-			reg = <0x000F9000 0x000E8000>;
+			reg = <0x000FA000 DT_SIZE_K(928)>;
 		};
-		storage_partition: partition@1e1000 {
+		storage_partition: partition@1E2000 {
 			label = "storage";
-			reg = <0x001e1000 0x0001f000>;
+			reg = <0x001E2000 DT_SIZE_K(120)>;
 		};
 	};
 };

--- a/boards/nxp/twr_ke18f/twr_ke18f.dts
+++ b/boards/nxp/twr_ke18f/twr_ke18f.dts
@@ -335,25 +335,25 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
-
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0xc000>;
+			reg = <0x00000000 DT_SIZE_K(64)>;
+			read-only;
 		};
-		/* Note slot 0 has one additional sector,
-		 * this is intended for use with the swap move algorithm
+		/* The MCUBoot swap-move algorithm uses the last 2 sectors
+		 * of the primary slot0 for swap status and move.
 		 */
-		slot0_partition: partition@c000 {
+		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x0000c000 0x37000>;
+			reg = <0x00010000 (DT_SIZE_K(200) + DT_SIZE_K(8))>;
 		};
-		slot1_partition: partition@43000 {
+		slot1_partition: partition@44000 {
 			label = "image-1";
-			reg = <0x00043000 0x36000>;
+			reg = <0x00044000 DT_SIZE_K(200)>;
 		};
-		storage_partition: partition@79000 {
+		storage_partition: partition@76000 {
 			label = "storage";
-			reg = <0x00079000 0x00007000>;
+			reg = <0x00076000 DT_SIZE_K(40)>;
 		};
 	};
 };

--- a/boards/nxp/twr_kv58f220m/twr_kv58f220m.dts
+++ b/boards/nxp/twr_kv58f220m/twr_kv58f220m.dts
@@ -113,25 +113,25 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
-
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x10000>;
+			reg = <0x00000000 DT_SIZE_K(64)>;
+			read-only;
 		};
-		/* Note slot 0 has one additional sector,
-		 * this is intended for use with the swap move algorithm
+		/* The MCUBoot swap-move algorithm uses the last 2 sectors
+		 * of the primary slot0 for swap status and move.
 		 */
 		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x00010000 0x68000>;
+			reg = <0x00010000 (DT_SIZE_K(416) + DT_SIZE_K(16))>;
 		};
-		slot1_partition: partition@78000 {
+		slot1_partition: partition@7C000 {
 			label = "image-1";
-			reg = <0x00078000 0x66000>;
+			reg = <0x0007C000 DT_SIZE_K(416)>;
 		};
-		storage_partition: partition@de000 {
-			label = "image-scratch";
-			reg = <0x000de000 0x22000>;
+		storage_partition: partition@E4000 {
+			label = "storage";
+			reg = <0x000E4000 DT_SIZE_K(112)>;
 		};
 	};
 };


### PR DESCRIPTION
- Optimize slot sizes for MCUBoot swap move algorithm for frdm_k22f/k64f/k82f, twr_ke18f/kv58f220m, hexiwear_mk64f12 and rddrone_fmuk66 boards.
- Use DT_SIZE_K/M macros for slot sizes.