### PR TITLE
drivers: serial: nrfx_uarte2: Handle a case when interrupt driven API does not enable error interrupt

### DIFF
--- a/drivers/serial/uart_async_to_irq.c
+++ b/drivers/serial/uart_async_to_irq.c
@@ -363,6 +363,13 @@ int uart_async_to_irq_rx_disable(const struct device *dev)
 	return 0;
 }
 
+bool uart_async_to_irq_err_enabled(const struct device *dev)
+{
+	struct uart_async_to_irq_data *data = get_data(dev);
+
+	return (data->flags & A2I_ERR_IRQ_ENABLED) ? true : false;
+}
+
 void uart_async_to_irq_trampoline_cb(const struct device *dev)
 {
 	struct uart_async_to_irq_data *data = get_data(dev);

--- a/drivers/serial/uart_nrfx_uarte2.c
+++ b/drivers/serial/uart_nrfx_uarte2.c
@@ -248,7 +248,7 @@ static void on_rx_done(const struct device *dev, const nrfx_uarte_event_t *event
 		evt.data.rx_stop.data.buf = event->data.rx.p_buffer;
 		evt.data.rx_stop.data.len = event->data.rx.length;
 		/* Keep error code for uart_err_check(). */
-		if (!IS_INT_DRIVEN_API(dev)) {
+		if (!IS_INT_DRIVEN_API(dev) || !uart_async_to_irq_err_enabled(dev)) {
 			data->async->err = 0;
 		}
 		data->async->user_callback(dev, &evt, data->async->user_data);

--- a/include/zephyr/drivers/serial/uart_async_to_irq.h
+++ b/include/zephyr/drivers/serial/uart_async_to_irq.h
@@ -137,6 +137,13 @@ int uart_async_to_irq_rx_enable(const struct device *dev);
  */
 int uart_async_to_irq_rx_disable(const struct device *dev);
 
+/** @brief Checking if error interrupt is enabled.
+ *
+ * @retval true if error interrupt is enabled.
+ * @retval false if error interrupt is not enabled.
+ */
+bool uart_async_to_irq_err_enabled(const struct device *dev);
+
 /* Starting from here API is internal only. */
 
 /** @cond INTERNAL_HIDDEN


### PR DESCRIPTION
Driver was expecting that interrupt driven API will call `uart_err_check()` soon after error is reported and was keeping error state until that happens and because of that it was not reporting new bytes. This is not always the case and if error interrupt is not enabled then error should be ignored.