### PR TITLE
drivers: crypto: make driver API and conf structs const

### DIFF
--- a/drivers/crypto/crypto_it8xxx2_sha.c
+++ b/drivers/crypto/crypto_it8xxx2_sha.c
@@ -215,7 +215,7 @@ static int it8xxx2_sha_init(const struct device *dev)
 	return 0;
 }
 
-static struct crypto_driver_api it8xxx2_crypto_api = {
+static const struct crypto_driver_api it8xxx2_crypto_api = {
 	.hash_begin_session = it8xxx2_hash_begin_session,
 	.hash_free_session = it8xxx2_hash_session_free,
 	.query_hw_caps = it8xxx2_query_hw_caps,

--- a/drivers/crypto/crypto_it8xxx2_sha_v2.c
+++ b/drivers/crypto/crypto_it8xxx2_sha_v2.c
@@ -340,7 +340,7 @@ static int it8xxx2_sha_init(const struct device *dev)
 	return 0;
 }
 
-static struct crypto_driver_api it8xxx2_crypto_api = {
+static const struct crypto_driver_api it8xxx2_crypto_api = {
 	.hash_begin_session = it8xxx2_hash_begin_session,
 	.hash_free_session = it8xxx2_hash_session_free,
 	.query_hw_caps = it8xxx2_query_hw_caps,

--- a/drivers/crypto/crypto_mchp_xec_symcr.c
+++ b/drivers/crypto/crypto_mchp_xec_symcr.c
@@ -514,7 +514,7 @@ static int xec_symcr_init(const struct device *dev)
 	return ret;
 }
 
-static struct crypto_driver_api xec_symcr_api = {
+static const struct crypto_driver_api xec_symcr_api = {
 	.query_hw_caps = xec_symcr_query_hw_caps,
 	.hash_begin_session = xec_symcr_hash_session_begin,
 	.hash_free_session = xec_symcr_hash_session_free,

--- a/drivers/crypto/crypto_mcux_dcp.c
+++ b/drivers/crypto/crypto_mcux_dcp.c
@@ -331,7 +331,7 @@ static int crypto_dcp_init(const struct device *dev)
 	return 0;
 }
 
-static struct crypto_driver_api crypto_dcp_api = {
+static const struct crypto_driver_api crypto_dcp_api = {
 	.query_hw_caps = crypto_dcp_query_hw_caps,
 	.cipher_begin_session = crypto_dcp_cipher_begin_session,
 	.cipher_free_session = crypto_dcp_cipher_free_session,

--- a/drivers/crypto/crypto_npcx_sha.c
+++ b/drivers/crypto/crypto_npcx_sha.c
@@ -202,7 +202,7 @@ static int npcx_hash_init(const struct device *dev)
 	return 0;
 }
 
-static struct crypto_driver_api npcx_crypto_api = {
+static const struct crypto_driver_api npcx_crypto_api = {
 	.hash_begin_session = npcx_hash_session_setup,
 	.hash_free_session = npcx_hash_session_free,
 	.query_hw_caps = npcx_query_caps,

--- a/drivers/crypto/crypto_smartbond.c
+++ b/drivers/crypto/crypto_smartbond.c
@@ -922,7 +922,7 @@ crypto_smartbond_hash_set_async_callback(const struct device *dev, hash_completi
 }
 #endif
 
-static struct crypto_driver_api crypto_smartbond_driver_api = {
+static const struct crypto_driver_api crypto_smartbond_driver_api = {
 	.cipher_begin_session = crypto_smartbond_cipher_begin_session,
 	.cipher_free_session = crypto_smartbond_cipher_free_session,
 #if defined(CONFIG_CRYPTO_ASYNC)

--- a/drivers/crypto/crypto_stm32.c
+++ b/drivers/crypto/crypto_stm32.c
@@ -507,7 +507,7 @@ static struct crypto_stm32_data crypto_stm32_dev_data = {
 	}
 };
 
-static struct crypto_stm32_config crypto_stm32_dev_config = {
+static const struct crypto_stm32_config crypto_stm32_dev_config = {
 	.pclken = {
 		.enr = DT_INST_CLOCKS_CELL(0, bits),
 		.bus = DT_INST_CLOCKS_CELL(0, bus)


### PR DESCRIPTION
Save precious RAM by making sure driver API and config structs are declared as const

As an example, this saves 32 bytes of RAM for `west build -b da1469x_dk_pro/da14699 samples/drivers/crypto`