### PR TITLE
tests: drivers: no pll2 when testing the clock control on the stm32h7 serie

### DIFF
--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32h7_core/boards/clear_clocks.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32h7_core/boards/clear_clocks.overlay
@@ -42,6 +42,16 @@
 	status = "disabled";
 };
 
+&pll2 {
+	/delete-property/ div-m;
+	/delete-property/ mul-n;
+	/delete-property/ div-p;
+	/delete-property/ div-q;
+	/delete-property/ div-r;
+	/delete-property/ clocks;
+	status = "disabled";
+};
+
 &pll3 {
 	/delete-property/ div-m;
 	/delete-property/ mul-n;


### PR DESCRIPTION
Disable the pll2 when clearing the clock config prior to testing the clock_control driver for the stm32h7

Following the https://github.com/zephyrproject-rtos/zephyr/pull/74423 which enables the pll2 on the stm32h743/h753 nucleo boards, this pll2 has to be disabled when executing the tests/drivers/clock_control/stm32_clock_configuration/stm32h7_core


