### PR TITLE
net: sockets: tls: Fix iov_len comparison in sendmsg()

### DIFF
--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -2457,7 +2457,7 @@ static ssize_t dtls_sendmsg_merge_and_send(struct tls_context *ctx,
 	for (int i = 0; i < msg->msg_iovlen; i++) {
 		struct iovec *vec = msg->msg_iov + i;
 
-		if (vec->iov_len >= 0) {
+		if (vec->iov_len > 0) {
 			if (len + vec->iov_len > sizeof(sendmsg_buf)) {
 				k_mutex_unlock(&sendmsg_lock);
 				errno = EMSGSIZE;


### PR DESCRIPTION
vec->iov_len is of type size_t, so the comparison was always true. Additionally, doing the memcpy() when iov_len was 0 did not really make sense, so do it only when the actual length is larger than 0.

Fixes #74785