### PR TITLE
arch: arm: Fix missing include for sys_define_gpr_with_alias

### DIFF
--- a/include/zephyr/arch/arm/arch.h
+++ b/include/zephyr/arch/arm/arch.h
@@ -19,9 +19,6 @@
 /* Add include for DTS generated information */
 #include <zephyr/devicetree.h>
 
-/* ARM GPRs are often designated by two different names */
-#define sys_define_gpr_with_alias(name1, name2) union { uint32_t name1, name2; }
-
 #include <zephyr/arch/arm/thread.h>
 #include <zephyr/arch/arm/exception.h>
 #include <zephyr/arch/arm/irq.h>

--- a/include/zephyr/arch/arm/cortex_a_r/exception.h
+++ b/include/zephyr/arch/arm/cortex_a_r/exception.h
@@ -54,6 +54,9 @@ struct __extra_esf_info {
 };
 #endif /* CONFIG_EXTRA_EXCEPTION_INFO */
 
+/* ARM GPRs are often designated by two different names */
+#define sys_define_gpr_with_alias(name1, name2) union { uint32_t name1, name2; }
+
 struct arch_esf {
 #if defined(CONFIG_EXTRA_EXCEPTION_INFO)
 	struct __extra_esf_info extra_info;

--- a/include/zephyr/arch/arm/cortex_m/exception.h
+++ b/include/zephyr/arch/arm/cortex_m/exception.h
@@ -98,6 +98,9 @@ struct __extra_esf_info {
 };
 #endif /* CONFIG_EXTRA_EXCEPTION_INFO */
 
+/* ARM GPRs are often designated by two different names */
+#define sys_define_gpr_with_alias(name1, name2) union { uint32_t name1, name2; }
+
 struct arch_esf {
 	struct __basic_sf {
 		sys_define_gpr_with_alias(a1, r0);


### PR DESCRIPTION
The sys_define_gpr_with_alias macro was defined by arch.h, but was used by the two exception.h files that did not include it.

Attempting to include arch.h from exception.h would resolve in a recursive include, so the macro was simply moved to the files that used it.

An alternative could have been to define a new file that defined it, that could have been included by exception.h