### PR TITLE
drivers/flash: Add missing documentation for flash_fill

### DIFF
--- a/include/zephyr/drivers/flash.h
+++ b/include/zephyr/drivers/flash.h
@@ -316,6 +316,21 @@ static inline int z_impl_flash_erase(const struct device *dev, off_t offset,
 	return rc;
 }
 
+/**
+ * @brief Fill selected range of device with specified value
+ *
+ * Utility function that allows to fill specified range on a device with
+ * provided value. The @p offset and @p size of range need to be aligned to
+ * a write block size of a device.
+ *
+ * @param  dev             : flash device
+ * @param  val             : value to use for filling the range
+ * @param  offset          : offset of the range to fill
+ * @param  size            : size of the range
+ *
+ * @return  0 on success, negative errno code on fail.
+ *
+ */
 __syscall int flash_fill(const struct device *dev, uint8_t val, off_t offset, size_t size);
 
 /**


### PR DESCRIPTION
Add the missing flash_fill documentation.

Fixes #74407

### Rationale for 3.7.0 milestone
Please consider this for release 3.7.0 as a fix for incomplete documentation of Flash API.