### PR TITLE
Fix init hang issue

### DIFF
--- a/kernel/Kconfig.device
+++ b/kernel/Kconfig.device
@@ -45,6 +45,14 @@ config KERNEL_INIT_PRIORITY_OBJECTS
 	  priority needs to be higher than minimal default initialization
 	  priority.
 
+config KERNEL_INIT_PRIORITY_LIBC
+	int "LIBC initialization priority"
+	default 35
+	help
+	  LIBC uses this priority for initialization. This
+	  priority needs to be higher than minimal default initialization
+	  priority.
+
 config KERNEL_INIT_PRIORITY_DEFAULT
 	int "Default init priority"
 	default 40

--- a/lib/libc/common/source/stdlib/malloc.c
+++ b/lib/libc/common/source/stdlib/malloc.c
@@ -260,7 +260,7 @@ void free(void *ptr)
 	malloc_unlock();
 }
 
-SYS_INIT(malloc_prepare, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+SYS_INIT(malloc_prepare, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_LIBC);
 #else /* No malloc arena */
 void *malloc(size_t size)
 {

--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -142,7 +142,7 @@ static int malloc_prepare(void)
 	return 0;
 }
 
-SYS_INIT(malloc_prepare, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+SYS_INIT(malloc_prepare, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_LIBC);
 
 /* Current offset from HEAP_BASE of unused memory */
 LIBC_BSS static size_t heap_sz;

--- a/modules/mbedtls/zephyr_init.c
+++ b/modules/mbedtls/zephyr_init.c
@@ -104,7 +104,7 @@ static int _mbedtls_init(void)
 }
 
 #if defined(CONFIG_MBEDTLS_INIT)
-SYS_INIT(_mbedtls_init, POST_KERNEL, 0);
+SYS_INIT(_mbedtls_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 #endif
 
 /* if CONFIG_MBEDTLS_INIT is not defined then this function


### PR DESCRIPTION
modules: mbedtls: Fix init hang issue
libc: common: Fix init hang issue

In device init phase, it will call _mbedtls_init before malloc_prepare
as mbedtls has higher priority defined in SYS_INIT..
_mbedtls_init() will call psa_crypto_init() and malloc buffer,
but z_malloc_heap is not initialized, which will cause device hang.
Should call malloc_prepare() before _mbedtls_init to fix this issue,
so exchange their priority to init in SYS_INIT.

Fixes #74980