### PR TITLE
drivers: cc13xx_cc26xx: pwm: enable pwm(gpt) in sleep/deepsleep mode

### DIFF
--- a/drivers/pwm/pwm_cc13xx_cc26xx_timer.c
+++ b/drivers/pwm/pwm_cc13xx_cc26xx_timer.c
@@ -176,6 +176,8 @@ static int init_pwm(const struct device *dev)
 
 	/* Enable GPIO peripheral. */
 	PRCMPeripheralRunEnable(get_timer_peripheral(config));
+	PRCMPeripheralSleepEnable(get_timer_peripheral(config));
+	PRCMPeripheralDeepSleepEnable(get_timer_peripheral(config));
 
 	/* Load PRCM settings. */
 	PRCMLoadSet();


### PR DESCRIPTION
In existing implementation of PWM driver for `cc13xx_c26xx`, GPT(General Purpose Timer) was not enabled in Sleep and DeepSleep mode in `init_pwm` function: https://github.com/zephyrproject-rtos/zephyr/blob/e67b12e63611291ac567bac4abfb9d43ecac0ce8/drivers/pwm/pwm_cc13xx_cc26xx_timer.c#L170-L185 that's why peripheral was getting disabled if `k_sleep` was used, that was causing some undefined behavior in `fade_led` example.



By enabling peripheral in sleep mode and deepsleep mode, it makes work properly even if thread is suspended using `k_sleep`