### PR TITLE
drivers: i2c: stm32: remove redundant new line

### DIFF
--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -1119,7 +1119,7 @@ int stm32_i2c_configure_timing(const struct device *dev, uint32_t clock)
 		return -EINVAL;
 	}
 
-	LOG_INF("I2C TIMING = 0x%x\n", timing);
+	LOG_INF("I2C TIMING = 0x%x", timing);
 	LL_I2C_SetTiming(i2c, timing);
 
 	return 0;


### PR DESCRIPTION
LOG_* adds "\n" by itself.

Fixes redundant lines during startup:

```
[00:00:00.100,000] <inf> i2c_ll_stm32_v2: I2C TIMING = 0xb0f6343d

[00:00:00.100,000] <inf> i2c_ll_stm32_v2: I2C TIMING = 0xb0f6343d

[00:00:00.100,000] <inf> i2c_ll_stm32_v2: I2C TIMING = 0xb0f6343d

[00:00:00.100,000] <inf> i2c_ll_stm32_v2: I2C TIMING = 0xb0f6343d

[00:00:00.100,000] <inf> flash_stm32_qspi: Reading SFDP
```