### PR TITLE
modem: chat: patch unintended behavior in modem_chat_run_script()

### DIFF
--- a/subsys/modem/modem_chat.c
+++ b/subsys/modem/modem_chat.c
@@ -877,6 +877,8 @@ int modem_chat_run_script_async(struct modem_chat *chat, const struct modem_chat
 		return -EBUSY;
 	}
 
+	k_sem_reset(&chat->script_stopped_sem);
+
 	chat->pending_script = script;
 	k_work_submit(&chat->script_run_work);
 	return 0;
@@ -885,8 +887,6 @@ int modem_chat_run_script_async(struct modem_chat *chat, const struct modem_chat
 int modem_chat_run_script(struct modem_chat *chat, const struct modem_chat_script *script)
 {
 	int ret;
-
-	k_sem_reset(&chat->script_stopped_sem);
 
 	ret = modem_chat_run_script_async(chat, script);
 	if (ret < 0) {


### PR DESCRIPTION
Trying to start a chat script using either modem_chat_run_script() or modem_chat_run_script_async() should result in returning -EBUSY without affecting the currently running script and thread waiting on the current script to stop.

The current behavior causes the thread waiting for the current script to stop to return with error -EAGAIN, and the thread trying to start the new script to return with error -EBUSY.

This commit moves the reset of the sem the current thread is waiting on, to after the check of whether a script is currently running, leaving the current thread unaffected as is intended.

Bug discovered by @jakubjaszcz 