### PR TITLE
usb: device: add USB_DEVICE_CONFIGURATION KConfig option

### DIFF
--- a/subsys/usb/device/Kconfig
+++ b/subsys/usb/device/Kconfig
@@ -48,6 +48,23 @@ config USB_DEVICE_SN
 	  Serial Number String will be derived from
 	  Hardware Information Driver (HWINFO).
 
+config USB_CONFIGURATION_STRING_DESC_ENABLE
+	bool "USB configuration string descriptor support"
+	help
+	  Enable string descriptor that describes the default configuration.
+	  Since there is only one configuration, this string descriptor may not
+	  provide much useful information.
+
+if USB_CONFIGURATION_STRING_DESC_ENABLE
+
+config USB_CONFIGURATION_STRING_DESC
+	string "USB configuration string descriptor"
+	default "Default Configuration"
+	help
+	  String descriptor that describes the default configuration.
+
+endif # USB_CONFIGURATION_STRING_DESC_ENABLE
+
 config USB_COMPOSITE_DEVICE
 	bool "Use Interface Association Descriptor code triple"
 	help

--- a/subsys/usb/device/usb_descriptor.c
+++ b/subsys/usb/device/usb_descriptor.c
@@ -46,6 +46,10 @@ struct common_descriptor {
 #define USB_DESC_PRODUCT_IDX				2
 #define USB_DESC_SERIAL_NUMBER_IDX			3
 
+#ifdef CONFIG_USB_CONFIGURATION_STRING_DESC_ENABLE
+#define USB_DESC_CONFIGURATION_IDX			4
+#endif
+
 /*
  * Device and configuration descriptor placed in the device section,
  * no additional descriptor may be placed there.
@@ -86,7 +90,11 @@ USBD_DEVICE_DESCR_DEFINE(primary) struct common_descriptor common_desc = {
 		.wTotalLength = 0,
 		.bNumInterfaces = 0,
 		.bConfigurationValue = 1,
+#ifdef CONFIG_USB_CONFIGURATION_STRING_DESC_ENABLE
+		.iConfiguration = USB_DESC_CONFIGURATION_IDX,
+#else
 		.iConfiguration = 0,
+#endif
 		.bmAttributes = USB_SCD_RESERVED |
 				COND_CODE_1(CONFIG_USB_SELF_POWERED,
 					    (USB_SCD_SELF_POWERED), (0)) |
@@ -116,6 +124,14 @@ struct usb_string_desription {
 		uint8_t bDescriptorType;
 		uint8_t bString[USB_BSTRING_LENGTH(CONFIG_USB_DEVICE_SN)];
 	} __packed utf16le_sn;
+
+#ifdef CONFIG_USB_CONFIGURATION_STRING_DESC_ENABLE
+	struct usb_conf_descriptor {
+		uint8_t bLength;
+		uint8_t bDescriptorType;
+		uint8_t bString[USB_BSTRING_LENGTH(CONFIG_USB_CONFIGURATION_STRING_DESC)];
+	} __packed utf16le_conf;
+#endif
 } __packed;
 
 /*
@@ -149,6 +165,14 @@ USBD_STRING_DESCR_DEFINE(primary) struct usb_string_desription string_descr = {
 		.bDescriptorType = USB_DESC_STRING,
 		.bString = CONFIG_USB_DEVICE_SN,
 	},
+#ifdef CONFIG_USB_CONFIGURATION_STRING_DESC_ENABLE
+	/* Configuration String Descriptor */
+	.utf16le_conf = {
+		.bLength = USB_STRING_DESCRIPTOR_LENGTH(CONFIG_USB_CONFIGURATION_STRING_DESC),
+		.bDescriptorType = USB_DESC_STRING,
+		.bString = CONFIG_USB_CONFIGURATION_STRING_DESC,
+	},
+#endif
 };
 
 /* This element marks the end of the entire descriptor. */

--- a/tests/subsys/usb/desc_sections/src/desc_sections.c
+++ b/tests/subsys/usb/desc_sections/src/desc_sections.c
@@ -35,7 +35,11 @@ struct usb_test_config {
 #define TEST_BULK_EP_MPS		64
 #endif
 
+#if defined(CONFIG_USB_CONFIGURATION_STRING_DESC_ENABLE)
+#define TEST_DESCRIPTOR_TABLE_SPAN	201
+#else
 #define TEST_DESCRIPTOR_TABLE_SPAN	157
+#endif
 
 #define INITIALIZER_IF							\
 	{								\


### PR DESCRIPTION
To support usb configuration string, this change adds a KConfig option "USB_DEVICE_CONFIGURATION."

Tested with:
1. Google spikyrock project
2. samples/subsys/usb/hid/
    $ cat /sys/bus/usb/devices/3-3/configuration
    Zephyr USB Sample
