### PR TITLE
dai: ssp/ptl: Add missing definition in PTL

### DIFF
--- a/drivers/dai/intel/ssp/ssp_regs_v3.h
+++ b/drivers/dai/intel/ssp/ssp_regs_v3.h
@@ -53,6 +53,7 @@
 #define SSCR0_EFRDC     BIT(27)
 #define SSCR0_EFRDC2    BIT(28)
 #define SSCR0_DLE		DAI_INTEL_SSP_SET_BITS(30, 29, 0)
+#define SSCR0_ACS		BIT(30)
 #define SSCR0_MOD		BIT(31)
 
 /* SSCR1 bits */


### PR DESCRIPTION
SSCR0_ACS is missing in PTL header.