### PR TITLE
net: Support partial checksum offloading

### DIFF
--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -218,6 +218,8 @@ enum ethernet_config_type {
 	ETHERNET_CONFIG_TYPE_PORTS_NUM,
 	ETHERNET_CONFIG_TYPE_T1S_PARAM,
 	ETHERNET_CONFIG_TYPE_TXINJECTION_MODE,
+	ETHERNET_CONFIG_TYPE_RX_CHECKSUM_SUPPORT,
+	ETHERNET_CONFIG_TYPE_TX_CHECKSUM_SUPPORT
 };
 
 enum ethernet_qav_param_type {
@@ -465,6 +467,24 @@ struct ethernet_txtime_param {
 	bool enable_txtime;
 };
 
+/** Protocols that are supported by checksum offloading */
+enum ethernet_checksum_support {
+	/** Device does not support any L3/L4 checksum offloading */
+	ETHERNET_CHECKSUM_SUPPORT_NONE			= NET_IF_CHECKSUM_NONE_BIT,
+	/** Device supports checksum offloading for the IPv4 header */
+	ETHERNET_CHECKSUM_SUPPORT_IPV4_HEADER		= NET_IF_CHECKSUM_IPV4_HEADER_BIT,
+	/** Device supports checksum offloading for ICMPv4 payload (implies IPv4 header) */
+	ETHERNET_CHECKSUM_SUPPORT_IPV4_ICMP		= NET_IF_CHECKSUM_IPV4_ICMP_BIT,
+	/** Device supports checksum offloading for the IPv6 header */
+	ETHERNET_CHECKSUM_SUPPORT_IPV6_HEADER		= NET_IF_CHECKSUM_IPV6_HEADER_BIT,
+	/** Device supports checksum offloading for ICMPv6 payload (implies IPv6 header) */
+	ETHERNET_CHECKSUM_SUPPORT_IPV6_ICMP		= NET_IF_CHECKSUM_IPV6_ICMP_BIT,
+	/** Device supports TCP checksum offloading for all supported IP protocols */
+	ETHERNET_CHECKSUM_SUPPORT_TCP			= NET_IF_CHECKSUM_TCP_BIT,
+	/** Device supports UDP checksum offloading for all supported IP protocols */
+	ETHERNET_CHECKSUM_SUPPORT_UDP			= NET_IF_CHECKSUM_UDP_BIT,
+};
+
 /** @cond INTERNAL_HIDDEN */
 
 struct ethernet_config {
@@ -490,6 +510,8 @@ struct ethernet_config {
 
 		int priority_queues_num;
 		int ports_num;
+
+		enum ethernet_checksum_support chksum_support;
 
 		struct ethernet_filter filter;
 	};
@@ -912,6 +934,30 @@ enum ethernet_hw_caps net_eth_get_hw_capabilities(struct net_if *iface)
 
 	return eth->get_capabilities(net_if_get_device(iface));
 }
+
+/**
+ * @brief Return ethernet device hardware configuration information.
+ *
+ * @param iface Network interface
+ * @param type configuration type
+ * @param config Ethernet configuration
+ *
+ * @return 0 if ok, <0 if error
+ */
+static inline
+int net_eth_get_hw_config(struct net_if *iface, enum ethernet_config_type type,
+			 struct ethernet_config *config)
+{
+	const struct ethernet_api *eth =
+		(struct ethernet_api *)net_if_get_device(iface)->api;
+
+	if (!eth->get_config) {
+		return -ENOTSUP;
+	}
+
+	return eth->get_config(net_if_get_device(iface), type, config);
+}
+
 
 /**
  * @brief Add VLAN tag to the interface.

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -2643,16 +2643,61 @@ void net_if_unregister_link_cb(struct net_if_link_cb *link);
 void net_if_call_link_cb(struct net_if *iface, struct net_linkaddr *lladdr,
 			 int status);
 
+/** @cond INTERNAL_HIDDEN */
+
+/* used to ensure encoding of checksum support in net_if.h and
+ * ethernet.h is the same
+ */
+#define NET_IF_CHECKSUM_NONE_BIT			0
+#define NET_IF_CHECKSUM_IPV4_HEADER_BIT			BIT(0)
+#define NET_IF_CHECKSUM_IPV4_ICMP_BIT			BIT(1)
+/* Space for future protocols and restrictions for IPV4 */
+#define NET_IF_CHECKSUM_IPV6_HEADER_BIT			BIT(10)
+#define NET_IF_CHECKSUM_IPV6_ICMP_BIT			BIT(11)
+/* Space for future protocols and restrictions for IPV6 */
+#define NET_IF_CHECKSUM_TCP_BIT				BIT(21)
+#define NET_IF_CHECKSUM_UDP_BIT				BIT(22)
+
+/** @endcond */
+
+/**
+ * @brief Type of checksum for which support in the interface will be queried.
+ */
+enum net_if_checksum_type {
+	/** Interface supports IP version 4 header checksum calculation */
+	NET_IF_CHECKSUM_IPV4_HEADER = NET_IF_CHECKSUM_IPV4_HEADER_BIT,
+	/** Interface supports checksum calculation for TCP payload in IPv4 */
+	NET_IF_CHECKSUM_IPV4_TCP    = NET_IF_CHECKSUM_IPV4_HEADER_BIT |
+				      NET_IF_CHECKSUM_TCP_BIT,
+	/** Interface supports checksum calculation for UDP payload in IPv4 */
+	NET_IF_CHECKSUM_IPV4_UDP    = NET_IF_CHECKSUM_IPV4_HEADER_BIT |
+				      NET_IF_CHECKSUM_UDP_BIT,
+	/** Interface supports checksum calculation for ICMP4 payload in IPv4 */
+	NET_IF_CHECKSUM_IPV4_ICMP   = NET_IF_CHECKSUM_IPV4_ICMP_BIT,
+	/** Interface supports IP version 6 header checksum calculation */
+	NET_IF_CHECKSUM_IPV6_HEADER = NET_IF_CHECKSUM_IPV6_HEADER_BIT,
+	/** Interface supports checksum calculation for TCP payload in IPv6 */
+	NET_IF_CHECKSUM_IPV6_TCP    = NET_IF_CHECKSUM_IPV6_HEADER_BIT |
+				      NET_IF_CHECKSUM_TCP_BIT,
+	/** Interface supports checksum calculation for UDP payload in IPv6 */
+	NET_IF_CHECKSUM_IPV6_UDP    = NET_IF_CHECKSUM_IPV6_HEADER_BIT |
+				      NET_IF_CHECKSUM_UDP_BIT,
+	/** Interface supports checksum calculation for ICMP6 payload in IPv6 */
+	NET_IF_CHECKSUM_IPV6_ICMP   = NET_IF_CHECKSUM_IPV6_ICMP_BIT
+};
+
 /**
  * @brief Check if received network packet checksum calculation can be avoided
  * or not. For example many ethernet devices support network packet offloading
  * in which case the IP stack does not need to calculate the checksum.
  *
  * @param iface Network interface
+ * @param chksum_type L3 and/or L4 protocol for which to compute checksum
  *
  * @return True if checksum needs to be calculated, false otherwise.
  */
-bool net_if_need_calc_rx_checksum(struct net_if *iface);
+bool net_if_need_calc_rx_checksum(struct net_if *iface,
+				  enum net_if_checksum_type chksum_type);
 
 /**
  * @brief Check if network packet checksum calculation can be avoided or not
@@ -2661,10 +2706,12 @@ bool net_if_need_calc_rx_checksum(struct net_if *iface);
  * checksum.
  *
  * @param iface Network interface
+ * @param chksum_type L3 and/or L4 protocol for which to compute checksum
  *
  * @return True if checksum needs to be calculated, false otherwise.
  */
-bool net_if_need_calc_tx_checksum(struct net_if *iface);
+bool net_if_need_calc_tx_checksum(struct net_if *iface,
+				  enum net_if_checksum_type chksum_type);
 
 /**
  * @brief Get interface according to index

--- a/subsys/net/ip/icmpv4.c
+++ b/subsys/net/ip/icmpv4.c
@@ -65,7 +65,8 @@ int net_icmpv4_finalize(struct net_pkt *pkt, bool force_chksum)
 	}
 
 	icmp_hdr->chksum = 0U;
-	if (net_if_need_calc_tx_checksum(net_pkt_iface(pkt)) || force_chksum) {
+	if (net_if_need_calc_tx_checksum(net_pkt_iface(pkt), NET_IF_CHECKSUM_IPV4_ICMP) ||
+		force_chksum) {
 		icmp_hdr->chksum = net_calc_chksum_icmpv4(pkt);
 		net_pkt_set_chksum_done(pkt, true);
 	}
@@ -615,7 +616,7 @@ enum net_verdict net_icmpv4_input(struct net_pkt *pkt,
 		return NET_DROP;
 	}
 
-	if (net_if_need_calc_rx_checksum(net_pkt_iface(pkt)) ||
+	if (net_if_need_calc_rx_checksum(net_pkt_iface(pkt), NET_IF_CHECKSUM_IPV4_ICMP) ||
 	    net_pkt_is_ip_reassembled(pkt)) {
 		if (net_calc_chksum_icmpv4(pkt) != 0U) {
 			NET_DBG("DROP: Invalid checksum");

--- a/subsys/net/ip/icmpv6.c
+++ b/subsys/net/ip/icmpv6.c
@@ -69,7 +69,8 @@ int net_icmpv6_finalize(struct net_pkt *pkt, bool force_chksum)
 	}
 
 	icmp_hdr->chksum = 0U;
-	if (net_if_need_calc_tx_checksum(net_pkt_iface(pkt)) || force_chksum) {
+	if (net_if_need_calc_tx_checksum(net_pkt_iface(pkt), NET_IF_CHECKSUM_IPV6_ICMP) ||
+		force_chksum) {
 		icmp_hdr->chksum = net_calc_chksum_icmpv6(pkt);
 		net_pkt_set_chksum_done(pkt, true);
 	}
@@ -347,7 +348,7 @@ enum net_verdict net_icmpv6_input(struct net_pkt *pkt,
 	}
 
 
-	if (net_if_need_calc_rx_checksum(net_pkt_iface(pkt)) ||
+	if (net_if_need_calc_rx_checksum(net_pkt_iface(pkt), NET_IF_CHECKSUM_IPV6_ICMP) ||
 	    net_pkt_is_ip_reassembled(pkt)) {
 		if (net_calc_chksum_icmpv6(pkt) != 0U) {
 			NET_DBG("DROP: invalid checksum");

--- a/subsys/net/ip/ipv4.c
+++ b/subsys/net/ip/ipv4.c
@@ -122,7 +122,7 @@ int net_ipv4_finalize(struct net_pkt *pkt, uint8_t next_header_proto)
 	ipv4_hdr->len   = htons(net_pkt_get_len(pkt));
 	ipv4_hdr->proto = next_header_proto;
 
-	if (net_if_need_calc_tx_checksum(net_pkt_iface(pkt))) {
+	if (net_if_need_calc_tx_checksum(net_pkt_iface(pkt), NET_IF_CHECKSUM_IPV4_HEADER)) {
 		ipv4_hdr->chksum = net_calc_chksum_ipv4(pkt);
 	}
 
@@ -323,7 +323,7 @@ enum net_verdict net_ipv4_input(struct net_pkt *pkt, bool is_loopback)
 		goto drop;
 	}
 
-	if (net_if_need_calc_rx_checksum(net_pkt_iface(pkt)) &&
+	if (net_if_need_calc_rx_checksum(net_pkt_iface(pkt), NET_IF_CHECKSUM_IPV4_HEADER) &&
 	    net_calc_chksum_ipv4(pkt) != 0U) {
 		NET_DBG("DROP: invalid chksum");
 		goto drop;

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -4932,14 +4932,33 @@ void net_if_call_link_cb(struct net_if *iface, struct net_linkaddr *lladdr,
 	k_mutex_unlock(&lock);
 }
 
-static bool need_calc_checksum(struct net_if *iface, enum ethernet_hw_caps caps)
+static bool need_calc_checksum(struct net_if *iface, enum ethernet_hw_caps caps,
+			      enum net_if_checksum_type chksum_type)
 {
 #if defined(CONFIG_NET_L2_ETHERNET)
+	struct ethernet_config config;
+	enum ethernet_config_type config_type;
+
 	if (net_if_l2(iface) != &NET_L2_GET_NAME(ETHERNET)) {
 		return true;
 	}
 
-	return !(net_eth_get_hw_capabilities(iface) & caps);
+	if (!(net_eth_get_hw_capabilities(iface) & caps)) {
+		return true; /* No checksum offload*/
+	}
+
+	if (caps == ETHERNET_HW_RX_CHKSUM_OFFLOAD) {
+		config_type = ETHERNET_CONFIG_TYPE_RX_CHECKSUM_SUPPORT;
+	} else {
+		config_type = ETHERNET_CONFIG_TYPE_TX_CHECKSUM_SUPPORT;
+	}
+
+	if (net_eth_get_hw_config(iface, config_type, &config) != 0) {
+		return false; /* No extra info, assume all offloaded. */
+	}
+
+	/* bitmaps are encoded such that this works */
+	return !((config.chksum_support & chksum_type) == chksum_type);
 #else
 	ARG_UNUSED(iface);
 	ARG_UNUSED(caps);
@@ -4948,14 +4967,14 @@ static bool need_calc_checksum(struct net_if *iface, enum ethernet_hw_caps caps)
 #endif
 }
 
-bool net_if_need_calc_tx_checksum(struct net_if *iface)
+bool net_if_need_calc_tx_checksum(struct net_if *iface, enum net_if_checksum_type chksum_type)
 {
-	return need_calc_checksum(iface, ETHERNET_HW_TX_CHKSUM_OFFLOAD);
+	return need_calc_checksum(iface, ETHERNET_HW_TX_CHKSUM_OFFLOAD, chksum_type);
 }
 
-bool net_if_need_calc_rx_checksum(struct net_if *iface)
+bool net_if_need_calc_rx_checksum(struct net_if *iface, enum net_if_checksum_type chksum_type)
 {
-	return need_calc_checksum(iface, ETHERNET_HW_RX_CHKSUM_OFFLOAD);
+	return need_calc_checksum(iface, ETHERNET_HW_RX_CHKSUM_OFFLOAD, chksum_type);
 }
 
 int net_if_get_by_iface(struct net_if *iface)

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -4043,6 +4043,8 @@ int net_tcp_finalize(struct net_pkt *pkt, bool force_chksum)
 {
 	NET_PKT_DATA_ACCESS_DEFINE(tcp_access, struct net_tcp_hdr);
 	struct net_tcp_hdr *tcp_hdr;
+	enum net_if_checksum_type type = net_pkt_family(pkt) == AF_INET6 ?
+		NET_IF_CHECKSUM_IPV6_TCP : NET_IF_CHECKSUM_IPV4_TCP;
 
 	tcp_hdr = (struct net_tcp_hdr *)net_pkt_get_data(pkt, &tcp_access);
 	if (!tcp_hdr) {
@@ -4051,7 +4053,7 @@ int net_tcp_finalize(struct net_pkt *pkt, bool force_chksum)
 
 	tcp_hdr->chksum = 0U;
 
-	if (net_if_need_calc_tx_checksum(net_pkt_iface(pkt)) || force_chksum) {
+	if (net_if_need_calc_tx_checksum(net_pkt_iface(pkt), type) || force_chksum) {
 		tcp_hdr->chksum = net_calc_chksum_tcp(pkt);
 		net_pkt_set_chksum_done(pkt, true);
 	}
@@ -4063,9 +4065,11 @@ struct net_tcp_hdr *net_tcp_input(struct net_pkt *pkt,
 				  struct net_pkt_data_access *tcp_access)
 {
 	struct net_tcp_hdr *tcp_hdr;
+	enum net_if_checksum_type type = net_pkt_family(pkt) == AF_INET6 ?
+		NET_IF_CHECKSUM_IPV6_TCP : NET_IF_CHECKSUM_IPV4_TCP;
 
 	if (IS_ENABLED(CONFIG_NET_TCP_CHECKSUM) &&
-	    (net_if_need_calc_rx_checksum(net_pkt_iface(pkt)) ||
+	    (net_if_need_calc_rx_checksum(net_pkt_iface(pkt), type) ||
 	     net_pkt_is_ip_reassembled(pkt)) &&
 	    net_calc_chksum_tcp(pkt) != 0U) {
 		NET_DBG("DROP: checksum mismatch");


### PR DESCRIPTION
The Xilinx AXI Ethernet subsystem is capable of RX/Tx checksum offloading. While it supports computing IP and UDP/TCP checksums, it does not support computing ICMP checksums and only computes IP checksums for ICMP messages. Thus, this patch adds an default-disabled option for always computing the ICMP checksum in software while relying on hardware to compute the remaining checksums.