### PR TITLE
manifest: Update hal_nordic with nrfx_grtc fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -188,7 +188,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: ab5cb2e2faeb1edfad7a25286dcb513929ae55da
+      revision: 6459c0255fe133f77597ac4b248a3d83c8abe2eb
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
This update fixes the `nrfx_grtc_syscounter_cc_int_enable()` function. Removed clearing and enabling event for the corresponding CC channel inside.