### PR TITLE
boards: st: nucleo_h743/h753 use the default FDCAN clock

### DIFF
--- a/boards/st/nucleo_h743zi/nucleo_h743zi.dts
+++ b/boards/st/nucleo_h743zi/nucleo_h743zi.dts
@@ -89,6 +89,16 @@
 	status = "okay";
 };
 
+&pll2 {
+	div-m = <4>;
+	mul-n = <120>;
+	div-p = <2>;
+	div-q = <3>; /* gives 80MHz to the FDCAN */
+	div-r = <2>;
+	clocks = <&clk_hse>;
+	status = "okay";
+};
+
 &rcc {
 	clocks = <&pll>;
 	clock-frequency = <DT_FREQ_M(480)>;
@@ -171,7 +181,7 @@ zephyr_udc0: &usbotg_fs {
 	pinctrl-0 = <&fdcan1_rx_pd0 &fdcan1_tx_pd1>;
 	pinctrl-names = "default";
 	clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000100>,
-		 <&rcc STM32_SRC_PLL1_Q FDCAN_SEL(1)>;
+		 <&rcc STM32_SRC_PLL2_Q FDCAN_SEL(2)>;
 	status = "okay";
 };
 

--- a/boards/st/nucleo_h753zi/nucleo_h753zi.dts
+++ b/boards/st/nucleo_h753zi/nucleo_h753zi.dts
@@ -86,6 +86,16 @@
 	status = "okay";
 };
 
+&pll2 {
+	div-m = <4>;
+	mul-n = <120>;
+	div-p = <2>;
+	div-q = <3>; /* gives 80MHz to the FDCAN */
+	div-r = <2>;
+	clocks = <&clk_hse>;
+	status = "okay";
+};
+
 &rcc {
 	clocks = <&pll>;
 	clock-frequency = <DT_FREQ_M(480)>;
@@ -147,6 +157,8 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &fdcan1 {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000100>,
+		 <&rcc STM32_SRC_PLL2_Q FDCAN_SEL(2)>;
 	pinctrl-0 = <&fdcan1_rx_pd0 &fdcan1_tx_pd1>;
 	pinctrl-names = "default";
 	status = "okay";


### PR DESCRIPTION
When using the FDCAN1, use the default HSE clock source on the nucleo_h743zi or nucleo_h753zi boards, now that sysclck is 480MHz

This is fixing the error when running the  tests/subsys/canbus/isotp/implementation/  on the nucleo_h743zi since the 
sysclock is 480MHz (https://github.com/zephyrproject-rtos/zephyr/pull/73705)