### PR TITLE
everywhere: replace double words

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -215,7 +215,7 @@ config SRAM_BASE_ADDRESS
 	hex "SRAM Base Address"
 	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_SRAM))
 	help
-	  The SRAM base address. The default value comes from from
+	  The SRAM base address. The default value comes from
 	  /chosen/zephyr,sram in devicetree. The user should generally avoid
 	  changing it via menuconfig or in configuration files.
 

--- a/arch/arm/core/cortex_a_r/isr_wrapper.S
+++ b/arch/arm/core/cortex_a_r/isr_wrapper.S
@@ -189,7 +189,7 @@ _idle_state_cleared:
 	 *
 	 * Note that interrupts are disabled up to this point on the ARM
 	 * architecture variants other than the Cortex-M. It is also important
-	 * to note that that most interrupt controllers require that the nested
+	 * to note that most interrupt controllers require that the nested
 	 * interrupts are handled after the active interrupt is acknowledged;
 	 * this is be done through the `get_active` interrupt controller
 	 * interface function.

--- a/arch/x86/core/ia32/crt0.S
+++ b/arch/x86/core/ia32/crt0.S
@@ -273,7 +273,7 @@ __csSet:
 	/* Don't clear BSS if the section is not present
 	 * in memory at boot. Or else it would cause page
 	 * faults. Zeroing BSS will be done later once the
-	 * the paging mechanism has been initialized.
+	 * paging mechanism has been initialized.
 	 */
 	call	z_bss_zero
 #endif

--- a/arch/x86/ia32.cmake
+++ b/arch/x86/ia32.cmake
@@ -126,7 +126,7 @@ add_bin_file_to_the_next_link(gen_idt_output irq_int_vector_map)
 add_bin_file_to_the_next_link(gen_idt_output irq_vectors_alloc)
 
 if(CONFIG_GDT_DYNAMIC)
-  # Use gen_gdt.py and objcopy to generate gdt.o from from the elf
+  # Use gen_gdt.py and objcopy to generate gdt.o from the elf
   # file ${ZEPHYR_PREBUILT_EXECUTABLE}, creating the temp file gdt.bin along the
   # way.
   #

--- a/boards/nuvoton/numaker_pfm_m467/numaker_pfm_m467.dts
+++ b/boards/nuvoton/numaker_pfm_m467/numaker_pfm_m467.dts
@@ -122,7 +122,7 @@
 	status = "okay";
 };
 
-/* On enabled, 'core-clock', as above, is required to to be 192MHz. */
+/* On enabled, 'core-clock', as above, is required to be 192MHz. */
 zephyr_udc0: &usbd {
 	pinctrl-0 = <&usbd_default>;
 	pinctrl-names = "default";

--- a/boards/weact/stm32g431_core/doc/index.rst
+++ b/boards/weact/stm32g431_core/doc/index.rst
@@ -81,7 +81,7 @@ Hardware Configuration
 +---------------+---------+-----------------------------------------------+
 | SB6/SB7       | Open    | Connect PB4/PB6 (UCPD1_CCx) to USB-C CCx pins |
 +---------------+---------+-----------------------------------------------+
-| SB3/SB5       | Open    | Connect PA9/PA10 (UCPD1_DBCCx) to to PB6/PB4  |
+| SB3/SB5       | Open    | Connect PA9/PA10 (UCPD1_DBCCx) to PB6/PB4     |
 +---------------+---------+-----------------------------------------------+
 | SB4           | Open    | Connect PB2 to VBUS voltage divider           |
 +---------------+---------+-----------------------------------------------+

--- a/cmake/modules/dts.cmake
+++ b/cmake/modules/dts.cmake
@@ -76,7 +76,7 @@ find_package(Dtc 1.4.6)
 # - DTC_OVERLAY_FILE: list of devicetree overlay files which will be
 #   used to modify or extend the base devicetree.
 # - EXTRA_DTC_OVERLAY_FILE: list of extra devicetree overlay files.
-#   This variable is is similar to DTC_OVERLAY_FILE but the files in
+#   This variable is similar to DTC_OVERLAY_FILE but the files in
 #   EXTRA_DTC_OVERLAY_FILE will be applied after DTC_OVERLAY_FILE and
 #   thus files specified by EXTRA_DTC_OVERLAY_FILE have higher precedence.
 # - EXTRA_DTC_FLAGS: list of extra command line options to pass to

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -505,7 +505,7 @@ function(zephyr_library_compile_options item)
   # library and link with it to obtain the flags.
   #
   # Linking with a dummy interface library will place flags later on
-  # the command line than the the flags from zephyr_interface because
+  # the command line than the flags from zephyr_interface because
   # zephyr_interface will be the first interface library that flags
   # are taken from.
 

--- a/doc/connectivity/networking/api/http_server.rst
+++ b/doc/connectivity/networking/api/http_server.rst
@@ -277,7 +277,7 @@ in the reply.
 Websocket resources
 ===================
 
-Websocket resources register an application callback, which is is called when a
+Websocket resources register an application callback, which is called when a
 Websocket connection upgrade takes place. The callback is provided with a socket
 descriptor corresponding to the underlying TCP/TLS connection. Once called,
 the application takes full control over the socket, i. e. is responsible to

--- a/doc/kernel/services/data_passing/pipes.rst
+++ b/doc/kernel/services/data_passing/pipes.rst
@@ -80,7 +80,7 @@ Alternatively, a pipe can be defined and initialized at compile time by
 calling :c:macro:`K_PIPE_DEFINE`.
 
 The following code has the same effect as the code segment above. Observe
-that that macro defines both the pipe and its ring buffer.
+that macro defines both the pipe and its ring buffer.
 
 .. code-block:: c
 

--- a/doc/releases/release-notes-2.5.rst
+++ b/doc/releases/release-notes-2.5.rst
@@ -745,7 +745,7 @@ USB
   * Separate PID for DFU mode added to avoid problems caused by the host OS
     caching the remaining descriptors when switching to DFU mode.
   * Added timer for appDETACH state and revised descriptor handling to
-    to meet specification requirements.
+    meet specification requirements.
 
 * USB HID class
 
@@ -1562,7 +1562,7 @@ release:
 * :github:`29146` - canisotp: mimxrt1064_evk: no DT_CHOSEN_ZEPHYR_CAN_PRIMARY_LABEL defined cause tests failure
 * :github:`29145` - net: frdmk64f many net related applications meet hardfault, hal driver assert
 * :github:`29139` - tests/kernel/fatal/exception failed on nsim_sem_mpu_stack_guard board
-* :github:`29120` - STM32: Few issues on on pinctrl generation script
+* :github:`29120` - STM32: Few issues on pinctrl generation script
 * :github:`29113` - Build failure with OSPD
 * :github:`29111` - Atmel SAM V71 UART_0 fail
 * :github:`29109` - HAL STM32 Missing ETH pin control configurations in DT files

--- a/doc/releases/release-notes-3.0.rst
+++ b/doc/releases/release-notes-3.0.rst
@@ -181,7 +181,7 @@ Deprecated in this release
   :c:func:`can_set_bitrate` and :c:func:`can_set_mode`.
 * :c:func:`can_attach_workq` is deprecated in favor of utilizing
   :c:func:`can_add_rx_filter_msgq` and :c:func:`k_work_poll_submit`.
-* :c:func:`can_attach_isr` is is deprecated and replaced by
+* :c:func:`can_attach_isr` is deprecated and replaced by
   :c:func:`can_add_rx_filter`.
 * :c:macro:`CAN_DEFINE_MSGQ` is deprecated and replaced by
   :c:macro:`CAN_MSGQ_DEFINE`.

--- a/drivers/adc/adc_mcux_lpadc.c
+++ b/drivers/adc/adc_mcux_lpadc.c
@@ -424,7 +424,7 @@ static void mcux_lpadc_isr(const struct device *dev)
 	LOG_DBG("Finished channel %d. Raw result is 0x%04x",
 		channel, conv_result.convValue);
 	/*
-	 * For 12 or 13 bit resolution the the LSBs will be 0, so a bit shift
+	 * For 12 or 13 bit resolution the LSBs will be 0, so a bit shift
 	 * is needed. For differential modes, the ADC conversion to
 	 * millivolts expects to use a shift one less than the resolution.
 	 *

--- a/drivers/bluetooth/hci/hci_ifx_cyw208xx.c
+++ b/drivers/bluetooth/hci/hci_ifx_cyw208xx.c
@@ -10,7 +10,7 @@
   *
   *  This driver uses btstack-integration asset as hosts platform adaptation layer
   *  (porting layer) for CYW20829. btstack-integration layer implements/
-  *  invokes the interfaces defined by BTSTACK to to enable communication
+  *  invokes the interfaces defined by BTSTACK to enable communication
   *  with the BT controller by using IPC_BTSS (IPC Bluetooth sub-system interface).
   *  Zephyr CYW20829 driver implements wiced_bt_**** functions requreds for
   *  btstack-integration asset and Zephyr Bluetooth driver interface

--- a/drivers/can/can_fake.c
+++ b/drivers/can/can_fake.c
@@ -61,7 +61,7 @@ static int fake_can_get_core_clock_delegate(const struct device *dev, uint32_t *
 {
 	ARG_UNUSED(dev);
 
-	/* Recommended CAN clock from from CiA 601-3 */
+	/* Recommended CAN clock from CiA 601-3 */
 	*rate = MHZ(80);
 
 	return 0;

--- a/drivers/can/can_loopback.c
+++ b/drivers/can/can_loopback.c
@@ -352,7 +352,7 @@ static int can_loopback_get_core_clock(const struct device *dev, uint32_t *rate)
 {
 	ARG_UNUSED(dev);
 
-	/* Recommended CAN clock from from CiA 601-3 */
+	/* Recommended CAN clock from CiA 601-3 */
 	*rate = MHZ(80);
 
 	return 0;

--- a/drivers/clock_control/beetle_clock_control.c
+++ b/drivers/clock_control/beetle_clock_control.c
@@ -205,7 +205,7 @@ static int beetle_pll_enable(uint32_t mainclk)
 	/* Set PLLCTRL Register */
 	__BEETLE_SYSCON->pllctrl = BEETLE_PLL_CONFIGURATION;
 
-	/* Switch the the Main clock to PLL and set prescaler */
+	/* Switch the Main clock to PLL and set prescaler */
 	__BEETLE_SYSCON->mainclk = pre_mainclk;
 
 	while (!__BEETLE_SYSCON->pllstatus) {

--- a/drivers/dai/intel/dmic/Kconfig.dmic
+++ b/drivers/dai/intel/dmic/Kconfig.dmic
@@ -36,7 +36,7 @@ config DAI_INTEL_DMIC_TPLG_PARAMS
 	  All registers configuration is computed on the fly
 	  based on use case and microphone datasheet parameters
 	  and topology defined PCM format. The parameters are
-	  easy to to customize in the topology.
+	  easy to customize in the topology.
 	  WORK IN PROGRESS, not enabled in the driver yet
 
 endchoice

--- a/drivers/eeprom/eeprom_at2x.c
+++ b/drivers/eeprom/eeprom_at2x.c
@@ -313,7 +313,7 @@ static int eeprom_at24_write(const struct device *dev, off_t offset,
 	bus_addr = eeprom_at24_translate_offset(dev, &offset);
 
 	/*
-	 * Not all I2C EEPROMs support repeated start so the the
+	 * Not all I2C EEPROMs support repeated start so the
 	 * address (offset) and data (buf) must be provided in one
 	 * write transaction (block).
 	 */

--- a/drivers/flash/flash_simulator_native.c
+++ b/drivers/flash/flash_simulator_native.c
@@ -30,7 +30,7 @@
 
 /*
  * Initialize the flash buffer.
- * And, if the content is to be kept on disk map it to the the buffer to the file.
+ * And, if the content is to be kept on disk map it to the buffer to the file.
  *
  * Returns -1 on failure
  *	    0 on success

--- a/drivers/gpio/gpio_hogs.c
+++ b/drivers/gpio/gpio_hogs.c
@@ -38,7 +38,7 @@ struct gpio_hogs {
 #define GPIO_HOGS_NODE_IS_GPIO_CTLR(node_id)			\
 	DT_PROP_OR(node_id, gpio_controller, 0)
 
-/* Expands to to 1 if node_id is a GPIO hog, empty otherwise */
+/* Expands to 1 if node_id is a GPIO hog, empty otherwise */
 #define GPIO_HOGS_NODE_IS_GPIO_HOG(node_id)			\
 	IF_ENABLED(DT_PROP_OR(node_id, gpio_hog, 0), 1)
 

--- a/drivers/input/Kconfig.sbus
+++ b/drivers/input/Kconfig.sbus
@@ -29,7 +29,7 @@ config INPUT_SBUS_REPORT_FILTER
 	default 1
 	help
 	  SBUS tends to be a bit noisy you can increase the threshold to
-	  to lower the amounts of input events. Set to 0 for no filtering
+	  lower the amounts of input events. Set to 0 for no filtering
 
 config INPUT_SBUS_SEND_SYNC
 	bool "Send Sync to input subsys on each SBUS frame"

--- a/drivers/led/ht16k33.c
+++ b/drivers/led/ht16k33.c
@@ -213,7 +213,7 @@ static bool ht16k33_process_keyscan_data(const struct device *dev)
 
 	err = i2c_burst_read_dt(&config->i2c, HT16K33_CMD_KEY_DATA_ADDR, keys, sizeof(keys));
 	if (err) {
-		LOG_WRN("Failed to to read HT16K33 key data (err %d)", err);
+		LOG_WRN("Failed to read HT16K33 key data (err %d)", err);
 		/* Reprocess */
 		return true;
 	}
@@ -380,7 +380,7 @@ static int ht16k33_init(const struct device *dev)
 		err = i2c_burst_read_dt(&config->i2c, HT16K33_CMD_KEY_DATA_ADDR, keys,
 					sizeof(keys));
 		if (err) {
-			LOG_ERR("Failed to to read HT16K33 key data");
+			LOG_ERR("Failed to read HT16K33 key data");
 			return -EIO;
 		}
 

--- a/drivers/mipi_dbi/mipi_dbi_smartbond.c
+++ b/drivers/mipi_dbi/mipi_dbi_smartbond.c
@@ -77,7 +77,7 @@ struct mipi_dbi_smartbond_config {
 	lcdc_smartbond_bgcolor_cfg bgcolor_cfg;
 };
 
-/* Mark the device is is progress and so it's not allowed to enter the sleep state. */
+/* Mark the device is progress and so it's not allowed to enter the sleep state. */
 static inline void mipi_dbi_smartbond_pm_policy_state_lock_get(void)
 {
 	/*

--- a/drivers/mipi_dsi/dsi_mcux_2l.c
+++ b/drivers/mipi_dsi/dsi_mcux_2l.c
@@ -86,7 +86,7 @@ static int dsi_mcux_tx_color(const struct device *dev, uint8_t channel,
 	 * Color streams are a special case for this DSI peripheral, because
 	 * the SMARTDMA peripheral (if enabled) can be used to accelerate
 	 * the transfer of data to the DSI. The SMARTDMA has the additional
-	 * advantage over traditional DMA of being able to to automatically
+	 * advantage over traditional DMA of being able to automatically
 	 * byte swap color data. This is advantageous, as most graphical
 	 * frameworks store RGB data in little endian format, but many
 	 * MIPI displays expect color data in big endian format.

--- a/drivers/rtc/rtc_pcf8563.c
+++ b/drivers/rtc/rtc_pcf8563.c
@@ -92,7 +92,7 @@ struct pcf8563_data {
  * with 8.4.2 Register Minutes.
  *
  * For seconds, first bit is ignored (it is used to check the clock integrity).
- * The the upper digit takes the next 3 bits for the tens place and then the rest
+ * The upper digit takes the next 3 bits for the tens place and then the rest
  * bits for the unit
  * So for example, value 43 is 40 * 10 + 3, so the tens digit is 4 and unit digit is 3.
  * Then we put the number 3 in the last 4 bits and the number 4 in next 3 bits
@@ -391,7 +391,7 @@ void gpio_callback_function(const struct device *dev, struct gpio_callback *cb,
 	struct pcf8563_data *data = CONTAINER_OF(cb, struct pcf8563_data, int1_callback);
 
 	LOG_DBG("PCF8563 interrupt detected");
-	/* By using a work we are able to to run "heavier" code */
+	/* By using a work we are able to run "heavier" code */
 	k_work_submit(&(data->callback_work));
 
 }

--- a/drivers/sensor/st/lis2dh/Kconfig
+++ b/drivers/sensor/st/lis2dh/Kconfig
@@ -155,7 +155,7 @@ config LIS2DH_MEASURE_TEMPERATURE
 	  relative temperature. For example, it is X degrees C
 	  cooler or warmer.
 	  Each chip has an offset.  This offset must be applied
-	  to the result. The offset can be obtained by comparing the
+	  to the result. The offset can be obtained by comparing
 	  the reported temperature to a reference.
 	  This option does not apply to the LSM330DLHC.
 

--- a/drivers/serial/uart_altera.c
+++ b/drivers/serial/uart_altera.c
@@ -78,7 +78,7 @@
 
 /*
  * The value ALT_AVALON_UART_FC is a value set in the device flag field to
- * indicate the the device is using flow control, i.e. the driver must
+ * indicate the device is using flow control, i.e. the driver must
  * throttle on transmit if the nCTS pin is low.
  */
 #define ALT_AVALON_UART_FC 0x2

--- a/drivers/serial/uart_intel_lw.c
+++ b/drivers/serial/uart_intel_lw.c
@@ -68,7 +68,7 @@
 
 /*
  * The value INTEL_LW_UART_FC is a value set in the device flag field to
- * indicate the the device is using flow control, i.e. the driver must
+ * indicate the device is using flow control, i.e. the driver must
  * throttle on transmit if the nCTS pin is low.
  */
 #define INTEL_LW_UART_FC 0x2

--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -1054,7 +1054,7 @@ static int mcux_lpuart_configure_async(const struct device *dev)
 			      mcux_lpuart_async_tx_timeout);
 
 	/* Disable the UART Receiver until the async API provides a buffer to
-	 * to receive into with rx_enable
+	 * receive into with rx_enable
 	 */
 	uart_config.enableRx = false;
 	/* Clearing the fifo of any junk received before the async rx enable was called */

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1158,7 +1158,7 @@ static void endrx_isr(const struct device *dev)
 	data->async->rx_flush_cnt = 0;
 
 	/* The 'rx_offset' can be bigger than 'rx_amount', so it the length
-	 * of data we report back the the user may need to be clipped.
+	 * of data we report back the user may need to be clipped.
 	 * This can happen because the 'rx_offset' count derives from RXRDY
 	 * events, which can occur already for the next buffer before we are
 	 * here to handle this buffer. (The next buffer is now already active

--- a/drivers/spi/spi_mcux_flexcomm.c
+++ b/drivers/spi/spi_mcux_flexcomm.c
@@ -638,7 +638,7 @@ static int transceive_dma(const struct device *dev,
 		/* at this point, last just means whether or not
 		 * this transfer will completely cover
 		 * the current tx/rx buffer in data->ctx
-		 * or require additional transfers because the
+		 * or require additional transfers because
 		 * the two buffers are not the same size.
 		 *
 		 * if it covers the current ctx tx/rx buffers, then

--- a/drivers/timer/native_posix_timer.c
+++ b/drivers/timer/native_posix_timer.c
@@ -65,7 +65,7 @@ void np_timer_isr_test_hook(const void *arg)
  *
  * Informs the system clock driver that the next needed call to
  * sys_clock_announce() will not be until the specified number of ticks
- * from the the current time have elapsed.
+ * from the current time have elapsed.
  *
  * See system_timer.h for more information
  *

--- a/dts/arm/st/f4/stm32f429vX.dtsi
+++ b/dts/arm/st/f4/stm32f429vX.dtsi
@@ -2,7 +2,7 @@
  * Copyright (c) 2018 Daniel Wagenknecht
  *
  * Document the usage of /delete-node/ for device tree nodes
- * that are missing on on only a small subset of SoCs of a given group
+ * that are missing on only a small subset of SoCs of a given group
  * of SoCs.
  * Don't remove this file even if none of the SoCs currently
  * implemented in zephyr use it.

--- a/dts/bindings/espi/nuvoton,npcx-espi-vw-conf.yaml
+++ b/dts/bindings/espi/nuvoton,npcx-espi-vw-conf.yaml
@@ -7,7 +7,7 @@ compatible: "nuvoton,npcx-espi-vw-conf"
 
 child-binding:
   description: |
-    Child node to to present the mapping between VW signal, its core register and input source of
+    Child node to present the mapping between VW signal, its core register and input source of
     MIWU
 
   properties:

--- a/dts/bindings/input/futaba,sbus.yaml
+++ b/dts/bindings/input/futaba,sbus.yaml
@@ -5,8 +5,8 @@ description: |
   SBUS input driver using
   This driver implements the SBUS protocol used on RC radio's
   to send out analogue joystick and switches output.
-  SBUS is an single-wire inverted serial protocol to either you need to
-  to the rx-invert feature of your serial driver or use an external signal inverter.
+  SBUS is an single-wire inverted serial protocol so either you need to use
+  the rx-invert feature of your serial driver or use an external signal inverter.
   The driver binds this to the Zephyr input system using INPUT_EV_CODES.
 
   The following examples defines a a binding of 2 joysticks and a button using 5 channels.

--- a/dts/bindings/interrupt-controller/st,stm32-exti.yaml
+++ b/dts/bindings/interrupt-controller/st,stm32-exti.yaml
@@ -23,7 +23,7 @@ properties:
     type: array
     required: true
     description: |
-      Description of the the input lines range for each interrupt line supported
+      Description of the input lines range for each interrupt line supported
       by the external interrupt controller. For each line a couple of integers is
       provided: the number of the first line of the range start and the length
       of the range.

--- a/dts/bindings/pinctrl/nxp,imx-iomuxc.yaml
+++ b/dts/bindings/pinctrl/nxp,imx-iomuxc.yaml
@@ -28,7 +28,7 @@ child-binding:
       description: |
         An array of values defining the pin mux selection, in the following format:
         <mux_register, mux_val, input_reg, daisy_val, cfg_reg>
-        mux_register: register that will be written to to make mux selection
+        mux_register: register that will be written to make mux selection
         mux_val: value to write to mux_register
         input_reg: peripheral register that will direct peripheral signal to pin
         daisy_val: value to write to input_reg

--- a/include/zephyr/bluetooth/audio/csip.h
+++ b/include/zephyr/bluetooth/audio/csip.h
@@ -270,7 +270,7 @@ struct bt_csip_set_coordinator_set_info {
 	uint8_t set_size;
 
 	/**
-	 * @brief The rank of the set on on the remote device
+	 * @brief The rank of the set on the remote device
 	 *
 	 * Will be 0 if not exposed by the server.
 	 */

--- a/include/zephyr/bluetooth/audio/mcc.h
+++ b/include/zephyr/bluetooth/audio/mcc.h
@@ -726,7 +726,7 @@ int bt_mcc_read_current_track_obj_id(struct bt_conn *conn);
 /**
  * @brief Set Current Track Object ID
  *
- * Set the Current Track to the the track given by the @p id parameter
+ * Set the Current Track to the track given by the @p id parameter
  *
  * @param conn  Connection to the peer device
  * @param id    Object Transfer Service ID (UINT48) of the track to set as the current track
@@ -747,7 +747,7 @@ int bt_mcc_read_next_track_obj_id(struct bt_conn *conn);
 /**
  * @brief Set Next Track Object ID
  *
- * Set the Next Track to the the track given by the @p id parameter
+ * Set the Next Track to the track given by the @p id parameter
  *
  * @param conn  Connection to the peer device
  * @param id   Object Transfer Service ID (UINT48) of the track to set as the next track
@@ -768,7 +768,7 @@ int bt_mcc_read_current_group_obj_id(struct bt_conn *conn);
 /**
  * @brief Set Current Group Object ID
  *
- * Set the Current Group to the the group given by the @p id parameter
+ * Set the Current Group to the group given by the @p id parameter
  *
  * @param conn  Connection to the peer device
  * @param id   Object Transfer Service ID (UINT48) of the group to set as the current group

--- a/include/zephyr/bluetooth/audio/media_proxy.h
+++ b/include/zephyr/bluetooth/audio/media_proxy.h
@@ -1066,7 +1066,7 @@ int media_proxy_ctrl_get_commands_supported(struct media_player *player);
  * May result in up to three callbacks
  * - one for the actual sending of the search to the player
  * - one for the result code for the search from the player
- * - if the search is successful, one for the the search results object ID in the OTs
+ * - if the search is successful, one for the search results object ID in the OTs
  *
  * Requires Object Transfer Service
  *

--- a/include/zephyr/bluetooth/audio/vcp.h
+++ b/include/zephyr/bluetooth/audio/vcp.h
@@ -246,7 +246,7 @@ struct bt_vcp_vol_ctlr_cb {
 	 * Called when the value is remotely read as the Volume Controller.
 	 * Called if the value is changed by the Volume Renderer.
 	 *
-	 * A non-zero value indicates the the volume has been changed on the
+	 * A non-zero value indicates the volume has been changed on the
 	 * Volume Renderer since it was booted.
 	 *
 	 * @param vol_ctlr  Volume Controller instance pointer.

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -901,7 +901,7 @@ int bt_conn_le_create_synced(const struct bt_le_ext_adv *adv,
  *  This uses the Auto Connection Establishment procedure.
  *  The procedure will continue until a single connection is established or the
  *  procedure is stopped through @ref bt_conn_create_auto_stop.
- *  To establish connections to all devices in the the filter accept list the
+ *  To establish connections to all devices in the filter accept list the
  *  procedure should be started again in the connected callback after a
  *  new connection has been established.
  *

--- a/include/zephyr/cache.h
+++ b/include/zephyr/cache.h
@@ -390,7 +390,7 @@ static ALWAYS_INLINE int sys_cache_instr_flush_and_invd_range(void *addr, size_t
 
 /**
  *
- * @brief Get the the d-cache line size.
+ * @brief Get the d-cache line size.
  *
  * The API is provided to get the data cache line.
  *
@@ -417,7 +417,7 @@ static ALWAYS_INLINE size_t sys_cache_data_line_size_get(void)
 
 /**
  *
- * @brief Get the the i-cache line size.
+ * @brief Get the i-cache line size.
  *
  * The API is provided to get the instruction cache line.
  *

--- a/include/zephyr/crypto/crypto.h
+++ b/include/zephyr/crypto/crypto.h
@@ -473,7 +473,7 @@ static inline int hash_compute(struct hash_ctx *ctx, struct hash_pkt *pkt)
 /**
  * @brief Perform  a cryptographic multipart hash operation.
  *
- * This function can be called zero or more times, passing a slice of the
+ * This function can be called zero or more times, passing a slice of
  * the data. The hash is calculated using all the given pieces.
  * To calculate the hash call @c hash_compute().
  *

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -316,7 +316,7 @@
  *     DT_PROP(DT_INST(1, vnd_soc_serial), current_speed)
  *
  *     // 9600, because there is only one disabled node, and
- *     // disabled nodes are "at the the end" of the instance
+ *     // disabled nodes are "at the end" of the instance
  *     // number "list".
  *     DT_PROP(DT_INST(2, vnd_soc_serial), current_speed)
  * @endcode
@@ -788,7 +788,7 @@
  * - for type phandle, idx must be 0 and the expansion is a node
  *   identifier (this treats phandle like a phandles of length 1)
  *
- * - for type string, idx must be 0 and the expansion is the the
+ * - for type string, idx must be 0 and the expansion is the
  *   entire string (this treats string like string-array of length 1)
  *
  * These properties are handled as special cases:

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -1255,7 +1255,7 @@ struct i3c_driver_data {
  * @param dev_list Pointer to the device list struct.
  * @param id Pointer to I3C device ID struct.
  *
- * @return Pointer the the I3C target device descriptor, or
+ * @return Pointer to the I3C target device descriptor, or
  *         NULL if none is found.
  */
 struct i3c_device_desc *i3c_dev_list_find(const struct i3c_dev_list *dev_list,
@@ -1270,7 +1270,7 @@ struct i3c_device_desc *i3c_dev_list_find(const struct i3c_dev_list *dev_list,
  * @param dev_list Pointer to the device list struct.
  * @param addr Dynamic address to be matched.
  *
- * @return Pointer the the I3C target device descriptor, or
+ * @return Pointer to the I3C target device descriptor, or
  *         NULL if none is found.
  */
 struct i3c_device_desc *i3c_dev_list_i3c_addr_find(struct i3c_dev_attached_list *dev_list,
@@ -1285,7 +1285,7 @@ struct i3c_device_desc *i3c_dev_list_i3c_addr_find(struct i3c_dev_attached_list 
  * @param dev_list Pointer to the device list struct.
  * @param addr Address to be matched.
  *
- * @return Pointer the the I2C target device descriptor, or
+ * @return Pointer to the I2C target device descriptor, or
  *         NULL if none is found.
  */
 struct i3c_i2c_device_desc *i3c_dev_list_i2c_addr_find(struct i3c_dev_attached_list *dev_list,

--- a/include/zephyr/drivers/kscan.h
+++ b/include/zephyr/drivers/kscan.h
@@ -72,7 +72,7 @@ __subsystem struct kscan_driver_api {
  * @brief Configure a Keyboard scan instance.
  *
  * @param dev Pointer to the device structure for the driver instance.
- * @param callback called when keyboard devices reply to to a keyboard
+ * @param callback called when keyboard devices reply to a keyboard
  * event such as key pressed/released.
  *
  * @retval 0 If successful.

--- a/include/zephyr/drivers/led.h
+++ b/include/zephyr/drivers/led.h
@@ -273,7 +273,7 @@ static inline int z_impl_led_set_channel(const struct device *dev,
  * @param led LED number
  * @param num_colors Number of colors in the array.
  * @param color Array of colors. It must be ordered following the color
- *        mapping of the LED controller. See the the color_mapping member
+ *        mapping of the LED controller. See the color_mapping member
  *        in struct led_info.
  * @return 0 on success, negative on error
  */

--- a/include/zephyr/drivers/mspi.h
+++ b/include/zephyr/drivers/mspi.h
@@ -663,7 +663,7 @@ static inline int z_impl_mspi_transceive(const struct device *controller,
 /**
  * @brief Configure a MSPI XIP settings.
  *
- * This routine provides a generic interface to to configure the XIP feature.
+ * This routine provides a generic interface to configure the XIP feature.
  *
  * @param controller Pointer to the device structure for the driver instance.
  * @param dev_id Pointer to the device ID structure from a device.
@@ -694,7 +694,7 @@ static inline int z_impl_mspi_xip_config(const struct device *controller,
 /**
  * @brief Configure a MSPI scrambling settings.
  *
- * This routine provides a generic interface to to configure the scrambling
+ * This routine provides a generic interface to configure the scrambling
  * feature.
  *
  * @param controller Pointer to the device structure for the driver instance.

--- a/include/zephyr/drivers/timer/system_timer.h
+++ b/include/zephyr/drivers/timer/system_timer.h
@@ -33,7 +33,7 @@ extern "C" {
  *
  * Informs the system clock driver that the next needed call to
  * sys_clock_announce() will not be until the specified number of ticks
- * from the the current time have elapsed.  Note that spurious calls
+ * from the current time have elapsed.  Note that spurious calls
  * to sys_clock_announce() are allowed (i.e. it's legal to announce
  * every tick and implement this function as a noop), the requirement
  * is that one tick announcement should occur within one tick BEFORE

--- a/include/zephyr/input/input_analog_axis_settings.h
+++ b/include/zephyr/input/input_analog_axis_settings.h
@@ -18,7 +18,7 @@
 /**
  * @brief Save the calibration data.
  *
- * Save the calibration data permanently on the specifided device, requires the
+ * Save the calibration data permanently on the specifided device, requires
  * the @ref settings subsystem to be configured and initialized.
  *
  * @param dev Analog axis device.

--- a/include/zephyr/irq_multilevel.h
+++ b/include/zephyr/irq_multilevel.h
@@ -191,7 +191,7 @@ static inline unsigned int irq_from_level(unsigned int irq, unsigned int level)
 }
 
 /**
- * @brief Converts irq from level 1 to to a given level
+ * @brief Converts irq from level 1 to a given level
  *
  * @param irq IRQ number in its zephyr format
  * @param level IRQ level

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -3457,7 +3457,7 @@ void k_work_queue_init(struct k_work_q *queue);
  *
  * @param stack pointer to the work thread stack area.
  *
- * @param stack_size size of the the work thread stack area, in bytes.
+ * @param stack_size size of the work thread stack area, in bytes.
  *
  * @param prio initial thread priority
  *

--- a/include/zephyr/mgmt/ec_host_cmd/simulator.h
+++ b/include/zephyr/mgmt/ec_host_cmd/simulator.h
@@ -20,7 +20,7 @@
  * @brief Install callback for when this device would sends data to host
  *
  * When this host command simulator device should send data to the host, it
- * will call the the callback parameter provided by this function. Note that
+ * will call the callback parameter provided by this function. Note that
  * only one callback may be installed at a time. Calling this a second time
  * will override the first callback installation.
  *

--- a/include/zephyr/net/net_context.h
+++ b/include/zephyr/net/net_context.h
@@ -85,7 +85,7 @@ struct net_context;
  *
  * @param context The context to use.
  * @param pkt Network buffer that is received. If the pkt is not NULL,
- * then the callback will own the buffer and it needs to to unref the pkt
+ * then the callback will own the buffer and it needs to unref the pkt
  * as soon as it has finished working with it.  On EOF, pkt will be NULL.
  * @param ip_hdr a pointer to relevant IP (v4 or v6) header.
  * @param proto_hdr a pointer to relevant protocol (udp or tcp) header.

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -2596,7 +2596,7 @@ struct net_if *net_if_select_src_iface(const struct sockaddr *dst);
  * @typedef net_if_link_callback_t
  * @brief Define callback that is called after a network packet
  *        has been sent.
- * @param iface A pointer to a struct net_if to which the the net_pkt was sent to.
+ * @param iface A pointer to a struct net_if to which the net_pkt was sent to.
  * @param dst Link layer address of the destination where the network packet was sent.
  * @param status Send status, 0 is ok, < 0 error.
  */
@@ -2765,7 +2765,7 @@ void net_if_foreach(net_if_cb_t cb, void *user_data);
 int net_if_up(struct net_if *iface);
 
 /**
- * @brief Check if interface is is up and running.
+ * @brief Check if interface is up and running.
  *
  * @param iface Pointer to network interface
  *

--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -504,8 +504,8 @@ static inline void bytecpy(void *dst, const void *src, size_t size)
  * Swap @a size bytes between memory regions @a a and @a b. This is
  * guaranteed to be done byte by byte.
  *
- * @param a Pointer to the the first memory region.
- * @param b Pointer to the the second memory region.
+ * @param a Pointer to the first memory region.
+ * @param b Pointer to the second memory region.
  * @param size The number of bytes to swap.
  */
 static inline void byteswp(void *a, void *b, size_t size)

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -134,7 +134,7 @@ uint8_t *z_priv_stack_find(k_thread_stack_t *stack)
 /*
  * Note that dyn_obj->data is where the kernel object resides
  * so it is the one that actually needs to be aligned.
- * Due to the need to get the the fields inside struct dyn_obj
+ * Due to the need to get the fields inside struct dyn_obj
  * from kernel object pointers (i.e. from data[]), the offset
  * from data[] needs to be fixed at build time. Therefore,
  * data[] is declared with __aligned(), such that when dyn_obj

--- a/lib/utils/utf8.c
+++ b/lib/utils/utf8.c
@@ -34,7 +34,7 @@ char *utf8_trunc(char *utf8_str)
 	}
 	bytes_truncated++; /* include the starting byte */
 
-	/* Verify if the the last character actually need to be truncated
+	/* Verify if the last character actually need to be truncated
 	 * Handles the case where the number of bytes in the last UTF8-char
 	 * matches the number of bytes we searched for the starting byte
 	 */

--- a/samples/boards/nrf/mesh/onoff-app/src/main.c
+++ b/samples/boards/nrf/mesh/onoff-app/src/main.c
@@ -87,7 +87,7 @@ static struct bt_mesh_health_srv health_srv = {
 /*
  * Publication Declarations
  *
- * The publication messages are initialized to the
+ * The publication messages are initialized to
  * the size of the opcode + content
  *
  * For publication, the message must be in static or global as

--- a/samples/shields/x_nucleo_iks02a1/microphone/README.rst
+++ b/samples/shields/x_nucleo_iks02a1/microphone/README.rst
@@ -54,7 +54,7 @@ To build the sample you can use following command:
    have a dependency on HSE/HSI:
    :zephyr_file:`boards/shields/x_nucleo_iks02a1/boards/nucleo_f411re.overlay`
 
-   The user is invited to to verify which osci is configured on the used host board
+   The user is invited to verify which osci is configured on the used host board
    defconfig file and calculate the final I2SClk frequency, e.g.
    :zephyr_file:`boards/st/nucleo_f411re/nucleo_f411re.dts`
 

--- a/scripts/build/check_init_priorities.py
+++ b/scripts/build/check_init_priorities.py
@@ -322,7 +322,7 @@ def _parse_args(argv):
     parser.add_argument("-i", "--initlevels", action="store_true",
                         help="print the initlevel functions instead of checking the device dependencies")
     parser.add_argument("--edt-pickle", default=pathlib.Path("edt.pickle"),
-                        help="name of the the pickled edtlib.EDT file",
+                        help="name of the pickled edtlib.EDT file",
                         type=pathlib.Path)
 
     return parser.parse_args(argv)

--- a/scripts/native_simulator/Makefile
+++ b/scripts/native_simulator/Makefile
@@ -3,7 +3,7 @@
 
 # Native Simulator (NSI) Makefile.
 # It builds the simulator runner itself, and produces the final
-# Linux executable by linking it to the the embedded cpu library
+# Linux executable by linking it to the embedded cpu library
 
 # By default all the build output is placed under the _build folder, but the user can override it
 # setting the NSI_BUILD_PATH

--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -191,7 +191,7 @@ class Lcov(CoverageTool):
             logger.error(f"Unable to determine lcov version: {e}")
             sys.exit(1)
         except FileNotFoundError as e:
-            logger.error(f"Unable to to find lcov tool: {e}")
+            logger.error(f"Unable to find lcov tool: {e}")
             sys.exit(1)
 
     def add_ignore_file(self, pattern):
@@ -304,7 +304,7 @@ class Gcovr(CoverageTool):
             logger.error(f"Unable to determine gcovr version: {e}")
             sys.exit(1)
         except FileNotFoundError as e:
-            logger.error(f"Unable to to find gcovr tool: {e}")
+            logger.error(f"Unable to find gcovr tool: {e}")
             sys.exit(1)
 
     def add_ignore_file(self, pattern):

--- a/scripts/spelling.txt
+++ b/scripts/spelling.txt
@@ -710,6 +710,7 @@ framwork||framework
 frequence||frequency
 frequncy||frequency
 frequancy||frequency
+from from||from
 frome||from
 fronend||frontend
 fucntion||function
@@ -773,6 +774,7 @@ hypervior||hypervisor
 hypter||hyper
 idel||idle
 identidier||identifier
+if if||if
 iff||if and only if
 iligal||illegal
 illigal||illegal
@@ -904,6 +906,7 @@ invokation||invocation
 invokations||invocations
 ireelevant||irrelevant
 irrelevent||irrelevant
+is is||is
 isnt||isn't
 isssue||issue
 issus||issues
@@ -1084,6 +1087,7 @@ ommiting||omitting
 ommitted||omitted
 onself||oneself
 onthe||on the
+on on||on
 ony||only
 openning||opening
 operatione||operation
@@ -1545,6 +1549,7 @@ temeprature||temperature
 temorary||temporary
 temproarily||temporarily
 temperture||temperature
+that that||that
 the the||the
 theads||threads
 therfore||therefore
@@ -1565,6 +1570,7 @@ tipically||typically
 timeing||timing
 timout||timeout
 tmis||this
+to to||to
 toogle||toggle
 torerable||tolerable
 torlence||tolerance

--- a/scripts/west_commands/runners/mdb.py
+++ b/scripts/west_commands/runners/mdb.py
@@ -183,7 +183,7 @@ class MdbHwBinaryRunner(ZephyrBinaryRunner):
                             help='''choose the number of cores that target has,
                                     e.g. --cores=1''')
         parser.add_argument('--dig-device', default='',
-                            help='''choose the the specific digilent device to
+                            help='''choose the specific digilent device to
                              connect, this is useful when multiple
                              targets are connected''')
 

--- a/scripts/west_commands/runners/nios2.py
+++ b/scripts/west_commands/runners/nios2.py
@@ -38,7 +38,7 @@ class Nios2BinaryRunner(ZephyrBinaryRunner):
         # TODO merge quartus-flash.py script into this file.
         parser.add_argument('--quartus-flash', required=True)
         parser.add_argument('--cpu-sof', required=True,
-                            help='path to the the CPU .sof data')
+                            help='path to the CPU .sof data')
         parser.add_argument('--tui', default=False, action='store_true',
                             help='if given, GDB uses -tui')
 

--- a/soc/aspeed/ast10x0/Kconfig
+++ b/soc/aspeed/ast10x0/Kconfig
@@ -26,7 +26,7 @@ config SRAM_NC_SIZE
 config SRAM_NC_BASE_ADDRESS
 	hex "noncached SRAM Base Address"
 	help
-	  The non-cached SRAM base address. The default value comes from from
+	  The non-cached SRAM base address. The default value comes from
 	  reg[1] of /chosen/zephyr,sram in devicetree. The user should
 	  generally avoid changing it via menuconfig or in configuration files.
 

--- a/soc/gd/gd32/gd32vf103/entry.S
+++ b/soc/gd/gd32/gd32vf103/entry.S
@@ -25,7 +25,7 @@ SECTION_FUNC(init, __nuclei_start)
 	jr	a0
 
 _start0800:
-	/* Set the the NMI base to share with mtvec by setting CSR_MMISC_CTL */
+	/* Set the NMI base to share with mtvec by setting CSR_MMISC_CTL */
 	li	t0, 0x200
 	csrs	CSR_MMISC_CTL, t0
 

--- a/soc/intel/intel_adsp/ace/include/adsp_imr_layout.h
+++ b/soc/intel/intel_adsp/ace/include/adsp_imr_layout.h
@@ -4,7 +4,7 @@
 #ifndef ZEPHYR_SOC_INTEL_ADSP_ACE_IMR_LAYOUT_H_
 #define ZEPHYR_SOC_INTEL_ADSP_ACE_IMR_LAYOUT_H_
 
-/* These structs and macros are from from the ROM code header
+/* These structs and macros are from the ROM code header
  * on cAVS platforms, please keep them immutable
  */
 

--- a/soc/microchip/mec/mec172x/timing.c
+++ b/soc/microchip/mec/mec172x/timing.c
@@ -13,7 +13,7 @@
 
 /*
  * This code is conditionally built please refer to the SoC cmake file and
- * is not built normally. If this is is not built then timer5 is available
+ * is not built normally. If this is not built then timer5 is available
  * for other uses.
  */
 #define BTMR_XEC_REG_BASE						\

--- a/soc/native/inf_clock/posix_board_if.h
+++ b/soc/native/inf_clock/posix_board_if.h
@@ -11,7 +11,7 @@
 
 /*
  * This file lists the functions the posix "inf_clock" soc
- * expect the the board to provide
+ * expect the board to provide
  *
  * All functions listed here must be provided by the implementation of the board
  *

--- a/soc/neorv32/soc_irq.S
+++ b/soc/neorv32/soc_irq.S
@@ -14,7 +14,7 @@ GTEXT(__soc_handle_irq)
  */
 SECTION_FUNC(exception.other, __soc_handle_irq)
 	/*
-	 * The the MIP CSR on the NEORV32 is read-only and can thus not be used for
+	 * The MIP CSR on the NEORV32 is read-only and can thus not be used for
 	 * clearing a pending IRQ. Instead we disable the IRQ in the MIE CSR and
 	 * re-enable it (if it was enabled when clearing).
 	 */

--- a/soc/nordic/Kconfig
+++ b/soc/nordic/Kconfig
@@ -19,7 +19,7 @@ config NRF_SOC_SECURE_SUPPORTED
 	def_bool !TRUSTED_EXECUTION_NONSECURE || (BUILD_WITH_TFM && TFM_PARTITION_PLATFORM)
 	depends on !SOC_SERIES_NRF54HX
 	help
-	  Hidden function to indicate that that the soc_secure functions are
+	  Hidden function to indicate that the soc_secure functions are
 	  available.
 	  The functions are always available when not in non-secure.
 	  For non-secure the functions must redirect to secure services exposed

--- a/soc/nordic/nrf53/soc.c
+++ b/soc/nordic/nrf53/soc.c
@@ -183,7 +183,7 @@ static void cpu_idle_prepare_monitor_begin(void)
 static bool cpu_idle_prepare_monitor_end(void)
 {
 	/* The value stored is irrelevant. If any exception took place after
-	 * cpu_idle_prepare_monitor_begin, the the local monitor is cleared and
+	 * cpu_idle_prepare_monitor_begin, the local monitor is cleared and
 	 * the store fails returning 1.
 	 * See Arm v8-M Architecture Reference Manual:
 	 *   Chapter B9.2 The local monitors
@@ -265,7 +265,7 @@ void z_arm_on_enter_cpu_idle_prepare(void)
 					 */
 					rtc_pretick_cc_set_on_time = false;
 				} else {
-					/* The written rtc_pretick_cc is guaranteed to to trigger
+					/* The written rtc_pretick_cc is guaranteed to trigger
 					 * compare event.
 					 */
 					rtc_pretick_cc_set_on_time = true;

--- a/soc/openisa/rv32m1/soc.h
+++ b/soc/openisa/rv32m1/soc.h
@@ -17,7 +17,7 @@
  * interrupts.
  *
  * Level 1 interrupts go straight to the SoC. Level 2 interrupts must
- * go through one of the 8 channels in the the INTMUX
+ * go through one of the 8 channels in the INTMUX
  * peripheral. There are 32 level 1 interrupts, including 8 INTMUX
  * interrupts. Each INTMUX interrupt can mux at most
  * CONFIG_MAX_IRQ_PER_AGGREGATOR (which happens to be 32) interrupts

--- a/subsys/bluetooth/audio/Kconfig.mcs
+++ b/subsys/bluetooth/audio/Kconfig.mcs
@@ -60,7 +60,7 @@ config BT_MCC_SEGMENT_NAME_MAX
 	default 25
 	range 1 255
 	help
-	  Sets the the maximum number of bytes (including the null termination)
+	  Sets the maximum number of bytes (including the null termination)
 	  of the name of any track segment in the media player. If the name is
 	  longer, the media control client will truncate the name when reading
 	  it.

--- a/subsys/bluetooth/audio/Kconfig.mpl
+++ b/subsys/bluetooth/audio/Kconfig.mpl
@@ -59,7 +59,7 @@ config BT_MPL_SEGMENT_NAME_MAX
 	default 25
 	range 1 255
 	help
-	  Sets the the maximum number of bytes (including the null termination)
+	  Sets the maximum number of bytes (including the null termination)
 	  of the name of any track segment in the media player.
 
 config BT_MPL_GROUP_TITLE_MAX

--- a/subsys/bluetooth/audio/mcc.c
+++ b/subsys/bluetooth/audio/mcc.c
@@ -1109,7 +1109,7 @@ static uint8_t mcs_notify_handler(struct bt_conn *conn,
 #endif /* defined(CONFIG_BT_MCC_READ_MEDIA_STATE) */
 
 	} else if (handle == mcs_inst->cp_handle) {
-		/* The control point is is a special case - only */
+		/* The control point is a special case - only */
 		/* writable and notifiable.  Handle directly here. */
 		struct mpl_cmd_ntf ntf = {0};
 		int cb_err = 0;

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -849,7 +849,7 @@ config BT_CTLR_ADV_ISO_STREAM_COUNT
 	range BT_CTLR_ADV_ISO_STREAM_MAX 64
 	default BT_ISO_MAX_CHAN
 	help
-	  Maximum Broadcast ISO Streams supported in the the Controller across
+	  Maximum Broadcast ISO Streams supported in the Controller across
 	  all Broadcast ISO groups.
 
 config BT_CTLR_ADV_ISO_PDU_LEN_MAX
@@ -882,7 +882,7 @@ config BT_CTLR_SYNC_ISO_STREAM_COUNT
 	range BT_CTLR_SYNC_ISO_STREAM_MAX 64
 	default BT_ISO_MAX_CHAN
 	help
-	  Maximum ISO Synchronized Receiver Streams supported in the the
+	  Maximum ISO Synchronized Receiver Streams supported in the
 	  Controller across all Broadcast ISO groups.
 
 config BT_CTLR_SYNC_ISO_PDU_LEN_MAX

--- a/subsys/bluetooth/controller/ll_sw/isoal.c
+++ b/subsys/bluetooth/controller/ll_sw/isoal.c
@@ -2453,7 +2453,7 @@ static uint16_t isoal_tx_framed_find_correct_tx_event(const struct isoal_source 
 			       actual_grp_ref_point);
 
 		/* If the event selected is the last event segmented for, then
-		 * it is possible that that some payloads have already been
+		 * it is possible that some payloads have already been
 		 * released for this event. Segmentation should continue from
 		 * that payload.
 		 */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
@@ -1170,13 +1170,13 @@ static void isr_rx_done(void *param)
 		 *
 		 * When a Synchronized Receiver receives such a PDU where
 		 * (instant - bigEventCounter) mod 65536 is greater than or
-		 * equal to 32767 (because the instant is in the past), the
+		 * equal to 32767 (because the instant is in the past),
 		 * the Link Layer may stop synchronization with the BIG.
 		 */
 
 		/* Note: We are not validating whether the control PDU was
 		 * received after the instant but apply the new channel map.
-		 * If the channel map was new at or after the instant and the
+		 * If the channel map was new at or after the instant and
 		 * the channel at the event counter did not match then the
 		 * control PDU would not have been received.
 		 */

--- a/subsys/bluetooth/controller/util/mem.h
+++ b/subsys/bluetooth/controller/util/mem.h
@@ -18,7 +18,7 @@
  * @brief Round up to nearest multiple of 4, for unsigned integers
  * @details
  *   The addition of 3 forces x into the next multiple of 4. This is responsible
- *   for the rounding in the the next step, to be Up.
+ *   for the rounding in the next step, to be Up.
  *   For ANDing of ~3: We observe y & (~3) == (y>>2)<<2, and we recognize
  *   (y>>2) as a floored division, which is almost undone by the left-shift. The
  *   flooring can't be undone so have achieved a rounding.

--- a/subsys/bluetooth/controller/util/memq.c
+++ b/subsys/bluetooth/controller/util/memq.c
@@ -94,7 +94,7 @@ memq_link_t *memq_enqueue(memq_link_t *link, void *mem, memq_link_t **tail)
 	/* Let the old tail element point to the new tail element */
 	(*tail)->next = link;
 
-	/* Let the old tail element point the the new memory */
+	/* Let the old tail element point the new memory */
 	(*tail)->mem = mem;
 
 	/* Update the tail-pointer to point to the new tail element.

--- a/subsys/bluetooth/host/buf_view.h
+++ b/subsys/bluetooth/host/buf_view.h
@@ -60,7 +60,7 @@ struct net_buf *bt_buf_make_view(struct net_buf *view,
 
 /** @internal
  *
- *  @brief Check if if `parent` has view.
+ *  @brief Check if `parent` has view.
  *
  *  If `parent` has been passed to @ref bt_buf_make_view() and the resulting
  *  view buffer has not been destroyed.

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -437,7 +437,7 @@ static inline bool bt_conn_is_handle_valid(struct bt_conn *conn)
 bool bt_conn_is_peer_addr_le(const struct bt_conn *conn, uint8_t id,
 			     const bt_addr_le_t *peer);
 
-/* Helpers for identifying & looking up connections based on the the index to
+/* Helpers for identifying & looking up connections based on the index to
  * the connection list. This is useful for O(1) lookups, but can't be used
  * e.g. as the handle since that's assigned to us by the controller.
  */

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -302,7 +302,7 @@ struct bt_dev_le {
 #endif /* CONFIG_BT_BROADCASTER */
 
 #if defined(CONFIG_BT_SMP)
-	/* Size of the the controller resolving list */
+	/* Size of the controller resolving list */
 	uint8_t                    rl_size;
 	/* Number of entries in the resolving list. rl_entries > rl_size
 	 * means that host-side resolving is used.

--- a/subsys/bluetooth/mesh/friend.c
+++ b/subsys/bluetooth/mesh/friend.c
@@ -1506,7 +1506,7 @@ static void friend_lpn_enqueue_tx(struct bt_mesh_friend *frnd,
 
 	if (type == BT_MESH_FRIEND_PDU_SINGLE && !info.ctl) {
 		/* Unsegmented application packets may be reencrypted later,
-		 * as they depend on the the sequence number being the same
+		 * as they depend on the sequence number being the same
 		 * when encrypting in transport and network.
 		 */
 		FRIEND_ADV(buf)->app_idx = tx->ctx->app_idx;

--- a/subsys/debug/coredump/coredump_core.c
+++ b/subsys/debug/coredump/coredump_core.c
@@ -66,7 +66,7 @@ static void dump_thread(struct k_thread *thread)
 	/*
 	 * When dumping minimum information,
 	 * the current thread struct and stack need to
-	 * to be dumped so debugger can examine them.
+	 * be dumped so debugger can examine them.
 	 */
 
 	if (thread == NULL) {

--- a/subsys/fs/Kconfig
+++ b/subsys/fs/Kconfig
@@ -76,7 +76,7 @@ config FILE_SYSTEM_SHELL_BUFFER_SIZE
 	help
 	  Size of the buffer used for file system commands, will determine the
 	  maximum size that can be used with a read/write test. Note that this
-	  is is used on the stack.
+	  is used on the stack.
 
 endif # FILE_SYSTEM_SHELL
 

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
@@ -77,7 +77,7 @@ img_mgmt_state_flags(int query_slot)
 
 	flags = 0;
 
-	/* Determine if this is is pending or confirmed (only applicable for
+	/* Determine if this is pending or confirmed (only applicable for
 	 * unified images and loaders.
 	 */
 	swap_type = img_mgmt_swap_type(query_slot);

--- a/subsys/mgmt/mcumgr/grp/os_mgmt/src/os_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/src/os_mgmt.c
@@ -65,7 +65,7 @@ K_WORK_DELAYABLE_DEFINE(os_mgmt_reset_work, os_mgmt_reset_work_handler);
 
 /* This is passed to zcbor_map_start/end_endcode as a number of
  * expected "columns" (tid, priority, and so on)
- * The value here does not affect memory allocation is is used
+ * The value here does not affect memory allocation is used
  * to predict how big the map may be. If you increase number
  * of "columns" the taskstat sends you may need to increase the
  * value otherwise zcbor_map_end_encode may return with error.

--- a/subsys/mgmt/mcumgr/transport/src/smp_bt.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_bt.c
@@ -464,7 +464,7 @@ static int smp_bt_tx_pkt(struct net_buf *nb)
 
 	/* Verify that the device is connected, the necessity for this check is that the remote
 	 * device might have sent a command and disconnected before the command has been processed
-	 * completely, if this happens then the the connection details will still be valid due to
+	 * completely, if this happens then the connection details will still be valid due to
 	 * the incremented connection reference count, but the connection has actually been
 	 * dropped, this avoids waiting for a semaphore that will never be given which would
 	 * otherwise cause a deadlock.

--- a/subsys/mgmt/osdp/Kconfig.cp
+++ b/subsys/mgmt/osdp/Kconfig.cp
@@ -9,7 +9,7 @@ config OSDP_NUM_CONNECTED_PD
 	default 1
 	range 1 126
 	help
-	  In PD mode, number of connected PDs is is always 1 and cannot
+	  In PD mode, number of connected PDs is always 1 and cannot
 	  be configured.
 
 config OSDP_PD_ADDRESS_LIST
@@ -48,7 +48,7 @@ config OSDP_MASTER_KEY
 	string "Secure Channel Master Key"
 	default "NONE"
 	help
-	  Hexadecimal string representation of the the 16 byte OSDP Secure Channel
+	  Hexadecimal string representation of the 16 byte OSDP Secure Channel
 	  master Key. This is a mandatory key when secure channel is enabled.
 
 endif # OSDP_SC_ENABLED

--- a/subsys/mgmt/osdp/Kconfig.pd
+++ b/subsys/mgmt/osdp/Kconfig.pd
@@ -10,7 +10,7 @@ config OSDP_NUM_CONNECTED_PD
 	int
 	default 1
 	help
-	  In PD mode, number of connected PDs is is always 1 and cannot
+	  In PD mode, number of connected PDs is always 1 and cannot
 	  be configured.
 
 config OSDP_PD_COMMAND_QUEUE_SIZE
@@ -37,7 +37,7 @@ config OSDP_PD_SCBK
 	string "Secure Channel Base Key (SCBK)"
 	default "NONE"
 	help
-	  Hexadecimal string representation of the the 16 byte OSDP PD Secure
+	  Hexadecimal string representation of the 16 byte OSDP PD Secure
 	  Channel Base Key. When this field is sent to "NONE", the PD is set to
 	  "Install Mode". In this mode, the PD would allow a CP to setup a secure
 	  channel with default SCBK. Once as secure channel is active with the

--- a/subsys/net/ip/connection.h
+++ b/subsys/net/ip/connection.h
@@ -166,7 +166,7 @@ static inline int net_conn_unregister(struct net_conn_handle *handle)
  * @param remote_addr Remote address
  * @param remote_port Remote port
  *
- * @return Return 0 if the the change succeed, <0 otherwise.
+ * @return Return 0 if the change succeed, <0 otherwise.
  */
 int net_conn_update(struct net_conn_handle *handle,
 		    net_conn_cb_t cb,

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -2095,7 +2095,7 @@ struct net_if_mcast_addr *net_if_ipv6_maddr_add(struct net_if *iface,
 	}
 
 	if (net_if_ipv6_maddr_lookup(addr, &iface)) {
-		NET_WARN("Multicast address %s is is already registered.",
+		NET_WARN("Multicast address %s is already registered.",
 			net_sprint_ipv6_addr(addr));
 		goto out;
 	}

--- a/subsys/net/ip/net_timeout.c
+++ b/subsys/net/ip/net_timeout.c
@@ -121,7 +121,7 @@ uint32_t net_timeout_evaluate(struct net_timeout *timeout,
 
 	/* The residual elapsed must reduce timer_timeout, which is capped at
 	 * NET_TIMEOUT_MAX_VALUE.  But if subtracting would reduce the
-	 * counter to zero or go negative we need to reduce the the wrap
+	 * counter to zero or go negative we need to reduce the wrap
 	 * counter once more and add the residual to the counter, so the
 	 * counter remains positive.
 	 */

--- a/subsys/net/l2/ethernet/vlan.c
+++ b/subsys/net/l2/ethernet/vlan.c
@@ -191,7 +191,7 @@ static struct vlan_context *get_vlan(struct net_if *iface,
 	}
 
 	/* If the interface is virtual, then it should be be the VLAN one.
-	 * Just get the Ethernet interface it points to to get the context.
+	 * Just get the Ethernet interface it points to get the context.
 	 */
 	ctx = get_vlan_ctx(net_virtual_get_iface(iface), vlan_tag, false);
 

--- a/subsys/net/l2/ppp/Kconfig
+++ b/subsys/net/l2/ppp/Kconfig
@@ -95,7 +95,7 @@ config NET_L2_PPP_THREAD_PRIO
 	int "Priority of the PPP TX thread"
 	default 1
 	help
-	  Set the priority of the the PPP TX thread, that handles all
+	  Set the priority of the PPP TX thread, that handles all
 	  transmission of PPP packets.
 	  Value 0 = highest priortity.
 	  When CONFIG_NET_TC_THREAD_COOPERATIVE = y, lowest priority is

--- a/subsys/net/lib/capture/capture.c
+++ b/subsys/net/lib/capture/capture.c
@@ -425,7 +425,7 @@ int net_capture_setup(const char *remote_addr, const char *my_local_addr,
 		(void)net_capture_cleanup(ctx->dev);
 
 		/* net_context is cleared by the cleanup so no need to goto
-		 * to fail label.
+		 * the fail label.
 		 */
 		return ret;
 	}

--- a/subsys/net/lib/coap/coap_server.c
+++ b/subsys/net/lib/coap/coap_server.c
@@ -92,7 +92,7 @@ static int coap_service_remove_observer(const struct coap_service *service,
 		/* Prefer addr+token to find the observer */
 		obs = coap_find_observer(service->data->observers, MAX_OBSERVERS, addr, token, tkl);
 	} else if (tkl > 0) {
-		/* Then try to to find the observer by token */
+		/* Then try to find the observer by token */
 		obs = coap_find_observer_by_token(service->data->observers, MAX_OBSERVERS, token,
 						  tkl);
 	} else if (addr != NULL) {

--- a/subsys/net/lib/sockets/socketpair.c
+++ b/subsys/net/lib/sockets/socketpair.c
@@ -597,7 +597,7 @@ out:
  * -# @ref SPAIR_SIG_DATA - data has been written to the @em local
  *    @ref spair.pipe. Thus, allowing more data to be read.
  *
- * -# @ref SPAIR_SIG_CANCEL - read of the the @em local @spair.pipe
+ * -# @ref SPAIR_SIG_CANCEL - read of the @em local @spair.pipe
  *    must be cancelled for some reason (e.g. the file descriptor will be
  *    closed imminently). In this case, the function will return -1 and set
  *    @ref errno to @ref EINTR.

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -29,7 +29,7 @@ LOG_MODULE_DECLARE(pm_device, CONFIG_PM_DEVICE_LOG_LEVEL);
  *
  * @note Asynchronous operations are not supported when in pre-kernel mode. In
  * this case, the async flag will be always forced to be false, and so the
- * the function will be blocking.
+ * function will be blocking.
  *
  * @funcprops \pre_kernel_ok
  *

--- a/subsys/sip_svc/sip_svc_id_mgr.c
+++ b/subsys/sip_svc/sip_svc_id_mgr.c
@@ -195,7 +195,7 @@ void sip_svc_id_map_delete(struct sip_svc_id_map *id_map)
 	}
 }
 
-/* Retrieve index from from database with key(id)*/
+/* Retrieve index from database with key(id)*/
 static int sip_svc_id_map_get_idx(struct sip_svc_id_map *id_map, uint32_t id)
 {
 	int i;

--- a/subsys/tracing/sysview/SYSVIEW_Zephyr.txt
+++ b/subsys/tracing/sysview/SYSVIEW_Zephyr.txt
@@ -1,4 +1,4 @@
-# Inspired by the the same configuration file available in the SystemView tool
+# Inspired by the same configuration file available in the SystemView tool
 
 Option    ReversePriority
 #

--- a/subsys/usb/usb_c/usbc_pe_common.c
+++ b/subsys/usb/usb_c/usbc_pe_common.c
@@ -381,7 +381,7 @@ bool pe_is_explicit_contract(const struct device *dev)
 }
 
 /**
- * @brief Return true if the PE is is within an atomic messaging sequence
+ * @brief Return true if the PE is within an atomic messaging sequence
  *	  that it initiated with a SOP* port partner.
  */
 bool pe_dpm_initiated_ams(const struct device *dev)

--- a/subsys/usb/usb_c/usbc_pe_common_internal.h
+++ b/subsys/usb/usb_c/usbc_pe_common_internal.h
@@ -370,7 +370,7 @@ bool policy_check(const struct device *dev, const enum usbc_policy_check_t pc);
  * @brief Notify the DPM of a policy change
  *
  * @param dev Pointer to the device structure for the driver instance
- * @param notify The notification to send the the DPM
+ * @param notify The notification to send the DPM
  */
 void policy_notify(const struct device *dev, const enum usbc_policy_notify_t notify);
 
@@ -574,7 +574,7 @@ bool pe_is_explicit_contract(const struct device *dev);
 void pe_invalidate_explicit_contract(const struct device *dev);
 
 /**
- * @brief Return true if the PE is is within an atomic messaging sequence
+ * @brief Return true if the PE is within an atomic messaging sequence
  *	  that it initiated with a SOP* port partner.
  *
  * @note The PRL layer polls this instead of using AMS_START and AMS_END

--- a/tests/bluetooth/audio/cap_commander/src/test_micp.c
+++ b/tests/bluetooth/audio/cap_commander/src/test_micp.c
@@ -134,7 +134,7 @@ ZTEST_F(cap_commander_test_micp, test_commander_change_microphone_gain_setting_d
 	zexpect_call_count("bt_cap_commander_cb.microphone_gain_setting_changed", 1,
 			   mock_cap_commander_microphone_gain_changed_cb_fake.call_count);
 
-	/* That that it still works as expected if we set the same value twice */
+	/* Test that it still works as expected if we set the same value twice */
 	err = bt_cap_commander_change_microphone_gain_setting(&param);
 	zassert_equal(0, err, "Unexpected return value %d", err);
 
@@ -344,7 +344,7 @@ ZTEST_F(cap_commander_test_micp, test_commander_change_microphone_mute_state_dou
 	zexpect_call_count("bt_cap_commander_cb.microphone_mute_changed", 1,
 			   mock_cap_commander_microphone_mute_changed_cb_fake.call_count);
 
-	/* That that it still works as expected if we set the same value twice */
+	/* Test that it still works as expected if we set the same value twice */
 	err = bt_cap_commander_change_microphone_mute_state(&param);
 	zassert_equal(0, err, "Unexpected return value %d", err);
 

--- a/tests/bluetooth/host/id/bt_id_create/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_id_create/src/test_suite_invalid_inputs.c
@@ -152,7 +152,7 @@ ZTEST(bt_id_create_invalid_inputs, test_pa_address_exists_in_id_list)
  *
  *  Constraints:
  *   - A static random address is used
- *   - Input IRK is is filled with zeros
+ *   - Input IRK is filled with zeros
  *
  *  Expected behaviour:
  *   - '-EINVAL' error code is returned representing invalid values were used.

--- a/tests/bluetooth/host/keys/bt_keys_get_type/src/main.c
+++ b/tests/bluetooth/host/keys/bt_keys_get_type/src/main.c
@@ -131,7 +131,7 @@ ZTEST(bt_keys_get_type_initially_filled_list, test_get_non_existing_key_referenc
  *  Expected behaviour:
  *   - A valid reference is returned by bt_keys_get_type()
  *   - Key reference returned matches the previously returned one
- *     when it was firstly inserted in the the list
+ *     when it was firstly inserted in the list
  */
 ZTEST(bt_keys_get_type_initially_filled_list, test_get_existing_key_reference)
 {

--- a/tests/bluetooth/tester/src/btp_gap.c
+++ b/tests/bluetooth/tester/src/btp_gap.c
@@ -628,7 +628,7 @@ int tester_gap_create_adv_instance(struct bt_le_adv_param *param, uint8_t own_ad
 		break;
 #if defined(CONFIG_BT_PRIVACY)
 	case BTP_GAP_ADDR_TYPE_RESOLVABLE_PRIVATE:
-		/* RPA usage is is controlled via privacy settings */
+		/* RPA usage is controlled via privacy settings */
 		if (!atomic_test_bit(&current_settings, BTP_GAP_SETTINGS_PRIVACY)) {
 			return -EINVAL;
 		}

--- a/tests/bsim/bluetooth/audio/src/mcc_test.c
+++ b/tests/bsim/bluetooth/audio/src/mcc_test.c
@@ -729,7 +729,7 @@ static void test_invalid_send_cmd(void)
 	}
 }
 
-/* Helper function to write commands to to the control point, including the
+/* Helper function to write commands to the control point, including the
  * flag handling.
  * Will FAIL on error to send the command.
  * Will WAIT for the required flags before returning.

--- a/tests/bsim/bluetooth/audio/src/media_controller_test.c
+++ b/tests/bsim/bluetooth/audio/src/media_controller_test.c
@@ -595,7 +595,7 @@ static bool test_verify_media_state_wait_flags(uint8_t expected_state)
 	return true;
 }
 
-/* Helper function to write commands to to the control point, including the
+/* Helper function to write commands to the control point, including the
  * flag handling.
  * Will FAIL on error to send the command.
  * Will WAIT for the required flags before returning.

--- a/tests/bsim/bluetooth/host/adv/resume2/connecter/main.c
+++ b/tests/bsim/bluetooth/host/adv/resume2/connecter/main.c
@@ -19,7 +19,7 @@ LOG_MODULE_REGISTER(connecter, LOG_LEVEL_INF);
  * before starting over.
  *
  * This app is added to the simulation simply to exercise the
- * the DUT's connectable advertiser.
+ * DUT's connectable advertiser.
  *
  * Multiple instances of this app are added to the simulation,
  * to exercise BT_MAX_CONN of the DUT.

--- a/tests/bsim/bluetooth/mesh/src/test_dfu.c
+++ b/tests/bsim/bluetooth/mesh/src/test_dfu.c
@@ -1649,7 +1649,7 @@ static const struct bst_test_instance test_dfu[] = {
 	TEST_CASE(dist, dfu_slot_reservation,
 		      "Distributor checks that the correct number of slots can be reserved"),
 	TEST_CASE(dist, dfu_slot_idempotency,
-		      "Distributor checks that the the DFU slot APIs are idempotent"),
+		      "Distributor checks that the DFU slot APIs are idempotent"),
 	TEST_CASE(cli, stop, "DFU Client stops at configured point of Firmware Distribution"),
 	TEST_CASE(cli, fail_on_persistency, "DFU Client doesn't give up DFU Transfer"),
 	TEST_CASE(cli, all_targets_lost_on_metadata,

--- a/tests/bsim/bluetooth/mesh/tests_scripts/friendship/lpn_disable.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/friendship/lpn_disable.sh
@@ -7,7 +7,7 @@ source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
 # Check that disabling LPN gives correct behaviour.
 #
 # In this test the lpn node will enable the lpn feature, and then immediately
-# disables it again. Then we check that that the lpn node is actually in a
+# disables it again. Then we check that the lpn node is actually in a
 # disabled state. This test ensures that a lpn disable call is not overwritten
 # by a subsequent lpn enable call, since the enable call is associated with
 # internal callback structures that might produce incorrect internal state

--- a/tests/bsim/bluetooth/mesh/tests_scripts/large_comp_data/get_metadata_split.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/large_comp_data/get_metadata_split.sh
@@ -4,7 +4,7 @@
 
 source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
 
-# Test that the the LCD server model is able to split the
+# Test that the LCD server model is able to split the
 # metadata when the total size exceeds the maximum access message size.
 #
 # Test procedure:

--- a/tests/bsim/bluetooth/mesh/tests_scripts/provision/pb_remote_client_server_same_dev.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/provision/pb_remote_client_server_same_dev.sh
@@ -6,7 +6,7 @@ source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
 
 # Test a node re-provisioning through Remote Provisioning models. Procedure:
 # 1. Device (prov_device_pb_remote_client_server_same_dev) provisions it self
-#    and start scanning for an upprovisioned device, and provisions the the
+#    and start scanning for an upprovisioned device, and provisions the
 #    second device (prov_device_pb_remote_server_same_dev) with local RPR server.
 # 2. The first device (prov_device_pb_remote_client_server_same_dev) execute
 #    device key refresh procedure the second device (prov_device_pb_remote_server_same_dev).

--- a/tests/drivers/clock_control/clock_control_api/src/test_clock_control.c
+++ b/tests/drivers/clock_control/clock_control_api/src/test_clock_control.c
@@ -256,7 +256,7 @@ ZTEST(clock_control, test_async_on_stopped)
 }
 
 /*
- * Test checks that that second start returns error.
+ * Test checks that the second start returns error.
  */
 static void test_double_start_on_instance(const struct device *dev,
 						clock_control_subsys_t subsys,
@@ -282,7 +282,7 @@ ZTEST(clock_control, test_double_start)
 }
 
 /*
- * Test checks that that second stop returns 0.
+ * Test checks that the second stop returns 0.
  * Test precondition: clock is stopped.
  */
 static void test_double_stop_on_instance(const struct device *dev,

--- a/tests/kernel/common/src/atomic.c
+++ b/tests/kernel/common/src/atomic.c
@@ -343,7 +343,7 @@ ZTEST(atomic, test_threads_access_atomic)
  *		if incremented in atomic and non-atomic manner
  *
  * @details According to C standard the value of a signed variable
- *	is undefined in case of overflow. This test checks that the the value
+ *	is undefined in case of overflow. This test checks that the value
  *	of atomic_t will be the same in case of overflow if incremented in atomic
  *	and non-atomic manner. This allows us to increment an atomic variable
  *	in a non-atomic manner (as long as it is logically safe)

--- a/tests/kernel/obj_core/obj_core_stats/src/main.c
+++ b/tests/kernel/obj_core/obj_core_stats/src/main.c
@@ -77,7 +77,7 @@ ZTEST(obj_core_stats_system, test_obj_core_stats_system)
 
 	/*
 	 * Not much can be predicted for the raw stats aside from the
-	 * the contents of the CPU sampling to be at least as large as
+	 * contents of the CPU sampling to be at least as large as
 	 * kernel sampling. The same goes for the query stats.
 	 */
 

--- a/tests/kernel/workq/critical/src/main.c
+++ b/tests/kernel/workq/critical/src/main.c
@@ -15,7 +15,7 @@
  * This test has two threads that increment a counter.  The routine that
  * increments the counter is invoked from workqueue due to the two threads
  * calling using it.  The final result of the counter is expected
- * to be the the number of times work item was called to increment
+ * to be the number of times work item was called to increment
  * the counter.
  *
  * This is done with time slicing both disabled and enabled to ensure that the

--- a/tests/net/socket/af_packet/src/main.c
+++ b/tests/net/socket/af_packet/src/main.c
@@ -267,7 +267,7 @@ ZTEST(socket_packet, test_raw_packet_sockets)
 	addrlen = sizeof(src);
 	errno = 0;
 
-	/* The recvfrom reads the the whole received packet - including its
+	/* The recvfrom reads the whole received packet - including its
 	 * IP (20B) and UDP (8) headers. After those we can expect payload,
 	 * which have been sent.
 	 */

--- a/tests/posix/common/src/_main.c
+++ b/tests/posix/common/src/_main.c
@@ -10,7 +10,7 @@ extern bool fdtable_fd_is_initialized(int fd);
 
 ZTEST(posix_apis, test_fdtable_init)
 {
-	/* ensure that the the stdin, stdout, and stderr fdtable entries are initialized */
+	/* ensure that the stdin, stdout, and stderr fdtable entries are initialized */
 	zassert_true(fdtable_fd_is_initialized(0));
 	zassert_true(fdtable_fd_is_initialized(1));
 	zassert_true(fdtable_fd_is_initialized(2));


### PR DESCRIPTION
Treewide search and replace on a range of double word combinations:
    * `the the`
    * `to to`
    * `if if`
    * `that that`
    * `on on`
    * `is is`
    * `from from`

Add double prepositions to the default spelling check list.