### PR TITLE
tests: drivers: can: api: restore default bitrates

### DIFF
--- a/tests/drivers/can/api/src/canfd.c
+++ b/tests/drivers/can/api/src/canfd.c
@@ -388,6 +388,9 @@ ZTEST_USER(canfd, test_set_timing_data_min)
 	err = can_set_timing_data(can_dev, can_get_timing_data_min(can_dev));
 	zassert_equal(err, 0, "failed to set minimum timing data parameters (err %d)", err);
 
+	err = can_set_bitrate_data(can_dev, CONFIG_CAN_DEFAULT_BITRATE_DATA);
+	zassert_equal(err, 0, "failed to restore default data bitrate");
+
 	err = can_start(can_dev);
 	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
 }
@@ -434,6 +437,9 @@ ZTEST_USER(canfd, test_set_timing_data_max)
 
 	err = can_set_timing_data(can_dev, can_get_timing_data_max(can_dev));
 	zassert_equal(err, 0, "failed to set maximum timing data parameters (err %d)", err);
+
+	err = can_set_bitrate_data(can_dev, CONFIG_CAN_DEFAULT_BITRATE_DATA);
+	zassert_equal(err, 0, "failed to restore default data bitrate");
 
 	err = can_start(can_dev);
 	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);

--- a/tests/drivers/can/api/src/classic.c
+++ b/tests/drivers/can/api/src/classic.c
@@ -529,6 +529,9 @@ ZTEST_USER(can_classic, test_set_bitrate)
 	err = can_set_bitrate(can_dev, TEST_BITRATE_1);
 	zassert_equal(err, 0, "failed to set bitrate");
 
+	err = can_set_bitrate(can_dev, CONFIG_CAN_DEFAULT_BITRATE);
+	zassert_equal(err, 0, "failed to restore default bitrate");
+
 	err = can_start(can_dev);
 	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
 }
@@ -546,6 +549,9 @@ ZTEST_USER(can_classic, test_set_timing_min)
 	err = can_set_timing(can_dev, can_get_timing_min(can_dev));
 	zassert_equal(err, 0, "failed to set minimum timing parameters (err %d)", err);
 
+	err = can_set_bitrate(can_dev, CONFIG_CAN_DEFAULT_BITRATE);
+	zassert_equal(err, 0, "failed to restore default bitrate");
+
 	err = can_start(can_dev);
 	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
 }
@@ -562,6 +568,9 @@ ZTEST_USER(can_classic, test_set_timing_max)
 
 	err = can_set_timing(can_dev, can_get_timing_max(can_dev));
 	zassert_equal(err, 0, "failed to set maximum timing parameters (err %d)", err);
+
+	err = can_set_bitrate(can_dev, CONFIG_CAN_DEFAULT_BITRATE);
+	zassert_equal(err, 0, "failed to restore default bitrate");
 
 	err = can_start(can_dev);
 	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);
@@ -1180,10 +1189,13 @@ ZTEST_USER(can_classic, test_filters_preserved_through_bitrate_change)
 	zassert_equal(state, CAN_STATE_STOPPED, "CAN controller not stopped");
 
 	err = can_set_bitrate(can_dev, TEST_BITRATE_2);
-	zassert_equal(err, 0, "failed to set bitrate");
+	zassert_equal(err, 0, "failed to set bitrate 2");
 
 	err = can_set_bitrate(can_dev, TEST_BITRATE_1);
-	zassert_equal(err, 0, "failed to set bitrate");
+	zassert_equal(err, 0, "failed to set bitrate 1");
+
+	err = can_set_bitrate(can_dev, CONFIG_CAN_DEFAULT_BITRATE);
+	zassert_equal(err, 0, "failed to restore default bitrate");
 
 	err = can_start(can_dev);
 	zassert_equal(err, 0, "failed to start CAN controller (err %d)", err);


### PR DESCRIPTION
Restore the default CAN bitrates after having tested setting bitrate and timing. This ensures the arbitration phase bitrate is proportional to the data phase bitrate, allowing CAN FD transmission tests to complete.

Fixes: #73723