### PR TITLE
west.yaml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -287,7 +287,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 018dc01d484358d81f889c36471d9ce5590965b6
+      revision: 898a1ca64a759541d9fcc37fef921db93d99ad70
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
898a1ca64a759541d9fcc37fef921db93d99ad70

Brings following Zephyr relevant feature:

898a1ca6 boot: zephyr: add ESP32-C6 support

Notes on process:

The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
After the main branch gets updated, this PR does not require further changes and should be merged as is.