### PR TITLE
posix + kernel: support for realtime signals

### DIFF
--- a/doc/kernel/services/index.rst
+++ b/doc/kernel/services/index.rst
@@ -37,6 +37,7 @@ synchronization.
    threads/nothread.rst
    interrupts.rst
    polling.rst
+   signals.rst
    synchronization/semaphores.rst
    synchronization/mutexes.rst
    synchronization/condvar.rst

--- a/doc/kernel/services/signals.rst
+++ b/doc/kernel/services/signals.rst
@@ -1,0 +1,210 @@
+.. _signals:
+
+Signal API
+##########
+
+The signal API supports signalling between threads.
+
+.. contents::
+    :local:
+    :depth: 2
+
+Concepts
+********
+
+The signal API provides a way for one thread to notify another thread that an
+event has occurred using a predefined integer value
+(see :zephyr_file:`include/zephyr/posix/signal.h`).
+
+Zephyr's signal API can be broken down into functions that manipulate and
+query *signal sets* (:c:struct:`k_sig_set`), and functions that are used to
+send and receive signals (see :ref:`Signal API Implementation <signals_implementation>`).
+
+Standard vs Real-time Signals
+=============================
+
+Signals may be divided into two categories; *standard* and *real-time*. The
+main differences between the two are
+
+* ISO C and POSIX do not specify whether standard signals are queued or merged.
+* ISO C and POSIX do not specify the priority of standard signals.
+
+To illustrate the former point, if ``SIGALRM`` is sent twice to an
+application, the implementation may merge those into one signal or queue them.
+On the other hand, Real-time signals are always queued in the order they are
+generated, and are never merged.
+
+Standard signals therefore have a shortcoming at the specification level; there
+can be no guarantee of determinism if a signal generated at one time instance
+is merged with another signal generated at another time instance. Zephyr removes
+this ambiguity by delivering all signals in the order they are generated, and
+not merging any signals. Zephyr's handling of standard signals is similar
+to how Zephyr handles real-time signals.
+
+.. note::
+    Zephyr queues all signals in the order they are generated, and never
+    merges any signals (real-time or otherwise).
+
+To address the latter point, real-time signals have a priority with respect to
+other real-time signals. However, the POSIX specification does not clarify the
+priority of real-time signals with respect to standard signals. To address
+this ambiguity, Zephyr always delivers unmasked, real-time signals in
+prioritized order (lowest-numbered signal) and *then* delivers standard signals
+in the order they are generated.
+
+.. note::
+    Zephyr prioritizes real-time signals before standard signals.
+
+Limitations
+===========
+
+As per ISO C and POSIX, signals should be delivered and handled to the
+application asynchronously if they are not masked. Currently, Zephyr
+does not support asynchronous signal delivery, as that may introduce
+elements of non-determinism. Therefore, all signals should be received
+synchronously via calls to :c:func:`k_sig_timedwait`.
+
+.. _signals_implementation:
+
+Implementation
+**************
+
+Signal Sets
+===========
+
+When :kconfig:option:`CONFIG_SIGNAL` is enabled, every :c:struct:`k_thread` is
+created with an initially-empty :c:struct:`k_sig_set` of masked signals. If a
+signal is masked (i.e. part of the set), the corresponding bit in the signal
+set is 1, otherwise it is 0. Thus an initially empty :c:struct:`k_sig_set` is
+zero-valued. Signal sets should not be modified directly, but indirectly via
+the functions provided in the signal API.
+
+Before a signal set can be used, it must be initialized via
+:c:func:`k_sig_emptyset` or :c:func:`k_sig_fillset`, which either create an
+empty or full signal set, respectively. Using a signal set without first
+initializing it via either of the two aforementioned functions results in
+undefined behaviour.
+
+.. code-block:: c
+    :caption: Initialize a :c:struct:`k_sig_set`
+
+    struct k_sig_set set;
+
+    k_sig_emptyset(&set);
+    /* or */
+    k_sig_fillset(&set);
+
+
+Signals may then be added via :c:func:`k_sig_addset`, removed via
+:c:func:`k_sig_delset`, and tested for via :c:func:`k_sig_ismember`.
+
+.. code-block:: c
+    :caption: Add, remove, or query signals in a :c:struct:`k_sig_set`
+
+    k_sig_addset(&set, SIGINT);
+    /* or */
+    k_sig_delset(&set, SIGTERM);
+
+    if (k_sig_ismember(&set, SIGINT) == 1) {
+        /* SIGINT is in the set */
+    }
+
+The Signal Mask
+===============
+
+The signal mask belonging to each thread may only be modified by the thread
+itself using :c:func:`k_sig_mask`. The signal mask may be manipulated in one
+of three possible ways
+
+1. :c:macro:`K_SIG_BLOCK` - the signals in the set provided are added to the mask
+2. :c:macro:`K_SIG_UNBLOCK` - the signals in the set provided are removed from
+   the mask
+3. :c:macro:`K_SIG_SETMASK` - the mask is replaced by the set provided.
+
+In order to retrieve that current value of the signal mask, or to obtain the
+value of the set before it was modified, pass a non-``NULL`` pointer for the
+``oset`` (old set) argument to :c:func:`k_sig_mask`.
+
+.. code-block:: c
+    :caption: Manipulate the signal mask of the current thread
+
+    struct k_sig_set set, oset;
+
+    k_sig_emptyset(&set);
+    k_sig_addset(&set, SIGINT);
+
+    k_sig_mask(K_SIG_BLOCK, &set, NULL);
+    /* SIGINT is now blocked */
+
+    /* Retrieve the current signal mask */
+    k_sig_mask(-1, NULL, &oset);
+    /* oset contains SIGINT and other previously masked signals */
+
+Sending Signals
+===============
+
+Signals are queued to a thread using :c:func:`k_sig_queue()`. The first
+argument to this function is of type :c:type:`k_pid_t`. Although the name of
+:c:type:`k_pid_t` may imply the opposite, Zephyr does not yet support
+processes and :c:type:`k_pid_t` is synonymous with :c:type:`k_tid_t`. Along
+with the signal number, :c:func:`k_sig_queue()` also accepts a
+:c:union:`k_sig_val` which may be used to pass additional information to the
+receiving thread in the form of a pointer or integer value.
+
+.. code-block:: c
+    :caption: Send a signal to the current thread
+
+    /* arbitrary data to be sent with the signal */
+    int data = 1234;
+    extern uint8_t shared_resource[4200];
+    k_pid_t pid = (k_pid_t) k_current_get();
+    union k_sig_val val = {
+        .sival_int = data,
+    };
+
+    /* use an integer value */
+    k_sig_queue(pid, SIGUSR1, val);
+
+    /* use a pointer value */
+    val.sival_ptr = &shared_resource;
+    k_sig_queue(pid, SIGUSR2, val);
+
+Receiving Signals
+=================
+
+A thread may query for the signals pending delivery via
+:c:func:`k_sig_pending`. This function takes only one argument, a pointer to a
+signal set, which will be filled with the signals pending delivery.
+
+To receive a signal, and wait for a configurable amount of time for one to be
+delivered, the function :c:func:`k_sig_timedwait` is used.
+
+.. code-block:: c
+    :caption: Receive a signal
+
+    struct k_sig_set set;
+    struct k_sig_info info;
+
+    k_sig_emptyset(&set);
+    k_sig_addset(&set, SIGUSR1);
+    k_sig_timedwait(&set, &info, K_FOREVER);
+    /* SIGUSR1 has been received */
+
+    /*
+     * Additional data may be in info.si_value.sival_int or
+     * info.si_value.sival_ptr
+     */
+
+Configuration Options
+*********************
+
+Related configuration options:
+
+* :kconfig:option:`CONFIG_SIGNAL`
+* :kconfig:option:`CONFIG_SIGNAL_QUEUE_SIZE`
+* :kconfig:option:`CONFIG_SIGNAL_SET_SIZE`
+
+API Reference
+*************
+
+.. doxygengroup:: k_sig_apis

--- a/doc/services/portability/posix/conformance/index.rst
+++ b/doc/services/portability/posix/conformance/index.rst
@@ -43,7 +43,7 @@ POSIX System Interfaces
     :ref:`_POSIX_SEMAPHORES<posix_option_group_semaphores>`, 200809L, :kconfig:option:`CONFIG_POSIX_SEMAPHORES`
     :ref:`_POSIX_SPIN_LOCKS<posix_option_group_spin_locks>`, 200809L, :kconfig:option:`CONFIG_POSIX_SPIN_LOCKS`
     :ref:`_POSIX_THREAD_SAFE_FUNCTIONS<posix_thread_safe_functions>`, -1, :kconfig:option:`CONFIG_POSIX_THREAD_SAFE_FUNCTIONS`
-    :ref:`_POSIX_THREADS<posix_option_group_threads_base>`, -1, :kconfig:option:`CONFIG_POSIX_THREADS`
+    :ref:`_POSIX_THREADS<posix_option_group_threads_base>`, 200809L, :kconfig:option:`CONFIG_POSIX_THREADS`
     :ref:`_POSIX_TIMEOUTS<posix_option_timeouts>`, 200809L, :kconfig:option:`CONFIG_POSIX_TIMEOUTS`
     :ref:`_POSIX_TIMERS<posix_option_group_timers>`, 200809L, :kconfig:option:`CONFIG_POSIX_TIMERS`
     _POSIX2_C_BIND, 200809L,

--- a/doc/services/portability/posix/conformance/index.rst
+++ b/doc/services/portability/posix/conformance/index.rst
@@ -39,7 +39,7 @@ POSIX System Interfaces
     :ref:`_POSIX_MAPPED_FILES<posix_option_group_mapped_files>`, 200809L, :kconfig:option:`CONFIG_POSIX_MAPPED_FILES`
     :ref:`_POSIX_MEMORY_PROTECTION<posix_option_group_memory_protection>`, 200809L, :kconfig:option:`CONFIG_POSIX_MEMORY_PROTECTION` :ref:`†<posix_undefined_behaviour>`
     :ref:`_POSIX_READER_WRITER_LOCKS<posix_option_reader_writer_locks>`, 200809L, :kconfig:option:`CONFIG_POSIX_READER_WRITER_LOCKS`
-    :ref:`_POSIX_REALTIME_SIGNALS<posix_option_group_realtime_signals>`, -1, :kconfig:option:`CONFIG_POSIX_REALTIME_SIGNALS`
+    :ref:`_POSIX_REALTIME_SIGNALS<posix_option_group_realtime_signals>`, 200809L, :kconfig:option:`CONFIG_POSIX_REALTIME_SIGNALS`
     :ref:`_POSIX_SEMAPHORES<posix_option_group_semaphores>`, 200809L, :kconfig:option:`CONFIG_POSIX_SEMAPHORES`
     :ref:`_POSIX_SPIN_LOCKS<posix_option_group_spin_locks>`, 200809L, :kconfig:option:`CONFIG_POSIX_SPIN_LOCKS`
     :ref:`_POSIX_THREAD_SAFE_FUNCTIONS<posix_thread_safe_functions>`, -1, :kconfig:option:`CONFIG_POSIX_THREAD_SAFE_FUNCTIONS`

--- a/doc/services/portability/posix/kconfig/index.rst
+++ b/doc/services/portability/posix/kconfig/index.rst
@@ -24,7 +24,6 @@ implementation of the POSIX API.
 * :kconfig:option:`CONFIG_POSIX_PTHREAD_ATTR_GUARDSIZE_BITS`
 * :kconfig:option:`CONFIG_POSIX_PTHREAD_ATTR_GUARDSIZE_DEFAULT`
 * :kconfig:option:`CONFIG_POSIX_PTHREAD_ATTR_STACKSIZE_BITS`
-* :kconfig:option:`CONFIG_POSIX_RTSIG_MAX`
 * :kconfig:option:`CONFIG_POSIX_SIGNAL_STRING_DESC`
 * :kconfig:option:`CONFIG_POSIX_THREAD_KEYS_MAX`
 * :kconfig:option:`CONFIG_POSIX_THREAD_THREADS_MAX`
@@ -35,6 +34,7 @@ implementation of the POSIX API.
 * :kconfig:option:`CONFIG_POSIX_SEM_NAMELEN_MAX`
 * :kconfig:option:`CONFIG_POSIX_SEM_NSEMS_MAX`
 * :kconfig:option:`CONFIG_POSIX_SEM_VALUE_MAX`
+* :kconfig:option:`CONFIG_SIGNAL_SET_SIZE`
 * :kconfig:option:`CONFIG_TIMER_CREATE_WAIT`
 * :kconfig:option:`CONFIG_THREAD_STACK_INFO`
 * :kconfig:option:`CONFIG_ZVFS_EVENTFD_MAX`

--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -566,7 +566,7 @@ Enable this option group with :kconfig:option:`CONFIG_POSIX_THREADS`.
     pthread_join(),yes
     pthread_key_create(),yes
     pthread_key_delete(),yes
-    pthread_kill(),
+    pthread_kill(),yes
     pthread_mutex_destroy(),yes
     pthread_mutex_init(),yes
     pthread_mutex_lock(),yes

--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -408,9 +408,9 @@ Enable this option group with :kconfig:option:`CONFIG_POSIX_REALTIME_SIGNALS`.
    :header: API, Supported
    :widths: 50,10
 
-    sigqueue(),
-    sigtimedwait(),
-    sigwaitinfo(),
+    sigqueue(),yes
+    sigtimedwait(),yes
+    sigwaitinfo(),yes
 
 .. _posix_option_group_semaphores:
 

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -6242,6 +6242,137 @@ void k_sys_runtime_stats_enable(void);
  */
 void k_sys_runtime_stats_disable(void);
 
+/**
+ * @addtogroup k_sig_apis
+ * @{
+ */
+
+/**
+ * @brief Add the signal @a sig to the signal set @a set.
+ *
+ * @param set the set to which @a sig should be added.
+ * @param sig the signal which should be added to @a set.
+ *
+ * @retval 0 on success.
+ * @return -EINVAL if @a sig is invalid.
+ */
+int k_sig_addset(struct k_sig_set *set, int sig);
+
+/**
+ * @brief Remove the signal @a sig from signal set @a set.
+ *
+ * @param set the set from which @a sig should be removed.
+ * @param sig the signal which should be removed from @a set.
+ *
+ * @retval 0 on success.
+ * @return -EINVAL if @a sig is invalid.
+ */
+int k_sig_delset(struct k_sig_set *set, int sig);
+
+/**
+ * @brief Check if signal @a sig is part of signal set @a set.
+ *
+ * @param set the set to check.
+ * @param sig the signal which should be checked.
+ *
+ * @retval 0 if @a sig is not part of @a set.
+ * @retval 1 if @a sig is part of @a set.
+ * @return -EINVAL if @a sig is invalid.
+ */
+int k_sig_ismember(const struct k_sig_set *set, int sig);
+
+/**
+ * @brief Initialize a signal set with the set of all signals.
+ *
+ * @param set signal set to initialize.
+ *
+ * @retval 0 on success.
+ * @return -EINVAL if @a sig is invalid.
+ */
+int k_sig_fillset(struct k_sig_set *set);
+
+/**
+ * @brief Initialize a signal set as empty.
+ *
+ * @param set signal set to initialize.
+ *
+ * @retval 0 on success.
+ * @return -EINVAL if @a sig is invalid.
+ */
+int k_sig_emptyset(struct k_sig_set *set);
+
+/**
+ * @brief Manipulate the signal mask of the calling thread.
+ *
+ * The parameter @a how may be specified as @ref K_SIG_BLOCK,
+ * @ref K_SIG_UNBLOCK, or @ref K_SIG_SETMASK. If @a how is @ref K_SIG_BLOCK,
+ * then the signals in @a set are added to the signal mask of the calling
+ * thread. If @a how is @ref K_SIG_UNBLOCK, then the signals in @a set
+ * are removed from the
+ *
+ * @param how how to manipulate the set
+ * @param set the set to manipulate
+ * @param[out] oset the resulting set
+ * @retval 0 on success
+ * @retval -EINVAL for invalid values of @a how
+ */
+__syscall int k_sig_mask(int how, const struct k_sig_set *set, struct k_sig_set *oset);
+
+/**
+ * @brief Get the set of pending signals for the calling thread.
+ *
+ * @param[out] set the set of pending signals for the calling thread.
+ * @retval 0 on success
+ * @retval -EINVAL for invalid values of @a set
+ */
+__syscall int k_sig_pending(struct k_sig_set *set);
+
+/**
+ * @brief Queue a signal for process ID @a pid.
+ *
+ * Queue the signal @a signo for process ID @a pid with value @a value.
+ *
+ * This function is safe to call in ISR context.
+ *
+ * @param pid the process ID for which to queue the signal.
+ * @param signo the signal number to queue.
+ * @param value the value associated with the signal.
+ *
+ * @retval 0 on success.
+ * @retval -EAGAIN if there were insufficient resources available.
+ * @retval -EINVAL if @a signo is invalid.
+ * @return -EPERM if the calling thread lacks permissions to signal the process with id @a pid.
+ * @return -ESRCH if a process with id @a pid does not exist.
+ */
+__syscall int k_sig_queue(k_pid_t pid, int signo, union k_sig_val value);
+
+/**
+ * @brief Wait for any signal in @a set for a maximum duration specified by @a timeout.
+ *
+ * Wait for any signal in @a set to be delivered to the calling thread.
+ *
+ * This call does not block if @ref K_NO_WAIT is specified in the @a timeout parameter.
+ * This call blocks indefinitely if @ref K_FOREVER is specified in the @a timeout parameter.
+ *
+ * @param set set of signals to wait for.
+ * @param[out] info pointer to a location in which to store signal-related information.
+ * @param timeout upper bound time to wait for a signal in @a set to be delivered.
+ *
+ * @retval 0 on success.
+ * @retval -EAGAIN if no signal in @a set was received within the specified @a timeout.
+ * @retval -EINTR if the operation was interrupted by a signal.
+ * @retval -ENOSYS if dynamic thread stack allocation is disabled
+ * @retval -EWOULDBLOCK if the operation would block and was called in ISR context.
+ *
+ * @see CONFIG_DYNAMIC_THREAD
+ */
+__syscall int k_sig_timedwait(const struct k_sig_set *set, struct k_sig_info *info,
+			      k_timeout_t timeout);
+
+/**
+ * @}
+ */
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/kernel/signal.h
+++ b/include/zephyr/kernel/signal.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2024, Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_ZEPHYR_KERNEL_SIGNAL_H_
+#define ZEPHYR_INCLUDE_ZEPHYR_KERNEL_SIGNAL_H_
+
+#include <zephyr/sys/util.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Kernel Signal APIs
+ * @defgroup k_sig_apis Kernel Signal APIs
+ * @ingroup kernel_apis
+ * @{
+ */
+
+/**
+ * @brief Block signals in the accompanying @ref k_sig_set
+ *
+ * @see @ref k_sig_mask
+ */
+#define K_SIG_BLOCK 0
+
+/**
+ * @brief Set signals in the accompanying @ref k_sig_set
+ *
+ * @see @ref k_sig_mask
+ */
+#define K_SIG_SETMASK 1
+
+/**
+ * @brief Unblock signals in the accompanying @ref k_sig_set
+ *
+ * @see @ref k_sig_mask
+ */
+#define K_SIG_UNBLOCK 2
+
+/**
+ * @brief Minimum realtime signal number
+ *
+ * Programs should only attempt to iterate over real-time signals relative to K_SIG_RTMIN and
+ * @ref K_SIG_NUM_RT.
+ *
+ * For example:
+ *
+ * @code{.c}
+ * for (int i = 0; i < K_SIG_NUM_RT; ++i) {
+ *   int sig = K_SIG_RTMIN + i;
+ *   // Do something with sig
+ * }
+ * @endcode
+ *
+ * @note K_SIG_RTMAX is intentionally not defined since it would inevitably lead to off-by-one
+ * errors.
+ */
+#define K_SIG_RTMIN 32
+
+/** @brief Number of supported realtime signals */
+#define K_SIG_NUM_RT MAX(CONFIG_SIGNAL_SET_SIZE - K_SIG_RTMIN, 0)
+
+/**
+ * @brief Signal value
+ *
+ * This union is passed to @ref k_sig_queue and is embedded in @ref k_sig_info, as an output
+ * parameter of @ref k_sig_timedwait.
+ */
+union k_sig_val {
+	int sival_int; /**< Integer signal value */
+	void *sival_ptr; /**< Pointer signal value */
+};
+
+/**
+ * @brief Signal info
+ *
+ * A pointer to an instance of this structure may be passed to @ref k_sig_timedwait to receive
+ * additional signal information.
+ */
+struct k_sig_info {
+	int si_signo; /**< Signal number */
+	int si_code; /**< Additional signal code */
+	union k_sig_val si_value; /**< Signal value */
+};
+
+/** @brief A bitset large enough to contain all signal bits. */
+struct k_sig_set {
+	unsigned long sig[DIV_ROUND_UP(MAX(CONFIG_SIGNAL_SET_SIZE, 1), BITS_PER_LONG)];
+};
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_ZEPHYR_KERNEL_SIGNAL_H_ */

--- a/include/zephyr/kernel/thread.h
+++ b/include/zephyr/kernel/thread.h
@@ -11,6 +11,10 @@
 #include <zephyr/kernel/mm/demand_paging.h>
 #endif /* CONFIG_DEMAND_PAGING_THREAD_STATS */
 
+#ifdef CONFIG_SIGNAL
+#include <zephyr/kernel/signal.h>
+#endif /* CONFIG_SIGNAL */
+
 #include <zephyr/kernel/stats.h>
 #include <zephyr/arch/arch_interface.h>
 
@@ -145,6 +149,10 @@ struct _thread_base {
 #ifdef CONFIG_SCHED_THREAD_USAGE
 	struct k_cycle_stats  usage;   /* Track thread usage statistics */
 #endif /* CONFIG_SCHED_THREAD_USAGE */
+
+#ifdef CONFIG_SIGNAL
+	struct k_sig_set sig_mask; /* masked signals */
+#endif
 };
 
 typedef struct _thread_base _thread_base_t;
@@ -378,5 +386,6 @@ struct k_thread {
 
 typedef struct k_thread _thread_t;
 typedef struct k_thread *k_tid_t;
+typedef k_tid_t k_pid_t;
 
 #endif /* ZEPHYR_INCLUDE_KERNEL_THREAD_H_ */

--- a/include/zephyr/kernel_includes.h
+++ b/include/zephyr/kernel_includes.h
@@ -42,6 +42,7 @@
 #include <zephyr/kernel/thread_stack.h>
 #include <zephyr/app_memory/mem_domain.h>
 #include <zephyr/sys/kobject.h>
+#include <zephyr/kernel/signal.h>
 #include <zephyr/kernel/thread.h>
 /* FIXME This needs to be removed. Exposes some private APIs to SOF */
 #include <zephyr/kernel/internal/smp.h>

--- a/include/zephyr/posix/posix_features.h
+++ b/include/zephyr/posix/posix_features.h
@@ -259,13 +259,14 @@
 #define _POSIX_PATH_MAX                     (256)
 #define _POSIX_PIPE_BUF                     (512)
 #define _POSIX_RE_DUP_MAX                   (255)
-#define _POSIX_RTSIG_MAX \
-	COND_CODE_1(CONFIG_POSIX_REALTIME_SIGNALS, (CONFIG_POSIX_RTSIG_MAX), (0))
+#define _POSIX_RTSIG_MAX                                                                           \
+	(((CONFIG_SIGNAL_SET_SIZE - K_SIG_RTMIN) > 0) ? (CONFIG_SIGNAL_SET_SIZE - K_SIG_RTMIN) : 0)
 #define _POSIX_SEM_NSEMS_MAX \
 	COND_CODE_1(CONFIG_POSIX_SEMAPHORES, (CONFIG_POSIX_SEM_NSEMS_MAX), (0))
 #define _POSIX_SEM_VALUE_MAX \
 	COND_CODE_1(CONFIG_POSIX_SEMAPHORES, (CONFIG_POSIX_SEM_VALUE_MAX), (0))
-#define _POSIX_SIGQUEUE_MAX                 (32)
+#define _POSIX_SIGQUEUE_MAX \
+	COND_CODE_1(CONFIG_POSIX_REALTIME_SIGNALS, (CONFIG_POSIX_SIGQUEUE_MAX), (0))
 #define _POSIX_SSIZE_MAX                    (32767)
 #define _POSIX_SS_REPL_MAX                  (4)
 #define _POSIX_STREAM_MAX                   (8)

--- a/include/zephyr/posix/signal.h
+++ b/include/zephyr/posix/signal.h
@@ -9,6 +9,9 @@
 #include "posix_types.h"
 #include "posix_features.h"
 
+#include <zephyr/kernel.h>
+#include <zephyr/posix/signal.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -47,13 +50,11 @@ extern "C" {
 
 #define SIGRTMIN 32
 #define SIGRTMAX (SIGRTMIN + RTSIG_MAX)
-#define _NSIG (SIGRTMAX + 1)
 
 BUILD_ASSERT(RTSIG_MAX >= 0);
 
-typedef struct {
-	unsigned long sig[DIV_ROUND_UP(_NSIG, BITS_PER_LONG)];
-} sigset_t;
+typedef struct k_sig_set sigset_t;
+struct timespec;
 
 #ifndef SIGEV_NONE
 #define SIGEV_NONE 1
@@ -68,13 +69,13 @@ typedef struct {
 #endif
 
 #ifndef SIG_BLOCK
-#define SIG_BLOCK 0
+#define SIG_BLOCK K_SIG_BLOCK
 #endif
 #ifndef SIG_SETMASK
-#define SIG_SETMASK 1
+#define SIG_SETMASK K_SIG_SETMASK
 #endif
 #ifndef SIG_UNBLOCK
-#define SIG_UNBLOCK 2
+#define SIG_UNBLOCK K_SIG_UNBLOCK
 #endif
 
 typedef int	sig_atomic_t;		/* Atomic entity type (ANSI) */
@@ -92,6 +93,8 @@ struct sigevent {
 	int sigev_signo;
 };
 
+typedef struct k_sig_info siginfo_t;
+
 char *strsignal(int signum);
 int sigemptyset(sigset_t *set);
 int sigfillset(sigset_t *set);
@@ -101,6 +104,11 @@ int sigismember(const sigset_t *set, int signo);
 int sigprocmask(int how, const sigset_t *ZRESTRICT set, sigset_t *ZRESTRICT oset);
 
 int pthread_sigmask(int how, const sigset_t *ZRESTRICT set, sigset_t *ZRESTRICT oset);
+
+int sigqueue(pid_t pid, int signo, union sigval value);
+int sigtimedwait(const sigset_t *ZRESTRICT set, siginfo_t *ZRESTRICT info,
+		 const struct timespec *ZRESTRICT timeout);
+int sigwaitinfo(const sigset_t *ZRESTRICT set, siginfo_t *ZRESTRICT info);
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/posix/signal.h
+++ b/include/zephyr/posix/signal.h
@@ -103,6 +103,7 @@ int sigdelset(sigset_t *set, int signo);
 int sigismember(const sigset_t *set, int signo);
 int sigprocmask(int how, const sigset_t *ZRESTRICT set, sigset_t *ZRESTRICT oset);
 
+int pthread_kill(pthread_t thread, int sig);
 int pthread_sigmask(int how, const sigset_t *ZRESTRICT set, sigset_t *ZRESTRICT oset);
 
 int sigqueue(pid_t pid, int signo, union sigval value);

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -149,6 +149,7 @@ target_sources_ifdef(CONFIG_EVENTS                kernel PRIVATE events.c)
 target_sources_ifdef(CONFIG_PIPES                 kernel PRIVATE pipes.c)
 target_sources_ifdef(CONFIG_SCHED_THREAD_USAGE    kernel PRIVATE usage.c)
 target_sources_ifdef(CONFIG_OBJ_CORE              kernel PRIVATE obj_core.c)
+target_sources_ifdef(CONFIG_SIGNAL                kernel PRIVATE signal.c)
 
 if(${CONFIG_KERNEL_MEM_POOL})
   target_sources(kernel PRIVATE mempool.c)

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -676,6 +676,63 @@ config POLL
 	  concurrently, which can be either directly triggered or triggered by
 	  the availability of some kernel objects (semaphores and FIFOs).
 
+config SIGNAL
+	bool "Signal support"
+	depends on POLL
+	depends on RING_BUFFER
+	help
+	  Select 'y' here to support signals.
+
+if SIGNAL
+
+config SIGNAL_QUEUE_SIZE_32
+	bool
+	help
+	  This is a hidden symbol used by subsystems (like POSIX) to indirectly
+	  affect a default size reflective of the standard, since we may not refer
+	  to POSIX Kconfig options here.
+
+config SIGNAL_QUEUE_SIZE
+	int "Signal queue size"
+	range 1 256
+	default 32 if SIGNAL_QUEUE_SIZE_32
+	default 1
+	help
+	  Size of kernel signal queue.
+
+config SIGNAL_POSIX_NEEDED
+	bool
+	help
+	  This is a hidden symbol used to indirectly affect the default signal set
+	  size.
+
+config SIGNAL_RT_NEEDED
+	bool
+	help
+	  This is a hidden symbol used to indirectly affect the default signal set
+	  size.
+
+module := SIGNAL
+module-str = k_sig
+source "subsys/logging/Kconfig.template.log_config"
+
+endif # SIGNAL
+
+# defined outside of the SIGNAL block to ensure struct k_sig_set is always well-defined
+config SIGNAL_SET_SIZE
+	int "Maximum number of signals"
+	default 0 if !SIGNAL
+	# 6 ISO C signals
+	default 6 if !SIGNAL_POSIX_NEEDED && !SIGNAL_RT_NEEDED
+	# 6 ISO C signals, 26 unused POSIX signals, and at least 8 Realtime signals
+	default 40 if !SIGNAL_POSIX_NEEDED && SIGNAL_RT_NEEDED
+	# 6 ISO C signals, and 26 POSIX signals
+	default 32 if SIGNAL_POSIX_NEEDED && !SIGNAL_RT_NEEDED
+	# 6 ISO C signals, 26 POSIX signals, and at least 8 Realtime signals
+	default 40 if SIGNAL_POSIX_NEEDED && SIGNAL_RT_NEEDED
+	help
+	  Maximum number of signals that can be represented in a struct k_sigset.
+
 config MEM_SLAB_TRACE_MAX_UTILIZATION
 	bool "Getting maximum slab utilization"
 	help

--- a/kernel/signal.c
+++ b/kernel/signal.c
@@ -1,0 +1,545 @@
+/*
+ * Copyright (c) 2023, Meta
+ * Copyright (c) 2024, Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+#include <string.h>
+#include <stdalign.h>
+
+#include <zephyr/internal/syscall_handler.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/math_extras.h>
+#include <zephyr/sys/ring_buffer.h>
+
+#ifndef BITS_PER_BYTE
+#define BITS_PER_BYTE 8
+#endif
+
+#define K_NSIG CONFIG_SIGNAL_SET_SIZE
+
+LOG_MODULE_REGISTER(k_sig, CONFIG_SIGNAL_LOG_LEVEL);
+
+struct k_sig_fifo_element {
+	k_tid_t tid;
+	union k_sig_val value;
+	int signo;
+};
+
+/*
+ * We use a ring buffer of bytes, where each byte is an index of an allocated k_sig_fifo_element
+ * from the slab below. This should save some space, since 256 signals should be well beyond
+ * enough to queue.
+ */
+BUILD_ASSERT(CONFIG_SIGNAL_QUEUE_SIZE > 0, "SIGQUEUE_MAX is too small");
+BUILD_ASSERT(CONFIG_SIGNAL_QUEUE_SIZE <= BIT(BITS_PER_BYTE), "SIGQUEUE_MAX is too large");
+
+BUILD_ASSERT(CONFIG_SIGNAL_SET_SIZE >= 0);
+
+RING_BUF_DECLARE_STATIC(k_sig_fifo, CONFIG_SIGNAL_QUEUE_SIZE);
+static struct k_poll_signal k_sig_fifo_ready = K_POLL_SIGNAL_INITIALIZER(k_sig_fifo_ready);
+K_MEM_SLAB_DEFINE_STATIC(k_sig_slab, sizeof(struct k_sig_fifo_element), CONFIG_SIGNAL_QUEUE_SIZE,
+			 alignof(struct k_sig_fifo_element));
+static struct k_sig_fifo_element *const k_sig_array =
+	(struct k_sig_fifo_element *)_k_mem_slab_buf_k_sig_slab;
+static struct k_spinlock *const k_sig_lock = &k_sig_slab.lock;
+
+static int k_sig_min_rt_in_set(const struct k_sig_set *set);
+static bool k_sig_setisempty(const struct k_sig_set *set);
+static void k_sig_unset(struct k_sig_set *result, const struct k_sig_set *set);
+static void k_sig_orset(struct k_sig_set *result, const struct k_sig_set *set2);
+static void k_sig_fifo_dump(void);
+static inline void k_sig_dump_set(const struct k_sig_set *set, const char *label);
+
+/** @brief True if thread id @a tid is valid */
+static bool k_sig_pid_is_valid(k_pid_t pid)
+{
+	k_tid_t tid = (k_tid_t)pid;
+	const uint32_t valid_states = _THREAD_PENDING | _THREAD_SUSPENDED | _THREAD_QUEUED;
+
+	if (pid == NULL) {
+		LOG_DBG("pid is NULL");
+		return false;
+	}
+
+	if (_current == tid) {
+		/* current tid is always valid (thread signals itself) */
+		return true;
+	}
+
+	if ((tid->base.thread_state & valid_states) != 0) {
+		return true;
+	}
+
+	LOG_DBG("thread state %x is invalid (valid mask: %x)", tid->base.thread_state,
+		valid_states);
+
+	return false;
+}
+
+static void k_sig_pending_unlocked(struct k_sig_set *set)
+{
+	struct k_thread *tid = _current;
+
+	k_sig_emptyset(set);
+	for (size_t i = 0, N = ring_buf_size_get(&k_sig_fifo); i < N; ++i) {
+		uint8_t p;
+		struct k_sig_fifo_element *entry;
+
+		ring_buf_get(&k_sig_fifo, &p, 1);
+		ring_buf_put(&k_sig_fifo, &p, 1);
+		entry = &((struct k_sig_fifo_element *)k_sig_slab.buffer)[p];
+
+		if (entry->tid == tid) {
+			k_sig_addset(set, entry->signo);
+		}
+	}
+}
+
+static bool k_sig_match(const struct k_sig_set *match, uint8_t *pos)
+{
+	bool found = false;
+	/* if filter_signo <= 0, any signal will do, otherwise choose only the specified signal */
+	int filter_sig = 0;
+	k_tid_t tid = _current;
+	struct k_sig_set set;
+	struct k_sig_set pend;
+	struct k_sig_set *const mask = &_current->base.sig_mask;
+
+	K_SPINLOCK(k_sig_lock) {
+		k_sig_pending_unlocked(&pend);
+
+		k_sig_dump_set(match, "match  : ");
+		k_sig_dump_set(&pend, "pending: ");
+		k_sig_dump_set(mask, "mask:    ");
+
+		ARRAY_FOR_EACH(set.sig, i) {
+			set.sig[i] = match->sig[i] & pend.sig[i] & ~mask->sig[i];
+		}
+
+		if (k_sig_setisempty(&set)) {
+			found = false;
+			K_SPINLOCK_BREAK;
+		}
+
+		filter_sig = k_sig_min_rt_in_set(&set);
+
+		for (int i = 0, N = ring_buf_size_get(&k_sig_fifo); i < N; ++i) {
+			uint8_t p;
+			struct k_sig_fifo_element *entry;
+
+			ring_buf_get(&k_sig_fifo, &p, 1);
+			entry = &k_sig_array[p];
+
+			if (!found && (entry->tid == tid) && (filter_sig > 0) &&
+			    (entry->signo == filter_sig)) {
+				/* a signal matching 'filter_sig' was found */
+				*pos = p;
+				found = true;
+			} else if (!found && (entry->tid == tid) && (filter_sig <= 0) &&
+				   ((bool)k_sig_ismember(&set, entry->signo))) {
+				/* a signal in 'set' was found */
+				*pos = p;
+				found = true;
+			} else {
+				/* no matching signal found. replace in the correct order */
+				ring_buf_put(&k_sig_fifo, &p, 1);
+			}
+		}
+	}
+
+	return found;
+}
+
+int z_impl_k_sig_queue(k_pid_t pid, int signo, union k_sig_val value)
+{
+	uint8_t pos;
+	struct k_sig_fifo_element *entry = NULL;
+
+	if ((signo < 0) || (signo > CONFIG_SIGNAL_SET_SIZE)) {
+		LOG_DBG("invalid signo %d", signo);
+		return -EINVAL;
+	}
+
+	if (!k_sig_pid_is_valid(pid)) {
+		LOG_DBG("invalid pid %p", pid);
+		return -ESRCH;
+	}
+
+	if (signo == 0) {
+		/* Only check if pid is valid. Do not attempt to deliver signo */
+		LOG_DBG("pid %lx is valid", POINTER_TO_UINT(pid));
+		return 0;
+	}
+
+#if defined(CONFIG_USERSPACE) && defined(CONFIG_DYNAMIC_OBJECTS)
+	if (k_object_validate(k_object_find(pid), K_OBJ_THREAD, _OBJ_INIT_TRUE) < 0) {
+		/* Only allow signals from threads granted access */
+		LOG_ERR("tid %lx does not have permissions for tid %lx", POINTER_TO_UINT(_current),
+			POINTER_TO_UINT(pid));
+		return -EPERM;
+	}
+#endif
+
+	if (k_mem_slab_alloc(&k_sig_slab, (void **)&entry, K_NO_WAIT) != 0) {
+		LOG_DBG("no more signals to alloc");
+		return -EAGAIN;
+	}
+
+	K_SPINLOCK(k_sig_lock) {
+		*entry = (struct k_sig_fifo_element){
+			.tid = pid,
+			.signo = signo,
+			.value = value,
+		};
+		pos = entry - k_sig_array;
+
+		ring_buf_put(&k_sig_fifo, &pos, 1);
+		if (IS_ENABLED(CONFIG_SIGNAL_LOG_LEVEL_DBG)) {
+			struct k_sig_set pend;
+
+			LOG_DBG("%lx: pushed signal %d", POINTER_TO_UINT(_current), signo);
+			k_sig_pending_unlocked(&pend);
+			k_sig_dump_set(&pend, "pending: ");
+			k_sig_fifo_dump();
+		}
+
+		k_poll_signal_raise(&k_sig_fifo_ready, (int)(intptr_t)pid);
+	}
+
+	return 0;
+}
+
+#ifdef CONFIG_USERSPACE
+int z_vrfy_k_sig_queue(k_pid_t pid, int signo, union k_sig_val value)
+{
+	return z_impl_k_sig_queue(pid, signo, value);
+}
+#include <syscalls/k_sig_queue_mrsh.c>
+#endif
+
+int z_impl_k_sig_timedwait(const struct k_sig_set *ZRESTRICT set, struct k_sig_info *ZRESTRICT info,
+			   k_timeout_t timeout)
+{
+	uint8_t pos;
+	int ret = -EAGAIN;
+	int self = (int)(intptr_t)_current;
+	k_timepoint_t end = sys_timepoint_calc(timeout);
+
+	if (set == NULL) {
+		return -EINVAL;
+	}
+
+	do {
+		if (k_sig_match(set, &pos)) {
+			ret = k_sig_array[pos].signo;
+			break;
+		}
+
+		timeout = sys_timepoint_timeout(end);
+		ret = k_poll(&(struct k_poll_event)K_POLL_EVENT_INITIALIZER(K_POLL_TYPE_SIGNAL,
+									    K_POLL_MODE_NOTIFY_ONLY,
+									    &k_sig_fifo_ready),
+			     1, timeout);
+		if (ret < 0) {
+			k_sig_dump_set(set, "time-out waiting for a signal");
+			ret = -EAGAIN;
+			break;
+		}
+
+		int signalled = 0;
+		int result = 0;
+
+		k_poll_signal_check(&k_sig_fifo_ready, &signalled, &result);
+
+		if ((bool)signalled) {
+			/*
+			 * We cheat slighly on 64-bit platforms by shoe-horning the
+			 * least-significant 32-bits of a k_tid_t into the signal. Not a problem on
+			 * 32-bit platforms. Even on 64-bit platforms, not really a major concern
+			 * because we check the queue every time anyway, but this allows us to
+			 * re-post signals for other threads.
+			 */
+			if (result == self) {
+				k_poll_signal_reset(&k_sig_fifo_ready);
+				if (k_sig_match(set, &pos)) {
+					ret = k_sig_array[pos].signo;
+					break;
+				}
+
+				LOG_DBG("signaled, but failed to match! signalled: %d "
+					"result: %x ",
+					signalled, result);
+				ret = -EAGAIN;
+				break;
+			}
+		}
+
+	} while (!K_TIMEOUT_EQ(timeout, K_NO_WAIT));
+
+	if (ret > 0) {
+		if (info != NULL) {
+			*info = (struct k_sig_info){
+				.si_signo = ret,
+				.si_value = k_sig_array[pos].value,
+			};
+		}
+
+		k_mem_slab_free(&k_sig_slab, &k_sig_array[pos]);
+
+		if (IS_ENABLED(CONFIG_SIGNAL_LOG_LEVEL_DBG)) {
+			struct k_sig_set pend;
+
+			K_SPINLOCK(k_sig_lock) {
+				k_sig_pending_unlocked(&pend);
+				LOG_DBG("%lx: popped signal %d", POINTER_TO_UINT(_current), ret);
+				k_sig_dump_set(&pend, "pending: ");
+				k_sig_fifo_dump();
+			}
+		}
+	}
+
+	return ret;
+}
+
+#ifdef CONFIG_USERSPACE
+int z_vrfy_k_sig_timedwait(const struct k_sig_set *ZRESTRICT set, struct k_sig_info *ZRESTRICT info,
+			   k_timeout_t timeout)
+{
+	K_OOPS(K_SYSCALL_MEMORY_READ(set, sizeof(struct k_sig_set)));
+	if (info != NULL) {
+		K_OOPS(K_SYSCALL_MEMORY_WRITE(info, sizeof(struct k_sig_info)));
+	}
+
+	return z_impl_k_sig_timedwait(set, info, timeout);
+}
+#include <syscalls/k_sig_timedwait_mrsh.c>
+#endif
+
+int z_impl_k_sig_mask(int how, const struct k_sig_set *set, struct k_sig_set *oset)
+{
+	int ret = 0;
+	k_tid_t tid = k_current_get();
+
+	if (!(how == K_SIG_BLOCK || how == K_SIG_SETMASK || how == K_SIG_UNBLOCK)) {
+		return -EINVAL;
+	}
+
+	if (oset != NULL) {
+		*oset = tid->base.sig_mask;
+	}
+
+	if (set == NULL) {
+		return 0;
+	}
+
+	switch (how) {
+	case K_SIG_BLOCK:
+		k_sig_orset(&tid->base.sig_mask, set);
+		break;
+	case K_SIG_SETMASK:
+		tid->base.sig_mask = *set;
+		break;
+	case K_SIG_UNBLOCK:
+		k_sig_unset(&tid->base.sig_mask, set);
+		break;
+	}
+
+	return ret;
+}
+
+#ifdef CONFIG_USERSPACE
+int z_vrfy_k_sig_mask(int how, const struct k_sig_set *set, struct k_sig_set *oset)
+{
+	if (set != NULL) {
+		K_OOPS(K_SYSCALL_MEMORY_READ(set, sizeof(*set)));
+	}
+
+	if (oset != NULL) {
+		K_OOPS(K_SYSCALL_MEMORY_WRITE(oset, sizeof(*oset)));
+	}
+
+	return z_impl_k_sig_mask(how, set, oset);
+}
+#include <syscalls/k_sig_mask_mrsh.c>
+#endif
+
+int z_impl_k_sig_pending(struct k_sig_set *set)
+{
+	K_SPINLOCK(k_sig_lock) {
+		k_sig_pending_unlocked(set);
+	}
+
+	return 0;
+}
+
+#ifdef CONFIG_USERSPACE
+int z_vrfy_k_sig_pending(struct k_sig_set *set)
+{
+	K_OOPS(K_SYSCALL_MEMORY_WRITE(set, sizeof(*set)));
+	return z_impl_k_sig_pending(set);
+}
+#include <syscalls/k_sig_pending_mrsh.c>
+#endif
+
+int k_sig_addset(struct k_sig_set *set, int sig)
+{
+	int bit = (sig - 1) & BIT_MASK(LOG2(BITS_PER_LONG));
+	int i = (sig - 1) >> LOG2(BITS_PER_LONG);
+
+	if (set == NULL || sig <= 0 || sig > K_NSIG) {
+		return -EINVAL;
+	}
+
+	if (IS_ENABLED(CONFIG_64BIT)) {
+		set->sig[i] |= BIT64(bit);
+	} else {
+		set->sig[i] |= BIT(bit);
+	}
+
+	return 0;
+}
+
+int k_sig_delset(struct k_sig_set *set, int sig)
+{
+	int bit = (sig - 1) & BIT_MASK(LOG2(BITS_PER_LONG));
+	int i = (sig - 1) >> LOG2(BITS_PER_LONG);
+
+	if (set == NULL || sig <= 0 || sig > K_NSIG) {
+		return -EINVAL;
+	}
+
+	if (IS_ENABLED(CONFIG_64BIT)) {
+		set->sig[i] &= ~BIT64(bit);
+	} else {
+		set->sig[i] &= ~BIT(bit);
+	}
+
+	return 0;
+}
+
+int k_sig_ismember(const struct k_sig_set *set, int sig)
+{
+	int bit = (sig - 1) & BIT_MASK(LOG2(BITS_PER_LONG));
+	int i = (sig - 1) >> LOG2(BITS_PER_LONG);
+
+	if (set == NULL || sig <= 0 || sig > K_NSIG) {
+		return -EINVAL;
+	}
+
+	if (IS_ENABLED(CONFIG_64BIT)) {
+		return (set->sig[i] & BIT64(bit)) != 0;
+	} else {
+		return (set->sig[i] & BIT(bit)) != 0;
+	}
+}
+
+int k_sig_fillset(struct k_sig_set *set)
+{
+	if (set == NULL) {
+		return -EINVAL;
+	}
+
+	ARRAY_FOR_EACH(set->sig, i) {
+		set->sig[i] = -1;
+	}
+
+	return 0;
+}
+
+int k_sig_emptyset(struct k_sig_set *set)
+{
+	if (set == NULL) {
+		return -EINVAL;
+	}
+
+	ARRAY_FOR_EACH(set->sig, i) {
+		set->sig[i] = 0;
+	}
+
+	return 0;
+}
+
+static void k_sig_orset(struct k_sig_set *result, const struct k_sig_set *set2)
+{
+	ARRAY_FOR_EACH(result->sig, i) {
+		result->sig[i] |= set2->sig[i];
+	}
+}
+
+static void k_sig_unset(struct k_sig_set *result, const struct k_sig_set *set)
+{
+	ARRAY_FOR_EACH(result->sig, i) {
+		result->sig[i] &= ~set->sig[i];
+	}
+}
+
+static bool k_sig_setisempty(const struct k_sig_set *set)
+{
+	ARRAY_FOR_EACH(set->sig, i) {
+		if (set->sig[i] == 0) {
+			continue;
+		}
+
+		return false;
+	}
+
+	return true;
+}
+
+/* finds the lowest-numbered real-time signal in a set (or zero if no RT signal is in set) */
+static int k_sig_min_rt_in_set(const struct k_sig_set *set)
+{
+	unsigned long word;
+
+	if (K_SIG_NUM_RT == 0) {
+		return 0;
+	}
+
+	ARRAY_FOR_EACH(set->sig, i) {
+		word = set->sig[i];
+
+		if (i == 0) {
+			word &= ~BIT_MASK(K_SIG_RTMIN - 1);
+		}
+
+		if (word == 0) {
+			continue;
+		}
+
+		return (i * BITS_PER_LONG) +
+		       (IS_ENABLED(CONFIG_64BIT) ? u64_count_trailing_zeros(word)
+						 : u32_count_trailing_zeros(word)) +
+		       1;
+	}
+
+	return 0;
+}
+
+static void k_sig_fifo_dump(void)
+{
+	if (IS_ENABLED(CONFIG_SIGNAL_LOG_LEVEL_DBG)) {
+		uint8_t buf[CONFIG_SIGNAL_QUEUE_SIZE];
+		size_t N = ring_buf_size_get(&k_sig_fifo);
+
+		if (N == 0) {
+			LOG_DBG("sigq: (empty)");
+			return;
+		}
+
+		ring_buf_get(&k_sig_fifo, buf, N);
+		ring_buf_put(&k_sig_fifo, buf, N);
+
+		LOG_HEXDUMP_DBG(buf, N, "sigq");
+	}
+}
+
+static inline void k_sig_dump_set(const struct k_sig_set *set, const char *label)
+{
+	if (IS_ENABLED(CONFIG_SIGNAL_LOG_LEVEL_DBG)) {
+		LOG_HEXDUMP_DBG(set, sizeof(*set), label);
+	}
+}

--- a/lib/posix/options/CMakeLists.txt
+++ b/lib/posix/options/CMakeLists.txt
@@ -133,6 +133,10 @@ if (NOT CONFIG_TC_PROVIDES_POSIX_READER_WRITER_LOCKS)
   zephyr_library_sources_ifdef(CONFIG_POSIX_READER_WRITER_LOCKS rwlock.c)
 endif()
 
+if (NOT CONFIG_TC_PROVIDES_POSIX_REALTIME_SIGNALS)
+  zephyr_library_sources_ifdef(CONFIG_POSIX_REALTIME_SIGNALS rtsig.c)
+endif()
+
 if (NOT CONFIG_TC_PROVIDES_POSIX_SEMAPHORES)
   zephyr_library_sources_ifdef(CONFIG_POSIX_SEMAPHORES semaphore.c)
 endif()

--- a/lib/posix/options/Kconfig.deprecated
+++ b/lib/posix/options/Kconfig.deprecated
@@ -93,12 +93,11 @@ config POSIX_FS
 
 config POSIX_LIMITS_RTSIG_MAX
 	int "_POSIX_RTSIG_MAX value in limits.h [DEPRECATED]"
-	default POSIX_RTSIG_MAX if POSIX_REALTIME_SIGNALS
-	default 0
+	default 8
 	help
 	  This option is deprecated.
 
-	  Please use CONFIG_POSIX_RTSIG_MAX instead.
+	  Please use _POSIX_RTSIG_MAX instead.
 
 config POSIX_MAX_FDS
 	int "Maximum number of open file descriptors [DEPRECATED]"

--- a/lib/posix/options/Kconfig.signal
+++ b/lib/posix/options/Kconfig.signal
@@ -7,23 +7,31 @@ menu "POSIX signals"
 config POSIX_REALTIME_SIGNALS
 	bool "POSIX realtime signals [EXPERIMENTAL]"
 	select EXPERIMENTAL
+	select POLL
+	select RING_BUFFER
+	select SIGNAL
+	select SIGNAL_QUEUE_SIZE_32
+	select SIGNAL_RT_NEEDED
 	help
 	  Enable support for POSIX realtime signals.
 
 if POSIX_REALTIME_SIGNALS
 
-config POSIX_RTSIG_MAX
-	int "Maximum number of realtime signals"
-	default 8
+config POSIX_SIGQUEUE_MAX
+	int
+	default SIGNAL_QUEUE_SIZE
 	help
-	  Define the maximum number of realtime signals (RTSIG_MAX).
-	  The range of realtime signals is [SIGRTMIN .. (SIGRTMIN+RTSIG_MAX)]
+	  The maximum number of queued signals
 
 endif # POSIX_REALTIME_SIGNALS
 
 config POSIX_SIGNALS
 	bool "POSIX signals [EXPERIMENTAL]"
 	select EXPERIMENTAL
+	select POLL
+	select RING_BUFFER
+	select SIGNAL
+	select SIGNAL_POSIX_NEEDED
 	help
 	  Enable support for POSIX signals.
 

--- a/lib/posix/options/posix_internal.h
+++ b/lib/posix/options/posix_internal.h
@@ -59,9 +59,6 @@ struct posix_thread {
 	/* Exit status */
 	void *retval;
 
-	/* Signal mask */
-	sigset_t sigset;
-
 	/* Queue ID (internal-only) */
 	uint8_t qid;
 };

--- a/lib/posix/options/pthread.c
+++ b/lib/posix/options/pthread.c
@@ -1411,51 +1411,6 @@ int pthread_atfork(void (*prepare)(void), void (*parent)(void), void (*child)(vo
 	return ENOSYS;
 }
 
-/* this should probably go into signal.c but we need access to the lock */
-int pthread_sigmask(int how, const sigset_t *ZRESTRICT set, sigset_t *ZRESTRICT oset)
-{
-	int ret = 0;
-	struct posix_thread *t;
-
-	if (!(how == SIG_BLOCK || how == SIG_SETMASK || how == SIG_UNBLOCK)) {
-		return EINVAL;
-	}
-
-	K_SPINLOCK(&pthread_pool_lock) {
-		t = to_posix_thread(pthread_self());
-		if (t == NULL) {
-			ret = ESRCH;
-			K_SPINLOCK_BREAK;
-		}
-
-		if (oset != NULL) {
-			*oset = t->sigset;
-		}
-
-		if (set == NULL) {
-			K_SPINLOCK_BREAK;
-		}
-
-		switch (how) {
-		case SIG_BLOCK:
-			for (size_t i = 0; i < ARRAY_SIZE(set->sig); ++i) {
-				t->sigset.sig[i] |= set->sig[i];
-			}
-			break;
-		case SIG_SETMASK:
-			t->sigset = *set;
-			break;
-		case SIG_UNBLOCK:
-			for (size_t i = 0; i < ARRAY_SIZE(set->sig); ++i) {
-				t->sigset.sig[i] &= ~set->sig[i];
-			}
-			break;
-		}
-	}
-
-	return ret;
-}
-
 static int posix_thread_pool_init(void)
 {
 	ARRAY_FOR_EACH_PTR(posix_thread_pool, th) {

--- a/lib/posix/options/pthread.c
+++ b/lib/posix/options/pthread.c
@@ -1411,6 +1411,15 @@ int pthread_atfork(void (*prepare)(void), void (*parent)(void), void (*child)(vo
 	return ENOSYS;
 }
 
+int pthread_kill(pthread_t thread, int sig)
+{
+	if (!IS_ENABLED(CONFIG_POSIX_REALTIME_SIGNALS)) {
+		return ENOTSUP;
+	}
+
+	return sigqueue((pid_t)thread, sig, (union sigval){0});
+}
+
 static int posix_thread_pool_init(void)
 {
 	ARRAY_FOR_EACH_PTR(posix_thread_pool, th) {

--- a/lib/posix/options/rtsig.c
+++ b/lib/posix/options/rtsig.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024, Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "posix_internal.h"
+
+#include <errno.h>
+#include <time.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/posix/signal.h>
+
+int sigqueue(pid_t pid, int signo, union sigval value)
+{
+	struct posix_thread *pth = to_posix_thread(pid);
+	union k_sig_val val = {
+		.sival_ptr = value.sival_ptr,
+	};
+
+	if (pth == NULL) {
+		errno = ESRCH;
+		return -1;
+	}
+
+	return k_sig_queue(&pth->thread, signo, val);
+}
+
+int sigtimedwait(const sigset_t *ZRESTRICT set, siginfo_t *ZRESTRICT info,
+		 const struct timespec *ZRESTRICT timeout)
+{
+	int ret;
+	k_timeout_t to;
+
+	if (timeout == NULL) {
+		to = K_FOREVER;
+	} else {
+		to = K_MSEC(timeout->tv_sec * MSEC_PER_SEC + timeout->tv_nsec / NSEC_PER_MSEC);
+	}
+
+	ret = k_sig_timedwait(set, info, to);
+	if (ret < 0) {
+		errno = -ret;
+		return -1;
+	}
+
+	return ret;
+}
+
+int sigwaitinfo(const sigset_t *ZRESTRICT set, siginfo_t *ZRESTRICT info)
+{
+	int ret;
+
+	ret = k_sig_timedwait(set, info, K_FOREVER);
+	if (ret < 0) {
+		errno = -ret;
+		return -1;
+	}
+
+	return ret;
+}

--- a/tests/kernel/signal/CMakeLists.txt
+++ b/tests/kernel/signal/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(signal)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/signal/prj.conf
+++ b/tests/kernel/signal/prj.conf
@@ -1,0 +1,10 @@
+CONFIG_POLL=y
+CONFIG_RING_BUFFER=y
+CONFIG_SIGNAL=y
+CONFIG_ZTEST=y
+
+# allow up to 8 realtime signals
+CONFIG_SIGNAL_SET_SIZE=40
+
+# ensure the queue can hold our set of realtime signals
+CONFIG_SIGNAL_QUEUE_SIZE=8

--- a/tests/kernel/signal/src/main.c
+++ b/tests/kernel/signal/src/main.c
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2024, Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+
+BUILD_ASSERT(K_SIG_NUM_RT >= 0);
+
+static struct k_sig_set rt_sigset;
+
+static void block_non_realtime_signals(void)
+{
+	/*
+	 * Normal signals are not yet a thing in Zephyr. Specifically, they behave just like
+	 * realtime signals (which is not POSIX conformant). More specifically, normal signals are
+	 * not delivered asynchronously. To keep this test mostly compliant though, we block normal
+	 * signals and only consider realtime signals.
+	 */
+
+	struct k_sig_set set;
+
+	k_sig_fillset(&set);
+	for (int i = 0; i < K_SIG_NUM_RT; ++i) {
+		k_sig_delset(&set, (K_SIG_RTMIN + i));
+	}
+
+	zassert_ok(k_sig_mask(K_SIG_BLOCK, &set, NULL));
+}
+
+ZTEST(signal, test_k_sig_queue)
+{
+	{
+		/* Degenerate cases */
+		zassert_not_ok(k_sig_queue(NULL, -1, (union k_sig_val){0}));
+		zassert_not_ok(k_sig_queue(NULL, K_SIG_RTMIN, (union k_sig_val){0}));
+		zassert_not_ok(k_sig_queue((k_pid_t)k_current_get(), -1, (union k_sig_val){0}));
+	}
+
+	struct k_sig_info info;
+	const k_timeout_t timeout = K_NO_WAIT;
+	const struct k_sig_set set = rt_sigset;
+
+	block_non_realtime_signals();
+
+	/*
+	 * Test for multiple real-time signals of the same type being returned in the order
+	 * they were queued.
+	 */
+	for (int i = 0; i < CONFIG_SIGNAL_QUEUE_SIZE; ++i) {
+		zassert_ok(k_sig_queue((k_pid_t)k_current_get(), K_SIG_RTMIN,
+				       (union k_sig_val){.sival_int = i}),
+			   "failed to queue the %d-th signal", i);
+	}
+
+	for (int i = 0; i < CONFIG_SIGNAL_QUEUE_SIZE; ++i) {
+		int actual;
+
+		info = (struct k_sig_info){0};
+		actual = k_sig_timedwait(&set, &info, timeout);
+
+		zassert_equal(
+			K_SIG_RTMIN, actual,
+			"iteration %d expected K_SIG_RTMIN (%d) but k_sig_timedwait() returned %d "
+			"(errno: %d)",
+			i, K_SIG_RTMIN, actual, errno);
+		zassert_equal(info.si_value.sival_int, i);
+	}
+
+	/*
+	 * test for different real-time signals being delivered lowest-numbered first
+	 */
+	for (int i = K_SIG_NUM_RT - 1; i >= 0; --i) {
+		zassert_ok(k_sig_queue((k_pid_t)k_current_get(), (K_SIG_RTMIN + i),
+				       (union k_sig_val){0}),
+			   "unable to queue signal %d", (K_SIG_RTMIN + i));
+	}
+
+	for (int i = 0; i < K_SIG_NUM_RT; ++i) {
+		int actual = k_sig_timedwait(&set, NULL, timeout);
+
+		zassert_equal((K_SIG_RTMIN + i), actual,
+			      "expected signal %d, but k_sig_timedwait() returned %d",
+			      (K_SIG_RTMIN + i), actual);
+	}
+}
+
+static struct sigqueue_work {
+	struct k_work_delayable dwork;
+	k_tid_t tid;
+} sigq_work;
+
+static void do_queue(struct k_work *work)
+{
+	struct sigqueue_work *sq_work = CONTAINER_OF(
+		CONTAINER_OF(work, struct k_work_delayable, work), struct sigqueue_work, dwork);
+
+	zassert_ok(k_sig_queue(sq_work->tid, K_SIG_RTMIN, (union k_sig_val){0}));
+}
+
+static void queue_signal_after_ms(k_tid_t tid, int delay_ms)
+{
+	sigq_work.tid = tid;
+	k_work_init_delayable(&sigq_work.dwork, do_queue);
+	k_work_schedule(&sigq_work.dwork, K_MSEC(delay_ms));
+}
+
+ZTEST(signal, test_k_sig_timedwait)
+{
+	struct k_sig_info info;
+	k_pid_t self = (k_pid_t)k_current_get();
+	uint32_t begin_ms, delta_ms, end_ms;
+	const struct k_sig_set set = rt_sigset;
+
+	const struct stw_args_exp {
+		const struct k_sig_set *set;
+		struct k_sig_info *info;
+		k_timeout_t timeout;
+		int expected_error;
+	} harness[] = {
+		{NULL, NULL, K_NO_WAIT, -EINVAL},
+		{NULL, &info, K_NO_WAIT, -EINVAL},
+		{&set, NULL, K_NO_WAIT, 0},
+		{&set, &info, K_NO_WAIT, 0},
+	};
+
+	block_non_realtime_signals();
+
+	ARRAY_FOR_EACH_PTR(harness, a) {
+		errno = 0;
+		if (a->expected_error == 0) {
+			zassert_ok(k_sig_queue(self, K_SIG_RTMIN, (union k_sig_val){0}));
+			zassert_equal(K_SIG_RTMIN, k_sig_timedwait(a->set, a->info, K_NO_WAIT));
+		} else {
+			zassert_equal(a->expected_error,
+				      k_sig_timedwait(a->set, a->info, a->timeout),
+				      "k_sig_timeout() succeeded, but error %d was expected",
+				      a->expected_error);
+		}
+	}
+
+	/* Without a queued signal, k_sig_timedwait should timeout immediately if timespec == 0.0 */
+	begin_ms = k_uptime_get_32();
+	zassert_equal(-EAGAIN, k_sig_timedwait(&set, NULL, K_NO_WAIT));
+	end_ms = k_uptime_get_32();
+	delta_ms = end_ms - begin_ms;
+	/* hard to say how fast this will execute on every platform, but 50 ms should be safe */
+	zassert_true(delta_ms < 50);
+
+	/* Without a queued signal, k_sig_timedwait should timeout after 100 ms if timeout is 100 ms
+	 */
+	begin_ms = k_uptime_get_32();
+	zassert_equal(-EAGAIN, k_sig_timedwait(&set, NULL, K_MSEC(100)));
+	end_ms = k_uptime_get_32();
+	delta_ms = end_ms - begin_ms;
+	zassert_true(delta_ms >= 100);
+
+	/*
+	 * Queue a signal after 1s. k_sig_timedwait should return successfully after 100 ms
+	 * and before 200 ms if timespec == INFINITY
+	 */
+	begin_ms = k_uptime_get_32();
+	queue_signal_after_ms(k_current_get(), 100);
+	zassert_equal(K_SIG_RTMIN, k_sig_timedwait(&set, NULL, K_SECONDS(42)));
+	end_ms = k_uptime_get_32();
+	delta_ms = end_ms - begin_ms;
+	zassert_true(delta_ms >= 100);
+	zassert_true(delta_ms < 200);
+}
+
+static void *setup(void)
+{
+	k_sig_emptyset(&rt_sigset);
+
+	for (int i = 0; i < K_SIG_NUM_RT; ++i) {
+		k_sig_addset(&rt_sigset, (K_SIG_RTMIN + i));
+	}
+
+	return NULL;
+}
+
+ZTEST_SUITE(signal, NULL, setup, NULL, NULL, NULL);

--- a/tests/kernel/signal/testcase.yaml
+++ b/tests/kernel/signal/testcase.yaml
@@ -1,0 +1,14 @@
+common:
+  tags:
+    - kernel
+  platform_exclude:
+    # undefined reference to `bootutil_key_cnt'
+    - mps2/an521/cpu0/ns
+
+tests:
+  kernel.signal: {}
+  kernel.signal.userspace:
+    filter: CONFIG_ARCH_HAS_USERSPACE
+    tags: userspace
+    extra_configs:
+      - CONFIG_TEST_USERSPACE=y

--- a/tests/posix/common/prj.conf
+++ b/tests/posix/common/prj.conf
@@ -28,3 +28,6 @@ CONFIG_POSIX_PRIORITY_SCHEDULING=y
 # for networking
 CONFIG_NET_TEST=y
 CONFIG_TEST_RANDOM_GENERATOR=y
+
+# sigqueue(), sigtimedwait(), sigwaitinfo()
+CONFIG_POSIX_REALTIME_SIGNALS=y

--- a/tests/posix/common/src/signal.c
+++ b/tests/posix/common/src/signal.c
@@ -16,183 +16,136 @@ ZTEST(signal, test_sigemptyset)
 {
 	sigset_t set;
 
-	for (int i = 0; i < ARRAY_SIZE(set.sig); i++) {
-		set.sig[i] = -1;
-	}
-
+	memset(&set, 0xff, sizeof(set));
 	zassert_ok(sigemptyset(&set));
 
-	for (int i = 0; i < ARRAY_SIZE(set.sig); i++) {
-		zassert_equal(set.sig[i], 0u, "set.sig[%d] is not empty: 0x%lx", i, set.sig[i]);
+	for (int i = 1; i <= SIGRTMAX; ++i) {
+		zassert_false(sigismember(&set, i), "signal %d is part of empty set", i);
 	}
 }
 
 ZTEST(signal, test_sigfillset)
 {
-	sigset_t set = (sigset_t){0};
+	sigset_t set;
 
+	memset(&set, 0x00, sizeof(set));
 	zassert_ok(sigfillset(&set));
 
-	for (int i = 0; i < ARRAY_SIZE(set.sig); i++) {
-		zassert_equal(set.sig[i], -1, "set.sig[%d] is not filled: 0x%lx", i, set.sig[i]);
+	for (int i = 1; i <= SIGRTMAX; ++i) {
+		zassert_true(sigismember(&set, i), "signal %d is not part of filled set", i);
 	}
 }
 
-ZTEST(signal, test_sigaddset_oor)
+static void sigaddset_common(sigset_t *set, int signo)
 {
-	sigset_t set = (sigset_t){0};
-
-	zassert_equal(sigaddset(&set, -1), -1, "rc should be -1");
-	zassert_equal(errno, EINVAL, "errno should be %s", "EINVAL");
-
-	zassert_equal(sigaddset(&set, 0), -1, "rc should be -1");
-	zassert_equal(errno, EINVAL, "errno should be %s", "EINVAL");
-
-	zassert_equal(sigaddset(&set, _NSIG), -1, "rc should be -1");
-	zassert_equal(errno, EINVAL, "errno should be %s", "EINVAL");
+	zassert_ok(sigemptyset(set));
+	zassert_ok(sigaddset(set, signo), "failed to add signal %d", signo);
+	for (int i = 1; i <= SIGRTMAX; ++i) {
+		if (i == signo) {
+			zassert_true(sigismember(set, i), "signal %d should be part of set", i);
+		} else {
+			zassert_false(sigismember(set, i), "signal %d should not be part of set",
+				      i);
+		}
+	}
 }
 
 ZTEST(signal, test_sigaddset)
 {
-	int signo;
-	sigset_t set = (sigset_t){0};
-	sigset_t target = (sigset_t){0};
+	sigset_t set;
 
-	signo = SIGHUP;
-	zassert_ok(sigaddset(&set, signo));
-	WRITE_BIT(target.sig[0], signo, 1);
-	for (int i = 0; i < ARRAY_SIZE(set.sig); i++) {
-		zassert_equal(set.sig[i], target.sig[i],
-			      "set.sig[%d of %d] has content: %lx, expected %lx", i,
-			      ARRAY_SIZE(set.sig) - 1, set.sig[i], target.sig[i]);
+	zassert_ok(sigemptyset(&set));
+
+	{
+		/* Degenerate cases */
+		zassert_equal(sigaddset(&set, -1), -1, "rc should be -1");
+		zassert_equal(errno, EINVAL, "errno should be %s", "EINVAL");
+
+		zassert_equal(sigaddset(&set, 0), -1, "rc should be -1");
+		zassert_equal(errno, EINVAL, "errno should be %s", "EINVAL");
+
+		zassert_equal(sigaddset(&set, CONFIG_SIGNAL_SET_SIZE + 1), -1, "rc should be -1");
+		zassert_equal(errno, EINVAL, "errno should be %s", "EINVAL");
 	}
 
-	signo = SIGSYS;
-	zassert_ok(sigaddset(&set, signo));
-	WRITE_BIT(target.sig[0], signo, 1);
-	for (int i = 0; i < ARRAY_SIZE(set.sig); i++) {
-		zassert_equal(set.sig[i], target.sig[i],
-			      "set.sig[%d of %d] has content: %lx, expected %lx", i,
-			      ARRAY_SIZE(set.sig) - 1, set.sig[i], target.sig[i]);
-	}
-
-	signo = SIGRTMIN; /* >=32, will be in the second sig set for 32bit */
-	zassert_ok(sigaddset(&set, signo));
-#ifdef CONFIG_64BIT
-	WRITE_BIT(target.sig[0], signo, 1);
-#else /* 32BIT */
-	WRITE_BIT(target.sig[1], (signo)-BITS_PER_LONG, 1);
-#endif
-	for (int i = 0; i < ARRAY_SIZE(set.sig); i++) {
-		zassert_equal(set.sig[i], target.sig[i],
-			      "set.sig[%d of %d] has content: %lx, expected %lx", i,
-			      ARRAY_SIZE(set.sig) - 1, set.sig[i], target.sig[i]);
-	}
-
-	signo = SIGRTMAX;
-	zassert_ok(sigaddset(&set, signo));
-	WRITE_BIT(target.sig[signo / BITS_PER_LONG], signo % BITS_PER_LONG, 1);
-	for (int i = 0; i < ARRAY_SIZE(set.sig); i++) {
-		zassert_equal(set.sig[i], target.sig[i],
-			      "set.sig[%d of %d] has content: %lx, expected %lx", i,
-			      ARRAY_SIZE(set.sig) - 1, set.sig[i], target.sig[i]);
-	}
+	sigaddset_common(&set, SIGHUP);
+	sigaddset_common(&set, SIGSYS);
+	/* >=32, will be in the second sig set for 32bit */
+	sigaddset_common(&set, SIGRTMIN);
+	sigaddset_common(&set, SIGRTMAX);
 }
 
-ZTEST(signal, test_sigdelset_oor)
+static void sigdelset_common(sigset_t *set, int signo)
 {
-	sigset_t set = (sigset_t){0};
-
-	zassert_equal(sigdelset(&set, -1), -1, "rc should be -1");
-	zassert_equal(errno, EINVAL, "errno should be %s", "EINVAL");
-
-	zassert_equal(sigdelset(&set, 0), -1, "rc should be -1");
-	zassert_equal(errno, EINVAL, "errno should be %s", "EINVAL");
-
-	zassert_equal(sigdelset(&set, _NSIG), -1, "rc should be -1");
-	zassert_equal(errno, EINVAL, "errno should be %s", "EINVAL");
+	zassert_ok(sigfillset(set));
+	zassert_ok(sigdelset(set, signo));
+	for (int i = 1; i <= SIGRTMAX; ++i) {
+		if (i == signo) {
+			zassert_false(sigismember(set, i), "signal %d should not be part of set",
+				      i);
+		} else {
+			zassert_true(sigismember(set, i), "signal %d should be part of set", i);
+		}
+	}
 }
 
 ZTEST(signal, test_sigdelset)
 {
-	int signo;
-	sigset_t set = (sigset_t){0};
-	sigset_t target = (sigset_t){0};
+	sigset_t set;
 
-	signo = SIGHUP;
-	zassert_ok(sigdelset(&set, signo));
-	WRITE_BIT(target.sig[0], signo, 0);
-	for (int i = 0; i < ARRAY_SIZE(set.sig); i++) {
-		zassert_equal(set.sig[i], target.sig[i],
-			      "set.sig[%d of %d] has content: %lx, expected %lx", i,
-			      ARRAY_SIZE(set.sig) - 1, set.sig[i], target.sig[i]);
+	zassert_ok(sigemptyset(&set));
+
+	{
+		/* Degenerate cases */
+		zassert_equal(sigdelset(&set, -1), -1, "rc should be -1");
+		zassert_equal(errno, EINVAL, "errno should be %s", "EINVAL");
+
+		zassert_equal(sigdelset(&set, 0), -1, "rc should be -1");
+		zassert_equal(errno, EINVAL, "errno should be %s", "EINVAL");
+
+		zassert_equal(sigdelset(&set, CONFIG_SIGNAL_SET_SIZE + 1), -1, "rc should be -1");
+		zassert_equal(errno, EINVAL, "errno should be %s", "EINVAL");
 	}
 
-	signo = SIGSYS;
-	zassert_ok(sigdelset(&set, signo));
-	WRITE_BIT(target.sig[0], signo, 0);
-	for (int i = 0; i < ARRAY_SIZE(set.sig); i++) {
-		zassert_equal(set.sig[i], target.sig[i],
-			      "set.sig[%d of %d] has content: %lx, expected %lx", i,
-			      ARRAY_SIZE(set.sig) - 1, set.sig[i], target.sig[i]);
-	}
-
-	signo = SIGRTMIN; /* >=32, will be in the second sig set for 32bit */
-	zassert_ok(sigdelset(&set, signo));
-#ifdef CONFIG_64BIT
-	WRITE_BIT(target.sig[0], signo, 0);
-#else /* 32BIT */
-	WRITE_BIT(target.sig[1], (signo)-BITS_PER_LONG, 0);
-#endif
-	for (int i = 0; i < ARRAY_SIZE(set.sig); i++) {
-		zassert_equal(set.sig[i], target.sig[i],
-			      "set.sig[%d of %d] has content: %lx, expected %lx", i,
-			      ARRAY_SIZE(set.sig) - 1, set.sig[i], target.sig[i]);
-	}
-
-	signo = SIGRTMAX;
-	zassert_ok(sigdelset(&set, signo));
-	WRITE_BIT(target.sig[signo / BITS_PER_LONG], signo % BITS_PER_LONG, 0);
-	for (int i = 0; i < ARRAY_SIZE(set.sig); i++) {
-		zassert_equal(set.sig[i], target.sig[i],
-			      "set.sig[%d of %d] has content: %lx, expected %lx", i,
-			      ARRAY_SIZE(set.sig) - 1, set.sig[i], target.sig[i]);
-	}
-}
-
-ZTEST(signal, test_sigismember_oor)
-{
-	sigset_t set = {0};
-
-	zassert_equal(sigismember(&set, -1), -1, "rc should be -1");
-	zassert_equal(errno, EINVAL, "errno should be %s", "EINVAL");
-
-	zassert_equal(sigismember(&set, 0), -1, "rc should be -1");
-	zassert_equal(errno, EINVAL, "errno should be %s", "EINVAL");
-
-	zassert_equal(sigismember(&set, _NSIG), -1, "rc should be -1");
-	zassert_equal(errno, EINVAL, "errno should be %s", "EINVAL");
+	sigdelset_common(&set, SIGHUP);
+	sigdelset_common(&set, SIGSYS);
+	/* >=32, will be in the second sig set for 32bit */
+	sigdelset_common(&set, SIGRTMIN);
+	sigdelset_common(&set, SIGRTMAX);
 }
 
 ZTEST(signal, test_sigismember)
 {
-	sigset_t set = (sigset_t){0};
+	sigset_t set;
 
-#ifdef CONFIG_64BIT
-	set.sig[0] = BIT(SIGHUP) | BIT(SIGSYS) | BIT(SIGRTMIN);
-#else /* 32BIT */
-	set.sig[0] = BIT(SIGHUP) | BIT(SIGSYS);
-	set.sig[1] = BIT((SIGRTMIN)-BITS_PER_LONG);
-#endif
-	WRITE_BIT(set.sig[SIGRTMAX / BITS_PER_LONG], SIGRTMAX % BITS_PER_LONG, 1);
+	zassert_ok(sigemptyset(&set));
 
-	zassert_equal(sigismember(&set, SIGHUP), 1, "%s expected to be member", "SIGHUP");
-	zassert_equal(sigismember(&set, SIGSYS), 1, "%s expected to be member", "SIGSYS");
-	zassert_equal(sigismember(&set, SIGRTMIN), 1, "%s expected to be member", "SIGRTMIN");
-	zassert_equal(sigismember(&set, SIGRTMAX), 1, "%s expected to be member", "SIGRTMAX");
+	{
+		/* Degenerate cases */
+		zassert_equal(sigismember(&set, -1), -1, "rc should be -1");
+		zassert_equal(errno, EINVAL, "errno should be %s", "EINVAL");
 
+		zassert_equal(sigismember(&set, 0), -1, "rc should be -1");
+		zassert_equal(errno, EINVAL, "errno should be %s", "EINVAL");
+
+		zassert_equal(sigismember(&set, SIGRTMAX + 1), -1, "rc should be -1");
+		zassert_equal(errno, EINVAL, "errno should be %s", "EINVAL");
+	}
+
+	for (int i = 0; i < RTSIG_MAX; ++i) {
+		zassert_equal(0, sigismember(&set, (SIGRTMIN + i)),
+			      "signal %d should not be part of set", (SIGRTMIN + i));
+	}
+
+	zassert_ok(sigfillset(&set));
+
+	for (int i = 0; i < RTSIG_MAX; ++i) {
+		zassert_equal(1, sigismember(&set, (SIGRTMIN + i)),
+			      "signal %d should be part of set", (SIGRTMIN + i));
+	}
+
+	zassert_ok(sigdelset(&set, SIGKILL));
 	zassert_equal(sigismember(&set, SIGKILL), 0, "%s not expected to be member", "SIGKILL");
-	zassert_equal(sigismember(&set, SIGTERM), 0, "%s not expected to be member", "SIGTERM");
 }
 
 ZTEST(signal, test_signal_strsignal)
@@ -202,7 +155,7 @@ ZTEST(signal, test_signal_strsignal)
 
 	zassert_mem_equal(strsignal(-1), "Invalid signal", sizeof("Invalid signal"));
 	zassert_mem_equal(strsignal(0), "Invalid signal", sizeof("Invalid signal"));
-	zassert_mem_equal(strsignal(_NSIG), "Invalid signal", sizeof("Invalid signal"));
+	zassert_mem_equal(strsignal(SIGRTMAX + 1), "Invalid signal", sizeof("Invalid signal"));
 
 	zassert_mem_equal(strsignal(30), "Signal 30", sizeof("Signal 30"));
 	snprintf(buf, sizeof(buf), "RT signal %d", SIGRTMIN - SIGRTMIN);
@@ -232,6 +185,9 @@ static void *test_sigmask_entry(void *arg)
 	static sigset_t set[2];
 	const int invalid_how = 0x9a2ba9e;
 	sigmask_fn sigmask = arg;
+
+	sigemptyset(&set[0]);
+	sigemptyset(&set[1]);
 
 	/* invalid how results in EINVAL */
 	zassert_equal(sigmask(invalid_how, NULL, NULL), EINVAL);
@@ -318,6 +274,290 @@ ZTEST(signal, test_sigprocmask)
 		zassert_ok(pthread_create(&th, NULL, test_sigmask_entry, sigprocmask));
 		zassert_ok(pthread_join(th, NULL));
 	}
+}
+
+static void realtime_sigset(sigset_t *set)
+{
+	sigemptyset(set);
+	for (int i = 0; i < RTSIG_MAX; ++i) {
+		sigaddset(set, (SIGRTMIN + i));
+	}
+}
+
+static void block_non_realtime_signals(void)
+{
+	/*
+	 * Normal signals are not yet a thing in Zephyr. Specifically, they behave just like
+	 * realtime signals (which is not POSIX conformant). More specifically, normal signals are
+	 * not delivered asynchronously. To keep this test mostly compliant though, we block normal
+	 * signals and only consider realtime signals.
+	 */
+
+	sigset_t set;
+
+	sigfillset(&set);
+	for (int i = 0; i < RTSIG_MAX; ++i) {
+		sigdelset(&set, (SIGRTMIN + i));
+	}
+
+	zassert_ok(pthread_sigmask(SIG_BLOCK, &set, NULL));
+}
+
+/*
+ * This is a workaround for the fact that Zephyr threads and POSIX threads are not yet fully
+ * interchangeable. I.e. the "is a" relationship is not bidirectional. A POSIX thread is a
+ * Zephyr thread, but a Zephyr thread is not a POSIX thread. The most obvious tell is
+ * that pthread_self() only returns a valid pthread_t for POSIX threads; invalid pthread_t
+ * cannot be used successfully in subsequent pthread operations.
+ *
+ * Note: Zephyr threads can still use k_sig_queue() directly.
+ */
+static void *test_sigqueue_thread(void *arg)
+{
+	sigset_t set;
+	siginfo_t info;
+	struct timespec timeout = {0};
+
+	ARG_UNUSED(arg);
+
+	block_non_realtime_signals();
+	realtime_sigset(&set);
+
+	/*
+	 * Test for multiple real-time signals of the same type being returned in the order
+	 * they were queued.
+	 *
+	 * Note: Normally, sigtimedwait() would only populate the siginfo_t argument if a SA_SIGINFO
+	 * flag provided by sigaction(), but that is part of POSIX_SIGNALS Option Group
+	 * (unimplemented) and sigqueue(), sigtimedwait(), sigwaitinfo() are part of the
+	 * POSIX_REALTIME_SIGNALS Option Group.
+	 *
+	 * Currently, we sigwaitinfo(), sigtimedwait(), assume that the siginfo_t argument should be
+	 * populated if it is non-NULL.
+	 */
+	for (int i = 0; i < SIGQUEUE_MAX; ++i) {
+		zassert_ok(
+			sigqueue((pid_t)pthread_self(), SIGRTMIN, (union sigval){.sival_int = i}),
+			"failed to que the %d-th signal", i);
+	}
+
+	for (int i = 0; i < SIGQUEUE_MAX; ++i) {
+		int actual;
+
+		info = (siginfo_t){0};
+		actual = sigtimedwait(&set, &info, &timeout);
+
+		zassert_equal(SIGRTMIN, actual,
+			      "iteration %d expected SIGRTMIN (%d) but sigtimedwait() returned %d "
+			      "(errno: %d)",
+			      i, SIGRTMIN, actual, errno);
+		zassert_equal(info.si_value.sival_int, i);
+	}
+
+	/*
+	 * test for different real-time signals being delivered lowest-numbered first
+	 */
+	for (int i = RTSIG_MAX - 1; i >= 0; --i) {
+		zassert_ok(sigqueue((pid_t)pthread_self(), (SIGRTMIN + i), (union sigval){0}),
+			   "unable to queue signal %d", (SIGRTMIN + i));
+	}
+
+	for (int i = 0; i < RTSIG_MAX; ++i) {
+		int actual = sigtimedwait(&set, NULL, &timeout);
+
+		zassert_equal((SIGRTMIN + i), actual,
+			      "expected signal %d, but sigtimedwait() returned %d", (SIGRTMIN + i),
+			      actual);
+	}
+
+	return NULL;
+}
+
+ZTEST(signal, test_sigqueue)
+{
+	pthread_t th;
+
+	{
+		/* Degenerate cases */
+		zassert_not_ok(sigqueue(-1, -1, (union sigval){0}));
+		zassert_not_ok(sigqueue(-1, SIGUSR1, (union sigval){0}));
+		zassert_not_ok(sigqueue((pid_t)pthread_self(), -1, (union sigval){0}));
+	}
+
+	zassert_ok(pthread_create(&th, NULL, test_sigqueue_thread, NULL));
+	zassert_ok(pthread_join(th, NULL));
+}
+
+static void *sleep_100ms_and_queue(void *arg)
+{
+	k_msleep(100);
+	zassert_ok(sigqueue(POINTER_TO_INT(arg), SIGRTMIN, (union sigval){0}));
+
+	return NULL;
+}
+
+static void queue_signal_after_100ms(pthread_t th)
+{
+	pthread_t t1;
+
+	zassert_ok(pthread_create(&t1, NULL, sleep_100ms_and_queue, INT_TO_POINTER(th)));
+	zassert_ok(pthread_join(t1, NULL));
+}
+
+/*
+ * This is a workaround for the fact that Zephyr threads and POSIX threads are not yet fully
+ * interchangeable. I.e. the "is a" relationship is not bidirectional. A POSIX thread is a
+ * Zephyr thread, but a Zephyr thread is not a POSIX thread. The most obvious tell is
+ * that pthread_self() only returns a valid pthread_t for POSIX threads; invalid pthread_t
+ * cannot be used successfully in subsequent pthread operations.
+ *
+ * Note: Zephyr threads can still use k_sig_timedwait() directly.
+ */
+static void *test_sigtimedwait_thread(void *arg)
+{
+	sigset_t set;
+	siginfo_t info;
+	pid_t self = (pid_t)pthread_self();
+	uint32_t begin_ms, delta_ms, end_ms;
+	struct timespec timeout = {0};
+
+	ARG_UNUSED(arg);
+
+	block_non_realtime_signals();
+	realtime_sigset(&set);
+
+	const struct stw_args_exp {
+		const sigset_t *set;
+		siginfo_t *info;
+		struct timespec *timeout;
+		int expected_errno;
+	} harness[] = {
+		{NULL, NULL, NULL, EINVAL},
+		{NULL, NULL, &timeout, EINVAL},
+		{NULL, &info, NULL, EINVAL},
+		{NULL, &info, &timeout, EINVAL},
+		{&set, NULL, NULL, 0},
+		{&set, NULL, &timeout, 0},
+		{&set, &info, NULL, 0},
+		{&set, &info, &timeout, 0},
+	};
+
+	ARRAY_FOR_EACH_PTR(harness, a) {
+		errno = 0;
+		if (a->expected_errno == 0) {
+			zassert_ok(sigqueue(self, SIGRTMIN, (union sigval){0}));
+			zassert_equal(SIGRTMIN, sigtimedwait(a->set, a->info, a->timeout));
+			zassert_equal(errno, 0);
+		} else {
+			zassert_equal(-1, sigtimedwait(a->set, a->info, a->timeout));
+			zassert_equal(errno, a->expected_errno);
+		}
+	}
+
+	/* Without a queued signal, sigtimedwait should timeout immediately if timespec == 0.0 */
+	begin_ms = k_uptime_get_32();
+	zassert_equal(-1, sigtimedwait(&set, NULL, &timeout));
+	zassert_equal(errno, EAGAIN);
+	end_ms = k_uptime_get_32();
+	delta_ms = end_ms - begin_ms;
+	/* hard to say how fast this will execute on every platform, but this should be safe */
+	zassert_true(delta_ms < 50);
+
+	/* Without a queued signal, sigtimedwait should timeout after 1s if timespec == 1.0 */
+	timeout.tv_sec = 1;
+	begin_ms = k_uptime_get_32();
+	zassert_equal(-1, sigtimedwait(&set, NULL, &timeout));
+	zassert_equal(errno, EAGAIN);
+	end_ms = k_uptime_get_32();
+	delta_ms = end_ms - begin_ms;
+	zassert_true(delta_ms >= MSEC_PER_SEC);
+
+	/*
+	 * Queue a signal after 100 ms. sigtimedwait should return successfully after 100 ms
+	 * and before 200 ms if timespec == INFINITY
+	 */
+	timeout.tv_sec = 42; /* basically infinity ¯\_(ツ)_/¯ */
+	begin_ms = k_uptime_get_32();
+	queue_signal_after_100ms(pthread_self());
+	zassert_equal(SIGRTMIN, sigtimedwait(&set, NULL, &timeout));
+	end_ms = k_uptime_get_32();
+	delta_ms = end_ms - begin_ms;
+	zassert_true(delta_ms >= 100);
+	zassert_true(delta_ms < 200);
+
+	return NULL;
+}
+
+ZTEST(signal, test_sigtimedwait)
+{
+	pthread_t t1;
+
+	zassert_ok(pthread_create(&t1, NULL, test_sigtimedwait_thread, NULL));
+	zassert_ok(pthread_join(t1, NULL));
+}
+
+/*
+ * This is a workaround for the fact that Zephyr threads and POSIX threads are not yet fully
+ * interchangeable. I.e. the "is a" relationship is not bidirectional. A POSIX thread is a
+ * Zephyr thread, but a Zephyr thread is not a POSIX thread. The most obvious tell is
+ * that pthread_self() only returns a valid pthread_t for POSIX threads; invalid pthread_t
+ * cannot be used successfully in subsequent pthread operations.
+ */
+static void *test_sigwaitinfo_thread(void *arg)
+{
+	sigset_t set;
+	siginfo_t info;
+	uint32_t begin_ms, delta_ms, end_ms;
+
+	ARG_UNUSED(arg);
+
+	block_non_realtime_signals();
+	realtime_sigset(&set);
+
+	const struct swi_args_exp {
+		const sigset_t *set;
+		siginfo_t *info;
+		int expected_errno;
+	} harness[] = {
+		{NULL, NULL, EINVAL},
+		{NULL, &info, EINVAL},
+		{&set, NULL, 0},
+		{&set, &info, 0},
+	};
+
+	ARRAY_FOR_EACH_PTR(harness, a) {
+		errno = 0;
+		if (a->expected_errno == 0) {
+			zassert_ok(sigqueue((pid_t)pthread_self(), SIGRTMIN, (union sigval){0}));
+			zassert_equal(SIGRTMIN, sigwaitinfo(a->set, a->info));
+			zassert_equal(errno, 0);
+		} else {
+			zassert_equal(-1, sigwaitinfo(a->set, a->info));
+			zassert_equal(errno, a->expected_errno);
+		}
+	}
+
+	/*
+	 * Queue a signal after 100 ms. sigwaitinfo should return successfully after 100 ms and
+	 * before 200 ms
+	 */
+	begin_ms = k_uptime_get_32();
+	queue_signal_after_100ms(pthread_self());
+	zassert_equal(SIGRTMIN, sigwaitinfo(&set, NULL));
+	end_ms = k_uptime_get_32();
+	delta_ms = end_ms - begin_ms;
+	zassert_true(delta_ms >= 100);
+	zassert_true(delta_ms < 200);
+
+	return NULL;
+}
+
+ZTEST(signal, test_sigwaitinfo)
+{
+	pthread_t t1;
+
+	zassert_ok(pthread_create(&t1, NULL, test_sigwaitinfo_thread, NULL));
+	zassert_ok(pthread_join(t1, NULL));
 }
 
 static void before(void *arg)

--- a/tests/posix/common/testcase.yaml
+++ b/tests/posix/common/testcase.yaml
@@ -61,7 +61,7 @@ tests:
       - CONFIG_POSIX_SIGNAL_STRING_DESC=n
   portability.posix.common.signal.big_nsig:
     extra_configs:
-      - CONFIG_POSIX_RTSIG_MAX=1024
+      - CONFIG_SIGNAL_SET_SIZE=1024
   portability.posix.common.dynamic_stack:
     extra_configs:
       - CONFIG_DYNAMIC_THREAD=y

--- a/tests/posix/common/testcase.yaml
+++ b/tests/posix/common/testcase.yaml
@@ -61,7 +61,11 @@ tests:
       - CONFIG_POSIX_SIGNAL_STRING_DESC=n
   portability.posix.common.signal.big_nsig:
     extra_configs:
-      - CONFIG_SIGNAL_SET_SIZE=1024
+      # The signal set size is intentionally limited according to the max signal queue size
+      # This effectively fixes RTSIG_MAX to 256, so we can queue all realtime signals.
+      - CONFIG_SIGNAL_SET_SIZE=288
+      # implementation max signal queue size
+      - CONFIG_SIGNAL_QUEUE_SIZE=256
   portability.posix.common.dynamic_stack:
     extra_configs:
       - CONFIG_DYNAMIC_THREAD=y

--- a/tests/posix/headers/src/signal_h.c
+++ b/tests/posix/headers/src/signal_h.c
@@ -72,15 +72,15 @@ ZTEST(posix_headers, test_signal_h)
 	/* zassert_not_equal(-1, offsetof(stack_t, ss_size)); */ /* not implemented */
 	/* zassert_not_equal(-1, offsetof(stack_t, ss_flags)); */ /* not implemented */
 
-	/* zassert_not_equal(-1, offsetof(siginfo_t, si_signo)); */ /* not implemented */
-	/* zassert_not_equal(-1, offsetof(siginfo_t, si_code)); */ /* not implemented */
+	zassert_not_equal(-1, offsetof(siginfo_t, si_signo));
+	zassert_not_equal(-1, offsetof(siginfo_t, si_code));
 	/* zassert_not_equal(-1, offsetof(siginfo_t, si_errno)); */ /* not implemented */
 	/* zassert_not_equal(-1, offsetof(siginfo_t, si_pid)); */ /* not implemented */
 	/* zassert_not_equal(-1, offsetof(siginfo_t, si_uid)); */ /* not implemented */
 	/* zassert_not_equal(-1, offsetof(siginfo_t, si_addr)); */ /* not implemented */
 	/* zassert_not_equal(-1, offsetof(siginfo_t, si_status)); */ /* not implemented */
 	/* zassert_not_equal(-1, offsetof(siginfo_t, si_band)); */ /* not implemented */
-	/* zassert_not_equal(-1, offsetof(siginfo_t, si_value)); */ /* not implemented */
+	zassert_not_equal(-1, offsetof(siginfo_t, si_value));
 
 	/* zassert_not_equal(-1, ILL_ILLOPC); */ /* not implemented */
 	/* zassert_not_equal(-1, ILL_ILLOPN); */ /* not implemented */
@@ -168,6 +168,12 @@ ZTEST(posix_headers, test_signal_h)
 	zassert_not_null(pthread_sigmask);
 #endif /* CONFIG_POSIX_SIGNALS */
 
+#ifdef CONFIG_POSIX_REALTIME_SIGNALS
+	zassert_not_null(sigqueue);
+	zassert_not_null(sigtimedwait);
+	zassert_not_null(sigwaitinfo);
+#endif
+
 	if (IS_ENABLED(CONFIG_POSIX_API)) {
 		/* zassert_not_null(kill); */ /* not implemented */
 		/* zassert_not_null(killpg); */ /* not implemented */
@@ -183,12 +189,9 @@ ZTEST(posix_headers, test_signal_h)
 		/* zassert_not_null(signal); */ /* not implemented */
 		/* zassert_not_null(sigpause); */ /* not implemented */
 		/* zassert_not_null(sigpending); */ /* not implemented */
-		/* zassert_not_null(sigqueue); */ /* not implemented */
 		/* zassert_not_null(sigrelse); */ /* not implemented */
 		/* zassert_not_null(sigset); */ /* not implemented */
 		/* zassert_not_null(sigsuspend); */ /* not implemented */
-		/* zassert_not_null(sigtimedwait); */ /* not implemented */
 		/* zassert_not_null(sigwait); */ /* not implemented */
-		/* zassert_not_null(sigwaitinfo); */ /* not implemented */
 	}
 }

--- a/tests/posix/headers/src/signal_h.c
+++ b/tests/posix/headers/src/signal_h.c
@@ -168,6 +168,10 @@ ZTEST(posix_headers, test_signal_h)
 	zassert_not_null(pthread_sigmask);
 #endif /* CONFIG_POSIX_SIGNALS */
 
+#ifdef CONFIG_POSIX_THREADS
+	zassert_not_null(pthread_kill);
+#endif
+
 #ifdef CONFIG_POSIX_REALTIME_SIGNALS
 	zassert_not_null(sigqueue);
 	zassert_not_null(sigtimedwait);
@@ -179,7 +183,6 @@ ZTEST(posix_headers, test_signal_h)
 		/* zassert_not_null(killpg); */ /* not implemented */
 		/* zassert_not_null(psiginfo); */ /* not implemented */
 		/* zassert_not_null(psignal); */ /* not implemented */
-		/* zassert_not_null(pthread_kill); */ /* not implemented */
 		/* zassert_not_null(raise); */ /* not implemented */
 		/* zassert_not_null(sigaction); */ /* not implemented */
 		/* zassert_not_null(sigaltstack); */ /* not implemented */


### PR DESCRIPTION
This was required for practicality
* ring_buffer: support static rings

These add support to the kernel
* kernel: initial support for signals
* tests: kernel: add tests for `k_sigqueue()` and `k_sigtimedwait()`
* doc: kernel: services: add a doc about signals

These complete the `POSIX_REALTIME_SIGNALS` Option Group (and `_POSIX_REALTIME_SIGNALS` Option)
* posix: add realtime signal support
* tests: posix: common: add tests for realtime signals
* doc: posix: mark realtime signals as supported 🎉

These add `pthread_kill()` to (finally) complete the `POSIX_THREADS_BASE` Option Group and `_POSIX_THREADS` Option
* posix: threads: implement `pthread_kill()`
* tests: posix: headers: test for `pthread_kill()`
* doc: posix: mark posix threads as supported 🎉

[Kernel Doc Preview](https://builds.zephyrproject.io/zephyr/pr/74918/docs/kernel/services/signals.html)
[POSIX Doc Preview](https://builds.zephyrproject.io/zephyr/pr/74918/docs/services/portability/posix/index.html)

Fixes #59943
Fixes #74993
Fixes #74994
Fixes #74995