### PR TITLE
MAINTAINERS: put the CANopen runner script under the CAN area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1008,6 +1008,7 @@ Release Notes:
     - samples/modules/canopennode/
     - samples/net/sockets/can/
     - samples/subsys/canbus/
+    - scripts/west_commands/runners/canopen_program.py
     - subsys/canbus/
     - subsys/net/l2/canbus/
     - tests/drivers/build_all/can/

--- a/scripts/ci/twister_ignore.txt
+++ b/scripts/ci/twister_ignore.txt
@@ -48,3 +48,4 @@ scripts/ci/pylintrc
 scripts/footprint/*
 scripts/set_assignees.py
 scripts/gitlint/zephyr_commit_rules.py
+scripts/west_commands/runners/canopen_program.py


### PR DESCRIPTION
Put the scripts/west_commands/runners/canopen_program.py script under the CAN area and ignore changes to this script in CI. This prevents unnecessary complex test plans as the one generated in CI for https://github.com/zephyrproject-rtos/zephyr/pull/75240. 

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>