### PR TITLE
doc: usb: fixup and document USB message notifications 

### DIFF
--- a/doc/connectivity/usb/device_next/api/index.rst
+++ b/doc/connectivity/usb/device_next/api/index.rst
@@ -10,3 +10,4 @@ New USB device support APIs
    usbd.rst
    usbd_hid_device.rst
    uac2_device.rst
+   usbd_msc_device.rst

--- a/doc/connectivity/usb/device_next/api/usbd.rst
+++ b/doc/connectivity/usb/device_next/api/usbd.rst
@@ -9,3 +9,5 @@ API reference
 *************
 
 .. doxygengroup:: usbd_api
+
+.. doxygengroup:: usbd_msg_api

--- a/doc/connectivity/usb/device_next/api/usbd_msc_device.rst
+++ b/doc/connectivity/usb/device_next/api/usbd_msc_device.rst
@@ -1,0 +1,12 @@
+.. _usbd_msc_device:
+
+USB Mass Storage Class device API
+#################################
+
+USB Mass Storage Class device API defined in
+:zephyr_file:`include/zephyr/usb/class/usbd_msc.h`.
+
+API Reference
+*************
+
+.. doxygengroup:: usbd_msc_device

--- a/doc/connectivity/usb/device_next/usb_device.rst
+++ b/doc/connectivity/usb/device_next/usb_device.rst
@@ -41,7 +41,7 @@ instance (`n`) and is used as an argument to the :c:func:`usbd_register_class`.
 +-----------------------------------+-------------------------+-------------------------+
 | USB CDC ECM class                 | Ethernet device         | :samp:`cdc_ecm_{n}`     |
 +-----------------------------------+-------------------------+-------------------------+
-| USB Mass Storage Class (MSC)      | :ref:`disk_access_api`  | :samp:`msc_{n}`         |
+| USB Mass Storage Class (MSC)      | :ref:`usbd_msc_device`  | :samp:`msc_{n}`         |
 +-----------------------------------+-------------------------+-------------------------+
 | USB Human Interface Devices (HID) | :ref:`usbd_hid_device`  | :samp:`hid_{n}`         |
 +-----------------------------------+-------------------------+-------------------------+

--- a/doc/connectivity/usb/device_next/usb_device.rst
+++ b/doc/connectivity/usb/device_next/usb_device.rst
@@ -30,22 +30,22 @@ The USB device stack has built-in USB functions. Some can be used directly in
 the user application through a special API, such as HID or Audio class devices,
 while others use a general Zephyr RTOS driver API, such as MSC and CDC class
 implementations. The *Identification string* identifies a class or function
-instance (n) and is used as an argument to the :c:func:`usbd_register_class`.
+instance (`n`) and is used as an argument to the :c:func:`usbd_register_class`.
 
 +-----------------------------------+-------------------------+-------------------------+
 | Class or function                 | User API (if any)       | Identification string   |
 +===================================+=========================+=========================+
-| USB Audio 2 class                 | :ref:`uac2_device`      | uac2_(n)                |
+| USB Audio 2 class                 | :ref:`uac2_device`      | :samp:`uac2_{n}`        |
 +-----------------------------------+-------------------------+-------------------------+
-| USB CDC ACM class                 | :ref:`uart_api`         | cdc_acm_(n)             |
+| USB CDC ACM class                 | :ref:`uart_api`         | :samp:`cdc_acm_{n}`     |
 +-----------------------------------+-------------------------+-------------------------+
-| USB CDC ECM class                 | Ethernet device         | cdc_ecm_(n)             |
+| USB CDC ECM class                 | Ethernet device         | :samp:`cdc_ecm_{n}`     |
 +-----------------------------------+-------------------------+-------------------------+
-| USB Mass Storage Class (MSC)      | :ref:`disk_access_api`  | msc_(n)                 |
+| USB Mass Storage Class (MSC)      | :ref:`disk_access_api`  | :samp:`msc_{n}`         |
 +-----------------------------------+-------------------------+-------------------------+
-| USB Human Interface Devices (HID) | :ref:`usbd_hid_device`  | hid_(n)                 |
+| USB Human Interface Devices (HID) | :ref:`usbd_hid_device`  | :samp:`hid_{n}`         |
 +-----------------------------------+-------------------------+-------------------------+
-| Bluetooth HCI USB transport layer | :ref:`bt_hci_raw`       | bt_hci_(n)              |
+| Bluetooth HCI USB transport layer | :ref:`bt_hci_raw`       | :samp:`bt_hci_{n}`      |
 +-----------------------------------+-------------------------+-------------------------+
 
 Samples
@@ -99,6 +99,7 @@ must not be directly accessed or manipulated by the application.
 
 .. literalinclude:: ../../../../samples/subsys/usb/common/sample_usbd_init.c
    :language: c
+   :dedent:
    :start-after: doc device instantiation start
    :end-before: doc device instantiation end
 
@@ -112,6 +113,7 @@ require a single instantiation of the language descriptor using the
 
 .. literalinclude:: ../../../../samples/subsys/usb/common/sample_usbd_init.c
    :language: c
+   :dedent:
    :start-after: doc string instantiation start
    :end-before: doc string instantiation end
 
@@ -120,6 +122,7 @@ initializing the USB device with :c:func:`usbd_add_descriptor`.
 
 .. literalinclude:: ../../../../samples/subsys/usb/common/sample_usbd_init.c
    :language: c
+   :dedent:
    :start-after: doc add string descriptor start
    :end-before: doc add string descriptor end
 
@@ -129,6 +132,7 @@ a configuration. Later, USB device functions are assigned to a configuration.
 
 .. literalinclude:: ../../../../samples/subsys/usb/common/sample_usbd_init.c
    :language: c
+   :dedent:
    :start-after: doc configuration instantiation start
    :end-before: doc configuration instantiation end
 
@@ -140,6 +144,7 @@ configuration will get ``bConfigurationValue`` one, and then further upward.
 
 .. literalinclude:: ../../../../samples/subsys/usb/common/sample_usbd_init.c
    :language: c
+   :dedent:
    :start-after: doc configuration register start
    :end-before: doc configuration register end
 
@@ -155,6 +160,7 @@ instances.
 
 .. literalinclude:: ../../../../samples/subsys/usb/common/sample_usbd_init.c
    :language: c
+   :dedent:
    :start-after: doc functions register start
    :end-before: doc functions register end
 
@@ -173,6 +179,7 @@ steps, which should be performed prior to initializing the USB device.
 
 .. literalinclude:: ../../../../samples/subsys/usb/common/sample_usbd_init.c
    :language: c
+   :dedent:
    :start-after: doc device init start
    :end-before: doc device init end
 
@@ -183,5 +190,6 @@ enumerating the device. The application can disable the USB device using
 
 .. literalinclude:: ../../../../samples/subsys/usb/hid-keyboard/src/main.c
    :language: c
+   :dedent:
    :start-after: doc device enable start
    :end-before: doc device enable end

--- a/doc/connectivity/usb/device_next/usb_device.rst
+++ b/doc/connectivity/usb/device_next/usb_device.rst
@@ -193,3 +193,31 @@ enumerating the device. The application can disable the USB device using
    :dedent:
    :start-after: doc device enable start
    :end-before: doc device enable end
+
+USB Message notifications
+=========================
+
+The application can register a callback using :c:func:`usbd_msg_register_cb` to
+receive message notification from the USB device support subsystem. The
+messages are mostly about the common device state changes, and a few specific
+types from the USB CDC ACM implementation.
+
+.. literalinclude:: ../../../../samples/subsys/usb/common/sample_usbd_init.c
+   :language: c
+   :dedent:
+   :start-after: doc device init-and-msg start
+   :end-before: doc device init-and-msg end
+
+The helper function :c:func:`usbd_msg_type_string()` can be used to convert
+:c:enumerator:`usbd_msg_type` to a human readable form for logging.
+
+If the controller supports VBUS state change detection, the battery-powered
+application may want to enable the USB device only when it is connected to a
+host. A generic application should use :c:func:`usbd_can_detect_vbus` to check
+for this capability.
+
+.. literalinclude:: ../../../../samples/subsys/usb/hid-keyboard/src/main.c
+   :language: c
+   :dedent:
+   :start-after: doc device msg-cb start
+   :end-before: doc device msg-cb end

--- a/include/zephyr/usb/class/usbd_msc.h
+++ b/include/zephyr/usb/class/usbd_msc.h
@@ -23,6 +23,25 @@ struct usbd_msc_lun {
 	const char *revision;
 };
 
+/**
+ * @brief USB Mass Storage Class device API
+ * @defgroup usbd_msc_device USB Mass Storage Class device API
+ * @ingroup usb
+ * @{
+ */
+
+/**
+ * @brief Define USB Mass Storage Class logical unit
+ *
+ * Use this macro to create Logical Unit mapping in USB MSC for selected disk.
+ * Up to `CONFIG_USBD_MSC_LUNS_PER_INSTANCE` disks can be registered on single
+ * USB MSC instance. Currently only one USB MSC instance is supported.
+ *
+ * @param disk_name Disk name as used in @ref disk_access_interface
+ * @param t10_vendor T10 Vendor Indetification
+ * @param t10_product T10 Product Identification
+ * @param t10_revision T10 Product Revision Level
+ */
 #define USBD_DEFINE_MSC_LUN(disk_name, t10_vendor, t10_product, t10_revision)	\
 	STRUCT_SECTION_ITERABLE(usbd_msc_lun, usbd_msc_lun_##disk_name) = {	\
 		.disk = STRINGIFY(disk_name),					\
@@ -30,5 +49,9 @@ struct usbd_msc_lun {
 		.product = t10_product,						\
 		.revision = t10_revision,					\
 	}
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_INCLUDE_USB_CLASS_USBD_MSC_H_ */

--- a/include/zephyr/usb/usbd_msg.h
+++ b/include/zephyr/usb/usbd_msg.h
@@ -52,7 +52,9 @@ enum usbd_msg_type {
 	USBD_MSG_MAX_NUMBER,
 };
 
-
+/**
+ * @cond INTERNAL_HIDDEN
+ */
 static const char *const usbd_msg_type_list[] = {
 	"VBUS ready",
 	"VBUS removed",
@@ -67,6 +69,7 @@ static const char *const usbd_msg_type_list[] = {
 
 BUILD_ASSERT(ARRAY_SIZE(usbd_msg_type_list) == USBD_MSG_MAX_NUMBER,
 	     "Number of entries in usbd_msg_type_list is not equal to USBD_MSG_MAX_NUMBER");
+/** @endcond */
 
 /**
  * @brief USB device message

--- a/samples/subsys/usb/common/sample_usbd_init.c
+++ b/samples/subsys/usb/common/sample_usbd_init.c
@@ -148,15 +148,15 @@ struct usbd_context *sample_usbd_init_device(usbd_msg_cb_t msg_cb)
 
 	sample_fix_code_triple(&sample_usbd, USBD_SPEED_FS);
 
-	/* doc message callback register start */
 	if (msg_cb != NULL) {
+		/* doc device init-and-msg start */
 		err = usbd_msg_register_cb(&sample_usbd, msg_cb);
 		if (err) {
 			LOG_ERR("Failed to register message callback");
 			return NULL;
 		}
+		/* doc device init-and-msg end */
 	}
-	/* doc message callback register end */
 
 	if (IS_ENABLED(CONFIG_SAMPLE_USBD_20_EXTENSION_DESC)) {
 		(void)usbd_device_set_bcd(&sample_usbd, USBD_SPEED_FS, 0x0201);

--- a/samples/subsys/usb/hid-keyboard/src/main.c
+++ b/samples/subsys/usb/hid-keyboard/src/main.c
@@ -141,6 +141,28 @@ struct hid_device_ops kb_ops = {
 	.output_report = kb_output_report,
 };
 
+/* doc device msg-cb start */
+static void msg_cb(struct usbd_context *const usbd_ctx,
+		   const struct usbd_msg *const msg)
+{
+	LOG_INF("USBD message: %s", usbd_msg_type_string(msg->type));
+
+	if (usbd_can_detect_vbus(usbd_ctx)) {
+		if (msg->type == USBD_MSG_VBUS_READY) {
+			if (usbd_enable(usbd_ctx)) {
+				LOG_ERR("Failed to enable device support");
+			}
+		}
+
+		if (msg->type == USBD_MSG_VBUS_REMOVED) {
+			if (usbd_disable(usbd_ctx)) {
+				LOG_ERR("Failed to disable device support");
+			}
+		}
+	}
+}
+/* doc device msg-cb end */
+
 int main(void)
 {
 	struct usbd_context *sample_usbd;
@@ -178,19 +200,21 @@ int main(void)
 		return ret;
 	}
 
-	sample_usbd = sample_usbd_init_device(NULL);
+	sample_usbd = sample_usbd_init_device(msg_cb);
 	if (sample_usbd == NULL) {
 		LOG_ERR("Failed to initialize USB device");
 		return -ENODEV;
 	}
 
-	/* doc device enable start */
-	ret = usbd_enable(sample_usbd);
-	if (ret) {
-		LOG_ERR("Failed to enable device support");
-		return ret;
+	if (!usbd_can_detect_vbus(sample_usbd)) {
+		/* doc device enable start */
+		ret = usbd_enable(sample_usbd);
+		if (ret) {
+			LOG_ERR("Failed to enable device support");
+			return ret;
+		}
+		/* doc device enable end */
 	}
-	/* doc device enable end */
 
 	LOG_INF("HID keyboard sample is initialized");
 


### PR DESCRIPTION
Make example code most left-aligned.
Also use :samp: to format identification strings in the table.
Followup on commit https://github.com/zephyrproject-rtos/zephyr/commit/8739efe0fc603dc8e413c8006f1ecb6044330351
("doc: usb: add initial USB device configuraiton howto").

Add doxygen group with MSC device API and document macro to create
mapping between disk access and MSC LUN.

Add documentation about USB message notifications.