### PR TITLE
Fix mspi post RFC

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1516,10 +1516,15 @@ Release Notes:
     - swift-tk
   files:
     - drivers/mspi/
+    - drivers/memc/*mspi*
+    - drivers/flash/*mspi*
     - include/zephyr/drivers/mspi.h
     - include/zephyr/drivers/mspi/
+    - samples/drivers/mspi/
     - tests/drivers/mspi/
     - doc/hardware/peripherals/mspi.rst
+    - dts/bindings/mspi/
+    - dts/bindings/mtd/mspi*
   labels:
     - "area: MSPI"
   tests:

--- a/drivers/flash/Kconfig.mspi
+++ b/drivers/flash/Kconfig.mspi
@@ -1,21 +1,20 @@
 # Copyright (c) 2024 Ambiq Micro Inc. <www.ambiq.com>
 # SPDX-License-Identifier: Apache-2.0
 
+menu "MSPI flash device driver"
+
 config FLASH_MSPI
-	bool "MSPI flash drivers"
-	default y
-	depends on FLASH
+	bool
 	select FLASH_HAS_DRIVER_ENABLED
 	select MSPI
-
-if FLASH_MSPI
-
-menu "MSPI flash driver"
+	help
+	  MSPI flash drivers are enabled.
 
 config FLASH_MSPI_EMUL_DEVICE
 	bool "MSPI flash device emulator"
 	default y
 	depends on DT_HAS_ZEPHYR_MSPI_EMUL_FLASH_ENABLED
+	select FLASH_MSPI
 	select FLASH_HAS_PAGE_LAYOUT
 	select FLASH_HAS_EXPLICIT_ERASE
 
@@ -23,11 +22,10 @@ config FLASH_MSPI_ATXP032
 	bool "MSPI ATXP032 driver"
 	default y
 	depends on DT_HAS_MSPI_ATXP032_ENABLED
+	select FLASH_MSPI
 	select FLASH_HAS_PAGE_LAYOUT
 	select FLASH_HAS_EXPLICIT_ERASE
 	select FLASH_JESD216
 	select MSPI_AMBIQ_AP3 if SOC_SERIES_APOLLO3X
 
 endmenu
-
-endif # FLASH_MSPI

--- a/drivers/memc/Kconfig.mspi
+++ b/drivers/memc/Kconfig.mspi
@@ -1,22 +1,19 @@
 # Copyright (c) 2024, Ambiq Micro Inc. <www.ambiq.com>
 # SPDX-License-Identifier: Apache-2.0
 
+menu "MSPI MEMC device driver"
+
 config MEMC_MSPI
-	bool "MSPI memory controller drivers"
-	default y
-	depends on MEMC
+	bool
 	select MSPI
-
-if MEMC_MSPI
-
-menu "MSPI memory controller driver"
+	help
+	  MSPI MEMC drivers are enabled.
 
 config MEMC_MSPI_APS6404L
 	bool "MSPI AP Memory APS6404L pSRAM driver"
 	default y
 	depends on DT_HAS_MSPI_APS6404L_ENABLED
+	select MEMC_MSPI
 	select MSPI_AMBIQ_AP3 if SOC_SERIES_APOLLO3X
 
 endmenu
-
-endif # MEMC_MSPI

--- a/dts/bindings/mspi/ambiq,mspi-device.yaml
+++ b/dts/bindings/mspi/ambiq,mspi-device.yaml
@@ -3,6 +3,8 @@
 
 description: Ambiq MSPI device
 
+compatible: "ambiq,mspi-device"
+
 include: [mspi-device.yaml, "jedec,jesd216.yaml"]
 
 properties:

--- a/dts/bindings/mtd/mspi-aps6404l.yaml
+++ b/dts/bindings/mtd/mspi-aps6404l.yaml
@@ -1,8 +1,8 @@
-# Copyright 2024 Ambiq Micro Inc.
+# Copyright (c) 2024, Ambiq Micro Inc. <www.ambiq.com>
 # SPDX-License-Identifier: Apache-2.0
 
 description: AP Memory APS6404L pSRAM on MSPI bus
 
 compatible: "mspi-aps6404l"
 
-include: ambiq,mspi-device.yaml
+include: [mspi-device.yaml, "jedec,jesd216.yaml"]

--- a/dts/bindings/mtd/mspi-atxp032.yaml
+++ b/dts/bindings/mtd/mspi-atxp032.yaml
@@ -5,4 +5,4 @@ description: NOR Flash devices ATXP032 on MSPI bus
 
 compatible: "mspi-atxp032"
 
-include: ambiq,mspi-device.yaml
+include: [mspi-device.yaml, "jedec,jesd216.yaml"]

--- a/samples/drivers/memc/boards/apollo3p_evb.overlay
+++ b/samples/drivers/memc/boards/apollo3p_evb.overlay
@@ -33,7 +33,7 @@
 	cmdq-buffer-size = <256>;
 
 	aps6404l: aps6404l@0 {
-		compatible = "mspi-aps6404l";
+		compatible = "ambiq,mspi-device", "mspi-aps6404l";
 		size = <DT_SIZE_M(64)>;
 		reg = <0>;
 		status = "okay";

--- a/samples/drivers/mspi/mspi_async/boards/apollo3p_evb.overlay
+++ b/samples/drivers/mspi/mspi_async/boards/apollo3p_evb.overlay
@@ -33,7 +33,7 @@
 	cmdq-buffer-size = <256>;
 
 	aps6404l: aps6404l@0 {
-		compatible = "mspi-aps6404l";
+		compatible = "ambiq,mspi-device", "mspi-aps6404l";
 		size = <DT_SIZE_M(64)>;
 		reg = <0>;
 		status = "okay";

--- a/samples/drivers/mspi/mspi_flash/boards/apollo3p_evb.overlay
+++ b/samples/drivers/mspi/mspi_flash/boards/apollo3p_evb.overlay
@@ -34,7 +34,7 @@
 	cmdq-buffer-size = <256>;
 
 	aps6404l: aps6404l@0 {
-		compatible = "mspi-aps6404l";
+		compatible = "ambiq,mspi-device", "mspi-aps6404l";
 		size = <DT_SIZE_M(64)>;
 		reg = <0>;
 		status = "disabled";
@@ -55,7 +55,7 @@
 	};
 
 	atxp032: atxp032@1 {
-		compatible = "mspi-atxp032";
+		compatible = "ambiq,mspi-device", "mspi-atxp032";
 		size = <DT_SIZE_M(32)>;
 		reg = <1>;
 		status = "okay";

--- a/tests/drivers/mspi/flash/boards/apollo3p_evb.overlay
+++ b/tests/drivers/mspi/flash/boards/apollo3p_evb.overlay
@@ -28,7 +28,7 @@
 	cmdq-buffer-size = <256>;
 
 	atxp032: atxp032@0 {
-		compatible = "mspi-atxp032";
+		compatible = "ambiq,mspi-device", "mspi-atxp032";
 		size = <DT_SIZE_M(32)>;
 		reg = <0>;
 		status = "okay";


### PR DESCRIPTION
This PR fixes https://github.com/zephyrproject-rtos/zephyr/issues/74349
Also fixes issue mentioned https://github.com/zephyrproject-rtos/zephyr/pull/71769#discussion_r1640567801 to make MSPI device bindings independent of SoC.