### PR TITLE
doc: kernel: do not start doxygen comment with #

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -4865,7 +4865,7 @@ void k_mbox_data_get(struct k_mbox_msg *rx_msg, void *buffer);
 struct k_pipe {
 	unsigned char *buffer;          /**< Pipe buffer: may be NULL */
 	size_t         size;            /**< Buffer size */
-	size_t         bytes_used;      /**< # bytes used in buffer */
+	size_t         bytes_used;      /**< Number of bytes used in buffer */
 	size_t         read_index;      /**< Where in buffer to read from */
 	size_t         write_index;     /**< Where in buffer to write */
 	struct k_spinlock lock;		/**< Synchronization lock */


### PR DESCRIPTION
Comment starting with "#" was causing incorrect rendering (as well as LaTeX warnings)

![image](https://github.com/zephyrproject-rtos/zephyr/assets/128251/37b9c0b5-e7c8-4e8b-8d41-322dc7e6ca7f)
