### PR TITLE
Bluetooth: Host: Add log entry for connection creation timeout

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1252,7 +1252,7 @@ static void le_conn_complete_cancel(uint8_t err)
 		int busy_status = k_work_delayable_busy_get(&conn->deferred_work);
 
 		if (!(busy_status & (K_WORK_QUEUED | K_WORK_DELAYED))) {
-			/* Connection initiation timeout triggered. */
+			LOG_WRN("Connection creation timeout triggered");
 			conn->err = err;
 			bt_conn_set_state(conn, BT_CONN_DISCONNECTED);
 		} else {


### PR DESCRIPTION
This makes it more clear what is happening when the host cancels connection creation where the controller raises
the connection complete event with status set to
"UNKNOWN CONNECTION IDENTIFIER (0x02)".

This is especially useful for developers not familiar with this detail in the spec.

See also: Core_v5.4, Vol 4, Part E, Section 7.8.13, LE Create Connection Cancel command.