### PR TITLE
doc: Misc trivial formatting clean-ups

### DIFF
--- a/boards/altr/max10/doc/index.rst
+++ b/boards/altr/max10/doc/index.rst
@@ -172,7 +172,7 @@ directly into RAM and then boot it from the __start symbol.
 In order for this to work, your entire kernel must be located in RAM. Make sure
 the following config options are disabled:
 
-.. code-block:: console
+.. code-block:: cfg
 
    CONFIG_XIP=n
    CONFIG_INCLUDE_RESET_VECTOR=n
@@ -265,7 +265,7 @@ In order for this to work, execute-in-place must be disabled, since the GDB
 'load' command can only put text and data in RAM. Ensure this is in your
 configuration:
 
-.. code-block:: console
+.. code-block:: cfg
 
    CONFIG_XIP=n
 

--- a/boards/arduino/portenta_h7/doc/index.rst
+++ b/boards/arduino/portenta_h7/doc/index.rst
@@ -15,6 +15,7 @@ with 2MBytes of Flash memory, 1MB RAM, 480 MHz CPU, Art Accelerator, L1 cache, e
 large set of peripherals, SMPS, and MIPI-DSI.
 
 Additionally, the board features:
+
 - USB OTG FS
 - 3 color user LEDs
 

--- a/boards/nxp/lpcxpresso55s69/doc/index.rst
+++ b/boards/nxp/lpcxpresso55s69/doc/index.rst
@@ -124,6 +124,7 @@ included during the build process.
 
 CPU1 does not work without CPU0 enabling it.
 To enable it, run one of the following samples in ``subsys\ipc``:
+
 - ``ipm_mcux``
 - ``openamp``
 

--- a/boards/nxp/mimxrt1170_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1170_evk/doc/index.rst
@@ -344,6 +344,7 @@ Configuring a Debug Probe
 A debug probe is used for both flashing and debugging the board. The on-board
 debugger listed below works with the LinkServer runner by default, or can be
 reprogrammed with JLink firmware.
+
 - MIMXRT1170-EVKB: :ref:`mcu-link-cmsis-onboard-debug-probe`
 - MIMXRT1170-EVK:  :ref:`opensda-daplink-onboard-debug-probe`
 
@@ -392,10 +393,12 @@ We will use the on-board debugger
 microcontroller as a usb-to-serial adapter for the serial console. The following
 jumper settings are default on these boards, and are required to connect the
 UART signals to the USB bridge circuit:
+
 - MIMXRT1170-EVKB: JP2 open (default)
 - MIMXRT1170-EVK:  J31 and J32 shorted (default)
 
 Connect a USB cable from your PC to the on-board debugger USB port:
+
 - MIMXRT1170-EVKB: J86
 - MIMXRT1170-EVK:  J11
 

--- a/boards/nxp/rd_rw612_bga/doc/index.rst
+++ b/boards/nxp/rd_rw612_bga/doc/index.rst
@@ -177,6 +177,7 @@ To use ethernet on the RD_RW612_BGA board, you first need to make the following
 modifications to the board hardware:
 
 Add resistors:
+
 - R485
 - R486
 - R487
@@ -184,7 +185,9 @@ Add resistors:
 - R489
 - R491
 - R490
+
 Remove resistors:
+
 - R522
 - R521
 - R520

--- a/boards/phytec/mimx8mp_phyboard_pollux/doc/index.rst
+++ b/boards/phytec/mimx8mp_phyboard_pollux/doc/index.rst
@@ -178,7 +178,7 @@ change it to
 In your prj.conf overwrite the configuration like this for the **DDR** memory
 region:
 
-.. code-block:: console
+.. code-block:: cfg
 
    CONFIG_CODE_DDR=y
    CONFIG_CODE_ITCM=n

--- a/boards/seco/stm32f3_seco_d23/doc/index.rst
+++ b/boards/seco/stm32f3_seco_d23/doc/index.rst
@@ -194,7 +194,9 @@ Flashing an application to SECO SBC-3.5-PX30
 
 First, connect the SECO SBC-3.5-PX30 to your host computer using
 CN56 connector to an ST-Link.
+
 The pinout is (1-8):
+
 - VDD
 - UART1_TX
 - UART1_RX

--- a/boards/seeed/lora_e5_dev_board/doc/lora_e5_dev_board.rst
+++ b/boards/seeed/lora_e5_dev_board/doc/lora_e5_dev_board.rst
@@ -112,6 +112,7 @@ features:
 Other hardware features are not yet supported on this Zephyr port.
 
 The default configuration can be found in:
+
 - :zephyr_file:`boards/seeed/lora_e5_dev_board/lora_e5_dev_board_defconfig`
 - :zephyr_file:`boards/seeed/lora_e5_dev_board/lora_e5_dev_board.dts`
 

--- a/boards/st/b_g474e_dpow1/doc/index.rst
+++ b/boards/st/b_g474e_dpow1/doc/index.rst
@@ -42,6 +42,7 @@ More information about the board can be found at the `B-G474E-DPOW1 website`_.
 
 
 More information about STM32G474RE can be found here:
+
 - `G474RE on www.st.com`_
 - `STM32G4 reference manual`_
 

--- a/boards/st/nucleo_wba52cg/doc/nucleo_wba52cg.rst
+++ b/boards/st/nucleo_wba52cg/doc/nucleo_wba52cg.rst
@@ -262,7 +262,9 @@ Debugging using STM32CubeIDE
 ----------------------------
 
 You can debug an application using a STM32WBA compatible version of STM32CubeIDE.
+
 For that:
+
 - Create an empty STM32WBA project by going to File > New > STM32 project
 - Select your MCU, click Next, and select an Empty project.
 - Right click on your project name, select Debug as > Debug configurations

--- a/boards/st/nucleo_wba55cg/doc/nucleo_wba55cg.rst
+++ b/boards/st/nucleo_wba55cg/doc/nucleo_wba55cg.rst
@@ -275,7 +275,9 @@ Debugging using STM32CubeIDE
 ----------------------------
 
 You can debug an application using a STM32WBA compatible version of STM32CubeIDE.
+
 For that:
+
 - Create an empty STM32WBA project by going to File > New > STM32 project
 - Select your MCU, click Next, and select an Empty project.
 - Right click on your project name, select Debug as > Debug configurations

--- a/boards/st/stm32g071b_disco/doc/index.rst
+++ b/boards/st/stm32g071b_disco/doc/index.rst
@@ -51,6 +51,7 @@ More information about the board can be found at the `STM32G071B-DISCO website`_
 
 
 More information about STM32G071RB can be found here:
+
 - `G071RB on www.st.com`_
 - `STM32G071 reference manual`_
 

--- a/boards/st/stm32g081b_eval/doc/index.rst
+++ b/boards/st/stm32g081b_eval/doc/index.rst
@@ -92,6 +92,7 @@ More information about the board can be found at the `STM32G081B-EVAL website`_.
 
 
 More information about STM32G081RB can be found here:
+
 - `G081RB on www.st.com`_
 - `STM32G081 reference manual`_
 

--- a/boards/xen/xenvm/doc/index.rst
+++ b/boards/xen/xenvm/doc/index.rst
@@ -79,10 +79,12 @@ configuration by altering device tree and Kconfig options. This will be covered
 in detail in next section.
 
 Most of Xen-specific features are not supported at the moment. This includes:
+
 * XenBus (under development)
 * Xen PV drivers
 
 Now only following features are supported:
+
 * Xen Enlighten memory page
 * Xen event channels
 * Xen PV console (2 versions: regular ring buffer based for DomU and consoleio for Dom0)

--- a/doc/connectivity/networking/api/mqtt_sn.rst
+++ b/doc/connectivity/networking/api/mqtt_sn.rst
@@ -131,6 +131,7 @@ Deviations from the standard
 ****************************
 
 Certain parts of the protocol are not yet supported in the library.
+
 * Pre-defined topic IDs
 * QoS -1 - it's most useful with predefined topics
 * Gateway discovery using ADVERTISE, SEARCHGW and GWINFO messages.

--- a/doc/connectivity/networking/qemu_user_setup.rst
+++ b/doc/connectivity/networking/qemu_user_setup.rst
@@ -33,7 +33,7 @@ Using SLIRP with Zephyr
 In order to use SLIRP with Zephyr, the user has to set the Kconfig option to
 enable User Networking.
 
-.. code-block:: console
+.. code-block:: cfg
 
    CONFIG_NET_QEMU_USER=y
 
@@ -58,7 +58,7 @@ offloads this to the user, and expects that they will provide arguments
 based on requirements. For this, there is a Kconfig string which can be
 populated by the user.
 
-.. code-block:: console
+.. code-block:: cfg
 
    CONFIG_NET_QEMU_USER_EXTRA_ARGS="net=192.168.0.0/24,hostfwd=tcp::8080-:8080"
 

--- a/doc/develop/application/index.rst
+++ b/doc/develop/application/index.rst
@@ -1253,7 +1253,7 @@ An example of loading ``stm31l0`` specific Kconfig files in this structure:
 
 can be done with the following content in ``st/stm32/Kconfig.soc``:
 
-.. code-block:: none
+.. code-block:: kconfig
 
    rsource "*/Kconfig.soc"
 

--- a/doc/develop/application/index.rst
+++ b/doc/develop/application/index.rst
@@ -639,7 +639,7 @@ Application configuration options are usually set in :file:`prj.conf` in the
 application directory. For example, C++ support could be enabled with this
 assignment:
 
-.. code-block:: none
+.. code-block:: cfg
 
    CONFIG_CPP=y
 
@@ -666,7 +666,7 @@ marked ``[EXPERIMENTAL]`` in their Kconfig title.
 The :kconfig:option:`CONFIG_WARN_EXPERIMENTAL` setting can be used to enable warnings
 at CMake configure time if any experimental feature is enabled.
 
-.. code-block:: none
+.. code-block:: cfg
 
    CONFIG_WARN_EXPERIMENTAL=y
 

--- a/doc/develop/flash_debug/nordic_segger.rst
+++ b/doc/develop/flash_debug/nordic_segger.rst
@@ -160,7 +160,7 @@ which can be very useful if the UART (through USB CDC ACM) is already being used
 a purpose different than logging (such as HCI traffic in the hci_uart application).
 To use RTT, you will first need to enable it by adding the following lines in your ``.conf`` file:
 
-.. code-block:: text
+.. code-block:: cfg
 
    CONFIG_USE_SEGGER_RTT=y
    CONFIG_RTT_CONSOLE=y
@@ -178,7 +178,7 @@ with the RTT one if they are enabled by default in the particular sample or
 application you are running. For example, to disable the UART console,
 add this to your ``.conf`` file:
 
-.. code-block:: console
+.. code-block:: cfg
 
    CONFIG_UART_CONSOLE=n
 

--- a/doc/develop/languages/c/picolibc.rst
+++ b/doc/develop/languages/c/picolibc.rst
@@ -74,7 +74,7 @@ To build without toolchain bundled Picolibc, the toolchain must
 enable :kconfig:option:`CONFIG_PICOLIBC_SUPPORTED`. For example,
 this needs to be added to the toolchain Kconfig file:
 
-.. code-block:: none
+.. code-block:: kconfig
 
    config TOOLCHAIN_<name>_PICOLIBC_SUPPORTED
       def_bool y

--- a/doc/project/dev_env_and_tools.rst
+++ b/doc/project/dev_env_and_tools.rst
@@ -210,10 +210,10 @@ Developers are expected to fix issues and rework their patches and submit again.
 
 The CI infrastructure currently runs the following tests:
 
-- Run ''checkpatch'' for code style issues (can vote -1 on errors; see note)
+- Run ``checkpatch`` for code style issues (can vote -1 on errors; see note)
 - Gitlint: Git commit style based on project requirements
 - License Check: Check for conflicting licenses
-- Run ''twister'' script
+- Run ``twister`` script
 
   - Run kernel tests in QEMU (can vote -1 on errors)
   - Build various samples for different boards (can vote -1 on errors)
@@ -222,10 +222,12 @@ The CI infrastructure currently runs the following tests:
 
 .. note::
 
-   ''checkpatch'' is a Perl script that uses regular expressions to
+   ``checkpatch`` is a Perl script that uses regular expressions to
    extract information that requires a C language parser to process
    accurately.  As such it sometimes issues false positives.  Known
-   cases include constructs like::
+   cases include constructs like:
+
+    .. code-block:: c
 
       static uint8_t __aligned(PAGE_SIZE) page_pool[PAGE_SIZE * POOL_PAGES];
       IOPCTL_Type *base = config->base;
@@ -264,46 +266,43 @@ These are the labels we currently have, grouped by applicability:
 Labels applicable to issues only
 ================================
 
-* *priority: {high|medium|low}*
+.. list-table::
+   :header-rows: 1
 
-To classify the impact and importance of a bug or
-:ref:`feature <feature-tracking>`.
+   * - Label
+     - Description
 
-Note: Issue priorities are generally set or changed during the bug-triage or TSC
-meetings.
+   * - :guilabel:`priority: {high|medium|low}`
+     - To classify the impact and importance of a bug or
+       :ref:`feature <feature-tracking>`.
 
-* *Regression*
+       Note: Issue priorities are generally set or changed during the bug-triage or TSC
+       meetings.
 
-Something, which was working, but does not anymore (bug subtype).
+   * - :guilabel:`Regression`
+     - Something, which was working, but does not anymore (bug subtype).
 
-* *Enhancement*
+   * - :guilabel:`Enhancement`
+     - Changes/Updates/Additions to existing :ref:`features <feature-tracking>`.
 
-Changes/Updates/Additions to existing :ref:`features <feature-tracking>`.
+   * - :guilabel:`Feature request`
+     - A request for a new :ref:`feature <feature-tracking>`.
 
-* *Feature request*
+   * - :guilabel:`Feature`
+     - A :ref:`planned feature<feature-tracking>` with a milestone.
 
-A request for a new :ref:`feature <feature-tracking>`.
+   * - :guilabel:`Hardware Support`
+     - Covers porting an existing feature (including Zephyr itself) to new hardware.
 
-* *Feature*
+   * - :guilabel:`Duplicate`
+     - This issue is a duplicate of another issue (please specify).
 
-A :ref:`planned feature<feature-tracking>` with a milestone.
+   * - :guilabel:`Good first issue`
+     - Good for a first time contributor to take.
 
-* *Hardware Support*
-
-Covers porting an existing feature (including Zephyr itself) to new hardware.
-
-* *Duplicate*
-
-This issue is a duplicate of another issue (please specify).
-
-* *Good first issue*
-
-Good for a first time contributor to take.
-
-* *Release Notes*
-
-Issues that need to be mentioned in release notes as known issues with
-additional information.
+   * - :guilabel:`Release Notes`
+     - Issues that need to be mentioned in release notes as known issues with
+       additional information.
 
 Any issue must be classified and labeled as either *Bug*, *Enhancement*, *RFC*,
 *Feature*, *Feature Request* or *Hardware Support*. More information on how
@@ -315,36 +314,37 @@ Labels applicable to pull requests only
 
 The issue or PR describes a change to a stable API.
 
-* *Hotfix*
+.. list-table::
+   :header-rows: 1
 
-Fix for an issue blocking development.
+   * - Label
+     - Description
 
-* *Trivial*
+   * - :guilabel:`Hotfix`
+     - Fix for an issue blocking development.
 
-* *Maintainer*
+   * - :guilabel:`Trivial`
+     - Simple changes that can have shorter review time and be reviewed by anyone, i.e. typos,
+       straightforward one-liner bug fixes, etc.
 
-Maintainer review required.
+   * - :guilabel:`Maintainer`
+     - Maintainer review required.
 
-* *Security Review*
+   * - :guilabel:`Security Review`
+     - To be reviewed by a security expert.
 
-To be reviewed by a security expert.
+   * - :guilabel:`DNM`
+     - This PR should not be merged (Do Not Merge). For work in progress, GitHub
+       "draft" PRs are preferred.
 
-* *DNM*
+   * - :guilabel:`Needs review`
+     - The PR needs attention from the maintainers.
 
-This PR should not be merged (Do Not Merge). For work in progress, GitHub
-"draft" PRs are preferred.
+   * - :guilabel:`Backport`
+     - The PR is a backport or should be backported.
 
-* *Needs review*
-
-The PR needs attention from the maintainers.
-
-* *Backport*
-
-The PR is a backport or should be backported.
-
-* *Licensing*
-
-The PR has licensing issues which require a licensing expert to review it.
+   * - :guilabel:`Licensing`
+     - The PR has licensing issues which require a licensing expert to review it.
 
 .. note::
    For all labels applicable to PRs: Please note that the label, together with
@@ -355,74 +355,66 @@ The PR has licensing issues which require a licensing expert to review it.
 Labels applicable to both pull requests and issues
 ==================================================
 
-* *area: **
+.. list-table::
+   :header-rows: 1
 
-Indicates Zephyr subsystems (e.g, *area: Kernel*, *area: I2C*,
-*area: Memory Management*), project functions (e.g., *area: Debugging*,
-*area: Documentation*, *area: Process*), or other categories (e.g.,
-*area: Coding Style*, *area: MISRA-C*) affected by the bug or the pull request.
+   * - Label
+     - Description
 
-An area maintainer should be able to filter by an area label and find all issues
-and PRs which relate to that area.
+   * - :guilabel:`area: {area-name}`
+     - Indicates Zephyr subsystems (e.g, :guilabel:`area: Kernel`, :guilabel:`area: I2C`,
+       :guilabel:`area: Memory Management`), project functions (e.g., :guilabel:`area: Debugging`,
+       :guilabel:`area: Documentation`, :guilabel:`area: Process`), or other categories (e.g.,
+       :guilabel:`area: Coding Style`, :guilabel:`area: MISRA-C`) affected by the bug or the pull request.
 
-* *platform: **
+       An area maintainer should be able to filter by an area label and find all issues
+       and PRs which relate to that area.
 
-An issue or PR which affects only a particular platform.
+   * - :guilabel:`platform: {platform-name}`
+     - An issue or PR which affects only a particular platform.
 
-* *dev-review*
+   * - :guilabel:`dev-review`
+     - The issue is to be discussed in the following `dev-review`_ if time
+       permits.
 
-The issue is to be discussed in the following `dev-review`_ if time
-permits.
+       .. _`dev-review`: https://github.com/zephyrproject-rtos/zephyr/wiki/Zephyr-Committee-and-Working-Group-Meetings#zephyr-dev-meeting
 
-.. _`dev-review`: https://github.com/zephyrproject-rtos/zephyr/wiki/Zephyr-Committee-and-Working-Group-Meetings#zephyr-dev-meeting
+   * - :guilabel:`TSC`
+     - TSC stands for Technical Steering Committee. The issue is to be discussed in the
+       following `TSC meeting`_ if time permits.
 
-* *TSC*
+       .. _`TSC meeting`: https://github.com/zephyrproject-rtos/zephyr/wiki/Zephyr-Committee-and-Working-Group-Meetings#technical-steering-committee-tsc
 
-TSC stands for Technical Steering Committee. The issue is to be discussed in the
-following `TSC meeting`_ if time permits.
+   * - :guilabel:`Breaking API Change`
+     - The issue or PR describes a breaking change to a stable API. See additional information
+       in :ref:`breaking_api_changes`.
 
-.. _`TSC meeting`: https://github.com/zephyrproject-rtos/zephyr/wiki/Zephyr-Committee-and-Working-Group-Meetings#technical-steering-committee-tsc
+   * - :guilabel:`bug`
+     - The issue is a bug, or the PR is fixing a bug.
 
-* *Breaking API Change*
+   * - :guilabel:`Coverity`
+     - A Coverity detected issue or its fix.
 
-The issue or PR describes a breaking change to a stable API. See additional information
-in :ref:`breaking_api_changes`.
+   * - :guilabel:`Waiting for response`
+     - The Zephyr developers are waiting for the submitter to respond to a question, or
+       address an issue.
 
-* *Bug*
+   * - :guilabel:`Blocked`
+     - Blocked by another PR or issue.
 
-The issue is a bug, or the PR is fixing a bug.
+   * - :guilabel:`Stale`
+     - An issue or a PR which seems abandoned, and requires attention by the author.
 
-* *Coverity*
+   * - :guilabel:`In progress`
+     - For PRs: is work in progress and should not be merged yet. For issues: Is being
+       worked on.
 
-A Coverity detected issue or its fix.
+   * - :guilabel:`RFC`
+     - The author would like input from the community. For a PR it should be considered
+       a draft.
 
-* *Waiting for response*
+   * - :guilabel:`LTS`
+     - Long term release branch related.
 
-The Zephyr developers are waiting for the submitter to respond to a question, or
-address an issue.
-
-* *Blocked*
-
-Blocked by another PR or issue.
-
-* *Stale*
-
-An issue or a PR which seems abandoned, and requires attention by the author.
-
-* *In progress*
-
-For PRs: is work in progress and should not be merged yet. For issues: Is being
-worked on.
-
-* *RFC*
-
-The author would like input from the community. For a PR it should be considered
-a draft.
-
-* *LTS*
-
-Long term release branch related.
-
-* *EXT*
-
-Related to an external component.
+   * - :guilabel:`EXT`
+     - Related to an external component.

--- a/samples/bluetooth/hci_uart/README.rst
+++ b/samples/bluetooth/hci_uart/README.rst
@@ -173,7 +173,7 @@ so:
 On the host application, some config options need to be used to select the H4
 driver instead of the built-in controller:
 
-.. code-block:: kconfig
+.. code-block:: cfg
 
    CONFIG_BT_HCI=y
    CONFIG_BT_CTLR=n

--- a/samples/bluetooth/hci_uart_3wire/README.rst
+++ b/samples/bluetooth/hci_uart_3wire/README.rst
@@ -173,7 +173,7 @@ so:
 On the host application, some config options need to be used to select the H5
 driver instead of the built-in controller:
 
-.. code-block:: kconfig
+.. code-block:: cfg
 
    CONFIG_BT_HCI=y
    CONFIG_BT_CTLR=n

--- a/samples/bluetooth/hci_uart_async/README.rst
+++ b/samples/bluetooth/hci_uart_async/README.rst
@@ -139,7 +139,7 @@ so:
 On the host application, some config options need to be used to select the H4
 driver instead of the built-in controller:
 
-.. code-block:: kconfig
+.. code-block:: cfg
 
    CONFIG_BT_HCI=y
    CONFIG_BT_CTLR=n

--- a/samples/modules/tflite-micro/hello_world/README.rst
+++ b/samples/modules/tflite-micro/hello_world/README.rst
@@ -98,7 +98,7 @@ It is recommended that you copy and modify one of the two TensorFlow
 samples when creating your own TensorFlow project. To build with
 TensorFlow, you must enable the below Kconfig options in your :file:`prj.conf`:
 
-.. code-block:: kconfig
+.. code-block:: cfg
 
     CONFIG_CPP=y
     CONFIG_REQUIRES_FULL_LIBC=y
@@ -108,7 +108,7 @@ Note that the CMSIS-NN kernel sample demonstrates how to use CMSIS-NN optimized 
 TensorFlow Lite Micro, in that is sets below Kconfig option. Note also that this
 Kconfig option is only set for Arm Cortex-M cores, i.e. option CPU_CORTEX_M is set.
 
-.. code-block:: kconfig
+.. code-block:: cfg
 
     CONFIG_TENSORFLOW_LITE_MICRO_CMSIS_NN_KERNELS=y
 

--- a/samples/modules/tflite-micro/magic_wand/README.rst
+++ b/samples/modules/tflite-micro/magic_wand/README.rst
@@ -111,7 +111,7 @@ It is recommended that you copy and modify one of the two TensorFlow
 samples when creating your own TensorFlow project. To build with
 TensorFlow, you must enable the below Kconfig options in your :file:`prj.conf`:
 
-.. code-block:: kconfig
+.. code-block:: cfg
 
     CONFIG_CPP=y
     CONFIG_REQUIRES_FULL_LIBC=y

--- a/samples/net/cloud/mqtt_azure/README.rst
+++ b/samples/net/cloud/mqtt_azure/README.rst
@@ -38,23 +38,23 @@ copied from `<https://github.com/Azure/azure-iot-sdk-c/blob/master/certs/certs.c
 Configure the following Kconfig options based on your Azure Cloud IoT Hub
 in your own overlay config file:
 
-- SAMPLE_CLOUD_AZURE_USERNAME - Username field use::
+- ``SAMPLE_CLOUD_AZURE_USERNAME`` - Username field use::
 
     {iothubhostname}/{device_id}/?api-version=2018-06-30,
 
   where ``{iothubhostname}`` is the full CName of the IoT hub.
 
-- SAMPLE_CLOUD_AZURE_PASSWORD    - Password field, use an SAS token.
-- SAMPLE_CLOUD_AZURE_CLIENT_ID   - ClientId field, use the deviceId.
-- SAMPLE_CLOUD_AZURE_HOSTNAME    - IoT hub hostname
-- SAMPLE_CLOUD_AZURE_SERVER_ADDR - IP address of the Azure MQTT broker
-- SAMPLE_CLOUD_AZURE_SERVER_PORT - Port number of the Azure MQTT broker
+- ``SAMPLE_CLOUD_AZURE_PASSWORD``    - Password field, use an SAS token.
+- ``SAMPLE_CLOUD_AZURE_CLIENT_ID``   - ClientId field, use the deviceId.
+- ``SAMPLE_CLOUD_AZURE_HOSTNAME``    - IoT hub hostname
+- ``SAMPLE_CLOUD_AZURE_SERVER_ADDR`` - IP address of the Azure MQTT broker
+- ``SAMPLE_CLOUD_AZURE_SERVER_PORT`` - Port number of the Azure MQTT broker
 
 You'll also need to set these Kconfig options if you're running
 the sample behind a proxy:
 
-- SAMPLE_SOCKS_ADDR - IP address of SOCKS5 Proxy server
-- SAMPLE_SOCKS_PORT - Port number of SOCKS5 Proxy server
+- ``SAMPLE_SOCKS_ADDR`` - IP address of SOCKS5 Proxy server
+- ``SAMPLE_SOCKS_PORT`` - Port number of SOCKS5 Proxy server
 
 On your Linux host computer, open a terminal window, locate the source code
 of this sample application (i.e., :zephyr_file:`samples/net/cloud/mqtt_azure`) and type:

--- a/samples/net/cloud/mqtt_azure/README.rst
+++ b/samples/net/cloud/mqtt_azure/README.rst
@@ -76,7 +76,7 @@ Sample overlay file
 
 This is the overlay template for Azure IoT hub and other details:
 
-.. code-block:: console
+.. code-block:: cfg
 
 	CONFIG_SAMPLE_CLOUD_AZURE_USERNAME="<username>"
 	CONFIG_SAMPLE_CLOUD_AZURE_PASSWORD="<SAS token>"

--- a/samples/net/dns_resolve/README.rst
+++ b/samples/net/dns_resolve/README.rst
@@ -47,7 +47,7 @@ In this sample application, both static or DHCPv4 IP addresses are supported.
 Static IP addresses are specified in the project configuration file,
 for example:
 
-.. code-block:: console
+.. code-block:: cfg
 
 	CONFIG_NET_CONFIG_MY_IPV6_ADDR="2001:db8::1"
 	CONFIG_NET_CONFIG_PEER_IPV6_ADDR="2001:db8::2"
@@ -75,7 +75,7 @@ the appropriate 'prj.conf' file and update the DNS server addresses.  For
 instance, if using the usual IP addresses assigned to testing, update them
 to the following values:
 
-.. code-block:: console
+.. code-block:: cfg
 
     CONFIG_DNS_SERVER1="192.0.2.2:5353"
     CONFIG_DNS_SERVER2="[2001:db8::2]:5353"
@@ -113,7 +113,7 @@ LLMNR Responder
 If you want Zephyr to respond to a LLMNR DNS request that Windows host is
 sending, then following config options could be set:
 
-.. code-block:: console
+.. code-block:: cfg
 
     CONFIG_NET_HOSTNAME_ENABLE=y
     CONFIG_NET_HOSTNAME="zephyr-device"

--- a/samples/net/mqtt_publisher/README.rst
+++ b/samples/net/mqtt_publisher/README.rst
@@ -84,9 +84,9 @@ following macros to specify those values:
 
 Max number of MQTT PUBLISH iterations is defined in Kconfig:
 
-.. code-block:: c
+.. code-block:: cfg
 
-	CONFIG_NET_SAMPLE_APP_MAX_ITERATIONS	5
+	CONFIG_NET_SAMPLE_APP_MAX_ITERATIONS=5
 
 On your Linux host computer, open a terminal window, locate the source code
 of this sample application (i.e., :zephyr_file:`samples/net/mqtt_publisher`) and type:
@@ -202,9 +202,9 @@ Sample output
 
 This is the output from the FRDM UART console, with:
 
-.. code-block:: c
+.. code-block:: cfg
 
-	CONFIG_NET_SAMPLE_APP_MAX_ITERATIONS     5
+	CONFIG_NET_SAMPLE_APP_MAX_ITERATIONS=5
 
 .. code-block:: console
 

--- a/samples/net/sockets/http_server/README.rst
+++ b/samples/net/sockets/http_server/README.rst
@@ -103,7 +103,7 @@ CPU Usage Profiling
 We can use ``perf`` to collect statistics about the CPU usage of our server
 running in native_sim board with the ``stat`` command:
 
-.. code-block:: bash
+.. code-block:: console
 
    $ sudo perf stat -p <pid_of_server>
 
@@ -117,14 +117,14 @@ Hotspot Analysis
 ``perf record`` and ``perf report`` can be used together to identify the
 functions in our code that consume the most CPU time:
 
-.. code-block:: bash
+.. code-block:: console
 
    $ sudo perf record -g -p <pid_of_server> -o perf.data
 
 After running our server under load (For example, using ApacheBench tool),
 we can stop the recording and analyze the data using:
 
-.. code-block:: bash
+.. code-block:: console
 
    $ sudo perf report -i perf.data
 
@@ -136,13 +136,13 @@ spending the most time.
 To do this, we need to convert the ``perf.data`` to a format that ``FlameGraph``
 can understand:
 
-.. code-block:: bash
+.. code-block:: console
 
    $ sudo perf script | ~/FlameGraph/stackcollapse-perf.pl > out.perf-folded
 
 And, then, generate the ``FlameGraph``:
 
-.. code-block:: bash
+.. code-block:: console
 
    $ ~/FlameGraph/flamegraph.pl out.perf-folded > flamegraph.svg
 

--- a/samples/net/syslog_net/README.rst
+++ b/samples/net/syslog_net/README.rst
@@ -26,7 +26,7 @@ Building and Running
 For configuring the remote IPv6 syslog server, set the following
 variables in prj.conf file:
 
-.. code-block:: console
+.. code-block:: cfg
 
 	CONFIG_LOG_BACKEND_NET=y
 	CONFIG_LOG_BACKEND_NET_SERVER="[2001:db8::2]:514"

--- a/samples/net/tftp_client/README.rst
+++ b/samples/net/tftp_client/README.rst
@@ -56,13 +56,17 @@ Build the tftp-client sample application for :ref:`native_sim <native_sim>` like
 Download and run a TFTP server (like TFTPd), then create file1.bin (with data) and newfile.bin.
 
 Please note that default IP server address is 192.0.2.2 and default port is 69.
-To specify an IP server address and/or port, change configurations in ``prj.conf``::
+To specify an IP server address and/or port, change these configurations in ``prj.conf``:
+
+.. code-block:: cfg
 
     CONFIG_TFTP_APP_SERVER="10.0.0.10"
     CONFIG_TFTP_APP_PORT="70"
 
 To connect to server using hostname, enable DNS resolver by changing these two
-configurations in ``prj.conf``::
+configurations in ``prj.conf``:
+
+.. code-block:: cfg
 
     CONFIG_DNS_RESOLVER=y
     CONFIG_TFTP_APP_SERVER="my-tftp-server.org"
@@ -70,13 +74,16 @@ configurations in ``prj.conf``::
 Sample output
 ==================================
 
-Sample run on native_sim platform with TFTP server on host machine
-Launch net-setup.sh in net-tools
-.. code-block:: console
+This sample can be run on :ref:`native_sim<native_sim>` while running a TFTP server on the host
+machine.
+
+Launch :command:`net-setup.sh` in net-tools:
+
+.. code-block:: bash
 
    net-setup.sh
 
-.. code-block:: console
+.. code-block:: bash
 
     <inf> net_config: Initializing network
     <inf> net_config: IPv4 address: 192.0.2.1

--- a/samples/net/vlan/README.rst
+++ b/samples/net/vlan/README.rst
@@ -22,8 +22,8 @@ Building and Running
 ********************
 
 A good way to run this VLAN application is with QEMU as described in
-:ref:`networking_with_eth_qemu`. You can use *zeth-vlan.conf* configuration
-file when running *net-setup.sh* script in Linux like this:
+:ref:`networking_with_eth_qemu`. You can use :file:`zeth-vlan.conf` configuration
+file when running :file:`net-setup.sh` script in Linux like this:
 
 .. code-block:: console
 
@@ -41,8 +41,8 @@ Follow these steps to build the VLAN sample application:
    :goals: build
    :compact:
 
-The default configuration file prj.conf creates two virtual LAN networks
-with these settings:
+The default configuration file :zephyr_file:`samples/net/vlan/prj.conf` creates
+two virtual LAN networks with these settings:
 
 - VLAN tag 100: IPv4 198.51.100.1 and IPv6 2001:db8:100::1
 - VLAN tag 200: IPv4 203.0.113.1 and IPv6 2001:db8:200::1
@@ -51,8 +51,8 @@ Setting up Linux Host
 =====================
 
 The :zephyr_file:`samples/net/vlan/vlan-setup-linux.sh` provides a script that
-can be executed on the Linux host. It creates two VLAN interfaces *vlan.100*
-and *vlan.200* on the Linux host and creates routes to Zephyr.
+can be executed on the Linux host. It creates two VLAN interfaces ``vlan.100``
+and ``vlan.200`` on the Linux host and creates routes to Zephyr.
 
 If everything is configured correctly, you will be able to successfully execute
 the following commands on the Linux host.
@@ -64,6 +64,6 @@ the following commands on the Linux host.
     ping -c 1 2001:db8:200::1
     ping -c 1 203.0.113.1
 
-The network packets to *2001:db8:100::1* or *198.51.100.1* will have VLAN
+The network packets to ``2001:db8:100::1`` or ``198.51.100.1`` will have VLAN
 tag 100 set to them. The vlan tag 200 will be set to network packets to
-*2001:db8:200::1* or *203.0.113.1*.
+``2001:db8:200::1`` or ``203.0.113.1``.

--- a/samples/sensor/bq274xx/README.rst
+++ b/samples/sensor/bq274xx/README.rst
@@ -6,7 +6,8 @@ BQ274XX Sensor Sample
 Overview
 ********
 
-This sample application retrieves all the fuel gauge parameters,
+This sample application retrieves all the fuel gauge parameters:
+
 - Voltage, in volts
 - Average current, in amps
 - Standby current, in amps

--- a/samples/sensor/qdec/README.rst
+++ b/samples/sensor/qdec/README.rst
@@ -10,6 +10,7 @@ This sample reads the value of the counter which has been configured in
 quadrature decoder mode.
 
 It requires:
+
 * an external mechanical encoder
 * pin to be properly configured in the device tree
 

--- a/samples/subsys/logging/ble_backend/README.rst
+++ b/samples/subsys/logging/ble_backend/README.rst
@@ -12,7 +12,7 @@ BLE Logger uses the NRF Connect SDK NUS service as UUID to make it compatible
 with already existing apps to debug BLE connections over UART.
 
 The notification size of the ble backend buffer is dependent on the
-transmission size of the mtu set with `CONFIG_BT_L2CAP_TX_MTU`. Be sure
+transmission size of the mtu set with :kconfig:option:`CONFIG_BT_L2CAP_TX_MTU`. Be sure
 to change this configuration to increase the logger throughput over BLE.
 
 Requirements

--- a/samples/subsys/mgmt/osdp/README.rst
+++ b/samples/subsys/mgmt/osdp/README.rst
@@ -20,12 +20,13 @@ too much resource requirements. The security is not top-notch (AES-128) but it
 is reasonable enough, given that the alternative is no security at all.
 
 OSDP Supports the control of the following components on a PD:
-   - LED
-   - Buzzer
-   - Keypad
-   - Output (GPIOs)
-   - Input Control (GPIOs)
-   - Displays
-   - Device status (tamper, power, etc.,)
-   - Card Reader
-   - Fingerprint Reader
+
+- LED
+- Buzzer
+- Keypad
+- Output (GPIOs)
+- Input Control (GPIOs)
+- Displays
+- Device status (tamper, power, etc.,)
+- Card Reader
+- Fingerprint Reader

--- a/samples/subsys/usb/audio/headphones_microphone/README.rst
+++ b/samples/subsys/usb/audio/headphones_microphone/README.rst
@@ -27,6 +27,7 @@ Testing
 *******
 
 Steps to test the sample:
+
 - Build and flash the sample as described above.
 - Connect to the HOST.
 - Chose default Audio IN/OUT.

--- a/samples/subsys/usb/audio/headset/README.rst
+++ b/samples/subsys/usb/audio/headset/README.rst
@@ -26,6 +26,7 @@ Testing
 *******
 
 Steps to test the sample:
+
 - Build and flash the sample as described above.
 - Connect to the HOST.
 - Chose default Audio IN/OUT.

--- a/samples/subsys/usb/console/README.rst
+++ b/samples/subsys/usb/console/README.rst
@@ -29,7 +29,7 @@ for the reel_board board:
 
 Plug the board into a host device, for sample, a PC running Linux OS.
 The board will be detected as a CDC_ACM serial device. To see the console output
-from the sample, use a command similar to "minicom -D /dev/ttyACM0".
+from the sample, use a command similar to :command:`minicom -D /dev/ttyACM0`.
 
 .. code-block:: console
 
@@ -41,5 +41,5 @@ from the sample, use a command similar to "minicom -D /dev/ttyACM0".
 Troubleshooting
 ===============
 
-You may need to stop modemmanager via "sudo stop modemmanager", if it is
+You may need to stop :program:`modemmanager` via :command:`sudo stop modemmanager`, if it is
 trying to access the device in the background.

--- a/samples/tfm_integration/psa_crypto/README.rst
+++ b/samples/tfm_integration/psa_crypto/README.rst
@@ -74,11 +74,13 @@ This sample will only build on a Linux or macOS development system
 
 TF-M BL2 logs
 =============
-Add the following to ``prj.conf`` to see the logs from TF-M BL2:
-   .. code-block:: bash
 
-      CONFIG_TFM_BL2=y
-      CONFIG_TFM_CMAKE_BUILD_TYPE_DEBUG=y
+Add the following to ``prj.conf`` to see the logs from TF-M BL2:
+
+.. code-block:: cfg
+
+   CONFIG_TFM_BL2=y
+   CONFIG_TFM_CMAKE_BUILD_TYPE_DEBUG=y
 
 On MPS2+ AN521:
 ===============

--- a/samples/userspace/syscall_perf/README.rst
+++ b/samples/userspace/syscall_perf/README.rst
@@ -12,11 +12,11 @@ Overview
 ********
 
 This application creates a supervisor and a user thread.
-Then both threads call k_current_get() which returns a reference to the
+Then both threads call :c:func:`k_current_get()` which returns a reference to the
 current thread. The user thread has to go through a system call.
 
 Both threads are showing the number of core clock cycles and the number of
-instructions executed while calling k_current_get().
+instructions executed while calling :c:func:`k_current_get()`.
 
 
 Sample Output


### PR DESCRIPTION
See commits, everything should be pretty straightforward and they're only fixing actual rendering issues (or sub-optimal rendering, ex. syntax highlighting), content hasn't been touched.

**Note**: the fix made to https://docs.zephyrproject.org/latest/project/dev_env_and_tools.html#labels-applicable-to-issues-only (a preview of the new look being captured below for convenience) in the last commit is maybe slightly more substantial than the other changes, so I can move this to another PR if people prefer...

# BEFORE

![image](https://github.com/zephyrproject-rtos/zephyr/assets/128251/bf6ec60b-e152-4427-a995-fedbef9a72c5)

# AFTER

![image](https://github.com/zephyrproject-rtos/zephyr/assets/128251/37b05f56-3570-40ea-9f44-b2ac60f941aa)

