### PR TITLE
mbedtls: Fix build with TFM and PSA client

### DIFF
--- a/modules/mbedtls/Kconfig.tls-generic
+++ b/modules/mbedtls/Kconfig.tls-generic
@@ -495,6 +495,7 @@ config MBEDTLS_PSA_CRYPTO_CLIENT
 	default y
 	depends on BUILD_WITH_TFM || MBEDTLS_PSA_CRYPTO_C
 	select PSA_CRYPTO_CLIENT
+	select PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY
 
 config MBEDTLS_LMS
 	bool "Support LMS signature schemes"


### PR DESCRIPTION
See #74201 for the error I am trying to fix, I don't know if this is the right way to fix this but seems like the file was not building because this dependency was missing in the build, this is a hotfix to unblock issue I found from ci running on #74026