### PR TITLE
kernel: Unified type of stack protection canary __stack_chk_guard.

### DIFF
--- a/kernel/compiler_stack_protect.c
+++ b/kernel/compiler_stack_protect.c
@@ -47,11 +47,11 @@ void _StackCheckHandler(void)
  * The canary value gets initialized in z_cstart().
  */
 #ifdef CONFIG_STACK_CANARIES_TLS
-__thread uintptr_t __stack_chk_guard;
+__thread volatile uintptr_t __stack_chk_guard;
 #elif CONFIG_USERSPACE
-K_APP_DMEM(z_libc_partition) uintptr_t __stack_chk_guard;
+K_APP_DMEM(z_libc_partition) volatile uintptr_t __stack_chk_guard;
 #else
-__noinit uintptr_t __stack_chk_guard;
+__noinit volatile uintptr_t __stack_chk_guard;
 #endif
 
 /**


### PR DESCRIPTION
Extern declaration of **__stack_chk_guard** added **volatile** to the type while the declaration was non-volatile. This cause type check errors with compilers that declares the **__stack_chk_guard** variable in an internal pre-include header file (IAR).

While I think the volatile keyword is unnecessary, I decided to keep it and add it to the declarations in
kernel/compiler_stack_protect.c

Tested with IAR ICCARM and the Zephyr SDK GCC.