### PR TITLE
soc: stm32: config DBGMCU register writing for SWO configuration

### DIFF
--- a/soc/st/stm32/common/soc_config.c
+++ b/soc/st/stm32/common/soc_config.c
@@ -30,7 +30,7 @@ static int st_stm32_common_config(void)
 #if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_SOC_SERIES_STM32H5X)
 	LL_DBGMCU_EnableTraceClock();
 #endif
-#if !defined(CONFIG_SOC_SERIES_STM32WBX)
+#if !defined(CONFIG_SOC_SERIES_STM32WBX) && defined(DBGMCU_CR_TRACE_IOEN)
 	LL_DBGMCU_SetTracePinAssignment(LL_DBGMCU_TRACE_ASYNCH);
 #endif
 #endif /* CONFIG_LOG_BACKEND_SWO */


### PR DESCRIPTION
Some stm32 series, do not have a LL_DBGMCU_SetTracePinAssignment function  to enable trace IO port, this is the case with the stm32h7 serie.

Completes the https://github.com/zephyrproject-rtos/zephyr/pull/44585

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/74375