### PR TITLE
driver: spi: gd32: fix spi reg clear wrong flag

### DIFF
--- a/drivers/spi/spi_gd32.c
+++ b/drivers/spi/spi_gd32.c
@@ -414,11 +414,13 @@ static int spi_gd32_transceive_impl(const struct device *dev,
 
 #ifdef CONFIG_SPI_GD32_DMA
 dma_error:
+	SPI_CTL1(cfg->reg) &=
+		~(SPI_CTL1_DMATEN | SPI_CTL1_DMAREN);
 #endif
 	spi_context_cs_control(&data->ctx, false);
 
 	SPI_CTL0(cfg->reg) &=
-		~(SPI_CTL0_SPIEN | SPI_CTL1_DMATEN | SPI_CTL1_DMAREN);
+		~(SPI_CTL0_SPIEN);
 
 error:
 	spi_context_release(&data->ctx, ret);


### PR DESCRIPTION
SPI DMATEN and DMAREN flags are in SPI_CTL1 register. fixed wrong register.