### PR TITLE
intel_adsp: power: Fix for ACE30 Power Management

### DIFF
--- a/dts/xtensa/intel/intel_adsp_ace30_ptl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace30_ptl.dtsi
@@ -188,25 +188,6 @@
 			status = "okay";
 		};
 
-		/*
-		 * FIXME this is modeling individual alh channels/instances
-		 * with node labels, which has problems. A better representation
-		 * is discussed here:
-		 *
-		 * https://github.com/zephyrproject-rtos/zephyr/pull/50287#discussion_r974591009
-		 */
-		alh0: alh0@24400 {
-			compatible = "intel,alh-dai";
-			reg = <0x00024400 0x00024600>;
-			status = "okay";
-		};
-
-		alh1: alh1@24400 {
-			compatible = "intel,alh-dai";
-			reg = <0x00024400 0x00024600>;
-			status = "okay";
-		};
-
 		sspbase: ssp_base@28000 {
 			compatible = "intel,ssp-sspbase";
 			reg = <0x28000 0x1000>;

--- a/dts/xtensa/intel/intel_adsp_ace30_ptl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace30_ptl.dtsi
@@ -439,21 +439,9 @@
 				compatible = "intel,adsp-power-domain";
 				bit-position = <15>;
 			};
-			ml1_domain: ml1_domain {
-				compatible = "intel,adsp-power-domain";
-				bit-position = <13>;
-			};
 			ml0_domain: ml0_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <12>;
-			};
-			io3_domain: io3_domain {
-				compatible = "intel,adsp-power-domain";
-				bit-position = <11>;
-			};
-			io2_domain: io2_domain {
-				compatible = "intel,adsp-power-domain";
-				bit-position = <10>;
 			};
 			io1_domain: io1_domain {
 				compatible = "intel,adsp-power-domain";

--- a/dts/xtensa/intel/intel_adsp_ace30_ptl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace30_ptl.dtsi
@@ -458,37 +458,37 @@
 				compatible = "intel,adsp-power-domain";
 				bit-position = <15>;
 			};
-			hub_hp_domain: hub_hpp_domain {
+			ml1_domain: ml1_domain {
 				compatible = "intel,adsp-power-domain";
-				bit-position = <6>;
-			};
-			io0_domain: io0_domain {
-				compatible = "intel,adsp-power-domain";
-				bit-position = <8>;
-			};
-			io1_domain: io1_domain {
-				compatible = "intel,adsp-power-domain";
-				bit-position = <9>;
-			};
-			io2_domain: io2_domain {
-				compatible = "intel,adsp-power-domain";
-				bit-position = <10>;
-			};
-			io3_domain: io3_domain {
-				compatible = "intel,adsp-power-domain";
-				bit-position = <11>;
-			};
-			hst_domain: hst_domain {
-				compatible = "intel,adsp-power-domain";
-				bit-position = <5>;
+				bit-position = <13>;
 			};
 			ml0_domain: ml0_domain {
 				compatible = "intel,adsp-power-domain";
 				bit-position = <12>;
 			};
-			ml1_domain: ml1_domain {
+			io3_domain: io3_domain {
 				compatible = "intel,adsp-power-domain";
-				bit-position = <13>;
+				bit-position = <11>;
+			};
+			io2_domain: io2_domain {
+				compatible = "intel,adsp-power-domain";
+				bit-position = <10>;
+			};
+			io1_domain: io1_domain {
+				compatible = "intel,adsp-power-domain";
+				bit-position = <9>;
+			};
+			io0_domain: io0_domain {
+				compatible = "intel,adsp-power-domain";
+				bit-position = <8>;
+			};
+			hub_hp_domain: hub_hpp_domain {
+				compatible = "intel,adsp-power-domain";
+				bit-position = <6>;
+			};
+			hst_domain: hst_domain {
+				compatible = "intel,adsp-power-domain";
+				bit-position = <5>;
 			};
 		};
 

--- a/soc/intel/intel_adsp/ace/include/ace30_ptl/adsp_power.h
+++ b/soc/intel/intel_adsp/ace/include/ace30_ptl/adsp_power.h
@@ -16,9 +16,8 @@
 
 /* Power Control register - controls the power domain operations. */
 struct ace_pwrctl {
-	uint16_t rsvd0      : 5;
+	uint16_t rsvd4      : 5;
 	uint16_t wphstpg    : 1;
-	uint16_t rsvd6      : 1;
 	uint16_t wphubhppg  : 1;
 	uint16_t wpdspulppg : 1;
 	uint16_t wpioxpg    : 2;
@@ -30,6 +29,7 @@ struct ace_pwrctl {
 
 struct ace_pwrctl2 {
 	uint16_t wpdsphpxpg : 5;
+	uint16_t rsvd15     : 11;
 };
 
 #define ACE_PWRCTL ((volatile struct ace_pwrctl *) &ACE_DfPMCCU.dfpwrctl)
@@ -37,19 +37,20 @@ struct ace_pwrctl2 {
 
 /* Power Status register - reports the power domain status. */
 struct ace_pwrsts {
-	uint16_t rsvd0     : 5;
+	uint16_t rsvd4     : 5;
 	uint16_t hstpgs    : 1;
-	uint16_t rsvd6     : 1;
 	uint16_t hubhppgs  : 1;
 	uint16_t dspulppgs : 1;
-	uint16_t ioxpgs    : 4;
-	uint16_t mlpgs     : 2;
-	uint16_t rsvd14    : 1;
+	uint16_t ioxpgs    : 2;
+	uint16_t rsvd11    : 2;
+	uint16_t mlpgs     : 1;
+	uint16_t rsvd14    : 2;
 	uint16_t hubulppgs : 1;
 };
 
 struct ace_pwrsts2 {
 	uint16_t dsphpxpgs : 5;
+	uint16_t rsvd15    : 11;
 };
 
 #define ACE_PWRSTS ((volatile struct ace_pwrsts *) &ACE_DfPMCCU.dfpwrsts)

--- a/soc/intel/intel_adsp/ace/power.c
+++ b/soc/intel/intel_adsp/ace/power.c
@@ -164,9 +164,6 @@ static ALWAYS_INLINE void _restore_core_context(void)
 {
 	uint32_t core_id = arch_proc_id();
 
-#ifdef CONFIG_XTENSA_MMU
-	xtensa_mmu_init();
-#endif
 	XTENSA_WSR("PS", core_desc[core_id].ps);
 	XTENSA_WSR("VECBASE", core_desc[core_id].vecbase);
 	XTENSA_WSR("EXCSAVE2", core_desc[core_id].excsave2);
@@ -175,6 +172,9 @@ static ALWAYS_INLINE void _restore_core_context(void)
 #if (XCHAL_NUM_MISC_REGS == 2)
 	XTENSA_WSR("MISC0", core_desc[core_id].misc[0]);
 	XTENSA_WSR("MISC1", core_desc[core_id].misc[1]);
+#endif
+#ifdef CONFIG_XTENSA_MMU
+	xtensa_mmu_reinit();
 #endif
 	__asm__ volatile("mov a0, %0" :: "r"(core_desc[core_id].a0));
 	__asm__ volatile("mov a1, %0" :: "r"(core_desc[core_id].a1));


### PR DESCRIPTION
# Summary of Changes for Pull Request

This pull request includes a series of updates to the ACE30 PTL firmware and device tree source files. The changes improve the accuracy of the hardware representation, clean up redundant code, ensure proper power management procedures are followed, and fix issues found in power flows. Below is a summary of the included changes:

## Device Tree Source (DTS) Updates

### Reordering of Power Domains
- Power domain entries in the ACE30 PTL DTS file have been reordered by bit position for improved readability and logical grouping.

### Removal of Non-Existent Power Domains
- Removed definitions of power domains from the ACE30 PTL DTS file that do not exist in the actual hardware, preventing potential misconfiguration.

### Removal of ALH Nodes
- Removed the Audio Link Hub (ALH) nodes from the ACE30 PTL DTS file as they are not utilized in the ACE 3.0 PTL architecture.

## Firmware Code Updates

### Use of MMU Reinitialization API
- Updated the core context restore process to use the new `xtensa_mmu_reinit()` API instead of `xtensa_mmu_init()`. This change fixes an issue in the power flow where the MMU context was not properly preserved across low-power states, ensuring that runtime changes to the MMU configuration are retained.