### PR TITLE
Bluetooth: BAP: Support setting different values per dir in CIG

### DIFF
--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -1143,8 +1143,10 @@ struct bt_bap_unicast_group_param {
 /**
  * @brief Create audio unicast group.
  *
- * Create a new audio unicast group with one or more audio streams as a unicast client. Streams in
- * a unicast group shall share the same interval, framing and latency (see @ref bt_audio_codec_qos).
+ * Create a new audio unicast group with one or more audio streams as a unicast client.
+ * All streams shall share the same framing.
+ * All streams in the same direction shall share the same interval and latency (see
+ * @ref bt_audio_codec_qos).
  *
  * @param[in]  param          The unicast group create parameters.
  * @param[out] unicast_group  Pointer to the unicast group created.

--- a/subsys/bluetooth/audio/bap_endpoint.h
+++ b/subsys/bluetooth/audio/bap_endpoint.h
@@ -64,11 +64,27 @@ struct bt_bap_ep {
 	struct bt_bap_broadcast_sink *broadcast_sink;
 };
 
+struct bt_bap_unicast_group_cig_param {
+	uint32_t c_to_p_interval;
+	uint32_t p_to_c_interval;
+	uint16_t c_to_p_latency;
+	uint16_t p_to_c_latency;
+	uint8_t framing;
+	uint8_t packing;
+#if defined(CONFIG_BT_ISO_TEST_PARAMS)
+	uint8_t c_to_p_ft;
+	uint8_t p_to_c_ft;
+	uint16_t iso_interval;
+#endif /* CONFIG_BT_ISO_TEST_PARAMS */
+};
+
 struct bt_bap_unicast_group {
+	/* Group-wide QoS used to create the CIG */
+	struct bt_bap_unicast_group_cig_param cig_param;
+
+	/* Unicast group fields */
 	uint8_t index;
 	bool allocated;
-	/* QoS used to create the CIG */
-	const struct bt_audio_codec_qos *qos;
 	struct bt_iso_cig *cig;
 	/* The ISO API for CIG creation requires an array of pointers to ISO channels */
 	struct bt_iso_chan *cis[UNICAST_GROUP_STREAM_CNT];

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
@@ -52,7 +52,7 @@ static struct bt_bap_ep *g_sources[CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT];
 static struct bt_bap_unicast_group_stream_pair_param pair_params[ARRAY_SIZE(test_streams)];
 static struct bt_bap_unicast_group_stream_param stream_params[ARRAY_SIZE(test_streams)];
 
-/* Mandatory support preset by both client and server */
+/*Mandatory support preset by both client and server */
 static struct bt_bap_lc3_preset preset_16_2_1 = BT_BAP_LC3_UNICAST_PRESET_16_2_1(
 	BT_AUDIO_LOCATION_FRONT_LEFT, BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED);
 
@@ -627,7 +627,8 @@ static void discover_sources(void)
 	WAIT_FOR_FLAG(flag_source_discovered);
 }
 
-static int codec_configure_stream(struct bt_bap_stream *stream, struct bt_bap_ep *ep)
+static int codec_configure_stream(struct bt_bap_stream *stream, struct bt_bap_ep *ep,
+				  struct bt_audio_codec_cfg *codec_cfg)
 {
 	int err;
 
@@ -636,7 +637,7 @@ static int codec_configure_stream(struct bt_bap_stream *stream, struct bt_bap_ep
 
 	do {
 
-		err = bt_bap_stream_config(default_conn, stream, ep, &preset_16_2_1.codec_cfg);
+		err = bt_bap_stream_config(default_conn, stream, ep, codec_cfg);
 		if (err == -EBUSY) {
 			k_sleep(BAP_STREAM_RETRY_WAIT);
 		} else if (err != 0) {
@@ -656,7 +657,8 @@ static void codec_configure_streams(size_t stream_cnt)
 	for (size_t i = 0U; i < ARRAY_SIZE(pair_params); i++) {
 		if (pair_params[i].rx_param != NULL && g_sources[i] != NULL) {
 			struct bt_bap_stream *stream = pair_params[i].rx_param->stream;
-			const int err = codec_configure_stream(stream, g_sources[i]);
+			const int err = codec_configure_stream(stream, g_sources[i],
+							       &preset_16_2_1.codec_cfg);
 
 			if (err != 0) {
 				FAIL("Unable to configure source stream[%zu]: %d", i, err);
@@ -666,7 +668,8 @@ static void codec_configure_streams(size_t stream_cnt)
 
 		if (pair_params[i].tx_param != NULL && g_sinks[i] != NULL) {
 			struct bt_bap_stream *stream = pair_params[i].tx_param->stream;
-			const int err = codec_configure_stream(stream, g_sinks[i]);
+			const int err = codec_configure_stream(stream, g_sinks[i],
+							       &preset_16_2_1.codec_cfg);
 
 			if (err != 0) {
 				FAIL("Unable to configure sink stream[%zu]: %d", i, err);
@@ -1191,6 +1194,45 @@ static void test_main_acl_disconnect(void)
 	PASS("Unicast client ACL disconnect passed\n");
 }
 
+static void test_main_async_group(void)
+{
+	struct bt_bap_stream rx_stream = {0};
+	struct bt_bap_stream tx_stream = {0};
+	struct bt_audio_codec_qos rx_qos = BT_AUDIO_CODEC_QOS_UNFRAMED(7500U, 30U, 2U, 75U, 40000U);
+	struct bt_audio_codec_qos tx_qos =
+		BT_AUDIO_CODEC_QOS_UNFRAMED(10000U, 40U, 2U, 100U, 40000U);
+	struct bt_bap_unicast_group_stream_param rx_param = {
+		.qos = &rx_qos,
+		.stream = &rx_stream,
+	};
+	struct bt_bap_unicast_group_stream_param tx_param = {
+		.qos = &tx_qos,
+		.stream = &tx_stream,
+	};
+	struct bt_bap_unicast_group_stream_pair_param pair_param = {
+		.rx_param = &rx_param,
+		.tx_param = &tx_param,
+	};
+	struct bt_bap_unicast_group_param param = {
+		.params = &pair_param,
+		.params_count = 1U,
+		.packing = BT_ISO_PACKING_SEQUENTIAL,
+	};
+	struct bt_bap_unicast_group *unicast_group;
+	int err;
+
+	init();
+
+	err = bt_bap_unicast_group_create(&param, &unicast_group);
+	if (err != 0) {
+		FAIL("Unable to create unicast group: %d", err);
+
+		return;
+	}
+
+	PASS("Unicast client async group parameters passed\n");
+}
+
 static const struct bst_test_instance test_unicast_client[] = {
 	{
 		.test_id = "unicast_client",
@@ -1203,6 +1245,15 @@ static const struct bst_test_instance test_unicast_client[] = {
 		.test_pre_init_f = test_init,
 		.test_tick_f = test_tick,
 		.test_main_f = test_main_acl_disconnect,
+	},
+	{
+		.test_id = "unicast_client_async_group",
+		.test_pre_init_f = test_init,
+		.test_tick_f = test_tick,
+		.test_main_f = test_main_async_group,
+		.test_descr = "Tests that a unicast group (CIG) can be created with different "
+			      "values in each direction, such as 10000us SDU interval in C to P "
+			      "and 7500us for P to C",
 	},
 	BSTEST_END_MARKER,
 };

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_unicast_client_async_group.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_unicast_client_async_group.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2021-2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+SIMULATION_ID="bap_unicast_client_async_group"
+VERBOSITY_LEVEL=2
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+cd ${BSIM_OUT_PATH}/bin
+
+printf "\n\n======== BAP Unicast Client Aync Group parameters test =========\n\n"
+
+Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=unicast_client_async_group -rs=23 -D=1
+
+# Simulation time should be larger than the WAIT_TIME in common.h
+Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
+  -D=1 -sim_length=60e6 $@
+
+wait_for_background_jobs


### PR DESCRIPTION
The interval and latency for a CIG are set for each direction now, allowing applications to use e.g. 10ms for sink ASEs and 7.5ms for source ASEs.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/64186