### PR TITLE
scripts: twisterlib: coverage: fix multiple branch excludes

### DIFF
--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -330,7 +330,10 @@ class Gcovr(CoverageTool):
         ztestfile = os.path.join(outdir, "ztest.json")
 
         excludes = Gcovr._interleave_list("-e", self.ignores)
-        excludes += Gcovr._interleave_list("--exclude-branches-by-pattern", self.ignore_branch_patterns)
+        if len(self.ignore_branch_patterns) > 0:
+            # Last pattern overrides previous values, so merge all patterns together
+            merged_regex = "|".join([f"({p})" for p in self.ignore_branch_patterns])
+            excludes += ["--exclude-branches-by-pattern", merged_regex]
 
         # Different ifdef-ed implementations of the same function should not be
         # in conflict treated by GCOVR as separate objects for coverage statistics.

--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -428,5 +428,8 @@ def run_coverage(testplan, options):
     # Ignore branch coverage on LOG_* and LOG_HEXDUMP_* macros
     # Branch misses are due to the implementation of Z_LOG2 and cannot be avoided
     coverage_tool.add_ignore_branch_pattern(r"^\s*LOG_(?:HEXDUMP_)?(?:DBG|INF|WRN|ERR)\(.*")
+    # Ignore branch coverage on __ASSERT* macros
+    # Covering the failing case is not desirable as it will immediately terminate the test.
+    coverage_tool.add_ignore_branch_pattern(r"^\s*__ASSERT(?:_EVAL|_NO_MSG|_POST_ACTION)?\(.*")
     coverage_completed = coverage_tool.generate(options.outdir)
     return coverage_completed


### PR DESCRIPTION
Multiple values for `--exclude-branches-by-pattern` will result in only
the last value taking effect. Resolve this by merging all the provided
regex patterns into a single pattern with the `|` operator.

Disable branch coverage for the `__ASSERT` family of macros. Covering
all of the assertion branches by definition means triggering the
assertion, which can be either challenging or impossible to exercise,
and in either case results in the immediate termination of the test.
