### PR TITLE
drivers: udc_dwc2: Fix control OUT buffer leak

### DIFF
--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -1339,6 +1339,15 @@ static int udc_dwc2_ep_deactivate(const struct device *dev,
 	sys_write32(dxepctl, dxepctl_reg);
 	dwc2_set_epint(dev, cfg, false);
 
+	if (cfg->addr == USB_CONTROL_EP_OUT) {
+		struct net_buf *buf = udc_buf_get_all(dev, cfg->addr);
+
+		/* Release the buffer allocated in dwc2_ctrl_feed_dout() */
+		if (buf) {
+			net_buf_unref(buf);
+		}
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
Release buffer allocated in dwc2_ctrl_feed_dout() on endpoint deactivate to prevent the buffer from leaking on USB stack disable.