### PR TITLE
Updates for Infineon CAT1 platform 

### DIFF
--- a/boards/infineon/cy8cproto_062_4343w/cy8cproto_062_4343w-common.dtsi
+++ b/boards/infineon/cy8cproto_062_4343w/cy8cproto_062_4343w-common.dtsi
@@ -15,7 +15,7 @@
 		compatible = "gpio-leds";
 		user_led: led_0 {
 			label = "LED_0";
-			gpios = <&gpio_prt13 7 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio_prt13 7 GPIO_ACTIVE_LOW>;
 		};
 	};
 

--- a/drivers/bluetooth/hci/h4_ifx_cyw43xxx.c
+++ b/drivers/bluetooth/hci/h4_ifx_cyw43xxx.c
@@ -32,6 +32,7 @@ BUILD_ASSERT(DT_PROP(DT_INST_GPARENT(0), hw_flow_control) == 1,
 
 /* BT settling time after power on */
 #define BT_POWER_ON_SETTLING_TIME_MS      (500u)
+#define BT_POWER_CBUCK_DISCHARGE_TIME_MS  (300u)
 
 /* Stabilization delay after FW loading */
 #define BT_STABILIZATION_DELAY_MS         (250u)
@@ -230,12 +231,16 @@ int bt_h4_vnd_setup(const struct device *dev)
 	}
 
 	/* Configure bt_reg_on as output  */
-	err = gpio_pin_configure_dt(&bt_reg_on, GPIO_OUTPUT);
+	err = gpio_pin_configure_dt(&bt_reg_on, GPIO_OUTPUT_LOW);
 	if (err) {
 		LOG_ERR("Error %d: failed to configure bt_reg_on %s pin %d",
 			err, bt_reg_on.port->name, bt_reg_on.pin);
 		return err;
 	}
+
+	/* Allow BT CBUCK regulator to discharge */
+	(void)k_msleep(BT_POWER_CBUCK_DISCHARGE_TIME_MS);
+
 	err = gpio_pin_set_dt(&bt_reg_on, 1);
 	if (err) {
 		return err;

--- a/drivers/serial/uart_ifx_cat1.c
+++ b/drivers/serial/uart_ifx_cat1.c
@@ -233,7 +233,7 @@ static int ifx_cat1_uart_configure(const struct device *dev,
 
 	/* Enable RTS/CTS flow control */
 	if ((result == CY_RSLT_SUCCESS) && cfg->flow_ctrl) {
-		result = cyhal_uart_enable_flow_control(&data->obj, true, true);
+		Cy_SCB_UART_EnableCts(data->obj.base);
 	}
 
 	return (result == CY_RSLT_SUCCESS) ? 0 : -ENOTSUP;
@@ -437,6 +437,11 @@ static int ifx_cat1_uart_init(const struct device *dev)
 		.resource = &data->hw_resource,
 		.config = &_cyhal_uart_default_config,
 		.clock = &data->clock,
+		.gpios = {
+			.pin_tx  = NC,
+			.pin_rts = NC,
+			.pin_cts = NC,
+		},
 	};
 
 	/* Dedicate SCB HW resource */


### PR DESCRIPTION
[cy8cproto_062_4343w: board: fix polarity for LED_0](https://github.com/zephyrproject-rtos/zephyr/commit/c8c59dc1504d74b2f983f9058d14f7d90388037c)

[drivers: serial: CAT1 UART driver: fix HW flow control](https://github.com/zephyrproject-rtos/zephyr/commit/3cc60601c345f1e4391a3ceb59682beb87dfd2ab)

[driver/bluetooth/h4_ifx_cyw43xxx: Allow CBUCK regulator to discharge](https://github.com/zephyrproject-rtos/zephyr/commit/17405712a19aaeb740fdac21353549b723b8b4f5)

cc: @lawrencek52