### PR TITLE
scripts: checkpatch.pl: treat `.overlay` files as dts

### DIFF
--- a/boards/actinius/icarus_som_dk/actinius_icarus_som_dk_common-pinctrl.dtsi
+++ b/boards/actinius/icarus_som_dk/actinius_icarus_som_dk_common-pinctrl.dtsi
@@ -68,7 +68,7 @@
 		};
 	};
 
-    pwm0_default: pwm0_default {
+	pwm0_default: pwm0_default {
 		group1 {
 			psels = <NRF_PSEL(PWM_OUT0, 0, 3)>;
 			nordic,invert;

--- a/boards/st/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
+++ b/boards/st/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
@@ -142,13 +142,13 @@ stm32_lp_tick_source: &lptim1 {
 		status = "okay";
 
 		partitions {
-			   compatible = "fixed-partitions";
-			   #address-cells = <1>;
-			   #size-cells = <1>;
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
 
-			   partition@0 {
-			       reg = <0x00000000 DT_SIZE_M(64)>;
-			   };
+			partition@0 {
+				reg = <0x00000000 DT_SIZE_M(64)>;
+			};
 		};
 	};
 };

--- a/boards/st/stm32l562e_dk/stm32l562e_dk_common.dtsi
+++ b/boards/st/stm32l562e_dk/stm32l562e_dk_common.dtsi
@@ -175,13 +175,13 @@ stm32_lp_tick_source: &lptim1 {
 		];
 
 		partitions {
-			   compatible = "fixed-partitions";
-			   #address-cells = <1>;
-			   #size-cells = <1>;
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
 
-			   partition@0 {
-			       reg = <0x00000000 DT_SIZE_M(64)>;
-			   };
+			partition@0 {
+				reg = <0x00000000 DT_SIZE_M(64)>;
+			};
 		};
 	};
 };

--- a/dts/arm/infineon/cat3/xmc/xmc4xxx.dtsi
+++ b/dts/arm/infineon/cat3/xmc/xmc4xxx.dtsi
@@ -247,10 +247,10 @@
 			};
 
 			mdio: mdio {
-			      compatible = "infineon,xmc4xxx-mdio";
-			      status = "disabled";
-			      #address-cells = <1>;
-			      #size-cells = <0>;
+				compatible = "infineon,xmc4xxx-mdio";
+				status = "disabled";
+				#address-cells = <1>;
+				#size-cells = <0>;
 			};
 		};
 
@@ -263,24 +263,24 @@
 			#size-cells = <1>;
 
 			can_node0: can_node0@48014200 {
-				      compatible = "infineon,xmc4xxx-can-node";
-				      reg = <0x48014200 0x100>;
-				      interrupts = <76 1>;
-				      status = "disabled";
+				compatible = "infineon,xmc4xxx-can-node";
+				reg = <0x48014200 0x100>;
+				interrupts = <76 1>;
+				status = "disabled";
 			};
 
 			can_node1: can_node1@48014300 {
-				      compatible = "infineon,xmc4xxx-can-node";
-				      reg = <0x48014300 0x100>;
-				      interrupts = <77 1>;
-				      status = "disabled";
+				compatible = "infineon,xmc4xxx-can-node";
+				reg = <0x48014300 0x100>;
+				interrupts = <77 1>;
+				status = "disabled";
 			};
 
 			can_node2: can_node2@48014400 {
-				      compatible = "infineon,xmc4xxx-can-node";
-				      reg = <0x48014400 0x100>;
-				      interrupts = <78 1>;
-				      status = "disabled";
+					compatible = "infineon,xmc4xxx-can-node";
+					reg = <0x48014400 0x100>;
+					interrupts = <78 1>;
+					status = "disabled";
 			};
 		};
 	};

--- a/dts/arm/silabs/efm32_jg_pg_12b.dtsi
+++ b/dts/arm/silabs/efm32_jg_pg_12b.dtsi
@@ -26,7 +26,7 @@
 	};
 
 	sram0: memory@20000000 {
-	       compatible = "mmio-sram";
+		compatible = "mmio-sram";
 	};
 
 	soc {

--- a/dts/arm/silabs/efm32_pg_1b.dtsi
+++ b/dts/arm/silabs/efm32_pg_1b.dtsi
@@ -21,7 +21,7 @@
 	};
 
 	sram0: memory@20000000 {
-	       compatible = "mmio-sram";
+		compatible = "mmio-sram";
 	};
 
 	soc {
@@ -144,17 +144,17 @@
 				 * control in a distributed way (GPIO registers and PSEL
 				 * registers on each peripheral).
 				 */
-				 compatible = "silabs,gecko-pinctrl";
+				compatible = "silabs,gecko-pinctrl";
 			};
 		};
 
-                wdog0: wdog@40052000 {
-                        compatible = "silabs,gecko-wdog";
-                        reg = <0x40052000 0x400>;
-                        peripheral-id = <0>;
-                        interrupts = <2 0>;
-                        status = "disabled";
-                };
+		wdog0: wdog@40052000 {
+			compatible = "silabs,gecko-wdog";
+			reg = <0x40052000 0x400>;
+			peripheral-id = <0>;
+			interrupts = <2 0>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/dts/arm/silabs/efm32gg11b.dtsi
+++ b/dts/arm/silabs/efm32gg11b.dtsi
@@ -27,7 +27,7 @@
 	};
 
 	sram0: memory@20000000 {
-	       compatible = "mmio-sram";
+		compatible = "mmio-sram";
 	};
 
 	soc {

--- a/dts/arm/silabs/efm32gg12b.dtsi
+++ b/dts/arm/silabs/efm32gg12b.dtsi
@@ -26,7 +26,7 @@
 	};
 
 	sram0: memory@20000000 {
-	       compatible = "mmio-sram";
+		compatible = "mmio-sram";
 	};
 
 	soc {

--- a/dts/x86/intel/elkhart_lake.dtsi
+++ b/dts/x86/intel/elkhart_lake.dtsi
@@ -29,8 +29,8 @@
 	};
 
 	ibecc: ibecc {
-	       compatible = "intel,ibecc";
-	       status = "okay";
+		compatible = "intel,ibecc";
+		status = "okay";
 	};
 
 	intc: ioapic@fec00000  {

--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -3135,7 +3135,7 @@ sub process {
 
 # check for DT compatible documentation
 		if (defined $root &&
-			(($realfile =~ /\.dtsi?$/ && $line =~ /^\+\s*compatible\s*=\s*\"/) ||
+			(($realfile =~ /\.(dts|dtsi|overlay)$/ && $line =~ /^\+\s*compatible\s*=\s*\"/) ||
 			 ($realfile =~ /\.[ch]$/ && $line =~ /^\+.*\.compatible\s*=\s*\"/))) {
 
 			my @compats = $rawline =~ /\"([a-zA-Z0-9\-\,\.\+_]+)\"/g;
@@ -3172,7 +3172,7 @@ sub process {
 				my $comment = "";
 				if ($realfile =~ /\.(h|s|S)$/) {
 					$comment = '/*';
-				} elsif ($realfile =~ /\.(c|dts|dtsi)$/) {
+				} elsif ($realfile =~ /\.(c|dts|dtsi|overlay)$/) {
 					$comment = '//';
 				} elsif (($checklicenseline == 2) || $realfile =~ /\.(sh|pl|py|awk|tc|yaml)$/) {
 					$comment = '#';
@@ -3214,7 +3214,7 @@ sub process {
 		}
 
 # check we are in a valid source file if not then ignore this hunk
-		next if ($realfile !~ /\.(h|c|s|S|sh|dtsi|dts)$/);
+		next if ($realfile !~ /\.(h|c|s|S|sh|dtsi|dts|overlay)$/);
 
 # check for using SPDX-License-Identifier on the wrong line number
 		if ($realline != $checklicenseline &&
@@ -3295,7 +3295,7 @@ sub process {
 		}
 
 # check we are in a valid source file C or perl if not then ignore this hunk
-		next if ($realfile !~ /\.(h|c|pl|dtsi|dts)$/);
+		next if ($realfile !~ /\.(h|c|pl|dtsi|dts|overlay)$/);
 
 # at the beginning of a line any tabs must come first and anything
 # more than $tabsize must use tabs, except multi-line macros which may start


### PR DESCRIPTION
Treat devicetree overlay files as DTS source for the purposes of checkpatch.
Fixes #74570.

Cleanup leading spaces found via the following regexes:
```
  r" compatible ="
  r"^  "
```
in:
```
  zephyr/**/*.dts
  zephyr/**/*.dtsi
```