### PR TITLE
drivers: clock_control: fix incorrectly allocated structure in clock control drivers

### DIFF
--- a/drivers/clock_control/beetle_clock_control.c
+++ b/drivers/clock_control/beetle_clock_control.c
@@ -243,7 +243,7 @@ static const struct beetle_clock_control_cfg_t beetle_cc_cfg = {
  * @brief Clock Control device init
  *
  */
-DEVICE_DT_INST_DEFINE(0, &beetle_clock_control_init, NULL,
+DEVICE_DT_INST_DEFINE(0, beetle_clock_control_init, NULL,
 		      NULL, &beetle_cc_cfg, PRE_KERNEL_1,
 		      CONFIG_CLOCK_CONTROL_INIT_PRIORITY,
 		      &beetle_clock_control_api);

--- a/drivers/clock_control/clock_control_adsp.c
+++ b/drivers/clock_control/clock_control_adsp.c
@@ -28,6 +28,6 @@ static const struct clock_control_driver_api cavs_clock_api = {
 	.set_rate = cavs_clock_ctrl_set_rate
 };
 
-DEVICE_DT_DEFINE(DT_NODELABEL(clkctl), &cavs_clock_ctrl_init, NULL,
+DEVICE_DT_DEFINE(DT_NODELABEL(clkctl), cavs_clock_ctrl_init, NULL,
 		 NULL, NULL, POST_KERNEL,
 		 CONFIG_CLOCK_CONTROL_INIT_PRIORITY, &cavs_clock_api);

--- a/drivers/clock_control/clock_control_esp32.c
+++ b/drivers/clock_control/clock_control_esp32.c
@@ -607,7 +607,7 @@ static const struct esp32_clock_config esp32_clock_config0 = {
 };
 
 DEVICE_DT_DEFINE(DT_NODELABEL(rtc),
-		 &clock_control_esp32_init,
+		 clock_control_esp32_init,
 		 NULL,
 		 NULL,
 		 &esp32_clock_config0,

--- a/drivers/clock_control/clock_control_gd32.c
+++ b/drivers/clock_control/clock_control_gd32.c
@@ -198,7 +198,7 @@ clock_control_gd32_get_status(const struct device *dev,
 	return CLOCK_CONTROL_STATUS_OFF;
 }
 
-static struct clock_control_driver_api clock_control_gd32_api = {
+static const struct clock_control_driver_api clock_control_gd32_api = {
 	.on = clock_control_gd32_on,
 	.off = clock_control_gd32_off,
 	.get_rate = clock_control_gd32_get_rate,

--- a/drivers/clock_control/clock_control_ifx_cat1.c
+++ b/drivers/clock_control/clock_control_ifx_cat1.c
@@ -715,7 +715,7 @@ static const struct clock_control_driver_api clock_control_infineon_cat1_api = {
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(clk_imo), okay)
 DEVICE_DT_DEFINE(DT_NODELABEL(clk_imo),
-		 &clock_control_infineon_cat1_init,
+		 clock_control_infineon_cat1_init,
 		 NULL,
 		 NULL,
 		 NULL,
@@ -725,7 +725,7 @@ DEVICE_DT_DEFINE(DT_NODELABEL(clk_imo),
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(clk_iho), okay)
 DEVICE_DT_DEFINE(DT_NODELABEL(clk_iho),
-		 &clock_control_infineon_cat1_init,
+		 clock_control_infineon_cat1_init,
 		 NULL,
 		 NULL,
 		 NULL,

--- a/drivers/clock_control/clock_control_litex.c
+++ b/drivers/clock_control/clock_control_litex.c
@@ -1794,6 +1794,6 @@ static const struct litex_clk_device ldev_init = {
 	.nclkout = NCLKOUT
 };
 
-DEVICE_DT_DEFINE(DT_NODELABEL(clock0), &litex_clk_init, NULL,
+DEVICE_DT_DEFINE(DT_NODELABEL(clock0), litex_clk_init, NULL,
 		    NULL, &ldev_init, POST_KERNEL,
 		    CONFIG_CLOCK_CONTROL_INIT_PRIORITY, &litex_clk_api);

--- a/drivers/clock_control/clock_control_lpc11u6x.c
+++ b/drivers/clock_control/clock_control_lpc11u6x.c
@@ -355,7 +355,7 @@ static const struct lpc11u6x_syscon_config syscon_config = {
 static struct lpc11u6x_syscon_data syscon_data;
 
 DEVICE_DT_INST_DEFINE(0,
-		    &lpc11u6x_syscon_init,
+		    lpc11u6x_syscon_init,
 		    NULL,
 		    &syscon_data, &syscon_config,
 		    PRE_KERNEL_1, CONFIG_CLOCK_CONTROL_INIT_PRIORITY,

--- a/drivers/clock_control/clock_control_mchp_xec.c
+++ b/drivers/clock_control/clock_control_mchp_xec.c
@@ -1090,7 +1090,7 @@ const struct xec_pcr_config pcr_xec_config = {
 };
 
 DEVICE_DT_INST_DEFINE(0,
-		    &xec_clock_control_init,
+		    xec_clock_control_init,
 		    NULL,
 		    NULL, &pcr_xec_config,
 		    PRE_KERNEL_1,

--- a/drivers/clock_control/clock_control_mchp_xec.c
+++ b/drivers/clock_control/clock_control_mchp_xec.c
@@ -1014,7 +1014,7 @@ void mchp_xec_clk_ctrl_sys_sleep_disable(void)
 #endif
 
 /* Clock controller driver registration */
-static struct clock_control_driver_api xec_clock_control_api = {
+static const struct clock_control_driver_api xec_clock_control_api = {
 	.on = xec_clock_control_on,
 	.off = xec_clock_control_off,
 	.get_rate = xec_clock_control_get_subsys_rate,

--- a/drivers/clock_control/clock_control_mcux_pcc.c
+++ b/drivers/clock_control/clock_control_mcux_pcc.c
@@ -143,7 +143,7 @@ static uint32_t clocks[] = {};
 	};								\
 									\
 	DEVICE_DT_INST_DEFINE(inst,					\
-			    &mcux_pcc_init,				\
+			    mcux_pcc_init,				\
 			    NULL,					\
 			    NULL, &mcux_pcc##inst##_config,		\
 			    PRE_KERNEL_1,				\

--- a/drivers/clock_control/clock_control_mcux_scg.c
+++ b/drivers/clock_control/clock_control_mcux_scg.c
@@ -151,7 +151,7 @@ static const struct clock_control_driver_api mcux_scg_driver_api = {
 };
 
 DEVICE_DT_INST_DEFINE(0,
-		    &mcux_scg_init,
+		    mcux_scg_init,
 		    NULL,
 		    NULL, NULL,
 		    PRE_KERNEL_1, CONFIG_CLOCK_CONTROL_INIT_PRIORITY,

--- a/drivers/clock_control/clock_control_mcux_sim.c
+++ b/drivers/clock_control/clock_control_mcux_sim.c
@@ -110,7 +110,7 @@ static const struct clock_control_driver_api mcux_sim_driver_api = {
 };
 
 DEVICE_DT_DEFINE(NXP_KINETIS_SIM_NODE,
-		    &mcux_sim_init,
+		    mcux_sim_init,
 		    NULL,
 		    NULL, NULL,
 		    PRE_KERNEL_1, CONFIG_CLOCK_CONTROL_INIT_PRIORITY,

--- a/drivers/clock_control/clock_control_npcx.c
+++ b/drivers/clock_control/clock_control_npcx.c
@@ -147,7 +147,7 @@ void npcx_clock_control_turn_off_system_sleep(void)
 #endif /* CONFIG_PM */
 
 /* Clock controller driver registration */
-static struct clock_control_driver_api npcx_clock_control_api = {
+static const struct clock_control_driver_api npcx_clock_control_api = {
 	.on = npcx_clock_control_on,
 	.off = npcx_clock_control_off,
 	.get_rate = npcx_clock_control_get_subsys_rate,

--- a/drivers/clock_control/clock_control_npcx.c
+++ b/drivers/clock_control/clock_control_npcx.c
@@ -256,7 +256,7 @@ const struct npcx_pcc_config pcc_config = {
 };
 
 DEVICE_DT_INST_DEFINE(0,
-		    &npcx_clock_control_init,
+		    npcx_clock_control_init,
 		    NULL,
 		    NULL, &pcc_config,
 		    PRE_KERNEL_1,

--- a/drivers/clock_control/clock_control_nrf_auxpll.c
+++ b/drivers/clock_control/clock_control_nrf_auxpll.c
@@ -99,7 +99,7 @@ static enum clock_control_status clock_control_nrf_auxpll_get_status(const struc
 	return CLOCK_CONTROL_STATUS_OFF;
 }
 
-static struct clock_control_driver_api clock_control_nrf_auxpll_api = {
+static const struct clock_control_driver_api clock_control_nrf_auxpll_api = {
 	.on = clock_control_nrf_auxpll_on,
 	.off = clock_control_nrf_auxpll_off,
 	.get_rate = clock_control_nrf_auxpll_get_rate,

--- a/drivers/clock_control/clock_control_numaker_scc.c
+++ b/drivers/clock_control/clock_control_numaker_scc.c
@@ -156,7 +156,7 @@ static int numaker_scc_init(const struct device *dev)
 		.core_clock = DT_INST_PROP_OR(inst, core_clock, 0),                                \
 	};                                                                                         \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(inst, &numaker_scc_init, NULL, NULL, &numaker_scc_config_##inst,     \
+	DEVICE_DT_INST_DEFINE(inst, numaker_scc_init, NULL, NULL, &numaker_scc_config_##inst,     \
 			      PRE_KERNEL_1, CONFIG_CLOCK_CONTROL_INIT_PRIORITY, &numaker_scc_api);
 
 DT_INST_FOREACH_STATUS_OKAY(NUMICRO_SCC_INIT);

--- a/drivers/clock_control/clock_control_numaker_scc.c
+++ b/drivers/clock_control/clock_control_numaker_scc.c
@@ -95,7 +95,7 @@ static inline int numaker_scc_configure(const struct device *dev, clock_control_
 }
 
 /* System clock controller driver registration */
-static struct clock_control_driver_api numaker_scc_api = {
+static const struct clock_control_driver_api numaker_scc_api = {
 	.on = numaker_scc_on,
 	.off = numaker_scc_off,
 	.get_rate = numaker_scc_get_rate,

--- a/drivers/clock_control/clock_control_nxp_s32.c
+++ b/drivers/clock_control/clock_control_nxp_s32.c
@@ -74,7 +74,7 @@ static const struct clock_control_driver_api nxp_s32_clock_driver_api = {
 };
 
 DEVICE_DT_INST_DEFINE(0,
-		      &nxp_s32_clock_init,
+		      nxp_s32_clock_init,
 		      NULL, NULL, NULL,
 		      PRE_KERNEL_1, CONFIG_CLOCK_CONTROL_INIT_PRIORITY,
 		      &nxp_s32_clock_driver_api);

--- a/drivers/clock_control/clock_control_pwm.c
+++ b/drivers/clock_control/clock_control_pwm.c
@@ -129,7 +129,7 @@ static int clock_control_pwm_init(const struct device *dev)
 	return 0;
 }
 
-static struct clock_control_driver_api clock_control_pwm_api = {
+static const struct clock_control_driver_api clock_control_pwm_api = {
 	.on = clock_control_pwm_on,
 	.get_rate = clock_control_pwm_get_rate,
 	.set_rate = clock_control_pwm_set_rate,

--- a/drivers/clock_control/clock_control_renesas_ra.c
+++ b/drivers/clock_control/clock_control_renesas_ra.c
@@ -304,5 +304,5 @@ static int clock_control_ra_init(const struct device *dev)
 	return 0;
 }
 
-DEVICE_DT_INST_DEFINE(0, &clock_control_ra_init, NULL, NULL, NULL, PRE_KERNEL_1,
+DEVICE_DT_INST_DEFINE(0, clock_control_ra_init, NULL, NULL, NULL, PRE_KERNEL_1,
 		      CONFIG_CLOCK_CONTROL_INIT_PRIORITY, &ra_clock_control_driver_api);

--- a/drivers/clock_control/clock_control_rpi_pico.c
+++ b/drivers/clock_control/clock_control_rpi_pico.c
@@ -880,6 +880,6 @@ static struct clock_control_rpi_pico_data clock_control_rpi_pico_data = {
 	.rosc_ph_freq = CLOCK_FREQ(rosc_ph),
 };
 
-DEVICE_DT_INST_DEFINE(0, &clock_control_rpi_pico_init, NULL, &clock_control_rpi_pico_data,
+DEVICE_DT_INST_DEFINE(0, clock_control_rpi_pico_init, NULL, &clock_control_rpi_pico_data,
 		      &clock_control_rpi_pico_config, PRE_KERNEL_1,
 		      CONFIG_CLOCK_CONTROL_INIT_PRIORITY, &clock_control_rpi_pico_api);

--- a/drivers/clock_control/clock_control_sam_pmc.c
+++ b/drivers/clock_control/clock_control_sam_pmc.c
@@ -129,7 +129,7 @@ atmel_sam_clock_control_get_status(const struct device *dev,
 	return status;
 }
 
-static struct clock_control_driver_api atmel_sam_clock_control_api = {
+static const struct clock_control_driver_api atmel_sam_clock_control_api = {
 	.on = atmel_sam_clock_control_on,
 	.off = atmel_sam_clock_control_off,
 	.get_rate = atmel_sam_clock_control_get_rate,

--- a/drivers/clock_control/clock_control_smartbond.c
+++ b/drivers/clock_control/clock_control_smartbond.c
@@ -582,7 +582,7 @@ int smartbond_clocks_init(const struct device *dev)
 	return 0;
 }
 
-static struct clock_control_driver_api smartbond_clock_control_api = {
+static const struct clock_control_driver_api smartbond_clock_control_api = {
 	.on = smartbond_clock_control_on,
 	.off = smartbond_clock_control_off,
 	.get_rate = smartbond_clock_control_get_rate,

--- a/drivers/clock_control/clock_control_smartbond.c
+++ b/drivers/clock_control/clock_control_smartbond.c
@@ -616,7 +616,7 @@ static int smartbond_clocks_pm_action(const struct device *dev, enum pm_device_a
 PM_DEVICE_DT_DEFINE(DT_NODELABEL(osc), smartbond_clocks_pm_action);
 
 DEVICE_DT_DEFINE(DT_NODELABEL(osc),
-		 &smartbond_clocks_init,
+		 smartbond_clocks_init,
 		 PM_DEVICE_DT_GET(DT_NODELABEL(osc)),
 		 NULL, NULL,
 		 PRE_KERNEL_1,

--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -473,7 +473,7 @@ static enum clock_control_status stm32_clock_control_get_status(const struct dev
 	}
 }
 
-static struct clock_control_driver_api stm32_clock_control_api = {
+static const struct clock_control_driver_api stm32_clock_control_api = {
 	.on = stm32_clock_control_on,
 	.off = stm32_clock_control_off,
 	.get_rate = stm32_clock_control_get_subsys_rate,

--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -867,7 +867,7 @@ void __weak config_regulator_voltage(uint32_t hclk_freq) {}
  * that the device init runs just after SOC init
  */
 DEVICE_DT_DEFINE(DT_NODELABEL(rcc),
-		    &stm32_clock_control_init,
+		    stm32_clock_control_init,
 		    NULL,
 		    NULL, NULL,
 		    PRE_KERNEL_1,

--- a/drivers/clock_control/clock_stm32_ll_h5.c
+++ b/drivers/clock_control/clock_stm32_ll_h5.c
@@ -772,7 +772,7 @@ int stm32_clock_control_init(const struct device *dev)
  * that the device init runs just after SOC init
  */
 DEVICE_DT_DEFINE(DT_NODELABEL(rcc),
-		    &stm32_clock_control_init,
+		    stm32_clock_control_init,
 		    NULL,
 		    NULL, NULL,
 		    PRE_KERNEL_1,

--- a/drivers/clock_control/clock_stm32_ll_h5.c
+++ b/drivers/clock_control/clock_stm32_ll_h5.c
@@ -338,7 +338,7 @@ static int stm32_clock_control_get_subsys_rate(const struct device *dev,
 	return 0;
 }
 
-static struct clock_control_driver_api stm32_clock_control_api = {
+static const struct clock_control_driver_api stm32_clock_control_api = {
 	.on = stm32_clock_control_on,
 	.off = stm32_clock_control_off,
 	.get_rate = stm32_clock_control_get_subsys_rate,

--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -648,7 +648,7 @@ static int stm32_clock_control_get_subsys_rate(const struct device *clock,
 	return 0;
 }
 
-static struct clock_control_driver_api stm32_clock_control_api = {
+static const struct clock_control_driver_api stm32_clock_control_api = {
 	.on = stm32_clock_control_on,
 	.off = stm32_clock_control_off,
 	.get_rate = stm32_clock_control_get_subsys_rate,

--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -1151,7 +1151,7 @@ void HAL_RCC_CSSCallback(void)
  * that the device init runs just after SOC init
  */
 DEVICE_DT_DEFINE(DT_NODELABEL(rcc),
-		    &stm32_clock_control_init,
+		    stm32_clock_control_init,
 		    NULL,
 		    NULL, NULL,
 		    PRE_KERNEL_1,

--- a/drivers/clock_control/clock_stm32_ll_mp1.c
+++ b/drivers/clock_control/clock_stm32_ll_mp1.c
@@ -410,7 +410,7 @@ static int stm32_clock_control_init(const struct device *dev)
  * that the device init runs just after SOC init
  */
 DEVICE_DT_DEFINE(DT_NODELABEL(rcc),
-		    &stm32_clock_control_init,
+		    stm32_clock_control_init,
 		    NULL,
 		    NULL, NULL,
 		    PRE_KERNEL_1,

--- a/drivers/clock_control/clock_stm32_ll_mp1.c
+++ b/drivers/clock_control/clock_stm32_ll_mp1.c
@@ -393,7 +393,7 @@ static int stm32_clock_control_get_subsys_rate(const struct device *clock,
 	return 0;
 }
 
-static struct clock_control_driver_api stm32_clock_control_api = {
+static const struct clock_control_driver_api stm32_clock_control_api = {
 	.on = stm32_clock_control_on,
 	.off = stm32_clock_control_off,
 	.get_rate = stm32_clock_control_get_subsys_rate,

--- a/drivers/clock_control/clock_stm32_ll_u5.c
+++ b/drivers/clock_control/clock_stm32_ll_u5.c
@@ -376,7 +376,7 @@ static enum clock_control_status stm32_clock_control_get_status(const struct dev
 	}
 }
 
-static struct clock_control_driver_api stm32_clock_control_api = {
+static const struct clock_control_driver_api stm32_clock_control_api = {
 	.on = stm32_clock_control_on,
 	.off = stm32_clock_control_off,
 	.get_rate = stm32_clock_control_get_subsys_rate,

--- a/drivers/clock_control/clock_stm32_ll_u5.c
+++ b/drivers/clock_control/clock_stm32_ll_u5.c
@@ -903,7 +903,7 @@ int stm32_clock_control_init(const struct device *dev)
  * that the device init runs just after SOC init
  */
 DEVICE_DT_DEFINE(DT_NODELABEL(rcc),
-		    &stm32_clock_control_init,
+		    stm32_clock_control_init,
 		    NULL,
 		    NULL, NULL,
 		    PRE_KERNEL_1,

--- a/drivers/clock_control/clock_stm32_ll_wba.c
+++ b/drivers/clock_control/clock_stm32_ll_wba.c
@@ -290,7 +290,7 @@ static enum clock_control_status stm32_clock_control_get_status(const struct dev
 	}
 }
 
-static struct clock_control_driver_api stm32_clock_control_api = {
+static const struct clock_control_driver_api stm32_clock_control_api = {
 	.on = stm32_clock_control_on,
 	.off = stm32_clock_control_off,
 	.get_rate = stm32_clock_control_get_subsys_rate,

--- a/drivers/clock_control/clock_stm32_ll_wba.c
+++ b/drivers/clock_control/clock_stm32_ll_wba.c
@@ -610,7 +610,7 @@ int stm32_clock_control_init(const struct device *dev)
  * that the device init runs just after SOC init
  */
 DEVICE_DT_DEFINE(DT_NODELABEL(rcc),
-		    &stm32_clock_control_init,
+		    stm32_clock_control_init,
 		    NULL,
 		    NULL, NULL,
 		    PRE_KERNEL_1,

--- a/drivers/clock_control/clock_stm32_mux.c
+++ b/drivers/clock_control/clock_stm32_mux.c
@@ -40,7 +40,7 @@ static const struct stm32_clk_mux_config stm32_clk_mux_cfg_##id = {	\
 	.pclken = STM32_CLOCK_INFO(0, DT_DRV_INST(id))			\
 };									\
 									\
-DEVICE_DT_INST_DEFINE(id, &stm32_clk_mux_init, NULL,			\
+DEVICE_DT_INST_DEFINE(id, stm32_clk_mux_init, NULL,			\
 		      NULL, &stm32_clk_mux_cfg_##id,			\
 		      PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_OBJECTS,\
 		      NULL);


### PR DESCRIPTION
- set `clock_control_driver_api` as `static const`
By using `static const`, we ensure immutability, leading to usage of only
`.rodata` and a reduction in the `.data` area.
- remove '&' when assigning `clock_control_xxx_init`
Remove address-of operator ('&') when assigning `clock_control_xxx_init`
function pointer in `DEVICE_DT_INST_DEFINE` macro.
