### PR TITLE
samples: Use DEFAULT_IMAGE for sysbuild

### DIFF
--- a/samples/drivers/ipm/ipm_mcux/sysbuild.cmake
+++ b/samples/drivers/ipm/ipm_mcux/sysbuild.cmake
@@ -12,8 +12,8 @@ ExternalZephyrProject_Add(
 # Add dependencies so that the remote sample will be built first
 # This is required because some primary cores need information from the
 # remote core's build, such as the output image's LMA
-add_dependencies(ipm_mcux ipm_mcux_remote)
-sysbuild_add_dependencies(CONFIGURE ipm_mcux ipm_mcux_remote)
+add_dependencies(${DEFAULT_IMAGE} ipm_mcux_remote)
+sysbuild_add_dependencies(CONFIGURE ${DEFAULT_IMAGE} ipm_mcux_remote)
 
 if(SB_CONFIG_BOOTLOADER_MCUBOOT)
   # Make sure MCUboot is flashed first

--- a/samples/subsys/ipc/openamp/sysbuild.cmake
+++ b/samples/subsys/ipc/openamp/sysbuild.cmake
@@ -12,8 +12,8 @@ ExternalZephyrProject_Add(
 # Add dependencies so that the remote sample will be built first
 # This is required because some primary cores need information from the
 # remote core's build, such as the output image's LMA
-add_dependencies(openamp openamp_remote)
-sysbuild_add_dependencies(CONFIGURE openamp openamp_remote)
+add_dependencies(${DEFAULT_IMAGE} openamp_remote)
+sysbuild_add_dependencies(CONFIGURE ${DEFAULT_IMAGE} openamp_remote)
 
 if(SB_CONFIG_BOOTLOADER_MCUBOOT)
   # Make sure MCUboot is flashed first

--- a/samples/subsys/ipc/rpmsg_service/sysbuild.cmake
+++ b/samples/subsys/ipc/rpmsg_service/sysbuild.cmake
@@ -12,4 +12,4 @@ ExternalZephyrProject_Add(
     BOARD ${SB_CONFIG_RPMSG_REMOTE_BOARD}
   )
 
-add_dependencies(rpmsg_service rpmsg_service_remote)
+add_dependencies(${DEFAULT_IMAGE} rpmsg_service_remote)

--- a/samples/sysbuild/hello_world/sysbuild.cmake
+++ b/samples/sysbuild/hello_world/sysbuild.cmake
@@ -11,5 +11,5 @@ ExternalZephyrProject_Add(
   BOARD ${SB_CONFIG_REMOTE_BOARD}
 )
 
-add_dependencies(hello_world remote)
-sysbuild_add_dependencies(FLASH hello_world remote)
+add_dependencies(${DEFAULT_IMAGE} remote)
+sysbuild_add_dependencies(FLASH ${DEFAULT_IMAGE} remote)


### PR DESCRIPTION
Uses the variable for the default image when adding sysbuild dependencies so that they can be copied out-of-tree and still work