### PR TITLE
west: percepio: update module

### DIFF
--- a/modules/percepio/CMakeLists.txt
+++ b/modules/percepio/CMakeLists.txt
@@ -73,6 +73,17 @@ if(CONFIG_PERCEPIO_TRACERECORDER)
     )
   endif()
 
+  if(CONFIG_PERCEPIO_TRC_CFG_STREAM_PORT_FILE)
+    zephyr_library_sources(
+      ${TRACERECORDER_DIR}/streamports/File/trcStreamPort.c
+    )
+
+    zephyr_include_directories(
+      ${TRACERECORDER_DIR}/kernelports/Zephyr/streamports/File/config/
+      ${TRACERECORDER_DIR}/streamports/File/include/
+    )
+  endif()
+
   if (CONFIG_PERCEPIO_TRC_CFG_STREAM_PORT_ZEPHYR_SEMIHOST)
     zephyr_library_sources(
       ${TRACERECORDER_DIR}/kernelports/Zephyr/streamports/Semihost/trcStreamPort.c

--- a/west.yml
+++ b/west.yml
@@ -310,7 +310,7 @@ manifest:
       path: modules/lib/openthread
     - name: percepio
       path: modules/debug/percepio
-      revision: 99ffb4bbe87e3ef0866c51f9a7dcd8bccd36c8f3
+      revision: 1a67f3e2dbc2a8d53e5248d72bac946db381692d
       groups:
         - debug
     - name: picolibc

--- a/west.yml
+++ b/west.yml
@@ -310,7 +310,7 @@ manifest:
       path: modules/lib/openthread
     - name: percepio
       path: modules/debug/percepio
-      revision: 7f6fb3f12ea1493a2f8ab6a876fb255a39db47c8
+      revision: 99ffb4bbe87e3ef0866c51f9a7dcd8bccd36c8f3
       groups:
         - debug
     - name: picolibc


### PR DESCRIPTION
Update the percepio module to use TraceRecorder v4.9.1.hotfix1

Signed-off-by: Erik Tamlin [erik.tamlin@percepio.com](mailto:erik.tamlin@percepio.com)
