### PR TITLE
soc: nordic: configure run once for nrf54h20

### DIFF
--- a/soc/nordic/soc.yml
+++ b/soc/nordic/soc.yml
@@ -68,6 +68,7 @@ runners:
       - runners:
           - nrfjprog
           - jlink
+          - nrfutil
         run: first
         groups:
           - qualifiers:
@@ -85,10 +86,15 @@ runners:
           - qualifiers:
               - nrf54l15/cpuapp
               - nrf54l15/cpuflpr
+          - qualifiers:
+              - nrf54h20/cpuapp
+              - nrf54h20/cpurad
+              - nrf54h20/cpuppr
     '--reset':
       - runners:
           - nrfjprog
           - jlink
+          - nrfutil
         run: last
         groups:
           - qualifiers:
@@ -106,3 +112,7 @@ runners:
           - qualifiers:
               - nrf54l15/cpuapp
               - nrf54l15/cpuflpr
+          - qualifiers:
+              - nrf54h20/cpuapp
+              - nrf54h20/cpurad
+              - nrf54h20/cpuppr


### PR DESCRIPTION
Erase and reset must run only once during flashing. This prevents a situation, where the next flashed image erases the previous one.