### PR TITLE
usb: device_next: make buffers data cache and DMA friendly

### DIFF
--- a/doc/connectivity/usb/device_next/api/udc.rst
+++ b/doc/connectivity/usb/device_next/api/udc.rst
@@ -16,3 +16,5 @@ API reference
 *************
 
 .. doxygengroup:: udc_api
+
+.. doxygengroup:: udc_buf

--- a/drivers/usb/udc/Kconfig
+++ b/drivers/usb/udc/Kconfig
@@ -25,6 +25,13 @@ config UDC_BUF_POOL_SIZE
 	help
 	  Total amount of memory available for UDC requests.
 
+config UDC_BUF_FORCE_NOCACHE
+	bool "Place the buffer pools in the nocache memory region"
+	depends on NOCACHE_MEMORY && DCACHE
+	help
+	  Place the buffer pools in the nocache memory region if the driver
+	  cannot handle buffers in cached memory.
+
 config UDC_WORKQUEUE
 	bool "Use a dedicate work queue for UDC drivers"
 	help

--- a/drivers/usb/udc/Kconfig.dwc2
+++ b/drivers/usb/udc/Kconfig.dwc2
@@ -12,7 +12,7 @@ config UDC_DWC2
 
 config UDC_DWC2_DMA
 	bool "DWC2 USB DMA support"
-	default n
+	default y
 	depends on UDC_DWC2
 	help
 	  Enable Buffer DMA if DWC2 USB controller supports Internal DMA.

--- a/drivers/usb/udc/Kconfig.mcux
+++ b/drivers/usb/udc/Kconfig.mcux
@@ -6,6 +6,7 @@ config UDC_NXP_EHCI
 	default y
 	depends on DT_HAS_NXP_EHCI_ENABLED
 	select NOCACHE_MEMORY if HAS_MCUX_CACHE && CPU_HAS_DCACHE
+	imply UDC_BUF_FORCE_NOCACHE
 	help
 	  NXP MCUX USB Device Controller Driver for EHCI.
 

--- a/drivers/usb/udc/udc_common.c
+++ b/drivers/usb/udc/udc_common.c
@@ -10,6 +10,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/usb/usb_ch9.h>
+#include <zephyr/drivers/usb/udc_buf.h>
 #include "udc_common.h"
 
 #include <zephyr/logging/log.h>
@@ -20,9 +21,39 @@
 #endif
 LOG_MODULE_REGISTER(udc, CONFIG_UDC_DRIVER_LOG_LEVEL);
 
+static inline uint8_t *udc_pool_data_alloc(struct net_buf *const buf,
+					   size_t *const size, k_timeout_t timeout)
+{
+	struct net_buf_pool *const buf_pool = net_buf_pool_get(buf->pool_id);
+	struct k_heap *const pool = buf_pool->alloc->alloc_data;
+	void *b;
+
+	*size = ROUND_UP(*size, UDC_BUF_GRANULARITY);
+	b = k_heap_aligned_alloc(pool, UDC_BUF_ALIGN, *size, timeout);
+	if (b == NULL) {
+		*size = 0;
+		return NULL;
+	}
+
+	return b;
+}
+
+static inline void udc_pool_data_unref(struct net_buf *buf, uint8_t *const data)
+{
+	struct net_buf_pool *buf_pool = net_buf_pool_get(buf->pool_id);
+	struct k_heap *pool = buf_pool->alloc->alloc_data;
+
+	k_heap_free(pool, data);
+}
+
+const struct net_buf_data_cb net_buf_dma_cb = {
+	.alloc = udc_pool_data_alloc,
+	.unref = udc_pool_data_unref,
+};
+
 static inline void udc_buf_destroy(struct net_buf *buf);
 
-NET_BUF_POOL_VAR_DEFINE(udc_ep_pool,
+UDC_BUF_POOL_VAR_DEFINE(udc_ep_pool,
 			CONFIG_UDC_BUF_COUNT, CONFIG_UDC_BUF_POOL_SIZE,
 			sizeof(struct udc_buf_info), udc_buf_destroy);
 

--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -2244,14 +2244,6 @@ static const struct udc_api udc_dwc2_api = {
 		.ghwcfg4 = DT_INST_PROP(n, ghwcfg4),				\
 	};									\
 										\
-	IF_ENABLED(CONFIG_DCACHE, (BUILD_ASSERT(				\
-		!IS_ENABLED(CONFIG_UDC_DWC2_DMA) ||				\
-		(DT_INST_PROP(n, ghwcfg2) & USB_DWC2_GHWCFG2_OTGARCH_MASK) !=	\
-			(USB_DWC2_GHWCFG2_OTGARCH_INTERNALDMA <<		\
-			 USB_DWC2_GHWCFG2_OTGARCH_POS),				\
-		"USB stack does not provide D-Cache aware buffers yet");	\
-	))									\
-										\
 	static struct udc_dwc2_data udc_priv_##n = {				\
 	};									\
 										\

--- a/drivers/usb/udc/udc_mcux_ehci.c
+++ b/drivers/usb/udc/udc_mcux_ehci.c
@@ -52,37 +52,6 @@ struct udc_mcux_data {
 	uint8_t controller_id; /* 0xFF is invalid value */
 };
 
-/* TODO: implement the cache maintenance
- * solution1: Use the non-cached buf to do memcpy before/after giving buffer to usb controller.
- * solution2: Use cache API to flush/invalid cache. but it needs the given buffer is
- * cache line size aligned and the buffer range cover multiple of cache line size block.
- * Need to change the usb stack to implement it, will try to implement it later.
- */
-#if defined(CONFIG_NOCACHE_MEMORY)
-K_HEAP_DEFINE_NOCACHE(mcux_packet_alloc_pool, USB_DEVICE_CONFIG_ENDPOINTS * 2u * 1024u);
-
-/* allocate non-cached buffer for usb */
-static void *udc_mcux_nocache_alloc(uint32_t size)
-{
-	void *p = (void *)k_heap_alloc(&mcux_packet_alloc_pool, size, K_NO_WAIT);
-
-	if (p != NULL) {
-		(void)memset(p, 0, size);
-	}
-
-	return p;
-}
-
-/* free the allocated non-cached buffer */
-static void udc_mcux_nocache_free(void *p)
-{
-	if (p == NULL) {
-		return;
-	}
-	k_heap_free(&mcux_packet_alloc_pool, p);
-}
-#endif
-
 static int udc_mcux_control(const struct device *dev, usb_device_control_type_t command,
 				void *param)
 {
@@ -128,21 +97,12 @@ static int udc_mcux_ep_feed(const struct device *dev,
 
 		if (USB_EP_DIR_IS_OUT(cfg->addr)) {
 			len = net_buf_tailroom(buf);
-#if defined(CONFIG_NOCACHE_MEMORY)
-			data = (len == 0 ? NULL : udc_mcux_nocache_alloc(len));
-#else
 			data = net_buf_tail(buf);
-#endif
 			status = mcux_if->deviceRecv(priv->mcux_device.controllerHandle,
 					cfg->addr, data, len);
 		} else {
 			len = buf->len;
-#if defined(CONFIG_NOCACHE_MEMORY)
-			data = (len == 0 ? NULL : udc_mcux_nocache_alloc(len));
-			memcpy(data, buf->data, len);
-#else
 			data = buf->data;
-#endif
 			status = mcux_if->deviceSend(priv->mcux_device.controllerHandle,
 					cfg->addr, data, len);
 		}
@@ -258,10 +218,6 @@ static int udc_mcux_handler_ctrl_out(const struct device *dev, struct net_buf *b
 	uint32_t len;
 
 	len = MIN(net_buf_tailroom(buf), mcux_len);
-#if defined(CONFIG_NOCACHE_MEMORY)
-	memcpy(net_buf_tail(buf), mcux_buf, len);
-	udc_mcux_nocache_free(mcux_buf);
-#endif
 	net_buf_add(buf, len);
 	if (udc_ctrl_stage_is_status_out(dev)) {
 		/* Update to next stage of control transfer */
@@ -289,9 +245,6 @@ static int udc_mcux_handler_ctrl_in(const struct device *dev, struct net_buf *bu
 	len = MIN(buf->len, mcux_len);
 	buf->data += len;
 	buf->len -= len;
-#if defined(CONFIG_NOCACHE_MEMORY)
-	udc_mcux_nocache_free(mcux_buf);
-#endif
 
 	if (udc_ctrl_stage_is_status_in(dev) ||
 	udc_ctrl_stage_is_no_data(dev)) {
@@ -324,9 +277,6 @@ static int udc_mcux_handler_non_ctrl_in(const struct device *dev, uint8_t ep,
 	buf->data += len;
 	buf->len -= len;
 
-#if defined(CONFIG_NOCACHE_MEMORY)
-	udc_mcux_nocache_free(mcux_buf);
-#endif
 	err = udc_submit_ep_event(dev, buf, 0);
 	udc_mcux_ep_try_feed(dev, udc_get_ep_cfg(dev, ep));
 
@@ -340,14 +290,8 @@ static int udc_mcux_handler_non_ctrl_out(const struct device *dev, uint8_t ep,
 	uint32_t len;
 
 	len = MIN(net_buf_tailroom(buf), mcux_len);
-#if defined(CONFIG_NOCACHE_MEMORY)
-	memcpy(net_buf_tail(buf), mcux_buf, len);
-#endif
 	net_buf_add(buf, len);
 
-#if defined(CONFIG_NOCACHE_MEMORY)
-	udc_mcux_nocache_free(mcux_buf);
-#endif
 	err = udc_submit_ep_event(dev, buf, 0);
 	udc_mcux_ep_try_feed(dev, udc_get_ep_cfg(dev, ep));
 

--- a/include/zephyr/drivers/usb/udc.h
+++ b/include/zephyr/drivers/usb/udc.h
@@ -14,7 +14,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
-#include <zephyr/net/buf.h>
+#include <zephyr/drivers/usb/udc_buf.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/usb/usb_ch9.h>
 

--- a/include/zephyr/drivers/usb/udc_buf.h
+++ b/include/zephyr/drivers/usb/udc_buf.h
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Buffers for USB device support
+ */
+
+#ifndef ZEPHYR_INCLUDE_UDC_BUF_H
+#define ZEPHYR_INCLUDE_UDC_BUF_H
+
+#include <zephyr/kernel.h>
+#include <zephyr/net/buf.h>
+
+#if defined(CONFIG_DCACHE) && !defined(CONFIG_UDC_BUF_FORCE_NOCACHE)
+/*
+ * Here we try to get DMA-safe buffers, but we lack a consistent source of
+ * information about data cache properties, such as line cache size, and a
+ * consistent source of information about what part of memory is DMA'able.
+ * For now, we simply assume that all available memory is DMA'able and use
+ * Kconfig option DCACHE_LINE_SIZE for alignment and granularity.
+ */
+#define Z_UDC_BUF_ALIGN		CONFIG_DCACHE_LINE_SIZE
+#define Z_UDC_BUF_GRANULARITY	CONFIG_DCACHE_LINE_SIZE
+#else
+/*
+ * Default alignment and granularity to pointer size if the platform does not
+ * have a data cache or buffers are placed in nocache memory region.
+ */
+#define Z_UDC_BUF_ALIGN		sizeof(void *)
+#define Z_UDC_BUF_GRANULARITY	sizeof(void *)
+#endif
+
+/**
+ * @brief Buffer macros and definitions used in USB device support
+ * @defgroup udc_buf Buffer macros and definitions used in USB device support
+ * @ingroup usb
+ * @{
+ */
+
+/** Buffer alignment required by the UDC driver */
+#define UDC_BUF_ALIGN		Z_UDC_BUF_ALIGN
+
+/** Buffer granularity required by the UDC driver */
+#define UDC_BUF_GRANULARITY	Z_UDC_BUF_GRANULARITY
+
+/**
+ * @brief Define a UDC driver-compliant static buffer
+ *
+ * This macro should be used if the application defines its own buffers to be
+ * used for USB transfers.
+ *
+ * @param name Buffer name
+ * @param size Buffer size
+ */
+#define UDC_STATIC_BUF_DEFINE(name, size)					\
+	static uint8_t __aligned(UDC_BUF_ALIGN) name[ROUND_UP(size, UDC_BUF_GRANULARITY)];
+
+/**
+ * @brief Verify that the buffer is aligned as required by the UDC driver
+ *
+ * @see IS_ALIGNED
+ *
+ * @param buf Buffer pointer
+ */
+#define IS_UDC_ALIGNED(buf) IS_ALIGNED(buf, UDC_BUF_ALIGN)
+
+/**
+ * @cond INTERNAL_HIDDEN
+ */
+#define UDC_HEAP_DEFINE(name, bytes, in_section)				\
+	uint8_t in_section __aligned(UDC_BUF_ALIGN)				\
+		kheap_##name[MAX(bytes, Z_HEAP_MIN_SIZE)];			\
+	STRUCT_SECTION_ITERABLE(k_heap, name) = {				\
+		.heap = {							\
+			.init_mem = kheap_##name,				\
+			.init_bytes = MAX(bytes, Z_HEAP_MIN_SIZE),		\
+		 },								\
+	}
+
+#define UDC_K_HEAP_DEFINE(name, size)						\
+	COND_CODE_1(CONFIG_UDC_BUF_FORCE_NOCACHE,				\
+		    (UDC_HEAP_DEFINE(name, size, __nocache)),			\
+		    (UDC_HEAP_DEFINE(name, size, __noinit)))
+
+extern const struct net_buf_data_cb net_buf_dma_cb;
+/** @endcond */
+
+/**
+ * @brief Define a new pool for UDC buffers with variable-size payloads
+ *
+ * This macro is similar to `NET_BUF_POOL_VAR_DEFINE`, but provides buffers
+ * with alignment and granularity suitable for use by UDC driver.
+ *
+ * @see NET_BUF_POOL_VAR_DEFINE
+ *
+ * @param pname      Name of the pool variable.
+ * @param count      Number of buffers in the pool.
+ * @param size       Maximum data payload per buffer.
+ * @param ud_size    User data space to reserve per buffer.
+ * @param fdestroy   Optional destroy callback when buffer is freed.
+ */
+#define UDC_BUF_POOL_VAR_DEFINE(pname, count, size, ud_size, fdestroy)		\
+	_NET_BUF_ARRAY_DEFINE(pname, count, ud_size);				\
+	UDC_K_HEAP_DEFINE(net_buf_mem_pool_##pname, size);			\
+	static const struct net_buf_data_alloc net_buf_data_alloc_##pname = {	\
+		.cb = &net_buf_dma_cb,						\
+		.alloc_data = &net_buf_mem_pool_##pname,			\
+		.max_alloc_size = 0,						\
+	};									\
+	static STRUCT_SECTION_ITERABLE(net_buf_pool, pname) =			\
+		NET_BUF_POOL_INITIALIZER(pname, &net_buf_data_alloc_##pname,	\
+					 _net_buf_##pname, count, ud_size,	\
+					 fdestroy)
+
+/**
+ * @brief Define a new pool for UDC buffers based on fixed-size data
+ *
+ * This macro is similar to `NET_BUF_POOL_DEFINE`, but provides buffers
+ * with alignment and granularity suitable for use by UDC driver.
+ *
+ * @see NET_BUF_POOL_DEFINE
+
+ * @param pname      Name of the pool variable.
+ * @param count      Number of buffers in the pool.
+ * @param size       Maximum data payload per buffer.
+ * @param ud_size    User data space to reserve per buffer.
+ * @param fdestroy   Optional destroy callback when buffer is freed.
+ */
+#define UDC_BUF_POOL_DEFINE(pname, count, size, ud_size, fdestroy)		\
+	_NET_BUF_ARRAY_DEFINE(pname, count, ud_size);				\
+	static uint8_t __nocache __aligned(UDC_BUF_ALIGN)			\
+		net_buf_data_##pname[count][size];				\
+	static const struct net_buf_pool_fixed net_buf_fixed_##pname = {	\
+		.data_pool = (uint8_t *)net_buf_data_##pname,			\
+	};									\
+	static const struct net_buf_data_alloc net_buf_fixed_alloc_##pname = {	\
+		.cb = &net_buf_fixed_cb,					\
+		.alloc_data = (void *)&net_buf_fixed_##pname,			\
+		.max_alloc_size = size,						\
+	};									\
+	static STRUCT_SECTION_ITERABLE(net_buf_pool, pname) =			\
+		NET_BUF_POOL_INITIALIZER(pname, &net_buf_fixed_alloc_##pname,	\
+					 _net_buf_##pname, count, ud_size,	\
+					 fdestroy)
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_INCLUDE_UDC_BUF_H */

--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -18,7 +18,7 @@
 #include <zephyr/usb/bos.h>
 #include <zephyr/usb/usb_ch9.h>
 #include <zephyr/usb/usbd_msg.h>
-#include <zephyr/net/buf.h>
+#include <zephyr/drivers/usb/udc_buf.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/logging/log.h>

--- a/samples/subsys/usb/hid-keyboard/src/main.c
+++ b/samples/subsys/usb/hid-keyboard/src/main.c
@@ -51,7 +51,7 @@ struct kb_event {
 
 K_MSGQ_DEFINE(kb_msgq, sizeof(struct kb_event), 2, 1);
 
-static uint8_t __aligned(sizeof(void *)) report[KB_REPORT_COUNT];
+UDC_STATIC_BUF_DEFINE(report, KB_REPORT_COUNT);
 static uint32_t kb_duration;
 static bool kb_ready;
 
@@ -273,7 +273,7 @@ int main(void)
 			continue;
 		}
 
-		ret = hid_device_submit_report(hid_dev, sizeof(report), report);
+		ret = hid_device_submit_report(hid_dev, KB_REPORT_COUNT, report);
 		if (ret) {
 			LOG_ERR("HID submit report error, %d", ret);
 		}

--- a/samples/subsys/usb/hid-mouse/src/main.c
+++ b/samples/subsys/usb/hid-mouse/src/main.c
@@ -174,11 +174,11 @@ int main(void)
 	}
 
 	while (true) {
-		uint8_t __aligned(sizeof(void *)) report[MOUSE_REPORT_COUNT];
+		UDC_STATIC_BUF_DEFINE(report, MOUSE_REPORT_COUNT);
 
 		k_msgq_get(&mouse_msgq, &report, K_FOREVER);
 
-		ret = hid_int_ep_write(hid_dev, report, sizeof(report), NULL);
+		ret = hid_int_ep_write(hid_dev, report, MOUSE_REPORT_COUNT, NULL);
 		if (ret) {
 			LOG_ERR("HID write error, %d", ret);
 		} else {

--- a/samples/subsys/usb/uac2_explicit_feedback/src/main.c
+++ b/samples/subsys/usb/uac2_explicit_feedback/src/main.c
@@ -36,7 +36,8 @@ LOG_MODULE_REGISTER(uac2_sample, LOG_LEVEL_INF);
  * when USB host decides to perform rapid terminal enable/disable cycles.
  */
 #define I2S_BUFFERS_COUNT   7
-K_MEM_SLAB_DEFINE_STATIC(i2s_tx_slab, MAX_BLOCK_SIZE, I2S_BUFFERS_COUNT, 4);
+K_MEM_SLAB_DEFINE_STATIC(i2s_tx_slab, ROUND_UP(MAX_BLOCK_SIZE, UDC_BUF_GRANULARITY),
+			 I2S_BUFFERS_COUNT, UDC_BUF_ALIGN);
 
 struct usb_i2s_ctx {
 	const struct device *i2s_dev;

--- a/subsys/usb/device_next/class/bt_hci.c
+++ b/subsys/usb/device_next/class/bt_hci.c
@@ -73,9 +73,9 @@ static K_FIFO_DEFINE(bt_hci_tx_queue);
  * REVISE: global (bulk, interrupt, iso) specific pools would be more
  * RAM usage efficient.
  */
-NET_BUF_POOL_FIXED_DEFINE(bt_hci_ep_pool,
-			  3, 512,
-			  sizeof(struct udc_buf_info), NULL);
+UDC_BUF_POOL_DEFINE(bt_hci_ep_pool,
+		    3, 512,
+		    sizeof(struct udc_buf_info), NULL);
 /* HCI RX/TX threads */
 static K_KERNEL_STACK_DEFINE(rx_thread_stack, CONFIG_BT_HCI_TX_STACK_SIZE);
 static struct k_thread rx_thread_data;

--- a/subsys/usb/device_next/class/usbd_cdc_acm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_acm.c
@@ -32,9 +32,9 @@
 #endif
 LOG_MODULE_REGISTER(usbd_cdc_acm, CONFIG_USBD_CDC_ACM_LOG_LEVEL);
 
-NET_BUF_POOL_FIXED_DEFINE(cdc_acm_ep_pool,
-			  DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) * 2,
-			  512, sizeof(struct udc_buf_info), NULL);
+UDC_BUF_POOL_DEFINE(cdc_acm_ep_pool,
+		    DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) * 2,
+		    512, sizeof(struct udc_buf_info), NULL);
 
 #define CDC_ACM_DEFAULT_LINECODING	{sys_cpu_to_le32(115200), 0, 0, 8}
 #define CDC_ACM_DEFAULT_INT_EP_MPS	16

--- a/subsys/usb/device_next/class/usbd_cdc_ecm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ecm.c
@@ -36,10 +36,10 @@ enum {
  * Transfers through two endpoints proceed in a synchronous manner,
  * with maximum block of NET_ETH_MAX_FRAME_SIZE.
  */
-NET_BUF_POOL_FIXED_DEFINE(cdc_ecm_ep_pool,
-			  DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) * 2,
-			  NET_ETH_MAX_FRAME_SIZE,
-			  sizeof(struct udc_buf_info), NULL);
+UDC_BUF_POOL_DEFINE(cdc_ecm_ep_pool,
+		    DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) * 2,
+		    NET_ETH_MAX_FRAME_SIZE,
+		    sizeof(struct udc_buf_info), NULL);
 
 struct cdc_ecm_notification {
 	union {

--- a/subsys/usb/device_next/class/usbd_hid.c
+++ b/subsys/usb/device_next/class/usbd_hid.c
@@ -496,6 +496,8 @@ static struct net_buf *hid_buf_alloc_ext(struct hid_device_data *const ddata,
 	struct net_buf *buf = NULL;
 	struct udc_buf_info *bi;
 
+	__ASSERT(IS_UDC_ALIGNED(data), "Application provided unaligned buffer");
+
 	buf = net_buf_alloc_with_data(ddata->pool_in, data, size, K_NO_WAIT);
 	if (!buf) {
 		return NULL;

--- a/subsys/usb/device_next/class/usbd_hid_macros.h
+++ b/subsys/usb/device_next/class/usbd_hid_macros.h
@@ -1156,7 +1156,7 @@
 
 #define HID_OUT_POOL_DEFINE(n)							\
 	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, out_report_size),			\
-		    (NET_BUF_POOL_DEFINE(hid_buf_pool_out_##n,			\
+		    (UDC_BUF_POOL_DEFINE(hid_buf_pool_out_##n,			\
 					 CONFIG_USBD_HID_OUT_BUF_COUNT,		\
 					 DT_INST_PROP(n, out_report_size),	\
 					 sizeof(struct udc_buf_info), NULL)),	\

--- a/subsys/usb/device_next/class/usbd_msc.c
+++ b/subsys/usb/device_next/class/usbd_msc.c
@@ -63,9 +63,9 @@ struct CSW {
 /* Can be 64 if device is not High-Speed capable */
 #define MSC_BUF_SIZE 512
 
-NET_BUF_POOL_FIXED_DEFINE(msc_ep_pool,
-			  MSC_NUM_INSTANCES * 2, MSC_BUF_SIZE,
-			  sizeof(struct udc_buf_info), NULL);
+UDC_BUF_POOL_DEFINE(msc_ep_pool,
+		    MSC_NUM_INSTANCES * 2, MSC_BUF_SIZE,
+		    sizeof(struct udc_buf_info), NULL);
 
 struct msc_event {
 	struct usbd_class_data *c_data;

--- a/subsys/usb/device_next/class/usbd_uac2.c
+++ b/subsys/usb/device_next/class/usbd_uac2.c
@@ -40,7 +40,7 @@ LOG_MODULE_REGISTER(usbd_uac2, CONFIG_USBD_UAC2_LOG_LEVEL);
  * "wasted memory" here is likely to be smaller than the memory overhead for
  * more complex "only as much as needed" schemes (e.g. heap).
  */
-NET_BUF_POOL_DEFINE(uac2_pool, UAC2_NUM_ENDPOINTS, 6,
+UDC_BUF_POOL_DEFINE(uac2_pool, UAC2_NUM_ENDPOINTS, 6,
 		    sizeof(struct udc_buf_info), NULL);
 
 /* 5.2.2 Control Request Layout */
@@ -204,6 +204,8 @@ uac2_buf_alloc(const uint8_t ep, void *data, uint16_t size)
 {
 	struct net_buf *buf = NULL;
 	struct udc_buf_info *bi;
+
+	__ASSERT(IS_UDC_ALIGNED(data), "Application provided unaligned buffer");
 
 	buf = net_buf_alloc_with_data(&uac2_pool, data, size, K_NO_WAIT);
 	if (!buf) {


### PR DESCRIPTION
Use our own version of alloc and unref callbacks to get buffers with specific alignment and granularity. Do not use ref callbac because it breaks alignment.