### PR TITLE
drivers: uart: uart_elementary: Add missing pull-ups to nrf54h20dk

### DIFF
--- a/tests/drivers/uart/uart_elementary/boards/nrf54h20dk_nrf54h20_cpuapp_dual_uart.overlay
+++ b/tests/drivers/uart/uart_elementary/boards/nrf54h20dk_nrf54h20_cpuapp_dual_uart.overlay
@@ -6,8 +6,11 @@
 &pinctrl {
 	uart135_default_alt: uart135_default_alt {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 0, 6)>,
-				<NRF_PSEL(UART_RX, 0, 9)>;
+			psels = <NRF_PSEL(UART_RX, 0, 9)>;
+				bias-pull-up;
+		};
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 0, 6)>;
 		};
 	};
 
@@ -32,8 +35,11 @@ dut: &uart135 {
 &pinctrl {
 	uart137_default_alt: uart137_default_alt {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 0, 8)>,
-				 <NRF_PSEL(UART_RX, 0, 7)>;
+			psels = <NRF_PSEL(UART_RX, 0, 7)>;
+			bias-pull-up;
+		};
+		group2 {
+			psels = <NRF_PSEL(UART_TX, 0, 8)>;
 		};
 	};
 


### PR DESCRIPTION
Add missing pull-up for RX pin in nrf54h20dk dual uart configuration. Lack of pull-up was causing test failures.