### PR TITLE
ci: bsim tests: Fix for missing twister*.xml

### DIFF
--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -163,7 +163,7 @@ jobs:
       - name: Merge Test Results
         run: |
           pip3 install junitparser junit2html
-          junitparser merge ./bsim_*/*bsim_results.*.xml ./twister-out/twister.xml junit.xml
+          junitparser merge --glob "./bsim_*/*bsim_results.*.xml" "./twister-out/twister.xml" junit.xml
           junit2html junit.xml junit.html
 
       - name: Upload Unit Test Results in HTML


### PR DESCRIPTION
Do not fail during results merge if
twister did not run (or produce an xml).
Depending on what has changed in a PR
and therefore what tests are run this can happen.