### PR TITLE
modules: tfm: fix `TFM_MCUBOOT_IMAGE_NUMBER == 1`

### DIFF
--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -386,6 +386,7 @@ if (CONFIG_BUILD_WITH_TFM)
 
   if (CONFIG_TFM_BL2)
     set(PREPROCESSED_FILE_S "${TFM_BINARY_DIR}/bl2/ext/mcuboot/CMakeFiles/signing_layout_s.dir/signing_layout_s.o")
+    set(PREPROCESSED_FILE_S_NS "${TFM_BINARY_DIR}/bl2/ext/mcuboot/CMakeFiles/signing_layout_s.dir/signing_layout_s_ns.o")
     set(PREPROCESSED_FILE_NS "${TFM_BINARY_DIR}/bl2/ext/mcuboot/CMakeFiles/signing_layout_ns.dir/signing_layout_ns.o")
     set(TFM_MCUBOOT_DIR "${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/bl2/ext/mcuboot")
   endif()
@@ -408,13 +409,19 @@ if (CONFIG_BUILD_WITH_TFM)
     if(PAD)
       set(pad_args --pad --pad-header)
     endif()
+    # Secure + Non-secure images are signed the same way as a secure only
+    # build, but with a different layout file.
+    set(layout_file ${PREPROCESSED_FILE_${SUFFIX}})
+    if(SUFFIX STREQUAL "S_NS")
+      set(SUFFIX "S")
+    endif()
     set (${OUT_ARG}
       # Add the MCUBoot script to the path so that if there is a version of imgtool in there then
       # it gets used over the system imgtool. Used so that imgtool from upstream
       # mcuboot is preferred over system imgtool
       ${CMAKE_COMMAND} -E env PYTHONPATH=${ZEPHYR_MCUBOOT_MODULE_DIR}/scripts
       ${PYTHON_EXECUTABLE} ${TFM_MCUBOOT_DIR}/scripts/wrapper/wrapper.py
-      --layout ${PREPROCESSED_FILE_${SUFFIX}}
+      --layout ${layout_file}
       -k ${CONFIG_TFM_KEY_FILE_${SUFFIX}}
       --public-key-format ${TFM_PUBLIC_KEY_FORMAT}
       --align 1
@@ -458,7 +465,7 @@ if (CONFIG_BUILD_WITH_TFM)
     )
 
   elseif(CONFIG_TFM_MCUBOOT_IMAGE_NUMBER STREQUAL "1")
-    tfm_sign(sign_cmd NS TRUE ${S_NS_FILE} ${S_NS_SIGNED_FILE})
+    tfm_sign(sign_cmd S_NS TRUE ${S_NS_FILE} ${S_NS_SIGNED_FILE})
 
     set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
       COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/mergehex.py

--- a/modules/trusted-firmware-m/Kconfig.tfm
+++ b/modules/trusted-firmware-m/Kconfig.tfm
@@ -192,7 +192,9 @@ config TFM_IMAGE_VERSION_S
 	help
 	  MCUBoot may be configured to prevent rollback prevention based on image
 	  versions of both the secure firmware and non-secure firmware. This sets
-	  the secure firmware's version for rollback prevention.
+	  the secure firmware's version for rollback prevention. This version is
+	  also used for merged secure + non-secure builds
+	  (TFM_MCUBOOT_IMAGE_NUMBER == 1).
 
 config TFM_IMAGE_VERSION_NS
 	string "Version of the Non-Secure Image"
@@ -250,7 +252,8 @@ config TFM_KEY_FILE_S
 	help
 	  The path and filename for the .pem file containing the private key
 	  that should be used by the BL2 bootloader when signing secure
-	  firmware images.
+	  firmware images. This key file is also used for merged secure +
+	  non-secure builds (TFM_MCUBOOT_IMAGE_NUMBER == 1).
 
 config TFM_KEY_FILE_NS
 	string "Path to private key used to sign non-secure firmware images."

--- a/samples/tfm_integration/config_build/CMakeLists.txt
+++ b/samples/tfm_integration/config_build/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(tfm_build_config)
+
+target_sources(app PRIVATE src/main.c)

--- a/samples/tfm_integration/config_build/prj.conf
+++ b/samples/tfm_integration/config_build/prj.conf
@@ -1,0 +1,1 @@
+# nothing here

--- a/samples/tfm_integration/config_build/sample.yaml
+++ b/samples/tfm_integration/config_build/sample.yaml
@@ -1,0 +1,29 @@
+sample:
+  description: Test TF-M builds in various configurations
+  name: TF-M build configuration
+common:
+  tags:
+    - trusted-firmware-m
+  platform_allow:
+    - mps2/an521/cpu0/ns
+    - v2m_musca_s1/musca_s1/ns
+    - nrf5340dk/nrf5340/cpuapp/ns
+    - nrf9160dk/nrf9160/ns
+    - bl5340_dvk/nrf5340/cpuapp/ns
+  harness: console
+  harness_config:
+    type: one_line
+    regex:
+      - "Hello World! (.*)"
+tests:
+  sample.config_build.no_bl2:
+    extra_configs:
+      - CONFIG_TFM_BL2=n
+  sample.config_build.single_image:
+    tags:
+      - mcuboot
+    platform_allow:
+      # Platform fails no_bl2
+      - stm32l562e_dk/stm32l562xx/ns
+    extra_configs:
+      - CONFIG_TFM_MCUBOOT_IMAGE_NUMBER=1

--- a/samples/tfm_integration/config_build/src/main.c
+++ b/samples/tfm_integration/config_build/src/main.c
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2024 Embeint Inc
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+
+int main(void)
+{
+	printf("Hello World! %s\n", CONFIG_BOARD_TARGET);
+
+	return 0;
+}


### PR DESCRIPTION
Fix builds with `CONFIG_TFM_MCUBOOT_IMAGE_NUMBER=1`. The merged binary should be signed with the same argumements as a secure build, not a non-secure build, except with a different layout file generated by the TF-M build system.

Fixes #68345.

Note that the test case provided works correctly for 3 boards, but results in `imgtool` overflows (which are marked as "skipped" tests) for the following platforms:
 * bl5340_dvk/nrf5340/cpuapp/ns
 * stm32l562e_dk/stm32l562xx/ns
 * mps2/an521/cpu0/ns

Resolving these will require delving into the TF-M repo and is beyond the scope of this PR.