### PR TITLE
drivers: sensor: npm1300: Fixed discharge current scaling

### DIFF
--- a/drivers/sensor/nordic/npm1300_charger/npm1300_charger.c
+++ b/drivers/sensor/nordic/npm1300_charger/npm1300_charger.c
@@ -189,7 +189,7 @@ static void calc_current(const struct npm1300_charger_config *const config,
 
 	switch (data->ibat_stat) {
 	case IBAT_STAT_DISCHARGE:
-		full_scale_ma = config->dischg_limit_microamp / 1000;
+		full_scale_ma = config->dischg_limit_microamp / 1196;
 		break;
 	case IBAT_STAT_CHARGE_TRICKLE:
 	/* Fallthrough */


### PR DESCRIPTION
The scaling factor for current measurement was incorrect. Full range scaling during discharge is discharge current limit / 1.196.