### PR TITLE
tests: rtc: time_incrementing: set nsec member

### DIFF
--- a/tests/drivers/rtc/rtc_api/src/test_time.c
+++ b/tests/drivers/rtc/rtc_api/src/test_time.c
@@ -27,6 +27,9 @@ ZTEST(rtc_api, test_set_get_time)
 
 	gmtime_r(&timer_set, (struct tm *)(&datetime_set));
 
+	datetime_set.tm_isdst = -1;
+	datetime_set.tm_nsec = 0;
+
 	memset(&datetime_get, 0xFF, sizeof(datetime_get));
 
 	zassert_equal(rtc_set_time(rtc, &datetime_set), 0, "Failed to set time");

--- a/tests/drivers/rtc/rtc_api/src/test_time_incrementing.c
+++ b/tests/drivers/rtc/rtc_api/src/test_time_incrementing.c
@@ -29,6 +29,9 @@ ZTEST(rtc_api, test_time_counting)
 
 	gmtime_r(&timer_set, (struct tm *)(&datetime_set));
 
+	datetime_set.tm_isdst = -1;
+	datetime_set.tm_nsec = 0;
+
 	zassert_equal(rtc_set_time(rtc, &datetime_set), 0, "Failed to set time");
 
 	for (i = 0; i < RTC_TEST_TIME_COUNTING_POLL_LIMIT; i++) {

--- a/tests/drivers/rtc/rtc_api/src/test_y2k.c
+++ b/tests/drivers/rtc/rtc_api/src/test_y2k.c
@@ -28,7 +28,10 @@ ZTEST(rtc_api, test_y2k)
 		Y2K,
 	};
 
-	static struct rtc_time rtm[2];
+	static struct rtc_time rtm[2] = {
+		{.tm_isdst = -1, .tm_nsec = 0},
+		{.tm_isdst = -1, .tm_nsec = 0},
+	};
 	struct tm *const tm[2] = {
 		(struct tm *const)&rtm[0],
 		(struct tm *const)&rtm[1],


### PR DESCRIPTION
The rtc test suite uses timegm to convert a unix
timestamp to datetime, specifically struct tm which has no nsec field, so the nsec field is not initialized properly.

Update tests to init nsec and isdst members of struct rtc_time.