### PR TITLE
tests: fs: nvs: Add several tests to check NVS resiliency to an undetected bad ATE

### DIFF
--- a/tests/subsys/fs/nvs/src/main.c
+++ b/tests/subsys/fs/nvs/src/main.c
@@ -979,6 +979,15 @@ static void test_nvs_undetected_bad_ate_length_callback(struct nvs_ate *ate,
 		   (items[3].size / 2); /* Half of the next item data */
 }
 
+/* The offset of the data is wrong and overflows on the previous item data */
+static void test_nvs_undetected_bad_ate_offset_callback(struct nvs_ate *ate,
+							struct bad_ate_item_t *items)
+{
+	/* Take data CRCs into account */
+	ate->offset = (items[0].size + sizeof(uint32_t)) / 2;
+	ate->len = items[1].size + sizeof(uint32_t);
+}
+
 static void test_nvs_undetected_bad_ate_main(struct nvs_fixture *fixture,
 					     bad_ate_item_callback_t callback_corrupt_ate)
 {
@@ -1113,5 +1122,20 @@ ZTEST_F(nvs, test_nvs_undetected_bad_ate_length)
 {
 #if defined(CONFIG_NVS_DATA_CRC) && !defined(CONFIG_NVS_LOOKUP_CACHE)
 	test_nvs_undetected_bad_ate_main(fixture, test_nvs_undetected_bad_ate_length_callback);
+#endif
+}
+
+/*
+ * Tamper an ATE offset field value to simulate an ATE CRC-8 undetected error.
+ * Write 4 items of various data size, with the item #1 simulating a CRC-8 undetected error
+ * on the item data size. The data offset is decreased to overflow on item 0.
+ * Thanks to the data CRC-32, reading such item returns an error.
+ * After running the garbage collector, the faulty item 1 has been copied with parts of the
+ * preceding item data. The other items are healthy and the NVS is still working.
+ */
+ZTEST_F(nvs, test_nvs_undetected_bad_ate_offset)
+{
+#if defined(CONFIG_NVS_DATA_CRC) && !defined(CONFIG_NVS_LOOKUP_CACHE)
+	test_nvs_undetected_bad_ate_main(fixture, test_nvs_undetected_bad_ate_offset_callback);
 #endif
 }


### PR DESCRIPTION
With data CRC-32 enabled, check that correct data is still correct even if an ATE length and/or offset fields are corrupted and this corruption is not detected by the ATE 8-bit CRC. Check also that the corrupted ATE data is always considered bad thanks to the CRC-32.

In addition, fix the formatting of the NVS data CRC notes in the documentation.