### PR TITLE
doc: soc porting: Fix introduction paragraph

### DIFF
--- a/doc/hardware/porting/soc_porting.rst
+++ b/doc/hardware/porting/soc_porting.rst
@@ -3,9 +3,8 @@
 SoC Porting Guide
 ###################
 
-To add Zephyr support for a new :term:`SoC`, you need a *SoC directory* with
-various files in it, and a SoC :file:`.dtsi` in
-:zephyr_file:`dts/<ARCH>/<VENDOR>` is required.
+This page describes how to add support for a new :term:`SoC` in Zephyr, be it in
+the upstream Zephyr project or locally in your own repository.
 
 SoC Definitions
 ***************


### PR DESCRIPTION
The introductory paragraph had a broken link and was arbitrarily referencing a couple of files that will be described extensively later. Instead, just present the content generically.

Fixes #69990.