### PR TITLE
drivers: rtc: rtc_shell: Add devices as sub commands

### DIFF
--- a/drivers/rtc/rtc_shell.c
+++ b/drivers/rtc/rtc_shell.c
@@ -217,6 +217,16 @@ static int cmd_get(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
+static void device_name_get(size_t idx, struct shell_static_entry *entry)
+{
+	const struct device *dev = shell_device_lookup(idx, NULL);
+
+	entry->syntax = (dev != NULL) ? dev->name : NULL;
+	entry->handler = NULL;
+	entry->help = NULL;
+	entry->subcmd = NULL;
+}
+
 #define RTC_GET_HELP                                                                               \
 	("Get current time (UTC)\n"                                                                \
 	 "Usage: rtc get <device>")
@@ -225,10 +235,12 @@ static int cmd_get(const struct shell *sh, size_t argc, char **argv)
 	("Set UTC time\n"                                                                          \
 	 "Usage: rtc set <device> <YYYY-MM-DDThh:mm:ss> | <YYYY-MM-DD> | <hh:mm:ss>")
 
+SHELL_DYNAMIC_CMD_CREATE(dsub_device_name, device_name_get);
+
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_rtc,
 			       /* Alphabetically sorted */
-			       SHELL_CMD_ARG(set, NULL, RTC_SET_HELP, cmd_set, 3, 0),
-			       SHELL_CMD_ARG(get, NULL, RTC_GET_HELP, cmd_get, 2, 0),
+			       SHELL_CMD_ARG(set, &dsub_device_name, RTC_SET_HELP, cmd_set, 3, 0),
+			       SHELL_CMD_ARG(get, &dsub_device_name, RTC_GET_HELP, cmd_get, 2, 0),
 			       SHELL_SUBCMD_SET_END);
 
 SHELL_CMD_REGISTER(rtc, &sub_rtc, "RTC commands", NULL);


### PR DESCRIPTION
This commit adds support for <device> entry tab completion and device lookup if enabled.