### PR TITLE
Bluetooth: Classic: HF_AG: Fix unexpected return

### DIFF
--- a/subsys/bluetooth/host/classic/hfp_ag.c
+++ b/subsys/bluetooth/host/classic/hfp_ag.c
@@ -473,7 +473,7 @@ static int bt_hfp_ag_bac_handler(struct bt_hfp_ag *ag, struct net_buf *buf)
 	}
 	hfp_ag_unlock(ag);
 
-	while (err == 0) {
+	while (buf->len > 0) {
 		err = get_number(buf, &codec);
 		if (err != 0) {
 			return -ENOTSUP;


### PR DESCRIPTION
When `buf->len` is 0, the function of the while-loop will be returned with error code `-ENOTSUP`.
The code block after while-loop cannot be reached
event though it is a correct command.

Use `buf->len` as the end condition of the while-loop.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/74730