### PR TITLE
tests: subsys: storage: flash_map: Extend timeout storage.flash_map.mpu

### DIFF
--- a/tests/subsys/storage/flash_map/testcase.yaml
+++ b/tests/subsys/storage/flash_map/testcase.yaml
@@ -14,6 +14,7 @@ tests:
       - native_sim
   storage.flash_map.mpu:
     extra_args: OVERLAY_CONFIG=overlay-mpu.conf
+    timeout: 120
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832


### PR DESCRIPTION
The test `storage.flash_map.mpu` for `nrf52840dk/nrf52840` fails althought the output is correct. Time to test execution is not enough. This change extend test execution timeout.