### PR TITLE
drivers: gnss: gnss_u_blox_m10: fix compiler warning

### DIFF
--- a/drivers/gnss/gnss_u_blox_m10.c
+++ b/drivers/gnss/gnss_u_blox_m10.c
@@ -12,6 +12,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/gpio.h>
 #include <string.h>
+#include <stdlib.h>
 
 #include "gnss_nmea0183.h"
 #include "gnss_nmea0183_match.h"


### PR DESCRIPTION
Fix warning on implicit declaration of function 'malloc' when compiling
gnss_u_blox_m10.c.