### PR TITLE
lib: change controlling expressions in if/while to Boolean

### DIFF
--- a/lib/crc/crc7_sw.c
+++ b/lib/crc/crc7_sw.c
@@ -8,7 +8,7 @@
 
 uint8_t crc7_be(uint8_t seed, const uint8_t *src, size_t len)
 {
-	while (len--) {
+	while (len-- != 0UL) {
 		uint8_t e = seed ^ *src++;
 		uint8_t f = e ^ (e >> 4) ^ (e >> 7);
 

--- a/lib/crc/crc8_sw.c
+++ b/lib/crc/crc8_sw.c
@@ -37,13 +37,13 @@ uint8_t crc8(const uint8_t *src, size_t len, uint8_t polynomial, uint8_t initial
 
 		for (j = 0; j < 8; j++) {
 			if (reversed) {
-				if (crc & 0x01) {
+				if ((crc & 0x01) != 0) {
 					crc = (crc >> 1) ^ polynomial;
 				} else {
 					crc >>= 1;
 				}
 			} else {
-				if (crc & 0x80) {
+				if ((crc & 0x80) != 0) {
 					crc = (crc << 1) ^ polynomial;
 				} else {
 					crc <<= 1;

--- a/lib/heap/heap.c
+++ b/lib/heap/heap.c
@@ -229,7 +229,7 @@ static chunkid_t alloc_chunk(struct z_heap *h, chunksz_t sz)
 	 * fragmentation waste of the order of the block allocated
 	 * only.
 	 */
-	if (b->next) {
+	if (b->next != 0U) {
 		chunkid_t first = b->next;
 		int i = CONFIG_SYS_HEAP_ALLOC_LOOPS;
 		do {

--- a/lib/libc/minimal/source/stdlib/strtol.c
+++ b/lib/libc/minimal/source/stdlib/strtol.c
@@ -117,7 +117,7 @@ long strtol(const char *nptr, char **endptr, register int base)
 	if (any < 0) {
 		acc = neg ? LONG_MIN : LONG_MAX;
 		errno = ERANGE;
-	} else if (neg) {
+	} else if (neg != 0) {
 		acc = -acc;
 	}
 

--- a/lib/libc/minimal/source/stdlib/strtoul.c
+++ b/lib/libc/minimal/source/stdlib/strtoul.c
@@ -96,7 +96,7 @@ unsigned long strtoul(const char *nptr, char **endptr, register int base)
 	if (any < 0) {
 		acc = ULONG_MAX;
 		errno = ERANGE;
-	} else if (neg) {
+	} else if (neg != 0) {
 		acc = -acc;
 	}
 	if (endptr != NULL) {

--- a/lib/libc/minimal/source/string/string.c
+++ b/lib/libc/minimal/source/string/string.c
@@ -92,7 +92,7 @@ char *strrchr(const char *s, int c)
 		if (*s == (char)c) {
 			match = (char *)s;
 		}
-	} while (*s++);
+	} while (*s++ != '\0');
 
 	return match;
 }

--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -979,7 +979,7 @@ static char *encode_float(double value,
 			/* Round only if the bit that would round is
 			 * set.
 			 */
-			if (fract & mask) {
+			if ((fract & mask) != 0ULL) {
 				fract += mask;
 			}
 		}
@@ -1160,7 +1160,7 @@ static char *encode_float(double value,
 
 	/* Round the value to the last digit being printed. */
 	uint64_t round = BIT64(59); /* 0.5 */
-	while (decimals--) {
+	while (decimals-- != 0) {
 		_ldiv10(&round);
 	}
 	fract += round;
@@ -1817,7 +1817,7 @@ int z_cbvprintf_impl(cbprintf_cb out, void *ctx, const char *fp,
 
 			OUTS(cp, bpe);
 		} else {
-			if (conv->altform_0c | conv->altform_0) {
+			if ((conv->altform_0c | conv->altform_0) != 0) {
 				OUTC('0');
 			}
 

--- a/lib/os/cbprintf_packaged.c
+++ b/lib/os/cbprintf_packaged.c
@@ -753,7 +753,7 @@ process_string:
 #endif
 
 	/* Store strings pointer locations of read only strings. */
-	if (s_ro_cnt) {
+	if (s_ro_cnt != 0U) {
 		for (i = 0; i < s_idx; i++) {
 			if (!(str_ptr_pos[i] & STR_POS_RO_FLAG)) {
 				continue;

--- a/lib/os/fdtable.c
+++ b/lib/os/fdtable.c
@@ -224,7 +224,7 @@ void *z_get_fd_obj_and_vtable(int fd, const struct fd_op_vtable **vtable,
 	entry = &fdtable[fd];
 	*vtable = entry->vtable;
 
-	if (lock) {
+	if (lock != NULL) {
 		*lock = &entry->lock;
 	}
 

--- a/lib/os/mpsc_pbuf.c
+++ b/lib/os/mpsc_pbuf.c
@@ -14,7 +14,7 @@
 			mpsc_state_print(buffer); \
 		} \
 	} \
-} while (0)
+} while (false)
 
 static inline void mpsc_state_print(struct mpsc_pbuf_buffer *buffer)
 {

--- a/lib/utils/onoff.c
+++ b/lib/utils/onoff.c
@@ -173,7 +173,7 @@ static void notify_one(struct onoff_manager *mgr,
 	onoff_client_callback cb =
 		(onoff_client_callback)sys_notify_finalize(&cli->notify, res);
 
-	if (cb) {
+	if (cb != NULL) {
 		cb(mgr, cli, state, res);
 	}
 }
@@ -643,7 +643,7 @@ int onoff_sync_finalize(struct onoff_sync_service *srv,
 
 	k_spin_unlock(&srv->lock, key);
 
-	if (cli) {
+	if (cli != NULL) {
 		/* Detect service mis-use: onoff does not callback on transition
 		 * to off, so no client should have been passed.
 		 */


### PR DESCRIPTION
Use `do { ... } while (false)` instead of `do { ... } while (0)`. 
Use comparisons with zero instead of implicitly testing integers. 
Use comparisons with NULL instead of implicitly testing pointers. 
Use comparisons with NUL instead of implicitly testing plain chars. 
Use `bool` instead of `int` to represent Boolean values. 
Use `while (true)` instead of `while (1)` to express infinite loops.

This corresponds to following coding guideline:

> The controlling expression of an if statement and the controlling expression of an iteration-statement shall have essentially Boolean type

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/5d02614e34a86b549c7707d3d9f0984bc3a5f22a