### PR TITLE
dts: ke1xz: Fix ranges warning on GPIO

### DIFF
--- a/dts/arm/nxp/nxp_ke1xz.dtsi
+++ b/dts/arm/nxp/nxp_ke1xz.dtsi
@@ -167,17 +167,18 @@
 			clocks = <&pcc 0x134 KINETIS_PCC_SRC_NONE_OR_EXT>;
 		};
 
-		gpios0: gpios0 {
+		gpios0: gpios0@400ff000 {
 			compatible = "nxp,gpio-cluster";
 			interrupts = <7 2>;
-
+			reg = <0x400ff000 0x200>;
+			ranges = <0x0 0x400ff000 0x200>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 
 			gpioa: gpio@400ff000 {
 				compatible = "nxp,kinetis-gpio";
 				status = "disabled";
-				reg = <0x400ff000 0x40>;
+				reg = <0x0 0x40>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				nxp,kinetis-port = <&porta>;
@@ -193,17 +194,18 @@
 			};
 		};
 
-		gpios1: gpios1 {
+		gpios1: gpios1@400ff040 {
 			compatible = "nxp,gpio-cluster";
 			interrupts = <26 2>;
-
+			reg = <0x400ff040 0x200>;
+			ranges = <0x40 0x400ff040 0x200>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 
 			gpiob: gpio@400ff040 {
 				compatible = "nxp,kinetis-gpio";
 				status = "disabled";
-				reg = <0x400ff040 0x40>;
+				reg = <0x40 0x40>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				nxp,kinetis-port = <&portb>;
@@ -212,7 +214,7 @@
 			gpioc: gpio@400ff080 {
 				compatible = "nxp,kinetis-gpio";
 				status = "disabled";
-				reg = <0x400ff080 0x40>;
+				reg = <0x80 0x40>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				nxp,kinetis-port = <&portc>;
@@ -221,7 +223,7 @@
 			gpiod: gpio@400ff0c0 {
 				compatible = "nxp,kinetis-gpio";
 				status = "disabled";
-				reg = <0x400ff0c0 0x40>;
+				reg = <0xc0 0x40>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				nxp,kinetis-port = <&portd>;


### PR DESCRIPTION
Fix simple bus reg / ranges warning from GPIO
nodes by giving the parent nodes addresses
and describing a ranges other than empty.