### PR TITLE
net: tcp: Coverity fixes

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -278,7 +278,7 @@ int net_tcp_endpoint_copy(struct net_context *ctx,
 	}
 
 	if (peer != NULL) {
-		memcpy(local, &conn->dst.sa, newlen);
+		memcpy(peer, &conn->dst.sa, newlen);
 	}
 
 	return 0;


### PR DESCRIPTION
Fixes for Coverity reports in TCP subsystem.

Fixes #74788
Fixes #74789
Fixes #74792