### PR TITLE
drivers: flash: Fix stm32 ospi and xpsi reset gpios handling

### DIFF
--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -898,6 +898,8 @@ static int stm32_ospi_mem_reset(const struct device *dev)
 	struct flash_stm32_ospi_data *dev_data = dev->data;
 
 #if STM32_OSPI_RESET_GPIO
+	const struct flash_stm32_ospi_config *dev_cfg = dev->config;
+
 	/* Generate RESETn pulse for the flash memory */
 	gpio_pin_configure_dt(&dev_cfg->reset, GPIO_OUTPUT_ACTIVE);
 	k_msleep(DT_INST_PROP(0, reset_gpios_duration));

--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -737,6 +737,8 @@ static int stm32_xspi_mem_reset(const struct device *dev)
 	struct flash_stm32_xspi_data *dev_data = dev->data;
 
 #if STM32_XSPI_RESET_GPIO
+	const struct flash_stm32_xspi_config *dev_cfg = dev->config;
+
 	/* Generate RESETn pulse for the flash memory */
 	gpio_pin_configure_dt(&dev_cfg->reset, GPIO_OUTPUT_ACTIVE);
 	k_msleep(DT_INST_PROP(0, reset_gpios_duration));

--- a/dts/bindings/flash_controller/st,stm32-ospi-nor.yaml
+++ b/dts/bindings/flash_controller/st,stm32-ospi-nor.yaml
@@ -32,6 +32,9 @@ properties:
   reset-gpios:
     type: phandle-array
     description: RESETn pin
+  reset-gpios-duration:
+    type: int
+    description: The duration (in ms) for the flash memory reset pulse
   spi-bus-width:
     type: int
     required: true


### PR DESCRIPTION
Fix compilation error when reset-gpios is enabled. Undefined reference to dev_cfg variable.
Reset gpio duration needs to be defined, but is not in binding file.