### PR TITLE
x86: select CONFIG_THREAD_STACK_INFO for exception stack trace

### DIFF
--- a/arch/x86/core/Kconfig.ia32
+++ b/arch/x86/core/Kconfig.ia32
@@ -167,6 +167,7 @@ config X86_EXCEPTION_STACK_TRACE
 	bool
 	default y
 	select DEBUG_INFO
+	select THREAD_STACK_INFO
 	depends on !OMIT_FRAME_POINTER
 	help
 	  Internal config to enable runtime stack traces on fatal exceptions.

--- a/arch/x86/core/Kconfig.intel64
+++ b/arch/x86/core/Kconfig.intel64
@@ -33,6 +33,7 @@ config X86_EXCEPTION_STACK_TRACE
 	bool
 	default y
 	select DEBUG_INFO
+	select THREAD_STACK_INFO
 	depends on !OMIT_FRAME_POINTER
 	depends on NO_OPTIMIZATIONS
 	help


### PR DESCRIPTION
When CONFIG_X86_EXCEPTION_STACK_TRACE is enabled, also forcibly enable CONFIG_THREAD_STACK_INFO. Without the thread stack info, it is possible the stack unwinding would go out of the thread stack and into unknown memory, resulting in hard fault.