### PR TITLE
dts: x86: intel: ish: Remove d0i1 and modify d0i2

### DIFF
--- a/dts/x86/intel/intel_ish5.dtsi
+++ b/dts/x86/intel/intel_ish5.dtsi
@@ -18,17 +18,10 @@
 			substate-id = <1>;
 		};
 
-		d0i1: d0i1 {
-			compatible = "zephyr,power-state";
-			power-state-name = "suspend-to-idle";
-			min-residency-us = <2000>;
-			substate-id = <2>;
-		};
-
 		d0i2: d0i2 {
 			compatible = "zephyr,power-state";
 			power-state-name = "suspend-to-ram";
-			min-residency-us = <4000>;
+			min-residency-us = <10000>;
 			substate-id = <3>;
 		};
 
@@ -48,7 +41,7 @@
 			device_type = "cpu";
 			compatible = "intel,ish";
 			reg = <0>;
-			cpu-power-states = <&d0i0 &d0i1 &d0i2 &d0i3>;
+			cpu-power-states = <&d0i0 &d0i2 &d0i3>;
 		};
 	};
 


### PR DESCRIPTION
Remove d0i1 and change threshold for d0i2 to 10ms for pm setting according to the requirements to pass CTS for chrome projects.