### PR TITLE
lib: smf: use `while (true)` in `get_child_of` for better clarity

### DIFF
--- a/lib/smf/smf.c
+++ b/lib/smf/smf.c
@@ -36,7 +36,9 @@ static bool share_paren(const struct smf_state *test_state, const struct smf_sta
 static const struct smf_state *get_child_of(const struct smf_state *states,
 					    const struct smf_state *parent)
 {
-	for (const struct smf_state *tmp = states;; tmp = tmp->parent) {
+	const struct smf_state *tmp = states;
+
+	while (true) {
 		if (tmp->parent == parent) {
 			return tmp;
 		}
@@ -44,9 +46,9 @@ static const struct smf_state *get_child_of(const struct smf_state *states,
 		if (tmp->parent == NULL) {
 			return NULL;
 		}
-	}
 
-	return NULL;
+		tmp = tmp->parent;
+	}
 }
 
 static const struct smf_state *get_last_of(const struct smf_state *states)


### PR DESCRIPTION
Replace the condition-less `for` loop (`;;`) in `get_child_of` with a `while (true)` loop and remove the redundant `return NULL;` at the end, which is never reached.

This change aims to enhance readability since `while (true)` is better suited for this scenario.