### PR TITLE
Allow running more tests on nrf54h20dk/nrf54h20/cpuppr

### DIFF
--- a/soc/nordic/nrf54h/Kconfig.defconfig.nrf54h20_cpuflpr
+++ b/soc/nordic/nrf54h/Kconfig.defconfig.nrf54h20_cpuflpr
@@ -6,4 +6,8 @@ if SOC_NRF54H20_CPUFLPR
 config NUM_IRQS
 	default 496
 
+# As FLPR has limited memory most of tests does not fit with asserts enabled.
+config ASSERT
+	default n
+
 endif # SOC_NRF54H20_CPUFLPR

--- a/soc/nordic/nrf54h/Kconfig.defconfig.nrf54h20_cpuppr
+++ b/soc/nordic/nrf54h/Kconfig.defconfig.nrf54h20_cpuppr
@@ -8,5 +8,9 @@ config NUM_IRQS
 
 config SYS_CLOCK_TICKS_PER_SEC
 	default 1000
+#
+# As PPR has limited memory most of tests does not fit with asserts enabled.
+config ASSERT
+	default n
 
 endif # SOC_NRF54H20_CPUPPR

--- a/soc/nordic/nrf54l/Kconfig.defconfig.nrf54l15_cpuflpr
+++ b/soc/nordic/nrf54l/Kconfig.defconfig.nrf54l15_cpuflpr
@@ -8,4 +8,8 @@ if SOC_NRF54L15_CPUFLPR
 config NUM_IRQS
 	default 287
 
+# As FLPR has limited memory most of tests does not fit with asserts enabled.
+config ASSERT
+	default n
+
 endif # SOC_NRF54L15_CPUFLPR

--- a/soc/nordic/nrf54l/Kconfig.defconfig.nrf54l15_enga_cpuflpr
+++ b/soc/nordic/nrf54l/Kconfig.defconfig.nrf54l15_enga_cpuflpr
@@ -11,5 +11,8 @@ config RISCV_HAS_CPU_IDLE
 config NUM_IRQS
 	int
 	default 287
+# As FLPR has limited memory most of tests does not fit with asserts enabled.
+config ASSERT
+	default n
 
 endif # SOC_NRF54L15_ENGA_CPUFLPR

--- a/soc/nordic/nrf92/Kconfig.defconfig.nrf9280_cpuppr
+++ b/soc/nordic/nrf92/Kconfig.defconfig.nrf9280_cpuppr
@@ -12,4 +12,8 @@ config SYS_CLOCK_TICKS_PER_SEC
 config RV_BOOT_HART
 	default 13 if SOC_NRF9230_ENGB
 
+# As FLPR has limited memory most of tests does not fit with asserts enabled.
+config ASSERT
+	default n
+
 endif # SOC_NRF9280_CPUPPR

--- a/tests/kernel/interrupt/src/nested_irq.c
+++ b/tests/kernel/interrupt/src/nested_irq.c
@@ -62,6 +62,12 @@
 
 #define IRQ0_PRIO	1
 #define IRQ1_PRIO	2
+#elif defined(CONFIG_SOC_NRF54H20_CPUPPR)
+#define IRQ0_LINE	14
+#define IRQ1_LINE	15
+
+#define IRQ0_PRIO	1
+#define IRQ1_PRIO	2
 #else
 /*
  * For all the other platforms, use the last two available IRQ lines for


### PR DESCRIPTION
`cpuppr` is a coprocessor which requires `cpuapp` to start it. When sysbuild is used then `vpr_launcher` application can be used for `cpuapp` to run `cpuppr`. Adding `Kconfig.sysbuild` to main test folder and enabling `vpr_launcher` for `nrf54h20dk/nrf54h20/cpuppr` there.

Additionally, overwriting default for `CONFIG_ASSERT` to `n` for that board when `ZTEST` is enabled as with asserts enabled most tests does not fit.

Combining that with #73790 allows to run most of sw tests on that target.