### PR TITLE
drivers: adc: sam0: Adjust resolution with the oversampling factor

### DIFF
--- a/drivers/adc/adc_sam0.c
+++ b/drivers/adc/adc_sam0.c
@@ -343,26 +343,52 @@ static int start_read(const struct device *dev,
 	switch (sequence->resolution) {
 	case 8:
 		if (sequence->oversampling) {
-			LOG_ERR("Oversampling requires 12 bit resolution");
+			LOG_ERR("Oversampling requires minimum 13 bit resolution");
 			return -EINVAL;
 		}
-
 		ADC_RESSEL(adc) = ADC_RESSEL_8BIT;
 		break;
 	case 10:
 		if (sequence->oversampling) {
-			LOG_ERR("Oversampling requires 12 bit resolution");
+			LOG_ERR("Oversampling requires minimum 13 bit resolution");
 			return -EINVAL;
 		}
-
 		ADC_RESSEL(adc) = ADC_RESSEL_10BIT;
 		break;
 	case 12:
 		if (sequence->oversampling) {
-			ADC_RESSEL(adc) = ADC_RESSEL_16BIT;
-		} else {
-			ADC_RESSEL(adc) = ADC_RESSEL_12BIT;
+			LOG_ERR("Oversampling requires minimum 13 bit resolution");
+			return -EINVAL;
 		}
+		ADC_RESSEL(adc) = ADC_RESSEL_12BIT;
+		break;
+	case 13:
+		if (sequence->oversampling != 2U) {
+			LOG_ERR("13 bit resolution requires an oversampling of 2");
+			return -EINVAL;
+		}
+		ADC_RESSEL(adc) = ADC_RESSEL_16BIT;
+		break;
+	case 14:
+		if (sequence->oversampling != 4U) {
+			LOG_ERR("14 bit resolution requires an oversampling of 4");
+			return -EINVAL;
+		}
+		ADC_RESSEL(adc) = ADC_RESSEL_16BIT;
+		break;
+	case 15:
+		if (sequence->oversampling != 6U) {
+			LOG_ERR("15 bit resolution requires an oversampling of 6");
+			return -EINVAL;
+		}
+		ADC_RESSEL(adc) = ADC_RESSEL_16BIT;
+		break;
+	case 16:
+		if (sequence->oversampling != 8U) {
+			LOG_ERR("16 bit resolution requires an oversampling of 8");
+			return -EINVAL;
+		}
+		ADC_RESSEL(adc) = ADC_RESSEL_16BIT;
 		break;
 	default:
 		LOG_ERR("ADC resolution value %d is not valid",


### PR DESCRIPTION
When using the oversampling factor on the SAMD21 family, the value that you get from the conversion is 16 bits instead of 12.

Using a factor of 8 adds 3 bits, a factor of 6 adds 2 bits, etc. I corrected this by dividing the factor by 2 and adding it to the resolution variable. 

I didn't find other MCU families that use hardware oversampling. If there are others, we need to check if this is correct for that type of ADC. 

Fixes: #74607
Signed-off-by: Robin Carrupt <robincarrupt@gmail.com>