### PR TITLE
Driver: Sensor: HTS221: Remove log message when trigger disabled

### DIFF
--- a/drivers/sensor/st/hts221/hts221.c
+++ b/drivers/sensor/st/hts221/hts221.c
@@ -191,8 +191,6 @@ int hts221_init(const struct device *dev)
 		LOG_ERR("Failed to initialize interrupt.");
 		return status;
 	}
-#else
-	LOG_INF("Cannot enable trigger without drdy-gpios");
 #endif
 
 	return 0;


### PR DESCRIPTION
My students are using a disco_l475_iot1 board with HTS221 sensor. When logging is enabled, the following log message is always emitted: "HTS221: Cannot enable trigger without drdy-gpios"

This message is confusing to my students as they are not using the HTS221 sensor in their projects. However since HTS221 is enabled in the devicetree it gets initialized on boot and the log message appears.

It doesn't seem necessary to tell people that they haven't enabled CONFIG_HTS221_TRIGGER at log level INF. I'd be amenable to changing this to LOG_DBG, but I don't think it needs to exist at all.