### PR TITLE
posix: add a missing include prefix

### DIFF
--- a/include/zephyr/posix/posix_features.h
+++ b/include/zephyr/posix/posix_features.h
@@ -8,7 +8,7 @@
 #ifndef INCLUDE_ZEPHYR_POSIX_POSIX_FEATURES_H_
 #define INCLUDE_ZEPHYR_POSIX_POSIX_FEATURES_H_
 
-#include <autoconf.h>              /* CONFIG_* */
+#include <zephyr/autoconf.h>       /* CONFIG_* */
 #include <zephyr/sys/util_macro.h> /* COND_CODE_1() */
 
 /*


### PR DESCRIPTION
Add the missing prefix so this builds with
CONFIG_LEGACY_GENERATED_INCLUDE_PATH=n