### PR TITLE
sysbuild: check for existence of APPLICATION_CONFIG_DIR

### DIFF
--- a/share/sysbuild/cmake/modules/sysbuild_kconfig.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_kconfig.cmake
@@ -73,6 +73,13 @@ if(NOT DEFINED SB_CONF_FILE)
   set(SB_CONF_FILE ${CMAKE_CURRENT_BINARY_DIR}/empty.conf)
 endif()
 
+if(NOT EXISTS "${APPLICATION_CONFIG_DIR}")
+  message(FATAL_ERROR "${APPLICATION_CONFIG_DIR} (APPLICATION_CONFIG_DIR) doesn't exist. "
+          "Unable to lookup sysbuild.conf or other related sysbuild configuration files. "
+	  "Please ensure APPLICATION_CONFIG_DIR points to a valid location."
+  )
+endif()
+
 # Empty files to make kconfig.py happy.
 file(TOUCH ${CMAKE_CURRENT_BINARY_DIR}/empty.conf)
 set(APPLICATION_SOURCE_DIR ${sysbuild_toplevel_SOURCE_DIR})


### PR DESCRIPTION
Check for existence of APPLICATION_CONFIG_DIR in sysbuild. sysbuild.conf is an optional file, meaning that sysbuild will not fail if APPLICATION_CONFIG_DIR points to a non-existing folder.

A normal Zephyr build already fails when passing an invalid APPLICATION_CONFIG_DIR but only because it cannot find a required prj.conf in the folder.

Checking the existence of APPLICATION_CONFIG_DIR in sysbuild and fail the build when a non-existing folder is passed to sysbuild ensures sysbuild behaves similar to a normal Zephyr build regarding a non-existing folder, while still allow sysbuild.conf itself to be optional.