### PR TITLE
zephyr: remove deprecated functions

### DIFF
--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -2342,11 +2342,6 @@ void bt_le_scan_cb_unregister(struct bt_le_scan_cb *cb);
  *         protocol error or negative (POSIX) in case of stack internal error.
  */
 int bt_le_filter_accept_list_add(const bt_addr_le_t *addr);
-__deprecated
-static inline int bt_le_whitelist_add(const bt_addr_le_t *addr)
-{
-	return bt_le_filter_accept_list_add(addr);
-}
 
 /**
  * @brief Remove device (LE) from filter accept list.
@@ -2363,11 +2358,6 @@ static inline int bt_le_whitelist_add(const bt_addr_le_t *addr)
  *         protocol error or negative (POSIX) in case of stack internal error.
  */
 int bt_le_filter_accept_list_remove(const bt_addr_le_t *addr);
-__deprecated
-static inline int bt_le_whitelist_rem(const bt_addr_le_t *addr)
-{
-	return bt_le_filter_accept_list_remove(addr);
-}
 
 /**
  * @brief Clear filter accept list.
@@ -2382,11 +2372,6 @@ static inline int bt_le_whitelist_rem(const bt_addr_le_t *addr)
  *         protocol error or negative (POSIX) in case of stack internal error.
  */
 int bt_le_filter_accept_list_clear(void);
-__deprecated
-static inline int bt_le_whitelist_clear(void)
-{
-	return bt_le_filter_accept_list_clear();
-}
 
 /**
  * @brief Set (LE) channel map.

--- a/include/zephyr/data/json.h
+++ b/include/zephyr/data/json.h
@@ -32,11 +32,7 @@ enum json_tokens {
 	JSON_TOK_NONE = '_',
 	JSON_TOK_OBJECT_START = '{',
 	JSON_TOK_OBJECT_END = '}',
-	/* JSON_TOK_LIST_START will be removed use JSON_TOK_ARRAY_START */
-	JSON_TOK_LIST_START __deprecated = '[',
 	JSON_TOK_ARRAY_START = '[',
-	/* JSON_TOK_LIST_END will be removed use JSON_TOK_ARRAY_END */
-	JSON_TOK_LIST_END __deprecated = ']',
 	JSON_TOK_ARRAY_END = ']',
 	JSON_TOK_STRING = '"',
 	JSON_TOK_COLON = ':',

--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -310,8 +310,8 @@ struct lwm2m_time_series_elem {
  * of using the resource's data buffer.
  *
  * The client or LwM2M objects can register a function of this type via:
- * lwm2m_engine_register_read_callback()
- * lwm2m_engine_register_pre_write_callback()
+ * lwm2m_register_read_callback()
+ * lwm2m_register_pre_write_callback()
  *
  * @param[in] obj_inst_id Object instance ID generating the callback.
  * @param[in] res_id Resource ID generating the callback.
@@ -338,8 +338,8 @@ typedef void *(*lwm2m_engine_get_data_cb_t)(uint16_t obj_inst_id,
  * Beginning of the block transfer has the offset set to 0.
  *
  * A function of this type can be registered via:
- * lwm2m_engine_register_validate_callback()
- * lwm2m_engine_register_post_write_callback()
+ * lwm2m_register_validate_callback()
+ * lwm2m_register_post_write_callback()
  *
  * @param[in] obj_inst_id Object instance ID generating the callback.
  * @param[in] res_id Resource ID generating the callback.
@@ -370,8 +370,8 @@ typedef int (*lwm2m_engine_set_data_cb_t)(uint16_t obj_inst_id,
  * and object instance delete.
  *
  * Register a function of this type via:
- * lwm2m_engine_register_create_callback()
- * lwm2m_engine_register_delete_callback()
+ * lwm2m_register_create_callback()
+ * lwm2m_register_delete_callback()
  *
  * @param[in] obj_inst_id Object instance ID generating the callback.
  *
@@ -386,7 +386,7 @@ typedef int (*lwm2m_engine_user_cb_t)(uint16_t obj_inst_id);
  * Resource executes trigger a callback of this type.
  *
  * Register a function of this type via:
- * lwm2m_engine_register_exec_callback()
+ * lwm2m_register_exec_callback()
  *
  * @param[in] obj_inst_id Object instance ID generating the callback.
  * @param[in] args Pointer to execute arguments payload. (This can be
@@ -438,7 +438,7 @@ typedef int (*lwm2m_engine_execute_cb_t)(uint16_t obj_inst_id,
  * @name Battery status codes used for the "Battery Status" resource (3/0/20)
  *        of the LwM2M Device object.  As the battery status changes, an LwM2M
  *        client can set one of the following codes via:
- *        lwm2m_engine_set_u8("3/0/20", [battery status])
+ *        lwm2m_set_u8("3/0/20", [battery status])
  * @{
  */
 #define LWM2M_DEVICE_BATTERY_STATUS_NORMAL	0 /**< The battery is operating normally and not on
@@ -496,7 +496,7 @@ int lwm2m_device_add_err(uint8_t error_code);
  * @name LWM2M Firmware Update object result codes
  *
  * After processing a firmware update, the client sets the result via one of
- * the following codes via lwm2m_engine_set_u8("5/0/5", [result code])
+ * the following codes via lwm2m_set_u8("5/0/5", [result code])
  * @{
  */
 
@@ -747,26 +747,6 @@ struct lwm2m_objlnk {
 /**
  * @brief Change an observer's pmin value.
  *
- * @deprecated Use lwm2m_update_observer_min_period() instead.
- *
- * LwM2M clients use this function to modify the pmin attribute
- * for an observation being made.
- * Example to update the pmin of a temperature sensor value being observed:
- * lwm2m_engine_update_observer_min_period("client_ctx, 3303/0/5700", 5);
- *
- * @param[in] client_ctx LwM2M context
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res"
- * @param[in] period_s Value of pmin to be given (in seconds).
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_update_observer_min_period(struct lwm2m_ctx *client_ctx, const char *pathstr,
-					    uint32_t period_s);
-
-/**
- * @brief Change an observer's pmin value.
- *
  * LwM2M clients use this function to modify the pmin attribute
  * for an observation being made.
  * Example to update the pmin of a temperature sensor value being observed:
@@ -780,26 +760,6 @@ int lwm2m_engine_update_observer_min_period(struct lwm2m_ctx *client_ctx, const 
  */
 int lwm2m_update_observer_min_period(struct lwm2m_ctx *client_ctx,
 				     const struct lwm2m_obj_path *path, uint32_t period_s);
-
-/**
- * @brief Change an observer's pmax value.
- *
- * @deprecated Use lwm2m_update_observer_max_period() instead.
- *
- * LwM2M clients use this function to modify the pmax attribute
- * for an observation being made.
- * Example to update the pmax of a temperature sensor value being observed:
- * lwm2m_engine_update_observer_max_period("client_ctx, 3303/0/5700", 5);
- *
- * @param[in] client_ctx LwM2M context
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res"
- * @param[in] period_s Value of pmax to be given (in seconds).
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_update_observer_max_period(struct lwm2m_ctx *client_ctx, const char *pathstr,
-					    uint32_t period_s);
 
 /**
  * @brief Change an observer's pmax value.
@@ -821,22 +781,6 @@ int lwm2m_update_observer_max_period(struct lwm2m_ctx *client_ctx,
 /**
  * @brief Create an LwM2M object instance.
  *
- * @deprecated Use lwm2m_create_obj_inst() instead.
- *
- * LwM2M clients use this function to create non-default LwM2M objects:
- * Example to create first temperature sensor object:
- * lwm2m_engine_create_obj_inst("3303/0");
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst"
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_create_obj_inst(const char *pathstr);
-
-/**
- * @brief Create an LwM2M object instance.
- *
  * LwM2M clients use this function to create non-default LwM2M objects:
  * Example to create first temperature sensor object:
  * lwm2m_create_obj_inst(&LWM2M_OBJ(3303, 0));
@@ -846,20 +790,6 @@ int lwm2m_engine_create_obj_inst(const char *pathstr);
  * @return 0 for success or negative in case of error.
  */
 int lwm2m_create_object_inst(const struct lwm2m_obj_path *path);
-
-/**
- * @brief Delete an LwM2M object instance.
- *
- * @deprecated Use lwm2m_delete_obj_inst() instead.
- *
- * LwM2M clients use this function to delete LwM2M objects.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst"
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_delete_obj_inst(const char *pathstr);
 
 /**
  * @brief Delete an LwM2M object instance.
@@ -890,20 +820,6 @@ void lwm2m_registry_unlock(void);
 /**
  * @brief Set resource (instance) value (opaque buffer)
  *
- * @deprecated Use lwm2m_set_opaque() instead.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[in] data_ptr Data buffer
- * @param[in] data_len Length of buffer
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_set_opaque(const char *pathstr, const char *data_ptr, uint16_t data_len);
-
-/**
- * @brief Set resource (instance) value (opaque buffer)
- *
  * @param[in] path LwM2M path as a struct
  * @param[in] data_ptr Data buffer
  * @param[in] data_len Length of buffer
@@ -911,19 +827,6 @@ int lwm2m_engine_set_opaque(const char *pathstr, const char *data_ptr, uint16_t 
  * @return 0 for success or negative in case of error.
  */
 int lwm2m_set_opaque(const struct lwm2m_obj_path *path, const char *data_ptr, uint16_t data_len);
-
-/**
- * @brief Set resource (instance) value (string)
- *
- * @deprecated Use lwm2m_set_string() instead.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[in] data_ptr NULL terminated char buffer
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_set_string(const char *pathstr, const char *data_ptr);
 
 /**
  * @brief Set resource (instance) value (string)
@@ -938,38 +841,12 @@ int lwm2m_set_string(const struct lwm2m_obj_path *path, const char *data_ptr);
 /**
  * @brief Set resource (instance) value (u8)
  *
- * @deprecated Use lwm2m_set_u8() instead.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[in] value u8 value
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_set_u8(const char *pathstr, uint8_t value);
-
-/**
- * @brief Set resource (instance) value (u8)
- *
  * @param[in] path LwM2M path as a struct
  * @param[in] value u8 value
  *
  * @return 0 for success or negative in case of error.
  */
 int lwm2m_set_u8(const struct lwm2m_obj_path *path, uint8_t value);
-
-/**
- * @brief Set resource (instance) value (u16)
- *
- * @deprecated Use lwm2m_set_u16() instead.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[in] value u16 value
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_set_u16(const char *pathstr, uint16_t value);
 
 /**
  * @brief Set resource (instance) value (u16)
@@ -984,38 +861,12 @@ int lwm2m_set_u16(const struct lwm2m_obj_path *path, uint16_t value);
 /**
  * @brief Set resource (instance) value (u32)
  *
- * @deprecated Use lwm2m_set_u32() instead.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[in] value u32 value
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_set_u32(const char *pathstr, uint32_t value);
-
-/**
- * @brief Set resource (instance) value (u32)
- *
  * @param[in] path LwM2M path as a struct
  * @param[in] value u32 value
  *
  * @return 0 for success or negative in case of error.
  */
 int lwm2m_set_u32(const struct lwm2m_obj_path *path, uint32_t value);
-
-/**
- * @brief Set resource (instance) value (u64)
- *
- * @deprecated Use lwm2m_set_u64() instead.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[in] value u64 value
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_set_u64(const char *pathstr, uint64_t value);
 
 /**
  * @brief Set resource (instance) value (u64)
@@ -1035,38 +886,12 @@ int lwm2m_set_u64(const struct lwm2m_obj_path *path, uint64_t value);
 /**
  * @brief Set resource (instance) value (s8)
  *
- * @deprecated Use lwm2m_set_s8() instead.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[in] value s8 value
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_set_s8(const char *pathstr, int8_t value);
-
-/**
- * @brief Set resource (instance) value (s8)
- *
  * @param[in] path LwM2M path as a struct
  * @param[in] value s8 value
  *
  * @return 0 for success or negative in case of error.
  */
 int lwm2m_set_s8(const struct lwm2m_obj_path *path, int8_t value);
-
-/**
- * @brief Set resource (instance) value (s16)
- *
- * @deprecated Use lwm2m_set_s16() instead.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[in] value s16 value
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_set_s16(const char *pathstr, int16_t value);
 
 /**
  * @brief Set resource (instance) value (s16)
@@ -1081,38 +906,12 @@ int lwm2m_set_s16(const struct lwm2m_obj_path *path, int16_t value);
 /**
  * @brief Set resource (instance) value (s32)
  *
- * @deprecated Use lwm2m_set_s32() instead.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[in] value s32 value
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_set_s32(const char *pathstr, int32_t value);
-
-/**
- * @brief Set resource (instance) value (s32)
- *
  * @param[in] path LwM2M path as a struct
  * @param[in] value s32 value
  *
  * @return 0 for success or negative in case of error.
  */
 int lwm2m_set_s32(const struct lwm2m_obj_path *path, int32_t value);
-
-/**
- * @brief Set resource (instance) value (s64)
- *
- * @deprecated Use lwm2m_set_s64() instead.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[in] value s64 value
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_set_s64(const char *pathstr, int64_t value);
 
 /**
  * @brief Set resource (instance) value (s64)
@@ -1127,38 +926,12 @@ int lwm2m_set_s64(const struct lwm2m_obj_path *path, int64_t value);
 /**
  * @brief Set resource (instance) value (bool)
  *
- * @deprecated Use lwm2m_set_bool() instead.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[in] value bool value
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_set_bool(const char *pathstr, bool value);
-
-/**
- * @brief Set resource (instance) value (bool)
- *
  * @param[in] path LwM2M path as a struct
  * @param[in] value bool value
  *
  * @return 0 for success or negative in case of error.
  */
 int lwm2m_set_bool(const struct lwm2m_obj_path *path, bool value);
-
-/**
- * @brief Set resource (instance) value (double)
- *
- * @deprecated Use lwm2m_set_f64() instead.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[in] value double value
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_set_float(const char *pathstr, const double *value);
 
 /**
  * @brief Set resource (instance) value (double)
@@ -1173,38 +946,12 @@ int lwm2m_set_f64(const struct lwm2m_obj_path *path, const double value);
 /**
  * @brief Set resource (instance) value (Objlnk)
  *
- * @deprecated Use lwm2m_set_objlnk() instead.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[in] value pointer to the lwm2m_objlnk structure
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_set_objlnk(const char *pathstr, const struct lwm2m_objlnk *value);
-
-/**
- * @brief Set resource (instance) value (Objlnk)
- *
  * @param[in] path LwM2M path as a struct
  * @param[in] value pointer to the lwm2m_objlnk structure
  *
  * @return 0 for success or negative in case of error.
  */
 int lwm2m_set_objlnk(const struct lwm2m_obj_path *path, const struct lwm2m_objlnk *value);
-
-/**
- * @brief Set resource (instance) value (Time)
- *
- * @deprecated Use lwm2m_set_time() instead.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[in] value Epoch timestamp
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_set_time(const char *pathstr, time_t value);
 
 /**
  * @brief Set resource (instance) value (Time)
@@ -1265,20 +1012,6 @@ int lwm2m_set_bulk(const struct lwm2m_res_item res_list[], size_t res_list_size)
 /**
  * @brief Get resource (instance) value (opaque buffer)
  *
- * @deprecated Use lwm2m_get_opaque() instead.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[out] buf Data buffer to copy data into
- * @param[in] buflen Length of buffer
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_get_opaque(const char *pathstr, void *buf, uint16_t buflen);
-
-/**
- * @brief Get resource (instance) value (opaque buffer)
- *
  * @param[in] path LwM2M path as a struct
  * @param[out] buf Data buffer to copy data into
  * @param[in] buflen Length of buffer
@@ -1286,20 +1019,6 @@ int lwm2m_engine_get_opaque(const char *pathstr, void *buf, uint16_t buflen);
  * @return 0 for success or negative in case of error.
  */
 int lwm2m_get_opaque(const struct lwm2m_obj_path *path, void *buf, uint16_t buflen);
-
-/**
- * @brief Get resource (instance) value (string)
- *
- * @deprecated Use lwm2m_get_string() instead.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[out] str String buffer to copy data into
- * @param[in] buflen Length of buffer
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_get_string(const char *pathstr, void *str, uint16_t buflen);
 
 /**
  * @brief Get resource (instance) value (string)
@@ -1315,38 +1034,12 @@ int lwm2m_get_string(const struct lwm2m_obj_path *path, void *str, uint16_t bufl
 /**
  * @brief Get resource (instance) value (u8)
  *
- * @deprecated Use lwm2m_get_u8() instead.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[out] value u8 buffer to copy data into
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_get_u8(const char *pathstr, uint8_t *value);
-
-/**
- * @brief Get resource (instance) value (u8)
- *
  * @param[in] path LwM2M path as a struct
  * @param[out] value u8 buffer to copy data into
  *
  * @return 0 for success or negative in case of error.
  */
 int lwm2m_get_u8(const struct lwm2m_obj_path *path, uint8_t *value);
-
-/**
- * @brief Get resource (instance) value (u16)
- *
- * @deprecated Use lwm2m_get_u16() instead.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[out] value u16 buffer to copy data into
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_get_u16(const char *pathstr, uint16_t *value);
 
 /**
  * @brief Get resource (instance) value (u16)
@@ -1361,38 +1054,12 @@ int lwm2m_get_u16(const struct lwm2m_obj_path *path, uint16_t *value);
 /**
  * @brief Get resource (instance) value (u32)
  *
- * @deprecated Use lwm2m_get_u32() instead.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[out] value u32 buffer to copy data into
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_get_u32(const char *pathstr, uint32_t *value);
-
-/**
- * @brief Get resource (instance) value (u32)
- *
  * @param[in] path LwM2M path as a struct
  * @param[out] value u32 buffer to copy data into
  *
  * @return 0 for success or negative in case of error.
  */
 int lwm2m_get_u32(const struct lwm2m_obj_path *path, uint32_t *value);
-
-/**
- * @brief Get resource (instance) value (u64)
- *
- * @deprecated Use lwm2m_get_u64() instead.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[out] value u64 buffer to copy data into
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_get_u64(const char *pathstr, uint64_t *value);
 
 /**
  * @brief Get resource (instance) value (u64)
@@ -1412,38 +1079,12 @@ int lwm2m_get_u64(const struct lwm2m_obj_path *path, uint64_t *value);
 /**
  * @brief Get resource (instance) value (s8)
  *
- * @deprecated Use lwm2m_get_s8() instead.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[out] value s8 buffer to copy data into
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_get_s8(const char *pathstr, int8_t *value);
-
-/**
- * @brief Get resource (instance) value (s8)
- *
  * @param[in] path LwM2M path as a struct
  * @param[out] value s8 buffer to copy data into
  *
  * @return 0 for success or negative in case of error.
  */
 int lwm2m_get_s8(const struct lwm2m_obj_path *path, int8_t *value);
-
-/**
- * @brief Get resource (instance) value (s16)
- *
- * @deprecated Use lwm2m_get_s16() instead.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[out] value s16 buffer to copy data into
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_get_s16(const char *pathstr, int16_t *value);
 
 /**
  * @brief Get resource (instance) value (s16)
@@ -1458,38 +1099,12 @@ int lwm2m_get_s16(const struct lwm2m_obj_path *path, int16_t *value);
 /**
  * @brief Get resource (instance) value (s32)
  *
- * @deprecated Use lwm2m_get_s32() instead.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[out] value s32 buffer to copy data into
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_get_s32(const char *pathstr, int32_t *value);
-
-/**
- * @brief Get resource (instance) value (s32)
- *
  * @param[in] path LwM2M path as a struct
  * @param[out] value s32 buffer to copy data into
  *
  * @return 0 for success or negative in case of error.
  */
 int lwm2m_get_s32(const struct lwm2m_obj_path *path, int32_t *value);
-
-/**
- * @brief Get resource (instance) value (s64)
- *
- * @deprecated Use lwm2m_get_s64() instead.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[out] value s64 buffer to copy data into
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_get_s64(const char *pathstr, int64_t *value);
 
 /**
  * @brief Get resource (instance) value (s64)
@@ -1504,38 +1119,12 @@ int lwm2m_get_s64(const struct lwm2m_obj_path *path, int64_t *value);
 /**
  * @brief Get resource (instance) value (bool)
  *
- * @deprecated Use lwm2m_get_bool() instead.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[out] value bool buffer to copy data into
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_get_bool(const char *pathstr, bool *value);
-
-/**
- * @brief Get resource (instance) value (bool)
- *
  * @param[in] path LwM2M path as a struct
  * @param[out] value bool buffer to copy data into
  *
  * @return 0 for success or negative in case of error.
  */
 int lwm2m_get_bool(const struct lwm2m_obj_path *path, bool *value);
-
-/**
- * @brief Get resource (instance) value (double)
- *
- * @deprecated Use lwm2m_get_f64() instead.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[out] buf double buffer to copy data into
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_get_float(const char *pathstr, double *buf);
 
 /**
  * @brief Get resource (instance) value (double)
@@ -1550,38 +1139,12 @@ int lwm2m_get_f64(const struct lwm2m_obj_path *path, double *value);
 /**
  * @brief Get resource (instance) value (Objlnk)
  *
- * @deprecated Use lwm2m_get_objlnk() instead.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[out] buf lwm2m_objlnk buffer to copy data into
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_get_objlnk(const char *pathstr, struct lwm2m_objlnk *buf);
-
-/**
- * @brief Get resource (instance) value (Objlnk)
- *
  * @param[in] path LwM2M path as a struct
  * @param[out] buf lwm2m_objlnk buffer to copy data into
  *
  * @return 0 for success or negative in case of error.
  */
 int lwm2m_get_objlnk(const struct lwm2m_obj_path *path, struct lwm2m_objlnk *buf);
-
-/**
- * @brief Get resource (instance) value (Time)
- *
- * @deprecated Use lwm2m_get_time() instead.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[out] buf time_t pointer to copy data
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_get_time(const char *pathstr, time_t *buf);
 
 /**
  * @brief Get resource (instance) value (Time)
@@ -1596,8 +1159,6 @@ int lwm2m_get_time(const struct lwm2m_obj_path *path, time_t *buf);
 /**
  * @brief Set resource (instance) read callback
  *
- * @deprecated Use lwm2m_register_read_callback() instead.
- *
  * LwM2M clients can use this to set the callback function for resource reads when data
  * handling in the LwM2M engine needs to be bypassed.
  * For example reading back opaque binary data from external storage.
@@ -1605,29 +1166,7 @@ int lwm2m_get_time(const struct lwm2m_obj_path *path, time_t *buf);
  * This callback should not generally be used for any data that might be observed as
  * engine does not have any knowledge of data changes.
  *
- * When separate buffer for data should be used, use lwm2m_engine_set_res_buf() instead
- * to set the storage.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[in] cb Read resource callback
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_register_read_callback(const char *pathstr,
-					lwm2m_engine_get_data_cb_t cb);
-
-/**
- * @brief Set resource (instance) read callback
- *
- * LwM2M clients can use this to set the callback function for resource reads when data
- * handling in the LwM2M engine needs to be bypassed.
- * For example reading back opaque binary data from external storage.
- *
- * This callback should not generally be used for any data that might be observed as
- * engine does not have any knowledge of data changes.
- *
- * When separate buffer for data should be used, use lwm2m_engine_set_res_buf() instead
+ * When separate buffer for data should be used, use lwm2m_set_res_buf() instead
  * to set the storage.
  *
  * @param[in] path LwM2M path as a struct
@@ -1636,24 +1175,6 @@ int lwm2m_engine_register_read_callback(const char *pathstr,
  * @return 0 for success or negative in case of error.
  */
 int lwm2m_register_read_callback(const struct lwm2m_obj_path *path, lwm2m_engine_get_data_cb_t cb);
-
-/**
- * @brief Set resource (instance) pre-write callback
- *
- * @deprecated Use lwm2m_register_pre_write_callback() instead.
- *
- * This callback is triggered before setting the value of a resource.  It
- * can pass a special data buffer to the engine so that the actual resource
- * value can be calculated later, etc.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[in] cb Pre-write resource callback
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_register_pre_write_callback(const char *pathstr,
-					     lwm2m_engine_get_data_cb_t cb);
 
 /**
  * @brief Set resource (instance) pre-write callback
@@ -1669,32 +1190,6 @@ int lwm2m_engine_register_pre_write_callback(const char *pathstr,
  */
 int lwm2m_register_pre_write_callback(const struct lwm2m_obj_path *path,
 				      lwm2m_engine_get_data_cb_t cb);
-
-/**
- * @brief Set resource (instance) validation callback
- *
- * @deprecated Use lwm2m_register_validate_callback() instead.
- *
- * This callback is triggered before setting the value of a resource to the
- * resource data buffer.
- *
- * The callback allows an LwM2M client or object to validate the data before
- * writing and notify an error if the data should be discarded for any reason
- * (by returning a negative error code).
- *
- * @note All resources that have a validation callback registered are initially
- *       decoded into a temporary validation buffer. Make sure that
- *       ``CONFIG_LWM2M_ENGINE_VALIDATION_BUFFER_SIZE`` is large enough to
- *       store each of the validated resources (individually).
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[in] cb Validate resource data callback
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_register_validate_callback(const char *pathstr,
-					    lwm2m_engine_set_data_cb_t cb);
 
 /**
  * @brief Set resource (instance) validation callback
@@ -1722,26 +1217,6 @@ int lwm2m_register_validate_callback(const struct lwm2m_obj_path *path,
 /**
  * @brief Set resource (instance) post-write callback
  *
- * @deprecated Use lwm2m_register_post_write_callback() instead.
- *
- * This callback is triggered after setting the value of a resource to the
- * resource data buffer.
- *
- * It allows an LwM2M client or object to post-process the value of a resource
- * or trigger other related resource calculations.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[in] cb Post-write resource callback
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_register_post_write_callback(const char *pathstr,
-					      lwm2m_engine_set_data_cb_t cb);
-
-/**
- * @brief Set resource (instance) post-write callback
- *
  * This callback is triggered after setting the value of a resource to the
  * resource data buffer.
  *
@@ -1759,22 +1234,6 @@ int lwm2m_register_post_write_callback(const struct lwm2m_obj_path *path,
 /**
  * @brief Set resource execute event callback
  *
- * @deprecated Use lwm2m_register_exec_callback() instead.
- *
- * This event is triggered when the execute method of a resource is enabled.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res"
- * @param[in] cb Execute resource callback
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_register_exec_callback(const char *pathstr,
-					lwm2m_engine_execute_cb_t cb);
-
-/**
- * @brief Set resource execute event callback
- *
  * This event is triggered when the execute method of a resource is enabled.
  *
  * @param[in] path LwM2M path as a struct
@@ -1783,22 +1242,6 @@ int lwm2m_engine_register_exec_callback(const char *pathstr,
  * @return 0 for success or negative in case of error.
  */
 int lwm2m_register_exec_callback(const struct lwm2m_obj_path *path, lwm2m_engine_execute_cb_t cb);
-
-/**
- * @brief Set object instance create event callback
- *
- * @deprecated Use lwm2m_register_create_callback instead.
- *
- * This event is triggered when an object instance is created.
- *
- * @param[in] obj_id LwM2M object id
- * @param[in] cb Create object instance callback
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_register_create_callback(uint16_t obj_id,
-					  lwm2m_engine_user_cb_t cb);
 
 /**
  * @brief Set object instance create event callback
@@ -1812,22 +1255,6 @@ int lwm2m_engine_register_create_callback(uint16_t obj_id,
  */
 int lwm2m_register_create_callback(uint16_t obj_id,
 				   lwm2m_engine_user_cb_t cb);
-
-/**
- * @brief Set object instance delete event callback
- *
- * @deprecated Use lwm2m_register_delete_callback instead
- *
- * This event is triggered when an object instance is deleted.
- *
- * @param[in] obj_id LwM2M object id
- * @param[in] cb Delete object instance callback
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_register_delete_callback(uint16_t obj_id,
-					  lwm2m_engine_user_cb_t cb);
 
 /**
  * @brief Set object instance delete event callback
@@ -1860,26 +1287,6 @@ int lwm2m_register_delete_callback(uint16_t obj_id,
 /**
  * @brief Set data buffer for a resource
  *
- * @deprecated Use lwm2m_set_res_buf() instead.
- *
- * Use this function to set the data buffer and flags for the specified LwM2M
- * resource.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[in] buffer_ptr Data buffer pointer
- * @param[in] buffer_len Length of buffer
- * @param[in] data_len Length of existing data in the buffer
- * @param[in] data_flags Data buffer flags (such as read-only, etc)
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_set_res_buf(const char *pathstr, void *buffer_ptr, uint16_t buffer_len,
-			     uint16_t data_len, uint8_t data_flags);
-
-/**
- * @brief Set data buffer for a resource
- *
  * Use this function to set the data buffer and flags for the specified LwM2M
  * resource.
  *
@@ -1895,76 +1302,16 @@ int lwm2m_set_res_buf(const struct lwm2m_obj_path *path, void *buffer_ptr, uint1
 		      uint16_t data_len, uint8_t data_flags);
 
 /**
- * @brief Set data buffer for a resource
- *
- * Use this function to set the data buffer and flags for the specified LwM2M
- * resource.
- *
- * @deprecated Use lwm2m_set_res_buf() instead, so you can define buffer size and data size
- *             separately.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[in] data_ptr Data buffer pointer
- * @param[in] data_len Length of buffer
- * @param[in] data_flags Data buffer flags (such as read-only, etc)
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_set_res_data(const char *pathstr, void *data_ptr, uint16_t data_len,
-			      uint8_t data_flags);
-
-/**
- * @brief Update data size for a resource
- *
- * @deprecated Use lwm2m_set_res_data_len() instead.
- *
- * Use this function to set the new size of data in the buffer if you write
- * to a buffer received by lwm2m_engine_get_res_buf().
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[in] data_len Length of data
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_set_res_data_len(const char *pathstr, uint16_t data_len);
-
-/**
  * @brief Update data size for a resource
  *
  * Use this function to set the new size of data in the buffer if you write
- * to a buffer received by lwm2m_engine_get_res_buf().
+ * to a buffer received by lwm2m_get_res_buf().
  *
  * @param[in] path LwM2M path as a struct
  * @param[in] data_len Length of data
  * @return 0 for success or negative in case of error.
  */
 int lwm2m_set_res_data_len(const struct lwm2m_obj_path *path, uint16_t data_len);
-
-/**
- * @brief Get data buffer for a resource
- *
- * @deprecated Use lwm2m_get_res_buf() instead.
- *
- * Use this function to get the data buffer information for the specified LwM2M
- * resource.
- *
- * If you directly write into the buffer, you must use lwm2m_engine_set_res_data_len()
- * function to update the new size of the written data.
- *
- * All parameters except pathstr can NULL if you don't want to read those values.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[out] buffer_ptr Data buffer pointer
- * @param[out] buffer_len Length of buffer
- * @param[out] data_len Length of existing data in the buffer
- * @param[out] data_flags Data buffer flags (such as read-only, etc)
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_get_res_buf(const char *pathstr, void **buffer_ptr, uint16_t *buffer_len,
-			     uint16_t *data_len, uint8_t *data_flags);
 
 /**
  * @brief Get data buffer for a resource
@@ -1989,41 +1336,6 @@ int lwm2m_get_res_buf(const struct lwm2m_obj_path *path, void **buffer_ptr, uint
 		      uint16_t *data_len, uint8_t *data_flags);
 
 /**
- * @brief Get data buffer for a resource
- *
- * Use this function to get the data buffer information for the specified LwM2M
- * resource.
- *
- * @deprecated Use lwm2m_get_res_buf() as it can tell you the size of the buffer as well.
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[out] data_ptr Data buffer pointer
- * @param[out] data_len Length of existing data in the buffer
- * @param[out] data_flags Data buffer flags (such as read-only, etc)
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_get_res_data(const char *pathstr, void **data_ptr, uint16_t *data_len,
-			      uint8_t *data_flags);
-
-/**
- * @brief Create a resource instance
- *
- * @deprecated Use lwm2m_create_res_inst() instead.
- *
- * LwM2M clients use this function to create multi-resource instances:
- * Example to create 0 instance of device available power sources:
- * lwm2m_engine_create_res_inst("3/0/6/0");
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res/res-inst"
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_create_res_inst(const char *pathstr);
-
-/**
  * @brief Create a resource instance
  *
  * LwM2M clients use this function to create multi-resource instances:
@@ -2035,20 +1347,6 @@ int lwm2m_engine_create_res_inst(const char *pathstr);
  * @return 0 for success or negative in case of error.
  */
 int lwm2m_create_res_inst(const struct lwm2m_obj_path *path);
-
-/**
- * @brief Delete a resource instance
- *
- * @deprecated Use lwm2m_delete_res_inst() instead.
- *
- * Use this function to remove an existing resource instance
- *
- * @param[in] pathstr LwM2M path string "obj/obj-inst/res/res-inst"
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_engine_delete_res_inst(const char *pathstr);
 
 /**
  * @brief Delete a resource instance
@@ -2072,22 +1370,6 @@ int lwm2m_delete_res_inst(const struct lwm2m_obj_path *path);
  * @return 0 for success or negative in case of error.
  */
 int lwm2m_update_device_service_period(uint32_t period_ms);
-
-/**
- * @brief Check whether a path is observed
- *
- * @deprecated Use lwm2m_path_is_observed() instead.
- *
- * @param[in] pathstr LwM2M path string to check, e.g. "3/0/1"
- *
- * @return true when there exists an observation of the same level
- *         or lower as the given path, false if it doesn't or path is not a
- *         valid LwM2M-path.
- *         E.g. true if path refers to a resource and the parent object has an
- *         observation, false for the inverse.
- */
-__deprecated
-bool lwm2m_engine_path_is_observed(const char *pathstr);
 
 /**
  * @brief Check whether a path is observed
@@ -2181,12 +1463,6 @@ enum lwm2m_rd_client_event {
 	/** Server disabled */
 	LWM2M_RD_CLIENT_EVENT_SERVER_DISABLED,
 };
-
-/**
- *	Define for old event name keeping backward compatibility.
- */
-#define LWM2M_RD_CLIENT_EVENT_REG_UPDATE_FAILURE                                                   \
-	LWM2M_RD_CLIENT_EVENT_REG_TIMEOUT __DEPRECATED_MACRO
 
 /*
  * LwM2M RD client flags, used to configure LwM2M session.
@@ -2302,40 +1578,6 @@ enum lwm2m_send_status {
 typedef void (*lwm2m_send_cb_t)(enum lwm2m_send_status status);
 
 /** 
- * @brief LwM2M SEND operation to given path list
- *
- * @deprecated Use lwm2m_send_cb() instead.
- *
- * @param ctx LwM2M context
- * @param path_list LwM2M Path string list
- * @param path_list_size Length of path list. Max size is CONFIG_LWM2M_COMPOSITE_PATH_LIST_SIZE
- * @param confirmation_request True request confirmation for operation.
- *
- * @return 0 for success or negative in case of error.
- *
- */
-__deprecated
-int lwm2m_engine_send(struct lwm2m_ctx *ctx, char const *path_list[], uint8_t path_list_size,
-		      bool confirmation_request);
-
-/** 
- * @brief LwM2M SEND operation to given path list
- *
- * @deprecated Use lwm2m_send_cb() instead.
- *
- * @param ctx LwM2M context
- * @param path_list LwM2M path struct list
- * @param path_list_size Length of path list. Max size is CONFIG_LWM2M_COMPOSITE_PATH_LIST_SIZE
- * @param confirmation_request True request confirmation for operation.
- *
- * @return 0 for success or negative in case of error.
- *
- */
-__deprecated
-int lwm2m_send(struct lwm2m_ctx *ctx, const struct lwm2m_obj_path path_list[],
-	       uint8_t path_list_size, bool confirmation_request);
-
-/** 
  * @brief LwM2M SEND operation to given path list asynchronously with confirmation callback
  *
  * @param ctx LwM2M context
@@ -2356,25 +1598,6 @@ int lwm2m_send_cb(struct lwm2m_ctx *ctx, const struct lwm2m_obj_path path_list[]
  *
  */
 struct lwm2m_ctx *lwm2m_rd_client_ctx(void);
-
-/** 
- * @brief Enable data cache for a resource.
- *
- * @deprecated Use lwm2m_enable_cache instead
- *
- * Application may enable caching of resource data by allocating buffer for LwM2M engine to use.
- * Buffer must be size of struct @ref lwm2m_time_series_elem times cache_len
- *
- * @param resource_path LwM2M resourcepath string "obj/obj-inst/res(/res-inst)"
- * @param data_cache Pointer to Data cache array
- * @param cache_len number of cached entries
- *
- * @return 0 for success or negative in case of error.
- *
- */
-__deprecated
-int lwm2m_engine_enable_cache(char const *resource_path, struct lwm2m_time_series_elem *data_cache,
-			      size_t cache_len);
 
 /** 
  * @brief Enable data cache for a resource.

--- a/include/zephyr/net/openthread.h
+++ b/include/zephyr/net/openthread.h
@@ -128,15 +128,6 @@ int openthread_state_changed_cb_unregister(struct openthread_context *ot_context
 					   struct openthread_state_changed_cb *cb);
 
 /**
- * @brief Sets function which will be called when certain configuration or state
- * changes within OpenThread.
- *
- * @param cb function to call in callback procedure.
- * @deprecated Use openthread_state_changed_cb_register() instead.
- */
-__deprecated void openthread_set_state_changed_cb(otStateChangedCallback cb);
-
-/**
  * @brief Get OpenThread thread identification.
  */
 k_tid_t openthread_thread_id_get(void);

--- a/subsys/mgmt/mcumgr/transport/include/mgmt/mcumgr/transport/smp_internal.h
+++ b/subsys/mgmt/mcumgr/transport/include/mgmt/mcumgr/transport/smp_internal.h
@@ -57,12 +57,6 @@ void smp_rx_req(struct smp_transport *smtp, struct net_buf *nb);
 void smp_tx_req(struct k_work *work);
 #endif
 
-__deprecated static inline
-void zephyr_smp_rx_req(struct zephyr_smp_transport *smpt, struct net_buf *nb)
-{
-	smp_rx_req((struct smp_transport *)smpt, nb);
-}
-
 /**
  * @brief Allocates a response buffer.
  *
@@ -76,12 +70,6 @@ void zephyr_smp_rx_req(struct zephyr_smp_transport *smpt, struct net_buf *nb)
  */
 void *smp_alloc_rsp(const void *req, void *arg);
 
-__deprecated static inline
-void *zephyr_smp_alloc_rsp(const void *req, void *arg)
-{
-	return smp_alloc_rsp(req, arg);
-}
-
 
 /**
  * @brief Frees an allocated buffer.
@@ -90,12 +78,6 @@ void *zephyr_smp_alloc_rsp(const void *req, void *arg)
  * @param arg		The streamer providing the callback.
  */
 void smp_free_buf(void *buf, void *arg);
-
-__deprecated static inline
-void zephyr_smp_free_buf(void *buf, void *arg)
-{
-	smp_free_buf(buf, arg);
-}
 
 #ifdef __cplusplus
 }

--- a/subsys/net/lib/dns/dns_sd.c
+++ b/subsys/net/lib/dns/dns_sd.c
@@ -1139,36 +1139,6 @@ int dns_sd_query_extract(const uint8_t *query, size_t query_size, struct dns_sd_
 	return offset;
 }
 
-int dns_sd_extract_service_proto_domain(const uint8_t *query, size_t query_size,
-					struct dns_sd_rec *record, char *service,
-					size_t service_size, char *proto, size_t proto_size,
-					char *domain, size_t domain_size)
-{
-	char instance[DNS_SD_INSTANCE_MAX_SIZE + 1];
-	char *label[4];
-	size_t size[] = {
-		ARRAY_SIZE(instance),
-		service_size,
-		proto_size,
-		domain_size,
-	};
-	size_t n = ARRAY_SIZE(label);
-
-	BUILD_ASSERT(ARRAY_SIZE(label) == ARRAY_SIZE(size),
-		"label and size arrays are different size");
-
-	/*
-	 * work around for bug in compliance scripts which say that the array
-	 * should be static const (incorrect)
-	 */
-	label[0] = instance;
-	label[1] = service;
-	label[2] = proto;
-	label[3] = domain;
-
-	return dns_sd_query_extract(query, query_size, record, label, size, &n);
-}
-
 bool dns_sd_is_service_type_enumeration(const struct dns_sd_rec *rec)
 {
 	static const struct dns_sd_rec filter = {

--- a/subsys/net/lib/dns/dns_sd.h
+++ b/subsys/net/lib/dns/dns_sd.h
@@ -69,37 +69,6 @@ int dns_sd_query_extract(const uint8_t *query, size_t query_size, struct dns_sd_
 			 char **label, size_t *size, size_t *n);
 
 /**
- * @brief Extract the Service, Protocol, and Domain from a DNS-SD PTR query
- *
- * This function zero-initializes @p record and populates the appropriate
- * fields so that @p record may be subsequently passed to @ref dns_sd_rec_match.
- *
- * If a query with a supported format is found, the function returns the
- * length of the initial, variable-length portion of the query.
- *
- * For example, if the query begins with "._foo._tcp.local.", where
- * the '.' character represents a length of the subsequent string value,
- * then this function will return 17.
- *
- * @param query a pointer to the start of the query
- * @param query_size the number of bytes contained in the query
- * @param[out] record the DNS-SD record to initialize and populate
- * @param service buffer to store the null-terminated service
- * @param service_size the size of @p service
- * @param proto buffer to store the null-terminated proto
- * @param proto_size the size of @p proto
- * @param domain buffer to store the null-terminated domain
- * @param domain_size the size of @p domain
- * @return on success, a positive number representing length of the query
- * @return on failure, a negative errno value
- */
-__deprecated
-int dns_sd_extract_service_proto_domain(const uint8_t *query,
-	size_t query_size, struct dns_sd_rec *record, char *service,
-	size_t service_size, char *proto, size_t proto_size,
-	char *domain, size_t domain_size);
-
-/**
  * @brief See if the DNS SD @p filter matches the @p record
  *
  * The fields in @p filter should be populated with filter elements to

--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -3602,34 +3602,3 @@ cleanup:
 	return -ENOTSUP;
 #endif
 }
-
-int lwm2m_send(struct lwm2m_ctx *ctx, const struct lwm2m_obj_path path_list[],
-			 uint8_t path_list_size, bool confirmation_request)
-{
-	if (!confirmation_request) {
-		return -EINVAL;
-	}
-
-	return lwm2m_send_cb(ctx, path_list, path_list_size, NULL);
-}
-
-int lwm2m_engine_send(struct lwm2m_ctx *ctx, char const *path_list[], uint8_t path_list_size,
-		      bool confirmation_request)
-{
-	int ret;
-	struct lwm2m_obj_path lwm2m_path_list[CONFIG_LWM2M_COMPOSITE_PATH_LIST_SIZE];
-
-	if (path_list_size > CONFIG_LWM2M_COMPOSITE_PATH_LIST_SIZE) {
-		return -E2BIG;
-	}
-
-	for (int i = 0; i < path_list_size; i++) {
-		/* translate path -> path_obj */
-		ret = lwm2m_string_to_path(path_list[i], &lwm2m_path_list[i], '/');
-		if (ret < 0) {
-			return ret;
-		}
-	}
-
-	return lwm2m_send_cb(ctx, lwm2m_path_list, path_list_size, NULL);
-}

--- a/subsys/net/lib/lwm2m/lwm2m_observation.c
+++ b/subsys/net/lib/lwm2m/lwm2m_observation.c
@@ -1047,20 +1047,6 @@ int lwm2m_update_observer_min_period(struct lwm2m_ctx *client_ctx,
 	return lwm2m_update_or_allocate_attribute(ref, LWM2M_ATTR_PMIN, &period_s);
 }
 
-int lwm2m_engine_update_observer_min_period(struct lwm2m_ctx *client_ctx, const char *pathstr,
-					    uint32_t period_s)
-{
-	int ret;
-	struct lwm2m_obj_path path;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-
-	return lwm2m_update_observer_min_period(client_ctx, &path, period_s);
-}
-
 int lwm2m_update_observer_max_period(struct lwm2m_ctx *client_ctx,
 				     const struct lwm2m_obj_path *path, uint32_t period_s)
 {
@@ -1105,20 +1091,6 @@ int lwm2m_update_observer_max_period(struct lwm2m_ctx *client_ctx,
 	/* Update Observer timestamp */
 	return lwm2m_engine_observer_timestamp_update(&client_ctx->observer, path,
 						      client_ctx->srv_obj_inst);
-}
-
-int lwm2m_engine_update_observer_max_period(struct lwm2m_ctx *client_ctx, const char *pathstr,
-					    uint32_t period_s)
-{
-	int ret;
-	struct lwm2m_obj_path path;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-
-	return lwm2m_update_observer_max_period(client_ctx, &path, period_s);
 }
 
 struct lwm2m_attr *lwm2m_engine_get_next_attr(const void *ref, struct lwm2m_attr *prev)
@@ -1391,19 +1363,6 @@ bool lwm2m_path_is_observed(const struct lwm2m_obj_path *path)
 		}
 	}
 	return false;
-}
-
-bool lwm2m_engine_path_is_observed(const char *pathstr)
-{
-	int ret;
-	struct lwm2m_obj_path path;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return false;
-	}
-
-	return lwm2m_path_is_observed(&path);
 }
 
 int lwm2m_engine_observation_handler(struct lwm2m_message *msg, int observe, uint16_t accept,

--- a/subsys/net/lib/lwm2m/lwm2m_pull_context.c
+++ b/subsys/net/lib/lwm2m/lwm2m_pull_context.c
@@ -20,6 +20,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include "lwm2m_pull_context.h"
 #include "lwm2m_engine.h"
+#include "lwm2m_util.h"
 
 static K_SEM_DEFINE(lwm2m_pull_sem, 1, 1);
 
@@ -287,8 +288,15 @@ static int do_firmware_transfer_reply_cb(const struct coap_packet *response,
 		LOG_DBG("total: %zd, current: %zd", context.block_ctx.total_size,
 			context.block_ctx.current);
 
+		struct lwm2m_obj_path path;
+
+		ret = lwm2m_string_to_path("5/0/0", &path, '/');
+		if (ret < 0) {
+			goto error;
+		}
+
 		/* look up firmware package resource */
-		ret = lwm2m_engine_get_resource("5/0/0", &res);
+		ret = lwm2m_get_resource(&path, &res);
 		if (ret < 0) {
 			goto error;
 		}

--- a/subsys/net/lib/lwm2m/lwm2m_registry.c
+++ b/subsys/net/lib/lwm2m/lwm2m_registry.c
@@ -336,22 +336,6 @@ int lwm2m_create_object_inst(const struct lwm2m_obj_path *path)
 	return 0;
 }
 
-int lwm2m_engine_create_obj_inst(const char *pathstr)
-{
-	struct lwm2m_obj_path path;
-	int ret = 0;
-
-	LOG_DBG("path:%s", pathstr);
-
-	/* translate path -> path_obj */
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-
-	return lwm2m_create_object_inst(&path);
-}
-
 int lwm2m_delete_object_inst(const struct lwm2m_obj_path *path)
 {
 	int ret = 0;
@@ -369,22 +353,6 @@ int lwm2m_delete_object_inst(const struct lwm2m_obj_path *path)
 	engine_trigger_update(true);
 
 	return 0;
-}
-
-int lwm2m_engine_delete_obj_inst(const char *pathstr)
-{
-	struct lwm2m_obj_path path;
-	int ret = 0;
-
-	LOG_DBG("path: %s", pathstr);
-
-	/* translate path -> path_obj */
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-
-	return lwm2m_delete_object_inst(&path);
 }
 
 struct lwm2m_engine_obj_inst *lwm2m_engine_get_obj_inst(const struct lwm2m_obj_path *path)
@@ -522,36 +490,6 @@ int lwm2m_set_res_buf(const struct lwm2m_obj_path *path, void *buffer_ptr, uint1
 
 	k_mutex_unlock(&registry_lock);
 	return ret;
-}
-
-int lwm2m_engine_set_res_buf(const char *pathstr, void *buffer_ptr, uint16_t buffer_len,
-			     uint16_t data_len, uint8_t data_flags)
-{
-	struct lwm2m_obj_path path;
-	int ret = 0;
-
-	/* translate path -> path_obj */
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-
-	return lwm2m_set_res_buf(&path, buffer_ptr, buffer_len, data_len, data_flags);
-}
-
-int lwm2m_engine_set_res_data(const char *pathstr, void *data_ptr, uint16_t data_len,
-			      uint8_t data_flags)
-{
-	struct lwm2m_obj_path path;
-	int ret = 0;
-
-	/* translate path -> path_obj */
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-
-	return lwm2m_set_res_buf(&path, data_ptr, data_len, data_len, data_flags);
 }
 
 static bool lwm2m_validate_time_resource_lenghts(uint16_t resource_length, uint16_t buf_length)
@@ -789,18 +727,6 @@ int lwm2m_set_opaque(const struct lwm2m_obj_path *path, const char *data_ptr, ui
 	return lwm2m_engine_set(path, data_ptr, data_len);
 }
 
-int lwm2m_engine_set_opaque(const char *pathstr, const char *data_ptr, uint16_t data_len)
-{
-	struct lwm2m_obj_path path;
-	int ret = 0;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-	return lwm2m_set_opaque(&path, data_ptr, data_len);
-}
-
 int lwm2m_set_string(const struct lwm2m_obj_path *path, const char *data_ptr)
 {
 	uint16_t len = strlen(data_ptr);
@@ -813,33 +739,9 @@ int lwm2m_set_string(const struct lwm2m_obj_path *path, const char *data_ptr)
 	return lwm2m_engine_set(path, data_ptr, len);
 }
 
-int lwm2m_engine_set_string(const char *pathstr, const char *data_ptr)
-{
-	struct lwm2m_obj_path path;
-	int ret = 0;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-	return lwm2m_set_string(&path, data_ptr);
-}
-
 int lwm2m_set_u8(const struct lwm2m_obj_path *path, uint8_t value)
 {
 	return lwm2m_engine_set(path, &value, 1);
-}
-
-int lwm2m_engine_set_u8(const char *pathstr, uint8_t value)
-{
-	struct lwm2m_obj_path path;
-	int ret = 0;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-	return lwm2m_set_u8(&path, value);
 }
 
 int lwm2m_set_u16(const struct lwm2m_obj_path *path, uint16_t value)
@@ -847,33 +749,9 @@ int lwm2m_set_u16(const struct lwm2m_obj_path *path, uint16_t value)
 	return lwm2m_engine_set(path, &value, 2);
 }
 
-int lwm2m_engine_set_u16(const char *pathstr, uint16_t value)
-{
-	struct lwm2m_obj_path path;
-	int ret = 0;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-	return lwm2m_set_u16(&path, value);
-}
-
 int lwm2m_set_u32(const struct lwm2m_obj_path *path, uint32_t value)
 {
 	return lwm2m_engine_set(path, &value, 4);
-}
-
-int lwm2m_engine_set_u32(const char *pathstr, uint32_t value)
-{
-	struct lwm2m_obj_path path;
-	int ret = 0;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-	return lwm2m_set_u32(&path, value);
 }
 
 int lwm2m_set_u64(const struct lwm2m_obj_path *path, uint64_t value)
@@ -881,33 +759,9 @@ int lwm2m_set_u64(const struct lwm2m_obj_path *path, uint64_t value)
 	return lwm2m_engine_set(path, &value, 8);
 }
 
-int lwm2m_engine_set_u64(const char *pathstr, uint64_t value)
-{
-	struct lwm2m_obj_path path;
-	int ret = 0;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-	return lwm2m_set_s64(&path, (int64_t) value);
-}
-
 int lwm2m_set_s8(const struct lwm2m_obj_path *path, int8_t value)
 {
 	return lwm2m_engine_set(path, &value, 1);
-}
-
-int lwm2m_engine_set_s8(const char *pathstr, int8_t value)
-{
-	struct lwm2m_obj_path path;
-	int ret = 0;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-	return lwm2m_set_s8(&path, value);
 }
 
 int lwm2m_set_s16(const struct lwm2m_obj_path *path, int16_t value)
@@ -916,50 +770,14 @@ int lwm2m_set_s16(const struct lwm2m_obj_path *path, int16_t value)
 
 }
 
-int lwm2m_engine_set_s16(const char *pathstr, int16_t value)
-{
-	struct lwm2m_obj_path path;
-	int ret = 0;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-	return lwm2m_set_s16(&path, value);
-}
-
 int lwm2m_set_s32(const struct lwm2m_obj_path *path, int32_t value)
 {
 	return lwm2m_engine_set(path, &value, 4);
 }
 
-int lwm2m_engine_set_s32(const char *pathstr, int32_t value)
-{
-	struct lwm2m_obj_path path;
-	int ret = 0;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-	return lwm2m_set_s32(&path, value);
-}
-
 int lwm2m_set_s64(const struct lwm2m_obj_path *path, int64_t value)
 {
 	return lwm2m_engine_set(path, &value, 8);
-}
-
-int lwm2m_engine_set_s64(const char *pathstr, int64_t value)
-{
-	struct lwm2m_obj_path path;
-	int ret = 0;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-	return lwm2m_set_s64(&path, value);
 }
 
 int lwm2m_set_bool(const struct lwm2m_obj_path *path, bool value)
@@ -969,33 +787,9 @@ int lwm2m_set_bool(const struct lwm2m_obj_path *path, bool value)
 	return lwm2m_engine_set(path, &temp, 1);
 }
 
-int lwm2m_engine_set_bool(const char *pathstr, bool value)
-{
-	struct lwm2m_obj_path path;
-	int ret = 0;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-	return lwm2m_set_bool(&path, value);
-}
-
 int lwm2m_set_f64(const struct lwm2m_obj_path *path, const double value)
 {
 	return lwm2m_engine_set(path, &value, sizeof(double));
-}
-
-int lwm2m_engine_set_float(const char *pathstr, const double *value)
-{
-	struct lwm2m_obj_path path;
-	int ret = 0;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-	return lwm2m_set_f64(&path, *value);
 }
 
 int lwm2m_set_objlnk(const struct lwm2m_obj_path *path, const struct lwm2m_objlnk *value)
@@ -1003,33 +797,9 @@ int lwm2m_set_objlnk(const struct lwm2m_obj_path *path, const struct lwm2m_objln
 	return lwm2m_engine_set(path, value, sizeof(struct lwm2m_objlnk));
 }
 
-int lwm2m_engine_set_objlnk(const char *pathstr, const struct lwm2m_objlnk *value)
-{
-	struct lwm2m_obj_path path;
-	int ret = 0;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-	return lwm2m_set_objlnk(&path, value);
-}
-
 int lwm2m_set_time(const struct lwm2m_obj_path *path, time_t value)
 {
 	return lwm2m_engine_set(path, &value, sizeof(time_t));
-}
-
-int lwm2m_engine_set_time(const char *pathstr, time_t value)
-{
-	struct lwm2m_obj_path path;
-	int ret = 0;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-	return lwm2m_set_time(&path, value);
 }
 
 int lwm2m_set_res_data_len(const struct lwm2m_obj_path *path, uint16_t data_len)
@@ -1045,20 +815,6 @@ int lwm2m_set_res_data_len(const struct lwm2m_obj_path *path, uint16_t data_len)
 		return ret;
 	}
 	return lwm2m_set_res_buf(path, buffer_ptr, buffer_len, data_len, data_flags);
-}
-
-int lwm2m_engine_set_res_data_len(const char *pathstr, uint16_t data_len)
-{
-	struct lwm2m_obj_path path;
-	int ret = 0;
-
-	/* translate path -> path_obj */
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-
-	return lwm2m_set_res_data_len(&path, data_len);
 }
 /* User data getter functions */
 
@@ -1102,36 +858,6 @@ int lwm2m_get_res_buf(const struct lwm2m_obj_path *path, void **buffer_ptr, uint
 
 	k_mutex_unlock(&registry_lock);
 	return 0;
-}
-
-int lwm2m_engine_get_res_buf(const char *pathstr, void **buffer_ptr, uint16_t *buffer_len,
-			     uint16_t *data_len, uint8_t *data_flags)
-{
-	struct lwm2m_obj_path path;
-	int ret = 0;
-
-	/* translate path -> path_obj */
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-
-	return lwm2m_get_res_buf(&path, buffer_ptr, buffer_len, data_len, data_flags);
-}
-
-int lwm2m_engine_get_res_data(const char *pathstr, void **data_ptr, uint16_t *data_len,
-			      uint8_t *data_flags)
-{
-	struct lwm2m_obj_path path;
-	int ret = 0;
-
-	/* translate path -> path_obj */
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-
-	return lwm2m_get_res_buf(&path, data_ptr, NULL, data_len, data_flags);
 }
 
 static int lwm2m_engine_get(const struct lwm2m_obj_path *path, void *buf, uint16_t buflen)
@@ -1278,18 +1004,6 @@ int lwm2m_get_opaque(const struct lwm2m_obj_path *path, void *buf, uint16_t bufl
 	return lwm2m_engine_get(path, buf, buflen);
 }
 
-int lwm2m_engine_get_opaque(const char *pathstr, void *buf, uint16_t buflen)
-{
-	struct lwm2m_obj_path path;
-	int ret = 0;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-	return lwm2m_get_opaque(&path, buf, buflen);
-}
-
 int lwm2m_get_string(const struct lwm2m_obj_path *path, void *str, uint16_t buflen)
 {
 	/* Ensure termination, in case resource is not a string type */
@@ -1301,33 +1015,9 @@ int lwm2m_get_string(const struct lwm2m_obj_path *path, void *str, uint16_t bufl
 	return lwm2m_engine_get(path, str, buflen);
 }
 
-int lwm2m_engine_get_string(const char *pathstr, void *str, uint16_t buflen)
-{
-	struct lwm2m_obj_path path;
-	int ret = 0;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-	return lwm2m_get_string(&path, str, buflen);
-}
-
 int lwm2m_get_u8(const struct lwm2m_obj_path *path, uint8_t *value)
 {
 	return lwm2m_engine_get(path, value, 1);
-}
-
-int lwm2m_engine_get_u8(const char *pathstr, uint8_t *value)
-{
-	struct lwm2m_obj_path path;
-	int ret = 0;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-	return lwm2m_get_u8(&path, value);
 }
 
 int lwm2m_get_u16(const struct lwm2m_obj_path *path, uint16_t *value)
@@ -1335,33 +1025,9 @@ int lwm2m_get_u16(const struct lwm2m_obj_path *path, uint16_t *value)
 	return lwm2m_engine_get(path, value, 2);
 }
 
-int lwm2m_engine_get_u16(const char *pathstr, uint16_t *value)
-{
-	struct lwm2m_obj_path path;
-	int ret = 0;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-	return lwm2m_get_u16(&path, value);
-}
-
 int lwm2m_get_u32(const struct lwm2m_obj_path *path, uint32_t *value)
 {
 	return lwm2m_engine_get(path, value, 4);
-}
-
-int lwm2m_engine_get_u32(const char *pathstr, uint32_t *value)
-{
-	struct lwm2m_obj_path path;
-	int ret = 0;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-	return lwm2m_get_u32(&path, value);
 }
 
 int lwm2m_get_u64(const struct lwm2m_obj_path *path, uint64_t *value)
@@ -1369,33 +1035,9 @@ int lwm2m_get_u64(const struct lwm2m_obj_path *path, uint64_t *value)
 	return lwm2m_engine_get(path, value, 8);
 }
 
-int lwm2m_engine_get_u64(const char *pathstr, uint64_t *value)
-{
-	struct lwm2m_obj_path path;
-	int ret = 0;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-	return lwm2m_get_s64(&path, (int64_t *) value);
-}
-
 int lwm2m_get_s8(const struct lwm2m_obj_path *path, int8_t *value)
 {
 	return lwm2m_engine_get(path, value, 1);
-}
-
-int lwm2m_engine_get_s8(const char *pathstr, int8_t *value)
-{
-	struct lwm2m_obj_path path;
-	int ret = 0;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-	return lwm2m_get_s8(&path, value);
 }
 
 int lwm2m_get_s16(const struct lwm2m_obj_path *path, int16_t *value)
@@ -1403,50 +1045,14 @@ int lwm2m_get_s16(const struct lwm2m_obj_path *path, int16_t *value)
 	return lwm2m_engine_get(path, value, 2);
 }
 
-int lwm2m_engine_get_s16(const char *pathstr, int16_t *value)
-{
-	struct lwm2m_obj_path path;
-	int ret = 0;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-	return lwm2m_get_s16(&path, value);
-}
-
 int lwm2m_get_s32(const struct lwm2m_obj_path *path, int32_t *value)
 {
 	return lwm2m_engine_get(path, value, 4);
 }
 
-int lwm2m_engine_get_s32(const char *pathstr, int32_t *value)
-{
-	struct lwm2m_obj_path path;
-	int ret = 0;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-	return lwm2m_get_s32(&path, value);
-}
-
 int lwm2m_get_s64(const struct lwm2m_obj_path *path, int64_t *value)
 {
 	return lwm2m_engine_get(path, value, 8);
-}
-
-int lwm2m_engine_get_s64(const char *pathstr, int64_t *value)
-{
-	struct lwm2m_obj_path path;
-	int ret = 0;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-	return lwm2m_get_s64(&path, value);
 }
 
 int lwm2m_get_bool(const struct lwm2m_obj_path *path, bool *value)
@@ -1462,33 +1068,9 @@ int lwm2m_get_bool(const struct lwm2m_obj_path *path, bool *value)
 	return ret;
 }
 
-int lwm2m_engine_get_bool(const char *pathstr, bool *value)
-{
-	struct lwm2m_obj_path path;
-	int ret = 0;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-	return lwm2m_get_bool(&path, value);
-}
-
 int lwm2m_get_f64(const struct lwm2m_obj_path *path, double *value)
 {
 	return lwm2m_engine_get(path, value, sizeof(double));
-}
-
-int lwm2m_engine_get_float(const char *pathstr, double *buf)
-{
-	struct lwm2m_obj_path path;
-	int ret = 0;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-	return lwm2m_get_f64(&path, buf);
 }
 
 int lwm2m_get_objlnk(const struct lwm2m_obj_path *path, struct lwm2m_objlnk *buf)
@@ -1496,33 +1078,9 @@ int lwm2m_get_objlnk(const struct lwm2m_obj_path *path, struct lwm2m_objlnk *buf
 	return lwm2m_engine_get(path, buf, sizeof(struct lwm2m_objlnk));
 }
 
-int lwm2m_engine_get_objlnk(const char *pathstr, struct lwm2m_objlnk *buf)
-{
-	struct lwm2m_obj_path path;
-	int ret = 0;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-	return lwm2m_get_objlnk(&path, buf);
-}
-
 int lwm2m_get_time(const struct lwm2m_obj_path *path, time_t *buf)
 {
 	return lwm2m_engine_get(path, buf, sizeof(time_t));
-}
-
-int lwm2m_engine_get_time(const char *pathstr, time_t *buf)
-{
-	struct lwm2m_obj_path path;
-	int ret = 0;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-	return lwm2m_get_time(&path, buf);
 }
 
 int lwm2m_get_resource(const struct lwm2m_obj_path *path, struct lwm2m_engine_res **res)
@@ -1691,19 +1249,6 @@ int lwm2m_create_res_inst(const struct lwm2m_obj_path *path)
 	return lwm2m_engine_allocate_resource_instance(res, &res_inst, path->res_inst_id);
 }
 
-int lwm2m_engine_create_res_inst(const char *pathstr)
-{
-	int ret;
-	struct lwm2m_obj_path path;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-
-	return lwm2m_create_res_inst(&path);
-}
-
 int lwm2m_delete_res_inst(const struct lwm2m_obj_path *path)
 {
 	int ret;
@@ -1733,19 +1278,6 @@ int lwm2m_delete_res_inst(const struct lwm2m_obj_path *path)
 	k_mutex_unlock(&registry_lock);
 	return 0;
 }
-
-int lwm2m_engine_delete_res_inst(const char *pathstr)
-{
-	int ret;
-	struct lwm2m_obj_path path;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-
-	return lwm2m_delete_res_inst(&path);
-}
 /* Register callbacks */
 
 int lwm2m_register_read_callback(const struct lwm2m_obj_path *path, lwm2m_engine_get_data_cb_t cb)
@@ -1762,19 +1294,6 @@ int lwm2m_register_read_callback(const struct lwm2m_obj_path *path, lwm2m_engine
 	return 0;
 }
 
-int lwm2m_engine_register_read_callback(const char *pathstr, lwm2m_engine_get_data_cb_t cb)
-{
-	int ret;
-	struct lwm2m_obj_path path;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-
-	return lwm2m_register_read_callback(&path, cb);
-}
-
 int lwm2m_register_pre_write_callback(const struct lwm2m_obj_path *path,
 				      lwm2m_engine_get_data_cb_t cb)
 {
@@ -1788,19 +1307,6 @@ int lwm2m_register_pre_write_callback(const struct lwm2m_obj_path *path,
 
 	res->pre_write_cb = cb;
 	return 0;
-}
-
-int lwm2m_engine_register_pre_write_callback(const char *pathstr, lwm2m_engine_get_data_cb_t cb)
-{
-	int ret;
-	struct lwm2m_obj_path path;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-
-	return lwm2m_register_pre_write_callback(&path, cb);
 }
 
 int lwm2m_register_validate_callback(const struct lwm2m_obj_path *path,
@@ -1828,29 +1334,6 @@ int lwm2m_register_validate_callback(const struct lwm2m_obj_path *path,
 #endif /* CONFIG_LWM2M_ENGINE_VALIDATION_BUFFER_SIZE > 0 */
 }
 
-int lwm2m_engine_register_validate_callback(const char *pathstr, lwm2m_engine_set_data_cb_t cb)
-{
-#if CONFIG_LWM2M_ENGINE_VALIDATION_BUFFER_SIZE > 0
-	int ret;
-	struct lwm2m_obj_path path;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-
-	return lwm2m_register_validate_callback(&path, cb);
-#else
-	ARG_UNUSED(pathstr);
-	ARG_UNUSED(cb);
-
-	LOG_ERR("Validation disabled. Set "
-		"CONFIG_LWM2M_ENGINE_VALIDATION_BUFFER_SIZE > 0 to "
-		"enable validation support.");
-	return -ENOTSUP;
-#endif /* CONFIG_LWM2M_ENGINE_VALIDATION_BUFFER_SIZE > 0 */
-}
-
 int lwm2m_register_post_write_callback(const struct lwm2m_obj_path *path,
 				       lwm2m_engine_set_data_cb_t cb)
 {
@@ -1864,19 +1347,6 @@ int lwm2m_register_post_write_callback(const struct lwm2m_obj_path *path,
 
 	res->post_write_cb = cb;
 	return 0;
-}
-
-int lwm2m_engine_register_post_write_callback(const char *pathstr, lwm2m_engine_set_data_cb_t cb)
-{
-	int ret;
-	struct lwm2m_obj_path path;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-
-	return lwm2m_register_post_write_callback(&path, cb);
 }
 
 int lwm2m_register_exec_callback(const struct lwm2m_obj_path *path, lwm2m_engine_execute_cb_t cb)
@@ -1893,19 +1363,6 @@ int lwm2m_register_exec_callback(const struct lwm2m_obj_path *path, lwm2m_engine
 	return 0;
 }
 
-int lwm2m_engine_register_exec_callback(const char *pathstr, lwm2m_engine_execute_cb_t cb)
-{
-	int ret;
-	struct lwm2m_obj_path path;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-
-	return lwm2m_register_exec_callback(&path, cb);
-}
-
 int lwm2m_register_create_callback(uint16_t obj_id, lwm2m_engine_user_cb_t cb)
 {
 	struct lwm2m_engine_obj *obj = NULL;
@@ -1920,11 +1377,6 @@ int lwm2m_register_create_callback(uint16_t obj_id, lwm2m_engine_user_cb_t cb)
 	return 0;
 }
 
-int lwm2m_engine_register_create_callback(uint16_t obj_id, lwm2m_engine_user_cb_t cb)
-{
-	return lwm2m_register_create_callback(obj_id, cb);
-}
-
 int lwm2m_register_delete_callback(uint16_t obj_id, lwm2m_engine_user_cb_t cb)
 {
 	struct lwm2m_engine_obj *obj = NULL;
@@ -1937,11 +1389,6 @@ int lwm2m_register_delete_callback(uint16_t obj_id, lwm2m_engine_user_cb_t cb)
 
 	obj->user_delete_cb = cb;
 	return 0;
-}
-
-int lwm2m_engine_register_delete_callback(uint16_t obj_id, lwm2m_engine_user_cb_t cb)
-{
-	return lwm2m_register_delete_callback(obj_id, cb);
 }
 /* Generic data handlers */
 
@@ -2205,32 +1652,6 @@ int lwm2m_enable_cache(const struct lwm2m_obj_path *path, struct lwm2m_time_seri
 	ring_buf_init(&cache_entry->rb, cache_entry_size * cache_len, (uint8_t *)data_cache);
 
 	return 0;
-#else
-	LOG_ERR("LwM2M resource cache is only supported for "
-		"CONFIG_LWM2M_RESOURCE_DATA_CACHE_SUPPORT");
-	return -ENOTSUP;
-#endif /* CONFIG_LWM2M_RESOURCE_DATA_CACHE_SUPPORT */
-}
-
-int lwm2m_engine_enable_cache(const char *resource_path, struct lwm2m_time_series_elem *data_cache,
-			    size_t cache_len)
-{
-#if defined(CONFIG_LWM2M_RESOURCE_DATA_CACHE_SUPPORT)
-	struct lwm2m_obj_path path;
-	int ret;
-
-	/* translate path -> path_obj */
-	ret = lwm2m_string_to_path(resource_path, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-
-	if (path.level < LWM2M_PATH_LEVEL_RESOURCE) {
-		LOG_ERR("path must have at least 3 parts");
-		return -EINVAL;
-	}
-
-	return lwm2m_enable_cache(&path, data_cache, cache_len);
 #else
 	LOG_ERR("LwM2M resource cache is only supported for "
 		"CONFIG_LWM2M_RESOURCE_DATA_CACHE_SUPPORT");

--- a/subsys/net/lib/lwm2m/lwm2m_registry.c
+++ b/subsys/net/lib/lwm2m/lwm2m_registry.c
@@ -1093,19 +1093,6 @@ int lwm2m_get_resource(const struct lwm2m_obj_path *path, struct lwm2m_engine_re
 	return path_to_objs(path, NULL, NULL, res, NULL);
 }
 
-int lwm2m_engine_get_resource(const char *pathstr, struct lwm2m_engine_res **res)
-{
-	int ret;
-	struct lwm2m_obj_path path;
-
-	ret = lwm2m_string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
-	}
-
-	return lwm2m_get_resource(&path, res);
-}
-
 size_t lwm2m_engine_get_opaque_more(struct lwm2m_input_context *in, uint8_t *buf, size_t buflen,
 				    struct lwm2m_opaque_context *opaque, bool *last_block)
 {

--- a/subsys/net/lib/lwm2m/lwm2m_registry.h
+++ b/subsys/net/lib/lwm2m/lwm2m_registry.h
@@ -70,17 +70,6 @@ int lwm2m_engine_get_create_res_inst(const struct lwm2m_obj_path *path,
 				     struct lwm2m_engine_res_inst **res_inst);
 
 /**
- * @brief Gets the resource specified by @p pathstr.
- *
- * @deprecated Use lwm2m_get_resource() instead.
- *
- * @param[in] pathstr Path to resource (i.e 100/100/100/x, the fourth component is optional)
- * @param[out] res Engine resource buffer pointer.
- * @return 0 for success or negative in case of error.
- */
-int lwm2m_engine_get_resource(const char *pathstr, struct lwm2m_engine_res **res);
-
-/**
  * @brief Gets the resource specified by @p path.
  *
  * @param[in] path Path to resource (i.e 100/100/100/x, the fourth component is optional)

--- a/subsys/settings/include/settings/settings_file.h
+++ b/subsys/settings/include/settings/settings_file.h
@@ -32,11 +32,6 @@ int settings_file_dst(struct settings_file *cf);
 
 void settings_mount_file_backend(struct settings_file *cf);
 
-__deprecated static inline void settings_mount_fs_backend(struct settings_file *cf)
-{
-	settings_mount_file_backend(cf);
-}
-
 #ifdef __cplusplus
 }
 #endif

--- a/tests/net/lib/lwm2m/lwm2m_registry/src/lwm2m_registry.c
+++ b/tests/net/lib/lwm2m/lwm2m_registry/src/lwm2m_registry.c
@@ -410,110 +410,6 @@ ZTEST(lwm2m_registry, test_strings)
 	zassert_equal(ret, -ENOMEM);
 }
 
-#if CONFIG_TEST_DEPRECATED
-/* Don't test deprecated functions on Twister builds */
-ZTEST(lwm2m_registry, test_deprecated_functions)
-{
-	bool b = true;
-	uint8_t opaque[] = {0xde, 0xad, 0xbe, 0xff, 0, 0};
-	char string[] = "Hello";
-	uint8_t u8 = 8;
-	int8_t s8 = -8;
-	uint16_t u16 = 16;
-	int16_t s16 = -16;
-	uint32_t u32 = 32;
-	int32_t s32 = -32;
-	int64_t s64 = -64;
-	time_t t = 1687949519;
-	double d = 3.1415;
-	double d2;
-	struct lwm2m_objlnk objl = {.obj_id = 1, .obj_inst = 2};
-	uint16_t l = sizeof(opaque);
-
-	zassert_equal(lwm2m_engine_set_bool("32768/0/" STRINGIFY(LWM2M_RES_TYPE_BOOL), b), 0);
-	zassert_equal(
-		lwm2m_engine_set_opaque("32768/0/" STRINGIFY(LWM2M_RES_TYPE_OPAQUE), opaque, l), 0);
-	zassert_equal(lwm2m_engine_set_string("32768/0/" STRINGIFY(LWM2M_RES_TYPE_STRING), string),
-					      0);
-	zassert_equal(lwm2m_engine_set_u8("32768/0/" STRINGIFY(LWM2M_RES_TYPE_U8), u8), 0);
-	zassert_equal(lwm2m_engine_set_s8("32768/0/" STRINGIFY(LWM2M_RES_TYPE_S8), s8), 0);
-	zassert_equal(lwm2m_engine_set_u16("32768/0/" STRINGIFY(LWM2M_RES_TYPE_U16), u16), 0);
-	zassert_equal(lwm2m_engine_set_s16("32768/0/" STRINGIFY(LWM2M_RES_TYPE_S16), s16), 0);
-	zassert_equal(lwm2m_engine_set_u32("32768/0/" STRINGIFY(LWM2M_RES_TYPE_U32), u32), 0);
-	zassert_equal(lwm2m_engine_set_s32("32768/0/" STRINGIFY(LWM2M_RES_TYPE_S32), s32), 0);
-	zassert_equal(lwm2m_engine_set_s64("32768/0/" STRINGIFY(LWM2M_RES_TYPE_S64), s64), 0);
-	zassert_equal(lwm2m_engine_set_time("32768/0/" STRINGIFY(LWM2M_RES_TYPE_TIME), t), 0);
-	zassert_equal(lwm2m_engine_set_float("32768/0/" STRINGIFY(LWM2M_RES_TYPE_FLOAT), &d), 0);
-	zassert_equal(lwm2m_engine_set_objlnk("32768/0/" STRINGIFY(LWM2M_RES_TYPE_OBJLNK), &objl),
-					      0);
-	zassert_equal(lwm2m_engine_get_bool("32768/0/" STRINGIFY(LWM2M_RES_TYPE_BOOL), &b), 0);
-	zassert_equal(lwm2m_engine_get_opaque(
-		"32768/0/" STRINGIFY(LWM2M_RES_TYPE_OPAQUE), &opaque, l), 0);
-	zassert_equal(lwm2m_engine_get_string(
-		"32768/0/" STRINGIFY(LWM2M_RES_TYPE_STRING), &string, l), 0);
-	zassert_equal(lwm2m_engine_get_u8("32768/0/" STRINGIFY(LWM2M_RES_TYPE_U8), &u8), 0);
-	zassert_equal(lwm2m_engine_get_s8("32768/0/" STRINGIFY(LWM2M_RES_TYPE_S8), &s8), 0);
-	zassert_equal(lwm2m_engine_get_u16("32768/0/" STRINGIFY(LWM2M_RES_TYPE_U16), &u16), 0);
-	zassert_equal(lwm2m_engine_get_s16("32768/0/" STRINGIFY(LWM2M_RES_TYPE_S16), &s16), 0);
-	zassert_equal(lwm2m_engine_get_u32("32768/0/" STRINGIFY(LWM2M_RES_TYPE_U32), &u32), 0);
-	zassert_equal(lwm2m_engine_get_s32("32768/0/" STRINGIFY(LWM2M_RES_TYPE_S32), &s32), 0);
-	zassert_equal(lwm2m_engine_get_s64("32768/0/" STRINGIFY(LWM2M_RES_TYPE_S64), &s64), 0);
-	zassert_equal(lwm2m_engine_get_time("32768/0/" STRINGIFY(LWM2M_RES_TYPE_TIME), &t), 0);
-	zassert_equal(lwm2m_engine_get_float("32768/0/" STRINGIFY(LWM2M_RES_TYPE_FLOAT), &d2), 0);
-	zassert_equal(lwm2m_engine_get_objlnk("32768/0/" STRINGIFY(LWM2M_RES_TYPE_OBJLNK), &objl),
-					      0);
-
-	zassert_equal(b, true);
-	zassert_equal(memcmp(opaque, &(uint8_t[6]) {0xde, 0xad, 0xbe, 0xff, 0, 0}, l), 0);
-	zassert_str_equal(string, "Hello");
-	zassert_equal(u8, 8);
-	zassert_equal(s8, -8);
-	zassert_equal(u16, 16);
-	zassert_equal(s16, -16);
-	zassert_equal(u32, 32);
-	zassert_equal(s32, -32);
-	zassert_equal(s64, -64);
-	zassert_equal(t, 1687949519);
-	zassert_equal(d, d2);
-	zassert_equal(
-		memcmp(&objl, &(struct lwm2m_objlnk){.obj_id = 1, .obj_inst = 2}, sizeof(objl)), 0);
-
-	uint64_t u64 = 0xc0ffee;
-
-	zassert_equal(lwm2m_engine_set_u64("32768/0/" STRINGIFY(LWM2M_RES_TYPE_S64), u64), 0);
-	zassert_equal(lwm2m_engine_get_u64("32768/0/" STRINGIFY(LWM2M_RES_TYPE_S64), &u64), 0);
-	zassert_equal(u64, 0xc0ffee);
-
-	zassert_equal(lwm2m_engine_create_obj_inst("32768/1"), -ENOMEM);
-	zassert_equal(lwm2m_engine_delete_obj_inst("32768/1"), -ENOENT);
-
-	void *o_ptr;
-	uint16_t o_len;
-
-	lwm2m_get_res_buf(&LWM2M_OBJ(32768, 0, LWM2M_RES_TYPE_OPAQUE), &o_ptr, &o_len, NULL, NULL);
-
-	zassert_equal(lwm2m_engine_set_res_buf(
-		"32768/0/" STRINGIFY(LWM2M_RES_TYPE_OPAQUE), opaque, sizeof(opaque), 6, 0), 0);
-	void *p;
-	uint16_t len;
-
-	zassert_equal(lwm2m_engine_get_res_buf(
-		"32768/0/" STRINGIFY(LWM2M_RES_TYPE_OPAQUE), &p, NULL, &len, NULL), 0);
-	zassert_true(p == opaque);
-	zassert_equal(len, 6);
-
-	zassert_equal(lwm2m_engine_set_res_data(
-		"32768/0/" STRINGIFY(LWM2M_RES_TYPE_OPAQUE), string, sizeof(string), 0), 0);
-	lwm2m_engine_get_res_data("32768/0/" STRINGIFY(LWM2M_RES_TYPE_OPAQUE), &p, &len, NULL);
-	zassert_true(p == string);
-	zassert_equal(len, sizeof(string));
-	zassert_equal(lwm2m_engine_set_res_data_len("32768/0/" STRINGIFY(LWM2M_RES_TYPE_OPAQUE), 0),
-						    0);
-
-	lwm2m_set_res_buf(&LWM2M_OBJ(32768, 0, LWM2M_RES_TYPE_OPAQUE), o_ptr, o_len, 0, 0);
-}
-#endif
-
 ZTEST(lwm2m_registry, test_lock_unlock)
 {
 	/* Should be recursive mutex and should not block */
@@ -619,8 +515,6 @@ ZTEST(lwm2m_registry, test_resource_cache)
 	/* Resource cache is turned off */
 	zassert_is_null(lwm2m_cache_entry_get_by_object(&path));
 	zassert_equal(lwm2m_enable_cache(&path, &e, 1), -ENOTSUP);
-	/* deprecated */
-	/* zassert_equal(lwm2m_engine_enable_cache("32768/0/1", &e, 1), -ENOTSUP); */
 	zassert_false(lwm2m_cache_write(NULL, NULL));
 	zassert_false(lwm2m_cache_read(NULL, NULL));
 	zassert_equal(lwm2m_cache_size(NULL), 0);


### PR DESCRIPTION
Removed the following functions/symbols that have been marked as deprecated for more than 2 releases:

- `bt_le_whitelist_add`
- `JSON_TOK_LIST_START`
- `JSON_TOK_LIST_END`
- `lwm2m_engine_update_observer_min_period`
- `lwm2m_engine_update_observer_max_period`
- `lwm2m_engine_create_obj_inst`
- `lwm2m_engine_delete_obj_inst`
- `lwm2m_engine_set_opaque`
- `lwm2m_engine_set_string`
- `lwm2m_engine_set_u8`
- `lwm2m_engine_set_u16`
- `lwm2m_engine_set_u32`
- `lwm2m_engine_set_u64`
- `lwm2m_engine_set_s8`
- `lwm2m_engine_set_s16`
- `lwm2m_engine_set_s32`
- `lwm2m_engine_set_s64`
- `lwm2m_engine_set_bool`
- `lwm2m_engine_set_float`
- `lwm2m_engine_set_objlnk`
- `lwm2m_engine_set_time`
- `lwm2m_engine_get_opaque`
- `lwm2m_engine_get_string`
- `lwm2m_engine_get_u8`
- `lwm2m_engine_get_u16`
- `lwm2m_engine_get_u32`
- `lwm2m_engine_get_u64`
- `lwm2m_engine_get_s8`
- `lwm2m_engine_get_s16`
- `lwm2m_engine_get_s32`
- `lwm2m_engine_get_s64`
- `lwm2m_engine_get_bool`
- `lwm2m_engine_get_float`
- `lwm2m_engine_get_objlnk`
- `lwm2m_engine_get_time`
- `lwm2m_engine_register_read_callback`
- `lwm2m_engine_register_pre_write_callback`
- `lwm2m_engine_register_validate_callback`
- `lwm2m_engine_register_post_write_callback`
- `lwm2m_engine_register_exec_callback`
- `lwm2m_engine_register_create_callback`
- `lwm2m_engine_register_delete_callback`
- `lwm2m_engine_set_res_buf`
- `lwm2m_engine_set_res_data`
- `lwm2m_engine_set_res_data_len`
- `lwm2m_engine_get_res_buf`
- `lwm2m_engine_get_res_data`
- `lwm2m_engine_create_res_inst`
- `lwm2m_engine_delete_res_inst`
- `lwm2m_engine_path_is_observed`
- `LWM2M_RD_CLIENT_EVENT_REG_UPDATE_FAILURE`
- `lwm2m_engine_send`
- `lwm2m_send`
- `lwm2m_engine_enable_cache`
- `openthread_set_state_changed_cb`
- `zephyr_smp_rx_req`
- `zephyr_smp_alloc_rsp`
- `zephyr_smp_free_buf`
- `dns_sd_extract_service_proto_domain`
- `settings_mount_fs_backend`