### PR TITLE
drivers i2c I2C_DW:Fix I2C scan example

### DIFF
--- a/drivers/i2c/Kconfig.dw
+++ b/drivers/i2c/Kconfig.dw
@@ -22,3 +22,8 @@ config I2C_DW_LPSS_DMA
 	  This option enables I2C DMA feature to be used for asynchronous
 	  data transfers. All Tx operations are done using dma channel 0 and
 	  all Rx operations are done using dma channel 1.
+
+config I2C_DW_RW_TIMEOUT_MS
+	int "Set the Read/Write timeout in milliseconds"
+	depends on I2C_DW
+	default 100

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -632,6 +632,7 @@ static int i2c_dw_transfer(const struct device *dev,
 	uint8_t pflags;
 	int ret;
 	uint32_t reg_base = get_regs(dev);
+	uint32_t value = 0;
 
 	__ASSERT_NO_MSG(msgs);
 	if (!num_msgs) {
@@ -675,6 +676,11 @@ static int i2c_dw_transfer(const struct device *dev,
 
 		/* Process all the messages */
 	while (msg_left > 0) {
+		/* Workaround for I2C scanner as DW HW does not support 0 byte transfers.*/
+		if ((cur_msg->len == 0) && (cur_msg->buf != NULL)) {
+			cur_msg->len = 1;
+		}
+
 		pflags = dw->xfr_flags;
 
 		dw->xfr_buf = cur_msg->buf;
@@ -714,7 +720,12 @@ static int i2c_dw_transfer(const struct device *dev,
 		}
 
 		/* Wait for transfer to be done */
-		k_sem_take(&dw->device_sync_sem, K_FOREVER);
+		ret = k_sem_take(&dw->device_sync_sem, K_MSEC(CONFIG_I2C_DW_RW_TIMEOUT_MS));
+		if (ret != 0) {
+			write_intr_mask(DW_DISABLE_ALL_I2C_INT, reg_base);
+			value = read_clr_intr(reg_base);
+			break;
+		}
 
 		if (dw->state & I2C_DW_CMD_ERROR) {
 			ret = -EIO;


### PR DESCRIPTION
Solves two similar issues listed below:

Issue 1: I2C scanner example for DesignWare hardware gets stuck indefenitely resulting in system hang up. This is because DW driver does not handle 0 byte transfer correctly which is the case for I2C scan example. Fixed it by overwriting the msg length to 1 if it is 0 and the buffer is not NULL.

Issue 2: Similarly, if the I2C pins are not pulled up (nothing connected to I2C pins), the DW hardware does not actually sending the data (assuming contention on the bus) hence not releasing the semaphore resulting in calling thread waiting forever. Fixed it by adding a timeout to k_sem_take call and return error if cannot successfully acquire it.

Fixes: #70332.

Micropython seems to tackle this issue by supporting zero length transfer through Soft I2C implementation. Since Zephyr doesn't currently support that this commit provides a temporary solution to unblock the I2C Scan example.

Link: [Micropython I2C workaround](https://github.com/micropython/micropython/blob/master/ports/rp2/machine_i2c.c#L158)