### PR TITLE
arch: arm64: Fix ICC_SGI1R mask for arm64

### DIFF
--- a/include/zephyr/arch/arm64/cpu.h
+++ b/include/zephyr/arch/arm64/cpu.h
@@ -171,7 +171,7 @@
 #define SGIR_AFF1_SHIFT		(16)
 #define SGIR_AFF2_SHIFT		(32)
 #define SGIR_AFF3_SHIFT		(48)
-#define SGIR_AFF_MASK		(0xf)
+#define SGIR_AFF_MASK		(0xff)
 #define SGIR_INTID_SHIFT	(24)
 #define SGIR_INTID_MASK		(0xf)
 #define SGIR_IRM_SHIFT		(40)


### PR DESCRIPTION
According to "Arm A-profile Architecture Registers", Interrupt Controller Software Generaated Interrupt Group 1 Register (ICC_SGI1R), AFF is 8 bits width and the mask should be 0xFF but not 0xF.

Cortex_a_r is okay and no need to be fixed.

This is a commit message fix for https://github.com/zephyrproject-rtos/zephyr/pull/73319.
Sorry for that again.

And added more description about impact of this bug.
If enable SMP mode on some cores with MPIDR higher than 0xF, and enable TICKLESS_KERNEL for the system,  secondary cores will have no chance to be scheduled after startup due to IPI not correct broadcast.