### PR TITLE
soc/st/stm32/st32wbax: fixing STM32WBA55 Ext Adv issue

### DIFF
--- a/soc/st/stm32/stm32wbax/Kconfig.defconfig
+++ b/soc/st/stm32/stm32wbax/Kconfig.defconfig
@@ -35,6 +35,9 @@ config ENTROPY_STM32_CLK_CHECK
 config FPU
 	default y
 
+config SYSTEM_WORKQUEUE_STACK_SIZE
+	default 2048
+
 endif
 
 if PM_S2RAM

--- a/west.yml
+++ b/west.yml
@@ -234,7 +234,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 855f195793df094644ce8b8617c01275408bbf58
+      revision: d12e21e35d8d33c5fdf711d1a1c07f38c9295f70
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
STM32WBA55 BLE Extended Advertising fixed using a correct BLE Controller configuration (west.yml update).

SYSTEM_WORKQUEUE_STACK_SIZE increase is required to fix not only BLE Ext Adv but also other BLE use cases according STM32WBA HCI driver