### PR TITLE
boards: st: stm32CubeProgrammer runner does not need hex-file path

### DIFF
--- a/boards/st/b_u585i_iot02a/board.cmake
+++ b/boards/st/b_u585i_iot02a/board.cmake
@@ -14,7 +14,6 @@ endif()
 
 if(CONFIG_STM32_MEMMAP)
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
-board_runner_args(stm32cubeprogrammer "--hex-file=${ZEPHYR_BASE}/build/zephyr/zephyr.hex")
 board_runner_args(stm32cubeprogrammer "--extload=MX25LM51245G_STM32U585I-IOT02A.stldr")
 else()
 board_runner_args(stm32cubeprogrammer "--erase" "--port=swd" "--reset-mode=hw")

--- a/boards/st/stm32h745i_disco/board.cmake
+++ b/boards/st/stm32h745i_disco/board.cmake
@@ -11,7 +11,6 @@ endif()
 
 if(CONFIG_STM32_MEMMAP)
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
-board_runner_args(stm32cubeprogrammer "--hex-file=${ZEPHYR_BASE}/build/zephyr/zephyr.hex")
 board_runner_args(stm32cubeprogrammer "--extload=MT25TL01G_STM32H745I-DISCO.stldr")
 else()
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")

--- a/boards/st/stm32h747i_disco/board.cmake
+++ b/boards/st/stm32h747i_disco/board.cmake
@@ -13,7 +13,6 @@ endif()
 
 if(CONFIG_STM32_MEMMAP)
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
-board_runner_args(stm32cubeprogrammer "--hex-file=${ZEPHYR_BASE}/build/zephyr/zephyr.hex")
 board_runner_args(stm32cubeprogrammer "--extload=MT25TL01G_STM32H747I-DISCO.stldr")
 else()
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")

--- a/boards/st/stm32h750b_dk/board.cmake
+++ b/boards/st/stm32h750b_dk/board.cmake
@@ -5,7 +5,6 @@ board_runner_args(openocd --target-handle=_CHIPNAME.cpu0)
 
 if(CONFIG_STM32_MEMMAP)
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
-board_runner_args(stm32cubeprogrammer "--hex-file=${ZEPHYR_BASE}/build/zephyr/zephyr.hex")
 board_runner_args(stm32cubeprogrammer "--extload=MT25TL01G_STM32H750B-DISCO.stldr")
 else()
 board_runner_args(stm32cubeprogrammer "--erase" "--port=swd" "--reset-mode=hw" )

--- a/boards/st/stm32h7b3i_dk/board.cmake
+++ b/boards/st/stm32h7b3i_dk/board.cmake
@@ -6,7 +6,6 @@ board_runner_args(openocd --target-handle=_CHIPNAME.cpu0)
 
 if(CONFIG_STM32_MEMMAP)
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
-board_runner_args(stm32cubeprogrammer "--hex-file=${ZEPHYR_BASE}/build/zephyr/zephyr.hex")
 board_runner_args(stm32cubeprogrammer "--extload=MX25LM51245G_STM32H7B3I-DISCO.stldr")
 else()
 board_runner_args(stm32cubeprogrammer "--erase" "--port=swd" "--reset-mode=hw" )


### PR DESCRIPTION
Do not give the path of the zephyr.hex when flashing with the STM32CubeProgrammer in MemoryMapped mode.
West flash can retrieve the path and file correctly. 
Twister does not need the path to flash the hex.file correctly

Fixing error when running twister for the  _samples/application_development/code_relocation_nocopy_  on the b_u585i_iot02a  :
`FATAL ERROR: download file /local/ztb/zephyrproject/zephyr/build/zephyr/zephyr.hex does not exist`



