### PR TITLE
boards: nordic: nrf54h20dk: Counter and i2c are supported by cpuppr

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuppr.yaml
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuppr.yaml
@@ -11,6 +11,8 @@ sysbuild: true
 ram: 62
 flash: 62
 supported:
+  - counter
   - gpio
+  - i2c
   - pwm
   - spi


### PR DESCRIPTION
Extend Twister configuration for nrf54h20dk/nrf54h20/cpuppr.
Add counter and i2c to the list of supported peripherals.