### PR TITLE
llext: documentation-related code changes

### DIFF
--- a/subsys/llext/llext.c
+++ b/subsys/llext/llext.c
@@ -201,7 +201,7 @@ int llext_unload(struct llext **ext)
 	*ext = NULL;
 	k_mutex_unlock(&llext_lock);
 
-	llext_free_sections(tmp);
+	llext_free_regions(tmp);
 	llext_free(tmp->sym_tab.syms);
 	llext_free(tmp->exp_tab.syms);
 	llext_free(tmp);

--- a/subsys/llext/llext.c
+++ b/subsys/llext/llext.c
@@ -215,7 +215,7 @@ int llext_call_fn(struct llext *ext, const char *sym_name)
 
 	fn = llext_find_sym(&ext->exp_tab, sym_name);
 	if (fn == NULL) {
-		return -EINVAL;
+		return -ENOENT;
 	}
 	fn();
 

--- a/subsys/llext/llext_link.c
+++ b/subsys/llext/llext_link.c
@@ -28,7 +28,7 @@ LOG_MODULE_DECLARE(llext, CONFIG_LLEXT_LOG_LEVEL);
 __weak int arch_elf_relocate(elf_rela_t *rel, uintptr_t loc,
 			     uintptr_t sym_base_addr, const char *sym_name, uintptr_t load_bias)
 {
-	return -EOPNOTSUPP;
+	return -ENOTSUP;
 }
 
 __weak void arch_elf_relocate_local(struct llext_loader *ldr, struct llext *ext,

--- a/subsys/llext/llext_link.c
+++ b/subsys/llext/llext_link.c
@@ -239,17 +239,17 @@ int llext_link(struct llext_loader *ldr, struct llext *ext, bool do_local)
 			continue;
 		}
 
+		LOG_DBG("relocation section %s (%d) acting on section %d has %zd relocations",
+			name, i, shdr->sh_info, (size_t)rel_cnt);
+
 		enum llext_mem mem_idx = ldr->sect_map[shdr->sh_info].mem_idx;
 
 		if (mem_idx == LLEXT_MEM_COUNT) {
-			LOG_ERR("Section %d has no corresponding memory region", shdr->sh_info);
+			LOG_ERR("Section %d not loaded in any memory region", shdr->sh_info);
 			return -ENOEXEC;
 		}
 
 		sect_base = (uintptr_t)llext_loaded_sect_ptr(ldr, ext, shdr->sh_info);
-
-		LOG_DBG("relocation section %s (%d) acting on section %d has %zd relocations",
-			name, i, shdr->sh_info, (size_t)rel_cnt);
 
 		for (int j = 0; j < rel_cnt; j++) {
 			/* get each relocation entry */

--- a/subsys/llext/llext_load.c
+++ b/subsys/llext/llext_load.c
@@ -139,12 +139,12 @@ static int llext_load_elf_data(struct llext_loader *ldr, struct llext *ext)
  */
 static int llext_find_tables(struct llext_loader *ldr)
 {
-	int sect_cnt, i;
+	int table_cnt, i;
 
 	memset(ldr->sects, 0, sizeof(ldr->sects));
 
 	/* Find symbol and string tables */
-	for (i = 0, sect_cnt = 0; i < ldr->sect_cnt; ++i) {
+	for (i = 0, table_cnt = 0; i < ldr->sect_cnt && table_cnt < 3; ++i) {
 		elf_shdr_t *shdr = ldr->sect_hdrs + i;
 
 		LOG_DBG("section %d at 0x%zx: name %d, type %d, flags 0x%zx, "
@@ -165,7 +165,7 @@ static int llext_find_tables(struct llext_loader *ldr)
 			LOG_DBG("symtab at %d", i);
 			ldr->sects[LLEXT_MEM_SYMTAB] = *shdr;
 			ldr->sect_map[i].mem_idx = LLEXT_MEM_SYMTAB;
-			sect_cnt++;
+			table_cnt++;
 			break;
 		case SHT_STRTAB:
 			if (ldr->hdr.e_shstrndx == i) {
@@ -177,7 +177,7 @@ static int llext_find_tables(struct llext_loader *ldr)
 				ldr->sects[LLEXT_MEM_STRTAB] = *shdr;
 				ldr->sect_map[i].mem_idx = LLEXT_MEM_STRTAB;
 			}
-			sect_cnt++;
+			table_cnt++;
 			break;
 		default:
 			break;

--- a/subsys/llext/llext_load.c
+++ b/subsys/llext/llext_load.c
@@ -63,7 +63,7 @@ static int llext_load_elf_data(struct llext_loader *ldr, struct llext *ext)
 	/* check whether this is a valid ELF file */
 	if (memcmp(ldr->hdr.e_ident, ELF_MAGIC, sizeof(ELF_MAGIC)) != 0) {
 		LOG_HEXDUMP_ERR(ldr->hdr.e_ident, 16, "Invalid ELF, magic does not match");
-		return -EINVAL;
+		return -ENOEXEC;
 	}
 
 	switch (ldr->hdr.e_type) {
@@ -77,7 +77,7 @@ static int llext_load_elf_data(struct llext_loader *ldr, struct llext *ext)
 
 	default:
 		LOG_ERR("Unsupported ELF file type %x", ldr->hdr.e_type);
-		return -EINVAL;
+		return -ENOEXEC;
 	}
 
 	/*
@@ -88,7 +88,7 @@ static int llext_load_elf_data(struct llext_loader *ldr, struct llext *ext)
 
 	if (ldr->hdr.e_shentsize != sizeof(elf_shdr_t)) {
 		LOG_ERR("Invalid section header size %d", ldr->hdr.e_shentsize);
-		return -EINVAL;
+		return -ENOEXEC;
 	}
 
 	ldr->sect_cnt = ldr->hdr.e_shnum;
@@ -188,7 +188,7 @@ static int llext_find_tables(struct llext_loader *ldr)
 	    !ldr->sects[LLEXT_MEM_STRTAB].sh_type ||
 	    !ldr->sects[LLEXT_MEM_SYMTAB].sh_type) {
 		LOG_ERR("Some sections are missing or present multiple times!");
-		return -ENOENT;
+		return -ENOEXEC;
 	}
 
 	return 0;
@@ -263,7 +263,7 @@ static int llext_map_sections(struct llext_loader *ldr, struct llext *ext)
 				 * independent entities.
 				 */
 				LOG_ERR("Multiple SHT_NOBITS sections are not supported");
-				return -ENOEXEC;
+				return -ENOTSUP;
 			}
 
 			if (ldr->hdr.e_type == ET_DYN) {
@@ -514,7 +514,7 @@ static int llext_copy_symbols(struct llext_loader *ldr, struct llext *ext,
 					LOG_DBG("section %d peeked at %p", sect, base);
 				} else {
 					LOG_ERR("No data for section %d", sect);
-					return -EOPNOTSUPP;
+					return -ENOTSUP;
 				}
 			}
 

--- a/subsys/llext/llext_mem.c
+++ b/subsys/llext/llext_mem.c
@@ -52,13 +52,10 @@ static void llext_init_mem_part(struct llext *ext, enum llext_mem mem_idx,
 		default:
 			break;
 		}
-		LOG_DBG("mem partition %d start 0x%lx, size %d", mem_idx,
-			ext->mem_parts[mem_idx].start,
-			ext->mem_parts[mem_idx].size);
 	}
 #endif
 
-	LOG_DBG("mem idx %d: start 0x%zx, size %zd", mem_idx, (size_t)start, len);
+	LOG_DBG("region %d: start 0x%zx, size %zd", mem_idx, (size_t)start, len);
 }
 
 static int llext_copy_section(struct llext_loader *ldr, struct llext *ext,
@@ -143,7 +140,7 @@ int llext_copy_strings(struct llext_loader *ldr, struct llext *ext)
 	return ret;
 }
 
-int llext_copy_sections(struct llext_loader *ldr, struct llext *ext)
+int llext_copy_regions(struct llext_loader *ldr, struct llext *ext)
 {
 	for (enum llext_mem mem_idx = 0; mem_idx < LLEXT_MEM_COUNT; mem_idx++) {
 		/* strings have already been copied */
@@ -161,7 +158,7 @@ int llext_copy_sections(struct llext_loader *ldr, struct llext *ext)
 	return 0;
 }
 
-void llext_free_sections(struct llext *ext)
+void llext_free_regions(struct llext *ext)
 {
 	for (int i = 0; i < LLEXT_MEM_COUNT; i++) {
 		if (ext->mem_on_heap[i]) {

--- a/subsys/llext/llext_priv.h
+++ b/subsys/llext/llext_priv.h
@@ -20,8 +20,8 @@ struct llext_elf_sect_map {
  */
 
 int llext_copy_strings(struct llext_loader *ldr, struct llext *ext);
-int llext_copy_sections(struct llext_loader *ldr, struct llext *ext);
-void llext_free_sections(struct llext *ext);
+int llext_copy_regions(struct llext_loader *ldr, struct llext *ext);
+void llext_free_regions(struct llext *ext);
 
 static inline void *llext_alloc(size_t bytes)
 {

--- a/subsys/llext/shell.c
+++ b/subsys/llext/shell.c
@@ -39,7 +39,7 @@ static int cmd_llext_list_symbols(const struct shell *sh, size_t argc, char *arg
 
 	if (m == NULL) {
 		shell_print(sh, "No such llext %s", argv[1]);
-		return -EINVAL;
+		return -ENOENT;
 	}
 
 	shell_print(sh, "Extension: %s symbols", m->name);
@@ -159,7 +159,7 @@ static int cmd_llext_unload(const struct shell *sh, size_t argc, char *argv[])
 
 	if (ext == NULL) {
 		shell_print(sh, "No such extension %s", argv[1]);
-		return -EINVAL;
+		return -ENOENT;
 	}
 
 	llext_unload(&ext);
@@ -174,7 +174,7 @@ static int cmd_llext_call_fn(const struct shell *sh, size_t argc, char *argv[])
 
 	if (ext == NULL) {
 		shell_print(sh, "No such extension %s", argv[1]);
-		return -EINVAL;
+		return -ENOENT;
 	}
 
 	llext_call_fn(ext, argv[2]);


### PR DESCRIPTION
This is the first part of #75126, containing the 3 commits with code changes needed to harmonize error values and messages with the documentation introduced there:

* The first fixes an ELF sanity check that was not functional in the latest code.
* The second changes llext error return values so that all LLEXT functions offer a stanardized interpretation.
* The third unifies the terms "memory index", "region", or even "section" to "_region_" when referring to the "merged sections" used by LLEXT, to minimize the confusion with the actual ELF sections defined in the spec. 