### PR TITLE
doc: develop: tools: Exclude webp images from PDF

### DIFF
--- a/doc/develop/tools/clion.rst
+++ b/doc/develop/tools/clion.rst
@@ -58,10 +58,12 @@ not happen, go to :menuselection:`Settings --> Build, Execution, Deployment --> 
 #. Click :menuselection:`Add environment --> From file` and select
    ``..\.venv\Scripts\activate.bat``.
 
-   .. figure:: img/clion_toolchain_mingw.webp
-      :width: 600px
-      :align: center
-      :alt: MinGW toolchain with environment script
+   .. only:: html
+
+      .. figure:: img/clion_toolchain_mingw.webp
+         :width: 600px
+         :align: center
+         :alt: MinGW toolchain with environment script
 
    Click :guilabel:`Apply` to save the changes.
 
@@ -72,10 +74,12 @@ not happen, go to :menuselection:`Settings --> Build, Execution, Deployment --> 
 
       -DBOARD=nrf52840dk/nrf52840
 
-   .. figure:: img/clion_cmakeprofile.webp
-      :width: 600px
-      :align: center
-      :alt: CMake profile
+   .. only:: html
+
+      .. figure:: img/clion_cmakeprofile.webp
+         :width: 600px
+         :align: center
+         :alt: CMake profile
 
 #. Click :guilabel:`Apply` to save the changes.
 
@@ -166,17 +170,21 @@ your setup is different, make sure to adjust the configuration settings accordin
         * - :guilabel:`TCP/IP port`
           - Auto
 
-    .. figure:: img/clion_gdbserverconfig.webp
-       :width: 500px
-       :align: center
-       :alt: Embedded GDB server configuration
+   .. only:: html
+
+      .. figure:: img/clion_gdbserverconfig.webp
+         :width: 500px
+         :align: center
+         :alt: Embedded GDB server configuration
 
 #. Click :guilabel:`Next` to set the Segger J-Link parameters.
 
-    .. figure:: img/clion_segger_settings.webp
-       :width: 500px
-       :align: center
-       :alt: Segger J-Link parameters
+   .. only:: html
+
+      .. figure:: img/clion_segger_settings.webp
+         :width: 500px
+         :align: center
+         :alt: Segger J-Link parameters
 
 #. Click :guilabel:`Create` when ready.
 
@@ -193,10 +201,12 @@ Start debugging
    Zephyr tasks are listed in the :guilabel:`Threads & Variables` pane. You can switch between them
    and inspect the variables for each task.
 
-    .. figure:: img/clion_debug_threads.webp
-       :width: 800px
-       :align: center
-       :alt: Viewing Zephyr tasks during a debug session
+   .. only:: html
+
+      .. figure:: img/clion_debug_threads.webp
+         :width: 800px
+         :align: center
+         :alt: Viewing Zephyr tasks during a debug session
 
    Refer to `CLion web help`_ for detailed description of the IDE debug capabilities.
 


### PR DESCRIPTION
Until Sphinx 7.4.0 is out, it's not possible to use .webp in Latex/PDF See https://github.com/sphinx-doc/sphinx/pull/12224

This fix is needed to have a working PDF for 3.7 and is a temporary workaround for #70990

Tested locally and PDF builds successfully.