### PR TITLE
usb: device_next: Clarify UAC2 send buffer requirements

### DIFF
--- a/include/zephyr/usb/class/usbd_uac2.h
+++ b/include/zephyr/usb/class/usbd_uac2.h
@@ -58,7 +58,7 @@ struct uac2_ops {
 	 * USB stack calls this function to obtain receive buffer address for
 	 * AudioStreaming interface. The buffer is owned by USB stack until
 	 * @ref data_recv_cb callback is called. The buffer must be sufficiently
-	 * aligned for use by UDC driver.
+	 * aligned and otherwise suitable for use by UDC driver.
 	 *
 	 * @param dev USB Audio 2 device
 	 * @param terminal Input Terminal ID linked to AudioStreaming interface
@@ -125,6 +125,9 @@ void usbd_uac2_set_ops(const struct device *dev,
 
 /**
  * @brief Send audio data to output terminal
+ *
+ * Data buffer must be sufficiently aligned and otherwise suitable for use by
+ * UDC driver.
  *
  * @param dev USB Audio 2 device
  * @param terminal Output Terminal ID linked to AudioStreaming interface


### PR DESCRIPTION
The original intention was that the audio buffers supplied by application to the UAC2 API can be directly used by UDC driver. The buffer alignment requirement was explicitly stated with regards to the receive buffer, but was mistakenly omitted on transmit buffer.

While the missing comment is added, mention also that the buffer has to be otherwise suitable for use by UDC driver, because alignment might not be the only UDC driver requirement. For example, the UDC driver can require the buffer to reside in memory region that it can access with DMA.