### PR TITLE
drivers: mipi-dbi: add support for st,stm32-fmc

### DIFF
--- a/boards/st/stm32l562e_dk/Kconfig.defconfig
+++ b/boards/st/stm32l562e_dk/Kconfig.defconfig
@@ -25,4 +25,9 @@ config BT_HCI_VS
 
 endif # BT
 
+if MIPI_DBI_STM32_FMC
+	config MIPI_DBI_STM32_FMC_MEM_BARRIER
+	default n
+endif # MIPI_DBI_STM32_FMC
+
 endif # BOARD_STM32L562E_DK

--- a/boards/st/stm32l562e_dk/Kconfig.defconfig
+++ b/boards/st/stm32l562e_dk/Kconfig.defconfig
@@ -25,9 +25,15 @@ config BT_HCI_VS
 
 endif # BT
 
-if MIPI_DBI_STM32_FMC
-	config MIPI_DBI_STM32_FMC_MEM_BARRIER
-	default n
-endif # MIPI_DBI_STM32_FMC
+config MIPI_DBI_STM32_FMC_MEM_BARRIER
+	default n if MIPI_DBI_STM32_FMC
+
+if DISPLAY
+
+choice ST7789V_PIXEL_FORMAT
+	default ST7789V_BGR565
+endchoice
+
+endif # DISPLAY
 
 endif # BOARD_STM32L562E_DK

--- a/boards/st/stm32l562e_dk/stm32l562e_dk.dts
+++ b/boards/st/stm32l562e_dk/stm32l562e_dk.dts
@@ -20,6 +20,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,bt-c2h-uart = &usart1;
+		zephyr,display = &st7789v;
 	};
 
 	aliases {

--- a/boards/st/stm32l562e_dk/stm32l562e_dk_common.dtsi
+++ b/boards/st/stm32l562e_dk/stm32l562e_dk_common.dtsi
@@ -8,6 +8,8 @@
 #include <st/l5/stm32l562qeixq-pinctrl.dtsi>
 #include "arduino_r3_connector.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/memory-controller/stm32-fmc-nor-psram.h>
+#include <zephyr/dt-bindings/mipi_dbi/mipi_dbi.h>
 
 / {
 	leds {
@@ -39,6 +41,76 @@
 
 	chosen {
 		zephyr,bt-hci = &hci_spi;
+	};
+};
+
+&fmc {
+	pinctrl-0 = <&fmc_a0_pf0 &fmc_nce_pd7 &fmc_nwe_pd5 &fmc_noe_pd4
+		     &fmc_d0_pd14 &fmc_d1_pd15 &fmc_d2_pd0 &fmc_d3_pd1
+		     &fmc_d4_pe7 &fmc_d5_pe8 &fmc_d6_pe9 &fmc_d7_pe10
+		     &fmc_d8_pe11 &fmc_d9_pe12 &fmc_d10_pe13 &fmc_d11_pe14
+		     &fmc_d12_pe15 &fmc_d13_pd8 &fmc_d14_pd9 &fmc_d15_pd10>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	sram {
+		compatible = "st,stm32-fmc-nor-psram";
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		bank@0 {
+			reg = <0x0>;
+			st,control = <STM32_FMC_DATA_ADDRESS_MUX_DISABLE
+				STM32_FMC_MEMORY_TYPE_SRAM
+				STM32_FMC_NORSRAM_MEM_BUS_WIDTH_16
+				STM32_FMC_BURST_ACCESS_MODE_DISABLE
+				STM32_FMC_WAIT_SIGNAL_POLARITY_LOW
+				STM32_FMC_WAIT_TIMING_BEFORE_WS
+				STM32_FMC_WRITE_OPERATION_ENABLE
+				STM32_FMC_WAIT_SIGNAL_DISABLE
+				STM32_FMC_EXTENDED_MODE_DISABLE
+				STM32_FMC_ASYNCHRONOUS_WAIT_DISABLE
+				STM32_FMC_WRITE_BURST_DISABLE
+				STM32_FMC_CONTINUOUS_CLOCK_SYNC_ONLY
+				STM32_FMC_WRITE_FIFO_DISABLE
+				STM32_FMC_PAGE_SIZE_NONE>;
+			st,timing = <1 1 32 0 2 2 STM32_FMC_ACCESS_MODE_A>;
+
+			fmc-mipi-dbi {
+				compatible = "st,stm32-fmc-mipi-dbi";
+				reset-gpios = <&gpiof 14 GPIO_ACTIVE_LOW>;
+				power-gpios = <&gpioh 0 GPIO_ACTIVE_LOW>;
+				register-select-pin = <0>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				st7789v: lcd-panel@0 {
+					compatible = "sitronix,st7789v";
+					reg = <0>;
+					mipi-mode = <MIPI_DBI_MODE_8080_BUS_16_BIT>;
+					/* A write cycle should be 68ns */
+					mipi-max-frequency = <14705882>;
+					width = <240>;
+					height = <240>;
+					x-offset = <0>;
+					y-offset = <0>;
+					vcom = <0x1F>;
+					gctrl = <0x35>;
+					vdvs = <0x20>;
+					mdac = <0x00>;
+					gamma = <0x01>;
+					colmod = <0x05>;
+					lcm = <0x2c>;
+					porch-param = [0c 0c 00 33 33];
+					cmd2en-param = [5a 69 02 00];
+					pwctrl1-param = [a4 a1];
+					pvgam-param = [D0 08 11 08 0C 15 39 33 50 36 13 14 29 2D];
+					nvgam-param = [D0 08 10 08 06 06 39 44 51 0B 16 14 2F 31];
+					ram-param = [00 F0];
+					rgb-param = [40 02 14];
+				};
+			};
+		};
 	};
 };
 

--- a/drivers/display/Kconfig.st7789v
+++ b/drivers/display/Kconfig.st7789v
@@ -24,4 +24,7 @@ config ST7789V_RGB888
 config ST7789V_RGB565
 	bool "RGB565"
 
+config ST7789V_BGR565
+	bool "BGR565"
+
 endchoice

--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -52,10 +52,10 @@ struct st7789v_data {
 	uint16_t y_offset;
 };
 
-#ifdef CONFIG_ST7789V_RGB565
-#define ST7789V_PIXEL_SIZE 2u
-#else
+#ifdef CONFIG_ST7789V_RGB888
 #define ST7789V_PIXEL_SIZE 3u
+#else
+#define ST7789V_PIXEL_SIZE 2u
 #endif
 
 static void st7789v_set_lcd_margins(const struct device *dev,
@@ -164,6 +164,8 @@ static int st7789v_write(const struct device *dev,
 	}
 	if (IS_ENABLED(CONFIG_ST7789V_RGB565)) {
 		pixfmt = PIXEL_FORMAT_RGB_565;
+	} else if (IS_ENABLED(CONFIG_ST7789V_BGR565)) {
+		pixfmt = PIXEL_FORMAT_BGR_565;
 	} else {
 		pixfmt = PIXEL_FORMAT_RGB_888;
 	}
@@ -197,6 +199,9 @@ static void st7789v_get_capabilities(const struct device *dev,
 #ifdef CONFIG_ST7789V_RGB565
 	capabilities->supported_pixel_formats = PIXEL_FORMAT_RGB_565;
 	capabilities->current_pixel_format = PIXEL_FORMAT_RGB_565;
+#elif CONFIG_ST7789V_BGR565
+	capabilities->supported_pixel_formats = PIXEL_FORMAT_BGR_565;
+	capabilities->current_pixel_format = PIXEL_FORMAT_BGR_565;
 #else
 	capabilities->supported_pixel_formats = PIXEL_FORMAT_RGB_888;
 	capabilities->current_pixel_format = PIXEL_FORMAT_RGB_888;
@@ -209,6 +214,8 @@ static int st7789v_set_pixel_format(const struct device *dev,
 {
 #ifdef CONFIG_ST7789V_RGB565
 	if (pixel_format == PIXEL_FORMAT_RGB_565) {
+#elif CONFIG_ST7789V_BGR565
+	if (pixel_format == PIXEL_FORMAT_BGR_565) {
 #else
 	if (pixel_format == PIXEL_FORMAT_RGB_888) {
 #endif

--- a/drivers/mipi_dbi/CMakeLists.txt
+++ b/drivers/mipi_dbi/CMakeLists.txt
@@ -6,6 +6,7 @@ zephyr_sources_ifdef(CONFIG_MIPI_DBI_SPI mipi_dbi_spi.c)
 zephyr_sources_ifdef(CONFIG_MIPI_DBI_SMARTBOND mipi_dbi_smartbond.c)
 zephyr_sources_ifdef(CONFIG_MIPI_DBI_NXP_LCDIC mipi_dbi_nxp_lcdic.c)
 zephyr_sources_ifdef(CONFIG_MIPI_DBI_NXP_FLEXIO_LCDIF mipi_dbi_nxp_flexio_lcdif.c)
+zephyr_sources_ifdef(CONFIG_MIPI_DBI_STM32_FMC mipi_dbi_stm32_fmc.c)
 # Data bus width is used by the SDK driver and processes it as a compile time option
 if(CONFIG_MIPI_DBI_NXP_FLEXIO_LCDIF)
   dt_chosen(flexio0_lcd PROPERTY "zephyr,display")

--- a/drivers/mipi_dbi/Kconfig
+++ b/drivers/mipi_dbi/Kconfig
@@ -25,5 +25,6 @@ source "drivers/mipi_dbi/Kconfig.spi"
 source "drivers/mipi_dbi/Kconfig.smartbond"
 source "drivers/mipi_dbi/Kconfig.nxp_lcdic"
 source "drivers/mipi_dbi/Kconfig.nxp_flexio_lcdif"
+source "drivers/mipi_dbi/Kconfig.stm32_fmc"
 
 endif

--- a/drivers/mipi_dbi/Kconfig.stm32_fmc
+++ b/drivers/mipi_dbi/Kconfig.stm32_fmc
@@ -1,0 +1,18 @@
+# Copyright (c) 2024 Bootlin
+# SPDX-License-Identifier: Apache-2.0
+
+config MIPI_DBI_STM32_FMC
+	bool "MIPI DBI driver for STM32 FMC"
+	default y
+	depends on DT_HAS_ST_STM32_FMC_MIPI_DBI_ENABLED
+	select MEMC
+	help
+	  Enable support for MIPI DBI driver for controller based on the stm32 FMC.
+
+if MIPI_DBI_STM32_FMC
+
+config MIPI_DBI_STM32_FMC_MEM_BARRIER
+	bool "Adds memory barrier after every address and data register access"
+	default y
+
+endif # MIPI_DBI_STM32_FMC

--- a/drivers/mipi_dbi/mipi_dbi_stm32_fmc.c
+++ b/drivers/mipi_dbi/mipi_dbi_stm32_fmc.c
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2024 Bootlin
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT st_stm32_fmc_mipi_dbi
+
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/mipi_dbi.h>
+#include <zephyr/drivers/clock_control/stm32_clock_control.h>
+#include <zephyr/sys/barrier.h>
+#include <zephyr/sys/sys_io.h>
+#include <zephyr/sys/byteorder.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(mipi_dbi_stm32_fmc, CONFIG_MIPI_DBI_LOG_LEVEL);
+
+struct mipi_dbi_stm32_fmc_config {
+	/* Reset GPIO */
+	const struct gpio_dt_spec reset;
+	/* Power GPIO */
+	const struct gpio_dt_spec power;
+	mem_addr_t register_addr;
+	mem_addr_t data_addr;
+	uint32_t fmc_address_setup_time;
+	uint32_t fmc_data_setup_time;
+	uint32_t fmc_memory_width;
+};
+
+struct mipi_dbi_stm32_fmc_data {
+	const struct mipi_dbi_config *dbi_config;
+};
+
+int mipi_dbi_stm32_fmc_check_config(const struct device *dev,
+				    const struct mipi_dbi_config *dbi_config)
+{
+	const struct mipi_dbi_stm32_fmc_config *config = dev->config;
+	struct mipi_dbi_stm32_fmc_data *data = dev->data;
+	uint32_t fmc_write_cycles;
+
+	if (data->dbi_config == dbi_config) {
+		return 0;
+	}
+
+	if (dbi_config->mode != MIPI_DBI_MODE_8080_BUS_16_BIT) {
+		LOG_ERR("Only support Intel 8080 16-bits");
+		return -ENOTSUP;
+	}
+
+	if (config->fmc_memory_width != FMC_NORSRAM_MEM_BUS_WIDTH_16) {
+		LOG_ERR("Only supports 16-bit bus width");
+		return -EINVAL;
+	}
+
+	uint32_t hclk_freq =
+		STM32_AHB_PRESCALER * DT_PROP(STM32_CLOCK_CONTROL_NODE, clock_frequency);
+
+	/* According to the FMC documentation*/
+	fmc_write_cycles =
+		((config->fmc_address_setup_time + 1) + (config->fmc_data_setup_time + 1)) * 1;
+
+	if (hclk_freq / fmc_write_cycles > dbi_config->config.frequency) {
+		LOG_ERR("Frequency is too high for the display controller");
+		return -EINVAL;
+	}
+
+	data->dbi_config = dbi_config;
+	return 0;
+}
+
+int mipi_dbi_stm32_fmc_command_write(const struct device *dev,
+				     const struct mipi_dbi_config *dbi_config, uint8_t cmd,
+				     const uint8_t *data_buf, size_t len)
+{
+	const struct mipi_dbi_stm32_fmc_config *config = dev->config;
+	int ret;
+	size_t i;
+
+	ret = mipi_dbi_stm32_fmc_check_config(dev, dbi_config);
+	if (ret < 0) {
+		return ret;
+	}
+
+	sys_write16(cmd, config->register_addr);
+	if (IS_ENABLED(CONFIG_MIPI_DBI_STM32_FMC_MEM_BARRIER)) {
+		barrier_dsync_fence_full();
+	}
+
+	for (i = 0U; i < len; i++) {
+		sys_write16((uint16_t)data_buf[i], config->data_addr);
+		if (IS_ENABLED(CONFIG_MIPI_DBI_STM32_FMC_MEM_BARRIER)) {
+			barrier_dsync_fence_full();
+		}
+	}
+
+	return 0;
+}
+
+static int mipi_dbi_stm32_fmc_write_display(const struct device *dev,
+					    const struct mipi_dbi_config *dbi_config,
+					    const uint8_t *framebuf,
+					    struct display_buffer_descriptor *desc,
+					    enum display_pixel_format pixfmt)
+{
+	const struct mipi_dbi_stm32_fmc_config *config = dev->config;
+	size_t i;
+	int ret;
+
+	ret = mipi_dbi_stm32_fmc_check_config(dev, dbi_config);
+	if (ret < 0) {
+		return ret;
+	}
+
+	for (i = 0U; i < desc->buf_size; i += 2) {
+		sys_write16(sys_get_le16(&framebuf[i]), config->data_addr);
+		if (IS_ENABLED(CONFIG_MIPI_DBI_STM32_FMC_MEM_BARRIER)) {
+			barrier_dsync_fence_full();
+		}
+	}
+
+	return 0;
+}
+
+static int mipi_dbi_stm32_fmc_reset(const struct device *dev, uint32_t delay)
+{
+	const struct mipi_dbi_stm32_fmc_config *config = dev->config;
+	int ret;
+
+	if (config->reset.port == NULL) {
+		return -ENOTSUP;
+	}
+
+	ret = gpio_pin_set_dt(&config->reset, 1);
+	if (ret < 0) {
+		return ret;
+	}
+
+	k_msleep(delay);
+
+	return gpio_pin_set_dt(&config->reset, 0);
+}
+
+static int mipi_dbi_stm32_fmc_init(const struct device *dev)
+{
+	const struct mipi_dbi_stm32_fmc_config *config = dev->config;
+
+	if (config->reset.port) {
+		if (!gpio_is_ready_dt(&config->reset)) {
+			LOG_ERR("Reset GPIO device not ready");
+			return -ENODEV;
+		}
+
+		if (gpio_pin_configure_dt(&config->reset, GPIO_OUTPUT_INACTIVE)) {
+			LOG_ERR("Couldn't configure reset pin");
+			return -EIO;
+		}
+	}
+
+	if (config->power.port) {
+		if (!gpio_is_ready_dt(&config->power)) {
+			LOG_ERR("Power GPIO device not ready");
+			return -ENODEV;
+		}
+
+		if (gpio_pin_configure_dt(&config->power, GPIO_OUTPUT)) {
+			LOG_ERR("Couldn't configure power pin");
+			return -EIO;
+		}
+	}
+
+	return 0;
+}
+
+static struct mipi_dbi_driver_api mipi_dbi_stm32_fmc_driver_api = {
+	.reset = mipi_dbi_stm32_fmc_reset,
+	.command_write = mipi_dbi_stm32_fmc_command_write,
+	.write_display = mipi_dbi_stm32_fmc_write_display,
+};
+
+#define MIPI_DBI_FMC_GET_ADDRESS(n) _CONCAT(FMC_BANK1_, UTIL_INC(DT_REG_ADDR(DT_INST_PARENT(n))))
+
+#define MIPI_DBI_FMC_GET_DATA_ADDRESS(n)                                                           \
+	MIPI_DBI_FMC_GET_ADDRESS(n) + (1 << (DT_INST_PROP(n, register_select_pin) + 1))
+
+#define MIPI_DBI_STM32_FMC_INIT(n)                                                                 \
+	static const struct mipi_dbi_stm32_fmc_config mipi_dbi_stm32_fmc_config_##n = {            \
+		.reset = GPIO_DT_SPEC_INST_GET_OR(n, reset_gpios, {}),                             \
+		.power = GPIO_DT_SPEC_INST_GET_OR(n, power_gpios, {}),                             \
+		.register_addr = MIPI_DBI_FMC_GET_ADDRESS(n),                                      \
+		.data_addr = MIPI_DBI_FMC_GET_DATA_ADDRESS(n),                                     \
+		.fmc_address_setup_time = DT_PROP_BY_IDX(DT_INST_PARENT(n), st_timing, 0),         \
+		.fmc_data_setup_time = DT_PROP_BY_IDX(DT_INST_PARENT(n), st_timing, 2),            \
+		.fmc_memory_width = DT_PROP_BY_IDX(DT_INST_PARENT(n), st_control, 2),              \
+	};                                                                                         \
+                                                                                                   \
+	static struct mipi_dbi_stm32_fmc_data mipi_dbi_stm32_fmc_data_##n;                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(n, mipi_dbi_stm32_fmc_init, NULL, &mipi_dbi_stm32_fmc_data_##n,      \
+			      &mipi_dbi_stm32_fmc_config_##n, POST_KERNEL,                         \
+			      CONFIG_MIPI_DBI_INIT_PRIORITY, &mipi_dbi_stm32_fmc_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(MIPI_DBI_STM32_FMC_INIT)

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -704,6 +704,13 @@
 			interrupts = <106 0>;
 			status = "disabled";
 		};
+
+		fmc: fmc@44020000 {
+			compatible = "st,stm32-fmc";
+			reg = <0x44020000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x00000001>;
+			status = "disabled";
+		};
 	};
 
 	die_temp: dietemp {

--- a/dts/bindings/mipi-dbi/st,mipi-dbi-fmc.yaml
+++ b/dts/bindings/mipi-dbi/st,mipi-dbi-fmc.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2024 Bootlin
+# SPDX-License-Identifier: Apache-2.0
+
+description: STM32 FMC display controller
+compatible: "st,stm32-fmc-mipi-dbi"
+
+include: ["mipi-dbi-controller.yaml"]
+
+properties:
+  reset-gpios:
+    type: phandle-array
+    description: |
+      Reset GPIO pin. Set high to reset the display
+
+  power-gpios:
+    type: phandle-array
+    description: |
+      Power GPIO pin. Set high to power the display.
+
+  register-select-pin:
+    type: int
+    required: true
+    description: |
+      Address pin used as Register Select for the display controller.


### PR DESCRIPTION
This patch series adds the STM32 FMC memory controller and the st7789v display controller to the stm32l562e-dk board. It also adds a MIPI DBI driver for the STM32 FMC.

There is still an issue where I'm not sure what is the best way to solve it :

On the binding `mipi-dbi-device.yaml`, there is a property `mipi-max-frequency`. It's not required when using a memory controller as it is a variable needed for serial busses, but the macro `MIPI_DBI_CONFIG_DT_INST`, called in the st7789v driver invokes the macro `MIPI_DBI_SPI_CONFIG_DT`, wich uses this property to fill the field `frequency` of the struct `spi_config`.

But in my case, with the FMC, I don't need nor use the frequency property. But, due to this macro, I have to put a value. The driver works for any possible value, as I don't use the property. A possible workaround would be to create a version of the `MIPI_DBI_CONFIG_DT_INST` for the devices who don't need the spi_config struct ? But I'm not sure that is the right way.