### PR TITLE
llext: [DNM] enable Xtensa read-only tests

### DIFF
--- a/tests/subsys/llext/simple/testcase.yaml
+++ b/tests/subsys/llext/simple/testcase.yaml
@@ -14,12 +14,13 @@ common:
     - qemu_arc/qemu_arc_hs5x
     - qemu_arc/qemu_arc_hs6x
     - qemu_cortex_m0
-    - qemu_xtensa/dc233c/mmu
   integration_platforms:
     - qemu_cortex_a9          # ARM Cortex-A9 (ARMv7-A ISA)
     - qemu_cortex_r5          # ARM Cortex-R5 (ARMv7-R ISA)
     - mps2/an385              # ARM Cortex-M3 (ARMv7-M ISA)
     - mps2/an521/cpu0         # ARM Cortex-M33 (ARMv8-M ISA)
+    - qemu_xtensa
+    - qemu_xtensa/dc233c/mmu
 
 tests:
   # While there is in practice no value in compiling subsys/llext/*.c
@@ -32,36 +33,35 @@ tests:
   # Run the suite with all combinations of core Kconfig options for the llext
   # subsystem (storage type, ELF type, MPU/MMU etc)
   llext.simple.readonly:
-    arch_allow: arm # Xtensa needs writable storage
+    arch_allow: arm xtensa
     filter: not CONFIG_MPU and not CONFIG_MMU and not CONFIG_SOC_SERIES_S32ZE
     extra_configs:
       - arch:arm:CONFIG_ARM_MPU=n
       - arch:arm:CONFIG_ARM_AARCH32_MMU=n
+      - arch:xtensa:CONFIG_XTENSA_MMU=n
       - CONFIG_LLEXT_STORAGE_WRITABLE=n
   llext.simple.readonly_mpu:
     min_ram: 128
-    arch_allow: arm # Xtensa needs writable storage
+    arch_allow: arm xtensa
     filter: CONFIG_ARCH_HAS_USERSPACE
     extra_configs:
       - CONFIG_USERSPACE=y
       - CONFIG_LLEXT_STORAGE_WRITABLE=n
   llext.simple.writable:
     arch_allow: arm xtensa
-    integration_platforms:
-      - qemu_xtensa             # Xtensa ISA
     filter: not CONFIG_MPU and not CONFIG_MMU and not CONFIG_SOC_SERIES_S32ZE
     extra_configs:
       - arch:arm:CONFIG_ARM_MPU=n
       - arch:arm:CONFIG_ARM_AARCH32_MMU=n
+      - arch:xtensa:CONFIG_XTENSA_MMU=n
       - CONFIG_LLEXT_STORAGE_WRITABLE=y
   llext.simple.writable_relocatable:
     arch_allow: arm xtensa
-    integration_platforms:
-      - qemu_xtensa             # Xtensa ISA
     filter: not CONFIG_MPU and not CONFIG_MMU
     extra_configs:
       - arch:arm:CONFIG_ARM_MPU=n
       - arch:arm:CONFIG_ARM_AARCH32_MMU=n
+      - arch:xtensa:CONFIG_XTENSA_MMU=n
       - CONFIG_LLEXT_STORAGE_WRITABLE=y
       - CONFIG_LLEXT_TYPE_ELF_RELOCATABLE=y
 
@@ -69,22 +69,20 @@ tests:
   # storage to cover both ARM and Xtensa architectures on the same test.
   llext.simple.writable_slid_linking:
     arch_allow: arm xtensa
-    integration_platforms:
-      - qemu_xtensa             # Xtensa ISA
     filter: not CONFIG_MPU and not CONFIG_MMU and not CONFIG_SOC_SERIES_S32ZE
     extra_configs:
       - arch:arm:CONFIG_ARM_MPU=n
       - arch:arm:CONFIG_ARM_AARCH32_MMU=n
+      - arch:xtensa:CONFIG_XTENSA_MMU=n
       - CONFIG_LLEXT_STORAGE_WRITABLE=y
       - CONFIG_LLEXT_EXPORT_BUILTINS_BY_SLID=y
   llext.simple.writable_relocatable_slid_linking:
     arch_allow: arm xtensa
-    integration_platforms:
-      - qemu_xtensa             # Xtensa ISA
     filter: not CONFIG_MPU and not CONFIG_MMU
     extra_configs:
       - arch:arm:CONFIG_ARM_MPU=n
       - arch:arm:CONFIG_ARM_AARCH32_MMU=n
+      - arch:xtensa:CONFIG_XTENSA_MMU=n
       - CONFIG_LLEXT_STORAGE_WRITABLE=y
       - CONFIG_LLEXT_TYPE_ELF_RELOCATABLE=y
       - CONFIG_LLEXT_EXPORT_BUILTINS_BY_SLID=y


### PR DESCRIPTION
This test-only patch removes the restrictions that prevent testing the LLEXT read-only code paths for the Xtensa architecture. Enabling these will be a first step in identifying the issues that prevent the Xtensa architecture from loading from read-only storage.