### PR TITLE
subsys: random: reduce the severity of the CONFIG_TIMER_RANDOM_GENERATOR warning to avoid warning fatigue

### DIFF
--- a/subsys/random/CMakeLists.txt
+++ b/subsys/random/CMakeLists.txt
@@ -9,7 +9,7 @@ zephyr_library_sources_ifdef(CONFIG_USERSPACE           random_handlers.c)
 endif()
 
 if (CONFIG_TIMER_RANDOM_GENERATOR)
-  message(WARNING "
+  message(VERBOSE "
     Warning: CONFIG_TIMER_RANDOM_GENERATOR is not a truly random generator.
     This capability is not secure and it is provided for testing purposes only.
     Use it carefully.")


### PR DESCRIPTION
The message does not indicate a problem with the configuration so it should not be emitted at a high severity level. Misuse of high-severity messages incentivizes the user to ignore them, which may cause one to overlook a warning that actually matters.