### PR TITLE
drivers: udc_dwc: remove rwup flag

### DIFF
--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -2029,7 +2029,6 @@ static int dwc2_driver_preinit(const struct device *dev)
 
 	k_mutex_init(&data->mutex);
 
-	data->caps.rwup = true;
 	data->caps.addr_before_status = true;
 	data->caps.mps0 = UDC_MPS0_64;
 


### PR DESCRIPTION
The driver does not implement host_wakeup, remove rwup capability flag.