### PR TITLE
samples: tflite-micro: fix link to original magic_wand sample

### DIFF
--- a/samples/modules/tflite-micro/magic_wand/README.rst
+++ b/samples/modules/tflite-micro/magic_wand/README.rst
@@ -16,7 +16,7 @@ from an accelerometer.
     `the Antmicro tutorial on Renode emulation for TensorFlow`_.
 
 .. _the TensorFlow Magic Wand sample for Zephyr:
-    https://github.com/tensorflow/tflite-micro/tree/main/tensorflow/lite/micro/examples/magic_wand
+    https://github.com/tensorflow/tflite-micro-arduino-examples/tree/main/examples/magic_wand
 
 .. _the Antmicro tutorial on Renode emulation for TensorFlow:
     https://github.com/antmicro/litex-vexriscv-tensorflow-lite-demo


### PR DESCRIPTION
Fixes link to magic_wand sample, which was removed from the tflite-micro
repository.