### PR TITLE
Renesas: Smartbond: Handling USBD DMA via the driver class and not directly

### DIFF
--- a/boards/renesas/da1469x_dk_pro/dts/da1469x_dk_pro_lcdc.overlay
+++ b/boards/renesas/da1469x_dk_pro/dts/da1469x_dk_pro_lcdc.overlay
@@ -19,10 +19,6 @@
     };
 };
 
-&dma {
-    status = "okay";
-};
-
 &pinctrl {
     i2c2_default: i2c2_default {
         group1 {

--- a/boards/renesas/da1469x_dk_pro/dts/da1469x_dk_pro_mipi_dbi.overlay
+++ b/boards/renesas/da1469x_dk_pro/dts/da1469x_dk_pro_mipi_dbi.overlay
@@ -33,15 +33,10 @@
     };
 };
 
-&spi2 {
-    status = "okay";
-};
-
 &lcdc {
     compatible = "renesas,smartbond-mipi-dbi";
     status = "okay";
     reset-gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
-    spi-dev = <&spi2>;
     pinctrl-0 = <&mipi_dbi_default>;
     pinctrl-1 = <&mipi_dbi_read>;
     pinctrl-2 = <&mipi_dbi_sleep>;

--- a/boards/renesas/da1469x_dk_pro/dts/da1469x_dk_pro_psram.overlay
+++ b/boards/renesas/da1469x_dk_pro/dts/da1469x_dk_pro_psram.overlay
@@ -10,6 +10,10 @@
 	};
 };
 
+&psram {
+	status = "okay";
+};
+
 /* QSPIC settings for the APS6404L-3SQR QSPI PSRAM memory in QPI mode. */
 &memc {
 	status = "okay";

--- a/drivers/dma/dma_smartbond.c
+++ b/drivers/dma/dma_smartbond.c
@@ -853,7 +853,7 @@ static int dma_smartbond_get_status(const struct device *dev, uint32_t channel,
 
 	/* Convert transfers to bytes. */
 	stat->total_copied = dma_idx_reg * bus_width;
-	stat->pending_length = ((dma_len_reg + 1) - dma_idx_reg) * bus_width;
+	stat->pending_length = (dma_len_reg - dma_idx_reg) * bus_width;
 	stat->busy = DMA_CTRL_REG_GET_FIELD(DMA_ON, dma_ctrl_reg);
 	stat->dir = data->channel_data[channel].dir;
 

--- a/drivers/mipi_dbi/Kconfig.smartbond
+++ b/drivers/mipi_dbi/Kconfig.smartbond
@@ -7,6 +7,5 @@ config MIPI_DBI_SMARTBOND
 	bool "Smartbond MIPI DBI host controller driver"
 	depends on DT_HAS_RENESAS_SMARTBOND_MIPI_DBI_ENABLED
 	default y
-	select SPI
 	help
 	  Enable Smartbond MIPI DBI host controller.

--- a/drivers/mipi_dbi/mipi_dbi_smartbond.c
+++ b/drivers/mipi_dbi/mipi_dbi_smartbond.c
@@ -509,7 +509,7 @@ static int mipi_dbi_smartbond_pm_action(const struct device *dev, enum pm_device
 
 static int mipi_dbi_smartbond_init(const struct device *dev)
 {
-	const struct mipi_dbi_smartbond_config *config = dev->config;
+	__unused const struct mipi_dbi_smartbond_config *config = dev->config;
 	struct mipi_dbi_smartbond_data *data = dev->data;
 	int ret;
 

--- a/drivers/usb/device/Kconfig
+++ b/drivers/usb/device/Kconfig
@@ -78,6 +78,7 @@ config USB_DC_SMARTBOND
 	default y
 	select CLOCK_CONTROL_SMARTBOND
 	select CLOCK_CONTROL
+	select DMA
 	depends on DT_HAS_RENESAS_SMARTBOND_USBD_ENABLED
 	help
 	  SmartBond family USB device controller Driver.

--- a/drivers/usb/device/usb_dc_smartbond.c
+++ b/drivers/usb/device/usb_dc_smartbond.c
@@ -29,6 +29,8 @@
 #include <zephyr/drivers/clock_control/smartbond_clock_control.h>
 #include <zephyr/pm/policy.h>
 
+#include <zephyr/drivers/dma.h>
+
 LOG_MODULE_REGISTER(usb_dc_smartbond, CONFIG_USB_DRIVER_LOG_LEVEL);
 
 /* USB device controller access from devicetree */
@@ -38,9 +40,9 @@ LOG_MODULE_REGISTER(usb_dc_smartbond, CONFIG_USB_DRIVER_LOG_LEVEL);
 #define USB_IRQ_PRI                    DT_INST_IRQ_BY_IDX(0, 0, priority)
 #define VBUS_IRQ                       DT_INST_IRQ_BY_IDX(0, 1, irq)
 #define VBUS_IRQ_PRI                   DT_INST_IRQ_BY_IDX(0, 1, priority)
-#define DMA_CHANNEL_RX                 DT_INST_PROP(0, dma_chan_rx)
-#define DMA_CHANNEL_TX                 DT_INST_PROP(0, dma_chan_tx)
-/* Minimal transfer size needed to use DMA. For short transfers
+
+/*
+ * Minimal transfer size needed to use DMA. For short transfers
  * it may be simpler to just fill hardware FIFO with data instead
  * of programming DMA registers.
  */
@@ -129,6 +131,32 @@ struct smartbond_ep_state {
 	struct smartbond_ep_reg_set *regs;
 };
 
+static struct usb_smartbond_dma_cfg {
+	int tx_chan;
+	int rx_chan;
+	uint8_t tx_slot_mux;
+	uint8_t rx_slot_mux;
+	const struct device *tx_dev;
+	const struct device *rx_dev;
+	struct dma_config tx_cfg;
+	struct dma_config rx_cfg;
+	struct dma_block_config tx_block_cfg;
+	struct dma_block_config rx_block_cfg;
+} usbd_dma_cfg = {
+	.tx_chan =
+		DT_DMAS_CELL_BY_NAME(DT_NODELABEL(usbd), tx, channel),
+	.tx_slot_mux =
+		DT_DMAS_CELL_BY_NAME(DT_NODELABEL(usbd), tx, config),
+	.tx_dev =
+		DEVICE_DT_GET(DT_DMAS_CTLR_BY_NAME(DT_NODELABEL(usbd), tx)),
+	.rx_chan =
+		DT_DMAS_CELL_BY_NAME(DT_NODELABEL(usbd), rx, channel),
+	.rx_slot_mux =
+		DT_DMAS_CELL_BY_NAME(DT_NODELABEL(usbd), rx, config),
+	.rx_dev =
+		DEVICE_DT_GET(DT_DMAS_CTLR_BY_NAME(DT_NODELABEL(usbd), rx)),
+};
+
 struct usb_dc_state {
 	bool vbus_present;
 	bool attached;
@@ -143,52 +171,6 @@ struct usb_dc_state {
 
 static struct usb_dc_state dev_state;
 
-#define DA146XX_DMA_USB_MUX       (0x6 << ((DMA_CHANNEL_RX) * 2))
-#define DA146XX_DMA_USB_MUX_MASK  (0xF << ((DMA_CHANNEL_RX) * 2))
-
-struct smartbond_dma_channel {
-	uint32_t dma_a_start;
-	uint32_t dma_b_start;
-	uint32_t dma_int;
-	uint32_t dma_len;
-	uint32_t dma_ctrl;
-	uint32_t dma_idx;
-	/* Extend structure size for array like usage, registers for each channel
-	 * are 0x20 bytes apart.
-	 */
-	volatile uint32_t RESERVED[2];
-};
-
-#define DMA_CHANNEL_REGS(n) ((struct smartbond_dma_channel *)(DMA) + (n))
-#define RX_DMA_REGS  DMA_CHANNEL_REGS(DMA_CHANNEL_RX)
-#define TX_DMA_REGS  DMA_CHANNEL_REGS(DMA_CHANNEL_TX)
-
-#define RX_DMA_START ((1 << DMA_DMA0_CTRL_REG_DMA_ON_Pos) |            \
-		      (0 << DMA_DMA0_CTRL_REG_BW_Pos) |                        \
-		      (1 << DMA_DMA0_CTRL_REG_DREQ_MODE_Pos) |                 \
-		      (1 << DMA_DMA0_CTRL_REG_BINC_Pos) |                      \
-		      (0 << DMA_DMA0_CTRL_REG_AINC_Pos) |                      \
-		      (0 << DMA_DMA0_CTRL_REG_CIRCULAR_Pos) |                  \
-		      (2 << DMA_DMA0_CTRL_REG_DMA_PRIO_Pos) |                  \
-		      (0 << DMA_DMA0_CTRL_REG_DMA_IDLE_Pos) |                  \
-		      (0 << DMA_DMA0_CTRL_REG_DMA_INIT_Pos) |                  \
-		      (0 << DMA_DMA0_CTRL_REG_REQ_SENSE_Pos) |                 \
-		      (0 << DMA_DMA0_CTRL_REG_BURST_MODE_Pos) |                \
-		      (0 << DMA_DMA0_CTRL_REG_BUS_ERROR_DETECT_Pos))
-
-#define TX_DMA_START ((1 << DMA_DMA0_CTRL_REG_DMA_ON_Pos) |            \
-		      (0 << DMA_DMA0_CTRL_REG_BW_Pos) |                        \
-		      (1 << DMA_DMA0_CTRL_REG_DREQ_MODE_Pos) |                 \
-		      (0 << DMA_DMA0_CTRL_REG_BINC_Pos) |                      \
-		      (1 << DMA_DMA0_CTRL_REG_AINC_Pos) |                      \
-		      (0 << DMA_DMA0_CTRL_REG_CIRCULAR_Pos) |                  \
-		      (7 << DMA_DMA0_CTRL_REG_DMA_PRIO_Pos) |                  \
-		      (0 << DMA_DMA0_CTRL_REG_DMA_IDLE_Pos) |                  \
-		      (0 << DMA_DMA0_CTRL_REG_DMA_INIT_Pos) |                  \
-		      (1 << DMA_DMA0_CTRL_REG_REQ_SENSE_Pos) |                 \
-		      (0 << DMA_DMA0_CTRL_REG_BURST_MODE_Pos) |                \
-		      (0 << DMA_DMA0_CTRL_REG_BUS_ERROR_DETECT_Pos))
-
 /*
  * DA146xx register fields and bit mask are very long. Filed masks repeat register names.
  * Those convenience macros are a way to reduce complexity of register modification lines.
@@ -200,6 +182,139 @@ struct smartbond_dma_channel {
 #define REG_SET_VAL(reg, field, val)                                   \
 	USB->reg = (USB->reg & ~USB_##reg##_##field##_Msk) |               \
 		   (val << USB_##reg##_##field##_Pos)
+
+static int usb_smartbond_dma_validate(void)
+{
+	/*
+	 * DMA RX should be assigned an even number and
+	 * DMA TX should be assigned the right next
+	 * channel (odd number).
+	 */
+	if (!(usbd_dma_cfg.tx_chan & 0x1) ||
+			(usbd_dma_cfg.rx_chan & 0x1) ||
+			(usbd_dma_cfg.tx_chan != (usbd_dma_cfg.rx_chan + 1))) {
+		LOG_ERR("Invalid RX/TX channel selection");
+		return -EINVAL;
+	}
+
+	if (usbd_dma_cfg.rx_slot_mux != usbd_dma_cfg.tx_slot_mux) {
+		LOG_ERR("TX/RX DMA slots mismatch");
+		return -EINVAL;
+	}
+
+	if (!device_is_ready(usbd_dma_cfg.tx_dev) ||
+		!device_is_ready(usbd_dma_cfg.rx_dev)) {
+		LOG_ERR("TX/RX DMA device is not ready");
+		return -ENODEV;
+	}
+
+	return 0;
+}
+
+static int usb_smartbond_dma_config(void)
+{
+	struct dma_config *tx = &usbd_dma_cfg.tx_cfg;
+	struct dma_config *rx = &usbd_dma_cfg.rx_cfg;
+	struct dma_block_config *tx_block = &usbd_dma_cfg.tx_block_cfg;
+	struct dma_block_config *rx_block = &usbd_dma_cfg.rx_block_cfg;
+
+	if (dma_request_channel(usbd_dma_cfg.rx_dev,
+				(void *)&usbd_dma_cfg.rx_chan) < 0) {
+		LOG_ERR("RX DMA channel is already occupied");
+		return -EIO;
+	}
+
+	if (dma_request_channel(usbd_dma_cfg.tx_dev,
+				(void *)&usbd_dma_cfg.tx_chan) < 0) {
+		LOG_ERR("TX DMA channel is already occupied");
+		return -EIO;
+	}
+
+	tx->channel_direction = MEMORY_TO_PERIPHERAL;
+	tx->dma_callback = NULL;
+	tx->user_data = NULL;
+	tx->block_count = 1;
+	tx->head_block = tx_block;
+
+	tx->error_callback_dis = 1;
+	/* DMA callback is not used */
+	tx->complete_callback_en = 1;
+
+	tx->dma_slot = usbd_dma_cfg.tx_slot_mux;
+	tx->channel_priority = 7;
+
+	/* Burst mode is not using when DREQ is one */
+	tx->source_burst_length = 1;
+	tx->dest_burst_length = 1;
+	/* USB is byte-oriented protocol */
+	tx->source_data_size = 1;
+	tx->dest_data_size = 1;
+
+	/* Do not change */
+	tx_block->dest_addr_adj = 0x2;
+	/* Incremental */
+	tx_block->source_addr_adj = 0x0;
+
+	/* Should reflect TX buffer */
+	tx_block->source_address = 0;
+	/* Should reflect USB TX FIFO. Temporarily assign an SRAM location. */
+	tx_block->dest_address = MCU_SYSRAM_M_BASE;
+	/* Should reflect total bytes to be transmitted */
+	tx_block->block_size = 0;
+
+	rx->channel_direction = PERIPHERAL_TO_MEMORY;
+	rx->dma_callback = NULL;
+	rx->user_data = NULL;
+	rx->block_count = 1;
+	rx->head_block = rx_block;
+
+	rx->error_callback_dis = 1;
+	/* DMA callback is not used */
+	rx->complete_callback_en = 1;
+
+	rx->dma_slot = usbd_dma_cfg.rx_slot_mux;
+	rx->channel_priority = 2;
+
+	/* Burst mode is not using when DREQ is one */
+	rx->source_burst_length = 1;
+	rx->dest_burst_length = 1;
+	/* USB is byte-oriented protocol */
+	rx->source_data_size = 1;
+	rx->dest_data_size = 1;
+
+	/* Do not change */
+	rx_block->source_addr_adj = 0x2;
+	/* Incremenetal */
+	rx_block->dest_addr_adj = 0x0;
+
+	/* Should reflect USB RX FIFO */
+	rx_block->source_address = 0;
+	/* Should reflect RX buffer. Temporarily assign an SRAM location. */
+	rx_block->dest_address = MCU_SYSRAM_M_BASE;
+	/* Should reflect total bytes to be received */
+	rx_block->block_size = 0;
+
+	if (dma_config(usbd_dma_cfg.rx_dev, usbd_dma_cfg.rx_chan, rx) < 0) {
+		LOG_ERR("RX DMA configuration failed");
+		return -EINVAL;
+	}
+
+	if (dma_config(usbd_dma_cfg.tx_dev, usbd_dma_cfg.tx_chan, tx) < 0) {
+		LOG_ERR("TX DMA configuration failed");
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static void usb_smartbond_dma_deconfig(void)
+{
+	dma_stop(usbd_dma_cfg.tx_dev,  usbd_dma_cfg.tx_chan);
+	dma_stop(usbd_dma_cfg.rx_dev, usbd_dma_cfg.rx_chan);
+
+	dma_release_channel(usbd_dma_cfg.tx_dev, usbd_dma_cfg.tx_chan);
+	dma_release_channel(usbd_dma_cfg.rx_dev, usbd_dma_cfg.rx_chan);
+}
 
 static struct smartbond_ep_state *usb_dc_get_ep_state(uint8_t ep)
 {
@@ -315,16 +430,12 @@ static bool try_allocate_dma(struct smartbond_ep_state *ep_state, uint8_t dir)
 
 static void start_rx_dma(volatile void *src, void *dst, uint16_t size)
 {
-	LOG_DBG("");
-	/* Setup SRC and DST registers */
-	RX_DMA_REGS->dma_a_start = (uint32_t)src;
-	RX_DMA_REGS->dma_b_start = (uint32_t)dst;
-	/* Don't need DMA interrupt, read end is determined by
-	 * RX_LAST or RX_ERR events.
-	 */
-	RX_DMA_REGS->dma_int = size - 1;
-	RX_DMA_REGS->dma_len = size - 1;
-	RX_DMA_REGS->dma_ctrl = RX_DMA_START;
+	if (dma_reload(usbd_dma_cfg.rx_dev, usbd_dma_cfg.rx_chan,
+		(uint32_t)src, (uint32_t)dst, size) < 0) {
+		LOG_ERR("Failed to reload RX DMA");
+	} else {
+		dma_start(usbd_dma_cfg.rx_dev, usbd_dma_cfg.rx_chan);
+	}
 }
 
 static void start_rx_packet(struct smartbond_ep_state *ep_state)
@@ -368,14 +479,12 @@ static void start_rx_packet(struct smartbond_ep_state *ep_state)
 
 static void start_tx_dma(void *src, volatile void *dst, uint16_t size)
 {
-	LOG_DBG("%d", size);
-	/* Setup SRC and DST registers. */
-	TX_DMA_REGS->dma_a_start = (uint32_t)src;
-	TX_DMA_REGS->dma_b_start = (uint32_t)dst;
-	/* Interrupt not needed. */
-	TX_DMA_REGS->dma_int = size;
-	TX_DMA_REGS->dma_len = size - 1;
-	TX_DMA_REGS->dma_ctrl = TX_DMA_START;
+	if (dma_reload(usbd_dma_cfg.tx_dev, usbd_dma_cfg.tx_chan,
+		(uint32_t)src, (uint32_t)dst, size) < 0) {
+		LOG_ERR("Failed to reload TX DMA");
+	} else {
+		dma_start(usbd_dma_cfg.tx_dev, usbd_dma_cfg.tx_chan);
+	}
 }
 
 static void start_tx_packet(struct smartbond_ep_state *ep_state)
@@ -398,7 +507,8 @@ static void start_tx_packet(struct smartbond_ep_state *ep_state)
 	    remaining > DMA_MIN_TRANSFER_SIZE &&
 	    (uint32_t)(ep_state->buffer) >= CONFIG_SRAM_BASE_ADDRESS &&
 	    try_allocate_dma(ep_state, USB_EP_DIR_IN)) {
-		/* Whole packet will be put in FIFO by DMA.
+		/*
+		 * Whole packet will be put in FIFO by DMA.
 		 * Set LAST bit before start.
 		 */
 		start_tx_dma(ep_state->buffer + ep_state->transferred,
@@ -534,28 +644,34 @@ static void handle_epx_rx_ev(uint8_t ep_idx)
 			ep_state->last_packet_size = 0;
 			if (dev_state.dma_ep[0] == ep_state) {
 				/* Stop DMA */
-				RX_DMA_REGS->dma_ctrl &= ~DMA_DMA0_CTRL_REG_DMA_ON_Msk;
+				dma_stop(usbd_dma_cfg.rx_dev, usbd_dma_cfg.rx_chan);
 				/* Restart DMA since packet was dropped,
 				 * all parameters should still work.
 				 */
-				RX_DMA_REGS->dma_ctrl |= DMA_DMA0_CTRL_REG_DMA_ON_Msk;
+				dma_start(usbd_dma_cfg.rx_dev, usbd_dma_cfg.rx_chan);
 			}
 			break;
 		}
 
 		if (dev_state.dma_ep[0] == ep_state) {
-			/* Disable DMA and update last_packet_size
+			struct dma_status rx_dma_status;
+
+			dma_get_status(usbd_dma_cfg.rx_dev, usbd_dma_cfg.rx_chan, &rx_dma_status);
+			/*
+			 * Disable DMA and update last_packet_size
 			 * with what DMA reported.
 			 */
-			RX_DMA_REGS->dma_ctrl &= ~DMA_DMA0_CTRL_REG_DMA_ON_Msk;
-			ep_state->last_packet_size = RX_DMA_REGS->dma_idx;
+			dma_stop(usbd_dma_cfg.rx_dev, usbd_dma_cfg.rx_chan);
+			ep_state->last_packet_size = rx_dma_status.total_copied;
+
 			/*
 			 * When DMA did not finished (packet was smaller then MPS),
 			 * dma_idx holds exact number of bytes transmitted. When DMA
 			 * finished value in dma_idx is one less then actual number of
 			 * transmitted bytes.
 			 */
-			if (ep_state->last_packet_size == RX_DMA_REGS->dma_len) {
+			if (ep_state->last_packet_size ==
+				(rx_dma_status.total_copied + rx_dma_status.pending_length)) {
 				ep_state->last_packet_size++;
 			}
 			/* Release DMA to use by other endpoints. */
@@ -613,11 +729,15 @@ static void handle_epx_tx_ev(struct smartbond_ep_state *ep_state)
 
 	if (GET_BIT(txs, USB_USB_TXS1_REG_USB_TX_DONE)) {
 		if (dev_state.dma_ep[1] == ep_state) {
-			/* Disable DMA and update last_packet_size with what
+			struct dma_status tx_dma_status;
+
+			dma_get_status(usbd_dma_cfg.tx_dev, usbd_dma_cfg.tx_chan, &tx_dma_status);
+			/*
+			 * Disable DMA and update last_packet_size with what
 			 * DMA reported.
 			 */
-			TX_DMA_REGS->dma_ctrl &= ~DMA_DMA1_CTRL_REG_DMA_ON_Msk;
-			ep_state->last_packet_size = TX_DMA_REGS->dma_idx + 1;
+			dma_stop(usbd_dma_cfg.tx_dev, usbd_dma_cfg.tx_chan);
+			ep_state->last_packet_size = tx_dma_status.total_copied + 1;
 			/* Release DMA to used by other endpoints. */
 			dev_state.dma_ep[1] = NULL;
 		}
@@ -949,6 +1069,7 @@ static void usb_change_state(bool attached, bool vbus_present)
 		 * IRQ response time
 		 */
 		pm_policy_state_lock_get(PM_STATE_STANDBY, PM_ALL_SUBSTATES);
+		usb_smartbond_dma_config();
 		usb_clock_on();
 		dev_state.status_cb(USB_DC_CONNECTED, NULL);
 		USB->USB_MCTRL_REG = USB_USB_MCTRL_REG_USBEN_Msk;
@@ -965,11 +1086,6 @@ static void usb_change_state(bool attached, bool vbus_present)
 
 		USB->USB_MCTRL_REG = USB_USB_MCTRL_REG_USBEN_Msk |
 				     USB_USB_MCTRL_REG_USB_NAT_Msk;
-
-		/* Select chosen DMA to be triggered by USB. */
-		DMA->DMA_REQ_MUX_REG =
-			(DMA->DMA_REQ_MUX_REG & ~DA146XX_DMA_USB_MUX_MASK) |
-			DA146XX_DMA_USB_MUX;
 	} else if (dev_state.attached && dev_state.vbus_present) {
 		/*
 		 * USB was previously in use now either VBUS is gone or application
@@ -980,6 +1096,7 @@ static void usb_change_state(bool attached, bool vbus_present)
 		USB->USB_MCTRL_REG = 0;
 		usb_clock_off();
 		dev_state.status_cb(USB_DC_DISCONNECTED, NULL);
+		usb_smartbond_dma_deconfig();
 		/* Allow standby USB not in use or not connected */
 		pm_policy_state_lock_put(PM_STATE_STANDBY, PM_ALL_SUBSTATES);
 	} else {
@@ -1001,6 +1118,16 @@ static void usb_dc_smartbond_vbus_isr(void)
 
 static int usb_init(void)
 {
+	int ret = 0;
+
+	BUILD_ASSERT(DT_DMAS_HAS_NAME(DT_NODELABEL(usbd), tx), "Unasigned TX DMA");
+	BUILD_ASSERT(DT_DMAS_HAS_NAME(DT_NODELABEL(usbd), rx), "Unasigned RX DMA");
+
+	ret = usb_smartbond_dma_validate();
+	if (ret != 0) {
+		return ret;
+	}
+
 	for (int i = 0; i < EP_MAX; ++i) {
 		dev_state.ep_state[0][i].regs = reg_sets[i];
 		dev_state.ep_state[0][i].ep_addr = i | USB_EP_DIR_OUT;
@@ -1024,7 +1151,7 @@ static int usb_init(void)
 	IRQ_CONNECT(USB_IRQ, USB_IRQ_PRI, usb_dc_smartbond_isr, 0, 0);
 	irq_enable(USB_IRQ);
 
-	return 0;
+	return ret;
 }
 
 int usb_dc_ep_disable(const uint8_t ep)

--- a/dts/arm/renesas/smartbond/da1469x.dtsi
+++ b/dts/arm/renesas/smartbond/da1469x.dtsi
@@ -9,6 +9,7 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/adc/smartbond-adc.h>
 #include <zephyr/dt-bindings/pinctrl/smartbond-pinctrl.h>
+#include <zephyr/dt-bindings/dma/dma_smartbond.h>
 
 / {
 	chosen {
@@ -371,8 +372,9 @@
 		usbd: usb@50040000 {
 			compatible = "renesas,smartbond-usbd";
 			reg = <0x50040000 0x1B0>;
-			dma-chan-rx = <6>;
-			dma-chan-tx = <7>;
+			dmas = <&dma 0 DMA_SMARTBOND_TRIG_MUX_USB>,
+				<&dma 1 DMA_SMARTBOND_TRIG_MUX_USB>;
+			dma-names = "rx", "tx";
 			dma-min-transfer-size = <65>;
 			fifo-read-threshold = <4>;
 			ep-out-buf-size = <8 64 64 64>;
@@ -384,7 +386,7 @@
 			compatible = "renesas,smartbond-dma";
 			reg = <0x50040800 0x110>;
 			interrupts = <1 0>;
-			status = "disabled";
+			status = "okay";
 			dma-channels = <8>;
 			block-count = <1>;
 			#dma-cells = <2>;

--- a/dts/bindings/usb/renesas,smartbond-usbd.yaml
+++ b/dts/bindings/usb/renesas,smartbond-usbd.yaml
@@ -8,16 +8,6 @@ compatible: "renesas,smartbond-usbd"
 include: usb-controller.yaml
 
 properties:
-  dma-chan-rx:
-    type: int
-    description: |
-      DMA Channel for USB RX (0/2/4/6).
-
-  dma-chan-tx:
-    type: int
-    description: |
-      DMA Channel for USB TX (1/3/5/7).
-
   dma-min-transfer-size:
     type: int
     description: |


### PR DESCRIPTION
This PR should fix the way the USB device is handling the DMA engine. Initial request was initially raised  #73803.