### PR TITLE
drivers: display: make driver API structs const

### DIFF
--- a/drivers/display/display_renesas_lcdc.c
+++ b/drivers/display/display_renesas_lcdc.c
@@ -606,7 +606,7 @@ static int display_smartbond_pm_action(const struct device *dev, enum pm_device_
 }
 #endif
 
-static struct display_driver_api display_smartbond_driver_api = {
+static const struct display_driver_api display_smartbond_driver_api = {
 	.write =  display_smartbond_write,
 	.read = display_smartbond_read,
 	.get_framebuffer = display_smartbond_get_framebuffer,

--- a/drivers/display/ls0xx.c
+++ b/drivers/display/ls0xx.c
@@ -278,7 +278,7 @@ static const struct ls0xx_config ls0xx_config = {
 #endif
 };
 
-static struct display_driver_api ls0xx_driver_api = {
+static const struct display_driver_api ls0xx_driver_api = {
 	.blanking_on = ls0xx_blanking_on,
 	.blanking_off = ls0xx_blanking_off,
 	.write = ls0xx_write,

--- a/drivers/display/ssd1306.c
+++ b/drivers/display/ssd1306.c
@@ -455,7 +455,7 @@ static int ssd1306_init(const struct device *dev)
 	return 0;
 }
 
-static struct display_driver_api ssd1306_driver_api = {
+static const struct display_driver_api ssd1306_driver_api = {
 	.blanking_on = ssd1306_suspend,
 	.blanking_off = ssd1306_resume,
 	.write = ssd1306_write,

--- a/drivers/display/ssd16xx.c
+++ b/drivers/display/ssd16xx.c
@@ -1020,7 +1020,7 @@ static int ssd16xx_init(const struct device *dev)
 	return ssd16xx_controller_init(dev);
 }
 
-static struct display_driver_api ssd16xx_driver_api = {
+static const struct display_driver_api ssd16xx_driver_api = {
 	.blanking_on = ssd16xx_blanking_on,
 	.blanking_off = ssd16xx_blanking_off,
 	.write = ssd16xx_write,

--- a/drivers/display/uc81xx.c
+++ b/drivers/display/uc81xx.c
@@ -754,7 +754,7 @@ static const struct uc81xx_quirks uc8179_quirks = {
 };
 #endif
 
-static struct display_driver_api uc81xx_driver_api = {
+static const struct display_driver_api uc81xx_driver_api = {
 	.blanking_on = uc81xx_blanking_on,
 	.blanking_off = uc81xx_blanking_off,
 	.write = uc81xx_write,


### PR DESCRIPTION
Save precious RAM by making sure driver API structs are declared as const

before: 
```
$ west build -b az3166_iotdevkit/stm32f412rx samples/subsys/display/lvgl -p auto

...

Memory region         Used Size  Region Size  %age Used
           FLASH:      237908 B         1 MB     22.69%
             RAM:       35136 B       256 KB     13.40%
        IDT_LIST:          0 GB        32 KB      0.00%
```

after:

```
Memory region         Used Size  Region Size  %age Used
           FLASH:      237908 B         1 MB     22.69%
             RAM:       35072 B       256 KB     13.38%
        IDT_LIST:          0 GB        32 KB      0.00%
```
