### PR TITLE
boards: frdm_ke1xz series: Suppress no-simple-bus DTC warning

### DIFF
--- a/boards/nxp/frdm_ke15z/pre_dt_board.cmake
+++ b/boards/nxp/frdm_ke15z/pre_dt_board.cmake
@@ -1,0 +1,5 @@
+# Copyright (c) 2024, NXP
+# SPDX-License-Identifier: Apache-2.0
+
+# Suppress "simple_bus_reg" on KE1xz boards as all GPIO share an interrupt.
+list(APPEND EXTRA_DTC_FLAGS "-Wno-simple_bus_reg")

--- a/boards/nxp/frdm_ke17z/pre_dt_board.cmake
+++ b/boards/nxp/frdm_ke17z/pre_dt_board.cmake
@@ -1,0 +1,5 @@
+# Copyright (c) 2024, NXP
+# SPDX-License-Identifier: Apache-2.0
+
+# Suppress "simple_bus_reg" on KE1xz boards as all GPIO share an interrupt.
+list(APPEND EXTRA_DTC_FLAGS "-Wno-simple_bus_reg")

--- a/boards/nxp/frdm_ke17z512/pre_dt_board.cmake
+++ b/boards/nxp/frdm_ke17z512/pre_dt_board.cmake
@@ -1,0 +1,5 @@
+# Copyright (c) 2024, NXP
+# SPDX-License-Identifier: Apache-2.0
+
+# Suppress "simple_bus_reg" on KE1xz boards as all GPIO share an interrupt.
+list(APPEND EXTRA_DTC_FLAGS "-Wno-simple_bus_reg")


### PR DESCRIPTION
All KE1xz GPIOs share a common register and need the dtc warning suppressed.