### PR TITLE
linker: nxp: adsp: add orphan linker section

### DIFF
--- a/soc/nxp/imx/imx8/adsp/linker.ld
+++ b/soc/nxp/imx/imx8/adsp/linker.ld
@@ -522,4 +522,6 @@ SECTIONS
     KEEP (*(.fw_metadata))
     . = ALIGN(_EXT_MAN_ALIGN_);
   } >fw_metadata_seg :metadata_entries_phdr
+
+  /DISCARD/ : { *(.note.GNU-stack) }
 }

--- a/soc/nxp/imx/imx8ulp/adsp/linker.ld
+++ b/soc/nxp/imx/imx8ulp/adsp/linker.ld
@@ -522,4 +522,6 @@ SECTIONS
     KEEP (*(.fw_metadata))
     . = ALIGN(_EXT_MAN_ALIGN_);
   } >fw_metadata_seg :metadata_entries_phdr
+
+  /DISCARD/ : { *(.note.GNU-stack) }
 }

--- a/soc/nxp/imx/imx8x/adsp/linker.ld
+++ b/soc/nxp/imx/imx8x/adsp/linker.ld
@@ -522,4 +522,6 @@ SECTIONS
     KEEP (*(.fw_metadata))
     . = ALIGN(_EXT_MAN_ALIGN_);
   } >fw_metadata_seg :metadata_entries_phdr
+
+  /DISCARD/ : { *(.note.GNU-stack) }
 }


### PR DESCRIPTION
Add missing linker section to avoid warning
about orphans when building with host compiler.