### PR TITLE
net: dns: Do not fail if cache flush bit is set in class

### DIFF
--- a/subsys/net/lib/dns/dns_pack.c
+++ b/subsys/net/lib/dns/dns_pack.c
@@ -590,7 +590,7 @@ int dns_unpack_query(struct dns_msg_t *dns_msg, struct net_buf *buf,
 	}
 
 	query_class = dns_unpack_query_qclass(end_of_label);
-	if (query_class != DNS_CLASS_IN) {
+	if ((query_class & DNS_CLASS_IN) != DNS_CLASS_IN) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Mask the DNS_CLASS_FLUSH value when checking if the DNS_CLASS_IN is set when unpacking a query.

Fixes #74829