### PR TITLE
soc: nordic: configure recover run once for nrf54h20

### DIFF
--- a/soc/nordic/soc.yml
+++ b/soc/nordic/soc.yml
@@ -48,6 +48,7 @@ runners:
     '--recover':
       - runners:
           - nrfjprog
+          - nrfutil
         run: first
         groups:
           - qualifiers:
@@ -64,6 +65,10 @@ runners:
           - qualifiers:
               - nrf54l15/cpuapp
               - nrf54l15/cpuflpr
+          - qualifiers:
+              - nrf54h20/cpuapp
+              - nrf54h20/cpurad
+              - nrf54h20/cpuppr
     '--erase':
       - runners:
           - nrfjprog


### PR DESCRIPTION
The nrfutil device v2.4.x now supports the recover operation. Configure run once to ensure that domains are not unnecessarily erased.