### PR TITLE
kernel: Generate warnings for pending that takes too long

### DIFF
--- a/include/zephyr/kernel/thread.h
+++ b/include/zephyr/kernel/thread.h
@@ -372,6 +372,10 @@ struct k_thread {
 	_wait_q_t  halt_queue;
 #endif /* CONFIG_SMP */
 
+#ifdef CONFIG_KERNEL_WARN_LONG_TIME_PENDING
+	int long_time_warns;
+#endif /* CONFIG_KERNEL_WARN_LONG_TIME_PENDING */
+
 	/** arch-specifics: must always be at the end */
 	struct _thread_arch arch;
 };

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -9,6 +9,12 @@ module = KERNEL
 module-str = kernel
 source "subsys/logging/Kconfig.template.log_config"
 
+config KERNEL_WARN_LONG_TIME_PENDING
+	bool "Generate warn for long time pending wait for event"
+	help
+	  Generate warning for long-time pending wait for event,
+	  this might indicate buffer leaks or deadlock is happening.
+
 config MULTITHREADING
 	bool "Multi-threading" if ARCH_HAS_SINGLE_THREAD_SUPPORT
 	default y

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -648,6 +648,11 @@ char *z_setup_new_thread(struct k_thread *new_thread,
 		CONFIG_SCHED_THREAD_USAGE_AUTO_ENABLE;
 #endif /* CONFIG_SCHED_THREAD_USAGE */
 
+#ifdef CONFIG_KERNEL_WARN_LONG_TIME_PENDING
+	/* Disable by default */
+	new_thread->long_time_warns = -1;
+#endif /* CONFIG_KERNEL_WARN_LONG_TIME_PENDING */
+
 	SYS_PORT_TRACING_OBJ_FUNC(k_thread, create, new_thread);
 
 	return stack_ptr;

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -671,6 +671,13 @@ static void work_queue_main(void *workq_ptr, void *p2, void *p3)
 		}
 
 		if (work == NULL) {
+			/* Disable */
+#if defined(CONFIG_KERNEL_WARN_LONG_TIME_PENDING)
+			int backup = _current->long_time_warns;
+
+			_current->long_time_warns = -1;
+#endif /* CONFIG_KERNEL_WARN_LONG_TIME_PENDING */
+
 			/* Nothing's had a chance to add work since we took
 			 * the lock, and we didn't find work nor got asked to
 			 * stop.  Just go to sleep: when something happens the
@@ -679,6 +686,11 @@ static void work_queue_main(void *workq_ptr, void *p2, void *p3)
 
 			(void)z_sched_wait(&lock, key, &queue->notifyq,
 					   K_FOREVER, NULL);
+
+			/* Restore */
+#if defined(CONFIG_KERNEL_WARN_LONG_TIME_PENDING)
+			_current->long_time_warns = backup;
+#endif /* CONFIG_KERNEL_WARN_LONG_TIME_PENDING */
 			continue;
 		}
 

--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -10,6 +10,7 @@ menuconfig BT
 	# will need some refactoring to work on SMP systems.
 	depends on !SMP
 	select NET_BUF
+	imply KERNEL_WARN_LONG_TIME_PENDING
 	help
 	  This option enables Bluetooth support.
 


### PR DESCRIPTION
This might indicate buffer leaks or deadlock is happening.