### PR TITLE
[DNM][Test only] llext: test coverage cleanup

### DIFF
--- a/samples/subsys/llext/modules/sample.yaml
+++ b/samples/subsys/llext/modules/sample.yaml
@@ -4,23 +4,38 @@ common:
     - arm
     - xtensa
   platform_exclude:
+    # platforms with active issues
     - apollo4p_evb            # See #73443
     - apollo4p_blue_kxr_evb   # See #73443
     - numaker_pfm_m487        # See #63167
+    - s32z2xxdc2/s32z270/rtu0 # See commit 18a0660
+    - s32z2xxdc2/s32z270/rtu1 # See commit 18a0660
+    # platforms that are always skipped by the runtime filter
+    - qemu_arc/qemu_arc_em
+    - qemu_arc/qemu_arc_hs
+    - qemu_arc/qemu_arc_hs/xip
+    - qemu_arc/qemu_arc_hs5x
+    - qemu_arc/qemu_arc_hs6x
+    - qemu_cortex_m0
+    - qemu_xtensa/dc233c/mmu
   integration_platforms:
-    - qemu_xtensa
-    - qemu_cortex_r5
-    - mps2/an385
+    - qemu_cortex_a9          # ARM Cortex-A9 (ARMv7-A ISA)
+    - qemu_cortex_r5          # ARM Cortex-R5 (ARMv7-R ISA)
+    - mps2/an385              # ARM Cortex-M3 (ARMv7-M ISA)
+    - mps2/an521/cpu0         # ARM Cortex-M33 (ARMv8-M ISA)
   harness: console
+
 sample:
   name: CONFIG_MODULES test
   description: Call code directly and from extensions
+
 tests:
   sample.llext.modules.module_build:
     filter: not CONFIG_MPU and not CONFIG_MMU and not CONFIG_SOC_SERIES_S32ZE
     extra_configs:
-      - CONFIG_HELLO_WORLD_MODE=m
       - arch:arm:CONFIG_ARM_MPU=n
+      - arch:arm:CONFIG_ARM_AARCH32_MMU=n
+      - CONFIG_HELLO_WORLD_MODE=m
     harness_config:
       type: one_line
       regex:

--- a/samples/subsys/llext/modules/sample.yaml
+++ b/samples/subsys/llext/modules/sample.yaml
@@ -21,7 +21,6 @@ tests:
     extra_configs:
       - CONFIG_HELLO_WORLD_MODE=m
       - arch:arm:CONFIG_ARM_MPU=n
-      - arch:xtensa:CONFIG_LLEXT_STORAGE_WRITABLE=y
     harness_config:
       type: one_line
       regex:

--- a/samples/subsys/llext/shell_loader/sample.yaml
+++ b/samples/subsys/llext/shell_loader/sample.yaml
@@ -1,17 +1,32 @@
 common:
-  tags: llext
+  tags: shell llext
   arch_allow:
     - arm
     - xtensa
   filter: not CONFIG_MPU and not CONFIG_MMU and not CONFIG_SOC_SERIES_S32ZE
   platform_exclude:
-    - numaker_pfm_m487 # See #63167
+    # platforms with active issues
+    - apollo4p_evb            # See #73443
+    - apollo4p_blue_kxr_evb   # See #73443
+    - numaker_pfm_m487        # See #63167
+    - s32z2xxdc2/s32z270/rtu0 # See commit 18a0660
+    - s32z2xxdc2/s32z270/rtu1 # See commit 18a0660
+    # platforms that are always skipped by the runtime filter
+    - qemu_arc/qemu_arc_em
+    - qemu_arc/qemu_arc_hs
+    - qemu_arc/qemu_arc_hs/xip
+    - qemu_arc/qemu_arc_hs5x
+    - qemu_arc/qemu_arc_hs6x
+    - qemu_cortex_m0
+    - qemu_xtensa/dc233c/mmu
+
 sample:
   description: Loadable extensions with shell sample
   name: Extension loader shell
+
 tests:
   sample.llext.shell:
-    tags: shell llext
     harness: keyboard
     extra_configs:
       - arch:arm:CONFIG_ARM_MPU=n
+      - arch:arm:CONFIG_ARM_AARCH32_MMU=n

--- a/subsys/llext/Kconfig
+++ b/subsys/llext/Kconfig
@@ -62,6 +62,7 @@ config LLEXT_SHELL_MAX_SIZE
 
 config LLEXT_STORAGE_WRITABLE
 	bool "llext storage is writable"
+	default y if XTENSA
 	help
 	  Select if LLEXT storage is writable, i.e. if extensions are stored in
 	  RAM and can be modified in place

--- a/tests/subsys/llext/simple/src/hello_world_ext.c
+++ b/tests/subsys/llext/simple/src/hello_world_ext.c
@@ -7,8 +7,11 @@
 /*
  * This very simple hello world C code can be used as a test case for building
  * probably the simplest loadable extension. It requires a single symbol be
- * linked, section relocation support, and the ability to export and call out to
- * a function.
+ * linked, section relocation support, and the ability to export and call out
+ * to a function.
+ *
+ * Note that this is also used in the llext_find_section test case, so it is
+ * important that number is the first symbol in the .data section.
  */
 
 #include <stdint.h>
@@ -16,7 +19,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/ztest_assert.h>
 
-static const uint32_t number = 42;
+uint32_t number = 42;
 
 void test_entry(void)
 {
@@ -25,3 +28,6 @@ void test_entry(void)
 	zassert_equal(number, 42);
 }
 LL_EXTENSION_SYMBOL(test_entry);
+
+/* for llext_find_section test case */
+LL_EXTENSION_SYMBOL(number);

--- a/tests/subsys/llext/simple/src/test_llext_simple.c
+++ b/tests/subsys/llext/simple/src/test_llext_simple.c
@@ -212,47 +212,55 @@ void load_call_unload(struct llext_test *test_case)
 		};								\
 		load_call_unload(&test_case);					\
 	}
-static LLEXT_CONST uint8_t hello_world_ext[] __aligned(4) = {
+
+/*
+ * ELF file should be aligned to at least sizeof(elf_word) to avoid issues. A
+ * larger value eases debugging, since it reduces the differences in addresses
+ * between similar runs.
+ */
+#define ELF_ALIGN __aligned(4096)
+
+static LLEXT_CONST uint8_t hello_world_ext[] ELF_ALIGN = {
 	#include "hello_world.inc"
 };
 LLEXT_LOAD_UNLOAD(hello_world, false, NULL)
 
-static LLEXT_CONST uint8_t logging_ext[] __aligned(4) = {
+static LLEXT_CONST uint8_t logging_ext[] ELF_ALIGN = {
 	#include "logging.inc"
 };
 LLEXT_LOAD_UNLOAD(logging, true, NULL)
 
-static LLEXT_CONST uint8_t relative_jump_ext[] __aligned(4) = {
+static LLEXT_CONST uint8_t relative_jump_ext[] ELF_ALIGN = {
 	#include "relative_jump.inc"
 };
 LLEXT_LOAD_UNLOAD(relative_jump, true, NULL)
 
-static LLEXT_CONST uint8_t object_ext[] __aligned(4) = {
+static LLEXT_CONST uint8_t object_ext[] ELF_ALIGN = {
 	#include "object.inc"
 };
 LLEXT_LOAD_UNLOAD(object, true, NULL)
 
 #ifndef CONFIG_LLEXT_TYPE_ELF_RELOCATABLE
-static LLEXT_CONST uint8_t syscalls_ext[] __aligned(4) = {
+static LLEXT_CONST uint8_t syscalls_ext[] ELF_ALIGN = {
 	#include "syscalls.inc"
 };
 LLEXT_LOAD_UNLOAD(syscalls, true, NULL)
 
-static LLEXT_CONST uint8_t threads_kernel_objects_ext[] __aligned(4) = {
+static LLEXT_CONST uint8_t threads_kernel_objects_ext[] ELF_ALIGN = {
 	#include "threads_kernel_objects.inc"
 };
 LLEXT_LOAD_UNLOAD(threads_kernel_objects, true, threads_objects_perm_setup)
 #endif
 
 #ifndef CONFIG_LLEXT_TYPE_ELF_OBJECT
-static LLEXT_CONST uint8_t multi_file_ext[] __aligned(4) = {
+static LLEXT_CONST uint8_t multi_file_ext[] ELF_ALIGN = {
 	#include "multi_file.inc"
 };
 LLEXT_LOAD_UNLOAD(multi_file, true, NULL)
 #endif
 
 #if defined(CONFIG_LLEXT_TYPE_ELF_RELOCATABLE) && defined(CONFIG_XTENSA)
-static LLEXT_CONST uint8_t pre_located_ext[] __aligned(4) = {
+static LLEXT_CONST uint8_t pre_located_ext[] ELF_ALIGN = {
 	#include "pre_located.inc"
 };
 

--- a/tests/subsys/llext/simple/testcase.yaml
+++ b/tests/subsys/llext/simple/testcase.yaml
@@ -1,12 +1,25 @@
 common:
   tags: llext
-  arch_allow:
-    - arm
-    - xtensa
   platform_exclude:
+    # platforms with active issues
     - apollo4p_evb            # See #73443
     - apollo4p_blue_kxr_evb   # See #73443
     - numaker_pfm_m487        # See #63167
+    - s32z2xxdc2/s32z270/rtu0 # See commit 18a0660
+    - s32z2xxdc2/s32z270/rtu1 # See commit 18a0660
+    # platforms that are always skipped by the runtime filter
+    - qemu_arc/qemu_arc_em
+    - qemu_arc/qemu_arc_hs
+    - qemu_arc/qemu_arc_hs/xip
+    - qemu_arc/qemu_arc_hs5x
+    - qemu_arc/qemu_arc_hs6x
+    - qemu_cortex_m0
+    - qemu_xtensa/dc233c/mmu
+  integration_platforms:
+    - qemu_cortex_a9          # ARM Cortex-A9 (ARMv7-A ISA)
+    - qemu_cortex_r5          # ARM Cortex-R5 (ARMv7-R ISA)
+    - mps2/an385              # ARM Cortex-M3 (ARMv7-M ISA)
+    - mps2/an521/cpu0         # ARM Cortex-M33 (ARMv8-M ISA)
 
 tests:
   # While there is in practice no value in compiling subsys/llext/*.c
@@ -15,61 +28,63 @@ tests:
   # future.
   llext.simple.loader_build:
     build_only: true
-    # How to override the above and allow ANY arch?
-    arch_allow: arm arm64 x86 x86_64 xtensa posix
 
+  # Run the suite with all combinations of core Kconfig options for the llext
+  # subsystem (storage type, ELF type, MPU/MMU etc)
   llext.simple.readonly:
-    arch_exclude: xtensa # for now
+    arch_allow: arm # Xtensa needs writable storage
     filter: not CONFIG_MPU and not CONFIG_MMU and not CONFIG_SOC_SERIES_S32ZE
     extra_configs:
       - arch:arm:CONFIG_ARM_MPU=n
+      - arch:arm:CONFIG_ARM_AARCH32_MMU=n
       - CONFIG_LLEXT_STORAGE_WRITABLE=n
   llext.simple.readonly_mpu:
     min_ram: 128
-    arch_exclude: xtensa # for now
+    arch_allow: arm # Xtensa needs writable storage
     filter: CONFIG_ARCH_HAS_USERSPACE
     extra_configs:
       - CONFIG_USERSPACE=y
       - CONFIG_LLEXT_STORAGE_WRITABLE=n
   llext.simple.writable:
+    arch_allow: arm xtensa
+    integration_platforms:
+      - qemu_xtensa             # Xtensa ISA
     filter: not CONFIG_MPU and not CONFIG_MMU and not CONFIG_SOC_SERIES_S32ZE
     extra_configs:
       - arch:arm:CONFIG_ARM_MPU=n
+      - arch:arm:CONFIG_ARM_AARCH32_MMU=n
       - CONFIG_LLEXT_STORAGE_WRITABLE=y
   llext.simple.writable_relocatable:
-    arch_exclude: arm arm64
-    filter: not CONFIG_MPU and not CONFIG_MMU
+    arch_allow: arm xtensa
     integration_platforms:
-      - qemu_xtensa
+      - qemu_xtensa             # Xtensa ISA
+    filter: not CONFIG_MPU and not CONFIG_MMU
     extra_configs:
+      - arch:arm:CONFIG_ARM_MPU=n
+      - arch:arm:CONFIG_ARM_AARCH32_MMU=n
       - CONFIG_LLEXT_STORAGE_WRITABLE=y
       - CONFIG_LLEXT_TYPE_ELF_RELOCATABLE=y
-  llext.simple.readonly_slid_linking:
-    arch_exclude: xtensa # for now
-    filter: not CONFIG_MPU and not CONFIG_MMU and not CONFIG_SOC_SERIES_S32ZE
-    extra_configs:
-      - arch:arm:CONFIG_ARM_MPU=n
-      - CONFIG_LLEXT_STORAGE_WRITABLE=n
-      - CONFIG_LLEXT_EXPORT_BUILTINS_BY_SLID=y
-  llext.simple.readonly_mpu_slid_linking:
-    min_ram: 128
-    arch_exclude: xtensa # for now
-    filter: CONFIG_ARCH_HAS_USERSPACE
-    extra_configs:
-      - CONFIG_USERSPACE=y
-      - CONFIG_LLEXT_STORAGE_WRITABLE=n
-      - CONFIG_LLEXT_EXPORT_BUILTINS_BY_SLID=y
+
+  # Test the Symbol Link Identifier (SLID) linking feature on writable
+  # storage to cover both ARM and Xtensa architectures on the same test.
   llext.simple.writable_slid_linking:
+    arch_allow: arm xtensa
+    integration_platforms:
+      - qemu_xtensa             # Xtensa ISA
     filter: not CONFIG_MPU and not CONFIG_MMU and not CONFIG_SOC_SERIES_S32ZE
     extra_configs:
       - arch:arm:CONFIG_ARM_MPU=n
+      - arch:arm:CONFIG_ARM_AARCH32_MMU=n
       - CONFIG_LLEXT_STORAGE_WRITABLE=y
+      - CONFIG_LLEXT_EXPORT_BUILTINS_BY_SLID=y
   llext.simple.writable_relocatable_slid_linking:
-    arch_exclude: arm arm64
-    filter: not CONFIG_MPU and not CONFIG_MMU
+    arch_allow: arm xtensa
     integration_platforms:
-      - qemu_xtensa
+      - qemu_xtensa             # Xtensa ISA
+    filter: not CONFIG_MPU and not CONFIG_MMU
     extra_configs:
+      - arch:arm:CONFIG_ARM_MPU=n
+      - arch:arm:CONFIG_ARM_AARCH32_MMU=n
       - CONFIG_LLEXT_STORAGE_WRITABLE=y
       - CONFIG_LLEXT_TYPE_ELF_RELOCATABLE=y
       - CONFIG_LLEXT_EXPORT_BUILTINS_BY_SLID=y


### PR DESCRIPTION
This PR reworks the `testcase.yaml` file for the llext subsystem to further reduce the number of tests performed by CI while improving overall coverage.

The changes are:

- Remove the `arch_allow` field from the common section to allow any arch to be tested in the `build_only` test. All other tests explicitly narrow down the arches they are applicable to.
- In addition to platforms with active issues, also exclude a number of platforms that are always skipped by the runtime filter due to RAM/Flash limitations.
- Add `integration_platforms` to limit the test count to a few selected platforms which are representative of the different arches.
- Remove a number of duplicate SLID tests, do the minimal set of tests that cover both ARM and Xtensa architectures on all ELF types.
- Test the relocatable case on ARM as well.

Additionally, this PR enforces a large buffer alignment on stored llexts. This has no runtime effect, but eases debugging since similar builds will produce consistent placement and their logs can be more easily compared.