### PR TITLE
toolchain: clang: arm: do not use fp instruction when CONFIG_FPU=n

### DIFF
--- a/cmake/compiler/clang/target_arm.cmake
+++ b/cmake/compiler/clang/target_arm.cmake
@@ -25,6 +25,10 @@ if(CONFIG_FPU)
   elseif(CONFIG_FP_SOFTABI)
     list(APPEND ARM_C_FLAGS   -mfloat-abi=softfp)
   endif()
+else()
+  list(APPEND ARM_C_FLAGS   -mfpu=none)
+  # Disable usage of FPU registers
+  list(APPEND ARM_C_FLAGS   -mfloat-abi=soft)
 endif()
 
 if(CONFIG_FP16)


### PR DESCRIPTION
Clang uses floating-point instructions by default, even if -mfpu is not defined. Disable using FPU when CONFIG_FPU=n.

Using floating-point instructions when FPU is not enabled generates Usage Fault.