### PR TITLE
Add st_b_lcd40_dsi1_mb1166 display shield support for stm32f769i_disco board

### DIFF
--- a/boards/shields/st_b_lcd40_dsi1_mb1166/boards/st_b_lcd40_dsi1_mb1166/stm32f769i_disco.conf
+++ b/boards/shields/st_b_lcd40_dsi1_mb1166/boards/st_b_lcd40_dsi1_mb1166/stm32f769i_disco.conf
@@ -1,0 +1,5 @@
+# Copyright (c) 2024 Linumiz
+# SPDX-License-Identifier: Apache-2.0
+
+# Initialize after LTDC and MIPI-DSI
+CONFIG_DISPLAY_OTM8009A_INIT_PRIORITY=87

--- a/boards/shields/st_b_lcd40_dsi1_mb1166/boards/stm32f769i_disco.conf
+++ b/boards/shields/st_b_lcd40_dsi1_mb1166/boards/stm32f769i_disco.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2024 Linumiz
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_MEMC=y
+CONFIG_STM32_LTDC_RGB888=y
+CONFIG_HEAP_MEM_POOL_SIZE=65536

--- a/boards/shields/st_b_lcd40_dsi1_mb1166/boards/stm32f769i_disco.overlay
+++ b/boards/shields/st_b_lcd40_dsi1_mb1166/boards/stm32f769i_disco.overlay
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024 Linumiz
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/display/panel.h>
+
+&zephyr_lcd_controller {
+	status = "okay";
+	ext-sdram = <&sdram1>;
+};
+
+&zephyr_mipi_dsi {
+	status = "okay";
+
+	pll-ndiv = <100>;
+	pll-idf = <5>;
+	pll-odf = <0>;
+
+	vs-active-high;
+	hs-active-high;
+	de-active-high;
+};

--- a/boards/shields/st_b_lcd40_dsi1_mb1166/st_b_lcd40_dsi1_mb1166.overlay
+++ b/boards/shields/st_b_lcd40_dsi1_mb1166/st_b_lcd40_dsi1_mb1166.overlay
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/display/panel.h>
+#include <zephyr/dt-bindings/mipi_dsi/mipi_dsi.h>
 
 / {
 	lvgl_pointer {

--- a/boards/shields/st_b_lcd40_dsi1_mb1166/st_b_lcd40_dsi1_mb1166_a09.overlay
+++ b/boards/shields/st_b_lcd40_dsi1_mb1166/st_b_lcd40_dsi1_mb1166_a09.overlay
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/dt-bindings/display/panel.h>
+#include <zephyr/dt-bindings/mipi_dsi/mipi_dsi.h>
 
 / {
 	lvgl_pointer {

--- a/boards/st/stm32f769i_disco/doc/index.rst
+++ b/boards/st/stm32f769i_disco/doc/index.rst
@@ -125,6 +125,29 @@ The STM32F769I Discovery kit has up to 8 UARTs. The Zephyr console output is ass
 which connected to the onboard ST-LINK/V2 Virtual COM port interface. Default communication
 settings are 115200 8N1.
 
+Display
+=======
+
+The STM32F769I Discovery kit has a dedicated DSI LCD connector **CN1**, where
+the MB1166 (B-LCD40-DSI1) display extension board can be mounted. Enable display
+support in Zephyr by adding the shield ``st_b_lcd40_dsi1_mb1166`` or
+``st_b_lcd40_dsi1_mb1166_a09`` to your build command, for example:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/drivers/display
+   :board: stm32f769i_disco
+   :shield: st_b_lcd40_dsi1_mb1166
+   :goals: build flash
+
+.. note::
+   The shield comes in different hardware revisions, the MB1166-A09
+   is utilizing a NT35510 panel controller and shall specifically
+   use ``st_b_lcd40_dsi1_mb1166_a09`` as SHIELD when building.
+   Prior versions are utilizing an OTM8009a controller and shall
+   use shield name without postfix, that is: ``st_b_lcd40_dsi1_mb1166``.
+   Shield version is printed on a sticker placed below the two bottom
+   mounting holes and has the format: MB1166-Axx.
+
 Programming and Debugging
 *************************
 

--- a/boards/st/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/st/stm32f769i_disco/stm32f769i_disco.dts
@@ -93,6 +93,7 @@
 	mul-n = <432>;
 	div-p = <2>;
 	div-q = <9>;
+	div-r = <7>;
 	clocks = <&clk_hse>;
 	status = "okay";
 };

--- a/boards/st/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/st/stm32f769i_disco/stm32f769i_disco.dts
@@ -22,7 +22,6 @@
 		zephyr,flash = &flash0;
 		zephyr,dtcm = &dtcm;
 		zephyr,flash-controller = &mx25l51245g;
-		zephyr,touch = &ft6202;
 	};
 
 	sdram1: sdram@c0000000 {
@@ -63,11 +62,6 @@
 		};
 	};
 
-	lvgl_pointer {
-		compatible = "zephyr,lvgl-pointer-input";
-		input = <&ft6202>;
-	};
-
 	aliases {
 		led0 = &red_led_1;
 		led1 = &green_led_2;
@@ -81,6 +75,13 @@
 		zephyr,memory-region = "QSPI_AVAIL";
 		zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_IO) )>;
 	};
+};
+
+qsh_030_i2c: &i2c4 {
+	pinctrl-0 = <&i2c4_scl_pd12 &i2c4_sda_pb7>;
+	pinctrl-names = "default";
+	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &clk_hse {
@@ -129,19 +130,6 @@ arduino_serial: &usart6 {};
 	pinctrl-names = "default";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
-};
-
-&i2c4 {
-	pinctrl-0 = <&i2c4_scl_pd12 &i2c4_sda_pb7>;
-	pinctrl-names = "default";
-	status = "okay";
-	clock-frequency = <I2C_BITRATE_FAST>;
-
-	ft6202: ft6202@2a {
-		compatible = "focaltech,ft5336";
-		reg = <0x2a>;
-		int-gpios = <&gpioi 13 GPIO_ACTIVE_LOW>;
-	};
 };
 
 &spi2 {

--- a/boards/st/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/st/stm32f769i_disco/stm32f769i_disco.dts
@@ -75,6 +75,23 @@
 		zephyr,memory-region = "QSPI_AVAIL";
 		zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_IO) )>;
 	};
+
+	dsi_lcd_qsh_030: connector_dsi_lcd {
+		compatible = "st,dsi-lcd-qsh-030";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <4 0 &gpioi 13 0>,	/* TOUCH_INT */
+			   <35 0 &gpiod 12 0>,	/* SCLK/MCLK */
+			   <39 0 &gpiod 11 0>,	/* I2S */
+			   <40 0 &gpiob 9 0>,	/* I2C4_SDA */
+			   <44 0 &gpiob 8 0>,	/* I2C4_SCL */
+			   <45 0 &gpioa 8 0>,	/* CEC_CLK */
+			   <47 0 &gpioa 15 0>,	/* CEC */
+			   <49 0 &gpioj 2 0>,	/* DSI_TE */
+			   <53 0 &gpioi 14 0>,	/* LCD_BL_CTRL */
+			   <57 0 &gpioj 15 0>;	/* DSI_RESET */
+	};
 };
 
 qsh_030_i2c: &i2c4 {
@@ -254,3 +271,9 @@ zephyr_udc0: &usbotg_hs {
 	phys = <&otghs_ulpi_phy>;
 	status = "okay";
 };
+
+/* alias used by display shields */
+zephyr_mipi_dsi: &mipi_dsi {};
+
+/* alias used by LCD display shields */
+zephyr_lcd_controller: &ltdc {};

--- a/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m7.dts
+++ b/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m7.dts
@@ -64,10 +64,34 @@
 		led1 = &orange_led_2;
 		sw0 = &wake_up;
 	};
+
+	dsi_lcd_qsh_030: connector_dsi_lcd {
+		compatible = "st,dsi-lcd-qsh-030";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <4 0 &gpiok 7 0>,	/* TOUCH_INT */
+			   <35 0 &gpioe 5 0>,	/* SCLK/MCLK */
+			   <39 0 &gpioe 6 0>,	/* I2S */
+			   <40 0 &gpiod 13 0>,	/* I2C4_SDA */
+			   <44 0 &gpiod 12 0>,	/* I2C4_SCL */
+			   <45 0 &gpioa 8 0>,	/* CEC_CLK */
+			   <47 0 &gpiob 6 0>,	/* CEC */
+			   <49 0 &gpioj 2 0>,	/* DSI_TE */
+			   <53 0 &gpioj 12 0>,	/* LCD_BL_CTRL */
+			   <57 0 &gpiog 3 0>;	/* DSI_RESET */
+	};
 };
 
 &clk_hse {
 	clock-frequency = <DT_FREQ_M(25)>;
+	status = "okay";
+};
+
+qsh_030_i2c: &i2c4 {
+	pinctrl-0 = <&i2c4_scl_pd12 &i2c4_sda_pd13>;
+	pinctrl-names = "default";
+	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 };
 

--- a/dts/arm/st/f7/stm32f765.dtsi
+++ b/dts/arm/st/f7/stm32f765.dtsi
@@ -91,6 +91,18 @@
 			status = "disabled";
 		};
 
+		mipi_dsi: dsihost@40016c00 {
+			compatible = "st,stm32-mipi-dsi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40016c00 0x800>;
+			clock-names = "dsiclk", "refclk", "pixelclk";
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x08000000>,
+				 <&rcc STM32_SRC_HSI NO_SEL>,
+				 <&rcc STM32_SRC_PLL_R DSI_SEL(1)>;
+			resets = <&rctl STM32_RESET(APB2, 27U)>;
+			status = "disabled";
+		};
 	};
 
 	smbus4: smbus4 {

--- a/dts/bindings/clock/st,stm32f7-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32f7-pll-clock.yaml
@@ -6,11 +6,12 @@ description: |
 
   Takes one of clk_hse or clk_hsi as input clock.
 
-  Up to 2 output clocks could be supported and for each output clock, the
+  Up to 3 output clocks could be supported and for each output clock, the
   frequency can be computed with the following formula:
 
     f(PLL_P) = f(VCO clock) / PLLP  --> PLLCLK (System Clock)
     f(PLL_Q) = f(VCO clock) / PLLQ  --> PLL48CLK (Optional)
+    f(PLL_R) = f(VCO clock) / PLLR  --> PLLDSICLK (Optional)
 
       with f(VCO clock) = f(PLL clock input) × (PLLN / PLLM)
 
@@ -56,3 +57,9 @@ properties:
     description: |
         PLL division factor for PLL48CK
         Valid range: 2 - 15
+
+  div-r:
+    type: int
+    description: |
+        PLL division factor for PLLDSICLK
+        Valid range: 2 - 7

--- a/samples/drivers/display/sample.yaml
+++ b/samples/drivers/display/sample.yaml
@@ -15,6 +15,24 @@ tests:
       - CONFIG_SDL_DISPLAY=n
       - CONFIG_TEST=y
     tags: display
+  sample.display.max7219:
+    platform_allow: nrf52840dk/nrf52840
+    extra_args: SHIELD=max7219_8x8
+    tags:
+      - display
+      - shield
+    harness: console
+    harness_config:
+      fixture: fixture_display
+  sample.display.st_b_lcd40_dsi1_mb1166:
+    filter: dt_compat_enabled("orisetech,otm8009a")
+    platform_allow:
+      - stm32h747i_disco/stm32h747xx/m7
+      - stm32f769i_disco
+    extra_args: SHIELD=st_b_lcd40_dsi1_mb1166
+    tags:
+      - display
+      - shield
     harness: console
     harness_config:
       fixture: fixture_display

--- a/samples/modules/lvgl/demos/sample.yaml
+++ b/samples/modules/lvgl/demos/sample.yaml
@@ -51,7 +51,9 @@ tests:
       - CONFIG_LV_Z_DEMO_MULTILANG=y
   sample.modules.lvgl.demos.st_b_lcd40_dsi1_mb1166:
     filter: dt_compat_enabled("orisetech,otm8009a")
-    platform_allow: stm32h747i_disco/stm32h747xx/m7
+    platform_allow:
+      - stm32h747i_disco/stm32h747xx/m7
+      - stm32f769i_disco
     extra_args: SHIELD=st_b_lcd40_dsi1_mb1166
     harness: console
     harness_config:

--- a/samples/subsys/display/lvgl/sample.yaml
+++ b/samples/subsys/display/lvgl/sample.yaml
@@ -41,7 +41,9 @@ tests:
   sample.subsys.display.lvgl.st_b_lcd40_dsi1_mb1166:
     tags: shield
     filter: dt_compat_enabled("orisetech,otm8009a")
-    platform_allow: stm32h747i_disco/stm32h747xx/m7
+    platform_allow:
+      - stm32h747i_disco/stm32h747xx/m7
+      - stm32f769i_disco
     extra_args: SHIELD=st_b_lcd40_dsi1_mb1166
     harness: console
     harness_config:


### PR DESCRIPTION
PR covers
- Add mipi ltdc display shield support for stm32f769i_disco board
- Replace direct hal api for ltdc block reset to zephyr reset api framework