### PR TITLE
sensor: lm75: fix: Enforce dependency of int-gpios with Trigger feature

### DIFF
--- a/drivers/sensor/lm75/Kconfig
+++ b/drivers/sensor/lm75/Kconfig
@@ -25,6 +25,7 @@ config LM75_TRIGGER_NONE
 
 config LM75_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_LM75),int-gpios)
 	depends on GPIO
 	select LM75_TRIGGER
 

--- a/drivers/sensor/lm75/lm75.c
+++ b/drivers/sensor/lm75/lm75.c
@@ -346,13 +346,17 @@ int lm75_init(const struct device *dev)
 	}
 
 #if LM75_TRIGGER_SUPPORT
-	data->dev = dev;
-	k_work_queue_start(&data->workq, data->stack, K_THREAD_STACK_SIZEOF(data->stack),
-			   CONFIG_LM75_TRIGGER_THREAD_PRIO, NULL);
-	k_thread_name_set(&data->workq.thread, "lm75_trigger");
-	k_work_init(&data->work, lm75_trigger_work_handler);
-
+	/** Even if Trigger support is enabled, there may be multiple
+	 * instances. This handles those who may not have Trigger support.
+	 */
 	if (cfg->int_gpio.port != NULL) {
+
+		data->dev = dev;
+		k_work_queue_start(&data->workq, data->stack, K_THREAD_STACK_SIZEOF(data->stack),
+				CONFIG_LM75_TRIGGER_THREAD_PRIO, NULL);
+		k_thread_name_set(&data->workq.thread, "lm75_trigger");
+		k_work_init(&data->work, lm75_trigger_work_handler);
+
 		if (!device_is_ready(cfg->int_gpio.port)) {
 			LOG_ERR("INT GPIO not ready");
 			return -EINVAL;


### PR DESCRIPTION
### Description
Fixing points brought up on #57586.

### Details
As pointed out on #57586: `LM75_TRIGGER_GLOBAL_THREAD` can't be enabled without the int-gpios being present in the DTS node. This commit requires at least one LM75 instance featuring it, otherwise it won't work.

### Testing
Ran locally:
``` console
twister -p native_sim -T tests/drivers/build_all/sensor
```
Confirm that by removing `int-gpios` property, LM75 Trigger setting defaults to `CONFIG_LM75_TRIGGER_NONE`.