### PR TITLE
toolchain: gcc: fix SECTION_DATA_PROLOGUE for XIP

### DIFF
--- a/include/zephyr/linker/linker-tool-gcc.h
+++ b/include/zephyr/linker/linker-tool-gcc.h
@@ -200,7 +200,7 @@
  */
 #if defined(CONFIG_XIP)
 #define SECTION_DATA_PROLOGUE(name, options, align) \
-	name options : ALIGN_WITH_INPUT align
+	name options : ALIGN_WITH_INPUT
 #else
 #define SECTION_DATA_PROLOGUE(name, options, align) \
 	SECTION_PROLOGUE(name, options, align)


### PR DESCRIPTION
Current if CONFIG_XIP is enabled, then ALIGN_WITH_INPUT and the align argument to SECTION_DATA_PROLOGUE are set together, and that is not a valid option combination; if ALIGN_WITH_INPUT is present, then the section's LMA alignment is inherited from the previous section, and that cannot be combined with another alignment option.

The background for this line is in the following commit: 6b3c5e8bb2cee171a233638a1b33e0c92121c50c

Additionally, this is the documentation from ld:

(from https://sourceware.org/binutils/docs/ld/Forced-Output-Alignment.html)

> 3.6.8.3 Forced Output Alignment
>
> You can increase an output section’s alignment by using ALIGN. As an
> alternative you can enforce that the difference between the VMA and
> LMA remains intact throughout this output section with the
> ALIGN_WITH_INPUT attribute.

fixes: #72696 