### PR TITLE
Bluetooth: shell: Fix missing check for buffer allocation

### DIFF
--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -1244,6 +1244,11 @@ static int cmd_hci_cmd(const struct shell *sh, size_t argc, char *argv[])
 		}
 
 		buf = bt_hci_cmd_create(BT_OP(ogf, ocf), len);
+		if (buf == NULL) {
+			shell_error(sh, "Unable to allocate HCI buffer");
+			return -ENOMEM;
+		}
+
 		net_buf_add_mem(buf, hex_data, len);
 	}
 


### PR DESCRIPTION
In practice this allocation is very unlikely to fail, however being consistent with checking for a failure keeps Coverity happy.

Fixes #74725