### PR TITLE
tests: logging/dictionary: fix pytest failures on hardware

### DIFF
--- a/tests/subsys/logging/dictionary/pytest/test_logging_dictionary.py
+++ b/tests/subsys/logging/dictionary/pytest/test_logging_dictionary.py
@@ -147,7 +147,7 @@ def test_logging_dictionary(dut: DeviceAdapter, is_fpu_build):
     '''
     Main entrance to setup test result validation.
     '''
-    build_dir = dut.device_config.build_dir
+    build_dir = dut.device_config.app_build_dir
 
     logger.info(f'FPU build? {is_fpu_build}')
 

--- a/tests/subsys/logging/dictionary/pytest/test_logging_dictionary.py
+++ b/tests/subsys/logging/dictionary/pytest/test_logging_dictionary.py
@@ -38,8 +38,10 @@ def process_logs(dut: DeviceAdapter, build_dir):
     logger.info(f'Dictionary JSON: {dictionary_json}')
 
     # Read the encoded logs and save them to a file
-    # as the log parser requires file as input
-    handler_output = dut.readlines_until(regex = '.*##ZLOGV1##[0-9]+', timeout = 10.0)
+    # as the log parser requires file as input.
+    # Timeout is intentionally long. Twister will
+    # timeout earlier with per-test timeout.
+    handler_output = dut.readlines_until(regex = '.*##ZLOGV1##[0-9]+', timeout = 600.0)
 
     encoded_logs = handler_output[-1]
 

--- a/tests/subsys/logging/dictionary/pytest/test_logging_dictionary.py
+++ b/tests/subsys/logging/dictionary/pytest/test_logging_dictionary.py
@@ -39,7 +39,7 @@ def process_logs(dut: DeviceAdapter, build_dir):
 
     # Read the encoded logs and save them to a file
     # as the log parser requires file as input
-    handler_output = dut.readlines_until(regex = '^##ZLOGV1##[0-9]+', timeout = 10.0)
+    handler_output = dut.readlines_until(regex = '.*##ZLOGV1##[0-9]+', timeout = 10.0)
 
     encoded_logs = handler_output[-1]
 
@@ -67,7 +67,7 @@ def expected_regex_common():
     '''
     return [
     # *** Booting Zephyr OS build <version> ***
-    re.compile(r'^[*][*][*] Booting Zephyr OS build [0-9a-z.-]+'),
+    re.compile(r'.*[*][*][*] Booting Zephyr OS build [0-9a-z.-]+'),
     # Hello World! <board name>
     re.compile(r'[\s]+Hello World! [\w-]+'),
     # [        10] <err> hello_world: error string


### PR DESCRIPTION
These should fix pytest failures on hardware.

Tested on `frdm_k64f` and `up_squared`.

Fixes #75253