### PR TITLE
ci: bsim: Fix reports merge failing

### DIFF
--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -163,7 +163,7 @@ jobs:
       - name: Merge Test Results
         run: |
           pip3 install junitparser junit2html
-          junitparser merge ./bsim_*/*bsim_results.*.xml ./twister-out/twister.xml junit.xml
+          junitparser merge ./bsim_*/*bsim_results.*.xml junit.xml
           junit2html junit.xml junit.html
 
       - name: Upload Unit Test Results in HTML


### PR DESCRIPTION
With a recent change the test results are now merged together. We tried to merge the bsim results with `./twister-out/twister.xml` but that file doesn't exist in the bsim ci, this cause the `junitparser` command to fail.

Remove the twister file to the list of files to merge.

One example of such failure: https://github.com/zephyrproject-rtos/zephyr/pull/73378

Ping @valeriosetti