### PR TITLE
llext: cache section headers 

### DIFF
--- a/include/zephyr/llext/loader.h
+++ b/include/zephyr/llext/loader.h
@@ -71,6 +71,8 @@ struct llext_loader {
 	/** @cond ignore */
 	elf_ehdr_t hdr;
 	elf_shdr_t sects[LLEXT_MEM_COUNT];
+	elf_shdr_t *sect_hdrs;
+	bool sect_hdrs_on_heap;
 	enum llext_mem *sect_map;
 	uint32_t sect_cnt;
 	/** @endcond */

--- a/subsys/llext/llext.c
+++ b/subsys/llext/llext.c
@@ -136,7 +136,6 @@ int llext_load(struct llext_loader *ldr, const char *name, struct llext **ext,
 		ret = -ENOMEM;
 		goto out;
 	}
-	memset(*ext, 0, sizeof(struct llext));
 
 	ret = do_llext_load(ldr, *ext, ldr_parm);
 	if (ret < 0) {
@@ -179,6 +178,7 @@ int llext_unload(struct llext **ext)
 	k_mutex_unlock(&llext_lock);
 
 	llext_free_sections(tmp);
+	llext_free(tmp->sym_tab.syms);
 	llext_free(tmp->exp_tab.syms);
 	llext_free(tmp);
 


### PR DESCRIPTION
The `llext_load()` and `llext_link()` functions need to access section header data from the ELF file quite often, but this is currently done by seeking and reading each section header whenever it becomes necessary (even lots of times for the same section, in the case of symbols). 

This PR reworks the current code by loading the whole section table in memory and accessing the array elements directly in the code. The memory for the section headers is freed at the end of the `llext_load()` function. If `llext_peek()` is supported, no allocation is performed and the data is fetched directly from the ELF file buffer.

* The first commit is cosmetic, and restores some debug messages which were lost in the split-file refactor.
* The second commit in the series refactors the code freeing memory at the end of `llext_load()` so that it's clearer and more explicit. As an improvement, the symbol table is kept in memory in debug builds to ease debugging.
* The third commit adds the code that loads this section header array and frees it (or uses it directly from the ELF file buffer if available).
* The last commit is a pure refactor that introduces no logic changes, but removes all code reading section headers and replaces it with the array indexing. 
