### PR TITLE
everywhere: replace double words

### DIFF
--- a/arch/arc/core/mpu/arc_mpu_v2_internal.h
+++ b/arch/arc/core/mpu/arc_mpu_v2_internal.h
@@ -118,7 +118,7 @@ static inline bool _is_enabled_region(uint32_t r_index)
 }
 
 /**
- * This internal function check if the given buffer in in the region
+ * This internal function check if the given buffer is in the region
  */
 static inline bool _is_in_region(uint32_t r_index, uint32_t start, uint32_t size)
 {

--- a/arch/arc/core/mpu/arc_mpu_v6_internal.h
+++ b/arch/arc/core/mpu/arc_mpu_v6_internal.h
@@ -156,7 +156,7 @@ static inline bool _is_enabled_region(uint32_t r_index)
 }
 
 /**
- * This internal function check if the given buffer in in the region
+ * This internal function check if the given buffer is in the region
  */
 static inline bool _is_in_region(uint32_t r_index, uint32_t start, uint32_t size)
 {

--- a/arch/xtensa/core/README_MMU.txt
+++ b/arch/xtensa/core/README_MMU.txt
@@ -254,7 +254,7 @@ of access variability.  But it also means that the TLB entries end up
 being stored twice in the same CPU, wasting transistors that could
 presumably store other useful data.
 
-But it it also important to note that the L1 data cache on Xtensa is
+But it is also important to note that the L1 data cache on Xtensa is
 incoherent!  The cache being used for refill reflects the last access
 on the current CPU only, and not of the underlying memory being
 mapped.  Page table changes in the data cache of one CPU will be

--- a/boards/native/native_posix/native_rtc.h
+++ b/boards/native/native_posix/native_rtc.h
@@ -44,7 +44,7 @@ extern "C" {
 uint64_t native_rtc_gettime_us(int clock_type);
 
 /**
- * @brief Get the value of a clock split in in nsec and seconds
+ * @brief Get the value of a clock split in nsec and seconds
  *
  * @param clock_type Which clock to measure from
  * @param nsec Pointer to store the nanoseconds

--- a/doc/connectivity/networking/api/http_server.rst
+++ b/doc/connectivity/networking/api/http_server.rst
@@ -103,7 +103,7 @@ macro:
 
     HTTP_SERVICE_DEFINE(my_service, "0.0.0.0", &http_service_port, 1, 10, NULL);
 
-Alternatively, an HTTPS service can be defined with with
+Alternatively, an HTTPS service can be defined with
 :c:macro:`HTTPS_SERVICE_DEFINE`:
 
 .. code-block:: c

--- a/doc/connectivity/networking/api/lwm2m.rst
+++ b/doc/connectivity/networking/api/lwm2m.rst
@@ -670,7 +670,7 @@ where it cannot recover.
      - Try to recover network connection. Then restart the client by calling :c:func:`lwm2m_rd_client_start`.
        This might also indicate configuration issue.
 
-Sending of data in the table above refers to calling :c:func:`lwm2m_send_cb` or by writing into of of the observed resources where observation would trigger a notify message.
+Sending of data in the table above refers to calling :c:func:`lwm2m_send_cb` or by writing into one of the observed resources where observation would trigger a notify message.
 Receiving of data refers to receiving read, write or execute operations from the server. Application can register callbacks for these operations.
 
 Configuring lifetime and activity period

--- a/doc/connectivity/networking/net_config_guide.rst
+++ b/doc/connectivity/networking/net_config_guide.rst
@@ -174,7 +174,7 @@ TCP Options
 :kconfig:option:`CONFIG_NET_TCP_RETRY_COUNT`
   Maximum number of TCP segment retransmissions.
   The following formula can be used to determine the time (in ms)
-  that a segment will be be buffered awaiting retransmission:
+  that a segment will be buffered awaiting retransmission:
 
   .. math::
 

--- a/doc/develop/flash_debug/probes.rst
+++ b/doc/develop/flash_debug/probes.rst
@@ -210,7 +210,7 @@ The probe may be updated to use CMSIS-DAP firmware with the following steps:
    be done by installing :ref:`linkserver-debug-host-tools`.
 
 #. Put the LPC-Link2 microcontroller into DFU boot mode by attaching the DFU
-   jumper, then then connecting to the USB debug port on the board. This
+   jumper, then connecting to the USB debug port on the board. This
    jumper is connected to ``P2_6`` on the LPC4322 SOC.
 
 #. Run the ``program_CMSIS`` script, found in the installed LPCScrypt ``scripts``
@@ -241,7 +241,7 @@ The probe may be updated to use the J-Link firmware with the following steps:
    be done by installing :ref:`linkserver-debug-host-tools`.
 
 #. Put the LPC-Link2 microcontroller into DFU boot mode by attaching the DFU
-   jumper, then then connecting to the USB debug port on the board. This
+   jumper, then connecting to the USB debug port on the board. This
    jumper is connected to ``P2_6`` on the LPC4322 SOC.
 
 #. Run the ``program_JLINK`` script, found in the installed LPCScrypt ``scripts``

--- a/doc/releases/release-notes-1.14.rst
+++ b/doc/releases/release-notes-1.14.rst
@@ -2067,7 +2067,7 @@ release:
 * :github:`10345` - The OpenAMP remote build is for wrong board
 * :github:`10344` - SPI Chip Select usage is not unambiguous
 * :github:`10329` - SystemView overflow event
-* :github:`10320` - arm: mpu: mpu_config and and mpu_regions to be declared/defined as const
+* :github:`10320` - arm: mpu: mpu_config and mpu_regions to be declared/defined as const
 * :github:`10318` - It is not documented what YAML bindings do
 * :github:`10316` - net: sockets: Close doesn't unblock recv
 * :github:`10313` - net: sockets: Packets are leaked on TCP abort connection

--- a/doc/releases/release-notes-3.1.rst
+++ b/doc/releases/release-notes-3.1.rst
@@ -490,7 +490,7 @@ Drivers and Sensors
     series. Interrupt driven mode. Supports 1 and 8 lines in Single or Dual
     Transfer Modes.
   * STM32L5: Added support for Single Bank.
-  * STM32 QSPI driver was extended with with QER (SFDP, DTS), custom quad write opcode
+  * STM32 QSPI driver was extended with QER (SFDP, DTS), custom quad write opcode
     and 1-1-4 read mode.
   * Added support for STM32U5 series.
 

--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -210,7 +210,7 @@ Deprecated in this release
 
 * MCUmgr subsystem, specifically the SMP transport API, is dropping `zephyr_`
   prefix, deprecating prefixed functions and callback type definitions with the
-  prefix and replacing them with with prefix-less variants.
+  prefix and replacing them with prefix-less variants.
   The :c:struct:`zephyr_smp_transport` type, representing transport object,
   is now replaced with :c:struct:`smp_transport`, and the later one is used,
   instead of the former one, by all prefix-less functions.
@@ -3486,7 +3486,7 @@ Addressed issues
 * :github:`50732` - net: tests/net/ieee802154/l2/net.ieee802154.l2 failed on reel_board due to build failure
 * :github:`50709` - tests: arch: arm: arm_thread_swap fails on stm32g0 or stm32l0
 * :github:`50684` - After enabling  CONFIG_SPI_STM32_DMA in project config file for STM32MP157-dk2 Zephyr throwing error
-* :github:`50665` - MEC15xx/MEC1501: UART and and special purpose pins missing pinctrl configuration
+* :github:`50665` - MEC15xx/MEC1501: UART and special purpose pins missing pinctrl configuration
 * :github:`50658` - Bluetooth: BLE stack notifications blocks host side for too long (``drivers/bluetooth/hci/spi.c`` and ``hci_spi``)
 * :github:`50656` - Wrong definition of bank size for intel memory management driver.
 * :github:`50655` - STM32WB55 Bus Fault when connecting then disconnecting then connecting then disconnecting then connecting

--- a/doc/services/mem_mgmt/index.rst
+++ b/doc/services/mem_mgmt/index.rst
@@ -92,7 +92,7 @@ to define and create a set of memory heaps from which the user can allocate
 memory from with certain attributes / capabilities.
 
 When the :kconfig:option:`CONFIG_MEM_ATTR_HEAP` is set, every region marked
-with one of the memory attributes listed in in
+with one of the memory attributes listed in
 :zephyr_file:`include/zephyr/dt-bindings/memory-attr/memory-attr-sw.h` is added
 to a pool of memory heaps used for dynamic allocation of memory buffers with
 certain attributes.

--- a/drivers/adc/adc_ads1x1x.c
+++ b/drivers/adc/adc_ads1x1x.c
@@ -616,7 +616,7 @@ static const struct adc_driver_api ads1x1x_api = {
 /* The ADS111X provides 16 bits of data in binary two's complement format
  * A positive full-scale (+FS) input produces an output code of 7FFFh and a
  * negative full-scale (–FS) input produces an output code of 8000h. Single
- * ended signal measurements only only use the positive code range from
+ * ended signal measurements only use the positive code range from
  * 0000h to 7FFFh
  */
 #define ADS111X_RESOLUTION 16
@@ -659,7 +659,7 @@ DT_INST_FOREACH_STATUS_OKAY(ADS1113_INIT)
 /* The ADS101X provides 12 bits of data in binary two's complement format
  * A positive full-scale (+FS) input produces an output code of 7FFh and a
  * negative full-scale (–FS) input produces an output code of 800h. Single
- * ended signal measurements only only use the positive code range from
+ * ended signal measurements only use the positive code range from
  * 000h to 7FFh
  */
 #define ADS101X_RESOLUTION 12

--- a/drivers/audio/dmic_nrfx_pdm.c
+++ b/drivers/audio/dmic_nrfx_pdm.c
@@ -207,7 +207,7 @@ static bool check_pdm_frequencies(const struct dmic_nrfx_pdm_drv_cfg *drv_cfg,
 				better_found = true;
 			}
 
-			/* Since frequencies are are in ascending order, stop
+			/* Since frequencies are in ascending order, stop
 			 * checking next ones for the current ratio after
 			 * resulting PCM rate goes above the one requested.
 			 */

--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -160,7 +160,7 @@ config BT_SPI_INIT_PRIORITY
 	default 75
 
 config BT_BLUENRG_ACI
-	bool "ACI message with with BlueNRG-based devices"
+	bool "ACI message with BlueNRG-based devices"
 	select BT_HCI_SET_PUBLIC_ADDR
 	help
 	  Enable support for devices compatible with the BlueNRG Bluetooth

--- a/drivers/clock_control/clock_control_mchp_xec.c
+++ b/drivers/clock_control/clock_control_mchp_xec.c
@@ -267,7 +267,7 @@ static int periph_clk_src_using_pin(enum periph_clk32k_src src)
 /* MEC15xx uses the same 32KHz source for both PLL and Peripheral 32K clock domains.
  * We ignore the peripheral clock source.
  * If XTAL is selected (parallel) or single-ended the external 32KHz MUST stay on
- * even when when VTR goes off.
+ * even when VTR goes off.
  * If PIN(32KHZ_IN pin) as the external source, hardware can auto-switch to internal
  * silicon OSC if the signal on the 32KHZ_PIN goes away.
  * We ignore th

--- a/drivers/dma/dma_xmc4xxx.c
+++ b/drivers/dma/dma_xmc4xxx.c
@@ -393,7 +393,7 @@ static int dma_xmc4xxx_get_status(const struct device *dev, uint32_t channel,
 
 	stat->pending_length  = dma_channel->block_ts - XMC_DMA_CH_GetTransferredData(dma, channel);
 	stat->pending_length *= dma_channel->source_data_size;
-	/* stat->dir and other remaining fields are not set. They are are not */
+	/* stat->dir and other remaining fields are not set. They are not */
 	/* useful for xmc4xxx peripheral drivers. */
 
 	return 0;

--- a/drivers/ethernet/eth_smsc91x.c
+++ b/drivers/ethernet/eth_smsc91x.c
@@ -522,7 +522,7 @@ static int smsc_send_pkt(struct smsc_data *sc, uint8_t *buf, uint16_t len)
 	smsc_write_2(sc, DATA0, len + PKT_CTRL_DATA_LEN);
 	smsc_write_multi_2(sc, DATA0, (uint16_t *)buf, len / 2);
 
-	/* Push out the control byte and and the odd byte if needed. */
+	/* Push out the control byte and the odd byte if needed. */
 	if (len & 1) {
 		smsc_write_2(sc, DATA0, (CTRL_ODD << 8) | buf[len - 1]);
 	} else {

--- a/drivers/sdhc/rcar_mmc.c
+++ b/drivers/sdhc/rcar_mmc.c
@@ -2045,7 +2045,7 @@ static int rcar_mmc_init_controller_regs(const struct device *dev)
 	reg |= RCAR_MMC_DMA_MODE_ADDR_INC | RCAR_MMC_DMA_MODE_WIDTH;
 	rcar_mmc_write_reg32(dev, RCAR_MMC_DMA_MODE, reg);
 
-	/* store version of of introductory IP */
+	/* store version of introductory IP */
 	data->ver = rcar_mmc_read_reg32(dev, RCAR_MMC_VERSION);
 	data->ver &= RCAR_MMC_VERSION_IP;
 

--- a/drivers/sensor/bosch/bme280/bme280.c
+++ b/drivers/sensor/bosch/bme280/bme280.c
@@ -121,7 +121,7 @@ static int bme280_wait_until_ready(const struct device *dev)
 	uint8_t status = 0;
 	int ret;
 
-	/* Wait for NVM to copy and and measurement to be completed */
+	/* Wait for NVM to copy and measurement to be completed */
 	do {
 		k_sleep(K_MSEC(3));
 		ret = bme280_reg_read(dev, BME280_REG_STATUS, &status, 1);

--- a/drivers/serial/leuart_gecko.c
+++ b/drivers/serial/leuart_gecko.c
@@ -65,7 +65,7 @@ static void leuart_gecko_poll_out(const struct device *dev, unsigned char c)
 	LEUART_TypeDef *base = DEV_BASE(dev);
 
 	/* LEUART_Tx function already waits for the transmit buffer being empty
-	 * and and waits for the bus to be free to transmit.
+	 * and waits for the bus to be free to transmit.
 	 */
 	LEUART_Tx(base, c);
 }

--- a/dts/bindings/input/futaba,sbus.yaml
+++ b/dts/bindings/input/futaba,sbus.yaml
@@ -9,7 +9,7 @@ description: |
   the rx-invert feature of your serial driver or use an external signal inverter.
   The driver binds this to the Zephyr input system using INPUT_EV_CODES.
 
-  The following examples defines a a binding of 2 joysticks and a button using 5 channels.
+  The following examples defines a binding of 2 joysticks and a button using 5 channels.
 
   &lpuart6 {
     status = "okay";

--- a/dts/bindings/led_strip/ws2812.yaml
+++ b/dts/bindings/led_strip/ws2812.yaml
@@ -28,7 +28,7 @@ description: |
     0 bit: 300 ns high and 900 ns low.
     1 bit: 900 ns high and 300 ns low.
 
-  There is a a +/- 80 ns tolerance for each timing.
+  There is a +/- 80 ns tolerance for each timing.
 
   The latch/reset delay is 250 us and it must be set using the reset-delay
   property. The pixel order depends on the model and it can be configured

--- a/dts/bindings/pinctrl/ti,cc13xx-cc26xx-pinctrl.yaml
+++ b/dts/bindings/pinctrl/ti,cc13xx-cc26xx-pinctrl.yaml
@@ -123,7 +123,7 @@ child-binding:
         configured as an output.
           2: min 2 mA (SoC default)
           4: min 4 mA
-          8: min 8 mA for for double drive strength IOs, min 4 mA for normal IOs
+          8: min 8 mA for double drive strength IOs, min 4 mA for normal IOs
 
     ti,input-edge-detect:
       type: int

--- a/include/zephyr/bluetooth/audio/media_proxy.h
+++ b/include/zephyr/bluetooth/audio/media_proxy.h
@@ -787,7 +787,7 @@ int media_proxy_ctrl_get_track_position(struct media_player *player);
  * @brief Set Track Position
  *
  * Set the playing position of the media player in the current
- * track. The position is given in in hundredths of a second,
+ * track. The position is given in hundredths of a second,
  * from the beginning of the track of the track for positive
  * values, and (backwards) from the end of the track for
  * negative values.
@@ -1178,7 +1178,7 @@ struct media_proxy_pl_calls {
 	 * @brief Set Track Position
 	 *
 	 * Set the playing position of the media player in the current
-	 * track. The position is given in in hundredths of a second,
+	 * track. The position is given in hundredths of a second,
 	 * from the beginning of the track of the track for positive
 	 * values, and (backwards) from the end of the track for
 	 * negative values.

--- a/include/zephyr/drivers/i2c/rtio.h
+++ b/include/zephyr/drivers/i2c/rtio.h
@@ -43,7 +43,7 @@ struct i2c_rtio {
 	};
 
 /**
- * @brief Copy an an array of i2c_msgs to rtio submissions and a transaction
+ * @brief Copy an array of i2c_msgs to rtio submissions and a transaction
  *
  * @retval sqe Last sqe setup in the copy
  * @retval NULL Not enough memory to copy the transaction

--- a/include/zephyr/kernel/mm/demand_paging.h
+++ b/include/zephyr/kernel/mm/demand_paging.h
@@ -252,7 +252,7 @@ void k_mem_paging_eviction_remove(struct k_mem_page_frame *pf);
  *
  * The architecture-specific memory fault handler will invoke this to tell the
  * eviction algorithm the provided physical address belongs to a page frame
- * being accessed and such page frame should become unlikely to be be
+ * being accessed and such page frame should become unlikely to be
  * considered as the next eviction candidate.
  *
  * This function is invoked with interrupts locked.

--- a/include/zephyr/mgmt/mcumgr/mgmt/callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/mgmt/callbacks.h
@@ -137,7 +137,7 @@ enum smp_group_events {
 	/** Callback when a command is received, data is mgmt_evt_op_cmd_arg(). */
 	MGMT_EVT_OP_CMD_RECV			= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_SMP, 0),
 
-	/** Callback when a a status is updated, data is mgmt_evt_op_cmd_arg(). */
+	/** Callback when a status is updated, data is mgmt_evt_op_cmd_arg(). */
 	MGMT_EVT_OP_CMD_STATUS			= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_SMP, 1),
 
 	/** Callback when a command has been processed, data is mgmt_evt_op_cmd_arg(). */

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -2985,7 +2985,7 @@ static inline void net_if_unset_promisc(struct net_if *iface)
  * @param iface Pointer to network interface
  *
  * @return True if interface is in promisc mode,
- *         False if interface is not in in promiscuous mode.
+ *         False if interface is not in promiscuous mode.
  */
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)
 bool net_if_is_promisc(struct net_if *iface);

--- a/include/zephyr/sys/onoff.h
+++ b/include/zephyr/sys/onoff.h
@@ -340,7 +340,7 @@ static inline bool onoff_has_error(const struct onoff_manager *mgr)
  *
  * @retval non-negative the observed state of the machine at the time
  * the request was processed, if successful.
- * @retval -EIO if service has recorded an an error.
+ * @retval -EIO if service has recorded an error.
  * @retval -EINVAL if the parameters are invalid.
  * @retval -EAGAIN if the reference count would overflow.
  */
@@ -361,7 +361,7 @@ int onoff_request(struct onoff_manager *mgr,
  *
  * @retval non-negative the observed state (ONOFF_STATE_ON) of the
  * machine at the time of the release, if the release succeeds.
- * @retval -EIO if service has recorded an an error.
+ * @retval -EIO if service has recorded an error.
  * @retval -ENOTSUP if the machine is not in a state that permits
  * release.
  */

--- a/include/zephyr/sys/sys_heap.h
+++ b/include/zephyr/sys/sys_heap.h
@@ -42,7 +42,7 @@ extern "C" {
  * are constant time (though there is a search of the smallest bucket
  * that has a compile-time-configurable upper bound, setting this to
  * extreme values results in an effectively linear search of the
- * list), objectively fast (~hundred instructions) and and amenable to
+ * list), objectively fast (~hundred instructions) and amenable to
  * locked operation.
  */
 

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -299,7 +299,7 @@ choice SCHED_ALGORITHM
 	prompt "Scheduler priority queue algorithm"
 	default SCHED_DUMB
 	help
-	  The kernel can be built with with several choices for the
+	  The kernel can be built with several choices for the
 	  ready queue implementation, offering different choices between
 	  code size, constant factor runtime overhead and performance
 	  scaling when many threads are added.

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -82,7 +82,7 @@ static void clear_perms_cb(struct k_object *ko, void *ctx_ptr);
 const char *otype_to_str(enum k_objects otype)
 {
 	const char *ret;
-	/* -fdata-sections doesn't work right except in very very recent
+	/* -fdata-sections doesn't work right except in very recent
 	 * GCC and these literal strings would appear in the binary even if
 	 * otype_to_str was omitted by the linker
 	 */

--- a/samples/subsys/usb/webusb/src/main.c
+++ b/samples/subsys/usb/webusb/src/main.c
@@ -64,7 +64,7 @@ static struct msosv2_descriptor_t {
 		.wLength = sizeof(struct msosv2_function_subset_header),
 		.wDescriptorType = MS_OS_20_SUBSET_HEADER_FUNCTION,
 		/* The WebUSB interface number becomes the first when CDC_ACM is enabled by
-		 * configuration.  Beware that if this sample is used as as inspiration for
+		 * configuration.  Beware that if this sample is used as an inspiration for
 		 * applications, where the WebUSB interface is no longer the first,
 		 * remember to adjust bFirstInterface.
 		 */

--- a/samples/tfm_integration/psa_crypto/src/psa_attestation.c
+++ b/samples/tfm_integration/psa_crypto/src/psa_attestation.c
@@ -33,7 +33,7 @@ psa_status_t att_get_iat(uint8_t *ch_buffer, uint32_t ch_sz,
 	size_t token_buf_size = ATT_MAX_TOKEN_SIZE;
 
 
-	/* Call with with bigger challenge object than allowed */
+	/* Call with bigger challenge object than allowed */
 
 	/*
 	 * First determine how large the token is on this system.

--- a/scripts/build/subfolder_list.py
+++ b/scripts/build/subfolder_list.py
@@ -30,7 +30,7 @@ def parse_args():
                         help='File to write containing a list of all \
                               directories found')
     parser.add_argument('-t', '--trigger-file', required=False,
-                        help='Trigger file to be be touched to re-run CMake')
+                        help='Trigger file to be touched to re-run CMake')
 
     args = parser.parse_args()
 

--- a/scripts/dts/python-devicetree/src/devicetree/dtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/dtlib.py
@@ -2035,7 +2035,7 @@ def to_nums(data: bytes, length: int = 4, signed: bool = False) -> List[int]:
 
     if len(data) % length:
         _err(f"{data!r} is {len(data)} bytes long, "
-             f"expected a length that's a a multiple of {length}")
+             f"expected a length that's a multiple of {length}")
 
     return [int.from_bytes(data[i:i + length], "big", signed=signed)
             for i in range(0, len(data), length)]

--- a/scripts/dts/python-devicetree/tests/test_dtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_dtlib.py
@@ -1903,7 +1903,7 @@ def test_prop_type_casting():
     verify_raw_to_num_error(dtlib.to_num, b"foo", 2, "b'foo' is 3 bytes long, expected 2")
     verify_raw_to_num_error(dtlib.to_nums, 0, 0, "'0' has type 'int', expected 'bytes'")
     verify_raw_to_num_error(dtlib.to_nums, b"", 0, "'length' must be greater than zero, was 0")
-    verify_raw_to_num_error(dtlib.to_nums, b"foooo", 2, "b'foooo' is 5 bytes long, expected a length that's a a multiple of 2")
+    verify_raw_to_num_error(dtlib.to_nums, b"foooo", 2, "b'foooo' is 5 bytes long, expected a length that's a multiple of 2")
 
 def test_duplicate_labels():
     '''

--- a/scripts/kconfig/kconfiglib.py
+++ b/scripts/kconfig/kconfiglib.py
@@ -3729,7 +3729,7 @@ class Kconfig(object):
 
         if node.is_configdefault:
             # Store any defaults for later application after the complete tree
-            # is known. The current length of of the default array is stored so
+            # is known. The current length of the default array is stored so
             # the configdefaults can be inserted in the order they originally
             # appeared.
             sym.configdefaults.append((len(sym.defaults), node.defaults))

--- a/scripts/native_simulator/native/src/include/native_rtc.h
+++ b/scripts/native_simulator/native/src/include/native_rtc.h
@@ -43,7 +43,7 @@ extern "C" {
 uint64_t native_rtc_gettime_us(int clock_type);
 
 /**
- * @brief Get the value of a clock split in in nsec and seconds
+ * @brief Get the value of a clock split in nsec and seconds
  *
  * @param clock_type Which clock to measure from
  * @param nsec Pointer to store the nanoseconds

--- a/scripts/spelling.txt
+++ b/scripts/spelling.txt
@@ -88,6 +88,7 @@ againt||against
 agaist||against
 aggreataon||aggregation
 aggreation||aggregation
+are are||are
 ajust||adjust
 albumns||albums
 alegorical||allegorical
@@ -127,11 +128,13 @@ amount of times||number of times
 amout||amount
 amplifer||amplifier
 amplifyer||amplifier
+an an||an
 an union||a union
 an user||a user
 an userspace||a userspace
 an one||a one
 analysator||analyzer
+and and||and
 ang||and
 anniversery||anniversary
 annoucement||announcement
@@ -164,6 +167,7 @@ arne't||aren't
 arraival||arrival
 artifical||artificial
 artillary||artillery
+as as||as an
 asign||assign
 asser||assert
 assertation||assertion
@@ -238,6 +242,7 @@ bandwith||bandwidth
 banlance||balance
 batery||battery
 battey||battery
+be be||be
 beacuse||because
 becasue||because
 becomming||becoming
@@ -701,6 +706,7 @@ followings||following
 follwing||following
 fonud||found
 forseeable||foreseeable
+for for||for
 forse||force
 fortan||fortran
 forwardig||forwarding
@@ -748,6 +754,7 @@ grranted||granted
 guage||gauge
 guarenteed||guaranteed
 guarentee||guarantee
+of of||of
 halfs||halves
 hander||handler
 handfull||handful
@@ -801,6 +808,7 @@ implemntation||implementation
 implentation||implementation
 implmentation||implementation
 implmenting||implementing
+in in||is in
 incative||inactive
 incomming||incoming
 incompaitiblity||incompatibility
@@ -910,6 +918,7 @@ is is||is
 isnt||isn't
 isssue||issue
 issus||issues
+it it||it is
 iteraions||iterations
 iternations||iterations
 itertation||iteration
@@ -1435,6 +1444,7 @@ sliped||slipped
 softwade||software
 softwares||software
 soley||solely
+some some||some
 souce||source
 speach||speech
 specfic||specific
@@ -1600,6 +1610,7 @@ trigerring||triggering
 trun||turn
 tunning||tuning
 ture||true
+two two||the two
 tyep||type
 udpate||update
 updtes||updates
@@ -1689,6 +1700,7 @@ verisons||versions
 verison||version
 veritical||vertical
 verson||version
+very very||very
 vicefersa||vice-versa
 virtal||virtual
 virtaul||virtual
@@ -1704,6 +1716,7 @@ wiat||wait
 wether||whether
 whataver||whatever
 whcih||which
+when when||when
 whenver||whenever
 wheter||whether
 whe||when
@@ -1711,6 +1724,7 @@ wierd||weird
 wihout||without
 wiil||will
 wirte||write
+with with||with
 withing||within
 wnat||want
 wont||won't

--- a/soc/ite/ec/common/chip_chipregs.h
+++ b/soc/ite/ec/common/chip_chipregs.h
@@ -615,7 +615,7 @@ struct ep_ext_regs_9x {
 };
 
 /* From BXh to BDh are EP FIFO 1-3 Control 0/1 Registers, and their
- * definitions as as follows:
+ * definitions as follows:
  * B8h: EP_FIFO1_CONTROL0_REG
  * B9h: EP_FIFO1_CONTROL1_REG
  * BAh: EP_FIFO2_CONTROL0_REG
@@ -657,7 +657,7 @@ struct ep_ext_regs_bx {
 
 
 /* From D6h to DDh are EP Extended Control Registers, and their
- * definitions as as follows:
+ * definitions as follows:
  * D6h: EP0_EXT_CTRL1
  * D7h: EP0_EXT_CTRL2
  * D8h: EP1_EXT_CTRL1

--- a/subsys/bluetooth/audio/shell/media_controller.c
+++ b/subsys/bluetooth/audio/shell/media_controller.c
@@ -603,7 +603,7 @@ static int cmd_media_read_playback_speed(const struct shell *sh, size_t argc, ch
 	int err = media_proxy_ctrl_get_playback_speed(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Playback speed get get failed (%d)", err);
+		shell_error(ctx_shell, "Playback speed get failed (%d)", err);
 	}
 
 	return err;

--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -1543,7 +1543,7 @@ static void ticks_to_expire_prep(struct ticker_node *ticker,
  *
  * @details Calculates whether the remainder should increments expiration time
  * for above-microsecond precision counter HW. The remainder enables improved
- * ticker precision, but is disabled for for sub-microsecond precision
+ * ticker precision, but is disabled for sub-microsecond precision
  * configurations.
  * Note: This is the same functionality as ticker_remainder_inc(), except this
  * function allows doing the calculation without modifying any tickers
@@ -1574,7 +1574,7 @@ static inline uint8_t ticker_add_to_remainder(uint32_t *remainder, uint32_t to_a
  *
  * @details Calculates whether the remainder should increments expiration time
  * for above-microsecond precision counter HW. The remainder enables improved
- * ticker precision, but is disabled for for sub-microsecond precision
+ * ticker precision, but is disabled for sub-microsecond precision
  * configurations.
  *
  * @param ticker Pointer to ticker node
@@ -1592,7 +1592,7 @@ static uint8_t ticker_remainder_inc(struct ticker_node *ticker)
  *
  * @details Calculates whether the remainder should decrements expiration time
  * for above-microsecond precision counter HW. The remainder enables improved
- * ticker precision, but is disabled for for sub-microsecond precision
+ * ticker precision, but is disabled for sub-microsecond precision
  * configurations.
  *
  * @param ticker Pointer to ticker node

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -765,7 +765,7 @@ config BT_SCAN_WITH_IDENTITY
 	  always use a non-resolvable private address (NRPA) in order to avoid
 	  disclosing local identity information. By not scanning with the
 	  identity address the scanner will receive directed advertise reports
-	  for for the local identity. If this use case is required, then enable
+	  for the local identity. If this use case is required, then enable
 	  this option.
 
 config BT_SCAN_AND_INITIATE_IN_PARALLEL

--- a/subsys/lorawan/services/clock_sync.c
+++ b/subsys/lorawan/services/clock_sync.c
@@ -23,7 +23,7 @@ LOG_MODULE_REGISTER(lorawan_clock_sync, CONFIG_LORAWAN_SERVICES_LOG_LEVEL);
  * Version of LoRaWAN Application Layer Clock Synchronization Specification
  *
  * This implementation only supports TS003-2.0.0, as the previous revision TS003-1.0.0
- * requested to temporarily disable ADR and and set nb_trans to 1. This causes issues on the
+ * requested to temporarily disable ADR and set nb_trans to 1. This causes issues on the
  * server side and is not recommended anymore.
  */
 #define CLOCK_SYNC_PACKAGE_VERSION 2

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
@@ -186,7 +186,7 @@ img_mgmt_flash_area_id(int slot)
  * find any unused and non-active available (auto-select); any other positive
  * value is direct (slot + 1) to be used; if checks are positive, then area
  * ID is returned, -1 is returned otherwise.
- * Note that auto-selection is performed only between two two first slots.
+ * Note that auto-selection is performed only between the two first slots.
  */
 static int img_mgmt_get_unused_slot_area_id(int slot)
 {

--- a/subsys/mgmt/osdp/src/osdp_pd.c
+++ b/subsys/mgmt/osdp/src/osdp_pd.c
@@ -700,7 +700,7 @@ static int pd_build_reply(struct osdp_pd *pd, uint8_t *buf, int max_len)
 		}
 		/**
 		 * If COMSET succeeds, the PD must reply with the old params and
-		 * then switch to the new params from then then on. We have the
+		 * then switch to the new params from then on. We have the
 		 * new params in the commands struct that we just enqueued so
 		 * we can peek at tail of command queue and set that to
 		 * pd->addr/pd->baud_rate.

--- a/subsys/mgmt/osdp/src/osdp_sc.c
+++ b/subsys/mgmt/osdp/src/osdp_sc.c
@@ -92,7 +92,7 @@ void osdp_compute_cp_cryptogram(struct osdp_pd *pd)
 /**
  * Like memcmp; but operates at constant time.
  *
- * Returns 0 if memory pointed to by s1 and and s2 are identical; non-zero
+ * Returns 0 if memory pointed to by s1 and s2 are identical; non-zero
  * otherwise.
  */
 static int osdp_ct_compare(const void *s1, const void *s2, size_t len)

--- a/subsys/net/l2/ethernet/vlan.c
+++ b/subsys/net/l2/ethernet/vlan.c
@@ -190,7 +190,7 @@ static struct vlan_context *get_vlan(struct net_if *iface,
 		goto out;
 	}
 
-	/* If the interface is virtual, then it should be be the VLAN one.
+	/* If the interface is virtual, then it should be the VLAN one.
 	 * Just get the Ethernet interface it points to get the context.
 	 */
 	ctx = get_vlan_ctx(net_virtual_get_iface(iface), vlan_tag, false);

--- a/subsys/random/Kconfig
+++ b/subsys/random/Kconfig
@@ -113,7 +113,7 @@ config CTR_DRBG_CSPRNG_GENERATOR
 	help
 	  Enables the CTR-DRBG pseudo-random number generator. This CSPRNG
 	  shall use the entropy API for an initialization seed. The CTR-DRBG
-	  is a a FIPS140-2 recommended cryptographically secure random number
+	  is a FIPS140-2 recommended cryptographically secure random number
 	  generator.
 
 endchoice # CSPRNG_GENERATOR_CHOICE

--- a/subsys/usb/device/usb_device.c
+++ b/subsys/usb/device/usb_device.c
@@ -1446,7 +1446,7 @@ int usb_wakeup_request(void)
 /*
  * The functions class_handler(), custom_handler() and vendor_handler()
  * go through the interfaces one after the other and compare the
- * bInterfaceNumber with the wIndex and and then call the appropriate
+ * bInterfaceNumber with the wIndex and then call the appropriate
  * callback of the USB function.
  * Note, a USB function can have more than one interface and the
  * request does not have to be directed to the first interface (unlikely).

--- a/tests/bluetooth/df/connectionless_cte_chains/src/common.c
+++ b/tests/bluetooth/df/connectionless_cte_chains/src/common.c
@@ -253,7 +253,7 @@ void common_release_per_adv_chain(struct ll_adv_set *adv_set)
 /*
  * @brief Helper function that validates content of periodic advertising PDU.
  *
- * The function verifies if content of periodic advertising PDU as as expected. The function
+ * The function verifies if content of periodic advertising PDU as expected. The function
  * verifies two types of PDUs: AUX_SYNC_IND and AUX_CHAIN_IND. AUX_CHAIN_IND is validated
  * as if its superior PDU is AUX_SYNC_IND only.
  *

--- a/tests/bsim/bluetooth/mesh/src/test_sar.c
+++ b/tests/bsim/bluetooth/mesh/src/test_sar.c
@@ -305,7 +305,7 @@ static const struct bst_test_instance test_sar[] = {
 	TEST_CASE(cli, max_len_sdu_slow_send,
 		  "Send a 32-segment message with SAR configured with slowest timings."),
 	TEST_CASE(srv, max_len_sdu_slow_receive,
-		  "Receive a 32-segment message with with SAR configured with slowest timings."),
+		  "Receive a 32-segment message with SAR configured with slowest timings."),
 
 	BSTEST_END_MARKER};
 

--- a/tests/kernel/common/src/irq_offload.c
+++ b/tests/kernel/common/src/irq_offload.c
@@ -116,7 +116,7 @@ ZTEST(common_1cpu, test_nested_irq_offload)
 	/* Do this in a thread to exercise a regression case: the
 	 * offload handler will suspend the thread it interrupted,
 	 * ensuring that the interrupt returns back to this thread and
-	 * effects a context switch of of the nested interrupt (see
+	 * effects a context switch of the nested interrupt (see
 	 * #45779).  Requires that this be a 1cpu test case,
 	 * obviously.
 	 */

--- a/tests/kernel/fifo/fifo_usage/src/main.c
+++ b/tests/kernel/fifo/fifo_usage/src/main.c
@@ -20,7 +20,7 @@
  * Scenario #2
  * Test Thread enters an item into fifo2, starts a Child Thread and
  * extract an item from fifo1 once the item is there.  The Child Thread
- * will extract an item from fifo2 once the item is there and and enter
+ * will extract an item from fifo2 once the item is there and enter
  * an item to fifo1.  The flow of control goes from Test Thread to
  * Child Thread and so forth.
  *
@@ -175,7 +175,7 @@ ZTEST(fifo_usage, test_single_fifo_play)
  * @brief Tests dual fifo get and put operation in thread context
  * @details test Thread enters an item into fifo2, starts a Child Thread and
  * extract an item from fifo1 once the item is there.  The Child Thread
- * will extract an item from fifo2 once the item is there and and enter
+ * will extract an item from fifo2 once the item is there and enter
  * an item to fifo1.  The flow of control goes from Test Thread to
  * Child Thread and so forth.
  * @see k_fifo_get(), k_fifo_is_empty(), k_fifo_put(), #K_FIFO_DEFINE(x)

--- a/tests/kernel/sched/deadline/src/main.c
+++ b/tests/kernel/sched/deadline/src/main.c
@@ -20,7 +20,7 @@ K_THREAD_STACK_ARRAY_DEFINE(worker_stacks, NUM_THREADS, STACK_SIZE);
 
 int thread_deadlines[NUM_THREADS];
 
-/* The number of worker threads that ran, and and array of their
+/* The number of worker threads that ran, and array of their
  * indices in execution order
  */
 int n_exec;

--- a/tests/kernel/stack/stack/src/main.c
+++ b/tests/kernel/stack/stack/src/main.c
@@ -20,7 +20,7 @@
  * Scenario #2
  * Test thread enters an item into stack2, starts a Child thread and
  * extract an item from stack1 once the item is there. The child thread
- * will extract an item from stack2 once the item is there and and enter
+ * will extract an item from stack2 once the item is there and enter
  * an item to stack1. The flow of control goes from Test thread to Child
  * thread and so forth.
  *

--- a/tests/kernel/xip/src/main.c
+++ b/tests/kernel/xip/src/main.c
@@ -13,7 +13,7 @@
  *
  * @details This module tests that XIP performs as expected. If the first
  * task is even activated that is a good indication that XIP is
- * working. However, the test does do some some testing on
+ * working. However, the test does do some testing on
  * global variables for completeness sake.
  *
  * @{

--- a/tests/subsys/pm/power_domain/src/main.c
+++ b/tests/subsys/pm/power_domain/src/main.c
@@ -294,7 +294,7 @@ ZTEST(power_domain_1cpu, test_on_power_domain)
 	pm_device_power_domain_add(devc, domain);
 	zassert_true(pm_device_on_power_domain(devc), "devc is not in the power domain.");
 	pm_device_power_domain_remove(devc, domain);
-	zassert_false(pm_device_on_power_domain(devc), "devc in in the power domain.");
+	zassert_false(pm_device_on_power_domain(devc), "devc in the power domain.");
 }
 
 ZTEST_SUITE(power_domain_1cpu, NULL, NULL, ztest_simple_1cpu_before,


### PR DESCRIPTION
``` python
import os
import re

common_words = set([
    'about', 'after', 'all', 'also', 'an', 'and',
     'any', 'are', 'as', 'at',
    'be', 'because', 'but', 'by', 'can', 'come',
    'could', 'day', 'do', 'even',
    'first', 'for', 'get', 'give', 'go', 'has',
    'have', 'he', 'her',
    'him', 'his', 'how', 'I', 'in', 'into', 'it',
    'its', 'just',
    'know', 'like', 'look', 'make', 'man', 'many',
    'me', 'more', 'my', 'new',
    'no', 'not', 'now', 'of', 'one', 'only', 'or',
    'other', 'our', 'out',
    'over', 'people', 'say', 'see', 'she', 'so',
    'some', 'take', 'tell', 'than',
    'their', 'them', 'then', 'there', 'these',
    'they', 'think',
    'this', 'time', 'two', 'up', 'use', 'very',
    'want', 'was', 'way',
    'we', 'well', 'what', 'when', 'which', 'who',
    'will', 'with', 'would',
    'year', 'you', 'your'
])

valid_extensions = set([
    'c', 'h', 'yaml', 'cmake', 'conf', 'txt', 'overlay', 'rst', 'dtsi',
    'Kconfig', 'dts', 'defconfig', 'yml', 'ld', 'sh', 'py', 'soc', 'cfg'
])

def filter_repeated_words(text):
    # Split the text into lines
    lines = text.split('\n')

    # Combine lines into a single string with unique separator
    combined_text = '/*sep*/'.join(lines)

    # Replace repeated words within a line
    def replace_within_line(match):
        return match.group(1)

    # Regex for matching repeated words within a line
    within_line_pattern = re.compile(r'\b(' + '|'.join(map(re.escape, common_words)) + r')\b\s+\b\1\b')
    combined_text = within_line_pattern.sub(replace_within_line, combined_text)

    # Replace repeated words across line boundaries
    def replace_across_lines(match):
        return match.group(1) + match.group(2)

    # Regex for matching repeated words across line boundaries
    across_lines_pattern = re.compile(r'\b(' + '|'.join(map(re.escape, common_words)) + r')\b(\s*[*\/\n\s]*)\b\1\b')
    combined_text = across_lines_pattern.sub(replace_across_lines, combined_text)

    # Split the text back into lines
    filtered_text = combined_text.split('/*sep*/')

    return '\n'.join(filtered_text)

def process_file(file_path):
    with open(file_path, 'r', encoding='utf-8') as file:
        text = file.read()

    new_text = filter_repeated_words(text)

    with open(file_path, 'w', encoding='utf-8') as file:
        file.write(new_text)

def process_directory(directory_path):
    for root, dirs, files in os.walk(directory_path):
        dirs[:] = [d for d in dirs if not d.startswith('.')]
        for file in files:
            # Filter out hidden files
            if file.startswith('.'):
                continue
            file_extension = file.split('.')[-1]
            if file_extension in valid_extensions:  # 只处理指定后缀的文件
                file_path = os.path.join(root, file)
                print(f"Processed file: {file_path}")
                process_file(file_path)

directory_to_process = "/home/mi/works/github/zephyrproject/zephyr"
process_directory(directory_to_process)
```