### PR TITLE
Audio tests ci fix

### DIFF
--- a/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast_reception.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast_reception.sh
@@ -7,6 +7,7 @@
 SIMULATION_ID="cap_broadcast_reception"
 VERBOSITY_LEVEL=2
 NR_OF_DEVICES=3
+EXECUTE_TIMEOUT=180
 
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 

--- a/tests/bsim/bluetooth/audio/test_scripts/mcs_mcc.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/mcs_mcc.sh
@@ -8,7 +8,7 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 SIMULATION_ID="mcs_mcc"
 VERBOSITY_LEVEL=2
-EXECUTE_TIMEOUT=50
+EXECUTE_TIMEOUT=180
 
 cd ${BSIM_OUT_PATH}/bin
 


### PR DESCRIPTION
    tests/bsim/bluetooth/audio: Reduce verbosity
    
    These tests produce extremely verbose logs
    (tenths of thousands of lines)
    Let's reduce the logging level so we don't overload
    the CI interface when a failure occurs.

--------

    tests/bsim/bluetooth/audio: Increase real time deadline
    
    These 2 tests have been seen failing in CI due to
    the real time timeout.
    Let's increase their deadline so it does not happen.
    

The tests can be seen failing in this run: 
https://github.com/zephyrproject-rtos/zephyr/actions/runs/9546981787/job/26310982623?pr=74410#step:13:35049
