### PR TITLE
tests: dma/chan_blen_transfer: place TX buf in RAM

### DIFF
--- a/tests/drivers/dma/chan_blen_transfer/src/test_dma.c
+++ b/tests/drivers/dma/chan_blen_transfer/src/test_dma.c
@@ -22,7 +22,7 @@
 
 #define RX_BUFF_SIZE (48)
 
-static __aligned(32) const char tx_data[] = "It is harder to be kind than to be wise........";
+static __aligned(32) char tx_data[] = "It is harder to be kind than to be wise........";
 static __aligned(32) char rx_data[RX_BUFF_SIZE] = { 0 };
 
 static void test_done(const struct device *dma_dev, void *arg,


### PR DESCRIPTION
This PR removes the `const` qualifier from `tx_data` (source) buffer of the `chan_blen_transfer` DMA test, to ensure it gets placed in RAM rather than flash.
This ensures the test can pass on hardware where the DMA controller is unable to access flash.

Fixes #75125.