### PR TITLE
tests: bluetooth: tester: Fix zero length array in middle of struct

### DIFF
--- a/tests/bluetooth/tester/src/btp/btp_mesh.h
+++ b/tests/bluetooth/tester/src/btp/btp_mesh.h
@@ -114,8 +114,7 @@ struct btp_mesh_health_generate_faults_rp {
 	uint8_t test_id;
 	uint8_t cur_faults_count;
 	uint8_t reg_faults_count;
-	uint8_t current_faults[0];
-	uint8_t registered_faults[0];
+	uint8_t faults[];
 } __packed;
 
 #define BTP_MESH_HEALTH_CLEAR_FAULTS		0x0c

--- a/tests/bluetooth/tester/src/btp_mesh.c
+++ b/tests/bluetooth/tester/src/btp_mesh.c
@@ -1734,12 +1734,12 @@ static uint8_t health_generate_faults(const void *cmd, uint16_t cmd_len,
 
 	cur_faults_count = MIN(sizeof(cur_faults), sizeof(some_faults));
 	memcpy(cur_faults, some_faults, cur_faults_count);
-	memcpy(rp->current_faults, cur_faults, cur_faults_count);
+	memcpy(rp->faults, cur_faults, cur_faults_count);
 	rp->cur_faults_count = cur_faults_count;
 
 	reg_faults_count = MIN(sizeof(reg_faults), sizeof(some_faults));
 	memcpy(reg_faults, some_faults, reg_faults_count);
-	memcpy(rp->registered_faults + cur_faults_count, reg_faults, reg_faults_count);
+	memcpy(rp->faults + cur_faults_count, reg_faults, reg_faults_count);
 	rp->reg_faults_count = reg_faults_count;
 
 	bt_mesh_health_srv_fault_update(&elements[0]);


### PR DESCRIPTION
Zero length arrays are only allowed at the end of the structure. Here those were used as placeholders for BTP response creation and can be easily replaced with common member.