### PR TITLE
drivers: display: ssd16xx: convert to MIPI DBI API

### DIFF
--- a/boards/phytec/reel_board/reel_board.dts
+++ b/boards/phytec/reel_board/reel_board.dts
@@ -46,6 +46,54 @@
 		pwm-led3 = &back_pwm_led;
 		watchdog0 = &wdt0;
 	};
+
+	mipi_dbi {
+		compatible = "zephyr,mipi-dbi-spi";
+		spi-dev = <&spi1>;
+		reset-gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
+		dc-gpios = <&gpio0 16 GPIO_ACTIVE_HIGH>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		ssd16xx: ssd16xxfb@0 {
+			compatible = "gooddisplay,gdeh0213b1", "solomon,ssd1673";
+			mipi-max-frequency = <4000000>;
+			reg = <0>;
+			width = <250>;
+			height = <122>;
+			busy-gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
+
+			full {
+				gdv = [10 0a];
+				sdv = [19];
+				vcom = <0xa8>;
+				border-waveform = <0x71>;
+				dummy-line = <0x1a>;
+				gate-line-width = <0x08>;
+				lut = [
+					22 55 AA 55 AA 55 AA 11
+					00 00 00 00 00 00 00 00
+					1E 1E 1E 1E 1E 1E 1E 1E
+					01 00 00 00 00
+				];
+			};
+
+			partial {
+				gdv = [10 0a];
+				sdv = [19];
+				vcom = <0xa8>;
+				border-waveform = <0x71>;
+				dummy-line = <0x1a>;
+				gate-line-width = <0x08>;
+				lut = [
+					18 00 00 00 00 00 00 00
+					00 00 00 00 00 00 00 00
+					0F 01 00 00 00 00 00 00
+					00 00 00 00 00
+				];
+			};
+		};
+	};
 };
 
 &spi1 {
@@ -56,44 +104,4 @@
 	pinctrl-0 = <&spi1_default>;
 	pinctrl-1 = <&spi1_sleep>;
 	pinctrl-names = "default", "sleep";
-	ssd16xx: ssd16xxfb@0 {
-		compatible = "gooddisplay,gdeh0213b1", "solomon,ssd1673";
-		spi-max-frequency = <4000000>;
-		reg = <0>;
-		width = <250>;
-		height = <122>;
-		reset-gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
-		dc-gpios = <&gpio0 16 GPIO_ACTIVE_LOW>;
-		busy-gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
-
-		full {
-			gdv = [10 0a];
-			sdv = [19];
-			vcom = <0xa8>;
-			border-waveform = <0x71>;
-			dummy-line = <0x1a>;
-			gate-line-width = <0x08>;
-			lut = [
-				22 55 AA 55 AA 55 AA 11
-				00 00 00 00 00 00 00 00
-				1E 1E 1E 1E 1E 1E 1E 1E
-				01 00 00 00 00
-			];
-		};
-
-		partial {
-			gdv = [10 0a];
-			sdv = [19];
-			vcom = <0xa8>;
-			border-waveform = <0x71>;
-			dummy-line = <0x1a>;
-			gate-line-width = <0x08>;
-			lut = [
-				18 00 00 00 00 00 00 00
-				00 00 00 00 00 00 00 00
-				0F 01 00 00 00 00 00 00
-				00 00 00 00 00
-			];
-		};
-	};
 };

--- a/boards/phytec/reel_board/reel_board_nrf52840_2.overlay
+++ b/boards/phytec/reel_board/reel_board_nrf52840_2.overlay
@@ -27,6 +27,91 @@
 	aliases {
 		watchdog0 = &wdt0;
 	};
+
+	mipi_dbi {
+		compatible = "zephyr,mipi-dbi-spi";
+		spi-dev = <&spi1>;
+		reset-gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
+		dc-gpios = <&gpio0 16 GPIO_ACTIVE_HIGH>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		ssd16xx: ssd16xxfb@0 {
+			compatible = "gooddisplay,gdeh0213b72", "solomon,ssd1675a";
+			mipi-max-frequency = <4000000>;
+			reg = <0>;
+			width = <250>;
+			height = <122>;
+			busy-gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
+
+			full {
+				gdv = [15];
+				sdv = [41 a8 32];
+				vcom = <0x26>;
+				border-waveform = <0x03>;
+				dummy-line = <0x30>;
+				gate-line-width = <0x0a>;
+				lut = [
+					/*
+					 * Waveform Composition
+					 *
+					 * There are 7 Voltage Source (VS) Level groups
+					 * n = {0,1,2...6}, each group contains
+					 * 4 phases x = {A,B,C,D}.
+					 * 2 bits represent the voltage in a phase:
+					 * 00 – VSS, 01 – VSH1, 10 – VSL, 11 - VSH2
+					 *
+					 * For example 0x80 represents sequence VSL-VSS-VSS-VSS,
+					 */
+					80 60 40 00 00 00 00 /* LUT0: BB: VS 0..6 */
+					10 60 20 00 00 00 00 /* LUT1: BW: VS 0..6 */
+					80 60 40 00 00 00 00 /* LUT2: WB: VS 0..6 */
+					10 60 20 00 00 00 00 /* LUT3: WW: VS 0..6 */
+					00 00 00 00 00 00 00 /* LUT4: VCOM: VS 0..6 */
+					/*
+					 * TPnx determines the length of each phase,
+					 * and RPn repeat count of a sequence.
+					 * TPnA, TPnB, TPnC, TPnD, RPn
+					 *
+					 * For example TP0A=3, TP0B=3, and RP0=2:
+					 * VS sequence                    : VSL-VSS-VSS-VSS
+					 * number of Gate Pulses (length) :  3   3   0   0
+					 * repeat count                   :        2
+					 */
+					03 03 00 00 02 /* TP0A TP0B TP0C TP0D RP0 */
+					09 09 00 00 02 /* TP1A TP1B TP1C TP1D RP1 */
+					03 03 00 00 02 /* TP2A TP2B TP2C TP2D RP2 */
+					00 00 00 00 00 /* TP3A TP3B TP3C TP3D RP3 */
+					00 00 00 00 00 /* TP4A TP4B TP4C TP4D RP4 */
+					00 00 00 00 00 /* TP5A TP5B TP5C TP5D RP5 */
+					00 00 00 00 00 /* TP6A TP6B TP6C TP6D RP6 */
+				];
+			};
+
+			partial {
+				gdv = [15];
+				sdv = [41 a8 32];
+				vcom = <0x26>;
+				border-waveform = <0x01>;
+				dummy-line = <0x30>;
+				gate-line-width = <0x0a>;
+				lut = [
+					00 00 00 00 00 00 00 /* LUT0: BB: VS0..6 */
+					80 00 00 00 00 00 00 /* LUT1: BW: VS0..6 */
+					40 00 00 00 00 00 00 /* LUT2: WB: VS0..6 */
+					80 00 00 00 00 00 00 /* LUT3: WW: VS0..6 */
+					00 00 00 00 00 00 00 /* LUT4: VCOM: VS0..6 */
+					0A 00 00 00 04 /* TP0A TP0B TP0C TP0D RP0 */
+					00 00 00 00 00 /* TP1A TP1B TP1C TP1D RP1 */
+					00 00 00 00 00 /* TP2A TP2B TP2C TP2D RP2 */
+					00 00 00 00 00 /* TP3A TP3B TP3C TP3D RP3 */
+					00 00 00 00 00 /* TP4A TP4B TP4C TP4D RP4 */
+					00 00 00 00 00 /* TP5A TP5B TP5C TP5D RP5 */
+					00 00 00 00 00 /* TP6A TP6B TP6C TP6D RP6 */
+				];
+			};
+		};
+	};
 };
 
 &spi1 {
@@ -37,81 +122,4 @@
 	pinctrl-0 = <&spi1_default>;
 	pinctrl-1 = <&spi1_sleep>;
 	pinctrl-names = "default", "sleep";
-	ssd16xx: ssd16xxfb@0 {
-		compatible = "gooddisplay,gdeh0213b72", "solomon,ssd1675a";
-		spi-max-frequency = <4000000>;
-		reg = <0>;
-		width = <250>;
-		height = <122>;
-		reset-gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
-		dc-gpios = <&gpio0 16 GPIO_ACTIVE_LOW>;
-		busy-gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
-
-		full {
-			gdv = [15];
-			sdv = [41 a8 32];
-			vcom = <0x26>;
-			border-waveform = <0x03>;
-			dummy-line = <0x30>;
-			gate-line-width = <0x0a>;
-			lut = [
-				/*
-				 * Waveform Composition
-				 *
-				 * There are 7 Voltage Source (VS) Level groups
-				 * n = {0,1,2...6}, each group contains
-				 * 4 phases x = {A,B,C,D}.
-				 * 2 bits represent the voltage in a phase:
-				 * 00 – VSS, 01 – VSH1, 10 – VSL, 11 - VSH2
-				 *
-				 * For example 0x80 represents sequence VSL-VSS-VSS-VSS,
-				 */
-				80 60 40 00 00 00 00 /* LUT0: BB: VS 0..6 */
-				10 60 20 00 00 00 00 /* LUT1: BW: VS 0..6 */
-				80 60 40 00 00 00 00 /* LUT2: WB: VS 0..6 */
-				10 60 20 00 00 00 00 /* LUT3: WW: VS 0..6 */
-				00 00 00 00 00 00 00 /* LUT4: VCOM: VS 0..6 */
-				/*
-				 * TPnx determines the length of each phase,
-				 * and RPn repeat count of a sequence.
-				 * TPnA, TPnB, TPnC, TPnD, RPn
-				 *
-				 * For example TP0A=3, TP0B=3, and RP0=2:
-				 * VS sequence                    : VSL-VSS-VSS-VSS
-				 * number of Gate Pulses (length) :  3   3   0   0
-				 * repeat count                   :        2
-				 */
-				03 03 00 00 02 /* TP0A TP0B TP0C TP0D RP0 */
-				09 09 00 00 02 /* TP1A TP1B TP1C TP1D RP1 */
-				03 03 00 00 02 /* TP2A TP2B TP2C TP2D RP2 */
-				00 00 00 00 00 /* TP3A TP3B TP3C TP3D RP3 */
-				00 00 00 00 00 /* TP4A TP4B TP4C TP4D RP4 */
-				00 00 00 00 00 /* TP5A TP5B TP5C TP5D RP5 */
-				00 00 00 00 00 /* TP6A TP6B TP6C TP6D RP6 */
-			];
-		};
-
-		partial {
-			gdv = [15];
-			sdv = [41 a8 32];
-			vcom = <0x26>;
-			border-waveform = <0x01>;
-			dummy-line = <0x30>;
-			gate-line-width = <0x0a>;
-			lut = [
-				00 00 00 00 00 00 00 /* LUT0: BB: VS0..6 */
-				80 00 00 00 00 00 00 /* LUT1: BW: VS0..6 */
-				40 00 00 00 00 00 00 /* LUT2: WB: VS0..6 */
-				80 00 00 00 00 00 00 /* LUT3: WW: VS0..6 */
-				00 00 00 00 00 00 00 /* LUT4: VCOM: VS0..6 */
-				0A 00 00 00 04 /* TP0A TP0B TP0C TP0D RP0 */
-				00 00 00 00 00 /* TP1A TP1B TP1C TP1D RP1 */
-				00 00 00 00 00 /* TP2A TP2B TP2C TP2D RP2 */
-				00 00 00 00 00 /* TP3A TP3B TP3C TP3D RP3 */
-				00 00 00 00 00 /* TP4A TP4B TP4C TP4D RP4 */
-				00 00 00 00 00 /* TP5A TP5B TP5C TP5D RP5 */
-				00 00 00 00 00 /* TP6A TP6B TP6C TP6D RP6 */
-			];
-		};
-	};
 };

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0154a07.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0154a07.overlay
@@ -10,27 +10,32 @@
 	chosen {
 		zephyr,display = &ssd16xx_waveshare_epaper_gdeh0154a07;
 	};
-};
 
-&arduino_spi {
-	ssd16xx_waveshare_epaper_gdeh0154a07: ssd16xxfb@0 {
-		compatible = "gooddisplay,gdeh0154a07", "solomon,ssd1681";
-		spi-max-frequency = <4000000>;
-		reg = <0>;
-		width = <200>;
-		height = <200>;
-		dc-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>;	/* D9 */
+	mipi_dbi_waveshare_epaper_gdeh0154a07 {
+		compatible = "zephyr,mipi-dbi-spi";
+		spi-dev = <&arduino_spi>;
+		dc-gpios = <&arduino_header 15 GPIO_ACTIVE_HIGH>;	/* D9 */
 		reset-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>;	/* D8 */
-		busy-gpios = <&arduino_header 13 GPIO_ACTIVE_HIGH>;	/* D7 */
+		#address-cells = <1>;
+		#size-cells = <0>;
 
-		tssv = <0x80>;
+		ssd16xx_waveshare_epaper_gdeh0154a07: ssd16xxfb@0 {
+			compatible = "gooddisplay,gdeh0154a07", "solomon,ssd1681";
+			mipi-max-frequency = <4000000>;
+			reg = <0>;
+			width = <200>;
+			height = <200>;
+			busy-gpios = <&arduino_header 13 GPIO_ACTIVE_HIGH>;	/* D7 */
 
-		full {
-			border-waveform = <0x05>;
-		};
+			tssv = <0x80>;
 
-		partial {
-			border-waveform = <0x3c>;
+			full {
+				border-waveform = <0x05>;
+			};
+
+			partial {
+				border-waveform = <0x3c>;
+			};
 		};
 	};
 };

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0213b1.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0213b1.overlay
@@ -10,47 +10,52 @@
 	chosen {
 		zephyr,display = &ssd16xx_waveshare_epaper_gdeh0213b1;
 	};
-};
 
-&arduino_spi {
-	ssd16xx_waveshare_epaper_gdeh0213b1: ssd16xxfb@0 {
-		compatible = "gooddisplay,gdeh0213b1", "solomon,ssd1673";
-		spi-max-frequency = <4000000>;
-		reg = <0>;
-		width = <250>;
-		height = <120>;
-		dc-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>;	/* D9 */
+	mipi_dbi_waveshare_epaper_gdeh0213b1 {
+		compatible = "zephyr,mipi-dbi-spi";
+		spi-dev = <&arduino_spi>;
+		dc-gpios = <&arduino_header 15 GPIO_ACTIVE_HIGH>;	/* D9 */
 		reset-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>;	/* D8 */
-		busy-gpios = <&arduino_header 13 GPIO_ACTIVE_HIGH>;	/* D7 */
+		#address-cells = <1>;
+		#size-cells = <0>;
 
-		full {
-			gdv = [10 0a];
-			sdv = [19];
-			vcom = <0xa8>;
-			border-waveform = <0x71>;
-			dummy-line = <0x1a>;
-			gate-line-width = <0x08>;
-			lut = [
-				22 55 AA 55 AA 55 AA 11
-				00 00 00 00 00 00 00 00
-				1E 1E 1E 1E 1E 1E 1E 1E
-				01 00 00 00 00
-			];
-		};
+		ssd16xx_waveshare_epaper_gdeh0213b1: ssd16xxfb@0 {
+			compatible = "gooddisplay,gdeh0213b1", "solomon,ssd1673";
+			mipi-max-frequency = <4000000>;
+			reg = <0>;
+			width = <250>;
+			height = <120>;
+			busy-gpios = <&arduino_header 13 GPIO_ACTIVE_HIGH>;	/* D7 */
 
-		partial {
-			gdv = [10 0a];
-			sdv = [19];
-			vcom = <0xa8>;
-			border-waveform = <0x71>;
-			dummy-line = <0x1a>;
-			gate-line-width = <0x08>;
-			lut = [
-				18 00 00 00 00 00 00 00
-				00 00 00 00 00 00 00 00
-				0F 01 00 00 00 00 00 00
-				00 00 00 00 00
-			];
+			full {
+				gdv = [10 0a];
+				sdv = [19];
+				vcom = <0xa8>;
+				border-waveform = <0x71>;
+				dummy-line = <0x1a>;
+				gate-line-width = <0x08>;
+				lut = [
+					22 55 AA 55 AA 55 AA 11
+					00 00 00 00 00 00 00 00
+					1E 1E 1E 1E 1E 1E 1E 1E
+					01 00 00 00 00
+				];
+			};
+
+			partial {
+				gdv = [10 0a];
+				sdv = [19];
+				vcom = <0xa8>;
+				border-waveform = <0x71>;
+				dummy-line = <0x1a>;
+				gate-line-width = <0x08>;
+				lut = [
+					18 00 00 00 00 00 00 00
+					00 00 00 00 00 00 00 00
+					0F 01 00 00 00 00 00 00
+					00 00 00 00 00
+				];
+			};
 		};
 	};
 };

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0213b72.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0213b72.overlay
@@ -10,63 +10,68 @@
 	chosen {
 		zephyr,display = &ssd16xx_waveshare_epaper_gdeh0213b72;
 	};
-};
 
-&arduino_spi {
-	ssd16xx_waveshare_epaper_gdeh0213b72: ssd16xxfb@0 {
-		compatible = "gooddisplay,gdeh0213b72", "solomon,ssd1675a";
-		spi-max-frequency = <4000000>;
-		reg = <0>;
-		width = <250>;
-		height = <120>;
-		dc-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>;	/* D9 */
+	mipi_dbi_waveshare_epaper_gdeh0213b72 {
+		compatible = "zephyr,mipi-dbi-spi";
+		spi-dev = <&arduino_spi>;
+		dc-gpios = <&arduino_header 15 GPIO_ACTIVE_HIGH>;	/* D9 */
 		reset-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>;	/* D8 */
-		busy-gpios = <&arduino_header 13 GPIO_ACTIVE_HIGH>;	/* D7 */
+		#address-cells = <1>;
+		#size-cells = <0>;
 
-		full {
-			gdv = [15];
-			sdv = [41 a8 32];
-			vcom = <0x55>;
-			border-waveform = <0x03>;
-			dummy-line = <0x30>;
-			gate-line-width = <0x0a>;
-			lut = [
-				80 60 40 00 00 00 00
-				10 60 20 00 00 00 00
-				80 60 40 00 00 00 00
-				10 60 20 00 00 00 00
-				00 00 00 00 00 00 00
-				03 03 00 00 02
-				09 09 00 00 02
-				03 03 00 00 02
-				00 00 00 00 00
-				00 00 00 00 00
-				00 00 00 00 00
-				00 00 00 00 00
-			];
-		};
+		ssd16xx_waveshare_epaper_gdeh0213b72: ssd16xxfb@0 {
+			compatible = "gooddisplay,gdeh0213b72", "solomon,ssd1675a";
+			mipi-max-frequency = <4000000>;
+			reg = <0>;
+			width = <250>;
+			height = <120>;
+			busy-gpios = <&arduino_header 13 GPIO_ACTIVE_HIGH>;	/* D7 */
 
-		partial {
-			gdv = [15];
-			sdv = [41 a8 32];
-			vcom = <0x26>;
-			border-waveform = <0x01>;
-			dummy-line = <0x30>;
-			gate-line-width = <0x0a>;
-			lut = [
-				00 00 00 00 00 00 00
-				80 00 00 00 00 00 00
-				40 00 00 00 00 00 00
-				80 00 00 00 00 00 00
-				00 00 00 00 00 00 00
-				0A 00 00 00 04
-				00 00 00 00 00
-				00 00 00 00 00
-				00 00 00 00 00
-				00 00 00 00 00
-				00 00 00 00 00
-				00 00 00 00 00
-			];
+			full {
+				gdv = [15];
+				sdv = [41 a8 32];
+				vcom = <0x55>;
+				border-waveform = <0x03>;
+				dummy-line = <0x30>;
+				gate-line-width = <0x0a>;
+				lut = [
+					80 60 40 00 00 00 00
+					10 60 20 00 00 00 00
+					80 60 40 00 00 00 00
+					10 60 20 00 00 00 00
+					00 00 00 00 00 00 00
+					03 03 00 00 02
+					09 09 00 00 02
+					03 03 00 00 02
+					00 00 00 00 00
+					00 00 00 00 00
+					00 00 00 00 00
+					00 00 00 00 00
+				];
+			};
+
+			partial {
+				gdv = [15];
+				sdv = [41 a8 32];
+				vcom = <0x26>;
+				border-waveform = <0x01>;
+				dummy-line = <0x30>;
+				gate-line-width = <0x0a>;
+				lut = [
+					00 00 00 00 00 00 00
+					80 00 00 00 00 00 00
+					40 00 00 00 00 00 00
+					80 00 00 00 00 00 00
+					00 00 00 00 00 00 00
+					0A 00 00 00 04
+					00 00 00 00 00
+					00 00 00 00 00
+					00 00 00 00 00
+					00 00 00 00 00
+					00 00 00 00 00
+					00 00 00 00 00
+				];
+			};
 		};
 	};
 };

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdeh029a1.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdeh029a1.overlay
@@ -10,45 +10,50 @@
 	chosen {
 		zephyr,display = &ssd16xx_waveshare_epaper_gdeh029a1;
 	};
-};
 
-&arduino_spi {
-	ssd16xx_waveshare_epaper_gdeh029a1: ssd16xxfb@0 {
-		compatible = "gooddisplay,gdeh029a1", "solomon,ssd1608";
-		spi-max-frequency = <4000000>;
-		reg = <0>;
-		width = <296>;
-		height = <128>;
-		dc-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>;	/* D9 */
+	mipi_dbi_waveshare_epaper_gdeh029a1 {
+		compatible = "zephyr,mipi-dbi-spi";
+		spi-dev = <&arduino_spi>;
+		dc-gpios = <&arduino_header 15 GPIO_ACTIVE_HIGH>;	/* D9 */
 		reset-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>;	/* D8 */
-		busy-gpios = <&arduino_header 13 GPIO_ACTIVE_HIGH>;	/* D7 */
+		#address-cells = <1>;
+		#size-cells = <0>;
 
-		softstart = [d7 d6 9d];
+		ssd16xx_waveshare_epaper_gdeh029a1: ssd16xxfb@0 {
+			compatible = "gooddisplay,gdeh029a1", "solomon,ssd1608";
+			mipi-max-frequency = <4000000>;
+			reg = <0>;
+			width = <296>;
+			height = <128>;
+			busy-gpios = <&arduino_header 13 GPIO_ACTIVE_HIGH>;	/* D7 */
 
-		full {
-			vcom = <0x9a>;
-			border-waveform = <0x33>;
-			dummy-line = <0x1a>;
-			gate-line-width = <0x08>;
-			lut = [
-				50 AA 55 AA 11 00 00 00
-				00 00 00 00 00 00 00 00
-				00 00 00 00 FF FF 1F 00
-				00 00 00 00 00 00
-			];
-		};
+			softstart = [d7 d6 9d];
 
-		partial {
-			vcom = <0xa8>;
-			border-waveform = <0x01>;
-			dummy-line = <0x1a>;
-			gate-line-width = <0x08>;
-			lut = [
-				10 18 18 08 18 18 08 00
-				00 00 00 00 00 00 00 00
-				00 00 00 00 13 14 44 12
-				00 00 00 00 00 00
-			];
+			full {
+				vcom = <0x9a>;
+				border-waveform = <0x33>;
+				dummy-line = <0x1a>;
+				gate-line-width = <0x08>;
+				lut = [
+					50 AA 55 AA 11 00 00 00
+					00 00 00 00 00 00 00 00
+					00 00 00 00 FF FF 1F 00
+					00 00 00 00 00 00
+				];
+			};
+
+			partial {
+				vcom = <0xa8>;
+				border-waveform = <0x01>;
+				dummy-line = <0x1a>;
+				gate-line-width = <0x08>;
+				lut = [
+					10 18 18 08 18 18 08 00
+					00 00 00 00 00 00 00 00
+					00 00 00 00 13 14 44 12
+					00 00 00 00 00 00
+				];
+			};
 		};
 	};
 };

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdey0213b74.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdey0213b74.overlay
@@ -10,27 +10,32 @@
 	chosen {
 		zephyr,display = &ssd16xx_waveshare_epaper_gdey0213b74;
 	};
-};
 
-&arduino_spi {
-	ssd16xx_waveshare_epaper_gdey0213b74: ssd16xxfb@0 {
-		compatible = "gooddisplay,gdey0213b74", "solomon,ssd1680";
-		spi-max-frequency = <4000000>;
-		reg = <0>;
-		width = <250>;
-		height = <122>;
-		dc-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>;	/* D9 */
+	mipi_dbi_waveshare_epaper_gdey0213b74 {
+		compatible = "zephyr,mipi-dbi-spi";
+		spi-dev = <&arduino_spi>;
+		dc-gpios = <&arduino_header 15 GPIO_ACTIVE_HIGH>;	/* D9 */
 		reset-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>;	/* D8 */
-		busy-gpios = <&arduino_header 13 GPIO_ACTIVE_HIGH>;	/* D7 */
+		#address-cells = <1>;
+		#size-cells = <0>;
 
-		tssv = <0x80>;
+		ssd16xx_waveshare_epaper_gdey0213b74: ssd16xxfb@0 {
+			compatible = "gooddisplay,gdey0213b74", "solomon,ssd1680";
+			mipi-max-frequency = <4000000>;
+			reg = <0>;
+			width = <250>;
+			height = <122>;
+			busy-gpios = <&arduino_header 13 GPIO_ACTIVE_HIGH>;	/* D7 */
 
-		full {
-			border-waveform = <0x05>;
-		};
+			tssv = <0x80>;
 
-		partial {
-			border-waveform = <0x3c>;
+			full {
+				border-waveform = <0x05>;
+			};
+
+			partial {
+				border-waveform = <0x3c>;
+			};
 		};
 	};
 };

--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -355,8 +355,8 @@ Display
 * ST7789V based displays now use the MIPI DBI driver class. These displays
   must now be declared within a MIPI DBI driver wrapper device, which will
   manage interfacing with the display. (:github:`73750`) Note that the
-  `cmd-data-gpios` pin has changed polarity with this update, to align better
-  with the new `dc-gpios` name. For an example, see below:
+  ``cmd-data-gpios`` pin has changed polarity with this update, to align better
+  with the new ``dc-gpios`` name. For an example, see below:
 
   .. code-block:: devicetree
 
@@ -391,6 +391,47 @@ Display
             reg = <0>;
             mipi-max-frequency = <32000000>;
             mipi-mode = <MIPI_DBI_MODE_SPI_4WIRE>;
+            ...
+        };
+    };
+
+* SSD16XX based displays now use the MIPI DBI driver class (:github:`73946`).
+  These displays must now be declared within a MIPI DBI driver wrapper device,
+  which will manage interfacing with the display. Note that the ``dc-gpios``
+  pin has changed polarity with this update. For an example, see below:
+
+  .. code-block:: devicetree
+
+    /* Legacy SSD16XX display definition */
+    &spi0 {
+        ssd1680: ssd1680@0 {
+            compatible = "solomon,ssd1680";
+            reg = <0>;
+            spi-max-frequency = <4000000>;
+            reset-gpios = <&gpio0 6 GPIO_ACTIVE_LOW>;
+            dc-gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+            ...
+        };
+    };
+
+    /* New display definition with MIPI DBI device */
+
+    #include <zephyr/dt-bindings/mipi_dbi/mipi_dbi.h>
+
+    ...
+
+    mipi_dbi {
+        compatible = "zephyr,mipi-dbi-spi";
+        reset-gpios = <&gpio0 6 GPIO_ACTIVE_LOW>;
+        dc-gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
+        spi-dev = <&spi0>;
+        #address-cells = <1>;
+        #size-cells = <0>;
+
+        ssd1680: ssd1680@0 {
+            compatible = "solomon,ssd1680";
+            reg = <0>;
+            mipi-max-frequency = <4000000>;
             ...
         };
     };

--- a/drivers/display/Kconfig.ssd16xx
+++ b/drivers/display/Kconfig.ssd16xx
@@ -12,6 +12,6 @@ config SSD16XX
 		DT_HAS_SOLOMON_SSD1675A_ENABLED || \
 		DT_HAS_SOLOMON_SSD1680_ENABLED || \
 		DT_HAS_SOLOMON_SSD1681_ENABLED
-	select SPI
+	select MIPI_DBI
 	help
 	  Enable driver for SSD16XX compatible controller.

--- a/dts/bindings/display/solomon,ssd16xx-common.yaml
+++ b/dts/bindings/display/solomon,ssd16xx-common.yaml
@@ -3,30 +3,12 @@
 
 description: SSD16XX EPD display controller
 
-include: [spi-device.yaml, display-controller.yaml]
+include: [mipi-dbi-spi-device.yaml, display-controller.yaml]
 
 properties:
   softstart:
     type: uint8-array
     description: Booster soft start values
-
-  reset-gpios:
-    type: phandle-array
-    required: true
-    description: RESET pin.
-
-      The RESET pin of SSD16XX is active low.
-      If connected directly the MCU pin should be configured
-      as active low.
-
-  dc-gpios:
-    type: phandle-array
-    required: true
-    description: DC pin.
-
-      The DC pin of SSD16XX is active low (transmission command byte).
-      If connected directly the MCU pin should be configured
-      as active low.
 
   busy-gpios:
     type: phandle-array

--- a/tests/drivers/build_all/display/app.overlay
+++ b/tests/drivers/build_all/display/app.overlay
@@ -98,6 +98,15 @@
 				rgb-param = [40 02 14];
 				mipi-mode = <MIPI_DBI_MODE_SPI_4WIRE>;
 			};
+
+			test_mipi_dbi_ssd1680: ssd1680@4 {
+				compatible = "gooddisplay,gdey0213b74", "solomon,ssd1680";
+				mipi-max-frequency = <4000000>;
+				reg = <4>;
+				width = <250>;
+				height = <122>;
+				busy-gpios = <&test_gpio 0 0>;
+			};
 		};
 
 
@@ -111,7 +120,7 @@
 
 			/* one entry for every devices at spi.dtsi */
 			cs-gpios = <&test_gpio 0 0 &test_gpio 0 1 &test_gpio 0 2
-				&test_gpio 0 3>;
+				&test_gpio 0 3 &test_gpio 0 4>;
 
 			test_spi_gc9x01x: gc9x01x@1 {
 				compatible = "galaxycore,gc9x01x";


### PR DESCRIPTION
Convert SSD16XX display driver to use MIPI DBI API. This PR also
updates in tree board devicetrees to include the emulated MIPI DBI SPI
driver.

PR has been tested using `samples/drivers/display`, on `reel_board@2`