### PR TITLE
fdtable: replace z_ prefix with zvfs_ for fdtable.h functions

### DIFF
--- a/doc/connectivity/networking/api/sockets.rst
+++ b/doc/connectivity/networking/api/sockets.rst
@@ -185,11 +185,11 @@ Every offloaded socket implementation should also implement a set of socket
 APIs, specified in :c:struct:`socket_op_vtable` struct.
 
 The function registered for socket creation should allocate a new file
-descriptor using :c:func:`z_reserve_fd` function. Any additional actions,
+descriptor using :c:func:`zvfs_reserve_fd` function. Any additional actions,
 specific to the creation of a particular offloaded socket implementation,
 should take place after the file descriptor is allocated. As a final step,
 if the offloaded socket was created successfully, the file descriptor should
-be finalized with :c:func:`z_finalize_typed_fd`, or :c:func:`z_finalize_fd`
+be finalized with :c:func:`zvfs_finalize_typed_fd`, or :c:func:`zvfs_finalize_fd`
 functions. The finalize function allows to register a
 :c:struct:`socket_op_vtable` structure implementing socket APIs for an
 offloaded socket along with an optional socket context data pointer.

--- a/drivers/modem/modem_socket.c
+++ b/drivers/modem/modem_socket.c
@@ -164,7 +164,7 @@ int modem_socket_get(struct modem_socket_config *cfg, int family, int type, int 
 		return -ENOMEM;
 	}
 
-	cfg->sockets[i].sock_fd = z_reserve_fd();
+	cfg->sockets[i].sock_fd = zvfs_reserve_fd();
 	if (cfg->sockets[i].sock_fd < 0) {
 		k_sem_give(&cfg->sem_lock);
 		return -errno;
@@ -175,7 +175,7 @@ int modem_socket_get(struct modem_socket_config *cfg, int family, int type, int 
 	cfg->sockets[i].ip_proto = proto;
 	cfg->sockets[i].id = (cfg->assign_id) ? (i + cfg->base_socket_id) :
 		(cfg->base_socket_id + cfg->sockets_len);
-	z_finalize_typed_fd(cfg->sockets[i].sock_fd, &cfg->sockets[i],
+	zvfs_finalize_typed_fd(cfg->sockets[i].sock_fd, &cfg->sockets[i],
 			    (const struct fd_op_vtable *)cfg->vtable, ZVFS_MODE_IFSOCK);
 
 	k_sem_give(&cfg->sem_lock);

--- a/drivers/modem/simcom-sim7080.c
+++ b/drivers/modem/simcom-sim7080.c
@@ -576,7 +576,7 @@ static int offload_poll(struct zsock_pollfd *fds, int nfds, int msecs)
 		}
 
 		/* If vtable matches, then it's modem socket. */
-		obj = z_get_fd_obj(fds[i].fd,
+		obj = zvfs_get_fd_obj(fds[i].fd,
 				   (const struct fd_op_vtable *)&offload_socket_fd_op_vtable,
 				   EINVAL);
 		if (obj == NULL) {

--- a/drivers/net/nsos_sockets.c
+++ b/drivers/net/nsos_sockets.c
@@ -181,7 +181,7 @@ static int nsos_socket_create(int family, int type, int proto)
 		return -1;
 	}
 
-	fd = z_reserve_fd();
+	fd = zvfs_reserve_fd();
 	if (fd < 0) {
 		return -1;
 	}
@@ -202,7 +202,7 @@ static int nsos_socket_create(int family, int type, int proto)
 		goto free_sock;
 	}
 
-	z_finalize_typed_fd(fd, sock, &nsos_socket_fd_op_vtable.fd_vtable, ZVFS_MODE_IFSOCK);
+	zvfs_finalize_typed_fd(fd, sock, &nsos_socket_fd_op_vtable.fd_vtable, ZVFS_MODE_IFSOCK);
 
 	return fd;
 
@@ -210,7 +210,7 @@ free_sock:
 	k_free(sock);
 
 free_fd:
-	z_free_fd(fd);
+	zvfs_free_fd(fd);
 
 	return -1;
 }
@@ -703,7 +703,7 @@ static int nsos_accept(void *obj, struct sockaddr *addr, socklen_t *addrlen)
 		goto close_adapt_fd;
 	}
 
-	zephyr_fd = z_reserve_fd();
+	zephyr_fd = zvfs_reserve_fd();
 	if (zephyr_fd < 0) {
 		ret = -errno_to_nsos_mid(-zephyr_fd);
 		goto close_adapt_fd;
@@ -718,13 +718,13 @@ static int nsos_accept(void *obj, struct sockaddr *addr, socklen_t *addrlen)
 	conn_sock->fd = zephyr_fd;
 	conn_sock->poll.mid.fd = adapt_fd;
 
-	z_finalize_typed_fd(zephyr_fd, conn_sock, &nsos_socket_fd_op_vtable.fd_vtable,
-			    ZVFS_MODE_IFSOCK);
+	zvfs_finalize_typed_fd(zephyr_fd, conn_sock, &nsos_socket_fd_op_vtable.fd_vtable,
+			       ZVFS_MODE_IFSOCK);
 
 	return zephyr_fd;
 
 free_zephyr_fd:
-	z_free_fd(zephyr_fd);
+	zvfs_free_fd(zephyr_fd);
 
 close_adapt_fd:
 	nsi_host_close(adapt_fd);

--- a/drivers/wifi/eswifi/eswifi_socket_offload.c
+++ b/drivers/wifi/eswifi/eswifi_socket_offload.c
@@ -145,7 +145,7 @@ static int __eswifi_socket_accept(void *obj, struct sockaddr *addr,
 static int eswifi_socket_accept(void *obj, struct sockaddr *addr,
 				socklen_t *addrlen)
 {
-	int fd = z_reserve_fd();
+	int fd = zvfs_reserve_fd();
 	int sock;
 
 	if (fd < 0) {
@@ -154,11 +154,11 @@ static int eswifi_socket_accept(void *obj, struct sockaddr *addr,
 
 	sock = __eswifi_socket_accept(obj, addr, addrlen);
 	if (sock < 0) {
-		z_free_fd(fd);
+		zvfs_free_fd(fd);
 		return -1;
 	}
 
-	z_finalize_typed_fd(fd, SD_TO_OBJ(sock),
+	zvfs_finalize_typed_fd(fd, SD_TO_OBJ(sock),
 			    (const struct fd_op_vtable *)&eswifi_socket_fd_op_vtable,
 			    ZVFS_MODE_IFSOCK);
 
@@ -475,7 +475,7 @@ static int eswifi_socket_poll(struct zsock_pollfd *fds, int nfds, int msecs)
 		return -1;
 	}
 
-	obj = z_get_fd_obj(fds[0].fd,
+	obj = zvfs_get_fd_obj(fds[0].fd,
 			   (const struct fd_op_vtable *)
 						&eswifi_socket_fd_op_vtable,
 			   0);
@@ -581,7 +581,7 @@ static bool eswifi_socket_is_supported(int family, int type, int proto)
 
 int eswifi_socket_create(int family, int type, int proto)
 {
-	int fd = z_reserve_fd();
+	int fd = zvfs_reserve_fd();
 	int sock;
 
 	if (fd < 0) {
@@ -590,11 +590,11 @@ int eswifi_socket_create(int family, int type, int proto)
 
 	sock = eswifi_socket_open(family, type, proto);
 	if (sock < 0) {
-		z_free_fd(fd);
+		zvfs_free_fd(fd);
 		return -1;
 	}
 
-	z_finalize_typed_fd(fd, SD_TO_OBJ(sock),
+	zvfs_finalize_typed_fd(fd, SD_TO_OBJ(sock),
 			    (const struct fd_op_vtable *)&eswifi_socket_fd_op_vtable,
 			    ZVFS_MODE_IFSOCK);
 

--- a/drivers/wifi/simplelink/simplelink_sockets.c
+++ b/drivers/wifi/simplelink/simplelink_sockets.c
@@ -588,7 +588,7 @@ static int simplelink_poll(struct zsock_pollfd *fds, int nfds, int msecs)
 		if (fds[i].fd < 0) {
 			continue;
 		} else {
-			obj = z_get_fd_obj(fds[i].fd,
+			obj = zvfs_get_fd_obj(fds[i].fd,
 					   (const struct fd_op_vtable *)
 						&simplelink_socket_fd_op_vtable,
 					   ENOTSUP);
@@ -617,7 +617,7 @@ static int simplelink_poll(struct zsock_pollfd *fds, int nfds, int msecs)
 	if (retval > 0) {
 		for (i = 0; i < nfds; i++) {
 			if (fds[i].fd >= 0) {
-				obj = z_get_fd_obj(
+				obj = zvfs_get_fd_obj(
 					fds[i].fd,
 					(const struct fd_op_vtable *)
 						&simplelink_socket_fd_op_vtable,
@@ -1260,7 +1260,7 @@ static bool simplelink_is_supported(int family, int type, int proto)
 
 int simplelink_socket_create(int family, int type, int proto)
 {
-	int fd = z_reserve_fd();
+	int fd = zvfs_reserve_fd();
 	int sock;
 
 	if (fd < 0) {
@@ -1269,11 +1269,11 @@ int simplelink_socket_create(int family, int type, int proto)
 
 	sock = simplelink_socket(family, type, proto);
 	if (sock < 0) {
-		z_free_fd(fd);
+		zvfs_free_fd(fd);
 		return -1;
 	}
 
-	z_finalize_typed_fd(fd, SD_TO_OBJ(sock),
+	zvfs_finalize_typed_fd(fd, SD_TO_OBJ(sock),
 			    (const struct fd_op_vtable *)&simplelink_socket_fd_op_vtable,
 			    ZVFS_MODE_IFSOCK);
 
@@ -1283,7 +1283,7 @@ int simplelink_socket_create(int family, int type, int proto)
 static int simplelink_socket_accept(void *obj, struct sockaddr *addr,
 			     socklen_t *addrlen)
 {
-	int fd = z_reserve_fd();
+	int fd = zvfs_reserve_fd();
 	int sock;
 
 	if (fd < 0) {
@@ -1292,11 +1292,11 @@ static int simplelink_socket_accept(void *obj, struct sockaddr *addr,
 
 	sock = simplelink_accept(obj, addr, addrlen);
 	if (sock < 0) {
-		z_free_fd(fd);
+		zvfs_free_fd(fd);
 		return -1;
 	}
 
-	z_finalize_typed_fd(fd, SD_TO_OBJ(sock),
+	zvfs_finalize_typed_fd(fd, SD_TO_OBJ(sock),
 			    (const struct fd_op_vtable *)&simplelink_socket_fd_op_vtable,
 			    ZVFS_MODE_IFSOCK);
 

--- a/include/zephyr/sys/fdtable.h
+++ b/include/zephyr/sys/fdtable.h
@@ -52,50 +52,50 @@ struct fd_op_vtable {
  *
  * This function allows to reserve a space for file descriptor entry in
  * the underlying table, and thus allows caller to fail fast if no free
- * descriptor is available. If this function succeeds, z_finalize_fd()
- * or z_free_fd() must be called mandatorily.
+ * descriptor is available. If this function succeeds, zvfs_finalize_fd()
+ * or zvfs_free_fd() must be called mandatorily.
  *
  * @return Allocated file descriptor, or -1 in case of error (errno is set)
  */
-int z_reserve_fd(void);
+int zvfs_reserve_fd(void);
 
 /**
  * @brief Finalize creation of file descriptor, with type.
  *
- * This function should be called exactly once after z_reserve_fd(), and
+ * This function should be called exactly once after zvfs_reserve_fd(), and
  * should not be called in any other case.
  *
- * The difference between this function and @ref z_finalize_fd is that the
+ * The difference between this function and @ref zvfs_finalize_fd is that the
  * latter does not relay type information of the created file descriptor.
  *
  * Values permitted for @a mode are one of `ZVFS_MODE_..`.
  *
- * @param fd File descriptor previously returned by z_reserve_fd()
+ * @param fd File descriptor previously returned by zvfs_reserve_fd()
  * @param obj pointer to I/O object structure
  * @param vtable pointer to I/O operation implementations for the object
  * @param mode File type as specified above.
  */
-void z_finalize_typed_fd(int fd, void *obj, const struct fd_op_vtable *vtable, uint32_t mode);
+void zvfs_finalize_typed_fd(int fd, void *obj, const struct fd_op_vtable *vtable, uint32_t mode);
 
 /**
  * @brief Finalize creation of file descriptor.
  *
- * This function should be called exactly once after z_reserve_fd(), and
+ * This function should be called exactly once after zvfs_reserve_fd(), and
  * should not be called in any other case.
  *
- * @param fd File descriptor previously returned by z_reserve_fd()
+ * @param fd File descriptor previously returned by zvfs_reserve_fd()
  * @param obj pointer to I/O object structure
  * @param vtable pointer to I/O operation implementations for the object
  */
-static inline void z_finalize_fd(int fd, void *obj, const struct fd_op_vtable *vtable)
+static inline void zvfs_finalize_fd(int fd, void *obj, const struct fd_op_vtable *vtable)
 {
-	z_finalize_typed_fd(fd, obj, vtable, ZVFS_MODE_UNSPEC);
+	zvfs_finalize_typed_fd(fd, obj, vtable, ZVFS_MODE_UNSPEC);
 }
 
 /**
  * @brief Allocate file descriptor for underlying I/O object.
  *
- * This function combines operations of z_reserve_fd() and z_finalize_fd()
+ * This function combines operations of zvfs_reserve_fd() and zvfs_finalize_fd()
  * in one step, and provided for convenience.
  *
  * @param obj pointer to I/O object structure
@@ -103,17 +103,17 @@ static inline void z_finalize_fd(int fd, void *obj, const struct fd_op_vtable *v
  *
  * @return Allocated file descriptor, or -1 in case of error (errno is set)
  */
-int z_alloc_fd(void *obj, const struct fd_op_vtable *vtable);
+int zvfs_alloc_fd(void *obj, const struct fd_op_vtable *vtable);
 
 /**
  * @brief Release reserved file descriptor.
  *
- * This function may be called once after z_reserve_fd(), and should
+ * This function may be called once after zvfs_reserve_fd(), and should
  * not be called in any other case.
  *
- * @param fd File descriptor previously returned by z_reserve_fd()
+ * @param fd File descriptor previously returned by zvfs_reserve_fd()
  */
-void z_free_fd(int fd);
+void zvfs_free_fd(int fd);
 
 /**
  * @brief Get underlying object pointer from file descriptor.
@@ -125,18 +125,18 @@ void z_free_fd(int fd);
  * but vtable param is not NULL and doesn't match object's vtable,
  * NULL is returned and errno set to err param.
  *
- * @param fd File descriptor previously returned by z_reserve_fd()
+ * @param fd File descriptor previously returned by zvfs_reserve_fd()
  * @param vtable Expected object vtable or NULL
  * @param err errno value to set if object vtable doesn't match
  *
  * @return Object pointer or NULL, with errno set
  */
-void *z_get_fd_obj(int fd, const struct fd_op_vtable *vtable, int err);
+void *zvfs_get_fd_obj(int fd, const struct fd_op_vtable *vtable, int err);
 
 /**
  * @brief Get underlying object pointer and vtable pointer from file descriptor.
  *
- * @param fd File descriptor previously returned by z_reserve_fd()
+ * @param fd File descriptor previously returned by zvfs_reserve_fd()
  * @param vtable A pointer to a pointer variable to store the vtable
  * @param lock An optional pointer to a pointer variable to store the mutex
  *        preventing concurrent descriptor access. The lock is not taken,
@@ -145,13 +145,13 @@ void *z_get_fd_obj(int fd, const struct fd_op_vtable *vtable, int err);
  *
  * @return Object pointer or NULL, with errno set
  */
-void *z_get_fd_obj_and_vtable(int fd, const struct fd_op_vtable **vtable,
+void *zvfs_get_fd_obj_and_vtable(int fd, const struct fd_op_vtable **vtable,
 			      struct k_mutex **lock);
 
 /**
  * @brief Get the mutex and condition variable associated with the given object and vtable.
  *
- * @param obj Object previously returned by a call to e.g. @ref z_get_fd_obj.
+ * @param obj Object previously returned by a call to e.g. @ref zvfs_get_fd_obj.
  * @param vtable A pointer the vtable associated with @p obj.
  * @param lock An optional pointer to a pointer variable to store the mutex
  *        preventing concurrent descriptor access. The lock is not taken,
@@ -163,7 +163,7 @@ void *z_get_fd_obj_and_vtable(int fd, const struct fd_op_vtable **vtable,
  *
  * @return `true` on success, `false` otherwise.
  */
-bool z_get_obj_lock_and_cond(void *obj, const struct fd_op_vtable *vtable, struct k_mutex **lock,
+bool zvfs_get_obj_lock_and_cond(void *obj, const struct fd_op_vtable *vtable, struct k_mutex **lock,
 			     struct k_condvar **cond);
 
 /**
@@ -178,7 +178,7 @@ bool z_get_obj_lock_and_cond(void *obj, const struct fd_op_vtable *vtable, struc
  * @param request ioctl request number
  * @param ... Variadic arguments to ioctl
  */
-static inline int z_fdtable_call_ioctl(const struct fd_op_vtable *vtable, void *obj,
+static inline int zvfs_fdtable_call_ioctl(const struct fd_op_vtable *vtable, void *obj,
 				       unsigned long request, ...)
 {
 	va_list args;

--- a/lib/os/zvfs/zvfs_eventfd.c
+++ b/lib/os/zvfs/zvfs_eventfd.c
@@ -184,8 +184,8 @@ static int zvfs_eventfd_close_op(void *obj)
 		return -1;
 	}
 
-	err = (int)z_get_obj_lock_and_cond(obj, &zvfs_eventfd_fd_vtable, &lock, &cond);
-	__ASSERT((bool)err, "z_get_obj_lock_and_cond() failed");
+	err = (int)zvfs_get_obj_lock_and_cond(obj, &zvfs_eventfd_fd_vtable, &lock, &cond);
+	__ASSERT((bool)err, "zvfs_get_obj_lock_and_cond() failed");
 	__ASSERT_NO_MSG(lock != NULL);
 	__ASSERT_NO_MSG(cond != NULL);
 
@@ -346,8 +346,8 @@ static ssize_t zvfs_eventfd_rw_op(void *obj, void *buf, size_t sz,
 		goto unlock_spin;
 	}
 
-	err = (int)z_get_obj_lock_and_cond(obj, &zvfs_eventfd_fd_vtable, &lock, &cond);
-	__ASSERT((bool)err, "z_get_obj_lock_and_cond() failed");
+	err = (int)zvfs_get_obj_lock_and_cond(obj, &zvfs_eventfd_fd_vtable, &lock, &cond);
+	__ASSERT((bool)err, "zvfs_get_obj_lock_and_cond() failed");
 	__ASSERT_NO_MSG(lock != NULL);
 	__ASSERT_NO_MSG(cond != NULL);
 
@@ -423,7 +423,7 @@ int zvfs_eventfd(unsigned int initval, int flags)
 
 	efd = &efds[offset];
 
-	fd = z_reserve_fd();
+	fd = zvfs_reserve_fd();
 	if (fd < 0) {
 		sys_bitarray_free(&efds_bitarray, 1, offset);
 		return -1;
@@ -441,7 +441,7 @@ int zvfs_eventfd(unsigned int initval, int flags)
 
 	k_poll_signal_raise(&efd->write_sig, 0);
 
-	z_finalize_fd(fd, efd, &zvfs_eventfd_fd_vtable);
+	zvfs_finalize_fd(fd, efd, &zvfs_eventfd_fd_vtable);
 
 	return fd;
 }
@@ -451,7 +451,7 @@ int zvfs_eventfd_read(int fd, zvfs_eventfd_t *value)
 	int ret;
 	void *obj;
 
-	obj = z_get_fd_obj(fd, &zvfs_eventfd_fd_vtable, EBADF);
+	obj = zvfs_get_fd_obj(fd, &zvfs_eventfd_fd_vtable, EBADF);
 	if (obj == NULL) {
 		return -1;
 	}
@@ -470,7 +470,7 @@ int zvfs_eventfd_write(int fd, zvfs_eventfd_t value)
 	int ret;
 	void *obj;
 
-	obj = z_get_fd_obj(fd, &zvfs_eventfd_fd_vtable, EBADF);
+	obj = zvfs_get_fd_obj(fd, &zvfs_eventfd_fd_vtable, EBADF);
 	if (obj == NULL) {
 		return -1;
 	}

--- a/lib/posix/options/fs.c
+++ b/lib/posix/options/fs.c
@@ -92,14 +92,14 @@ int zvfs_open(const char *name, int flags)
 		return zmode;
 	}
 
-	fd = z_reserve_fd();
+	fd = zvfs_reserve_fd();
 	if (fd < 0) {
 		return -1;
 	}
 
 	ptr = posix_fs_alloc_obj(false);
 	if (ptr == NULL) {
-		z_free_fd(fd);
+		zvfs_free_fd(fd);
 		errno = EMFILE;
 		return -1;
 	}
@@ -110,12 +110,12 @@ int zvfs_open(const char *name, int flags)
 
 	if (rc < 0) {
 		posix_fs_free_obj(ptr);
-		z_free_fd(fd);
+		zvfs_free_fd(fd);
 		errno = -rc;
 		return -1;
 	}
 
-	z_finalize_fd(fd, ptr, &fs_fd_op_vtable);
+	zvfs_finalize_fd(fd, ptr, &fs_fd_op_vtable);
 
 	return fd;
 }

--- a/lib/posix/options/shm.c
+++ b/lib/posix/options/shm.c
@@ -325,7 +325,7 @@ int shm_open(const char *name, int oflag, mode_t mode)
 		return -1;
 	}
 
-	fd = z_reserve_fd();
+	fd = zvfs_reserve_fd();
 	if (fd < 0) {
 		errno = EMFILE;
 		return -1;
@@ -341,7 +341,7 @@ int shm_open(const char *name, int oflag, mode_t mode)
 
 	if (creat) {
 		if ((shm != NULL) && excl) {
-			z_free_fd(fd);
+			zvfs_free_fd(fd);
 			errno = EEXIST;
 			return -1;
 		}
@@ -349,7 +349,7 @@ int shm_open(const char *name, int oflag, mode_t mode)
 		if (shm == NULL) {
 			shm = k_calloc(1, sizeof(*shm));
 			if (shm == NULL) {
-				z_free_fd(fd);
+				zvfs_free_fd(fd);
 				errno = ENOSPC;
 				return -1;
 			}
@@ -363,7 +363,7 @@ int shm_open(const char *name, int oflag, mode_t mode)
 	}
 
 	++shm->refs;
-	z_finalize_typed_fd(fd, shm, &shm_vtable, ZVFS_MODE_IFSHM);
+	zvfs_finalize_typed_fd(fd, shm, &shm_vtable, ZVFS_MODE_IFSHM);
 
 	return fd;
 }

--- a/subsys/net/lib/shell/websocket.c
+++ b/subsys/net/lib/shell/websocket.c
@@ -30,7 +30,7 @@ static void websocket_context_cb(struct websocket_context *context,
 	char addr_local[ADDR_LEN + 7];
 	char addr_remote[ADDR_LEN + 7] = "";
 
-	net_ctx = z_get_fd_obj(context->real_sock, NULL, 0);
+	net_ctx = zvfs_get_fd_obj(context->real_sock, NULL, 0);
 	if (net_ctx == NULL) {
 		PR_ERROR("Invalid fd %d", context->real_sock);
 		return;

--- a/subsys/net/lib/sockets/socket_dispatcher.c
+++ b/subsys/net/lib/sockets/socket_dispatcher.c
@@ -60,7 +60,7 @@ static int sock_dispatch_socket(struct dispatcher_context *ctx,
 		return -1;
 	}
 
-	obj = z_get_fd_obj_and_vtable(new_fd,
+	obj = zvfs_get_fd_obj_and_vtable(new_fd,
 				      (const struct fd_op_vtable **)&vtable,
 				      NULL);
 	if (obj == NULL) {
@@ -69,10 +69,10 @@ static int sock_dispatch_socket(struct dispatcher_context *ctx,
 
 	/* Reassing FD with new obj and entry. */
 	fd = ctx->fd;
-	z_finalize_typed_fd(fd, obj, (const struct fd_op_vtable *)vtable, ZVFS_MODE_IFSOCK);
+	zvfs_finalize_typed_fd(fd, obj, (const struct fd_op_vtable *)vtable, ZVFS_MODE_IFSOCK);
 
 	/* Release FD that is no longer in use. */
-	z_free_fd(new_fd);
+	zvfs_free_fd(new_fd);
 
 	dispatcher_ctx_free(ctx);
 
@@ -148,7 +148,7 @@ static ssize_t sock_dispatch_read_vmeth(void *obj, void *buffer, size_t count)
 		return -1;
 	}
 
-	new_obj = z_get_fd_obj_and_vtable(fd, &vtable, NULL);
+	new_obj = zvfs_get_fd_obj_and_vtable(fd, &vtable, NULL);
 	if (new_obj == NULL) {
 		return -1;
 	}
@@ -168,7 +168,7 @@ static ssize_t sock_dispatch_write_vmeth(void *obj, const void *buffer,
 		return -1;
 	}
 
-	new_obj = z_get_fd_obj_and_vtable(fd, &vtable, NULL);
+	new_obj = zvfs_get_fd_obj_and_vtable(fd, &vtable, NULL);
 	if (new_obj == NULL) {
 		return -1;
 	}
@@ -193,7 +193,7 @@ static int sock_dispatch_ioctl_vmeth(void *obj, unsigned int request,
 		return -1;
 	}
 
-	new_obj = z_get_fd_obj_and_vtable(fd, &vtable, NULL);
+	new_obj = zvfs_get_fd_obj_and_vtable(fd, &vtable, NULL);
 	if (new_obj == NULL) {
 		return -1;
 	}
@@ -471,7 +471,7 @@ static int sock_dispatch_create(int family, int type, int proto)
 		goto out;
 	}
 
-	fd = z_reserve_fd();
+	fd = zvfs_reserve_fd();
 	if (fd < 0) {
 		goto out;
 	}
@@ -482,7 +482,7 @@ static int sock_dispatch_create(int family, int type, int proto)
 	entry->proto = proto;
 	entry->is_used = true;
 
-	z_finalize_typed_fd(fd, entry, (const struct fd_op_vtable *)&sock_dispatch_fd_op_vtable,
+	zvfs_finalize_typed_fd(fd, entry, (const struct fd_op_vtable *)&sock_dispatch_fd_op_vtable,
 			    ZVFS_MODE_IFSOCK);
 
 out:

--- a/subsys/net/lib/sockets/socketpair.c
+++ b/subsys/net/lib/sockets/socketpair.c
@@ -74,7 +74,7 @@ static inline bool sock_is_nonblock(const struct spair *spair)
 /** Determine if a @ref spair is connected */
 static inline bool sock_is_connected(const struct spair *spair)
 {
-	const struct spair *remote = z_get_fd_obj(spair->remote,
+	const struct spair *remote = zvfs_get_fd_obj(spair->remote,
 		(const struct fd_op_vtable *)&spair_fd_op_vtable, 0);
 
 	if (remote == NULL) {
@@ -99,7 +99,7 @@ static inline bool sock_is_eof(const struct spair *spair)
  */
 static inline size_t spair_write_avail(struct spair *spair)
 {
-	struct spair *const remote = z_get_fd_obj(spair->remote,
+	struct spair *const remote = zvfs_get_fd_obj(spair->remote,
 		(const struct fd_op_vtable *)&spair_fd_op_vtable, 0);
 
 	if (remote == NULL) {
@@ -169,7 +169,7 @@ static void spair_delete(struct spair *spair)
 	}
 
 	if (spair->remote != -1) {
-		remote = z_get_fd_obj(spair->remote,
+		remote = zvfs_get_fd_obj(spair->remote,
 			(const struct fd_op_vtable *)&spair_fd_op_vtable, 0);
 
 		if (remote != NULL) {
@@ -258,14 +258,14 @@ static struct spair *spair_new(void)
 	res = k_poll_signal_raise(&spair->writeable, SPAIR_SIG_DATA);
 	__ASSERT(res == 0, "k_poll_signal_raise() failed: %d", res);
 
-	spair->remote = z_reserve_fd();
+	spair->remote = zvfs_reserve_fd();
 	if (spair->remote == -1) {
 		errno = ENFILE;
 		goto cleanup;
 	}
 
-	z_finalize_typed_fd(spair->remote, spair, (const struct fd_op_vtable *)&spair_fd_op_vtable,
-			    ZVFS_MODE_IFSOCK);
+	zvfs_finalize_typed_fd(spair->remote, spair,
+			       (const struct fd_op_vtable *)&spair_fd_op_vtable, ZVFS_MODE_IFSOCK);
 
 	goto out;
 
@@ -437,7 +437,7 @@ static ssize_t spair_write(void *obj, const void *buffer, size_t count)
 
 	have_local_sem = true;
 
-	remote = z_get_fd_obj(spair->remote,
+	remote = zvfs_get_fd_obj(spair->remote,
 		(const struct fd_op_vtable *)&spair_fd_op_vtable, 0);
 
 	if (remote == NULL) {
@@ -501,7 +501,7 @@ static ssize_t spair_write(void *obj, const void *buffer, size_t count)
 				goto out;
 			}
 
-			remote = z_get_fd_obj(spair->remote,
+			remote = zvfs_get_fd_obj(spair->remote,
 				(const struct fd_op_vtable *)
 				&spair_fd_op_vtable, 0);
 
@@ -788,7 +788,7 @@ static int zsock_poll_prepare_ctx(struct spair *const spair,
 			goto out;
 		}
 
-		remote = z_get_fd_obj(spair->remote,
+		remote = zvfs_get_fd_obj(spair->remote,
 			(const struct fd_op_vtable *)
 			&spair_fd_op_vtable, 0);
 
@@ -838,7 +838,7 @@ static int zsock_poll_update_ctx(struct spair *const spair,
 			goto pollout_done;
 		}
 
-		remote = z_get_fd_obj(spair->remote,
+		remote = zvfs_get_fd_obj(spair->remote,
 			(const struct fd_op_vtable *) &spair_fd_op_vtable, 0);
 
 		__ASSERT(remote != NULL, "remote is NULL");

--- a/subsys/net/lib/sockets/sockets_can.c
+++ b/subsys/net/lib/sockets/sockets_can.c
@@ -58,14 +58,14 @@ int zcan_socket(int family, int type, int proto)
 	int fd;
 	int ret;
 
-	fd = z_reserve_fd();
+	fd = zvfs_reserve_fd();
 	if (fd < 0) {
 		return -1;
 	}
 
 	ret = net_context_get(family, type, proto, &ctx);
 	if (ret < 0) {
-		z_free_fd(fd);
+		zvfs_free_fd(fd);
 		errno = -ret;
 		return -1;
 	}
@@ -80,7 +80,7 @@ int zcan_socket(int family, int type, int proto)
 	 */
 	k_condvar_init(&ctx->cond.recv);
 
-	z_finalize_typed_fd(fd, ctx, (const struct fd_op_vtable *)&can_sock_fd_op_vtable,
+	zvfs_finalize_typed_fd(fd, ctx, (const struct fd_op_vtable *)&can_sock_fd_op_vtable,
 			    ZVFS_MODE_IFSOCK);
 
 	return fd;

--- a/subsys/net/lib/sockets/sockets_net_mgmt.c
+++ b/subsys/net/lib/sockets/sockets_net_mgmt.c
@@ -69,7 +69,7 @@ int znet_mgmt_socket(int family, int type, int proto)
 		return -1;
 	}
 
-	fd = z_reserve_fd();
+	fd = zvfs_reserve_fd();
 	if (fd < 0) {
 		errno = ENOSPC;
 		return -1;
@@ -80,7 +80,7 @@ int znet_mgmt_socket(int family, int type, int proto)
 	mgmt->alloc_timeout = MSG_ALLOC_TIMEOUT;
 	mgmt->wait_timeout = K_FOREVER;
 
-	z_finalize_typed_fd(fd, mgmt, (const struct fd_op_vtable *)&net_mgmt_sock_fd_op_vtable,
+	zvfs_finalize_typed_fd(fd, mgmt, (const struct fd_op_vtable *)&net_mgmt_sock_fd_op_vtable,
 			    ZVFS_MODE_IFSOCK);
 
 	return fd;

--- a/subsys/net/lib/sockets/sockets_packet.c
+++ b/subsys/net/lib/sockets/sockets_packet.c
@@ -46,7 +46,7 @@ static int zpacket_socket(int family, int type, int proto)
 	int fd;
 	int ret;
 
-	fd = z_reserve_fd();
+	fd = zvfs_reserve_fd();
 	if (fd < 0) {
 		return -1;
 	}
@@ -67,7 +67,7 @@ static int zpacket_socket(int family, int type, int proto)
 
 	ret = net_context_get(family, type, proto, &ctx);
 	if (ret < 0) {
-		z_free_fd(fd);
+		zvfs_free_fd(fd);
 		errno = -ret;
 		return -1;
 	}
@@ -77,7 +77,7 @@ static int zpacket_socket(int family, int type, int proto)
 
 	/* recv_q and accept_q are in union */
 	k_fifo_init(&ctx->recv_q);
-	z_finalize_typed_fd(fd, ctx, (const struct fd_op_vtable *)&packet_sock_fd_op_vtable,
+	zvfs_finalize_typed_fd(fd, ctx, (const struct fd_op_vtable *)&packet_sock_fd_op_vtable,
 			    ZVFS_MODE_IFSOCK);
 
 	return fd;

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -2060,7 +2060,7 @@ static int protocol_check(int family, int type, int *proto)
 static int ztls_socket(int family, int type, int proto)
 {
 	enum net_ip_protocol_secure tls_proto = proto;
-	int fd = z_reserve_fd();
+	int fd = zvfs_reserve_fd();
 	int sock = -1;
 	int ret;
 	struct tls_context *ctx;
@@ -2090,7 +2090,7 @@ static int ztls_socket(int family, int type, int proto)
 	ctx->type = (proto == IPPROTO_TCP) ? SOCK_STREAM : SOCK_DGRAM;
 	ctx->sock = sock;
 
-	z_finalize_typed_fd(fd, ctx, (const struct fd_op_vtable *)&tls_sock_fd_op_vtable,
+	zvfs_finalize_typed_fd(fd, ctx, (const struct fd_op_vtable *)&tls_sock_fd_op_vtable,
 			    ZVFS_MODE_IFSOCK);
 
 	return fd;
@@ -2099,7 +2099,7 @@ release_tls:
 	(void)tls_release(ctx);
 
 free_fd:
-	z_free_fd(fd);
+	zvfs_free_fd(fd);
 
 	return -1;
 }
@@ -2198,7 +2198,7 @@ int ztls_accept_ctx(struct tls_context *parent, struct sockaddr *addr,
 	struct tls_context *child = NULL;
 	int ret, err, fd, sock;
 
-	fd = z_reserve_fd();
+	fd = zvfs_reserve_fd();
 	if (fd < 0) {
 		return -1;
 	}
@@ -2218,7 +2218,7 @@ int ztls_accept_ctx(struct tls_context *parent, struct sockaddr *addr,
 		goto error;
 	}
 
-	z_finalize_typed_fd(fd, child, (const struct fd_op_vtable *)&tls_sock_fd_op_vtable,
+	zvfs_finalize_typed_fd(fd, child, (const struct fd_op_vtable *)&tls_sock_fd_op_vtable,
 			    ZVFS_MODE_IFSOCK);
 
 	child->sock = sock;
@@ -2252,7 +2252,7 @@ error:
 		__ASSERT(err == 0, "Child socket close failed");
 	}
 
-	z_free_fd(fd);
+	zvfs_free_fd(fd);
 
 	errno = -ret;
 	return -1;
@@ -3000,7 +3000,7 @@ static int ztls_poll_prepare_ctx(struct tls_context *ctx,
 		pfd->events &= ~ZSOCK_POLLIN;
 	}
 
-	obj = z_get_fd_obj_and_vtable(
+	obj = zvfs_get_fd_obj_and_vtable(
 		ctx->sock, (const struct fd_op_vtable **)&vtable, &lock);
 	if (obj == NULL) {
 		ret = -EBADF;
@@ -3009,7 +3009,7 @@ static int ztls_poll_prepare_ctx(struct tls_context *ctx,
 
 	(void)k_mutex_lock(lock, K_FOREVER);
 
-	ret = z_fdtable_call_ioctl(vtable, obj, ZFD_IOCTL_POLL_PREPARE,
+	ret = zvfs_fdtable_call_ioctl(vtable, obj, ZFD_IOCTL_POLL_PREPARE,
 				   pfd, pev, pev_end);
 	if (ret != 0) {
 		goto exit;
@@ -3195,7 +3195,7 @@ static int ztls_poll_update_ctx(struct tls_context *ctx,
 	int ret;
 	short events = pfd->events;
 
-	obj = z_get_fd_obj_and_vtable(
+	obj = zvfs_get_fd_obj_and_vtable(
 		ctx->sock, (const struct fd_op_vtable **)&vtable, &lock);
 	if (obj == NULL) {
 		return -EBADF;
@@ -3210,7 +3210,7 @@ static int ztls_poll_update_ctx(struct tls_context *ctx,
 		 * to monitor the underlying socket now.
 		 */
 		if ((*pev)->state != K_POLL_STATE_NOT_READY) {
-			ret = z_fdtable_call_ioctl(vtable, obj,
+			ret = zvfs_fdtable_call_ioctl(vtable, obj,
 						   ZFD_IOCTL_POLL_PREPARE,
 						   pfd, pev, *pev + 1);
 			if (ret != 0 && ret != -EALREADY) {
@@ -3232,7 +3232,7 @@ static int ztls_poll_update_ctx(struct tls_context *ctx,
 		pfd->events &= ~ZSOCK_POLLIN;
 	}
 
-	ret = z_fdtable_call_ioctl(vtable, obj, ZFD_IOCTL_POLL_UPDATE,
+	ret = zvfs_fdtable_call_ioctl(vtable, obj, ZFD_IOCTL_POLL_UPDATE,
 				   pfd, pev);
 	if (ret != 0) {
 		goto exit;
@@ -3312,7 +3312,7 @@ static int ztls_poll_offload(struct zsock_pollfd *fds, int nfds, int timeout)
 	for (i = 0; i < nfds; i++) {
 		fd_backup[i] = fds[i].fd;
 
-		ctx = z_get_fd_obj(fds[i].fd,
+		ctx = zvfs_get_fd_obj(fds[i].fd,
 				   (const struct fd_op_vtable *)
 						     &tls_sock_fd_op_vtable,
 				   0);
@@ -3334,7 +3334,7 @@ static int ztls_poll_offload(struct zsock_pollfd *fds, int nfds, int timeout)
 	}
 
 	/* Get offloaded sockets vtable. */
-	ctx = z_get_fd_obj_and_vtable(fds[0].fd,
+	ctx = zvfs_get_fd_obj_and_vtable(fds[0].fd,
 				      (const struct fd_op_vtable **)&vtable,
 				      NULL);
 	if (ctx == NULL) {
@@ -3349,7 +3349,7 @@ static int ztls_poll_offload(struct zsock_pollfd *fds, int nfds, int timeout)
 			fds[i].revents = 0;
 		}
 
-		ret = z_fdtable_call_ioctl(vtable, ctx, ZFD_IOCTL_POLL_OFFLOAD,
+		ret = zvfs_fdtable_call_ioctl(vtable, ctx, ZFD_IOCTL_POLL_OFFLOAD,
 					   fds, nfds, remaining);
 		if (ret < 0) {
 			goto exit;
@@ -3359,7 +3359,7 @@ static int ztls_poll_offload(struct zsock_pollfd *fds, int nfds, int timeout)
 		ret = 0;
 
 		for (i = 0; i < nfds; i++) {
-			ctx = z_get_fd_obj(fd_backup[i],
+			ctx = zvfs_get_fd_obj(fd_backup[i],
 					   (const struct fd_op_vtable *)
 							&tls_sock_fd_op_vtable,
 					   0);
@@ -3643,7 +3643,7 @@ mbedtls_ssl_context *ztls_get_mbedtls_ssl_context(int fd)
 {
 	struct tls_context *ctx;
 
-	ctx = z_get_fd_obj(fd, (const struct fd_op_vtable *)
+	ctx = zvfs_get_fd_obj(fd, (const struct fd_op_vtable *)
 					&tls_sock_fd_op_vtable, EBADF);
 	if (ctx == NULL) {
 		return NULL;
@@ -3677,7 +3677,7 @@ static int tls_sock_ioctl_vmeth(void *obj, unsigned int request, va_list args)
 		void *fd_obj;
 		int ret;
 
-		fd_obj = z_get_fd_obj_and_vtable(ctx->sock,
+		fd_obj = zvfs_get_fd_obj_and_vtable(ctx->sock,
 				(const struct fd_op_vtable **)&vtable, &lock);
 		if (fd_obj == NULL) {
 			errno = EBADF;

--- a/subsys/net/lib/websocket/websocket.c
+++ b/subsys/net/lib/websocket/websocket.c
@@ -362,14 +362,14 @@ int websocket_connect(int sock, struct websocket_request *wreq,
 
 	ctx->user_data = user_data;
 
-	fd = z_reserve_fd();
+	fd = zvfs_reserve_fd();
 	if (fd < 0) {
 		ret = -ENOSPC;
 		goto out;
 	}
 
 	ctx->sock = fd;
-	z_finalize_typed_fd(fd, ctx, (const struct fd_op_vtable *)&websocket_fd_op_vtable,
+	zvfs_finalize_typed_fd(fd, ctx, (const struct fd_op_vtable *)&websocket_fd_op_vtable,
 			    ZVFS_MODE_IFSOCK);
 
 	/* Call the user specified callback and if it accepts the connection
@@ -468,7 +468,7 @@ static inline int websocket_poll_offload(struct zsock_pollfd *fds, int nfds,
 	for (i = 0; i < nfds; i++) {
 		fd_backup[i] = fds[i].fd;
 
-		ctx = z_get_fd_obj(fds[i].fd,
+		ctx = zvfs_get_fd_obj(fds[i].fd,
 				   (const struct fd_op_vtable *)
 						     &websocket_fd_op_vtable,
 				   0);
@@ -480,7 +480,7 @@ static inline int websocket_poll_offload(struct zsock_pollfd *fds, int nfds,
 	}
 
 	/* Get offloaded sockets vtable. */
-	ctx = z_get_fd_obj_and_vtable(fds[0].fd,
+	ctx = zvfs_get_fd_obj_and_vtable(fds[0].fd,
 				      (const struct fd_op_vtable **)&vtable,
 				      NULL);
 	if (ctx == NULL) {
@@ -489,7 +489,7 @@ static inline int websocket_poll_offload(struct zsock_pollfd *fds, int nfds,
 		goto exit;
 	}
 
-	ret = z_fdtable_call_ioctl(vtable, ctx, ZFD_IOCTL_POLL_OFFLOAD,
+	ret = zvfs_fdtable_call_ioctl(vtable, ctx, ZFD_IOCTL_POLL_OFFLOAD,
 				   fds, nfds, timeout);
 
 exit:
@@ -526,7 +526,7 @@ static int websocket_ioctl_vmeth(void *obj, unsigned int request, va_list args)
 		const struct fd_op_vtable *vtable;
 		void *core_obj;
 
-		core_obj = z_get_fd_obj_and_vtable(
+		core_obj = zvfs_get_fd_obj_and_vtable(
 				ctx->real_sock,
 				(const struct fd_op_vtable **)&vtable,
 				NULL);
@@ -645,7 +645,7 @@ int websocket_send_msg(int ws_sock, const uint8_t *payload, size_t payload_len,
 		return -EINVAL;
 	}
 
-	ctx = z_get_fd_obj(ws_sock, NULL, 0);
+	ctx = zvfs_get_fd_obj(ws_sock, NULL, 0);
 	if (ctx == NULL) {
 		return -EBADF;
 	}
@@ -932,7 +932,7 @@ int websocket_recv_msg(int ws_sock, uint8_t *buf, size_t buf_len,
 	end = sys_timepoint_calc(tout);
 
 #if defined(CONFIG_NET_TEST)
-	struct test_data *test_data = z_get_fd_obj(ws_sock, NULL, 0);
+	struct test_data *test_data = zvfs_get_fd_obj(ws_sock, NULL, 0);
 
 	if (test_data == NULL) {
 		return -EBADF;
@@ -940,7 +940,7 @@ int websocket_recv_msg(int ws_sock, uint8_t *buf, size_t buf_len,
 
 	ctx = test_data->ctx;
 #else
-	ctx = z_get_fd_obj(ws_sock, NULL, 0);
+	ctx = zvfs_get_fd_obj(ws_sock, NULL, 0);
 	if (ctx == NULL) {
 		return -EBADF;
 	}
@@ -1164,14 +1164,14 @@ int websocket_register(int sock, uint8_t *recv_buf, size_t recv_buf_len)
 	ctx->recv_buf.buf = recv_buf;
 	ctx->recv_buf.size = recv_buf_len;
 
-	fd = z_reserve_fd();
+	fd = zvfs_reserve_fd();
 	if (fd < 0) {
 		ret = -ENOSPC;
 		goto out;
 	}
 
 	ctx->sock = fd;
-	z_finalize_typed_fd(fd, ctx, (const struct fd_op_vtable *)&websocket_fd_op_vtable,
+	zvfs_finalize_typed_fd(fd, ctx, (const struct fd_op_vtable *)&websocket_fd_op_vtable,
 			    ZVFS_MODE_IFSOCK);
 
 	NET_DBG("[%p] WS connection to peer established (fd %d)", ctx, fd);

--- a/tests/net/socket/offload_dispatcher/src/main.c
+++ b/tests/net/socket/offload_dispatcher/src/main.c
@@ -271,13 +271,13 @@ static const struct socket_op_vtable offload_1_socket_fd_op_vtable = {
 
 int offload_1_socket(int family, int type, int proto)
 {
-	int fd = z_reserve_fd();
+	int fd = zvfs_reserve_fd();
 
 	if (fd < 0) {
 		return -1;
 	}
 
-	z_finalize_typed_fd(fd, &test_socket_ctx[OFFLOAD_1],
+	zvfs_finalize_typed_fd(fd, &test_socket_ctx[OFFLOAD_1],
 			    (const struct fd_op_vtable *)&offload_1_socket_fd_op_vtable,
 			    ZVFS_MODE_IFSOCK);
 
@@ -333,13 +333,13 @@ static const struct socket_op_vtable offload_2_socket_fd_op_vtable = {
 
 int offload_2_socket(int family, int type, int proto)
 {
-	int fd = z_reserve_fd();
+	int fd = zvfs_reserve_fd();
 
 	if (fd < 0) {
 		return -1;
 	}
 
-	z_finalize_typed_fd(fd, &test_socket_ctx[OFFLOAD_2],
+	zvfs_finalize_typed_fd(fd, &test_socket_ctx[OFFLOAD_2],
 			    (const struct fd_op_vtable *)&offload_2_socket_fd_op_vtable,
 			    ZVFS_MODE_IFSOCK);
 
@@ -775,7 +775,7 @@ ZTEST(net_socket_offload_tls, test_tls_native_iface_offloaded)
 	zassert_false(test_socket_ctx[OFFLOAD_2].socket_called,
 		     "TLS socket dispatched to wrong iface");
 
-	obj = z_get_fd_obj_and_vtable(test_sock, &vtable, NULL);
+	obj = zvfs_get_fd_obj_and_vtable(test_sock, &vtable, NULL);
 	zassert_not_null(obj, "No obj found");
 	zassert_true(net_socket_is_tls(obj), "Socket is not a native TLS sock");
 
@@ -822,7 +822,7 @@ ZTEST(net_socket_offload_tls, test_tls_native_iface_native)
 	zassert_false(test_socket_ctx[OFFLOAD_2].socket_called,
 		     "TLS socket dispatched to wrong iface");
 
-	obj = z_get_fd_obj_and_vtable(test_sock, &vtable, NULL);
+	obj = zvfs_get_fd_obj_and_vtable(test_sock, &vtable, NULL);
 	zassert_not_null(obj, "No obj found");
 	zassert_true(net_socket_is_tls(obj), "Socket is not a native TLS sock");
 

--- a/tests/net/socket/websocket/src/main.c
+++ b/tests/net/socket/websocket/src/main.c
@@ -57,9 +57,9 @@ static int test_fd_alloc(void *obj)
 {
 	int fd;
 
-	fd = z_reserve_fd();
+	fd = zvfs_reserve_fd();
 	zassert_not_equal(fd, -1, "Failed to allocate FD");
-	z_finalize_fd(fd, obj, NULL);
+	zvfs_finalize_fd(fd, obj, NULL);
 
 	return fd;
 }
@@ -82,7 +82,7 @@ static int test_recv_buf(uint8_t *input_buf, size_t input_len,
 	ret = websocket_recv_msg(fd, recv_buffer, recv_len,
 				 msg_type, remaining, 0);
 
-	z_free_fd(fd);
+	zvfs_free_fd(fd);
 
 	return ret;
 }
@@ -395,7 +395,7 @@ ZTEST(net_websocket, test_send_and_recv_lorem_ipsum)
 		      "Should have sent %zd bytes but sent %d instead",
 		      test_msg_len, ret);
 
-	z_free_fd(fd);
+	zvfs_free_fd(fd);
 }
 
 ZTEST(net_websocket, test_recv_two_large_split_msg)
@@ -418,7 +418,7 @@ ZTEST(net_websocket, test_recv_two_large_split_msg)
 		      "1st should have sent %zd bytes but sent %d instead",
 		      test_msg_len, ret);
 
-	z_free_fd(fd);
+	zvfs_free_fd(fd);
 }
 
 ZTEST(net_websocket, test_send_and_recv_empty_pong)
@@ -439,7 +439,7 @@ ZTEST(net_websocket, test_send_and_recv_empty_pong)
 	zassert_equal(ret, test_msg_len, "Should have sent %zd bytes but sent %d instead",
 		      test_msg_len, ret);
 
-	z_free_fd(fd);
+	zvfs_free_fd(fd);
 }
 
 ZTEST(net_websocket, test_recv_in_small_buffer)


### PR DESCRIPTION
```shell
searching for files that use z_alloc_fd...
replacing z_alloc_fd with zvfs_alloc_fd in 3 files...
searching for files that use z_fdtable_call_ioctl...
replacing z_fdtable_call_ioctl with zvfs_fdtable_call_ioctl in 5 files...
searching for files that use z_finalize_fd...
replacing z_finalize_fd with zvfs_finalize_fd in 8 files...
searching for files that use z_finalize_typed_fd...
replacing z_finalize_typed_fd with zvfs_finalize_typed_fd in 17 files...
searching for files that use z_free_fd...
replacing z_free_fd with zvfs_free_fd in 14 files...
searching for files that use z_get_fd_obj...
replacing z_get_fd_obj with zvfs_get_fd_obj in 14 files...
searching for files that use z_get_fd_obj_and_vtable...
searching for files that use z_get_obj_lock_and_cond...
replacing z_get_obj_lock_and_cond with zvfs_get_obj_lock_and_cond in 3 files...
searching for files that use z_reserve_fd...
replacing z_reserve_fd with zvfs_reserve_fd in 21 files...
```

[fdtable-z-to-zvfs.sh.txt](https://github.com/user-attachments/files/15975374/fdtable-z-to-zvfs.sh.txt)

Fixes #74538