### PR TITLE
Enabling support of OpenThread on TI CC1352P7

### DIFF
--- a/boards/ti/common/launchxl-pinctrl.dtsi
+++ b/boards/ti/common/launchxl-pinctrl.dtsi
@@ -18,6 +18,17 @@
 		input-enable;
 	};
 
+	/* UART1 */
+	uart1_tx_default: uart1_tx_default {
+		pinmux = <22 IOC_PORT_MCU_UART1_TX>;
+		bias-disable;
+	};
+	uart1_rx_default: uart1_rx_default {
+		pinmux = <24 IOC_PORT_MCU_UART1_RX>;
+		bias-disable;
+		input-enable;
+	};
+
 	/* I2C0 */
 	i2c0_scl_default: i2c0_scl_default {
 		pinmux = <4 IOC_PORT_MCU_I2C_MSSCL>;

--- a/boards/ti/common/launchxl.dtsi
+++ b/boards/ti/common/launchxl.dtsi
@@ -76,6 +76,13 @@
 	pinctrl-names = "default";
 };
 
+&uart1 {
+	status = "disabled";
+	current-speed = <115200>;
+	pinctrl-0 = <&uart1_rx_default &uart1_tx_default>;
+	pinctrl-names = "default";
+};
+
 &i2c0 {
 	status = "okay";
 	pinctrl-0 = <&i2c0_scl_default &i2c0_sda_default>;

--- a/drivers/ieee802154/ieee802154_cc13xx_cc26xx.c
+++ b/drivers/ieee802154/ieee802154_cc13xx_cc26xx.c
@@ -31,6 +31,10 @@ LOG_MODULE_REGISTER(ieee802154_cc13xx_cc26xx);
 
 #include "ieee802154_cc13xx_cc26xx.h"
 
+#if defined(CONFIG_NET_L2_OPENTHREAD)
+#include <zephyr/net/openthread.h>
+#endif
+
 /* Overrides from SmartRF Studio 7 2.13.0 */
 static uint32_t overrides[] = {
 	/* DC/DC regulator: In Tx, use DCDCCTL5[3:0]=0x3 (DITHER_EN=0 and IPEAK=3). */
@@ -802,11 +806,21 @@ static struct ieee802154_cc13xx_cc26xx_data ieee802154_cc13xx_cc26xx_data = {
 };
 
 #if defined(CONFIG_NET_L2_IEEE802154)
+#define L2 IEEE802154_L2
+#define L2_CTX_TYPE NET_L2_GET_CTX_TYPE(IEEE802154_L2)
+#define MTU IEEE802154_MTU
+#elif defined(CONFIG_NET_L2_OPENTHREAD)
+#define L2 OPENTHREAD_L2
+#define L2_CTX_TYPE NET_L2_GET_CTX_TYPE(OPENTHREAD_L2)
+#define MTU 1280
+#endif
+
+#if defined(CONFIG_NET_L2_IEEE802154) || defined(CONFIG_NET_L2_PHY_IEEE802154)
 NET_DEVICE_DT_INST_DEFINE(0, ieee802154_cc13xx_cc26xx_init, NULL,
 			  &ieee802154_cc13xx_cc26xx_data, NULL,
 			  CONFIG_IEEE802154_CC13XX_CC26XX_INIT_PRIO,
-			  &ieee802154_cc13xx_cc26xx_radio_api, IEEE802154_L2,
-			  NET_L2_GET_CTX_TYPE(IEEE802154_L2), IEEE802154_MTU);
+			  &ieee802154_cc13xx_cc26xx_radio_api, L2,
+			  L2_CTX_TYPE, MTU);
 #else
 DEVICE_DT_INST_DEFINE(0, ieee802154_cc13xx_cc26xx_init, NULL,
 		      &ieee802154_cc13xx_cc26xx_data, NULL, POST_KERNEL,

--- a/drivers/ieee802154/ieee802154_cc13xx_cc26xx.c
+++ b/drivers/ieee802154/ieee802154_cc13xx_cc26xx.c
@@ -777,7 +777,13 @@ static struct ieee802154_cc13xx_cc26xx_data ieee802154_cc13xx_cc26xx_data = {
 	},
 
 	.cmd_radio_setup = {
+#if defined(CONFIG_SOC_CC1352R) || defined(CONFIG_SOC_CC2652R) || \
+	defined(CONFIG_SOC_CC1352R7) || defined(CONFIG_SOC_CC2652R7)
 		.commandNo = CMD_RADIO_SETUP,
+#elif defined(CONFIG_SOC_CC1352P) || defined(CONFIG_SOC_CC2652P) || \
+	defined(CONFIG_SOC_CC1352P7) || defined(CONFIG_SOC_CC2652P7)
+		.commandNo = CMD_RADIO_SETUP_PA,
+#endif /* CONFIG_SOC_CCxx52x */
 		.status = IDLE,
 		.pNextOp = NULL,
 		.startTrigger.triggerType = TRIG_NOW,

--- a/drivers/ieee802154/ieee802154_cc13xx_cc26xx.h
+++ b/drivers/ieee802154/ieee802154_cc13xx_cc26xx.h
@@ -80,7 +80,15 @@ struct ieee802154_cc13xx_cc26xx_data {
 	volatile rfc_CMD_IEEE_CSMA_t cmd_ieee_csma;
 	volatile rfc_CMD_IEEE_TX_t cmd_ieee_tx;
 	volatile rfc_CMD_IEEE_RX_ACK_t cmd_ieee_rx_ack;
+#if defined(CONFIG_SOC_CC1352R) || defined(CONFIG_SOC_CC2652R) || \
+	defined(CONFIG_SOC_CC1352R7) || defined(CONFIG_SOC_CC2652R7)
 	volatile rfc_CMD_RADIO_SETUP_t cmd_radio_setup;
+#elif defined(CONFIG_SOC_CC1352P) || defined(CONFIG_SOC_CC2652P) || \
+	defined(CONFIG_SOC_CC1352P7) || defined(CONFIG_SOC_CC2652P7)
+	volatile rfc_CMD_RADIO_SETUP_PA_t cmd_radio_setup;
+#else
+	BUILD_ASSERT(false, "unknown model");
+#endif /* CONFIG_SOC_CCxx52x */
 
 	volatile int16_t saved_cmdhandle;
 };

--- a/samples/net/openthread/coprocessor/boards/cc1352p7_lp.overlay
+++ b/samples/net/openthread/coprocessor/boards/cc1352p7_lp.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2024 Alexandre Bailon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		/* Use XDS110 UART for the NCP */
+		zephyr,ot-uart = &uart0;
+		/* Use UART1 for debugging / zephyr console */
+		zephyr,shell-uart = &uart1;
+		zephyr,console = &uart1;
+	};
+};
+
+&uart1 {
+	status = "okay";
+};

--- a/samples/subsys/settings/socs/cc1352p7.conf
+++ b/samples/subsys/settings/socs/cc1352p7.conf
@@ -1,0 +1,1 @@
+CONFIG_NVS=y


### PR DESCRIPTION
This adds support of OpenThread to TI CC1352 and updates the OpenThread coprocessor application to support it the TI CC1352P7 Launchpad.
I used the CC1352P7 launchpad because I had a few of them in my closet).
I have only tested OpenThread on the launchpad (and on the beagleplay) but it should work on with all CC13x2 and CC26x2 SoC.
