### PR TITLE
tests: kernel: timer: timer_behavior: Tweak expected std deviation

### DIFF
--- a/tests/kernel/timer/timer_behavior/pytest/test_timer.py
+++ b/tests/kernel/timer/timer_behavior/pytest/test_timer.py
@@ -37,7 +37,10 @@ def do_analysis(test, stats, stats_count, config, sys_clock_hw_cycles_per_sec):
     max_bound = (test_period + period_max_drift * test_period +
                  expected_period_drift) / 1_000_000
 
+    cyc_us = 1000000 / sys_clock_hw_cycles_per_sec
     max_stddev = int(config['TIMER_TEST_MAX_STDDEV']) / 1_000_000
+    # Max STDDEV cannot be lower than clock single cycle
+    max_stddev = max(cyc_us, max_stddev)
 
     max_drift_ppm = int(config['TIMER_EXTERNAL_TEST_MAX_DRIFT_PPM'])
     time_diff = stats['total_time'] - seconds - expected_total_drift
@@ -62,13 +65,13 @@ def do_analysis(test, stats, stats_count, config, sys_clock_hw_cycles_per_sec):
                 f', "min_bound_us":{min_bound * 1_000_000:.6f}'
                 f', "max_bound_us":{max_bound * 1_000_000:.6f}'
                 f', "expected_period_cycles":{expected_period:.0f}'
+                f', "MAX_STD_DEV":{max_stddev:.6f}'
                 f', "sys_clock_hw_cycles_per_sec":{sys_clock_hw_cycles_per_sec}, ' +
                 ', '.join(['"CONFIG_{}":{}'.format(k, str(config[k]).rstrip()) for k in [
                                             'SYS_CLOCK_HW_CYCLES_PER_SEC',
                                             'SYS_CLOCK_TICKS_PER_SEC',
                                             'TIMER_TEST_PERIOD',
                                             'TIMER_TEST_SAMPLES',
-                                            'TIMER_TEST_MAX_STDDEV',
                                             'TIMER_EXTERNAL_TEST_PERIOD_MAX_DRIFT_PPM',
                                             'TIMER_EXTERNAL_TEST_MAX_DRIFT_PPM'
                                                                                  ]

--- a/tests/kernel/timer/timer_behavior/src/jitter_drift.c
+++ b/tests/kernel/timer/timer_behavior/src/jitter_drift.c
@@ -235,6 +235,8 @@ static void do_test_using(void (*sample_collection_fn)(void), const char *mechan
 		* CONFIG_TIMER_TEST_SAMPLES;
 	double time_diff_us = actual_time_us - expected_time_us
 		- expected_time_drift_us;
+	/* If max stddev is lower than a single clock cycle then round it up. */
+	uint32_t max_stddev = MAX(k_cyc_to_us_ceil32(1), CONFIG_TIMER_TEST_MAX_STDDEV);
 
 	TC_PRINT("timer clock rate %d, kernel tick rate %d\n",
 		 sys_clock_hw_cycles_per_sec(), CONFIG_SYS_CLOCK_TICKS_PER_SEC);
@@ -283,7 +285,7 @@ static void do_test_using(void (*sample_collection_fn)(void), const char *mechan
 		 ", \"CONFIG_SYS_CLOCK_TICKS_PER_SEC\":%d"
 		 ", \"CONFIG_TIMER_TEST_PERIOD\":%d"
 		 ", \"CONFIG_TIMER_TEST_SAMPLES\":%d"
-		 ", \"CONFIG_TIMER_TEST_MAX_STDDEV\":%d"
+		 ", \"MAX STD DEV\":%d"
 		 "}\n",
 		 mechanism,
 		 CONFIG_TIMER_TEST_SAMPLES - periodic_rollovers, periodic_rollovers,
@@ -304,7 +306,7 @@ static void do_test_using(void (*sample_collection_fn)(void), const char *mechan
 		 CONFIG_SYS_CLOCK_TICKS_PER_SEC,
 		 CONFIG_TIMER_TEST_PERIOD,
 		 CONFIG_TIMER_TEST_SAMPLES,
-		 CONFIG_TIMER_TEST_MAX_STDDEV
+		 max_stddev
 		 );
 
 	/* Validate the maximum/minimum timer period is off by no more than 10% */
@@ -323,10 +325,11 @@ static void do_test_using(void (*sample_collection_fn)(void), const char *mechan
 		"Longest timer period too long (off by more than expected %d%)",
 		CONFIG_TIMER_TEST_PERIOD_MAX_DRIFT_PERCENT);
 
+
 	/* Validate the timer deviation (precision/jitter of the timer) is within a configurable
 	 * bound
 	 */
-	zassert_true(stddev_us < (double)CONFIG_TIMER_TEST_MAX_STDDEV,
+	zassert_true(stddev_us < (double)max_stddev,
 		     "Standard deviation (in microseconds) outside expected bound");
 
 	/* Validate the timer drift (accuracy over time) is within a configurable bound */


### PR DESCRIPTION
If frequency of the system clock is lower then deviation may exceed default value (10us). Instead of adjusting the default value, test is rounding up expected standard deviation to a single clock cycle.

Fixes #71863.