### PR TITLE
ci: doc: Improve handling of Doxygen warnings

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -253,7 +253,7 @@ jobs:
         fi
 
         DOC_TAG=${DOC_TAG} \
-        SPHINXOPTS="-q -j ${JOB_COUNT}" \
+        SPHINXOPTS="-q -j ${JOB_COUNT} -W" \
         LATEXMKOPTS="-quiet -halt-on-error" \
         make -C doc pdf
 

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -17,7 +17,6 @@ env:
   # The latest CMake available directly with apt is 3.18, but we need >=3.20
   # so we fetch that through pip.
   CMAKE_VERSION: 3.20.5
-  DOXYGEN_VERSION: 1.9.6
   # Job count is set to 2 less than the vCPU count of 16 because the total available RAM is 32GiB
   # and each sphinx-build process may use more than 2GiB of RAM.
   JOB_COUNT: 14
@@ -79,10 +78,7 @@ jobs:
     - name: install-pkgs
       run: |
         sudo apt-get update
-        sudo apt-get install -y wget python3-pip git ninja-build graphviz lcov
-        wget --no-verbose "https://github.com/doxygen/doxygen/releases/download/Release_${DOXYGEN_VERSION//./_}/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz"
-        sudo tar xf doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz -C /opt
-        echo "/opt/doxygen-${DOXYGEN_VERSION}/bin" >> $GITHUB_PATH
+        sudo apt-get install -y wget python3-pip git ninja-build doxygen graphviz lcov
         echo "${HOME}/.local/bin" >> $GITHUB_PATH
 
     - name: checkout

--- a/doc/known-warnings.txt
+++ b/doc/known-warnings.txt
@@ -22,3 +22,8 @@
 .*Duplicate C declaration.*\n.*'\.\. c:.*:: .*struct in_addr.*'.*
 .*Duplicate C declaration.*\n.*'\.\. c:.*:: .*struct in6_addr.*'.*
 .*Duplicate C declaration.*\n.*'\.\. c:.*:: .*struct net_if.*'.*
+
+# As of Doxygen 1.9.7, anonymous unions/structs don't have an auto-generated
+# name anymore, causing issues with Breathe
+.*Invalid C declaration: Expected identifier in nested name.*\n.*\n.*\^.*
+.*Error in declarator or parameters\nInvalid C declaration: Expected identifier in nested name.*\n.*.*\n.*\^.*

--- a/include/zephyr/bluetooth/classic/a2dp.h
+++ b/include/zephyr/bluetooth/classic/a2dp.h
@@ -65,6 +65,7 @@ BT_A2DP_EP_INIT(BT_AVDTP_SOURCE, _codec, _capability)
  * SBC is mandatory as a2dp specification, BT_A2DP_SBC_SINK_EP_DEFAULT
  * is more convenient for user to register SBC endpoint.
  *
+ *  @param _name the endpoint variable name.
  *  @param _freq sbc codec frequency.
  *               for example: A2DP_SBC_SAMP_FREQ_44100 | A2DP_SBC_SAMP_FREQ_48000
  *  @param _ch_mode sbc codec channel mode.
@@ -151,6 +152,7 @@ static struct bt_a2dp_ep _name = BT_A2DP_SOURCE_EP_INIT(BT_A2DP_SBC,\
 
 /** @brief define the SBC default configuration.
  *
+ *  @param _name the endpoint configuration variable name.
  *  @param _freq_cfg sbc codec frequency.
  *               for example: A2DP_SBC_SAMP_FREQ_44100
  *  @param _ch_mode_cfg sbc codec channel mode.
@@ -173,6 +175,7 @@ struct bt_a2dp_codec_cfg _name = {.codec_config = &bt_a2dp_codec_ie##_name,}
 
 /** @brief define the SBC default configuration.
  *
+ *  @param _name the endpoint configuration variable name.
  *  @param _freq_cfg the frequency to configure the remote same codec type endpoint.
  */
 #define BT_A2DP_SBC_EP_CFG_DEFAULT(_name, _freq_cfg)\

--- a/include/zephyr/tracing/tracing.h
+++ b/include/zephyr/tracing/tracing.h
@@ -1764,13 +1764,15 @@
 
 /**
  * @brief Trace System heap realloc enter
- * @param heap
+ * @param heap Heap object
+ * @param ptr Pointer to reallocate
  */
 #define sys_port_trace_k_heap_sys_k_realloc_enter(heap, ptr)
 
 /**
  * @brief Trace System heap realloc exit
  * @param heap Heap object
+ * @param ptr Pointer to reallocate
  * @param ret Return value
  */
 #define sys_port_trace_k_heap_sys_k_realloc_exit(heap, ptr, ret)


### PR DESCRIPTION
* Re-introduce "fail on warning" behaviour in CI, fixes #72605
* Since recent (1.9.7 and later) Doxygen versions cause additional Breathe warnings, and since it's expected many developers will likely run such a recent version on their machine if they [followed our documentation](https://docs.zephyrproject.org/latest/contribute/documentation/generation.html#zephyr-doc), CI job has been updated to use APT-provided version of Doxygen in CI (note that latex/pdf build was already doing so), and the warning filters have been added to known-warnings.txt