### PR TITLE
scripts: west robot & simulation: Fix OOT

### DIFF
--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -600,8 +600,11 @@ harness_config: <harness configuration options>
         If the scope is set to ``function``, DUT is launched for every test case
         in python script. For ``session`` scope, DUT is launched only once.
 
-    robot_test_path: <robot file path> (default empty)
-        Specify a path to a file containing a Robot Framework test suite to be run.
+    robot_testsuite: <robot file path> (default empty)
+        Specify one or more paths to a file containing a Robot Framework test suite to be run.
+
+    robot_option: <robot option> (default empty)
+        One or more options to be send to robotframework.
 
     bsim_exe_name: <string>
         If provided, the executable filename when copying to BabbleSim's bin
@@ -658,7 +661,33 @@ harness_config: <harness configuration options>
           robot.example:
             harness: robot
             harness_config:
-              robot_test_path: [robot file path]
+              robot_testsuite: [robot file path]
+
+    It can be more than one test suite using a list.
+
+    .. code-block:: yaml
+
+        tests:
+          robot.example:
+            harness: robot
+            harness_config:
+              robot_testsuite:
+                - [robot file path 1]
+                - [robot file path 2]
+                - [robot file path n]
+
+    One or more options can be passed to robotframework.
+
+    .. code-block:: yaml
+
+        tests:
+          robot.example:
+            harness: robot
+            harness_config:
+              robot_testsuite: [robot file path]
+              robot_option:
+                - --exclude tag
+                - --stop-on-error
 
 filter: <expression>
     Filter whether the testcase should be run by evaluating an expression

--- a/samples/subsys/shell/shell_module/sample.yaml
+++ b/samples/subsys/shell/shell_module/sample.yaml
@@ -75,4 +75,4 @@ tests:
   sample.shell.shell_module.robot:
     harness: robot
     harness_config:
-      robot_test_path: shell_module.robot
+      robot_testsuite: shell_module.robot

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -18,6 +18,7 @@ import sys
 import threading
 import time
 
+from pathlib import Path
 from queue import Queue, Empty
 from twisterlib.environment import ZEPHYR_BASE, strip_ansi_sequences
 from twisterlib.error import TwisterException
@@ -241,7 +242,11 @@ class BinaryHandler(Handler):
             # os.path.join cannot be used on a Mock object, so we are
             # explicitly checking the type
             if isinstance(self.instance.platform, Platform):
-                resc = os.path.join(self.options.coverage_basedir, self.instance.platform.resc)
+                for board_dir in self.options.board_root:
+                    path = os.path.join(Path(board_dir).parent, self.instance.platform.resc)
+                    if os.path.exists(path):
+                        resc = path
+                        break
                 uart = self.instance.platform.uart
                 command = ["renode-test",
                             "--variable", "KEYWORDS:" + keywords,

--- a/scripts/schemas/twister/testsuite-schema.yaml
+++ b/scripts/schemas/twister/testsuite-schema.yaml
@@ -120,8 +120,11 @@ schema;scenario-schema:
           required: false
           sequence:
             - type: str
-        "robot_test_path":
-          type: str
+        "robot_testsuite":
+          type: any
+          required: false
+        "robot_option":
+          type: any
           required: false
         "record":
           type: map

--- a/scripts/tests/twister/test_harness.py
+++ b/scripts/tests/twister/test_harness.py
@@ -133,7 +133,8 @@ def test_robot_configure(tmp_path):
 
     instance = TestInstance(testsuite=mock_testsuite, platform=mock_platform, outdir=outdir)
     instance.testsuite.harness_config = {
-        'robot_test_path': '/path/to/robot/test'
+        'robot_testsuite': '/path/to/robot/test',
+        'robot_option': 'test_option'
     }
     robot_harness = Robot()
 
@@ -143,6 +144,7 @@ def test_robot_configure(tmp_path):
     #Assert
     assert robot_harness.instance == instance
     assert robot_harness.path == '/path/to/robot/test'
+    assert robot_harness.option == 'test_option'
 
 
 def test_robot_handle(tmp_path):
@@ -190,6 +192,7 @@ def test_robot_run_robot_test(tmp_path, caplog, exp_out, returncode, expected_st
     handler.log = "handler.log"
 
     path = "path"
+    option = "option"
 
     mock_platform = mock.Mock()
     mock_platform.name = "mock_platform"
@@ -209,6 +212,7 @@ def test_robot_run_robot_test(tmp_path, caplog, exp_out, returncode, expected_st
 
     robot = Robot()
     robot.path = path
+    robot.option = option
     robot.instance = instance
     proc_mock = mock.Mock(
         returncode = returncode,

--- a/scripts/west_commands/runners/renode-robot.py
+++ b/scripts/west_commands/runners/renode-robot.py
@@ -28,6 +28,8 @@ class RenodeRobotRunner(ZephyrBinaryRunner):
     @classmethod
     def do_add_parser(cls, parser):
         parser.add_argument('--testsuite',
+                            metavar='SUITE',
+                            action='append',
                             help='path to Robot test suite')
         parser.add_argument('--renode-robot-arg',
                             metavar='ARG',
@@ -54,7 +56,8 @@ class RenodeRobotRunner(ZephyrBinaryRunner):
                 for arg in self.renode_robot_arg:
                     cmd.append(arg)
             if self.testsuite is not None:
-                cmd.append(self.testsuite)
+                for suite in self.testsuite:
+                    cmd.append(suite)
             else:
                 self.logger.error("No Robot testsuite passed to renode-test! Use the `--testsuite` argument to provide one.")
         subprocess.run(cmd, check=True)

--- a/tests/drivers/console/line_splitting/testcase.yaml
+++ b/tests/drivers/console/line_splitting/testcase.yaml
@@ -8,4 +8,8 @@ common:
 tests:
   drivers.console.line_splitting:
     harness_config:
-      robot_test_path: line_splitting.robot
+      robot_testsuite: line_splitting.robot
+  drivers.console.line_splitting.plus.some_option:
+    harness_config:
+      robot_testsuite: line_splitting.robot
+      robot_option: --exclude some_flag


### PR DESCRIPTION
The current version of scipts do not consider OOT boards use cases and the tests with robot now are strict to only one robot file, which is not realistic for real environment. This address those issues and allow multiple testsuits at command line and lists at tests entries.

After this changes it will be possible define multiple robot files:
```
    harness: robot
    harness_config:
      robot_test_path:
        - <user_path>/T1.robot
        - <user_path>/T2.robot
        - <user_path>/Tn.robot
```

And add multiple testsuites at command line
```
west build -p -b <board> <app>
west robot --testsuite <user_path>/T1.robot --testsuite <user_path>/T2.robot --testsuite <user_path>/Tn.robot
```

And it will find the correct OOT board directory

```
(.venv) gfbudke@debian12:~/workspace$ west robot --context -r renode-robot
-- west robot: rebuilding
ninja: no work to do.
build configuration:
  build directory: /home/gfbudke/workspace/build
  board: <board>
  runners.yaml: /home/gfbudke/workspace/build/zephyr/runners.yaml
renode-robot capabilities:
  RunnerCaps(commands={'robot'}, dev_id=False, flash_addr=False, erase=False, reset=False, extload=False, tool_opt=False, file=False, hide_load_files=True)
renode-robot options:
  --testsuite SUITE     path to Robot test suite
  --renode-robot-arg ARG
                        additional argument passed to renode-test
  --renode-robot-help   print all possible `renode-test` arguments
renode-robot arguments from runners.yaml:
  --renode-robot-arg=--variable=ELF:@/home/gfbudke/workspace/build/zephyr/zephyr.elf
  --renode-robot-arg=--variable=RESC:@/home/gfbudke/workspace/app/boards/OOT_DIR/USER_BOARD/support/BOARD.resc
  --renode-robot-arg=--variable=UART:sysbus.usart3
  --renode-robot-arg=--variable=KEYWORDS:/home/gfbudke/workspace/deps/zephyr/tests/robot/common.robot
  --renode-robot-arg=--variable=RESULTS_DIR:/home/gfbudke/workspace/build
```

Without this path the RESC would be set to

`--renode-robot-arg=--variable=RESC:@/home/gfbudke/workspace/deps/zephyr/.`

Fixes: #74563