### PR TITLE
drivers: dp: swdp_bitbang: Update SWD clock calculation

### DIFF
--- a/drivers/dp/swdp_ll_pin.h
+++ b/drivers/dp/swdp_ll_pin.h
@@ -6,8 +6,9 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/gpio.h>
+#include <soc.h>
 
-#if defined(CONFIG_SOC_SERIES_NRF52X)
+#if defined(CONFIG_SOC_SERIES_NRF52X) || defined(CONFIG_SOC_SERIES_NRF53X)
 #define CPU_CLOCK		64000000U
 #else
 #define CPU_CLOCK		CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC


### PR DESCRIPTION
This patch updates the SWD clock calculation to the latest behavior of DAPLink.

I'm doing this patch because I had trouble getting the frequencies right otherwise.

You can find the reference implementation here:
https://github.com/ARMmbed/DAPLink/blob/main/source/daplink/cmsis-dap/DAP.c