### PR TITLE
drivers: nxp_s32_canxl: improve CANXL error report

### DIFF
--- a/drivers/can/can_nxp_s32_canxl.c
+++ b/drivers/can/can_nxp_s32_canxl.c
@@ -56,6 +56,17 @@
 #define CAN_NXP_S32_FD_MODE 1
 #endif
 
+#define BCANXL_ST_STFERR_MASK   BIT(4)
+#define BCANXL_ST_FRMERR_MASK   BIT(5)
+#define BCANXL_ST_CRCERR_MASK   BIT(6)
+#define BCANXL_ST_ACKERR_MASK   BIT(7)
+#define BCANXL_ST_BIT0ERR_MASK  BIT(8)
+#define BCANXL_ST_BIT1ERR_MASK  BIT(9)
+#define BCANXL_ST_OVRERR_MASK   BIT(15)
+#define BCANXL_ST_FLTCONF(x) (uint8_t)((x << BCANXL_ST_FLTCONF_SHIFT) & BCANXL_ST_FLTCONF_MASK)
+
+#define CANXL_CLEAR_ALL_ERRORS  0x7FFF0F00U
+
 LOG_MODULE_REGISTER(nxp_s32_canxl, CONFIG_CAN_LOG_LEVEL);
 
 struct can_nxp_s32_config {
@@ -196,6 +207,10 @@ static int can_nxp_s32_start(const struct device *dev)
 		}
 	}
 
+	/* Reset statistics and clear all errors */
+	CAN_STATS_RESET(dev);
+	Canexcel_Ip_ClearErrorStatus(config->instance, CANXL_CLEAR_ALL_ERRORS);
+
 	data->common.started = true;
 
 	return 0;
@@ -334,18 +349,19 @@ static int can_nxp_s32_get_state(const struct device *dev, enum can_state *state
 {
 	const struct can_nxp_s32_config *config = dev->config;
 	struct can_nxp_s32_data *data = dev->data;
-	uint32_t sys_status = config->base_sic->SYSS;
+	uint8_t bcanxl_status;
 
 	if (state) {
 		if (!data->common.started) {
 			*state = CAN_STATE_STOPPED;
 		} else {
-			if (sys_status & CANXL_SIC_SYSS_CBOFF_MASK) {
+			Canexcel_Ip_GetControllerStatus(config->instance, &bcanxl_status);
+			if (bcanxl_status & BCANXL_ST_FLTCONF(2)) {
 				*state = CAN_STATE_BUS_OFF;
-			} else if (sys_status & CANXL_SIC_SYSS_CPASERR_MASK) {
+			} else if (bcanxl_status & BCANXL_ST_FLTCONF(1)) {
 				*state = CAN_STATE_ERROR_PASSIVE;
-			} else if (sys_status & (CANXL_SIC_SYSS_CRXWRN_MASK
-						| CANXL_SIC_SYSS_CTXWRN_MASK)) {
+			} else if (config->base_sic->SYSS &
+				(CANXL_SIC_SYSS_CRXWRN_MASK | CANXL_SIC_SYSS_CTXWRN_MASK)) {
 				*state = CAN_STATE_ERROR_WARNING;
 			} else {
 				*state = CAN_STATE_ERROR_ACTIVE;
@@ -354,9 +370,8 @@ static int can_nxp_s32_get_state(const struct device *dev, enum can_state *state
 	}
 
 	if (err_cnt) {
-		/* NXP S32 CANXL HAL is not supported error counter */
-		err_cnt->tx_err_cnt = 0;
-		err_cnt->rx_err_cnt = 0;
+		Canexcel_Ip_GetControllerTxErrorCounter(config->instance, &err_cnt->tx_err_cnt);
+		Canexcel_Ip_GetControllerRxErrorCounter(config->instance, &err_cnt->rx_err_cnt);
 	}
 
 	return 0;
@@ -752,6 +767,28 @@ static void can_nxp_s32_err_callback(const struct device *dev,
 		break;
 	}
 
+	if (u32SysStatus & BCANXL_ST_BIT0ERR_MASK) {
+		CAN_STATS_BIT0_ERROR_INC(dev);
+	}
+	if (u32SysStatus & BCANXL_ST_BIT1ERR_MASK) {
+		CAN_STATS_BIT1_ERROR_INC(dev);
+	}
+	if (u32SysStatus & BCANXL_ST_ACKERR_MASK) {
+		CAN_STATS_ACK_ERROR_INC(dev);
+	}
+	if (u32SysStatus & BCANXL_ST_STFERR_MASK) {
+		CAN_STATS_STUFF_ERROR_INC(dev);
+	}
+	if (u32SysStatus & BCANXL_ST_FRMERR_MASK) {
+		CAN_STATS_FORM_ERROR_INC(dev);
+	}
+	if (u32SysStatus & BCANXL_ST_CRCERR_MASK) {
+		CAN_STATS_CRC_ERROR_INC(dev);
+	}
+	if (u32SysStatus & BCANXL_ST_OVRERR_MASK) {
+		CAN_STATS_RX_OVERRUN_INC(dev);
+	}
+
 	can_nxp_s32_get_state(dev, &state, &err_cnt);
 	if (data->state != state) {
 		data->state = state;
@@ -988,6 +1025,10 @@ static int can_nxp_s32_init(const struct device *dev)
 	CanXL_SetErrIntCmd(config->base_sic, CANXL_INT_ERR, TRUE);
 	CanXL_SetErrIntCmd(config->base_sic, CANXL_INT_BUSOFF, TRUE);
 	CanXL_SetErrIntCmd(config->base_sic, CANXL_INT_PASIVE_ERR, TRUE);
+	CanXL_SetErrIntCmd(config->base_sic, CANXL_INT_RXSMB_OVER, TRUE);
+#ifdef CAN_NXP_S32_FD_MODE
+	CanXL_SetErrIntCmd(config->base_sic, CANXL_INT_ERR_FAST, TRUE);
+#endif
 #ifdef CONFIG_CAN_NXP_S32_RX_FIFO
 	CanXL_SetErrIntCmd(config->base_sic, CANXL_INT_RXFIFO_OVER, TRUE);
 


### PR DESCRIPTION
Update to enable CANXL_INT_RXSMB_OVER and CAN_INT_ERR_FAST(error for CAN-FD).
Statistic CAN errors and count CAN TX and RX errors via BCANXL that uses CANXL MRU to exchange information with CAN host.