### PR TITLE
native/posix arch: prevent building w stack_protector w picolibc

### DIFF
--- a/arch/posix/CMakeLists.txt
+++ b/arch/posix/CMakeLists.txt
@@ -111,6 +111,15 @@ elseif (CONFIG_NATIVE_LIBRARY)
     )
   endif()
 
+  if (CONFIG_PICOLIBC)
+    # In some distributions (Arch Linux) gcc builds by default with stack protection
+    # When building with picolibc, this results in the picolibc stack_protector code being built
+    # into the final binary. This causes trouble in some configurations. Let's prevent this
+    # combination
+    check_set_compiler_property(APPEND PROPERTY no_stack_protector "-fno-stack-protector")
+    zephyr_compile_options($<TARGET_PROPERTY:compiler,no_stack_protector>)
+  endif()
+
   if (CONFIG_COMPILER_WARNINGS_AS_ERRORS)
     target_compile_options(native_simulator INTERFACE $<TARGET_PROPERTY:compiler,warnings_as_errors>)
   endif()


### PR DESCRIPTION
When building with picolibc with the stack_protector enabled (-fstack-protector), we end up with the embedded image picolibc stack protector initialization being called at the very start of the native runner execution.
This is not something we want to happen, as when Zephyr's embeded getentropy() is built into the embedded image, picolibc's __stack_chk_init() will call into it
causing a segfault as Zephyr is not yet initialized.

In some distributions (Arch Linux) gcc builds by default with stack protection so when building with picolibc, let's pass the compiler the option to not do so if it supports it, to avoid this combination.

Fixes #74601