### PR TITLE
Add support for backup registers on STM32G0

### DIFF
--- a/boards/st/nucleo_g071rb/nucleo_g071rb.dts
+++ b/boards/st/nucleo_g071rb/nucleo_g071rb.dts
@@ -94,6 +94,10 @@
 	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000400>,
 		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
 	status = "okay";
+
+	backup_regs {
+		status = "okay";
+	};
 };
 
 &iwdg {

--- a/drivers/bbram/bbram_stm32.c
+++ b/drivers/bbram/bbram_stm32.c
@@ -11,6 +11,7 @@
 #include <zephyr/drivers/bbram.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
+#include <stm32_ll_pwr.h>
 #include <stm32_ll_rtc.h>
 LOG_MODULE_REGISTER(bbram, CONFIG_BBRAM_LOG_LEVEL);
 
@@ -65,6 +66,10 @@ static int bbram_stm32_write(const struct device *dev, size_t offset, size_t siz
 		return -EFAULT;
 	}
 
+#if defined(PWR_CR_DBP) || defined(PWR_CR1_DBP) || defined(PWR_DBPCR_DBP) || defined(PWR_DBPR_DBP)
+	LL_PWR_EnableBkUpAccess();
+#endif /* PWR_CR_DBP || PWR_CR1_DBP || PWR_DBPCR_DBP || PWR_DBPR_DBP */
+
 	for (size_t written = 0; written < size; written += to_copy) {
 		reg = STM32_BKP_REG(STM32_BKP_REG_INDEX(offset + written));
 		begin = STM32_BKP_REG_BYTE_INDEX(offset + written);
@@ -72,6 +77,10 @@ static int bbram_stm32_write(const struct device *dev, size_t offset, size_t siz
 		bytecpy((uint8_t *)&reg + begin, data + written, to_copy);
 		STM32_BKP_REG(STM32_BKP_REG_INDEX(offset + written)) = reg;
 	}
+
+#if defined(PWR_CR_DBP) || defined(PWR_CR1_DBP) || defined(PWR_DBPCR_DBP) || defined(PWR_DBPR_DBP)
+	LL_PWR_DisableBkUpAccess();
+#endif /* PWR_CR_DBP || PWR_CR1_DBP || PWR_DBPCR_DBP || PWR_DBPR_DBP */
 
 	return 0;
 }

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -192,6 +192,18 @@
 			alarms-count = <2>;
 			alrm-exti-line = <19>;
 			status = "disabled";
+
+			/* In STM32G0, the backup registers are defined as part of the TAMP
+			 * peripheral. This peripheral is not implemented in Zephyr yet, however,
+			 * the reference manual states that tamp_pclk is connected to rtc_pclk.
+			 * It makes sense to have BBRAM instantiated as a child of RTC, so that
+			 * the driver can verify that its parent device (RTC) is ready.
+			 */
+			bbram: backup_regs {
+				compatible = "st,stm32-bbram";
+				st,backup-regs = <5>;
+				status = "disabled";
+			};
 		};
 
 		iwdg: watchdog@40003000 {

--- a/tests/drivers/bbram/testcase.yaml
+++ b/tests/drivers/bbram/testcase.yaml
@@ -21,9 +21,11 @@ tests:
     extra_args: OVERLAY_CONFIG="stm32.conf"
     filter: dt_compat_enabled("st,stm32-bbram")
     integration_platforms:
+      - nucleo_g071rb
       - stm32f746g_disco
   drivers.bbram.stm32_rtc:
     extra_args: OVERLAY_CONFIG="stm32_rtc.conf"
     filter: dt_compat_enabled("st,stm32-bbram")
     integration_platforms:
+      - nucleo_g071rb
       - stm32f746g_disco


### PR DESCRIPTION
This is inspired from the STM32WL case, which should also be fixed at the same time (not tested, but the datasheet also mentions the Backup Domain Protection)