### PR TITLE
Hard fault on CMUX release if trying to open DLCI

### DIFF
--- a/include/zephyr/modem/cmux.h
+++ b/include/zephyr/modem/cmux.h
@@ -139,6 +139,10 @@ struct modem_cmux {
 	enum modem_cmux_state state;
 	bool flow_control_on;
 
+	/* Work lock */
+	bool attached;
+	struct k_spinlock work_lock;
+
 	/* Receive state*/
 	enum modem_cmux_receive_state receive_state;
 

--- a/subsys/modem/modem_cmux.c
+++ b/subsys/modem/modem_cmux.c
@@ -1068,30 +1068,51 @@ static void modem_cmux_dlci_advertise_receive_buf_stat(struct modem_cmux_dlci *d
 static int modem_cmux_dlci_pipe_api_open(void *data)
 {
 	struct modem_cmux_dlci *dlci = (struct modem_cmux_dlci *)data;
+	struct modem_cmux *cmux = dlci->cmux;
+	int ret = 0;
 
-	if (k_work_delayable_is_pending(&dlci->open_work) == true) {
-		return -EBUSY;
+	K_SPINLOCK(&cmux->work_lock) {
+		if (!cmux->attached) {
+			ret = -EPERM;
+			K_SPINLOCK_BREAK;
+		}
+
+		if (k_work_delayable_is_pending(&dlci->open_work) == true) {
+			ret = -EBUSY;
+			K_SPINLOCK_BREAK;
+		}
+
+		k_work_schedule(&dlci->open_work, K_NO_WAIT);
 	}
 
-	k_work_schedule(&dlci->open_work, K_NO_WAIT);
-	return 0;
+	return ret;
 }
 
 static int modem_cmux_dlci_pipe_api_transmit(void *data, const uint8_t *buf, size_t size)
 {
 	struct modem_cmux_dlci *dlci = (struct modem_cmux_dlci *)data;
 	struct modem_cmux *cmux = dlci->cmux;
+	int ret;
 
-	struct modem_cmux_frame frame = {
-		.dlci_address = dlci->dlci_address,
-		.cr = true,
-		.pf = false,
-		.type = MODEM_CMUX_FRAME_TYPE_UIH,
-		.data = buf,
-		.data_len = size,
-	};
+	K_SPINLOCK(&cmux->work_lock) {
+		if (!cmux->attached) {
+			ret = -EPERM;
+			K_SPINLOCK_BREAK;
+		}
 
-	return modem_cmux_transmit_data_frame(cmux, &frame);
+		struct modem_cmux_frame frame = {
+			.dlci_address = dlci->dlci_address,
+			.cr = true,
+			.pf = false,
+			.type = MODEM_CMUX_FRAME_TYPE_UIH,
+			.data = buf,
+			.data_len = size,
+		};
+
+		ret = modem_cmux_transmit_data_frame(cmux, &frame);
+	}
+
+	return ret;
 }
 
 static int modem_cmux_dlci_pipe_api_receive(void *data, uint8_t *buf, size_t size)
@@ -1113,13 +1134,24 @@ static int modem_cmux_dlci_pipe_api_receive(void *data, uint8_t *buf, size_t siz
 static int modem_cmux_dlci_pipe_api_close(void *data)
 {
 	struct modem_cmux_dlci *dlci = (struct modem_cmux_dlci *)data;
+	struct modem_cmux *cmux = dlci->cmux;
+	int ret = 0;
 
-	if (k_work_delayable_is_pending(&dlci->close_work) == true) {
-		return -EBUSY;
+	K_SPINLOCK(&cmux->work_lock) {
+		if (!cmux->attached) {
+			ret = -EPERM;
+			K_SPINLOCK_BREAK;
+		}
+
+		if (k_work_delayable_is_pending(&dlci->close_work) == true) {
+			ret = -EBUSY;
+			K_SPINLOCK_BREAK;
+		}
+
+		k_work_schedule(&dlci->close_work, K_NO_WAIT);
 	}
 
-	k_work_schedule(&dlci->close_work, K_NO_WAIT);
-	return 0;
+	return ret;
 }
 
 struct modem_pipe_api modem_cmux_dlci_pipe_api = {
@@ -1185,14 +1217,17 @@ static void modem_cmux_dlci_close_handler(struct k_work *item)
 	k_work_schedule(&dlci->close_work, MODEM_CMUX_T1_TIMEOUT);
 }
 
-static void modem_cmux_dlci_pipes_notify_closed(struct modem_cmux *cmux)
+static void modem_cmux_dlci_pipes_release(struct modem_cmux *cmux)
 {
 	sys_snode_t *node;
 	struct modem_cmux_dlci *dlci;
+	struct k_work_sync sync;
 
 	SYS_SLIST_FOR_EACH_NODE(&cmux->dlcis, node) {
 		dlci = (struct modem_cmux_dlci *)node;
 		modem_pipe_notify_closed(&dlci->pipe);
+		k_work_cancel_delayable_sync(&dlci->open_work, &sync);
+		k_work_cancel_delayable_sync(&dlci->close_work, &sync);
 	}
 }
 
@@ -1257,10 +1292,19 @@ struct modem_pipe *modem_cmux_dlci_init(struct modem_cmux *cmux, struct modem_cm
 
 int modem_cmux_attach(struct modem_cmux *cmux, struct modem_pipe *pipe)
 {
+	if (cmux->pipe != NULL) {
+		return -EALREADY;
+	}
+
 	cmux->pipe = pipe;
 	ring_buf_reset(&cmux->transmit_rb);
 	cmux->receive_state = MODEM_CMUX_RECEIVE_STATE_SOF;
 	modem_pipe_attach(cmux->pipe, modem_cmux_bus_callback, cmux);
+
+	K_SPINLOCK(&cmux->work_lock) {
+		cmux->attached = true;
+	}
+
 	return 0;
 }
 
@@ -1283,17 +1327,26 @@ int modem_cmux_connect(struct modem_cmux *cmux)
 
 int modem_cmux_connect_async(struct modem_cmux *cmux)
 {
-	__ASSERT_NO_MSG(cmux->pipe != NULL);
+	int ret;
 
 	if (k_event_test(&cmux->event, MODEM_CMUX_EVENT_CONNECTED_BIT)) {
 		return -EALREADY;
 	}
 
-	if (k_work_delayable_is_pending(&cmux->connect_work) == false) {
-		k_work_schedule(&cmux->connect_work, K_NO_WAIT);
+	K_SPINLOCK(&cmux->work_lock) {
+		if (!cmux->attached) {
+			ret = -EPERM;
+			K_SPINLOCK_BREAK;
+		}
+
+		if (k_work_delayable_is_pending(&cmux->connect_work) == false) {
+			k_work_schedule(&cmux->connect_work, K_NO_WAIT);
+		}
+
+		ret = 0;
 	}
 
-	return 0;
+	return ret;
 }
 
 int modem_cmux_disconnect(struct modem_cmux *cmux)
@@ -1304,6 +1357,7 @@ int modem_cmux_disconnect(struct modem_cmux *cmux)
 	if (ret < 0) {
 		return ret;
 	}
+
 	if (k_event_wait(&cmux->event, MODEM_CMUX_EVENT_DISCONNECTED_BIT, false,
 			 MODEM_CMUX_T2_TIMEOUT) == 0) {
 		return -EAGAIN;
@@ -1314,25 +1368,40 @@ int modem_cmux_disconnect(struct modem_cmux *cmux)
 
 int modem_cmux_disconnect_async(struct modem_cmux *cmux)
 {
-	__ASSERT_NO_MSG(cmux->pipe != NULL);
+	int ret = 0;
 
 	if (k_event_test(&cmux->event, MODEM_CMUX_EVENT_DISCONNECTED_BIT)) {
 		return -EALREADY;
 	}
 
-	if (k_work_delayable_is_pending(&cmux->disconnect_work) == false) {
-		k_work_schedule(&cmux->disconnect_work, K_NO_WAIT);
+	K_SPINLOCK(&cmux->work_lock) {
+		if (!cmux->attached) {
+			ret = -EPERM;
+			K_SPINLOCK_BREAK;
+		}
+
+		if (k_work_delayable_is_pending(&cmux->disconnect_work) == false) {
+			k_work_schedule(&cmux->disconnect_work, K_NO_WAIT);
+		}
 	}
 
-	return 0;
+	return ret;
 }
 
 void modem_cmux_release(struct modem_cmux *cmux)
 {
 	struct k_work_sync sync;
 
-	/* Close DLCI pipes */
-	modem_cmux_dlci_pipes_notify_closed(cmux);
+	if (cmux->pipe == NULL) {
+		return;
+	}
+
+	K_SPINLOCK(&cmux->work_lock) {
+		cmux->attached = false;
+	}
+
+	/* Close DLCI pipes and cancel DLCI work */
+	modem_cmux_dlci_pipes_release(cmux);
 
 	/* Release bus pipe */
 	if (cmux->pipe) {


### PR DESCRIPTION
This PR extends the modem CMUX test suite and patches the modem CMUX module to ensure that modem CMUX release stops any and all work, and prevents any new work from being started before the modem is attached to a pipe again.

fixes: #74708