### PR TITLE
kernel: mm: rename memory mapping functions from z_ to mm_memmap_

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -792,7 +792,7 @@ config ARCH_MAPS_ALL_RAM
 	  virtual addresses elsewhere, this is limited to only management of the
 	  virtual address space. The kernel's page frame ontology will not consider
 	  this mapping at all; non-kernel pages will be considered free (unless marked
-	  as reserved) and Z_PAGE_FRAME_MAPPED will not be set.
+	  as reserved) and K_MEM_PAGE_FRAME_MAPPED will not be set.
 
 config DCLS
 	bool "Processor is configured in DCLS mode"

--- a/arch/x86/core/efi.c
+++ b/arch/x86/core/efi.c
@@ -33,8 +33,8 @@ void efi_init(struct efi_boot_arg *efi_arg)
 		return;
 	}
 
-	z_phys_map((uint8_t **)&efi, (uintptr_t)efi_arg,
-		   sizeof(struct efi_boot_arg), 0);
+	k_mem_map_phys_bare((uint8_t **)&efi, (uintptr_t)efi_arg,
+			    sizeof(struct efi_boot_arg), 0);
 }
 
 /* EFI thunk.  Not a lot of code, but lots of context:

--- a/arch/x86/core/fatal.c
+++ b/arch/x86/core/fatal.c
@@ -208,7 +208,7 @@ static inline uintptr_t get_cr3(const struct arch_esf *esf)
 
 static inline pentry_t *get_ptables(const struct arch_esf *esf)
 {
-	return z_mem_virt_addr(get_cr3(esf));
+	return k_mem_virt_addr(get_cr3(esf));
 }
 
 #ifdef CONFIG_X86_64

--- a/arch/x86/core/fatal.c
+++ b/arch/x86/core/fatal.c
@@ -434,7 +434,7 @@ void z_x86_page_fault_handler(struct arch_esf *esf)
 		} else
 #else
 		{
-			was_valid_access = z_page_fault(virt);
+			was_valid_access = k_mem_page_fault(virt);
 		}
 #endif /* CONFIG_X86_KPTI */
 		if (was_valid_access) {

--- a/arch/x86/core/ia32/crt0.S
+++ b/arch/x86/core/ia32/crt0.S
@@ -60,7 +60,7 @@
 	 * Until we enable these page tables, only physical memory addresses
 	 * work.
 	 */
-	movl	$Z_MEM_PHYS_ADDR(z_x86_kernel_ptables), %eax
+	movl	$K_MEM_PHYS_ADDR(z_x86_kernel_ptables), %eax
 	movl	%eax, %cr3
 
 #ifdef CONFIG_X86_PAE
@@ -126,7 +126,7 @@ SECTION_FUNC(BOOT_TEXT, __start)
 	 */
 #if CONFIG_SET_GDT
 	/* load 32-bit operand size GDT */
-	lgdt	Z_MEM_PHYS_ADDR(_gdt_rom)
+	lgdt	K_MEM_PHYS_ADDR(_gdt_rom)
 
 	/* If we set our own GDT, update the segment registers as well.
 	 */
@@ -138,7 +138,7 @@ SECTION_FUNC(BOOT_TEXT, __start)
 	movw	%ax, %fs	/* Zero FS */
 	movw	%ax, %gs	/* Zero GS */
 
-	ljmp	$CODE_SEG, $Z_MEM_PHYS_ADDR(__csSet)	/* set CS = 0x08 */
+	ljmp	$CODE_SEG, $K_MEM_PHYS_ADDR(__csSet)	/* set CS = 0x08 */
 
 __csSet:
 #endif /* CONFIG_SET_GDT */
@@ -180,7 +180,8 @@ __csSet:
 	andl	$~0x400, %eax		/* CR4[OSXMMEXCPT] = 0 */
 	movl	%eax, %cr4		/* move EAX to CR4 */
 
-	ldmxcsr Z_MEM_PHYS_ADDR(_sse_mxcsr_default_value)   /* initialize SSE control/status reg */
+	/* initialize SSE control/status reg */
+	ldmxcsr K_MEM_PHYS_ADDR(_sse_mxcsr_default_value)
 
   #endif /* CONFIG_X86_SSE */
 
@@ -199,7 +200,7 @@ __csSet:
 	 */
 #ifdef CONFIG_INIT_STACKS
 	movl $0xAAAAAAAA, %eax
-	leal Z_MEM_PHYS_ADDR(z_interrupt_stacks), %edi
+	leal K_MEM_PHYS_ADDR(z_interrupt_stacks), %edi
 #ifdef CONFIG_X86_STACK_PROTECTION
 	addl $4096, %edi
 #endif
@@ -208,7 +209,7 @@ __csSet:
 	rep  stosl
 #endif
 
-	movl	$Z_MEM_PHYS_ADDR(z_interrupt_stacks), %esp
+	movl	$K_MEM_PHYS_ADDR(z_interrupt_stacks), %esp
 #ifdef CONFIG_X86_STACK_PROTECTION
 	/* In this configuration, all stacks, including IRQ stack, are declared
 	 * with a 4K non-present guard page preceding the stack buffer
@@ -347,9 +348,9 @@ _gdt:
 	 * descriptor here */
 
 	/* Limit on GDT */
-	.word Z_MEM_PHYS_ADDR(_gdt_rom_end) - Z_MEM_PHYS_ADDR(_gdt_rom) - 1
+	.word K_MEM_PHYS_ADDR(_gdt_rom_end) - K_MEM_PHYS_ADDR(_gdt_rom) - 1
 	/* table address: _gdt_rom */
-	.long Z_MEM_PHYS_ADDR(_gdt_rom)
+	.long K_MEM_PHYS_ADDR(_gdt_rom)
 	.word   0x0000
 
 	/* Entry 1 (selector=0x0008): Code descriptor: DPL0 */

--- a/arch/x86/core/ia32/crt0.S
+++ b/arch/x86/core/ia32/crt0.S
@@ -89,7 +89,7 @@
 	orl	$(CR0_PG | CR0_WP), %eax
 	movl	%eax, %cr0
 
-#ifdef Z_VM_KERNEL
+#ifdef K_MEM_IS_VM_KERNEL
 	/* Jump to a virtual address, which works because the identity and
 	 * virtual mappings both are to the same physical address.
 	 */
@@ -98,7 +98,7 @@ vm_enter:
 	/* We are now executing in virtual memory. We'll un-map the identity
 	 * mappings later once we are in the C domain
 	 */
-#endif /* Z_VM_KERNEL */
+#endif /* K_MEM_IS_VM_KERNEL */
 
 #endif /* CONFIG_X86_MMU */
 .endm
@@ -244,7 +244,7 @@ __csSet:
 	ltr %ax
 #endif
 
-#ifdef Z_VM_KERNEL
+#ifdef K_MEM_IS_VM_KERNEL
 	/* Need to reset the stack to virtual address after
 	 * page table is loaded.
 	 */
@@ -255,7 +255,7 @@ __csSet:
 #else
 	addl	$CONFIG_ISR_STACK_SIZE, %esp
 #endif
-#endif /* Z_VM_KERNEL */
+#endif /* K_MEM_IS_VM_KERNEL */
 
 #ifdef CONFIG_THREAD_LOCAL_STORAGE
 	pushl %esp

--- a/arch/x86/core/ia32/fatal.c
+++ b/arch/x86/core/ia32/fatal.c
@@ -156,7 +156,7 @@ struct task_state_segment _df_tss = {
 	.ss = DATA_SEG,
 	.eip = (uint32_t)df_handler_top,
 	.cr3 = (uint32_t)
-		Z_MEM_PHYS_ADDR(POINTER_TO_UINT(&z_x86_kernel_ptables[0]))
+		K_MEM_PHYS_ADDR(POINTER_TO_UINT(&z_x86_kernel_ptables[0]))
 };
 
 __pinned_func
@@ -213,7 +213,7 @@ static FUNC_NORETURN __used void df_handler_top(void)
 	_main_tss.es = DATA_SEG;
 	_main_tss.ss = DATA_SEG;
 	_main_tss.eip = (uint32_t)df_handler_bottom;
-	_main_tss.cr3 = z_mem_phys_addr(z_x86_kernel_ptables);
+	_main_tss.cr3 = k_mem_phys_addr(z_x86_kernel_ptables);
 	_main_tss.eflags = 0U;
 
 	/* NT bit is set in EFLAGS so we will task switch back to _main_tss

--- a/arch/x86/core/ia32/userspace.S
+++ b/arch/x86/core/ia32/userspace.S
@@ -51,7 +51,7 @@ SECTION_FUNC(PINNED_TEXT, z_x86_trampoline_to_kernel)
 	pushl	%edi
 
 	/* Switch to kernel page table */
-	movl	$Z_MEM_PHYS_ADDR(z_x86_kernel_ptables), %esi
+	movl	$K_MEM_PHYS_ADDR(z_x86_kernel_ptables), %esi
 	movl	%esi, %cr3
 
 	/* Save old trampoline stack pointer in %edi */
@@ -156,7 +156,7 @@ SECTION_FUNC(TEXT, z_x86_syscall_entry_stub)
 	pushl	%edi
 
 	/* Switch to kernel page table */
-	movl	$Z_MEM_PHYS_ADDR(z_x86_kernel_ptables), %esi
+	movl	$K_MEM_PHYS_ADDR(z_x86_kernel_ptables), %esi
 	movl	%esi, %cr3
 
 	/* Save old trampoline stack pointer in %edi */

--- a/arch/x86/core/intel64/locore.S
+++ b/arch/x86/core/intel64/locore.S
@@ -44,7 +44,7 @@
 	/* Page tables created at build time by gen_mmu.py
 	 * NOTE: Presumes phys=virt
 	 */
-	movl $Z_MEM_PHYS_ADDR(z_x86_kernel_ptables), %eax
+	movl $K_MEM_PHYS_ADDR(z_x86_kernel_ptables), %eax
 	movl %eax, %cr3
 
 	set_efer
@@ -66,7 +66,7 @@
 	clts
 
 	/* NOTE: Presumes phys=virt */
-	movq $Z_MEM_PHYS_ADDR(z_x86_kernel_ptables), %rax
+	movq $K_MEM_PHYS_ADDR(z_x86_kernel_ptables), %rax
 	movq %rax, %cr3
 
 	set_efer

--- a/arch/x86/core/intel64/userspace.S
+++ b/arch/x86/core/intel64/userspace.S
@@ -87,7 +87,7 @@ z_x86_syscall_entry_stub:
 	pushq	%rax
 
 	/* NOTE: Presumes phys=virt */
-	movq	$Z_MEM_PHYS_ADDR(z_x86_kernel_ptables), %rax
+	movq	$K_MEM_PHYS_ADDR(z_x86_kernel_ptables), %rax
 	movq	%rax, %cr3
 	popq	%rax
 	movq	$0, -8(%rsp)	/* Delete stashed RAX data */

--- a/arch/x86/core/legacy_bios.c
+++ b/arch/x86/core/legacy_bios.c
@@ -17,18 +17,18 @@ static uintptr_t bios_search_rsdp_buff(uintptr_t search_phy_add, uint32_t search
 {
 	uint64_t *search_buff;
 
-	z_phys_map((uint8_t **)&search_buff, search_phy_add, search_length, 0);
+	k_mem_map_phys_bare((uint8_t **)&search_buff, search_phy_add, search_length, 0);
 	if (!search_buff) {
 		return 0;
 	}
 
 	for (int i = 0; i < search_length / 8u; i++) {
 		if (search_buff[i] == RSDP_SIGNATURE) {
-			z_phys_unmap((uint8_t *)search_buff, search_length);
+			k_mem_unmap_phys_bare((uint8_t *)search_buff, search_length);
 			return (search_phy_add + (i * 8u));
 		}
 	}
-	z_phys_unmap((uint8_t *)search_buff, search_length);
+	k_mem_unmap_phys_bare((uint8_t *)search_buff, search_length);
 
 	return 0;
 }
@@ -38,10 +38,10 @@ void *bios_acpi_rsdp_get(void)
 	uint8_t *bios_ext_data, *zero_page_base;
 	uintptr_t search_phy_add, rsdp_phy_add;
 
-	z_phys_map(&zero_page_base, 0, DATA_SIZE_K(4u), 0);
+	k_mem_map_phys_bare(&zero_page_base, 0, DATA_SIZE_K(4u), 0);
 	bios_ext_data = EBDA_ADD + zero_page_base;
 	search_phy_add = (uintptr_t)((*(uint16_t *)bios_ext_data) << 4u);
-	z_phys_unmap(zero_page_base, DATA_SIZE_K(4u));
+	k_mem_unmap_phys_bare(zero_page_base, DATA_SIZE_K(4u));
 
 	if ((search_phy_add >= BIOS_EXT_DATA_LOW) && (search_phy_add < BIOS_EXT_DATA_HIGH)) {
 		rsdp_phy_add = bios_search_rsdp_buff(search_phy_add, DATA_SIZE_K(1u));

--- a/arch/x86/core/multiboot.c
+++ b/arch/x86/core/multiboot.c
@@ -41,8 +41,8 @@ void z_multiboot_init(struct multiboot_info *info_pa)
 	 */
 	info = info_pa;
 #else
-	z_phys_map((uint8_t **)&info, POINTER_TO_UINT(info_pa),
-		   sizeof(*info_pa), K_MEM_CACHE_NONE);
+	k_mem_map_phys_bare((uint8_t **)&info, POINTER_TO_UINT(info_pa),
+			    sizeof(*info_pa), K_MEM_CACHE_NONE);
 #endif /* CONFIG_ARCH_MAPS_ALL_RAM */
 
 	if (info == NULL) {
@@ -70,8 +70,8 @@ void z_multiboot_init(struct multiboot_info *info_pa)
 #else
 		uint8_t *address_va;
 
-		z_phys_map(&address_va, info->mmap_addr, info->mmap_length,
-			   K_MEM_CACHE_NONE);
+		k_mem_map_phys_bare(&address_va, info->mmap_addr, info->mmap_length,
+				    K_MEM_CACHE_NONE);
 
 		address = POINTER_TO_UINT(address_va);
 #endif /* CONFIG_ARCH_MAPS_ALL_RAM */

--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -2004,11 +2004,12 @@ static void mark_addr_page_reserved(uintptr_t addr, size_t len)
 	uintptr_t end = ROUND_UP(addr + len, CONFIG_MMU_PAGE_SIZE);
 
 	for (; pos < end; pos += CONFIG_MMU_PAGE_SIZE) {
-		if (!z_is_page_frame(pos)) {
+		if (!k_mem_is_page_frame(pos)) {
 			continue;
 		}
 
-		z_page_frame_set(z_phys_to_page_frame(pos), Z_PAGE_FRAME_RESERVED);
+		k_mem_page_frame_set(k_mem_phys_to_page_frame(pos),
+				     K_MEM_PAGE_FRAME_RESERVED);
 	}
 }
 

--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -313,7 +313,7 @@ static inline uintptr_t get_entry_phys(pentry_t entry, int level)
 __pinned_func
 static inline pentry_t *next_table(pentry_t entry, int level)
 {
-	return z_mem_virt_addr(get_entry_phys(entry, level));
+	return k_mem_virt_addr(get_entry_phys(entry, level));
 }
 
 /* Number of table entries at this level */
@@ -416,12 +416,12 @@ void z_x86_tlb_ipi(const void *arg)
 	 * if KPTI is turned on
 	 */
 	ptables_phys = z_x86_cr3_get();
-	__ASSERT(ptables_phys == z_mem_phys_addr(&z_x86_kernel_ptables), "");
+	__ASSERT(ptables_phys == k_mem_phys_addr(&z_x86_kernel_ptables), "");
 #else
 	/* We might have been moved to another memory domain, so always invoke
 	 * z_x86_thread_page_tables_get() instead of using current CR3 value.
 	 */
-	ptables_phys = z_mem_phys_addr(z_x86_thread_page_tables_get(_current));
+	ptables_phys = k_mem_phys_addr(z_x86_thread_page_tables_get(_current));
 #endif
 	/*
 	 * In the future, we can consider making this smarter, such as
@@ -661,7 +661,7 @@ static void dump_ptables(pentry_t *table, uint8_t *base, int level)
 #endif
 
 	printk("%s at %p (0x%" PRIxPTR "): ", info->name, table,
-	       z_mem_phys_addr(table));
+	       k_mem_phys_addr(table));
 	if (level == 0) {
 		printk("entire address space\n");
 	} else {
@@ -826,7 +826,7 @@ static inline pentry_t pte_finalize_value(pentry_t val, bool user_table,
 {
 #ifdef CONFIG_X86_KPTI
 	static const uintptr_t shared_phys_addr =
-		Z_MEM_PHYS_ADDR(POINTER_TO_UINT(&z_shared_kernel_page_start));
+		K_MEM_PHYS_ADDR(POINTER_TO_UINT(&z_shared_kernel_page_start));
 
 	if (user_table && (val & MMU_US) == 0 && (val & MMU_P) != 0 &&
 	    get_entry_phys(val, level) != shared_phys_addr) {
@@ -1720,7 +1720,7 @@ static int copy_page_table(pentry_t *dst, pentry_t *src, int level)
 			 * cast needed for PAE case where sizeof(void *) and
 			 * sizeof(pentry_t) are not the same.
 			 */
-			dst[i] = ((pentry_t)z_mem_phys_addr(child_dst) |
+			dst[i] = ((pentry_t)k_mem_phys_addr(child_dst) |
 				  INT_FLAGS);
 
 			ret = copy_page_table(child_dst,
@@ -1924,11 +1924,11 @@ int arch_mem_domain_thread_add(struct k_thread *thread)
 	 * z_x86_current_stack_perms()
 	 */
 	if (is_migration) {
-		old_ptables = z_mem_virt_addr(thread->arch.ptables);
+		old_ptables = k_mem_virt_addr(thread->arch.ptables);
 		set_stack_perms(thread, domain->arch.ptables);
 	}
 
-	thread->arch.ptables = z_mem_phys_addr(domain->arch.ptables);
+	thread->arch.ptables = k_mem_phys_addr(domain->arch.ptables);
 	LOG_DBG("set thread %p page tables to 0x%" PRIxPTR, thread,
 		thread->arch.ptables);
 

--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -2112,7 +2112,7 @@ void arch_mem_page_in(void *addr, uintptr_t phys)
 __pinned_func
 void arch_mem_scratch(uintptr_t phys)
 {
-	page_map_set(z_x86_page_tables_get(), Z_SCRATCH_PAGE,
+	page_map_set(z_x86_page_tables_get(), K_MEM_SCRATCH_PAGE,
 		     phys | MMU_P | MMU_RW | MMU_XD, NULL, MASK_ALL,
 		     OPTION_FLUSH);
 }

--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -1307,7 +1307,7 @@ void arch_mem_unmap(void *addr, size_t size)
 	ARG_UNUSED(ret);
 }
 
-#ifdef Z_VM_KERNEL
+#ifdef K_MEM_IS_VM_KERNEL
 __boot_func
 static void identity_map_remove(uint32_t level)
 {
@@ -1346,7 +1346,7 @@ static void identity_map_remove(uint32_t level)
 __boot_func
 void z_x86_mmu_init(void)
 {
-#ifdef Z_VM_KERNEL
+#ifdef K_MEM_IS_VM_KERNEL
 	/* We booted with physical address space being identity mapped.
 	 * As we are now executing in virtual address space,
 	 * the identity map is no longer needed. So remove them.

--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -2231,7 +2231,7 @@ bool z_x86_kpti_is_access_ok(void *addr, pentry_t *ptables)
 
 	/* Might as well also check if it's un-mapped, normally we don't
 	 * fetch the PTE from the page tables until we are inside
-	 * z_page_fault() and call arch_page_fault_status_get()
+	 * k_mem_page_fault() and call arch_page_fault_status_get()
 	 */
 	if (level != PTE_LEVEL || pte == 0 || is_flipped_pte(pte)) {
 		return false;

--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -593,7 +593,7 @@ static void print_entries(pentry_t entries_array[], uint8_t *base, int level,
 				if (phys == virt) {
 					/* Identity mappings */
 					COLOR(YELLOW);
-				} else if (phys + Z_MEM_VM_OFFSET == virt) {
+				} else if (phys + K_MEM_VIRT_OFFSET == virt) {
 					/* Permanent RAM mappings */
 					COLOR(GREEN);
 				} else {

--- a/arch/x86/include/x86_mmu.h
+++ b/arch/x86/include/x86_mmu.h
@@ -182,7 +182,7 @@ static inline uintptr_t z_x86_cr3_get(void)
 /* Return the virtual address of the page tables installed in this CPU in CR3 */
 static inline pentry_t *z_x86_page_tables_get(void)
 {
-	return z_mem_virt_addr(z_x86_cr3_get());
+	return k_mem_virt_addr(z_x86_cr3_get());
 }
 
 /* Return cr2 value, which contains the page fault linear address.
@@ -215,7 +215,7 @@ static inline pentry_t *z_x86_thread_page_tables_get(struct k_thread *thread)
 		 * the kernel's page tables and not the page tables associated
 		 * with their memory domain.
 		 */
-		return z_mem_virt_addr(thread->arch.ptables);
+		return k_mem_virt_addr(thread->arch.ptables);
 	}
 #else
 	ARG_UNUSED(thread);

--- a/arch/xtensa/core/ptables.c
+++ b/arch/xtensa/core/ptables.c
@@ -353,7 +353,7 @@ __weak void arch_reserved_pages_update(void)
 	for (page = CONFIG_SRAM_BASE_ADDRESS, idx = 0;
 	     page < (uintptr_t)z_mapped_start;
 	     page += CONFIG_MMU_PAGE_SIZE, idx++) {
-		z_page_frame_set(&z_page_frames[idx], Z_PAGE_FRAME_RESERVED);
+		k_mem_page_frame_set(&k_mem_page_frames[idx], K_MEM_PAGE_FRAME_RESERVED);
 	}
 }
 #endif /* CONFIG_ARCH_HAS_RESERVED_PAGE_FRAMES */

--- a/boards/qemu/x86/qemu_x86_tiny.ld
+++ b/boards/qemu/x86/qemu_x86_tiny.ld
@@ -245,7 +245,7 @@ MEMORY
 	*mpsc_pbuf.c.obj(.##lsect)					\
 	*mpsc_pbuf.c.obj(.##lsect.*)
 
-epoint = Z_MEM_PHYS_ADDR(CONFIG_KERNEL_ENTRY);
+epoint = K_MEM_PHYS_ADDR(CONFIG_KERNEL_ENTRY);
 ENTRY(epoint)
 
 /* SECTIONS definitions */

--- a/boards/qemu/x86/qemu_x86_tiny.ld
+++ b/boards/qemu/x86/qemu_x86_tiny.ld
@@ -25,7 +25,7 @@
  * the same as its physical location, although an identity mapping for RAM
  * is still supported by setting CONFIG_KERNEL_VM_BASE=CONFIG_SRAM_BASE_ADDRESS.
  */
-#ifdef Z_VM_KERNEL
+#ifdef K_MEM_IS_VM_KERNEL
 
 #define KERNEL_BASE_ADDR \
 	(CONFIG_KERNEL_VM_BASE + CONFIG_KERNEL_VM_OFFSET)
@@ -55,7 +55,7 @@
 
 MEMORY
     {
-#if defined(Z_VM_KERNEL)
+#if defined(K_MEM_IS_VM_KERNEL)
     ROM (rx)        : ORIGIN = PHYS_LOAD_ADDR, LENGTH = PHYS_RAM_AVAIL
 #endif
     RAM (wx)        : ORIGIN = KERNEL_BASE_ADDR, LENGTH = KERNEL_RAM_SIZE
@@ -75,7 +75,7 @@ MEMORY
     IDT_LIST        : ORIGIN = 0xFFFF1000, LENGTH = 2K
     }
 
-#if defined(Z_VM_KERNEL)
+#if defined(K_MEM_IS_VM_KERNEL)
 	#define ROMABLE_REGION ROM
 	#define RAMABLE_REGION RAM
 #else

--- a/doc/kernel/memory_management/demand_paging.rst
+++ b/doc/kernel/memory_management/demand_paging.rst
@@ -72,10 +72,10 @@ Page Frame
   * ``Z_PAGE_FRAME_BACKED`` indicates a page frame has a clean copy
     in the backing store.
 
-Z_SCRATCH_PAGE
+K_MEM_SCRATCH_PAGE
   The virtual address of a special page provided to the backing store to:
-  * Copy a data page from ``Z_SCRATCH_PAGE`` to the specified location; or,
-  * Copy a data page from the provided location to ``Z_SCRATCH_PAGE``.
+  * Copy a data page from ``k_MEM_SCRATCH_PAGE`` to the specified location; or,
+  * Copy a data page from the provided location to ``K_MEM_SCRATCH_PAGE``.
   This is used as an intermediate page for page in/out operations. This
   scratch needs to be mapped read/write for backing store code to access.
   However the data page itself may only be mapped as read-only in virtual
@@ -163,10 +163,10 @@ which must be implemented:
 
 * :c:func:`k_mem_paging_backing_store_page_in()` copies a data page
   from the backing store location associated with the provided
-  ``location`` token to the page pointed by ``Z_SCRATCH_PAGE``.
+  ``location`` token to the page pointed by ``K_MEM_SCRATCH_PAGE``.
 
 * :c:func:`k_mem_paging_backing_store_page_out()` copies a data page
-  from ``Z_SCRATCH_PAGE`` to the backing store location associated
+  from ``K_MEM_SCRATCH_PAGE`` to the backing store location associated
   with the provided ``location`` token.
 
 * :c:func:`k_mem_paging_backing_store_page_finalize()` is invoked after

--- a/doc/kernel/memory_management/demand_paging.rst
+++ b/doc/kernel/memory_management/demand_paging.rst
@@ -50,26 +50,26 @@ Page Frame
   A page frame is a page-sized physical memory region in RAM. It is a
   container where a data page may be placed. It is always referred to by
   physical address. Zephyr has a convention of using ``uintptr_t`` for physical
-  addresses. For every page frame, a ``struct z_page_frame`` is instantiated to
+  addresses. For every page frame, a ``struct k_mem_page_frame`` is instantiated to
   store metadata. Flags for each page frame:
 
-  * ``Z_PAGE_FRAME_FREE`` indicates a page frame is unused and on the list of
+  * ``K_MEM_PAGE_FRAME_FREE`` indicates a page frame is unused and on the list of
     free page frames. When this flag is set, none of the other flags are
     meaningful and they must not be modified.
 
-  * ``Z_PAGE_FRAME_PINNED`` indicates a page frame is pinned in memory
+  * ``K_MEM_PAGE_FRAME_PINNED`` indicates a page frame is pinned in memory
     and should never be paged out.
 
-  * ``Z_PAGE_FRAME_RESERVED`` indicates a physical page reserved by hardware
+  * ``K_MEM_PAGE_FRAME_RESERVED`` indicates a physical page reserved by hardware
     and should not be used at all.
 
-  * ``Z_PAGE_FRAME_MAPPED`` is set when a physical page is mapped to
+  * ``K_MEM_PAGE_FRAME_MAPPED`` is set when a physical page is mapped to
     virtual memory address.
 
-  * ``Z_PAGE_FRAME_BUSY`` indicates a page frame is currently involved in
+  * ``K_MEM_PAGE_FRAME_BUSY`` indicates a page frame is currently involved in
     a page-in/out operation.
 
-  * ``Z_PAGE_FRAME_BACKED`` indicates a page frame has a clean copy
+  * ``K_MEM_PAGE_FRAME_BACKED`` indicates a page frame has a clean copy
     in the backing store.
 
 K_MEM_SCRATCH_PAGE

--- a/doc/kernel/memory_management/virtual_memory.rst
+++ b/doc/kernel/memory_management/virtual_memory.rst
@@ -73,7 +73,7 @@ below.
 .. code-block:: none
    :emphasize-lines: 1, 3, 9, 22, 24
 
-   +--------------+ <- Z_VIRT_RAM_START
+   +--------------+ <- K_MEM_VIRT_RAM_START
    | Undefined VM | <- architecture specific reserved area
    +--------------+ <- Z_KERNEL_VIRT_START
    | Mapping for  |
@@ -96,17 +96,17 @@ below.
    | Mapping      |
    +--------------+ <- memory mappings start here
    | Reserved     | <- special purpose virtual page(s) of size Z_VM_RESERVED
-   +--------------+ <- Z_VIRT_RAM_END
+   +--------------+ <- K_MEM_VIRT_RAM_END
 
-* ``Z_VIRT_RAM_START`` is the beginning of the virtual memory address space.
+* ``K_MEM_VIRT_RAM_START`` is the beginning of the virtual memory address space.
   This needs to be page aligned. Currently, it is the same as
   :kconfig:option:`CONFIG_KERNEL_VM_BASE`.
 
-* ``Z_VIRT_RAM_SIZE`` is the size of the virtual memory address space.
+* ``K_MEM_VIRT_RAM_SIZE`` is the size of the virtual memory address space.
   This needs to be page aligned. Currently, it is the same as
   :kconfig:option:`CONFIG_KERNEL_VM_SIZE`.
 
-* ``Z_VIRT_RAM_END`` is simply (``Z_VIRT_RAM_START`` + ``Z_VIRT_RAM_SIZE``).
+* ``K_MEM_VIRT_RAM_END`` is simply (``K_MEM_VIRT_RAM_START`` + ``K_MEM_VIRT_RAM_SIZE``).
 
 * ``Z_KERNEL_VIRT_START`` is the same as ``z_mapped_start`` specified in the linker
   script. This is the virtual address of the beginning of the kernel image at
@@ -176,7 +176,7 @@ mappings must be aligned on page size and have finer access control.
   * The requested size must be multiple of page size.
 
   * The address returned is inside the virtual address space between
-    ``Z_FREE_VM_START`` and ``Z_VIRT_RAM_END``.
+    ``Z_FREE_VM_START`` and ``K_MEM_VIRT_RAM_END``.
 
   * The mapped region is not guaranteed to be physically contiguous in memory.
 

--- a/doc/kernel/memory_management/virtual_memory.rst
+++ b/doc/kernel/memory_management/virtual_memory.rst
@@ -95,7 +95,7 @@ below.
    +--------------+
    | Mapping      |
    +--------------+ <- memory mappings start here
-   | Reserved     | <- special purpose virtual page(s) of size Z_VM_RESERVED
+   | Reserved     | <- special purpose virtual page(s) of size K_MEM_VM_RESERVED
    +--------------+ <- K_MEM_VIRT_RAM_END
 
 * ``K_MEM_VIRT_RAM_START`` is the beginning of the virtual memory address space.
@@ -126,7 +126,7 @@ below.
   * If it is disabled, ``K_MEM_VM_FREE_START`` is the same ``K_MEM_KERNEL_VIRT_END`` which
     is the end of the kernel image.
 
-* ``Z_VM_RESERVED`` is an area reserved to support kernel functions. For example,
+* ``K_MEM_VM_RESERVED`` is an area reserved to support kernel functions. For example,
   some addresses are reserved to support demand paging.
 
 

--- a/doc/kernel/memory_management/virtual_memory.rst
+++ b/doc/kernel/memory_management/virtual_memory.rst
@@ -81,7 +81,7 @@ below.
    | image        |
    |              |
    |              |
-   +--------------+ <- Z_FREE_VM_START
+   +--------------+ <- K_MEM_VM_FREE_START
    |              |
    | Unused,      |
    | Available VM |
@@ -115,7 +115,7 @@ below.
 * ``K_MEM_KERNEL_VIRT_END`` is the same as ``z_mapped_end`` specified in the linker
   script. This is the virtual address of the end of the kernel image at boot time.
 
-* ``Z_FREE_VM_START`` is the beginning of the virtual address space where addresses
+* ``K_MEM_VM_FREE_START`` is the beginning of the virtual address space where addresses
   can be allocated for memory mapping. This depends on whether
   :kconfig:option:`CONFIG_ARCH_MAPS_ALL_RAM` is enabled.
 
@@ -123,7 +123,7 @@ below.
     memory address space, and it is the same as
     (:kconfig:option:`CONFIG_SRAM_BASE_ADDRESS` + :kconfig:option:`CONFIG_SRAM_SIZE`).
 
-  * If it is disabled, ``Z_FREE_VM_START`` is the same ``K_MEM_KERNEL_VIRT_END`` which
+  * If it is disabled, ``K_MEM_VM_FREE_START`` is the same ``K_MEM_KERNEL_VIRT_END`` which
     is the end of the kernel image.
 
 * ``Z_VM_RESERVED`` is an area reserved to support kernel functions. For example,
@@ -176,7 +176,7 @@ mappings must be aligned on page size and have finer access control.
   * The requested size must be multiple of page size.
 
   * The address returned is inside the virtual address space between
-    ``Z_FREE_VM_START`` and ``K_MEM_VIRT_RAM_END``.
+    ``K_MEM_VM_FREE_START`` and ``K_MEM_VIRT_RAM_END``.
 
   * The mapped region is not guaranteed to be physically contiguous in memory.
 

--- a/doc/kernel/memory_management/virtual_memory.rst
+++ b/doc/kernel/memory_management/virtual_memory.rst
@@ -75,7 +75,7 @@ below.
 
    +--------------+ <- K_MEM_VIRT_RAM_START
    | Undefined VM | <- architecture specific reserved area
-   +--------------+ <- Z_KERNEL_VIRT_START
+   +--------------+ <- K_MEM_KERNEL_VIRT_START
    | Mapping for  |
    | main kernel  |
    | image        |
@@ -108,11 +108,11 @@ below.
 
 * ``K_MEM_VIRT_RAM_END`` is simply (``K_MEM_VIRT_RAM_START`` + ``K_MEM_VIRT_RAM_SIZE``).
 
-* ``Z_KERNEL_VIRT_START`` is the same as ``z_mapped_start`` specified in the linker
+* ``K_MEM_KERNEL_VIRT_START`` is the same as ``z_mapped_start`` specified in the linker
   script. This is the virtual address of the beginning of the kernel image at
   boot time.
 
-* ``Z_KERNEL_VIRT_END`` is the same as ``z_mapped_end`` specified in the linker
+* ``K_MEM_KERNEL_VIRT_END`` is the same as ``z_mapped_end`` specified in the linker
   script. This is the virtual address of the end of the kernel image at boot time.
 
 * ``Z_FREE_VM_START`` is the beginning of the virtual address space where addresses
@@ -123,7 +123,7 @@ below.
     memory address space, and it is the same as
     (:kconfig:option:`CONFIG_SRAM_BASE_ADDRESS` + :kconfig:option:`CONFIG_SRAM_SIZE`).
 
-  * If it is disabled, ``Z_FREE_VM_START`` is the same ``Z_KERNEL_VIRT_END`` which
+  * If it is disabled, ``Z_FREE_VM_START`` is the same ``K_MEM_KERNEL_VIRT_END`` which
     is the end of the kernel image.
 
 * ``Z_VM_RESERVED`` is an area reserved to support kernel functions. For example,

--- a/drivers/ethernet/eth_dwmac_mmu.c
+++ b/drivers/ethernet/eth_dwmac_mmu.c
@@ -47,7 +47,7 @@ void dwmac_platform_init(struct dwmac_priv *p)
 	sys_cache_data_invd_range(dwmac_tx_rx_descriptors,
 				  sizeof(dwmac_tx_rx_descriptors));
 
-	desc_phys_addr = z_mem_phys_addr(dwmac_tx_rx_descriptors);
+	desc_phys_addr = k_mem_phys_addr(dwmac_tx_rx_descriptors);
 
 	/* remap descriptor rings uncached */
 	k_mem_map_phys_bare(&desc_uncached_addr, desc_phys_addr,

--- a/drivers/ethernet/eth_dwmac_mmu.c
+++ b/drivers/ethernet/eth_dwmac_mmu.c
@@ -50,9 +50,9 @@ void dwmac_platform_init(struct dwmac_priv *p)
 	desc_phys_addr = z_mem_phys_addr(dwmac_tx_rx_descriptors);
 
 	/* remap descriptor rings uncached */
-	z_phys_map(&desc_uncached_addr, desc_phys_addr,
-		   sizeof(dwmac_tx_rx_descriptors),
-		   K_MEM_PERM_RW | K_MEM_CACHE_NONE);
+	k_mem_map_phys_bare(&desc_uncached_addr, desc_phys_addr,
+			    sizeof(dwmac_tx_rx_descriptors),
+			    K_MEM_PERM_RW | K_MEM_CACHE_NONE);
 
 	LOG_DBG("desc virt %p uncached %p phys 0x%lx",
 		dwmac_tx_rx_descriptors, desc_uncached_addr, desc_phys_addr);

--- a/drivers/pcie/host/msi.c
+++ b/drivers/pcie/host/msi.c
@@ -96,9 +96,9 @@ static bool map_msix_table_entries(pcie_bdf_t bdf,
 		return false;
 	}
 
-	z_phys_map((uint8_t **)&mapped_table,
-		   bar.phys_addr + table_offset,
-		   n_vector * PCIE_MSIR_TABLE_ENTRY_SIZE, K_MEM_PERM_RW);
+	k_mem_map_phys_bare((uint8_t **)&mapped_table,
+			    bar.phys_addr + table_offset,
+			    n_vector * PCIE_MSIR_TABLE_ENTRY_SIZE, K_MEM_PERM_RW);
 
 	for (i = 0; i < n_vector; i++) {
 		vectors[i].msix_vector = (struct msix_vector *)

--- a/drivers/sdhc/rcar_mmc.c
+++ b/drivers/sdhc/rcar_mmc.c
@@ -2167,7 +2167,7 @@ exit_disable_clk:
 
 exit_unmap:
 #if defined(DEVICE_MMIO_IS_IN_RAM) && defined(CONFIG_MMU)
-	z_phys_unmap((uint8_t *)DEVICE_MMIO_GET(dev), DEVICE_MMIO_ROM_PTR(dev)->size);
+	k_mem_unmap_phys_bare((uint8_t *)DEVICE_MMIO_GET(dev), DEVICE_MMIO_ROM_PTR(dev)->size);
 #endif
 	return ret;
 }

--- a/drivers/sdhc/rcar_mmc.c
+++ b/drivers/sdhc/rcar_mmc.c
@@ -566,7 +566,7 @@ static int rcar_mmc_dma_rx_tx_data(const struct device *dev, struct sdhc_data *d
 	reg |= RCAR_MMC_EXTMODE_DMA_EN;
 	rcar_mmc_write_reg32(dev, RCAR_MMC_EXTMODE, reg);
 
-	dma_addr = z_mem_phys_addr(data->data);
+	dma_addr = k_mem_phys_addr(data->data);
 
 	rcar_mmc_write_reg32(dev, RCAR_MMC_DMA_ADDR_L, dma_addr);
 	rcar_mmc_write_reg32(dev, RCAR_MMC_DMA_ADDR_H, 0);
@@ -830,7 +830,7 @@ static int rcar_mmc_rx_tx_data(const struct device *dev, struct sdhc_data *data,
 	int ret = 0;
 
 #ifdef CONFIG_RCAR_MMC_DMA_SUPPORT
-	if (!(z_mem_phys_addr(data->data) >> 32)) {
+	if (!(k_mem_phys_addr(data->data) >> 32)) {
 		ret = rcar_mmc_dma_rx_tx_data(dev, data, is_read);
 	} else
 #endif

--- a/drivers/virtualization/virt_ivshmem.c
+++ b/drivers/virtualization/virt_ivshmem.c
@@ -219,9 +219,9 @@ static bool ivshmem_configure(const struct device *dev)
 			LOG_ERR("Invalid state table size %zu", state_table_size);
 			return false;
 		}
-		z_phys_map((uint8_t **)&data->state_table_shmem,
-			   shmem_phys_addr, state_table_size,
-			   K_MEM_CACHE_WB | K_MEM_PERM_USER);
+		k_mem_map_phys_bare((uint8_t **)&data->state_table_shmem,
+				    shmem_phys_addr, state_table_size,
+				    K_MEM_CACHE_WB | K_MEM_PERM_USER);
 
 		/* R/W section (optional) */
 		cap_pos = vendor_cap + IVSHMEM_CFG_RW_SECTION_SZ / 4;
@@ -229,9 +229,10 @@ static bool ivshmem_configure(const struct device *dev)
 		size_t rw_section_offset = state_table_size;
 		LOG_INF("RW section size 0x%zX", data->rw_section_size);
 		if (data->rw_section_size > 0) {
-			z_phys_map((uint8_t **)&data->rw_section_shmem,
-				   shmem_phys_addr + rw_section_offset, data->rw_section_size,
-				   K_MEM_CACHE_WB | K_MEM_PERM_RW | K_MEM_PERM_USER);
+			k_mem_map_phys_bare((uint8_t **)&data->rw_section_shmem,
+					    shmem_phys_addr + rw_section_offset,
+					    data->rw_section_size,
+					    K_MEM_CACHE_WB | K_MEM_PERM_RW | K_MEM_PERM_USER);
 		}
 
 		/* Output sections */
@@ -249,8 +250,8 @@ static bool ivshmem_configure(const struct device *dev)
 			if (i == regs->id) {
 				flags |= K_MEM_PERM_RW;
 			}
-			z_phys_map((uint8_t **)&data->output_section_shmem[i],
-				   phys_addr, data->output_section_size, flags);
+			k_mem_map_phys_bare((uint8_t **)&data->output_section_shmem[i],
+					    phys_addr, data->output_section_size, flags);
 		}
 
 		data->size = output_section_offset +
@@ -273,9 +274,9 @@ static bool ivshmem_configure(const struct device *dev)
 
 		data->size = mbar_shmem.size;
 
-		z_phys_map((uint8_t **)&data->shmem,
-			   shmem_phys_addr, data->size,
-			   K_MEM_CACHE_WB | K_MEM_PERM_RW | K_MEM_PERM_USER);
+		k_mem_map_phys_bare((uint8_t **)&data->shmem,
+				    shmem_phys_addr, data->size,
+				    K_MEM_CACHE_WB | K_MEM_PERM_RW | K_MEM_PERM_USER);
 	}
 
 	if (msi_x_bar_present) {

--- a/drivers/watchdog/wdt_andes_atcwdt200.c
+++ b/drivers/watchdog/wdt_andes_atcwdt200.c
@@ -332,14 +332,14 @@ static int wdt_atcwdt200_init(const struct device *dev)
 
 	ret = syscon_write_reg(syscon_dev, SMU_RESET_REGLO,
 				((uint32_t)((unsigned long)
-					Z_MEM_PHYS_ADDR(CONFIG_KERNEL_ENTRY))));
+					K_MEM_PHYS_ADDR(CONFIG_KERNEL_ENTRY))));
 	if (ret < 0) {
 		return -EINVAL;
 	}
 
 	ret = syscon_write_reg(syscon_dev, SMU_RESET_REGHI,
 				((uint32_t)((uint64_t)((unsigned long)
-						Z_MEM_PHYS_ADDR(CONFIG_KERNEL_ENTRY)) >> 32)));
+						K_MEM_PHYS_ADDR(CONFIG_KERNEL_ENTRY)) >> 32)));
 	if (ret < 0) {
 		return -EINVAL;
 	}

--- a/include/zephyr/arch/arm64/arm_mem.h
+++ b/include/zephyr/arch/arm64/arm_mem.h
@@ -7,7 +7,7 @@
 #define ZEPHYR_INCLUDE_ARCH_ARM64_ARM_MEM_H_
 
 /*
- * Define ARM specific memory flags used by z_phys_map()
+ * Define ARM specific memory flags used by k_mem_map_phys_bare()
  * followed public definitions in include/kernel/mm.h.
  */
 /* For ARM64, K_MEM_CACHE_NONE is nGnRnE. */

--- a/include/zephyr/arch/x86/ia32/linker.ld
+++ b/include/zephyr/arch/x86/ia32/linker.ld
@@ -44,7 +44,7 @@
 
 #include <zephyr/linker/linker-tool.h>
 
-#if defined(CONFIG_XIP) || defined(Z_VM_KERNEL)
+#if defined(CONFIG_XIP) || defined(K_MEM_IS_VM_KERNEL)
 	#define ROMABLE_REGION ROM
 	#define RAMABLE_REGION RAM
 #else

--- a/include/zephyr/arch/x86/ia32/linker.ld
+++ b/include/zephyr/arch/x86/ia32/linker.ld
@@ -68,7 +68,7 @@
 	#define MMU_PAGE_ALIGN_PERM
 #endif
 
-epoint = Z_MEM_PHYS_ADDR(CONFIG_KERNEL_ENTRY);
+epoint = K_MEM_PHYS_ADDR(CONFIG_KERNEL_ENTRY);
 ENTRY(epoint)
 
 /* SECTIONS definitions */

--- a/include/zephyr/arch/x86/memory.ld
+++ b/include/zephyr/arch/x86/memory.ld
@@ -39,7 +39,7 @@
  * the same as its physical location, although an identity mapping for RAM
  * is still supported by setting CONFIG_KERNEL_VM_BASE=CONFIG_SRAM_BASE_ADDRESS.
  */
-#ifdef Z_VM_KERNEL
+#ifdef K_MEM_IS_VM_KERNEL
 #define KERNEL_BASE_ADDR  (CONFIG_KERNEL_VM_BASE + CONFIG_KERNEL_VM_OFFSET)
 #define KERNEL_RAM_SIZE   (CONFIG_KERNEL_VM_SIZE - CONFIG_KERNEL_VM_OFFSET)
 #define PHYS_RAM_AVAIL    (PHYS_RAM_SIZE - CONFIG_SRAM_OFFSET)
@@ -87,7 +87,7 @@ MEMORY
      * or copied into physical RAM by a loader (MMU)
      */
     ROM (rx)        : ORIGIN = PHYS_LOAD_ADDR, LENGTH = FLASH_ROM_SIZE
-#elif defined(Z_VM_KERNEL)
+#elif defined(K_MEM_IS_VM_KERNEL)
     ROM (rx)        : ORIGIN = PHYS_LOAD_ADDR, LENGTH = PHYS_RAM_AVAIL
 #endif
     /* Linear address range to link the kernel. If non-XIP, everything is

--- a/include/zephyr/kernel/internal/mm.h
+++ b/include/zephyr/kernel/internal/mm.h
@@ -44,8 +44,27 @@
 #define K_MEM_VIRT_OFFSET	0
 #endif /* CONFIG_MMU */
 
-#define Z_MEM_PHYS_ADDR(virt)	((virt) - K_MEM_VIRT_OFFSET)
-#define Z_MEM_VIRT_ADDR(phys)	((phys) + K_MEM_VIRT_OFFSET)
+/**
+ * @brief Get physical address from virtual address.
+ *
+ * This only works in the kernel's permanent mapping of RAM.
+ *
+ * @param virt Virtual address
+ *
+ * @return Physical address.
+ */
+#define K_MEM_PHYS_ADDR(virt)	((virt) - K_MEM_VIRT_OFFSET)
+
+/**
+ * @brief Get virtual address from physical address.
+ *
+ * This only works in the kernel's permanent mapping of RAM.
+ *
+ * @param phys Physical address
+ *
+ * @return Virtual address.
+ */
+#define K_MEM_VIRT_ADDR(phys)	((phys) + K_MEM_VIRT_OFFSET)
 
 #if K_MEM_VIRT_OFFSET != 0
 #define Z_VM_KERNEL 1
@@ -61,8 +80,18 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/mem_manage.h>
 
-/* Just like Z_MEM_PHYS_ADDR() but with type safety and assertions */
-static inline uintptr_t z_mem_phys_addr(void *virt)
+/**
+ * @brief Get physical address from virtual address.
+ *
+ * This only works in the kernel's permanent mapping of RAM.
+ *
+ * Just like K_MEM_PHYS_ADDR() but with type safety and assertions.
+ *
+ * @param virt Virtual address
+ *
+ * @return Physical address.
+ */
+static inline uintptr_t k_mem_phys_addr(void *virt)
 {
 	uintptr_t addr = (uintptr_t)virt;
 
@@ -101,11 +130,21 @@ static inline uintptr_t z_mem_phys_addr(void *virt)
 	 * the above checks won't be sufficient with demand paging
 	 */
 
-	return Z_MEM_PHYS_ADDR(addr);
+	return K_MEM_PHYS_ADDR(addr);
 }
 
-/* Just like Z_MEM_VIRT_ADDR() but with type safety and assertions */
-static inline void *z_mem_virt_addr(uintptr_t phys)
+/**
+ * @brief Get virtual address from physical address.
+ *
+ * This only works in the kernel's permanent mapping of RAM.
+ *
+ * Just like K_MEM_VIRT_ADDR() but with type safety and assertions.
+ *
+ * @param phys Physical address
+ *
+ * @return Virtual address.
+ */
+static inline void *k_mem_virt_addr(uintptr_t phys)
 {
 #if defined(CONFIG_KERNEL_VM_USE_CUSTOM_MEM_RANGE_CHECK)
 	__ASSERT(sys_mm_is_phys_addr_in_range(phys),
@@ -128,7 +167,7 @@ static inline void *z_mem_virt_addr(uintptr_t phys)
 	 * the above check won't be sufficient with demand paging
 	 */
 
-	return (void *)Z_MEM_VIRT_ADDR(phys);
+	return (void *)K_MEM_VIRT_ADDR(phys);
 }
 
 #ifdef __cplusplus

--- a/include/zephyr/kernel/internal/mm.h
+++ b/include/zephyr/kernel/internal/mm.h
@@ -67,7 +67,10 @@
 #define K_MEM_VIRT_ADDR(phys)	((phys) + K_MEM_VIRT_OFFSET)
 
 #if K_MEM_VIRT_OFFSET != 0
-#define Z_VM_KERNEL 1
+/**
+ * @brief Kernel is mapped in virtual memory if defined.
+ */
+#define K_MEM_IS_VM_KERNEL 1
 #ifdef CONFIG_XIP
 #error "XIP and a virtual memory kernel are not allowed"
 #endif

--- a/include/zephyr/kernel/internal/mm.h
+++ b/include/zephyr/kernel/internal/mm.h
@@ -16,11 +16,14 @@
  * @{
  */
 
-/*
+/**
+ * @def K_MEM_VIRT_OFFSET
+ * @brief Address offset of permanent virtual mapping from physical address.
+ *
  * This is the offset to subtract from a virtual address mapped in the
  * kernel's permanent mapping of RAM, to obtain its physical address.
  *
- *     virt_addr = phys_addr + Z_MEM_VM_OFFSET
+ *     virt_addr = phys_addr + K_MEM_VIRT_OFFSET
  *
  * This only works for virtual addresses within the interval
  * [CONFIG_KERNEL_VM_BASE, CONFIG_KERNEL_VM_BASE + (CONFIG_SRAM_SIZE * 1024)).
@@ -35,16 +38,16 @@
  * constraints defined.
  */
 #ifdef CONFIG_MMU
-#define Z_MEM_VM_OFFSET	((CONFIG_KERNEL_VM_BASE + CONFIG_KERNEL_VM_OFFSET) - \
-			 (CONFIG_SRAM_BASE_ADDRESS + CONFIG_SRAM_OFFSET))
+#define K_MEM_VIRT_OFFSET	((CONFIG_KERNEL_VM_BASE + CONFIG_KERNEL_VM_OFFSET) - \
+				 (CONFIG_SRAM_BASE_ADDRESS + CONFIG_SRAM_OFFSET))
 #else
-#define Z_MEM_VM_OFFSET	0
+#define K_MEM_VIRT_OFFSET	0
 #endif /* CONFIG_MMU */
 
-#define Z_MEM_PHYS_ADDR(virt)	((virt) - Z_MEM_VM_OFFSET)
-#define Z_MEM_VIRT_ADDR(phys)	((phys) + Z_MEM_VM_OFFSET)
+#define Z_MEM_PHYS_ADDR(virt)	((virt) - K_MEM_VIRT_OFFSET)
+#define Z_MEM_VIRT_ADDR(phys)	((phys) + K_MEM_VIRT_OFFSET)
 
-#if Z_MEM_VM_OFFSET != 0
+#if K_MEM_VIRT_OFFSET != 0
 #define Z_VM_KERNEL 1
 #ifdef CONFIG_XIP
 #error "XIP and a virtual memory kernel are not allowed"

--- a/include/zephyr/kernel/internal/mm.h
+++ b/include/zephyr/kernel/internal/mm.h
@@ -243,8 +243,6 @@ void z_phys_unmap(uint8_t *virt, size_t size);
  *
  * @see k_mem_map() for additional information if called via that.
  *
- * @see k_mem_phys_map() for additional information if called via that.
- *
  * @param phys Physical address base of the memory region if not requesting
  *             anonymous memory. Must be page-aligned.
  * @param size Size of the memory mapping. This must be page-aligned.
@@ -267,8 +265,6 @@ void *k_mem_map_phys_guard(uintptr_t phys, size_t size, uint32_t flags, bool is_
  * for the kernel.
  *
  * @see k_mem_unmap() for additional information if called via that.
- *
- * @see k_mem_phys_unmap() for additional information if called via that.
  *
  * @note Calling this function on a region which was not mapped via
  *       k_mem_map_phys_guard() to begin with is undefined behavior.

--- a/include/zephyr/kernel/internal/mm.h
+++ b/include/zephyr/kernel/internal/mm.h
@@ -140,6 +140,9 @@ extern "C" {
  * linear address representing the base of where the physical region is mapped
  * in the virtual address space for the Zephyr kernel.
  *
+ * The memory mapped via this function must be unmapped using
+ * k_mem_unmap_phys_bare().
+ *
  * This function alters the active page tables in the area reserved
  * for the kernel. This function will choose the virtual address
  * and return it to the caller.
@@ -173,8 +176,8 @@ extern "C" {
  * @param[in]  size Size of the memory region
  * @param[in]  flags Caching mode and access flags, see K_MAP_* macros
  */
-void z_phys_map(uint8_t **virt_ptr, uintptr_t phys, size_t size,
-		uint32_t flags);
+void k_mem_map_phys_bare(uint8_t **virt_ptr, uintptr_t phys, size_t size,
+			 uint32_t flags);
 
 /**
  * Unmap a virtual memory region from kernel's virtual address space.
@@ -188,7 +191,7 @@ void z_phys_map(uint8_t **virt_ptr, uintptr_t phys, size_t size,
  *
  * This will align the input parameters to page boundaries so that
  * this can be used with the virtual address as returned by
- * z_phys_map().
+ * k_mem_map_phys_bare().
  *
  * This API is only available if CONFIG_MMU is enabled.
  *
@@ -203,7 +206,7 @@ void z_phys_map(uint8_t **virt_ptr, uintptr_t phys, size_t size,
  * @param virt Starting address of the virtual address region to be unmapped.
  * @param size Size of the virtual address region
  */
-void z_phys_unmap(uint8_t *virt, size_t size);
+void k_mem_unmap_phys_bare(uint8_t *virt, size_t size);
 
 /**
  * Map memory into virtual address space with guard pages.

--- a/include/zephyr/kernel/mm.h
+++ b/include/zephyr/kernel/mm.h
@@ -170,7 +170,7 @@ size_t k_mem_free_get(void);
  */
 static inline void *k_mem_map(size_t size, uint32_t flags)
 {
-	return k_mem_map_impl((uintptr_t)NULL, size, flags, true);
+	return k_mem_map_phys_guard((uintptr_t)NULL, size, flags, true);
 }
 
 /**
@@ -214,7 +214,7 @@ static inline void *k_mem_map(size_t size, uint32_t flags)
  */
 static inline void *k_mem_phys_map(uintptr_t phys, size_t size, uint32_t flags)
 {
-	return k_mem_map_impl(phys, size, flags, false);
+	return k_mem_map_phys_guard(phys, size, flags, false);
 }
 
 /**
@@ -232,7 +232,7 @@ static inline void *k_mem_phys_map(uintptr_t phys, size_t size, uint32_t flags)
  */
 static inline void k_mem_unmap(void *addr, size_t size)
 {
-	k_mem_unmap_impl(addr, size, true);
+	k_mem_unmap_phys_guard(addr, size, true);
 }
 
 /**
@@ -255,7 +255,7 @@ static inline void k_mem_unmap(void *addr, size_t size)
  */
 static inline void k_mem_phys_unmap(void *addr, size_t size)
 {
-	k_mem_unmap_impl(addr, size, false);
+	k_mem_unmap_phys_guard(addr, size, false);
 }
 
 /**

--- a/include/zephyr/kernel/mm.h
+++ b/include/zephyr/kernel/mm.h
@@ -174,50 +174,6 @@ static inline void *k_mem_map(size_t size, uint32_t flags)
 }
 
 /**
- * Map a physical memory region into kernel's virtual address space with guard pages.
- *
- * This function maps a contiguous physical memory region into kernel's
- * virtual address space. Given a physical address and a size, return a
- * linear address representing the base of where the physical region is mapped
- * in the virtual address space for the Zephyr kernel.
- *
- * This function alters the active page tables in the area reserved
- * for the kernel. This function will choose the virtual address
- * and return it to the caller.
- *
- * If user thread access control needs to be managed in any way, do not enable
- * K_MEM_PERM_USER flags here; instead manage the region's permissions
- * with memory domain APIs after the mapping has been established. Setting
- * K_MEM_PERM_USER here will allow all user threads to access this memory
- * which is usually undesirable.
- *
- * Unless K_MEM_MAP_UNINIT is used, the returned memory will be zeroed.
- *
- * The returned virtual memory pointer will be page-aligned. The size
- * parameter, and any base address for re-mapping purposes must be page-
- * aligned.
- *
- * Note that the allocation includes two guard pages immediately before
- * and after the requested region. The total size of the allocation will be
- * the requested size plus the size of these two guard pages.
- *
- * Many K_MEM_MAP_* flags have been implemented to alter the behavior of this
- * function, with details in the documentation for these flags.
- *
- * @param phys Physical address base of the memory region.
- *             This must be page-aligned.
- * @param size Size of the memory mapping. This must be page-aligned.
- * @param flags K_MEM_PERM_*, K_MEM_MAP_* control flags.
- *
- * @return The mapped memory location, or NULL if insufficient virtual address
- *         space or insufficient memory for paging structures.
- */
-static inline void *k_mem_phys_map(uintptr_t phys, size_t size, uint32_t flags)
-{
-	return k_mem_map_phys_guard(phys, size, flags, false);
-}
-
-/**
  * Un-map mapped memory
  *
  * This removes a memory mapping for the provided page-aligned region.
@@ -233,29 +189,6 @@ static inline void *k_mem_phys_map(uintptr_t phys, size_t size, uint32_t flags)
 static inline void k_mem_unmap(void *addr, size_t size)
 {
 	k_mem_unmap_phys_guard(addr, size, true);
-}
-
-/**
- * Un-map memory mapped via k_mem_phys_map().
- *
- * This unmaps a virtual memory region from kernel's virtual address space.
- *
- * This function alters the active page tables in the area reserved
- * for the kernel.
- *
- * This removes a memory mapping for the provided page-aligned region
- * and the guard pages. The kernel may re-use the associated virtual address
- * region later.
- *
- * @note Calling this function on a region which was not mapped via
- *       k_mem_phys_map() to begin with is undefined behavior.
- *
- * @param addr Page-aligned memory region base virtual address
- * @param size Page-aligned memory region size
- */
-static inline void k_mem_phys_unmap(void *addr, size_t size)
-{
-	k_mem_unmap_phys_guard(addr, size, false);
 }
 
 /**

--- a/include/zephyr/kernel/mm/demand_paging.h
+++ b/include/zephyr/kernel/mm/demand_paging.h
@@ -302,9 +302,9 @@ int k_mem_paging_backing_store_location_get(struct z_page_frame *pf,
 void k_mem_paging_backing_store_location_free(uintptr_t location);
 
 /**
- * Copy a data page from Z_SCRATCH_PAGE to the specified location
+ * Copy a data page from K_MEM_SCRATCH_PAGE to the specified location
  *
- * Immediately before this is called, Z_SCRATCH_PAGE will be mapped read-write
+ * Immediately before this is called, K_MEM_SCRATCH_PAGE will be mapped read-write
  * to the intended source page frame for the calling context.
  *
  * Calls to this and k_mem_paging_backing_store_page_in() will always be
@@ -315,9 +315,9 @@ void k_mem_paging_backing_store_location_free(uintptr_t location);
 void k_mem_paging_backing_store_page_out(uintptr_t location);
 
 /**
- * Copy a data page from the provided location to Z_SCRATCH_PAGE.
+ * Copy a data page from the provided location to K_MEM_SCRATCH_PAGE.
  *
- * Immediately before this is called, Z_SCRATCH_PAGE will be mapped read-write
+ * Immediately before this is called, K_MEM_SCRATCH_PAGE will be mapped read-write
  * to the intended destination page frame for the calling context.
  *
  * Calls to this and k_mem_paging_backing_store_page_out() will always be

--- a/include/zephyr/kernel/mm/demand_paging.h
+++ b/include/zephyr/kernel/mm/demand_paging.h
@@ -229,7 +229,7 @@ __syscall void k_mem_paging_histogram_backing_store_page_out_get(
  * @param [out] dirty Whether the page to evict is dirty
  * @return The page frame to evict
  */
-struct z_page_frame *k_mem_paging_eviction_select(bool *dirty);
+struct k_mem_page_frame *k_mem_paging_eviction_select(bool *dirty);
 
 /**
  * Initialization function
@@ -258,16 +258,16 @@ void k_mem_paging_eviction_init(void);
  * contents for later retrieval. The location value must be page-aligned.
  *
  * This function may be called multiple times on the same data page. If its
- * page frame has its Z_PAGE_FRAME_BACKED bit set, it is expected to return
+ * page frame has its K_MEM_PAGE_FRAME_BACKED bit set, it is expected to return
  * the previous backing store location for the data page containing a cached
  * clean copy. This clean copy may be updated on page-out, or used to
  * discard clean pages without needing to write out their contents.
  *
  * If the backing store is full, some other backing store location which caches
  * a loaded data page may be selected, in which case its associated page frame
- * will have the Z_PAGE_FRAME_BACKED bit cleared (as it is no longer cached).
+ * will have the K_MEM_PAGE_FRAME_BACKED bit cleared (as it is no longer cached).
  *
- * z_page_frame_to_virt(pf) will indicate the virtual address the page is
+ * k_mem_page_frame_to_virt(pf) will indicate the virtual address the page is
  * currently mapped to. Large, sparse backing stores which can contain the
  * entire address space may simply generate location tokens purely as a
  * function of that virtual address with no other management necessary.
@@ -285,7 +285,7 @@ void k_mem_paging_eviction_init(void);
  * @return 0 Success
  * @return -ENOMEM Backing store is full
  */
-int k_mem_paging_backing_store_location_get(struct z_page_frame *pf,
+int k_mem_paging_backing_store_location_get(struct k_mem_page_frame *pf,
 					    uintptr_t *location,
 					    bool page_fault);
 
@@ -331,7 +331,7 @@ void k_mem_paging_backing_store_page_in(uintptr_t location);
  * Update internal accounting after a page-in
  *
  * This is invoked after k_mem_paging_backing_store_page_in() and interrupts
- * have been* re-locked, making it safe to access the z_page_frame data.
+ * have been* re-locked, making it safe to access the k_mem_page_frame data.
  * The location value will be the same passed to
  * k_mem_paging_backing_store_page_in().
  *
@@ -340,14 +340,14 @@ void k_mem_paging_backing_store_page_in(uintptr_t location);
  * if it is paged out again. This may be a no-op in some implementations.
  *
  * If the backing store caches paged-in data pages, this is the appropriate
- * time to set the Z_PAGE_FRAME_BACKED bit. The kernel only skips paging
+ * time to set the K_MEM_PAGE_FRAME_BACKED bit. The kernel only skips paging
  * out clean data pages if they are noted as clean in the page tables and the
- * Z_PAGE_FRAME_BACKED bit is set in their associated page frame.
+ * K_MEM_PAGE_FRAME_BACKED bit is set in their associated page frame.
  *
  * @param pf Page frame that was loaded in
  * @param location Location of where the loaded data page was retrieved
  */
-void k_mem_paging_backing_store_page_finalize(struct z_page_frame *pf,
+void k_mem_paging_backing_store_page_finalize(struct k_mem_page_frame *pf,
 					      uintptr_t location);
 
 /**
@@ -360,7 +360,7 @@ void k_mem_paging_backing_store_page_finalize(struct z_page_frame *pf,
  * - Initialize any internal data structures and accounting for the backing
  *   store.
  * - If the backing store already contains all or some loaded kernel data pages
- *   at boot time, Z_PAGE_FRAME_BACKED should be appropriately set for their
+ *   at boot time, K_MEM_PAGE_FRAME_BACKED should be appropriately set for their
  *   associated page frames, and any internal accounting set up appropriately.
  */
 void k_mem_paging_backing_store_init(void);

--- a/include/zephyr/linker/linker-defs.h
+++ b/include/zephyr/linker/linker-defs.h
@@ -292,7 +292,7 @@ extern char lnkr_boot_noinit_size[];
 /* lnkr_pinned_start[] and lnkr_pinned_end[] must encapsulate
  * all the pinned sections as these are used by
  * the MMU code to mark the physical page frames with
- * Z_PAGE_FRAME_PINNED.
+ * K_MEM_PAGE_FRAME_PINNED.
  */
 extern char lnkr_pinned_start[];
 extern char lnkr_pinned_end[];

--- a/include/zephyr/linker/linker-tool-gcc.h
+++ b/include/zephyr/linker/linker-tool-gcc.h
@@ -89,7 +89,7 @@
  */
 #if defined(CONFIG_ARCH_POSIX)
 #define GROUP_LINK_IN(where)
-#elif !defined(Z_VM_KERNEL)
+#elif !defined(K_MEM_IS_VM_KERNEL)
 #define GROUP_LINK_IN(where) > where
 #endif
 
@@ -113,7 +113,7 @@
  */
 #if defined(CONFIG_ARCH_POSIX)
 #define GROUP_ROM_LINK_IN(vregion, lregion)
-#elif defined(Z_VM_KERNEL)
+#elif defined(K_MEM_IS_VM_KERNEL)
 #define GROUP_ROM_LINK_IN(vregion, lregion) > vregion AT > lregion
 #else
 #define GROUP_ROM_LINK_IN(vregion, lregion) > lregion
@@ -133,7 +133,7 @@
  */
 #if defined(CONFIG_ARCH_POSIX)
 #define GROUP_DATA_LINK_IN(vregion, lregion)
-#elif defined(CONFIG_XIP) || defined(Z_VM_KERNEL)
+#elif defined(CONFIG_XIP) || defined(K_MEM_IS_VM_KERNEL)
 #define GROUP_DATA_LINK_IN(vregion, lregion) > vregion AT > lregion
 #else
 #define GROUP_DATA_LINK_IN(vregion, lregion) > vregion
@@ -151,7 +151,7 @@
  */
 #if defined(CONFIG_ARCH_POSIX)
 #define GROUP_NOLOAD_LINK_IN(vregion, lregion)
-#elif defined(Z_VM_KERNEL)
+#elif defined(K_MEM_IS_VM_KERNEL)
 #define GROUP_NOLOAD_LINK_IN(vregion, lregion) > vregion AT > lregion
 #elif defined(CONFIG_XIP)
 #define GROUP_NOLOAD_LINK_IN(vregion, lregion) > vregion AT > vregion
@@ -172,7 +172,7 @@
  * @param align Alignment directives, such as SUBALIGN(). ALIGN() itself is
  *              not allowed. May be blank.
  */
-#ifdef Z_VM_KERNEL
+#ifdef K_MEM_IS_VM_KERNEL
 /* If we have a virtual memory map we need ALIGN_WITH_INPUT in all sections */
 #define SECTION_PROLOGUE(name, options, align) \
 	name options : ALIGN_WITH_INPUT align

--- a/include/zephyr/sys/device_mmio.h
+++ b/include/zephyr/sys/device_mmio.h
@@ -101,8 +101,8 @@ static inline void device_map(mm_reg_t *virt_addr, uintptr_t phys_addr,
 	/* Pass along flags and add that we want supervisor mode
 	 * read-write access.
 	 */
-	z_phys_map((uint8_t **)virt_addr, phys_addr, size,
-		   flags | K_MEM_PERM_RW);
+	k_mem_map_phys_bare((uint8_t **)virt_addr, phys_addr, size,
+			    flags | K_MEM_PERM_RW);
 #else
 	ARG_UNUSED(size);
 	ARG_UNUSED(flags);

--- a/kernel/Kconfig.vm
+++ b/kernel/Kconfig.vm
@@ -202,7 +202,7 @@ config KERNEL_VM_USE_CUSTOM_MEM_RANGE_CHECK
 	bool
 	help
 	  Use custom memory range check functions instead of the generic
-	  checks in z_mem_phys_addr() and z_mem_virt_addr().
+	  checks in k_mem_phys_addr() and k_mem_virt_addr().
 
 	  sys_mm_is_phys_addr_in_range() and
 	  sys_mm_is_virt_addr_in_range() must be implemented.

--- a/kernel/include/kernel_arch_interface.h
+++ b/kernel/include/kernel_arch_interface.h
@@ -341,7 +341,7 @@ int arch_page_phys_get(void *virt, uintptr_t *phys);
  * example of this is reserved regions in the first megabyte on PC-like systems.
  *
  * Implementations of this function should mark all relevant entries in
- * z_page_frames with K_PAGE_FRAME_RESERVED. This function is called at
+ * k_mem_page_frames with K_PAGE_FRAME_RESERVED. This function is called at
  * early system initialization with mm_lock held.
  */
 void arch_reserved_pages_update(void);

--- a/kernel/include/kernel_arch_interface.h
+++ b/kernel/include/kernel_arch_interface.h
@@ -390,9 +390,9 @@ void arch_mem_page_in(void *addr, uintptr_t phys);
  * Update current page tables for a temporary mapping
  *
  * Map a physical page frame address to a special virtual address
- * Z_SCRATCH_PAGE, with read/write access to supervisor mode, such that
+ * K_MEM_SCRATCH_PAGE, with read/write access to supervisor mode, such that
  * when this function returns, the calling context can read/write the page
- * frame's contents from the Z_SCRATCH_PAGE address.
+ * frame's contents from the K_MEM_SCRATCH_PAGE address.
  *
  * This mapping only needs to be done on the current set of page tables,
  * as it is only used for a short period of time exclusively by the caller.

--- a/kernel/include/mmu.h
+++ b/kernel/include/mmu.h
@@ -404,7 +404,8 @@ int k_mem_page_frame_evict(uintptr_t phys);
  * @retval false This page fault was from an un-mapped page, should
  *               be treated as an error, and not re-tried.
  */
-bool z_page_fault(void *addr);
+bool k_mem_page_fault(void *addr);
+
 #endif /* CONFIG_DEMAND_PAGING */
 #endif /* CONFIG_MMU */
 #endif /* KERNEL_INCLUDE_MMU_H */

--- a/kernel/include/mmu.h
+++ b/kernel/include/mmu.h
@@ -25,10 +25,17 @@
  * anonymous mappings. We don't currently maintain an ontology of these in the
  * core kernel.
  */
-#define Z_PHYS_RAM_START	((uintptr_t)CONFIG_SRAM_BASE_ADDRESS)
-#define Z_PHYS_RAM_SIZE		(KB(CONFIG_SRAM_SIZE))
-#define Z_PHYS_RAM_END		(Z_PHYS_RAM_START + Z_PHYS_RAM_SIZE)
-#define Z_NUM_PAGE_FRAMES	(Z_PHYS_RAM_SIZE / (size_t)CONFIG_MMU_PAGE_SIZE)
+
+/** Start address of physical memory. */
+#define K_MEM_PHYS_RAM_START	((uintptr_t)CONFIG_SRAM_BASE_ADDRESS)
+
+/** Size of physical memory. */
+#define K_MEM_PHYS_RAM_SIZE	(KB(CONFIG_SRAM_SIZE))
+
+/** End address (exclusive) of physical memory. */
+#define K_MEM_PHYS_RAM_END	(K_MEM_PHYS_RAM_START + K_MEM_PHYS_RAM_SIZE)
+
+#define Z_NUM_PAGE_FRAMES	(K_MEM_PHYS_RAM_SIZE / (size_t)CONFIG_MMU_PAGE_SIZE)
 
 /** End virtual address of virtual address space */
 #define Z_VIRT_RAM_START	((uint8_t *)CONFIG_KERNEL_VM_BASE)
@@ -76,7 +83,7 @@
 #define K_MEM_BOOT_PHYS_TO_VIRT(phys) ((uint8_t *)(((uintptr_t)(phys)) + K_MEM_VM_OFFSET))
 
 #ifdef CONFIG_ARCH_MAPS_ALL_RAM
-#define Z_FREE_VM_START	K_MEM_BOOT_PHYS_TO_VIRT(Z_PHYS_RAM_END)
+#define Z_FREE_VM_START	K_MEM_BOOT_PHYS_TO_VIRT(K_MEM_PHYS_RAM_END)
 #else
 #define Z_FREE_VM_START	Z_KERNEL_VIRT_END
 #endif /* CONFIG_ARCH_MAPS_ALL_RAM */
@@ -227,7 +234,7 @@ extern struct z_page_frame z_page_frames[Z_NUM_PAGE_FRAMES];
 static inline uintptr_t z_page_frame_to_phys(struct z_page_frame *pf)
 {
 	return (uintptr_t)((pf - z_page_frames) * CONFIG_MMU_PAGE_SIZE) +
-			Z_PHYS_RAM_START;
+			  K_MEM_PHYS_RAM_START;
 }
 
 /* Presumes there is but one mapping in the virtual address space */
@@ -241,8 +248,8 @@ static inline void *z_page_frame_to_virt(struct z_page_frame *pf)
 static inline bool z_is_page_frame(uintptr_t phys)
 {
 	z_assert_phys_aligned(phys);
-	return IN_RANGE(phys, (uintptr_t)Z_PHYS_RAM_START,
-			(uintptr_t)(Z_PHYS_RAM_END - 1));
+	return IN_RANGE(phys, (uintptr_t)K_MEM_PHYS_RAM_START,
+			(uintptr_t)(K_MEM_PHYS_RAM_END - 1));
 }
 
 static inline struct z_page_frame *z_phys_to_page_frame(uintptr_t phys)
@@ -250,7 +257,7 @@ static inline struct z_page_frame *z_phys_to_page_frame(uintptr_t phys)
 	__ASSERT(z_is_page_frame(phys),
 		 "0x%lx not an SRAM physical address", phys);
 
-	return &z_page_frames[(phys - Z_PHYS_RAM_START) /
+	return &z_page_frames[(phys - K_MEM_PHYS_RAM_START) /
 			      CONFIG_MMU_PAGE_SIZE];
 }
 
@@ -278,8 +285,8 @@ void z_page_frames_dump(void);
 
 /* Convenience macro for iterating over all page frames */
 #define Z_PAGE_FRAME_FOREACH(_phys, _pageframe) \
-	for ((_phys) = Z_PHYS_RAM_START, (_pageframe) = z_page_frames; \
-	     (_phys) < Z_PHYS_RAM_END; \
+	for ((_phys) = K_MEM_PHYS_RAM_START, (_pageframe) = z_page_frames; \
+	     (_phys) < K_MEM_PHYS_RAM_END; \
 	     (_phys) += CONFIG_MMU_PAGE_SIZE, (_pageframe)++)
 
 #ifdef CONFIG_DEMAND_PAGING

--- a/kernel/include/mmu.h
+++ b/kernel/include/mmu.h
@@ -356,7 +356,7 @@ void k_mem_page_frames_dump(void);
  *
  * @return Number of successful page faults
  */
-unsigned long z_num_pagefaults_get(void);
+unsigned long k_mem_num_pagefaults_get(void);
 
 /**
  * Free a page frame physical address by evicting its contents

--- a/kernel/include/mmu.h
+++ b/kernel/include/mmu.h
@@ -40,8 +40,14 @@
 #define Z_KERNEL_VIRT_END	((uint8_t *)&z_mapped_end[0])
 #define Z_KERNEL_VIRT_SIZE	(Z_KERNEL_VIRT_END - Z_KERNEL_VIRT_START)
 
-#define Z_VM_OFFSET	 ((CONFIG_KERNEL_VM_BASE + CONFIG_KERNEL_VM_OFFSET) - \
-			  (CONFIG_SRAM_BASE_ADDRESS + CONFIG_SRAM_OFFSET))
+/**
+ * @brief Offset for translating between static physical and virtual addresses.
+ *
+ * @note Do not use directly unless you know exactly what you are going.
+ */
+#define K_MEM_VM_OFFSET	\
+	((CONFIG_KERNEL_VM_BASE + CONFIG_KERNEL_VM_OFFSET) - \
+	 (CONFIG_SRAM_BASE_ADDRESS + CONFIG_SRAM_OFFSET))
 
 /**
  * @brief Get physical address from virtual address for boot RAM mappings.
@@ -54,7 +60,7 @@
  *
  * @return Physical address.
  */
-#define K_MEM_BOOT_VIRT_TO_PHYS(virt) ((uintptr_t)(((uint8_t *)(virt)) - Z_VM_OFFSET))
+#define K_MEM_BOOT_VIRT_TO_PHYS(virt) ((uintptr_t)(((uint8_t *)(virt)) - K_MEM_VM_OFFSET))
 
 /**
  * @brief Get virtual address from physical address for boot RAM mappings.
@@ -67,7 +73,7 @@
  *
  * @return Virtual address.
  */
-#define K_MEM_BOOT_PHYS_TO_VIRT(phys) ((uint8_t *)(((uintptr_t)(phys)) + Z_VM_OFFSET))
+#define K_MEM_BOOT_PHYS_TO_VIRT(phys) ((uint8_t *)(((uintptr_t)(phys)) + K_MEM_VM_OFFSET))
 
 #ifdef CONFIG_ARCH_MAPS_ALL_RAM
 #define Z_FREE_VM_START	K_MEM_BOOT_PHYS_TO_VIRT(Z_PHYS_RAM_END)

--- a/kernel/include/mmu.h
+++ b/kernel/include/mmu.h
@@ -313,16 +313,21 @@ void z_page_frames_dump(void);
 	     (_phys) < K_MEM_PHYS_RAM_END; \
 	     (_phys) += CONFIG_MMU_PAGE_SIZE, (_pageframe)++)
 
+/**
+ * @def K_MEM_VM_RESERVED
+ * @brief Reserve space at the end of virtual memory.
+ */
 #ifdef CONFIG_DEMAND_PAGING
 /* We reserve a virtual page as a scratch area for page-ins/outs at the end
  * of the address space
  */
-#define Z_VM_RESERVED	CONFIG_MMU_PAGE_SIZE
+#define K_MEM_VM_RESERVED	CONFIG_MMU_PAGE_SIZE
+
 #define Z_SCRATCH_PAGE	((void *)((uintptr_t)CONFIG_KERNEL_VM_BASE + \
 				     (uintptr_t)CONFIG_KERNEL_VM_SIZE - \
 				     CONFIG_MMU_PAGE_SIZE))
 #else
-#define Z_VM_RESERVED	0
+#define K_MEM_VM_RESERVED	0
 #endif /* CONFIG_DEMAND_PAGING */
 
 #ifdef CONFIG_DEMAND_PAGING

--- a/kernel/include/mmu.h
+++ b/kernel/include/mmu.h
@@ -43,15 +43,34 @@
 #define Z_VM_OFFSET	 ((CONFIG_KERNEL_VM_BASE + CONFIG_KERNEL_VM_OFFSET) - \
 			  (CONFIG_SRAM_BASE_ADDRESS + CONFIG_SRAM_OFFSET))
 
-/* Only applies to boot RAM mappings within the Zephyr image that have never
- * been remapped or paged out. Never use this unless you know exactly what you
- * are doing.
+/**
+ * @brief Get physical address from virtual address for boot RAM mappings.
+ *
+ * @note Only applies to boot RAM mappings within the Zephyr image that have never
+ *       been remapped or paged out. Never use this unless you know exactly what you
+ *       are doing.
+ *
+ * @param virt Virtual address.
+ *
+ * @return Physical address.
  */
-#define Z_BOOT_VIRT_TO_PHYS(virt) ((uintptr_t)(((uint8_t *)(virt)) - Z_VM_OFFSET))
-#define Z_BOOT_PHYS_TO_VIRT(phys) ((uint8_t *)(((uintptr_t)(phys)) + Z_VM_OFFSET))
+#define K_MEM_BOOT_VIRT_TO_PHYS(virt) ((uintptr_t)(((uint8_t *)(virt)) - Z_VM_OFFSET))
+
+/**
+ * @brief Get virtual address from physical address for boot RAM mappings.
+ *
+ * @note Only applies to boot RAM mappings within the Zephyr image that have never
+ *       been remapped or paged out. Never use this unless you know exactly what you
+ *       are doing.
+ *
+ * @param phys Physical address.
+ *
+ * @return Virtual address.
+ */
+#define K_MEM_BOOT_PHYS_TO_VIRT(phys) ((uint8_t *)(((uintptr_t)(phys)) + Z_VM_OFFSET))
 
 #ifdef CONFIG_ARCH_MAPS_ALL_RAM
-#define Z_FREE_VM_START	Z_BOOT_PHYS_TO_VIRT(Z_PHYS_RAM_END)
+#define Z_FREE_VM_START	K_MEM_BOOT_PHYS_TO_VIRT(Z_PHYS_RAM_END)
 #else
 #define Z_FREE_VM_START	Z_KERNEL_VIRT_END
 #endif /* CONFIG_ARCH_MAPS_ALL_RAM */

--- a/kernel/include/mmu.h
+++ b/kernel/include/mmu.h
@@ -323,9 +323,12 @@ void z_page_frames_dump(void);
  */
 #define K_MEM_VM_RESERVED	CONFIG_MMU_PAGE_SIZE
 
-#define Z_SCRATCH_PAGE	((void *)((uintptr_t)CONFIG_KERNEL_VM_BASE + \
-				     (uintptr_t)CONFIG_KERNEL_VM_SIZE - \
-				     CONFIG_MMU_PAGE_SIZE))
+/**
+ * @brief Location of the scratch page used for demand paging.
+ */
+#define K_MEM_SCRATCH_PAGE	((void *)((uintptr_t)CONFIG_KERNEL_VM_BASE + \
+					  (uintptr_t)CONFIG_KERNEL_VM_SIZE - \
+					  CONFIG_MMU_PAGE_SIZE))
 #else
 #define K_MEM_VM_RESERVED	0
 #endif /* CONFIG_DEMAND_PAGING */

--- a/kernel/include/mmu.h
+++ b/kernel/include/mmu.h
@@ -46,10 +46,14 @@
 /** End address (exclusive) of virtual memory. */
 #define K_MEM_VIRT_RAM_END	(K_MEM_VIRT_RAM_START + K_MEM_VIRT_RAM_SIZE)
 
-/* Boot-time virtual location of the kernel image. */
-#define Z_KERNEL_VIRT_START	((uint8_t *)&z_mapped_start[0])
-#define Z_KERNEL_VIRT_END	((uint8_t *)&z_mapped_end[0])
-#define Z_KERNEL_VIRT_SIZE	(Z_KERNEL_VIRT_END - Z_KERNEL_VIRT_START)
+/** Boot-time virtual start address of the kernel image. */
+#define K_MEM_KERNEL_VIRT_START	((uint8_t *)&z_mapped_start[0])
+
+/** Boot-time virtual end address of the kernel image. */
+#define K_MEM_KERNEL_VIRT_END	((uint8_t *)&z_mapped_end[0])
+
+/** Boot-time virtual address space size of the kernel image. */
+#define K_MEM_KERNEL_VIRT_SIZE	(K_MEM_KERNEL_VIRT_END - K_MEM_KERNEL_VIRT_START)
 
 /**
  * @brief Offset for translating between static physical and virtual addresses.
@@ -89,7 +93,7 @@
 #ifdef CONFIG_ARCH_MAPS_ALL_RAM
 #define Z_FREE_VM_START	K_MEM_BOOT_PHYS_TO_VIRT(K_MEM_PHYS_RAM_END)
 #else
-#define Z_FREE_VM_START	Z_KERNEL_VIRT_END
+#define Z_FREE_VM_START	K_MEM_KERNEL_VIRT_END
 #endif /* CONFIG_ARCH_MAPS_ALL_RAM */
 
 /*

--- a/kernel/include/mmu.h
+++ b/kernel/include/mmu.h
@@ -90,10 +90,26 @@
  */
 #define K_MEM_BOOT_PHYS_TO_VIRT(phys) ((uint8_t *)(((uintptr_t)(phys)) + K_MEM_VM_OFFSET))
 
+/**
+ * @def K_MEM_VM_FREE_START
+ * @brief Start address of unused, available virtual addresses.
+ *
+ * This is the start address of the virtual memory region where
+ * addresses can be allocated for memory mapping. This depends on whether
+ * CONFIG_ARCH_MAPS_ALL_RAM is enabled:
+ *
+ * - If it is enabled, which means all physical memory are mapped in virtual
+ *   memory address space, and it is the same as
+ *   (CONFIG_SRAM_BASE_ADDRESS + CONFIG_SRAM_SIZE).
+ *
+ * - If it is disabled, K_MEM_VM_FREE_START is the same K_MEM_KERNEL_VIRT_END which
+ *   is the end of the kernel image.
+ *
+ */
 #ifdef CONFIG_ARCH_MAPS_ALL_RAM
-#define Z_FREE_VM_START	K_MEM_BOOT_PHYS_TO_VIRT(K_MEM_PHYS_RAM_END)
+#define K_MEM_VM_FREE_START	K_MEM_BOOT_PHYS_TO_VIRT(K_MEM_PHYS_RAM_END)
 #else
-#define Z_FREE_VM_START	K_MEM_KERNEL_VIRT_END
+#define K_MEM_VM_FREE_START	K_MEM_KERNEL_VIRT_END
 #endif /* CONFIG_ARCH_MAPS_ALL_RAM */
 
 /*

--- a/kernel/include/mmu.h
+++ b/kernel/include/mmu.h
@@ -37,10 +37,14 @@
 
 #define Z_NUM_PAGE_FRAMES	(K_MEM_PHYS_RAM_SIZE / (size_t)CONFIG_MMU_PAGE_SIZE)
 
-/** End virtual address of virtual address space */
-#define Z_VIRT_RAM_START	((uint8_t *)CONFIG_KERNEL_VM_BASE)
-#define Z_VIRT_RAM_SIZE		((size_t)CONFIG_KERNEL_VM_SIZE)
-#define Z_VIRT_RAM_END		(Z_VIRT_RAM_START + Z_VIRT_RAM_SIZE)
+/** Start address of virtual memory. */
+#define K_MEM_VIRT_RAM_START	((uint8_t *)CONFIG_KERNEL_VM_BASE)
+
+/** Size of virtual memory. */
+#define K_MEM_VIRT_RAM_SIZE	((size_t)CONFIG_KERNEL_VM_SIZE)
+
+/** End address (exclusive) of virtual memory. */
+#define K_MEM_VIRT_RAM_END	(K_MEM_VIRT_RAM_START + K_MEM_VIRT_RAM_SIZE)
 
 /* Boot-time virtual location of the kernel image. */
 #define Z_KERNEL_VIRT_START	((uint8_t *)&z_mapped_start[0])
@@ -270,11 +274,11 @@ static inline void z_mem_assert_virtual_region(uint8_t *addr, size_t size)
 	__ASSERT(!Z_DETECT_POINTER_OVERFLOW(addr, size),
 		 "region %p size %zu zero or wraps around", addr, size);
 	__ASSERT(IN_RANGE((uintptr_t)addr,
-			  (uintptr_t)Z_VIRT_RAM_START,
-			  ((uintptr_t)Z_VIRT_RAM_END - 1)) &&
+			  (uintptr_t)K_MEM_VIRT_RAM_START,
+			  ((uintptr_t)K_MEM_VIRT_RAM_END - 1)) &&
 		 IN_RANGE(((uintptr_t)addr + size - 1),
-			  (uintptr_t)Z_VIRT_RAM_START,
-			  ((uintptr_t)Z_VIRT_RAM_END - 1)),
+			  (uintptr_t)K_MEM_VIRT_RAM_START,
+			  ((uintptr_t)K_MEM_VIRT_RAM_END - 1)),
 		 "invalid virtual address region %p (%zu)", addr, size);
 }
 

--- a/kernel/include/mmu.h
+++ b/kernel/include/mmu.h
@@ -15,17 +15,6 @@
 #include <zephyr/kernel/mm.h>
 #include <zephyr/linker/linker-defs.h>
 
-/*
- * At present, page frame management is only done for main system RAM,
- * and we generate paging structures based on CONFIG_SRAM_BASE_ADDRESS
- * and CONFIG_SRAM_SIZE.
- *
- * If we have other RAM regions (DCCM, etc) these typically have special
- * properties and shouldn't be used generically for demand paging or
- * anonymous mappings. We don't currently maintain an ontology of these in the
- * core kernel.
- */
-
 /** Start address of physical memory. */
 #define K_MEM_PHYS_RAM_START	((uintptr_t)CONFIG_SRAM_BASE_ADDRESS)
 
@@ -34,8 +23,6 @@
 
 /** End address (exclusive) of physical memory. */
 #define K_MEM_PHYS_RAM_END	(K_MEM_PHYS_RAM_START + K_MEM_PHYS_RAM_SIZE)
-
-#define Z_NUM_PAGE_FRAMES	(K_MEM_PHYS_RAM_SIZE / (size_t)CONFIG_MMU_PAGE_SIZE)
 
 /** Start address of virtual memory. */
 #define K_MEM_VIRT_RAM_START	((uint8_t *)CONFIG_KERNEL_VM_BASE)
@@ -112,28 +99,46 @@
 #define K_MEM_VM_FREE_START	K_MEM_KERNEL_VIRT_END
 #endif /* CONFIG_ARCH_MAPS_ALL_RAM */
 
-/*
+/**
+ * @defgroup kernel_mm_page_frame_apis Kernel Memory Page Frame Management APIs
+ * @ingroup kernel_mm_internal_apis
+ * @{
+ *
  * Macros and data structures for physical page frame accounting,
  * APIs for use by eviction and backing store algorithms. This code
  * is otherwise not application-facing.
  */
 
+/**
+ * @brief Number of page frames.
+ *
+ * At present, page frame management is only done for main system RAM,
+ * and we generate paging structures based on CONFIG_SRAM_BASE_ADDRESS
+ * and CONFIG_SRAM_SIZE.
+ *
+ * If we have other RAM regions (DCCM, etc) these typically have special
+ * properties and shouldn't be used generically for demand paging or
+ * anonymous mappings. We don't currently maintain an ontology of these in the
+ * core kernel.
+ */
+#define K_MEM_NUM_PAGE_FRAMES	(K_MEM_PHYS_RAM_SIZE / (size_t)CONFIG_MMU_PAGE_SIZE)
+
 /*
- * z_page_frame flags bits
+ * k_mem_page_frame flags bits
  *
  * Requirements:
- * - Z_PAGE_FRAME_FREE must be one of the possible sfnode flag bits
+ * - K_MEM_PAGE_FRAME_FREE must be one of the possible sfnode flag bits
  * - All bit values must be lower than CONFIG_MMU_PAGE_SIZE
  */
 
 /** This physical page is free and part of the free list */
-#define Z_PAGE_FRAME_FREE		BIT(0)
+#define K_MEM_PAGE_FRAME_FREE		BIT(0)
 
 /** This physical page is reserved by hardware; we will never use it */
-#define Z_PAGE_FRAME_RESERVED		BIT(1)
+#define K_MEM_PAGE_FRAME_RESERVED	BIT(1)
 
 /** This page contains critical kernel data and will never be swapped */
-#define Z_PAGE_FRAME_PINNED		BIT(2)
+#define K_MEM_PAGE_FRAME_PINNED		BIT(2)
 
 /**
  * This physical page is mapped to some virtual memory address
@@ -141,17 +146,17 @@
  * Currently, we just support one mapping per page frame. If a page frame
  * is mapped to multiple virtual pages then it must be pinned.
  */
-#define Z_PAGE_FRAME_MAPPED		BIT(3)
+#define K_MEM_PAGE_FRAME_MAPPED		BIT(3)
 
 /**
  * This page frame is currently involved in a page-in/out operation
  */
-#define Z_PAGE_FRAME_BUSY		BIT(4)
+#define K_MEM_PAGE_FRAME_BUSY		BIT(4)
 
 /**
  * This page frame has a clean copy in the backing store
  */
-#define Z_PAGE_FRAME_BACKED		BIT(5)
+#define K_MEM_PAGE_FRAME_BACKED		BIT(5)
 
 /**
  * Data structure for physical page frames
@@ -159,17 +164,17 @@
  * An array of these is instantiated, one element per physical RAM page.
  * Hence it's necessary to constrain its size as much as possible.
  */
-struct z_page_frame {
+struct k_mem_page_frame {
 	union {
 		/*
-		 * If mapped, Z_PAGE_FRAME_* flags and virtual address
+		 * If mapped, K_MEM_PAGE_FRAME_* flags and virtual address
 		 * this page is mapped to.
 		 */
 		uintptr_t va_and_flags;
 
 		/*
 		 * If unmapped and available, free pages list membership
-		 * with the Z_PAGE_FRAME_FREE flag.
+		 * with the K_MEM_PAGE_FRAME_FREE flag.
 		 */
 		sys_sfnode_t node;
 	};
@@ -177,68 +182,68 @@ struct z_page_frame {
 	/* Backing store and eviction algorithms may both need to
 	 * require additional per-frame custom data for accounting purposes.
 	 * They should declare their own array with indices matching
-	 * z_page_frames[] ones whenever possible.
+	 * k_mem_page_frames[] ones whenever possible.
 	 * They may also want additional flags bits that could be stored here
 	 * and they shouldn't clobber each other. At all costs the total
-	 * size of struct z_page_frame must be minimized.
+	 * size of struct k_mem_page_frame must be minimized.
 	 */
 };
 
 /* Note: this must be false for the other flag bits to be valid */
-static inline bool z_page_frame_is_free(struct z_page_frame *pf)
+static inline bool k_mem_page_frame_is_free(struct k_mem_page_frame *pf)
 {
-	return (pf->va_and_flags & Z_PAGE_FRAME_FREE) != 0U;
+	return (pf->va_and_flags & K_MEM_PAGE_FRAME_FREE) != 0U;
 }
 
-static inline bool z_page_frame_is_pinned(struct z_page_frame *pf)
+static inline bool k_mem_page_frame_is_pinned(struct k_mem_page_frame *pf)
 {
-	return (pf->va_and_flags & Z_PAGE_FRAME_PINNED) != 0U;
+	return (pf->va_and_flags & K_MEM_PAGE_FRAME_PINNED) != 0U;
 }
 
-static inline bool z_page_frame_is_reserved(struct z_page_frame *pf)
+static inline bool k_mem_page_frame_is_reserved(struct k_mem_page_frame *pf)
 {
-	return (pf->va_and_flags & Z_PAGE_FRAME_RESERVED) != 0U;
+	return (pf->va_and_flags & K_MEM_PAGE_FRAME_RESERVED) != 0U;
 }
 
-static inline bool z_page_frame_is_mapped(struct z_page_frame *pf)
+static inline bool k_mem_page_frame_is_mapped(struct k_mem_page_frame *pf)
 {
-	return (pf->va_and_flags & Z_PAGE_FRAME_MAPPED) != 0U;
+	return (pf->va_and_flags & K_MEM_PAGE_FRAME_MAPPED) != 0U;
 }
 
-static inline bool z_page_frame_is_busy(struct z_page_frame *pf)
+static inline bool k_mem_page_frame_is_busy(struct k_mem_page_frame *pf)
 {
-	return (pf->va_and_flags & Z_PAGE_FRAME_BUSY) != 0U;
+	return (pf->va_and_flags & K_MEM_PAGE_FRAME_BUSY) != 0U;
 }
 
-static inline bool z_page_frame_is_backed(struct z_page_frame *pf)
+static inline bool k_mem_page_frame_is_backed(struct k_mem_page_frame *pf)
 {
-	return (pf->va_and_flags & Z_PAGE_FRAME_BACKED) != 0U;
+	return (pf->va_and_flags & K_MEM_PAGE_FRAME_BACKED) != 0U;
 }
 
-static inline bool z_page_frame_is_evictable(struct z_page_frame *pf)
+static inline bool k_mem_page_frame_is_evictable(struct k_mem_page_frame *pf)
 {
-	return (!z_page_frame_is_free(pf) &&
-		!z_page_frame_is_reserved(pf) &&
-		z_page_frame_is_mapped(pf) &&
-		!z_page_frame_is_pinned(pf) &&
-		!z_page_frame_is_busy(pf));
+	return (!k_mem_page_frame_is_free(pf) &&
+		!k_mem_page_frame_is_reserved(pf) &&
+		k_mem_page_frame_is_mapped(pf) &&
+		!k_mem_page_frame_is_pinned(pf) &&
+		!k_mem_page_frame_is_busy(pf));
 }
 
 /* If true, page is not being used for anything, is not reserved, is not
  * a member of some free pages list, isn't busy, and is ready to be mapped
  * in memory
  */
-static inline bool z_page_frame_is_available(struct z_page_frame *page)
+static inline bool k_mem_page_frame_is_available(struct k_mem_page_frame *page)
 {
 	return page->va_and_flags == 0U;
 }
 
-static inline void z_page_frame_set(struct z_page_frame *pf, uint8_t flags)
+static inline void k_mem_page_frame_set(struct k_mem_page_frame *pf, uint8_t flags)
 {
 	pf->va_and_flags |= flags;
 }
 
-static inline void z_page_frame_clear(struct z_page_frame *pf, uint8_t flags)
+static inline void k_mem_page_frame_clear(struct k_mem_page_frame *pf, uint8_t flags)
 {
 	/* ensure bit inversion to follow is done on the proper type width */
 	uintptr_t wide_flags = flags;
@@ -246,46 +251,46 @@ static inline void z_page_frame_clear(struct z_page_frame *pf, uint8_t flags)
 	pf->va_and_flags &= ~wide_flags;
 }
 
-static inline void z_assert_phys_aligned(uintptr_t phys)
+static inline void k_mem_assert_phys_aligned(uintptr_t phys)
 {
 	__ASSERT(phys % CONFIG_MMU_PAGE_SIZE == 0U,
 		 "physical address 0x%lx is not page-aligned", phys);
 	(void)phys;
 }
 
-extern struct z_page_frame z_page_frames[Z_NUM_PAGE_FRAMES];
+extern struct k_mem_page_frame k_mem_page_frames[K_MEM_NUM_PAGE_FRAMES];
 
-static inline uintptr_t z_page_frame_to_phys(struct z_page_frame *pf)
+static inline uintptr_t k_mem_page_frame_to_phys(struct k_mem_page_frame *pf)
 {
-	return (uintptr_t)((pf - z_page_frames) * CONFIG_MMU_PAGE_SIZE) +
+	return (uintptr_t)((pf - k_mem_page_frames) * CONFIG_MMU_PAGE_SIZE) +
 			  K_MEM_PHYS_RAM_START;
 }
 
 /* Presumes there is but one mapping in the virtual address space */
-static inline void *z_page_frame_to_virt(struct z_page_frame *pf)
+static inline void *k_mem_page_frame_to_virt(struct k_mem_page_frame *pf)
 {
 	uintptr_t flags_mask = CONFIG_MMU_PAGE_SIZE - 1;
 
 	return (void *)(pf->va_and_flags & ~flags_mask);
 }
 
-static inline bool z_is_page_frame(uintptr_t phys)
+static inline bool k_mem_is_page_frame(uintptr_t phys)
 {
-	z_assert_phys_aligned(phys);
+	k_mem_assert_phys_aligned(phys);
 	return IN_RANGE(phys, (uintptr_t)K_MEM_PHYS_RAM_START,
 			(uintptr_t)(K_MEM_PHYS_RAM_END - 1));
 }
 
-static inline struct z_page_frame *z_phys_to_page_frame(uintptr_t phys)
+static inline struct k_mem_page_frame *k_mem_phys_to_page_frame(uintptr_t phys)
 {
-	__ASSERT(z_is_page_frame(phys),
+	__ASSERT(k_mem_is_page_frame(phys),
 		 "0x%lx not an SRAM physical address", phys);
 
-	return &z_page_frames[(phys - K_MEM_PHYS_RAM_START) /
-			      CONFIG_MMU_PAGE_SIZE];
+	return &k_mem_page_frames[(phys - K_MEM_PHYS_RAM_START) /
+				  CONFIG_MMU_PAGE_SIZE];
 }
 
-static inline void z_mem_assert_virtual_region(uint8_t *addr, size_t size)
+static inline void k_mem_assert_virtual_region(uint8_t *addr, size_t size)
 {
 	__ASSERT((uintptr_t)addr % CONFIG_MMU_PAGE_SIZE == 0U,
 		 "unaligned addr %p", addr);
@@ -302,16 +307,21 @@ static inline void z_mem_assert_virtual_region(uint8_t *addr, size_t size)
 		 "invalid virtual address region %p (%zu)", addr, size);
 }
 
-/* Debug function, pretty-print page frame information for all frames
+/**
+ * @brief Pretty-print page frame information for all page frames.
+ *
+ * Debug function, pretty-print page frame information for all frames
  * concisely to printk.
  */
-void z_page_frames_dump(void);
+void k_mem_page_frames_dump(void);
 
 /* Convenience macro for iterating over all page frames */
-#define Z_PAGE_FRAME_FOREACH(_phys, _pageframe) \
-	for ((_phys) = K_MEM_PHYS_RAM_START, (_pageframe) = z_page_frames; \
+#define K_MEM_PAGE_FRAME_FOREACH(_phys, _pageframe) \
+	for ((_phys) = K_MEM_PHYS_RAM_START, (_pageframe) = k_mem_page_frames; \
 	     (_phys) < K_MEM_PHYS_RAM_END; \
 	     (_phys) += CONFIG_MMU_PAGE_SIZE, (_pageframe)++)
+
+/** @} */
 
 /**
  * @def K_MEM_VM_RESERVED
@@ -365,7 +375,7 @@ unsigned long z_num_pagefaults_get(void);
  * @retval 0 Success
  * @retval -ENOMEM Insufficient backing store space
  */
-int z_page_frame_evict(uintptr_t phys);
+int k_mem_page_frame_evict(uintptr_t phys);
 
 /**
  * Handle a page fault for a virtual data page

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -417,8 +417,8 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 #ifdef CONFIG_MMU
 	/* Invoked here such that backing store or eviction algorithms may
 	 * initialize kernel objects, and that all POST_KERNEL and later tasks
-	 * may perform memory management tasks (except for z_phys_map() which
-	 * is allowed at any time)
+	 * may perform memory management tasks (except for
+	 * k_mem_map_phys_bare() which is allowed at any time)
 	 */
 	z_mem_manage_init();
 #endif /* CONFIG_MMU */

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -165,7 +165,7 @@ void z_page_frames_dump(void)
  * | image        |
  * |		  |
  * |		  |
- * +--------------+ <- Z_FREE_VM_START
+ * +--------------+ <- K_MEM_VM_FREE_START
  * |              |
  * | Unused,      |
  * | Available VM |
@@ -195,7 +195,7 @@ SYS_BITARRAY_DEFINE_STATIC(virt_region_bitmap,
 
 static bool virt_region_inited;
 
-#define Z_VIRT_REGION_START_ADDR	Z_FREE_VM_START
+#define Z_VIRT_REGION_START_ADDR	K_MEM_VM_FREE_START
 #define Z_VIRT_REGION_END_ADDR		(K_MEM_VIRT_RAM_END - Z_VM_RESERVED)
 
 static inline uintptr_t virt_from_bitmap_offset(size_t offset, size_t size)
@@ -227,7 +227,7 @@ static void virt_region_init(void)
 	}
 
 	/* Mark all bits up to Z_FREE_VM_START as allocated */
-	num_bits = POINTER_TO_UINT(Z_FREE_VM_START)
+	num_bits = POINTER_TO_UINT(K_MEM_VM_FREE_START)
 		   - POINTER_TO_UINT(K_MEM_VIRT_RAM_START);
 	offset = virt_to_bitmap_offset(K_MEM_VIRT_RAM_START, num_bits);
 	num_bits /= CONFIG_MMU_PAGE_SIZE;
@@ -327,7 +327,7 @@ static void *virt_region_alloc(size_t size, size_t align)
 		 * | image        |
 		 * |		  |
 		 * |		  |
-		 * +--------------+ <- Z_FREE_VM_START
+		 * +--------------+ <- K_MEM_VM_FREE_START
 		 * | ...          |
 		 * +==============+ <- dest_addr
 		 * | Unused       |

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -561,7 +561,7 @@ static int map_anon_page(void *addr, uint32_t flags)
 	return 0;
 }
 
-void *k_mem_map_impl(uintptr_t phys, size_t size, uint32_t flags, bool is_anon)
+void *k_mem_map_phys_guard(uintptr_t phys, size_t size, uint32_t flags, bool is_anon)
 {
 	uint8_t *dst;
 	size_t total_size;
@@ -645,7 +645,7 @@ out:
 	return dst;
 }
 
-void k_mem_unmap_impl(void *addr, size_t size, bool is_anon)
+void k_mem_unmap_phys_guard(void *addr, size_t size, bool is_anon)
 {
 	uintptr_t phys;
 	uint8_t *pos;

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -147,8 +147,8 @@ void z_page_frames_dump(void)
  * Call all of these functions with z_mm_lock held.
  *
  * Overall virtual memory map: When the kernel starts, it resides in
- * virtual memory in the region Z_KERNEL_VIRT_START to
- * Z_KERNEL_VIRT_END. Unused virtual memory past this, up to the limit
+ * virtual memory in the region K_MEM_KERNEL_VIRT_START to
+ * K_MEM_KERNEL_VIRT_END. Unused virtual memory past this, up to the limit
  * noted by CONFIG_KERNEL_VM_SIZE may be used for runtime memory mappings.
  *
  * If CONFIG_ARCH_MAPS_ALL_RAM is set, we do not just map the kernel image,
@@ -159,7 +159,7 @@ void z_page_frames_dump(void)
  *
  * +--------------+ <- K_MEM_VIRT_RAM_START
  * | Undefined VM | <- May contain ancillary regions like x86_64's locore
- * +--------------+ <- Z_KERNEL_VIRT_START (often == K_MEM_VIRT_RAM_START)
+ * +--------------+ <- K_MEM_KERNEL_VIRT_START (often == K_MEM_VIRT_RAM_START)
  * | Mapping for  |
  * | main kernel  |
  * | image        |
@@ -321,7 +321,7 @@ static void *virt_region_alloc(size_t size, size_t align)
 		 *
 		 * +--------------+ <- K_MEM_VIRT_RAM_START
 		 * | Undefined VM |
-		 * +--------------+ <- Z_KERNEL_VIRT_START (often == K_MEM_VIRT_RAM_START)
+		 * +--------------+ <- K_MEM_KERNEL_VIRT_START (often == K_MEM_VIRT_RAM_START)
 		 * | Mapping for  |
 		 * | main kernel  |
 		 * | image        |
@@ -970,7 +970,7 @@ void z_mem_manage_init(void)
 	/* All pages composing the Zephyr image are mapped at boot in a
 	 * predictable way. This can change at runtime.
 	 */
-	VIRT_FOREACH(Z_KERNEL_VIRT_START, Z_KERNEL_VIRT_SIZE, addr)
+	VIRT_FOREACH(K_MEM_KERNEL_VIRT_START, K_MEM_KERNEL_VIRT_SIZE, addr)
 	{
 		pf = z_phys_to_page_frame(K_MEM_BOOT_VIRT_TO_PHYS(addr));
 		frame_mapped_set(pf, addr);

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -179,7 +179,7 @@ void z_page_frames_dump(void)
  * +--------------+
  * | Mapping      |
  * +--------------+ <- mappings start here
- * | Reserved     | <- special purpose virtual page(s) of size Z_VM_RESERVED
+ * | Reserved     | <- special purpose virtual page(s) of size K_MEM_VM_RESERVED
  * +--------------+ <- K_MEM_VIRT_RAM_END
  */
 
@@ -196,7 +196,7 @@ SYS_BITARRAY_DEFINE_STATIC(virt_region_bitmap,
 static bool virt_region_inited;
 
 #define Z_VIRT_REGION_START_ADDR	K_MEM_VM_FREE_START
-#define Z_VIRT_REGION_END_ADDR		(K_MEM_VIRT_RAM_END - Z_VM_RESERVED)
+#define Z_VIRT_REGION_END_ADDR		(K_MEM_VIRT_RAM_END - K_MEM_VM_RESERVED)
 
 static inline uintptr_t virt_from_bitmap_offset(size_t offset, size_t size)
 {
@@ -219,9 +219,9 @@ static void virt_region_init(void)
 	 * already allocated so they will never be used.
 	 */
 
-	if (Z_VM_RESERVED > 0) {
+	if (K_MEM_VM_RESERVED > 0) {
 		/* Mark reserved region at end of virtual address space */
-		num_bits = Z_VM_RESERVED / CONFIG_MMU_PAGE_SIZE;
+		num_bits = K_MEM_VM_RESERVED / CONFIG_MMU_PAGE_SIZE;
 		(void)sys_bitarray_set_region(&virt_region_bitmap,
 					      num_bits, 0);
 	}

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -936,7 +936,7 @@ static void mark_linker_section_pinned(void *start_addr, void *end_addr,
 
 	VIRT_FOREACH(UINT_TO_POINTER(pinned_start), pinned_size, addr)
 	{
-		pf = z_phys_to_page_frame(Z_BOOT_VIRT_TO_PHYS(addr));
+		pf = z_phys_to_page_frame(K_MEM_BOOT_VIRT_TO_PHYS(addr));
 		frame_mapped_set(pf, addr);
 
 		if (pin) {
@@ -972,7 +972,7 @@ void z_mem_manage_init(void)
 	 */
 	VIRT_FOREACH(Z_KERNEL_VIRT_START, Z_KERNEL_VIRT_SIZE, addr)
 	{
-		pf = z_phys_to_page_frame(Z_BOOT_VIRT_TO_PHYS(addr));
+		pf = z_phys_to_page_frame(K_MEM_BOOT_VIRT_TO_PHYS(addr));
 		frame_mapped_set(pf, addr);
 
 		/* TODO: for now we pin the whole Zephyr image. Demand paging

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -215,7 +215,7 @@ static void virt_region_init(void)
 	size_t offset, num_bits;
 
 	/* There are regions where we should never map via
-	 * k_mem_map() and z_phys_map(). Mark them as
+	 * k_mem_map() and k_mem_map_phys_bare(). Mark them as
 	 * already allocated so they will never be used.
 	 */
 
@@ -791,7 +791,7 @@ __weak FUNC_ALIAS(virt_region_align, arch_virt_region_align, size_t);
  * Data will be copied and BSS zeroed, but this must not rely on any
  * initialization functions being called prior to work correctly.
  */
-void z_phys_map(uint8_t **virt_ptr, uintptr_t phys, size_t size, uint32_t flags)
+void k_mem_map_phys_bare(uint8_t **virt_ptr, uintptr_t phys, size_t size, uint32_t flags)
 {
 	uintptr_t aligned_phys, addr_offset;
 	size_t aligned_size, align_boundary;
@@ -878,7 +878,7 @@ fail:
 	k_panic();
 }
 
-void z_phys_unmap(uint8_t *virt, size_t size)
+void k_mem_unmap_phys_bare(uint8_t *virt, size_t size)
 {
 	uintptr_t aligned_virt, addr_offset;
 	size_t aligned_size;

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -1586,7 +1586,7 @@ void k_mem_pin(void *addr, size_t size)
 	virt_region_foreach(addr, size, do_mem_pin);
 }
 
-bool z_page_fault(void *addr)
+bool k_mem_page_fault(void *addr)
 {
 	return do_page_fault(addr, false);
 }

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -111,7 +111,7 @@ void z_page_frames_dump(void)
 
 	__ASSERT(page_frames_initialized, "%s called too early", __func__);
 	printk("Physical memory from 0x%lx to 0x%lx\n",
-	       Z_PHYS_RAM_START, Z_PHYS_RAM_END);
+	       K_MEM_PHYS_RAM_START, K_MEM_PHYS_RAM_END);
 
 	for (int i = 0; i < Z_NUM_PAGE_FRAMES; i++) {
 		struct z_page_frame *pf = &z_page_frames[i];

--- a/kernel/paging/statistics.c
+++ b/kernel/paging/statistics.c
@@ -76,7 +76,7 @@ k_mem_paging_backing_store_histogram_bounds[
 #endif /* CONFIG_DEMAND_PAGING_STATS_USING_TIMING_FUNCTIONS */
 #endif /* CONFIG_DEMAND_PAGING_TIMING_HISTOGRAM */
 
-unsigned long z_num_pagefaults_get(void)
+unsigned long k_mem_num_pagefaults_get(void)
 {
 	unsigned long ret;
 	unsigned int key;

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -429,8 +429,9 @@ static char *setup_thread_stack(struct k_thread *new_thread,
 	 * stack. If CONFIG_INIT_STACKS is enabled, the stack will be
 	 * cleared below.
 	 */
-	void *stack_mapped = k_mem_phys_map((uintptr_t)stack, stack_obj_size,
-					    K_MEM_PERM_RW | K_MEM_CACHE_WB | K_MEM_MAP_UNINIT);
+	void *stack_mapped = k_mem_map_phys_guard((uintptr_t)stack, stack_obj_size,
+				K_MEM_PERM_RW | K_MEM_CACHE_WB | K_MEM_MAP_UNINIT,
+				false);
 
 	__ASSERT_NO_MSG((uintptr_t)stack_mapped != 0);
 
@@ -1051,8 +1052,8 @@ void do_thread_cleanup(struct k_thread *thread)
 
 #ifdef CONFIG_THREAD_STACK_MEM_MAPPED
 	if (thread_cleanup_stack_addr != NULL) {
-		k_mem_phys_unmap(thread_cleanup_stack_addr,
-				 thread_cleanup_stack_sz);
+		k_mem_unmap_phys_guard(thread_cleanup_stack_addr,
+				       thread_cleanup_stack_sz, false);
 
 		thread_cleanup_stack_addr = NULL;
 	}

--- a/soc/intel/intel_socfpga_std/cyclonev/soc.c
+++ b/soc/intel/intel_socfpga_std/cyclonev/soc.c
@@ -26,12 +26,12 @@ void arch_reserved_pages_update(void)
 	uintptr_t end = ROUND_UP(addr + len, CONFIG_MMU_PAGE_SIZE);
 
 	for (; pos < end; pos += CONFIG_MMU_PAGE_SIZE) {
-		if (!z_is_page_frame(pos)) {
+		if (!k_mem_is_page_frame(pos)) {
 			continue;
 		}
-		struct z_page_frame *pf = z_phys_to_page_frame(pos);
+		struct k_mem_page_frame *pf = k_mem_phys_to_page_frame(pos);
 
-		z_page_frame_set(pf, Z_PAGE_FRAME_RESERVED);
+		k_mem_page_frame_set(pf, K_MEM_PAGE_FRAME_RESERVED);
 	}
 }
 

--- a/subsys/demand_paging/backing_store/backing_store_qemu_x86_tiny.c
+++ b/subsys/demand_paging/backing_store/backing_store_qemu_x86_tiny.c
@@ -40,12 +40,12 @@ void *location_to_flash(uintptr_t location)
 	return UINT_TO_POINTER(ptr);
 }
 
-int k_mem_paging_backing_store_location_get(struct z_page_frame *pf,
+int k_mem_paging_backing_store_location_get(struct k_mem_page_frame *pf,
 					    uintptr_t *location,
 					    bool page_fault)
 {
 	/* Simply returns the virtual address */
-	*location = POINTER_TO_UINT(z_page_frame_to_virt(pf));
+	*location = POINTER_TO_UINT(k_mem_page_frame_to_virt(pf));
 
 	return 0;
 }
@@ -67,7 +67,7 @@ void k_mem_paging_backing_store_page_in(uintptr_t location)
 		     CONFIG_MMU_PAGE_SIZE);
 }
 
-void k_mem_paging_backing_store_page_finalize(struct z_page_frame *pf,
+void k_mem_paging_backing_store_page_finalize(struct k_mem_page_frame *pf,
 					      uintptr_t location)
 {
 	/* Nothing to do */

--- a/subsys/demand_paging/backing_store/backing_store_qemu_x86_tiny.c
+++ b/subsys/demand_paging/backing_store/backing_store_qemu_x86_tiny.c
@@ -57,13 +57,13 @@ void k_mem_paging_backing_store_location_free(uintptr_t location)
 
 void k_mem_paging_backing_store_page_out(uintptr_t location)
 {
-	(void)memcpy(location_to_flash(location), Z_SCRATCH_PAGE,
+	(void)memcpy(location_to_flash(location), K_MEM_SCRATCH_PAGE,
 		     CONFIG_MMU_PAGE_SIZE);
 }
 
 void k_mem_paging_backing_store_page_in(uintptr_t location)
 {
-	(void)memcpy(Z_SCRATCH_PAGE, location_to_flash(location),
+	(void)memcpy(K_MEM_SCRATCH_PAGE, location_to_flash(location),
 		     CONFIG_MMU_PAGE_SIZE);
 }
 

--- a/subsys/demand_paging/backing_store/ram.c
+++ b/subsys/demand_paging/backing_store/ram.c
@@ -112,13 +112,13 @@ void k_mem_paging_backing_store_location_free(uintptr_t location)
 
 void k_mem_paging_backing_store_page_out(uintptr_t location)
 {
-	(void)memcpy(location_to_slab(location), Z_SCRATCH_PAGE,
+	(void)memcpy(location_to_slab(location), K_MEM_SCRATCH_PAGE,
 		     CONFIG_MMU_PAGE_SIZE);
 }
 
 void k_mem_paging_backing_store_page_in(uintptr_t location)
 {
-	(void)memcpy(Z_SCRATCH_PAGE, location_to_slab(location),
+	(void)memcpy(K_MEM_SCRATCH_PAGE, location_to_slab(location),
 		     CONFIG_MMU_PAGE_SIZE);
 }
 

--- a/subsys/demand_paging/backing_store/ram.c
+++ b/subsys/demand_paging/backing_store/ram.c
@@ -30,24 +30,24 @@
  * are freed as soon as pages are paged in, in
  * k_mem_paging_backing_store_page_finalize().
  * This implies that all data pages are treated as dirty as
- * Z_PAGE_FRAME_BACKED is never set, even if the data page was paged out before
+ * K_MEM_PAGE_FRAME_BACKED is never set, even if the data page was paged out before
  * and not modified since then.
  *
  * An optimization a real backing store will want is have
  * k_mem_paging_backing_store_page_finalize() note the storage location of
- * a paged-in data page in a custom field of its associated z_page_frame, and
- * set the Z_PAGE_FRAME_BACKED bit. Invocations of
+ * a paged-in data page in a custom field of its associated k_mem_page_frame, and
+ * set the K_MEM_PAGE_FRAME_BACKED bit. Invocations of
  * k_mem_paging_backing_store_location_get() will have logic to return
  * the previous clean page location instead of allocating
- * a new one if Z_PAGE_FRAME_BACKED is set.
+ * a new one if K_MEM_PAGE_FRAME_BACKED is set.
  *
  * This will, however, require the implementation of a clean page
  * eviction algorithm, to free backing store locations for loaded data pages
- * as the backing store fills up, and clear the Z_PAGE_FRAME_BACKED bit
+ * as the backing store fills up, and clear the K_MEM_PAGE_FRAME_BACKED bit
  * appropriately.
  *
  * All of this logic is local to the backing store implementation; from the
- * core kernel's perspective the only change is that Z_PAGE_FRAME_BACKED
+ * core kernel's perspective the only change is that K_MEM_PAGE_FRAME_BACKED
  * starts getting set for certain page frames after a page-in (and possibly
  * cleared at a later time).
  */
@@ -82,7 +82,7 @@ static uintptr_t slab_to_location(void *slab)
 	return offset;
 }
 
-int k_mem_paging_backing_store_location_get(struct z_page_frame *pf,
+int k_mem_paging_backing_store_location_get(struct k_mem_page_frame *pf,
 					    uintptr_t *location,
 					    bool page_fault)
 {
@@ -122,7 +122,7 @@ void k_mem_paging_backing_store_page_in(uintptr_t location)
 		     CONFIG_MMU_PAGE_SIZE);
 }
 
-void k_mem_paging_backing_store_page_finalize(struct z_page_frame *pf,
+void k_mem_paging_backing_store_page_finalize(struct k_mem_page_frame *pf,
 					      uintptr_t location)
 {
 	k_mem_paging_backing_store_location_free(location);

--- a/subsys/demand_paging/eviction/nru.c
+++ b/subsys/demand_paging/eviction/nru.c
@@ -27,38 +27,39 @@
 static void nru_periodic_update(struct k_timer *timer)
 {
 	uintptr_t phys;
-	struct z_page_frame *pf;
+	struct k_mem_page_frame *pf;
 	unsigned int key = irq_lock();
 
-	Z_PAGE_FRAME_FOREACH(phys, pf) {
-		if (!z_page_frame_is_evictable(pf)) {
+	K_MEM_PAGE_FRAME_FOREACH(phys, pf) {
+		if (!k_mem_page_frame_is_evictable(pf)) {
 			continue;
 		}
 
 		/* Clear accessed bit in page tables */
-		(void)arch_page_info_get(z_page_frame_to_virt(pf), NULL, true);
+		(void)arch_page_info_get(k_mem_page_frame_to_virt(pf),
+					 NULL, true);
 	}
 
 	irq_unlock(key);
 }
 
-struct z_page_frame *k_mem_paging_eviction_select(bool *dirty_ptr)
+struct k_mem_page_frame *k_mem_paging_eviction_select(bool *dirty_ptr)
 {
 	unsigned int last_prec = 4U;
-	struct z_page_frame *last_pf = NULL, *pf;
+	struct k_mem_page_frame *last_pf = NULL, *pf;
 	bool accessed;
 	bool last_dirty = false;
 	bool dirty = false;
 	uintptr_t flags, phys;
 
-	Z_PAGE_FRAME_FOREACH(phys, pf) {
+	K_MEM_PAGE_FRAME_FOREACH(phys, pf) {
 		unsigned int prec;
 
-		if (!z_page_frame_is_evictable(pf)) {
+		if (!k_mem_page_frame_is_evictable(pf)) {
 			continue;
 		}
 
-		flags = arch_page_info_get(z_page_frame_to_virt(pf), NULL, false);
+		flags = arch_page_info_get(k_mem_page_frame_to_virt(pf), NULL, false);
 		accessed = (flags & ARCH_DATA_PAGE_ACCESSED) != 0UL;
 		dirty = (flags & ARCH_DATA_PAGE_DIRTY) != 0UL;
 

--- a/tests/arch/x86/pagetables/src/main.c
+++ b/tests/arch/x86/pagetables/src/main.c
@@ -197,7 +197,8 @@ ZTEST(x86_pagetables, test_ram_perms)
 	/* All RAM page frame entries aside from 0x0 must have a mapping.
 	 * We currently identity-map on x86, no conversion necessary other than a cast
 	 */
-	for (pos = (uint8_t *)Z_PHYS_RAM_START; pos < (uint8_t *)Z_PHYS_RAM_END;
+	for (pos = (uint8_t *)K_MEM_PHYS_RAM_START;
+	     pos < (uint8_t *)K_MEM_PHYS_RAM_END;
 	     pos += CONFIG_MMU_PAGE_SIZE) {
 		if (pos == NULL) {
 			continue;

--- a/tests/arch/x86/pagetables/src/main.c
+++ b/tests/arch/x86/pagetables/src/main.c
@@ -87,12 +87,12 @@ ZTEST(x86_pagetables, test_ram_perms)
 	pentry_t entry, flags, expected;
 
 #ifdef CONFIG_LINKER_GENERIC_SECTIONS_PRESENT_AT_BOOT
-	const uint8_t *mem_range_end = Z_KERNEL_VIRT_END;
+	const uint8_t *mem_range_end = K_MEM_KERNEL_VIRT_END;
 #else
 	const uint8_t *mem_range_end = (uint8_t *)lnkr_pinned_end;
 #endif /* CONFIG_LINKER_GENERIC_SECTIONS_PRESENT_AT_BOOT */
 
-	for (pos = Z_KERNEL_VIRT_START; pos < mem_range_end;
+	for (pos = K_MEM_KERNEL_VIRT_START; pos < mem_range_end;
 	     pos += CONFIG_MMU_PAGE_SIZE) {
 		if (pos == NULL) {
 			/* We have another test specifically for NULL page */

--- a/tests/kernel/mem_protect/demand_paging/src/main.c
+++ b/tests/kernel/mem_protect/demand_paging/src/main.c
@@ -93,7 +93,7 @@ ZTEST(demand_paging, test_map_anon_pages)
 	zassert_not_null(arena, "failed to map anonymous memory arena size %zu",
 			 arena_size);
 	printk("Anonymous memory arena %p size %zu\n", arena, arena_size);
-	z_page_frames_dump();
+	k_mem_page_frames_dump();
 }
 
 static void print_paging_stats(struct k_mem_paging_stats_t *stats, const char *scope)

--- a/tests/kernel/mem_protect/demand_paging/src/main.c
+++ b/tests/kernel/mem_protect/demand_paging/src/main.c
@@ -121,7 +121,7 @@ ZTEST(demand_paging, test_touch_anon_pages)
 	struct k_mem_paging_stats_t stats;
 	k_tid_t tid = k_current_get();
 
-	faults = z_num_pagefaults_get();
+	faults = k_mem_num_pagefaults_get();
 
 	printk("checking zeroes\n");
 	/* The mapped area should have started out zeroed. Check this. */
@@ -145,7 +145,7 @@ ZTEST(demand_paging, test_touch_anon_pages)
 			      i, &arena[i], arena[i], nums[i % 10]);
 	}
 
-	faults = z_num_pagefaults_get() - faults;
+	faults = k_mem_num_pagefaults_get() - faults;
 
 	/* Specific number depends on how much RAM we have but shouldn't be 0 */
 	zassert_not_equal(faults, 0UL, "no page faults handled?");
@@ -201,7 +201,7 @@ static void test_k_mem_page_out(void)
 	 * are measuring stuff
 	 */
 	key = irq_lock();
-	faults = z_num_pagefaults_get();
+	faults = k_mem_num_pagefaults_get();
 	ret = k_mem_page_out(arena, HALF_BYTES);
 	zassert_equal(ret, 0, "k_mem_page_out failed with %d", ret);
 
@@ -209,7 +209,7 @@ static void test_k_mem_page_out(void)
 	for (size_t i = 0; i < HALF_BYTES; i++) {
 		arena[i] = nums[i % 10];
 	}
-	faults = z_num_pagefaults_get() - faults;
+	faults = k_mem_num_pagefaults_get() - faults;
 	irq_unlock(key);
 
 	zassert_equal(faults, HALF_PAGES,
@@ -236,12 +236,12 @@ ZTEST(demand_paging_api, test_k_mem_page_in)
 
 	k_mem_page_in(arena, HALF_BYTES);
 
-	faults = z_num_pagefaults_get();
+	faults = k_mem_num_pagefaults_get();
 	/* Write to the supposedly evicted region */
 	for (size_t i = 0; i < HALF_BYTES; i++) {
 		arena[i] = nums[i % 10];
 	}
-	faults = z_num_pagefaults_get() - faults;
+	faults = k_mem_num_pagefaults_get() - faults;
 	irq_unlock(key);
 
 	zassert_equal(faults, 0, "%d page faults when 0 expected",
@@ -262,11 +262,11 @@ ZTEST(demand_paging_api, test_k_mem_pin)
 
 	key = irq_lock();
 	/* Show no faults writing to the pinned area */
-	faults = z_num_pagefaults_get();
+	faults = k_mem_num_pagefaults_get();
 	for (size_t i = 0; i < HALF_BYTES; i++) {
 		arena[i] = nums[i % 10];
 	}
-	faults = z_num_pagefaults_get() - faults;
+	faults = k_mem_num_pagefaults_get() - faults;
 	irq_unlock(key);
 
 	zassert_equal(faults, 0, "%d page faults when 0 expected",
@@ -309,7 +309,7 @@ ZTEST(demand_paging_stat, test_backing_store_capacity)
 	zassert_is_null(ret, "k_mem_map shouldn't have succeeded");
 
 	key = irq_lock();
-	faults = z_num_pagefaults_get();
+	faults = k_mem_num_pagefaults_get();
 	/* Poke all anonymous memory */
 	for (size_t i = 0; i < HALF_BYTES; i++) {
 		arena[i] = nums[i % 10];
@@ -317,7 +317,7 @@ ZTEST(demand_paging_stat, test_backing_store_capacity)
 	for (size_t i = 0; i < size; i++) {
 		mem[i] = nums[i % 10];
 	}
-	faults = z_num_pagefaults_get() - faults;
+	faults = k_mem_num_pagefaults_get() - faults;
 	irq_unlock(key);
 
 	zassert_not_equal(faults, 0, "should have had some pagefaults");

--- a/tests/kernel/mem_protect/mem_map/src/main.c
+++ b/tests/kernel/mem_protect/mem_map/src/main.c
@@ -407,7 +407,7 @@ ZTEST(mem_map_api, test_k_mem_map_exhaustion)
 	 *    virtual address (plus itself and guard page)
 	 *    to obtain the end address.
 	 * 2. Calculate how big this region is from
-	 *    Z_FREE_VM_START to end address.
+	 *    K_MEM_VM_FREE_START to end address.
 	 * 3. Calculate how many times we can call k_mem_map().
 	 *    Remember there are two guard pages for every
 	 *    mapping call (hence 1 + 2 == 3).
@@ -417,7 +417,7 @@ ZTEST(mem_map_api, test_k_mem_map_exhaustion)
 	k_mem_unmap(addr, CONFIG_MMU_PAGE_SIZE);
 
 	cnt = POINTER_TO_UINT(addr) + CONFIG_MMU_PAGE_SIZE * 2;
-	cnt -= POINTER_TO_UINT(Z_FREE_VM_START);
+	cnt -= POINTER_TO_UINT(K_MEM_VM_FREE_START);
 	cnt /= CONFIG_MMU_PAGE_SIZE * 3;
 
 	/* If we are limited by virtual address space... */

--- a/tests/kernel/mem_protect/mem_map/src/main.c
+++ b/tests/kernel/mem_protect/mem_map/src/main.c
@@ -21,7 +21,7 @@
 #define BASE_FLAGS	(K_MEM_CACHE_WB)
 volatile bool expect_fault;
 
-/* z_phys_map() doesn't have alignment requirements, any oddly-sized buffer
+/* k_mem_map_phys_bare() doesn't have alignment requirements, any oddly-sized buffer
  * can get mapped. BUF_SIZE has a odd size to make sure the mapped buffer
  * spans multiple pages.
  */
@@ -52,7 +52,7 @@ void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf)
  *
  * @ingroup kernel_memprotect_tests
  */
-ZTEST(mem_map, test_z_phys_map_rw)
+ZTEST(mem_map, test_k_mem_map_phys_bare_rw)
 {
 	uint8_t *mapped_rw, *mapped_ro;
 	uint8_t *buf = test_page + BUF_OFFSET;
@@ -60,12 +60,12 @@ ZTEST(mem_map, test_z_phys_map_rw)
 	expect_fault = false;
 
 	/* Map in a page that allows writes */
-	z_phys_map(&mapped_rw, z_mem_phys_addr(buf),
-		   BUF_SIZE, BASE_FLAGS | K_MEM_PERM_RW);
+	k_mem_map_phys_bare(&mapped_rw, z_mem_phys_addr(buf),
+			    BUF_SIZE, BASE_FLAGS | K_MEM_PERM_RW);
 
 	/* Map again this time only allowing reads */
-	z_phys_map(&mapped_ro, z_mem_phys_addr(buf),
-		   BUF_SIZE, BASE_FLAGS);
+	k_mem_map_phys_bare(&mapped_ro, z_mem_phys_addr(buf),
+			    BUF_SIZE, BASE_FLAGS);
 
 	/* Initialize read-write buf with some bytes */
 	for (int i = 0; i < BUF_SIZE; i++) {
@@ -122,7 +122,7 @@ static void transplanted_function(bool *executed)
  *
  * @ingroup kernel_memprotect_tests
  */
-ZTEST(mem_map, test_z_phys_map_exec)
+ZTEST(mem_map, test_k_mem_map_phys_bare_exec)
 {
 #ifndef SKIP_EXECUTE_TESTS
 	uint8_t *mapped_exec, *mapped_ro;
@@ -138,17 +138,18 @@ ZTEST(mem_map, test_z_phys_map_exec)
 	func = transplanted_function;
 
 	/* Now map with execution enabled and try to run the copied fn */
-	z_phys_map(&mapped_exec, z_mem_phys_addr(__test_mem_map_start),
-		   (uintptr_t)(__test_mem_map_end - __test_mem_map_start),
-		   BASE_FLAGS | K_MEM_PERM_EXEC);
+	k_mem_map_phys_bare(&mapped_exec, z_mem_phys_addr(__test_mem_map_start),
+			    (uintptr_t)(__test_mem_map_end - __test_mem_map_start),
+			    BASE_FLAGS | K_MEM_PERM_EXEC);
 
 	func = (void (*)(bool *executed))mapped_exec;
 	func(&executed);
 	zassert_true(executed, "function did not execute");
 
 	/* Now map without execution and execution should now fail */
-	z_phys_map(&mapped_ro, z_mem_phys_addr(__test_mem_map_start),
-		   (uintptr_t)(__test_mem_map_end - __test_mem_map_start), BASE_FLAGS);
+	k_mem_map_phys_bare(&mapped_ro, z_mem_phys_addr(__test_mem_map_start),
+			    (uintptr_t)(__test_mem_map_end - __test_mem_map_start),
+			    BASE_FLAGS);
 
 	func = (void (*)(bool *executed))mapped_ro;
 	expect_fault = true;
@@ -166,18 +167,18 @@ ZTEST(mem_map, test_z_phys_map_exec)
  *
  * @ingroup kernel_memprotect_tests
  */
-ZTEST(mem_map, test_z_phys_map_side_effect)
+ZTEST(mem_map, test_k_mem_map_phys_bare_side_effect)
 {
 	uint8_t *mapped;
 
 	expect_fault = false;
 
-	/* z_phys_map() is supposed to always create fresh mappings.
+	/* k_mem_map_phys_bare() is supposed to always create fresh mappings.
 	 * Show that by mapping test_page to an RO region, we can still
 	 * modify test_page.
 	 */
-	z_phys_map(&mapped, z_mem_phys_addr(test_page),
-		   sizeof(test_page), BASE_FLAGS);
+	k_mem_map_phys_bare(&mapped, z_mem_phys_addr(test_page),
+			    sizeof(test_page), BASE_FLAGS);
 
 	/* Should NOT fault */
 	test_page[0] = 42;
@@ -190,26 +191,26 @@ ZTEST(mem_map, test_z_phys_map_side_effect)
 }
 
 /**
- * Test that z_phys_unmap() unmaps the memory and it is no longer
+ * Test that k_mem_unmap_phys_bare() unmaps the memory and it is no longer
  * accessible afterwards.
  *
  * @ingroup kernel_memprotect_tests
  */
-ZTEST(mem_map, test_z_phys_unmap)
+ZTEST(mem_map, test_k_mem_unmap_phys_bare)
 {
 	uint8_t *mapped;
 
 	expect_fault = false;
 
 	/* Map in a page that allows writes */
-	z_phys_map(&mapped, z_mem_phys_addr(test_page),
-		   sizeof(test_page), BASE_FLAGS | K_MEM_PERM_RW);
+	k_mem_map_phys_bare(&mapped, z_mem_phys_addr(test_page),
+			    sizeof(test_page), BASE_FLAGS | K_MEM_PERM_RW);
 
 	/* Should NOT fault */
 	mapped[0] = 42;
 
 	/* Unmap the memory */
-	z_phys_unmap(mapped, sizeof(test_page));
+	k_mem_unmap_phys_bare(mapped, sizeof(test_page));
 
 	/* Should fault since test_page is no longer accessible */
 	expect_fault = true;
@@ -219,18 +220,18 @@ ZTEST(mem_map, test_z_phys_unmap)
 }
 
 /**
- * Show that z_phys_unmap() can reclaim the virtual region correctly.
+ * Show that k_mem_unmap_phys_bare() can reclaim the virtual region correctly.
  *
  * @ingroup kernel_memprotect_tests
  */
-ZTEST(mem_map, test_z_phys_map_unmap_reclaim_addr)
+ZTEST(mem_map, test_k_mem_map_phys_bare_unmap_reclaim_addr)
 {
 	uint8_t *mapped, *mapped_old;
 	uint8_t *buf = test_page + BUF_OFFSET;
 
 	/* Map the buffer the first time. */
-	z_phys_map(&mapped, z_mem_phys_addr(buf),
-		   BUF_SIZE, BASE_FLAGS);
+	k_mem_map_phys_bare(&mapped, z_mem_phys_addr(buf),
+			    BUF_SIZE, BASE_FLAGS);
 
 	printk("Mapped (1st time): %p\n", mapped);
 
@@ -240,18 +241,17 @@ ZTEST(mem_map, test_z_phys_map_unmap_reclaim_addr)
 	/*
 	 * Unmap the buffer.
 	 * This should reclaim the bits in virtual region tracking,
-	 * so that the next time z_phys_map() is called with
+	 * so that the next time k_mem_map_phys_bare() is called with
 	 * the same arguments, it will return the same address.
 	 */
-	z_phys_unmap(mapped, BUF_SIZE);
+	k_mem_unmap_phys_bare(mapped, BUF_SIZE);
 
 	/*
 	 * Map again the same buffer using same parameters.
 	 * It should give us back the same virtual address
 	 * as above when it is mapped the first time.
 	 */
-	z_phys_map(&mapped, z_mem_phys_addr(buf),
-		   BUF_SIZE, BASE_FLAGS);
+	k_mem_map_phys_bare(&mapped, z_mem_phys_addr(buf), BUF_SIZE, BASE_FLAGS);
 
 	printk("Mapped (2nd time): %p\n", mapped);
 
@@ -508,8 +508,8 @@ ZTEST(mem_map_api, test_k_mem_map_user)
 	 */
 	expect_fault = false;
 
-	z_phys_map(&mapped, z_mem_phys_addr(test_page), sizeof(test_page),
-		   BASE_FLAGS | K_MEM_PERM_RW | K_MEM_PERM_USER);
+	k_mem_map_phys_bare(&mapped, z_mem_phys_addr(test_page), sizeof(test_page),
+			    BASE_FLAGS | K_MEM_PERM_RW | K_MEM_PERM_USER);
 
 	printk("mapped a page: %p - %p (with K_MEM_PERM_USER)\n", mapped,
 		mapped + CONFIG_MMU_PAGE_SIZE);
@@ -521,7 +521,7 @@ ZTEST(mem_map_api, test_k_mem_map_user)
 	k_thread_join(&user_thread, K_FOREVER);
 
 	/* Unmap the memory */
-	z_phys_unmap(mapped, sizeof(test_page));
+	k_mem_unmap_phys_bare(mapped, sizeof(test_page));
 
 	/*
 	 * Map the region without using K_MEM_PERM_USER and try to access it
@@ -529,8 +529,8 @@ ZTEST(mem_map_api, test_k_mem_map_user)
 	 */
 	expect_fault = true;
 
-	z_phys_map(&mapped, z_mem_phys_addr(test_page), sizeof(test_page),
-		   BASE_FLAGS | K_MEM_PERM_RW);
+	k_mem_map_phys_bare(&mapped, z_mem_phys_addr(test_page), sizeof(test_page),
+			    BASE_FLAGS | K_MEM_PERM_RW);
 
 	printk("mapped a page: %p - %p (without K_MEM_PERM_USER)\n", mapped,
 		mapped + CONFIG_MMU_PAGE_SIZE);

--- a/tests/kernel/mem_protect/mem_map/src/main.c
+++ b/tests/kernel/mem_protect/mem_map/src/main.c
@@ -60,11 +60,11 @@ ZTEST(mem_map, test_k_mem_map_phys_bare_rw)
 	expect_fault = false;
 
 	/* Map in a page that allows writes */
-	k_mem_map_phys_bare(&mapped_rw, z_mem_phys_addr(buf),
+	k_mem_map_phys_bare(&mapped_rw, k_mem_phys_addr(buf),
 			    BUF_SIZE, BASE_FLAGS | K_MEM_PERM_RW);
 
 	/* Map again this time only allowing reads */
-	k_mem_map_phys_bare(&mapped_ro, z_mem_phys_addr(buf),
+	k_mem_map_phys_bare(&mapped_ro, k_mem_phys_addr(buf),
 			    BUF_SIZE, BASE_FLAGS);
 
 	/* Initialize read-write buf with some bytes */
@@ -138,7 +138,7 @@ ZTEST(mem_map, test_k_mem_map_phys_bare_exec)
 	func = transplanted_function;
 
 	/* Now map with execution enabled and try to run the copied fn */
-	k_mem_map_phys_bare(&mapped_exec, z_mem_phys_addr(__test_mem_map_start),
+	k_mem_map_phys_bare(&mapped_exec, k_mem_phys_addr(__test_mem_map_start),
 			    (uintptr_t)(__test_mem_map_end - __test_mem_map_start),
 			    BASE_FLAGS | K_MEM_PERM_EXEC);
 
@@ -147,7 +147,7 @@ ZTEST(mem_map, test_k_mem_map_phys_bare_exec)
 	zassert_true(executed, "function did not execute");
 
 	/* Now map without execution and execution should now fail */
-	k_mem_map_phys_bare(&mapped_ro, z_mem_phys_addr(__test_mem_map_start),
+	k_mem_map_phys_bare(&mapped_ro, k_mem_phys_addr(__test_mem_map_start),
 			    (uintptr_t)(__test_mem_map_end - __test_mem_map_start),
 			    BASE_FLAGS);
 
@@ -177,7 +177,7 @@ ZTEST(mem_map, test_k_mem_map_phys_bare_side_effect)
 	 * Show that by mapping test_page to an RO region, we can still
 	 * modify test_page.
 	 */
-	k_mem_map_phys_bare(&mapped, z_mem_phys_addr(test_page),
+	k_mem_map_phys_bare(&mapped, k_mem_phys_addr(test_page),
 			    sizeof(test_page), BASE_FLAGS);
 
 	/* Should NOT fault */
@@ -203,7 +203,7 @@ ZTEST(mem_map, test_k_mem_unmap_phys_bare)
 	expect_fault = false;
 
 	/* Map in a page that allows writes */
-	k_mem_map_phys_bare(&mapped, z_mem_phys_addr(test_page),
+	k_mem_map_phys_bare(&mapped, k_mem_phys_addr(test_page),
 			    sizeof(test_page), BASE_FLAGS | K_MEM_PERM_RW);
 
 	/* Should NOT fault */
@@ -230,7 +230,7 @@ ZTEST(mem_map, test_k_mem_map_phys_bare_unmap_reclaim_addr)
 	uint8_t *buf = test_page + BUF_OFFSET;
 
 	/* Map the buffer the first time. */
-	k_mem_map_phys_bare(&mapped, z_mem_phys_addr(buf),
+	k_mem_map_phys_bare(&mapped, k_mem_phys_addr(buf),
 			    BUF_SIZE, BASE_FLAGS);
 
 	printk("Mapped (1st time): %p\n", mapped);
@@ -251,7 +251,7 @@ ZTEST(mem_map, test_k_mem_map_phys_bare_unmap_reclaim_addr)
 	 * It should give us back the same virtual address
 	 * as above when it is mapped the first time.
 	 */
-	k_mem_map_phys_bare(&mapped, z_mem_phys_addr(buf), BUF_SIZE, BASE_FLAGS);
+	k_mem_map_phys_bare(&mapped, k_mem_phys_addr(buf), BUF_SIZE, BASE_FLAGS);
 
 	printk("Mapped (2nd time): %p\n", mapped);
 
@@ -508,7 +508,7 @@ ZTEST(mem_map_api, test_k_mem_map_user)
 	 */
 	expect_fault = false;
 
-	k_mem_map_phys_bare(&mapped, z_mem_phys_addr(test_page), sizeof(test_page),
+	k_mem_map_phys_bare(&mapped, k_mem_phys_addr(test_page), sizeof(test_page),
 			    BASE_FLAGS | K_MEM_PERM_RW | K_MEM_PERM_USER);
 
 	printk("mapped a page: %p - %p (with K_MEM_PERM_USER)\n", mapped,
@@ -529,7 +529,7 @@ ZTEST(mem_map_api, test_k_mem_map_user)
 	 */
 	expect_fault = true;
 
-	k_mem_map_phys_bare(&mapped, z_mem_phys_addr(test_page), sizeof(test_page),
+	k_mem_map_phys_bare(&mapped, k_mem_phys_addr(test_page), sizeof(test_page),
 			    BASE_FLAGS | K_MEM_PERM_RW);
 
 	printk("mapped a page: %p - %p (without K_MEM_PERM_USER)\n", mapped,

--- a/tests/kernel/mem_protect/syscalls/src/main.c
+++ b/tests/kernel/mem_protect/syscalls/src/main.c
@@ -27,7 +27,7 @@
 #define FAULTY_ADDRESS 0xBFFFFFFF
 #elif CONFIG_MMU
 /* Just past the zephyr image mapping should be a non-present page */
-#define FAULTY_ADDRESS Z_FREE_VM_START
+#define FAULTY_ADDRESS K_MEM_VM_FREE_START
 #else
 #define FAULTY_ADDRESS 0xFFFFFFF0
 #endif

--- a/tests/kernel/mem_protect/syscalls/testcase.yaml
+++ b/tests/kernel/mem_protect/syscalls/testcase.yaml
@@ -1,6 +1,9 @@
 tests:
   kernel.memory_protection.syscalls:
-    platform_exclude: qemu_arc/qemu_arc_em
+    platform_exclude:
+      - qemu_arc/qemu_arc_em
+      # Too few MPU regions for USERSPACE testing
+      - numaker_m2l31ki
     filter: CONFIG_ARCH_HAS_USERSPACE
     arch_exclude:
       - posix

--- a/tests/lib/shared_multi_heap/src/main.c
+++ b/tests/lib/shared_multi_heap/src/main.c
@@ -46,7 +46,7 @@ static void smh_reg_map(struct shared_multi_heap_region *region)
 	mem_attr = (region->attr == SMH_REG_ATTR_CACHEABLE) ? K_MEM_CACHE_WB : K_MEM_CACHE_NONE;
 	mem_attr |= K_MEM_PERM_RW;
 
-	z_phys_map(&v_addr, region->addr, region->size, mem_attr);
+	k_mem_map_phys_bare(&v_addr, region->addr, region->size, mem_attr);
 
 	region->addr = (uintptr_t) v_addr;
 }

--- a/west.yml
+++ b/west.yml
@@ -30,7 +30,7 @@ manifest:
   # Please add items below based on alphabetical order
   projects:
     - name: acpica
-      revision: da5f2721e1c7f188fe04aa50af76f4b94f3c3ea3
+      revision: 8d24867bc9c9d81c81eeac59391cda59333affd4
       path: modules/lib/acpica
     - name: bsim
       repo-path: babblesim-manifest


### PR DESCRIPTION
This renames (mostly) the internal memory mapping functions from `z_` to have their own namespace `mm_memmap_` and `mm_vm_`. Also allows doxygen to start generating pages on them. See individual commits for details.