### PR TITLE
ARCMWDT: Fix cbprintf issue with omitted function prototype

### DIFF
--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -1316,12 +1316,13 @@ static inline void store_count(const struct conversion *conv,
 }
 
 /* Outline function to emit all characters in [sp, ep). */
-static int outs(cbprintf_cb out,
+static int outs(cbprintf_cb __out,
 		void *ctx,
 		const char *sp,
 		const char *ep)
 {
 	size_t count = 0;
+	int (*out)(int, void *) = __out;
 
 	while ((sp < ep) || ((ep == NULL) && *sp)) {
 		int rc = out((int)*sp++, ctx);
@@ -1335,12 +1336,13 @@ static int outs(cbprintf_cb out,
 	return (int)count;
 }
 
-int z_cbvprintf_impl(cbprintf_cb out, void *ctx, const char *fp,
+int z_cbvprintf_impl(cbprintf_cb __out, void *ctx, const char *fp,
 		     va_list ap, uint32_t flags)
 {
 	char buf[CONVERTED_BUFLEN];
 	size_t count = 0;
 	sint_value_type sint;
+	int (*out)(int, void *) = __out;
 
 	const bool tagged_ap = (flags & Z_CBVPRINTF_PROCESS_FLAG_TAGGED_ARGS)
 			       == Z_CBVPRINTF_PROCESS_FLAG_TAGGED_ARGS;


### PR DESCRIPTION
MWDT compiler (LLVM 16.0.6 based) requires function to be declared with argument types and produce warnings otherwise. This PR provides explicitly type cast for out routine inside z_cbvprintf_impl().

This fixes https://github.com/zephyrproject-rtos/zephyr/issues/74562