### PR TITLE
doc: usb: add missing macro documentation, fix sample references, add note about planned deprecation

### DIFF
--- a/doc/connectivity/usb/device/api/usb_dc.rst
+++ b/doc/connectivity/usb/device/api/usb_dc.rst
@@ -8,7 +8,7 @@ The USB device controller driver API is described in
 as the ``usb_dc`` API.
 
 This API has some limitations by design, it does not follow :ref:`device_model_api`
-and is being replaced by a new UDC driver API.
+and is being replaced by :ref:`udc_api`.
 
 API reference
 *************

--- a/doc/connectivity/usb/device/usb_device.rst
+++ b/doc/connectivity/usb/device/usb_device.rst
@@ -25,11 +25,11 @@ over time. It provides the following functionalities:
   customer applications. The APIs is described in
   :zephyr_file:`include/zephyr/usb/usb_device.h`
 
-The device stack and :ref:`usb_dc_api` have some limitations, such as not being
-able to support more than one controller instance at runtime and only supporting
-one USB device configuration. We are actively working on new USB support, which
-means we will continue to maintain the device stack described here until all
-supported USB classes are ported, but do not expect any new features or enhancements.
+.. note::
+   It is planned to deprecate all APIs listed in :ref:`usb_api` and the
+   functions that depend on them between Zephyr v3.7.0 and v4.0.0, and remove
+   them in v4.2.0. The new USB device support, represented by the APIs in
+   :ref:`usb_device_next_api`, will become the default in Zephyr v4.0.0.
 
 Supported USB classes
 *********************

--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -388,6 +388,26 @@ static inline void *usbd_class_get_private(const struct usbd_class_data *const c
 	return c_data->priv;
 }
 
+/**
+ * @brief Define USB device context structure
+ *
+ * Macro defines a USB device structure needed by the stack to manage its
+ * properties and runtime data. The @p vid and @p pid  parameters can also be
+ * changed using usbd_device_set_vid() and usbd_device_set_pid().
+ *
+ * Example of use:
+ *
+ * @code{.c}
+ * USBD_DEVICE_DEFINE(sample_usbd,
+ *                    DEVICE_DT_GET(DT_NODELABEL(zephyr_udc0)),
+ *                    YOUR_VID, YOUR_PID);
+ * @endcode
+ *
+ * @param device_name USB device context name
+ * @param udc_dev     Pointer to UDC device structure
+ * @param vid         Vendor ID
+ * @param pid         Product ID
+ */
 #define USBD_DEVICE_DEFINE(device_name, udc_dev, vid, pid)		\
 	static struct usb_device_descriptor				\
 	fs_desc_##device_name = {					\
@@ -430,6 +450,20 @@ static inline void *usbd_class_get_private(const struct usbd_class_data *const c
 		.hs_desc = &hs_desc_##device_name,			\
 	}
 
+/**
+ * @brief Define USB device configuration
+ *
+ * USB device requires at least one configuration instance per supported speed.
+ * @p attrib is a combination of `USB_SCD_SELF_POWERED` or `USB_SCD_REMOTE_WAKEUP`,
+ * depending on which characteristic the USB device should have in this
+ * configuration.
+ *
+ * @param name   Configuration name
+ * @param attrib Configuration characteristics. Attributes can also be updated
+ *               with usbd_config_attrib_rwup() and usbd_config_attrib_self()
+ * @param power  bMaxPower value in 2 mA units. This value can also be set with
+ *               usbd_config_maxpower()
+ */
 #define USBD_CONFIGURATION_DEFINE(name, attrib, power)			\
 	static struct usb_cfg_descriptor				\
 	cfg_desc_##name = {						\
@@ -563,6 +597,17 @@ static inline void *usbd_class_get_private(const struct usbd_class_data *const c
 		.bDescriptorType = USB_DESC_BOS,				\
 	}
 
+/**
+ * @brief Define USB device support class data
+ *
+ * Macro defines class (function) data, as well as corresponding node
+ * structures used internally by the stack.
+ *
+ * @param class_name   Class name
+ * @param class_api    Pointer to struct usbd_class_api
+ * @param class_priv   Class private data
+ * @param class_v_reqs Pointer to struct usbd_cctx_vendor_req
+ */
 #define USBD_DEFINE_CLASS(class_name, class_api, class_priv, class_v_reqs)	\
 	static struct usbd_class_data class_name = {				\
 		.name = STRINGIFY(class_name),					\

--- a/samples/subsys/usb/cdc_acm/README.rst
+++ b/samples/subsys/usb/cdc_acm/README.rst
@@ -1,6 +1,6 @@
 .. zephyr:code-sample:: usb-cdc-acm
    :name: USB CDC-ACM
-   :relevant-api: usbd_api _usb_device_core_api
+   :relevant-api: usbd_api _usb_device_core_api uart_interface
 
    Use USB CDC-ACM driver to implement a serial port echo.
 

--- a/samples/subsys/usb/cdc_acm_composite/README.rst
+++ b/samples/subsys/usb/cdc_acm_composite/README.rst
@@ -1,6 +1,6 @@
 .. zephyr:code-sample:: usb-cdc-acm-composite
    :name: USB CDC-ACM composite
-   :relevant-api: usbd_api
+   :relevant-api: _usb_device_core_api
 
    Implement a composite USB device exposing two serial ports using USB CDC-ACM driver.
 

--- a/samples/subsys/usb/console/README.rst
+++ b/samples/subsys/usb/console/README.rst
@@ -1,6 +1,6 @@
 .. zephyr:code-sample:: usb-cdc-acm-console
    :name: Console over USB CDC ACM
-   :relevant-api: _usb_device_core_api usbd_api uart_interface
+   :relevant-api: _usb_device_core_api usbd_api
 
    Output "Hello World!" to the console over USB CDC ACM.
 

--- a/samples/subsys/usb/dfu/README.rst
+++ b/samples/subsys/usb/dfu/README.rst
@@ -1,6 +1,6 @@
 .. zephyr:code-sample:: usb-dfu
    :name: USB DFU (Device Firmware Upgrade)
-   :relevant-api: usbd_api _usb_device_core_api
+   :relevant-api: _usb_device_core_api
 
    Implement device firmware upgrade using the USB DFU class driver.
 

--- a/samples/subsys/usb/hid-keyboard/README.rst
+++ b/samples/subsys/usb/hid-keyboard/README.rst
@@ -1,6 +1,6 @@
 .. zephyr:code-sample:: usb-hid-keyboard
    :name: USB HID keyboard
-   :relevant-api: usbd_api usbd_hid_class input_interface
+   :relevant-api: usbd_api usbd_hid_device input_interface
 
    Implement a basic HID keyboard device.
 

--- a/samples/subsys/usb/hid-mouse/README.rst
+++ b/samples/subsys/usb/hid-mouse/README.rst
@@ -1,6 +1,6 @@
 .. zephyr:code-sample:: usb-hid-mouse
    :name: USB HID mouse
-   :relevant-api: _usb_device_core_api usb_hid_class input_interface
+   :relevant-api: _usb_device_core_api usb_hid_device_api input_interface
 
    Implement a basic HID mouse device.
 

--- a/samples/subsys/usb/hid/README.rst
+++ b/samples/subsys/usb/hid/README.rst
@@ -1,6 +1,6 @@
 .. zephyr:code-sample:: usb-hid
    :name: USB HID (Human Interface Device)
-   :relevant-api: usbd_api usb_hid_device_api
+   :relevant-api: _usb_device_core_api usb_hid_device_api
 
    Use USB HID driver to enumerate as a raw HID device.
 

--- a/samples/subsys/usb/mass/README.rst
+++ b/samples/subsys/usb/mass/README.rst
@@ -1,6 +1,6 @@
 .. zephyr:code-sample:: usb-mass
    :name: USB Mass Storage
-   :relevant-api: usbd_api _usb_device_core_api file_system_api
+   :relevant-api: usbd_api usbd_msc_device _usb_device_core_api file_system_api
 
    Expose board's RAM or FLASH as a USB disk using USB Mass Storage driver.
 

--- a/samples/subsys/usb/uac2_explicit_feedback/README.rst
+++ b/samples/subsys/usb/uac2_explicit_feedback/README.rst
@@ -1,6 +1,6 @@
 .. zephyr:code-sample:: uac2-explicit-feedback
    :name: USB Audio asynchronous explicit feedback sample
-   :relevant-api: _usb_device_core_api i2s_interface
+   :relevant-api: usbd_api uac2_device i2s_interface
 
    USB Audio 2 explicit feedback sample playing audio on I2S.
 

--- a/samples/subsys/usb/webusb/README.rst
+++ b/samples/subsys/usb/webusb/README.rst
@@ -1,6 +1,6 @@
 .. zephyr:code-sample:: webusb
    :name: WebUSB
-   :relevant-api: usbd_api
+   :relevant-api: _usb_device_core_api
 
    Receive and echo data from a web page using WebUSB API.
 


### PR DESCRIPTION
Add missing documentation to USBD_DEVICE_DEFINE,
USBD_CONFIGURATION_DEFINE and USBD_DEFINE_CLASS macros.

Remove references to new device APIs that are not supported by the
samples.

Add a note about about the deprecation of current USB device support.