### PR TITLE
drivers: crypto: stm32: use reset api and register information from dts

### DIFF
--- a/drivers/crypto/crypto_stm32_priv.h
+++ b/drivers/crypto/crypto_stm32_priv.h
@@ -12,6 +12,7 @@
 #define CRYPTO_STM32_AES_MAX_KEY_LEN (256 / 8)
 
 struct crypto_stm32_config {
+	const struct reset_dt_spec reset;
 	struct stm32_pclken pclken;
 };
 

--- a/dts/arm/st/f4/stm32f415.dtsi
+++ b/dts/arm/st/f4/stm32f415.dtsi
@@ -14,6 +14,7 @@
 			compatible = "st,stm32-cryp";
 			reg = <0x50060000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00000010>;
+			resets = <&rctl STM32_RESET(AHB2, 4U)>;
 			interrupts = <79 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f4/stm32f417.dtsi
+++ b/dts/arm/st/f4/stm32f417.dtsi
@@ -14,6 +14,7 @@
 			compatible = "st,stm32-cryp";
 			reg = <0x50060000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00000010>;
+			resets = <&rctl STM32_RESET(AHB2, 4U)>;
 			interrupts = <79 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f4/stm32f423.dtsi
+++ b/dts/arm/st/f4/stm32f423.dtsi
@@ -14,6 +14,7 @@
 			compatible = "st,stm32-aes";
 			reg = <0x50060000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00000010>;
+			resets = <&rctl STM32_RESET(AHB2, 4U)>;
 			interrupts = <79 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f4/stm32f437.dtsi
+++ b/dts/arm/st/f4/stm32f437.dtsi
@@ -15,6 +15,7 @@
 			compatible = "st,stm32-cryp";
 			reg = <0x50060000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00000010>;
+			resets = <&rctl STM32_RESET(AHB2, 4U)>;
 			interrupts = <79 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/g0/stm32g0_crypt.dtsi
+++ b/dts/arm/st/g0/stm32g0_crypt.dtsi
@@ -14,6 +14,7 @@
 			compatible = "st,stm32-aes";
 			reg = <0x40026000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x00010000>;
+			resets = <&rctl STM32_RESET(AHB1, 16U)>;
 			interrupts = <31 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -443,6 +443,7 @@
 			compatible = "st,stm32-aes";
 			reg = <0x420c0000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00010000>;
+			resets = <&rctl STM32_RESET(AHB2, 16U)>;
 			interrupts = <116 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/h7/stm32h730.dtsi
+++ b/dts/arm/st/h7/stm32h730.dtsi
@@ -14,6 +14,7 @@
 			compatible = "st,stm32-cryp";
 			reg = <0x48021000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00000010>;
+			resets = <&rctl STM32_RESET(AHB2, 4U)>;
 			interrupts = <79 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/h7/stm32h7b0.dtsi
+++ b/dts/arm/st/h7/stm32h7b0.dtsi
@@ -19,6 +19,7 @@
 			compatible = "st,stm32-cryp";
 			reg = <0x48021000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00000010>;
+			resets = <&rctl STM32_RESET(AHB2, 4U)>;
 			interrupts = <79 0>;
 			interrupt-names = "cryp";
 			status = "disabled";

--- a/dts/arm/st/l4/stm32l422.dtsi
+++ b/dts/arm/st/l4/stm32l422.dtsi
@@ -14,6 +14,7 @@
 			compatible = "st,stm32-aes";
 			reg = <0x50060000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00010000>;
+			resets = <&rctl STM32_RESET(AHB2, 16U)>;
 			interrupts = <79 0>;
 			interrupt-names = "aes";
 			status = "disabled";

--- a/dts/arm/st/l4/stm32l462.dtsi
+++ b/dts/arm/st/l4/stm32l462.dtsi
@@ -14,6 +14,7 @@
 			compatible = "st,stm32-aes";
 			reg = <0x50060000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00010000>;
+			resets = <&rctl STM32_RESET(AHB2, 16U)>;
 			interrupts = <79 0>;
 			interrupt-names = "aes";
 			status = "disabled";

--- a/dts/arm/st/l4/stm32l496.dtsi
+++ b/dts/arm/st/l4/stm32l496.dtsi
@@ -62,6 +62,7 @@
 			compatible = "st,stm32-aes";
 			reg = <0x50060000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00010000>;
+			resets = <&rctl STM32_RESET(AHB2, 16U)>;
 			interrupts = <79 0>;
 			interrupt-names = "aes";
 			status = "disabled";

--- a/dts/arm/st/l4/stm32l4p5.dtsi
+++ b/dts/arm/st/l4/stm32l4p5.dtsi
@@ -297,6 +297,7 @@
 			compatible = "st,stm32-aes";
 			reg = <0x50060000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00010000>;
+			resets = <&rctl STM32_RESET(AHB2, 16U)>;
 			interrupts = <79 0>;
 			interrupt-names = "aes";
 			status = "disabled";

--- a/dts/arm/st/l5/stm32l562.dtsi
+++ b/dts/arm/st/l5/stm32l562.dtsi
@@ -14,6 +14,7 @@
 			compatible = "st,stm32-aes";
 			reg = <0x420c0000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00010000>;
+			resets = <&rctl STM32_RESET(AHB2, 16U)>;
 			interrupts = <93 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -719,6 +719,7 @@
 			compatible = "st,stm32-aes";
 			reg = <0x420c0000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00010000>;
+			resets = <&rctl STM32_RESET(AHB2L, 16U)>;
 			interrupts = <93 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -511,6 +511,7 @@
 			compatible = "st,stm32-aes";
 			reg = <0x50060000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00010000>;
+			resets = <&rctl STM32_RESET(AHB2, 16U)>;
 			interrupts = <51 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -452,6 +452,7 @@
 			compatible = "st,stm32-aes";
 			reg = <0x58001800 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x00020000>;
+			resets = <&rctl STM32_RESET(AHB3, 16U)>;
 			interrupts = <51 0>;
 			status = "disabled";
 		};

--- a/dts/bindings/crypto/st,stm32-crypto-common.yaml
+++ b/dts/bindings/crypto/st,stm32-crypto-common.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Markus Fuchs <markus.fuchs@de.sauter-bc.com>
 # SPDX-License-Identifier: Apache-2.0
 
-include: base.yaml
+include: [base.yaml, reset-device.yaml]
 
 properties:
   reg:
@@ -11,4 +11,7 @@ properties:
     required: true
 
   clocks:
+    required: true
+
+  resets:
     required: true


### PR DESCRIPTION
Replace direct hal api for crypto block reset to zephyr reset api framework.