### PR TITLE
random: `sys_csrand_get` backend for `TEST_RANDOM_GENERATOR`

### DIFF
--- a/subsys/random/CMakeLists.txt
+++ b/subsys/random/CMakeLists.txt
@@ -8,16 +8,17 @@ zephyr_library()
 zephyr_library_sources_ifdef(CONFIG_USERSPACE           random_handlers.c)
 endif()
 
-if (CONFIG_TIMER_RANDOM_GENERATOR)
+if (CONFIG_TIMER_RANDOM_GENERATOR OR CONFIG_TEST_CSPRNG_GENERATOR)
   message(WARNING "
-    Warning: CONFIG_TIMER_RANDOM_GENERATOR is not a truly random generator.
-    This capability is not secure and it is provided for testing purposes only.
-    Use it carefully.")
+    Warning: CONFIG_TIMER_RANDOM_GENERATOR and CONFIG_TEST_CSPRNG_GENERATOR are
+    not truly random generators. This capability is not secure and it is
+    provided for testing purposes only. Use it carefully.")
 endif()
 
 zephyr_library_sources_ifdef(CONFIG_TIMER_RANDOM_GENERATOR          random_timer.c)
 zephyr_library_sources_ifdef(CONFIG_XOSHIRO_RANDOM_GENERATOR        random_xoshiro128.c)
 zephyr_library_sources_ifdef(CONFIG_CTR_DRBG_CSPRNG_GENERATOR       random_ctr_drbg.c)
+zephyr_library_sources_ifdef(CONFIG_TEST_CSPRNG_GENERATOR           random_test_csprng.c)
 
 if (CONFIG_ENTROPY_DEVICE_RANDOM_GENERATOR OR CONFIG_HARDWARE_DEVICE_CS_GENERATOR)
 zephyr_library_sources(random_entropy_device.c)

--- a/subsys/random/Kconfig
+++ b/subsys/random/Kconfig
@@ -88,6 +88,7 @@ config CSPRNG_ENABLED
 choice CSPRNG_GENERATOR_CHOICE
 	prompt "Cryptographically secure random generator"
 	default HARDWARE_DEVICE_CS_GENERATOR
+	default TEST_CSPRNG_GENERATOR
 	help
 	  Platform dependent cryptographically secure random number support.
 
@@ -115,6 +116,13 @@ config CTR_DRBG_CSPRNG_GENERATOR
 	  shall use the entropy API for an initialization seed. The CTR-DRBG
 	  is a FIPS140-2 recommended cryptographically secure random number
 	  generator.
+
+config TEST_CSPRNG_GENERATOR
+	bool "Use insecure CSPRNG for testing purposes"
+	depends on TEST_RANDOM_GENERATOR
+	help
+	  Route calls to `sys_csrand_get` through `sys_rand_get` to enable
+	  libraries that use the former to be tested with ZTEST.
 
 endchoice # CSPRNG_GENERATOR_CHOICE
 

--- a/subsys/random/random_test_csprng.c
+++ b/subsys/random/random_test_csprng.c
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2024 Embeint Inc
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/random/random.h>
+
+int z_impl_sys_csrand_get(void *dst, size_t outlen)
+{
+	sys_rand_get(dst, outlen);
+	return 0;
+}

--- a/tests/subsys/random/rng/src/main.c
+++ b/tests/subsys/random/rng/src/main.c
@@ -32,6 +32,7 @@ ZTEST(rng_common, test_rand32)
 	int rnd_cnt;
 	int equal_count = 0;
 	uint32_t buf[N_VALUES];
+	int err;
 
 	/* Test early boot random number generation function */
 	/* Cover the case, where argument "length" is < size of "size_t" */
@@ -91,7 +92,7 @@ ZTEST(rng_common, test_rand32)
 
 	memset(buf, 0, sizeof(buf));
 
-	int err = sys_csrand_get(buf, sizeof(buf));
+	err = sys_csrand_get(buf, sizeof(buf));
 
 	zassert_true(err == 0, "sys_csrand_get returned an error");
 
@@ -110,7 +111,12 @@ ZTEST(rng_common, test_rand32)
 
 #else
 
-	printk("Cryptographically secure random number APIs not enabled\n");
+	printk("Cryptographically secure implementation not enabled\n");
+	printk("Ensure sys_csrand_get passes for library usage\n");
+
+	err = sys_csrand_get(buf, sizeof(buf));
+
+	zassert_true(err == 0, "sys_csrand_get returned an error");
 
 #endif /* CONFIG_CSPRNG_ENABLED */
 }


### PR DESCRIPTION
When non-random number generation is allowed via
`TEST_RANDOM_GENERATOR`, enable an implementation for `sys_csrand_get`
that stubs out to `sys_rand_get`. This enables libraries that request
CS random numbers to be tested in CI, even if the results are not CS in
that context.

The documentation for `TEST_RANDOM_GENERATOR` is explicit enough about
the dangers of enabling this in production.
