### PR TITLE
fix number of counter channels for NXP S32Z2 RTU.PIT

### DIFF
--- a/tests/drivers/counter/counter_basic_api/boards/s32z2xxdc2_s32z270_rtu0.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/s32z2xxdc2_s32z270_rtu0.overlay
@@ -31,3 +31,23 @@
 &pit0_channel0 {
 	status = "okay";
 };
+
+&pit0_channel1 {
+	status = "okay";
+};
+
+&pit0_channel2 {
+	status = "okay";
+};
+
+&pit0_channel3 {
+	status = "okay";
+};
+
+&pit0_channel4 {
+	status = "okay";
+};
+
+&pit0_channel5 {
+	status = "okay";
+};

--- a/tests/drivers/counter/counter_basic_api/boards/s32z2xxdc2_s32z270_rtu1.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/s32z2xxdc2_s32z270_rtu1.overlay
@@ -31,3 +31,23 @@
 &pit0_channel0 {
 	status = "okay";
 };
+
+&pit0_channel1 {
+	status = "okay";
+};
+
+&pit0_channel2 {
+	status = "okay";
+};
+
+&pit0_channel3 {
+	status = "okay";
+};
+
+&pit0_channel4 {
+	status = "okay";
+};
+
+&pit0_channel5 {
+	status = "okay";
+};

--- a/west.yml
+++ b/west.yml
@@ -198,7 +198,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: bee15c31e19ff1982583d9b750ef844d64320160
+      revision: 862e001504bd6e0a4feade6a718e9f973116849c
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
According to S32Z2 RM, RTU.PIT has 6 channels, currently only 4 are declared in the HAL device headers. Also make sure that all PIT channels are tested.

Fixes #74360