### PR TITLE
doc: mm: fix heap function references in documentation

### DIFF
--- a/doc/kernel/memory_management/heap.rst
+++ b/doc/kernel/memory_management/heap.rst
@@ -231,6 +231,10 @@ API Reference
 
 .. doxygengroup:: heap_apis
 
+.. doxygengroup:: low_level_heap_allocator
+
+.. doxygengroup:: multi_heap_wrapper
+
 Heap listener
 *************
 

--- a/include/zephyr/sys/multi_heap.h
+++ b/include/zephyr/sys/multi_heap.h
@@ -10,6 +10,12 @@
 #define MAX_MULTI_HEAPS 8
 
 /**
+ * @defgroup multi_heap_wrapper Multi-Heap Wrapper
+ * @ingroup heaps
+ * @{
+ */
+
+/**
  * @brief Multi-heap allocator
  *
  * A sys_multi_heap represents a single allocator made from multiple,
@@ -161,5 +167,9 @@ const struct sys_multi_heap_rec *sys_multi_heap_get_heap(const struct sys_multi_
  * @param block Block to free, must be a pointer to a block allocated by sys_multi_heap_alloc
  */
 void sys_multi_heap_free(struct sys_multi_heap *mheap, void *block);
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_INCLUDE_SYS_MULTI_HEAP_H_ */

--- a/include/zephyr/sys/sys_heap.h
+++ b/include/zephyr/sys/sys_heap.h
@@ -66,6 +66,12 @@ struct z_heap_stress_result {
 	uint64_t accumulated_in_use_bytes;
 };
 
+/**
+ * @defgroup low_level_heap_allocator Low Level Heap Allocator
+ * @ingroup heaps
+ * @{
+ */
+
 #ifdef CONFIG_SYS_HEAP_RUNTIME_STATS
 
 /**
@@ -252,6 +258,9 @@ void sys_heap_stress(void *(*alloc_fn)(void *arg, size_t bytes),
  */
 void sys_heap_print_info(struct sys_heap *heap, bool dump_chunks);
 
+/**
+ * @}
+ */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Add missing doxygengroup Low Level Heap Allocator and Multi-Heap Wrapper Utility.