### PR TITLE
boards: nucleo: tag some st boards to test for "usbd"

### DIFF
--- a/boards/st/b_g474e_dpow1/b_g474e_dpow1.yaml
+++ b/boards/st/b_g474e_dpow1/b_g474e_dpow1.yaml
@@ -14,4 +14,5 @@ supported:
   - watchdog
   - tcpc
   - usb
+  - usbd
 vendor: st

--- a/boards/st/b_l072z_lrwan1/b_l072z_lrwan1.yaml
+++ b/boards/st/b_l072z_lrwan1/b_l072z_lrwan1.yaml
@@ -20,4 +20,5 @@ supported:
   - eeprom
   - nvs
   - lora
+  - usbd
 vendor: st

--- a/boards/st/b_u585i_iot02a/b_u585i_iot02a.yaml
+++ b/boards/st/b_u585i_iot02a/b_u585i_iot02a.yaml
@@ -24,4 +24,5 @@ supported:
   - counter
   - i2c
   - rtc
+  - usbd
 vendor: st

--- a/boards/st/disco_l475_iot1/disco_l475_iot1.yaml
+++ b/boards/st/disco_l475_iot1/disco_l475_iot1.yaml
@@ -26,6 +26,7 @@ supported:
   - qspi
   - dma
   - rtc
+  - usbd
 ram: 96
 flash: 1024
 vendor: st

--- a/boards/st/nucleo_f042k6/nucleo_f042k6.dts
+++ b/boards/st/nucleo_f042k6/nucleo_f042k6.dts
@@ -117,3 +117,9 @@
 &vbat {
 	status = "okay";
 };
+
+zephyr_udc0: &usb {
+	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/boards/st/nucleo_f042k6/nucleo_f042k6.yaml
+++ b/boards/st/nucleo_f042k6/nucleo_f042k6.yaml
@@ -13,6 +13,7 @@ supported:
   - spi
   - gpio
   - adc
+  - usbd
 testing:
   ignore_tags:
     - net

--- a/boards/st/nucleo_f207zg/nucleo_f207zg.yaml
+++ b/boards/st/nucleo_f207zg/nucleo_f207zg.yaml
@@ -25,4 +25,5 @@ supported:
   - rng
   - dma
   - rtc
+  - usbd
 vendor: st

--- a/boards/st/nucleo_f429zi/nucleo_f429zi.yaml
+++ b/boards/st/nucleo_f429zi/nucleo_f429zi.yaml
@@ -25,4 +25,5 @@ supported:
   - dma
   - nvs
   - rtc
+  - usbd
 vendor: st

--- a/boards/st/nucleo_f756zg/nucleo_f756zg.yaml
+++ b/boards/st/nucleo_f756zg/nucleo_f756zg.yaml
@@ -19,4 +19,5 @@ supported:
   - i2c
   - pwm
   - spi
+  - usbd
 vendor: st

--- a/boards/st/nucleo_g0b1re/nucleo_g0b1re.yaml
+++ b/boards/st/nucleo_g0b1re/nucleo_g0b1re.yaml
@@ -23,4 +23,5 @@ supported:
   - dma
   - usb_device
   - lptim
+  - usbd
 vendor: st

--- a/boards/st/nucleo_h743zi/nucleo_h743zi.yaml
+++ b/boards/st/nucleo_h743zi/nucleo_h743zi.yaml
@@ -26,4 +26,5 @@ supported:
   - dac
   - dma
   - rtc
+  - usbd
 vendor: st

--- a/boards/st/nucleo_wb55rg/nucleo_wb55rg.yaml
+++ b/boards/st/nucleo_wb55rg/nucleo_wb55rg.yaml
@@ -23,4 +23,5 @@ supported:
   - usb_device
   - nvs
   - rtc
+  - usbd
 vendor: st

--- a/boards/st/stm32f103_mini/stm32f103_mini.yaml
+++ b/boards/st/stm32f103_mini/stm32f103_mini.yaml
@@ -16,4 +16,5 @@ supported:
   - watchdog
   - adc
   - counter
+  - usbd
 vendor: st

--- a/boards/st/stm32f3_disco/stm32f3_disco_stm32f303xc_E.yaml
+++ b/boards/st/stm32f3_disco/stm32f3_disco_stm32f303xc_E.yaml
@@ -21,4 +21,5 @@ supported:
   - adc
   - dac
   - rtc
+  - usbd
 vendor: st

--- a/boards/st/stm32h573i_dk/stm32h573i_dk.yaml
+++ b/boards/st/stm32h573i_dk/stm32h573i_dk.yaml
@@ -25,4 +25,5 @@ supported:
   - usb
   - i2c
   - rtc
+  - usbd
 vendor: st

--- a/boards/st/stm32l562e_dk/stm32l562e_dk.yaml
+++ b/boards/st/stm32l562e_dk/stm32l562e_dk.yaml
@@ -22,6 +22,7 @@ supported:
   - usb
   - usb_device
   - nvs
+  - usbd
 ram: 192
 flash: 512
 vendor: st


### PR DESCRIPTION
Add the usbd test tag to few ST boards, this should be picking a board for every variation of the HAL file (checked for #define USBD_FS_SPEED), so it should catch any inconsistencies between HALs.


There should be one for each of: f0 f1 f2 f3 f4 f7 g0 g4 h5 h7 l0 l4 l5 u5 wb.

Nothing for l1, can't find any boards with a USB port.