### PR TITLE
Bluetooth: Host: Fix HCI command timeout usage

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4627,7 +4627,7 @@ int bt_configure_data_path(uint8_t dir, uint8_t id, uint8_t vs_config_len,
 static bool process_pending_cmd(k_timeout_t timeout)
 {
 	if (!k_fifo_is_empty(&bt_dev.cmd_tx_queue)) {
-		if (k_sem_take(&bt_dev.ncmd_sem, K_NO_WAIT) == 0) {
+		if (k_sem_take(&bt_dev.ncmd_sem, timeout) == 0) {
 			hci_core_send_cmd();
 			return true;
 		}


### PR DESCRIPTION
Fix Bluetooth initialization problem caused by PR [#72090](https://github.com/zephyrproject-rtos/zephyr/pull/72090) at least for ST boards that are using BlueNRG BLE modules.

Fixes [#74528](https://github.com/zephyrproject-rtos/zephyr/issues/74528)