### PR TITLE
Bluetooth: BAP: Fix missing len increment when merging non-LC3 data

### DIFF
--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -622,6 +622,7 @@ static bool base_subgroup_bis_index_cb(const struct bt_bap_base_subgroup_bis *bi
 
 		memcpy(&sink_bis->codec_cfg.data[sink_bis->codec_cfg.data_len], bis->data,
 		       bis->data_len);
+		sink_bis->codec_cfg.data_len += bis->data_len;
 	}
 #endif /* CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0 */
 


### PR DESCRIPTION
If we are merging subgroup and BIS codec configuration data for a codec other than LC3, then we just append them, but did not properly update the length.