### PR TITLE
bluetooth: correct `bt_le_scan_param` scan type

### DIFF
--- a/samples/bluetooth/central_multilink/src/central_multilink.c
+++ b/samples/bluetooth/central_multilink/src/central_multilink.c
@@ -90,7 +90,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 static void start_scan(void)
 {
 	struct bt_le_scan_param scan_param = {
-		.type       = BT_HCI_LE_SCAN_PASSIVE,
+		.type       = BT_LE_SCAN_TYPE_PASSIVE,
 		.options    = BT_LE_SCAN_OPT_NONE,
 		.interval   = SCAN_INTERVAL,
 		.window     = SCAN_WINDOW,

--- a/samples/bluetooth/scan_adv/src/main.c
+++ b/samples/bluetooth/scan_adv/src/main.c
@@ -12,7 +12,6 @@
 #include <zephyr/sys/util.h>
 
 #include <zephyr/bluetooth/bluetooth.h>
-#include <zephyr/bluetooth/hci.h>
 
 static uint8_t mfg_data[] = { 0xff, 0xff, 0x00 };
 
@@ -29,7 +28,7 @@ static void scan_cb(const bt_addr_le_t *addr, int8_t rssi, uint8_t adv_type,
 int main(void)
 {
 	struct bt_le_scan_param scan_param = {
-		.type       = BT_HCI_LE_SCAN_PASSIVE,
+		.type       = BT_LE_SCAN_TYPE_PASSIVE,
 		.options    = BT_LE_SCAN_OPT_NONE,
 		.interval   = 0x0010,
 		.window     = 0x0010,

--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -1461,8 +1461,8 @@ void bt_hci_le_adv_report(struct net_buf *buf)
 
 static bool valid_le_scan_param(const struct bt_le_scan_param *param)
 {
-	if (param->type != BT_HCI_LE_SCAN_PASSIVE &&
-	    param->type != BT_HCI_LE_SCAN_ACTIVE) {
+	if (param->type != BT_LE_SCAN_TYPE_PASSIVE &&
+	    param->type != BT_LE_SCAN_TYPE_ACTIVE) {
 		return false;
 	}
 

--- a/subsys/bluetooth/mesh/adv.c
+++ b/subsys/bluetooth/mesh/adv.c
@@ -378,8 +378,8 @@ int bt_mesh_scan_active_set(bool active)
 int bt_mesh_scan_enable(void)
 {
 	struct bt_le_scan_param scan_param = {
-		.type = active_scanning ? BT_HCI_LE_SCAN_ACTIVE :
-					  BT_HCI_LE_SCAN_PASSIVE,
+		.type = active_scanning ? BT_LE_SCAN_TYPE_ACTIVE :
+					  BT_LE_SCAN_TYPE_PASSIVE,
 		.interval = MESH_SCAN_INTERVAL,
 		.window = MESH_SCAN_WINDOW
 	};

--- a/tests/bsim/bluetooth/host/privacy/peripheral/src/tester_rpa_expired.c
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/src/tester_rpa_expired.c
@@ -108,7 +108,7 @@ void start_rpa_scanning(void)
 {
 	/* Start passive scanning */
 	struct bt_le_scan_param scan_param = {
-		.type       = BT_HCI_LE_SCAN_PASSIVE,
+		.type       = BT_LE_SCAN_TYPE_PASSIVE,
 		.options    = BT_LE_SCAN_OPT_FILTER_DUPLICATE,
 		.interval   = 0x0040,
 		.window     = 0x0020,

--- a/tests/bsim/bluetooth/host/privacy/peripheral/src/tester_rpa_rotation.c
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/src/tester_rpa_rotation.c
@@ -122,7 +122,7 @@ void start_scanning(void)
 {
 	/* Start passive scanning */
 	struct bt_le_scan_param scan_param = {
-		.type       = BT_HCI_LE_SCAN_PASSIVE,
+		.type       = BT_LE_SCAN_TYPE_PASSIVE,
 		.options    = BT_LE_SCAN_OPT_FILTER_DUPLICATE,
 		.interval   = 0x0040,
 		.window     = 0x0020,

--- a/tests/bsim/bluetooth/ll/advx/src/main.c
+++ b/tests/bsim/bluetooth/ll/advx/src/main.c
@@ -1300,7 +1300,7 @@ static struct bt_le_per_adv_sync_cb sync_cb = {
 static void test_scanx_main(void)
 {
 	struct bt_le_scan_param scan_param = {
-		.type       = BT_HCI_LE_SCAN_ACTIVE,
+		.type       = BT_LE_SCAN_TYPE_ACTIVE,
 		.options    = BT_LE_SCAN_OPT_NONE,
 		.interval   = 0x0004,
 		.window     = 0x0004,

--- a/tests/bsim/bluetooth/ll/bis/src/main.c
+++ b/tests/bsim/bluetooth/ll/bis/src/main.c
@@ -753,7 +753,7 @@ static struct bt_le_scan_cb scan_callbacks = {
 static void test_iso_recv_main(void)
 {
 	struct bt_le_scan_param scan_param = {
-		.type       = BT_HCI_LE_SCAN_ACTIVE,
+		.type       = BT_LE_SCAN_TYPE_ACTIVE,
 		.options    = BT_LE_SCAN_OPT_NONE,
 		.interval   = 0x0004,
 		.window     = 0x0004,
@@ -1028,7 +1028,7 @@ static void test_iso_recv_main(void)
 static void test_iso_recv_vs_dp_main(void)
 {
 	struct bt_le_scan_param scan_param = {
-		.type       = BT_HCI_LE_SCAN_ACTIVE,
+		.type       = BT_LE_SCAN_TYPE_ACTIVE,
 		.options    = BT_LE_SCAN_OPT_NONE,
 		.interval   = 0x0004,
 		.window     = 0x0004,

--- a/tests/bsim/bluetooth/mesh/src/mesh_test.c
+++ b/tests/bsim/bluetooth/mesh/src/mesh_test.c
@@ -569,7 +569,7 @@ void bt_mesh_test_send_over_adv(void *data, size_t len)
 int bt_mesh_test_wait_for_packet(bt_le_scan_cb_t scan_cb, struct k_sem *observer_sem, uint16_t wait)
 {
 	struct bt_le_scan_param scan_param = {
-		.type       = BT_HCI_LE_SCAN_PASSIVE,
+		.type       = BT_LE_SCAN_TYPE_PASSIVE,
 		.options    = BT_LE_SCAN_OPT_NONE,
 		.interval   = BT_MESH_ADV_SCAN_UNIT(1000),
 		.window     = BT_MESH_ADV_SCAN_UNIT(1000)


### PR DESCRIPTION
The `type` parameter of `struct bt_le_scan_param` is documented as taking a `BT_LE_SCAN_TYPE_*` value, not a `BT_HCI_LE_SCAN_*` value.

In practice this makes no difference as the values are defined as the same integer, but does result in `<zephyr/bluetooth/hci.h>` not needing to be included.