### PR TITLE
Replace sizeof(*ptr) with sizeof(struct foo) to make CI happy

### DIFF
--- a/subsys/modem/backends/modem_backend_tty.c
+++ b/subsys/modem/backends/modem_backend_tty.c
@@ -117,7 +117,7 @@ struct modem_pipe *modem_backend_tty_init(struct modem_backend_tty *backend,
 	__ASSERT_NO_MSG(config != NULL);
 	__ASSERT_NO_MSG(config->tty_path != NULL);
 
-	memset(backend, 0x00, sizeof(*backend));
+	memset(backend, 0x00, sizeof(struct modem_backend_tty));
 	backend->tty_path = config->tty_path;
 	backend->stack = config->stack;
 	backend->stack_size = config->stack_size;

--- a/subsys/modem/backends/modem_backend_uart.c
+++ b/subsys/modem/backends/modem_backend_uart.c
@@ -37,7 +37,7 @@ struct modem_pipe *modem_backend_uart_init(struct modem_backend_uart *backend,
 	__ASSERT_NO_MSG(config->transmit_buf != NULL);
 	__ASSERT_NO_MSG(config->transmit_buf_size > 0);
 
-	memset(backend, 0x00, sizeof(*backend));
+	memset(backend, 0x00, sizeof(struct modem_backend_uart));
 	backend->uart = config->uart;
 	k_work_init_delayable(&backend->receive_ready_work,
 			      modem_backend_uart_receive_ready_handler);

--- a/subsys/modem/modem_chat.c
+++ b/subsys/modem/modem_chat.c
@@ -805,7 +805,7 @@ int modem_chat_init(struct modem_chat *chat, const struct modem_chat_config *con
 	__ASSERT_NO_MSG(!((config->filter == NULL) && (config->filter_size > 0)));
 	__ASSERT_NO_MSG(!((config->unsol_matches == NULL) && (config->unsol_matches_size > 0)));
 
-	memset(chat, 0x00, sizeof(*chat));
+	memset(chat, 0x00, sizeof(struct modem_chat));
 	chat->pipe = NULL;
 	chat->user_data = config->user_data;
 	chat->receive_buf = config->receive_buf;

--- a/subsys/modem/modem_cmux.c
+++ b/subsys/modem/modem_cmux.c
@@ -1205,7 +1205,7 @@ void modem_cmux_init(struct modem_cmux *cmux, const struct modem_cmux_config *co
 	__ASSERT_NO_MSG(config->transmit_buf != NULL);
 	__ASSERT_NO_MSG(config->transmit_buf_size >= 148);
 
-	memset(cmux, 0x00, sizeof(*cmux));
+	memset(cmux, 0x00, sizeof(struct modem_cmux));
 	cmux->callback = config->callback;
 	cmux->user_data = config->user_data;
 	cmux->receive_buf = config->receive_buf;
@@ -1237,7 +1237,7 @@ struct modem_pipe *modem_cmux_dlci_init(struct modem_cmux *cmux, struct modem_cm
 	__ASSERT_NO_MSG(config->receive_buf != NULL);
 	__ASSERT_NO_MSG(config->receive_buf_size >= 126);
 
-	memset(dlci, 0x00, sizeof(*dlci));
+	memset(dlci, 0x00, sizeof(struct modem_cmux_dlci));
 	dlci->cmux = cmux;
 	dlci->dlci_address = config->dlci_address;
 	ring_buf_init(&dlci->receive_rb, config->receive_buf_size, config->receive_buf);

--- a/subsys/modem/modem_ubx.c
+++ b/subsys/modem/modem_ubx.c
@@ -319,7 +319,7 @@ int modem_ubx_init(struct modem_ubx *ubx, const struct modem_ubx_config *config)
 	__ASSERT_NO_MSG(config->work_buf != NULL);
 	__ASSERT_NO_MSG(config->work_buf_size > 0);
 
-	memset(ubx, 0x00, sizeof(*ubx));
+	memset(ubx, 0x00, sizeof(struct modem_ubx));
 	ubx->user_data = config->user_data;
 
 	ubx->receive_buf = config->receive_buf;


### PR DESCRIPTION
CI coverity checks keep falsely reporting out-of-bounds issues if `sizeof(*ptr)` is used. This PR changes all uses of `sizeof()` to use explicit structs rather than the dereference.

See:
#74745
#69115
#74746

Fixes: #74745
Fixes: #74746