### PR TITLE
Add I2C support for NXP frdm_ke17z board

### DIFF
--- a/boards/nxp/frdm_ke17z/doc/index.rst
+++ b/boards/nxp/frdm_ke17z/doc/index.rst
@@ -59,6 +59,8 @@ features:
 +-----------+------------+-------------------------------------+
 | UART      | on-chip    | uart                                |
 +-----------+------------+-------------------------------------+
+| I2C       | on-chip    | i2c                                 |
++-----------+------------+-------------------------------------+
 
 The default configuration can be found in the defconfig file:
 :zephyr_file:`boards/nxp/frdm_ke17z/frdm_ke17z_defconfig`.

--- a/boards/nxp/frdm_ke17z/frdm_ke17z-pinctrl.dtsi
+++ b/boards/nxp/frdm_ke17z/frdm_ke17z-pinctrl.dtsi
@@ -17,4 +17,14 @@
 			slew-rate = "slow";
 		};
 	};
+
+	lpi2c0_default: lpi2c0_default {
+		group0 {
+			pinmux = <LPI2C0_SDA_PTA16>,
+				<LPI2C0_SCL_PTB8>;
+			bias-pull-up;
+			drive-strength = "low";
+			slew-rate = "slow";
+		};
+	};
 };

--- a/boards/nxp/frdm_ke17z/frdm_ke17z.dts
+++ b/boards/nxp/frdm_ke17z/frdm_ke17z.dts
@@ -67,6 +67,12 @@
 	pinctrl-names = "default";
 };
 
+&lpi2c0 {
+	status = "okay";
+	pinctrl-0 = <&lpi2c0_default>;
+	pinctrl-names = "default";
+};
+
 &gpiod {
 	status = "okay";
 };

--- a/boards/nxp/frdm_ke17z/frdm_ke17z.yaml
+++ b/boards/nxp/frdm_ke17z/frdm_ke17z.yaml
@@ -11,4 +11,5 @@ toolchain:
 supported:
   - gpio
   - uart
+  - i2c
 vendor: nxp

--- a/samples/drivers/i2c/target_eeprom/boards/frdm_ke17z.overlay
+++ b/samples/drivers/i2c/target_eeprom/boards/frdm_ke17z.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&lpi2c0 {
+	eeprom0: eeprom@54 {
+		reg = <0x54>;
+		size = <256>;
+		compatible = "zephyr,i2c-target-eeprom";
+		status = "okay";
+	};
+};
+
+target_eeprom: &eeprom0{};

--- a/samples/drivers/i2c/target_eeprom/boards/frdm_ke17z512.overlay
+++ b/samples/drivers/i2c/target_eeprom/boards/frdm_ke17z512.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&lpi2c0 {
+	eeprom0: eeprom@54 {
+		reg = <0x54>;
+		size = <256>;
+		compatible = "zephyr,i2c-target-eeprom";
+		status = "okay";
+	};
+};
+
+target_eeprom: &eeprom0{};

--- a/samples/drivers/i2c/target_eeprom/sample.yaml
+++ b/samples/drivers/i2c/target_eeprom/sample.yaml
@@ -7,3 +7,16 @@ tests:
     platform_allow:
       - lpcxpresso55s69/lpc55s69/cpu0
     harness: TBD
+  sample.drivers.i2c.target.kinetis:
+    tags: i2c_target
+    filter: dt_nodelabel_enabled("target_eeprom")
+    platform_allow:
+      - frdm_ke17z
+      - frdm_ke17z512
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - "i2c target sample"
+        - "i2c target driver registered"
+        - "i2c target driver unregistered"


### PR DESCRIPTION
The frdm_ke17z contains only one lpi2c0 instance and tested the `samples/drivers/i2c/target_eeprom` case.