### PR TITLE
bluetooth: host: bt_disable: Let threads run before aborting

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4329,6 +4329,9 @@ int bt_disable(void)
 	disconnected_handles_reset();
 #endif /* CONFIG_BT_CONN */
 
+	/* Let threads run before aborting */
+	k_yield();
+
 #if defined(CONFIG_BT_RECV_WORKQ_BT)
 	/* Abort RX thread */
 	k_thread_abort(&bt_workq.thread);


### PR DESCRIPTION
This means we can raise the disconnected events which are pending from `bt_conn_cleanup_all` if bt_disable is called a cooperative thread.

Without this the events were not raised until bluetooth was enabled again.

fixes #72721