### PR TITLE
samples: drivers: mbox: Disable UART Flow Control on nrf54h20

### DIFF
--- a/samples/drivers/mbox/remote/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/drivers/mbox/remote/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -18,3 +18,7 @@
 &cpurad_bellboard {
 	status = "okay";
 };
+
+&uart136 {
+	/delete-property/ hw-flow-control;
+};

--- a/samples/drivers/mbox/remote/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
+++ b/samples/drivers/mbox/remote/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
@@ -18,3 +18,7 @@
 &cpuppr_vevif {
 	status = "okay";
 };
+
+&uart135 {
+	/delete-property/ hw-flow-control;
+};

--- a/samples/drivers/mbox/remote/boards/nrf54l15pdk_nrf54l15_cpuflpr.overlay
+++ b/samples/drivers/mbox/remote/boards/nrf54l15pdk_nrf54l15_cpuflpr.overlay
@@ -18,3 +18,7 @@
 &cpuflpr_vevif_tx {
 	status = "okay";
 };
+
+&uart30 {
+	/delete-property/ hw-flow-control;
+};

--- a/samples/drivers/mbox/remote/boards/nrf54l15pdk_nrf54l15_cpuflpr_xip.overlay
+++ b/samples/drivers/mbox/remote/boards/nrf54l15pdk_nrf54l15_cpuflpr_xip.overlay
@@ -18,3 +18,7 @@
 &cpuflpr_vevif_tx {
 	status = "okay";
 };
+
+&uart30 {
+	/delete-property/ hw-flow-control;
+};


### PR DESCRIPTION
Nrf54h20dk has UART Flow Control enabled by default on all cores.
It's a source of problem when mbox sample is run in Twister.
Twister opens serial port only on host core, thus nobody confirms reception of logs from remote core.
As a result, remote core stucks on printing boot banner.

Twister fails sample due to the timeout while waiting for messages from remote to host.

Disable Flow Control on remote core when mbox sample is executed on nrf54h20.