### PR TITLE
drivers: rtc: api: Add helper for determining calibration

### DIFF
--- a/include/zephyr/drivers/rtc.h
+++ b/include/zephyr/drivers/rtc.h
@@ -22,7 +22,7 @@
  * @{
  */
 
-#include <zephyr/types.h>
+#include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <errno.h>
 
@@ -459,6 +459,8 @@ static inline int z_impl_rtc_update_set_callback(const struct device *dev,
  * the RTC clock, a negative value will decrease the
  * frequency of the RTC clock.
  *
+ * @see rtc_calibration_from_frequency()
+ *
  * @param dev Device instance
  * @param calibration Calibration to set in parts per billion
  *
@@ -525,6 +527,20 @@ struct tm;
 static inline struct tm *rtc_time_to_tm(struct rtc_time *timeptr)
 {
 	return (struct tm *)timeptr;
+}
+
+/**
+ * @brief Determine required calibration to 1 Hertz from frequency.
+ *
+ * @param frequency Frequency of the RTC in nano Hertz
+ *
+ * @return The required calibration in parts per billion
+ */
+static inline int32_t rtc_calibration_from_frequency(uint32_t frequency)
+{
+	__ASSERT_NO_MSG(frequency > 0);
+
+	return (int32_t)((1000000000000000000LL / frequency) - 1000000000);
 }
 
 /**

--- a/tests/drivers/rtc/rtc_api_helpers/CMakeLists.txt
+++ b/tests/drivers/rtc/rtc_api_helpers/CMakeLists.txt
@@ -10,6 +10,5 @@ project(rtc_api)
 target_sources(app PRIVATE
 	src/main.c
 	src/test_rtc_time_to_tm.c
+	src/test_rtc_calibration_from_frequency.c
 )
-
-target_include_directories(app PRIVATE inc)

--- a/tests/drivers/rtc/rtc_api_helpers/src/test_rtc_calibration_from_frequency.c
+++ b/tests/drivers/rtc/rtc_api_helpers/src/test_rtc_calibration_from_frequency.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 Bjarki Arge Andreasen
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+#include <zephyr/drivers/rtc.h>
+
+struct test_sample {
+	uint32_t frequency;
+	int32_t calibration;
+};
+
+static const struct test_sample test_samples[] = {
+	{
+		.frequency = 1000000000,
+		.calibration = 0,
+	},
+	{
+		.frequency = 1000000001,
+		.calibration = -1,
+	},
+	{
+		.frequency = 999999999,
+		.calibration = 1,
+	},
+	{
+		.frequency = 2000000000,
+		.calibration = -500000000,
+	},
+	{
+		.frequency = 500000000,
+		.calibration = 1000000000,
+	},
+};
+
+ZTEST(rtc_api_helpers, test_validate_calibration_from_frequency)
+{
+	uint32_t frequency;
+	int32_t calibration;
+	int32_t result;
+
+	ARRAY_FOR_EACH(test_samples, i) {
+		frequency = test_samples[i].frequency;
+		calibration = test_samples[i].calibration;
+		result = rtc_calibration_from_frequency(frequency);
+		zassert_equal(result, calibration);
+	}
+}


### PR DESCRIPTION
### Overview
Add helper function which calculates the required calibration to 1 Hertz from the actual frequency of an RTC. This helper is both functional and adds to the documentation of the RTC calibration API.

```
static inline int32_t rtc_calibration_from_frequency(uint32_t frequency)
{
	if (frequency == 0) {
		return INT32_MAX;
	}

	return (int32_t)((1000000000000000000 / frequency) - 1000000000);
}
```

Clarification regarding how to calculate the calibration value has been requested on Discord before, this addition should help provide that clarification.

The commit additionally extends the rtc_api_helpers test suite with a test to validate the conversion function itself.

To validate the calibration calculation in practice, I used a b_u585i_iot02a (rtc_ll_stm32.c) and calibrated it to match the RTC of my phone. (TL;DR calibrated from 1.000468528Hz to 0.999991933Hz, reducing the error from 468528ppb to -8066ppb)

### Question for reviewers
Should I remove the division by zero check? It seems kind of unnecessary given that if an RTC is running at 0 Hertz or other far from 1Hz frequency, something has probably gone wrong somewhere upstream :)

### Procedure for practical test
1. Set calibration value to 450000ppb, which was rounded to 450134ppb by the driver. This should increase the frequency of the RTC above 1Hz
2. Get time of RTC and start stopwatch on phone at the same time: 
* RTC: 12:23:51.726
* stopwatch: 0
3. Wait for approximately 40 minutes
4. Get time of RTC and start stopwatch on phone at the same time:
* RTC: 13:00:45.863
* stopwatch: 00:36:53.100
5. Calculate frequency in nano Hertz using stopwatch as 1Hz reference clock
* 13:00:45.863 - 12:23:51.726 = 2214.136 seconds
* 00:36:53.100 = 2213.1 seconds
* (1 / 2213.1) * 2214.136 * 1000000000 = 1000468528nHz
6. Use rtc_calibration_from_frequency() to determine calibration value:
* rtc_calibration_from_frequency(1000468528) = -468309
7. Get and add the existing calibration value of 450134ppb to the required calibration value
* 450134ppb + (-468309) = -18175
8. Set the calibration value to -18175, which was rounded to -18120 by the driver
9. Get time of RTC and start stopwatch on phone at the same time: 
* RTC: 13:23:37.558
* stopwatch: 0
10. Wait for approximately 7 hours
11. Get time of RTC and start stopwatch on phone at the same time:
* RTC: 20:35:27.679
* stopwatch: 07:11:50.330
12. Calculate frequency in nano Hertz using stopwatch as 1Hz reference clock
* 20:35:27.679 - 13:23:37.558 = 25910.121 seconds
* 07:11:50.330 = 25910.33 seconds
* (1 / 25910.33) * 25910.121 * 1000000000 = 999991933nHz