### PR TITLE
Enable spi_loopback tests on nucleo_h745zi_q boards

### DIFF
--- a/boards/st/nucleo_h745zi_q/doc/index.rst
+++ b/boards/st/nucleo_h745zi_q/doc/index.rst
@@ -117,6 +117,8 @@ features:
 +-------------+------------+-------------------------------------+
 | USB OTG FS  | on-chip    | USB device                          |
 +-------------+------------+-------------------------------------+
+| SPI         | on-chip    | spi                                 |
++-------------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.
 
@@ -138,6 +140,7 @@ and a ST morpho connector. Board is configured as follows:
 - LD2 : PB7
 - LD3 : PB14
 - I2C : PB8, PB9
+- SPI : PA5, PA6, PB5, PD14
 
 System Clock
 ------------

--- a/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m4.dts
+++ b/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m4.dts
@@ -35,3 +35,11 @@
 &rcc {
 	clock-frequency = <DT_FREQ_M(240)>;
 };
+
+&spi1 {
+	pinctrl-0 = <&spi1_sck_pa5 &spi1_miso_pa6 &spi1_mosi_pb5>;
+	pinctrl-names = "default";
+	cs-gpios = <&gpiod 14 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+
+	status = "okay";
+};

--- a/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m4.dts
+++ b/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m4.dts
@@ -40,6 +40,5 @@
 	pinctrl-0 = <&spi1_sck_pa5 &spi1_miso_pa6 &spi1_mosi_pb5>;
 	pinctrl-names = "default";
 	cs-gpios = <&gpiod 14 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
-
 	status = "okay";
 };

--- a/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m4.yaml
+++ b/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m4.yaml
@@ -12,6 +12,7 @@ supported:
   - arduino_gpio
   - gpio
   - netif:eth
+  - spi
 testing:
   ignore_tags:
     - mpu

--- a/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m7.dts
+++ b/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m7.dts
@@ -132,6 +132,13 @@
 	status = "okay";
 };
 
+&spi1 {
+	pinctrl-0 = <&spi1_sck_pa5 &spi1_miso_pa6 &spi1_mosi_pb5>;
+	pinctrl-names = "default";
+	cs-gpios = <&gpiod 14 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+	status = "okay";
+};
+
 zephyr_udc0: &usbotg_fs {
 	pinctrl-0 = <&usb_otg_fs_dm_pa11 &usb_otg_fs_dp_pa12>;
 	pinctrl-names = "default";

--- a/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m7.yaml
+++ b/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m7.yaml
@@ -17,5 +17,6 @@ supported:
   - i2c
   - pwm
   - netif:eth
+  - spi
   - usb_device
 vendor: st

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_h743zi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_h743zi.overlay
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
-
 /* Set div-q to get test clk freq into acceptable SPI freq range */
 &pll {
 	/delete-property/ div-q;

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_h745zi_q_stm32h745xx_m4.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_h745zi_q_stm32h745xx_m4.overlay
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 Linutronix GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Set div-q to get test clk freq into acceptable SPI freq range */
+&pll {
+	/delete-property/ div-q;
+	div-q = <8>;
+};
+
+&sram2 {
+	zephyr,memory-attr = < DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE) >;
+};
+
+&spi1 {
+	dmas = <&dmamux1 0 38 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
+		&dmamux1 1 37 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+	dma-names = "tx", "rx";
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <500000>;
+	};
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <16000000>;
+	};
+};
+
+&dma1 {
+	status = "okay";
+};
+
+&dma2 {
+	status = "okay";
+};
+
+&dmamux1 {
+	status = "okay";
+};

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_h745zi_q_stm32h745xx_m7.conf
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_h745zi_q_stm32h745xx_m7.conf
@@ -1,0 +1,6 @@
+#
+# Copyright (c) 2023 Graphcore Ltd, All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+CONFIG_NOCACHE_MEMORY=y

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_h745zi_q_stm32h745xx_m7.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_h745zi_q_stm32h745xx_m7.overlay
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 Linutronix GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Set div-q to get test clk freq into acceptable SPI freq range */
+&pll {
+	/delete-property/ div-q;
+	div-q = <8>;
+};
+
+&sram2 {
+	zephyr,memory-attr = < DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE) >;
+};
+
+&spi1 {
+	dmas = <&dmamux1 0 38 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
+		&dmamux1 1 37 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+	dma-names = "tx", "rx";
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <500000>;
+	};
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <16000000>;
+	};
+};
+
+&dma1 {
+	status = "okay";
+};
+
+&dma2 {
+	status = "okay";
+};
+
+&dmamux1 {
+	status = "okay";
+};

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_h753zi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_h753zi.overlay
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
-
 /* Set div-q to get test clk freq into acceptable SPI freq range */
 &pll {
 	/delete-property/ div-q;

--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -56,6 +56,8 @@ tests:
     platform_allow:
       - nucleo_h743zi
       - nucleo_h753zi
+      - nucleo_h745zi_q/stm32h745xx/m4
+      - nucleo_h745zi_q/stm32h745xx/m7
   drivers.spi.stm32_spi_dma.loopback:
     extra_args: OVERLAY_CONFIG="overlay-stm32-spi-dma.conf"
     filter: CONFIG_SOC_FAMILY_STM32
@@ -71,6 +73,8 @@ tests:
       - nucleo_wl55jc
       - nucleo_h743zi
       - nucleo_h753zi
+      - nucleo_h745zi_q/stm32h745xx/m4
+      - nucleo_h745zi_q/stm32h745xx/m7
       - stm32h573i_dk
     integration_platforms:
       - nucleo_g474re
@@ -83,6 +87,8 @@ tests:
     platform_allow:
       - nucleo_h743zi
       - nucleo_h753zi
+      - nucleo_h745zi_q/stm32h745xx/m4
+      - nucleo_h745zi_q/stm32h745xx/m7
   drivers.spi.stm32_spi_16bits_frames_dma.loopback:
     extra_args:
       - OVERLAY_CONFIG="overlay-stm32-spi-16bits-dma.conf"
@@ -91,6 +97,8 @@ tests:
     platform_allow:
       - nucleo_h743zi
       - nucleo_h753zi
+      - nucleo_h745zi_q/stm32h745xx/m4
+      - nucleo_h745zi_q/stm32h745xx/m7
   drivers.spi.stm32_spi_16bits_frames_dma_dt_nocache_mem.loopback:
     extra_args:
       - OVERLAY_CONFIG="overlay-stm32-spi-16bits-dma-dt-nocache-mem.conf"
@@ -99,6 +107,8 @@ tests:
     platform_allow:
       - nucleo_h743zi
       - nucleo_h753zi
+      - nucleo_h745zi_q/stm32h745xx/m4
+      - nucleo_h745zi_q/stm32h745xx/m7
   drivers.spi.stm32_spi_interrupt.loopback:
     extra_args: OVERLAY_CONFIG="overlay-stm32-spi-interrupt.conf"
     filter: CONFIG_SOC_FAMILY_STM32
@@ -111,6 +121,8 @@ tests:
       - nucleo_g474re
       - nucleo_h743zi
       - nucleo_h753zi
+      - nucleo_h745zi_q/stm32h745xx/m4
+      - nucleo_h745zi_q/stm32h745xx/m7
       - nucleo_l152re
       - nucleo_wb55rg
       - nucleo_wl55jc


### PR DESCRIPTION
The SIP loopback test have no configuration and overlay for the Nucleo-H745ZI-Q board.
Profide a configuration and overlay for these board.