### PR TITLE
arch: riscv: support disabling SW ISR table generation

### DIFF
--- a/arch/riscv/core/CMakeLists.txt
+++ b/arch/riscv/core/CMakeLists.txt
@@ -6,7 +6,6 @@ zephyr_library_sources(
   cpu_idle.c
   fatal.c
   irq_manage.c
-  isr.S
   prep_c.c
   reboot.c
   reset.S
@@ -21,6 +20,7 @@ endif ()
 zephyr_library_sources_ifdef(CONFIG_FPU_SHARING fpu.c fpu.S)
 zephyr_library_sources_ifdef(CONFIG_DEBUG_COREDUMP coredump.c)
 zephyr_library_sources_ifdef(CONFIG_IRQ_OFFLOAD irq_offload.c)
+zephyr_library_sources_ifdef(CONFIG_GEN_SW_ISR_TABLE isr.S)
 zephyr_library_sources_ifdef(CONFIG_RISCV_PMP pmp.c pmp.S)
 zephyr_library_sources_ifdef(CONFIG_THREAD_LOCAL_STORAGE tls.c)
 zephyr_library_sources_ifdef(CONFIG_USERSPACE userspace.S)

--- a/soc/common/riscv-privileged/vector.S
+++ b/soc/common/riscv-privileged/vector.S
@@ -12,7 +12,9 @@ GTEXT(__start)
 
 /* imports */
 GTEXT(__initialize)
+#if defined(CONFIG_GEN_SW_ISR_TABLE)
 GTEXT(_isr_wrapper)
+#endif
 
 SECTION_FUNC(vectors, __start)
 #if defined(CONFIG_RISCV_GP)
@@ -35,7 +37,11 @@ SECTION_FUNC(vectors, __start)
 	 * mtvec.base must be aligned to 64 bytes (this is done using
 	 * CONFIG_RISCV_TRAP_HANDLER_ALIGNMENT)
 	 */
+#if defined(CONFIG_GEN_SW_ISR_TABLE)
 	la t0, _isr_wrapper
+#else
+	add t0, zero, zero
+#endif
 	addi t0, t0, 0x03 /* Enable CLIC vectored mode by setting LSB */
 	csrw mtvec, t0
 


### PR DESCRIPTION
Minimal changes needed to build and run nRF54L15 FLPR with disabled SW ISR table generation.