### PR TITLE
xtensa: mmu: clear ZSR_DEPC_SAVE at boot

### DIFF
--- a/arch/xtensa/core/ptables.c
+++ b/arch/xtensa/core/ptables.c
@@ -317,6 +317,13 @@ void xtensa_mmu_init(void)
 
 	xtensa_init_paging(xtensa_kernel_ptables);
 
+	/*
+	 * This is used to determine whether we are faulting inside double
+	 * exception if this is not zero. Sometimes SoC starts with this not
+	 * being set to zero. So clear it during boot.
+	 */
+	XTENSA_WSR(ZSR_DEPC_SAVE_STR, 0);
+
 	arch_xtensa_mmu_post_init(_current_cpu->id == 0);
 }
 


### PR DESCRIPTION
ZSR_DEPC_SAVE is being used to determine whether we are faulting inside double exception if this is not zero. It is possible that the boot ROM or custom startup code leaves this non-zero, which would result in a fake triple fault. So clear it at boot. Note that the zeroing is done in MMU init code as these triple faults are not actual hardware ones but only semantics, and will occur once MMU is enabled.

Fixes #75194