### PR TITLE
soc: lpc: mcxn: fix the flash_fill() fail.

### DIFF
--- a/soc/nxp/lpc/lpc55xxx/Kconfig.defconfig
+++ b/soc/nxp/lpc/lpc55xxx/Kconfig.defconfig
@@ -38,6 +38,10 @@ config LPC55XXX_SRAM_CLOCKS
 config LPC55XXX_USB_RAM
 	default y
 
+# Set to the minimal size of data which can be written.
+config FLASH_FILL_BUFFER_SIZE
+	default 512
+
 if SOC_LPC55S06
 
 config LPC55XXX_USB_RAM

--- a/soc/nxp/mcx/mcxnx4x/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxnx4x/Kconfig.defconfig
@@ -20,4 +20,8 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 16000 if MCUX_LPTMR_TIMER
 	default 150000000 if CORTEX_M_SYSTICK
 
+# Set to the minimal size of data which can be written.
+config FLASH_FILL_BUFFER_SIZE
+	default 128
+
 endif # SOC_SERIES_MCXNX4X


### PR DESCRIPTION
- Fix flash_fill() for lpc55 and mcxnx4.
- Set FLASH_FILL_BUFFER_SIZE to the minimal size of data which can be written to a device (by default is only 32).
- Fix the [flash_map.test_flash_area_erase_and_flatten] failed test of tests/subsys/storage/flash_map.