### PR TITLE
net: lib: lwm2m: Fix expected block calculation

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -2107,13 +2107,7 @@ static int parse_write_op(struct lwm2m_message *msg, uint16_t format)
 		}
 
 		block_ctx->last_block = last_block;
-
-		/* Initial block sent by the server might be larger or smaller than
-		 * our block size, therefore it is needed to take this into account
-		 * when calculating next expected block number.
-		 */
-		block_ctx->expected +=
-			1 << MAX(0, GET_BLOCK_SIZE(block_opt) - block_ctx->ctx.block_size);
+		block_ctx->expected++;
 	}
 
 	r = do_write_op(msg, format);


### PR DESCRIPTION
Coverity reported that a formula used to calculate the next expected block in case the block size from the request differs our own block size has a bug. The expression used to calculate the block size diff would evaluate to an unsigned integer, giving (wrongly) enormous results in case block size from the request is smaller than the Zephyr's default.

It turns out however, that this formula is no longer needed at all. Since commit d3081e2f30fd17a1e737db378d1b1e3cecf53fb2, Zephyr's LwM2M implementation will no longer negotiate the block size in case of write operation, but simply comply with the block size included in the request. This means that calculating the diff makes no longer sense and can be safely removed - the next expected block number should be simply increased by 1.

Fixes #74786