### PR TITLE
arm64: linker: lld: Handle symtab/strtab/shstrtab to fix warnings

### DIFF
--- a/include/zephyr/arch/arm64/scripts/linker.ld
+++ b/include/zephyr/arch/arm64/scripts/linker.ld
@@ -335,6 +335,15 @@ SECTIONS
 
     /DISCARD/ : { *(.note.GNU-stack) }
 
+/* Output section descriptions are needed for these sections to suppress
+ * warnings when "--orphan-handling=warn" is set for lld.
+ */
+#if defined(CONFIG_LLVM_USE_LLD)
+    SECTION_PROLOGUE(.symtab, 0,) { *(.symtab) }
+    SECTION_PROLOGUE(.strtab, 0,) { *(.strtab) }
+    SECTION_PROLOGUE(.shstrtab, 0,) { *(.shstrtab) }
+#endif
+
     /* Sections generated from 'zephyr,memory-region' nodes */
     LINKER_DT_SECTIONS()
 


### PR DESCRIPTION
lld will produce warnings for the symtab, strtab, and shstrtab sections if --orphan-handling=warn is specified and there are no matching rules in the linker script for these sections.

Handle these sections when building with lld to prevent the warnings.