### PR TITLE
samples: sensor: sensor_shell: Extend timeout for pytest tests

### DIFF
--- a/samples/sensor/sensor_shell/sample.yaml
+++ b/samples/sensor/sensor_shell/sample.yaml
@@ -19,6 +19,7 @@ tests:
     filter: CONFIG_SERIAL and dt_chosen_enabled("zephyr,shell-uart")
     min_ram: 40
     harness: pytest
+    timeout: 180
     extra_configs:
       - arch:posix:CONFIG_NATIVE_UART_0_ON_STDINOUT=y
       - CONFIG_SAMPLES_SENSOR_SHELL_FAKE_SENSOR=y


### PR DESCRIPTION
The test `sample.sensor.shell.pytest` fails althought the output is correct. Time to execution is not enough.
This change extend test execution timeout.