### PR TITLE
fs: nvs:  Add configurable CRC-24 support for ATEs

### DIFF
--- a/doc/services/storage/nvs/nvs.rst
+++ b/doc/services/storage/nvs/nvs.rst
@@ -16,19 +16,27 @@ at least one id-data pair stored in flash at all time.
 NVS allows storage of binary blobs, strings, integers, longs, and any
 combination of these.
 
-Each element is stored in flash as metadata (8 byte) and data. The metadata is
-written in a table starting from the end of a nvs sector, the data is
-written one after the other from the start of the sector. The metadata consists
+Each element is stored in flash as metadata and data. The metadata is called ATE, standing for
+Allocation Table Entry. The metadata is written in a table starting from the end of a NVS sector,
+the data is written one after the other from the start of the sector. The metadata consists
 of: id, data offset in sector, data length, part (unused), and a CRC. This CRC is
 only calculated over the metadata and only ensures that a write has been
 completed. The actual data of the element can be protected by a different (and optional)
 CRC-32. Use the :kconfig:option:`CONFIG_NVS_DATA_CRC` configuration item to enable
 the data part CRC.
-**Note:** the data CRC is checked only when the whole data of the element is read.
+
+.. note:: The data CRC is checked only when the whole data of the element is read.
 The data CRC is not checked for a partial read, as it is stored at the end of the
 element data area.
-**Note 2:** enabling the data CRC feature on a previously existing NVS content without
+
+.. note:: Enabling the data CRC feature on a previously existing NVS content without
 data CRC will make all existing data invalid.
+
+The metadata CRC can be kept small (1 byte, CRC-8) to decrease the flash space required for each
+metadata part. This metadata CRC can also be larger (3 bytes, CRC-24) to increase the robustness
+to memory corruption, at the cost of 2 more bytes needed per metadata.
+Refer to the :kconfig:option:`CONFIG_NVS_ATE_CRC8` and :kconfig:option:`CONFIG_NVS_ATE_CRC24`
+configuration items to select the one to use.
 
 A write of data to nvs always starts with writing the data, followed by a write
 of the metadata. Data that is written in flash without metadata is ignored

--- a/subsys/fs/nvs/Kconfig
+++ b/subsys/fs/nvs/Kconfig
@@ -37,6 +37,23 @@ config NVS_DATA_CRC
 	  The CRC-32 is transparently stored at the end of the data field,
 	  in the NVS data section, so 4 more bytes are needed per NVS element.
 
+choice NVS_ATE_CRC
+	bool "Allocation Table Entry CRC"
+	default NVS_ATE_CRC8
+
+config NVS_ATE_CRC8
+	bool "CRC-8"
+	help
+	  Need less storage room than CRC-24, but is far less robust.
+
+config NVS_ATE_CRC24
+	bool "CRC-24"
+	help
+	  Need 2 extra bytes of NVS storage for each ATE, but is far more
+	  robust than CRC-8.
+
+endchoice # NVS_ATE_CRC
+
 module = NVS
 module-str = nvs
 source "subsys/logging/Kconfig.template.log_config"

--- a/subsys/fs/nvs/nvs_priv.h
+++ b/subsys/fs/nvs/nvs_priv.h
@@ -45,12 +45,17 @@ struct nvs_ate {
 	uint16_t offset;	/* data offset within sector */
 	uint16_t len;	/* data len within sector */
 	uint8_t part;	/* part of a multipart data - future extension */
-	uint8_t crc8;	/* crc8 check of the entry */
+#ifdef CONFIG_NVS_ATE_CRC8
+	uint8_t crc;	/* CRC-8 check of the entry */
+#else
+	uint8_t crc[3];	/* CRC-24 check of the entry */
+#endif
 } __packed;
 
-BUILD_ASSERT(offsetof(struct nvs_ate, crc8) ==
-		 sizeof(struct nvs_ate) - sizeof(uint8_t),
-		 "crc8 must be the last member");
+
+BUILD_ASSERT(offsetof(struct nvs_ate, crc) ==
+		 sizeof(struct nvs_ate) - SIZEOF_FIELD(struct nvs_ate, crc),
+		 "crc must be the last member");
 
 #ifdef __cplusplus
 }

--- a/tests/subsys/fs/nvs/testcase.yaml
+++ b/tests/subsys/fs/nvs/testcase.yaml
@@ -26,3 +26,22 @@ tests:
       - CONFIG_NVS_LOOKUP_CACHE=y
       - CONFIG_NVS_LOOKUP_CACHE_SIZE=64
     platform_allow: native_sim
+  filesystem.nvs.ate_crc24:
+    extra_args:
+      - CONFIG_NVS_ATE_CRC24=y
+    platform_allow:
+      - native_sim
+      - qemu_x86
+  filesystem.nvs.ate_crc24_cache:
+    extra_args:
+      - CONFIG_NVS_ATE_CRC24=y
+      - CONFIG_NVS_LOOKUP_CACHE=y
+      - CONFIG_NVS_LOOKUP_CACHE_SIZE=64
+    platform_allow: native_sim
+  filesystem.nvs.ate_crc24_data_crc:
+    extra_args:
+      - CONFIG_NVS_ATE_CRC24=y
+      - CONFIG_NVS_DATA_CRC=y
+    platform_allow:
+      - native_sim
+      - qemu_x86


### PR DESCRIPTION
Our current application requires a more robust CRC than CRC-8.
This pull requests allows to select the current ATE CRC-8 (this is the default choice), or to select a CRC-24 for improved robustness.
This 3-byte CRC requires 2 more flash memory bytes per ATE than the 1-byte CRC.