### PR TITLE
drivers/smartbond: Remove atomic flags from drivers

### DIFF
--- a/drivers/dma/dma_smartbond.c
+++ b/drivers/dma/dma_smartbond.c
@@ -157,10 +157,6 @@ struct dma_smartbond_data {
 
 	ATOMIC_DEFINE(channels_atomic, DMA_CHANNELS_COUNT);
 
-#if defined(CONFIG_PM_DEVICE)
-	ATOMIC_DEFINE(pm_policy_state_flag, 1);
-#endif
-
 	/* User callbacks and data to be stored per channel */
 	struct dma_channel_data channel_data[DMA_CHANNELS_COUNT];
 };
@@ -182,26 +178,17 @@ static bool dma_smartbond_is_dma_active(void)
 	return false;
 }
 
-static inline void dma_smartbond_pm_policy_state_lock_get(const struct device *dev)
+static inline void dma_smartbond_pm_policy_state_lock_get(void)
 {
 #if defined(CONFIG_PM_DEVICE)
-	struct dma_smartbond_data *data = dev->data;
-
-	if (atomic_test_and_set_bit(data->pm_policy_state_flag, 0) == 0) {
-		pm_policy_state_lock_get(PM_STATE_STANDBY, PM_ALL_SUBSTATES);
-	}
+	pm_policy_state_lock_get(PM_STATE_STANDBY, PM_ALL_SUBSTATES);
 #endif
 }
 
-static inline void dma_smartbond_pm_policy_state_lock_put(const struct device *dev)
+static inline void dma_smartbond_pm_policy_state_lock_put(void)
 {
 #if defined(CONFIG_PM_DEVICE)
-	struct dma_smartbond_data *data = dev->data;
-
-	/* Make PM lock put has a matched PM lock get invocation */
-	if (atomic_test_and_clear_bit(data->pm_policy_state_flag, 0) == 1) {
-		pm_policy_state_lock_put(PM_STATE_STANDBY, PM_ALL_SUBSTATES);
-	}
+	pm_policy_state_lock_put(PM_STATE_STANDBY, PM_ALL_SUBSTATES);
 #endif
 }
 
@@ -223,7 +210,7 @@ static void dma_smartbond_set_channel_status(const struct device *dev,
 		if (!irq_is_enabled(SMARTBOND_IRQN)) {
 			irq_enable(SMARTBOND_IRQN);
 			/* Prevent sleep as long as DMA operations are ongoing */
-			dma_smartbond_pm_policy_state_lock_get(dev);
+			dma_smartbond_pm_policy_state_lock_get();
 		}
 
 		DMA_CTRL_REG_SET_FIELD(DMA_ON, regs->DMA_CTRL_REG, 0x1);
@@ -246,7 +233,7 @@ static void dma_smartbond_set_channel_status(const struct device *dev,
 		if (!dma_smartbond_is_dma_active()) {
 			irq_disable(SMARTBOND_IRQN);
 			/* Allow entering sleep once all DMA channels are inactive */
-			dma_smartbond_pm_policy_state_lock_put(dev);
+			dma_smartbond_pm_policy_state_lock_put();
 		}
 	}
 

--- a/drivers/i2c/i2c_smartbond.c
+++ b/drivers/i2c/i2c_smartbond.c
@@ -35,34 +35,27 @@ struct i2c_smartbond_data {
 	uint32_t transmit_cnt, receive_cnt;
 	i2c_callback_t cb;
 	void *userdata;
-#if defined(CONFIG_PM_DEVICE)
-	ATOMIC_DEFINE(pm_policy_state_flag, 1);
-#endif
 #ifdef CONFIG_I2C_CALLBACK
 	k_spinlock_key_t spinlock_key;
 #endif
 };
 
 #if defined(CONFIG_PM_DEVICE)
-static inline void i2c_smartbond_pm_prevent_system_sleep(struct i2c_smartbond_data *data)
+static inline void i2c_smartbond_pm_prevent_system_sleep(void)
 {
-	if (atomic_test_and_set_bit(data->pm_policy_state_flag, 0) == 0) {
-		/*
-		 * Prevent the SoC from etering the normal sleep state as PDC does not support
-		 * waking up the application core following I2C events.
-		 */
-		pm_policy_state_lock_get(PM_STATE_STANDBY, PM_ALL_SUBSTATES);
-	}
+	/*
+	 * Prevent the SoC from etering the normal sleep state as PDC does not support
+	 * waking up the application core following I2C events.
+	 */
+	pm_policy_state_lock_get(PM_STATE_STANDBY, PM_ALL_SUBSTATES);
 }
 
-static inline void i2c_smartbond_pm_allow_system_sleep(struct i2c_smartbond_data *data)
+static inline void i2c_smartbond_pm_allow_system_sleep(void)
 {
-	if (atomic_test_and_clear_bit(data->pm_policy_state_flag, 0) == 1) {
-		/*
-		 * Allow the SoC to enter the nornmal sleep state once I2C transactions are done.
-		 */
-		pm_policy_state_lock_put(PM_STATE_STANDBY, PM_ALL_SUBSTATES);
-	}
+	/*
+	 * Allow the SoC to enter the nornmal sleep state once I2C transactions are done.
+	 */
+	pm_policy_state_lock_put(PM_STATE_STANDBY, PM_ALL_SUBSTATES);
 }
 #endif
 
@@ -72,7 +65,8 @@ static inline void i2c_smartbond_pm_policy_state_lock_get(const struct device *d
 #ifdef CONFIG_PM_DEVICE_RUNTIME
 	pm_device_runtime_get(dev);
 #else
-	i2c_smartbond_pm_prevent_system_sleep(dev->data);
+	ARG_UNUSED(dev);
+	i2c_smartbond_pm_prevent_system_sleep();
 #endif
 #endif
 }
@@ -83,7 +77,8 @@ static inline void i2c_smartbond_pm_policy_state_lock_put(const struct device *d
 #ifdef CONFIG_PM_DEVICE_RUNTIME
 	pm_device_runtime_put(dev);
 #else
-	i2c_smartbond_pm_allow_system_sleep(dev->data);
+	ARG_UNUSED(dev);
+	i2c_smartbond_pm_allow_system_sleep();
 #endif
 #endif
 }
@@ -613,7 +608,7 @@ static int i2c_smartbond_pm_action(const struct device *dev,
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
 #ifdef CONFIG_PM_DEVICE_RUNTIME
-		i2c_smartbond_pm_prevent_system_sleep(dev->data);
+		i2c_smartbond_pm_prevent_system_sleep();
 #endif
 		/*
 		 * Although the GPIO driver should already be initialized, make sure PD_COM
@@ -630,7 +625,7 @@ static int i2c_smartbond_pm_action(const struct device *dev,
 		 */
 		da1469x_pd_release(MCU_PD_DOMAIN_COM);
 #ifdef CONFIG_PM_DEVICE_RUNTIME
-		i2c_smartbond_pm_allow_system_sleep(dev->data);
+		i2c_smartbond_pm_allow_system_sleep();
 #endif
 		break;
 	default:


### PR DESCRIPTION
Remove atomic flags from drivers that use balanced calls for PM locking.