### PR TITLE
hal_nordic: Rework build-time allocation of PPI channels

### DIFF
--- a/modules/hal_nordic/nrfx/CMakeLists.txt
+++ b/modules/hal_nordic/nrfx/CMakeLists.txt
@@ -196,3 +196,6 @@ mdk_svd_ifdef(CONFIG_SOC_NRF54L15_ENGA_CPUAPP nrf54l15_enga_application.svd)
 mdk_svd_ifdef(CONFIG_SOC_NRF54L15_ENGA_CPUFLPR nrf54l15_enga_flpr.svd)
 mdk_svd_ifdef(CONFIG_SOC_NRF9120              nrf9120.svd)
 mdk_svd_ifdef(CONFIG_SOC_NRF9160              nrf9160.svd)
+
+include(reserve_ppi.cmake)
+register_function_finalize_ppi_reservations()

--- a/modules/hal_nordic/nrfx/nrfx_glue.h
+++ b/modules/hal_nordic/nrfx/nrfx_glue.h
@@ -314,93 +314,30 @@ void nrfx_busy_wait(uint32_t usec_to_wait);
 
 /*------------------------------------------------------------------------------*/
 
+/* This header is generated at build-time by reserve_ppi.cmake
+ *
+ * It defines `CMAKE_GEN_PPI_RESERVED_CHANNELS` and `CMAKE_GEN_PPI_RESERVED_GROUPS`
+ */
+#include <ppi_reserved.h>
+
+/* FIXME: use the cmake module for in-tree too: CTLR & radio driver */
+
 /** @brief Bitmask that defines DPPI channels that are reserved for use outside of the nrfx library. */
-#define NRFX_DPPI_CHANNELS_USED   (NRFX_PPI_CHANNELS_USED_BY_BT_CTLR |    \
-				   NRFX_PPI_CHANNELS_USED_BY_802154_DRV | \
-				   NRFX_PPI_CHANNELS_USED_BY_MPSL)
+#define NRFX_DPPI_CHANNELS_USED   CMAKE_GEN_PPI_RESERVED_CHANNELS
 
 /** @brief Bitmask that defines DPPI groups that are reserved for use outside of the nrfx library. */
-#define NRFX_DPPI_GROUPS_USED     (NRFX_PPI_GROUPS_USED_BY_BT_CTLR |    \
-				   NRFX_PPI_GROUPS_USED_BY_802154_DRV | \
-				   NRFX_PPI_GROUPS_USED_BY_MPSL)
+#define NRFX_DPPI_GROUPS_USED     CMAKE_GEN_PPI_RESERVED_GROUPS
 
 /** @brief Bitmask that defines PPI channels that are reserved for use outside of the nrfx library. */
-#define NRFX_PPI_CHANNELS_USED    (NRFX_PPI_CHANNELS_USED_BY_BT_CTLR |    \
-				   NRFX_PPI_CHANNELS_USED_BY_802154_DRV | \
-				   NRFX_PPI_CHANNELS_USED_BY_MPSL)
+#define NRFX_PPI_CHANNELS_USED    CMAKE_GEN_PPI_RESERVED_CHANNELS
 
 /** @brief Bitmask that defines PPI groups that are reserved for use outside of the nrfx library. */
-#define NRFX_PPI_GROUPS_USED      (NRFX_PPI_GROUPS_USED_BY_BT_CTLR |    \
-				   NRFX_PPI_GROUPS_USED_BY_802154_DRV | \
-				   NRFX_PPI_GROUPS_USED_BY_MPSL)
+#define NRFX_PPI_GROUPS_USED      CMAKE_GEN_PPI_RESERVED_GROUPS
 
 /** @brief Bitmask that defines GPIOTE130 channels reserved for use outside of the nrfx library. */
 #define NRFX_GPIOTE130_CHANNELS_USED \
 	(~NRFX_CONFIG_MASK_DT(DT_NODELABEL(gpiote130), owned_channels) | \
 	 NRFX_CONFIG_MASK_DT(DT_NODELABEL(gpiote130), child_owned_channels))
-
-
-#if defined(CONFIG_BT_CTLR)
-/*
- * The enabled Bluetooth controller subsystem is responsible for providing
- * definitions of the BT_CTLR_USED_* symbols used below in a file named
- * bt_ctlr_used_resources.h and for adding its location to global include
- * paths so that the file can be included here for all Zephyr libraries that
- * are to be built.
- */
-#include <bt_ctlr_used_resources.h>
-#define NRFX_PPI_CHANNELS_USED_BY_BT_CTLR    BT_CTLR_USED_PPI_CHANNELS
-#define NRFX_PPI_GROUPS_USED_BY_BT_CTLR      BT_CTLR_USED_PPI_GROUPS
-#else
-#define NRFX_PPI_CHANNELS_USED_BY_BT_CTLR    0
-#define NRFX_PPI_GROUPS_USED_BY_BT_CTLR      0
-#endif
-
-#if defined(CONFIG_NRF_802154_RADIO_DRIVER)
-#if defined(NRF52_SERIES)
-#include <../src/nrf_802154_peripherals_nrf52.h>
-#define NRFX_PPI_CHANNELS_USED_BY_802154_DRV   NRF_802154_PPI_CHANNELS_USED_MASK
-#define NRFX_PPI_GROUPS_USED_BY_802154_DRV     NRF_802154_PPI_GROUPS_USED_MASK
-#elif defined(NRF53_SERIES)
-#include <../src/nrf_802154_peripherals_nrf53.h>
-#define NRFX_PPI_CHANNELS_USED_BY_802154_DRV   NRF_802154_DPPI_CHANNELS_USED_MASK
-#define NRFX_PPI_GROUPS_USED_BY_802154_DRV     NRF_802154_DPPI_GROUPS_USED_MASK
-#elif defined(NRF54L_SERIES)
-#include <../src/nrf_802154_peripherals_nrf54l.h>
-#define NRFX_PPI_CHANNELS_USED_BY_802154_DRV   NRF_802154_DPPI_CHANNELS_USED_MASK
-#define NRFX_PPI_GROUPS_USED_BY_802154_DRV     NRF_802154_DPPI_GROUPS_USED_MASK
-#elif defined(NRF54H_SERIES)
-#include <../src/nrf_802154_peripherals_nrf54h.h>
-#define NRFX_PPI_CHANNELS_USED_BY_802154_DRV   NRF_802154_DPPI_CHANNELS_USED_MASK
-#define NRFX_PPI_GROUPS_USED_BY_802154_DRV     NRF_802154_DPPI_GROUPS_USED_MASK
-#else
-#error Unsupported chip family
-#endif
-#else // CONFIG_NRF_802154_RADIO_DRIVER
-#define NRFX_PPI_CHANNELS_USED_BY_802154_DRV   0
-#define NRFX_PPI_GROUPS_USED_BY_802154_DRV     0
-#endif // CONFIG_NRF_802154_RADIO_DRIVER
-
-#if defined(CONFIG_NRF_802154_RADIO_DRIVER) && !defined(CONFIG_NRF_802154_SL_OPENSOURCE)
-#include <mpsl.h>
-#define NRFX_PPI_CHANNELS_USED_BY_MPSL   MPSL_RESERVED_PPI_CHANNELS
-#define NRFX_PPI_GROUPS_USED_BY_MPSL     0
-#else
-#define NRFX_PPI_CHANNELS_USED_BY_MPSL   0
-#define NRFX_PPI_GROUPS_USED_BY_MPSL     0
-#endif
-
-#if defined(NRF_802154_VERIFY_PERIPHS_ALLOC_AGAINST_MPSL)
-BUILD_ASSERT(
-	(NRFX_PPI_CHANNELS_USED_BY_802154_DRV & NRFX_PPI_CHANNELS_USED_BY_MPSL) == 0,
-	"PPI channels used by the IEEE802.15.4 radio driver overlap with those "
-	"assigned to the MPSL.");
-
-BUILD_ASSERT(
-	(NRFX_PPI_GROUPS_USED_BY_802154_DRV & NRFX_PPI_GROUPS_USED_BY_MPSL) == 0,
-	"PPI groups used by the IEEE802.15.4 radio driver overlap with those "
-	"assigned to the MPSL.");
-#endif // NRF_802154_VERIFY_PERIPHS_ALLOC_AGAINST_MPSL
 
 /** @brief Bitmask that defines EGU instances that are reserved for use outside of the nrfx library. */
 #define NRFX_EGUS_USED            0

--- a/modules/hal_nordic/nrfx/reserve_ppi.cmake
+++ b/modules/hal_nordic/nrfx/reserve_ppi.cmake
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Function to add PPI reservations
+function(reserve_ppi module_name channels groups)
+  # Since cmake doesn't support maps or list-of-lists, we make our own poor
+  # man's version of a list-of-lists.
+  #
+  # We escape the ";" element delimiter with "," in order to later iterate on
+  # the top-level list and extract the PPIs for each module.
+  #
+  # Similarly, the channel and group lists are separated using ":", and
+  # extracted later with a regex.
+  string(REPLACE ";" "," channels_escaped_list "${channels}")
+  string(REPLACE ";" "," groups_escaped_list "${groups}")
+  message(DEBUG "Reserve PPIs: chans [${channels_escaped_list}] groups [${groups_escaped_list}] for ${module_name}")
+
+  set_property(GLOBAL APPEND PROPERTY PPI_MODULE_MAP "${module_name},${channels_escaped_list}:${groups_escaped_list}")
+endfunction()
+
+function(finalize_ppi_reservations)
+  # Retrieve the concatenated list of modules and their reserved PPI channels/groups
+  get_property(PPI_MODULE_MAP GLOBAL PROPERTY PPI_MODULE_MAP)
+
+  set(PPI_CHANNELS_LIST "")
+  set(PPI_GROUPS_LIST "")
+  set(PPI_INFO_MESSAGE "")
+
+  foreach(MODULE IN LISTS PPI_MODULE_MAP)
+    string(REPLACE "," ";" MODULE_ENTRY "${MODULE}")
+
+    # Pop the module's name from the list
+    list(GET MODULE_ENTRY 0 MODULE_NAME)
+    list(REMOVE_AT MODULE_ENTRY 0)
+
+    # Extract channel and group lists
+    string(REGEX MATCH ".*:" CHANNELS "${MODULE_ENTRY}")
+    string(REPLACE ":" "" CHANNELS "${CHANNELS}")
+    string(REGEX MATCH ":.*" GROUPS "${MODULE_ENTRY}")
+    string(REPLACE ":" "" GROUPS "${GROUPS}")
+
+    message(DEBUG "module: ${MODULE_NAME} chans ${CHANNELS} groups ${GROUPS}")
+
+    # Detect if channels are not already reserved
+    foreach(item IN LISTS CHANNELS)
+      list(FIND PPI_CHANNELS_LIST ${item} index)
+      if(${index} GREATER -1)
+        message(STATUS "Reserved PPIs: ${PPI_INFO_MESSAGE}")
+        message(FATAL_ERROR "${MODULE_NAME} takes already reserved channel ${item}")
+      endif()
+    endforeach()
+
+    # Detect if groups are not already reserved
+    foreach(item IN LISTS GROUPS)
+      list(FIND PPI_GROUPS_LIST ${item} index)
+      if(${index} GREATER -1)
+        message(STATUS "Reserved PPIs: ${PPI_INFO_MESSAGE}")
+        message(FATAL_ERROR "${MODULE_NAME} takes group ${item} but is already reserved")
+      endif()
+    endforeach()
+
+    # Append the PPIs to the reserved list
+    list(APPEND PPI_CHANNELS_LIST ${CHANNELS})
+    list(APPEND PPI_GROUPS_LIST ${GROUPS})
+
+    # Pretty-print the lists for user transparency
+    string(REPLACE ";" ", " PRINT_CHANNELS "${CHANNELS}")
+    string(REPLACE ";" ", " PRINT_GROUPS "${GROUPS}")
+    set(PPI_INFO_MESSAGE
+      "${PPI_INFO_MESSAGE} ${MODULE_NAME}: channels [${PRINT_CHANNELS}] groups [${PRINT_GROUPS}]")
+  endforeach()
+
+  # Display the info message
+  message(STATUS "Reserved PPIs: ${PPI_INFO_MESSAGE}")
+
+  # Convert the list of numbers to a bitfield expression
+  set(PPI_CHANNELS_DEFINE "0 ")
+  foreach(NUMBER IN LISTS PPI_CHANNELS_LIST)
+    if(PPI_CHANNELS_DEFINE)
+      set(PPI_CHANNELS_DEFINE "${PPI_CHANNELS_DEFINE} | ")
+    endif()
+    set(PPI_CHANNELS_DEFINE "${PPI_CHANNELS_DEFINE}BIT(${NUMBER})")
+  endforeach()
+
+  set(PPI_GROUPS_DEFINE "0 ")
+  foreach(NUMBER IN LISTS PPI_GROUPS_LIST)
+    if(PPI_GROUPS_DEFINE)
+      set(PPI_GROUPS_DEFINE "${PPI_GROUPS_DEFINE} | ")
+    endif()
+    set(PPI_GROUPS_DEFINE "${PPI_GROUPS_DEFINE}BIT(${NUMBER})")
+  endforeach()
+
+  # Generate the header used by nrfx_glue.h
+  file(WRITE ${CMAKE_BINARY_DIR}/zephyr/include/generated/ppi_reserved.h "
+    #pragma once
+
+    #include <zephyr/sys/util_macro.h>
+
+    #define CMAKE_GEN_PPI_RESERVED_CHANNELS (${PPI_CHANNELS_DEFINE})
+    #define CMAKE_GEN_PPI_RESERVED_GROUPS (${PPI_GROUPS_DEFINE})
+    ")
+endfunction()
+
+function(register_function_finalize_ppi_reservations)
+  # Defer the call to finalize_ppi_reservations until the end of the configure stage
+  # This should only be called once.
+  cmake_language(DEFER DIRECTORY ${CMAKE_SOURCE_DIR} CALL finalize_ppi_reservations)
+endfunction()

--- a/subsys/bluetooth/CMakeLists.txt
+++ b/subsys/bluetooth/CMakeLists.txt
@@ -13,6 +13,11 @@ add_subdirectory_ifdef(CONFIG_BT_AUDIO audio)
 add_subdirectory_ifdef(CONFIG_BT_CRYPTO crypto)
 
 if(CONFIG_BT_CTLR AND CONFIG_BT_LL_SW_SPLIT)
+  include(${ZEPHYR_BASE}/modules/hal_nordic/nrfx/reserve_ppi.cmake)
+
+  set(MPSL_PPIS 4 20)
+  reserve_ppi("MPSL" "${MPSL_PPIS}" "")
+
   add_subdirectory(controller)
 endif()
 

--- a/subsys/bluetooth/controller/CMakeLists.txt
+++ b/subsys/bluetooth/controller/CMakeLists.txt
@@ -217,3 +217,10 @@ zephyr_library_compile_options_ifdef(
   CONFIG_BT_CTLR_OPTIMIZE_FOR_SPEED
   ${OPTIMIZE_FOR_SPEED_FLAG}
   )
+
+# Reserve some PPI channels and groups
+include(${ZEPHYR_BASE}/modules/hal_nordic/nrfx/reserve_ppi.cmake)
+
+set(SDC_PPIS 13 2)
+set(SDC_PPI_GROUPS 9 5 3)
+reserve_ppi("SDC" "${SDC_PPIS}" "${SDC_PPI_GROUPS}")


### PR DESCRIPTION
This change attempts to fix issues with the current c-header-based solution for build-time reservation of PPI channels, notably:

1. modules that can reserve are hardcoded

That means upstream has to know about modules that are defined downstream only. In order to do this, either downstream Kconfig options have to be re-defined or weird checks on upstream Kconfig symbols need to be made.

Additionally, nrfx_glue.h needs to know way too much and have special logic for those modules that reserve PPIs. Having cmake spit out a ready-made list removes all of that logic.

2. Hard to debug

It took me a minute to find out where the magic defines are used, and how the reservation is done. Having a cmake function next to the library definition makes it easier to discover.

We also introduce a log message that can be useful for the final user.