### PR TITLE
check_compliance: allow `_MODULE` variant of Kconfig options

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -801,7 +801,8 @@ Missing SoC names or CONFIG_SOC vs soc.yml out of sync:
             for sym_name in re.findall(regex, line):
                 sym_name = sym_name[7:]  # Strip CONFIG_
                 if sym_name not in defined_syms and \
-                   sym_name not in self.UNDEF_KCONFIG_ALLOWLIST:
+                   sym_name not in self.UNDEF_KCONFIG_ALLOWLIST and \
+                   not (sym_name.endswith("_MODULE") and sym_name[:-7] in defined_syms):
 
                     undef_to_locs[sym_name].append(f"{path}:{lineno}")
 


### PR DESCRIPTION
Since b53a792ff0b Zephyr has the ability to define tristate Kconfig options. When tristate option `FOO` is chosen as a "module", this results in `autoconf.h` defining `CONFIG_FOO_MODULE` instead of `CONFIG_FOO`.

While developing #74060 i tried checking in this code:
```
#if defined(CONFIG_HELLO_WORLD_MODE_MODULE)
	printk("Hello, world, from an llext!\n");
#elif defined(CONFIG_HELLO_WORLD_MODE)
	printk("Hello, world, from the main binary!\n");
#else
	/* also detected by CMakeLists.txt */
	#error "Please set CONFIG_HELLO_WORLD_MODE to 'y' or 'm'"
#endif
```
... but this resulted in CI [rejecting the commit](https://github.com/zephyrproject-rtos/zephyr/actions/runs/9498394524/job/26177035754?pr=74060). It's obviously possible to [work around it](https://github.com/zephyrproject-rtos/zephyr/compare/4c850dab83b810794dcfba07e5a85f4b341706a2..594d8aa9c7a3a915730f7ba5e1ce5992de680fbe), but I think it could be useful to allow such code in the future.

This patch allows the check_compliance script to also accept references to a Kconfig symbol ending in `_MODULE` if the prefix is defined. Currently only 4 Kconfig entries out of 19115 have separate `FOO` and `FOO_MODULE` definitions (Infineon CY43* radios), so the risk introduced by relaxing this check is minimal.