### PR TITLE
Bluetooth: `imply` CONFIG_ASSERT

### DIFF
--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -10,6 +10,7 @@ menuconfig BT
 	# will need some refactoring to work on SMP systems.
 	depends on !SMP
 	select NET_BUF
+	imply ASSERT
 	help
 	  This option enables Bluetooth support.
 


### PR DESCRIPTION
We depend on asserts a lot in the Bluetooth subsystem.

Not enabling them will (and has) lead to confusing errors down the line, in unrelated parts of code.

Fixes #73316 (kinda)