### PR TITLE
manifest: Update hal_silabs version

### DIFF
--- a/boards/silabs/efr32_thunderboard/doc/brd4184.rst
+++ b/boards/silabs/efr32_thunderboard/doc/brd4184.rst
@@ -181,7 +181,7 @@ blobs from the SiLabs HAL repository.
 
 .. code-block:: console
 
-   west blobs fetch silabs
+   west blobs fetch hal_silabs
 
 Then build the Zephyr kernel and a Bluetooth sample with the following
 command. The :ref:`bluetooth-observer-sample` sample application is used in

--- a/boards/silabs/efr32xg24_dk2601b/doc/index.rst
+++ b/boards/silabs/efr32xg24_dk2601b/doc/index.rst
@@ -157,7 +157,7 @@ blobs from the SiLabs HAL repository.
 
 .. code-block:: console
 
-   west blobs fetch silabs
+   west blobs fetch hal_silabs
 
 Then build the Zephyr kernel and a Bluetooth sample with the following
 command. The :ref:`bluetooth-observer-sample` sample application is used in

--- a/west.yml
+++ b/west.yml
@@ -224,7 +224,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: 0c39ee28be31c59a98ed490c3811f68caa1fcbd3
+      revision: a09dd1b82b24aa3060e162c0dfa40026c0dba450
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
Update the hal_silabs version. The only change is an added explicit name for the module, so that it behaves consistently with other HAL modules.