### PR TITLE
Fix MCUboot failed to build on ESP32 platforms

### DIFF
--- a/samples/sysbuild/with_mcuboot/sample.yaml
+++ b/samples/sysbuild/with_mcuboot/sample.yaml
@@ -9,8 +9,18 @@ tests:
     platform_allow:
       - reel_board
       - nrf52840dk/nrf52840
+      - esp32_devkitc_wrover/esp32/procpu
+      - esp32s2_devkitc
+      - esp32s3_devkitm/esp32s3/procpu
+      - esp32c3_devkitm
+      - esp32c6_devkitc
     integration_platforms:
       - nrf52840dk/nrf52840
+      - esp32_devkitc_wrover/esp32/procpu
+      - esp32s2_devkitc
+      - esp32s3_devkitm/esp32s3/procpu
+      - esp32c3_devkitm
+      - esp32c6_devkitc
     tags: mcuboot
     harness: console
     harness_config:

--- a/soc/espressif/esp32/default.ld
+++ b/soc/espressif/esp32/default.ld
@@ -848,6 +848,7 @@ SECTIONS
     _instruction_reserved_start = ABSOLUTE(.);  /* This is a symbol marking the flash.text start, this can be used for mmu driver to maintain virtual address */
     _text_start = ABSOLUTE(.);
     __text_region_start = ABSOLUTE(.);
+    __rom_region_start = ABSOLUTE(.);
 
 #ifndef CONFIG_ESP32_WIFI_IRAM_OPT
     *libnet80211.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.*)
@@ -867,6 +868,7 @@ SECTIONS
     _text_end = ABSOLUTE(.);
     _instruction_reserved_end = ABSOLUTE(.);  /* This is a symbol marking the flash.text end, this can be used for mmu driver to maintain virtual address */
     __text_region_end = ABSOLUTE(.);
+    __rom_region_end = ABSOLUTE(.);
     _etext = .;
   } GROUP_DATA_LINK_IN(FLASH_CODE_REGION, ROMABLE_REGION)
 

--- a/soc/espressif/esp32/memory.h
+++ b/soc/espressif/esp32/memory.h
@@ -48,9 +48,9 @@
 	(SRAM1_SIZE - ((addr_dram) - SRAM1_DRAM_START) + SRAM1_IRAM_START)
 
 /* For safety margin between bootloader data section and startup stacks */
-#define BOOTLOADER_DRAM_SEG_LEN        0x6400
+#define BOOTLOADER_DRAM_SEG_LEN        0x7a00
 #define BOOTLOADER_IRAM_LOADER_SEG_LEN 0x4000
-#define BOOTLOADER_IRAM_SEG_LEN        0x9500
+#define BOOTLOADER_IRAM_SEG_LEN        0xa000
 
 /* Start of the lower region is determined by region size and the end of the higher region */
 #define BOOTLOADER_DRAM_SEG_START  0x3fff0000

--- a/soc/espressif/esp32c3/default.ld
+++ b/soc/espressif/esp32c3/default.ld
@@ -660,6 +660,7 @@ SECTIONS
     _text_start = ABSOLUTE(.);
     _instruction_reserved_start = ABSOLUTE(.);
     __text_region_start = ABSOLUTE(.);
+    __rom_region_start = ABSOLUTE(.);
 
 #if !defined(CONFIG_ESP32_WIFI_IRAM_OPT)
     *libnet80211.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.*)
@@ -691,6 +692,7 @@ SECTIONS
     _text_end = ABSOLUTE(.);
     _instruction_reserved_end = ABSOLUTE(.);
     __text_region_end = ABSOLUTE(.);
+    __rom_region_end = ABSOLUTE(.);
     _etext = .;
 
   } GROUP_DATA_LINK_IN(FLASH_CODE_REGION, ROMABLE_REGION)

--- a/soc/espressif/esp32c3/memory.h
+++ b/soc/espressif/esp32c3/memory.h
@@ -41,8 +41,8 @@
 /* For safety margin between bootloader data section and startup stacks */
 #define BOOTLOADER_STACK_OVERHEAD      0x0
 /* These lengths can be adjusted, if necessary: */
-#define BOOTLOADER_DRAM_SEG_LEN        0x9000
-#define BOOTLOADER_IRAM_SEG_LEN        0x9000
+#define BOOTLOADER_DRAM_SEG_LEN        0x9800
+#define BOOTLOADER_IRAM_SEG_LEN        0x9800
 #define BOOTLOADER_IRAM_LOADER_SEG_LEN 0x1400
 
 /* Start of the lower region is determined by region size and the end of the higher region */

--- a/soc/espressif/esp32c6/default.ld
+++ b/soc/espressif/esp32c6/default.ld
@@ -661,6 +661,7 @@ SECTIONS
     _text_start = ABSOLUTE(.);
     _instruction_reserved_start = ABSOLUTE(.);
     __text_region_start = ABSOLUTE(.);
+    __rom_region_start = ABSOLUTE(.);
 
 #if !defined(CONFIG_ESP32_WIFI_IRAM_OPT)
     *libnet80211.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.*)
@@ -692,6 +693,7 @@ SECTIONS
     _text_end = ABSOLUTE(.);
     _instruction_reserved_end = ABSOLUTE(.);
     __text_region_end = ABSOLUTE(.);
+    __rom_region_end = ABSOLUTE(.);
     _etext = .;
 
   } GROUP_DATA_LINK_IN(CACHED_REGION, ROMABLE_REGION)

--- a/soc/espressif/esp32s2/default.ld
+++ b/soc/espressif/esp32s2/default.ld
@@ -814,6 +814,7 @@ SECTIONS
     _instruction_reserved_start = ABSOLUTE(.);
     _text_start = ABSOLUTE(.);
     __text_region_start = ABSOLUTE(.);
+    __rom_region_start = ABSOLUTE(.);
 
 #if !defined(CONFIG_ESP32_WIFI_IRAM_OPT)
     *libnet80211.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.*)
@@ -843,6 +844,7 @@ SECTIONS
     _text_end = ABSOLUTE(.);
     _instruction_reserved_end = ABSOLUTE(.);  /* This is a symbol marking the flash.text end, this can be used for mmu driver to maintain virtual address */
     __text_region_end = ABSOLUTE(.);
+    __rom_region_end = ABSOLUTE(.);
     _etext = .;
 
   } GROUP_DATA_LINK_IN(FLASH_CODE_REGION, ROMABLE_REGION)
@@ -852,8 +854,7 @@ SECTIONS
   /* --- START OF .rodata --- */
 
   _image_drom_start = LOADADDR(.flash.rodata);
-  _image_drom_size = LOADADDR(.flash.rodata_end) + SIZEOF(.flash.rodata_end)  - _image_drom_start;
-  _image_drom_size2 = _rodata_end - _rodata_start;
+  _image_drom_size = LOADADDR(.flash.rodata_end) + SIZEOF(.flash.rodata_end) - _image_drom_start;
   _image_drom_vaddr = ADDR(.flash.rodata);
 
   /* Align next section to 64k to allow mapping */

--- a/soc/espressif/esp32s3/default.ld
+++ b/soc/espressif/esp32s3/default.ld
@@ -749,6 +749,7 @@ SECTIONS
     _instruction_reserved_start = ABSOLUTE(.);
     _text_start = ABSOLUTE(.);
     __text_region_start = ABSOLUTE(.);
+    __rom_region_start = ABSOLUTE(.);
 
 #if !defined(CONFIG_ESP32_WIFI_IRAM_OPT)
     *libnet80211.a:( .wifi0iram  .wifi0iram.* .wifislpiram .wifislpiram.*)
@@ -777,6 +778,7 @@ SECTIONS
     _text_end = ABSOLUTE(.);
     _instruction_reserved_end = ABSOLUTE(.);  /* This is a symbol marking the flash.text end, this can be used for mmu driver to maintain virtual address */
     __text_region_end = ABSOLUTE(.);
+    __rom_region_end = ABSOLUTE(.);
     _etext = .;
 
   } GROUP_DATA_LINK_IN(FLASH_CODE_REGION, ROMABLE_REGION)

--- a/soc/espressif/esp32s3/memory.h
+++ b/soc/espressif/esp32s3/memory.h
@@ -45,9 +45,9 @@
 
 /* For safety margin between bootloader data section and startup stacks */
 #define BOOTLOADER_STACK_OVERHEAD      0x0
-#define BOOTLOADER_DRAM_SEG_LEN        0x6400
+#define BOOTLOADER_DRAM_SEG_LEN        0x8000
 #define BOOTLOADER_IRAM_LOADER_SEG_LEN 0x1a00
-#define BOOTLOADER_IRAM_SEG_LEN        0xa000
+#define BOOTLOADER_IRAM_SEG_LEN        0xa800
 
 /* Start of the lower region is determined by region size and the end of the higher region */
 #define BOOTLOADER_IRAM_LOADER_SEG_START (BOOTLOADER_USER_DRAM_END - BOOTLOADER_STACK_OVERHEAD + \


### PR DESCRIPTION
The MCUboot is failing during the build on ESP32 and ESP32S3 boards. The reason is the recent changes in Xtensa architecture and the fact that CI didn't catch those changes. That's why we adding the ESP32 platforms to the MCUboot/--sysbuild samples.

Fixes #74695