### PR TITLE
boards: adi: Improve twister vendor filter coverage

### DIFF
--- a/boards/adi/apard32690/apard32690_max32690_m4.yaml
+++ b/boards/adi/apard32690/apard32690_max32690_m4.yaml
@@ -1,5 +1,6 @@
 identifier: apard32690/max32690/m4
 name: apard32690 m4
+vendor: adi
 type: mcu
 arch: arm
 toolchain:

--- a/boards/adi/max32655evkit/max32655evkit_max32655_m4.yaml
+++ b/boards/adi/max32655evkit/max32655evkit_max32655_m4.yaml
@@ -1,5 +1,6 @@
 identifier: max32655evkit/max32655/m4
 name: max32655evkit m4
+vendor: adi
 type: mcu
 arch: arm
 toolchain:

--- a/boards/adi/max32655fthr/max32655fthr_max32655_m4.yaml
+++ b/boards/adi/max32655fthr/max32655fthr_max32655_m4.yaml
@@ -1,5 +1,6 @@
 identifier: max32655fthr/max32655/m4
 name: max32655fthr m4
+vendor: adi
 type: mcu
 arch: arm
 toolchain:

--- a/boards/adi/max32670evkit/max32670evkit.yaml
+++ b/boards/adi/max32670evkit/max32670evkit.yaml
@@ -1,5 +1,6 @@
 identifier: max32670evkit
 name: max32670evkit
+vendor: adi
 type: mcu
 arch: arm
 toolchain:

--- a/boards/adi/max32672evkit/max32672evkit.yaml
+++ b/boards/adi/max32672evkit/max32672evkit.yaml
@@ -1,5 +1,6 @@
 identifier: max32672evkit
 name: max32672evkit
+vendor: adi
 type: mcu
 arch: arm
 toolchain:

--- a/boards/adi/max32672fthr/max32672fthr.yaml
+++ b/boards/adi/max32672fthr/max32672fthr.yaml
@@ -1,5 +1,6 @@
 identifier: max32672fthr
 name: max32672fthr
+vendor: adi
 type: mcu
 arch: arm
 toolchain:

--- a/boards/adi/max32680evkit/max32680evkit_max32680_m4.yaml
+++ b/boards/adi/max32680evkit/max32680evkit_max32680_m4.yaml
@@ -1,5 +1,6 @@
 identifier: max32680evkit/max32680/m4
 name: max32680evkit m4
+vendor: adi
 type: mcu
 arch: arm
 toolchain:

--- a/boards/adi/max32690evkit/max32690evkit_max32690_m4.yaml
+++ b/boards/adi/max32690evkit/max32690evkit_max32690_m4.yaml
@@ -1,5 +1,6 @@
 identifier: max32690evkit/max32690/m4
 name: max32690evkit m4
+vendor: adi
 type: mcu
 arch: arm
 toolchain:


### PR DESCRIPTION
Some of the new max32 family boards were missing the vendor name in their board yamls and not being tested by `twister --vendor adi`.

cc: @ozersa @ttmut 