### PR TITLE
soc: nxp_s32: disable TCP/UDP software checksum only if ethernet driver enabled

### DIFF
--- a/soc/nxp/s32/s32k3/Kconfig.defconfig
+++ b/soc/nxp/s32/s32k3/Kconfig.defconfig
@@ -15,7 +15,7 @@ config NUM_IRQS
 config FPU
 	default y
 
-if NET_L2_ETHERNET
+if ETH_DRIVER && NET_L2_ETHERNET
 
 config NET_TCP_CHECKSUM
 	default n
@@ -23,7 +23,7 @@ config NET_TCP_CHECKSUM
 config NET_UDP_CHECKSUM
 	default n
 
-endif # NET_L2_ETHERNET
+endif # ETH_DRIVER && NET_L2_ETHERNET
 
 config CACHE_MANAGEMENT
 	default y

--- a/soc/nxp/s32/s32ze/Kconfig.defconfig
+++ b/soc/nxp/s32/s32ze/Kconfig.defconfig
@@ -18,7 +18,7 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config MAIN_STACK_SIZE
 	default 1024
 
-if NET_L2_ETHERNET
+if ETH_DRIVER && NET_L2_ETHERNET
 
 # NETC drops TCP/UDP packets with invalid checksum
 config NET_TCP_CHECKSUM
@@ -27,6 +27,6 @@ config NET_TCP_CHECKSUM
 config NET_UDP_CHECKSUM
 	default n
 
-endif # NET_L2_ETHERNET
+endif # ETH_DRIVER && NET_L2_ETHERNET
 
 endif # SOC_SERIES_S32ZE


### PR DESCRIPTION
Only disable TCP/UDP software checksum if the ethernet driver enabled. This is to avoid interfere with net tests which don't need the on board driver to function.

For example with `tests/net/checksum_offload/net.offload`: the message which has invalid checksum must be dropped but is not because the test does not use on-board Ethernet driver --> cannot rely on hardware to discard the message.

Fix: #75304

```
SUITE PASS - 100.00% [net_chksum_offload]: pass = 32, fail = 0, skip = 0, total = 32 duration = 0.965 seconds
 - PASS - [net_chksum_offload.test_rx_chksum_offload_disabled_test_v4] duration = 0.012 seconds
 - PASS - [net_chksum_offload.test_rx_chksum_offload_disabled_test_v4_icmp_frag] duration = 0.001 seconds
 - PASS - [net_chksum_offload.test_rx_chksum_offload_disabled_test_v4_icmp_frag_bad] duration = 0.101 seconds
 - PASS - [net_chksum_offload.test_rx_chksum_offload_disabled_test_v4_udp_frag] duration = 0.012 seconds
 - PASS - [net_chksum_offload.test_rx_chksum_offload_disabled_test_v6] duration = 0.011 seconds
 - PASS - [net_chksum_offload.test_rx_chksum_offload_disabled_test_v6_icmp_frag] duration = 0.001 seconds
 - PASS - [net_chksum_offload.test_rx_chksum_offload_disabled_test_v6_icmp_frag_bad] duration = 0.101 seconds
 - PASS - [net_chksum_offload.test_rx_chksum_offload_disabled_test_v6_udp_frag] duration = 0.012 seconds
 - PASS - [net_chksum_offload.test_rx_chksum_offload_enabled_test_v4] duration = 0.011 seconds
 - PASS - [net_chksum_offload.test_rx_chksum_offload_enabled_test_v4_icmp_frag] duration = 0.001 seconds
 - PASS - [net_chksum_offload.test_rx_chksum_offload_enabled_test_v4_icmp_frag_bad] duration = 0.102 seconds
 - PASS - [net_chksum_offload.test_rx_chksum_offload_enabled_test_v4_udp_frag] duration = 0.012 seconds
 - PASS - [net_chksum_offload.test_rx_chksum_offload_enabled_test_v6] duration = 0.011 seconds
 - PASS - [net_chksum_offload.test_rx_chksum_offload_enabled_test_v6_icmp_frag] duration = 0.001 seconds
 - PASS - [net_chksum_offload.test_rx_chksum_offload_enabled_test_v6_icmp_frag_bad] duration = 0.102 seconds
 - PASS - [net_chksum_offload.test_rx_chksum_offload_enabled_test_v6_udp_frag] duration = 0.012 seconds
 - PASS - [net_chksum_offload.test_tx_chksum_offload_disabled_test_v4] duration = 0.001 seconds
 - PASS - [net_chksum_offload.test_tx_chksum_offload_disabled_test_v4_icmp_frag] duration = 0.001 seconds
 - PASS - [net_chksum_offload.test_tx_chksum_offload_disabled_test_v4_udp_frag] duration = 0.001 seconds
 - PASS - [net_chksum_offload.test_tx_chksum_offload_disabled_test_v4_udp_frag_bad] duration = 0.112 seconds
 - PASS - [net_chksum_offload.test_tx_chksum_offload_disabled_test_v6] duration = 0.001 seconds
 - PASS - [net_chksum_offload.test_tx_chksum_offload_disabled_test_v6_icmp_frag] duration = 0.001 seconds
 - PASS - [net_chksum_offload.test_tx_chksum_offload_disabled_test_v6_udp_frag] duration = 0.001 seconds
 - PASS - [net_chksum_offload.test_tx_chksum_offload_disabled_test_v6_udp_frag_bad] duration = 0.112 seconds
 - PASS - [net_chksum_offload.test_tx_chksum_offload_enabled_test_v4] duration = 0.001 seconds
 - PASS - [net_chksum_offload.test_tx_chksum_offload_enabled_test_v4_icmp_frag] duration = 0.001 seconds
 - PASS - [net_chksum_offload.test_tx_chksum_offload_enabled_test_v4_udp_frag] duration = 0.001 seconds
 - PASS - [net_chksum_offload.test_tx_chksum_offload_enabled_test_v4_udp_frag_bad] duration = 0.113 seconds
 - PASS - [net_chksum_offload.test_tx_chksum_offload_enabled_test_v6] duration = 0.001 seconds
 - PASS - [net_chksum_offload.test_tx_chksum_offload_enabled_test_v6_icmp_frag] duration = 0.001 seconds
 - PASS - [net_chksum_offload.test_tx_chksum_offload_enabled_test_v6_udp_frag] duration = 0.001 seconds
 - PASS - [net_chksum_offload.test_tx_chksum_offload_enabled_test_v6_udp_frag_bad] duration = 0.113 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```