### PR TITLE
zephyr: Add zero-len check for utf8_trunc

### DIFF
--- a/lib/utils/utf8.c
+++ b/lib/utils/utf8.c
@@ -16,7 +16,14 @@
 
 char *utf8_trunc(char *utf8_str)
 {
-	char *last_byte_p = utf8_str + strlen(utf8_str) - 1;
+	const size_t len = strlen(utf8_str);
+
+	if (len == 0U) {
+		/* no-op */
+		return utf8_str;
+	}
+
+	char *last_byte_p = utf8_str + len - 1U;
 	uint8_t bytes_truncated;
 	char seq_start_byte;
 

--- a/tests/unit/util/CMakeLists.txt
+++ b/tests/unit/util/CMakeLists.txt
@@ -4,7 +4,12 @@ cmake_minimum_required(VERSION 3.20.0)
 
 project(util)
 find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
-target_sources(testbinary PRIVATE main.c ${ZEPHYR_BASE}/lib/utils/dec.c)
+target_sources(testbinary
+  PRIVATE
+  main.c
+  ${ZEPHYR_BASE}/lib/utils/dec.c
+  ${ZEPHYR_BASE}/lib/utils/utf8.c
+)
 
 if(CONFIG_CPP)
   # When testing for C++ force test file C++ compilation


### PR DESCRIPTION
The function did not check if the provided string had a zero length before starting to truncate, which meant that last_byte_p could possible have pointed to the value before the string.