### PR TITLE
boards: st: add `adc1` dts node for `nucleo_h533re`

### DIFF
--- a/boards/st/nucleo_h533re/doc/index.rst
+++ b/boards/st/nucleo_h533re/doc/index.rst
@@ -170,6 +170,8 @@ The Zephyr nucleo_h533re board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | WATCHDOG  | on-chip    | independent watchdog                |
 +-----------+------------+-------------------------------------+
+| ADC       | on-chip    | ADC Controller                      |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.
 
@@ -205,9 +207,9 @@ For more details please refer to `STM32H5 Nucleo-64 board User Manual`_.
 Default Zephyr Peripheral Mapping:
 ----------------------------------
 
-- ADC1 channel 14 input: PB1
+- ADC1 channel 0 input: PA0
 - USART1 TX/RX : PB14/PB15 (Arduino USART1)
-- SPI1 SCK/MISO/MOSI/NSS: PA5/PA6/PA7/PC9
+- SPI1 SCK/MISO/MOSI/NSS: PA5/PA6/PA7/PA4
 - UART2 TX/RX : PA2/PA3 (VCP)
 - USER_PB : PC13
 
@@ -221,7 +223,7 @@ as well as main PLL clock. By default System clock is driven by PLL clock at
 Serial Port
 -----------
 
-Nucleo H533RE board has up to 6 U(S)ARTs. The Zephyr console output is assigned
+Nucleo H533RE board has up to 4 USARTs, 2 UARTs, and one LPUART. The Zephyr console output is assigned
 to USART2. Default settings are 115200 8N1.
 
 Programming and Debugging

--- a/boards/st/nucleo_h533re/nucleo_h533re.dts
+++ b/boards/st/nucleo_h533re/nucleo_h533re.dts
@@ -53,7 +53,9 @@
 		pwm-led0 = &green_pwm_led;
 		sw0 = &user_button;
 		watchdog0 = &iwdg;
+		die-temp0 = &die_temp;
 		volt-sensor0 = &vref;
+		volt-sensor1 = &vbat;
 	};
 };
 
@@ -118,7 +120,23 @@
 	};
 };
 
+&adc1 {
+	pinctrl-0 = <&adc1_inp0_pa0>; /* Arduino A0 */
+	pinctrl-names = "default";
+	st,adc-clock-source = <ASYNC>;
+	st,adc-prescaler = <8>;
+	status = "okay";
+};
+
+&die_temp {
+	status = "okay";
+};
+
 &vref {
+	status = "okay";
+};
+
+&vbat {
 	status = "okay";
 };
 

--- a/boards/st/nucleo_h533re/nucleo_h533re.yaml
+++ b/boards/st/nucleo_h533re/nucleo_h533re.yaml
@@ -14,4 +14,5 @@ supported:
   - watchdog
   - pwm
   - rtc
+  - adc
 vendor: st

--- a/tests/drivers/adc/adc_api/boards/nucleo_h533re.overlay
+++ b/tests/drivers/adc/adc_api/boards/nucleo_h533re.overlay
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) Alex Fabre <alex.fabre@rtone.fr>
+ */
+
+/ {
+	zephyr,user {
+		/* adjust channel number according to pinmux in board.dts */
+		io-channels = <&adc1 0>;
+	};
+};
+
+&adc1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};


### PR DESCRIPTION
Issue #72914 points out that some boards can have the `vbat` node enabled but do not implement any `adc` in their DTS.

This PR implements the `adc1` peripheral for this `nucleo_h533re` board: 

This PR also fixes the documentation around peripheral assignments for this board.

By default, adc1 channel 0 is now sensing on PA0