### PR TITLE
doc: board_porting: Fix Kconfig.defconfig example

### DIFF
--- a/doc/hardware/porting/board_porting.rst
+++ b/doc/hardware/porting/board_porting.rst
@@ -571,13 +571,6 @@ files for a board named ``plank``:
 
      if BOARD_PLANK
 
-     # Always set CONFIG_BOARD here. This isn't meant to be customized,
-     # but is set as a "default" due to Kconfig language restrictions.
-     config BOARD
-             default "plank"
-
-     # Other options you want enabled by default go next. Examples:
-
      config FOO
              default y
 


### PR DESCRIPTION
The part that says "Always set CONFIG_BOARD here" is outdated. In HWMv2, CONFIG_BOARD is set by the build system, and we don't want to encourage users to set it manually.