### PR TITLE
boards: use lowercase in the `renesas,r7fa4m1ab3cfm` compatible string

### DIFF
--- a/boards/arduino/uno_r4/arduino_uno_r4_common.dtsi
+++ b/boards/arduino/uno_r4/arduino_uno_r4_common.dtsi
@@ -10,7 +10,7 @@
 
 / {
 	model = "Arduino Uno R4 Board";
-	compatible = "renesas,r7fa4m1aB3cfm";
+	compatible = "renesas,r7fa4m1ab3cfm";
 
 	chosen {
 		zephyr,console = &uart2;


### PR DESCRIPTION
This PR unifies the `renesas,r7fa4m1ab3cfm` compatible string used in various platforms by making it lowercase for the `arduino_uno_r4` target.