### PR TITLE
boards: nxp: mimxrt1160_evk: fix LPI2C pinmux

### DIFF
--- a/boards/nxp/mimxrt1160_evk/mimxrt1160_evk-pinctrl.dtsi
+++ b/boards/nxp/mimxrt1160_evk/mimxrt1160_evk-pinctrl.dtsi
@@ -169,6 +169,7 @@
 			drive-strength = "normal";
 			drive-open-drain;
 			slew-rate = "fast";
+			input-enable;
 		};
 	};
 

--- a/boards/nxp/mimxrt1160_evk/mimxrt1160_evk.dtsi
+++ b/boards/nxp/mimxrt1160_evk/mimxrt1160_evk.dtsi
@@ -67,7 +67,7 @@
 
 &lpi2c5 {
 	status = "okay";
-	pinctrl-0 = <&pinmux_lpi2c1>;
+	pinctrl-0 = <&pinmux_lpi2c5>;
 	pinctrl-names = "default";
 
 	fxos8700: fxos8700@1f {
@@ -178,7 +178,7 @@
 };
 
 &lpi2c1 {
-	pinctrl-0 =<&pinmux_lpi2c5>;
+	pinctrl-0 =<&pinmux_lpi2c1>;
 	pinctrl-names = "default";
 };
 


### PR DESCRIPTION
Fixes typos in pinctrl pinmux nodes

Fixes #75178 .