### PR TITLE
tests: arch: arm: arm_irq_vector_table: exclude Renesas RA ICU

### DIFF
--- a/drivers/interrupt_controller/Kconfig.renesas_ra
+++ b/drivers/interrupt_controller/Kconfig.renesas_ra
@@ -5,5 +5,6 @@ config RENESAS_RA_ICU
 	bool "Renesas RA series interrupt controller unit"
 	default y
 	depends on DT_HAS_RENESAS_RA_INTERRUPT_CONTROLLER_UNIT_ENABLED
+	select GEN_ISR_TABLES
 	help
 	  Renesas RA series interrupt controller unit

--- a/tests/arch/arm/arm_irq_vector_table/testcase.yaml
+++ b/tests/arch/arm/arm_irq_vector_table/testcase.yaml
@@ -7,7 +7,7 @@ common:
   arch_allow: arm
 tests:
   arch.arm.irq_vector_table:
-    filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
+    filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE and
+            not CONFIG_GEN_ISR_TABLES
     platform_exclude:
       - mr_canhubk3
-      - arduino_uno_r4_minima


### PR DESCRIPTION
This fix will comprehensively exclude not only the Arduino Uno R4 Minima but also any board that uses the Renesas RA ICU.

Fixes #74398