### PR TITLE
soc: esp32c3: fix tls linking error

### DIFF
--- a/soc/espressif/esp32c3/default.ld
+++ b/soc/espressif/esp32c3/default.ld
@@ -787,10 +787,12 @@ SECTIONS
   {
     . = ALIGN(4);
 
+#ifdef CONFIG_THREAD_LOCAL_STORAGE
      /* create explicit symbol for __tdata_start so that it is loaded
       * into proper DROM region atributted by AT keyword below
       */
     __tdata_start = ADDR(tdata);
+#endif
 
     _rodata_reserved_end = ABSOLUTE(.);
     _image_rodata_end = ABSOLUTE(.);


### PR DESCRIPTION
Fix linking error due undefined tdata entry.
After #72642, tdata could be undefined due to
missing TLS check.

Fixed #74852