### PR TITLE
nordic: dts: Fix grtc interrupt line for secure nRF54L

### DIFF
--- a/dts/arm/nordic/nrf54l15_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf54l15_cpuapp.dtsi
@@ -35,8 +35,12 @@ cpuflpr_vevif: &cpuflpr_vevif_remote {};
 };
 
 &grtc {
+#ifdef USE_NON_SECURE_ADDRESS_MAP
+	interrupts = <227 NRF_DEFAULT_IRQ_PRIORITY>,
+#else
 	interrupts = <228 NRF_DEFAULT_IRQ_PRIORITY>,
-			<229 NRF_DEFAULT_IRQ_PRIORITY>; /* reserved for Zero Latency IRQs */
+#endif
+		<229 NRF_DEFAULT_IRQ_PRIORITY>; /* reserved for Zero Latency IRQs */
 };
 
 &gpiote20 {


### PR DESCRIPTION
When TF-M is used, zephyr must use a different interrupt line for GRTC.