### PR TITLE
drivers: ethernet: LAN865X configurable header buffer sizes

### DIFF
--- a/drivers/ethernet/Kconfig.lan865x
+++ b/drivers/ethernet/Kconfig.lan865x
@@ -18,6 +18,13 @@ menuconfig ETH_LAN865X
 
 if ETH_LAN865X
 
+config ETH_LAN865X_HEADER_BUFFER_SIZE
+	int "LAN865X driver header buffer size"
+	default 64
+	help
+	  The size of the first buffer for the LAN865X Controller to make sure
+	  headers can be set in a contiguous block.
+
 config ETH_LAN865X_INIT_PRIORITY
 	int "LAN865X driver init priority"
 	default 72

--- a/drivers/ethernet/eth_lan865x.c
+++ b/drivers/ethernet/eth_lan865x.c
@@ -395,7 +395,8 @@ static void lan865x_read_chunks(const struct device *dev)
 	struct net_pkt *pkt;
 	int ret;
 
-	pkt = net_pkt_rx_alloc(K_MSEC(cfg->timeout));
+	pkt = net_pkt_rx_alloc_with_buffer(ctx->iface, CONFIG_ETH_LAN865X_HEADER_BUFFER_SIZE,
+					   AF_UNSPEC, 0, K_MSEC(cfg->timeout));
 	if (!pkt) {
 		LOG_ERR("OA RX: Could not allocate packet!");
 		return;
@@ -409,6 +410,9 @@ static void lan865x_read_chunks(const struct device *dev)
 		k_sem_give(&ctx->tx_rx_sem);
 		return;
 	}
+
+	/* Try to keep headers compact */
+	net_pkt_compact(pkt);
 
 	/* Feed buffer frame to IP stack */
 	ret = net_recv_data(ctx->iface, pkt);


### PR DESCRIPTION
Allow to configure the LAN865X's first buffer size to support IPv6/ICMPv6 contiguous headers.

Ref: #74881