### PR TITLE
posix: allow for external implementation of option groups

### DIFF
--- a/lib/posix/options/CMakeLists.txt
+++ b/lib/posix/options/CMakeLists.txt
@@ -35,55 +35,109 @@ endif()
 
 zephyr_library()
 zephyr_library_sources_ifdef(CONFIG_EVENTFD eventfd.c)
-zephyr_library_sources_ifdef(CONFIG_POSIX_ASYNCHRONOUS_IO aio.c)
-zephyr_library_sources_ifdef(CONFIG_POSIX_BARRIERS barrier.c)
-zephyr_library_sources_ifdef(CONFIG_POSIX_C_LIB_EXT
-  fnmatch.c
-  getentropy.c
-  getopt/getopt.c
-  getopt/getopt_common.c
-)
-zephyr_library_sources_ifdef(CONFIG_POSIX_DEVICE_IO
-  # perror should be moved to the common libc
-  perror.c
-  device_io.c
-)
-zephyr_library_sources_ifdef(CONFIG_POSIX_FD_MGMT
-  fd_mgmt.c
-)
-zephyr_library_sources_ifdef(CONFIG_POSIX_FILE_SYSTEM fs.c)
+
+if (not(CONFIG_TC_PROVIDES_POSIX_ASYNCHRONOUS_IO))
+  zephyr_library_sources_ifdef(CONFIG_POSIX_ASYNCHRONOUS_IO aio.c)
+endif()
+
+if (not(CONFIG_TC_PROVIDES_POSIX_BARRIERS))
+  zephyr_library_sources_ifdef(CONFIG_POSIX_BARRIERS barrier.c)
+endif()
+
+if (not(CONFIG_TC_PROVIDES_POSIX_C_LIB_EXT))
+  zephyr_library_sources_ifdef(CONFIG_POSIX_C_LIB_EXT
+    fnmatch.c
+    getentropy.c
+    getopt/getopt.c
+    getopt/getopt_common.c
+  )
+endif()
+
+if (not(CONFIG_TC_PROVIDES_POSIX_DEVICE_IO))
+  zephyr_library_sources_ifdef(CONFIG_POSIX_DEVICE_IO
+    # perror should be moved to the common libc
+    perror.c
+    device_io.c
+  )
+endif()
+
+if (not(CONFIG_TC_PROVIDES_POSIX_FD_MGMT))
+  zephyr_library_sources_ifdef(CONFIG_POSIX_FD_MGMT
+    fd_mgmt.c
+  )
+endif()
+
+if (not(CONFIG_TC_PROVIDES_POSIX_FILE_SYSTEM))
+  zephyr_library_sources_ifdef(CONFIG_POSIX_FILE_SYSTEM fs.c)
+endif()
+
 zephyr_library_sources_ifdef(CONFIG_POSIX_FSYNC fsync.c)
 zephyr_library_sources_ifdef(CONFIG_POSIX_MESSAGE_PASSING mqueue.c)
-zephyr_library_sources_ifdef(CONFIG_POSIX_MULTI_PROCESS
-  sleep.c
-  multi_process.c
-)
-zephyr_library_sources_ifdef(CONFIG_POSIX_NETWORKING net.c)
-zephyr_library_sources_ifdef(CONFIG_POSIX_SIGNALS signal.c ${STRSIGNAL_TABLE_H})
-zephyr_library_sources_ifdef(CONFIG_POSIX_SINGLE_PROCESS
-  confstr.c
-  env.c
-  sysconf.c
-  uname.c
-)
-zephyr_library_sources_ifdef(CONFIG_POSIX_SPIN_LOCKS spinlock.c)
-zephyr_library_sources_ifdef(CONFIG_POSIX_SYSLOG syslog.c)
-zephyr_library_sources_ifdef(CONFIG_POSIX_TIMERS
-  clock.c
-  timer.c
-  timespec_to_timeout.c
-)
+
+if (not(CONFIG_TC_PROVIDES_POSIX_MULTI_PROCESS))
+  zephyr_library_sources_ifdef(CONFIG_POSIX_MULTI_PROCESS
+    sleep.c
+    multi_process.c
+  )
+endif()
+
+if (not(CONFIG_TC_PROVIDES_POSIX_NETWORKING))
+  zephyr_library_sources_ifdef(CONFIG_POSIX_NETWORKING net.c)
+endif()
+
+if (not(CONFIG_TC_PROVIDES_POSIX_SIGNALS))
+  zephyr_library_sources_ifdef(CONFIG_POSIX_SIGNALS signal.c ${STRSIGNAL_TABLE_H})
+endif()
+
+if (not(CONFIG_TC_PROVIDES_POSIX_SINGLE_PROCESS))
+  zephyr_library_sources_ifdef(CONFIG_POSIX_SINGLE_PROCESS
+    confstr.c
+    env.c
+    sysconf.c
+    uname.c
+  )
+endif()
+
+if (not(CONFIG_TC_PROVIDES_POSIX_SPIN_LOCKS))
+  zephyr_library_sources_ifdef(CONFIG_POSIX_SPIN_LOCKS spinlock.c)
+endif()
+
+if (not(CONFIG_TC_PROVIDES_POSIX_TIMERS))
+  zephyr_library_sources_ifdef(CONFIG_POSIX_TIMERS
+    clock.c
+    timer.c
+    timespec_to_timeout.c
+  )
+endif()
+
 zephyr_library_sources_ifdef(CONFIG_POSIX_PRIORITY_SCHEDULING sched.c)
-zephyr_library_sources_ifdef(CONFIG_POSIX_READER_WRITER_LOCKS rwlock.c)
-zephyr_library_sources_ifdef(CONFIG_POSIX_SEMAPHORES semaphore.c)
-zephyr_library_sources_ifdef(CONFIG_POSIX_THREADS
-  cond.c
-  key.c
-  mutex.c
-  pthread.c
-)
+
+if (not(CONFIG_TC_PROVIDES_POSIX_READER_WRITER_LOCKS))
+  # Note: the Option is _POSIX_READER_WRITER_LOCKS, while the Option Group is POSIX_RW_LOCKS.
+  # We have opted to use POSIX_READER_WRITER_LOCKS here to match the Option name.
+  zephyr_library_sources_ifdef(CONFIG_POSIX_READER_WRITER_LOCKS rwlock.c)
+endif()
+
+if (not(CONFIG_TC_PROVIDES_POSIX_SEMAPHORES))
+  zephyr_library_sources_ifdef(CONFIG_POSIX_SEMAPHORES semaphore.c)
+endif()
+
+if (not(CONFIG_TC_PROVIDES_POSIX_THREADS))
+  # Note: the Option is _POSIX_THREADS, while the Option Group is POSIX_THREADS_BASE.
+  # We have opted to use POSIX_THREADS here to match the Option name.
+  zephyr_library_sources_ifdef(CONFIG_POSIX_THREADS
+    cond.c
+    key.c
+    mutex.c
+    pthread.c
+  )
+endif()
+
 zephyr_library_sources_ifdef(CONFIG_XOPEN_STREAMS stropts.c)
-zephyr_library_sources_ifdef(CONFIG_XSI_SYSTEM_LOGGING syslog.c)
+
+if (not(CONFIG_TC_PROVIDES_XSI_SYSTEM_LOGGING))
+  zephyr_library_sources_ifdef(CONFIG_XSI_SYSTEM_LOGGING syslog.c)
+endif()
 
 zephyr_library_sources_ifdef(CONFIG_GETOPT_LONG
   getopt/getopt_long.c

--- a/lib/posix/options/Kconfig
+++ b/lib/posix/options/Kconfig
@@ -33,4 +33,6 @@ rsource "Kconfig.compat"
 
 rsource "Kconfig.deprecated"
 
+rsource "Kconfig.toolchain"
+
 endmenu # "POSIX Options"

--- a/lib/posix/options/Kconfig.toolchain
+++ b/lib/posix/options/Kconfig.toolchain
@@ -1,0 +1,267 @@
+# Copyright (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# External toolchains (i.e. C libraries) may provide implementations of POSIX features at the
+# granularity of Option Groups. This granularity was chosen to maximize the liklihood that
+# implementations are internally and externally consistent. It might be possible to extend
+# this to individual POSIX Options on a case-by-case basis.
+#
+# If an external toolchain provides a POSIX Option Group, it should use Kconfig to
+# select a non-user-configurable Kconfig option corresponding to the POSIX Option Group.
+#
+# For example, if Zephyr provides POSIX_SPIN_LOCKS, then the (existing, user-selectable) Kconfig
+# option CONFIG_POSIX_SPIN_LOCKS should be used. This will enable the corresponding
+# _POSIX_SPIN_LOCKS feature test macro in features.h and will ensure that sysconf(_SC_SPIN_LOCKS)
+# returns the correct value. It will enable spinlock.c to be compiled by CMake, etc.
+#
+# On the other hand, when an external toolchain provides POSIX_SPIN_LOCKS, the user still selects
+# CONFIG_POSIX_SPIN_LOCKS, but the toolchain's Kconfig file should specify
+#
+# select TC_PROVIDES_POSIX_SPIN_LOCKS
+#
+# This will effectively bypass the part in CMake where the compiler is instructed to build and
+# link Zephyr's internal implementation of POSIX spinlocks.
+#
+# Note: this requires that external toolchains provide a plain symbol in the global C namespace
+# for the functions that they should implement and not rely on macrobatics to map standard symbol
+# names other values. If a preceding underscore is required for the symbol name, as is the case
+# with many Newlib symbols, then the appropriate, non-user-configurable Kconfig option should also
+# be selected by the toolchain. For example,
+#
+# select POSIX_FD_MGMT_ALIAS_FCNTL
+#
+# Please note, that this mechanism is provided primarily for toolchain integrators. Users should
+# generally not need to interact with these options directly. These options are not supported as
+# part of the POSIX API.
+#
+# Also note, that any unexpected, unwanted, or undefined behaviour resulting from use of these
+# options is not the responsibility of the Zephyr project or its members.
+
+# The following list of Kconfig options are based on standard POSIX Subprofiling Option Groups
+# and may be used by external toolchains to override Zephyr's internal POSIX implementations.
+#
+# https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_subprofiles.html
+
+config TC_PROVIDES_POSIX_ASYNCHRONOUS_IO
+	bool
+
+config TC_PROVIDES_POSIX_BARRIERS
+	bool
+
+config TC_PROVIDES_POSIX_C_LANG_JUMP
+	bool
+
+config TC_PROVIDES_POSIX_C_LANG_MATH
+	bool
+
+config TC_PROVIDES_POSIX_C_LANG_SUPPORT
+	bool
+
+config TC_PROVIDES_POSIX_C_LANG_SUPPORT_R
+	bool
+
+config TC_PROVIDES_POSIX_C_LANG_WIDE_CHAR
+	bool
+
+config TC_PROVIDES_POSIX_C_LANG_WIDE_CHAR_EXT
+	bool
+
+config TC_PROVIDES_POSIX_C_LIB_EXT
+	bool
+
+config TC_PROVIDES_POSIX_CLOCK_SELECTION
+	bool
+
+config TC_PROVIDES_POSIX_DEVICE_IO
+	bool
+
+config TC_PROVIDES_POSIX_DEVICE_IO_EXT
+	bool
+
+config TC_PROVIDES_POSIX_DEVICE_SPECIFIC
+	bool
+
+config TC_PROVIDES_POSIX_DEVICE_SPECIFIC_R
+	bool
+
+config TC_PROVIDES_POSIX_DYNAMIC_LINKING
+	bool
+
+config TC_PROVIDES_POSIX_FD_MGMT
+	bool
+
+config TC_PROVIDES_POSIX_FIFO
+	bool
+
+config TC_PROVIDES_POSIX_FIFO_FD
+	bool
+
+config TC_PROVIDES_POSIX_FILE_ATTRIBUTES
+	bool
+
+config TC_PROVIDES_POSIX_FILE_ATTRIBUTES_FD
+	bool
+
+config TC_PROVIDES_POSIX_FILE_LOCKING
+	bool
+
+config TC_PROVIDES_POSIX_FILE_SYSTEM
+	bool
+
+config TC_PROVIDES_POSIX_FILE_SYSTEM_EXT
+	bool
+
+config TC_PROVIDES_POSIX_FILE_SYSTEM_FD
+	bool
+
+config TC_PROVIDES_POSIX_FILE_SYSTEM_GLOB
+	bool
+
+config TC_PROVIDES_POSIX_FILE_SYSTEM_R
+	bool
+
+config TC_PROVIDES_POSIX_I18N
+	bool
+
+config TC_PROVIDES_POSIX_JOB_CONTROL
+	bool
+
+config TC_PROVIDES_POSIX_MAPPED_FILES
+	bool
+
+config TC_PROVIDES_POSIX_MEMORY_PROTECTION
+	bool
+
+config TC_PROVIDES_POSIX_MULTI_CONCURRENT_LOCALES
+	bool
+
+config TC_PROVIDES_POSIX_MULTI_PROCESS
+	bool
+
+config TC_PROVIDES_POSIX_MULTI_PROCESS_FD
+	bool
+
+config TC_PROVIDES_POSIX_NETWORKING
+	bool
+
+config TC_PROVIDES_POSIX_PIPE
+	bool
+
+config TC_PROVIDES_POSIX_ROBUST_MUTEXES
+	bool
+
+config TC_PROVIDES_POSIX_REALTIME_SIGNALS
+	bool
+
+config TC_PROVIDES_POSIX_REGEXP
+	bool
+
+# Note: the Option is _POSIX_READER_WRITER_LOCKS, while the Option Group is POSIX_RW_LOCKS
+# We have opted to use POSIX_READER_WRITER_LOCKS here to match the Option name.
+config TC_PROVIDES_POSIX_READER_WRITER_LOCKS
+	bool
+
+config TC_PROVIDES_POSIX_SEMAPHORES
+	bool
+
+config TC_PROVIDES_POSIX_SHELL_FUNC
+	bool
+
+config TC_PROVIDES_POSIX_SIGNAL_JUMP
+	bool
+
+config TC_PROVIDES_POSIX_SIGNALS
+	bool
+
+config TC_PROVIDES_POSIX_SIGNALS_EXT
+	bool
+
+config TC_PROVIDES_POSIX_SINGLE_PROCESS
+	bool
+
+config TC_PROVIDES_POSIX_SPIN_LOCKS
+	bool
+
+config TC_PROVIDES_POSIX_SYMBOLIC_LINKS
+	bool
+
+config TC_PROVIDES_POSIX_SYMBOLIC_LINKS_FD
+	bool
+
+config TC_PROVIDES_POSIX_SYSTEM_DATABASE
+	bool
+
+config TC_PROVIDES_POSIX_SYSTEM_DATABASE_R
+	bool
+
+# Note: the Option is _POSIX_THREADS, while the Option Group is POSIX_THREADS_BASE.
+# We have opted to use POSIX_THREADS here to match the Option name.
+config TC_PROVIDES_POSIX_THREADS
+	bool
+
+config TC_PROVIDES_POSIX_THREADS_EXT
+	bool
+
+config TC_PROVIDES_POSIX_TIMERS
+	bool
+
+config TC_PROVIDES_POSIX_USER_GROUPS
+	bool
+
+config TC_PROVIDES_POSIX_USER_GROUPS_R
+	bool
+
+config TC_PROVIDES_POSIX_WIDE_CHAR_DEVICE_IO
+	bool
+
+config TC_PROVIDES_XSI_C_LANG_SUPPORT
+	bool
+
+config TC_PROVIDES_XSI_DBM
+	bool
+
+config TC_PROVIDES_XSI_DEVICE_IO
+	bool
+
+config TC_PROVIDES_XSI_DEVICE_SPECIFIC
+	bool
+
+config TC_PROVIDES_XSI_FILE_SYSTEM
+	bool
+
+config TC_PROVIDES_XSI_IPC
+	bool
+
+config TC_PROVIDES_XSI_JUMP
+	bool
+
+config TC_PROVIDES_XSI_MATH
+	bool
+
+config TC_PROVIDES_XSI_MULTI_PROCESS
+	bool
+
+config TC_PROVIDES_XSI_SIGNALS
+	bool
+
+config TC_PROVIDES_XSI_SINGLE_PROCESS
+	bool
+
+config TC_PROVIDES_XSI_SYSTEM_DATABASE
+	bool
+
+config TC_PROVIDES_XSI_SYSTEM_LOGGING
+	bool
+
+config TC_PROVIDES_XSI_THREADS_EXT
+	bool
+
+config TC_PROVIDES_XSI_TIMERS
+	bool
+
+config TC_PROVIDES_XSI_USER_GROUPS
+	bool
+
+config TC_PROVIDES_XSI_WIDE_CHAR
+	bool


### PR DESCRIPTION
Make it easier for external C libraries, toolchains, and integrators to override Zephyr's implementation of POSIX functions and symbols on a per-Option-Group basis.

Each implemented standard POSIX Subprofiing Option Group already has a Kconfig option in in Zephyr. This Kconfig option is used to ensure that the appropriate feature test macro is defined (`features.h`), that the appropriate `sysconf()` value is returned, and of course to enable compilation of the relevant Zephyr C source.

Generally, these existing Kconfig options have the form `CONFIG_<option-group>`.

This change adds another, non-user-configurable Kconfig option of the form `CONFIG_TC_PROVIDES_<option-group>`. 

When the TC_PROVIDES Kconfig option is enabled, Zephyr's internal implementation is not built via CMake, effectively making all of the C symbols in a particular POSIX Option Group undefined, and allowing third-parties to provide a custom implementation. This could be done through `-lc` on the command line, or via additional CMake rules.

This is useful, for example, if a specific C library has a smaller, or faster, or more secure version of some POSIX features. Perhaps a vendor has a very specific implementation that is already certified on their device. There could be a number of reasons. 

The granularity was chosen to be at the [Option Group](https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_subprofiles.html) level because it is most likely to be internally and externally consistent.

As a concrete example, to provide an alternate implementation of the `POSIX_FILE_SYSTEM` Option Group, one could specify the following via Kconfig

```
config MY_POSIX_FILE_SYSTEM
    bool "My POSIX filesystem implementation"
    select TC_PROVIDES_POSIX_FILE_SYSTEM
    help
      Select this option to link against my amazing POSIX FS implementation!
```

and then specify the following via `CMakeLists.txt`
```
zephyr_library()
zephyr_library_sources_ifdef(CONFIG_MY_POSIX_FILE_SYSTEM my_fs.c)
```

and then the following in a `prj.conf` file

```
CONFIG_MY_POSIX_FILESYSTEM=y
```