### PR TITLE
snps: board: rmx100: add PMP (MPU)

### DIFF
--- a/boards/snps/nsim/arc_v/support/rmx100.props
+++ b/boards/snps/nsim/arc_v/support/rmx100.props
@@ -4,3 +4,6 @@
 	nsim_mem-dev=clint,base=0x2000000,size=4096
 	nsim_mem-dev=uart0,kind=16550,base=0x10000000,irq=24
 	nsim_mem-dev=plic,base=0xc000000,size=0x04000000,interrupts=128,priorities=16
+	mpu_version=64
+	mpu_regions=16
+	mpu_granule=0

--- a/soc/snps/nsim/arc_v/rmx/Kconfig.defconfig
+++ b/soc/snps/nsim/arc_v/rmx/Kconfig.defconfig
@@ -15,4 +15,10 @@ config MULTI_LEVEL_INTERRUPTS
 config NUM_IRQS
 	default 18
 
+config RISCV_PMP
+	default y
+
+config PMP_SLOTS
+	default 16
+
 endif # SOC_SERIES_RMX


### PR DESCRIPTION
Add RV PMP to the SoC configuration and to simulator options