### PR TITLE
cmake: modules: fix FindThreads use of deprecated PTHREAD config

### DIFF
--- a/cmake/modules/FindThreads.cmake
+++ b/cmake/modules/FindThreads.cmake
@@ -26,7 +26,7 @@ include(FindPackageHandleStandardArgs)
 
 set(Threads_FOUND FALSE)
 
-if(DEFINED CONFIG_PTHREAD)
+if(DEFINED CONFIG_POSIX_THREADS)
   set(Threads_FOUND TRUE)
   set(CMAKE_THREAD_LIBS_INIT )
   set(CMAKE_USE_PTHREADS_INIT 1)


### PR DESCRIPTION
With the update of the Kconfig symbols to new naming scheme, CONFIG_PTHREAD does not exist anymore.
Use the new CONFIG_POSIX_THREADS instead

Follow-up: #73047