### PR TITLE
manifest: Update LittleFS to 2.9.3 from upstream

### DIFF
--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -251,6 +251,10 @@ Libraries / Subsystems
 
 * Storage
 
+  * LittleFS: The module has been updated with changes committed upstream
+    from version 2.8.1, the last module update, up to and including
+    the released version 2.9.3.
+
 * Task Watchdog
 
 * POSIX API

--- a/west.yml
+++ b/west.yml
@@ -272,7 +272,7 @@ manifest:
       path: modules/fs/littlefs
       groups:
         - fs
-      revision: 408c16a909dd6cf128874a76f21c793798c9e423
+      revision: 009bcff0ed4853a53df8256039fa815bda6854dd
     - name: loramac-node
       revision: fb00b383072518c918e2258b0916c996f2d4eebe
       path: modules/lib/loramac-node


### PR DESCRIPTION
Update Zephyr fork of LittleFS to v2.9.3.