### PR TITLE
boards: nxp: imxrt10xx: update debugging documentation

### DIFF
--- a/boards/nxp/common/opensda-debug.rst
+++ b/boards/nxp/common/opensda-debug.rst
@@ -1,0 +1,39 @@
+:orphan:
+
+.. nxp-opensda-probes
+
+A debug probe is used for both flashing and debugging the board. This board has
+an :ref:`opensda-onboard-debug-probe`. The default firmware present on this
+probe is the :ref:`opensda-daplink-onboard-debug-probe`.
+
+Based on the host tool installed, please use the following instructions
+to setup your debug probe:
+
+* :ref:`jlink-debug-host-tools`: `Using J-Link on NXP OpenSDA Boards`_
+* :ref:`linkserver-debug-host-tools`: `Using DAPLink on NXP OpenSDA Boards`_
+* :ref:`pyocd-debug-host-tools`: `Using DAPLink on NXP OpenSDA Boards`_
+
+Using DAPLink on NXP OpenSDA Boards
+-----------------------------------
+
+1. If the debug firmware has been modified, follow the instructions provided at
+   :ref:`opensda-daplink-onboard-debug-probe` to reprogram the default debug
+   probe firmware on this board.
+#. Ensure the SWD isolation jumpers are populated
+
+Using J-Link on NXP OpenSDA Boards
+----------------------------------
+
+There are two options: the onboard debug circuit can be updated with Segger
+J-Link firmware, or a :ref:`jlink-external-debug-probe` can be attached to the
+board.
+
+To update the onboard debug circuit, please do the following:
+
+1. If the debug firmware has been modified, follow the instructions provided at
+   :ref:`opensda-jlink-onboard-debug-probe` to reprogram the default debug
+   probe firmware on this board.
+#. Ensure the SWD isolation jumpers are removed.
+
+To attach an external J-Link probe, ensure the SWD isolation jumpers are
+removed, and connect the external probe to the JTAG/SWD header.

--- a/boards/nxp/common/rt1xxx-lpclink2-debug.rst
+++ b/boards/nxp/common/rt1xxx-lpclink2-debug.rst
@@ -1,0 +1,45 @@
+:orphan:
+
+.. rt1xxx-lpclink2-probes
+
+A debug probe is used for both flashing and debugging the board. This board has
+an :ref:`lpc-link2-onboard-debug-probe`. The default firmware present on this
+probe is the :ref:`lpclink2-daplink-onboard-debug-probe`.
+
+Based on the host tool installed, please use the following instructions
+to setup your debug probe:
+
+* :ref:`jlink-debug-host-tools`:
+  `Using J-Link with LPC-Link2 Probe`_
+* :ref:`linkserver-debug-host-tools`:
+  `Using CMSIS-DAP with LPC-Link2 Probe`_
+* :ref:`pyocd-debug-host-tools`:
+  `Using CMSIS-DAP with LPC-Link2 Probe`_
+
+Using CMSIS-DAP with LPC-Link2 Probe
+------------------------------------
+
+1. Follow the instructions provided at
+   :ref:`lpclink2-cmsis-onboard-debug-probe` to reprogram the default debug
+   probe firmware on this board.
+#. Ensure the SWD isolation jumpers are populated
+
+Using J-Link with LPC-Link2 Probe
+---------------------------------
+
+There are two options: the onboard debug circuit can be updated with Segger
+J-Link firmware, or a :ref:`jlink-external-debug-probe` can be attached to the
+EVK.
+
+To update the onboard debug circuit, please do the following:
+
+1. Switch the power source for the EVK to a different source than the
+   debug USB, as the J-Link firmware does not power the EVK via the
+   debug USB.
+#. Follow the instructions provided at
+   :ref:`lpclink2-jlink-onboard-debug-probe` to reprogram the default debug
+   probe firmware on this board.
+#. Ensure the SWD isolation jumpers are populated.
+
+To attach an external J-Link probe, ensure the SWD isolation jumpers are
+removed, then connect the probe to the external JTAG/SWD header

--- a/boards/nxp/mimxrt1010_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1010_evk/doc/index.rst
@@ -159,45 +159,26 @@ and the remaining are not used.
 Programming and Debugging
 *************************
 
-Build and flash applications as usual (see :ref:`build_an_application` and
-:ref:`application_run` for more details).
+This board supports 3 debug host tools. Please install your preferred host
+tool, then follow the instructions in `Configuring a Debug Probe`_ to
+configure the board appropriately.
+
+* :ref:`linkserver-debug-host-tools` (Default, Supported by NXP)
+* :ref:`jlink-debug-host-tools` (Supported by NXP)
+* :ref:`pyocd-debug-host-tools` (Not supported by NXP)
+
+Once the host tool and board are configured, build and flash applications
+as usual (see :ref:`build_an_application` and :ref:`application_run` for more
+details).
 
 Configuring a Debug Probe
 =========================
 
-A debug probe is used for both flashing and debugging the board. This board is
-configured by default to use the :ref:`opensda-daplink-onboard-debug-probe`,
-however the :ref:`pyocd-debug-host-tools` do not yet support programming the
-external flashes on this board so you must reconfigure the board for one of the
-following debug probes instead.
+For the RT1010, J61/J62 are the SWD isolation jumpers, J22 is the DFU
+mode jumper, and J16 is the 10 pin JTAG/SWD header.
 
-:ref:`jlink-external-debug-probe`
--------------------------------------------
-
-Install the :ref:`jlink-debug-host-tools` and make sure they are in your search
-path.
-
-Attach a J-Link 10-pin connector to J55. Check that jumpers J61 and J62 are
-**off** (they are on by default when boards ship from the factory) to ensure
-SWD signals are disconnected from the OpenSDA microcontroller.
-
-Using LinkServer
-----------------
-
-Install the :ref:`linkserver-debug-host-tools` and make sure they are in your
-search path. To use LinkServer the on board CMSIS-DAP firmware need updated with
-LPCScrypt installed with LinkServer.
-
-To enter board debuger FW update mode, connect J22 first, and power cycle board.
-For more details please refer to `Debug_Probe_Firmware_Programming.pdf`, which is
-installed with LinkServer.
-
-.. code-block:: console
-
-    :Ubuntu/Mac: scripts/program_CMSIS
-    :Windows: scripts/program_CMSIS.cmd
-
-You may also se the ``-r linkserver`` option with West to use the LinkServer.
+.. include:: ../../common/rt1xxx-lpclink2-debug.rst
+   :start-after: rt1xxx-lpclink2-probes
 
 Configuring a Console
 =====================

--- a/boards/nxp/mimxrt1015_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1015_evk/doc/index.rst
@@ -161,40 +161,26 @@ and the remaining are not used.
 Programming and Debugging
 *************************
 
-Build and flash applications as usual (see :ref:`build_an_application` and
-:ref:`application_run` for more details).
+This board supports 3 debug host tools. Please install your preferred host
+tool, then follow the instructions in `Configuring a Debug Probe`_ to
+configure the board appropriately.
+
+* :ref:`linkserver-debug-host-tools` (Default, Supported by NXP)
+* :ref:`jlink-debug-host-tools` (Supported by NXP)
+* :ref:`pyocd-debug-host-tools` (Not supported by NXP)
+
+Once the host tool and board are configured, build and flash applications
+as usual (see :ref:`build_an_application` and :ref:`application_run` for more
+details).
 
 Configuring a Debug Probe
 =========================
 
-A debug probe is used for both flashing and debugging the board. This board is
-configured by default to use the :ref:`opensda-daplink-onboard-debug-probe`.
+For the RT1015, J47/J48 are the SWD isolation jumpers, J42 is the DFU
+mode jumper, and J34 is the 10 pin JTAG/SWD header.
 
-Using LinkServer: :ref:`opensda-daplink-onboard-debug-probe`
-------------------------------------------------------------
-
-Install the :ref:`linkserver-debug-host-tools` and make sure they are in your
-search path.  LinkServer works with the default CMSIS-DAP firmware included in
-the on-board debugger.
-
-Linkserver is the default runner. You may also se the ``-r linkserver`` option
-with West to use the LinkServer runner.
-
-.. code-block:: console
-
-   west flash
-   west debug
-
-
-External JLink: :ref:`jlink-external-debug-probe`
--------------------------------------------------
-
-Install the :ref:`jlink-debug-host-tools` and make sure they are in your search
-path.
-
-Attach a J-Link 10-pin connector to J55. Check that jumpers J47 and J48 are
-**off** (they are on by default when boards ship from the factory) to ensure
-SWD signals are disconnected from the OpenSDA microcontroller.
+.. include:: ../../common/rt1xxx-lpclink2-debug.rst
+   :start-after: rt1xxx-lpclink2-probes
 
 Configuring a Console
 =====================

--- a/boards/nxp/mimxrt1020_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1020_evk/doc/index.rst
@@ -219,53 +219,26 @@ remaining are not used.
 Programming and Debugging
 *************************
 
-Build and flash applications as usual (see :ref:`build_an_application` and
-:ref:`application_run` for more details).
+This board supports 3 debug host tools. Please install your preferred host
+tool, then follow the instructions in `Configuring a Debug Probe`_ to
+configure the board appropriately.
+
+* :ref:`linkserver-debug-host-tools` (Default, Supported by NXP)
+* :ref:`jlink-debug-host-tools` (Supported by NXP)
+* :ref:`pyocd-debug-host-tools` (Not supported by NXP)
+
+Once the host tool and board are configured, build and flash applications
+as usual (see :ref:`build_an_application` and :ref:`application_run` for more
+details).
 
 Configuring a Debug Probe
 =========================
 
-A debug probe is used for both flashing and debugging the board. This board is
-configured by default to use the :ref:`opensda-daplink-onboard-debug-probe`,
-however the :ref:`pyocd-debug-host-tools` do not yet support programming the
-external flashes on this board so you must reconfigure the board for one of the
-following debug probes instead.
+For the RT1020, J47/J48 are the SWD isolation jumpers, J42 is the DFU
+mode jumper, and J16 is the 20 pin JTAG/SWD header.
 
-Using LinkServer
-----------------
-
-Install the :ref:`linkserver-debug-host-tools` and make sure they are in your
-search path.  LinkServer works with the default CMSIS-DAP firmware included in
-the on-board debugger.
-
-Linkserver is the default runner. You may also se the ``-r linkserver`` option
-with West to use the LinkServer runner.
-
-.. code-block:: console
-
-   west flash
-   west debug
-
-JLink (on-board): :ref:`opensda-jlink-onboard-debug-probe`
-----------------------------------------------------------
-
-Install the :ref:`jlink-debug-host-tools` and make sure they are in your search
-path.
-
-Follow the instructions in :ref:`opensda-jlink-onboard-debug-probe` to program
-the `OpenSDA J-Link MIMXRT1020-EVK Firmware`_. Check that jumpers J27 and J28
-are **on** (they are on by default when boards ship from the factory) to ensure
-SWD signals are connected to the OpenSDA microcontroller.
-
-External JLink: :ref:`jlink-external-debug-probe`
--------------------------------------------------
-
-Install the :ref:`jlink-debug-host-tools` and make sure they are in your search
-path.
-
-Attach a J-Link 20-pin connector to J16. Check that jumpers J27 and J28 are
-**off** (they are on by default when boards ship from the factory) to ensure
-SWD signals are disconnected from the OpenSDA microcontroller.
+.. include:: ../../common/rt1xxx-lpclink2-debug.rst
+   :start-after: rt1xxx-lpclink2-probes
 
 Configuring a Console
 =====================

--- a/boards/nxp/mimxrt1024_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1024_evk/doc/index.rst
@@ -206,27 +206,21 @@ remaining are not used.
 Programming and Debugging
 *************************
 
-Build and flash applications as usual (see :ref:`build_an_application` and
-:ref:`application_run` for more details).
+This board supports 2 debug host tools. Please install your preferred host
+tool, then follow the instructions in `Configuring a Debug Probe`_ to
+configure the board appropriately.
+
+* :ref:`jlink-debug-host-tools` (Default, Supported by NXP)
+* :ref:`pyocd-debug-host-tools` (Not supported by NXP)
 
 Configuring a Debug Probe
 =========================
 
-A debug probe is used for both flashing and debugging the board. This board is
-configured by default to use the :ref:`opensda-daplink-onboard-debug-probe`,
-however the :ref:`pyocd-debug-host-tools` do not yet support programming the
-external flashes on this board so you must reconfigure the board for one of the
-following debug probes instead.
+For the RT1024, J47/J48 are the SWD isolation jumpers, J42 is the DFU
+mode jumper, and J55 is the 10 pin JTAG/SWD header.
 
-:ref:`jlink-external-debug-probe`
----------------------------------
-
-Install the :ref:`jlink-debug-host-tools` and make sure they are in your search
-path.
-
-Attach a J-Link 10-pin connector to J55. Check that jumpers J47 and J48 are
-**off** (they are on by default when boards ship from the factory) to ensure
-SWD signals are disconnected from the OpenSDA microcontroller.
+.. include:: ../../common/rt1xxx-lpclink2-debug.rst
+   :start-after: rt1xxx-lpclink2-probes
 
 Configuring a Console
 =====================

--- a/boards/nxp/mimxrt1040_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1040_evk/doc/index.rst
@@ -180,58 +180,29 @@ Serial Port
 The MIMXRT1040 SoC has eight UARTs. ``LPUART1`` is configured for the console,
 and the remaining UARTs are not used.
 
-
 Programming and Debugging
 *************************
 
-Build and flash applications as usual (see :ref:`build_an_application` and
-:ref:`application_run` for more details).
+This board supports 3 debug host tools. Please install your preferred host
+tool, then follow the instructions in `Configuring a Debug Probe`_ to
+configure the board appropriately.
+
+* :ref:`jlink-debug-host-tools` (Default, Supported by NXP)
+* :ref:`linkserver-debug-host-tools` (Supported by NXP)
+* :ref:`pyocd-debug-host-tools` (Not supported by NXP)
+
+Once the host tool and board are configured, build and flash applications
+as usual (see :ref:`build_an_application` and :ref:`application_run` for more
+details).
 
 Configuring a Debug Probe
 =========================
 
-Programming and Debugging
-*************************
+For the RT1040, J9/J10 are the SWD isolation jumpers, J12 is the DFU
+mode jumper, and J2 is the 20 pin JTAG/SWD header.
 
-Build and flash applications as usual (see :ref:`build_an_application` and
-:ref:`application_run` for more details).
-
-Configuring a Debug Probe
-=========================
-
-A debug probe is used for both flashing and debugging the board. This board is
-configured by default to use the :ref:`opensda-daplink-onboard-debug-probe`,
-however the :ref:`pyocd-debug-host-tools` do not yet support programming the
-external flashes on this board so you must reconfigure the board for one of the
-following debug probes instead.
-
-Option 1: :ref:`opensda-jlink-onboard-debug-probe` (Recommended)
-----------------------------------------------------------------
-
-Install the :ref:`jlink-debug-host-tools` and make sure they are in your search
-path.
-
-Check that jumpers J9 and J10 are **on** to ensure SWD signals are connected to
-the OpenSDA microcontroller. Then, follow the instructions in `NXP AN13206`_ to
-program a JLink based firmware to the LPC4322 based debugger on this board.
-
-Once the JLink based firmware is present on this board, the SOC will no longer
-be powered via the USB connection to J1. Move J40 to short pins 3 and 4 in
-order to use J48 for USB power, and connect another USB cable to power the SoC.
-LED D16 should illuminate to indicate the board is powered, and it should now be
-possible to program the SoC.
-
-Option 2: :ref:`jlink-external-debug-probe`
--------------------------------------------
-
-Install the :ref:`jlink-debug-host-tools` and make sure they are in your search
-path.
-
-The board can be programmed using the :ref:`jlink-external-debug-probe`,
-provided the onboard debug circuit's SWD signals are isolated from the MCU.
-To do so, ensure that jumpers J9 and J10 are **off** (they are on by default
-when the board ships from the factory). The external probe's 20 pin connector
-can then be connected to J2 to program the SOC.
+.. include:: ../../common/rt1xxx-lpclink2-debug.rst
+   :start-after: rt1xxx-lpclink2-probes
 
 Configuring a Console
 =====================

--- a/boards/nxp/mimxrt1050_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1050_evk/doc/index.rst
@@ -17,9 +17,6 @@ and camera sensors. As with other i.MX processors, i.MX RT1050 also has rich
 audio and video features, including LCD display, basic 2D graphics, camera
 interface, SPDIF, and I2S audio interface.
 
-The following document refers to the discontinued MIMXRT1050-EVK board. For the
-MIMXRT1050-EVKB board, refer to `Board Revisions`_ section.
-
 .. image:: mimxrt1050_evk.jpg
    :align: center
    :alt: MIMXRT1050-EVK

--- a/boards/nxp/mimxrt1050_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1050_evk/doc/index.rst
@@ -311,58 +311,43 @@ Only USB device function is supported in Zephyr at the moment.
 Programming and Debugging
 *************************
 
-Build and flash applications as usual (see :ref:`build_an_application` and
-:ref:`application_run` for more details).
+.. note::
+   Newer revisions of this board use :ref:`lpc-link2-onboard-debug-probe`,
+   while older revisions use the :ref:`opensda-onboard-debug-probe`.
+   Schematic revisions A/A1 use the K20 OpenSDA probe, and B/B1 use the
+   LPC-Link2 LPC4322 probe.
 
-Configuring a Debug Probe
-=========================
+This board supports 3 debug host tools. Please install your preferred host
+tool, then follow the instructions in `Configuring a Debug Probe
+(Schematic A/A1)`_ or `Configuring a Debug Probe (Schematic B/B1)`_,
+depending on board schematic revision to configure the board appropriately.
 
-A debug probe is used for both flashing and debugging the board. This board is
-configured by default to use the :ref:`opensda-daplink-onboard-debug-probe`,
-however the :ref:`pyocd-debug-host-tools` do not yet support programming the
-external flashes on this board so you must reconfigure the board for one of the
-following debug probes instead.
+* :ref:`linkserver-debug-host-tools` (Default, NXP Supported)
+* :ref:`jlink-debug-host-tools` (NXP Supported)
+* :ref:`pyocd-debug-host-tools` (Not supported by NXP)
 
-Using LinkServer
-----------------
+Once the host tool and board are configured, build and flash applications
+as usual (see :ref:`build_an_application` and :ref:`application_run` for more
+details).
 
-Install the :ref:`linkserver-debug-host-tools` and make sure they are in your
-search path.  LinkServer works with the default CMSIS-DAP firmware included in
-the on-board debugger.
+Configuring a Debug Probe (Schematic A/A1)
+==========================================
 
-Linkserver is the default runner. You may also se the ``-r linkserver`` option
-with West to use the LinkServer runner.
+For the RT1050 Schematic Rev A, J32/J33 are the SWD isolation jumpers, SW4 is
+the reset button, and J21 is the 20 pin JTAG/SWD header.
 
-.. code-block:: console
+.. include:: ../../common/opensda-debug.rst
+   :start-after: nxp-opensda-probes
 
-   west flash
-   west debug
 
-JLink (on-board): :ref:`opensda-jlink-onboard-debug-probe`
-----------------------------------------------------------
+Configuring a Debug Probe (Schematic B/B1)
+==========================================
 
-Install the :ref:`jlink-debug-host-tools` and make sure they are in your search
-path.
+For the RT1050 Schematic Rev B, J47/J48 are the SWD isolation jumpers, J42 is
+the DFU mode jumper, and J21 is the 20 pin JTAG/SWD header.
 
-Follow the instructions in :ref:`opensda-jlink-onboard-debug-probe` to program
-the `OpenSDA J-Link MIMXRT1050-EVK-Hyperflash Firmware`_. Check that jumpers
-J32 and J33 are **on** (they are on by default when boards ship from the
-factory) to ensure SWD signals are connected to the OpenSDA microcontroller.
-
-Follow the instructions in `Enable QSPI flash support in SEGGER JLink`_
-in order to support your EVK if you have modified it to boot from QSPI NOR
-flash as specified by NXP AN12108.
-
-External JLink :ref:`jlink-external-debug-probe`
-------------------------------------------------
-
-Install the :ref:`jlink-debug-host-tools` and make sure they are in your search
-path.
-
-Attach a J-Link 20-pin connector to J21. Check that jumpers J32 and J33 with
-schematic rev A0/A1 or J47 and J48 with schematic rev B1 are **off** (they are
-on by default when boards ship from the factory) to ensure SWD signals are
-disconnected from the OpenSDA microcontroller.
+.. include:: ../../common/rt1xxx-lpclink2-debug.rst
+   :start-after: rt1xxx-lpclink2-probes
 
 Configuring a Console
 =====================

--- a/boards/nxp/mimxrt1060_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1060_evk/doc/index.rst
@@ -325,35 +325,31 @@ remaining are not used.
 Programming and Debugging
 *************************
 
-Build and flash applications as usual (see :ref:`build_an_application` and
-:ref:`application_run` for more details).
+This board supports 3 debug host tools. Please install your preferred host
+tool, then follow the instructions in `Configuring a Debug Probe`_ to
+configure the board appropriately.
+
+* :ref:`jlink-debug-host-tools` (Default, Supported by NXP)
+* :ref:`linkserver-debug-host-tools` (Supported by NXP)
+* :ref:`pyocd-debug-host-tools` (Not Supported by NXP)
+
+Once the host tool and board are configured, build and flash applications
+as usual (see :ref:`build_an_application` and :ref:`application_run` for more
+details).
 
 Configuring a Debug Probe
 =========================
 
-A debug probe is used for both flashing and debugging the board. This board is
-configured by default to use the :ref:`opensda-daplink-onboard-debug-probe`,
-however the :ref:`pyocd-debug-host-tools` do not yet support programming the
-external flashes on this board so you must reconfigure the board for one of the
-following debug probes instead.
+Two revisions of the RT1060 EVK exist. For the RT1060 EVK, J47/J48 are the SWD
+isolation jumpers, J42 is the DFU mode jumper, and the 20 pin JTAG/SWD header
+is present on J21. For the RT1060 EVKB, J9/J10 are the SWD isolation jumpers,
+J12 is the DFU mode jumper, and the 20 pin JTAG/SWD header is present on J2.
 
-.. _Using LinkServer:
+.. include:: ../../common/rt1xxx-lpclink2-debug.rst
+   :start-after: rt1xxx-lpclink2-probes
 
-        1. Install the :ref:`linkserver-debug-host-tools` and make sure they are in your search path.
-        2. To update the debug firmware, please follow the instructions on `MIMXRT1060-EVK Debug Firmware`
-
-.. _Using J-Link RT1060:
-
-Using J-Link
----------------------------------
-
-Install the :ref:`jlink-debug-host-tools` and make sure they are in your search
-path.
-
-There are two options: the onboard debug circuit can be updated with Segger
-J-Link firmware, or :ref:`jlink-external-debug-probe` can be attached to the
-EVK. See `Using J-Link with MIMXRT1060-EVK or MIMXRT1064-EVK`_ or
-`Using J-Link with MIMXRT1060-EVKB`_ for more details.
+See `Using J-Link with MIMXRT1060-EVK or MIMXRT1064-EVK`_ or `Using J-Link with
+MIMXRT1060-EVKB`_ for more details.
 
 Configuring a Console
 =====================
@@ -448,7 +444,7 @@ steps:
 
 If the west flash or debug commands fail, and the command hangs while executing
 runners.jlink, confirm the J-Link debug probe is configured, powered, and
-connected to the EVK properly. See :ref:`Using J-Link RT1060` for more details.
+connected to the EVK properly.
 
 .. _MIMXRT1060-EVK Website:
    https://www.nxp.com/design/development-boards/i-mx-evaluation-and-development-boards/i-mx-rt1060-evaluation-kit:MIMXRT1060-EVKB

--- a/boards/nxp/mimxrt1064_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1064_evk/doc/index.rst
@@ -315,8 +315,17 @@ and the remaining are not used.
 Programming and Debugging
 *************************
 
-Build and flash applications as usual (see :ref:`build_an_application` and
-:ref:`application_run` for more details).
+This board supports 3 debug host tools. Please install your preferred host
+tool, then follow the instructions in `Configuring a Debug Probe`_ to
+configure the board appropriately.
+
+* :ref:`jlink-debug-host-tools` (Default, Supported by NXP)
+* :ref:`linkserver-debug-host-tools` (Supported by NXP)
+* :ref:`pyocd-debug-host-tools` (Not supported by NXP)
+
+Once the host tool and board are configured, build and flash applications
+as usual (see :ref:`build_an_application` and :ref:`application_run` for more
+details).
 
 Configuring a Debug Probe
 =========================
@@ -326,28 +335,13 @@ Configuring a Debug Probe
 	unable to access the chip. Use caution when enabling ``CONFIG_PM``, and
 	if the debugger cannot flash the part, see :ref:`Troubleshooting RT1064`
 
-A debug probe is used for both flashing and debugging the board. This board is
-configured by default to use the :ref:`opensda-daplink-onboard-debug-probe`,
-however the :ref:`pyocd-debug-host-tools` do not yet support programming the
-external flashes on this board so you must reconfigure the board for one of the
-following debug probes instead.
+For the RT1064, J47/J48 are the SWD isolation jumpers, J42 is the DFU
+mode jumper, and J21 is the 20 pin JTAG/SWD header.
 
-.. _Using LinkServer:
+.. include:: ../../common/rt1xxx-lpclink2-debug.rst
+   :start-after: rt1xxx-lpclink2-probes
 
-        1. Install the :ref:`linkserver-debug-host-tools` and make sure they are in your search path.
-        2. To update the debug firmware, please follow the instructions on `MIMXRT1064-EVK Debug Firmware`
-
-.. _Using J-Link RT1064:
-
-Using J-Link
----------------------------------
-
-Install the :ref:`jlink-debug-host-tools` and make sure they are in your search
-path.
-
-There are two options: the onboard debug circuit can be updated with Segger
-J-Link firmware, or :ref:`jlink-external-debug-probe` can be attached to the
-EVK. See `Using J-Link with MIMXRT1060-EVK or MIMXRT1064-EVK`_ for more
+See `Using J-Link with MIMXRT1060-EVK or MIMXRT1064-EVK`_ for more
 details.
 
 Configuring a Console
@@ -446,8 +440,7 @@ steps:
 
 If the west flash or debug commands fail, and the command hangs while executing
 runners.jlink, confirm the J-Link debug probe is configured, powered, and
-connected to the EVK properly.  See :ref:`Using J-Link RT1064` for more
-details.
+connected to the EVK properly.
 
 .. _MIMXRT1064-EVK Website:
    https://www.nxp.com/support/developer-resources/run-time-software/i.mx-developer-resources/mimxrt1064-evk-i.mx-rt1064-evaluation-kit:MIMXRT1064-EVK

--- a/doc/develop/flash_debug/probes.rst
+++ b/doc/develop/flash_debug/probes.rst
@@ -24,9 +24,9 @@ and provides a variety of debug host tool options.
 
 Several hardware vendors have their own branded onboard debug probe
 implementations: NXP boards may use
-`OpenSDA <#opensda-daplink-onboard-debug-probe>`_,
-`LPC-Link2 <#lpclink2-jlink-onboard-debug-probe>`_, or
-`MCU-Link <#mcu-link-cmsis-onboard-debug-probe>`_, probes depending on
+`OpenSDA <#opensda-onboard-debug-probe>`_,
+`LPC-Link2 <#lpc-link2-onboard-debug-probe>`_, or
+`MCU-Link <#mcu-link-onboard-debug-probe>`_, probes depending on
 the microcontroller the debug probe firmware runs on.
 ST boards have the `ST-LINK probe <#stlink-v21-onboard-debug-probe>`_. Each
 onboard debug probe microcontroller can support one or more types of firmware
@@ -127,7 +127,10 @@ This debug probe is compatible with the following debug host tools:
 Once the MCU-Link host tools are installed, the following steps are
 required to program the CMSIS-DAP firmware:
 
-1. Put the MCU-Link microcontroller into DFU boot mode by attaching the DFU
+1. Make sure the MCU-Link utility is present on your host machine. This can
+   be done by installing :ref:`linkserver-debug-host-tools`.
+
+#. Put the MCU-Link microcontroller into DFU boot mode by attaching the DFU
    jumper then connecting to the USB debug port on the board.  This jumper may
    also be referred to as the ISP jumper, and will be connected to ``PIO0_5``
    on the LPC55S69.
@@ -152,7 +155,10 @@ These probes do not have JLink firmware installed by default, and must be
 updated. Once the MCU-Link host tools are installed, the following steps are
 required to program the JLink firmware:
 
-1. Put the MCU-Link microcontroller into DFU boot mode by attaching the DFU
+1. Make sure the MCU-Link utility is present on your host machine. This can
+   be done by installing :ref:`linkserver-debug-host-tools`.
+
+#. Put the MCU-Link microcontroller into DFU boot mode by attaching the DFU
    jumper then connecting to the USB debug port on the board.  This jumper may
    also be referred to as the ISP jumper, and will be connected to ``PIO0_5``
    on the LPC55S69.
@@ -198,10 +204,12 @@ This debug probe firmware is compatible with the following debug host tools:
 
 - :ref:`linkserver-debug-host-tools`
 
-After installing the LPCScrypt host tools, the firmware may be updated to
-use CMSIS-DAP firmware with the following steps:
+The probe may be updated to use CMSIS-DAP firmware with the following steps:
 
-1. Put the LPC-Link2 microcontroller into DFU boot mode by attaching the DFU
+1. Make sure the LPCScrypt utility is present on your host machine. This can
+   be done by installing :ref:`linkserver-debug-host-tools`.
+
+#. Put the LPC-Link2 microcontroller into DFU boot mode by attaching the DFU
    jumper, then then connecting to the USB debug port on the board. This
    jumper is connected to ``P2_6`` on the LPC4322 SOC.
 
@@ -225,12 +233,14 @@ tools:
 
 - :ref:`jlink-debug-host-tools`
 
-After installing the LPCScrypt host tools, the firmware may be updated to
-use CMSIS-DAP firmware with the following steps:
+The probe may be updated to use the J-Link firmware with the following steps:
 
 .. note:: Verify the firmware supports your board by visiting `Firmware for LPCXpresso`_
 
-1. Put the LPC-Link2 microcontroller into DFU boot mode by attaching the DFU
+1. Make sure the LPCScrypt utility is present on your host machine. This can
+   be done by installing :ref:`linkserver-debug-host-tools`.
+
+#. Put the LPC-Link2 microcontroller into DFU boot mode by attaching the DFU
    jumper, then then connecting to the USB debug port on the board. This
    jumper is connected to ``P2_6`` on the LPC4322 SOC.
 


### PR DESCRIPTION
Update the debugging documentation for the NXP iMXRT10xx evaluation kits, in an attempt to be more clear on debug strategies. This update takes the approach of listing all supported host tools for the EVK, and providing instructions on configuring the board for that host tool.

This PR also updates the probes documentation to be more explicit about installing the firmware programming tools needed for LPCLink2 and MCULink probes