### PR TITLE
boards: nuvoton: numaker_m2l31ki: reenable userspace

### DIFF
--- a/boards/nuvoton/numaker_m2l31ki/numaker_m2l31ki_defconfig
+++ b/boards/nuvoton/numaker_m2l31ki/numaker_m2l31ki_defconfig
@@ -21,6 +21,3 @@ CONFIG_UART_CONSOLE=y
 
 # Enable RMC
 CONFIG_FLASH=y
-
-# m2l31x has 4 MPU regions and can't afford to enable CONFIG_USERSPACE
-CONFIG_USERSPACE=n


### PR DESCRIPTION
In commit a30c5731aed (tests: drivers: can: api:
support numaker_m2l31ki, 2024-05-31), CONFIG_USERSPACE was disabled for
the numaker_m2l31ki. This fix is valid to support running the CAN API
testsuite, but Zephyr's infrastructure does not properly support
disabling userspace at the board level.

As a temporary workaround, reenable userspace to fix failing CI tests
on this board.
