### PR TITLE
intel_adsp/ace: power: flush and invalidate dcache before power_down

### DIFF
--- a/soc/intel/intel_adsp/ace/power.c
+++ b/soc/intel/intel_adsp/ace/power.c
@@ -348,6 +348,7 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 			/* do power down - this function won't return */
 			ret = pm_device_runtime_put(INTEL_ADSP_HST_DOMAIN_DEV);
 			__ASSERT_NO_MSG(ret == 0);
+			sys_cache_data_flush_and_invd_all();
 			power_down(true, sys_cache_cached_ptr_get(&hpsram_mask),
 				   true);
 		} else {


### PR DESCRIPTION
The power down function uses data cache locking and relies on sufficient amount of cache lines to be available for locking.

Flush and invalidate the dcache before entry to maximize the free resources before entry.

Link: https://github.com/thesofproject/sof/issues/9268