### PR TITLE
modem: pipelink: Add missing extern C in header

### DIFF
--- a/include/zephyr/modem/pipelink.h
+++ b/include/zephyr/modem/pipelink.h
@@ -11,6 +11,10 @@
 #ifndef ZEPHYR_MODEM_PIPELINK_
 #define ZEPHYR_MODEM_PIPELINK_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief Modem pipelink
  * @defgroup modem_pipelink Modem pipelink
@@ -156,5 +160,9 @@ void modem_pipelink_notify_disconnected(struct modem_pipelink *link);
 /** @} */
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZEPHYR_MODEM_PIPELINK_ */


### PR DESCRIPTION
<zephyr/modem/pipelink.h> was missing "extern C" statement.
Fails to compile with C++ enabled when using pipelink module.