### PR TITLE
scripts: pytest: execute 'zephyr.exe' in application build directory cwd

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/binary_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/binary_adapter.py
@@ -28,6 +28,7 @@ class BinaryAdapterBase(DeviceAdapter, abc.ABC):
             'stderr': subprocess.STDOUT,
             'stdin': subprocess.PIPE,
             'env': self.env,
+            'cwd': device_config.app_build_dir,
         }
 
     @abc.abstractmethod


### PR DESCRIPTION
Execute `zephyr.exe` in application build directory as 'current working
directory' (cwd). This makes sure that native_sim specific drivers (like
flash simulator with file backend in `flash.bin`) are using unique context
for external resources with relative paths.

This fixes executing native_sim tests in twister with flash simulator.
Previously a shared `flash.bin` was used for all executed `zephyr.exe`
processes in twister. After this patch a unique `flash.bin` file is used
for each tested sample, since those `flash.bin` is placed in application
build directory instead of twister root directory.