### PR TITLE
tests/twister: update confusing terminology

### DIFF
--- a/doc/develop/test/pytest.rst
+++ b/doc/develop/test/pytest.rst
@@ -28,7 +28,7 @@ developed as a part of Zephyr’s tree. To enable install-less operation, twiste
 they must add ``--allow-installed-plugin`` flag to twister’s call.
 
 Pytest-based test suites are discovered the same way as other twister tests, i.e., by a presence
-of testcase/sample.yaml. Inside, a keyword ``harness`` tells twister how to handle a given test.
+of test/sample.yaml. Inside, a keyword ``harness`` tells twister how to handle a given test.
 In the case of ``harness: pytest``, most of twister workflow (test suites discovery,
 parallelization, building and reporting) remains the same as for other harnesses. The change
 happens during the execution step. The below picture presents a simplified overview of the

--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -3,23 +3,22 @@
 Test Runner (Twister)
 #####################
 
-This script scans for the set of unit test applications in the git repository
+Twister scans for the set of test applications in the git repository
 and attempts to execute them. By default, it tries to build each test
-case on boards marked as default in the board definition file.
+application on boards marked as default in the board definition file.
 
-The default options will build the majority of the tests on a defined set of
-boards and will run in an emulated environment if available for the
-architecture or configuration being tested.
+The default options will build the majority of the test applications on a
+defined set of boards and will run in an emulated environment if available for
+the architecture or configuration being tested.
 
-In normal use, twister runs a limited set of kernel tests (inside
-an emulator).  Because of its limited test execution coverage, twister
+Because of the limited test execution coverage, twister
 cannot guarantee local changes will succeed in the full build
 environment, but it does sufficient testing by building samples and
 tests for different boards and different configurations to help keep the
 complete code tree buildable.
 
 When using (at least) one ``-v`` option, twister's console output
-shows for every test how the test is run (qemu, native_sim, etc.) or
+shows for every test application how the test is run (qemu, native_sim, etc.) or
 whether the binary was just built.  There are a few reasons why twister
 only builds a test and doesn't run it:
 
@@ -157,10 +156,10 @@ toolchain:
   The list of supported toolchains that can build this board. This should match
   one of the values used for :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` when building on the command line
 ram:
-  Available RAM on the board (specified in KB). This is used to match testcase
+  Available RAM on the board (specified in KB). This is used to match test scenario
   requirements.  If not specified we default to 128KB.
 flash:
-  Available FLASH on the board (specified in KB). This is used to match testcase
+  Available FLASH on the board (specified in KB). This is used to match test scenario
   requirements.  If not specified we default to 512KB.
 supported:
   A list of features this board supports. This can be specified as a single word
@@ -171,7 +170,7 @@ supported:
         supported:
           - pci
 
-  This indicates the board does support PCI. You can make a testcase build or
+  This indicates the board does support PCI. You can make a test scenario build or
   run only on such boards, or:
 
   .. code-block:: yaml
@@ -180,7 +179,7 @@ supported:
           - netif:eth
           - sensor:bmi16
 
-  A testcase can both depend on 'eth' to only test ethernet or on 'netif' to run
+  A test scenario can depend on 'eth' to only test ethernet or on 'netif' to run
   on any board with a networking interface.
 
 testing:
@@ -200,7 +199,7 @@ testing:
   .. _twister_board_timeout_multiplier:
 
   timeout_multiplier: <float> (default 1)
-    Multiply each test case timeout by specified ratio. This option allows to tune timeouts only
+    Multiply each test scenario timeout by specified ratio. This option allows to tune timeouts only
     for required platform. It can be useful in case naturally slow platform I.e.: HW board with
     power-efficient but slow CPU or simulation platform which can perform instruction accurate
     simulation but does it slowly.
@@ -211,26 +210,38 @@ env:
   used, for example, only if some required software or hardware is present, and to signal that
   presence to twister using these environment variables.
 
-Test Cases
-**********
+Tests
+******
 
-Test cases are detected by the presence of a ``testcase.yaml`` or a ``sample.yaml``
-files in the application's project directory. This file may contain one or more
-entries in the test section each identifying a test scenario.
+Tests are detected by the presence of a ``testcase.yaml`` or a ``sample.yaml``
+files in the application's project directory. This test application
+configuration file may contain one or more entries in the tests section each
+identifying a test scenario.
 
-The name of each testcase needs to be unique in the context of the overall
-testsuite and has to follow basic rules:
+Test application configurations are written using the YAML syntax and share the
+same structure as samples.
 
-#. The format of the test identifier shall be a string without any spaces or
+A test scenario is a set of conditions or variables, defined in test scenario
+entry, under which a set of test suites will be executed. Can be used
+interchangeably with test scenario entry.
+
+A test suite is a collection of test cases that are intended to be used to test
+a software program to ensure it meets certain requirements. The test cases in a
+test suite are often related or meant to be executed together.
+
+The name of each test scenario needs to be unique in the context of the overall
+test application and has to follow basic rules:
+
+#. The format of the test scenario identifier shall be a string without any spaces or
    special characters (allowed characters: alphanumeric and [\_=]) consisting
    of multiple sections delimited with a dot (.).
 
-#. Each test identifier shall start with a section followed by a subsection
-   separated by a dot. For example, a test that covers semaphores in the kernel
-   shall start with ``kernel.semaphore``.
+#. Each test scenario identifier shall start with a section followed by a
+   subsection separated by a dot. For example, a test scenario that covers
+   semaphores in the kernel shall start with ``kernel.semaphore``.
 
-#. All test identifiers within a testcase.yaml file need to be unique. For
-   example a testcase.yaml file covering semaphores in the kernel can have:
+#. All test scenario identifiers within a ``testcase.yaml`` file need to be unique. For
+   example a ``testcase.yaml`` file covering semaphores in the kernel can have:
 
    * ``kernel.semaphore``: For general semaphore tests
    * ``kernel.semaphore.stress``: Stress testing semaphores in the kernel.
@@ -238,17 +249,17 @@ testsuite and has to follow basic rules:
 #. Depending on the nature of the test, an identifier can consist of at least
    two sections:
 
-   * Ztest tests: The individual testcases in the ztest testsuite will be
-     concatenated to identifier in the testcase.yaml file generating unique
-     identifiers for every testcase in the suite.
+   * Ztest tests: The individual test cases in the ztest testsuite will be
+     concatenated by dot (`.`) to the identifier in the ``testcase.yaml`` file
+     generating unique identifiers for every test case in the suite.
 
    * Standalone tests and samples: This type of test should at least have 3
-     sections in the test identifier in the testcase.yaml (or sample.yaml) file.
-     The last section of the name shall signify the test itself.
+     sections concatnated by dot (`.`) in the test scenario identifier in the
+     ``testcase.yaml`` (or ``sample.yaml``) file.
+     The last section of the name shall signify the test case itself.
 
 
-Test cases are written using the YAML syntax and share the same structure as
-samples. The following is an example test with a few options that are
+The following is an example test configuration with a few options that are
 explained in this document.
 
 
@@ -288,32 +299,36 @@ related to the sample and what is being demonstrated:
             tags: tests
             min_ram: 16
 
-The full canonical name for each test case is:``<path to test case>/<test entry>``
+The full canonical name for each test scenario is:``<path to test application>/<test scenario identifier>``
 
-Each test block in the testcase meta data can define the following key/value
-pairs:
+A test scenario entry is a a block or entry starting with test scenario
+identifier in the YAML files.
+
+Each test scenario entry in the test application configuration can define the
+following key/value pairs:
 
 tags: <list of tags> (required)
-    A set of string tags for the testcase. Usually pertains to
+    A set of string tags for the test scenario. Usually pertains to
     functional domains but can be anything. Command line invocations
     of this script can filter the set of tests to run based on tag.
 
 skip: <True|False> (default False)
-    skip testcase unconditionally. This can be used for broken tests.
+    skip test scenario unconditionally. This can be used for broken tests for
+    example.
 
 slow: <True|False> (default False)
-    Don't run this test case unless ``--enable-slow`` or ``--enable-slow-only`` was
-    passed in on the command line. Intended for time-consuming test cases that
+    Don't run this test scenario unless ``--enable-slow`` or ``--enable-slow-only`` was
+    passed in on the command line. Intended for time-consuming test scenarios that
     are only run under certain circumstances, like daily builds. These test
-    cases are still compiled.
+    scenarios are still compiled.
 
 extra_args: <list of extra arguments>
-    Extra arguments to pass to Make when building or running the
-    test case.
+    Extra arguments to pass to build tool when building or running the
+    test scenario.
 
 extra_configs: <list of extra configurations>
-    Extra configuration options to be merged with a master prj.conf
-    when building or running the test case. For example:
+    Extra configuration options to be merged with a main prj.conf
+    when building or running the test scenario. For example:
 
     .. code-block:: yaml
 
@@ -356,7 +371,7 @@ build_only: <True|False> (default False)
     test shall not be used to verify the functionality of the driver.
 
 build_on_all: <True|False> (default False)
-    If true, attempt to build test on all available platforms. This is mostly
+    If true, attempt to build test scenario on all available platforms. This is mostly
     used in CI for increased coverage. Do not use this flag in new tests.
 
 depends_on: <list of features>
@@ -382,13 +397,13 @@ timeout: <number of seconds>
     Default to 60 seconds.
 
 arch_allow: <list of arches, such as x86, arm, arc>
-    Set of architectures that this test case should only be run for.
+    Set of architectures that this test scenario should only be run for.
 
 arch_exclude: <list of arches, such as x86, arm, arc>
-    Set of architectures that this test case should not run on.
+    Set of architectures that this test scenario should not run on.
 
 platform_allow: <list of platforms>
-    Set of platforms that this test case should only be run for. Do not use
+    Set of platforms that this test scenario should only be run for. Do not use
     this option to limit testing or building in CI due to time or resource
     constraints, this option should only be used if the test or sample can
     only be run on the allowed platform and nothing else.
@@ -400,7 +415,7 @@ integration_platforms: <YML list of platforms/boards>
     resource constraints.
 
 platform_exclude: <list of platforms>
-    Set of platforms that this test case should not run on.
+    Set of platforms that this test scenario should not run on.
 
 extra_sections: <list of extra binary sections>
     When computing sizes, twister will report errors if it finds
@@ -554,23 +569,23 @@ harness_config: <harness configuration options>
           ]
 
     fixture: <expression>
-        Specify a test case dependency on an external device(e.g., sensor),
+        Specify a test scenario dependency on an external device(e.g., sensor),
         and identify setups that fulfill this dependency. It depends on
         specific test setup and board selection logic to pick the particular
         board(s) out of multiple boards that fulfill the dependency in an
         automation setup based on ``fixture`` keyword. Some sample fixture names
         are i2c_hts221, i2c_bme280, i2c_FRAM, ble_fw and gpio_loop.
 
-        Only one fixture can be defined per testcase and the fixture name has to
+        Only one fixture can be defined per test scenario and the fixture name has to
         be unique across all tests in the test suite.
 
 .. _pytest_root:
 
     pytest_root: <list of pytest testpaths> (default pytest)
         Specify a list of pytest directories, files or subtests that need to be
-        executed when a test case begins to run. The default pytest directory is
+        executed when a test scenario begins to run. The default pytest directory is
         ``pytest``. After the pytest run is finished, Twister will check if
-        the test case passed or failed according to the pytest report.
+        the test scenario passed or failed according to the pytest report.
         As an example, a list of valid pytest roots is presented below:
 
         .. code-block:: yaml
@@ -661,7 +676,7 @@ harness_config: <harness configuration options>
               robot_test_path: [robot file path]
 
 filter: <expression>
-    Filter whether the testcase should be run by evaluating an expression
+    Filter whether the test scenario should be run by evaluating an expression
     against an environment containing the following values:
 
     .. code-block:: none
@@ -737,7 +752,7 @@ filter: <expression>
     Would match it.
 
 required_snippets: <list of needed snippets>
-    :ref:`Snippets <snippets>` are supported in twister for test cases that
+    :ref:`Snippets <snippets>` are supported in twister for test scenarios that
     require them. As with normal applications, twister supports using the base
     zephyr snippet directory and test application directory for finding
     snippets. Listed snippets will filter supported tests for boards (snippets
@@ -754,10 +769,10 @@ required_snippets: <list of needed snippets>
               - cdc-acm-console
               - user-snippet-example
 
-The set of test cases that actually run depends on directives in the testcase
+The set of test scenarios that actually run depends on directives in the test scenario
 filed and options passed in on the command line. If there is any confusion,
 running with ``-v`` or examining the discard report
-(:file:`twister_discard.csv`) can help show why particular test cases were
+(:file:`twister_discard.csv`) can help show why particular test scenarios were
 skipped.
 
 Metrics (such as pass/fail state and binary size) for the last code
@@ -775,7 +790,7 @@ Managing tests timeouts
 
 There are several parameters which control tests timeouts on various levels:
 
-* ``timeout`` option in each test case. See :ref:`here <twister_test_case_timeout>` for more
+* ``timeout`` option in each test scenario. See :ref:`here <twister_test_case_timeout>` for more
   details.
 * ``timeout_multiplier`` option in board configuration. See
   :ref:`here <twister_board_timeout_multiplier>` for more details.
@@ -784,7 +799,7 @@ There are several parameters which control tests timeouts on various levels:
   speed & load or we may select different simulation method (i.e. cycle accurate but slower
   one), etc...
 
-Overall test case timeout is a multiplication of these three parameters.
+Overall test scenario timeout is a multiplication of these three parameters.
 
 Running in Integration Mode
 ***************************
@@ -793,8 +808,8 @@ This mode is used in continuous integration (CI) and other automated
 environments used to give developers fast feedback on changes. The mode can
 be activated using the ``--integration`` option of twister and narrows down
 the scope of builds and tests if applicable to platforms defined under the
-integration keyword in the testcase definition file (testcase.yaml and
-sample.yaml).
+integration keyword in the test configuration file (``testcase.yaml`` and
+``sample.yaml``).
 
 
 Running tests on custom emulator
@@ -897,8 +912,8 @@ device flash operation, for example when device flashing takes significantly
 large time.
 
 The ``--device-flash-with-test`` option indicates that on the platform
-the flash operation also executes a test case, so the flash timeout is
-increased by a test case timeout.
+the flash operation also executes a test scenario, so the flash timeout is
+increased by a test scenario timeout.
 
 Executing tests on multiple devices
 ===================================
@@ -1091,7 +1106,7 @@ Fixtures
 +++++++++
 
 Some tests require additional setup or special wiring specific to the test.
-Running the tests without this setup or test fixture may fail. A testcase can
+Running the tests without this setup or test fixture may fail. A test scenario can
 specify the fixture it needs which can then be matched with hardware capability
 of a board and the fixtures it supports via the command line or using the hardware
 map file.
@@ -1110,7 +1125,7 @@ Fixtures are defined in the hardware map file as a list:
         serial: /dev/ttyACM9
 
 When running ``twister`` with ``--device-testing``, the configured fixture
-in the hardware map file will be matched to testcases requesting the same fixtures
+in the hardware map file will be matched to test scenarios requesting the same fixtures
 and these tests will be executed on the boards that provide this fixture.
 
 .. figure:: fixtures.svg
@@ -1119,11 +1134,11 @@ and these tests will be executed on the boards that provide this fixture.
 Fixtures can also be provided via twister command option ``--fixture``, this option
 can be used multiple times and all given fixtures will be appended as a list. And the
 given fixtures will be assigned to all boards, this means that all boards set by
-current twister command can run those testcases which request the same fixtures.
+current twister command can run those test scenarios which request the same fixtures.
 
 Some fixtures allow for configuration strings to be appended, separated from the
 fixture name by a ``:``. Only the fixture name is matched against the fixtures
-requested by testcases.
+requested by test scenarios.
 
 Notes
 +++++
@@ -1250,7 +1265,7 @@ locally. As of now, those options are available:
   CI)
 - Option to specify your own list of default platforms overriding what
   upstream defines.
-- Ability to override `build_on_all` options used in some testcases.
+- Ability to override `build_on_all` options used in some test scenarios.
   This will treat tests or sample as any other just build for default
   platforms you specify in the configuration file or on the command line.
 - Ignore some logic in twister to expand platform coverage in cases where
@@ -1345,7 +1360,7 @@ An example platforms plus level configuration:
 
 
 To run with above test_config.yaml file, only default_platforms with given test level
-test cases will run.
+test scenarios will run.
 
 .. tabs::
 

--- a/doc/develop/test/ztest.rst
+++ b/doc/develop/test/ztest.rst
@@ -267,13 +267,13 @@ src/main.c (see :ref:`best practices <main_c_bp>`)
 
 
 
-A test application may consist of multiple sub-tests or smaller tests that
-either can be testing functionality or APIs. Functions implementing a test
+A test application may consist of multiple test suites that
+either can be testing functionality or APIs. Functions implementing a test case
 should follow the guidelines below:
 
-* Test cases function names should be prefix with **test_**
+* Test cases function names should be prefixed with **test_**
 * Test cases should be documented using doxygen
-* Test function names should be unique within the section or component being
+* Test case function names should be unique within the section or component being
   tested
 
 For example:
@@ -283,7 +283,7 @@ For example:
    /**
     * @brief Test Asserts
     *
-    * This test verifies the zassert_true macro.
+    * This test case verifies the zassert_true macro.
     */
    ZTEST(my_suite, test_assert)
    {
@@ -295,7 +295,7 @@ Listing Tests
 
 Tests (test applications) in the Zephyr tree consist of many test scenarios that run as
 part of a project and test similar functionality, for example an API or a
-feature. The ``twister`` script can parse the test cases in all
+feature. The ``twister`` script can parse the test scenarios, suites and cases in all
 test applications or a subset of them, and can generate reports on a granular
 level, i.e. if test cases have passed or failed or if they were blocked or skipped.
 

--- a/doc/develop/test/ztest.rst
+++ b/doc/develop/test/ztest.rst
@@ -226,9 +226,9 @@ the **bar** component of **foo**, you should copy the sample folder to
    ./scripts/twister -s tests/foo/bar/test-identifier
 
 In the example above ``tests/foo/bar`` signifies the path to the test and the
-``test-identifier`` references a test defined in the :file:`testcase.yaml` file.
+``test-identifier`` references a test scenario defined in the :file:`testcase.yaml` file.
 
-To run all tests defined in a test project, run:
+To run all test scenarios defined in a test application, run:
 
 .. code-block:: console
 
@@ -267,7 +267,7 @@ src/main.c (see :ref:`best practices <main_c_bp>`)
 
 
 
-A test case project may consist of multiple sub-tests or smaller tests that
+A test application may consist of multiple sub-tests or smaller tests that
 either can be testing functionality or APIs. Functions implementing a test
 should follow the guidelines below:
 
@@ -293,18 +293,18 @@ For example:
 Listing Tests
 =============
 
-Tests (test projects) in the Zephyr tree consist of many testcases that run as
+Tests (test applications) in the Zephyr tree consist of many test scenarios that run as
 part of a project and test similar functionality, for example an API or a
-feature. The ``twister`` script can parse the testcases in all
-test projects or a subset of them, and can generate reports on a granular
-level, i.e. if cases have passed or failed or if they were blocked or skipped.
+feature. The ``twister`` script can parse the test cases in all
+test applications or a subset of them, and can generate reports on a granular
+level, i.e. if test cases have passed or failed or if they were blocked or skipped.
 
 Twister parses the source files looking for test case names, so you
 can list all kernel test cases, for example, by running:
 
 .. code-block:: console
 
-   twister --list-tests -T tests/kernel
+   ./scripts/twister --list-tests -T tests/kernel
 
 Skipping Tests
 ==============
@@ -378,18 +378,18 @@ Best practices for declaring the test suite
 *******************************************
 
 *twister* and other validation tools need to obtain the list of
-subcases that a Zephyr *ztest* test image will expose.
+test cases that a Zephyr *ztest* test image will expose.
 
 .. admonition:: Rationale
 
    This all is for the purpose of traceability. It's not enough to
-   have only a semaphore test project.  We also need to show that we
+   have only a semaphore test application.  We also need to show that we
    have testpoints for all APIs and functionality, and we trace back
    to documentation of the API, and functional requirements.
 
-   The idea is that test reports show results for every sub-testcase
+   The idea is that test reports show results for every test case
    as passed, failed, blocked, or skipped.  Reporting on only the
-   high-level test project level, particularly when tests do too
+   high-level test application, particularly when tests do too
    many things, is too vague.
 
 Other questions:
@@ -399,9 +399,9 @@ Other questions:
   If C pre-processing or building fails because of any issue, then we
   won't be able to tell the subcases.
 
-- Why not declare them in the YAML testcase description?
+- Why not declare them in the YAML test configuration?
 
-  A separate testcase description file would be harder to maintain
+  A separate test case description file would be harder to maintain
   than just keeping the information in the test source files
   themselves -- only one file to update when changes are made
   eliminates duplication.


### PR DESCRIPTION
- **twister: remove some of the confusion in terminology**
- **doc: ztest: Fix confusing terminology and align with twister.**

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/74151