### PR TITLE
west.yml: stm32: Remove PAGESIZE definition

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -234,7 +234,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 6443e5c4d391c3e9e283c5728cd07d855e663965
+      revision: 855f195793df094644ce8b8617c01275408bbf58
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
PAGESIZE definition from legacy.h conflicts with POSIX definition. Since this definition comes from legacy.h file which is only there for Cube backward compatibility that we don't maintain in Zephyr, simply remove it.

Note:
This is a second fix for #73363 which wasn't sufficiently tested. Legacy file is included in stm32yyxx_hal_def.h headers and actually removing it generates build errors as we're relying on some of the definitions. Removing this inclusion is necessary and will be done but on next release.

Fixes #73896