### PR TITLE
soc: esp32c3: add systimer clock disable option

### DIFF
--- a/drivers/timer/Kconfig.esp32
+++ b/drivers/timer/Kconfig.esp32
@@ -9,6 +9,7 @@ config ESP32_SYS_TIMER
 	default y
 	select TICKLESS_CAPABLE
 	select TIMER_HAS_64BIT_CYCLE_COUNTER
+	select SYSTEM_TIMER_HAS_DISABLE_SUPPORT
 	help
 	  This option enables the system timer driver for the Espressif ESP32Cx
 	  and provides the standard "system clock driver" interface.

--- a/drivers/timer/esp32_sys_timer.c
+++ b/drivers/timer/esp32_sys_timer.c
@@ -136,6 +136,13 @@ uint64_t sys_clock_cycle_get_64(void)
 	return get_systimer_alarm();
 }
 
+void sys_clock_disable(void)
+{
+	systimer_ll_enable_alarm(systimer_hal.dev, SYSTIMER_ALARM_OS_TICK_CORE0, false);
+	systimer_ll_enable_alarm_int(systimer_hal.dev, SYSTIMER_ALARM_OS_TICK_CORE0, false);
+	systimer_hal_deinit(&systimer_hal);
+}
+
 static int sys_clock_driver_init(void)
 {
 

--- a/west.yml
+++ b/west.yml
@@ -157,7 +157,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 0690c03f1540e8a5082da4c2b997e64bde8f4765
+      revision: 4e38d8d9fe16d4d41736c1ffae6566001a624fca
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
When both MCUBoot and application run, systimer is initialized twice.
As a consequence, application freezes as systimer new initialization
conflicts with previous.

This PR adds the systimer clock disable function, that shall be called
before mcuboot jump to application, making sure it will
work as expected.

Depends on #73292
Fixes #74189