### PR TITLE
doc: Make PR description a contributor expectation

### DIFF
--- a/doc/contribute/contributor_expectations.rst
+++ b/doc/contribute/contributor_expectations.rst
@@ -93,6 +93,8 @@ PR Requirements
 - Each commit in the PR must provide a commit message following the
   :ref:`commit-guidelines`.
 
+- The PR description must include a summary of the changes and their rationales.
+
 - All files in the PR must comply with :ref:`Licensing
   Requirements<licensing_requirements>`.
 


### PR DESCRIPTION
Make a PR description an expectation/requirement for pull requests submitted to the zephyr project.

As a reviewer, I am getting annoyed with how many PRs that show up that are non trivial with no description. It does not seem very respectful to reviewers when a contributor neglects to put even a single character in the description, and this makes me not want to review the PR. Descriptions are helpful to have an idea of what I am about to review rather than starting by piecing together context clues.