### PR TITLE
posix: pthread: correct log info of new stack address

### DIFF
--- a/lib/posix/options/pthread.c
+++ b/lib/posix/options/pthread.c
@@ -1250,7 +1250,7 @@ int pthread_attr_setstacksize(pthread_attr_t *_attr, size_t stacksize)
 			__get_attr_stacksize(attr) + attr->guardsize);
 		return ENOMEM;
 	}
-	LOG_DBG("Allocated thread stack %zu@%p", stacksize + attr->guardsize, attr->stack);
+	LOG_DBG("Allocated thread stack %zu@%p", stacksize + attr->guardsize, new_stack);
 
 	if (attr->stack != NULL) {
 		ret = k_thread_stack_free(attr->stack);


### PR DESCRIPTION
When a new stack is allocated successfully in pthread_attr_setstacksize, the new address should be printed not the original one.