### PR TITLE
fs: nvs: Add more strict checks to determine if an ATE is valid

### DIFF
--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -399,17 +399,19 @@ static int nvs_ate_cmp_const(const struct nvs_ate *entry, uint8_t value)
 }
 
 /* nvs_ate_valid validates an ate:
- *     return 1 if crc8 and offset valid,
+ *     return 1 if crc8, offset and length are valid,
  *            0 otherwise
  */
 static int nvs_ate_valid(struct nvs_fs *fs, const struct nvs_ate *entry)
 {
 	size_t ate_size;
+	uint32_t position;
 
 	ate_size = nvs_al_size(fs, sizeof(struct nvs_ate));
+	position = entry->offset + entry->len;
 
 	if ((nvs_ate_crc8_check(entry)) ||
-	    (entry->offset >= (fs->sector_size - ate_size))) {
+	    (position >= (fs->sector_size - ate_size))) {
 		return 0;
 	}
 


### PR DESCRIPTION
Make sure that the ATE metadata does not overflow the sector size.
Take into account the data length and also the mandatory reserved ATEs in each sector.