### PR TITLE
drivers: lora: Add low power IRQ mode

### DIFF
--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -556,6 +556,10 @@ Libraries / Subsystems
 
 * LoRa/LoRaWAN
 
+  * Added :kconfig:option:`CONFIG_LORA_SX127X_IRQS_ONLY_WHEN_ACTIVE` which allows for IRQs to be
+    enabled when the radio begins transmission and disabled when the radio ends transmission. This
+    is useful for devices where having interrupts enabled causes a large power drain.
+
 * ZBus
 
 HALs

--- a/drivers/lora/Kconfig.sx12xx
+++ b/drivers/lora/Kconfig.sx12xx
@@ -14,6 +14,19 @@ config LORA_SX127X
 	help
 	  Enable LoRa driver for Semtech SX1272 and SX1276.
 
+if LORA_SX127X
+
+config LORA_SX127X_IRQS_ONLY_WHEN_ACTIVE
+	bool "Only enable IRQs when radio is active"
+	default y if SOC_SERIES_NRF51X
+	help
+	  If enabled, this option will enable IRQs for the LoRa radio when the stack enables the
+	  antenna and disables them when the stack disables the antenna. This is intended for use
+	  on devices where having IRQs enabled cause the device to consume a large amount of
+	  power, e.g. nRF51.
+
+endif # LORA_SX127X
+
 config LORA_SX126X
 	bool "Semtech SX126x driver"
 	default y


### PR DESCRIPTION
Fixes an issue with devices that have high power usage when interrupts are enabled (e.g. nRF51) and the LoRa driver is enabled which would otherwise result in a constant very large power draw

On nRF51 reduces idle current consumption from 1.3mA to 68uA