### PR TITLE
drivers: dac: dacx3608: add broadcast register for synchronized output

### DIFF
--- a/drivers/dac/dac_dacx3608.c
+++ b/drivers/dac/dac_dacx3608.c
@@ -130,12 +130,18 @@ static int dacx3608_write_value(const struct device *dev, uint8_t channel,
 	uint16_t regval;
 	int ret;
 
-	if (channel > DACX3608_MAX_CHANNEL - 1) {
+	const bool brdcast = (channel == DAC_CHANNEL_BROADCAST) ? 1 : 0;
+
+	if (!brdcast && (channel > DACX3608_MAX_CHANNEL - 1)) {
 		LOG_ERR("Unsupported channel %d", channel);
 		return -ENOTSUP;
 	}
 
-	if (!(data->configured & BIT(channel))) {
+	/*
+	 * Check if channel is initialized
+	 * If broadcast channel is used, check if any channel is initialized
+	 */
+	if ((brdcast && !data->configured) || (!(data->configured & BIT(channel)))) {
 		LOG_ERR("Channel %d not initialized", channel);
 		return -EINVAL;
 	}
@@ -157,7 +163,9 @@ static int dacx3608_write_value(const struct device *dev, uint8_t channel,
 	regval = value << 2;
 	regval &= 0xFFFF;
 
-	ret = dacx3608_reg_write(dev, DACX3608_REG_DACA_DATA + channel, regval);
+	const uint8_t reg = brdcast ? DACX3608_REG_BRDCAST : DACX3608_REG_DACA_DATA + channel;
+
+	ret = dacx3608_reg_write(dev, reg, regval);
 	if (ret) {
 		LOG_ERR("Unable to set value %d on channel %d", value, channel);
 		return -EIO;

--- a/include/zephyr/drivers/dac.h
+++ b/include/zephyr/drivers/dac.h
@@ -28,6 +28,12 @@ extern "C" {
  */
 
 /**
+ * @brief Broadcast channel identifier for DACs that support it.
+ * @note Only for use in dac_write_value().
+ */
+#define DAC_CHANNEL_BROADCAST	0xFF
+
+/**
  * @brief Structure for specifying the configuration of a DAC channel.
  */
 struct dac_channel_cfg {


### PR DESCRIPTION
The dacx3608 line supports a broadcast register so all configured channels can output a singular value, simultaneously. This drastically reduces I2C overhead when using multi-channel control. An API addition was necessary to support a global broadcast channel number. The API addition does not break the write_value() implementation for other DAC drivers in the repo. This change is based on an out-of-tree driver developed internally to handle this use case.

Alternative to the API change, could be a KConfig option or device tree entry. Also, no support for the Broadcast channel was added to the channel_setup() implementation - this may or may not be confusing. I believe it makes sense to maintain explicit setup calls for each channel intended to be configured.