### PR TITLE
soc: nordic: Fix run once regex issue and add missing entries

### DIFF
--- a/soc/nordic/soc.yml
+++ b/soc/nordic/soc.yml
@@ -52,16 +52,37 @@ runners:
         run: first
         groups:
           - qualifiers:
-              - nrf51([0-9]{3})((.+)?)
+              - nrf51822
           - qualifiers:
-              - nrf52([0-9]{3})((.+)?)
+              - nrf52805
+          - qualifiers:
+              - nrf52810
+          - qualifiers:
+              - nrf52811
+          - qualifiers:
+              - nrf52820
+          - qualifiers:
+              - nrf52832
+          - qualifiers:
+              - nrf52833
+          - qualifiers:
+              - nrf52840
           - qualifiers:
               - nrf5340/cpunet
               - nrf5340/cpuapp
               - nrf5340/cpuapp/ns
           - qualifiers:
+              - nrf9131
+              - nrf9131/ns
+          - qualifiers:
+              - nrf9151
+              - nrf9151/ns
+          - qualifiers:
               - nrf9160
               - nrf9160/ns
+          - qualifiers:
+              - nrf9161
+              - nrf9161/ns
           - qualifiers:
               - nrf54l15/cpuapp
               - nrf54l15/cpuflpr
@@ -77,17 +98,38 @@ runners:
         run: first
         groups:
           - qualifiers:
-              - nrf51([0-9]{3})((.+)?)
+              - nrf51822
           - qualifiers:
-              - nrf52([0-9]{3})((.+)?)
+              - nrf52805
+          - qualifiers:
+              - nrf52810
+          - qualifiers:
+              - nrf52811
+          - qualifiers:
+              - nrf52820
+          - qualifiers:
+              - nrf52832
+          - qualifiers:
+              - nrf52833
+          - qualifiers:
+              - nrf52840
           - qualifiers:
               - nrf5340/cpunet
           - qualifiers:
               - nrf5340/cpuapp
               - nrf5340/cpuapp/ns
           - qualifiers:
+              - nrf9131
+              - nrf9131/ns
+          - qualifiers:
+              - nrf9151
+              - nrf9151/ns
+          - qualifiers:
               - nrf9160
               - nrf9160/ns
+          - qualifiers:
+              - nrf9161
+              - nrf9161/ns
           - qualifiers:
               - nrf54l15/cpuapp
               - nrf54l15/cpuflpr
@@ -103,17 +145,38 @@ runners:
         run: last
         groups:
           - qualifiers:
-              - nrf51([0-9]{3})((.+)?)
+              - nrf51822
           - qualifiers:
-              - nrf52([0-9]{3})((.+)?)
+              - nrf52805
+          - qualifiers:
+              - nrf52810
+          - qualifiers:
+              - nrf52811
+          - qualifiers:
+              - nrf52820
+          - qualifiers:
+              - nrf52832
+          - qualifiers:
+              - nrf52833
+          - qualifiers:
+              - nrf52840
           - qualifiers:
               - nrf5340/cpunet
           - qualifiers:
               - nrf5340/cpuapp
               - nrf5340/cpuapp/ns
           - qualifiers:
+              - nrf9131
+              - nrf9131/ns
+          - qualifiers:
+              - nrf9151
+              - nrf9151/ns
+          - qualifiers:
               - nrf9160
               - nrf9160/ns
+          - qualifiers:
+              - nrf9161
+              - nrf9161/ns
           - qualifiers:
               - nrf54l15/cpuapp
               - nrf54l15/cpuflpr


### PR DESCRIPTION
Fixes an issue whereby multiple boards would be grouped when using a regex to group them, and adds missing nRF91 entries to the list