### PR TITLE
boards: nucleo_h533re: configure USB

### DIFF
--- a/boards/st/nucleo_h533re/doc/index.rst
+++ b/boards/st/nucleo_h533re/doc/index.rst
@@ -172,6 +172,8 @@ The Zephyr nucleo_h533re board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | ADC       | on-chip    | ADC Controller                      |
 +-----------+------------+-------------------------------------+
+| USB       | on-chip    | USB full-speed host/device bus      |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.
 

--- a/boards/st/nucleo_h533re/nucleo_h533re.dts
+++ b/boards/st/nucleo_h533re/nucleo_h533re.dts
@@ -153,3 +153,13 @@
 		 <&rcc STM32_SRC_LSE RTC_SEL(1)>;
 	status = "okay";
 };
+
+&clk_hsi48 {
+	status = "okay";
+};
+
+zephyr_udc0: &usb {
+	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/boards/st/nucleo_h533re/nucleo_h533re.yaml
+++ b/boards/st/nucleo_h533re/nucleo_h533re.yaml
@@ -15,4 +15,6 @@ supported:
   - pwm
   - rtc
   - adc
+  - usb_device
+  - usb
 vendor: st


### PR DESCRIPTION
Configure USB interface in devicetree, so it can be used with USB samples.