### PR TITLE
drivers: clock_control: make driver API and conf structs const

### DIFF
--- a/drivers/clock_control/clock_control_gd32.c
+++ b/drivers/clock_control/clock_control_gd32.c
@@ -198,7 +198,7 @@ clock_control_gd32_get_status(const struct device *dev,
 	return CLOCK_CONTROL_STATUS_OFF;
 }
 
-static struct clock_control_driver_api clock_control_gd32_api = {
+static const struct clock_control_driver_api clock_control_gd32_api = {
 	.on = clock_control_gd32_on,
 	.off = clock_control_gd32_off,
 	.get_rate = clock_control_gd32_get_rate,

--- a/drivers/clock_control/clock_control_litex.c
+++ b/drivers/clock_control/clock_control_litex.c
@@ -26,7 +26,7 @@ static struct litex_clk_device *ldev;	/* global struct for whole driver */
 static struct litex_clk_clkout *clkouts;/* clkout array for whole driver */
 
 /* All DRP regs addresses and sizes */
-static struct litex_drp_reg drp[] = {
+static const struct litex_drp_reg drp[] = {
 	{DRP_ADDR_RESET,  1},
 	{DRP_ADDR_LOCKED, 1},
 	{DRP_ADDR_READ,   1},

--- a/drivers/clock_control/clock_control_mchp_xec.c
+++ b/drivers/clock_control/clock_control_mchp_xec.c
@@ -1014,7 +1014,7 @@ void mchp_xec_clk_ctrl_sys_sleep_disable(void)
 #endif
 
 /* Clock controller driver registration */
-static struct clock_control_driver_api xec_clock_control_api = {
+static const struct clock_control_driver_api xec_clock_control_api = {
 	.on = xec_clock_control_on,
 	.off = xec_clock_control_off,
 	.get_rate = xec_clock_control_get_subsys_rate,

--- a/drivers/clock_control/clock_control_npcx.c
+++ b/drivers/clock_control/clock_control_npcx.c
@@ -147,7 +147,7 @@ void npcx_clock_control_turn_off_system_sleep(void)
 #endif /* CONFIG_PM */
 
 /* Clock controller driver registration */
-static struct clock_control_driver_api npcx_clock_control_api = {
+static const struct clock_control_driver_api npcx_clock_control_api = {
 	.on = npcx_clock_control_on,
 	.off = npcx_clock_control_off,
 	.get_rate = npcx_clock_control_get_subsys_rate,

--- a/drivers/clock_control/clock_control_nrf_auxpll.c
+++ b/drivers/clock_control/clock_control_nrf_auxpll.c
@@ -99,7 +99,7 @@ static enum clock_control_status clock_control_nrf_auxpll_get_status(const struc
 	return CLOCK_CONTROL_STATUS_OFF;
 }
 
-static struct clock_control_driver_api clock_control_nrf_auxpll_api = {
+static const struct clock_control_driver_api clock_control_nrf_auxpll_api = {
 	.on = clock_control_nrf_auxpll_on,
 	.off = clock_control_nrf_auxpll_off,
 	.get_rate = clock_control_nrf_auxpll_get_rate,

--- a/drivers/clock_control/clock_control_numaker_scc.c
+++ b/drivers/clock_control/clock_control_numaker_scc.c
@@ -95,7 +95,7 @@ static inline int numaker_scc_configure(const struct device *dev, clock_control_
 }
 
 /* System clock controller driver registration */
-static struct clock_control_driver_api numaker_scc_api = {
+static const struct clock_control_driver_api numaker_scc_api = {
 	.on = numaker_scc_on,
 	.off = numaker_scc_off,
 	.get_rate = numaker_scc_get_rate,

--- a/drivers/clock_control/clock_control_pwm.c
+++ b/drivers/clock_control/clock_control_pwm.c
@@ -129,7 +129,7 @@ static int clock_control_pwm_init(const struct device *dev)
 	return 0;
 }
 
-static struct clock_control_driver_api clock_control_pwm_api = {
+static const struct clock_control_driver_api clock_control_pwm_api = {
 	.on = clock_control_pwm_on,
 	.get_rate = clock_control_pwm_get_rate,
 	.set_rate = clock_control_pwm_set_rate,

--- a/drivers/clock_control/clock_control_rv32m1_pcc.c
+++ b/drivers/clock_control/clock_control_rv32m1_pcc.c
@@ -58,7 +58,7 @@ static const struct clock_control_driver_api rv32m1_pcc_api = {
 };
 
 #define RV32M1_PCC_INIT(inst)						\
-	static struct rv32m1_pcc_config rv32m1_pcc##inst##_config = {	\
+	static const struct rv32m1_pcc_config rv32m1_pcc##inst##_config = {	\
 		.base_address = DT_INST_REG_ADDR(inst)			\
 	};								\
 									\

--- a/drivers/clock_control/clock_control_sam_pmc.c
+++ b/drivers/clock_control/clock_control_sam_pmc.c
@@ -129,7 +129,7 @@ atmel_sam_clock_control_get_status(const struct device *dev,
 	return status;
 }
 
-static struct clock_control_driver_api atmel_sam_clock_control_api = {
+static const struct clock_control_driver_api atmel_sam_clock_control_api = {
 	.on = atmel_sam_clock_control_on,
 	.off = atmel_sam_clock_control_off,
 	.get_rate = atmel_sam_clock_control_get_rate,

--- a/drivers/clock_control/clock_control_smartbond.c
+++ b/drivers/clock_control/clock_control_smartbond.c
@@ -582,7 +582,7 @@ int smartbond_clocks_init(const struct device *dev)
 	return 0;
 }
 
-static struct clock_control_driver_api smartbond_clock_control_api = {
+static const struct clock_control_driver_api smartbond_clock_control_api = {
 	.on = smartbond_clock_control_on,
 	.off = smartbond_clock_control_off,
 	.get_rate = smartbond_clock_control_get_rate,

--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -473,7 +473,7 @@ static enum clock_control_status stm32_clock_control_get_status(const struct dev
 	}
 }
 
-static struct clock_control_driver_api stm32_clock_control_api = {
+static const struct clock_control_driver_api stm32_clock_control_api = {
 	.on = stm32_clock_control_on,
 	.off = stm32_clock_control_off,
 	.get_rate = stm32_clock_control_get_subsys_rate,

--- a/drivers/clock_control/clock_stm32_ll_h5.c
+++ b/drivers/clock_control/clock_stm32_ll_h5.c
@@ -338,7 +338,7 @@ static int stm32_clock_control_get_subsys_rate(const struct device *dev,
 	return 0;
 }
 
-static struct clock_control_driver_api stm32_clock_control_api = {
+static const struct clock_control_driver_api stm32_clock_control_api = {
 	.on = stm32_clock_control_on,
 	.off = stm32_clock_control_off,
 	.get_rate = stm32_clock_control_get_subsys_rate,

--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -648,7 +648,7 @@ static int stm32_clock_control_get_subsys_rate(const struct device *clock,
 	return 0;
 }
 
-static struct clock_control_driver_api stm32_clock_control_api = {
+static const struct clock_control_driver_api stm32_clock_control_api = {
 	.on = stm32_clock_control_on,
 	.off = stm32_clock_control_off,
 	.get_rate = stm32_clock_control_get_subsys_rate,

--- a/drivers/clock_control/clock_stm32_ll_mp1.c
+++ b/drivers/clock_control/clock_stm32_ll_mp1.c
@@ -393,7 +393,7 @@ static int stm32_clock_control_get_subsys_rate(const struct device *clock,
 	return 0;
 }
 
-static struct clock_control_driver_api stm32_clock_control_api = {
+static const struct clock_control_driver_api stm32_clock_control_api = {
 	.on = stm32_clock_control_on,
 	.off = stm32_clock_control_off,
 	.get_rate = stm32_clock_control_get_subsys_rate,

--- a/drivers/clock_control/clock_stm32_ll_u5.c
+++ b/drivers/clock_control/clock_stm32_ll_u5.c
@@ -376,7 +376,7 @@ static enum clock_control_status stm32_clock_control_get_status(const struct dev
 	}
 }
 
-static struct clock_control_driver_api stm32_clock_control_api = {
+static const struct clock_control_driver_api stm32_clock_control_api = {
 	.on = stm32_clock_control_on,
 	.off = stm32_clock_control_off,
 	.get_rate = stm32_clock_control_get_subsys_rate,

--- a/drivers/clock_control/clock_stm32_ll_wba.c
+++ b/drivers/clock_control/clock_stm32_ll_wba.c
@@ -290,7 +290,7 @@ static enum clock_control_status stm32_clock_control_get_status(const struct dev
 	}
 }
 
-static struct clock_control_driver_api stm32_clock_control_api = {
+static const struct clock_control_driver_api stm32_clock_control_api = {
 	.on = stm32_clock_control_on,
 	.off = stm32_clock_control_off,
 	.get_rate = stm32_clock_control_get_subsys_rate,


### PR DESCRIPTION
Save precious RAM by making sure driver API and config structs are declared as const

As examples of the improvement: 

- Saves 24 bytes of RAM on `west build -b gd32a503v_eval/gd32a503 samples/hello_world/`
- Saves 36 bytes of RAM on `west build -b az3166_iotdevkit/stm32f412rx samples/hello_world`