### PR TITLE
doc: release: 3.7: Add note about LinkServer runner .hex support

### DIFF
--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -279,6 +279,8 @@ Build system and Infrastructure
   * Fixed issue whereby files used in a project (e.g. devicetree overlays or Kconfig fragments)
     were not correctly watched and CMake would not reconfigure if they were changed.
 
+  * Added flash support for Intel Hex files for the LinkServer runner.
+
 Drivers and Sensors
 *******************
 


### PR DESCRIPTION
Added note about enabled flash support for Intel Hex files for the LinkServer runner.