### PR TITLE
boards: microchip: skip flash based CI tests for PolarFire SoC

### DIFF
--- a/boards/microchip/mpfs_icicle/mpfs_icicle.yaml
+++ b/boards/microchip/mpfs_icicle/mpfs_icicle.yaml
@@ -9,4 +9,5 @@ testing:
   ignore_tags:
     - net
     - bluetooth
+    - flash
 vendor: microchip

--- a/boards/microchip/mpfs_icicle/mpfs_icicle_smp.yaml
+++ b/boards/microchip/mpfs_icicle/mpfs_icicle_smp.yaml
@@ -9,4 +9,5 @@ testing:
   ignore_tags:
     - net
     - bluetooth
+    - flash
 vendor: microchip


### PR DESCRIPTION
Microchip's PolarFire SoC has a system controller that utilizes an external spi flash for performing "auto update" of the FPGA design. This is not a feauture fully integrated into Zephyr as of yet, so in an effort to not constantly fail the CI, add flash tag to the ignore list. 

Fixes  #74205