### PR TITLE
drivers: ethernet: xlnx_gem: fix TX path stalling on ZynqMP

### DIFF
--- a/drivers/ethernet/eth_xlnx_gem_priv.h
+++ b/drivers/ethernet/eth_xlnx_gem_priv.h
@@ -170,6 +170,9 @@
  * LADDR3H  = gem.spec_addr3_top Specific address 3 top    register
  * LADDR4L  = gem.spec_addr4_bot Specific address 4 bottom register
  * LADDR4H  = gem.spec_addr4_top Specific address 4 top    register
+ *
+ * Register offsets required on the UltraScale+ only:
+ * TXQ1BASE = gem.transmit_q1_ptr (no equivalent in Zynq-7000)
  */
 #define ETH_XLNX_GEM_NWCTRL_OFFSET			0x00000000
 #define ETH_XLNX_GEM_NWCFG_OFFSET			0x00000004
@@ -192,6 +195,7 @@
 #define ETH_XLNX_GEM_LADDR3H_OFFSET			0x0000009C
 #define ETH_XLNX_GEM_LADDR4L_OFFSET			0x000000A0
 #define ETH_XLNX_GEM_LADDR4H_OFFSET			0x000000A4
+#define ETH_XLNX_GEM_TXQ1BASE_OFFSET			0x00000440
 
 /*
  * Masks for clearing registers during initialization:
@@ -487,7 +491,7 @@ static struct eth_xlnx_gem_dev_data eth_xlnx_gem##port##_dev_data = {\
 	.first_tx_buffer = NULL\
 };
 
-/* DMA memory area declaration macro */
+/* DMA memory area declaration macros */
 #define ETH_XLNX_GEM_DMA_AREA_DECL(port) \
 struct eth_xlnx_dma_area_gem##port {\
 	struct eth_xlnx_gem_bd rx_bd[DT_INST_PROP(port, rx_buffer_descriptors)];\
@@ -504,10 +508,27 @@ struct eth_xlnx_dma_area_gem##port {\
 		& ~(ETH_XLNX_BUFFER_ALIGNMENT - 1))];\
 };
 
-/* DMA memory area instantiation macro */
+#if defined(CONFIG_SOC_XILINX_ZYNQMP)
+#define ETH_XLNX_GEM_DMA_AREA_Q1_DECL(port) \
+struct eth_xlnx_dma_q1_area_gem##port {\
+	struct eth_xlnx_gem_bd tx_bd[1];\
+};
+#else
+#define ETH_XLNX_GEM_DMA_AREA_Q1_DECL(port);
+#endif
+
+/* DMA memory area instantiation macros */
 #define ETH_XLNX_GEM_DMA_AREA_INST(port) \
 static struct eth_xlnx_dma_area_gem##port eth_xlnx_gem##port##_dma_area\
 	__ocm_bss_section __aligned(4096);
+
+#if defined(CONFIG_SOC_XILINX_ZYNQMP)
+#define ETH_XLNX_GEM_DMA_AREA_Q1_INST(port) \
+static struct eth_xlnx_dma_q1_area_gem##port eth_xlnx_gem##port##_q1_dma_area\
+	__ocm_bss_section __aligned(8);
+#else
+#define ETH_XLNX_GEM_DMA_AREA_Q1_INST(port);
+#endif
 
 /* Interrupt configuration function macro */
 #define ETH_XLNX_GEM_CONFIG_IRQ_FUNC(port) \
@@ -519,7 +540,7 @@ static void eth_xlnx_gem##port##_irq_config(const struct device *dev)\
 	irq_enable(DT_INST_IRQN(port));\
 }
 
-/* RX/TX BD Ring initialization macro */
+/* RX/TX BD Ring initialization macros */
 #define ETH_XLNX_GEM_INIT_BD_RING(port) \
 if (dev_conf->base_addr == DT_REG_ADDR_BY_IDX(DT_INST(port, xlnx_gem), 0)) {\
 	dev_data->rxbd_ring.first_bd = &(eth_xlnx_gem##port##_dma_area.rx_bd[0]);\
@@ -528,13 +549,24 @@ if (dev_conf->base_addr == DT_REG_ADDR_BY_IDX(DT_INST(port, xlnx_gem), 0)) {\
 	dev_data->first_tx_buffer = (uint8_t *)eth_xlnx_gem##port##_dma_area.tx_buffer;\
 }
 
+#if defined(CONFIG_SOC_XILINX_ZYNQMP)
+#define ETH_XLNX_GEM_INIT_Q1_TX_BD(port) \
+if (dev_conf->base_addr == DT_REG_ADDR_BY_IDX(DT_INST(port, xlnx_gem), 0)) {\
+	dev_data->q1_txbd = &(eth_xlnx_gem##port##_q1_dma_area.tx_bd[0]);\
+}
+#else
+#define ETH_XLNX_GEM_INIT_Q1_TX_BD(port);
+#endif
+
 /* Top-level device initialization macro - bundles all of the above */
 #define ETH_XLNX_GEM_INITIALIZE(port) \
 ETH_XLNX_GEM_CONFIG_IRQ_FUNC(port);\
 ETH_XLNX_GEM_DEV_CONFIG(port);\
 ETH_XLNX_GEM_DEV_DATA(port);\
 ETH_XLNX_GEM_DMA_AREA_DECL(port);\
+ETH_XLNX_GEM_DMA_AREA_Q1_DECL(port);\
 ETH_XLNX_GEM_DMA_AREA_INST(port);\
+ETH_XLNX_GEM_DMA_AREA_Q1_INST(port);\
 ETH_XLNX_GEM_NET_DEV_INIT(port);\
 
 /* IRQ handler function type */
@@ -758,6 +790,9 @@ struct eth_xlnx_gem_dev_data {
 
 	struct eth_xlnx_gem_bdring	rxbd_ring;
 	struct eth_xlnx_gem_bdring	txbd_ring;
+#if defined(CONFIG_SOC_XILINX_ZYNQMP)
+	struct eth_xlnx_gem_bd		*q1_txbd;
+#endif
 
 #ifdef CONFIG_NET_STATISTICS_ETHERNET
 	struct net_stats_eth		stats;


### PR DESCRIPTION
This is the (pretty late) resumption of one of the aspects that should have originally been merged with #45556:

With the introduction of the ZynqMP/UltraScale+ SoCs, the GEM Ethernet controller was made 64-bit capable. On the 32-bit Zynq, the registers that point to the RX and TX DMA areas (RXQBASE/TXQBASE) are obviously 32-bit only. For the UltraScale+, a second set of RX/TX DMA pointer registers was added, both with a high and a low register in order to support DMA areas at locations above 4G: RX1QBASE/TX1QBASE. However, these registers do not replace the old 32-bit registers, those were retained for compatibility reasons.

The GEM driver has until now only used the 32-bit RXQBASE/TXQBASE registers, as those are sufficient for use of the GEM in conjunction with the Cortex-R5 cores. The newly added registers remained at their POR values, all 0x0. When using this approach on actual hardware instead of on qemu_cortex_r5, the following can be observed:

- RX works
- TX doesn't work:
- once the Start TX bit is set, the corresponding status register will show that a transmission is in progress. However, the status register never indicates either completion or failure, nor will there ever be an interrupt to indicate either success or failure. The TXQBASE pointer register never increments, which is normally the case once a TX BD entry has been processed.

It appears that the TX DMA state machine stalls completely.

The following attempts were made to get the TX DMA running again:

- Use the TX1QBASE-low register to point to the TX DMA area, leave the legacy TXQBASE register at 0x0. Same behaviour as above.
- Set both TXQBASE and TX1QBASE to the TX DMA area's address. The TX DMA then works, however, all packets are transmitted twice.
- Keep using TXQBASE for the actual DMA area address and have TX1QBASE point to a single, dummy TX buffer descriptor, which has the wrap bit set (so it's effectively a TX BD ring with ring size 1) and always indicates that it's not in use.

The latter approach gets the TX DMA up and running again, and it's this fix that is contained in this commit.

The UltraScale+ TRM (ug-1085) mentions that it is up to the programmer to decide which set of DMA pointer registers shall be used, but that the idle set of registers shall be, quote: "tied off properly" using the approach which was implemented in this commit.