### PR TITLE
manifest: net: openthread: Regular openthread upmerge to `e10a925`

### DIFF
--- a/modules/openthread/platform/diag.c
+++ b/modules/openthread/platform/diag.c
@@ -16,19 +16,39 @@
  *
  */
 static bool sDiagMode;
+static void *sDiagCallbackContext;
+static otPlatDiagOutputCallback sDiagOutputCallback;
 
-otError otPlatDiagProcess(otInstance *aInstance,
-			  uint8_t argc,
-			  char   *argv[],
-			  char   *aOutput,
-			  size_t  aOutputMaxLen)
+static void diag_output(const char *aFormat, ...)
 {
-	ARG_UNUSED(argc);
+	va_list args;
+
+	va_start(args, aFormat);
+
+	if (sDiagOutputCallback != NULL) {
+		sDiagOutputCallback(aFormat, args, sDiagCallbackContext);
+	}
+
+	va_end(args);
+}
+
+void otPlatDiagSetOutputCallback(otInstance *aInstance,
+				 otPlatDiagOutputCallback aCallback,
+				 void *aContext)
+{
+	OT_UNUSED_VARIABLE(aInstance);
+
+	sDiagOutputCallback  = aCallback;
+	sDiagCallbackContext = aContext;
+}
+
+otError otPlatDiagProcess(otInstance *aInstance, uint8_t aArgsLength, char *aArgs[])
+{
 	ARG_UNUSED(aInstance);
+	ARG_UNUSED(aArgsLength);
 
 	/* Add more platform specific diagnostics features here. */
-	snprintk(aOutput, aOutputMaxLen,
-		 "diag feature '%s' is not supported\r\n", argv[0]);
+	diag_output("diag feature '%s' is not supported\r\n", aArgs[0]);
 
 	return OT_ERROR_NOT_IMPLEMENTED;
 }

--- a/west.yml
+++ b/west.yml
@@ -306,7 +306,7 @@ manifest:
       revision: 76d2168bcdfcd23a9a7dce8c21f2083b90a1e60a
       path: modules/lib/open-amp
     - name: openthread
-      revision: 3873c6fcd5a8a9dd01b71e8efe32ef5dc7923bb1
+      revision: e10a92570f94ff1e0bc5e0da9ecf0ee135d955a6
       path: modules/lib/openthread
     - name: percepio
       path: modules/debug/percepio


### PR DESCRIPTION
Regular openthread upmerge to `e10a92570f94ff1e0bc5e0da9ecf0ee135d955a6`.

Additionally commit aligns platform implementation with diag changes:
https://github.com/openthread/openthread/pull/10354

based on:
https://github.com/openthread/ot-nrf528xx/pull/822