### PR TITLE
drivers: udc_dwc2: Allocate at least 8 bytes for control OUT

### DIFF
--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -469,7 +469,10 @@ static int dwc2_handle_evt_setup(const struct device *dev)
 		/*  Allocate and feed buffer for data OUT stage */
 		LOG_DBG("s:%p|feed for -out-", buf);
 
-		err = dwc2_ctrl_feed_dout(dev, udc_data_stage_length(buf));
+		/* Allocate at least 8 bytes in case the host decides to send
+		 * SETUP DATA instead of OUT DATA packet.
+		 */
+		err = dwc2_ctrl_feed_dout(dev, MAX(udc_data_stage_length(buf), 8));
 		if (err == -ENOMEM) {
 			err = udc_submit_ep_event(dev, buf, err);
 		}


### PR DESCRIPTION
Make sure to feed control OUT endpoint with at least 8 bytes buffer to make it possible to always receive SETUP data. This solves the assertion failure in net_buf_add() called inside dwc2_handle_evt_setup() when a host decides to start new control transfer immediately after it has issued control transfer with Data Stage from host to device with wLength less than 8.