### PR TITLE
soc: espressif: esp32: improve memory utilization

### DIFF
--- a/soc/espressif/esp32/default.ld
+++ b/soc/espressif/esp32/default.ld
@@ -12,23 +12,21 @@
 
 #include "memory.h"
 
-/* The "user_iram_end" represents the 2nd stage bootloader
- * "dram_seg" end address (that should not be overlapped).
- * If no bootloader is used we extend it to gain more user ram.
+/* The "user_iram_end" represents the last DRAM memory location
+ * that is occupied by the ROM code. Since the "iram_loader_seg"
+ * - which is the last memory the bootloader runs from - resides
+ * in the SRAM0 "cache" memory, the "user_iram_end" applies for\
+ * all build cases - Simple boot and the MCUboot application.
  */
-#ifdef CONFIG_ESP_SIMPLE_BOOT
-user_iram_end = SRAM1_DRAM_IRAM_CALC(SRAM1_DRAM_USABLE_START);
-#else
-user_iram_end = SRAM1_DRAM_IRAM_CALC(BOOTLOADER_DRAM_SEG_END);
-#endif
+user_iram_end = SRAM1_DRAM_IRAM_CALC(SRAM1_DRAM_USER_START);
 
 /* User available SRAM memory segments */
 user_iram_seg_org = (SRAM0_IRAM_START + SRAM0_CACHE_SIZE);
 user_iram_seg_len = user_iram_end - user_iram_seg_org;
-user_dram_seg_org = SRAM2_DRAM_USABLE_START;
-user_dram_seg_len = SRAM2_USABLE_SIZE;
-user_dram_2_seg_org = SRAM1_DRAM_USABLE_START;
-user_dram_2_seg_len = SRAM1_USABLE_SIZE;
+user_dram_seg_org = SRAM2_DRAM_USER_START;
+user_dram_seg_len = SRAM2_USER_SIZE;
+user_dram_2_seg_org = SRAM1_DRAM_USER_START;
+user_dram_2_seg_len = SRAM1_USER_SIZE;
 
 /* Aliases */
 #define FLASH_CODE_REGION   irom0_0_seg

--- a/soc/espressif/esp32/memory.h
+++ b/soc/espressif/esp32/memory.h
@@ -14,15 +14,15 @@
 #define SRAM1_DRAM_START    0x3ffe0000
 #define SRAM1_SIZE          0x20000
 #define SRAM1_DRAM_PROAPP_PRIV_SIZE 0x8000
-#define SRAM1_DRAM_USABLE_START 0x3ffe8000  /* Can be optimised - 0x3ffe5230 (?) */
-#define SRAM1_USABLE_SIZE   (0x40000000 - SRAM1_DRAM_USABLE_START)
+#define SRAM1_DRAM_USER_START 0x3ffe5400
+#define SRAM1_USER_SIZE     (0x40000000 - SRAM1_DRAM_USER_START)
 
 /* SRAM2 (200k) data memory */
 #define SRAM2_DRAM_START    0x3ffae000
 #define SRAM2_SIZE          0x32000
 #define SRAM2_DRAM_SHM_PRIV_SIZE 0x2000
-#define SRAM2_DRAM_USABLE_START  0x3ffb0000
-#define SRAM2_USABLE_SIZE   (SRAM1_DRAM_START - SRAM2_DRAM_USABLE_START)
+#define SRAM2_DRAM_USER_START 0x3ffb0000
+#define SRAM2_USER_SIZE     (SRAM1_DRAM_START - SRAM2_DRAM_USER_START)
 
 /** Simplified memory map for the bootloader.
  *  Make sure the bootloader can load into main memory without overwriting itself.
@@ -56,10 +56,7 @@
 #define BOOTLOADER_DRAM_SEG_START  0x3fff0000
 #define BOOTLOADER_DRAM_SEG_END    (BOOTLOADER_DRAM_SEG_START + BOOTLOADER_DRAM_SEG_LEN)
 #define BOOTLOADER_IRAM_LOADER_SEG_START 0x40078000
-/* TODO: It should be possible to have this @ 0x40080400
- * but due a bug we need to use different memory location.
- */
-#define BOOTLOADER_IRAM_SEG_START     0x400a0000
+#define BOOTLOADER_IRAM_SEG_START  0x400a0000
 
 /* Flash */
 #ifdef CONFIG_FLASH_SIZE


### PR DESCRIPTION
Move the user available memory boundary to allow more statical allocations.