### PR TITLE
dts: bindings: cpu: add definition for arm,cortex-m55

### DIFF
--- a/dts/bindings/cpu/arm,cortex-m55.yaml
+++ b/dts/bindings/cpu/arm,cortex-m55.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2024 Meta Platforms
+# SPDX-License-Identifier: Apache-2.0
+
+description: ARM Cortex-M55 CPU
+
+compatible: "arm,cortex-m55"
+
+include: arm,cortex-m.yaml

--- a/dts/bindings/cpu/arm,cortex-m55f.yaml
+++ b/dts/bindings/cpu/arm,cortex-m55f.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2024 Meta Platforms
+# SPDX-License-Identifier: Apache-2.0
+
+description: ARM Cortex-M55F CPU
+
+compatible: "arm,cortex-m55f"
+
+include: arm,cortex-m.yaml


### PR DESCRIPTION
A binding for the m55 cpu was missing. Add the yaml files.