### PR TITLE
drivers: eth_nxp_enet: fix MMIO mapping issue (fix #74370)

### DIFF
--- a/drivers/ethernet/nxp_enet/eth_nxp_enet.c
+++ b/drivers/ethernet/nxp_enet/eth_nxp_enet.c
@@ -784,8 +784,8 @@ static int eth_nxp_enet_device_pm_action(const struct device *dev, enum pm_devic
 			return ret;
 		}
 
-		ENET_Reset(config->base);
-		ENET_Down(config->base);
+		ENET_Reset(data->base);
+		ENET_Down(data->base);
 		clock_control_off(config->clock_dev, (clock_control_subsys_t)config->clock_subsys);
 	} else if (action == PM_DEVICE_ACTION_RESUME) {
 		LOG_DBG("Resuming");


### PR DESCRIPTION
Fixed #74370, the issue is caused by the update to introduce MMIO mapping, after MMIO mapping, should use data->base for device base memory address.