### PR TITLE
ARC: enable barriers for HS

### DIFF
--- a/arch/arc/Kconfig
+++ b/arch/arc/Kconfig
@@ -18,6 +18,7 @@ config CPU_ARCEM
 config CPU_ARCHS
 	bool
 	select ATOMIC_OPERATIONS_BUILTIN
+	select BARRIER_OPERATIONS_BUILTIN
 	help
 	  This option signifies the use of an ARC HS CPU
 


### PR DESCRIPTION
As we start to use data memory barriers in SMP scheduler code explicitly (not only internaly in the atomics implementation) let's enable barriers for ARC HS.