### PR TITLE
net: dhcpv4: Reimplement RENEW/REBIND logic according to RFC2131

### DIFF
--- a/subsys/net/lib/dhcpv4/dhcpv4_internal.h
+++ b/subsys/net/lib/dhcpv4/dhcpv4_internal.h
@@ -86,13 +86,7 @@ struct dhcp_msg {
 					 DHCPV4_OLV_END_SIZE)
 
 
-/* TODO:
- * 1) Support T2(Rebind) timer.
- */
-
-/* Maximum number of REQUEST or RENEWAL retransmits before reverting
- * to DISCOVER.
- */
+/* Maximum number of REQUEST retransmits before reverting to DISCOVER. */
 #define DHCPV4_MAX_NUMBER_OF_ATTEMPTS	3
 
 /* Initial message retry timeout (s).  This timeout increases
@@ -108,6 +102,11 @@ struct dhcp_msg {
  * RFC2131 4.1.1
  */
 #define DHCPV4_INITIAL_DELAY_MIN 1
+
+/* Minimum retransmission timeout in RENEW and REBIND states (in seconds).
+ * RFC2131 4.4.5
+ */
+#define DHCPV4_RENEW_REBIND_TIMEOUT_MIN 60
 
 #if defined(CONFIG_NET_DHCPV4)
 


### PR DESCRIPTION
DHCP Request retransmission in RENEW and REBIND states was not compliant with RFC2131.

The retransmission interval should not be calculated as in REQUESTING state in such case, but rather calculated based on the remaining T2 or lease time (depending on current state).

RFC doesn't also mention any retransmission count limit for those states. The client should retransmit the Request until T2 or lease expiry time is reached.