### PR TITLE
Fix implicit function declaration warning for subsys/net/lib/http/http_server_http1.c

### DIFF
--- a/subsys/net/lib/http/http_server_http1.c
+++ b/subsys/net/lib/http/http_server_http1.c
@@ -5,6 +5,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#undef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L /* Required for strnlen() */
+
 #include <errno.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/tests/net/lib/http_server/hpack/testcase.yaml
+++ b/tests/net/lib/http_server/hpack/testcase.yaml
@@ -9,5 +9,8 @@ common:
   integration_platforms:
     - native_sim
     - qemu_x86
+  platform_exclude:
+    - native_posix
+    - native_posix/native/64
 tests:
   net.http.server.http2_hpack: {}


### PR DESCRIPTION
    subsys/net/lib/http: Set feature macro as required
    
    This file uses strnlen() but the C library is not require to expose its prototype unless
    _POSIX_C_SOURCE is defined.
    So let's define it to avoid an implicit function declaration warning.

-------

    tests/net/lib/http_server/hpack: Exclude native_posix
    
    This test explicitly enables the POSIX_API which is not compatible with native_posix.
    Let's exclude this target.
    
Fixes #74843