### PR TITLE
Bluetooth: Controller: Auto-initiate DLE on setup

### DIFF
--- a/dts/bindings/bluetooth/zephyr,bt-hci-ipc.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-ipc.yaml
@@ -9,8 +9,6 @@ properties:
     default: "IPC"
   bt-hci-bus:
     default: "BT_HCI_BUS_IPM"
-  bt-hci-quirks:
-    default: ["BT_HCI_QUIRK_NO_AUTO_DLE"]
   bt-hci-ipc-name:
     type: string
     default: "nrf_bt_hci"

--- a/dts/bindings/bluetooth/zephyr,bt-hci-ll-sw-split.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-ll-sw-split.yaml
@@ -9,5 +9,3 @@ properties:
     default: "Controller"
   bt-hci-bus:
     default: "BT_HCI_BUS_VIRTUAL"
-  bt-hci-quirks:
-    default: ["BT_HCI_QUIRK_NO_AUTO_DLE"]

--- a/subsys/bluetooth/controller/ll_sw/lll_conn.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn.h
@@ -95,7 +95,6 @@ struct lll_conn {
 		uint16_t default_tx_time;
 #endif
 		uint16_t default_tx_octets;
-		uint8_t update;
 	} dle;
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -2520,17 +2520,25 @@ void ull_dle_init(struct ll_conn *conn, uint8_t phy)
 	/* Check whether the controller should perform a data length update after
 	 * connection is established
 	 */
+	bool update_data_length = false;
 #if defined(CONFIG_BT_CTLR_PHY)
 	if ((conn->lll.dle.local.max_rx_time != max_time_min ||
 	     conn->lll.dle.local.max_tx_time != max_time_min)) {
-		conn->lll.dle.update = 1;
+		update_data_length = 1;
 	} else
 #endif
 	{
 		if (conn->lll.dle.local.max_tx_octets != PDU_DC_PAYLOAD_SIZE_MIN ||
 		    conn->lll.dle.local.max_rx_octets != PDU_DC_PAYLOAD_SIZE_MIN) {
-			conn->lll.dle.update = 1;
+			update_data_length = 1;
 		}
+	}
+
+	if (update_data_length) {
+		/* We intend to update the data length when the connection starts. */
+		(void)ull_cp_data_length_update(conn,
+						conn->lll.dle.local.max_tx_octets,
+						conn->lll.dle.local.max_tx_time);
 	}
 }
 


### PR DESCRIPTION
This removes the need to issue the HCI LE Set Data Length command upon connection setup as it already issues the
HCI LE Write Suggested Default Data Length command when initializing the controller.

It seems like the code introduced in
commit f023b5f611df ("Bluetooth: controller: push topic branch to main") actually wanted to implement this behavior, as dle.update was already set.

With this change, the quirk BT_HCI_QUIRK_NO_AUTO_DLE can be removed. The quirk in the zephyr,bt-hci-ipc also existed there only for this reason. In this configuration the host had to assume worst case - that the controller didn't handle this.

References to the spec:
 - Core_v5.4, Vol 4, Part E, Section 7.8.35, HCI LE Write Suggested Default Data Length: This command sets _connInitialMaxTxOctets_.
 - Core_v5.4, Vol 6, Part B, Section 4.5.10, Data PDU length management:

   > _connMaxTxOctets_ shall be set to _connInitialMaxTxOctets_

   > The Controller may change the values of connMaxTxOctets,
     connMaxRxOctets, connMaxTxTime, and connMaxRxTime at any time after
     entering the Connection State. Whenever it does so, it shall
     communicate these values to the peer device using the
     Data Length Update procedure.

   Therefore, the host should not need initaite a data length update manually when a connect is established.