### PR TITLE
drivers/flash/nrf_rram increaser flash timeout multipler

### DIFF
--- a/drivers/flash/Kconfig.nrf_rram
+++ b/drivers/flash/Kconfig.nrf_rram
@@ -61,7 +61,7 @@ endchoice
 config SOC_FLASH_NRF_TIMEOUT_MULTIPLIER
 	int "Multiplier for flash operation timeouts [x0.1]"
 	depends on !SOC_FLASH_NRF_RADIO_SYNC_NONE
-	default 1
+	default 15
 	help
 	  This is a multiplier that will be divided by 10 that is applied
 	  to the flash erase and write operations timeout. The base for

--- a/soc/nordic/nrf54l/soc.h
+++ b/soc/nordic/nrf54l/soc.h
@@ -13,7 +13,7 @@
 
 #include <soc_nrf_common.h>
 
-#define FLASH_PAGE_ERASE_MAX_TIME_US 8000UL
+#define FLASH_PAGE_ERASE_MAX_TIME_US 42000UL
 #define FLASH_PAGE_MAX_CNT	     381UL
 
 #endif /* _NORDICSEMI_NRF54L_SOC_H_ */


### PR DESCRIPTION
Erasing rram is very similar to partial erase on flash. So we should use the same multiplier as there, 1.5. 0.1 multipler is way to low and was causing timeouts.

Was getting timeouts without this.

chose 15 since thats what is used [here](https://github.com/zephyrproject-rtos/zephyr/blob/7f0f0a4f97d6adb6c134db0788dd200fbfba8515/drivers/flash/Kconfig.nrf#L74), and thats pretty similar usecase.


### Rationale for 3.7.0 milestone

Fix for bug where erase of bigger range may cause timeout in case when synchronizing operation with radio. Basically it makes subsystems like MCUmgr to timeout when trying to upload image.