### PR TITLE
modules: hal_nordic: adjust HFCLK ramp-up time.

### DIFF
--- a/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_clock_zephyr.c
+++ b/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_clock_zephyr.c
@@ -78,7 +78,8 @@ void nrf_802154_clock_hfclk_stop(void)
 #elif defined(NRF54H_SERIES)
 
 #define NRF_LRCCONF_RADIO_PD NRF_LRCCONF010
-#define MAX_HFXO_RAMP_UP_TIME_US 1000
+/* HF clock time to ramp-up. */
+#define MAX_HFXO_RAMP_UP_TIME_US 550
 
 static void hfclk_started_timer_handler(struct k_timer *dummy)
 {


### PR DESCRIPTION
Changes the ramp-up time from 1000us to 550us
on nRF54H20.
The time must fit inside general preconditions ramp up.

The hfclk time can be adjusted this way because
the current solution is not precise until
the clock_control is available.