### PR TITLE
drivers: ethernet: stm32: fix PTP on STM32F7

### DIFF
--- a/drivers/ethernet/eth_stm32_hal_priv.h
+++ b/drivers/ethernet/eth_stm32_hal_priv.h
@@ -10,7 +10,7 @@
 #include <zephyr/types.h>
 
 /* Naming of the  ETH PTP Config Status changes depending on the stm32 serie */
-#if defined(CONFIG_SOC_SERIES_STM32F7X) || defined(CONFIG_SOC_SERIES_STM32F4X)
+#if defined(CONFIG_SOC_SERIES_STM32F4X)
 #define ETH_STM32_PTP_CONFIGURED HAL_ETH_PTP_CONFIGURATED
 #define ETH_STM32_PTP_NOT_CONFIGURED HAL_ETH_PTP_NOT_CONFIGURATED
 #else


### PR DESCRIPTION
As of recent update of stm32f7 HAL to cube version V1.17.2 the workaround for misspelled `HAL_ETH_PTP_CONFIGURATED` macro is not needed anymore, and causes PTP support to fail to compile.

See https://github.com/zephyrproject-rtos/hal_stm32/blame/855f195793df094644ce8b8617c01275408bbf58/stm32cube/stm32f7xx/drivers/include/stm32f7xx_hal_eth.h#L1696

cc @marwaiehm-st