### PR TITLE
remove usage of SYS_INIT in the kernel

### DIFF
--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -70,6 +70,7 @@ endif()
 if(CONFIG_MULTITHREADING)
 list(APPEND kernel_files
   idle.c
+  cpu.c
   mailbox.c
   msg_q.c
   mutex.c

--- a/kernel/condvar.c
+++ b/kernel/condvar.c
@@ -136,7 +136,7 @@ int z_vrfy_k_condvar_wait(struct k_condvar *condvar, struct k_mutex *mutex,
 #endif /* CONFIG_USERSPACE */
 
 #ifdef CONFIG_OBJ_CORE_CONDVAR
-static int init_condvar_obj_core_list(void)
+int init_condvar_obj_core_list(void)
 {
 	/* Initialize condvar object type */
 
@@ -152,7 +152,4 @@ static int init_condvar_obj_core_list(void)
 
 	return 0;
 }
-
-SYS_INIT(init_condvar_obj_core_list, PRE_KERNEL_1,
-	 CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
 #endif /* CONFIG_OBJ_CORE_CONDVAR */

--- a/kernel/cpu.c
+++ b/kernel/cpu.c
@@ -6,6 +6,7 @@
 #include <zephyr/kernel.h>
 #include <kernel_internal.h>
 #include <zephyr/init.h>
+#include <obj_core_init.h>
 
 
 #ifdef CONFIG_OBJ_CORE_SYSTEM
@@ -82,7 +83,7 @@ void z_init_cpu(uint8_t cpu_id)
 }
 
 #ifdef CONFIG_OBJ_CORE_SYSTEM
-static int init_cpu_obj_core_list(void)
+int init_cpu_obj_core_list(void)
 {
 	/* Initialize CPU object type */
 
@@ -96,7 +97,7 @@ static int init_cpu_obj_core_list(void)
 	return 0;
 }
 
-static int init_kernel_obj_core_list(void)
+int init_kernel_obj_core_list(void)
 {
 	/* Initialize kernel object type */
 
@@ -115,10 +116,4 @@ static int init_kernel_obj_core_list(void)
 
 	return 0;
 }
-
-SYS_INIT(init_cpu_obj_core_list, PRE_KERNEL_1,
-        CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
-
-SYS_INIT(init_kernel_obj_core_list, PRE_KERNEL_1,
-        CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
 #endif /* CONFIG_OBJ_CORE_SYSTEM */

--- a/kernel/cpu.c
+++ b/kernel/cpu.c
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2016,2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <kernel_internal.h>
+#include <zephyr/init.h>
+
+
+#ifdef CONFIG_OBJ_CORE_SYSTEM
+static struct k_obj_type obj_type_cpu;
+static struct k_obj_type obj_type_kernel;
+
+#ifdef CONFIG_OBJ_CORE_STATS_SYSTEM
+static struct k_obj_core_stats_desc  cpu_stats_desc = {
+	.raw_size = sizeof(struct k_cycle_stats),
+	.query_size = sizeof(struct k_thread_runtime_stats),
+	.raw   = z_cpu_stats_raw,
+	.query = z_cpu_stats_query,
+	.reset = NULL,
+	.disable = NULL,
+	.enable  = NULL,
+};
+
+static struct k_obj_core_stats_desc  kernel_stats_desc = {
+	.raw_size = sizeof(struct k_cycle_stats) * CONFIG_MP_MAX_NUM_CPUS,
+	.query_size = sizeof(struct k_thread_runtime_stats),
+	.raw   = z_kernel_stats_raw,
+	.query = z_kernel_stats_query,
+	.reset = NULL,
+	.disable = NULL,
+	.enable  = NULL,
+};
+#endif /* CONFIG_OBJ_CORE_STATS_SYSTEM */
+#endif /* CONFIG_OBJ_CORE_SYSTEM */
+
+struct k_thread z_idle_threads[CONFIG_MP_MAX_NUM_CPUS];
+
+/*
+ * storage space for the interrupt stack
+ *
+ * Note: This area is used as the system stack during kernel initialization,
+ * since the kernel hasn't yet set up its own stack areas. The dual purposing
+ * of this area is safe since interrupts are disabled until the kernel context
+ * switches to the init thread.
+ */
+K_KERNEL_PINNED_STACK_ARRAY_DEFINE(z_interrupt_stacks,
+				   CONFIG_MP_MAX_NUM_CPUS,
+				   CONFIG_ISR_STACK_SIZE);
+
+void z_init_cpu(uint8_t cpu_id)
+{
+	init_idle_thread(cpu_id);
+	_kernel.cpus[cpu_id].idle_thread = &z_idle_threads[cpu_id];
+	_kernel.cpus[cpu_id].id = cpu_id;
+	_kernel.cpus[cpu_id].irq_stack =
+		(K_KERNEL_STACK_BUFFER(z_interrupt_stacks[cpu_id]) +
+		 K_KERNEL_STACK_SIZEOF(z_interrupt_stacks[cpu_id]));
+#ifdef CONFIG_SCHED_THREAD_USAGE_ALL
+	_kernel.cpus[cpu_id].usage = &_kernel.usage[cpu_id];
+	_kernel.cpus[cpu_id].usage->track_usage =
+		CONFIG_SCHED_THREAD_USAGE_AUTO_ENABLE;
+#endif
+
+#ifdef CONFIG_PM
+	/*
+	 * Increment number of CPUs active. The pm subsystem
+	 * will keep track of this from here.
+	 */
+	atomic_inc(&_cpus_active);
+#endif
+
+#ifdef CONFIG_OBJ_CORE_SYSTEM
+	k_obj_core_init_and_link(K_OBJ_CORE(&_kernel.cpus[cpu_id]), &obj_type_cpu);
+#ifdef CONFIG_OBJ_CORE_STATS_SYSTEM
+	k_obj_core_stats_register(K_OBJ_CORE(&_kernel.cpus[cpu_id]),
+				  _kernel.cpus[cpu_id].usage,
+				  sizeof(struct k_cycle_stats));
+#endif
+#endif
+}
+
+#ifdef CONFIG_OBJ_CORE_SYSTEM
+static int init_cpu_obj_core_list(void)
+{
+	/* Initialize CPU object type */
+
+	z_obj_type_init(&obj_type_cpu, K_OBJ_TYPE_CPU_ID,
+			offsetof(struct _cpu, obj_core));
+
+#ifdef CONFIG_OBJ_CORE_STATS_SYSTEM
+	k_obj_type_stats_init(&obj_type_cpu, &cpu_stats_desc);
+#endif /* CONFIG_OBJ_CORE_STATS_SYSTEM */
+
+	return 0;
+}
+
+static int init_kernel_obj_core_list(void)
+{
+	/* Initialize kernel object type */
+
+	z_obj_type_init(&obj_type_kernel, K_OBJ_TYPE_KERNEL_ID,
+			offsetof(struct z_kernel, obj_core));
+
+#ifdef CONFIG_OBJ_CORE_STATS_SYSTEM
+	k_obj_type_stats_init(&obj_type_kernel, &kernel_stats_desc);
+#endif /* CONFIG_OBJ_CORE_STATS_SYSTEM */
+
+	k_obj_core_init_and_link(K_OBJ_CORE(&_kernel), &obj_type_kernel);
+#ifdef CONFIG_OBJ_CORE_STATS_SYSTEM
+	k_obj_core_stats_register(K_OBJ_CORE(&_kernel), _kernel.usage,
+			sizeof(_kernel.usage));
+#endif /* CONFIG_OBJ_CORE_STATS_SYSTEM */
+
+	return 0;
+}
+
+SYS_INIT(init_cpu_obj_core_list, PRE_KERNEL_1,
+        CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
+
+SYS_INIT(init_kernel_obj_core_list, PRE_KERNEL_1,
+        CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
+#endif /* CONFIG_OBJ_CORE_SYSTEM */

--- a/kernel/events.c
+++ b/kernel/events.c
@@ -346,7 +346,7 @@ uint32_t z_vrfy_k_event_wait_all(struct k_event *event, uint32_t events,
 #endif /* CONFIG_USERSPACE */
 
 #ifdef CONFIG_OBJ_CORE_EVENT
-static int init_event_obj_core_list(void)
+int init_event_obj_core_list(void)
 {
 	/* Initialize condvar object type */
 
@@ -361,7 +361,4 @@ static int init_event_obj_core_list(void)
 
 	return 0;
 }
-
-SYS_INIT(init_event_obj_core_list, PRE_KERNEL_1,
-	 CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
 #endif /* CONFIG_OBJ_CORE_EVENT */

--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -25,7 +25,9 @@ extern "C" {
 #endif
 
 /* Initialize per-CPU kernel data */
-void z_init_cpu(int id);
+void z_init_cpu(uint8_t cpu_id);
+
+void init_idle_thread(int cpu_id);
 
 /* Initialize a thread */
 void z_init_thread_base(struct _thread_base *thread_base, int priority,

--- a/kernel/include/obj_core_init.h
+++ b/kernel/include/obj_core_init.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023, Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef KERNEL_INCLUDE_OBJ_CORE_H
+#define KERNEL_INCLUDE_OBJ_CORE_H
+
+
+void init_obj_core(void);
+
+int init_sem_obj_core_list(void);
+
+int init_mutex_obj_core_list(void);
+
+int init_condvar_obj_core_list(void);
+
+int init_mem_slab_obj_core_list(void);
+
+int init_pipe_obj_core_list(void);
+
+int init_msgq_obj_core_list(void);
+
+int init_mailbox_obj_core_list(void);
+
+int init_stack_obj_core_list(void);
+
+int init_thread_obj_core_list(void);
+
+int init_fifo_obj_core_list(void);
+
+int init_lifo_obj_core_list(void);
+
+int init_timer_obj_core_list(void);
+
+int init_event_obj_core_list(void);
+
+int init_cpu_obj_core_list(void);
+
+int init_kernel_obj_core_list(void);
+
+#endif /* KERNEL_INCLUDE_OBJ_CORE_H */

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -360,7 +360,7 @@ static inline int z_vrfy_device_init(const struct device *dev)
 #endif
 
 extern void boot_banner(void);
-extern void k_sys_work_q_init(void);
+extern void init_system_workqueue(void);
 extern void init_kheap_statics(void);
 
 
@@ -387,7 +387,7 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 #endif /* CONFIG_MMU */
 	z_sys_post_kernel = true;
 
-	k_sys_work_q_init();
+	init_system_workqueue();
 #if defined(CONFIG_DEMAND_PAGING) && !defined(CONFIG_LINKER_GENERIC_SECTIONS_PRESENT_AT_BOOT)
 	/* When BSS sections are not present at boot, we need to wait for
 	 * paging mechanism to be initialized before we can zero out BSS.

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -545,6 +545,7 @@ void __weak z_early_rand_get(uint8_t *buf, size_t length)
 
 
 extern void init_mbox_module(void);
+extern void init_mem_slab_module(void);
 
 /**
  *
@@ -586,6 +587,7 @@ FUNC_NORETURN void z_cstart(void)
 #endif
 	init_kheap_statics();
 	init_mbox_module();
+	init_mem_slab_module();
 
 	/* PRE_KERNEL_1 marker */
 	z_sys_init_run_level(INIT_LEVEL_PRE_KERNEL_1);

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -133,6 +133,9 @@ extern const struct init_entry __init_SMP_start[];
 
 extern void idle(void *unused1, void *unused2, void *unused3);
 
+extern int init_mem_domain_module(void);
+extern int app_shmem_bss_zero(void);
+
 /* LCOV_EXCL_START
  *
  * This code is called so early in the boot process that code coverage
@@ -569,6 +572,7 @@ FUNC_NORETURN void z_cstart(void)
 #endif
 #if defined(CONFIG_USERSPACE)
 	app_shmem_bss_zero();
+	init_mem_domain_module();
 #endif
 
 	/* perform basic hardware initialization */

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -55,13 +55,6 @@ K_THREAD_PINNED_STACK_DEFINE(z_main_stack, CONFIG_MAIN_STACK_SIZE);
 struct k_thread z_main_thread;
 
 #ifdef CONFIG_MULTITHREADING
-__pinned_bss
-struct k_thread z_idle_threads[CONFIG_MP_MAX_NUM_CPUS];
-
-static K_KERNEL_PINNED_STACK_ARRAY_DEFINE(z_idle_stacks,
-					  CONFIG_MP_MAX_NUM_CPUS,
-					  CONFIG_IDLE_STACK_SIZE);
-
 static void z_init_static_threads(void)
 {
 	STRUCT_SECTION_FOREACH(_static_thread_data, thread_data) {
@@ -137,46 +130,7 @@ enum init_level {
 extern const struct init_entry __init_SMP_start[];
 #endif /* CONFIG_SMP */
 
-/*
- * storage space for the interrupt stack
- *
- * Note: This area is used as the system stack during kernel initialization,
- * since the kernel hasn't yet set up its own stack areas. The dual purposing
- * of this area is safe since interrupts are disabled until the kernel context
- * switches to the init thread.
- */
-K_KERNEL_PINNED_STACK_ARRAY_DEFINE(z_interrupt_stacks,
-				   CONFIG_MP_MAX_NUM_CPUS,
-				   CONFIG_ISR_STACK_SIZE);
-
 extern void idle(void *unused1, void *unused2, void *unused3);
-
-#ifdef CONFIG_OBJ_CORE_SYSTEM
-static struct k_obj_type obj_type_cpu;
-static struct k_obj_type obj_type_kernel;
-
-#ifdef CONFIG_OBJ_CORE_STATS_SYSTEM
-static struct k_obj_core_stats_desc  cpu_stats_desc = {
-	.raw_size = sizeof(struct k_cycle_stats),
-	.query_size = sizeof(struct k_thread_runtime_stats),
-	.raw   = z_cpu_stats_raw,
-	.query = z_cpu_stats_query,
-	.reset = NULL,
-	.disable = NULL,
-	.enable  = NULL,
-};
-
-static struct k_obj_core_stats_desc  kernel_stats_desc = {
-	.raw_size = sizeof(struct k_cycle_stats) * CONFIG_MP_MAX_NUM_CPUS,
-	.query_size = sizeof(struct k_thread_runtime_stats),
-	.raw   = z_kernel_stats_raw,
-	.query = z_kernel_stats_query,
-	.reset = NULL,
-	.disable = NULL,
-	.enable  = NULL,
-};
-#endif /* CONFIG_OBJ_CORE_STATS_SYSTEM */
-#endif /* CONFIG_OBJ_CORE_SYSTEM */
 
 /* LCOV_EXCL_START
  *
@@ -472,69 +426,6 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 } /* LCOV_EXCL_LINE ... because we just dumped final coverage data */
 
 #if defined(CONFIG_MULTITHREADING)
-__boot_func
-static void init_idle_thread(int i)
-{
-	struct k_thread *thread = &z_idle_threads[i];
-	k_thread_stack_t *stack = z_idle_stacks[i];
-	size_t stack_size = K_KERNEL_STACK_SIZEOF(z_idle_stacks[i]);
-
-#ifdef CONFIG_THREAD_NAME
-
-#if CONFIG_MP_MAX_NUM_CPUS > 1
-	char tname[8];
-	snprintk(tname, 8, "idle %02d", i);
-#else
-	char *tname = "idle";
-#endif /* CONFIG_MP_MAX_NUM_CPUS */
-
-#else
-	char *tname = NULL;
-#endif /* CONFIG_THREAD_NAME */
-
-	z_setup_new_thread(thread, stack,
-			  stack_size, idle, &_kernel.cpus[i],
-			  NULL, NULL, K_IDLE_PRIO, K_ESSENTIAL,
-			  tname);
-	z_mark_thread_as_started(thread);
-
-#ifdef CONFIG_SMP
-	thread->base.is_idle = 1U;
-#endif /* CONFIG_SMP */
-}
-
-void z_init_cpu(int id)
-{
-	init_idle_thread(id);
-	_kernel.cpus[id].idle_thread = &z_idle_threads[id];
-	_kernel.cpus[id].id = id;
-	_kernel.cpus[id].irq_stack =
-		(K_KERNEL_STACK_BUFFER(z_interrupt_stacks[id]) +
-		 K_KERNEL_STACK_SIZEOF(z_interrupt_stacks[id]));
-#ifdef CONFIG_SCHED_THREAD_USAGE_ALL
-	_kernel.cpus[id].usage = &_kernel.usage[id];
-	_kernel.cpus[id].usage->track_usage =
-		CONFIG_SCHED_THREAD_USAGE_AUTO_ENABLE;
-#endif
-
-#ifdef CONFIG_PM
-	/*
-	 * Increment number of CPUs active. The pm subsystem
-	 * will keep track of this from here.
-	 */
-	atomic_inc(&_cpus_active);
-#endif
-
-#ifdef CONFIG_OBJ_CORE_SYSTEM
-	k_obj_core_init_and_link(K_OBJ_CORE(&_kernel.cpus[id]), &obj_type_cpu);
-#ifdef CONFIG_OBJ_CORE_STATS_SYSTEM
-	k_obj_core_stats_register(K_OBJ_CORE(&_kernel.cpus[id]),
-				  _kernel.cpus[id].usage,
-				  sizeof(struct k_cycle_stats));
-#endif
-#endif
-}
-
 /**
  *
  * @brief Initializes kernel data structures
@@ -713,45 +604,3 @@ FUNC_NORETURN void z_cstart(void)
 
 	CODE_UNREACHABLE; /* LCOV_EXCL_LINE */
 }
-
-#ifdef CONFIG_OBJ_CORE_SYSTEM
-static int init_cpu_obj_core_list(void)
-{
-	/* Initialize CPU object type */
-
-	z_obj_type_init(&obj_type_cpu, K_OBJ_TYPE_CPU_ID,
-			offsetof(struct _cpu, obj_core));
-
-#ifdef CONFIG_OBJ_CORE_STATS_SYSTEM
-	k_obj_type_stats_init(&obj_type_cpu, &cpu_stats_desc);
-#endif /* CONFIG_OBJ_CORE_STATS_SYSTEM */
-
-	return 0;
-}
-
-static int init_kernel_obj_core_list(void)
-{
-	/* Initialize kernel object type */
-
-	z_obj_type_init(&obj_type_kernel, K_OBJ_TYPE_KERNEL_ID,
-			offsetof(struct z_kernel, obj_core));
-
-#ifdef CONFIG_OBJ_CORE_STATS_SYSTEM
-	k_obj_type_stats_init(&obj_type_kernel, &kernel_stats_desc);
-#endif /* CONFIG_OBJ_CORE_STATS_SYSTEM */
-
-	k_obj_core_init_and_link(K_OBJ_CORE(&_kernel), &obj_type_kernel);
-#ifdef CONFIG_OBJ_CORE_STATS_SYSTEM
-	k_obj_core_stats_register(K_OBJ_CORE(&_kernel), _kernel.usage,
-				  sizeof(_kernel.usage));
-#endif /* CONFIG_OBJ_CORE_STATS_SYSTEM */
-
-	return 0;
-}
-
-SYS_INIT(init_cpu_obj_core_list, PRE_KERNEL_1,
-	 CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
-
-SYS_INIT(init_kernel_obj_core_list, PRE_KERNEL_1,
-	 CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
-#endif /* CONFIG_OBJ_CORE_SYSTEM */

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -384,6 +384,13 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 	z_sys_post_kernel = true;
 
 	k_sys_work_q_init();
+#if defined(CONFIG_USERSPACE) && \
+	defined(CONFIG_DEMAND_PAGING) && !defined(CONFIG_LINKER_GENERIC_SECTIONS_PRESENT_AT_BOOT)
+	/* When BSS sections are not present at boot, we need to wait for
+	 * paging mechanism to be initialized before we can zero out BSS.
+	 */
+	app_shmem_bss_zero();
+#endif
 	z_sys_init_run_level(INIT_LEVEL_POST_KERNEL);
 #if defined(CONFIG_STACK_POINTER_RANDOM) && (CONFIG_STACK_POINTER_RANDOM != 0)
 	z_stack_adjust_initialized = 1;
@@ -559,6 +566,9 @@ FUNC_NORETURN void z_cstart(void)
 
 #if defined(CONFIG_OBJ_CORE)
 	init_obj_core();
+#endif
+#if defined(CONFIG_USERSPACE)
+	app_shmem_bss_zero();
 #endif
 
 	/* perform basic hardware initialization */

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -24,6 +24,7 @@
 #include <zephyr/linker/linker-defs.h>
 #include <ksched.h>
 #include <kthread.h>
+#include <obj_core_init.h>
 #include <string.h>
 #include <zephyr/sys/dlist.h>
 #include <kernel_internal.h>
@@ -553,6 +554,10 @@ FUNC_NORETURN void z_cstart(void)
 #endif /* CONFIG_MULTITHREADING */
 	/* do any necessary initialization of static devices */
 	z_device_state_init();
+
+#if defined(CONFIG_OBJ_CORE)
+	init_obj_core();
+#endif
 
 	/* perform basic hardware initialization */
 	z_sys_init_run_level(INIT_LEVEL_PRE_KERNEL_1);

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -357,6 +357,7 @@ static inline int z_vrfy_device_init(const struct device *dev)
 #endif
 
 extern void boot_banner(void);
+extern void k_sys_work_q_init(void);
 
 
 /**
@@ -382,6 +383,7 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 #endif /* CONFIG_MMU */
 	z_sys_post_kernel = true;
 
+	k_sys_work_q_init();
 	z_sys_init_run_level(INIT_LEVEL_POST_KERNEL);
 #if defined(CONFIG_STACK_POINTER_RANDOM) && (CONFIG_STACK_POINTER_RANDOM != 0)
 	z_stack_adjust_initialized = 1;

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -543,6 +543,9 @@ void __weak z_early_rand_get(uint8_t *buf, size_t length)
 	}
 }
 
+
+extern void init_mbox_module(void);
+
 /**
  *
  * @brief Initialize kernel
@@ -582,12 +585,14 @@ FUNC_NORETURN void z_cstart(void)
 	init_mem_domain_module();
 #endif
 	init_kheap_statics();
+	init_mbox_module();
 
-	/* perform basic hardware initialization */
+	/* PRE_KERNEL_1 marker */
 	z_sys_init_run_level(INIT_LEVEL_PRE_KERNEL_1);
 #if defined(CONFIG_SMP)
 	arch_smp_init();
 #endif
+	/* PRE_KERNEL_2 marker */
 	z_sys_init_run_level(INIT_LEVEL_PRE_KERNEL_2);
 
 #ifdef CONFIG_STACK_CANARIES

--- a/kernel/kheap.c
+++ b/kernel/kheap.c
@@ -20,7 +20,7 @@ void k_heap_init(struct k_heap *heap, void *mem, size_t bytes)
 	SYS_PORT_TRACING_OBJ_INIT(k_heap, heap);
 }
 
-static int statics_init(void)
+int init_kheap_statics(void)
 {
 	STRUCT_SECTION_FOREACH(k_heap, heap) {
 #if defined(CONFIG_DEMAND_PAGING) && !defined(CONFIG_LINKER_GENERIC_SECTIONS_PRESENT_AT_BOOT)
@@ -52,15 +52,6 @@ static int statics_init(void)
 	}
 	return 0;
 }
-
-SYS_INIT_NAMED(statics_init_pre, statics_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
-
-#if defined(CONFIG_DEMAND_PAGING) && !defined(CONFIG_LINKER_GENERIC_SECTIONS_PRESENT_AT_BOOT)
-/* Need to wait for paging mechanism to be initialized before
- * heaps that are not in pinned sections can be initialized.
- */
-SYS_INIT_NAMED(statics_init_post, statics_init, POST_KERNEL, 0);
-#endif /* CONFIG_DEMAND_PAGING && !CONFIG_LINKER_GENERIC_SECTIONS_PRESENT_AT_BOOT */
 
 void *k_heap_aligned_alloc(struct k_heap *heap, size_t align, size_t bytes,
 			k_timeout_t timeout)

--- a/kernel/mailbox.c
+++ b/kernel/mailbox.c
@@ -439,8 +439,7 @@ int k_mbox_get(struct k_mbox *mbox, struct k_mbox_msg *rx_msg, void *buffer,
 }
 
 #ifdef CONFIG_OBJ_CORE_MAILBOX
-
-static int init_mailbox_obj_core_list(void)
+int init_mailbox_obj_core_list(void)
 {
 	/* Initialize mailbox object type */
 
@@ -455,7 +454,4 @@ static int init_mailbox_obj_core_list(void)
 
 	return 0;
 }
-
-SYS_INIT(init_mailbox_obj_core_list, PRE_KERNEL_1,
-	 CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
 #endif /* CONFIG_OBJ_CORE_MAILBOX */

--- a/kernel/mailbox.c
+++ b/kernel/mailbox.c
@@ -51,7 +51,7 @@ static inline void mbox_async_free(struct k_mbox_async *async)
 /*
  * Do run-time initialization of mailbox object subsystem.
  */
-static int init_mbox_module(void)
+int init_mbox_module(void)
 {
 	/* array of asynchronous message descriptors */
 	static struct k_mbox_async __noinit async_msg[CONFIG_NUM_MBOX_ASYNC_MSGS];
@@ -79,9 +79,10 @@ static int init_mbox_module(void)
 
 	return 0;
 }
-
-SYS_INIT(init_mbox_module, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
-
+#else
+int init_mbox_module(void)
+{
+}
 #endif /* CONFIG_NUM_MBOX_ASYNC_MSGS > 0 */
 
 void k_mbox_init(struct k_mbox *mbox)

--- a/kernel/mem_domain.c
+++ b/kernel/mem_domain.c
@@ -338,7 +338,7 @@ int k_mem_domain_add_thread(struct k_mem_domain *domain, k_tid_t thread)
 	return ret;
 }
 
-static int init_mem_domain_module(void)
+int init_mem_domain_module(void)
 {
 	int ret;
 
@@ -363,6 +363,3 @@ static int init_mem_domain_module(void)
 
 	return 0;
 }
-
-SYS_INIT(init_mem_domain_module, PRE_KERNEL_1,
-	 CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/kernel/mem_slab.c
+++ b/kernel/mem_slab.c
@@ -129,7 +129,7 @@ static int create_free_list(struct k_mem_slab *slab)
  *
  * @return 0 on success, fails otherwise.
  */
-static int init_mem_slab_obj_core_list(void)
+int init_mem_slab_obj_core_list(void)
 {
 	int rc = 0;
 
@@ -164,9 +164,6 @@ static int init_mem_slab_obj_core_list(void)
 out:
 	return rc;
 }
-
-SYS_INIT(init_mem_slab_obj_core_list, PRE_KERNEL_1,
-	 CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
 
 int k_mem_slab_init(struct k_mem_slab *slab, void *buffer,
 		    size_t block_size, uint32_t num_blocks)

--- a/kernel/mem_slab.c
+++ b/kernel/mem_slab.c
@@ -129,7 +129,7 @@ static int create_free_list(struct k_mem_slab *slab)
  *
  * @return 0 on success, fails otherwise.
  */
-int init_mem_slab_obj_core_list(void)
+int init_mem_slab_module(void)
 {
 	int rc = 0;
 

--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -420,7 +420,7 @@ static inline uint32_t z_vrfy_k_msgq_num_used_get(struct k_msgq *msgq)
 #endif /* CONFIG_USERSPACE */
 
 #ifdef CONFIG_OBJ_CORE_MSGQ
-static int init_msgq_obj_core_list(void)
+int init_msgq_obj_core_list(void)
 {
 	/* Initialize msgq object type */
 
@@ -435,8 +435,4 @@ static int init_msgq_obj_core_list(void)
 
 	return 0;
 };
-
-SYS_INIT(init_msgq_obj_core_list, PRE_KERNEL_1,
-	 CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
-
 #endif /* CONFIG_OBJ_CORE_MSGQ */

--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -293,7 +293,7 @@ static inline int z_vrfy_k_mutex_unlock(struct k_mutex *mutex)
 #endif /* CONFIG_USERSPACE */
 
 #ifdef CONFIG_OBJ_CORE_MUTEX
-static int init_mutex_obj_core_list(void)
+int init_mutex_obj_core_list(void)
 {
 	/* Initialize mutex object type */
 
@@ -308,7 +308,4 @@ static int init_mutex_obj_core_list(void)
 
 	return 0;
 }
-
-SYS_INIT(init_mutex_obj_core_list, PRE_KERNEL_1,
-	 CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
 #endif /* CONFIG_OBJ_CORE_MUTEX */

--- a/kernel/obj_core.c
+++ b/kernel/obj_core.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/kernel/obj_core.h>
+#include <obj_core_init.h>
 
 static struct k_spinlock  lock;
 
@@ -325,3 +326,57 @@ int k_obj_core_stats_enable(struct k_obj_core *obj_core)
 	return rv;
 }
 #endif /* CONFIG_OBJ_CORE_STATS */
+
+
+
+void init_obj_core(void)
+{
+#ifdef CONFIG_OBJ_CORE_SEM
+	init_sem_obj_core_list();
+#endif
+#ifdef CONFIG_OBJ_CORE_MUTEX
+	init_mutex_obj_core_list();
+#endif
+#if CONFIG_OBJ_CORE_MSGQ
+	init_msgq_obj_core_list();
+#endif
+#ifdef CONFIG_OBJ_CORE_FIFO
+	init_fifo_obj_core_list();
+#endif
+#ifdef CONFIG_OBJ_CORE_LIFO
+	init_lifo_obj_core_list();
+#endif
+#ifdef CONFIG_OBJ_CORE_STACK
+	init_stack_obj_core_list();
+#endif
+#ifdef CONFIG_OBJ_CORE_TIMER
+	init_timer_obj_core_list();
+#endif
+#ifdef CONFIG_OBJ_CORE_CONDVAR
+	init_condvar_obj_core_list();
+#endif
+#ifdef CONFIG_OBJ_CORE_MAILBOX
+	init_mailbox_obj_core_list();
+#endif
+#ifdef CONFIG_OBJ_CORE_PIPE
+	init_pipe_obj_core_list();
+#endif
+#ifdef CONFIG_OBJ_CORE_MEM_SLAB
+	init_mem_slab_obj_core_list();
+#endif
+#ifdef CONFIG_OBJ_CORE_MEM_POOL
+	init_mem_pool_obj_core_list();
+#endif
+#ifdef CONFIG_OBJ_CORE_THREAD
+	init_thread_obj_core_list();
+#endif
+
+#ifdef CONFIG_OBJ_CORE_EVENT
+	init_event_obj_core_list();
+#endif
+
+#ifdef CONFIG_OBJ_CORE_SYSTEM
+	init_cpu_obj_core_list();
+	init_kernel_obj_core_list();
+#endif
+}

--- a/kernel/obj_core.c
+++ b/kernel/obj_core.c
@@ -361,12 +361,6 @@ void init_obj_core(void)
 #ifdef CONFIG_OBJ_CORE_PIPE
 	init_pipe_obj_core_list();
 #endif
-#ifdef CONFIG_OBJ_CORE_MEM_SLAB
-	init_mem_slab_obj_core_list();
-#endif
-#ifdef CONFIG_OBJ_CORE_MEM_POOL
-	init_mem_pool_obj_core_list();
-#endif
 #ifdef CONFIG_OBJ_CORE_THREAD
 	init_thread_obj_core_list();
 #endif

--- a/kernel/pipes.c
+++ b/kernel/pipes.c
@@ -811,7 +811,7 @@ size_t z_vrfy_k_pipe_write_avail(struct k_pipe *pipe)
 #endif /* CONFIG_USERSPACE */
 
 #ifdef CONFIG_OBJ_CORE_PIPE
-static int init_pipe_obj_core_list(void)
+int init_pipe_obj_core_list(void)
 {
 	/* Initialize pipe object type */
 
@@ -826,7 +826,4 @@ static int init_pipe_obj_core_list(void)
 
 	return 0;
 }
-
-SYS_INIT(init_pipe_obj_core_list, PRE_KERNEL_1,
-	 CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
 #endif /* CONFIG_OBJ_CORE_PIPE */

--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -436,7 +436,7 @@ static inline void *z_vrfy_k_queue_peek_tail(struct k_queue *queue)
 #ifdef CONFIG_OBJ_CORE_FIFO
 struct k_obj_type _obj_type_fifo;
 
-static int init_fifo_obj_core_list(void)
+int init_fifo_obj_core_list(void)
 {
 	/* Initialize fifo object type */
 
@@ -451,15 +451,12 @@ static int init_fifo_obj_core_list(void)
 
 	return 0;
 }
-
-SYS_INIT(init_fifo_obj_core_list, PRE_KERNEL_1,
-	 CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
 #endif /* CONFIG_OBJ_CORE_FIFO */
 
 #ifdef CONFIG_OBJ_CORE_LIFO
 struct k_obj_type _obj_type_lifo;
 
-static int init_lifo_obj_core_list(void)
+int init_lifo_obj_core_list(void)
 {
 	/* Initialize lifo object type */
 
@@ -474,7 +471,4 @@ static int init_lifo_obj_core_list(void)
 
 	return 0;
 }
-
-SYS_INIT(init_lifo_obj_core_list, PRE_KERNEL_1,
-	 CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
 #endif /* CONFIG_OBJ_CORE_LIFO */

--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -210,7 +210,7 @@ static inline unsigned int z_vrfy_k_sem_count_get(struct k_sem *sem)
 #endif /* CONFIG_USERSPACE */
 
 #ifdef CONFIG_OBJ_CORE_SEM
-static int init_sem_obj_core_list(void)
+int init_sem_obj_core_list(void)
 {
 	/* Initialize semaphore object type */
 
@@ -225,7 +225,4 @@ static int init_sem_obj_core_list(void)
 
 	return 0;
 }
-
-SYS_INIT(init_sem_obj_core_list, PRE_KERNEL_1,
-	 CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
 #endif /* CONFIG_OBJ_CORE_SEM */

--- a/kernel/stack.c
+++ b/kernel/stack.c
@@ -201,7 +201,7 @@ static inline int z_vrfy_k_stack_pop(struct k_stack *stack,
 #endif /* CONFIG_USERSPACE */
 
 #ifdef CONFIG_OBJ_CORE_STACK
-static int init_stack_obj_core_list(void)
+int init_stack_obj_core_list(void)
 {
 	/* Initialize stack object type */
 
@@ -216,7 +216,4 @@ static int init_stack_obj_core_list(void)
 
 	return 0;
 }
-
-SYS_INIT(init_stack_obj_core_list, PRE_KERNEL_1,
-	 CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
 #endif /* CONFIG_OBJ_CORE_STACK */

--- a/kernel/system_work_q.c
+++ b/kernel/system_work_q.c
@@ -19,7 +19,7 @@ static K_KERNEL_STACK_DEFINE(sys_work_q_stack,
 
 struct k_work_q k_sys_work_q;
 
-static int k_sys_work_q_init(void)
+int k_sys_work_q_init(void)
 {
 	struct k_work_queue_config cfg = {
 		.name = "sysworkq",
@@ -33,5 +33,3 @@ static int k_sys_work_q_init(void)
 			    CONFIG_SYSTEM_WORKQUEUE_PRIORITY, &cfg);
 	return 0;
 }
-
-SYS_INIT(k_sys_work_q_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/kernel/system_work_q.c
+++ b/kernel/system_work_q.c
@@ -19,7 +19,7 @@ static K_KERNEL_STACK_DEFINE(sys_work_q_stack,
 
 struct k_work_q k_sys_work_q;
 
-int k_sys_work_q_init(void)
+int init_system_workqueue(void)
 {
 	struct k_work_queue_config cfg = {
 		.name = "sysworkq",

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -49,7 +49,7 @@ static struct k_obj_core_stats_desc  thread_stats_desc = {
 };
 #endif /* CONFIG_OBJ_CORE_STATS_THREAD */
 
-static int init_thread_obj_core_list(void)
+int init_thread_obj_core_list(void)
 {
 	/* Initialize mem_slab object type */
 
@@ -65,8 +65,6 @@ static int init_thread_obj_core_list(void)
 	return 0;
 }
 
-SYS_INIT(init_thread_obj_core_list, PRE_KERNEL_1,
-	 CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
 #endif /* CONFIG_OBJ_CORE_THREAD */
 
 

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -345,7 +345,7 @@ static inline void z_vrfy_k_timer_user_data_set(struct k_timer *timer,
 #endif /* CONFIG_USERSPACE */
 
 #ifdef CONFIG_OBJ_CORE_TIMER
-static int init_timer_obj_core_list(void)
+int init_timer_obj_core_list(void)
 {
 	/* Initialize timer object type */
 
@@ -360,6 +360,4 @@ static int init_timer_obj_core_list(void)
 
 	return 0;
 }
-SYS_INIT(init_timer_obj_core_list, PRE_KERNEL_1,
-	 CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
 #endif /* CONFIG_OBJ_CORE_TIMER */

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -930,7 +930,7 @@ out:
 extern char __app_shmem_regions_start[];
 extern char __app_shmem_regions_end[];
 
-static int app_shmem_bss_zero(void)
+int app_shmem_bss_zero(void)
 {
 	struct z_app_region *region, *end;
 
@@ -966,17 +966,6 @@ static int app_shmem_bss_zero(void)
 
 	return 0;
 }
-
-SYS_INIT_NAMED(app_shmem_bss_zero_pre, app_shmem_bss_zero,
-	       PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
-
-#if defined(CONFIG_DEMAND_PAGING) && !defined(CONFIG_LINKER_GENERIC_SECTIONS_PRESENT_AT_BOOT)
-/* When BSS sections are not present at boot, we need to wait for
- * paging mechanism to be initialized before we can zero out BSS.
- */
-SYS_INIT_NAMED(app_shmem_bss_zero_post, app_shmem_bss_zero,
-	       POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
-#endif /* CONFIG_DEMAND_PAGING && !CONFIG_LINKER_GENERIC_SECTIONS_PRESENT_AT_BOOT */
 
 /*
  * Default handlers if otherwise unimplemented


### PR DESCRIPTION
- **init: move cpu initialization out of init**
- **kernel: initialize object cores directly**
- **init: move system work to main init process**
- **kernel: remove SYS_INIT usage for userspace**
- **init: remove SYS_INIT usage for memory domains**
- **init: initialize kheap statics in the main init process**
- **kernel: do not use SYS_INIT for mailbox initialization**
- **kernel: rename k_sys_work_q_init -> init_system_workqueue**
