### PR TITLE
demand_paging: eviction/nru: fix pathological behavior

### DIFF
--- a/subsys/demand_paging/eviction/nru.c
+++ b/subsys/demand_paging/eviction/nru.c
@@ -50,9 +50,17 @@ struct k_mem_page_frame *k_mem_paging_eviction_select(bool *dirty_ptr)
 	bool accessed;
 	bool last_dirty = false;
 	bool dirty = false;
-	uintptr_t flags, phys;
+	uintptr_t flags;
+	uint32_t pf_idx;
+	static uint32_t last_pf_idx;
 
-	K_MEM_PAGE_FRAME_FOREACH(phys, pf) {
+	/* similar to K_MEM_PAGE_FRAME_FOREACH except we don't always start at 0 */
+	last_pf_idx = (last_pf_idx + 1) % ARRAY_SIZE(k_mem_page_frames);
+	pf_idx = last_pf_idx;
+	do {
+		pf = &k_mem_page_frames[pf_idx];
+		pf_idx = (pf_idx + 1) % ARRAY_SIZE(k_mem_page_frames);
+
 		unsigned int prec;
 
 		if (!k_mem_page_frame_is_evictable(pf)) {
@@ -84,10 +92,12 @@ struct k_mem_page_frame *k_mem_paging_eviction_select(bool *dirty_ptr)
 			last_pf = pf;
 			last_dirty = dirty;
 		}
-	}
+	} while (pf_idx != last_pf_idx);
+
 	/* Shouldn't ever happen unless every page is pinned */
 	__ASSERT(last_pf != NULL, "no page to evict");
 
+	last_pf_idx = last_pf - k_mem_page_frames;
 	*dirty_ptr = last_dirty;
 
 	return last_pf;


### PR DESCRIPTION
Currently, the NRU algorithm always picks the lowest (and very often the
same) clean unaccessed page over and over when e.g. doing large anonymous
memory mappings. Spread the eviction selection more uniformly by by
starting the search right after the last victim instead of always
restarting from 0.

Signed-off-by: Nicolas Pitre <npitre@baylibre.com>
