### PR TITLE
irq: esp32: Interrupts priority configuration

### DIFF
--- a/drivers/can/can_esp32_twai.c
+++ b/drivers/can/can_esp32_twai.c
@@ -203,11 +203,15 @@ static int can_esp32_twai_init(const struct device *dev)
 	can_esp32_twai_write_reg32(dev, TWAI_CLOCK_DIVIDER_REG, twai_config->cdr32);
 #endif /* !CONFIG_SOC_SERIES_ESP32 */
 
-	esp_intr_alloc(twai_config->irq_source,
+	err = esp_intr_alloc(twai_config->irq_source,
 			ESP_PRIO_TO_FLAGS(twai_config->irq_priority) | ESP_INTR_FLAG_IRAM,
 			can_esp32_twai_isr, (void *)dev, NULL);
 
-	return 0;
+	if (err != 0) {
+		LOG_ERR("could not allocate interrupt (err %d)", err);
+	}
+
+	return err;
 }
 
 const struct can_driver_api can_esp32_twai_driver_api = {

--- a/drivers/can/can_esp32_twai.c
+++ b/drivers/can/can_esp32_twai.c
@@ -72,6 +72,7 @@ struct can_esp32_twai_config {
 	const clock_control_subsys_t clock_subsys;
 	int irq_source;
 	int irq_priority;
+	int irq_flags;
 #ifndef CONFIG_SOC_SERIES_ESP32
 	/* 32-bit variant of output clock divider register required for non-ESP32 MCUs */
 	uint32_t cdr32;
@@ -204,7 +205,8 @@ static int can_esp32_twai_init(const struct device *dev)
 #endif /* !CONFIG_SOC_SERIES_ESP32 */
 
 	err = esp_intr_alloc(twai_config->irq_source,
-			ESP_PRIO_TO_FLAGS(twai_config->irq_priority) | ESP_INTR_FLAG_IRAM,
+			ESP_PRIO_TO_FLAGS(twai_config->irq_priority) |
+			ESP_INT_FLAGS_CHECK(twai_config->irq_flags) | ESP_INTR_FLAG_IRAM,
 			can_esp32_twai_isr, (void *)dev, NULL);
 
 	if (err != 0) {
@@ -280,6 +282,7 @@ const struct can_driver_api can_esp32_twai_driver_api = {
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),                                      \
 		.irq_source = DT_INST_IRQ_BY_IDX(inst, 0, irq),                                    \
 		.irq_priority = DT_INST_IRQ_BY_IDX(inst, 0, priority),                             \
+		.irq_flags = DT_INST_IRQ_BY_IDX(inst, 0, flags),                                   \
 		TWAI_CDR32_INIT(inst)                                                              \
 	};                                                                                         \
 	CAN_ESP32_TWAI_ASSERT_CLKOUT_DIVIDER(inst);                                                \

--- a/drivers/counter/counter_esp32_rtc.c
+++ b/drivers/counter/counter_esp32_rtc.c
@@ -43,6 +43,7 @@ struct counter_esp32_config {
 	struct counter_config_info counter_info;
 	int irq_source;
 	int irq_priority;
+	int irq_flags;
 	const struct device *clock_dev;
 };
 
@@ -57,14 +58,14 @@ static int counter_esp32_init(const struct device *dev)
 	const struct counter_esp32_config *cfg = dev->config;
 	struct counter_esp32_data *data = dev->data;
 
-
 	/* RTC_SLOW_CLK is the default clk source */
 	clock_control_get_rate(cfg->clock_dev,
 			       (clock_control_subsys_t)ESP32_CLOCK_CONTROL_SUBSYS_RTC_SLOW,
 			       &data->clk_src_freq);
 
 	int ret = esp_intr_alloc(cfg->irq_source,
-				ESP_PRIO_TO_FLAGS(cfg->irq_priority),
+				ESP_PRIO_TO_FLAGS(cfg->irq_priority) |
+				ESP_INT_FLAGS_CHECK(cfg->irq_flags),
 				(ESP32_COUNTER_RTC_ISR_HANDLER)counter_esp32_isr,
 				(void *)dev,
 				NULL);
@@ -206,7 +207,8 @@ static const struct counter_esp32_config counter_config = {
 	},
 	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(0)),
 	.irq_source = DT_INST_IRQ_BY_IDX(0, 0, irq),
-	.irq_priority = DT_INST_IRQ_BY_IDX(0, 0, priority)
+	.irq_priority = DT_INST_IRQ_BY_IDX(0, 0, priority),
+	.irq_flags = DT_INST_IRQ_BY_IDX(0, 0, flags)
 };
 
 static const struct counter_driver_api rtc_timer_esp32_api = {

--- a/drivers/counter/counter_esp32_rtc.c
+++ b/drivers/counter/counter_esp32_rtc.c
@@ -63,13 +63,17 @@ static int counter_esp32_init(const struct device *dev)
 			       (clock_control_subsys_t)ESP32_CLOCK_CONTROL_SUBSYS_RTC_SLOW,
 			       &data->clk_src_freq);
 
-	esp_intr_alloc(cfg->irq_source,
-			ESP_PRIO_TO_FLAGS(cfg->irq_priority),
-			(ESP32_COUNTER_RTC_ISR_HANDLER)counter_esp32_isr,
-			(void *)dev,
-			NULL);
+	int ret = esp_intr_alloc(cfg->irq_source,
+				ESP_PRIO_TO_FLAGS(cfg->irq_priority),
+				(ESP32_COUNTER_RTC_ISR_HANDLER)counter_esp32_isr,
+				(void *)dev,
+				NULL);
 
-	return 0;
+	if (ret != 0) {
+		LOG_ERR("could not allocate interrupt (err %d)", ret);
+	}
+
+	return ret;
 }
 
 static int counter_esp32_start(const struct device *dev)

--- a/drivers/counter/counter_esp32_rtc.c
+++ b/drivers/counter/counter_esp32_rtc.c
@@ -42,6 +42,7 @@ static void counter_esp32_isr(void *arg);
 struct counter_esp32_config {
 	struct counter_config_info counter_info;
 	int irq_source;
+	int irq_priority;
 	const struct device *clock_dev;
 };
 
@@ -63,7 +64,7 @@ static int counter_esp32_init(const struct device *dev)
 			       &data->clk_src_freq);
 
 	esp_intr_alloc(cfg->irq_source,
-			0,
+			ESP_PRIO_TO_FLAGS(cfg->irq_priority),
 			(ESP32_COUNTER_RTC_ISR_HANDLER)counter_esp32_isr,
 			(void *)dev,
 			NULL);
@@ -200,7 +201,8 @@ static const struct counter_esp32_config counter_config = {
 		.channels = 1
 	},
 	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(0)),
-	.irq_source = DT_INST_IRQN(0),
+	.irq_source = DT_INST_IRQ_BY_IDX(0, 0, irq),
+	.irq_priority = DT_INST_IRQ_BY_IDX(0, 0, priority)
 };
 
 static const struct counter_driver_api rtc_timer_esp32_api = {

--- a/drivers/counter/counter_esp32_tmr.c
+++ b/drivers/counter/counter_esp32_tmr.c
@@ -96,13 +96,17 @@ static int counter_esp32_init(const struct device *dev)
 	timer_ll_set_reload_value(data->hal_ctx.dev, data->hal_ctx.timer_id, 0);
 	timer_ll_enable_counter(data->hal_ctx.dev, data->hal_ctx.timer_id, cfg->config.counter_en);
 
-	esp_intr_alloc(cfg->irq_source,
-			ESP_PRIO_TO_FLAGS(cfg->irq_priority),
-			(ISR_HANDLER)counter_esp32_isr, (void *)dev, NULL);
-
 	k_spin_unlock(&lock, key);
 
-	return 0;
+	int ret = esp_intr_alloc(cfg->irq_source,
+				ESP_PRIO_TO_FLAGS(cfg->irq_priority),
+				(ISR_HANDLER)counter_esp32_isr, (void *)dev, NULL);
+
+	if (ret != 0) {
+		LOG_ERR("could not allocate interrupt (err %d)", ret);
+	}
+
+	return ret;
 }
 
 static int counter_esp32_start(const struct device *dev)

--- a/drivers/counter/counter_esp32_tmr.c
+++ b/drivers/counter/counter_esp32_tmr.c
@@ -50,6 +50,7 @@ struct counter_esp32_config {
 	timer_group_t group;
 	timer_idx_t index;
 	int irq_source;
+	int irq_priority;
 };
 
 struct counter_esp32_data {
@@ -94,7 +95,11 @@ static int counter_esp32_init(const struct device *dev)
 	timer_ll_enable_alarm(data->hal_ctx.dev, data->hal_ctx.timer_id, cfg->config.alarm_en);
 	timer_ll_set_reload_value(data->hal_ctx.dev, data->hal_ctx.timer_id, 0);
 	timer_ll_enable_counter(data->hal_ctx.dev, data->hal_ctx.timer_id, cfg->config.counter_en);
-	esp_intr_alloc(cfg->irq_source, 0, (ISR_HANDLER)counter_esp32_isr, (void *)dev, NULL);
+
+	esp_intr_alloc(cfg->irq_source,
+			ESP_PRIO_TO_FLAGS(cfg->irq_priority),
+			(ISR_HANDLER)counter_esp32_isr, (void *)dev, NULL);
+
 	k_spin_unlock(&lock, key);
 
 	return 0;
@@ -254,7 +259,8 @@ static void counter_esp32_isr(void *arg)
 		},								 \
 		.group = DT_INST_PROP(idx, group),				 \
 		.index = DT_INST_PROP(idx, index),				 \
-		.irq_source = DT_INST_IRQN(idx),				 \
+		.irq_source = DT_INST_IRQ_BY_IDX(idx, 0, irq),			\
+		.irq_priority = DT_INST_IRQ_BY_IDX(idx, 0, priority)	\
 	};									 \
 										 \
 										 \

--- a/drivers/counter/counter_esp32_tmr.c
+++ b/drivers/counter/counter_esp32_tmr.c
@@ -51,6 +51,7 @@ struct counter_esp32_config {
 	timer_idx_t index;
 	int irq_source;
 	int irq_priority;
+	int irq_flags;
 };
 
 struct counter_esp32_data {
@@ -99,7 +100,8 @@ static int counter_esp32_init(const struct device *dev)
 	k_spin_unlock(&lock, key);
 
 	int ret = esp_intr_alloc(cfg->irq_source,
-				ESP_PRIO_TO_FLAGS(cfg->irq_priority),
+				ESP_PRIO_TO_FLAGS(cfg->irq_priority) |
+				ESP_INT_FLAGS_CHECK(cfg->irq_flags),
 				(ISR_HANDLER)counter_esp32_isr, (void *)dev, NULL);
 
 	if (ret != 0) {
@@ -264,7 +266,8 @@ static void counter_esp32_isr(void *arg)
 		.group = DT_INST_PROP(idx, group),				 \
 		.index = DT_INST_PROP(idx, index),				 \
 		.irq_source = DT_INST_IRQ_BY_IDX(idx, 0, irq),			\
-		.irq_priority = DT_INST_IRQ_BY_IDX(idx, 0, priority)	\
+		.irq_priority = DT_INST_IRQ_BY_IDX(idx, 0, priority),	\
+		.irq_flags = DT_INST_IRQ_BY_IDX(idx, 0, flags)	\
 	};									 \
 										 \
 										 \

--- a/drivers/ethernet/eth_esp32.c
+++ b/drivers/ethernet/eth_esp32.c
@@ -261,11 +261,12 @@ int eth_esp32_initialize(const struct device *dev)
 		      dev_data->dma_rx_buf, dev_data->dma_tx_buf);
 
 	/* Configure ISR */
-	res = esp_intr_alloc(DT_IRQN(DT_NODELABEL(eth)),
-		       ESP_INTR_FLAG_IRAM,
-		       eth_esp32_isr,
-		       (void *)dev,
-		       NULL);
+	res = esp_intr_alloc(DT_IRQ_BY_IDX(DT_NODELABEL(eth), 0, irq),
+			ESP_PRIO_TO_FLAGS(DT_IRQ_BY_IDX(DT_NODELABEL(eth), 0, priority)) |
+				ESP_INTR_FLAG_IRAM,
+			eth_esp32_isr,
+			(void *)dev,
+			NULL);
 	if (res != 0) {
 		goto err;
 	}

--- a/drivers/ethernet/eth_esp32.c
+++ b/drivers/ethernet/eth_esp32.c
@@ -263,6 +263,7 @@ int eth_esp32_initialize(const struct device *dev)
 	/* Configure ISR */
 	res = esp_intr_alloc(DT_IRQ_BY_IDX(DT_NODELABEL(eth), 0, irq),
 			ESP_PRIO_TO_FLAGS(DT_IRQ_BY_IDX(DT_NODELABEL(eth), 0, priority)) |
+			ESP_INT_FLAGS_CHECK(DT_IRQ_BY_IDX(DT_NODELABEL(eth), 0, flags)) |
 				ESP_INTR_FLAG_IRAM,
 			eth_esp32_isr,
 			(void *)dev,

--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -479,7 +479,8 @@ static int gpio_esp32_init(const struct device *dev)
 
 	if (!isr_connected) {
 		int ret = esp_intr_alloc(DT_IRQ_BY_IDX(DT_NODELABEL(gpio0), 0, irq),
-			ESP_PRIO_TO_FLAGS(DT_IRQ_BY_IDX(DT_NODELABEL(gpio0), 0, priority)),
+			ESP_PRIO_TO_FLAGS(DT_IRQ_BY_IDX(DT_NODELABEL(gpio0), 0, priority)) |
+			ESP_INT_FLAGS_CHECK(DT_IRQ_BY_IDX(DT_NODELABEL(gpio0), 0, flags)),
 			(ISR_HANDLER)gpio_esp32_isr,
 			(void *)dev,
 			NULL);

--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -478,11 +478,16 @@ static int gpio_esp32_init(const struct device *dev)
 	static bool isr_connected;
 
 	if (!isr_connected) {
-		esp_intr_alloc(DT_IRQ_BY_IDX(DT_NODELABEL(gpio0), 0, irq),
+		int ret = esp_intr_alloc(DT_IRQ_BY_IDX(DT_NODELABEL(gpio0), 0, irq),
 			ESP_PRIO_TO_FLAGS(DT_IRQ_BY_IDX(DT_NODELABEL(gpio0), 0, priority)),
 			(ISR_HANDLER)gpio_esp32_isr,
 			(void *)dev,
 			NULL);
+
+		if (ret != 0) {
+			LOG_ERR("could not allocate interrupt (err %d)", ret);
+			return ret;
+		}
 
 		isr_connected = true;
 	}

--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -478,8 +478,8 @@ static int gpio_esp32_init(const struct device *dev)
 	static bool isr_connected;
 
 	if (!isr_connected) {
-		esp_intr_alloc(DT_IRQN(DT_NODELABEL(gpio0)),
-			0,
+		esp_intr_alloc(DT_IRQ_BY_IDX(DT_NODELABEL(gpio0), 0, irq),
+			ESP_PRIO_TO_FLAGS(DT_IRQ_BY_IDX(DT_NODELABEL(gpio0), 0, priority)),
 			(ISR_HANDLER)gpio_esp32_isr,
 			(void *)dev,
 			NULL);

--- a/drivers/i2c/i2c_esp32.c
+++ b/drivers/i2c/i2c_esp32.c
@@ -90,6 +90,7 @@ struct i2c_esp32_config {
 	} mode;
 
 	int irq_source;
+	int irq_priority;
 
 	const uint32_t bitrate;
 	const uint32_t scl_timeout;
@@ -761,7 +762,11 @@ static int IRAM_ATTR i2c_esp32_init(const struct device *dev)
 
 	clock_control_on(config->clock_dev, config->clock_subsys);
 
-	esp_intr_alloc(config->irq_source, 0, i2c_esp32_isr, (void *)dev, NULL);
+	esp_intr_alloc(config->irq_source,
+			ESP_PRIO_TO_FLAGS(config->irq_priority) | ESP_INTR_FLAG_IRAM,
+			i2c_esp32_isr,
+			(void *)dev,
+			NULL);
 
 	i2c_hal_master_init(&data->hal);
 
@@ -822,7 +827,8 @@ static int IRAM_ATTR i2c_esp32_init(const struct device *dev)
 			.tx_lsb_first = DT_PROP(I2C(idx), tx_lsb),				   \
 			.rx_lsb_first = DT_PROP(I2C(idx), rx_lsb),				   \
 		},										   \
-		.irq_source = ETS_I2C_EXT##idx##_INTR_SOURCE,					   \
+		.irq_source = DT_INST_IRQ_BY_IDX(idx, 0, irq),				   \
+		.irq_priority = DT_INST_IRQ_BY_IDX(idx, 0, priority),		   \
 		.bitrate = I2C_FREQUENCY(idx),							   \
 		.scl_timeout = I2C_ESP32_TIMEOUT(idx),						   \
 	};											   \

--- a/drivers/i2c/i2c_esp32.c
+++ b/drivers/i2c/i2c_esp32.c
@@ -762,11 +762,16 @@ static int IRAM_ATTR i2c_esp32_init(const struct device *dev)
 
 	clock_control_on(config->clock_dev, config->clock_subsys);
 
-	esp_intr_alloc(config->irq_source,
+	ret = esp_intr_alloc(config->irq_source,
 			ESP_PRIO_TO_FLAGS(config->irq_priority) | ESP_INTR_FLAG_IRAM,
 			i2c_esp32_isr,
 			(void *)dev,
 			NULL);
+
+	if (ret != 0) {
+		LOG_ERR("could not allocate interrupt (err %d)", ret);
+		return ret;
+	}
 
 	i2c_hal_master_init(&data->hal);
 

--- a/drivers/i2c/i2c_esp32.c
+++ b/drivers/i2c/i2c_esp32.c
@@ -91,6 +91,7 @@ struct i2c_esp32_config {
 
 	int irq_source;
 	int irq_priority;
+	int irq_flags;
 
 	const uint32_t bitrate;
 	const uint32_t scl_timeout;
@@ -763,7 +764,8 @@ static int IRAM_ATTR i2c_esp32_init(const struct device *dev)
 	clock_control_on(config->clock_dev, config->clock_subsys);
 
 	ret = esp_intr_alloc(config->irq_source,
-			ESP_PRIO_TO_FLAGS(config->irq_priority) | ESP_INTR_FLAG_IRAM,
+			ESP_PRIO_TO_FLAGS(config->irq_priority) |
+			ESP_INT_FLAGS_CHECK(config->irq_flags) | ESP_INTR_FLAG_IRAM,
 			i2c_esp32_isr,
 			(void *)dev,
 			NULL);
@@ -834,6 +836,7 @@ static int IRAM_ATTR i2c_esp32_init(const struct device *dev)
 		},										   \
 		.irq_source = DT_INST_IRQ_BY_IDX(idx, 0, irq),				   \
 		.irq_priority = DT_INST_IRQ_BY_IDX(idx, 0, priority),		   \
+		.irq_flags = DT_INST_IRQ_BY_IDX(idx, 0, flags),				   \
 		.bitrate = I2C_FREQUENCY(idx),							   \
 		.scl_timeout = I2C_ESP32_TIMEOUT(idx),						   \
 	};											   \

--- a/drivers/input/input_esp32_touch_sensor.c
+++ b/drivers/input/input_esp32_touch_sensor.c
@@ -162,7 +162,10 @@ static esp_err_t esp32_rtc_isr_install(intr_handler_t intr_handler, const void *
 
 	REG_WRITE(RTC_CNTL_INT_ENA_REG, 0);
 	REG_WRITE(RTC_CNTL_INT_CLR_REG, UINT32_MAX);
-	err = esp_intr_alloc(ETS_RTC_CORE_INTR_SOURCE, 0, intr_handler, (void *)handler_arg, NULL);
+
+	err = esp_intr_alloc(DT_IRQ_BY_IDX(DT_NODELABEL(touch), 0, irq),
+				ESP_PRIO_TO_FLAGS(DT_IRQ_BY_IDX(DT_NODELABEL(touch), 0, priority)),
+				intr_handler, (void *)handler_arg, NULL);
 
 	return err;
 }

--- a/drivers/input/input_esp32_touch_sensor.c
+++ b/drivers/input/input_esp32_touch_sensor.c
@@ -164,8 +164,9 @@ static esp_err_t esp32_rtc_isr_install(intr_handler_t intr_handler, const void *
 	REG_WRITE(RTC_CNTL_INT_CLR_REG, UINT32_MAX);
 
 	err = esp_intr_alloc(DT_IRQ_BY_IDX(DT_NODELABEL(touch), 0, irq),
-				ESP_PRIO_TO_FLAGS(DT_IRQ_BY_IDX(DT_NODELABEL(touch), 0, priority)),
-				intr_handler, (void *)handler_arg, NULL);
+			ESP_PRIO_TO_FLAGS(DT_IRQ_BY_IDX(DT_NODELABEL(touch), 0, priority)) |
+			ESP_INT_FLAGS_CHECK(DT_IRQ_BY_IDX(DT_NODELABEL(touch), 0, flags)),
+			intr_handler, (void *)handler_arg, NULL);
 
 	return err;
 }

--- a/drivers/ipm/ipm_esp32.c
+++ b/drivers/ipm/ipm_esp32.c
@@ -35,8 +35,10 @@ struct esp32_ipm_memory {
 struct esp32_ipm_config {
 	int irq_source_pro_cpu;
 	int irq_priority_pro_cpu;
+	int irq_flags_pro_cpu;
 	int irq_source_app_cpu;
 	int irq_priority_app_cpu;
+	int irq_flags_app_cpu;
 };
 
 struct esp32_ipm_data {
@@ -222,6 +224,7 @@ static int esp32_ipm_init(const struct device *dev)
 	if (data->this_core_id == 0) {
 		ret = esp_intr_alloc(cfg->irq_source_pro_cpu,
 				ESP_PRIO_TO_FLAGS(cfg->irq_priority_pro_cpu) |
+				ESP_INT_FLAGS_CHECK(cfg->irq_flags_pro_cpu) |
 					ESP_INTR_FLAG_IRAM,
 				(intr_handler_t)esp32_ipm_isr,
 				(void *)dev,
@@ -239,6 +242,7 @@ static int esp32_ipm_init(const struct device *dev)
 		 */
 		ret = esp_intr_alloc(cfg->irq_source_app_cpu,
 				ESP_PRIO_TO_FLAGS(cfg->irq_priority_app_cpu) |
+				ESP_INT_FLAGS_CHECK(cfg->irq_flags_app_cpu) |
 					ESP_INTR_FLAG_IRAM,
 				(intr_handler_t)esp32_ipm_isr,
 				(void *)dev,
@@ -283,8 +287,10 @@ static const struct ipm_driver_api esp32_ipm_driver_api = {
 static struct esp32_ipm_config esp32_ipm_device_cfg_##idx = {		\
 	.irq_source_pro_cpu = DT_INST_IRQ_BY_IDX(idx, 0, irq),			\
 	.irq_priority_pro_cpu = DT_INST_IRQ_BY_IDX(idx, 0, priority),	\
+	.irq_flags_pro_cpu = DT_INST_IRQ_BY_IDX(idx, 0, flags),			\
 	.irq_source_app_cpu = DT_INST_IRQ_BY_IDX(idx, 1, irq),			\
 	.irq_priority_app_cpu = DT_INST_IRQ_BY_IDX(idx, 1, priority),	\
+	.irq_flags_app_cpu = DT_INST_IRQ_BY_IDX(idx, 1, flags),			\
 };	\
 	\
 static struct esp32_ipm_data esp32_ipm_device_data_##idx = {	\

--- a/drivers/ipm/ipm_esp32.c
+++ b/drivers/ipm/ipm_esp32.c
@@ -208,6 +208,7 @@ static int esp32_ipm_init(const struct device *dev)
 {
 	struct esp32_ipm_data *data = (struct esp32_ipm_data *)dev->data;
 	struct esp32_ipm_config *cfg = (struct esp32_ipm_config *)dev->config;
+	int ret;
 
 	data->this_core_id = esp_core_id();
 	data->other_core_id = (data->this_core_id  == 0) ? 1 : 0;
@@ -219,22 +220,34 @@ static int esp32_ipm_init(const struct device *dev)
 
 	/* pro_cpu is responsible to initialize the lock of shared memory */
 	if (data->this_core_id == 0) {
-		esp_intr_alloc(cfg->irq_source_pro_cpu,
-			ESP_PRIO_TO_FLAGS(cfg->irq_priority_pro_cpu) | ESP_INTR_FLAG_IRAM,
-			(intr_handler_t)esp32_ipm_isr,
-			(void *)dev,
-			NULL);
+		ret = esp_intr_alloc(cfg->irq_source_pro_cpu,
+				ESP_PRIO_TO_FLAGS(cfg->irq_priority_pro_cpu) |
+					ESP_INTR_FLAG_IRAM,
+				(intr_handler_t)esp32_ipm_isr,
+				(void *)dev,
+				NULL);
+
+		if (ret != 0) {
+			LOG_ERR("could not allocate interrupt (err %d)", ret);
+			return ret;
+		}
 
 		atomic_set(&data->control->lock, ESP32_IPM_LOCK_FREE_VAL);
 	} else {
 		/* app_cpu wait for initialization from pro_cpu, then takes it,
 		 * after that releases
 		 */
-		esp_intr_alloc(cfg->irq_source_app_cpu,
-			ESP_PRIO_TO_FLAGS(cfg->irq_priority_app_cpu) | ESP_INTR_FLAG_IRAM,
-			(intr_handler_t)esp32_ipm_isr,
-			(void *)dev,
-			NULL);
+		ret = esp_intr_alloc(cfg->irq_source_app_cpu,
+				ESP_PRIO_TO_FLAGS(cfg->irq_priority_app_cpu) |
+					ESP_INTR_FLAG_IRAM,
+				(intr_handler_t)esp32_ipm_isr,
+				(void *)dev,
+				NULL);
+
+		if (ret != 0) {
+			LOG_ERR("could not allocate interrupt (err %d)", ret);
+			return ret;
+		}
 
 		LOG_DBG("Waiting CPU0 to sync");
 		while (!atomic_cas(&data->control->lock,

--- a/drivers/ipm/ipm_esp32.c
+++ b/drivers/ipm/ipm_esp32.c
@@ -33,8 +33,10 @@ struct esp32_ipm_memory {
 };
 
 struct esp32_ipm_config {
-	uint32_t irq_source_pro_cpu;
-	uint32_t irq_source_app_cpu;
+	int irq_source_pro_cpu;
+	int irq_priority_pro_cpu;
+	int irq_source_app_cpu;
+	int irq_priority_app_cpu;
 };
 
 struct esp32_ipm_data {
@@ -218,7 +220,7 @@ static int esp32_ipm_init(const struct device *dev)
 	/* pro_cpu is responsible to initialize the lock of shared memory */
 	if (data->this_core_id == 0) {
 		esp_intr_alloc(cfg->irq_source_pro_cpu,
-			ESP_INTR_FLAG_IRAM,
+			ESP_PRIO_TO_FLAGS(cfg->irq_priority_pro_cpu) | ESP_INTR_FLAG_IRAM,
 			(intr_handler_t)esp32_ipm_isr,
 			(void *)dev,
 			NULL);
@@ -229,7 +231,7 @@ static int esp32_ipm_init(const struct device *dev)
 		 * after that releases
 		 */
 		esp_intr_alloc(cfg->irq_source_app_cpu,
-			ESP_INTR_FLAG_IRAM,
+			ESP_PRIO_TO_FLAGS(cfg->irq_priority_app_cpu) | ESP_INTR_FLAG_IRAM,
 			(intr_handler_t)esp32_ipm_isr,
 			(void *)dev,
 			NULL);
@@ -265,9 +267,11 @@ static const struct ipm_driver_api esp32_ipm_driver_api = {
 
 #define ESP32_IPM_INIT(idx)			\
 										\
-static struct esp32_ipm_config esp32_ipm_device_cfg_##idx = {	\
-	.irq_source_pro_cpu = DT_INST_IRQN(idx),		\
-	.irq_source_app_cpu = DT_INST_IRQN(idx) + 1,	\
+static struct esp32_ipm_config esp32_ipm_device_cfg_##idx = {		\
+	.irq_source_pro_cpu = DT_INST_IRQ_BY_IDX(idx, 0, irq),			\
+	.irq_priority_pro_cpu = DT_INST_IRQ_BY_IDX(idx, 0, priority),	\
+	.irq_source_app_cpu = DT_INST_IRQ_BY_IDX(idx, 1, irq),			\
+	.irq_priority_app_cpu = DT_INST_IRQ_BY_IDX(idx, 1, priority),	\
 };	\
 	\
 static struct esp32_ipm_data esp32_ipm_device_data_##idx = {	\

--- a/drivers/pwm/pwm_mc_esp32.c
+++ b/drivers/pwm/pwm_mc_esp32.c
@@ -540,7 +540,8 @@ static const struct pwm_driver_api mcpwm_esp32_api = {
 		int ret;                                                                   \
 		ret = esp_intr_alloc(DT_INST_IRQ_BY_IDX(idx, 0, irq),                      \
 				ESP_PRIO_TO_FLAGS(DT_INST_IRQ_BY_IDX(idx, 0, priority)) |          \
-					ESP_INTR_FLAG_IRAM,                                            \
+				ESP_INT_FLAGS_CHECK(DT_INST_IRQ_BY_IDX(idx, 0, flags)) |          \
+					ESP_INTR_FLAG_IRAM,                                        \
 				(intr_handler_t)mcpwm_esp32_isr, (void *)dev, NULL);               \
 		return ret;                                                                \
 	}

--- a/drivers/pwm/pwm_mc_esp32.c
+++ b/drivers/pwm/pwm_mc_esp32.c
@@ -533,8 +533,10 @@ static const struct pwm_driver_api mcpwm_esp32_api = {
 #define IRQ_CONFIG_FUNC(idx)                                                                       \
 	static void mcpwm_esp32_irq_config_func_##idx(const struct device *dev)                    \
 	{                                                                                          \
-		esp_intr_alloc(DT_INST_IRQN(idx), 0, (intr_handler_t)mcpwm_esp32_isr, (void *)dev, \
-			       NULL);                                                              \
+		esp_intr_alloc(DT_INST_IRQ_BY_IDX(idx, 0, irq),                            \
+				ESP_PRIO_TO_FLAGS(DT_INST_IRQ_BY_IDX(idx, 0, priority)) |          \
+					ESP_INTR_FLAG_IRAM,                                            \
+				(intr_handler_t)mcpwm_esp32_isr, (void *)dev, NULL);               \
 	}
 #define CAPTURE_INIT(idx) .irq_config_func = mcpwm_esp32_irq_config_func_##idx
 #else

--- a/drivers/sdhc/sdhc_esp32.c
+++ b/drivers/sdhc/sdhc_esp32.c
@@ -69,6 +69,7 @@ struct sdhc_esp32_config {
 
 	int irq_source;
 	int irq_priority;
+	int irq_flags;
 	uint8_t bus_width_cfg;
 
 	struct sdhc_host_props props;
@@ -1341,7 +1342,8 @@ static int sdhc_esp32_init(const struct device *dev)
 
 	/* Attach interrupt handler */
 	ret = esp_intr_alloc(cfg->irq_source,
-				ESP_PRIO_TO_FLAGS(cfg->irq_priority) | ESP_INTR_FLAG_IRAM,
+				ESP_PRIO_TO_FLAGS(cfg->irq_priority) |
+				ESP_INT_FLAGS_CHECK(cfg->irq_flags) | ESP_INTR_FLAG_IRAM,
 				&sdio_esp32_isr, (void *)dev,
 				&data->s_host_ctx.intr_handle);
 
@@ -1412,6 +1414,7 @@ static const struct sdhc_driver_api sdhc_api = {.reset = sdhc_esp32_reset,
 		.clock_subsys = (clock_control_subsys_t)DT_CLOCKS_CELL(DT_INST_PARENT(n), offset), \
 		.irq_source = DT_IRQ_BY_IDX(DT_INST_PARENT(n), 0, irq),                            \
 		.irq_priority = DT_IRQ_BY_IDX(DT_INST_PARENT(n), 0, priority),                     \
+		.irq_flags = DT_IRQ_BY_IDX(DT_INST_PARENT(n), 0, flags),                           \
 		.slot = DT_REG_ADDR(DT_DRV_INST(n)),                                               \
 		.bus_width_cfg = DT_INST_PROP(n, bus_width),                                       \
 		.pcfg = PINCTRL_DT_DEV_CONFIG_GET(DT_DRV_INST(n)),                                 \

--- a/drivers/sensor/espressif/pcnt_esp32/pcnt_esp32.c
+++ b/drivers/sensor/espressif/pcnt_esp32/pcnt_esp32.c
@@ -73,6 +73,7 @@ struct pcnt_esp32_config {
 	const clock_control_subsys_t clock_subsys;
 	const int irq_source;
 	const int irq_priority;
+	const int irq_flags;
 	struct pcnt_esp32_unit_config *unit_config;
 	const int unit_len;
 };
@@ -342,7 +343,8 @@ static int pcnt_esp32_trigger_set(const struct device *dev, const struct sensor_
 	data->trigger = trig;
 
 	ret = esp_intr_alloc(config->irq_source,
-			ESP_PRIO_TO_FLAGS(config->irq_priority) | ESP_INTR_FLAG_IRAM,
+			ESP_PRIO_TO_FLAGS(config->irq_priority) |
+			ESP_INT_FLAGS_CHECK(config->irq_flags) | ESP_INTR_FLAG_IRAM,
 			(intr_handler_t)pcnt_esp32_isr, (void *)dev, NULL);
 
 	if (ret != 0) {
@@ -405,6 +407,7 @@ static struct pcnt_esp32_config pcnt_esp32_config = {
 	.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(0, offset),
 	.irq_source = DT_INST_IRQ_BY_IDX(0, 0, irq),
 	.irq_priority = DT_INST_IRQ_BY_IDX(0, 0, priority),
+	.irq_flags = DT_INST_IRQ_BY_IDX(0, 0, flags),
 	.unit_config = unit_config,
 	.unit_len = ARRAY_SIZE(unit_config),
 };

--- a/drivers/serial/serial_esp32_usb.c
+++ b/drivers/serial/serial_esp32_usb.c
@@ -44,6 +44,7 @@ struct serial_esp32_usb_config {
 	const clock_control_subsys_t clock_subsys;
 	int irq_source;
 	int irq_priority;
+	int irq_flags;
 };
 
 struct serial_esp32_usb_data {
@@ -113,7 +114,8 @@ static int serial_esp32_usb_init(const struct device *dev)
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	ret = esp_intr_alloc(config->irq_source,
-			ESP_PRIO_TO_FLAGS(config->irq_priority),
+			ESP_PRIO_TO_FLAGS(config->irq_priority) |
+			ESP_INT_FLAGS_CHECK(config->irq_flags),
 			(ISR_HANDLER)serial_esp32_usb_isr,
 			(void *)dev, NULL);
 #endif
@@ -276,7 +278,8 @@ static const DRAM_ATTR struct serial_esp32_usb_config serial_esp32_usb_cfg = {
 	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(0)),
 	.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(0, offset),
 	.irq_source = DT_INST_IRQ_BY_IDX(0, 0, irq),
-	.irq_priority = DT_INST_IRQ_BY_IDX(0, 0, priority)
+	.irq_priority = DT_INST_IRQ_BY_IDX(0, 0, priority),
+	.irq_flags = DT_INST_IRQ_BY_IDX(0, 0, flags)
 };
 
 static struct serial_esp32_usb_data serial_esp32_usb_data_0;

--- a/drivers/serial/serial_esp32_usb.c
+++ b/drivers/serial/serial_esp32_usb.c
@@ -107,8 +107,12 @@ static int serial_esp32_usb_init(const struct device *dev)
 
 	int ret = clock_control_on(config->clock_dev, config->clock_subsys);
 
+	if (ret != 0) {
+		return ret;
+	}
+
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	esp_intr_alloc(config->irq_source,
+	ret = esp_intr_alloc(config->irq_source,
 			ESP_PRIO_TO_FLAGS(config->irq_priority),
 			(ISR_HANDLER)serial_esp32_usb_isr,
 			(void *)dev, NULL);

--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -81,6 +81,7 @@ struct uart_esp32_config {
 	const clock_control_subsys_t clock_subsys;
 	int irq_source;
 	int irq_priority;
+	int irq_flags;
 	bool tx_invert;
 	bool rx_invert;
 #if CONFIG_UART_ASYNC_API
@@ -937,7 +938,8 @@ static int uart_esp32_init(const struct device *dev)
 
 #if CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_UART_ASYNC_API
 	ret = esp_intr_alloc(config->irq_source,
-			ESP_PRIO_TO_FLAGS(config->irq_priority),
+			ESP_PRIO_TO_FLAGS(config->irq_priority) |
+			ESP_INT_FLAGS_CHECK(config->irq_flags),
 			(ISR_HANDLER)uart_esp32_isr,
 			(void *)dev,
 			NULL);
@@ -1024,6 +1026,7 @@ static const DRAM_ATTR struct uart_driver_api uart_esp32_api = {
 		.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(idx, offset),          \
 		.irq_source = DT_INST_IRQ_BY_IDX(idx, 0, irq),                                     \
 		.irq_priority = DT_INST_IRQ_BY_IDX(idx, 0, priority),                              \
+		.irq_flags = DT_INST_IRQ_BY_IDX(idx, 0, flags),                                    \
 		.tx_invert = DT_INST_PROP_OR(idx, tx_invert, false),                               \
 		.rx_invert = DT_INST_PROP_OR(idx, rx_invert, false),                               \
 		ESP_UART_DMA_INIT(idx)};                                                           \

--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -937,7 +937,7 @@ static int uart_esp32_init(const struct device *dev)
 
 #if CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_UART_ASYNC_API
 	ret = esp_intr_alloc(config->irq_source,
-			config->irq_priority,
+			ESP_PRIO_TO_FLAGS(config->irq_priority),
 			(ISR_HANDLER)uart_esp32_isr,
 			(void *)dev,
 			NULL);
@@ -1009,12 +1009,9 @@ static const DRAM_ATTR struct uart_driver_api uart_esp32_api = {
 #define ESP_UART_UHCI_INIT(n)                                                                      \
 	.uhci_dev = COND_CODE_1(DT_INST_NODE_HAS_PROP(n, dmas), (&UHCI0), (NULL))
 
-#define UART_IRQ_PRIORITY ESP_INTR_FLAG_LEVEL2
-
 #else
 #define ESP_UART_DMA_INIT(n)
 #define ESP_UART_UHCI_INIT(n)
-#define UART_IRQ_PRIORITY (0)
 #endif
 
 #define ESP32_UART_INIT(idx)                                                                       \
@@ -1025,8 +1022,8 @@ static const DRAM_ATTR struct uart_driver_api uart_esp32_api = {
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(idx)),                              \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(idx),                                       \
 		.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(idx, offset),          \
-		.irq_source = DT_INST_IRQN(idx),                                                   \
-		.irq_priority = UART_IRQ_PRIORITY,                                                 \
+		.irq_source = DT_INST_IRQ_BY_IDX(idx, 0, irq),                                     \
+		.irq_priority = DT_INST_IRQ_BY_IDX(idx, 0, priority),                              \
 		.tx_invert = DT_INST_PROP_OR(idx, tx_invert, false),                               \
 		.rx_invert = DT_INST_PROP_OR(idx, rx_invert, false),                               \
 		ESP_UART_DMA_INIT(idx)};                                                           \

--- a/drivers/spi/spi_esp32_spim.c
+++ b/drivers/spi/spi_esp32_spim.c
@@ -245,7 +245,7 @@ static int spi_esp32_init(const struct device *dev)
 	spi_ll_clear_int_stat(cfg->spi);
 
 	esp_intr_alloc(cfg->irq_source,
-			0,
+			ESP_PRIO_TO_FLAGS(cfg->irq_priority) | ESP_INTR_FLAG_IRAM,
 			(ISR_HANDLER)spi_esp32_isr,
 			(void *)dev,
 			NULL);
@@ -525,7 +525,8 @@ static const struct spi_driver_api spi_api = {
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(idx)),	\
 		.duty_cycle = 0, \
 		.input_delay_ns = 0, \
-		.irq_source = DT_INST_IRQN(idx), \
+		.irq_source = DT_INST_IRQ_BY_IDX(idx, 0, irq), \
+		.irq_priority = DT_INST_IRQ_BY_IDX(idx, 0, priority), \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(idx),	\
 		.clock_subsys =	\
 			(clock_control_subsys_t)DT_INST_CLOCKS_CELL(idx, offset),	\

--- a/drivers/spi/spi_esp32_spim.c
+++ b/drivers/spi/spi_esp32_spim.c
@@ -245,7 +245,8 @@ static int spi_esp32_init(const struct device *dev)
 	spi_ll_clear_int_stat(cfg->spi);
 
 	err = esp_intr_alloc(cfg->irq_source,
-			ESP_PRIO_TO_FLAGS(cfg->irq_priority) | ESP_INTR_FLAG_IRAM,
+			ESP_PRIO_TO_FLAGS(cfg->irq_priority) |
+			ESP_INT_FLAGS_CHECK(cfg->irq_flags) | ESP_INTR_FLAG_IRAM,
 			(ISR_HANDLER)spi_esp32_isr,
 			(void *)dev,
 			NULL);
@@ -532,6 +533,7 @@ static const struct spi_driver_api spi_api = {
 		.input_delay_ns = 0, \
 		.irq_source = DT_INST_IRQ_BY_IDX(idx, 0, irq), \
 		.irq_priority = DT_INST_IRQ_BY_IDX(idx, 0, priority), \
+		.irq_flags = DT_INST_IRQ_BY_IDX(idx, 0, flags), \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(idx),	\
 		.clock_subsys =	\
 			(clock_control_subsys_t)DT_INST_CLOCKS_CELL(idx, offset),	\

--- a/drivers/spi/spi_esp32_spim.c
+++ b/drivers/spi/spi_esp32_spim.c
@@ -244,11 +244,16 @@ static int spi_esp32_init(const struct device *dev)
 	spi_ll_disable_int(cfg->spi);
 	spi_ll_clear_int_stat(cfg->spi);
 
-	esp_intr_alloc(cfg->irq_source,
+	err = esp_intr_alloc(cfg->irq_source,
 			ESP_PRIO_TO_FLAGS(cfg->irq_priority) | ESP_INTR_FLAG_IRAM,
 			(ISR_HANDLER)spi_esp32_isr,
 			(void *)dev,
 			NULL);
+
+	if (err != 0) {
+		LOG_ERR("could not allocate interrupt (err %d)", err);
+		return err;
+	}
 #endif
 
 	err = spi_context_cs_configure_all(&data->ctx);

--- a/drivers/spi/spi_esp32_spim.h
+++ b/drivers/spi/spi_esp32_spim.h
@@ -30,6 +30,7 @@ struct spi_esp32_config {
 	int duty_cycle;
 	int input_delay_ns;
 	int irq_source;
+	int irq_priority;
 	const struct pinctrl_dev_config *pcfg;
 	clock_control_subsys_t clock_subsys;
 	bool use_iomux;

--- a/drivers/spi/spi_esp32_spim.h
+++ b/drivers/spi/spi_esp32_spim.h
@@ -31,6 +31,7 @@ struct spi_esp32_config {
 	int input_delay_ns;
 	int irq_source;
 	int irq_priority;
+	int irq_flags;
 	const struct pinctrl_dev_config *pcfg;
 	clock_control_subsys_t clock_subsys;
 	bool use_iomux;

--- a/drivers/timer/esp32_sys_timer.c
+++ b/drivers/timer/esp32_sys_timer.c
@@ -143,9 +143,8 @@ void sys_clock_disable(void)
 
 static int sys_clock_driver_init(void)
 {
-
-	esp_intr_alloc(DT_IRQN(DT_NODELABEL(systimer0)),
-		0,
+	esp_intr_alloc(DT_IRQ_BY_IDX(DT_NODELABEL(systimer0), 0, irq),
+		ESP_PRIO_TO_FLAGS(DT_IRQ_BY_IDX(DT_NODELABEL(systimer0), 0, priority)),
 		sys_timer_isr,
 		NULL,
 		NULL);

--- a/drivers/timer/esp32_sys_timer.c
+++ b/drivers/timer/esp32_sys_timer.c
@@ -143,11 +143,17 @@ void sys_clock_disable(void)
 
 static int sys_clock_driver_init(void)
 {
-	esp_intr_alloc(DT_IRQ_BY_IDX(DT_NODELABEL(systimer0), 0, irq),
+	int ret;
+
+	ret = esp_intr_alloc(DT_IRQ_BY_IDX(DT_NODELABEL(systimer0), 0, irq),
 		ESP_PRIO_TO_FLAGS(DT_IRQ_BY_IDX(DT_NODELABEL(systimer0), 0, priority)),
 		sys_timer_isr,
 		NULL,
 		NULL);
+
+	if (ret != 0) {
+		return ret;
+	}
 
 	systimer_hal_init(&systimer_hal);
 	systimer_hal_connect_alarm_counter(&systimer_hal,

--- a/drivers/timer/esp32_sys_timer.c
+++ b/drivers/timer/esp32_sys_timer.c
@@ -146,7 +146,8 @@ static int sys_clock_driver_init(void)
 	int ret;
 
 	ret = esp_intr_alloc(DT_IRQ_BY_IDX(DT_NODELABEL(systimer0), 0, irq),
-		ESP_PRIO_TO_FLAGS(DT_IRQ_BY_IDX(DT_NODELABEL(systimer0), 0, priority)),
+		ESP_PRIO_TO_FLAGS(DT_IRQ_BY_IDX(DT_NODELABEL(systimer0), 0, priority)) |
+		ESP_INT_FLAGS_CHECK(DT_IRQ_BY_IDX(DT_NODELABEL(systimer0), 0, flags)),
 		sys_timer_isr,
 		NULL,
 		NULL);

--- a/drivers/watchdog/wdt_esp32.c
+++ b/drivers/watchdog/wdt_esp32.c
@@ -167,11 +167,16 @@ static int wdt_esp32_init(const struct device *dev)
 
 	wdt_hal_init(&data->hal, config->wdt_inst, MWDT_TICK_PRESCALER, true);
 
-	esp_intr_alloc(config->irq_source,
-		ESP_PRIO_TO_FLAGS(cfg->irq_priority),
-		(ISR_HANDLER)wdt_esp32_isr,
-		(void *)dev,
-		NULL);
+	int ret = esp_intr_alloc(config->irq_source,
+				ESP_PRIO_TO_FLAGS(config->irq_priority),
+				(ISR_HANDLER)wdt_esp32_isr,
+				(void *)dev,
+				NULL);
+
+	if (ret != 0) {
+		LOG_ERR("could not allocate interrupt (err %d)", ret);
+		return ret;
+	}
 
 #ifndef CONFIG_WDT_DISABLE_AT_BOOT
 	wdt_esp32_enable(dev);

--- a/drivers/watchdog/wdt_esp32.c
+++ b/drivers/watchdog/wdt_esp32.c
@@ -52,6 +52,7 @@ struct wdt_esp32_config {
 	void (*connect_irq)(void);
 	int irq_source;
 	int irq_priority;
+	int irq_flags;
 };
 
 static inline void wdt_esp32_seal(const struct device *dev)
@@ -168,7 +169,8 @@ static int wdt_esp32_init(const struct device *dev)
 	wdt_hal_init(&data->hal, config->wdt_inst, MWDT_TICK_PRESCALER, true);
 
 	int ret = esp_intr_alloc(config->irq_source,
-				ESP_PRIO_TO_FLAGS(config->irq_priority),
+				ESP_PRIO_TO_FLAGS(config->irq_priority) |
+				ESP_INT_FLAGS_CHECK(config->irq_flags),
 				(ISR_HANDLER)wdt_esp32_isr,
 				(void *)dev,
 				NULL);
@@ -198,6 +200,7 @@ static const struct wdt_driver_api wdt_api = {
 		.wdt_inst = WDT_MWDT##idx,	\
 		.irq_source = DT_IRQ_BY_IDX(DT_NODELABEL(wdt##idx), 0, irq),	\
 		.irq_priority = DT_IRQ_BY_IDX(DT_NODELABEL(wdt##idx), 0, priority),	\
+		.irq_flags = DT_IRQ_BY_IDX(DT_NODELABEL(wdt##idx), 0, flags),	\
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(idx)), \
 		.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(idx, offset), \
 	};									   \

--- a/drivers/watchdog/wdt_esp32.c
+++ b/drivers/watchdog/wdt_esp32.c
@@ -51,6 +51,7 @@ struct wdt_esp32_config {
 	const clock_control_subsys_t clock_subsys;
 	void (*connect_irq)(void);
 	int irq_source;
+	int irq_priority;
 };
 
 static inline void wdt_esp32_seal(const struct device *dev)
@@ -167,7 +168,7 @@ static int wdt_esp32_init(const struct device *dev)
 	wdt_hal_init(&data->hal, config->wdt_inst, MWDT_TICK_PRESCALER, true);
 
 	esp_intr_alloc(config->irq_source,
-		0,
+		ESP_PRIO_TO_FLAGS(cfg->irq_priority),
 		(ISR_HANDLER)wdt_esp32_isr,
 		(void *)dev,
 		NULL);
@@ -190,7 +191,8 @@ static const struct wdt_driver_api wdt_api = {
 	static struct wdt_esp32_data wdt##idx##_data;				   \
 	static struct wdt_esp32_config wdt_esp32_config##idx = {		   \
 		.wdt_inst = WDT_MWDT##idx,	\
-		.irq_source = DT_IRQN(DT_NODELABEL(wdt##idx)),			   \
+		.irq_source = DT_IRQ_BY_IDX(DT_NODELABEL(wdt##idx), 0, irq),	\
+		.irq_priority = DT_IRQ_BY_IDX(DT_NODELABEL(wdt##idx), 0, priority),	\
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(idx)), \
 		.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(idx, offset), \
 	};									   \

--- a/drivers/watchdog/xt_wdt_esp32.c
+++ b/drivers/watchdog/xt_wdt_esp32.c
@@ -43,6 +43,7 @@ struct esp32_xt_wdt_config {
 	const clock_control_subsys_t clock_subsys;
 	int irq_source;
 	int irq_priority;
+	int irq_flags;
 };
 
 static int esp32_xt_wdt_setup(const struct device *dev, uint8_t options)
@@ -128,7 +129,8 @@ static int esp32_xt_wdt_init(const struct device *dev)
 						ESP32_RTC_SLOW_CLK_SRC_RC_SLOW_FREQ/1000);
 
 	int err = esp_intr_alloc(cfg->irq_source,
-				ESP_PRIO_TO_FLAGS(cfg->irq_priority),
+				ESP_PRIO_TO_FLAGS(cfg->irq_priority) |
+				ESP_INT_FLAGS_CHECK(cfg->irq_flags),
 				(ISR_HANDLER)esp32_xt_wdt_isr, (void *)dev, NULL);
 
 	if (err) {
@@ -155,7 +157,8 @@ static struct esp32_xt_wdt_config esp32_xt_wdt_config0 = {
 	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(0)),
 	.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(0, offset),
 	.irq_source = DT_INST_IRQ_BY_IDX(0, 0, irq),
-	.irq_priority = DT_INST_IRQ_BY_IDX(0, 0, priority)
+	.irq_priority = DT_INST_IRQ_BY_IDX(0, 0, priority),
+	.irq_flags = DT_INST_IRQ_BY_IDX(0, 0, flags)
 };
 
 DEVICE_DT_DEFINE(DT_NODELABEL(xt_wdt),

--- a/drivers/watchdog/xt_wdt_esp32.c
+++ b/drivers/watchdog/xt_wdt_esp32.c
@@ -42,6 +42,7 @@ struct esp32_xt_wdt_config {
 	const struct device *clock_dev;
 	const clock_control_subsys_t clock_subsys;
 	int irq_source;
+	int irq_priority;
 };
 
 static int esp32_xt_wdt_setup(const struct device *dev, uint8_t options)
@@ -126,8 +127,10 @@ static int esp32_xt_wdt_init(const struct device *dev)
 	xt_wdt_hal_enable_backup_clk(&data->hal,
 						ESP32_RTC_SLOW_CLK_SRC_RC_SLOW_FREQ/1000);
 
-	int err = esp_intr_alloc(cfg->irq_source, 0, (ISR_HANDLER)esp32_xt_wdt_isr, (void *)dev,
-				 NULL);
+	int err = esp_intr_alloc(cfg->irq_source,
+				ESP_PRIO_TO_FLAGS(cfg->irq_priority),
+				(ISR_HANDLER)esp32_xt_wdt_isr, (void *)dev, NULL);
+
 	if (err) {
 		LOG_ERR("Failed to register ISR\n");
 		return -EFAULT;
@@ -151,7 +154,8 @@ static struct esp32_xt_wdt_data esp32_xt_wdt_data0;
 static struct esp32_xt_wdt_config esp32_xt_wdt_config0 = {
 	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(0)),
 	.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(0, offset),
-	.irq_source = DT_INST_IRQN(0),
+	.irq_source = DT_INST_IRQ_BY_IDX(0, 0, irq),
+	.irq_priority = DT_INST_IRQ_BY_IDX(0, 0, priority)
 };
 
 DEVICE_DT_DEFINE(DT_NODELABEL(xt_wdt),

--- a/dts/bindings/interrupt-controller/espressif,esp32-intc.yaml
+++ b/dts/bindings/interrupt-controller/espressif,esp32-intc.yaml
@@ -10,5 +10,10 @@ properties:
   reg:
     required: true
 
+  "#interrupt-cells":
+    const: 3
+
 interrupt-cells:
   - irq
+  - priority
+  - flags

--- a/dts/riscv/espressif/esp32c2/esp32c2_common.dtsi
+++ b/dts/riscv/espressif/esp32c2/esp32c2_common.dtsi
@@ -59,7 +59,7 @@
 		intc: interrupt-controller@600c2000 {
 			compatible = "espressif,esp32-intc";
 			#address-cells = <0>;
-			#interrupt-cells = <1>;
+			#interrupt-cells = <3>;
 			interrupt-controller;
 			reg = <0x600c2000 0x198>;
 			status = "okay";
@@ -68,7 +68,7 @@
 		systimer0: systimer@60023000 {
 			compatible = "espressif,esp32-systimer";
 			reg = <0x60023000 0x80>;
-			interrupts = <SYSTIMER_TARGET0_EDGE_INTR_SOURCE>;
+			interrupts = <SYSTIMER_TARGET0_EDGE_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "okay";
 		};
@@ -86,7 +86,7 @@
 			reg = <0x60008004 0xC>;
 			compatible = "espressif,esp32-rtc-timer";
 			clocks = <&rtc ESP32_MODULE_MAX>;
-			interrupts = <RTC_CORE_INTR_SOURCE>;
+			interrupts = <RTC_CORE_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
 		};
@@ -111,7 +111,7 @@
 			gpio-controller;
 			#gpio-cells = <2>;
 			reg = <0x60004000 0x800>;
-			interrupts = <GPIO_INTR_SOURCE>;
+			interrupts = <GPIO_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			/* Maximum available pins (per port)
 			 * Actual occupied pins are specified
@@ -126,7 +126,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x60013000 0x1000>;
-			interrupts = <I2C_EXT0_INTR_SOURCE>;
+			interrupts = <I2C_EXT0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_I2C0_MODULE>;
 			status = "disabled";
@@ -136,7 +136,7 @@
 			compatible = "espressif,esp32-uart";
 			reg = <0x60000000 0x400>;
 			status = "disabled";
-			interrupts = <UART0_INTR_SOURCE>;
+			interrupts = <UART0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_UART0_MODULE>;
 		};
@@ -145,7 +145,7 @@
 			compatible = "espressif,esp32-uart";
 			reg = <0x60010000 0x400>;
 			status = "disabled";
-			interrupts = <UART1_INTR_SOURCE>;
+			interrupts = <UART1_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_UART1_MODULE>;
 			current-speed = <115200>;
@@ -165,7 +165,7 @@
 			reg = <0x6001F000 DT_SIZE_K(4)>;
 			group = <0>;
 			index = <0>;
-			interrupts = <TG0_T0_LEVEL_INTR_SOURCE>;
+			interrupts = <TG0_T0_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
 		};
@@ -179,7 +179,7 @@
 		spi2: spi@60024000 {
 			compatible = "espressif,esp32-spi";
 			reg = <0x60024000 DT_SIZE_K(4)>;
-			interrupts = <SPI2_INTR_SOURCE>;
+			interrupts = <SPI2_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_SPI2_MODULE>;
 			dma-clk = <ESP32_GDMA_MODULE>;
@@ -190,7 +190,7 @@
 		wdt0: watchdog@6001f048  {
 			compatible = "espressif,esp32-watchdog";
 			reg = <0x6001f048 0x20>;
-			interrupts = <TG0_WDT_LEVEL_INTR_SOURCE>;
+			interrupts = <TG0_WDT_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_TIMG0_MODULE>;
 			status = "disabled";

--- a/dts/riscv/espressif/esp32c3/esp32c3_common.dtsi
+++ b/dts/riscv/espressif/esp32c3/esp32c3_common.dtsi
@@ -88,7 +88,7 @@
 		intc: interrupt-controller@600c2000 {
 			compatible = "espressif,esp32-intc";
 			#address-cells = <0>;
-			#interrupt-cells = <1>;
+			#interrupt-cells = <3>;
 			interrupt-controller;
 			reg = <0x600c2000 0x198>;
 			status = "okay";
@@ -97,7 +97,7 @@
 		systimer0: systimer@60023000 {
 			compatible = "espressif,esp32-systimer";
 			reg = <0x60023000 0x80>;
-			interrupts = <SYSTIMER_TARGET0_EDGE_INTR_SOURCE>;
+			interrupts = <SYSTIMER_TARGET0_EDGE_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "okay";
 		};
@@ -115,7 +115,7 @@
 			compatible = "espressif,esp32-xt-wdt";
 			reg = <0x60008004 0x4>;
 			clocks = <&rtc ESP32_MODULE_MAX>;
-			interrupts = <RTC_CORE_INTR_SOURCE>;
+			interrupts = <RTC_CORE_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
 		};
@@ -124,7 +124,7 @@
 			reg = <0x60008004 0xC>;
 			compatible = "espressif,esp32-rtc-timer";
 			clocks = <&rtc ESP32_MODULE_MAX>;
-			interrupts = <RTC_CORE_INTR_SOURCE>;
+			interrupts = <RTC_CORE_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "okay";
 		};
@@ -149,7 +149,7 @@
 			gpio-controller;
 			#gpio-cells = <2>;
 			reg = <0x60004000 0x800>;
-			interrupts = <GPIO_INTR_SOURCE>;
+			interrupts = <GPIO_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			/* Maximum available pins (per port)
 			 * Actual occupied pins are specified
@@ -164,7 +164,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x60013000 0x1000>;
-			interrupts = <I2C_EXT0_INTR_SOURCE>;
+			interrupts = <I2C_EXT0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_I2C0_MODULE>;
 			status = "disabled";
@@ -174,7 +174,7 @@
 			compatible = "espressif,esp32-uart";
 			reg = <0x60000000 0x400>;
 			status = "disabled";
-			interrupts = <UART0_INTR_SOURCE>;
+			interrupts = <UART0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_UART0_MODULE>;
 		};
@@ -183,7 +183,7 @@
 			compatible = "espressif,esp32-uart";
 			reg = <0x60010000 0x400>;
 			status = "disabled";
-			interrupts = <UART1_INTR_SOURCE>;
+			interrupts = <UART1_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_UART1_MODULE>;
 			current-speed = <115200>;
@@ -202,7 +202,7 @@
 			compatible = "espressif,esp32-usb-serial";
 			reg = <0x60043000 0x400>;
 			status = "disabled";
-			interrupts = <USB_INTR_SOURCE>;
+			interrupts = <USB_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_USB_MODULE>;
 		};
@@ -212,7 +212,7 @@
 			reg = <0x6001F000 DT_SIZE_K(4)>;
 			group = <0>;
 			index = <0>;
-			interrupts = <TG0_T0_LEVEL_INTR_SOURCE>;
+			interrupts = <TG0_T0_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
 		};
@@ -222,7 +222,7 @@
 			reg = <0x60020000 DT_SIZE_K(4)>;
 			group = <1>;
 			index = <0>;
-			interrupts = <TG1_T0_LEVEL_INTR_SOURCE>;
+			interrupts = <TG1_T0_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
 		};
@@ -236,7 +236,7 @@
 		twai: can@6002b000 {
 			compatible = "espressif,esp32-twai";
 			reg = <0x6002b000 DT_SIZE_K(4)>;
-			interrupts = <TWAI_INTR_SOURCE>;
+			interrupts = <TWAI_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_TWAI_MODULE>;
 			status = "disabled";
@@ -245,7 +245,7 @@
 		spi2: spi@60024000 {
 			compatible = "espressif,esp32-spi";
 			reg = <0x60024000 DT_SIZE_K(4)>;
-			interrupts = <SPI2_INTR_SOURCE>;
+			interrupts = <SPI2_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_SPI2_MODULE>;
 			dma-clk = <ESP32_GDMA_MODULE>;
@@ -256,7 +256,7 @@
 		wdt0: watchdog@6001f048  {
 			compatible = "espressif,esp32-watchdog";
 			reg = <0x6001f048 0x20>;
-			interrupts = <TG0_WDT_LEVEL_INTR_SOURCE>;
+			interrupts = <TG0_WDT_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_TIMG0_MODULE>;
 			status = "disabled";
@@ -265,7 +265,7 @@
 		wdt1: watchdog@60020048 {
 			compatible = "espressif,esp32-watchdog";
 			reg = <0x60020048 0x20>;
-			interrupts = <TG1_WDT_LEVEL_INTR_SOURCE>;
+			interrupts = <TG1_WDT_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_TIMG1_MODULE>;
 			status = "disabled";
@@ -300,7 +300,10 @@
 			compatible = "espressif,esp32-gdma";
 			reg = <0x6003f000 DT_SIZE_K(4)>;
 			#dma-cells = <1>;
-			interrupts = <DMA_CH0_INTR_SOURCE DMA_CH1_INTR_SOURCE DMA_CH2_INTR_SOURCE>;
+			interrupts =
+				<DMA_CH0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>,
+				<DMA_CH1_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>,
+				<DMA_CH2_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_GDMA_MODULE>;
 			dma-channels = <6>;

--- a/dts/riscv/espressif/esp32c6/esp32c6_common.dtsi
+++ b/dts/riscv/espressif/esp32c6/esp32c6_common.dtsi
@@ -69,7 +69,7 @@
 		intc: interrupt-controller@60010000 {
 			compatible = "espressif,esp32-intc";
 			#address-cells = <0>;
-			#interrupt-cells = <1>;
+			#interrupt-cells = <3>;
 			interrupt-controller;
 			reg = <0x60010000 DT_SIZE_K(4)>;
 			status = "okay";
@@ -78,7 +78,7 @@
 		systimer0: systimer@6000a000 {
 			compatible = "espressif,esp32-systimer";
 			reg = <0x6000A000 DT_SIZE_K(4)>;
-			interrupts = <SYSTIMER_TARGET0_EDGE_INTR_SOURCE>;
+			interrupts = <SYSTIMER_TARGET0_EDGE_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "okay";
 		};
@@ -96,7 +96,7 @@
 			compatible = "espressif,esp32-rtc-timer";
 			reg = <0x600B0C00 DT_SIZE_K(1)>;
 			clocks = <&rtc ESP32_MODULE_MAX>;
-			interrupts = <LP_RTC_TIMER_INTR_SOURCE>;
+			interrupts = <LP_RTC_TIMER_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
 		};
@@ -104,7 +104,7 @@
 		spi2: spi@60081000 {
 			compatible = "espressif,esp32-spi";
 			reg = <0x60081000 DT_SIZE_K(4)>;
-			interrupts = <GSPI2_INTR_SOURCE>;
+			interrupts = <GSPI2_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_SPI2_MODULE>;
 			dma-clk = <ESP32_GDMA_MODULE>;
@@ -115,7 +115,7 @@
 		wdt0: watchdog@60008048  {
 			compatible = "espressif,esp32-watchdog";
 			reg = <0x60008048 0x20>;
-			interrupts = <TG0_WDT_LEVEL_INTR_SOURCE>;
+			interrupts = <TG0_WDT_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_TIMG0_MODULE>;
 			status = "disabled";
@@ -124,7 +124,7 @@
 		wdt1: watchdog@60009048 {
 			compatible = "espressif,esp32-watchdog";
 			reg = <0x60009048 0x20>;
-			interrupts = <TG1_WDT_LEVEL_INTR_SOURCE>;
+			interrupts = <TG1_WDT_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_TIMG1_MODULE>;
 			status = "disabled";
@@ -148,9 +148,13 @@
 			compatible = "espressif,esp32-gdma";
 			reg = <0x60080000 DT_SIZE_K(4)>;
 			#dma-cells = <1>;
-			interrupts = <DMA_IN_CH0_INTR_SOURCE DMA_OUT_CH0_INTR_SOURCE
-				DMA_IN_CH1_INTR_SOURCE DMA_OUT_CH1_INTR_SOURCE
-				DMA_IN_CH2_INTR_SOURCE DMA_OUT_CH2_INTR_SOURCE>;
+			interrupts =
+				<DMA_IN_CH0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>,
+				<DMA_OUT_CH0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>,
+				<DMA_IN_CH1_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>,
+				<DMA_OUT_CH1_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>,
+				<DMA_IN_CH2_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>,
+				<DMA_OUT_CH2_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_GDMA_MODULE>;
 			dma-channels = <6>;
@@ -163,7 +167,7 @@
 			gpio-controller;
 			#gpio-cells = <2>;
 			reg = <0x60091000 DT_SIZE_K(4)>;
-			interrupts = <GPIO_INTR_SOURCE>;
+			interrupts = <GPIO_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			ngpios = <30>;   /* 0..29 */
 		};
@@ -172,7 +176,7 @@
 			compatible = "espressif,esp32-uart";
 			reg = <0x60000000 DT_SIZE_K(4)>;
 			status = "disabled";
-			interrupts = <UART0_INTR_SOURCE>;
+			interrupts = <UART0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_UART0_MODULE>;
 		};
@@ -181,7 +185,7 @@
 			compatible = "espressif,esp32-uart";
 			reg = <0x60001000 DT_SIZE_K(4)>;
 			status = "disabled";
-			interrupts = <UART1_INTR_SOURCE>;
+			interrupts = <UART1_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_UART1_MODULE>;
 			current-speed = <115200>;
@@ -191,7 +195,7 @@
 			compatible = "espressif,esp32-usb-serial";
 			reg = <0x6000F000 0x1000>;
 			status = "disabled";
-			interrupts = <USB_SERIAL_JTAG_INTR_SOURCE>;
+			interrupts = <USB_SERIAL_JTAG_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_USB_MODULE>;
 		};
@@ -205,5 +209,4 @@
 			status = "disabled";
 		};
 	};
-
 };

--- a/dts/xtensa/espressif/esp32/esp32_common.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_common.dtsi
@@ -74,7 +74,7 @@
 
 	eth: eth {
 		compatible = "espressif,esp32-eth";
-		interrupts = <ETH_MAC_INTR_SOURCE>;
+		interrupts = <ETH_MAC_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 		interrupt-parent = <&intc>;
 		clocks = <&rtc ESP32_EMAC_MODULE>;
 		status = "disabled";
@@ -110,7 +110,7 @@
 		};
 
 		intc: interrupt-controller@3ff00104 {
-			#interrupt-cells = <1>;
+			#interrupt-cells = <3>;
 			compatible = "espressif,esp32-intc";
 			interrupt-controller;
 			reg = <0x3ff00104 0x114>;
@@ -131,7 +131,7 @@
 			reg = <0x3ff48004 0xC>;
 			compatible = "espressif,esp32-rtc-timer";
 			clocks = <&rtc ESP32_MODULE_MAX>;
-			interrupts = <RTC_CORE_INTR_SOURCE>;
+			interrupts = <RTC_CORE_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "okay";
 		};
@@ -139,8 +139,6 @@
 		flash: flash-controller@3ff42000 {
 			compatible = "espressif,esp32-flash-controller";
 			reg = <0x3ff42000 0x1000>;
-			/* interrupts = <3 0>; */
-
 			#address-cells = <1>;
 			#size-cells = <1>;
 
@@ -166,7 +164,9 @@
 			status = "disabled";
 			shared-memory = <&ipmmem0>;
 			shared-memory-size = <0x400>;
-			interrupts = <FROM_CPU_INTR0_SOURCE FROM_CPU_INTR1_SOURCE>;
+			interrupts =
+				<FROM_CPU_INTR0_SOURCE IRQ_DEFAULT_PRIORITY 0>,
+				<FROM_CPU_INTR1_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 		};
 
@@ -176,7 +176,9 @@
 			status = "disabled";
 			shared-memory = <&ipmmem0>;
 			shared-memory-size = <0x400>;
-			interrupts = <FROM_CPU_INTR0_SOURCE FROM_CPU_INTR1_SOURCE>;
+			interrupts =
+				<FROM_CPU_INTR0_SOURCE IRQ_DEFAULT_PRIORITY 0>,
+				<FROM_CPU_INTR1_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			#mbox-cells = <1>;
 		};
@@ -184,21 +186,21 @@
 		ipi0: ipi@3f4c0058 {
 			compatible = "espressif,crosscore-interrupt";
 			reg = <0x3f4c0058 0x4>;
-			interrupts = <FROM_CPU_INTR0_SOURCE>;
+			interrupts = <FROM_CPU_INTR0_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 		};
 
 		ipi1: ipi@3f4c005c {
 			compatible = "espressif,crosscore-interrupt";
 			reg = <0x3f4c005c 0x4>;
-			interrupts = <FROM_CPU_INTR1_SOURCE>;
+			interrupts = <FROM_CPU_INTR1_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 		};
 
 		uart0: uart@3ff40000 {
 			compatible = "espressif,esp32-uart";
 			reg = <0x3ff40000 0x400>;
-			interrupts = <UART0_INTR_SOURCE>;
+			interrupts = <UART0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_UART0_MODULE>;
 			status = "disabled";
@@ -207,7 +209,7 @@
 		uart1: uart@3ff50000 {
 			compatible = "espressif,esp32-uart";
 			reg = <0x3ff50000 0x400>;
-			interrupts = <UART1_INTR_SOURCE>;
+			interrupts = <UART1_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_UART1_MODULE>;
 			status = "disabled";
@@ -216,7 +218,7 @@
 		uart2: uart@3ff6e000 {
 			compatible = "espressif,esp32-uart";
 			reg = <0x3ff6E000 0x400>;
-			interrupts = <UART2_INTR_SOURCE>;
+			interrupts = <UART2_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_UART2_MODULE>;
 			status = "disabled";
@@ -225,7 +227,7 @@
 		pcnt: pcnt@3ff57000 {
 			compatible = "espressif,esp32-pcnt";
 			reg = <0x3ff57000 0x1000>;
-			interrupts = <PCNT_INTR_SOURCE>;
+			interrupts = <PCNT_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_PCNT_MODULE>;
 			status = "disabled";
@@ -242,7 +244,7 @@
 		mcpwm0: mcpwm@3ff5e000 {
 			compatible = "espressif,esp32-mcpwm";
 			reg = <0x3ff5e000 0x1000>;
-			interrupts = <PWM0_INTR_SOURCE>;
+			interrupts = <PWM0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_PWM0_MODULE>;
 			#pwm-cells = <3>;
@@ -252,7 +254,7 @@
 		mcpwm1: mcpwm@3ff6c000 {
 			compatible = "espressif,esp32-mcpwm";
 			reg = <0x3ff6c000 0x1000>;
-			interrupts = <PWM1_INTR_SOURCE>;
+			interrupts = <PWM1_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_PWM1_MODULE>;
 			#pwm-cells = <3>;
@@ -277,7 +279,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x3ff44000 0x800>;
-				interrupts = <GPIO_INTR_SOURCE>;
+				interrupts = <GPIO_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 				interrupt-parent = <&intc>;
 				/* Maximum available pins (per port)
 				 * Actual occupied pins are specified
@@ -292,7 +294,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x3ff44800 0x800>;
-				interrupts = <GPIO_INTR_SOURCE>;
+				interrupts = <GPIO_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 				interrupt-parent = <&intc>;
 				ngpios = <8>;   /* 32..39 */
 			};
@@ -301,7 +303,7 @@
 		touch: touch@3ff48858 {
 			compatible = "espressif,esp32-touch";
 			reg = <0x3ff48858 0x38>;
-			interrupts = <RTC_CORE_INTR_SOURCE>;
+			interrupts = <RTC_CORE_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
 		};
@@ -311,7 +313,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x3ff53000 0x1000>;
-			interrupts = <I2C_EXT0_INTR_SOURCE>;
+			interrupts = <I2C_EXT0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_I2C0_MODULE>;
 			status = "disabled";
@@ -322,7 +324,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x3ff67000 0x1000>;
-			interrupts = <I2C_EXT1_INTR_SOURCE>;
+			interrupts = <I2C_EXT1_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_I2C1_MODULE>;
 			status = "disabled";
@@ -331,14 +333,13 @@
 		trng0: trng@3ff75144 {
 			compatible = "espressif,esp32-trng";
 			reg = <0x3FF75144 0x4>;
-			/* interrupts = <33 0>; - FIXME: Enable interrupts when interrupt-controller got supported in device tree */
 			status = "disabled";
 		};
 
 		wdt0: watchdog@3ff5f048 {
 			compatible = "espressif,esp32-watchdog";
 			reg = <0x3ff5f048 0x20>;
-			interrupts = <TG0_WDT_LEVEL_INTR_SOURCE>;
+			interrupts = <TG0_WDT_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_TIMG0_MODULE>;
 			status = "okay";
@@ -347,7 +348,7 @@
 		wdt1: watchdog@3ff60048 {
 			compatible = "espressif,esp32-watchdog";
 			reg = <0x3ff60048 0x20>;
-			interrupts = <TG1_WDT_LEVEL_INTR_SOURCE>;
+			interrupts = <TG1_WDT_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_TIMG1_MODULE>;
 			status = "disabled";
@@ -356,7 +357,7 @@
 		spi2: spi@3ff64000 {
 			compatible = "espressif,esp32-spi";
 			reg = <0x3ff64000 DT_SIZE_K(4)>;
-			interrupts = <SPI2_INTR_SOURCE>;
+			interrupts = <SPI2_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_HSPI_MODULE>;
 			dma-clk = <ESP32_SPI_DMA_MODULE>;
@@ -367,7 +368,7 @@
 		spi3: spi@3ff65000 {
 			compatible = "espressif,esp32-spi";
 			reg = <0x3ff65000 DT_SIZE_K(4)>;
-			interrupts = <SPI3_INTR_SOURCE>;
+			interrupts = <SPI3_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_VSPI_MODULE>;
 			dma-clk = <ESP32_SPI_DMA_MODULE>;
@@ -378,7 +379,7 @@
 		twai: can@3ff6b000 {
 			compatible = "espressif,esp32-twai";
 			reg = <0x3ff6b000 DT_SIZE_K(4)>;
-			interrupts = <TWAI_INTR_SOURCE>;
+			interrupts = <TWAI_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_TWAI_MODULE>;
 			status = "disabled";
@@ -389,7 +390,7 @@
 			reg = <0x3ff5f000 DT_SIZE_K(4)>;
 			group = <0>;
 			index = <0>;
-			interrupts = <TG0_T0_LEVEL_INTR_SOURCE>;
+			interrupts = <TG0_T0_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
 		};
@@ -399,7 +400,7 @@
 			reg = <0x3ff5f024 DT_SIZE_K(4)>;
 			group = <0>;
 			index = <1>;
-			interrupts = <TG0_T1_LEVEL_INTR_SOURCE>;
+			interrupts = <TG0_T1_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
 		};
@@ -409,7 +410,7 @@
 			reg = <0x3ff60000 DT_SIZE_K(4)>;
 			group = <1>;
 			index = <0>;
-			interrupts = <TG1_T0_LEVEL_INTR_SOURCE>;
+			interrupts = <TG1_T0_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
 		};
@@ -419,7 +420,7 @@
 			reg = <0x3ff60024 DT_SIZE_K(4)>;
 			group = <1>;
 			index = <1>;
-			interrupts = <TG1_T1_LEVEL_INTR_SOURCE>;
+			interrupts = <TG1_T1_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
 		};
@@ -427,7 +428,7 @@
 		dac: dac@3ff48800 {
 			compatible = "espressif,esp32-dac";
 			reg = <0x3ff48800 0x100>;
-			interrupts = <RTC_CORE_INTR_SOURCE>;
+			interrupts = <RTC_CORE_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_SARADC_MODULE>;
 			#io-channel-cells = <1>;
@@ -455,7 +456,7 @@
 		sdhc: sdhc@3ff68000 {
 			compatible = "espressif,esp32-sdhc";
 			reg = <0x3ff68000 0x1000>;
-			interrupts = <SDIO_HOST_INTR_SOURCE>;
+			interrupts = <SDIO_HOST_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_SDMMC_MODULE>;
 			#address-cells = <1>;

--- a/dts/xtensa/espressif/esp32s2/esp32s2_common.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_common.dtsi
@@ -85,7 +85,7 @@
 		};
 
 		intc: interrupt-controller@3f4c2000 {
-			#interrupt-cells = <1>;
+			#interrupt-cells = <3>;
 			compatible = "espressif,esp32-intc";
 			interrupt-controller;
 			reg = <0x3f4c2000 0x114>;
@@ -105,7 +105,7 @@
 			compatible = "espressif,esp32-xt-wdt";
 			reg = <0x3f408004 0x4>;
 			clocks = <&rtc ESP32_MODULE_MAX>;
-			interrupts = <RTC_CORE_INTR_SOURCE>;
+			interrupts = <RTC_CORE_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
 		};
@@ -114,7 +114,7 @@
 			reg = <0x3f408004 0xC>;
 			compatible = "espressif,esp32-rtc-timer";
 			clocks = <&rtc ESP32_MODULE_MAX>;
-			interrupts = <RTC_CORE_INTR_SOURCE>;
+			interrupts = <RTC_CORE_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "okay";
 		};
@@ -146,7 +146,7 @@
 			compatible = "espressif,esp32-uart";
 			reg = <0x3f400000 0x400>;
 			status = "disabled";
-			interrupts = <UART0_INTR_SOURCE>;
+			interrupts = <UART0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_UART0_MODULE>;
 		};
@@ -155,7 +155,7 @@
 			compatible = "espressif,esp32-uart";
 			reg = <0x3f410000 0x400>;
 			status = "disabled";
-			interrupts = <UART1_INTR_SOURCE>;
+			interrupts = <UART1_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_UART1_MODULE>;
 			current-speed = <115200>;
@@ -164,7 +164,7 @@
 		pcnt: pcnt@3f417000 {
 			compatible = "espressif,esp32-pcnt";
 			reg = <0x3f417000 0x1000>;
-			interrupts = <PCNT_INTR_SOURCE>;
+			interrupts = <PCNT_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_PCNT_MODULE>;
 			status = "disabled";
@@ -184,7 +184,7 @@
 			gpio-controller;
 			#gpio-cells = <2>;
 			reg = <0x3f404000 0x800>;
-			interrupts = <GPIO_INTR_SOURCE>;
+			interrupts = <GPIO_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			/* Maximum available pins (per port)
 			 * Actual occupied pins are specified
@@ -199,7 +199,7 @@
 			gpio-controller;
 			#gpio-cells = <2>;
 			reg = <0x3f404800 0x800>;
-			interrupts = <GPIO_INTR_SOURCE>;
+			interrupts = <GPIO_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			ngpios = <22>;   /* 32..53 */
 		};
@@ -207,7 +207,7 @@
 		touch: touch@3f40885c {
 			compatible = "espressif,esp32-touch";
 			reg = <0x3f40885c 0xc0 0x3f408104 0x18>;
-			interrupts = <RTC_CORE_INTR_SOURCE>;
+			interrupts = <RTC_CORE_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
 		};
@@ -217,7 +217,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x3f413000 0x1000>;
-			interrupts = <I2C_EXT0_INTR_SOURCE>;
+			interrupts = <I2C_EXT0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_I2C0_MODULE>;
 			status = "disabled";
@@ -228,7 +228,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x3f427000 0x1000>;
-			interrupts = <I2C_EXT1_INTR_SOURCE>;
+			interrupts = <I2C_EXT1_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_I2C1_MODULE>;
 			status = "disabled";
@@ -239,7 +239,7 @@
 			reg = <0x3f41f000 DT_SIZE_K(4)>;
 			group = <0>;
 			index = <0>;
-			interrupts = <TG0_T0_LEVEL_INTR_SOURCE>;
+			interrupts = <TG0_T0_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
 		};
@@ -249,7 +249,7 @@
 			reg = <0x3f41f024 DT_SIZE_K(4)>;
 			group = <0>;
 			index = <1>;
-			interrupts = <TG0_T1_LEVEL_INTR_SOURCE>;
+			interrupts = <TG0_T1_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
 		};
@@ -259,7 +259,7 @@
 			reg = <0x3f420000 DT_SIZE_K(4)>;
 			group = <1>;
 			index = <0>;
-			interrupts = <TG1_T0_LEVEL_INTR_SOURCE>;
+			interrupts = <TG1_T0_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
 		};
@@ -269,7 +269,7 @@
 			reg = <0x3f420024 DT_SIZE_K(4)>;
 			group = <1>;
 			index = <1>;
-			interrupts = <TG1_T1_LEVEL_INTR_SOURCE>;
+			interrupts = <TG1_T1_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 		};
 
@@ -282,7 +282,7 @@
 		spi2: spi@3f424000 {
 			compatible = "espressif,esp32-spi";
 			reg = <0x3f424000 DT_SIZE_K(4)>;
-			interrupts = <SPI2_INTR_SOURCE>;
+			interrupts = <SPI2_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_FSPI_MODULE>;
 			dma-clk = <ESP32_SPI2_DMA_MODULE>;
@@ -293,7 +293,7 @@
 		spi3: spi@3f425000 {
 			compatible = "espressif,esp32-spi";
 			reg = <0x3f425000 DT_SIZE_K(4)>;
-			interrupts = <SPI3_INTR_SOURCE>;
+			interrupts = <SPI3_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_HSPI_MODULE>;
 			dma-clk = <ESP32_SPI3_DMA_MODULE>;
@@ -304,7 +304,7 @@
 		wdt0: watchdog@3f41f048 {
 			compatible = "espressif,esp32-watchdog";
 			reg = <0x3f41f048 0x20>;
-			interrupts = <TG0_WDT_LEVEL_INTR_SOURCE>;
+			interrupts = <TG0_WDT_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_TIMG0_MODULE>;
 			status = "disabled";
@@ -313,7 +313,7 @@
 		wdt1: watchdog@3f42f048 {
 			compatible = "espressif,esp32-watchdog";
 			reg = <0x3f42f048 0x20>;
-			interrupts = <TG1_WDT_LEVEL_INTR_SOURCE>;
+			interrupts = <TG1_WDT_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_TIMG1_MODULE>;
 			status = "disabled";
@@ -322,7 +322,7 @@
 		dac: dac@3f408800 {
 			compatible = "espressif,esp32-dac";
 			reg = <0x3f408800 0x100>;
-			interrupts = <RTC_CORE_INTR_SOURCE>;
+			interrupts = <RTC_CORE_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_PERIPH_SARADC_MODULE>;
 			#io-channel-cells = <1>;
@@ -356,7 +356,7 @@
 		twai: can@3f42b000 {
 			compatible = "espressif,esp32-twai";
 			reg = <0x3f42b000 DT_SIZE_K(4)>;
-			interrupts = <TWAI_INTR_SOURCE>;
+			interrupts = <TWAI_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_TWAI_MODULE>;
 			status = "disabled";

--- a/dts/xtensa/espressif/esp32s3/esp32s3_common.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_common.dtsi
@@ -102,7 +102,7 @@
 		};
 
 		intc: interrupt-controller@600c2000 {
-			#interrupt-cells = <1>;
+			#interrupt-cells = <3>;
 			compatible = "espressif,esp32-intc";
 			interrupt-controller;
 			reg = <0x600c2000 0x1000>;
@@ -122,7 +122,7 @@
 			compatible = "espressif,esp32-xt-wdt";
 			reg = <0x60021004 0x4>;
 			clocks = <&rtc ESP32_MODULE_MAX>;
-			interrupts = <RTC_CORE_INTR_SOURCE>;
+			interrupts = <RTC_CORE_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
 		};
@@ -131,7 +131,7 @@
 			reg = <0x60008004 0xC>;
 			compatible = "espressif,esp32-rtc-timer";
 			clocks = <&rtc ESP32_MODULE_MAX>;
-			interrupts = <RTC_CORE_INTR_SOURCE>;
+			interrupts = <RTC_CORE_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
 		};
@@ -139,8 +139,6 @@
 		flash: flash-controller@60002000 {
 			compatible = "espressif,esp32-flash-controller";
 			reg = <0x60002000 0x1000>;
-			/* interrupts = <3 0>; */
-
 			#address-cells = <1>;
 			#size-cells = <1>;
 
@@ -167,7 +165,9 @@
 			status = "disabled";
 			shared-memory = <&ipmmem0>;
 			shared-memory-size = <0x400>;
-			interrupts = <FROM_CPU_INTR0_SOURCE FROM_CPU_INTR1_SOURCE>;
+			interrupts =
+				<FROM_CPU_INTR0_SOURCE IRQ_DEFAULT_PRIORITY 0>,
+				<FROM_CPU_INTR1_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 		};
 
@@ -177,7 +177,9 @@
 			status = "disabled";
 			shared-memory = <&ipmmem0>;
 			shared-memory-size = <0x400>;
-			interrupts = <FROM_CPU_INTR0_SOURCE FROM_CPU_INTR1_SOURCE>;
+			interrupts =
+				<FROM_CPU_INTR0_SOURCE IRQ_DEFAULT_PRIORITY 0>,
+				<FROM_CPU_INTR1_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			#mbox-cells = <1>;
 		};
@@ -185,7 +187,7 @@
 		uart0: uart@60000000 {
 			compatible = "espressif,esp32-uart";
 			reg = <0x60000000 0x1000>;
-			interrupts = <UART0_INTR_SOURCE>;
+			interrupts = <UART0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_UART0_MODULE>;
 			status = "disabled";
@@ -194,7 +196,7 @@
 		uart1: uart@60010000 {
 			compatible = "espressif,esp32-uart";
 			reg = <0x60010000 0x1000>;
-			interrupts = <UART1_INTR_SOURCE>;
+			interrupts = <UART1_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_UART1_MODULE>;
 			status = "disabled";
@@ -203,7 +205,7 @@
 		uart2: uart@6002e000 {
 			compatible = "espressif,esp32-uart";
 			reg = <0x6002e000 0x1000>;
-			interrupts = <UART2_INTR_SOURCE>;
+			interrupts = <UART2_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_UART2_MODULE>;
 			status = "disabled";
@@ -227,7 +229,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x60004000 0x800>;
-				interrupts = <GPIO_INTR_SOURCE>;
+				interrupts = <GPIO_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 				interrupt-parent = <&intc>;
 				/* Maximum available pins (per port)
 				 * Actual occupied pins are specified
@@ -242,7 +244,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x60004800 0x800>;
-				interrupts = <GPIO_INTR_SOURCE>;
+				interrupts = <GPIO_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 				interrupt-parent = <&intc>;
 				ngpios = <22>; /* 32..53 */
 			};
@@ -251,7 +253,7 @@
 		touch: touch@6000885c {
 			compatible = "espressif,esp32-touch";
 			reg = <0x6000885c 0x88 0x60008908 0x18>;
-			interrupts = <RTC_CORE_INTR_SOURCE>;
+			interrupts = <RTC_CORE_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
 		};
@@ -261,7 +263,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x60013000 DT_SIZE_K(4)>;
-			interrupts = <I2C_EXT0_INTR_SOURCE>;
+			interrupts = <I2C_EXT0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_I2C0_MODULE>;
 			status = "disabled";
@@ -272,7 +274,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x60027000 DT_SIZE_K(4)>;
-			interrupts = <I2C_EXT1_INTR_SOURCE>;
+			interrupts = <I2C_EXT1_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_I2C1_MODULE>;
 			status = "disabled";
@@ -281,7 +283,7 @@
 		spi2: spi@60024000 {
 			compatible = "espressif,esp32-spi";
 			reg = <0x60024000 DT_SIZE_K(4)>;
-			interrupts = <SPI2_INTR_SOURCE>;
+			interrupts = <SPI2_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_SPI2_MODULE>;
 			dma-clk = <ESP32_GDMA_MODULE>;
@@ -292,7 +294,7 @@
 		spi3: spi@60025000 {
 			compatible = "espressif,esp32-spi";
 			reg = <0x60025000 DT_SIZE_K(4)>;
-			interrupts = <SPI3_INTR_SOURCE>;
+			interrupts = <SPI3_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_SPI3_MODULE>;
 			dma-clk = <ESP32_GDMA_MODULE>;
@@ -328,7 +330,7 @@
 		twai: can@6002b000 {
 			compatible = "espressif,esp32-twai";
 			reg = <0x6002b000 DT_SIZE_K(4)>;
-			interrupts = <TWAI_INTR_SOURCE>;
+			interrupts = <TWAI_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_TWAI_MODULE>;
 			status = "disabled";
@@ -338,7 +340,7 @@
 			compatible = "espressif,esp32-usb-serial";
 			reg = <0x60038000 DT_SIZE_K(4)>;
 			status = "disabled";
-			interrupts = <USB_SERIAL_JTAG_INTR_SOURCE>;
+			interrupts = <USB_SERIAL_JTAG_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_USB_MODULE>;
 		};
@@ -348,7 +350,7 @@
 			reg = <0x6001f000 DT_SIZE_K(4)>;
 			group = <0>;
 			index = <0>;
-			interrupts = <TG0_T0_LEVEL_INTR_SOURCE>;
+			interrupts = <TG0_T0_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
 		};
@@ -358,7 +360,7 @@
 			reg = <0x6001f024 DT_SIZE_K(4)>;
 			group = <0>;
 			index = <1>;
-			interrupts = <TG0_T1_LEVEL_INTR_SOURCE>;
+			interrupts = <TG0_T1_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
 		};
@@ -368,7 +370,7 @@
 			reg = <0x60020000 DT_SIZE_K(4)>;
 			group = <1>;
 			index = <0>;
-			interrupts = <TG1_T0_LEVEL_INTR_SOURCE>;
+			interrupts = <TG1_T0_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
 		};
@@ -378,14 +380,14 @@
 			reg = <0x60020024 DT_SIZE_K(4)>;
 			group = <1>;
 			index = <1>;
-			interrupts = <TG1_T1_LEVEL_INTR_SOURCE>;
+			interrupts = <TG1_T1_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 		};
 
 		wdt0: watchdog@6001f048 {
 			compatible = "espressif,esp32-watchdog";
 			reg = <0x6001f048 0x20>;
-			interrupts = <TG0_WDT_LEVEL_INTR_SOURCE>;
+			interrupts = <TG0_WDT_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_TIMG0_MODULE>;
 			status = "disabled";
@@ -394,7 +396,7 @@
 		wdt1: watchdog@60020048 {
 			compatible = "espressif,esp32-watchdog";
 			reg = <0x60020048 0x20>;
-			interrupts = <TG1_WDT_LEVEL_INTR_SOURCE>;
+			interrupts = <TG1_WDT_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_TIMG1_MODULE>;
 			status = "disabled";
@@ -417,7 +419,7 @@
 		mcpwm0: mcpwm@6001e000 {
 			compatible = "espressif,esp32-mcpwm";
 			reg = <0x6001e000 DT_SIZE_K(4)>;
-			interrupts = <PWM0_INTR_SOURCE>;
+			interrupts = <PWM0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_PWM0_MODULE>;
 			#pwm-cells = <3>;
@@ -427,7 +429,7 @@
 		mcpwm1: mcpwm@6002c000 {
 			compatible = "espressif,esp32-mcpwm";
 			reg = <0x6002c000 DT_SIZE_K(4)>;
-			interrupts = <PWM1_INTR_SOURCE>;
+			interrupts = <PWM1_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_PWM1_MODULE>;
 			#pwm-cells = <3>;
@@ -437,7 +439,7 @@
 		pcnt: pcnt@60017000 {
 			compatible = "espressif,esp32-pcnt";
 			reg = <0x60017000 DT_SIZE_K(4)>;
-			interrupts = <PCNT_INTR_SOURCE>;
+			interrupts = <PCNT_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_PCNT_MODULE>;
 			status = "disabled";
@@ -447,9 +449,17 @@
 			compatible = "espressif,esp32-gdma";
 			reg = <0x6003f000 DT_SIZE_K(4)>;
 			#dma-cells = <1>;
-			interrupts = <DMA_IN_CH0_INTR_SOURCE DMA_OUT_CH0_INTR_SOURCE
-						DMA_IN_CH1_INTR_SOURCE DMA_OUT_CH1_INTR_SOURCE
-						DMA_IN_CH2_INTR_SOURCE DMA_OUT_CH2_INTR_SOURCE>;
+			interrupts =
+				<DMA_IN_CH0_INTR_SOURCE IRQ_DEFAULT_PRIORITY ESP_INTR_FLAG_SHARED>,
+				<DMA_OUT_CH0_INTR_SOURCE IRQ_DEFAULT_PRIORITY ESP_INTR_FLAG_SHARED>,
+				<DMA_IN_CH1_INTR_SOURCE IRQ_DEFAULT_PRIORITY ESP_INTR_FLAG_SHARED>,
+				<DMA_OUT_CH1_INTR_SOURCE IRQ_DEFAULT_PRIORITY ESP_INTR_FLAG_SHARED>,
+				<DMA_IN_CH2_INTR_SOURCE IRQ_DEFAULT_PRIORITY ESP_INTR_FLAG_SHARED>,
+				<DMA_OUT_CH2_INTR_SOURCE IRQ_DEFAULT_PRIORITY ESP_INTR_FLAG_SHARED>,
+				<DMA_IN_CH3_INTR_SOURCE IRQ_DEFAULT_PRIORITY ESP_INTR_FLAG_SHARED>,
+				<DMA_OUT_CH3_INTR_SOURCE IRQ_DEFAULT_PRIORITY ESP_INTR_FLAG_SHARED>,
+				<DMA_IN_CH4_INTR_SOURCE IRQ_DEFAULT_PRIORITY ESP_INTR_FLAG_SHARED>,
+				<DMA_OUT_CH4_INTR_SOURCE IRQ_DEFAULT_PRIORITY ESP_INTR_FLAG_SHARED>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_GDMA_MODULE>;
 			dma-channels = <10>;
@@ -460,7 +470,7 @@
 		sdhc: sdhc@60028000 {
 			compatible = "espressif,esp32-sdhc";
 			reg = <0x60028000 0x1000>;
-			interrupts = <SDIO_HOST_INTR_SOURCE>;
+			interrupts = <SDIO_HOST_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_SDMMC_MODULE>;
 			#address-cells = <1>;

--- a/include/zephyr/drivers/interrupt_controller/intc_esp32.h
+++ b/include/zephyr/drivers/interrupt_controller/intc_esp32.h
@@ -45,6 +45,17 @@
 				 ESP_INTR_FLAG_NMI)
 
 /*
+ * Get the interrupt flags from the supplied priority.
+ */
+#define ESP_PRIO_TO_FLAGS(priority) \
+	((priority) > 0 ? ((1 << (priority)) & ESP_INTR_FLAG_LEVELMASK) : 0)
+
+/*
+ * Check interrupt flags from input and filter unallowed values.
+ */
+#define ESP_INT_FLAGS_CHECK(int_flags) ((int_flags) & ESP_INTR_FLAG_SHARED)
+
+/*
  * The esp_intr_alloc* functions can allocate an int for all *_INTR_SOURCE int sources that
  * are routed through the interrupt mux. Apart from these sources, each core also has some internal
  * sources that do not pass through the interrupt mux. To allocate an interrupt for these sources,
@@ -294,7 +305,6 @@ int esp_intr_set_in_iram(struct intr_handle_data_t *handle, bool is_in_iram);
  * @brief Disable interrupts that aren't specifically marked as running from IRAM
  */
 void esp_intr_noniram_disable(void);
-
 
 /**
  * @brief Re-enable interrupts disabled by esp_intr_noniram_disable

--- a/include/zephyr/drivers/interrupt_controller/intc_esp32c3.h
+++ b/include/zephyr/drivers/interrupt_controller/intc_esp32c3.h
@@ -40,6 +40,18 @@
 				 ESP_INTR_FLAG_LEVEL4|ESP_INTR_FLAG_LEVEL5|ESP_INTR_FLAG_LEVEL6| \
 				 ESP_INTR_FLAG_NMI)
 
+/*
+ * Get the interrupt flags from the supplied priority.
+ */
+#define ESP_PRIO_TO_FLAGS(priority) \
+	((priority) > 0 ? ((1 << (priority)) & ESP_INTR_FLAG_LEVELMASK) : 0)
+
+/*
+ * Check interrupt flags from input and filter unallowed values.
+ */
+#define ESP_INT_FLAGS_CHECK(int_flags) ((int_flags) & ESP_INTR_FLAG_SHARED)
+
+
 /* Function prototype for interrupt handler function */
 typedef void (*isr_handler_t)(const void *arg);
 

--- a/include/zephyr/dt-bindings/interrupt-controller/esp-esp32c2-intmux.h
+++ b/include/zephyr/dt-bindings/interrupt-controller/esp-esp32c2-intmux.h
@@ -51,4 +51,12 @@
 #define CORE0_PIF_PMS_SIZE_INTR_SOURCE         41
 #define CACHE_CORE0_ACS_INTR_SOURCE            42
 
+/* RISC-V supports priority values from 1 (lowest) to 15.
+ * As interrupt controller for Xtensa and RISC-V is shared, this is
+ * set to an intermediate and compatible value.
+ */
+#define IRQ_DEFAULT_PRIORITY	3
+
+#define ESP_INTR_FLAG_SHARED	(1<<8)	/* Interrupt can be shared between ISRs */
+
 #endif

--- a/include/zephyr/dt-bindings/interrupt-controller/esp-esp32c3-intmux.h
+++ b/include/zephyr/dt-bindings/interrupt-controller/esp-esp32c3-intmux.h
@@ -70,4 +70,12 @@
 #define BAK_PMS_VIOLATE_INTR_SOURCE         60
 #define CACHE_CORE0_ACS_INTR_SOURCE         61
 
+/* RISC-V supports priority values from 1 (lowest) to 15.
+ * As interrupt controller for Xtensa and RISC-V is shared, this is
+ * set to an intermediate and compatible value.
+ */
+#define IRQ_DEFAULT_PRIORITY	3
+
+#define ESP_INTR_FLAG_SHARED	(1<<8)	/* Interrupt can be shared between ISRs */
+
 #endif

--- a/include/zephyr/dt-bindings/interrupt-controller/esp-esp32c6-intmux.h
+++ b/include/zephyr/dt-bindings/interrupt-controller/esp-esp32c6-intmux.h
@@ -86,4 +86,12 @@
 #define ECC_INTR_SOURCE                    76  /* interrupt of ECC accelerator, level*/
 #define MAX_INTR_SOURCE                    77
 
+/* RISC-V supports priority values from 1 (lowest) to 15.
+ * As interrupt controller for Xtensa and RISC-V is shared, this is
+ * set to an intermediate and compatible value.
+ */
+#define IRQ_DEFAULT_PRIORITY	3
+
+#define ESP_INTR_FLAG_SHARED	(1<<8)	/* Interrupt can be shared between ISRs */
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_INTERRUPT_CONTROLLER_ESP32C6_INTMUX_H_ */

--- a/include/zephyr/dt-bindings/interrupt-controller/esp-xtensa-intmux.h
+++ b/include/zephyr/dt-bindings/interrupt-controller/esp-xtensa-intmux.h
@@ -79,4 +79,11 @@
 #define CACHE_IA_INTR_SOURCE                68  /* Cache Invalid Access, LEVEL */
 #define MAX_INTR_SOURCE                     69  /* total number of interrupt sources */
 
+/* For Xtensa architecture, zero will allocate low/medium
+ * levels of priority (ESP_INTR_FLAG_LOWMED)
+ */
+#define IRQ_DEFAULT_PRIORITY	0
+
+#define ESP_INTR_FLAG_SHARED	(1<<8)	/* Interrupt can be shared between ISRs */
+
 #endif

--- a/include/zephyr/dt-bindings/interrupt-controller/esp32s2-xtensa-intmux.h
+++ b/include/zephyr/dt-bindings/interrupt-controller/esp32s2-xtensa-intmux.h
@@ -106,4 +106,11 @@
 #define ICACHE_SYNC_INTR_SOURCE             94  /* instruction cache sync done, level */
 #define MAX_INTR_SOURCE                     95  /* total number of interrupt sources */
 
+/* For Xtensa architecture, zero will allocate low/medium
+ * levels of priority (ESP_INTR_FLAG_LOWMED)
+ */
+#define IRQ_DEFAULT_PRIORITY	0
+
+#define ESP_INTR_FLAG_SHARED	(1<<8)	/* Interrupt can be shared between ISRs */
+
 #endif

--- a/include/zephyr/dt-bindings/interrupt-controller/esp32s3-xtensa-intmux.h
+++ b/include/zephyr/dt-bindings/interrupt-controller/esp32s3-xtensa-intmux.h
@@ -104,4 +104,11 @@
 #define DMA_EXTMEM_REJECT_SOURCE              98
 #define MAX_INTR_SOURCE                       99 /* number of interrupt sources */
 
+/* For Xtensa architecture, zero will allocate low/medium
+ * levels of priority (ESP_INTR_FLAG_LOWMED)
+ */
+#define IRQ_DEFAULT_PRIORITY	0
+
+#define ESP_INTR_FLAG_SHARED	(1<<8)	/* Interrupt can be shared between ISRs */
+
 #endif

--- a/soc/espressif/esp32/esp32-mp.c
+++ b/soc/espressif/esp32/esp32-mp.c
@@ -276,14 +276,18 @@ void arch_cpu_start(int cpu_num, k_thread_stack_t *stack, int sz,
 	cpus_active[0] = true;
 	cpus_active[cpu_num] = true;
 
-	esp_intr_alloc(DT_IRQN(DT_NODELABEL(ipi0)),
-		ESP_INTR_FLAG_IRAM,
+	esp_intr_alloc(DT_IRQ_BY_IDX(DT_NODELABEL(ipi0), 0, irq),
+		ESP_PRIO_TO_FLAGS(DT_IRQ_BY_IDX(DT_NODELABEL(ipi0), 0, priority)) |
+		ESP_INT_FLAGS_CHECK(DT_IRQ_BY_IDX(DT_NODELABEL(ipi0), 0, flags)) |
+			ESP_INTR_FLAG_IRAM,
 		esp_crosscore_isr,
 		NULL,
 		NULL);
 
-	esp_intr_alloc(DT_IRQN(DT_NODELABEL(ipi1)),
-		ESP_INTR_FLAG_IRAM,
+	esp_intr_alloc(DT_IRQ_BY_IDX(DT_NODELABEL(ipi1), 0, irq),
+		ESP_PRIO_TO_FLAGS(DT_IRQ_BY_IDX(DT_NODELABEL(ipi1), 0, priority)) |
+		ESP_INT_FLAGS_CHECK(DT_IRQ_BY_IDX(DT_NODELABEL(ipi1), 0, flags)) |
+			ESP_INTR_FLAG_IRAM,
 		esp_crosscore_isr,
 		NULL,
 		NULL);


### PR DESCRIPTION
Allows configuring interrupts priority and flags in the device tree for Espressif SoC's