### PR TITLE
ztest: expand ztest_shell subcommand.

### DIFF
--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -1321,15 +1321,53 @@ static int cmd_shuffle(const struct shell *sh, size_t argc, char **argv)
 
 static int cmd_run_suite(const struct shell *sh, size_t argc, char **argv)
 {
+	struct getopt_state *state;
+	int opt;
+	static struct option long_options[] = {{"repeat_iter", required_argument, 0, 'r'},
+		{0, 0, 0, 0}};
+	int opt_index = 0;
+	int val;
+	int opt_num = 0;
+
+	int repeat_iter = 1;
+
+	while ((opt = getopt_long(argc, argv, "r:", long_options, &opt_index)) != -1) {
+		state = getopt_state_get();
+		switch (opt) {
+		case 'r':
+			val = atoi(state->optarg);
+			if (val < 1) {
+				shell_fprintf(sh, SHELL_ERROR,
+					"Invalid number of suite interations\n");
+				return -ENOEXEC;
+			}
+			repeat_iter = val;
+			opt_num++;
+			break;
+		default:
+			shell_fprintf(sh, SHELL_ERROR,
+				"Invalid option or option usage: %s\n", argv[opt_index + 1]);
+			return -ENOEXEC;
+		}
+	}
 	int count = 0;
 	bool shuffle = false;
+	const char *shell_command = argv[0];
 
-	ztest_set_test_args(argv[1]);
+	if (opt_num == 1) {
+		ztest_set_test_args(argv[3]);
+	} else {
+		ztest_set_test_args(argv[1]);
+	}
 
 	for (struct ztest_suite_node *ptr = _ztest_suite_node_list_start;
 			ptr < _ztest_suite_node_list_end; ++ptr) {
 		__ztest_init_unit_test_result_for_suite(ptr);
-		count += __ztest_run_test_suite(ptr, NULL, shuffle, 1, 1);
+		if (strcmp(shell_command, "run-testcase") == 0) {
+			count += __ztest_run_test_suite(ptr, NULL, shuffle, 1, repeat_iter);
+		} else if (strcmp(shell_command, "run-testsuite") == 0) {
+			count += __ztest_run_test_suite(ptr, NULL, shuffle, repeat_iter, 1);
+		}
 		if (test_status == ZTEST_STATUS_CRITICAL_ERROR ||
 				(test_status == ZTEST_STATUS_HAS_FAILURE && FAIL_FAST)) {
 			break;
@@ -1392,8 +1430,8 @@ static void testsuite_list_get(size_t idx, struct shell_static_entry *entry)
 		SHELL_CMD_ARG(list-testcases, NULL,
 			"List all test cases", cmd_list_cases, 0, 0),
 		SHELL_CMD_ARG(run-testsuite, &testsuite_names,
-			"Run test suite", cmd_run_suite, 2, 0),
-		SHELL_CMD_ARG(run-testcase, NULL, "Run testcase", cmd_run_suite, 2, 0),
+			"Run test suite", cmd_run_suite, 2, 2),
+		SHELL_CMD_ARG(run-testcase, NULL, "Run testcase", cmd_run_suite, 2, 2),
 		SHELL_SUBCMD_SET_END /* Array terminated. */
 	);
 


### PR DESCRIPTION
Expand ztest_shell subcommands  `run-testcase` and `run-testsuite` to include additional parameter `-r` repeat-iter. This allows to run a particula testcase or testsuite several times.

Example of usage.
`west build -b qemu_x86 -p -t run tests/kernel/semaphore/semaphore/ -- -DCONFIG_ZTEST_SHELL=y`
```
SeaBIOS (version zephyr-v1.0.0-0-g31d4e0e-dirty-20200714_234759-fv-az50-zephyr)
Booting from ROM..
*** Booting Zephyr OS build v3.6.0-5504-g0d56a3c3f4c3 ***


uart:~$ ztest list
  list-testsuites  list-testcases
uart:~$ ztest list-testcases 
semaphore::test_k_sem_correct_count_limit
semaphore::test_k_sem_define
semaphore::test_k_sem_init
semaphore::test_sem_count_get
semaphore::test_sem_give_from_isr
semaphore::test_sem_give_from_thread
semaphore::test_sem_give_take_from_isr
semaphore::test_sem_measure_timeout_from_thread
semaphore::test_sem_measure_timeouts
semaphore::test_sem_multi_take_timeout_diff_sem
semaphore::test_sem_multiple_threads_wait
semaphore::test_sem_reset
semaphore::test_sem_reset_waiting
semaphore::test_sem_take_multiple
semaphore::test_sem_take_no_wait
semaphore::test_sem_take_no_wait_fails
semaphore::test_sem_take_timeout
semaphore::test_sem_take_timeout_fails
semaphore::test_sem_take_timeout_forever
semaphore::test_sem_thread2isr
semaphore::test_sem_thread2thread
semaphore_1cpu::test_sem_multiple_take_and_timeouts
semaphore_1cpu::test_sem_queue_mutual_exclusion
semaphore_1cpu::test_sem_take_timeout_isr
semaphore_null_case::test_sem_count_get_null
semaphore_null_case::test_sem_give_null
semaphore_null_case::test_sem_init_null
semaphore_null_case::test_sem_reset_null
semaphore_null_case::test_sem_take_null
uart:~$ ztest run-testcase semaphore::test_k_sem_init -r 2
Running TESTSUITE semaphore
===================================================================
START - test_k_sem_init
 PASS - test_k_sem_init in 0.002 seconds
===================================================================
START - test_k_sem_init
 PASS - test_k_sem_init in 0.001 seconds
===================================================================
TESTSUITE semaphore succeeded
uart:~$ ztest list-testsuites 
semaphore
semaphore_1cpu
semaphore_null_case
uart:~$ ztest run-testsuite semaphore -r 2
Running TESTSUITE semaphore
===================================================================
START - test_k_sem_correct_count_limit
 PASS - test_k_sem_correct_count_limit in 0.004 seconds
===================================================================
START - test_k_sem_define
 PASS - test_k_sem_define in 0.001 seconds
===================================================================
START - test_k_sem_init
 PASS - test_k_sem_init in 0.001 seconds
===================================================================
START - test_sem_count_get
 PASS - test_sem_count_get in 0.001 seconds
===================================================================
START - test_sem_give_from_isr
 PASS - test_sem_give_from_isr in 0.001 seconds
===================================================================
START - test_sem_give_from_thread
 PASS - test_sem_give_from_thread in 0.001 seconds
===================================================================
START - test_sem_give_take_from_isr
 PASS - test_sem_give_take_from_isr in 0.001 seconds
===================================================================
START - test_sem_measure_timeout_from_thread
 PASS - test_sem_measure_timeout_from_thread in 0.001 seconds
===================================================================
START - test_sem_measure_timeouts
 PASS - test_sem_measure_timeouts in 1.009 seconds
===================================================================
START - test_sem_multi_take_timeout_diff_sem
 PASS - test_sem_multi_take_timeout_diff_sem in 5.010 seconds
===================================================================
START - test_sem_multiple_threads_wait
 PASS - test_sem_multiple_threads_wait in 2.038 seconds
===================================================================
START - test_sem_reset
 PASS - test_sem_reset in 0.109 seconds
===================================================================
START - test_sem_reset_waiting
 PASS - test_sem_reset_waiting in 0.019 seconds
===================================================================
START - test_sem_take_multiple
 PASS - test_sem_take_multiple in 1.009 seconds
===================================================================
START - test_sem_take_no_wait
 PASS - test_sem_take_no_wait in 0.003 seconds
===================================================================
START - test_sem_take_no_wait_fails
 PASS - test_sem_take_no_wait_fails in 0.001 seconds
===================================================================
START - test_sem_take_timeout
 PASS - test_sem_take_timeout in 0.001 seconds
===================================================================
START - test_sem_take_timeout_fails
 PASS - test_sem_take_timeout_fails in 0.543 seconds
===================================================================
START - test_sem_take_timeout_forever
 PASS - test_sem_take_timeout_forever in 0.109 seconds
===================================================================
START - test_sem_thread2isr
 PASS - test_sem_thread2isr in 0.001 seconds
===================================================================
START - test_sem_thread2thread
 PASS - test_sem_thread2thread in 0.002 seconds
===================================================================
TESTSUITE semaphore succeeded
Running TESTSUITE semaphore
===================================================================
START - test_k_sem_correct_count_limit
 PASS - test_k_sem_correct_count_limit in 0.001 seconds
===================================================================
START - test_k_sem_define
 PASS - test_k_sem_define in 0.001 seconds
===================================================================
START - test_k_sem_init
 PASS - test_k_sem_init in 0.001 seconds
===================================================================
START - test_sem_count_get
 PASS - test_sem_count_get in 0.001 seconds
===================================================================
START - test_sem_give_from_isr
 PASS - test_sem_give_from_isr in 0.001 seconds
===================================================================
START - test_sem_give_from_thread
 PASS - test_sem_give_from_thread in 0.001 seconds
===================================================================
START - test_sem_give_take_from_isr
 PASS - test_sem_give_take_from_isr in 0.001 seconds
===================================================================
START - test_sem_measure_timeout_from_thread
 PASS - test_sem_measure_timeout_from_thread in 0.001 seconds
===================================================================
START - test_sem_measure_timeouts
 PASS - test_sem_measure_timeouts in 1.010 seconds
===================================================================
START - test_sem_multi_take_timeout_diff_sem
 PASS - test_sem_multi_take_timeout_diff_sem in 5.009 seconds
===================================================================
START - test_sem_multiple_threads_wait
 PASS - test_sem_multiple_threads_wait in 2.038 seconds
===================================================================
START - test_sem_reset
 PASS - test_sem_reset in 0.109 seconds
===================================================================
START - test_sem_reset_waiting
 PASS - test_sem_reset_waiting in 0.019 seconds
===================================================================
START - test_sem_take_multiple
 PASS - test_sem_take_multiple in 1.009 seconds
===================================================================
START - test_sem_take_no_wait
 PASS - test_sem_take_no_wait in 0.002 seconds
===================================================================
START - test_sem_take_no_wait_fails
 PASS - test_sem_take_no_wait_fails in 0.001 seconds
===================================================================
START - test_sem_take_timeout
 PASS - test_sem_take_timeout in 0.001 seconds
===================================================================
START - test_sem_take_timeout_fails
 PASS - test_sem_take_timeout_fails in 0.543 seconds
===================================================================
START - test_sem_take_timeout_forever
 PASS - test_sem_take_timeout_forever in 0.109 seconds
===================================================================
START - test_sem_thread2isr
 PASS - test_sem_thread2isr in 0.001 seconds
===================================================================
START - test_sem_thread2thread
 PASS - test_sem_thread2thread in 0.002 seconds
===================================================================
TESTSUITE semaphore succeeded
uart:~$ 
```
