### PR TITLE
lib/posix: Get uptime in ticks instead of cycles

### DIFF
--- a/lib/posix/options/clock.c
+++ b/lib/posix/options/clock.c
@@ -225,7 +225,7 @@ static int __z_clock_nanosleep(clockid_t clock_id, int flags, const struct times
 		ns = rqtp->tv_sec * NSEC_PER_SEC + rqtp->tv_nsec;
 	}
 
-	uptime_ns = k_cyc_to_ns_ceil64(k_cycle_get_32());
+	uptime_ns = k_ticks_to_ns_ceil64(sys_clock_tick_get());
 
 	if (flags & TIMER_ABSTIME && clock_id == CLOCK_REALTIME) {
 		key = k_spin_lock(&rt_clock_base_lock);


### PR DESCRIPTION
__z_clock_nanosleep function was getting current time in cycles, via k_cycle_get_32(), to perform its time calculations. However, when calling k_sleep() to actually sleep, times are measured in ticks.

This causes a problem when there's a big skew between the uptime measured in cycles vs uptime measured in ticks: in some platforms, the system clock maybe up for a long time already when Zephyr starts counting ticks, for instance, while downloading an image via PXE. In this case, the calculations done inside __z_clock_nanosleep end up measuring a much bigger current time than expected, thus sleeping too much, basically all the time since system clock initialization.

This patch fixes that by avoiding the cycle trip: stick to ticks, instead. They start counting from Zephyr initialization instead, which is the expected uptime.

Fixes #69608