### PR TITLE
modem: pipe: Add explicit timeout to sync APIs

### DIFF
--- a/drivers/gnss/gnss_luatos_air530z.c
+++ b/drivers/gnss/gnss_luatos_air530z.c
@@ -188,21 +188,21 @@ static int gnss_luatos_air530z_init(const struct device *dev)
 
 	luatos_air530z_init_dynamic_script(dev);
 
-	ret = modem_pipe_open(data->uart_pipe);
+	ret = modem_pipe_open(data->uart_pipe, K_SECONDS(10));
 	if (ret < 0) {
 		return ret;
 	}
 
 	ret = modem_chat_attach(&data->chat, data->uart_pipe);
 	if (ret < 0) {
-		modem_pipe_close(data->uart_pipe);
+		modem_pipe_close(data->uart_pipe, K_SECONDS(10));
 		return ret;
 	}
 
 	ret = modem_chat_run_script(&data->chat, &init_script);
 	if (ret < 0) {
 		LOG_ERR("Failed to run init_script");
-		modem_pipe_close(data->uart_pipe);
+		modem_pipe_close(data->uart_pipe, K_SECONDS(10));
 		return ret;
 	}
 
@@ -222,20 +222,20 @@ static int luatos_air530z_pm_resume(const struct device *dev)
 	struct gnss_luatos_air530z_data *data = dev->data;
 	int ret;
 
-	ret = modem_pipe_open(data->uart_pipe);
+	ret = modem_pipe_open(data->uart_pipe, K_SECONDS(10));
 	if (ret < 0) {
 		return ret;
 	}
 
 	ret = modem_chat_attach(&data->chat, data->uart_pipe);
 	if (ret < 0) {
-		modem_pipe_close(data->uart_pipe);
+		modem_pipe_close(data->uart_pipe, K_SECONDS(10));
 		return ret;
 	}
 
 	ret = modem_chat_run_script(&data->chat, &init_script);
 	if (ret < 0) {
-		modem_pipe_close(data->uart_pipe);
+		modem_pipe_close(data->uart_pipe, K_SECONDS(10));
 		return ret;
 	}
 
@@ -251,7 +251,7 @@ static int luatos_air530z_pm_action(const struct device *dev, enum pm_device_act
 	switch (action) {
 	case PM_DEVICE_ACTION_SUSPEND:
 		gpio_pin_set_dt(&config->on_off_gpio, 0);
-		ret = modem_pipe_close(data->uart_pipe);
+		ret = modem_pipe_close(data->uart_pipe, K_SECONDS(10));
 		break;
 
 	case PM_DEVICE_ACTION_RESUME:

--- a/drivers/gnss/gnss_nmea_generic.c
+++ b/drivers/gnss/gnss_nmea_generic.c
@@ -64,7 +64,7 @@ static int gnss_nmea_generic_resume(const struct device *dev)
 	struct gnss_nmea_generic_data *data = dev->data;
 	int ret;
 
-	ret = modem_pipe_open(data->uart_pipe);
+	ret = modem_pipe_open(data->uart_pipe, K_SECONDS(10));
 	if (ret < 0) {
 		return ret;
 	}
@@ -76,7 +76,7 @@ static int gnss_nmea_generic_resume(const struct device *dev)
 	}
 
 	if (ret < 0) {
-		modem_pipe_close(data->uart_pipe);
+		modem_pipe_close(data->uart_pipe, K_SECONDS(10));
 	}
 	return ret;
 }

--- a/drivers/gnss/gnss_quectel_lcx6g.c
+++ b/drivers/gnss/gnss_quectel_lcx6g.c
@@ -205,7 +205,7 @@ static int quectel_lcx6g_resume(const struct device *dev)
 
 	quectel_lcx6g_await_pm_ready(dev);
 
-	ret = modem_pipe_open(data->uart_pipe);
+	ret = modem_pipe_open(data->uart_pipe, K_SECONDS(10));
 	if (ret < 0) {
 		LOG_ERR("Failed to open pipe");
 		return ret;
@@ -214,21 +214,21 @@ static int quectel_lcx6g_resume(const struct device *dev)
 	ret = modem_chat_attach(&data->chat, data->uart_pipe);
 	if (ret < 0) {
 		LOG_ERR("Failed to attach chat");
-		modem_pipe_close(data->uart_pipe);
+		modem_pipe_close(data->uart_pipe, K_SECONDS(10));
 		return ret;
 	}
 
 	ret = modem_chat_run_script(&data->chat, &resume_script);
 	if (ret < 0) {
 		LOG_ERR("Failed to initialize GNSS");
-		modem_pipe_close(data->uart_pipe);
+		modem_pipe_close(data->uart_pipe, K_SECONDS(10));
 		return ret;
 	}
 
 	ret = quectel_lcx6g_configure_pps(dev);
 	if (ret < 0) {
 		LOG_ERR("Failed to configure PPS");
-		modem_pipe_close(data->uart_pipe);
+		modem_pipe_close(data->uart_pipe, K_SECONDS(10));
 		return ret;
 	}
 
@@ -253,7 +253,7 @@ static int quectel_lcx6g_suspend(const struct device *dev)
 		LOG_INF("Suspended");
 	}
 
-	modem_pipe_close(data->uart_pipe);
+	modem_pipe_close(data->uart_pipe, K_SECONDS(10));
 	return ret;
 }
 
@@ -268,7 +268,7 @@ static int quectel_lcx6g_turn_off(const struct device *dev)
 
 	LOG_INF("Powered off");
 
-	return modem_pipe_close(data->uart_pipe);
+	return modem_pipe_close(data->uart_pipe, K_SECONDS(10));
 }
 
 static int quectel_lcx6g_pm_action(const struct device *dev, enum pm_device_action action)

--- a/drivers/gnss/gnss_u_blox_m10.c
+++ b/drivers/gnss/gnss_u_blox_m10.c
@@ -93,14 +93,14 @@ static int ubx_m10_resume(const struct device *dev)
 	struct ubx_m10_data *data = dev->data;
 	int ret;
 
-	ret = modem_pipe_open(data->uart_pipe);
+	ret = modem_pipe_open(data->uart_pipe, K_SECONDS(10));
 	if (ret < 0) {
 		return ret;
 	}
 
 	ret = modem_chat_attach(&data->chat, data->uart_pipe);
 	if (ret < 0) {
-		(void)modem_pipe_close(data->uart_pipe);
+		(void)modem_pipe_close(data->uart_pipe, K_SECONDS(10));
 		return ret;
 	}
 
@@ -111,7 +111,7 @@ static int ubx_m10_turn_off(const struct device *dev)
 {
 	struct ubx_m10_data *data = dev->data;
 
-	return modem_pipe_close(data->uart_pipe);
+	return modem_pipe_close(data->uart_pipe, K_SECONDS(10));
 }
 
 static int ubx_m10_init_nmea0183_match(const struct device *dev)
@@ -204,7 +204,7 @@ static int ubx_m10_modem_module_change(const struct device *dev, bool change_fro
 	}
 
 	if (ret < 0) {
-		(void)modem_pipe_close(data->uart_pipe);
+		(void)modem_pipe_close(data->uart_pipe, K_SECONDS(10));
 	}
 
 	return ret;

--- a/include/zephyr/modem/pipe.h
+++ b/include/zephyr/modem/pipe.h
@@ -87,6 +87,7 @@ void modem_pipe_init(struct modem_pipe *pipe, void *data, struct modem_pipe_api 
  * @brief Open pipe
  *
  * @param pipe Pipe instance
+ * @param timeout Timeout waiting for pipe to open
  *
  * @retval 0 if pipe was successfully opened or was already open
  * @retval -errno code otherwise
@@ -95,7 +96,7 @@ void modem_pipe_init(struct modem_pipe *pipe, void *data, struct modem_pipe_api 
  * It may block the calling thread, which in the case of the system workqueue
  * can result in a deadlock until this call times out waiting for the pipe to be open.
  */
-int modem_pipe_open(struct modem_pipe *pipe);
+int modem_pipe_open(struct modem_pipe *pipe, k_timeout_t timeout);
 
 /**
  * @brief Open pipe asynchronously
@@ -163,6 +164,7 @@ void modem_pipe_release(struct modem_pipe *pipe);
  * @brief Close pipe
  *
  * @param pipe Pipe instance
+ * @param timeout Timeout waiting for pipe to close
  *
  * @retval 0 if pipe open was called closed or pipe was already closed
  * @retval -errno code otherwise
@@ -171,7 +173,7 @@ void modem_pipe_release(struct modem_pipe *pipe);
  * It may block the calling thread, which in the case of the system workqueue
  * can result in a deadlock until this call times out waiting for the pipe to be closed.
  */
-int modem_pipe_close(struct modem_pipe *pipe);
+int modem_pipe_close(struct modem_pipe *pipe, k_timeout_t timeout);
 
 /**
  * @brief Close pipe asynchronously

--- a/subsys/modem/modem_pipe.c
+++ b/subsys/modem/modem_pipe.c
@@ -35,9 +35,11 @@ static uint32_t pipe_test_events(struct modem_pipe *pipe, uint32_t events)
 	return k_event_test(&pipe->event, events);
 }
 
-static uint32_t pipe_await_events(struct modem_pipe *pipe, uint32_t events)
+static uint32_t pipe_await_events(struct modem_pipe *pipe,
+				  uint32_t events,
+				  k_timeout_t timeout)
 {
-	return k_event_wait(&pipe->event, events, false, K_MSEC(10000));
+	return k_event_wait(&pipe->event, events, false, timeout);
 }
 
 static void pipe_post_events(struct modem_pipe *pipe, uint32_t events)
@@ -88,7 +90,7 @@ void modem_pipe_init(struct modem_pipe *pipe, void *data, struct modem_pipe_api 
 	k_event_init(&pipe->event);
 }
 
-int modem_pipe_open(struct modem_pipe *pipe)
+int modem_pipe_open(struct modem_pipe *pipe, k_timeout_t timeout)
 {
 	int ret;
 
@@ -101,7 +103,7 @@ int modem_pipe_open(struct modem_pipe *pipe)
 		return ret;
 	}
 
-	if (!pipe_await_events(pipe, PIPE_EVENT_OPENED_BIT)) {
+	if (!pipe_await_events(pipe, PIPE_EVENT_OPENED_BIT, timeout)) {
 		return -EAGAIN;
 	}
 
@@ -156,7 +158,7 @@ void modem_pipe_release(struct modem_pipe *pipe)
 	pipe_set_callback(pipe, NULL, NULL);
 }
 
-int modem_pipe_close(struct modem_pipe *pipe)
+int modem_pipe_close(struct modem_pipe *pipe, k_timeout_t timeout)
 {
 	int ret;
 
@@ -169,7 +171,7 @@ int modem_pipe_close(struct modem_pipe *pipe)
 		return ret;
 	}
 
-	if (!pipe_await_events(pipe, PIPE_EVENT_CLOSED_BIT)) {
+	if (!pipe_await_events(pipe, PIPE_EVENT_CLOSED_BIT, timeout)) {
 		return -EAGAIN;
 	}
 

--- a/tests/subsys/modem/backends/tty/src/main.c
+++ b/tests/subsys/modem/backends/tty/src/main.c
@@ -108,7 +108,7 @@ static void *test_modem_backend_tty_setup(void)
 
 	tty_pipe = modem_backend_tty_init(&tty_backend, &config);
 	modem_pipe_attach(tty_pipe, modem_pipe_callback_handler, NULL);
-	__ASSERT_NO_MSG(modem_pipe_open(tty_pipe) == 0);
+	__ASSERT_NO_MSG(modem_pipe_open(tty_pipe, K_SECONDS(10)) == 0);
 	return NULL;
 }
 
@@ -119,7 +119,7 @@ static void test_modem_backend_tty_before(void *f)
 
 static void test_modem_backend_tty_teardown(void *f)
 {
-	modem_pipe_close(tty_pipe);
+	modem_pipe_close(tty_pipe, K_SECONDS(10));
 }
 
 /*************************************************************************************************/
@@ -129,12 +129,12 @@ ZTEST(modem_backend_tty_suite, test_close_open)
 {
 	bool result;
 
-	zassert_ok(modem_pipe_close(tty_pipe), "Failed to close pipe");
-	zassert_ok(modem_pipe_close(tty_pipe), "Pipe should already be closed");
-	zassert_ok(modem_pipe_open(tty_pipe), "Failed to open pipe");
+	zassert_ok(modem_pipe_close(tty_pipe, K_SECONDS(10)), "Failed to close pipe");
+	zassert_ok(modem_pipe_close(tty_pipe, K_SECONDS(10)), "Pipe should already be closed");
+	zassert_ok(modem_pipe_open(tty_pipe, K_SECONDS(10)), "Failed to open pipe");
 	result = atomic_test_bit(&tty_pipe_events, TEST_MODEM_BACKEND_TTY_PIPE_EVENT_TIDLE_BIT);
 	zassert_true(result, "Transmit idle event should be set");
-	zassert_ok(modem_pipe_open(tty_pipe), "Pipe should already be open");
+	zassert_ok(modem_pipe_open(tty_pipe, K_SECONDS(10)), "Pipe should already be open");
 }
 
 ZTEST(modem_backend_tty_suite, test_receive_ready_event_not_raised)

--- a/tests/subsys/modem/backends/uart/src/main.c
+++ b/tests/subsys/modem/backends/uart/src/main.c
@@ -172,12 +172,12 @@ static void test_modem_backend_uart_before(void *f)
 	prng_reset();
 	ring_buf_reset(&transmit_ring_buf);
 	k_sem_reset(&receive_ready_sem);
-	__ASSERT_NO_MSG(modem_pipe_open(pipe) == 0);
+	__ASSERT_NO_MSG(modem_pipe_open(pipe, K_SECONDS(10)) == 0);
 }
 
 static void test_modem_backend_uart_after(void *f)
 {
-	__ASSERT_NO_MSG(modem_pipe_close(pipe) == 0);
+	__ASSERT_NO_MSG(modem_pipe_close(pipe, K_SECONDS(10)) == 0);
 }
 
 /*************************************************************************************************/

--- a/tests/subsys/modem/modem_chat/src/main.c
+++ b/tests/subsys/modem/modem_chat/src/main.c
@@ -280,7 +280,7 @@ static void *test_modem_chat_setup(void)
 	};
 
 	mock_pipe = modem_backend_mock_init(&mock, &mock_config);
-	zassert(modem_pipe_open(mock_pipe) == 0, "Failed to open mock pipe");
+	zassert(modem_pipe_open(mock_pipe, K_SECONDS(10)) == 0, "Failed to open mock pipe");
 	zassert(modem_chat_attach(&cmd, mock_pipe) == 0, "Failed to attach pipe mock to modem CMD");
 	return NULL;
 }

--- a/tests/subsys/modem/modem_cmux/src/main.c
+++ b/tests/subsys/modem/modem_cmux/src/main.c
@@ -283,7 +283,7 @@ static void *test_modem_cmux_setup(void)
 	};
 
 	bus_mock_pipe = modem_backend_mock_init(&bus_mock, &bus_mock_config);
-	__ASSERT_NO_MSG(modem_pipe_open(bus_mock_pipe) == 0);
+	__ASSERT_NO_MSG(modem_pipe_open(bus_mock_pipe, K_SECONDS(10)) == 0);
 
 	/* Connect CMUX */
 	__ASSERT_NO_MSG(modem_cmux_attach(&cmux, bus_mock_pipe) == 0);
@@ -731,9 +731,9 @@ ZTEST(modem_cmux, test_modem_cmux_disconnect_connect)
 ZTEST(modem_cmux, test_modem_cmux_disconnect_connect_sync)
 {
 	modem_backend_mock_prime(&bus_mock, &transaction_dlci1_disc);
-	zassert_true(modem_pipe_close(dlci1_pipe) == 0, "Failed to close DLCI1");
+	zassert_true(modem_pipe_close(dlci1_pipe, K_SECONDS(10)) == 0, "Failed to close DLCI1");
 	modem_backend_mock_prime(&bus_mock, &transaction_dlci2_disc);
-	zassert_true(modem_pipe_close(dlci2_pipe) == 0, "Failed to close DLCI2");
+	zassert_true(modem_pipe_close(dlci2_pipe, K_SECONDS(10)) == 0, "Failed to close DLCI2");
 	modem_backend_mock_prime(&bus_mock, &transaction_control_cld);
 	zassert_true(modem_cmux_disconnect(&cmux) == 0, "Failed to disconnect CMUX");
 	zassert_true(modem_cmux_disconnect(&cmux) == -EALREADY,
@@ -745,21 +745,25 @@ ZTEST(modem_cmux, test_modem_cmux_disconnect_connect_sync)
 		     "Should already be connected");
 
 	modem_backend_mock_prime(&bus_mock, &transaction_dlci1_sabm);
-	zassert_true(modem_pipe_open(dlci1_pipe) == 0, "Failed to open DLCI1 pipe");
+	zassert_true(modem_pipe_open(dlci1_pipe, K_SECONDS(10)) == 0,
+		     "Failed to open DLCI1 pipe");
 	modem_backend_mock_prime(&bus_mock, &transaction_dlci2_sabm);
-	zassert_true(modem_pipe_open(dlci2_pipe) == 0, "Failed to open DLCI2 pipe");
+	zassert_true(modem_pipe_open(dlci2_pipe, K_SECONDS(10)) == 0,
+		     "Failed to open DLCI2 pipe");
 }
 
 ZTEST(modem_cmux, test_modem_cmux_dlci_close_open_sync)
 {
 	modem_backend_mock_prime(&bus_mock, &transaction_dlci1_disc);
-	zassert_true(modem_pipe_close(dlci1_pipe) == 0, "Failed to close DLCI1");
+	zassert_true(modem_pipe_close(dlci1_pipe, K_SECONDS(10)) == 0, "Failed to close DLCI1");
 	modem_backend_mock_prime(&bus_mock, &transaction_dlci2_disc);
-	zassert_true(modem_pipe_close(dlci2_pipe) == 0, "Failed to close DLCI2");
+	zassert_true(modem_pipe_close(dlci2_pipe, K_SECONDS(10)) == 0, "Failed to close DLCI2");
 	modem_backend_mock_prime(&bus_mock, &transaction_dlci1_sabm);
-	zassert_true(modem_pipe_open(dlci1_pipe) == 0, "Failed to open DLCI1 pipe");
+	zassert_true(modem_pipe_open(dlci1_pipe, K_SECONDS(10)) == 0,
+		     "Failed to open DLCI1 pipe");
 	modem_backend_mock_prime(&bus_mock, &transaction_dlci2_sabm);
-	zassert_true(modem_pipe_open(dlci2_pipe) == 0, "Failed to open DLCI2 pipe");
+	zassert_true(modem_pipe_open(dlci2_pipe, K_SECONDS(10)) == 0,
+		     "Failed to open DLCI2 pipe");
 }
 
 ZTEST_SUITE(modem_cmux, NULL, test_modem_cmux_setup, test_modem_cmux_before, NULL, NULL);

--- a/tests/subsys/modem/modem_cmux_pair/src/main.c
+++ b/tests/subsys/modem/modem_cmux_pair/src/main.c
@@ -236,7 +236,7 @@ static void cmux_dte_init(void)
 	dlci2_pipe = modem_cmux_dlci_init(&cmux_dte, &dlci2, &dlci2_config);
 	/* Init Backend DTE */
 	bus_mock_pipe = modem_backend_mock_init(&bus_mock_dte, &bus_mock_config);
-	__ASSERT_NO_MSG(modem_pipe_open(bus_mock_pipe) == 0);
+	__ASSERT_NO_MSG(modem_pipe_open(bus_mock_pipe, K_SECONDS(10)) == 0);
 	__ASSERT_NO_MSG(modem_cmux_attach(&cmux_dte, bus_mock_pipe) == 0);
 	modem_pipe_attach(dlci1_pipe, test_dlci1_pipe_cb, NULL);
 	modem_pipe_attach(dlci2_pipe, test_dlci2_pipe_cb, NULL);
@@ -278,7 +278,7 @@ static void cmux_dce_init(void)
 	dlci2_pipe_dce = modem_cmux_dlci_init(&cmux_dce, &dlci2_dce, &dlci2_config);
 	/* Init Backend DCE */
 	bus_mock_pipe_dce = modem_backend_mock_init(&bus_mock_dce, &bus_mock_config);
-	__ASSERT_NO_MSG(modem_pipe_open(bus_mock_pipe_dce) == 0);
+	__ASSERT_NO_MSG(modem_pipe_open(bus_mock_pipe_dce, K_SECONDS(10)) == 0);
 	__ASSERT_NO_MSG(modem_cmux_attach(&cmux_dce, bus_mock_pipe_dce) == 0);
 	modem_pipe_attach(dlci1_pipe_dce, test_dlci1_pipe_cb_dce, NULL);
 	modem_pipe_attach(dlci2_pipe_dce, test_dlci2_pipe_cb_dce, NULL);
@@ -543,8 +543,8 @@ ZTEST(modem_cmux_pair, test_modem_cmux_disconnect_connect_sync)
 {
 	uint32_t events;
 
-	zassert_true(modem_pipe_close(dlci1_pipe) == 0, "Failed to close DLCI1");
-	zassert_true(modem_pipe_close(dlci2_pipe) == 0, "Failed to close DLCI2");
+	zassert_true(modem_pipe_close(dlci1_pipe, K_SECONDS(10)) == 0, "Failed to close DLCI1");
+	zassert_true(modem_pipe_close(dlci2_pipe, K_SECONDS(10)) == 0, "Failed to close DLCI2");
 	events = k_event_wait_all(&cmux_event_dce,
 				  (EVENT_CMUX_DLCI1_CLOSED | EVENT_CMUX_DLCI2_CLOSED), false,
 				  K_MSEC(100));
@@ -563,8 +563,8 @@ ZTEST(modem_cmux_pair, test_modem_cmux_disconnect_connect_sync)
 	zassert_true(modem_cmux_connect(&cmux_dte) == -EALREADY, "Should already be connected");
 	zassert_true(modem_cmux_connect(&cmux_dce) == -EALREADY, "Should already be connected");
 
-	zassert_true(modem_pipe_open(dlci1_pipe) == 0, "Failed to open DLCI1 pipe");
-	zassert_true(modem_pipe_open(dlci2_pipe) == 0, "Failed to open DLCI2 pipe");
+	zassert_true(modem_pipe_open(dlci1_pipe, K_SECONDS(10)) == 0, "Failed to open DLCI1 pipe");
+	zassert_true(modem_pipe_open(dlci2_pipe, K_SECONDS(10)) == 0, "Failed to open DLCI2 pipe");
 	events = k_event_wait_all(&cmux_event_dce, (EVENT_CMUX_DLCI1_OPEN | EVENT_CMUX_DLCI2_OPEN),
 				  false, K_MSEC(100));
 	zassert_true((events & EVENT_CMUX_DLCI1_OPEN), "DCE DLCI1 not open as expected");
@@ -575,8 +575,8 @@ ZTEST(modem_cmux_pair, test_modem_cmux_dlci_close_open_sync)
 {
 	uint32_t events;
 
-	zassert_true(modem_pipe_close(dlci1_pipe) == 0, "Failed to close DLCI1");
-	zassert_true(modem_pipe_close(dlci2_pipe) == 0, "Failed to close DLCI2");
+	zassert_true(modem_pipe_close(dlci1_pipe, K_SECONDS(10)) == 0, "Failed to close DLCI1");
+	zassert_true(modem_pipe_close(dlci2_pipe, K_SECONDS(10)) == 0, "Failed to close DLCI2");
 
 	events = k_event_wait_all(&cmux_event_dce,
 				  (EVENT_CMUX_DLCI1_CLOSED | EVENT_CMUX_DLCI2_CLOSED), false,
@@ -584,8 +584,8 @@ ZTEST(modem_cmux_pair, test_modem_cmux_dlci_close_open_sync)
 	zassert_true((events & EVENT_CMUX_DLCI1_CLOSED), "DCE DLCI1 not closed as expected");
 	zassert_true((events & EVENT_CMUX_DLCI2_CLOSED), "DCE DLCI2 not closed as expected");
 
-	zassert_true(modem_pipe_open(dlci1_pipe) == 0, "Failed to open DLCI1 pipe");
-	zassert_true(modem_pipe_open(dlci2_pipe) == 0, "Failed to open DLCI2 pipe");
+	zassert_true(modem_pipe_open(dlci1_pipe, K_SECONDS(10)) == 0, "Failed to open DLCI1 pipe");
+	zassert_true(modem_pipe_open(dlci2_pipe, K_SECONDS(10)) == 0, "Failed to open DLCI2 pipe");
 	/* Verify DCE side channels are open also */
 	events = k_event_wait_all(&cmux_event_dce, (EVENT_CMUX_DLCI1_OPEN | EVENT_CMUX_DLCI2_OPEN),
 				  false, K_MSEC(100));

--- a/tests/subsys/modem/modem_pipe/src/main.c
+++ b/tests/subsys/modem/modem_pipe/src/main.c
@@ -223,14 +223,14 @@ static void modem_backend_fake_before(void *f)
 
 static void modem_backend_fake_after(void *f)
 {
-	__ASSERT(modem_pipe_close(test_pipe) == 0, "Failed to close pipe");
+	__ASSERT(modem_pipe_close(test_pipe, K_SECONDS(10)) == 0, "Failed to close pipe");
 	modem_pipe_release(test_pipe);
 }
 
 /* Opening pipe shall raise events OPENED and TRANSMIT_IDLE */
 static void test_pipe_open(void)
 {
-	zassert_ok(modem_pipe_open(test_pipe), "Failed to open pipe");
+	zassert_ok(modem_pipe_open(test_pipe, K_SECONDS(10)), "Failed to open pipe");
 	zassert_true(test_backend.open_called, "open was not called");
 	zassert_equal(atomic_get(&test_state),
 		      BIT(TEST_MODEM_PIPE_EVENT_OPENED_BIT) |
@@ -241,7 +241,7 @@ static void test_pipe_open(void)
 /* Re-opening pipe shall have no effect */
 static void test_pipe_reopen(void)
 {
-	zassert_ok(modem_pipe_open(test_pipe), "Failed to re-open pipe");
+	zassert_ok(modem_pipe_open(test_pipe, K_SECONDS(10)), "Failed to re-open pipe");
 	zassert_false(test_backend.open_called, "open was called");
 	zassert_equal(atomic_get(&test_state), 0,
 		      "Unexpected state %u", atomic_get(&test_state));
@@ -250,7 +250,7 @@ static void test_pipe_reopen(void)
 /* Closing pipe shall raise event CLOSED */
 static void test_pipe_close(void)
 {
-	zassert_ok(modem_pipe_close(test_pipe), "Failed to close pipe");
+	zassert_ok(modem_pipe_close(test_pipe, K_SECONDS(10)), "Failed to close pipe");
 	zassert_true(test_backend.close_called, "close was not called");
 	zassert_equal(atomic_get(&test_state), BIT(TEST_MODEM_PIPE_EVENT_CLOSED_BIT),
 		      "Unexpected state %u", atomic_get(&test_state));
@@ -259,7 +259,7 @@ static void test_pipe_close(void)
 /* Re-closing pipe shall have no effect */
 static void test_pipe_reclose(void)
 {
-	zassert_ok(modem_pipe_close(test_pipe), "Failed to re-close pipe");
+	zassert_ok(modem_pipe_close(test_pipe, K_SECONDS(10)), "Failed to re-close pipe");
 	zassert_false(test_backend.close_called, "close was called");
 	zassert_equal(atomic_get(&test_state), 0,
 		      "Unexpected state %u", atomic_get(&test_state));

--- a/tests/subsys/modem/modem_ppp/src/main.c
+++ b/tests/subsys/modem/modem_ppp/src/main.c
@@ -276,7 +276,7 @@ static void *test_modem_ppp_setup(void)
 	};
 
 	mock_pipe = modem_backend_mock_init(&mock, &mock_config);
-	zassert_true(modem_pipe_open(mock_pipe) == 0, "Failed to open mock pipe");
+	zassert_true(modem_pipe_open(mock_pipe, K_SECONDS(10)) == 0, "Failed to open mock pipe");
 	modem_ppp_attach(&ppp, mock_pipe);
 	return NULL;
 }


### PR DESCRIPTION
The modem pipe APIs include synchronous calls to open/close, which internally use a fixed timeout of 10 seconds. The timeout should be configurable through the APIs, anywhere from K_NO_WAIT to K_FOREVER.

This commit adds timeout parameters to the open/close APIs, and updates in-tree usage of the open/close APIs to explicitly provide the previously implicit timeout of 10 seconds.

The timeouts can be optimized to be lower in some cases,  but initially just keep the 10 second timeouts to not break anything :)