### PR TITLE
posix: clock: Use 64-bit counter for nanosleep

### DIFF
--- a/lib/posix/options/clock.c
+++ b/lib/posix/options/clock.c
@@ -225,7 +225,7 @@ static int __z_clock_nanosleep(clockid_t clock_id, int flags, const struct times
 		ns = rqtp->tv_sec * NSEC_PER_SEC + rqtp->tv_nsec;
 	}
 
-	uptime_ns = k_cyc_to_ns_ceil64(k_cycle_get_32());
+	uptime_ns = k_ticks_to_ns_ceil64(k_uptime_ticks());
 
 	if (flags & TIMER_ABSTIME && clock_id == CLOCK_REALTIME) {
 		key = k_spin_lock(&rt_clock_base_lock);


### PR DESCRIPTION
Using the 32-bit counter to get the uptime in nanoseconds would overflow relatively quickly (~43 sec on my board). This changes the uptime to be taken from `k_uptime_ticks`, which is 64 bit and is also what is done in `clock_settime` aswell.