### PR TITLE
doc: Add build env variable to know if doxygen has run

### DIFF
--- a/doc/_extensions/zephyr/api_overview.py
+++ b/doc/_extensions/zephyr/api_overview.py
@@ -141,6 +141,9 @@ def sync_contents(app: Sphinx) -> None:
     else:
         doxygen_out_dir = Path(app.outdir) / "_doxygen"
 
+    if not app.env.doxygen_input_changed:
+        return
+
     doxygen_xml_dir = doxygen_out_dir / "xml"
     groups = parse_xml_dir(doxygen_xml_dir)
 

--- a/doc/_extensions/zephyr/doxyrunner.py
+++ b/doc/_extensions/zephyr/doxyrunner.py
@@ -362,8 +362,8 @@ def doxygen_build(app: Sphinx) -> None:
     )
 
     logger.info("Checking if Doxygen needs to be run...")
-    changed = doxygen_input_has_changed(app.env, doxyfile)
-    if not changed:
+    app.env.doxygen_input_changed = doxygen_input_has_changed(app.env, doxyfile)
+    if not app.env.doxygen_input_changed:
         logger.info("Doxygen build will be skipped (no changes)!")
         return
 


### PR DESCRIPTION
Some extensions may be able to run faster if they can check if Doxygen contents has changed from one build to the other