### PR TITLE
tests: poll: fix misconstructed k_poll_event test

### DIFF
--- a/tests/kernel/poll/src/test_poll.c
+++ b/tests/kernel/poll/src/test_poll.c
@@ -115,10 +115,13 @@ ZTEST_USER(poll_api_1cpu, test_poll_no_wait)
 		      -EINVAL,
 		      NULL);
 
+	/* can't use the initializer to misconstruct this */
 	struct k_poll_event bad_events2[] = {
-		K_POLL_EVENT_INITIALIZER(0xFU,
-					 K_POLL_MODE_NOTIFY_ONLY,
-					 &no_wait_sem),
+		{ .type = 0xFU,
+		  .state = K_POLL_STATE_NOT_READY,
+		  .mode = K_POLL_MODE_NOTIFY_ONLY,
+		  .obj = &no_wait_sem,
+		},
 	};
 	zassert_equal(k_poll(bad_events2, ARRAY_SIZE(bad_events), K_NO_WAIT),
 		      -EINVAL,


### PR DESCRIPTION
Since commit 0c23cf94a43b ("include/kernel: check type of object passed
to K_POLL_EVENT_INITIALIZER") it is no longer possible to use arbitrary
type literals with the initializer macro. Misconstructing a k_poll_event
type for test purpose must be done explicitly.

Signed-off-by: Nicolas Pitre <npitre@baylibre.com>
