### PR TITLE
arch: isr_tables: Make isr_tables an object library

### DIFF
--- a/arch/common/CMakeLists.txt
+++ b/arch/common/CMakeLists.txt
@@ -86,10 +86,10 @@ if (DEFINED CONFIG_ARM OR DEFINED CONFIG_X86 OR DEFINED CONFIG_ARM64
 endif()
 
 
-# isr_tables is a normal CMake library and not a zephyr_library because it
-# should not be --whole-archive'd
+# isr_tables is not a zephyr_library, because it shouldn't be --whole-archive'd,
+# but we should always link with isr_tables.c.obj regardless.
 if (CONFIG_GEN_ISR_TABLES)
-  add_library(isr_tables
+  add_library(isr_tables OBJECT
     isr_tables.c
   )
 


### PR DESCRIPTION
Given that `isr_tables` cannot use `--whole-archive`, the ISR table sections are at risk of being dropped by the linker. Example:
```
$ west build -b qemu_cortex_m3 -DCONFIG_GEN_SW_ISR_TABLE=n
...
gen_isr_tables.py: error: Cannot find the intlist section!
```
Even when the sections are marked as used, they can be discarded when linking against `libisr_tables.a`. This is fixed by changing the CMake library type from `STATIC` (default) to `OBJECT`, which lets us link with `isr_tables.c.obj` directly and keep the required sections.