### PR TITLE
libc: newlib: add config to use custom sbrk

### DIFF
--- a/include/zephyr/sys/libc-hooks.h
+++ b/include/zephyr/sys/libc-hooks.h
@@ -56,7 +56,7 @@ __syscall size_t zephyr_fwrite(const void *ZRESTRICT ptr, size_t size,
 #define Z_MALLOC_PARTITION_EXISTS 1
 #endif
 
-#elif defined(CONFIG_NEWLIB_LIBC)
+#elif defined(CONFIG_NEWLIB_LIBC) && !defined(CONFIG_NEWLIB_LIBC_CUSTOM_SBRK)
 /* If we are using newlib, the heap arena is in one of two areas:
  *  - If we have an MPU that requires power of two alignment, the heap bounds
  *    must be specified in Kconfig via CONFIG_NEWLIB_LIBC_ALIGNED_HEAP_SIZE.

--- a/lib/libc/newlib/Kconfig
+++ b/lib/libc/newlib/Kconfig
@@ -64,4 +64,10 @@ config NEWLIB_LIBC_HEAP_LISTENER
 	  Notify registered heap listeners upon certain events related to the newlib
 	  libc heap usage, such as the heap resize.
 
+config NEWLIB_LIBC_CUSTOM_SBRK
+	bool "Allow user to define _sbrk"
+	help
+	  Allow user to define custom version of the _sbrk function. Some application
+	  may need to use the remaining RAM for also other purposes than heap.
+
 endif # NEWLIB_LIBC

--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -32,6 +32,8 @@ int _lseek(int file, int ptr, int dir);
 int _kill(int pid, int sig);
 int _getpid(void);
 
+#ifndef CONFIG_NEWLIB_LIBC_CUSTOM_SBRK
+
 #define LIBC_BSS	K_APP_BMEM(z_libc_partition)
 #define LIBC_DATA	K_APP_DMEM(z_libc_partition)
 
@@ -146,6 +148,7 @@ SYS_INIT(malloc_prepare, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_LIBC);
 
 /* Current offset from HEAP_BASE of unused memory */
 LIBC_BSS static size_t heap_sz;
+#endif /* CONFIG_NEWLIB_LIBC_CUSTOM_SBRK */
 
 static int _stdout_hook_default(int c)
 {
@@ -297,6 +300,7 @@ __weak void _exit(int status)
 	}
 }
 
+#ifndef CONFIG_NEWLIB_LIBC_CUSTOM_SBRK
 void *_sbrk(intptr_t count)
 {
 	void *ret, *ptr;
@@ -317,6 +321,7 @@ void *_sbrk(intptr_t count)
 	return ret;
 }
 __weak FUNC_ALIAS(_sbrk, sbrk, void *);
+#endif /* CONFIG_NEWLIB_LIBC_CUSTOM_SBRK */
 
 #ifdef CONFIG_MULTITHREADING
 


### PR DESCRIPTION
Add a config to use the custom _sbrk function, defined by a user.

It is possible that an application doesn't want to use the entire remaining RAM for the heap.