### PR TITLE
modules: thrift: update doc and makefiles to build with macos

### DIFF
--- a/samples/modules/thrift/hello/README.rst
+++ b/samples/modules/thrift/hello/README.rst
@@ -57,12 +57,23 @@ Requirements
    west update
 
 - QEMU Networking (described in :ref:`networking_with_qemu`)
-- Thrift dependencies installed for your host OS e.g. in Ubuntu
+- Thrift dependencies installed for your host OS
 
-.. code-block:: console
-   :caption: Install additional dependencies in Ubuntu
+.. tabs::
 
-   sudo apt install -y libboost-all-dev thrift-compiler libthrift-dev
+   .. group-tab:: Ubuntu
+
+      .. code-block:: bash
+        :caption: Install thrift dependencies in Ubuntu
+
+         sudo apt install -y libboost-all-dev thrift-compiler libthrift-dev
+
+   .. group-tab:: macOS
+
+      .. code-block:: bash
+        :caption: Install thrift dependencies in macOS
+
+         brew install boost openssl thrift
 
 Building and Running
 ********************

--- a/samples/modules/thrift/hello/client/Makefile
+++ b/samples/modules/thrift/hello/client/Makefile
@@ -3,6 +3,8 @@
 
 .PHONY: all clean
 
+OS = $(shell uname -s)
+
 CXXFLAGS :=
 CXXFLAGS += -std=c++17
 
@@ -14,6 +16,14 @@ GENOBJ = $(filter-out %.h, $(GENSRC:.cpp=.o))
 THRIFT_FLAGS :=
 THRIFT_FLAGS += $(shell pkg-config --cflags thrift)
 THRIFT_FLAGS += -I$(GEN_DIR)
+ifeq ($(OS),Darwin)
+# get Homebrew prefix
+HOMEBREW_PREFIX := $(shell brew --prefix)
+# get boost include path (no pkgconfig file)
+BOOST_INCLUDE := $(shell find $(HOMEBREW_PREFIX) -path '*/Cellar/boost/*/include' -type d | head -n 1)
+THRIFT_FLAGS += -I$(BOOST_INCLUDE)
+THRIFT_FLAGS += $(shell pkg-config --cflags openssl)
+endif
 THRIFT_LIBS = $(shell pkg-config --libs thrift)
 
 all: hello_client hello_client_compact hello_client_ssl hello_client_py.stamp

--- a/samples/modules/thrift/hello/server/Makefile
+++ b/samples/modules/thrift/hello/server/Makefile
@@ -3,6 +3,8 @@
 
 .PHONY: all clean
 
+OS = $(shell uname -s)
+
 CXXFLAGS :=
 CXXFLAGS += -std=c++17
 
@@ -14,6 +16,14 @@ GENOBJ = $(filter-out %.h, $(GENSRC:.cpp=.o))
 THRIFT_FLAGS :=
 THRIFT_FLAGS += $(shell pkg-config --cflags thrift)
 THRIFT_FLAGS += -I$(GEN_DIR)
+ifeq ($(OS),Darwin)
+# get Homebrew prefix
+HOMEBREW_PREFIX := $(shell brew --prefix)
+# get boost include path (no pkgconfig file)
+BOOST_INCLUDE := $(shell find $(HOMEBREW_PREFIX) -path '*/Cellar/boost/*/include' -type d | head -n 1)
+THRIFT_FLAGS += -I$(BOOST_INCLUDE)
+THRIFT_FLAGS += $(shell pkg-config --cflags openssl)
+endif
 THRIFT_LIBS :=
 THRIFT_LIBS = $(shell pkg-config --libs thrift)
 


### PR DESCRIPTION
Added tabs to the thrift doc so that building works for macos and is consistent with the rest of the documentation in terms of one tab per os (I unfortunately do not have a windows dev environment at my disposal, but would be happy to add those package installation instructions if someone knows what they might be).

Updated client and server makefiles to discover include paths for boost and openssl.

[Doc Preview](https://builds.zephyrproject.io/zephyr/pr/74557/docs/samples/modules/thrift/hello/README.html)