### PR TITLE
Bluetooth: Host: Avoid registering a callback twice

### DIFF
--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -1817,8 +1817,11 @@ int bt_le_per_adv_sync_delete(struct bt_le_per_adv_sync *per_adv_sync);
  * such as synced, terminated and when data is received.
  *
  * @param cb Callback struct. Must point to memory that remains valid.
+ *
+ * @retval 0 Success.
+ * @retval -EEXIST if @p cb was already registered.
  */
-void bt_le_per_adv_sync_cb_register(struct bt_le_per_adv_sync_cb *cb);
+int bt_le_per_adv_sync_cb_register(struct bt_le_per_adv_sync_cb *cb);
 
 /**
  * @brief Enables receiving periodic advertising reports for a sync.
@@ -2304,8 +2307,11 @@ int bt_le_scan_stop(void);
  * API was used to start the scanner.
  *
  * @param cb Callback struct. Must point to memory that remains valid.
+ *
+ * @retval 0 Success.
+ * @retval -EEXIST if @p cb was already registered.
  */
-void bt_le_scan_cb_register(struct bt_le_scan_cb *cb);
+int bt_le_scan_cb_register(struct bt_le_scan_cb *cb);
 
 /**
  * @brief Unregister scanner packet callbacks.

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -1256,8 +1256,11 @@ struct bt_conn_cb {
  *  Register callbacks to monitor the state of connections.
  *
  *  @param cb Callback struct. Must point to memory that remains valid.
+ *
+ * @retval 0 Success.
+ * @retval -EEXIST if @p cb was already registered.
  */
-void bt_conn_cb_register(struct bt_conn_cb *cb);
+int bt_conn_cb_register(struct bt_conn_cb *cb);
 
 /**
  * @brief Unregister connection callbacks.

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -1247,7 +1247,8 @@ struct bt_conn_cb {
 				const struct bt_conn_le_path_loss_threshold_report *report);
 #endif /* CONFIG_BT_PATH_LOSS_MONITORING */
 
-	struct bt_conn_cb *_next;
+	/** @internal Internally used field for list handling */
+	sys_snode_t _node;
 };
 
 /** @brief Register connection callbacks.

--- a/include/zephyr/bluetooth/testing.h
+++ b/include/zephyr/bluetooth/testing.h
@@ -53,8 +53,11 @@ struct bt_test_cb {
 /** Register callbacks for Bluetooth testing purposes
  *
  *  @param cb bt_test_cb callback structure
+ *
+ * @retval 0 Success.
+ * @retval -EEXIST if @p cb was already registered.
  */
-void bt_test_cb_register(struct bt_test_cb *cb);
+int bt_test_cb_register(struct bt_test_cb *cb);
 
 /** Unregister callbacks for Bluetooth testing purposes
  *

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2465,11 +2465,15 @@ bt_security_t bt_conn_get_security(const struct bt_conn *conn)
 }
 #endif /* CONFIG_BT_SMP */
 
-void bt_conn_cb_register(struct bt_conn_cb *cb)
+int bt_conn_cb_register(struct bt_conn_cb *cb)
 {
-	if (!sys_slist_find(&conn_cbs, &cb->_node, NULL)) {
-		sys_slist_append(&conn_cbs, &cb->_node);
+	if (sys_slist_find(&conn_cbs, &cb->_node, NULL)) {
+		return -EEXIST;
 	}
+
+	sys_slist_append(&conn_cbs, &cb->_node);
+
+	return 0;
 }
 
 int bt_conn_cb_unregister(struct bt_conn_cb *cb)

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -119,7 +119,8 @@ const struct bt_conn_auth_cb *bt_auth;
 sys_slist_t bt_auth_info_cbs = SYS_SLIST_STATIC_INIT(&bt_auth_info_cbs);
 #endif /* CONFIG_BT_SMP || CONFIG_BT_CLASSIC */
 
-static struct bt_conn_cb *callback_list;
+
+static sys_slist_t callback_list = SYS_SLIST_STATIC_INIT(&callback_list);
 
 static struct bt_conn_tx conn_tx[CONFIG_BT_CONN_TX_MAX];
 
@@ -1544,9 +1545,11 @@ static void tx_complete_work(struct k_work *work)
 static void notify_recycled_conn_slot(void)
 {
 #if defined(CONFIG_BT_CONN)
-	for (struct bt_conn_cb *cb = callback_list; cb; cb = cb->_next) {
-		if (cb->recycled) {
-			cb->recycled();
+	struct bt_conn_cb *callback;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&callback_list, callback, _node) {
+		if (callback->recycled) {
+			callback->recycled();
 		}
 	}
 
@@ -1639,9 +1642,11 @@ int bt_conn_disconnect(struct bt_conn *conn, uint8_t reason)
 
 static void notify_connected(struct bt_conn *conn)
 {
-	for (struct bt_conn_cb *cb = callback_list; cb; cb = cb->_next) {
-		if (cb->connected) {
-			cb->connected(conn, conn->err);
+	struct bt_conn_cb *callback;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&callback_list, callback, _node) {
+		if (callback->connected) {
+			callback->connected(conn, conn->err);
 		}
 	}
 
@@ -1654,9 +1659,11 @@ static void notify_connected(struct bt_conn *conn)
 
 static void notify_disconnected(struct bt_conn *conn)
 {
-	for (struct bt_conn_cb *cb = callback_list; cb; cb = cb->_next) {
-		if (cb->disconnected) {
-			cb->disconnected(conn, conn->err);
+	struct bt_conn_cb *callback;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&callback_list, callback, _node) {
+		if (callback->disconnected) {
+			callback->disconnected(conn, conn->err);
 		}
 	}
 
@@ -1679,9 +1686,11 @@ void notify_remote_info(struct bt_conn *conn)
 		return;
 	}
 
-	for (struct bt_conn_cb *cb = callback_list; cb; cb = cb->_next) {
-		if (cb->remote_info_available) {
-			cb->remote_info_available(conn, &remote_info);
+	struct bt_conn_cb *callback;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&callback_list, callback, _node) {
+		if (callback->remote_info_available) {
+			callback->remote_info_available(conn, &remote_info);
 		}
 	}
 
@@ -1706,11 +1715,13 @@ void notify_le_param_updated(struct bt_conn *conn)
 		atomic_clear_bit(conn->flags, BT_CONN_PERIPHERAL_PARAM_SET);
 	}
 
-	for (struct bt_conn_cb *cb = callback_list; cb; cb = cb->_next) {
-		if (cb->le_param_updated) {
-			cb->le_param_updated(conn, conn->le.interval,
-					     conn->le.latency,
-					     conn->le.timeout);
+	struct bt_conn_cb *callback;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&callback_list, callback, _node) {
+		if (callback->le_param_updated) {
+			callback->le_param_updated(conn, conn->le.interval,
+						   conn->le.latency,
+						   conn->le.timeout);
 		}
 	}
 
@@ -1726,9 +1737,11 @@ void notify_le_param_updated(struct bt_conn *conn)
 #if defined(CONFIG_BT_USER_DATA_LEN_UPDATE)
 void notify_le_data_len_updated(struct bt_conn *conn)
 {
-	for (struct bt_conn_cb *cb = callback_list; cb; cb = cb->_next) {
-		if (cb->le_data_len_updated) {
-			cb->le_data_len_updated(conn, &conn->le.data_len);
+	struct bt_conn_cb *callback;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&callback_list, callback, _node) {
+		if (callback->le_data_len_updated) {
+			callback->le_data_len_updated(conn, &conn->le.data_len);
 		}
 	}
 
@@ -1743,9 +1756,11 @@ void notify_le_data_len_updated(struct bt_conn *conn)
 #if defined(CONFIG_BT_USER_PHY_UPDATE)
 void notify_le_phy_updated(struct bt_conn *conn)
 {
-	for (struct bt_conn_cb *cb = callback_list; cb; cb = cb->_next) {
-		if (cb->le_phy_updated) {
-			cb->le_phy_updated(conn, &conn->le.phy);
+	struct bt_conn_cb *callback;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&callback_list, callback, _node) {
+		if (callback->le_phy_updated) {
+			callback->le_phy_updated(conn, &conn->le.phy);
 		}
 	}
 
@@ -1763,12 +1778,14 @@ bool le_param_req(struct bt_conn *conn, struct bt_le_conn_param *param)
 		return false;
 	}
 
-	for (struct bt_conn_cb *cb = callback_list; cb; cb = cb->_next) {
-		if (!cb->le_param_req) {
+	struct bt_conn_cb *callback;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&callback_list, callback, _node) {
+		if (!callback->le_param_req) {
 			continue;
 		}
 
-		if (!cb->le_param_req(conn, param)) {
+		if (!callback->le_param_req(conn, param)) {
 			return false;
 		}
 
@@ -2242,9 +2259,12 @@ void bt_conn_identity_resolved(struct bt_conn *conn)
 		rpa = &conn->le.init_addr;
 	}
 
-	for (struct bt_conn_cb *cb = callback_list; cb; cb = cb->_next) {
-		if (cb->identity_resolved) {
-			cb->identity_resolved(conn, rpa, &conn->le.dst);
+
+	struct bt_conn_cb *callback;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&callback_list, callback, _node) {
+		if (callback->identity_resolved) {
+			callback->identity_resolved(conn, rpa, &conn->le.dst);
 		}
 	}
 
@@ -2352,9 +2372,11 @@ void bt_conn_security_changed(struct bt_conn *conn, uint8_t hci_err,
 		bt_iso_security_changed(conn, hci_err);
 	}
 
-	for (struct bt_conn_cb *cb = callback_list; cb; cb = cb->_next) {
-		if (cb->security_changed) {
-			cb->security_changed(conn, conn->sec_level, err);
+	struct bt_conn_cb *callback;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&callback_list, callback, _node) {
+		if (callback->security_changed) {
+			callback->security_changed(conn, conn->sec_level, err);
 		}
 	}
 
@@ -2444,40 +2466,20 @@ bt_security_t bt_conn_get_security(const struct bt_conn *conn)
 
 void bt_conn_cb_register(struct bt_conn_cb *cb)
 {
-	cb->_next = callback_list;
-	callback_list = cb;
+	sys_slist_append(&callback_list, &cb->_node);
 }
 
 int bt_conn_cb_unregister(struct bt_conn_cb *cb)
 {
-	struct bt_conn_cb *previous_callback;
-
 	CHECKIF(cb == NULL) {
 		return -EINVAL;
 	}
 
-	if (callback_list == NULL) {
-		/* No callsback registered */
+	if (!sys_slist_find_and_remove(&callback_list, &cb->_node)) {
 		return -ENOENT;
 	}
 
-	if (callback_list == cb) {
-		callback_list = callback_list->_next;
-		return 0;
-	}
-
-	previous_callback = callback_list;
-
-	while (previous_callback->_next) {
-		if (previous_callback->_next == cb) {
-			previous_callback->_next = previous_callback->_next->_next;
-			return 0;
-		}
-
-		previous_callback = previous_callback->_next;
-	}
-
-	return -ENOENT;
+	return 0;
 }
 
 bool bt_conn_exists_le(uint8_t id, const bt_addr_le_t *peer)
@@ -2765,9 +2767,11 @@ static int bt_conn_get_tx_power_level(struct bt_conn *conn, uint8_t type,
 void notify_tx_power_report(struct bt_conn *conn,
 			    struct bt_conn_le_tx_power_report report)
 {
-	for (struct bt_conn_cb *cb = callback_list; cb; cb = cb->_next) {
-		if (cb->tx_power_report) {
-			cb->tx_power_report(conn, &report);
+	struct bt_conn_cb *callback;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&callback_list, callback, _node) {
+		if (callback->tx_power_report) {
+			callback->tx_power_report(conn, &report);
 		}
 	}
 
@@ -2888,9 +2892,11 @@ int bt_conn_le_get_tx_power_level(struct bt_conn *conn,
 void notify_path_loss_threshold_report(struct bt_conn *conn,
 				       struct bt_conn_le_path_loss_threshold_report report)
 {
-	for (struct bt_conn_cb *cb = callback_list; cb; cb = cb->_next) {
-		if (cb->path_loss_threshold_report) {
-			cb->path_loss_threshold_report(conn, &report);
+	struct bt_conn_cb *callback;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&callback_list, callback, _node) {
+		if (callback->path_loss_threshold_report) {
+			callback->path_loss_threshold_report(conn, &report);
 		}
 	}
 
@@ -3664,9 +3670,11 @@ void bt_hci_le_df_connection_iq_report_common(uint8_t event, struct net_buf *buf
 		return;
 	}
 
-	for (struct bt_conn_cb *cb = callback_list; cb; cb = cb->_next) {
-		if (cb->cte_report_cb) {
-			cb->cte_report_cb(conn, &iq_report);
+	struct bt_conn_cb *callback;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&callback_list, callback, _node) {
+		if (callback->cte_report_cb) {
+			callback->cte_report_cb(conn, &iq_report);
 		}
 	}
 
@@ -3706,9 +3714,11 @@ void bt_hci_le_df_cte_req_failed(struct net_buf *buf)
 		return;
 	}
 
-	for (struct bt_conn_cb *cb = callback_list; cb; cb = cb->_next) {
-		if (cb->cte_report_cb) {
-			cb->cte_report_cb(conn, &iq_report);
+	struct bt_conn_cb *callback;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&callback_list, callback, _node) {
+		if (callback->cte_report_cb) {
+			callback->cte_report_cb(conn, &iq_report);
 		}
 	}
 

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2466,7 +2466,9 @@ bt_security_t bt_conn_get_security(const struct bt_conn *conn)
 
 void bt_conn_cb_register(struct bt_conn_cb *cb)
 {
-	sys_slist_append(&callback_list, &cb->_node);
+	if (!sys_slist_find(&callback_list, &cb->_node, NULL)) {
+		sys_slist_append(&callback_list, &cb->_node);
+	}
 }
 
 int bt_conn_cb_unregister(struct bt_conn_cb *cb)
@@ -3490,6 +3492,10 @@ int bt_conn_auth_info_cb_register(struct bt_conn_auth_info_cb *cb)
 {
 	CHECKIF(cb == NULL) {
 		return -EINVAL;
+	}
+
+	if (sys_slist_find(&bt_auth_info_cbs, &cb->node, NULL)) {
+		return -EALREADY;
 	}
 
 	sys_slist_append(&bt_auth_info_cbs, &cb->node);

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -120,7 +120,7 @@ sys_slist_t bt_auth_info_cbs = SYS_SLIST_STATIC_INIT(&bt_auth_info_cbs);
 #endif /* CONFIG_BT_SMP || CONFIG_BT_CLASSIC */
 
 
-static sys_slist_t callback_list = SYS_SLIST_STATIC_INIT(&callback_list);
+static sys_slist_t conn_cbs = SYS_SLIST_STATIC_INIT(&conn_cbs);
 
 static struct bt_conn_tx conn_tx[CONFIG_BT_CONN_TX_MAX];
 
@@ -1547,7 +1547,7 @@ static void notify_recycled_conn_slot(void)
 #if defined(CONFIG_BT_CONN)
 	struct bt_conn_cb *callback;
 
-	SYS_SLIST_FOR_EACH_CONTAINER(&callback_list, callback, _node) {
+	SYS_SLIST_FOR_EACH_CONTAINER(&conn_cbs, callback, _node) {
 		if (callback->recycled) {
 			callback->recycled();
 		}
@@ -1644,7 +1644,8 @@ static void notify_connected(struct bt_conn *conn)
 {
 	struct bt_conn_cb *callback;
 
-	SYS_SLIST_FOR_EACH_CONTAINER(&callback_list, callback, _node) {
+	SYS_SLIST_FOR_EACH_CONTAINER(&conn_cbs, callback, _node) {
+
 		if (callback->connected) {
 			callback->connected(conn, conn->err);
 		}
@@ -1661,7 +1662,7 @@ static void notify_disconnected(struct bt_conn *conn)
 {
 	struct bt_conn_cb *callback;
 
-	SYS_SLIST_FOR_EACH_CONTAINER(&callback_list, callback, _node) {
+	SYS_SLIST_FOR_EACH_CONTAINER(&conn_cbs, callback, _node) {
 		if (callback->disconnected) {
 			callback->disconnected(conn, conn->err);
 		}
@@ -1688,7 +1689,7 @@ void notify_remote_info(struct bt_conn *conn)
 
 	struct bt_conn_cb *callback;
 
-	SYS_SLIST_FOR_EACH_CONTAINER(&callback_list, callback, _node) {
+	SYS_SLIST_FOR_EACH_CONTAINER(&conn_cbs, callback, _node) {
 		if (callback->remote_info_available) {
 			callback->remote_info_available(conn, &remote_info);
 		}
@@ -1717,7 +1718,7 @@ void notify_le_param_updated(struct bt_conn *conn)
 
 	struct bt_conn_cb *callback;
 
-	SYS_SLIST_FOR_EACH_CONTAINER(&callback_list, callback, _node) {
+	SYS_SLIST_FOR_EACH_CONTAINER(&conn_cbs, callback, _node) {
 		if (callback->le_param_updated) {
 			callback->le_param_updated(conn, conn->le.interval,
 						   conn->le.latency,
@@ -1739,7 +1740,7 @@ void notify_le_data_len_updated(struct bt_conn *conn)
 {
 	struct bt_conn_cb *callback;
 
-	SYS_SLIST_FOR_EACH_CONTAINER(&callback_list, callback, _node) {
+	SYS_SLIST_FOR_EACH_CONTAINER(&conn_cbs, callback, _node) {
 		if (callback->le_data_len_updated) {
 			callback->le_data_len_updated(conn, &conn->le.data_len);
 		}
@@ -1758,7 +1759,7 @@ void notify_le_phy_updated(struct bt_conn *conn)
 {
 	struct bt_conn_cb *callback;
 
-	SYS_SLIST_FOR_EACH_CONTAINER(&callback_list, callback, _node) {
+	SYS_SLIST_FOR_EACH_CONTAINER(&conn_cbs, callback, _node) {
 		if (callback->le_phy_updated) {
 			callback->le_phy_updated(conn, &conn->le.phy);
 		}
@@ -1780,7 +1781,7 @@ bool le_param_req(struct bt_conn *conn, struct bt_le_conn_param *param)
 
 	struct bt_conn_cb *callback;
 
-	SYS_SLIST_FOR_EACH_CONTAINER(&callback_list, callback, _node) {
+	SYS_SLIST_FOR_EACH_CONTAINER(&conn_cbs, callback, _node) {
 		if (!callback->le_param_req) {
 			continue;
 		}
@@ -2262,7 +2263,7 @@ void bt_conn_identity_resolved(struct bt_conn *conn)
 
 	struct bt_conn_cb *callback;
 
-	SYS_SLIST_FOR_EACH_CONTAINER(&callback_list, callback, _node) {
+	SYS_SLIST_FOR_EACH_CONTAINER(&conn_cbs, callback, _node) {
 		if (callback->identity_resolved) {
 			callback->identity_resolved(conn, rpa, &conn->le.dst);
 		}
@@ -2374,7 +2375,7 @@ void bt_conn_security_changed(struct bt_conn *conn, uint8_t hci_err,
 
 	struct bt_conn_cb *callback;
 
-	SYS_SLIST_FOR_EACH_CONTAINER(&callback_list, callback, _node) {
+	SYS_SLIST_FOR_EACH_CONTAINER(&conn_cbs, callback, _node) {
 		if (callback->security_changed) {
 			callback->security_changed(conn, conn->sec_level, err);
 		}
@@ -2466,8 +2467,8 @@ bt_security_t bt_conn_get_security(const struct bt_conn *conn)
 
 void bt_conn_cb_register(struct bt_conn_cb *cb)
 {
-	if (!sys_slist_find(&callback_list, &cb->_node, NULL)) {
-		sys_slist_append(&callback_list, &cb->_node);
+	if (!sys_slist_find(&conn_cbs, &cb->_node, NULL)) {
+		sys_slist_append(&conn_cbs, &cb->_node);
 	}
 }
 
@@ -2477,7 +2478,7 @@ int bt_conn_cb_unregister(struct bt_conn_cb *cb)
 		return -EINVAL;
 	}
 
-	if (!sys_slist_find_and_remove(&callback_list, &cb->_node)) {
+	if (!sys_slist_find_and_remove(&conn_cbs, &cb->_node)) {
 		return -ENOENT;
 	}
 
@@ -2771,7 +2772,7 @@ void notify_tx_power_report(struct bt_conn *conn,
 {
 	struct bt_conn_cb *callback;
 
-	SYS_SLIST_FOR_EACH_CONTAINER(&callback_list, callback, _node) {
+	SYS_SLIST_FOR_EACH_CONTAINER(&conn_cbs, callback, _node) {
 		if (callback->tx_power_report) {
 			callback->tx_power_report(conn, &report);
 		}
@@ -3678,7 +3679,7 @@ void bt_hci_le_df_connection_iq_report_common(uint8_t event, struct net_buf *buf
 
 	struct bt_conn_cb *callback;
 
-	SYS_SLIST_FOR_EACH_CONTAINER(&callback_list, callback, _node) {
+	SYS_SLIST_FOR_EACH_CONTAINER(&conn_cbs, callback, _node) {
 		if (callback->cte_report_cb) {
 			callback->cte_report_cb(conn, &iq_report);
 		}
@@ -3722,7 +3723,7 @@ void bt_hci_le_df_cte_req_failed(struct net_buf *buf)
 
 	struct bt_conn_cb *callback;
 
-	SYS_SLIST_FOR_EACH_CONTAINER(&callback_list, callback, _node) {
+	SYS_SLIST_FOR_EACH_CONTAINER(&conn_cbs, callback, _node) {
 		if (callback->cte_report_cb) {
 			callback->cte_report_cb(conn, &iq_report);
 		}

--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -1586,11 +1586,15 @@ int bt_le_scan_stop(void)
 	return bt_le_scan_update(false);
 }
 
-void bt_le_scan_cb_register(struct bt_le_scan_cb *cb)
+int bt_le_scan_cb_register(struct bt_le_scan_cb *cb)
 {
-	if (!sys_slist_find(&scan_cbs, &cb->node, NULL)) {
-		sys_slist_append(&scan_cbs, &cb->node);
+	if (sys_slist_find(&scan_cbs, &cb->node, NULL)) {
+		return -EEXIST;
 	}
+
+	sys_slist_append(&scan_cbs, &cb->node);
+
+	return 0;
 }
 
 void bt_le_scan_cb_unregister(struct bt_le_scan_cb *cb)
@@ -1833,11 +1837,15 @@ int bt_le_per_adv_sync_delete(struct bt_le_per_adv_sync *per_adv_sync)
 	return err;
 }
 
-void bt_le_per_adv_sync_cb_register(struct bt_le_per_adv_sync_cb *cb)
+int bt_le_per_adv_sync_cb_register(struct bt_le_per_adv_sync_cb *cb)
 {
-	if (!sys_slist_find(&pa_sync_cbs, &cb->node, NULL)) {
-		sys_slist_append(&pa_sync_cbs, &cb->node);
+	if (sys_slist_find(&pa_sync_cbs, &cb->node, NULL)) {
+		return -EEXIST;
 	}
+
+	sys_slist_append(&pa_sync_cbs, &cb->node);
+
+	return 0;
 }
 
 static int bt_le_set_per_adv_recv_enable(

--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -1588,7 +1588,9 @@ int bt_le_scan_stop(void)
 
 void bt_le_scan_cb_register(struct bt_le_scan_cb *cb)
 {
-	sys_slist_append(&scan_cbs, &cb->node);
+	if (!sys_slist_find(&scan_cbs, &cb->node, NULL)) {
+		sys_slist_append(&scan_cbs, &cb->node);
+	}
 }
 
 void bt_le_scan_cb_unregister(struct bt_le_scan_cb *cb)
@@ -1833,7 +1835,9 @@ int bt_le_per_adv_sync_delete(struct bt_le_per_adv_sync *per_adv_sync)
 
 void bt_le_per_adv_sync_cb_register(struct bt_le_per_adv_sync_cb *cb)
 {
-	sys_slist_append(&pa_sync_cbs, &cb->node);
+	if (!sys_slist_find(&pa_sync_cbs, &cb->node, NULL)) {
+		sys_slist_append(&pa_sync_cbs, &cb->node);
+	}
 }
 
 static int bt_le_set_per_adv_recv_enable(

--- a/subsys/bluetooth/host/testing.c
+++ b/subsys/bluetooth/host/testing.c
@@ -22,7 +22,9 @@ static sys_slist_t cb_slist;
 
 void bt_test_cb_register(struct bt_test_cb *cb)
 {
-	sys_slist_append(&cb_slist, &cb->node);
+	if (!sys_slist_find(&cb_slist, &cb->node, NULL)) {
+		sys_slist_append(&cb_slist, &cb->node);
+	}
 }
 
 void bt_test_cb_unregister(struct bt_test_cb *cb)

--- a/subsys/bluetooth/host/testing.c
+++ b/subsys/bluetooth/host/testing.c
@@ -20,11 +20,15 @@
 
 static sys_slist_t cb_slist;
 
-void bt_test_cb_register(struct bt_test_cb *cb)
+int bt_test_cb_register(struct bt_test_cb *cb)
 {
-	if (!sys_slist_find(&cb_slist, &cb->node, NULL)) {
-		sys_slist_append(&cb_slist, &cb->node);
+	if (sys_slist_find(&cb_slist, &cb->node, NULL)) {
+		return -EEXIST;
 	}
+
+	sys_slist_append(&cb_slist, &cb->node);
+
+	return 0;
 }
 
 void bt_test_cb_unregister(struct bt_test_cb *cb)


### PR DESCRIPTION
When a callback is registered twice, the slist becomes circular and we get stuck in a loop

In this PR we have choosen to ignore the second registration call if the callback has already been registed. The alternative is to trigger an assertion. That doesn't work if the assertions are turned off.