### PR TITLE
samples: sensor: bme680: Allow coverage calculation

### DIFF
--- a/samples/sensor/bme680/src/main.c
+++ b/samples/sensor/bme680/src/main.c
@@ -21,7 +21,11 @@ int main(void)
 
 	printf("Device %p name is %s\n", dev, dev->name);
 
+#ifndef CONFIG_COVERAGE
 	while (1) {
+#else
+	for (int i = 0; i < 5; i++) {
+#endif
 		k_sleep(K_MSEC(3000));
 
 		sensor_sample_fetch(dev);


### PR DESCRIPTION
Sample must end to dump coverage data.