### PR TITLE
tests: drivers: gpio: Add nrf54h20dk/nrf54h20/cpuppr targets

### DIFF
--- a/tests/drivers/gpio/gpio_api_1pin/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
+++ b/tests/drivers/gpio/gpio_api_1pin/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		led0 = &led0;
+    };
+
+    leds {
+	compatible = "gpio-leds";
+
+	led0: led_0 {
+		gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
+          };
+    };
+};
+
+&gpio0 {
+    status = "okay";
+};
+
+&gpiote130 {
+    status = "okay";
+    owned-channels = < 0 >;
+};

--- a/tests/drivers/gpio/gpio_api_1pin/boards/nrf54h20dk_nrf54h20_vpr_launcher.toml
+++ b/tests/drivers/gpio/gpio_api_1pin/boards/nrf54h20dk_nrf54h20_vpr_launcher.toml
@@ -1,0 +1,2 @@
+[gpio_secure_0]
+PIN_8 = "NonSecure"

--- a/tests/drivers/gpio/gpio_api_1pin/sysbuild/vpr_launcher/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/gpio/gpio_api_1pin/sysbuild/vpr_launcher/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,5 @@
+&gpiote130 {
+	owned-channels = < 0 >;
+	nonsecure-channels = < 0 >;
+	child-owned-channels = < 0 >;
+};

--- a/tests/drivers/gpio/gpio_api_1pin/sysbuild/vpr_launcher/prj.conf
+++ b/tests/drivers/gpio/gpio_api_1pin/sysbuild/vpr_launcher/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_NRF_REGTOOL_EXTRA_GENERATE_ARGS="-i ../../../tests/drivers/gpio/gpio_api_1pin/boards/nrf54h20dk_nrf54h20_vpr_launcher.toml"

--- a/tests/drivers/gpio/gpio_api_1pin/testcase.yaml
+++ b/tests/drivers/gpio/gpio_api_1pin/testcase.yaml
@@ -12,3 +12,17 @@ tests:
       - neorv32
       - hifive1  # see #69350
     filter: dt_enabled_alias_with_parent_compat("led0", "gpio-leds")
+  drivers.gpio.1pin.nrf54h20dk_nrf54h20_cpuppr:
+    tags:
+      - drivers
+      - gpio
+    depends_on: gpio
+    # Fix exclude when we can exclude just sim run
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuppr
+    sysbuild: true
+    extra_configs:
+      # Disable asserts to fit in limited code memory
+      - CONFIG_ASSERT=n
+    extra_args:
+      - SB_CONFIG_VPR_LAUNCHER=y

--- a/tests/drivers/gpio/gpio_basic_api/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "nrf54h20dk_nrf54h20_common.dtsi"

--- a/tests/drivers/gpio/gpio_basic_api/boards/nrf54h20dk_nrf54h20_vpr_launcher.toml
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nrf54h20dk_nrf54h20_vpr_launcher.toml
@@ -1,0 +1,7 @@
+[gpio_secure_0]
+PIN_6 = "NonSecure"
+PIN_7 = "NonSecure"
+
+[gpio_own_0]
+PIN_6 = "Own"
+PIN_7 = "Own"

--- a/tests/drivers/gpio/gpio_basic_api/sysbuild/vpr_launcher/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/sysbuild/vpr_launcher/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,13 @@
+&gpiote130 {
+	owned-channels = < 0 1 >;
+	nonsecure-channels = < 0 1 >;
+	child-owned-channels = < 0 1 >;
+};
+
+/ {
+	resources {
+		compatible = "test-gpio-basic-api";
+		out-gpios = <&gpio0 6 0>;
+		in-gpios = <&gpio0 7 0>;
+	};
+};

--- a/tests/drivers/gpio/gpio_basic_api/sysbuild/vpr_launcher/prj.conf
+++ b/tests/drivers/gpio/gpio_basic_api/sysbuild/vpr_launcher/prj.conf
@@ -1,0 +1,2 @@
+CONFIG_NRF_REGTOOL_EXTRA_GENERATE_ARGS="-i ../../../tests/drivers/gpio/gpio_basic_api/boards/nrf54h20dk_nrf54h20_vpr_launcher.toml"
+CONFIG_NRF_REGTOOL_VERBOSITY=2

--- a/tests/drivers/gpio/gpio_basic_api/testcase.yaml
+++ b/tests/drivers/gpio/gpio_basic_api/testcase.yaml
@@ -30,3 +30,18 @@ tests:
     extra_args: "DTC_OVERLAY_FILE=boards/frdm_ke17z_fgpio.overlay"
     harness_config:
       fixture: fgpio_loopback
+
+  drivers.gpio.2pin.nrf54h20dk_nrf54h20_cpuppr:
+    tags:
+      - drivers
+      - gpio
+    depends_on: gpio
+    # Fix exclude when we can exclude just sim run
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuppr
+    sysbuild: true
+    extra_configs:
+      # Disable asserts to fit in limited code memory
+      - CONFIG_ASSERT=n
+    extra_args:
+      - SB_CONFIG_VPR_LAUNCHER=y


### PR DESCRIPTION
Add overlays for cpuppr targets in `gpio_basic_api` and `gpio_api_1pin`.