### PR TITLE
logging: Do not store module name pointer when strings are stripped

### DIFF
--- a/include/zephyr/logging/log.h
+++ b/include/zephyr/logging/log.h
@@ -328,7 +328,8 @@ void z_log_vprintk(const char *fmt, va_list ap);
 		log_source_const_data,								\
 		Z_LOG_ITEM_CONST_DATA(_name)) =							\
 	{											\
-		.name = COND_CODE_1(CONFIG_LOG_FMT_SECTION,					\
+		.name = IS_ENABLED(LOG_FMT_SECTION_STRIP) ? NULL :				\
+			COND_CODE_1(CONFIG_LOG_FMT_SECTION,					\
 				(UTIL_CAT(_name, _str)), (STRINGIFY(_name))),			\
 		.level = (_level)								\
 	}


### PR DESCRIPTION
When logging strings are stripped then addresses to log module names are invalid. Do not store that address in the const data structure associated with the logging module to avoid someone accessing it. Store null instead.

Fixes #75161.