### PR TITLE
tracing: trace sys_init calls

### DIFF
--- a/include/zephyr/tracing/tracing.h
+++ b/include/zephyr/tracing/tracing.h
@@ -2348,6 +2348,16 @@ void sys_trace_isr_exit_to_scheduler(void);
 void sys_trace_idle(void);
 #endif /* CONFIG_PERCEPIO_TRACERECORDER */
 
+/**
+ * @brief Called when entering an init function
+ */
+#define sys_trace_sys_init_enter(entry, level)
+
+/**
+ * @brief Called when exiting an init function
+ */
+#define sys_trace_sys_init_exit(entry, level, result)
+
 /** @} */ /* end of subsys_tracing_apis */
 
 /** @} */ /* end of subsys_tracing */

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -363,12 +363,15 @@ static void z_sys_init_run_level(enum init_level level)
 
 	for (entry = levels[level]; entry < levels[level+1]; entry++) {
 		const struct device *dev = entry->dev;
+		int result;
 
+		sys_trace_sys_init_enter(entry, level);
 		if (dev != NULL) {
-			do_device_init(entry);
+			result = do_device_init(entry);
 		} else {
-			(void)entry->init_fn.sys();
+			result = entry->init_fn.sys();
 		}
+		sys_trace_sys_init_exit(entry, level, result);
 	}
 }
 

--- a/subsys/tracing/ctf/tracing_ctf.h
+++ b/subsys/tracing/ctf/tracing_ctf.h
@@ -349,6 +349,9 @@ extern "C" {
 #define sys_port_trace_pm_device_runtime_disable_enter(dev)
 #define sys_port_trace_pm_device_runtime_disable_exit(dev, ret)
 
+#define sys_trace_sys_init_enter(...)
+#define sys_trace_sys_init_exit(...)
+
 void sys_trace_idle(void);
 void sys_trace_isr_enter(void);
 void sys_trace_isr_exit(void);

--- a/subsys/tracing/sysview/tracing_sysview.h
+++ b/subsys/tracing/sysview/tracing_sysview.h
@@ -675,6 +675,9 @@ void sys_trace_k_thread_info(struct k_thread *thread);
 	SEGGER_SYSVIEW_RecordEndCallU32(TID_PM_DEVICE_RUNTIME_DISABLE,	       \
 					(uint32_t)ret)
 
+#define sys_trace_sys_init_enter(...)
+#define sys_trace_sys_init_exit(...)
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/tracing/test/tracing_test.h
+++ b/subsys/tracing/test/tracing_test.h
@@ -732,4 +732,7 @@ void sys_trace_k_event_init(struct k_event *event);
 #define sys_port_trace_socket_socketpair_enter(family, type, proto, sv)
 #define sys_port_trace_socket_socketpair_exit(sockA, sockB, ret)
 
+#define sys_trace_sys_init_enter(...)
+#define sys_trace_sys_init_exit(...)
+
 #endif /* ZEPHYR_TRACE_TEST_H */

--- a/subsys/tracing/user/tracing_user.c
+++ b/subsys/tracing/user/tracing_user.c
@@ -7,6 +7,7 @@
 
 #include <tracing_user.h>
 #include <zephyr/kernel.h>
+#include <zephyr/init.h>
 
 void __weak sys_trace_thread_create_user(struct k_thread *thread) {}
 void __weak sys_trace_thread_abort_user(struct k_thread *thread) {}
@@ -22,6 +23,8 @@ void __weak sys_trace_thread_priority_set_user(struct k_thread *thread, int prio
 void __weak sys_trace_isr_enter_user(void) {}
 void __weak sys_trace_isr_exit_user(void) {}
 void __weak sys_trace_idle_user(void) {}
+void __weak sys_trace_sys_init_enter_user(const struct init_entry *entry, int level) {}
+void __weak sys_trace_sys_init_exit_user(const struct init_entry *entry, int level, int result) {}
 
 void sys_trace_thread_create(struct k_thread *thread)
 {
@@ -91,4 +94,14 @@ void sys_trace_isr_exit(void)
 void sys_trace_idle(void)
 {
 	sys_trace_idle_user();
+}
+
+void sys_trace_sys_init_enter(const struct init_entry *entry, int level)
+{
+	sys_trace_sys_init_enter_user(entry, level);
+}
+
+void sys_trace_sys_init_exit(const struct init_entry *entry, int level, int result)
+{
+	sys_trace_sys_init_exit_user(entry, level, result);
 }

--- a/subsys/tracing/user/tracing_user.h
+++ b/subsys/tracing/user/tracing_user.h
@@ -8,6 +8,7 @@
 #ifndef _TRACE_USER_H
 #define _TRACE_USER_H
 #include <zephyr/kernel.h>
+#include <zephyr/init.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -27,6 +28,8 @@ void sys_trace_thread_pend_user(struct k_thread *thread);
 void sys_trace_isr_enter_user(void);
 void sys_trace_isr_exit_user(void);
 void sys_trace_idle_user(void);
+void sys_trace_sys_init_enter_user(const struct init_entry *entry, int level);
+void sys_trace_sys_init_exit_user(const struct init_entry *entry, int level, int result);
 
 void sys_trace_thread_create(struct k_thread *thread);
 void sys_trace_thread_abort(struct k_thread *thread);
@@ -42,6 +45,8 @@ void sys_trace_thread_pend(struct k_thread *thread);
 void sys_trace_isr_enter(void);
 void sys_trace_isr_exit(void);
 void sys_trace_idle(void);
+void sys_trace_sys_init_enter(const struct init_entry *entry, int level);
+void sys_trace_sys_init_exit(const struct init_entry *entry, int level, int result);
 
 #define sys_port_trace_k_thread_foreach_enter()
 #define sys_port_trace_k_thread_foreach_exit()


### PR DESCRIPTION
The init functions has `int` as return type, but currently there is no way to know the result of the `SYS_INIT`s.

This PR creates additional tracing APIs to trace the enter and (exit + result) of SYS_INIT and DEVICE_DT_DEFINE (and friends), which can be useful to debug things.