### PR TITLE
soc: espressif: esp32: fix SPIRAM allocation

### DIFF
--- a/soc/espressif/esp32/default.ld
+++ b/soc/espressif/esp32/default.ld
@@ -660,6 +660,33 @@ SECTIONS
     _data_end = ABSOLUTE(.);
   } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
+  /* --- SPIRAM BEGIN --- */
+
+#ifdef CONFIG_ESP_SPIRAM
+  .ext_ram.bss (NOLOAD):
+  {
+    _ext_ram_data_start = ABSOLUTE(.);
+
+#ifdef CONFIG_ESP32_WIFI_NET_ALLOC_SPIRAM
+    *libdrivers__wifi.a:(.noinit .noinit.*)
+    *libsubsys__net__l2__ethernet.a:(.noinit .noinit.*)
+    *libsubsys__net__lib__config.a:(.noinit .noinit.*)
+    *libsubsys__net__ip.a:(.noinit .noinit.*)
+    *libsubsys__net.a:(.noinit .noinit.*)
+#endif /* CONFIG_ESP32_WIFI_NET_ALLOC_SPIRAM */
+
+    _ext_ram_bss_start = ABSOLUTE(.);
+    *(.ext_ram.bss*)
+    _ext_ram_bss_end = ABSOLUTE(.);
+    _spiram_heap_start = ABSOLUTE(.);
+    . = . + CONFIG_ESP_SPIRAM_HEAP_SIZE;
+
+    _ext_ram_data_end = ABSOLUTE(.);
+  } GROUP_LINK_IN(ext_ram_seg)
+#endif /* CONFIG_ESP_SPIRAM */
+
+  /* --- SPIRAM END --- */
+
   /* Shared RAM */
   .dram0.bss (NOLOAD) :
   {
@@ -716,33 +743,6 @@ SECTIONS
   /* #include <zephyr/linker/ram-end.ld> */
 
   /* --- DRAM END --- */
-
-  /* --- SPIRAM BEGIN --- */
-
-#ifdef CONFIG_ESP_SPIRAM
-  .ext_ram.bss (NOLOAD):
-  {
-    _ext_ram_data_start = ABSOLUTE(.);
-
-#ifdef CONFIG_ESP32_WIFI_NET_ALLOC_SPIRAM
-    *libdrivers__wifi.a:(.noinit .noinit.*)
-    *libsubsys__net__l2__ethernet.a:(.noinit .noinit.*)
-    *libsubsys__net__lib__config.a:(.noinit .noinit.*)
-    *libsubsys__net__ip.a:(.noinit .noinit.*)
-    *libsubsys__net.a:(.noinit .noinit.*)
-#endif /* CONFIG_ESP32_WIFI_NET_ALLOC_SPIRAM */
-
-    _ext_ram_bss_start = ABSOLUTE(.);
-    *(.ext_ram.bss*)
-    _ext_ram_bss_end = ABSOLUTE(.);
-    _spiram_heap_start = ABSOLUTE(.);
-    . = . + CONFIG_ESP_SPIRAM_HEAP_SIZE;
-
-    _ext_ram_data_end = ABSOLUTE(.);
-  } GROUP_LINK_IN(ext_ram_seg)
-#endif /* CONFIG_ESP_SPIRAM */
-
-  /* --- SPIRAM END --- */
 
   /* --- RODATA BEGIN --- */
 


### PR DESCRIPTION
Fixing the SPIRAM allocation by moving the output section before tha data is spilled in the generic output section.
The issue is described here: https://github.com/zephyrproject-rtos/zephyr/issues/74675