### PR TITLE
Added frdm_ke17z512 platform to allow testing drivers.i2c.target_api.single_role.eeprom_target

### DIFF
--- a/tests/drivers/i2c/i2c_target_api/testcase.yaml
+++ b/tests/drivers/i2c/i2c_target_api/testcase.yaml
@@ -39,3 +39,4 @@ tests:
       - mimxrt1170_evk/mimxrt1176/cm7
       - mimxrt1040_evk
       - mimxrt1060_evk
+      - frdm_ke17z512


### PR DESCRIPTION
Added frdm_ke17z512 platform to allow testing `drivers.i2c.target_api.single_role.eeprom_target`