### PR TITLE
everywhere: reindent `.overlay` files with tabs

### DIFF
--- a/boards/arduino/portenta_h7/arduino_portenta_h7_stm32h747xx_m7_1_0_0.overlay
+++ b/boards/arduino/portenta_h7/arduino_portenta_h7_stm32h747xx_m7_1_0_0.overlay
@@ -5,5 +5,5 @@
  */
 
 &clk_lsi {
-    status = "okay";
+	status = "okay";
 };

--- a/boards/arduino/portenta_h7/arduino_portenta_h7_stm32h747xx_m7_4_10_0.overlay
+++ b/boards/arduino/portenta_h7/arduino_portenta_h7_stm32h747xx_m7_4_10_0.overlay
@@ -5,6 +5,6 @@
  */
 
 &clk_lse {
-    clock-frequency = <32768>;
-    status = "okay";
+	clock-frequency = <32768>;
+	status = "okay";
 };

--- a/boards/renesas/da1469x_dk_pro/dts/da1469x_dk_pro_lcdc.overlay
+++ b/boards/renesas/da1469x_dk_pro/dts/da1469x_dk_pro_lcdc.overlay
@@ -8,74 +8,74 @@
  #include <zephyr/dt-bindings/display/panel.h>
 
 / {
-    chosen {
-        zephyr,display = &lcdc;
-    };
+	chosen {
+		zephyr,display = &lcdc;
+	};
 
-    lvgl_pointer {
-        input = <&display_touch>;
-        status = "okay";
-        swap-xy;
-    };
+	lvgl_pointer {
+		input = <&display_touch>;
+		status = "okay";
+		swap-xy;
+	};
 };
 
 &pinctrl {
-    i2c2_default: i2c2_default {
-        group1 {
-            pinmux = <SMARTBOND_PINMUX(I2C2_SDA, 0, 19)>,
-                <SMARTBOND_PINMUX(I2C2_SCL, 0, 18)>;
-            bias-pull-up;
-        };
-    };
+	i2c2_default: i2c2_default {
+		group1 {
+			pinmux = <SMARTBOND_PINMUX(I2C2_SDA, 0, 19)>,
+				 <SMARTBOND_PINMUX(I2C2_SCL, 0, 18)>;
+			bias-pull-up;
+		};
+	};
 
-    i2c2_sleep: i2c2_sleep {
-        group1 {
-            pinmux = <SMARTBOND_PINMUX(GPIO, 0, 19)>,
-                <SMARTBOND_PINMUX(GPIO, 0, 18)>;
-            bias-pull-up;
-        };
-    };
+	i2c2_sleep: i2c2_sleep {
+		group1 {
+			pinmux = <SMARTBOND_PINMUX(GPIO, 0, 19)>,
+				 <SMARTBOND_PINMUX(GPIO, 0, 18)>;
+			bias-pull-up;
+		};
+	};
 };
 
 &i2c2 {
-    clock-frequency = <400000>;
-    status = "okay";
+	clock-frequency = <400000>;
+	status = "okay";
 
-    display_touch: ft6206@38 {
-        compatible = "focaltech,ft5336";
-        status = "okay";
-        reg = <0x38>;
-        int-gpios = <&gpio0 31 GPIO_ACTIVE_LOW>;
-    };
+	display_touch: ft6206@38 {
+		compatible = "focaltech,ft5336";
+		status = "okay";
+		reg = <0x38>;
+		int-gpios = <&gpio0 31 GPIO_ACTIVE_LOW>;
+	};
 };
 
 &lcdc {
-    status = "okay";
-    pinctrl-0 = <&display_controller_default>;
-    pinctrl-1 = <&display_controller_sleep>;
-    pinctrl-names = "default", "sleep";
-    width = <480>;
-    height = <272>;
-    disp-gpios = <&gpio0 25 GPIO_ACTIVE_HIGH>;
-    pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+	status = "okay";
+	pinctrl-0 = <&display_controller_default>;
+	pinctrl-1 = <&display_controller_sleep>;
+	pinctrl-names = "default", "sleep";
+	width = <480>;
+	height = <272>;
+	disp-gpios = <&gpio0 25 GPIO_ACTIVE_HIGH>;
+	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
 
-    /*
-     * Panel settings for the NHD-4.3-480272EF-ASXP-CTP
-     * display panel model which integrates the SC7283
-     * driver IC.
-     */
-    display-timings {
-        compatible = "zephyr,panel-timing";
-        hsync-len = <2>;
-        hfront-porch = <2>;
-        hback-porch = <3>;
-        vsync-len = <2>;
-        vfront-porch = <2>;
-        vback-porch = <2>;
-        hsync-active = <0>;
-        vsync-active = <0>;
-        de-active = <1>;
-        pixelclk-active = <1>;
-        clock-frequency = <12000000>;
-      };
+	/*
+	 * Panel settings for the NHD-4.3-480272EF-ASXP-CTP
+	 * display panel model which integrates the SC7283
+	 * driver IC.
+	 */
+	display-timings {
+		compatible = "zephyr,panel-timing";
+		hsync-len = <2>;
+		hfront-porch = <2>;
+		hback-porch = <3>;
+		vsync-len = <2>;
+		vfront-porch = <2>;
+		vback-porch = <2>;
+		hsync-active = <0>;
+		vsync-active = <0>;
+		de-active = <1>;
+		pixelclk-active = <1>;
+		clock-frequency = <12000000>;
+	};
 };

--- a/boards/renesas/da1469x_dk_pro/dts/da1469x_dk_pro_mipi_dbi.overlay
+++ b/boards/renesas/da1469x_dk_pro/dts/da1469x_dk_pro_mipi_dbi.overlay
@@ -8,50 +8,50 @@
  #include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {
-    chosen {
-        zephyr,display = &ili9340;
-    };
+	chosen {
+		zephyr,display = &ili9340;
+	};
 
-    lvgl_pointer {
-        input = <&display_touch>;
-        status = "okay";
-        swap-xy;
-        invert-x;
-        invert-y;
-    };
+	lvgl_pointer {
+		input = <&display_touch>;
+		status = "okay";
+		swap-xy;
+		invert-x;
+		invert-y;
+	};
 };
 
 &i2c2 {
-    clock-frequency = <400000>;
-    status = "okay";
+	clock-frequency = <400000>;
+	status = "okay";
 
-    display_touch: ft6206@38 {
-        compatible = "focaltech,ft5336";
-        status = "okay";
-        reg = <0x38>;
-        int-gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
-    };
+	display_touch: ft6206@38 {
+		compatible = "focaltech,ft5336";
+		status = "okay";
+		reg = <0x38>;
+		int-gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
+	};
 };
 
 &lcdc {
-    compatible = "renesas,smartbond-mipi-dbi";
-    status = "okay";
-    reset-gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
-    pinctrl-0 = <&mipi_dbi_default>;
-    pinctrl-1 = <&mipi_dbi_read>;
-    pinctrl-2 = <&mipi_dbi_sleep>;
-    pinctrl-names = "default", "read", "sleep";
-    #address-cells = <1>;
-    #size-cells = <0>;
+	compatible = "renesas,smartbond-mipi-dbi";
+	status = "okay";
+	reset-gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+	pinctrl-0 = <&mipi_dbi_default>;
+	pinctrl-1 = <&mipi_dbi_read>;
+	pinctrl-2 = <&mipi_dbi_sleep>;
+	pinctrl-names = "default", "read", "sleep";
+	#address-cells = <1>;
+	#size-cells = <0>;
 
-    ili9340: ili9340@0 {
-        compatible = "ilitek,ili9340";
-        mipi-max-frequency = <48000000>;
-        status = "okay";
-        reg = <0>;
-        width = <240>;
-        height = <320>;
-        pixel-format = <ILI9XXX_PIXEL_FORMAT_RGB565>;
-        rotation = <0>;
-    };
+	ili9340: ili9340@0 {
+		compatible = "ilitek,ili9340";
+		mipi-max-frequency = <48000000>;
+		status = "okay";
+		reg = <0>;
+		width = <240>;
+		height = <320>;
+		pixel-format = <ILI9XXX_PIXEL_FORMAT_RGB565>;
+		rotation = <0>;
+	};
 };

--- a/boards/renesas/da1469x_dk_pro/dts/da1469x_dk_pro_psram.overlay
+++ b/boards/renesas/da1469x_dk_pro/dts/da1469x_dk_pro_psram.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- / {
+/ {
 	aliases {
 		sram-ext = &memc;
 	};

--- a/boards/shields/adafruit_data_logger/adafruit_data_logger.overlay
+++ b/boards/shields/adafruit_data_logger/adafruit_data_logger.overlay
@@ -12,17 +12,17 @@
 	leds {
 		compatible = "gpio-leds";
 		/*
-		* LED1 connection must be manually established using a jumper between
-                * pins "L1" and "Digital I/O 3".
-		*/
+		 * LED1 connection must be manually established using a jumper between
+		 * pins "L1" and "Digital I/O 3".
+		 */
 		green_led_adafruit_data_logger: led_1__adafruit_data_logger {
 			gpios = <&arduino_header 9 GPIO_ACTIVE_HIGH>; /* D3 */
 			label = "User LED1";
 		};
 		/*
-		* LED2 connection must be manually established using a jumper between
-                * pins "L2" and "Digital I/O 4".
-		*/
+		 * LED2 connection must be manually established using a jumper between
+		 * pins "L2" and "Digital I/O 4".
+		 */
 		red_led_adafruit_data_logger: led_2_adafruit_data_logger {
 			gpios = <&arduino_header 10 GPIO_ACTIVE_HIGH>; /* D4 */
 			label = "User LED2";
@@ -57,9 +57,9 @@
 		alarms-count = <1>;
 		battery-switch-over = "standard";
 		/*
-		* Interrupt connection must be manually established using a jumper wire between
-                * pins "SQ" and "Digital I/O 7".
-		*/
+		 * Interrupt connection must be manually established using a jumper wire between
+		 * pins "SQ" and "Digital I/O 7".
+		 */
 		int1-gpios = <&arduino_header 13 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>; /* D7 */
 		status = "okay";
 	};

--- a/boards/shields/esp_8266/boards/numaker_pfm_m467.overlay
+++ b/boards/shields/esp_8266/boards/numaker_pfm_m467.overlay
@@ -5,14 +5,14 @@
  */
 
 &pinctrl {
-    uart2_esp8266: uart2_esp8266 {
-	group0 {
-		pinmux = <PC1MFP_UART2_TXD>,
-			 <PC0MFP_UART2_RXD>,
-			 <PC3MFP_UART2_nRTS>,
-			 <PC2MFP_UART2_nCTS>;
+	uart2_esp8266: uart2_esp8266 {
+		group0 {
+			pinmux = <PC1MFP_UART2_TXD>,
+				 <PC0MFP_UART2_RXD>,
+				 <PC3MFP_UART2_nRTS>,
+				 <PC2MFP_UART2_nCTS>;
+		};
 	};
-    };
 };
 
 &uart2 {
@@ -27,7 +27,7 @@
 		compatible = "espressif,esp-at";
 		reset-gpios = <&gpioc 4 GPIO_ACTIVE_LOW>;
 		status = "okay";
-    };
+	};
 };
 
 &gpioc {

--- a/boards/shields/nxp_btb44_ov5640/nxp_btb44_ov5640.overlay
+++ b/boards/shields/nxp_btb44_ov5640/nxp_btb44_ov5640.overlay
@@ -11,38 +11,38 @@
 };
 
 &nxp_cam_i2c {
-    status = "okay";
+	status = "okay";
 
-    ov5640: ov5640@3c {
-        compatible = "ovti,ov5640";
-        reg = <0x3c>;
-        reset-gpios = <&nxp_cam_connector 9 GPIO_ACTIVE_LOW>;
-        powerdown-gpios = <&nxp_cam_connector 17 GPIO_ACTIVE_HIGH>;
+	ov5640: ov5640@3c {
+		compatible = "ovti,ov5640";
+		reg = <0x3c>;
+		reset-gpios = <&nxp_cam_connector 9 GPIO_ACTIVE_LOW>;
+		powerdown-gpios = <&nxp_cam_connector 17 GPIO_ACTIVE_HIGH>;
 
-        port {
-            ov5640_ep_out: endpoint {
-                remote-endpoint = <&mipi_csi2rx_ep_in>;
-            };
-        };
-    };
+		port {
+			ov5640_ep_out: endpoint {
+				remote-endpoint = <&mipi_csi2rx_ep_in>;
+			};
+		};
+	};
 };
 
 &nxp_mipi_csi {
-    status = "okay";
+	status = "okay";
 
-    sensor = <&ov5640>;
+	sensor = <&ov5640>;
 
-    ports {
-        port@1 {
-            reg = <1>;
+	ports {
+		port@1 {
+			reg = <1>;
 
-            mipi_csi2rx_ep_in: endpoint {
-                remote-endpoint = <&ov5640_ep_out>;
-            };
-        };
-    };
+			mipi_csi2rx_ep_in: endpoint {
+				remote-endpoint = <&ov5640_ep_out>;
+			};
+		};
+	};
 };
 
 &nxp_csi {
-    status = "okay";
+	status = "okay";
 };

--- a/boards/shields/ssd1306/boards/reel_board.overlay
+++ b/boards/shields/ssd1306/boards/reel_board.overlay
@@ -1,3 +1,3 @@
 &arduino_i2c {
-        compatible = "nordic,nrf-twi";
+	compatible = "nordic,nrf-twi";
 };

--- a/boards/shields/waveshare_ups/boards/rpi_pico.overlay
+++ b/boards/shields/waveshare_ups/boards/rpi_pico.overlay
@@ -6,13 +6,13 @@
 
 
 &pinctrl {
-        i2c1_default: i2c1_default {
-                group1 {
-                        bias-pull-up;
-                };
-        };
+	i2c1_default: i2c1_default {
+		group1 {
+			bias-pull-up;
+		};
+	};
 };
 
 &pico_i2c1 {
-        status = "okay";
+	status = "okay";
 };

--- a/boards/shields/waveshare_ups/waveshare_pico_ups_b.overlay
+++ b/boards/shields/waveshare_ups/waveshare_pico_ups_b.overlay
@@ -10,10 +10,10 @@
 		compatible = "ti,ina219";
 		reg = <0x43>;
 		brng = <1>;
-                pg = <3>;
-                sadc = <12>;
-                badc = <12>;
-                shunt-milliohm = <100>;
-                lsb-microamp = <20>;
+		pg = <3>;
+		sadc = <12>;
+		badc = <12>;
+		shunt-milliohm = <100>;
+		lsb-microamp = <20>;
 	};
 };

--- a/boards/shields/x_nucleo_bnrg2a1/x_nucleo_bnrg2a1.overlay
+++ b/boards/shields/x_nucleo_bnrg2a1/x_nucleo_bnrg2a1.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- / {
+/ {
 	 chosen {
 		 zephyr,bt-hci = &hci_spi;
 	 };

--- a/boards/shields/x_nucleo_idb05a1/x_nucleo_idb05a1.overlay
+++ b/boards/shields/x_nucleo_idb05a1/x_nucleo_idb05a1.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- / {
+/ {
 	 chosen {
 		 zephyr,bt-hci = &spbtle_rf_x_nucleo_idb05a1;
 	 };

--- a/boards/st/stm32f411e_disco/stm32f411e_disco_stm32f411xe_B.overlay
+++ b/boards/st/stm32f411e_disco/stm32f411e_disco_stm32f411xe_B.overlay
@@ -12,18 +12,18 @@
 };
 
 &i2c1 {
-    /delete-node/ lsm303agr-magn@1e;
-    /delete-node/ lsm303agr-accel@19;
+	/delete-node/ lsm303agr-magn@1e;
+	/delete-node/ lsm303agr-accel@19;
 
 	lsm303dlhc_magn: lsm303dlhc-magn@1e {
 		compatible = "st,lsm303dlhc-magn";
-        status = "okay";
+		status = "okay";
 		reg = <0x1e>;
 	};
 
 	lsm303dlhc_accel: lsm303dlhc-accel@19 {
 		compatible = "st,lis2dh", "st,lsm303dlhc-accel";
-        status = "okay";
+		status = "okay";
 		reg = <0x19>;
 		irq-gpios = <&gpioe 4 GPIO_ACTIVE_HIGH>,
 			  <&gpioe 5 GPIO_ACTIVE_HIGH>;

--- a/samples/basic/blinky_pwm/boards/nucleo_l476rg.overlay
+++ b/samples/basic/blinky_pwm/boards/nucleo_l476rg.overlay
@@ -15,9 +15,9 @@
 		};
 	};
 
-    aliases {
-        pwm-led0 = &green_pwm_led;
-    };
+	aliases {
+		pwm-led0 = &green_pwm_led;
+	};
 
 };
 

--- a/samples/basic/blinky_pwm/boards/rcar_h3ulcb_r8a77951_r7.overlay
+++ b/samples/basic/blinky_pwm/boards/rcar_h3ulcb_r8a77951_r7.overlay
@@ -5,21 +5,21 @@
  */
 
 / {
-    pwmleds {
-        compatible = "pwm-leds";
-        pwm_led_0: pwm_led_0 {
-            pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
-            label = "PWM LED 0";
-        };
-    };
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_led_0: pwm_led_0 {
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+			label = "PWM LED 0";
+		};
+	};
 
-    aliases {
-        pwm-led0 = &pwm_led_0;
-        pwm-0 = &pwm0;
-    };
+	aliases {
+		pwm-led0 = &pwm_led_0;
+		pwm-0 = &pwm0;
+	};
 
 };
 
 &pwm0 {
-    status = "okay";
+	status = "okay";
 };

--- a/samples/basic/custom_dts_binding/boards/nucleo_l073rz.overlay
+++ b/samples/basic/custom_dts_binding/boards/nucleo_l073rz.overlay
@@ -7,7 +7,7 @@
 / {
 	load_switch: load_switch {
 		compatible = "power-switch";
-                /* using built-in LED pin for demonstration */
+		/* using built-in LED pin for demonstration */
 		gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
 	};
 };

--- a/samples/bluetooth/beacon/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/bluetooth/beacon/boards/nrf52840dk_nrf52840.overlay
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 /{
-    coex_gpio: coex {
-        compatible = "gpio-radio-coex";
-        grant-gpios = <&gpio1 0 (GPIO_PULL_DOWN | GPIO_ACTIVE_LOW)>;
-        grant-delay-us = <150>;
-    };
+	coex_gpio: coex {
+		compatible = "gpio-radio-coex";
+		grant-gpios = <&gpio1 0 (GPIO_PULL_DOWN | GPIO_ACTIVE_LOW)>;
+		grant-delay-us = <150>;
+	};
 };
 
 &radio {
-    coex = <&coex_gpio>;
+	coex = <&coex_gpio>;
 };

--- a/samples/bluetooth/hci_uart_async/app.overlay
+++ b/samples/bluetooth/hci_uart_async/app.overlay
@@ -6,15 +6,15 @@
  */
 
 bt_c2h_uart: &uart0 {
-        status = "okay";
-        current-speed = <1000000>;
+	status = "okay";
+	current-speed = <1000000>;
 	hw-flow-control;
 };
 
 / {
-        chosen {
-                zephyr,bt-c2h-uart = &bt_c2h_uart;
-        };
+	chosen {
+		zephyr,bt-c2h-uart = &bt_c2h_uart;
+	};
 };
 
 /* Some boards are by default assigning the &uart0 to these other
@@ -22,10 +22,10 @@ bt_c2h_uart: &uart0 {
  * instead of accidental interference.
  */
 / {
-        chosen {
-                 /delete-property/ zephyr,console;
-                 /delete-property/ zephyr,shell-uart;
-                 /delete-property/ zephyr,uart-mcumgr;
-                 /delete-property/ zephyr,bt-mon-uart;
-        };
+	chosen {
+		/delete-property/ zephyr,console;
+		/delete-property/ zephyr,shell-uart;
+		/delete-property/ zephyr,uart-mcumgr;
+		/delete-property/ zephyr,bt-mon-uart;
+	};
 };

--- a/samples/boards/stm32/h7_dual_core/boards/stm32h747i_disco_stm32h747xx_m4.overlay
+++ b/samples/boards/stm32/h7_dual_core/boards/stm32h747i_disco_stm32h747xx_m4.overlay
@@ -1,3 +1,3 @@
 &mailbox {
-    status = "okay";
+	status = "okay";
 };

--- a/samples/boards/stm32/h7_dual_core/boards/stm32h747i_disco_stm32h747xx_m7.overlay
+++ b/samples/boards/stm32/h7_dual_core/boards/stm32h747i_disco_stm32h747xx_m7.overlay
@@ -1,3 +1,3 @@
 &mailbox {
-    status = "okay";
+	status = "okay";
 };

--- a/samples/boards/stm32/power_mgmt/adc/boards/nucleo_wba52cg.overlay
+++ b/samples/boards/stm32/power_mgmt/adc/boards/nucleo_wba52cg.overlay
@@ -12,15 +12,15 @@
 };
 
 &adc4 {
-    pinctrl-0 = <&adc4_in8_pa1>;
-    #address-cells = <1>;
-    #size-cells = <0>;
+	pinctrl-0 = <&adc4_in8_pa1>;
+	#address-cells = <1>;
+	#size-cells = <0>;
 
-    channel@8 {
-        reg = <8>;
-        zephyr,gain = "ADC_GAIN_1";
-        zephyr,reference = "ADC_REF_INTERNAL";
-        zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
-        zephyr,resolution = <12>;
-    };
+	channel@8 {
+		reg = <8>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
 };

--- a/samples/drivers/adc/adc_dt/boards/frdm_rw612.overlay
+++ b/samples/drivers/adc/adc_dt/boards/frdm_rw612.overlay
@@ -6,10 +6,10 @@
 #include <zephyr/dt-bindings/adc/nxp,gau-adc.h>
 
 / {
-        zephyr,user {
+	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&adc0 0 &adc0 1>;
-        };
+	};
 };
 
 &adc0 {

--- a/samples/drivers/adc/adc_dt/boards/gd32f350r_eval.overlay
+++ b/samples/drivers/adc/adc_dt/boards/gd32f350r_eval.overlay
@@ -4,7 +4,7 @@
  * Copyright (c) 2022 BrainCo Inc.
  */
 
- / {
+/ {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&adc0 11>;

--- a/samples/drivers/adc/adc_dt/boards/gd32l233r_eval.overlay
+++ b/samples/drivers/adc/adc_dt/boards/gd32l233r_eval.overlay
@@ -4,7 +4,7 @@
  * Copyright (c) 2022 BrainCo Inc.
  */
 
- / {
+/ {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&adc0 1>;

--- a/samples/drivers/adc/adc_dt/boards/gd32vf103v_eval.overlay
+++ b/samples/drivers/adc/adc_dt/boards/gd32vf103v_eval.overlay
@@ -4,7 +4,7 @@
  * Copyright (c) 2022 BrainCo Inc.
  */
 
- / {
+/ {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&adc0 13>;

--- a/samples/drivers/adc/adc_dt/boards/nucleo_c031c6.overlay
+++ b/samples/drivers/adc/adc_dt/boards/nucleo_c031c6.overlay
@@ -4,7 +4,7 @@
  * Copyright (c) 2023 Benjamin Björnsson <benjamin.bjornsson@gmail.com>
  */
 
- / {
+/ {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&adc1 0>, <&adc1 1>, <&adc1 4>;

--- a/samples/drivers/adc/adc_dt/boards/nucleo_h563zi.overlay
+++ b/samples/drivers/adc/adc_dt/boards/nucleo_h563zi.overlay
@@ -4,7 +4,7 @@
  * Copyright (c) 2024, Vitrolife A/S
  */
 
- / {
+/ {
 	zephyr,user {
 		/* CN9 pin 1 */
 		io-channels = <&adc1 3>;

--- a/samples/drivers/adc/adc_dt/boards/nucleo_h7a3zi_q.overlay
+++ b/samples/drivers/adc/adc_dt/boards/nucleo_h7a3zi_q.overlay
@@ -1,7 +1,7 @@
 /* Copyright (c) 2021 STMicroelectronics
    SPDX-License-Identifier: Apache-2.0 */
 
- / {
+/ {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&adc1 15>;

--- a/samples/drivers/adc/adc_dt/boards/nucleo_u575zi_q.overlay
+++ b/samples/drivers/adc/adc_dt/boards/nucleo_u575zi_q.overlay
@@ -1,7 +1,7 @@
 /* Copyright (c) 2022 STMicroelectronics
    SPDX-License-Identifier: Apache-2.0 */
 
- / {
+/ {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&adc1 1>;

--- a/samples/drivers/adc/adc_dt/boards/rd_rw612_bga.overlay
+++ b/samples/drivers/adc/adc_dt/boards/rd_rw612_bga.overlay
@@ -6,10 +6,10 @@
 #include <zephyr/dt-bindings/adc/nxp,gau-adc.h>
 
 / {
-        zephyr,user {
+	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&adc0 0 &adc0 1>;
-        };
+	};
 };
 
 &adc0 {

--- a/samples/drivers/adc/adc_dt/boards/stm32h573i_dk.overlay
+++ b/samples/drivers/adc/adc_dt/boards/stm32h573i_dk.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- / {
+/ {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&adc1 6>;

--- a/samples/drivers/adc/adc_dt/boards/stm32h735g_disco.overlay
+++ b/samples/drivers/adc/adc_dt/boards/stm32h735g_disco.overlay
@@ -1,7 +1,7 @@
 /* Copyright (c) 2021 STMicroelectronics
    SPDX-License-Identifier: Apache-2.0 */
 
- / {
+/ {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&adc1 0>;

--- a/samples/drivers/adc/adc_dt/boards/stm32l496g_disco.overlay
+++ b/samples/drivers/adc/adc_dt/boards/stm32l496g_disco.overlay
@@ -1,7 +1,7 @@
 /* Copyright (c) 2021 STMicroelectronics
    SPDX-License-Identifier: Apache-2.0 */
 
- / {
+/ {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&adc1 2>;

--- a/samples/drivers/audio/dmic/boards/mimxrt595_evk_mimxrt595s_cm33.overlay
+++ b/samples/drivers/audio/dmic/boards/mimxrt595_evk_mimxrt595s_cm33.overlay
@@ -1,3 +1,3 @@
 dmic_dev: &dmic0 {
-        status = "okay";
+	status = "okay";
 };

--- a/samples/drivers/audio/dmic/boards/rd_rw612_bga.overlay
+++ b/samples/drivers/audio/dmic/boards/rd_rw612_bga.overlay
@@ -1,3 +1,3 @@
 dmic_dev: &dmic0 {
-        status = "okay";
+	status = "okay";
 };

--- a/samples/drivers/counter/alarm/boards/arduino_due.overlay
+++ b/samples/drivers/counter/alarm/boards/arduino_due.overlay
@@ -1,4 +1,4 @@
 &tc0 {
-        clk = <4>;
-        status = "okay";
+	clk = <4>;
+	status = "okay";
 };

--- a/samples/drivers/counter/alarm/boards/sam4e_xpro.overlay
+++ b/samples/drivers/counter/alarm/boards/sam4e_xpro.overlay
@@ -1,4 +1,4 @@
 &tc0 {
-        clk = <4>;
-        status = "okay";
+	clk = <4>;
+	status = "okay";
 };

--- a/samples/drivers/counter/alarm/boards/sam4s_xplained.overlay
+++ b/samples/drivers/counter/alarm/boards/sam4s_xplained.overlay
@@ -1,4 +1,4 @@
 &tc0 {
-        clk = <4>;
-        status = "okay";
+	clk = <4>;
+	status = "okay";
 };

--- a/samples/drivers/counter/alarm/boards/sam_e70_xplained_same70q21.overlay
+++ b/samples/drivers/counter/alarm/boards/sam_e70_xplained_same70q21.overlay
@@ -1,4 +1,4 @@
 &tc0 {
-        clk = <4>;
-        status = "okay";
+	clk = <4>;
+	status = "okay";
 };

--- a/samples/drivers/counter/alarm/boards/sam_e70_xplained_same70q21b.overlay
+++ b/samples/drivers/counter/alarm/boards/sam_e70_xplained_same70q21b.overlay
@@ -1,4 +1,4 @@
 &tc0 {
-        clk = <4>;
-        status = "okay";
+	clk = <4>;
+	status = "okay";
 };

--- a/samples/drivers/counter/alarm/boards/sam_v71_xult_samv71q21.overlay
+++ b/samples/drivers/counter/alarm/boards/sam_v71_xult_samv71q21.overlay
@@ -1,4 +1,4 @@
 &tc0 {
-        clk = <4>;
-        status = "okay";
+	clk = <4>;
+	status = "okay";
 };

--- a/samples/drivers/counter/alarm/boards/sam_v71_xult_samv71q21b.overlay
+++ b/samples/drivers/counter/alarm/boards/sam_v71_xult_samv71q21b.overlay
@@ -1,4 +1,4 @@
 &tc0 {
-        clk = <4>;
-        status = "okay";
+	clk = <4>;
+	status = "okay";
 };

--- a/samples/drivers/crypto/boards/da1469x_dk_pro.overlay
+++ b/samples/drivers/crypto/boards/da1469x_dk_pro.overlay
@@ -5,5 +5,5 @@
  */
 
 &crypto {
-    status = "okay";
+	status = "okay";
 };

--- a/samples/drivers/dac/boards/frdm_mcxn947.overlay
+++ b/samples/drivers/dac/boards/frdm_mcxn947.overlay
@@ -6,12 +6,12 @@
 
 / {
 
-    /*
-    * Please note on the FRDM-MCXN947 board, DAC0 output signal port is J1-4.
-    */
-    zephyr,user {
-        dac = <&dac0>;
-        dac-channel-id = <0>;
-        dac-resolution = <12>;
-    };
+	/*
+	 * Please note on the FRDM-MCXN947 board, DAC0 output signal port is J1-4.
+	 */
+	zephyr,user {
+		dac = <&dac0>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
+	};
 };

--- a/samples/drivers/dac/boards/lpcxpresso55s36.overlay
+++ b/samples/drivers/dac/boards/lpcxpresso55s36.overlay
@@ -5,9 +5,9 @@
  */
 
 / {
-    zephyr,user {
-        dac = <&dac0>;
-        dac-channel-id = <0>;
-        dac-resolution = <12>;
-    };
+	zephyr,user {
+		dac = <&dac0>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
+	};
 };

--- a/samples/drivers/ht16k33/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/drivers/ht16k33/boards/nrf52840dk_nrf52840.overlay
@@ -10,7 +10,7 @@
 	ht16k33@70 {
 		compatible = "holtek,ht16k33";
 		reg = <0x70>;
-                /* Uncomment to use IRQ instead of polling: */
+		/* Uncomment to use IRQ instead of polling: */
 		/* irq-gpios = <&gpio1 8 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>; */
 
 		kscan-input {

--- a/samples/drivers/ipm/ipm_esp32/boards/esp32_devkitc_wroom_procpu.overlay
+++ b/samples/drivers/ipm/ipm_esp32/boards/esp32_devkitc_wroom_procpu.overlay
@@ -1,3 +1,3 @@
 &ipm0 {
-    status = "okay";
+	status = "okay";
 };

--- a/samples/drivers/ipm/ipm_esp32/boards/esp32_devkitc_wrover_procpu.overlay
+++ b/samples/drivers/ipm/ipm_esp32/boards/esp32_devkitc_wrover_procpu.overlay
@@ -1,3 +1,3 @@
 &ipm0 {
-    status = "okay";
+	status = "okay";
 };

--- a/samples/drivers/ipm/ipm_esp32/boards/esp32s3_devkitm_procpu.overlay
+++ b/samples/drivers/ipm/ipm_esp32/boards/esp32s3_devkitm_procpu.overlay
@@ -1,3 +1,3 @@
 &ipm0 {
-    status = "okay";
+	status = "okay";
 };

--- a/samples/drivers/ipm/ipm_esp32/boards/yd_esp32_procpu.overlay
+++ b/samples/drivers/ipm/ipm_esp32/boards/yd_esp32_procpu.overlay
@@ -1,3 +1,3 @@
 &ipm0 {
-    status = "okay";
+	status = "okay";
 };

--- a/samples/drivers/ipm/ipm_ivshmem/boards/qemu_cortex_a53.overlay
+++ b/samples/drivers/ipm/ipm_ivshmem/boards/qemu_cortex_a53.overlay
@@ -5,10 +5,10 @@
  */
  #include "pcie_ivshmem.dtsi"
 
- / {
-     ipm_ivshmem0: ipm_ivshmem {
-         compatible = "linaro,ivshmem-ipm";
-         ivshmem = <&ivshmem0>;
-         status = "okay";
-     };
- };
+/ {
+	ipm_ivshmem0: ipm_ivshmem {
+		compatible = "linaro,ivshmem-ipm";
+		ivshmem = <&ivshmem0>;
+		status = "okay";
+	};
+};

--- a/samples/drivers/led_strip/boards/esp32c3_devkitm.overlay
+++ b/samples/drivers/led_strip/boards/esp32c3_devkitm.overlay
@@ -10,22 +10,22 @@
 	/* Workaround to support WS2812 driver */
 	line-idle-low;
 
-        led_strip: ws2812@0 {
-                compatible = "worldsemi,ws2812-spi";
+	led_strip: ws2812@0 {
+		compatible = "worldsemi,ws2812-spi";
 
-                /* SPI */
-                reg = <0>; /* ignored, but necessary for SPI bindings */
-                spi-max-frequency = <6400000>;
+		/* SPI */
+		reg = <0>; /* ignored, but necessary for SPI bindings */
+		spi-max-frequency = <6400000>;
 
-                /* WS2812 */
-                chain-length = <1>; /* arbitrary; change at will */
-                spi-cpha;
-                spi-one-frame = <0xf0>; /* 11110000: 625 ns high and 625 ns low */
-                spi-zero-frame = <0xc0>; /* 11000000: 312.5 ns high and 937.5 ns low */
-                color-mapping = <LED_COLOR_ID_GREEN
-                                 LED_COLOR_ID_RED
-                                 LED_COLOR_ID_BLUE>;
-        };
+		/* WS2812 */
+		chain-length = <1>; /* arbitrary; change at will */
+		spi-cpha;
+		spi-one-frame = <0xf0>; /* 11110000: 625 ns high and 625 ns low */
+		spi-zero-frame = <0xc0>; /* 11000000: 312.5 ns high and 937.5 ns low */
+		color-mapping = <LED_COLOR_ID_GREEN
+				 LED_COLOR_ID_RED
+				 LED_COLOR_ID_BLUE>;
+	};
 };
 
 &pinctrl {
@@ -37,7 +37,7 @@
 };
 
 / {
-        aliases {
-                led-strip = &led_strip;
-        };
+	aliases {
+		led-strip = &led_strip;
+	};
 };

--- a/samples/drivers/led_strip/boards/esp32s2_saola.overlay
+++ b/samples/drivers/led_strip/boards/esp32s2_saola.overlay
@@ -10,22 +10,22 @@
 	/* Workaround to support WS2812 driver */
 	line-idle-low;
 
-        led_strip: ws2812@0 {
-                compatible = "worldsemi,ws2812-spi";
+	led_strip: ws2812@0 {
+		compatible = "worldsemi,ws2812-spi";
 
-                /* SPI */
-                reg = <0>; /* ignored, but necessary for SPI bindings */
-                spi-max-frequency = <6400000>;
+		/* SPI */
+		reg = <0>; /* ignored, but necessary for SPI bindings */
+		spi-max-frequency = <6400000>;
 
-                /* WS2812 */
-                chain-length = <1>; /* arbitrary; change at will */
-                spi-cpha;
-                spi-one-frame = <0xf0>; /* 11110000: 625 ns high and 625 ns low */
-                spi-zero-frame = <0xc0>; /* 11000000: 312.5 ns high and 937.5 ns low */
-                color-mapping = <LED_COLOR_ID_GREEN
-                                 LED_COLOR_ID_RED
-                                 LED_COLOR_ID_BLUE>;
-        };
+		/* WS2812 */
+		chain-length = <1>; /* arbitrary; change at will */
+		spi-cpha;
+		spi-one-frame = <0xf0>; /* 11110000: 625 ns high and 625 ns low */
+		spi-zero-frame = <0xc0>; /* 11000000: 312.5 ns high and 937.5 ns low */
+		color-mapping = <LED_COLOR_ID_GREEN
+				 LED_COLOR_ID_RED
+				 LED_COLOR_ID_BLUE>;
+	};
 };
 
 &pinctrl {
@@ -37,7 +37,7 @@
 };
 
 / {
-        aliases {
-                led-strip = &led_strip;
-        };
+	aliases {
+		led-strip = &led_strip;
+	};
 };

--- a/samples/drivers/led_strip/boards/esp32s3_devkitm_procpu.overlay
+++ b/samples/drivers/led_strip/boards/esp32s3_devkitm_procpu.overlay
@@ -10,22 +10,22 @@
 	/* Workaround to support WS2812 driver */
 	line-idle-low;
 
-        led_strip: ws2812@0 {
-                compatible = "worldsemi,ws2812-spi";
+	led_strip: ws2812@0 {
+		compatible = "worldsemi,ws2812-spi";
 
-                /* SPI */
-                reg = <0>; /* ignored, but necessary for SPI bindings */
-                spi-max-frequency = <6400000>;
+		/* SPI */
+		reg = <0>; /* ignored, but necessary for SPI bindings */
+		spi-max-frequency = <6400000>;
 
-                /* WS2812 */
-                chain-length = <1>; /* arbitrary; change at will */
-                spi-cpha;
-                spi-one-frame = <0xf0>; /* 11110000: 625 ns high and 625 ns low */
-                spi-zero-frame = <0xc0>; /* 11000000: 312.5 ns high and 937.5 ns low */
-                color-mapping = <LED_COLOR_ID_GREEN
-                                 LED_COLOR_ID_RED
-                                 LED_COLOR_ID_BLUE>;
-        };
+		/* WS2812 */
+		chain-length = <1>; /* arbitrary; change at will */
+		spi-cpha;
+		spi-one-frame = <0xf0>; /* 11110000: 625 ns high and 625 ns low */
+		spi-zero-frame = <0xc0>; /* 11000000: 312.5 ns high and 937.5 ns low */
+		color-mapping = <LED_COLOR_ID_GREEN
+				 LED_COLOR_ID_RED
+				 LED_COLOR_ID_BLUE>;
+	};
 };
 
 &pinctrl {
@@ -37,7 +37,7 @@
 };
 
 / {
-        aliases {
-                led-strip = &led_strip;
-        };
+	aliases {
+		led-strip = &led_strip;
+	};
 };

--- a/samples/drivers/memc/boards/apollo3p_evb.overlay
+++ b/samples/drivers/memc/boards/apollo3p_evb.overlay
@@ -57,7 +57,7 @@
 
 &pinctrl {
 
-    mspi1_sleep: mspi1_sleep{
+	mspi1_sleep: mspi1_sleep{
 
 		group1 {
 			pinmux = <GPIO_P51>,

--- a/samples/drivers/spi_flash/boards/b_u585i_iot02a.overlay
+++ b/samples/drivers/spi_flash/boards/b_u585i_iot02a.overlay
@@ -5,7 +5,7 @@
  */
 
 &octospi2 {
-            /* channel 12-15 are for transfers to/from external memories */
-            dmas = <&gpdma1 12 41 0x10480>; /* request 41 for OCTOSPI2 */
-            dma-names = "tx_rx";
+	/* channel 12-15 are for transfers to/from external memories */
+	dmas = <&gpdma1 12 41 0x10480>; /* request 41 for OCTOSPI2 */
+	dma-names = "tx_rx";
 };

--- a/samples/drivers/spi_flash/boards/stm32h573i_dk.overlay
+++ b/samples/drivers/spi_flash/boards/stm32h573i_dk.overlay
@@ -5,7 +5,7 @@
  */
 
 &xspi1 {
-       /* request 57 for XSPI1 */
+	/* request 57 for XSPI1 */
 	dmas = <&gpdma1 4 57 STM32_DMA_PERIPH_TX
 		&gpdma1 5 57 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";

--- a/samples/drivers/spi_flash/boards/stm32h735g_disco.overlay
+++ b/samples/drivers/spi_flash/boards/stm32h735g_disco.overlay
@@ -5,8 +5,8 @@
  */
 
 &octospi1 {
-            dmas = <&dma1 1 0x16 0x480>; /* request for OCTOSPI1 fifo THreshold */
-            dma-names = "tx_rx";
+	dmas = <&dma1 1 0x16 0x480>; /* request for OCTOSPI1 fifo THreshold */
+	dma-names = "tx_rx";
 };
 
 &mdma {

--- a/samples/drivers/spi_flash/boards/stm32l562e_dk.overlay
+++ b/samples/drivers/spi_flash/boards/stm32l562e_dk.overlay
@@ -5,8 +5,8 @@
  */
 
 &octospi1 {
-            dmas = <&dma1 0 41 0x480>; /* request 41 for OCTOSPI1 */
-            dma-names = "tx_rx";
+	dmas = <&dma1 0 41 0x480>; /* request 41 for OCTOSPI1 */
+	dma-names = "tx_rx";
 };
 
 &dma1 {

--- a/samples/net/cellular_modem/boards/mg100.overlay
+++ b/samples/net/cellular_modem/boards/mg100.overlay
@@ -1,6 +1,6 @@
 / {
-    aliases {
-        modem-uart = &uart1;
-        modem = &hl7800;
-    };
+	aliases {
+		modem-uart = &uart1;
+		modem = &hl7800;
+	};
 };

--- a/samples/net/cellular_modem/boards/pinnacle_100_dvk.overlay
+++ b/samples/net/cellular_modem/boards/pinnacle_100_dvk.overlay
@@ -1,6 +1,6 @@
 / {
-    aliases {
-        modem-uart = &uart1;
-        modem = &hl7800;
-    };
+	aliases {
+		modem-uart = &uart1;
+		modem = &hl7800;
+	};
 };

--- a/samples/net/cloud/aws_iot_mqtt/boards/nucleo_f429zi.overlay
+++ b/samples/net/cloud/aws_iot_mqtt/boards/nucleo_f429zi.overlay
@@ -1,3 +1,3 @@
 &mac {
-    local-mac-address = [00 00 00 77 77 77];
+	local-mac-address = [00 00 00 77 77 77];
 };

--- a/samples/sensor/die_temp_polling/boards/esp32c3_devkitm.overlay
+++ b/samples/sensor/die_temp_polling/boards/esp32c3_devkitm.overlay
@@ -7,5 +7,5 @@
  */
 
 &coretemp {
-    status = "okay";
+	status = "okay";
 };

--- a/samples/sensor/die_temp_polling/boards/esp32c3_luatos_core.overlay
+++ b/samples/sensor/die_temp_polling/boards/esp32c3_luatos_core.overlay
@@ -7,5 +7,5 @@
  */
 
 &coretemp {
-    status = "okay";
+	status = "okay";
 };

--- a/samples/sensor/die_temp_polling/boards/esp32c3_luatos_core_esp32c3_usb.overlay
+++ b/samples/sensor/die_temp_polling/boards/esp32c3_luatos_core_esp32c3_usb.overlay
@@ -7,5 +7,5 @@
  */
 
 &coretemp {
-    status = "okay";
+	status = "okay";
 };

--- a/samples/sensor/die_temp_polling/boards/mimxrt1050_evk.overlay
+++ b/samples/sensor/die_temp_polling/boards/mimxrt1050_evk.overlay
@@ -5,5 +5,5 @@
  */
 
 &tempmon {
-    status = "okay";
+	status = "okay";
 };

--- a/samples/sensor/die_temp_polling/boards/nrf51dk_nrf51822.overlay
+++ b/samples/sensor/die_temp_polling/boards/nrf51dk_nrf51822.overlay
@@ -5,7 +5,7 @@
  */
 
 / {
-        aliases {
-                die-temp0 = &temp;
-        };
+	aliases {
+		die-temp0 = &temp;
+	};
 };

--- a/samples/sensor/die_temp_polling/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/sensor/die_temp_polling/boards/nrf52840dk_nrf52840.overlay
@@ -5,7 +5,7 @@
  */
 
 / {
-        aliases {
-                die-temp0 = &temp;
-        };
+	aliases {
+		die-temp0 = &temp;
+	};
 };

--- a/samples/sensor/mcux_lpcmp/boards/frdm_mcxn947_mcxn947_cpu0.overlay
+++ b/samples/sensor/mcux_lpcmp/boards/frdm_mcxn947_mcxn947_cpu0.overlay
@@ -5,5 +5,5 @@
  */
 
 &lpcmp0 {
-    function-clock = "CMP_CLOCK";
+	function-clock = "CMP_CLOCK";
 };

--- a/samples/sensor/mpr/boards/arduino_due.overlay
+++ b/samples/sensor/mpr/boards/arduino_due.overlay
@@ -5,8 +5,8 @@
  */
 
 &twi0 {
-    mpr@18 {
-        compatible = "honeywell,mpr";
-        reg = <0x18>;
-    };
+	mpr@18 {
+		compatible = "honeywell,mpr";
+		reg = <0x18>;
+	};
 };

--- a/samples/sensor/ms5837/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/sensor/ms5837/boards/nrf52840dk_nrf52840.overlay
@@ -5,10 +5,10 @@
  */
 
 &i2c1 {
-    status = "okay";
-    clock-frequency = <I2C_BITRATE_STANDARD>;
-    ms5837@76 {
-        compatible = "meas,ms5837";
-        reg = <0x76>;
-    };
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	ms5837@76 {
+		compatible = "meas,ms5837";
+		reg = <0x76>;
+	};
 };

--- a/samples/sensor/sensor_shell/app.overlay
+++ b/samples/sensor/sensor_shell/app.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- / {
+/ {
 	app {
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/samples/shields/npm1300_ek/nrf52dk_nrf52832.overlay
+++ b/samples/shields/npm1300_ek/nrf52dk_nrf52832.overlay
@@ -14,7 +14,7 @@
 };
 
 &npm1300_ek_buck1 {
-        regulator-init-microvolt = <2000000>;
+	regulator-init-microvolt = <2000000>;
 };
 
 &npm1300_ek_buck2 {

--- a/samples/subsys/fs/fs_sample/boards/hifive_unmatched.overlay
+++ b/samples/subsys/fs/fs_sample/boards/hifive_unmatched.overlay
@@ -5,16 +5,16 @@
  */
 
 &spi2 {
-        status = "okay";
+	status = "okay";
 
-        sdhc0: sdhc@0 {
-                compatible = "zephyr,sdhc-spi-slot";
-                reg = <0>;
-                status = "okay";
-                mmc {
-                    compatible = "zephyr,sdmmc-disk";
-                    status = "okay";
-                };
-                spi-max-frequency = <20000000>;
-        };
+	sdhc0: sdhc@0 {
+		compatible = "zephyr,sdhc-spi-slot";
+		reg = <0>;
+		status = "okay";
+		mmc {
+			compatible = "zephyr,sdmmc-disk";
+			status = "okay";
+		};
+		spi-max-frequency = <20000000>;
+	};
 };

--- a/samples/subsys/fs/fs_sample/boards/nrf52840_blip.overlay
+++ b/samples/subsys/fs/fs_sample/boards/nrf52840_blip.overlay
@@ -5,17 +5,17 @@
  */
 
 &spi1 {
-        status = "okay";
-        cs-gpios = <&gpio0 17 GPIO_ACTIVE_HIGH>;
+	status = "okay";
+	cs-gpios = <&gpio0 17 GPIO_ACTIVE_HIGH>;
 
-        sdhc0: sdhc@0 {
-                compatible = "zephyr,sdhc-spi-slot";
-                reg = <0>;
-                status = "okay";
-                mmc {
-                    compatible = "zephyr,sdmmc-disk";
-                    status = "okay";
-                };
-                spi-max-frequency = <24000000>;
-        };
+	sdhc0: sdhc@0 {
+		compatible = "zephyr,sdhc-spi-slot";
+		reg = <0>;
+		status = "okay";
+		mmc {
+			compatible = "zephyr,sdmmc-disk";
+			status = "okay";
+		};
+		spi-max-frequency = <24000000>;
+	};
 };

--- a/samples/subsys/fs/fs_sample/boards/nucleo_f429zi.overlay
+++ b/samples/subsys/fs/fs_sample/boards/nucleo_f429zi.overlay
@@ -5,16 +5,16 @@
  */
 
 &spi1 {
-        sdhc0: sdhc@0 {
-                compatible = "zephyr,sdhc-spi-slot";
-                reg = <0>;
-                status = "okay";
-                mmc {
-                    compatible = "zephyr,sdmmc-disk";
-                    status = "okay";
-                };
-                spi-max-frequency = <25000000>;
-                spi-clock-mode-cpol;
-                spi-clock-mode-cpha;
-        };
+	sdhc0: sdhc@0 {
+		compatible = "zephyr,sdhc-spi-slot";
+		reg = <0>;
+		status = "okay";
+		mmc {
+			compatible = "zephyr,sdmmc-disk";
+			status = "okay";
+		};
+		spi-max-frequency = <25000000>;
+		spi-clock-mode-cpol;
+		spi-clock-mode-cpha;
+	};
 };

--- a/samples/subsys/fs/littlefs/boards/b_u585i_iot02a.overlay
+++ b/samples/subsys/fs/littlefs/boards/b_u585i_iot02a.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- / {
+/ {
 	fstab {
 		compatible = "zephyr,fstab";
 		lfs1: lfs1 {

--- a/samples/subsys/fs/littlefs/boards/nucleo_h7a3zi_q.overlay
+++ b/samples/subsys/fs/littlefs/boards/nucleo_h7a3zi_q.overlay
@@ -16,7 +16,7 @@
 			block-cycles = <512>;
 			partition = <&lfs1_partition>;
 			mount-point = "/lfs1";
-    };
+		};
 	};
 };
 

--- a/samples/subsys/fs/littlefs/boards/stm32f429i_disc1.overlay
+++ b/samples/subsys/fs/littlefs/boards/stm32f429i_disc1.overlay
@@ -16,7 +16,7 @@
 			block-cycles = <512>;
 			partition = <&lfs1_partition>;
 			mount-point = "/lfs1";
-    };
+		};
 	};
 };
 

--- a/samples/subsys/fs/littlefs/boards/stm32l562e_dk.overlay
+++ b/samples/subsys/fs/littlefs/boards/stm32l562e_dk.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- / {
+/ {
 	fstab {
 		compatible = "zephyr,fstab";
 		lfs1: lfs1 {

--- a/samples/subsys/ipc/ipc_service/static_vrings/boards/lpcxpresso55s69_lpc55s69_cpu0.overlay
+++ b/samples/subsys/ipc/ipc_service/static_vrings/boards/lpcxpresso55s69_lpc55s69_cpu0.overlay
@@ -7,7 +7,7 @@
 #include <zephyr/dt-bindings/ipc_service/static_vrings.h>
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 
- / {
+/ {
 	chosen {
 		/* Delete ipc chosen property where old IPM mailbox driver bellow is
 		 * configured.

--- a/samples/subsys/ipc/ipc_service/static_vrings/remote/boards/lpcxpresso55s69_lpc55s69_cpu1.overlay
+++ b/samples/subsys/ipc/ipc_service/static_vrings/remote/boards/lpcxpresso55s69_lpc55s69_cpu1.overlay
@@ -7,7 +7,7 @@
 #include <zephyr/dt-bindings/ipc_service/static_vrings.h>
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 
- / {
+/ {
 	chosen {
 		/* Delete ipc chosen property where old IPM mailbox driver bellow is
 		 * configured.

--- a/samples/subsys/logging/logger/bt.overlay
+++ b/samples/subsys/logging/logger/bt.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- / {
+/ {
 	chosen {
 		zephyr,console = &bt_nus_console_uart;
 	};

--- a/samples/subsys/shell/shell_module/bt.overlay
+++ b/samples/subsys/shell/shell_module/bt.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- / {
+/ {
 	chosen {
 		zephyr,console = &bt_nus_console_uart;
 		zephyr,shell-uart = &bt_nus_console_uart;

--- a/samples/subsys/tracing/boards/mps2_an521_cpu0.overlay
+++ b/samples/subsys/tracing/boards/mps2_an521_cpu0.overlay
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 / {
-       chosen {
-               zephyr,tracing-uart = &uart1;
-       };
+	chosen {
+		zephyr,tracing-uart = &uart1;
+	};
 };

--- a/samples/subsys/tracing/boards/qemu_x86.overlay
+++ b/samples/subsys/tracing/boards/qemu_x86.overlay
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 / {
-       chosen {
-               zephyr,tracing-uart = &uart1;
-       };
+	chosen {
+		zephyr,tracing-uart = &uart1;
+	};
 };

--- a/samples/subsys/tracing/boards/qemu_x86_64.overlay
+++ b/samples/subsys/tracing/boards/qemu_x86_64.overlay
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 / {
-       chosen {
-               zephyr,tracing-uart = &uart1;
-       };
+	chosen {
+		zephyr,tracing-uart = &uart1;
+	};
 };

--- a/scripts/tests/twister_blackbox/test_data/tests/qemu_overflow/dummy/qemu_x86.overlay
+++ b/scripts/tests/twister_blackbox/test_data/tests/qemu_overflow/dummy/qemu_x86.overlay
@@ -1,3 +1,3 @@
 &dram0 {
-        reg = < 0x100000 DT_SIZE_M(1) >;
+	reg = < 0x100000 DT_SIZE_M(1) >;
 };

--- a/tests/bluetooth/hci_uart_async/app.overlay
+++ b/tests/bluetooth/hci_uart_async/app.overlay
@@ -1,7 +1,7 @@
 / {
-        chosen {
+	chosen {
 		zephyr,bt-c2h-uart = &test_uart;
-        };
+	};
 
 	test_uart: test_uart {
 		compatible = "vnd,serial";

--- a/tests/bluetooth/tester/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/tests/bluetooth/tester/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,14 +1,14 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 / {
-    chosen {
-        zephyr,uart-pipe = &uart0;
-    };
+	chosen {
+		zephyr,uart-pipe = &uart0;
+	};
 };
 
 &uart0 {
-    compatible = "nordic,nrf-uarte";
-    current-speed = <115200>;
-    status = "okay";
-    hw-flow-control;
+	compatible = "nordic,nrf-uarte";
+	current-speed = <115200>;
+	status = "okay";
+	hw-flow-control;
 };

--- a/tests/boards/mec15xxevb_assy6853/qspi/boards/mec15xxevb_assy6853.overlay
+++ b/tests/boards/mec15xxevb_assy6853/qspi/boards/mec15xxevb_assy6853.overlay
@@ -5,15 +5,15 @@
  */
 
 &spi0 {
-        status = "okay";
-        port_sel = <0>;
-        chip_select = <0>;
-        lines = <4>;
+	status = "okay";
+	port_sel = <0>;
+	chip_select = <0>;
+	lines = <4>;
 
-        pinctrl-0 = < &shd_cs0_n_gpio055
-                      &shd_clk_gpio056
-                      &shd_io0_gpio223
-                      &shd_io1_gpio224
-                      &shd_io2_gpio227
-                      &shd_io3_gpio016 >;
+	pinctrl-0 = < &shd_cs0_n_gpio055
+		      &shd_clk_gpio056
+		      &shd_io0_gpio223
+		      &shd_io1_gpio224
+		      &shd_io2_gpio227
+		      &shd_io3_gpio016 >;
 };

--- a/tests/boards/mec172xevb_assy6906/qspi/boards/mec172xevb_assy6906.overlay
+++ b/tests/boards/mec172xevb_assy6906/qspi/boards/mec172xevb_assy6906.overlay
@@ -5,14 +5,14 @@
  */
 
 &spi0 {
-        status = "okay";
-        chip-select = <0>;
-        lines = <4>;
+	status = "okay";
+	chip-select = <0>;
+	lines = <4>;
 
-        pinctrl-0 = < &shd_cs0_n_gpio055
-                      &shd_clk_gpio056
-                      &shd_io0_gpio223
-                      &shd_io1_gpio224
-                      &shd_io2_gpio227
-                      &shd_io3_gpio016 >;
+	pinctrl-0 = < &shd_cs0_n_gpio055
+		      &shd_clk_gpio056
+		      &shd_io0_gpio223
+		      &shd_io1_gpio224
+		      &shd_io2_gpio227
+		      &shd_io3_gpio016 >;
 };

--- a/tests/cmake/overlays/var_expansions/my_extra_module/zephyr/my_extra_module-board.overlay
+++ b/tests/cmake/overlays/var_expansions/my_extra_module/zephyr/my_extra_module-board.overlay
@@ -5,5 +5,5 @@
  */
 
 / {
-        /* This file is intentionally empty */
+	/* This file is intentionally empty */
 };

--- a/tests/cmake/overlays/var_expansions/my_module/zephyr/my_module-board.overlay
+++ b/tests/cmake/overlays/var_expansions/my_module/zephyr/my_module-board.overlay
@@ -5,5 +5,5 @@
  */
 
 / {
-        /* This file is intentionally empty */
+	/* This file is intentionally empty */
 };

--- a/tests/crypto/crypto_hash/boards/da1469x_dk_pro.overlay
+++ b/tests/crypto/crypto_hash/boards/da1469x_dk_pro.overlay
@@ -5,5 +5,5 @@
  */
 
 &crypto {
-    status = "okay";
+	status = "okay";
 };

--- a/tests/drivers/adc/adc_api/boards/esp32s3_devkitc_procpu.overlay
+++ b/tests/drivers/adc/adc_api/boards/esp32s3_devkitc_procpu.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- / {
+/ {
 	 zephyr,user {
 		 io-channels = <&adc0 0>, <&adc0 1>;
 	 };

--- a/tests/drivers/adc/adc_api/boards/esp32s3_devkitm_procpu.overlay
+++ b/tests/drivers/adc/adc_api/boards/esp32s3_devkitm_procpu.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- / {
+/ {
 	 zephyr,user {
 		 io-channels = <&adc0 9>, <&adc1 0>;
 	 };

--- a/tests/drivers/adc/adc_api/boards/esp32s3_luatos_core_procpu.overlay
+++ b/tests/drivers/adc/adc_api/boards/esp32s3_luatos_core_procpu.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- / {
+/ {
 	 zephyr,user {
 		 io-channels = <&adc0 9>, <&adc1 0>;
 	 };

--- a/tests/drivers/adc/adc_api/boards/esp32s3_luatos_core_procpu_usb.overlay
+++ b/tests/drivers/adc/adc_api/boards/esp32s3_luatos_core_procpu_usb.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- / {
+/ {
 	 zephyr,user {
 		 io-channels = <&adc0 9>, <&adc1 0>;
 	 };

--- a/tests/drivers/adc/adc_api/boards/lpcxpresso55s28.overlay
+++ b/tests/drivers/adc/adc_api/boards/lpcxpresso55s28.overlay
@@ -22,7 +22,7 @@
 		zephyr,reference = "ADC_REF_EXTERNAL0";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
-                zephyr,input-positive = <MCUX_LPADC_CH0A>;
+		zephyr,input-positive = <MCUX_LPADC_CH0A>;
 	};
 
 	channel@1 {
@@ -31,6 +31,6 @@
 		zephyr,reference = "ADC_REF_EXTERNAL0";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
-                zephyr,input-positive = <MCUX_LPADC_CH1A>;
+		zephyr,input-positive = <MCUX_LPADC_CH1A>;
 	};
 };

--- a/tests/drivers/adc/adc_api/boards/mimxrt1170_evk_mimxrt1176_cm7_A.overlay
+++ b/tests/drivers/adc/adc_api/boards/mimxrt1170_evk_mimxrt1176_cm7_A.overlay
@@ -22,7 +22,7 @@
 		zephyr,reference = "ADC_REF_EXTERNAL0";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
-                zephyr,input-positive = <MCUX_LPADC_CH0A>;
+		zephyr,input-positive = <MCUX_LPADC_CH0A>;
 	};
 
 	channel@1 {
@@ -31,6 +31,6 @@
 		zephyr,reference = "ADC_REF_EXTERNAL0";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
-                zephyr,input-positive = <MCUX_LPADC_CH1A>;
+		zephyr,input-positive = <MCUX_LPADC_CH1A>;
 	};
 };

--- a/tests/drivers/adc/adc_api/boards/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
+++ b/tests/drivers/adc/adc_api/boards/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
@@ -22,7 +22,7 @@
 		zephyr,reference = "ADC_REF_EXTERNAL0";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
-                zephyr,input-positive = <MCUX_LPADC_CH0A>;
+		zephyr,input-positive = <MCUX_LPADC_CH0A>;
 	};
 
 	channel@1 {
@@ -31,6 +31,6 @@
 		zephyr,reference = "ADC_REF_EXTERNAL0";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
-                zephyr,input-positive = <MCUX_LPADC_CH1A>;
+		zephyr,input-positive = <MCUX_LPADC_CH1A>;
 	};
 };

--- a/tests/drivers/adc/adc_api/boards/mimxrt595_evk_mimxrt595s_cm33.overlay
+++ b/tests/drivers/adc/adc_api/boards/mimxrt595_evk_mimxrt595s_cm33.overlay
@@ -22,7 +22,7 @@
 		zephyr,reference = "ADC_REF_EXTERNAL0";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
-                zephyr,input-positive = <MCUX_LPADC_CH0A>;
+		zephyr,input-positive = <MCUX_LPADC_CH0A>;
 	};
 
 	channel@1 {
@@ -31,6 +31,6 @@
 		zephyr,reference = "ADC_REF_EXTERNAL0";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
-                zephyr,input-positive = <MCUX_LPADC_CH1A>;
+		zephyr,input-positive = <MCUX_LPADC_CH1A>;
 	};
 };

--- a/tests/drivers/adc/adc_api/boards/mimxrt685_evk_mimxrt685s_cm33.overlay
+++ b/tests/drivers/adc/adc_api/boards/mimxrt685_evk_mimxrt685s_cm33.overlay
@@ -22,7 +22,7 @@
 		zephyr,reference = "ADC_REF_EXTERNAL0";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
-                zephyr,input-positive = <MCUX_LPADC_CH0A>;
+		zephyr,input-positive = <MCUX_LPADC_CH0A>;
 	};
 
 	channel@1 {
@@ -31,6 +31,6 @@
 		zephyr,reference = "ADC_REF_EXTERNAL0";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
-                zephyr,input-positive = <MCUX_LPADC_CH1A>;
+		zephyr,input-positive = <MCUX_LPADC_CH1A>;
 	};
 };

--- a/tests/drivers/adc/adc_api/boards/nucleo_f722ze.overlay
+++ b/tests/drivers/adc/adc_api/boards/nucleo_f722ze.overlay
@@ -5,28 +5,28 @@
  */
 
 / {
-    zephyr,user {
-        io-channels = <&adc1 3>, <&adc1 10>;
-    };
+	zephyr,user {
+		io-channels = <&adc1 3>, <&adc1 10>;
+	};
 };
 
 &adc1 {
-    #address-cells = <1>;
-    #size-cells = <0>;
+	#address-cells = <1>;
+	#size-cells = <0>;
 
-    channel@3 {
-        reg = <3>;
-        zephyr,gain = "ADC_GAIN_1";
-        zephyr,reference = "ADC_REF_INTERNAL";
-        zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
-        zephyr,resolution = <12>;
-    };
+	channel@3 {
+		reg = <3>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
 
-    channel@a {
-        reg = <10>;
-        zephyr,gain = "ADC_GAIN_1";
-        zephyr,reference = "ADC_REF_INTERNAL";
-        zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
-        zephyr,resolution = <12>;
-    };
+	channel@a {
+		reg = <10>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
 };

--- a/tests/drivers/build_all/adc/boards/native_sim.overlay
+++ b/tests/drivers/build_all/adc/boards/native_sim.overlay
@@ -80,7 +80,7 @@
 				compatible = "ti,ads1119";
 				reg = <0x6>;
 				#io-channel-cells = <1>;
-  			};
+			};
 
 			test_i2c_ads1112: ads1112@7 {
 				compatible = "ti,ads1112";

--- a/tests/drivers/build_all/gnss/app.overlay
+++ b/tests/drivers/build_all/gnss/app.overlay
@@ -9,14 +9,14 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-                test_uart: uart@0 {
-                        compatible = "vnd,serial";
-                        reg = <0x0 0x1000>;
-                        status = "okay";
+		test_uart: uart@0 {
+			compatible = "vnd,serial";
+			reg = <0x0 0x1000>;
+			status = "okay";
 
 			gnss: gnss-nmea-generic {
 				compatible = "gnss-nmea-generic";
 			};
-                };
+		};
 	};
 };

--- a/tests/drivers/build_all/gpio/adc_ads1145s0x_gpio.overlay
+++ b/tests/drivers/build_all/gpio/adc_ads1145s0x_gpio.overlay
@@ -1,21 +1,21 @@
 &test_spi {
-        test_spi_ads114s08: ads114s08@0 {
-                compatible = "ti,ads114s08";
-                status = "okay";
-                spi-max-frequency = <10000000>;
-                reg = <0x00>;
-                #address-cells = <1>;
-                #size-cells = <0>;
-                #io-channel-cells = <1>;
-                reset-gpios = <&test_gpio 0 0>;
-                drdy-gpios = <&test_gpio 0 0>;
-                start-sync-gpios = <&test_gpio 0 0>;
+	test_spi_ads114s08: ads114s08@0 {
+		compatible = "ti,ads114s08";
+		status = "okay";
+		spi-max-frequency = <10000000>;
+		reg = <0x00>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		#io-channel-cells = <1>;
+		reset-gpios = <&test_gpio 0 0>;
+		drdy-gpios = <&test_gpio 0 0>;
+		start-sync-gpios = <&test_gpio 0 0>;
 
-                test_spi_ads114s08_gpio: ads114s0x_gpio {
-                        compatible = "ti,ads114s0x-gpio";
-                        gpio-controller;
-                        ngpios = <4>;
-                        #gpio-cells = <2>;
-                };
-        };
+		test_spi_ads114s08_gpio: ads114s0x_gpio {
+			compatible = "ti,ads114s0x-gpio";
+			gpio-controller;
+			ngpios = <4>;
+			#gpio-cells = <2>;
+		};
+	};
 };

--- a/tests/drivers/build_all/gpio/efinix_sapphire.overlay
+++ b/tests/drivers/build_all/gpio/efinix_sapphire.overlay
@@ -17,5 +17,5 @@
 			ngpios = <4>;
 			status = "okay";
 		};
-    };
+	};
 };

--- a/tests/drivers/build_all/gpio/iproc.overlay
+++ b/tests/drivers/build_all/gpio/iproc.overlay
@@ -6,7 +6,7 @@
  * Application overlay for testing iproc driver builds
  */
 
- / {
+/ {
 	test {
 		test_int_gpio {
 			#address-cells = <1>;

--- a/tests/drivers/build_all/i2c/boards/qemu_cortex_m3.overlay
+++ b/tests/drivers/build_all/i2c/boards/qemu_cortex_m3.overlay
@@ -6,32 +6,32 @@
 
  #include <zephyr/dt-bindings/i2c/i2c.h>
 
- / {
-    i2c0: i2c@88888888 {
-        compatible = "xlnx,xps-iic-2.00.a";
-        #address-cells = <1>;
-        #size-cells = <0>;
-        reg = <0x88888888 0x10000>;
-        interrupt-parent = <&nvic>;
-        interrupts = <4 1>;
-    };
+/ {
+	i2c0: i2c@88888888 {
+		compatible = "xlnx,xps-iic-2.00.a";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x88888888 0x10000>;
+		interrupt-parent = <&nvic>;
+		interrupts = <4 1>;
+	};
 
-    i2c1: i2c@88898888 {
-        compatible = "xlnx,xps-iic-2.1";
-        #address-cells = <1>;
-        #size-cells = <0>;
-        reg = <0x88898888 0x10000>;
-        interrupt-parent = <&nvic>;
-        interrupts = <5 1>;
-    };
+	i2c1: i2c@88898888 {
+		compatible = "xlnx,xps-iic-2.1";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x88898888 0x10000>;
+		interrupt-parent = <&nvic>;
+		interrupts = <5 1>;
+	};
 
-    i2c2: i2c@888A8888 {
+	i2c2: i2c@888A8888 {
 	compatible = "brcm,iproc-i2c";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
-        #address-cells = <1>;
-        #size-cells = <0>;
-        reg = <0x888A8888 0x100>;
-        interrupt-parent = <&nvic>;
-        interrupts = <6 1>;
-    };
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x888A8888 0x100>;
+		interrupt-parent = <&nvic>;
+		interrupts = <6 1>;
+	};
 };

--- a/tests/drivers/build_all/i3c/boards/qemu_cortex_m3.overlay
+++ b/tests/drivers/build_all/i3c/boards/qemu_cortex_m3.overlay
@@ -4,16 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- / {
-    i3c0: i3c@88888888 {
-        compatible = "cdns,i3c";
-        #address-cells = <3>;
-        #size-cells = <0>;
-        reg = <0x88888888 0x400>;
-        interrupt-parent = <&nvic>;
-        interrupts = <4 1>;
-        input-clock-frequency = <200000000>;
-        i3c-scl-hz = <12500000>;
-        i2c-scl-hz = <400000>;
-    };
+/ {
+	i3c0: i3c@88888888 {
+		compatible = "cdns,i3c";
+		#address-cells = <3>;
+		#size-cells = <0>;
+		reg = <0x88888888 0x400>;
+		interrupt-parent = <&nvic>;
+		interrupts = <4 1>;
+		input-clock-frequency = <200000000>;
+		i3c-scl-hz = <12500000>;
+		i2c-scl-hz = <400000>;
+	};
 };

--- a/tests/drivers/build_all/input/app.overlay
+++ b/tests/drivers/build_all/input/app.overlay
@@ -19,9 +19,9 @@
 
 			channel@0 {
 				reg = <0>;
-                                zephyr,gain = "ADC_GAIN_1";
-                                zephyr,reference = "ADC_REF_VDD_1";
-                                zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+				zephyr,gain = "ADC_GAIN_1";
+				zephyr,reference = "ADC_REF_VDD_1";
+				zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 			};
 		};
 
@@ -288,17 +288,17 @@
 				invert-y;
 			};
 
-                        paw32xx@3 {
-                                compatible = "pixart,paw32xx";
-                                reg = <3>;
-                                spi-max-frequency = <0>;
-                                motion-gpios = <&test_gpio 0 0>;
-                                zephyr,axis-x = <0>;
-                                zephyr,axis-y = <1>;
-                                invert-x;
-                                invert-y;
-                                res-cpi = <800>;
-                        };
+			paw32xx@3 {
+				compatible = "pixart,paw32xx";
+				reg = <3>;
+				spi-max-frequency = <0>;
+				motion-gpios = <&test_gpio 0 0>;
+				zephyr,axis-x = <0>;
+				zephyr,axis-y = <1>;
+				invert-x;
+				invert-y;
+				res-cpi = <800>;
+			};
 		};
 	};
 };

--- a/tests/drivers/build_all/uart/boards/qemu_cortex_m3.overlay
+++ b/tests/drivers/build_all/uart/boards/qemu_cortex_m3.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- / {
+/ {
 	uart3: uart@88888888 {
 		compatible = "cdns,uart";
 		reg = <0x88888888 0x400>;

--- a/tests/drivers/build_all/watchdog/boards/qemu_cortex_m3.overlay
+++ b/tests/drivers/build_all/watchdog/boards/qemu_cortex_m3.overlay
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- / {
-    watchdog: watchdog@88888888 {
-	compatible = "xlnx,xps-timebase-wdt-1.00.a";
-	reg = <0x88888888 0x10000>;
-	clocks = <&sysclk>;
-	xlnx,wdt-interval = <31>;
-	xlnx,wdt-enable-once = <1>;
-    };
+/ {
+	watchdog: watchdog@88888888 {
+		compatible = "xlnx,xps-timebase-wdt-1.00.a";
+		reg = <0x88888888 0x10000>;
+		clocks = <&sysclk>;
+		xlnx,wdt-interval = <31>;
+		xlnx,wdt-enable-once = <1>;
+	};
 };

--- a/tests/drivers/console_switching/boards/qemu_riscv64.overlay
+++ b/tests/drivers/console_switching/boards/qemu_riscv64.overlay
@@ -5,35 +5,35 @@
  */
 
 / {
-    chosen {
-        zephyr,console = &devmux0;
-        zephyr,shell_uart = &devmux0;
-    };
+	chosen {
+		zephyr,console = &devmux0;
+		zephyr,shell_uart = &devmux0;
+	};
 
-    euart0: uart_emul0 {
-        compatible = "zephyr,uart-emul";
-        current-speed = <0>;
-        status = "okay";
-    };
+	euart0: uart_emul0 {
+		compatible = "zephyr,uart-emul";
+		current-speed = <0>;
+		status = "okay";
+	};
 
-    euart1: uart_emul1 {
-        compatible = "zephyr,uart-emul";
-        current-speed = <0>;
-        status = "okay";
-    };
+	euart1: uart_emul1 {
+		compatible = "zephyr,uart-emul";
+		current-speed = <0>;
+		status = "okay";
+	};
 
-    devmux0: dev_mux_0 {
-        compatible = "zephyr,devmux";
-        devices = <&uart0 &euart0 &euart1>;
-        zephyr,mutable;
-        status = "okay";
-    };
+	devmux0: dev_mux_0 {
+		compatible = "zephyr,devmux";
+		devices = <&uart0 &euart0 &euart1>;
+		zephyr,mutable;
+		status = "okay";
+	};
 
-    devmux1: dev_mux_1 {
-        compatible = "zephyr,devmux";
-        devices = <&uart0 &euart0 &euart1>;
-        zephyr,mutable;
-        selected = <2>;
-        status = "okay";
-    };
+	devmux1: dev_mux_1 {
+		compatible = "zephyr,devmux";
+		devices = <&uart0 &euart0 &euart1>;
+		zephyr,mutable;
+		selected = <2>;
+		status = "okay";
+	};
 };

--- a/tests/drivers/counter/counter_basic_api/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
@@ -4,7 +4,7 @@
 
 /* PPR does not have interrupts for fast peripherals. */
 &timer120 {
-    status = "disabled";
+	status = "disabled";
 };
 
 &timer121 {

--- a/tests/drivers/dac/dac_loopback/boards/lpcxpresso55s36.overlay
+++ b/tests/drivers/dac/dac_loopback/boards/lpcxpresso55s36.overlay
@@ -5,6 +5,6 @@
  */
 
 &dac0 {
-    /* To align reference voltage with ADC. */
-    voltage-reference = <1>;
+	/* To align reference voltage with ADC. */
+	voltage-reference = <1>;
 };

--- a/tests/drivers/flash/common/boards/nrf52840_size_in_bytes.overlay
+++ b/tests/drivers/flash/common/boards/nrf52840_size_in_bytes.overlay
@@ -5,6 +5,6 @@
  */
 
 &mx25r64 {
-        /delete-property/ size;
-        size-in-bytes = <8388608>;
+	/delete-property/ size;
+	size-in-bytes = <8388608>;
 };

--- a/tests/drivers/gpio/gpio_basic_api/boards/cc1352r1_launchxl.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/cc1352r1_launchxl.overlay
@@ -7,9 +7,9 @@
 /* Connect DIO21 to DIO22 to run this test */
 
 / {
-        resources {
-                compatible = "test-gpio-basic-api";
-                out-gpios = <&gpio0 22 0>;
-                in-gpios = <&gpio0 21 0>;
-        };
+	resources {
+		compatible = "test-gpio-basic-api";
+		out-gpios = <&gpio0 22 0>;
+		in-gpios = <&gpio0 21 0>;
+	};
 };

--- a/tests/drivers/gpio/gpio_basic_api/boards/cc3220sf_launchxl.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/cc3220sf_launchxl.overlay
@@ -7,9 +7,9 @@
 /* Connect P07 to P08 to run this test */
 
 / {
-        resources {
-                compatible = "test-gpio-basic-api";
-                out-gpios = <&gpioa2 1 0>;
-                in-gpios = <&gpioa2 0 0>;
-        };
+	resources {
+		compatible = "test-gpio-basic-api";
+		out-gpios = <&gpioa2 1 0>;
+		in-gpios = <&gpioa2 0 0>;
+	};
 };

--- a/tests/drivers/gpio/gpio_basic_api/boards/cc3235sf_launchxl.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/cc3235sf_launchxl.overlay
@@ -7,9 +7,9 @@
 /* Connect P07 to P08 to run this test */
 
 / {
-        resources {
-                compatible = "test-gpio-basic-api";
-                out-gpios = <&gpioa2 1 0>;
-                in-gpios = <&gpioa2 0 0>;
-        };
+	resources {
+		compatible = "test-gpio-basic-api";
+		out-gpios = <&gpioa2 1 0>;
+		in-gpios = <&gpioa2 0 0>;
+	};
 };

--- a/tests/drivers/gpio/gpio_basic_api/boards/gd32f403z_eval.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/gd32f403z_eval.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- / {
+/ {
 	resources {
 		compatible = "test-gpio-basic-api";
 		/* Unplug jumpers from P3 and P2 and bridge PD0/PD1 */

--- a/tests/drivers/gpio/gpio_basic_api/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- / {
+/ {
 	resources {
 		compatible = "test-gpio-basic-api";
 		out-gpios = <&gpio1 10 0>;
@@ -13,9 +13,9 @@
 };
 
 &gpiote20 {
-    status = "okay";
+	status = "okay";
 };
 
 &gpio1 {
-    status = "okay";
+	status = "okay";
 };

--- a/tests/drivers/gpio/gpio_hogs/boards/frdm_k64f.overlay
+++ b/tests/drivers/gpio/gpio_hogs/boards/frdm_k64f.overlay
@@ -7,11 +7,11 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {
-     zephyr,user {
-             output-high-gpios = <&gpioc 5 GPIO_ACTIVE_LOW>;
-             output-low-gpios = <&gpiob 20 GPIO_ACTIVE_HIGH>;
-             input-gpios = <&gpioc 7 GPIO_ACTIVE_HIGH>;
-     };
+	zephyr,user {
+		output-high-gpios = <&gpioc 5 GPIO_ACTIVE_LOW>;
+		output-low-gpios = <&gpiob 20 GPIO_ACTIVE_HIGH>;
+		input-gpios = <&gpioc 7 GPIO_ACTIVE_HIGH>;
+	};
 };
 
 &gpioc {

--- a/tests/drivers/gpio/gpio_hogs/boards/native_sim.overlay
+++ b/tests/drivers/gpio/gpio_hogs/boards/native_sim.overlay
@@ -7,11 +7,11 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {
-     zephyr,user {
-             output-high-gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
-             output-low-gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
-             input-gpios = <&gpio0 3 GPIO_ACTIVE_HIGH>;
-     };
+	zephyr,user {
+		output-high-gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+		output-low-gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
+		input-gpios = <&gpio0 3 GPIO_ACTIVE_HIGH>;
+	};
 };
 
 &gpio0 {

--- a/tests/drivers/gpio/gpio_hogs/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/gpio/gpio_hogs/boards/nrf52840dk_nrf52840.overlay
@@ -7,11 +7,11 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {
-     zephyr,user {
-             output-high-gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
-             output-low-gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
-             input-gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
-     };
+	zephyr,user {
+		output-high-gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+		output-low-gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
+		input-gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+	};
 };
 
 &gpio0 {

--- a/tests/drivers/gpio/gpio_hogs/boards/nrf52_bsim.overlay
+++ b/tests/drivers/gpio/gpio_hogs/boards/nrf52_bsim.overlay
@@ -7,11 +7,11 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {
-     zephyr,user {
-             output-high-gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
-             output-low-gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
-             input-gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
-     };
+	zephyr,user {
+		output-high-gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+		output-low-gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
+		input-gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+	};
 };
 
 &gpio0 {

--- a/tests/drivers/gpio/gpio_hogs/boards/nucleo_g474re.overlay
+++ b/tests/drivers/gpio/gpio_hogs/boards/nucleo_g474re.overlay
@@ -7,11 +7,11 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {
-     zephyr,user {
-             output-high-gpios = <&gpioc 2 GPIO_ACTIVE_LOW>;
-             output-low-gpios = <&gpiof 1 GPIO_ACTIVE_HIGH>;
-             input-gpios = <&gpioc 3 GPIO_ACTIVE_HIGH>;
-     };
+	zephyr,user {
+		output-high-gpios = <&gpioc 2 GPIO_ACTIVE_LOW>;
+		output-low-gpios = <&gpiof 1 GPIO_ACTIVE_HIGH>;
+		input-gpios = <&gpioc 3 GPIO_ACTIVE_HIGH>;
+	};
 };
 
 &gpioc {

--- a/tests/drivers/gpio/gpio_ite_it8xxx2_v2/boards/native_sim.overlay
+++ b/tests/drivers/gpio/gpio_ite_it8xxx2_v2/boards/native_sim.overlay
@@ -9,37 +9,37 @@
 #include <zephyr/sys/util_macro.h>
 
 / {
-        intc: interrupt-controller@f03f00 {
-                compatible = "vnd,intc";
-                #address-cells = <0>;
-                #interrupt-cells = <2>;
-                interrupt-controller;
-                reg = <0x00f03f00 0x0100>;
-        };
+	intc: interrupt-controller@f03f00 {
+		compatible = "vnd,intc";
+		#address-cells = <0>;
+		#interrupt-cells = <2>;
+		interrupt-controller;
+		reg = <0x00f03f00 0x0100>;
+	};
 
-        gpioa: gpio@f01601 {
-                compatible = "ite,it8xxx2-gpio-v2";
-                reg = <0x00f01601 1   /* GPDR (set) */
-                        0x00f01618 1   /* GPDMR (get) */
-                        0x00f01630 1   /* GPOTR */
-                        0x00f01648 1   /* P18SCR */
-                        0x00f01660 8>; /* GPCR */
-                ngpios = <8>;
-                gpio-controller;
-                interrupts = <9 IRQ_TYPE_LEVEL_HIGH
-                                2 IRQ_TYPE_LEVEL_HIGH
-                                3 IRQ_TYPE_LEVEL_HIGH
-                                4 IRQ_TYPE_LEVEL_HIGH
-                                5 IRQ_TYPE_LEVEL_HIGH
-                                6 IRQ_TYPE_LEVEL_HIGH
-                                7 IRQ_TYPE_LEVEL_HIGH
-                                8 IRQ_TYPE_LEVEL_HIGH>;
-                interrupt-parent = <&intc>;
-                wuc-base = <0xf01b20 0xf01b20 0xf01b20 0xf01b1c
-                                0xf01b1c 0xf01b1c 0xf01b1c 0xf01b24>;
-                wuc-mask = <BIT(3)   BIT(4)   BIT(5)   BIT(0)
-                                BIT(1)   BIT(2)   BIT(3)   BIT(4)  >;
-                has-volt-sel = <1 1 1 1 1 1 1 1>;
-                #gpio-cells = <2>;
-        };
+	gpioa: gpio@f01601 {
+		compatible = "ite,it8xxx2-gpio-v2";
+		reg = <0x00f01601 1   /* GPDR (set) */
+		       0x00f01618 1   /* GPDMR (get) */
+		       0x00f01630 1   /* GPOTR */
+		       0x00f01648 1   /* P18SCR */
+		       0x00f01660 8>; /* GPCR */
+		ngpios = <8>;
+		gpio-controller;
+		interrupts = <9 IRQ_TYPE_LEVEL_HIGH
+			      2 IRQ_TYPE_LEVEL_HIGH
+			      3 IRQ_TYPE_LEVEL_HIGH
+			      4 IRQ_TYPE_LEVEL_HIGH
+			      5 IRQ_TYPE_LEVEL_HIGH
+			      6 IRQ_TYPE_LEVEL_HIGH
+			      7 IRQ_TYPE_LEVEL_HIGH
+			      8 IRQ_TYPE_LEVEL_HIGH>;
+		interrupt-parent = <&intc>;
+		wuc-base = <0xf01b20 0xf01b20 0xf01b20 0xf01b1c
+					0xf01b1c 0xf01b1c 0xf01b1c 0xf01b24>;
+		wuc-mask = <BIT(3)   BIT(4)   BIT(5)   BIT(0)
+			    BIT(1)   BIT(2)   BIT(3)   BIT(4)  >;
+		has-volt-sel = <1 1 1 1 1 1 1 1>;
+		#gpio-cells = <2>;
+	};
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/xmc47_relax_kit.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/xmc47_relax_kit.overlay
@@ -67,8 +67,8 @@
 };
 
 &i2c_sda_p3_15_u1c1 {
-    /delete-property/ drive-open-drain;
-    bias-pull-up;
+	/delete-property/ drive-open-drain;
+	bias-pull-up;
 };
 
 &i2c_sda_dout0_p1_9_u1c1 {

--- a/tests/drivers/i2c/i2c_tca954x/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/i2c/i2c_tca954x/boards/nrf52840dk_nrf52840.overlay
@@ -25,7 +25,7 @@
 			reg = <1>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-        };
+		};
 	};
 };
 

--- a/tests/drivers/i2s/i2s_speed/boards/mimxrt595_evk_mimxrt595s_cm33.overlay
+++ b/tests/drivers/i2s/i2s_speed/boards/mimxrt595_evk_mimxrt595s_cm33.overlay
@@ -12,9 +12,9 @@
 };
 
 &i2s0 {
-    status = "okay";
+	status = "okay";
 };
 
 &i2s1 {
-    status = "okay";
+	status = "okay";
 };

--- a/tests/drivers/input/gpio_kbd_matrix/boards/native_sim.overlay
+++ b/tests/drivers/input/gpio_kbd_matrix/boards/native_sim.overlay
@@ -5,7 +5,7 @@
  */
 
 &gpio0 {
-        ngpios = <12>;
+	ngpios = <12>;
 };
 
 / {

--- a/tests/drivers/input/kbd_matrix/boards/native_sim.overlay
+++ b/tests/drivers/input/kbd_matrix/boards/native_sim.overlay
@@ -13,5 +13,5 @@
 		debounce-down-ms = <40>;
 		debounce-up-ms = <80>;
 		poll-timeout-ms = <500>;
-        };
+	};
 };

--- a/tests/drivers/mspi/api/boards/native_sim.overlay
+++ b/tests/drivers/mspi/api/boards/native_sim.overlay
@@ -3,8 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-  / {
+/ {
 	aliases {
 		mspi0 = &mspi0;
 	};

--- a/tests/drivers/mspi/flash/boards/native_sim.overlay
+++ b/tests/drivers/mspi/flash/boards/native_sim.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- / {
+/ {
 	aliases {
 		mspi0 = &mspi0;
 	};

--- a/tests/drivers/pinctrl/api/app.overlay
+++ b/tests/drivers/pinctrl/api/app.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- / {
+/ {
 	pinctrl {
 		compatible = "vnd,pinctrl-test";
 

--- a/tests/drivers/pwm/pwm_api/boards/rcar_h3ulcb_r8a77951_r7.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/rcar_h3ulcb_r8a77951_r7.overlay
@@ -5,5 +5,5 @@
  */
 
 &pwm0 {
-    status = "okay";
+	status = "okay";
 };

--- a/tests/drivers/regulator/api/app.overlay
+++ b/tests/drivers/regulator/api/app.overlay
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- / {
+/ {
 	regulator: regulator {
 		compatible = "zephyr,fake-regulator";
 

--- a/tests/drivers/regulator/voltage/boards/rpi_pico.overlay
+++ b/tests/drivers/regulator/voltage/boards/rpi_pico.overlay
@@ -4,7 +4,7 @@
  */
 
 / {
-        /* NOTE: It is necessary to connect VREG_OUT to the ADC to perform the test.
+	/* NOTE: It is necessary to connect VREG_OUT to the ADC to perform the test.
 	 * But the rpi_pico board and most boards that use the rp2040, VREG_OUT and
 	 * DVDD are directly connected, and no available exposed trace on the board.
 	 *

--- a/tests/drivers/retained_mem/api/boards/nrf52840dk_nrf52840_ram.overlay
+++ b/tests/drivers/retained_mem/api/boards/nrf52840dk_nrf52840_ram.overlay
@@ -8,8 +8,8 @@
 		retainedmem0: retainedmem {
 			compatible = "zephyr,retained-ram";
 			status = "okay";
-	        };
-        };
+		};
+	};
 
 	aliases {
 		retainedmemtestdevice = &retainedmem0;

--- a/tests/drivers/retained_mem/api/boards/qemu_cortex_m3.overlay
+++ b/tests/drivers/retained_mem/api/boards/qemu_cortex_m3.overlay
@@ -10,8 +10,8 @@
 		retainedmem0: retainedmem {
 			compatible = "zephyr,retained-ram";
 			status = "okay";
-	        };
-        };
+		};
+	};
 
 	aliases {
 		retainedmemtestdevice = &retainedmem0;

--- a/tests/drivers/rtc/rtc_api/boards/da1469x_dk_pro.overlay
+++ b/tests/drivers/rtc/rtc_api/boards/da1469x_dk_pro.overlay
@@ -5,11 +5,11 @@
  */
 
 / {
-    aliases {
-        rtc = &rtc;
-    };
+	aliases {
+		rtc = &rtc;
+	};
 };
 
 &rtc {
-    status = "okay";
+	status = "okay";
 };

--- a/tests/drivers/rtc/rtc_api/boards/qemu_x86.overlay
+++ b/tests/drivers/rtc/rtc_api/boards/qemu_x86.overlay
@@ -10,9 +10,9 @@
  * operation and the update callback.
  */
 &hpet {
-        no-legacy-irq;
+	no-legacy-irq;
 };
 
 &rtc {
-        status = "okay";
+	status = "okay";
 };

--- a/tests/drivers/rtc/rtc_api/boards/qemu_x86_64.overlay
+++ b/tests/drivers/rtc/rtc_api/boards/qemu_x86_64.overlay
@@ -10,9 +10,9 @@
  * operation and the update callback.
  */
 &hpet {
-        no-legacy-irq;
+	no-legacy-irq;
 };
 
 &rtc {
-        status = "okay";
+	status = "okay";
 };

--- a/tests/drivers/spi/spi_loopback/boards/rpi_pico.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/rpi_pico.overlay
@@ -7,14 +7,14 @@
 #include <zephyr/dt-bindings/dma/rpi_pico_dma.h>
 
 &dma {
-        status = "okay";
+	status = "okay";
 };
 
 &spi0 {
 	cs-gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
 
-        dmas = <&dma 0 RPI_PICO_DMA_SLOT_SPI0_TX 0>, <&dma 1 RPI_PICO_DMA_SLOT_SPI0_RX 0>;
-        dma-names = "tx", "rx";
+	dmas = <&dma 0 RPI_PICO_DMA_SLOT_SPI0_TX 0>, <&dma 1 RPI_PICO_DMA_SLOT_SPI0_RX 0>;
+	dma-names = "tx", "rx";
 
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/rpi_pico_delete_dma_props.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/rpi_pico_delete_dma_props.overlay
@@ -5,6 +5,6 @@
  */
 
 &spi0 {
-        /delete-property/ dmas;
-        /delete-property/ dma-names;
+	/delete-property/ dmas;
+	/delete-property/ dma-names;
 };

--- a/tests/drivers/uart/uart_async_api/boards/intel_adl_crb.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/intel_adl_crb.overlay
@@ -5,9 +5,9 @@
  */
 
 dut: &uart2 {
-        status = "okay";
+	status = "okay";
 };
 
 &uart2_dma {
-        status = "okay";
+	status = "okay";
 };

--- a/tests/drivers/uart/uart_async_api/boards/intel_rpl_s_crb.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/intel_rpl_s_crb.overlay
@@ -5,9 +5,9 @@
  */
 
 dut: &uart0 {
-        status = "okay";
+	status = "okay";
 };
 
 &uart0_dma {
-        status = "okay";
+	status = "okay";
 };

--- a/tests/drivers/uart/uart_async_api/boards/mimxrt1010_evk.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/mimxrt1010_evk.overlay
@@ -1,9 +1,9 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 / {
-       chosen {
-               zephyr,sram = &dtcm;
-       };
+	chosen {
+		zephyr,sram = &dtcm;
+	};
 };
 
 dut: &lpuart4 {

--- a/tests/drivers/uart/uart_async_api/boards/mimxrt1015_evk.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/mimxrt1015_evk.overlay
@@ -1,9 +1,9 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 / {
-       chosen {
-               zephyr,sram = &dtcm;
-       };
+	chosen {
+		zephyr,sram = &dtcm;
+	};
 };
 
 dut: &lpuart4 {

--- a/tests/drivers/uart/uart_async_api/boards/mimxrt1020_evk.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/mimxrt1020_evk.overlay
@@ -1,9 +1,9 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 / {
-       chosen {
-               zephyr,sram = &dtcm;
-       };
+	chosen {
+		zephyr,sram = &dtcm;
+	};
 };
 
 dut: &lpuart2 {

--- a/tests/drivers/uart/uart_async_api/boards/mimxrt1024_evk.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/mimxrt1024_evk.overlay
@@ -1,9 +1,9 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 / {
-       chosen {
-               zephyr,sram = &dtcm;
-       };
+	chosen {
+		zephyr,sram = &dtcm;
+	};
 };
 
 dut: &lpuart2 {

--- a/tests/drivers/uart/uart_async_api/boards/mimxrt1050_evk.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/mimxrt1050_evk.overlay
@@ -1,9 +1,9 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 / {
-       chosen {
-               zephyr,sram = &dtcm;
-       };
+	chosen {
+		zephyr,sram = &dtcm;
+	};
 };
 
 dut: &lpuart3 {

--- a/tests/drivers/uart/uart_async_api/boards/mimxrt1060_evk.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/mimxrt1060_evk.overlay
@@ -1,9 +1,9 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 / {
-       chosen {
-               zephyr,sram = &dtcm;
-       };
+	chosen {
+		zephyr,sram = &dtcm;
+	};
 };
 
 dut: &lpuart3 {

--- a/tests/drivers/uart/uart_async_api/boards/mimxrt1060_evkb.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/mimxrt1060_evkb.overlay
@@ -1,9 +1,9 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 / {
-       chosen {
-               zephyr,sram = &dtcm;
-       };
+	chosen {
+		zephyr,sram = &dtcm;
+	};
 };
 
 dut: &lpuart3 {

--- a/tests/drivers/uart/uart_async_api/boards/mimxrt1064_evk.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/mimxrt1064_evk.overlay
@@ -1,9 +1,9 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 / {
-       chosen {
-               zephyr,sram = &dtcm;
-       };
+	chosen {
+		zephyr,sram = &dtcm;
+	};
 };
 
 dut: &lpuart3 {

--- a/tests/drivers/uart/uart_async_api/boards/mimxrt1160_evk_mimxrt1166_cm7.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/mimxrt1160_evk_mimxrt1166_cm7.overlay
@@ -1,9 +1,9 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 / {
-       chosen {
-               zephyr,sram = &dtcm;
-       };
+	chosen {
+		zephyr,sram = &dtcm;
+	};
 };
 
 dut: &lpuart2 {

--- a/tests/drivers/uart/uart_async_api/boards/mimxrt1170_evk_mimxrt1176_cm7_A.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/mimxrt1170_evk_mimxrt1176_cm7_A.overlay
@@ -1,9 +1,9 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 / {
-       chosen {
-               zephyr,sram = &dtcm;
-       };
+	chosen {
+		zephyr,sram = &dtcm;
+	};
 };
 
 dut: &lpuart2 {

--- a/tests/drivers/uart/uart_async_api/boards/stm32h735g_disco.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/stm32h735g_disco.overlay
@@ -9,7 +9,7 @@ dut: &uart7 {
 	dmas = <&dmamux1 2 80 STM32_DMA_PERIPH_TX>,
 		<&dmamux1 3 79 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
-    pinctrl-0 = <&uart7_tx_pf7 &uart7_rx_pf6>;
+	pinctrl-0 = <&uart7_tx_pf7 &uart7_rx_pf6>;
 	pinctrl-names = "default";
 	current-speed = <115200>;
 	status = "okay";

--- a/tests/kernel/timer/timer_behavior/boards/frdm_k64f.overlay
+++ b/tests/kernel/timer/timer_behavior/boards/frdm_k64f.overlay
@@ -5,9 +5,9 @@
  */
 
 / {
-    resources {
-        compatible = "test-kernel-timer-behavior-external";
+	resources {
+		compatible = "test-kernel-timer-behavior-external";
 
-        timerout-gpios = <&gpioc 3 GPIO_ACTIVE_LOW>; /* Arduino D7 */
-    };
+		timerout-gpios = <&gpioc 3 GPIO_ACTIVE_LOW>; /* Arduino D7 */
+	};
 };

--- a/tests/kernel/timer/timer_behavior/boards/mec15xxevb_assy6853.overlay
+++ b/tests/kernel/timer/timer_behavior/boards/mec15xxevb_assy6853.overlay
@@ -5,9 +5,9 @@
  */
 
 / {
-    resources {
-        compatible = "test-kernel-timer-behavior-external";
+	resources {
+		compatible = "test-kernel-timer-behavior-external";
 
-        timerout-gpios = <&gpio_140_176 14 GPIO_ACTIVE_LOW>;
-    };
+		timerout-gpios = <&gpio_140_176 14 GPIO_ACTIVE_LOW>;
+	};
 };

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -56,9 +56,9 @@
 		};
 
 		test_phandles: phandle-holder-0 {
-                        /*
-                         * There should only be one vnd,phandle-holder in the entire DTS.
-                         */
+			/*
+			 * There should only be one vnd,phandle-holder in the entire DTS.
+			 */
 			compatible = "vnd,phandle-holder";
 			/*
 			 * At least one of these phandles must refer to
@@ -164,7 +164,7 @@
 			#baz-cells = < 0x1 >;
 			interrupts = <4 3>;
 			status = "okay";
-                        ngpios = <100>;
+			ngpios = <100>;
 
 			test_gpio_hog_1 {
 				gpio-hog;
@@ -189,7 +189,7 @@
 			#baz-cells = < 0x1 >;
 			interrupts = <5 2>;
 			status = "okay";
-                        ngpios = <200>;
+			ngpios = <200>;
 
 			test_gpio_hog_3 {
 				gpio-hog;
@@ -611,7 +611,7 @@
 				#size-cells = <1>;
 
 				ranges = <0x0 0x0 0x0 0x3eff0000 0x10000>,
-				         <0x0 0x10000000 0x0 0x10000000 0x2eff0000>;
+					 <0x0 0x10000000 0x0 0x10000000 0x2eff0000>;
 			};
 
 			test_ranges_empty: empty@2 {
@@ -755,8 +755,8 @@
 		};
 	};
 
-        non-deprecated-label {
-                compatible = "vnd,non-deprecated-label";
-                label = "FOO";
-        };
+	non-deprecated-label {
+		compatible = "vnd,non-deprecated-label";
+		label = "FOO";
+	};
 };

--- a/tests/lib/devicetree/api_ext/app.overlay
+++ b/tests/lib/devicetree/api_ext/app.overlay
@@ -11,7 +11,7 @@
  * (and be extended to test) real hardware.
  */
 
- / {
+/ {
 	test {
 		#address-cells = < 0x1 >;
 		#size-cells = < 0x1 >;

--- a/tests/lib/devicetree/memory_region/app.overlay
+++ b/tests/lib/devicetree/memory_region/app.overlay
@@ -2,7 +2,7 @@
  * Copyright (c) 2022, Carlo Caione <ccaione@baylibre.com>
  */
 
- / {
+/ {
 	test {
 		#address-cells = < 0x1 >;
 		#size-cells = < 0x1 >;

--- a/tests/lib/gui/lvgl/boards/stm32h747i_disco_stm32h747xx_m7.overlay
+++ b/tests/lib/gui/lvgl/boards/stm32h747i_disco_stm32h747xx_m7.overlay
@@ -5,7 +5,7 @@
  */
 
 &sdmmc1 {
-        sdmmc {
+	sdmmc {
 		compatible = "zephyr,sdmmc-disk";
 	};
 };

--- a/tests/subsys/emul/app.overlay
+++ b/tests/subsys/emul/app.overlay
@@ -19,13 +19,13 @@
 
 	emul_tester_a: driver@aa {
 		compatible = "vnd,emul-tester";
-                reg = <0xaa>;
+		reg = <0xaa>;
 		status = "okay";
 		scale = <1>;
 	};
 	emul_tester_b: driver@bb {
 		compatible = "vnd,emul-tester";
-                reg = <0xbb>;
+		reg = <0xbb>;
 		status = "okay";
 		scale = <10>;
 	};

--- a/tests/subsys/fs/ext2/boards/hifive_unmatched.overlay
+++ b/tests/subsys/fs/ext2/boards/hifive_unmatched.overlay
@@ -5,16 +5,16 @@
  */
 
 &spi2 {
-        status = "okay";
+	status = "okay";
 
-        sdhc0: sdhc@0 {
-                compatible = "zephyr,sdhc-spi-slot";
-                reg = <0>;
-                status = "okay";
-                mmc {
-                    compatible = "zephyr,sdmmc-disk";
-                    status = "okay";
-                };
-                spi-max-frequency = <20000000>;
-        };
+	sdhc0: sdhc@0 {
+		compatible = "zephyr,sdhc-spi-slot";
+		reg = <0>;
+		status = "okay";
+		mmc {
+			compatible = "zephyr,sdmmc-disk";
+			status = "okay";
+		};
+		spi-max-frequency = <20000000>;
+	};
 };

--- a/tests/subsys/input/longpress/boards/native_sim.overlay
+++ b/tests/subsys/input/longpress/boards/native_sim.overlay
@@ -18,7 +18,7 @@
 		short-codes = <INPUT_KEY_A>, <INPUT_KEY_B>;
 		long-codes = <INPUT_KEY_X>, <INPUT_KEY_Y>;
 		long-delay-ms = <100>;
-        };
+	};
 
 	longpress_no_short: longpress-no-short {
 		input = <&fake_input_device>;

--- a/tests/subsys/lorawan/clock_sync/boards/native_sim.overlay
+++ b/tests/subsys/lorawan/clock_sync/boards/native_sim.overlay
@@ -9,9 +9,9 @@
 #include <zephyr/dt-bindings/lora/sx126x.h>
 
 / {
-        chosen {
-                zephyr,code-partition = &slot0_partition;
-        };
+	chosen {
+		zephyr,code-partition = &slot0_partition;
+	};
 
 	aliases {
 		lora0 = &lora;

--- a/tests/subsys/lorawan/frag_decoder/boards/native_sim.overlay
+++ b/tests/subsys/lorawan/frag_decoder/boards/native_sim.overlay
@@ -9,9 +9,9 @@
 #include <zephyr/dt-bindings/lora/sx126x.h>
 
 / {
-        chosen {
-                zephyr,code-partition = &slot0_partition;
-        };
+	chosen {
+		zephyr,code-partition = &slot0_partition;
+	};
 
 	aliases {
 		lora0 = &lora;

--- a/tests/subsys/tracing/tracing_api/boards/qemu_x86.overlay
+++ b/tests/subsys/tracing/tracing_api/boards/qemu_x86.overlay
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 / {
-       chosen {
-               zephyr,tracing-uart = &uart0;
-       };
+	chosen {
+		zephyr,tracing-uart = &uart0;
+	};
 };

--- a/tests/subsys/usb/uac2/app.overlay
+++ b/tests/subsys/usb/uac2/app.overlay
@@ -40,11 +40,11 @@
 			clock-source = <&uac_aclk>;
 			terminal-type = <BIDIRECTIONAL_TERMINAL_HEADSET>;
 			/* Circular reference, macros will figure it out and
-                         * provide correct associated terminal ID because the
-                         * terminals associations are always 1-to-1.
-                         *
-                         * assoc-terminal = <&headphones_output>;
-                         */
+			 * provide correct associated terminal ID because the
+			 * terminals associations are always 1-to-1.
+			 *
+			 * assoc-terminal = <&headphones_output>;
+			 */
 			front-left;
 		};
 


### PR DESCRIPTION
`checkpatch.pl` requires that dts sources are indented with tabs, fix all the spaces that slipped in while checkpatch wasn't watching (#74570).
