### PR TITLE
sysbuild: Import image devicetrees

### DIFF
--- a/cmake/modules/dts.cmake
+++ b/cmake/modules/dts.cmake
@@ -122,12 +122,6 @@ set(GEN_DRIVER_KCONFIG_SCRIPT   ${DT_SCRIPTS}/gen_driver_kconfig_dts.py)
 # Generated Kconfig symbols go here.
 set(DTS_KCONFIG                 ${KCONFIG_BINARY_DIR}/Kconfig.dts)
 
-# This generates DT information needed by the CMake APIs.
-set(GEN_DTS_CMAKE_SCRIPT        ${DT_SCRIPTS}/gen_dts_cmake.py)
-# The generated information itself, which we include() after
-# creating it.
-set(DTS_CMAKE                   ${PROJECT_BINARY_DIR}/dts.cmake)
-
 # The location of a file containing known vendor prefixes, relative to
 # each element of DTS_ROOT. Users can define their own in their own
 # modules.
@@ -283,7 +277,6 @@ set_property(DIRECTORY APPEND PROPERTY
   ${GEN_EDT_SCRIPT}
   ${GEN_DEFINES_SCRIPT}
   ${GEN_DRIVER_KCONFIG_SCRIPT}
-  ${GEN_DTS_CMAKE_SCRIPT}
   )
 
 #
@@ -346,31 +339,12 @@ if(NOT "${ret}" STREQUAL "0")
 endif()
 
 #
-# Run GEN_DTS_CMAKE_SCRIPT.
+# Import devicetree contents into CMake.
+# This enables the CMake dt_* API.
 #
-# A temporary file is copied to the original file if it differs. This prevents issue such as a
-# cycle when sysbuild is used of configuring and building multiple times due to the dts.cmake file
-# of images having a newer modification time than the sysbuild build.ninja file, despite the
-# output having not changed
-#
-set(dts_cmake_tmp ${DTS_CMAKE}.new)
 
-execute_process(
-  COMMAND ${PYTHON_EXECUTABLE} ${GEN_DTS_CMAKE_SCRIPT}
-  --edt-pickle ${EDT_PICKLE}
-  --cmake-out ${dts_cmake_tmp}
-  WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-  RESULT_VARIABLE ret
-  )
-if(NOT "${ret}" STREQUAL "0")
-  message(FATAL_ERROR "gen_dts_cmake.py failed with return code: ${ret}")
-else()
-  zephyr_file_copy(${dts_cmake_tmp} ${DTS_CMAKE} ONLY_IF_DIFFERENT)
-  file(REMOVE ${dts_cmake_tmp})
-  set(dts_cmake_tmp)
-  message(STATUS "Including generated dts.cmake file: ${DTS_CMAKE}")
-  include(${DTS_CMAKE})
-endif()
+add_custom_target(devicetree_target)
+zephyr_dt_import(EDT_PICKLE_FILE ${EDT_PICKLE} TARGET devicetree_target)
 
 #
 # Run dtc if it was found.

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -3818,7 +3818,7 @@ endfunction()
 #   will make this clear in each case.
 
 # Usage:
-#   dt_nodelabel(<var> NODELABEL <label>)
+#   dt_nodelabel(<var> NODELABEL <label> [REQUIRED] [TARGET <target>])
 #
 # Function for retrieving the node path for the node having nodelabel
 # <label>.
@@ -3842,10 +3842,14 @@ endfunction()
 # <var>              : Return variable where the node path will be stored
 # NODELABEL <label>  : Node label
 # REQUIRED           : Generate a fatal error if the node-label is not found
+# TARGET <target>    : Optional target to retrieve devicetree information from
 function(dt_nodelabel var)
   set(options "REQUIRED")
   set(req_single_args "NODELABEL")
-  cmake_parse_arguments(DT_LABEL "${options}" "${req_single_args}" "" ${ARGN})
+  set(single_args "TARGET")
+  cmake_parse_arguments(DT_LABEL "${options}" "${req_single_args};${single_args}" "" ${ARGN})
+
+  dt_target_internal(DT_LABEL_TARGET)
 
   if(${ARGV0} IN_LIST req_single_args)
     message(FATAL_ERROR "dt_nodelabel(${ARGV0} ...) missing return parameter.")
@@ -3859,7 +3863,7 @@ function(dt_nodelabel var)
     endif()
   endforeach()
 
-  get_target_property(${var} devicetree_target "DT_NODELABEL|${DT_LABEL_NODELABEL}")
+  get_target_property(${var} ${DT_LABEL_TARGET} "DT_NODELABEL|${DT_LABEL_NODELABEL}")
   if(${${var}} STREQUAL ${var}-NOTFOUND)
     if(DT_LABEL_REQUIRED)
       message(FATAL_ERROR "required nodelabel not found: ${DT_LABEL_NODELABEL}")
@@ -3871,7 +3875,7 @@ function(dt_nodelabel var)
 endfunction()
 
 # Usage:
-#   dt_alias(<var> PROPERTY <prop>)
+#   dt_alias(<var> PROPERTY <prop> [REQUIRED] [TARGET <target>])
 #
 # Get a node path for an /aliases node property.
 #
@@ -3890,10 +3894,14 @@ endfunction()
 # <var>           : Return variable where the node path will be stored
 # PROPERTY <prop> : The alias to check
 # REQUIRED        : Generate a fatal error if the alias is not found
+# TARGET <target> : Optional target to retrieve devicetree information from
 function(dt_alias var)
   set(options "REQUIRED")
   set(req_single_args "PROPERTY")
-  cmake_parse_arguments(DT_ALIAS "${options}" "${req_single_args}" "" ${ARGN})
+  set(single_args "TARGET")
+  cmake_parse_arguments(DT_ALIAS "${options}" "${req_single_args};${single_args}" "" ${ARGN})
+
+  dt_target_internal(DT_ALIAS_TARGET)
 
   if(${ARGV0} IN_LIST req_single_args)
     message(FATAL_ERROR "dt_alias(${ARGV0} ...) missing return parameter.")
@@ -3907,7 +3915,7 @@ function(dt_alias var)
     endif()
   endforeach()
 
-  get_target_property(${var} devicetree_target "DT_ALIAS|${DT_ALIAS_PROPERTY}")
+  get_target_property(${var} ${DT_ALIAS_TARGET} "DT_ALIAS|${DT_ALIAS_PROPERTY}")
   if(${${var}} STREQUAL ${var}-NOTFOUND)
     if(DT_ALIAS_REQUIRED)
       message(FATAL_ERROR "required alias not found: ${DT_ALIAS_PROPERTY}")
@@ -3919,7 +3927,7 @@ function(dt_alias var)
 endfunction()
 
 # Usage:
-#   dt_node_exists(<var> PATH <path>)
+#   dt_node_exists(<var> PATH <path> [TARGET <target>])
 #
 # Tests whether a node with path <path> exists in the devicetree.
 #
@@ -3932,11 +3940,15 @@ endfunction()
 # The result of the check, either TRUE or FALSE, will be returned in
 # the <var> parameter.
 #
-# <var>       : Return variable where the check result will be returned
-# PATH <path> : Node path
+# <var>           : Return variable where the check result will be returned
+# PATH <path>     : Node path
+# TARGET <target> : Optional target to retrieve devicetree information from
 function(dt_node_exists var)
   set(req_single_args "PATH")
-  cmake_parse_arguments(DT_NODE "" "${req_single_args}" "" ${ARGN})
+  set(single_args "TARGET")
+  cmake_parse_arguments(DT_NODE "" "${req_single_args};${single_args}" "" ${ARGN})
+
+  dt_target_internal(DT_NODE_TARGET)
 
   if(${ARGV0} IN_LIST req_single_args)
     message(FATAL_ERROR "dt_node_exists(${ARGV0} ...) missing return parameter.")
@@ -3950,7 +3962,7 @@ function(dt_node_exists var)
     endif()
   endforeach()
 
-  dt_path_internal(canonical "${DT_NODE_PATH}")
+  dt_path_internal(canonical "${DT_NODE_PATH}" "${DT_NODE_TARGET}")
   if (DEFINED canonical)
     set(${var} TRUE PARENT_SCOPE)
   else()
@@ -3959,7 +3971,7 @@ function(dt_node_exists var)
 endfunction()
 
 # Usage:
-#   dt_node_has_status(<var> PATH <path> STATUS <status>)
+#   dt_node_has_status(<var> PATH <path> STATUS <status> [TARGET <target>])
 #
 # Tests whether <path> refers to a node which:
 # - exists in the devicetree, and
@@ -3979,9 +3991,13 @@ endfunction()
 # <var>           : Return variable where the check result will be returned
 # PATH <path>     : Node path
 # STATUS <status> : Status to check
+# TARGET <target> : Optional target to retrieve devicetree information from
 function(dt_node_has_status var)
   set(req_single_args "PATH;STATUS")
-  cmake_parse_arguments(DT_NODE "" "${req_single_args}" "" ${ARGN})
+  set(single_args "TARGET")
+  cmake_parse_arguments(DT_NODE "" "${req_single_args};${single_args}" "" ${ARGN})
+
+  dt_target_internal(DT_NODE_TARGET)
 
   if(${ARGV0} IN_LIST req_single_args)
     message(FATAL_ERROR "dt_node_has_status(${ARGV0} ...) missing return parameter.")
@@ -3995,13 +4011,13 @@ function(dt_node_has_status var)
     endif()
   endforeach()
 
-  dt_path_internal(canonical ${DT_NODE_PATH})
+  dt_path_internal(canonical ${DT_NODE_PATH} ${DT_NODE_TARGET})
   if(NOT DEFINED canonical)
     set(${var} FALSE PARENT_SCOPE)
     return()
   endif()
 
-  dt_prop(status PATH ${canonical} PROPERTY status)
+  dt_prop(status PATH ${canonical} PROPERTY status TARGET ${DT_NODE_TARGET})
 
   if(NOT DEFINED status OR status STREQUAL "ok")
     set(status "okay")
@@ -4016,7 +4032,7 @@ endfunction()
 
 # Usage:
 #
-#   dt_prop(<var> PATH <path> PROPERTY <prop> [INDEX <idx>])
+#   dt_prop(<var> PATH <path> PROPERTY <prop> [INDEX <idx>] [REQUIRED] [TARGET <target>])
 #
 # Get a devicetree property value. The value will be returned in the
 # <var> parameter.
@@ -4065,11 +4081,14 @@ endfunction()
 #                  appears in the DTS source
 # INDEX <idx>    : Optional index when retrieving a value in an array property
 # REQUIRED       : Generate a fatal error if the property is not found
+# TARGET <target>: Optional target to retrieve devicetree information from
 function(dt_prop var)
   set(options "REQUIRED")
   set(req_single_args "PATH;PROPERTY")
-  set(single_args "INDEX")
+  set(single_args "INDEX;TARGET")
   cmake_parse_arguments(DT_PROP "${options}" "${req_single_args};${single_args}" "" ${ARGN})
+
+  dt_target_internal(DT_PROP_TARGET)
 
   if(${ARGV0} IN_LIST req_single_args)
     message(FATAL_ERROR "dt_prop(${ARGV0} ...) missing return parameter.")
@@ -4083,8 +4102,8 @@ function(dt_prop var)
     endif()
   endforeach()
 
-  dt_path_internal(canonical "${DT_PROP_PATH}")
-  get_property(exists TARGET devicetree_target
+  dt_path_internal(canonical "${DT_PROP_PATH}" "${DT_PROP_TARGET}")
+  get_property(exists TARGET ${DT_PROP_TARGET}
       PROPERTY "DT_PROP|${canonical}|${DT_PROP_PROPERTY}"
       SET
   )
@@ -4097,7 +4116,7 @@ function(dt_prop var)
     return()
   endif()
 
-  get_target_property(val devicetree_target
+  get_target_property(val ${DT_PROP_TARGET}
       "DT_PROP|${canonical}|${DT_PROP_PROPERTY}"
   )
 
@@ -4111,7 +4130,7 @@ endfunction()
 
 # Usage:
 #
-#   dt_comp_path(<var> COMPATIBLE <compatible> [INDEX <idx>])
+#   dt_comp_path(<var> COMPATIBLE <compatible> [INDEX <idx>] [TARGET <target>])
 #
 # Get a list of paths for the nodes with the given compatible. The value will
 # be returned in the <var> parameter.
@@ -4124,11 +4143,14 @@ endfunction()
 # COMPATIBLE <compatible>: Compatible for which the list of paths should be
 #                          returned, as it appears in the DTS source
 # INDEX <idx>            : Optional index when retrieving a value in an array property
+# TARGET <target>        : Optional target to retrieve devicetree information from
 
 function(dt_comp_path var)
   set(req_single_args "COMPATIBLE")
-  set(single_args "INDEX")
+  set(single_args "INDEX;TARGET")
   cmake_parse_arguments(DT_COMP "" "${req_single_args};${single_args}" "" ${ARGN})
+
+  dt_target_internal(DT_COMP_TARGET)
 
   if(${ARGV0} IN_LIST req_single_args)
     message(FATAL_ERROR "dt_comp_path(${ARGV0} ...) missing return parameter.")
@@ -4142,7 +4164,7 @@ function(dt_comp_path var)
     endif()
   endforeach()
 
-  get_property(exists TARGET devicetree_target
+  get_property(exists TARGET ${DT_COMP_TARGET}
       PROPERTY "DT_COMP|${DT_COMP_COMPATIBLE}"
       SET
   )
@@ -4152,7 +4174,7 @@ function(dt_comp_path var)
     return()
   endif()
 
-  get_target_property(val devicetree_target
+  get_target_property(val ${DT_COMP_TARGET}
       "DT_COMP|${DT_COMP_COMPATIBLE}"
   )
 
@@ -4165,7 +4187,7 @@ function(dt_comp_path var)
 endfunction()
 
 # Usage:
-#   dt_num_regs(<var> PATH <path>)
+#   dt_num_regs(<var> PATH <path> [TARGET <target>])
 #
 # Get the number of register blocks in the node's reg property;
 # this may be zero.
@@ -4180,9 +4202,13 @@ endfunction()
 #
 # <var>          : Return variable where the property value will be stored
 # PATH <path>    : Node path
+# TARGET <target>: Optional target to retrieve devicetree information from
 function(dt_num_regs var)
   set(req_single_args "PATH")
-  cmake_parse_arguments(DT_REG "" "${req_single_args}" "" ${ARGN})
+  set(single_args "TARGET")
+  cmake_parse_arguments(DT_REG "" "${req_single_args};${single_args}" "" ${ARGN})
+
+  dt_target_internal(DT_REG_TARGET)
 
   if(${ARGV0} IN_LIST req_single_args)
     message(FATAL_ERROR "dt_num_regs(${ARGV0} ...) missing return parameter.")
@@ -4196,14 +4222,14 @@ function(dt_num_regs var)
     endif()
   endforeach()
 
-  dt_path_internal(canonical "${DT_REG_PATH}")
-  get_target_property(${var} devicetree_target "DT_REG|${canonical}|NUM")
+  dt_path_internal(canonical "${DT_REG_PATH}" "${DT_REG_TARGET}")
+  get_target_property(${var} ${DT_REG_TARGET} "DT_REG|${canonical}|NUM")
 
   set(${var} ${${var}} PARENT_SCOPE)
 endfunction()
 
 # Usage:
-#   dt_reg_addr(<var> PATH <path> [INDEX <idx>] [NAME <name>])
+#   dt_reg_addr(<var> PATH <path> [INDEX <idx>] [NAME <name>] [TARGET <target>])
 #
 # Get the base address of the register block at index <idx>, or with
 # name <name>. If <idx> and <name> are both omitted, the value at
@@ -4226,10 +4252,13 @@ endfunction()
 # PATH <path>    : Node path
 # INDEX <idx>    : Register block index number
 # NAME <name>    : Register block name
+# TARGET <target>: Optional target to retrieve devicetree information from
 function(dt_reg_addr var)
   set(req_single_args "PATH")
-  set(single_args "INDEX;NAME")
+  set(single_args "INDEX;NAME;TARGET")
   cmake_parse_arguments(DT_REG "" "${req_single_args};${single_args}" "" ${ARGN})
+
+  dt_target_internal(DT_REG_TARGET)
 
   if(${ARGV0} IN_LIST req_single_args)
     message(FATAL_ERROR "dt_reg_addr(${ARGV0} ...) missing return parameter.")
@@ -4248,15 +4277,16 @@ function(dt_reg_addr var)
   elseif(NOT DEFINED DT_REG_INDEX AND NOT DEFINED DT_REG_NAME)
     set(DT_REG_INDEX 0)
   elseif(DEFINED DT_REG_NAME)
-    dt_reg_index_private(DT_REG_INDEX "${DT_REG_PATH}" "${DT_REG_NAME}")
+    dt_prop(reg_names PATH "${DT_REG_PATH}" PROPERTY "reg-names" TARGET "${DT_REG_TARGET}")
+    list(FIND reg_names "${DT_REG_NAME}" DT_REG_INDEX)
     if(DT_REG_INDEX EQUAL "-1")
       set(${var} PARENT_SCOPE)
       return()
     endif()
   endif()
 
-  dt_path_internal(canonical "${DT_REG_PATH}")
-  get_target_property(${var}_list devicetree_target "DT_REG|${canonical}|ADDR")
+  dt_path_internal(canonical "${DT_REG_PATH}" "${DT_REG_TARGET}")
+  get_target_property(${var}_list ${DT_REG_TARGET} "DT_REG|${canonical}|ADDR")
 
   list(GET ${var}_list ${DT_REG_INDEX} ${var})
 
@@ -4268,7 +4298,7 @@ function(dt_reg_addr var)
 endfunction()
 
 # Usage:
-#   dt_reg_size(<var> PATH <path> [INDEX <idx>] [NAME <name>])
+#   dt_reg_size(<var> PATH <path> [INDEX <idx>] [NAME <name>] [TARGET <target>])
 #
 # Get the size of the register block at index <idx>, or with
 # name <name>. If <idx> and <name> are both omitted, the value at
@@ -4286,10 +4316,13 @@ endfunction()
 # PATH <path>    : Node path
 # INDEX <idx>    : Register block index number
 # NAME <name>    : Register block name
+# TARGET <target>: Optional target to retrieve devicetree information from
 function(dt_reg_size var)
   set(req_single_args "PATH")
-  set(single_args "INDEX;NAME")
+  set(single_args "INDEX;NAME;TARGET")
   cmake_parse_arguments(DT_REG "" "${req_single_args};${single_args}" "" ${ARGN})
+
+  dt_target_internal(DT_REG_TARGET)
 
   if(${ARGV0} IN_LIST req_single_args)
     message(FATAL_ERROR "dt_reg_size(${ARGV0} ...) missing return parameter.")
@@ -4308,15 +4341,16 @@ function(dt_reg_size var)
   elseif(NOT DEFINED DT_REG_INDEX AND NOT DEFINED DT_REG_NAME)
     set(DT_REG_INDEX 0)
   elseif(DEFINED DT_REG_NAME)
-    dt_reg_index_private(DT_REG_INDEX "${DT_REG_PATH}" "${DT_REG_NAME}")
+    dt_prop(reg_names PATH "${DT_REG_PATH}" PROPERTY "reg-names" TARGET "${DT_REG_TARGET}")
+    list(FIND reg_names "${DT_REG_NAME}" DT_REG_INDEX)
     if(DT_REG_INDEX EQUAL "-1")
       set(${var} PARENT_SCOPE)
       return()
     endif()
   endif()
 
-  dt_path_internal(canonical "${DT_REG_PATH}")
-  get_target_property(${var}_list devicetree_target "DT_REG|${canonical}|SIZE")
+  dt_path_internal(canonical "${DT_REG_PATH}" "${DT_REG_TARGET}")
+  get_target_property(${var}_list ${DT_REG_TARGET} "DT_REG|${canonical}|SIZE")
 
   list(GET ${var}_list ${DT_REG_INDEX} ${var})
 
@@ -4327,19 +4361,8 @@ function(dt_reg_size var)
   set(${var} ${${var}} PARENT_SCOPE)
 endfunction()
 
-# Internal helper for dt_reg_addr/dt_reg_size; not meant to be used directly
-function(dt_reg_index_private var path name)
-  dt_prop(reg_names PATH "${path}" PROPERTY "reg-names")
-  if(NOT DEFINED reg_names)
-    set(index "-1")
-  else()
-    list(FIND reg_names "${name}" index)
-  endif()
-  set(${var} "${index}" PARENT_SCOPE)
-endfunction()
-
 # Usage:
-#   dt_has_chosen(<var> PROPERTY <prop>)
+#   dt_has_chosen(<var> PROPERTY <prop> [TARGET <target>])
 #
 # Test if the devicetree's /chosen node has a given property
 # <prop> which contains the path to a node.
@@ -4363,9 +4386,13 @@ endfunction()
 #
 # <var>           : Return variable
 # PROPERTY <prop> : Chosen property
+# TARGET <target> : Optional target to retrieve devicetree information from
 function(dt_has_chosen var)
   set(req_single_args "PROPERTY")
-  cmake_parse_arguments(DT_CHOSEN "" "${req_single_args}" "" ${ARGN})
+  set(single_args "TARGET")
+  cmake_parse_arguments(DT_CHOSEN "" "${req_single_args};${single_args}" "" ${ARGN})
+
+  dt_target_internal(DT_CHOSEN_TARGET)
 
   if(${ARGV0} IN_LIST req_single_args)
     message(FATAL_ERROR "dt_has_chosen(${ARGV0} ...) missing return parameter.")
@@ -4379,7 +4406,7 @@ function(dt_has_chosen var)
     endif()
   endforeach()
 
-  get_target_property(exists devicetree_target "DT_CHOSEN|${DT_CHOSEN_PROPERTY}")
+  get_target_property(exists ${DT_CHOSEN_TARGET} "DT_CHOSEN|${DT_CHOSEN_PROPERTY}")
 
   if(${exists} STREQUAL exists-NOTFOUND)
     set(${var} FALSE PARENT_SCOPE)
@@ -4389,7 +4416,7 @@ function(dt_has_chosen var)
 endfunction()
 
 # Usage:
-#   dt_chosen(<var> PROPERTY <prop>)
+#   dt_chosen(<var> PROPERTY <prop> [TARGET <target>])
 #
 # Get a node path for a /chosen node property.
 #
@@ -4398,9 +4425,13 @@ endfunction()
 #
 # <var>           : Return variable where the node path will be stored
 # PROPERTY <prop> : Chosen property
+# TARGET <target> : Optional target to retrieve devicetree information from
 function(dt_chosen var)
   set(req_single_args "PROPERTY")
-  cmake_parse_arguments(DT_CHOSEN "" "${req_single_args}" "" ${ARGN})
+  set(single_args "TARGET")
+  cmake_parse_arguments(DT_CHOSEN "" "${req_single_args};${single_args}" "" ${ARGN})
+
+  dt_target_internal(DT_CHOSEN_TARGET)
 
   if(${ARGV0} IN_LIST req_single_args)
     message(FATAL_ERROR "dt_chosen(${ARGV0} ...) missing return parameter.")
@@ -4414,12 +4445,31 @@ function(dt_chosen var)
     endif()
   endforeach()
 
-  get_target_property(${var} devicetree_target "DT_CHOSEN|${DT_CHOSEN_PROPERTY}")
+  get_target_property(${var} ${DT_CHOSEN_TARGET} "DT_CHOSEN|${DT_CHOSEN_PROPERTY}")
 
   if(${${var}} STREQUAL ${var}-NOTFOUND)
     set(${var} PARENT_SCOPE)
   else()
     set(${var} ${${var}} PARENT_SCOPE)
+  endif()
+endfunction()
+
+# Internal helper. Check that the CMake target named by variable 'var' is valid
+# for use in other dt_* functions. If 'var' is undefined, set it to the default
+# name of "devicetree_target", which is initialized in cmake/modules/dts.cmake.
+# In general, a valid target is one that has been passed to zephyr_dt_import().
+function(dt_target_internal var)
+  if(NOT DEFINED ${var})
+    set(${var} devicetree_target)
+    set(${var} ${${var}} PARENT_SCOPE)
+  endif()
+
+  set(devicetree_imported FALSE)
+  if(TARGET ${${var}})
+    dt_path_internal_exists(devicetree_imported "/" ${${var}})
+  endif()
+  if(NOT devicetree_imported)
+    message(FATAL_ERROR "devicetree is not yet imported into target '${${var}}'")
   endif()
 endfunction()
 
@@ -4443,17 +4493,17 @@ endfunction()
 #
 # Example usage:
 #
-#   dt_path_internal(ret "/foo/bar")     # sets ret to "/foo/bar"
-#   dt_path_internal(ret "my-alias")     # sets ret to "/foo/bar"
-#   dt_path_internal(ret "my-alias/baz") # sets ret to "/foo/bar/baz"
-#   dt_path_internal(ret "/blub")        # ret is undefined
-function(dt_path_internal var path)
+#   dt_path_internal(ret "/foo/bar" target)     # sets ret to "/foo/bar"
+#   dt_path_internal(ret "my-alias" target)     # sets ret to "/foo/bar"
+#   dt_path_internal(ret "my-alias/baz" target) # sets ret to "/foo/bar/baz"
+#   dt_path_internal(ret "/blub" target)        # ret is undefined
+function(dt_path_internal var path target)
   string(FIND "${path}" "/" slash_index)
 
   if("${slash_index}" EQUAL 0)
     # If the string starts with a slash, it should be an existing
     # canonical path.
-    dt_path_internal_exists(check "${path}")
+    dt_path_internal_exists(check "${path}" "${target}")
     if (check)
       set(${var} "${path}" PARENT_SCOPE)
       return()
@@ -4461,7 +4511,7 @@ function(dt_path_internal var path)
   else()
     # Otherwise, try to expand a leading alias.
     string(SUBSTRING "${path}" 0 "${slash_index}" alias_name)
-    dt_alias(alias_path PROPERTY "${alias_name}")
+    dt_alias(alias_path PROPERTY "${alias_name}" TARGET "${target}")
 
     # If there is a leading alias, append the rest of the string
     # onto it and see if that's an existing node.
@@ -4470,7 +4520,7 @@ function(dt_path_internal var path)
       if (NOT "${slash_index}" EQUAL -1)
         string(SUBSTRING "${path}" "${slash_index}" -1 rest)
       endif()
-      dt_path_internal_exists(expanded_path_exists "${alias_path}${rest}")
+      dt_path_internal_exists(expanded_path_exists "${alias_path}${rest}" "${target}")
       if (expanded_path_exists)
         set(${var} "${alias_path}${rest}" PARENT_SCOPE)
         return()
@@ -4485,8 +4535,8 @@ endfunction()
 # Internal helper. Set 'var' to TRUE if a canonical path 'path' refers
 # to an existing node. Set it to FALSE otherwise. See
 # dt_path_internal for a definition and examples of 'canonical' paths.
-function(dt_path_internal_exists var path)
-  get_target_property(path_prop devicetree_target "DT_NODE|${path}")
+function(dt_path_internal_exists var path target)
+  get_target_property(path_prop "${target}" "DT_NODE|${path}")
   if (path_prop)
     set(${var} TRUE PARENT_SCOPE)
   else()

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -3816,6 +3816,10 @@ endfunction()
 #   alias at the beginning of a path interchangeably with the full
 #   path to the aliased node in these functions. The usage comments
 #   will make this clear in each case.
+#
+# - These methods are also available to sysbuild. To retrieve the DT
+#   information of some <image>, after its CMake configuration step,
+#   the dt_* function call must include a "TARGET <image>" argument.
 
 # Usage:
 #   dt_nodelabel(<var> NODELABEL <label> [REQUIRED] [TARGET <target>])

--- a/scripts/dts/gen_dts_cmake.py
+++ b/scripts/dts/gen_dts_cmake.py
@@ -11,13 +11,12 @@ That data can then be used in the rest of the build system.
 
 The generated CMake file looks like this:
 
-  add_custom_target(devicetree_target)
-  set_target_properties(devicetree_target PROPERTIES
+  set_target_properties(${DEVICETREE_TARGET} PROPERTIES
                         "DT_PROP|/soc|compatible" "vnd,soc;")
   ...
 
-It defines a special CMake target, and saves various values in the
-devicetree as CMake target properties.
+It takes an input variable - DEVICETREE_TARGET - and saves various
+values in the devicetree as properties of this CMake target.
 
 Be careful:
 
@@ -170,15 +169,12 @@ def main():
         cmake_comp = f'DT_COMP|{comp}'
         cmake_props.append(f'"{cmake_comp}" "{cmake_path}"')
 
+    cmake_props = map(
+        'set_target_properties(${{DEVICETREE_TARGET}} PROPERTIES {})'.format,
+        cmake_props
+    )
     with open(args.cmake_out, "w", encoding="utf-8") as cmake_file:
-        print('add_custom_target(devicetree_target)', file=cmake_file)
-        print(file=cmake_file)
-
-        for prop in cmake_props:
-            print(
-                f'set_target_properties(devicetree_target PROPERTIES {prop})',
-                file=cmake_file
-            )
+        print("\n".join(cmake_props), file=cmake_file)
 
 
 if __name__ == "__main__":

--- a/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
@@ -512,6 +512,7 @@ function(ExternalZephyrProject_Cmake)
   endif()
   load_cache(IMAGE ${ZCMAKE_APPLICATION} BINARY_DIR ${BINARY_DIR})
   import_kconfig(CONFIG_ ${BINARY_DIR}/zephyr/.config TARGET ${ZCMAKE_APPLICATION})
+  zephyr_dt_import(EDT_PICKLE_FILE ${BINARY_DIR}/zephyr/edt.pickle TARGET ${ZCMAKE_APPLICATION})
 
   # This custom target informs CMake how the BYPRODUCTS are generated if a target
   # depends directly on the BYPRODUCT instead of depending on the image target.


### PR DESCRIPTION
Make the image devicetrees available to sysbuild for advanced use cases.

This is done by calling `zephyr_dt_import` on each image target. The DT
target properties are all expected to be prefixed with `DT_`, so there
should be no conflicts.

Thus, the DT contents of a given `<image>` can be retrieved using e.g.:

    dt_nodelabel(<var> NODELABEL <label> TARGET <image>)

as noted in `extensions.cmake`.