### PR TITLE
boards: st: fix sysbuild multi image flash

### DIFF
--- a/boards/st/nucleo_h533re/board.cmake
+++ b/boards/st/nucleo_h533re/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(stm32cubeprogrammer "--erase" "--port=swd" "--reset-mode=hw")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 
 board_runner_args(pyocd "--target=stm32h533retx")
 

--- a/boards/st/nucleo_h563zi/board.cmake
+++ b/boards/st/nucleo_h563zi/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(stm32cubeprogrammer "--erase" "--port=swd" "--reset-mode=hw")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 
 board_runner_args(pyocd "--target=stm32h563zitx")
 

--- a/boards/st/nucleo_u575zi_q/board.cmake
+++ b/boards/st/nucleo_u575zi_q/board.cmake
@@ -1,4 +1,4 @@
-board_runner_args(stm32cubeprogrammer "--erase" "--port=swd" "--reset-mode=hw")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 
 board_runner_args(openocd "--tcl-port=6666")

--- a/boards/st/stm32f429i_disc1/board.cmake
+++ b/boards/st/stm32f429i_disc1/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(stm32cubeprogrammer "--erase" "--port=swd" "--reset-mode=hw")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 board_runner_args(jlink "--device=STM32F429ZI" "--speed=4000")
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/st/stm32h573i_dk/board.cmake
+++ b/boards/st/stm32h573i_dk/board.cmake
@@ -4,7 +4,7 @@ if(CONFIG_STM32_MEMMAP)
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 board_runner_args(stm32cubeprogrammer "--extload=MX25LM51245G_STM32H573I-DK-RevB-SFIx.stldr")
 else()
-board_runner_args(stm32cubeprogrammer "--erase" "--port=swd" "--reset-mode=hw")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 endif()
 
 board_runner_args(pyocd "--target=stm32h573iikx")

--- a/boards/st/stm32h750b_dk/board.cmake
+++ b/boards/st/stm32h750b_dk/board.cmake
@@ -7,7 +7,7 @@ if(CONFIG_STM32_MEMMAP)
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 board_runner_args(stm32cubeprogrammer "--extload=MT25TL01G_STM32H750B-DISCO.stldr")
 else()
-board_runner_args(stm32cubeprogrammer "--erase" "--port=swd" "--reset-mode=hw" )
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw" )
 endif()
 
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)

--- a/boards/st/stm32h7b3i_dk/board.cmake
+++ b/boards/st/stm32h7b3i_dk/board.cmake
@@ -8,7 +8,7 @@ if(CONFIG_STM32_MEMMAP)
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 board_runner_args(stm32cubeprogrammer "--extload=MX25LM51245G_STM32H7B3I-DISCO.stldr")
 else()
-board_runner_args(stm32cubeprogrammer "--erase" "--port=swd" "--reset-mode=hw" )
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw" )
 endif()
 
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)

--- a/boards/st/stm32h7s78_dk/board.cmake
+++ b/boards/st/stm32h7s78_dk/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(stm32cubeprogrammer "--erase" "--port=swd" "--reset-mode=hw")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 board_runner_args(openocd --target-handle=_CHIPNAME.cpu0)
 
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)

--- a/boards/st/stm32u5a9j_dk/board.cmake
+++ b/boards/st/stm32u5a9j_dk/board.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(stm32cubeprogrammer "--erase" "--port=swd" "--reset-mode=hw")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 
 board_runner_args(openocd "--tcl-port=6666")
 board_runner_args(openocd --cmd-pre-init "gdb_report_data_abort enable")


### PR DESCRIPTION
**Problem:**

When flashing a multi-image project with STLink through sysbuild, the flash utility is told to erase the whole flash between each single image flash.

Resulting in a partial flash where only the last image is effectively stored on flash...

**Correction:**

A `west flash` must not implicitly perform a mass erase on its own.

If a flash erase is required, the option has to be passed manually.

The problem is discussed in the following issue:
zephyrproject-rtos/zephyr#69582

*note: This is my first contribution to the project*