### PR TITLE
posix: conditionally generate posix_clock syscall header

### DIFF
--- a/lib/posix/options/CMakeLists.txt
+++ b/lib/posix/options/CMakeLists.txt
@@ -2,9 +2,7 @@
 
 set(GEN_DIR ${ZEPHYR_BINARY_DIR}/include/generated)
 
-zephyr_syscall_header(
-  posix_clock.h
-)
+zephyr_syscall_header_ifdef(CONFIG_POSIX_TIMERS posix_clock.h)
 
 if(CONFIG_POSIX_API)
   zephyr_include_directories(${ZEPHYR_BASE}/include/zephyr/posix)


### PR DESCRIPTION
If POSIX_TIMERS is not configured, there is no reason to generate syscall headers from posix_clock.h .

Make header generation conditional on POSIX_TIMERS in this case.