### PR TITLE
samples: stm32: serial_wakeup: Enable fifo

### DIFF
--- a/samples/boards/stm32/power_mgmt/serial_wakeup/boards/b_u585i_iot02a.overlay
+++ b/samples/boards/stm32/power_mgmt/serial_wakeup/boards/b_u585i_iot02a.overlay
@@ -20,6 +20,9 @@
 	/* Configure device as wakeup source */
 	wakeup-source;
 
+	/* Enable FIFO to avoid losing chars on device wakeup */
+	fifo-enable;
+
 	/* Configure sleep pinctrl configuration which will be used when
 	 * device is not configured as wakeup source by the application.
 	 * This use case is only applicable in PM_DEVICE mode.

--- a/samples/boards/stm32/power_mgmt/serial_wakeup/boards/nucleo_h563zi.overlay
+++ b/samples/boards/stm32/power_mgmt/serial_wakeup/boards/nucleo_h563zi.overlay
@@ -12,6 +12,9 @@
 	/* Configure device as wakeup source */
 	wakeup-source;
 
+	/* Enable FIFO to avoid losing chars on device wakeup */
+	fifo-enable;
+
 	/* Configure sleep pinctrl configuration which will be used when
 	 * device is not configured as wakeup source by the application.
 	 * This use case is only applicable in PM_DEVICE mode.

--- a/samples/boards/stm32/power_mgmt/serial_wakeup/boards/nucleo_wb55rg.overlay
+++ b/samples/boards/stm32/power_mgmt/serial_wakeup/boards/nucleo_wb55rg.overlay
@@ -21,6 +21,9 @@
 	/* Configure device as wakeup source */
 	wakeup-source;
 
+	/* Enable FIFO to avoid losing chars on device wakeup */
+	fifo-enable;
+
 	/* Configure sleep pinctrl configuration which will be used when
 	 * device is not configured as wakeup source by the application.
 	 * This use case is only applicable in PM_DEVICE mode.

--- a/samples/boards/stm32/power_mgmt/serial_wakeup/boards/nucleo_wl55jc.overlay
+++ b/samples/boards/stm32/power_mgmt/serial_wakeup/boards/nucleo_wl55jc.overlay
@@ -15,6 +15,9 @@
 
 	/* Enable as wakeup source */
 	wakeup-source;
+
+	/* Enable FIFO to avoid losing chars on device wakeup */
+	fifo-enable;
 };
 
 &clk_lse {

--- a/samples/boards/stm32/power_mgmt/serial_wakeup/boards/stm32l562e_dk.overlay
+++ b/samples/boards/stm32/power_mgmt/serial_wakeup/boards/stm32l562e_dk.overlay
@@ -27,6 +27,9 @@
 
 	wakeup-source;
 
+	/* Enable FIFO to avoid losing chars on device wakeup */
+	fifo-enable;
+
 	status = "okay";
 };
 


### PR DESCRIPTION
Uart FIFO is useful in case of wakeup on serial as it will allow to avoid losing chars.
Enable it systematically on all overlays for this sample.


Seen useful here: https://github.com/zephyrproject-rtos/zephyr/issues/74441