### PR TITLE
soc/*adsp: Fix snippets linkage

### DIFF
--- a/soc/intel/intel_adsp/ace/ace-link.ld
+++ b/soc/intel/intel_adsp/ace/ace-link.ld
@@ -461,6 +461,9 @@ SECTIONS {
     *(.tm_clone_table)
   } >ram
 
+#include <snippets-sections.ld>
+#include <snippets-ram-sections.ld>
+
   /* This section is cached.  By default it contains only declared
   * thread stacks, but applications can put symbols here too.
   */

--- a/soc/intel/intel_adsp/cavs/include/xtensa-cavs-linker.ld
+++ b/soc/intel/intel_adsp/cavs/include/xtensa-cavs-linker.ld
@@ -380,6 +380,9 @@ SECTIONS {
 #define RAMABLE_REGION ucram
 #define ROMABLE_REGION ucram
 
+#include <snippets-sections.ld>
+#include <snippets-ram-sections.ld>
+
 #include <zephyr/linker/common-ram.ld>
 
   .tm_clone_table : {
@@ -471,8 +474,6 @@ SECTIONS {
     . = ALIGN(16);
   } >noload
 
-
-#include <snippets-sections.ld>
 
 #include <zephyr/linker/debug-sections.ld>
 

--- a/soc/nxp/imx/imx8/adsp/linker.ld
+++ b/soc/nxp/imx/imx8/adsp/linker.ld
@@ -17,6 +17,7 @@ OUTPUT_ARCH(xtensa)
 #include <xtensa/config/core-isa.h>
 #include <memory.h>
 #include <zephyr/linker/sections.h>
+#include <zephyr/linker/iterable_sections.h>
 
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/linker/linker-tool.h>
@@ -340,6 +341,8 @@ SECTIONS
     __rodata_region_end = ABSOLUTE(.);
   } >sdram0 :sdram0_phdr
 
+#include <snippets-sections.ld>
+
   .module_init : ALIGN(4)
   {
    _module_init_start = ABSOLUTE(.);
@@ -405,6 +408,8 @@ SECTIONS
     __data_end = ABSOLUTE(.);
     . = ALIGN(4096);
   } >sdram0 :sdram0_phdr
+
+#include <snippets-ram-sections.ld>
 
   .lit4 : ALIGN(4)
   {

--- a/soc/nxp/imx/imx8ulp/adsp/linker.ld
+++ b/soc/nxp/imx/imx8ulp/adsp/linker.ld
@@ -17,6 +17,7 @@ OUTPUT_ARCH(xtensa)
 #include <xtensa/config/core-isa.h>
 #include <memory.h>
 #include <zephyr/linker/sections.h>
+#include <zephyr/linker/iterable_sections.h>
 
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/linker/linker-tool.h>
@@ -340,6 +341,8 @@ SECTIONS
     __rodata_region_end = ABSOLUTE(.);
   } >sdram0 :sdram0_phdr
 
+#include <snippets-sections.ld>
+
   .module_init : ALIGN(4)
   {
    _module_init_start = ABSOLUTE(.);
@@ -405,6 +408,8 @@ SECTIONS
     __data_end = ABSOLUTE(.);
     . = ALIGN(4096);
   } >sdram0 :sdram0_phdr
+
+#include <snippets-ram-sections.ld>
 
   .lit4 : ALIGN(4)
   {

--- a/soc/nxp/imx/imx8x/adsp/linker.ld
+++ b/soc/nxp/imx/imx8x/adsp/linker.ld
@@ -17,6 +17,7 @@ OUTPUT_ARCH(xtensa)
 #include <xtensa/config/core-isa.h>
 #include <memory.h>
 #include <zephyr/linker/sections.h>
+#include <zephyr/linker/iterable_sections.h>
 
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/linker/linker-tool.h>
@@ -340,6 +341,8 @@ SECTIONS
     __rodata_region_end = ABSOLUTE(.);
   } >sdram0 :sdram0_phdr
 
+#include <snippets-sections.ld>
+
   .module_init : ALIGN(4)
   {
    _module_init_start = ABSOLUTE(.);
@@ -405,6 +408,8 @@ SECTIONS
     __data_end = ABSOLUTE(.);
     . = ALIGN(4096);
   } >sdram0 :sdram0_phdr
+
+#include <snippets-ram-sections.ld>
 
   .lit4 : ALIGN(4)
   {


### PR DESCRIPTION
The Intel and NXP adsp linker scripts (mostly evolved via cut/paste between themselves) never actually had support for linker "sections" snippets as e.g. needed for STRUCT_SECTION_ITERABLE() usage[1].  Add them in reasonably appropriate places (Intel doesn't really have a clean .rodata area, because of the way cache address munging works, so in fact they're adjacent there).

[1] Actually cAVS did have the include for ROM snippets, but it was in
    the wrong place and dumped the symbols into unusable addresses at
    the top of memory.