### PR TITLE
scripts: fixed missing argument in parse_from_attribute call.

### DIFF
--- a/scripts/footprint/size_report
+++ b/scripts/footprint/size_report
@@ -82,7 +82,7 @@ def get_die_mapped_address(die, parser, dwarfinfo):
         if 'DW_AT_location' in die.attributes:
             loc_attr = die.attributes['DW_AT_location']
             if parser.attribute_has_location(loc_attr, die.cu['version']):
-                loc = parser.parse_from_attribute(loc_attr, die.cu['version'])
+                loc = parser.parse_from_attribute(loc_attr, die.cu['version'], die)
                 if isinstance(loc, LocationExpr):
                     addr = describe_DWARF_expr(loc.loc_expr,
                                                dwarfinfo.structs)


### PR DESCRIPTION
In size_report script, if the DWARF section of ELF file contains both debug_loc and a debug_loclists sections, LocationListsPair class is used to track locations. In that case, parse_from_attribute was missing one argument which was causing the script to fail.