### PR TITLE
Bluetooth: test: privacy/legacy: Scan continuously

### DIFF
--- a/tests/bsim/bluetooth/host/privacy/legacy/src/dut.c
+++ b/tests/bsim/bluetooth/host/privacy/legacy/src/dut.c
@@ -96,9 +96,6 @@ void dut_procedure(void)
 	LOG_DBG("start adv with RPA");
 	start_advertising(BT_LE_ADV_OPT_CONNECTABLE);
 
-	/* signal tester it can start scanning again, expecting an RPA this time */
-	backchannel_sync_send();
-
 	/* Test pass verdict is decided by the tester */
 	PASS("DUT done\n");
 }


### PR DESCRIPTION
Some controllers, like the SoftDevice Controller can miss the first few advertisements after the host tells it to start scanning. The DUT would assumes the first RPA advertisements report it gets is the first that was sent, but it was actually not the first. This would skew the tester's judgement about the timing of RPA rotations.

To remedy this, the tester will scan continuously and switch between expecting the identity address and the RPA without stopping the scanner.

The tester will tell the DUT to switch to RPA after it has received the identity address advertisement. This ensures that the tester will not miss the first RPA advertisement.

I recommend using [a split diff view for this patch](https://github.com/zephyrproject-rtos/zephyr/pull/74673/files?diff=split&w=0), as the unified diff is not very meaningful.