### PR TITLE
llext: fix issues identified in #74509

### DIFF
--- a/include/zephyr/llext/loader.h
+++ b/include/zephyr/llext/loader.h
@@ -23,6 +23,10 @@ extern "C" {
 
 #include <zephyr/llext/llext.h>
 
+/** @cond ignore */
+struct llext_elf_sect_map; /* defined in llext_priv.h */
+/** @endcond */
+
 /**
  * @brief Linkable loadable extension loader context
  */
@@ -73,7 +77,7 @@ struct llext_loader {
 	elf_shdr_t sects[LLEXT_MEM_COUNT];
 	elf_shdr_t *sect_hdrs;
 	bool sect_hdrs_on_heap;
-	enum llext_mem *sect_map;
+	struct llext_elf_sect_map *sect_map;
 	uint32_t sect_cnt;
 	/** @endcond */
 };

--- a/samples/subsys/llext/modules/sample.yaml
+++ b/samples/subsys/llext/modules/sample.yaml
@@ -4,23 +4,38 @@ common:
     - arm
     - xtensa
   platform_exclude:
+    # platforms with active issues
     - apollo4p_evb            # See #73443
     - apollo4p_blue_kxr_evb   # See #73443
     - numaker_pfm_m487        # See #63167
+    - s32z2xxdc2/s32z270/rtu0 # See commit 18a0660
+    - s32z2xxdc2/s32z270/rtu1 # See commit 18a0660
+    # platforms that are always skipped by the runtime filter
+    - qemu_arc/qemu_arc_em
+    - qemu_arc/qemu_arc_hs
+    - qemu_arc/qemu_arc_hs/xip
+    - qemu_arc/qemu_arc_hs5x
+    - qemu_arc/qemu_arc_hs6x
+    - qemu_cortex_m0
+    - qemu_xtensa/dc233c/mmu
   integration_platforms:
-    - qemu_xtensa
-    - qemu_cortex_r5
-    - mps2/an385
+    - qemu_cortex_a9          # ARM Cortex-A9 (ARMv7-A ISA)
+    - qemu_cortex_r5          # ARM Cortex-R5 (ARMv7-R ISA)
+    - mps2/an385              # ARM Cortex-M3 (ARMv7-M ISA)
+    - mps2/an521/cpu0         # ARM Cortex-M33 (ARMv8-M ISA)
   harness: console
+
 sample:
   name: CONFIG_MODULES test
   description: Call code directly and from extensions
+
 tests:
   sample.llext.modules.module_build:
     filter: not CONFIG_MPU and not CONFIG_MMU and not CONFIG_SOC_SERIES_S32ZE
     extra_configs:
-      - CONFIG_HELLO_WORLD_MODE=m
       - arch:arm:CONFIG_ARM_MPU=n
+      - arch:arm:CONFIG_ARM_AARCH32_MMU=n
+      - CONFIG_HELLO_WORLD_MODE=m
     harness_config:
       type: one_line
       regex:

--- a/samples/subsys/llext/modules/sample.yaml
+++ b/samples/subsys/llext/modules/sample.yaml
@@ -21,7 +21,6 @@ tests:
     extra_configs:
       - CONFIG_HELLO_WORLD_MODE=m
       - arch:arm:CONFIG_ARM_MPU=n
-      - arch:xtensa:CONFIG_LLEXT_STORAGE_WRITABLE=y
     harness_config:
       type: one_line
       regex:

--- a/samples/subsys/llext/shell_loader/sample.yaml
+++ b/samples/subsys/llext/shell_loader/sample.yaml
@@ -1,17 +1,32 @@
 common:
-  tags: llext
+  tags: shell llext
   arch_allow:
     - arm
     - xtensa
   filter: not CONFIG_MPU and not CONFIG_MMU and not CONFIG_SOC_SERIES_S32ZE
   platform_exclude:
-    - numaker_pfm_m487 # See #63167
+    # platforms with active issues
+    - apollo4p_evb            # See #73443
+    - apollo4p_blue_kxr_evb   # See #73443
+    - numaker_pfm_m487        # See #63167
+    - s32z2xxdc2/s32z270/rtu0 # See commit 18a0660
+    - s32z2xxdc2/s32z270/rtu1 # See commit 18a0660
+    # platforms that are always skipped by the runtime filter
+    - qemu_arc/qemu_arc_em
+    - qemu_arc/qemu_arc_hs
+    - qemu_arc/qemu_arc_hs/xip
+    - qemu_arc/qemu_arc_hs5x
+    - qemu_arc/qemu_arc_hs6x
+    - qemu_cortex_m0
+    - qemu_xtensa/dc233c/mmu
+
 sample:
   description: Loadable extensions with shell sample
   name: Extension loader shell
+
 tests:
   sample.llext.shell:
-    tags: shell llext
     harness: keyboard
     extra_configs:
       - arch:arm:CONFIG_ARM_MPU=n
+      - arch:arm:CONFIG_ARM_AARCH32_MMU=n

--- a/subsys/llext/Kconfig
+++ b/subsys/llext/Kconfig
@@ -62,6 +62,7 @@ config LLEXT_SHELL_MAX_SIZE
 
 config LLEXT_STORAGE_WRITABLE
 	bool "llext storage is writable"
+	default y if XTENSA
 	help
 	  Select if LLEXT storage is writable, i.e. if extensions are stored in
 	  RAM and can be modified in place

--- a/subsys/llext/llext_link.c
+++ b/subsys/llext/llext_link.c
@@ -288,9 +288,9 @@ int llext_link(struct llext_loader *ldr, struct llext *ext, bool do_local)
 				 * adding st_value to the start address of the section
 				 * in which the target symbol resides.
 				 */
-				enum llext_mem mem_idx = ldr->sect_map[sym.st_shndx].mem_idx;
-
-				link_addr = (uintptr_t)ext->mem[mem_idx] + sym.st_value;
+				link_addr = (uintptr_t)llext_loaded_sect_ptr(ldr, ext,
+									     sym.st_shndx)
+					    + sym.st_value;
 			} else {
 				LOG_ERR("rela section %d, entry %d: cannot apply relocation: "
 					"target symbol has unexpected section index %d (0x%X)",

--- a/subsys/llext/llext_link.c
+++ b/subsys/llext/llext_link.c
@@ -288,8 +288,9 @@ int llext_link(struct llext_loader *ldr, struct llext *ext, bool do_local)
 				 * adding st_value to the start address of the section
 				 * in which the target symbol resides.
 				 */
-				link_addr = (uintptr_t)ext->mem[ldr->sect_map[sym.st_shndx]]
-					+ sym.st_value;
+				enum llext_mem mem_idx = ldr->sect_map[sym.st_shndx].mem_idx;
+
+				link_addr = (uintptr_t)ext->mem[mem_idx] + sym.st_value;
 			} else {
 				LOG_ERR("rela section %d, entry %d: cannot apply relocation: "
 					"target symbol has unexpected section index %d (0x%X)",

--- a/subsys/llext/llext_link.c
+++ b/subsys/llext/llext_link.c
@@ -118,6 +118,13 @@ static void llext_link_plt(struct llext_loader *ldr, struct llext *ext,
 		/*
 		 * Both r_offset and sh_addr are addresses for which the extension
 		 * has been built.
+		 *
+		 * NOTE: The calculations below assumes offsets from the
+		 * beginning of the .text section in the ELF file can be
+		 * applied to the memory location of mem[LLEXT_MEM_TEXT].
+		 *
+		 * This is valid only when CONFIG_LLEXT_STORAGE_WRITABLE=y
+		 * and peek() is usable on the source ELF file.
 		 */
 		size_t got_offset;
 
@@ -162,7 +169,7 @@ static void llext_link_plt(struct llext_loader *ldr, struct llext *ext,
 
 int llext_link(struct llext_loader *ldr, struct llext *ext, bool do_local)
 {
-	uintptr_t loc = 0;
+	uintptr_t sect_base = 0;
 	elf_rela_t rel;
 	elf_sym_t sym;
 	elf_word rel_cnt = 0;
@@ -172,44 +179,77 @@ int llext_link(struct llext_loader *ldr, struct llext *ext, bool do_local)
 	for (i = 0; i < ldr->sect_cnt; ++i) {
 		elf_shdr_t *shdr = ldr->sect_hdrs + i;
 
-		/* find relocation sections */
-		if (shdr->sh_type != SHT_REL && shdr->sh_type != SHT_RELA) {
+		/* find proper relocation sections */
+		switch (shdr->sh_type) {
+		case SHT_REL:
+			if (shdr->sh_entsize != sizeof(elf_rel_t)) {
+				LOG_ERR("Invalid entry size %zd for SHT_REL section %d",
+					(size_t)shdr->sh_entsize, i);
+				return -ENOEXEC;
+			}
+			break;
+		case SHT_RELA:
+			/* FIXME: currently implemented only on the Xtensa code path */
+			if (!IS_ENABLED(CONFIG_XTENSA)) {
+				LOG_ERR("Found unsupported SHT_RELA section %d", i);
+				return -ENOTSUP;
+			}
+			if (shdr->sh_entsize != sizeof(elf_rela_t)) {
+				LOG_ERR("Invalid entry size %zd for SHT_RELA section %d",
+					(size_t)shdr->sh_entsize, i);
+				return -ENOEXEC;
+			}
+			break;
+		default:
+			/* ignore this section */
 			continue;
+		}
+
+		if (shdr->sh_info >= ldr->sect_cnt ||
+		    shdr->sh_size % shdr->sh_entsize != 0) {
+			LOG_ERR("Sanity checks failed for section %d "
+				"(info %zd, size %zd, entsize %zd)", i,
+				(size_t)shdr->sh_info,
+				(size_t)shdr->sh_size,
+				(size_t)shdr->sh_entsize);
+			return -ENOEXEC;
 		}
 
 		rel_cnt = shdr->sh_size / shdr->sh_entsize;
 
 		name = llext_string(ldr, ext, LLEXT_MEM_SHSTRTAB, shdr->sh_name);
 
-		if (strcmp(name, ".rel.text") == 0) {
-			loc = (uintptr_t)ext->mem[LLEXT_MEM_TEXT];
-		} else if (strcmp(name, ".rel.bss") == 0 ||
-			   strcmp(name, ".rela.bss") == 0) {
-			loc = (uintptr_t)ext->mem[LLEXT_MEM_BSS];
-		} else if (strcmp(name, ".rel.rodata") == 0 ||
-			   strcmp(name, ".rela.rodata") == 0) {
-			loc = (uintptr_t)ext->mem[LLEXT_MEM_RODATA];
-		} else if (strcmp(name, ".rel.data") == 0) {
-			loc = (uintptr_t)ext->mem[LLEXT_MEM_DATA];
-		} else if (strcmp(name, ".rel.exported_sym") == 0) {
-			loc = (uintptr_t)ext->mem[LLEXT_MEM_EXPORT];
-		} else if (strcmp(name, ".rela.plt") == 0 ||
-			   strcmp(name, ".rela.dyn") == 0) {
-			llext_link_plt(ldr, ext, shdr, do_local, NULL);
-			continue;
-		} else if (strncmp(name, ".rela", 5) == 0 && strlen(name) > 5) {
-			elf_shdr_t *tgt = llext_section_by_name(ldr, name + 5);
+		/*
+		 * FIXME: The Xtensa port is currently using a different way of
+		 * handling relocations that ultimately results in separate
+		 * arch-specific code paths. This code should be merged with
+		 * the logic below once the differences are resolved.
+		 */
+		if (IS_ENABLED(CONFIG_XTENSA)) {
+			elf_shdr_t *tgt;
 
-			if (tgt)
-				llext_link_plt(ldr, ext, shdr, do_local, tgt);
+			if (strcmp(name, ".rela.plt") == 0 ||
+			    strcmp(name, ".rela.dyn") == 0) {
+				tgt = NULL;
+			} else {
+				tgt = ldr->sect_hdrs + shdr->sh_info;
+			}
+
+			llext_link_plt(ldr, ext, shdr, do_local, tgt);
 			continue;
-		} else if (strcmp(name, ".rel.dyn") == 0) {
-			/* we assume that first load segment starts at MEM_TEXT */
-			loc = (uintptr_t)ext->mem[LLEXT_MEM_TEXT];
 		}
 
-		LOG_DBG("relocation section %s (%d) linked to section %d has %zd relocations",
-			name, i, shdr->sh_link, (size_t)rel_cnt);
+		enum llext_mem mem_idx = ldr->sect_map[shdr->sh_info].mem_idx;
+
+		if (mem_idx == LLEXT_MEM_COUNT) {
+			LOG_ERR("Section %d has no corresponding memory region", shdr->sh_info);
+			return -ENOEXEC;
+		}
+
+		sect_base = (uintptr_t)llext_loaded_sect_ptr(ldr, ext, shdr->sh_info);
+
+		LOG_DBG("relocation section %s (%d) acting on section %d has %zd relocations",
+			name, i, shdr->sh_info, (size_t)rel_cnt);
 
 		for (int j = 0; j < rel_cnt; j++) {
 			/* get each relocation entry */
@@ -237,16 +277,16 @@ int llext_link(struct llext_loader *ldr, struct llext *ext, bool do_local)
 
 			name = llext_string(ldr, ext, LLEXT_MEM_STRTAB, sym.st_name);
 
-			LOG_DBG("relocation %d:%d info %zx (type %zd, sym %zd) offset %zd sym_name "
-				"%s sym_type %d sym_bind %d sym_ndx %d",
+			LOG_DBG("relocation %d:%d info 0x%zx (type %zd, sym %zd) offset %zd "
+				"sym_name %s sym_type %d sym_bind %d sym_ndx %d",
 				i, j, (size_t)rel.r_info, (size_t)ELF_R_TYPE(rel.r_info),
-				(size_t)ELF_R_SYM(rel.r_info),
-				(size_t)rel.r_offset, name, ELF_ST_TYPE(sym.st_info),
+				(size_t)ELF_R_SYM(rel.r_info), (size_t)rel.r_offset,
+				name, ELF_ST_TYPE(sym.st_info),
 				ELF_ST_BIND(sym.st_info), sym.st_shndx);
 
 			uintptr_t link_addr, op_loc;
 
-			op_loc = loc + rel.r_offset;
+			op_loc = sect_base + rel.r_offset;
 
 			if (ELF_R_SYM(rel.r_info) == 0) {
 				/* no symbol ex: R_ARM_V4BX relocation, R_ARM_RELATIVE  */

--- a/subsys/llext/llext_load.c
+++ b/subsys/llext/llext_load.c
@@ -38,27 +38,6 @@ LOG_MODULE_DECLARE(llext, CONFIG_LLEXT_LOG_LEVEL);
 
 static const char ELF_MAGIC[] = {0x7f, 'E', 'L', 'F'};
 
-elf_shdr_t *llext_section_by_name(struct llext_loader *ldr, const char *search_name)
-{
-	int i;
-
-	for (i = 0; i < ldr->sect_cnt; ++i) {
-		elf_shdr_t *shdr = ldr->sect_hdrs + i;
-		const char *name = llext_peek(ldr,
-					      ldr->sects[LLEXT_MEM_SHSTRTAB].sh_offset +
-					      shdr->sh_name);
-		if (!name) {
-			/* The peek() method isn't supported */
-			return NULL;
-		}
-		if (!strcmp(name, search_name)) {
-			return shdr;
-		}
-	}
-
-	return NULL;
-}
-
 /*
  * Load basic ELF file data
  */

--- a/subsys/llext/llext_priv.h
+++ b/subsys/llext/llext_priv.h
@@ -59,6 +59,18 @@ static inline const char *llext_string(struct llext_loader *ldr, struct llext *e
 	return (char *)ext->mem[mem_idx] + idx;
 }
 
+static inline const void *llext_loaded_sect_ptr(struct llext_loader *ldr, struct llext *ext,
+						unsigned int sh_ndx)
+{
+	enum llext_mem mem_idx = ldr->sect_map[sh_ndx].mem_idx;
+
+	if (mem_idx == LLEXT_MEM_COUNT) {
+		return NULL;
+	}
+
+	return (const uint8_t *)ext->mem[mem_idx] + ldr->sect_map[sh_ndx].offset;
+}
+
 /*
  * Relocation (llext_link.c)
  */

--- a/subsys/llext/llext_priv.h
+++ b/subsys/llext/llext_priv.h
@@ -51,8 +51,6 @@ static inline void llext_free(void *ptr)
 int do_llext_load(struct llext_loader *ldr, struct llext *ext,
 		  struct llext_load_param *ldr_parm);
 
-elf_shdr_t *llext_section_by_name(struct llext_loader *ldr, const char *search_name);
-
 static inline const char *llext_string(struct llext_loader *ldr, struct llext *ext,
 				       enum llext_mem mem_idx, unsigned int idx)
 {

--- a/subsys/llext/llext_priv.h
+++ b/subsys/llext/llext_priv.h
@@ -10,6 +10,11 @@
 #include <zephyr/kernel.h>
 #include <zephyr/llext/llext.h>
 
+struct llext_elf_sect_map {
+	enum llext_mem mem_idx;
+	size_t offset;
+};
+
 /*
  * Memory management (llext_mem.c)
  */

--- a/tests/subsys/llext/simple/CMakeLists.txt
+++ b/tests/subsys/llext/simple/CMakeLists.txt
@@ -27,6 +27,10 @@ if (CONFIG_LLEXT_TYPE_ELF_RELOCATABLE AND CONFIG_XTENSA)
     list(APPEND ext_names pre_located)
 endif()
 
+if (CONFIG_LLEXT_STORAGE_WRITABLE)
+    list(APPEND ext_names find_section)
+endif()
+
 # generate extension targets foreach extension given by 'ext_names'
 foreach(ext_name ${ext_names})
   set(ext_src ${PROJECT_SOURCE_DIR}/src/${ext_name}_ext.c)

--- a/tests/subsys/llext/simple/src/find_section_ext.c
+++ b/tests/subsys/llext/simple/src/find_section_ext.c
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024 Arduino SA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* This very basic extension only contains a global variable "number", which is
+ * expected to be mapped at offset 0 in the .data section. This can be used in
+ * CONFIG_LLEXT_STORAGE_WRITABLE-enabled builds to verify that the variable
+ * address, as calculated by the llext loader, matches the start of the .data
+ * section in the ELF buffer as returned by llext_find_section.
+ *
+ * If only this test fails, the llext_find_section API is likely broken.
+ */
+
+#include <zephyr/llext/symbol.h>
+
+int number = 42;
+
+void test_entry(void)
+{
+	/* unused */
+}
+
+LL_EXTENSION_SYMBOL(number);

--- a/tests/subsys/llext/simple/src/test_llext_simple.c
+++ b/tests/subsys/llext/simple/src/test_llext_simple.c
@@ -212,47 +212,55 @@ void load_call_unload(struct llext_test *test_case)
 		};								\
 		load_call_unload(&test_case);					\
 	}
-static LLEXT_CONST uint8_t hello_world_ext[] __aligned(4) = {
+
+/*
+ * ELF file should be aligned to at least sizeof(elf_word) to avoid issues. A
+ * larger value eases debugging, since it reduces the differences in addresses
+ * between similar runs.
+ */
+#define ELF_ALIGN __aligned(4096)
+
+static LLEXT_CONST uint8_t hello_world_ext[] ELF_ALIGN = {
 	#include "hello_world.inc"
 };
 LLEXT_LOAD_UNLOAD(hello_world, false, NULL)
 
-static LLEXT_CONST uint8_t logging_ext[] __aligned(4) = {
+static LLEXT_CONST uint8_t logging_ext[] ELF_ALIGN = {
 	#include "logging.inc"
 };
 LLEXT_LOAD_UNLOAD(logging, true, NULL)
 
-static LLEXT_CONST uint8_t relative_jump_ext[] __aligned(4) = {
+static LLEXT_CONST uint8_t relative_jump_ext[] ELF_ALIGN = {
 	#include "relative_jump.inc"
 };
 LLEXT_LOAD_UNLOAD(relative_jump, true, NULL)
 
-static LLEXT_CONST uint8_t object_ext[] __aligned(4) = {
+static LLEXT_CONST uint8_t object_ext[] ELF_ALIGN = {
 	#include "object.inc"
 };
 LLEXT_LOAD_UNLOAD(object, true, NULL)
 
 #ifndef CONFIG_LLEXT_TYPE_ELF_RELOCATABLE
-static LLEXT_CONST uint8_t syscalls_ext[] __aligned(4) = {
+static LLEXT_CONST uint8_t syscalls_ext[] ELF_ALIGN = {
 	#include "syscalls.inc"
 };
 LLEXT_LOAD_UNLOAD(syscalls, true, NULL)
 
-static LLEXT_CONST uint8_t threads_kernel_objects_ext[] __aligned(4) = {
+static LLEXT_CONST uint8_t threads_kernel_objects_ext[] ELF_ALIGN = {
 	#include "threads_kernel_objects.inc"
 };
 LLEXT_LOAD_UNLOAD(threads_kernel_objects, true, threads_objects_perm_setup)
 #endif
 
 #ifndef CONFIG_LLEXT_TYPE_ELF_OBJECT
-static LLEXT_CONST uint8_t multi_file_ext[] __aligned(4) = {
+static LLEXT_CONST uint8_t multi_file_ext[] ELF_ALIGN = {
 	#include "multi_file.inc"
 };
 LLEXT_LOAD_UNLOAD(multi_file, true, NULL)
 #endif
 
 #if defined(CONFIG_LLEXT_TYPE_ELF_RELOCATABLE) && defined(CONFIG_XTENSA)
-static LLEXT_CONST uint8_t pre_located_ext[] __aligned(4) = {
+static LLEXT_CONST uint8_t pre_located_ext[] ELF_ALIGN = {
 	#include "pre_located.inc"
 };
 

--- a/tests/subsys/llext/simple/testcase.yaml
+++ b/tests/subsys/llext/simple/testcase.yaml
@@ -1,12 +1,25 @@
 common:
   tags: llext
-  arch_allow:
-    - arm
-    - xtensa
   platform_exclude:
+    # platforms with active issues
     - apollo4p_evb            # See #73443
     - apollo4p_blue_kxr_evb   # See #73443
     - numaker_pfm_m487        # See #63167
+    - s32z2xxdc2/s32z270/rtu0 # See commit 18a0660
+    - s32z2xxdc2/s32z270/rtu1 # See commit 18a0660
+    # platforms that are always skipped by the runtime filter
+    - qemu_arc/qemu_arc_em
+    - qemu_arc/qemu_arc_hs
+    - qemu_arc/qemu_arc_hs/xip
+    - qemu_arc/qemu_arc_hs5x
+    - qemu_arc/qemu_arc_hs6x
+    - qemu_cortex_m0
+    - qemu_xtensa/dc233c/mmu
+  integration_platforms:
+    - qemu_cortex_a9          # ARM Cortex-A9 (ARMv7-A ISA)
+    - qemu_cortex_r5          # ARM Cortex-R5 (ARMv7-R ISA)
+    - mps2/an385              # ARM Cortex-M3 (ARMv7-M ISA)
+    - mps2/an521/cpu0         # ARM Cortex-M33 (ARMv8-M ISA)
 
 tests:
   # While there is in practice no value in compiling subsys/llext/*.c
@@ -15,61 +28,63 @@ tests:
   # future.
   llext.simple.loader_build:
     build_only: true
-    # How to override the above and allow ANY arch?
-    arch_allow: arm arm64 x86 x86_64 xtensa posix
 
+  # Run the suite with all combinations of core Kconfig options for the llext
+  # subsystem (storage type, ELF type, MPU/MMU etc)
   llext.simple.readonly:
-    arch_exclude: xtensa # for now
+    arch_allow: arm # Xtensa needs writable storage
     filter: not CONFIG_MPU and not CONFIG_MMU and not CONFIG_SOC_SERIES_S32ZE
     extra_configs:
       - arch:arm:CONFIG_ARM_MPU=n
+      - arch:arm:CONFIG_ARM_AARCH32_MMU=n
       - CONFIG_LLEXT_STORAGE_WRITABLE=n
   llext.simple.readonly_mpu:
     min_ram: 128
-    arch_exclude: xtensa # for now
+    arch_allow: arm # Xtensa needs writable storage
     filter: CONFIG_ARCH_HAS_USERSPACE
     extra_configs:
       - CONFIG_USERSPACE=y
       - CONFIG_LLEXT_STORAGE_WRITABLE=n
   llext.simple.writable:
+    arch_allow: arm xtensa
+    integration_platforms:
+      - qemu_xtensa             # Xtensa ISA
     filter: not CONFIG_MPU and not CONFIG_MMU and not CONFIG_SOC_SERIES_S32ZE
     extra_configs:
       - arch:arm:CONFIG_ARM_MPU=n
+      - arch:arm:CONFIG_ARM_AARCH32_MMU=n
       - CONFIG_LLEXT_STORAGE_WRITABLE=y
   llext.simple.writable_relocatable:
-    arch_exclude: arm arm64
-    filter: not CONFIG_MPU and not CONFIG_MMU
+    arch_allow: arm xtensa
     integration_platforms:
-      - qemu_xtensa
+      - qemu_xtensa             # Xtensa ISA
+    filter: not CONFIG_MPU and not CONFIG_MMU
     extra_configs:
+      - arch:arm:CONFIG_ARM_MPU=n
+      - arch:arm:CONFIG_ARM_AARCH32_MMU=n
       - CONFIG_LLEXT_STORAGE_WRITABLE=y
       - CONFIG_LLEXT_TYPE_ELF_RELOCATABLE=y
-  llext.simple.readonly_slid_linking:
-    arch_exclude: xtensa # for now
-    filter: not CONFIG_MPU and not CONFIG_MMU and not CONFIG_SOC_SERIES_S32ZE
-    extra_configs:
-      - arch:arm:CONFIG_ARM_MPU=n
-      - CONFIG_LLEXT_STORAGE_WRITABLE=n
-      - CONFIG_LLEXT_EXPORT_BUILTINS_BY_SLID=y
-  llext.simple.readonly_mpu_slid_linking:
-    min_ram: 128
-    arch_exclude: xtensa # for now
-    filter: CONFIG_ARCH_HAS_USERSPACE
-    extra_configs:
-      - CONFIG_USERSPACE=y
-      - CONFIG_LLEXT_STORAGE_WRITABLE=n
-      - CONFIG_LLEXT_EXPORT_BUILTINS_BY_SLID=y
+
+  # Test the Symbol Link Identifier (SLID) linking feature on writable
+  # storage to cover both ARM and Xtensa architectures on the same test.
   llext.simple.writable_slid_linking:
+    arch_allow: arm xtensa
+    integration_platforms:
+      - qemu_xtensa             # Xtensa ISA
     filter: not CONFIG_MPU and not CONFIG_MMU and not CONFIG_SOC_SERIES_S32ZE
     extra_configs:
       - arch:arm:CONFIG_ARM_MPU=n
+      - arch:arm:CONFIG_ARM_AARCH32_MMU=n
       - CONFIG_LLEXT_STORAGE_WRITABLE=y
+      - CONFIG_LLEXT_EXPORT_BUILTINS_BY_SLID=y
   llext.simple.writable_relocatable_slid_linking:
-    arch_exclude: arm arm64
-    filter: not CONFIG_MPU and not CONFIG_MMU
+    arch_allow: arm xtensa
     integration_platforms:
-      - qemu_xtensa
+      - qemu_xtensa             # Xtensa ISA
+    filter: not CONFIG_MPU and not CONFIG_MMU
     extra_configs:
+      - arch:arm:CONFIG_ARM_MPU=n
+      - arch:arm:CONFIG_ARM_AARCH32_MMU=n
       - CONFIG_LLEXT_STORAGE_WRITABLE=y
       - CONFIG_LLEXT_TYPE_ELF_RELOCATABLE=y
       - CONFIG_LLEXT_EXPORT_BUILTINS_BY_SLID=y


### PR DESCRIPTION
PR #74509 expanded the llext test suite and identified a number of shortcomings related to the latest changes. In particular:
* The section merge commit did not consider the fact that relocations and symbols are relative to the set of original sections, not the merged ones. Offsets must be calculated and used properly in symbols and linking logic.
* `llext_find_section` uses a section header cache that Is basically not available when the API can be used. Partially revert the changes and reduce the number of sections identified by name in the code.

This PR fixes the above issues, with a green CI run on all the new test cases.

The first 4 commits are taken directly from the PR above (and can be viewed separately there).