### PR TITLE
net: hostname: Add a function to set the hostname postfix as is

### DIFF
--- a/doc/connectivity/networking/api/net_hostname.rst
+++ b/doc/connectivity/networking/api/net_hostname.rst
@@ -27,10 +27,12 @@ interface is used as a postfix. In Ethernet networks, the link local address
 refers to MAC address. For example, if the link local address is
 ``01:02:03:04:05:06``, then the unique hostname could be
 ``zephyr010203040506``. If you want to set the prefix yourself, then call
-``net_hostname_set_postfix()`` before the network interfaces are created.
-For example for the Ethernet networks, the initialization priority is set by
-:kconfig:option:`CONFIG_ETH_INIT_PRIORITY` so you would need to set the postfix before
-that. The postfix can be set only once.
+``net_hostname_set_postfix_str()`` before the network interfaces are created.
+Alternatively, if you prefer a hexadecimal conversion for the prefix, then call
+``net_hostname_set_postfix()``. For example for the Ethernet networks,
+the initialization priority is set by :kconfig:option:`CONFIG_ETH_INIT_PRIORITY`
+so you would need to set the postfix before that.
+The postfix can be set only once.
 
 API Reference
 *************

--- a/include/zephyr/net/hostname.h
+++ b/include/zephyr/net/hostname.h
@@ -92,11 +92,12 @@ static inline void net_hostname_init(void)
 /**
  * @brief Set the device hostname postfix
  *
- * @details Set the device hostname to some value. This is only used if
+ * @details Convert the hostname postfix to hexadecimal value and set the
+ * device hostname with the converted value. This is only used if
  * CONFIG_NET_HOSTNAME_UNIQUE is set.
  *
  * @param hostname_postfix Usually link address. The function will convert this
- * to a string.
+ * to a hexadecimal string.
  * @param postfix_len Length of the hostname_postfix array.
  *
  * @return 0 if ok, <0 if error
@@ -106,6 +107,33 @@ int net_hostname_set_postfix(const uint8_t *hostname_postfix,
 			      int postfix_len);
 #else
 static inline int net_hostname_set_postfix(const uint8_t *hostname_postfix,
+					   int postfix_len)
+{
+	ARG_UNUSED(hostname_postfix);
+	ARG_UNUSED(postfix_len);
+	return -EMSGSIZE;
+}
+#endif /* CONFIG_NET_HOSTNAME_UNIQUE */
+
+/**
+ * @brief Set the postfix string for the network hostname.
+ *
+ * @details Set the hostname postfix string for the network hostname as is, without any conversion.
+ * This is only used if CONFIG_NET_HOSTNAME_UNIQUE is set. The function checks if the combined
+ * length of the default hostname (defined by CONFIG_NET_HOSTNAME) and the postfix does not exceed
+ * NET_HOSTNAME_MAX_LEN. If the postfix is too long, the function returns an
+ * error.
+ *
+ * @param hostname_postfix Pointer to the postfix string to be appended to the network hostname.
+ * @param postfix_len Length of the hostname_postfix array.
+ *
+ * @return 0 if ok, <0 if error
+ */
+#if defined(CONFIG_NET_HOSTNAME_UNIQUE)
+int net_hostname_set_postfix_str(const uint8_t *hostname_postfix,
+			     int postfix_len);
+#else
+static inline int net_hostname_set_postfix_str(const uint8_t *hostname_postfix,
 					   int postfix_len)
 {
 	ARG_UNUSED(hostname_postfix);


### PR DESCRIPTION
Fixes: #72363

The existing function to set the postfix is converting postfix string to hexadecimal. Adding a new function to handle a use case where the provided postfix should be used as is without any conversion.