### PR TITLE
net: lib: http_server: Fix dynamic HTTP post zero 0 length reply issue

### DIFF
--- a/subsys/net/lib/http/http_server_http1.c
+++ b/subsys/net/lib/http/http_server_http1.c
@@ -233,11 +233,10 @@ static int dynamic_post_req(struct http_resource_detail_dynamic *dynamic_detail,
 			}
 
 			(void)http_server_sendall(client, crlf, 2);
-
-			offset += copy_len;
-			remaining -= copy_len;
 		}
 
+		offset += copy_len;
+		remaining -= copy_len;
 		copy_len = MIN(remaining, dynamic_detail->data_buffer_len);
 	}
 


### PR DESCRIPTION
Returning 0 from a dynamic detail callback as reply length (`send_len`) resulted in an infinite loop because it prevented `offset` and `remaining` counters to be processed.


