### PR TITLE
Bluetooth: audio: BAP broadcast assistant code synchronisation

### DIFF
--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_assistant_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_assistant_test.c
@@ -82,7 +82,7 @@ static void bap_broadcast_assistant_scan_cb(const struct bt_le_scan_recv_info *i
 
 static bool metadata_entry(struct bt_data *data, void *user_data)
 {
-	char metadata[512];
+	char metadata[CONFIG_BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE];
 
 	(void)bin2hex(data->data, data->data_len, metadata, sizeof(metadata));
 
@@ -97,7 +97,7 @@ static void bap_broadcast_assistant_recv_state_cb(
 	const struct bt_bap_scan_delegator_recv_state *state)
 {
 	char le_addr[BT_ADDR_LE_STR_LEN];
-	char bad_code[33];
+	char bad_code[BT_AUDIO_BROADCAST_CODE_SIZE * 2 + 1];
 
 	if (err != 0) {
 		FAIL("BASS recv state read failed (%d)\n", err);
@@ -120,7 +120,12 @@ static void bap_broadcast_assistant_recv_state_cb(
 	       state->encrypt_state == BT_BAP_BIG_ENC_STATE_BAD_CODE ? ", bad code" : "",
 	       bad_code);
 
-	for (int i = 0; i < state->num_subgroups; i++) {
+	if (state->encrypt_state == BT_BAP_BIG_ENC_STATE_BAD_CODE) {
+		FAIL("Encryption state is BT_BAP_BIG_ENC_STATE_BAD_CODE");
+		return;
+	}
+
+	for (uint8_t i = 0; i < state->num_subgroups; i++) {
 		const struct bt_bap_bass_subgroup *subgroup = &state->subgroups[i];
 		struct net_buf_simple buf;
 
@@ -136,6 +141,7 @@ static void bap_broadcast_assistant_recv_state_cb(
 		}
 	}
 
+#if defined(CONFIG_BT_PER_ADV_SYNC_TRANSFER_SENDER)
 	if (state->pa_sync_state == BT_BAP_PA_STATE_INFO_REQ) {
 		err = bt_le_per_adv_sync_transfer(g_pa_sync, conn,
 						  BT_UUID_BASS_VAL);
@@ -144,6 +150,7 @@ static void bap_broadcast_assistant_recv_state_cb(
 			return;
 		}
 	}
+#endif /* CONFIG_BT_PER_ADV_SYNC_TRANSFER_SENDER */
 
 	if (state->pa_sync_state == BT_BAP_PA_STATE_SYNCED) {
 		SET_FLAG(flag_state_synced);


### PR DESCRIPTION
There is (almost) identical code in the CAP broadcast reception start babblesim test and the BAP broadcast assistant test. This PR makes the code in both tests identical