### PR TITLE
scripts: ci: check_compliance.py: Add clang-format check

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -38,7 +38,7 @@ jobs:
       run: |
         pip3 install setuptools
         pip3 install wheel
-        pip3 install python-magic lxml junitparser gitlint pylint pykwalify yamllint
+        pip3 install python-magic lxml junitparser gitlint pylint pykwalify yamllint clang-format unidiff
         pip3 install west
 
     - name: west setup
@@ -94,16 +94,23 @@ jobs:
           exit 1;
         fi
 
+        warns=("ClangFormat")
         files=($(./scripts/ci/check_compliance.py -l))
+
         for file in "${files[@]}"; do
           f="${file}.txt"
           if [[ -s $f ]]; then
-            errors=$(cat $f)
-            errors="${errors//'%'/'%25'}"
-            errors="${errors//$'\n'/'%0A'}"
-            errors="${errors//$'\r'/'%0D'}"
-            echo "::error file=${f}::$errors"
-            exit=1
+            results=$(cat $f)
+            results="${results//'%'/'%25'}"
+            results="${results//$'\n'/'%0A'}"
+            results="${results//$'\r'/'%0D'}"
+
+            if [[ "${warns[@]}" =~ "${file}" ]]; then
+              echo "::warning file=${f}::$results"
+            else
+              echo "::error file=${f}::$results"
+              exit=1
+            fi
           fi
         done
 

--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ tags
 BinaryFiles.txt
 BoardYml.txt
 Checkpatch.txt
+ClangFormat.txt
 DevicetreeBindings.txt
 GitDiffCheck.txt
 Gitlint.txt

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1514,10 +1514,11 @@ def annotate(res):
     """
     https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#about-workflow-commands
     """
+    msg = res.message.replace('%', '%25').replace('\n', '%0A').replace('\r', '%0D')
     notice = f'::{res.severity} file={res.file}' + \
              (f',line={res.line}' if res.line else '') + \
              (f',col={res.col}' if res.col else '') + \
-             f',title={res.title}::{res.message}'
+             f',title={res.title}::{msg}'
     print(notice)
 
 

--- a/scripts/requirements-compliance.txt
+++ b/scripts/requirements-compliance.txt
@@ -1,9 +1,11 @@
 # COMPLIANCE: required by the compliance scripts
 
 # used by ci/check_compliance
+clang-format
 python-magic
 python-magic-bin; sys_platform == "win32"
 lxml
 junitparser>=2
 pylint>=3
+unidiff
 yamllint


### PR DESCRIPTION
Add a new compliance check that reports any clang-format issues on the git diff.

See [the test PR](https://github.com/zephyrproject-rtos/zephyr/pull/75117/files) on how these are reported.