### PR TITLE
shell: introduce `shell_xxx_impl` wrapper functions for output macros

### DIFF
--- a/include/zephyr/shell/shell.h
+++ b/include/zephyr/shell/shell.h
@@ -1093,7 +1093,8 @@ void shell_hexdump(const struct shell *sh, const uint8_t *data, size_t len);
  * @param[in] ... List of parameters to print.
  */
 #define shell_info(_sh, _ft, ...) \
-	shell_fprintf(_sh, SHELL_INFO, _ft "\n", ##__VA_ARGS__)
+	shell_info_impl(_sh, _ft "\n", ##__VA_ARGS__)
+void __printf_like(2, 3) shell_info_impl(const struct shell *sh, const char *fmt, ...);
 
 /**
  * @brief Print normal message to the shell.
@@ -1105,7 +1106,8 @@ void shell_hexdump(const struct shell *sh, const uint8_t *data, size_t len);
  * @param[in] ... List of parameters to print.
  */
 #define shell_print(_sh, _ft, ...) \
-	shell_fprintf(_sh, SHELL_NORMAL, _ft "\n", ##__VA_ARGS__)
+	shell_print_impl(_sh, _ft "\n", ##__VA_ARGS__)
+void __printf_like(2, 3) shell_print_impl(const struct shell *sh, const char *fmt, ...);
 
 /**
  * @brief Print warning message to the shell.
@@ -1117,7 +1119,8 @@ void shell_hexdump(const struct shell *sh, const uint8_t *data, size_t len);
  * @param[in] ... List of parameters to print.
  */
 #define shell_warn(_sh, _ft, ...) \
-	shell_fprintf(_sh, SHELL_WARNING, _ft "\n", ##__VA_ARGS__)
+	shell_warn_impl(_sh, _ft "\n", ##__VA_ARGS__)
+void __printf_like(2, 3) shell_warn_impl(const struct shell *sh, const char *fmt, ...);
 
 /**
  * @brief Print error message to the shell.
@@ -1129,7 +1132,8 @@ void shell_hexdump(const struct shell *sh, const uint8_t *data, size_t len);
  * @param[in] ... List of parameters to print.
  */
 #define shell_error(_sh, _ft, ...) \
-	shell_fprintf(_sh, SHELL_ERROR, _ft "\n", ##__VA_ARGS__)
+	shell_error_impl(_sh, _ft "\n", ##__VA_ARGS__)
+void __printf_like(2, 3) shell_error_impl(const struct shell *sh, const char *fmt, ...);
 
 /**
  * @brief Process function, which should be executed when data is ready in the


### PR DESCRIPTION
Refactor shell output macros to minimize caller overhead by eliminating direct `color` parameter passing:
- Introduce wrapper functions: `shell_info_impl`, `shell_print_impl`, `shell_warn_impl`, `shell_error_impl`.
- Replace `shell_fprintf` in macros with these new wrappers.
- Update `shell_hexdump_line` to use the new wrappers, minimizing caller overhead.