### PR TITLE
boards: nxp: add test feature 'usbd'

### DIFF
--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_hyperflash.yaml
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_hyperflash.yaml
@@ -26,6 +26,7 @@ supported:
   - sdhc
   - spi
   - usb_device
+  - usbd
   - watchdog
   - adc
 vendor: nxp

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_qspi.yaml
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_qspi.yaml
@@ -26,6 +26,7 @@ supported:
   - sdhc
   - spi
   - usb_device
+  - usbd
   - watchdog
   - adc
 vendor: nxp

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_hyperflash.yaml
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_hyperflash.yaml
@@ -29,5 +29,6 @@ supported:
   - sdhc
   - spi
   - usb_device
+  - usbd
   - watchdog
 vendor: nxp

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi.yaml
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi.yaml
@@ -31,5 +31,6 @@ supported:
   - sdhc
   - spi
   - usb_device
+  - usbd
   - watchdog
 vendor: nxp

--- a/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.yaml
+++ b/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.yaml
@@ -31,4 +31,5 @@ supported:
   - spi
   - watchdog
   - usb_device
+  - usbd
 vendor: nxp


### PR DESCRIPTION
Commit b6b43c3ed70a
("drivers: udc: implement udc_mcux_ehci and udc_mcux_ip3511") introduced MCUX shim driver using UDC driver API. Add test feature 'usbd' to a few supported boards to allow Twister to select these boards for testing during CI runs.

@dleach02 Not sure if it can (or should) be added to all the boards that already has test feature 'usb_device'. At least each controller variant should be covered for now. (See also https://github.com/zephyrproject-rtos/zephyr/pull/73269)