### PR TITLE
boards: mps2_an385: add NVS support

### DIFF
--- a/boards/arm/mps2/mps2_an385.dts
+++ b/boards/arm/mps2/mps2_an385.dts
@@ -73,6 +73,33 @@
 		reg = <0 0x400000>;
 	};
 
+	sim_flash_controller: sim_flash_controller {
+		compatible = "zephyr,sim-flash";
+
+		#address-cells = <1>;
+		#size-cells = <1>;
+		erase-value = <0x00>;
+
+		flash_sim0: flash_sim@0 {
+			compatible = "soc-nv-flash";
+			reg = <0x00000000 0x8000>;
+
+			erase-block-size = <1024>;
+			write-block-size = <4>;
+
+			partitions {
+				compatible = "fixed-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				storage_partition: partition@0 {
+					label = "storage_partition";
+					reg = <0x00000000 0x8000>;
+				};
+			};
+		};
+	};
+
 	sysclk: system-clock {
 		compatible = "fixed-clock";
 		clock-frequency = <25000000>;

--- a/tests/subsys/fs/nvs/src/main.c
+++ b/tests/subsys/fs/nvs/src/main.c
@@ -8,11 +8,12 @@
  * This test is designed to be run using flash-simulator which provide
  * functionality for flash property customization and emulating errors in
  * flash operation in parallel to regular flash API.
- * Test should be run on qemu_x86 or native_sim target.
+ * Test should be run on qemu_x86, mps2_an385 or native_sim target.
  */
 
-#if !defined(CONFIG_BOARD_QEMU_X86) && !defined(CONFIG_ARCH_POSIX)
-#error "Run only on qemu_x86 or a posix architecture based target (for ex. native_sim)"
+#if !defined(CONFIG_BOARD_QEMU_X86) && !defined(CONFIG_ARCH_POSIX) &&                              \
+	!defined(CONFIG_BOARD_MPS2_AN385)
+#error "Run only on qemu_x86, mps2_an385, or a posix architecture based target (for ex. native_sim)"
 #endif
 
 #include <stdio.h>

--- a/tests/subsys/fs/nvs/testcase.yaml
+++ b/tests/subsys/fs/nvs/testcase.yaml
@@ -2,7 +2,9 @@ common:
   tags: nvs
 tests:
   filesystem.nvs:
-    platform_allow: qemu_x86
+    platform_allow:
+      - qemu_x86
+      - mps2/an385
   filesystem.nvs.0x00:
     extra_args: DTC_OVERLAY_FILE=boards/qemu_x86_ev_0x00.overlay
     platform_allow: qemu_x86


### PR DESCRIPTION
  Add support for NVS on the board by default. Using the simulated flash
  driver is required as this board has no flash controller. Support is
  desired as this is the ARM board used by coverage testing.