### PR TITLE
usb: cdc_acm: Update log level only if UART console is enabled

### DIFF
--- a/subsys/usb/device/class/cdc_acm.c
+++ b/subsys/usb/device/class/cdc_acm.c
@@ -57,6 +57,7 @@
 
 #include <zephyr/logging/log.h>
 #if DT_NODE_HAS_COMPAT(DT_CHOSEN(zephyr_console), zephyr_cdc_acm_uart) \
+	&& defined(CONFIG_LOG_BACKEND_UART) \
 	&& defined(CONFIG_USB_CDC_ACM_LOG_LEVEL) \
 	&& CONFIG_USB_CDC_ACM_LOG_LEVEL != LOG_LEVEL_NONE
 /* Prevent endless recursive logging loop and warn user about it */

--- a/subsys/usb/device_next/class/usbd_cdc_acm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_acm.c
@@ -22,6 +22,7 @@
 
 #include <zephyr/logging/log.h>
 #if DT_NODE_HAS_COMPAT(DT_CHOSEN(zephyr_console), zephyr_cdc_acm_uart) \
+	&& defined(CONFIG_LOG_BACKEND_UART) \
 	&& defined(CONFIG_USBD_CDC_ACM_LOG_LEVEL) \
 	&& CONFIG_USBD_CDC_ACM_LOG_LEVEL != LOG_LEVEL_NONE
 /* Prevent endless recursive logging loop and warn user about it */


### PR DESCRIPTION
Change updates log level only if UART console is enabled in Kconfig configuration. The log level update is not needed in case logs are provided over other backend (e.g. RTT).

Change affects both USB stacks.