### PR TITLE
drivers: adc: lmp90xxx: fix checksum mismatch return value

### DIFF
--- a/drivers/adc/adc_lmp90xxx.c
+++ b/drivers/adc/adc_lmp90xxx.c
@@ -639,7 +639,7 @@ static int lmp90xxx_adc_read_channel(const struct device *dev,
 		if (buf[3] != crc) {
 			LOG_ERR("CRC mismatch (0x%02x vs. 0x%02x)", buf[3],
 				crc);
-			return err;
+			return -EIO;
 		}
 	}
 


### PR DESCRIPTION
During channel reads, zero is returned on CRC mismatches: the returned error variable is not written to after a previous non-zero check. Return -EIO to mirror other drivers' checksum validation behaviors.

Fixes: #75373