### PR TITLE
west.yml: hal_stm32: STM32Cube packages update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -234,7 +234,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 8eaef657413d07550a583ec13049684ec33d08c8
+      revision: 6443e5c4d391c3e9e283c5728cd07d855e663965
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
- Update stm32f0 to cube version V1.11.5
- Update stm32f3 to cube version V1.11.5
- Update stm32f7 to cube version V1.17.2
- Update stm32wb to cube version V1.19.1

Update of lib/stm32/stm32wb package to version V1.19.1