### PR TITLE
net: change controlling expressions in while to Boolean

### DIFF
--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -490,7 +490,7 @@ static void dbg_update_neighbor_lladdr_raw(uint8_t *new_lladdr,
 			net_sprint_ipv6_addr(dst),		\
 			net_pkt_iface(pkt),				\
 			net_if_get_by_iface(net_pkt_iface(pkt)));	\
-	} while (0)
+	} while (false)
 
 #define dbg_addr_recv(pkt_str, src, dst, pkt)	\
 	dbg_addr("Received", pkt_str, src, dst, pkt)
@@ -508,7 +508,7 @@ static void dbg_update_neighbor_lladdr_raw(uint8_t *new_lladdr,
 			net_sprint_ipv6_addr(target),	\
 			net_pkt_iface(pkt),				\
 			net_if_get_by_iface(net_pkt_iface(pkt)));	\
-	} while (0)
+	} while (false)
 
 #define dbg_addr_recv_tgt(pkt_str, src, dst, tgt, pkt)		\
 	dbg_addr_with_tgt("Received", pkt_str, src, dst, tgt, pkt)

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -130,7 +130,7 @@ static sys_slist_t timestamp_callbacks;
 			net_pkt_iface(pkt));				\
 									\
 		NET_ASSERT(pkt->frags);					\
-	} while (0)
+	} while (false)
 #else
 #define debug_check_packet(...)
 #endif /* CONFIG_NET_IF_LOG_LEVEL >= LOG_LEVEL_DBG */

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -263,7 +263,7 @@ void net_pkt_allocs_foreach(net_pkt_allocs_cb_t cb, void *user_data)
 			NET_ERR("**ERROR** frag %p not in use (%s:%s():%d)", \
 				frag, __FILE__, __func__, __LINE__);     \
 		}                                                       \
-	} while (0)
+	} while (false)
 
 const char *net_pkt_slab2str(struct k_mem_slab *slab)
 {

--- a/subsys/net/ip/route.c
+++ b/subsys/net/ip/route.c
@@ -258,7 +258,7 @@ static int nbr_nexthop_put(struct net_nbr *nbr)
 			net_sprint_ipv6_addr(dst),		\
 			net_sprint_ipv6_addr(naddr),	\
 			route->iface);					\
-	} } while (0)
+	} } while (false)
 
 /* Route was accessed, so place it in front of the routes list */
 static inline void update_route_access(struct net_route_entry *route)

--- a/subsys/net/ip/tp.c
+++ b/subsys/net/ip/tp.c
@@ -334,7 +334,7 @@ enum tp_type tp_msg_to_type(const char *s)
 		type = _type;		\
 		goto out;		\
 	}				\
-} while (0)
+} while (false)
 
 	is_tp(s, TP_COMMAND);
 	is_tp(s, TP_CONFIG_REQUEST);

--- a/subsys/net/ip/tp_priv.h
+++ b/subsys/net/ip/tp_priv.h
@@ -20,7 +20,7 @@ extern "C" {
 #define tp_err(fmt, args...) do {				\
 	printk("%s: Error: " fmt "\n", __func__, ## args);	\
 	k_oops();						\
-} while (0)
+} while (false)
 
 #define tp_assert(cond, fmt, args...) do {			\
 	if ((cond) == false) {					\
@@ -28,7 +28,7 @@ extern "C" {
 			__func__, #cond, ## args);		\
 		k_oops();					\
 	}							\
-} while (0)
+} while (false)
 
 #define is(_a, _b) (strcmp((_a), (_b)) == 0)
 #define ip_get(_x) ((struct net_ipv4_hdr *) net_pkt_ip_data((_x)))

--- a/subsys/net/lib/http/http_parser.c
+++ b/subsys/net/lib/http/http_parser.c
@@ -72,7 +72,7 @@ do {                                                                       \
 	if (!FOR##_mark) {                                                 \
 		FOR##_mark = p;                                            \
 	}                                                                  \
-} while (0)
+} while (false)
 
 /* Don't allow the total size of the HTTP headers (including the status
  * line) to exceed HTTP_MAX_HEADER_SIZE.  This check is here to protect

--- a/subsys/net/lib/http/http_parser_url.c
+++ b/subsys/net/lib/http/http_parser_url.c
@@ -44,7 +44,7 @@ do {                                                                       \
 	if (!FOR##_mark) {                                                 \
 		FOR##_mark = p;                                            \
 	}                                                                  \
-} while (0)
+} while (false)
 
 
 #ifdef HTTP_PARSER_STRICT

--- a/subsys/net/lib/mqtt/mqtt_internal.h
+++ b/subsys/net/lib/mqtt/mqtt_internal.h
@@ -115,14 +115,14 @@ extern "C" {
 		if ((param) == NULL) { \
 			return -EINVAL; \
 		} \
-	} while (0)
+	} while (false)
 
 #define NULL_PARAM_CHECK_VOID(param) \
 	do { \
 		if ((param) == NULL) { \
 			return; \
 		} \
-	} while (0)
+	} while (false)
 
 /** Buffer context to iterate over buffer. */
 struct buf_ctx {


### PR DESCRIPTION
Use `do { ... } while (false)` instead of `do { ... } while (0)`.

This corresponds to following coding guideline:

> The controlling expression of an if statement and the controlling expression of an iteration-statement shall have essentially Boolean type

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/5d02614e34a86b549c7707d3d9f0984bc3a5f22a