### PR TITLE
scripts: twister: handlers: Enable BinaryHandler to run sysbuilt tests

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -249,7 +249,7 @@ class BinaryHandler(Handler):
                             "--variable", "RESC:@" + resc,
                             "--variable", "UART:" + uart]
         elif self.call_make_run:
-            command = [self.generator_cmd, "run"]
+            command = [self.generator_cmd, "-C", self.get_default_domain_build_dir(), "run"]
         elif self.instance.testsuite.type == "unit":
             command = [self.binary]
         else:

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -416,7 +416,7 @@ TESTDATA_4 = [
       f'--suppressions={ZEPHYR_BASE}/scripts/valgrind.supp',
       '--log-file=build_dir/valgrind.log', '--track-origins=yes',
       'generator']),
-    (False, True, False, 123, None, ['generator', 'run', '--seed=123']),
+    (False, True, False, 123, None, ['generator', '-C', 'build_dir', 'run', '--seed=123']),
     (False, False, False, None, ['ex1', 'ex2'], ['build_dir/zephyr/zephyr.exe', 'ex1', 'ex2']),
 ]
 


### PR DESCRIPTION
Running sysbuilt tests fails because of missing "run" target.

This adds the default domain context to the command.