### PR TITLE
soc: nxp: add flashing configuration

### DIFF
--- a/soc/nxp/imxrt/soc.yml
+++ b/soc/nxp/imxrt/soc.yml
@@ -34,3 +34,41 @@ family:
     - name: mimxrt685s
       cpuclusters:
       - name: cm33
+runners:
+  run_once:
+    '--erase':
+    - run: first
+      runners:
+      - all
+      groups:
+      - qualifiers:
+        - mimxrt10([0-9]{2})
+      - qualifiers:
+        - mimxrt1166/cm7
+        - mimxrt1166/cm4
+      - qualifiers:
+        - mimxrt1176/cm7
+        - mimxrt1176/cm4
+      - qualifiers:
+        - mimxrt595s/cm33
+        - mimxrt595s/f1
+      - qualifiers:
+        - mimxrt685s/cm33
+    '--reset':
+    - run: last
+      runners:
+      - all
+      groups:
+      - qualifiers:
+        - mimxrt10([0-9]{2})
+      - qualifiers:
+        - mimxrt1166/cm7
+        - mimxrt1166/cm4
+      - qualifiers:
+        - mimxrt1176/cm7
+        - mimxrt1176/cm4
+      - qualifiers:
+        - mimxrt595s/cm33
+        - mimxrt595s/f1
+      - qualifiers:
+        - mimxrt685s/cm33

--- a/soc/nxp/kinetis/soc.yml
+++ b/soc/nxp/kinetis/soc.yml
@@ -34,3 +34,39 @@ family:
     - name: mke15z7
     - name: mke17z7
     - name: mke17z9
+runners:
+  run_once:
+    '--erase':
+    - run: first
+      runners:
+      - all
+      groups:
+      - qualifiers:
+        - mk64f12
+      - qualifiers:
+        - mk66f18
+      - qualifiers:
+        - mk22f51212
+      - qualifiers:
+        - mk82f25615
+      - qualifiers:
+        - mke18f16
+      - qualifiers:
+        - mkv58f24
+    '--reset':
+    - run: last
+      runners:
+      - all
+      groups:
+      - qualifiers:
+        - mk64f12
+      - qualifiers:
+        - mk66f18
+      - qualifiers:
+        - mk22f51212
+      - qualifiers:
+        - mk82f25615
+      - qualifiers:
+        - mke18f16
+      - qualifiers:
+        - mkv58f24

--- a/soc/nxp/lpc/soc.yml
+++ b/soc/nxp/lpc/soc.yml
@@ -25,3 +25,37 @@ family:
       cpuclusters:
       - name: cpu0
       - name: cpu1
+runners:
+  run_once:
+    '--erase':
+    - run: first
+      runners:
+      - all
+      groups:
+      - qualifiers:
+        - lpc55s06
+      - qualifiers:
+        - lpc55s16
+      - qualifiers:
+        - lpc55s28
+      - qualifiers:
+        - lpc55s36
+      - qualifiers:
+        - lpc55s69/cpu0
+        - lpc55s69/cpu1
+    '--reset':
+    - run: last
+      runners:
+      - all
+      groups:
+      - qualifiers:
+        - lpc55s06
+      - qualifiers:
+        - lpc55s16
+      - qualifiers:
+        - lpc55s28
+      - qualifiers:
+        - lpc55s36
+      - qualifiers:
+        - lpc55s69/cpu0
+        - lpc55s69/cpu1

--- a/soc/nxp/mcx/soc.yml
+++ b/soc/nxp/mcx/soc.yml
@@ -7,3 +7,21 @@ family:
       cpuclusters:
       - name: cpu0
       - name: cpu1
+runners:
+  run_once:
+    '--erase':
+    - run: first
+      runners:
+      - all
+      groups:
+      - qualifiers:
+        - mcxn947/cpu0
+        - mcxn947/cpu1
+    '--reset':
+    - run: last
+      runners:
+      - all
+      groups:
+      - qualifiers:
+        - mcxn947/cpu0
+        - mcxn947/cpu1

--- a/soc/nxp/rw/soc.yml
+++ b/soc/nxp/rw/soc.yml
@@ -5,3 +5,23 @@ family:
     socs:
     - name: rw612
     - name: rw610
+runners:
+  run_once:
+    '--erase':
+    - run: first
+      runners:
+      - all
+      groups:
+      - qualifiers:
+        - rw612
+      - qualifiers:
+        - rw610
+    '--reset':
+    - run: last
+      runners:
+      - all
+      groups:
+      - qualifiers:
+        - rw612
+      - qualifiers:
+        - rw610


### PR DESCRIPTION
- Added a flash runner configuration for rw, mcx, lpc, kinetis and imxrt, used for sysbuild multi-image projects like MCUBoot.
- Solved the mass erase issue.
- The sysbuild project "west flash --erase" command caused the mass_erase->flash_img1->reset->mass_erase->flash_img2->reset sequence. It was fixed to the mass_erase->flash_img1-> flash_img2->reset sequence.