### PR TITLE
soc: mt8195: remove prompts for SoC kconfigs

### DIFF
--- a/boards/mediatek/mt8195_adsp/Kconfig.mt8195_adsp
+++ b/boards/mediatek/mt8195_adsp/Kconfig.mt8195_adsp
@@ -2,4 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_MT8195_ADSP
-	bool "Mediatek MT8195 Audio DSP"
+	select SOC_MT8195_ADSP
+	help
+	  Board with Mediatek MT8195 Audio DSP

--- a/boards/mediatek/mt8195_adsp/mt8195_adsp_defconfig
+++ b/boards/mediatek/mt8195_adsp/mt8195_adsp_defconfig
@@ -1,5 +1,4 @@
 # Copyright 2023 The ChromiumOS Authors
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_SOC_SERIES_MT8195_ADSP=y
 CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC=13000000

--- a/soc/mediatek/mtk_adsp/Kconfig
+++ b/soc/mediatek/mtk_adsp/Kconfig
@@ -2,12 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config SOC_FAMILY_MTK_ADSP
-	bool "Mediatek MT8xxx Series Audio DSPs"
+	bool
 	select XTENSA
 	select XTENSA_GEN_HANDLERS
+	help
+	  Mediatek MT8xxx Series Audio DSPs
 
 config SOC_SERIES_MT8195_ADSP
-	bool "Mediatek 8195 Audio DSP"
+	bool
 	select SOC_FAMILY_MTK_ADSP
 	help
 	  Mediatek MT8195 Audio DSP


### PR DESCRIPTION
This removes the prompts for the mt8195 and related kconfigs, so these cannot be overridden from command line (though technically they cannot be disabled as they are being selected). This also prevents them from appearing in the build .config file as not being set even when we are being for other SoCs.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/74347