### PR TITLE
doc: usb: add initial USB device configuration howto 

### DIFF
--- a/doc/connectivity/usb/device_next/api/index.rst
+++ b/doc/connectivity/usb/device_next/api/index.rst
@@ -9,3 +9,4 @@ New USB device support APIs
    udc.rst
    usbd.rst
    usbd_hid_device.rst
+   uac2_device.rst

--- a/doc/connectivity/usb/device_next/api/index.rst
+++ b/doc/connectivity/usb/device_next/api/index.rst
@@ -8,3 +8,4 @@ New USB device support APIs
 
    udc.rst
    usbd.rst
+   usbd_hid_device.rst

--- a/doc/connectivity/usb/device_next/api/uac2_device.rst
+++ b/doc/connectivity/usb/device_next/api/uac2_device.rst
@@ -1,0 +1,11 @@
+.. _uac2_device:
+
+Audio Class 2 device API
+########################
+
+USB Audio Class 2 device specific API defined in :zephyr_file:`include/zephyr/usb/class/usbd_uac2.h`.
+
+API Reference
+*************
+
+.. doxygengroup:: uac2_device

--- a/doc/connectivity/usb/device_next/api/usbd_hid_device.rst
+++ b/doc/connectivity/usb/device_next/api/usbd_hid_device.rst
@@ -1,0 +1,11 @@
+.. _usbd_hid_device:
+
+HID device API
+##############
+
+HID device specific API defined in :zephyr_file:`include/zephyr/usb/class/usbd_hid.h`.
+
+API Reference
+*************
+
+.. doxygengroup:: usbd_hid_device

--- a/doc/connectivity/usb/device_next/usb_device.rst
+++ b/doc/connectivity/usb/device_next/usb_device.rst
@@ -76,3 +76,112 @@ configuration ``-DCONF_FILE=usbd_next_prj.conf`` either directly or via
   set the configuration overlay file
   ``-DDEXTRA_CONF_FILE=overlay-usbd_next_ecm.conf`` and devicetree overlay file
   ``-DDTC_OVERLAY_FILE="usbd_next_ecm.overlay`` either directly or via ``west``.
+
+How to configure and enable USB device support
+**********************************************
+
+For the USB device support samples in the Zephyr project repository, we have a
+common file for instantiation, configuration and initialization,
+:zephyr_file:`samples/subsys/usb/common/sample_usbd_init.c`. The following code
+snippets from this file are used as examples. USB Samples Kconfig options used
+in the USB samples and prefixed with ``SAMPLE_USBD_`` have default values
+specific to the Zephyr project and the scope is limited to the project samples.
+In the examples below, you will need to replace these Kconfig options and other
+defaults with values appropriate for your application or hardware.
+
+The USB device stack requires a context structure to manage its properties and
+runtime data. The preferred way to define a device context is to use the
+:c:macro:`USBD_DEVICE_DEFINE` macro. This creates a static
+:c:struct:`usbd_context` variable with a given name. Any number of contexts may
+be instantiated. A USB controller device can be assigned to multiple contexts,
+but only one context can be initialized and used at a time. Context properties
+must not be directly accessed or manipulated by the application.
+
+.. literalinclude:: ../../../../samples/subsys/usb/common/sample_usbd_init.c
+   :language: c
+   :start-after: doc device instantiation start
+   :end-before: doc device instantiation end
+
+Your USB device may have manufacturer, product, and serial number string
+descriptors. To instantiate these string descriptors, the application should
+use the appropriate :c:macro:`USBD_DESC_MANUFACTURER_DEFINE`,
+:c:macro:`USBD_DESC_PRODUCT_DEFINE`, and
+:c:macro:`USBD_DESC_SERIAL_NUMBER_DEFINE` macros. String descriptors also
+require a single instantiation of the language descriptor using the
+:c:macro:`USBD_DESC_LANG_DEFINE` macro.
+
+.. literalinclude:: ../../../../samples/subsys/usb/common/sample_usbd_init.c
+   :language: c
+   :start-after: doc string instantiation start
+   :end-before: doc string instantiation end
+
+String descriptors must be added to the device context at runtime before
+initializing the USB device with :c:func:`usbd_add_descriptor`.
+
+.. literalinclude:: ../../../../samples/subsys/usb/common/sample_usbd_init.c
+   :language: c
+   :start-after: doc add string descriptor start
+   :end-before: doc add string descriptor end
+
+USB device requires at least one configuration instance per supported speed.
+The application should use :c:macro:`USBD_CONFIGURATION_DEFINE` to instantiate
+a configuration. Later, USB device functions are assigned to a configuration.
+
+.. literalinclude:: ../../../../samples/subsys/usb/common/sample_usbd_init.c
+   :language: c
+   :start-after: doc configuration instantiation start
+   :end-before: doc configuration instantiation end
+
+Each configuration instance for a specific speed must be added to the device
+context at runtime before the USB device is initialized using
+:c:func:`usbd_add_configuration`. Note :c:enumerator:`USBD_SPEED_FS` and
+:c:enumerator:`USBD_SPEED_HS`. The first full-speed or high-speed
+configuration will get ``bConfigurationValue`` one, and then further upward.
+
+.. literalinclude:: ../../../../samples/subsys/usb/common/sample_usbd_init.c
+   :language: c
+   :start-after: doc configuration register start
+   :end-before: doc configuration register end
+
+
+Although we have already done a lot, this USB device has no function. A device
+can have multiple configurations with different set of functions at different
+speeds. A function or class can be registered on a USB device before
+it is initialized using :c:func:`usbd_register_class`. The desired
+configuration is specified using :c:enumerator:`USBD_SPEED_FS` or
+:c:enumerator:`USBD_SPEED_HS` and the configuration number.  For simple cases,
+:c:func:`usbd_register_all_classes` can be used to register all available
+instances.
+
+.. literalinclude:: ../../../../samples/subsys/usb/common/sample_usbd_init.c
+   :language: c
+   :start-after: doc functions register start
+   :end-before: doc functions register end
+
+The last step in the preparation is to initialize the device with
+:c:func:`usbd_init`. After this, the configuration of the device cannot be
+changed. A device can be deinitialized with :c:func:`usbd_shutdown` and all
+instances can be reused, but the previous steps must be repeated. So it is
+possible to shutdown a device, register another type of configuration or
+function, and initialize it again.  At the USB controller level,
+:c:func:`usbd_init` does only what is necessary to detect VBUS changes. There
+are controller types where the next step is only possible if a VBUS signal is
+present.
+
+A function or class implementation may require its own specific configuration
+steps, which should be performed prior to initializing the USB device.
+
+.. literalinclude:: ../../../../samples/subsys/usb/common/sample_usbd_init.c
+   :language: c
+   :start-after: doc device init start
+   :end-before: doc device init end
+
+The final step to enable the USB device is :c:func:`usbd_enable`, after that,
+if the USB device is connected to a USB host controller, the host can start
+enumerating the device. The application can disable the USB device using
+:c:func:`usbd_disable`.
+
+.. literalinclude:: ../../../../samples/subsys/usb/hid-keyboard/src/main.c
+   :language: c
+   :start-after: doc device enable start
+   :end-before: doc device enable end

--- a/doc/connectivity/usb/device_next/usb_device.rst
+++ b/doc/connectivity/usb/device_next/usb_device.rst
@@ -1,57 +1,78 @@
 .. _usb_device_stack_next:
 
-New experimental USB device support
-###################################
+New USB device support
+######################
 
 Overview
 ********
 
-The new USB device support is experimental. It consists of :ref:`udc_api`
-and :ref:`usbd_api`. The new device stack brings support for multiple device
-controllers, support for multiple configurations, and dynamic registration of
-class instances to a configuration at runtime. The stack also provides a specific
-class API that should be used to implement the functions (classes).
-It will replace :ref:`usb_device_stack`.
+USB device support consists of the USB device controller (UDC) drivers
+, :ref:`udc_api`, and USB device stack, :ref:`usbd_api`.
+The :ref:`udc_api` provides a generic and vendor independent interface to USB
+device controllers, and although, there a is clear separation between these
+layers, the purpose of :ref:`udc_api` is to serve new Zephyr's USB device stack
+exclusively.
 
-If you would like to play around with the new device support, or the new USB
-support in general, please try :zephyr:code-sample:`usb-shell` sample. The sample is mainly to help
-test the capabilities of the stack and correct implementation of the USB controller
-drivers.
+The new device stack supports multiple device controllers, meaning that if a
+SoC has multiple controllers, they can be used simultaneously. Full and
+high-speed device controllers are supported. It also provides support for
+registering multiple function or class instances to a configuration at runtime,
+or changing the configuration later. It has built-in support for several USB
+classes and provides an API to implement custom USB functions.
 
-Supported USB classes
-*********************
+The new USB device support is considered experimental and will replace
+:ref:`usb_device_stack`.
 
-Bluetooth HCI USB transport layer
-=================================
-
-See :ref:`bluetooth-hci-usb-sample` sample for reference.
-To build the sample for the new device support, set the configuration
-``-DCONF_FILE=usbd_next_prj.conf`` either directly or via ``west``.
-
-CDC ACM
-=======
-
-CDC ACM implementation has support for multiple instances.
-Description from :ref:`usb_device_cdc_acm` also applies to the new implementation.
-See :zephyr:code-sample:`usb-cdc-acm` sample for reference.
-To build the sample for the new device support, set the configuration
-``-DCONF_FILE=usbd_next_prj.conf`` either directly or via ``west``.
-
-Mass Storage Class
+Built-in functions
 ==================
 
-See :zephyr:code-sample:`usb-mass` sample for reference.
-To build the sample for the new device support, set the configuration
-``-DCONF_FILE=usbd_next_prj.conf`` either directly or via ``west``.
+The USB device stack has built-in USB functions. Some can be used directly in
+the user application through a special API, such as HID or Audio class devices,
+while others use a general Zephyr RTOS driver API, such as MSC and CDC class
+implementations. The *Identification string* identifies a class or function
+instance (n) and is used as an argument to the :c:func:`usbd_register_class`.
 
-Networking
-==========
++-----------------------------------+-------------------------+-------------------------+
+| Class or function                 | User API (if any)       | Identification string   |
++===================================+=========================+=========================+
+| USB Audio 2 class                 | :ref:`uac2_device`      | uac2_(n)                |
++-----------------------------------+-------------------------+-------------------------+
+| USB CDC ACM class                 | :ref:`uart_api`         | cdc_acm_(n)             |
++-----------------------------------+-------------------------+-------------------------+
+| USB CDC ECM class                 | Ethernet device         | cdc_ecm_(n)             |
++-----------------------------------+-------------------------+-------------------------+
+| USB Mass Storage Class (MSC)      | :ref:`disk_access_api`  | msc_(n)                 |
++-----------------------------------+-------------------------+-------------------------+
+| USB Human Interface Devices (HID) | :ref:`usbd_hid_device`  | hid_(n)                 |
++-----------------------------------+-------------------------+-------------------------+
+| Bluetooth HCI USB transport layer | :ref:`bt_hci_raw`       | bt_hci_(n)              |
++-----------------------------------+-------------------------+-------------------------+
 
-At the moment only CDC ECM class is implemented and has support for multiple instances.
-It provides a virtual Ethernet connection between the remote (USB host) and
-Zephyr network support.
+Samples
+=======
 
-See :zephyr:code-sample:`zperf` for reference.
-To build the sample for the new device support, set the configuration overlay file
-``-DDEXTRA_CONF_FILE=overlay-usbd_next_ecm.conf`` and devicetree overlay file
-``-DDTC_OVERLAY_FILE="usbd_next_ecm.overlay`` either directly or via ``west``.
+* :zephyr:code-sample:`usb-hid-keyboard`
+
+* :zephyr:code-sample:`uac2-explicit-feedback`
+
+Samples ported to new USB device support
+----------------------------------------
+
+To build a sample that supports both the old and new USB device stack, set the
+configuration ``-DCONF_FILE=usbd_next_prj.conf`` either directly or via
+``west``.
+
+* :ref:`bluetooth-hci-usb-sample`
+
+* :zephyr:code-sample:`usb-cdc-acm`
+
+* :zephyr:code-sample:`usb-cdc-acm-console`
+
+* :zephyr:code-sample:`usb-mass`
+
+* :zephyr:code-sample:`usb-hid-mouse`
+
+* :zephyr:code-sample:`zperf` To build the sample for the new device support,
+  set the configuration overlay file
+  ``-DDEXTRA_CONF_FILE=overlay-usbd_next_ecm.conf`` and devicetree overlay file
+  ``-DDTC_OVERLAY_FILE="usbd_next_ecm.overlay`` either directly or via ``west``.

--- a/include/zephyr/usb/class/usbd_uac2.h
+++ b/include/zephyr/usb/class/usbd_uac2.h
@@ -19,6 +19,18 @@
 
 #include <zephyr/device.h>
 
+/**
+ * @brief USB Audio Class 2 device API
+ * @defgroup uac2_device USB Audio Class 2 device API
+ * @ingroup usb
+ * @{
+ */
+
+/**
+ * @brief Get entity ID
+ *
+ * @param node node identifier
+ */
 #define UAC2_ENTITY_ID(node)							\
 	({									\
 		BUILD_ASSERT(DT_NODE_HAS_COMPAT(DT_PARENT(node), zephyr_uac2));	\
@@ -135,5 +147,9 @@ void usbd_uac2_set_ops(const struct device *dev,
  */
 int usbd_uac2_send(const struct device *dev, uint8_t terminal,
 		   void *data, uint16_t size);
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_INCLUDE_USB_CLASS_USBD_UAC2_H_ */

--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -660,13 +660,32 @@ int usbd_add_configuration(struct usbd_context *uds_ctx,
  * @param[in] uds_ctx Pointer to USB device support context
  * @param[in] name    Class instance name
  * @param[in] speed   Configuration speed
- * @param[in] cfg     Configuration value (similar to bConfigurationValue)
+ * @param[in] cfg     Configuration value (bConfigurationValue)
  *
  * @return 0 on success, other values on fail.
  */
 int usbd_register_class(struct usbd_context *uds_ctx,
 			const char *name,
 			const enum usbd_speed speed, uint8_t cfg);
+
+/**
+ * @brief Register all available USB class instances
+ *
+ * Register all available instances. Like usbd_register_class, but does not
+ * take the instance name and instead registers all available instances.
+ *
+ * @note This cannot be combined. If your application calls
+ * usbd_register_class for any device, configuration number, or instance,
+ * either usbd_register_class or this function will fail.
+ *
+ * @param[in] uds_ctx Pointer to USB device support context
+ * @param[in] speed   Configuration speed
+ * @param[in] cfg     Configuration value (bConfigurationValue)
+ *
+ * @return 0 on success, other values on fail.
+ */
+int usbd_register_all_classes(struct usbd_context *uds_ctx,
+			      const enum usbd_speed speed, uint8_t cfg);
 
 /**
  * @brief Unregister an USB class instance
@@ -678,13 +697,28 @@ int usbd_register_class(struct usbd_context *uds_ctx,
  * @param[in] uds_ctx Pointer to USB device support context
  * @param[in] name    Class instance name
  * @param[in] speed   Configuration speed
- * @param[in] cfg     Configuration value (similar to bConfigurationValue)
+ * @param[in] cfg     Configuration value (bConfigurationValue)
  *
  * @return 0 on success, other values on fail.
  */
 int usbd_unregister_class(struct usbd_context *uds_ctx,
 			  const char *name,
 			  const enum usbd_speed speed, uint8_t cfg);
+
+/**
+ * @brief Unregister all available USB class instances
+ *
+ * Unregister all available instances. Like usbd_unregister_class, but does not
+ * take the instance name and instead unregisters all available instances.
+ *
+ * @param[in] uds_ctx Pointer to USB device support context
+ * @param[in] speed   Configuration speed
+ * @param[in] cfg     Configuration value (bConfigurationValue)
+ *
+ * @return 0 on success, other values on fail.
+ */
+int usbd_unregister_all_classes(struct usbd_context *uds_ctx,
+				const enum usbd_speed speed, uint8_t cfg);
 
 /**
  * @brief Register USB notification message callback

--- a/samples/subsys/usb/common/sample_usbd_init.c
+++ b/samples/subsys/usb/common/sample_usbd_init.c
@@ -15,27 +15,40 @@ LOG_MODULE_REGISTER(usbd_sample_config);
 
 #define ZEPHYR_PROJECT_USB_VID		0x2fe3
 
+/* doc device instantiation start */
+/*
+ * Instantiate a context named sample_usbd using the default USB device
+ * controller, the Zephyr project vendor ID, and the sample product ID.
+ * Zephyr project vendor ID must not be used outside of Zephyr samples.
+ */
 USBD_DEVICE_DEFINE(sample_usbd,
 		   DEVICE_DT_GET(DT_NODELABEL(zephyr_udc0)),
 		   ZEPHYR_PROJECT_USB_VID, CONFIG_SAMPLE_USBD_PID);
+/* doc device instantiation end */
 
+/* doc string instantiation start */
 USBD_DESC_LANG_DEFINE(sample_lang);
 USBD_DESC_MANUFACTURER_DEFINE(sample_mfr, CONFIG_SAMPLE_USBD_MANUFACTURER);
 USBD_DESC_PRODUCT_DEFINE(sample_product, CONFIG_SAMPLE_USBD_PRODUCT);
 USBD_DESC_SERIAL_NUMBER_DEFINE(sample_sn);
+/* doc string instantiation end */
 
+/* doc configuration instantiation start */
 static const uint8_t attributes = (IS_ENABLED(CONFIG_SAMPLE_USBD_SELF_POWERED) ?
 				   USB_SCD_SELF_POWERED : 0) |
 				  (IS_ENABLED(CONFIG_SAMPLE_USBD_REMOTE_WAKEUP) ?
 				   USB_SCD_REMOTE_WAKEUP : 0);
 
+/* Full speed configuration */
 USBD_CONFIGURATION_DEFINE(sample_fs_config,
 			  attributes,
 			  CONFIG_SAMPLE_USBD_MAX_POWER);
 
+/* High speed configuration */
 USBD_CONFIGURATION_DEFINE(sample_hs_config,
 			  attributes,
 			  CONFIG_SAMPLE_USBD_MAX_POWER);
+/* doc configuration instantiation end */
 
 /*
  * This does not yet provide valuable information, but rather serves as an
@@ -73,6 +86,7 @@ struct usbd_context *sample_usbd_init_device(usbd_msg_cb_t msg_cb)
 {
 	int err;
 
+	/* doc add string descriptor start */
 	err = usbd_add_descriptor(&sample_usbd, &sample_lang);
 	if (err) {
 		LOG_ERR("Failed to initialize language descriptor (%d)", err);
@@ -96,6 +110,7 @@ struct usbd_context *sample_usbd_init_device(usbd_msg_cb_t msg_cb)
 		LOG_ERR("Failed to initialize SN descriptor (%d)", err);
 		return NULL;
 	}
+	/* doc add string descriptor end */
 
 	if (usbd_caps_speed(&sample_usbd) == USBD_SPEED_HS) {
 		err = usbd_add_configuration(&sample_usbd, USBD_SPEED_HS,
@@ -114,21 +129,26 @@ struct usbd_context *sample_usbd_init_device(usbd_msg_cb_t msg_cb)
 		sample_fix_code_triple(&sample_usbd, USBD_SPEED_HS);
 	}
 
+	/* doc configuration register start */
 	err = usbd_add_configuration(&sample_usbd, USBD_SPEED_FS,
 				     &sample_fs_config);
 	if (err) {
 		LOG_ERR("Failed to add Full-Speed configuration");
 		return NULL;
 	}
+	/* doc configuration register end */
 
+	/* doc functions register start */
 	err = usbd_register_all_classes(&sample_usbd, USBD_SPEED_FS, 1);
 	if (err) {
 		LOG_ERR("Failed to add register classes");
 		return NULL;
 	}
+	/* doc functions register end */
 
 	sample_fix_code_triple(&sample_usbd, USBD_SPEED_FS);
 
+	/* doc message callback register start */
 	if (msg_cb != NULL) {
 		err = usbd_msg_register_cb(&sample_usbd, msg_cb);
 		if (err) {
@@ -136,6 +156,7 @@ struct usbd_context *sample_usbd_init_device(usbd_msg_cb_t msg_cb)
 			return NULL;
 		}
 	}
+	/* doc message callback register end */
 
 	if (IS_ENABLED(CONFIG_SAMPLE_USBD_20_EXTENSION_DESC)) {
 		(void)usbd_device_set_bcd(&sample_usbd, USBD_SPEED_FS, 0x0201);
@@ -148,11 +169,13 @@ struct usbd_context *sample_usbd_init_device(usbd_msg_cb_t msg_cb)
 		}
 	}
 
+	/* doc device init start */
 	err = usbd_init(&sample_usbd);
 	if (err) {
 		LOG_ERR("Failed to initialize device support");
 		return NULL;
 	}
+	/* doc device init end */
 
 	return &sample_usbd;
 }

--- a/samples/subsys/usb/hid-keyboard/src/main.c
+++ b/samples/subsys/usb/hid-keyboard/src/main.c
@@ -184,11 +184,13 @@ int main(void)
 		return -ENODEV;
 	}
 
+	/* doc device enable start */
 	ret = usbd_enable(sample_usbd);
 	if (ret) {
 		LOG_ERR("Failed to enable device support");
 		return ret;
 	}
+	/* doc device enable end */
 
 	LOG_INF("HID keyboard sample is initialized");
 

--- a/subsys/usb/device_next/usbd_class.c
+++ b/subsys/usb/device_next/usbd_class.c
@@ -340,6 +340,42 @@ register_class_error:
 	return ret;
 }
 
+int usbd_register_all_classes(struct usbd_context *const uds_ctx,
+			      const enum usbd_speed speed, const uint8_t cfg)
+{
+	int ret;
+
+	if (speed == USBD_SPEED_HS) {
+		STRUCT_SECTION_FOREACH_ALTERNATE(usbd_class_hs, usbd_class_node, c_nd) {
+			ret = usbd_register_class(uds_ctx, c_nd->c_data->name,
+						  speed, cfg);
+			if (ret) {
+				LOG_ERR("Failed to register %s to HS configuration %u",
+					c_nd->c_data->name, cfg);
+				return ret;
+			}
+		}
+
+		return 0;
+	}
+
+	if (speed == USBD_SPEED_FS) {
+		STRUCT_SECTION_FOREACH_ALTERNATE(usbd_class_fs, usbd_class_node, c_nd) {
+			ret = usbd_register_class(uds_ctx, c_nd->c_data->name,
+						  speed, cfg);
+			if (ret) {
+				LOG_ERR("Failed to register %s to FS configuration %u",
+					c_nd->c_data->name, cfg);
+				return ret;
+			}
+		}
+
+		return 0;
+	}
+
+	return -ENOTSUP;
+}
+
 int usbd_unregister_class(struct usbd_context *const uds_ctx,
 			  const char *name,
 			  const enum usbd_speed speed, const uint8_t cfg)
@@ -406,4 +442,40 @@ int usbd_unregister_class(struct usbd_context *const uds_ctx,
 unregister_class_error:
 	usbd_device_unlock(uds_ctx);
 	return ret;
+}
+
+int usbd_unregister_all_classes(struct usbd_context *const uds_ctx,
+				const enum usbd_speed speed, const uint8_t cfg)
+{
+	int ret;
+
+	if (speed == USBD_SPEED_HS) {
+		STRUCT_SECTION_FOREACH_ALTERNATE(usbd_class_hs, usbd_class_node, c_nd) {
+			ret = usbd_unregister_class(uds_ctx, c_nd->c_data->name,
+						    speed, cfg);
+			if (ret) {
+				LOG_ERR("Failed to unregister %s to HS configuration %u",
+					c_nd->c_data->name, cfg);
+				return ret;
+			}
+		}
+
+		return 0;
+	}
+
+	if (speed == USBD_SPEED_FS) {
+		STRUCT_SECTION_FOREACH_ALTERNATE(usbd_class_fs, usbd_class_node, c_nd) {
+			ret = usbd_unregister_class(uds_ctx, c_nd->c_data->name,
+						    speed, cfg);
+			if (ret) {
+				LOG_ERR("Failed to unregister %s to FS configuration %u",
+					c_nd->c_data->name, cfg);
+				return ret;
+			}
+		}
+
+		return 0;
+	}
+
+	return -ENOTSUP;
 }

--- a/tests/subsys/usb/device_next/src/main.c
+++ b/tests/subsys/usb/device_next/src/main.c
@@ -134,9 +134,21 @@ static void *usb_test_enable(void)
 	zassert_equal(err, 0, "Failed to add configuration (%d)");
 
 	if (usbd_caps_speed(&test_usbd) == USBD_SPEED_HS) {
+		err = usbd_register_all_classes(&test_usbd, USBD_SPEED_HS, 1);
+		zassert_equal(err, 0, "Failed to unregister all instances(%d)");
+
+		err = usbd_unregister_all_classes(&test_usbd, USBD_SPEED_HS, 1);
+		zassert_equal(err, 0, "Failed to unregister all instances(%d)");
+
 		err = usbd_register_class(&test_usbd, "loopback_0", USBD_SPEED_HS, 1);
 		zassert_equal(err, 0, "Failed to register loopback_0 class (%d)");
 	}
+
+	err = usbd_register_all_classes(&test_usbd, USBD_SPEED_FS, 1);
+	zassert_equal(err, 0, "Failed to unregister all instances(%d)");
+
+	err = usbd_unregister_all_classes(&test_usbd, USBD_SPEED_FS, 1);
+	zassert_equal(err, 0, "Failed to unregister all instances(%d)");
 
 	err = usbd_register_class(&test_usbd, "loopback_0", USBD_SPEED_FS, 1);
 	zassert_equal(err, 0, "Failed to register loopback_0 class (%d)");


### PR DESCRIPTION
Add initial documentation how to configure and enable new USB device
support. Use literalinclude to pull code snippets from the samples.