### PR TITLE
cmake: modules: extension: Fix dtc file watch

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -2352,6 +2352,10 @@ function(toolchain_parse_make_rule input_file include_files)
   # the element separator, so let's get the pure `;` back.
   string(REPLACE "\;" ";" input_as_list ${input})
 
+  # The file might also contain multiple files on one line if one or both of
+  # the file paths are short, split these up into multiple elements using regex
+  string(REGEX REPLACE "([^ ])[ ]([^ ])" "\\1;\\2" input_as_list "${input_as_list}")
+
   # Pop the first line and treat it specially
   list(POP_FRONT input_as_list first_input_line)
   string(FIND ${first_input_line} ": " index)

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -2356,16 +2356,8 @@ function(toolchain_parse_make_rule input_file include_files)
   # the file paths are short, split these up into multiple elements using regex
   string(REGEX REPLACE "([^ ])[ ]([^ ])" "\\1;\\2" input_as_list "${input_as_list}")
 
-  # Pop the first line and treat it specially
+  # Pop the first item containing "empty_file.o:"
   list(POP_FRONT input_as_list first_input_line)
-  string(FIND ${first_input_line} ": " index)
-  math(EXPR j "${index} + 2")
-  string(SUBSTRING ${first_input_line} ${j} -1 first_include_file)
-
-  # Remove whitespace before and after filename and convert to CMake path.
-  string(STRIP "${first_include_file}" first_include_file)
-  file(TO_CMAKE_PATH "${first_include_file}" first_include_file)
-  set(result "${first_include_file}")
 
   # Remove whitespace before and after filename and convert to CMake path.
   foreach(file ${input_as_list})


### PR DESCRIPTION
Fixes an issue in the code that processes the output file of a compiler to see which files should be watched, the compiler can combine multiple files into a single line instead of putting them each on separate lines if the length of the file paths is short, therefore account for this and split it up into multiple elements

Fixes #74630