### PR TITLE
os: fdtable: include `zephyr/kernel.h` for `struct k_mutex`

### DIFF
--- a/include/zephyr/sys/fdtable.h
+++ b/include/zephyr/sys/fdtable.h
@@ -11,7 +11,7 @@
 
 /* FIXME: For native_posix ssize_t, off_t. */
 #include <zephyr/fs/fs.h>
-#include <zephyr/sys/mutex.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
 
 /* File mode bits */


### PR DESCRIPTION
Was getting the following error:
```
include/zephyr/sys/fdtable.h:150:38: warning: 'struct k_mutex' declared inside parameter list will not be visible outside of this definition or declaration
  150 |                               struct k_mutex **lock);
      |                                      ^~~~~~~
```
(#51667) tried to fix this by including `zephyr/sys/mutex.h`, but `struct k_mutex` is defined in `zephyr/kernel.h`, so include the latter instead.