### PR TITLE
MAINTAINERS: use shorter, more intuitive label for llext

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5068,6 +5068,6 @@ zbus:
     - subsys/llext/
     - doc/services/llext/
   labels:
-    - "area: Linkable Loadable Extensions"
+    - "area: llext"
   tests:
     - llext


### PR DESCRIPTION
Use a shorter, more intuitive label for the Linkable Loadable Extensions (llext) area. We currently have two labels for this area ("area: Linkable Loadable Extensions" and "area: llext"). I suggest unifying the two to the shorter label.