### PR TITLE
samples: sensor: qdec: Fix wrong harness

### DIFF
--- a/samples/sensor/qdec/sample.yaml
+++ b/samples/sensor/qdec/sample.yaml
@@ -4,15 +4,28 @@ sample:
 common:
   tags: sensors
   timeout: 5
+  harness: console
 
 tests:
   sample.sensor.qdec_sensor:
     filter: dt_alias_exists("qdec0")
+    harness_config:
+      type: multi_line
+      ordered: true
+      regex:
+        - "Quadrature decoder sensor test"
+        - "Position = (.*) degrees"
 
   sample.sensor.sam_qdec_sensor:
     platform_allow:
       - sam_e70_xplained/same70q21
       - sam_e70_xplained/same70q21b
+    harness_config:
+      type: multi_line
+      ordered: true
+      regex:
+        - "Quadrature decoder sensor test"
+        - "Position = (.*) degrees"
 
   sample.sensor.st_qdec_sensor:
     platform_allow: nucleo_f401re


### PR DESCRIPTION
The #73619 which fixes the atmel,sam-tc-qdec sensor implementation introduced a regression on the sample test removing the harness console. That changed the test to use the default ztest behavior which is incompatible with the test output. This restore the harness to the default console value.

Fixes: #74531