### PR TITLE
drivers: ethernet: phy_mii: check if there is a mdio config

### DIFF
--- a/drivers/ethernet/phy/phy_mii.c
+++ b/drivers/ethernet/phy/phy_mii.c
@@ -49,6 +49,10 @@ static inline int reg_read(const struct device *dev, uint16_t reg_addr,
 {
 	const struct phy_mii_dev_config *const cfg = dev->config;
 
+	/* if there is no mdio (fixed-link) it is not supported to read */
+	if (cfg->mdio == NULL) {
+		return -ENOTSUP;
+	}
 	return mdio_read(cfg->mdio, cfg->phy_addr, reg_addr, value);
 }
 
@@ -57,6 +61,10 @@ static inline int reg_write(const struct device *dev, uint16_t reg_addr,
 {
 	const struct phy_mii_dev_config *const cfg = dev->config;
 
+	/* if there is no mdio (fixed-link) it is not supported to write */
+	if (cfg->mdio == NULL) {
+		return -ENOTSUP;
+	}
 	return mdio_write(cfg->mdio, cfg->phy_addr, reg_addr, value);
 }
 


### PR DESCRIPTION
In fixed-link mode, mdio remains unconfigured. This results in a null pointer dereference, triggering a bus fault