### PR TITLE
tests: subsys: lorawan testing on the nucleo_wl55jc with timeout

### DIFF
--- a/tests/subsys/lorawan/clock_sync/testcase.yaml
+++ b/tests/subsys/lorawan/clock_sync/testcase.yaml
@@ -10,5 +10,6 @@ tests:
   lorawan.clock_sync.phy:
     depends_on: lora
     filter: CONFIG_ENTROPY_HAS_DRIVER
+    timeout: 500
     integration_platforms:
       - nucleo_wl55jc


### PR DESCRIPTION
Running the tests/subsys/lorawan/clock_sync/ requires a long timeout to pass. Set a timeout: 500 to cover most of the usecase

Increase the timeout to PASS the  tests/subsys/lorawan/clock_sync/ on nucleo_wl55jc
```
------ TESTSUITE SUMMARY START ------
SUITE PASS - 100.00% [clock_sync]: pass = 4, fail = 0, skip = 0, total = 4 duration = 158.568 seconds
- PASS - [clock_sync.test_app_time] duration = 62.521 seconds
- PASS - [clock_sync.test_device_app_time_periodicity] duration = 86.045 seconds
- PASS - [clock_sync.test_force_device_resync] duration = 10.001 seconds
- PASS - [clock_sync.test_package_version] duration = 0.001 seconds
------ TESTSUITE SUMMARY END ------
===================================================================
RunID: dd95576c760d76208464fbe148e9fd92
PROJECT EXECUTION SUCCESSFUL
```

