### PR TITLE
Ztest: Add support for data sets as input into ZTEST.

### DIFF
--- a/doc/develop/test/ztest.rst
+++ b/doc/develop/test/ztest.rst
@@ -46,8 +46,10 @@ Below is an example of a test suite using a predicate:
 Adding tests to a suite
 ***********************
 
-There are 4 macros used to add a test to a suite, they are:
+There are 5 macros used to add a test to a suite, they are:
 
+* :c:macro:`ZTEST_PARAM` ``(suite_name, test_name, params)`` - Which can be used to add a test
+  by ``test_name`` to a given suite by ``suite_name`` with an additional parameters by ``params``.
 * :c:macro:`ZTEST` ``(suite_name, test_name)`` - Which can be used to add a test by ``test_name`` to a
   given suite by ``suite_name``.
 * :c:macro:`ZTEST_USER` ``(suite_name, test_name)`` - Which behaves the same as :c:macro:`ZTEST`, only

--- a/subsys/testsuite/ztest/include/zephyr/ztest_test.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest_test.h
@@ -391,6 +391,27 @@ void ztest_test_skip(void);
 
 void ztest_skip_failed_assumption(void);
 
+#define Z_TEST_PARAM(suite, fn, t_options, param) \
+	struct ztest_unit_test_stats z_ztest_unit_test_stats_##suite##_##fn; \
+	static void _##suite##_##fn##_wrapper(void *data); \
+	static void suite##_##fn(void *params); \
+	static STRUCT_SECTION_ITERABLE(ztest_unit_test, z_ztest_unit_test__##suite##__##fn) = { \
+		.test_suite_name = STRINGIFY(suite), \
+		.name = STRINGIFY(fn), \
+		.test = (_##suite##_##fn##_wrapper), \
+		.thread_options = t_options, \
+		.stats = &z_ztest_unit_test_stats_##suite##_##fn \
+	}; \
+	static void _##suite##_##fn##_wrapper(void *wrapper_data) \
+	{ \
+		ARG_UNUSED(wrapper_data); suite##_##fn(param); \
+	} \
+	static inline void suite##_##fn(void *params)
+
+
+#define ZTEST_PARAM(suite, fn, params) Z_TEST_PARAM(suite, fn, 0, params)
+#define Z_ZTEST_PARAM(suite, fn, t_options) Z_TEST_PARAM(suite, fn, t_options, params)
+
 #define Z_TEST(suite, fn, t_options, use_fixture)                                                  \
 	struct ztest_unit_test_stats z_ztest_unit_test_stats_##suite##_##fn;                       \
 	static void _##suite##_##fn##_wrapper(void *data);                                         \

--- a/tests/ztest/ztest_params/CMakeLists.txt
+++ b/tests/ztest/ztest_params/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(ztest_params)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/ztest/ztest_params/prj.conf
+++ b/tests/ztest/ztest_params/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/ztest/ztest_params/src/main.c
+++ b/tests/ztest/ztest_params/src/main.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+
+/* initialize the example input data sets */
+int int_value = 10;
+int int_table[] = {0, 1, 2, 3};
+char char_value = 'Z';
+char char_table[] = {'H', 'e', 'l', 'l', 'o', ' ', 'Z', 'e', 'p', 'h', 'y', 'r'};
+char string[] = "Hello Zephyr";
+
+ZTEST_SUITE(ztest_params, NULL, NULL, NULL, NULL, NULL);
+
+ZTEST_PARAM(ztest_params, test_int_value, &int_value)
+{
+	zassert_equal(*((int *)params), 10);
+}
+
+ZTEST_PARAM(ztest_params, test_int_table, int_table)
+{
+	for (int i = 0; i < 4; i++) {
+		zassert_equal(((int *)params)[i], i);
+	}
+}
+
+ZTEST_PARAM(ztest_params, test_char_value, &char_value)
+{
+	zassert_equal('Z', *((char *)(params)));
+}
+
+ZTEST_PARAM(ztest_params, test_char_table, char_table)
+{
+	zassert_equal('H', ((char *)params)[0]);
+	zassert_equal('e', ((char *)params)[1]);
+	zassert_equal('l', ((char *)params)[2]);
+	zassert_equal('l', ((char *)params)[3]);
+	zassert_equal('o', ((char *)params)[4]);
+	zassert_equal(' ', ((char *)params)[5]);
+	zassert_equal('Z', ((char *)params)[6]);
+	zassert_equal('e', ((char *)params)[7]);
+	zassert_equal('p', ((char *)params)[8]);
+	zassert_equal('h', ((char *)params)[9]);
+	zassert_equal('y', ((char *)params)[10]);
+	zassert_equal('r', ((char *)params)[11]);
+}
+
+ZTEST_PARAM(ztest_params, test_string, string)
+{
+	zassert_equal(strcmp("Hello Zephyr", (char *)(params)), 0, "Strings are not equal");
+}

--- a/tests/ztest/ztest_params/testcase.yaml
+++ b/tests/ztest/ztest_params/testcase.yaml
@@ -1,0 +1,4 @@
+tests:
+  testing.ztest.ztest_params.ztest_params:
+    tags:
+      - test_framework


### PR DESCRIPTION
This pull request introduces a new macro, `ZTEST_PARAM`, which extends the functionality of the ZTEST framework. The primary motivation behind creating this new macro is to maintain backward compatibility with the existing `ZTEST` macro while adding the capability to create tests and pass parameters to them.

In addition to the new macro, this pull request also includes new tests `tests/ztest/ztest_params` designed to validate the functionality of the `ZTEST_PARAM` macro. These tests demonstrate how the new macro can be used and ensure its correctness.
