### PR TITLE
Board: disco_l475_iot1: Fix PWM assignment

### DIFF
--- a/boards/st/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/st/disco_l475_iot1/disco_l475_iot1.dts
@@ -50,6 +50,10 @@
 		compatible = "pwm-leds";
 		status = "disabled";
 
+		/*
+		 * green_pwm_1 is connected to CN1 pin 2 not LD1, since LD1
+		 * shares a pin with the Arduino SPI SCL line.
+		 */
 		green_pwm_1: green_led_1 {
 			pwms = <&pwm2 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 			label = "green LD1";
@@ -63,8 +67,8 @@
 	aliases {
 		led0 = &green_led_2;
 		led1 = &green_led_1;
-		pwm-led0 = &green_pwm_1;
-		pwm-led1 = &green_pwm_2;
+		pwm-led0 = &green_pwm_2;
+		pwm-led1 = &green_pwm_1;
 		sw0 = &user_button;
 		eswifi0 = &wifi0;
 		watchdog0 = &iwdg;
@@ -246,7 +250,7 @@
 
 	pwm2: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim2_ch1_pa15>;
+		pinctrl-0 = <&tim2_ch1_pa15>; /* CN1 pin 2 (ARD.D9-PWM) */
 		pinctrl-names = "default";
 	};
 };
@@ -257,7 +261,7 @@
 
 	pwm15: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim15_ch1_pb14>; /* CN1 D10 */
+		pinctrl-0 = <&tim15_ch1_pb14>; /* LED2 */
 		pinctrl-names = "default";
 	};
 };

--- a/boards/st/disco_l475_iot1/doc/index.rst
+++ b/boards/st/disco_l475_iot1/doc/index.rst
@@ -147,6 +147,8 @@ Connections and IOs
 Disco L475 IoT Board has 8 GPIO controllers. These controllers are responsible for pin muxing,
 input/output, pull-up, etc.
 
+Note that LED LD1 and SPI1 SCK use the same GPIO pin and cannot be used simultaneously.
+
 Available pins:
 ---------------
 
@@ -163,8 +165,10 @@ Default Zephyr Peripheral Mapping:
 - SPI1 NSS/SCK/MISO/MOSI : PA2/PA5/PA6/PA7 (Arduino SPI)
 - SPI3 SCK/MISO/MOSI : PC10/PC11/PC12 (BT SPI bus)
 - PWM_2_CH1 : PA15
+- PWM_15_CH1 : PB14 (LD2)
 - USER_PB : PC13
-- LD2 : PA5
+- LD1 : PA5 (same as SPI1 SCK)
+- LD2 : PB14
 - ADC12_IN5 : PA0
 - ADC123_IN3 : PC2
 - ADC123_IN4 : PC3


### PR DESCRIPTION
Most people would expect `green_pwm_1` to go to LD1 on the dev board.
However it is routed to CN1 pin 2, since routing it to LD1 would
interfere with SPI SCK on the Arduino connector. This PR adds a
comment to tell users that LD1 won't light up as expected and to
fix the comments stating which PWM goes to which pin.

This also swaps the `pwm-led0` assignment so it uses the LED that _is_
wired up.