### PR TITLE
hal_nordic: Fix reserved PPI faulty logic

### DIFF
--- a/modules/hal_nordic/Kconfig
+++ b/modules/hal_nordic/Kconfig
@@ -7,6 +7,10 @@ config ZEPHYR_HAL_NORDIC_MODULE
 config HAS_NORDIC_DRIVERS
 	bool
 
+config MPSL
+	bool
+	# Dummy kconfig to allow compiling outside of NCS
+
 menu "Nordic drivers"
 	depends on HAS_NORDIC_DRIVERS
 

--- a/modules/hal_nordic/nrfx/nrfx_glue.h
+++ b/modules/hal_nordic/nrfx/nrfx_glue.h
@@ -381,7 +381,7 @@ void nrfx_busy_wait(uint32_t usec_to_wait);
 #define NRFX_PPI_GROUPS_USED_BY_802154_DRV     0
 #endif // CONFIG_NRF_802154_RADIO_DRIVER
 
-#if defined(CONFIG_NRF_802154_RADIO_DRIVER) && !defined(CONFIG_NRF_802154_SL_OPENSOURCE)
+#if defined(CONFIG_MPSL)
 #include <mpsl.h>
 #define NRFX_PPI_CHANNELS_USED_BY_MPSL   MPSL_RESERVED_PPI_CHANNELS
 #define NRFX_PPI_GROUPS_USED_BY_MPSL     0


### PR DESCRIPTION
The list of reserved PPIs by MPSL should be kept if MPSL is enabled. The 802154 radio driver is not the only user of MPSL.