### PR TITLE
board: google_dragonclaw: add supported features

### DIFF
--- a/boards/google/dragonclaw/google_dragonclaw.yaml
+++ b/boards/google/dragonclaw/google_dragonclaw.yaml
@@ -9,3 +9,11 @@ toolchain:
 ram: 256
 flash: 1024
 vendor: google
+supported:
+  - counter
+  - dma
+  - gpio
+  - i2c
+  - spi
+  - pwm
+  - rtc


### PR DESCRIPTION
Add the list of supported features to the google_dragonclaw board definition.

It allows running more tests.