### PR TITLE
Bluetooth: BAP: Add bt_bap_base_get_size function

### DIFF
--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -1441,6 +1441,16 @@ struct bt_bap_base_subgroup_bis {
 const struct bt_bap_base *bt_bap_base_get_base_from_ad(const struct bt_data *ad);
 
 /**
+ * @brief Get the size of a BASE
+ *
+ * @param base The BASE pointer
+ *
+ * @retval -EINVAL if arguments are invalid
+ * @retval The size of the BASE
+ */
+int bt_bap_base_get_size(const struct bt_bap_base *base);
+
+/**
  * @brief Get the presentation delay value of a BASE
  *
  * @param base The BASE pointer

--- a/subsys/bluetooth/audio/bap_base.c
+++ b/subsys/bluetooth/audio/bap_base.c
@@ -221,6 +221,58 @@ const struct bt_bap_base *bt_bap_base_get_base_from_ad(const struct bt_data *ad)
 	return base;
 }
 
+int bt_bap_base_get_size(const struct bt_bap_base *base)
+{
+	struct net_buf_simple net_buf;
+	uint8_t subgroup_count;
+	size_t size = 0;
+
+	CHECKIF(base == NULL) {
+		LOG_DBG("base is NULL");
+
+		return -EINVAL;
+	}
+
+	net_buf_simple_init_with_data(&net_buf, (void *)base, BASE_MAX_SIZE);
+	base_pull_pd(&net_buf);
+	size += BASE_PD_SIZE;
+	subgroup_count = net_buf_simple_pull_u8(&net_buf);
+	size += BASE_SUBGROUP_COUNT_SIZE;
+
+	/* Parse subgroup data */
+	for (uint8_t i = 0U; i < subgroup_count; i++) {
+		uint8_t bis_count;
+		uint8_t len;
+
+		bis_count = base_pull_bis_count(&net_buf);
+		size += BASE_NUM_BIS_SIZE;
+
+		base_pull_codec_id(&net_buf, NULL);
+		size += BASE_CODEC_ID_SIZE;
+
+		/* Codec config */
+		len = base_pull_ltv(&net_buf, NULL);
+		size += len + BASE_CC_LEN_SIZE;
+
+		/* meta */
+		len = base_pull_ltv(&net_buf, NULL);
+		size += len + BASE_META_LEN_SIZE;
+
+		/* Parse BIS data */
+		for (uint8_t j = 0U; j < bis_count; j++) {
+			/* BIS index */
+			net_buf_simple_pull_u8(&net_buf);
+			size += BASE_BIS_INDEX_SIZE;
+
+			/* Codec config */
+			len = base_pull_ltv(&net_buf, NULL);
+			size += len + BASE_BIS_CC_LEN_SIZE;
+		}
+	}
+
+	return (int)size;
+}
+
 int bt_bap_base_get_pres_delay(const struct bt_bap_base *base)
 {
 	struct net_buf_simple net_buf;

--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -748,7 +748,7 @@ static bool pa_decode_base(struct bt_data *data, void *user_data)
 	struct bt_bap_broadcast_sink *sink = (struct bt_bap_broadcast_sink *)user_data;
 	const struct bt_bap_base *base = bt_bap_base_get_base_from_ad(data);
 	struct bt_bap_broadcast_sink_cb *listener;
-	size_t base_size;
+	int base_size;
 	int ret;
 
 	/* Base is NULL if the data does not contain a valid BASE */
@@ -794,11 +794,16 @@ static bool pa_decode_base(struct bt_data *data, void *user_data)
 	}
 
 	/* We provide the BASE without the service data UUID */
-	base_size = data->data_len - BT_UUID_SIZE_16;
+	base_size = bt_bap_base_get_size(base);
+	if (base_size < 0) {
+		LOG_DBG("BASE get size failed (%d)", base_size);
+
+		return false;
+	}
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&sink_cbs, listener, _node) {
 		if (listener->base_recv != NULL) {
-			listener->base_recv(sink, base, base_size);
+			listener->base_recv(sink, base, (size_t)base_size);
 		}
 	}
 

--- a/tests/bluetooth/audio/bap_base/src/main.c
+++ b/tests/bluetooth/audio/bap_base/src/main.c
@@ -154,6 +154,25 @@ ZTEST_F(bap_base_test_suite, test_base_get_base_from_ad_inval_param_uuid)
 	zassert_is_null(base);
 }
 
+ZTEST_F(bap_base_test_suite, test_base_get_size)
+{
+	const struct bt_bap_base *base = bt_bap_base_get_base_from_ad(&fixture->valid_base_ad);
+	int ret;
+
+	zassert_not_null(base);
+
+	ret = bt_bap_base_get_size(base);
+	zassert_equal(ret, 70, "Unexpected BASE size: %d", ret);
+}
+
+ZTEST_F(bap_base_test_suite, test_base_get_size_inval_param_null)
+{
+	int ret;
+
+	ret = bt_bap_base_get_size(NULL);
+	zassert_equal(ret, -EINVAL, "Unexpected return value: %d", ret);
+}
+
 ZTEST_F(bap_base_test_suite, test_base_get_pres_delay)
 {
 	const struct bt_bap_base *base = bt_bap_base_get_base_from_ad(&fixture->valid_base_ad);


### PR DESCRIPTION
bt_bap_base_get_size function returns the size of the BASE (struct bt_bap_base).

Fixes #73847