### PR TITLE
soc: atmel: sam: Add invalidate d-cache at z_arm_platform_init

### DIFF
--- a/soc/arm/atmel_sam/same70/soc.c
+++ b/soc/arm/atmel_sam/same70/soc.c
@@ -122,6 +122,7 @@ void z_arm_platform_init(void)
 	 * sys_cache*-functions can enable them, if requested by the
 	 * configuration.
 	 */
+	SCB_InvalidateDCache();
 	SCB_DisableDCache();
 
 	/*

--- a/soc/arm/atmel_sam/samv71/soc.c
+++ b/soc/arm/atmel_sam/samv71/soc.c
@@ -119,6 +119,7 @@ void z_arm_platform_init(void)
 	 * sys_cache*-functions can enable them, if requested by the
 	 * configuration.
 	 */
+	SCB_InvalidateDCache();
 	SCB_DisableDCache();
 
 	/*


### PR DESCRIPTION
Before that fix, the SOC was unable to boot properly. Starting turned directly into z_arm_usage_fault(). 

Fixes #73485

Signed-off-by: Sven Ginka <sven.ginka@gmail.com>
(cherry picked from commit c3d7b1c978f8b462dcbdda998dbaefa981b3d089)