### PR TITLE
modules: hal_nordic: nrfx: Add nrfx_config_ext.h

### DIFF
--- a/modules/hal_nordic/nrfx/nrfx_config.h
+++ b/modules/hal_nordic/nrfx/nrfx_config.h
@@ -1065,7 +1065,7 @@
 #elif defined(NRF9230_ENGB_XXAA) && defined(NRF_PPR)
     #include <nrfx_config_nrf9230_engb_ppr.h>
 #else
-    #error "Unknown device."
+    #include <nrfx_config_ext.h>
 #endif
 
 #endif // NRFX_CONFIG_H__

--- a/modules/hal_nordic/nrfx/nrfx_config_ext.h
+++ b/modules/hal_nordic/nrfx/nrfx_config_ext.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2023 - 2024, Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef NRFX_CONFIG_EXT_H__
+#define NRFX_CONFIG_EXT_H__
+
+#error "Unknown device."
+
+#endif /* NRFX_CONFIG_EXT_H__ */


### PR DESCRIPTION
Taking a cue from `nrfx/templates`, introduce this file so that it can be overridden out-of-tree to add external nRF product definitions.