### PR TITLE
mgmt: hawkbit: move to kernel heap

### DIFF
--- a/subsys/mgmt/hawkbit/Kconfig
+++ b/subsys/mgmt/hawkbit/Kconfig
@@ -161,6 +161,12 @@ config HAWKBIT_REBOOT_COLD
 
 endchoice
 
+config HEAP_MEM_POOL_ADD_SIZE_HAWKBIT
+	int "Heap memory pool size for hawkBit"
+	default 4096
+	help
+	  Set the size of the heap memory pool for hawkBit.
+
 module = HAWKBIT
 module-str = Log Level for hawkbit
 module-help = Enables logging for hawkBit code.


### PR DESCRIPTION
move to kernel heap, as there is now `k_realloc()` available.

Also fixes and improves the parts around it. 

Mainly taken from https://github.com/zephyrproject-rtos/zephyr/pull/70787