### PR TITLE
tests: drivers: i2c: i2c_target_api: Support 16-bit word address size

### DIFF
--- a/tests/drivers/i2c/i2c_target_api/boards/max32690evkit_max32690_m4.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/max32690evkit_max32690_m4.overlay
@@ -12,6 +12,7 @@
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
+		address-width = <16>;
 		size = <1024>;
 	};
 };
@@ -24,6 +25,7 @@
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
+		address-width = <16>;
 		size = <1024>;
 	};
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/mec1501modular_assy6885.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/mec1501modular_assy6885.overlay
@@ -8,6 +8,7 @@
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
+		address-width = <16>;
 		size = <1024>;
 	};
 };
@@ -17,6 +18,7 @@
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
+		address-width = <16>;
 		size = <1024>;
 	};
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/npcx9m6f_evb.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/npcx9m6f_evb.overlay
@@ -10,6 +10,7 @@
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
+		address-width = <16>;
 		size = <1024>;
 	};
 };
@@ -23,6 +24,7 @@
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
+		address-width = <16>;
 		size = <1024>;
 	};
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_h563zi.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_h563zi.overlay
@@ -20,6 +20,7 @@
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
+		address-width = <16>;
 		size = <1024>;
 	};
 };
@@ -31,6 +32,7 @@
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
+		address-width = <16>;
 		size = <1024>;
 	};
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_l476rg.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_l476rg.overlay
@@ -17,6 +17,7 @@
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
+		address-width = <16>;
 		size = <1024>;
 	};
 };
@@ -25,6 +26,7 @@
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
+		address-width = <16>;
 		size = <1024>;
 	};
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/numaker_m2l31ki.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/numaker_m2l31ki.overlay
@@ -24,6 +24,7 @@
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
+		address-width = <16>;
 		size = <1024>;
 	};
 };
@@ -36,6 +37,7 @@
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
+		address-width = <16>;
 		size = <1024>;
 	};
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/numaker_pfm_m467.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/numaker_pfm_m467.overlay
@@ -24,6 +24,7 @@
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
+		address-width = <16>;
 		size = <1024>;
 	};
 };
@@ -36,6 +37,7 @@
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;
+		address-width = <16>;
 		size = <1024>;
 	};
 };


### PR DESCRIPTION
i2c_target_api test uses `i2c_burst_read` and `i2c_burst_write` for reads and writes. These functions send only one byte as EEPROM word address, so tests fail when `address-width` is set to 16 bits. Update the tests so that 16-bit addresses can also be used.

Also, fix build failures by setting `<address-width>` to 16-bit for boards where EEPROM size is set to 1024.
See also: https://github.com/zephyrproject-rtos/zephyr/pull/71853/commits/3a7115f0963883a3c05759ed56a7828dd1a331be