### PR TITLE
hostap: Add new api to get sta connection state

### DIFF
--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -777,6 +777,27 @@ out:
 	return ret;
 }
 
+int supplicant_wpa_state(const struct device *dev, int *state)
+{
+	struct wpa_supplicant *wpa_s;
+	int ret = 0;
+
+	k_mutex_lock(&wpa_supplicant_mutex, K_FOREVER);
+
+	wpa_s = get_wpa_s_handle(dev);
+	if (!wpa_s) {
+		wpa_printf(MSG_ERROR, "Device %s not found", dev->name);
+		ret = -1;
+		goto out;
+	}
+
+	*state = wpa_s->wpa_state; /* 1-1 Mapping */
+
+out:
+	k_mutex_unlock(&wpa_supplicant_mutex);
+	return ret;
+}
+
 /* Below APIs are not natively supported by WPA supplicant, so,
  * these are just wrappers around driver offload APIs. But it is
  * transparent to the user.

--- a/modules/hostap/src/supp_api.h
+++ b/modules/hostap/src/supp_api.h
@@ -43,6 +43,16 @@ int supplicant_disconnect(const struct device *dev);
  * @brief
  *
  * @param dev: Wi-Fi interface name to use
+ * @param state: connection state info to fill
+ *
+ * @return: 0 for OK; -1 for ERROR
+ */
+int supplicant_wpa_state(const struct device *dev, int *state);
+
+/**
+ * @brief
+ *
+ * @param dev: Wi-Fi interface name to use
  * @param status: Status structure to fill
  *
  * @return: 0 for OK; -1 for ERROR


### PR DESCRIPTION
When do the cmd nxp_wifi get-txratecfg sta, it will get data rate by wifi_get_data_rate, then drv will get cmd lock and send cmd HostCmd_CMD_802_11_TX_RATE_QUERY to fw, but  before send the cmd, it will check connection state by is_sta_connected, in this process, it will get cmd lock again and send cmd HostCmd_CMD_RSSI_INFO, but the cmd lock is got by HostCmd_CMD_802_11_TX_RATE_QUERY and not put yet, so it will time out and cause the interface result return time to be extended.
Add a new api supplicant_wpa_state to get connection state.