### PR TITLE
drivers: sensor: sensirion: shtcx: remove chip property

### DIFF
--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -413,6 +413,23 @@ LED Strip
 Sensors
 =======
 
+* The ``chip`` devicetree property from the :dtcompatible:`sensirion,shtcx` sensor driver has been
+  removed. Chip variants are now selected using the matching compatible property (:github:`74033`).
+  For an example of the new shtc3 configuration, see below:
+
+  .. code-block:: devicetree
+
+    &i2c0 {
+        status = "okay";
+
+        shtc3: shtc3@70 {
+            compatible = "sensirion,shtc3", "sensirion,shtcx";
+            reg = <0x70>;
+            measure-mode = "normal";
+            clock-stretching;
+        };
+    };
+
 Serial
 ======
 

--- a/drivers/sensor/sensirion/shtcx/shtcx.c
+++ b/drivers/sensor/sensirion/shtcx/shtcx.c
@@ -237,10 +237,13 @@ static int shtcx_init(const struct device *dev)
 	return 0;
 }
 
+#define SHTCX_CHIP(inst) \
+	(DT_INST_NODE_HAS_COMPAT(inst, sensirion_shtc1) ? CHIP_SHTC1 : CHIP_SHTC3)
+
 #define SHTCX_CONFIG(inst)						       \
 	{								       \
 		.i2c = I2C_DT_SPEC_INST_GET(inst),			       \
-		.chip = DT_INST_ENUM_IDX(inst, chip),			       \
+		.chip = SHTCX_CHIP(inst),				       \
 		.measure_mode = DT_INST_ENUM_IDX(inst, measure_mode),	       \
 		.clock_stretching = DT_INST_PROP(inst, clock_stretching)       \
 	}

--- a/dts/bindings/sensor/sensirion,shtcx.yaml
+++ b/dts/bindings/sensor/sensirion,shtcx.yaml
@@ -1,24 +1,30 @@
 # Copyright (c) 2021, Thomas Stranger
 # SPDX-License-Identifier: Apache-2.0
 
-description: Sensirion SHTCx humidity and temperature sensor
+description: |
+  Sensirion SHTCx humidity and temperature sensor
+
+  Additionally use "sensirion,shtc1" or "sensirion,shtc3" compatibles
+  such that a generic driver can consider chip specific behaviour.
+
+  Example device tree node describing a Sensirion SHTC3 Sensor on the i2c0 bus:
+
+   &i2c0 {
+      status = "okay";
+      clock-frequency = <I2C_BITRATE_FAST>;
+      shtc3@70 {
+        compatible = "sensirion,shtc3", "sensirion,shtcx";
+        reg = <0x70>;
+        measure-mode = "normal";
+        clock-stretching;
+     };
+   };
 
 compatible: "sensirion,shtcx"
 
 include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
-  chip:
-    type: string
-    required: true
-    description: |
-      Specifies which chip exactly is used. This is necessary to get exact
-      timing information and supported command set.
-      SHTC3 has an additional sleep mode that is entered between measurements.
-    enum:
-      - "shtc1"
-      - "shtc3"
-
   measure-mode:
     type: string
     required: true

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -231,10 +231,9 @@ test_i2c_sht4xd: sht4x@20 {
 	repeatability = <2>;
 };
 
-test_i2c_shtc3: SHTC3@21 {
-	compatible = "sensirion,shtcx";
+test_i2c_shtc3: shtc3@21 {
+	compatible = "sensirion,shtc3", "sensirion,shtcx";
 	reg = <0x21>;
-	chip = "shtc3";
 	measure-mode = "normal";
 	clock-stretching;
 };
@@ -1048,4 +1047,11 @@ test_i2c_ina226: ina226@8d {
 	reg = <0x8d>;
 	current-lsb-microamps = <5000>;
 	rshunt-micro-ohms = <500>;
+};
+
+test_i2c_shtc1: shtc1@8e {
+	compatible = "sensirion,shtc1", "sensirion,shtcx";
+	reg = <0x8e>;
+	measure-mode = "low-power";
+	clock-stretching;
 };


### PR DESCRIPTION
Since a long time this driver was using a dts property to choose the specific chip variant instead of properly using compatibles. This PR fixes that:

Removes the dts "chip" property, the compatible should be used instead.

Any existing dts should be converted from something like:

```
test_i2c_shtc3: SHTC3@70 {
	compatible = "sensirion,shtcx";
	reg = <0x70>;
	chip = "shtc3";
	measure-mode = "normal";
	clock-stretching;
};
```

to something like:
```

test_i2c_shtc3: SHTC3@70 {
	compatible = "sensirion,shtc3", "sensirion,shtcx";
	reg = <0x70>;
	measure-mode = "normal";
	clock-stretching;
};
```

Tested with both an shtc3 and and an shtc1 chip.