### PR TITLE
ARCMWDT: Remove workaround with stripping DWARF info

### DIFF
--- a/cmake/compiler/arcmwdt/compiler_flags.cmake
+++ b/cmake/compiler/arcmwdt/compiler_flags.cmake
@@ -152,14 +152,8 @@ set_property(TARGET compiler-cpp PROPERTY no_rtti "-fno-rtti")
 # do not link in supplied run-time startup files
 set_compiler_property(PROPERTY freestanding -Hnocrt)
 
-# Flag to enable debugging
-if(CONFIG_THREAD_LOCAL_STORAGE)
-  # FIXME: Temporary workaround for ARC MWDT toolchain issue - LLDAC linker produce errors on
-  # debugging information (if -g option specified) of thread-local variables.
-  set_compiler_property(PROPERTY debug)
-else()
-  set_compiler_property(PROPERTY debug -g)
-endif()
+# Flag to keep DWARF information (enable debug info)
+set_compiler_property(PROPERTY debug -g)
 
 # compile common globals like normal definitions
 set_compiler_property(PROPERTY no_common -fno-common)


### PR DESCRIPTION
Remove obsolete workaround with conditional turning off "-g" flag when Thread Local Storage used.

Recent versions of MetaWare have no issue with linking files with TSL-related data.

Moreover, pointed workaround breaks userspace for recently added ARC-V platforms,
as they use both TLS and DWARF info while compilation process.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/29920