### PR TITLE
drivers: gnss: make `gnss_xxx_config` and `gnss_driver_api` as `const`

### DIFF
--- a/drivers/gnss/gnss_emul.c
+++ b/drivers/gnss/gnss_emul.c
@@ -336,7 +336,7 @@ static int gnss_emul_api_get_supported_systems(const struct device *dev, gnss_sy
 	return 0;
 }
 
-static struct gnss_driver_api api = {
+static const struct gnss_driver_api api = {
 	.set_fix_rate = gnss_emul_api_set_fix_rate,
 	.get_fix_rate = gnss_emul_api_get_fix_rate,
 	.set_navigation_mode = gnss_emul_api_set_navigation_mode,

--- a/drivers/gnss/gnss_luatos_air530z.c
+++ b/drivers/gnss/gnss_luatos_air530z.c
@@ -336,28 +336,28 @@ static int luatos_air530z_get_supported_systems(const struct device *dev, gnss_s
 	return 0;
 }
 
-static struct gnss_driver_api gnss_api = {
+static const struct gnss_driver_api gnss_api = {
 	.set_fix_rate = luatos_air530z_set_fix_rate,
 	.set_enabled_systems = luatos_air530z_set_enabled_systems,
 	.get_supported_systems = luatos_air530z_get_supported_systems,
 };
 
-#define LUATOS_AIR530Z(inst)								\
-	static struct gnss_luatos_air530z_config gnss_luatos_air530z_cfg_##inst = {	\
-		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),				\
-		.on_off_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, on_off_gpios, { 0 }),	\
-	};										\
-											\
-	static struct gnss_luatos_air530z_data gnss_luatos_air530z_data_##inst = {	\
-		.chat_delimiter = {'\r', '\n'},						\
-		.dynamic_separators_buf = {',', '*'},					\
-	};										\
-											\
-	PM_DEVICE_DT_INST_DEFINE(inst, luatos_air530z_pm_action);			\
-											\
-	DEVICE_DT_INST_DEFINE(inst, gnss_luatos_air530z_init,				\
-		PM_DEVICE_DT_INST_GET(inst),						\
-		&gnss_luatos_air530z_data_##inst,					\
+#define LUATOS_AIR530Z(inst)									\
+	static const struct gnss_luatos_air530z_config gnss_luatos_air530z_cfg_##inst = {	\
+		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),					\
+		.on_off_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, on_off_gpios, { 0 }),		\
+	};											\
+												\
+	static struct gnss_luatos_air530z_data gnss_luatos_air530z_data_##inst = {		\
+		.chat_delimiter = {'\r', '\n'},							\
+		.dynamic_separators_buf = {',', '*'},						\
+	};											\
+												\
+	PM_DEVICE_DT_INST_DEFINE(inst, luatos_air530z_pm_action);				\
+												\
+	DEVICE_DT_INST_DEFINE(inst, gnss_luatos_air530z_init,					\
+		PM_DEVICE_DT_INST_GET(inst),							\
+		&gnss_luatos_air530z_data_##inst,						\
 		&gnss_luatos_air530z_cfg_##inst,						\
 		POST_KERNEL, CONFIG_GNSS_INIT_PRIORITY, &gnss_api);
 

--- a/drivers/gnss/gnss_nmea_generic.c
+++ b/drivers/gnss/gnss_nmea_generic.c
@@ -81,7 +81,7 @@ static int gnss_nmea_generic_resume(const struct device *dev)
 	return ret;
 }
 
-static struct gnss_driver_api gnss_api = {
+static const struct gnss_driver_api gnss_api = {
 };
 
 static int gnss_nmea_generic_init_nmea0183_match(const struct device *dev)
@@ -183,7 +183,7 @@ MODEM_CHAT_SCRIPT_EMPTY_DEFINE(gnss_nmea_generic_init_chat_script);
 #endif
 
 #define GNSS_NMEA_GENERIC(inst)								\
-	static struct gnss_nmea_generic_config gnss_nmea_generic_cfg_##inst = {		\
+	static const struct gnss_nmea_generic_config gnss_nmea_generic_cfg_##inst = {	\
 		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),				\
 		.init_chat_script = &_CONCAT(DT_DRV_COMPAT, _init_chat_script),         \
 	};										\

--- a/drivers/gnss/gnss_quectel_lcx6g.c
+++ b/drivers/gnss/gnss_quectel_lcx6g.c
@@ -717,7 +717,7 @@ static int quectel_lcx6g_get_supported_systems(const struct device *dev, gnss_sy
 	return 0;
 }
 
-static struct gnss_driver_api gnss_api = {
+static const struct gnss_driver_api gnss_api = {
 	.set_fix_rate = quectel_lcx6g_set_fix_rate,
 	.get_fix_rate = quectel_lcx6g_get_fix_rate,
 	.set_navigation_mode = quectel_lcx6g_set_navigation_mode,
@@ -837,7 +837,7 @@ static int quectel_lcx6g_init(const struct device *dev)
 	_CONCAT(_CONCAT(_CONCAT(name, _), DT_DRV_COMPAT), inst)
 
 #define LCX6G_DEVICE(inst)								\
-	static struct quectel_lcx6g_config LCX6G_INST_NAME(inst, config) = {		\
+	static const struct quectel_lcx6g_config LCX6G_INST_NAME(inst, config) = {	\
 		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),				\
 		.pps_mode = DT_INST_STRING_UPPER_TOKEN(inst, pps_mode),			\
 		.pps_pulse_width = DT_INST_PROP(inst, pps_pulse_width),			\

--- a/drivers/gnss/gnss_u_blox_m10.c
+++ b/drivers/gnss/gnss_u_blox_m10.c
@@ -933,7 +933,7 @@ unlock:
 	return ret;
 }
 
-static struct gnss_driver_api gnss_api = {
+static const struct gnss_driver_api gnss_api = {
 	.set_fix_rate = ubx_m10_set_fix_rate,
 	.get_fix_rate = ubx_m10_get_fix_rate,
 	.set_navigation_mode = ubx_m10_set_navigation_mode,
@@ -1020,7 +1020,7 @@ static int ubx_m10_init(const struct device *dev)
 }
 
 #define UBX_M10(inst)										\
-	static struct ubx_m10_config ubx_m10_cfg_##inst = {					\
+	static const struct ubx_m10_config ubx_m10_cfg_##inst = {				\
 		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),					\
 		.uart_baudrate = DT_PROP(DT_DRV_INST(inst), uart_baudrate),			\
 	};											\


### PR DESCRIPTION
This change marks each instance of the `gnss_xxx_config` and `gnss_driver_api` as `const`.

By using `const`, we ensure immutability, leading to usage of only `.rodata` and a reduction in the `.data` area.