### PR TITLE
MAINTAINERS: add maintainer to Ambiq platform

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -237,10 +237,11 @@ MIPS arch:
     - arch.mips
 
 Ambiq Platforms:
-  status: odd fixes
+  status: maintained
+  maintainers:
+    - AlessandroLuo
   collaborators:
     - aaronyegx
-    - AlessandroLuo
     - RichardSWheatley
   files:
     - soc/ambiq/


### PR DESCRIPTION
Add maintainer to an area that is active and maintained.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
