### PR TITLE
samples: net: zperf: Start DHCPv4 when needed

### DIFF
--- a/samples/net/zperf/src/main.c
+++ b/samples/net/zperf/src/main.c
@@ -29,5 +29,9 @@ int main(void)
 #ifdef CONFIG_NET_LOOPBACK_SIMULATE_PACKET_DROP
 	loopback_set_packet_drop_ratio(1);
 #endif
+
+#if defined(CONFIG_NET_DHCPV4) && !defined(CONFIG_NET_CONFIG_SETTINGS)
+	net_dhcpv4_start(net_if_get_default());
+#endif
 	return 0;
 }


### PR DESCRIPTION
If config library is disabled but DHCPv4 client is enabled, then start DHCPv4 when zperf application starts.