### PR TITLE
sensing: Fix build warning on invalid array index

### DIFF
--- a/subsys/sensing/sensor_mgmt.h
+++ b/subsys/sensing/sensor_mgmt.h
@@ -26,7 +26,7 @@ extern "C" {
 	STRUCT_SECTION_END_EXTERN(sensing_sensor);				\
 	for (struct sensing_sensor *sensor = STRUCT_SECTION_END(sensing_sensor)	\
 		- 1;								\
-	     ({ __ASSERT(sensor >= STRUCT_SECTION_START(sensing_sensor) - 1,	\
+	     ({ __ASSERT(sensor >= STRUCT_SECTION_START(sensing_sensor),	\
 		"unexpected list start location");				\
 		sensor >= STRUCT_SECTION_START(sensing_sensor); });		\
 	     sensor--)


### PR DESCRIPTION
The assert was verifying that the current sensor address was greater or equal than the start of the iterable section - 1 which isn't quite right as the start is inclusive.

Fixes #73851 