### PR TITLE
drivers: loapic: move 'z_loapic_int_vec_set()' into pinned section

### DIFF
--- a/drivers/interrupt_controller/intc_loapic.c
+++ b/drivers/interrupt_controller/intc_loapic.c
@@ -200,7 +200,7 @@ uint32_t z_loapic_irq_base(void)
  *
  * This associates an IRQ with the desired vector in the IDT.
  */
-__boot_func
+__pinned_func
 void z_loapic_int_vec_set(unsigned int irq, /* IRQ number of the interrupt */
 				  unsigned int vector /* vector to copy into the LVT */
 				  )


### PR DESCRIPTION
Move it out of boot section because it's also called by none-boot function 'loapic_resume()' at runtime. Better to keep boot-only things in boot section to avoid paging in boot section things at runtime.