### PR TITLE
Pwm leds add info

### DIFF
--- a/boards/nordic/nrf52840dk/nrf52840dk_nrf52840-pinctrl.dtsi
+++ b/boards/nordic/nrf52840dk/nrf52840dk_nrf52840-pinctrl.dtsi
@@ -76,14 +76,20 @@
 
 	pwm0_default: pwm0_default {
 		group1 {
-			psels = <NRF_PSEL(PWM_OUT0, 0, 13)>;
+			psels = <NRF_PSEL(PWM_OUT0, 0, 13)>,
+				<NRF_PSEL(PWM_OUT1, 0, 14)>,
+				<NRF_PSEL(PWM_OUT2, 0, 15)>,
+				<NRF_PSEL(PWM_OUT3, 0, 16)>;
 			nordic,invert;
 		};
 	};
 
 	pwm0_sleep: pwm0_sleep {
 		group1 {
-			psels = <NRF_PSEL(PWM_OUT0, 0, 13)>;
+			psels = <NRF_PSEL(PWM_OUT0, 0, 13)>,
+				<NRF_PSEL(PWM_OUT1, 0, 14)>,
+				<NRF_PSEL(PWM_OUT2, 0, 15)>,
+				<NRF_PSEL(PWM_OUT3, 0, 16)>;
 			low-power-enable;
 		};
 	};

--- a/boards/nordic/nrf52840dk/nrf52840dk_nrf52840.dts
+++ b/boards/nordic/nrf52840dk/nrf52840dk_nrf52840.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <nordic/nrf52840_qiaa.dtsi>
+#include <zephyr/dt-bindings/led/led.h>
 #include "nrf52840dk_nrf52840-pinctrl.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
@@ -49,6 +50,27 @@
 		compatible = "pwm-leds";
 		pwm_led0: pwm_led_0 {
 			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+			label = "LED0";
+			index = <0>;
+			color-mapping = <LED_COLOR_ID_GREEN>;
+		};
+		pwm_led1: pwm_led_1 {
+			pwms = <&pwm0 1 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+			label = "LED1";
+			index = <1>;
+			color-mapping = <LED_COLOR_ID_GREEN>;
+		};
+		pwm_led2: pwm_led_2 {
+			pwms = <&pwm0 2 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+			label = "LED2";
+			index = <2>;
+			color-mapping = <LED_COLOR_ID_GREEN>;
+		};
+		pwm_led3: pwm_led_3 {
+			pwms = <&pwm0 3 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+			label = "LED3";
+			index = <3>;
+			color-mapping = <LED_COLOR_ID_GREEN>;
 		};
 	};
 

--- a/boards/nordic/nrf52840dongle/nrf52840dongle_nrf52840-pinctrl.dtsi
+++ b/boards/nordic/nrf52840dongle/nrf52840dongle_nrf52840-pinctrl.dtsi
@@ -60,7 +60,8 @@
 		group1 {
 			psels = <NRF_PSEL(PWM_OUT0, 0, 8)>,
 				<NRF_PSEL(PWM_OUT1, 1, 9)>,
-				<NRF_PSEL(PWM_OUT2, 0, 12)>;
+				<NRF_PSEL(PWM_OUT2, 0, 12)>,
+				<NRF_PSEL(PWM_OUT3, 0, 6)>;
 			nordic,invert;
 		};
 	};
@@ -69,7 +70,8 @@
 		group1 {
 			psels = <NRF_PSEL(PWM_OUT0, 0, 8)>,
 				<NRF_PSEL(PWM_OUT1, 1, 9)>,
-				<NRF_PSEL(PWM_OUT2, 0, 12)>;
+				<NRF_PSEL(PWM_OUT2, 0, 12)>,
+				<NRF_PSEL(PWM_OUT3, 0, 6)>;
 			low-power-enable;
 		};
 	};

--- a/boards/nordic/nrf52840dongle/nrf52840dongle_nrf52840.dts
+++ b/boards/nordic/nrf52840dongle/nrf52840dongle_nrf52840.dts
@@ -7,6 +7,7 @@
 
 /dts-v1/;
 #include <nordic/nrf52840_qiaa.dtsi>
+#include <zephyr/dt-bindings/led/led.h>
 #include "nrf52840dongle_nrf52840-pinctrl.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
@@ -48,14 +49,21 @@
 
 	pwmleds {
 		compatible = "pwm-leds";
-		red_pwm_led: pwm_led_0 {
-			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+		ld1_green_pwm_led: ld1_green_led {
+			pwms = <&pwm0 3 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+			label = "LD1";
+			index = <0>;
+			color-mapping = <LED_COLOR_ID_GREEN>;
 		};
-		green_pwm_led: pwm_led_1 {
-			pwms = <&pwm0 1 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
-		};
-		blue_pwm_led: pwm_led_2 {
-			pwms = <&pwm0 2 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+		ld2_rgb_pwm_led: ld2_rgb_led {
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>,
+			       <&pwm0 1 PWM_MSEC(20) PWM_POLARITY_INVERTED>,
+			       <&pwm0 2 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+			label = "LD2";
+			index = <1>;
+			color-mapping = <LED_COLOR_ID_RED>,
+					<LED_COLOR_ID_GREEN>,
+					<LED_COLOR_ID_BLUE>;
 		};
 	};
 
@@ -79,12 +87,9 @@
 		led1-red   = &led1_red;
 		led1-green = &led1_green;
 		led1-blue  = &led1_blue;
-		pwm-led0 = &red_pwm_led;
-		pwm-led1 = &green_pwm_led;
-		pwm-led2 = &blue_pwm_led;
-		red-pwm-led = &red_pwm_led;
-		green-pwm-led = &green_pwm_led;
-		blue-pwm-led = &blue_pwm_led;
+		pwm-led0 = &ld1_green_pwm_led;
+		pwm-led1 = &ld2_rgb_pwm_led;
+		rgb-pwm-led = &ld2_rgb_pwm_led;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0_green;
 		watchdog0 = &wdt0;

--- a/drivers/led/led_pwm.c
+++ b/drivers/led/led_pwm.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Seagate Technology LLC
+ * Copyright (c) 2024 Nick Ward <nix.ward@gmail.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -21,17 +22,25 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(led_pwm, CONFIG_LED_LOG_LEVEL);
 
+struct led_pwm_child {
+	uint32_t num_pwms;
+	const struct pwm_dt_spec *pwm;
+	struct led_info info;
+};
+
 struct led_pwm_config {
-	int num_leds;
-	const struct pwm_dt_spec *led;
+	uint32_t num_leds;
+	const struct led_pwm_child *child;
 };
 
 static int led_pwm_blink(const struct device *dev, uint32_t led,
 			 uint32_t delay_on, uint32_t delay_off)
 {
 	const struct led_pwm_config *config = dev->config;
-	const struct pwm_dt_spec *dt_led;
 	uint32_t period_usec, pulse_usec;
+	const struct pwm_dt_spec *pwm;
+	int pwm_ret = 0;
+	int ret;
 
 	if (led >= config->num_leds) {
 		return -EINVAL;
@@ -47,25 +56,95 @@ static int led_pwm_blink(const struct device *dev, uint32_t led,
 		return -EINVAL;
 	}
 
-	dt_led = &config->led[led];
+	for (int i = 0; i < config->child[led].num_pwms; i++) {
+		pwm = &config->child[led].pwm[i];
+		ret = pwm_set_dt(pwm, PWM_USEC(period_usec), PWM_USEC(pulse_usec));
+		if (ret != 0) {
+			LOG_ERR("LED child '%s' pwm[%u] set pulse: %d",
+				config->child[led].info.label, i, ret);
+			pwm_ret = ret; /* return the last error to occur */
+		}
+	}
 
-	return pwm_set_dt(dt_led, PWM_USEC(period_usec), PWM_USEC(pulse_usec));
+	return pwm_ret;
 }
+
+static int led_pwm_get_info(const struct device *dev, uint32_t led, const struct led_info **info)
+{
+	const struct led_pwm_config *config = dev->config;
+
+	if (led >= config->num_leds) {
+		*info = NULL;
+		return -EINVAL;
+	}
+
+	*info = &config->child[led].info;
+
+	return 0;
+}
+
+static int led_pwm_set_color(const struct device *dev, uint32_t led, uint8_t num_colors,
+			     const uint8_t *color)
+{
+	const struct led_pwm_config *config = dev->config;
+	const struct led_pwm_child *child;
+	const struct pwm_dt_spec *pwm;
+	int pwm_ret = 0;
+	uint32_t pulse;
+	int ret;
+
+	if (led >= config->num_leds) {
+		return -EINVAL;
+	}
+
+	child = &config->child[led];
+
+	if (num_colors != child->info.num_colors) {
+		LOG_ERR("Invalid number of colors: %u, supports: %u", num_colors,
+			child->info.num_colors);
+		return -EINVAL;
+	}
+
+	for (int i = 0; i < config->child[led].num_pwms; i++) {
+		pwm = &config->child[led].pwm[i];
+		pulse = (uint64_t)pwm->period * color[i] / 100;
+		ret = pwm_set_pulse_dt(pwm, pulse);
+		if (ret != 0) {
+			LOG_ERR("LED child '%s' pwm[%u] set pulse: %d",
+				config->child[led].info.label, i, ret);
+			pwm_ret = ret; /* return the last error to occur */
+		}
+	}
+
+	return pwm_ret;
+}
+
 
 static int led_pwm_set_brightness(const struct device *dev,
 				  uint32_t led, uint8_t value)
 {
 	const struct led_pwm_config *config = dev->config;
-	const struct pwm_dt_spec *dt_led;
+	const struct pwm_dt_spec *pwm;
+	int pwm_ret = 0;
+	uint32_t pulse;
+	int ret;
 
 	if (led >= config->num_leds || value > 100) {
 		return -EINVAL;
 	}
 
-	dt_led = &config->led[led];
+	for (int i = 0; i < config->child[led].num_pwms; i++) {
+		pwm = &config->child[led].pwm[i];
+		pulse = (uint64_t)pwm->period * value / 100;
+		ret = pwm_set_pulse_dt(pwm, pulse);
+		if (ret != 0) {
+			LOG_ERR("LED child '%s' pwm[%u] set pulse: %d",
+				config->child[led].info.label, i, ret);
+			pwm_ret = ret; /* return the last error to occur */
+		}
+	}
 
-	return pwm_set_pulse_dt(&config->led[led],
-			(uint32_t) ((uint64_t) dt_led->period * value / 100));
+	return pwm_ret;
 }
 
 static int led_pwm_on(const struct device *dev, uint32_t led)
@@ -81,20 +160,18 @@ static int led_pwm_off(const struct device *dev, uint32_t led)
 static int led_pwm_init(const struct device *dev)
 {
 	const struct led_pwm_config *config = dev->config;
-	int i;
+	const struct led_pwm_child *child;
+	const struct pwm_dt_spec *pwm;
 
-	if (!config->num_leds) {
-		LOG_ERR("%s: no LEDs found (DT child nodes missing)",
-			dev->name);
-		return -ENODEV;
-	}
-
-	for (i = 0; i < config->num_leds; i++) {
-		const struct pwm_dt_spec *led = &config->led[i];
-
-		if (!device_is_ready(led->dev)) {
-			LOG_ERR("%s: pwm device not ready", led->dev->name);
-			return -ENODEV;
+	for (int led = 0; led < config->num_leds; led++) {
+		child = &config->child[led];
+		for (int i = 0; i < child->num_pwms; i++) {
+			pwm = &child->pwm[i];
+			if (!pwm_is_ready_dt(pwm)) {
+				LOG_ERR("LED child '%s' pwm[%u]: device not ready",
+					child->info.label, i);
+				return -ENODEV;
+			}
 		}
 	}
 
@@ -106,17 +183,21 @@ static int led_pwm_pm_action(const struct device *dev,
 			     enum pm_device_action action)
 {
 	const struct led_pwm_config *config = dev->config;
+	const struct led_pwm_child *child;
+	const struct pwm_dt_spec *pwm;
+	int ret;
 
-	/* switch all underlying PWM devices to the new state */
-	for (size_t i = 0; i < config->num_leds; i++) {
-		int err;
-		const struct pwm_dt_spec *led = &config->led[i];
+	/* Switch all underlying PWM devices to the new state */
+	for (int led = 0; led < config->num_leds; led++) {
+		child = &config->child[led];
+		for (int i = 0; i < child->num_pwms; i++) {
+			pwm = &child->pwm[i];
+			LOG_DBG("PWM %p running pm action %" PRIu32, pwm->dev, action);
 
-		LOG_DBG("PWM %p running pm action %" PRIu32, led->dev, action);
-
-		err = pm_device_action_run(led->dev, action);
-		if (err && (err != -EALREADY)) {
-			LOG_DBG("Cannot switch PWM %p power state (err = %d)", led->dev, err);
+			ret = pm_device_action_run(pwm->dev, action);
+			if ((ret != 0) && (ret != -EALREADY)) {
+				LOG_ERR("Cannot switch PWM %p power state", pwm->dev);
+			}
 		}
 	}
 
@@ -129,24 +210,51 @@ static const struct led_driver_api led_pwm_api = {
 	.off		= led_pwm_off,
 	.blink		= led_pwm_blink,
 	.set_brightness	= led_pwm_set_brightness,
+	.get_info	= led_pwm_get_info,
+	.set_color	= led_pwm_set_color,
 };
 
-#define LED_PWM_DEVICE(id)					\
-								\
-static const struct pwm_dt_spec led_pwm_##id[] = {		\
-	DT_INST_FOREACH_CHILD_SEP(id, PWM_DT_SPEC_GET, (,))	\
-};								\
-								\
-static const struct led_pwm_config led_pwm_config_##id = {	\
-	.num_leds	= ARRAY_SIZE(led_pwm_##id),		\
-	.led		= led_pwm_##id,				\
-};								\
-								\
-PM_DEVICE_DT_INST_DEFINE(id, led_pwm_pm_action);		\
-								\
-DEVICE_DT_INST_DEFINE(id, &led_pwm_init,			\
-		      PM_DEVICE_DT_INST_GET(id), NULL,		\
-		      &led_pwm_config_##id, POST_KERNEL,	\
-		      CONFIG_LED_INIT_PRIORITY, &led_pwm_api);
+#define CHILD_LED_PWMS(led_node_id)                                                                \
+	static const struct pwm_dt_spec pwm_##led_node_id[] = {                                    \
+		DT_FOREACH_PROP_ELEM_SEP(led_node_id, pwms, PWM_DT_SPEC_GET_BY_PROP_AND_IDX, (,))};
+
+#define CHILD_LED_COLOR_MAPPING(led_node_id)                                                       \
+	const uint8_t color_mapping_##led_node_id[] = DT_PROP(led_node_id, color_mapping);
+
+#define CHILD_LED_INFO(led_node_id)                                                                \
+	{                                                                                          \
+		.num_pwms = ARRAY_SIZE(pwm_##led_node_id),                                         \
+		.pwm = pwm_##led_node_id,                                                          \
+		.info =                                                                            \
+			{                                                                          \
+				.label = DT_PROP(led_node_id, label),                              \
+				.index = DT_PROP(led_node_id, index),                              \
+				.num_colors = DT_PROP_LEN(led_node_id, color_mapping),             \
+				.color_mapping = color_mapping_##led_node_id,                      \
+			},                                                                         \
+	},
+
+#define LED_PWM_DEVICE(inst)                                                                       \
+                                                                                                   \
+	DT_INST_FOREACH_CHILD(inst, CHILD_LED_COLOR_MAPPING)                                       \
+                                                                                                   \
+	DT_INST_FOREACH_CHILD(inst, CHILD_LED_PWMS);                                               \
+                                                                                                   \
+	static const struct led_pwm_child led_child_##inst[] = {                                   \
+		DT_INST_FOREACH_CHILD(inst, CHILD_LED_INFO)};                                      \
+                                                                                                   \
+	BUILD_ASSERT(ARRAY_SIZE(led_child_##inst) > 0,                                             \
+		     "An led_pwm device must have child nodes\n");                                 \
+                                                                                                   \
+	static const struct led_pwm_config led_pwm_config_##inst = {                               \
+		.num_leds = ARRAY_SIZE(led_child_##inst),                                          \
+		.child = led_child_##inst,                                                         \
+	};                                                                                         \
+                                                                                                   \
+	PM_DEVICE_DT_INST_DEFINE(inst, led_pwm_pm_action);                                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(inst, &led_pwm_init, PM_DEVICE_DT_INST_GET(inst), NULL,              \
+			      &led_pwm_config_##inst, POST_KERNEL, CONFIG_LED_INIT_PRIORITY,       \
+			      &led_pwm_api);
 
 DT_INST_FOREACH_STATUS_OKAY(LED_PWM_DEVICE)

--- a/dts/bindings/led/pwm-leds.yaml
+++ b/dts/bindings/led/pwm-leds.yaml
@@ -5,6 +5,8 @@ description: PWM LEDs parent node
 
 compatible: "pwm-leds"
 
+include: "led-controller.yaml"
+
 child-binding:
   description: PWM LED child node
   properties:
@@ -16,13 +18,15 @@ child-binding:
 
         The period field is used by the set_brightness function of the LED API.
         Its value should at least be greater that 100 nanoseconds (for a full
-        brigtness granularity) and lesser than 50 milliseconds (average visual
+        brightness granularity) and lesser than 50 milliseconds (average visual
         persistence time of the human eye). Typical values for the PWM period
         are 10 or 20 milliseconds.
 
     label:
-      type: string
-      description: |
-        Human readable string describing the LED. It can be used by an
-        application to identify this LED or to retrieve its number/index
-        (i.e. child node number) on the parent device.
+      required: true
+
+    index:
+      required: true
+
+    color-mapping:
+      required: true

--- a/include/zephyr/devicetree/pwms.h
+++ b/include/zephyr/devicetree/pwms.h
@@ -24,6 +24,36 @@ extern "C" {
 
 /**
  * @brief Get the node identifier for the PWM controller from a
+ *        property name at an index
+ *
+ * Example devicetree fragment:
+ *
+ *     pwm1: pwm-controller@... { ... };
+ *
+ *     pwm2: pwm-controller@... { ... };
+ *
+ *     n: node {
+ *             pwms-foo = <&pwm1 1 PWM_POLARITY_NORMAL>,
+ *                    <&pwm2 3 PWM_POLARITY_INVERTED>;
+ *     };
+ *
+ * Example usage:
+ *
+ *     DT_PWMS_CTLR_BY_IDX(DT_NODELABEL(n), pwms_foo, 0) // DT_NODELABEL(pwm1)
+ *     DT_PWMS_CTLR_BY_IDX(DT_NODELABEL(n), pwms_foo, 1) // DT_NODELABEL(pwm2)
+ *
+ * @param node_id node identifier for a node with a pwms property
+ * @param prop lowercase-and-underscores property name
+ * @param idx logical index into pwms property
+ * @return the node identifier for the PWM controller referenced at
+ *         index "idx"
+ * @see DT_PROP_BY_PHANDLE_IDX()
+ */
+#define DT_PWMS_CTLR_BY_PROP_AND_IDX(node_id, prop, idx) \
+	DT_PHANDLE_BY_IDX(node_id, prop, idx)
+
+/**
+ * @brief Get the node identifier for the PWM controller from a
  *        pwms property at an index
  *
  * Example devicetree fragment:

--- a/include/zephyr/drivers/pwm.h
+++ b/include/zephyr/drivers/pwm.h
@@ -217,6 +217,55 @@ struct pwm_dt_spec {
  * @brief Static initializer for a struct pwm_dt_spec
  *
  * This returns a static initializer for a struct pwm_dt_spec given a devicetree
+ * node identifier, property name and an index.
+ *
+ * Example devicetree fragment:
+ *
+ * @code{.dts}
+ *    n: node {
+ *        pwms-foo = <&pwm1 1 1000 PWM_POLARITY_NORMAL>,
+ *               <&pwm2 3 2000 PWM_POLARITY_INVERTED>;
+ *    };
+ * @endcode
+ *
+ * Example usage:
+ *
+ * @code{.c}
+ *    const struct pwm_dt_spec spec =
+ *        PWM_DT_SPEC_GET_BY_IDX(DT_NODELABEL(n), pwms_foo, 1);
+ *
+ *    // Initializes 'spec' to:
+ *    // {
+ *    //         .dev = DEVICE_DT_GET(DT_NODELABEL(pwm2)),
+ *    //         .channel = 3,
+ *    //         .period = 2000,
+ *    //         .flags = PWM_POLARITY_INVERTED,
+ *    // }
+ * @endcode
+ *
+ * The device (dev) must still be checked for readiness, e.g. using
+ * device_is_ready(). It is an error to use this macro unless the node exists,
+ * has the 'prop' property, and that 'prop' property specifies a PWM controller,
+ * a channel, a period in nanoseconds and optionally flags.
+ *
+ * @param node_id Devicetree node identifier.
+ * @param prop lowercase-and-underscores property name.
+ * @param idx Logical index into 'pwms' property.
+ *
+ * @return Static initializer for a struct pwm_dt_spec for the property.
+ */
+#define PWM_DT_SPEC_GET_BY_PROP_AND_IDX(node_id, prop, idx)				       \
+	{								       \
+		.dev = DEVICE_DT_GET(DT_PWMS_CTLR_BY_PROP_AND_IDX(node_id, prop, idx)),       \
+		.channel = DT_PWMS_CHANNEL_BY_IDX(node_id, idx),	       \
+		.period = DT_PWMS_PERIOD_BY_IDX(node_id, idx),		       \
+		.flags = DT_PWMS_FLAGS_BY_IDX(node_id, idx),		       \
+	}
+
+/**
+ * @brief Static initializer for a struct pwm_dt_spec
+ *
+ * This returns a static initializer for a struct pwm_dt_spec given a devicetree
  * node identifier and an index.
  *
  * Example devicetree fragment:
@@ -256,12 +305,7 @@ struct pwm_dt_spec {
  * @see PWM_DT_SPEC_INST_GET_BY_IDX
  */
 #define PWM_DT_SPEC_GET_BY_IDX(node_id, idx)				       \
-	{								       \
-		.dev = DEVICE_DT_GET(DT_PWMS_CTLR_BY_IDX(node_id, idx)),       \
-		.channel = DT_PWMS_CHANNEL_BY_IDX(node_id, idx),	       \
-		.period = DT_PWMS_PERIOD_BY_IDX(node_id, idx),		       \
-		.flags = DT_PWMS_FLAGS_BY_IDX(node_id, idx),		       \
-	}
+	PWM_DT_SPEC_GET_BY_PROP_AND_IDX(node_id, pwms, idx)
 
 /**
  * @brief Static initializer for a struct pwm_dt_spec from a DT_DRV_COMPAT


### PR DESCRIPTION
Upgraded pwm-leds driver to use led-controller binding which adds index and color to child binding.
Additional upgraded driver to allow multiple PWM outputs per child LED.

This required two new pwm devicetree macros that allow the user to specify the property name to use rather than defaulting to pwms.

Modified the nrf52840dk and nrf52840dongle boards to use these new features of the pwm-leds driver.

I'm happy to follow up with a PR to upgrade other boards with RGB LEDs and possibly modify the basic/rgb_leds sample to utilize these new features. For now, I'm seeking feedback on the approach I've taken in this PR. Thanks.