### PR TITLE
Bugfix/Fix LPADC MCXN947 test case failure

### DIFF
--- a/boards/nxp/frdm_mcxn947/doc/index.rst
+++ b/boards/nxp/frdm_mcxn947/doc/index.rst
@@ -84,7 +84,7 @@ The FRDM-MCXN947 board configuration supports the following hardware features:
 +-----------+------------+-------------------------------------+
 | USDHC     | on-chip    | sdhc                                |
 +-----------+------------+-------------------------------------+
-| VREF      | on-chip    | REGULATOR                           |
+| VREF      | on-chip    | regulator                           |
 +-----------+------------+-------------------------------------+
 | ADC       | on-chip    | adc                                 |
 +-----------+------------+-------------------------------------+

--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -266,6 +266,12 @@ Device Drivers and Devicetree
 * `st,lis2mdl` property `spi-full-duplex` changed to `duplex =
   SPI_FULL_DUPLEX`. Full duplex is now the default.
 
+* The DT property ``nxp,reference-supply`` of :dtcompatible:`nxp,lpc-lpadc` driver has
+  been removed, users should remove this property from their devicetree if it is present.
+  Added new phandle-array type DT property ``nxp,references``, the user can use this
+  property to specify the reference voltage and reference voltage value to be used by
+  the lpadc. (:github:`75005`)
+
 Analog-to-Digital Converter (ADC)
 =================================
 

--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -386,6 +386,10 @@ Drivers and Sensors
 
   * Added support for STM32H7R/S series.
 
+  * Changed phandle type DT property ``nxp,reference-supply`` to phandle-array type DT property
+    ``nxp,references`` in ``nxp,lpc-lpadc`` binding. The NXP LPADC driver now supports passing
+    the reference voltage value by using ``nxp,references``.
+
 * Auxiliary Display
 
 * Audio

--- a/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
@@ -298,7 +298,7 @@
 		#io-channel-cells = <1>;
 		dmas = <&dma0 21>, <&dma0 22>;
 		dma-names = "adc0-dma0", "adc0-dma1";
-		nxp,reference-supply = <&vref0>;
+		nxp,references = <&vref0 1800>;
 		clocks = <&syscon MCUX_LPADC1_CLK>;
 	};
 
@@ -473,6 +473,7 @@
 		regulator-name = "lpc55s36-vref";
 		reg = <0xb5000 0x30>;
 		status = "disabled";
+		#nxp,reference-cells = <1>;
 		nxp,buffer-startup-delay-us = <400>;
 		nxp,bandgap-startup-time-us = <20>;
 	};

--- a/dts/arm/nxp/nxp_mcxn94x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn94x_common.dtsi
@@ -803,10 +803,12 @@
 		regulator-name = "mcxn94x-vref";
 		reg = <0x111000 0x14>;
 		status = "disabled";
+		#nxp,reference-cells = <1>;
 		nxp,buffer-startup-delay-us = <400>;
 		nxp,bandgap-startup-time-us = <20>;
 		regulator-min-microvolt = <1000000>;
 		regulator-max-microvolt = <2100000>;
+
 	};
 
 	lpadc0: lpadc@10d000 {
@@ -823,7 +825,7 @@
 		offset-value-b = <0>;
 		#io-channel-cells = <1>;
 		clocks = <&syscon MCUX_LPADC1_CLK>;
-		nxp,reference-supply = <&vref>;
+		nxp,references = <&vref 1800>;
 	};
 
 	lpadc1: lpadc@10e000 {

--- a/dts/bindings/adc/nxp,lpc-lpadc.yaml
+++ b/dts/bindings/adc/nxp,lpc-lpadc.yaml
@@ -71,8 +71,8 @@ properties:
     required: true
     description: Offset value B to use if CONFIG_LPADC_DO_OFFSET_CALIBRATION is false
 
-  nxp,reference-supply:
-    type: phandles
+  nxp,references:
+    type: phandle-array
     description: References to required regulators which must be enabled for LPADC to function
 
   "#io-channel-cells":

--- a/dts/bindings/regulator/nxp,vref.yaml
+++ b/dts/bindings/regulator/nxp,vref.yaml
@@ -33,3 +33,11 @@ properties:
     description: |
       Maximum bandgap startup time as specified in the
       appropriate device data sheet, in microseconds.
+
+  "#nxp,reference-cells":
+    type: int
+    const: 1
+    description: Number of items to expect in a vref specifier.
+
+nxp,reference-cells:
+  - vref_mv

--- a/samples/drivers/adc/adc_dt/sample.yaml
+++ b/samples/drivers/adc/adc_dt/sample.yaml
@@ -32,6 +32,7 @@ tests:
       - longan_nano
       - longan_nano/gd32vf103/lite
       - rd_rw612_bga
+      - frdm_mcxn947/mcxn947/cpu0
     integration_platforms:
       - nucleo_l073rz
       - nrf52840dk/nrf52840

--- a/tests/drivers/adc/adc_api/boards/frdm_mcxn947_mcxn947_cpu0.overlay
+++ b/tests/drivers/adc/adc_api/boards/frdm_mcxn947_mcxn947_cpu0.overlay
@@ -22,6 +22,7 @@
 		zephyr,reference = "ADC_REF_EXTERNAL1";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
+		zephyr,vref-mv = <1800>;
 		zephyr,input-positive = <MCUX_LPADC_CH1A>;
 	};
 
@@ -31,6 +32,7 @@
 		zephyr,reference = "ADC_REF_EXTERNAL1";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
+		zephyr,vref-mv = <1800>;
 		zephyr,input-positive = <MCUX_LPADC_CH2A>;
 	};
 };

--- a/tests/drivers/regulator/voltage/testcase.yaml
+++ b/tests/drivers/regulator/voltage/testcase.yaml
@@ -19,6 +19,7 @@ tests:
     platform_allow:
       - mimxrt685_evk/mimxrt685s/cm33
       - lpcxpresso55s36
+      - frdm_mcxn947/mcxn947/cpu0
     harness_config:
       fixture: gpio_loopback
   drivers.regulator.voltage.rpi_pico_vreg:


### PR DESCRIPTION
Change method to get adc ref voltage. When an application enables the USERSPACE, the driver cannot obtain the correct vref_mv by using 'CONTAINER_OF', because the z_vrf_adc_channel_setup function will not copy vref_mv from user space to kernel space.

Fixes #74842 