### PR TITLE
Revert "soc: riscv-privileged: support SoCs without reset vector #71052"

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -48,10 +48,11 @@ config RISCV_EXCEPTION_STACK_TRACE
 menu "RISCV Processor Options"
 
 config INCLUDE_RESET_VECTOR
-	bool "Include Reset vector"
+	bool "Jumps to __initialize directly"
 	help
-	  Include the reset vector stub, which initializes the stack and
-	  prepares for running C code.
+	  Select 'y' here to use the Zephyr provided default implementation that
+	  jumps to `__initialize` directly. Otherwise a SOC needs to provide its
+	  custom `__reset` routine.
 
 config RISCV_PRIVILEGED
 	bool

--- a/soc/common/riscv-privileged/vector.S
+++ b/soc/common/riscv-privileged/vector.S
@@ -103,10 +103,5 @@ SECTION_FUNC(vectors, __start)
 
 #endif /* CONFIG_RISCV_VECTORED_MODE */
 
-#if CONFIG_INCLUDE_RESET_VECTOR
 	/* Jump to __reset */
 	tail __reset
-#else
-	/* Jump to __initialize */
-	tail __initialize
-#endif

--- a/soc/nordic/common/vpr/Kconfig
+++ b/soc/nordic/common/vpr/Kconfig
@@ -18,5 +18,6 @@ config RISCV_CORE_NORDIC_VPR
 	select RISCV_SOC_CONTEXT_SAVE
 	select HAS_FLASH_LOAD_OFFSET
 	select ARCH_CPU_IDLE_CUSTOM
+	select INCLUDE_RESET_VECTOR
 	help
 	  Enable support for the RISC-V Nordic VPR core.


### PR DESCRIPTION
- Revert "#71052"
- Update the description of RISC-V's `CONFIG_INCLUDE_RESET_VECTOR`
- Update `RISCV_CORE_NORDIC_VPR` to select `INCLUDE_RESET_VECTOR` for bisectability

Fixes #75145