### PR TITLE
arch: call arch_smp_init() directly, do not use SYS_INIT

### DIFF
--- a/arch/arc/core/smp.c
+++ b/arch/arc/core/smp.c
@@ -195,5 +195,4 @@ int arch_smp_init(void)
 
 	return 0;
 }
-SYS_INIT(arch_smp_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 #endif

--- a/arch/arm/core/cortex_a_r/smp.c
+++ b/arch/arm/core/cortex_a_r/smp.c
@@ -268,6 +268,4 @@ int arch_smp_init(void)
 	return 0;
 }
 
-SYS_INIT(arch_smp_init, PRE_KERNEL_2, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
-
 #endif

--- a/arch/arm64/core/smp.c
+++ b/arch/arm64/core/smp.c
@@ -311,6 +311,5 @@ int arch_smp_init(void)
 
 	return 0;
 }
-SYS_INIT(arch_smp_init, PRE_KERNEL_2, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 
 #endif

--- a/arch/riscv/core/smp.c
+++ b/arch/riscv/core/smp.c
@@ -172,5 +172,4 @@ int arch_smp_init(void)
 
 	return 0;
 }
-SYS_INIT(arch_smp_init, PRE_KERNEL_2, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 #endif /* CONFIG_SMP */

--- a/arch/x86/core/intel64/smp.c
+++ b/arch/x86/core/intel64/smp.c
@@ -38,5 +38,3 @@ void arch_sched_broadcast_ipi(void)
 {
 	z_loapic_ipi(0, LOAPIC_ICR_IPI_OTHERS, CONFIG_SCHED_IPI_VECTOR);
 }
-
-SYS_INIT(arch_smp_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/arch/x86/core/prep_c.c
+++ b/arch/x86/core/prep_c.c
@@ -73,10 +73,6 @@ FUNC_NORETURN void z_prep_c(void *arg)
 	}
 #endif
 
-#if defined(CONFIG_SMP)
-	arch_smp_init();
-#endif
-
 	z_cstart();
 	CODE_UNREACHABLE;
 }

--- a/arch/xtensa/core/smp.c
+++ b/arch/xtensa/core/smp.c
@@ -19,3 +19,13 @@ void arch_spin_relax(void)
 #undef NOP1
 }
 #endif /* CONFIG_XTENSA_MORE_SPIN_RELAX_NOPS */
+
+
+/**
+ * init for multi-core/smp is done on the SoC level. Add this here for
+ * compatibility with other SMP systems.
+ */
+int arch_smp_init(void)
+{
+	return 0;
+}

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -660,6 +660,9 @@ FUNC_NORETURN void z_cstart(void)
 
 	/* perform basic hardware initialization */
 	z_sys_init_run_level(INIT_LEVEL_PRE_KERNEL_1);
+#if defined(CONFIG_SMP)
+	arch_smp_init();
+#endif
 	z_sys_init_run_level(INIT_LEVEL_PRE_KERNEL_2);
 
 #ifdef CONFIG_STACK_CANARIES


### PR DESCRIPTION
Move this to a call in the init process. arch_* calls are no services
and should be called consistently during initialization.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
