### PR TITLE
llext: add explicit cast to fix Coverity CID: 392507

### DIFF
--- a/subsys/llext/llext_load.c
+++ b/subsys/llext/llext_load.c
@@ -105,7 +105,7 @@ static int llext_load_elf_data(struct llext_loader *ldr, struct llext *ext)
 		ldr->sect_map[i].offset = 0;
 	}
 
-	ldr->sect_hdrs = llext_peek(ldr, ldr->hdr.e_shoff);
+	ldr->sect_hdrs = (elf_shdr_t *) llext_peek(ldr, ldr->hdr.e_shoff);
 	if (ldr->sect_hdrs) {
 		ldr->sect_hdrs_on_heap = false;
 	} else {


### PR DESCRIPTION
I assume #74817 is a false positive; however I found a possible workaround for a similar case [in a ML](https://mails.dpdk.org/archives/dev/2021-December/231212.html):

    Downcasting a void* to struct aesni_gcm_session* caused the session
    data to be treated as tainted. Removing the void* temporary variable
    and adding a cast avoids this issue.

Try the same approach here to see if this prevents the `ldr->sect_hdrs` pointer from being treated as tainted.
