### PR TITLE
net: lwm2m: Bypass send_queue when sending empty Ack

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -750,9 +750,12 @@ int lwm2m_send_empty_ack(struct lwm2m_ctx *client_ctx, uint16_t mid)
 		goto cleanup;
 	}
 
-	lwm2m_send_message_async(msg);
+	ret = zsock_send(client_ctx->sock_fd, msg->cpkt.data, msg->cpkt.offset, 0);
 
-	return 0;
+	if (ret < 0) {
+		LOG_ERR("Failed to send packet, err %d", errno);
+		ret = -errno;
+	}
 
 cleanup:
 	lwm2m_reset_message(msg, true);


### PR DESCRIPTION
In case we want to immediately send empty Ack to server, we should bypass all send queues.

This is required when we try to send Ack from callbacks that happen from socket-loop context. On those cases the Ack would have not been send because the callback might be blocking the socket-loop while processing a request (like write callbacks).

This fix makes the API submitted in https://github.com/zephyrproject-rtos/zephyr/pull/30392 to actually work on post-write callbacks that block for a long time. For example FOTA process that erases a flash before writing the content.
