### PR TITLE
ARCMWDT: Fix issues with posix types

### DIFF
--- a/include/zephyr/posix/posix_types.h
+++ b/include/zephyr/posix/posix_types.h
@@ -21,7 +21,9 @@
 extern "C" {
 #endif
 
+#if !defined(CONFIG_ARCMWDT_LIBC)
 typedef int pid_t;
+#endif
 
 #ifndef __useconds_t_defined
 typedef unsigned long useconds_t;

--- a/lib/libc/arcmwdt/include/signal.h
+++ b/lib/libc/arcmwdt/include/signal.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2024 Synopsys
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef LIB_LIBC_ARCMWDT_INCLUDE_SIGNAL_H_
+#define LIB_LIBC_ARCMWDT_INCLUDE_SIGNAL_H_
+
+#include <zephyr/posix/signal.h>
+
+#endif /* LIB_LIBC_ARCMWDT_INCLUDE_SIGNAL_H_ */


### PR DESCRIPTION
Fix posix pid_t type redifiniton (zephyr vs arcmwdtlib). Add omitted in arcmwdtlib type sigevent.

This Fixes https://github.com/zephyrproject-rtos/zephyr/issues/75105