### PR TITLE
tests: kernel/context: Avoid possible drift

### DIFF
--- a/tests/kernel/context/src/main.c
+++ b/tests/kernel/context/src/main.c
@@ -232,7 +232,7 @@ static void _test_kernel_cpu_idle(int atomic)
 	k_timer_init(&idle_timer, idle_timer_expiry_function, NULL);
 
 	for (i = 0; i < 5; i++) {
-		k_usleep(1);
+		k_sleep(K_MSEC(2));
 		t0 = k_uptime_ticks();
 		idle_loops = 0;
 		idle_timer_done = false;


### PR DESCRIPTION
Use microsecond resolution can cause drifts in slow simulators leading the system to return from idle before / after the timeout expected by the test and makig it fail. Increase the time used for the alignment.