### PR TITLE
drivers: flash: stm32: fix flash write error handling

### DIFF
--- a/drivers/flash/flash_stm32l5x.c
+++ b/drivers/flash/flash_stm32l5x.c
@@ -367,10 +367,16 @@ int flash_stm32_write_range(const struct device *dev, unsigned int offset,
 	}
 
 	if (icache_enabled) {
+		int rc2;
+
 		/* Since i-cache was disabled, this would start the
 		 * invalidation procedure, so wait for completion.
 		 */
-		rc = icache_wait_for_invalidate_complete();
+		rc2 = icache_wait_for_invalidate_complete();
+
+		if (!rc) {
+			rc = rc2;
+		}
 
 		/* I-cache should be enabled only after the
 		 * invalidation is complete.

--- a/drivers/flash/flash_stm32wbax.c
+++ b/drivers/flash/flash_stm32wbax.c
@@ -262,10 +262,16 @@ int flash_stm32_write_range(const struct device *dev, unsigned int offset,
 	}
 
 	if (icache_enabled) {
+		int rc2;
+
 		/* Since i-cache was disabled, this would start the
 		 * invalidation procedure, so wait for completion.
 		 */
-		rc = icache_wait_for_invalidate_complete();
+		rc2 = icache_wait_for_invalidate_complete();
+
+		if (!rc) {
+			rc = rc2;
+		}
 
 		/* I-cache should be enabled only after the
 		 * invalidation is complete.


### PR DESCRIPTION
The stm32 flash driver returns success even though writing failed when instruction cache was enabled. Fix by not overriding error code when re-enabling instruction cache.