### PR TITLE
drivers: dma: esp32: added support for multiple descriptors

### DIFF
--- a/drivers/dma/Kconfig.esp32
+++ b/drivers/dma/Kconfig.esp32
@@ -7,3 +7,9 @@ config DMA_ESP32
 	default y
 	help
 	  General Purpose DMA for ESP32 series.
+
+config DMA_ESP32_MAX_DESCRIPTOR_NUM
+	int "Maximal number of available DMA descriptors"
+	default 16
+	help
+	  Reserves memory for a maximal number of descriptors


### PR DESCRIPTION
In the past, configuring the GDMA was limited to using a single descriptor, which restricted memory transfers to a maximum of 4kB. 

- This pull request introduces support for multiple descriptors, allowing users to define multiple dma_blocks. 
- The maximum number of descriptors available can be configured using the `CONFIG_DMA_ESP32_DESCRIPTOR_NUM` option.   
- Additionally, the `dma_get_status()` function now provides the index of the currently processed descriptor through the `status.read_position` and `status.write_position` fields.

This is my first PR, and I welcome any feedback!