### PR TITLE
boards: luatos: esp32s3: update USB serial to use board variant

### DIFF
--- a/boards/luatos/esp32s3_luatos_core/doc/index.rst
+++ b/boards/luatos/esp32s3_luatos_core/doc/index.rst
@@ -232,7 +232,7 @@ If CH343 chip is disabled, You need use the following command to build:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
-   :board: esp32s3_luatos_core_usb/esp32s3/procpu
+   :board: esp32s3_luatos_core/esp32s3/procpu/usb
    :goals: build
 
 The usual ``flash`` target will work with the ``esp32s3_luatos_core`` board


### PR DESCRIPTION
Replace reference to separate USB config to use the HWMv2 board variant instead.

Fixes #74041
Signed-off-by: Eric Holmberg <eric.holmberg@northriversystems.co.nz>