### PR TITLE
ARCMWDT: Fix cbprintf issue with omitted function prototype

### DIFF
--- a/include/zephyr/sys/cbprintf.h
+++ b/include/zephyr/sys/cbprintf.h
@@ -302,6 +302,12 @@ typedef int (*cbprintf_cb)(int c, void *ctx);
 typedef int (*cbprintf_cb)(/* int c, void *ctx */);
 #endif
 
+/* Create local cbprintf_cb type to make calng-based compilers happy when handles
+ * OUTC() macro (see below). With strict rules (Wincompatible-function-pointer-types-strict)
+ * it's prohibited to pass arguments with mismatched types.
+ */
+typedef int (*cbprintf_cb_local)(int c, void *ctx);
+
 /** @brief Signature for a cbprintf multibyte callback function.
  *
  * @param buf data.

--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -1316,12 +1316,13 @@ static inline void store_count(const struct conversion *conv,
 }
 
 /* Outline function to emit all characters in [sp, ep). */
-static int outs(cbprintf_cb out,
+static int outs(cbprintf_cb __out,
 		void *ctx,
 		const char *sp,
 		const char *ep)
 {
 	size_t count = 0;
+	cbprintf_cb_local out = __out;
 
 	while ((sp < ep) || ((ep == NULL) && *sp)) {
 		int rc = out((int)*sp++, ctx);
@@ -1335,12 +1336,13 @@ static int outs(cbprintf_cb out,
 	return (int)count;
 }
 
-int z_cbvprintf_impl(cbprintf_cb out, void *ctx, const char *fp,
+int z_cbvprintf_impl(cbprintf_cb __out, void *ctx, const char *fp,
 		     va_list ap, uint32_t flags)
 {
 	char buf[CONVERTED_BUFLEN];
 	size_t count = 0;
 	sint_value_type sint;
+	cbprintf_cb_local out = __out;
 
 	const bool tagged_ap = (flags & Z_CBVPRINTF_PROCESS_FLAG_TAGGED_ARGS)
 			       == Z_CBVPRINTF_PROCESS_FLAG_TAGGED_ARGS;

--- a/lib/os/cbprintf_nano.c
+++ b/lib/os/cbprintf_nano.c
@@ -73,7 +73,7 @@ static inline int convert_value(uint_value_type num, unsigned int base,
  *
  * @return printed byte count if CONFIG_CBPRINTF_LIBC_SUBSTS is set
  */
-int z_cbvprintf_impl(cbprintf_cb out, void *ctx, const char *fmt,
+int z_cbvprintf_impl(cbprintf_cb __out, void *ctx, const char *fmt,
 		     va_list ap, uint32_t flags)
 {
 	size_t count = 0;
@@ -81,6 +81,7 @@ int z_cbvprintf_impl(cbprintf_cb out, void *ctx, const char *fmt,
 	char *prefix, *data;
 	int min_width, precision, data_len;
 	char padding_mode, length_mod, special;
+	cbprintf_cb_local out = __out;
 
 	const bool tagged_ap = (flags & Z_CBVPRINTF_PROCESS_FLAG_TAGGED_ARGS)
 			       == Z_CBVPRINTF_PROCESS_FLAG_TAGGED_ARGS;


### PR DESCRIPTION
MWDT compiler (LLVM 16.0.6 based) requires function to be declared with argument types and produce warnings otherwise. This PR provides explicitly type cast for out() routine inside z_cbvprintf_impl().

This fixes https://github.com/zephyrproject-rtos/zephyr/issues/74562