### PR TITLE
ztests: Use string comparison methods

### DIFF
--- a/scripts/coccinelle/macros.h
+++ b/scripts/coccinelle/macros.h
@@ -14,6 +14,8 @@
 
 /* Zephyr macros */
 
+#define ZTEST(suite, fn) static void _##suite##_##fn##_wrapper(void)
+
 /* Attributes */
 
 /* Confirmed problematic */

--- a/scripts/coccinelle/ztest_strcmp.cocci
+++ b/scripts/coccinelle/ztest_strcmp.cocci
@@ -1,0 +1,79 @@
+/// Find cases where ztest string comparisons macros can be used
+// Copyright: (C) 2024 Nordic Semiconductor ASA
+// SPDX-License-Identifier: Apache-2.0
+// Confidence: LOW
+// Options: --no-includes --include-headers
+
+virtual patch
+virtual context
+virtual org
+virtual report
+
+// Comparing result of strcmp with 0
+
+@@ expression E1,E2; @@
+- zassert_equal(strcmp(E1, E2), 0);
++ zassert_str_equal(E1, E2);
+
+@@ expression E1,E2,E3; @@
+- zassert_equal(strcmp(E1, E2), 0, E3);
++ zassert_str_equal(E1, E2, E3);
+
+@@ expression E1,E2; @@
+- zassert_equal(0, strcmp(E1, E2));
++ zassert_str_equal(E1, E2);
+
+@@ expression E1,E2,E3; @@
+- zassert_equal(0, !strcmp(E1, E2), E3);
++ zassert_str_equal(E1, E2, E3);
+
+
+
+// Using assert_true with !strcmp
+
+@@ expression E1,E2; @@
+- zassert_true(!strcmp(E1, E2));
++ zassert_str_equal(E1, E2);
+
+@@ expression E1,E2,E3; @@
+- zassert_true(!strcmp(E1, E2), E3);
++ zassert_str_equal(E1, E2, E3);
+
+
+// using zassert_true with strcmp(E1, E2) == 0
+
+@@expression E1,E2; @@
+- zassert_true(strcmp(E1, E2) == 0);
++ zassert_str_equal(E1, E2);
+
+@@expression E1,E2; @@
+- zassert_true((strcmp(E1, E2) == 0));
++ zassert_str_equal(E1, E2);
+
+@@expression E1,E2,E3; @@
+- zassert_true(strcmp(E1, E2) == 0, E3);
++ zassert_str_equal(E1, E2, E3);
+
+@@expression E1,E2,E3; @@
+- zassert_true((strcmp(E1, E2) == 0), E3);
++ zassert_str_equal(E1, E2, E3);
+
+
+
+// using zassert_true with 0 == strcmp(E1, E2)
+
+@@expression E1,E2; @@
+- zassert_true(0 == strcmp(E1, E2));
++ zassert_str_equal(E1, E2);
+
+@@expression E1,E2; @@
+- zassert_true((0 == strcmp(E1, E2)));
++ zassert_str_equal(E1, E2);
+
+@@expression E1,E2,E3; @@
+- zassert_true(0 == strcmp(E1, E2), E3);
++ zassert_str_equal(E1, E2, E3);
+
+@@expression E1,E2,E3; @@
+- zassert_true((0 == strcmp(E1, E2)), E3);
++ zassert_str_equal(E1, E2, E3);

--- a/tests/drivers/sensor/generic/src/dummy_sensor.c
+++ b/tests/drivers/sensor/generic/src/dummy_sensor.c
@@ -80,7 +80,7 @@ static int dummy_sensor_init(const struct device *dev)
 	const struct device *i2c = device_get_binding(config->i2c_name);
 
 	/* Bus and address should be configured. */
-	zassert_equal(strcmp(config->i2c_name, "dummy I2C"), 0);
+	zassert_str_equal(config->i2c_name, "dummy I2C");
 	zassert_equal(config->i2c_address, 123);
 
 	if (i2c != NULL) {

--- a/tests/kernel/common/src/printk.c
+++ b/tests/kernel/common/src/printk.c
@@ -220,7 +220,7 @@ ZTEST(printk, test_printk)
 	pk_console[pos] = '\0';
 	__printk_hook_install(_old_char_out);
 	printk("expected '%s'\n", expected);
-	zassert_true((strcmp(pk_console, expected) == 0), "printk failed");
+	zassert_str_equal(pk_console, expected, "printk failed");
 
 	(void)memset(pk_console, 0, sizeof(pk_console));
 	count = 0;
@@ -251,7 +251,7 @@ ZTEST(printk, test_printk)
 	count += snprintk(pk_console + count, sizeof(pk_console) - count,
 			  "0x%x %p %-2p\n", hex, ptr, (char *)42);
 	pk_console[count] = '\0';
-	zassert_true((strcmp(pk_console, expected) == 0), "snprintk failed");
+	zassert_str_equal(pk_console, expected, "snprintk failed");
 }
 
 extern void *common_setup(void);

--- a/tests/kernel/threads/thread_apis/src/test_kthread_for_each.c
+++ b/tests/kernel/threads/thread_apis/src/test_kthread_for_each.c
@@ -228,44 +228,44 @@ ZTEST(threads_lifecycle_1cpu, test_k_thread_state_str)
 
 	tid->base.thread_state = 0;
 	str = k_thread_state_str(tid, state_str, sizeof(state_str));
-	zassert_true(strcmp(str, "") == 0);
+	zassert_str_equal(str, "");
 
 	tid->base.thread_state = _THREAD_DUMMY;
 
 	str = k_thread_state_str(tid, NULL, sizeof(state_str));
-	zassert_true(strcmp(str, "") == 0);
+	zassert_str_equal(str, "");
 
 	str = k_thread_state_str(tid, state_str, 0);
-	zassert_true(strcmp(str, "") == 0);
+	zassert_str_equal(str, "");
 
 	str = k_thread_state_str(tid, state_str, sizeof(state_str));
-	zassert_true(strcmp(str, "dummy") == 0);
+	zassert_str_equal(str, "dummy");
 
 	tid->base.thread_state = _THREAD_PENDING;
 	str = k_thread_state_str(tid, state_str, sizeof(state_str));
-	zassert_true(strcmp(str, "pending") == 0);
+	zassert_str_equal(str, "pending");
 
 	tid->base.thread_state = _THREAD_PRESTART;
 	str = k_thread_state_str(tid, state_str, sizeof(state_str));
-	zassert_true(strcmp(str, "prestart") == 0);
+	zassert_str_equal(str, "prestart");
 
 	tid->base.thread_state = _THREAD_DEAD;
 	str = k_thread_state_str(tid, state_str, sizeof(state_str));
-	zassert_true(strcmp(str, "dead") == 0);
+	zassert_str_equal(str, "dead");
 
 	tid->base.thread_state = _THREAD_SUSPENDED;
 	str = k_thread_state_str(tid, state_str, sizeof(state_str));
-	zassert_true(strcmp(str, "suspended") == 0);
+	zassert_str_equal(str, "suspended");
 
 	tid->base.thread_state = _THREAD_ABORTING;
 	str = k_thread_state_str(tid, state_str, sizeof(state_str));
-	zassert_true(strcmp(str, "aborting") == 0);
+	zassert_str_equal(str, "aborting");
 
 	tid->base.thread_state = _THREAD_QUEUED;
 	str = k_thread_state_str(tid, state_str, sizeof(state_str));
-	zassert_true(strcmp(str, "queued") == 0);
+	zassert_str_equal(str, "queued");
 
 	tid->base.thread_state = _THREAD_PENDING | _THREAD_SUSPENDED;
 	str = k_thread_state_str(tid, state_str, sizeof(state_str));
-	zassert_true(strcmp(str, "pending+suspended") == 0);
+	zassert_str_equal(str, "pending+suspended");
 }

--- a/tests/kernel/threads/thread_apis/src/test_threads_suspend_resume.c
+++ b/tests/kernel/threads/thread_apis/src/test_threads_suspend_resume.c
@@ -165,19 +165,19 @@ ZTEST(threads_lifecycle, test_resume_unsuspend_thread)
 
 	/* Resume an unsuspend thread will not change the thread state. */
 	str = k_thread_state_str(tid, buffer, sizeof(buffer));
-	zassert_true(strcmp(str, "queued") == 0);
+	zassert_str_equal(str, "queued");
 	k_thread_resume(tid);
 	str = k_thread_state_str(tid, buffer, sizeof(buffer));
-	zassert_true(strcmp(str, "queued") == 0);
+	zassert_str_equal(str, "queued");
 
 	/* suspend created thread */
 	k_thread_suspend(tid);
 	str = k_thread_state_str(tid, buffer, sizeof(buffer));
-	zassert_true(strcmp(str, "suspended") == 0);
+	zassert_str_equal(str, "suspended");
 
 	/* Resume an suspend thread will make it to be next eligible.*/
 	k_thread_resume(tid);
 	str = k_thread_state_str(tid, buffer, sizeof(buffer));
-	zassert_true(strcmp(str, "queued") == 0);
+	zassert_str_equal(str, "queued");
 	k_thread_abort(tid);
 }

--- a/tests/kernel/workq/work/src/main.c
+++ b/tests/kernel/workq/work/src/main.c
@@ -237,7 +237,7 @@ static void test_queue_start(void)
 
 		zassert_true(tn != cfg.name);
 		zassert_true(tn != NULL);
-		zassert_equal(strcmp(tn, cfg.name), 0);
+		zassert_str_equal(tn, cfg.name);
 	}
 
 	cfg.name = NULL;
@@ -251,7 +251,7 @@ static void test_queue_start(void)
 
 		zassert_true(tn != cfg.name);
 		zassert_true(tn != NULL);
-		zassert_equal(strcmp(tn, ""), 0);
+		zassert_str_equal(tn, "");
 	}
 
 	cfg.name = "wq.coophi";

--- a/tests/lib/c_lib/common/src/main.c
+++ b/tests/lib/c_lib/common/src/main.c
@@ -230,7 +230,7 @@ ZTEST(libc_common, test_strcmp)
 	char test = 0;
 
 	zassert_true((strcmp(buffer, "fffff") < 0), "strcmp less ...");
-	zassert_true((strcmp(buffer, "eeeee") == 0), "strcmp equal ...");
+	zassert_str_equal(buffer, "eeeee", "strcmp equal ...");
 	zassert_true((strcmp(buffer, "ddddd") > 0), "strcmp greater ...");
 
 	zassert_true((strncasecmp(buffer, "FFFFF", 3) < 0), "strncasecmp less ...");
@@ -277,7 +277,7 @@ ZTEST(libc_common, test_strcpy)
 	(void)memset(buffer, '\0', BUFSIZE);
 	strcpy(buffer, "10 chars!\0");
 
-	zassert_true((strcmp(buffer, "10 chars!\0") == 0), "strcpy");
+	zassert_str_equal(buffer, "10 chars!\0", "strcpy");
 }
 
 /**
@@ -467,7 +467,7 @@ ZTEST(libc_common, test_checktype)
 		}
 	}
 	*ptr = '\0';
-	zassert_equal(strcmp(buf, exp_alnum), 0, "isalnum error");
+	zassert_str_equal(buf, exp_alnum, "isalnum error");
 
 	ptr = buf;
 	for (int i = 0; i < 128; i++) {
@@ -476,7 +476,7 @@ ZTEST(libc_common, test_checktype)
 		}
 	}
 	*ptr = '\0';
-	zassert_equal(strcmp(buf, exp_alpha), 0, "isalpha error");
+	zassert_str_equal(buf, exp_alpha, "isalpha error");
 
 	ptr = buf;
 	for (int i = 0; i < 128; i++) {
@@ -485,7 +485,7 @@ ZTEST(libc_common, test_checktype)
 		}
 	}
 	*ptr = '\0';
-	zassert_equal(strcmp(buf, exp_digit), 0, "isdigit error");
+	zassert_str_equal(buf, exp_digit, "isdigit error");
 
 	ptr = buf;
 	for (int i = 0; i < 128; i++) {
@@ -494,7 +494,7 @@ ZTEST(libc_common, test_checktype)
 		}
 	}
 	*ptr = '\0';
-	zassert_equal(strcmp(buf, exp_graph), 0, "isgraph error");
+	zassert_str_equal(buf, exp_graph, "isgraph error");
 
 	ptr = buf;
 	for (int i = 0; i < 128; i++) {
@@ -503,7 +503,7 @@ ZTEST(libc_common, test_checktype)
 		}
 	}
 	*ptr = '\0';
-	zassert_equal(strcmp(buf, exp_print), 0, "isprint error");
+	zassert_str_equal(buf, exp_print, "isprint error");
 
 	ptr = buf;
 	for (int i = 0; i < 128; i++) {
@@ -512,7 +512,7 @@ ZTEST(libc_common, test_checktype)
 		}
 	}
 	*ptr = '\0';
-	zassert_equal(strcmp(buf, exp_upper), 0, "isupper error");
+	zassert_str_equal(buf, exp_upper, "isupper error");
 
 	ptr = buf;
 	for (int i = 0; i < 128; i++) {
@@ -521,7 +521,7 @@ ZTEST(libc_common, test_checktype)
 		}
 	}
 	*ptr = '\0';
-	zassert_equal(strcmp(buf, exp_space), 0, "isspace error");
+	zassert_str_equal(buf, exp_space, "isspace error");
 
 	ptr = buf;
 	for (int i = 0; i < 128; i++) {
@@ -530,7 +530,7 @@ ZTEST(libc_common, test_checktype)
 		}
 	}
 	*ptr = '\0';
-	zassert_equal(strcmp(buf, exp_xdigit), 0, "isxdigit error");
+	zassert_str_equal(buf, exp_xdigit, "isxdigit error");
 }
 
 /**
@@ -642,7 +642,7 @@ ZTEST(libc_common, test_str_operate)
 	char *ptr;
 
 	zassert_not_null(strcat(str1, str3), "strcat false");
-	zassert_equal(strcmp(str1, "aabbccd"), 0, "test strcat failed");
+	zassert_str_equal(str1, "aabbccd", "test strcat failed");
 
 	ret = strcspn(str1, str2);
 	zassert_equal(ret, 2, "strcspn failed");
@@ -659,12 +659,12 @@ ZTEST(libc_common, test_str_operate)
 #if defined(__GNUC__) && __GNUC__ >= 7
 #pragma GCC diagnostic pop
 #endif
-	zassert_equal(strcmp(ncat, "ddeeaa"), 0, "strncat failed");
+	zassert_str_equal(ncat, "ddeeaa", "strncat failed");
 
 	zassert_is_null(strrchr(ncat, 'z'),
 		       "strrchr not found this word. failed");
 	ptr = strrchr(ncat, 'e');
-	zassert_equal(strcmp(ptr, "eaa"), 0, "strrchr failed");
+	zassert_str_equal(ptr, "eaa", "strrchr failed");
 
 	zassert_is_null(strstr(str1, "ayz"), "strstr aabbccd with ayz failed");
 	zassert_not_null(strstr(str1, str2), "strstr aabbccd with b succeed");
@@ -728,13 +728,11 @@ ZTEST(libc_common, test_strtol)
 
 	ret = strtol(str_normal, &stop, 10);
 	zassert_equal(ret, -1011, "strtol base = 10 failed");
-	zassert_true((strcmp(stop, " This stopped it") == 0),
-		"strtol get stop failed");
+	zassert_str_equal(stop, " This stopped it", "strtol get stop failed");
 
 	ret = strtol(str_abnormal, &stop, 0);
 	zassert_equal(ret, 0, "strtol base = 0 failed");
-	zassert_true((strcmp(stop, "ABCDEFGH") == 0),
-		"strtol get stop failed");
+	zassert_str_equal(stop, "ABCDEFGH", "strtol get stop failed");
 
 #if LONG_MAX > 2147483647
 	char border1[] = "-9223372036854775809";
@@ -817,13 +815,11 @@ ZTEST(libc_common, test_strtoul)
 
 	ret = strtoul(str_normal, &stop, 10);
 	zassert_equal(ret, -1011, "strtol base = 10 failed");
-	zassert_true((strcmp(stop, " This stopped it") == 0),
-		"strtol get stop failed");
+	zassert_str_equal(stop, " This stopped it", "strtol get stop failed");
 
 	ret = strtoul(str_abnormal, &stop, 0);
 	zassert_equal(ret, 0, "strtol base = 0 failed");
-	zassert_true((strcmp(stop, "ABCDEFGH") == 0),
-		"strtol get stop failed");
+	zassert_str_equal(stop, "ABCDEFGH", "strtol get stop failed");
 
 #if LONG_MAX > 2147483647
 	char border1[] = "18446744073709551615";
@@ -901,11 +897,11 @@ void test_strtoll(void)
 
 	ret = strtoll(str_normal, &stop, 10);
 	zassert_equal(ret, -1011, "strtoll base = 10 failed");
-	zassert_true((strcmp(stop, " This stopped it") == 0), "strtoll get stop failed");
+	zassert_str_equal(stop, " This stopped it", "strtoll get stop failed");
 
 	ret = strtoll(str_abnormal, &stop, 0);
 	zassert_equal(ret, 0, "strtoll base = 0 failed");
-	zassert_true((strcmp(stop, "ABCDEFGH") == 0), "strtoll get stop failed");
+	zassert_str_equal(stop, "ABCDEFGH", "strtoll get stop failed");
 
 	char border1[] = "-9223372036854775808";
 	char border2[] = "+9223372036854775807";
@@ -981,11 +977,12 @@ void test_strtoull(void)
 
 	ret = strtoull(str_normal, &stop, 10);
 	zassert_equal(ret, -1011, "strtoull base = 10 failed");
-	zassert_true((strcmp(stop, " This stopped it") == 0), "strtoull get stop failed");
+	zassert_str_equal(stop, " This stopped it",
+			  "strtoull get stop failed");
 
 	ret = strtoull(str_abnormal, &stop, 0);
 	zassert_equal(ret, 0, "strtoull base = 0 failed");
-	zassert_true((strcmp(stop, "ABCDEFGH") == 0), "strtoull get stop failed");
+	zassert_str_equal(stop, "ABCDEFGH", "strtoull get stop failed");
 
 	char border1[] = "+18446744073709551615";
 	char border2[] = "-18446744073709551615000";
@@ -1028,8 +1025,8 @@ ZTEST(libc_common, test_tolower_toupper)
 	}
 	lw[i] = up[i] = '\0';
 
-	zassert_equal(strcmp(up, toup), 0, "toupper error");
-	zassert_equal(strcmp(lw, tolw), 0, "tolower error");
+	zassert_str_equal(up, toup, "toupper error");
+	zassert_str_equal(lw, tolw, "tolower error");
 }
 
 void test_strtok_r_do(char *str, char *sep, int tlen,

--- a/tests/lib/cbprintf_package/src/main.c
+++ b/tests/lib/cbprintf_package/src/main.c
@@ -289,11 +289,11 @@ ZTEST(cbprintf_package, test_cbprintf_fsc_package)
 	/* Get pointer to the first string in the package. */
 	addr = (char *)&fsc_package[desc->desc.len * sizeof(int) + 1];
 
-	zassert_equal(strcmp(test_str, addr), 0);
+	zassert_str_equal(test_str, addr);
 
 	/* Get address of the second string. */
 	addr += strlen(addr) + 2;
-	zassert_equal(strcmp(test_str1, addr), 0);
+	zassert_str_equal(test_str1, addr);
 }
 
 static void check_package(void *package, size_t len, const char *exp_str)

--- a/tests/lib/json/src/main.c
+++ b/tests/lib/json/src/main.c
@@ -245,17 +245,17 @@ ZTEST(lib_json_test, test_json_decoding)
 	zassert_equal(ret, (1 << ARRAY_SIZE(test_descr)) - 1,
 		      "Not all fields decoded correctly");
 
-	zassert_true(!strcmp(ts.some_string, "zephyr 123\\uABCD456"),
-		     "String not decoded correctly");
+	zassert_str_equal(ts.some_string, "zephyr 123\\uABCD456",
+			  "String not decoded correctly");
 	zassert_equal(ts.some_int, 42, "Positive integer not decoded correctly");
 	zassert_equal(ts.some_bool, true, "Boolean not decoded correctly");
 	zassert_equal(ts.some_nested_struct.nested_int, -1234,
 		      "Nested negative integer not decoded correctly");
 	zassert_equal(ts.some_nested_struct.nested_bool, false,
 		      "Nested boolean value not decoded correctly");
-	zassert_true(!strcmp(ts.some_nested_struct.nested_string,
-			    "this should be escaped: \\t"),
-		     "Nested string not decoded correctly");
+	zassert_str_equal(ts.some_nested_struct.nested_string,
+			  "this should be escaped: \\t",
+			  "Nested string not decoded correctly");
 	zassert_equal(ts.some_array_len, 5,
 		      "Array doesn't have correct number of items");
 	zassert_true(!memcmp(ts.some_array, expected_array,
@@ -274,23 +274,23 @@ ZTEST(lib_json_test, test_json_decoding)
 		      "Named nested integer not decoded correctly");
 	zassert_equal(ts.xnother_nexx.nested_bool, true,
 		      "Named nested boolean not decoded correctly");
-	zassert_true(!strcmp(ts.xnother_nexx.nested_string,
-			     "no escape necessary"),
-		     "Named nested string not decoded correctly");
+	zassert_str_equal(ts.xnother_nexx.nested_string,
+			  "no escape necessary",
+			  "Named nested string not decoded correctly");
 	zassert_equal(ts.obj_array_len, 2,
 		      "Array of objects does not have correct number of items");
 	zassert_equal(ts.nested_obj_array[0].nested_int, 1,
 		      "Integer in first object array element not decoded correctly");
 	zassert_equal(ts.nested_obj_array[0].nested_bool, true,
 		      "Boolean value in first object array element not decoded correctly");
-	zassert_true(!strcmp(ts.nested_obj_array[0].nested_string, "true"),
-		     "String in first object array element not decoded correctly");
+	zassert_str_equal(ts.nested_obj_array[0].nested_string, "true",
+			  "String in first object array element not decoded correctly");
 	zassert_equal(ts.nested_obj_array[1].nested_int, 0,
 		      "Integer in second object array element not decoded correctly");
 	zassert_equal(ts.nested_obj_array[1].nested_bool, false,
 		      "Boolean value in second object array element not decoded correctly");
-	zassert_true(!strcmp(ts.nested_obj_array[1].nested_string, "false"),
-		     "String in second object array element not decoded correctly");
+	zassert_str_equal(ts.nested_obj_array[1].nested_string, "false",
+			  "String in second object array element not decoded correctly");
 }
 
 ZTEST(lib_json_test, test_json_limits)
@@ -315,7 +315,8 @@ ZTEST(lib_json_test, test_json_limits)
 	ret = json_obj_parse(encoded, sizeof(encoded) - 1, obj_limits_descr,
 			     ARRAY_SIZE(obj_limits_descr), &limits_decoded);
 
-	zassert_true(!strcmp(encoded, buffer), "Integer limits not encoded correctly");
+	zassert_str_equal(encoded, buffer,
+			  "Integer limits not encoded correctly");
 	zassert_true(!memcmp(&limits, &limits_decoded, sizeof(limits)),
 		     "Integer limits not decoded correctly");
 }
@@ -341,8 +342,8 @@ ZTEST(lib_json_test, test_json_encoding_array_array)
 	ret = json_obj_encode_buf(array_array_descr, ARRAY_SIZE(array_array_descr),
 				  &obj_array_array_ts, buffer, sizeof(buffer));
 	zassert_equal(ret, 0, "Encoding array returned error");
-	zassert_true(!strcmp(buffer, encoded),
-		     "Encoded array of objects is not consistent");
+	zassert_str_equal(buffer, encoded,
+			  "Encoded array of objects is not consistent");
 }
 
 ZTEST(lib_json_test, test_json_decoding_array_array)
@@ -364,18 +365,19 @@ ZTEST(lib_json_test, test_json_decoding_array_array)
 	zassert_equal(obj_array_array_ts.objects_array_len, 3,
 		      "Array doesn't have correct number of items");
 
-	zassert_true(!strcmp(obj_array_array_ts.objects_array[0].objects.name,
-			 "Sim\303\263n Bol\303\255var"), "String not decoded correctly");
+	zassert_str_equal(obj_array_array_ts.objects_array[0].objects.name,
+			  "Sim\303\263n Bol\303\255var",
+			  "String not decoded correctly");
 	zassert_equal(obj_array_array_ts.objects_array[0].objects.height, 168,
 		      "Sim\303\263n Bol\303\255var height not decoded correctly");
 
-	zassert_true(!strcmp(obj_array_array_ts.objects_array[1].objects.name,
-			 "Pel\303\251"), "String not decoded correctly");
+	zassert_str_equal(obj_array_array_ts.objects_array[1].objects.name,
+			  "Pel\303\251", "String not decoded correctly");
 	zassert_equal(obj_array_array_ts.objects_array[1].objects.height, 173,
 		      "Pel\303\251 height not decoded correctly");
 
-	zassert_true(!strcmp(obj_array_array_ts.objects_array[2].objects.name,
-			 "Usain Bolt"), "String not decoded correctly");
+	zassert_str_equal(obj_array_array_ts.objects_array[2].objects.name,
+			  "Usain Bolt", "String not decoded correctly");
 	zassert_equal(obj_array_array_ts.objects_array[2].objects.height, 195,
 		      "Usain Bolt height not decoded correctly");
 }
@@ -415,8 +417,8 @@ ZTEST(lib_json_test, test_json_obj_arr_encoding)
 	ret = json_obj_encode_buf(obj_array_descr, ARRAY_SIZE(obj_array_descr),
 				  &oa, buffer, sizeof(buffer));
 	zassert_equal(ret, 0, "Encoding array of object returned error");
-	zassert_true(!strcmp(buffer, encoded),
-		     "Encoded array of objects is not consistent");
+	zassert_str_equal(buffer, encoded,
+			  "Encoded array of objects is not consistent");
 }
 
 ZTEST(lib_json_test, test_json_arr_obj_decoding)
@@ -436,18 +438,19 @@ ZTEST(lib_json_test, test_json_arr_obj_decoding)
 	zassert_equal(obj_array_array_ts.num_elements, 3,
 		      "Array doesn't have correct number of items");
 
-	zassert_true(!strcmp(obj_array_array_ts.elements[0].name,
-			 "Sim\303\263n Bol\303\255var"), "String not decoded correctly");
+	zassert_str_equal(obj_array_array_ts.elements[0].name,
+			  "Sim\303\263n Bol\303\255var",
+			  "String not decoded correctly");
 	zassert_equal(obj_array_array_ts.elements[0].height, 168,
 		      "Sim\303\263n Bol\303\255var height not decoded correctly");
 
-	zassert_true(!strcmp(obj_array_array_ts.elements[1].name,
-			 "Pel\303\251"), "String not decoded correctly");
+	zassert_str_equal(obj_array_array_ts.elements[1].name, "Pel\303\251",
+			  "String not decoded correctly");
 	zassert_equal(obj_array_array_ts.elements[1].height, 173,
 		      "Pel\303\251 height not decoded correctly");
 
-	zassert_true(!strcmp(obj_array_array_ts.elements[2].name,
-			 "Usain Bolt"), "String not decoded correctly");
+	zassert_str_equal(obj_array_array_ts.elements[2].name, "Usain Bolt",
+			  "String not decoded correctly");
 	zassert_equal(obj_array_array_ts.elements[2].height, 195,
 		      "Usain Bolt height not decoded correctly");
 }
@@ -490,8 +493,8 @@ ZTEST(lib_json_test, test_json_arr_obj_encoding)
 
 	ret = json_arr_encode_buf(obj_array_descr, &oa, buffer, sizeof(buffer));
 	zassert_equal(ret, 0, "Encoding array of object returned error %d", ret);
-	zassert_true(!strcmp(buffer, encoded),
-		     "Encoded array of objects is not consistent");
+	zassert_str_equal(buffer, encoded,
+			  "Encoded array of objects is not consistent");
 }
 
 ZTEST(lib_json_test, test_json_obj_arr_decoding)
@@ -619,8 +622,8 @@ ZTEST(lib_json_test, test_json_2dim_arr_obj_encoding)
 	ret = json_obj_encode_buf(array_2dim_descr, ARRAY_SIZE(array_2dim_descr),
 				  &obj_array_array_ts, buffer, sizeof(buffer));
 	zassert_equal(ret, 0, "Encoding two-dimensional array returned error");
-	zassert_true(!strcmp(buffer, encoded),
-		     "Encoded two-dimensional array is not consistent");
+	zassert_str_equal(buffer, encoded,
+			  "Encoded two-dimensional array is not consistent");
 }
 
 ZTEST(lib_json_test, test_json_2dim_arr_extra_obj_encoding)
@@ -702,8 +705,8 @@ ZTEST(lib_json_test, test_json_2dim_arr_extra_obj_encoding)
 	ret = json_obj_encode_buf(array_2dim_extra_descr, ARRAY_SIZE(array_2dim_extra_descr),
 				  &obj_array_2dim_extra_ts, buffer, sizeof(buffer));
 	zassert_equal(ret, 0, "Encoding two-dimensional extra array returned error");
-	zassert_true(!strcmp(buffer, encoded),
-		     "Encoded two-dimensional extra array is not consistent");
+	zassert_str_equal(buffer, encoded,
+			  "Encoded two-dimensional extra array is not consistent");
 }
 
 ZTEST(lib_json_test, test_json_2dim_arr_extra_named_obj_encoding)
@@ -786,8 +789,8 @@ ZTEST(lib_json_test, test_json_2dim_arr_extra_named_obj_encoding)
 				  ARRAY_SIZE(array_2dim_extra_named_descr),
 				  &obj_array_2dim_extra_ts, buffer, sizeof(buffer));
 	zassert_equal(ret, 0, "Encoding two-dimensional extra named array returned error");
-	zassert_true(!strcmp(buffer, encoded),
-		     "Encoded two-dimensional extra named array is not consistent");
+	zassert_str_equal(buffer, encoded,
+			  "Encoded two-dimensional extra named array is not consistent");
 }
 
 ZTEST(lib_json_test, test_json_2dim_obj_arr_decoding)
@@ -1023,8 +1026,7 @@ ZTEST(lib_json_test, test_json_escape)
 	zassert_equal(ret, 0, "Escape did not succeed");
 	zassert_equal(len, sizeof(buf) - 1,
 		      "Escaped length not computed correctly");
-	zassert_true(!strcmp(buf, expected),
-		     "Escaped value is not correct");
+	zassert_str_equal(buf, expected, "Escaped value is not correct");
 }
 
 /* Edge case: only one character, which must be escaped. */
@@ -1040,8 +1042,7 @@ ZTEST(lib_json_test, test_json_escape_one)
 		      "Escaping one character did not succeed");
 	zassert_equal(len, sizeof(buf) - 1,
 		      "Escaping one character length is not correct");
-	zassert_true(!strcmp(buf, expected),
-		     "Escaped value is not correct");
+	zassert_str_equal(buf, expected, "Escaped value is not correct");
 }
 
 ZTEST(lib_json_test, test_json_escape_empty)
@@ -1067,8 +1068,8 @@ ZTEST(lib_json_test, test_json_escape_no_op)
 	zassert_equal(ret, 0, "Escape no-op not handled correctly");
 	zassert_equal(len, sizeof(nothing_to_escape) - 1,
 		      "Changed length of already escaped string");
-	zassert_true(!strcmp(nothing_to_escape, expected),
-		     "Altered string with nothing to escape");
+	zassert_str_equal(nothing_to_escape, expected,
+			  "Altered string with nothing to escape");
 }
 
 ZTEST(lib_json_test, test_json_escape_bounds_check)

--- a/tests/lib/sprintf/src/main.c
+++ b/tests/lib/sprintf/src/main.c
@@ -754,8 +754,8 @@ ZTEST(sprintf, test_sprintf_string)
 		     "Expected 'short string', got '%s'\n", buffer);
 
 	sprintf(buffer, "%s", REALLY_LONG_STRING);
-	zassert_true((strcmp(buffer, REALLY_LONG_STRING) == 0),
-		     "sprintf(%%s) of REALLY_LONG_STRING doesn't match!\n");
+	zassert_str_equal(buffer, REALLY_LONG_STRING,
+			  "sprintf(%%s) of REALLY_LONG_STRING doesn't match!\n");
 }
 
 

--- a/tests/modules/nanopb/src/main.c
+++ b/tests/modules/nanopb/src/main.c
@@ -67,7 +67,7 @@ ZTEST(nanopb_tests, test_nanopb_nested)
 
 	zassert_equal(42, msg.nested.id);
 	zassert_true(msg.has_nested);
-	zassert_equal(0, strcmp(msg.nested.name, "Test name"));
+	zassert_str_equal(msg.nested.name, "Test name");
 }
 
 ZTEST(nanopb_tests, test_nanopb_lib)

--- a/tests/net/conn_mgr_conn/src/main.c
+++ b/tests/net/conn_mgr_conn/src/main.c
@@ -639,7 +639,8 @@ ZTEST(conn_mgr_conn, test_conn_opt)
 		       0, "conn_mgr_if_get_opt should succeed for valid parameters");
 	printk("%d, %d", buf_len, strlen(buf) + 1);
 	zassert_equal(buf_len, strlen(buf) + 1, "conn_mgr_if_get_opt should return valid optlen");
-	zassert_equal(strcmp(buf, "A"), 0, "conn_mgr_if_get_opt should retrieve \"A\"");
+	zassert_str_equal(buf, "A",
+			  "conn_mgr_if_get_opt should retrieve \"A\"");
 
 	/* Verify that ifa1->Y was not affected */
 	memset(buf, 0, sizeof(buf));
@@ -668,7 +669,8 @@ ZTEST(conn_mgr_conn, test_conn_opt)
 	zassert_equal(conn_mgr_if_get_opt(ifa1, TEST_CONN_OPT_Y, &buf, &buf_len),
 		       0, "conn_mgr_if_get_opt should succeed for valid parameters");
 	zassert_equal(buf_len, strlen(buf) + 1, "conn_mgr_if_get_opt should return valid optlen");
-	zassert_equal(strcmp(buf, "ABC"), 0, "conn_mgr_if_get_opt should retrieve \"ABC\"");
+	zassert_str_equal(buf, "ABC",
+			  "conn_mgr_if_get_opt should retrieve \"ABC\"");
 
 	/* Verify that ifa1->X was not affected */
 	memset(buf, 0, sizeof(buf));
@@ -676,7 +678,8 @@ ZTEST(conn_mgr_conn, test_conn_opt)
 	zassert_equal(conn_mgr_if_get_opt(ifa1, TEST_CONN_OPT_X, &buf, &buf_len),
 		       0, "conn_mgr_if_get_opt should succeed for valid parameters");
 	zassert_equal(buf_len, strlen(buf) + 1, "conn_mgr_if_get_opt should return valid optlen");
-	zassert_equal(strcmp(buf, "A"), 0, "conn_mgr_if_get_opt should retrieve \"A\"");
+	zassert_str_equal(buf, "A",
+			  "conn_mgr_if_get_opt should retrieve \"A\"");
 
 	/* Next, we pass some buffers that are too large or too small.
 	 * This is an indirect way of verifying that buf_len is passed correctly.

--- a/tests/net/lib/http_server/prototype/src/main.c
+++ b/tests/net/lib/http_server/prototype/src/main.c
@@ -319,26 +319,26 @@ ZTEST(server_function_tests, test_http_server_start_stop)
 
 ZTEST(server_function_tests, test_get_frame_type_name)
 {
-	zassert_equal(strcmp(get_frame_type_name(HTTP_SERVER_DATA_FRAME), "DATA"), 0,
-		      "Unexpected frame type");
-	zassert_equal(strcmp(get_frame_type_name(HTTP_SERVER_HEADERS_FRAME), "HEADERS"), 0,
-		      "Unexpected frame type");
-	zassert_equal(strcmp(get_frame_type_name(HTTP_SERVER_PRIORITY_FRAME), "PRIORITY"), 0,
-		      "Unexpected frame type");
-	zassert_equal(strcmp(get_frame_type_name(HTTP_SERVER_RST_STREAM_FRAME), "RST_STREAM"), 0,
-		      "Unexpected frame type");
-	zassert_equal(strcmp(get_frame_type_name(HTTP_SERVER_SETTINGS_FRAME), "SETTINGS"), 0,
-		      "Unexpected frame type");
-	zassert_equal(strcmp(get_frame_type_name(HTTP_SERVER_PUSH_PROMISE_FRAME), "PUSH_PROMISE"),
-		      0, "Unexpected frame type");
-	zassert_equal(strcmp(get_frame_type_name(HTTP_SERVER_PING_FRAME), "PING"), 0,
-		      "Unexpected frame type");
-	zassert_equal(strcmp(get_frame_type_name(HTTP_SERVER_GOAWAY_FRAME), "GOAWAY"), 0,
-		      "Unexpected frame type");
-	zassert_equal(strcmp(get_frame_type_name(HTTP_SERVER_WINDOW_UPDATE_FRAME), "WINDOW_UPDATE"),
-		      0, "Unexpected frame type");
-	zassert_equal(strcmp(get_frame_type_name(HTTP_SERVER_CONTINUATION_FRAME), "CONTINUATION"),
-		      0, "Unexpected frame type");
+	zassert_str_equal(get_frame_type_name(HTTP_SERVER_DATA_FRAME), "DATA",
+			  "Unexpected frame type");
+	zassert_str_equal(get_frame_type_name(HTTP_SERVER_HEADERS_FRAME),
+			  "HEADERS", "Unexpected frame type");
+	zassert_str_equal(get_frame_type_name(HTTP_SERVER_PRIORITY_FRAME),
+			  "PRIORITY", "Unexpected frame type");
+	zassert_str_equal(get_frame_type_name(HTTP_SERVER_RST_STREAM_FRAME),
+			  "RST_STREAM", "Unexpected frame type");
+	zassert_str_equal(get_frame_type_name(HTTP_SERVER_SETTINGS_FRAME),
+			  "SETTINGS", "Unexpected frame type");
+	zassert_str_equal(get_frame_type_name(HTTP_SERVER_PUSH_PROMISE_FRAME),
+			  "PUSH_PROMISE", "Unexpected frame type");
+	zassert_str_equal(get_frame_type_name(HTTP_SERVER_PING_FRAME), "PING",
+			  "Unexpected frame type");
+	zassert_str_equal(get_frame_type_name(HTTP_SERVER_GOAWAY_FRAME),
+			  "GOAWAY", "Unexpected frame type");
+	zassert_str_equal(get_frame_type_name(HTTP_SERVER_WINDOW_UPDATE_FRAME),
+			  "WINDOW_UPDATE", "Unexpected frame type");
+	zassert_str_equal(get_frame_type_name(HTTP_SERVER_CONTINUATION_FRAME),
+			  "CONTINUATION", "Unexpected frame type");
 }
 
 ZTEST(server_function_tests, test_parse_http_frames)

--- a/tests/net/lib/lwm2m/lwm2m_registry/src/lwm2m_registry.c
+++ b/tests/net/lib/lwm2m/lwm2m_registry/src/lwm2m_registry.c
@@ -181,7 +181,7 @@ ZTEST(lwm2m_registry, test_get_set)
 
 	zassert_equal(b, true);
 	zassert_equal(memcmp(opaque, &(uint8_t[6]) {0xde, 0xad, 0xbe, 0xff, 0, 0}, l), 0);
-	zassert_equal(strcmp(string, "Hello"), 0);
+	zassert_str_equal(string, "Hello");
 	zassert_equal(u8, 8);
 	zassert_equal(s8, -8);
 	zassert_equal(u16, 16);
@@ -465,7 +465,7 @@ ZTEST(lwm2m_registry, test_deprecated_functions)
 
 	zassert_equal(b, true);
 	zassert_equal(memcmp(opaque, &(uint8_t[6]) {0xde, 0xad, 0xbe, 0xff, 0, 0}, l), 0);
-	zassert_equal(strcmp(string, "Hello"), 0);
+	zassert_str_equal(string, "Hello");
 	zassert_equal(u8, 8);
 	zassert_equal(s8, -8);
 	zassert_equal(u16, 16);
@@ -681,7 +681,7 @@ ZTEST(lwm2m_registry, test_set_bulk)
 	zassert_equal(b, true);
 	zassert_equal(memcmp(opaque, &(uint8_t[6]) {0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
 		sizeof(opaque)), 0);
-	zassert_equal(strcmp(string, "Hello world"), 0);
+	zassert_str_equal(string, "Hello world");
 	zassert_equal(u8, 80);
 	zassert_equal(s8, -80);
 	zassert_equal(u16, 160);

--- a/tests/subsys/debug/symtab/src/main.c
+++ b/tests/subsys/debug/symtab/src/main.c
@@ -37,21 +37,21 @@ ZTEST(test_symtab, test_symtab_find_symbol_name)
 	/* Find the name of functions with `symtab_find_symbol_name()` */
 	offset = -1;
 	symbol_name = symtab_find_symbol_name((uintptr_t)main, &offset);
-	zassert_equal(strcmp(symbol_name, "main"), 0);
+	zassert_str_equal(symbol_name, "main");
 	zassert_equal(offset, 0);
 
 	/* Do a few more just for fun */
 	symbol_name = symtab_find_symbol_name((uintptr_t)strcmp, NULL);
-	zassert_equal(strcmp(symbol_name, "strcmp"), 0);
+	zassert_str_equal(symbol_name, "strcmp");
 
 	symbol_name = symtab_find_symbol_name((uintptr_t)symtab_find_symbol_name, NULL);
-	zassert_equal(strcmp(symbol_name, "symtab_find_symbol_name"), 0);
+	zassert_str_equal(symbol_name, "symtab_find_symbol_name");
 
 	symbol_name = symtab_find_symbol_name((uintptr_t)test_main, NULL);
-	zassert_equal(strcmp(symbol_name, "test_main"), 0);
+	zassert_str_equal(symbol_name, "test_main");
 
 	symbol_name = symtab_find_symbol_name((uintptr_t)setup, NULL);
-	zassert_equal(strcmp(symbol_name, "setup"), 0);
+	zassert_str_equal(symbol_name, "setup");
 }
 
 /**
@@ -83,7 +83,7 @@ ZTEST(test_symtab, test_before_first)
 	if (first_addr > 0) {
 		offset = -1;
 		symbol_name = symtab_find_symbol_name(first_addr - 1, &offset);
-		zassert_equal(strcmp(symbol_name, "?"), 0);
+		zassert_str_equal(symbol_name, "?");
 		zassert_equal(offset, 0);
 	} else {
 		ztest_test_skip();
@@ -98,13 +98,13 @@ ZTEST(test_symtab, test_first)
 
 	offset = -1;
 	symbol_name = symtab_find_symbol_name(first_addr, &offset);
-	zassert_equal(strcmp(symbol_name, symtab->entries[0].name), 0);
+	zassert_str_equal(symbol_name, symtab->entries[0].name);
 	zassert_equal(offset, 0);
 
 	if ((symtab->entries[0].offset + 1) != symtab->entries[1].offset) {
 		offset = -1;
 		symbol_name = symtab_find_symbol_name(first_addr + 1, &offset);
-		zassert_equal(strcmp(symbol_name, symtab->entries[0].name), 0);
+		zassert_str_equal(symbol_name, symtab->entries[0].name);
 		zassert_equal(offset, 1);
 	}
 }
@@ -119,7 +119,7 @@ ZTEST(test_symtab, test_last)
 
 	offset = -1;
 	symbol_name = symtab_find_symbol_name(last_addr, &offset);
-	zassert_equal(strcmp(symbol_name, symtab->entries[last_idx].name), 0);
+	zassert_str_equal(symbol_name, symtab->entries[last_idx].name);
 	zassert_equal(offset, 0);
 }
 
@@ -135,7 +135,8 @@ ZTEST(test_symtab, test_after_last)
 	if (last_offset + 0x1 != symtab->entries[symtab->length].offset) {
 		offset = -1;
 		symbol_name = symtab_find_symbol_name(last_addr + 0x1, &offset);
-		zassert_equal(strcmp(symbol_name, symtab->entries[symtab->length - 1].name), 0);
+		zassert_str_equal(symbol_name,
+				  symtab->entries[symtab->length - 1].name);
 		zassert_equal(offset, 0x1);
 	} else {
 		ztest_test_skip();
@@ -153,6 +154,6 @@ ZTEST(test_symtab, test_after_dummy)
 	/* Test `offset` output with dummy symbol (after last dymbol) */
 	offset = -1;
 	symbol_name = symtab_find_symbol_name(last_dummy_addr + 0x42, &offset);
-	zassert_equal(strcmp(symbol_name, "?"), 0);
+	zassert_str_equal(symbol_name, "?");
 	zassert_equal(offset, 0);
 }

--- a/tests/subsys/fs/common/test_fs_basic.c
+++ b/tests/subsys/fs/common/test_fs_basic.c
@@ -43,8 +43,7 @@ static int create_write_hello(const struct fs_mount_t *mp)
 
 	zassert_equal(stat.type, FS_DIR_ENTRY_FILE,
 		      "stat new hello not file");
-	zassert_equal(strcmp(stat.name, HELLO), 0,
-		      "stat new hello not hello");
+	zassert_str_equal(stat.name, HELLO, "stat new hello not hello");
 	zassert_equal(stat.size, 0,
 		      "stat new hello not empty");
 
@@ -58,8 +57,7 @@ static int create_write_hello(const struct fs_mount_t *mp)
 
 	zassert_equal(stat.type, FS_DIR_ENTRY_FILE,
 		      "stat written hello not file");
-	zassert_equal(strcmp(stat.name, HELLO), 0,
-		      "stat written hello not hello");
+	zassert_str_equal(stat.name, HELLO, "stat written hello not hello");
 
 	/* Anomalous behavior requiring upstream response */
 	if (mp->type == FS_LITTLEFS) {
@@ -79,8 +77,7 @@ static int create_write_hello(const struct fs_mount_t *mp)
 
 	zassert_equal(stat.type, FS_DIR_ENTRY_FILE,
 		      "stat closed hello not file");
-	zassert_equal(strcmp(stat.name, HELLO), 0,
-		      "stat closed hello not hello");
+	zassert_str_equal(stat.name, HELLO, "stat closed hello not hello");
 	zassert_equal(stat.size, TESTFS_BUFFER_SIZE,
 		      "stat closed hello badsize");
 

--- a/tests/subsys/fs/fs_api/src/test_fs_dir_file.c
+++ b/tests/subsys/fs/fs_api/src/test_fs_dir_file.c
@@ -700,8 +700,8 @@ void test_file_read(void)
 	read_buff[brw] = 0;
 	TC_PRINT("Data read:\"%s\"\n\n", read_buff);
 
-	zassert_true(strcmp(test_str, read_buff) == 0,
-		    "Error - Data read does not match data written");
+	zassert_str_equal(test_str, read_buff,
+			  "Error - Data read does not match data written");
 
 	TC_PRINT("Data read matches data written\n");
 }

--- a/tests/subsys/fs/littlefs/src/test_util.c
+++ b/tests/subsys/fs/littlefs/src/test_util.c
@@ -31,12 +31,12 @@ ZTEST(littlefs, test_util_path_init_base)
 	zassert_equal(testfs_path_init(&path, NULL, TESTFS_PATH_END),
 		      path.path,
 		      "bad root init return");
-	zassert_equal(strcmp(path.path, "/"), 0, "bad root init path");
+	zassert_str_equal(path.path, "/", "bad root init path");
 
 	zassert_equal(testfs_path_init(&path, &mnt, TESTFS_PATH_END),
 		      path.path,
 		      "bad mnt init return");
-	zassert_equal(strcmp(path.path, mnt.mnt_point), 0, "bad mnt init path");
+	zassert_str_equal(path.path, mnt.mnt_point, "bad mnt init path");
 
 	if (IS_ENABLED(CONFIG_DEBUG)) {
 		struct fs_mount_t invalid = {
@@ -76,71 +76,35 @@ ZTEST(littlefs, test_util_path_init_overrun)
 
 ZTEST(littlefs, test_util_path_init_extended)
 {
-	zassert_equal(strcmp(testfs_path_init(&path, &mnt,
-					      ELT1,
-					      TESTFS_PATH_END),
-			     MNT "/" ELT1),
-		      0,
-		      "bad mnt init elt1");
+	zassert_str_equal(testfs_path_init(&path, &mnt, ELT1, TESTFS_PATH_END),
+			  MNT "/" ELT1, "bad mnt init elt1");
 
-	zassert_equal(strcmp(testfs_path_init(&path, &mnt,
-					      ELT1,
-					      ELT2,
-					      TESTFS_PATH_END),
-			     MNT "/" ELT1 "/" ELT2),
-		      0,
-		      "bad mnt init elt1 elt2");
+	zassert_str_equal(testfs_path_init(&path, &mnt, ELT1, ELT2, TESTFS_PATH_END),
+			  MNT "/" ELT1 "/" ELT2, "bad mnt init elt1 elt2");
 }
 
 ZTEST(littlefs, test_util_path_extend)
 {
-	zassert_equal(strcmp(testfs_path_extend(reset_path(),
-						TESTFS_PATH_END),
-			     MNT),
-		      0,
-		      "empty extend failed");
+	zassert_str_equal(testfs_path_extend(reset_path(), TESTFS_PATH_END),
+			  MNT, "empty extend failed");
 
-	zassert_equal(strcmp(testfs_path_extend(reset_path(),
-						ELT2,
-						TESTFS_PATH_END),
-			     MNT "/" ELT2),
-		      0,
-		      "elt extend failed");
+	zassert_str_equal(testfs_path_extend(reset_path(), ELT2, TESTFS_PATH_END),
+			  MNT "/" ELT2, "elt extend failed");
 
-	zassert_equal(strcmp(testfs_path_extend(reset_path(),
-						ELT1,
-						ELT2,
-						TESTFS_PATH_END),
-			     MNT "/" ELT1 "/" ELT2),
-		      0,
-		      "elt1 elt2 extend failed");
+	zassert_str_equal(testfs_path_extend(reset_path(), ELT1, ELT2, TESTFS_PATH_END),
+			  MNT "/" ELT1 "/" ELT2, "elt1 elt2 extend failed");
 }
 
 ZTEST(littlefs, test_util_path_extend_up)
 {
-	zassert_equal(strcmp(testfs_path_extend(reset_path(),
-						ELT2,
-						"..",
-						ELT1,
-						TESTFS_PATH_END),
-			     MNT "/" ELT1),
-		      0,
-		      "elt elt2, up, elt1 failed");
+	zassert_str_equal(testfs_path_extend(reset_path(), ELT2, "..", ELT1, TESTFS_PATH_END),
+			  MNT "/" ELT1, "elt elt2, up, elt1 failed");
 
-	zassert_equal(strcmp(testfs_path_extend(reset_path(),
-						"..",
-						TESTFS_PATH_END),
-			     "/"),
-		      0,
-		      "up strip mnt failed");
+	zassert_str_equal(testfs_path_extend(reset_path(), "..", TESTFS_PATH_END),
+			  "/", "up strip mnt failed");
 
-	zassert_equal(strcmp(testfs_path_extend(reset_path(),
-						"..",
-						"..",
-						TESTFS_PATH_END),
-			     "/"),
-		      0,
-		      "up from root failed");
+	zassert_str_equal(testfs_path_extend(reset_path(), "..", "..", TESTFS_PATH_END),
+			  "/", "up from root failed");
 }
 
 ZTEST(littlefs, test_util_path_extend_overrun)
@@ -150,11 +114,6 @@ ZTEST(littlefs, test_util_path_extend_overrun)
 	memset(long_elt, 'a', sizeof(long_elt) - 1);
 	long_elt[sizeof(long_elt) - 1] = '\0';
 
-	zassert_equal(strcmp(testfs_path_extend(reset_path(),
-						long_elt,
-						ELT1,
-						TESTFS_PATH_END),
-			     MNT),
-		      0,
-		      "stop at overrun failed");
+	zassert_str_equal(testfs_path_extend(reset_path(), long_elt, ELT1, TESTFS_PATH_END),
+			  MNT, "stop at overrun failed");
 }

--- a/tests/subsys/logging/log_links/src/main.c
+++ b/tests/subsys/logging/log_links/src/main.c
@@ -211,8 +211,8 @@ ZTEST(log_links, test_log_runtime_level_set)
 
 ZTEST(log_links, test_log_domain_name_get)
 {
-	zassert_equal(strcmp(log_domain_name_get(0), ""), 0,
-			"Unexpected domain name");
+	zassert_str_equal(log_domain_name_get(0), "",
+			  "Unexpected domain name");
 	zassert_equal(strcmp(log_domain_name_get(1), "domain1"), 0,
 			"Unexpected domain name (%s)", log_domain_name_get(1));
 	zassert_equal(strcmp(log_domain_name_get(2), "domain2"), 0,

--- a/tests/subsys/logging/log_output/src/log_output_test.c
+++ b/tests/subsys/logging/log_output/src/log_output_test.c
@@ -57,7 +57,7 @@ ZTEST(test_log_output, test_no_flags)
 	log_output_process(&log_output, 0, NULL, SNAME, NULL, LOG_LEVEL_INF, package, NULL, 0, 0);
 
 	mock_buffer[mock_len] = '\0';
-	zassert_equal(strcmp(exp_str, mock_buffer), 0);
+	zassert_str_equal(exp_str, mock_buffer);
 }
 
 ZTEST(test_log_output, test_raw)
@@ -73,7 +73,7 @@ ZTEST(test_log_output, test_raw)
 			   package, NULL, 0, 0);
 
 	mock_buffer[mock_len] = '\0';
-	zassert_equal(strcmp(exp_str, mock_buffer), 0);
+	zassert_str_equal(exp_str, mock_buffer);
 }
 
 ZTEST(test_log_output, test_no_flags_dname)
@@ -88,7 +88,7 @@ ZTEST(test_log_output, test_no_flags_dname)
 	log_output_process(&log_output, 0, DNAME, SNAME, NULL, LOG_LEVEL_INF, package, NULL, 0, 0);
 
 	mock_buffer[mock_len] = '\0';
-	zassert_equal(strcmp(exp_str, mock_buffer), 0);
+	zassert_str_equal(exp_str, mock_buffer);
 }
 
 ZTEST(test_log_output, test_level_flag)
@@ -105,7 +105,7 @@ ZTEST(test_log_output, test_level_flag)
 			   package, NULL, 0, flags);
 
 	mock_buffer[mock_len] = '\0';
-	zassert_equal(strcmp(exp_str, mock_buffer), 0);
+	zassert_str_equal(exp_str, mock_buffer);
 }
 
 ZTEST(test_log_output, test_ts_flag)
@@ -124,7 +124,7 @@ ZTEST(test_log_output, test_ts_flag)
 			   package, NULL, 0, flags);
 
 	mock_buffer[mock_len] = '\0';
-	zassert_equal(strcmp(exp_str, mock_buffer), 0);
+	zassert_str_equal(exp_str, mock_buffer);
 }
 
 ZTEST(test_log_output, test_format_ts)
@@ -145,7 +145,7 @@ ZTEST(test_log_output, test_format_ts)
 
 	mock_buffer[mock_len] = '\0';
 	printk("%s", mock_buffer);
-	zassert_equal(strcmp(exp_str, mock_buffer), 0);
+	zassert_str_equal(exp_str, mock_buffer);
 }
 
 ZTEST(test_log_output, test_ts_to_us)
@@ -182,7 +182,7 @@ ZTEST(test_log_output, test_levels)
 				   package, NULL, 0, flags);
 
 		mock_buffer[mock_len] = '\0';
-		zassert_equal(strcmp(exp_strs[i], mock_buffer), 0);
+		zassert_str_equal(exp_strs[i], mock_buffer);
 	}
 }
 
@@ -214,7 +214,7 @@ ZTEST(test_log_output, test_colors)
 				   package, NULL, 0, flags);
 
 		mock_buffer[mock_len] = '\0';
-		zassert_equal(strcmp(exp_strs[i], mock_buffer), 0);
+		zassert_str_equal(exp_strs[i], mock_buffer);
 	}
 }
 
@@ -244,7 +244,7 @@ ZTEST(test_log_output, test_thread_id)
 
 	mock_buffer[mock_len] = '\0';
 	printk("%s", mock_buffer);
-	zassert_equal(strcmp(exp_str, mock_buffer), 0);
+	zassert_str_equal(exp_str, mock_buffer);
 }
 
 ZTEST(test_log_output, test_skip_src)
@@ -262,7 +262,7 @@ ZTEST(test_log_output, test_skip_src)
 			   package, NULL, 0, flags);
 
 	mock_buffer[mock_len] = '\0';
-	zassert_equal(strcmp(exp_str, mock_buffer), 0);
+	zassert_str_equal(exp_str, mock_buffer);
 }
 
 static void before(void *notused)

--- a/tests/subsys/logging/log_timestamp/src/log_timestamp_test.c
+++ b/tests/subsys/logging/log_timestamp/src/log_timestamp_test.c
@@ -75,7 +75,7 @@ ZTEST(test_timestamp, test_custom_timestamp)
 			   package, NULL, 0, flags);
 
 	mock_buffer[mock_len] = '\0';
-	zassert_equal(strcmp(exp_str, mock_buffer), 0);
+	zassert_str_equal(exp_str, mock_buffer);
 }
 
 static void before(void *notused)

--- a/tests/subsys/mem_mgmt/mem_attr/src/main.c
+++ b/tests/subsys/mem_mgmt/mem_attr/src/main.c
@@ -26,15 +26,15 @@ ZTEST(mem_attr, test_mem_attr)
 			zassert_equal(region[idx].dt_attr, DT_MEM_ARM_MPU_FLASH |
 							   DT_MEM_NON_VOLATILE,
 							   "Wrong region address");
-			zassert_true((strcmp(region[idx].dt_name, "memory@10000000") == 0),
-				     "Wrong name");
+			zassert_str_equal(region[idx].dt_name,
+					  "memory@10000000", "Wrong name");
 		} else {
 			zassert_equal(region[idx].dt_addr, 0x20000000, "Wrong region address");
 			zassert_equal(region[idx].dt_size, 0x2000, "Wrong region size");
 			zassert_equal(region[idx].dt_attr, DT_MEM_ARM_MPU_RAM_NOCACHE,
 							   "Wrong region address");
-			zassert_true((strcmp(region[idx].dt_name, "memory@20000000") == 0),
-				      "Wrong name");
+			zassert_str_equal(region[idx].dt_name,
+					  "memory@20000000", "Wrong name");
 		}
 	}
 

--- a/tests/subsys/modem/modem_chat/src/main.c
+++ b/tests/subsys/modem/modem_chat/src/main.c
@@ -521,11 +521,16 @@ ZTEST(modem_chat, test_script_with_partial_matches)
 					 MODEM_CHAT_UTEST_ON_CMGL_PARTIAL_CALLED_BIT);
 		zassert_equal(called, true, "Match callback not called");
 		zassert_equal(argc_buffers, 5, "Incorrect number of args");
-		zassert_equal(strcmp(argv_buffers[0], "+CMGL: "), 0, "Incorrect argv received");
-		zassert_equal(strcmp(argv_buffers[1], "1"), 0, "Incorrect argv received");
-		zassert_equal(strcmp(argv_buffers[2], "1"), 0, "Incorrect argv received");
-		zassert_equal(strcmp(argv_buffers[3], ""), 0, "Incorrect argv received");
-		zassert_equal(strcmp(argv_buffers[4], "50"), 0, "Incorrect argv received");
+		zassert_str_equal(argv_buffers[0], "+CMGL: ",
+				  "Incorrect argv received");
+		zassert_str_equal(argv_buffers[1], "1",
+				  "Incorrect argv received");
+		zassert_str_equal(argv_buffers[2], "1",
+				  "Incorrect argv received");
+		zassert_str_equal(argv_buffers[3], "",
+				  "Incorrect argv received");
+		zassert_str_equal(argv_buffers[4], "50",
+				  "Incorrect argv received");
 
 		atomic_set(&callback_called, 0);
 		modem_backend_mock_put(&mock, cmgl_response_1, sizeof(cmgl_response_1) - 1);
@@ -535,9 +540,11 @@ ZTEST(modem_chat, test_script_with_partial_matches)
 					 MODEM_CHAT_UTEST_ON_CMGL_PARTIAL_ANY_CALLED_BIT);
 		zassert_equal(called, true, "Match callback not called");
 		zassert_equal(argc_buffers, 2, "Incorrect number of args");
-		zassert_equal(strcmp(argv_buffers[0], ""), 0, "Incorrect argv received");
-		zassert_equal(strcmp(argv_buffers[1], "07911326060032F064A9542954"), 0,
-			      "Incorrect argv received");
+		zassert_str_equal(argv_buffers[0], "",
+				  "Incorrect argv received");
+		zassert_str_equal(argv_buffers[1],
+				  "07911326060032F064A9542954",
+				  "Incorrect argv received");
 	}
 
 	atomic_set(&callback_called, 0);

--- a/tests/subsys/pm/device_driver_init/src/main.c
+++ b/tests/subsys/pm/device_driver_init/src/main.c
@@ -33,25 +33,29 @@ ZTEST(device_driver_init, test_device_driver_init)
 	enum pm_device_state state;
 	int rc;
 	state = -1;
-	zassert_equal(strcmp("",  pm_device_state_str(state)), 0, "Invalid device state");
+	zassert_str_equal("", pm_device_state_str(state),
+			  "Invalid device state");
 	/* No device runtime PM, starts on */
 	DEVICE_STATE_IS(DT_NODELABEL(test_reg), PM_DEVICE_STATE_ACTIVE);
 	DEVICE_STATE_IS(DT_NODELABEL(test_reg_chained), PM_DEVICE_STATE_ACTIVE);
 	POWER_GPIO_CONFIG_IS(DT_NODELABEL(test_reg), GPIO_OUTPUT_HIGH);
 	POWER_GPIO_CONFIG_IS(DT_NODELABEL(test_reg_chained), GPIO_OUTPUT_HIGH);
-	zassert_equal(strcmp("active",  pm_device_state_str(state)), 0, "Invalid device state");
+	zassert_str_equal("active", pm_device_state_str(state),
+			  "Invalid device state");
 	/* Device powered, zephyr,pm-device-runtime-auto, starts suspended */
 	DEVICE_STATE_IS(DT_NODELABEL(test_reg_chained_auto), PM_DEVICE_STATE_SUSPENDED);
 	DEVICE_STATE_IS(DT_NODELABEL(test_reg_auto), PM_DEVICE_STATE_SUSPENDED);
 	POWER_GPIO_CONFIG_IS(DT_NODELABEL(test_reg_chained_auto), GPIO_OUTPUT_LOW);
 	POWER_GPIO_CONFIG_IS(DT_NODELABEL(test_reg_auto), GPIO_OUTPUT_LOW);
-	zassert_equal(strcmp("suspended", pm_device_state_str(state)), 0, "Invalid device state");
+	zassert_str_equal("suspended", pm_device_state_str(state),
+			  "Invalid device state");
 	/* Device not powered, starts off */
 	DEVICE_STATE_IS(DT_NODELABEL(test_reg_auto_chained), PM_DEVICE_STATE_OFF);
 	DEVICE_STATE_IS(DT_NODELABEL(test_reg_auto_chained_auto), PM_DEVICE_STATE_OFF);
 	POWER_GPIO_CONFIG_IS(DT_NODELABEL(test_reg_auto_chained), GPIO_DISCONNECTED);
 	POWER_GPIO_CONFIG_IS(DT_NODELABEL(test_reg_auto_chained_auto), GPIO_DISCONNECTED);
-	zassert_equal(strcmp("off",  pm_device_state_str(state)), 0, "Invalid device state");
+	zassert_str_equal("off", pm_device_state_str(state),
+			  "Invalid device state");
 #else
 	/* Every regulator should be in "active" mode automatically.
 	 * State checking via GPIO as PM API is disabled.

--- a/tests/subsys/portability/cmsis_rtos_v2/src/event_flags.c
+++ b/tests/subsys/portability/cmsis_rtos_v2/src/event_flags.c
@@ -81,8 +81,8 @@ void test_event_flags_no_wait_timeout(void)
 		     "Invalid event Flags ID is unexpectedly working!");
 
 	name = osEventFlagsGetName(evt_id);
-	zassert_true(strcmp(event_flags_attrs.name, name) == 0,
-		     "Error getting event_flags object name");
+	zassert_str_equal(event_flags_attrs.name, name,
+			  "Error getting event_flags object name");
 
 	id1 = osThreadNew(thread1, evt_id, &thread1_attr);
 	zassert_true(id1 != NULL, "Failed creating thread1");

--- a/tests/subsys/portability/cmsis_rtos_v2/src/kernel.c
+++ b/tests/subsys/portability/cmsis_rtos_v2/src/kernel.c
@@ -78,7 +78,7 @@ ZTEST(cmsis_kernel, test_kernel_apis)
 	irq_offload(get_version_check, (const void *)&version_irq);
 
 	/* Check if the version value retrieved in ISR and thread is same */
-	zassert_equal(strcmp(version.info, version_irq.info), 0);
+	zassert_str_equal(version.info, version_irq.info);
 	zassert_equal(version.os_info.api, version_irq.os_info.api);
 	zassert_equal(version.os_info.kernel, version_irq.os_info.kernel);
 

--- a/tests/subsys/portability/cmsis_rtos_v2/src/mempool.c
+++ b/tests/subsys/portability/cmsis_rtos_v2/src/mempool.c
@@ -39,8 +39,7 @@ static void mempool_common_tests(osMemoryPoolId_t mp_id,
 		     "Something's wrong with osMemoryPoolGetName!");
 
 	name = osMemoryPoolGetName(mp_id);
-	zassert_true(strcmp(expected_name, name) == 0,
-		     "Error getting mempool name");
+	zassert_str_equal(expected_name, name, "Error getting mempool name");
 
 	zassert_equal(osMemoryPoolGetCapacity(dummy_id), 0,
 		      "Something's wrong with osMemoryPoolGetCapacity!");

--- a/tests/subsys/portability/cmsis_rtos_v2/src/mutex.c
+++ b/tests/subsys/portability/cmsis_rtos_v2/src/mutex.c
@@ -66,8 +66,7 @@ ZTEST(cmsis_mutex, test_mutex)
 	zassert_true(mutex_id != NULL, "Mutex1 creation failed");
 
 	name = osMutexGetName(mutex_id);
-	zassert_true(strcmp(mutex_attr.name, name) == 0,
-		     "Error getting Mutex name");
+	zassert_str_equal(mutex_attr.name, name, "Error getting Mutex name");
 
 	/* Try to release mutex without obtaining it */
 	status = osMutexRelease(mutex_id);

--- a/tests/subsys/portability/cmsis_rtos_v2/src/semaphore.c
+++ b/tests/subsys/portability/cmsis_rtos_v2/src/semaphore.c
@@ -78,8 +78,8 @@ ZTEST(cmsis_semaphore, test_semaphore)
 	zassert_true(semaphore_id != NULL, "semaphore creation failed");
 
 	name = osSemaphoreGetName(semaphore_id);
-	zassert_true(strcmp(sema_attr.name, name) == 0,
-		     "Error getting Semaphore name");
+	zassert_str_equal(sema_attr.name, name,
+			  "Error getting Semaphore name");
 
 	id = osThreadNew(thread_sema, semaphore_id, &thread_attr);
 	zassert_true(id != NULL, "Thread creation failed");

--- a/tests/subsys/portability/cmsis_rtos_v2/src/thread_apis.c
+++ b/tests/subsys/portability/cmsis_rtos_v2/src/thread_apis.c
@@ -46,8 +46,7 @@ static void thread1(void *argument)
 	zassert_true(thread_id != NULL, "Failed getting Thread ID");
 
 	name = osThreadGetName(thread_id);
-	zassert_true(strcmp(args->name, name) == 0,
-		     "Failed getting Thread name");
+	zassert_str_equal(args->name, name, "Failed getting Thread name");
 
 	/* This thread starts off at a high priority (same as thread2) */
 	(*args->yield_check)++;

--- a/tests/subsys/portability/cmsis_rtos_v2/src/timer.c
+++ b/tests/subsys/portability/cmsis_rtos_v2/src/timer.c
@@ -55,8 +55,7 @@ ZTEST(cmsis_timer, test_timer)
 	zassert_true(id1 != NULL, "error creating one-shot timer");
 
 	name = osTimerGetName(id1);
-	zassert_true(strcmp(timer_attr.name, name) == 0,
-		     "Error getting Timer name");
+	zassert_str_equal(timer_attr.name, name, "Error getting Timer name");
 
 	/* Stop the timer before start */
 	status = osTimerStop(id1);

--- a/tests/subsys/settings/fcb/src/settings_test_save_2_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_save_2_fcb.c
@@ -56,8 +56,7 @@ ZTEST(settings_config_fcb, test_config_save_2_fcb)
 	rc = settings_load();
 	zassert_true(rc == 0, "fcb read error");
 	zassert_true(val8 == 42U, "bad value read");
-	zassert_true(!strcmp(val_string[0], test_ref_value[0]),
-		     "bad value read");
+	zassert_str_equal(val_string[0], test_ref_value[0], "bad value read");
 	test_export_block = 1;
 
 	/*

--- a/tests/unit/cbprintf/main.c
+++ b/tests/unit/cbprintf/main.c
@@ -1306,14 +1306,14 @@ ZTEST(prf, test_cbprintf_fsc_package)
 	cbpprintf(fsc_package_cb, &pout, package);
 	*pout = '\0';
 
-	zassert_equal(strcmp(out_str, exp_str1), 0);
+	zassert_str_equal(out_str, exp_str1);
 	zassert_true(strcmp(exp_str0, exp_str1) != 0);
 
 	/* FSC package contains original content. */
 	pout = out_str;
 	cbpprintf(fsc_package_cb, &pout, fsc_package);
 	*pout = '\0';
-	zassert_equal(strcmp(out_str, exp_str0), 0);
+	zassert_str_equal(out_str, exp_str0);
 }
 
 ZTEST(prf, test_cbpprintf)

--- a/tests/unit/util/main.c
+++ b/tests/unit/util/main.c
@@ -14,49 +14,44 @@ ZTEST(util, test_u8_to_dec) {
 
 	len = u8_to_dec(text, sizeof(text), 0);
 	zassert_equal(len, 1, "Length of 0 is not 1");
-	zassert_equal(strcmp(text, "0"), 0,
-		      "Value=0 is not converted to \"0\"");
+	zassert_str_equal(text, "0", "Value=0 is not converted to \"0\"");
 
 	len = u8_to_dec(text, sizeof(text), 1);
 	zassert_equal(len, 1, "Length of 1 is not 1");
-	zassert_equal(strcmp(text, "1"), 0,
-		      "Value=1 is not converted to \"1\"");
+	zassert_str_equal(text, "1", "Value=1 is not converted to \"1\"");
 
 	len = u8_to_dec(text, sizeof(text), 11);
 	zassert_equal(len, 2, "Length of 11 is not 2");
-	zassert_equal(strcmp(text, "11"), 0,
-		      "Value=10 is not converted to \"11\"");
+	zassert_str_equal(text, "11", "Value=10 is not converted to \"11\"");
 
 	len = u8_to_dec(text, sizeof(text), 100);
 	zassert_equal(len, 3, "Length of 100 is not 3");
-	zassert_equal(strcmp(text, "100"), 0,
-		      "Value=100 is not converted to \"100\"");
+	zassert_str_equal(text, "100",
+			  "Value=100 is not converted to \"100\"");
 
 	len = u8_to_dec(text, sizeof(text), 101);
 	zassert_equal(len, 3, "Length of 101 is not 3");
-	zassert_equal(strcmp(text, "101"), 0,
-		      "Value=101 is not converted to \"101\"");
+	zassert_str_equal(text, "101",
+			  "Value=101 is not converted to \"101\"");
 
 	len = u8_to_dec(text, sizeof(text), 255);
 	zassert_equal(len, 3, "Length of 255 is not 3");
-	zassert_equal(strcmp(text, "255"), 0,
-		      "Value=255 is not converted to \"255\"");
+	zassert_str_equal(text, "255",
+			  "Value=255 is not converted to \"255\"");
 
 	memset(text, 0, sizeof(text));
 	len = u8_to_dec(text, 2, 123);
 	zassert_equal(len, 2,
 		      "Length of converted value using 2 byte buffer isn't 2");
-	zassert_equal(
-		strcmp(text, "12"), 0,
-		"Value=123 is not converted to \"12\" using 2-byte buffer");
+	zassert_str_equal(text, "12",
+			  "Value=123 is not converted to \"12\" using 2-byte buffer");
 
 	memset(text, 0, sizeof(text));
 	len = u8_to_dec(text, 1, 123);
 	zassert_equal(len, 1,
 		      "Length of converted value using 1 byte buffer isn't 1");
-	zassert_equal(
-		strcmp(text, "1"), 0,
-		"Value=123 is not converted to \"1\" using 1-byte buffer");
+	zassert_str_equal(text, "1",
+			  "Value=123 is not converted to \"1\" using 1-byte buffer");
 
 	memset(text, 0, sizeof(text));
 	len = u8_to_dec(text, 0, 123);
@@ -419,9 +414,9 @@ ZTEST(util, test_LIST_DROP_EMPTY) {
 	};
 
 	zassert_equal(ARRAY_SIZE(arr), 3, "Failed to cleanup list");
-	zassert_equal(strcmp(arr[0], "Henry"), 0, "Failed at 0");
-	zassert_equal(strcmp(arr[1], "Dorsett"), 0, "Failed at 1");
-	zassert_equal(strcmp(arr[2], "Case"), 0, "Failed at 0");
+	zassert_str_equal(arr[0], "Henry", "Failed at 0");
+	zassert_str_equal(arr[1], "Dorsett", "Failed at 1");
+	zassert_str_equal(arr[2], "Case", "Failed at 0");
 }
 
 ZTEST(util, test_nested_FOR_EACH) {


### PR DESCRIPTION
ztest now provides functionality to compare strings.
These are simpler to use than the strcmp ways.

This PR adds and applies a semantic patch to transforms many of the commonly used patterns.
It does not handle variable length macros.