### PR TITLE
boards: st/stm32wb5mm_dk: add arduino_r3_connector support

### DIFF
--- a/boards/st/stm32wb5mm_dk/arduino_r3_connector.dtsi
+++ b/boards/st/stm32wb5mm_dk/arduino_r3_connector.dtsi
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpioc 3 0>,	/* A0 */
+			   <1 0 &gpioa 2 0>,	/* A1 */
+			   <2 0 &gpioa 5 0>,	/* A2 */
+			   <3 0 &gpioc 1 0>,	/* A3 */
+			   <4 0 &gpioc 4 0>,	/* A4 */
+			   <5 0 &gpioc 5 0>,	/* A5 */
+			   <6 0 &gpioc 0 0>,	/* D0 */
+			   <7 0 &gpiob 5 0>,	/* D1 */
+			   <8 0 &gpiod 12 0>,	/* D2 */
+			   <9 0 &gpiod 14 0>,	/* D3 */
+			   <10 0 &gpioe 4 0>,	/* D4 */
+			   <11 0 &gpiob 10 0>,	/* D5 */
+			   <12 0 &gpioe 0 0>,	/* D6 */
+			   <13 0 &gpiob 2 0>,	/* D7 */
+			   <14 0 &gpiod 13 0>,	/* D8 */
+			   <15 0 &gpiod 15 0>,	/* D9 */
+			   <16 0 &gpioa 4 0>,	/* D10 */
+			   <17 0 &gpioa 7 0>,	/* D11 */
+			   <18 0 &gpiob 4 0>,	/* D12 */
+			   <19 0 &gpioa 1 0>,	/* D13 */
+			   <20 0 &gpioa 10 0>,	/* D14 */
+			   <21 0 &gpiob 8 0>;	/* D15 */
+	};
+};
+
+arduino_spi: &spi1 {};
+arduino_i2c: &i2c1 {};
+arduino_serial: &usart1 {};

--- a/boards/st/stm32wb5mm_dk/stm32wb5mm_dk.dts
+++ b/boards/st/stm32wb5mm_dk/stm32wb5mm_dk.dts
@@ -8,6 +8,7 @@
 #include <st/wb/stm32wb55Xg.dtsi>
 #include <st/wb/stm32wb55vgyx-pinctrl.dtsi>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include "arduino_r3_connector.dtsi"
 #include <zephyr/dt-bindings/led/led.h>
 #include <zephyr/dt-bindings/sensor/ism330dhcx.h>
 

--- a/boards/st/stm32wb5mm_dk/stm32wb5mm_dk.yaml
+++ b/boards/st/stm32wb5mm_dk/stm32wb5mm_dk.yaml
@@ -9,9 +9,12 @@ toolchain:
 ram: 256
 flash: 876
 supported:
+  - arduino_i2c
+  - arduino_spi
   - gpio
   - uart
   - i2c
+  - spi
   - vl53l0x
   - ism330dhcx
 vendor: st


### PR DESCRIPTION
This patch adds support for arduino_r3_connector in the DTS for 
stm32wb5mm_dk development board