### PR TITLE
subsys/portability/CMSIS: Do not redefine TRUE & FALSE

### DIFF
--- a/subsys/portability/cmsis_rtos_v2/wrapper.h
+++ b/subsys/portability/cmsis_rtos_v2/wrapper.h
@@ -10,8 +10,12 @@
 #include <zephyr/kernel.h>
 #include <cmsis_os2.h>
 
+#ifndef TRUE
 #define TRUE    1
+#endif
+#ifndef FALSE
 #define FALSE   0
+#endif
 
 struct cv2_thread {
 	sys_dnode_t node;


### PR DESCRIPTION
These macros tend to be defined by too many headers. Let's guard these definition with ifdefs to avoid
redefining them.

Fixes: #74000
Fixes: #73442