### PR TITLE
arch: introduce `arch_stack_walk()`

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -409,6 +409,14 @@ config FRAME_POINTER
 	  Select Y here to gain precise stack traces at the expense of slightly
 	  increased size and decreased speed.
 
+config ARCH_STACKWALK_MAX_FRAMES
+	int "Max depth for stack walk function"
+	default 8
+	depends on ARCH_HAS_STACKWALK
+	help
+	  Depending on implementation, this can place a hard limit on the depths of the stack
+	  for the stack walk function to examine.
+
 menu "Interrupt Configuration"
 
 config ISR_TABLES_LOCAL_DECLARATION_SUPPORTED
@@ -653,6 +661,11 @@ config ARCH_HAS_EXTRA_EXCEPTION_INFO
 
 config ARCH_HAS_GDBSTUB
 	bool
+
+config ARCH_HAS_STACKWALK
+	bool
+	help
+	  This is selected when the architecture implemented the arch_stack_walk() API.
 
 config ARCH_HAS_COHERENCE
 	bool

--- a/include/zephyr/arch/arch_interface.h
+++ b/include/zephyr/arch/arch_interface.h
@@ -1251,6 +1251,33 @@ bool arch_pcie_msi_vector_connect(msi_vector_t *vector,
  */
 void arch_spin_relax(void);
 
+/**
+ * stack_trace_callback_fn - Callback for @ref arch_stack_walk
+ * @param cookie Caller supplied pointer handed back by @ref arch_stack_walk
+ * @param addr The stack entry address to consume
+ *
+ * @return True, if the entry was consumed or skipped. False, if there is no space left to store
+ */
+typedef bool (*stack_trace_callback_fn)(void *cookie, unsigned long addr);
+
+/**
+ * @brief Architecture-specific function to walk the stack
+ *
+ * @param callback_fn Callback which is invoked by the architecture code for each entry.
+ * @param cookie Caller supplied pointer which is handed back to @a callback_fn
+ * @param thread Pointer to a k_thread struct, can be NULL
+ * @param esf Pointer to an arch_esf struct, can be NULL
+ *
+ * ============ ======= ============================================
+ * thread	esf
+ * ============ ======= ============================================
+ * thread	NULL	Stack trace from thread (can be _current)
+ * thread	esf	Stack trace starting on esf
+ * ============ ======= ============================================
+ */
+void arch_stack_walk(stack_trace_callback_fn callback_fn, void *cookie,
+		     const struct k_thread *thread, const struct arch_esf *esf);
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -382,6 +382,7 @@ config EXCEPTION_STACK_TRACE
 
 config EXCEPTION_STACK_TRACE_MAX_FRAMES
 	int "Configures the depth of stack trace"
+	default ARCH_STACKWALK_MAX_FRAMES if ARCH_HAS_STACKWALK
 	default 8
 	depends on EXCEPTION_STACK_TRACE
 	help


### PR DESCRIPTION
An architecture can indicate that it has an implementation for the `arch_stack_walk()` function by selecting
`ARCH_HAS_STACKWALK`.

Set the default value of `EXCEPTION_STACK_TRACE_MAX_FRAMES` to `ARCH_STACKWALK_MAX_FRAMES` if the latter is available.