### PR TITLE
arch: arm: cortex_m: Move bss/noinit sections to the end of linker script

### DIFF
--- a/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
@@ -353,56 +353,6 @@ SECTIONS
 
     __data_region_end = .;
 
-#ifndef CONFIG_USERSPACE
-   SECTION_DATA_PROLOGUE(_BSS_SECTION_NAME,(NOLOAD),)
-	{
-        /*
-         * For performance, BSS section is assumed to be 4 byte aligned and
-         * a multiple of 4 bytes
-         */
-        . = ALIGN(4);
-	__bss_start = .;
-	__kernel_ram_start = .;
-
-	*(.bss)
-	*(".bss.*")
-	*(COMMON)
-	*(".kernel_bss.*")
-
-#ifdef CONFIG_CODE_DATA_RELOCATION
-#include <linker_sram_bss_relocate.ld>
-#endif
-
-        /*
-         * As memory is cleared in words only, it is simpler to ensure the BSS
-         * section ends on a 4 byte boundary. This wastes a maximum of 3 bytes.
-		 */
-	__bss_end = ALIGN(4);
-	} GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
-
-    SECTION_PROLOGUE(_NOINIT_SECTION_NAME,(NOLOAD),)
-        {
-        /*
-         * This section is used for non-initialized objects that
-         * will not be cleared during the boot process.
-         */
-        *(.noinit)
-        *(".noinit.*")
-	*(".kernel_noinit.*")
-
-/* Located in generated directory. This file is populated by the
- * zephyr_linker_sources() Cmake function.
- */
-#include <snippets-noinit.ld>
-
-        } GROUP_NOLOAD_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
-#endif /* CONFIG_USERSPACE */
-
-    /* Define linker symbols */
-
-    __kernel_ram_end = RAM_ADDR + RAM_SIZE;
-    __kernel_ram_size = __kernel_ram_end - __kernel_ram_start;
-
 #if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_itcm), okay)
 GROUP_START(ITCM)
 
@@ -470,10 +420,6 @@ GROUP_END(DTCM)
  */
 #include <snippets-sections.ld>
 
-#include <zephyr/linker/ram-end.ld>
-
-    GROUP_END(RAMABLE_REGION)
-
 #include <zephyr/linker/debug-sections.ld>
 
     /DISCARD/ : { *(.note.GNU-stack) }
@@ -509,5 +455,59 @@ SECTION_PROLOGUE(.last_section,,)
 /* To provide the image size as a const expression,
  * calculate this value here. */
 _flash_used = LOADADDR(.last_section) + SIZEOF(.last_section) - __rom_region_start;
+
+#ifndef CONFIG_USERSPACE
+   SECTION_DATA_PROLOGUE(_BSS_SECTION_NAME,(NOLOAD),)
+	{
+        /*
+         * For performance, BSS section is assumed to be 4 byte aligned and
+         * a multiple of 4 bytes
+         */
+        . = ALIGN(4);
+	__bss_start = .;
+	__kernel_ram_start = .;
+
+	*(.bss)
+	*(".bss.*")
+	*(COMMON)
+	*(".kernel_bss.*")
+
+#ifdef CONFIG_CODE_DATA_RELOCATION
+#include <linker_sram_bss_relocate.ld>
+#endif
+
+        /*
+         * As memory is cleared in words only, it is simpler to ensure the BSS
+         * section ends on a 4 byte boundary. This wastes a maximum of 3 bytes.
+		 */
+	__bss_end = ALIGN(4);
+	} GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
+
+    SECTION_PROLOGUE(_NOINIT_SECTION_NAME,(NOLOAD),)
+        {
+        /*
+         * This section is used for non-initialized objects that
+         * will not be cleared during the boot process.
+         */
+        *(.noinit)
+        *(".noinit.*")
+	*(".kernel_noinit.*")
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-noinit.ld>
+
+        } GROUP_NOLOAD_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
+#endif /* CONFIG_USERSPACE */
+
+    /* Define linker symbols */
+
+    __kernel_ram_end = RAM_ADDR + RAM_SIZE;
+    __kernel_ram_size = __kernel_ram_end - __kernel_ram_start;
+
+#include <zephyr/linker/ram-end.ld>
+
+    GROUP_END(RAMABLE_REGION)
 
     }


### PR DESCRIPTION
This results in a smaller binary with `CONFIG_XIP=n` as these NOLOAD sections can be excluded

bss/noinit have been included in `CONFIG_XIP=n` binaries by default since c107827bb7456d7ead8af0b1febe932e1b2c4423. This also occurs if using iterable sections or adding code/data to ITCM/DTCM sections. Moving bss/noinit to the end of the linker file should ensure they are always excluded

Partial fix for #72307