### PR TITLE
bsim: Test also nrf54 in CI & some minor CI workflow improvements

### DIFF
--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -41,11 +41,6 @@ jobs:
       BSIM_OUT_PATH: /opt/bsim/
       BSIM_COMPONENTS_PATH: /opt/bsim/components
       EDTT_PATH: ../tools/edtt
-      bsim_bt_52_test_results_file: ./bsim_bt/52_bsim_results.xml
-      bsim_bt_53_test_results_file: ./bsim_bt/53_bsim_results.xml
-      bsim_bt_53split_test_results_file: ./bsim_bt/53_bsim_split_results.xml
-      bsim_net_52_test_results_file: ./bsim_net/52_bsim_results.xml
-      bsim_uart_test_results_file: ./bsim_uart/uart_bsim_results.xml
     steps:
       - name: Apply container owner mismatch workaround
         run: |
@@ -153,43 +148,17 @@ jobs:
       - name: Run Bluetooth Tests with BSIM
         if: steps.check-bluetooth-files.outputs.any_changed == 'true' || steps.check-common-files.outputs.any_changed == 'true'
         run: |
-          export ZEPHYR_BASE=${PWD}
-          # Build and run the BT tests for nrf52_bsim:
-          nice tests/bsim/bluetooth/compile.sh
-          RESULTS_FILE=${ZEPHYR_BASE}/${bsim_bt_52_test_results_file} \
-          TESTS_FILE=tests/bsim/bluetooth/tests.nrf52bsim.txt tests/bsim/run_parallel.sh
-          # Build and run the BT controller tests also for the nrf5340bsim/nrf5340/cpunet
-          nice tests/bsim/bluetooth/compile.nrf5340bsim_nrf5340_cpunet.sh
-          BOARD=nrf5340bsim/nrf5340/cpunet \
-          RESULTS_FILE=${ZEPHYR_BASE}/${bsim_bt_53_test_results_file} \
-          TESTS_FILE=tests/bsim/bluetooth/tests.nrf5340bsim_nrf5340_cpunet.txt \
-          tests/bsim/run_parallel.sh
-          # Build and run the nrf5340 split stack tests set
-          nice tests/bsim/bluetooth/compile.nrf5340bsim_nrf5340_cpuapp.sh
-          BOARD=nrf5340bsim/nrf5340/cpuapp \
-          RESULTS_FILE=${ZEPHYR_BASE}/${bsim_bt_53split_test_results_file} \
-          TESTS_FILE=tests/bsim/bluetooth/tests.nrf5340bsim_nrf5340_cpuapp.txt \
-          tests/bsim/run_parallel.sh
+          tests/bsim/ci.bt.sh
 
       - name: Run Networking Tests with BSIM
         if: steps.check-networking-files.outputs.any_changed == 'true' || steps.check-common-files.outputs.any_changed == 'true'
         run: |
-          export ZEPHYR_BASE=${PWD}
-          WORK_DIR=${ZEPHYR_BASE}/bsim_net nice tests/bsim/net/compile.sh
-          RESULTS_FILE=${ZEPHYR_BASE}/${bsim_net_52_test_results_file} \
-          SEARCH_PATH=tests/bsim/net/ tests/bsim/run_parallel.sh
+          tests/bsim/ci.net.sh
 
       - name: Run UART Tests with BSIM
         if: steps.check-uart-files.outputs.any_changed == 'true' || steps.check-common-files.outputs.any_changed == 'true'
         run: |
-          echo "UART: Single device tests"
-          ./scripts/twister -T tests/drivers/uart/ --force-color --inline-logs -v -M -p nrf52_bsim \
-            --fixture gpio_loopback -- -uart0_loopback
-          echo "UART: Multi device tests"
-          export ZEPHYR_BASE=${PWD}
-          WORK_DIR=${ZEPHYR_BASE}/bsim_uart nice tests/bsim/drivers/uart/compile.sh
-          RESULTS_FILE=${ZEPHYR_BASE}/${bsim_uart_test_results_file} \
-          SEARCH_PATH=tests/bsim/drivers/uart/ tests/bsim/run_parallel.sh
+          tests/bsim/ci.uart.sh
 
       - name: Merge Test Results
         run: |

--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -191,21 +191,27 @@ jobs:
           RESULTS_FILE=${ZEPHYR_BASE}/${bsim_uart_test_results_file} \
           SEARCH_PATH=tests/bsim/drivers/uart/ tests/bsim/run_parallel.sh
 
-      - name: Upload Test Results
+      - name: Merge Test Results
+        run: |
+          pip3 install junitparser junit2html
+          junitparser merge ./bsim_*/*bsim_results.*.xml ./twister-out/twister.xml junit.xml
+          junit2html junit.xml junit.html
+
+      - name: Upload Unit Test Results in HTML
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: bsim-test-results
+          name: HTML Unit Test Results
+          if-no-files-found: ignore
           path: |
-            ./bsim_bt/52_bsim_results.xml
-            ./bsim_bt/53_bsim_results.xml
-            ./bsim_bt/53_bsim_split_results.xml
-            ./bsim_net/52_bsim_results.xml
-            ./bsim_uart/uart_bsim_results.xml
-            ./twister-out/twister.xml
-            ./twister-out/twister.json
-            ${{ github.event_path }}
-          if-no-files-found: warn
+            junit.html
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          check_name: Bsim Test Results
+          files: "junit.xml"
+          comment_mode: off
 
       - name: Upload Event Details
         if: always()

--- a/tests/bsim/bluetooth/compile.nrf54l15bsim_nrf54l15_cpuapp.sh
+++ b/tests/bsim/bluetooth/compile.nrf54l15bsim_nrf54l15_cpuapp.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Copyright 2018 Oticon A/S
+# SPDX-License-Identifier: Apache-2.0
+
+# Compile all the applications needed by the Bluetooth bsim tests on the
+# nrf54l15bsim/nrf54l15/cpuapp
+
+#set -x #uncomment this line for debugging
+set -ue
+: "${ZEPHYR_BASE:?ZEPHYR_BASE must be set to point to the zephyr root directory}"
+
+export BOARD="${BOARD:-nrf54l15bsim/nrf54l15/cpuapp}"
+
+source ${ZEPHYR_BASE}/tests/bsim/compile.source
+
+app=tests/bsim/bluetooth/ll/multiple_id compile
+
+wait_for_background_jobs

--- a/tests/bsim/bluetooth/tests.nrf54l15bsim_nrf54l15_cpuapp.txt
+++ b/tests/bsim/bluetooth/tests.nrf54l15bsim_nrf54l15_cpuapp.txt
@@ -1,0 +1,3 @@
+# Search paths(s) for tests which will be run in the nrf54l15 app core
+# This file is used in CI to select which tests are run
+tests/bsim/bluetooth/ll/multiple_id/tests_scripts/multiple.sh

--- a/tests/bsim/ci.bt.sh
+++ b/tests/bsim/ci.bt.sh
@@ -33,3 +33,11 @@ BOARD=nrf5340bsim/nrf5340/cpuapp \
 RESULTS_FILE=${ZEPHYR_BASE}/bsim_out/bsim_results.bt.53_cpuapp.xml \
 TESTS_FILE=tests/bsim/bluetooth/tests.nrf5340bsim_nrf5340_cpuapp.txt \
 tests/bsim/run_parallel.sh
+
+# nrf54l15bsim/nrf54l15/cpuapp set:
+nice tests/bsim/bluetooth/compile.nrf54l15bsim_nrf54l15_cpuapp.sh
+
+BOARD=nrf54l15bsim/nrf54l15/cpuapp \
+RESULTS_FILE=${ZEPHYR_BASE}/bsim_out/bsim_results.bt.54l15_cpuapp.xml \
+TESTS_FILE=tests/bsim/bluetooth/tests.nrf54l15bsim_nrf54l15_cpuapp.txt \
+tests/bsim/run_parallel.sh

--- a/tests/bsim/ci.bt.sh
+++ b/tests/bsim/ci.bt.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Copyright 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# This script runs the Babblesim CI BT tests.
+# It can also be run locally.
+# Note it will produce its output in ${ZEPHYR_BASE}/bsim_bt/
+
+export ZEPHYR_BASE="${ZEPHYR_BASE:-${PWD}}"
+cd ${ZEPHYR_BASE}
+
+set -uex
+
+# nrf52_bsim set:
+nice tests/bsim/bluetooth/compile.sh
+
+RESULTS_FILE=${ZEPHYR_BASE}/bsim_out/bsim_results.bt.52.xml \
+TESTS_FILE=tests/bsim/bluetooth/tests.nrf52bsim.txt \
+tests/bsim/run_parallel.sh
+
+# nrf5340bsim/nrf5340/cpunet set:
+nice tests/bsim/bluetooth/compile.nrf5340bsim_nrf5340_cpunet.sh
+
+BOARD=nrf5340bsim/nrf5340/cpunet \
+RESULTS_FILE=${ZEPHYR_BASE}/bsim_out/bsim_results.bt.53_cpunet.xml \
+TESTS_FILE=tests/bsim/bluetooth/tests.nrf5340bsim_nrf5340_cpunet.txt \
+tests/bsim/run_parallel.sh
+
+# nrf5340 split stack set:
+nice tests/bsim/bluetooth/compile.nrf5340bsim_nrf5340_cpuapp.sh
+
+BOARD=nrf5340bsim/nrf5340/cpuapp \
+RESULTS_FILE=${ZEPHYR_BASE}/bsim_out/bsim_results.bt.53_cpuapp.xml \
+TESTS_FILE=tests/bsim/bluetooth/tests.nrf5340bsim_nrf5340_cpuapp.txt \
+tests/bsim/run_parallel.sh

--- a/tests/bsim/ci.net.sh
+++ b/tests/bsim/ci.net.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Copyright 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# This script runs the Babblesim CI networking tests.
+# It can also be run locally.
+# Note it will produce its output in ${ZEPHYR_BASE}/bsim_bt/
+
+export ZEPHYR_BASE="${ZEPHYR_BASE:-${PWD}}"
+cd ${ZEPHYR_BASE}
+
+set -uex
+
+WORK_DIR=${ZEPHYR_BASE}/bsim_net nice tests/bsim/net/compile.sh
+RESULTS_FILE=${ZEPHYR_BASE}/bsim_out/bsim_results.net.52.xml \
+SEARCH_PATH=tests/bsim/net/ tests/bsim/run_parallel.sh

--- a/tests/bsim/ci.uart.sh
+++ b/tests/bsim/ci.uart.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Copyright 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# This script runs the Babblesim CI UART tests.
+# It can also be run locally.
+# Note it will produce its output in ${ZEPHYR_BASE}/bsim_out/
+
+export ZEPHYR_BASE="${ZEPHYR_BASE:-${PWD}}"
+cd ${ZEPHYR_BASE}
+
+set -uex
+
+echo "UART: Single device tests"
+${ZEPHYR_BASE}/scripts/twister -T tests/drivers/uart/ --force-color --inline-logs -v -M \
+  -p nrf52_bsim --fixture gpio_loopback -- -uart0_loopback
+
+echo "UART: Multi device tests"
+WORK_DIR=${ZEPHYR_BASE}/bsim_uart nice tests/bsim/drivers/uart/compile.sh
+RESULTS_FILE=${ZEPHYR_BASE}/bsim_out/bsim_results.uart.52.xml \
+SEARCH_PATH=tests/bsim/drivers/uart/ tests/bsim/run_parallel.sh

--- a/tests/bsim/run_parallel.sh
+++ b/tests/bsim/run_parallel.sh
@@ -41,18 +41,17 @@ fi
 
 err=0
 i=0
+sh_filter="(/_|run_parallel|compile|generate_coverage_report.sh|/ci\.)"
 
 if [ -n "${TESTS_FILE}" ]; then
 	#remove comments and empty lines from file
 	search_pattern=$(sed 's/#.*$//;/^$/d' "${TESTS_FILE}") || exit 1
-	all_cases=`find ${search_pattern} -name "*.sh" | \
-	         grep -Ev "(/_|run_parallel|compile|generate_coverage_report.sh)"`
+	all_cases=`find ${search_pattern} -name "*.sh" | grep -Ev "${sh_filter}"`
 elif [ -n "${TESTS_LIST}" ]; then
 	all_cases=${TESTS_LIST}
 else
 	SEARCH_PATH="${SEARCH_PATH:-.}"
-	all_cases=`find ${SEARCH_PATH} -name "*.sh" | \
-	         grep -Ev "(/_|run_parallel|compile|generate_coverage_report.sh)"`
+	all_cases=`find ${SEARCH_PATH} -name "*.sh" | grep -Ev "${sh_filter}"`
 	#we dont run ourselves
 fi
 

--- a/tests/bsim/run_parallel.sh
+++ b/tests/bsim/run_parallel.sh
@@ -69,7 +69,7 @@ echo "Attempting to run ${n_cases} cases (logging to \
  `realpath ${RESULTS_FILE}`)"
 
 export CLEAN_XML="sed -E -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' \
-                  -e 's/\"/&quot;/g'"
+                  -e 's/\"/&quot;/g' -e $'s/\x1b\[[0-9;]*[a-zA-Z]//g'"
 
 echo -n "" > $tmp_res_file
 


### PR DESCRIPTION
* Also run simulation tests for the nrf54l15 in CI
* Move the workflow commands that run the tests to small script files so they can be easily run locally
* Remove escape sequences from tests output to avoid a corrupted xml
* Use the same steps to merge and publish the tests results as for the twister workflow (direct copy paste)