### PR TITLE
LE Audio: CAP initiator start from any state

### DIFF
--- a/include/zephyr/bluetooth/audio/cap.h
+++ b/include/zephyr/bluetooth/audio/cap.h
@@ -346,7 +346,10 @@ int bt_cap_initiator_unregister_cb(const struct bt_cap_initiator_cb *cb);
  *
  * @param param Parameters to start the audio streams.
  *
- * @return 0 on success or negative error value on failure.
+ * @retval 0 on success
+ * @retval -EBUSY if a CAP procedure is already in progress
+ * @retval -EINVAL if any parameter is invalid
+ * @retval -EALREADY All streams are already in the streaming state
  */
 int bt_cap_initiator_unicast_audio_start(const struct bt_cap_unicast_audio_start_param *param);
 

--- a/subsys/bluetooth/audio/cap_initiator.c
+++ b/subsys/bluetooth/audio/cap_initiator.c
@@ -719,11 +719,6 @@ static bool valid_unicast_audio_start_param(const struct bt_cap_unicast_audio_st
 
 		bap_stream = &cap_stream->bap_stream;
 
-		CHECKIF(bap_stream->ep != NULL) {
-			LOG_DBG("param->streams[%zu] is already started", i);
-			return false;
-		}
-
 		CHECKIF(bap_stream->group == NULL) {
 			LOG_DBG("param->streams[%zu] is not in a unicast group", i);
 			return false;

--- a/tests/bluetooth/audio/cap_initiator/include/test_common.h
+++ b/tests/bluetooth/audio/cap_initiator/include/test_common.h
@@ -6,7 +6,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/bluetooth/audio/bap.h>
+#include <zephyr/bluetooth/audio/bap_lc3_preset.h>
+#include <zephyr/bluetooth/audio/cap.h>
+#include <zephyr/bluetooth/conn.h>
+
 void test_mocks_init(void);
 void test_mocks_cleanup(void);
 
 void test_conn_init(struct bt_conn *conn);
+
+void test_unicast_set_state(struct bt_cap_stream *cap_stream, struct bt_conn *conn,
+			    struct bt_bap_ep *ep, struct bt_bap_lc3_preset *preset,
+			    enum bt_bap_ep_state state);

--- a/tests/bluetooth/audio/cap_initiator/src/test_common.c
+++ b/tests/bluetooth/audio/cap_initiator/src/test_common.c
@@ -6,12 +6,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/bluetooth/audio/bap.h>
+#include <zephyr/bluetooth/audio/bap_lc3_preset.h>
+#include <zephyr/bluetooth/audio/cap.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/hci_types.h>
 
+#include "bap_endpoint.h"
 #include "cap_initiator.h"
 #include "conn.h"
 #include "test_common.h"
+#include "ztest_assert.h"
 
 void test_mocks_init(void)
 {
@@ -32,4 +37,28 @@ void test_conn_init(struct bt_conn *conn)
 	conn->info.security.level = BT_SECURITY_L2;
 	conn->info.security.enc_key_size = BT_ENC_KEY_SIZE_MAX;
 	conn->info.security.flags = BT_SECURITY_FLAG_OOB | BT_SECURITY_FLAG_SC;
+}
+
+void test_unicast_set_state(struct bt_cap_stream *cap_stream, struct bt_conn *conn,
+			    struct bt_bap_ep *ep, struct bt_bap_lc3_preset *preset,
+			    enum bt_bap_ep_state state)
+{
+	struct bt_bap_stream *bap_stream = &cap_stream->bap_stream;
+
+	printk("Setting stream %p to state %d\n", bap_stream, state);
+
+	if (state == BT_BAP_EP_STATE_IDLE) {
+		return;
+	}
+
+	zassert_not_null(cap_stream);
+	zassert_not_null(conn);
+	zassert_not_null(ep);
+	zassert_not_null(preset);
+
+	bap_stream->conn = conn;
+	bap_stream->ep = ep;
+	bap_stream->qos = &preset->qos;
+	bap_stream->codec_cfg = &preset->codec_cfg;
+	bap_stream->ep->status.state = state;
 }

--- a/tests/bluetooth/audio/cap_initiator/src/test_unicast_start.c
+++ b/tests/bluetooth/audio/cap_initiator/src/test_unicast_start.c
@@ -92,6 +92,9 @@ static void cap_initiator_test_unicast_start_after(void *f)
 	for (size_t i = 0; i < ARRAY_SIZE(fixture->conns); i++) {
 		mock_bt_conn_disconnected(&fixture->conns[i], BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 	}
+
+	/* In the case of a test failing, we cancel the procedure so that subsequent won't fail */
+	bt_cap_initiator_unicast_audio_cancel();
 }
 
 static void cap_initiator_test_unicast_start_teardown(void *f)
@@ -117,6 +120,7 @@ static ZTEST_F(cap_initiator_test_unicast_start, test_initiator_unicast_start)
 	for (size_t i = 0U; i < ARRAY_SIZE(stream_params); i++) {
 		stream_params[i].stream = &fixture->cap_streams[i];
 		stream_params[i].codec_cfg = &fixture->preset.codec_cfg;
+		/* Distribute the streams equally among the connections */
 		stream_params[i].member.member = &fixture->conns[i % ARRAY_SIZE(fixture->conns)];
 		stream_params[i].ep = &fixture->eps[i];
 	}
@@ -128,11 +132,11 @@ static ZTEST_F(cap_initiator_test_unicast_start, test_initiator_unicast_start)
 			   mock_cap_initiator_unicast_start_complete_cb_fake.call_count);
 
 	for (size_t i = 0U; i < ARRAY_SIZE(stream_params); i++) {
-		const enum bt_bap_ep_state state =
-			fixture->cap_streams[i].bap_stream.ep->status.state;
+		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
+		const enum bt_bap_ep_state state = bap_stream->ep->status.state;
 
-		zassert_equal(state, BT_BAP_EP_STATE_STREAMING, "[%zu] Unexpected state: %d", i,
-			      state);
+		zassert_equal(state, BT_BAP_EP_STATE_STREAMING,
+			      "[%zu]: Stream %p unexpected state: %d", i, bap_stream, state);
 	}
 }
 
@@ -383,4 +387,116 @@ static ZTEST_F(cap_initiator_test_unicast_start,
 
 	zexpect_call_count("bt_cap_initiator_cb.unicast_start_complete_cb", 0,
 			   mock_cap_initiator_unicast_start_complete_cb_fake.call_count);
+}
+
+static ZTEST_F(cap_initiator_test_unicast_start,
+	       test_initiator_unicast_start_state_codec_configured)
+{
+	struct bt_cap_unicast_audio_start_stream_param
+		stream_params[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT] = {0};
+	const struct bt_cap_unicast_audio_start_param param = {
+		.type = BT_CAP_SET_TYPE_AD_HOC,
+		.count = ARRAY_SIZE(stream_params),
+		.stream_params = stream_params,
+	};
+	int err;
+
+	for (size_t i = 0U; i < ARRAY_SIZE(stream_params); i++) {
+		stream_params[i].stream = &fixture->cap_streams[i];
+		stream_params[i].codec_cfg = &fixture->preset.codec_cfg;
+		stream_params[i].member.member = &fixture->conns[i % ARRAY_SIZE(fixture->conns)];
+		stream_params[i].ep = &fixture->eps[i];
+
+		test_unicast_set_state(stream_params[i].stream, stream_params[i].member.member,
+				       stream_params[i].ep, &fixture->preset,
+				       BT_BAP_EP_STATE_CODEC_CONFIGURED);
+	}
+
+	err = bt_cap_initiator_unicast_audio_start(&param);
+	zassert_equal(err, 0, "Unexpected return value %d", err);
+
+	zexpect_call_count("bt_cap_initiator_cb.unicast_start_complete_cb", 1,
+			   mock_cap_initiator_unicast_start_complete_cb_fake.call_count);
+
+	for (size_t i = 0U; i < ARRAY_SIZE(stream_params); i++) {
+		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
+		const enum bt_bap_ep_state state = bap_stream->ep->status.state;
+
+		zassert_equal(state, BT_BAP_EP_STATE_STREAMING,
+			      "[%zu]: Stream %p unexpected state: %d", i, bap_stream, state);
+	}
+}
+
+static ZTEST_F(cap_initiator_test_unicast_start, test_initiator_unicast_start_state_qos_configured)
+{
+	struct bt_cap_unicast_audio_start_stream_param
+		stream_params[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT] = {0};
+	const struct bt_cap_unicast_audio_start_param param = {
+		.type = BT_CAP_SET_TYPE_AD_HOC,
+		.count = ARRAY_SIZE(stream_params),
+		.stream_params = stream_params,
+	};
+	int err;
+
+	for (size_t i = 0U; i < ARRAY_SIZE(stream_params); i++) {
+		stream_params[i].stream = &fixture->cap_streams[i];
+		stream_params[i].codec_cfg = &fixture->preset.codec_cfg;
+		stream_params[i].member.member = &fixture->conns[i % ARRAY_SIZE(fixture->conns)];
+		stream_params[i].ep = &fixture->eps[i];
+
+		test_unicast_set_state(stream_params[i].stream, stream_params[i].member.member,
+				       stream_params[i].ep, &fixture->preset,
+				       BT_BAP_EP_STATE_QOS_CONFIGURED);
+	}
+
+	err = bt_cap_initiator_unicast_audio_start(&param);
+	zassert_equal(err, 0, "Unexpected return value %d", err);
+
+	zexpect_call_count("bt_cap_initiator_cb.unicast_start_complete_cb", 1,
+			   mock_cap_initiator_unicast_start_complete_cb_fake.call_count);
+
+	for (size_t i = 0U; i < ARRAY_SIZE(stream_params); i++) {
+		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
+		const enum bt_bap_ep_state state = bap_stream->ep->status.state;
+
+		zassert_equal(state, BT_BAP_EP_STATE_STREAMING,
+			      "[%zu]: Stream %p unexpected state: %d", i, bap_stream, state);
+	}
+}
+
+static ZTEST_F(cap_initiator_test_unicast_start, test_initiator_unicast_start_state_enabling)
+{
+	struct bt_cap_unicast_audio_start_stream_param
+		stream_params[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT] = {0};
+	const struct bt_cap_unicast_audio_start_param param = {
+		.type = BT_CAP_SET_TYPE_AD_HOC,
+		.count = ARRAY_SIZE(stream_params),
+		.stream_params = stream_params,
+	};
+	int err;
+
+	for (size_t i = 0U; i < ARRAY_SIZE(stream_params); i++) {
+		stream_params[i].stream = &fixture->cap_streams[i];
+		stream_params[i].codec_cfg = &fixture->preset.codec_cfg;
+		stream_params[i].member.member = &fixture->conns[i % ARRAY_SIZE(fixture->conns)];
+		stream_params[i].ep = &fixture->eps[i];
+
+		test_unicast_set_state(stream_params[i].stream, stream_params[i].member.member,
+				       stream_params[i].ep, &fixture->preset,
+				       BT_BAP_EP_STATE_ENABLING);
+	}
+
+	err = bt_cap_initiator_unicast_audio_start(&param);
+	zassert_equal(err, 0, "Unexpected return value %d", err);
+
+	zexpect_call_count("bt_cap_initiator_cb.unicast_start_complete_cb", 1,
+			   mock_cap_initiator_unicast_start_complete_cb_fake.call_count);
+
+	for (size_t i = 0U; i < ARRAY_SIZE(stream_params); i++) {
+		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
+		const enum bt_bap_ep_state state = bap_stream->ep->status.state;
+
+		zassert_equal(state, BT_BAP_EP_STATE_STREAMING,
+			      "[%zu]: Stream %p unexpected state: %d", i, bap_stream, state);
+	}
 }


### PR DESCRIPTION
This adds support and testing of starting streams in any state allowed by BAP. 