### PR TITLE
Bluetooth: Host: Crypto: Fix implicit-function-declaration

### DIFF
--- a/subsys/bluetooth/common/rpa.c
+++ b/subsys/bluetooth/common/rpa.c
@@ -25,6 +25,8 @@ LOG_MODULE_REGISTER(bt_rpa);
 
 #if defined(CONFIG_BT_CTLR_CRYPTO) && defined(CONFIG_BT_HOST_CRYPTO)
 #include "../controller/util/util.h"
+#include "../controller/util/memq.h"
+#include "../controller/ll_sw/lll.h"
 #include "../controller/hal/ecb.h"
 #endif /* CONFIG_BT_CTLR_CRYPTO && CONFIG_BT_HOST_CRYPTO */
 

--- a/subsys/bluetooth/host/CMakeLists.txt
+++ b/subsys/bluetooth/host/CMakeLists.txt
@@ -31,10 +31,11 @@ if(CONFIG_BT_HCI_HOST)
     CONFIG_BT_OBSERVER
     scan.c
     )
-  zephyr_library_sources_ifdef(
-    CONFIG_BT_HOST_CRYPTO
-    crypto.c
-    )
+  if (CONFIG_BT_HOST_CRYPTO AND !CONFIG_BT_CTLR_CRYPTO)
+    zephyr_library_sources(
+      crypto.c
+      )
+  endif()
   zephyr_library_sources_ifdef(
     CONFIG_BT_ECC
     ecc.c

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3191,7 +3191,8 @@ static int common_init(void)
 	read_supported_commands_complete(rsp);
 	net_buf_unref(rsp);
 
-	if (IS_ENABLED(CONFIG_BT_HOST_CRYPTO_PRNG)) {
+	if (IS_ENABLED(CONFIG_BT_HOST_CRYPTO_PRNG) &&
+	    !IS_ENABLED(CONFIG_BT_CTLR_CRYPTO)) {
 		/* Initialize the PRNG so that it is safe to use it later
 		 * on in the initialization process.
 		 */


### PR DESCRIPTION
Fix compilation when both BT_HOST_CRYPTO and BT_CTLR_CRYPTO are enabled.

In this case, drop Host implementation and use direct call to Controller implemented crypto functions, i.e. bypass use of HCI Commands.

subsys/bluetooth/common/rpa.c:36:16: warning: implicit declaration of function ‘lll_csrand_get’
[-Wimplicit-function-declaration]

   36 |         return lll_csrand_get(buf, len);
      |                ^~~~~~~~~~~~~~