### PR TITLE
Update MAX32xxx UART Driver

### DIFF
--- a/drivers/serial/uart_max32.c
+++ b/drivers/serial/uart_max32.c
@@ -300,8 +300,10 @@ static void api_irq_tx_disable(const struct device *dev)
 static int api_irq_tx_ready(const struct device *dev)
 {
 	struct max32_uart_data *const data = dev->data;
+	const struct max32_uart_config *cfg = dev->config;
+	uint32_t inten = Wrap_MXC_UART_GetRegINTEN(cfg->regs);
 
-	return ((data->flags & (ADI_MAX32_UART_INT_TX | ADI_MAX32_UART_INT_TX_OEM)) ||
+	return ((inten & (ADI_MAX32_UART_INT_TX | ADI_MAX32_UART_INT_TX_OEM)) &&
 		!(data->status & MXC_F_UART_STATUS_TX_FULL));
 }
 
@@ -333,8 +335,10 @@ static int api_irq_tx_complete(const struct device *dev)
 static int api_irq_rx_ready(const struct device *dev)
 {
 	struct max32_uart_data *const data = dev->data;
+	const struct max32_uart_config *cfg = dev->config;
+	uint32_t inten = Wrap_MXC_UART_GetRegINTEN(cfg->regs);
 
-	return (data->flags & ADI_MAX32_UART_INT_RX);
+	return ((inten & ADI_MAX32_UART_INT_RX) && !(data->status & ADI_MAX32_UART_RX_EMPTY));
 }
 
 static void api_irq_err_enable(const struct device *dev)

--- a/west.yml
+++ b/west.yml
@@ -137,7 +137,7 @@ manifest:
       groups:
         - fs
     - name: hal_adi
-      revision: 2858da5ab4a7a01cde48a41818a1a6693529f68d
+      revision: dee9a7b1eff13a9da0560daf8842d61657f9d61e
       path: modules/hal/adi
       groups:
         - hal


### PR DESCRIPTION
As per of [irq_tx_ready](https://github.com/zephyrproject-rtos/zephyr/blob/main/include/zephyr/drivers/uart.h#L916) and [rx_ready](https://github.com/zephyrproject-rtos/zephyr/blob/main/include/zephyr/drivers/uart.h#L1017) function description these function content need to be updated. Expected workflow

tx_ready: if tx interrupt enabled AND tx fifo is not full
rx_ready: if rx interrupt enalbed AND rx fifo not empty

Test output with IPO/IBRO clock.
![image](https://github.com/zephyrproject-rtos/zephyr/assets/46590392/8b0736a8-c19d-47ac-9987-6f4ad66a5df8)

P.S: IBRO clock configuration
![image](https://github.com/zephyrproject-rtos/zephyr/assets/46590392/b0786eac-797e-4716-bf8e-3ca72f502064)

@MaureenHelm  FYI.