### PR TITLE
wifi: airoc: misc update of airoc wifi driver

### DIFF
--- a/drivers/wifi/infineon/airoc_wifi.c
+++ b/drivers/wifi/infineon/airoc_wifi.c
@@ -620,10 +620,18 @@ static int airoc_mgmt_ap_enable(const struct device *dev, struct wifi_connect_re
 			params->channel);
 	}
 
-	if (params->psk_length == 0) {
+	switch (params->security) {
+	case WIFI_SECURITY_TYPE_NONE:
 		security = WHD_SECURITY_OPEN;
-	} else {
+		break;
+	case WIFI_SECURITY_TYPE_PSK:
 		security = WHD_SECURITY_WPA2_AES_PSK;
+		break;
+	case WIFI_SECURITY_TYPE_SAE:
+		security = WHD_SECURITY_WPA3_SAE;
+		break;
+	default:
+		goto error;
 	}
 
 	if (whd_wifi_init_ap(airoc_ap_if, &ssid, security, (const uint8_t *)params->psk,

--- a/drivers/wifi/infineon/airoc_wifi.c
+++ b/drivers/wifi/infineon/airoc_wifi.c
@@ -502,7 +502,7 @@ static int airoc_mgmt_connect(const struct device *dev, struct wifi_connect_req_
 		goto error;
 	}
 
-	if (usr_result.security == 0) {
+	if (usr_result.security == WHD_SECURITY_UNKNOWN) {
 		ret = -EAGAIN;
 		LOG_ERR("Could not scan device");
 		goto error;

--- a/drivers/wifi/infineon/airoc_wifi.c
+++ b/drivers/wifi/infineon/airoc_wifi.c
@@ -658,6 +658,7 @@ static int airoc_mgmt_ap_enable(const struct device *dev, struct wifi_connect_re
 
 	data->is_ap_up = true;
 	airoc_if = airoc_ap_if;
+	net_if_dormant_off(data->iface);
 error:
 
 	k_sem_give(&data->sema_common);
@@ -703,6 +704,7 @@ static int airoc_mgmt_ap_disable(const struct device *dev)
 	if (whd_ret == CY_RSLT_SUCCESS) {
 		data->is_ap_up = false;
 		airoc_if = airoc_sta_if;
+		net_if_dormant_on(data->iface);
 	} else {
 		LOG_ERR("Can't stop wifi ap: %u", whd_ret);
 	}


### PR DESCRIPTION

- FIX: STA fails to connect AP, of which security is open
- FIX: SoftAP supports only OPEN and WPA2-PSK. Other scruity modes(e.g. WPA3-SAE, WPA-PSK) are not supported
- FIX: When creating softap, interface is not recognized as up.
- Add the support of join and leave of multicast address group

Signed-off-by: Morihisa Momona <Morihisa.Momona@infineon.com>