### PR TITLE
drivers: flash: mark unused argument

### DIFF
--- a/include/zephyr/drivers/flash.h
+++ b/include/zephyr/drivers/flash.h
@@ -109,6 +109,7 @@ int flash_params_get_erase_cap(const struct flash_parameters *p)
 #if defined(CONFIG_FLASH_HAS_NO_EXPLICIT_ERASE)
 	return (p->caps.no_explicit_erase) ? 0 : FLASH_ERASE_C_EXPLICIT;
 #else
+	ARG_UNUSED(p);
 	return FLASH_ERASE_C_EXPLICIT;
 #endif
 #endif


### PR DESCRIPTION
Fixes:

```
.../zephyr/drivers/flash.h: In function 'flash_params_get_erase_cap':
.../flash.h:106:63: error: unused parameter 'p' [-Werror=unused-parameter]
  106 | int flash_params_get_erase_cap(const struct flash_parameters *p)
      |                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
```