### PR TITLE
Bluetooth: iso: make TX path service all connections

### DIFF
--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -750,6 +750,9 @@ static struct net_buf *iso_data_pull(struct bt_conn *conn,
 
 	if (!frag) {
 		LOG_DBG("signaled ready but no frag available");
+		/* Service other connections */
+		bt_tx_irq_raise();
+
 		return NULL;
 	}
 
@@ -758,6 +761,9 @@ static struct net_buf *iso_data_pull(struct bt_conn *conn,
 
 		LOG_DBG("channel has been disconnected");
 		__ASSERT_NO_MSG(b == frag);
+
+		/* Service other connections */
+		bt_tx_irq_raise();
 
 		return NULL;
 	}


### PR DESCRIPTION
ISO connections that were in the TX queue were not getting serviced in time. This happens because `iso_data_pull()` returns `NULL` when that particular connection (`conn`) is done sending.

But it doesn't trigger the TX processor again to process other channels in the queue. This patch fixes that by calling `bt_tx_irq_raise()`.

We can't do this from `conn.c` as we don't know if the `NULL` returned is because the current channel is out of data or because it has data but it can't send it (e.g. the current buf is being "viewed" already).

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/74321