### PR TITLE
boards: ambiq: apollo4p_evb: fix multiple CI failure

### DIFF
--- a/boards/ambiq/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb.yaml
+++ b/boards/ambiq/apollo4p_blue_kxr_evb/apollo4p_blue_kxr_evb.yaml
@@ -20,7 +20,3 @@ testing:
   ignore_tags:
     - net
 vendor: ambiq
-# Provisional hack to prevent tests being run in this board, as it fails in many test & samples:
-twister: false
-# Once https://github.com/zephyrproject-rtos/zephyr/issues/74212, 73443 & 72775 are fixed
-# this should be removed

--- a/boards/ambiq/apollo4p_evb/apollo4p_evb.dts
+++ b/boards/ambiq/apollo4p_evb/apollo4p_evb.dts
@@ -14,6 +14,7 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-pipe = &uart0;
+		zephyr,flash-controller = &flash;
 	};
 
 	aliases {
@@ -101,6 +102,23 @@
 	pinctrl-0 = <&mspi2_default>;
 	pinctrl-names = "default";
 	status = "okay";
+};
+
+&flash0 {
+	erase-block-size = <2048>;
+	write-block-size = <16>;
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* Set 16KB of storage at the end of the 1952KB of flash */
+		storage_partition: partition@1e4000 {
+			label = "storage";
+			reg = <0x001e4000 0x4000>;
+		};
+	};
 };
 
 &gpio0_31 {

--- a/boards/ambiq/apollo4p_evb/apollo4p_evb.yaml
+++ b/boards/ambiq/apollo4p_evb/apollo4p_evb.yaml
@@ -20,7 +20,3 @@ testing:
     - net
     - bluetooth
 vendor: ambiq
-# Provisional hack to prevent tests being run in this board, as it fails in many test & samples:
-twister: false
-# Once https://github.com/zephyrproject-rtos/zephyr/issues/74212, 73443 & 72775 are fixed
-# this should be removed

--- a/soc/ambiq/apollo4x/Kconfig
+++ b/soc/ambiq/apollo4x/Kconfig
@@ -11,6 +11,4 @@ config SOC_SERIES_APOLLO4X
 	select CPU_HAS_ARM_MPU
 	select HAS_SWO
 	select AMBIQ_HAL
-	select CPU_HAS_DCACHE
-	select CPU_HAS_ICACHE
 	select HAS_PM

--- a/west.yml
+++ b/west.yml
@@ -147,7 +147,7 @@ manifest:
       groups:
         - hal
     - name: hal_ambiq
-      revision: 367ae6a0396e3074bebbd55ef72f8e577168e567
+      revision: e25327f026df1ee08f1bf01a4bbfeb5e5f4026f1
       path: modules/hal/ambiq
       groups:
         - hal


### PR DESCRIPTION
This PR is trying to fix multiple CI failures which were introduced from https://github.com/zephyrproject-rtos/zephyr/pull/70842.
Adds the missing flash controller node in apollo4p_evb to address the CI failure https://github.com/zephyrproject-rtos/zephyr/issues/74212. 
Remove the untestable cache kconfig from apollo4x boards to address the CI failure https://github.com/zephyrproject-rtos/zephyr/issues/72775, https://github.com/zephyrproject-rtos/zephyr/issues/73443 at this moment.
And enable the twister for apollo4x platforms. Refer to https://github.com/zephyrproject-rtos/zephyr/pull/74232.

Sorry for inconvenience.

Fixes #74212
Fixes #72775
Fixes #73443