### PR TITLE
drivers: rtc: rtc_ll_stm32: coverity 368806 fix

### DIFF
--- a/drivers/rtc/rtc_ll_stm32.c
+++ b/drivers/rtc/rtc_ll_stm32.c
@@ -537,7 +537,7 @@ static int rtc_stm32_get_time(const struct device *dev, struct rtc_time *timeptr
 #if HW_SUBSECOND_SUPPORT
 	uint64_t temp = ((uint64_t)(cfg->sync_prescaler - rtc_subsecond)) * 1000000000L;
 
-	timeptr->tm_nsec = DIV_ROUND_CLOSEST(temp, cfg->sync_prescaler + 1);
+	timeptr->tm_nsec = temp / (cfg->sync_prescaler + 1);
 #else
 	timeptr->tm_nsec = 0;
 #endif


### PR DESCRIPTION
Replace `DIV_ROUND_CLOSEST()` with a normal division to simplify operation and avoid redundant handling of signed integer rounding as the `temp` value is an unsigned value. The `temp` value is in nano precision, so rounding is largely inconsequential anyway compared to the comparatively low precision `sync_prescaler`.

Fixes: #74773

sanity check with `b_u585i_iot02a` to make sure it didn't break anything :)
```
uart:~$ rtc get rtc@46007800
2024-01-01T00:00:09.156
uart:~$ rtc get rtc@46007800
2024-01-01T00:00:09.304
uart:~$ rtc get rtc@46007800
2024-01-01T00:00:09.460
uart:~$ rtc get rtc@46007800
2024-01-01T00:00:09.605
uart:~$ rtc get rtc@46007800
2024-01-01T00:00:09.753
uart:~$ rtc get rtc@46007800
2024-01-01T00:00:09.894
uart:~$ rtc get rtc@46007800
2024-01-01T00:00:10.050
uart:~$ rtc get rtc@46007800
2024-01-01T00:00:10.199
uart:~$ rtc get rtc@46007800
```