### PR TITLE
sensors: Submit call returns void

### DIFF
--- a/drivers/sensor/asahi_kasei/akm09918c/akm09918c.h
+++ b/drivers/sensor/asahi_kasei/akm09918c/akm09918c.h
@@ -93,6 +93,6 @@ int akm09918c_sample_fetch_helper(const struct device *dev, enum sensor_channel 
 
 int akm09918c_get_decoder(const struct device *dev, const struct sensor_decoder_api **decoder);
 
-int akm09918c_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe);
+void akm09918c_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe);
 
 #endif /* ZEPHYR_DRIVERS_SENSOR_AKM09918C_AKM09918C_H_ */

--- a/drivers/sensor/asahi_kasei/akm09918c/akm09918c_async.c
+++ b/drivers/sensor/asahi_kasei/akm09918c/akm09918c_async.c
@@ -9,7 +9,7 @@
 
 LOG_MODULE_DECLARE(AKM09918C, CONFIG_SENSOR_LOG_LEVEL);
 
-int akm09918c_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
+void akm09918c_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
 {
 	uint32_t min_buf_len = sizeof(struct akm09918c_encoded_data);
 	int rc;
@@ -22,7 +22,7 @@ int akm09918c_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
 	if (rc != 0) {
 		LOG_ERR("Failed to get a read buffer of size %u bytes", min_buf_len);
 		rtio_iodev_sqe_err(iodev_sqe, rc);
-		return rc;
+		return;
 	}
 
 	edata = (struct akm09918c_encoded_data *)buf;
@@ -33,10 +33,8 @@ int akm09918c_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
 	if (rc != 0) {
 		LOG_ERR("Failed to fetch samples");
 		rtio_iodev_sqe_err(iodev_sqe, rc);
-		return rc;
+		return;
 	}
 
 	rtio_iodev_sqe_ok(iodev_sqe, 0);
-
-	return 0;
 }

--- a/drivers/sensor/bosch/bme280/bme280.h
+++ b/drivers/sensor/bosch/bme280/bme280.h
@@ -211,7 +211,7 @@ struct bme280_encoded_data {
 
 int bme280_get_decoder(const struct device *dev, const struct sensor_decoder_api **decoder);
 
-int bme280_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe);
+void bme280_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe);
 
 int bme280_sample_fetch(const struct device *dev,
 			       enum sensor_channel chan);

--- a/drivers/sensor/bosch/bme280/bme280_async.c
+++ b/drivers/sensor/bosch/bme280/bme280_async.c
@@ -9,7 +9,7 @@
 
 LOG_MODULE_DECLARE(BME280, CONFIG_SENSOR_LOG_LEVEL);
 
-int bme280_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
+void bme280_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
 {
 	uint32_t min_buf_len = sizeof(struct bme280_encoded_data);
 	int rc;
@@ -31,7 +31,7 @@ int bme280_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
 		default:
 			LOG_ERR("Unsupported channel type %d", channels[i].chan_type);
 			rtio_iodev_sqe_err(iodev_sqe, -ENOTSUP);
-			return -ENOTSUP;
+			return;
 		}
 	}
 
@@ -39,7 +39,7 @@ int bme280_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
 	if (rc != 0) {
 		LOG_ERR("Failed to get a read buffer of size %u bytes", min_buf_len);
 		rtio_iodev_sqe_err(iodev_sqe, rc);
-		return rc;
+		return;
 	}
 
 	struct bme280_encoded_data *edata;
@@ -52,10 +52,8 @@ int bme280_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
 	if (rc != 0) {
 		LOG_ERR("Failed to fetch samples");
 		rtio_iodev_sqe_err(iodev_sqe, rc);
-		return rc;
+		return;
 	}
 
 	rtio_iodev_sqe_ok(iodev_sqe, 0);
-
-	return 0;
 }

--- a/drivers/sensor/tdk/icm42688/icm42688_rtio.h
+++ b/drivers/sensor/tdk/icm42688/icm42688_rtio.h
@@ -10,9 +10,9 @@
 #include <zephyr/device.h>
 #include <zephyr/rtio/rtio.h>
 
-int icm42688_submit(const struct device *sensor, struct rtio_iodev_sqe *iodev_sqe);
+void icm42688_submit(const struct device *sensor, struct rtio_iodev_sqe *iodev_sqe);
 
-int icm42688_submit_stream(const struct device *sensor, struct rtio_iodev_sqe *iodev_sqe);
+void icm42688_submit_stream(const struct device *sensor, struct rtio_iodev_sqe *iodev_sqe);
 
 void icm42688_fifo_event(const struct device *dev);
 

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -687,7 +687,7 @@ struct sensor_read_config {
 	RTIO_IODEV_DEFINE(name, &__sensor_iodev_api, &_CONCAT(__sensor_read_config_, name))
 
 /* Used to submit an RTIO sqe to the sensor's iodev */
-typedef int (*sensor_submit_t)(const struct device *sensor, struct rtio_iodev_sqe *sqe);
+typedef void (*sensor_submit_t)(const struct device *sensor, struct rtio_iodev_sqe *sqe);
 
 /* The default decoder API */
 extern const struct sensor_decoder_api __sensor_default_decoder;

--- a/subsys/sensing/sensing_sensor.c
+++ b/subsys/sensing/sensing_sensor.c
@@ -22,6 +22,7 @@ static void sensing_iodev_submit(struct rtio_iodev_sqe *iodev_sqe)
 	if (api->submit != NULL) {
 		api->submit(dev, iodev_sqe);
 	} else {
+		LOG_ERR("submit function not supported for device %p %s!\n", dev, dev->name);
 		rtio_iodev_sqe_err(iodev_sqe, -ENOTSUP);
 	}
 }

--- a/subsys/sensing/sensor/phy_3d_sensor/phy_3d_sensor.c
+++ b/subsys/sensing/sensor/phy_3d_sensor/phy_3d_sensor.c
@@ -159,7 +159,7 @@ static int phy_3d_sensor_attr_set(const struct device *dev,
 	return ret;
 }
 
-static int phy_3d_sensor_submit(const struct device *dev,
+static void phy_3d_sensor_submit(const struct device *dev,
 		struct rtio_iodev_sqe *sqe)
 {
 	struct sensing_submit_config *config = (struct sensing_submit_config *)sqe->sqe.iodev->data;
@@ -175,21 +175,21 @@ static int phy_3d_sensor_submit(const struct device *dev,
 			(uint8_t **)&sample, &buffer_len);
 	if (ret) {
 		rtio_iodev_sqe_err(sqe, ret);
-		return ret;
+		return;
 	}
 
 	ret = sensor_sample_fetch_chan(cfg->hw_dev, custom->chan_all);
 	if (ret) {
 		LOG_ERR("%s: sample fetch failed: %d", dev->name, ret);
 		rtio_iodev_sqe_err(sqe, ret);
-		return ret;
+		return;
 	}
 
 	ret = sensor_channel_get(cfg->hw_dev, custom->chan_all, value);
 	if (ret) {
 		LOG_ERR("%s: channel get failed: %d", dev->name, ret);
 		rtio_iodev_sqe_err(sqe, ret);
-		return ret;
+		return;
 	}
 
 	for (i = 0; i < ARRAY_SIZE(value); ++i) {
@@ -206,7 +206,7 @@ static int phy_3d_sensor_submit(const struct device *dev,
 			sample->readings[0].z);
 
 	rtio_iodev_sqe_ok(sqe, 0);
-	return 0;
+	return;
 }
 
 static const struct sensor_driver_api phy_3d_sensor_api = {


### PR DESCRIPTION
The integer return of sensor_submit should be void as the call is asynchronous and the response is meant to be delivered using RTIO APIs signaling that the submission completed with error or success.

Change the function signature to void and fix all uses of the submit API, fixing some bugs in the process.