### PR TITLE
drivers: adc: saadc: Disable burst mode on unused channels

### DIFF
--- a/drivers/adc/adc_nrfx_saadc.c
+++ b/drivers/adc/adc_nrfx_saadc.c
@@ -479,6 +479,10 @@ static int start_read(const struct device *dev,
 				m_data.positive_inputs[channel_id]);
 			++active_channels;
 		} else {
+			nrf_saadc_burst_set(
+				NRF_SAADC,
+				channel_id,
+				NRF_SAADC_BURST_DISABLED);
 			nrf_saadc_channel_pos_input_set(
 				NRF_SAADC,
 				channel_id,


### PR DESCRIPTION
Burst mode enabled on an unused channel causes a freeze during a conversion consisting of several channels (not including the one with burst mode enabled).

Discovered on nRF52832 (nRF52-DK) using the following approach:
  channels 0-3 are used for application purposes as a sequence
  channel 4 is used for battery measurements with oversampling

After few successful conversions the sequence (channels 0-3) freezes the thread while waiting for semaphore to end the conversion.

The pull-requests fixes the issue by explicitly disabling burst mode on all unused channels.
Previously burst mode remained set if once set.