### PR TITLE
subsys: ipc: icmsg: Align to NO MULTITHREADING

### DIFF
--- a/include/zephyr/ipc/icmsg.h
+++ b/include/zephyr/ipc/icmsg.h
@@ -51,8 +51,10 @@ struct icmsg_data_t {
 
 	/* General */
 	const struct icmsg_config_t *cfg;
+#ifdef CONFIG_MULTITHREADING
 	struct k_work_delayable notify_work;
 	struct k_work mbox_work;
+#endif
 	atomic_t state;
 };
 

--- a/samples/drivers/mbox/remote/src/main.c
+++ b/samples/drivers/mbox/remote/src/main.c
@@ -51,6 +51,12 @@ int main(void)
 	printk("Maximum TX channels: %d\n", mbox_max_channels_get_dt(&tx_channel));
 
 	while (1) {
+#if defined(CONFIG_MULTITHREADING)
+		k_sleep(K_MSEC(3000));
+#else
+		k_busy_wait(3000000);
+#endif
+
 		printk("Ping (on channel %d)\n", tx_channel.channel_id);
 
 		ret = mbox_send_dt(&tx_channel, NULL);
@@ -58,10 +64,7 @@ int main(void)
 			printk("Could not send (%d)\n", ret);
 			return 0;
 		}
-
-		k_sleep(K_MSEC(3000));
 	}
 #endif /* CONFIG_TX_ENABLED */
-
 	return 0;
 }

--- a/samples/drivers/mbox/sample.yaml
+++ b/samples/drivers/mbox/sample.yaml
@@ -82,3 +82,38 @@ tests:
       regex:
         - "Ping \\(on channel 16\\)"
         - "Pong \\(on channel 15\\)"
+
+  sample.drivers.mbox.nrf54l15_no_multithreading:
+    platform_allow:
+      - nrf54l15pdk/nrf54l15/cpuapp
+    integration_platforms:
+      - nrf54l15pdk/nrf54l15/cpuapp
+    extra_args:
+      mbox_SNIPPET=nordic-flpr
+      mbox_CONFIG_MULTITHREADING=n
+      remote_CONFIG_MULTITHREADING=n
+    sysbuild: true
+    harness: console
+    harness_config:
+      type: multi_line
+      ordered: false
+      regex:
+        - "Ping \\(on channel 16\\)"
+        - "Pong \\(on channel 15\\)"
+
+  sample.drivers.mbox.nrf54l15_remote_no_multithreading:
+    platform_allow:
+      - nrf54l15pdk/nrf54l15/cpuapp
+    integration_platforms:
+      - nrf54l15pdk/nrf54l15/cpuapp
+    extra_args:
+      mbox_SNIPPET=nordic-flpr
+      remote_CONFIG_MULTITHREADING=n
+    sysbuild: true
+    harness: console
+    harness_config:
+      type: multi_line
+      ordered: false
+      regex:
+        - "Ping \\(on channel 16\\)"
+        - "Pong \\(on channel 15\\)"

--- a/samples/drivers/mbox/src/main.c
+++ b/samples/drivers/mbox/src/main.c
@@ -47,7 +47,11 @@ int main(void)
 	printk("Maximum TX channels: %d\n", mbox_max_channels_get_dt(&tx_channel));
 
 	while (1) {
+#if defined(CONFIG_MULTITHREADING)
 		k_sleep(K_MSEC(2000));
+#else
+		k_busy_wait(2000000);
+#endif
 
 		printk("Ping (on channel %d)\n", tx_channel.channel_id);
 

--- a/samples/subsys/ipc/ipc_service/icmsg/remote/src/main.c
+++ b/samples/subsys/ipc/ipc_service/icmsg/remote/src/main.c
@@ -14,26 +14,44 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(remote, LOG_LEVEL_INF);
 
-
+#if defined(CONFIG_MULTITHREADING)
 K_SEM_DEFINE(bound_sem, 0, 1);
+#else
+volatile uint32_t bound_sem = 1;
+volatile uint32_t recv_sem = 1;
+#endif
+
+static unsigned char expected_message = 'a';
+static size_t expected_len = PACKET_SIZE_START;
+static size_t received;
 
 static void ep_bound(void *priv)
 {
+	received = 0;
+#if defined(CONFIG_MULTITHREADING)
 	k_sem_give(&bound_sem);
+#else
+	bound_sem = 0;
+#endif
 	LOG_INF("Ep bounded");
 }
 
 static void ep_recv(const void *data, size_t len, void *priv)
 {
+#if defined(CONFIG_ASSERT)
 	struct data_packet *packet = (struct data_packet *)data;
-	static unsigned char expected_message = 'a';
-	static size_t expected_len = PACKET_SIZE_START;
 
 	__ASSERT(packet->data[0] == expected_message, "Unexpected message. Expected %c, got %c",
 		expected_message, packet->data[0]);
 	__ASSERT(len == expected_len, "Unexpected length. Expected %zu, got %zu",
 		expected_len, len);
+#endif
 
+#ifndef CONFIG_MULTITHREADING
+	recv_sem = 0;
+#endif
+
+	received += len;
 	expected_message++;
 	expected_len++;
 
@@ -61,11 +79,17 @@ static int send_for_time(struct ipc_ept *ep, const int64_t sending_time_ms)
 		ret = ipc_service_send(ep, &msg, mlen);
 		if (ret == -ENOMEM) {
 			/* No space in the buffer. Retry. */
+			ret = 0;
 			continue;
 		} else if (ret < 0) {
 			LOG_ERR("Failed to send (%c) failed with ret %d", msg.data[0], ret);
 			break;
 		}
+#if !defined(CONFIG_MULTITHREADING)
+		else {
+			recv_sem = 1;
+		}
+#endif
 
 		msg.data[0]++;
 		if (msg.data[0] > 'Z') {
@@ -79,7 +103,12 @@ static int send_for_time(struct ipc_ept *ep, const int64_t sending_time_ms)
 			mlen = PACKET_SIZE_START;
 		}
 
+#if defined(CONFIG_MULTITHREADING)
 		k_usleep(1);
+#else
+		while ((recv_sem != 0) && ((k_uptime_get() - start) < sending_time_ms)) {
+		};
+#endif
 	}
 
 	LOG_INF("Sent %zu [Bytes] over %lld [ms]", bytes_sent, sending_time_ms);
@@ -111,12 +140,17 @@ int main(void)
 	}
 
 	ret = ipc_service_register_endpoint(ipc0_instance, &ep, &ep_cfg);
-	if (ret != 0) {
+	if (ret < 0) {
 		LOG_ERR("ipc_service_register_endpoint() failure");
 		return ret;
 	}
 
+#if defined(CONFIG_MULTITHREADING)
 	k_sem_take(&bound_sem, K_FOREVER);
+#else
+	while (bound_sem != 0) {
+	};
+#endif
 
 	ret = send_for_time(&ep, SENDING_TIME_MS);
 	if (ret < 0) {
@@ -124,6 +158,7 @@ int main(void)
 		return ret;
 	}
 
+	LOG_INF("Received %zu [Bytes] in total", received);
 	LOG_INF("IPC-service REMOTE demo ended");
 
 	return 0;

--- a/samples/subsys/ipc/ipc_service/icmsg/sample.yaml
+++ b/samples/subsys/ipc/ipc_service/icmsg/sample.yaml
@@ -18,6 +18,7 @@ tests:
         - "host: Sent"
         - "host: Received"
         - "host: IPC-service HOST demo ended"
+
   sample.ipc.icmsg.nrf54l15:
     platform_allow: nrf54l15pdk/nrf54l15/cpuapp
     integration_platforms:
@@ -26,4 +27,60 @@ tests:
     extra_args:
       icmsg_SNIPPET=nordic-flpr
     sysbuild: true
-    harness: remote
+    harness: console
+    harness_config:
+      type: multi_line
+      ordered: false
+      regex:
+        - "host: IPC-service HOST demo started"
+        - "host: Ep bounded"
+        - "host: Perform sends for"
+        - "host: Sent"
+        - "host: Received"
+        - "host: IPC-service HOST demo ended"
+
+  sample.ipc.icmsg.nrf54l15_no_multithreading:
+    platform_allow: nrf54l15pdk/nrf54l15/cpuapp
+    integration_platforms:
+      - nrf54l15pdk/nrf54l15/cpuapp
+    tags: ipc
+    extra_args:
+      icmsg_SNIPPET=nordic-flpr
+      icmsg_CONFIG_MULTITHREADING=n
+      icmsg_CONFIG_LOG_MODE_MINIMAL=y
+      remote_CONFIG_MULTITHREADING=n
+      remote_CONFIG_LOG_MODE_MINIMAL=y
+    sysbuild: true
+    harness: console
+    harness_config:
+      type: multi_line
+      ordered: false
+      regex:
+        - "I: IPC-service HOST demo started"
+        - "I: Ep bounded"
+        - "I: Perform sends for"
+        - "I: Sent"
+        - "I: Received"
+        - "I: IPC-service HOST demo ended"
+
+  sample.ipc.icmsg.nrf54l15_remote_no_multithreading:
+    platform_allow: nrf54l15pdk/nrf54l15/cpuapp
+    integration_platforms:
+      - nrf54l15pdk/nrf54l15/cpuapp
+    tags: ipc
+    extra_args:
+      icmsg_SNIPPET=nordic-flpr
+      remote_CONFIG_MULTITHREADING=n
+      remote_CONFIG_LOG_MODE_MINIMAL=y
+    sysbuild: true
+    harness: console
+    harness_config:
+      type: multi_line
+      ordered: false
+      regex:
+        - "host: IPC-service HOST demo started"
+        - "host: Ep bounded"
+        - "host: Perform sends for"
+        - "host: Sent"
+        - "host: Received"
+        - "host: IPC-service HOST demo ended"

--- a/samples/subsys/ipc/ipc_service/icmsg/src/main.c
+++ b/samples/subsys/ipc/ipc_service/icmsg/src/main.c
@@ -18,29 +18,42 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(host, LOG_LEVEL_INF);
 
-
+#if defined(CONFIG_MULTITHREADING)
 K_SEM_DEFINE(bound_sem, 0, 1);
+#else
+volatile uint32_t bound_sem = 1;
+volatile uint32_t recv_sem = 1;
+#endif
+
 static unsigned char expected_message = 'A';
 static size_t expected_len = PACKET_SIZE_START;
-
 static size_t received;
 
 static void ep_bound(void *priv)
 {
 	received = 0;
-
+#if defined(CONFIG_MULTITHREADING)
 	k_sem_give(&bound_sem);
+#else
+	bound_sem = 0;
+#endif
 	LOG_INF("Ep bounded");
 }
 
 static void ep_recv(const void *data, size_t len, void *priv)
 {
+#if defined(CONFIG_ASSERT)
 	struct data_packet *packet = (struct data_packet *)data;
 
 	__ASSERT(packet->data[0] == expected_message, "Unexpected message. Expected %c, got %c",
 		expected_message, packet->data[0]);
 	__ASSERT(len == expected_len, "Unexpected length. Expected %zu, got %zu",
 		expected_len, len);
+#endif
+
+#ifndef CONFIG_MULTITHREADING
+	recv_sem = 0;
+#endif
 
 	received += len;
 	expected_message++;
@@ -76,6 +89,11 @@ static int send_for_time(struct ipc_ept *ep, const int64_t sending_time_ms)
 			LOG_ERR("Failed to send (%c) failed with ret %d", msg.data[0], ret);
 			break;
 		}
+#if !defined(CONFIG_MULTITHREADING)
+		else {
+			recv_sem = 1;
+		}
+#endif
 
 		msg.data[0]++;
 		if (msg.data[0] > 'z') {
@@ -89,7 +107,12 @@ static int send_for_time(struct ipc_ept *ep, const int64_t sending_time_ms)
 			mlen = PACKET_SIZE_START;
 		}
 
+#if defined(CONFIG_MULTITHREADING)
 		k_usleep(1);
+#else
+		while ((recv_sem != 0) && ((k_uptime_get() - start) < sending_time_ms)) {
+		};
+#endif
 	}
 
 	LOG_INF("Sent %zu [Bytes] over %lld [ms]", bytes_sent, sending_time_ms);
@@ -126,7 +149,12 @@ int main(void)
 		return ret;
 	}
 
+#if defined(CONFIG_MULTITHREADING)
 	k_sem_take(&bound_sem, K_FOREVER);
+#else
+	while (bound_sem != 0) {
+	};
+#endif
 
 	ret = send_for_time(&ep, SENDING_TIME_MS);
 	if (ret < 0) {
@@ -135,7 +163,11 @@ int main(void)
 	}
 
 	LOG_INF("Wait 500ms. Let remote core finish its sends");
+#if defined(CONFIG_MULTITHREADING)
 	k_msleep(500);
+#else
+	k_busy_wait(500000);
+#endif
 
 	LOG_INF("Received %zu [Bytes] in total", received);
 

--- a/subsys/ipc/ipc_service/lib/Kconfig.icmsg
+++ b/subsys/ipc/ipc_service/lib/Kconfig.icmsg
@@ -3,6 +3,7 @@
 
 config IPC_SERVICE_ICMSG_SHMEM_ACCESS_SYNC
 	bool "Synchronize access to shared memory"
+	depends on MULTITHREADING
 	default y
 	help
 	  Provide synchronization access to shared memory at a library level.
@@ -30,6 +31,7 @@ config IPC_SERVICE_ICMSG_BOND_NOTIFY_REPEAT_TO_MS
 
 config IPC_SERVICE_BACKEND_ICMSG_WQ_ENABLE
 	bool "Use dedicated workqueue"
+	depends on MULTITHREADING
 	default y
 	help
 	  Enable dedicated workqueue thread for the ICMsg backend.

--- a/subsys/ipc/ipc_service/lib/icmsg.c
+++ b/subsys/ipc/ipc_service/lib/icmsg.c
@@ -15,16 +15,20 @@
 #define BOND_NOTIFY_REPEAT_TO	K_MSEC(CONFIG_IPC_SERVICE_ICMSG_BOND_NOTIFY_REPEAT_TO_MS)
 #define SHMEM_ACCESS_TO		K_MSEC(CONFIG_IPC_SERVICE_ICMSG_SHMEM_ACCESS_TO_MS)
 
-
 static const uint8_t magic[] = {0x45, 0x6d, 0x31, 0x6c, 0x31, 0x4b,
 				0x30, 0x72, 0x6e, 0x33, 0x6c, 0x69, 0x34};
 
+#ifdef CONFIG_MULTITHREADING
 #if defined(CONFIG_IPC_SERVICE_BACKEND_ICMSG_WQ_ENABLE)
 static K_THREAD_STACK_DEFINE(icmsg_stack, CONFIG_IPC_SERVICE_BACKEND_ICMSG_WQ_STACK_SIZE);
 static struct k_work_q icmsg_workq;
 static struct k_work_q *const workq = &icmsg_workq;
 #else
 static struct k_work_q *const workq = &k_sys_work_q;
+#endif
+static void mbox_callback_process(struct k_work *item);
+#else
+static void mbox_callback_process(struct icmsg_data_t *dev_data);
 #endif
 
 static int mbox_deinit(const struct icmsg_config_t *conf,
@@ -42,12 +46,20 @@ static int mbox_deinit(const struct icmsg_config_t *conf,
 		return err;
 	}
 
+#ifdef CONFIG_MULTITHREADING
 	(void)k_work_cancel(&dev_data->mbox_work);
 	(void)k_work_cancel_delayable(&dev_data->notify_work);
+#endif
 
 	return 0;
 }
 
+static bool is_endpoint_ready(struct icmsg_data_t *dev_data)
+{
+	return atomic_get(&dev_data->state) == ICMSG_STATE_READY;
+}
+
+#ifdef CONFIG_MULTITHREADING
 static void notify_process(struct k_work *item)
 {
 	struct k_work_delayable *dwork = k_work_delayable_from_work(item);
@@ -66,37 +78,53 @@ static void notify_process(struct k_work *item)
 		(void)ret;
 	}
 }
-
-static bool is_endpoint_ready(struct icmsg_data_t *dev_data)
+#else
+static void notify_process(struct icmsg_data_t *dev_data)
 {
-	return atomic_get(&dev_data->state) == ICMSG_STATE_READY;
-}
+	(void)mbox_send_dt(&dev_data->cfg->mbox_tx, NULL);
+#if defined(CONFIG_SYS_CLOCK_EXISTS)
+	int64_t start = k_uptime_get();
+#endif
 
+	while (false == is_endpoint_ready(dev_data)) {
+		mbox_callback_process(dev_data);
+
+#if defined(CONFIG_SYS_CLOCK_EXISTS)
+		if ((k_uptime_get() - start) > CONFIG_IPC_SERVICE_ICMSG_BOND_NOTIFY_REPEAT_TO_MS) {
+#endif
+			(void)mbox_send_dt(&dev_data->cfg->mbox_tx, NULL);
+#if defined(CONFIG_SYS_CLOCK_EXISTS)
+			start = k_uptime_get();
+		};
+#endif
+	}
+}
+#endif
+
+#ifdef CONFIG_IPC_SERVICE_ICMSG_SHMEM_ACCESS_SYNC
 static int reserve_tx_buffer_if_unused(struct icmsg_data_t *dev_data)
 {
-#ifdef CONFIG_IPC_SERVICE_ICMSG_SHMEM_ACCESS_SYNC
 	int ret = k_mutex_lock(&dev_data->tx_lock, SHMEM_ACCESS_TO);
 
 	if (ret < 0) {
 		return ret;
 	}
-#endif
+
 	return 0;
 }
 
 static int release_tx_buffer(struct icmsg_data_t *dev_data)
 {
-#ifdef CONFIG_IPC_SERVICE_ICMSG_SHMEM_ACCESS_SYNC
 	return k_mutex_unlock(&dev_data->tx_lock);
-#endif
-	return 0;
 }
+#endif
 
 static uint32_t data_available(struct icmsg_data_t *dev_data)
 {
 	return pbuf_read(dev_data->rx_pb, NULL, 0);
 }
 
+#ifdef CONFIG_MULTITHREADING
 static void submit_mbox_work(struct icmsg_data_t *dev_data)
 {
 	if (k_work_submit_to_queue(workq, &dev_data->mbox_work) < 0) {
@@ -121,10 +149,33 @@ static void submit_work_if_buffer_free_and_data_available(
 
 	submit_mbox_work(dev_data);
 }
-
-static void mbox_callback_process(struct k_work *item)
+#else
+static void submit_if_buffer_free(struct icmsg_data_t *dev_data)
 {
+	mbox_callback_process(dev_data);
+}
+
+static void submit_if_buffer_free_and_data_available(
+		struct icmsg_data_t *dev_data)
+{
+
+	if (!data_available(dev_data)) {
+		return;
+	}
+
+	mbox_callback_process(dev_data);
+}
+#endif
+
+#ifdef CONFIG_MULTITHREADING
+static void mbox_callback_process(struct k_work *item)
+#else
+static void mbox_callback_process(struct icmsg_data_t *dev_data)
+#endif
+{
+#ifdef CONFIG_MULTITHREADING
 	struct icmsg_data_t *dev_data = CONTAINER_OF(item, struct icmsg_data_t, mbox_work);
+#endif
 
 	atomic_t state = atomic_get(&dev_data->state);
 
@@ -141,8 +192,7 @@ static void mbox_callback_process(struct k_work *item)
 
 	if (state == ICMSG_STATE_READY) {
 		if (dev_data->cb->received) {
-			dev_data->cb->received(rx_buffer, len,
-					       dev_data->ctx);
+			dev_data->cb->received(rx_buffer, len, dev_data->ctx);
 		}
 	} else {
 		__ASSERT_NO_MSG(state == ICMSG_STATE_BUSY);
@@ -162,15 +212,22 @@ static void mbox_callback_process(struct k_work *item)
 
 		atomic_set(&dev_data->state, ICMSG_STATE_READY);
 	}
-
+#ifdef CONFIG_MULTITHREADING
 	submit_work_if_buffer_free_and_data_available(dev_data);
+#else
+	submit_if_buffer_free_and_data_available(dev_data);
+#endif
 }
 
 static void mbox_callback(const struct device *instance, uint32_t channel,
 			  void *user_data, struct mbox_msg *msg_data)
 {
 	struct icmsg_data_t *dev_data = user_data;
+#ifdef CONFIG_MULTITHREADING
 	submit_work_if_buffer_free(dev_data);
+#else
+	submit_if_buffer_free(dev_data);
+#endif
 }
 
 static int mbox_init(const struct icmsg_config_t *conf,
@@ -178,8 +235,10 @@ static int mbox_init(const struct icmsg_config_t *conf,
 {
 	int err;
 
+#ifdef CONFIG_MULTITHREADING
 	k_work_init(&dev_data->mbox_work, mbox_callback_process);
 	k_work_init_delayable(&dev_data->notify_work, notify_process);
+#endif
 
 	err = mbox_register_callback_dt(&conf->mbox_rx, mbox_callback, dev_data);
 	if (err != 0) {
@@ -233,12 +292,14 @@ int icmsg_open(const struct icmsg_config_t *conf,
 	if (ret) {
 		return ret;
 	}
-
+#ifdef CONFIG_MULTITHREADING
 	ret = k_work_schedule_for_queue(workq, &dev_data->notify_work, K_NO_WAIT);
 	if (ret < 0) {
 		return ret;
 	}
-
+#else
+	notify_process(dev_data);
+#endif
 	return 0;
 }
 
@@ -263,7 +324,9 @@ int icmsg_send(const struct icmsg_config_t *conf,
 {
 	int ret;
 	int write_ret;
+#ifdef CONFIG_IPC_SERVICE_ICMSG_SHMEM_ACCESS_SYNC
 	int release_ret;
+#endif
 	int sent_bytes;
 
 	if (!is_endpoint_ready(dev_data)) {
@@ -275,14 +338,19 @@ int icmsg_send(const struct icmsg_config_t *conf,
 		return -ENODATA;
 	}
 
+#ifdef CONFIG_IPC_SERVICE_ICMSG_SHMEM_ACCESS_SYNC
 	ret = reserve_tx_buffer_if_unused(dev_data);
 	if (ret < 0) {
 		return -ENOBUFS;
 	}
+#endif
 
 	write_ret = pbuf_write(dev_data->tx_pb, msg, len);
+
+#ifdef CONFIG_IPC_SERVICE_ICMSG_SHMEM_ACCESS_SYNC
 	release_ret = release_tx_buffer(dev_data);
 	__ASSERT_NO_MSG(!release_ret);
+#endif
 
 	if (write_ret < 0) {
 		return write_ret;


### PR DESCRIPTION
Adapting icmsg to work without the MULTITHREADING functionality.
Dependencies for kernel work_queue, mutexes and other functions related to running multi-threaded applications have been 'ifdefed'.