### PR TITLE
drivers/sensor: lis2mdl: use common SPI duplex option

### DIFF
--- a/boards/st/sensortile_box/sensortile_box.dts
+++ b/boards/st/sensortile_box/sensortile_box.dts
@@ -191,7 +191,6 @@
 	lis2mdl: lis2mdl@0 {
 		compatible = "st,lis2mdl";
 		spi-max-frequency = <1000000>;
-		spi-full-duplex;
 		reg = <0>;
 	};
 };

--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -238,6 +238,9 @@ Device Drivers and Devicetree
         };
     };
 
+* `st,lis2mdl` property `spi-full-duplex` changed to `duplex =
+  SPI_FULL_DUPLEX`. Full duplex is now the default.
+
 Analog-to-Digital Converter (ADC)
 =================================
 

--- a/drivers/sensor/st/lis2mdl/lis2mdl.c
+++ b/drivers/sensor/st/lis2mdl/lis2mdl.c
@@ -528,10 +528,11 @@ static int lis2mdl_pm_action(const struct device *dev,
 		STMEMSC_CTX_SPI(&lis2mdl_config_##inst.stmemsc_cfg),	\
 		.stmemsc_cfg = {					\
 			.spi = SPI_DT_SPEC_INST_GET(inst,		\
-					   LIS2MDL_SPI_OPERATION,	\
-					   0),				\
+						LIS2MDL_SPI_OPERATION,	\
+						0),			\
 		},							\
-		.spi_4wires = DT_INST_PROP(inst, spi_full_duplex),	\
+		.spi_4wires = DT_INST_PROP(inst, duplex) ==		\
+						SPI_FULL_DUPLEX,	\
 		LIS2MDL_CONFIG_COMMON(inst)				\
 	}
 

--- a/dts/bindings/sensor/st,lis2mdl-common.yaml
+++ b/dts/bindings/sensor/st,lis2mdl-common.yaml
@@ -23,8 +23,3 @@ properties:
     description: |
       Set to enable the offset cancellation. Otherwise it would be
       disabled as default.
-
-  spi-full-duplex:
-    type: boolean
-    description: |
-      Enable SPI 4wires mode with separated MISO and MOSI lines


### PR DESCRIPTION
Driver used a custom SPI duplex option. Replaced with the common one found in spi-device.yaml.