### PR TITLE
arch: riscv: stacktrace: some optimization

### DIFF
--- a/arch/riscv/core/fatal.c
+++ b/arch/riscv/core/fatal.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/debug/symtab.h>
 #include <zephyr/kernel.h>
 #include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
@@ -80,14 +79,7 @@ FUNC_NORETURN void z_riscv_fatal_error_csf(unsigned int reason, const struct arc
 #endif /* CONFIG_RISCV_ISA_RV32E */
 		LOG_ERR("     sp: " PR_REG, z_riscv_get_sp_before_exc(esf));
 		LOG_ERR("     ra: " PR_REG, esf->ra);
-#ifndef CONFIG_SYMTAB
 		LOG_ERR("   mepc: " PR_REG, esf->mepc);
-#else
-		uint32_t offset = 0;
-		const char *name = symtab_find_symbol_name(esf->mepc, &offset);
-
-		LOG_ERR("   mepc: " PR_REG " [%s+0x%x]", esf->mepc, name, offset);
-#endif
 		LOG_ERR("mstatus: " PR_REG, esf->mstatus);
 		LOG_ERR("");
 	}
@@ -107,7 +99,7 @@ FUNC_NORETURN void z_riscv_fatal_error_csf(unsigned int reason, const struct arc
 		LOG_ERR("");
 	}
 
-	if (IS_ENABLED(CONFIG_EXCEPTION_STACK_TRACE) && (esf != NULL)) {
+	if (IS_ENABLED(CONFIG_EXCEPTION_STACK_TRACE)) {
 		z_riscv_unwind_stack(esf);
 	}
 


### PR DESCRIPTION
1. Stack trace now starts from `mepc`
2. Make sure that the stack unwinds in the right direction.