### PR TITLE
Bluetooth: Classic: HF_AG: Fix incorrect status judgment

### DIFF
--- a/subsys/bluetooth/host/classic/hfp_ag.c
+++ b/subsys/bluetooth/host/classic/hfp_ag.c
@@ -2241,7 +2241,7 @@ int bt_hfp_ag_remote_terminate(struct bt_hfp_ag *ag)
 		return -ENOTCONN;
 	}
 
-	if ((ag->call_state != BT_HFP_CALL_ACTIVE) || (ag->call_state != BT_HFP_CALL_HOLD)) {
+	if ((ag->call_state != BT_HFP_CALL_ACTIVE) && (ag->call_state != BT_HFP_CALL_HOLD)) {
 		hfp_ag_unlock(ag);
 		return -EINVAL;
 	}


### PR DESCRIPTION
Wrong condition of AG status is used for status checking.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/74726