### PR TITLE
intel-adsp/ace: fix firmware panic on MTL

### DIFF
--- a/soc/intel/intel_adsp/ace/power.c
+++ b/soc/intel/intel_adsp/ace/power.c
@@ -339,7 +339,8 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 					(void *)rom_entry;
 			sys_cache_data_flush_range((void *)imr_layout, sizeof(*imr_layout));
 #endif /* CONFIG_ADSP_IMR_CONTEXT_SAVE */
-			uint32_t hpsram_mask = 0;
+			/* This assumes a single HPSRAM segment */
+			static uint32_t hpsram_mask;
 #ifdef CONFIG_ADSP_POWER_DOWN_HPSRAM
 			/* turn off all HPSRAM banks - get a full bitmap */
 			uint32_t ebb_banks = ace_hpsram_get_bank_count();

--- a/soc/intel/intel_adsp/ace/power_down.S
+++ b/soc/intel/intel_adsp/ace/power_down.S
@@ -60,6 +60,10 @@ power_down:
 	ipfl pfl_reg, 128
 	ipfl pfl_reg, 192
 
+	/*
+	 * This assumes a single HPSRAM segment although the code below is
+	 * generic and uses MAX_MEMORY_SEGMENTS for their number
+	 */
 	mov  pfl_reg, pu32_hpsram_mask
 	dpfl pfl_reg, 0
 	/* move some values to registries before switching off whole memory */


### PR DESCRIPTION
The power_down() function attempts to lock the hpsram_mask on-stack variable in data cache, which causes an exception. Moving it to .bss by making it static fixes it.