### PR TITLE
drivers: spi: litex: add missing include

### DIFF
--- a/drivers/spi/spi_litespi.c
+++ b/drivers/spi/spi_litespi.c
@@ -11,6 +11,7 @@
 LOG_MODULE_REGISTER(spi_litespi);
 #include "spi_litespi.h"
 #include <stdbool.h>
+#include <soc.h>
 
 /* Helper Functions */
 static int spi_config(const struct spi_config *config, uint16_t *control)


### PR DESCRIPTION
add missing include of `soc.h` in `spi_litespi.c`

Resolves: #74972