### PR TITLE
soc: stm32h7: m4: Always enable hardware semaphore clock

### DIFF
--- a/soc/st/stm32/stm32h7x/soc_m4.c
+++ b/soc/st/stm32/stm32h7x/soc_m4.c
@@ -37,6 +37,9 @@ static int stm32h7_m4_init(void)
 	LL_ART_SetBaseAddress(DT_REG_ADDR(DT_CHOSEN(zephyr_flash)));
 	LL_ART_Enable();
 
+	/* Enable hardware semaphore clock */
+	LL_AHB4_GRP1_EnableClock(LL_AHB4_GRP1_PERIPH_HSEM);
+
 	/* In case CM4 has not been forced boot by CM7,
 	 * CM4 needs to wait until CM7 has setup clock configuration
 	 */
@@ -47,7 +50,6 @@ static int stm32h7_m4_init(void)
 		 * (system clock config, external memory configuration.. ).
 		 * End of system initialization is reached when CM7 takes HSEM.
 		 */
-		LL_AHB4_GRP1_EnableClock(LL_AHB4_GRP1_PERIPH_HSEM);
 		while ((HSEM->RLR[CFG_HW_ENTRY_STOP_MODE_SEMID] & HSEM_R_LOCK)
 				!= HSEM_R_LOCK)
 			;


### PR DESCRIPTION
When BCM4 bit is set to zero, the hardware semaphore clock (on M4) is never enabled on startup. The hardware semaphores might still randomly work, but very unreliably, and the locking procedure will need several retries despite no competition on the hardware semaphores. This leads to wasted clock cycles on the M4 and sometimes even random kernel panics.

This can be solved by always enabling the hardware semaphore clock in the init procedure of the M4, regardless of whether it is used within the initialization or not. On the M7, it is already always enabled.

Fixes Issue #73859.