### PR TITLE
ci: testplan: do not run tests on all platforms when a test changes

### DIFF
--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -313,8 +313,6 @@ class Filters:
             if self.platforms:
                 for platform in self.platforms:
                     _options.extend(["-p", platform])
-            else:
-                _options.append("--all")
             self.get_plan(_options, use_testsuite_root=False)
 
     def find_tags(self):


### PR DESCRIPTION
With many tests having 10s or scenarios and variants, anytime we make a
change to a test right now, we end up building all scenarios on all
platforms which ends up in multiple 10s of the thousands of instances
that need to run on 30 or 40 runners blocking CI for hours. We do not
really need that, a test needs to be smart about its coverage and not
rely on boiling the ocean to catch, mostly build errors that are
platform specific.

Change this to do the normal coverage we get on push events.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
