### PR TITLE
boards: nxp: lpcxpresso55xxx: list USB device as supported

### DIFF
--- a/boards/nxp/lpcxpresso55s16/lpcxpresso55s16.yaml
+++ b/boards/nxp/lpcxpresso55s16/lpcxpresso55s16.yaml
@@ -23,4 +23,5 @@ supported:
   - i2c
   - spi
   - usb_device
+  - usbd
 vendor: nxp

--- a/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.yaml
+++ b/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.yaml
@@ -19,4 +19,6 @@ supported:
   - gpio
   - pwm
   - dac
+  - usb_device
+  - usbd
 vendor: nxp


### PR DESCRIPTION
List USB device and USB device "next" as supported on the NXP LPCXpresso55S16 (which uses dedicated USB RAM) and LPCXpresso55S36 (which does not use dedicated USB RAM).

This allows testing these two implementations during CI runs.

~Note: The `tests/drivers/udc/drivers.usb.udc` test suite currently fails for these boards, but that is fixed by https://github.com/zephyrproject-rtos/zephyr/pull/75118~