### PR TITLE
Bluetooth: Host: Add Per Adv Sync handle getter

### DIFF
--- a/include/zephyr/bluetooth/hci.h
+++ b/include/zephyr/bluetooth/hci.h
@@ -97,6 +97,15 @@ int bt_hci_get_conn_handle(const struct bt_conn *conn, uint16_t *conn_handle);
  */
 int bt_hci_get_adv_handle(const struct bt_le_ext_adv *adv, uint8_t *adv_handle);
 
+/** @brief Get periodic advertising sync handle.
+ *
+ * @param sync Periodic advertising sync set.
+ * @param sync_handle Place to store the periodic advertising sync handle.
+ *
+ * @return 0 on success or negative error value on failure.
+ */
+int bt_hci_get_adv_sync_handle(const struct bt_le_per_adv_sync *sync, uint16_t *sync_handle);
+
 /** @brief Obtain the version string given a core version number.
  *
  * The core version of a controller can be obtained by issuing

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2479,6 +2479,19 @@ int bt_hci_get_adv_handle(const struct bt_le_ext_adv *adv, uint8_t *adv_handle)
 }
 #endif /* CONFIG_BT_EXT_ADV */
 
+#if defined(CONFIG_BT_PER_ADV_SYNC)
+int bt_hci_get_adv_sync_handle(const struct bt_le_per_adv_sync *sync, uint16_t *sync_handle)
+{
+	if (!atomic_test_bit(sync->flags, BT_PER_ADV_SYNC_CREATED)) {
+		return -EINVAL;
+	}
+
+	*sync_handle = sync->handle;
+
+	return 0;
+}
+#endif
+
 #if defined(CONFIG_BT_HCI_VS_EVT_USER)
 int bt_hci_register_vnd_evt_cb(bt_hci_vnd_evt_cb_t cb)
 {


### PR DESCRIPTION
The same way as `bt_hci_get_adv_handle` and `bt_hci_get_conn_handle` add a function to get the handle of a periodic advertising sync.