### PR TITLE
drivers: mdio_esp32: let the REF_CLK be initialized before the PHY.

### DIFF
--- a/dts/bindings/mdio/espressif,esp32-mdio.yaml
+++ b/dts/bindings/mdio/espressif,esp32-mdio.yaml
@@ -8,3 +8,9 @@ compatible: "espressif,esp32-mdio"
 include:
   - name: mdio-controller.yaml
   - name: pinctrl-device.yaml
+
+properties:
+  ref-clk-output-gpios:
+    type: phandle-array
+    description: |
+      GPIO to output RMII Clock.


### PR DESCRIPTION
When GPIO17 or 16 is used as an external REF_CLK signal, the output is enabled in eth_esp32.c This was added in PR number #65759 (by @bbilas ) and then refined in PR #74442 (by @sylvioalves). However this does not work for PHYs which need the REF_CLK for MDIO communication, such as LAN8720A. In such cases phy_mii driver tries to get the ID of such a PHY before REF_CLK is present. Therefore in this PR I propose to move REF_CLK initialization from eth_esp32.c to mdio_esp32.c which gets initialized before PHY and ETH. 

There's a topic about this as well: https://github.com/zephyrproject-rtos/zephyr/discussions/68907