### PR TITLE
drivers: sensor: maxim: max31865: Fix fault bit clearing

### DIFF
--- a/drivers/sensor/maxim/max31865/max31865.c
+++ b/drivers/sensor/maxim/max31865/max31865.c
@@ -177,15 +177,19 @@ static char *max31865_error_to_string(uint8_t fault_register)
 static int max31865_fault_register(const struct device *dev)
 {
 	uint8_t fault_register;
+	uint8_t saved_fault_bits;
 
 	max31865_spi_read(dev, (REG_FAULT_STATUS), &fault_register, 1);
 	struct max31865_data *data = dev->data;
+	saved_fault_bits  = data->config_control_bits & FAULT_BITS_CLEAR_MASK;
 	/*Clear fault register */
 	WRITE_BIT(data->config_control_bits, 1, 1);
+	data->config_control_bits &= ~FAULT_BITS_CLEAR_MASK;
 	configure_device(dev);
 	LOG_ERR("Fault Register: 0x%02x, %s", fault_register,
 		max31865_error_to_string(fault_register));
 	WRITE_BIT(data->config_control_bits, 1, 0);
+	data->config_control_bits |= saved_fault_bits;
 
 	return 0;
 }

--- a/drivers/sensor/maxim/max31865/max31865.h
+++ b/drivers/sensor/maxim/max31865/max31865.h
@@ -42,6 +42,9 @@ LOG_MODULE_REGISTER(MAX31865, CONFIG_SENSOR_LOG_LEVEL);
 #define REG_FAULT_STATUS       0x07
 #define WR(reg)		       ((reg) | 0x80)
 
+/* Bitmask to clear fault status bits D5, D3, and D2 */
+#define FAULT_BITS_CLEAR_MASK 0x2C
+
 /**
  * RTD data, RTD current, and measurement reference
  * voltage. The ITS-90 standard is used; other RTDs


### PR DESCRIPTION
Resolve incorrect fault status bits resetting. Ensures D1 sets and D5, D3, D2 reset, preventing undefined states.
Page 14 : https://www.analog.com/media/en/technical-documentation/data-sheets/max31865.pdf
![fc](https://github.com/zephyrproject-rtos/zephyr/assets/54628541/9cf0b519-387f-4922-a5df-aa877b50790f)
