### PR TITLE
boards: st: stm32h5 boards has openOCD runner from upstream

### DIFF
--- a/boards/st/nucleo_h533re/board.cmake
+++ b/boards/st/nucleo_h533re/board.cmake
@@ -6,6 +6,12 @@ board_runner_args(pyocd "--target=stm32h533retx")
 
 board_runner_args(jlink "--device=STM32H533RE" "--reset-after-load")
 
+board_runner_args(openocd "--tcl-port=6666")
+board_runner_args(openocd --cmd-pre-init "gdb_report_data_abort enable")
+board_runner_args(openocd "--no-halt")
+
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+# FIXME: official openocd runner not yet available.

--- a/boards/st/nucleo_h533re/doc/index.rst
+++ b/boards/st/nucleo_h533re/doc/index.rst
@@ -233,6 +233,24 @@ Applications for the ``nucleo_h533re`` board can be built and
 flashed in the usual way (see :ref:`build_an_application` and
 :ref:`application_run` for more details).
 
+OpenOCD Support
+===============
+
+For now, openocd support  for stm32h5 is not available on upstream OpenOCD.
+You can check `OpenOCD official Github mirror`_.
+In order to use it though, you should clone from the cutomized
+`STMicroelectronics OpenOCD Github`_ and compile it following usual README guidelines.
+Once it is done, you can set the OPENOCD and OPENOCD_DEFAULT_PATH variables in
+:zephyr_file:`boards/st/nucleo_h533re/board.cmake` to point the build
+to the paths of the OpenOCD binary and its scripts,  before
+including the common openocd.board.cmake file:
+
+   .. code-block:: none
+
+      set(OPENOCD "<path_to_openocd_repo>/src/openocd" CACHE FILEPATH "" FORCE)
+      set(OPENOCD_DEFAULT_PATH <path_to_opneocd_repo>/tcl)
+      include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+
 Flashing
 ========
 
@@ -253,6 +271,10 @@ This can be done by executing the following commands.
 
    $ pyocd pack --update
    $ pyocd pack --install stm32h5
+
+
+Alternatively, the openocd interface will be supported by a next openocd version.
+When available, OpenOCD could be used in the same way as other tools.
 
 
 Flashing an application to Nucleo H533RE
@@ -306,3 +328,9 @@ You can debug an application in the usual way. Here is an example for the
 
 .. _STM32CubeProgrammer:
    https://www.st.com/en/development-tools/stm32cubeprog.html
+
+.. _OpenOCD official Github mirror:
+   https://github.com/openocd-org/openocd/
+
+.. _STMicroelectronics OpenOCD Github:
+   https://github.com/STMicroelectronics/OpenOCD/tree/openocd-cubeide-r6

--- a/boards/st/nucleo_h533re/support/openocd.cfg
+++ b/boards/st/nucleo_h533re/support/openocd.cfg
@@ -1,0 +1,23 @@
+source [find interface/stlink-dap.cfg]
+
+source [find target/stm32h5x.cfg]
+
+transport select "dapdirect_swd"
+
+set CHIPNAME STM32H533RETX
+set BOARDNAME NUCLEO-STM32H533RE
+
+# Reset configuration
+# use hardware reset, connect under reset
+# connect_assert_srst needed if low power mode application running (WFI...)
+reset_config srst_only srst_nogate connect_assert_srst
+set CONNECT_UNDER_RESET 1
+set CORE_RESET 0
+
+# Due to the use of connect_assert_srst, running gdb requires
+# to reset halt just after openocd init.
+rename init old_init
+proc init {} {
+        old_init
+        reset halt
+}

--- a/boards/st/nucleo_h563zi/board.cmake
+++ b/boards/st/nucleo_h563zi/board.cmake
@@ -6,6 +6,12 @@ board_runner_args(pyocd "--target=stm32h563zitx")
 
 board_runner_args(jlink "--device=STM32H563ZI" "--reset-after-load")
 
+board_runner_args(openocd "--tcl-port=6666")
+board_runner_args(openocd --cmd-pre-init "gdb_report_data_abort enable")
+board_runner_args(openocd "--no-halt")
+
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+#include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+# FIXME: official openocd runner not yet available.

--- a/boards/st/nucleo_h563zi/doc/index.rst
+++ b/boards/st/nucleo_h563zi/doc/index.rst
@@ -247,6 +247,25 @@ Applications for the ``nucleo_h563zi`` board can be built and
 flashed in the usual way (see :ref:`build_an_application` and
 :ref:`application_run` for more details).
 
+OpenOCD Support
+===============
+
+For now, openocd support  for stm32h5 is not available on upstream OpenOCD.
+You can check `OpenOCD official Github mirror`_.
+In order to use it though, you should clone from the cutomized
+`STMicroelectronics OpenOCD Github`_ and compile it following usual README guidelines.
+Once it is done, you can set the OPENOCD and OPENOCD_DEFAULT_PATH variables in
+:zephyr_file:`boards/st/nucleo_h563zi/board.cmake` to point the build
+to the paths of the OpenOCD binary and its scripts,  before
+including the common openocd.board.cmake file:
+
+   .. code-block:: none
+
+      set(OPENOCD "<path_to_openocd_repo>/src/openocd" CACHE FILEPATH "" FORCE)
+      set(OPENOCD_DEFAULT_PATH <path_to_opneocd_repo>/tcl)
+      include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+
+
 Flashing
 ========
 
@@ -267,6 +286,10 @@ This can be done by executing the following commands.
 
    $ pyocd pack --update
    $ pyocd pack --install stm32h5
+
+
+Alternatively, the openocd interface will be supported by a next openocd version.
+When available, OpenOCD could be used in the same way as other tools.
 
 
 Flashing an application to Nucleo H563ZI
@@ -320,3 +343,9 @@ You can debug an application in the usual way.  Here is an example for the
 
 .. _STM32CubeProgrammer:
    https://www.st.com/en/development-tools/stm32cubeprog.html
+
+.. _OpenOCD official Github mirror:
+   https://github.com/openocd-org/openocd/
+
+.. _STMicroelectronics OpenOCD Github:
+   https://github.com/STMicroelectronics/OpenOCD/tree/openocd-cubeide-r6

--- a/boards/st/nucleo_h563zi/support/openocd.cfg
+++ b/boards/st/nucleo_h563zi/support/openocd.cfg
@@ -1,0 +1,23 @@
+source [find interface/stlink-dap.cfg]
+
+source [find target/stm32h5x.cfg]
+
+transport select "dapdirect_swd"
+
+set CHIPNAME STM32H563ZITX
+set BOARDNAME NUCLEO-STM32H563ZI
+
+# Reset configuration
+# use hardware reset, connect under reset
+# connect_assert_srst needed if low power mode application running (WFI...)
+reset_config srst_only srst_nogate connect_assert_srst
+set CONNECT_UNDER_RESET 1
+set CORE_RESET 0
+
+# Due to the use of connect_assert_srst, running gdb requires
+# to reset halt just after openocd init.
+rename init old_init
+proc init {} {
+        old_init
+        reset halt
+}

--- a/boards/st/stm32h573i_dk/board.cmake
+++ b/boards/st/stm32h573i_dk/board.cmake
@@ -9,6 +9,11 @@ endif()
 
 board_runner_args(pyocd "--target=stm32h573iikx")
 
+board_runner_args(openocd "--tcl-port=6666")
+board_runner_args(openocd --cmd-pre-init "gdb_report_data_abort enable")
+board_runner_args(openocd "--no-halt")
+
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
-# FIXME: openocd runner not yet available.
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+# FIXME: official openocd runner not yet available.

--- a/boards/st/stm32h573i_dk/doc/index.rst
+++ b/boards/st/stm32h573i_dk/doc/index.rst
@@ -249,13 +249,48 @@ Applications for the ``stm32h573i_dk`` board configuration can be built and
 flashed in the usual way (see :ref:`build_an_application` and
 :ref:`application_run` for more details).
 
+OpenOCD Support
+===============
+
+For now, openocd support  for stm32h5 is not available on upstream OpenOCD.
+You can check `OpenOCD official Github mirror`_.
+In order to use it though, you should clone from the cutomized
+`STMicroelectronics OpenOCD Github`_ and compile it following usual README guidelines.
+Once it is done, you can set the OPENOCD and OPENOCD_DEFAULT_PATH variables in
+:zephyr_file:`boards/st/stm32h573i_dk/board.cmake` to point the build
+to the paths of the OpenOCD binary and its scripts,  before
+including the common openocd.board.cmake file:
+
+   .. code-block:: none
+
+      set(OPENOCD "<path_to_openocd_repo>/src/openocd" CACHE FILEPATH "" FORCE)
+      set(OPENOCD_DEFAULT_PATH <path_to_opneocd_repo>/tcl)
+      include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+
+
 Flashing
 ========
 
 STM32H573I-DK Discovery board includes an ST-LINK/V3E embedded debug tool
 interface. Support is available on STM32CubeProgrammer V2.13.0.
 
-Alternatively, this interface will be supported by a next openocd version.
+
+Alternatively, pyocd or jlink via an external probe can also be used to flash
+and debug the board if west is told to use it as runner, which can be done by
+passing either or ``-r pyocd``, or ``-r jlink``.
+
+For pyocd additional target information needs to be installed.
+This can be done by executing the following commands.
+
+.. code-block:: console
+
+   $ pyocd pack --update
+   $ pyocd pack --install stm32h5
+
+
+Alternatively, the openocd interface will be supported by a next openocd version.
+When available, OpenOCD could be used in the same way as other tools.
+
 
 Flashing an application to STM32H573I-DK Discovery
 --------------------------------------------------
@@ -317,3 +352,9 @@ example for the :ref:`hello_world` application.
 
 .. _STM32CubeProgrammer:
    https://www.st.com/en/development-tools/stm32cubeprog.html
+
+.. _OpenOCD official Github mirror:
+   https://github.com/openocd-org/openocd/
+
+.. _STMicroelectronics OpenOCD Github:
+   https://github.com/STMicroelectronics/OpenOCD/tree/openocd-cubeide-r6

--- a/boards/st/stm32h573i_dk/support/openocd.cfg
+++ b/boards/st/stm32h573i_dk/support/openocd.cfg
@@ -1,0 +1,23 @@
+source [find interface/stlink-dap.cfg]
+
+source [find target/stm32h5x.cfg]
+
+transport select "dapdirect_swd"
+
+set CHIPNAME STM32H573IIKXQ
+set BOARDNAME STM32H573I-DK
+
+# Reset configuration
+# use hardware reset, connect under reset
+# connect_assert_srst needed if low power mode application running (WFI...)
+reset_config srst_only srst_nogate connect_assert_srst
+set CONNECT_UNDER_RESET 1
+set CORE_RESET 0
+
+# Due to the use of connect_assert_srst, running gdb requires
+# to reset halt just after openocd init.
+rename init old_init
+proc init {} {
+        old_init
+        reset halt
+}


### PR DESCRIPTION
Define the support /openocd.cfg and the board.cmake to add the openOCD as runner for the stm32h5x boards.
Note that the openOCD is hack downloaded and build from from https://github.com/STMicroelectronics/OpenOCD

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/74545