### PR TITLE
Stm32h7 flash controller on m4

### DIFF
--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -228,6 +228,7 @@ static struct flash_stm32_sector_t get_sector(const struct device *dev,
 {
 	struct flash_stm32_sector_t sector;
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
+	off_t temp_offset = offset + (CONFIG_FLASH_BASE_ADDRESS & 0xffffff);
 
 #ifdef DUAL_BANK
 	bool bank_swap;
@@ -235,20 +236,20 @@ static struct flash_stm32_sector_t get_sector(const struct device *dev,
 	bank_swap = (READ_BIT(FLASH->OPTCR, FLASH_OPTCR_SWAP_BANK)
 			== FLASH_OPTCR_SWAP_BANK);
 	sector.sector_index = offset / FLASH_SECTOR_SIZE;
-	if ((offset < (REAL_FLASH_SIZE_KB / 2)) && !bank_swap) {
+	if ((temp_offset < (REAL_FLASH_SIZE_KB / 2)) && !bank_swap) {
 		sector.bank = 1;
 		sector.cr = &regs->CR1;
 		sector.sr = &regs->SR1;
-	} else if ((offset >= BANK2_OFFSET) && bank_swap) {
+	} else if ((temp_offset >= BANK2_OFFSET) && bank_swap) {
 		sector.sector_index -= BANK2_OFFSET / FLASH_SECTOR_SIZE;
 		sector.bank = 1;
 		sector.cr = &regs->CR2;
 		sector.sr = &regs->SR2;
-	} else if ((offset < (REAL_FLASH_SIZE_KB / 2)) && bank_swap) {
+	} else if ((temp_offset < (REAL_FLASH_SIZE_KB / 2)) && bank_swap) {
 		sector.bank = 2;
 		sector.cr = &regs->CR1;
 		sector.sr = &regs->SR1;
-	} else if ((offset >= BANK2_OFFSET) && !bank_swap) {
+	} else if ((temp_offset >= BANK2_OFFSET) && !bank_swap) {
 		sector.sector_index -= BANK2_OFFSET / FLASH_SECTOR_SIZE;
 		sector.bank = 2;
 		sector.cr = &regs->CR2;

--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -36,11 +36,16 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 #define STM32H7_FLASH_TIMEOUT	\
 	(2 * DT_PROP(DT_INST(0, st_stm32_nv_flash), max_erase_time))
 
+#define STM32H7_M4_FLASH_SIZE DT_PROP_OR(DT_INST(0, st_stm32_nv_flash), bank2_flash_size, 0)
 #ifdef CONFIG_CPU_CORTEX_M4
-#error Flash driver on M4 core is not supported yet
+#if STM32H7_M4_FLASH_SIZE == 0
+#error Flash driver on M4 requires the DT property bank2-flash-size
+#else
+#define REAL_FLASH_SIZE_KB (KB(STM32H7_M4_FLASH_SIZE * 2))
 #endif
-
-#define REAL_FLASH_SIZE_KB	KB(LL_GetFlashSize())
+#else
+#define REAL_FLASH_SIZE_KB KB(LL_GetFlashSize())
+#endif
 #define SECTOR_PER_BANK		((REAL_FLASH_SIZE_KB / FLASH_SECTOR_SIZE) / 2)
 #if defined(DUAL_BANK)
 #define STM32H7_SERIES_MAX_FLASH_KB	KB(2048)

--- a/dts/bindings/mtd/st,stm32-nv-flash.yaml
+++ b/dts/bindings/mtd/st,stm32-nv-flash.yaml
@@ -12,3 +12,9 @@ properties:
     type: int
     description: max erase time(millisecond) of a flash sector or page or half-page
     required: true
+  bank2-flash-size:
+    type: int
+    description: |
+      Embedded flash memory bank 2 size in KBytes.
+      Used by CM4 CPU because it cannot access flash controller register to read size.
+      Provides a way to configure this size when the flash controller driver runs on CM4 CPU.

--- a/samples/drivers/flash_shell/boards/stm32h745i_disco_stm32h745xx_m4.overlay
+++ b/samples/drivers/flash_shell/boards/stm32h745i_disco_stm32h745xx_m4.overlay
@@ -1,0 +1,9 @@
+/ {
+	chosen {
+		zephyr,flash-controller = &flash;
+	};
+};
+
+&flash1 {
+	bank2-flash-size = <1024>;
+};

--- a/samples/drivers/flash_shell/boards/stm32h747i_disco_stm32h747xx_m4.overlay
+++ b/samples/drivers/flash_shell/boards/stm32h747i_disco_stm32h747xx_m4.overlay
@@ -1,0 +1,3 @@
+&flash1 {
+	bank2-flash-size = <1024>;
+};

--- a/samples/drivers/flash_shell/sample.yaml
+++ b/samples/drivers/flash_shell/sample.yaml
@@ -10,7 +10,6 @@ tests:
     platform_exclude:
       - nucleo_h745zi_q/stm32h745xx/m4
       - stm32h7s78_dk
-      - stm32h745i_disco/stm32h745xx/m4
       - gd32f350r_eval
       - arduino_portenta_h7/stm32h747xx/m4
       - arduino_giga_r1/stm32h747xx/m4

--- a/samples/drivers/flash_shell/sample.yaml
+++ b/samples/drivers/flash_shell/sample.yaml
@@ -11,7 +11,6 @@ tests:
       - nucleo_h745zi_q/stm32h745xx/m4
       - stm32h7s78_dk
       - stm32h745i_disco/stm32h745xx/m4
-      - stm32h747i_disco/stm32h747xx/m4
       - gd32f350r_eval
       - arduino_portenta_h7/stm32h747xx/m4
       - arduino_giga_r1/stm32h747xx/m4


### PR DESCRIPTION
Hello,

We have been using STM32H7 based SoC in our project and made some updates to the flash controller driver on STMH7 SoC to allow it run on a M4 core. I am sending the updates from that work to benefit the SoC users.

The initial draft was discussed at https://github.com/zephyrproject-rtos/zephyr/pull/65250
Based on the feedback, I have removed the SoC flash example as I discovered that the flash shell command is sufficient to verify the flash functionality.

I have used the samples/drivers/flash_shell to test this patch by using the build commands below and using west flash to program the image onto the board.

west build -p always -b stm32h747i_disco/stm32h747xx/m4 -d m4 samples/drivers/flash_shell
west build -p always -b stm32h745i_disco/stm32h745xx/m4 -d m4 samples/drivers/flash_shell

I have an additional commits to allow testing which enable usart1 shell/console on M4 and disable the same for M7
https://github.com/mkaricheri/zephyr/tree/stm32h7_flash_controller_on_m4-test

I test flash erase/read/write as below for  stm32h747i_disco & stm32h745i_disco

```
*** Booting Zephyr OS build v3.7.0-rc2-66-g0d6dc6f64f4a ***
Flash shell sample
uart:~$ flash erase flash-controller@52002000 c0000 40000
Erase success.
[00:00:21.945,000] <err> flash_stm32h7: Cortex M4: ART enabled not supported
uart:~$ flash read flash-controller@52002000 c0000 32
000C0000: ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff |........ ........
000C0010: ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff |........ ........
000C0020: ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff |........ ........
000C0030: ff ff                                            |..
uart:~$ flash write flash-controller@52002000 c0000 12345678 23456789 3456789
Write OK.
Verified.
uart:~$ flash read flash-controller@52002000 c0000 32
000C0000: 78 56 34 12 89 67 45 23  90 78 56 34 ff ff ff ff |xV4..gE# .xV4....
000C0010: ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff |........ ........
000C0020: ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff |........ ........
000C0030: ff ff   
uart:~$ flash write flash-controller@52002000 c0000 12345678 23456789 3456789
Write internal ERROR!
uart:~$ flash page_info flash-controller@52002000 c0000
Page for address 0xc0000:
start offset: 0xc0000
size: 131072
index: 6

                              
```
