### PR TITLE
MAINTAINERS: nxp drivers: add MarkWangChinese to NXP Drivers

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3391,6 +3391,7 @@ NXP Drivers:
     - decsny
     - manuargue
     - dbaluta
+    - MarkWangChinese
   files:
     - drivers/*/*imx*
     - drivers/*/*lpc*.c


### PR DESCRIPTION
Add MarkWangChinese to NXP drivers. He helps support USB, Bluetooth