### PR TITLE
drivers: serial: esp32_usb: fix interrupt-enable race condition

### DIFF
--- a/drivers/serial/serial_esp32_usb.c
+++ b/drivers/serial/serial_esp32_usb.c
@@ -142,7 +142,9 @@ static void serial_esp32_usb_irq_tx_enable(const struct device *dev)
 	usb_serial_jtag_ll_ena_intr_mask(USB_SERIAL_JTAG_INTR_SERIAL_IN_EMPTY);
 
 	if (data->irq_cb != NULL) {
+		unsigned int key = irq_lock();
 		data->irq_cb(dev, data->irq_cb_data);
+		arch_irq_unlock(key);
 	}
 }
 
@@ -220,8 +222,8 @@ static void serial_esp32_usb_irq_callback_set(const struct device *dev,
 {
 	struct serial_esp32_usb_data *data = dev->data;
 
-	data->irq_cb = cb;
 	data->irq_cb_data = cb_data;
+	data->irq_cb = cb;
 }
 
 static void serial_esp32_usb_isr(void *arg)


### PR DESCRIPTION
After enabling interrupts, serial_esp32_usb_irq_tx_enable() calls the interrupt handler to handle any old events that occurred while interrupts were disabled.  However, this happens in the callers context, so if an interrupt arrives during the call, it will call the interrupt handler again resulting in corruption if the interrupt handler is not reentrant.

Fixes #74569