### PR TITLE
scripts: west: blobs: Check for existence of modules

### DIFF
--- a/scripts/west_commands/blobs.py
+++ b/scripts/west_commands/blobs.py
@@ -81,7 +81,15 @@ class Blobs(WestCommand):
     def get_blobs(self, args):
         blobs = []
         modules = args.modules
-        for module in zephyr_module.parse_modules(ZEPHYR_BASE, self.manifest):
+        all_modules = zephyr_module.parse_modules(ZEPHYR_BASE, self.manifest)
+        all_names = [m.meta.get('name', None) for m in all_modules]
+
+        unknown = set(modules) - set(all_names)
+
+        if len(unknown):
+            log.die(f'Unknown module(s): {unknown}')
+
+        for module in all_modules:
             # Filter by module
             module_name = module.meta.get('name', None)
             if len(modules) and module_name not in modules:


### PR DESCRIPTION
Instead of blindly using the module names provided by the user via command-line arguments, check if those actually exist in the current manifest, and error out if any of them does not.

Fixes #73901.