### PR TITLE
net: lib: dhcpv4: Add check for input parameter of echo_reply_handler

### DIFF
--- a/subsys/net/lib/dhcpv4/dhcpv4_server.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4_server.c
@@ -737,7 +737,7 @@ static int echo_reply_handler(struct net_icmp_ctx *icmp_ctx,
 			      void *user_data)
 {
 	struct dhcpv4_server_ctx *ctx = user_data;
-	struct dhcpv4_server_probe_ctx *probe_ctx = &ctx->probe_ctx;
+	struct dhcpv4_server_probe_ctx *probe_ctx;
 	struct dhcpv4_addr_slot *new_slot = NULL;
 	struct in_addr peer_addr;
 
@@ -747,6 +747,12 @@ static int echo_reply_handler(struct net_icmp_ctx *icmp_ctx,
 	ARG_UNUSED(icmp_hdr);
 
 	k_mutex_lock(&server_lock, K_FOREVER);
+
+	if (ctx == NULL) {
+		goto out;
+	}
+
+	probe_ctx = &ctx->probe_ctx;
 
 	if (probe_ctx->slot == NULL) {
 		goto out;


### PR DESCRIPTION
For station and internal AP coexist case, station connected to external AP, ping from station to external AP cause cpu hang.

Internal AP dhcpv4 server register handler echo_reply_handler on icmp handler by net_icmp_init_ctx for dhcp server snoop feature. Ping also register handler handle_ipv4_echo_reply on icmp handler for ping cmd. If no external station connect to internal AP, input parameter ‘user_data’ of function echo_reply_handler is NULL. When we trigger ping process, icmp_call_handlers fetch all handlers from icmp handler if receive any ICMP packet, so echo_reply_handler be called, but input parameter is NULL, cause CPU hang. Add input parameters check to fix this issue.