### PR TITLE
Bluetooth: Audio: Unchecked return value in audio.h

### DIFF
--- a/subsys/bluetooth/audio/shell/audio.h
+++ b/subsys/bluetooth/audio/shell/audio.h
@@ -283,8 +283,12 @@ static void print_ltv_array(const struct shell *sh, size_t indent, const uint8_t
 		.cnt = 0U,
 		.indent = indent,
 	};
+	int err;
 
-	bt_audio_data_parse(ltv_data, ltv_data_len, print_ltv_elem, &ltv_info);
+	err = bt_audio_data_parse(ltv_data, ltv_data_len, print_ltv_elem, &ltv_info);
+	if (err != 0 && err != -ECANCELED) {
+		shell_error(sh, "%*sInvalid LTV data: %d", indent, "", err);
+	}
 }
 
 static inline char *context_bit_to_str(enum bt_audio_context context)


### PR DESCRIPTION
Unchecked return value in functions: print_ltv_array (Line 287)

Fixes #74733