### PR TITLE
doc: esp32: fix rendering of MCUboot note

### DIFF
--- a/boards/espressif/esp32_devkitc_wroom/doc/index.rst
+++ b/boards/espressif/esp32_devkitc_wroom/doc/index.rst
@@ -141,9 +141,10 @@ There are two options to be used when building an application:
 
    User can select the MCUboot bootloader by adding the following line
    to the board default configuration file.
-   ```
-   CONFIG_BOOTLOADER_MCUBOOT=y
-   ```
+
+   .. code:: cfg
+
+      CONFIG_BOOTLOADER_MCUBOOT=y
 
 Sysbuild
 ========

--- a/boards/espressif/esp32_devkitc_wrover/doc/index.rst
+++ b/boards/espressif/esp32_devkitc_wrover/doc/index.rst
@@ -141,9 +141,10 @@ There are two options to be used when building an application:
 
    User can select the MCUboot bootloader by adding the following line
    to the board default configuration file.
-   ```
-   CONFIG_BOOTLOADER_MCUBOOT=y
-   ```
+
+   .. code:: cfg
+
+      CONFIG_BOOTLOADER_MCUBOOT=y
 
 Sysbuild
 ========

--- a/boards/espressif/esp32_ethernet_kit/doc/index.rst
+++ b/boards/espressif/esp32_ethernet_kit/doc/index.rst
@@ -463,9 +463,10 @@ There are two options to be used when building an application:
 
    User can select the MCUboot bootloader by adding the following line
    to the board default configuration file.
-   ```
-   CONFIG_BOOTLOADER_MCUBOOT=y
-   ```
+
+   .. code:: cfg
+
+      CONFIG_BOOTLOADER_MCUBOOT=y
 
 Sysbuild
 ========

--- a/boards/espressif/esp32c3_devkitm/doc/index.rst
+++ b/boards/espressif/esp32c3_devkitm/doc/index.rst
@@ -116,9 +116,10 @@ There are two options to be used when building an application:
 
    User can select the MCUboot bootloader by adding the following line
    to the board default configuration file.
-   ```
-   CONFIG_BOOTLOADER_MCUBOOT=y
-   ```
+
+   .. code:: cfg
+
+      CONFIG_BOOTLOADER_MCUBOOT=y
 
 Sysbuild
 ========

--- a/boards/espressif/esp32c6_devkitc/doc/index.rst
+++ b/boards/espressif/esp32c6_devkitc/doc/index.rst
@@ -146,9 +146,10 @@ There are two options to be used when building an application:
 
    User can select the MCUboot bootloader by adding the following line
    to the board default configuration file.
-   ```
-   CONFIG_BOOTLOADER_MCUBOOT=y
-   ```
+
+   .. code:: cfg
+
+      CONFIG_BOOTLOADER_MCUBOOT=y
 
 Sysbuild
 ========

--- a/boards/espressif/esp32s2_devkitc/doc/index.rst
+++ b/boards/espressif/esp32s2_devkitc/doc/index.rst
@@ -112,9 +112,10 @@ There are two options to be used when building an application:
 
    User can select the MCUboot bootloader by adding the following line
    to the board default configuration file.
-   ```
-   CONFIG_BOOTLOADER_MCUBOOT=y
-   ```
+
+   .. code:: cfg
+
+      CONFIG_BOOTLOADER_MCUBOOT=y
 
 Sysbuild
 ========

--- a/boards/espressif/esp32s2_saola/doc/index.rst
+++ b/boards/espressif/esp32s2_saola/doc/index.rst
@@ -112,9 +112,10 @@ There are two options to be used when building an application:
 
    User can select the MCUboot bootloader by adding the following line
    to the board default configuration file.
-   ```
-   CONFIG_BOOTLOADER_MCUBOOT=y
-   ```
+
+   .. code:: cfg
+
+      CONFIG_BOOTLOADER_MCUBOOT=y
 
 Sysbuild
 ========

--- a/boards/espressif/esp32s3_devkitc/doc/index.rst
+++ b/boards/espressif/esp32s3_devkitc/doc/index.rst
@@ -161,9 +161,10 @@ There are two options to be used when building an application:
 
    User can select the MCUboot bootloader by adding the following line
    to the board default configuration file.
-   ```
-   CONFIG_BOOTLOADER_MCUBOOT=y
-   ```
+
+   .. code:: cfg
+
+      CONFIG_BOOTLOADER_MCUBOOT=y
 
 Sysbuild
 ========

--- a/boards/espressif/esp32s3_devkitm/doc/index.rst
+++ b/boards/espressif/esp32s3_devkitm/doc/index.rst
@@ -161,9 +161,10 @@ There are two options to be used when building an application:
 
    User can select the MCUboot bootloader by adding the following line
    to the board default configuration file.
-   ```
-   CONFIG_BOOTLOADER_MCUBOOT=y
-   ```
+
+   .. code:: cfg
+
+      CONFIG_BOOTLOADER_MCUBOOT=y
 
 Sysbuild
 ========

--- a/boards/espressif/esp_wrover_kit/doc/index.rst
+++ b/boards/espressif/esp_wrover_kit/doc/index.rst
@@ -527,9 +527,10 @@ There are two options to be used when building an application:
 
    User can select the MCUboot bootloader by adding the following line
    to the board default configuration file.
-   ```
-   CONFIG_BOOTLOADER_MCUBOOT=y
-   ```
+
+   .. code:: cfg
+
+      CONFIG_BOOTLOADER_MCUBOOT=y
 
 Sysbuild
 ========

--- a/boards/franzininho/esp32s2_franzininho/doc/index.rst
+++ b/boards/franzininho/esp32s2_franzininho/doc/index.rst
@@ -79,9 +79,10 @@ There are two options to be used when building an application:
 
    User can select the MCUboot bootloader by adding the following line
    to the board default configuration file.
-   ```
-   CONFIG_BOOTLOADER_MCUBOOT=y
-   ```
+
+   .. code:: cfg
+
+      CONFIG_BOOTLOADER_MCUBOOT=y
 
 Sysbuild
 ========

--- a/boards/hardkernel/odroid_go/doc/index.rst
+++ b/boards/hardkernel/odroid_go/doc/index.rst
@@ -120,9 +120,10 @@ There are two options to be used when building an application:
 
    User can select the MCUboot bootloader by adding the following line
    to the board default configuration file.
-   ```
-   CONFIG_BOOTLOADER_MCUBOOT=y
-   ```
+
+   .. code:: cfg
+
+      CONFIG_BOOTLOADER_MCUBOOT=y
 
 Sysbuild
 ========

--- a/boards/heltec/heltec_wifi_lora32_v2/doc/index.rst
+++ b/boards/heltec/heltec_wifi_lora32_v2/doc/index.rst
@@ -67,9 +67,10 @@ There are two options to be used when building an application:
 
    User can select the MCUboot bootloader by adding the following line
    to the board default configuration file.
-   ```
-   CONFIG_BOOTLOADER_MCUBOOT=y
-   ```
+
+   .. code:: cfg
+
+      CONFIG_BOOTLOADER_MCUBOOT=y
 
 Sysbuild
 ========

--- a/boards/heltec/heltec_wireless_stick_lite_v3/doc/index.rst
+++ b/boards/heltec/heltec_wireless_stick_lite_v3/doc/index.rst
@@ -181,9 +181,10 @@ There are two options to be used when building an application:
 
    User can select the MCUboot bootloader by adding the following line
    to the board default configuration file.
-   ```
-   CONFIG_BOOTLOADER_MCUBOOT=y
-   ```
+
+   .. code:: cfg
+
+      CONFIG_BOOTLOADER_MCUBOOT=y
 
 Sysbuild
 ========

--- a/boards/lilygo/ttgo_lora32/doc/index.rst
+++ b/boards/lilygo/ttgo_lora32/doc/index.rst
@@ -111,9 +111,9 @@ There are two options to be used when building an application:
    User can select the MCUboot bootloader by adding the following line
    to the board default configuration file.
 
-.. code-block:: cfg
+   .. code-block:: cfg
 
-   CONFIG_BOOTLOADER_MCUBOOT=y
+      CONFIG_BOOTLOADER_MCUBOOT=y
 
 Sysbuild
 ========

--- a/boards/lilygo/ttgo_t8c3/doc/index.rst
+++ b/boards/lilygo/ttgo_t8c3/doc/index.rst
@@ -108,9 +108,10 @@ There are two options to be used when building an application:
 
    User can select the MCUboot bootloader by adding the following line
    to the board default configuration file.
-   ```
-   CONFIG_BOOTLOADER_MCUBOOT=y
-   ```
+
+   .. code:: cfg
+
+      CONFIG_BOOTLOADER_MCUBOOT=y
 
 Sysbuild
 ========

--- a/boards/luatos/esp32c3_luatos_core/doc/index.rst
+++ b/boards/luatos/esp32c3_luatos_core/doc/index.rst
@@ -134,9 +134,10 @@ There are two options to be used when building an application:
 
    User can select the MCUboot bootloader by adding the following line
    to the board default configuration file.
-   ```
-   CONFIG_BOOTLOADER_MCUBOOT=y
-   ```
+
+   .. code:: cfg
+
+      CONFIG_BOOTLOADER_MCUBOOT=y
 
 Sysbuild
 ========

--- a/boards/luatos/esp32s3_luatos_core/doc/index.rst
+++ b/boards/luatos/esp32s3_luatos_core/doc/index.rst
@@ -160,9 +160,10 @@ There are two options to be used when building an application:
 
    User can select the MCUboot bootloader by adding the following line
    to the board default configuration file.
-   ```
-   CONFIG_BOOTLOADER_MCUBOOT=y
-   ```
+
+   .. code:: cfg
+
+      CONFIG_BOOTLOADER_MCUBOOT=y
 
 Sysbuild
 ========

--- a/boards/m5stack/m5stickc_plus/doc/index.rst
+++ b/boards/m5stack/m5stickc_plus/doc/index.rst
@@ -109,9 +109,10 @@ There are two options to be used when building an application:
 
    User can select the MCUboot bootloader by adding the following line
    to the board default configuration file.
-   ```
-   CONFIG_BOOTLOADER_MCUBOOT=y
-   ```
+
+   .. code:: cfg
+
+      CONFIG_BOOTLOADER_MCUBOOT=y
 
 Sysbuild
 ========

--- a/boards/m5stack/stamp_c3/doc/index.rst
+++ b/boards/m5stack/stamp_c3/doc/index.rst
@@ -78,9 +78,10 @@ There are two options to be used when building an application:
 
    User can select the MCUboot bootloader by adding the following line
    to the board default configuration file.
-   ```
-   CONFIG_BOOTLOADER_MCUBOOT=y
-   ```
+
+   .. code:: cfg
+
+      CONFIG_BOOTLOADER_MCUBOOT=y
 
 Sysbuild
 ========

--- a/boards/olimex/olimex_esp32_evb/doc/index.rst
+++ b/boards/olimex/olimex_esp32_evb/doc/index.rst
@@ -136,9 +136,10 @@ There are two options to be used when building an application:
 
    User can select the MCUboot bootloader by adding the following line
    to the board default configuration file.
-   ```
-   CONFIG_BOOTLOADER_MCUBOOT=y
-   ```
+
+   .. code:: cfg
+
+      CONFIG_BOOTLOADER_MCUBOOT=y
 
 Sysbuild
 ========

--- a/boards/others/icev_wireless/doc/index.rst
+++ b/boards/others/icev_wireless/doc/index.rst
@@ -123,9 +123,10 @@ There are two options to be used when building an application:
 
    User can select the MCUboot bootloader by adding the following line
    to the board default configuration file.
-   ```
-   CONFIG_BOOTLOADER_MCUBOOT=y
-   ```
+
+   .. code:: cfg
+
+      CONFIG_BOOTLOADER_MCUBOOT=y
 
 Sysbuild
 ========

--- a/boards/seeed/xiao_esp32c3/doc/index.rst
+++ b/boards/seeed/xiao_esp32c3/doc/index.rst
@@ -105,9 +105,10 @@ There are two options to be used when building an application:
 
    User can select the MCUboot bootloader by adding the following line
    to the board default configuration file.
-   ```
-   CONFIG_BOOTLOADER_MCUBOOT=y
-   ```
+
+   .. code:: cfg
+
+      CONFIG_BOOTLOADER_MCUBOOT=y
 
 Sysbuild
 ========

--- a/boards/seeed/xiao_esp32s3/doc/index.rst
+++ b/boards/seeed/xiao_esp32s3/doc/index.rst
@@ -120,9 +120,10 @@ There are two options to be used when building an application:
 
    User can select the MCUboot bootloader by adding the following line
    to the board default configuration file.
-   ```
-   CONFIG_BOOTLOADER_MCUBOOT=y
-   ```
+
+   .. code:: cfg
+
+      CONFIG_BOOTLOADER_MCUBOOT=y
 
 Sysbuild
 ========

--- a/boards/vcc-gnd/yd_esp32/doc/index.rst
+++ b/boards/vcc-gnd/yd_esp32/doc/index.rst
@@ -141,9 +141,10 @@ There are two options to be used when building an application:
 
    User can select the MCUboot bootloader by adding the following line
    to the board default configuration file.
-   ```
-   CONFIG_BOOTLOADER_MCUBOOT=y
-   ```
+
+   .. code:: cfg
+
+      CONFIG_BOOTLOADER_MCUBOOT=y
 
 Sysbuild
 ========


### PR DESCRIPTION
Use proper syntax to ensure rendering of the `CONFIG_BOOTLOADER_MCUBOOT` snippet is correct.

### BEFORE

![image](https://github.com/zephyrproject-rtos/zephyr/assets/128251/2323045b-f93b-4090-92eb-d3b3b7bfd604)

### AFTER

![image](https://github.com/zephyrproject-rtos/zephyr/assets/128251/2b6e023e-c3ed-4d35-8fc7-072e7c98db6a)
