### PR TITLE
boards: lpcxpresso55s36: enable usb_device

### DIFF
--- a/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.yaml
+++ b/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.yaml
@@ -19,4 +19,5 @@ supported:
   - gpio
   - pwm
   - dac
+  - usb_device
 vendor: nxp


### PR DESCRIPTION
since #58095 usb_device is support by this platform