### PR TITLE
rtio: Remove builtin iodev mpsc queue

### DIFF
--- a/drivers/i2c/i2c_rtio.c
+++ b/drivers/i2c/i2c_rtio.c
@@ -61,8 +61,6 @@ void i2c_rtio_init(struct i2c_rtio *ctx, const struct device *dev)
 	ctx->dt_spec.bus = dev;
 	ctx->iodev.data = &ctx->dt_spec;
 	ctx->iodev.api = &i2c_iodev_api;
-	/* TODO drop the builtin submission queue? */
-	mpsc_init(&ctx->iodev.iodev_sq);
 }
 
 /**

--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -75,6 +75,7 @@ struct spi_mcux_data {
 
 #ifdef CONFIG_SPI_RTIO
 	struct rtio *r;
+	struct mpsc io_q;
 	struct rtio_iodev iodev;
 	struct rtio_iodev_sqe *txn_head;
 	struct rtio_iodev_sqe *txn_curr;
@@ -702,7 +703,7 @@ static int spi_mcux_init(const struct device *dev)
 	data->dt_spec.bus = dev;
 	data->iodev.api = &spi_iodev_api;
 	data->iodev.data = &data->dt_spec;
-	mpsc_init(&data->iodev.iodev_sq);
+	mpsc_init(&data->io_q);
 #endif
 
 	err = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
@@ -803,7 +804,7 @@ static void spi_mcux_iodev_next(const struct device *dev, bool completion)
 		return;
 	}
 
-	struct mpsc_node *next = mpsc_pop(&data->iodev.iodev_sq);
+	struct mpsc_node *next = mpsc_pop(&data->io_q);
 
 	if (next != NULL) {
 		struct rtio_iodev_sqe *next_sqe = CONTAINER_OF(next, struct rtio_iodev_sqe, q);
@@ -832,7 +833,7 @@ static void spi_mcux_iodev_submit(const struct device *dev,
 {
 	struct spi_mcux_data *data = dev->data;
 
-	mpsc_push(&data->iodev.iodev_sq, &iodev_sqe->q);
+	mpsc_push(&data->io_q, &iodev_sqe->q);
 	spi_mcux_iodev_next(dev, false);
 }
 

--- a/drivers/spi/spi_sam.c
+++ b/drivers/spi/spi_sam.c
@@ -53,6 +53,7 @@ struct spi_sam_data {
 
 #ifdef CONFIG_SPI_RTIO
 	struct rtio *r; /* context for thread calls */
+	struct mpsc io_q;
 	struct rtio_iodev iodev;
 	struct rtio_iodev_sqe *txn_head;
 	struct rtio_iodev_sqe *txn_curr;
@@ -691,7 +692,7 @@ static void spi_sam_iodev_next(const struct device *dev, bool completion)
 		return;
 	}
 
-	struct mpsc_node *next = mpsc_pop(&data->iodev.iodev_sq);
+	struct mpsc_node *next = mpsc_pop(&data->io_q);
 
 	if (next != NULL) {
 		struct rtio_iodev_sqe *next_sqe = CONTAINER_OF(next, struct rtio_iodev_sqe, q);
@@ -736,7 +737,7 @@ static void spi_sam_iodev_submit(const struct device *dev,
 {
 	struct spi_sam_data *data = dev->data;
 
-	mpsc_push(&data->iodev.iodev_sq, &iodev_sqe->q);
+	mpsc_push(&data->io_q, &iodev_sqe->q);
 	spi_sam_iodev_next(dev, false);
 }
 #endif
@@ -866,7 +867,7 @@ static int spi_sam_init(const struct device *dev)
 	data->dt_spec.bus = dev;
 	data->iodev.api = &spi_iodev_api;
 	data->iodev.data = &data->dt_spec;
-	mpsc_init(&data->iodev.iodev_sq);
+	mpsc_init(&data->io_q);
 #endif
 
 	spi_context_unlock_unconditionally(&data->ctx);

--- a/samples/subsys/rtio/sensor_batch_processing/src/vnd_sensor.c
+++ b/samples/subsys/rtio/sensor_batch_processing/src/vnd_sensor.c
@@ -20,6 +20,7 @@ struct vnd_sensor_config {
 
 struct vnd_sensor_data {
 	struct rtio_iodev iodev;
+	struct mpsc io_q;
 	struct k_timer timer;
 	const struct device *dev;
 	uint32_t sample_number;
@@ -83,13 +84,13 @@ static void vnd_sensor_iodev_submit(struct rtio_iodev_sqe *iodev_sqe)
 {
 	struct vnd_sensor_data *data = (struct vnd_sensor_data *) iodev_sqe->sqe.iodev;
 
-	mpsc_push(&data->iodev.iodev_sq, &iodev_sqe->q);
+	mpsc_push(&data->io_q, &iodev_sqe->q);
 }
 
 static void vnd_sensor_handle_int(const struct device *dev)
 {
 	struct vnd_sensor_data *data = dev->data;
-	struct mpsc_node *node = mpsc_pop(&data->iodev.iodev_sq);
+	struct mpsc_node *node = mpsc_pop(&data->io_q);
 
 	if (node != NULL) {
 		struct rtio_iodev_sqe *iodev_sqe = CONTAINER_OF(node, struct rtio_iodev_sqe, q);
@@ -116,7 +117,7 @@ static int vnd_sensor_init(const struct device *dev)
 
 	data->dev = dev;
 
-	mpsc_init(&data->iodev.iodev_sq);
+	mpsc_init(&data->io_q);
 
 	k_timer_init(&data->timer, vnd_sensor_timer_expiry, NULL);
 


### PR DESCRIPTION
I/O Devices were meant to be handles of sorts and had a built
in mpsc queue as this made sense initially. As time has gone on it
turned out that often we wanted the mpsc queue to be an implementation
detail hidden in a driver. In fact pretty much all drivers work this way now.

Keeping the struct mpsc queue as a member of rtio_iodev meant wasted
memory in cases where it wasn't used. It also meant a bit of confusion
as the queue might be accidently used in places where it shouldn't be.

Remove the mpsc queue member from struct rtio_iodev and the last
remaining usages of it. Will ensure RTIO for 3.7 LTS avoids causing
unneeded churn for future users.