### PR TITLE
github: hello_world_multiplatform: upgrade from macos-12 to macos-13

### DIFF
--- a/.github/workflows/hello_world_multiplatform.yaml
+++ b/.github/workflows/hello_world_multiplatform.yaml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-12, macos-14, windows-2022]
+        os: [ubuntu-22.04, macos-13, macos-14, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout


### PR DESCRIPTION
Upgrade the CI image for x86 macos from 12 to 13, this is apparently the latest "free" x86 macos runner that will be supported, let's switch to it until it gets deprecated.