### PR TITLE
boards: arm64: Set CPU compatible for Renesas Spider S4 A55 board

### DIFF
--- a/dts/arm64/renesas/r8a779f0.dtsi
+++ b/dts/arm64/renesas/r8a779f0.dtsi
@@ -21,7 +21,7 @@
 		#size-cells = <0>;
 
 		a55: cpu@0 {
-			compatible = "arm,armv8";
+			compatible = "arm,cortex-a55", "arm,armv8";
 			reg = <0>;
 			device_type = "cpu";
 			enable-method = "psci";


### PR DESCRIPTION
Add a more precise Cortex-A55 compat on top of the generic armv8 one.