### PR TITLE
Bluetooth: shell: Enable sysbuild for nRF5340

### DIFF
--- a/tests/bluetooth/shell/Kconfig.sysbuild
+++ b/tests/bluetooth/shell/Kconfig.sysbuild
@@ -1,0 +1,15 @@
+# Copyright 2023-2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+source "share/sysbuild/Kconfig"
+
+config NET_CORE_BOARD
+	string
+	default "nrf5340dk/nrf5340/cpunet" if $(BOARD) = "nrf5340dk"
+	default "nrf5340_audio_dk/nrf5340/cpunet" if $(BOARD) = "nrf5340_audio_dk"
+	default "nrf5340bsim/nrf5340/cpunet" if $(BOARD_TARGET_STRING) = "NRF5340BSIM_NRF5340_CPUAPP"
+
+config NET_CORE_IMAGE_HCI_IPC
+	bool "HCI IPC image on network core"
+	default y
+	depends on NET_CORE_BOARD != ""

--- a/tests/bluetooth/shell/sysbuild.cmake
+++ b/tests/bluetooth/shell/sysbuild.cmake
@@ -1,0 +1,19 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if(SB_CONFIG_NET_CORE_IMAGE_HCI_IPC)
+  # For builds in the nrf5340, we build the netcore image with the controller
+
+  set(NET_APP hci_ipc)
+  set(NET_APP_SRC_DIR ${ZEPHYR_BASE}/samples/bluetooth/${NET_APP})
+
+  ExternalZephyrProject_Add(
+    APPLICATION ${NET_APP}
+    SOURCE_DIR  ${NET_APP_SRC_DIR}
+    BOARD       ${SB_CONFIG_NET_CORE_BOARD}
+  )
+
+  native_simulator_set_child_images(${DEFAULT_IMAGE} ${NET_APP})
+endif()
+
+native_simulator_set_final_executable(${DEFAULT_IMAGE})


### PR DESCRIPTION
Enable sysbuild for nRF5340 app core.

This automatically builds the image for the network core, making a better user experience.