### PR TITLE
Bluetooth: Controller: Fix missing lock around LLCP data (remote)

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -221,6 +221,9 @@ struct node_tx *llcp_tx_alloc(struct ll_conn *conn, struct proc_ctx *ctx)
 
 	ARG_UNUSED(conn);
 	tx = (struct node_tx *)mem_acquire(&mem_tx.free);
+	if (!tx) {
+		return NULL;
+	}
 
 	pdu = (struct pdu_data *)tx->pdu;
 	ull_pdu_data_init(pdu);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -53,10 +53,10 @@
 #include <soc.h>
 #include "hal/debug.h"
 
-#define LLCTRL_PDU_SIZE (offsetof(struct pdu_data, llctrl) + sizeof(struct pdu_data_llctrl))
 #define PROC_CTX_BUF_SIZE WB_UP(sizeof(struct proc_ctx))
-#define TX_CTRL_BUF_SIZE WB_UP(offsetof(struct node_tx, pdu) + LLCTRL_PDU_SIZE)
-#define NTF_BUF_SIZE WB_UP(offsetof(struct node_rx_pdu, pdu) + LLCTRL_PDU_SIZE)
+#define TX_CTRL_BUF_SIZE WB_UP(offsetof(struct node_tx, pdu) + \
+				offsetof(struct pdu_data, llctrl) + \
+				PDU_DC_CTRL_TX_SIZE_MAX)
 
 /* LLCP Allocations */
 #if defined(LLCP_TX_CTRL_BUF_QUEUE_ENABLE)

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
@@ -921,6 +921,9 @@ void llcp_rr_new(struct ll_conn *conn, memq_link_t *link, struct node_rx_pdu *rx
 
 	ctx = llcp_create_remote_procedure(proc);
 	if (!ctx) {
+		/* It is ok to return here, maybe peer violated having only one
+		 * active control procedure?
+		 */
 		return;
 	}
 


### PR DESCRIPTION
Add mayfly locking around the access to the remote pending procedure list as it is accessed by both thread and mayfly.

Relates to commit f192fccf3ae4 ("Bluetooth: controller: Add lock around LLCP data").

Related to #74345.
