### PR TITLE
drivers: spi: nrf: use dmm

### DIFF
--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -10,6 +10,7 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/mem_mgmt/mem_attr.h>
 #include <soc.h>
+#include <dmm.h>
 #ifdef CONFIG_SOC_NRF52832_ALLOW_SPIM_DESPITE_PAN_58
 #include <nrfx_ppi.h>
 #endif
@@ -66,9 +67,7 @@ struct spi_nrfx_config {
 #endif
 	uint32_t wake_pin;
 	nrfx_gpiote_t wake_gpiote;
-#ifdef CONFIG_DCACHE
-	uint32_t mem_attr;
-#endif
+	void *mem_reg;
 };
 
 static void event_handler(const nrfx_spim_evt_t *p_event, void *p_context);
@@ -350,11 +349,6 @@ static void transfer_next_chunk(const struct device *dev)
 			}
 
 			memcpy(dev_data->tx_buffer, tx_buf, chunk_len);
-#ifdef CONFIG_DCACHE
-			if (dev_config->mem_attr & DT_MEM_CACHEABLE) {
-				sys_cache_data_flush_range(dev_data->tx_buffer, chunk_len);
-			}
-#endif
 			tx_buf = dev_data->tx_buffer;
 		}
 
@@ -371,10 +365,20 @@ static void transfer_next_chunk(const struct device *dev)
 
 		dev_data->chunk_len = chunk_len;
 
-		xfer.p_tx_buffer = tx_buf;
-		xfer.tx_length   = spi_context_tx_buf_on(ctx) ? chunk_len : 0;
-		xfer.p_rx_buffer = rx_buf;
-		xfer.rx_length   = spi_context_rx_buf_on(ctx) ? chunk_len : 0;
+		xfer.tx_length = spi_context_tx_buf_on(ctx) ? chunk_len : 0;
+		xfer.rx_length = spi_context_rx_buf_on(ctx) ? chunk_len : 0;
+
+		error = dmm_buffer_out_prepare(dev_config->mem_reg, tx_buf, xfer.tx_length,
+					       (void **)&xfer.p_tx_buffer);
+		if (error != 0) {
+			goto transfer_next_chunk_end;
+		}
+
+		error = dmm_buffer_in_prepare(dev_config->mem_reg, rx_buf, xfer.rx_length,
+					      (void **)&xfer.p_rx_buffer);
+		if (error != 0) {
+			goto transfer_next_chunk_end;
+		}
 
 #ifdef CONFIG_SOC_NRF52832_ALLOW_SPIM_DESPITE_PAN_58
 		if (xfer.rx_length == 1 && xfer.tx_length <= 1) {
@@ -399,6 +403,7 @@ static void transfer_next_chunk(const struct device *dev)
 		}
 	}
 
+transfer_next_chunk_end:
 	finish_transaction(dev, error);
 }
 
@@ -406,9 +411,7 @@ static void event_handler(const nrfx_spim_evt_t *p_event, void *p_context)
 {
 	const struct device *dev = p_context;
 	struct spi_nrfx_data *dev_data = dev->data;
-#ifdef CONFIG_DCACHE
 	const struct spi_nrfx_config *dev_config = dev->config;
-#endif
 
 	if (p_event->type == NRFX_SPIM_EVENT_DONE) {
 		/* Chunk length is set to 0 when a transaction is aborted
@@ -422,15 +425,21 @@ static void event_handler(const nrfx_spim_evt_t *p_event, void *p_context)
 #ifdef CONFIG_SOC_NRF52832_ALLOW_SPIM_DESPITE_PAN_58
 		anomaly_58_workaround_clear(dev_data);
 #endif
+
+		if (spi_context_tx_buf_on(&dev_data->ctx)) {
+			dmm_buffer_out_release(dev_config->mem_reg,
+					       (void **)p_event->xfer_desc.p_tx_buffer);
+		}
+
+		if (spi_context_rx_buf_on(&dev_data->ctx)) {
+			dmm_buffer_in_release(dev_config->mem_reg, dev_data->ctx.rx_buf,
+				dev_data->chunk_len, p_event->xfer_desc.p_rx_buffer);
+		}
+
 #ifdef SPI_BUFFER_IN_RAM
 		if (spi_context_rx_buf_on(&dev_data->ctx) &&
 		    p_event->xfer_desc.p_rx_buffer != NULL &&
 		    p_event->xfer_desc.p_rx_buffer != dev_data->ctx.rx_buf) {
-#ifdef CONFIG_DCACHE
-			if (dev_config->mem_attr & DT_MEM_CACHEABLE) {
-				sys_cache_data_invd_range(dev_data->rx_buffer, dev_data->chunk_len);
-			}
-#endif
 			(void)memcpy(dev_data->ctx.rx_buf,
 				     dev_data->rx_buffer,
 				     dev_data->chunk_len);
@@ -653,7 +662,6 @@ static int spi_nrfx_init(const struct device *dev)
 #define SPIM(idx)			DT_NODELABEL(spi##idx)
 #define SPIM_PROP(idx, prop)		DT_PROP(SPIM(idx), prop)
 #define SPIM_HAS_PROP(idx, prop)	DT_NODE_HAS_PROP(SPIM(idx), prop)
-#define SPIM_MEM_REGION(idx)		DT_PHANDLE(SPIM(idx), memory_regions)
 
 #define SPI_NRFX_SPIM_EXTENDED_CONFIG(idx)				\
 	IF_ENABLED(NRFX_SPIM_EXTENDED_ENABLED,				\
@@ -662,13 +670,6 @@ static int spi_nrfx_init(const struct device *dev)
 			     (.rx_delay = SPIM_PROP(idx, rx_delay),),	\
 			     ())					\
 		))
-
-#define SPIM_GET_MEM_ATTR(idx)								 \
-	COND_CODE_1(SPIM_HAS_PROP(idx, memory_regions),					 \
-		(COND_CODE_1(DT_NODE_HAS_PROP(SPIM_MEM_REGION(idx), zephyr_memory_attr), \
-			(DT_PROP(SPIM_MEM_REGION(idx), zephyr_memory_attr)),		 \
-			(0))),								 \
-		(0))
 
 #define SPI_NRFX_SPIM_DEFINE(idx)					       \
 	NRF_DT_CHECK_NODE_HAS_PINCTRL_SLEEP(SPIM(idx));			       \
@@ -680,10 +681,10 @@ static int spi_nrfx_init(const struct device *dev)
 	IF_ENABLED(SPI_BUFFER_IN_RAM,					       \
 		(static uint8_t spim_##idx##_tx_buffer			       \
 			[CONFIG_SPI_NRFX_RAM_BUFFER_SIZE]		       \
-			SPIM_MEMORY_SECTION(idx);			       \
+			DMM_MEMORY_SECTION(SPIM(idx));			       \
 		 static uint8_t spim_##idx##_rx_buffer			       \
 			[CONFIG_SPI_NRFX_RAM_BUFFER_SIZE]		       \
-			SPIM_MEMORY_SECTION(idx);))			       \
+			DMM_MEMORY_SECTION(SPIM(idx));))		       \
 	static struct spi_nrfx_data spi_##idx##_data = {		       \
 		SPI_CONTEXT_INIT_LOCK(spi_##idx##_data, ctx),		       \
 		SPI_CONTEXT_INIT_SYNC(spi_##idx##_data, ctx),		       \
@@ -718,8 +719,7 @@ static int spi_nrfx_init(const struct device *dev)
 		.wake_pin = NRF_DT_GPIOS_TO_PSEL_OR(SPIM(idx), wake_gpios,     \
 						    WAKE_PIN_NOT_USED),	       \
 		.wake_gpiote = WAKE_GPIOTE_INSTANCE(SPIM(idx)),		       \
-		IF_ENABLED(CONFIG_DCACHE,				       \
-			(.mem_attr = SPIM_GET_MEM_ATTR(idx),))		       \
+		.mem_reg = DMM_DEV_TO_REG(SPIM(idx)),			       \
 	};								       \
 	BUILD_ASSERT(!SPIM_HAS_PROP(idx, wake_gpios) ||			       \
 		     !(DT_GPIO_FLAGS(SPIM(idx), wake_gpios) & GPIO_ACTIVE_LOW),\
@@ -732,12 +732,6 @@ static int spi_nrfx_init(const struct device *dev)
 		      &spi_##idx##z_config,				       \
 		      POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,		       \
 		      &spi_nrfx_driver_api)
-
-#define SPIM_MEMORY_SECTION(idx)					       \
-	COND_CODE_1(SPIM_HAS_PROP(idx, memory_regions),			       \
-		(__attribute__((__section__(LINKER_DT_NODE_REGION_NAME(	       \
-			SPIM_MEM_REGION(idx)))))),			       \
-		())
 
 #ifdef CONFIG_HAS_HW_NRF_SPIM0
 SPI_NRFX_SPIM_DEFINE(0);

--- a/drivers/spi/spi_nrfx_spis.c
+++ b/drivers/spi/spi_nrfx_spis.c
@@ -8,6 +8,7 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/gpio.h>
 #include <soc.h>
+#include <dmm.h>
 #include <nrfx_spis.h>
 
 #include <zephyr/logging/log.h>
@@ -21,6 +22,9 @@ struct spi_nrfx_data {
 	const struct device *dev;
 	struct k_sem wake_sem;
 	struct gpio_callback wake_cb_data;
+	/* todo: remove once this is available in HAL or nrfx_spis_evt_t */
+	void *xfer_tx_buf;
+	void *xfer_rx_buf;
 };
 
 struct spi_nrfx_config {
@@ -30,6 +34,7 @@ struct spi_nrfx_config {
 	uint16_t max_buf_len;
 	const struct pinctrl_dev_config *pcfg;
 	struct gpio_dt_spec wake_gpio;
+	void *mem_reg;
 };
 
 static inline nrf_spis_mode_t get_nrf_spis_mode(uint16_t operation)
@@ -114,8 +119,10 @@ static int prepare_for_transfer(const struct device *dev,
 				const uint8_t *tx_buf, size_t tx_buf_len,
 				uint8_t *rx_buf, size_t rx_buf_len)
 {
+	struct spi_nrfx_data *dev_data = dev->data;
 	const struct spi_nrfx_config *dev_config = dev->config;
 	nrfx_err_t result;
+	int err;
 
 	if (tx_buf_len > dev_config->max_buf_len ||
 	    rx_buf_len > dev_config->max_buf_len) {
@@ -123,6 +130,22 @@ static int prepare_for_transfer(const struct device *dev,
 			tx_buf_len, rx_buf_len);
 		return -EINVAL;
 	}
+
+	err = dmm_buffer_out_prepare(dev_config->mem_reg, tx_buf, tx_buf_len, (void **)&tx_buf);
+	if (err != 0) {
+		LOG_INF("tx alloc err=%d", err);
+		return err;
+	}
+
+	err = dmm_buffer_in_prepare(dev_config->mem_reg, rx_buf, rx_buf_len, (void **)&rx_buf);
+	if (err != 0) {
+		LOG_INF("tx alloc err=%d", err);
+		return err;
+	}
+
+	/* todo: remove once this is available in HAL or nrfx_spis_evt_t */
+	dev_data->xfer_tx_buf = (void *)tx_buf;
+	dev_data->xfer_rx_buf = rx_buf;
 
 	result = nrfx_spis_buffers_set(&dev_config->spis,
 				       tx_buf, tx_buf_len,
@@ -193,6 +216,7 @@ static int transceive(const struct device *dev,
 			nrf_spis_enable(dev_config->spis.p_reg);
 		}
 
+		spi_context_buffers_setup(&dev_data->ctx, tx_bufs, rx_bufs, 1);
 		error = prepare_for_transfer(dev,
 					     tx_buf ? tx_buf->buf : NULL,
 					     tx_buf ? tx_buf->len : 0,
@@ -273,9 +297,15 @@ static const struct spi_driver_api spi_nrfx_driver_api = {
 
 static void event_handler(const nrfx_spis_evt_t *p_event, void *p_context)
 {
-	struct spi_nrfx_data *dev_data = p_context;
+	const struct device *dev = p_context;
+	struct spi_nrfx_data *dev_data = dev->data;
+	const struct spi_nrfx_config *dev_config = dev->config;
 
 	if (p_event->evt_type == NRFX_SPIS_XFER_DONE) {
+		/* todo: use p_event once buffers are available in HAL or nrfx_spis_evt_t */
+		dmm_buffer_out_release(dev_config->mem_reg, dev_data->xfer_tx_buf);
+		dmm_buffer_in_release(dev_config->mem_reg, dev_data->ctx.rx_buf,
+				      p_event->rx_amount, dev_data->xfer_rx_buf);
 		spi_context_complete(&dev_data->ctx, dev_data->dev,
 				     p_event->rx_amount);
 	}
@@ -297,7 +327,7 @@ static int spi_nrfx_init(const struct device *dev)
 	 * actually used are set in configure() when a transfer is prepared.
 	 */
 	result = nrfx_spis_init(&dev_config->spis, &dev_config->config,
-				event_handler, dev_data);
+				event_handler, (void *)dev);
 
 	if (result != NRFX_SUCCESS) {
 		LOG_ERR("Failed to initialize device: %s", dev->name);
@@ -386,6 +416,7 @@ static int spi_nrfx_init(const struct device *dev)
 		.pcfg = PINCTRL_DT_DEV_CONFIG_GET(SPIS(idx)),		       \
 		.max_buf_len = BIT_MASK(SPIS_PROP(idx, easydma_maxcnt_bits)),  \
 		.wake_gpio = GPIO_DT_SPEC_GET_OR(SPIS(idx), wake_gpios, {0}),  \
+		.mem_reg = DMM_DEV_TO_REG(SPIS(idx)),			       \
 	};								       \
 	BUILD_ASSERT(!DT_NODE_HAS_PROP(SPIS(idx), wake_gpios) ||	       \
 		     !(DT_GPIO_FLAGS(SPIS(idx), wake_gpios) & GPIO_ACTIVE_LOW),\

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_cpurad.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_cpurad.overlay
@@ -5,6 +5,10 @@
  */
 #include "nrf54h20dk_nrf54h20_common.dtsi"
 
+&cpurad_dma_region {
+	reg = <0x1680 DT_SIZE_K(2)>;
+};
+
 &spi130 {
 	memory-regions = <&cpurad_dma_region>;
 };

--- a/tests/drivers/spi/spi_controller_peripheral/src/main.c
+++ b/tests/drivers/spi/spi_controller_peripheral/src/main.c
@@ -39,14 +39,8 @@ static struct k_poll_signal async_sig_spim = K_POLL_SIGNAL_INITIALIZER(async_sig
 static struct k_poll_event async_evt_spim =
 	K_POLL_EVENT_INITIALIZER(K_POLL_TYPE_SIGNAL, K_POLL_MODE_NOTIFY_ONLY, &async_sig_spim);
 
-#define MEMORY_SECTION(node)                                                                       \
-	COND_CODE_1(DT_NODE_HAS_PROP(node, memory_regions),                                        \
-		    (__attribute__((__section__(                                                   \
-			    LINKER_DT_NODE_REGION_NAME(DT_PHANDLE(node, memory_regions)))))),      \
-		    ())
-
-static uint8_t spim_buffer[32] MEMORY_SECTION(DT_BUS(DT_NODELABEL(dut_spi_dt)));
-static uint8_t spis_buffer[32] MEMORY_SECTION(DT_NODELABEL(dut_spis));
+static uint8_t spim_buffer[32];
+static uint8_t spis_buffer[32];
 
 struct test_data {
 	struct k_work_delayable test_work;

--- a/tests/drivers/spi/spi_controller_peripheral/testcase.yaml
+++ b/tests/drivers/spi/spi_controller_peripheral/testcase.yaml
@@ -57,3 +57,10 @@ tests:
       - nrf52840dk/nrf52840
       - nrf54l15pdk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
+
+  drivers.spi.direct_xfer:
+    extra_configs:
+      - CONFIG_SPI_NRFX_RAM_BUFFER_SIZE=0
+    platform_exclude:
+      - nrf52840dk/nrf52840
+      - nrf54l15pdk/nrf54l15/cpuapp


### PR DESCRIPTION
`dmm` is a Nordic cache helper used to streamline the process of allocating DMA buffer in correct memory region and managing the data cache on nRF54H20: https://github.com/zephyrproject-rtos/zephyr/pull/71278

SPI driver should use it to support a case when `CONFIG_SPI_NRFX_RAM_BUFFER_SIZE` is set to `0` on nRF54H20.