### PR TITLE
soc: xlnx: remove duplicate soc entry

### DIFF
--- a/soc/xlnx/zynq7000/soc.yml
+++ b/soc/xlnx/zynq7000/soc.yml
@@ -4,7 +4,6 @@ family:
   - name: xc7zxxx
     socs:
     - name: xc7z010
-    - name: xc7z010
     - name: xc7z015
     - name: xc7z020
     - name: xc7z030


### PR DESCRIPTION
xc7z010 is duplicated.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
