### PR TITLE
drivers: counter: Update Counter support for Apollo4 SoCs

### DIFF
--- a/tests/drivers/counter/counter_basic_api/boards/apollo4p_evb.conf
+++ b/tests/drivers/counter/counter_basic_api/boards/apollo4p_evb.conf
@@ -1,0 +1,1 @@
+CONFIG_PM=n


### PR DESCRIPTION
Counter cannot use PM

Signed-off-by: Richard Wheatley <richard.wheatley@ambiq.com>