### PR TITLE
doc: modem: fix double from

### DIFF
--- a/doc/services/modem/index.rst
+++ b/doc/services/modem/index.rst
@@ -57,7 +57,7 @@ Modem pipelink
 
 This module is used to share modem pipes globally. This module aims to
 decouple the creation and setup of modem pipes in device drivers from
-from the users of said pipes. See
+the users of said pipes. See
 :zephyr_file:`drivers/modem/modem_at_shell.c` and
 :zephyr_file:`drivers/modem/modem_cellular.c` for examples of how to
 use the modem pipelink between device driver and application.


### PR DESCRIPTION
Fix the double 'from' in the "Modem pipelink" chapter.