### PR TITLE
maintainers: remove gopiotr from twister collaborators

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3045,7 +3045,6 @@ Twister:
   collaborators:
     - PerMac
     - hakehuang
-    - gopiotr
     - golowanow
     - gchwier
     - LukaszMrugala


### PR DESCRIPTION
Piotr no longer works in Nordic and was not active in Zephyr since December 2023.