### PR TITLE
tests: drivers: counter: counter_basic_api: run on google_dragonclaw

### DIFF
--- a/tests/drivers/counter/counter_basic_api/boards/google_dragonclaw.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/google_dragonclaw.overlay
@@ -1,0 +1,83 @@
+&timers2 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers3 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers4 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers5 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers7 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers8 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers9 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers10 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers11 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers12 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers13 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers14 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/testcase.yaml
+++ b/tests/drivers/counter/counter_basic_api/testcase.yaml
@@ -25,7 +25,10 @@ tests:
       - drivers
       - counter
     depends_on: counter
-    platform_allow: nucleo_f429zi nucleo_wba52cg
+    platform_allow:
+      - nucleo_f429zi
+      - nucleo_wba52cg
+      - google_dragonclaw
     timeout: 600
     extra_configs:
       - CONFIG_COUNTER_RTC_STM32_SUBSECONDS=y


### PR DESCRIPTION
Add google_dragonclaw board definition and allow running the drivers.counter.basic_api.stm32_subsec test on the board.