### PR TITLE
sensor/ntc_thermistor: Corrected the type of adc values to accept 16 bits

### DIFF
--- a/drivers/sensor/ntc_thermistor/ntc_thermistor.c
+++ b/drivers/sensor/ntc_thermistor/ntc_thermistor.c
@@ -15,8 +15,8 @@ LOG_MODULE_REGISTER(NTC_THERMISTOR, CONFIG_SENSOR_LOG_LEVEL);
 
 struct ntc_thermistor_data {
 	struct k_mutex mutex;
-	int16_t raw;
-	int16_t sample_val;
+	int32_t raw;
+	int32_t sample_val;
 };
 
 struct ntc_thermistor_config {


### PR DESCRIPTION
The NTC thermistor sensor in `drivers/sensor/ntc_thermistor/ntc_thermistor.c` cannot work with a 16-bit ADC. The voltage becomes negative if the ADC raw value is 0x8000 or higher. 

To correct this, I changed the types in the `ntc_thermistor_data` struct from `int16_t` to `int32_t`. 

This also corrects a potential problem at line 53 where we transform an `int16_t` into an `int32_t`.

Fixes: #75203
Signed-off-by: Robin Carrupt [robincarrupt@gmail.com](mailto:robincarrupt@gmail.com)