### PR TITLE
dts: nxp: Fix sramx offset for LPC51U68

### DIFF
--- a/dts/arm/nxp/nxp_lpc51u68.dtsi
+++ b/dts/arm/nxp/nxp_lpc51u68.dtsi
@@ -40,7 +40,7 @@
 
 		sramx:memory@4000000 {
 			compatible = "mmio-sram";
-			reg = <0x40000000 DT_SIZE_K(32)>;
+			reg = <0x04000000 DT_SIZE_K(32)>;
 		};
 
 		flash0: flash@0 {


### PR DESCRIPTION
The current value is wrong and overlaps with `syscon`.