### PR TITLE
drivers: gpio: imx rt11xx: fix wrong gpio pull disable mask

### DIFF
--- a/drivers/gpio/gpio_mcux_igpio.c
+++ b/drivers/gpio/gpio_mcux_igpio.c
@@ -124,7 +124,7 @@ static int mcux_igpio_configure(const struct device *dev,
 			}
 		} else {
 			/* Set pin to no pull */
-			reg |= IOMUXC_SW_PAD_CTL_PAD_PUS_MASK;
+			reg |= IOMUXC_SW_PAD_CTL_PAD_PULL_MASK;
 		}
 		/* PDRV/SNVS/LPSR reg have different ODE bits */
 		if (config->pin_muxes[cfg_idx].pdrv_mux) {


### PR DESCRIPTION
A wrong bit mask (wrong: IOMUXC_SW_PAD_CTL_PAD_PUS_MASK = 0x8 ~ bit 3) was used. That bit mask is for PUE/PUS-type gpio registers, but this is the section for registers with alternative PULL (PDRV) type layout. Right bit mask: IOMUXC_SW_PAD_CTL_PAD_PULL_MASK = 0xC (bit 2 & 3). Rather than disabling pull, Zephyr was enabling pull down.

I'm wondering if it is a problem that the two bits 2 and 3 are cleared 8 lines before, because the reference manual says that the combination 00 is forbidden.

Fixes #75390