### PR TITLE
riscv: fix compilation error when building OOT SoC with custom `__soc_is_irq`

### DIFF
--- a/include/zephyr/arch/riscv/irq.h
+++ b/include/zephyr/arch/riscv/irq.h
@@ -18,6 +18,8 @@
 extern "C" {
 #endif
 
+#include <zephyr/sys/util_macro.h>
+
 #ifndef _ASMLANGUAGE
 #include <zephyr/irq.h>
 #include <zephyr/sw_isr_table.h>


### PR DESCRIPTION
Fixes the following compilation error when building OOT RISCV SOC on v3.7.0 (update from v3.5.0):

```
/data/users/ycsin/firmware/zephyr/modules/soc_latest/soc/meta/common/soc_irq.S: Assembler messages:
/data/users/ycsin/firmware/zephyr/modules/soc_latest/soc/meta/common/soc_irq.S:36: Error: illegal operands `li t1,BIT64(63U)'
```

This is likely due to changes introduced in #67829