### PR TITLE
libc: picolibc: fputc should return the value it has written

### DIFF
--- a/lib/libc/picolibc/stdio.c
+++ b/lib/libc/picolibc/stdio.c
@@ -10,8 +10,7 @@ static LIBC_DATA int (*_stdout_hook)(int);
 
 int z_impl_zephyr_fputc(int a, FILE *out)
 {
-	(*_stdout_hook)(a);
-	return 0;
+	return ((out == stdout) || (out == stderr)) ? (*_stdout_hook)(a) : EOF;
 }
 
 #ifdef CONFIG_USERSPACE
@@ -24,8 +23,7 @@ static inline int z_vrfy_zephyr_fputc(int c, FILE *stream)
 
 static int picolibc_put(char a, FILE *f)
 {
-	zephyr_fputc(a, f);
-	return 0;
+	return zephyr_fputc(a, f);
 }
 
 static LIBC_DATA FILE __stdout = FDEV_SETUP_STREAM(picolibc_put, NULL, NULL, 0);


### PR DESCRIPTION
According to the documentations:
- [en.cppreference.com/w/c/io/fputc](https://en.cppreference.com/w/c/io/fputc)

> ### Return value
> On success, returns the written character.
> On failure, returns [EOF](https://en.cppreference.com/w/c/io) and sets the error indicator (see [ferror()](https://en.cppreference.com/w/c/io/ferror)) on stream.

- [pubs.opengroup.org/onlinepubs/9699919799/functions/fputc.html](https://pubs.opengroup.org/onlinepubs/9699919799/functions/fputc.html)

> Upon successful completion, fputc() shall return the value it has written. Otherwise, it shall return EOF, the error indicator for the stream shall be set, [[CX](javascript:open_code('CX'))] [Option Start]  and errno shall be set to indicate the error.


This commit changes it to return the written value on success, and EOF if failed, which is the same as minimal libc, **but the error indicator is still not set**.

https://github.com/zephyrproject-rtos/zephyr/blob/901a8f7efbb47aebbbf6c498d5bc47215ca937a7/lib/libc/minimal/source/stdout/stdout_console.c#L28-L31