### PR TITLE
boards: nxp: mimxrt1064: Remove display chosen node

### DIFF
--- a/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -32,7 +32,6 @@
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,canbus = &flexcan2;
-		zephyr,display = &lcdif;
 	};
 
 	sdram0: memory@80000000 {


### PR DESCRIPTION
As display stuffs have been moved to a shield, the display chosen node must be removed as well because chosen node requires the node to be enabled. This causes CI failure for https://github.com/zephyrproject-rtos/zephyr/pull/72633