### PR TITLE
toolchain: llvm: Fixes for CONFIG_MINIMAL_LIBC

### DIFF
--- a/include/zephyr/toolchain/llvm.h
+++ b/include/zephyr/toolchain/llvm.h
@@ -35,11 +35,12 @@
  * Avoid collision with defines from include/zephyr/toolchain/zephyr_stdint.h
  */
 #ifdef CONFIG_MINIMAL_LIBC
-#ifndef CONFIG_ENFORCE_ZEPHYR_STDINT
 
 #define __int_c(v, suffix) v ## suffix
 #define int_c(v, suffix) __int_c(v, suffix)
 #define uint_c(v, suffix) __int_c(v ## U, suffix)
+
+#ifndef CONFIG_ENFORCE_ZEPHYR_STDINT
 
 #ifdef __INT64_TYPE__
 #undef __int_least64_c_suffix__

--- a/include/zephyr/toolchain/llvm.h
+++ b/include/zephyr/toolchain/llvm.h
@@ -86,6 +86,8 @@
 #endif /* __int_least32_c_suffix__ */
 #endif /* __INT_LEAST32_TYPE__ */
 
+#endif /* !CONFIG_ENFORCE_ZEPHYR_STDINT */
+
 #ifdef __INT16_TYPE__
 #undef __int_least16_c_suffix__
 #undef __int_least8_c_suffix__
@@ -121,8 +123,6 @@
 #define __UINT8_C(x)	x ## U
 #endif /* __int_least8_c_suffix__ */
 #endif /* __INT_LEAST8_TYPE__ */
-
-#endif /* !CONFIG_ENFORCE_ZEPHYR_STDINT */
 
 #define __INTMAX_C(x)	int_c(x, __INTMAX_C_SUFFIX__)
 #define __UINTMAX_C(x)	int_c(x, __UINTMAX_C_SUFFIX__)


### PR DESCRIPTION
Fix problems like:
```
zephyrproject/zephyr/tests/lib/c_lib/common/src/main.c:153:6: error: function-like macro 'int_c' is not defined
        && (UINTMAX_C(11) == 11)        \
            ^
zephyrproject/zephyr/lib/libc/minimal/include/stdint.h:122:23: note: expanded from macro 'UINTMAX_C'
#define UINTMAX_C(_v) __UINTMAX_C(_v)
                      ^
zephyrproject/zephyr/include/zephyr/toolchain/llvm.h:127:24: note: expanded from macro '__UINTMAX_C'
#define __UINTMAX_C(x)  int_c(x, __UINTMAX_C_SUFFIX__)
```