### PR TITLE
coredump: Better support for threads in core dumps

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -32,6 +32,7 @@ config ARM
 	bool
 	select ARCH_IS_SET
 	select ARCH_SUPPORTS_COREDUMP if CPU_CORTEX_M
+	select ARCH_SUPPORTS_COREDUMP_THREADS if CPU_CORTEX_M
 	# FIXME: current state of the code for all ARM requires this, but
 	# is really only necessary for Cortex-M with ARM MPU!
 	select GEN_PRIV_STACKS
@@ -652,6 +653,9 @@ config ARCH_HAS_NESTED_EXCEPTION_DETECTION
 	bool
 
 config ARCH_SUPPORTS_COREDUMP
+	bool
+
+config ARCH_SUPPORTS_COREDUMP_THREADS
 	bool
 
 config ARCH_SUPPORTS_ARCH_HW_INIT

--- a/doc/services/debugging/coredump.rst
+++ b/doc/services/debugging/coredump.rst
@@ -30,6 +30,13 @@ Here are the choices regarding memory dump:
   walking the stack in the debugger. Use this only if absolute minimum of data
   dump is desired.
 
+* ``DEBUG_COREDUMP_MEMORY_DUMP_THREADS``: Dumps the thread struct and stack of all
+  threads and all data required to debug threads.
+
+* ``DEBUG_COREDUMP_MEMORY_DUMP_LINKER_RAM``: Dumps the memory region between
+  _image_ram_start[] and _image_ram_end[]. This includes at least data, noinit,
+  and BSS sections. This is the default.
+
 Additional memory can be included in a dump (even with the "DEBUG_COREDUMP_MEMORY_DUMP_MIN"
 config selected) through one or more :ref:`coredump devices <coredump_device_api>`
 
@@ -244,7 +251,8 @@ File Format
 ***********
 
 The core dump binary file consists of one file header, one
-architecture-specific block, and multiple memory blocks. All numbers in
+architecture-specific block, zero or one threads metadata block(s),
+and multiple memory blocks. All numbers in
 the headers below are little endian.
 
 File Header
@@ -314,6 +322,36 @@ to the target architecture (e.g. CPU registers)
    * - Register byte stream
      - ``uint8_t[]``
      - Contains target architecture specific data.
+
+Threads Metadata Block
+---------------------------
+
+The threads metadata block contains the byte stream of data necessary
+for debugging threads.
+
+.. list-table:: Threads Metadata Block
+   :widths: 2 1 7
+   :header-rows: 1
+
+   * - Field
+     - Data Type
+     - Description
+   * - ID
+     - ``char``
+     - ``T`` to indicate this is a threads metadata block.
+   * - Header version
+     - ``uint16_t``
+     - Identify the version of the header. This needs to be incremented
+       whenever the header struct is modified. This allows parser to
+       reject older header versions so it will not incorrectly parse
+       the header.
+   * - Number of bytes
+     - ``uint16_t``
+     - Number of bytes following the header which contains the byte stream
+       for target data.
+   * - Byte stream
+     - ``uint8_t[]``
+     - Contains data necessary for debugging threads.
 
 Memory Block
 ------------

--- a/include/zephyr/debug/coredump.h
+++ b/include/zephyr/debug/coredump.h
@@ -142,9 +142,12 @@ struct coredump_cmd_copy_arg {
 #include <zephyr/arch/cpu.h>
 #include <zephyr/sys/byteorder.h>
 
-#define COREDUMP_HDR_VER		1
+#define COREDUMP_HDR_VER		2
 
 #define	COREDUMP_ARCH_HDR_ID		'A'
+
+#define THREADS_META_HDR_ID		'T'
+#define THREADS_META_HDR_VER		1
 
 #define	COREDUMP_MEM_HDR_ID		'M'
 #define COREDUMP_MEM_HDR_VER		1
@@ -183,6 +186,18 @@ struct coredump_hdr_t {
 /* Architecture-specific block header */
 struct coredump_arch_hdr_t {
 	/* COREDUMP_ARCH_HDR_ID */
+	char		id;
+
+	/* Header version */
+	uint16_t	hdr_version;
+
+	/* Number of bytes in this block (excluding header) */
+	uint16_t	num_bytes;
+} __packed;
+
+/* Threads metadata header */
+struct coredump_threads_meta_hdr_t {
+	/* THREADS_META_HDR_ID */
 	char		id;
 
 	/* Header version */

--- a/scripts/coredump/coredump_parser/elf_parser.py
+++ b/scripts/coredump/coredump_parser/elf_parser.py
@@ -5,9 +5,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import struct
 
 import elftools
 from elftools.elf.elffile import ELFFile
+from enum import IntEnum
 
 
 # ELF section flags
@@ -16,6 +18,27 @@ SHF_ALLOC = 0x2
 SHF_EXEC = 0x4
 SHF_WRITE_ALLOC = SHF_WRITE | SHF_ALLOC
 SHF_ALLOC_EXEC = SHF_ALLOC | SHF_EXEC
+
+# Must match enum in thread_info.c
+class ThreadInfoOffset(IntEnum):
+    THREAD_INFO_OFFSET_VERSION = 0
+    THREAD_INFO_OFFSET_K_CURR_THREAD = 1
+    THREAD_INFO_OFFSET_K_THREADS = 2
+    THREAD_INFO_OFFSET_T_ENTRY = 3
+    THREAD_INFO_OFFSET_T_NEXT_THREAD = 4
+    THREAD_INFO_OFFSET_T_STATE = 5
+    THREAD_INFO_OFFSET_T_USER_OPTIONS = 6
+    THREAD_INFO_OFFSET_T_PRIO = 7
+    THREAD_INFO_OFFSET_T_STACK_PTR = 8
+    THREAD_INFO_OFFSET_T_NAME = 9
+    THREAD_INFO_OFFSET_T_ARCH = 10
+    THREAD_INFO_OFFSET_T_PREEMPT_FLOAT = 11
+    THREAD_INFO_OFFSET_T_COOP_FLOAT = 12
+    THREAD_INFO_OFFSET_T_ARM_EXC_RETURN = 13
+    THREAD_INFO_OFFSET_T_ARC_RELINQUISH_CAUSE = 14
+
+    def __int__(self):
+        return self.value
 
 
 logger = logging.getLogger("parser")
@@ -34,6 +57,9 @@ class CoredumpElfFile():
         self.fd = None
         self.elf = None
         self.memory_regions = list()
+        self.kernel_thread_info_offsets = None
+        self.kernel_thread_info_num_offsets = None
+        self.kernel_thread_info_size_t_size = None
 
     def open(self):
         self.fd = open(self.elffile, "rb")
@@ -45,11 +71,35 @@ class CoredumpElfFile():
     def get_memory_regions(self):
         return self.memory_regions
 
+    def get_kernel_thread_info_size_t_size(self):
+        return self.kernel_thread_info_size_t_size
+
+    def has_kernel_thread_info(self):
+        return self.kernel_thread_info_offsets is not None
+
+    def get_kernel_thread_info_offset(self, thread_info_offset_index):
+        if self.has_kernel_thread_info() and thread_info_offset_index <= ThreadInfoOffset.THREAD_INFO_OFFSET_T_ARC_RELINQUISH_CAUSE:
+            return self.kernel_thread_info_offsets[thread_info_offset_index]
+        else:
+            return None
+
     def parse(self):
         if self.fd is None:
             self.open()
 
+        kernel_thread_info_offsets_segment = None
+        kernel_thread_info_num_offsets_segment = None
+        _kernel_thread_info_offsets = None
+        _kernel_thread_info_num_offsets = None
+        _kernel_thread_info_size_t_size = None
+
         for section in self.elf.iter_sections():
+            # Find symbols for _kernel_thread_info data
+            if isinstance(section, elftools.elf.sections.SymbolTableSection):
+                _kernel_thread_info_offsets = section.get_symbol_by_name("_kernel_thread_info_offsets")
+                _kernel_thread_info_num_offsets = section.get_symbol_by_name("_kernel_thread_info_num_offsets")
+                _kernel_thread_info_size_t_size = section.get_symbol_by_name("_kernel_thread_info_size_t_size")
+
             # REALLY NEED to match exact type as all other sections
             # (debug, text, etc.) are descendants where
             # isinstance() would match.
@@ -89,5 +139,49 @@ class CoredumpElfFile():
                              sect_desc))
 
                 self.memory_regions.append(mem_region)
+
+        if _kernel_thread_info_size_t_size is not None and \
+           _kernel_thread_info_num_offsets is not None and \
+           _kernel_thread_info_offsets is not None:
+            for seg in self.elf.iter_segments():
+                if seg.header['p_type'] != 'PT_LOAD':
+                    continue
+
+                # Store segment of kernel_thread_info_offsets
+                info_offsets_symbol = _kernel_thread_info_offsets[0]
+                if info_offsets_symbol['st_value'] >= seg['p_vaddr'] and info_offsets_symbol['st_value'] < seg['p_vaddr'] + seg['p_filesz']:
+                    kernel_thread_info_offsets_segment = seg
+
+                # Store segment of kernel_thread_info_num_offsets
+                num_offsets_symbol = _kernel_thread_info_num_offsets[0]
+                if num_offsets_symbol['st_value'] >= seg['p_vaddr'] and num_offsets_symbol['st_value'] < seg['p_vaddr'] + seg['p_filesz']:
+                    kernel_thread_info_num_offsets_segment = seg
+
+                # Read and store size_t size
+                size_t_size_symbol = _kernel_thread_info_size_t_size[0]
+                if size_t_size_symbol['st_value'] >= seg['p_vaddr'] and size_t_size_symbol['st_value'] < seg['p_vaddr'] + seg['p_filesz']:
+                    offset = size_t_size_symbol['st_value'] - seg['p_vaddr'] + seg['p_offset']
+                    self.elf.stream.seek(offset)
+                    self.kernel_thread_info_size_t_size = struct.unpack('B', self.elf.stream.read(size_t_size_symbol['st_size']))[0]
+
+            struct_format = "I"
+            if self.kernel_thread_info_size_t_size == 8:
+                struct_format = "Q"
+
+            # Read and store count of offset values
+            num_offsets_symbol = _kernel_thread_info_num_offsets[0]
+            offset = num_offsets_symbol['st_value'] - kernel_thread_info_num_offsets_segment['p_vaddr'] + kernel_thread_info_num_offsets_segment['p_offset']
+            self.elf.stream.seek(offset)
+            self.kernel_thread_info_num_offsets = struct.unpack(struct_format, self.elf.stream.read(num_offsets_symbol['st_size']))[0]
+
+            array_format = ""
+            for _ in range(self.kernel_thread_info_num_offsets):
+                array_format = array_format + struct_format
+
+            # Read and store array of offset values
+            info_offsets_symbol = _kernel_thread_info_offsets[0]
+            offset = info_offsets_symbol['st_value'] - kernel_thread_info_offsets_segment['p_vaddr'] + kernel_thread_info_offsets_segment['p_offset']
+            self.elf.stream.seek(offset)
+            self.kernel_thread_info_offsets = struct.unpack(array_format, self.elf.stream.read(info_offsets_symbol['st_size']))
 
         return True

--- a/scripts/coredump/gdbstubs/arch/arm_cortex_m.py
+++ b/scripts/coredump/gdbstubs/arch/arm_cortex_m.py
@@ -8,6 +8,7 @@ import binascii
 import logging
 import struct
 
+from coredump_parser.elf_parser import ThreadInfoOffset
 from gdbstubs.gdbstub import GdbStub
 
 
@@ -80,15 +81,15 @@ class GdbStub_ARM_CortexM(GdbStub):
             self.registers[RegNum.R10] = tu[15]
             self.registers[RegNum.R11] = tu[16]
 
-    def handle_register_group_read_packet(self):
+    def send_registers_packet(self, registers):
         reg_fmt = "<I"
 
         idx = 0
         pkt = b''
 
         while idx < self.GDB_G_PKT_NUM_REGS:
-            if idx in self.registers:
-                bval = struct.pack(reg_fmt, self.registers[idx])
+            if idx in registers:
+                bval = struct.pack(reg_fmt, registers[idx])
                 pkt += binascii.hexlify(bval)
             else:
                 # Register not in coredump -> unknown value
@@ -98,6 +99,12 @@ class GdbStub_ARM_CortexM(GdbStub):
             idx += 1
 
         self.put_gdb_packet(pkt)
+
+    def handle_register_group_read_packet(self):
+        if not self.elffile.has_kernel_thread_info():
+            self.send_registers_packet(self.registers)
+        else:
+            self.handle_thread_register_group_read_packet()
 
     def handle_register_single_read_packet(self, pkt):
         # Mark registers as "<unavailable>".
@@ -111,3 +118,57 @@ class GdbStub_ARM_CortexM(GdbStub):
         reg = int(pkt_str[1:pkt_str.index('=')], 16)
         self.registers[reg] = int.from_bytes(binascii.unhexlify(pkt[3:]), byteorder = 'little')
         self.put_gdb_packet(b'+')
+
+    def arch_supports_thread_operations(self):
+        return True
+
+    def handle_thread_register_group_read_packet(self):
+        # For selected_thread 0, use the register data retrieved from the dump's arch section
+        if self.selected_thread == 0:
+            self.send_registers_packet(self.registers)
+        else:
+            thread_ptr = self.thread_ptrs[self.selected_thread]
+
+            # Get stack pointer out of thread struct
+            t_stack_ptr_offset = self.elffile.get_kernel_thread_info_offset(ThreadInfoOffset.THREAD_INFO_OFFSET_T_STACK_PTR)
+            size_t_size = self.elffile.get_kernel_thread_info_size_t_size()
+            stack_ptr_bytes = self.get_memory(thread_ptr + t_stack_ptr_offset, size_t_size)
+
+            thread_registers = dict()
+
+            if stack_ptr_bytes is not None:
+                # Read registers stored at top of stack
+                stack_ptr = int.from_bytes(stack_ptr_bytes, "little")
+                barray = self.get_memory(stack_ptr, (size_t_size * 8))
+
+                if barray is not None:
+                    tu = struct.unpack("<IIIIIIII", barray)
+                    thread_registers[RegNum.R0] = tu[0]
+                    thread_registers[RegNum.R1] = tu[1]
+                    thread_registers[RegNum.R2] = tu[2]
+                    thread_registers[RegNum.R3] = tu[3]
+                    thread_registers[RegNum.R12] = tu[4]
+                    thread_registers[RegNum.LR] = tu[5]
+                    thread_registers[RegNum.PC] = tu[6]
+                    thread_registers[RegNum.XPSR] = tu[7]
+
+                    # Set SP to point to stack just after these registers
+                    thread_registers[RegNum.SP] = stack_ptr + 32
+
+                    # Read the exc_return value from the thread's arch struct
+                    t_arch_offset = self.elffile.get_kernel_thread_info_offset(ThreadInfoOffset.THREAD_INFO_OFFSET_T_ARCH)
+                    t_exc_return_offset = self.elffile.get_kernel_thread_info_offset(ThreadInfoOffset.THREAD_INFO_OFFSET_T_ARM_EXC_RETURN)
+
+                    # Value of 0xffffffff indicates THREAD_INFO_UNIMPLEMENTED
+                    if t_exc_return_offset != 0xffffffff:
+                        exc_return_bytes = self.get_memory(thread_ptr + t_arch_offset + t_exc_return_offset, 1)
+                        exc_return = int.from_bytes(exc_return_bytes, "little")
+
+                        # If the bit 4 is not set, the stack frame is extended for floating point data, adjust the SP accordingly
+                        if (exc_return & (1 << 4)) == 0:
+                            thread_registers[RegNum.SP] = thread_registers[RegNum.SP] + 72
+
+                    # Set R7 to match the stack pointer in case the frame pointer is not omitted
+                    thread_registers[RegNum.R7] = thread_registers[RegNum.SP]
+
+            self.send_registers_packet(thread_registers)

--- a/scripts/coredump/gdbstubs/gdbstub.py
+++ b/scripts/coredump/gdbstubs/gdbstub.py
@@ -8,6 +8,8 @@ import abc
 import binascii
 import logging
 
+from coredump_parser.elf_parser import ThreadInfoOffset
+
 
 logger = logging.getLogger("gdbstub")
 
@@ -18,6 +20,8 @@ class GdbStub(abc.ABC):
         self.elffile = elffile
         self.socket = None
         self.gdb_signal = None
+        self.thread_ptrs = list()
+        self.selected_thread = 0
 
         mem_regions = list()
 
@@ -89,6 +93,36 @@ class GdbStub(abc.ABC):
 
         socket.send(pkt)
 
+    def get_memory(self, start_address, length):
+        def get_mem_region(addr):
+            for r in self.mem_regions:
+                if r['start'] <= addr < r['end']:
+                    return r
+
+            return None
+
+        # FIXME: Need more efficient way of extracting memory content
+        remaining = length
+        addr = start_address
+        barray = b''
+        r = get_mem_region(addr)
+        while remaining > 0:
+            if r is None:
+                barray = None
+                break
+
+            if addr > r['end']:
+                r = get_mem_region(addr)
+                continue
+
+            offset = addr - r['start']
+            barray += r['data'][offset:offset+1]
+
+            addr += 1
+            remaining -= 1
+
+        return barray
+
     def handle_signal_query_packet(self):
         # the '?' packet
         pkt = b'S'
@@ -120,38 +154,13 @@ class GdbStub(abc.ABC):
     def handle_memory_read_packet(self, pkt):
         # the 'm' packet for reading memory: m<addr>,<len>
 
-        def get_mem_region(addr):
-            for r in self.mem_regions:
-                if r['start'] <= addr < r['end']:
-                    return r
-
-            return None
-
         # extract address and length from packet
         # and convert them into usable integer values
         str_addr, str_length = pkt[1:].split(b',')
         s_addr = int(b'0x' + str_addr, 16)
         length = int(b'0x' + str_length, 16)
 
-        # FIXME: Need more efficient way of extracting memory content
-        remaining = length
-        addr = s_addr
-        barray = b''
-        r = get_mem_region(addr)
-        while remaining > 0:
-            if r is None:
-                barray = None
-                break
-
-            if addr > r['end']:
-                r = get_mem_region(addr)
-                continue
-
-            offset = addr - r['start']
-            barray += r['data'][offset:offset+1]
-
-            addr += 1
-            remaining -= 1
+        barray = self.get_memory(s_addr, length)
 
         if barray is not None:
             pkt = binascii.hexlify(barray)
@@ -166,7 +175,133 @@ class GdbStub(abc.ABC):
         self.put_gdb_packet(b"E02")
 
     def handle_general_query_packet(self, pkt):
+        if self.arch_supports_thread_operations() and self.elffile.has_kernel_thread_info():
+            # For packets qfThreadInfo/qsThreadInfo, obtain a list of all active thread IDs
+            if pkt[0:12] == b"qfThreadInfo":
+                threads_metadata_data = self.logfile.get_threads_metadata()["data"]
+                size_t_size = self.elffile.get_kernel_thread_info_size_t_size()
+
+                # First, find and store the thread that _kernel considers current
+                k_curr_thread_offset = self.elffile.get_kernel_thread_info_offset(ThreadInfoOffset.THREAD_INFO_OFFSET_K_CURR_THREAD)
+                curr_thread_ptr_bytes = threads_metadata_data[k_curr_thread_offset:(k_curr_thread_offset + size_t_size)]
+                curr_thread_ptr = int.from_bytes(curr_thread_ptr_bytes, "little")
+                self.thread_ptrs.append(curr_thread_ptr)
+
+                thread_count = 1
+                response = b"m1"
+
+                # Next, find the pointer to the linked list of threads in the _kernel struct
+                k_threads_offset = self.elffile.get_kernel_thread_info_offset(ThreadInfoOffset.THREAD_INFO_OFFSET_K_THREADS)
+                thread_ptr_bytes = threads_metadata_data[k_threads_offset:(k_threads_offset + size_t_size)]
+                thread_ptr = int.from_bytes(thread_ptr_bytes, "little")
+
+                if thread_ptr != curr_thread_ptr:
+                    self.thread_ptrs.append(thread_ptr)
+                    thread_count += 1
+                    response += b"," + bytes(str(thread_count), 'ascii')
+
+                # Next walk the linked list, counting the number of threads and construct the response for qfThreadInfo along the way
+                t_next_thread_offset = self.elffile.get_kernel_thread_info_offset(ThreadInfoOffset.THREAD_INFO_OFFSET_T_NEXT_THREAD)
+                while thread_ptr is not None:
+                    thread_ptr_bytes = self.get_memory(thread_ptr + t_next_thread_offset, size_t_size)
+
+                    if thread_ptr_bytes is not None:
+                        thread_ptr = int.from_bytes(thread_ptr_bytes, "little")
+                        if thread_ptr == 0:
+                            thread_ptr = None
+                            continue
+
+                        if thread_ptr != curr_thread_ptr:
+                            self.thread_ptrs.append(thread_ptr)
+                            thread_count += 1
+                            response += b"," + bytes(f'{thread_count:x}', 'ascii')
+                    else:
+                        thread_ptr = None
+
+                self.put_gdb_packet(response)
+            elif pkt[0:12] == b"qsThreadInfo":
+                self.put_gdb_packet(b"l")
+
+            # For qThreadExtraInfo, obtain a printable string description of thread attributes for the provided thread
+            elif pkt[0:16] == b"qThreadExtraInfo":
+                thread_info_bytes = b''
+
+                thread_index_str = ''
+                for n in range(17, len(pkt)):
+                    thread_index_str += chr(pkt[n])
+
+                thread_id = int(thread_index_str, 16)
+                if len(self.thread_ptrs) > thread_id:
+                    thread_info_bytes += b'name: '
+                    thread_ptr = self.thread_ptrs[thread_id - 1]
+                    t_name_offset = self.elffile.get_kernel_thread_info_offset(ThreadInfoOffset.THREAD_INFO_OFFSET_T_NAME)
+
+                    thread_name_next_byte = self.get_memory(thread_ptr + t_name_offset, 1)
+                    index = 0
+                    while (thread_name_next_byte is not None) and (thread_name_next_byte != b'\x00'):
+                        thread_info_bytes += thread_name_next_byte
+
+                        index += 1
+                        thread_name_next_byte = self.get_memory(thread_ptr + t_name_offset + index, 1)
+
+                    t_state_offset = self.elffile.get_kernel_thread_info_offset(ThreadInfoOffset.THREAD_INFO_OFFSET_T_STATE)
+                    thread_state_byte = self.get_memory(thread_ptr + t_state_offset, 1)
+                    if thread_state_byte is not None:
+                        thread_state = int.from_bytes(thread_state_byte, "little")
+                        thread_info_bytes += b', state: ' + bytes(hex(thread_state), 'ascii')
+
+                    t_user_options_offset = self.elffile.get_kernel_thread_info_offset(ThreadInfoOffset.THREAD_INFO_OFFSET_T_USER_OPTIONS)
+                    thread_user_options_byte = self.get_memory(thread_ptr + t_user_options_offset, 1)
+                    if thread_user_options_byte is not None:
+                        thread_user_options = int.from_bytes(thread_user_options_byte, "little")
+                        thread_info_bytes += b', user_options: ' + bytes(hex(thread_user_options), 'ascii')
+
+                    t_prio_offset = self.elffile.get_kernel_thread_info_offset(ThreadInfoOffset.THREAD_INFO_OFFSET_T_PRIO)
+                    thread_prio_byte = self.get_memory(thread_ptr + t_prio_offset, 1)
+                    if thread_prio_byte is not None:
+                        thread_prio = int.from_bytes(thread_prio_byte, "little")
+                        thread_info_bytes += b', prio: ' + bytes(hex(thread_prio), 'ascii')
+
+                self.put_gdb_packet(binascii.hexlify(thread_info_bytes))
+            else:
+                self.put_gdb_packet(b'')
+        else:
+            self.put_gdb_packet(b'')
+
+    def arch_supports_thread_operations(self):
+        return False
+
+    def handle_thread_alive_packet(self, pkt):
+        # the 'T' packet for finding out if a thread is alive.
+        if self.arch_supports_thread_operations() and self.elffile.has_kernel_thread_info():
+            # Reply OK to report thread alive, allowing GDB to perform other thread operations
+            self.put_gdb_packet(b'OK')
+        else:
+            self.put_gdb_packet(b'')
+
+    def handle_thread_register_group_read_packet(self):
         self.put_gdb_packet(b'')
+
+    def handle_thread_op_packet(self, pkt):
+        # the 'H' packet for setting thread for subsequent operations.
+        if self.arch_supports_thread_operations() and self.elffile.has_kernel_thread_info():
+            if pkt[0:2] == b"Hg":
+                thread_index_str = ''
+                for n in range(2, len(pkt)):
+                    thread_index_str += chr(pkt[n])
+
+                # Thread-id of '0' indicates an arbitrary process or thread
+                if thread_index_str in ('0', ''):
+                    self.selected_thread = 0
+                    self.handle_register_group_read_packet()
+                    return
+
+                self.selected_thread = int(thread_index_str, 16) - 1
+                self.handle_thread_register_group_read_packet()
+            else:
+                self.put_gdb_packet(b'')
+        else:
+            self.put_gdb_packet(b'')
 
     def run(self, socket):
         self.socket = socket
@@ -199,6 +334,10 @@ class GdbStub(abc.ABC):
                 self.handle_memory_write_packet(pkt)
             elif pkt_type == b'q':
                 self.handle_general_query_packet(pkt)
+            elif pkt_type == b'T':
+                self.handle_thread_alive_packet(pkt)
+            elif pkt_type == b'H':
+                self.handle_thread_op_packet(pkt)
             elif pkt_type == b'k':
                 # GDB quits
                 break

--- a/subsys/debug/coredump/Kconfig
+++ b/subsys/debug/coredump/Kconfig
@@ -58,6 +58,15 @@ config DEBUG_COREDUMP_MEMORY_DUMP_MIN
 	  Don't use this unless you want absolutely
 	  minimum core dump.
 
+config DEBUG_COREDUMP_MEMORY_DUMP_THREADS
+	bool "Threads"
+	select THREAD_STACK_INFO
+	select DEBUG_THREAD_INFO
+	select DEBUG_COREDUMP_THREADS_METADATA
+	help
+	  Dumps the thread struct and stack of all
+	  threads and all data required to debug threads.
+
 config DEBUG_COREDUMP_MEMORY_DUMP_LINKER_RAM
 	bool "RAM defined by linker section"
 	help
@@ -74,5 +83,12 @@ config DEBUG_COREDUMP_SHELL
 	depends on SHELL
 	help
 	  This shell provides access to coredump and its backends.
+
+config DEBUG_COREDUMP_THREADS_METADATA
+	bool "Threads metadata"
+	select DEBUG_THREAD_INFO
+	help
+	  Core dump will contain the threads metadata section containing
+	  any necessary data to enable debugging threads
 
 endif # DEBUG_COREDUMP

--- a/subsys/debug/coredump/Kconfig
+++ b/subsys/debug/coredump/Kconfig
@@ -60,6 +60,7 @@ config DEBUG_COREDUMP_MEMORY_DUMP_MIN
 
 config DEBUG_COREDUMP_MEMORY_DUMP_THREADS
 	bool "Threads"
+	depends on !SMP
 	select THREAD_STACK_INFO
 	select DEBUG_THREAD_INFO
 	select DEBUG_COREDUMP_THREADS_METADATA
@@ -86,6 +87,7 @@ config DEBUG_COREDUMP_SHELL
 
 config DEBUG_COREDUMP_THREADS_METADATA
 	bool "Threads metadata"
+	depends on !SMP
 	select DEBUG_THREAD_INFO
 	help
 	  Core dump will contain the threads metadata section containing

--- a/subsys/debug/coredump/Kconfig
+++ b/subsys/debug/coredump/Kconfig
@@ -61,6 +61,7 @@ config DEBUG_COREDUMP_MEMORY_DUMP_MIN
 config DEBUG_COREDUMP_MEMORY_DUMP_THREADS
 	bool "Threads"
 	depends on !SMP
+	depends on ARCH_SUPPORTS_COREDUMP_THREADS
 	select THREAD_STACK_INFO
 	select DEBUG_THREAD_INFO
 	select DEBUG_COREDUMP_THREADS_METADATA
@@ -88,6 +89,7 @@ config DEBUG_COREDUMP_SHELL
 config DEBUG_COREDUMP_THREADS_METADATA
 	bool "Threads metadata"
 	depends on !SMP
+	depends on ARCH_SUPPORTS_COREDUMP_THREADS
 	select DEBUG_THREAD_INFO
 	help
 	  Core dump will contain the threads metadata section containing

--- a/subsys/debug/coredump/coredump_core.c
+++ b/subsys/debug/coredump/coredump_core.c
@@ -58,6 +58,8 @@ static void dump_header(unsigned int reason)
 	backend_api->buffer_output((uint8_t *)&hdr, sizeof(hdr));
 }
 
+#if defined(CONFIG_DEBUG_COREDUMP_MEMORY_DUMP_MIN) || \
+	defined(CONFIG_DEBUG_COREDUMP_MEMORY_DUMP_THREADS)
 static void dump_thread(struct k_thread *thread)
 {
 	uintptr_t end_addr;
@@ -80,6 +82,7 @@ static void dump_thread(struct k_thread *thread)
 
 	coredump_memory_dump(thread->stack_info.start, end_addr);
 }
+#endif
 
 #if defined(CONFIG_COREDUMP_DEVICE)
 static void process_coredump_dev_memory(const struct device *dev)

--- a/tests/subsys/debug/coredump_threads/CMakeLists.txt
+++ b/tests/subsys/debug/coredump_threads/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(debug_coredump_threads)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/subsys/debug/coredump_threads/prj.conf
+++ b/tests/subsys/debug/coredump_threads/prj.conf
@@ -1,0 +1,7 @@
+# Copyright Meta Platforms, Inc. and its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+
+CONFIG_DEBUG_COREDUMP=y
+CONFIG_DEBUG_COREDUMP_MEMORY_DUMP_THREADS=y

--- a/tests/subsys/debug/coredump_threads/src/main.c
+++ b/tests/subsys/debug/coredump_threads/src/main.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright Meta Platforms, Inc. and its affiliates.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+
+#define STACK_SIZE 256
+#define THREAD_COUNT 7
+
+static struct k_thread threads[THREAD_COUNT];
+static uint32_t params[THREAD_COUNT];
+static K_THREAD_STACK_ARRAY_DEFINE(thread_stacks, THREAD_COUNT, STACK_SIZE);
+static K_SEM_DEFINE(sem, 0, 1);
+
+static void func0(uint32_t param)
+{
+	int ret = -EAGAIN;
+
+	while (ret != 0) {
+		ret = k_sem_take(&sem, K_NO_WAIT);
+		k_sleep(K_MSEC(param));
+	}
+
+	k_panic();
+}
+
+static void test_thread_entry(void *p1, void *p2, void *p3)
+{
+	uint32_t *param = (uint32_t *)p1;
+
+	func0(*param);
+}
+
+static void *coredump_threads_suite_setup(void)
+{
+	/* Spawn a few threads */
+	for (int i = 0; i < THREAD_COUNT; i++) {
+		params[i] = i;
+		k_thread_create(
+			&threads[i],
+			thread_stacks[i],
+			K_THREAD_STACK_SIZEOF(thread_stacks[i]),
+			test_thread_entry,
+			&params[i],
+			NULL,
+			NULL,
+			(THREAD_COUNT - i), /* arbitrary priority */
+			0,
+			K_NO_WAIT);
+
+		char thread_name[32];
+
+		snprintf(thread_name, sizeof(thread_name), "thread%d", i);
+		k_thread_name_set(&threads[i], thread_name);
+	}
+
+	return NULL;
+}
+
+ZTEST_SUITE(coredump_threads, NULL, coredump_threads_suite_setup, NULL, NULL, NULL);
+
+ZTEST(coredump_threads, test_crash)
+{
+	/* Give semaphore allowing one of the waiting threads to continue and panic */
+	k_sem_give(&sem);
+	for (int i = 0; i < THREAD_COUNT; i++) {
+		k_thread_join(&threads[i], K_FOREVER);
+	}
+}

--- a/tests/subsys/debug/coredump_threads/testcase.yaml
+++ b/tests/subsys/debug/coredump_threads/testcase.yaml
@@ -1,0 +1,34 @@
+# Copyright Meta Platforms, Inc. and its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
+common:
+  tags:
+    - coredump
+  ignore_faults: true
+  ignore_qemu_crash: true
+  integration_platforms:
+    - qemu_cortex_m3
+tests:
+  debug.coredump.threads:
+    filter: CONFIG_DEBUG_COREDUMP_MEMORY_DUMP_THREADS
+    harness: console
+    harness_config:
+      type: multi_line
+      # Verify core dump contains threads metadata section and several
+      # memory sections, two for each thread
+      regex:
+        - "E: #CD:BEGIN#"
+        - "E: #CD:5([aA])45([0-9a-fA-F]+)"
+        - "E: #CD:41([0-9a-fA-F]+)"
+        - "E: #CD:54([0-9a-fA-F]+)"
+        - "E: #CD:4([dD])([0-9a-fA-F]+)"
+        - "E: #CD:4([dD])([0-9a-fA-F]+)"
+        - "E: #CD:4([dD])([0-9a-fA-F]+)"
+        - "E: #CD:4([dD])([0-9a-fA-F]+)"
+        - "E: #CD:4([dD])([0-9a-fA-F]+)"
+        - "E: #CD:4([dD])([0-9a-fA-F]+)"
+        - "E: #CD:4([dD])([0-9a-fA-F]+)"
+        - "E: #CD:4([dD])([0-9a-fA-F]+)"
+        - "E: #CD:4([dD])([0-9a-fA-F]+)"
+        - "E: #CD:4([dD])([0-9a-fA-F]+)"
+        - "E: #CD:END#"


### PR DESCRIPTION
https://github.com/zephyrproject-rtos/zephyr/issues/74195

Update core dump file format to support a new section which contains
metadata about threads necessary for debugging.

Define configs to capture that metadata and include it in the dumps
when enabled.

Update documentation to reflect the changes.

Add z_test which uses new configs to capture multiple
threads in a core dump and with all of the context
necessary to debug the threads.

Update zephyr gdb-server scripts to understand threads.

Parse the kernel_thread_info out of the elf file to be used
for finding offsets to data from _kernel structs or from
individual threads.

Update log_parser to understand latest format change, which
allows for the presence of a new section, threads metadata.

Update gdbstub to respond to various packets to describe
the threads present in a dump, and allow switching to
thread context of each thread.

Add support in arm_cortex_m python script to read thread
registers off of a thread's stack when switching context.


---------
Manually test the updates in this change by running the new "coredump_threads"  twister test.

```
./scripts/twister -c -v -T tests/subsys/debug/coredump_threads -p qemu_cortex_m3
```

Convert text output of test to the binary format used by the zephyr gdb server:
```
./scripts/coredump/coredump_serial_log_parser.py ~/zephyrproject/zephyr/twister-out/qemu_cortex_m3/tests/subsys/debug/coredump_threads/debug.coredump.threads/handler.log ~/dumps/twist.bin
```

Run the gdb-server:
```
./scripts/coredump/coredump_gdbserver.py --debug -v ~/zephyrproject/zephyr/twister-out/qemu_cortex_m3/tests/subsys/debug/coredump_threads/debug.coredump.threads/zephyr/zephyr.elf ~/dumps/twist.bin
```

Connect with gdb:
```
./arm-zephyr-eabi-gdb ~/zephyrproject/zephyr/twister-out/qemu_cortex_m3/tests/subsys/debug/coredump_threads/debug.coredump.threads/zephyr/zephyr.elf -ex 'target remote :1234'
```

First observe, that backtrace of failing thread still displays as expected:
```
(gdb) bt
#0  test_thread_entry (p1=<optimized out>, p2=<optimized out>, p3=<optimized out>) at ~/zephyrproject/zephyr/tests/subsys/debug/coredump_threads/src/main.c:27
#1  0x00000bb4 in z_arm_fault_init () at ~/zephyrproject/zephyr/arch/arm/core/cortex_m/fault.c:1196
Backtrace stopped: previous frame identical to this frame (corrupt stack?)
```

Now try simple thread operations:
```
(gdb) info threads
  Id   Target Id                                                              Frame
* 1    Thread 1 (name: thread6, state: 0x80, user_options: 0x0, prio: 0x1)    test_thread_entry (p1=<optimized out>, p2=<optimized out>, p3=<optimized out>)
    at ~/zephyrproject/zephyr/tests/subsys/debug/coredump_threads/src/main.c:27
  2    Thread 2 (name: test_crash, state: 0x2, user_options: 0x8, prio: 0xff) __ISB () at ~/zephyrproject/modules/hal/cmsis/CMSIS/Core/Include/cmsis_gcc.h:260
  3    Thread 3 (name: thread5, state: 0x80, user_options: 0x0, prio: 0x2)    __ISB () at ~/zephyrproject/modules/hal/cmsis/CMSIS/Core/Include/cmsis_gcc.h:260
  4    Thread 4 (name: thread4, state: 0x80, user_options: 0x0, prio: 0x3)    __ISB () at ~/zephyrproject/modules/hal/cmsis/CMSIS/Core/Include/cmsis_gcc.h:260
  5    Thread 5 (name: thread3, state: 0x80, user_options: 0x0, prio: 0x4)    __ISB () at ~/zephyrproject/modules/hal/cmsis/CMSIS/Core/Include/cmsis_gcc.h:260
  6    Thread 6 (name: thread2, state: 0x80, user_options: 0x0, prio: 0x5)    __ISB () at ~/zephyrproject/modules/hal/cmsis/CMSIS/Core/Include/cmsis_gcc.h:260
  7    Thread 7 (name: thread1, state: 0x80, user_options: 0x0, prio: 0x6)    __ISB () at ~/zephyrproject/modules/hal/cmsis/CMSIS/Core/Include/cmsis_gcc.h:260
  8    Thread 8 (name: thread0, state: 0x80, user_options: 0x0, prio: 0x7)    arch_swap (key=0) at ~/zephyrproject/zephyr/arch/arm/core/cortex_m/swap.c:49
  9    Thread 9 (name: idle, state: 0x0, user_options: 0x1, prio: 0xf)        z_thread_entry (entry=0x1eb9 <idle>, p1=0x20000884 <_kernel>, p2=0x0 <cbvprintf_package>,
    p3=0x0 <cbvprintf_package>)
    at ~/zephyrproject/zephyr/twister-out/qemu_cortex_m3/tests/subsys/debug/coredump_threads/debug.coredump.threads/zephyr/include/generated/zephyr/syscalls/kernel.h:215
  10   Thread 10 (name: main, state: 0x2, user_options: 0x1, prio: 0x0)       __ISB () at ~/zephyrproject/modules/hal/cmsis/CMSIS/Core/Include/cmsis_gcc.h:260
```

Switch to other thread context and check backtrace:
```
(gdb) thread 2
[Switching to thread 2 (Thread 2)]
#0  __ISB () at ~/zephyrproject/modules/hal/cmsis/CMSIS/Core/Include/cmsis_gcc.h:260
260       __ASM volatile ("isb 0xF":::"memory");


(gdb) bt
#0  __ISB () at ~/zephyrproject/modules/hal/cmsis/CMSIS/Core/Include/cmsis_gcc.h:260
#1  arch_irq_unlock (key=0) at ~/zephyrproject/zephyr/include/zephyr/arch/arm/asm_inline_gcc.h:90
#2  arch_swap (key=0) at ~/zephyrproject/zephyr/arch/arm/core/cortex_m/swap.c:44
#3  0x000032c8 in z_swap_irqlock (key=<optimized out>) at ~/zephyrproject/zephyr/kernel/include/kswap.h:209
#4  0x000003f0 in k_thread_join (timeout=..., thread=<unavailable>)
    at ~/zephyrproject/zephyr/twister-out/qemu_cortex_m3/tests/subsys/debug/coredump_threads/debug.coredump.threads/zephyr/include/generated/zephyr/syscalls/kernel.h:119
#5  coredump_threads_test_crash () at ~/zephyrproject/zephyr/tests/subsys/debug/coredump_threads/src/main.c:70
#6  _coredump_threads_test_crash_wrapper (wrapper_data=<optimized out>) at ~/zephyrproject/zephyr/tests/subsys/debug/coredump_threads/src/main.c:65
#7  0x000010fa in run_test_functions (suite=<unavailable>, data=0x0 <cbvprintf_package>, test=0x4610 <z_ztest_unit_test.coredump_threads.test_crash>)
    at ~/zephyrproject/zephyr/subsys/testsuite/ztest/src/ztest.c:319
#8  test_cb (a=<unavailable>, b=0x4610 <z_ztest_unit_test.coredump_threads.test_crash>, c=0x0 <cbvprintf_package>)
    at ~/zephyrproject/zephyr/subsys/testsuite/ztest/src/ztest.c:653
#9  0x0000065a in z_thread_entry (entry=0x10c9 <test_cb>, p1=0x45f4 <z_ztest_test_node_coredump_threads>, p2=0x4610 <z_ztest_unit_test.coredump_threads.test_crash>,
    p3=0x0 <cbvprintf_package>) at ~/zephyrproject/zephyr/lib/os/thread_entry.c:48
#10 0x00000000 in ?? ()


(gdb) thread 5
[Switching to thread 5 (Thread 5)]
#0  __ISB () at ~/zephyrproject/modules/hal/cmsis/CMSIS/Core/Include/cmsis_gcc.h:260
260       __ASM volatile ("isb 0xF":::"memory");


(gdb) bt
#0  __ISB () at ~/zephyrproject/modules/hal/cmsis/CMSIS/Core/Include/cmsis_gcc.h:260
#1  arch_irq_unlock (key=0) at ~/zephyrproject/zephyr/include/zephyr/arch/arm/asm_inline_gcc.h:90
#2  arch_swap (key=0, key@entry=<unavailable>) at ~/zephyrproject/zephyr/arch/arm/core/cortex_m/swap.c:44
#3  0x00003038 in z_swap_irqlock (key=<unavailable>) at ~/zephyrproject/zephyr/kernel/include/kswap.h:209
#4  z_swap (key=..., lock=0x200009a8 <_sched_spinlock>) at ~/zephyrproject/zephyr/kernel/include/kswap.h:220
#5  z_tick_sleep (ticks=<optimized out>) at ~/zephyrproject/zephyr/kernel/sched.c:1161
#6  0x000030ec in z_impl_k_sleep (timeout=...) at ~/zephyrproject/zephyr/kernel/sched.c:1192
#7  0x000004b6 in k_sleep (timeout=...)
    at ~/zephyrproject/zephyr/twister-out/qemu_cortex_m3/tests/subsys/debug/coredump_threads/debug.coredump.threads/zephyr/include/generated/zephyr/syscalls/kernel.h:135
#8  func0 (param=<optimized out>) at ~/zephyrproject/zephyr/tests/subsys/debug/coredump_threads/src/main.c:24
#9  test_thread_entry (p1=<optimized out>, p2=<optimized out>, p3=<optimized out>) at ~/zephyrproject/zephyr/tests/subsys/debug/coredump_threads/src/main.c:34
#10 0x0000065a in z_thread_entry (entry=0x489 <test_thread_entry>, p1=0x2000083c <params+12>, p2=0x0 <cbvprintf_package>, p3=0x0 <cbvprintf_package>)
    at ~/zephyrproject/zephyr/lib/os/thread_entry.c:48
#11 0x00000000 in ?? ()


(gdb) thread 10
[Switching to thread 10 (Thread 10)]
#0  __ISB () at ~/zephyrproject/modules/hal/cmsis/CMSIS/Core/Include/cmsis_gcc.h:260
260       __ASM volatile ("isb 0xF":::"memory");


(gdb) bt
#0  __ISB () at ~/zephyrproject/modules/hal/cmsis/CMSIS/Core/Include/cmsis_gcc.h:260
#1  arch_irq_unlock (key=0) at ~/zephyrproject/zephyr/include/zephyr/arch/arm/asm_inline_gcc.h:90
#2  arch_swap (key=0) at ~/zephyrproject/zephyr/arch/arm/core/cortex_m/swap.c:44
#3  0x000032c8 in z_swap_irqlock (key=<optimized out>) at ~/zephyrproject/zephyr/kernel/include/kswap.h:209
#4  0x00001258 in k_thread_join (thread=0x20000530 <ztest_thread>, timeout=...)
    at ~/zephyrproject/zephyr/twister-out/qemu_cortex_m3/tests/subsys/debug/coredump_threads/debug.coredump.threads/zephyr/include/generated/zephyr/syscalls/kernel.h:119
#5  run_test (data=<unavailable>, test=<unavailable>, suite=<unavailable>) at ~/zephyrproject/zephyr/subsys/testsuite/ztest/src/ztest.c:687
#6  z_ztest_run_test_suite_ptr (suite=<unavailable>, suite@entry=0x45f4 <z_ztest_test_node_coredump_threads>, case_iter=case_iter@entry=1, suite_iter=<optimized out>,
    shuffle=<optimized out>) at ~/zephyrproject/zephyr/subsys/testsuite/ztest/src/ztest.c:870
#7  0x0000149c in __ztest_run_test_suite (shuffle=<optimized out>, case_iter=<optimized out>, suite_iter=<optimized out>, state=<optimized out>,
    ptr=0x45f4 <z_ztest_test_node_coredump_threads>) at ~/zephyrproject/zephyr/subsys/testsuite/ztest/src/ztest.c:1068
#8  z_impl_ztest_run_test_suites (state=0x0 <cbvprintf_package>, shuffle=<optimized out>, suite_iter=1, case_iter=1)
    at ~/zephyrproject/zephyr/subsys/testsuite/ztest/src/ztest.c:1117
#9  0x0000416c in test_main () at ~/zephyrproject/zephyr/subsys/testsuite/ztest/src/ztest.c:1204
#10 0x000015a6 in main () at ~/zephyrproject/zephyr/subsys/testsuite/ztest/src/ztest.c:1420
```