### PR TITLE
boards: esp32s3_devkitm: remove conflicting usb_serial reference

### DIFF
--- a/boards/espressif/esp32s3_devkitm/esp32s3_devkitm_procpu.dts
+++ b/boards/espressif/esp32s3_devkitm/esp32s3_devkitm_procpu.dts
@@ -43,10 +43,6 @@
 	};
 };
 
-&usb_serial {
-	status = "okay";
-};
-
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;


### PR DESCRIPTION
The usb_serial node is referenced twice in the procpu dts file. The first time the status is set to "okay", while the second it is set to "disabled". Only the second status is honored, so the first is removed to eliminate confusion.