### PR TITLE
tests: net: socket: Add tests for tracing

### DIFF
--- a/tests/net/socket/tcp/testcase.yaml
+++ b/tests/net/socket/tcp/testcase.yaml
@@ -19,3 +19,13 @@ tests:
     extra_configs:
       - CONFIG_NET_TC_THREAD_PREEMPTIVE=y
       - CONFIG_NET_TCP_RANDOMIZED_RTO=n
+  net.socket.tcp.tracing:
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+    extra_configs:
+      - CONFIG_TRACING=y
+      - CONFIG_TRACING_CTF=y
+      - CONFIG_TRACING_BACKEND_POSIX=y
+      - CONFIG_TRACING_PACKET_MAX_SIZE=256
+      - CONFIG_TRACING_SYNC=y

--- a/tests/net/socket/udp/testcase.yaml
+++ b/tests/net/socket/udp/testcase.yaml
@@ -28,3 +28,13 @@ tests:
       - CONFIG_NET_STATISTICS_USER_API=y
       - CONFIG_NET_MGMT_EVENT=y
       - CONFIG_NET_MGMT=y
+  net.socket.udp.tracing:
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+    extra_configs:
+      - CONFIG_TRACING=y
+      - CONFIG_TRACING_CTF=y
+      - CONFIG_TRACING_BACKEND_POSIX=y
+      - CONFIG_TRACING_PACKET_MAX_SIZE=256
+      - CONFIG_TRACING_SYNC=y


### PR DESCRIPTION
Make sure we at least build test the network socket tracing support. The tracing tests do not enable networking so do the socket tracing tests here.