### PR TITLE
drivers: eth: native_posix: if_name from cmd line

### DIFF
--- a/doc/connectivity/networking/native_sim_setup.rst
+++ b/doc/connectivity/networking/native_sim_setup.rst
@@ -142,3 +142,17 @@ For TCP test, type:
 .. code-block:: console
 
    ./echo-client -t 127.0.0.1
+
+Setting interface name from command line
+****************************************
+
+By default the Ethernet interface name used by native_sim is determined by
+:kconfig:option:`CONFIG_ETH_NATIVE_POSIX_DRV_NAME`, but is also possible
+to set it from the command line using ``--eth-if=<interface_name>``.
+This can be useful if the application has to be
+run in multiple instances and recompiling it for each instance would be
+troublesome.
+
+.. code-block:: console
+
+   ./zephyr.exe --eth-if=zeth2

--- a/drivers/ethernet/eth_native_posix.c
+++ b/drivers/ethernet/eth_native_posix.c
@@ -23,6 +23,8 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <stdbool.h>
 #include <errno.h>
 #include <stddef.h>
+#include <cmdline.h>
+#include <posix_native_task.h>
 
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/net_core.h>
@@ -68,6 +70,8 @@ struct eth_context {
 	const struct device *ptp_clock;
 #endif
 };
+
+static const char *if_name_cmd_opt;
 
 #define DEFINE_RX_THREAD(x, _)						\
 	K_KERNEL_STACK_DEFINE(rx_thread_stack_##x,			\
@@ -343,6 +347,10 @@ static void eth_iface_init(struct net_if *iface)
 		ctx->if_name = CONFIG_ETH_NATIVE_POSIX_DRV_NAME;
 	}
 
+	if (if_name_cmd_opt != NULL) {
+		ctx->if_name = if_name_cmd_opt;
+	}
+
 	LOG_DBG("Interface %p using \"%s\"", iface, ctx->if_name);
 
 	net_if_set_link_addr(iface, ll_addr->addr, ll_addr->len,
@@ -587,3 +595,22 @@ LISTIFY(CONFIG_ETH_NATIVE_POSIX_INTERFACE_COUNT, PTP_INIT_FUNC, (), _)
 LISTIFY(CONFIG_ETH_NATIVE_POSIX_INTERFACE_COUNT, DEFINE_PTP_DEVICE, (;), _);
 
 #endif /* CONFIG_ETH_NATIVE_POSIX_PTP_CLOCK */
+
+static void add_native_posix_options(void)
+{
+	static struct args_struct_t eth_native_posix_options[] = {
+		{
+			.is_mandatory = false,
+			.option = "eth-if",
+			.name = "name",
+			.type = 's',
+			.dest = (void *)&if_name_cmd_opt,
+			.descript = "Name of the eth interface to use",
+		},
+		ARG_TABLE_ENDMARKER,
+	};
+
+	native_add_command_line_opts(eth_native_posix_options);
+}
+
+NATIVE_TASK(add_native_posix_options, PRE_BOOT_1, 10);


### PR DESCRIPTION
# Reasoning
Iface name which is used by native posix ethernet driver can only be specified at compile-time. I wanted to run two instances of the same program on native posix but did not want to make two separate builds only to change the iface name. I have implemented getting the iface name from environmental variable.

If it does not find the specified variable it falls back to `CONFIG_ETH_NATIVE_POSIX_DRV_NAME`

# Example usage
prj.conf
```
CONFIG_ETH_NATIVE_POSIX_GET_DRV_NAME_FROM_ENV=y
CONFIG_ETH_NATIVE_POSIX_DRV_NAME_ENV_VAR="ZETH"
```

Invocation
```sh
ZETH=zeth0 ./zephyr.exe &
ZETH=zeth1 ./zephyr.exe &
```
