### PR TITLE
arch: x86: corrected parameter names

### DIFF
--- a/arch/x86/core/intel64/irq.c
+++ b/arch/x86/core/intel64/irq.c
@@ -100,8 +100,8 @@ void z_x86_irq_connect_on_vector(unsigned int irq,
  */
 
 int arch_irq_connect_dynamic(unsigned int irq, unsigned int priority,
-			     void (*func)(const void *arg),
-			     const void *arg, uint32_t flags)
+			     void (*routine)(const void *parameter),
+			     const void *parameter, uint32_t flags)
 {
 	uint32_t key;
 	int vector;
@@ -124,7 +124,7 @@ int arch_irq_connect_dynamic(unsigned int irq, unsigned int priority,
 #endif /* CONFIG_INTEL_VTD_ICTL */
 
 		z_irq_controller_irq_config(vector, irq, flags);
-		z_x86_irq_connect_on_vector(irq, vector, func, arg);
+		z_x86_irq_connect_on_vector(irq, vector, routine, parameter);
 	}
 
 	irq_unlock(key);

--- a/include/zephyr/arch/x86/arch.h
+++ b/include/zephyr/arch/x86/arch.h
@@ -216,7 +216,7 @@ static ALWAYS_INLINE int sys_test_and_clear_bit(mem_addr_t addr,
  * at build time and defined via the linker script. On Intel64, it's an array.
  */
 
-extern unsigned char _irq_to_interrupt_vector[];
+extern unsigned char _irq_to_interrupt_vector[CONFIG_MAX_IRQ_LINES];
 
 #define Z_IRQ_TO_INTERRUPT_VECTOR(irq) \
 	((unsigned int) _irq_to_interrupt_vector[irq])


### PR DESCRIPTION
Applied the exact parameter names of the interface to the implementations

This corresponds to following coding guideline:

> All declarations of an object or function shall use the same names and type qualifiers.

This PR is part of the enhancement issue https://github.com/zephyrproject-rtos/zephyr/issues/48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
https://github.com/zephyrproject-rtos/zephyr/commit/bdc5f2c7da9b13e042e8ec729f67ccc54e10195a