### PR TITLE
west: runners: stm32cubeprogrammer: Fixed behaivor if programmer is i…

### DIFF
--- a/scripts/west_commands/runners/stm32cubeprogrammer.py
+++ b/scripts/west_commands/runners/stm32cubeprogrammer.py
@@ -85,6 +85,10 @@ class STM32CubeProgrammerBinaryRunner(ZephyrBinaryRunner):
             )
 
         if platform.system() == "Windows":
+            cmd = shutil.which("STM32_Programmer_CLI")
+            if cmd is not None:
+                return Path(cmd)
+
             cli = (
                 Path("STMicroelectronics")
                 / "STM32Cube"


### PR DESCRIPTION
[…](west: runners: stm32cubeprogrammer: Fixed behaivor if programmer is i)n path

West isn't able to find the CubeProgrammer if one installs the STM32CubeProgrammer with a custom path under windows even if it is available in the CLI with `STM32_CubeProgrammer.exe` to fix that I  added a check if it is available through the PATH environment variable, if not we default back to old behaivor.