### PR TITLE
samples: llext: modules: increase stack size to prevent stack overflow

### DIFF
--- a/samples/subsys/llext/modules/prj.conf
+++ b/samples/subsys/llext/modules/prj.conf
@@ -12,3 +12,8 @@ CONFIG_LLEXT=y
 CONFIG_LLEXT_LOG_LEVEL_DBG=y
 CONFIG_LLEXT_HEAP_SIZE=64
 CONFIG_LLEXT_TYPE_ELF_RELOCATABLE=y
+
+# This test consumes large amounts of stack when loading the LLEXT.
+# Increase the available size to avoid overflowing (see issue #74536).
+
+CONFIG_MAIN_STACK_SIZE=2048


### PR DESCRIPTION
Make main stack bigger for the `samples/subsys/llext/modules` sample to prevent stack overflow. On STM32 Nucleo-F401RE, the test only has 64 bytes of free stack left as early as `main` and the sample crashes with a USAGE FAULT due to the stack overflow.

Fixes #74536.