### PR TITLE
soc: nordic: common: dmm: Initialize dmm as early as possible

### DIFF
--- a/soc/nordic/common/dmm.c
+++ b/soc/nordic/common/dmm.c
@@ -293,5 +293,3 @@ int dmm_init(void)
 
 	return 0;
 }
-
-SYS_INIT(dmm_init, POST_KERNEL, 0);

--- a/soc/nordic/common/dmm.h
+++ b/soc/nordic/common/dmm.h
@@ -139,6 +139,14 @@ int dmm_buffer_in_prepare(void *region, void *user_buffer, size_t user_length, v
  */
 int dmm_buffer_in_release(void *region, void *user_buffer, size_t user_length, void *buffer_in);
 
+/**
+ * @brief Initialize DMM.
+ *
+ * @retval 0 If succeeded.
+ * @retval -errno Negative errno code on failure.
+ */
+int dmm_init(void);
+
 /** @endcond */
 
 #else
@@ -175,6 +183,11 @@ static ALWAYS_INLINE int dmm_buffer_in_release(void *region, void *user_buffer, 
 	ARG_UNUSED(user_buffer);
 	ARG_UNUSED(user_length);
 	ARG_UNUSED(buffer_in);
+	return 0;
+}
+
+static ALWAYS_INLINE int dmm_init(void)
+{
 	return 0;
 }
 

--- a/soc/nordic/nrf54h/soc.c
+++ b/soc/nordic/nrf54h/soc.c
@@ -14,6 +14,7 @@
 #include <hal/nrf_lrcconf.h>
 #include <hal/nrf_spu.h>
 #include <soc/nrfx_coredep.h>
+#include <dmm.h>
 
 LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 
@@ -88,12 +89,19 @@ static int trim_hsfll(void)
 
 static int nordicsemi_nrf54h_init(void)
 {
+	int err;
+
 	sys_cache_instr_enable();
 	sys_cache_data_enable();
 
 	power_domain_init();
 
 	trim_hsfll();
+
+	err = dmm_init();
+	if (err < 0) {
+		return err;
+	}
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(ccm030), okay)
 	/* DMASEC is set to non-secure by default, which prevents CCM from


### PR DESCRIPTION
DMM shall be initialized as early as possible to allow drivers to use it. For example, uart may need it early since it starts RX during initilization in some configurations.