### PR TITLE
NXP RW6xx: Add additional support to Wakeup from low power modes

### DIFF
--- a/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
+++ b/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
@@ -282,3 +282,8 @@ zephyr_udc0: &usb_otg {
 	status = "okay";
 	wakeup-source;
 };
+
+&pin1 {
+	status = "okay";
+	wakeup-level = "low";
+};

--- a/dts/arm/nxp/nxp_rw6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rw6xx_common.dtsi
@@ -147,6 +147,16 @@
 	pmu: pmu@31000 {
 		reg = <0x31000 0x130>;
 		compatible = "nxp,rw-pmu";
+		pin0: pin0 {
+			compatible = "nxp,aon-wakeup-pin";
+			interrupts = <100 0>;
+			status = "disabled";
+		};
+		pin1: pin1 {
+			compatible = "nxp,aon-wakeup-pin";
+			interrupts = <101 0>;
+			status = "disabled";
+		};
 	};
 
 	trng: random@14000 {

--- a/dts/bindings/power/nxp,aon-wakeup-pin.yaml
+++ b/dts/bindings/power/nxp,aon-wakeup-pin.yaml
@@ -1,0 +1,24 @@
+# Copyright 2024, NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: Some NXP SoC's have pins dedicated to generate a wakeup interrupt.
+
+compatible: "nxp,aon-wakeup-pin"
+
+include: base.yaml
+
+properties:
+  interrupts:
+    type: array
+    required: true
+    description: Interrupt to wakeup the SoC from low power modes.
+
+  wakeup-level:
+    type: string
+    enum:
+      - "low"
+      - "high"
+    default: "high"
+    description: |
+        Wakeup level on the pin, default is wakeup on high level
+        which is the reset value.

--- a/soc/nxp/rw/power.c
+++ b/soc/nxp/rw/power.c
@@ -6,6 +6,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/pm/pm.h>
 #include <zephyr/init.h>
+#include <zephyr/drivers/pinctrl.h>
 
 #include "fsl_power.h"
 
@@ -27,10 +28,57 @@ LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
 power_sleep_config_t slp_cfg;
 
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(pin0), okay) || DT_NODE_HAS_STATUS(DT_NODELABEL(pin1), okay)
+pinctrl_soc_pin_t pin_cfg;
+#endif
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(pin0), okay)
+static void pin0_isr(const struct device *dev)
+{
+	uint8_t level = ~(DT_ENUM_IDX(DT_NODELABEL(pin0), wakeup_level)) & 0x1;
+
+	POWER_ConfigWakeupPin(kPOWER_WakeupPin0, level);
+	NVIC_ClearPendingIRQ(DT_IRQN(DT_NODELABEL(pin0)));
+	DisableIRQ(DT_IRQN(DT_NODELABEL(pin0)));
+	POWER_DisableWakeup(DT_IRQN(DT_NODELABEL(pin0)));
+}
+#endif
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(pin1), okay)
+static void pin1_isr(const struct device *dev)
+{
+	uint8_t level = ~(DT_ENUM_IDX(DT_NODELABEL(pin1), wakeup_level)) & 0x1;
+
+	POWER_ConfigWakeupPin(kPOWER_WakeupPin1, level);
+	NVIC_ClearPendingIRQ(DT_IRQN(DT_NODELABEL(pin1)));
+	DisableIRQ(DT_IRQN(DT_NODELABEL(pin1)));
+	POWER_DisableWakeup(DT_IRQN(DT_NODELABEL(pin1)));
+}
+#endif
+
 /* Invoke Low Power/System Off specific Tasks */
 __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 {
 	ARG_UNUSED(substate_id);
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(pin0), okay)
+	pin_cfg = IOMUX_GPIO_IDX(24) | IOMUX_TYPE(IOMUX_GPIO);
+	pinctrl_configure_pins(&pin_cfg, 1, 0);
+	POWER_ConfigWakeupPin(kPOWER_WakeupPin0, DT_ENUM_IDX(DT_NODELABEL(pin0), wakeup_level));
+	POWER_ClearWakeupStatus(DT_IRQN(DT_NODELABEL(pin0)));
+	NVIC_ClearPendingIRQ(DT_IRQN(DT_NODELABEL(pin0)));
+	EnableIRQ(DT_IRQN(DT_NODELABEL(pin0)));
+	POWER_EnableWakeup(DT_IRQN(DT_NODELABEL(pin0)));
+#endif
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(pin1), okay)
+	pin_cfg = IOMUX_GPIO_IDX(25) | IOMUX_TYPE(IOMUX_GPIO);
+	pinctrl_configure_pins(&pin_cfg, 1, 0);
+	POWER_ConfigWakeupPin(kPOWER_WakeupPin1, DT_ENUM_IDX(DT_NODELABEL(pin1), wakeup_level));
+	POWER_ClearWakeupStatus(DT_IRQN(DT_NODELABEL(pin1)));
+	NVIC_ClearPendingIRQ(DT_IRQN(DT_NODELABEL(pin1)));
+	EnableIRQ(DT_IRQN(DT_NODELABEL(pin1)));
+	POWER_EnableWakeup(DT_IRQN(DT_NODELABEL(pin1)));
+#endif
 
 	/* Set PRIMASK */
 	__disable_irq();
@@ -70,6 +118,30 @@ static int nxp_rw6xx_power_init(void)
 	slp_cfg.clkGate = suspend_sleepconfig[2];
 	slp_cfg.memPdCfg = suspend_sleepconfig[3];
 	slp_cfg.pm3BuckCfg = suspend_sleepconfig[4];
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(pin0), okay)
+	/* PIN 0 uses GPIO0_24, confiure the pin as GPIO */
+	pin_cfg = IOMUX_GPIO_IDX(24) | IOMUX_TYPE(IOMUX_GPIO);
+	pinctrl_configure_pins(&pin_cfg, 1, 0);
+
+	/* Initialize the settings in the PMU for this wakeup interrupt */
+	pin0_isr(NULL);
+
+	IRQ_CONNECT(DT_IRQN(DT_NODELABEL(pin0)), DT_IRQ(DT_NODELABEL(pin0), priority), pin0_isr,
+		    NULL, 0);
+#endif
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(pin1), okay)
+	/* PIN 1 uses GPIO0_25, confiure the pin as GPIO */
+	pin_cfg = IOMUX_GPIO_IDX(25) | IOMUX_TYPE(IOMUX_GPIO);
+	pinctrl_configure_pins(&pin_cfg, 1, 0);
+
+	/* Initialize the settings in the PMU for this wakeup interrupt */
+	pin1_isr(NULL);
+
+	IRQ_CONNECT(DT_IRQN(DT_NODELABEL(pin1)), DT_IRQ(DT_NODELABEL(pin1), priority), pin1_isr,
+		    NULL, 0);
+#endif
 
 	return 0;
 }


### PR DESCRIPTION
This SoC has an external pin interrupt that can be used to wakeup from low power modes.