### PR TITLE
doc: release-notes: display release notes for 3.7

### DIFF
--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -523,6 +523,11 @@ Display
         };
     };
 
+* The ``orientation-flipped`` property has been removed from the SSD16XX
+  display driver, as the driver now supports display rotation. Users should
+  drop this property from their devicetree, and set orientation at runtime
+  via :c:func:`display_set_orientation` (:github:`73360`)
+
 Enhanced Serial Peripheral Interface (eSPI)
 ===========================================
 

--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -302,6 +302,27 @@ Drivers and Sensors
 
 * Display
 
+  * All in tree displays capable of supporting the :ref:`mipi_dbi_api` have
+    been converted to use it. GC9X01X, UC81XX, SSD16XX, ST7789V, ST7735R based
+    displays have been converted to this API. Boards using these displays will
+    need their devicetree updated, see the display section of
+    :ref:`migration_3.7` for examples of this process.
+  * Added driver for ST7796S display controller (:dtcompatible:`sitronix,st7796s`)
+  * Added support for :c:func:`display_read` API to ILI9XXX display driver,
+    which can be enabled with :kconfig:option:`CONFIG_ILI9XXX_READ`
+  * Added support for :c:func:`display_set_orientation` API to SSD16XXX
+    display driver
+  * Added driver for NT35510 MIPI-DSI display controller
+    (:dtcompatible:`frida,nt35510`)
+  * Added driver to abstract LED strip devices as displays
+    (:dtcompatible:`led-strip-matrix`)
+  * Added support for :c:func:`display_set_pixel_format` API to NXP eLCDIF
+    driver. ARGB8888, RGB888, and BGR565 formats are supported.
+  * Added support for inverting color at runtime to the SSD1306 driver, via
+    the :c:func:`display_set_pixel_format` API.
+  * Inversion mode can now be disabled in the ST7789V driver
+    (:dtcompatible:`sitronix,st7789v`) using the ``inversion-off`` property.
+
 * DMA
 
 * Entropy


### PR DESCRIPTION
Add display release notes for 3.7, as well as an update to the migration guide for the ssd16xx display controller (as a DT property was dropped)