### PR TITLE
drivers: sensor: ntc_thermistor: adds support for VDD based ADC reference

### DIFF
--- a/drivers/sensor/ntc_thermistor/ntc_thermistor.h
+++ b/drivers/sensor/ntc_thermistor/ntc_thermistor.h
@@ -7,6 +7,7 @@
 #ifndef NTC_THERMISTOR_H
 #define NTC_THERMISTOR_H
 
+#include <stdbool.h>
 #include <zephyr/types.h>
 
 struct ntc_compensation {
@@ -21,30 +22,32 @@ struct ntc_type {
 
 struct ntc_config {
 	bool connected_positive;
-	uint32_t pullup_uv;
+	uint32_t pullup_mv;
 	uint32_t pullup_ohm;
 	uint32_t pulldown_ohm;
 	struct ntc_type type;
 };
 
 /**
- * @brief Converts ohm to temperature in milli centigrade
+ * @brief Converts ohm to temperature in milli centigrade.
  *
- * @param type: Pointer to ntc_type table info
- * @param ohm: Read resistance of NTC thermistor
+ * @param[in] type Pointer to ntc_type table info
+ * @param[in] ohm Read resistance of NTC thermistor
  *
- * @return temperature in milli centigrade
+ * @return Temperature in milli centigrade
  */
 int32_t ntc_get_temp_mc(const struct ntc_type *type, unsigned int ohm);
 
 /**
- * @brief Calculate the resistance read from NTC Thermistor
+ * @brief Calculate the resistance read from NTC thermistor.
  *
- * @param cfg: NTC Thermistor configuration
- * @sample_mv: Measured voltage in mV
+ * @param[in] cfg NTC thermistor configuration
+ * @param[in] sample_value Measured voltage relative to `sample_value_max`
+ * @param[in] sample_value_max Maximum of `sample_value`
  *
  * @return Thermistor resistance
  */
-uint32_t ntc_get_ohm_of_thermistor(const struct ntc_config *cfg, int sample_mv);
+uint32_t ntc_get_ohm_of_thermistor(const struct ntc_config *cfg, int sample_value,
+				  int sample_value_max);
 
 #endif /* NTC_THERMISTOR_H */

--- a/drivers/sensor/ntc_thermistor/ntc_thermistor_calc.c
+++ b/drivers/sensor/ntc_thermistor/ntc_thermistor_calc.c
@@ -5,8 +5,6 @@
  */
 
 #include <limits.h>
-#include <stdlib.h>
-#include <zephyr/devicetree.h>
 #include "ntc_thermistor.h"
 
 /**
@@ -31,11 +29,11 @@ static int ntc_fixp_linear_interpolate(int x0, int y0, int x1, int y1, int x)
 }
 
 /**
- * ntc_lookup_comp() - Finds indicies where ohm falls between
+ * Finds indices where ohm falls between.
  *
- * @ohm: key value search is looking for
- * @i_low: return Lower interval index value
- * @i_high: return Higher interval index value
+ * @param ohm key value search is looking for
+ * @param i_low return Lower interval index value
+ * @param i_high return Higher interval index value
  */
 static void ntc_lookup_comp(const struct ntc_type *type, unsigned int ohm, int *i_low, int *i_high)
 {
@@ -62,29 +60,23 @@ static void ntc_lookup_comp(const struct ntc_type *type, unsigned int ohm, int *
 	*i_high = high;
 }
 
-/**
- * ntc_get_ohm_of_thermistor() - Calculate the resistance read from NTC Thermistor
- *
- * @cfg: NTC Thermistor configuration
- * @sample_mv: Measured voltage in mV
- */
-uint32_t ntc_get_ohm_of_thermistor(const struct ntc_config *cfg, int sample_mv)
+uint32_t ntc_get_ohm_of_thermistor(const struct ntc_config *cfg, int sample_value,
+				   int sample_value_max)
 {
-	int pullup_mv = cfg->pullup_uv / 1000;
 	uint32_t ohm;
 
-	if (sample_mv <= 0) {
+	if (sample_value <= 0) {
 		return cfg->connected_positive ? INT_MAX : 0;
 	}
 
-	if (sample_mv >= pullup_mv) {
+	if (sample_value >= sample_value_max) {
 		return cfg->connected_positive ? 0 : INT_MAX;
 	}
 
 	if (cfg->connected_positive) {
-		ohm = cfg->pulldown_ohm * (pullup_mv - sample_mv) / sample_mv;
+		ohm = cfg->pulldown_ohm * (sample_value_max - sample_value) / sample_value;
 	} else {
-		ohm = cfg->pullup_ohm * sample_mv / (pullup_mv - sample_mv);
+		ohm = cfg->pullup_ohm * sample_value / (sample_value_max - sample_value);
 	}
 
 	return ohm;

--- a/dts/bindings/sensor/ntc-thermistor.yaml
+++ b/dts/bindings/sensor/ntc-thermistor.yaml
@@ -15,6 +15,9 @@ properties:
     type: int
     description: |
       The pullup voltage microvoltage in the circuit.
+      If not specified, it is assumed that the pullup voltage is VDD. Therefore,
+      the specified ADC IO channel must be configured so that VDD is used as the
+      reference voltage.
 
   pullup-ohm:
     type: int


### PR DESCRIPTION
The NTC thermistor implementation assumes a constant pull-up voltage and that the ADC channel is measured against a reference voltage so that the absolute voltage across the NTC can be calculated. Based on the relationship of `pullup-uv` and this absolute NTC voltage, the resistance of the NTC is calculated.

There are applications where the "pullup-uv" is not constant, but VDD. Most ADCs support relative measurements against VDD. If `pullup-uv` is not defined, the implementation assumes now that the ADC channel is configured to use VDD as a reference and therefore no millivolt conversion is required.

In addition, only one of the specified pull-up/pull-down resistances was taken into account. If a FET switches the resistor divider on the NTC side, the NTC resistance was too high. In the new implementation, the specified value (e.g. FET resistance) is subtracted from the NTC to achieve slightly better accuracy.