### PR TITLE
timer: start directly in init.c

### DIFF
--- a/boards/qemu/cortex_m0/nrf_timer_timer.c
+++ b/boards/qemu/cortex_m0/nrf_timer_timer.c
@@ -233,7 +233,7 @@ uint32_t sys_clock_cycle_get_32(void)
 	return ret;
 }
 
-static int sys_clock_driver_init(void)
+int init_sys_clock_driver(void)
 {
 	nrf_timer_prescaler_set(TIMER, NRF_TIMER_FREQ_1MHz);
 	nrf_timer_bit_width_set(TIMER, NRF_TIMER_BIT_WIDTH_32);
@@ -254,6 +254,3 @@ static int sys_clock_driver_init(void)
 
 	return 0;
 }
-
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
-	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/altera_avalon_timer_hal.c
+++ b/drivers/timer/altera_avalon_timer_hal.c
@@ -73,7 +73,7 @@ uint32_t sys_clock_elapsed(void)
 	return 0;
 }
 
-static int sys_clock_driver_init(void)
+int init_sys_clock_driver(void)
 {
 
 	IOWR_ALTERA_AVALON_TIMER_PERIODL(TIMER_0_BASE,
@@ -89,6 +89,3 @@ static int sys_clock_driver_init(void)
 
 	return 0;
 }
-
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
-	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/ambiq_stimer.c
+++ b/drivers/timer/ambiq_stimer.c
@@ -176,7 +176,7 @@ uint32_t sys_clock_cycle_get_32(void)
 	return am_hal_stimer_counter_get();
 }
 
-static int stimer_init(void)
+int init_sys_clock_driver(void)
 {
 	uint32_t oldCfg;
 
@@ -202,5 +202,3 @@ static int stimer_init(void)
 	}
 	return 0;
 }
-
-SYS_INIT(stimer_init, PRE_KERNEL_2, CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/apic_timer.c
+++ b/drivers/timer/apic_timer.c
@@ -86,7 +86,7 @@ uint32_t sys_clock_cycle_get_32(void)
 	return (uint32_t)sys_clock_cycle_get_64();
 }
 
-static int sys_clock_driver_init(void)
+int init_sys_clock_driver(void)
 {
 	uint32_t val;
 
@@ -112,6 +112,3 @@ static int sys_clock_driver_init(void)
 
 	return 0;
 }
-
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
-	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/apic_tsc.c
+++ b/drivers/timer/apic_tsc.c
@@ -255,7 +255,7 @@ void smp_timer_init(void)
 	irq_enable(timer_irq());
 }
 
-static int sys_clock_driver_init(void)
+int init_sys_clock_driver(void)
 {
 #ifdef CONFIG_ASSERT
 	uint32_t eax, ebx, ecx, edx;
@@ -317,6 +317,3 @@ static int sys_clock_driver_init(void)
 
 	return 0;
 }
-
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
-	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/arcv2_timer0.c
+++ b/drivers/timer/arcv2_timer0.c
@@ -413,7 +413,7 @@ void smp_timer_init(void)
  *
  * @return 0
  */
-static int sys_clock_driver_init(void)
+int init_sys_clock_driver(void)
 {
 
 	/* ensure that the timer will not generate interrupts */
@@ -445,6 +445,3 @@ static int sys_clock_driver_init(void)
 
 	return 0;
 }
-
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
-	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/arm_arch_timer.c
+++ b/drivers/timer/arm_arch_timer.c
@@ -226,7 +226,7 @@ void smp_timer_init(void)
 }
 #endif
 
-static int sys_clock_driver_init(void)
+int init_sys_clock_driver(void)
 {
 
 	IRQ_CONNECT(ARM_ARCH_TIMER_IRQ, ARM_ARCH_TIMER_PRIO,
@@ -245,6 +245,3 @@ static int sys_clock_driver_init(void)
 
 	return 0;
 }
-
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
-	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/cc13xx_cc26xx_rtc_timer.c
+++ b/drivers/timer/cc13xx_cc26xx_rtc_timer.c
@@ -234,7 +234,7 @@ uint64_t sys_clock_cycle_get_64(void)
 	return AONRTCCurrent64BitValueGet() / RTC_COUNTS_PER_CYCLE;
 }
 
-static int sys_clock_driver_init(void)
+int init_sys_clock_driver(void)
 {
 
 	rtc_last = 0U;
@@ -250,6 +250,3 @@ static int sys_clock_driver_init(void)
 
 	return 0;
 }
-
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
-	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -430,7 +430,7 @@ void sys_clock_disable(void)
 	SysTick->CTRL &= ~SysTick_CTRL_ENABLE_Msk;
 }
 
-static int sys_clock_driver_init(void)
+int init_sys_clock_driver(void)
 {
 
 	NVIC_SetPriority(SysTick_IRQn, _IRQ_PRIO_OFFSET);
@@ -443,6 +443,3 @@ static int sys_clock_driver_init(void)
 			  SysTick_CTRL_CLKSOURCE_Msk);
 	return 0;
 }
-
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
-	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/esp32_sys_timer.c
+++ b/drivers/timer/esp32_sys_timer.c
@@ -141,7 +141,7 @@ void sys_clock_disable(void)
 	systimer_hal_deinit(&systimer_hal);
 }
 
-static int sys_clock_driver_init(void)
+int init_sys_clock_driver(void)
 {
 
 	esp_intr_alloc(DT_IRQN(DT_NODELABEL(systimer0)),
@@ -160,6 +160,3 @@ static int sys_clock_driver_init(void)
 	set_systimer_alarm(last_count + CYC_PER_TICK);
 	return 0;
 }
-
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_1,
-	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/gecko_burtc_timer.c
+++ b/drivers/timer/gecko_burtc_timer.c
@@ -181,7 +181,7 @@ uint32_t sys_clock_cycle_get_32(void)
 	}
 }
 
-static int burtc_init(void)
+int init_sys_clock_driver(void)
 {
 	uint32_t hw_clock_freq;
 	BURTC_Init_TypeDef init = BURTC_INIT_DEFAULT;
@@ -239,6 +239,3 @@ static int burtc_init(void)
 
 	return 0;
 }
-
-SYS_INIT(burtc_init, PRE_KERNEL_2,
-	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -413,7 +413,7 @@ void sys_clock_idle_exit(void)
 }
 
 __boot_func
-static int sys_clock_driver_init(void)
+int init_sys_clock_driver(void)
 {
 	extern int z_clock_hw_cycles_per_sec;
 	uint32_t hz, reg;
@@ -462,6 +462,3 @@ static int sys_clock_driver_init(void)
 
 	return 0;
 }
-
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
-	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/intel_adsp_timer.c
+++ b/drivers/timer/intel_adsp_timer.c
@@ -212,7 +212,7 @@ void smp_timer_init(void)
 {
 }
 
-static int sys_clock_driver_init(void)
+int init_sys_clock_driver(void)
 {
 	uint64_t curr = count();
 
@@ -226,8 +226,5 @@ static int sys_clock_driver_init(void)
 /* Runs on core 0 only */
 void intel_adsp_clock_soft_off_exit(void)
 {
-	(void)sys_clock_driver_init();
+	(void)init_sys_clock_driver();
 }
-
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
-	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/ite_it8xxx2_timer.c
+++ b/drivers/timer/ite_it8xxx2_timer.c
@@ -395,7 +395,7 @@ static int timer_init(enum ext_timer_idx ext_timer,
 	return 0;
 }
 
-static int sys_clock_driver_init(void)
+int init_sys_clock_driver(void)
 {
 	int ret;
 
@@ -468,6 +468,3 @@ static int sys_clock_driver_init(void)
 
 	return 0;
 }
-
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
-	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/leon_gptimer.c
+++ b/drivers/timer/leon_gptimer.c
@@ -103,7 +103,7 @@ static void init_downcounter(volatile struct gptimer_timer_regs *tmr)
 	tmr->ctrl = GPTIMER_CTRL_LD | GPTIMER_CTRL_RS | GPTIMER_CTRL_EN;
 }
 
-static int sys_clock_driver_init(void)
+int init_sys_clock_driver(void)
 {
 	const int timer_interrupt = get_timer_irq();
 	volatile struct gptimer_regs *regs = get_regs();
@@ -128,6 +128,3 @@ static int sys_clock_driver_init(void)
 	irq_enable(timer_interrupt);
 	return 0;
 }
-
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
-	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/litex_timer.c
+++ b/drivers/timer/litex_timer.c
@@ -79,7 +79,7 @@ uint32_t sys_clock_elapsed(void)
 	return 0;
 }
 
-static int sys_clock_driver_init(void)
+int init_sys_clock_driver(void)
 {
 	IRQ_CONNECT(TIMER_IRQ, DT_INST_IRQ(0, priority),
 			litex_timer_irq_handler, NULL, 0);
@@ -96,6 +96,3 @@ static int sys_clock_driver_init(void)
 
 	return 0;
 }
-
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
-	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/mchp_xec_rtos_timer.c
+++ b/drivers/timer/mchp_xec_rtos_timer.c
@@ -398,7 +398,7 @@ void arch_busy_wait(uint32_t usec_to_wait)
 }
 #endif
 
-static int sys_clock_driver_init(void)
+int init_sys_clock_driver(void)
 {
 
 #ifdef CONFIG_TICKLESS_KERNEL
@@ -443,6 +443,3 @@ static int sys_clock_driver_init(void)
 
 	return 0;
 }
-
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
-	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/mcux_gpt_timer.c
+++ b/drivers/timer/mcux_gpt_timer.c
@@ -191,7 +191,7 @@ uint32_t sys_clock_cycle_get_32(void)
  *
  * Enable the hw timer, setting its tick period, and setup its interrupt
  */
-int sys_clock_driver_init(void)
+int init_sys_clock_driver(void)
 {
 	gpt_config_t gpt_config;
 
@@ -245,6 +245,3 @@ int sys_clock_driver_init(void)
 
 	return 0;
 }
-
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
-	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/mcux_lptmr_timer.c
+++ b/drivers/timer/mcux_lptmr_timer.c
@@ -100,7 +100,7 @@ static void mcux_lptmr_timer_isr(const void *arg)
 	LPTMR_ClearStatusFlags(LPTMR_BASE, kLPTMR_TimerCompareFlag);
 }
 
-static int sys_clock_driver_init(void)
+int init_sys_clock_driver(void)
 {
 	lptmr_config_t config;
 
@@ -128,6 +128,3 @@ static int sys_clock_driver_init(void)
 
 	return 0;
 }
-
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
-	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/mcux_os_timer.c
+++ b/drivers/timer/mcux_os_timer.c
@@ -255,7 +255,7 @@ void sys_clock_idle_exit(void)
 #endif
 }
 
-static int sys_clock_driver_init(void)
+int init_sys_clock_driver(void)
 {
 
 	/* Configure event timer's ISR */
@@ -284,6 +284,3 @@ static int sys_clock_driver_init(void)
 
 	return 0;
 }
-
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
-	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/mips_cp0_timer.c
+++ b/drivers/timer/mips_cp0_timer.c
@@ -112,7 +112,7 @@ uint32_t sys_clock_cycle_get_32(void)
 	return get_cp0_count();
 }
 
-static int sys_clock_driver_init(void)
+int init_sys_clock_driver(void)
 {
 
 	IRQ_CONNECT(MIPS_MACHINE_TIMER_IRQ, 0, timer_isr, NULL, 0);
@@ -128,6 +128,3 @@ static int sys_clock_driver_init(void)
 
 	return 0;
 }
-
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
-	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/mtk_adsp_timer.c
+++ b/drivers/timer/mtk_adsp_timer.c
@@ -151,7 +151,7 @@ static void timer_isr(__maybe_unused void *arg)
 	}
 }
 
-static int mtk_adsp_timer_init(void)
+int init_sys_clock_driver(void)
 {
 	IRQ_CONNECT(DT_IRQN(DT_NODELABEL(ostimer0)), 0, timer_isr, 0, 0);
 	irq_enable(DT_IRQN(DT_NODELABEL(ostimer0)));
@@ -176,5 +176,3 @@ static int mtk_adsp_timer_init(void)
 
 	return 0;
 }
-
-SYS_INIT(mtk_adsp_timer_init, PRE_KERNEL_2, CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/native_posix_timer.c
+++ b/drivers/timer/native_posix_timer.c
@@ -123,7 +123,7 @@ void sys_clock_disable(void)
  *
  * Enable the hw timer, setting its tick period, and setup its interrupt
  */
-static int sys_clock_driver_init(void)
+int init_sys_clock_driver(void)
 {
 
 	tick_period = 1000000ul / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
@@ -136,6 +136,3 @@ static int sys_clock_driver_init(void)
 
 	return 0;
 }
-
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
-	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/npcx_itim_timer.c
+++ b/drivers/timer/npcx_itim_timer.c
@@ -325,7 +325,7 @@ uint64_t npcx_clock_get_sleep_ticks(void)
 }
 #endif /* CONFIG_PM */
 
-static int sys_clock_driver_init(void)
+int init_sys_clock_driver(void)
 {
 	int ret;
 	uint32_t sys_tmr_rate;
@@ -410,5 +410,3 @@ static int sys_clock_driver_init(void)
 
 	return 0;
 }
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
-	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/nrf_grtc_timer.c
+++ b/drivers/timer/nrf_grtc_timer.c
@@ -461,7 +461,7 @@ uint32_t sys_clock_elapsed(void)
 	return (uint32_t)(counter_sub(counter(), last_count) / CYC_PER_TICK);
 }
 
-static int sys_clock_driver_init(void)
+int z_init_sys_clock_driver(void)
 {
 	nrfx_err_t err_code;
 
@@ -535,8 +535,15 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 #if defined(CONFIG_NRF_GRTC_TIMER_APP_DEFINED_INIT)
 int nrf_grtc_timer_clock_driver_init(void)
 {
-	return sys_clock_driver_init();
+	return z_init_sys_clock_driver();
+}
+int init_sys_clock_driver(void)
+{
+	return 0;
 }
 #else
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2, CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);
+int init_sys_clock_driver(void)
+{
+	return z_init_sys_clock_driver();
+}
 #endif

--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -724,7 +724,7 @@ void sys_clock_disable(void)
 	NVIC_ClearPendingIRQ(RTC_IRQn);
 }
 
-static int sys_clock_driver_init(void)
+int init_sys_clock_driver(void)
 {
 	static const enum nrf_lfclk_start_mode mode =
 		IS_ENABLED(CONFIG_SYSTEM_CLOCK_NO_WAIT) ?
@@ -767,6 +767,3 @@ static int sys_clock_driver_init(void)
 
 	return 0;
 }
-
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
-	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/rcar_cmt_timer.c
+++ b/drivers/timer/rcar_cmt_timer.c
@@ -89,7 +89,7 @@ uint32_t sys_clock_cycle_get_32(void)
  * The second one is used for cycles count, the match value is set
  * at max uint32_t.
  */
-static int sys_clock_driver_init(void)
+int init_sys_clock_driver(void)
 {
 	const struct device *clk;
 	uint32_t reg_val;
@@ -156,6 +156,3 @@ static int sys_clock_driver_init(void)
 
 	return 0;
 }
-
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
-	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -238,7 +238,7 @@ uint64_t sys_clock_cycle_get_64(void)
 	return mtime() << CONFIG_RISCV_MACHINE_TIMER_SYSTEM_CLOCK_DIVIDER;
 }
 
-static int sys_clock_driver_init(void)
+int init_sys_clock_driver(void)
 {
 
 	set_divider();
@@ -258,6 +258,3 @@ void smp_timer_init(void)
 	irq_enable(TIMER_IRQN);
 }
 #endif
-
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
-	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/rv32m1_lptmr_timer.c
+++ b/drivers/timer/rv32m1_lptmr_timer.c
@@ -71,7 +71,7 @@ uint32_t sys_clock_elapsed(void)
 	return 0;
 }
 
-static int sys_clock_driver_init(void)
+int init_sys_clock_driver(void)
 {
 	uint32_t csr, psr, sircdiv; /* LPTMR registers */
 
@@ -147,6 +147,3 @@ static int sys_clock_driver_init(void)
 	SYSTEM_TIMER_INSTANCE->CSR = csr;
 	return 0;
 }
-
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
-	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/sam0_rtc_timer.c
+++ b/drivers/timer/sam0_rtc_timer.c
@@ -245,7 +245,7 @@ uint32_t sys_clock_cycle_get_32(void)
 	return rtc_count();
 }
 
-static int sys_clock_driver_init(void)
+int init_sys_clock_driver(void)
 {
 	int retval;
 
@@ -327,6 +327,3 @@ static int sys_clock_driver_init(void)
 
 	return 0;
 }
-
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
-	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/smartbond_timer.c
+++ b/drivers/timer/smartbond_timer.c
@@ -193,7 +193,7 @@ static void timer2_isr(const void *arg)
 	sys_clock_announce(dticks);
 }
 
-static int sys_clock_driver_init(void)
+int init_sys_clock_driver(void)
 {
 #if CONFIG_PM
 	uint8_t pdc_idx;
@@ -220,5 +220,3 @@ static int sys_clock_driver_init(void)
 
 	return 0;
 }
-
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2, CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -402,7 +402,7 @@ void stm32_lptim_wait_ready(void)
 #endif
 }
 
-static int sys_clock_driver_init(void)
+int init_sys_clock_driver(void)
 {
 	uint32_t count_per_tick;
 	int err;
@@ -572,7 +572,7 @@ void stm32_clock_control_standby_exit(void)
 	if (clock_control_get_status(clk_ctrl,
 				     (clock_control_subsys_t) &lptim_clk[0])
 				     != CLOCK_CONTROL_STATUS_ON) {
-		sys_clock_driver_init();
+		init_sys_clock_driver();
 	}
 #endif /* CONFIG_STM32_LPTIM_STDBY_TIMER */
 }
@@ -622,6 +622,3 @@ void sys_clock_idle_exit(void)
 	}
 #endif /* CONFIG_STM32_LPTIM_STDBY_TIMER */
 }
-
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
-	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/xlnx_psttc_timer.c
+++ b/drivers/timer/xlnx_psttc_timer.c
@@ -146,7 +146,7 @@ uint32_t sys_clock_cycle_get_32(void)
 	return read_count();
 }
 
-static int sys_clock_driver_init(void)
+int init_sys_clock_driver(void)
 {
 	uint32_t reg_val;
 
@@ -201,6 +201,3 @@ static int sys_clock_driver_init(void)
 
 	return 0;
 }
-
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
-	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -120,7 +120,7 @@ void smp_timer_init(void)
 }
 #endif
 
-static int sys_clock_driver_init(void)
+int init_sys_clock_driver(void)
 {
 
 	IRQ_CONNECT(TIMER_IRQ, 0, ccompare_isr, 0, 0);
@@ -128,6 +128,3 @@ static int sys_clock_driver_init(void)
 	irq_enable(TIMER_IRQ);
 	return 0;
 }
-
-SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2,
-	 CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/include/zephyr/drivers/timer/system_timer.h
+++ b/include/zephyr/drivers/timer/system_timer.h
@@ -161,6 +161,17 @@ uint32_t sys_clock_cycle_get_32(void);
 uint64_t sys_clock_cycle_get_64(void);
 
 /**
+ * @cond INTERNAL_HIDDEN
+ * @brief Initialize system clock driver
+ * @note This function is called by the kernel during system initialization.
+ *       It should not be called by application code.
+ * @return 0 on success, negative errno code on fail
+ * @endcond
+ */
+int init_sys_clock_driver(void);
+
+
+/**
  * @}
  */
 

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -37,6 +37,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/pm/device_runtime.h>
 #include <zephyr/internal/syscall_handler.h>
+#include <zephyr/drivers/timer/system_timer.h>
 LOG_MODULE_REGISTER(os, CONFIG_KERNEL_LOG_LEVEL);
 
 BUILD_ASSERT(CONFIG_MP_NUM_CPUS == CONFIG_MP_MAX_NUM_CPUS,
@@ -667,6 +668,9 @@ FUNC_NORETURN void z_cstart(void)
 	arch_smp_init();
 #endif
 	z_sys_init_run_level(INIT_LEVEL_PRE_KERNEL_2);
+#if defined(CONFIG_SYS_CLOCK_EXISTS)
+	init_sys_clock_driver();
+#endif
 
 #ifdef CONFIG_STACK_CANARIES
 	uintptr_t stack_guard;


### PR DESCRIPTION
Do not use SYS_INIT, directly call init_sys_clock_driver() during the
init process.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
