### PR TITLE
doc: modules: fix indentation

### DIFF
--- a/doc/develop/modules.rst
+++ b/doc/develop/modules.rst
@@ -785,7 +785,7 @@ module ``bar`` to be present in the build system:
    name: foo
    build:
      depends:
-     - bar
+       - bar
 
 This example will ensure that ``bar`` is present when ``foo`` is included into
 the build system, and it will also ensure that ``bar`` is processed before


### PR DESCRIPTION
Fix the indentation of `bar` in the code block.

- [Current](https://docs.zephyrproject.org/latest/develop/modules.html#zephyr-module-dependencies)
- [This PR](https://builds.zephyrproject.io/zephyr/pr/75221/docs/develop/modules.html#zephyr-module-dependencies)