### PR TITLE
west.yml: update hal_espressif for bugfixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -157,7 +157,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: e4e8df61b371554f4ce08d203426d7875421666e
+      revision: 826077a9d9c762ea7033f137b992b1b36b4aeacb
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
This update includes bugfixes related to esp_timer, responsible for handling Wi-Fi thread events.
Also removes all constructor attributes from non-used hal functions.

Fixes #74368
Fixes #74277
Fixes #75063