### PR TITLE
security: Use proper flexible array

### DIFF
--- a/drivers/dai/intel/ssp/dai-params-intel-ipc4.h
+++ b/drivers/dai/intel/ssp/dai-params-intel-ipc4.h
@@ -320,7 +320,7 @@ struct dai_intel_ipc4_ssp_configuration_blob {
 	struct dai_intel_ipc4_ssp_driver_config i2s_driver_config;
 
 	/* optional configuration parameters */
-	union dai_intel_ipc4_ssp_dma_control i2s_dma_control[0];
+	FLEXIBLE_ARRAY_DECLARE(union dai_intel_ipc4_ssp_dma_control, i2s_dma_control);
 } __packed;
 
 #define SSP_BLOB_VER_1_5 0xee000105

--- a/drivers/entropy/entropy_nrf5.c
+++ b/drivers/entropy/entropy_nrf5.c
@@ -8,6 +8,7 @@
 #include <zephyr/drivers/entropy.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/atomic.h>
+#include <zephyr/sys/util.h>
 #include <soc.h>
 #include <hal/nrf_rng.h>
 #include <zephyr/irq.h>
@@ -76,7 +77,7 @@ struct rng_pool {
 	uint8_t last;
 	uint8_t mask;
 	uint8_t threshold;
-	uint8_t buffer[0];
+	FLEXIBLE_ARRAY_DECLARE(uint8_t, buffer);
 };
 
 #define RNG_POOL_DEFINE(name, len) uint8_t name[sizeof(struct rng_pool) + (len)]

--- a/drivers/entropy/entropy_smartbond.c
+++ b/drivers/entropy/entropy_smartbond.c
@@ -12,6 +12,7 @@
 #include <DA1469xAB.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/policy.h>
+#include <zephyr/sys/util.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(smartbond_entropy, CONFIG_ENTROPY_LOG_LEVEL);
@@ -27,7 +28,7 @@ struct rng_pool {
 	uint8_t last;
 	uint8_t mask;
 	uint8_t threshold;
-	uint8_t buffer[0];
+	FLEXIBLE_ARRAY_DECLARE(uint8_t, buffer);
 };
 
 #define RNG_POOL_DEFINE(name, len) uint8_t name[sizeof(struct rng_pool) + (len)]

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -65,7 +65,7 @@ struct rng_pool {
 	uint8_t last;
 	uint8_t mask;
 	uint8_t threshold;
-	uint8_t buffer[0];
+	FLEXIBLE_ARRAY_DECLARE(uint8_t, buffer);
 };
 
 #define RNG_POOL_DEFINE(name, len) uint8_t name[sizeof(struct rng_pool) + (len)]

--- a/drivers/espi/espi_it8xxx2.c
+++ b/drivers/espi/espi_it8xxx2.c
@@ -11,6 +11,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/interrupt_controller/wuc_ite_it8xxx2.h>
 #include <zephyr/kernel.h>
+#include <zephyr/sys/util.h>
 #include <soc.h>
 #include <soc_dt.h>
 #include "soc_espi.h"
@@ -945,7 +946,7 @@ static int espi_it8xxx2_write_lpc_request(const struct device *dev,
 		   ((((tag) & 0xF) << 4) | (((len) >> 8) & 0xF))
 
 struct espi_oob_msg_packet {
-	uint8_t data_byte[0];
+	FLEXIBLE_ARRAY_DECLARE(uint8_t, data_byte);
 };
 
 static int espi_it8xxx2_send_oob(const struct device *dev,

--- a/drivers/i2c/i2c_ite_enhance.c
+++ b/drivers/i2c/i2c_ite_enhance.c
@@ -53,7 +53,7 @@ struct i2c_cq_packet {
 	uint8_t id;
 	uint8_t cmd_l;
 	uint8_t cmd_h;
-	uint8_t wdata[0];
+	FLEXIBLE_ARRAY_DECLARE(uint8_t, wdata);
 };
 #endif /* CONFIG_I2C_IT8XXX2_CQ_MODE */
 

--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -130,6 +130,29 @@ extern "C" {
 #endif /* __cplusplus */
 
 /**
+ * @brief Declare a flexible array member.
+ *
+ * This macro declares a flexible array member in a struct. The member
+ * is named @p name and has type @p type.
+ *
+ * Since C99, flexible arrays are part of the C standard, but for historical
+ * reasons many places still use an older GNU extension that is declare
+ * zero length arrays.
+ *
+ * Although zero length arrays are flexible arrays, we can't blindly
+ * replace [0] with [] because of some syntax limitations. This macro
+ * workaround these limitations.
+ *
+ * It is specially useful for cases where flexible arrays are
+ * used in unions or are not the last element in the struct.
+ */
+#define FLEXIBLE_ARRAY_DECLARE(type, name) \
+	struct { \
+		struct { } __unused_##name; \
+		type name[]; \
+	}
+
+/**
  * @brief Whether @p ptr is an element of @p array
  *
  * This macro can be seen as a slightly stricter version of @ref PART_OF_ARRAY


### PR DESCRIPTION
Zero length arrays are a GNU extension and are not part of C standard. Lets declare flexible arrays properly.

Besides the compliant with C standard it open possibilities to improve memory safety.

Additional information: https://people.kernel.org/kees/bounded-flexible-arrays-in-c