### PR TITLE
boards: croxel_cx1825: fix: Remove arduino support claims

### DIFF
--- a/boards/croxel/croxel_cx1825/croxel_cx1825_nrf52840.dts
+++ b/boards/croxel/croxel_cx1825/croxel_cx1825_nrf52840.dts
@@ -81,7 +81,7 @@
 	pinctrl-names = "default", "sleep";
 };
 
-arduino_i2c: &i2c0 {
+&i2c0 {
 	compatible = "nordic,nrf-twi";
 	status = "okay";
 	pinctrl-0 = <&i2c0_default>;

--- a/boards/croxel/croxel_cx1825/croxel_cx1825_nrf52840.yaml
+++ b/boards/croxel/croxel_cx1825/croxel_cx1825_nrf52840.yaml
@@ -9,8 +9,6 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
-  - arduino_gpio
-  - arduino_i2c
   - ble
   - counter
   - gpio


### PR DESCRIPTION
This board is not compatible with the Arduino pinout. Therefore, this patch removes all Arduino references to avoid confusion and CI failures.

Fixes #74889.