### PR TITLE
shield: x_nucleo_iks4a1: support sht4x

### DIFF
--- a/boards/shields/x_nucleo_iks4a1/x_nucleo_iks4a1.overlay
+++ b/boards/shields/x_nucleo_iks4a1/x_nucleo_iks4a1.overlay
@@ -10,6 +10,7 @@
 		accel0 = &lsm6dso16is_6a_x_nucleo_iks4a1;
 		accel1 = &lsm6dsv16x_6b_x_nucleo_iks4a1;
 		press0 = &lps22df_5d_x_nucleo_iks4a1;
+		temphum0 = &sht4x_44_x_nucleo_iks4a1;
 	};
 };
 
@@ -44,5 +45,12 @@
 		reg = <0x5d>;
 		drdy-pulsed;
 		drdy-gpios =  <&arduino_header 12 GPIO_ACTIVE_HIGH>; /* D6 (PB10) */
+	};
+
+	sht4x_44_x_nucleo_iks4a1: sht4x@44 {
+		status = "okay";
+		compatible = "sensirion,sht4x";
+		reg = <0x44>;
+		repeatability = <2>;
 	};
 };

--- a/boards/shields/x_nucleo_iks4a1/x_nucleo_iks4a1_shub1.overlay
+++ b/boards/shields/x_nucleo_iks4a1/x_nucleo_iks4a1_shub1.overlay
@@ -7,6 +7,7 @@
 / {
 	aliases {
 		accel0 = &lsm6dsv16x_6b_x_nucleo_iks4a1;
+		temphum0 = &sht4x_44_x_nucleo_iks4a1;
 	};
 };
 
@@ -18,5 +19,12 @@
 		gyro-odr = <0x02>;
 		int1-gpios =  <&arduino_header 11 GPIO_ACTIVE_HIGH>; /* D5 */
 		drdy-pin = <1>;
+	};
+
+	sht4x_44_x_nucleo_iks4a1: sht4x@44 {
+		status = "okay";
+		compatible = "sensirion,sht4x";
+		reg = <0x44>;
+		repeatability = <2>;
 	};
 };

--- a/boards/shields/x_nucleo_iks4a1/x_nucleo_iks4a1_shub2.overlay
+++ b/boards/shields/x_nucleo_iks4a1/x_nucleo_iks4a1_shub2.overlay
@@ -7,6 +7,7 @@
 / {
 	aliases {
 		accel0 = &lsm6dso16is_6a_x_nucleo_iks4a1_shub;
+		temphum0 = &sht4x_44_x_nucleo_iks4a1;
 	};
 };
 
@@ -16,5 +17,12 @@
 		reg = <0x6a>;
 		irq-gpios =  <&arduino_header 5 GPIO_ACTIVE_HIGH>; /* A5 */
 		drdy-pin = <1>;
+	};
+
+	sht4x_44_x_nucleo_iks4a1: sht4x@44 {
+		status = "okay";
+		compatible = "sensirion,sht4x";
+		reg = <0x44>;
+		repeatability = <2>;
 	};
 };


### PR DESCRIPTION
The pr #67912 added the support of the x-nucleo-iks4a1 shield.
Although the shield have on board the sht4x temperature/humidity sensor, the binding was non-existent.
This PR add the missing sht4x bindings.