### PR TITLE
testsuite: coverage: Add Kconfig to control compiler flags

### DIFF
--- a/arch/common/CMakeLists.txt
+++ b/arch/common/CMakeLists.txt
@@ -99,7 +99,9 @@ if (CONFIG_GEN_ISR_TABLES)
 endif()
 
 if(CONFIG_COVERAGE)
-  zephyr_compile_options($<TARGET_PROPERTY:compiler,coverage>)
+  if (CONFIG_COVERAGE_USE_COMPILER_FLAGS)
+    zephyr_compile_options($<TARGET_PROPERTY:compiler,coverage>)
+  endif()
   zephyr_link_libraries_ifndef(CONFIG_NATIVE_LIBRARY $<TARGET_PROPERTY:linker,coverage>)
 endif()
 

--- a/subsys/testsuite/Kconfig
+++ b/subsys/testsuite/Kconfig
@@ -97,6 +97,16 @@ config FORCE_COVERAGE
 	  does not guarantee that coverage data will be gathered.
 	  Application may not fit memory or crash at runtime.
 
+config COVERAGE_USE_COMPILER_FLAGS
+	bool "Whether to use instrumentation flags during compilation"
+	depends on COVERAGE
+	default y
+	help
+	  If disabled, then compiler flags for coverage will not be applied,
+	  while all the other instrumentation will still hold. This can be
+	  useful when some of the code is compiled separately and coverage
+	  only needs to be collected for that code only.
+
 config TEST_USERSPACE
 	bool "Indicate that this test exercises user mode"
 	help


### PR DESCRIPTION
This adds KConfig option allowing to opt-out of coverage-related compiler flags during compilation.

If disabled, then compiler flags for coverage will not be applied, while all the other instrumentation will still hold. This can be useful when some of the code is compiled separately and coverage only needs to be collected for that code only.