### PR TITLE
Bluetooth: Host: Remove conn param update checks

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -3008,15 +3008,6 @@ int bt_conn_le_param_update(struct bt_conn *conn,
 	LOG_DBG("conn %p features 0x%02x params (%d-%d %d %d)", conn, conn->le.features[0],
 		param->interval_min, param->interval_max, param->latency, param->timeout);
 
-	/* Check if there's a need to update conn params */
-	if (conn->le.interval >= param->interval_min &&
-	    conn->le.interval <= param->interval_max &&
-	    conn->le.latency == param->latency &&
-	    conn->le.timeout == param->timeout) {
-		atomic_clear_bit(conn->flags, BT_CONN_PERIPHERAL_PARAM_SET);
-		return -EALREADY;
-	}
-
 	if (IS_ENABLED(CONFIG_BT_CENTRAL) &&
 	    conn->role == BT_CONN_ROLE_CENTRAL) {
 		return send_conn_le_param_update(conn, param);


### PR DESCRIPTION
The rationale behind that change is that the Application can use the `bt_conn_le_param_update()` API to signal the controller to reschedule the link.

Even if the new connection params are within the old ones, the controller would be free to choose an e.g. smaller interval. The host API should not prevent this usage.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/74292