### PR TITLE
samples: sensor: qdec: fix mimxrt1050_evk build failure.

### DIFF
--- a/samples/sensor/qdec/boards/mimxrt1050_evk.overlay
+++ b/samples/sensor/qdec/boards/mimxrt1050_evk.overlay
@@ -37,11 +37,6 @@
 	status = "disabled";
 };
 
-/* disable to avoid encoder emulater conflict */
-&touch_controller {
-	status = "disabled";
-};
-
 &qdec1 {
 	status = "okay";
 	pinctrl-0 = <&pinmux_qdec1>;


### PR DESCRIPTION
Recent PR turned on test case for twister which revealed a bug with building the test case for RT1050 EVK. The touch_controller DTS node was removed a by commit 57ad325e and further deprecated by bde07beb5 when the platform was converted to tread displays as shields.

Fixes #74841