### PR TITLE
net: sockets: use z_finalize_typed_fd() to identify as sockets

### DIFF
--- a/doc/connectivity/networking/api/sockets.rst
+++ b/doc/connectivity/networking/api/sockets.rst
@@ -186,12 +186,13 @@ APIs, specified in :c:struct:`socket_op_vtable` struct.
 
 The function registered for socket creation should allocate a new file
 descriptor using :c:func:`z_reserve_fd` function. Any additional actions,
-specific to the creation of a particular offloaded socket implementation should
-take place after the file descriptor is allocated. As a final step, if the
-offloaded socket was created successfully, the file descriptor should be
-finalized with :c:func:`z_finalize_fd` function. The finalize function allows
-to register a :c:struct:`socket_op_vtable` structure implementing socket APIs
-for an offloaded socket along with an optional socket context data pointer.
+specific to the creation of a particular offloaded socket implementation,
+should take place after the file descriptor is allocated. As a final step,
+if the offloaded socket was created successfully, the file descriptor should
+be finalized with :c:func:`z_finalize_typed_fd`, or :c:func:`z_finalize_fd`
+functions. The finalize function allows to register a
+:c:struct:`socket_op_vtable` structure implementing socket APIs for an
+offloaded socket along with an optional socket context data pointer.
 
 Finally, when an offloaded network interface is initialized, it should indicate
 that the interface is offloaded with :c:func:`net_if_socket_offload_set`

--- a/drivers/modem/modem_socket.c
+++ b/drivers/modem/modem_socket.c
@@ -175,8 +175,8 @@ int modem_socket_get(struct modem_socket_config *cfg, int family, int type, int 
 	cfg->sockets[i].ip_proto = proto;
 	cfg->sockets[i].id = (cfg->assign_id) ? (i + cfg->base_socket_id) :
 		(cfg->base_socket_id + cfg->sockets_len);
-	z_finalize_fd(cfg->sockets[i].sock_fd, &cfg->sockets[i],
-		      (const struct fd_op_vtable *)cfg->vtable);
+	z_finalize_typed_fd(cfg->sockets[i].sock_fd, &cfg->sockets[i],
+			    (const struct fd_op_vtable *)cfg->vtable, ZVFS_MODE_IFSOCK);
 
 	k_sem_give(&cfg->sem_lock);
 	return cfg->sockets[i].sock_fd;

--- a/drivers/net/nsos_sockets.c
+++ b/drivers/net/nsos_sockets.c
@@ -202,7 +202,7 @@ static int nsos_socket_create(int family, int type, int proto)
 		goto free_sock;
 	}
 
-	z_finalize_fd(fd, sock, &nsos_socket_fd_op_vtable.fd_vtable);
+	z_finalize_typed_fd(fd, sock, &nsos_socket_fd_op_vtable.fd_vtable, ZVFS_MODE_IFSOCK);
 
 	return fd;
 
@@ -718,7 +718,8 @@ static int nsos_accept(void *obj, struct sockaddr *addr, socklen_t *addrlen)
 	conn_sock->fd = zephyr_fd;
 	conn_sock->poll.mid.fd = adapt_fd;
 
-	z_finalize_fd(zephyr_fd, conn_sock, &nsos_socket_fd_op_vtable.fd_vtable);
+	z_finalize_typed_fd(zephyr_fd, conn_sock, &nsos_socket_fd_op_vtable.fd_vtable,
+			    ZVFS_MODE_IFSOCK);
 
 	return zephyr_fd;
 

--- a/drivers/wifi/eswifi/eswifi_socket_offload.c
+++ b/drivers/wifi/eswifi/eswifi_socket_offload.c
@@ -158,9 +158,9 @@ static int eswifi_socket_accept(void *obj, struct sockaddr *addr,
 		return -1;
 	}
 
-	z_finalize_fd(fd, SD_TO_OBJ(sock),
-		      (const struct fd_op_vtable *)
-					&eswifi_socket_fd_op_vtable);
+	z_finalize_typed_fd(fd, SD_TO_OBJ(sock),
+			    (const struct fd_op_vtable *)&eswifi_socket_fd_op_vtable,
+			    ZVFS_MODE_IFSOCK);
 
 	return fd;
 }
@@ -594,9 +594,9 @@ int eswifi_socket_create(int family, int type, int proto)
 		return -1;
 	}
 
-	z_finalize_fd(fd, SD_TO_OBJ(sock),
-		      (const struct fd_op_vtable *)
-					&eswifi_socket_fd_op_vtable);
+	z_finalize_typed_fd(fd, SD_TO_OBJ(sock),
+			    (const struct fd_op_vtable *)&eswifi_socket_fd_op_vtable,
+			    ZVFS_MODE_IFSOCK);
 
 	return fd;
 }

--- a/drivers/wifi/simplelink/simplelink_sockets.c
+++ b/drivers/wifi/simplelink/simplelink_sockets.c
@@ -1273,9 +1273,9 @@ int simplelink_socket_create(int family, int type, int proto)
 		return -1;
 	}
 
-	z_finalize_fd(fd, SD_TO_OBJ(sock),
-		      (const struct fd_op_vtable *)
-					&simplelink_socket_fd_op_vtable);
+	z_finalize_typed_fd(fd, SD_TO_OBJ(sock),
+			    (const struct fd_op_vtable *)&simplelink_socket_fd_op_vtable,
+			    ZVFS_MODE_IFSOCK);
 
 	return fd;
 }
@@ -1296,9 +1296,9 @@ static int simplelink_socket_accept(void *obj, struct sockaddr *addr,
 		return -1;
 	}
 
-	z_finalize_fd(fd, SD_TO_OBJ(sock),
-		      (const struct fd_op_vtable *)
-					&simplelink_socket_fd_op_vtable);
+	z_finalize_typed_fd(fd, SD_TO_OBJ(sock),
+			    (const struct fd_op_vtable *)&simplelink_socket_fd_op_vtable,
+			    ZVFS_MODE_IFSOCK);
 
 	return fd;
 }

--- a/subsys/net/lib/sockets/socket_dispatcher.c
+++ b/subsys/net/lib/sockets/socket_dispatcher.c
@@ -69,7 +69,7 @@ static int sock_dispatch_socket(struct dispatcher_context *ctx,
 
 	/* Reassing FD with new obj and entry. */
 	fd = ctx->fd;
-	z_finalize_fd(fd, obj, (const struct fd_op_vtable *)vtable);
+	z_finalize_typed_fd(fd, obj, (const struct fd_op_vtable *)vtable, ZVFS_MODE_IFSOCK);
 
 	/* Release FD that is no longer in use. */
 	z_free_fd(new_fd);
@@ -482,8 +482,8 @@ static int sock_dispatch_create(int family, int type, int proto)
 	entry->proto = proto;
 	entry->is_used = true;
 
-	z_finalize_fd(fd, entry,
-		      (const struct fd_op_vtable *)&sock_dispatch_fd_op_vtable);
+	z_finalize_typed_fd(fd, entry, (const struct fd_op_vtable *)&sock_dispatch_fd_op_vtable,
+			    ZVFS_MODE_IFSOCK);
 
 out:
 	k_mutex_unlock(&dispatcher_lock);

--- a/subsys/net/lib/sockets/socketpair.c
+++ b/subsys/net/lib/sockets/socketpair.c
@@ -264,8 +264,8 @@ static struct spair *spair_new(void)
 		goto cleanup;
 	}
 
-	z_finalize_fd(spair->remote, spair,
-		      (const struct fd_op_vtable *)&spair_fd_op_vtable);
+	z_finalize_typed_fd(spair->remote, spair, (const struct fd_op_vtable *)&spair_fd_op_vtable,
+			    ZVFS_MODE_IFSOCK);
 
 	goto out;
 

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -207,7 +207,8 @@ static int zsock_socket_internal(int family, int type, int proto)
 		net_context_ref(ctx);
 	}
 
-	z_finalize_fd(fd, ctx, (const struct fd_op_vtable *)&sock_fd_op_vtable);
+	z_finalize_typed_fd(fd, ctx, (const struct fd_op_vtable *)&sock_fd_op_vtable,
+			    ZVFS_MODE_IFSOCK);
 
 	NET_DBG("socket: ctx=%p, fd=%d", ctx, fd);
 
@@ -710,7 +711,8 @@ int zsock_accept_ctx(struct net_context *parent, struct sockaddr *addr,
 
 	NET_DBG("accept: ctx=%p, fd=%d", ctx, fd);
 
-	z_finalize_fd(fd, ctx, (const struct fd_op_vtable *)&sock_fd_op_vtable);
+	z_finalize_typed_fd(fd, ctx, (const struct fd_op_vtable *)&sock_fd_op_vtable,
+			    ZVFS_MODE_IFSOCK);
 
 	return fd;
 }

--- a/subsys/net/lib/sockets/sockets_can.c
+++ b/subsys/net/lib/sockets/sockets_can.c
@@ -80,8 +80,8 @@ int zcan_socket(int family, int type, int proto)
 	 */
 	k_condvar_init(&ctx->cond.recv);
 
-	z_finalize_fd(fd, ctx,
-		      (const struct fd_op_vtable *)&can_sock_fd_op_vtable);
+	z_finalize_typed_fd(fd, ctx, (const struct fd_op_vtable *)&can_sock_fd_op_vtable,
+			    ZVFS_MODE_IFSOCK);
 
 	return fd;
 }

--- a/subsys/net/lib/sockets/sockets_net_mgmt.c
+++ b/subsys/net/lib/sockets/sockets_net_mgmt.c
@@ -80,8 +80,8 @@ int znet_mgmt_socket(int family, int type, int proto)
 	mgmt->alloc_timeout = MSG_ALLOC_TIMEOUT;
 	mgmt->wait_timeout = K_FOREVER;
 
-	z_finalize_fd(fd, mgmt,
-		     (const struct fd_op_vtable *)&net_mgmt_sock_fd_op_vtable);
+	z_finalize_typed_fd(fd, mgmt, (const struct fd_op_vtable *)&net_mgmt_sock_fd_op_vtable,
+			    ZVFS_MODE_IFSOCK);
 
 	return fd;
 }

--- a/subsys/net/lib/sockets/sockets_packet.c
+++ b/subsys/net/lib/sockets/sockets_packet.c
@@ -77,8 +77,8 @@ static int zpacket_socket(int family, int type, int proto)
 
 	/* recv_q and accept_q are in union */
 	k_fifo_init(&ctx->recv_q);
-	z_finalize_fd(fd, ctx,
-		      (const struct fd_op_vtable *)&packet_sock_fd_op_vtable);
+	z_finalize_typed_fd(fd, ctx, (const struct fd_op_vtable *)&packet_sock_fd_op_vtable,
+			    ZVFS_MODE_IFSOCK);
 
 	return fd;
 }

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -2090,8 +2090,8 @@ static int ztls_socket(int family, int type, int proto)
 	ctx->type = (proto == IPPROTO_TCP) ? SOCK_STREAM : SOCK_DGRAM;
 	ctx->sock = sock;
 
-	z_finalize_fd(
-		fd, ctx, (const struct fd_op_vtable *)&tls_sock_fd_op_vtable);
+	z_finalize_typed_fd(fd, ctx, (const struct fd_op_vtable *)&tls_sock_fd_op_vtable,
+			    ZVFS_MODE_IFSOCK);
 
 	return fd;
 
@@ -2218,8 +2218,8 @@ int ztls_accept_ctx(struct tls_context *parent, struct sockaddr *addr,
 		goto error;
 	}
 
-	z_finalize_fd(
-		fd, child, (const struct fd_op_vtable *)&tls_sock_fd_op_vtable);
+	z_finalize_typed_fd(fd, child, (const struct fd_op_vtable *)&tls_sock_fd_op_vtable,
+			    ZVFS_MODE_IFSOCK);
 
 	child->sock = sock;
 

--- a/subsys/net/lib/websocket/websocket.c
+++ b/subsys/net/lib/websocket/websocket.c
@@ -369,8 +369,8 @@ int websocket_connect(int sock, struct websocket_request *wreq,
 	}
 
 	ctx->sock = fd;
-	z_finalize_fd(fd, ctx,
-		      (const struct fd_op_vtable *)&websocket_fd_op_vtable);
+	z_finalize_typed_fd(fd, ctx, (const struct fd_op_vtable *)&websocket_fd_op_vtable,
+			    ZVFS_MODE_IFSOCK);
 
 	/* Call the user specified callback and if it accepts the connection
 	 * then continue.
@@ -1171,8 +1171,8 @@ int websocket_register(int sock, uint8_t *recv_buf, size_t recv_buf_len)
 	}
 
 	ctx->sock = fd;
-	z_finalize_fd(fd, ctx,
-		      (const struct fd_op_vtable *)&websocket_fd_op_vtable);
+	z_finalize_typed_fd(fd, ctx, (const struct fd_op_vtable *)&websocket_fd_op_vtable,
+			    ZVFS_MODE_IFSOCK);
 
 	NET_DBG("[%p] WS connection to peer established (fd %d)", ctx, fd);
 

--- a/tests/net/socket/offload_dispatcher/src/main.c
+++ b/tests/net/socket/offload_dispatcher/src/main.c
@@ -277,9 +277,9 @@ int offload_1_socket(int family, int type, int proto)
 		return -1;
 	}
 
-	z_finalize_fd(fd, &test_socket_ctx[OFFLOAD_1],
-		      (const struct fd_op_vtable *)
-					&offload_1_socket_fd_op_vtable);
+	z_finalize_typed_fd(fd, &test_socket_ctx[OFFLOAD_1],
+			    (const struct fd_op_vtable *)&offload_1_socket_fd_op_vtable,
+			    ZVFS_MODE_IFSOCK);
 
 	test_socket_ctx[OFFLOAD_1].socket_called = true;
 
@@ -339,9 +339,9 @@ int offload_2_socket(int family, int type, int proto)
 		return -1;
 	}
 
-	z_finalize_fd(fd, &test_socket_ctx[OFFLOAD_2],
-		      (const struct fd_op_vtable *)
-					&offload_2_socket_fd_op_vtable);
+	z_finalize_typed_fd(fd, &test_socket_ctx[OFFLOAD_2],
+			    (const struct fd_op_vtable *)&offload_2_socket_fd_op_vtable,
+			    ZVFS_MODE_IFSOCK);
 
 	test_socket_ctx[OFFLOAD_2].socket_called = true;
 


### PR DESCRIPTION
Fill-in the mode field of the fd_entry so that the implementation can be made aware that the specific file descriptors created are sockets.
