### PR TITLE
drivers: ambiq: Add dependencies to avoid showing to non-ambiq platforms

### DIFF
--- a/drivers/i2c/Kconfig.ambiq
+++ b/drivers/i2c/Kconfig.ambiq
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-config I2C_AMBIQ
+menuconfig I2C_AMBIQ
 	bool "AMBIQ I2C driver"
 	default y
 	depends on DT_HAS_AMBIQ_I2C_ENABLED
@@ -13,6 +13,8 @@ config I2C_AMBIQ
 	select AMBIQ_HAL_USE_I2C
 	help
 	  Enable driver for Ambiq I2C.
+
+if I2C_AMBIQ
 
 config I2C_AMBIQ_DMA
 	bool "AMBIQ APOLLO I2C DMA Support"
@@ -24,3 +26,5 @@ config I2C_DMA_TCB_BUFFER_SIZE
 	default 1024
 	help
 	  DMA Transfer Control Buffer size in words
+
+endif # I2C_AMBIQ

--- a/drivers/spi/Kconfig.ambiq
+++ b/drivers/spi/Kconfig.ambiq
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-config SPI_AMBIQ
+menuconfig SPI_AMBIQ
 	bool "AMBIQ SPI driver"
 	default y
 	depends on DT_HAS_AMBIQ_SPI_ENABLED
@@ -14,6 +14,8 @@ config SPI_AMBIQ
 	select AMBIQ_HAL_USE_SPI
 	help
 	  Enable driver for Ambiq SPI.
+
+if SPI_AMBIQ
 
 config SPI_AMBIQ_DMA
 	bool "AMBIQ APOLLO SPI DMA Support"
@@ -27,6 +29,8 @@ config SPI_DMA_TCB_BUFFER_SIZE
 	depends on SPI_AMBIQ_DMA
 	help
 	  DMA Transfer Control Buffer size in words
+
+endif # SPI_AMBIQ
 
 config MSPI_AMBIQ
 	bool "AMBIQ MSPI driver"


### PR DESCRIPTION
Fixed the Kconfig.ambiq under i2c and spi so that they don't litter.