### PR TITLE
hal_espressif: remove extra not-used constructor

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -157,7 +157,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 826077a9d9c762ea7033f137b992b1b36b4aeacb
+      revision: 61b977fd2b033c656b1b2fa07b3137872236f710
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
After #74682, any function with constructor attribution requires additional configuration. Due to some left-over and not-used code in hal_espressif with that attribution, some samples started failing. This is an additional to ##75063

Fixes #75169