### PR TITLE
RW6xx: Fix the PM state definitions

### DIFF
--- a/dts/arm/nxp/nxp_rw6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rw6xx_common.dtsi
@@ -22,13 +22,13 @@
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
-		cpu-power-states = <&idle &suspend>;
 
 		cpu0: cpu@0 {
 			compatible = "arm,cortex-m33f";
 			reg = <0>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+			cpu-power-states = <&idle &suspend>;
 
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv8m-mpu";


### PR DESCRIPTION
The CPU states were not picked up by the PM subsystem