### PR TITLE
soc: intel_adsp/hda: fix range checking

### DIFF
--- a/soc/intel/intel_adsp/common/include/intel_adsp_hda.h
+++ b/soc/intel/intel_adsp/common/include/intel_adsp_hda.h
@@ -8,6 +8,7 @@
 #include <zephyr/cache.h>
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
+#include <zephyr/sys/util.h>
 #include <adsp_shim.h>
 #include <adsp_memory.h>
 #include <adsp_shim.h>
@@ -172,7 +173,7 @@ static inline int intel_adsp_hda_set_buffer(uint32_t base,
 #  define _INTEL_ADSP_SIZE  CONFIG_KERNEL_VM_SIZE
 #else
 #  define _INTEL_ADSP_BASE  CONFIG_SRAM_BASE_ADDRESS
-#  define _INTEL_ADSP_SIZE  CONFIG_SRAM_SIZE
+#  define _INTEL_ADSP_SIZE  KB(CONFIG_SRAM_SIZE)
 #endif
 
 	__ASSERT(aligned_addr >= _INTEL_ADSP_BASE


### PR DESCRIPTION
intel_adsp_hda_set_buffer() asserts when the HDA buffer is outside of RAM space. However, it uses CONFIG_SRAM_SIZE as if it is bytes. In reality, CONFIG_SRAM_SIZE is in KB so we need to multiply it by 1024, or simply use marco KB().

Fixes #74250