### PR TITLE
soc: nordic: Resolve z_arm_platform_init in the linker generator

### DIFF
--- a/soc/nordic/common/CMakeLists.txt
+++ b/soc/nordic/common/CMakeLists.txt
@@ -3,7 +3,13 @@
 
 add_subdirectory_ifdef(CONFIG_RISCV_CORE_NORDIC_VPR vpr)
 
-zephyr_linker_sources_ifdef(CONFIG_ARM SECTIONS arm_platform_init.ld)
+if(CONFIG_ARM)
+  # Let SystemInit() be called in place of z_arm_platform_init() by default.
+  zephyr_linker_symbol(SYMBOL z_arm_platform_init EXPR "@SystemInit@")
+
+  # This file is used when the CMake linker script generator is disabled.
+  zephyr_linker_sources(SECTIONS arm_platform_init.ld)
+endif()
 
 zephyr_library_sources_ifdef(CONFIG_POWEROFF poweroff.c)
 


### PR DESCRIPTION
Fixes #72673
Follow-up to #70977 and #71590

The CMake linker generator doesn't have an API equivalent to `PROVIDE`, but the existing `zephyr_linker_symbol()` function should do just fine. It still lets us set `z_arm_platform_init = SystemInit` and thus keep the reduced ROM space.