### PR TITLE
.gitignore: do not ignore .\#* files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,10 @@
 *.swp
 *.swo
 *~
-.\#*
+
+# Emacs
 \#*\#
+
 build*/
 !doc/build/
 !scripts/build


### PR DESCRIPTION
I just wasted dozens of failed build attempts and more than 5 minutes staring at this cryptic build error:

```
Traceback (most recent call last):
  File "scripts/build/parse_syscalls.py", line 216, in <module>
    main()
  File "scripts/build/parse_syscalls.py", line 194, in main
    syscalls, tagged = analyze_headers(args.include, args.scan,
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "scripts/build/parse_syscalls.py", line 118, in analyze_headers
    with open(one_file, "r", encoding="utf-8") as fp:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory:

                  'zephyr/include/zephyr/pm/.#device.h'
```

Because this file didn't show in `git status`, I kept believing that building from scratch would make it go away.

`git status` should never hide source files that the build system uses. Maybe `parse_syscalls.py` should be "Emacs-aware"? Or maybe not. As long as it's not, `git status` must show every spurious file that might affect the build and break it.

This is the first time that I see an error like this; so Emacs does not leave files like this behind on a regular basis. Only when there is a some sort of glitch; and then we definitely want to know about it.

More generally speaking, the choice of an editor is a personal preference. So patterns matching Emacs files belong to personal $HOME/.gitignore files; they shouldn't be mass-duplicated into every single git repo instead. Stuffing every project with editor-specific configuration of every editor obviously does not scale. But that's probably for another day.

This is a partial revert of commit 3f4159c5c7ad ("gitignore: Ignore emacs temporary edit files")