### PR TITLE
net: ip: fix typo

### DIFF
--- a/subsys/net/ip/Kconfig.tcp
+++ b/subsys/net/ip/Kconfig.tcp
@@ -93,7 +93,7 @@ config NET_TCP_RANDOMIZED_RTO
 	  due to a packet collision. If the transmission timeout is the same
 	  both stacks will retry at the same moment resulting in another
 	  collision. By introducing a randomized retry timeout, the chance of
-	  a second collision is reduced and it reduces furter the more
+	  a second collision is reduced and it reduces further the more
 	  retransmissions occur.
 
 config NET_TCP_RETRY_COUNT

--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -592,7 +592,7 @@ static enum net_verdict conn_raw_socket(struct net_pkt *pkt,
 
 	/*
 	 * After l2 processed only deliver protocol matched pkt,
-	 * unless the connetion protocol is all packets
+	 * unless the connection protocol is all packets
 	 */
 	if (type == SOCK_DGRAM && net_pkt_is_l2_processed(pkt) &&
 	    conn->proto != ETH_P_ALL &&
@@ -745,7 +745,7 @@ enum net_verdict net_conn_input(struct net_pkt *pkt,
 			/* We might have a match for v4-to-v6 mapping, check more */
 		}
 
-		/* Is the candidate connection matching the packet's protocol wihin the family? */
+		/* Is the candidate connection matching the packet's protocol within the family? */
 		if (conn->proto != proto) {
 			/* For packet socket data, the proto is set to ETH_P_ALL
 			 * or IPPROTO_RAW but the listener might have a specific

--- a/subsys/net/ip/ipv4.c
+++ b/subsys/net/ip/ipv4.c
@@ -196,7 +196,7 @@ int net_ipv4_parse_hdr_options(struct net_pkt *pkt,
 			break;
 
 		case NET_IPV4_OPTS_EO:
-			/* Options length should be zero, when cursor reachs to
+			/* Options length should be zero, when cursor reaches to
 			 * End of options.
 			 */
 			if (total_opts_len) {

--- a/subsys/net/ip/ipv6.h
+++ b/subsys/net/ip/ipv6.h
@@ -244,7 +244,7 @@ net_ipv6_mld_leave(struct net_if *iface, const struct in6_addr *addr)
  * @brief Send MLDv2 report message with a single entry.
  *
  * @param iface Network interface where message is sent
- * @param addr Mutlicast group
+ * @param addr Multicast group
  * @param mode MLDv2 mode (NET_IPV6_MLDv2_MODE_IS_INCLUDE NET_IPV6_MLDv2_MODE_IS_EXCLUDE)
  *
  * @return Return 0 if leaving is done, <0 otherwise.

--- a/subsys/net/ip/ipv6_pe.c
+++ b/subsys/net/ip/ipv6_pe.c
@@ -38,7 +38,7 @@ BUILD_ASSERT(CONFIG_NET_IPV6_PE_TEMP_PREFERRED_LIFETIME <
 	     CONFIG_NET_IPV6_PE_TEMP_VALID_LIFETIME);
 
 /* IPv6 privacy extension (RFC 8981) constants. Note that the code uses
- * seconds value internally for applicaple options. These are also values
+ * seconds value internally for applicable options. These are also values
  * that can be changed at runtime if needed as recommended in RFC 8981
  * chapter 3.6.
  */

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -2437,7 +2437,7 @@ static struct tcp *tcp_conn_new(struct net_pkt *pkt)
 	 * address, remote port) to be properly identified. Remote address and port
 	 * are already copied above from conn->dst. The call to net_context_bind
 	 * with the prepared local_addr further copies the local address. However,
-	 * this call wont copy the local port, as the bind would then fail due to
+	 * this call won't copy the local port, as the bind would then fail due to
 	 * an address/port reuse without the REUSEPORT option enables for both
 	 * connections. Therefore, we copy the port after the bind call.
 	 * It is safe to bind to this address/port combination, as the new TCP
@@ -3263,7 +3263,7 @@ next_state:
 				 * RISK:
 				 * There is a tiny risk of creating a ACK loop this way when
 				 * both ends of the connection are out of order due to packet
-				 * loss is a simulatanious bidirectional data flow.
+				 * loss is a simultaneous bidirectional data flow.
 				 */
 				tcp_out(conn, ACK); /* peer has resent */
 
@@ -4304,7 +4304,8 @@ enum net_verdict tp_input(struct net_conn *net_conn,
 		conn = (void *)sys_slist_peek_head(&tcp_conns);
 		tcp_to_json(conn, buf, &json_len);
 		break;
-	case TP_DEBUG_STOP: case TP_DEBUG_CONTINUE:
+	case TP_DEBUG_STOP:
+	case TP_DEBUG_CONTINUE:
 		tp_state = tp->type;
 		break;
 	default:
@@ -4535,7 +4536,7 @@ void net_tcp_init(void)
 		tcp_max_timeout_ms += rto;
 		rto += rto >> 1;
 	}
-	/* At the last timeout cicle */
+	/* At the last timeout cycle */
 	tcp_max_timeout_ms += tcp_rto;
 
 	/* When CONFIG_NET_TCP_RANDOMIZED_RTO is active in can be worse case 1.5 times larger */

--- a/subsys/net/ip/utils.c
+++ b/subsys/net/ip/utils.c
@@ -548,7 +548,7 @@ uint16_t calc_chksum(uint16_t sum_in, const uint8_t *data, size_t len)
 	size_t pending = len;
 	int odd_start = ((uintptr_t)data & 0x01);
 
-	/* Sum in is in host endiannes, working order endiannes is both dependent on endianness
+	/* Sum in is in host endianness, working order endianness is both dependent on endianness
 	 * and the offset of starting
 	 */
 	if (odd_start == CHECKSUM_BIG_ENDIAN) {
@@ -600,7 +600,7 @@ uint16_t calc_chksum(uint16_t sum_in, const uint8_t *data, size_t len)
 		sum = (sum & 0xffff) + (sum >> 16);
 	}
 
-	/* Sum in is in host endiannes, working order endiannes is both dependent on endianness
+	/* Sum in is in host endianness, working order endianness is both dependent on endianness
 	 * and the offset of starting
 	 */
 	if (odd_start == CHECKSUM_BIG_ENDIAN) {


### PR DESCRIPTION
Utilize a code spell-checking tool to scan for and correct spelling errors in all files within the `subsys/net/ip` directory.