### PR TITLE
boards: ambiq: apollo3: add connector dtsi for apollo3 boards

### DIFF
--- a/boards/ambiq/apollo3_evb/apollo3_evb-pinctrl.dtsi
+++ b/boards/ambiq/apollo3_evb/apollo3_evb-pinctrl.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <dt-bindings/pinctrl/ambiq-apollo3-pinctrl.h>
+#include "apollo3_evb_connector.dtsi"
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/ambiq/apollo3_evb/apollo3_evb_connector.dtsi
+++ b/boards/ambiq/apollo3_evb/apollo3_evb_connector.dtsi
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2024 Ambiq <www.ambiq.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	ambiq_header: connector {
+		compatible = "ambiq-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffff80>;
+		gpio-map-pass-thru = <0 0x7f>;
+		gpio-map = <0 0 &gpio0_31 0 0>, /* IOS_SPI_SCK, IOS_I2C_SCL */
+			<1 0 &gpio0_31 1 0>, /* IOS_SPI_MOSI, IOS_I2C_SDA */
+			<2 0 &gpio0_31 2 0>, /* IOS_SPI_MISO */
+			<3 0 &gpio0_31 3 0>, /* IOS_CE */
+			<4 0 &gpio0_31 4 0>, /* IOS_INT */
+			<5 0 &gpio0_31 5 0>, /* IOM0_SPI_SCK, IOM0_I2C_SCL */
+			<6 0 &gpio0_31 6 0>, /* IOM0_SPI_MISO, IOM0_I2C_SDA */
+			<7 0 &gpio0_31 7 0>, /* IOM0_SPI_MOSI */
+			<8 0 &gpio0_31 8 0>, /* IOM1_SPI_SCK, IOM1_I2C_SCL */
+			<9 0 &gpio0_31 9 0>, /* IOM1_SPI_MISO, IOM1_I2C_SDA */
+			<10 0 &gpio0_31 10 0>, /* LED0, IOM1_SPI_MOSI */
+			<11 0 &gpio0_31 11 0>, /* DISP_RESET */
+			<12 0 &gpio0_31 12 0>, /* MSPI0_CE0 */
+			<13 0 &gpio0_31 13 0>, /* IOM0_CS */
+			<14 0 &gpio0_31 14 0>, /* LED3 */
+			<15 0 &gpio0_31 15 0>, /* LED2 */
+			<16 0 &gpio0_31 16 0>, /* BUTTON0 */
+			<17 0 &gpio0_31 17 0>, /* LED4 */
+			<18 0 &gpio0_31 18 0>, /* BUTTON1 */
+			<19 0 &gpio0_31 19 0>, /* BUTTON2 */
+			<20 0 &gpio0_31 20 0>, /* SWDCK */
+			<21 0 &gpio0_31 21 0>, /* SWDIO */
+			<22 0 &gpio0_31 22 0>, /* MSPI0_D0, UART0_TX */
+			<23 0 &gpio0_31 23 0>, /* MSPI0_D3, UART0_RX */
+			<24 0 &gpio0_31 24 0>, /* MSPI0_SCK */
+			<25 0 &gpio0_31 25 0>, /* IOM2_MISO_SCK, IOM2_I2C_SDA */
+			<26 0 &gpio0_31 26 0>, /* MSPI0_D1 */
+			<27 0 &gpio0_31 27 0>, /* IOM2_SPI_SCK, IOM2_I2C_SCL*/
+			<28 0 &gpio0_31 28 0>, /* MSPI0_CE0 */
+			<29 0 &gpio0_31 29 0>, /* IOM3_CS */
+			<30 0 &gpio0_31 30 0>, /* LED1 */
+			<31 0 &gpio0_31 31 0>, /* DISP_3V3_EN */
+			<32 0 &gpio32_63 0 0>, /* BLEIF_MOSI */
+			<33 0 &gpio32_63 1 0>, /* BLEIF_CSN */
+			<34 0 &gpio32_63 2 0>, /* IOM1_CS */
+			<35 0 &gpio32_63 3 0>, /* BLEIF_STATUS */
+			<36 0 &gpio32_63 4 0>, /* PDM_DATA */
+			<37 0 &gpio32_63 5 0>, /* PDM_CLK */
+			<38 0 &gpio32_63 6 0>, /* DISP_TE */
+			<39 0 &gpio32_63 7 0>, /* DISP_PWR_EN */
+			<40 0 &gpio32_63 8 0>, /* IOM4_SPI_MISO, IOM4_I2C_SDA */
+			<41 0 &gpio32_63 9 0>, /* SWO */
+			<42 0 &gpio32_63 10 0>, /* IOM3_I2C_SCL  */
+			<43 0 &gpio32_63 11 0>, /* IOM3_I2C_SDA */
+			<44 0 &gpio32_63 12 0>, /* IOM4_SPI_MOSI */
+			<45 0 &gpio32_63 13 0>, /* DISP_2V8_EN */
+			<46 0 &gpio32_63 14 0>, /* ACC_INT */
+			<47 0 &gpio32_63 15 0>, /* IOM5_SPI_MOSI */
+			<48 0 &gpio32_63 16 0>, /* IOM5_I2C_SCL */
+			<49 0 &gpio32_63 17 0>; /* IOM5_I2C_SDA */
+	};
+};
+
+ambiq_spi0: &spi0 {};
+ambiq_i2c3: &i2c3 {};

--- a/boards/ambiq/apollo3p_evb/apollo3p_evb-pinctrl.dtsi
+++ b/boards/ambiq/apollo3p_evb/apollo3p_evb-pinctrl.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <dt-bindings/pinctrl/ambiq-apollo3-pinctrl.h>
+#include "apollo3p_evb_connector.dtsi"
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/ambiq/apollo3p_evb/apollo3p_evb_connector.dtsi
+++ b/boards/ambiq/apollo3p_evb/apollo3p_evb_connector.dtsi
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2024 Ambiq <www.ambiq.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	ambiq_header: connector {
+		compatible = "ambiq-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffff80>;
+		gpio-map-pass-thru = <0 0x7f>;
+		gpio-map = <0 0 &gpio0_31 0 0>, /* IOS_SPI_SCK, IOS_I2C_SCL */
+			<1 0 &gpio0_31 1 0>, /* IOS_SPI_MOSI, IOS_I2C_SDA */
+			<2 0 &gpio0_31 2 0>, /* IOS_SPI_MISO */
+			<3 0 &gpio0_31 3 0>, /* IOS_CE */
+			<4 0 &gpio0_31 4 0>, /* IOS_INT */
+			<5 0 &gpio0_31 5 0>, /* IOM0_SPI_SCK, IOM0_I2C_SCL */
+			<6 0 &gpio0_31 6 0>, /* IOM0_SPI_MISO, IOM0_I2C_SDA */
+			<7 0 &gpio0_31 7 0>, /* IOM0_SPI_MOSI */
+			<8 0 &gpio0_31 8 0>, /* IOM1_SPI_SCK, IOM1_I2C_SCL */
+			<9 0 &gpio0_31 9 0>, /* IOM1_SPI_MISO, IOM1_I2C_SDA */
+			<10 0 &gpio0_31 10 0>, /* LED0, IOM1_SPI_MOSI */
+			<11 0 &gpio0_31 11 0>, /* DISP_RESET */
+			<12 0 &gpio0_31 12 0>, /* MSPI0_CE0 */
+			<13 0 &gpio0_31 13 0>, /* IOM0_CS */
+			<14 0 &gpio0_31 14 0>, /* LED3 */
+			<15 0 &gpio0_31 15 0>, /* LED2 */
+			<16 0 &gpio0_31 16 0>, /* BUTTON0 */
+			<17 0 &gpio0_31 17 0>, /* LED4 */
+			<18 0 &gpio0_31 18 0>, /* BUTTON1 */
+			<19 0 &gpio0_31 19 0>, /* BUTTON2 */
+			<20 0 &gpio0_31 20 0>, /* SWDCK */
+			<21 0 &gpio0_31 21 0>, /* SWDIO */
+			<22 0 &gpio0_31 22 0>, /* MSPI0_D0, UART0_TX */
+			<23 0 &gpio0_31 23 0>, /* MSPI0_D3, UART0_RX */
+			<24 0 &gpio0_31 24 0>, /* MSPI0_SCK */
+			<25 0 &gpio0_31 25 0>, /* IOM2_MISO_SCK, IOM2_I2C_SDA */
+			<26 0 &gpio0_31 26 0>, /* MSPI0_D1 */
+			<27 0 &gpio0_31 27 0>, /* IOM2_SPI_SCK, IOM2_I2C_SCL*/
+			<28 0 &gpio0_31 28 0>, /* MSPI0_CE0 */
+			<29 0 &gpio0_31 29 0>, /* IOM3_CS */
+			<30 0 &gpio0_31 30 0>, /* LED1 */
+			<31 0 &gpio0_31 31 0>, /* DISP_3V3_EN */
+			<32 0 &gpio32_63 0 0>, /* BLEIF_MOSI */
+			<33 0 &gpio32_63 1 0>, /* BLEIF_CSN */
+			<34 0 &gpio32_63 2 0>, /* IOM1_CS */
+			<35 0 &gpio32_63 3 0>, /* BLEIF_STATUS */
+			<36 0 &gpio32_63 4 0>, /* PDM_DATA */
+			<37 0 &gpio32_63 5 0>, /* PDM_CLK */
+			<38 0 &gpio32_63 6 0>, /* DISP_TE */
+			<39 0 &gpio32_63 7 0>, /* DISP_PWR_EN */
+			<40 0 &gpio32_63 8 0>, /* IOM4_SPI_MISO, IOM4_I2C_SDA */
+			<41 0 &gpio32_63 9 0>, /* SWO */
+			<42 0 &gpio32_63 10 0>, /* IOM3_I2C_SCL  */
+			<43 0 &gpio32_63 11 0>, /* IOM3_I2C_SDA */
+			<44 0 &gpio32_63 12 0>, /* IOM4_SPI_MOSI */
+			<45 0 &gpio32_63 13 0>, /* DISP_2V8_EN */
+			<46 0 &gpio32_63 14 0>, /* ACC_INT */
+			<47 0 &gpio32_63 15 0>, /* IOM5_SPI_MOSI */
+			<48 0 &gpio32_63 16 0>, /* IOM5_I2C_SCL */
+			<49 0 &gpio32_63 17 0>, /* IOM5_I2C_SDA */
+			<50 0 &gpio32_63 18 0>, /* MSPI1_CE0 */
+			<51 0 &gpio32_63 19 0>, /* MSPI1_D0 */
+			<52 0 &gpio32_63 20 0>, /* MSPI1_D1 */
+			<53 0 &gpio32_63 21 0>, /* MSPI1_D2 */
+			<54 0 &gpio32_63 22 0>, /* MSPI1_D3 */
+			<55 0 &gpio32_63 23 0>, /* MSPI1_D4 */
+			<56 0 &gpio32_63 24 0>, /* MSPI1_D5 */
+			<57 0 &gpio32_63 25 0>, /* MSPI1_D6 */
+			<58 0 &gpio32_63 26 0>, /* MSPI1_D7 */
+			<59 0 &gpio32_63 27 0>, /* MSPI1_SCK */
+			<60 0 &gpio32_63 28 0>, /* MSPI1_DMDQS */
+			<61 0 &gpio32_63 29 0>, /* MSPI2_CE1 */
+			<62 0 &gpio32_63 30 0>, /* MSPI1_CE1 */
+			<63 0 &gpio32_63 31 0>, /* MSPI2_CE0 */
+			<64 0 &gpio64_95 0 0>, /* MSPI2_D0 */
+			<65 0 &gpio64_95 1 0>, /* MSPI2_D1 */
+			<66 0 &gpio64_95 2 0>, /* MSPI2_D2 */
+			<67 0 &gpio64_95 3 0>, /* MSPI2_D3 */
+			<68 0 &gpio64_95 4 0>, /* MSPI0_SCK */
+			<69 0 &gpio64_95 5 0>, /* MSPI1_CE0 */
+			<70 0 &gpio64_95 6 0>, /* See am_hal_pins.h file for further info */
+			<71 0 &gpio64_95 7 0>, /* See am_hal_pins.h file for further info */
+			<72 0 &gpio64_95 8 0>, /* See am_hal_pins.h file for further info */
+			<73 0 &gpio64_95 9 0>, /* See am_hal_pins.h file for further info */
+			<74 0 &gpio64_95 10 0>; /* See am_hal_pins.h file for further info */
+	};
+};
+
+ambiq_spi0: &spi0 {};
+ambiq_i2c3: &i2c3 {};

--- a/drivers/gpio/gpio_ambiq.c
+++ b/drivers/gpio/gpio_ambiq.c
@@ -36,6 +36,7 @@ struct ambiq_gpio_data {
 static int ambiq_gpio_pin_configure(const struct device *dev, gpio_pin_t pin, gpio_flags_t flags)
 {
 	const struct ambiq_gpio_config *const dev_cfg = dev->config;
+	int ret;
 
 #if defined(CONFIG_SOC_SERIES_APOLLO3X)
 	pin += dev_cfg->offset;
@@ -106,9 +107,12 @@ static int ambiq_gpio_pin_configure(const struct device *dev, gpio_pin_t pin, gp
 		am_hal_gpio_state_write(pin, AM_HAL_GPIO_OUTPUT_CLEAR);
 	}
 #endif
-	am_hal_gpio_pinconfig(pin, pincfg);
 
-	return 0;
+	if (am_hal_gpio_pinconfig(pin, pincfg) != AM_HAL_STATUS_SUCCESS) {
+		ret = -ENOTSUP;
+	}
+
+	return ret;
 }
 
 #ifdef CONFIG_GPIO_GET_CONFIG

--- a/tests/drivers/counter/counter_basic_api/boards/apollo3_evb.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/apollo3_evb.overlay
@@ -1,0 +1,31 @@
+&counter0 {
+	status = "okay";
+};
+
+&counter1 {
+	status = "disabled";
+};
+
+&counter2 {
+	status = "disabled";
+};
+
+&counter3 {
+	status = "disabled";
+};
+
+&counter4 {
+	status = "disabled";
+};
+
+&counter5 {
+	status = "disabled";
+};
+
+&counter6 {
+	status = "disabled";
+};
+
+&counter7 {
+	status = "disabled";
+};

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -977,7 +977,7 @@ static bool reliable_cancel_capable(const struct device *dev)
 	}
 #endif
 #ifdef CONFIG_COUNTER_AMBIQ
-	if (dev == DEVICE_DT_GET(DT_NODELABEL(counter0))) {
+	if (single_channel_alarm_capable(dev)) {
 		return true;
 	}
 #endif

--- a/tests/drivers/gpio/gpio_basic_api/boards/apollo3_evb.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/apollo3_evb.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2024 Ambiq Micro Inc. <www.ambiq.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	resources {
+		compatible = "test-gpio-basic-api";
+		out-gpios = <&ambiq_header 5 0>;
+		in-gpios = <&ambiq_header 6 0>;
+	};
+};


### PR DESCRIPTION
Added connector dtsi files for apollo3_evb and apollo3p_evb, and ran gpio_basic_api to test, all cases passed