### PR TITLE
net: dns: Avoid superfluous error message

### DIFF
--- a/subsys/net/lib/dns/dispatcher.c
+++ b/subsys/net/lib/dns/dispatcher.c
@@ -161,7 +161,7 @@ void dns_dispatcher_svc_handler(struct k_work *work)
 	int ret;
 
 	ret = recv_data(pev);
-	if (ret < 0 && ret != DNS_EAI_ALLDONE) {
+	if (ret < 0 && ret != DNS_EAI_ALLDONE && ret != -ENOENT) {
 		NET_ERR("DNS recv error (%d)", ret);
 	}
 }


### PR DESCRIPTION
If we have configured the DNS dispatcher to be only as a responder but receive a query response, or if we are only as a resolver but receive a query, then the dispatcher just ignores the packet and returns -ENOENT.

Unfortunately we print an error message in this case

[00:10:18.818,000] <err> net_dns_dispatcher: DNS recv error (-2)

which is totally unnecessary and causes confusion so do not print an error message in this case.