### PR TITLE
Bluetooth: Fix CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY build warnings

### DIFF
--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -593,6 +593,7 @@ static bool update_keys_check(struct bt_smp *smp, struct bt_keys *keys)
 	return true;
 }
 
+#ifndef CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY
 static bool update_debug_keys_check(struct bt_smp *smp)
 {
 	struct bt_conn *conn = smp->chan.chan.conn;
@@ -612,6 +613,7 @@ static bool update_debug_keys_check(struct bt_smp *smp)
 
 	return false;
 }
+#endif /* CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY */
 
 #if defined(CONFIG_BT_PRIVACY) || defined(CONFIG_BT_SIGNING) || \
 	!defined(CONFIG_BT_SMP_SC_PAIR_ONLY)
@@ -3111,7 +3113,6 @@ static int smp_send_pairing_req(struct bt_conn *conn)
 static uint8_t smp_pairing_rsp(struct bt_smp *smp, struct net_buf *buf)
 {
 	struct bt_conn *conn = smp->chan.chan.conn;
-	const struct bt_conn_auth_cb *smp_auth_cb = latch_auth_cb(smp);
 	struct bt_smp_pairing *rsp = (void *)buf->data;
 	struct bt_smp_pairing *req = (struct bt_smp_pairing *)&smp->preq[1];
 	uint8_t err;
@@ -3166,7 +3167,17 @@ static uint8_t smp_pairing_rsp(struct bt_smp *smp, struct net_buf *buf)
 		return err;
 	}
 
-	if (!atomic_test_bit(smp->flags, SMP_FLAG_SC)) {
+	/* the OR operation evaluated by "if" statement bellow seems redundant
+	 * when CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY is enabled, because in
+	 * that case the SMP_FLAG_SC will always be set to false. But it's
+	 * needed in order to inform the compiler that the inside of the "if"
+	 * is the return point for CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY enabled
+	 * builds. This avoids compiler warnings regarding the code after the
+	 * "if" statement, that would happen for builds with
+	 * CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY enabled
+	 */
+	if (IS_ENABLED(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY) ||
+	    !atomic_test_bit(smp->flags, SMP_FLAG_SC)) {
 #if defined(CONFIG_BT_SMP_SC_PAIR_ONLY)
 		return BT_SMP_ERR_AUTH_REQUIREMENTS;
 #else
@@ -3180,6 +3191,8 @@ static uint8_t smp_pairing_rsp(struct bt_smp *smp, struct net_buf *buf)
 		return legacy_pairing_rsp(smp);
 #endif /* CONFIG_BT_SMP_SC_PAIR_ONLY */
 	}
+
+	const struct bt_conn_auth_cb *smp_auth_cb = latch_auth_cb(smp);
 
 	smp->local_dist &= SEND_KEYS_SC;
 	smp->remote_dist &= RECV_KEYS_SC;
@@ -3535,6 +3548,7 @@ static uint8_t sc_smp_check_confirm(struct bt_smp *smp)
 	return 0;
 }
 
+#ifndef CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY
 static bool le_sc_oob_data_req_check(struct bt_smp *smp)
 {
 	struct bt_smp_pairing *req = (struct bt_smp_pairing *)&smp->preq[1];
@@ -3579,6 +3593,7 @@ static void le_sc_oob_config_set(struct bt_smp *smp,
 
 	info->lesc.oob_config = oob_config;
 }
+#endif /* CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY */
 
 static uint8_t smp_pairing_random(struct bt_smp *smp, struct net_buf *buf)
 {
@@ -4078,6 +4093,7 @@ static uint8_t smp_security_request(struct bt_smp *smp, struct net_buf *buf)
 }
 #endif /* CONFIG_BT_CENTRAL */
 
+#ifndef CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY
 static uint8_t generate_dhkey(struct bt_smp *smp)
 {
 	if (IS_ENABLED(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)) {
@@ -4119,6 +4135,7 @@ static uint8_t display_passkey(struct bt_smp *smp)
 
 	return 0;
 }
+#endif /* CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY */
 
 #if defined(CONFIG_BT_PERIPHERAL)
 static uint8_t smp_public_key_periph(struct bt_smp *smp)
@@ -4177,6 +4194,12 @@ static uint8_t smp_public_key_periph(struct bt_smp *smp)
 }
 #endif /* CONFIG_BT_PERIPHERAL */
 
+#ifdef CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY
+static uint8_t smp_public_key(struct bt_smp *smp, struct net_buf *buf)
+{
+	return BT_SMP_ERR_AUTH_REQUIREMENTS;
+}
+#else
 static uint8_t smp_public_key(struct bt_smp *smp, struct net_buf *buf)
 {
 	const struct bt_conn_auth_cb *smp_auth_cb = latch_auth_cb(smp);
@@ -4289,6 +4312,7 @@ static uint8_t smp_public_key(struct bt_smp *smp, struct net_buf *buf)
 
 	return 0;
 }
+#endif /* CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY */
 
 static uint8_t smp_dhkey_check(struct bt_smp *smp, struct net_buf *buf)
 {


### PR DESCRIPTION
This commit fixes compilation warnings that are present when compiling with CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY as can be seen in this compiler log:

"""
In file included from /zephyr-sdk-0.16.1/arm-zephyr-eabi/picolibc/ include/string.h:215,
                 from /zephyr/subsys/bluetooth/host/smp.c:15:
In function '__memcpy_ichk',
    inlined from 'sc_send_public_key' at /zephyr/subsys/bluetooth/host/
smp.c:3006:2:
/zephyr-sdk-0.16.1/arm-zephyr-eabi/picolibc/include/ssp/string.h:83:1: warning: argument 2 null where non-null expected [-Wnonnull]
   83 | __ssp_bos_icheck3_restrict(memcpy, void *, const void *)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
/zephyr-sdk-0.16.1/arm-zephyr-eabi/picolibc/include/ssp/string.h:83:1: note: in a call to built-in function '__builtin_memcpy' /zephyr/subsys/bluetooth/host/smp.c: In function 'smp_public_key': /zephyr/subsys/bluetooth/host/smp.c:4214:21: warning: argument 2 null where non-null expected [-Wnonnull]
 4214 | memcmp(smp->pkey, sc_public_key, BT_PUB_KEY_COORD_LEN) == 0) {
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/zephyr-sdk-0.16.1/arm-zephyr-eabi/picolibc/include/string.h:62:10: note: in a call to function 'memcmp' declared 'nonnull'
   62 | int memcmp (const void *, const void *, size_t);
      |     ^~~~~~
"""

The warning is caused by the potential use of NULL "sc_public_key" global pointer that is not assigned a value in "smp_init()" if CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY is enabled. This commit conditionally changes the behavior of function "smp_public_key()" if CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY is activated to simply return and not use the "sc_public_key" variable. Other functions that are not called anymore by "smp_public_key()" are also conditionally deactivated when CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY is enabled