### PR TITLE
Bluetooth: Document semantics of callbacks and `bt_disable()`

### DIFF
--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -235,6 +235,11 @@ int bt_enable(bt_ready_cb_t cb);
  * stored with @kconfig{CONFIG_BT_SETTINGS}. These can be restored
  * with settings_load() before reenabling the stack.
  *
+ * This API does _not_ clear previously registered callbacks
+ * like @ref bt_le_scan_cb_register and @ref bt_conn_cb_register.
+ * That is, the application shall not re-register them when
+ * the Bluetooth subsystem is re-enabled later.
+ *
  * Close and release HCI resources. Result is architecture dependent.
  *
  * @return Zero on success or (negative) error code otherwise.


### PR DESCRIPTION
Callbacks are not unregistered upon `bt_disable()`. This seems intentional as it is possible register callbacks before `bt_enable()`, that is state which is independent of `bt_enable()`. 

The callback registering functions currently do not validate if it has already been registered. This can result in bugs where the app gets stuck in an infinite loop at a later point in time of execution.
We should make the application fail early when it tries adding the same callback twice. That will be done separately. For now we will document the behavior.





