### PR TITLE
doc: release/migration-notes/3.7: add bits about PCIe, I3C, UART and Xtensa

### DIFF
--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -659,6 +659,9 @@ Sensors
 Serial
 ======
 
+* The Raspberry Pi UART driver ``uart_rpi_pico`` has been removed.
+  Use ``uart_pl011`` (:dtcompatible:`arm,pl011`) instead. (:github:`71074`)
+
 Timer
 =====
 

--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -64,6 +64,10 @@ Kernel
 
 * The named struct ``z_arch_esf_t`` is now deprecated. Use ``struct arch_esf`` instead. (:github:`73593`)
 
+* The header file :zephyr_file:`include/zephyr/arch/arch_interface.h` has been moved from
+  ``include/zephyr/sys/`` into ``include/zephyr/arch/``. Out-of-tree source files will need to
+  update the include path. (:github:`64987`)
+
 Boards
 ******
 

--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -162,6 +162,23 @@ Architectures
 
 * Xtensa
 
+  * Added support to save/restore HiFi AudioEngine registers.
+
+  * Added support to utilize MPU.
+
+  * Added support to automatically generate interrupt handlers.
+
+  * Added support to generate vector table at build time to be included in the linker script.
+
+  * Added kconfig :kconfig:option:`CONFIG_XTENSA_BREAK_ON_UNRECOVERABLE_EXCEPTIONS` to guard
+    using break instruction for unrecoverable exceptions. Enabling the break instruction via
+    this kconfig may result in an infinite interrupt storm which may hinder debugging efforts.
+
+  * Fixed an issue where passing the 7th argument via syscall was handled incorrectly.
+
+  * Fixed an issue where :c:func:`arch_user_string_nlen` accessing unmapped memory resulted
+    in an unrecoverable exception.
+
 Kernel
 ******
 

--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -427,6 +427,13 @@ Drivers and Sensors
 
 * I3C
 
+  * Added shell support for querying bus and CCC commands.
+
+  * Added driver to support the I3C controller on NPCX.
+
+  * Improvements and bug fixes on :dtcompatible:`nxp,mcux-i3c`, including handling the bus
+    being busy more gracefully instead of simply returning errors.
+
 * IEEE 802.15.4
 
 * Input

--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -476,6 +476,9 @@ Drivers and Sensors
 
 * PCIE
 
+  * ``pcie_bdf_lookup`` and ``pcie_probe`` have been removed since they have been
+    deprecated since v3.3.0.
+
 * MEMC
 
 * MIPI-DBI

--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -543,6 +543,73 @@ Drivers and Sensors
     enables using Bluetooth as a transport to all the subsystems that are currently supported by
     UART (e.g: Console, Shell, Logging).
 
+  * Added support for HSCIF (High Speed Serial Communication Interface with FIFO) in the UART
+    driver for Renesas RCar platforms.
+
+  * Added driver for ENE KB1200 UART.
+
+  * Added driver for UART on Analog Devices MAX32 series microcontrollers.
+
+  * Added driver for UART on Renesas RA8 devices.
+
+  * ``uart_emul`` (:dtcompatible:`zephyr,uart-emul`):
+
+    * Added support for asynchronous API for the emulated UART driver.
+
+  * ``uart_esp32`` (:dtcompatible:`espressif,esp32-uart`):
+
+    * Added support to invert TX and RX pin signals.
+
+    * Added support for ESP32C6 SoC.
+
+  * ``uart_native_tty`` (:dtcompatible:`zephyr,native-tty-uart`):
+
+    * Added support to emulate interrupt driven UART.
+
+  * ``uart_mcux_lpuart`` (:dtcompatible:`nxp,kinetis-lpuart`):
+
+    * Added support for single wire half-duplex communication.
+
+    * Added support to invert TX and RX pin signals.
+
+  * ``uart_npcx`` (:dtcompatible:`nuvoton,npcx-uart`):
+
+    * Added support for asynchronous API.
+
+    * Added support for baud rate of 3MHz.
+
+  * ``uart_nrfx_uarte`` (:dtcompatible:`nordic,nrf-uarte`):
+
+    * Added support to put TX and RX pins into low power mode when UART is not active.
+
+  * ``uart_nrfx_uarte2`` (:dtcompatible:`nordic,nrf-uarte`):
+
+    * Prevents UART from transmitting when device is suspended.
+
+    * Fixed some events not being triggered.
+
+  * ``uart_pl011`` (:dtcompatible:`arm,pl011`):
+
+    * Added support for runtime configuration.
+
+    * Added support for reset device.
+
+    * Added support to use clock control to determine frequency.
+
+    * Added support for hardware flow control.
+
+    * Added support for UART on Ambiq Apollo3 SoC.
+
+  * ``uart_smartbond`` (:dtcompatible:`renesas,smartbond-uart`):
+
+    * Added support for power management.
+
+    * Added support to wake up via DTR and RX lines.
+
+  * ``uart_stm32`` (:dtcompatible:`st,stm32-uart`):
+
+    * Added support to identify if DMA buffers are in data cache or non-cacheable memory.
+
 * SPI
 
   * Added support for Ambiq Apollo3 series general IOM based SPI.


### PR DESCRIPTION
Adding bits to release notes and migration notes on PCIe, I3C, UART and Xtensa.