### PR TITLE
bluetooth: host: Use K_WORK replace delayable

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4653,10 +4653,10 @@ static void tx_processor(struct k_work *item)
 	}
 }
 
-K_WORK_DELAYABLE_DEFINE(tx_work, tx_processor);
+static K_WORK_DEFINE(tx_work, tx_processor);
 
 void bt_tx_irq_raise(void)
 {
 	LOG_DBG("kick TX");
-	k_work_reschedule(&tx_work, K_NO_WAIT);
+	k_work_submit(&tx_work);
 }


### PR DESCRIPTION
Use K_WORK defined. This delayed work is never used with any other timeout than K_NO_WAIT, so the "delayed" part of it is never actually needed