### PR TITLE
include: adc: Fix initialization of .differential in ADC_CHANNEL_CFG_DT

### DIFF
--- a/include/zephyr/drivers/adc.h
+++ b/include/zephyr/drivers/adc.h
@@ -241,12 +241,13 @@ struct adc_channel_cfg {
 	.reference        = DT_STRING_TOKEN(node_id, zephyr_reference), \
 	.acquisition_time = DT_PROP(node_id, zephyr_acquisition_time), \
 	.channel_id       = DT_REG_ADDR(node_id), \
-IF_ENABLED(CONFIG_ADC_CONFIGURABLE_INPUTS, \
-	(.differential    = DT_NODE_HAS_PROP(node_id, zephyr_input_negative), \
-	 .input_positive  = DT_PROP_OR(node_id, zephyr_input_positive, 0), \
-	 .input_negative  = DT_PROP_OR(node_id, zephyr_input_negative, 0),)) \
-IF_ENABLED(DT_PROP(node_id, zephyr_differential), \
+IF_ENABLED(UTIL_OR(DT_PROP(node_id, zephyr_differential), \
+		   UTIL_AND(CONFIG_ADC_CONFIGURABLE_INPUTS, \
+			    DT_NODE_HAS_PROP(node_id, zephyr_input_negative))), \
 	(.differential    = true,)) \
+IF_ENABLED(CONFIG_ADC_CONFIGURABLE_INPUTS, \
+	(.input_positive  = DT_PROP_OR(node_id, zephyr_input_positive, 0), \
+	 .input_negative  = DT_PROP_OR(node_id, zephyr_input_negative, 0),)) \
 IF_ENABLED(CONFIG_ADC_CONFIGURABLE_EXCITATION_CURRENT_SOURCE_PIN, \
 	(.current_source_pin_set = DT_NODE_HAS_PROP(node_id, zephyr_current_source_pin), \
 	 .current_source_pin = DT_PROP_OR(node_id, zephyr_current_source_pin, {0}),)) \


### PR DESCRIPTION
This is a follow-up to commit ff0f389d0b26999443444b0e37c4d66d4a845eff.

When the `zephyr,differential` property is used together with a driver that selects `ADC_CONFIGURABLE_INPUTS`, the `differential` field is initialized twice what causes a compilation error in C++. Fix this by refactoring the logic around initialization of `.differential`.

Fixes #74686.