### PR TITLE
scripts: print the file name when decode syscall

### DIFF
--- a/scripts/build/parse_syscalls.py
+++ b/scripts/build/parse_syscalls.py
@@ -119,7 +119,7 @@ def analyze_headers(include_dir, scan_dir, file_list):
             try:
                 contents = fp.read()
             except Exception:
-                sys.stderr.write("Error decoding %s\n" % path)
+                sys.stderr.write("Error decoding %s (included in %s)\n" % (one_file, path))
                 raise
 
         fn = os.path.basename(one_file)


### PR DESCRIPTION
the script shows an incorrect file name, I check the wrong file first, then I find the script did not print the current reading file name.

Fix this to prevent others from wasting their time on this.

The new error message:

```
[1/179] Generating misc/generated/syscalls.json, misc/generated/struct_tags.json
Error decoding zmk/app/modules/hal/altera/drivers/altera_msgdma/HAL/src/altera_msgdma.c (included in zephyr/subsys/net/pkt_filter/ethernet.c)
Traceback (most recent call last):
  File "zephyr/scripts/build/parse_syscalls.py", line 216, in <module>
    main()
  File "zephyr/scripts/build/parse_syscalls.py", line 194, in main
    syscalls, tagged = analyze_headers(args.include, args.scan,
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "zephyr/scripts/build/parse_syscalls.py", line 120, in analyze_headers
    contents = fp.read()
               ^^^^^^^^^
  File "<frozen codecs>", line 322, in decode
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x92 in position 52638: invalid start byte
```