### PR TITLE
doc: detail how to find the drop-down version selector

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -9,7 +9,7 @@
     <div class="wy-alert wy-alert-danger" data-nosnippet>
      This is the documentation for the latest (main) development branch of
      Zephyr. If you are looking for the documentation of previous releases, use
-     the drop-down menu on the left and select the desired version.
+     the drop-down list at the bottom of the left panel and select the desired version.
     </div>
   {% endif %}
   {{ super() }}


### PR DESCRIPTION
Adding more guidance in the documentation website top banner