### PR TITLE
bluetooth: host: Split cmd complete & cmd status to separate pool

### DIFF
--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -94,20 +94,37 @@ config BT_BUF_ACL_RX_COUNT
 	  When Controller to Host flow control is not enabled the Controller
 	  can assume that the Host has infinite amount of buffers.
 
+config BT_BUF_CMD_COMPLETE_EVT_SIZE
+	  int "Maximum supported HCI Command Complete Event buffer length"
+	  # LE Read Supported Commands command complete event.
+	  default 68
+	  range 68 255
+	  help
+	    Maximum supported HCI Command Complete event buffer size.
+	    This value does not include the HCI Event header. This value is
+	    used by both the Host and the Controller for buffer sizes that
+	    include HCI Command Complete events. It should be set according
+	    to the expected HCI Command Complete events that can be generated
+	    from the configuration.
+
+	    If the subset of possible HCI Command Complete events is unknown,
+	    this should be set to the maximum of 255.
+
 config BT_BUF_EVT_RX_SIZE
 	int "Maximum supported HCI Event buffer length"
 	default 255 if (BT_EXT_ADV && BT_OBSERVER) || BT_PER_ADV_SYNC || BT_DF_CONNECTION_CTE_RX || BT_CLASSIC
-	# LE Read Supported Commands command complete event.
-	default 68
-	range 68 255
+	default BT_BUF_CMD_COMPLETE_EVT_SIZE
+	range BT_BUF_CMD_COMPLETE_EVT_SIZE 255
 	help
 	  Maximum supported HCI event buffer size. This value does not include
 	  the HCI Event header.
-	  This value is used by both the Host and the Controller for buffer
-	  sizes that include HCI events. It should be set according to the
-	  expected HCI events that can be generated from the configuration.
-	  If the subset of possible HCI events is unknown, this should be set to
-	  the maximum of 255.
+	  This value is used by both the Host and the Controller for buffer sizes
+	  that include HCI events also include HCI Command Complete event. It should
+	  be set according to the expected HCI events that can be generated from the
+	  configuration.
+
+	  If the subset of possible HCI events is unknown, this should be set to the
+	  maximum of 255.
 
 config BT_BUF_EVT_RX_COUNT
 	int "Number of HCI Event buffers"

--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -97,6 +97,7 @@ config BT_BUF_ACL_RX_COUNT
 config BT_BUF_CMD_COMPLETE_EVT_SIZE
 	  int "Maximum supported HCI Command Complete Event buffer length"
 	  # LE Read Supported Commands command complete event.
+	  default 255 if !BT_CTLR
 	  default 68
 	  range 68 255
 	  help
@@ -107,8 +108,8 @@ config BT_BUF_CMD_COMPLETE_EVT_SIZE
 	    to the expected HCI Command Complete events that can be generated
 	    from the configuration.
 
-	    If the subset of possible HCI Command Complete events is unknown,
-	    this should be set to the maximum of 255.
+	    If the subset of possible HCI Command Complete events is unknown or
+	    if you use a split build (ie hci on another chip), then you better use 255,
 
 config BT_BUF_EVT_RX_SIZE
 	int "Maximum supported HCI Event buffer length"

--- a/subsys/bluetooth/host/buf.c
+++ b/subsys/bluetooth/host/buf.c
@@ -146,39 +146,6 @@ struct net_buf *bt_buf_get_evt(uint8_t evt, bool discardable,
 	return buf;
 }
 
-#ifdef ZTEST_UNITTEST
-#if defined(CONFIG_BT_HCI_ACL_FLOW_CONTROL)
-struct net_buf_pool *bt_buf_get_evt_pool(void)
-{
-	return &evt_pool;
-}
-
-struct net_buf_pool *bt_buf_get_acl_in_pool(void)
-{
-	return &acl_in_pool;
-}
-#else
-struct net_buf_pool *bt_buf_get_hci_rx_pool(void)
-{
-	return &hci_rx_pool;
-}
-#endif /* CONFIG_BT_HCI_ACL_FLOW_CONTROL */
-
-#if defined(CONFIG_BT_BUF_EVT_DISCARDABLE_COUNT)
-struct net_buf_pool *bt_buf_get_discardable_pool(void)
-{
-	return &discardable_pool;
-}
-#endif /* CONFIG_BT_BUF_EVT_DISCARDABLE_COUNT */
-
-#if defined(CONFIG_BT_CONN) || defined(CONFIG_BT_ISO)
-struct net_buf_pool *bt_buf_get_num_complete_pool(void)
-{
-	return &sync_evt_pool;
-}
-#endif /* CONFIG_BT_CONN || CONFIG_BT_ISO */
-#endif /* ZTEST_UNITTEST */
-
 struct net_buf *bt_buf_make_view(struct net_buf *view,
 				 struct net_buf *parent,
 				 size_t len,


### PR DESCRIPTION
The default main branch, cmd complete & cmd status use common normal net_buf pool, will be increase dead-lock, so split it to separate.

This always ensures that the event flow is not blocked.