### PR TITLE
doc: Add ability to generate man pages

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -18,6 +18,7 @@ set(LATEXMKOPTS "-halt-on-error -no-shell-escape" CACHE STRING "Default latexmk 
 set(DT_TURBO_MODE OFF CACHE BOOL "Enable DT turbo mode")
 set(DOC_TAG "development" CACHE STRING "Documentation tag")
 set(DTS_ROOTS "${ZEPHYR_BASE}" CACHE STRING "DT bindings root folders")
+set(DOXYGEN_MANPAGES OFF CACHE BOOL "Ask doxygen to also build man pages")
 
 separate_arguments(SPHINXOPTS)
 separate_arguments(SPHINXOPTS_EXTRA)
@@ -88,6 +89,12 @@ set(DOXY_OUT ${CMAKE_CURRENT_BINARY_DIR}/doxygen)
 set(DOXYFILE_IN ${CMAKE_CURRENT_LIST_DIR}/zephyr.doxyfile.in)
 set(DOXYFILE_OUT ${CMAKE_CURRENT_BINARY_DIR}/zephyr.doxyfile)
 set(ZEPHYR_VERSION "${Zephyr_VERSION}")
+
+if(DOXYGEN_MANPAGES)
+  set(GENERATE_MAN_PAGES "YES")
+else()
+  set(GENERATE_MAN_PAGES "NO")
+endif()
 
 configure_file(${DOXYFILE_IN} ${DOXYFILE_OUT} @ONLY)
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -9,6 +9,8 @@ SPHINXOPTS_EXTRA ?=
 LATEXMKOPTS ?= -halt-on-error -no-shell-escape
 DT_TURBO_MODE ?= 0
 
+DOXYGEN_MANPAGES ?= 0
+
 # ------------------------------------------------------------------------------
 # Documentation targets
 
@@ -29,6 +31,7 @@ configure:
 		-DSPHINXOPTS="${SPHINXOPTS}" \
 		-DSPHINXOPTS_EXTRA="${SPHINXOPTS_EXTRA}" \
 		-DLATEXMKOPTS="${LATEXMKOPTS}" \
+		-DDOXYGEN_MANPAGES=${DOXYGEN_MANPAGES} \
 		-DDT_TURBO_MODE=${DT_TURBO_MODE}
 
 clean:

--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -2153,7 +2153,7 @@ RTF_EXTENSIONS_FILE    =
 # classes and files.
 # The default value is: NO.
 
-GENERATE_MAN           = NO
+GENERATE_MAN           = @GENERATE_MAN_PAGES@
 
 # The MAN_OUTPUT tag is used to specify where the man pages will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of
@@ -2187,7 +2187,7 @@ MAN_SUBDIR             =
 # The default value is: NO.
 # This tag requires that the tag GENERATE_MAN is set to YES.
 
-MAN_LINKS              = NO
+MAN_LINKS              = YES
 
 #---------------------------------------------------------------------------
 # Configuration options related to the XML output


### PR DESCRIPTION
For those who cannot really make the transition from command line to GUI (well... me...), add the ability to generate man pages so there can be a quicker way of finding out symbol meanings. Do this with:

* `BUILD_MANPAGES=1 make doxygen`