### PR TITLE
doc: css: Use body color for captions

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -194,6 +194,9 @@ a.icon-home:visited {
     border-color: var(--code-border-color);
 }
 
+.rst-content table.docutils caption, .rst-content table.field-list caption, .wy-table caption {
+    color: var(--body-color);
+}
 .wy-table-odd td,
 .wy-table-striped tr:nth-child(2n-1) td,
 .rst-content table.docutils:not(.field-list) tr:nth-child(2n-1) td {


### PR DESCRIPTION
Make sure that captions (tables, figures, ...) can be properly seen on both light and dark them by setting their text color to the default "body" color.
Fixes #73190.