### PR TITLE
posix: streams: add stub for missing putpmsg() function

### DIFF
--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -909,18 +909,23 @@ _POSIX_TIMEOUTS
 _XOPEN_STREAMS
 ++++++++++++++
 
+With the exception of ``ioctl()``, functions in the ``_XOPEN_STREAMS`` option group are not
+implemented in Zephyr but are provided so that conformant applications can still link.
+Unimplemented functions in this option group will fail, setting ``errno`` to ``ENOSYS``
+:ref:`†<posix_undefined_behaviour>`.
+
 .. csv-table:: _XOPEN_STREAMS
    :header: API, Supported
    :widths: 50,10
 
-    fattach(),yes (will fail with ``ENOSYS``:ref:`†<posix_undefined_behaviour>`)
-    fdetach(),yes (will fail with ``ENOSYS``:ref:`†<posix_undefined_behaviour>`)
-    getmsg(),  yes (will fail with ``ENOSYS``:ref:`†<posix_undefined_behaviour>`)
-    getpmsg(),  yes (will fail with ``ENOSYS``:ref:`†<posix_undefined_behaviour>`)
-    ioctl(),yes
-    isastream(),yes (will fail with ``ENOSYS``:ref:`†<posix_undefined_behaviour>`)
-    putmsg(), yes (will fail with ``ENOSYS``:ref:`†<posix_undefined_behaviour>`)
-    putpmsg(),
+    fattach(), yes :ref:`†<posix_undefined_behaviour>`
+    fdetach(), yes :ref:`†<posix_undefined_behaviour>`
+    getmsg(), yes :ref:`†<posix_undefined_behaviour>`
+    getpmsg(), yes :ref:`†<posix_undefined_behaviour>`
+    ioctl(), yes
+    isastream(), yes :ref:`†<posix_undefined_behaviour>`
+    putmsg(), yes :ref:`†<posix_undefined_behaviour>`
+    putpmsg(), yes :ref:`†<posix_undefined_behaviour>`
 
 .. _Subprofiling Considerations:
     https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_subprofiles.html

--- a/include/zephyr/posix/posix_features.h
+++ b/include/zephyr/posix/posix_features.h
@@ -208,7 +208,11 @@
 /* #define _XOPEN_REALTIME (-1L) */
 /* #define _XOPEN_REALTIME_THREADS (-1L) */
 /* #define _XOPEN_SHM (-1L) */
-#define _XOPEN_STREAMS COND_CODE_1(CONFIG_XOPEN_STREAMS, (_XOPEN_VERSION), (-1))
+
+#ifdef CONFIG_XOPEN_STREAMS
+#define _XOPEN_STREAMS _XOPEN_VERSION
+#endif
+
 /* #define _XOPEN_UNIX (-1L) */
 /* #define _XOPEN_UUCP (-1L) */
 

--- a/lib/posix/options/stropts.c
+++ b/lib/posix/options/stropts.c
@@ -19,6 +19,19 @@ int putmsg(int fildes, const struct strbuf *ctlptr, const struct strbuf *dataptr
 	return -1;
 }
 
+int putpmsg(int fildes, const struct strbuf *ctlptr, const struct strbuf *dataptr, int band,
+	    int flags)
+{
+	ARG_UNUSED(fildes);
+	ARG_UNUSED(ctlptr);
+	ARG_UNUSED(dataptr);
+	ARG_UNUSED(band);
+	ARG_UNUSED(flags);
+
+	errno = ENOSYS;
+	return -1;
+}
+
 int fdetach(const char *path)
 {
 	ARG_UNUSED(path);


### PR DESCRIPTION
The putpmsg() function was left unimplemented when other functions in the `_XOPEN_STREAMS` Option were added.

Add a stub to complete the Option.

Only define `_XOPEN_STREAMS` if the Kconfig option is selected (rather than setting it to -1)

Additionally, clean up xopen streams doc to be a bit more presentable.

Fixes #66979

[Doc Preview](https://builds.zephyrproject.io/zephyr/pr/73964/docs/services/portability/posix/index.html)
