### PR TITLE
tests: drivers: counter: support STM32 when RTC is disabled

### DIFF
--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -124,7 +124,9 @@ static const struct device *const period_devs[] = {
 #ifdef CONFIG_COUNTER_MCUX_LPC_RTC
 	DEVS_FOR_DT_COMPAT(nxp_lpc_rtc)
 #endif
+#ifdef CONFIG_COUNTER_RTC_STM32
 	DEVS_FOR_DT_COMPAT(st_stm32_rtc)
+#endif
 };
 
 typedef void (*counter_test_func_t)(const struct device *dev);


### PR DESCRIPTION
Add a missing `#ifdef` check which prevents building the `tests/drivers/counter/counter_basic_api` test for STM32 boards under the following conditions:
 * RTC node is defined in device tree (`compatible = "st,stm32-rtc"`)
 * RTC node is disabled in device tree (`status = "disabled"`)
 * Kconfig `CONFIG_COUNTER_RTC_STM32=n` is specified

This check matches the ones done a few lines above for NXP MCUs.

Without this check, building the test under the conditions listed above failed with the infamous `undefined reference to '__device_dts_ord_N'` linker error, because the test attempts to obtain RTC's `struct device` despite `CONFIG_COUNTER_RTC_STM32=n`, which ultimately fails because the RTC driver is not built unless there is an enabled RTC node in the Device Tree.