### PR TITLE
dts: arm: st: add npgios to all stm32 gpio controllers

### DIFF
--- a/dts/arm/st/l4/stm32l496.dtsi
+++ b/dts/arm/st/l4/stm32l496.dtsi
@@ -44,6 +44,7 @@
 				compatible = "st,stm32-gpio";
 				gpio-controller;
 				#gpio-cells = <2>;
+				ngpios = <12>;
 				reg = <0x48002000 0x400>;
 				clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00000100>;
 			};

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -228,6 +228,7 @@
 				compatible = "st,stm32-gpio";
 				gpio-controller;
 				#gpio-cells = <2>;
+				ngpios = <5>;
 				reg = <0x48001000 0x400>;
 				clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00000010>;
 			};
@@ -236,6 +237,7 @@
 				compatible = "st,stm32-gpio";
 				gpio-controller;
 				#gpio-cells = <2>;
+				ngpios = <4>;
 				reg = <0x48001c00 0x400>;
 				clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00000080>;
 			};

--- a/dts/bindings/gpio/st,stm32-gpio.yaml
+++ b/dts/bindings/gpio/st,stm32-gpio.yaml
@@ -5,7 +5,11 @@ description: STM32 GPIO node
 
 compatible: "st,stm32-gpio"
 
-include: [gpio-controller.yaml, base.yaml]
+include:
+  - name: gpio-controller.yaml
+    property-blocklist:
+      - ngpios
+  - name: base.yaml
 
 properties:
   reg:
@@ -16,6 +20,19 @@ properties:
 
   "#gpio-cells":
     const: 2
+
+  ngpios:
+    type: int
+    default: 16
+    description: |
+        This property indicates the number of in-use slots of available slots
+        for GPIOs. The STM32 GPIO controller typically has all 16 possible port
+        IO with few exceptions. It should only be necessary to explicitly set
+        this property if the controller itself does not implement all 16 port
+        IO register bits; for example PORTE in the STM32WB55xx series which only
+        implements the first 5. Package restrictions on the number of exposed
+        GPIO should not influence this property. For cases in which there might
+        be holes in the slot range, this value should be the max slot number+1.
 
 gpio-cells:
   - pin


### PR DESCRIPTION
For almost all STM32 GPIO controllers, the number of supported GPIO pins managed by a single controller is 16 (with some exceptions for fewer). However, the default for ngpios in the device tree bindings for gpio-controllers is 32; leading to inaccuracies in handling GPIO for these controllers, such as presenting too many GPIOs in the GPIO shell. This patch adds the ngpios property for all currently supported STM32 GPIO controllers.