### PR TITLE
tests: settings: functional: file: add native_sim/native/64 overlay

### DIFF
--- a/tests/subsys/settings/functional/file/native_sim_native_64.overlay
+++ b/tests/subsys/settings/functional/file/native_sim_native_64.overlay
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2019 Jan Van Winkel <jan.van_winkel@dxplore.eu>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &storage_partition;
+/delete-node/ &scratch_partition;
+
+&flash0 {
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		storage_partition: partition@70000 {
+			label = "storage";
+			reg = <0x00070000 0x20000>;
+		};
+	};
+};


### PR DESCRIPTION
In 0be0d2175bd (cmake: modules: extensions: Revert using common board files), the overlay for `native_sim/native/64` in the settings functional file test was not recreated. Duplicate the overlay used for the `native_sim` target to support this test correctly.