### PR TITLE
subsys: debug: no UNALIGNED_ACCESS_SUPPORTED for cortex M0 or M0plus

### DIFF
--- a/subsys/debug/mipi_stp_decoder.c
+++ b/subsys/debug/mipi_stp_decoder.c
@@ -6,7 +6,9 @@
 #include <zephyr/debug/mipi_stp_decoder.h>
 #include <string.h>
 
-#if defined(CONFIG_CPU_CORTEX_M) && !defined(CONFIG_CPU_CORTEX_M0)
+#if defined(CONFIG_CPU_CORTEX_M) && \
+	!defined(CONFIG_CPU_CORTEX_M0) && \
+	!defined(CONFIG_CPU_CORTEX_M0PLUS)
 #define UNALIGNED_ACCESS_SUPPORTED 1
 #else
 #define UNALIGNED_ACCESS_SUPPORTED 0


### PR DESCRIPTION
Set the UNALIGNED_ACCESS_SUPPORTED only for MCU with cortex M that are neither M0 nor M0plus
Cortex M0 or M0plus mcus do not support un-aligned address access

--> add the M0plus condition to define UNALIGNED_ACCESS_SUPPORTED in subsys/debug/mipi_stp_decoder.c

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/75039