### PR TITLE
boards: nordic: nrf54h20dk: add miscellaneous shared mem for cpusec

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-memory_map.dtsi
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-memory_map.dtsi
@@ -26,8 +26,18 @@
 				reg = <0x800 DT_SIZE_K(2)>;
 			};
 
-			cpuapp_data: memory@1000 {
-				reg = <0x1000 DT_SIZE_K(256)>;
+			/* todo: remove once cpuapp_ram0x_region can be used by cache helpers */
+			cpuapp_cpusec_misc_shm: memory@1000 {
+				compatible = "zephyr,memory-region";
+				reg = <0x1000 DT_SIZE_K(16)>;
+				status = "disabled";
+				#memory-region-cells = <0>;
+				zephyr,memory-region = "CPUAPP_CPUSEC_MISC_SHM";
+				zephyr,memory-attr = <( DT_MEM_CACHEABLE )>;
+			};
+
+			cpuapp_data: memory@5000 {
+				reg = <0x5000 DT_SIZE_K(240)>;
 			};
 		};
 
@@ -48,6 +58,16 @@
 
 			cpurad_cpusec_ipc_shm: memory@800 {
 				reg = <0x800 DT_SIZE_K(2)>;
+			};
+
+			/* todo: remove once cpurad_ram0x_region can be used by cache helpers */
+			cpurad_cpusec_misc_shm: memory@1000 {
+				compatible = "zephyr,memory-region";
+				reg = <0x1000 DT_SIZE_K(16)>;
+				status = "disabled";
+				#memory-region-cells = <0>;
+				zephyr,memory-region = "CPURAD_CPUSEC_MISC_SHM";
+				zephyr,memory-attr = <( DT_MEM_CACHEABLE )>;
 			};
 		};
 

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -114,6 +114,10 @@
 	status = "okay";
 };
 
+&cpuapp_cpusec_misc_shm {
+	status = "okay";
+};
+
 &cpuapp_cpurad_ram0x_region {
 	status = "okay";
 };

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_cpurad.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_cpurad.overlay
@@ -17,3 +17,11 @@
 &dut_spis {
 	memory-regions = <&cpurad_dma_region>;
 };
+
+&cpuapp_dma_region {
+	reg = <0xe80 0x80>;
+};
+
+&cpurad_dma_region {
+	reg = <0xf00 DT_SIZE_K(4)>;
+};


### PR DESCRIPTION
This is auxiliary shared memory needed for some of IPC communication.