### PR TITLE
modbus: support async modbus serial

### DIFF
--- a/subsys/modbus/Kconfig
+++ b/subsys/modbus/Kconfig
@@ -48,6 +48,12 @@ config MODBUS_SERIAL
 	help
 	  Enable Modbus over serial line support.
 
+config MODBUS_SERIAL_ASYNC_API
+	depends on MODBUS_SERIAL && UART_ASYNC_API
+	bool "Modbus over serial line UART ASYNC API support"
+	help
+	  Use UART ASYNC API for Modbus over serial line.
+
 config MODBUS_ASCII_MODE
 	depends on MODBUS_SERIAL
 	bool "Modbus transmission mode ASCII"


### PR DESCRIPTION
Support the use of async api in modbus_serial.c. Reason for this extension are crc mismatches happening due to rx data loss when using the interrupt driven api (default modbus implementation) at higher speeds and/or high cpu load. It is recommended to use the async api (implemented in this MR) along with hardware byte counting requiring a timer instance and one PPI channel to achieve a robust communication at high baudrates. A new Kconfig CONFIG_MODBUS_SERIAL_ASYNC_API to enable/disable this feature has been added. 

Fixes #71767

Signed-off-by: Anouar Raddaoui <a.raddaoui@smight.com>