### PR TITLE
tests/bsim: Provisionally disable the nrf54l15 BT tests

### DIFF
--- a/tests/bsim/ci.bt.sh
+++ b/tests/bsim/ci.bt.sh
@@ -35,9 +35,12 @@ TESTS_FILE=tests/bsim/bluetooth/tests.nrf5340bsim_nrf5340_cpuapp.txt \
 tests/bsim/run_parallel.sh
 
 # nrf54l15bsim/nrf54l15/cpuapp set:
-nice tests/bsim/bluetooth/compile.nrf54l15bsim_nrf54l15_cpuapp.sh
+# We provisionally disable the nrf54l15 BT tests in CI due to instability issues in the
+# controller for this platform. See https://github.com/zephyrproject-rtos/zephyr/issues/74635
+# This should be reverted once the underlaying issue is fixed
+#nice tests/bsim/bluetooth/compile.nrf54l15bsim_nrf54l15_cpuapp.sh
 
-BOARD=nrf54l15bsim/nrf54l15/cpuapp \
-RESULTS_FILE=${ZEPHYR_BASE}/bsim_out/bsim_results.bt.54l15_cpuapp.xml \
-TESTS_FILE=tests/bsim/bluetooth/tests.nrf54l15bsim_nrf54l15_cpuapp.txt \
-tests/bsim/run_parallel.sh
+#BOARD=nrf54l15bsim/nrf54l15/cpuapp \
+#RESULTS_FILE=${ZEPHYR_BASE}/bsim_out/bsim_results.bt.54l15_cpuapp.xml \
+#TESTS_FILE=tests/bsim/bluetooth/tests.nrf54l15bsim_nrf54l15_cpuapp.txt \
+#tests/bsim/run_parallel.sh


### PR DESCRIPTION
Let's provisionally disable the nrf54l15 BT tests in CI due to instability issues in the controller for this platform.
See https://github.com/zephyrproject-rtos/zephyr/issues/74635

This should be reverted once the underlying issue is fixed.

Mitigates #74635

Note 54l15 support is the controller was added as experimental ~2 weeks ago.