### PR TITLE
drivers: ethernet: enc28j60: Add DT property to set random mac

### DIFF
--- a/drivers/ethernet/eth_enc28j60.c
+++ b/drivers/ethernet/eth_enc28j60.c
@@ -25,6 +25,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <ethernet/eth_stats.h>
 
 #include "eth_enc28j60_priv.h"
+#include "eth.h"
 
 #define D10D24S 11
 
@@ -801,10 +802,19 @@ static int eth_enc28j60_init(const struct device *dev)
 	/* Errata B7/1 */
 	k_busy_wait(D10D24S);
 
-	/* Assign octets not previously taken from devicetree */
-	context->mac_address[0] = MICROCHIP_OUI_B0;
-	context->mac_address[1] = MICROCHIP_OUI_B1;
-	context->mac_address[2] = MICROCHIP_OUI_B2;
+	/* Apply a random MAC address if requested in DT */
+	if (config->random_mac) {
+		gen_random_mac(context->mac_address, MICROCHIP_OUI_B0, MICROCHIP_OUI_B1,
+			       MICROCHIP_OUI_B2);
+		LOG_INF("Random MAC Addr %02x:%02x:%02x:%02x:%02x:%02x", context->mac_address[0],
+			context->mac_address[1], context->mac_address[2], context->mac_address[3],
+			context->mac_address[4], context->mac_address[5]);
+	} else {
+		/* Assign octets not previously taken from devicetree */
+		context->mac_address[0] = MICROCHIP_OUI_B0;
+		context->mac_address[1] = MICROCHIP_OUI_B1;
+		context->mac_address[2] = MICROCHIP_OUI_B2;
+	}
 
 	if (eth_enc28j60_init_buffers(dev)) {
 		return -ETIMEDOUT;
@@ -850,6 +860,7 @@ static int eth_enc28j60_init(const struct device *dev)
 		.full_duplex = DT_INST_PROP(0, full_duplex),                                       \
 		.timeout = CONFIG_ETH_ENC28J60_TIMEOUT,                                            \
 		.hw_rx_filter = DT_INST_PROP_OR(inst, hw_rx_filter, ENC28J60_RECEIVE_FILTERS),     \
+		.random_mac = DT_INST_PROP(inst, zephyr_random_mac_address),                    \
 	};                                                                                         \
                                                                                                    \
 	ETH_NET_DEVICE_DT_INST_DEFINE(inst, eth_enc28j60_init, NULL, &eth_enc28j60_runtime_##inst, \

--- a/drivers/ethernet/eth_enc28j60_priv.h
+++ b/drivers/ethernet/eth_enc28j60_priv.h
@@ -227,6 +227,7 @@ struct eth_enc28j60_config {
 	uint8_t full_duplex;
 	int32_t timeout;
 	uint8_t hw_rx_filter;
+	bool random_mac;
 };
 
 struct eth_enc28j60_runtime {


### PR DESCRIPTION
Use the DT property zephyr,random-mac-address to set a boot time random mac address.