### PR TITLE
display: stm32: ltdc: minor fixes

### DIFF
--- a/boards/st/stm32f429i_disc1/stm32f429i_disc1.dts
+++ b/boards/st/stm32f429i_disc1/stm32f429i_disc1.dts
@@ -235,7 +235,7 @@
 		     &ltdc_hsync_pc6 &ltdc_vsync_pa4>;
 	pinctrl-names = "default";
 	ext-sdram = <&sdram2>;
-	display-controller = <&ili9341>;
+	panel-controller = <&ili9341>;
 	status = "okay";
 
 	width = <240>;

--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -539,6 +539,9 @@ Display
   drop this property from their devicetree, and set orientation at runtime
   via :c:func:`display_set_orientation` (:github:`73360`)
 
+* The ``display-controller`` property of :dtcompatible:`st,stm32-ltdc`
+  has been renamed to ``panel-controller`` (:github:`75050`)
+
 Enhanced Serial Peripheral Interface (eSPI)
 ===========================================
 

--- a/drivers/display/display_stm32_ltdc.c
+++ b/drivers/display/display_stm32_ltdc.c
@@ -252,8 +252,10 @@ static int stm32_ltdc_display_blanking_off(const struct device *dev)
 	const struct display_stm32_ltdc_config *config = dev->config;
 	const struct device *panel_dev = config->panel_controller;
 
+	/* Panel controller's phandle is not passed to LTDC in devicetree */
 	if (panel_dev == NULL) {
-		return 0;
+		LOG_ERR("There is no panel controller to forward blanking_off call to");
+		return -ENOSYS;
 	}
 
 	if (!device_is_ready(panel_dev)) {
@@ -269,8 +271,10 @@ static int stm32_ltdc_display_blanking_on(const struct device *dev)
 	const struct display_stm32_ltdc_config *config = dev->config;
 	const struct device *panel_dev = config->panel_controller;
 
+	/* Panel controller's phandle is not passed to LTDC in devicetree */
 	if (panel_dev == NULL) {
-		return 0;
+		LOG_ERR("There is no panel controller to forward blanking_on call to");
+		return -ENOSYS;
 	}
 
 	if (!device_is_ready(panel_dev)) {

--- a/drivers/display/display_stm32_ltdc.c
+++ b/drivers/display/display_stm32_ltdc.c
@@ -75,7 +75,7 @@ struct display_stm32_ltdc_config {
 	struct stm32_pclken pclken;
 	const struct pinctrl_dev_config *pctrl;
 	void (*irq_config_func)(const struct device *dev);
-	const struct device *display_controller;
+	const struct device *panel_controller;
 };
 
 static void stm32_ltdc_global_isr(const struct device *dev)
@@ -250,35 +250,35 @@ static int stm32_ltdc_read(const struct device *dev, const uint16_t x,
 static int stm32_ltdc_display_blanking_off(const struct device *dev)
 {
 	const struct display_stm32_ltdc_config *config = dev->config;
-	const struct device *display_dev = config->display_controller;
+	const struct device *panel_dev = config->panel_controller;
 
-	if (display_dev == NULL) {
+	if (panel_dev == NULL) {
 		return 0;
 	}
 
-	if (!device_is_ready(display_dev)) {
-		LOG_ERR("Display device %s not ready", display_dev->name);
+	if (!device_is_ready(panel_dev)) {
+		LOG_ERR("Panel controller's device %s is not ready", panel_dev->name);
 		return -ENODEV;
 	}
 
-	return display_blanking_off(display_dev);
+	return display_blanking_off(panel_dev);
 }
 
 static int stm32_ltdc_display_blanking_on(const struct device *dev)
 {
 	const struct display_stm32_ltdc_config *config = dev->config;
-	const struct device *display_dev = config->display_controller;
+	const struct device *panel_dev = config->panel_controller;
 
-	if (display_dev == NULL) {
+	if (panel_dev == NULL) {
 		return 0;
 	}
 
-	if (!device_is_ready(config->display_controller)) {
-		LOG_ERR("Display device %s not ready", display_dev->name);
+	if (!device_is_ready(panel_dev)) {
+		LOG_ERR("Panel controller's device %s is not ready", panel_dev->name);
 		return -ENODEV;
 	}
 
-	return display_blanking_on(display_dev);
+	return display_blanking_on(panel_dev);
 }
 
 static int stm32_ltdc_init(const struct device *dev)
@@ -607,8 +607,8 @@ static const struct display_driver_api stm32_ltdc_display_api = {
 		},										\
 		.pctrl = STM32_LTDC_DEVICE_PINCTRL_GET(inst),					\
 		.irq_config_func = stm32_ltdc_irq_config_func_##inst,				\
-		.display_controller = DEVICE_DT_GET_OR_NULL(					\
-			DT_INST_PHANDLE(inst, display_controller)),				\
+		.panel_controller = DEVICE_DT_GET_OR_NULL(					\
+			DT_INST_PHANDLE(inst, panel_controller)),				\
 	};											\
 	DEVICE_DT_INST_DEFINE(inst,								\
 			&stm32_ltdc_init,							\

--- a/dts/bindings/display/st,stm32-ltdc.yaml
+++ b/dts/bindings/display/st,stm32-ltdc.yaml
@@ -66,8 +66,8 @@ properties:
     type: int
     description: Last pixel in y direction on layer 0. Defaults to height.
 
-  display-controller:
+  panel-controller:
     type: phandle
     description: |
-      Phandle of the display's controller. When provided, it's used to forward some of the
+      Phandle of the panel's controller. When provided, it's used to forward some of the
       configuration calls (e.g. blanking on/off) sent to LTDC device.


### PR DESCRIPTION
Renames the `display-controller` property of `st,stm32-ltdc` to `panel-controller`.

Clarifies why NULL checks are necessary for panel controller device inside blanking_on/off functions in LTDC driver,
& fixes return value when the panel controller's phandle is not passed to LTDC in devicetree. 

Addresses https://github.com/zephyrproject-rtos/zephyr/pull/68105#discussion_r1476504953