### PR TITLE
dts: bindings: dma: correct compatible name of Intel SEDI dma controller

### DIFF
--- a/dts/bindings/dma/intel,sedi-dma.yaml
+++ b/dts/bindings/dma/intel,sedi-dma.yaml
@@ -4,7 +4,7 @@
 
 description: Intel SEDI DMA controller.
 
-compatible: "intel,sedi_dma"
+compatible: "intel,sedi-dma"
 
 include: dma-controller.yaml
 

--- a/dts/x86/intel/intel_ish5.dtsi
+++ b/dts/x86/intel/intel_ish5.dtsi
@@ -189,7 +189,7 @@
 		};
 
 		dma0: dma@10100000 {
-			compatible = "intel,sedi_dma";
+			compatible = "intel,sedi-dma";
 			#dma-cells = <2>;
 			dma-channels = <8>;
 			peripheral-id = <0>;


### PR DESCRIPTION
Replace an underscore with a hyphen in the name to align with the general naming convention.