### PR TITLE
Bluetooth: Controller: Fix empty PDU buffer overrun under ISR latency

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -604,7 +604,7 @@ config BT_CTLR_DYNAMIC_INTERRUPTS
 	  permit use of SoC's peripheral for custom use when Bluetooth is not
 	  enabled.
 
-choice
+choice BT_CTLR_OPTIMIZE
 	prompt "Optimization options"
 	depends on !LTO
 	default BT_CTLR_OPTIMIZE_FOR_SPEED
@@ -1247,6 +1247,16 @@ config BT_CTLR_USER_CPR_ANCHOR_POINT_MOVE
 	  Only applicable for peripheral.
 
 endmenu
+
+# Workaround to be able to have default for "choice" in hidden "menu" above
+choice BT_CTLR_OPTIMIZE
+	prompt "Optimization options"
+	depends on !LTO
+
+config BT_CTLR_OPTIMIZE_FOR_SPEED
+	bool "Optimize for Speed"
+
+endchoice
 
 source "subsys/bluetooth/controller/coex/Kconfig"
 

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -8603,11 +8603,13 @@ static void encode_control(struct node_rx_pdu *node_rx,
 
 #if defined(CONFIG_BT_CTLR_PROFILE_ISR)
 	case NODE_RX_TYPE_PROFILE:
-		LOG_INF("l: %u, %u, %u; t: %u, %u, %u; cpu: %u, %u, %u, %u.",
+		LOG_INF("l: %u, %u, %u; t: %u, %u, %u; cpu: %u (%u), %u (%u), %u (%u), %u (%u).",
 			pdu_data->profile.lcur, pdu_data->profile.lmin, pdu_data->profile.lmax,
 			pdu_data->profile.cur, pdu_data->profile.min, pdu_data->profile.max,
-			pdu_data->profile.radio, pdu_data->profile.lll, pdu_data->profile.ull_high,
-			pdu_data->profile.ull_low);
+			pdu_data->profile.radio, pdu_data->profile.radio_ticks,
+			pdu_data->profile.lll, pdu_data->profile.lll_ticks,
+			pdu_data->profile.ull_high, pdu_data->profile.ull_high_ticks,
+			pdu_data->profile.ull_low, pdu_data->profile.ull_low_ticks);
 		return;
 #endif /* CONFIG_BT_CTLR_PROFILE_ISR */
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -596,6 +596,7 @@ void radio_status_reset(void)
 	 *       EVENT_* registers are not reset to save code and CPU time.
 	 */
 	nrf_radio_event_clear(NRF_RADIO, NRF_RADIO_EVENT_READY);
+	nrf_radio_event_clear(NRF_RADIO, NRF_RADIO_EVENT_ADDRESS);
 	nrf_radio_event_clear(NRF_RADIO, NRF_RADIO_EVENT_END);
 #if defined(CONFIG_BT_CTLR_DF_SUPPORT) && !defined(CONFIG_ZTEST)
 	/* Clear it only for SoCs supporting DF extension */
@@ -614,6 +615,11 @@ void radio_status_reset(void)
 uint32_t radio_is_ready(void)
 {
 	return (NRF_RADIO->EVENTS_READY != 0);
+}
+
+uint32_t radio_is_address(void)
+{
+	return (NRF_RADIO->EVENTS_ADDRESS != 0);
 }
 
 #if defined(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -1861,10 +1861,8 @@ static void *radio_ccm_ext_rx_pkt_set(struct ccm *cnf, uint8_t phy, uint8_t pdu_
 #endif /* CONFIG_HAS_HW_NRF_RADIO_BLE_CODED */
 #endif /* CONFIG_BT_CTLR_PHY_CODED */
 	}
-#endif /* !CONFIG_SOC_SERIES_NRF51X */
 
-#if !defined(CONFIG_SOC_SERIES_NRF51X) && \
-	!defined(CONFIG_SOC_NRF52832) && \
+#if !defined(CONFIG_SOC_NRF52832) && \
 	(!defined(CONFIG_BT_CTLR_DATA_LENGTH_MAX) || \
 	 (CONFIG_BT_CTLR_DATA_LENGTH_MAX < ((HAL_RADIO_PDU_LEN_MAX) - 4U)))
 	uint8_t max_len = (NRF_RADIO->PCNF1 & RADIO_PCNF1_MAXLEN_Msk) >>
@@ -1888,6 +1886,11 @@ static void *radio_ccm_ext_rx_pkt_set(struct ccm *cnf, uint8_t phy, uint8_t pdu_
 		break;
 	}
 #endif /* CONFIG_HAS_HW_NRF_CCM_HEADERMASK */
+
+#else /* CONFIG_SOC_SERIES_NRF51X */
+	hal_trigger_crypt_ppi_config();
+	hal_radio_nrf_ppi_channels_enable(BIT(HAL_TRIGGER_CRYPT_PPI));
+#endif /* CONFIG_SOC_SERIES_NRF51X */
 
 	NRF_CCM->MODE = mode;
 	NRF_CCM->CNFPTR = (uint32_t)cnf;

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.h
@@ -84,6 +84,7 @@ void radio_disable(void);
 
 void radio_status_reset(void);
 uint32_t radio_is_ready(void);
+uint32_t radio_is_address(void);
 uint32_t radio_is_done(void);
 uint32_t radio_has_disabled(void);
 uint32_t radio_is_idle(void);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -1292,6 +1292,11 @@ static void isr_rx(void *param)
 		}
 	}
 
+	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+		lll_prof_cputime_capture();
+		lll_prof_send();
+	}
+
 isr_rx_do_close:
 	radio_isr_set(isr_done, param);
 	radio_disable();

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -607,6 +607,11 @@ static void isr_rx(void *param)
 		}
 	}
 
+	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+		lll_prof_cputime_capture();
+		lll_prof_send();
+	}
+
 isr_rx_do_close:
 	radio_isr_set(isr_done, param);
 	radio_disable();

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -396,7 +396,12 @@ void lll_conn_isr_rx(void *param)
 #endif /* HAL_RADIO_GPIO_HAVE_PA_PIN */
 
 	/* assert if radio packet ptr is not set and radio started tx */
-	LL_ASSERT(!radio_is_ready());
+	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+		LL_ASSERT_MSG(!radio_is_ready(), "%s: Radio ISR latency: %u", __func__,
+			      lll_prof_latency_get());
+	} else {
+		LL_ASSERT(!radio_is_ready());
+	}
 
 lll_conn_isr_rx_exit:
 	/* Save the AA captured for the first Rx in connection event */
@@ -497,6 +502,10 @@ void lll_conn_isr_tx(void *param)
 	struct lll_conn *lll;
 	uint32_t hcto;
 
+	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+		lll_prof_latency_capture();
+	}
+
 	/* Clear radio tx status and events */
 	lll_isr_tx_status_reset();
 
@@ -566,7 +575,12 @@ void lll_conn_isr_tx(void *param)
 	lll_conn_rx_pkt_set(lll);
 
 	/* assert if radio packet ptr is not set and radio started rx */
-	LL_ASSERT(!radio_is_ready());
+	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
+		LL_ASSERT_MSG(!radio_is_ready(), "%s: Radio ISR latency: %u", __func__,
+			      lll_prof_latency_get());
+	} else {
+		LL_ASSERT(!radio_is_ready());
+	}
 
 #if defined(CONFIG_BT_CTLR_DF_CONN_CTE_TX)
 	pdu_tx = get_last_tx_pdu(lll);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -397,10 +397,10 @@ void lll_conn_isr_rx(void *param)
 
 	/* assert if radio packet ptr is not set and radio started tx */
 	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
-		LL_ASSERT_MSG(!radio_is_ready(), "%s: Radio ISR latency: %u", __func__,
+		LL_ASSERT_MSG(!radio_is_address(), "%s: Radio ISR latency: %u", __func__,
 			      lll_prof_latency_get());
 	} else {
-		LL_ASSERT(!radio_is_ready());
+		LL_ASSERT(!radio_is_address());
 	}
 
 lll_conn_isr_rx_exit:
@@ -576,10 +576,10 @@ void lll_conn_isr_tx(void *param)
 
 	/* assert if radio packet ptr is not set and radio started rx */
 	if (IS_ENABLED(CONFIG_BT_CTLR_PROFILE_ISR)) {
-		LL_ASSERT_MSG(!radio_is_ready(), "%s: Radio ISR latency: %u", __func__,
+		LL_ASSERT_MSG(!radio_is_address(), "%s: Radio ISR latency: %u", __func__,
 			      lll_prof_latency_get());
 	} else {
-		LL_ASSERT(!radio_is_ready());
+		LL_ASSERT(!radio_is_address());
 	}
 
 #if defined(CONFIG_BT_CTLR_DF_CONN_CTE_TX)

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_prof.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_prof.c
@@ -23,22 +23,22 @@
 
 static int send(struct node_rx_pdu *rx);
 static inline void sample(uint32_t *timestamp);
-static inline void delta(uint32_t timestamp, uint8_t *cputime);
+static inline void delta(uint32_t timestamp, uint16_t *cputime);
 
 static uint32_t timestamp_radio;
 static uint32_t timestamp_lll;
 static uint32_t timestamp_ull_high;
 static uint32_t timestamp_ull_low;
-static uint8_t cputime_radio;
-static uint8_t cputime_lll;
-static uint8_t cputime_ull_high;
-static uint8_t cputime_ull_low;
-static uint8_t latency_min = (uint8_t) -1;
-static uint8_t latency_max;
-static uint8_t latency_prev;
-static uint8_t cputime_min = (uint8_t) -1;
-static uint8_t cputime_max;
-static uint8_t cputime_prev;
+static uint16_t cputime_radio;
+static uint16_t cputime_lll;
+static uint16_t cputime_ull_high;
+static uint16_t cputime_ull_low;
+static uint16_t latency_min = UINT16_MAX;
+static uint16_t latency_max;
+static uint16_t latency_prev;
+static uint16_t cputime_min = UINT16_MAX;
+static uint16_t cputime_max;
+static uint16_t cputime_prev;
 static uint32_t timestamp_latency;
 
 void lll_prof_enter_radio(void)
@@ -155,7 +155,7 @@ void lll_prof_reserve_send(struct node_rx_pdu *rx)
 
 static int send(struct node_rx_pdu *rx)
 {
-	uint8_t latency, cputime, prev;
+	uint16_t latency, cputime, prev;
 	struct pdu_data *pdu;
 	struct profile *p;
 	uint8_t chg = 0U;
@@ -248,13 +248,13 @@ static inline void sample(uint32_t *timestamp)
 	*timestamp = radio_tmr_sample_get();
 }
 
-static inline void delta(uint32_t timestamp, uint8_t *cputime)
+static inline void delta(uint32_t timestamp, uint16_t *cputime)
 {
 	uint32_t delta;
 
 	radio_tmr_sample();
 	delta = radio_tmr_sample_get() - timestamp;
-	if (delta < UINT8_MAX && delta > *cputime) {
+	if (delta < UINT16_MAX && delta > *cputime) {
 		*cputime = delta;
 	}
 }

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_prof.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_prof.c
@@ -294,11 +294,15 @@ static uint16_t latency_get(void)
 	/* calculate the elapsed time in us since on-air radio packet end
 	 * to ISR entry
 	 */
+	if (!IS_ENABLED(CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER)) {
 #if defined(HAL_RADIO_GPIO_HAVE_PA_PIN)
-	latency = timestamp_latency - timestamp_radio_end;
+		latency = timestamp_latency - timestamp_radio_end;
 #else /* !HAL_RADIO_GPIO_HAVE_PA_PIN */
-	latency = timestamp_latency - radio_tmr_end_get();
+		latency = timestamp_latency - radio_tmr_end_get();
 #endif /* !HAL_RADIO_GPIO_HAVE_PA_PIN */
+	} else {
+		latency = timestamp_latency;
+	}
 
 	return latency;
 }

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_prof_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_prof_internal.h
@@ -25,6 +25,7 @@ static inline void lll_prof_exit_ull_low(void) {}
 #endif
 
 void lll_prof_latency_capture(void);
+uint16_t lll_prof_latency_get(void);
 void lll_prof_radio_end_backup(void);
 void lll_prof_cputime_capture(void);
 void lll_prof_send(void);

--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -931,16 +931,16 @@ struct pdu_data_llctrl {
 
 #if defined(CONFIG_BT_CTLR_PROFILE_ISR)
 struct profile {
-	uint8_t lcur;
-	uint8_t lmin;
-	uint8_t lmax;
-	uint8_t cur;
-	uint8_t min;
-	uint8_t max;
-	uint8_t radio;
-	uint8_t lll;
-	uint8_t ull_high;
-	uint8_t ull_low;
+	uint16_t lcur;
+	uint16_t lmin;
+	uint16_t lmax;
+	uint16_t cur;
+	uint16_t min;
+	uint16_t max;
+	uint16_t radio;
+	uint16_t lll;
+	uint16_t ull_high;
+	uint16_t ull_low;
 } __packed;
 #endif /* CONFIG_BT_CTLR_PROFILE_ISR */
 

--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -941,6 +941,10 @@ struct profile {
 	uint16_t lll;
 	uint16_t ull_high;
 	uint16_t ull_low;
+	uint8_t  radio_ticks;
+	uint8_t  lll_ticks;
+	uint8_t  ull_high_ticks;
+	uint8_t  ull_low_ticks;
 } __packed;
 #endif /* CONFIG_BT_CTLR_PROFILE_ISR */
 


### PR DESCRIPTION
Fix regression using speed optimization introduced in commit https://github.com/cvinayak/zephyr/commit/1b7fe792e0c52635f371df9c2e14d1f4ce8fcacc ("Bluetooth: Controller: Support Link Time Optimizations (LTO)").

Fix regression in encrypted connection introduced in commit https://github.com/cvinayak/zephyr/commit/f3deccda91ef688fa1cf6c4c5f589aa194181491 ("Bluetooth: Controller: CCM read data to early when DF enabled on PHY 1M").
Due to this nRF51x SoC hang waiting to encrypt and/or
check MIC.

Only 3 bytes (PDU_EM_LL_SIZE_MAX) is required for empty PDU
transmission, but in case of Radio ISR latency if rx packet
pointer is not setup then Radio DMA will use previously
assigned buffer which can be this empty PDU buffer. Radio
DMA will overrun this buffer and cause memory corruption.
Any detection of ISR latency will not happen if the ISR
function pointer in RAM is corrupted by this overrun.
Increasing ISR latencies in OS and CPU usage in the
ULL_HIGH priority if it is same as LLL priority in Controller
implementation then it is making it tight to execute
Controller code in the tIFS between Tx-Rx PDU's Radio ISRs.

Other fixes to ISR profiling needed as part of analysis of increased ISR latencies.

Related to #74345.
Fixes #76427.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>