### PR TITLE
boards: imx93_evk: ca55: correct board name in yaml

### DIFF
--- a/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.yaml
+++ b/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: imx93_evk/mimx9352/a55
-name: NXP i.MX93 Plus EVK A55
+name: NXP i.MX93 EVK A55
 type: mcu
 arch: arm64
 toolchain:


### PR DESCRIPTION
Correct the board name.