### PR TITLE
drivers: rtc: rv3028: add support for user memory access

### DIFF
--- a/drivers/eeprom/CMakeLists.txt
+++ b/drivers/eeprom/CMakeLists.txt
@@ -26,3 +26,8 @@ zephyr_library_sources_ifdef(CONFIG_EEPROM_FAKE eeprom_fake.c)
 zephyr_library_sources_ifdef(CONFIG_EEPROM_AT2X_EMUL eeprom_at2x_emul.c)
 
 zephyr_library_sources_ifdef(CONFIG_EEPROM_MB85RCXX eeprom_mb85rcxx.c)
+
+if(CONFIG_EEPROM_RV3028)
+  zephyr_library_sources(eeprom_rv3028.c)
+  zephyr_library_include_directories(${ZEPHYR_BASE}/drivers/rtc)
+endif()

--- a/drivers/eeprom/Kconfig
+++ b/drivers/eeprom/Kconfig
@@ -99,6 +99,7 @@ source "drivers/eeprom/Kconfig.eeprom_emu"
 source "drivers/eeprom/Kconfig.tmp116"
 source "drivers/eeprom/Kconfig.xec"
 source "drivers/eeprom/Kconfig.mb85rcxx"
+source "drivers/eeprom/Kconfig.rv3028"
 
 config EEPROM_SIMULATOR
 	bool "Simulated EEPROM driver"

--- a/drivers/eeprom/Kconfig.rv3028
+++ b/drivers/eeprom/Kconfig.rv3028
@@ -1,0 +1,20 @@
+# Copyright (c) 2024 ANITRA system s.r.o.
+# SPDX-License-Identifier: Apache-2.0
+
+config EEPROM_RV3028
+	bool "Micro Crystal RV3028 User EEPROM support"
+	default y
+	depends on RTC_RV3028
+	depends on DT_HAS_MICROCRYSTAL_RV3028_EEPROM_ENABLED
+
+if EEPROM_RV3028
+
+config EEPROM_RV3028_INIT_PRIORITY
+	int "RV3028 EEPROM init priority"
+	default RTC_INIT_PRIORITY
+	help
+	  RV3028 EEPROM driver device initialization priority. The EEPROM is
+	  part of the RV3028 RTC device and has to be initialized after the RTC
+	  driver.
+
+endif # EEPROM_RV3028

--- a/drivers/eeprom/eeprom_rv3028.c
+++ b/drivers/eeprom/eeprom_rv3028.c
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2024 ANITRA system s.r.o.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT microcrystal_rv3028_eeprom
+
+#include <zephyr/drivers/eeprom.h>
+#include <zephyr/kernel.h>
+#include "rtc_rv3028.h"
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(rv3028, CONFIG_EEPROM_LOG_LEVEL);
+
+#define RV3028_USER_EEPROM_SIZE 0x2B
+
+struct rv3028_eeprom_config {
+	const struct device *parent;
+	uint8_t addr;
+	uint8_t size;
+};
+
+static size_t rv3028_eeprom_get_size(const struct device *dev)
+{
+	const struct rv3028_eeprom_config *config = dev->config;
+
+	return config->size;
+}
+
+static int rv3028_eeprom_read(const struct device *dev, off_t offset, void *data, size_t len)
+{
+	const struct rv3028_eeprom_config *config = dev->config;
+	const struct device *rtc_dev = config->parent;
+	uint8_t *dst = data;
+	uint8_t addr;
+	int err;
+
+	if (!len) {
+		return 0;
+	}
+
+	if (offset + len > config->size) {
+		LOG_ERR("attempt to read past device boundary");
+		return -EINVAL;
+	}
+
+	rv3028_lock_sem(rtc_dev);
+
+	err = rv3028_enter_eerd(rtc_dev);
+	if (err) {
+		goto unlock;
+	}
+
+	for (size_t i = 0; i < len; i++) {
+		addr = config->addr + offset + i;
+
+		err = rv3028_write_reg8(rtc_dev, RV3028_REG_EEPROM_ADDRESS, addr);
+		if (err) {
+			goto unlock;
+		}
+
+		err = rv3028_eeprom_command(rtc_dev, RV3028_EEPROM_CMD_READ);
+		if (err) {
+			goto unlock;
+		}
+
+		k_msleep(RV3028_EEBUSY_READ_POLL_MS);
+
+		err = rv3028_eeprom_wait_busy(rtc_dev, RV3028_EEBUSY_READ_POLL_MS);
+		if (err) {
+			goto unlock;
+		}
+
+		err = rv3028_read_reg8(rtc_dev, RV3028_REG_EEPROM_DATA, &dst[i]);
+		if (err) {
+			goto unlock;
+		}
+	}
+
+unlock:
+	rv3028_exit_eerd(rtc_dev);
+	rv3028_unlock_sem(rtc_dev);
+
+	return err;
+}
+
+static int rv3028_eeprom_write(const struct device *dev, off_t offset, const void *data, size_t len)
+{
+	const struct rv3028_eeprom_config *config = dev->config;
+	const struct device *rtc_dev = config->parent;
+	const uint8_t *src = data;
+	uint8_t cmd[2];
+	int err;
+
+	if (!len) {
+		return 0;
+	}
+
+	if (offset + len > config->size) {
+		LOG_ERR("attempt to write past device boundary");
+		return -EINVAL;
+	}
+
+	rv3028_lock_sem(rtc_dev);
+
+	err = rv3028_enter_eerd(rtc_dev);
+	if (err) {
+		goto unlock;
+	}
+
+	for (size_t i = 0; i < len; i++) {
+		cmd[0] = config->addr + offset + i;
+		cmd[1] = src[i];
+
+		err = rv3028_write_regs(rtc_dev, RV3028_REG_EEPROM_ADDRESS, cmd, sizeof(cmd));
+		if (err) {
+			goto unlock;
+		}
+
+		err = rv3028_eeprom_command(rtc_dev, RV3028_EEPROM_CMD_WRITE);
+		if (err) {
+			goto unlock;
+		}
+
+		k_msleep(RV3028_EEBUSY_WRITE_POLL_MS);
+
+		err = rv3028_eeprom_wait_busy(rtc_dev, RV3028_EEBUSY_WRITE_POLL_MS);
+		if (err) {
+			goto unlock;
+		}
+	}
+
+unlock:
+	rv3028_exit_eerd(rtc_dev);
+	rv3028_unlock_sem(rtc_dev);
+
+	return err;
+}
+
+static int rv3028_eeprom_init(const struct device *dev)
+{
+	const struct rv3028_eeprom_config *config = dev->config;
+
+	if (!device_is_ready(config->parent)) {
+		LOG_ERR("parent device %s is not ready", config->parent->name);
+		return -ENODEV;
+	}
+
+	return 0;
+}
+
+static const struct eeprom_driver_api rv3028_eeprom_api = {
+	.size = rv3028_eeprom_get_size,
+	.read = rv3028_eeprom_read,
+	.write = rv3028_eeprom_write,
+};
+
+#define RV3028_EEPROM_ASSERT_AREA_SIZE(inst)                                                       \
+	BUILD_ASSERT(DT_INST_REG_SIZE(inst) + DT_INST_REG_ADDR(inst) <= RV3028_USER_EEPROM_SIZE,   \
+		     "Invalid RV3028 EEPROM area size");
+
+#define RV3028_EEPROM_DEFINE(inst)                                                                 \
+	RV3028_EEPROM_ASSERT_AREA_SIZE(inst)                                                       \
+                                                                                                   \
+	static const struct rv3028_eeprom_config rv3028_eeprom_config_##inst = {                   \
+		.parent = DEVICE_DT_GET(DT_INST_BUS(inst)),                                        \
+		.addr = DT_INST_REG_ADDR(inst),                                                    \
+		.size = DT_INST_REG_SIZE(inst),                                                    \
+	};                                                                                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(inst, rv3028_eeprom_init, NULL, NULL, &rv3028_eeprom_config_##inst,  \
+			      POST_KERNEL, CONFIG_EEPROM_RV3028_INIT_PRIORITY, &rv3028_eeprom_api);
+
+DT_INST_FOREACH_STATUS_OKAY(RV3028_EEPROM_DEFINE);

--- a/drivers/retained_mem/CMakeLists.txt
+++ b/drivers/retained_mem/CMakeLists.txt
@@ -8,3 +8,7 @@ zephyr_library_sources_ifdef(CONFIG_RETAINED_MEM_NRF_GPREGRET retained_mem_nrf_g
 zephyr_library_sources_ifdef(CONFIG_RETAINED_MEM_NRF_RAM_CTRL retained_mem_nrf_ram_ctrl.c)
 zephyr_library_sources_ifdef(CONFIG_RETAINED_MEM_ZEPHYR_RAM   retained_mem_zephyr_ram.c)
 zephyr_library_sources_ifdef(CONFIG_RETAINED_MEM_ZEPHYR_REG   retained_mem_zephyr_reg.c)
+if(CONFIG_RETAINED_MEM_RV3028)
+  zephyr_library_sources(retained_mem_rv3028.c)
+  zephyr_library_include_directories(${ZEPHYR_BASE}/drivers/rtc)
+endif()

--- a/drivers/retained_mem/Kconfig
+++ b/drivers/retained_mem/Kconfig
@@ -34,7 +34,7 @@ module-str = retained_mem
 source "subsys/logging/Kconfig.template.log_config"
 
 source "drivers/retained_mem/Kconfig.nrf"
-
+source "drivers/retained_mem/Kconfig.rv3028"
 source "drivers/retained_mem/Kconfig.zephyr"
 
 endif # RETAINED_MEM

--- a/drivers/retained_mem/Kconfig.rv3028
+++ b/drivers/retained_mem/Kconfig.rv3028
@@ -1,0 +1,20 @@
+# Copyright (c) 2024 ANITRA system s.r.o.
+# SPDX-License-Identifier: Apache-2.0
+
+config RETAINED_MEM_RV3028
+	bool "Micro Crystal RV3028 User RAM support"
+	default y
+	depends on RTC_RV3028
+	depends on DT_HAS_MICROCRYSTAL_RV3028_RETMEM_ENABLED
+
+if RETAINED_MEM_RV3028
+
+config RETAINED_MEM_RV3028_INIT_PRIORITY
+	int "RV3028 User RAM init priority"
+	default RTC_INIT_PRIORITY
+	help
+	  RV3028 User RAM driver device initialization priority. The memory is
+	  part of the RV3028 RTC device and has to be initialized after the
+	  RV3028 RTC driver.
+
+endif # RETAINED_MEM_RV3028

--- a/drivers/retained_mem/retained_mem_rv3028.c
+++ b/drivers/retained_mem/retained_mem_rv3028.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2024 ANITRA system s.r.o.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT microcrystal_rv3028_retmem
+
+#include <zephyr/drivers/retained_mem.h>
+#include "rtc_rv3028.h"
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(rv3028, CONFIG_RETAINED_MEM_LOG_LEVEL);
+
+#define RV3028_USER_RAM_SIZE (2 * sizeof(uint8_t))
+
+struct rv3028_retained_mem_config {
+	const struct device *parent;
+	uint8_t addr;
+	uint8_t size;
+};
+
+static ssize_t rv3028_retained_mem_size(const struct device *dev)
+{
+	const struct rv3028_retained_mem_config *config = dev->config;
+
+	return config->size;
+}
+
+static int rv3028_retained_mem_read(const struct device *dev, off_t offset, uint8_t *buffer,
+				    size_t size)
+{
+	const struct rv3028_retained_mem_config *config = dev->config;
+	const struct device *rtc_dev = config->parent;
+
+	return rv3028_read_regs(rtc_dev, config->addr + offset, buffer, size);
+}
+
+static int rv3028_retained_mem_write(const struct device *dev, off_t offset, const uint8_t *buffer,
+				     size_t size)
+{
+	const struct rv3028_retained_mem_config *config = dev->config;
+	const struct device *rtc_dev = config->parent;
+
+	return rv3028_write_regs(rtc_dev, config->addr + offset, buffer, size);
+}
+
+static int rv3028_retained_mem_clear(const struct device *dev)
+{
+	const struct rv3028_retained_mem_config *config = dev->config;
+	const struct device *rtc_dev = config->parent;
+	uint8_t block[RV3028_USER_RAM_SIZE] = {0};
+
+	return rv3028_write_regs(rtc_dev, config->addr, block, config->size);
+}
+
+static int rv3028_retmem_init(const struct device *dev)
+{
+	const struct rv3028_retained_mem_config *config = dev->config;
+
+	if (!device_is_ready(config->parent)) {
+		LOG_ERR("parent device %s is not ready", config->parent->name);
+		return -ENODEV;
+	}
+
+	return 0;
+}
+
+static const struct retained_mem_driver_api rv3028_retmem_api = {
+	.size = rv3028_retained_mem_size,
+	.read = rv3028_retained_mem_read,
+	.write = rv3028_retained_mem_write,
+	.clear = rv3028_retained_mem_clear,
+};
+
+#define RV3028_RETMEM_ASSERT_AREA_SIZE(inst)                                                       \
+	BUILD_ASSERT(DT_INST_REG_ADDR(inst) >= RV3028_REG_USER_RAM1 &&                             \
+			     DT_INST_REG_ADDR(inst) + DT_INST_REG_SIZE(inst) <=                    \
+				     RV3028_REG_USER_RAM1 + RV3028_USER_RAM_SIZE,                  \
+		     "Invalid RV3028 RAM area size");
+
+#define RV3028_RETMEM_DEFINE(inst)                                                                 \
+	RV3028_RETMEM_ASSERT_AREA_SIZE(inst)                                                       \
+                                                                                                   \
+	static const struct rv3028_retained_mem_config rv3028_retained_mem_config_##inst = {       \
+		.parent = DEVICE_DT_GET(DT_INST_BUS(inst)),                                        \
+		.addr = DT_INST_REG_ADDR(inst),                                                    \
+		.size = DT_INST_REG_SIZE(inst),                                                    \
+	};                                                                                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(inst, rv3028_retmem_init, NULL, NULL,                                \
+			      &rv3028_retained_mem_config_##inst, POST_KERNEL,                     \
+			      CONFIG_RETAINED_MEM_RV3028_INIT_PRIORITY, &rv3028_retmem_api);
+
+DT_INST_FOREACH_STATUS_OKAY(RV3028_RETMEM_DEFINE);

--- a/drivers/rtc/rtc_rv3028.c
+++ b/drivers/rtc/rtc_rv3028.c
@@ -6,52 +6,16 @@
 
 #define DT_DRV_COMPAT microcrystal_rv3028
 
-#include <zephyr/kernel.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/rtc.h>
-#include <zephyr/logging/log.h>
-#include <zephyr/sys/util.h>
+#include "rtc_rv3028.h"
 #include "rtc_utils.h"
 
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(rv3028, CONFIG_RTC_LOG_LEVEL);
 
-/* RV3028 RAM register addresses */
-#define RV3028_REG_SECONDS              0x00
-#define RV3028_REG_MINUTES              0x01
-#define RV3028_REG_HOURS                0x02
-#define RV3028_REG_WEEKDAY              0x03
-#define RV3028_REG_DATE                 0x04
-#define RV3028_REG_MONTH                0x05
-#define RV3028_REG_YEAR                 0x06
-#define RV3028_REG_ALARM_MINUTES        0x07
-#define RV3028_REG_ALARM_HOURS          0x08
-#define RV3028_REG_ALARM_WEEKDAY        0x09
-#define RV3028_REG_STATUS               0x0E
-#define RV3028_REG_CONTROL1             0x0F
-#define RV3028_REG_CONTROL2             0x10
-#define RV3028_REG_EVENT_CONTROL        0x13
-#define RV3028_REG_TS_COUNT             0x14
-#define RV3028_REG_TS_SECONDS           0x15
-#define RV3028_REG_TS_MINUTES           0x16
-#define RV3028_REG_TS_HOURS             0x17
-#define RV3028_REG_TS_DATE              0x18
-#define RV3028_REG_TS_MONTH             0x19
-#define RV3028_REG_TS_YEAR              0x1A
-#define RV3028_REG_UNIXTIME0            0x1B
-#define RV3028_REG_UNIXTIME1            0x1C
-#define RV3028_REG_UNIXTIME2            0x1D
-#define RV3028_REG_UNIXTIME3            0x1E
-#define RV3028_REG_USER_RAM1            0x1F
-#define RV3028_REG_USER_RAM2            0x20
-#define RV3028_REG_EEPROM_ADDRESS       0x25
-#define RV3028_REG_EEPROM_DATA          0x26
-#define RV3028_REG_EEPROM_COMMAND       0x27
-#define RV3028_REG_ID                   0x28
-#define RV3028_REG_CLKOUT               0x35
-#define RV3028_REG_OFFSET               0x36
-#define RV3028_REG_BACKUP               0x37
-
+/* RV3028 registers bit masks */
 #define RV3028_CONTROL1_TD              BIT(0)
 #define RV3028_CONTROL1_TE              GENMASK(2, 1)
 #define RV3028_CONTROL1_EERD            BIT(3)
@@ -67,15 +31,6 @@ LOG_MODULE_REGISTER(rv3028, CONFIG_RTC_LOG_LEVEL);
 #define RV3028_CONTROL2_UIE             BIT(5)
 #define RV3028_CONTROL2_TSE             BIT(7)
 
-#define RV3028_STATUS_PORF              BIT(0)
-#define RV3028_STATUS_EVF               BIT(1)
-#define RV3028_STATUS_AF                BIT(2)
-#define RV3028_STATUS_TF                BIT(3)
-#define RV3028_STATUS_UF                BIT(4)
-#define RV3028_STATUS_BSF               BIT(5)
-#define RV3028_STATUS_CLKF              BIT(6)
-#define RV3028_STATUS_EEBUSY            BIT(7)
-
 #define RV3028_CLKOUT_FD                GENMASK(2, 0)
 #define RV3028_CLKOUT_PORIE             BIT(3)
 #define RV3028_CLKOUT_CLKSY             BIT(6)
@@ -90,13 +45,6 @@ LOG_MODULE_REGISTER(rv3028, CONFIG_RTC_LOG_LEVEL);
 #define RV3028_BSM_LEVEL                0x3
 #define RV3028_BSM_DIRECT               0x1
 #define RV3028_BSM_DISABLED             0x0
-
-/* RV3028 EE command register values */
-#define RV3028_EEPROM_CMD_INIT          0x00
-#define RV3028_EEPROM_CMD_UPDATE        0x11
-#define RV3028_EEPROM_CMD_REFRESH       0x12
-#define RV3028_EEPROM_CMD_WRITE         0x21
-#define RV3028_EEPROM_CMD_READ          0x22
 
 #define RV3028_SECONDS_MASK             GENMASK(6, 0)
 #define RV3028_MINUTES_MASK             GENMASK(6, 0)
@@ -122,10 +70,6 @@ LOG_MODULE_REGISTER(rv3028, CONFIG_RTC_LOG_LEVEL);
 
 /* The RV3028 enumerates months 1 to 12 */
 #define RV3028_MONTH_OFFSET 1
-
-#define RV3028_EEBUSY_READ_POLL_MS      1
-#define RV3028_EEBUSY_WRITE_POLL_MS     10
-#define RV3028_EEBUSY_TIMEOUT_MS        100
 
 /* RTC alarm time fields supported by the RV3028 */
 #define RV3028_RTC_ALARM_TIME_MASK                                                                 \
@@ -170,21 +114,21 @@ struct rv3028_data {
 #endif /* RV3028_INT_GPIOS_IN_USE */
 };
 
-static void rv3028_lock_sem(const struct device *dev)
+void rv3028_lock_sem(const struct device *dev)
 {
 	struct rv3028_data *data = dev->data;
 
 	(void)k_sem_take(&data->lock, K_FOREVER);
 }
 
-static void rv3028_unlock_sem(const struct device *dev)
+void rv3028_unlock_sem(const struct device *dev)
 {
 	struct rv3028_data *data = dev->data;
 
 	k_sem_give(&data->lock);
 }
 
-static int rv3028_read_regs(const struct device *dev, uint8_t addr, void *buf, size_t len)
+int rv3028_read_regs(const struct device *dev, uint8_t addr, void *buf, size_t len)
 {
 	const struct rv3028_config *config = dev->config;
 	int err;
@@ -198,12 +142,12 @@ static int rv3028_read_regs(const struct device *dev, uint8_t addr, void *buf, s
 	return 0;
 }
 
-static int rv3028_read_reg8(const struct device *dev, uint8_t addr, uint8_t *val)
+int rv3028_read_reg8(const struct device *dev, uint8_t addr, uint8_t *val)
 {
 	return rv3028_read_regs(dev, addr, val, sizeof(*val));
 }
 
-static int rv3028_write_regs(const struct device *dev, uint8_t addr, void *buf, size_t len)
+int rv3028_write_regs(const struct device *dev, uint8_t addr, const void *buf, size_t len)
 {
 	const struct rv3028_config *config = dev->config;
 	uint8_t block[sizeof(addr) + len];
@@ -221,12 +165,12 @@ static int rv3028_write_regs(const struct device *dev, uint8_t addr, void *buf, 
 	return 0;
 }
 
-static int rv3028_write_reg8(const struct device *dev, uint8_t addr, uint8_t val)
+int rv3028_write_reg8(const struct device *dev, uint8_t addr, uint8_t val)
 {
 	return rv3028_write_regs(dev, addr, &val, sizeof(val));
 }
 
-static int rv3028_update_reg8(const struct device *dev, uint8_t addr, uint8_t mask, uint8_t val)
+int rv3028_update_reg8(const struct device *dev, uint8_t addr, uint8_t mask, uint8_t val)
 {
 	const struct rv3028_config *config = dev->config;
 	int err;
@@ -241,7 +185,7 @@ static int rv3028_update_reg8(const struct device *dev, uint8_t addr, uint8_t ma
 	return 0;
 }
 
-static int rv3028_eeprom_wait_busy(const struct device *dev, int poll_ms)
+int rv3028_eeprom_wait_busy(const struct device *dev, int poll_ms)
 {
 	uint8_t status = 0;
 	int err;
@@ -268,12 +212,12 @@ static int rv3028_eeprom_wait_busy(const struct device *dev, int poll_ms)
 	return 0;
 }
 
-static int rv3028_exit_eerd(const struct device *dev)
+int rv3028_exit_eerd(const struct device *dev)
 {
 	return rv3028_update_reg8(dev, RV3028_REG_CONTROL1, RV3028_CONTROL1_EERD, 0);
 }
 
-static int rv3028_enter_eerd(const struct device *dev)
+int rv3028_enter_eerd(const struct device *dev)
 {
 	uint8_t ctrl1;
 	bool eerd;
@@ -301,7 +245,7 @@ static int rv3028_enter_eerd(const struct device *dev)
 	return ret;
 }
 
-static int rv3028_eeprom_command(const struct device *dev, uint8_t command)
+int rv3028_eeprom_command(const struct device *dev, uint8_t command)
 {
 	int err;
 
@@ -483,7 +427,7 @@ static int rv3028_set_time(const struct device *dev, const struct rtc_time *time
 	date[5] = bin2bcd(timeptr->tm_mon + RV3028_MONTH_OFFSET) & RV3028_MONTH_MASK;
 	date[6] = bin2bcd(timeptr->tm_year - RV3028_YEAR_OFFSET) & RV3028_YEAR_MASK;
 
-	err = rv3028_write_regs(dev, RV3028_REG_SECONDS, &date, sizeof(date));
+	err = rv3028_write_regs(dev, RV3028_REG_SECONDS, date, sizeof(date));
 	if (err) {
 		goto unlock;
 	}
@@ -599,7 +543,7 @@ static int rv3028_alarm_set_time(const struct device *dev, uint16_t id, uint16_t
 		timeptr->tm_mday, timeptr->tm_hour, timeptr->tm_min, mask);
 
 	/* Write registers RV3028_REG_ALARM_MINUTES through RV3028_REG_ALARM_WEEKDAY */
-	return rv3028_write_regs(dev, RV3028_REG_ALARM_MINUTES, &regs, sizeof(regs));
+	return rv3028_write_regs(dev, RV3028_REG_ALARM_MINUTES, regs, sizeof(regs));
 }
 
 static int rv3028_alarm_get_time(const struct device *dev, uint16_t id, uint16_t *mask,
@@ -909,7 +853,7 @@ static const struct rtc_driver_api rv3028_driver_api = {
 	 (FIELD_PREP(RV3028_BACKUP_TCR, DT_INST_ENUM_IDX_OR(inst, trickle_resistor_ohms, 0))) |    \
 	 (DT_INST_NODE_HAS_PROP(inst, trickle_resistor_ohms) ? RV3028_BACKUP_TCE : 0))
 
-#define RV3028_INIT(inst)                                                                          \
+#define RV3028_DEFINE(inst)                                                                        \
 	static const struct rv3028_config rv3028_config_##inst = {                                 \
 		.i2c = I2C_DT_SPEC_INST_GET(inst),                                                 \
 		.cof = DT_INST_ENUM_IDX_OR(inst, clkout_frequency, RV3028_CLKOUT_FD_LOW),          \
@@ -923,4 +867,4 @@ static const struct rtc_driver_api rv3028_driver_api = {
 			      &rv3028_config_##inst, POST_KERNEL, CONFIG_RTC_INIT_PRIORITY,        \
 			      &rv3028_driver_api);
 
-DT_INST_FOREACH_STATUS_OKAY(RV3028_INIT)
+DT_INST_FOREACH_STATUS_OKAY(RV3028_DEFINE)

--- a/drivers/rtc/rtc_rv3028.h
+++ b/drivers/rtc/rtc_rv3028.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2024 ANITRA system s.r.o.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_RTC_RTC_RV3028_RTC_RV3028_H_
+#define ZEPHYR_DRIVERS_RTC_RTC_RV3028_RTC_RV3028_H_
+
+#include <zephyr/device.h>
+#include <sys/types.h>
+
+void rv3028_lock_sem(const struct device *dev);
+
+void rv3028_unlock_sem(const struct device *dev);
+
+int rv3028_read_regs(const struct device *dev, uint8_t addr, void *buf, size_t len);
+
+int rv3028_read_reg8(const struct device *dev, uint8_t addr, uint8_t *val);
+
+int rv3028_write_regs(const struct device *dev, uint8_t addr, const void *buf, size_t len);
+
+int rv3028_write_reg8(const struct device *dev, uint8_t addr, uint8_t val);
+
+int rv3028_update_reg8(const struct device *dev, uint8_t addr, uint8_t mask, uint8_t val);
+
+int rv3028_eeprom_wait_busy(const struct device *dev, int poll_ms);
+
+int rv3028_exit_eerd(const struct device *dev);
+
+int rv3028_enter_eerd(const struct device *dev);
+
+int rv3028_eeprom_command(const struct device *dev, uint8_t command);
+
+/* RV3028 RAM register addresses */
+#define RV3028_REG_SECONDS              0x00
+#define RV3028_REG_MINUTES              0x01
+#define RV3028_REG_HOURS                0x02
+#define RV3028_REG_WEEKDAY              0x03
+#define RV3028_REG_DATE                 0x04
+#define RV3028_REG_MONTH                0x05
+#define RV3028_REG_YEAR                 0x06
+#define RV3028_REG_ALARM_MINUTES        0x07
+#define RV3028_REG_ALARM_HOURS          0x08
+#define RV3028_REG_ALARM_WEEKDAY        0x09
+#define RV3028_REG_STATUS               0x0E
+#define RV3028_REG_CONTROL1             0x0F
+#define RV3028_REG_CONTROL2             0x10
+#define RV3028_REG_EVENT_CONTROL        0x13
+#define RV3028_REG_TS_COUNT             0x14
+#define RV3028_REG_TS_SECONDS           0x15
+#define RV3028_REG_TS_MINUTES           0x16
+#define RV3028_REG_TS_HOURS             0x17
+#define RV3028_REG_TS_DATE              0x18
+#define RV3028_REG_TS_MONTH             0x19
+#define RV3028_REG_TS_YEAR              0x1A
+#define RV3028_REG_UNIXTIME0            0x1B
+#define RV3028_REG_UNIXTIME1            0x1C
+#define RV3028_REG_UNIXTIME2            0x1D
+#define RV3028_REG_UNIXTIME3            0x1E
+#define RV3028_REG_USER_RAM1            0x1F
+#define RV3028_REG_USER_RAM2            0x20
+#define RV3028_REG_EEPROM_ADDRESS       0x25
+#define RV3028_REG_EEPROM_DATA          0x26
+#define RV3028_REG_EEPROM_COMMAND       0x27
+#define RV3028_REG_ID                   0x28
+#define RV3028_REG_CLKOUT               0x35
+#define RV3028_REG_OFFSET               0x36
+#define RV3028_REG_BACKUP               0x37
+
+/* RV3028 EE command register values */
+#define RV3028_EEPROM_CMD_INIT          0x00
+#define RV3028_EEPROM_CMD_UPDATE        0x11
+#define RV3028_EEPROM_CMD_REFRESH       0x12
+#define RV3028_EEPROM_CMD_WRITE         0x21
+#define RV3028_EEPROM_CMD_READ          0x22
+
+#define RV3028_EEBUSY_READ_POLL_MS      1
+#define RV3028_EEBUSY_WRITE_POLL_MS     10
+#define RV3028_EEBUSY_TIMEOUT_MS        100
+
+/* RV3028 Status register bit masks */
+#define RV3028_STATUS_PORF              BIT(0)
+#define RV3028_STATUS_EVF               BIT(1)
+#define RV3028_STATUS_AF                BIT(2)
+#define RV3028_STATUS_TF                BIT(3)
+#define RV3028_STATUS_UF                BIT(4)
+#define RV3028_STATUS_BSF               BIT(5)
+#define RV3028_STATUS_CLKF              BIT(6)
+#define RV3028_STATUS_EEBUSY            BIT(7)
+
+#endif /* ZEPHYR_DRIVERS_RTC_RTC_RV3028_RTC_RV3028_H_ */

--- a/dts/bindings/mtd/microcrystal,rv3028-eeprom.yaml
+++ b/dts/bindings/mtd/microcrystal,rv3028-eeprom.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) 2024 ANITRA system s.r.o.
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Micro Crystal RV3028 RTC User EEPROM
+
+  There are 43 bytes of non-volatile user EEPROM at addresses 0x00 to 0x2a for general use.
+
+  Example configuration:
+    rtc: rv3028@52 {
+      compatible = "microcrystal,rv3028";
+      status = "okay";
+      reg = <0x52>;
+      backup-switch-mode = "disabled";
+
+      #address-cells = <1>;
+      #size-cells = <1>;
+
+      rtc_eeprom: rv3028-eeprom@0 {
+        compatible: "microcrystal,rv3028-eeprom";
+        reg = <0x0 0x2b>;
+        status = "okay";
+      };
+    };
+
+compatible: "microcrystal,rv3028-eeprom"
+
+include: base.yaml
+
+on-bus: microcrystal,rv3028
+
+properties:
+  reg:
+    required: true
+    description: EEPROM base address and size in bytes

--- a/dts/bindings/retained_mem/microcrystal,rv3028-retmem.yaml
+++ b/dts/bindings/retained_mem/microcrystal,rv3028-retmem.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) 2024 ANITRA system s.r.o.
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Micro Crystal RV3028 RTC User RAM
+
+  There are two free RAM bytes for general use at addresses 0x1f and 0x20.
+
+  Example configuration:
+    rtc: rv3028@52 {
+      compatible = "microcrystal,rv3028";
+      status = "okay";
+      reg = <0x52>;
+      backup-switch-mode = "disabled";
+
+      #address-cells = <1>;
+      #size-cells = <1>;
+
+      rtc_retmem: rv3028-retmem@1f {
+        compatible: "microcrystal,rv3028-retmem";
+        reg = <0x1f 0x2>;
+        status = "okay";
+      };
+    };
+
+compatible: "microcrystal,rv3028-retmem"
+
+include: base.yaml
+
+on-bus: microcrystal,rv3028
+
+properties:
+  reg:
+    required: true
+    description: RAM base address and size in bytes

--- a/dts/bindings/rtc/microcrystal,rv3028.yaml
+++ b/dts/bindings/rtc/microcrystal,rv3028.yaml
@@ -5,6 +5,8 @@ description: Micro Crystal RV3028 RTC
 
 compatible: "microcrystal,rv3028"
 
+bus: microcrystal,rv3028
+
 include:
   - name: rtc-device.yaml
   - name: i2c-device.yaml
@@ -52,3 +54,9 @@ properties:
     type: phandle-array
     description: |
       GPIO connected to the RV3028 INT interrupt output. This signal is open-drain, active low.
+
+  "#address-cells":
+    const: 1
+
+  "#size-cells":
+    const: 1


### PR DESCRIPTION
This PR aims to add support for user memory access in the Micro Crystal RV3028 RTC. The device has two free RAM bytes, which are exposed as a `microcrystal,rv3028-retmem` child node, and 43 bytes of general-purpose EEPROM, accessible via `microcrystal,rv3028-eeprom` child nodes.

@bjarki-trackunit, can I ask you for feedback? :) I didn't find any driver in the tree that implements the `retained_mem` API through its children, so I am unsure if I took the right approach. ~~I am also concerned that implementing a memory clearing interface for EEPROM could shorten its lifespan.~~