### PR TITLE
bluetooth: shell: refactor shell print for Bluetooth-specific context

### DIFF
--- a/subsys/bluetooth/host/shell/CMakeLists.txt
+++ b/subsys/bluetooth/host/shell/CMakeLists.txt
@@ -1,7 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library()
-zephyr_library_sources(bt.c)
+zephyr_library_sources(
+  bt.c
+  bt_shell_private.c
+  )
 zephyr_library_sources_ifdef(CONFIG_BT_CONN gatt.c)
 zephyr_library_sources_ifdef(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL l2cap.c)
 zephyr_library_sources_ifdef(CONFIG_BT_ISO iso.c)

--- a/subsys/bluetooth/host/shell/bt.c
+++ b/subsys/bluetooth/host/shell/bt.c
@@ -1580,7 +1580,7 @@ static int cmd_id_show(const struct shell *sh, size_t argc, char *argv[])
 
 		bt_addr_le_to_str(&addrs[i], addr_str, sizeof(addr_str));
 		shell_print(sh, "%s%zu: %s", i == selected_id ? "*" : " ", i,
-		      addr_str);
+			    addr_str);
 	}
 
 	return 0;
@@ -1625,7 +1625,7 @@ static int cmd_active_scan_on(const struct shell *sh, uint32_t options,
 	err = bt_le_scan_start(&param, NULL);
 	if (err) {
 		shell_error(sh, "Bluetooth set active scan failed "
-		      "(err %d)", err);
+			    "(err %d)", err);
 		return err;
 	} else {
 		shell_print(sh, "Bluetooth active scan enabled");
@@ -1753,7 +1753,7 @@ static int cmd_scan_filter_set_name(const struct shell *sh, size_t argc,
 	const char *name_arg = argv[1];
 
 	if (strlen(name_arg) >= sizeof(scan_filter.name)) {
-		shell_error(ctx_shell, "Name is too long (max %zu): %s\n",
+		shell_error(sh, "Name is too long (max %zu): %s\n",
 			    sizeof(scan_filter.name), name_arg);
 		return -ENOEXEC;
 	}
@@ -1773,8 +1773,7 @@ static int cmd_scan_filter_set_addr(const struct shell *sh, size_t argc,
 
 	/* Validate length including null terminator. */
 	if (len > max_cpy_len) {
-		shell_error(ctx_shell, "Invalid address string: %s\n",
-			    addr_arg);
+		shell_error(sh, "Invalid address string: %s\n", addr_arg);
 		return -ENOEXEC;
 	}
 
@@ -1784,9 +1783,7 @@ static int cmd_scan_filter_set_addr(const struct shell *sh, size_t argc,
 		uint8_t tmp;
 
 		if (c != ':' && char2hex(c, &tmp) < 0) {
-			shell_error(ctx_shell,
-					"Invalid address string: %s\n",
-					addr_arg);
+			shell_error(sh, "Invalid address string: %s\n", addr_arg);
 			return -ENOEXEC;
 		}
 	}
@@ -2307,7 +2304,7 @@ static int cmd_adv_data(const struct shell *sh, size_t argc, char *argv[])
 			if (*data_len == ARRAY_SIZE(ad)) {
 				/* Maximum entries limit reached. */
 				shell_print(sh, "Failed to set advertising data: "
-						"Maximum entries limit reached");
+					    "Maximum entries limit reached");
 
 				return -ENOEXEC;
 			}
@@ -2327,7 +2324,7 @@ static int cmd_adv_data(const struct shell *sh, size_t argc, char *argv[])
 		if (strcmp(arg, "scan-response") && *data_len == ARRAY_SIZE(ad)) {
 			/* Maximum entries limit reached. */
 			shell_print(sh, "Failed to set advertising data: "
-					"Maximum entries limit reached");
+				    "Maximum entries limit reached");
 
 			return -ENOEXEC;
 		}
@@ -2341,7 +2338,7 @@ static int cmd_adv_data(const struct shell *sh, size_t argc, char *argv[])
 		} else if (!strcmp(arg, "scan-response")) {
 			if (data == sd) {
 				shell_print(sh, "Failed to set advertising data: "
-						"duplicate scan-response option");
+					    "duplicate scan-response option");
 				return -ENOEXEC;
 			}
 
@@ -2358,7 +2355,7 @@ static int cmd_adv_data(const struct shell *sh, size_t argc, char *argv[])
 
 			if (!len || (len - 1) != (hex_data[hex_data_len])) {
 				shell_print(sh, "Failed to set advertising data: "
-						"malformed hex data");
+					    "malformed hex data");
 				return -ENOEXEC;
 			}
 
@@ -2379,7 +2376,7 @@ static int cmd_adv_data(const struct shell *sh, size_t argc, char *argv[])
 		if (*data_len == ARRAY_SIZE(ad)) {
 			/* Maximum entries limit reached. */
 			shell_print(sh, "Failed to set advertising data: "
-					"Maximum entries limit reached");
+				    "Maximum entries limit reached");
 
 			return -ENOEXEC;
 		}
@@ -2499,7 +2496,7 @@ static int cmd_adv_delete(const struct shell *sh, size_t argc, char *argv[])
 
 	err = bt_le_ext_adv_delete(adv);
 	if (err) {
-		shell_error(ctx_shell, "Failed to delete advertiser set");
+		shell_error(sh, "Failed to delete advertiser set");
 		return err;
 	}
 
@@ -3109,7 +3106,7 @@ static int cmd_set_power_report_enable(const struct shell *sh, size_t argc, char
 			return -ENOEXEC;
 		}
 		err = bt_conn_le_set_tx_power_report_enable(default_conn, local_enable,
-							     remote_enable);
+							    remote_enable);
 		if (!err) {
 			shell_print(sh, "Tx Power Report: local: %s, remote: %s",
 				    enabled2str(local_enable), enabled2str(remote_enable));
@@ -3494,11 +3491,11 @@ static int cmd_info(const struct shell *sh, size_t argc, char *argv[])
 
 	err = bt_conn_get_info(conn, &info);
 	if (err) {
-		shell_print(ctx_shell, "Failed to get info");
+		shell_print(sh, "Failed to get info");
 		goto done;
 	}
 
-	shell_print(ctx_shell, "Type: %s, Role: %s, Id: %u",
+	shell_print(sh, "Type: %s, Role: %s, Id: %u",
 		    get_conn_type_str(info.type),
 		    get_conn_role_str(info.role),
 		    info.id);
@@ -3509,20 +3506,20 @@ static int cmd_info(const struct shell *sh, size_t argc, char *argv[])
 		print_le_addr("Remote on-air", info.le.remote);
 		print_le_addr("Local on-air", info.le.local);
 
-		shell_print(ctx_shell, "Interval: 0x%04x (%u us)",
+		shell_print(sh, "Interval: 0x%04x (%u us)",
 			    info.le.interval,
 			    BT_CONN_INTERVAL_TO_US(info.le.interval));
-		shell_print(ctx_shell, "Latency: 0x%04x",
+		shell_print(sh, "Latency: 0x%04x",
 			    info.le.latency);
-		shell_print(ctx_shell, "Supervision timeout: 0x%04x (%d ms)",
+		shell_print(sh, "Supervision timeout: 0x%04x (%d ms)",
 			    info.le.timeout, info.le.timeout * 10);
 #if defined(CONFIG_BT_USER_PHY_UPDATE)
-		shell_print(ctx_shell, "LE PHY: TX PHY %s, RX PHY %s",
+		shell_print(sh, "LE PHY: TX PHY %s, RX PHY %s",
 			    phy2str(info.le.phy->tx_phy),
 			    phy2str(info.le.phy->rx_phy));
 #endif
 #if defined(CONFIG_BT_USER_DATA_LEN_UPDATE)
-		shell_print(ctx_shell, "LE data len: TX (len: %d time: %d)"
+		shell_print(sh, "LE data len: TX (len: %d time: %d)"
 			    " RX (len: %d time: %d)",
 			    info.le.data_len->tx_max_len,
 			    info.le.data_len->tx_max_time,
@@ -3530,7 +3527,7 @@ static int cmd_info(const struct shell *sh, size_t argc, char *argv[])
 			    info.le.data_len->rx_max_time);
 #endif
 #if defined(CONFIG_BT_SUBRATING)
-		shell_print(ctx_shell, "LE Subrating: Subrate Factor: %d"
+		shell_print(sh, "LE Subrating: Subrate Factor: %d"
 			    " Continuation Number: %d",
 			    info.le.subrate->factor,
 			    info.le.subrate->continuation_number);
@@ -3542,7 +3539,7 @@ static int cmd_info(const struct shell *sh, size_t argc, char *argv[])
 		char addr_str[BT_ADDR_STR_LEN];
 
 		bt_addr_to_str(info.br.dst, addr_str, sizeof(addr_str));
-		shell_print(ctx_shell, "Peer address %s", addr_str);
+		shell_print(sh, "Peer address %s", addr_str);
 	}
 #endif /* defined(CONFIG_BT_CLASSIC) */
 
@@ -3559,8 +3556,8 @@ static int cmd_conn_update(const struct shell *sh, size_t argc, char *argv[])
 
 	if (default_conn == NULL) {
 		shell_error(sh,
-				"%s: at least, one connection is required",
-				sh->ctx->active_cmd.syntax);
+			    "%s: at least, one connection is required",
+			    sh->ctx->active_cmd.syntax);
 		return -ENOEXEC;
 	}
 
@@ -3608,8 +3605,8 @@ static int cmd_conn_data_len_update(const struct shell *sh, size_t argc,
 
 	if (default_conn == NULL) {
 		shell_error(sh,
-				"%s: at least, one connection is required",
-				sh->ctx->active_cmd.syntax);
+			    "%s: at least, one connection is required",
+			    sh->ctx->active_cmd.syntax);
 		return -ENOEXEC;
 	}
 
@@ -3633,8 +3630,6 @@ static int cmd_conn_data_len_update(const struct shell *sh, size_t argc,
 		shell_print(sh, "Calculated tx time: %d", param.tx_max_time);
 	}
 
-
-
 	err = bt_conn_le_data_len_update(default_conn, &param);
 	if (err) {
 		shell_error(sh, "data len update failed (err %d).", err);
@@ -3655,8 +3650,8 @@ static int cmd_conn_phy_update(const struct shell *sh, size_t argc,
 
 	if (default_conn == NULL) {
 		shell_error(sh,
-				"%s: at least, one connection is required",
-				sh->ctx->active_cmd.syntax);
+			    "%s: at least, one connection is required",
+			    sh->ctx->active_cmd.syntax);
 		return -ENOEXEC;
 	}
 
@@ -3772,7 +3767,7 @@ static int cmd_clear(const struct shell *sh, size_t argc, char *argv[])
 		err = bt_unpair(selected_id, NULL);
 		if (err) {
 			shell_error(sh, "Failed to clear pairings (err %d)",
-			      err);
+				    err);
 			return err;
 		} else {
 			shell_print(sh, "Pairings successfully cleared");

--- a/subsys/bluetooth/host/shell/bt_shell_private.c
+++ b/subsys/bluetooth/host/shell/bt_shell_private.c
@@ -1,0 +1,89 @@
+/**
+ * @file bt_shell_private.c
+ * @brief Bluetooth shell private module
+ *
+ * Provide common function which can be shared using privately inside Bluetooth shell.
+ */
+
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/shell/shell_backend.h>
+#include "bt_shell_private.h"
+
+static void wall_vfprintf(enum shell_vt100_color color, const char *fmt, va_list args)
+{
+	int count;
+	const struct shell *sh;
+
+	count = shell_backend_count_get();
+	for (int i = 0; i < count; i++) {
+		va_list args_copy;
+
+		va_copy(args_copy, args);   /* Create a copy of 'args' to safely reuse */
+		sh = shell_backend_get(i);
+		shell_vfprintf(sh, color, fmt, args_copy);
+		va_end(args_copy);          /* Clean up to prevent resource leaks */
+	}
+}
+
+void bt_shell_hexdump(const uint8_t *data, size_t len)
+{
+	int count;
+	const struct shell *sh;
+
+	count = shell_backend_count_get();
+	for (int i = 0; i < count; i++) {
+		sh = shell_backend_get(i);
+		shell_hexdump(sh, data, len);
+	}
+}
+
+void bt_shell_fprintf(enum shell_vt100_color color,
+		      const char *fmt, ...)
+{
+	va_list args;
+
+	va_start(args, fmt);
+	wall_vfprintf(color, fmt, args);
+	va_end(args);
+}
+
+void bt_shell_fprintf_info(const char *fmt, ...)
+{
+	va_list args;
+
+	va_start(args, fmt);
+	wall_vfprintf(SHELL_INFO, fmt, args);
+	va_end(args);
+}
+
+void bt_shell_fprintf_print(const char *fmt, ...)
+{
+	va_list args;
+
+	va_start(args, fmt);
+	wall_vfprintf(SHELL_NORMAL, fmt, args);
+	va_end(args);
+}
+
+void bt_shell_fprintf_warn(const char *fmt, ...)
+{
+	va_list args;
+
+	va_start(args, fmt);
+	wall_vfprintf(SHELL_WARNING, fmt, args);
+	va_end(args);
+}
+
+void bt_shell_fprintf_error(const char *fmt, ...)
+{
+	va_list args;
+
+	va_start(args, fmt);
+	wall_vfprintf(SHELL_ERROR, fmt, args);
+	va_end(args);
+}

--- a/subsys/bluetooth/host/shell/bt_shell_private.h
+++ b/subsys/bluetooth/host/shell/bt_shell_private.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __BT_SHELL_PRIVATE_H
+#define __BT_SHELL_PRIVATE_H
+
+#include <zephyr/shell/shell.h>
+
+/**
+ * @brief printf-like function which sends formatted data stream to the shell.
+ * (Bluetooth context specific)
+ *
+ * This function can be used from the command handler or from threads, but not
+ * from an interrupt context.
+ *
+ * @param[in] color Printed text color.
+ * @param[in] fmt   Format string.
+ * @param[in] ...   List of parameters to print.
+ */
+__printf_like(2, 3) void bt_shell_fprintf(enum shell_vt100_color color,
+					  const char *fmt, ...);
+
+/**
+ * @brief printf-like function which sends formatted data stream to the shell.
+ * (Bluetooth context specific)
+ *
+ * This function can be used from the command handler or from threads, but not
+ * from an interrupt context.
+ *
+ * @param[in] fmt   Format string.
+ * @param[in] ...   List of parameters to print.
+ */
+__printf_like(1, 2) void bt_shell_fprintf_info(const char *fmt, ...);
+__printf_like(1, 2) void bt_shell_fprintf_print(const char *fmt, ...);
+__printf_like(1, 2) void bt_shell_fprintf_warn(const char *fmt, ...);
+__printf_like(1, 2) void bt_shell_fprintf_error(const char *fmt, ...);
+
+/**
+ * @brief Print data in hexadecimal format.
+ * (Bluetooth context specific)
+ *
+ * @param[in] data Pointer to data.
+ * @param[in] len  Length of data.
+ */
+void bt_shell_hexdump(const uint8_t *data, size_t len);
+
+/**
+ * @brief Print info message to the shell.
+ * (Bluetooth context specific)
+ *
+ * @param[in] _ft Format string.
+ * @param[in] ... List of parameters to print.
+ */
+#define bt_shell_info(_ft, ...) \
+	bt_shell_fprintf_info(_ft "\n", ##__VA_ARGS__)
+
+/**
+ * @brief Print normal message to the shell.
+ * (Bluetooth context specific)
+ *
+ * @param[in] _ft Format string.
+ * @param[in] ... List of parameters to print.
+ */
+#define bt_shell_print(_ft, ...) \
+	bt_shell_fprintf_print(_ft "\n", ##__VA_ARGS__)
+
+/**
+ * @brief Print warning message to the shell.
+ * (Bluetooth context specific)
+ *
+ * @param[in] _ft Format string.
+ * @param[in] ... List of parameters to print.
+ */
+#define bt_shell_warn(_ft, ...) \
+	bt_shell_fprintf_warn(_ft "\n", ##__VA_ARGS__)
+
+/**
+ * @brief Print error message to the shell.
+ * (Bluetooth context specific)
+ *
+ * @param[in] _ft Format string.
+ * @param[in] ... List of parameters to print.
+ */
+#define bt_shell_error(_ft, ...) \
+	bt_shell_fprintf_error(_ft "\n", ##__VA_ARGS__)
+
+#endif /* __BT_SHELL_PRIVATE_H */

--- a/subsys/bluetooth/host/shell/cs.c
+++ b/subsys/bluetooth/host/shell/cs.c
@@ -24,7 +24,8 @@
 #include <zephyr/bluetooth/cs.h>
 #include <errno.h>
 
-#include "bt.h"
+#include "host/shell/bt.h"
+#include "host/shell/bt_shell_private.h"
 
 static int check_cs_sync_antenna_selection_input(uint16_t input)
 {
@@ -138,21 +139,21 @@ static int cmd_read_remote_fae_table(const struct shell *sh, size_t argc, char *
 
 static bool process_step_data(struct bt_le_cs_subevent_step *step, void *user_data)
 {
-	shell_print(ctx_shell, "Subevent results contained step data: ");
-	shell_print(ctx_shell, "- Step mode %d\n"
+	bt_shell_print("Subevent results contained step data: ");
+	bt_shell_print("- Step mode %d\n"
 		"- Step channel %d\n"
 		"- Step data hexdump:",
 		step->mode,
 		step->channel);
-	shell_hexdump(ctx_shell, step->data, step->data_len);
+	bt_shell_hexdump(step->data, step->data_len);
 
 	return true;
 }
 
 static void cs_test_subevent_data_cb(struct bt_conn_le_cs_subevent_result *result)
 {
-	shell_print(ctx_shell, "Received subevent results.");
-	shell_print(ctx_shell, "Subevent Header:\n"
+	bt_shell_print("Received subevent results.");
+	bt_shell_print("Subevent Header:\n"
 		"- Procedure Counter: %d\n"
 		"- Frequency Compensation: 0x%04x\n"
 		"- Reference Power Level: %d\n"
@@ -179,7 +180,7 @@ static void cs_test_subevent_data_cb(struct bt_conn_le_cs_subevent_result *resul
 
 static void cs_test_end_complete_cb(void)
 {
-	shell_print(ctx_shell, "CS Test End Complete.");
+	bt_shell_print("CS Test End Complete.");
 }
 
 static int cmd_cs_test_simple(const struct shell *sh, size_t argc, char *argv[])

--- a/subsys/bluetooth/host/shell/gatt.c
+++ b/subsys/bluetooth/host/shell/gatt.c
@@ -27,6 +27,7 @@
 #include <zephyr/shell/shell.h>
 
 #include "host/shell/bt.h"
+#include "host/shell/bt_shell_private.h"
 
 #if defined(CONFIG_BT_GATT_CLIENT) || defined(CONFIG_BT_GATT_DYNAMIC_DB)
 extern uint8_t selected_id;
@@ -75,8 +76,8 @@ static void update_write_stats(uint16_t len)
 
 static void print_write_stats(void)
 {
-	shell_print(ctx_shell, "Write #%u: %u bytes (%u bps)",
-		    write_stats.count, write_stats.total, write_stats.rate);
+	bt_shell_print("Write #%u: %u bytes (%u bps)",
+		       write_stats.count, write_stats.total, write_stats.rate);
 }
 #endif /* CONFIG_BT_GATT_CLIENT || CONFIG_BT_GATT_DYNAMIC_DB */
 
@@ -94,8 +95,8 @@ static struct bt_gatt_exchange_params exchange_params;
 static void exchange_func(struct bt_conn *conn, uint8_t err,
 			  struct bt_gatt_exchange_params *params)
 {
-	shell_print(ctx_shell, "Exchange %s", err == 0U ? "successful" :
-		    "failed");
+	bt_shell_print("Exchange %s", err == 0U ? "successful" :
+		       "failed");
 
 	/* Release global `exchange_params`. */
 	__ASSERT_NO_MSG(params == &exchange_params);
@@ -139,43 +140,43 @@ static int cmd_exchange_mtu(const struct shell *sh,
 static struct bt_gatt_discover_params discover_params;
 static struct bt_uuid_16 uuid = BT_UUID_INIT_16(0);
 
-static void print_chrc_props(const struct shell *sh, uint8_t properties)
+static void print_chrc_props(uint8_t properties)
 {
-	shell_print(sh, "Properties: ");
+	bt_shell_print("Properties: ");
 
 	if (properties & BT_GATT_CHRC_BROADCAST) {
-		shell_print(sh, "[bcast]");
+		bt_shell_print("[bcast]");
 	}
 
 	if (properties & BT_GATT_CHRC_READ) {
-		shell_print(sh, "[read]");
+		bt_shell_print("[read]");
 	}
 
 	if (properties & BT_GATT_CHRC_WRITE) {
-		shell_print(sh, "[write]");
+		bt_shell_print("[write]");
 	}
 
 	if (properties & BT_GATT_CHRC_WRITE_WITHOUT_RESP) {
-		shell_print(sh, "[write w/w rsp]");
+		bt_shell_print("[write w/w rsp]");
 	}
 
 	if (properties & BT_GATT_CHRC_NOTIFY) {
-		shell_print(sh, "[notify]");
+		bt_shell_print("[notify]");
 	}
 
 	if (properties & BT_GATT_CHRC_INDICATE) {
-		shell_print(sh, "[indicate]");
+		bt_shell_print("[indicate]");
 	}
 
 	if (properties & BT_GATT_CHRC_AUTH) {
-		shell_print(sh, "[auth]");
+		bt_shell_print("[auth]");
 	}
 
 	if (properties & BT_GATT_CHRC_EXT_PROP) {
-		shell_print(sh, "[ext prop]");
+		bt_shell_print("[ext prop]");
 	}
 
-	shell_print(sh, "");
+	bt_shell_print("");
 }
 
 static uint8_t discover_func(struct bt_conn *conn,
@@ -188,7 +189,7 @@ static uint8_t discover_func(struct bt_conn *conn,
 	char str[BT_UUID_STR_LEN];
 
 	if (!attr) {
-		shell_print(ctx_shell, "Discover complete");
+		bt_shell_print("Discover complete");
 		(void)memset(params, 0, sizeof(*params));
 		return BT_GATT_ITER_STOP;
 	}
@@ -198,29 +199,29 @@ static uint8_t discover_func(struct bt_conn *conn,
 	case BT_GATT_DISCOVER_PRIMARY:
 		gatt_service = attr->user_data;
 		bt_uuid_to_str(gatt_service->uuid, str, sizeof(str));
-		shell_print(ctx_shell, "Service %s found: start handle %x, "
-			    "end_handle %x", str, attr->handle,
-			    gatt_service->end_handle);
+		bt_shell_print("Service %s found: start handle %x, "
+			       "end_handle %x", str, attr->handle,
+			       gatt_service->end_handle);
 		break;
 	case BT_GATT_DISCOVER_CHARACTERISTIC:
 		gatt_chrc = attr->user_data;
 		bt_uuid_to_str(gatt_chrc->uuid, str, sizeof(str));
-		shell_print(ctx_shell, "Characteristic %s found: handle %x",
-			    str, attr->handle);
-		print_chrc_props(ctx_shell, gatt_chrc->properties);
+		bt_shell_print("Characteristic %s found: handle %x",
+			       str, attr->handle);
+		print_chrc_props(gatt_chrc->properties);
 		break;
 	case BT_GATT_DISCOVER_INCLUDE:
 		gatt_include = attr->user_data;
 		bt_uuid_to_str(gatt_include->uuid, str, sizeof(str));
-		shell_print(ctx_shell, "Include %s found: handle %x, start %x, "
-			    "end %x", str, attr->handle,
-			    gatt_include->start_handle,
-			    gatt_include->end_handle);
+		bt_shell_print("Include %s found: handle %x, start %x, "
+			       "end %x", str, attr->handle,
+			       gatt_include->start_handle,
+			       gatt_include->end_handle);
 		break;
 	default:
 		bt_uuid_to_str(attr->uuid, str, sizeof(str));
-		shell_print(ctx_shell, "Descriptor %s found: handle %x", str,
-			    attr->handle);
+		bt_shell_print("Descriptor %s found: handle %x", str,
+			       attr->handle);
 		break;
 	}
 
@@ -291,13 +292,13 @@ static uint8_t read_func(struct bt_conn *conn, uint8_t err,
 			 struct bt_gatt_read_params *params,
 			 const void *data, uint16_t length)
 {
-	shell_print(ctx_shell, "Read complete: err 0x%02x length %u", err, length);
+	bt_shell_print("Read complete: err 0x%02x length %u", err, length);
 
 	if (!data) {
 		(void)memset(params, 0, sizeof(*params));
 		return BT_GATT_ITER_STOP;
 	} else {
-		shell_hexdump(ctx_shell, data, length);
+		bt_shell_hexdump(data, length);
 	}
 
 	return BT_GATT_ITER_CONTINUE;
@@ -429,7 +430,7 @@ static uint8_t gatt_write_buf[BT_ATT_MAX_ATTRIBUTE_LEN];
 static void write_func(struct bt_conn *conn, uint8_t err,
 		       struct bt_gatt_write_params *params)
 {
-	shell_print(ctx_shell, "Write complete: err 0x%02x", err);
+	bt_shell_print("Write complete: err 0x%02x", err);
 
 	(void)memset(&write_params, 0, sizeof(write_params));
 }
@@ -557,14 +558,14 @@ static uint8_t notify_func(struct bt_conn *conn,
 			const void *data, uint16_t length)
 {
 	if (!data) {
-		shell_print(ctx_shell, "Unsubscribed");
+		bt_shell_print("Unsubscribed");
 		params->value_handle = 0U;
 		return BT_GATT_ITER_STOP;
 	}
 
-	shell_print(ctx_shell, "Notification: value_handle %u, length %u",
-		    params->value_handle, length);
-	shell_hexdump(ctx_shell, data, length);
+	bt_shell_print("Notification: value_handle %u, length %u",
+		       params->value_handle, length);
+	bt_shell_hexdump(data, length);
 
 	return BT_GATT_ITER_CONTINUE;
 }
@@ -793,7 +794,7 @@ static ssize_t write_vnd1(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			  uint8_t flags)
 {
 	if (echo_enabled) {
-		shell_print(ctx_shell, "Echo attr len %u", len);
+		bt_shell_print("Echo attr len %u", len);
 		bt_gatt_notify(conn, attr, buf, len);
 	}
 

--- a/subsys/bluetooth/host/shell/iso.c
+++ b/subsys/bluetooth/host/shell/iso.c
@@ -23,6 +23,7 @@
 #include <zephyr/bluetooth/iso.h>
 
 #include "host/shell/bt.h"
+#include "host/shell/bt_shell_private.h"
 
 #if defined(CONFIG_BT_ISO_TX)
 #define DEFAULT_IO_QOS                                                                             \
@@ -75,8 +76,8 @@ static void iso_recv(struct bt_iso_chan *chan, const struct bt_iso_recv_info *in
 		struct net_buf *buf)
 {
 	if (info->flags & BT_ISO_FLAGS_VALID) {
-		shell_print(ctx_shell, "Incoming data channel %p len %u, seq: %d, ts: %d",
-			    chan, buf->len, info->seq_num, info->ts);
+		bt_shell_print("Incoming data channel %p len %u, seq: %d, ts: %d",
+			       chan, buf->len, info->seq_num, info->ts);
 	}
 }
 #endif /* CONFIG_BT_ISO_RX */
@@ -86,7 +87,7 @@ static void iso_connected(struct bt_iso_chan *chan)
 	struct bt_iso_info iso_info;
 	int err;
 
-	shell_print(ctx_shell, "ISO Channel %p connected", chan);
+	bt_shell_print("ISO Channel %p connected", chan);
 
 
 	err = bt_iso_chan_get_info(chan, &iso_info);
@@ -108,8 +109,8 @@ static void iso_connected(struct bt_iso_chan *chan)
 
 static void iso_disconnected(struct bt_iso_chan *chan, uint8_t reason)
 {
-	shell_print(ctx_shell, "ISO Channel %p disconnected with reason 0x%02x",
-		    chan, reason);
+	bt_shell_print("ISO Channel %p disconnected with reason 0x%02x",
+		       chan, reason);
 }
 
 static struct bt_iso_chan_ops iso_ops = {
@@ -474,11 +475,11 @@ static int cmd_connect(const struct shell *sh, size_t argc, char *argv[])
 static int iso_accept(const struct bt_iso_accept_info *info,
 		      struct bt_iso_chan **chan)
 {
-	shell_print(ctx_shell, "Incoming request from %p with CIG ID 0x%02X and CIS ID 0x%02X",
-		    info->acl, info->cig_id, info->cis_id);
+	bt_shell_print("Incoming request from %p with CIG ID 0x%02X and CIS ID 0x%02X",
+		       info->acl, info->cig_id, info->cis_id);
 
 	if (iso_chan.iso) {
-		shell_print(ctx_shell, "No channels available");
+		bt_shell_print("No channels available");
 		return -ENOMEM;
 	}
 

--- a/subsys/bluetooth/host/shell/l2cap.c
+++ b/subsys/bluetooth/host/shell/l2cap.c
@@ -30,6 +30,7 @@
 #include <zephyr/shell/shell.h>
 
 #include "host/shell/bt.h"
+#include "host/shell/bt_shell_private.h"
 
 #define CREDITS			10
 #define DATA_MTU		(23 * CREDITS)
@@ -89,7 +90,7 @@ static void l2cap_recv_cb(struct k_work *work)
 	struct net_buf *buf;
 
 	while ((buf = k_fifo_get(&l2cap_recv_fifo, K_NO_WAIT))) {
-		shell_print(ctx_shell, "Confirming reception");
+		bt_shell_print("Confirming reception");
 		bt_l2cap_chan_recv_complete(&c->ch.chan, buf);
 	}
 }
@@ -102,18 +103,18 @@ static int l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 		return l2cap_recv_metrics(chan, buf);
 	}
 
-	shell_print(ctx_shell, "Incoming data channel %p len %u", chan,
-		    buf->len);
+	bt_shell_print("Incoming data channel %p len %u", chan,
+		       buf->len);
 
 	if (buf->len) {
-		shell_hexdump(ctx_shell, buf->data, buf->len);
+		bt_shell_hexdump(buf->data, buf->len);
 	}
 
 	if (l2cap_recv_delay_ms > 0) {
 		/* Submit work only if queue is empty */
 		if (k_fifo_is_empty(&l2cap_recv_fifo)) {
-			shell_print(ctx_shell, "Delaying response in %u ms...",
-				    l2cap_recv_delay_ms);
+			bt_shell_print("Delaying response in %u ms...",
+				       l2cap_recv_delay_ms);
 		}
 
 		k_fifo_put(&l2cap_recv_fifo, buf);
@@ -127,12 +128,12 @@ static int l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 
 static void l2cap_sent(struct bt_l2cap_chan *chan)
 {
-	shell_print(ctx_shell, "Outgoing data channel %p transmitted", chan);
+	bt_shell_print("Outgoing data channel %p transmitted", chan);
 }
 
 static void l2cap_status(struct bt_l2cap_chan *chan, atomic_t *status)
 {
-	shell_print(ctx_shell, "Channel %p status %u", chan, (uint32_t)*status);
+	bt_shell_print("Channel %p status %u", chan, (uint32_t)*status);
 }
 
 static void l2cap_connected(struct bt_l2cap_chan *chan)
@@ -141,19 +142,19 @@ static void l2cap_connected(struct bt_l2cap_chan *chan)
 
 	k_work_init_delayable(&c->recv_work, l2cap_recv_cb);
 
-	shell_print(ctx_shell, "Channel %p connected", chan);
+	bt_shell_print("Channel %p connected", chan);
 }
 
 static void l2cap_disconnected(struct bt_l2cap_chan *chan)
 {
-	shell_print(ctx_shell, "Channel %p disconnected", chan);
+	bt_shell_print("Channel %p disconnected", chan);
 }
 
 static struct net_buf *l2cap_alloc_buf(struct bt_l2cap_chan *chan)
 {
 	/* print if metrics is disabled */
 	if (!metrics) {
-		shell_print(ctx_shell, "Channel %p requires buffer", chan);
+		bt_shell_print("Channel %p requires buffer", chan);
 	}
 
 	return net_buf_alloc(&data_rx_pool, K_FOREVER);
@@ -217,7 +218,7 @@ static int l2cap_accept(struct bt_conn *conn, struct bt_l2cap_server *server,
 {
 	int err;
 
-	shell_print(ctx_shell, "Incoming conn %p", conn);
+	bt_shell_print("Incoming conn %p", conn);
 
 	err = l2cap_accept_policy(conn);
 	if (err < 0) {
@@ -225,7 +226,7 @@ static int l2cap_accept(struct bt_conn *conn, struct bt_l2cap_server *server,
 	}
 
 	if (l2ch_chan.ch.chan.conn) {
-		shell_print(ctx_shell, "No channels available");
+		bt_shell_print("No channels available");
 		return -ENOMEM;
 	}
 


### PR DESCRIPTION
This PR aims to eliminate the dependency on `ctx_shell` in the Bluetooth `host/shell/*`, making the code more maintainable.
- Introduced `bt_shell_private.c` and `bt_shell_private.h` to provide common functions for the Bluetooth shell.
- Limit the usage of `ctx_shell` to cases where printing requires it and `sh` is not available. 
(Interim commit before switch to `bt_shell_*`) 
- Refactor shell print to eliminate `ctx_shell` usage in the Bluetooth `host/shell/*`.

Fixes #41796
