### PR TITLE
twister: Fix output directory reaching backup limit

### DIFF
--- a/scripts/pylib/twister/twisterlib/twister_main.py
+++ b/scripts/pylib/twister/twisterlib/twister_main.py
@@ -94,6 +94,9 @@ def main(options, default_options):
                     print("Renaming output directory to {}".format(new_out))
                     shutil.move(options.outdir, new_out)
                     break
+            else:
+                sys.exit(f"Too many '{options.outdir}.*' directories. Run either with --no-clean, "
+                         "or --clobber-output, or delete these directories manually.")
 
     previous_results_file = None
     os.makedirs(options.outdir, exist_ok=True)


### PR DESCRIPTION
Stop Twister if there are too many backup copies of the output directory.
Before this fix, Twister silently kept artifacts from the last run, unless `--clobber-output` was explicitly given.

Fixes: #74224 