### PR TITLE
docs: posix: fix for unimplemented functions

### DIFF
--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -872,16 +872,16 @@ _POSIX_THREAD_SAFE_FUNCTIONS
     flockfile(),
     ftrylockfile(),
     funlockfile(),
-    getc_unlocked(), yes
-    getchar_unlocked(), yes
+    getc_unlocked(),
+    getchar_unlocked(),
     getgrgid_r(),
     getgrnam_r(),
     getpwnam_r(),
     getpwuid_r(),
     gmtime_r(), yes
     localtime_r(),
-    putc_unlocked(), yes
-    putchar_unlocked(), yes
+    putc_unlocked(),
+    putchar_unlocked(),
     rand_r(), yes
     readdir_r(),
     strerror_r(), yes


### PR DESCRIPTION
The following functions are not implemented:
- getc_unlocked()
- getchar_unlocked()
- putc_unlocked()
- putchar_unlocked()

https://github.com/zephyrproject-rtos/zephyr/blob/9ae5352372dd9965805980e0c712612f21ed2229/doc/services/portability/posix/option_groups/index.rst?plain=1#L545-L560
