### PR TITLE
ci: move github runners from macos-11 to macos-14

### DIFF
--- a/.github/workflows/devicetree_checks.yml
+++ b/.github/workflows/devicetree_checks.yml
@@ -27,9 +27,9 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12']
-        os: [ubuntu-22.04, macos-11, windows-2022]
+        os: [ubuntu-22.04, macos-14, windows-2022]
         exclude:
-        - os: macos-11
+        - os: macos-14
           python-version: 3.6
         - os: windows-2022
           python-version: 3.6

--- a/.github/workflows/west_cmds.yml
+++ b/.github/workflows/west_cmds.yml
@@ -30,9 +30,9 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12']
-        os: [ubuntu-22.04, macos-11, windows-2022]
+        os: [ubuntu-22.04, macos-14, windows-2022]
         exclude:
-        - os: macos-11
+        - os: macos-14
           python-version: 3.6
         - os: windows-2022
           python-version: 3.6


### PR DESCRIPTION
Move the GitHub runners currently on macos-11 to macos-14 as the former is no longer supported by GitHub.

More information: https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/
Example of CI job hanging, waiting for a macos-11 runner: https://github.com/zephyrproject-rtos/zephyr/actions/runs/9741628542/job/26893114262