### PR TITLE
Bluetooth: Host: Don't give cmd buf as evt buf on send fail

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2963,9 +2963,9 @@ static void hci_core_send_cmd(void)
 	err = bt_send(buf);
 	if (err) {
 		LOG_ERR("Unable to send to driver (err %d)", err);
-		k_sem_give(&bt_dev.ncmd_sem);
-		hci_cmd_done(cmd(buf)->opcode, BT_HCI_ERR_UNSPECIFIED, buf);
 		net_buf_unref(buf);
+		k_sem_give(&bt_dev.ncmd_sem);
+		hci_cmd_done(cmd(buf)->opcode, BT_HCI_ERR_UNSPECIFIED, NULL);
 		bt_tx_irq_raise();
 	}
 }


### PR DESCRIPTION
There is no reason to do this, and it makes no sense since the buffer does not contain the response.