### PR TITLE
doc: Bluetooth: Add sample app for CAP ini/acc in status table

### DIFF
--- a/doc/connectivity/bluetooth/api/audio/bluetooth-le-audio-arch.rst
+++ b/doc/connectivity/bluetooth/api/audio/bluetooth-le-audio-arch.rst
@@ -141,13 +141,15 @@ Bluetooth Audio Stack.
    |        |                               |         |                  | - BSIM test           |                                                  |
    |        |                               |         |                  | - Sample Application  |                                                  |
    +--------+-------------------------------+---------+------------------+-----------------------+--------------------------------------------------+
-   | CAP    | Acceptor                      | 1.0     | 3.2              | - Feature complete    | - Sample Application                             |
+   | CAP    | Acceptor                      | 1.0     | 3.2              | - Feature complete    |                                                  |
    |        |                               |         |                  | - Shell Module        |                                                  |
    |        |                               |         |                  | - BSIM test           |                                                  |
+   |        |                               |         |                  | - Sample Application  |                                                  |
    |        +-------------------------------+---------+------------------+-----------------------+--------------------------------------------------+
-   |        | Initiator                     | 1.0     | 3.3              | - Feature complete    | - Sample Application                             |
+   |        | Initiator                     | 1.0     | 3.3              | - Feature complete    |                                                  |
    |        |                               |         |                  | - Shell Module        |                                                  |
    |        |                               |         |                  | - BSIM test           |                                                  |
+   |        |                               |         |                  | - Sample Application  |                                                  |
    |        +-------------------------------+---------+------------------+-----------------------+--------------------------------------------------+
    |        | Commander                     |         |                  | - WIP                 | - Feature complete                               |
    |        |                               |         |                  |                       | - Shell Module                                   |


### PR DESCRIPTION
Add the sample application as existing for the CAP initiator and CAP acceptor.

The samples are still in progress of being improved and fully featured, but they exist and can be used already now.