### PR TITLE
posix: allow for external implementation of option groups

### DIFF
--- a/lib/posix/options/CMakeLists.txt
+++ b/lib/posix/options/CMakeLists.txt
@@ -8,18 +8,20 @@ if(CONFIG_POSIX_API)
   zephyr_include_directories(${ZEPHYR_BASE}/include/zephyr/posix)
 endif()
 
-if(CONFIG_POSIX_SIGNALS)
-  set(STRSIGNAL_TABLE_H ${GEN_DIR}/posix/strsignal_table.h)
+if (NOT CONFIG_TC_PROVIDES_POSIX_SIGNALS)
+  if(CONFIG_POSIX_SIGNALS)
+    set(STRSIGNAL_TABLE_H ${GEN_DIR}/posix/strsignal_table.h)
 
-  add_custom_command(
-    OUTPUT ${STRSIGNAL_TABLE_H}
-    COMMAND
-    ${PYTHON_EXECUTABLE}
-    ${ZEPHYR_BASE}/scripts/build/gen_strsignal_table.py
-    -i ${ZEPHYR_BASE}/include/zephyr/posix/signal.h
-    -o ${STRSIGNAL_TABLE_H}
-    DEPENDS ${ZEPHYR_BASE}/include/zephyr/posix/signal.h
-  )
+    add_custom_command(
+      OUTPUT ${STRSIGNAL_TABLE_H}
+      COMMAND
+      ${PYTHON_EXECUTABLE}
+      ${ZEPHYR_BASE}/scripts/build/gen_strsignal_table.py
+      -i ${ZEPHYR_BASE}/include/zephyr/posix/signal.h
+      -o ${STRSIGNAL_TABLE_H}
+      DEPENDS ${ZEPHYR_BASE}/include/zephyr/posix/signal.h
+    )
+  endif()
 endif()
 
 if(CONFIG_POSIX_API OR CONFIG_POSIX_THREADS OR CONFIG_POSIX_TIMERS OR
@@ -33,60 +35,124 @@ endif()
 
 zephyr_library()
 zephyr_library_sources_ifdef(CONFIG_EVENTFD eventfd.c)
-zephyr_library_sources_ifdef(CONFIG_POSIX_ASYNCHRONOUS_IO aio.c)
-zephyr_library_sources_ifdef(CONFIG_POSIX_BARRIERS barrier.c)
-zephyr_library_sources_ifdef(CONFIG_POSIX_C_LIB_EXT
-  fnmatch.c
-  getentropy.c
-  getopt/getopt.c
-  getopt/getopt_common.c
-)
-zephyr_library_sources_ifdef(CONFIG_POSIX_DEVICE_IO
-  # perror should be moved to the common libc
-  perror.c
-  device_io.c
-)
-zephyr_library_sources_ifdef(CONFIG_POSIX_FD_MGMT
-  fd_mgmt.c
-)
-zephyr_library_sources_ifdef(CONFIG_POSIX_FILE_SYSTEM fs.c)
+
+if (NOT CONFIG_TC_PROVIDES_POSIX_ASYNCHRONOUS_IO)
+  zephyr_library_sources_ifdef(CONFIG_POSIX_ASYNCHRONOUS_IO aio.c)
+endif()
+
+if (NOT CONFIG_TC_PROVIDES_POSIX_BARRIERS)
+  zephyr_library_sources_ifdef(CONFIG_POSIX_BARRIERS barrier.c)
+endif()
+
+if (NOT CONFIG_TC_PROVIDES_POSIX_C_LIB_EXT)
+  zephyr_library_sources_ifdef(CONFIG_POSIX_C_LIB_EXT
+    fnmatch.c
+    getentropy.c
+    getopt/getopt.c
+    getopt/getopt_common.c
+  )
+endif()
+
+if (NOT CONFIG_TC_PROVIDES_POSIX_DEVICE_IO)
+  zephyr_library_sources_ifdef(CONFIG_POSIX_DEVICE_IO
+    # perror should be moved to the common libc
+    perror.c
+    device_io.c
+  )
+endif()
+
+if (NOT CONFIG_TC_PROVIDES_POSIX_FD_MGMT)
+  zephyr_library_sources_ifdef(CONFIG_POSIX_FD_MGMT
+    fd_mgmt.c
+  )
+endif()
+
+if (NOT CONFIG_TC_PROVIDES_POSIX_FILE_SYSTEM)
+  zephyr_library_sources_ifdef(CONFIG_POSIX_FILE_SYSTEM fs.c)
+endif()
+
 zephyr_library_sources_ifdef(CONFIG_POSIX_FSYNC fsync.c)
 zephyr_library_sources_ifdef(CONFIG_POSIX_MEMLOCK mlockall.c)
 zephyr_library_sources_ifdef(CONFIG_POSIX_MEMLOCK_RANGE mlock.c)
+
+if (NOT CONFIG_TC_PROVIDES_POSIX_MEMORY_PROTECTION)
 zephyr_library_sources_ifdef(CONFIG_POSIX_MEMORY_PROTECTION mprotect.c)
-zephyr_library_sources_ifdef(CONFIG_POSIX_MAPPED_FILES mmap.c)
+endif()
+
+if (NOT CONFIG_TC_PROVIDES_POSIX_MAPPED_FILES)
+  zephyr_library_sources_ifdef(CONFIG_POSIX_MAPPED_FILES mmap.c)
+endif()
+
 zephyr_library_sources_ifdef(CONFIG_POSIX_MESSAGE_PASSING mqueue.c)
-zephyr_library_sources_ifdef(CONFIG_POSIX_MULTI_PROCESS
-  sleep.c
-  multi_process.c
-)
-zephyr_library_sources_ifdef(CONFIG_POSIX_NETWORKING net.c)
-zephyr_library_sources_ifdef(CONFIG_POSIX_SHARED_MEMORY_OBJECTS shm.c)
-zephyr_library_sources_ifdef(CONFIG_POSIX_SIGNALS signal.c ${STRSIGNAL_TABLE_H})
-zephyr_library_sources_ifdef(CONFIG_POSIX_SINGLE_PROCESS
-  confstr.c
-  env.c
-  sysconf.c
-  uname.c
-)
-zephyr_library_sources_ifdef(CONFIG_POSIX_SPIN_LOCKS spinlock.c)
-zephyr_library_sources_ifdef(CONFIG_POSIX_SYSLOG syslog.c)
-zephyr_library_sources_ifdef(CONFIG_POSIX_TIMERS
-  clock.c
-  timer.c
-  timespec_to_timeout.c
-)
+
+if (NOT CONFIG_TC_PROVIDES_POSIX_MULTI_PROCESS)
+  zephyr_library_sources_ifdef(CONFIG_POSIX_MULTI_PROCESS
+    sleep.c
+    multi_process.c
+  )
+endif()
+
+if (NOT CONFIG_TC_PROVIDES_POSIX_NETWORKING)
+  zephyr_library_sources_ifdef(CONFIG_POSIX_NETWORKING net.c)
+endif()
+
+if (NOT CONFIG_TC_PROVIDES_POSIX_SHARED_MEMORY_OBJECTS)
+  zephyr_library_sources_ifdef(CONFIG_POSIX_SHARED_MEMORY_OBJECTS shm.c)
+endif()
+
+if (NOT CONFIG_TC_PROVIDES_POSIX_SIGNALS)
+  zephyr_library_sources_ifdef(CONFIG_POSIX_SIGNALS signal.c ${STRSIGNAL_TABLE_H})
+endif()
+
+if (NOT CONFIG_TC_PROVIDES_POSIX_SINGLE_PROCESS)
+  zephyr_library_sources_ifdef(CONFIG_POSIX_SINGLE_PROCESS
+    confstr.c
+    env.c
+    sysconf.c
+    uname.c
+  )
+endif()
+
+if (NOT CONFIG_TC_PROVIDES_POSIX_SPIN_LOCKS)
+  zephyr_library_sources_ifdef(CONFIG_POSIX_SPIN_LOCKS spinlock.c)
+endif()
+
+if (NOT CONFIG_TC_PROVIDES_POSIX_TIMERS)
+  zephyr_library_sources_ifdef(CONFIG_POSIX_TIMERS
+    clock.c
+    timer.c
+    timespec_to_timeout.c
+  )
+endif()
+
 zephyr_library_sources_ifdef(CONFIG_POSIX_PRIORITY_SCHEDULING sched.c)
-zephyr_library_sources_ifdef(CONFIG_POSIX_READER_WRITER_LOCKS rwlock.c)
-zephyr_library_sources_ifdef(CONFIG_POSIX_SEMAPHORES semaphore.c)
-zephyr_library_sources_ifdef(CONFIG_POSIX_THREADS
-  cond.c
-  key.c
-  mutex.c
-  pthread.c
-)
+
+if (NOT CONFIG_TC_PROVIDES_POSIX_READER_WRITER_LOCKS)
+  # Note: the Option is _POSIX_READER_WRITER_LOCKS, while the Option Group is POSIX_RW_LOCKS.
+  # We have opted to use POSIX_READER_WRITER_LOCKS here to match the Option name.
+  zephyr_library_sources_ifdef(CONFIG_POSIX_READER_WRITER_LOCKS rwlock.c)
+endif()
+
+if (NOT CONFIG_TC_PROVIDES_POSIX_SEMAPHORES)
+  zephyr_library_sources_ifdef(CONFIG_POSIX_SEMAPHORES semaphore.c)
+endif()
+
+if (NOT CONFIG_TC_PROVIDES_POSIX_THREADS)
+  # Note: the Option is _POSIX_THREADS, while the Option Group is POSIX_THREADS_BASE.
+  # We have opted to use POSIX_THREADS here to match the Option name.
+  zephyr_library_sources_ifdef(CONFIG_POSIX_THREADS
+    cond.c
+    key.c
+    mutex.c
+    pthread.c
+  )
+endif()
+
 zephyr_library_sources_ifdef(CONFIG_XOPEN_STREAMS stropts.c)
-zephyr_library_sources_ifdef(CONFIG_XSI_SYSTEM_LOGGING syslog.c)
+
+if (NOT CONFIG_TC_PROVIDES_XSI_SYSTEM_LOGGING)
+  zephyr_library_sources_ifdef(CONFIG_XSI_SYSTEM_LOGGING syslog.c)
+endif()
 
 zephyr_library_sources_ifdef(CONFIG_GETOPT_LONG
   getopt/getopt_long.c

--- a/lib/posix/options/Kconfig
+++ b/lib/posix/options/Kconfig
@@ -33,4 +33,6 @@ rsource "Kconfig.compat"
 
 rsource "Kconfig.deprecated"
 
+rsource "Kconfig.toolchain"
+
 endmenu # "POSIX Options"

--- a/lib/posix/options/Kconfig.toolchain
+++ b/lib/posix/options/Kconfig.toolchain
@@ -1,0 +1,240 @@
+# Copyright (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# The following list of Kconfig options are based on standard POSIX Subprofiling Option Groups
+# and may be used to override Zephyr's internal POSIX implementations. This facility is mainly
+# for toolchain integrators, C library maintainers, etc, and is not intended for general users.
+#
+# Use these features with caution as doing so might introduce unwanted, unexpected, or undefined
+# behavior.
+#
+# POSIX Subprofiling Option Groups are defined at the link below:
+#
+# https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_subprofiles.html
+
+config TC_PROVIDES_POSIX_ASYNCHRONOUS_IO
+	bool
+
+config TC_PROVIDES_POSIX_BARRIERS
+	bool
+
+config TC_PROVIDES_POSIX_C_LANG_JUMP
+	bool
+
+config TC_PROVIDES_POSIX_C_LANG_MATH
+	bool
+
+config TC_PROVIDES_POSIX_C_LANG_SUPPORT
+	bool
+
+config TC_PROVIDES_POSIX_C_LANG_SUPPORT_R
+	bool
+
+config TC_PROVIDES_POSIX_C_LANG_WIDE_CHAR
+	bool
+
+config TC_PROVIDES_POSIX_C_LANG_WIDE_CHAR_EXT
+	bool
+
+config TC_PROVIDES_POSIX_C_LIB_EXT
+	bool
+
+config TC_PROVIDES_POSIX_CLOCK_SELECTION
+	bool
+
+config TC_PROVIDES_POSIX_DEVICE_IO
+	bool
+
+config TC_PROVIDES_POSIX_DEVICE_IO_EXT
+	bool
+
+config TC_PROVIDES_POSIX_DEVICE_SPECIFIC
+	bool
+
+config TC_PROVIDES_POSIX_DEVICE_SPECIFIC_R
+	bool
+
+config TC_PROVIDES_POSIX_DYNAMIC_LINKING
+	bool
+
+config TC_PROVIDES_POSIX_FD_MGMT
+	bool
+
+config TC_PROVIDES_POSIX_FIFO
+	bool
+
+config TC_PROVIDES_POSIX_FIFO_FD
+	bool
+
+config TC_PROVIDES_POSIX_FILE_ATTRIBUTES
+	bool
+
+config TC_PROVIDES_POSIX_FILE_ATTRIBUTES_FD
+	bool
+
+config TC_PROVIDES_POSIX_FILE_LOCKING
+	bool
+
+config TC_PROVIDES_POSIX_FILE_SYSTEM
+	bool
+
+config TC_PROVIDES_POSIX_FILE_SYSTEM_EXT
+	bool
+
+config TC_PROVIDES_POSIX_FILE_SYSTEM_FD
+	bool
+
+config TC_PROVIDES_POSIX_FILE_SYSTEM_GLOB
+	bool
+
+config TC_PROVIDES_POSIX_FILE_SYSTEM_R
+	bool
+
+config TC_PROVIDES_POSIX_I18N
+	bool
+
+config TC_PROVIDES_POSIX_JOB_CONTROL
+	bool
+
+config TC_PROVIDES_POSIX_MAPPED_FILES
+	bool
+
+config TC_PROVIDES_POSIX_MEMORY_PROTECTION
+	bool
+
+config TC_PROVIDES_POSIX_MULTI_CONCURRENT_LOCALES
+	bool
+
+config TC_PROVIDES_POSIX_MULTI_PROCESS
+	bool
+
+config TC_PROVIDES_POSIX_MULTI_PROCESS_FD
+	bool
+
+config TC_PROVIDES_POSIX_NETWORKING
+	bool
+
+config TC_PROVIDES_POSIX_PIPE
+	bool
+
+config TC_PROVIDES_POSIX_ROBUST_MUTEXES
+	bool
+
+config TC_PROVIDES_POSIX_REALTIME_SIGNALS
+	bool
+
+config TC_PROVIDES_POSIX_REGEXP
+	bool
+
+# Note: the Option is _POSIX_READER_WRITER_LOCKS, while the Option Group is POSIX_RW_LOCKS
+# We have opted to use POSIX_READER_WRITER_LOCKS here to match the Option name.
+config TC_PROVIDES_POSIX_READER_WRITER_LOCKS
+	bool
+
+config TC_PROVIDES_POSIX_SEMAPHORES
+	bool
+
+config TC_PROVIDES_POSIX_SHARED_MEMORY_OBJECTS
+	bool
+
+config TC_PROVIDES_POSIX_SHELL_FUNC
+	bool
+
+config TC_PROVIDES_POSIX_SIGNAL_JUMP
+	bool
+
+config TC_PROVIDES_POSIX_SIGNALS
+	bool
+
+config TC_PROVIDES_POSIX_SIGNALS_EXT
+	bool
+
+config TC_PROVIDES_POSIX_SINGLE_PROCESS
+	bool
+
+config TC_PROVIDES_POSIX_SPIN_LOCKS
+	bool
+
+config TC_PROVIDES_POSIX_SYMBOLIC_LINKS
+	bool
+
+config TC_PROVIDES_POSIX_SYMBOLIC_LINKS_FD
+	bool
+
+config TC_PROVIDES_POSIX_SYSTEM_DATABASE
+	bool
+
+config TC_PROVIDES_POSIX_SYSTEM_DATABASE_R
+	bool
+
+# Note: the Option is _POSIX_THREADS, while the Option Group is POSIX_THREADS_BASE.
+# We have opted to use POSIX_THREADS here to match the Option name.
+config TC_PROVIDES_POSIX_THREADS
+	bool
+
+config TC_PROVIDES_POSIX_THREADS_EXT
+	bool
+
+config TC_PROVIDES_POSIX_TIMERS
+	bool
+
+config TC_PROVIDES_POSIX_USER_GROUPS
+	bool
+
+config TC_PROVIDES_POSIX_USER_GROUPS_R
+	bool
+
+config TC_PROVIDES_POSIX_WIDE_CHAR_DEVICE_IO
+	bool
+
+config TC_PROVIDES_XSI_C_LANG_SUPPORT
+	bool
+
+config TC_PROVIDES_XSI_DBM
+	bool
+
+config TC_PROVIDES_XSI_DEVICE_IO
+	bool
+
+config TC_PROVIDES_XSI_DEVICE_SPECIFIC
+	bool
+
+config TC_PROVIDES_XSI_FILE_SYSTEM
+	bool
+
+config TC_PROVIDES_XSI_IPC
+	bool
+
+config TC_PROVIDES_XSI_JUMP
+	bool
+
+config TC_PROVIDES_XSI_MATH
+	bool
+
+config TC_PROVIDES_XSI_MULTI_PROCESS
+	bool
+
+config TC_PROVIDES_XSI_SIGNALS
+	bool
+
+config TC_PROVIDES_XSI_SINGLE_PROCESS
+	bool
+
+config TC_PROVIDES_XSI_SYSTEM_DATABASE
+	bool
+
+config TC_PROVIDES_XSI_SYSTEM_LOGGING
+	bool
+
+config TC_PROVIDES_XSI_THREADS_EXT
+	bool
+
+config TC_PROVIDES_XSI_TIMERS
+	bool
+
+config TC_PROVIDES_XSI_USER_GROUPS
+	bool
+
+config TC_PROVIDES_XSI_WIDE_CHAR
+	bool


### PR DESCRIPTION
**CONFIG_TC_PROVIDES_...**

This provides external C libraries with a convenient mechanism for overriding Zephyr's POSIX API, at Option Group granularity.

Each implemented standard POSIX Subprofiing Option Group already has a Kconfig option in Zephyr. This Kconfig option is used to ensure that any appropriate feature test macros are defined (`features.h`), that any appropriate `sysconf()` values are returned, and of course to enable compilation of the relevant Zephyr C source files via CMake.

Generally, these existing Kconfig options have the form `CONFIG_POSIX_xxxx`, where `POSIX_xxxx` is the name of a standard IEEE 1003.1-2017 Option Group.

We add a number of Kconfig options in `Kconfig.toolchain`, all of the form `CONFIG_TC_PROVIDES_POSIX_xxxx`. Selecting these options instruct CMake to bypass the usual rules for compiling Zephyr's implementation of the selected POSIX Option Group.

The TC_PROVIDES Kconfig options are not user configurable, as they are intended to be used primarily by maintainers, and should be selected by a separate Kconfig option.

This is useful, for example, if a specific C library has a smaller, or faster, or more secure version of some POSIX features. Perhaps a vendor has a very specific implementation that is already certified on their device. There could be a number of reasons. 

**Why only Option Groups? Why not Options?**

Subprofiling Option Groups such as `POSIX_THREADS_BASE` differ from POSIX Options like `_POSIX_THREAD_ATTR_STACKADDR` in that the Option Group is a mostly autonomous unit of functionality, while Options may just change one aspect of behaviour inside one or more a units of functionality.

The granularity was chosen to be at the [Option Group](https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_subprofiles.html) level because implementations are most likely to be cleanly interoperable at Option Group level of abstraction, and because those are the lines officially drawn by IEEE to split up POSIX functionality.

Individual POSIX Options (e.g. `_POSIX_THREAD_SAFE_FUNCTIONS`) are often not as easily separated from other features that they may be tied to. Moreover, a given function may be required by more than one POSIX Option.

However, we may be able to add similar mechanisms for Options on a case-by-case basis in the future.