### PR TITLE
tests: Remove obsolete filter for ARC nSIM platform

### DIFF
--- a/tests/lib/heap/testcase.yaml
+++ b/tests/lib/heap/testcase.yaml
@@ -13,7 +13,6 @@ tests:
       - qemu_xtensa
       - esp32s2_saola
       - esp32s2_lolin_mini
-    filter: not CONFIG_SOC_NSIM
     timeout: 480
     integration_platforms:
       - native_sim


### PR DESCRIPTION
Remove nSIM platform filter for tests/lib/heap. The filter is no longer needed as nSIM performence was improved and test timeout was increased because of another platforms.