### PR TITLE
boards: adi: Fix input subsys tests and samples for max32 boards

### DIFF
--- a/boards/adi/max32655evkit/max32655evkit_max32655_m4.dts
+++ b/boards/adi/max32655evkit/max32655evkit_max32655_m4.dts
@@ -9,6 +9,7 @@
  #include <adi/max32/max32655.dtsi>
  #include <adi/max32/max32655-pinctrl.dtsi>
  #include <zephyr/dt-bindings/gpio/adi-max32-gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
 	 model = "Analog Devices MAX32655EVKIT";
@@ -38,15 +39,18 @@
 		 pb1: pb1 {
 			 gpios = <&gpio0 18 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			 label = "SW2";
+			 zephyr,code = <INPUT_KEY_0>;
 		 };
 		 pb2: pb2 {
 			 gpios = <&gpio0 19 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			 label = "SW3";
+			 zephyr,code = <INPUT_KEY_1>;
 		 };
 		 pb_wakeup: pb_wakeup {
 			gpios = <&gpio3 1 (GPIO_PULL_UP | GPIO_ACTIVE_LOW
 								| MAX32_GPIO_VSEL_VDDIOH)>;
 			label = "Wakeup";
+			zephyr,code = <INPUT_KEY_WAKEUP>;
 		};
 	 };
 

--- a/boards/adi/max32655fthr/max32655fthr_max32655_m4.dts
+++ b/boards/adi/max32655fthr/max32655fthr_max32655_m4.dts
@@ -9,6 +9,7 @@
 #include <adi/max32/max32655.dtsi>
 #include <adi/max32/max32655-pinctrl.dtsi>
 #include <zephyr/dt-bindings/gpio/adi-max32-gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
 	model = "Analog Devices MAX32655FTHR";
@@ -42,15 +43,18 @@
 		pb1: pb1 {
 			gpios = <&gpio0 2 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "SW2";
+			zephyr,code = <INPUT_KEY_0>;
 		};
 		pb2: pb2 {
 			gpios = <&gpio0 3 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "SW3";
+			zephyr,code = <INPUT_KEY_1>;
 		};
 		pb_wakeup: pb_wakeup {
 			gpios = <&gpio3 1 (GPIO_PULL_UP | GPIO_ACTIVE_LOW
 					| MAX32_GPIO_VSEL_VDDIOH)>;
 			label = "Wakeup";
+			zephyr,code = <INPUT_KEY_WAKEUP>;
 		};
 	};
 

--- a/boards/adi/max32680evkit/max32680evkit_max32680_m4.dts
+++ b/boards/adi/max32680evkit/max32680evkit_max32680_m4.dts
@@ -9,6 +9,7 @@
  #include <adi/max32/max32680.dtsi>
  #include <adi/max32/max32680-pinctrl.dtsi>
  #include <zephyr/dt-bindings/gpio/adi-max32-gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
 	 model = "Analog Devices MAX32680EVKIT";
@@ -38,10 +39,12 @@
 		 pb1: pb1 {
 			 gpios = <&gpio0 26 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			 label = "SW1";
+			 zephyr,code = <INPUT_KEY_0>;
 		 };
 		 pb2: pb2 {
 			 gpios = <&gpio0 27 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			 label = "SW2";
+			 zephyr,code = <INPUT_KEY_1>;
 		 };
 	 };
 

--- a/boards/adi/max32690evkit/max32690evkit_max32690_m4.dts
+++ b/boards/adi/max32690evkit/max32690evkit_max32690_m4.dts
@@ -9,6 +9,7 @@
 #include <adi/max32/max32690.dtsi>
 #include <adi/max32/max32690-pinctrl.dtsi>
 #include <zephyr/dt-bindings/gpio/adi-max32-gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
 	model = "Analog Devices MAX32690EVKIT";
@@ -38,6 +39,7 @@
 		pb0: pb0 {
 			gpios = <&gpio4 0 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "SW2";
+			zephyr,code = <INPUT_KEY_0>;
 		};
 	};
 


### PR DESCRIPTION
Input subystem tests and samples were failing to build on these max32 boards because the zephyr,code property was missing on gpio-keys child nodes. The devicetree binding doesn't specify the property as required, but the driver implements a build assert when the property isn't defined.

Fixes twister build failures observed in #74622. These build failures can be reproduced in main and will probably show up in other PRs and the weekly build, therefore labeling this PR as a hotfix.

cc: @ozersa @ttmut 