### PR TITLE
Add marwaiehm-st as STM32 collaborator and file clean up

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -26,8 +26,6 @@
 /soc/arm/infineon_xmc/                    @parthitce
 /soc/arm/silabs_exx32/efm32pg1b/          @rdmeneze
 /soc/arm/silabs_exx32/efr32mg21/          @l-alfred
-/soc/arm/st_stm32/                        @erwango
-/soc/arm/st_stm32/*/power.c               @FRASTM
 /soc/arm/st_stm32/stm32mp1/               @arnopo
 /soc/arm/st_stm32/stm32h7/*stm32h735*     @benediktibk
 /soc/arm/st_stm32/stm32l4/*stm32l451*     @benediktibk
@@ -65,7 +63,6 @@
 /boards/arm/cy8ckit_062s4/                @DaWei8823
 /boards/arm/cy8ckit_062_wifi_bt/          @ifyall @npal-cy
 /boards/arm/cy8cproto_062_4343w/          @ifyall @npal-cy
-/boards/arm/disco_l475_iot1/              @erwango
 /boards/arm/efm32pg_stk3401a/             @rdmeneze
 /boards/arm/faze/                         @mbittan @simonguinot
 /boards/arm/frdm*/                        @mmahadevan108 @dleach02
@@ -82,7 +79,6 @@
 /boards/arm/msp_exp432p401r_launchxl/     @Mani-Sadhasivam
 /boards/arm/npcx7m6fb_evb/                @MulinChao @ChiHuaL
 /boards/arm/nrf*/                         @carlescufi @lemrey
-/boards/arm/nucleo*/                      @erwango @ABOSTM @FRASTM
 /boards/arm/nucleo_f401re/                @idlethread
 /boards/arm/nuvoton_pfm_m487/             @ssekar15
 /boards/arm/qemu_cortex_a9/               @ibirnbaum
@@ -102,10 +98,8 @@
 /boards/arm/sensortile_box/               @avisconti
 /boards/arm/steval_fcu001v1/              @Navin-Sankar
 /boards/arm/stm32l1_disco/                @karlp
-/boards/arm/stm32*_disco/                 @erwango @ABOSTM @FRASTM
 /boards/arm/stm32h735g_disco/             @benediktibk
 /boards/arm/stm32f3_disco/                @ydamigos
-/boards/arm/stm32*_eval/                  @erwango @ABOSTM @FRASTM
 /boards/arm/rcar_*/                       @aaillet
 /boards/arm/ubx_bmd345eval_nrf52840/      @Navin-Sankar @brec-u-blox
 /boards/arm/nrf5340_audio_dk_nrf5340      @koffes @alexsven @erikrobstad @rick1082 @gWacey
@@ -149,7 +143,6 @@
 /drivers/*/*cc13xx_cc26xx*                @bwitherspoon
 /drivers/*/*gd32*                         @nandojve
 /drivers/*/*mcux*                         @mmahadevan108 @dleach02
-/drivers/*/*stm32*                        @erwango @ABOSTM @FRASTM
 /drivers/*/*native_posix*                 @aescolar @daor-oti
 /drivers/*/*lpc11u6x*                     @mbittan @simonguinot
 /drivers/*/*npcx*                         @MulinChao @ChiHuaL
@@ -228,7 +221,6 @@
 /drivers/gpio/*b91*                       @andy-liu-telink
 /drivers/gpio/*lmp90xxx*                  @henrikbrixandersen
 /drivers/gpio/*nct38xx*                   @MulinChao @ChiHuaL
-/drivers/gpio/*stm32*                     @erwango
 /drivers/gpio/*eos_s3*                    @fkokosinski @kgugala
 /drivers/gpio/*rcar*                      @aaillet
 /drivers/gpio/*esp32*                     @sylvioalves
@@ -371,7 +363,6 @@
 /drivers/timer/*xlnx_psttc*               @wjliang @stephanosio
 /drivers/timer/*cc13xx_cc26xx_rtc*        @vanti
 /drivers/timer/*cavs*                     @dcpleung
-/drivers/timer/*stm32_lptim*              @FRASTM
 /drivers/timer/*leon_gptimer*             @julius-barendt
 /drivers/timer/*mips_cp0*                 @frantony
 /drivers/timer/*rcar_cmt*                 @aaillet
@@ -421,7 +412,6 @@
 /dts/arm64/renesas/                       @lorc @xakep-amatop
 /dts/arm/quicklogic/                      @fkokosinski @kgugala
 /dts/arm/seeed_studio/                    @str4t0m
-/dts/arm/st/                              @erwango
 /dts/arm/st/h7/*stm32h735*                @benediktibk
 /dts/arm/st/l4/*stm32l451*                @benediktibk
 /dts/arm/ti/cc13?2*                       @bwitherspoon
@@ -475,7 +465,6 @@
 /dts/bindings/*/nxp*s32*                  @manuargue
 /dts/bindings/*/openisa*                  @dleach02
 /dts/bindings/*/raspberrypi*pico*         @yonsch
-/dts/bindings/*/st*                       @erwango
 /dts/bindings/sensor/ams*                 @alexanderwachter
 /dts/bindings/*/sifive*                   @mateusz-holenko @kgugala @pgielda
 /dts/bindings/*/andes*                    @cwshu @kevinwang821020 @jimmyzhe

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3615,6 +3615,7 @@ STM32 Platforms:
     - FRASTM
     - gautierg-st
     - GeorgeCGV
+    - marwaiehm-st
   files:
     - boards/st/
     - drivers/*/*stm32*.c
@@ -4472,6 +4473,7 @@ West:
     - ABOSTM
     - gautierg-st
     - Desvauxm-st
+    - marwaiehm-st
   files:
     - modules/Kconfig.stm32
   labels:

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4470,9 +4470,7 @@ West:
     - erwango
   collaborators:
     - FRASTM
-    - ABOSTM
     - gautierg-st
-    - Desvauxm-st
     - marwaiehm-st
   files:
     - modules/Kconfig.stm32


### PR DESCRIPTION
- Add @marwaiehm-st as STM32 collaborator.
- Clean up STM32 entries in MAINTAINERS and CODEOWNERS files