### PR TITLE
drivers: intc: esp32: fix kconfig visibility

### DIFF
--- a/drivers/interrupt_controller/Kconfig.esp32
+++ b/drivers/interrupt_controller/Kconfig.esp32
@@ -5,7 +5,9 @@
 
 config INTC_ESP32
 	bool "Interrupt allocator for Xtensa-based Espressif SoCs"
-	default y if SOC_FAMILY_ESPRESSIF_ESP32 && !SOC_SERIES_ESP32C3 && !SOC_SERIES_ESP32C6
+	default y
+	depends on SOC_FAMILY_ESPRESSIF_ESP32
+	depends on !SOC_SERIES_ESP32C3 && !SOC_SERIES_ESP32C6
 	help
 	  Enable custom interrupt allocator for Espressif SoCs based on Xtensa
 	  architecture.

--- a/drivers/interrupt_controller/Kconfig.esp32c3
+++ b/drivers/interrupt_controller/Kconfig.esp32c3
@@ -3,6 +3,7 @@
 
 config INTC_ESP32C3
 	bool "ESP32C3 interrupt controller driver"
+	depends on SOC_FAMILY_ESPRESSIF_ESP32
 	depends on SOC_SERIES_ESP32C3 || SOC_SERIES_ESP32C6
 	default y
 	help


### PR DESCRIPTION
Kconfig options in those drivers are visible and selectable to any board/soc when it should not. This makes sure both depends on proper family.

Fixes #74347