### PR TITLE
subsys: modem: optimize memory footprint

### DIFF
--- a/include/zephyr/modem/cmux.h
+++ b/include/zephyr/modem/cmux.h
@@ -111,7 +111,7 @@ struct modem_cmux_dlci {
 };
 
 struct modem_cmux_frame {
-	uint16_t dlci_address;
+	uint8_t dlci_address;
 	bool cr;
 	bool pf;
 	uint8_t type;

--- a/include/zephyr/modem/pipe.h
+++ b/include/zephyr/modem/pipe.h
@@ -63,7 +63,7 @@ struct modem_pipe_api {
 
 struct modem_pipe {
 	void *data;
-	struct modem_pipe_api *api;
+	const struct modem_pipe_api *api;
 	modem_pipe_api_callback callback;
 	void *user_data;
 	struct k_spinlock spinlock;
@@ -77,7 +77,7 @@ struct modem_pipe {
  * @param data Pipe data to bind to pipe instance
  * @param api Pipe API implementation to bind to pipe instance
  */
-void modem_pipe_init(struct modem_pipe *pipe, void *data, struct modem_pipe_api *api);
+void modem_pipe_init(struct modem_pipe *pipe, void *data, const struct modem_pipe_api *api);
 
 /**
  * @endcond

--- a/subsys/modem/backends/modem_backend_tty.c
+++ b/subsys/modem/backends/modem_backend_tty.c
@@ -103,7 +103,7 @@ static int modem_backend_tty_close(void *data)
 	return 0;
 }
 
-struct modem_pipe_api modem_backend_tty_api = {
+static const struct modem_pipe_api modem_backend_tty_api = {
 	.open = modem_backend_tty_open,
 	.transmit = modem_backend_tty_transmit,
 	.receive = modem_backend_tty_receive,

--- a/subsys/modem/backends/modem_backend_uart_async.c
+++ b/subsys/modem/backends/modem_backend_uart_async.c
@@ -269,7 +269,7 @@ static int modem_backend_uart_async_close(void *data)
 	return 0;
 }
 
-struct modem_pipe_api modem_backend_uart_async_api = {
+static const struct modem_pipe_api modem_backend_uart_async_api = {
 	.open = modem_backend_uart_async_open,
 	.transmit = modem_backend_uart_async_transmit,
 	.receive = modem_backend_uart_async_receive,

--- a/subsys/modem/backends/modem_backend_uart_isr.c
+++ b/subsys/modem/backends/modem_backend_uart_isr.c
@@ -233,7 +233,7 @@ static int modem_backend_uart_isr_close(void *data)
 	return 0;
 }
 
-struct modem_pipe_api modem_backend_uart_isr_api = {
+static const struct modem_pipe_api modem_backend_uart_isr_api = {
 	.open = modem_backend_uart_isr_open,
 	.transmit = modem_backend_uart_isr_transmit,
 	.receive = modem_backend_uart_isr_receive,

--- a/subsys/modem/modem_cmux.c
+++ b/subsys/modem/modem_cmux.c
@@ -740,7 +740,7 @@ static void modem_cmux_process_received_byte(struct modem_cmux *cmux, uint8_t by
 
 	case MODEM_CMUX_RECEIVE_STATE_RESYNC:
 		/*
-		 * Allow any number of consequtive flags (0xF9).
+		 * Allow any number of consecutive flags (0xF9).
 		 * 0xF9 could also be a valid address field for DLCI 62.
 		 */
 		if (byte == 0xF9) {
@@ -992,7 +992,7 @@ static void modem_cmux_connect_handler(struct k_work *item)
 
 	cmux->state = MODEM_CMUX_STATE_CONNECTING;
 
-	struct modem_cmux_frame frame = {
+	static const struct modem_cmux_frame frame = {
 		.dlci_address = 0,
 		.cr = true,
 		.pf = true,
@@ -1154,7 +1154,7 @@ static int modem_cmux_dlci_pipe_api_close(void *data)
 	return ret;
 }
 
-struct modem_pipe_api modem_cmux_dlci_pipe_api = {
+static const struct modem_pipe_api modem_cmux_dlci_pipe_api = {
 	.open = modem_cmux_dlci_pipe_api_open,
 	.transmit = modem_cmux_dlci_pipe_api_transmit,
 	.receive = modem_cmux_dlci_pipe_api_receive,

--- a/subsys/modem/modem_pipe.c
+++ b/subsys/modem/modem_pipe.c
@@ -75,7 +75,7 @@ static int pipe_call_close(struct modem_pipe *pipe)
 	return pipe->api->close(pipe->data);
 }
 
-void modem_pipe_init(struct modem_pipe *pipe, void *data, struct modem_pipe_api *api)
+void modem_pipe_init(struct modem_pipe *pipe, void *data, const struct modem_pipe_api *api)
 {
 	__ASSERT_NO_MSG(pipe != NULL);
 	__ASSERT_NO_MSG(data != NULL);


### PR DESCRIPTION
Series of commits to optimize memory footprint in `modem_cmux.c`
- modem: pipe: make `modem_pipe_api` a pointer to constant
- modem: cmux: apply `static const` to reduce RAM usage
- modem: cmux: optimize `modem_cmux_frame` structure padding
