### PR TITLE
tests: drivers: watchdog window reduced to fit stm32 board config

### DIFF
--- a/boards/st/nucleo_h753zi/nucleo_h753zi.dts
+++ b/boards/st/nucleo_h753zi/nucleo_h753zi.dts
@@ -58,6 +58,7 @@
 		led1 = &yellow_led;
 		pwm-led0 = &red_pwm_led;
 		sw0 = &user_button;
+		watchdog0 = &iwdg;
 		volt-sensor1 = &vbat;
 	};
 };
@@ -241,6 +242,10 @@ zephyr_udc0: &usbotg_fs {
 		};
 
 	};
+};
+
+&iwdg1 {
+	status = "okay";
 };
 
 &vbat {

--- a/boards/st/nucleo_h753zi/nucleo_h753zi.yaml
+++ b/boards/st/nucleo_h753zi/nucleo_h753zi.yaml
@@ -20,5 +20,6 @@ supported:
   - netif:eth
   - spi
   - usb_device
+  - watchdog
   - can
 vendor: st

--- a/samples/drivers/watchdog/boards/stm32h7_wwdg.overlay
+++ b/samples/drivers/watchdog/boards/stm32h7_wwdg.overlay
@@ -11,10 +11,6 @@
 	};
 };
 
-&rcc {
-	d2ppre1 = <16>;
-};
-
 &wwdg {
 	status = "okay";
 };

--- a/samples/drivers/watchdog/sample.yaml
+++ b/samples/drivers/watchdog/sample.yaml
@@ -48,7 +48,9 @@ tests:
   sample.drivers.watchdog.stm32h7_wwdg:
     extra_args: DTC_OVERLAY_FILE=boards/stm32h7_wwdg.overlay
     filter: dt_compat_enabled("st,stm32-window-watchdog")
-    platform_allow: nucleo_h743zi
+    platform_allow:
+      - nucleo_h743zi
+      - nucleo_h753zi
   sample.drivers.watchdog.stm32_iwdg:
     extra_args: DTC_OVERLAY_FILE=boards/stm32_iwdg.overlay
     filter: dt_compat_enabled("st,stm32-watchdog")
@@ -63,6 +65,7 @@ tests:
       - nucleo_g071rb
       - nucleo_g474re
       - nucleo_h743zi
+      - nucleo_h753zi
       - nucleo_l073rz
       - nucleo_l152re
       - nucleo_wb55rg

--- a/tests/drivers/watchdog/wdt_basic_api/boards/stm32_wwdg_h7.overlay
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/stm32_wwdg_h7.overlay
@@ -4,7 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* stm32h7 has no apb1 prescaler */
+/* stm32h7 has no apb1 prescaler; wwdg is clocked by APB3 (d1ppre) */
+
+&rcc {
+	/delete-property/ d1ppre;
+	d1ppre = <16>;
+};
 
 &wwdg {
 	status = "okay";

--- a/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
+++ b/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
@@ -71,7 +71,8 @@
 #elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_window_watchdog)
 #define WDT_NODE DT_INST(0, st_stm32_window_watchdog)
 #define TIMEOUTS 0
-#define WDT_TEST_MAX_WINDOW 200
+/* Boards where the sysclock is high and APB1 prescaler 16 requires a lower WDG window */
+#define WDT_TEST_MAX_WINDOW 170U
 #elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_watchdog)
 #define WDT_NODE DT_INST(0, st_stm32_watchdog)
 #define TIMEOUTS 0
@@ -159,8 +160,8 @@ static struct wdt_timeout_cfg m_cfg_wdt1;
  */
 volatile DATATYPE m_state __attribute__((section(NOINIT_SECTION)));
 
-/* m_testcase_index is incremented after each test to make test possible
- * switch to next testcase.
+	/* m_testcase_index is incremented after each test to make test possible
+	 * switch to next testcase.
  */
 volatile DATATYPE m_testcase_index __attribute__((section(NOINIT_SECTION)));
 


### PR DESCRIPTION
Reduce the windows watchdog so that nucleo_f429 and nucleo_f746 can pass the tests/drivers/watchdog/wdt_basic_api whatever their sysclock and APB clock.

That change applies on the NUCLEO_F429ZI  target (cannot be a ./boards/nucleo_f429zi.overlay due to the existing stm32_wwdg.overlay)

Fixing the error when executing on the stm32f429zi or stm32f746zg nucleo boards
```
Running TESTSUITE wdt_basic_test_suite
===================================================================
START - test_wdt
Testcase: test_wdt_no_callback
Testcase passed
Testcase: test_wdt_callback_1
CB1 not supported on platform
Testcase: test_wdt_bad_window_max
PASS - test_wdt in 0.013 seconds
===================================================================
TESTSUITE wdt_basic_test_suite succeeded
------ TESTSUITE SUMMARY START ------
SUITE PASS - 100.00% [wdt_basic_test_suite]: pass = 1, fail = 0, skip = 0, total = 1 duration = 0.013 seconds
- PASS - [wdt_basic_test_suite.testRunning TESTSUITE wdt_basic_test_suite
===================================================================
START - test_wdt
Testcase: test_wdt_no_callback
Watchdog install error
Assertion failed at WEST_TOPDIR/zephyr/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c:387: wdt_basic_test_suite_test_wdt: test_wdt_no_callback() == TC_PASS is false
FAIL - test_wdt in 0.021 seconds
===================================================================
TESTSUITE wdt_basic_test_suite failed.
------ TESTSUITE SUMMARY START ------
SUITE FAIL -   0.00% [wdt_basic_test_suite]: pass = 0, fail = 1, skip = 0, total = 1 duration = 0.021 seconds
- FAIL - [wdt_basic_test_suite.test_wdt] duration = 0.021 seconds
------ TESTSUITE SUMMARY END ------
===================================================================
RunID: e47f82fc05b160a9bf7204cfba4e659b
PROJECT EXECUTION FAILED

```
