### PR TITLE
MAINTAINERS: add valeriosetti as collaborator for Mbed TLS module

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4668,6 +4668,7 @@ West:
     - ceolin
   collaborators:
     - ithinuel
+    - valeriosetti
   files:
     - modules/mbedtls/
   labels:


### PR DESCRIPTION
Previous commit 8defc560fe8fafe007604f8193fe299d284055b3 forgot to add valeriosetti also in "West project: mbedtls". This PR fixes this.