### PR TITLE
net: lib: dns: Fix DNS dispatcher double net buf unref

### DIFF
--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -659,8 +659,6 @@ static int dispatcher_cb(void *my_ctx, int sock,
 		NET_DBG("%s read failed (%d)", "mDNS", ret);
 	}
 
-	net_buf_unref(dns_data);
-
 	return ret;
 }
 

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -275,10 +275,6 @@ quit:
 	release_query(&ctx->queries[i]);
 
 free_buf:
-	if (dns_data) {
-		net_buf_unref(dns_data);
-	}
-
 	if (dns_cname) {
 		net_buf_unref(dns_cname);
 	}


### PR DESCRIPTION
The `dns_data` buffer, allocated by the DNS dispatcher was dereferenced twice - once in registered DNS handler, second time in the dispatcher itself.

Since the buffer was allocated by the dispatcher, and it's not really guaranteed that the buffer will be freed in the registered handler (this depends on the processing outcome, the function may return early w/o freeing the net buf in case of errors), it makes most sense for the dispatcher to keep ownership of the buffer. Hence, the registered handlers will no longer release the buffer provided in any case, and the dispatcher will free it on exit.

Fixes #74377