### PR TITLE
boards: imx93_evk: enable gpio_exp0 as nodes using it are enabled

### DIFF
--- a/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.dts
+++ b/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.dts
@@ -128,7 +128,7 @@
 				line-name = "exp_sel";
 				output-low;
 			};
-			status = "disabled";
+			status = "okay";
 		};
 	};
 };


### PR DESCRIPTION
The CAN PHY sets its `standby-gpios` to
`<&gpio_exp0 8 GPIO_ACTIVE_HIGH>` and it has `status` set to `okay`. This means that the `gpio_exp0` node must also be enabled, otherwise we get into compilation errors on some CAN samples.

Issue observed here: https://github.com/zephyrproject-rtos/zephyr/actions/runs/9467833284/job/26088264264?pr=74101