### PR TITLE
dts: arm: nxp: fix clock name for FTM nodes

### DIFF
--- a/dts/arm/nxp/nxp_s32k1xx.dtsi
+++ b/dts/arm/nxp/nxp_s32k1xx.dtsi
@@ -243,7 +243,7 @@
 			reg = <0x40038000 0x1000>;
 			interrupts = <99 0>, <100 0>, <101 0>, <102 0>, <104 0>;
 			interrupt-names = "0-1", "2-3", "4-5", "6-7", "overflow";
-			clocks = <&clock NXP_S32_FTM0_CLK>;
+			clocks = <&clock NXP_S32_CORE_CLK>;
 			prescaler = <1>;
 			status = "disabled";
 		};
@@ -253,7 +253,7 @@
 			reg = <0x40039000 0x1000>;
 			interrupts = <105 0>, <106 0>, <107 0>, <108 0>, <110 0>;
 			interrupt-names = "0-1", "2-3", "4-5", "6-7", "overflow";
-			clocks = <&clock NXP_S32_FTM1_CLK>;
+			clocks = <&clock NXP_S32_CORE_CLK>;
 			prescaler = <1>;
 			status = "disabled";
 		};
@@ -263,7 +263,7 @@
 			reg = <0x4003a000 0x1000>;
 			interrupts = <111 0>, <112 0>, <113 0>, <114 0>, <116 0>;
 			interrupt-names = "0-1", "2-3", "4-5", "6-7", "overflow";
-			clocks = <&clock NXP_S32_FTM2_CLK>;
+			clocks = <&clock NXP_S32_CORE_CLK>;
 			prescaler = <1>;
 			status = "disabled";
 		};
@@ -273,7 +273,7 @@
 			reg = <0x40026000 0x1000>;
 			interrupts = <117 0>, <118 0>, <119 0>, <120 0>, <122 0>;
 			interrupt-names = "0-1", "2-3", "4-5", "6-7", "overflow";
-			clocks = <&clock NXP_S32_FTM3_CLK>;
+			clocks = <&clock NXP_S32_CORE_CLK>;
 			prescaler = <1>;
 			status = "disabled";
 		};
@@ -283,7 +283,7 @@
 			reg = <0x4006e000 0x1000>;
 			interrupts = <123 0>, <124 0>, <125 0>, <126 0>, <128 0>;
 			interrupt-names = "0-1", "2-3", "4-5", "6-7", "overflow";
-			clocks = <&clock NXP_S32_FTM4_CLK>;
+			clocks = <&clock NXP_S32_CORE_CLK>;
 			prescaler = <1>;
 			status = "disabled";
 		};
@@ -293,7 +293,7 @@
 			reg = <0x4006f000 0x1000>;
 			interrupts = <129 0>, <130 0>, <131 0>, <132 0>, <134 0>;
 			interrupt-names = "0-1", "2-3", "4-5", "6-7", "overflow";
-			clocks = <&clock NXP_S32_FTM5_CLK>;
+			clocks = <&clock NXP_S32_CORE_CLK>;
 			prescaler = <1>;
 			status = "disabled";
 		};
@@ -303,6 +303,7 @@
 			reg = <0x40070000 0x1000>;
 			interrupts = <135 0>, <136 0>, <137 0>, <138 0>, <140 0>;
 			interrupt-names = "0-1", "2-3", "4-5", "6-7", "overflow";
+			clocks = <&clock NXP_S32_CORE_CLK>;
 			prescaler = <1>;
 			status = "disabled";
 		};
@@ -312,6 +313,7 @@
 			reg = <0x40071000 0x1000>;
 			interrupts = <141 0>, <142 0>, <143 0>, <144 0>, <146 0>;
 			interrupt-names = "0-1", "2-3", "4-5", "6-7", "overflow";
+			clocks = <&clock NXP_S32_CORE_CLK>;
 			prescaler = <1>;
 			status = "disabled";
 		};


### PR DESCRIPTION
Clock `NXP_S32_FTMx_CLK` reference the output of PCC FTM clock, but FTM has an internal clock mux to select the clock source of the counter, which for `ucans32k1sic` board is set to system clock. Fix the clock nodes to use the correct clock name. So far this was working because both `NXP_S32_FTMx_CLK` and `NXP_S32_CORE_CLK` are configured to the same frequency.

Fixes #74348

```
west twister -p ucans32k1sic --device-testing --device-serial=/dev/ttyUSB_ucans32k1sic  --fixture pwm_loopback   -T tests/drivers/pwm  -T samples/drivers/led_pwm/  -T samples/basic/blinky_pwm/  -T samples/basic/fade_led/  -T samples/basic/rgb_led/ 

INFO    - Zephyr version: v3.7.0-rc1-1-gf893cd7766eb
INFO    - Using 'zephyr' toolchain.

INFO    - Total complete:    6/   6  100%  skipped:    1, failed:    0, error:    0
INFO    - 6 test scenarios (6 test instances) selected, 1 configurations skipped (1 by static filter, 0 at runtime).
INFO    - 5 of 6 test configurations passed (100.00%), 0 failed, 0 errored, 1 skipped with 0 warnings in 96.95 seconds
INFO    - In total 12 test cases were executed, 2 skipped on 1 out of total 1 platforms (100.00%)
INFO    - 5 test configurations executed on platforms, 0 test configurations were only built.
```