### PR TITLE
tests: drivers: counter: fix skip test check

### DIFF
--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -181,6 +181,8 @@ static void counter_tear_down_instance(const struct device *dev)
 static void test_all_instances(counter_test_func_t func,
 				counter_capability_func_t capability_check)
 {
+	int devices_skipped = 0;
+
 	zassert_true(ARRAY_SIZE(devices) > 0, "No device found");
 	for (int i = 0; i < ARRAY_SIZE(devices); i++) {
 		counter_setup_instance(devices[i]);
@@ -190,11 +192,14 @@ static void test_all_instances(counter_test_func_t func,
 			func(devices[i]);
 		} else {
 			TC_PRINT("Skipped for %s\n", devices[i]->name);
-			ztest_test_skip();
+			devices_skipped++;
 		}
 		counter_tear_down_instance(devices[i]);
 		/* Allow logs to be printed. */
 		k_sleep(K_MSEC(100));
+	}
+	if (devices_skipped == ARRAY_SIZE(devices)) {
+		ztest_test_skip();
 	}
 }
 


### PR DESCRIPTION
When running this test with multiple counter instances that support different capabilities, if one of the instances does not support the test required capabilities, the test will be immediately skipped not giving the chance to run to the subsequent instances.
Fix this by marking the test as skipped, only of all counter instances under test were skipped.

Fixes #74358

All instances skipped:
```
Running TESTSUITE counter_basic
===================================================================
START - test_all_channels
Skipped for pit0_channel@0
Skipped for pit0_channel@1
 SKIP - test_all_channels in 0.207 seconds
===================================================================
```

Some instances skipped, others executed:
```
===================================================================
START - test_all_channels
Skipped for pit0_channel@0
Testing stm@76200000
Testing stm@76210000
Testing stm@76020000
Testing stm@76030000
 PASS - test_all_channels in 0.636 seconds
===================================================================
```
