### PR TITLE
usb: device_next: rename the rate properties to use the correct unit

### DIFF
--- a/dts/bindings/usb/zephyr,hid-device.yaml
+++ b/dts/bindings/usb/zephyr,hid-device.yaml
@@ -36,11 +36,11 @@ properties:
       The size of the longest input report that the HID device can generate.
       This property is used to determine the buffer length used for transfers.
 
-  in-polling-rate:
+  in-polling-period-us:
     type: int
     required: true
     description: |
-      Input or output type reports polling rate in microseconds. For USB full
+      Input or output type reports polling period in microseconds. For USB full
       speed this could be clamped to 1ms or 255ms depending on the value.
 
   out-report-size:
@@ -50,9 +50,9 @@ properties:
       When this property is present, a USB device will use out pipe for output
       reports, otherwise control pipe will be used for output reports.
 
-  out-polling-rate:
+  out-polling-period-us:
     type: int
     description: |
-      Output type reports polling rate in microseconds. For USB full
+      Output type reports polling period in microseconds. For USB full
       speed this could be clamped to 1ms or 255ms depending on the value.
       This option is only effective if the out-report-size property is defined.

--- a/samples/subsys/usb/hid-keyboard/app.overlay
+++ b/samples/subsys/usb/hid-keyboard/app.overlay
@@ -10,6 +10,6 @@
 		interface-name = "HID0";
 		protocol-code = "keyboard";
 		in-report-size = <64>;
-		in-polling-rate = <1000>;
+		in-polling-period-us = <1000>;
 	};
 };

--- a/samples/subsys/usb/hid-keyboard/large_in_report.overlay
+++ b/samples/subsys/usb/hid-keyboard/large_in_report.overlay
@@ -9,6 +9,6 @@
 		compatible = "zephyr,hid-device";
 		interface-name = "HID0";
 		in-report-size = <256>;
-		in-polling-rate = <1000>;
+		in-polling-period-us = <1000>;
 	};
 };

--- a/samples/subsys/usb/hid-keyboard/large_out_report.overlay
+++ b/samples/subsys/usb/hid-keyboard/large_out_report.overlay
@@ -10,6 +10,6 @@
 	hid_dev_0: hid_dev_0 {
 		compatible = "zephyr,hid-device";
 		out-report-size = <128>;
-		out-polling-rate = <16000>;
+		out-polling-period-us = <16000>;
 	};
 };

--- a/samples/subsys/usb/hid-keyboard/out_report.overlay
+++ b/samples/subsys/usb/hid-keyboard/out_report.overlay
@@ -10,6 +10,6 @@
 	hid_dev_0: hid_dev_0 {
 		compatible = "zephyr,hid-device";
 		out-report-size = <64>;
-		out-polling-rate = <16000>;
+		out-polling-period-us = <16000>;
 	};
 };

--- a/samples/subsys/usb/hid-mouse/usbd_next.overlay
+++ b/samples/subsys/usb/hid-mouse/usbd_next.overlay
@@ -9,7 +9,7 @@
 		compatible = "zephyr,hid-device";
 		interface-name = "HID0";
 		protocol-code = "none";
-		in-polling-rate = <1000>;
+		in-polling-period-us = <1000>;
 		in-report-size = <64>;
 	};
 };

--- a/subsys/usb/device_next/class/usbd_hid_macros.h
+++ b/subsys/usb/device_next/class/usbd_hid_macros.h
@@ -1056,16 +1056,16 @@
 		 HID_MPS_LESS_65(DT_INST_PROP(n, in_report_size)))
 
 /* Get IN endpoint polling rate based on the desired speed. */
-#define HID_IN_EP_INTERVAL(n, hs)						\
-	COND_CODE_1(hs,								\
-		    (USB_HS_INT_EP_INTERVAL(DT_INST_PROP(n, in_polling_rate))),	\
-		    (USB_FS_INT_EP_INTERVAL(DT_INST_PROP(n, in_polling_rate))))
+#define HID_IN_EP_INTERVAL(n, hs)							\
+	COND_CODE_1(hs,									\
+		    (USB_HS_INT_EP_INTERVAL(DT_INST_PROP(n, in_polling_period_us))),	\
+		    (USB_FS_INT_EP_INTERVAL(DT_INST_PROP(n, in_polling_period_us))))
 
 /* Get OUT endpoint polling rate based on the desired speed. */
-#define HID_OUT_EP_INTERVAL(n, hs)						\
-	COND_CODE_1(hs,								\
-		    (USB_HS_INT_EP_INTERVAL(DT_INST_PROP(n, out_polling_rate))),\
-		    (USB_FS_INT_EP_INTERVAL(DT_INST_PROP(n, out_polling_rate))))
+#define HID_OUT_EP_INTERVAL(n, hs)							\
+	COND_CODE_1(hs,									\
+		    (USB_HS_INT_EP_INTERVAL(DT_INST_PROP(n, out_polling_period_us))),	\
+		    (USB_FS_INT_EP_INTERVAL(DT_INST_PROP(n, out_polling_period_us))))
 
 /* Get the number of endpoints, which can be either 1 or 2 */
 #define HID_NUM_ENDPOINTS(n)							\


### PR DESCRIPTION
The polling properties are a period in us but are named as "-rate" right now, which would imply that that's a frequency. Rename them to "period-us" to make that unambiguous.