### PR TITLE
scripts: checkpatch: add `stdio.h` `FILE` typedef

### DIFF
--- a/scripts/checkpatch/typedefsfile
+++ b/scripts/checkpatch/typedefsfile
@@ -7,3 +7,4 @@ pinctrl_soc_pin_t
 io_rw_32
 \b[a-zA-Z_][a-zA-Z0-9_]*TypeDef
 Pwm
+FILE


### PR DESCRIPTION
Add `FILE` typedef in the `stdio.h` so that when doing `FILE *file` definition checkpatch doesn't complain about the position of the '*' and fail in CI.

![Screenshot 2024-06-19 at 1 26 10 AM](https://github.com/zephyrproject-rtos/zephyr/assets/1563974/f7132487-eea2-41fc-a096-39c553cd4cd6)
