### PR TITLE
bugfix: driver: esp32: eth_mdio: fix clock and function calls

### DIFF
--- a/drivers/ethernet/eth_esp32.c
+++ b/drivers/ethernet/eth_esp32.c
@@ -212,8 +212,9 @@ int eth_esp32_initialize(const struct device *dev)
 	clock_control_subsys_t clock_subsys =
 		(clock_control_subsys_t)DT_CLOCKS_CELL(DT_NODELABEL(eth), offset);
 
+	/* clock is shared, so do not bail out if already enabled */
 	res = clock_control_on(clock_dev, clock_subsys);
-	if (res != 0) {
+	if (res < 0 && res != -EALREADY) {
 		goto err;
 	}
 

--- a/drivers/ethernet/eth_esp32.c
+++ b/drivers/ethernet/eth_esp32.c
@@ -18,6 +18,8 @@
 #include <hal/emac_hal.h>
 #include <hal/emac_ll.h>
 #include <soc/rtc.h>
+#include <soc/io_mux_reg.h>
+#include <clk_ctrl_os.h>
 
 #include "eth.h"
 
@@ -200,6 +202,35 @@ static void phy_link_state_changed(const struct device *phy_dev,
 	}
 }
 
+#if DT_INST_NODE_HAS_PROP(0, ref_clk_output_gpios)
+static int emac_config_apll_clock(void)
+{
+	uint32_t expt_freq = MHZ(50);
+	uint32_t real_freq = 0;
+	esp_err_t ret = periph_rtc_apll_freq_set(expt_freq, &real_freq);
+
+	if (ret == ESP_ERR_INVALID_ARG) {
+		LOG_ERR("Set APLL clock coefficients failed");
+		return -EIO;
+	}
+
+	if (ret == ESP_ERR_INVALID_STATE) {
+		LOG_INF("APLL is occupied already, it is working at %d Hz", real_freq);
+	}
+
+	/* If the difference of real APLL frequency
+	 * is not within 50 ppm, i.e. 2500 Hz,
+	 * the APLL is unavailable
+	 */
+	if (abs((int)real_freq - (int)expt_freq) > 2500) {
+		LOG_ERR("The APLL is working at an unusable frequency");
+		return -EIO;
+	}
+
+	return 0;
+}
+#endif /* DT_INST_NODE_HAS_PROP(0, ref_clk_output_gpios) */
+
 int eth_esp32_initialize(const struct device *dev)
 {
 	struct eth_esp32_dev_data *const dev_data = dev->data;
@@ -253,10 +284,14 @@ int eth_esp32_initialize(const struct device *dev)
 			DT_INST_GPIO_PIN(0, ref_clk_output_gpios) == 17,
 			"Only GPIO16/17 are allowed as a GPIO REF_CLK source!");
 		int ref_clk_gpio = DT_INST_GPIO_PIN(0, ref_clk_output_gpios);
-
 		emac_hal_iomux_rmii_clk_output(ref_clk_gpio);
 		emac_ll_clock_enable_rmii_output(dev_data->hal.ext_regs);
-		rtc_clk_apll_enable(true, 0, 0, 6, 2);
+		periph_rtc_apll_acquire();
+		res = emac_config_apll_clock();
+		if (res != 0) {
+			goto err;
+		}
+		rtc_clk_apll_enable(true);
 #else
 		emac_hal_iomux_rmii_clk_input();
 		emac_ll_clock_enable_rmii_input(dev_data->hal.ext_regs);

--- a/drivers/mdio/mdio_esp32.c
+++ b/drivers/mdio/mdio_esp32.c
@@ -104,8 +104,9 @@ static int mdio_esp32_initialize(const struct device *dev)
 	clock_control_subsys_t clock_subsys =
 		(clock_control_subsys_t)DT_CLOCKS_CELL(DT_NODELABEL(mdio), offset);
 
+	/* clock is shared, so do not bail out if already enabled */
 	res = clock_control_on(clock_dev, clock_subsys);
-	if (res != 0) {
+	if (res < 0 && res != -EALREADY) {
 		goto err;
 	}
 

--- a/west.yml
+++ b/west.yml
@@ -157,7 +157,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 99dce9490ef4a84ddffe75c9d8853b30008c64bc
+      revision: e4e8df61b371554f4ce08d203426d7875421666e
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
Both MDIO and Ethernet drivers share the same clock subsystem. After clock control update in #73807, clock_control_on() now returns -EALREADY for already initialized clock subsystem. As a result, ethernet driver won't initialize as needed. 
Due to the same clock control and hal updates, internal functions required updates.

Fixes #74440
Fixes #74632

As this PR updates hal_espressif, it also fixes #74632.