### PR TITLE
boards: infineon: cyw20829m2evk_02: update memory partitions map

### DIFF
--- a/boards/infineon/cyw920829m2evk_02/cyw920829m2evk_02.dts
+++ b/boards/infineon/cyw920829m2evk_02/cyw920829m2evk_02.dts
@@ -99,15 +99,15 @@ uart2: &scb2 {
 			bootstrap_region: flash@60000050 {
 				compatible = "zephyr,memory-region", "soc-nv-flash";
 				zephyr,memory-region = "BOOTSTRAP_FLASH";
-				reg = <0x60000050 0x2550>;
+				reg = <0x60000050 DT_SIZE_K(12)>;
 			};
-			app_region: flash@60002600 {
+			app_region: flash@60003050 {
 				compatible = "soc-nv-flash";
-				reg = <0x60002600 0x5da00>;
+				reg = <0x60003050 0x6CFB0>; /* 435kb */
 			};
-			storage_partition: flash@60060000 {
+			storage_partition: flash@60070000 {
 				compatible = "soc-nv-flash";
-				reg = <0x60060000 0x20000>;
+				reg = <0x60070000 DT_SIZE_K(64)>;
 			};
 		};
 	};

--- a/dts/arm/infineon/cat1b/cyw20829/cyw20829.dtsi
+++ b/dts/arm/infineon/cat1b/cyw20829/cyw20829.dtsi
@@ -21,13 +21,13 @@
 
 	sram0: memory@20000000 {
 		compatible = "mmio-sram";
-		reg = <0x20000000 0x3DC00>;
+		reg = <0x20000000 DT_SIZE_K(244)>;
 	};
 
-	sram_bootstrap: memory@2003DC00 {
+	sram_bootstrap: memory@2003D000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		zephyr,memory-region = "BOOTSTRAP_RAM";
-		reg = <0x2003DC00 0x2400>;
+		reg = <0x2003D000 DT_SIZE_K(12)>;
 	};
 
 	soc {


### PR DESCRIPTION
With current memory map configuration we have build error with some samples where enabled no_optimization option.
Refer to twister log for details: https://github.com/zephyrproject-rtos/zephyr/actions/runs/9403512709/job/25901560157?pr=73748

So update memory partitions map as following:

ram:
sram:                   : 244k  (addr 0x20000000)
sram_bootstrap   : 12k   (addr 0x2003D000)

flash:
toc2_region         : 80b   (addr 0x60000000)
bootstrap_region : 12k   (addr 0x60000050)
app_region          : 435k  (addr 0x60003050)
storage_partition : 64k   (addr 0x60070000)