### PR TITLE
samples: drivers: flash_shell does not run on stm32h745/m4 boards

### DIFF
--- a/samples/drivers/flash_shell/sample.yaml
+++ b/samples/drivers/flash_shell/sample.yaml
@@ -9,6 +9,8 @@ tests:
     filter: CONFIG_FLASH_HAS_DRIVER_ENABLED
     platform_exclude:
       - nucleo_h745zi_q/stm32h745xx/m4
+      - stm32h7s78_dk
+      - stm32h745i_disco/stm32h745xx/m4
       - stm32h747i_disco/stm32h747xx/m4
       - gd32f350r_eval
       - arduino_portenta_h7/stm32h747xx/m4


### PR DESCRIPTION
Do not run the samples/drivers/flash_shell application on the stm32h745i_disco//m4 as the flsh controller is not supported yet on the M4 core (only M7).
Just like the nucleo stm32h745//m4 is excluded

Fix the build error on west build -p auto -b stm32h745i_disco//m4 samples/drivers/flash_shell
```
./drivers/flash/flash_stm32h7x.c:35:2: error: #error Flash driver on M4 core is not supported yet
   35 | #error Flash driver on M4 core is not supported yet
```

