### PR TITLE
drivers: rtc: update alarm_set_callback to return ENOTSUP

### DIFF
--- a/drivers/rtc/rtc_pcf8523.c
+++ b/drivers/rtc/rtc_pcf8523.c
@@ -581,10 +581,17 @@ unlock:
 	return err;
 }
 
-#if PCF8523_INT1_GPIOS_IN_USE
 static int pcf8523_alarm_set_callback(const struct device *dev, uint16_t id,
 				      rtc_alarm_callback callback, void *user_data)
 {
+#ifndef PCF8523_INT1_GPIOS_IN_USE
+	ARG_UNUSED(dev);
+	ARG_UNUSED(id);
+	ARG_UNUSED(callback);
+	ARG_UNUSED(user_data);
+
+	return -ENOTSUP;
+#else
 	const struct pcf8523_config *config = dev->config;
 	struct pcf8523_data *data = dev->data;
 	uint8_t control_1;
@@ -638,8 +645,8 @@ unlock:
 	k_sem_give(&data->int1_sem);
 
 	return err;
-}
 #endif /* PCF8523_INT1_GPIOS_IN_USE */
+}
 #endif /* CONFIG_RTC_ALARM */
 
 #if PCF8523_INT1_GPIOS_IN_USE && defined(CONFIG_RTC_UPDATE)
@@ -928,9 +935,7 @@ static const struct rtc_driver_api pcf8523_driver_api = {
 	.alarm_set_time = pcf8523_alarm_set_time,
 	.alarm_get_time = pcf8523_alarm_get_time,
 	.alarm_is_pending = pcf8523_alarm_is_pending,
-#if PCF8523_INT1_GPIOS_IN_USE
 	.alarm_set_callback = pcf8523_alarm_set_callback,
-#endif /* PCF8523_INT1_GPIOS_IN_USE */
 #endif /* CONFIG_RTC_ALARM */
 #if PCF8523_INT1_GPIOS_IN_USE && defined(CONFIG_RTC_UPDATE)
 	.update_set_callback = pcf8523_update_set_callback,

--- a/drivers/rtc/rtc_pcf8563.c
+++ b/drivers/rtc/rtc_pcf8563.c
@@ -380,9 +380,19 @@ void gpio_callback_function(const struct device *dev, struct gpio_callback *cb,
 
 }
 
+#endif
+
 static int pcf8563_alarm_set_callback(const struct device *dev, uint16_t id,
 				      rtc_alarm_callback callback, void *user_data)
 {
+#ifndef PCF8563_INT1_GPIOS_IN_USE
+	ARG_UNUSED(dev);
+	ARG_UNUSED(id);
+	ARG_UNUSED(callback);
+	ARG_UNUSED(user_data);
+
+	return -ENOTSUP;
+#else
 	const struct pcf8563_config *config = dev->config;
 	struct pcf8563_data *data = dev->data;
 	int ret;
@@ -416,8 +426,8 @@ static int pcf8563_alarm_set_callback(const struct device *dev, uint16_t id,
 	gpio_add_callback(config->int1.port, &data->int1_callback);
 	LOG_DBG("Alarm set");
 	return 0;
-}
 #endif
+}
 
 static const struct rtc_driver_api pcf8563_driver_api = {
 	.set_time = pcf8563_set_time,
@@ -427,9 +437,7 @@ static const struct rtc_driver_api pcf8563_driver_api = {
 	.alarm_set_time = pcf8563_alarm_set_time,
 	.alarm_get_time = pcf8563_alarm_get_time,
 	.alarm_is_pending = pcf8563_alarm_is_pending,
-#ifdef PCF8563_INT1_GPIOS_IN_USE
 	.alarm_set_callback = pcf8563_alarm_set_callback,
-#endif
 #endif
 };
 

--- a/drivers/rtc/rtc_rv3028.c
+++ b/drivers/rtc/rtc_rv3028.c
@@ -711,11 +711,17 @@ unlock:
 	return err;
 }
 
-#if RV3028_INT_GPIOS_IN_USE
-
 static int rv3028_alarm_set_callback(const struct device *dev, uint16_t id,
 				     rtc_alarm_callback callback, void *user_data)
 {
+#ifndef RV3028_INT_GPIOS_IN_USE
+	ARG_UNUSED(dev);
+	ARG_UNUSED(id);
+	ARG_UNUSED(callback);
+	ARG_UNUSED(user_data);
+
+	return -ENOTSUP;
+#else
 	const struct rv3028_config *config = dev->config;
 	struct rv3028_data *data = dev->data;
 	uint8_t control_2;
@@ -766,9 +772,9 @@ unlock:
 	k_work_submit(&data->work);
 
 	return err;
+#endif /* RV3028_INT_GPIOS_IN_USE */
 }
 
-#endif /* RV3028_INT_GPIOS_IN_USE */
 #endif /* CONFIG_RTC_ALARM */
 
 #if RV3028_INT_GPIOS_IN_USE && defined(CONFIG_RTC_UPDATE)
@@ -952,9 +958,7 @@ static const struct rtc_driver_api rv3028_driver_api = {
 	.alarm_set_time = rv3028_alarm_set_time,
 	.alarm_get_time = rv3028_alarm_get_time,
 	.alarm_is_pending = rv3028_alarm_is_pending,
-#if RV3028_INT_GPIOS_IN_USE
 	.alarm_set_callback = rv3028_alarm_set_callback,
-#endif /* RV3028_INT_GPIOS_IN_USE */
 #endif /* CONFIG_RTC_ALARM */
 #if RV3028_INT_GPIOS_IN_USE && defined(CONFIG_RTC_UPDATE)
 	.update_set_callback = rv3028_update_set_callback,

--- a/tests/drivers/rtc/rtc_api/src/test_alarm_callback.c
+++ b/tests/drivers/rtc/rtc_api/src/test_alarm_callback.c
@@ -55,7 +55,12 @@ ZTEST(rtc_api, test_alarm_callback)
 	for (uint16_t i = 0; i < alarms_count; i++) {
 		ret = rtc_alarm_set_callback(rtc, i, NULL, NULL);
 
-		zassert_ok(ret, "Failed to clear and disable alarm %d", i);
+		if (ret == -ENOTSUP) {
+			TC_PRINT("Alarm callbacks not supported\n");
+			ztest_test_skip();
+		} else {
+			zassert_ok(ret, "Failed to clear and disable alarm %d", i);
+		}
 	}
 
 	/* Validate alarms supported fields */


### PR DESCRIPTION
This PR addresses the issue related to the `rtc.h` API returning `ENOSYS` for a driver not implementing `alarm_set_callback` when the ALARM functionality is enabled but interrupts, and thus alarm callbacks, are not supported by the current configuration.
    
The following drivers have been modified to return correct code:
- rtc_pcf8523
- rtc_pcf8563
- rtc_rv3028

I have also updated test_alarm_callback to check for `ENOTSUP`.