### PR TITLE
drivers/gpio/gpio_rzt2m: Handle trig == GPIO_INT_TRIG_WAKE

### DIFF
--- a/drivers/gpio/gpio_rzt2m.c
+++ b/drivers/gpio/gpio_rzt2m.c
@@ -360,6 +360,9 @@ static int rzt2m_gpio_pin_interrupt_configure(const struct device *dev, gpio_pin
 		break;
 	case GPIO_INT_TRIG_BOTH:
 		md_mode = INT_BOTH_EDGE;
+		break;
+	default:
+		return -EINVAL;
 	}
 
 	rzt2m_gpio_unlock();


### PR DESCRIPTION
Fix a build warning due to the enumerate for the trigger polarity possibly being (from the point of the compiler) also GPIO_INT_TRIG_WAKE.
We fix it by simply returning a not valid argument error which is what most other drivers do if they do something smart enough.

Fixes #74213