### PR TITLE
Fix bt_audio_codec_cfg_get_chan_allocation() calls

### DIFF
--- a/tests/bluetooth/audio/bap_broadcast_source/src/main.c
+++ b/tests/bluetooth/audio/bap_broadcast_source/src/main.c
@@ -239,7 +239,7 @@ ZTEST_F(bap_broadcast_source_test_suite, test_broadcast_source_create_start_send
 			zassert_equal(bt_audio_codec_cfg_get_frame_dur(codec_cfg),
 				      BT_AUDIO_CODEC_CFG_DURATION_10);
 			/* verify bis specific codec data */
-			bt_audio_codec_cfg_get_chan_allocation(codec_cfg, &chan_allocation);
+			bt_audio_codec_cfg_get_chan_allocation(codec_cfg, &chan_allocation, false);
 			zassert_equal(chan_allocation,
 				      BT_AUDIO_LOCATION_FRONT_LEFT | BT_AUDIO_LOCATION_FRONT_RIGHT);
 			/* Since BAP doesn't care about the `buf` we can just provide NULL */

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_source_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_source_test.c
@@ -112,7 +112,7 @@ static void validate_stream_codec_cfg(const struct bt_bap_stream *stream)
 	/* The broadcast source sets the channel allocation in the BIS to
 	 * BT_AUDIO_LOCATION_FRONT_CENTER
 	 */
-	ret = bt_audio_codec_cfg_get_chan_allocation(codec_cfg, &chan_allocation);
+	ret = bt_audio_codec_cfg_get_chan_allocation(codec_cfg, &chan_allocation, false);
 	if (ret == 0) {
 		if (chan_allocation != BT_AUDIO_LOCATION_FRONT_CENTER) {
 			FAIL("Unexpected channel allocation: 0x%08X", chan_allocation);


### PR DESCRIPTION
c6cc034b5cbaad096e1a1e91dbd0705a6b1a263f changed the prototype of bt_audio_codec_cfg_get_chan_allocation()
to take an extra parameter.
But two calls in new tests came into main with the old one. Let's fix it.

Fixes #74261