### PR TITLE
dts: arm: nxp: lpc55s1x: add usbphy1 devicetree node

### DIFF
--- a/boards/nxp/lpcxpresso55s16/lpcxpresso55s16.dts
+++ b/boards/nxp/lpcxpresso55s16/lpcxpresso55s16.dts
@@ -26,4 +26,12 @@
 
 zephyr_udc0: &usbhs {
 	status = "okay";
+	phy_handle = <&usbphy1>;
+};
+
+&usbphy1 {
+	status = "okay";
+	tx-d-cal = <5>;
+	tx-cal-45-dp-ohms = <10>;
+	tx-cal-45-dm-ohms = <10>;
 };

--- a/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
@@ -266,6 +266,12 @@
 		num-bidir-endpoints = <6>;
 		status = "disabled";
 	};
+
+	usbphy1: usbphy@38000 {
+		compatible = "nxp,usbphy";
+		reg = <0x38000 0x1000>;
+		status = "disabled";
+	};
 };
 
 &nvic {


### PR DESCRIPTION
Add devicetree node for the USB1 High Speed PHY present in the NXP LPC55S1x
series.

Fixes: #74605

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>