### PR TITLE
Bluetooth: Host: Enforce correct pool in `bt_hci_cmd_send_sync`

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <errno.h>
+#include <zephyr/net/buf.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/check.h>
 #include <zephyr/sys/util.h>
@@ -354,6 +355,12 @@ int bt_hci_cmd_send_sync(uint16_t opcode, struct net_buf *buf,
 		buf = bt_hci_cmd_create(opcode, 0);
 		if (!buf) {
 			return -ENOBUFS;
+		}
+	} else {
+		/* `cmd(buf)` depends on this  */
+		if (net_buf_pool_get(buf->pool_id) != &hci_cmd_pool) {
+			__ASSERT_NO_MSG(false);
+			return -EINVAL;
 		}
 	}
 


### PR DESCRIPTION
`cmd(buf)` depends on this since it uses `net_buf_id`, which would alias multiple pools.