### PR TITLE
dts: pinctrl: unify pinctrl binding for imx8mp/n/m

### DIFF
--- a/boards/nxp/imx8mm_evk/imx8mm_evk-pinctrl.dtsi
+++ b/boards/nxp/imx8mm_evk/imx8mm_evk-pinctrl.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NXP
+ * Copyright 2022,2024 NXP
  * SPDX-License-Identifier: Apache-2.0
  *
  */
@@ -12,7 +12,7 @@
 			pinmux = <&iomuxc_uart2_rxd_uart_rx_uart2_rx>,
 				<&iomuxc_uart2_txd_uart_tx_uart2_tx>;
 			slew-rate = "fast";
-			drive-strength = "40-ohm";
+			drive-strength = "x6";
 		};
 	};
 
@@ -21,7 +21,7 @@
 			pinmux = <&iomuxc_uart4_rxd_uart_rx_uart4_rx>,
 				<&iomuxc_uart4_txd_uart_tx_uart4_tx>;
 			slew-rate = "fast";
-			drive-strength = "40-ohm";
+			drive-strength = "x6";
 		};
 	};
 

--- a/boards/nxp/imx8mn_evk/imx8mn_evk-pinctrl.dtsi
+++ b/boards/nxp/imx8mn_evk/imx8mn_evk-pinctrl.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 NXP
+ * Copyright 2022,2024 NXP
  * SPDX-License-Identifier: Apache-2.0
  *
  */
@@ -12,7 +12,7 @@
 			pinmux = <&iomuxc_uart2_rxd_uart_rx_uart2_rx>,
 				<&iomuxc_uart2_txd_uart_tx_uart2_tx>;
 			slew-rate = "fast";
-			drive-strength = "40-ohm";
+			drive-strength = "x6";
 		};
 	};
 
@@ -21,7 +21,7 @@
 			pinmux = <&iomuxc_uart4_rxd_uart_rx_uart4_rx>,
 				<&iomuxc_uart4_txd_uart_tx_uart4_tx>;
 			slew-rate = "fast";
-			drive-strength = "40-ohm";
+			drive-strength = "x6";
 		};
 	};
 

--- a/boards/phytec/mimx8mm_phyboard_polis/mimx8mm_phyboard_polis-pinctrl.dtsi
+++ b/boards/phytec/mimx8mm_phyboard_polis/mimx8mm_phyboard_polis-pinctrl.dtsi
@@ -12,7 +12,7 @@
 			pinmux = <&iomuxc_uart4_rxd_uart_rx_uart4_rx>,
 				<&iomuxc_uart4_txd_uart_tx_uart4_tx>;
 			slew-rate = "fast";
-			drive-strength = "40-ohm";
+			drive-strength = "x6";
 		};
 	};
 
@@ -21,7 +21,7 @@
 			pinmux = <&iomuxc_uart3_rxd_uart_rx_uart3_rx>,
 				<&iomuxc_uart3_txd_uart_tx_uart3_tx>;
 			slew-rate = "fast";
-			drive-strength = "40-ohm";
+			drive-strength = "x6";
 		};
 	};
 
@@ -32,7 +32,7 @@
 				<&iomuxc_sai3_txfs_uart_tx_uart2_rx>,
 				<&iomuxc_sai3_txc_uart_rx_uart2_tx>;
 			slew-rate = "fast";
-			drive-strength = "40-ohm";
+			drive-strength = "x6";
 		};
 	};
 
@@ -43,7 +43,7 @@
 				<&iomuxc_sai2_rxd0_uart_rts_b_uart1_rts_b>,
 				<&iomuxc_sai2_txfs_uart_cts_b_uart1_cts_b>;
 			slew-rate = "fast";
-			drive-strength = "40-ohm";
+			drive-strength = "x6";
 		};
 	};
 };

--- a/dts/arm/nxp/nxp_imx8mm_m4.dtsi
+++ b/dts/arm/nxp/nxp_imx8mm_m4.dtsi
@@ -5,3 +5,8 @@
  */
 
 #include <nxp/nxp_imx8m_m4.dtsi>
+
+&pinctrl {
+	status = "okay";
+	compatible = "nxp,imx8mp-pinctrl";
+};

--- a/dts/arm64/nxp/nxp_mimx8mm_a53.dtsi
+++ b/dts/arm64/nxp/nxp_mimx8mm_a53.dtsi
@@ -100,7 +100,7 @@
 		status = "okay";
 		pinctrl: pinctrl {
 			status = "okay";
-			compatible = "nxp,imx8m-pinctrl";
+			compatible = "nxp,imx8mp-pinctrl";
 		};
 	};
 

--- a/dts/arm64/nxp/nxp_mimx8mn_a53.dtsi
+++ b/dts/arm64/nxp/nxp_mimx8mn_a53.dtsi
@@ -100,7 +100,7 @@
 		status = "okay";
 		pinctrl: pinctrl {
 			status = "okay";
-			compatible = "nxp,imx8m-pinctrl";
+			compatible = "nxp,imx8mp-pinctrl";
 		};
 	};
 


### PR DESCRIPTION
Currently imx8mm/n use pinctrl binding of nxp,imx8m-pinctrl.yaml which
is used for imx8mq series platforms, but imx8mm/n have different pinctrl
hardware module with imx8mq, so change imx8mm/n to use binding of
nxp,imx8mp-pinctrl.yaml as imx8mm, imx8mn and imx8mp have the same
pinctrl hardware module.