### PR TITLE
drivers: pinctrl: gecko: Fix location configuration for I2C

### DIFF
--- a/drivers/pinctrl/pinctrl_gecko.c
+++ b/drivers/pinctrl/pinctrl_gecko.c
@@ -324,7 +324,7 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt, uintp
 		case GECKO_FUN_I2C_SCL_LOC:
 #ifdef CONFIG_SOC_GECKO_HAS_INDIVIDUAL_PIN_LOCATION
 			i2c_base->ROUTEPEN |= I2C_ROUTEPEN_SCLPEN;
-			i2c_base->ROUTELOC0 &= ~_I2C_ROUTEPEN_SCLPEN_MASK;
+			i2c_base->ROUTELOC0 &= ~_I2C_ROUTELOC0_SCLLOC_MASK;
 			i2c_base->ROUTELOC0 |= (loc << _I2C_ROUTELOC0_SCLLOC_SHIFT);
 #elif defined(I2C_ROUTE_SCLPEN)
 			i2c_base->ROUTE = I2C_ROUTE_SDAPEN | I2C_ROUTE_SCLPEN | (loc << 8);

--- a/drivers/pinctrl/pinctrl_gecko.c
+++ b/drivers/pinctrl/pinctrl_gecko.c
@@ -289,6 +289,12 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt, uintp
 			GPIO_PinModeSet(pin_config.port, pin_config.pin, pin_config.mode,
 				pin_config.out);
 
+#if defined(GPIO_I2C_ROUTEEN_SDAPEN)
+			GPIO->I2CROUTE[I2C_NUM(i2c_base)].SDAROUTE =
+				(pin_config.pin << _GPIO_I2C_SDAROUTE_PIN_SHIFT) |
+				(pin_config.port << _GPIO_I2C_SDAROUTE_PORT_SHIFT);
+			GPIO->I2CROUTE[I2C_NUM(i2c_base)].ROUTEEN |= GPIO_I2C_ROUTEEN_SDAPEN;
+#endif
 			break;
 
 		case GECKO_FUN_I2C_SCL:
@@ -296,6 +302,13 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt, uintp
 			pin_config.out = 1;
 			GPIO_PinModeSet(pin_config.port, pin_config.pin, pin_config.mode,
 				pin_config.out);
+
+#if defined(GPIO_I2C_ROUTEEN_SCLPEN)
+			GPIO->I2CROUTE[I2C_NUM(i2c_base)].SCLROUTE =
+				(pin_config.pin << _GPIO_I2C_SCLROUTE_PIN_SHIFT) |
+				(pin_config.port << _GPIO_I2C_SCLROUTE_PORT_SHIFT);
+			GPIO->I2CROUTE[I2C_NUM(i2c_base)].ROUTEEN |= GPIO_I2C_ROUTEEN_SCLPEN;
+#endif
 			break;
 
 		case GECKO_FUN_I2C_SDA_LOC:
@@ -303,12 +316,7 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt, uintp
 			i2c_base->ROUTEPEN |= I2C_ROUTEPEN_SDAPEN;
 			i2c_base->ROUTELOC0 &= ~_I2C_ROUTELOC0_SDALOC_MASK;
 			i2c_base->ROUTELOC0 |= (loc << _I2C_ROUTELOC0_SDALOC_SHIFT);
-#elif defined(GPIO_I2C_ROUTEEN_SCLPEN) && defined(GPIO_I2C_ROUTEEN_SDAPEN)
-			GPIO->I2CROUTE[I2C_NUM(i2c_base)].ROUTEEN |= GPIO_I2C_ROUTEEN_SDAPEN;
-			GPIO->I2CROUTE[I2C_NUM(i2c_base)].SDAROUTE =
-				(pin_config.pin << _GPIO_I2C_SDAROUTE_PIN_SHIFT) |
-				(pin_config.port << _GPIO_I2C_SDAROUTE_PORT_SHIFT);
-#else
+#elif defined(I2C_ROUTE_SDAPEN)
 			i2c_base->ROUTE = I2C_ROUTE_SDAPEN | I2C_ROUTE_SCLPEN | (loc << 8);
 #endif
 			break;
@@ -318,12 +326,7 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt, uintp
 			i2c_base->ROUTEPEN |= I2C_ROUTEPEN_SCLPEN;
 			i2c_base->ROUTELOC0 &= ~_I2C_ROUTEPEN_SCLPEN_MASK;
 			i2c_base->ROUTELOC0 |= (loc << _I2C_ROUTELOC0_SCLLOC_SHIFT);
-#elif defined(GPIO_I2C_ROUTEEN_SCLPEN) && defined(GPIO_I2C_ROUTEEN_SDAPEN)
-			GPIO->I2CROUTE[I2C_NUM(i2c_base)].ROUTEEN |= GPIO_I2C_ROUTEEN_SCLPEN;
-			GPIO->I2CROUTE[I2C_NUM(i2c_base)].SCLROUTE =
-				(pin_config.pin << _GPIO_I2C_SCLROUTE_PIN_SHIFT) |
-				(pin_config.port << _GPIO_I2C_SCLROUTE_PORT_SHIFT);
-#else
+#elif defined(I2C_ROUTE_SCLPEN)
 			i2c_base->ROUTE = I2C_ROUTE_SDAPEN | I2C_ROUTE_SCLPEN | (loc << 8);
 #endif
 			break;


### PR DESCRIPTION
I2C location configuration in the gecko pinctrl driver was broken for Series 1 and Series 2. Series 1 cleared the wrong bitmask when writing location, while Series 2 used the wrong values entirely due to port/pin info not being available in the `*_LOC` case.

With these fixes, I am able to communicate with the Si7021 RHT sensor on boards from both series.

Fixes #74420