### PR TITLE
Bluetooth: Controller: Change condition in while to Boolean

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/debug.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/debug.h
@@ -103,7 +103,7 @@
 	do { \
 		DEBUG_PORT->DIRSET = DEBUG_PIN_MASK; \
 		DEBUG_PORT->OUTCLR = DEBUG_PIN_MASK; \
-	} while (0)
+	} while (false)
 
 #define DEBUG_CPU_SLEEP(flag) \
 	do { \
@@ -114,7 +114,7 @@
 			DEBUG_PORT->OUTCLR = DEBUG_PIN0; \
 			DEBUG_PORT->OUTSET = DEBUG_PIN0; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_TICKER_ISR(flag) \
 	do { \
@@ -125,7 +125,7 @@
 			DEBUG_PORT->OUTSET = DEBUG_PIN1; \
 			DEBUG_PORT->OUTCLR = DEBUG_PIN1; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_TICKER_TASK(flag) \
 	do { \
@@ -136,7 +136,7 @@
 			DEBUG_PORT->OUTSET = DEBUG_PIN1; \
 			DEBUG_PORT->OUTCLR = DEBUG_PIN1; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_TICKER_JOB(flag) \
 	do { \
@@ -147,7 +147,7 @@
 			DEBUG_PORT->OUTSET = DEBUG_PIN2; \
 			DEBUG_PORT->OUTCLR = DEBUG_PIN2; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_ISR(flag) \
 	do { \
@@ -158,7 +158,7 @@
 			DEBUG_PORT->OUTSET = DEBUG_PIN7; \
 			DEBUG_PORT->OUTCLR = DEBUG_PIN7; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_XTAL(flag) \
 	do { \
@@ -169,7 +169,7 @@
 			DEBUG_PORT->OUTSET = DEBUG_PIN8; \
 			DEBUG_PORT->OUTCLR = DEBUG_PIN8; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_ACTIVE(flag) \
 	do { \
@@ -180,7 +180,7 @@
 			DEBUG_PORT->OUTSET = DEBUG_PIN9; \
 			DEBUG_PORT->OUTCLR = DEBUG_PIN9; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_CLOSE(flag) \
 	do { \
@@ -190,7 +190,7 @@
 		} else { \
 			DEBUG_PORT->OUTCLR = DEBUG_CLOSE_MASK; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_PREPARE_A(flag) \
 	do { \
@@ -201,7 +201,7 @@
 			DEBUG_PORT->OUTCLR = DEBUG_PIN3; \
 			DEBUG_PORT->OUTSET = DEBUG_PIN3; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_START_A(flag) \
 	do { \
@@ -212,7 +212,7 @@
 			DEBUG_PORT->OUTCLR = DEBUG_PIN3; \
 			DEBUG_PORT->OUTSET = DEBUG_PIN3; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_CLOSE_A(flag) \
 	do { \
@@ -222,7 +222,7 @@
 		} else { \
 			DEBUG_PORT->OUTCLR = DEBUG_PIN3; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_PREPARE_S(flag) \
 	do { \
@@ -233,7 +233,7 @@
 			DEBUG_PORT->OUTCLR = DEBUG_PIN4; \
 			DEBUG_PORT->OUTSET = DEBUG_PIN4; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_START_S(flag) \
 	do { \
@@ -244,7 +244,7 @@
 			DEBUG_PORT->OUTCLR = DEBUG_PIN4; \
 			DEBUG_PORT->OUTSET = DEBUG_PIN4; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_CLOSE_S(flag) \
 	do { \
@@ -254,7 +254,7 @@
 		} else { \
 			DEBUG_PORT->OUTCLR = DEBUG_PIN4; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_PREPARE_O(flag) \
 	do { \
@@ -265,7 +265,7 @@
 			DEBUG_PORT->OUTCLR = DEBUG_PIN5; \
 			DEBUG_PORT->OUTSET = DEBUG_PIN5; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_START_O(flag) \
 	do { \
@@ -276,7 +276,7 @@
 			DEBUG_PORT->OUTCLR = DEBUG_PIN5; \
 			DEBUG_PORT->OUTSET = DEBUG_PIN5; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_CLOSE_O(flag) \
 	do { \
@@ -286,7 +286,7 @@
 		} else { \
 			DEBUG_PORT->OUTCLR = DEBUG_PIN5; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_PREPARE_M(flag) \
 	do { \
@@ -297,7 +297,7 @@
 			DEBUG_PORT->OUTCLR = DEBUG_PIN6; \
 			DEBUG_PORT->OUTSET = DEBUG_PIN6; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_START_M(flag) \
 	do { \
@@ -308,7 +308,7 @@
 			DEBUG_PORT->OUTCLR = DEBUG_PIN6; \
 			DEBUG_PORT->OUTSET = DEBUG_PIN6; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_CLOSE_M(flag) \
 	do { \
@@ -318,7 +318,7 @@
 		} else { \
 			DEBUG_PORT->OUTCLR = DEBUG_PIN6; \
 		} \
-	} while (0)
+	} while (false)
 
 #else
 #define DEBUG_INIT()

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -85,7 +85,7 @@ static uint8_t force_md_cnt;
 			if (force_md_cnt) { \
 				force_md_cnt--; \
 			} \
-		} while (0)
+		} while (false)
 
 #define FORCE_MD_CNT_GET() force_md_cnt
 
@@ -95,7 +95,7 @@ static uint8_t force_md_cnt;
 			    (trx_cnt >= ((CONFIG_BT_BUF_ACL_TX_COUNT) - 1))) { \
 				force_md_cnt = BT_CTLR_FORCE_MD_COUNT; \
 			} \
-		} while (0)
+		} while (false)
 
 #else /* !CONFIG_BT_CTLR_FORCE_MD_COUNT */
 #define FORCE_MD_CNT_INIT()

--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/debug.h
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/debug.h
@@ -102,7 +102,7 @@ extern const struct device *vega_debug_portd;
 		\
 		gpio_pin_set(DEBUG0_PORT, DEBUG0_PIN, 1); \
 		gpio_pin_set(DEBUG0_PORT, DEBUG0_PIN, 0); \
-	} while (0)
+	} while (false)
 
 #define DEBUG_CPU_SLEEP(flag) gpio_pin_set(DEBUG0_PORT, DEBUG0_PIN, flag)
 
@@ -126,7 +126,7 @@ extern const struct device *vega_debug_portd;
 			gpio_pin_set(DEBUG5_PORT, DEBUG5_PIN, flag); \
 			gpio_pin_set(DEBUG6_PORT, DEBUG6_PIN, flag); \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_PREPARE_A(flag) \
 		gpio_pin_set(DEBUG3_PORT, DEBUG3_PIN, flag)


### PR DESCRIPTION
Use `do { ... } while (false)` instead of `do { ... } while (0)`.

This corresponds to following coding guideline:
> The controlling expression of an if statement and the controlling expression of an iteration-statement shall have essentially Boolean type

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/5d02614e34a86b549c7707d3d9f0984bc3a5f22a