### PR TITLE
drivers: udc_stm32: only check for HS_SPEED if defined

### DIFF
--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -789,9 +789,11 @@ static enum udc_bus_speed udc_stm32_device_speed(const struct device *dev)
 {
 	struct udc_stm32_data *priv = udc_get_private(dev);
 
+#ifdef USBD_HS_SPEED
 	if (priv->pcd.Init.speed == USBD_HS_SPEED) {
 		return UDC_BUS_SPEED_HS;
 	}
+#endif
 
 	if (priv->pcd.Init.speed == USBD_FS_SPEED) {
 		return UDC_BUS_SPEED_FS;


### PR DESCRIPTION
Seems like not all stm32 devices define USBD_HS_SPEED in the HAL, only check for USBD_HS_SPEED if defined. Fixes a build failure with the new stack on F1 MCUs.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/75307