### PR TITLE
Do not loose terminating null in mdns_responder for network interface name

### DIFF
--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -794,7 +794,7 @@ config NET_INTERFACE_NAME
 config NET_INTERFACE_NAME_LEN
 	int "Network interface max name length"
 	default 8
-	range 1 15
+	range 2 15
 	depends on NET_INTERFACE_NAME
 	help
 	  Maximum length of the network interface name.

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -741,7 +741,7 @@ static int init_listener(void)
 				ifindex, ret);
 		} else {
 			memset(&if_req, 0, sizeof(if_req));
-			strncpy(if_req.ifr_name, name, sizeof(if_req.ifr_name));
+			strncpy(if_req.ifr_name, name, sizeof(if_req.ifr_name) - 1);
 
 			ret = zsock_setsockopt(v6, SOL_SOCKET, SO_BINDTODEVICE,
 					       &if_req, sizeof(if_req));


### PR DESCRIPTION
Copy one byte less so that the possible terminating null is not lost.

Fixes #74795