### PR TITLE
Manifest: Update to latest version of bsim and edtt

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -127,7 +127,7 @@ manifest:
       revision: 0c8669d81381ccf3b1a01d699f3b68b50134a99f
       path: modules/lib/cmsis-nn
     - name: edtt
-      revision: 64e5105ad82390164fb73fc654be3f73a608209a
+      revision: 8d7b543d4d2f2be0f78481e4e1d8d73a88024803
       path: tools/edtt
       groups:
         - tools

--- a/west.yml
+++ b/west.yml
@@ -34,7 +34,7 @@ manifest:
       path: modules/lib/acpica
     - name: bsim
       repo-path: babblesim-manifest
-      revision: 68f6282c6a7f54641b75f5f9fc953c85e272a983
+      revision: 9351ae1ad44864a49c351f9704f65f43046abeb0
       path: tools/bsim
       groups:
         - babblesim
@@ -56,7 +56,7 @@ manifest:
       remote: babblesim
       repo-path: ext_2G4_phy_v1
       path: tools/bsim/components/ext_2G4_phy_v1
-      revision: d8302b8d51409b9e717a1a0ba6b443d3b5552a6c
+      revision: 04eeb3c3794444122fbeeb3715f4233b0b50cfbb
       groups:
         - babblesim
     - name: babblesim_ext_2G4_channel_NtNcable


### PR DESCRIPTION
    manifest: Update EDTT to latest
    
    Update the EDTT module to:
    8d7b543d4d2f2be0f78481e4e1d8d73a88024803
    
    Including the following:
    * 8d7b543 Fix some issues found during CIS Central testing
    * fb426f1 Fix crash due to race when creating simulation folder
    
----

    manifest: Update bsim to version v2.2.1
    
    Includes just changes for the phy dump conversion scripts,
    to add support in the csv2pcap conversion for coded phy.
