### PR TITLE
cmake: use SOC_ROOT for SoCs instead of BOARD_ROOT

### DIFF
--- a/cmake/modules/kconfig.cmake
+++ b/cmake/modules/kconfig.cmake
@@ -26,7 +26,7 @@ file(MAKE_DIRECTORY ${KCONFIG_BINARY_DIR})
 if(HWMv1)
   # Support multiple SOC_ROOT
   file(MAKE_DIRECTORY ${KCONFIG_BINARY_DIR}/soc)
-  set(kconfig_soc_root ${BOARD_ROOT})
+  set(kconfig_soc_root ${SOC_ROOT})
   list(REMOVE_ITEM kconfig_soc_root ${ZEPHYR_BASE})
   set(soc_defconfig_file ${KCONFIG_BINARY_DIR}/soc/Kconfig.defconfig)
 


### PR DESCRIPTION
kconfig_soc_root was mistakenly set to value of BOARD_ROOT. Fix this by correctly set kconfig_soc_root to the value of SOC_ROOT.