### PR TITLE
posix: signal: use the provided argument in the macros

### DIFF
--- a/lib/posix/options/signal.c
+++ b/lib/posix/options/signal.c
@@ -11,8 +11,8 @@
 #include <zephyr/posix/pthread.h>
 #include <zephyr/posix/signal.h>
 
-#define SIGNO_WORD_IDX(_signo) (signo / BITS_PER_LONG)
-#define SIGNO_WORD_BIT(_signo) (signo & BIT_MASK(LOG2(BITS_PER_LONG)))
+#define SIGNO_WORD_IDX(_signo) (_signo / BITS_PER_LONG)
+#define SIGNO_WORD_BIT(_signo) (_signo & BIT_MASK(LOG2(BITS_PER_LONG)))
 
 BUILD_ASSERT(CONFIG_POSIX_RTSIG_MAX >= 0);
 


### PR DESCRIPTION
The `SIGNO_WORD_IDX` & `SIGNO_WORD_BIT` macros should have used its own argument `_signo` instead of `signo`. It didn't cause and error because the function's argument has `signo`.