### PR TITLE
STM32 WBA BLE Public Address Management properly reworked

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -71,6 +71,7 @@ config BT_STM32WBA
 	default y
 	depends on DT_HAS_ST_HCI_STM32WBA_ENABLED
 	select HAS_STM32LIB
+	select BT_HCI_SET_PUBLIC_ADDR
 	help
 	  ST STM32WBA HCI Bluetooth interface
 


### PR DESCRIPTION
STM32WBA BLE HCI driver was not able to set a unique BLE MAC address (specific for each device).
With this change CONFIG_BT_HCI_SET_PUBLIC_ADDR is used and a proper
implementation  of  "setup" interface has been provided.