### PR TITLE
soc: esp32xx: always use section prologue with alignment

### DIFF
--- a/soc/espressif/esp32/default.ld
+++ b/soc/espressif/esp32/default.ld
@@ -47,6 +47,10 @@ user_dram_2_seg_len = SRAM1_USER_SIZE;
 #undef GROUP_ROM_LINK_IN
 #define GROUP_ROM_LINK_IN(vregion, lregion) > RODATA_REGION AT > lregion
 
+/* Make sure new sections have consistent alignment between input and output sections */
+#undef SECTION_PROLOGUE
+#define SECTION_PROLOGUE SECTION_DATA_PROLOGUE
+
 MEMORY
 {
 #ifdef CONFIG_BOOTLOADER_MCUBOOT

--- a/soc/espressif/esp32c3/default.ld
+++ b/soc/espressif/esp32c3/default.ld
@@ -41,6 +41,10 @@ user_dram_seg_len = user_idram_size;
 #undef GROUP_ROM_LINK_IN
 #define GROUP_ROM_LINK_IN(vregion, lregion) > RODATA_REGION AT > lregion
 
+/* Make sure new sections have consistent alignment between input and output sections */
+#undef SECTION_PROLOGUE
+#define SECTION_PROLOGUE SECTION_DATA_PROLOGUE
+
 /* Global symbols required for espressif hal build */
 MEMORY
 {

--- a/soc/espressif/esp32c6/default.ld
+++ b/soc/espressif/esp32c6/default.ld
@@ -34,6 +34,10 @@ user_sram_size = (user_sram_end - user_sram_org);
 #undef GROUP_ROM_LINK_IN
 #define GROUP_ROM_LINK_IN(vregion, lregion) > CACHED_REGION AT > lregion
 
+/* Make sure new sections have consistent alignment between input and output sections */
+#undef SECTION_PROLOGUE
+#define SECTION_PROLOGUE SECTION_DATA_PROLOGUE
+
 /* TODO: add RTC support */
 #define RESERVE_RTC_MEM 0
 

--- a/soc/espressif/esp32s2/default.ld
+++ b/soc/espressif/esp32s2/default.ld
@@ -42,6 +42,10 @@ user_dram_seg_len = user_idram_size;
 #undef GROUP_ROM_LINK_IN
 #define GROUP_ROM_LINK_IN(vregion, lregion) > RODATA_REGION AT > lregion
 
+/* Make sure new sections have consistent alignment between input and output sections */
+#undef SECTION_PROLOGUE
+#define SECTION_PROLOGUE SECTION_DATA_PROLOGUE
+
 #define RESERVE_RTC_MEM 0
 
 MEMORY

--- a/soc/espressif/esp32s3/default.ld
+++ b/soc/espressif/esp32s3/default.ld
@@ -41,6 +41,10 @@ user_dram_seg_len = user_idram_size;
 #undef GROUP_ROM_LINK_IN
 #define GROUP_ROM_LINK_IN(vregion, lregion) > RODATA_REGION AT > lregion
 
+/* Make sure new sections have consistent alignment between input and output sections */
+#undef SECTION_PROLOGUE
+#define SECTION_PROLOGUE SECTION_DATA_PROLOGUE
+
 MEMORY
 {
 #ifdef CONFIG_BOOTLOADER_MCUBOOT


### PR DESCRIPTION
ESP32 requires proper alignment between sections. There are some scenarios, as reported in #74533, that the section can get shifted, causing runtime failure.
Making sure SECTION_PROLOGUE is used with ALIGN_WITH_INPUT will guarantee its consistency.

Fixes #74533