### PR TITLE
Bluetooth: host: conn param update fixes

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2957,7 +2957,7 @@ int bt_conn_le_param_update(struct bt_conn *conn,
 	    conn->le.latency == param->latency &&
 	    conn->le.timeout == param->timeout) {
 		atomic_clear_bit(conn->flags, BT_CONN_PERIPHERAL_PARAM_SET);
-		return -EALREADY;
+		return 0;
 	}
 
 	if (IS_ENABLED(CONFIG_BT_CENTRAL) &&

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2952,6 +2952,8 @@ int bt_conn_le_param_update(struct bt_conn *conn,
 	/* Check if there's a need to update conn params */
 	if (conn->le.interval >= param->interval_min &&
 	    conn->le.interval <= param->interval_max &&
+	    conn->le.interval_min == param->interval_min &&
+	    conn->le.interval_max == param->interval_max &&
 	    conn->le.latency == param->latency &&
 	    conn->le.timeout == param->timeout) {
 		atomic_clear_bit(conn->flags, BT_CONN_PERIPHERAL_PARAM_SET);


### PR DESCRIPTION
Fixes bug where it was not possible to change the connection interval min/max if the current interval was within min/max already.
Fixes return code so that parameters identical to the current parameters are accepted without error.