### PR TITLE
Enable bluetooth for MIMXRT1040-EVK

### DIFF
--- a/boards/nxp/mimxrt1040_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1040_evk/doc/index.rst
@@ -122,6 +122,8 @@ already supported, which can also be re-used on this mimxrt1040_evk board:
 |           |            | :ref:`rk043fn02h_ct`, and           |
 |           |            | :ref:`rk043fn66hs_ctg` shields      |
 +-----------+------------+-------------------------------------+
+| UART      | NXP NW61x  | M.2 WIFI/BT module                  |
++-----------+------------+-------------------------------------+
 
 The default configuration can be found in
 :zephyr_file:`boards/nxp/mimxrt1040_evk/mimxrt1040_evk_defconfig`
@@ -162,6 +164,14 @@ The MIMXRT1040 SoC has five pairs of pinmux/gpio controllers.
 +---------------+-----------------+---------------------------+
 | GPIO_AD_B1_01 | LPI2C1_SDA      | I2C Data                  |
 +---------------+-----------------+---------------------------+
+| GPIO_AD_B1_06 | LPUART3_TX      | M.2 BT HCI                |
++---------------+-----------------+---------------------------+
+| GPIO_AD_B1_07 | LPUART3_RX      | M.2 BT HCI                |
++---------------+-----------------+---------------------------+
+| GPIO_AD_B1_04 | LPUART3_CTS_b   | M.2 BT HCI                |
++---------------+-----------------+---------------------------+
+| GPIO_AD_B1_05 | LPUART3_RTS_b   | M.2 BT HCI                |
++---------------+-----------------+---------------------------+
 
 .. note::
         In order to use the SPI peripheral on this board, resistors R350, R346,
@@ -182,7 +192,20 @@ Serial Port
 ===========
 
 The MIMXRT1040 SoC has eight UARTs. ``LPUART1`` is configured for the console,
+``LPUART3`` for the Bluetooth Host Controller Interface (BT HCI),
 and the remaining UARTs are not used.
+
+Fetch Binary Blobs
+==================
+
+The board Bluetooth/WiFi module requires fetching some binary blob files, to do
+that run the command:
+
+.. code-block:: console
+
+   west blobs fetch hal_nxp
+
+.. note:: Only Bluetooth functionality is currently supported.
 
 Programming and Debugging
 *************************
@@ -303,6 +326,16 @@ steps:
 
 #. Reset by pressing SW1
 
+Bluetooth Module
+----------------
+
+For Murate 2EL M.2 Mdoule, the following hardware rework needs to be applied,
+Solder 0 ohm resistors for R96, and R93.
+Remove resistors from R497, R498, R456 and R457.
+
+And due to pin conflict issue, the PCM interface of Bluetooth module cannot be supported.
+
+For the debugger fails to connect with the following error, please refer to section `WiFi Module`.
 
 WiFi Module
 -----------

--- a/boards/nxp/mimxrt1040_evk/mimxrt1040_evk-pinctrl.dtsi
+++ b/boards/nxp/mimxrt1040_evk/mimxrt1040_evk-pinctrl.dtsi
@@ -94,6 +94,37 @@
 		};
 	};
 
+	pinmux_lpuart3_flowcontrol: pinmux_lpuart3_flowcontrol {
+		group0 {
+			pinmux = <&iomuxc_gpio_ad_b1_04_lpuart3_cts_b>,
+				<&iomuxc_gpio_ad_b1_05_lpuart3_rts_b>,
+				<&iomuxc_gpio_ad_b1_06_lpuart3_tx>,
+				<&iomuxc_gpio_ad_b1_07_lpuart3_rx>;
+			drive-strength = "r0-6";
+			slew-rate = "slow";
+			nxp,speed = "100-mhz";
+		};
+	};
+
+	pinmux_lpuart3_sleep: pinmux_lpuart3_sleep {
+		group0 {
+			pinmux = <&iomuxc_gpio_ad_b1_05_gpio1_io21>,
+				<&iomuxc_gpio_ad_b1_07_gpio1_io23>;
+			drive-strength = "r0";
+			bias-pull-up;
+			bias-pull-up-value = "100k";
+			slew-rate = "slow";
+			nxp,speed = "50-mhz";
+		};
+		group1 {
+			pinmux = <&iomuxc_gpio_ad_b1_04_lpuart3_cts_b>,
+				<&iomuxc_gpio_ad_b1_06_lpuart3_tx>;
+			drive-strength = "r0-6";
+			slew-rate = "slow";
+			nxp,speed = "100-mhz";
+		};
+	};
+
 	pinmux_lcdif: pinmux_lcdif {
 		group0 {
 			pinmux = <&iomuxc_gpio_b0_00_lcdif_clk>,

--- a/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.dts
+++ b/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.dts
@@ -29,6 +29,7 @@
 		zephyr,flash = &w25q64jvssiq;
 		zephyr,flash-controller = &w25q64jvssiq;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,bt-hci = &bt_hci_uart;
 	};
 
 	sdram0: memory@80000000 {
@@ -213,4 +214,30 @@ zephyr_lcdif: &lcdif {
 
 &systick {
 	status = "okay";
+};
+
+m2_hci_uart: &lpuart3 {
+	pinctrl-0 = <&pinmux_lpuart3_flowcontrol>;
+	pinctrl-1 = <&pinmux_lpuart3_sleep>;
+	pinctrl-names = "default", "sleep";
+
+	bt_hci_uart: bt_hci_uart {
+		compatible = "zephyr,bt-hci-uart";
+
+		m2_bt_module {
+			compatible = "nxp,bt-hci-uart";
+			sdio-reset-gpios = <&gpio3 4 GPIO_ACTIVE_HIGH>;
+			w-disable-gpios = <&gpio3 2 GPIO_ACTIVE_HIGH>;
+			hci-operation-speed = <115200>;
+			hw-flow-control;
+			fw-download-primary-speed = <115200>;
+			fw-download-secondary-speed = <3000000>;
+			fw-download-secondary-flowcontrol;
+		};
+	};
+};
+
+&m2_hci_uart {
+	status = "okay";
+	current-speed = <115200>;
 };

--- a/samples/bluetooth/handsfree/boards/mimxrt1040_evk_mimxrt1042.conf
+++ b/samples/bluetooth/handsfree/boards/mimxrt1040_evk_mimxrt1042.conf
@@ -1,0 +1,2 @@
+#select NXP NW612 Chipset
+CONFIG_BT_NXP_NW612=y

--- a/samples/bluetooth/handsfree_ag/boards/mimxrt1040_evk_mimxrt1042.conf
+++ b/samples/bluetooth/handsfree_ag/boards/mimxrt1040_evk_mimxrt1042.conf
@@ -1,0 +1,2 @@
+#select NXP NW612 Chipset
+CONFIG_BT_NXP_NW612=y


### PR DESCRIPTION
Add Bluetooth support for MIMXRT1040-EVK. Currently, only support Murata 2EL M.2 module.

Add MIMXRT1040-EVK board support to sample handsfree/handsfree_ag.
