### PR TITLE
doc: west: Clarify basic west terms

### DIFF
--- a/doc/develop/west/basics.rst
+++ b/doc/develop/west/basics.rst
@@ -6,14 +6,20 @@ Basics
 This page introduces west's basic concepts and provides references to further
 reading.
 
-West's built-in commands allow you to work with *projects* (Git
-repositories) under a common *workspace* directory.
+West's built-in commands allow you to work with :term:`projects <west project>`
+(Git repositories) under a common :term:`workspace <west workspace>` directory.
+
+West works in the following manner: the ``west init`` command creates the
+:term:`west workspace`, and clones the :term:`manifest repo <west manifest
+repository>`, while the ``west update`` command initially clones, and later updates, the
+:term:`projects <west project>` listed in the manifest in the workspace.
 
 Example workspace
 *****************
 
-If you've followed the upstream Zephyr getting started guide, your
-workspace looks like this:
+If you've followed the :ref:`getting_started`, your local
+:term:`west workspace`, which in this case is the folder named
+:file:`zephyrproject` as well as all its subfolders, looks like this:
 
 .. code-block:: none
 

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -173,15 +173,30 @@ Glossary of Terms
       :term:`west manifest`. Its location is given by the :ref:`manifest.path
       configuration option <west-config-index>`. See :ref:`west-basics`.
 
+   west project
+      Each of the entries in a :term:`west manifest`, which describe a Git
+      repository that will be cloned and managed by west when working with the
+      corresponding :term:`west manifest repository`. Note that a west project
+      is different from a :term:`zephyr module`, although many projects are also
+      modules. See :ref:`west-manifests-projects` for additional information.
+
    west workspace
-      A directory on your system with a :file:`.west` subdirectory and
-      a :term:`west manifest repository`. You clone the Zephyr source
-      code onto your system by creating a west workspace using the
-      ``west init`` command. See :ref:`west-basics`.
+      A folder on your system with a :file:`.west` subdirectory and a
+      :term:`west manifest repository` in it. You clone the Zephyr source code,
+      as well as that of its :term:`west projects <west project>` onto your
+      system by creating a west workspace using the ``west init`` command. See
+      :ref:`west-basics`.
 
    XIP
       (eXecute In Place) a method of executing programs directly from long
       term storage rather than copying it into RAM, saving writable memory for
       dynamic data and not the static program code.
+
+   zephyr module
+      A Git repository containing a :file:`zephyr/module.yml` file, used by the
+      Zephyr build system to integrate the source code and configuration files
+      of the module into a regular Zephyr build. Zephyr modules may be west
+      projects, but they do not have to. See :ref:`modules` for additional
+      details.
 
 .. _System on a chip: https://en.wikipedia.org/wiki/System_on_a_chip


### PR DESCRIPTION
Terms like the west workspace or even west projects and modules were not documented prominently enough, prompting users to ask for additional clarification. This patch attempts to resolve this by adding terms and explanation of concepts to the glossary and west doc pages.

Fixes #67376.