### PR TITLE
modem: modem_cellular: improve device instantiation macro

### DIFF
--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -2109,6 +2109,37 @@ MODEM_CHAT_SCRIPT_DEFINE(sqn_gm02s_periodic_chat_script,
 #define MODEM_CELLULAR_GET_USER_PIPES(inst) \
 	MODEM_CELLULAR_INST_NAME(user_pipes, inst)
 
+/* Extract the first argument (pipe name) from a pair */
+#define MODEM_CELLULAR_GET_PIPE_NAME_ARG(arg1, ...) arg1
+
+/* Extract the second argument (DLCI address) from a pair */
+#define MODEM_CELLULAR_GET_DLCI_ADDRESS_ARG(arg1, arg2, ...) arg2
+
+/* Define user pipe data using instance and extracted pipe name */
+#define MODEM_CELLULAR_DEFINE_USER_PIPE_DATA_HELPER(_args, inst)                                   \
+	MODEM_CELLULAR_DEFINE_USER_PIPE_DATA(inst,                                                 \
+					     MODEM_CELLULAR_GET_PIPE_NAME_ARG _args,               \
+					     CONFIG_MODEM_CELLULAR_USER_PIPE_BUFFER_SIZES)
+
+/* Initialize user pipe using instance, extracted pipe name, and DLCI address */
+#define MODEM_CELLULAR_INIT_USER_PIPE_HELPER(_args, inst)                                          \
+	MODEM_CELLULAR_INIT_USER_PIPE(inst,                                                        \
+				      MODEM_CELLULAR_GET_PIPE_NAME_ARG _args,                      \
+				      MODEM_CELLULAR_GET_DLCI_ADDRESS_ARG _args)
+
+/*
+ * Define and initialize user pipes dynamically
+ * Takes an instance and pairs of (pipe name, DLCI address)
+ */
+#define MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, ...)                                       \
+	FOR_EACH_FIXED_ARG(MODEM_CELLULAR_DEFINE_USER_PIPE_DATA_HELPER,                            \
+			   (;), inst, __VA_ARGS__);                                                \
+	MODEM_CELLULAR_DEFINE_USER_PIPES(                                                          \
+		inst,                                                                              \
+		FOR_EACH_FIXED_ARG(MODEM_CELLULAR_INIT_USER_PIPE_HELPER,                           \
+				   (,), inst, __VA_ARGS__)                                         \
+	);
+
 #define MODEM_CELLULAR_DEVICE_QUECTEL_BG95(inst)                                                   \
 	MODEM_PPP_DEFINE(MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 64);                 \
                                                                                                    \
@@ -2118,23 +2149,9 @@ MODEM_CHAT_SCRIPT_DEFINE(sqn_gm02s_periodic_chat_script,
 		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
 	};                                                                                         \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_USER_PIPE_DATA(                                                      \
-		inst,                                                                              \
-		user_pipe_0,                                                                       \
-		CONFIG_MODEM_CELLULAR_USER_PIPE_BUFFER_SIZES                                       \
-	);                                                                                         \
-                                                                                                   \
-	MODEM_CELLULAR_DEFINE_USER_PIPE_DATA(                                                      \
-		inst,                                                                              \
-		user_pipe_1,                                                                       \
-		CONFIG_MODEM_CELLULAR_USER_PIPE_BUFFER_SIZES                                       \
-	);                                                                                         \
-                                                                                                   \
-	MODEM_CELLULAR_DEFINE_USER_PIPES(                                                          \
-		inst,                                                                              \
-		MODEM_CELLULAR_INIT_USER_PIPE(inst, user_pipe_0, 3),                               \
-		MODEM_CELLULAR_INIT_USER_PIPE(inst, user_pipe_1, 4),                               \
-	);                                                                                         \
+	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst,                                            \
+						  (user_pipe_0, 3),                                \
+						  (user_pipe_1, 4))                                \
                                                                                                    \
 	static const struct modem_cellular_config MODEM_CELLULAR_INST_NAME(config, inst) = {       \
 		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),                                          \
@@ -2167,23 +2184,9 @@ MODEM_CHAT_SCRIPT_DEFINE(sqn_gm02s_periodic_chat_script,
 		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
 	};                                                                                         \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_USER_PIPE_DATA(                                                      \
-		inst,                                                                              \
-		user_pipe_0,                                                                       \
-		CONFIG_MODEM_CELLULAR_USER_PIPE_BUFFER_SIZES                                       \
-	);                                                                                         \
-                                                                                                   \
-	MODEM_CELLULAR_DEFINE_USER_PIPE_DATA(                                                      \
-		inst,                                                                              \
-		user_pipe_1,                                                                       \
-		CONFIG_MODEM_CELLULAR_USER_PIPE_BUFFER_SIZES                                       \
-	);                                                                                         \
-                                                                                                   \
-	MODEM_CELLULAR_DEFINE_USER_PIPES(                                                          \
-		inst,                                                                              \
-		MODEM_CELLULAR_INIT_USER_PIPE(inst, user_pipe_0, 3),                               \
-		MODEM_CELLULAR_INIT_USER_PIPE(inst, user_pipe_1, 4),                               \
-	);                                                                                         \
+	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst,                                            \
+						  (user_pipe_0, 3),                                \
+						  (user_pipe_1, 4))                                \
                                                                                                    \
 	static const struct modem_cellular_config MODEM_CELLULAR_INST_NAME(config, inst) = {       \
 		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),                                          \
@@ -2216,23 +2219,9 @@ MODEM_CHAT_SCRIPT_DEFINE(sqn_gm02s_periodic_chat_script,
 		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
 	};                                                                                         \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_USER_PIPE_DATA(                                                      \
-		inst,                                                                              \
-		user_pipe_0,                                                                       \
-		CONFIG_MODEM_CELLULAR_USER_PIPE_BUFFER_SIZES                                       \
-	);                                                                                         \
-                                                                                                   \
-	MODEM_CELLULAR_DEFINE_USER_PIPE_DATA(                                                      \
-		inst,                                                                              \
-		user_pipe_1,                                                                       \
-		CONFIG_MODEM_CELLULAR_USER_PIPE_BUFFER_SIZES                                       \
-	);                                                                                         \
-                                                                                                   \
-	MODEM_CELLULAR_DEFINE_USER_PIPES(                                                          \
-		inst,                                                                              \
-		MODEM_CELLULAR_INIT_USER_PIPE(inst, user_pipe_0, 3),                               \
-		MODEM_CELLULAR_INIT_USER_PIPE(inst, user_pipe_1, 4),                               \
-	);                                                                                         \
+	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst,                                            \
+						  (user_pipe_0, 3),                                \
+						  (user_pipe_1, 4))                                \
                                                                                                    \
 	static const struct modem_cellular_config MODEM_CELLULAR_INST_NAME(config, inst) = {       \
 		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),                                          \
@@ -2265,23 +2254,9 @@ MODEM_CHAT_SCRIPT_DEFINE(sqn_gm02s_periodic_chat_script,
 		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
 	};                                                                                         \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_USER_PIPE_DATA(                                                      \
-		inst,                                                                              \
-		gnss_pipe,                                                                         \
-		CONFIG_MODEM_CELLULAR_USER_PIPE_BUFFER_SIZES                                       \
-	);                                                                                         \
-                                                                                                   \
-	MODEM_CELLULAR_DEFINE_USER_PIPE_DATA(                                                      \
-		inst,                                                                              \
-		user_pipe_0,                                                                       \
-		CONFIG_MODEM_CELLULAR_USER_PIPE_BUFFER_SIZES                                       \
-	);                                                                                         \
-                                                                                                   \
-	MODEM_CELLULAR_DEFINE_USER_PIPES(                                                          \
-		inst,                                                                              \
-		MODEM_CELLULAR_INIT_USER_PIPE(inst, gnss_pipe, 3),                                 \
-		MODEM_CELLULAR_INIT_USER_PIPE(inst, user_pipe_0, 4),                               \
-	);                                                                                         \
+	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst,                                            \
+						  (gnss_pipe, 3),                                  \
+						  (user_pipe_0, 4))                                \
                                                                                                    \
 	static const struct modem_cellular_config MODEM_CELLULAR_INST_NAME(config, inst) = {       \
 		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),                                          \
@@ -2314,23 +2289,9 @@ MODEM_CHAT_SCRIPT_DEFINE(sqn_gm02s_periodic_chat_script,
 		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
 	};                                                                                         \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_USER_PIPE_DATA(                                                      \
-		inst,                                                                              \
-		gnss_pipe,                                                                         \
-		CONFIG_MODEM_CELLULAR_USER_PIPE_BUFFER_SIZES                                       \
-	);                                                                                         \
-                                                                                                   \
-	MODEM_CELLULAR_DEFINE_USER_PIPE_DATA(                                                      \
-		inst,                                                                              \
-		user_pipe_0,                                                                       \
-		CONFIG_MODEM_CELLULAR_USER_PIPE_BUFFER_SIZES                                       \
-	);                                                                                         \
-                                                                                                   \
-	MODEM_CELLULAR_DEFINE_USER_PIPES(                                                          \
-		inst,                                                                              \
-		MODEM_CELLULAR_INIT_USER_PIPE(inst, gnss_pipe, 4),                                 \
-		MODEM_CELLULAR_INIT_USER_PIPE(inst, user_pipe_0, 3),                               \
-	);                                                                                         \
+	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst,                                            \
+						  (gnss_pipe, 4),                                  \
+						  (user_pipe_0, 3))                                \
                                                                                                    \
 	static const struct modem_cellular_config MODEM_CELLULAR_INST_NAME(config, inst) = {       \
 		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),                                          \
@@ -2364,23 +2325,9 @@ MODEM_CHAT_SCRIPT_DEFINE(sqn_gm02s_periodic_chat_script,
 		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
 	};                                                                                         \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_USER_PIPE_DATA(                                                      \
-		inst,                                                                              \
-		user_pipe_0,                                                                       \
-		CONFIG_MODEM_CELLULAR_USER_PIPE_BUFFER_SIZES                                       \
-	);                                                                                         \
-                                                                                                   \
-	MODEM_CELLULAR_DEFINE_USER_PIPE_DATA(                                                      \
-		inst,                                                                              \
-		user_pipe_1,                                                                       \
-		CONFIG_MODEM_CELLULAR_USER_PIPE_BUFFER_SIZES                                       \
-	);                                                                                         \
-                                                                                                   \
-	MODEM_CELLULAR_DEFINE_USER_PIPES(                                                          \
-		inst,                                                                              \
-		MODEM_CELLULAR_INIT_USER_PIPE(inst, user_pipe_0, 3),                               \
-		MODEM_CELLULAR_INIT_USER_PIPE(inst, user_pipe_1, 4),                               \
-	);                                                                                         \
+	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst,                                            \
+						  (user_pipe_0, 3),                                \
+						  (user_pipe_1, 4))                                \
                                                                                                    \
 	static const struct modem_cellular_config MODEM_CELLULAR_INST_NAME(config, inst) = {       \
 		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),                                          \
@@ -2413,16 +2360,8 @@ MODEM_CHAT_SCRIPT_DEFINE(sqn_gm02s_periodic_chat_script,
 		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
 	};                                                                                         \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_USER_PIPE_DATA(                                                      \
-		inst,                                                                              \
-		user_pipe_0,                                                                       \
-		CONFIG_MODEM_CELLULAR_USER_PIPE_BUFFER_SIZES                                       \
-	);                                                                                         \
-                                                                                                   \
-	MODEM_CELLULAR_DEFINE_USER_PIPES(                                                          \
-		inst,                                                                              \
-		MODEM_CELLULAR_INIT_USER_PIPE(inst, user_pipe_0, 3),                               \
-	);                                                                                         \
+	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst,                                            \
+						  (user_pipe_0, 3))                                \
                                                                                                    \
 	static const struct modem_cellular_config MODEM_CELLULAR_INST_NAME(config, inst) = {       \
 		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),                                          \
@@ -2454,16 +2393,8 @@ MODEM_CHAT_SCRIPT_DEFINE(sqn_gm02s_periodic_chat_script,
 		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
 	};                                                                                         \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_USER_PIPE_DATA(                                                      \
-		inst,                                                                              \
-		gnss_pipe,                                                                         \
-		CONFIG_MODEM_CELLULAR_USER_PIPE_BUFFER_SIZES                                       \
-	);                                                                                         \
-                                                                                                   \
-	MODEM_CELLULAR_DEFINE_USER_PIPES(                                                          \
-		inst,                                                                              \
-		MODEM_CELLULAR_INIT_USER_PIPE(inst, gnss_pipe, 3),                                 \
-	);                                                                                         \
+	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst,                                            \
+						  (gnss_pipe, 3))                                  \
                                                                                                    \
 	static const struct modem_cellular_config MODEM_CELLULAR_INST_NAME(config, inst) = {       \
 		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),                                          \
@@ -2496,23 +2427,9 @@ MODEM_CHAT_SCRIPT_DEFINE(sqn_gm02s_periodic_chat_script,
 		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
 	};                                                                                         \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_USER_PIPE_DATA(                                                      \
-		inst,                                                                              \
-		user_pipe_0,                                                                       \
-		CONFIG_MODEM_CELLULAR_USER_PIPE_BUFFER_SIZES                                       \
-	);                                                                                         \
-                                                                                                   \
-	MODEM_CELLULAR_DEFINE_USER_PIPE_DATA(                                                      \
-		inst,                                                                              \
-		user_pipe_1,                                                                       \
-		CONFIG_MODEM_CELLULAR_USER_PIPE_BUFFER_SIZES                                       \
-	);                                                                                         \
-                                                                                                   \
-	MODEM_CELLULAR_DEFINE_USER_PIPES(                                                          \
-		inst,                                                                              \
-		MODEM_CELLULAR_INIT_USER_PIPE(inst, user_pipe_0, 3),                               \
-		MODEM_CELLULAR_INIT_USER_PIPE(inst, user_pipe_1, 4),                               \
-	);                                                                                         \
+	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst,                                            \
+						  (user_pipe_0, 3),                                \
+						  (user_pipe_1, 4))                                \
                                                                                                    \
 	static const struct modem_cellular_config MODEM_CELLULAR_INST_NAME(config, inst) = {       \
 		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),                                          \

--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -2140,6 +2140,34 @@ MODEM_CHAT_SCRIPT_DEFINE(sqn_gm02s_periodic_chat_script,
 				   (,), inst, __VA_ARGS__)                                         \
 	);
 
+/* Helper to define modem instance */
+#define MODEM_CELLULAR_DEFINE_INSTANCE(inst, power_ms, reset_ms, startup_ms, shutdown_ms, start,   \
+				       init_script,                                                \
+				       dial_script,                                                \
+				       periodic_script)                                            \
+	static const struct modem_cellular_config MODEM_CELLULAR_INST_NAME(config, inst) = {       \
+		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),                                          \
+		.power_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_power_gpios, {}),                 \
+		.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_reset_gpios, {}),                 \
+		.power_pulse_duration_ms = (power_ms),                                             \
+		.reset_pulse_duration_ms = (reset_ms),                                             \
+		.startup_time_ms  = (startup_ms),                                                  \
+		.shutdown_time_ms = (shutdown_ms),                                                 \
+		.autostarts       = (start),                                                       \
+		.init_chat_script = (init_script),                                                 \
+		.dial_chat_script = (dial_script),                                                 \
+		.periodic_chat_script = (periodic_script),                                         \
+		.user_pipes = MODEM_CELLULAR_GET_USER_PIPES(inst),                                 \
+		.user_pipes_size = ARRAY_SIZE(MODEM_CELLULAR_GET_USER_PIPES(inst)),                \
+	};                                                                                         \
+                                                                                                   \
+	PM_DEVICE_DT_INST_DEFINE(inst, modem_cellular_pm_action);                                  \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(inst, modem_cellular_init, PM_DEVICE_DT_INST_GET(inst),              \
+			      &MODEM_CELLULAR_INST_NAME(data, inst),                               \
+			      &MODEM_CELLULAR_INST_NAME(config, inst), POST_KERNEL, 99,            \
+			      &modem_cellular_api);
+
 #define MODEM_CELLULAR_DEVICE_QUECTEL_BG95(inst)                                                   \
 	MODEM_PPP_DEFINE(MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 64);                 \
                                                                                                    \
@@ -2153,27 +2181,10 @@ MODEM_CHAT_SCRIPT_DEFINE(sqn_gm02s_periodic_chat_script,
 						  (user_pipe_0, 3),                                \
 						  (user_pipe_1, 4))                                \
                                                                                                    \
-	static const struct modem_cellular_config MODEM_CELLULAR_INST_NAME(config, inst) = {       \
-		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),                                          \
-		.power_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_power_gpios, {}),                 \
-		.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_reset_gpios, {}),                 \
-		.power_pulse_duration_ms = 1500,                                                   \
-		.reset_pulse_duration_ms = 100,                                                    \
-		.startup_time_ms = 10000,                                                          \
-		.shutdown_time_ms = 5000,                                                          \
-		.init_chat_script = &quectel_bg95_init_chat_script,                                \
-		.dial_chat_script = &quectel_bg95_dial_chat_script,                                \
-		.periodic_chat_script = &_CONCAT(DT_DRV_COMPAT, _periodic_chat_script),            \
-		.user_pipes = MODEM_CELLULAR_GET_USER_PIPES(inst),                                 \
-		.user_pipes_size = ARRAY_SIZE(MODEM_CELLULAR_GET_USER_PIPES(inst)),                \
-	};                                                                                         \
-                                                                                                   \
-	PM_DEVICE_DT_INST_DEFINE(inst, modem_cellular_pm_action);                                  \
-                                                                                                   \
-	DEVICE_DT_INST_DEFINE(inst, modem_cellular_init, PM_DEVICE_DT_INST_GET(inst),              \
-			      &MODEM_CELLULAR_INST_NAME(data, inst),                               \
-			      &MODEM_CELLULAR_INST_NAME(config, inst), POST_KERNEL, 99,            \
-			      &modem_cellular_api);
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 100, 10000, 5000, false,                        \
+				       &quectel_bg95_init_chat_script,                             \
+				       &quectel_bg95_dial_chat_script,                             \
+				       &quectel_bg95_periodic_chat_script)
 
 #define MODEM_CELLULAR_DEVICE_QUECTEL_EG25_G(inst)                                                 \
 	MODEM_PPP_DEFINE(MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 64);                 \
@@ -2188,27 +2199,10 @@ MODEM_CHAT_SCRIPT_DEFINE(sqn_gm02s_periodic_chat_script,
 						  (user_pipe_0, 3),                                \
 						  (user_pipe_1, 4))                                \
                                                                                                    \
-	static const struct modem_cellular_config MODEM_CELLULAR_INST_NAME(config, inst) = {       \
-		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),                                          \
-		.power_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_power_gpios, {}),                 \
-		.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_reset_gpios, {}),                 \
-		.power_pulse_duration_ms = 1500,                                                   \
-		.reset_pulse_duration_ms = 500,                                                    \
-		.startup_time_ms = 15000,                                                          \
-		.shutdown_time_ms = 5000,                                                          \
-		.init_chat_script = &quectel_eg25_g_init_chat_script,                              \
-		.dial_chat_script = &quectel_eg25_g_dial_chat_script,                              \
-		.periodic_chat_script = &_CONCAT(DT_DRV_COMPAT, _periodic_chat_script),            \
-		.user_pipes = MODEM_CELLULAR_GET_USER_PIPES(inst),                                 \
-		.user_pipes_size = ARRAY_SIZE(MODEM_CELLULAR_GET_USER_PIPES(inst)),                \
-	};                                                                                         \
-                                                                                                   \
-	PM_DEVICE_DT_INST_DEFINE(inst, modem_cellular_pm_action);                                  \
-                                                                                                   \
-	DEVICE_DT_INST_DEFINE(inst, modem_cellular_init, PM_DEVICE_DT_INST_GET(inst),              \
-			      &MODEM_CELLULAR_INST_NAME(data, inst),                               \
-			      &MODEM_CELLULAR_INST_NAME(config, inst), POST_KERNEL, 99,            \
-			      &modem_cellular_api);
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 500, 15000, 5000, false,                        \
+				       &quectel_eg25_g_init_chat_script,                           \
+				       &quectel_eg25_g_dial_chat_script,                           \
+				       &quectel_eg25_g_periodic_chat_script)
 
 #define MODEM_CELLULAR_DEVICE_SIMCOM_SIM7080(inst)                                                 \
 	MODEM_PPP_DEFINE(MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 64);                 \
@@ -2223,27 +2217,10 @@ MODEM_CHAT_SCRIPT_DEFINE(sqn_gm02s_periodic_chat_script,
 						  (user_pipe_0, 3),                                \
 						  (user_pipe_1, 4))                                \
                                                                                                    \
-	static const struct modem_cellular_config MODEM_CELLULAR_INST_NAME(config, inst) = {       \
-		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),                                          \
-		.power_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_power_gpios, {}),                 \
-		.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_reset_gpios, {}),                 \
-		.power_pulse_duration_ms = 1500,                                                   \
-		.reset_pulse_duration_ms = 100,                                                    \
-		.startup_time_ms = 10000,                                                          \
-		.shutdown_time_ms = 5000,                                                          \
-		.init_chat_script = &simcom_sim7080_init_chat_script,                              \
-		.dial_chat_script = &simcom_sim7080_dial_chat_script,                              \
-		.periodic_chat_script = &simcom_sim7080_periodic_chat_script,                      \
-		.user_pipes = MODEM_CELLULAR_GET_USER_PIPES(inst),                                 \
-		.user_pipes_size = ARRAY_SIZE(MODEM_CELLULAR_GET_USER_PIPES(inst)),                \
-	};                                                                                         \
-                                                                                                   \
-	PM_DEVICE_DT_INST_DEFINE(inst, modem_cellular_pm_action);                                  \
-                                                                                                   \
-	DEVICE_DT_INST_DEFINE(inst, modem_cellular_init, PM_DEVICE_DT_INST_GET(inst),              \
-			      &MODEM_CELLULAR_INST_NAME(data, inst),                               \
-			      &MODEM_CELLULAR_INST_NAME(config, inst), POST_KERNEL, 99,            \
-			      &modem_cellular_api);
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 100, 10000, 5000, false,                        \
+				       &simcom_sim7080_init_chat_script,                           \
+				       &simcom_sim7080_dial_chat_script,                           \
+				       &simcom_sim7080_periodic_chat_script)
 
 #define MODEM_CELLULAR_DEVICE_U_BLOX_SARA_R4(inst)                                                 \
 	MODEM_PPP_DEFINE(MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 64);                 \
@@ -2258,27 +2235,10 @@ MODEM_CHAT_SCRIPT_DEFINE(sqn_gm02s_periodic_chat_script,
 						  (gnss_pipe, 3),                                  \
 						  (user_pipe_0, 4))                                \
                                                                                                    \
-	static const struct modem_cellular_config MODEM_CELLULAR_INST_NAME(config, inst) = {       \
-		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),                                          \
-		.power_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_power_gpios, {}),                 \
-		.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_reset_gpios, {}),                 \
-		.power_pulse_duration_ms = 1500,                                                   \
-		.reset_pulse_duration_ms = 100,                                                    \
-		.startup_time_ms = 10000,                                                          \
-		.shutdown_time_ms = 5000,                                                          \
-		.init_chat_script = &u_blox_sara_r4_init_chat_script,                              \
-		.dial_chat_script = &u_blox_sara_r4_dial_chat_script,                              \
-		.periodic_chat_script = &u_blox_sara_r4_periodic_chat_script,                      \
-		.user_pipes = MODEM_CELLULAR_GET_USER_PIPES(inst),                                 \
-		.user_pipes_size = ARRAY_SIZE(MODEM_CELLULAR_GET_USER_PIPES(inst)),                \
-	};                                                                                         \
-                                                                                                   \
-	PM_DEVICE_DT_INST_DEFINE(inst, modem_cellular_pm_action);                                  \
-                                                                                                   \
-	DEVICE_DT_INST_DEFINE(inst, modem_cellular_init, PM_DEVICE_DT_INST_GET(inst),              \
-			      &MODEM_CELLULAR_INST_NAME(data, inst),                               \
-			      &MODEM_CELLULAR_INST_NAME(config, inst), POST_KERNEL, 99,            \
-			      &modem_cellular_api);
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 100, 10000, 5000, false,                        \
+				       &u_blox_sara_r4_init_chat_script,                           \
+				       &u_blox_sara_r4_dial_chat_script,                           \
+				       &u_blox_sara_r4_periodic_chat_script)
 
 #define MODEM_CELLULAR_DEVICE_U_BLOX_SARA_R5(inst)                                                 \
 	MODEM_PPP_DEFINE(MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 64);                 \
@@ -2293,28 +2253,10 @@ MODEM_CHAT_SCRIPT_DEFINE(sqn_gm02s_periodic_chat_script,
 						  (gnss_pipe, 4),                                  \
 						  (user_pipe_0, 3))                                \
                                                                                                    \
-	static const struct modem_cellular_config MODEM_CELLULAR_INST_NAME(config, inst) = {       \
-		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),                                          \
-		.power_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_power_gpios, {}),                 \
-		.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_reset_gpios, {}),                 \
-		.autostarts = true,                                                                \
-		.power_pulse_duration_ms = 1500,                                                   \
-		.reset_pulse_duration_ms = 100,                                                    \
-		.startup_time_ms = 1500,                                                           \
-		.shutdown_time_ms = 13000,                                                         \
-		.init_chat_script = &u_blox_sara_r5_init_chat_script,                              \
-		.dial_chat_script = &u_blox_sara_r5_dial_chat_script,                              \
-		.periodic_chat_script = &u_blox_sara_r5_periodic_chat_script,                      \
-		.user_pipes = MODEM_CELLULAR_GET_USER_PIPES(inst),                                 \
-		.user_pipes_size = ARRAY_SIZE(MODEM_CELLULAR_GET_USER_PIPES(inst)),                \
-	};                                                                                         \
-                                                                                                   \
-	PM_DEVICE_DT_INST_DEFINE(inst, modem_cellular_pm_action);                                  \
-                                                                                                   \
-	DEVICE_DT_INST_DEFINE(inst, modem_cellular_init, PM_DEVICE_DT_INST_GET(inst),              \
-			      &MODEM_CELLULAR_INST_NAME(data, inst),                               \
-			      &MODEM_CELLULAR_INST_NAME(config, inst), POST_KERNEL, 99,            \
-			      &modem_cellular_api);
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 100, 1500, 13000, true,                         \
+				       &u_blox_sara_r5_init_chat_script,                           \
+				       &u_blox_sara_r5_dial_chat_script,                           \
+				       &u_blox_sara_r5_periodic_chat_script)
 
 #define MODEM_CELLULAR_DEVICE_SWIR_HL7800(inst)                                                    \
 	MODEM_PPP_DEFINE(MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 64);                 \
@@ -2329,27 +2271,10 @@ MODEM_CHAT_SCRIPT_DEFINE(sqn_gm02s_periodic_chat_script,
 						  (user_pipe_0, 3),                                \
 						  (user_pipe_1, 4))                                \
                                                                                                    \
-	static const struct modem_cellular_config MODEM_CELLULAR_INST_NAME(config, inst) = {       \
-		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),                                          \
-		.power_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_power_gpios, {}),                 \
-		.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_reset_gpios, {}),                 \
-		.power_pulse_duration_ms = 1500,                                                   \
-		.reset_pulse_duration_ms = 100,                                                    \
-		.startup_time_ms = 10000,                                                          \
-		.shutdown_time_ms = 5000,                                                          \
-		.init_chat_script = &swir_hl7800_init_chat_script,                                 \
-		.dial_chat_script = &swir_hl7800_dial_chat_script,                                 \
-		.periodic_chat_script = &swir_hl7800_periodic_chat_script,                         \
-		.user_pipes = MODEM_CELLULAR_GET_USER_PIPES(inst),                                 \
-		.user_pipes_size = ARRAY_SIZE(MODEM_CELLULAR_GET_USER_PIPES(inst)),                \
-	};                                                                                         \
-                                                                                                   \
-	PM_DEVICE_DT_INST_DEFINE(inst, modem_cellular_pm_action);                                  \
-                                                                                                   \
-	DEVICE_DT_INST_DEFINE(inst, modem_cellular_init, PM_DEVICE_DT_INST_GET(inst),              \
-			      &MODEM_CELLULAR_INST_NAME(data, inst),                               \
-			      &MODEM_CELLULAR_INST_NAME(config, inst), POST_KERNEL, 99,            \
-			      &modem_cellular_api);
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 100, 10000, 5000, false,                        \
+				       &swir_hl7800_init_chat_script,                              \
+				       &swir_hl7800_dial_chat_script,                              \
+				       &swir_hl7800_periodic_chat_script)
 
 #define MODEM_CELLULAR_DEVICE_TELIT_ME910G1(inst)                                                  \
 	MODEM_PPP_DEFINE(MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 64);                 \
@@ -2363,27 +2288,10 @@ MODEM_CHAT_SCRIPT_DEFINE(sqn_gm02s_periodic_chat_script,
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst,                                            \
 						  (user_pipe_0, 3))                                \
                                                                                                    \
-	static const struct modem_cellular_config MODEM_CELLULAR_INST_NAME(config, inst) = {       \
-		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),                                          \
-		.power_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_power_gpios, {}),                 \
-		.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_reset_gpios, {}),                 \
-		.power_pulse_duration_ms = 5050,                                                   \
-		.reset_pulse_duration_ms = 250,                                                    \
-		.startup_time_ms = 15000,                                                          \
-		.shutdown_time_ms = 5000,                                                          \
-		.init_chat_script = &telit_me910g1_init_chat_script,                               \
-		.dial_chat_script = &telit_me910g1_dial_chat_script,                               \
-		.periodic_chat_script = &telit_me910g1_periodic_chat_script,                       \
-		.user_pipes = MODEM_CELLULAR_GET_USER_PIPES(inst),                                 \
-		.user_pipes_size = ARRAY_SIZE(MODEM_CELLULAR_GET_USER_PIPES(inst)),                \
-	};                                                                                         \
-                                                                                                   \
-	PM_DEVICE_DT_INST_DEFINE(inst, modem_cellular_pm_action);                                  \
-                                                                                                   \
-	DEVICE_DT_INST_DEFINE(inst, modem_cellular_init, PM_DEVICE_DT_INST_GET(inst),              \
-			      &MODEM_CELLULAR_INST_NAME(data, inst),                               \
-			      &MODEM_CELLULAR_INST_NAME(config, inst), POST_KERNEL, 99,            \
-			      &modem_cellular_api);
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 5050, 250, 15000, 5000, false,                        \
+				       &telit_me910g1_init_chat_script,                            \
+				       &telit_me910g1_dial_chat_script,                            \
+				       &telit_me910g1_periodic_chat_script)
 
 #define MODEM_CELLULAR_DEVICE_NORDIC_NRF91_SLM(inst)						   \
 	MODEM_PPP_DEFINE(MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 1500);               \
@@ -2396,27 +2304,10 @@ MODEM_CHAT_SCRIPT_DEFINE(sqn_gm02s_periodic_chat_script,
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst,                                            \
 						  (gnss_pipe, 3))                                  \
                                                                                                    \
-	static const struct modem_cellular_config MODEM_CELLULAR_INST_NAME(config, inst) = {       \
-		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),                                          \
-		.power_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_power_gpios, {}),                 \
-		.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_reset_gpios, {}),                 \
-		.power_pulse_duration_ms = 100,                                                    \
-		.reset_pulse_duration_ms = 100,                                                    \
-		.startup_time_ms = 2000,                                                           \
-		.shutdown_time_ms = 10000,                                                         \
-		.init_chat_script = &nordic_nrf91_slm_init_chat_script,                            \
-		.dial_chat_script = &nordic_nrf91_slm_dial_chat_script,                            \
-		.periodic_chat_script = &nordic_nrf91_slm_periodic_chat_script,                    \
-		.user_pipes = MODEM_CELLULAR_GET_USER_PIPES(inst),                                 \
-		.user_pipes_size = ARRAY_SIZE(MODEM_CELLULAR_GET_USER_PIPES(inst)),                \
-	};                                                                                         \
-                                                                                                   \
-	PM_DEVICE_DT_INST_DEFINE(inst, modem_cellular_pm_action);                                  \
-                                                                                                   \
-	DEVICE_DT_INST_DEFINE(inst, modem_cellular_init, PM_DEVICE_DT_INST_GET(inst),              \
-			      &MODEM_CELLULAR_INST_NAME(data, inst),                               \
-			      &MODEM_CELLULAR_INST_NAME(config, inst), POST_KERNEL, 99,            \
-			      &modem_cellular_api);
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 100, 100, 2000, 10000, false,                         \
+				       &nordic_nrf91_slm_init_chat_script,                         \
+				       &nordic_nrf91_slm_dial_chat_script,                         \
+				       &nordic_nrf91_slm_periodic_chat_script)
 
 #define MODEM_CELLULAR_DEVICE_SQN_GM02S(inst)                                                      \
 	MODEM_PPP_DEFINE(MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 64);                 \
@@ -2431,28 +2322,10 @@ MODEM_CHAT_SCRIPT_DEFINE(sqn_gm02s_periodic_chat_script,
 						  (user_pipe_0, 3),                                \
 						  (user_pipe_1, 4))                                \
                                                                                                    \
-	static const struct modem_cellular_config MODEM_CELLULAR_INST_NAME(config, inst) = {       \
-		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),                                          \
-		.power_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_power_gpios, {}),                 \
-		.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_reset_gpios, {}),                 \
-		.autostarts = true,                                                                \
-		.power_pulse_duration_ms = 1500,                                                   \
-		.reset_pulse_duration_ms = 100,                                                    \
-		.startup_time_ms = 2000,                                                           \
-		.shutdown_time_ms = 5000,                                                          \
-		.init_chat_script = &sqn_gm02s_init_chat_script,                                   \
-		.dial_chat_script = &sqn_gm02s_dial_chat_script,                                   \
-		.periodic_chat_script = &sqn_gm02s_periodic_chat_script,                           \
-		.user_pipes = MODEM_CELLULAR_GET_USER_PIPES(inst),                                 \
-		.user_pipes_size = ARRAY_SIZE(MODEM_CELLULAR_GET_USER_PIPES(inst)),                \
-	};                                                                                         \
-                                                                                                   \
-	PM_DEVICE_DT_INST_DEFINE(inst, modem_cellular_pm_action);                                  \
-                                                                                                   \
-	DEVICE_DT_INST_DEFINE(inst, modem_cellular_init, PM_DEVICE_DT_INST_GET(inst),              \
-			      &MODEM_CELLULAR_INST_NAME(data, inst),                               \
-			      &MODEM_CELLULAR_INST_NAME(config, inst), POST_KERNEL, 99,            \
-			      &modem_cellular_api);
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 1500, 100, 2000, 5000, true,                          \
+				       &sqn_gm02s_init_chat_script,                                \
+				       &sqn_gm02s_dial_chat_script,                                \
+				       &sqn_gm02s_periodic_chat_script)
 
 #define DT_DRV_COMPAT quectel_bg95
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_QUECTEL_BG95)


### PR DESCRIPTION
- Introduced the `MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES` macro to
consolidate multiple user pipe data definitions into a single macro call.

- Introduced `MODEM_CELLULAR_DEFINE_INSTANCE` macro to streamline
the definition and initialization of modem cellular instances.
