### PR TITLE
intel_adsp/ace: power: pad the hpsram_mask passed to power_down

### DIFF
--- a/soc/intel/intel_adsp/ace/power.c
+++ b/soc/intel/intel_adsp/ace/power.c
@@ -339,16 +339,19 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 					(void *)rom_entry;
 			sys_cache_data_flush_range((void *)imr_layout, sizeof(*imr_layout));
 #endif /* CONFIG_ADSP_IMR_CONTEXT_SAVE */
-			uint32_t hpsram_mask = 0;
+			const int dcache_words = XCHAL_DCACHE_LINESIZE / 4;
+			uint32_t hpsram_mask[dcache_words] __aligned(XCHAL_DCACHE_LINESIZE);
+
+			hpsram_mask[0] = 0;
 #ifdef CONFIG_ADSP_POWER_DOWN_HPSRAM
 			/* turn off all HPSRAM banks - get a full bitmap */
 			uint32_t ebb_banks = ace_hpsram_get_bank_count();
-			hpsram_mask = (1 << ebb_banks) - 1;
+			hpsram_mask[0] = (1 << ebb_banks) - 1;
 #endif /* CONFIG_ADSP_POWER_DOWN_HPSRAM */
-			/* do power down - this function won't return */
 			ret = pm_device_runtime_put(INTEL_ADSP_HST_DOMAIN_DEV);
 			__ASSERT_NO_MSG(ret == 0);
-			power_down(true, sys_cache_cached_ptr_get(&hpsram_mask),
+			/* do power down - this function won't return */
+			power_down(true, sys_cache_cached_ptr_get(&hpsram_mask[0]),
 				   true);
 		} else {
 			power_gate_entry(cpu);


### PR DESCRIPTION
The power_down() function will lock dcache for the hpsram_mask array. On some platforms, the dcache lock will fail if the array is on cache line that can be used for window register context saves.

Work around this by padding the hssram_mask to a full cacheline.

Link: https://github.com/thesofproject/sof/issues/9268