### PR TITLE
boards: st: stm32h735g_disco: enable USB device support

### DIFF
--- a/boards/st/stm32h735g_disco/doc/index.rst
+++ b/boards/st/stm32h735g_disco/doc/index.rst
@@ -69,10 +69,12 @@ The current Zephyr stm32h735g_disco board configuration supports the following h
 +-----------+------------+-------------------------------------+
 | FDCAN2    | on-chip    | CAN-FD Controller                   |
 +-----------+------------+-------------------------------------+
-| FDCAN2    | on-chip    | CAN-FD Controller (disabled by      |
+| FDCAN3    | on-chip    | CAN-FD Controller (disabled by      |
 |           |            | default. Solder bridges SB29 and    |
 |           |            | SB30 need to be closed for FDCAN3   |
 |           |            | to work)                            |
++-----------+------------+-------------------------------------+
+| USB       | on-chip    | usb_device                          |
 +-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on Zephyr porting.

--- a/boards/st/stm32h735g_disco/stm32h735g_disco.dts
+++ b/boards/st/stm32h735g_disco/stm32h735g_disco.dts
@@ -246,3 +246,9 @@
 		max-bitrate = <8000000>;
 	};
 };
+
+zephyr_udc0: &usbotg_hs {
+	status = "okay";
+	pinctrl-0 = <&usb_otg_hs_dm_pa11 &usb_otg_hs_dp_pa12>;
+	pinctrl-names = "default";
+};

--- a/boards/st/stm32h735g_disco/stm32h735g_disco.yaml
+++ b/boards/st/stm32h735g_disco/stm32h735g_disco.yaml
@@ -16,4 +16,5 @@ supported:
   - adc
   - counter
   - can
+  - usb_device
 vendor: st


### PR DESCRIPTION
Enable USB device support on the stm32h735g_disco board.