### PR TITLE
kernel: mem_slab: only define slab_ptr_is_good with assert enabled

### DIFF
--- a/kernel/mem_slab.c
+++ b/kernel/mem_slab.c
@@ -204,7 +204,8 @@ out:
 	return rc;
 }
 
-static inline bool slab_ptr_is_good(struct k_mem_slab *slab, const void *ptr)
+#if __ASSERT_ON
+static bool slab_ptr_is_good(struct k_mem_slab *slab, const void *ptr)
 {
 	const char *p = ptr;
 	ptrdiff_t offset = p - slab->buffer;
@@ -213,6 +214,7 @@ static inline bool slab_ptr_is_good(struct k_mem_slab *slab, const void *ptr)
 	       (offset < (slab->info.block_size * slab->info.num_blocks)) &&
 	       ((offset % slab->info.block_size) == 0);
 }
+#endif
 
 int k_mem_slab_alloc(struct k_mem_slab *slab, void **mem, k_timeout_t timeout)
 {


### PR DESCRIPTION
Seen this downstream on a clang 18 arm setup, could not quite reproduce it upstream so I guess it boils down to compiler versions.

---

Add a __ASSERT_ON guard around slab_ptr_is_good, as that is only used in assertions and leavint it on seems to generate a build warning with some clang versions:

kernel/mem_slab.c:207:20: error: unused function 'slab_ptr_is_good'
  207 | static inline bool slab_ptr_is_good(struct k_mem_slab *slab,...
      |                    ^~~~~~~~~~~~~~~~