### PR TITLE
scripts: set_assignee: change reviewer and labeling algorithm

### DIFF
--- a/scripts/get_maintainer.py
+++ b/scripts/get_maintainer.py
@@ -221,9 +221,11 @@ class Maintainers:
 
         # Make 'path' relative to the repository root and normalize it.
         # normpath() would remove a trailing '/', so we add it afterwards.
-        path = os.path.normpath(os.path.join(
+        # Ensure the path is in posix format to allow script to run in
+        # any OS (the manifest tends to format paths as posix style).
+        path = pathlib.PurePath(os.path.join(
             os.path.relpath(os.getcwd(), self._toplevel),
-            path))
+            path)).as_posix()
 
         if is_dir:
             path += "/"


### PR DESCRIPTION
Change the reviewers allocation strategy on a PR to bias walking through each touched area to pull in the maintainers from that area into the collab list first. Then process the collaborators by picking one collaborator at a time from each area impacted. Note that the order of the names in each collaborator list will matter if there is a large array of areas being touched as it will be more likely to select someone from the top of the list. As such, it may be more prudent to put higher priority people at the top of the list... sort of a "promotion ladder". Also, when an area's collaboration list is exhausted, it is dropped from the iterator list.

Allow the highest priority labels to be applied to the PR based on areas touched.

Signed-off-by: David Leach <david.leach@nxp.com>