### PR TITLE
doc: releases: migration-guide-3.7: Add note for BT_LE_ADV_PARAM

### DIFF
--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -756,6 +756,22 @@ Bluetooth Host
   longer used in Zephyr 3.4.0 and later. Any references to this field should be removed. No further
   action is needed.
 
+* :c:macro:`BT_LE_ADV_PARAM` now returns a :code:`const` pointer.
+  Any place where the result is stored in a local variable such as
+  :code:`struct bt_le_adv_param *param = BT_LE_ADV_CONN;` will need to
+  be updated to :code:`const struct bt_le_adv_param *param = BT_LE_ADV_CONN;` or use it for
+  initialization like :code:`struct bt_le_adv_param param = *BT_LE_ADV_CONN;`
+
+  The change to :c:macro:`BT_LE_ADV_PARAM` also affects all of its derivatives, including but not
+  limited to:
+
+  * :c:macro:`BT_LE_ADV_CONN`
+  * :c:macro:`BT_LE_ADV_NCONN`
+  * :c:macro:`BT_LE_EXT_ADV_SCAN`
+  * :c:macro:`BT_LE_EXT_ADV_CODED_NCONN_NAME`
+
+  (:github:`75065`)
+
 Bluetooth Crypto
 ================
 


### PR DESCRIPTION
The macro was modified in a way that may cause issues for some. See e.g. 15d66ccc23b05805ba8eab7c8afe2fb1db7ad4af
for an example of it needing a change.

The migration guide GH PR number refers to the PR that modified the macro.