### PR TITLE
MAINTAINERS: Add jthm-ot to Bluetooth Audio

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -438,6 +438,7 @@ Bluetooth Audio:
     - larsgk
     - pin-zephyr
     - niym-ot
+    - jthm-ot
   files:
     - subsys/bluetooth/audio/
     - include/zephyr/bluetooth/audio/


### PR DESCRIPTION
Jens has contributed the following PRs

https://github.com/zephyrproject-rtos/zephyr/pull/68678
https://github.com/zephyrproject-rtos/zephyr/pull/72409
https://github.com/zephyrproject-rtos/zephyr/pull/72915
https://github.com/zephyrproject-rtos/zephyr/pull/73564
https://github.com/zephyrproject-rtos/zephyr/pull/73656

and is attending the weekly LE Audio Zephyr meetings.