### PR TITLE
net: websocket: Remove dead code

### DIFF
--- a/subsys/net/lib/websocket/websocket.c
+++ b/subsys/net/lib/websocket/websocket.c
@@ -1184,10 +1184,6 @@ int websocket_register(int sock, uint8_t *recv_buf, size_t recv_buf_len)
 	return fd;
 
 out:
-	if (fd >= 0) {
-		(void)zsock_close(fd);
-	}
-
 	websocket_context_unref(ctx);
 
 	return ret;


### PR DESCRIPTION
The zsock_close() is not needed as the fd is always <0 so the close is never called.

Fixes #74791
Coverity-CID: 366273