### PR TITLE
fix fallthrough on `sample_channel_get` on AQI

### DIFF
--- a/drivers/sensor/ens160/ens160.c
+++ b/drivers/sensor/ens160/ens160.c
@@ -148,6 +148,7 @@ static int ens160_channel_get(const struct device *dev, enum sensor_channel chan
 	case SENSOR_CHAN_ENS160_AQI:
 		val->val1 = data->aqi;
 		val->val2 = 0;
+		break;
 	default:
 		return -ENOTSUP;
 	}


### PR DESCRIPTION
There is a small bug present in ENS161 sensor driver where while getting samples for AQI logging return ERRNO -134
Cause was a lack of break in switch statement.