### PR TITLE
Bluetooth: Mesh: align mesh and host psa usage

### DIFF
--- a/samples/bluetooth/mesh/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
+++ b/samples/bluetooth/mesh/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
@@ -1,4 +1,2 @@
-# The option adds TinyCrypt based bt_rand.
-CONFIG_BT_HOST_CRYPTO=n
-# The option adds GATT caching feature that is based on TinyCrypt.
-CONFIG_BT_GATT_CACHING=n
+# Enable PSA as a crypto backend in host
+CONFIG_BT_USE_PSA_API=y

--- a/samples/bluetooth/mesh_demo/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
+++ b/samples/bluetooth/mesh_demo/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
@@ -1,4 +1,2 @@
-# The option adds TinyCrypt based bt_rand.
-CONFIG_BT_HOST_CRYPTO=n
-# The option adds GATT caching feature that is based on TinyCrypt.
-CONFIG_BT_GATT_CACHING=n
+# Enable PSA as a crypto backend in host
+CONFIG_BT_USE_PSA_API=y

--- a/samples/bluetooth/mesh_provisioner/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
+++ b/samples/bluetooth/mesh_provisioner/boards/nrf5340dk_nrf5340_cpuapp_ns.conf
@@ -1,2 +1,2 @@
-# The option adds TinyCrypt based bt_rand.
-CONFIG_BT_HOST_CRYPTO=n
+# Enable PSA as a crypto backend in host
+CONFIG_BT_USE_PSA_API=y

--- a/subsys/bluetooth/mesh/CMakeLists.txt
+++ b/subsys/bluetooth/mesh/CMakeLists.txt
@@ -127,8 +127,6 @@ endif()
 
 zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)
 
-if (CONFIG_BUILD_WITH_TFM)
-  target_include_directories(${ZEPHYR_CURRENT_LIBRARY} PRIVATE
-    $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/api_ns/interface/include
-  )
-endif()
+zephyr_library_include_directories_ifdef(CONFIG_BUILD_WITH_TFM
+  $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/api_ns/interface/include
+)

--- a/tests/bsim/bluetooth/mesh/overlay_psa.conf
+++ b/tests/bsim/bluetooth/mesh/overlay_psa.conf
@@ -1,7 +1,5 @@
-# The option adds TinyCrypt based bt_rand.
-CONFIG_BT_HOST_CRYPTO=n
-# The option adds GATT caching feature that is based on TinyCrypt.
-CONFIG_BT_GATT_CACHING=n
+# Enable PSA as a crypto backend in host
+CONFIG_BT_USE_PSA_API=y
 
 # Enable mbedTLS PSA as a crypto backend
 CONFIG_BT_MESH_USES_MBEDTLS_PSA=y


### PR DESCRIPTION
Commit aligns usage mesh and host PSA.
Since PSA crypto is supported in host then
there is no reason to switch off some of host
features to get rid of tinycrypt functions in
the final image.

I run `mesh` sample on `nrf5340dk/nrf5340/cpuapp/ns` it seems working(I were able to provision, bind app key and change OnOff server state over mobile app on iPhone). No tinycrypt in the final image.