### PR TITLE
west: commands: runners: canopen: increase default SDO timeout

### DIFF
--- a/scripts/west_commands/runners/canopen_program.py
+++ b/scripts/west_commands/runners/canopen_program.py
@@ -31,7 +31,7 @@ PROGRAM_DOWNLOAD_CHUNK_SIZE = PROGRAM_DOWNLOAD_BUFFER_SIZE // 2
 
 # Default timeouts and retries
 DEFAULT_TIMEOUT = 10.0 # seconds
-DEFAULT_SDO_TIMEOUT = 0.3 # seconds
+DEFAULT_SDO_TIMEOUT = 1 # seconds
 DEFAULT_SDO_RETRIES = 1
 
 # Object dictionary indexes


### PR DESCRIPTION
Increase the default SDO timeout for the CANopen program download west runner from 0.3 seconds to 1 second. Depending on the flash size and speed, a full erase may take slightly longer than 300 ms.

The timeout can be customized by using the --sdo-timeout runner parameter.

Fixes: #73987