### PR TITLE
cmake: emu: armfvp: Fix find program’s search paths

### DIFF
--- a/cmake/emu/armfvp.cmake
+++ b/cmake/emu/armfvp.cmake
@@ -1,11 +1,9 @@
 # Copyright (c) 2021-2022 Arm Limited (or its affiliates). All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-set(armfvp_bin_path $ENV{ARMFVP_BIN_PATH})
-
 find_program(
   ARMFVP
-  PATHS ${armfvp_bin_path}
+  PATHS ENV ARMFVP_BIN_PATH
   NO_DEFAULT_PATH
   NAMES ${ARMFVP_BIN_NAME}
   )


### PR DESCRIPTION
The current implementation does not work well when ARMFVP_BIN_PATH is a colon separated list.

This lets `find_program` deal with the lists.