### PR TITLE
bluetooth: `bt_le_ext_adv_start_param` is const

### DIFF
--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -1241,7 +1241,7 @@ struct bt_le_ext_adv_start_param {
  * @param param  Advertise start parameters.
  */
 int bt_le_ext_adv_start(struct bt_le_ext_adv *adv,
-			struct bt_le_ext_adv_start_param *param);
+			const struct bt_le_ext_adv_start_param *param);
 
 /**
  * @brief Stop advertising with the given advertising set

--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -1613,7 +1613,7 @@ int bt_le_ext_adv_update_param(struct bt_le_ext_adv *adv,
 }
 
 int bt_le_ext_adv_start(struct bt_le_ext_adv *adv,
-			struct bt_le_ext_adv_start_param *param)
+			const struct bt_le_ext_adv_start_param *param)
 {
 	struct bt_conn *conn = NULL;
 	int err;


### PR DESCRIPTION
`bt_le_ext_adv_start` does not modify the `param` argument, which can therefore be marked as `const`. This allows the struct to exist purely in ROM.