### PR TITLE
drivers: spi: gecko: propagate spi config error

### DIFF
--- a/drivers/spi/spi_gecko.c
+++ b/drivers/spi/spi_gecko.c
@@ -346,8 +346,13 @@ static int spi_gecko_transceive(const struct device *dev,
 {
 	struct spi_gecko_data *data = dev->data;
 	uint16_t control = 0;
+	int ret;
 
-	spi_config(dev, config, &control);
+	ret = spi_config(dev, config, &control);
+	if (ret < 0) {
+		return ret;
+	}
+
 	spi_context_buffers_setup(&data->ctx, tx_bufs, rx_bufs, 1);
 	spi_gecko_xfer(dev, config);
 	return 0;


### PR DESCRIPTION
This commit catch the return code of the spi_config function and early returns on error so that high level spi transfer api gets the error too.

Even though you have LOG_ERR in all error in spi_config() function, if you don't have LOG enabled, you are blind on any misconfiguration with this driver.

With this change, SPI api transfer call will fail on any mistake caught by spi_config() function.

Fixes: #75086