### PR TITLE
tests: drivers: spi loopback testing on the nucleo_h743/h753 boards

### DIFF
--- a/tests/drivers/spi/spi_loopback/boards/nucleo_h743zi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_h743zi.overlay
@@ -6,6 +6,12 @@
 
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 
+/* Set div-q to get test clk freq into acceptable SPI freq range */
+&pll {
+	/delete-property/ div-q;
+	div-q = <8>;
+};
+
 &sram2 {
 	zephyr,memory-attr = < DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE) >;
 };

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_h753zi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_h753zi.overlay
@@ -6,6 +6,12 @@
 
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 
+/* Set div-q to get test clk freq into acceptable SPI freq range */
+&pll {
+	/delete-property/ div-q;
+	div-q = <8>;
+};
+
 &sram2 {
 	zephyr,memory-attr = < DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE) >;
 };

--- a/tests/drivers/spi/spi_loopback/overlay-stm32-spi-16bits.overlay
+++ b/tests/drivers/spi/spi_loopback/overlay-stm32-spi-16bits.overlay
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* Set div-q to get test clk freq into acceptable SPI freq range */
+&pll {
+	/delete-property/ div-q;
+	div-q = <8>;
+};
+
 &sram2 {
 	zephyr,memory-attr = < DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE) >;
 };


### PR DESCRIPTION
Reduce the spi1 clock freq to pass the testcase on the nucleo _h753zi or nucleo_h743zi boards
Connect D11 & D12 pins on the board to pass the test

The testcase.yaml is running 2 test items only on the nucleo_h743zi & nucleo_h753zi
- drivers.spi.stm32_spi_16bits_frames_dma.loopback:
- drivers.spi.stm32_spi_16bits_frames_dma_dt_nocache_mem.loopback
Due to the extra_config adding an overlay file:  **DTC_OVERLAY_FILE="overlay-stm32-spi-16bits.overlay"**
the boards/nucleo_h743zi.overlay or boards/nucleo_h753zi.overlay  are not merged  when executing for nucleo_h743zi or nucleo_h753zi  with twister 
(does twister take only one overlay file ?)
