### PR TITLE
drivers: bbram: npcx: apply workaround and fix issue with clearing status register .

### DIFF
--- a/drivers/bbram/bbram_npcx.c
+++ b/drivers/bbram/bbram_npcx.c
@@ -26,8 +26,16 @@ static int get_bit_and_reset(const struct device *dev, int mask)
 {
 	int result = DRV_STATUS(dev) & mask;
 
-	/* Clear the bit(s) */
+	/*
+	 * Clear the bit(s):
+	 *   For emulator, write 0 to clear status bit(s).
+	 *   For real chip, write 1 to clear status bit(s).
+	 */
+#ifdef CONFIG_BBRAM_NPCX_EMUL
 	DRV_STATUS(dev) &= ~mask;
+#else
+	DRV_STATUS(dev) = mask;
+#endif
 
 	return result;
 }

--- a/dts/arm/nuvoton/npcx/npcx.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx.dtsi
@@ -80,13 +80,6 @@
 	};
 
 	soc {
-		bbram: bb-ram@400af000 {
-			compatible = "nuvoton,npcx-bbram";
-			reg = <0x400af000 0x80
-			       0x400af100 0x1>;
-			reg-names = "memory", "status";
-		};
-
 		pcc: clock-controller@4000d000 {
 			compatible = "nuvoton,npcx-pcc";
 			/* Cells for bus type, clock control reg and bit */

--- a/dts/arm/nuvoton/npcx/npcx4.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx4.dtsi
@@ -63,6 +63,19 @@
 	soc {
 		compatible = "nuvoton,npcx4", "nuvoton,npcx", "simple-bus";
 
+		/*
+		 * Writing to BKUP_STS register might affect the value stored in
+		 * the first byte of the BBRAM.
+		 * Workaround it by not using the first byte of the BBRAM.
+		 * (See npcx4 Errata 2.27)
+		 */
+		bbram: bb-ram@400af001 {
+			compatible = "nuvoton,npcx-bbram";
+			reg = <0x400af001 0x7F
+			       0x400af100 0x1>;
+			reg-names = "memory", "status";
+		};
+
 		/* Specific soc devices in npcx4 series */
 		itims: timer@400b0000 {
 			compatible = "nuvoton,npcx-itim-timer";

--- a/dts/arm/nuvoton/npcx/npcx7.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx7.dtsi
@@ -59,6 +59,13 @@
 	soc {
 		compatible = "nuvoton,npcx7", "nuvoton,npcx", "simple-bus";
 
+		bbram: bb-ram@400af000 {
+			compatible = "nuvoton,npcx-bbram";
+			reg = <0x400af000 0x80
+			       0x400af100 0x1>;
+			reg-names = "memory", "status";
+		};
+
 		/* Specific soc devices in npcx7 series */
 		itims: timer@400bc000 {
 			compatible = "nuvoton,npcx-itim-timer";

--- a/dts/arm/nuvoton/npcx/npcx9.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx9.dtsi
@@ -60,6 +60,13 @@
 	soc {
 		compatible = "nuvoton,npcx9", "nuvoton,npcx", "simple-bus";
 
+		bbram: bb-ram@400af000 {
+			compatible = "nuvoton,npcx-bbram";
+			reg = <0x400af000 0x80
+			       0x400af100 0x1>;
+			reg-names = "memory", "status";
+		};
+
 		/* Specific soc devices in npcx9 series */
 		itims: timer@400b0000 {
 			compatible = "nuvoton,npcx-itim-timer";


### PR DESCRIPTION
This PR updates the NPCX BBRAM driver with the following two changes:
1. Fix the way to clear the BBRAM status register. Those bits in the register should be write-1-to-clear in the real chip.
2. Workaround the first byte issue in npcx4 chips by preventing the BBRAM offset 0 from accessing.
    So the available BBRAM capacity is 128 -1 =127 bytes. 