### PR TITLE
pm: policy: low latency events handling

### DIFF
--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -68,6 +68,29 @@ static inline void pm_state_notify(bool entering_state)
 	k_spin_unlock(&pm_notifier_lock, pm_notifier_key);
 }
 
+static inline int32_t ticks_expiring_sooner(int32_t ticks1, int32_t ticks2)
+{
+	/*
+	 * Ticks are relative numbers that defines the number of ticks
+	 * until the next event.
+	 * Its maximum value is K_TICKS_FOREVER ((uint32_t)-1) which is -1
+	 * when we cast it to (int32_t)
+	 * We need to find out which one is the closest
+	 */
+
+	__ASSERT(ticks1 >= -1, "ticks1 has unexpected negative value");
+	__ASSERT(ticks2 >= -1, "ticks2 has unexpected negative value");
+
+	if (ticks1 == K_TICKS_FOREVER) {
+		return ticks2;
+	}
+	if (ticks2 == K_TICKS_FOREVER) {
+		return ticks1;
+	}
+	/* At this step ticks1 and ticks2 are positive */
+	return MIN(ticks1, ticks2);
+}
+
 void pm_system_resume(void)
 {
 	uint8_t id = _current_cpu->id;
@@ -117,12 +140,20 @@ bool pm_state_force(uint8_t cpu, const struct pm_state_info *info)
 	return true;
 }
 
-bool pm_system_suspend(int32_t ticks)
+bool pm_system_suspend(int32_t kernel_ticks)
 {
 	uint8_t id = _current_cpu->id;
 	k_spinlock_key_t key;
+	int32_t ticks, events_ticks;
 
-	SYS_PORT_TRACING_FUNC_ENTER(pm, system_suspend, ticks);
+	SYS_PORT_TRACING_FUNC_ENTER(pm, system_suspend, kernel_ticks);
+
+	/*
+	 * CPU needs to be fully wake up before the event is triggered.
+	 * We need to find out first the ticks to the next event
+	 */
+	events_ticks = pm_policy_next_event_ticks();
+	ticks = ticks_expiring_sooner(kernel_ticks, events_ticks);
 
 	key = k_spin_lock(&pm_forced_state_lock);
 	if (z_cpus_pm_forced_state[id].state != PM_STATE_ACTIVE) {


### PR DESCRIPTION
Some events needs to be handled with a very low latency constraint. If the system is in deep sleep, exit latency from this low level state exceeds sometimes the maximum latency constraint of these events.

Before suspending the system, select which events is happening sooner, kernel events or normal events.
CPU will be up just before the next event occurs taking into account the exit latency of the current power state

Change also the policy event API to take as argument absolute time in HW cycles instead of time in us

Fixes #64753 