### PR TITLE
boards apollo4p*: Provisionally disable in twister

### DIFF
--- a/boards/ambiq/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb.yaml
+++ b/boards/ambiq/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb.yaml
@@ -20,3 +20,7 @@ testing:
   ignore_tags:
     - net
 vendor: ambiq
+# Provisional hack to prevent tests being run in this board, as it fails in many test & samples:
+twister: false
+# Once https://github.com/zephyrproject-rtos/zephyr/issues/74212, 73443 & 72775 are fixed
+# this should be removed

--- a/boards/ambiq/apollo4p_evb/apollo4p_evb.yaml
+++ b/boards/ambiq/apollo4p_evb/apollo4p_evb.yaml
@@ -20,3 +20,7 @@ testing:
     - net
     - bluetooth
 vendor: ambiq
+# Provisional hack to prevent tests being run in this board, as it fails in many test & samples:
+twister: false
+# Once https://github.com/zephyrproject-rtos/zephyr/issues/74212, 73443 & 72775 are fixed
+# this should be removed


### PR DESCRIPTION
These boards fail to build for several samples & tests which is blocking CI.
Let's provisionally disable them until the matter is properly resolved.

See
https://github.com/zephyrproject-rtos/zephyr/issues/72775 https://github.com/zephyrproject-rtos/zephyr/issues/73443 https://github.com/zephyrproject-rtos/zephyr/issues/74212 for more information.

Once these issues are fixed, this change should be reverted.

Mitigates:
* #72775
* #73443
* #74212