### PR TITLE
Nrfx none adc support on nrf54h20

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.yaml
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.yaml
@@ -12,6 +12,7 @@ toolchain:
 ram: 256
 flash: 296
 supported:
+  - adc
   - can
   - counter
   - gpio

--- a/samples/drivers/adc/adc_dt/sample.yaml
+++ b/samples/drivers/adc/adc_dt/sample.yaml
@@ -16,6 +16,7 @@ tests:
       - nrf51dk/nrf51822
       - nrf52840dk/nrf52840
       - nrf54l15pdk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
       - mec172xevb_assy6906
       - gd32f350r_eval
       - gd32f450i_eval

--- a/samples/drivers/adc/adc_sequence/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/drivers/adc/adc_sequence/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ */
+
+/ {
+	aliases {
+		adc0 = &adc;
+	};
+};
+
+/ {
+	zephyr,user {
+		io-channels = <&adc 0>, <&adc 1>, <&adc 7>;
+	};
+};
+
+&adc {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1_2";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_AIN1>; /* P1.01 */
+		zephyr,resolution = <10>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1_2";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_AIN2>; /* P1.02 */
+		zephyr,resolution = <12>;
+		zephyr,oversampling = <8>;
+	};
+
+	channel@7 {
+		reg = <7>;
+		zephyr,gain = "ADC_GAIN_1_2";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_AIN3>; /* P1.03 */
+		zephyr,input-negative = <NRF_SAADC_AIN7>; /* P1.07 */
+		zephyr,resolution = <12>;
+	};
+};

--- a/samples/drivers/adc/adc_sequence/sample.yaml
+++ b/samples/drivers/adc/adc_sequence/sample.yaml
@@ -10,6 +10,7 @@ tests:
       - cy8cproto_062_4343w
       - nrf52840dk/nrf52840
       - nrf54l15pdk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
     harness: console


### PR DESCRIPTION
Enable ADC Twister tests on nrf54h20.