### PR TITLE
tests: lib: spsc_pbuf: Disable tests with cache management enabled

### DIFF
--- a/include/zephyr/sys/spsc_pbuf.h
+++ b/include/zephyr/sys/spsc_pbuf.h
@@ -25,7 +25,11 @@ extern "C" {
  * @{
  */
 
-/** @brief Flag indicating that cache shall be handled. */
+/** @brief Flag indicating that cache shall be handled.
+ *
+ * It shall be used only when packet buffer is shared between two cores as on a single
+ * core cache shall not be handled manually because it results in data corruption.
+ */
 #define SPSC_PBUF_CACHE BIT(0)
 
 /** @brief Size of the field which stores maximum utilization. */

--- a/lib/os/Kconfig
+++ b/lib/os/Kconfig
@@ -60,7 +60,9 @@ config SPSC_PBUF_CACHE_ALWAYS
 	bool "Always handle cache"
 	help
 	  Handle cache writeback and invalidation for all instances. Option used
-	  to avoid runtime check and thus reduce memory footprint.
+	  to avoid runtime check and thus reduce memory footprint. Beware! It shall
+	  be used only if all packet buffer instances are used for data sharing
+	  between cores.
 
 config SPSC_PBUF_CACHE_NEVER
 	bool "Never handle cache"

--- a/tests/lib/spsc_pbuf/testcase.yaml
+++ b/tests/lib/spsc_pbuf/testcase.yaml
@@ -9,9 +9,10 @@ tests:
   libraries.spsc_pbuf.cache:
     integration_platforms:
       - native_sim
-    # Exclude platform which does not link with cache functions
-    platform_exclude: ast1030_evb
-    timeout: 120
+    # This configuration only make sense for interprocessor data sharing so
+    # configuration can only be verified against compilation errors on a single core.
+    platform_allow: native_sim
+    build_only: true
     extra_configs:
       - CONFIG_SPSC_PBUF_CACHE_ALWAYS=y
 


### PR DESCRIPTION
`libraries.spsc_pbuf.cache` configuration was failing on a core with data cache enabled.

Test was using a configuration which enforces cache management in the packet buffer. However it shall not be used if producer and consumer is the same core. Testing this configuration on a single core does not make sense as it actually fails on cores with data cache.

Making this configuration build_only so it is checked against compilation errors.

Additionally, added clarification in the header file and Kconfig about when cache management shall be enabled in spsc_pbuf.
