### PR TITLE
drivers: flash: qspi stm32 driver supporting requires_ulbpr

### DIFF
--- a/drivers/flash/Kconfig.stm32
+++ b/drivers/flash/Kconfig.stm32
@@ -84,4 +84,12 @@ config FLASH_STM32_BLOCK_REGISTERS
 	  registers improves system security, because flash content (or
 	  protection settings) can't be changed even when exploit was found.
 
+config USE_MICROCHIP_QSPI_FLASH_WITH_STM32
+	bool "Include patch for Microchip qspi flash when running with stm32"
+	depends on DT_HAS_ST_STM32_QSPI_NOR_ENABLED
+	help
+	  Set to use Microchip qspi flash memories which supports
+	  the Global Block Protection Unlock instruction (ULBPR - 98H),
+	  and write with SPI_NOR_CMD_PP_1_1_4 on 4 lines
+
 endif # SOC_FLASH_STM32

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -187,9 +187,16 @@ static inline int qspi_prepare_quad_program(const struct device *dev,
 			dev_data->qspi_write_cmd == SPI_NOR_CMD_PP_1_4_4);
 
 	cmd->Instruction = dev_data->qspi_write_cmd;
+#if defined(CONFIG_USE_MICROCHIP_QSPI_FLASH_WITH_STM32)
+	/* Microchip qspi-NOR flash, does not follow the standard rules */
+	if (cmd->Instruction == SPI_NOR_CMD_PP_1_1_4) {
+		cmd->AddressMode = QSPI_ADDRESS_4_LINES;
+	}
+#else
 	cmd->AddressMode = ((cmd->Instruction == SPI_NOR_CMD_PP_1_1_4)
 				? QSPI_ADDRESS_1_LINE
 				: QSPI_ADDRESS_4_LINES);
+#endif /* CONFIG_USE_MICROCHIP_QSPI_FLASH_WITH_STM32 */
 	cmd->DataMode = QSPI_DATA_4_LINES;
 	cmd->DummyCycles = 0;
 

--- a/dts/bindings/flash_controller/st,stm32-qspi-nor.yaml
+++ b/dts/bindings/flash_controller/st,stm32-qspi-nor.yaml
@@ -61,3 +61,13 @@ properties:
       supporting 1-4-4 mode also would support fast page programming.
 
       If absent, then 1-4-4 program page is used in quad mode.
+
+  requires-ulbpr:
+    type: boolean
+    description: |
+      Indicates the device requires the ULBPR (0x98) command.
+
+      Some flash chips such as the Microchip SST26VF series have a block
+      protection register that initializes to write-protected.  Use this
+      property to indicate that the BPR must be unlocked before write
+      operations can proceed.


### PR DESCRIPTION
Add the support of the requires_ulbpr property when a Microchip quad-spi flash is mounted.
Set the CONFIG_USE_MICROCHIP_QSPI_FLASH_WITH_STM32=y flag to access the command

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/68622