### PR TITLE
boards: rak: rak11720: Add missing bt_hci flag.

### DIFF
--- a/boards/rak/rak11720/rak11720.dts
+++ b/boards/rak/rak11720/rak11720.dts
@@ -21,6 +21,7 @@
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-pipe = &uart0;
 		zephyr,flash-controller = &flash;
+		zephyr,bt_hci = &bt_hci_apollo;
 	};
 
 	aliases {

--- a/boards/rak/rak11720/rak11720_apollo3-pinctrl.dtsi
+++ b/boards/rak/rak11720/rak11720_apollo3-pinctrl.dtsi
@@ -70,7 +70,7 @@
 			pinmux = <M0SCK_P5>, <M0MISO_P6>, <M0MOSI_P7>;
 		};
 		group2 {
-			pinmux = <NCE11_P11>;
+			pinmux = <NCE1_P1>;
 			drive-push-pull;
 			ambiq,iom-nce-module = <0>;
 			ambiq,iom-num = <0>;
@@ -81,7 +81,7 @@
 			pinmux = <M1SCK_P8>, <M1MISO_P9>, <M1MOSI_P10>;
 		};
 		group2 {
-			pinmux = <NCE14_P14>;
+			pinmux = <NCE11_P11>;
 			drive-push-pull;
 			ambiq,iom-nce-module = <1>;
 			ambiq,iom-num = <1>;


### PR DESCRIPTION
Update dts file to use the new HCI api of apollo3 blue.
Fixing wrongly defined spi pins.

It is tested with samples/ble/beacon and samples/ble/peripheral samples. Hal_ambiq commit id is e25327f026df1ee08f1bf01a4bbfeb5e5f4026f1.
