### PR TITLE
fdtable: fix longstanding layering violations

### DIFF
--- a/drivers/bluetooth/hci/userchan.c
+++ b/drivers/bluetooth/hci/userchan.c
@@ -188,7 +188,7 @@ static void rx_thread(void *p1, void *p2, void *p3)
 		struct net_buf *buf;
 		size_t buf_tailroom;
 		size_t buf_add_len;
-		ssize_t len;
+		k_ssize_t len;
 		const uint8_t *frame_start = frame;
 
 		if (!uc_ready(uc->fd)) {

--- a/drivers/disk/flashdisk.c
+++ b/drivers/disk/flashdisk.c
@@ -28,13 +28,13 @@ struct flashdisk_data {
 	struct disk_info info;
 	struct k_mutex lock;
 	const unsigned int area_id;
-	const off_t offset;
+	const k_off_t offset;
 	uint8_t *const cache;
 	const size_t cache_size;
 	const size_t size;
 	const size_t sector_size;
 	size_t page_size;
-	off_t cached_addr;
+	k_off_t cached_addr;
 	bool cache_valid;
 	bool cache_dirty;
 	bool erase_required;
@@ -89,7 +89,7 @@ static int flashdisk_init_runtime(struct flashdisk_data *ctx,
 {
 	int rc;
 	struct flash_pages_info page;
-	off_t offset;
+	k_off_t offset;
 
 	flashdisk_probe_erase(ctx);
 
@@ -126,7 +126,8 @@ static int flashdisk_init_runtime(struct flashdisk_data *ctx,
 		while (offset < ctx->offset + ctx->size) {
 			rc = flash_get_page_info_by_offs(ctx->info.dev, offset, &page);
 			if (rc < 0) {
-				LOG_ERR("Error %d getting page info at offset %lx", rc, offset);
+				LOG_ERR("Error %d getting page info at offset %lx", rc,
+					(long)offset);
 				return rc;
 			}
 			if (page.size != ctx->page_size) {
@@ -200,7 +201,7 @@ static int disk_flash_access_read(struct disk_info *disk, uint8_t *buff,
 				uint32_t start_sector, uint32_t sector_count)
 {
 	struct flashdisk_data *ctx;
-	off_t fl_addr;
+	k_off_t fl_addr;
 	uint32_t remaining;
 	uint32_t offset;
 	uint32_t len;
@@ -272,7 +273,7 @@ static int flashdisk_cache_commit(struct flashdisk_data *ctx)
 	return 0;
 }
 
-static int flashdisk_cache_load(struct flashdisk_data *ctx, off_t fl_addr)
+static int flashdisk_cache_load(struct flashdisk_data *ctx, k_off_t fl_addr)
 {
 	int rc;
 
@@ -308,11 +309,11 @@ static int flashdisk_cache_load(struct flashdisk_data *ctx, off_t fl_addr)
 /* input size is either less or equal to a block size (ctx->page_size)
  * and write data never spans across adjacent blocks.
  */
-static int flashdisk_cache_write(struct flashdisk_data *ctx, off_t start_addr,
-				uint32_t size, const void *buff)
+static int flashdisk_cache_write(struct flashdisk_data *ctx, k_off_t start_addr, uint32_t size,
+				 const void *buff)
 {
 	int rc;
-	off_t fl_addr;
+	k_off_t fl_addr;
 	uint32_t offset;
 
 	/* adjust offset if starting address is not erase-aligned address */
@@ -347,7 +348,7 @@ static int disk_flash_access_write(struct disk_info *disk, const uint8_t *buff,
 				 uint32_t start_sector, uint32_t sector_count)
 {
 	struct flashdisk_data *ctx;
-	off_t fl_addr;
+	k_off_t fl_addr;
 	uint32_t remaining;
 	uint32_t size;
 	int rc = 0;
@@ -369,7 +370,7 @@ static int disk_flash_access_write(struct disk_info *disk, const uint8_t *buff,
 
 	/* check if start address is erased-aligned address  */
 	if (fl_addr & (ctx->page_size - 1)) {
-		off_t block_bnd;
+		k_off_t block_bnd;
 
 		/* not aligned */
 		/* check if the size goes over flash block boundary */

--- a/drivers/display/display_hx8394.c
+++ b/drivers/display/display_hx8394.c
@@ -406,7 +406,7 @@ const uint8_t hx8394_cmd3[] = {0xC6U, 0xEDU};
 
 const uint8_t tear_config[] = {HX8394_SET_TEAR, HX8394_TEAR_VBLANK};
 
-static ssize_t hx8394_mipi_tx(const struct device *mipi_dev, uint8_t channel,
+static k_ssize_t hx8394_mipi_tx(const struct device *mipi_dev, uint8_t channel,
 			      const void *buf, size_t len)
 {
 	/* Send MIPI transfers using low power mode */

--- a/drivers/eeprom/eeprom_at2x.c
+++ b/drivers/eeprom/eeprom_at2x.c
@@ -88,8 +88,7 @@ static inline int eeprom_at2x_write_enable(const struct device *dev)
 }
 #endif /* ANY_INST_HAS_WP_GPIOS */
 
-static int eeprom_at2x_read(const struct device *dev, off_t offset, void *buf,
-			    size_t len)
+static int eeprom_at2x_read(const struct device *dev, k_off_t offset, void *buf, size_t len)
 {
 	const struct eeprom_at2x_config *config = dev->config;
 	struct eeprom_at2x_data *data = dev->data;
@@ -124,13 +123,11 @@ static int eeprom_at2x_read(const struct device *dev, off_t offset, void *buf,
 	return 0;
 }
 
-static size_t eeprom_at2x_limit_write_count(const struct device *dev,
-					    off_t offset,
-					    size_t len)
+static size_t eeprom_at2x_limit_write_count(const struct device *dev, k_off_t offset, size_t len)
 {
 	const struct eeprom_at2x_config *config = dev->config;
 	size_t count = len;
-	off_t page_boundary;
+	k_off_t page_boundary;
 
 	/* We can at most write one page at a time */
 	if (count > config->pagesize) {
@@ -146,9 +143,7 @@ static size_t eeprom_at2x_limit_write_count(const struct device *dev,
 	return count;
 }
 
-static int eeprom_at2x_write(const struct device *dev, off_t offset,
-			     const void *buf,
-			     size_t len)
+static int eeprom_at2x_write(const struct device *dev, k_off_t offset, const void *buf, size_t len)
 {
 	const struct eeprom_at2x_config *config = dev->config;
 	struct eeprom_at2x_data *data = dev->data;
@@ -233,8 +228,7 @@ static bool eeprom_at24_bus_is_ready(const struct device *dev)
  * but also to address higher part of eeprom for chips
  * with more than 2^(addr_width) adressable word.
  */
-static uint16_t eeprom_at24_translate_offset(const struct device *dev,
-					     off_t *offset)
+static uint16_t eeprom_at24_translate_offset(const struct device *dev, k_off_t *offset)
 {
 	const struct eeprom_at2x_config *config = dev->config;
 
@@ -244,8 +238,7 @@ static uint16_t eeprom_at24_translate_offset(const struct device *dev,
 	return config->bus.i2c.addr + addr_incr;
 }
 
-static size_t eeprom_at24_adjust_read_count(const struct device *dev,
-					    off_t offset, size_t len)
+static size_t eeprom_at24_adjust_read_count(const struct device *dev, k_off_t offset, size_t len)
 {
 	const struct eeprom_at2x_config *config = dev->config;
 	const size_t remainder = BIT(config->addr_width) - offset;
@@ -257,8 +250,7 @@ static size_t eeprom_at24_adjust_read_count(const struct device *dev,
 	return len;
 }
 
-static int eeprom_at24_read(const struct device *dev, off_t offset, void *buf,
-			    size_t len)
+static int eeprom_at24_read(const struct device *dev, k_off_t offset, void *buf, size_t len)
 {
 	const struct eeprom_at2x_config *config = dev->config;
 	int64_t timeout;
@@ -299,8 +291,7 @@ static int eeprom_at24_read(const struct device *dev, off_t offset, void *buf,
 	return len;
 }
 
-static int eeprom_at24_write(const struct device *dev, off_t offset,
-			     const void *buf, size_t len)
+static int eeprom_at24_write(const struct device *dev, k_off_t offset, const void *buf, size_t len)
 {
 	const struct eeprom_at2x_config *config = dev->config;
 	int count = eeprom_at2x_limit_write_count(dev, offset, len);
@@ -415,8 +406,7 @@ static int eeprom_at25_wait_for_idle(const struct device *dev)
 	return -EBUSY;
 }
 
-static int eeprom_at25_read(const struct device *dev, off_t offset, void *buf,
-			    size_t len)
+static int eeprom_at25_read(const struct device *dev, k_off_t offset, void *buf, size_t len)
 {
 	const struct eeprom_at2x_config *config = dev->config;
 	struct eeprom_at2x_data *data = dev->data;
@@ -502,8 +492,7 @@ static int eeprom_at25_wren(const struct device *dev)
 	return spi_write_dt(&config->bus.spi, &tx);
 }
 
-static int eeprom_at25_write(const struct device *dev, off_t offset,
-			     const void *buf, size_t len)
+static int eeprom_at25_write(const struct device *dev, k_off_t offset, const void *buf, size_t len)
 {
 	const struct eeprom_at2x_config *config = dev->config;
 	int count = eeprom_at2x_limit_write_count(dev, offset, len);

--- a/drivers/eeprom/eeprom_fake.c
+++ b/drivers/eeprom/eeprom_fake.c
@@ -19,9 +19,10 @@ struct fake_eeprom_config {
 	size_t size;
 };
 
-DEFINE_FAKE_VALUE_FUNC(int, fake_eeprom_read, const struct device *, off_t, void *, size_t);
+DEFINE_FAKE_VALUE_FUNC(int, fake_eeprom_read, const struct device *, k_off_t, void *, size_t);
 
-DEFINE_FAKE_VALUE_FUNC(int, fake_eeprom_write, const struct device *, off_t, const void *, size_t);
+DEFINE_FAKE_VALUE_FUNC(int, fake_eeprom_write, const struct device *, k_off_t, const void *,
+		       size_t);
 
 DEFINE_FAKE_VALUE_FUNC(size_t, fake_eeprom_size, const struct device *);
 

--- a/drivers/eeprom/eeprom_handlers.c
+++ b/drivers/eeprom/eeprom_handlers.c
@@ -7,7 +7,7 @@
 #include <zephyr/internal/syscall_handler.h>
 #include <zephyr/drivers/eeprom.h>
 
-static inline int z_vrfy_eeprom_read(const struct device *dev, off_t offset,
+static inline int z_vrfy_eeprom_read(const struct device *dev, k_off_t offset,
 				     void *data, size_t len)
 {
 	K_OOPS(K_SYSCALL_DRIVER_EEPROM(dev, read));
@@ -18,7 +18,7 @@ static inline int z_vrfy_eeprom_read(const struct device *dev, off_t offset,
 }
 #include <zephyr/syscalls/eeprom_read_mrsh.c>
 
-static inline int z_vrfy_eeprom_write(const struct device *dev, off_t offset,
+static inline int z_vrfy_eeprom_write(const struct device *dev, k_off_t offset,
 				      const void *data, size_t len)
 {
 	K_OOPS(K_SYSCALL_DRIVER_EEPROM(dev, write));

--- a/drivers/eeprom/eeprom_lpc11u6x.c
+++ b/drivers/eeprom/eeprom_lpc11u6x.c
@@ -29,7 +29,7 @@ struct eeprom_lpc11u6x_config {
 };
 
 static int eeprom_lpc11u6x_read(const struct device *dev,
-				off_t offset, void *data, size_t len)
+				k_off_t offset, void *data, size_t len)
 {
 	const struct eeprom_lpc11u6x_config *config = dev->config;
 	uint32_t cmd[5];
@@ -62,7 +62,7 @@ static int eeprom_lpc11u6x_read(const struct device *dev,
 }
 
 static int eeprom_lpc11u6x_write(const struct device *dev,
-				 off_t offset, const void *data, size_t len)
+				 k_off_t offset, const void *data, size_t len)
 {
 	const struct eeprom_lpc11u6x_config *config = dev->config;
 	uint32_t cmd[5];

--- a/drivers/eeprom/eeprom_mb85rcxx.c
+++ b/drivers/eeprom/eeprom_mb85rcxx.c
@@ -12,6 +12,7 @@
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/types.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(EEPROM_MB85RCXX, CONFIG_EEPROM_LOG_LEVEL);
@@ -40,11 +41,11 @@ static int mb85rcxx_write_protect_set(const struct device *dev, int value)
 	return gpio_pin_set_dt(&cfg->wp_gpio, value);
 }
 
-static uint16_t mb85rcxx_translate_address(const struct device *dev, off_t offset, uint8_t *addr)
+static uint16_t mb85rcxx_translate_address(const struct device *dev, k_off_t offset, uint8_t *addr)
 {
 	const struct mb85rcxx_config *cfg = dev->config;
 
-	off_t page_offset = offset % cfg->pagesize;
+	k_off_t page_offset = offset % cfg->pagesize;
 
 	if (cfg->addr_width > 8) {
 		sys_put_be16(page_offset, addr);
@@ -56,10 +57,10 @@ static uint16_t mb85rcxx_translate_address(const struct device *dev, off_t offse
 	return cfg->i2c.addr + (offset >> cfg->addr_width);
 }
 
-static size_t mb85rcxx_remaining_len_in_page(const struct device *dev, off_t offset, size_t len)
+static size_t mb85rcxx_remaining_len_in_page(const struct device *dev, k_off_t offset, size_t len)
 {
 	const struct mb85rcxx_config *cfg = dev->config;
-	off_t page_offset = offset % cfg->pagesize;
+	k_off_t page_offset = offset % cfg->pagesize;
 	size_t rem = cfg->pagesize - page_offset;
 
 	if (rem > len) {
@@ -97,7 +98,7 @@ static int mb85rcxx_init(const struct device *dev)
 	return 0;
 }
 
-static int mb85rcxx_read(const struct device *dev, off_t offset, void *buf, size_t len)
+static int mb85rcxx_read(const struct device *dev, k_off_t offset, void *buf, size_t len)
 {
 	const struct mb85rcxx_config *cfg = dev->config;
 	struct mb85rcxx_data *data = dev->data;
@@ -151,7 +152,7 @@ static int mb85rcxx_i2c_write(const struct device *dev, uint16_t i2c_addr, uint8
 	return i2c_transfer(cfg->i2c.bus, &msgs[0], 2, i2c_addr);
 }
 
-static int mb85rcxx_write(const struct device *dev, off_t offset, const void *buf, size_t len)
+static int mb85rcxx_write(const struct device *dev, k_off_t offset, const void *buf, size_t len)
 {
 	const struct mb85rcxx_config *cfg = dev->config;
 	struct mb85rcxx_data *data = dev->data;

--- a/drivers/eeprom/eeprom_mchp_xec.c
+++ b/drivers/eeprom/eeprom_mchp_xec.c
@@ -168,7 +168,7 @@ static void eeprom_xec_wait_write_compl(struct eeprom_xec_regs * const regs)
 }
 
 static void eeprom_xec_data_read_32_bytes(struct eeprom_xec_regs * const regs,
-							uint8_t *buf, size_t len, off_t offset)
+							uint8_t *buf, size_t len, k_off_t offset)
 {
 	/* Issue the READ command to transfer buffer to EEPROM memory */
 	eeprom_xec_execute_reg_set(regs, len, XEC_EEPROM_EXC_CMD_READ, offset);
@@ -181,7 +181,7 @@ static void eeprom_xec_data_read_32_bytes(struct eeprom_xec_regs * const regs,
 }
 
 static void eeprom_xec_data_write_32_bytes(struct eeprom_xec_regs * const regs,
-							uint8_t *buf, size_t len, off_t offset)
+							uint8_t *buf, size_t len, k_off_t offset)
 {
 	uint16_t sz;
 	uint16_t rem_bytes;
@@ -220,7 +220,7 @@ static void eeprom_xec_data_write_32_bytes(struct eeprom_xec_regs * const regs,
 	eeprom_xec_wait_write_compl(regs);
 }
 
-static int eeprom_xec_read(const struct device *dev, off_t offset,
+static int eeprom_xec_read(const struct device *dev, k_off_t offset,
 				void *buf,
 				size_t len)
 {
@@ -257,7 +257,7 @@ static int eeprom_xec_read(const struct device *dev, off_t offset,
 	return 0;
 }
 
-static int eeprom_xec_write(const struct device *dev, off_t offset,
+static int eeprom_xec_write(const struct device *dev, k_off_t offset,
 				const void *buf, size_t len)
 {
 	const struct eeprom_xec_config *config = dev->config;

--- a/drivers/eeprom/eeprom_shell.c
+++ b/drivers/eeprom/eeprom_shell.c
@@ -11,6 +11,7 @@
  */
 
 #include <zephyr/shell/shell.h>
+#include <zephyr/types.h>
 #include <zephyr/drivers/eeprom.h>
 #include <stdlib.h>
 
@@ -75,7 +76,7 @@ static int cmd_write(const struct shell *sh, size_t argc, char **argv)
 	uint8_t rd_buf[CONFIG_EEPROM_SHELL_BUFFER_SIZE];
 	const struct device *eeprom;
 	unsigned long byte;
-	off_t offset;
+	k_off_t offset;
 	size_t len;
 	int err;
 	int i;

--- a/drivers/eeprom/eeprom_simulator.c
+++ b/drivers/eeprom/eeprom_simulator.c
@@ -95,8 +95,7 @@ static const char default_eeprom_file_path[] = "eeprom.bin";
 static uint8_t mock_eeprom[DT_INST_PROP(0, size)];
 #endif /* CONFIG_ARCH_POSIX */
 
-static int eeprom_range_is_valid(const struct device *dev, off_t offset,
-				 size_t len)
+static int eeprom_range_is_valid(const struct device *dev, k_off_t offset, size_t len)
 {
 	const struct eeprom_sim_config *config = dev->config;
 
@@ -107,8 +106,7 @@ static int eeprom_range_is_valid(const struct device *dev, off_t offset,
 	return 0;
 }
 
-static int eeprom_sim_read(const struct device *dev, off_t offset, void *data,
-			   size_t len)
+static int eeprom_sim_read(const struct device *dev, k_off_t offset, void *data, size_t len)
 {
 	if (!len) {
 		return 0;
@@ -136,9 +134,7 @@ static int eeprom_sim_read(const struct device *dev, off_t offset, void *data,
 	return 0;
 }
 
-static int eeprom_sim_write(const struct device *dev, off_t offset,
-			    const void *data,
-			    size_t len)
+static int eeprom_sim_write(const struct device *dev, k_off_t offset, const void *data, size_t len)
 {
 	const struct eeprom_sim_config *config = dev->config;
 

--- a/drivers/eeprom/eeprom_stm32.c
+++ b/drivers/eeprom/eeprom_stm32.c
@@ -21,7 +21,7 @@ struct eeprom_stm32_config {
 	size_t size;
 };
 
-static int eeprom_stm32_read(const struct device *dev, off_t offset,
+static int eeprom_stm32_read(const struct device *dev, k_off_t offset,
 				void *buf,
 				size_t len)
 {
@@ -52,7 +52,7 @@ static int eeprom_stm32_read(const struct device *dev, off_t offset,
 	return 0;
 }
 
-static int eeprom_stm32_write(const struct device *dev, off_t offset,
+static int eeprom_stm32_write(const struct device *dev, k_off_t offset,
 				const void *buf, size_t len)
 {
 	const struct eeprom_stm32_config *config = dev->config;

--- a/drivers/eeprom/eeprom_tmp116.c
+++ b/drivers/eeprom/eeprom_tmp116.c
@@ -26,7 +26,7 @@ static size_t eeprom_tmp116_size(const struct device *dev)
 	return EEPROM_TMP116_SIZE;
 }
 
-static int eeprom_tmp116_write(const struct device *dev, off_t offset,
+static int eeprom_tmp116_write(const struct device *dev, k_off_t offset,
 			       const void *data, size_t len)
 {
 	const struct eeprom_tmp116_config *config = dev->config;
@@ -34,7 +34,7 @@ static int eeprom_tmp116_write(const struct device *dev, off_t offset,
 	return tmp116_eeprom_write(config->parent, offset, data, len);
 }
 
-static int eeprom_tmp116_read(const struct device *dev, off_t offset, void *data,
+static int eeprom_tmp116_read(const struct device *dev, k_off_t offset, void *data,
 			      size_t len)
 {
 	const struct eeprom_tmp116_config *config = dev->config;

--- a/drivers/ethernet/eth_cyclonev.c
+++ b/drivers/ethernet/eth_cyclonev.c
@@ -26,7 +26,6 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include "phy_cyclonev.c"
 #include <ethernet/eth_stats.h>
-#include <sys/types.h>
 #include <zephyr/irq.h>
 #define TX_AVAIL_WAIT	    K_MSEC(1)
 #define INC_WRAP(idx, size) ({ idx = (idx + 1) % size; })

--- a/drivers/ethernet/eth_dwmac.c
+++ b/drivers/ethernet/eth_dwmac.c
@@ -12,7 +12,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
-#include <sys/types.h>
 #include <zephyr/kernel.h>
 #include <zephyr/cache.h>
 #include <zephyr/net/ethernet.h>

--- a/drivers/ethernet/eth_dwmac_mmu.c
+++ b/drivers/ethernet/eth_dwmac_mmu.c
@@ -14,7 +14,6 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #define DT_DRV_COMPAT snps_designware_ethernet
 
-#include <sys/types.h>
 #include <zephyr/kernel/mm.h>
 #include <zephyr/kernel.h>
 #include <zephyr/cache.h>

--- a/drivers/ethernet/eth_dwmac_stm32h7x.c
+++ b/drivers/ethernet/eth_dwmac_stm32h7x.c
@@ -17,7 +17,6 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 /* be compatible with the HAL-based driver here */
 #define DT_DRV_COMPAT st_stm32_ethernet
 
-#include <sys/types.h>
 #include <zephyr/kernel.h>
 #include <zephyr/net/ethernet.h>
 #include <ethernet/eth.h>

--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -11,7 +11,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
-#include <sys/types.h>
 #include <zephyr/kernel.h>
 #include <zephyr/net/ethernet.h>
 #include <ethernet/eth_stats.h>
@@ -134,7 +133,7 @@ static struct net_pkt *e1000_rx(struct e1000_dev *dev)
 {
 	struct net_pkt *pkt = NULL;
 	void *buf;
-	ssize_t len;
+	k_ssize_t len;
 
 	LOG_DBG("rx.sta: 0x%02hx", dev->rx.sta);
 

--- a/drivers/ethernet/phy_cyclonev.c
+++ b/drivers/ethernet/phy_cyclonev.c
@@ -13,11 +13,10 @@
 /* According to default Cyclone V DevKit Bootstrap Encoding Scheme */
 #include "eth_cyclonev_priv.h"
 
+#include <stdint.h>
 #include <stdio.h>
 
 #include <zephyr/kernel.h>
-
-#include <sys/types.h>
 
 #define PHY_ADDR (4)
 

--- a/drivers/flash/flash_ambiq.c
+++ b/drivers/flash/flash_ambiq.c
@@ -55,7 +55,7 @@ static const struct flash_parameters flash_ambiq_parameters = {
 #endif
 };
 
-static bool flash_ambiq_valid_range(off_t offset, size_t len)
+static bool flash_ambiq_valid_range(k_off_t offset, size_t len)
 {
 	if ((offset < 0) || offset >= SOC_NV_FLASH_SIZE || (SOC_NV_FLASH_SIZE - offset) < len) {
 		return false;
@@ -64,7 +64,7 @@ static bool flash_ambiq_valid_range(off_t offset, size_t len)
 	return true;
 }
 
-static int flash_ambiq_read(const struct device *dev, off_t offset, void *data, size_t len)
+static int flash_ambiq_read(const struct device *dev, k_off_t offset, void *data, size_t len)
 {
 	ARG_UNUSED(dev);
 
@@ -76,12 +76,12 @@ static int flash_ambiq_read(const struct device *dev, off_t offset, void *data, 
 		return 0;
 	}
 
-	memcpy(data, (uint8_t *)(SOC_NV_FLASH_ADDR + offset), len);
+	memcpy(data, (uint8_t *)(SOC_NV_FLASH_ADDR + (uintptr_t)offset), len);
 
 	return 0;
 }
 
-static int flash_ambiq_write(const struct device *dev, off_t offset, const void *data, size_t len)
+static int flash_ambiq_write(const struct device *dev, k_off_t offset, const void *data, size_t len)
 {
 	ARG_UNUSED(dev);
 
@@ -114,15 +114,15 @@ static int flash_ambiq_write(const struct device *dev, off_t offset, const void 
 			src++;
 		}
 #if (CONFIG_SOC_SERIES_APOLLO4X)
-		ret = am_hal_mram_main_program(
-			AM_HAL_MRAM_PROGRAM_KEY, aligned,
-			(uint32_t *)(SOC_NV_FLASH_ADDR + offset + i * FLASH_WRITE_BLOCK_SIZE),
-			FLASH_WRITE_BLOCK_SIZE / sizeof(uint32_t));
+		ret = am_hal_mram_main_program(AM_HAL_MRAM_PROGRAM_KEY, aligned,
+					       (uint32_t *)(SOC_NV_FLASH_ADDR + (uintptr_t)offset +
+							    i * FLASH_WRITE_BLOCK_SIZE),
+					       FLASH_WRITE_BLOCK_SIZE / sizeof(uint32_t));
 #elif (CONFIG_SOC_SERIES_APOLLO3X)
-		ret = am_hal_flash_program_main(
-			AM_HAL_FLASH_PROGRAM_KEY, aligned,
-			(uint32_t *)(SOC_NV_FLASH_ADDR + offset + i * FLASH_WRITE_BLOCK_SIZE),
-			FLASH_WRITE_BLOCK_SIZE / sizeof(uint32_t));
+		ret = am_hal_flash_program_main(AM_HAL_FLASH_PROGRAM_KEY, aligned,
+						(uint32_t *)(SOC_NV_FLASH_ADDR + (uintptr_t)offset +
+							     i * FLASH_WRITE_BLOCK_SIZE),
+						FLASH_WRITE_BLOCK_SIZE / sizeof(uint32_t));
 #endif /* CONFIG_SOC_SERIES_APOLLO4X */
 		if (ret) {
 			break;
@@ -136,7 +136,7 @@ static int flash_ambiq_write(const struct device *dev, off_t offset, const void 
 	return ret;
 }
 
-static int flash_ambiq_erase(const struct device *dev, off_t offset, size_t len)
+static int flash_ambiq_erase(const struct device *dev, k_off_t offset, size_t len)
 {
 	ARG_UNUSED(dev);
 

--- a/drivers/flash/flash_andes_qspi.c
+++ b/drivers/flash/flash_andes_qspi.c
@@ -129,7 +129,7 @@ static inline uint16_t dev_page_size(const struct device *dev)
  * @return 0 on success
  */
 static int flash_andes_qspi_access(const struct device *const dev,
-				   uint8_t opcode, uint8_t access, off_t addr,
+				   uint8_t opcode, uint8_t access, k_off_t addr,
 				   void *data, size_t length)
 {
 	struct flash_andes_qspi_data *dev_data = dev->data;
@@ -262,7 +262,7 @@ static int flash_andes_qspi_wait_until_ready(const struct device *dev)
  * @return 0 on success, negative errno code otherwise
  */
 static int read_sfdp(const struct device *const dev,
-		     off_t addr, void *data, size_t length)
+		     k_off_t addr, void *data, size_t length)
 {
 	/* READ_SFDP requires a 24-bit address followed by a single
 	 * byte for a wait state.  This is effected by using 32-bit
@@ -301,7 +301,7 @@ static int flash_andes_qspi_wrsr(const struct device *dev,
 }
 
 static int flash_andes_qspi_read(const struct device *dev,
-				 off_t addr, void *dest, size_t size)
+				 k_off_t addr, void *dest, size_t size)
 {
 	const size_t flash_size = dev_flash_size(dev);
 	int ret;
@@ -324,7 +324,7 @@ static int flash_andes_qspi_read(const struct device *dev,
 	return ret;
 }
 
-static int flash_andes_qspi_write(const struct device *dev, off_t addr,
+static int flash_andes_qspi_write(const struct device *dev, k_off_t addr,
 				  const void *src, size_t size)
 {
 	const size_t flash_size = dev_flash_size(dev);
@@ -380,7 +380,7 @@ out:
 }
 
 static int flash_andes_qspi_erase(const struct device *dev,
-				  off_t addr, size_t size)
+				  k_off_t addr, size_t size)
 {
 	const size_t flash_size = dev_flash_size(dev);
 	int ret = 0;
@@ -472,7 +472,7 @@ static int flash_andes_qspi_write_protection_set(const struct device *dev,
 
 #if defined(CONFIG_FLASH_JESD216_API)
 
-static int flash_andes_qspi_sfdp_read(const struct device *dev, off_t addr,
+static int flash_andes_qspi_sfdp_read(const struct device *dev, k_off_t addr,
 				      void *dest, size_t size)
 {
 	acquire_device(dev);

--- a/drivers/flash/flash_cadence_nand.c
+++ b/drivers/flash/flash_cadence_nand.c
@@ -81,7 +81,7 @@ void flash_cdns_page_layout(const struct device *nand_dev, const struct flash_pa
 
 #endif
 
-static int flash_cdns_nand_erase(const struct device *nand_dev, off_t offset, size_t len)
+static int flash_cdns_nand_erase(const struct device *nand_dev, k_off_t offset, size_t len)
 {
 	struct flash_cadence_nand_data *const nand_data = DEV_DATA(nand_dev);
 	struct cadence_nand_params *nand_param = &nand_data->params;
@@ -96,7 +96,7 @@ static int flash_cdns_nand_erase(const struct device *nand_dev, off_t offset, si
 	return ret;
 }
 
-static int flash_cdns_nand_write(const struct device *nand_dev, off_t offset, const void *data,
+static int flash_cdns_nand_write(const struct device *nand_dev, k_off_t offset, const void *data,
 				 size_t len)
 {
 	struct flash_cadence_nand_data *const nand_data = DEV_DATA(nand_dev);
@@ -117,7 +117,8 @@ static int flash_cdns_nand_write(const struct device *nand_dev, off_t offset, co
 	return ret;
 }
 
-static int flash_cdns_nand_read(const struct device *nand_dev, off_t offset, void *data, size_t len)
+static int flash_cdns_nand_read(const struct device *nand_dev, k_off_t offset, void *data,
+				size_t len)
 {
 	struct flash_cadence_nand_data *const nand_data = DEV_DATA(nand_dev);
 	struct cadence_nand_params *nand_param = &nand_data->params;

--- a/drivers/flash/flash_cadence_qspi_nor.c
+++ b/drivers/flash/flash_cadence_qspi_nor.c
@@ -35,7 +35,7 @@ static const struct flash_parameters flash_cad_parameters = {
 #define DEV_DATA(dev)	((struct flash_cad_priv *)((dev)->data))
 #define DEV_CFG(dev)	((struct flash_cad_config *)((dev)->config))
 
-static int flash_cad_read(const struct device *dev, off_t offset,
+static int flash_cad_read(const struct device *dev, k_off_t offset,
 				void *data, size_t len)
 {
 	struct flash_cad_priv *priv = dev->data;
@@ -57,7 +57,7 @@ static int flash_cad_read(const struct device *dev, off_t offset,
 	return 0;
 }
 
-static int flash_cad_erase(const struct device *dev, off_t offset,
+static int flash_cad_erase(const struct device *dev, k_off_t offset,
 				size_t len)
 {
 	struct flash_cad_priv *priv = dev->data;
@@ -79,7 +79,7 @@ static int flash_cad_erase(const struct device *dev, off_t offset,
 	return 0;
 }
 
-static int flash_cad_write(const struct device *dev, off_t offset,
+static int flash_cad_write(const struct device *dev, k_off_t offset,
 				const void *data, size_t len)
 {
 	struct flash_cad_priv *priv = dev->data;

--- a/drivers/flash/flash_esp32.c
+++ b/drivers/flash/flash_esp32.c
@@ -69,7 +69,7 @@ static inline void flash_esp32_sem_give(const struct device *dev)
 
 #endif /* CONFIG_MULTITHREADING */
 
-static int flash_esp32_read(const struct device *dev, off_t address, void *buffer, size_t length)
+static int flash_esp32_read(const struct device *dev, k_off_t address, void *buffer, size_t length)
 {
 	int ret = 0;
 
@@ -88,7 +88,7 @@ static int flash_esp32_read(const struct device *dev, off_t address, void *buffe
 }
 
 static int flash_esp32_write(const struct device *dev,
-			     off_t address,
+			     k_off_t address,
 			     const void *buffer,
 			     size_t length)
 {
@@ -109,7 +109,7 @@ static int flash_esp32_write(const struct device *dev,
 	return 0;
 }
 
-static int flash_esp32_erase(const struct device *dev, off_t start, size_t len)
+static int flash_esp32_erase(const struct device *dev, k_off_t start, size_t len)
 {
 	flash_esp32_sem_take(dev);
 	int ret = esp_flash_erase_region(NULL, start, len);

--- a/drivers/flash/flash_gd32.c
+++ b/drivers/flash/flash_gd32.c
@@ -28,7 +28,7 @@ static const struct flash_parameters flash_gd32_parameters = {
 	.erase_value = 0xff,
 };
 
-static int flash_gd32_read(const struct device *dev, off_t offset,
+static int flash_gd32_read(const struct device *dev, k_off_t offset,
 			   void *data, size_t len)
 {
 	if ((offset > SOC_NV_FLASH_SIZE) ||
@@ -45,7 +45,7 @@ static int flash_gd32_read(const struct device *dev, off_t offset,
 	return 0;
 }
 
-static int flash_gd32_write(const struct device *dev, off_t offset,
+static int flash_gd32_write(const struct device *dev, k_off_t offset,
 			    const void *data, size_t len)
 {
 	struct flash_gd32_data *dev_data = dev->data;
@@ -68,7 +68,7 @@ static int flash_gd32_write(const struct device *dev, off_t offset,
 	return ret;
 }
 
-static int flash_gd32_erase(const struct device *dev, off_t offset, size_t size)
+static int flash_gd32_erase(const struct device *dev, k_off_t offset, size_t size)
 {
 	struct flash_gd32_data *data = dev->data;
 	int ret = 0;

--- a/drivers/flash/flash_gd32.h
+++ b/drivers/flash/flash_gd32.h
@@ -29,11 +29,11 @@ typedef uint8_t flash_prg_t;
 /* Helper for conditional compilation directives, KB cannot be used because it has type casting. */
 #define PRE_KB(x) ((x) << 10)
 
-bool flash_gd32_valid_range(off_t offset, uint32_t len, bool write);
+bool flash_gd32_valid_range(k_off_t offset, uint32_t len, bool write);
 
-int flash_gd32_write_range(off_t offset, const void *data, size_t len);
+int flash_gd32_write_range(k_off_t offset, const void *data, size_t len);
 
-int flash_gd32_erase_block(off_t offset, size_t size);
+int flash_gd32_erase_block(k_off_t offset, size_t size);
 
 #ifdef CONFIG_FLASH_PAGE_LAYOUT
 void flash_gd32_pages_layout(const struct device *dev,

--- a/drivers/flash/flash_gd32_v1.c
+++ b/drivers/flash/flash_gd32_v1.c
@@ -62,7 +62,7 @@ static int gd32_fmc_v1_wait_idle(void)
 	return 0;
 }
 
-bool flash_gd32_valid_range(off_t offset, uint32_t len, bool write)
+bool flash_gd32_valid_range(k_off_t offset, uint32_t len, bool write)
 {
 	if ((offset > SOC_NV_FLASH_SIZE) ||
 	    ((offset + len) > SOC_NV_FLASH_SIZE)) {
@@ -94,7 +94,7 @@ bool flash_gd32_valid_range(off_t offset, uint32_t len, bool write)
 	return true;
 }
 
-int flash_gd32_write_range(off_t offset, const void *data, size_t len)
+int flash_gd32_write_range(k_off_t offset, const void *data, size_t len)
 {
 	flash_prg_t *prg_flash = (flash_prg_t *)((uint8_t *)SOC_NV_FLASH_ADDR + offset);
 	flash_prg_t *prg_data = (flash_prg_t *)data;
@@ -166,7 +166,7 @@ expired_out:
 	return ret;
 }
 
-int flash_gd32_erase_block(off_t offset, size_t size)
+int flash_gd32_erase_block(k_off_t offset, size_t size)
 {
 	uint32_t page_addr = SOC_NV_FLASH_ADDR + offset;
 	int ret = 0;

--- a/drivers/flash/flash_gd32_v2.c
+++ b/drivers/flash/flash_gd32_v2.c
@@ -93,7 +93,7 @@ static int gd32_fmc_v2_bank0_wait_idle(void)
 	return 0;
 }
 
-static int gd32_fmc_v2_bank0_write(off_t offset, const void *data, size_t len)
+static int gd32_fmc_v2_bank0_write(k_off_t offset, const void *data, size_t len)
 {
 	flash_prg_t *prg_flash = (flash_prg_t *)((uint8_t *)SOC_NV_FLASH_ADDR + offset);
 	flash_prg_t *prg_data = (flash_prg_t *)data;
@@ -165,7 +165,7 @@ expired_out:
 	return ret;
 }
 
-static int gd32_fmc_v2_bank0_erase_block(off_t offset, size_t size)
+static int gd32_fmc_v2_bank0_erase_block(k_off_t offset, size_t size)
 {
 	uint32_t page_addr = SOC_NV_FLASH_ADDR + offset;
 	int ret = 0;
@@ -208,7 +208,7 @@ static int gd32_fmc_v2_bank1_wait_idle(void)
 	return 0;
 }
 
-static int gd32_fmc_v2_bank1_write(off_t offset, const void *data, size_t len)
+static int gd32_fmc_v2_bank1_write(k_off_t offset, const void *data, size_t len)
 {
 	flash_prg_t *prg_flash = (flash_prg_t *)((uint8_t *)SOC_NV_FLASH_ADDR + offset);
 	flash_prg_t *prg_data = (flash_prg_t *)data;
@@ -280,7 +280,7 @@ expired_out:
 	return ret;
 }
 
-static int gd32_fmc_v2_bank1_erase_block(off_t offset, size_t size)
+static int gd32_fmc_v2_bank1_erase_block(k_off_t offset, size_t size)
 {
 	uint32_t page_addr = SOC_NV_FLASH_ADDR + offset;
 	int ret = 0;
@@ -299,7 +299,7 @@ static int gd32_fmc_v2_bank1_erase_block(off_t offset, size_t size)
 }
 #endif /* GD32_NV_FLASH_V2_BANK1_SIZE */
 
-bool flash_gd32_valid_range(off_t offset, uint32_t len, bool write)
+bool flash_gd32_valid_range(k_off_t offset, uint32_t len, bool write)
 {
 	if ((offset > SOC_NV_FLASH_SIZE) ||
 	    ((offset + len) > SOC_NV_FLASH_SIZE)) {
@@ -345,7 +345,7 @@ bool flash_gd32_valid_range(off_t offset, uint32_t len, bool write)
 	return true;
 }
 
-int flash_gd32_write_range(off_t offset, const void *data, size_t len)
+int flash_gd32_write_range(k_off_t offset, const void *data, size_t len)
 {
 	size_t len0 = 0U;
 	int ret = 0;
@@ -384,7 +384,7 @@ int flash_gd32_write_range(off_t offset, const void *data, size_t len)
 	return 0;
 }
 
-int flash_gd32_erase_block(off_t offset, size_t size)
+int flash_gd32_erase_block(k_off_t offset, size_t size)
 {
 	size_t size0 = 0U;
 	int ret = 0;

--- a/drivers/flash/flash_gd32_v3.c
+++ b/drivers/flash/flash_gd32_v3.c
@@ -90,7 +90,7 @@ static int gd32_fmc_v3_wait_idle(void)
 	return 0;
 }
 
-bool flash_gd32_valid_range(off_t offset, uint32_t len, bool write)
+bool flash_gd32_valid_range(k_off_t offset, uint32_t len, bool write)
 {
 	const struct flash_pages_layout *page_layout;
 	uint32_t cur = 0U, next = 0U;
@@ -137,7 +137,7 @@ bool flash_gd32_valid_range(off_t offset, uint32_t len, bool write)
 	return true;
 }
 
-int flash_gd32_write_range(off_t offset, const void *data, size_t len)
+int flash_gd32_write_range(k_off_t offset, const void *data, size_t len)
 {
 	flash_prg_t *prg_flash = (flash_prg_t *)((uint8_t *)SOC_NV_FLASH_ADDR + offset);
 	flash_prg_t *prg_data = (flash_prg_t *)data;
@@ -213,7 +213,7 @@ expired_out:
 	return ret;
 }
 
-int flash_gd32_erase_block(off_t offset, size_t size)
+int flash_gd32_erase_block(k_off_t offset, size_t size)
 {
 	const struct flash_pages_layout *page_layout;
 	uint32_t erase_offset = 0U;

--- a/drivers/flash/flash_gecko.c
+++ b/drivers/flash/flash_gecko.c
@@ -30,12 +30,12 @@ static const struct flash_parameters flash_gecko_parameters = {
 	.erase_value = 0xff,
 };
 
-static bool write_range_is_valid(off_t offset, uint32_t size);
-static bool read_range_is_valid(off_t offset, uint32_t size);
-static int erase_flash_block(off_t offset, size_t size);
+static bool write_range_is_valid(k_off_t offset, uint32_t size);
+static bool read_range_is_valid(k_off_t offset, uint32_t size);
+static int erase_flash_block(k_off_t offset, size_t size);
 static void flash_gecko_write_protection(bool enable);
 
-static int flash_gecko_read(const struct device *dev, off_t offset,
+static int flash_gecko_read(const struct device *dev, k_off_t offset,
 			    void *data,
 			    size_t size)
 {
@@ -52,7 +52,7 @@ static int flash_gecko_read(const struct device *dev, off_t offset,
 	return 0;
 }
 
-static int flash_gecko_write(const struct device *dev, off_t offset,
+static int flash_gecko_write(const struct device *dev, k_off_t offset,
 			     const void *data, size_t size)
 {
 	struct flash_gecko_data *const dev_data = dev->data;
@@ -83,7 +83,7 @@ static int flash_gecko_write(const struct device *dev, off_t offset,
 	return ret;
 }
 
-static int flash_gecko_erase(const struct device *dev, off_t offset,
+static int flash_gecko_erase(const struct device *dev, k_off_t offset,
 			     size_t size)
 {
 	struct flash_gecko_data *const dev_data = dev->data;
@@ -137,25 +137,25 @@ static void flash_gecko_write_protection(bool enable)
  * - A flash address to write to must be aligned to words.
  * - Number of bytes to write must be divisible by 4.
  */
-static bool write_range_is_valid(off_t offset, uint32_t size)
+static bool write_range_is_valid(k_off_t offset, uint32_t size)
 {
 	return read_range_is_valid(offset, size)
 		&& (offset % sizeof(uint32_t) == 0)
 		&& (size % 4 == 0U);
 }
 
-static bool read_range_is_valid(off_t offset, uint32_t size)
+static bool read_range_is_valid(k_off_t offset, uint32_t size)
 {
 	return (offset + size) <= (CONFIG_FLASH_SIZE * 1024);
 }
 
-static int erase_flash_block(off_t offset, size_t size)
+static int erase_flash_block(k_off_t offset, size_t size)
 {
 	MSC_Status_TypeDef msc_ret;
 	void *address;
 	int ret = 0;
 
-	for (off_t tmp = offset; tmp < offset + size; tmp += FLASH_PAGE_SIZE) {
+	for (k_off_t tmp = offset; tmp < offset + size; tmp += FLASH_PAGE_SIZE) {
 		address = (uint8_t *)CONFIG_FLASH_BASE_ADDRESS + tmp;
 		msc_ret = MSC_ErasePage(address);
 		if (msc_ret < 0) {

--- a/drivers/flash/flash_handlers.c
+++ b/drivers/flash/flash_handlers.c
@@ -7,7 +7,7 @@
 #include <zephyr/internal/syscall_handler.h>
 #include <zephyr/drivers/flash.h>
 
-static inline int z_vrfy_flash_read(const struct device *dev, off_t offset,
+static inline int z_vrfy_flash_read(const struct device *dev, k_off_t offset,
 				    void *data, size_t len)
 {
 	K_OOPS(K_SYSCALL_DRIVER_FLASH(dev, read));
@@ -18,7 +18,7 @@ static inline int z_vrfy_flash_read(const struct device *dev, off_t offset,
 }
 #include <zephyr/syscalls/flash_read_mrsh.c>
 
-static inline int z_vrfy_flash_write(const struct device *dev, off_t offset,
+static inline int z_vrfy_flash_write(const struct device *dev, k_off_t offset,
 				     const void *data, size_t len)
 {
 	K_OOPS(K_SYSCALL_DRIVER_FLASH(dev, write));
@@ -28,7 +28,7 @@ static inline int z_vrfy_flash_write(const struct device *dev, off_t offset,
 }
 #include <zephyr/syscalls/flash_write_mrsh.c>
 
-static inline int z_vrfy_flash_erase(const struct device *dev, off_t offset,
+static inline int z_vrfy_flash_erase(const struct device *dev, k_off_t offset,
 				     size_t size)
 {
 	K_OOPS(K_SYSCALL_DRIVER_FLASH(dev, erase));
@@ -50,7 +50,7 @@ static inline const struct flash_parameters *z_vrfy_flash_get_parameters(const s
 }
 #include <zephyr/syscalls/flash_get_parameters_mrsh.c>
 
-int z_vrfy_flash_fill(const struct device *dev, uint8_t val, off_t offset,
+int z_vrfy_flash_fill(const struct device *dev, uint8_t val, k_off_t offset,
 		      size_t size)
 {
 	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_FLASH));
@@ -58,7 +58,7 @@ int z_vrfy_flash_fill(const struct device *dev, uint8_t val, off_t offset,
 }
 #include <zephyr/syscalls/flash_fill_mrsh.c>
 
-int z_vrfy_flash_flatten(const struct device *dev, off_t offset, size_t size)
+int z_vrfy_flash_flatten(const struct device *dev, k_off_t offset, size_t size)
 {
 	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_FLASH));
 	return z_impl_flash_flatten(dev, offset, size);
@@ -68,7 +68,7 @@ int z_vrfy_flash_flatten(const struct device *dev, off_t offset, size_t size)
 
 #ifdef CONFIG_FLASH_PAGE_LAYOUT
 static inline int z_vrfy_flash_get_page_info_by_offs(const struct device *dev,
-						     off_t offs,
+						     k_off_t offs,
 						     struct flash_pages_info *info)
 {
 	K_OOPS(K_SYSCALL_DRIVER_FLASH(dev, page_layout));
@@ -103,7 +103,7 @@ static inline size_t z_vrfy_flash_get_page_count(const struct device *dev)
 #ifdef CONFIG_FLASH_JESD216_API
 
 static inline int z_vrfy_flash_sfdp_read(const struct device *dev,
-					 off_t offset,
+					 k_off_t offset,
 					 void *data, size_t len)
 {
 	K_OOPS(K_SYSCALL_DRIVER_FLASH(dev, sfdp_read));

--- a/drivers/flash/flash_ifx_cat1.c
+++ b/drivers/flash/flash_ifx_cat1.c
@@ -50,7 +50,8 @@ static inline void flash_ifx_sem_give(const struct device *dev)
 	k_sem_give(&data->sem);
 }
 
-static int ifx_cat1_flash_read(const struct device *dev, off_t offset, void *data, size_t data_len)
+static int ifx_cat1_flash_read(const struct device *dev, k_off_t offset, void *data,
+			       size_t data_len)
 {
 	struct ifx_cat1_flash_data *dev_data = dev->data;
 	const struct ifx_cat1_flash_config *dev_config = dev->config;
@@ -72,7 +73,7 @@ out:
 	return ret;
 }
 
-static int ifx_cat1_flash_write(const struct device *dev, off_t offset, const void *data,
+static int ifx_cat1_flash_write(const struct device *dev, k_off_t offset, const void *data,
 				size_t data_len)
 {
 	struct ifx_cat1_flash_data *dev_data = dev->data;
@@ -111,7 +112,7 @@ out:
 	return ret;
 }
 
-static int ifx_cat1_flash_erase(const struct device *dev, off_t offset, size_t size)
+static int ifx_cat1_flash_erase(const struct device *dev, k_off_t offset, size_t size)
 {
 	struct ifx_cat1_flash_data *data = dev->data;
 	const struct ifx_cat1_flash_config *config = dev->config;

--- a/drivers/flash/flash_ite_it8xxx2.c
+++ b/drivers/flash/flash_ite_it8xxx2.c
@@ -340,7 +340,7 @@ void __soc_ram_code ramcode_flash_erase(int addr, int cmd)
 }
 
 /* Read data from flash */
-static int __soc_ram_code flash_it8xxx2_read(const struct device *dev, off_t offset, void *data,
+static int __soc_ram_code flash_it8xxx2_read(const struct device *dev, k_off_t offset, void *data,
 					     size_t len)
 {
 	struct smfi_it8xxx2_regs *const flash_regs = FLASH_IT8XXX2_REG_BASE;
@@ -366,7 +366,7 @@ static int __soc_ram_code flash_it8xxx2_read(const struct device *dev, off_t off
 }
 
 /* Write data to the flash, page by page */
-static int __soc_ram_code flash_it8xxx2_write(const struct device *dev, off_t offset,
+static int __soc_ram_code flash_it8xxx2_write(const struct device *dev, k_off_t offset,
 					      const void *src_data, size_t len)
 {
 	struct flash_it8xxx2_dev_data *data = dev->data;
@@ -409,7 +409,7 @@ static int __soc_ram_code flash_it8xxx2_write(const struct device *dev, off_t of
 }
 
 /* Erase multiple blocks */
-static int __soc_ram_code flash_it8xxx2_erase(const struct device *dev, off_t offset, size_t len)
+static int __soc_ram_code flash_it8xxx2_erase(const struct device *dev, k_off_t offset, size_t len)
 {
 	struct flash_it8xxx2_dev_data *data = dev->data;
 	int v_size = len, v_addr = offset, ret = -EINVAL;

--- a/drivers/flash/flash_mcux_flexspi_hyperflash.c
+++ b/drivers/flash/flash_mcux_flexspi_hyperflash.c
@@ -370,7 +370,7 @@ static int flash_flexspi_hyperflash_check_vendor_id(const struct device *dev)
 	return ret;
 }
 
-static int flash_flexspi_hyperflash_page_program(const struct device *dev, off_t
+static int flash_flexspi_hyperflash_page_program(const struct device *dev, k_off_t
 		offset, const void *buffer, size_t len)
 {
 	struct flash_flexspi_hyperflash_data *data = dev->data;
@@ -390,7 +390,7 @@ static int flash_flexspi_hyperflash_page_program(const struct device *dev, off_t
 	return memc_flexspi_transfer(&data->controller, &transfer);
 }
 
-static int flash_flexspi_hyperflash_read(const struct device *dev, off_t offset,
+static int flash_flexspi_hyperflash_read(const struct device *dev, k_off_t offset,
 		void *buffer, size_t len)
 {
 	struct flash_flexspi_hyperflash_data *data = dev->data;
@@ -407,7 +407,7 @@ static int flash_flexspi_hyperflash_read(const struct device *dev, off_t offset,
 	return 0;
 }
 
-static int flash_flexspi_hyperflash_write(const struct device *dev, off_t offset,
+static int flash_flexspi_hyperflash_write(const struct device *dev, k_off_t offset,
 		const void *buffer, size_t len)
 {
 	struct flash_flexspi_hyperflash_data *data = dev->data;
@@ -494,7 +494,7 @@ static int flash_flexspi_hyperflash_write(const struct device *dev, off_t offset
 	return ret;
 }
 
-static int flash_flexspi_hyperflash_erase(const struct device *dev, off_t offset, size_t size)
+static int flash_flexspi_hyperflash_erase(const struct device *dev, k_off_t offset, size_t size)
 {
 	struct flash_flexspi_hyperflash_data *data = dev->data;
 	flexspi_transfer_t transfer;

--- a/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
+++ b/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
@@ -267,7 +267,7 @@ static int flash_flexspi_nor_write_enable(const struct device *dev,
 }
 
 static int flash_flexspi_nor_erase_sector(const struct device *dev,
-		off_t offset)
+		k_off_t offset)
 {
 	struct flash_flexspi_nor_data *data = dev->data;
 
@@ -281,7 +281,7 @@ static int flash_flexspi_nor_erase_sector(const struct device *dev,
 		.dataSize = 0,
 	};
 
-	LOG_DBG("Erasing sector at 0x%08zx", (ssize_t) offset);
+	LOG_DBG("Erasing sector at 0x%08zx", (k_ssize_t) offset);
 
 	return memc_flexspi_transfer(data->controller, &transfer);
 }
@@ -306,7 +306,7 @@ static int flash_flexspi_nor_erase_chip(const struct device *dev)
 }
 
 static int flash_flexspi_nor_page_program(const struct device *dev,
-		off_t offset, const void *buffer, size_t len)
+		k_off_t offset, const void *buffer, size_t len)
 {
 	struct flash_flexspi_nor_data *data = dev->data;
 
@@ -320,7 +320,7 @@ static int flash_flexspi_nor_page_program(const struct device *dev,
 		.dataSize = len,
 	};
 
-	LOG_DBG("Page programming %d bytes to 0x%08zx", len, (ssize_t) offset);
+	LOG_DBG("Page programming %d bytes to 0x%08zx", len, (k_ssize_t) offset);
 
 	return memc_flexspi_transfer(data->controller, &transfer);
 }
@@ -356,7 +356,7 @@ static int flash_flexspi_enable_octal_mode(const struct device *dev)
 	return 0;
 }
 
-static int flash_flexspi_nor_read(const struct device *dev, off_t offset,
+static int flash_flexspi_nor_read(const struct device *dev, k_off_t offset,
 		void *buffer, size_t len)
 {
 	struct flash_flexspi_nor_data *data = dev->data;
@@ -369,7 +369,7 @@ static int flash_flexspi_nor_read(const struct device *dev, off_t offset,
 	return 0;
 }
 
-static int flash_flexspi_nor_write(const struct device *dev, off_t offset,
+static int flash_flexspi_nor_write(const struct device *dev, k_off_t offset,
 		const void *buffer, size_t len)
 {
 	struct flash_flexspi_nor_data *data = dev->data;
@@ -431,7 +431,7 @@ static int flash_flexspi_nor_write(const struct device *dev, off_t offset,
 	return 0;
 }
 
-static int flash_flexspi_nor_erase(const struct device *dev, off_t offset,
+static int flash_flexspi_nor_erase(const struct device *dev, k_off_t offset,
 		size_t size)
 {
 	struct flash_flexspi_nor_data *data = dev->data;

--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -208,7 +208,7 @@ static int flash_flexspi_nor_write_enable(struct flash_flexspi_nor_data *data)
 }
 
 static int flash_flexspi_nor_erase_sector(struct flash_flexspi_nor_data *data,
-	off_t offset)
+	k_off_t offset)
 {
 	flexspi_transfer_t transfer = {
 		.deviceAddress = offset,
@@ -220,13 +220,13 @@ static int flash_flexspi_nor_erase_sector(struct flash_flexspi_nor_data *data,
 		.dataSize = 0,
 	};
 
-	LOG_DBG("Erasing sector at 0x%08zx", (ssize_t) offset);
+	LOG_DBG("Erasing sector at 0x%08zx", (k_ssize_t) offset);
 
 	return memc_flexspi_transfer(&data->controller, &transfer);
 }
 
 static int flash_flexspi_nor_erase_block(struct flash_flexspi_nor_data *data,
-					  off_t offset)
+					  k_off_t offset)
 {
 	flexspi_transfer_t transfer = {
 		.deviceAddress = offset,
@@ -238,7 +238,7 @@ static int flash_flexspi_nor_erase_block(struct flash_flexspi_nor_data *data,
 		.dataSize = 0,
 	};
 
-	LOG_DBG("Erasing block at 0x%08zx", (ssize_t) offset);
+	LOG_DBG("Erasing block at 0x%08zx", (k_ssize_t) offset);
 
 	return memc_flexspi_transfer(&data->controller, &transfer);
 }
@@ -261,7 +261,7 @@ static int flash_flexspi_nor_erase_chip(struct flash_flexspi_nor_data *data)
 }
 
 static int flash_flexspi_nor_page_program(struct flash_flexspi_nor_data *data,
-		off_t offset, const void *buffer, size_t len)
+		k_off_t offset, const void *buffer, size_t len)
 {
 	flexspi_transfer_t transfer = {
 		.deviceAddress = offset,
@@ -273,7 +273,7 @@ static int flash_flexspi_nor_page_program(struct flash_flexspi_nor_data *data,
 		.dataSize = len,
 	};
 
-	LOG_DBG("Page programming %d bytes to 0x%08zx", len, (ssize_t) offset);
+	LOG_DBG("Page programming %d bytes to 0x%08zx", len, (k_ssize_t) offset);
 
 	return memc_flexspi_transfer(&data->controller, &transfer);
 }
@@ -305,7 +305,7 @@ static int flash_flexspi_nor_wait_bus_busy(struct flash_flexspi_nor_data *data)
 	return 0;
 }
 
-static int flash_flexspi_nor_read(const struct device *dev, off_t offset,
+static int flash_flexspi_nor_read(const struct device *dev, k_off_t offset,
 		void *buffer, size_t len)
 {
 	struct flash_flexspi_nor_data *data = dev->data;
@@ -318,7 +318,7 @@ static int flash_flexspi_nor_read(const struct device *dev, off_t offset,
 	return 0;
 }
 
-static int flash_flexspi_nor_write(const struct device *dev, off_t offset,
+static int flash_flexspi_nor_write(const struct device *dev, k_off_t offset,
 		const void *buffer, size_t len)
 {
 	struct flash_flexspi_nor_data *data = dev->data;
@@ -374,7 +374,7 @@ static int flash_flexspi_nor_write(const struct device *dev, off_t offset,
 	return 0;
 }
 
-static int flash_flexspi_nor_erase(const struct device *dev, off_t offset,
+static int flash_flexspi_nor_erase(const struct device *dev, k_off_t offset,
 		size_t size)
 {
 	struct flash_flexspi_nor_data *data = dev->data;
@@ -843,7 +843,7 @@ static int flash_flexspi_nor_config_flash(struct flash_flexspi_nor_data *data,
 
 /* Helper so we can avoid flash access while performing SFDP probe */
 static int flash_flexspi_nor_sfdp_read_helper(struct flash_flexspi_nor_data *dev_data,
-		off_t offset, void *data, size_t len)
+		k_off_t offset, void *data, size_t len)
 {
 	flexspi_transfer_t transfer = {
 		.deviceAddress = offset,
@@ -863,7 +863,7 @@ static int flash_flexspi_nor_sfdp_read_helper(struct flash_flexspi_nor_data *dev
 #if defined(CONFIG_FLASH_JESD216_API)
 
 static int flash_flexspi_nor_sfdp_read(const struct device *dev,
-		off_t offset, void *data, size_t len)
+		k_off_t offset, void *data, size_t len)
 {
 	struct flash_flexspi_nor_data *dev_data = dev->data;
 

--- a/drivers/flash/flash_mspi_atxp032.c
+++ b/drivers/flash/flash_mspi_atxp032.c
@@ -264,33 +264,33 @@ static int flash_mspi_atxp032_get_vendor_id(const struct device *flash, uint8_t 
 	return ret;
 }
 
-static int flash_mspi_atxp032_unprotect_sector(const struct device *flash, off_t addr)
+static int flash_mspi_atxp032_unprotect_sector(const struct device *flash, k_off_t addr)
 {
 	int ret;
 
-	LOG_DBG("unprotect sector at 0x%08zx", (ssize_t)addr);
+	LOG_DBG("unprotect sector at 0x%08zx", (k_ssize_t)addr);
 
 	ret = flash_mspi_atxp032_command_write(flash, 0x39, addr, 4, 0, NULL, 0);
 
 	return ret;
 }
 
-static int flash_mspi_atxp032_erase_sector(const struct device *flash, off_t addr)
+static int flash_mspi_atxp032_erase_sector(const struct device *flash, k_off_t addr)
 {
 	int ret;
 
-	LOG_DBG("Erasing sector at 0x%08zx", (ssize_t)addr);
+	LOG_DBG("Erasing sector at 0x%08zx", (k_ssize_t)addr);
 
 	ret = flash_mspi_atxp032_command_write(flash, SPI_NOR_CMD_SE, addr, 4, 0, NULL, 0);
 
 	return ret;
 }
 
-static int flash_mspi_atxp032_erase_block(const struct device *flash, off_t addr)
+static int flash_mspi_atxp032_erase_block(const struct device *flash, k_off_t addr)
 {
 	int ret;
 
-	LOG_DBG("Erasing block at 0x%08zx", (ssize_t)addr);
+	LOG_DBG("Erasing block at 0x%08zx", (k_ssize_t)addr);
 
 	ret = flash_mspi_atxp032_command_write(flash, SPI_NOR_CMD_BE, addr, 4, 0, NULL, 0);
 
@@ -308,7 +308,7 @@ static int flash_mspi_atxp032_erase_chip(const struct device *flash)
 	return ret;
 }
 
-static int flash_mspi_atxp032_page_program(const struct device *flash, off_t offset, void *wdata,
+static int flash_mspi_atxp032_page_program(const struct device *flash, k_off_t offset, void *wdata,
 					   size_t len)
 {
 	const struct flash_mspi_atxp032_config *cfg = flash->config;
@@ -332,7 +332,7 @@ static int flash_mspi_atxp032_page_program(const struct device *flash, off_t off
 	data->trans.num_packet        = 1;
 	data->trans.timeout           = CONFIG_MSPI_COMPLETION_TIMEOUT_TOLERANCE;
 
-	LOG_DBG("Page programming %d bytes to 0x%08zx", len, (ssize_t)offset);
+	LOG_DBG("Page programming %d bytes to 0x%08zx", len, (k_ssize_t)offset);
 
 	ret = mspi_transceive(cfg->bus, &cfg->dev_id, (const struct mspi_xfer *)&data->trans);
 	if (ret) {
@@ -387,7 +387,7 @@ static int flash_mspi_atxp032_busy_wait(const struct device *flash)
 	return ret;
 }
 
-static int flash_mspi_atxp032_read(const struct device *flash, off_t offset, void *rdata,
+static int flash_mspi_atxp032_read(const struct device *flash, k_off_t offset, void *rdata,
 				   size_t len)
 {
 	const struct flash_mspi_atxp032_config *cfg = flash->config;
@@ -414,7 +414,7 @@ static int flash_mspi_atxp032_read(const struct device *flash, off_t offset, voi
 	data->trans.num_packet        = 1;
 	data->trans.timeout           = CONFIG_MSPI_COMPLETION_TIMEOUT_TOLERANCE;
 
-	LOG_DBG("Read %d bytes from 0x%08zx", len, (ssize_t)offset);
+	LOG_DBG("Read %d bytes from 0x%08zx", len, (k_ssize_t)offset);
 
 	ret = mspi_transceive(cfg->bus, &cfg->dev_id, (const struct mspi_xfer *)&data->trans);
 	if (ret) {
@@ -427,7 +427,7 @@ static int flash_mspi_atxp032_read(const struct device *flash, off_t offset, voi
 	return ret;
 }
 
-static int flash_mspi_atxp032_write(const struct device *flash, off_t offset, const void *wdata,
+static int flash_mspi_atxp032_write(const struct device *flash, k_off_t offset, const void *wdata,
 				    size_t len)
 {
 	int ret;
@@ -473,7 +473,7 @@ static int flash_mspi_atxp032_write(const struct device *flash, off_t offset, co
 	return ret;
 }
 
-static int flash_mspi_atxp032_erase(const struct device *flash, off_t offset, size_t size)
+static int flash_mspi_atxp032_erase(const struct device *flash, k_off_t offset, size_t size)
 {
 	const struct flash_mspi_atxp032_config *cfg = flash->config;
 	int ret = 0;
@@ -701,7 +701,7 @@ static int flash_mspi_atxp032_init(const struct device *flash)
 }
 
 #if defined(CONFIG_FLASH_JESD216_API)
-static int flash_mspi_atxp032_read_sfdp(const struct device *flash, off_t addr, void *rdata,
+static int flash_mspi_atxp032_read_sfdp(const struct device *flash, k_off_t addr, void *rdata,
 					size_t size)
 {
 	const struct flash_mspi_atxp032_config *cfg = flash->config;
@@ -727,7 +727,7 @@ static int flash_mspi_atxp032_read_sfdp(const struct device *flash, off_t addr, 
 	data->trans.num_packet        = 1;
 	data->trans.timeout           = CONFIG_MSPI_COMPLETION_TIMEOUT_TOLERANCE;
 
-	LOG_DBG("Read %d bytes from 0x%08zx", size, (ssize_t)addr);
+	LOG_DBG("Read %d bytes from 0x%08zx", size, (k_ssize_t)addr);
 
 	ret = mspi_transceive(cfg->bus, &cfg->dev_id, (const struct mspi_xfer *)&data->trans);
 

--- a/drivers/flash/flash_mspi_emul_device.c
+++ b/drivers/flash/flash_mspi_emul_device.c
@@ -140,7 +140,7 @@ static int emul_mspi_device_transceive(const struct emul *target,
 	return 0;
 }
 
-static int flash_mspi_emul_erase(const struct device *flash, off_t offset, size_t size)
+static int flash_mspi_emul_erase(const struct device *flash, k_off_t offset, size_t size)
 {
 	const struct flash_mspi_emul_device_config *cfg = flash->config;
 	struct flash_mspi_emul_device_data *data = flash->data;
@@ -196,7 +196,7 @@ static int flash_mspi_emul_erase(const struct device *flash, off_t offset, size_
  * @retval 0 if successful.
  * @retval -Error flash read fail.
  */
-static int flash_mspi_emul_write(const struct device *flash, off_t offset,
+static int flash_mspi_emul_write(const struct device *flash, k_off_t offset,
 				 const void *wdata, size_t len)
 {
 	const struct flash_mspi_emul_device_config *cfg = flash->config;
@@ -232,7 +232,7 @@ static int flash_mspi_emul_write(const struct device *flash, off_t offset,
 		data->packet.data_buf          = src;
 		data->packet.num_bytes         = i;
 
-		LOG_DBG("Write %d bytes to 0x%08zx", i, (ssize_t)offset);
+		LOG_DBG("Write %d bytes to 0x%08zx", i, (k_ssize_t)offset);
 
 		ret = mspi_transceive(data->bus, &cfg->dev_id,
 				      (const struct mspi_xfer *)&data->xfer);
@@ -265,7 +265,7 @@ static int flash_mspi_emul_write(const struct device *flash, off_t offset,
  * @retval 0 if successful.
  * @retval -Error flash read fail.
  */
-static int flash_mspi_emul_read(const struct device *flash, off_t offset,
+static int flash_mspi_emul_read(const struct device *flash, k_off_t offset,
 				void *rdata, size_t len)
 {
 	const struct flash_mspi_emul_device_config *cfg = flash->config;
@@ -292,7 +292,7 @@ static int flash_mspi_emul_read(const struct device *flash, off_t offset,
 	data->xfer.num_packet          = 1;
 	data->xfer.timeout             = CONFIG_MSPI_COMPLETION_TIMEOUT_TOLERANCE;
 
-	LOG_DBG("Read %d bytes from 0x%08zx", len, (ssize_t)offset);
+	LOG_DBG("Read %d bytes from 0x%08zx", len, (k_ssize_t)offset);
 
 	ret = mspi_transceive(data->bus, &cfg->dev_id, (const struct mspi_xfer *)&data->xfer);
 	if (ret) {

--- a/drivers/flash/flash_npcx_fiu_nor.c
+++ b/drivers/flash/flash_npcx_fiu_nor.c
@@ -60,7 +60,7 @@ static const struct flash_parameters flash_npcx_parameters = {
 		     DT_INST_STRING_TOKEN(inst, quad_enable_requirements))),	\
 		    ((JESD216_DW15_QER_VAL_NONE)))
 
-static inline bool is_within_region(off_t addr, size_t size, off_t region_start,
+static inline bool is_within_region(k_off_t addr, size_t size, k_off_t region_start,
 				    size_t region_size)
 {
 	return (addr >= region_start &&
@@ -196,7 +196,7 @@ static int flash_npcx_nor_read_jedec_id(const struct device *dev, uint8_t *id)
 	return flash_npcx_uma_read(dev, SPI_NOR_CMD_RDID, id, SPI_NOR_MAX_ID_LEN);
 }
 
-static int flash_npcx_nor_read_sfdp(const struct device *dev, off_t addr,
+static int flash_npcx_nor_read_sfdp(const struct device *dev, k_off_t addr,
 				    void *data, size_t size)
 {
 	uint8_t sfdp_addr[4];
@@ -231,7 +231,7 @@ static void flash_npcx_nor_pages_layout(const struct device *dev,
 }
 #endif /* CONFIG_FLASH_PAGE_LAYOUT */
 
-static int flash_npcx_nor_read(const struct device *dev, off_t addr,
+static int flash_npcx_nor_read(const struct device *dev, k_off_t addr,
 				 void *data, size_t size)
 {
 	const struct flash_npcx_nor_config *config = dev->config;
@@ -254,7 +254,7 @@ static int flash_npcx_nor_read(const struct device *dev, off_t addr,
 	return 0;
 }
 
-static int flash_npcx_nor_erase(const struct device *dev, off_t addr, size_t size)
+static int flash_npcx_nor_erase(const struct device *dev, k_off_t addr, size_t size)
 {
 	const struct flash_npcx_nor_config *config = dev->config;
 	int ret = 0;
@@ -306,7 +306,7 @@ static int flash_npcx_nor_erase(const struct device *dev, off_t addr, size_t siz
 	return ret;
 }
 
-static int flash_npcx_nor_write(const struct device *dev, off_t addr,
+static int flash_npcx_nor_write(const struct device *dev, k_off_t addr,
 				  const void *data, size_t size)
 {
 	const struct flash_npcx_nor_config *config = dev->config;

--- a/drivers/flash/flash_nxp_s32_qspi_nor.c
+++ b/drivers/flash/flash_nxp_s32_qspi_nor.c
@@ -321,7 +321,7 @@ static ALWAYS_INLINE Qspi_Ip_MemoryConfigType *get_memory_config(const struct de
 #endif
 }
 
-static ALWAYS_INLINE bool area_is_subregion(const struct device *dev, off_t offset, size_t size)
+static ALWAYS_INLINE bool area_is_subregion(const struct device *dev, k_off_t offset, size_t size)
 {
 	Qspi_Ip_MemoryConfigType *memory_cfg = get_memory_config(dev);
 
@@ -567,7 +567,7 @@ static int nxp_s32_qspi_set_quad_mode(const struct device *dev, bool enabled)
 }
 #endif /* !defined(CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME) */
 
-static int nxp_s32_qspi_read(const struct device *dev, off_t offset, void *dest, size_t size)
+static int nxp_s32_qspi_read(const struct device *dev, k_off_t offset, void *dest, size_t size)
 {
 	struct nxp_s32_qspi_data *data = dev->data;
 	Qspi_Ip_StatusType status;
@@ -587,8 +587,8 @@ static int nxp_s32_qspi_read(const struct device *dev, off_t offset, void *dest,
 		status = Qspi_Ip_Read(data->instance, (uint32_t)offset, (uint8_t *)dest,
 				      (uint32_t)size);
 		if (status != STATUS_QSPI_IP_SUCCESS) {
-			LOG_ERR("Failed to read %zu bytes at 0x%lx (%d)",
-				size, offset, status);
+			LOG_ERR("Failed to read %zu bytes at 0x%x (%d)", size, (uint32_t)offset,
+				status);
 			ret = -EIO;
 		}
 
@@ -598,7 +598,8 @@ static int nxp_s32_qspi_read(const struct device *dev, off_t offset, void *dest,
 	return ret;
 }
 
-static int nxp_s32_qspi_write(const struct device *dev, off_t offset, const void *src, size_t size)
+static int nxp_s32_qspi_write(const struct device *dev, k_off_t offset, const void *src,
+			      size_t size)
 {
 	struct nxp_s32_qspi_data *data = dev->data;
 	Qspi_Ip_MemoryConfigType *memory_cfg = get_memory_config(dev);
@@ -622,8 +623,8 @@ static int nxp_s32_qspi_write(const struct device *dev, off_t offset, const void
 		status = Qspi_Ip_Program(data->instance, (uint32_t)offset,
 					(const uint8_t *)src, (uint32_t)len);
 		if (status != STATUS_QSPI_IP_SUCCESS) {
-			LOG_ERR("Failed to write %zu bytes at 0x%lx (%d)",
-				len, offset, status);
+			LOG_ERR("Failed to write %zu bytes at 0x%lx (%d)", len, (long)offset,
+				status);
 			ret = -EIO;
 			break;
 		}
@@ -637,8 +638,8 @@ static int nxp_s32_qspi_write(const struct device *dev, off_t offset, const void
 			status = Qspi_Ip_ProgramVerify(data->instance, (uint32_t)offset,
 						       (const uint8_t *)src, (uint32_t)len);
 			if (status != STATUS_QSPI_IP_SUCCESS) {
-				LOG_ERR("Write verification failed at 0x%lx (%d)",
-					offset, status);
+				LOG_ERR("Write verification failed at 0x%lx (%d)", (long)offset,
+					status);
 				ret = -EIO;
 				break;
 			}
@@ -654,7 +655,7 @@ static int nxp_s32_qspi_write(const struct device *dev, off_t offset, const void
 	return ret;
 }
 
-static int nxp_s32_qspi_erase_block(const struct device *dev, off_t offset,
+static int nxp_s32_qspi_erase_block(const struct device *dev, k_off_t offset,
 				    size_t size, size_t *erase_size)
 {
 	struct nxp_s32_qspi_data *data = dev->data;
@@ -694,7 +695,7 @@ static int nxp_s32_qspi_erase_block(const struct device *dev, off_t offset,
 	return ret;
 }
 
-static int nxp_s32_qspi_erase(const struct device *dev, off_t offset, size_t size)
+static int nxp_s32_qspi_erase(const struct device *dev, k_off_t offset, size_t size)
 {
 	struct nxp_s32_qspi_data *data = dev->data;
 	Qspi_Ip_MemoryConfigType *memory_cfg = get_memory_config(dev);
@@ -733,7 +734,7 @@ static int nxp_s32_qspi_erase(const struct device *dev, off_t offset, size_t siz
 							erase_size);
 				if (status != STATUS_QSPI_IP_SUCCESS) {
 					LOG_ERR("Erase verification failed at 0x%lx (%d)",
-						offset, status);
+						(long)offset, status);
 					ret = -EIO;
 					break;
 				}
@@ -771,7 +772,7 @@ static int nxp_s32_qspi_read_id(const struct device *dev, uint8_t *id)
 #endif /* CONFIG_FLASH_JESD216_API || !CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME */
 
 #if defined(CONFIG_FLASH_JESD216_API)
-static int nxp_s32_qspi_sfdp_read(const struct device *dev, off_t offset, void *buf, size_t len)
+static int nxp_s32_qspi_sfdp_read(const struct device *dev, k_off_t offset, void *buf, size_t len)
 {
 	struct nxp_s32_qspi_data *data = dev->data;
 	Qspi_Ip_StatusType status;

--- a/drivers/flash/flash_page_layout.c
+++ b/drivers/flash/flash_page_layout.c
@@ -8,7 +8,7 @@
 
 #include <zephyr/drivers/flash.h>
 
-static int flash_get_page_info(const struct device *dev, off_t offs,
+static int flash_get_page_info(const struct device *dev, k_off_t offs,
 			       uint32_t index, struct flash_pages_info *info)
 {
 	const struct flash_driver_api *api = dev->api;
@@ -42,7 +42,7 @@ static int flash_get_page_info(const struct device *dev, off_t offs,
 	return -EINVAL; /* page at offs or idx doesn't exist */
 }
 
-int z_impl_flash_get_page_info_by_offs(const struct device *dev, off_t offs,
+int z_impl_flash_get_page_info_by_offs(const struct device *dev, k_off_t offs,
 				       struct flash_pages_info *info)
 {
 	return flash_get_page_info(dev, offs, 0U, info);
@@ -79,7 +79,7 @@ void flash_page_foreach(const struct device *dev, flash_page_cb cb,
 	const struct flash_pages_layout *layout;
 	struct flash_pages_info page_info;
 	size_t block, num_blocks, page = 0, i;
-	off_t off = 0;
+	k_off_t off = 0;
 
 	api->page_layout(dev, &layout, &num_blocks);
 

--- a/drivers/flash/flash_rpi_pico.c
+++ b/drivers/flash/flash_rpi_pico.c
@@ -183,12 +183,12 @@ void __no_inline_not_in_flash_func(flash_write_partial)(uint32_t flash_offs, con
 	flash_enable_xip_via_boot2();
 }
 
-static bool is_valid_range(off_t offset, uint32_t size)
+static bool is_valid_range(k_off_t offset, uint32_t size)
 {
 	return (offset >= 0) && ((offset + size) <= FLASH_SIZE);
 }
 
-static int flash_rpi_read(const struct device *dev, off_t offset, void *data, size_t size)
+static int flash_rpi_read(const struct device *dev, k_off_t offset, void *data, size_t size)
 {
 	if (size == 0) {
 		return 0;
@@ -204,7 +204,7 @@ static int flash_rpi_read(const struct device *dev, off_t offset, void *data, si
 	return 0;
 }
 
-static int flash_rpi_write(const struct device *dev, off_t offset, const void *data, size_t size)
+static int flash_rpi_write(const struct device *dev, k_off_t offset, const void *data, size_t size)
 {
 	uint32_t key;
 	size_t bytes_to_write;
@@ -250,7 +250,7 @@ static int flash_rpi_write(const struct device *dev, off_t offset, const void *d
 	return 0;
 }
 
-static int flash_rpi_erase(const struct device *dev, off_t offset, size_t size)
+static int flash_rpi_erase(const struct device *dev, k_off_t offset, size_t size)
 {
 	uint32_t key;
 

--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -623,7 +623,7 @@ static int cmd_load(const struct shell *sh, size_t argc, char *argv[])
 	int result;
 	uint32_t addr;
 	uint32_t size;
-	ssize_t write_block_size;
+	k_ssize_t write_block_size;
 
 	result = parse_helper(sh, &argc, &argv, &flash_dev, &addr);
 	if (result) {
@@ -691,8 +691,8 @@ static int cmd_page_info(const struct shell *sh, size_t argc, char *argv[])
 		return -EINVAL;
 	}
 
-	shell_print(sh, "Page for address 0x%x:\nstart offset: 0x%lx\nsize: %zu\nindex: %d",
-			addr, info.start_offset, info.size, info.index);
+	shell_print(sh, "Page for address 0x%x:\nstart offset: 0x%lx\nsize: %zu\nindex: %d", addr,
+		    (long)info.start_offset, info.size, info.index);
 	return 0;
 }
 

--- a/drivers/flash/flash_simulator.c
+++ b/drivers/flash/flash_simulator.c
@@ -170,7 +170,7 @@ static const struct flash_parameters flash_sim_parameters = {
 	},
 };
 
-static int flash_range_is_valid(const struct device *dev, off_t offset,
+static int flash_range_is_valid(const struct device *dev, k_off_t offset,
 				size_t len)
 {
 	ARG_UNUSED(dev);
@@ -183,7 +183,7 @@ static int flash_range_is_valid(const struct device *dev, off_t offset,
 	return 1;
 }
 
-static int flash_sim_read(const struct device *dev, const off_t offset,
+static int flash_sim_read(const struct device *dev, const k_off_t offset,
 			  void *data,
 			  const size_t len)
 {
@@ -214,7 +214,7 @@ static int flash_sim_read(const struct device *dev, const off_t offset,
 	return 0;
 }
 
-static int flash_sim_write(const struct device *dev, const off_t offset,
+static int flash_sim_write(const struct device *dev, const k_off_t offset,
 			   const void *data, const size_t len)
 {
 	uint8_t buf[FLASH_SIMULATOR_PROG_UNIT];
@@ -299,7 +299,7 @@ static int flash_sim_write(const struct device *dev, const off_t offset,
 
 static void unit_erase(const uint32_t unit)
 {
-	const off_t unit_addr = FLASH_SIMULATOR_BASE_OFFSET +
+	const k_off_t unit_addr = FLASH_SIMULATOR_BASE_OFFSET +
 				(unit * FLASH_SIMULATOR_ERASE_UNIT);
 
 	/* erase the memory unit by setting it to erase value */
@@ -307,7 +307,7 @@ static void unit_erase(const uint32_t unit)
 	       FLASH_SIMULATOR_ERASE_UNIT);
 }
 
-static int flash_sim_erase(const struct device *dev, const off_t offset,
+static int flash_sim_erase(const struct device *dev, const k_off_t offset,
 			   const size_t len)
 {
 	ARG_UNUSED(dev);

--- a/drivers/flash/flash_smartbond.c
+++ b/drivers/flash/flash_smartbond.c
@@ -29,7 +29,7 @@ static const struct flash_parameters flash_smartbond_parameters = {
 	.erase_value = 0xff,
 };
 
-static bool range_is_valid(off_t offset, uint32_t size)
+static bool range_is_valid(k_off_t offset, uint32_t size)
 {
 	return (offset + size) <= (CONFIG_FLASH_SIZE * 1024);
 }
@@ -145,7 +145,7 @@ static __ramfunc void qspic_write(uint32_t address, const uint8_t *data, size_t 
 	}
 }
 
-static int flash_smartbond_read(const struct device *dev, off_t offset,
+static int flash_smartbond_read(const struct device *dev, k_off_t offset,
 			      void *data, size_t size)
 {
 	const struct flash_smartbond_config *config = dev->config;
@@ -164,7 +164,7 @@ static int flash_smartbond_read(const struct device *dev, off_t offset,
 }
 
 static __ramfunc int flash_smartbond_write(const struct device *dev,
-					 off_t offset, const void *data,
+					 k_off_t offset, const void *data,
 					 size_t size)
 {
 	unsigned int key;
@@ -194,7 +194,7 @@ static __ramfunc int flash_smartbond_write(const struct device *dev,
 	return 0;
 }
 
-static __ramfunc int flash_smartbond_erase(const struct device *dev, off_t offset,
+static __ramfunc int flash_smartbond_erase(const struct device *dev, k_off_t offset,
 					 size_t size)
 {
 	unsigned int key;

--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -45,7 +45,7 @@ static const struct flash_parameters flash_stm32_parameters = {
 
 static int flash_stm32_write_protection(const struct device *dev, bool enable);
 
-bool __weak flash_stm32_valid_range(const struct device *dev, off_t offset,
+bool __weak flash_stm32_valid_range(const struct device *dev, k_off_t offset,
 				    uint32_t len, bool write)
 {
 	if (write && !flash_stm32_valid_write(offset, len)) {
@@ -133,7 +133,7 @@ int flash_stm32_wait_flash_idle(const struct device *dev)
 }
 
 static void flash_stm32_flush_caches(const struct device *dev,
-				     off_t offset, size_t len)
+				     k_off_t offset, size_t len)
 {
 #if defined(CONFIG_SOC_SERIES_STM32F0X) || defined(CONFIG_SOC_SERIES_STM32F3X) || \
 	defined(CONFIG_SOC_SERIES_STM32G0X) || defined(CONFIG_SOC_SERIES_STM32L5X) || \
@@ -162,7 +162,7 @@ static void flash_stm32_flush_caches(const struct device *dev,
 #endif
 }
 
-static int flash_stm32_read(const struct device *dev, off_t offset,
+static int flash_stm32_read(const struct device *dev, k_off_t offset,
 			    void *data,
 			    size_t len)
 {
@@ -183,7 +183,7 @@ static int flash_stm32_read(const struct device *dev, off_t offset,
 	return 0;
 }
 
-static int flash_stm32_erase(const struct device *dev, off_t offset,
+static int flash_stm32_erase(const struct device *dev, k_off_t offset,
 			     size_t len)
 {
 	int rc;
@@ -220,7 +220,7 @@ static int flash_stm32_erase(const struct device *dev, off_t offset,
 	return rc;
 }
 
-static int flash_stm32_write(const struct device *dev, off_t offset,
+static int flash_stm32_write(const struct device *dev, k_off_t offset,
 			     const void *data, size_t len)
 {
 	int rc;

--- a/drivers/flash/flash_stm32.h
+++ b/drivers/flash/flash_stm32.h
@@ -261,7 +261,7 @@ struct flash_stm32_priv {
 
 #ifdef CONFIG_FLASH_PAGE_LAYOUT
 static inline bool flash_stm32_range_exists(const struct device *dev,
-					    off_t offset,
+					    k_off_t offset,
 					    uint32_t len)
 {
 	struct flash_pages_info info;
@@ -271,13 +271,13 @@ static inline bool flash_stm32_range_exists(const struct device *dev,
 }
 #endif	/* CONFIG_FLASH_PAGE_LAYOUT */
 
-static inline bool flash_stm32_valid_write(off_t offset, uint32_t len)
+static inline bool flash_stm32_valid_write(k_off_t offset, uint32_t len)
 {
 	return ((offset % FLASH_STM32_WRITE_BLOCK_SIZE == 0) &&
 		(len % FLASH_STM32_WRITE_BLOCK_SIZE == 0U));
 }
 
-bool flash_stm32_valid_range(const struct device *dev, off_t offset,
+bool flash_stm32_valid_range(const struct device *dev, k_off_t offset,
 			     uint32_t len, bool write);
 
 int flash_stm32_write_range(const struct device *dev, unsigned int offset,

--- a/drivers/flash/flash_stm32_ex_op.c
+++ b/drivers/flash/flash_stm32_ex_op.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/types.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/flash/stm32_flash_api_extensions.h>
 #include <zephyr/kernel.h>

--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -437,7 +437,7 @@ static int ospi_read_jedec_id(const struct device *dev,  uint8_t *id)
  * Read Serial Flash Discovery Parameter from the octoFlash at init :
  * perform a read access over SPI bus for SDFP (DataMode is already set)
  */
-static int stm32_ospi_read_sfdp(const struct device *dev, off_t addr,
+static int stm32_ospi_read_sfdp(const struct device *dev, k_off_t addr,
 				void *data,
 				size_t size)
 {
@@ -487,7 +487,7 @@ static int stm32_ospi_read_sfdp(const struct device *dev, off_t addr,
  * perform a read access over SPI bus for SDFP (DataMode is already set)
  * or get it from the sdfp table (in the DTS)
  */
-static int ospi_read_sfdp(const struct device *dev, off_t addr, void *data,
+static int ospi_read_sfdp(const struct device *dev, k_off_t addr, void *data,
 			  size_t size)
 {
 #if DT_NODE_HAS_PROP(DT_INST(0, st_stm32_ospi_nor), sfdp_bfp)
@@ -516,7 +516,7 @@ static int ospi_read_sfdp(const struct device *dev, off_t addr, void *data,
 #endif /* sfdp_bfp */
 }
 
-static bool ospi_address_is_valid(const struct device *dev, off_t addr,
+static bool ospi_address_is_valid(const struct device *dev, k_off_t addr,
 				  size_t size)
 {
 	const struct flash_stm32_ospi_config *dev_cfg = dev->config;
@@ -1124,7 +1124,7 @@ static int stm32_ospi_abort(const struct device *dev)
  *   set addr = 0
  * NOTE: cannot erase in MemoryMapped mode
  */
-static int flash_stm32_ospi_erase(const struct device *dev, off_t addr,
+static int flash_stm32_ospi_erase(const struct device *dev, k_off_t addr,
 				  size_t size)
 {
 	const struct flash_stm32_ospi_config *dev_cfg = dev->config;
@@ -1296,7 +1296,7 @@ end_erase:
 }
 
 /* Function to read the flash with possible OSPI/SPI and STR/DTR */
-static int flash_stm32_ospi_read(const struct device *dev, off_t addr,
+static int flash_stm32_ospi_read(const struct device *dev, k_off_t addr,
 				 void *data, size_t size)
 {
 	int ret = 0;
@@ -1404,7 +1404,7 @@ static int flash_stm32_ospi_read(const struct device *dev, off_t addr,
  * Function to write the flash (page program) : with possible OSPI/SPI and STR/DTR
  * NOTE: writing  in MemoryMapped mode is not guaranted
  */
-static int flash_stm32_ospi_write(const struct device *dev, off_t addr,
+static int flash_stm32_ospi_write(const struct device *dev, k_off_t addr,
 				  const void *data, size_t size)
 {
 	const struct flash_stm32_ospi_config *dev_cfg = dev->config;

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -343,7 +343,7 @@ static int qspi_read_jedec_id(const struct device *dev, uint8_t *id)
 /*
  * Read Serial Flash Discovery Parameter
  */
-static int qspi_read_sfdp(const struct device *dev, off_t addr, void *data,
+static int qspi_read_sfdp(const struct device *dev, k_off_t addr, void *data,
 			  size_t size)
 {
 	struct flash_stm32_qspi_data *dev_data = dev->data;
@@ -383,7 +383,7 @@ static int qspi_read_sfdp(const struct device *dev, off_t addr, void *data,
 	return 0;
 }
 
-static bool qspi_address_is_valid(const struct device *dev, off_t addr,
+static bool qspi_address_is_valid(const struct device *dev, k_off_t addr,
 				  size_t size)
 {
 	const struct flash_stm32_qspi_config *dev_cfg = dev->config;
@@ -452,7 +452,7 @@ static int stm32_qspi_abort(const struct device *dev)
 }
 #endif
 
-static int flash_stm32_qspi_read(const struct device *dev, off_t addr,
+static int flash_stm32_qspi_read(const struct device *dev, k_off_t addr,
 				 void *data, size_t size)
 {
 	int ret;
@@ -535,7 +535,7 @@ static int qspi_wait_until_ready(const struct device *dev)
 	return ret;
 }
 
-static int flash_stm32_qspi_write(const struct device *dev, off_t addr,
+static int flash_stm32_qspi_write(const struct device *dev, k_off_t addr,
 				  const void *data, size_t size)
 {
 	int ret = 0;
@@ -622,7 +622,7 @@ end:
 	return ret;
 }
 
-static int flash_stm32_qspi_erase(const struct device *dev, off_t addr,
+static int flash_stm32_qspi_erase(const struct device *dev, k_off_t addr,
 				  size_t size)
 {
 	const struct flash_stm32_qspi_config *dev_cfg = dev->config;

--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -301,7 +301,7 @@ static int xspi_read_jedec_id(const struct device *dev,  uint8_t *id)
  * perform a read access over SPI bus for SDFP (DataMode is already set)
  * The SFDP table is not given by a DTS property
  */
-static int stm32_xspi_read_sfdp(const struct device *dev, off_t addr,
+static int stm32_xspi_read_sfdp(const struct device *dev, k_off_t addr,
 				void *data,
 				size_t size)
 {
@@ -349,7 +349,7 @@ static int stm32_xspi_read_sfdp(const struct device *dev, off_t addr,
  * Read Serial Flash Discovery Parameter :
  * perform a read access over SPI bus for SDFP (DataMode is already set)
  */
-static int xspi_read_sfdp(const struct device *dev, off_t addr, void *data,
+static int xspi_read_sfdp(const struct device *dev, k_off_t addr, void *data,
 			  size_t size)
 {
 	LOG_INF("Read SFDP from externalFlash");
@@ -362,7 +362,7 @@ static int xspi_read_sfdp(const struct device *dev, off_t addr, void *data,
 	return -EINVAL;
 }
 
-static bool xspi_address_is_valid(const struct device *dev, off_t addr,
+static bool xspi_address_is_valid(const struct device *dev, k_off_t addr,
 				  size_t size)
 {
 	const struct flash_stm32_xspi_config *dev_cfg = dev->config;
@@ -974,7 +974,7 @@ static int stm32_xspi_abort(const struct device *dev)
  *   set size >= flash size
  *   set addr = 0
  */
-static int flash_stm32_xspi_erase(const struct device *dev, off_t addr,
+static int flash_stm32_xspi_erase(const struct device *dev, k_off_t addr,
 				  size_t size)
 {
 	const struct flash_stm32_xspi_config *dev_cfg = dev->config;
@@ -1144,7 +1144,7 @@ erase_end:
 }
 
 /* Function to read the flash with possible OCTO/SPI and STR/DTR */
-static int flash_stm32_xspi_read(const struct device *dev, off_t addr,
+static int flash_stm32_xspi_read(const struct device *dev, k_off_t addr,
 				 void *data, size_t size)
 {
 	const struct flash_stm32_xspi_config *dev_cfg = dev->config;
@@ -1244,9 +1244,7 @@ static int flash_stm32_xspi_read(const struct device *dev, off_t addr,
 		}
 	}
 
-	LOG_DBG("XSPI: read %zu data at 0x%lx",
-		size,
-		(long)(STM32_XSPI_BASE_ADDRESS + addr));
+	LOG_DBG("XSPI: read %zu data at 0x%lx", size, STM32_XSPI_BASE_ADDRESS + (long)addr);
 	xspi_lock_thread(dev);
 
 	ret = xspi_read_access(dev, &cmd, data, size);
@@ -1260,7 +1258,7 @@ read_end:
 }
 
 /* Function to write the flash (page program) : with possible OCTO/SPI and STR/DTR */
-static int flash_stm32_xspi_write(const struct device *dev, off_t addr,
+static int flash_stm32_xspi_write(const struct device *dev, k_off_t addr,
 				  const void *data, size_t size)
 {
 	const struct flash_stm32_xspi_config *dev_cfg = dev->config;
@@ -1335,9 +1333,7 @@ static int flash_stm32_xspi_write(const struct device *dev, off_t addr,
 	cmd_pp.AddressWidth = stm32_xspi_hal_address_size(dev);
 	cmd_pp.DummyCycles = 0U;
 
-	LOG_DBG("XSPI: write %zu data at 0x%lx",
-		size,
-		(long)(STM32_XSPI_BASE_ADDRESS + addr));
+	LOG_DBG("XSPI: write %zu data at 0x%lx", size, STM32_XSPI_BASE_ADDRESS + (long)addr);
 
 	ret = stm32_xspi_mem_ready(dev,
 				   dev_cfg->data_mode, dev_cfg->data_rate);

--- a/drivers/flash/flash_stm32f1x.c
+++ b/drivers/flash/flash_stm32f1x.c
@@ -39,7 +39,7 @@ typedef uint8_t flash_prg_t;
 #error Unknown erase value
 #endif
 
-static unsigned int get_page(off_t offset)
+static unsigned int get_page(k_off_t offset)
 {
 	return offset / FLASH_PAGE_SIZE;
 }
@@ -121,11 +121,10 @@ static void erase_page_end(FLASH_TypeDef *regs)
 }
 #endif
 
-static int write_value(const struct device *dev, off_t offset,
+static int write_value(const struct device *dev, k_off_t offset,
 		       flash_prg_t val)
 {
-	volatile flash_prg_t *flash = (flash_prg_t *)(
-		offset + FLASH_STM32_BASE_ADDRESS);
+	volatile flash_prg_t *flash = (flash_prg_t *)((uintptr_t)offset + FLASH_STM32_BASE_ADDRESS);
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
 	int rc;
 

--- a/drivers/flash/flash_stm32f2x.c
+++ b/drivers/flash/flash_stm32f2x.c
@@ -13,7 +13,7 @@
 
 #include "flash_stm32.h"
 
-bool flash_stm32_valid_range(const struct device *dev, off_t offset,
+bool flash_stm32_valid_range(const struct device *dev, k_off_t offset,
 			     uint32_t len,
 			     bool write)
 {
@@ -52,7 +52,7 @@ static inline void flush_cache(FLASH_TypeDef *regs)
 	}
 }
 
-static int write_byte(const struct device *dev, off_t offset, uint8_t val)
+static int write_byte(const struct device *dev, k_off_t offset, uint8_t val)
 {
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
 	uint32_t tmp;
@@ -76,7 +76,7 @@ static int write_byte(const struct device *dev, off_t offset, uint8_t val)
 	/* flush the register write */
 	tmp = regs->CR;
 
-	*((uint8_t *) offset + FLASH_STM32_BASE_ADDRESS) = val;
+	*((uint8_t *)((uintptr_t)offset + FLASH_STM32_BASE_ADDRESS)) = val;
 
 	/* Wait until the BSY bit is cleared */
 	rc = flash_stm32_wait_flash_idle(dev);

--- a/drivers/flash/flash_stm32f4x.c
+++ b/drivers/flash/flash_stm32f4x.c
@@ -36,7 +36,7 @@ typedef uint8_t flash_prg_t;
 #error Write block size must be a power of 2, from 1 to 8
 #endif
 
-bool flash_stm32_valid_range(const struct device *dev, off_t offset,
+bool flash_stm32_valid_range(const struct device *dev, k_off_t offset,
 			     uint32_t len,
 			     bool write)
 {
@@ -80,7 +80,7 @@ static inline void flush_cache(FLASH_TypeDef *regs)
 	}
 }
 
-static int write_value(const struct device *dev, off_t offset, flash_prg_t val)
+static int write_value(const struct device *dev, k_off_t offset, flash_prg_t val)
 {
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
 #if defined(FLASH_OPTCR_DB1M)
@@ -117,7 +117,7 @@ static int write_value(const struct device *dev, off_t offset, flash_prg_t val)
 	/* flush the register write */
 	tmp = regs->CR;
 
-	*((flash_prg_t *)(offset + FLASH_STM32_BASE_ADDRESS)) = val;
+	*((flash_prg_t *)((uintptr_t)offset + FLASH_STM32_BASE_ADDRESS)) = val;
 
 	rc = flash_stm32_wait_flash_idle(dev);
 	regs->CR &= (~FLASH_CR_PG);

--- a/drivers/flash/flash_stm32f7x.c
+++ b/drivers/flash/flash_stm32f7x.c
@@ -15,7 +15,7 @@
 
 #include "flash_stm32.h"
 
-bool flash_stm32_valid_range(const struct device *dev, off_t offset,
+bool flash_stm32_valid_range(const struct device *dev, k_off_t offset,
 			     uint32_t len,
 			     bool write)
 {
@@ -38,7 +38,7 @@ static inline void flush_cache(FLASH_TypeDef *regs)
 	}
 }
 
-static int write_byte(const struct device *dev, off_t offset, uint8_t val)
+static int write_byte(const struct device *dev, k_off_t offset, uint8_t val)
 {
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
 	int rc;
@@ -60,7 +60,7 @@ static int write_byte(const struct device *dev, off_t offset, uint8_t val)
 	barrier_dsync_fence_full();
 
 	/* write the data */
-	*((uint8_t *) offset + FLASH_STM32_BASE_ADDRESS) = val;
+	*((uint8_t *)((uintptr_t)offset + FLASH_STM32_BASE_ADDRESS)) = val;
 	/* flush the register write */
 	barrier_dsync_fence_full();
 

--- a/drivers/flash/flash_stm32g0x.c
+++ b/drivers/flash/flash_stm32g0x.c
@@ -54,9 +54,9 @@ static inline void flush_cache(FLASH_TypeDef *regs)
 	}
 }
 
-static int write_dword(const struct device *dev, off_t offset, uint64_t val)
+static int write_dword(const struct device *dev, k_off_t offset, uint64_t val)
 {
-	volatile uint32_t *flash = (uint32_t *)(offset + FLASH_STM32_BASE_ADDRESS);
+	volatile uint32_t *flash = (uint32_t *)((uintptr_t)offset + FLASH_STM32_BASE_ADDRESS);
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
 	uint32_t tmp;
 	int rc;

--- a/drivers/flash/flash_stm32g4x.c
+++ b/drivers/flash/flash_stm32g4x.c
@@ -27,7 +27,7 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
  * offset and len must be aligned on 8 for write,
  * positive and not beyond end of flash
  */
-bool flash_stm32_valid_range(const struct device *dev, off_t offset,
+bool flash_stm32_valid_range(const struct device *dev, k_off_t offset,
 			     uint32_t len,
 			     bool write)
 {
@@ -73,9 +73,9 @@ static inline void flush_cache(FLASH_TypeDef *regs)
 	}
 }
 
-static int write_dword(const struct device *dev, off_t offset, uint64_t val)
+static int write_dword(const struct device *dev, k_off_t offset, uint64_t val)
 {
-	volatile uint32_t *flash = (uint32_t *)(offset + FLASH_STM32_BASE_ADDRESS);
+	volatile uint32_t *flash = (uint32_t *)((uintptr_t)offset + FLASH_STM32_BASE_ADDRESS);
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
 #if defined(FLASH_STM32_DBANK)
 	bool dcache_enabled = false;

--- a/drivers/flash/flash_stm32l4x.c
+++ b/drivers/flash/flash_stm32l4x.c
@@ -62,14 +62,14 @@ static inline void flush_cache(FLASH_TypeDef *regs)
  *
  * STM32L4R/Sxx devices can have up to 512 4K pages on two 256x4K pages banks
  */
-static unsigned int get_page(off_t offset)
+static unsigned int get_page(k_off_t offset)
 {
 	return offset >> STM32L4X_PAGE_SHIFT;
 }
 
-static int write_dword(const struct device *dev, off_t offset, uint64_t val)
+static int write_dword(const struct device *dev, k_off_t offset, uint64_t val)
 {
-	volatile uint32_t *flash = (uint32_t *)(offset + FLASH_STM32_BASE_ADDRESS);
+	volatile uint32_t *flash = (uint32_t *)((uintptr_t)offset + FLASH_STM32_BASE_ADDRESS);
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
 #ifdef CONTROL_DCACHE
 	bool dcache_enabled = false;

--- a/drivers/flash/flash_stm32l5x.c
+++ b/drivers/flash/flash_stm32l5x.c
@@ -133,7 +133,7 @@ static int icache_wait_for_invalidate_complete(void)
  * offset and len must be aligned on write-block-size for write,
  * positive and not beyond end of flash
  */
-bool flash_stm32_valid_range(const struct device *dev, off_t offset,
+bool flash_stm32_valid_range(const struct device *dev, k_off_t offset,
 			     uint32_t len,
 			     bool write)
 {
@@ -157,11 +157,10 @@ bool flash_stm32_valid_range(const struct device *dev, off_t offset,
 	return flash_stm32_range_exists(dev, offset, len);
 }
 
-static int write_nwords(const struct device *dev, off_t offset, const uint32_t *buff, size_t n)
+static int write_nwords(const struct device *dev, k_off_t offset, const uint32_t *buff, size_t n)
 {
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
-	volatile uint32_t *flash = (uint32_t *)(offset
-						+ FLASH_STM32_BASE_ADDRESS);
+	volatile uint32_t *flash = (uint32_t *)((uintptr_t)offset + FLASH_STM32_BASE_ADDRESS);
 	bool full_zero = true;
 	uint32_t tmp;
 	int rc;

--- a/drivers/flash/flash_stm32wba_fm.c
+++ b/drivers/flash/flash_stm32wba_fm.c
@@ -57,7 +57,7 @@ void FM_BackgroundProcess_Entry(struct k_work *work)
 	FM_BackgroundProcess();
 }
 
-bool flash_stm32_valid_range(const struct device *dev, off_t offset,
+bool flash_stm32_valid_range(const struct device *dev, k_off_t offset,
 				    uint32_t len, bool write)
 {
 	if (write && !flash_stm32_valid_write(offset, len)) {
@@ -77,7 +77,7 @@ static inline void flash_stm32_sem_give(const struct device *dev)
 	k_sem_give(&FLASH_STM32_PRIV(dev)->sem);
 }
 
-static int flash_stm32_read(const struct device *dev, off_t offset,
+static int flash_stm32_read(const struct device *dev, k_off_t offset,
 			    void *data,
 			    size_t len)
 {
@@ -100,7 +100,7 @@ static int flash_stm32_read(const struct device *dev, off_t offset,
 	return 0;
 }
 
-static int flash_stm32_erase(const struct device *dev, off_t offset,
+static int flash_stm32_erase(const struct device *dev, k_off_t offset,
 			     size_t len)
 {
 	int rc;
@@ -133,7 +133,7 @@ static int flash_stm32_erase(const struct device *dev, off_t offset,
 	return rc;
 }
 
-static int flash_stm32_write(const struct device *dev, off_t offset,
+static int flash_stm32_write(const struct device *dev, k_off_t offset,
 			     const void *data, size_t len)
 {
 	int rc;
@@ -150,11 +150,10 @@ static int flash_stm32_write(const struct device *dev, off_t offset,
 
 	flash_stm32_sem_take(dev);
 
-	LOG_DBG("Write offset: %p, len: %zu", (void *)offset, len);
+	LOG_DBG("Write offset: %p, len: %zu", (void *)(uintptr_t)offset, len);
 
-	rc = FM_Write((uint32_t *)data,
-		      (uint32_t *)(FLASH_STM32_BASE_ADDRESS + offset),
-		      (int32_t)len/4, &cb_ptr);
+	rc = FM_Write((uint32_t *)data, (uint32_t *)(FLASH_STM32_BASE_ADDRESS + (uintptr_t)offset),
+		      (int32_t)len / 4, &cb_ptr);
 	if (rc == 0) {
 		k_sem_take(&flash_busy, K_FOREVER);
 	} else {

--- a/drivers/flash/flash_stm32wbax.c
+++ b/drivers/flash/flash_stm32wbax.c
@@ -105,11 +105,10 @@ static int icache_wait_for_invalidate_complete(void)
 	return status;
 }
 
-static int write_qword(const struct device *dev, off_t offset, const uint32_t *buff)
+static int write_qword(const struct device *dev, k_off_t offset, const uint32_t *buff)
 {
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
-	volatile uint32_t *flash = (uint32_t *)(offset
-						+ FLASH_STM32_BASE_ADDRESS);
+	volatile uint32_t *flash = (uint32_t *)((uintptr_t)offset + FLASH_STM32_BASE_ADDRESS);
 	uint32_t tmp;
 	int rc;
 

--- a/drivers/flash/flash_stm32wbx.c
+++ b/drivers/flash/flash_stm32wbx.c
@@ -29,7 +29,7 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 /*
  * Up to 255 4K pages
  */
-static uint32_t get_page(off_t offset)
+static uint32_t get_page(k_off_t offset)
 {
 	return offset >> STM32WBX_PAGE_SHIFT;
 }
@@ -58,9 +58,9 @@ static inline void flush_cache(FLASH_TypeDef *regs)
 	}
 }
 
-static int write_dword(const struct device *dev, off_t offset, uint64_t val)
+static int write_dword(const struct device *dev, k_off_t offset, uint64_t val)
 {
-	volatile uint32_t *flash = (uint32_t *)(offset + FLASH_STM32_BASE_ADDRESS);
+	volatile uint32_t *flash = (uint32_t *)((uintptr_t)offset + FLASH_STM32_BASE_ADDRESS);
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
 	uint32_t tmp;
 	int ret, rc;

--- a/drivers/flash/flash_util.c
+++ b/drivers/flash/flash_util.c
@@ -9,12 +9,12 @@
 
 #include <zephyr/drivers/flash.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/kernel.h>
 #include <string.h>
 
 LOG_MODULE_REGISTER(flash, CONFIG_FLASH_LOG_LEVEL);
 
-int z_impl_flash_fill(const struct device *dev, uint8_t val, off_t offset,
-		      size_t size)
+int z_impl_flash_fill(const struct device *dev, uint8_t val, k_off_t offset, size_t size)
 {
 	uint8_t filler[CONFIG_FLASH_FILL_BUFFER_SIZE];
 	const struct flash_driver_api *api =
@@ -61,7 +61,7 @@ int z_impl_flash_fill(const struct device *dev, uint8_t val, off_t offset,
 	return rc;
 }
 
-int z_impl_flash_flatten(const struct device *dev, off_t offset, size_t size)
+int z_impl_flash_flatten(const struct device *dev, k_off_t offset, size_t size)
 {
 	const struct flash_driver_api *api =
 		(const struct flash_driver_api *)dev->api;

--- a/drivers/flash/jesd216.c
+++ b/drivers/flash/jesd216.c
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
-#include <sys/types.h>
 #include <zephyr/kernel.h>
 #include "jesd216.h"
 #include "spi_nor.h"

--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -727,7 +727,7 @@ static int qspi_read_jedec_id(const struct device *dev, uint8_t *id)
 	return rc;
 }
 
-static int qspi_sfdp_read(const struct device *dev, off_t offset,
+static int qspi_sfdp_read(const struct device *dev, k_off_t offset,
 			  void *data, size_t len)
 {
 	__ASSERT(data != NULL, "null destination");
@@ -775,27 +775,27 @@ out:
 #endif /* CONFIG_FLASH_JESD216_API */
 
 static inline nrfx_err_t read_non_aligned(const struct device *dev,
-					  off_t addr,
+					  k_off_t addr,
 					  void *dest, size_t size)
 {
 	uint8_t __aligned(WORD_SIZE) buf[WORD_SIZE * 2];
 	uint8_t *dptr = dest;
 
-	off_t flash_prefix = (WORD_SIZE - (addr % WORD_SIZE)) % WORD_SIZE;
+	k_off_t flash_prefix = (WORD_SIZE - (addr % WORD_SIZE)) % WORD_SIZE;
 
 	if (flash_prefix > size) {
 		flash_prefix = size;
 	}
 
-	off_t dest_prefix = (WORD_SIZE - (off_t)dptr % WORD_SIZE) % WORD_SIZE;
+	k_off_t dest_prefix = (WORD_SIZE - (uintptr_t)dptr % WORD_SIZE) % WORD_SIZE;
 
 	if (dest_prefix > size) {
 		dest_prefix = size;
 	}
 
-	off_t flash_suffix = (size - flash_prefix) % WORD_SIZE;
-	off_t flash_middle = size - flash_prefix - flash_suffix;
-	off_t dest_middle = size - dest_prefix -
+	k_off_t flash_suffix = (size - flash_prefix) % WORD_SIZE;
+	k_off_t flash_middle = size - flash_prefix - flash_suffix;
+	k_off_t dest_middle = size - dest_prefix -
 			    (size - dest_prefix) % WORD_SIZE;
 
 	if (flash_middle > dest_middle) {
@@ -845,7 +845,7 @@ static inline nrfx_err_t read_non_aligned(const struct device *dev,
 	return res;
 }
 
-static int qspi_nor_read(const struct device *dev, off_t addr, void *dest,
+static int qspi_nor_read(const struct device *dev, k_off_t addr, void *dest,
 			 size_t size)
 {
 	const struct qspi_nor_config *params = dev->config;
@@ -879,7 +879,7 @@ static int qspi_nor_read(const struct device *dev, off_t addr, void *dest,
 }
 
 /* addr aligned, sptr not null, slen less than 4 */
-static inline nrfx_err_t write_sub_word(const struct device *dev, off_t addr,
+static inline nrfx_err_t write_sub_word(const struct device *dev, k_off_t addr,
 					const void *sptr, size_t slen)
 {
 	uint8_t __aligned(4) buf[4];
@@ -908,7 +908,7 @@ BUILD_ASSERT((CONFIG_NORDIC_QSPI_NOR_STACK_WRITE_BUFFER_SIZE % 4) == 0,
  *
  * If not enabled return the error the peripheral would have produced.
  */
-static nrfx_err_t write_through_buffer(const struct device *dev, off_t addr,
+static nrfx_err_t write_through_buffer(const struct device *dev, k_off_t addr,
 				       const void *sptr, size_t slen)
 {
 	nrfx_err_t res = NRFX_SUCCESS;
@@ -936,7 +936,7 @@ static nrfx_err_t write_through_buffer(const struct device *dev, off_t addr,
 	return res;
 }
 
-static int qspi_nor_write(const struct device *dev, off_t addr,
+static int qspi_nor_write(const struct device *dev, k_off_t addr,
 			  const void *src,
 			  size_t size)
 {
@@ -992,7 +992,7 @@ static int qspi_nor_write(const struct device *dev, off_t addr,
 	return rc != 0 ? rc : rc2;
 }
 
-static int qspi_nor_erase(const struct device *dev, off_t addr, size_t size)
+static int qspi_nor_erase(const struct device *dev, k_off_t addr, size_t size)
 {
 	const struct qspi_nor_config *params = dev->config;
 	int rc;

--- a/drivers/flash/soc_flash_b91.c
+++ b/drivers/flash/soc_flash_b91.c
@@ -36,7 +36,7 @@ static const struct flash_parameters flash_b91_parameters = {
 
 
 /* Check for correct offset and length */
-static bool flash_b91_is_range_valid(off_t offset, size_t len)
+static bool flash_b91_is_range_valid(k_off_t offset, size_t len)
 {
 	/* check for min value */
 	if ((offset < 0) || (len < 1)) {
@@ -62,7 +62,7 @@ static int flash_b91_init(const struct device *dev)
 }
 
 /* API implementation: erase */
-static int flash_b91_erase(const struct device *dev, off_t offset, size_t len)
+static int flash_b91_erase(const struct device *dev, k_off_t offset, size_t len)
 {
 	int page_nums = len / PAGE_SIZE;
 	struct flash_b91_data *dev_data = dev->data;
@@ -119,7 +119,7 @@ static int flash_b91_erase(const struct device *dev, off_t offset, size_t len)
 }
 
 /* API implementation: write */
-static int flash_b91_write(const struct device *dev, off_t offset,
+static int flash_b91_write(const struct device *dev, k_off_t offset,
 			   const void *data, size_t len)
 {
 	void *buf = NULL;
@@ -172,7 +172,7 @@ static int flash_b91_write(const struct device *dev, off_t offset,
 }
 
 /* API implementation: read */
-static int flash_b91_read(const struct device *dev, off_t offset,
+static int flash_b91_read(const struct device *dev, k_off_t offset,
 			  void *data, size_t len)
 {
 	ARG_UNUSED(dev);

--- a/drivers/flash/soc_flash_cc13xx_cc26xx.c
+++ b/drivers/flash/soc_flash_cc13xx_cc26xx.c
@@ -73,9 +73,9 @@ static uint32_t flash_cc13xx_cc26xx_cache_disable(void)
 	return vims_mode;
 }
 
-static bool flash_cc13xx_cc26xx_range_protected(off_t offs, size_t size)
+static bool flash_cc13xx_cc26xx_range_protected(k_off_t offs, size_t size)
 {
-	off_t sector, end;
+	k_off_t sector, end;
 
 	sector = (offs / FLASH_ERASE_SIZE) * FLASH_ERASE_SIZE;
 	end = offs + size;
@@ -99,7 +99,7 @@ static bool flash_cc13xx_cc26xx_range_protected(off_t offs, size_t size)
 	return false;
 }
 
-static int flash_cc13xx_cc26xx_erase(const struct device *dev, off_t offs,
+static int flash_cc13xx_cc26xx_erase(const struct device *dev, k_off_t offs,
 				     size_t size)
 {
 	struct flash_priv *priv = dev->data;
@@ -158,7 +158,7 @@ static int flash_cc13xx_cc26xx_erase(const struct device *dev, off_t offs,
 	return rc;
 }
 
-static int flash_cc13xx_cc26xx_write(const struct device *dev, off_t offs,
+static int flash_cc13xx_cc26xx_write(const struct device *dev, k_off_t offs,
 				     const void *data, size_t size)
 {
 	struct flash_priv *priv = dev->data;
@@ -216,7 +216,7 @@ static int flash_cc13xx_cc26xx_write(const struct device *dev, off_t offs,
 	return rc;
 }
 
-static int flash_cc13xx_cc26xx_read(const struct device *dev, off_t offs,
+static int flash_cc13xx_cc26xx_read(const struct device *dev, k_off_t offs,
 				    void *data, size_t size)
 {
 	ARG_UNUSED(dev);

--- a/drivers/flash/soc_flash_lpc.c
+++ b/drivers/flash/soc_flash_lpc.c
@@ -43,7 +43,7 @@ static const struct flash_parameters flash_lpc_parameters = {
 	.erase_value = 0xff,
 };
 
-static inline void prepare_erase_write(off_t offset, size_t len,
+static inline void prepare_erase_write(k_off_t offset, size_t len,
 						uint32_t sector_size)
 {
 	uint32_t start;
@@ -54,7 +54,7 @@ static inline void prepare_erase_write(off_t offset, size_t len,
 	FLASHIAP_PrepareSectorForWrite(start, stop);
 }
 
-static int flash_lpc_erase(const struct device *dev, off_t offset, size_t len)
+static int flash_lpc_erase(const struct device *dev, k_off_t offset, size_t len)
 {
 	struct flash_priv *priv = dev->data;
 	status_t rc;
@@ -81,7 +81,7 @@ static int flash_lpc_erase(const struct device *dev, off_t offset, size_t len)
 	return (rc == kStatus_FLASHIAP_Success) ? 0 : -EINVAL;
 }
 
-static int flash_lpc_read(const struct device *dev, off_t offset,
+static int flash_lpc_read(const struct device *dev, k_off_t offset,
 				void *data, size_t len)
 {
 	struct flash_priv *priv = dev->data;
@@ -94,7 +94,7 @@ static int flash_lpc_read(const struct device *dev, off_t offset,
 	return 0;
 }
 
-static int flash_lpc_write(const struct device *dev, off_t offset,
+static int flash_lpc_write(const struct device *dev, k_off_t offset,
 				const void *data, size_t len)
 {
 	struct flash_priv *priv = dev->data;

--- a/drivers/flash/soc_flash_mcux.c
+++ b/drivers/flash/soc_flash_mcux.c
@@ -147,7 +147,7 @@ static const struct flash_parameters flash_mcux_parameters = {
  *
  */
 
-static int flash_mcux_erase(const struct device *dev, off_t offset,
+static int flash_mcux_erase(const struct device *dev, k_off_t offset,
 			    size_t len)
 {
 	struct flash_priv *priv = dev->data;
@@ -181,7 +181,7 @@ static int flash_mcux_erase(const struct device *dev, off_t offset,
  * @return 	0 on success,
  * 			-EIO for erroneous area
  */
-static int flash_mcux_read(const struct device *dev, off_t offset,
+static int flash_mcux_read(const struct device *dev, k_off_t offset,
 				void *data, size_t len)
 {
 	struct flash_priv *priv = dev->data;
@@ -228,7 +228,7 @@ static int flash_mcux_read(const struct device *dev, off_t offset,
 	return rc;
 }
 
-static int flash_mcux_write(const struct device *dev, off_t offset,
+static int flash_mcux_write(const struct device *dev, k_off_t offset,
 				const void *data, size_t len)
 {
 	struct flash_priv *priv = dev->data;

--- a/drivers/flash/soc_flash_nios2_qspi.c
+++ b/drivers/flash/soc_flash_nios2_qspi.c
@@ -71,7 +71,7 @@ static const struct flash_parameters flash_nios2_qspi_parameters = {
 static int flash_nios2_qspi_write_protection(const struct device *dev,
 					     bool enable);
 
-static int flash_nios2_qspi_erase(const struct device *dev, off_t offset,
+static int flash_nios2_qspi_erase(const struct device *dev, k_off_t offset,
 				  size_t len)
 {
 	struct flash_nios2_qspi_config *flash_cfg = dev->data;
@@ -276,7 +276,7 @@ qspi_write_block_err:
 	return rc;
 }
 
-static int flash_nios2_qspi_write(const struct device *dev, off_t offset,
+static int flash_nios2_qspi_write(const struct device *dev, k_off_t offset,
 				  const void *data, size_t len)
 {
 	struct flash_nios2_qspi_config *flash_cfg = dev->data;
@@ -353,7 +353,7 @@ qspi_write_err:
 	return rc;
 }
 
-static int flash_nios2_qspi_read(const struct device *dev, off_t offset,
+static int flash_nios2_qspi_read(const struct device *dev, k_off_t offset,
 				 void *data, size_t len)
 {
 	struct flash_nios2_qspi_config *flash_cfg = dev->data;

--- a/drivers/flash/soc_flash_nrf_mram.c
+++ b/drivers/flash/soc_flash_nrf_mram.c
@@ -37,7 +37,7 @@ BUILD_ASSERT((ERASE_BLOCK_SIZE % WRITE_BLOCK_SIZE) == 0,
  * @return Absolute address in MRAM, or NULL if @p offset or @p len are not
  *         within bounds or appropriately aligned.
  */
-static uintptr_t validate_and_map_addr(off_t offset, size_t len, bool must_align)
+static uintptr_t validate_and_map_addr(k_off_t offset, size_t len, bool must_align)
 {
 	if (unlikely(offset < 0 || offset >= MRAM_SIZE || len > MRAM_SIZE - offset)) {
 		LOG_ERR("invalid offset: %ld:%zu", offset, len);
@@ -82,7 +82,7 @@ static void commit_changes(uintptr_t addr_end)
 	sys_write8(sys_read8(addr_end), addr_end);
 }
 
-static int nrf_mram_read(const struct device *dev, off_t offset, void *data, size_t len)
+static int nrf_mram_read(const struct device *dev, k_off_t offset, void *data, size_t len)
 {
 	ARG_UNUSED(dev);
 
@@ -99,7 +99,7 @@ static int nrf_mram_read(const struct device *dev, off_t offset, void *data, siz
 	return 0;
 }
 
-static int nrf_mram_write(const struct device *dev, off_t offset, const void *data, size_t len)
+static int nrf_mram_write(const struct device *dev, k_off_t offset, const void *data, size_t len)
 {
 	ARG_UNUSED(dev);
 
@@ -117,7 +117,7 @@ static int nrf_mram_write(const struct device *dev, off_t offset, const void *da
 	return 0;
 }
 
-static int nrf_mram_erase(const struct device *dev, off_t offset, size_t size)
+static int nrf_mram_erase(const struct device *dev, k_off_t offset, size_t size)
 {
 	ARG_UNUSED(dev);
 

--- a/drivers/flash/soc_flash_numaker.c
+++ b/drivers/flash/soc_flash_numaker.c
@@ -32,7 +32,7 @@ static const struct flash_parameters flash_numaker_parameters = {
 };
 
 /* Validate offset and length */
-static bool flash_numaker_is_range_valid(off_t offset, size_t len)
+static bool flash_numaker_is_range_valid(k_off_t offset, size_t len)
 {
 	uint32_t aprom_size = (FMC_APROM_END - FMC_APROM_BASE);
 
@@ -59,7 +59,7 @@ static bool flash_numaker_is_range_valid(off_t offset, size_t len)
  * return -EINVAL erroneous code
  */
 
-static int flash_numaker_erase(const struct device *dev, off_t offset, size_t len)
+static int flash_numaker_erase(const struct device *dev, k_off_t offset, size_t len)
 {
 	struct flash_numaker_data *dev_data = dev->data;
 	uint32_t rc = 0;
@@ -129,7 +129,7 @@ done:
  * return 0       on success,
  * return -EIO     erroneous code
  */
-static int flash_numaker_read(const struct device *dev, off_t offset, void *data, size_t len)
+static int flash_numaker_read(const struct device *dev, k_off_t offset, void *data, size_t len)
 {
 	struct flash_numaker_data *dev_data = dev->data;
 	uint32_t addr = dev_data->flash_block_base + offset;
@@ -168,7 +168,8 @@ static int32_t flash_numaker_block_write(uint32_t u32_addr, uint8_t *pu8_data, i
 	return retval;
 }
 
-static int flash_numaker_write(const struct device *dev, off_t offset, const void *data, size_t len)
+static int flash_numaker_write(const struct device *dev, k_off_t offset, const void *data,
+			       size_t len)
 {
 	struct flash_numaker_data *dev_data = dev->data;
 	uint32_t rc = 0;

--- a/drivers/flash/soc_flash_numaker_rmc.c
+++ b/drivers/flash/soc_flash_numaker_rmc.c
@@ -35,7 +35,7 @@ static const struct flash_parameters flash_numaker_parameters = {
 };
 
 /* Validate offset and length */
-static bool flash_numaker_is_range_valid(off_t offset, size_t len)
+static bool flash_numaker_is_range_valid(k_off_t offset, size_t len)
 {
 	uint32_t aprom_size = RMC_APROM_END - RMC_APROM_BASE;
 
@@ -62,7 +62,7 @@ static bool flash_numaker_is_range_valid(off_t offset, size_t len)
  * return -EINVAL erroneous code
  */
 
-static int flash_numaker_erase(const struct device *dev, off_t offset, size_t len)
+static int flash_numaker_erase(const struct device *dev, k_off_t offset, size_t len)
 {
 	struct flash_numaker_data *dev_data = dev->data;
 	uint32_t rc = 0;
@@ -122,7 +122,7 @@ done:
  * return 0       on success,
  * return -EIO     erroneous code
  */
-static int flash_numaker_read(const struct device *dev, off_t offset, void *data, size_t len)
+static int flash_numaker_read(const struct device *dev, k_off_t offset, void *data, size_t len)
 {
 	struct flash_numaker_data *dev_data = dev->data;
 	uint32_t addr = dev_data->flash_block_base + offset;
@@ -162,7 +162,8 @@ static int32_t flash_numaker_block_write(uint32_t u32_addr, const uint8_t *pu8_d
 	return retval;
 }
 
-static int flash_numaker_write(const struct device *dev, off_t offset, const void *data, size_t len)
+static int flash_numaker_write(const struct device *dev, k_off_t offset, const void *data,
+			       size_t len)
 {
 	struct flash_numaker_data *dev_data = dev->data;
 	uint32_t rc = 0;

--- a/drivers/flash/soc_flash_rv32m1.c
+++ b/drivers/flash/soc_flash_rv32m1.c
@@ -42,7 +42,7 @@ static const struct flash_parameters flash_mcux_parameters = {
  *
  */
 
-static int flash_mcux_erase(const struct device *dev, off_t offset,
+static int flash_mcux_erase(const struct device *dev, k_off_t offset,
 			    size_t len)
 {
 	struct flash_priv *priv = dev->data;
@@ -65,7 +65,7 @@ static int flash_mcux_erase(const struct device *dev, off_t offset,
 	return (rc == kStatus_Success) ? 0 : -EINVAL;
 }
 
-static int flash_mcux_read(const struct device *dev, off_t offset,
+static int flash_mcux_read(const struct device *dev, k_off_t offset,
 				void *data, size_t len)
 {
 	struct flash_priv *priv = dev->data;
@@ -83,7 +83,7 @@ static int flash_mcux_read(const struct device *dev, off_t offset,
 	return 0;
 }
 
-static int flash_mcux_write(const struct device *dev, off_t offset,
+static int flash_mcux_write(const struct device *dev, k_off_t offset,
 				const void *data, size_t len)
 {
 	struct flash_priv *priv = dev->data;

--- a/drivers/flash/soc_flash_xmc4xxx.c
+++ b/drivers/flash/soc_flash_xmc4xxx.c
@@ -53,7 +53,7 @@ static void flash_xmc4xxx_page_layout(const struct device *dev,
 }
 #endif
 
-static int flash_xmc4xxx_read(const struct device *dev, off_t offset, void *data, size_t len)
+static int flash_xmc4xxx_read(const struct device *dev, k_off_t offset, void *data, size_t len)
 {
 	const struct flash_xmc4xxx_config *dev_config = dev->config;
 
@@ -67,7 +67,8 @@ static int flash_xmc4xxx_read(const struct device *dev, off_t offset, void *data
 static __aligned(4) uint8_t
 	aligned_page[DT_PROP(DT_INST(0, infineon_xmc4xxx_nv_flash), write_block_size)];
 
-static int flash_xmc4xxx_write(const struct device *dev, off_t offset, const void *data, size_t len)
+static int flash_xmc4xxx_write(const struct device *dev, k_off_t offset, const void *data,
+			       size_t len)
 {
 	struct flash_xmc4xxx_data *dev_data = dev->data;
 	const struct flash_xmc4xxx_config *dev_config = dev->config;
@@ -114,7 +115,7 @@ static int flash_xmc4xxx_write(const struct device *dev, off_t offset, const voi
 }
 
 #if CONFIG_FLASH_PAGE_LAYOUT
-static int flash_xmc4xxx_erase(const struct device *dev, off_t offset, size_t size)
+static int flash_xmc4xxx_erase(const struct device *dev, k_off_t offset, size_t size)
 {
 	struct flash_xmc4xxx_data *dev_data = dev->data;
 	const struct flash_xmc4xxx_config *dev_config = dev->config;
@@ -163,7 +164,7 @@ finish:
 	return ret;
 }
 #else
-static int flash_xmc4xxx_erase(const struct device *dev, off_t offset, size_t size)
+static int flash_xmc4xxx_erase(const struct device *dev, k_off_t offset, size_t size)
 {
 	ARG_UNUSED(dev);
 	ARG_UNUSED(offset);

--- a/drivers/flash/spi_flash_at45.c
+++ b/drivers/flash/spi_flash_at45.c
@@ -236,12 +236,12 @@ static int configure_page_size(const struct device *dev)
 	return (err != 0) ? -EIO : 0;
 }
 
-static bool is_valid_request(off_t addr, size_t size, size_t chip_size)
+static bool is_valid_request(k_off_t addr, size_t size, size_t chip_size)
 {
 	return (addr >= 0 && (addr + size) <= chip_size);
 }
 
-static int spi_flash_at45_read(const struct device *dev, off_t offset,
+static int spi_flash_at45_read(const struct device *dev, k_off_t offset,
 			       void *data, size_t len)
 {
 	const struct spi_flash_at45_config *cfg = dev->config;
@@ -287,7 +287,7 @@ static int spi_flash_at45_read(const struct device *dev, off_t offset,
 	return (err != 0) ? -EIO : 0;
 }
 
-static int perform_write(const struct device *dev, off_t offset,
+static int perform_write(const struct device *dev, k_off_t offset,
 			 const void *data, size_t len)
 {
 	const struct spi_flash_at45_config *cfg = dev->config;
@@ -323,7 +323,7 @@ static int perform_write(const struct device *dev, off_t offset,
 	return (err != 0) ? -EIO : 0;
 }
 
-static int spi_flash_at45_write(const struct device *dev, off_t offset,
+static int spi_flash_at45_write(const struct device *dev, k_off_t offset,
 				const void *data, size_t len)
 {
 	const struct spi_flash_at45_config *cfg = dev->config;
@@ -343,9 +343,9 @@ static int spi_flash_at45_write(const struct device *dev, off_t offset,
 
 	while (len) {
 		size_t chunk_len = len;
-		off_t current_page_start =
+		k_off_t current_page_start =
 			offset - (offset & (cfg->page_size - 1));
-		off_t current_page_end = current_page_start + cfg->page_size;
+		k_off_t current_page_end = current_page_start + cfg->page_size;
 
 		if (chunk_len > (current_page_end - offset)) {
 			chunk_len = (current_page_end - offset);
@@ -397,14 +397,14 @@ static int perform_chip_erase(const struct device *dev)
 }
 
 static bool is_erase_possible(size_t entity_size,
-			      off_t offset, size_t requested_size)
+			      k_off_t offset, size_t requested_size)
 {
 	return (requested_size >= entity_size &&
 		(offset & (entity_size - 1)) == 0);
 }
 
 static int perform_erase_op(const struct device *dev, uint8_t opcode,
-			    off_t offset)
+			    k_off_t offset)
 {
 	const struct spi_flash_at45_config *cfg = dev->config;
 	int err;
@@ -433,7 +433,7 @@ static int perform_erase_op(const struct device *dev, uint8_t opcode,
 	return (err != 0) ? -EIO : 0;
 }
 
-static int spi_flash_at45_erase(const struct device *dev, off_t offset,
+static int spi_flash_at45_erase(const struct device *dev, k_off_t offset,
 				size_t size)
 {
 	const struct spi_flash_at45_config *cfg = dev->config;

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -368,7 +368,7 @@ static inline void delay_until_exit_dpd_ok(const struct device *const dev)
  */
 static int spi_nor_access(const struct device *const dev,
 			  uint8_t opcode, unsigned int access,
-			  off_t addr, void *data, size_t length)
+			  k_off_t addr, void *data, size_t length)
 {
 	const struct spi_nor_config *const driver_cfg = dev->config;
 	struct spi_nor_data *const driver_data = dev->data;
@@ -486,7 +486,7 @@ static int spi_nor_wait_until_ready(const struct device *dev, k_timeout_t poll_d
  * @return 0 on success, negative errno code otherwise
  */
 static int read_sfdp(const struct device *const dev,
-		     off_t addr, void *data, size_t length)
+		     k_off_t addr, void *data, size_t length)
 {
 	/* READ_SFDP requires a 24-bit address followed by a single
 	 * byte for a wait state.  This is effected by using 32-bit
@@ -772,7 +772,7 @@ static int mxicy_configure(const struct device *dev, const uint8_t *jedec_id)
 
 #endif /* ANY_INST_HAS_MXICY_MX25R_POWER_MODE */
 
-static int spi_nor_read(const struct device *dev, off_t addr, void *dest,
+static int spi_nor_read(const struct device *dev, k_off_t addr, void *dest,
 			size_t size)
 {
 	const size_t flash_size = dev_flash_size(dev);
@@ -819,7 +819,7 @@ static int flash_spi_nor_ex_op(const struct device *dev, uint16_t code,
 }
 #endif
 
-static int spi_nor_write(const struct device *dev, off_t addr,
+static int spi_nor_write(const struct device *dev, k_off_t addr,
 			 const void *src,
 			 size_t size)
 {
@@ -882,7 +882,7 @@ static int spi_nor_write(const struct device *dev, off_t addr,
 	return ret;
 }
 
-static int spi_nor_erase(const struct device *dev, off_t addr, size_t size)
+static int spi_nor_erase(const struct device *dev, k_off_t addr, size_t size)
 {
 	const size_t flash_size = dev_flash_size(dev);
 	int ret;
@@ -995,7 +995,7 @@ static int spi_nor_write_protection_set(const struct device *dev,
 
 #if defined(CONFIG_FLASH_JESD216_API) || defined(CONFIG_SPI_NOR_SFDP_RUNTIME)
 
-static int spi_nor_sfdp_read(const struct device *dev, off_t addr,
+static int spi_nor_sfdp_read(const struct device *dev, k_off_t addr,
 			     void *dest, size_t size)
 {
 	acquire_device(dev);

--- a/drivers/hwinfo/hwinfo_ambiq.c
+++ b/drivers/hwinfo/hwinfo_ambiq.c
@@ -9,7 +9,7 @@
 #include <string.h>
 #include <zephyr/sys/byteorder.h>
 
-ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
+int z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 {
 
 	struct ambiq_hwinfo {

--- a/drivers/hwinfo/hwinfo_andes.c
+++ b/drivers/hwinfo/hwinfo_andes.c
@@ -30,7 +30,7 @@
 static const struct device *const syscon_dev =
 			DEVICE_DT_GET(DT_NODELABEL(syscon));
 
-ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
+int z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 {
 	int ret = 0;
 	uint8_t id[3];

--- a/drivers/hwinfo/hwinfo_cc13xx_cc26xx.c
+++ b/drivers/hwinfo/hwinfo_cc13xx_cc26xx.c
@@ -20,7 +20,7 @@
 #define CC13XX_CC26XX_DEVID_SIZE	8
 #endif
 
-ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
+int z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 {
 	uint8_t *mac;
 

--- a/drivers/hwinfo/hwinfo_esp32.c
+++ b/drivers/hwinfo/hwinfo_esp32.c
@@ -13,7 +13,7 @@
 #include <zephyr/drivers/hwinfo.h>
 #include <string.h>
 
-ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
+int z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 {
 #if !defined(CONFIG_SOC_SERIES_ESP32)
 	uint32_t rdata1 = sys_read32(EFUSE_RD_MAC_SPI_SYS_0_REG);

--- a/drivers/hwinfo/hwinfo_gecko.c
+++ b/drivers/hwinfo/hwinfo_gecko.c
@@ -19,7 +19,7 @@
 #define HAS_BROWNOUT 1
 #endif
 
-ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
+int z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 {
 	uint64_t unique_id = sys_cpu_to_be64(SYSTEM_GetUnique());
 

--- a/drivers/hwinfo/hwinfo_handlers.c
+++ b/drivers/hwinfo/hwinfo_handlers.c
@@ -7,7 +7,7 @@
 #include <zephyr/internal/syscall_handler.h>
 #include <zephyr/drivers/hwinfo.h>
 
-ssize_t z_vrfy_hwinfo_get_device_id(uint8_t *buffer, size_t length)
+int z_vrfy_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 {
 	K_OOPS(K_SYSCALL_MEMORY_WRITE(buffer, length));
 
@@ -15,7 +15,7 @@ ssize_t z_vrfy_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 }
 #include <zephyr/syscalls/hwinfo_get_device_id_mrsh.c>
 
-ssize_t z_vrfy_hwinfo_get_device_eui64(uint8_t *buffer)
+int z_vrfy_hwinfo_get_device_eui64(uint8_t *buffer)
 {
 	K_OOPS(K_SYSCALL_MEMORY_WRITE(buffer, 8));
 

--- a/drivers/hwinfo/hwinfo_imxrt.c
+++ b/drivers/hwinfo/hwinfo_imxrt.c
@@ -13,7 +13,7 @@ struct imxrt_uid {
 	uint32_t id[2];
 };
 
-ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
+int z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 {
 	struct imxrt_uid dev_id;
 

--- a/drivers/hwinfo/hwinfo_litex.c
+++ b/drivers/hwinfo/hwinfo_litex.c
@@ -12,10 +12,10 @@
 #include <zephyr/device.h>
 #include <zephyr/sys/util.h>
 
-ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
+int z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 {
 	uint32_t addr = DT_INST_REG_ADDR(0);
-	ssize_t end = MIN(length, DT_INST_REG_ADDR(0) / 4 *
+	int end = MIN(length, DT_INST_REG_ADDR(0) / 4 *
 			CONFIG_LITEX_CSR_DATA_WIDTH / 8);
 	for (int i = 0; i < end; i++) {
 #if CONFIG_LITEX_CSR_DATA_WIDTH == 8

--- a/drivers/hwinfo/hwinfo_mcux_sim.c
+++ b/drivers/hwinfo/hwinfo_mcux_sim.c
@@ -25,7 +25,7 @@
 				       HWINFO_DEVICE_ID_LENGTH_M + \
 				       HWINFO_DEVICE_ID_LENGTH_H)
 
-ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
+int z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 {
 	uint32_t id[HWINFO_DEVICE_ID_LENGTH_TOTAL];
 	uint32_t *idp = id;

--- a/drivers/hwinfo/hwinfo_mcux_syscon.c
+++ b/drivers/hwinfo/hwinfo_mcux_syscon.c
@@ -16,7 +16,7 @@ struct uid {
 	uint32_t id[UID_WORD_COUNT];
 };
 
-ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
+int z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 {
 	volatile const uint32_t * const uid_addr = (uint32_t *) DT_INST_REG_ADDR(0);
 	struct uid dev_id;

--- a/drivers/hwinfo/hwinfo_nrf.c
+++ b/drivers/hwinfo/hwinfo_nrf.c
@@ -22,7 +22,7 @@ struct nrf_uid {
 	uint32_t id[2];
 };
 
-ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
+int z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 {
 	struct nrf_uid dev_id;
 	uint32_t deviceid[2];

--- a/drivers/hwinfo/hwinfo_psoc6.c
+++ b/drivers/hwinfo/hwinfo_psoc6.c
@@ -14,7 +14,7 @@
 
 #include <cy_syslib.h>
 
-ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
+int z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 {
 	uint8_t *uid_addr = (uint8_t *) DT_INST_REG_ADDR(0);
 

--- a/drivers/hwinfo/hwinfo_rpi_pico.c
+++ b/drivers/hwinfo/hwinfo_rpi_pico.c
@@ -15,7 +15,7 @@
 #define HAD_PSM_RESTART_BIT BIT(VREG_AND_CHIP_RESET_CHIP_RESET_HAD_PSM_RESTART_LSB)
 #define HAD_POR_BIT BIT(VREG_AND_CHIP_RESET_CHIP_RESET_HAD_POR_LSB)
 
-ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
+int z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 {
 	uint8_t id[FLASH_RUID_DATA_BYTES];
 	uint32_t key;

--- a/drivers/hwinfo/hwinfo_rw61x.c
+++ b/drivers/hwinfo/hwinfo_rw61x.c
@@ -16,7 +16,7 @@
  */
 static bool reset_cleared;
 
-ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
+int z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 {
 	uint32_t id_length = length;
 
@@ -24,7 +24,7 @@ ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 		return -EINVAL;
 	}
 
-	return (ssize_t)id_length;
+	return (int)id_length;
 }
 
 int z_impl_hwinfo_get_supported_reset_cause(uint32_t *supported)

--- a/drivers/hwinfo/hwinfo_sam.c
+++ b/drivers/hwinfo/hwinfo_sam.c
@@ -12,7 +12,7 @@
 
 static uint8_t sam_uid[16];
 
-ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
+int z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 {
 	if (length > sizeof(sam_uid)) {
 		length = sizeof(sam_uid);

--- a/drivers/hwinfo/hwinfo_sam0.c
+++ b/drivers/hwinfo/hwinfo_sam0.c
@@ -15,7 +15,7 @@ struct sam0_uid {
 	uint32_t id[4];
 };
 
-ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
+int z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 {
 	struct sam0_uid dev_id;
 

--- a/drivers/hwinfo/hwinfo_sam4l.c
+++ b/drivers/hwinfo/hwinfo_sam4l.c
@@ -12,7 +12,7 @@
 #include <soc.h>
 #include <string.h>
 
-ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
+int z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 {
 	uint8_t *uid_addr = (uint8_t *) DT_INST_REG_ADDR(0);
 

--- a/drivers/hwinfo/hwinfo_shell.c
+++ b/drivers/hwinfo/hwinfo_shell.c
@@ -13,7 +13,7 @@
 static int cmd_get_device_id(const struct shell *sh, size_t argc, char **argv)
 {
 	uint8_t dev_id[16];
-	ssize_t length;
+	int length;
 	int i;
 
 	length = hwinfo_get_device_id(dev_id, sizeof(dev_id));

--- a/drivers/hwinfo/hwinfo_stm32.c
+++ b/drivers/hwinfo/hwinfo_stm32.c
@@ -19,7 +19,7 @@ struct stm32_uid {
 	uint32_t id[3];
 };
 
-ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
+int z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 {
 	struct stm32_uid dev_id;
 

--- a/drivers/hwinfo/hwinfo_weak_impl.c
+++ b/drivers/hwinfo/hwinfo_weak_impl.c
@@ -6,7 +6,7 @@
 
 #include <zephyr/drivers/hwinfo.h>
 
-ssize_t __weak z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
+int __weak z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 {
 	return -ENOSYS;
 }

--- a/drivers/input/input_analog_axis_settings.c
+++ b/drivers/input/input_analog_axis_settings.c
@@ -40,7 +40,7 @@ static int analog_axis_calibration_load(const char *key, size_t len_rd,
 	char dev_name[ANALOG_AXIS_SETTINGS_PATH_MAX];
 	const char *next;
 	int nlen;
-	ssize_t len;
+	k_ssize_t len;
 
 	nlen = settings_name_next(key, &next);
 	if (nlen + 1 > sizeof(dev_name)) {

--- a/drivers/memc/memc_mcux_flexspi.c
+++ b/drivers/memc/memc_mcux_flexspi.c
@@ -251,7 +251,7 @@ int memc_flexspi_transfer(const struct device *dev,
 }
 
 void *memc_flexspi_get_ahb_address(const struct device *dev,
-		flexspi_port_t port, off_t offset)
+		flexspi_port_t port, k_off_t offset)
 {
 	struct memc_flexspi_data *data = dev->data;
 	int i;

--- a/drivers/memc/memc_mcux_flexspi.h
+++ b/drivers/memc/memc_mcux_flexspi.h
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/device.h>
-#include <sys/types.h>
 #include <fsl_flexspi.h>
 
 /* Size of a command in the LUT table */
@@ -99,5 +98,4 @@ int memc_flexspi_transfer(const struct device *dev,
  * @param offset: byte offset from start of device to get AHB address for
  * @return 0 on success, negative value on failure
  */
-void *memc_flexspi_get_ahb_address(const struct device *dev,
-		flexspi_port_t port, off_t offset);
+void *memc_flexspi_get_ahb_address(const struct device *dev, flexspi_port_t port, k_off_t offset);

--- a/drivers/memc/memc_nxp_s32_qspi.h
+++ b/drivers/memc/memc_nxp_s32_qspi.h
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/device.h>
-#include <sys/types.h>
 
 #include <Qspi_Ip.h>
 

--- a/drivers/mipi_dsi/dsi_mcux.c
+++ b/drivers/mipi_dsi/dsi_mcux.c
@@ -217,7 +217,7 @@ static int dsi_mcux_attach(const struct device *dev,
 	return 0;
 }
 
-static ssize_t dsi_mcux_transfer(const struct device *dev, uint8_t channel,
+static k_ssize_t dsi_mcux_transfer(const struct device *dev, uint8_t channel,
 				 struct mipi_dsi_msg *msg)
 {
 	const struct display_mcux_mipi_dsi_config *config = dev->config;

--- a/drivers/mipi_dsi/dsi_mcux_2l.c
+++ b/drivers/mipi_dsi/dsi_mcux_2l.c
@@ -364,7 +364,7 @@ static int dsi_mcux_detach(const struct device *dev, uint8_t channel,
 
 
 
-static ssize_t dsi_mcux_transfer(const struct device *dev, uint8_t channel,
+static k_ssize_t dsi_mcux_transfer(const struct device *dev, uint8_t channel,
 				 struct mipi_dsi_msg *msg)
 {
 	const struct mcux_mipi_dsi_config *config = dev->config;

--- a/drivers/mipi_dsi/dsi_stm32.c
+++ b/drivers/mipi_dsi/dsi_stm32.c
@@ -310,13 +310,13 @@ static int mipi_dsi_stm32_attach(const struct device *dev, uint8_t channel,
 	return 0;
 }
 
-static ssize_t mipi_dsi_stm32_transfer(const struct device *dev, uint8_t channel,
+static k_ssize_t mipi_dsi_stm32_transfer(const struct device *dev, uint8_t channel,
 				       struct mipi_dsi_msg *msg)
 {
 	struct mipi_dsi_stm32_data *data = dev->data;
 	uint32_t param1 = 0;
 	uint32_t param2 = 0;
-	ssize_t len;
+	k_ssize_t len;
 	int ret;
 
 	switch (msg->type) {

--- a/drivers/mipi_dsi/mipi_dsi.c
+++ b/drivers/mipi_dsi/mipi_dsi.c
@@ -8,7 +8,7 @@
 
 #include <zephyr/drivers/mipi_dsi.h>
 
-ssize_t mipi_dsi_generic_read(const struct device *dev, uint8_t channel,
+k_ssize_t mipi_dsi_generic_read(const struct device *dev, uint8_t channel,
 			      const void *params, size_t nparams,
 			      void *buf, size_t len)
 {
@@ -39,7 +39,7 @@ ssize_t mipi_dsi_generic_read(const struct device *dev, uint8_t channel,
 	return mipi_dsi_transfer(dev, channel, &msg);
 }
 
-ssize_t mipi_dsi_generic_write(const struct device *dev, uint8_t channel,
+k_ssize_t mipi_dsi_generic_write(const struct device *dev, uint8_t channel,
 			       const void *buf, size_t len)
 {
 	struct mipi_dsi_msg msg = {
@@ -68,7 +68,7 @@ ssize_t mipi_dsi_generic_write(const struct device *dev, uint8_t channel,
 	return mipi_dsi_transfer(dev, channel, &msg);
 }
 
-ssize_t mipi_dsi_dcs_read(const struct device *dev, uint8_t channel,
+k_ssize_t mipi_dsi_dcs_read(const struct device *dev, uint8_t channel,
 			  uint8_t cmd, void *buf, size_t len)
 {
 	struct mipi_dsi_msg msg = {
@@ -81,7 +81,7 @@ ssize_t mipi_dsi_dcs_read(const struct device *dev, uint8_t channel,
 	return mipi_dsi_transfer(dev, channel, &msg);
 }
 
-ssize_t mipi_dsi_dcs_write(const struct device *dev, uint8_t channel,
+k_ssize_t mipi_dsi_dcs_write(const struct device *dev, uint8_t channel,
 			   uint8_t cmd, const void *buf, size_t len)
 {
 	struct mipi_dsi_msg msg = {

--- a/drivers/misc/devmux/devmux.c
+++ b/drivers/misc/devmux/devmux.c
@@ -72,9 +72,9 @@ struct devmux_data *devmux_data_get(const struct device *dev)
 	return NULL;
 }
 
-ssize_t z_impl_devmux_select_get(const struct device *dev)
+int z_impl_devmux_select_get(const struct device *dev)
 {
-	ssize_t index;
+	int index;
 	struct devmux_data *const data = devmux_data_get(dev);
 
 	if (!devmux_device_is_valid(dev)) {
@@ -83,14 +83,14 @@ ssize_t z_impl_devmux_select_get(const struct device *dev)
 
 	K_SPINLOCK(&data->lock)
 	{
-		index = data->selected;
+		index = (int)data->selected;
 	}
 
 	return index;
 }
 
 #ifdef CONFIG_USERSPACE
-ssize_t z_vrfy_devmux_select_get(const struct device *dev)
+int z_vrfy_devmux_select_get(const struct device *dev)
 {
 	return z_impl_devmux_select_get(dev);
 }

--- a/drivers/modem/quectel-bg9x.c
+++ b/drivers/modem/quectel-bg9x.c
@@ -437,12 +437,9 @@ MODEM_CMD_DEFINE(on_cmd_unsol_rdy)
 /* Func: send_socket_data
  * Desc: This function will send "binary" data over the socket object.
  */
-static ssize_t send_socket_data(struct modem_socket *sock,
-				const struct sockaddr *dst_addr,
-				struct modem_cmd *handler_cmds,
-				size_t handler_cmds_len,
-				const char *buf, size_t buf_len,
-				k_timeout_t timeout)
+static k_ssize_t send_socket_data(struct modem_socket *sock, const struct sockaddr *dst_addr,
+				     struct modem_cmd *handler_cmds, size_t handler_cmds_len,
+				     const char *buf, size_t buf_len, k_timeout_t timeout)
 {
 	int  ret;
 	char send_buf[sizeof("AT+QISEND=##,####")] = {0};
@@ -517,9 +514,8 @@ exit:
 /* Func: offload_sendto
  * Desc: This function will send data on the socket object.
  */
-static ssize_t offload_sendto(void *obj, const void *buf, size_t len,
-			      int flags, const struct sockaddr *to,
-			      socklen_t tolen)
+static k_ssize_t offload_sendto(void *obj, const void *buf, size_t len, int flags,
+				   const struct sockaddr *to, socklen_t tolen)
 {
 	int ret;
 	struct modem_socket *sock = (struct modem_socket *) obj;
@@ -574,9 +570,8 @@ static ssize_t offload_sendto(void *obj, const void *buf, size_t len,
 /* Func: offload_recvfrom
  * Desc: This function will receive data on the socket object.
  */
-static ssize_t offload_recvfrom(void *obj, void *buf, size_t len,
-				int flags, struct sockaddr *from,
-				socklen_t *fromlen)
+static k_ssize_t offload_recvfrom(void *obj, void *buf, size_t len, int flags,
+				     struct sockaddr *from, socklen_t *fromlen)
 {
 	struct modem_socket *sock = (struct modem_socket *)obj;
 	char   sendbuf[sizeof("AT+QIRD=##,####")] = {0};
@@ -635,7 +630,7 @@ exit:
 /* Func: offload_read
  * Desc: This function reads data from the given socket object.
  */
-static ssize_t offload_read(void *obj, void *buffer, size_t count)
+static k_ssize_t offload_read(void *obj, void *buffer, size_t count)
 {
 	return offload_recvfrom(obj, buffer, count, 0, NULL, 0);
 }
@@ -643,7 +638,7 @@ static ssize_t offload_read(void *obj, void *buffer, size_t count)
 /* Func: offload_write
  * Desc: This function writes data to the given socket object.
  */
-static ssize_t offload_write(void *obj, const void *buffer, size_t count)
+static k_ssize_t offload_write(void *obj, const void *buffer, size_t count)
 {
 	return offload_sendto(obj, buffer, count, 0, NULL, 0);
 }
@@ -811,9 +806,9 @@ static int offload_close(void *obj)
 /* Func: offload_sendmsg
  * Desc: This function sends messages to the modem.
  */
-static ssize_t offload_sendmsg(void *obj, const struct msghdr *msg, int flags)
+static k_ssize_t offload_sendmsg(void *obj, const struct msghdr *msg, int flags)
 {
-	ssize_t sent = 0;
+	k_ssize_t sent = 0;
 	int rc;
 
 	LOG_DBG("msg_iovlen:%zd flags:%d", msg->msg_iovlen, flags);
@@ -840,7 +835,7 @@ static ssize_t offload_sendmsg(void *obj, const struct msghdr *msg, int flags)
 		}
 	}
 
-	return (ssize_t) sent;
+	return (k_ssize_t)sent;
 }
 
 /* Func: modem_rx

--- a/drivers/modem/simcom-sim7080.c
+++ b/drivers/modem/simcom-sim7080.c
@@ -214,8 +214,8 @@ error:
  * As terminating byte a STRG+Z (0x1A) is sent. The module will
  * then send a OK or ERROR.
  */
-static ssize_t offload_sendto(void *obj, const void *buf, size_t len, int flags,
-			      const struct sockaddr *dest_addr, socklen_t addrlen)
+static k_ssize_t offload_sendto(void *obj, const void *buf, size_t len, int flags,
+				   const struct sockaddr *dest_addr, socklen_t addrlen)
 {
 	int ret;
 	struct modem_socket *sock = (struct modem_socket *)obj;
@@ -372,8 +372,8 @@ MODEM_CMD_DEFINE(on_cmd_carecv)
 /*
  * Read data from a given socket.
  */
-static ssize_t offload_recvfrom(void *obj, void *buf, size_t max_len, int flags,
-				struct sockaddr *src_addr, socklen_t *addrlen)
+static k_ssize_t offload_recvfrom(void *obj, void *buf, size_t max_len, int flags,
+				     struct sockaddr *src_addr, socklen_t *addrlen)
 {
 	struct modem_socket *sock = (struct modem_socket *)obj;
 	char sendbuf[sizeof("AT+CARECV=##,####")];
@@ -446,10 +446,10 @@ exit:
 /*
  * Sends messages to the modem.
  */
-static ssize_t offload_sendmsg(void *obj, const struct msghdr *msg, int flags)
+static k_ssize_t offload_sendmsg(void *obj, const struct msghdr *msg, int flags)
 {
 	struct modem_socket *sock = obj;
-	ssize_t sent = 0;
+	k_ssize_t sent = 0;
 	const char *buf;
 	size_t len;
 	int ret;
@@ -516,7 +516,7 @@ static void socket_close(struct modem_socket *sock)
 /*
  * Offloads read by reading from a given socket.
  */
-static ssize_t offload_read(void *obj, void *buffer, size_t count)
+static k_ssize_t offload_read(void *obj, void *buffer, size_t count)
 {
 	return offload_recvfrom(obj, buffer, count, 0, NULL, 0);
 }
@@ -524,7 +524,7 @@ static ssize_t offload_read(void *obj, void *buffer, size_t count)
 /*
  * Offloads write by writing to a given socket.
  */
-static ssize_t offload_write(void *obj, const void *buffer, size_t count)
+static k_ssize_t offload_write(void *obj, const void *buffer, size_t count)
 {
 	return offload_sendto(obj, buffer, count, 0, NULL, 0);
 }

--- a/drivers/net/nsos_sockets.c
+++ b/drivers/net/nsos_sockets.c
@@ -22,7 +22,6 @@ LOG_MODULE_REGISTER(nsos_sockets);
 #include <zephyr/net/net_ip.h>
 #include <zephyr/net/offloaded_netdev.h>
 #include <zephyr/net/socket_offload.h>
-#include <zephyr/posix/fcntl.h>
 #include <zephyr/sys/fdtable.h>
 #include <zephyr/sys/dlist.h>
 
@@ -220,7 +219,7 @@ static int nsos_adapt_get_zephyr_errno(void)
 	return errno_from_nsos_mid(nsos_adapt_get_errno());
 }
 
-static ssize_t nsos_read(void *obj, void *buf, size_t sz)
+static k_ssize_t nsos_read(void *obj, void *buf, size_t sz)
 {
 	struct nsos_socket *sock = obj;
 	int ret;
@@ -233,7 +232,7 @@ static ssize_t nsos_read(void *obj, void *buf, size_t sz)
 	return ret;
 }
 
-static ssize_t nsos_write(void *obj, const void *buf, size_t sz)
+static k_ssize_t nsos_write(void *obj, const void *buf, size_t sz)
 {
 	struct nsos_socket *sock = obj;
 	int ret;
@@ -362,7 +361,7 @@ static int nsos_ioctl(void *obj, unsigned int request, va_list args)
 	case ZFD_IOCTL_POLL_OFFLOAD:
 		return -EOPNOTSUPP;
 
-	case F_GETFL: {
+	case ZVFS_F_GETFL: {
 		int flags;
 
 		flags = nsos_adapt_fcntl_getfl(sock->poll.mid.fd);
@@ -370,7 +369,7 @@ static int nsos_ioctl(void *obj, unsigned int request, va_list args)
 		return fl_from_nsos_mid(flags);
 	}
 
-	case F_SETFL: {
+	case ZVFS_F_SETFL: {
 		int flags = va_arg(args, int);
 		int ret;
 
@@ -734,8 +733,8 @@ return_ret:
 	return -1;
 }
 
-static ssize_t nsos_sendto(void *obj, const void *buf, size_t len, int flags,
-			   const struct sockaddr *addr, socklen_t addrlen)
+static k_ssize_t nsos_sendto(void *obj, const void *buf, size_t len, int flags,
+			     const struct sockaddr *addr, socklen_t addrlen)
 {
 	struct nsos_socket *sock = obj;
 	struct nsos_mid_sockaddr_storage addr_storage_mid;
@@ -773,7 +772,7 @@ return_ret:
 	return ret;
 }
 
-static ssize_t nsos_sendmsg(void *obj, const struct msghdr *msg, int flags)
+static k_ssize_t nsos_sendmsg(void *obj, const struct msghdr *msg, int flags)
 {
 	struct nsos_socket *sock = obj;
 	struct nsos_mid_sockaddr_storage addr_storage_mid;
@@ -834,8 +833,9 @@ return_ret:
 	return ret;
 }
 
-static ssize_t nsos_recvfrom(void *obj, void *buf, size_t len, int flags,
-			     struct sockaddr *addr, socklen_t *addrlen)
+static k_ssize_t nsos_recvfrom(void *obj, void *buf, size_t len, int flags, struct sockaddr *addr,
+			       socklen_t *addrlen)
+
 {
 	struct nsos_socket *sock = obj;
 	struct nsos_mid_sockaddr_storage addr_storage_mid;
@@ -873,7 +873,7 @@ return_ret:
 	return ret;
 }
 
-static ssize_t nsos_recvmsg(void *obj, struct msghdr *msg, int flags)
+static k_ssize_t nsos_recvmsg(void *obj, struct msghdr *msg, int flags)
 {
 	errno = ENOTSUP;
 	return -1;

--- a/drivers/retained_mem/retained_mem_handlers.c
+++ b/drivers/retained_mem/retained_mem_handlers.c
@@ -7,14 +7,14 @@
 #include <zephyr/drivers/retained_mem.h>
 #include <zephyr/internal/syscall_handler.h>
 
-static inline ssize_t z_vrfy_retained_mem_size(const struct device *dev)
+static inline k_ssize_t z_vrfy_retained_mem_size(const struct device *dev)
 {
 	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_RETAINED_MEM));
 	return z_impl_retained_mem_size(dev);
 }
 #include <zephyr/syscalls/retained_mem_size_mrsh.c>
 
-static inline int z_vrfy_retained_mem_read(const struct device *dev, off_t offset,
+static inline int z_vrfy_retained_mem_read(const struct device *dev, k_off_t offset,
 					   uint8_t *buffer, size_t size)
 {
 	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_RETAINED_MEM));
@@ -23,7 +23,7 @@ static inline int z_vrfy_retained_mem_read(const struct device *dev, off_t offse
 }
 #include <zephyr/syscalls/retained_mem_read_mrsh.c>
 
-static inline int z_vrfy_retained_mem_write(const struct device *dev, off_t offset,
+static inline int z_vrfy_retained_mem_write(const struct device *dev, k_off_t offset,
 					    const uint8_t *buffer, size_t size)
 {
 	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_RETAINED_MEM));

--- a/drivers/retained_mem/retained_mem_nrf_gpregret.c
+++ b/drivers/retained_mem/retained_mem_nrf_gpregret.c
@@ -60,14 +60,14 @@ static int nrf_gpregret_init(const struct device *dev)
 	return 0;
 }
 
-static ssize_t nrf_gpregret_size(const struct device *dev)
+static k_ssize_t nrf_gpregret_size(const struct device *dev)
 {
 	const struct nrf_gpregret_config *config = dev->config;
 
-	return (ssize_t)config->size;
+	return (k_ssize_t)config->size;
 }
 
-static int nrf_gpregret_read(const struct device *dev, off_t offset, uint8_t *buffer, size_t size)
+static int nrf_gpregret_read(const struct device *dev, k_off_t offset, uint8_t *buffer, size_t size)
 {
 	const struct nrf_gpregret_config *config = dev->config;
 
@@ -80,7 +80,7 @@ static int nrf_gpregret_read(const struct device *dev, off_t offset, uint8_t *bu
 	return 0;
 }
 
-static int nrf_gpregret_write(const struct device *dev, off_t offset, const uint8_t *buffer,
+static int nrf_gpregret_write(const struct device *dev, k_off_t offset, const uint8_t *buffer,
 			      size_t size)
 {
 	const struct nrf_gpregret_config *config = dev->config;

--- a/drivers/retained_mem/retained_mem_zephyr_ram.c
+++ b/drivers/retained_mem/retained_mem_zephyr_ram.c
@@ -60,14 +60,14 @@ static int zephyr_retained_mem_ram_init(const struct device *dev)
 	return 0;
 }
 
-static ssize_t zephyr_retained_mem_ram_size(const struct device *dev)
+static k_ssize_t zephyr_retained_mem_ram_size(const struct device *dev)
 {
 	const struct zephyr_retained_mem_ram_config *config = dev->config;
 
-	return (ssize_t)config->size;
+	return (k_ssize_t)config->size;
 }
 
-static int zephyr_retained_mem_ram_read(const struct device *dev, off_t offset, uint8_t *buffer,
+static int zephyr_retained_mem_ram_read(const struct device *dev, k_off_t offset, uint8_t *buffer,
 					size_t size)
 {
 	const struct zephyr_retained_mem_ram_config *config = dev->config;
@@ -81,7 +81,7 @@ static int zephyr_retained_mem_ram_read(const struct device *dev, off_t offset, 
 	return 0;
 }
 
-static int zephyr_retained_mem_ram_write(const struct device *dev, off_t offset,
+static int zephyr_retained_mem_ram_write(const struct device *dev, k_off_t offset,
 					 const uint8_t *buffer, size_t size)
 {
 	const struct zephyr_retained_mem_ram_config *config = dev->config;

--- a/drivers/retained_mem/retained_mem_zephyr_reg.c
+++ b/drivers/retained_mem/retained_mem_zephyr_reg.c
@@ -61,14 +61,14 @@ static int zephyr_retained_mem_reg_init(const struct device *dev)
 	return 0;
 }
 
-static ssize_t zephyr_retained_mem_reg_size(const struct device *dev)
+static k_ssize_t zephyr_retained_mem_reg_size(const struct device *dev)
 {
 	const struct zephyr_retained_mem_reg_config *config = dev->config;
 
-	return (ssize_t)config->size;
+	return (k_ssize_t)config->size;
 }
 
-static int zephyr_retained_mem_reg_read(const struct device *dev, off_t offset, uint8_t *buffer,
+static int zephyr_retained_mem_reg_read(const struct device *dev, k_off_t offset, uint8_t *buffer,
 					size_t size)
 {
 	const struct zephyr_retained_mem_reg_config *config = dev->config;
@@ -82,7 +82,7 @@ static int zephyr_retained_mem_reg_read(const struct device *dev, off_t offset, 
 	return 0;
 }
 
-static int zephyr_retained_mem_reg_write(const struct device *dev, off_t offset,
+static int zephyr_retained_mem_reg_write(const struct device *dev, k_off_t offset,
 					 const uint8_t *buffer, size_t size)
 {
 	const struct zephyr_retained_mem_reg_config *config = dev->config;

--- a/drivers/sensor/ti/tmp116/tmp116.c
+++ b/drivers/sensor/ti/tmp116/tmp116.c
@@ -48,8 +48,7 @@ static int tmp116_reg_write(const struct device *dev, uint8_t reg,
 	return i2c_write_dt(&cfg->bus, tx_buf, sizeof(tx_buf));
 }
 
-static bool check_eeprom_bounds(const struct device *dev, off_t offset,
-			       size_t len)
+static bool check_eeprom_bounds(const struct device *dev, k_off_t offset, size_t len)
 {
 	struct tmp116_data *drv_data = dev->data;
 
@@ -69,8 +68,7 @@ static bool check_eeprom_bounds(const struct device *dev, off_t offset,
 	return true;
 }
 
-int tmp116_eeprom_write(const struct device *dev, off_t offset,
-			const void *data, size_t len)
+int tmp116_eeprom_write(const struct device *dev, k_off_t offset, const void *data, size_t len)
 {
 	uint8_t reg;
 	const uint16_t *src = data;
@@ -113,8 +111,7 @@ int tmp116_eeprom_write(const struct device *dev, off_t offset,
 	return res;
 }
 
-int tmp116_eeprom_read(const struct device *dev, off_t offset, void *data,
-		       size_t len)
+int tmp116_eeprom_read(const struct device *dev, k_off_t offset, void *data, size_t len)
 {
 	uint8_t reg;
 	uint16_t *dst = data;

--- a/drivers/wifi/eswifi/eswifi_socket_offload.c
+++ b/drivers/wifi/eswifi/eswifi_socket_offload.c
@@ -262,8 +262,7 @@ static int eswifi_socket_setsockopt(void *obj, int level, int optname,
 	return ret;
 }
 
-static ssize_t eswifi_socket_send(void *obj, const void *buf, size_t len,
-				  int flags)
+static k_ssize_t eswifi_socket_send(void *obj, const void *buf, size_t len, int flags)
 {
 	int sock = OBJ_TO_SD(obj);
 	struct eswifi_off_socket *socket;
@@ -305,9 +304,8 @@ static ssize_t eswifi_socket_send(void *obj, const void *buf, size_t len,
 	return ret;
 }
 
-static ssize_t eswifi_socket_sendto(void *obj, const void *buf, size_t len,
-				    int flags, const struct sockaddr *to,
-				    socklen_t tolen)
+static k_ssize_t eswifi_socket_sendto(void *obj, const void *buf, size_t len, int flags,
+					 const struct sockaddr *to, socklen_t tolen)
 {
 	if (to != NULL) {
 		errno = EOPNOTSUPP;
@@ -317,8 +315,7 @@ static ssize_t eswifi_socket_sendto(void *obj, const void *buf, size_t len,
 	return eswifi_socket_send(obj, buf, len, flags);
 }
 
-static ssize_t eswifi_socket_recv(void *obj, void *buf, size_t max_len,
-				  int flags)
+static k_ssize_t eswifi_socket_recv(void *obj, void *buf, size_t max_len, int flags)
 {
 	int sock = OBJ_TO_SD(obj);
 	struct eswifi_off_socket *socket;
@@ -386,9 +383,8 @@ done:
 	return len;
 }
 
-static ssize_t eswifi_socket_recvfrom(void *obj, void *buf, size_t len,
-				      int flags, struct sockaddr *from,
-				      socklen_t *fromlen)
+static k_ssize_t eswifi_socket_recvfrom(void *obj, void *buf, size_t len, int flags,
+					   struct sockaddr *from, socklen_t *fromlen)
 {
 	if (fromlen != NULL) {
 		errno = EOPNOTSUPP;
@@ -628,13 +624,12 @@ static int eswifi_socket_ioctl(void *obj, unsigned int request, va_list args)
 	}
 }
 
-static ssize_t eswifi_socket_read(void *obj, void *buffer, size_t count)
+static k_ssize_t eswifi_socket_read(void *obj, void *buffer, size_t count)
 {
 	return eswifi_socket_recvfrom(obj, buffer, count, 0, NULL, 0);
 }
 
-static ssize_t eswifi_socket_write(void *obj, const void *buffer,
-				   size_t count)
+static k_ssize_t eswifi_socket_write(void *obj, const void *buffer, size_t count)
 {
 	return eswifi_socket_sendto(obj, buffer, count, 0, NULL, 0);
 }

--- a/drivers/wifi/simplelink/simplelink_sockets.c
+++ b/drivers/wifi/simplelink/simplelink_sockets.c
@@ -869,7 +869,7 @@ exit:
  */
 static int handle_recv_flags(int sd, int flags, bool set, int *nb_enabled)
 {
-	ssize_t retval = 0;
+	k_ssize_t retval = 0;
 	SlSocklen_t optlen = sizeof(SlSockNonblocking_t);
 	SlSockNonblocking_t enableOption;
 
@@ -902,11 +902,11 @@ static int handle_recv_flags(int sd, int flags, bool set, int *nb_enabled)
 	return retval;
 }
 
-static ssize_t simplelink_recvfrom(void *obj, void *buf, size_t len, int flags,
+static k_ssize_t simplelink_recvfrom(void *obj, void *buf, size_t len, int flags,
 				   struct sockaddr *from, socklen_t *fromlen)
 {
 	int sd = OBJ_TO_SD(obj);
-	ssize_t retval;
+	k_ssize_t retval;
 	SlSockAddr_t *sl_addr;
 	SlSockAddrIn_t sl_addr_in;
 	SlSockAddrIn6_t sl_addr_in6;
@@ -922,10 +922,10 @@ static ssize_t simplelink_recvfrom(void *obj, void *buf, size_t len, int flags,
 							    &sl_addr_in,
 							    &sl_addr_in6,
 							    &sl_addrlen);
-			retval = (ssize_t)sl_RecvFrom(sd, buf, len, 0, sl_addr,
+			retval = (k_ssize_t)sl_RecvFrom(sd, buf, len, 0, sl_addr,
 						      &sl_addrlen);
 		} else {
-			retval = (ssize_t)sl_Recv(sd, buf, len, 0);
+			retval = (k_ssize_t)sl_Recv(sd, buf, len, 0);
 		}
 
 		handle_recv_flags(sd, flags, FALSE, &nb_enabled);
@@ -948,12 +948,12 @@ static ssize_t simplelink_recvfrom(void *obj, void *buf, size_t len, int flags,
 	return retval;
 }
 
-static ssize_t simplelink_sendto(void *obj, const void *buf, size_t len,
+static k_ssize_t simplelink_sendto(void *obj, const void *buf, size_t len,
 				 int flags, const struct sockaddr *to,
 				 socklen_t tolen)
 {
 	int sd = OBJ_TO_SD(obj);
-	ssize_t retval;
+	k_ssize_t retval;
 	SlSockAddr_t *sl_addr;
 	SlSockAddrIn_t sl_addr_in;
 	SlSockAddrIn6_t sl_addr_in6;
@@ -972,7 +972,7 @@ static ssize_t simplelink_sendto(void *obj, const void *buf, size_t len,
 		retval = sl_SendTo(sd, buf, (uint16_t)len, flags,
 				   sl_addr, sl_addrlen);
 	} else {
-		retval = (ssize_t)sl_Send(sd, buf, len, flags);
+		retval = (k_ssize_t)sl_Send(sd, buf, len, flags);
 	}
 
 exit:
@@ -983,7 +983,7 @@ exit:
 	return retval;
 }
 
-static ssize_t simplelink_sendmsg(void *obj, const struct msghdr *msg,
+static k_ssize_t simplelink_sendmsg(void *obj, const struct msghdr *msg,
 				  int flags)
 {
 	errno = -ENOTSUP;
@@ -1143,7 +1143,7 @@ static int simplelink_fcntl(int sd, int cmd, va_list args)
 	SlSocklen_t optlen = sizeof(SlSockNonblocking_t);
 
 	switch (cmd) {
-	case F_GETFL:
+	case ZVFS_F_GETFL:
 		retval = sl_GetSockOpt(sd, SL_SOL_SOCKET, SL_SO_NONBLOCKING,
 			(_u8 *)&enableOption, &optlen);
 		if (retval == 0) {
@@ -1152,7 +1152,7 @@ static int simplelink_fcntl(int sd, int cmd, va_list args)
 			}
 		}
 		break;
-	case F_SETFL:
+	case ZVFS_F_SETFL:
 		if ((va_arg(args, int) & O_NONBLOCK) != 0) {
 			enableOption.NonBlockingEnabled = 1;
 		} else {
@@ -1206,12 +1206,12 @@ static int simplelink_ioctl(void *obj, unsigned int request, va_list args)
 	}
 }
 
-static ssize_t simplelink_read(void *obj, void *buffer, size_t count)
+static k_ssize_t simplelink_read(void *obj, void *buffer, size_t count)
 {
 	return simplelink_recvfrom(obj, buffer, count, 0, NULL, 0);
 }
 
-static ssize_t simplelink_write(void *obj, const void *buffer,
+static k_ssize_t simplelink_write(void *obj, const void *buffer,
 					  size_t count)
 {
 	return simplelink_sendto(obj, buffer, count, 0, NULL, 0);

--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -20,8 +20,7 @@
 #include <stdint.h>
 #include <stddef.h>
 
-#include <sys/types.h>
-
+#include <zephyr/types.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/bluetooth/conn.h>
@@ -142,10 +141,8 @@ struct bt_gatt_attr;
  *  @return Number of bytes read, or in case of an error
  *          ``BT_GATT_ERR()`` with a specific ``BT_ATT_ERR_*`` error code.
  */
-typedef ssize_t (*bt_gatt_attr_read_func_t)(struct bt_conn *conn,
-					    const struct bt_gatt_attr *attr,
-					    void *buf, uint16_t len,
-					    uint16_t offset);
+typedef k_ssize_t (*bt_gatt_attr_read_func_t)(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+					      void *buf, uint16_t len, uint16_t offset);
 
 /** @typedef bt_gatt_attr_write_func_t
  *  @brief Attribute write callback
@@ -160,10 +157,9 @@ typedef ssize_t (*bt_gatt_attr_read_func_t)(struct bt_conn *conn,
  *  @return Number of bytes written, or in case of an error
  *          ``BT_GATT_ERR()`` with a specific ``BT_ATT_ERR_*`` error code.
  */
-typedef ssize_t (*bt_gatt_attr_write_func_t)(struct bt_conn *conn,
-					     const struct bt_gatt_attr *attr,
-					     const void *buf, uint16_t len,
-					     uint16_t offset, uint8_t flags);
+typedef k_ssize_t (*bt_gatt_attr_write_func_t)(struct bt_conn *conn,
+					       const struct bt_gatt_attr *attr, const void *buf,
+					       uint16_t len, uint16_t offset, uint8_t flags);
 
 /** @brief GATT Attribute structure. */
 struct bt_gatt_attr {
@@ -612,9 +608,9 @@ uint16_t bt_gatt_attr_value_handle(const struct bt_gatt_attr *attr);
  *  @return number of bytes read in case of success or negative values in
  *          case of error.
  */
-ssize_t bt_gatt_attr_read(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-			  void *buf, uint16_t buf_len, uint16_t offset,
-			  const void *value, uint16_t value_len);
+k_ssize_t bt_gatt_attr_read(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
+			    uint16_t buf_len, uint16_t offset, const void *value,
+			    uint16_t value_len);
 
 /** @brief Read Service Attribute helper.
  *
@@ -631,9 +627,8 @@ ssize_t bt_gatt_attr_read(struct bt_conn *conn, const struct bt_gatt_attr *attr,
  *  @return number of bytes read in case of success or negative values in
  *          case of error.
  */
-ssize_t bt_gatt_attr_read_service(struct bt_conn *conn,
-				  const struct bt_gatt_attr *attr,
-				  void *buf, uint16_t len, uint16_t offset);
+k_ssize_t bt_gatt_attr_read_service(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+				    void *buf, uint16_t len, uint16_t offset);
 
 /**
  *  @brief Statically define and register a service.
@@ -730,9 +725,8 @@ ssize_t bt_gatt_attr_read_service(struct bt_conn *conn,
  *  @return number of bytes read in case of success or negative values in
  *          case of error.
  */
-ssize_t bt_gatt_attr_read_included(struct bt_conn *conn,
-				   const struct bt_gatt_attr *attr,
-				   void *buf, uint16_t len, uint16_t offset);
+k_ssize_t bt_gatt_attr_read_included(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+				     void *buf, uint16_t len, uint16_t offset);
 
 /**
  *  @brief Include Service Declaration Macro.
@@ -760,9 +754,8 @@ ssize_t bt_gatt_attr_read_included(struct bt_conn *conn,
  *  @return number of bytes read in case of success or negative values in
  *          case of error.
  */
-ssize_t bt_gatt_attr_read_chrc(struct bt_conn *conn,
-			       const struct bt_gatt_attr *attr, void *buf,
-			       uint16_t len, uint16_t offset);
+k_ssize_t bt_gatt_attr_read_chrc(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
+				 uint16_t len, uint16_t offset);
 
 #define BT_GATT_CHRC_INIT(_uuid, _handle, _props) \
 {                                                 \
@@ -838,8 +831,8 @@ struct _bt_gatt_ccc {
 	 *  @return Number of bytes to write, or in case of an error
 	 *          BT_GATT_ERR() with a specific error code.
 	 */
-	ssize_t (*cfg_write)(struct bt_conn *conn,
-			     const struct bt_gatt_attr *attr, uint16_t value);
+	k_ssize_t (*cfg_write)(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+			       uint16_t value);
 
 	/** @brief CCC attribute match handler
 	 *
@@ -872,9 +865,8 @@ struct _bt_gatt_ccc {
  *  @return number of bytes read in case of success or negative values in
  *          case of error.
  */
-ssize_t bt_gatt_attr_read_ccc(struct bt_conn *conn,
-			      const struct bt_gatt_attr *attr, void *buf,
-			      uint16_t len, uint16_t offset);
+k_ssize_t bt_gatt_attr_read_ccc(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
+				uint16_t len, uint16_t offset);
 
 /** @brief Write Client Characteristic Configuration Attribute helper.
  *
@@ -892,10 +884,8 @@ ssize_t bt_gatt_attr_read_ccc(struct bt_conn *conn,
  *  @return number of bytes written in case of success or negative values in
  *          case of error.
  */
-ssize_t bt_gatt_attr_write_ccc(struct bt_conn *conn,
-			       const struct bt_gatt_attr *attr, const void *buf,
-			       uint16_t len, uint16_t offset, uint8_t flags);
-
+k_ssize_t bt_gatt_attr_write_ccc(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+				 const void *buf, uint16_t len, uint16_t offset, uint8_t flags);
 
 /**
  *  @brief Initialize Client Characteristic Configuration Declaration Macro.
@@ -957,9 +947,8 @@ ssize_t bt_gatt_attr_write_ccc(struct bt_conn *conn,
  *  @return number of bytes read in case of success or negative values in
  *          case of error.
  */
-ssize_t bt_gatt_attr_read_cep(struct bt_conn *conn,
-			      const struct bt_gatt_attr *attr, void *buf,
-			      uint16_t len, uint16_t offset);
+k_ssize_t bt_gatt_attr_read_cep(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
+				uint16_t len, uint16_t offset);
 
 /**
  *  @brief Characteristic Extended Properties Declaration Macro.
@@ -989,9 +978,8 @@ ssize_t bt_gatt_attr_read_cep(struct bt_conn *conn,
  *  @return number of bytes read in case of success or negative values in
  *          case of error.
  */
-ssize_t bt_gatt_attr_read_cud(struct bt_conn *conn,
-			      const struct bt_gatt_attr *attr, void *buf,
-			      uint16_t len, uint16_t offset);
+k_ssize_t bt_gatt_attr_read_cud(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
+				uint16_t len, uint16_t offset);
 
 /**
  *  @brief Characteristic User Format Descriptor Declaration Macro.
@@ -1022,9 +1010,8 @@ ssize_t bt_gatt_attr_read_cud(struct bt_conn *conn,
  *  @return number of bytes read in case of success or negative values in
  *          case of error.
  */
-ssize_t bt_gatt_attr_read_cpf(struct bt_conn *conn,
-			      const struct bt_gatt_attr *attr, void *buf,
-			      uint16_t len, uint16_t offset);
+k_ssize_t bt_gatt_attr_read_cpf(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
+				uint16_t len, uint16_t offset);
 
 /**
  *  @brief Characteristic Presentation Format Descriptor Declaration Macro.

--- a/include/zephyr/bluetooth/l2cap.h
+++ b/include/zephyr/bluetooth/l2cap.h
@@ -18,8 +18,7 @@
  * @{
  */
 
-#include <sys/types.h>
-
+#include <zephyr/types.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/bluetooth/buf.h>
 #include <zephyr/bluetooth/conn.h>
@@ -422,8 +421,8 @@ struct bt_l2cap_chan_ops {
 	 *  @param seg_offset The byte offset of this segment in the SDU.
 	 *  @param seg The segment payload.
 	 */
-	void (*seg_recv)(struct bt_l2cap_chan *chan, size_t sdu_len,
-			 off_t seg_offset, struct net_buf_simple *seg);
+	void (*seg_recv)(struct bt_l2cap_chan *chan, size_t sdu_len, k_off_t seg_offset,
+			 struct net_buf_simple *seg);
 #endif /* CONFIG_BT_L2CAP_SEG_RECV */
 };
 

--- a/include/zephyr/bluetooth/mesh/access.h
+++ b/include/zephyr/bluetooth/mesh/access.h
@@ -10,8 +10,13 @@
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_ACCESS_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_ACCESS_H_
 
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include <zephyr/sys/util.h>
 #include <zephyr/settings/settings.h>
+#include <zephyr/types.h>
 #include <zephyr/bluetooth/mesh/msg.h>
 
 /* Internal macros used to initialize array members */
@@ -366,7 +371,7 @@ struct bt_mesh_model_op {
 	 *  message. If the message has fixed length then this value should
 	 *  be negative. Use BT_MESH_LEN_* macros when defining this value.
 	 */
-	const ssize_t len;
+	const k_ssize_t len;
 
 	/** @brief Handler function for this opcode.
 	 *

--- a/include/zephyr/bluetooth/mesh/blob.h
+++ b/include/zephyr/bluetooth/mesh/blob.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_BLOB_H__
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_BLOB_H__
 
-#include <sys/types.h>
+#include <stdint.h>
 
 #include <zephyr/kernel.h>
 
@@ -99,7 +99,7 @@ struct bt_mesh_blob_block {
 	/** Block size in bytes */
 	size_t size;
 	/** Offset in bytes from the start of the BLOB. */
-	off_t offset;
+	k_off_t offset;
 	/** Block number */
 	uint16_t number;
 	/** Number of chunks in block. */
@@ -112,7 +112,7 @@ struct bt_mesh_blob_block {
 /** BLOB data chunk. */
 struct bt_mesh_blob_chunk {
 	/** Offset of the chunk data from the start of the block. */
-	off_t offset;
+	k_off_t offset;
 	/** Chunk data size. */
 	size_t size;
 	/** Chunk data. */

--- a/include/zephyr/bluetooth/mesh/blob_cli.h
+++ b/include/zephyr/bluetooth/mesh/blob_cli.h
@@ -7,7 +7,8 @@
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_BLOB_CLI_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_BLOB_CLI_H_
 
-#include <sys/types.h>
+#include <stddef.h>
+#include <stdint.h>
 
 #include <zephyr/bluetooth/mesh/access.h>
 #include <zephyr/bluetooth/mesh/blob.h>

--- a/include/zephyr/bluetooth/mesh/blob_io_flash.h
+++ b/include/zephyr/bluetooth/mesh/blob_io_flash.h
@@ -9,6 +9,8 @@
 
 #include <stdint.h>
 
+#include <zephyr/types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -26,8 +28,7 @@ struct bt_mesh_blob_io_flash {
 	/** Active stream mode. */
 	enum bt_mesh_blob_io_mode mode;
 	/** Offset into the flash area to place the BLOB at (in bytes). */
-	off_t offset;
-
+	k_off_t offset;
 
 	/* Internal flash area pointer. */
 	const struct flash_area *area;
@@ -43,8 +44,8 @@ struct bt_mesh_blob_io_flash {
  *
  *  @return 0 on success or (negative) error code otherwise.
  */
-int bt_mesh_blob_io_flash_init(struct bt_mesh_blob_io_flash *flash,
-			       uint8_t area_id, off_t offset);
+int bt_mesh_blob_io_flash_init(struct bt_mesh_blob_io_flash *flash, uint8_t area_id,
+			       k_off_t offset);
 
 /** @} */
 

--- a/include/zephyr/bluetooth/mesh/cfg.h
+++ b/include/zephyr/bluetooth/mesh/cfg.h
@@ -12,8 +12,9 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 
-#include <sys/types.h>
+#include <zephyr/types.h>
 
 /**
  * @brief Runtime Configuration
@@ -500,7 +501,7 @@ uint8_t bt_mesh_subnet_priv_node_id_get(uint16_t net_idx,
  *  @return The number of indexes added to the @c net_idxs array, or @c -ENOMEM
  *          if the number of known Subnets exceeds the @c max parameter.
  */
-ssize_t bt_mesh_subnets_get(uint16_t net_idxs[], size_t max, off_t skip);
+k_ssize_t bt_mesh_subnets_get(uint16_t net_idxs[], size_t max, k_off_t skip);
 
 /**
  * @}
@@ -611,8 +612,7 @@ bool bt_mesh_app_key_exists(uint16_t app_idx);
  *  @return The number of indexes added to the @c app_idxs array, or @c -ENOMEM
  *          if the number of known Applications exceeds the @c max parameter.
  */
-ssize_t bt_mesh_app_keys_get(uint16_t net_idx, uint16_t app_idxs[], size_t max,
-			     off_t skip);
+k_ssize_t bt_mesh_app_keys_get(uint16_t net_idx, uint16_t app_idxs[], size_t max, k_off_t skip);
 
 /**
  * @}

--- a/include/zephyr/bluetooth/mesh/dfu.h
+++ b/include/zephyr/bluetooth/mesh/dfu.h
@@ -7,7 +7,8 @@
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_DFU_H__
 #define ZEPHYR_INCLUDE_BLUETOOTH_MESH_DFU_H__
 
-#include <sys/types.h>
+#include <stddef.h>
+#include <stdint.h>
 
 #include <zephyr/kernel.h>
 #include <zephyr/bluetooth/mesh/blob.h>

--- a/include/zephyr/bluetooth/mesh/dfu_metadata.h
+++ b/include/zephyr/bluetooth/mesh/dfu_metadata.h
@@ -17,8 +17,6 @@
 
 #include <stdint.h>
 
-#include <sys/types.h>
-
 #include <zephyr/kernel.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/bluetooth/services/ots.h
+++ b/include/zephyr/bluetooth/services/ots.h
@@ -20,8 +20,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include <sys/types.h>
-
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/crc.h>
@@ -680,9 +678,8 @@ struct bt_ots_cb {
 	 *          shall be smaller or equal to the len parameter.
 	 *  @return Negative value in case of an error.
 	 */
-	ssize_t (*obj_read)(struct bt_ots *ots, struct bt_conn *conn,
-			   uint64_t id, void **data, size_t len,
-			   off_t offset);
+	k_ssize_t (*obj_read)(struct bt_ots *ots, struct bt_conn *conn, uint64_t id, void **data,
+			      size_t len, k_off_t offset);
 
 	/** @brief Object write callback
 	 *
@@ -710,9 +707,8 @@ struct bt_ots_cb {
 	 *  @return -EINPROGRESS has a special meaning and is unsupported at
 	 *          the moment. It should not be returned.
 	 */
-	ssize_t (*obj_write)(struct bt_ots *ots, struct bt_conn *conn, uint64_t id,
-			     const void *data, size_t len, off_t offset,
-			     size_t rem);
+	k_ssize_t (*obj_write)(struct bt_ots *ots, struct bt_conn *conn, uint64_t id,
+			       const void *data, size_t len, k_off_t offset, size_t rem);
 
 	/** @brief Object name written callback
 	 *
@@ -745,7 +741,7 @@ struct bt_ots_cb {
 	 *  @return 0 to accept, or any negative value to reject.
 	 */
 	int (*obj_cal_checksum)(struct bt_ots *ots, struct bt_conn *conn, uint64_t id,
-				off_t offset, size_t len, void **data);
+				k_off_t offset, size_t len, void **data);
 };
 
 /** @brief Descriptor for OTS initialization. */
@@ -1072,7 +1068,7 @@ int bt_ots_client_read_object_data(struct bt_ots_client *otc_inst,
  *  @return int         0 if success, ERRNO on failure.
  */
 int bt_ots_client_write_object_data(struct bt_ots_client *otc_inst, struct bt_conn *conn,
-				    const void *buf, size_t len, off_t offset,
+				    const void *buf, size_t len, k_off_t offset,
 				    enum bt_ots_oacp_write_op_mode mode);
 
 /** @brief Get the checksum of the current selected object.
@@ -1091,7 +1087,7 @@ int bt_ots_client_write_object_data(struct bt_ots_client *otc_inst, struct bt_co
  *  @return int         0 if success, ERRNO on failure.
  */
 int bt_ots_client_get_object_checksum(struct bt_ots_client *otc_inst, struct bt_conn *conn,
-				      off_t offset, size_t len);
+				      k_off_t offset, size_t len);
 
 /** @brief Directory listing object metadata callback
  *

--- a/include/zephyr/console/console.h
+++ b/include/zephyr/console/console.h
@@ -7,7 +7,6 @@
 #ifndef ZEPHYR_INCLUDE_CONSOLE_CONSOLE_H_
 #define ZEPHYR_INCLUDE_CONSOLE_CONSOLE_H_
 
-#include <sys/types.h>
 #include <zephyr/types.h>
 #include <zephyr/kernel.h>
 
@@ -45,7 +44,7 @@ int console_init(void);
  *         <0, in case of error (e.g. -EAGAIN if timeout expired). errno
  *             variable is also set.
  */
-ssize_t console_read(void *dummy, void *buf, size_t size);
+k_ssize_t console_read(void *dummy, void *buf, size_t size);
 
 /**
  * @brief Write data to console.
@@ -57,7 +56,7 @@ ssize_t console_read(void *dummy, void *buf, size_t size);
  *         <0, in case of error (e.g. -EAGAIN if timeout expired). errno
  *             variable is also set.
  */
-ssize_t console_write(void *dummy, const void *buf, size_t size);
+k_ssize_t console_write(void *dummy, const void *buf, size_t size);
 
 /** @brief Get next char from console input buffer.
  *

--- a/include/zephyr/console/tty.h
+++ b/include/zephyr/console/tty.h
@@ -7,7 +7,8 @@
 #ifndef ZEPHYR_INCLUDE_CONSOLE_TTY_H_
 #define ZEPHYR_INCLUDE_CONSOLE_TTY_H_
 
-#include <sys/types.h>
+#include <stdint.h>
+
 #include <zephyr/types.h>
 #include <zephyr/kernel.h>
 
@@ -118,7 +119,7 @@ int tty_set_tx_buf(struct tty_serial *tty, void *buf, size_t size);
  *         <0, in case of error (e.g. -EAGAIN if timeout expired). errno
  *             variable is also set.
  */
-ssize_t tty_read(struct tty_serial *tty, void *buf, size_t size);
+k_ssize_t tty_read(struct tty_serial *tty, void *buf, size_t size);
 
 /**
  * @brief Write data to tty device.
@@ -130,7 +131,7 @@ ssize_t tty_read(struct tty_serial *tty, void *buf, size_t size);
  *         <0, in case of error (e.g. -EAGAIN if timeout expired). errno
  *             variable is also set.
  */
-ssize_t tty_write(struct tty_serial *tty, const void *buf, size_t size);
+k_ssize_t tty_write(struct tty_serial *tty, const void *buf, size_t size);
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/data/json.h
+++ b/include/zephyr/data/json.h
@@ -9,9 +9,9 @@
 
 #include <zephyr/sys/util.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
-#include <sys/types.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -682,7 +682,7 @@ int json_arr_separate_parse_object(struct json_obj *json, const struct json_obj_
  * @return 0 if string has been escaped properly, or -ENOMEM if there
  * was not enough space to escape the buffer
  */
-ssize_t json_escape(char *str, size_t *len, size_t buf_size);
+k_ssize_t json_escape(char *str, size_t *len, size_t buf_size);
 
 /**
  * @brief Calculates the JSON-escaped string length
@@ -704,8 +704,8 @@ size_t json_calc_escaped_len(const char *str, size_t len);
  * @return Number of bytes necessary to encode the values if >0,
  * an error code is returned.
  */
-ssize_t json_calc_encoded_len(const struct json_obj_descr *descr,
-			      size_t descr_len, const void *val);
+k_ssize_t json_calc_encoded_len(const struct json_obj_descr *descr, size_t descr_len,
+				const void *val);
 
 /**
  * @brief Calculates the string length to fully encode an array
@@ -716,8 +716,7 @@ ssize_t json_calc_encoded_len(const struct json_obj_descr *descr,
  * @return Number of bytes necessary to encode the values if >0,
  * an error code is returned.
  */
-ssize_t json_calc_encoded_arr_len(const struct json_obj_descr *descr,
-				  const void *val);
+k_ssize_t json_calc_encoded_arr_len(const struct json_obj_descr *descr, const void *val);
 
 /**
  * @brief Encodes an object in a contiguous memory location

--- a/include/zephyr/debug/coredump.h
+++ b/include/zephyr/debug/coredump.h
@@ -9,7 +9,8 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include <sys/types.h>
+
+#include <zephyr/types.h>
 
 /*
  * Define COREDUMP_*_STR as public to allow coredump_backend_other to re-use
@@ -127,7 +128,7 @@ enum coredump_cmd_id {
 /** Coredump copy command (@ref COREDUMP_CMD_COPY_STORED_DUMP) argument definition */
 struct coredump_cmd_copy_arg {
 	/** Copy offset */
-	off_t offset;
+	k_off_t offset;
 
 	/** Copy destination buffer */
 	uint8_t *buffer;

--- a/include/zephyr/dfu/mcuboot.h
+++ b/include/zephyr/dfu/mcuboot.h
@@ -18,7 +18,6 @@
 
 #include <stdbool.h>
 #include <stddef.h>
-#include <sys/types.h>
 
 #include <zephyr/types.h>
 
@@ -269,7 +268,7 @@ int boot_erase_img_bank(uint8_t area_id);
  * @param area_id flash_area ID of image bank to get the status offset
  * @return a positive offset on success, negative errno code on fail
  */
-ssize_t boot_get_area_trailer_status_offset(uint8_t area_id);
+k_ssize_t boot_get_area_trailer_status_offset(uint8_t area_id);
 
 /**
  * @brief Get the offset of the status from an image bank size
@@ -278,7 +277,7 @@ ssize_t boot_get_area_trailer_status_offset(uint8_t area_id);
  * @return offset of the status. When negative the status will not fit
  * the given size
  */
-ssize_t boot_get_trailer_status_offset(size_t area_size);
+k_ssize_t boot_get_trailer_status_offset(size_t area_size);
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/drivers/edac.h
+++ b/include/zephyr/drivers/edac.h
@@ -13,8 +13,7 @@
 #define ZEPHYR_INCLUDE_DRIVERS_EDAC_H_
 
 #include <errno.h>
-
-#include <sys/types.h>
+#include <stdint.h>
 
 /**
  * @defgroup edac EDAC API

--- a/include/zephyr/drivers/eeprom.h
+++ b/include/zephyr/drivers/eeprom.h
@@ -25,9 +25,10 @@
  * @{
  */
 
-#include <zephyr/types.h>
 #include <stddef.h>
-#include <sys/types.h>
+#include <stdint.h>
+
+#include <zephyr/types.h>
 #include <zephyr/device.h>
 
 #ifdef __cplusplus
@@ -44,16 +45,14 @@ extern "C" {
  * @brief Callback API upon reading from the EEPROM.
  * See @a eeprom_read() for argument description
  */
-typedef int (*eeprom_api_read)(const struct device *dev, off_t offset,
-			       void *data,
-			       size_t len);
+typedef int (*eeprom_api_read)(const struct device *dev, k_off_t offset, void *data, size_t len);
 
 /**
  * @brief Callback API upon writing to the EEPROM.
  * See @a eeprom_write() for argument description
  */
-typedef int (*eeprom_api_write)(const struct device *dev, off_t offset,
-				const void *data, size_t len);
+typedef int (*eeprom_api_write)(const struct device *dev, k_off_t offset, const void *data,
+				size_t len);
 
 /**
  * @brief Callback API upon getting the EEPROM size.
@@ -79,14 +78,12 @@ __subsystem struct eeprom_driver_api {
  *
  *  @return 0 on success, negative errno code on failure.
  */
-__syscall int eeprom_read(const struct device *dev, off_t offset, void *data,
-			  size_t len);
+__syscall int eeprom_read(const struct device *dev, k_off_t offset, void *data, size_t len);
 
-static inline int z_impl_eeprom_read(const struct device *dev, off_t offset,
-				     void *data, size_t len)
+static inline int z_impl_eeprom_read(const struct device *dev, k_off_t offset, void *data,
+				     size_t len)
 {
-	const struct eeprom_driver_api *api =
-		(const struct eeprom_driver_api *)dev->api;
+	const struct eeprom_driver_api *api = (const struct eeprom_driver_api *)dev->api;
 
 	return api->read(dev, offset, data, len);
 }
@@ -101,12 +98,10 @@ static inline int z_impl_eeprom_read(const struct device *dev, off_t offset,
  *
  *  @return 0 on success, negative errno code on failure.
  */
-__syscall int eeprom_write(const struct device *dev, off_t offset,
-			   const void *data,
-			   size_t len);
+__syscall int eeprom_write(const struct device *dev, k_off_t offset, const void *data, size_t len);
 
-static inline int z_impl_eeprom_write(const struct device *dev, off_t offset,
-				      const void *data, size_t len)
+static inline int z_impl_eeprom_write(const struct device *dev, k_off_t offset, const void *data,
+				      size_t len)
 {
 	const struct eeprom_driver_api *api =
 		(const struct eeprom_driver_api *)dev->api;

--- a/include/zephyr/drivers/eeprom/eeprom_fake.h
+++ b/include/zephyr/drivers/eeprom/eeprom_fake.h
@@ -9,14 +9,16 @@
 
 #include <zephyr/drivers/eeprom.h>
 #include <zephyr/fff.h>
+#include <zephyr/types.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-DECLARE_FAKE_VALUE_FUNC(int, fake_eeprom_read, const struct device *, off_t, void *, size_t);
+DECLARE_FAKE_VALUE_FUNC(int, fake_eeprom_read, const struct device *, k_off_t, void *, size_t);
 
-DECLARE_FAKE_VALUE_FUNC(int, fake_eeprom_write, const struct device *, off_t, const void *, size_t);
+DECLARE_FAKE_VALUE_FUNC(int, fake_eeprom_write, const struct device *, k_off_t, const void *,
+			size_t);
 
 DECLARE_FAKE_VALUE_FUNC(size_t, fake_eeprom_size, const struct device *);
 

--- a/include/zephyr/drivers/flash.h
+++ b/include/zephyr/drivers/flash.h
@@ -21,10 +21,9 @@
  */
 
 #include <errno.h>
+#include <stddef.h>
 
 #include <zephyr/types.h>
-#include <stddef.h>
-#include <sys/types.h>
 #include <zephyr/device.h>
 
 #ifdef __cplusplus
@@ -125,9 +124,7 @@ int flash_params_get_erase_cap(const struct flash_parameters *p)
  * @{
  */
 
-typedef int (*flash_api_read)(const struct device *dev, off_t offset,
-			      void *data,
-			      size_t len);
+typedef int (*flash_api_read)(const struct device *dev, k_off_t offset, void *data, size_t len);
 /**
  * @brief Flash write implementation handler type
  *
@@ -136,8 +133,8 @@ typedef int (*flash_api_read)(const struct device *dev, off_t offset,
  * after the operation completes (successfully or not) matches the write-protect
  * state when the operation was started.
  */
-typedef int (*flash_api_write)(const struct device *dev, off_t offset,
-			       const void *data, size_t len);
+typedef int (*flash_api_write)(const struct device *dev, k_off_t offset, const void *data,
+			       size_t len);
 
 /**
  * @brief Flash erase implementation handler type
@@ -152,8 +149,7 @@ typedef int (*flash_api_write)(const struct device *dev, off_t offset,
  * work more effectively, or if device has a support for internal fill
  * operation the erase in driver uses.
  */
-typedef int (*flash_api_erase)(const struct device *dev, off_t offset,
-			       size_t size);
+typedef int (*flash_api_erase)(const struct device *dev, k_off_t offset, size_t size);
 
 typedef const struct flash_parameters* (*flash_api_get_parameters)(const struct device *dev);
 
@@ -184,11 +180,11 @@ typedef void (*flash_api_pages_layout)(const struct device *dev,
 				       size_t *layout_size);
 #endif /* CONFIG_FLASH_PAGE_LAYOUT */
 
-typedef int (*flash_api_sfdp_read)(const struct device *dev, off_t offset,
-				   void *data, size_t len);
+typedef int (*flash_api_sfdp_read)(const struct device *dev, k_off_t offset, void *data,
+				   size_t len);
 typedef int (*flash_api_read_jedec_id)(const struct device *dev, uint8_t *id);
-typedef int (*flash_api_ex_op)(const struct device *dev, uint16_t code,
-			       const uintptr_t in, void *out);
+typedef int (*flash_api_ex_op)(const struct device *dev, uint16_t code, const uintptr_t in,
+			       void *out);
 
 __subsystem struct flash_driver_api {
 	flash_api_read read;
@@ -229,15 +225,12 @@ __subsystem struct flash_driver_api {
  *
  *  @return  0 on success, negative errno code on fail.
  */
-__syscall int flash_read(const struct device *dev, off_t offset, void *data,
-			 size_t len);
+__syscall int flash_read(const struct device *dev, k_off_t offset, void *data, size_t len);
 
-static inline int z_impl_flash_read(const struct device *dev, off_t offset,
-				    void *data,
+static inline int z_impl_flash_read(const struct device *dev, k_off_t offset, void *data,
 				    size_t len)
 {
-	const struct flash_driver_api *api =
-		(const struct flash_driver_api *)dev->api;
+	const struct flash_driver_api *api = (const struct flash_driver_api *)dev->api;
 
 	return api->read(dev, offset, data, len);
 }
@@ -260,15 +253,12 @@ static inline int z_impl_flash_read(const struct device *dev, off_t offset,
  *
  *  @return  0 on success, negative errno code on fail.
  */
-__syscall int flash_write(const struct device *dev, off_t offset,
-			  const void *data,
-			  size_t len);
+__syscall int flash_write(const struct device *dev, k_off_t offset, const void *data, size_t len);
 
-static inline int z_impl_flash_write(const struct device *dev, off_t offset,
-				     const void *data, size_t len)
+static inline int z_impl_flash_write(const struct device *dev, k_off_t offset, const void *data,
+				     size_t len)
 {
-	const struct flash_driver_api *api =
-		(const struct flash_driver_api *)dev->api;
+	const struct flash_driver_api *api = (const struct flash_driver_api *)dev->api;
 	int rc;
 
 	rc = api->write(dev, offset, data, len);
@@ -304,15 +294,13 @@ static inline int z_impl_flash_write(const struct device *dev, off_t offset,
  *  @see flash_get_page_info_by_offs()
  *  @see flash_get_page_info_by_idx()
  */
-__syscall int flash_erase(const struct device *dev, off_t offset, size_t size);
+__syscall int flash_erase(const struct device *dev, k_off_t offset, size_t size);
 
-static inline int z_impl_flash_erase(const struct device *dev, off_t offset,
-				     size_t size)
+static inline int z_impl_flash_erase(const struct device *dev, k_off_t offset, size_t size)
 {
 	int rc = -ENOSYS;
 
-	const struct flash_driver_api *api =
-		(const struct flash_driver_api *)dev->api;
+	const struct flash_driver_api *api = (const struct flash_driver_api *)dev->api;
 
 	if (api->erase != NULL) {
 		rc = api->erase(dev, offset, size);
@@ -336,7 +324,7 @@ static inline int z_impl_flash_erase(const struct device *dev, off_t offset,
  * @return  0 on success, negative errno code on fail.
  *
  */
-__syscall int flash_fill(const struct device *dev, uint8_t val, off_t offset, size_t size);
+__syscall int flash_fill(const struct device *dev, uint8_t val, k_off_t offset, size_t size);
 
 /**
  *  @brief  Erase part or all of a flash memory or level it
@@ -375,10 +363,10 @@ __syscall int flash_fill(const struct device *dev, uint8_t val, off_t offset, si
  *
  *  @see flash_erase()
  */
-__syscall int flash_flatten(const struct device *dev, off_t offset, size_t size);
+__syscall int flash_flatten(const struct device *dev, k_off_t offset, size_t size);
 
 struct flash_pages_info {
-	off_t start_offset; /* offset from the base of flash address */
+	k_off_t start_offset; /* offset from the base of flash address */
 	size_t size;
 	uint32_t index;
 };
@@ -393,8 +381,7 @@ struct flash_pages_info {
  *
  *  @return  0 on success, -EINVAL if page of the offset doesn't exist.
  */
-__syscall int flash_get_page_info_by_offs(const struct device *dev,
-					  off_t offset,
+__syscall int flash_get_page_info_by_offs(const struct device *dev, k_off_t offset,
 					  struct flash_pages_info *info);
 
 /**
@@ -406,8 +393,7 @@ __syscall int flash_get_page_info_by_offs(const struct device *dev,
  *
  *  @return  0 on success, -EINVAL  if page of the index doesn't exist.
  */
-__syscall int flash_get_page_info_by_idx(const struct device *dev,
-					 uint32_t page_index,
+__syscall int flash_get_page_info_by_idx(const struct device *dev, uint32_t page_index,
 					 struct flash_pages_info *info);
 
 /**
@@ -443,8 +429,7 @@ typedef bool (*flash_page_cb)(const struct flash_pages_info *info, void *data);
  * @param cb Callback to invoke for each flash page
  * @param data Private data for callback function
  */
-void flash_page_foreach(const struct device *dev, flash_page_cb cb,
-			void *data);
+void flash_page_foreach(const struct device *dev, flash_page_cb cb, void *data);
 #endif /* CONFIG_FLASH_PAGE_LAYOUT */
 
 #if defined(CONFIG_FLASH_JESD216_API)
@@ -468,12 +453,10 @@ void flash_page_foreach(const struct device *dev, flash_page_cb cb,
  * @retval -ENOTSUP if the flash driver does not support SFDP access
  * @retval negative values for other errors.
  */
-__syscall int flash_sfdp_read(const struct device *dev, off_t offset,
-			      void *data, size_t len);
+__syscall int flash_sfdp_read(const struct device *dev, k_off_t offset, void *data, size_t len);
 
-static inline int z_impl_flash_sfdp_read(const struct device *dev,
-					 off_t offset,
-					 void *data, size_t len)
+static inline int z_impl_flash_sfdp_read(const struct device *dev, k_off_t offset, void *data,
+					 size_t len)
 {
 	int rv = -ENOTSUP;
 	const struct flash_driver_api *api =

--- a/include/zephyr/drivers/hwinfo.h
+++ b/include/zephyr/drivers/hwinfo.h
@@ -22,10 +22,11 @@
  * @{
  */
 
-#include <zephyr/types.h>
-#include <sys/types.h>
-#include <stddef.h>
 #include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <zephyr/types.h>
 #include <zephyr/kernel.h>
 
 #ifdef __cplusplus
@@ -91,9 +92,9 @@ extern "C" {
  * @retval -ENOSYS if there is no implementation for the particular device.
  * @retval any negative value on driver specific errors.
  */
-__syscall ssize_t hwinfo_get_device_id(uint8_t *buffer, size_t length);
+__syscall int hwinfo_get_device_id(uint8_t *buffer, size_t length);
 
-ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length);
+int z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length);
 
 /**
  * @brief Copy the device EUI64 to a buffer

--- a/include/zephyr/drivers/mipi_dsi.h
+++ b/include/zephyr/drivers/mipi_dsi.h
@@ -21,7 +21,8 @@
  * @{
  */
 #include <errno.h>
-#include <sys/types.h>
+#include <stdint.h>
+
 #include <zephyr/device.h>
 #include <zephyr/display/mipi_display.h>
 #include <zephyr/dt-bindings/mipi_dsi/mipi_dsi.h>
@@ -122,8 +123,7 @@ struct mipi_dsi_msg {
 __subsystem struct mipi_dsi_driver_api {
 	int (*attach)(const struct device *dev, uint8_t channel,
 		      const struct mipi_dsi_device *mdev);
-	ssize_t (*transfer)(const struct device *dev, uint8_t channel,
-			    struct mipi_dsi_msg *msg);
+	k_ssize_t (*transfer)(const struct device *dev, uint8_t channel, struct mipi_dsi_msg *msg);
 	int (*detach)(const struct device *dev, uint8_t channel,
 		      const struct mipi_dsi_device *mdev);
 };
@@ -155,9 +155,8 @@ static inline int mipi_dsi_attach(const struct device *dev,
  *
  * @return Size of the transferred data on success, negative on error.
  */
-static inline ssize_t mipi_dsi_transfer(const struct device *dev,
-					uint8_t channel,
-					struct mipi_dsi_msg *msg)
+static inline k_ssize_t mipi_dsi_transfer(const struct device *dev, uint8_t channel,
+					  struct mipi_dsi_msg *msg)
 {
 	const struct mipi_dsi_driver_api *api = (const struct mipi_dsi_driver_api *)dev->api;
 
@@ -176,9 +175,8 @@ static inline ssize_t mipi_dsi_transfer(const struct device *dev,
  *
  * @return Size of the read data on success, negative on error.
  */
-ssize_t mipi_dsi_generic_read(const struct device *dev, uint8_t channel,
-			      const void *params, size_t nparams,
-			      void *buf, size_t len);
+k_ssize_t mipi_dsi_generic_read(const struct device *dev, uint8_t channel, const void *params,
+				size_t nparams, void *buf, size_t len);
 
 /**
  * @brief MIPI-DSI generic write.
@@ -190,8 +188,8 @@ ssize_t mipi_dsi_generic_read(const struct device *dev, uint8_t channel,
  *
  * @return Size of the written data on success, negative on error.
  */
-ssize_t mipi_dsi_generic_write(const struct device *dev, uint8_t channel,
-			       const void *buf, size_t len);
+k_ssize_t mipi_dsi_generic_write(const struct device *dev, uint8_t channel, const void *buf,
+				 size_t len);
 
 /**
  * @brief MIPI-DSI DCS read.
@@ -204,8 +202,8 @@ ssize_t mipi_dsi_generic_write(const struct device *dev, uint8_t channel,
  *
  * @return Size of the read data on success, negative on error.
  */
-ssize_t mipi_dsi_dcs_read(const struct device *dev, uint8_t channel,
-			  uint8_t cmd, void *buf, size_t len);
+k_ssize_t mipi_dsi_dcs_read(const struct device *dev, uint8_t channel, uint8_t cmd, void *buf,
+			    size_t len);
 
 /**
  * @brief MIPI-DSI DCS write.
@@ -218,9 +216,8 @@ ssize_t mipi_dsi_dcs_read(const struct device *dev, uint8_t channel,
  *
  * @return Size of the written data on success, negative on error.
  */
-ssize_t mipi_dsi_dcs_write(const struct device *dev, uint8_t channel,
-			   uint8_t cmd, const void *buf, size_t len);
-
+k_ssize_t mipi_dsi_dcs_write(const struct device *dev, uint8_t channel, uint8_t cmd,
+			     const void *buf, size_t len);
 
 /**
  * @brief Detach a device from the MIPI-DSI bus

--- a/include/zephyr/drivers/misc/devmux/devmux.h
+++ b/include/zephyr/drivers/misc/devmux/devmux.h
@@ -62,7 +62,7 @@ extern "C" {
  * @return The index (>= 0) of the currently active multiplexed device on success
  * @retval -EINVAL If @p dev is invalid
  */
-__syscall ssize_t devmux_select_get(const struct device *dev);
+__syscall int devmux_select_get(const struct device *dev);
 
 /**
  * @brief Set the selection of a devmux device.

--- a/include/zephyr/drivers/retained_mem.h
+++ b/include/zephyr/drivers/retained_mem.h
@@ -14,7 +14,6 @@
 
 #include <stdint.h>
 #include <stddef.h>
-#include <sys/types.h>
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/types.h>
@@ -24,8 +23,12 @@
 extern "C" {
 #endif
 
-BUILD_ASSERT(!(sizeof(off_t) > sizeof(size_t)),
-	     "Size of off_t must be equal or less than size of size_t");
+/*
+ * Without the assert condition described this way, doxygen fails
+ * with the error "retained_mem.h:187: unbalanced grouping commands".
+ */
+BUILD_ASSERT(!(sizeof(size_t) > sizeof(k_off_t)),
+	     "Size of size_t must be equal or less than size of k_off_t");
 
 /**
  * @brief Retained memory driver interface
@@ -41,14 +44,14 @@ BUILD_ASSERT(!(sizeof(off_t) > sizeof(size_t)),
  * @brief	Callback API to get size of retained memory area.
  * See retained_mem_size() for argument description.
  */
-typedef ssize_t (*retained_mem_size_api)(const struct device *dev);
+typedef k_ssize_t (*retained_mem_size_api)(const struct device *dev);
 
 /**
  * @typedef	retained_mem_read_api
  * @brief	Callback API to read from retained memory area.
  * See retained_mem_read() for argument description.
  */
-typedef int (*retained_mem_read_api)(const struct device *dev, off_t offset, uint8_t *buffer,
+typedef int (*retained_mem_read_api)(const struct device *dev, k_off_t offset, uint8_t *buffer,
 				     size_t size);
 
 /**
@@ -56,7 +59,7 @@ typedef int (*retained_mem_read_api)(const struct device *dev, off_t offset, uin
  * @brief	Callback API to write to retained memory area.
  * See retained_mem_write() for argument description.
  */
-typedef int (*retained_mem_write_api)(const struct device *dev, off_t offset,
+typedef int (*retained_mem_write_api)(const struct device *dev, k_off_t offset,
 				      const uint8_t *buffer, size_t size);
 
 /**
@@ -92,9 +95,9 @@ __subsystem struct retained_mem_driver_api {
  * @retval		Positive value indicating size in bytes on success, else negative errno
  *			code.
  */
-__syscall ssize_t retained_mem_size(const struct device *dev);
+__syscall k_ssize_t retained_mem_size(const struct device *dev);
 
-static inline ssize_t z_impl_retained_mem_size(const struct device *dev)
+static inline k_ssize_t z_impl_retained_mem_size(const struct device *dev)
 {
 	struct retained_mem_driver_api *api = (struct retained_mem_driver_api *)dev->api;
 
@@ -111,10 +114,10 @@ static inline ssize_t z_impl_retained_mem_size(const struct device *dev)
  *
  * @retval		0 on success else negative errno code.
  */
-__syscall int retained_mem_read(const struct device *dev, off_t offset, uint8_t *buffer,
+__syscall int retained_mem_read(const struct device *dev, k_off_t offset, uint8_t *buffer,
 				size_t size);
 
-static inline int z_impl_retained_mem_read(const struct device *dev, off_t offset,
+static inline int z_impl_retained_mem_read(const struct device *dev, k_off_t offset,
 					   uint8_t *buffer, size_t size)
 {
 	struct retained_mem_driver_api *api = (struct retained_mem_driver_api *)dev->api;
@@ -145,10 +148,10 @@ static inline int z_impl_retained_mem_read(const struct device *dev, off_t offse
  *
  * @retval		0 on success else negative errno code.
  */
-__syscall int retained_mem_write(const struct device *dev, off_t offset, const uint8_t *buffer,
+__syscall int retained_mem_write(const struct device *dev, k_off_t offset, const uint8_t *buffer,
 				 size_t size);
 
-static inline int z_impl_retained_mem_write(const struct device *dev, off_t offset,
+static inline int z_impl_retained_mem_write(const struct device *dev, k_off_t offset,
 					    const uint8_t *buffer, size_t size)
 {
 	struct retained_mem_driver_api *api = (struct retained_mem_driver_api *)dev->api;

--- a/include/zephyr/drivers/sensor/tmp116.h
+++ b/include/zephyr/drivers/sensor/tmp116.h
@@ -7,15 +7,18 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_TMP116_H_
 #define ZEPHYR_INCLUDE_DRIVERS_SENSOR_TMP116_H_
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include <zephyr/device.h>
-#include <sys/types.h>
+#include <zephyr/types.h>
 
 #define EEPROM_TMP116_SIZE (4 * sizeof(uint16_t))
 
-int tmp116_eeprom_read(const struct device *dev, off_t offset, void *data,
+int tmp116_eeprom_read(const struct device *dev, k_off_t offset, void *data,
 		       size_t len);
 
-int tmp116_eeprom_write(const struct device *dev, off_t offset,
+int tmp116_eeprom_write(const struct device *dev, k_off_t offset,
 			const void *data, size_t len);
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_TMP116_H_ */

--- a/include/zephyr/fs/fcb.h
+++ b/include/zephyr/fs/fcb.h
@@ -12,6 +12,8 @@
  */
 #include <inttypes.h>
 #include <limits.h>
+#include <stddef.h>
+#include <stdint.h>
 
 #include <zephyr/storage/flash_map.h>
 #include <zephyr/sys/util_macro.h>
@@ -325,7 +327,7 @@ int fcb_clear(struct fcb *fcbp);
  *
  * @return  0 on success, negative errno code on fail.
  */
-int fcb_flash_read(const struct fcb *fcbp, const struct flash_sector *sector, off_t off,
+int fcb_flash_read(const struct fcb *fcbp, const struct flash_sector *sector, k_off_t off,
 		   void *dst, size_t len);
 
 /**
@@ -339,7 +341,7 @@ int fcb_flash_read(const struct fcb *fcbp, const struct flash_sector *sector, of
  *
  * @return  0 on success, negative errno code on fail.
  */
-int fcb_flash_write(const struct fcb *fcbp, const struct flash_sector *sector, off_t off,
+int fcb_flash_write(const struct fcb *fcbp, const struct flash_sector *sector, k_off_t off,
 		    const void *src, size_t len);
 
 /**

--- a/include/zephyr/fs/fs.h
+++ b/include/zephyr/fs/fs.h
@@ -8,9 +8,8 @@
 #ifndef ZEPHYR_INCLUDE_FS_FS_H_
 #define ZEPHYR_INCLUDE_FS_FS_H_
 
-#include <sys/types.h>
-
 #include <zephyr/sys/dlist.h>
+#include <zephyr/sys/fdtable.h>
 #include <zephyr/fs/fs_interface.h>
 
 #ifdef __cplusplus
@@ -365,7 +364,7 @@ int fs_rename(const char *from, const char *to);
  * @retval -ENOTSUP when not implemented by underlying file system driver;
  * @retval <0 a negative errno code on error.
  */
-ssize_t fs_read(struct fs_file_t *zfp, void *ptr, size_t size);
+k_ssize_t fs_read(struct fs_file_t *zfp, void *ptr, size_t size);
 
 /**
  * @brief Write file
@@ -386,7 +385,7 @@ ssize_t fs_read(struct fs_file_t *zfp, void *ptr, size_t size);
  * @retval -ENOTSUP when not implemented by underlying file system driver;
  * @retval <0 an other negative errno code on error.
  */
-ssize_t fs_write(struct fs_file_t *zfp, const void *ptr, size_t size);
+k_ssize_t fs_write(struct fs_file_t *zfp, const void *ptr, size_t size);
 
 /**
  * @brief Seek file
@@ -406,7 +405,7 @@ ssize_t fs_write(struct fs_file_t *zfp, const void *ptr, size_t size);
  * @retval -ENOTSUP if not supported by underlying file system driver;
  * @retval <0 an other negative errno code on error.
  */
-int fs_seek(struct fs_file_t *zfp, off_t offset, int whence);
+int fs_seek(struct fs_file_t *zfp, k_off_t offset, int whence);
 
 /**
  * @brief Get current file position.
@@ -422,7 +421,7 @@ int fs_seek(struct fs_file_t *zfp, off_t offset, int whence);
  *
  * The current revision does not validate the file object.
  */
-off_t fs_tell(struct fs_file_t *zfp);
+k_off_t fs_tell(struct fs_file_t *zfp);
 
 /**
  * @brief Truncate or extend an open file to a given size
@@ -444,7 +443,7 @@ off_t fs_tell(struct fs_file_t *zfp);
  * @retval -ENOTSUP when not implemented by underlying file system driver;
  * @retval <0 an other negative errno code on error.
  */
-int fs_truncate(struct fs_file_t *zfp, off_t length);
+int fs_truncate(struct fs_file_t *zfp, k_off_t length);
 
 /**
  * @brief Flush cached write data buffers of an open file

--- a/include/zephyr/fs/fs_sys.h
+++ b/include/zephyr/fs/fs_sys.h
@@ -42,7 +42,7 @@ struct fs_file_system_t {
 	 * @param nbytes Number of bytes to read.
 	 * @return Number of bytes read on success, negative errno code on fail.
 	 */
-	ssize_t (*read)(struct fs_file_t *filp, void *dest, size_t nbytes);
+	k_ssize_t (*read)(struct fs_file_t *filp, void *dest, size_t nbytes);
 	/**
 	 * Writes nbytes number of bytes.
 	 *
@@ -51,8 +51,7 @@ struct fs_file_system_t {
 	 * @param nbytes Number of bytes to write.
 	 * @return Number of bytes written on success, negative errno code on fail.
 	 */
-	ssize_t (*write)(struct fs_file_t *filp,
-					const void *src, size_t nbytes);
+	k_ssize_t (*write)(struct fs_file_t *filp, const void *src, size_t nbytes);
 	/**
 	 * Moves the file position to a new location in the file.
 	 *
@@ -61,14 +60,14 @@ struct fs_file_system_t {
 	 * @param whence Position in the file. Possible values: SEEK_CUR, SEEK_SET, SEEK_END.
 	 * @return New position in the file or negative errno code on fail.
 	 */
-	int (*lseek)(struct fs_file_t *filp, off_t off, int whence);
+	int (*lseek)(struct fs_file_t *filp, k_off_t off, int whence);
 	/**
 	 * Retrieves the current position in the file.
 	 *
 	 * @param filp File to get the current position from.
 	 * @return Current position in the file or negative errno code on fail.
 	 */
-	off_t (*tell)(struct fs_file_t *filp);
+	k_off_t (*tell)(struct fs_file_t *filp);
 	/**
 	 * Truncates/expands the file to the new length.
 	 *
@@ -76,7 +75,7 @@ struct fs_file_system_t {
 	 * @param length New length of the file.
 	 * @return 0 on success, negative errno code on fail.
 	 */
-	int (*truncate)(struct fs_file_t *filp, off_t length);
+	int (*truncate)(struct fs_file_t *filp, k_off_t length);
 	/**
 	 * Flushes the cache of an open file.
 	 *

--- a/include/zephyr/fs/nvs.h
+++ b/include/zephyr/fs/nvs.h
@@ -7,7 +7,6 @@
 #ifndef ZEPHYR_INCLUDE_FS_NVS_H_
 #define ZEPHYR_INCLUDE_FS_NVS_H_
 
-#include <sys/types.h>
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/toolchain.h>
@@ -37,8 +36,8 @@ extern "C" {
  * @brief Non-volatile Storage File system structure
  */
 struct nvs_fs {
-	 /** File system offset in flash **/
-	off_t offset;
+	/** File system offset in flash **/
+	k_off_t offset;
 	/** Allocation table entry write address.
 	 * Addresses are stored as uint32_t:
 	 * - high 2 bytes correspond to the sector
@@ -110,7 +109,7 @@ int nvs_clear(struct nvs_fs *fs);
  * to be written. When a rewrite of the same data already stored is attempted, nothing is written
  * to flash, thus 0 is returned. On error, returns negative value of errno.h defined error codes.
  */
-ssize_t nvs_write(struct nvs_fs *fs, uint16_t id, const void *data, size_t len);
+k_ssize_t nvs_write(struct nvs_fs *fs, uint16_t id, const void *data, size_t len);
 
 /**
  * @brief Delete an entry from the file system
@@ -135,7 +134,7 @@ int nvs_delete(struct nvs_fs *fs, uint16_t id);
  * indicates not all bytes were read, and more data is available. On error, returns negative
  * value of errno.h defined error codes.
  */
-ssize_t nvs_read(struct nvs_fs *fs, uint16_t id, void *data, size_t len);
+k_ssize_t nvs_read(struct nvs_fs *fs, uint16_t id, void *data, size_t len);
 
 /**
  * @brief Read a history entry from the file system.
@@ -151,7 +150,7 @@ ssize_t nvs_read(struct nvs_fs *fs, uint16_t id, void *data, size_t len);
  * indicates not all bytes were read, and more data is available. On error, returns negative
  * value of errno.h defined error codes.
  */
-ssize_t nvs_read_hist(struct nvs_fs *fs, uint16_t id, void *data, size_t len, uint16_t cnt);
+k_ssize_t nvs_read_hist(struct nvs_fs *fs, uint16_t id, void *data, size_t len, uint16_t cnt);
 
 /**
  * @brief Calculate the available free space in the file system.
@@ -162,7 +161,7 @@ ssize_t nvs_read_hist(struct nvs_fs *fs, uint16_t id, void *data, size_t len, ui
  * still be written to the file system. Calculating the free space is a time consuming operation,
  * especially on spi flash. On error, returns negative value of errno.h defined error codes.
  */
-ssize_t nvs_calc_free_space(struct nvs_fs *fs);
+k_ssize_t nvs_calc_free_space(struct nvs_fs *fs);
 
 /**
  * @}

--- a/include/zephyr/llext/llext.h
+++ b/include/zephyr/llext/llext.h
@@ -8,12 +8,14 @@
 #ifndef ZEPHYR_LLEXT_H
 #define ZEPHYR_LLEXT_H
 
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include <zephyr/sys/slist.h>
 #include <zephyr/llext/elf.h>
 #include <zephyr/llext/symbol.h>
 #include <zephyr/kernel.h>
-#include <sys/types.h>
-#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -250,7 +252,7 @@ int arch_elf_relocate(elf_rela_t *rel, uintptr_t loc,
  * @param search_name Section name to search for
  * @returns the section offset or a negative error code
  */
-ssize_t llext_find_section(struct llext_loader *loader, const char *search_name);
+k_ssize_t llext_find_section(struct llext_loader *loader, const char *search_name);
 
 /**
  * @brief Architecture specific function for updating addresses via relocation table

--- a/include/zephyr/net/socket.h
+++ b/include/zephyr/net/socket.h
@@ -455,9 +455,8 @@ __syscall int zsock_accept(int sock, struct sockaddr *addr, socklen_t *addrlen);
  * if :kconfig:option:`CONFIG_POSIX_API` is defined.
  * @endrst
  */
-__syscall ssize_t zsock_sendto(int sock, const void *buf, size_t len,
-			       int flags, const struct sockaddr *dest_addr,
-			       socklen_t addrlen);
+__syscall k_ssize_t zsock_sendto(int sock, const void *buf, size_t len, int flags,
+				 const struct sockaddr *dest_addr, socklen_t addrlen);
 
 /**
  * @brief Send data to a connected peer
@@ -471,8 +470,7 @@ __syscall ssize_t zsock_sendto(int sock, const void *buf, size_t len,
  * if :kconfig:option:`CONFIG_POSIX_API` is defined.
  * @endrst
  */
-static inline ssize_t zsock_send(int sock, const void *buf, size_t len,
-				 int flags)
+static inline k_ssize_t zsock_send(int sock, const void *buf, size_t len, int flags)
 {
 	return zsock_sendto(sock, buf, len, flags, NULL, 0);
 }
@@ -489,8 +487,7 @@ static inline ssize_t zsock_send(int sock, const void *buf, size_t len,
  * if :kconfig:option:`CONFIG_POSIX_API` is defined.
  * @endrst
  */
-__syscall ssize_t zsock_sendmsg(int sock, const struct msghdr *msg,
-				int flags);
+__syscall k_ssize_t zsock_sendmsg(int sock, const struct msghdr *msg, int flags);
 
 /**
  * @brief Receive data from an arbitrary network address
@@ -504,9 +501,8 @@ __syscall ssize_t zsock_sendmsg(int sock, const struct msghdr *msg,
  * if :kconfig:option:`CONFIG_POSIX_API` is defined.
  * @endrst
  */
-__syscall ssize_t zsock_recvfrom(int sock, void *buf, size_t max_len,
-				 int flags, struct sockaddr *src_addr,
-				 socklen_t *addrlen);
+__syscall k_ssize_t zsock_recvfrom(int sock, void *buf, size_t max_len, int flags,
+				   struct sockaddr *src_addr, socklen_t *addrlen);
 
 /**
  * @brief Receive a message from an arbitrary network address
@@ -520,7 +516,7 @@ __syscall ssize_t zsock_recvfrom(int sock, void *buf, size_t max_len,
  * if :kconfig:option:`CONFIG_POSIX_API` is defined.
  * @endrst
  */
-__syscall ssize_t zsock_recvmsg(int sock, struct msghdr *msg, int flags);
+__syscall k_ssize_t zsock_recvmsg(int sock, struct msghdr *msg, int flags);
 
 /**
  * @brief Receive data from a connected peer
@@ -534,8 +530,7 @@ __syscall ssize_t zsock_recvmsg(int sock, struct msghdr *msg, int flags);
  * if :kconfig:option:`CONFIG_POSIX_API` is defined.
  * @endrst
  */
-static inline ssize_t zsock_recv(int sock, void *buf, size_t max_len,
-				 int flags)
+static inline k_ssize_t zsock_recv(int sock, void *buf, size_t max_len, int flags)
 {
 	return zsock_recvfrom(sock, buf, max_len, flags, NULL, NULL);
 }

--- a/include/zephyr/net/socket_service.h
+++ b/include/zephyr/net/socket_service.h
@@ -22,7 +22,6 @@
  * @{
  */
 
-#include <sys/types.h>
 #include <zephyr/types.h>
 #include <zephyr/net/socket.h>
 

--- a/include/zephyr/posix/fcntl.h
+++ b/include/zephyr/posix/fcntl.h
@@ -7,25 +7,23 @@
 #ifndef ZEPHYR_POSIX_FCNTL_H_
 #define ZEPHYR_POSIX_FCNTL_H_
 
-#ifdef CONFIG_PICOLIBC
-#define O_CREAT 0x0040
-#else
-#define O_CREAT 0x0200
-#endif
+#include <zephyr/sys/fdtable.h>
 
-#define O_ACCMODE (O_RDONLY | O_WRONLY | O_RDWR)
+#define O_CREAT ZVFS_O_CREAT
 
-#define O_RDONLY 00
-#define O_WRONLY 01
-#define O_RDWR	 02
+#define O_ACCMODE ZVFS_O_ACCMODE
 
-#define O_APPEND   0x0400
-#define O_EXCL	   0x0800
-#define O_NONBLOCK 0x4000
+#define O_RDONLY ZVFS_O_RDONLY
+#define O_WRONLY ZVFS_O_WRONLY
+#define O_RDWR   ZVFS_O_RDWR
 
-#define F_DUPFD 0
-#define F_GETFL 3
-#define F_SETFL 4
+#define O_APPEND   ZVFS_O_APPEND
+#define O_EXCL     ZVFS_O_EXCL
+#define O_NONBLOCK ZVFS_O_NONBLOCK
+
+#define F_DUPFD ZVFS_F_DUPFD
+#define F_GETFL ZVFS_F_GETFL
+#define F_SETFL ZVFS_F_SETFL
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/retention/retention.h
+++ b/include/zephyr/retention/retention.h
@@ -14,7 +14,6 @@
 
 #include <stdint.h>
 #include <stddef.h>
-#include <sys/types.h>
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/types.h>
@@ -32,12 +31,12 @@ extern "C" {
  * @{
  */
 
-typedef ssize_t (*retention_size_api)(const struct device *dev);
+typedef k_ssize_t (*retention_size_api)(const struct device *dev);
 typedef int (*retention_is_valid_api)(const struct device *dev);
-typedef int (*retention_read_api)(const struct device *dev, off_t offset, uint8_t *buffer,
+typedef int (*retention_read_api)(const struct device *dev, k_off_t offset, uint8_t *buffer,
 				  size_t size);
-typedef int (*retention_write_api)(const struct device *dev, off_t offset,
-				   const uint8_t *buffer, size_t size);
+typedef int (*retention_write_api)(const struct device *dev, k_off_t offset, const uint8_t *buffer,
+				   size_t size);
 typedef int (*retention_clear_api)(const struct device *dev);
 
 struct retention_api {
@@ -56,7 +55,7 @@ struct retention_api {
  * @retval		Positive value indicating size in bytes on success, else negative errno
  *			code.
  */
-ssize_t retention_size(const struct device *dev);
+k_ssize_t retention_size(const struct device *dev);
 
 /**
  * @brief		Checks if the underlying data in the retention area is valid or not.
@@ -81,7 +80,7 @@ int retention_is_valid(const struct device *dev);
  * @retval 0		If successful.
  * @retval -errno	Error code code.
  */
-int retention_read(const struct device *dev, off_t offset, uint8_t *buffer, size_t size);
+int retention_read(const struct device *dev, k_off_t offset, uint8_t *buffer, size_t size);
 
 /**
  * @brief		Writes data to the retention area (underlying data does not need to be
@@ -95,7 +94,7 @@ int retention_read(const struct device *dev, off_t offset, uint8_t *buffer, size
  *
  * @retval		0 on success else negative errno code.
  */
-int retention_write(const struct device *dev, off_t offset, const uint8_t *buffer, size_t size);
+int retention_write(const struct device *dev, k_off_t offset, const uint8_t *buffer, size_t size);
 
 /**
  * @brief		Clears all data in the retention area (sets it to 0)

--- a/include/zephyr/settings/settings.h
+++ b/include/zephyr/settings/settings.h
@@ -8,7 +8,6 @@
 #ifndef ZEPHYR_INCLUDE_SETTINGS_SETTINGS_H_
 #define ZEPHYR_INCLUDE_SETTINGS_SETTINGS_H_
 
-#include <sys/types.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/iterable_sections.h>
@@ -58,7 +57,7 @@ extern "C" {
  * @return positive: Number of bytes read, 0: key-value pair is deleted.
  *                   On error returns -ERRNO code.
  */
-typedef ssize_t (*settings_read_cb)(void *cb_arg, void *data, size_t len);
+typedef k_ssize_t (*settings_read_cb)(void *cb_arg, void *data, size_t len);
 
 /**
  * @struct settings_handler

--- a/include/zephyr/storage/flash_map.h
+++ b/include/zephyr/storage/flash_map.h
@@ -37,7 +37,8 @@
  */
 #include <zephyr/types.h>
 #include <stddef.h>
-#include <sys/types.h>
+#include <stdint.h>
+
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 
@@ -61,7 +62,7 @@ struct flash_area {
 	uint8_t fa_id;
 	uint16_t pad16;
 	/** Start offset from the beginning of the flash device */
-	off_t fa_off;
+	k_off_t fa_off;
 	/** Total size */
 	size_t fa_size;
 	/** Backing flash device */
@@ -80,7 +81,7 @@ struct flash_area {
  */
 struct flash_sector {
 	/** Sector offset from the beginning of the flash device */
-	off_t fs_off;
+	k_off_t fs_off;
 	/** Sector size in bytes */
 	size_t fs_size;
 };
@@ -152,8 +153,7 @@ void flash_area_close(const struct flash_area *fa);
  *
  * @return  0 on success, negative errno code on fail.
  */
-int flash_area_read(const struct flash_area *fa, off_t off, void *dst,
-		    size_t len);
+int flash_area_read(const struct flash_area *fa, k_off_t off, void *dst, size_t len);
 
 /**
  * @brief Write data to flash area
@@ -169,8 +169,7 @@ int flash_area_read(const struct flash_area *fa, off_t off, void *dst,
  *
  * @return  0 on success, negative errno code on fail.
  */
-int flash_area_write(const struct flash_area *fa, off_t off, const void *src,
-		     size_t len);
+int flash_area_write(const struct flash_area *fa, k_off_t off, const void *src, size_t len);
 
 /**
  * @brief Erase flash area
@@ -185,7 +184,7 @@ int flash_area_write(const struct flash_area *fa, off_t off, const void *src,
  *
  * @return  0 on success, negative errno code on fail.
  */
-int flash_area_erase(const struct flash_area *fa, off_t off, size_t len);
+int flash_area_erase(const struct flash_area *fa, k_off_t off, size_t len);
 
 /**
  * @brief Erase flash area or fill with erase-value
@@ -208,7 +207,7 @@ int flash_area_erase(const struct flash_area *fa, off_t off, size_t len);
  *
  * @return  0 on success, negative errno code on fail.
  */
-int flash_area_flatten(const struct flash_area *fa, off_t off, size_t len);
+int flash_area_flatten(const struct flash_area *fa, k_off_t off, size_t len);
 
 /**
  * @brief Get write block size of the flash area

--- a/include/zephyr/storage/stream_flash.h
+++ b/include/zephyr/storage/stream_flash.h
@@ -63,7 +63,7 @@ struct stream_flash_ctx {
 	size_t available; /* Available bytes in write area */
 	stream_flash_callback_t callback; /* Callback invoked after write op */
 #ifdef CONFIG_STREAM_FLASH_ERASE
-	off_t last_erased_page_start_offset; /* Last erased offset */
+	k_off_t last_erased_page_start_offset; /* Last erased offset */
 #endif
 	uint8_t erase_value;
 	uint8_t write_block_size;	/* Offset/size device write alignment */
@@ -135,7 +135,7 @@ int stream_flash_buffered_write(struct stream_flash_ctx *ctx, const uint8_t *dat
  *
  * @return non-negative on success, negative errno code on fail
  */
-int stream_flash_erase_page(struct stream_flash_ctx *ctx, off_t off);
+int stream_flash_erase_page(struct stream_flash_ctx *ctx, k_off_t off);
 
 /**
  * @brief Load persistent stream write progress stored with key

--- a/include/zephyr/sys/fdtable.h
+++ b/include/zephyr/sys/fdtable.h
@@ -7,9 +7,10 @@
 #define ZEPHYR_INCLUDE_SYS_FDTABLE_H_
 
 #include <stdarg.h>
-#include <sys/types.h>
-/* FIXME: For native_posix ssize_t, off_t. */
-#include <zephyr/fs/fs.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
 
@@ -27,6 +28,24 @@
 #define ZVFS_MODE_IFLNK  0120000
 #define ZVFS_MODE_IFSOCK 0140000
 
+/* fcntl.h constants */
+
+#define ZVFS_O_CREAT COND_CODE_1(CONFIG_PICOLIBC, (0x0040), (0x0200))
+
+#define ZVFS_O_ACCMODE (ZVFS_O_RDONLY | ZVFS_O_WRONLY | ZVFS_O_RDWR)
+
+#define ZVFS_O_RDONLY 00
+#define ZVFS_O_WRONLY 01
+#define ZVFS_O_RDWR   02
+
+#define ZVFS_O_APPEND   0x0400
+#define ZVFS_O_EXCL     0x0800
+#define ZVFS_O_NONBLOCK 0x4000
+
+#define ZVFS_F_DUPFD 0
+#define ZVFS_F_GETFL 3
+#define ZVFS_F_SETFL 4
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -37,12 +56,12 @@ extern "C" {
  */
 struct fd_op_vtable {
 	union {
-		ssize_t (*read)(void *obj, void *buf, size_t sz);
-		ssize_t (*read_offs)(void *obj, void *buf, size_t sz, size_t offset);
+		k_ssize_t (*read)(void *obj, void *buf, size_t sz);
+		k_ssize_t (*read_offs)(void *obj, void *buf, size_t sz, k_off_t offset);
 	};
 	union {
-		ssize_t (*write)(void *obj, const void *buf, size_t sz);
-		ssize_t (*write_offs)(void *obj, const void *buf, size_t sz, size_t offset);
+		k_ssize_t (*write)(void *obj, const void *buf, size_t sz);
+		k_ssize_t (*write_offs)(void *obj, const void *buf, size_t sz, k_off_t offset);
 	};
 	int (*close)(void *obj);
 	int (*ioctl)(void *obj, unsigned int request, va_list args);

--- a/include/zephyr/types.h
+++ b/include/zephyr/types.h
@@ -29,6 +29,44 @@ typedef union {
 	void            (*thepfunc)(void);
 } z_max_align_t;
 
+/*
+ * Offset type
+ *
+ * k_off_t, much like the POSIX off_t, is a signed integer type used to represent file sizes and
+ * offsets.
+ *
+ * k_off_t effectively limits the size of files that can be handled by the system, it is
+ * therefore not tied to the word-size of the architecture.
+ *
+ * In order to overcome historical limitations of the off_t type, Zephyr may be configured to
+ * always define k_off_t as 64-bits.
+ */
+#ifdef CONFIG_OFFSET_64BIT
+typedef int64_t k_off_t;
+#else
+typedef long k_off_t;
+#endif
+
+/*
+ * Signed size type
+ *
+ * k_ssize_t, much like the POSIX ssize_t, is a signed integer type that effectively limits the
+ * size of I/O operations on files while still supporting negative return values.
+ *
+ * k_ssize_t is usually tied to the word-size of the architecture.
+ */
+#ifdef __SIZE_TYPE__
+#define unsigned signed /* parasoft-suppress MISRAC2012-RULE_20_4-a MISRAC2012-RULE_20_4-b */
+typedef __SIZE_TYPE__ k_ssize_t;
+#undef unsigned
+#else
+#ifdef CONFIG_64BIT
+typedef long k_ssize_t;
+#else
+typedef int k_ssize_t;
+#endif
+#endif
+
 #ifdef __cplusplus
 /* Zephyr requires an int main(void) signature with C linkage for the application main if present */
 extern int main(void);

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -866,6 +866,23 @@ config XIP
 	  supply a linker command file when building your image. Enabling this
 	  option increases both the code and data footprint of the image.
 
+config OFFSET_64BIT
+	bool "Use 64-bit offsets"
+	help
+	  Select 'y' here to ensure k_off_t is always 64-bits. This may be
+	  useful on platforms with files, disks, and memories larger than 2 GiB.
+
+	  If this option is not selected (the default), then the size of k_off_t
+	  will match the architecture word size (like size_t does currently).
+
+	  On 32-bit platforms, enabling this feature trades space and speed for
+	  flexibiltity, since using 64-bit offsets may require more instructions
+	  for a given operation. For example, a 64-bit load may require two 32-bit
+	  loads, and a 64-bit divide may need to be completed with several
+	  32-bit instructions (the operation is emulated via a compiler built-in
+	  function).
+
+	  Note: offsets have a signed integer representation.
 
 menu "Security Options"
 

--- a/lib/libc/minimal/include/sys/_types.h
+++ b/lib/libc/minimal/include/sys/_types.h
@@ -12,6 +12,10 @@
 
 #include <stdint.h>
 
+#include <zephyr/types.h>
+
+typedef k_off_t _OFF_T_;
+typedef k_ssize_t _SSIZE_T_;
 typedef int64_t _TIME_T_;
 typedef int32_t _SUSECONDS_T_;
 

--- a/lib/libc/minimal/include/sys/types.h
+++ b/lib/libc/minimal/include/sys/types.h
@@ -15,25 +15,12 @@ typedef unsigned int mode_t;
 
 #if !defined(__ssize_t_defined)
 #define __ssize_t_defined
-
-/* Static code analysis tool can raise a violation
- * in the line below where name of macro 'unsigned' is the same
- * as keyword. It is made on purpose, deliberated deviation.
- *
- * We trick compiler to make sure the type of ssize_t won't be unsigned long.
- * As otherwise the type of ssize_t will be unsigned long
- * which is not correct. More details view in commit b889120
- */
-#define unsigned signed /* parasoft-suppress MISRAC2012-RULE_20_4-a MISRAC2012-RULE_20_4-b */
-typedef __SIZE_TYPE__ ssize_t;
-#undef unsigned
-
+typedef _SSIZE_T_ ssize_t;
 #endif
 
 #if !defined(__off_t_defined)
 #define __off_t_defined
-/* off_t is defined such that it matches the size of a pointer */
-typedef __INTPTR_TYPE__ off_t;
+typedef _OFF_T_ off_t;
 #endif
 
 #if !defined(__time_t_defined)
@@ -46,6 +33,7 @@ typedef _TIME_T_ time_t;
 typedef _SUSECONDS_T_ suseconds_t;
 #endif
 
+/* FIXME: this is not a POSIX type or any kind of standard type. It should be removed */
 #if !defined(__mem_word_t_defined)
 #define __mem_word_t_defined
 

--- a/lib/libc/minimal/source/stdlib/qsort.c
+++ b/lib/libc/minimal/source/stdlib/qsort.c
@@ -7,7 +7,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include <sys/types.h>
+
 #include <zephyr/sys/util.h>
 
 /*

--- a/lib/libc/minimal/source/string/string.c
+++ b/lib/libc/minimal/source/string/string.c
@@ -7,8 +7,10 @@
  */
 
 #include <string.h>
+#include <stddef.h>
 #include <stdint.h>
-#include <sys/types.h>
+
+#include <zephyr/toolchain.h>
 
 /**
  *
@@ -284,7 +286,7 @@ void *memcpy(void *ZRESTRICT d, const void *ZRESTRICT s, size_t n)
 	const unsigned char *s_byte = (const unsigned char *)s;
 
 #if !defined(CONFIG_MINIMAL_LIBC_OPTIMIZE_STRING_FOR_SIZE)
-	const uintptr_t mask = sizeof(mem_word_t) - 1;
+	const uintptr_t mask = sizeof(uintptr_t) - 1;
 
 	if ((((uintptr_t)d ^ (uintptr_t)s_byte) & mask) == 0) {
 
@@ -300,12 +302,12 @@ void *memcpy(void *ZRESTRICT d, const void *ZRESTRICT s, size_t n)
 
 		/* do word-sized copying as long as possible */
 
-		mem_word_t *d_word = (mem_word_t *)d_byte;
-		const mem_word_t *s_word = (const mem_word_t *)s_byte;
+		uintptr_t *d_word = (uintptr_t *)d_byte;
+		const uintptr_t *s_word = (const uintptr_t *)s_byte;
 
-		while (n >= sizeof(mem_word_t)) {
+		while (n >= sizeof(uintptr_t)) {
 			*(d_word++) = *(s_word++);
-			n -= sizeof(mem_word_t);
+			n -= sizeof(uintptr_t);
 		}
 
 		d_byte = (unsigned char *)d_word;
@@ -338,7 +340,7 @@ void *memset(void *buf, int c, size_t n)
 	unsigned char c_byte = (unsigned char)c;
 
 #if !defined(CONFIG_MINIMAL_LIBC_OPTIMIZE_STRING_FOR_SIZE)
-	while (((uintptr_t)d_byte) & (sizeof(mem_word_t) - 1)) {
+	while (((uintptr_t)d_byte) & (sizeof(uintptr_t) - 1)) {
 		if (n == 0) {
 			return buf;
 		}
@@ -348,8 +350,8 @@ void *memset(void *buf, int c, size_t n)
 
 	/* do word-sized initialization as long as possible */
 
-	mem_word_t *d_word = (mem_word_t *)d_byte;
-	mem_word_t c_word = (mem_word_t)c_byte;
+	uintptr_t *d_word = (uintptr_t *)d_byte;
+	uintptr_t c_word = (uintptr_t)c_byte;
 
 	c_word |= c_word << 8;
 	c_word |= c_word << 16;
@@ -357,9 +359,9 @@ void *memset(void *buf, int c, size_t n)
 	c_word |= c_word << 32;
 #endif
 
-	while (n >= sizeof(mem_word_t)) {
+	while (n >= sizeof(uintptr_t)) {
 		*(d_word++) = c_word;
-		n -= sizeof(mem_word_t);
+		n -= sizeof(uintptr_t);
 	}
 
 	/* do byte-sized initialization until finished */

--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -15,7 +15,6 @@
 #include <stdint.h>
 #include <string.h>
 #include <zephyr/toolchain.h>
-#include <sys/types.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/cbprintf.h>
 

--- a/lib/os/cbprintf_nano.c
+++ b/lib/os/cbprintf_nano.c
@@ -10,8 +10,8 @@
 #include <stdint.h>
 #include <string.h>
 #include <zephyr/sys/cbprintf.h>
-#include <sys/types.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/types.h>
 
 #ifdef CONFIG_CBPRINTF_FULL_INTEGRAL
 typedef intmax_t int_value_type;
@@ -195,7 +195,7 @@ start:
 				if (*fmt == 'u') {
 					d = va_arg(ap, size_t);
 				} else {
-					d = va_arg(ap, ssize_t);
+					d = va_arg(ap, k_ssize_t);
 				}
 			} else if (length_mod == 'l') {
 				if (*fmt == 'u') {

--- a/lib/os/cbprintf_packaged.c
+++ b/lib/os/cbprintf_packaged.c
@@ -11,7 +11,6 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/linker/utils.h>
 #include <zephyr/sys/cbprintf.h>
-#include <sys/types.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/logging/log.h>

--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -21,7 +21,6 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/cbprintf.h>
 #include <zephyr/llext/symbol.h>
-#include <sys/types.h>
 
 /* Option present only when CONFIG_USERSPACE enabled. */
 #ifndef CONFIG_PRINTK_BUFFER_SIZE

--- a/lib/posix/options/fd_mgmt.c
+++ b/lib/posix/options/fd_mgmt.c
@@ -15,8 +15,8 @@
 
 /* prototypes for external, not-yet-public, functions in fdtable.c or fs.c */
 int zvfs_fcntl(int fd, int cmd, va_list arg);
-int zvfs_ftruncate(int fd, off_t length);
-off_t zvfs_lseek(int fd, off_t offset, int whence);
+int zvfs_ftruncate(int fd, k_off_t length);
+k_off_t zvfs_lseek(int fd, k_off_t offset, int whence);
 
 int fcntl(int fd, int cmd, ...)
 {
@@ -35,7 +35,7 @@ FUNC_ALIAS(fcntl, _fcntl, int);
 
 int ftruncate(int fd, off_t length)
 {
-	return zvfs_ftruncate(fd, length);
+	return zvfs_ftruncate(fd, (k_off_t)length);
 }
 #ifdef CONFIG_POSIX_FD_MGMT_ALIAS_FTRUNCATE
 FUNC_ALIAS(ftruncate, _ftruncate, int);
@@ -43,7 +43,7 @@ FUNC_ALIAS(ftruncate, _ftruncate, int);
 
 off_t lseek(int fd, off_t offset, int whence)
 {
-	return zvfs_lseek(fd, offset, whence);
+	return zvfs_lseek(fd, (k_off_t)offset, whence);
 }
 #ifdef CONFIG_POSIX_FD_MGMT_ALIAS_LSEEK
 FUNC_ALIAS(lseek, _lseek, off_t);

--- a/lib/posix/options/mmap.c
+++ b/lib/posix/options/mmap.c
@@ -65,7 +65,8 @@ void *mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off)
 	if (fd > 0) {
 		/* non-anonymous mapping */
 		virt = NULL;
-		if (zvfs_ioctl_wrap(fd, ZFD_IOCTL_MMAP, addr, len, prot, flags, off, &virt) < 0) {
+		if (zvfs_ioctl_wrap(fd, ZFD_IOCTL_MMAP, addr, len, prot, flags, (k_off_t)off,
+				    &virt) < 0) {
 			return MAP_FAILED;
 		}
 

--- a/lib/utils/json.c
+++ b/lib/utils/json.c
@@ -842,7 +842,7 @@ size_t json_calc_escaped_len(const char *str, size_t len)
 	return escaped_len;
 }
 
-ssize_t json_escape(char *str, size_t *len, size_t buf_size)
+k_ssize_t json_escape(char *str, size_t *len, size_t buf_size)
 {
 	char *next; /* Points after next character to escape. */
 	char *dest; /* Points after next place to write escaped character. */
@@ -1144,19 +1144,19 @@ int json_arr_encode_buf(const struct json_obj_descr *descr, const void *val,
 
 static int measure_bytes(const char *bytes, size_t len, void *data)
 {
-	ssize_t *total = data;
+	k_ssize_t *total = data;
 
-	*total += (ssize_t)len;
+	*total += (k_ssize_t)len;
 
 	ARG_UNUSED(bytes);
 
 	return 0;
 }
 
-ssize_t json_calc_encoded_len(const struct json_obj_descr *descr,
-			      size_t descr_len, const void *val)
+k_ssize_t json_calc_encoded_len(const struct json_obj_descr *descr, size_t descr_len,
+				const void *val)
 {
-	ssize_t total = 0;
+	k_ssize_t total = 0;
 	int ret;
 
 	ret = json_obj_encode(descr, descr_len, val, measure_bytes, &total);
@@ -1167,10 +1167,9 @@ ssize_t json_calc_encoded_len(const struct json_obj_descr *descr,
 	return total;
 }
 
-ssize_t json_calc_encoded_arr_len(const struct json_obj_descr *descr,
-				  const void *val)
+k_ssize_t json_calc_encoded_arr_len(const struct json_obj_descr *descr, const void *val)
 {
-	ssize_t total = 0;
+	k_ssize_t total = 0;
 	int ret;
 
 	ret = json_arr_encode(descr, val, measure_bytes, &total);

--- a/modules/canopennode/canopen_program.c
+++ b/modules/canopennode/canopen_program.c
@@ -286,7 +286,7 @@ static CO_SDO_abortCode_t canopen_odf_1f51(CO_ODF_arg_t *odf_arg)
  * @return 0 if successful, negative errno on failure
  */
 static int flash_crc(const struct flash_area *flash_area,
-		off_t offset, size_t size, uint32_t *pcrc)
+		k_off_t offset, size_t size, uint32_t *pcrc)
 {
 	uint32_t crc = 0;
 	uint8_t buffer[32];
@@ -315,7 +315,7 @@ static CO_SDO_abortCode_t canopen_odf_1f56(CO_ODF_arg_t *odf_arg)
 {
 	const struct flash_area *flash_area;
 	struct mcuboot_img_header header;
-	off_t offset = 0;
+	k_off_t offset = 0;
 	uint32_t crc = 0;
 	uint8_t fa_id;
 	uint32_t len;

--- a/modules/canopennode/canopen_storage.c
+++ b/modules/canopennode/canopen_storage.c
@@ -127,7 +127,7 @@ static int canopen_settings_set(const char *key, size_t len_rd,
 {
 	const char *next;
 	int nlen;
-	ssize_t len;
+	k_ssize_t len;
 
 	nlen = settings_name_next(key, &next);
 

--- a/modules/lvgl/lvgl_fs.c
+++ b/modules/lvgl/lvgl_fs.c
@@ -157,7 +157,7 @@ static lv_fs_res_t lvgl_fs_seek(struct _lv_fs_drv_t *drv, void *file, uint32_t p
 
 static lv_fs_res_t lvgl_fs_tell(struct _lv_fs_drv_t *drv, void *file, uint32_t *pos_p)
 {
-	off_t pos;
+	k_off_t pos;
 
 	pos = fs_tell((struct fs_file_t *)file);
 	if (pos < 0) {

--- a/modules/openthread/platform/ble.c
+++ b/modules/openthread/platform/ble.c
@@ -72,7 +72,7 @@ static otInstance *ble_openthread_instance;
 /* BLE service Objects */
 
 /* forward declaration for callback functions */
-static ssize_t on_receive(struct bt_conn *conn, const struct bt_gatt_attr *attr, const void *buf,
+static k_ssize_t on_receive(struct bt_conn *conn, const struct bt_gatt_attr *attr, const void *buf,
 			  uint16_t len, uint16_t offset, uint8_t flags);
 static void on_cccd_changed(const struct bt_gatt_attr *attr, uint16_t value);
 
@@ -188,7 +188,7 @@ static void ot_plat_ble_thread(void *unused1, void *unused2, void *unused3)
 /* Zephyr BLE service callbacks */
 
 /* This function is called whenever the RX Characteristic has been written to by a Client */
-static ssize_t on_receive(struct bt_conn *conn, const struct bt_gatt_attr *attr, const void *buf,
+static k_ssize_t on_receive(struct bt_conn *conn, const struct bt_gatt_attr *attr, const void *buf,
 			  uint16_t len, uint16_t offset, uint8_t flags)
 {
 	LOG_DBG("Received data, handle %" PRIu16 ", len %" PRIu16, attr->handle, len);

--- a/samples/bluetooth/central_otc/src/main.c
+++ b/samples/bluetooth/central_otc/src/main.c
@@ -97,7 +97,7 @@ struct otc_btn_work_info {
 
 struct otc_checksum_work_info {
 	struct k_work_delayable work;
-	off_t offset;
+	k_off_t offset;
 	size_t len;
 } otc_checksum_work;
 

--- a/samples/bluetooth/direct_adv/src/main.c
+++ b/samples/bluetooth/direct_adv/src/main.c
@@ -36,7 +36,7 @@ static int signed_value;
 static struct bt_le_adv_param adv_param;
 static bt_addr_le_t bond_addr;
 
-static ssize_t read_signed(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t read_signed(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			   void *buf, uint16_t len, uint16_t offset)
 {
 	int *value = &signed_value;
@@ -45,7 +45,7 @@ static ssize_t read_signed(struct bt_conn *conn, const struct bt_gatt_attr *attr
 				 sizeof(signed_value));
 }
 
-static ssize_t write_signed(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t write_signed(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			    const void *buf, uint16_t len, uint16_t offset,
 			    uint8_t flags)
 {

--- a/samples/bluetooth/eddystone/src/main.c
+++ b/samples/bluetooth/eddystone/src/main.c
@@ -168,7 +168,7 @@ static struct eds_slot eds_slots[NUMBER_OF_SLOTS] = {
 	},
 };
 
-static ssize_t read_caps(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t read_caps(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			 void *buf, uint16_t len, uint16_t offset)
 {
 	const struct eds_capabilities *caps = attr->user_data;
@@ -177,14 +177,14 @@ static ssize_t read_caps(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 				 sizeof(*caps));
 }
 
-static ssize_t read_slot(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t read_slot(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			 void *buf, uint16_t len, uint16_t offset)
 {
 	return bt_gatt_attr_read(conn, attr, buf, len, offset,
 				 &eds_active_slot, sizeof(eds_active_slot));
 }
 
-static ssize_t write_slot(struct bt_conn *conn,
+static k_ssize_t write_slot(struct bt_conn *conn,
 			  const struct bt_gatt_attr *attr, const void *buf,
 			  uint16_t len, uint16_t offset, uint8_t flags)
 {
@@ -205,7 +205,7 @@ static ssize_t write_slot(struct bt_conn *conn,
 	return len;
 }
 
-static ssize_t read_tx_power(struct bt_conn *conn,
+static k_ssize_t read_tx_power(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr,
 			     void *buf, uint16_t len, uint16_t offset)
 {
@@ -219,7 +219,7 @@ static ssize_t read_tx_power(struct bt_conn *conn,
 				 sizeof(slot->tx_power));
 }
 
-static ssize_t write_tx_power(struct bt_conn *conn,
+static k_ssize_t write_tx_power(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr,
 			      const void *buf, uint16_t len, uint16_t offset,
 			      uint8_t flags)
@@ -239,7 +239,7 @@ static ssize_t write_tx_power(struct bt_conn *conn,
 	return len;
 }
 
-static ssize_t read_adv_tx_power(struct bt_conn *conn,
+static k_ssize_t read_adv_tx_power(struct bt_conn *conn,
 				 const struct bt_gatt_attr *attr,
 				 void *buf, uint16_t len, uint16_t offset)
 {
@@ -253,7 +253,7 @@ static ssize_t read_adv_tx_power(struct bt_conn *conn,
 				 sizeof(slot->tx_power));
 }
 
-static ssize_t write_adv_tx_power(struct bt_conn *conn,
+static k_ssize_t write_adv_tx_power(struct bt_conn *conn,
 				  const struct bt_gatt_attr *attr,
 				  const void *buf, uint16_t len,
 				  uint16_t offset,
@@ -274,7 +274,7 @@ static ssize_t write_adv_tx_power(struct bt_conn *conn,
 	return len;
 }
 
-static ssize_t read_interval(struct bt_conn *conn,
+static k_ssize_t read_interval(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr,
 			     void *buf, uint16_t len, uint16_t offset)
 {
@@ -288,7 +288,7 @@ static ssize_t read_interval(struct bt_conn *conn,
 				 sizeof(slot->interval));
 }
 
-static ssize_t read_lock(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t read_lock(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			 void *buf, uint16_t len, uint16_t offset)
 {
 	struct eds_slot *slot = &eds_slots[eds_active_slot];
@@ -297,7 +297,7 @@ static ssize_t read_lock(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 				 sizeof(slot->state));
 }
 
-static ssize_t write_lock(struct bt_conn *conn,
+static k_ssize_t write_lock(struct bt_conn *conn,
 			  const struct bt_gatt_attr *attr, const void *buf,
 			  uint16_t len, uint16_t offset, uint8_t flags)
 {
@@ -332,7 +332,7 @@ static ssize_t write_lock(struct bt_conn *conn,
 	return len;
 }
 
-static ssize_t read_unlock(struct bt_conn *conn,
+static k_ssize_t read_unlock(struct bt_conn *conn,
 			   const struct bt_gatt_attr *attr,
 			   void *buf, uint16_t len, uint16_t offset)
 {
@@ -353,7 +353,7 @@ static ssize_t read_unlock(struct bt_conn *conn,
 				 sizeof(slot->challenge));
 }
 
-static ssize_t write_unlock(struct bt_conn *conn,
+static k_ssize_t write_unlock(struct bt_conn *conn,
 			    const struct bt_gatt_attr *attr, const void *buf,
 			    uint16_t len, uint16_t offset, uint8_t flags)
 {
@@ -372,7 +372,7 @@ static ssize_t write_unlock(struct bt_conn *conn,
 
 static uint8_t eds_ecdh[32] = {}; /* TODO: Add ECDH key */
 
-static ssize_t read_ecdh(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t read_ecdh(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			 void *buf, uint16_t len, uint16_t offset)
 {
 	uint8_t *value = attr->user_data;
@@ -383,7 +383,7 @@ static ssize_t read_ecdh(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 
 static uint8_t eds_eid[16] = {}; /* TODO: Add EID key */
 
-static ssize_t read_eid(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t read_eid(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			void *buf, uint16_t len, uint16_t offset)
 {
 	uint8_t *value = attr->user_data;
@@ -392,7 +392,7 @@ static ssize_t read_eid(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 				 sizeof(eds_eid));
 }
 
-static ssize_t read_adv_data(struct bt_conn *conn,
+static k_ssize_t read_adv_data(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr, void *buf,
 			     uint16_t len, uint16_t offset)
 {
@@ -453,7 +453,7 @@ static int eds_slot_restart(struct eds_slot *slot, uint8_t type)
 	return 0;
 }
 
-static ssize_t write_adv_data(struct bt_conn *conn,
+static k_ssize_t write_adv_data(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr,
 			      const void *buf, uint16_t len, uint16_t offset,
 			      uint8_t flags)
@@ -511,7 +511,7 @@ static ssize_t write_adv_data(struct bt_conn *conn,
 	}
 }
 
-static ssize_t write_reset(struct bt_conn *conn,
+static k_ssize_t write_reset(struct bt_conn *conn,
 			   const struct bt_gatt_attr *attr,
 			   const void *buf, uint16_t len, uint16_t offset,
 			   uint8_t flags)
@@ -520,7 +520,7 @@ static ssize_t write_reset(struct bt_conn *conn,
 	return BT_GATT_ERR(BT_ATT_ERR_WRITE_NOT_PERMITTED);
 }
 
-static ssize_t read_connectable(struct bt_conn *conn,
+static k_ssize_t read_connectable(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr, void *buf,
 			     uint16_t len, uint16_t offset)
 {
@@ -533,7 +533,7 @@ static ssize_t read_connectable(struct bt_conn *conn,
 				 &connectable, sizeof(connectable));
 }
 
-static ssize_t write_connectable(struct bt_conn *conn,
+static k_ssize_t write_connectable(struct bt_conn *conn,
 				 const struct bt_gatt_attr *attr,
 				 const void *buf, uint16_t len, uint16_t offset,
 				 uint8_t flags)

--- a/samples/bluetooth/encrypted_advertising/peripheral/src/peripheral_ead.c
+++ b/samples/bluetooth/encrypted_advertising/peripheral/src/peripheral_ead.c
@@ -34,7 +34,7 @@ static struct bt_conn *default_conn;
 static struct k_poll_signal disconn_signal;
 static struct k_poll_signal passkey_enter_signal;
 
-static ssize_t read_key_material(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
+static k_ssize_t read_key_material(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
 				 uint16_t len, uint16_t offset)
 {
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, attr->user_data,

--- a/samples/bluetooth/periodic_sync_rsp/src/main.c
+++ b/samples/bluetooth/periodic_sync_rsp/src/main.c
@@ -127,8 +127,8 @@ static const struct bt_uuid_128 pawr_svc_uuid =
 static const struct bt_uuid_128 pawr_char_uuid =
 	BT_UUID_INIT_128(BT_UUID_128_ENCODE(0x12345678, 0x1234, 0x5678, 0x1234, 0x56789abcdef1));
 
-static ssize_t write_timing(struct bt_conn *conn, const struct bt_gatt_attr *attr, const void *buf,
-			    uint16_t len, uint16_t offset, uint8_t flags)
+static k_ssize_t write_timing(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+			      const void *buf, uint16_t len, uint16_t offset, uint8_t flags)
 {
 	if (offset) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);

--- a/samples/bluetooth/peripheral/src/cts.c
+++ b/samples/bluetooth/peripheral/src/cts.c
@@ -30,7 +30,7 @@ static void ct_ccc_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 	/* TODO: Handle value */
 }
 
-static ssize_t read_ct(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t read_ct(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 		       void *buf, uint16_t len, uint16_t offset)
 {
 	const char *value = attr->user_data;
@@ -39,7 +39,7 @@ static ssize_t read_ct(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 				 sizeof(ct));
 }
 
-static ssize_t write_ct(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t write_ct(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			const void *buf, uint16_t len, uint16_t offset,
 			uint8_t flags)
 {

--- a/samples/bluetooth/peripheral/src/main.c
+++ b/samples/bluetooth/peripheral/src/main.c
@@ -46,7 +46,7 @@ static uint8_t vnd_value[VND_MAX_LEN + 1] = { 'V', 'e', 'n', 'd', 'o', 'r'};
 static uint8_t vnd_auth_value[VND_MAX_LEN + 1] = { 'V', 'e', 'n', 'd', 'o', 'r'};
 static uint8_t vnd_wwr_value[VND_MAX_LEN + 1] = { 'V', 'e', 'n', 'd', 'o', 'r' };
 
-static ssize_t read_vnd(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t read_vnd(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			void *buf, uint16_t len, uint16_t offset)
 {
 	const char *value = attr->user_data;
@@ -55,7 +55,7 @@ static ssize_t read_vnd(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 				 strlen(value));
 }
 
-static ssize_t write_vnd(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t write_vnd(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			 const void *buf, uint16_t len, uint16_t offset,
 			 uint8_t flags)
 {
@@ -102,7 +102,7 @@ static uint8_t vnd_long_value[VND_LONG_MAX_LEN + 1] = {
 		  'V', 'e', 'n', 'd', 'o', 'r', ' ', 'd', 'a', 't', 'a', '6',
 		  '.', ' ' };
 
-static ssize_t write_long_vnd(struct bt_conn *conn,
+static k_ssize_t write_long_vnd(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, const void *buf,
 			      uint16_t len, uint16_t offset, uint8_t flags)
 {
@@ -131,7 +131,7 @@ static struct bt_gatt_cep vnd_long_cep = {
 
 static int signed_value;
 
-static ssize_t read_signed(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t read_signed(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			   void *buf, uint16_t len, uint16_t offset)
 {
 	const char *value = attr->user_data;
@@ -140,7 +140,7 @@ static ssize_t read_signed(struct bt_conn *conn, const struct bt_gatt_attr *attr
 				 sizeof(signed_value));
 }
 
-static ssize_t write_signed(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t write_signed(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			    const void *buf, uint16_t len, uint16_t offset,
 			    uint8_t flags)
 {
@@ -161,7 +161,7 @@ static const struct bt_uuid_128 vnd_signed_uuid = BT_UUID_INIT_128(
 static const struct bt_uuid_128 vnd_write_cmd_uuid = BT_UUID_INIT_128(
 	BT_UUID_128_ENCODE(0x12345678, 0x1234, 0x5678, 0x1234, 0x56789abcdef4));
 
-static ssize_t write_without_rsp_vnd(struct bt_conn *conn,
+static k_ssize_t write_without_rsp_vnd(struct bt_conn *conn,
 				     const struct bt_gatt_attr *attr,
 				     const void *buf, uint16_t len, uint16_t offset,
 				     uint8_t flags)

--- a/samples/bluetooth/peripheral_accept_list/src/main.c
+++ b/samples/bluetooth/peripheral_accept_list/src/main.c
@@ -32,7 +32,7 @@ static int signed_value;
 static struct bt_le_adv_param adv_param;
 static int bond_count;
 
-static ssize_t read_signed(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t read_signed(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			   void *buf, uint16_t len, uint16_t offset)
 {
 	int *value = &signed_value;
@@ -41,7 +41,7 @@ static ssize_t read_signed(struct bt_conn *conn, const struct bt_gatt_attr *attr
 				 sizeof(signed_value));
 }
 
-static ssize_t write_signed(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t write_signed(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			    const void *buf, uint16_t len, uint16_t offset,
 			    uint8_t flags)
 {

--- a/samples/bluetooth/peripheral_csc/src/main.c
+++ b/samples/bluetooth/peripheral_csc/src/main.c
@@ -95,7 +95,7 @@ static void ctrl_point_ccc_cfg_changed(const struct bt_gatt_attr *attr,
 	ctrl_point_configured = value == BT_GATT_CCC_INDICATE;
 }
 
-static ssize_t read_location(struct bt_conn *conn,
+static k_ssize_t read_location(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr, void *buf,
 			     uint16_t len, uint16_t offset)
 {
@@ -105,7 +105,7 @@ static ssize_t read_location(struct bt_conn *conn,
 				 sizeof(*value));
 }
 
-static ssize_t read_csc_feature(struct bt_conn *conn,
+static k_ssize_t read_csc_feature(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr, void *buf,
 				uint16_t len, uint16_t offset)
 {
@@ -126,7 +126,7 @@ struct write_sc_ctrl_point_req {
 	};
 } __packed;
 
-static ssize_t write_ctrl_point(struct bt_conn *conn,
+static k_ssize_t write_ctrl_point(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr,
 				const void *buf, uint16_t len, uint16_t offset,
 				uint8_t flags)

--- a/samples/bluetooth/peripheral_esp/src/main.c
+++ b/samples/bluetooth/peripheral_esp/src/main.c
@@ -93,7 +93,7 @@
 #define ESS_DESC_APP_EXTERNAL					0x20
 #define ESS_DESC_APP_SOLAR					0x21
 
-static ssize_t read_u16(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t read_u16(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			void *buf, uint16_t len, uint16_t offset)
 {
 	const uint16_t *u16 = attr->user_data;
@@ -186,7 +186,7 @@ struct read_es_measurement_rp {
 	uint8_t measurement_uncertainty;
 } __packed;
 
-static ssize_t read_es_measurement(struct bt_conn *conn,
+static k_ssize_t read_es_measurement(struct bt_conn *conn,
 				   const struct bt_gatt_attr *attr, void *buf,
 				   uint16_t len, uint16_t offset)
 {
@@ -204,7 +204,7 @@ static ssize_t read_es_measurement(struct bt_conn *conn,
 				 sizeof(rsp));
 }
 
-static ssize_t read_temp_valid_range(struct bt_conn *conn,
+static k_ssize_t read_temp_valid_range(struct bt_conn *conn,
 				     const struct bt_gatt_attr *attr, void *buf,
 				     uint16_t len, uint16_t offset)
 {
@@ -226,7 +226,7 @@ struct es_trigger_setting_reference {
 	int16_t ref_val;
 } __packed;
 
-static ssize_t read_temp_trigger_setting(struct bt_conn *conn,
+static k_ssize_t read_temp_trigger_setting(struct bt_conn *conn,
 					 const struct bt_gatt_attr *attr,
 					 void *buf, uint16_t len,
 					 uint16_t offset)

--- a/samples/bluetooth/peripheral_hids/src/hog.c
+++ b/samples/bluetooth/peripheral_hids/src/hog.c
@@ -89,7 +89,7 @@ static uint8_t report_map[] = {
 };
 
 
-static ssize_t read_info(struct bt_conn *conn,
+static k_ssize_t read_info(struct bt_conn *conn,
 			  const struct bt_gatt_attr *attr, void *buf,
 			  uint16_t len, uint16_t offset)
 {
@@ -97,7 +97,7 @@ static ssize_t read_info(struct bt_conn *conn,
 				 sizeof(struct hids_info));
 }
 
-static ssize_t read_report_map(struct bt_conn *conn,
+static k_ssize_t read_report_map(struct bt_conn *conn,
 			       const struct bt_gatt_attr *attr, void *buf,
 			       uint16_t len, uint16_t offset)
 {
@@ -105,7 +105,7 @@ static ssize_t read_report_map(struct bt_conn *conn,
 				 sizeof(report_map));
 }
 
-static ssize_t read_report(struct bt_conn *conn,
+static k_ssize_t read_report(struct bt_conn *conn,
 			   const struct bt_gatt_attr *attr, void *buf,
 			   uint16_t len, uint16_t offset)
 {
@@ -118,14 +118,14 @@ static void input_ccc_changed(const struct bt_gatt_attr *attr, uint16_t value)
 	simulate_input = (value == BT_GATT_CCC_NOTIFY) ? 1 : 0;
 }
 
-static ssize_t read_input_report(struct bt_conn *conn,
+static k_ssize_t read_input_report(struct bt_conn *conn,
 				 const struct bt_gatt_attr *attr, void *buf,
 				 uint16_t len, uint16_t offset)
 {
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, NULL, 0);
 }
 
-static ssize_t write_ctrl_point(struct bt_conn *conn,
+static k_ssize_t write_ctrl_point(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr,
 				const void *buf, uint16_t len, uint16_t offset,
 				uint8_t flags)

--- a/samples/bluetooth/peripheral_ots/src/main.c
+++ b/samples/bluetooth/peripheral_ots/src/main.c
@@ -134,9 +134,8 @@ static void ots_obj_selected(struct bt_ots *ots, struct bt_conn *conn,
 	printk("Object with %s ID has been selected\n", id_str);
 }
 
-static ssize_t ots_obj_read(struct bt_ots *ots, struct bt_conn *conn,
-			    uint64_t id, void **data, size_t len,
-			    off_t offset)
+static k_ssize_t ots_obj_read(struct bt_ots *ots, struct bt_conn *conn, uint64_t id, void **data,
+			      size_t len, k_off_t offset)
 {
 	char id_str[BT_OTS_OBJ_ID_STR_LEN];
 	uint32_t obj_index = OTS_OBJ_ID_TO_OBJ_IDX(id);
@@ -166,9 +165,8 @@ static ssize_t ots_obj_read(struct bt_ots *ots, struct bt_conn *conn,
 	return len;
 }
 
-static ssize_t ots_obj_write(struct bt_ots *ots, struct bt_conn *conn,
-			     uint64_t id, const void *data, size_t len,
-			     off_t offset, size_t rem)
+static k_ssize_t ots_obj_write(struct bt_ots *ots, struct bt_conn *conn, uint64_t id,
+			       const void *data, size_t len, k_off_t offset, size_t rem)
 {
 	char id_str[BT_OTS_OBJ_ID_STR_LEN];
 	uint32_t obj_index = OTS_OBJ_ID_TO_OBJ_IDX(id);
@@ -196,7 +194,7 @@ static void ots_obj_name_written(struct bt_ots *ots, struct bt_conn *conn,
 }
 
 static int ots_obj_cal_checksum(struct bt_ots *ots, struct bt_conn *conn, uint64_t id,
-				off_t offset, size_t len, void **data)
+				k_off_t offset, size_t len, void **data)
 {
 	uint32_t obj_index = OTS_OBJ_ID_TO_OBJ_IDX(id);
 

--- a/samples/bluetooth/st_ble_sensor/src/main.c
+++ b/samples/bluetooth/st_ble_sensor/src/main.c
@@ -31,7 +31,7 @@ LOG_MODULE_REGISTER(main);
 static uint16_t but_val;
 
 /* Prototype */
-static ssize_t recv(struct bt_conn *conn,
+static k_ssize_t recv(struct bt_conn *conn,
 		    const struct bt_gatt_attr *attr, const void *buf,
 		    uint16_t len, uint16_t offset, uint8_t flags);
 
@@ -101,7 +101,7 @@ BT_GATT_CHARACTERISTIC(&but_notif_uuid.uuid, BT_GATT_CHRC_NOTIFY,
 BT_GATT_CCC(mpu_ccc_cfg_changed, BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),
 );
 
-static ssize_t recv(struct bt_conn *conn,
+static k_ssize_t recv(struct bt_conn *conn,
 		    const struct bt_gatt_attr *attr, const void *buf,
 		    uint16_t len, uint16_t offset, uint8_t flags)
 {

--- a/samples/boards/esp32/flash_encryption/src/main.c
+++ b/samples/boards/esp32/flash_encryption/src/main.c
@@ -25,7 +25,7 @@ int main(void)
 {
 	uint8_t buffer[32];
 	const struct device *flash_device;
-	off_t address = FIXED_PARTITION_OFFSET(storage_partition);
+	k_off_t address = FIXED_PARTITION_OFFSET(storage_partition);
 
 	flash_device = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
 	if (!device_is_ready(flash_device)) {

--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/storage.c
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/storage.c
@@ -115,7 +115,7 @@ void save_on_flash(uint8_t id)
 static int ps_set(const char *key, size_t len_rd,
 		  settings_read_cb read_cb, void *cb_arg)
 {
-	ssize_t len = 0;
+	k_ssize_t len = 0;
 	int key_len;
 	const char *next;
 

--- a/samples/boards/reel_board/mesh_badge/src/main.c
+++ b/samples/boards/reel_board/mesh_badge/src/main.c
@@ -26,8 +26,8 @@ static const struct bt_data sd[] = {
 	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
 };
 
-static ssize_t read_name(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-			 void *buf, uint16_t len, uint16_t offset)
+static k_ssize_t read_name(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
+			   uint16_t len, uint16_t offset)
 {
 	const char *value = bt_get_name();
 
@@ -35,9 +35,8 @@ static ssize_t read_name(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 				 strlen(value));
 }
 
-static ssize_t write_name(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-			  const void *buf, uint16_t len, uint16_t offset,
-			  uint8_t flags)
+static k_ssize_t write_name(struct bt_conn *conn, const struct bt_gatt_attr *attr, const void *buf,
+			    uint16_t len, uint16_t offset, uint8_t flags)
 {
 	char name[CONFIG_BT_DEVICE_NAME_MAX];
 	int err;

--- a/samples/net/sockets/echo_async/src/socket_echo.c
+++ b/samples/net/sockets/echo_async/src/socket_echo.c
@@ -22,8 +22,8 @@
 
 #else
 
-#include <zephyr/posix/fcntl.h>
 #include <zephyr/net/socket.h>
+#include <zephyr/posix/fcntl.h>
 #include <zephyr/kernel.h>
 
 #ifdef CONFIG_NET_IPV6

--- a/submanifests/optional.yaml
+++ b/submanifests/optional.yaml
@@ -34,7 +34,7 @@ manifest:
       groups:
         - optional
     - name: sof
-      revision: 3f1716b0da7a48358bc265586b90b2252745c14c
+      revision: pull/47/head
       path: modules/audio/sof
       remote: upstream
       groups:

--- a/subsys/bluetooth/audio/aics.c
+++ b/subsys/bluetooth/audio/aics.c
@@ -43,12 +43,12 @@ LOG_MODULE_REGISTER(bt_aics);
 #define AICS_CP_SET_GAIN_LEN        0x03
 
 
-static ssize_t write_description(struct bt_conn *conn,
+static k_ssize_t write_description(struct bt_conn *conn,
 				 const struct bt_gatt_attr *attr,
 				 const void *buf, uint16_t len, uint16_t offset,
 				 uint8_t flags);
 
-static ssize_t write_aics_control(struct bt_conn *conn,
+static k_ssize_t write_aics_control(struct bt_conn *conn,
 				  const struct bt_gatt_attr *attr,
 				  const void *buf, uint16_t len,
 				  uint16_t offset, uint8_t flags);
@@ -56,23 +56,23 @@ static ssize_t write_aics_control(struct bt_conn *conn,
 #if defined(CONFIG_BT_AICS)
 static void aics_state_cfg_changed(const struct bt_gatt_attr *attr,
 				   uint16_t value);
-static ssize_t read_aics_state(struct bt_conn *conn,
+static k_ssize_t read_aics_state(struct bt_conn *conn,
 			       const struct bt_gatt_attr *attr,
 			       void *buf, uint16_t len, uint16_t offset);
-static ssize_t read_aics_gain_settings(struct bt_conn *conn,
+static k_ssize_t read_aics_gain_settings(struct bt_conn *conn,
 				       const struct bt_gatt_attr *attr,
 				       void *buf, uint16_t len,
 				       uint16_t offset);
-static ssize_t read_type(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t read_type(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			 void *buf, uint16_t len, uint16_t offset);
 static void aics_input_status_cfg_changed(const struct bt_gatt_attr *attr,
 					  uint16_t value);
-static ssize_t read_input_status(struct bt_conn *conn,
+static k_ssize_t read_input_status(struct bt_conn *conn,
 				 const struct bt_gatt_attr *attr,
 				 void *buf, uint16_t len, uint16_t offset);
 static void aics_description_cfg_changed(const struct bt_gatt_attr *attr,
 					 uint16_t value);
-static ssize_t read_description(struct bt_conn *conn,
+static k_ssize_t read_description(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr, void *buf,
 				uint16_t len, uint16_t offset);
 
@@ -120,7 +120,7 @@ static void aics_state_cfg_changed(const struct bt_gatt_attr *attr,
 	LOG_DBG("value 0x%04x", value);
 }
 
-static ssize_t read_aics_state(struct bt_conn *conn,
+static k_ssize_t read_aics_state(struct bt_conn *conn,
 			       const struct bt_gatt_attr *attr, void *buf,
 			       uint16_t len, uint16_t offset)
 {
@@ -133,7 +133,7 @@ static ssize_t read_aics_state(struct bt_conn *conn,
 				 sizeof(inst->srv.state));
 }
 
-static ssize_t read_aics_gain_settings(struct bt_conn *conn,
+static k_ssize_t read_aics_gain_settings(struct bt_conn *conn,
 				       const struct bt_gatt_attr *attr,
 				       void *buf, uint16_t len, uint16_t offset)
 {
@@ -147,7 +147,7 @@ static ssize_t read_aics_gain_settings(struct bt_conn *conn,
 				 sizeof(inst->srv.gain_settings));
 }
 
-static ssize_t read_type(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t read_type(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			 void *buf, uint16_t len, uint16_t offset)
 {
 	struct bt_aics *inst = BT_AUDIO_CHRC_USER_DATA(attr);
@@ -164,7 +164,7 @@ static void aics_input_status_cfg_changed(const struct bt_gatt_attr *attr,
 	LOG_DBG("value 0x%04x", value);
 }
 
-static ssize_t read_input_status(struct bt_conn *conn,
+static k_ssize_t read_input_status(struct bt_conn *conn,
 				 const struct bt_gatt_attr *attr, void *buf,
 				 uint16_t len, uint16_t offset)
 {
@@ -246,7 +246,7 @@ static void value_changed(struct bt_aics *inst, enum bt_aics_notify notify)
 #define value_changed(...)
 #endif /* CONFIG_BT_AICS */
 
-static ssize_t write_aics_control(struct bt_conn *conn,
+static k_ssize_t write_aics_control(struct bt_conn *conn,
 				  const struct bt_gatt_attr *attr,
 				  const void *buf, uint16_t len,
 				  uint16_t offset, uint8_t flags)
@@ -366,7 +366,7 @@ static void aics_description_cfg_changed(const struct bt_gatt_attr *attr,
 }
 #endif /* CONFIG_BT_AICS */
 
-static ssize_t write_description(struct bt_conn *conn,
+static k_ssize_t write_description(struct bt_conn *conn,
 				 const struct bt_gatt_attr *attr,
 				 const void *buf, uint16_t len, uint16_t offset,
 				 uint8_t flags)
@@ -400,7 +400,7 @@ static ssize_t write_description(struct bt_conn *conn,
 }
 
 static int aics_write(struct bt_aics *inst,
-		      ssize_t (*write)(struct bt_conn *conn,
+		      k_ssize_t (*write)(struct bt_conn *conn,
 				       const struct bt_gatt_attr *attr,
 				       const void *buf, uint16_t len,
 				       uint16_t offset, uint8_t flags),
@@ -423,7 +423,7 @@ static int aics_write(struct bt_aics *inst,
 }
 
 #if defined(CONFIG_BT_AICS)
-static ssize_t read_description(struct bt_conn *conn,
+static k_ssize_t read_description(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr, void *buf,
 				uint16_t len, uint16_t offset)
 {

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -768,7 +768,7 @@ static void ascs_ep_get_status_enable(struct bt_bap_ep *ep, struct net_buf_simpl
 		bt_audio_dir_str(ep->dir), ep->cig_id, ep->cis_id);
 }
 
-static ssize_t ascs_ase_read_status_idle(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t ascs_ase_read_status_idle(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 					 void *buf, uint16_t len, uint16_t offset)
 {
 	struct bt_ascs_ase_status status = {
@@ -1438,13 +1438,13 @@ static struct bt_ascs_ase *ase_find(struct bt_conn *conn, uint8_t id)
 	return NULL;
 }
 
-static ssize_t ascs_ase_read(struct bt_conn *conn,
+static k_ssize_t ascs_ase_read(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr, void *buf,
 			     uint16_t len, uint16_t offset)
 {
 	uint8_t ase_id = POINTER_TO_UINT(BT_AUDIO_CHRC_USER_DATA(attr));
 	struct bt_ascs_ase *ase = NULL;
-	ssize_t ret_val;
+	k_ssize_t ret_val;
 	int err;
 
 	LOG_DBG("conn %p attr %p buf %p len %u offset %u", (void *)conn, attr, buf, len, offset);
@@ -1842,7 +1842,7 @@ static bool is_valid_config_len(struct bt_conn *conn, struct net_buf_simple *buf
 	return true;
 }
 
-static ssize_t ascs_config(struct bt_conn *conn, struct net_buf_simple *buf)
+static k_ssize_t ascs_config(struct bt_conn *conn, struct net_buf_simple *buf)
 {
 	const struct bt_ascs_config_op *req;
 	const struct bt_ascs_config *cfg;
@@ -2051,7 +2051,7 @@ static bool is_valid_qos_len(struct bt_conn *conn, struct net_buf_simple *buf)
 	return true;
 }
 
-static ssize_t ascs_qos(struct bt_conn *conn, struct net_buf_simple *buf)
+static k_ssize_t ascs_qos(struct bt_conn *conn, struct net_buf_simple *buf)
 {
 	const struct bt_ascs_qos_op *req;
 
@@ -2440,7 +2440,7 @@ static bool is_valid_enable_len(struct bt_conn *conn, struct net_buf_simple *buf
 	return true;
 }
 
-static ssize_t ascs_enable(struct bt_conn *conn, struct net_buf_simple *buf)
+static k_ssize_t ascs_enable(struct bt_conn *conn, struct net_buf_simple *buf)
 {
 	const struct bt_ascs_enable_op *req;
 	struct bt_ascs_metadata *meta;
@@ -2567,7 +2567,7 @@ static bool is_valid_start_len(struct bt_conn *conn, struct net_buf_simple *buf)
 	return true;
 }
 
-static ssize_t ascs_start(struct bt_conn *conn, struct net_buf_simple *buf)
+static k_ssize_t ascs_start(struct bt_conn *conn, struct net_buf_simple *buf)
 {
 	const struct bt_ascs_start_op *req;
 	int i;
@@ -2649,7 +2649,7 @@ static bool is_valid_disable_len(struct bt_conn *conn, struct net_buf_simple *bu
 	return true;
 }
 
-static ssize_t ascs_disable(struct bt_conn *conn, struct net_buf_simple *buf)
+static k_ssize_t ascs_disable(struct bt_conn *conn, struct net_buf_simple *buf)
 {
 	const struct bt_ascs_disable_op *req;
 
@@ -2779,7 +2779,7 @@ static bool is_valid_stop_len(struct bt_conn *conn, struct net_buf_simple *buf)
 	return true;
 }
 
-static ssize_t ascs_stop(struct bt_conn *conn, struct net_buf_simple *buf)
+static k_ssize_t ascs_stop(struct bt_conn *conn, struct net_buf_simple *buf)
 {
 	const struct bt_ascs_start_op *req;
 	int i;
@@ -2878,7 +2878,7 @@ static bool is_valid_metadata_len(struct bt_conn *conn, struct net_buf_simple *b
 	return true;
 }
 
-static ssize_t ascs_metadata(struct bt_conn *conn, struct net_buf_simple *buf)
+static k_ssize_t ascs_metadata(struct bt_conn *conn, struct net_buf_simple *buf)
 {
 	const struct bt_ascs_metadata_op *req;
 	struct bt_ascs_metadata *meta;
@@ -2954,7 +2954,7 @@ static bool is_valid_release_len(struct bt_conn *conn, struct net_buf_simple *bu
 	return true;
 }
 
-static ssize_t ascs_release(struct bt_conn *conn, struct net_buf_simple *buf)
+static k_ssize_t ascs_release(struct bt_conn *conn, struct net_buf_simple *buf)
 {
 	const struct bt_ascs_release_op *req;
 	int i;
@@ -2999,13 +2999,13 @@ static ssize_t ascs_release(struct bt_conn *conn, struct net_buf_simple *buf)
 	return buf->size;
 }
 
-static ssize_t ascs_cp_write(struct bt_conn *conn,
+static k_ssize_t ascs_cp_write(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr, const void *data,
 			     uint16_t len, uint16_t offset, uint8_t flags)
 {
 	const struct bt_ascs_ase_cp *req;
 	struct net_buf_simple buf;
-	ssize_t ret;
+	k_ssize_t ret;
 
 	if (flags & BT_GATT_WRITE_FLAG_PREPARE) {
 		/* Return 0 to allow long writes */

--- a/subsys/bluetooth/audio/audio_internal.h
+++ b/subsys/bluetooth/audio/audio_internal.h
@@ -19,11 +19,11 @@
 /** @brief LE Audio Attribute User Data. */
 struct bt_audio_attr_user_data {
 	/** Attribute read callback */
-	ssize_t (*read)(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+	k_ssize_t (*read)(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			void *buf, uint16_t len, uint16_t offset);
 
 	/** Attribute write callback */
-	ssize_t	(*write)(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+	k_ssize_t	(*write)(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			 const void *buf, uint16_t len, uint16_t offset,
 			 uint8_t flags);
 

--- a/subsys/bluetooth/audio/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/bap_scan_delegator.c
@@ -1012,7 +1012,7 @@ static int scan_delegator_rem_src(struct bt_conn *conn,
 	return 0;
 }
 
-static ssize_t write_control_point(struct bt_conn *conn,
+static k_ssize_t write_control_point(struct bt_conn *conn,
 				   const struct bt_gatt_attr *attr,
 				   const void *data, uint16_t len,
 				   uint16_t offset, uint8_t flags)
@@ -1117,7 +1117,7 @@ static void recv_state_cfg_changed(const struct bt_gatt_attr *attr,
 	LOG_DBG("value 0x%04x", value);
 }
 
-static ssize_t read_recv_state(struct bt_conn *conn,
+static k_ssize_t read_recv_state(struct bt_conn *conn,
 			       const struct bt_gatt_attr *attr, void *buf,
 			       uint16_t len, uint16_t offset)
 {
@@ -1126,7 +1126,7 @@ static ssize_t read_recv_state(struct bt_conn *conn,
 	struct bt_bap_scan_delegator_recv_state *state = &recv_state->state;
 
 	if (recv_state->active) {
-		ssize_t ret_val;
+		k_ssize_t ret_val;
 		int err;
 
 		LOG_DBG("Index %u: Source ID 0x%02x", idx, state->src_id);

--- a/subsys/bluetooth/audio/ccid.c
+++ b/subsys/bluetooth/audio/ccid.c
@@ -43,7 +43,7 @@ static uint8_t ccid_attr_cb(const struct bt_gatt_attr *attr, uint16_t handle, vo
 
 	if (attr->read != NULL) {
 		uint8_t ccid = 0U;
-		ssize_t res;
+		k_ssize_t res;
 
 		res = attr->read(NULL, attr, &ccid, sizeof(ccid), 0);
 

--- a/subsys/bluetooth/audio/csip_set_member.c
+++ b/subsys/bluetooth/audio/csip_set_member.c
@@ -239,7 +239,7 @@ int bt_csip_set_member_generate_rsi(const struct bt_csip_set_member_svc_inst *sv
 	return res;
 }
 
-static ssize_t read_sirk(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
+static k_ssize_t read_sirk(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
 			 uint16_t len, uint16_t offset)
 {
 	struct bt_csip_sirk enc_sirk;
@@ -247,7 +247,7 @@ static ssize_t read_sirk(struct bt_conn *conn, const struct bt_gatt_attr *attr, 
 	struct bt_csip_set_member_svc_inst *svc_inst = BT_AUDIO_CHRC_USER_DATA(attr);
 
 	if (svc_inst->cb != NULL && svc_inst->cb->sirk_read_req != NULL) {
-		ssize_t gatt_err = BT_GATT_ERR(BT_ATT_ERR_SUCCESS);
+		k_ssize_t gatt_err = BT_GATT_ERR(BT_ATT_ERR_SUCCESS);
 		uint8_t cb_rsp;
 
 		/* Ask higher layer for what SIRK to return, if any */
@@ -298,7 +298,7 @@ static void sirk_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 }
 #endif /* CONFIG_BT_CSIP_SET_MEMBER_NOTIFIABLE */
 
-static ssize_t read_set_size(struct bt_conn *conn,
+static k_ssize_t read_set_size(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr,
 			     void *buf, uint16_t len, uint16_t offset)
 {
@@ -317,7 +317,7 @@ static void set_size_cfg_changed(const struct bt_gatt_attr *attr,
 	LOG_DBG("value 0x%04x", value);
 }
 
-static ssize_t read_set_lock(struct bt_conn *conn,
+static k_ssize_t read_set_lock(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr,
 			     void *buf, uint16_t len, uint16_t offset)
 {
@@ -398,12 +398,12 @@ static uint8_t set_lock(struct bt_conn *conn,
 	return 0;
 }
 
-static ssize_t write_set_lock(struct bt_conn *conn,
+static k_ssize_t write_set_lock(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr,
 			      const void *buf, uint16_t len,
 			      uint16_t offset, uint8_t flags)
 {
-	ssize_t res;
+	k_ssize_t res;
 	uint8_t val;
 	struct bt_csip_set_member_svc_inst *svc_inst = BT_AUDIO_CHRC_USER_DATA(attr);
 
@@ -429,7 +429,7 @@ static void set_lock_cfg_changed(const struct bt_gatt_attr *attr,
 	LOG_DBG("value 0x%04x", value);
 }
 
-static ssize_t read_rank(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t read_rank(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			 void *buf, uint16_t len, uint16_t offset)
 {
 	struct bt_csip_set_member_svc_inst *svc_inst = BT_AUDIO_CHRC_USER_DATA(attr);

--- a/subsys/bluetooth/audio/gmap_server.c
+++ b/subsys/bluetooth/audio/gmap_server.c
@@ -30,8 +30,8 @@ LOG_MODULE_REGISTER(bt_gmap_server, CONFIG_BT_GMAP_LOG_LEVEL);
 static uint8_t gmap_role;
 static struct bt_gmap_feat gmap_features;
 
-static ssize_t read_gmap_role(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
-			      uint16_t len, uint16_t offset)
+static k_ssize_t read_gmap_role(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
+				uint16_t len, uint16_t offset)
 {
 	LOG_DBG("role 0x%02X", gmap_role);
 
@@ -39,8 +39,8 @@ static ssize_t read_gmap_role(struct bt_conn *conn, const struct bt_gatt_attr *a
 }
 
 #if defined(CONFIG_BT_GMAP_UGG_SUPPORTED)
-static ssize_t read_gmap_ugg_feat(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
-				  uint16_t len, uint16_t offset)
+static k_ssize_t read_gmap_ugg_feat(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+				    void *buf, uint16_t len, uint16_t offset)
 {
 	const uint8_t feat = (uint8_t)gmap_features.ugg_feat;
 
@@ -56,8 +56,8 @@ static const struct bt_gatt_attr ugg_feat_chrc[] = {
 #endif /* CONFIG_BT_GMAP_UGG_SUPPORTED */
 
 #if defined(CONFIG_BT_GMAP_UGT_SUPPORTED)
-static ssize_t read_gmap_ugt_feat(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
-				  uint16_t len, uint16_t offset)
+static k_ssize_t read_gmap_ugt_feat(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+				    void *buf, uint16_t len, uint16_t offset)
 {
 	const uint8_t feat = (uint8_t)gmap_features.ugt_feat;
 
@@ -74,8 +74,8 @@ static const struct bt_gatt_attr ugt_feat_chrc[] = {
 #endif /* CONFIG_BT_GMAP_UGT_SUPPORTED */
 
 #if defined(CONFIG_BT_GMAP_BGS_SUPPORTED)
-static ssize_t read_gmap_bgs_feat(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
-				  uint16_t len, uint16_t offset)
+static k_ssize_t read_gmap_bgs_feat(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+				    void *buf, uint16_t len, uint16_t offset)
 {
 	const uint8_t feat = (uint8_t)gmap_features.bgs_feat;
 
@@ -91,8 +91,8 @@ static const struct bt_gatt_attr bgs_feat_chrc[] = {
 #endif /* CONFIG_BT_GMAP_BGS_SUPPORTED */
 
 #if defined(CONFIG_BT_GMAP_BGR_SUPPORTED)
-static ssize_t read_gmap_bgr_feat(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
-				  uint16_t len, uint16_t offset)
+static k_ssize_t read_gmap_bgr_feat(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+				    void *buf, uint16_t len, uint16_t offset)
 {
 	const uint8_t feat = (uint8_t)gmap_features.bgr_feat;
 

--- a/subsys/bluetooth/audio/has.c
+++ b/subsys/bluetooth/audio/has.c
@@ -74,7 +74,7 @@ static int read_preset_response(struct has_client *client);
 static int preset_list_changed(struct has_client *client);
 static int preset_list_changed_generic_update_tail(struct has_client *client);
 static int preset_list_changed_record_deleted_last(struct has_client *client);
-static ssize_t write_control_point(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t write_control_point(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 				   const void *data, uint16_t len, uint16_t offset, uint8_t flags);
 
 static void preset_cp_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
@@ -82,7 +82,7 @@ static void preset_cp_cfg_changed(const struct bt_gatt_attr *attr, uint16_t valu
 	LOG_DBG("attr %p value 0x%04x", attr, value);
 }
 
-static ssize_t read_active_preset_index(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t read_active_preset_index(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 					void *buf, uint16_t len, uint16_t offset)
 {
 	uint8_t active_index;
@@ -106,7 +106,7 @@ static void features_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value
 }
 #endif /* CONFIG_BT_HAS_FEATURES_NOTIFIABLE */
 
-static ssize_t read_features(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
+static k_ssize_t read_features(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
 			     uint16_t len, uint16_t offset)
 {
 	LOG_DBG("conn %p attr %p offset %d", (void *)conn, attr, offset);
@@ -895,7 +895,7 @@ static int settings_set_cb(const char *name, size_t len_rd, settings_read_cb rea
 	struct client_context_store store;
 	struct client_context *context;
 	bt_addr_le_t addr;
-	ssize_t len;
+	k_ssize_t len;
 	int err;
 
 	if (!name) {
@@ -1447,7 +1447,7 @@ static uint8_t handle_control_point_op(struct bt_conn *conn, struct net_buf_simp
 	return BT_HAS_ERR_INVALID_OPCODE;
 }
 
-static ssize_t write_control_point(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t write_control_point(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 				   const void *data, uint16_t len, uint16_t offset, uint8_t flags)
 {
 	struct net_buf_simple buf;

--- a/subsys/bluetooth/audio/mcs.c
+++ b/subsys/bluetooth/audio/mcs.c
@@ -93,7 +93,7 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
  * of attribute configuration changes.
  * Functions for notifications are placed after the service definition.
  */
-static ssize_t read_player_name(struct bt_conn *conn,
+static k_ssize_t read_player_name(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr, void *buf,
 				uint16_t len, uint16_t offset)
 {
@@ -122,7 +122,7 @@ static void player_name_cfg_changed(const struct bt_gatt_attr *attr,
 }
 
 #ifdef CONFIG_BT_OTS
-static ssize_t read_icon_id(struct bt_conn *conn,
+static k_ssize_t read_icon_id(struct bt_conn *conn,
 			    const struct bt_gatt_attr *attr, void *buf,
 			    uint16_t len, uint16_t offset)
 {
@@ -138,7 +138,7 @@ static ssize_t read_icon_id(struct bt_conn *conn,
 }
 #endif /* CONFIG_BT_OTS */
 
-static ssize_t read_icon_url(struct bt_conn *conn,
+static k_ssize_t read_icon_url(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr, void *buf,
 			     uint16_t len, uint16_t offset)
 {
@@ -165,7 +165,7 @@ static void track_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 	LOG_DBG("value 0x%04x", value);
 }
 
-static ssize_t read_track_title(struct bt_conn *conn,
+static k_ssize_t read_track_title(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr,
 				void *buf, uint16_t len, uint16_t offset)
 {
@@ -193,7 +193,7 @@ static void track_title_cfg_changed(const struct bt_gatt_attr *attr,
 	LOG_DBG("value 0x%04x", value);
 }
 
-static ssize_t read_track_duration(struct bt_conn *conn,
+static k_ssize_t read_track_duration(struct bt_conn *conn,
 				   const struct bt_gatt_attr *attr, void *buf,
 				   uint16_t len, uint16_t offset)
 {
@@ -216,8 +216,8 @@ static void track_duration_cfg_changed(const struct bt_gatt_attr *attr, uint16_t
 	LOG_DBG("value 0x%04x", value);
 }
 
-static ssize_t read_track_position(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
-				   uint16_t len, uint16_t offset)
+static k_ssize_t read_track_position(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+				     void *buf, uint16_t len, uint16_t offset)
 {
 	int32_t position = media_proxy_sctrl_get_track_position();
 	int32_t position_le = sys_cpu_to_le32(position);
@@ -234,7 +234,7 @@ static ssize_t read_track_position(struct bt_conn *conn, const struct bt_gatt_at
 				 sizeof(position_le));
 }
 
-static ssize_t write_track_position(struct bt_conn *conn,
+static k_ssize_t write_track_position(struct bt_conn *conn,
 				    const struct bt_gatt_attr *attr,
 				    const void *buf, uint16_t len,
 				    uint16_t offset, uint8_t flags)
@@ -264,7 +264,7 @@ static void track_position_cfg_changed(const struct bt_gatt_attr *attr,
 	LOG_DBG("value 0x%04x", value);
 }
 
-static ssize_t read_playback_speed(struct bt_conn *conn,
+static k_ssize_t read_playback_speed(struct bt_conn *conn,
 				   const struct bt_gatt_attr *attr, void *buf,
 				   uint16_t len, uint16_t offset)
 {
@@ -281,8 +281,8 @@ static ssize_t read_playback_speed(struct bt_conn *conn,
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, &speed, sizeof(speed));
 }
 
-static ssize_t write_playback_speed(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-				    const void *buf, uint16_t len, uint16_t offset, uint8_t flags)
+static k_ssize_t write_playback_speed(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+				      const void *buf, uint16_t len, uint16_t offset, uint8_t flags)
 {
 	int8_t speed;
 
@@ -307,8 +307,8 @@ static void playback_speed_cfg_changed(const struct bt_gatt_attr *attr, uint16_t
 	LOG_DBG("value 0x%04x", value);
 }
 
-static ssize_t read_seeking_speed(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
-				  uint16_t len, uint16_t offset)
+static k_ssize_t read_seeking_speed(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+				    void *buf, uint16_t len, uint16_t offset)
 {
 	int8_t speed = media_proxy_sctrl_get_seeking_speed();
 
@@ -331,7 +331,7 @@ static void seeking_speed_cfg_changed(const struct bt_gatt_attr *attr,
 }
 
 #ifdef CONFIG_BT_OTS
-static ssize_t read_track_segments_id(struct bt_conn *conn,
+static k_ssize_t read_track_segments_id(struct bt_conn *conn,
 				      const struct bt_gatt_attr *attr,
 				      void *buf, uint16_t len, uint16_t offset)
 {
@@ -346,7 +346,7 @@ static ssize_t read_track_segments_id(struct bt_conn *conn,
 				 track_segments_id_le, sizeof(track_segments_id_le));
 }
 
-static ssize_t read_current_track_id(struct bt_conn *conn,
+static k_ssize_t read_current_track_id(struct bt_conn *conn,
 				     const struct bt_gatt_attr *attr, void *buf,
 				     uint16_t len, uint16_t offset)
 {
@@ -367,7 +367,7 @@ static ssize_t read_current_track_id(struct bt_conn *conn,
 				 sizeof(track_id_le));
 }
 
-static ssize_t write_current_track_id(struct bt_conn *conn,
+static k_ssize_t write_current_track_id(struct bt_conn *conn,
 				      const struct bt_gatt_attr *attr,
 				      const void *buf, uint16_t len, uint16_t offset,
 				      uint8_t flags)
@@ -403,7 +403,7 @@ static void current_track_id_cfg_changed(const struct bt_gatt_attr *attr,
 	LOG_DBG("value 0x%04x", value);
 }
 
-static ssize_t read_next_track_id(struct bt_conn *conn,
+static k_ssize_t read_next_track_id(struct bt_conn *conn,
 				  const struct bt_gatt_attr *attr, void *buf,
 				  uint16_t len, uint16_t offset)
 {
@@ -430,7 +430,7 @@ static ssize_t read_next_track_id(struct bt_conn *conn,
 				 track_id_le, sizeof(track_id_le));
 }
 
-static ssize_t write_next_track_id(struct bt_conn *conn,
+static k_ssize_t write_next_track_id(struct bt_conn *conn,
 				   const struct bt_gatt_attr *attr,
 				   const void *buf, uint16_t len, uint16_t offset,
 				   uint8_t flags)
@@ -466,7 +466,7 @@ static void next_track_id_cfg_changed(const struct bt_gatt_attr *attr,
 	LOG_DBG("value 0x%04x", value);
 }
 
-static ssize_t read_parent_group_id(struct bt_conn *conn,
+static k_ssize_t read_parent_group_id(struct bt_conn *conn,
 				    const struct bt_gatt_attr *attr, void *buf,
 				    uint16_t len, uint16_t offset)
 {
@@ -493,7 +493,7 @@ static void parent_group_id_cfg_changed(const struct bt_gatt_attr *attr,
 	LOG_DBG("value 0x%04x", value);
 }
 
-static ssize_t read_current_group_id(struct bt_conn *conn,
+static k_ssize_t read_current_group_id(struct bt_conn *conn,
 				     const struct bt_gatt_attr *attr, void *buf,
 				     uint16_t len, uint16_t offset)
 {
@@ -514,7 +514,7 @@ static ssize_t read_current_group_id(struct bt_conn *conn,
 				 sizeof(group_id_le));
 }
 
-static ssize_t write_current_group_id(struct bt_conn *conn,
+static k_ssize_t write_current_group_id(struct bt_conn *conn,
 				      const struct bt_gatt_attr *attr,
 				      const void *buf, uint16_t len, uint16_t offset,
 				      uint8_t flags)
@@ -551,7 +551,7 @@ static void current_group_id_cfg_changed(const struct bt_gatt_attr *attr, uint16
 }
 #endif /* CONFIG_BT_OTS */
 
-static ssize_t read_playing_order(struct bt_conn *conn,
+static k_ssize_t read_playing_order(struct bt_conn *conn,
 				  const struct bt_gatt_attr *attr, void *buf,
 				  uint16_t len, uint16_t offset)
 {
@@ -568,7 +568,7 @@ static ssize_t read_playing_order(struct bt_conn *conn,
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, &order, sizeof(order));
 }
 
-static ssize_t write_playing_order(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t write_playing_order(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 				   const void *buf, uint16_t len, uint16_t offset, uint8_t flags)
 {
 	LOG_DBG("Playing order write");
@@ -596,8 +596,9 @@ static void playing_order_cfg_changed(const struct bt_gatt_attr *attr, uint16_t 
 	LOG_DBG("value 0x%04x", value);
 }
 
-static ssize_t read_playing_orders_supported(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-					     void *buf, uint16_t len, uint16_t offset)
+static k_ssize_t read_playing_orders_supported(struct bt_conn *conn,
+					       const struct bt_gatt_attr *attr, void *buf,
+					       uint16_t len, uint16_t offset)
 {
 	uint16_t orders = media_proxy_sctrl_get_playing_orders_supported();
 	uint16_t orders_le = sys_cpu_to_le16(orders);
@@ -607,7 +608,7 @@ static ssize_t read_playing_orders_supported(struct bt_conn *conn, const struct 
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, &orders_le, sizeof(orders_le));
 }
 
-static ssize_t read_media_state(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
+static k_ssize_t read_media_state(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
 				uint16_t len, uint16_t offset)
 {
 	uint8_t state = media_proxy_sctrl_get_media_state();
@@ -630,7 +631,7 @@ static void media_state_cfg_changed(const struct bt_gatt_attr *attr,
 	LOG_DBG("value 0x%04x", value);
 }
 
-static ssize_t write_control_point(struct bt_conn *conn,
+static k_ssize_t write_control_point(struct bt_conn *conn,
 				   const struct bt_gatt_attr *attr,
 				   const void *buf, uint16_t len, uint16_t offset,
 				   uint8_t flags)
@@ -699,7 +700,7 @@ static void control_point_cfg_changed(const struct bt_gatt_attr *attr,
 	LOG_DBG("value 0x%04x", value);
 }
 
-static ssize_t read_opcodes_supported(struct bt_conn *conn,
+static k_ssize_t read_opcodes_supported(struct bt_conn *conn,
 				      const struct bt_gatt_attr *attr,
 				      void *buf, uint16_t len, uint16_t offset)
 {
@@ -723,7 +724,7 @@ static void opcodes_supported_cfg_changed(const struct bt_gatt_attr *attr, uint1
 }
 
 #ifdef CONFIG_BT_OTS
-static ssize_t write_search_control_point(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t write_search_control_point(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 					  const void *buf, uint16_t len, uint16_t offset,
 					  uint8_t flags)
 {
@@ -767,7 +768,7 @@ static void search_control_point_cfg_changed(const struct bt_gatt_attr *attr,
 	LOG_DBG("value 0x%04x", value);
 }
 
-static ssize_t read_search_results_id(struct bt_conn *conn,
+static k_ssize_t read_search_results_id(struct bt_conn *conn,
 				      const struct bt_gatt_attr *attr,
 				      void *buf, uint16_t len, uint16_t offset)
 {
@@ -810,7 +811,7 @@ static void search_results_id_cfg_changed(const struct bt_gatt_attr *attr,
 }
 #endif /* CONFIG_BT_OTS */
 
-static ssize_t read_content_ctrl_id(struct bt_conn *conn,
+static k_ssize_t read_content_ctrl_id(struct bt_conn *conn,
 				    const struct bt_gatt_attr *attr, void *buf,
 				    uint16_t len, uint16_t offset)
 {

--- a/subsys/bluetooth/audio/micp_mic_dev.c
+++ b/subsys/bluetooth/audio/micp_mic_dev.c
@@ -49,7 +49,7 @@ static void mute_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 	LOG_DBG("value 0x%04x", value);
 }
 
-static ssize_t read_mute(struct bt_conn *conn,
+static k_ssize_t read_mute(struct bt_conn *conn,
 			 const struct bt_gatt_attr *attr, void *buf,
 			 uint16_t len, uint16_t offset)
 {
@@ -81,7 +81,7 @@ static void notify_work_handler(struct k_work *work)
 	LOG_ERR("Mute state notification err %d", err);
 }
 
-static ssize_t write_mute(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t write_mute(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			  const void *buf, uint16_t len, uint16_t offset,
 			  uint8_t flags)
 {

--- a/subsys/bluetooth/audio/mpl.c
+++ b/subsys/bluetooth/audio/mpl.c
@@ -837,9 +837,9 @@ static int on_obj_created(struct bt_ots *ots, struct bt_conn *conn, uint64_t id,
 }
 
 
-static ssize_t on_object_send(struct bt_ots *ots, struct bt_conn *conn,
+static k_ssize_t on_object_send(struct bt_ots *ots, struct bt_conn *conn,
 			      uint64_t id, void **data, size_t len,
-			      off_t offset)
+			      k_off_t offset)
 {
 	if (obj.busy) {
 		/* TODO: Can there be a collision between select and internal */

--- a/subsys/bluetooth/audio/pacs.c
+++ b/subsys/bluetooth/audio/pacs.c
@@ -243,7 +243,7 @@ static enum bt_audio_context pacs_get_available_contexts_for_conn(struct bt_conn
 	return bt_pacs_get_available_contexts(dir);
 }
 
-static ssize_t available_contexts_read(struct bt_conn *conn,
+static k_ssize_t available_contexts_read(struct bt_conn *conn,
 				       const struct bt_gatt_attr *attr, void *buf,
 				       uint16_t len, uint16_t offset)
 {
@@ -286,7 +286,7 @@ static uint16_t supported_context_get(enum bt_audio_dir dir)
 	return BT_AUDIO_CONTEXT_TYPE_PROHIBITED;
 }
 
-static ssize_t supported_context_read(struct bt_conn *conn,
+static k_ssize_t supported_context_read(struct bt_conn *conn,
 				      const struct bt_gatt_attr *attr,
 				      void *buf, uint16_t len, uint16_t offset)
 {
@@ -356,10 +356,10 @@ static int set_supported_contexts(uint16_t contexts, uint16_t *supported,
 }
 
 #if defined(CONFIG_BT_PAC_SNK)
-static ssize_t snk_read(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t snk_read(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			void *buf, uint16_t len, uint16_t offset)
 {
-	ssize_t ret_val;
+	k_ssize_t ret_val;
 	int err;
 
 	LOG_DBG("conn %p attr %p buf %p len %u offset %u", conn, attr, buf, len, offset);
@@ -392,7 +392,7 @@ static void snk_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 #endif /* CONFIG_BT_PAC_SNK */
 
 #if defined(CONFIG_BT_PAC_SNK_LOC)
-static ssize_t snk_loc_read(struct bt_conn *conn,
+static k_ssize_t snk_loc_read(struct bt_conn *conn,
 			    const struct bt_gatt_attr *attr, void *buf,
 			    uint16_t len, uint16_t offset)
 {
@@ -434,7 +434,7 @@ static void set_snk_location(enum bt_audio_location location)
 #endif /* CONFIG_BT_PAC_SNK_LOC */
 
 #if defined(CONFIG_BT_PAC_SNK_LOC_WRITEABLE)
-static ssize_t snk_loc_write(struct bt_conn *conn,
+static k_ssize_t snk_loc_write(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr, const void *data,
 			     uint16_t len, uint16_t offset, uint8_t flags)
 {
@@ -461,10 +461,10 @@ static ssize_t snk_loc_write(struct bt_conn *conn,
 #endif /* CONFIG_BT_PAC_SNK_LOC_WRITEABLE */
 
 #if defined(CONFIG_BT_PAC_SRC)
-static ssize_t src_read(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t src_read(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			void *buf, uint16_t len, uint16_t offset)
 {
-	ssize_t ret_val;
+	k_ssize_t ret_val;
 	int err;
 
 	LOG_DBG("conn %p attr %p buf %p len %u offset %u", conn, attr, buf, len, offset);
@@ -497,7 +497,7 @@ static void src_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 #endif /* CONFIG_BT_PAC_SRC */
 
 #if defined(CONFIG_BT_PAC_SRC_LOC)
-static ssize_t src_loc_read(struct bt_conn *conn,
+static k_ssize_t src_loc_read(struct bt_conn *conn,
 			    const struct bt_gatt_attr *attr, void *buf,
 			    uint16_t len, uint16_t offset)
 {
@@ -539,7 +539,7 @@ static void set_src_location(enum bt_audio_location location)
 #endif /* CONFIG_BT_PAC_SRC_LOC */
 
 #if defined(CONFIG_BT_PAC_SRC_LOC_WRITEABLE)
-static ssize_t src_loc_write(struct bt_conn *conn,
+static k_ssize_t src_loc_write(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr, const void *data,
 			     uint16_t len, uint16_t offset, uint8_t flags)
 {

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -1743,7 +1743,7 @@ static int cmd_release(const struct shell *sh, size_t argc, char *argv[])
 #endif /* CONFIG_BT_BAP_UNICAST */
 
 #if IS_BAP_INITIATOR
-static ssize_t parse_config_data_args(const struct shell *sh, size_t argn, size_t argc,
+static k_ssize_t parse_config_data_args(const struct shell *sh, size_t argn, size_t argc,
 				      char *argv[], struct bt_audio_codec_cfg *codec_cfg)
 {
 	for (; argn < argc; argn++) {
@@ -1907,7 +1907,7 @@ static ssize_t parse_config_data_args(const struct shell *sh, size_t argn, size_
 	return argn;
 }
 
-static ssize_t parse_config_meta_args(const struct shell *sh, size_t argn, size_t argc,
+static k_ssize_t parse_config_meta_args(const struct shell *sh, size_t argn, size_t argc,
 				      char *argv[], struct bt_audio_codec_cfg *codec_cfg)
 {
 	for (; argn < argc; argn++) {
@@ -2248,7 +2248,7 @@ static int cmd_preset(const struct shell *sh, size_t argc, char *argv[])
 				const char *arg = argv[argn];
 
 				if (strcmp(arg, "config") == 0) {
-					ssize_t ret;
+					k_ssize_t ret;
 
 					if (++argn == argc) {
 						shell_help(sh);
@@ -2270,7 +2270,7 @@ static int cmd_preset(const struct shell *sh, size_t argc, char *argv[])
 
 					argn = ret;
 				} else if (strcmp(arg, "meta") == 0) {
-					ssize_t ret;
+					k_ssize_t ret;
 
 					if (++argn == argc) {
 						shell_help(sh);
@@ -4053,7 +4053,7 @@ static int cmd_bap(const struct shell *sh, size_t argc, char **argv)
 
 SHELL_CMD_ARG_REGISTER(bap, &bap_cmds, "Bluetooth BAP shell commands", cmd_bap, 1, 1);
 
-static ssize_t connectable_ad_data_add(struct bt_data *data_array,
+static k_ssize_t connectable_ad_data_add(struct bt_data *data_array,
 				       size_t data_array_size)
 {
 	static const uint8_t ad_ext_uuid16[] = {
@@ -4136,7 +4136,7 @@ static ssize_t connectable_ad_data_add(struct bt_data *data_array,
 	return ad_len;
 }
 
-static ssize_t nonconnectable_ad_data_add(struct bt_data *data_array,
+static k_ssize_t nonconnectable_ad_data_add(struct bt_data *data_array,
 					  const size_t data_array_size)
 {
 	static const uint8_t ad_ext_uuid16[] = {
@@ -4199,7 +4199,7 @@ static ssize_t nonconnectable_ad_data_add(struct bt_data *data_array,
 ssize_t audio_ad_data_add(struct bt_data *data_array, const size_t data_array_size,
 			  const bool discoverable, const bool connectable)
 {
-	ssize_t ad_len = 0;
+	k_ssize_t ad_len = 0;
 
 	if (!discoverable) {
 		return 0;

--- a/subsys/bluetooth/audio/shell/cap_initiator.c
+++ b/subsys/bluetooth/audio/shell/cap_initiator.c
@@ -159,7 +159,7 @@ static int cmd_cap_initiator_unicast_start(const struct shell *sh, size_t argc,
 	struct bt_cap_unicast_audio_start_param start_param = {0};
 	struct bt_bap_unicast_group_param group_param = {0};
 	size_t source_cnt = 1U;
-	ssize_t conn_cnt = 1U;
+	k_ssize_t conn_cnt = 1U;
 	size_t sink_cnt = 1U;
 	size_t pair_cnt = 0U;
 	int err = 0;
@@ -1436,7 +1436,8 @@ SHELL_CMD_ARG_REGISTER(cap_initiator, &cap_initiator_cmds,
 		       "Bluetooth CAP initiator shell commands",
 		       cmd_cap_initiator, 1, 1);
 
-static ssize_t nonconnectable_ad_data_add(struct bt_data *data_array, const size_t data_array_size)
+static k_ssize_t nonconnectable_ad_data_add(struct bt_data *data_array,
+					    const size_t data_array_size)
 {
 #if defined(CONFIG_BT_BAP_BROADCAST_SOURCE)
 	if (default_source.cap_source != NULL && default_source.is_cap) {

--- a/subsys/bluetooth/audio/tbs.c
+++ b/subsys/bluetooth/audio/tbs.c
@@ -510,7 +510,7 @@ static int notify_calls(const struct tbs_service_inst *inst)
 	return inst_notify_calls(&inst->inst);
 }
 
-static ssize_t read_provider_name(struct bt_conn *conn,
+static k_ssize_t read_provider_name(struct bt_conn *conn,
 				  const struct bt_gatt_attr *attr,
 				  void *buf, uint16_t len, uint16_t offset)
 {
@@ -532,7 +532,7 @@ static void provider_name_cfg_changed(const struct bt_gatt_attr *attr,
 	}
 }
 
-static ssize_t read_uci(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t read_uci(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			void *buf, uint16_t len, uint16_t offset)
 {
 	const struct service_inst *inst = BT_AUDIO_CHRC_USER_DATA(attr);
@@ -542,7 +542,7 @@ static ssize_t read_uci(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, inst->uci, strlen(inst->uci));
 }
 
-static ssize_t read_technology(struct bt_conn *conn,
+static k_ssize_t read_technology(struct bt_conn *conn,
 			       const struct bt_gatt_attr *attr,
 			       void *buf, uint16_t len, uint16_t offset)
 {
@@ -564,7 +564,7 @@ static void technology_cfg_changed(const struct bt_gatt_attr *attr,
 	}
 }
 
-static ssize_t read_uri_scheme_list(struct bt_conn *conn,
+static k_ssize_t read_uri_scheme_list(struct bt_conn *conn,
 				    const struct bt_gatt_attr *attr,
 				    void *buf, uint16_t len, uint16_t offset)
 {
@@ -615,7 +615,7 @@ static void uri_scheme_list_cfg_changed(const struct bt_gatt_attr *attr,
 	}
 }
 
-static ssize_t read_signal_strength(struct bt_conn *conn,
+static k_ssize_t read_signal_strength(struct bt_conn *conn,
 				    const struct bt_gatt_attr *attr,
 				    void *buf, uint16_t len, uint16_t offset)
 {
@@ -637,7 +637,7 @@ static void signal_strength_cfg_changed(const struct bt_gatt_attr *attr,
 	}
 }
 
-static ssize_t read_signal_strength_interval(struct bt_conn *conn,
+static k_ssize_t read_signal_strength_interval(struct bt_conn *conn,
 					     const struct bt_gatt_attr *attr,
 					     void *buf, uint16_t len,
 					     uint16_t offset)
@@ -656,7 +656,7 @@ static ssize_t read_signal_strength_interval(struct bt_conn *conn,
 				 sizeof(inst->signal_strength_interval));
 }
 
-static ssize_t write_signal_strength_interval(struct bt_conn *conn,
+static k_ssize_t write_signal_strength_interval(struct bt_conn *conn,
 					      const struct bt_gatt_attr *attr,
 					      const void *buf, uint16_t len,
 					      uint16_t offset, uint8_t flags)
@@ -697,7 +697,7 @@ static void current_calls_cfg_changed(const struct bt_gatt_attr *attr,
 	}
 }
 
-static ssize_t read_current_calls(struct bt_conn *conn,
+static k_ssize_t read_current_calls(struct bt_conn *conn,
 				  const struct bt_gatt_attr *attr,
 				  void *buf, uint16_t len, uint16_t offset)
 {
@@ -715,7 +715,7 @@ static ssize_t read_current_calls(struct bt_conn *conn,
 				 read_buf.data, read_buf.len);
 }
 
-static ssize_t read_ccid(struct bt_conn *conn,
+static k_ssize_t read_ccid(struct bt_conn *conn,
 			 const struct bt_gatt_attr *attr,
 			 void *buf, uint16_t len, uint16_t offset)
 {
@@ -726,7 +726,7 @@ static ssize_t read_ccid(struct bt_conn *conn,
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, &inst->ccid, sizeof(inst->ccid));
 }
 
-static ssize_t read_status_flags(struct bt_conn *conn,
+static k_ssize_t read_status_flags(struct bt_conn *conn,
 				 const struct bt_gatt_attr *attr,
 				 void *buf, uint16_t len, uint16_t offset)
 {
@@ -748,7 +748,7 @@ static void status_flags_cfg_changed(const struct bt_gatt_attr *attr,
 	}
 }
 
-static ssize_t read_incoming_uri(struct bt_conn *conn,
+static k_ssize_t read_incoming_uri(struct bt_conn *conn,
 					    const struct bt_gatt_attr *attr,
 					    void *buf, uint16_t len,
 					    uint16_t offset)
@@ -785,7 +785,7 @@ static void incoming_uri_cfg_changed(const struct bt_gatt_attr *attr,
 	}
 }
 
-static ssize_t read_call_state(struct bt_conn *conn,
+static k_ssize_t read_call_state(struct bt_conn *conn,
 			       const struct bt_gatt_attr *attr,
 			       void *buf, uint16_t len, uint16_t offset)
 {
@@ -1143,7 +1143,7 @@ static void notify_app(struct bt_conn *conn, struct tbs_service_inst *inst, uint
 	}
 }
 
-static ssize_t write_call_cp(struct bt_conn *conn,
+static k_ssize_t write_call_cp(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr,
 			     const void *buf, uint16_t len,
 			     uint16_t offset, uint8_t flags)
@@ -1343,7 +1343,7 @@ static void call_cp_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 	}
 }
 
-static ssize_t read_optional_opcodes(struct bt_conn *conn,
+static k_ssize_t read_optional_opcodes(struct bt_conn *conn,
 				     const struct bt_gatt_attr *attr,
 				     void *buf, uint16_t len, uint16_t offset)
 {
@@ -1365,7 +1365,7 @@ static void terminate_reason_cfg_changed(const struct bt_gatt_attr *attr,
 	}
 }
 
-static ssize_t read_friendly_name(struct bt_conn *conn,
+static k_ssize_t read_friendly_name(struct bt_conn *conn,
 				     const struct bt_gatt_attr *attr,
 				     void *buf, uint16_t len, uint16_t offset)
 {
@@ -1398,7 +1398,7 @@ static void friendly_name_cfg_changed(const struct bt_gatt_attr *attr,
 	}
 }
 
-static ssize_t read_incoming_call(struct bt_conn *conn,
+static k_ssize_t read_incoming_call(struct bt_conn *conn,
 				  const struct bt_gatt_attr *attr,
 				  void *buf, uint16_t len, uint16_t offset)
 {

--- a/subsys/bluetooth/audio/tmap.c
+++ b/subsys/bluetooth/audio/tmap.c
@@ -131,7 +131,7 @@ static uint8_t discover_func(struct bt_conn *conn, const struct bt_gatt_attr *at
 	return BT_GATT_ITER_STOP;
 }
 
-static ssize_t read_role(struct bt_conn *conn,
+static k_ssize_t read_role(struct bt_conn *conn,
 			 const struct bt_gatt_attr *attr, void *buf,
 			 uint16_t len, uint16_t offset)
 {

--- a/subsys/bluetooth/audio/vcp_vol_rend.c
+++ b/subsys/bluetooth/audio/vcp_vol_rend.c
@@ -78,7 +78,7 @@ static void volume_state_cfg_changed(const struct bt_gatt_attr *attr,
 	LOG_DBG("value 0x%04x", value);
 }
 
-static ssize_t read_vol_state(struct bt_conn *conn,
+static k_ssize_t read_vol_state(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, void *buf,
 			      uint16_t len, uint16_t offset)
 {
@@ -152,7 +152,7 @@ static void value_changed(struct bt_vcp_vol_rend *inst, enum vol_rend_notify not
 	notify_work_reschedule(inst, notify, K_NO_WAIT);
 }
 
-static ssize_t write_vcs_control(struct bt_conn *conn,
+static k_ssize_t write_vcs_control(struct bt_conn *conn,
 				 const struct bt_gatt_attr *attr,
 				 const void *buf, uint16_t len, uint16_t offset,
 				 uint8_t flags)
@@ -295,7 +295,7 @@ static void flags_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 }
 #endif /* CONFIG_BT_VCP_VOL_REND_VOL_FLAGS_NOTIFIABLE */
 
-static ssize_t read_flags(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t read_flags(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			  void *buf, uint16_t len, uint16_t offset)
 {
 	LOG_DBG("0x%02x", vol_rend.flags);

--- a/subsys/bluetooth/audio/vocs.c
+++ b/subsys/bluetooth/audio/vocs.c
@@ -47,7 +47,7 @@ static void offset_state_cfg_changed(const struct bt_gatt_attr *attr, uint16_t v
 	LOG_DBG("value 0x%04x", value);
 }
 
-static ssize_t read_offset_state(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t read_offset_state(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 				 void *buf, uint16_t len, uint16_t offset)
 {
 	struct bt_vocs_server *inst = BT_AUDIO_CHRC_USER_DATA(attr);
@@ -131,7 +131,7 @@ static void value_changed(struct bt_vocs_server *inst, enum bt_vocs_notify notif
 #define value_changed(...)
 #endif /* CONFIG_BT_VOCS */
 
-static ssize_t write_location(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t write_location(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			      const void *buf, uint16_t len, uint16_t offset, uint8_t flags)
 {
 	struct bt_vocs_server *inst = BT_AUDIO_CHRC_USER_DATA(attr);
@@ -166,7 +166,7 @@ static ssize_t write_location(struct bt_conn *conn, const struct bt_gatt_attr *a
 }
 
 #if defined(CONFIG_BT_VOCS)
-static ssize_t read_location(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t read_location(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			     void *buf, uint16_t len, uint16_t offset)
 {
 	struct bt_vocs_server *inst = BT_AUDIO_CHRC_USER_DATA(attr);
@@ -177,7 +177,7 @@ static ssize_t read_location(struct bt_conn *conn, const struct bt_gatt_attr *at
 }
 #endif /* CONFIG_BT_VOCS */
 
-static ssize_t write_vocs_control(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t write_vocs_control(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 				  const void *buf, uint16_t len, uint16_t offset, uint8_t flags)
 {
 	struct bt_vocs_server *inst = BT_AUDIO_CHRC_USER_DATA(attr);
@@ -248,7 +248,7 @@ static void output_desc_cfg_changed(const struct bt_gatt_attr *attr, uint16_t va
 }
 #endif /* CONFIG_BT_VOCS */
 
-static ssize_t write_output_desc(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t write_output_desc(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 				 const void *buf, uint16_t len, uint16_t offset, uint8_t flags)
 {
 	struct bt_vocs_server *inst = BT_AUDIO_CHRC_USER_DATA(attr);
@@ -281,7 +281,7 @@ static ssize_t write_output_desc(struct bt_conn *conn, const struct bt_gatt_attr
 }
 
 static int vocs_write(struct bt_vocs_server *inst,
-		      ssize_t (*write)(struct bt_conn *conn,
+		      k_ssize_t (*write)(struct bt_conn *conn,
 				       const struct bt_gatt_attr *attr,
 				       const void *buf, uint16_t len,
 				       uint16_t offset, uint8_t flags),
@@ -304,7 +304,7 @@ static int vocs_write(struct bt_vocs_server *inst,
 }
 
 #if defined(CONFIG_BT_VOCS)
-static ssize_t read_output_desc(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t read_output_desc(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 				void *buf, uint16_t len, uint16_t offset)
 {
 	struct bt_vocs_server *inst = BT_AUDIO_CHRC_USER_DATA(attr);

--- a/subsys/bluetooth/controller/ll_sw/ll_settings.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_settings.c
@@ -44,7 +44,7 @@ bool ll_settings_smi_tx(void)
 static int ctlr_set(const char *name, size_t len_rd,
 		    settings_read_cb read_cb, void *store)
 {
-	ssize_t len;
+	k_ssize_t len;
 	int nlen;
 	const char *next;
 

--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -505,7 +505,7 @@ static int set_data_add_complete(uint8_t *set_data, uint8_t set_data_len_max,
 
 			/* Check if ad fit in the remaining buffer */
 			if ((set_data_len + len + 2) > set_data_len_max) {
-				ssize_t shortened_len = set_data_len_max -
+				k_ssize_t shortened_len = set_data_len_max -
 							(set_data_len + 2);
 
 				if (!(type == BT_DATA_NAME_COMPLETE &&

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -1323,8 +1323,7 @@ struct read_type_data {
 	uint8_t err;
 };
 
-typedef bool (*attr_read_cb)(struct net_buf *buf, ssize_t read,
-			     void *user_data);
+typedef bool (*attr_read_cb)(struct net_buf *buf, k_ssize_t read, void *user_data);
 
 static bool attr_read_authorize(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr)
@@ -1340,8 +1339,7 @@ static bool attr_read_authorize(struct bt_conn *conn,
 	return authorization_cb->read_authorize(conn, attr);
 }
 
-static bool attr_read_type_cb(struct net_buf *frag, ssize_t read,
-			      void *user_data)
+static bool attr_read_type_cb(struct net_buf *frag, k_ssize_t read, void *user_data)
 {
 	struct read_type_data *data = user_data;
 
@@ -1358,13 +1356,12 @@ static bool attr_read_type_cb(struct net_buf *frag, ssize_t read,
 	return true;
 }
 
-static ssize_t att_chan_read(struct bt_att_chan *chan,
-			     const struct bt_gatt_attr *attr,
-			     struct net_buf *buf, uint16_t offset,
-			     attr_read_cb cb, void *user_data)
+static k_ssize_t att_chan_read(struct bt_att_chan *chan, const struct bt_gatt_attr *attr,
+			       struct net_buf *buf, uint16_t offset, attr_read_cb cb,
+			       void *user_data)
 {
 	struct bt_conn *conn = chan->chan.chan.conn;
-	ssize_t read;
+	k_ssize_t read;
 	struct net_buf *frag;
 	size_t len, total = 0;
 
@@ -1422,7 +1419,7 @@ static uint8_t read_type_cb(const struct bt_gatt_attr *attr, uint16_t handle,
 	struct read_type_data *data = user_data;
 	struct bt_att_chan *chan = data->chan;
 	struct bt_conn *conn = chan->chan.chan.conn;
-	ssize_t read;
+	k_ssize_t read;
 
 	/* Skip if doesn't match */
 	if (bt_uuid_cmp(attr->uuid, data->uuid)) {
@@ -1836,8 +1833,7 @@ struct read_group_data {
 	struct bt_att_group_data *group;
 };
 
-static bool attr_read_group_cb(struct net_buf *frag, ssize_t read,
-			       void *user_data)
+static bool attr_read_group_cb(struct net_buf *frag, k_ssize_t read, void *user_data)
 {
 	struct read_group_data *data = user_data;
 

--- a/subsys/bluetooth/host/classic/keys_br.c
+++ b/subsys/bluetooth/host/classic/keys_br.c
@@ -170,7 +170,7 @@ static int link_key_set(const char *name, size_t len_rd,
 			settings_read_cb read_cb, void *cb_arg)
 {
 	int err;
-	ssize_t len;
+	k_ssize_t len;
 	bt_addr_le_t le_addr;
 	struct bt_keys_link_key *link_key;
 	char val[BT_KEYS_LINK_KEY_STORAGE_LEN];

--- a/subsys/bluetooth/host/classic/sdp.c
+++ b/subsys/bluetooth/host/classic/sdp.c
@@ -1975,7 +1975,7 @@ int bt_sdp_discover(struct bt_conn *conn,
 }
 
 /* Helper getting length of data determined by DTD for integers */
-static inline ssize_t sdp_get_int_len(const uint8_t *data, size_t len)
+static inline k_ssize_t sdp_get_int_len(const uint8_t *data, size_t len)
 {
 	BT_ASSERT(data);
 
@@ -2023,7 +2023,7 @@ static inline ssize_t sdp_get_int_len(const uint8_t *data, size_t len)
 }
 
 /* Helper getting length of data determined by DTD for UUID */
-static inline ssize_t sdp_get_uuid_len(const uint8_t *data, size_t len)
+static inline k_ssize_t sdp_get_uuid_len(const uint8_t *data, size_t len)
 {
 	BT_ASSERT(data);
 
@@ -2051,7 +2051,7 @@ static inline ssize_t sdp_get_uuid_len(const uint8_t *data, size_t len)
 }
 
 /* Helper getting length of data determined by DTD for strings */
-static inline ssize_t sdp_get_str_len(const uint8_t *data, size_t len)
+static inline k_ssize_t sdp_get_str_len(const uint8_t *data, size_t len)
 {
 	const uint8_t *pnext;
 
@@ -2096,7 +2096,7 @@ err:
 }
 
 /* Helper getting length of data determined by DTD for sequences */
-static inline ssize_t sdp_get_seq_len(const uint8_t *data, size_t len)
+static inline k_ssize_t sdp_get_seq_len(const uint8_t *data, size_t len)
 {
 	const uint8_t *pnext;
 
@@ -2141,7 +2141,7 @@ err:
 }
 
 /* Helper getting length of attribute value data */
-static ssize_t sdp_get_attr_value_len(const uint8_t *data, size_t len)
+static k_ssize_t sdp_get_attr_value_len(const uint8_t *data, size_t len)
 {
 	BT_ASSERT(data);
 
@@ -2225,7 +2225,7 @@ static int bt_sdp_get_attr(const struct net_buf *buf,
 
 	data = buf->data;
 	while (data - buf->data < buf->len) {
-		ssize_t dlen;
+		k_ssize_t dlen;
 
 		/* data need to point to attribute id descriptor field (DTD)*/
 		if (data[0] != BT_SDP_UINT16) {
@@ -2267,7 +2267,7 @@ static int bt_sdp_get_attr(const struct net_buf *buf,
 }
 
 /* reads SEQ item length, moves input buffer data reader forward */
-static ssize_t sdp_get_seq_len_item(uint8_t **data, size_t len)
+static k_ssize_t sdp_get_seq_len_item(uint8_t **data, size_t len)
 {
 	const uint8_t *pnext;
 
@@ -2324,8 +2324,8 @@ err:
 
 static int sdp_loop_seqs(uint8_t **data, size_t len)
 {
-	ssize_t slen;
-	ssize_t pre_slen;
+	k_ssize_t slen;
+	k_ssize_t pre_slen;
 	uint8_t *end;
 
 	if (len <= 0) {
@@ -2360,7 +2360,7 @@ static int sdp_get_uuid_data(const struct bt_sdp_attr_item *attr,
 {
 	/* get start address of attribute value */
 	uint8_t *p = attr->val;
-	ssize_t slen;
+	k_ssize_t slen;
 
 	BT_ASSERT(p);
 

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -99,7 +99,7 @@ enum gatt_global_flags {
 
 static ATOMIC_DEFINE(gatt_flags, GATT_NUM_FLAGS);
 
-static ssize_t read_name(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t read_name(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			 void *buf, uint16_t len, uint16_t offset)
 {
 	const char *name = bt_get_name();
@@ -110,7 +110,7 @@ static ssize_t read_name(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 
 #if defined(CONFIG_BT_DEVICE_NAME_GATT_WRITABLE)
 
-static ssize_t write_name(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t write_name(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			 const void *buf, uint16_t len, uint16_t offset,
 			 uint8_t flags)
 {
@@ -133,7 +133,7 @@ static ssize_t write_name(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 
 #endif /* CONFIG_BT_DEVICE_NAME_GATT_WRITABLE */
 
-static ssize_t read_appearance(struct bt_conn *conn,
+static k_ssize_t read_appearance(struct bt_conn *conn,
 			       const struct bt_gatt_attr *attr, void *buf,
 			       uint16_t len, uint16_t offset)
 {
@@ -144,7 +144,7 @@ static ssize_t read_appearance(struct bt_conn *conn,
 }
 
 #if defined(CONFIG_BT_DEVICE_APPEARANCE_GATT_WRITABLE)
-static ssize_t write_appearance(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t write_appearance(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			 const void *buf, uint16_t len, uint16_t offset,
 			 uint8_t flags)
 {
@@ -199,7 +199,7 @@ BUILD_ASSERT((CONFIG_BT_PERIPHERAL_PREF_TIMEOUT * 4U) >
 	     ((1U + CONFIG_BT_PERIPHERAL_PREF_LATENCY) *
 	      CONFIG_BT_PERIPHERAL_PREF_MAX_INT));
 
-static ssize_t read_ppcp(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t read_ppcp(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			 void *buf, uint16_t len, uint16_t offset)
 {
 	struct __packed {
@@ -220,7 +220,7 @@ static ssize_t read_ppcp(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 #endif
 
 #if defined(CONFIG_BT_CENTRAL) && defined(CONFIG_BT_PRIVACY)
-static ssize_t read_central_addr_res(struct bt_conn *conn,
+static k_ssize_t read_central_addr_res(struct bt_conn *conn,
 				     const struct bt_gatt_attr *attr, void *buf,
 				     uint16_t len, uint16_t offset)
 {
@@ -470,7 +470,7 @@ done:
 	}
 }
 
-static ssize_t sc_ccc_cfg_write(struct bt_conn *conn,
+static k_ssize_t sc_ccc_cfg_write(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr, uint16_t value)
 {
 	LOG_DBG("value 0x%04x", value);
@@ -618,7 +618,7 @@ static struct gatt_cf_cfg *find_cf_cfg(struct bt_conn *conn)
 	return NULL;
 }
 
-static ssize_t cf_read(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t cf_read(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 		       void *buf, uint16_t len, uint16_t offset)
 {
 	struct gatt_cf_cfg *cfg;
@@ -660,7 +660,7 @@ static bool cf_set_value(struct gatt_cf_cfg *cfg, const uint8_t *value, uint16_t
 	return true;
 }
 
-static ssize_t cf_write(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t cf_write(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			const void *buf, uint16_t len, uint16_t offset, uint8_t flags)
 {
 	struct gatt_cf_cfg *cfg;
@@ -825,7 +825,7 @@ static uint8_t gen_hash_m(const struct bt_gatt_attr *attr, uint16_t handle,
 	struct gen_hash_state *state = user_data;
 	struct bt_uuid_16 *u16;
 	uint8_t data[sizeof(union hash_attr_value)];
-	ssize_t len;
+	k_ssize_t len;
 	uint16_t value;
 
 	if (attr->uuid->type != BT_UUID_TYPE_16)
@@ -1010,7 +1010,7 @@ static void db_hash_process(struct k_work *work)
 	do_db_hash();
 }
 
-static ssize_t db_hash_read(struct bt_conn *conn,
+static k_ssize_t db_hash_read(struct bt_conn *conn,
 			    const struct bt_gatt_attr *attr,
 			    void *buf, uint16_t len, uint16_t offset)
 {
@@ -1072,7 +1072,7 @@ static void remove_cf_cfg(struct bt_conn *conn)
 #define SF_BIT_EATT	0
 #define SF_BIT_LAST	SF_BIT_EATT
 
-static ssize_t sf_read(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t sf_read(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 		       void *buf, uint16_t len, uint16_t offset)
 {
 	uint8_t value = BIT(SF_BIT_EATT);
@@ -1822,7 +1822,7 @@ bool bt_gatt_service_is_registered(const struct bt_gatt_service *svc)
 }
 #endif /* CONFIG_BT_GATT_DYNAMIC_DB */
 
-ssize_t bt_gatt_attr_read(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+k_ssize_t bt_gatt_attr_read(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			  void *buf, uint16_t buf_len, uint16_t offset,
 			  const void *value, uint16_t value_len)
 {
@@ -1841,7 +1841,7 @@ ssize_t bt_gatt_attr_read(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 	return len;
 }
 
-ssize_t bt_gatt_attr_read_service(struct bt_conn *conn,
+k_ssize_t bt_gatt_attr_read_service(struct bt_conn *conn,
 				  const struct bt_gatt_attr *attr,
 				  void *buf, uint16_t len, uint16_t offset)
 {
@@ -1910,7 +1910,7 @@ uint16_t bt_gatt_attr_get_handle(const struct bt_gatt_attr *attr)
 	return 0;
 }
 
-ssize_t bt_gatt_attr_read_included(struct bt_conn *conn,
+k_ssize_t bt_gatt_attr_read_included(struct bt_conn *conn,
 				   const struct bt_gatt_attr *attr,
 				   void *buf, uint16_t len, uint16_t offset)
 {
@@ -1966,7 +1966,7 @@ uint16_t bt_gatt_attr_value_handle(const struct bt_gatt_attr *attr)
 	return handle;
 }
 
-ssize_t bt_gatt_attr_read_chrc(struct bt_conn *conn,
+k_ssize_t bt_gatt_attr_read_chrc(struct bt_conn *conn,
 			       const struct bt_gatt_attr *attr, void *buf,
 			       uint16_t len, uint16_t offset)
 {
@@ -2152,7 +2152,7 @@ static struct bt_gatt_ccc_cfg *find_ccc_cfg(const struct bt_conn *conn,
 	return NULL;
 }
 
-ssize_t bt_gatt_attr_read_ccc(struct bt_conn *conn,
+k_ssize_t bt_gatt_attr_read_ccc(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, void *buf,
 			      uint16_t len, uint16_t offset)
 {
@@ -2194,7 +2194,7 @@ static void gatt_ccc_changed(const struct bt_gatt_attr *attr,
 	}
 }
 
-ssize_t bt_gatt_attr_write_ccc(struct bt_conn *conn,
+k_ssize_t bt_gatt_attr_write_ccc(struct bt_conn *conn,
 			       const struct bt_gatt_attr *attr, const void *buf,
 			       uint16_t len, uint16_t offset, uint8_t flags)
 {
@@ -2239,7 +2239,7 @@ ssize_t bt_gatt_attr_write_ccc(struct bt_conn *conn,
 
 	/* Confirm write if cfg is managed by application */
 	if (ccc->cfg_write) {
-		ssize_t write = ccc->cfg_write(conn, attr, value);
+		k_ssize_t write = ccc->cfg_write(conn, attr, value);
 
 		if (write < 0) {
 			return write;
@@ -2276,7 +2276,7 @@ ssize_t bt_gatt_attr_write_ccc(struct bt_conn *conn,
 	return len;
 }
 
-ssize_t bt_gatt_attr_read_cep(struct bt_conn *conn,
+k_ssize_t bt_gatt_attr_read_cep(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, void *buf,
 			      uint16_t len, uint16_t offset)
 {
@@ -2287,7 +2287,7 @@ ssize_t bt_gatt_attr_read_cep(struct bt_conn *conn,
 				 sizeof(props));
 }
 
-ssize_t bt_gatt_attr_read_cud(struct bt_conn *conn,
+k_ssize_t bt_gatt_attr_read_cud(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, void *buf,
 			      uint16_t len, uint16_t offset)
 {
@@ -2305,7 +2305,7 @@ struct gatt_cpf {
 	uint16_t description;
 } __packed;
 
-ssize_t bt_gatt_attr_read_cpf(struct bt_conn *conn,
+k_ssize_t bt_gatt_attr_read_cpf(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, void *buf,
 			      uint16_t len, uint16_t offset)
 {
@@ -5784,7 +5784,7 @@ static int ccc_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 		struct ccc_store ccc_store[CCC_STORE_MAX];
 		struct ccc_load load;
 		bt_addr_le_t addr;
-		ssize_t len;
+		k_ssize_t len;
 		int err;
 		const char *next;
 
@@ -6132,7 +6132,7 @@ static int sc_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 	struct gatt_sc_cfg *cfg;
 	uint8_t id;
 	bt_addr_le_t addr;
-	ssize_t len;
+	k_ssize_t len;
 	int err;
 	const char *next;
 
@@ -6218,7 +6218,7 @@ static int cf_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 	struct gatt_cf_cfg *cfg;
 	bt_addr_le_t addr;
 	const char *next;
-	ssize_t len;
+	k_ssize_t len;
 	int err;
 	uint8_t id;
 
@@ -6303,7 +6303,7 @@ BT_SETTINGS_DEFINE(cf, "cf", cf_set, NULL);
 static int db_hash_set(const char *name, size_t len_rd,
 		       settings_read_cb read_cb, void *cb_arg)
 {
-	ssize_t len;
+	k_ssize_t len;
 
 	len = read_cb(cb_arg, db_hash.stored_hash, sizeof(db_hash.stored_hash));
 	if (len < 0) {

--- a/subsys/bluetooth/host/keys.c
+++ b/subsys/bluetooth/host/keys.c
@@ -352,7 +352,7 @@ static int keys_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 	struct bt_keys *keys;
 	bt_addr_le_t addr;
 	uint8_t id;
-	ssize_t len;
+	k_ssize_t len;
 	int err;
 	char val[BT_KEYS_STORAGE_LEN];
 	const char *next;

--- a/subsys/bluetooth/host/settings.c
+++ b/subsys/bluetooth/host/settings.c
@@ -119,7 +119,7 @@ int bt_settings_decode_key(const char *key, bt_addr_le_t *addr)
 static int set_setting(const char *name, size_t len_rd, settings_read_cb read_cb,
 	       void *cb_arg)
 {
-	ssize_t len;
+	k_ssize_t len;
 	const char *next;
 
 	if (!atomic_test_bit(bt_dev.flags, BT_DEV_ENABLE)) {

--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -1859,7 +1859,7 @@ bool bt_mesh_model_is_extended(const struct bt_mesh_model *model)
 static int mod_set_bind(const struct bt_mesh_model *mod, size_t len_rd,
 			settings_read_cb read_cb, void *cb_arg)
 {
-	ssize_t len;
+	k_ssize_t len;
 	int i;
 
 	/* Start with empty array regardless of cleared or set value */
@@ -1888,7 +1888,7 @@ static int mod_set_sub(const struct bt_mesh_model *mod, size_t len_rd,
 		       settings_read_cb read_cb, void *cb_arg)
 {
 	size_t size = mod->groups_cnt * sizeof(mod->groups[0]);
-	ssize_t len;
+	k_ssize_t len;
 
 	/* Start with empty array regardless of cleared or set value */
 	(void)memset(mod->groups, 0, size);
@@ -1916,7 +1916,7 @@ static int mod_set_sub_va(const struct bt_mesh_model *mod, size_t len_rd,
 {
 #if CONFIG_BT_MESH_LABEL_COUNT > 0
 	uint16_t uuidxs[CONFIG_BT_MESH_LABEL_COUNT];
-	ssize_t len;
+	k_ssize_t len;
 	int i;
 	int count;
 

--- a/subsys/bluetooth/mesh/app_keys.c
+++ b/subsys/bluetooth/mesh/app_keys.c
@@ -439,7 +439,7 @@ bool bt_mesh_app_key_exists(uint16_t app_idx)
 }
 
 ssize_t bt_mesh_app_keys_get(uint16_t net_idx, uint16_t app_idxs[], size_t max,
-			     off_t skip)
+			     k_off_t skip)
 {
 	size_t count = 0;
 

--- a/subsys/bluetooth/mesh/blob_io_flash.c
+++ b/subsys/bluetooth/mesh/blob_io_flash.c
@@ -119,7 +119,7 @@ static int wr_chunk(const struct bt_mesh_blob_io *io,
 
 	uint8_t buf[ROUND_UP(BLOB_CHUNK_SIZE_MAX(BT_MESH_RX_SDU_MAX),
 			  WRITE_BLOCK_SIZE)];
-	off_t area_offset = flash->offset + block->offset + chunk->offset;
+	k_off_t area_offset = flash->offset + block->offset + chunk->offset;
 	int i = 0;
 
 	/* Write block align the chunk data */
@@ -138,7 +138,7 @@ static int wr_chunk(const struct bt_mesh_blob_io *io,
 }
 
 int bt_mesh_blob_io_flash_init(struct bt_mesh_blob_io_flash *flash,
-			       uint8_t area_id, off_t offset)
+			       uint8_t area_id, k_off_t offset)
 {
 	int err;
 

--- a/subsys/bluetooth/mesh/blob_srv.c
+++ b/subsys/bluetooth/mesh/blob_srv.c
@@ -866,7 +866,7 @@ static int blob_srv_settings_set(const struct bt_mesh_model *mod, const char *na
 				 void *cb_arg)
 {
 	struct bt_mesh_blob_srv *srv = mod->rt->user_data;
-	ssize_t len;
+	k_ssize_t len;
 
 	if (len_rd < offsetof(struct bt_mesh_blob_srv_state, blocks)) {
 		return -EINVAL;

--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -381,7 +381,7 @@ static int app_key_get(const struct bt_mesh_model *model,
 	uint16_t app_idx[CONFIG_BT_MESH_APP_KEY_COUNT];
 	uint16_t get_idx;
 	uint8_t status;
-	ssize_t count;
+	k_ssize_t count;
 
 	get_idx = net_buf_simple_pull_le16(buf);
 	if (get_idx > 0xfff) {
@@ -1726,7 +1726,7 @@ static int net_key_get(const struct bt_mesh_model *model,
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_NET_KEY_LIST,
 				 IDX_LEN(CONFIG_BT_MESH_SUBNET_COUNT));
 	uint16_t net_idx[CONFIG_BT_MESH_SUBNET_COUNT];
-	ssize_t count;
+	k_ssize_t count;
 
 	bt_mesh_model_msg_init(&msg, OP_NET_KEY_LIST);
 

--- a/subsys/bluetooth/mesh/dfd_srv.c
+++ b/subsys/bluetooth/mesh/dfd_srv.c
@@ -50,7 +50,7 @@ BUILD_ASSERT((DFD_RECEIVERS_ADD_MSG_MAXLEN + BT_MESH_MODEL_OP_LEN(BT_MESH_DFD_OP
 	     "incoming SDU size.");
 
 struct slot_search_ctx {
-	off_t offset;
+	k_off_t offset;
 	size_t size;
 	bool failed;
 };

--- a/subsys/bluetooth/mesh/dfu_srv.c
+++ b/subsys/bluetooth/mesh/dfu_srv.c
@@ -463,7 +463,7 @@ static int dfu_srv_settings_set(const struct bt_mesh_model *mod, const char *nam
 				void *cb_arg)
 {
 	struct bt_mesh_dfu_srv *srv = mod->rt->user_data;
-	ssize_t len;
+	k_ssize_t len;
 
 	if (len_rd < sizeof(srv->update)) {
 		return -EINVAL;

--- a/subsys/bluetooth/mesh/pb_gatt_srv.c
+++ b/subsys/bluetooth/mesh/pb_gatt_srv.c
@@ -62,7 +62,7 @@ static void proxy_msg_recv(struct bt_mesh_proxy_role *role)
 	}
 }
 
-static ssize_t gatt_recv(struct bt_conn *conn,
+static k_ssize_t gatt_recv(struct bt_conn *conn,
 			 const struct bt_gatt_attr *attr, const void *buf,
 			 uint16_t len, uint16_t offset, uint8_t flags)
 {
@@ -128,7 +128,7 @@ static void prov_ccc_changed(const struct bt_gatt_attr *attr, uint16_t value)
 	LOG_DBG("value 0x%04x", value);
 }
 
-static ssize_t prov_ccc_write(struct bt_conn *conn,
+static k_ssize_t prov_ccc_write(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, uint16_t value)
 {
 	if (cli->conn != conn) {

--- a/subsys/bluetooth/mesh/proxy_srv.c
+++ b/subsys/bluetooth/mesh/proxy_srv.c
@@ -81,7 +81,7 @@ static struct bt_mesh_proxy_client *find_client(struct bt_conn *conn)
 	return &clients[bt_conn_index(conn)];
 }
 
-static ssize_t gatt_recv(struct bt_conn *conn,
+static k_ssize_t gatt_recv(struct bt_conn *conn,
 			 const struct bt_gatt_attr *attr, const void *buf,
 			 uint16_t len, uint16_t offset, uint8_t flags)
 {
@@ -902,7 +902,7 @@ static void proxy_ccc_changed(const struct bt_gatt_attr *attr, uint16_t value)
 	LOG_DBG("value 0x%04x", value);
 }
 
-static ssize_t proxy_ccc_write(struct bt_conn *conn,
+static k_ssize_t proxy_ccc_write(struct bt_conn *conn,
 			       const struct bt_gatt_attr *attr, uint16_t value)
 {
 	struct bt_mesh_proxy_client *client;

--- a/subsys/bluetooth/mesh/settings.c
+++ b/subsys/bluetooth/mesh/settings.c
@@ -63,7 +63,7 @@ static ATOMIC_DEFINE(pending_flags, BT_MESH_SETTINGS_FLAG_COUNT);
 int bt_mesh_settings_set(settings_read_cb read_cb, void *cb_arg,
 			 void *out, size_t read_len)
 {
-	ssize_t len;
+	k_ssize_t len;
 
 	len = read_cb(cb_arg, out, read_len);
 	if (len < 0) {

--- a/subsys/bluetooth/mesh/subnet.c
+++ b/subsys/bluetooth/mesh/subnet.c
@@ -707,7 +707,7 @@ enum bt_mesh_subnets_node_id_state bt_mesh_subnets_node_id_state_get(void)
 	return BT_MESH_SUBNETS_NODE_ID_STATE_NONE;
 }
 
-ssize_t bt_mesh_subnets_get(uint16_t net_idxs[], size_t max, off_t skip)
+ssize_t bt_mesh_subnets_get(uint16_t net_idxs[], size_t max, k_off_t skip)
 {
 	size_t count = 0;
 

--- a/subsys/bluetooth/services/bas.c
+++ b/subsys/bluetooth/services/bas.c
@@ -37,9 +37,8 @@ static void blvl_ccc_cfg_changed(const struct bt_gatt_attr *attr,
 	LOG_INF("BAS Notifications %s", notif_enabled ? "enabled" : "disabled");
 }
 
-static ssize_t read_blvl(struct bt_conn *conn,
-			       const struct bt_gatt_attr *attr, void *buf,
-			       uint16_t len, uint16_t offset)
+static k_ssize_t read_blvl(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
+			   uint16_t len, uint16_t offset)
 {
 	uint8_t lvl8 = battery_level;
 

--- a/subsys/bluetooth/services/dis.c
+++ b/subsys/bluetooth/services/dis.c
@@ -83,7 +83,7 @@ static uint8_t dis_sw_rev[CONFIG_BT_DIS_STR_MAX] =
 
 #endif /* CONFIG_BT_DIS_SETTINGS */
 
-static ssize_t read_str(struct bt_conn *conn,
+static k_ssize_t read_str(struct bt_conn *conn,
 			  const struct bt_gatt_attr *attr, void *buf,
 			  uint16_t len, uint16_t offset)
 {
@@ -92,7 +92,7 @@ static ssize_t read_str(struct bt_conn *conn,
 }
 
 #if CONFIG_BT_DIS_PNP
-static ssize_t read_pnp_id(struct bt_conn *conn,
+static k_ssize_t read_pnp_id(struct bt_conn *conn,
 			   const struct bt_gatt_attr *attr, void *buf,
 			   uint16_t len, uint16_t offset)
 {
@@ -145,7 +145,7 @@ BT_GATT_SERVICE_DEFINE(dis_svc,
 static int dis_set(const char *name, size_t len_rd,
 		   settings_read_cb read_cb, void *store)
 {
-	ssize_t len;
+	k_ssize_t len;
 	int nlen;
 	const char *next;
 

--- a/subsys/bluetooth/services/hrs.c
+++ b/subsys/bluetooth/services/hrs.c
@@ -72,7 +72,7 @@ static void hrmc_ccc_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value
 	}
 }
 
-static ssize_t read_blsc(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t read_blsc(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			 void *buf, uint16_t len, uint16_t offset)
 {
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, &hrs_blsc,

--- a/subsys/bluetooth/services/ias/ias.c
+++ b/subsys/bluetooth/services/ias/ias.c
@@ -101,8 +101,9 @@ int bt_ias_local_alert_stop(void)
 	return 0;
 }
 
-static ssize_t bt_ias_write_alert_lvl(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-				      const void *buf, uint16_t len, uint16_t offset, uint8_t flags)
+static k_ssize_t bt_ias_write_alert_lvl(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+					const void *buf, uint16_t len, uint16_t offset,
+					uint8_t flags)
 {
 	struct net_buf_simple data;
 	enum bt_ias_alert_lvl alert_val;

--- a/subsys/bluetooth/services/ots/ots.c
+++ b/subsys/bluetooth/services/ots/ots.c
@@ -117,7 +117,7 @@ static bool ots_obj_validate_prop_against_oacp(uint32_t prop, uint32_t oacp)
 	return true;
 }
 
-static ssize_t ots_feature_read(struct bt_conn *conn,
+static k_ssize_t ots_feature_read(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr, void *buf,
 				uint16_t len, uint16_t offset)
 {
@@ -129,7 +129,7 @@ static ssize_t ots_feature_read(struct bt_conn *conn,
 		sizeof(ots->features));
 }
 
-static ssize_t ots_obj_name_read(struct bt_conn *conn,
+static k_ssize_t ots_obj_name_read(struct bt_conn *conn,
 				 const struct bt_gatt_attr *attr, void *buf,
 				 uint16_t len, uint16_t offset)
 {
@@ -206,7 +206,7 @@ ssize_t ots_obj_name_write(struct bt_conn *conn,
 }
 #endif
 
-static ssize_t ots_obj_type_read(struct bt_conn *conn,
+static k_ssize_t ots_obj_type_read(struct bt_conn *conn,
 				 const struct bt_gatt_attr *attr, void *buf,
 				 uint16_t len, uint16_t offset)
 {
@@ -235,7 +235,7 @@ static ssize_t ots_obj_type_read(struct bt_conn *conn,
 	}
 }
 
-static ssize_t ots_obj_size_read(struct bt_conn *conn,
+static k_ssize_t ots_obj_size_read(struct bt_conn *conn,
 				 const struct bt_gatt_attr *attr, void *buf,
 				 uint16_t len, uint16_t offset)
 {
@@ -253,7 +253,7 @@ static ssize_t ots_obj_size_read(struct bt_conn *conn,
 				 sizeof(ots->cur_obj->metadata.size));
 }
 
-static ssize_t ots_obj_id_read(struct bt_conn *conn,
+static k_ssize_t ots_obj_id_read(struct bt_conn *conn,
 			       const struct bt_gatt_attr *attr, void *buf,
 			       uint16_t len, uint16_t offset)
 {
@@ -277,7 +277,7 @@ static ssize_t ots_obj_id_read(struct bt_conn *conn,
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, id, sizeof(id));
 }
 
-static ssize_t ots_obj_prop_read(struct bt_conn *conn,
+static k_ssize_t ots_obj_prop_read(struct bt_conn *conn,
 				 const struct bt_gatt_attr *attr, void *buf,
 				 uint16_t len, uint16_t offset)
 {

--- a/subsys/bluetooth/services/ots/ots_client.c
+++ b/subsys/bluetooth/services/ots/ots_client.c
@@ -170,8 +170,8 @@ static void write_obj_tx_done(struct bt_gatt_ots_l2cap *l2cap_ctx,
 	cur_inst = NULL;
 }
 
-static ssize_t rx_done(struct bt_gatt_ots_l2cap *l2cap_ctx,
-		       struct bt_conn *conn, struct net_buf *buf)
+static k_ssize_t rx_done(struct bt_gatt_ots_l2cap *l2cap_ctx, struct bt_conn *conn,
+			 struct net_buf *buf)
 {
 	const uint32_t offset = cur_inst->rcvd_size;
 	bool is_complete = false;
@@ -1386,9 +1386,9 @@ int bt_ots_client_read_object_data(struct bt_ots_client *otc_inst,
 	return oacp_read(conn, inst);
 }
 
-int bt_ots_client_write_object_data(struct bt_ots_client *otc_inst,
-				    struct bt_conn *conn, const void *buf, size_t len,
-				    off_t offset, enum bt_ots_oacp_write_op_mode mode)
+int bt_ots_client_write_object_data(struct bt_ots_client *otc_inst, struct bt_conn *conn,
+				    const void *buf, size_t len, k_off_t offset,
+				    enum bt_ots_oacp_write_op_mode mode)
 {
 	struct bt_otc_internal_instance_t *inst;
 
@@ -1422,12 +1422,13 @@ int bt_ots_client_write_object_data(struct bt_ots_client *otc_inst,
 	}
 
 	CHECKIF((sizeof(offset) > sizeof(uint32_t) && (offset > UINT32_MAX)) || (offset < 0)) {
-		LOG_ERR("offset %ld exceeds UINT32 and must be >= 0", offset);
+		LOG_ERR("offset %ld exceeds UINT32 and must be >= 0", (long)offset);
 		return -EINVAL;
 	}
 
 	CHECKIF(offset > otc_inst->cur_object.size.cur) {
-		LOG_ERR("offset %ld exceeds cur size %zu", offset, otc_inst->cur_object.size.cur);
+		LOG_ERR("offset %ld exceeds cur size %zu", (long)offset,
+			otc_inst->cur_object.size.cur);
 		return -EINVAL;
 	}
 
@@ -1439,8 +1440,8 @@ int bt_ots_client_write_object_data(struct bt_ots_client *otc_inst,
 
 	CHECKIF(((len + offset) > otc_inst->cur_object.size.alloc) &&
 		!BT_OTS_OBJ_GET_PROP_APPEND(otc_inst->cur_object.props)) {
-		LOG_ERR("APPEND is not supported. Invalid new end of object %lu alloc %zu."
-		, (len + offset), otc_inst->cur_object.size.alloc);
+		LOG_ERR("APPEND is not supported. Invalid new end of object %lu alloc %zu.",
+			(len + (unsigned long)offset), otc_inst->cur_object.size.alloc);
 		return -EINVAL;
 	}
 
@@ -1455,7 +1456,7 @@ int bt_ots_client_write_object_data(struct bt_ots_client *otc_inst,
 }
 
 int bt_ots_client_get_object_checksum(struct bt_ots_client *otc_inst, struct bt_conn *conn,
-				      off_t offset, size_t len)
+				      k_off_t offset, size_t len)
 {
 	struct bt_otc_internal_instance_t *inst;
 
@@ -1483,13 +1484,14 @@ int bt_ots_client_get_object_checksum(struct bt_ots_client *otc_inst, struct bt_
 	}
 
 	CHECKIF((sizeof(offset) > sizeof(uint32_t) && (offset > UINT32_MAX)) || (offset < 0)) {
-		LOG_DBG("offset exceeds %ld UINT32 and must be >= 0", offset);
+		LOG_DBG("offset exceeds %ld UINT32 and must be >= 0", (long)offset);
 		return -EINVAL;
 	}
 
 	CHECKIF((len + offset) > otc_inst->cur_object.size.cur) {
 		LOG_DBG("The sum of offset (%ld) and length (%zu) exceed the Current Size %lu "
-			"alloc %zu.", offset, len, (len + offset), otc_inst->cur_object.size.cur);
+			"alloc %zu.",
+			(long)offset, len, (len + (long)offset), otc_inst->cur_object.size.cur);
 		return -EINVAL;
 	}
 

--- a/subsys/bluetooth/services/ots/ots_dir_list.c
+++ b/subsys/bluetooth/services/ots/ots_dir_list.c
@@ -132,7 +132,7 @@ static void bt_ots_dir_list_reset_anchor(struct bt_ots_dir_list *dir_list, void 
 }
 
 static int bt_ots_dir_list_search_forward(struct bt_ots_dir_list *dir_list, void *obj_manager,
-					  off_t offset)
+					  k_off_t offset)
 {
 	int err;
 	char id_str[BT_OTS_OBJ_ID_STR_LEN];
@@ -160,7 +160,7 @@ static int bt_ots_dir_list_search_forward(struct bt_ots_dir_list *dir_list, void
 }
 
 static int bt_ots_dir_list_search_backward(struct bt_ots_dir_list *dir_list, void *obj_manager,
-					   off_t offset)
+					   k_off_t offset)
 {
 	int err;
 	char id_str[BT_OTS_OBJ_ID_STR_LEN];
@@ -184,7 +184,8 @@ static int bt_ots_dir_list_search_backward(struct bt_ots_dir_list *dir_list, voi
 	return 0;
 }
 
-static int bt_ots_dir_list_search(struct bt_ots_dir_list *dir_list, void *obj_manager, off_t offset)
+static int bt_ots_dir_list_search(struct bt_ots_dir_list *dir_list, void *obj_manager,
+				  k_off_t offset)
 {
 	int err = 0;
 	char id_str[BT_OTS_OBJ_ID_STR_LEN];
@@ -306,12 +307,12 @@ void bt_ots_dir_list_init(struct bt_ots_dir_list **dir_list, void *obj_manager)
 }
 
 ssize_t bt_ots_dir_list_content_get(struct bt_ots_dir_list *dir_list, void *obj_manager,
-				    void **data, size_t len, off_t offset)
+				    void **data, size_t len, k_off_t offset)
 {
 	int err;
 	size_t last_rec_len;
 	size_t rec_len;
-	off_t rec_offset;
+	k_off_t rec_offset;
 	struct bt_gatt_ots_object *obj;
 
 	err = bt_ots_dir_list_search(dir_list, obj_manager, offset);

--- a/subsys/bluetooth/services/ots/ots_dir_list_internal.h
+++ b/subsys/bluetooth/services/ots/ots_dir_list_internal.h
@@ -33,7 +33,7 @@ extern "C" {
 struct bt_ots_dir_list {
 	struct net_buf_simple net_buf;
 	struct bt_gatt_ots_object *dir_list_obj;
-	off_t anchor_offset;
+	k_off_t anchor_offset;
 	struct bt_gatt_ots_object *anchor_object;
 	uint8_t _content[OTS_DIR_LIST_BUFFER_SIZE];
 };
@@ -160,7 +160,7 @@ void bt_ots_dir_list_selected(struct bt_ots_dir_list *dir_list, void *obj_manage
 			      struct bt_gatt_ots_object *cur_obj);
 void bt_ots_dir_list_init(struct bt_ots_dir_list **dir_list, void *obj_manager);
 ssize_t bt_ots_dir_list_content_get(struct bt_ots_dir_list *dir_list, void *obj_manager,
-				    void **data, size_t len, off_t offset);
+				    void **data, size_t len, k_off_t offset);
 bool bt_ots_dir_list_is_idle(const struct bt_ots_dir_list *dir_list);
 
 #ifdef __cplusplus

--- a/subsys/bluetooth/services/ots/ots_l2cap_internal.h
+++ b/subsys/bluetooth/services/ots/ots_l2cap_internal.h
@@ -29,7 +29,7 @@ struct bt_gatt_ots_l2cap {
 	struct bt_gatt_ots_l2cap_tx tx;
 	void (*tx_done)(struct bt_gatt_ots_l2cap *l2cap_ctx,
 			struct bt_conn *conn);
-	ssize_t (*rx_done)(struct bt_gatt_ots_l2cap *l2cap_ctx,
+	k_ssize_t (*rx_done)(struct bt_gatt_ots_l2cap *l2cap_ctx,
 			   struct bt_conn *conn, struct net_buf *buf);
 	void (*closed)(struct bt_gatt_ots_l2cap *l2cap_ctx,
 			struct bt_conn *conn);

--- a/subsys/bluetooth/services/ots/ots_oacp.c
+++ b/subsys/bluetooth/services/ots/ots_oacp.c
@@ -27,7 +27,7 @@ LOG_MODULE_DECLARE(bt_ots, CONFIG_BT_OTS_LOG_LEVEL);
 #define OACP_PROC_TYPE_SIZE	1
 
 #if defined(CONFIG_BT_OTS_OACP_WRITE_SUPPORT)
-static ssize_t oacp_write_proc_cb(struct bt_gatt_ots_l2cap *l2cap_ctx,
+static k_ssize_t oacp_write_proc_cb(struct bt_gatt_ots_l2cap *l2cap_ctx,
 			struct bt_conn *conn, struct net_buf *buf);
 
 static void oacp_l2cap_closed(struct bt_gatt_ots_l2cap *l2cap_ctx,
@@ -449,8 +449,8 @@ static void oacp_read_proc_cb(struct bt_gatt_ots_l2cap *l2cap_ctx,
 {
 	int err;
 	void *obj_chunk;
-	off_t offset;
-	ssize_t len;
+	k_off_t offset;
+	k_ssize_t len;
 	struct bt_ots *ots;
 	struct bt_gatt_ots_object_read_op *read_op;
 
@@ -534,15 +534,15 @@ static void oacp_read_proc_execute(struct bt_ots *ots,
 }
 
 #if defined(CONFIG_BT_OTS_OACP_WRITE_SUPPORT)
-static ssize_t oacp_write_proc_cb(struct bt_gatt_ots_l2cap *l2cap_ctx,
+static k_ssize_t oacp_write_proc_cb(struct bt_gatt_ots_l2cap *l2cap_ctx,
 			struct bt_conn *conn, struct net_buf *buf)
 {
 	struct bt_gatt_ots_object_write_op *write_op;
 	struct bt_ots *ots;
-	off_t offset;
+	k_off_t offset;
 	size_t rem;
 	size_t len;
-	ssize_t rc;
+	k_ssize_t rc;
 
 	ots = CONTAINER_OF(l2cap_ctx, struct bt_ots, l2cap);
 

--- a/subsys/bluetooth/services/tps.c
+++ b/subsys/bluetooth/services/tps.c
@@ -21,7 +21,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(tps);
 
-static ssize_t read_tx_power_level(struct bt_conn *conn,
+static k_ssize_t read_tx_power_level(struct bt_conn *conn,
 				   const struct bt_gatt_attr *attr, void *buf,
 				   uint16_t len, uint16_t offset)
 {

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -1714,7 +1714,7 @@ static int cmd_scan_filter_clear_addr(const struct shell *sh, size_t argc,
 #endif /* CONFIG_BT_OBSERVER */
 
 #if defined(CONFIG_BT_BROADCASTER)
-static ssize_t ad_init(struct bt_data *data_array, const size_t data_array_size,
+static k_ssize_t ad_init(struct bt_data *data_array, const size_t data_array_size,
 		       const atomic_t *adv_options)
 {
 	const bool discoverable = atomic_test_bit(adv_options, SHELL_ADV_OPT_DISCOVERABLE);
@@ -1760,7 +1760,7 @@ static ssize_t ad_init(struct bt_data *data_array, const size_t data_array_size,
 	}
 
 	if (IS_ENABLED(CONFIG_BT_CSIP_SET_MEMBER)) {
-		ssize_t csis_ad_len;
+		k_ssize_t csis_ad_len;
 
 		csis_ad_len = csis_ad_data_add(&data_array[ad_len],
 					       data_array_size - ad_len, discoverable);
@@ -1774,7 +1774,7 @@ static ssize_t ad_init(struct bt_data *data_array, const size_t data_array_size,
 
 	if (IS_ENABLED(CONFIG_BT_AUDIO) && IS_ENABLED(CONFIG_BT_EXT_ADV) && adv_ext) {
 		const bool connectable = atomic_test_bit(adv_options, SHELL_ADV_OPT_CONNECTABLE);
-		ssize_t audio_ad_len;
+		k_ssize_t audio_ad_len;
 
 		audio_ad_len = audio_ad_data_add(&data_array[ad_len], data_array_size - ad_len,
 						 discoverable, connectable);
@@ -1809,8 +1809,8 @@ static int cmd_advertise(const struct shell *sh, size_t argc, char *argv[])
 	struct bt_data sd[4];
 	bool discoverable = true;
 	bool appearance = false;
-	ssize_t ad_len = 0;
-	ssize_t sd_len = 0;
+	k_ssize_t ad_len = 0;
+	k_ssize_t sd_len = 0;
 	int err;
 	bool with_name = true;
 	bool name_ad = false;
@@ -2114,7 +2114,7 @@ static int cmd_adv_data(const struct shell *sh, size_t argc, char *argv[])
 	size_t hex_data_len;
 	size_t ad_len = 0;
 	size_t sd_len = 0;
-	ssize_t len = 0;
+	k_ssize_t len = 0;
 	bool discoverable = false;
 	size_t *data_len;
 	int err;
@@ -2501,13 +2501,13 @@ static int cmd_per_adv_param(const struct shell *sh, size_t argc,
 	return 0;
 }
 
-static ssize_t pa_ad_init(struct bt_data *data_array,
+static k_ssize_t pa_ad_init(struct bt_data *data_array,
 			  const size_t data_array_size)
 {
 	size_t ad_len = 0;
 
 	if (IS_ENABLED(CONFIG_BT_AUDIO)) {
-		ssize_t audio_pa_ad_len;
+		k_ssize_t audio_pa_ad_len;
 
 		audio_pa_ad_len = audio_pa_data_add(&data_array[ad_len],
 						    data_array_size - ad_len);
@@ -2527,7 +2527,7 @@ static int cmd_per_adv_data(const struct shell *sh, size_t argc,
 	struct bt_le_ext_adv *adv = adv_sets[selected_adv];
 	static uint8_t hex_data[256];
 	static struct bt_data ad[2U];
-	ssize_t stack_ad_len;
+	k_ssize_t stack_ad_len;
 	uint8_t ad_len = 0;
 	int err;
 

--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -788,7 +788,7 @@ static void vnd1_ccc_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value
 	echo_enabled = (value == BT_GATT_CCC_NOTIFY) ? 1 : 0;
 }
 
-static ssize_t write_vnd1(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t write_vnd1(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			  const void *buf, uint16_t len, uint16_t offset,
 			  uint8_t flags)
 {
@@ -800,7 +800,7 @@ static ssize_t write_vnd1(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 	return len;
 }
 
-static ssize_t read_vnd(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t read_vnd(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			void *buf, uint16_t len, uint16_t offset)
 {
 	const char *value = attr->user_data;
@@ -809,7 +809,7 @@ static ssize_t read_vnd(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 				 strlen(value));
 }
 
-static ssize_t write_vnd(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t write_vnd(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			 const void *buf, uint16_t len, uint16_t offset,
 			 uint8_t flags)
 {
@@ -828,7 +828,7 @@ static ssize_t write_vnd(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 static uint8_t vnd_long_value1[MAX_DATA] = { 'V', 'e', 'n', 'd', 'o', 'r' };
 static uint8_t vnd_long_value2[MAX_DATA] = { 'S', 't', 'r', 'i', 'n', 'g' };
 
-static ssize_t read_long_vnd(struct bt_conn *conn,
+static k_ssize_t read_long_vnd(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr, void *buf,
 			     uint16_t len, uint16_t offset)
 {
@@ -838,7 +838,7 @@ static ssize_t read_long_vnd(struct bt_conn *conn,
 				 sizeof(vnd_long_value1));
 }
 
-static ssize_t write_long_vnd(struct bt_conn *conn,
+static k_ssize_t write_long_vnd(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, const void *buf,
 			      uint16_t len, uint16_t offset, uint8_t flags)
 {
@@ -1101,7 +1101,7 @@ static const struct bt_uuid_128 met_char_uuid = BT_UUID_INIT_128(
 static uint8_t met_char_value[BT_ATT_MAX_ATTRIBUTE_LEN] = {
 	'M', 'e', 't', 'r', 'i', 'c', 's' };
 
-static ssize_t read_met(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t read_met(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			void *buf, uint16_t len, uint16_t offset)
 {
 	const char *value = attr->user_data;
@@ -1113,7 +1113,7 @@ static ssize_t read_met(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 				 value_len);
 }
 
-static ssize_t write_met(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t write_met(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			 const void *buf, uint16_t len, uint16_t offset,
 			 uint8_t flags)
 {
@@ -1175,7 +1175,7 @@ static uint8_t get_cb(const struct bt_gatt_attr *attr, uint16_t handle,
 {
 	struct shell *sh = user_data;
 	uint8_t buf[256];
-	ssize_t ret;
+	k_ssize_t ret;
 	char str[BT_UUID_STR_LEN];
 
 	bt_uuid_to_str(attr->uuid, str, sizeof(str));
@@ -1226,7 +1226,7 @@ static uint8_t set_cb(const struct bt_gatt_attr *attr, uint16_t handle,
 	struct set_data *data = user_data;
 	uint8_t buf[256];
 	size_t i;
-	ssize_t ret;
+	k_ssize_t ret;
 
 	if (!attr->write) {
 		shell_error(data->sh, "Write not supported");

--- a/subsys/console/tty.c
+++ b/subsys/console/tty.c
@@ -159,7 +159,7 @@ static int tty_getchar(struct tty_serial *tty)
 	return c;
 }
 
-static ssize_t tty_read_unbuf(struct tty_serial *tty, void *buf, size_t size)
+static k_ssize_t tty_read_unbuf(struct tty_serial *tty, void *buf, size_t size)
 {
 	uint8_t *p = buf;
 	size_t out_size = 0;

--- a/subsys/debug/coredump/coredump_backend_flash_partition.c
+++ b/subsys/debug/coredump/coredump_backend_flash_partition.c
@@ -163,11 +163,11 @@ static void partition_close(void)
  * @param cb_arg argument passed to callback
  * @return 0 if successful, error otherwise.
  */
-static int data_read(off_t off, uint8_t *dst, size_t len,
+static int data_read(k_off_t off, uint8_t *dst, size_t len,
 		     data_read_cb_t cb, void *cb_arg)
 {
 	int ret = 0;
-	off_t offset = off;
+	k_off_t offset = off;
 	size_t remaining = len;
 	size_t copy_sz;
 	uint8_t *ptr = dst;
@@ -247,7 +247,7 @@ static int process_stored_dump(data_read_cb_t cb, void *cb_arg)
 {
 	int ret;
 	struct flash_hdr_t hdr;
-	off_t offset;
+	k_off_t offset;
 
 	ret = partition_open();
 	if (ret != 0) {
@@ -299,7 +299,7 @@ out:
  * @return dump size if successful; 0 if stored coredump is not found
  *         or is not valid; error otherwise
  */
-static int get_stored_dump(off_t off, uint8_t *dst, size_t len)
+static int get_stored_dump(k_off_t off, uint8_t *dst, size_t len)
 {
 	int ret;
 	struct flash_hdr_t hdr;
@@ -640,7 +640,7 @@ struct coredump_backend_api coredump_backend_flash_partition = {
 
 /* Print buffer */
 static char print_buf[PRINT_BUF_SZ_RAW];
-static off_t print_buf_ptr;
+static k_off_t print_buf_ptr;
 
 /**
  * @brief Shell command to get backend error.

--- a/subsys/dfu/boot/mcuboot.c
+++ b/subsys/dfu/boot/mcuboot.c
@@ -261,14 +261,14 @@ int boot_erase_img_bank(uint8_t area_id)
 
 ssize_t boot_get_trailer_status_offset(size_t area_size)
 {
-	return (ssize_t)area_size - BOOT_MAGIC_SZ - BOOT_MAX_ALIGN * 2;
+	return (k_ssize_t)area_size - BOOT_MAGIC_SZ - BOOT_MAX_ALIGN * 2;
 }
 
 ssize_t boot_get_area_trailer_status_offset(uint8_t area_id)
 {
 	int rc;
 	const struct flash_area *fa;
-	ssize_t offset;
+	k_ssize_t offset;
 
 	rc = flash_area_open(area_id, &fa);
 	if (rc) {

--- a/subsys/dfu/img_util/flash_img.c
+++ b/subsys/dfu/img_util/flash_img.c
@@ -54,7 +54,7 @@ int flash_img_buffered_write(struct flash_img_context *ctx, const uint8_t *data,
 	}
 
 #ifdef CONFIG_IMG_ERASE_PROGRESSIVELY
-	ssize_t status_offset = boot_get_trailer_status_offset(
+	k_ssize_t status_offset = boot_get_trailer_status_offset(
 		ctx->flash_area->fa_size);
 	rc = stream_flash_erase_page(&ctx->stream,
 				ctx->flash_area->fa_off +

--- a/subsys/fs/ext2/ext2_impl.c
+++ b/subsys/fs/ext2/ext2_impl.c
@@ -606,10 +606,10 @@ success:
 
 /* Inode operations --------------------------------------------------------- */
 
-ssize_t ext2_inode_read(struct ext2_inode *inode, void *buf, uint32_t offset, size_t nbytes)
+k_ssize_t ext2_inode_read(struct ext2_inode *inode, void *buf, uint32_t offset, size_t nbytes)
 {
 	int rc = 0;
-	ssize_t read = 0;
+	k_ssize_t read = 0;
 	uint32_t block_size = inode->i_fs->block_size;
 
 	while (read < nbytes && offset < inode->i_size) {
@@ -638,10 +638,11 @@ ssize_t ext2_inode_read(struct ext2_inode *inode, void *buf, uint32_t offset, si
 	return read;
 }
 
-ssize_t ext2_inode_write(struct ext2_inode *inode, const void *buf, uint32_t offset, size_t nbytes)
+k_ssize_t ext2_inode_write(struct ext2_inode *inode, const void *buf, uint32_t offset,
+			      size_t nbytes)
 {
 	int rc = 0;
-	ssize_t written = 0;
+	k_ssize_t written = 0;
 	uint32_t block_size = inode->i_fs->block_size;
 
 	while (written < nbytes) {
@@ -686,7 +687,7 @@ ssize_t ext2_inode_write(struct ext2_inode *inode, const void *buf, uint32_t off
 	return written;
 }
 
-int ext2_inode_trunc(struct ext2_inode *inode, off_t length)
+int ext2_inode_trunc(struct ext2_inode *inode, k_off_t length)
 {
 	if (length > UINT32_MAX) {
 		return -ENOTSUP;

--- a/subsys/fs/ext2/ext2_impl.h
+++ b/subsys/fs/ext2/ext2_impl.h
@@ -184,8 +184,7 @@ int ext2_lookup_inode(struct ext2_data *fs, struct ext2_lookup_args *args);
  * @retval >=0 number of bytes read on success
  * @retval <0 error code
  */
-ssize_t ext2_inode_read(struct ext2_inode *inode, void *buf, uint32_t offset,
-			size_t nbytes);
+k_ssize_t ext2_inode_read(struct ext2_inode *inode, void *buf, uint32_t offset, size_t nbytes);
 
 /**
  * @brief Write to inode at given offset
@@ -198,8 +197,8 @@ ssize_t ext2_inode_read(struct ext2_inode *inode, void *buf, uint32_t offset,
  * @retval >=0 number of bytes read on success
  * @retval <0 error code
  */
-ssize_t ext2_inode_write(struct ext2_inode *inode, const void *buf,
-			 uint32_t offset, size_t nbytes);
+k_ssize_t ext2_inode_write(struct ext2_inode *inode, const void *buf, uint32_t offset,
+			      size_t nbytes);
 
 /**
  * @brief Truncate the inode
@@ -211,7 +210,7 @@ ssize_t ext2_inode_write(struct ext2_inode *inode, const void *buf,
  * @retval -ENOTSUP when requested size is too big
  * @retval <0 other error
  */
-int ext2_inode_trunc(struct ext2_inode *inode, off_t size);
+int ext2_inode_trunc(struct ext2_inode *inode, k_off_t size);
 
 /**
  * @brief Sync currently fetched blocks

--- a/subsys/fs/ext2/ext2_ops.c
+++ b/subsys/fs/ext2/ext2_ops.c
@@ -132,7 +132,7 @@ out:
 	return rc;
 }
 
-static ssize_t ext2_read(struct fs_file_t *filp, void *dest, size_t nbytes)
+static k_ssize_t ext2_read(struct fs_file_t *filp, void *dest, size_t nbytes)
 {
 	struct ext2_file *f = filp->filep;
 
@@ -140,7 +140,7 @@ static ssize_t ext2_read(struct fs_file_t *filp, void *dest, size_t nbytes)
 		return -EACCES;
 	}
 
-	ssize_t r = ext2_inode_read(f->f_inode, dest, f->f_off, nbytes);
+	k_ssize_t r = ext2_inode_read(f->f_inode, dest, f->f_off, nbytes);
 
 	if (r < 0) {
 		return r;
@@ -149,7 +149,7 @@ static ssize_t ext2_read(struct fs_file_t *filp, void *dest, size_t nbytes)
 	return r;
 }
 
-static ssize_t ext2_write(struct fs_file_t *filp, const void *src, size_t nbytes)
+static k_ssize_t ext2_write(struct fs_file_t *filp, const void *src, size_t nbytes)
 {
 	struct ext2_file *f = filp->filep;
 
@@ -161,7 +161,7 @@ static ssize_t ext2_write(struct fs_file_t *filp, const void *src, size_t nbytes
 		f->f_off = f->f_inode->i_size;
 	}
 
-	ssize_t r = ext2_inode_write(f->f_inode, src, f->f_off, nbytes);
+	k_ssize_t r = ext2_inode_write(f->f_inode, src, f->f_off, nbytes);
 
 	if (r < 0) {
 		return r;
@@ -171,10 +171,10 @@ static ssize_t ext2_write(struct fs_file_t *filp, const void *src, size_t nbytes
 	return r;
 }
 
-static int ext2_lseek(struct fs_file_t *filp, off_t off, int whence)
+static int ext2_lseek(struct fs_file_t *filp, k_off_t off, int whence)
 {
 	struct ext2_file *f = filp->filep;
-	off_t new_off = 0;
+	k_off_t new_off = 0;
 
 	switch (whence) {
 	case FS_SEEK_SET:
@@ -190,6 +190,7 @@ static int ext2_lseek(struct fs_file_t *filp, off_t off, int whence)
 		break;
 
 	default:
+		printk("invalid value for 'whence': %d\n", whence);
 		return -EINVAL;
 	}
 
@@ -197,18 +198,19 @@ static int ext2_lseek(struct fs_file_t *filp, off_t off, int whence)
 	if (new_off < 0 || new_off > f->f_inode->i_size) {
 		return -EINVAL;
 	}
+
 	f->f_off = new_off;
 	return 0;
 }
 
-static off_t ext2_tell(struct fs_file_t *filp)
+static k_off_t ext2_tell(struct fs_file_t *filp)
 {
 	struct ext2_file *f = filp->filep;
 
 	return f->f_off;
 }
 
-static int ext2_truncate(struct fs_file_t *filp, off_t length)
+static int ext2_truncate(struct fs_file_t *filp, k_off_t length)
 {
 	struct ext2_file *f = filp->filep;
 

--- a/subsys/fs/fat_fs.c
+++ b/subsys/fs/fat_fs.c
@@ -189,7 +189,7 @@ static int fatfs_rename(struct fs_mount_t *mountp, const char *from,
 	return res;
 }
 
-static ssize_t fatfs_read(struct fs_file_t *zfp, void *ptr, size_t size)
+static k_ssize_t fatfs_read(struct fs_file_t *zfp, void *ptr, size_t size)
 {
 	FRESULT res;
 	unsigned int br;
@@ -202,13 +202,13 @@ static ssize_t fatfs_read(struct fs_file_t *zfp, void *ptr, size_t size)
 	return br;
 }
 
-static ssize_t fatfs_write(struct fs_file_t *zfp, const void *ptr, size_t size)
+static k_ssize_t fatfs_write(struct fs_file_t *zfp, const void *ptr, size_t size)
 {
 	int res = -ENOTSUP;
 
 #if !defined(CONFIG_FS_FATFS_READ_ONLY)
 	unsigned int bw;
-	off_t pos = f_size((FIL *)zfp->filep);
+	k_off_t pos = f_size((FIL *)zfp->filep);
 	res = FR_OK;
 
 	/* FA_APPEND flag means that file has been opened for append.
@@ -234,10 +234,10 @@ static ssize_t fatfs_write(struct fs_file_t *zfp, const void *ptr, size_t size)
 	return res;
 }
 
-static int fatfs_seek(struct fs_file_t *zfp, off_t offset, int whence)
+static int fatfs_seek(struct fs_file_t *zfp, k_off_t offset, int whence)
 {
 	FRESULT res = FR_OK;
-	off_t pos;
+	k_off_t pos;
 
 	switch (whence) {
 	case FS_SEEK_SET:
@@ -262,17 +262,17 @@ static int fatfs_seek(struct fs_file_t *zfp, off_t offset, int whence)
 	return translate_error(res);
 }
 
-static off_t fatfs_tell(struct fs_file_t *zfp)
+static k_off_t fatfs_tell(struct fs_file_t *zfp)
 {
 	return f_tell((FIL *)zfp->filep);
 }
 
-static int fatfs_truncate(struct fs_file_t *zfp, off_t length)
+static int fatfs_truncate(struct fs_file_t *zfp, k_off_t length)
 {
 	int res = -ENOTSUP;
 
 #if !defined(CONFIG_FS_FATFS_READ_ONLY)
-	off_t cur_length = f_size((FIL *)zfp->filep);
+	k_off_t cur_length = f_size((FIL *)zfp->filep);
 
 	/* f_lseek expands file if new position is larger than file size */
 	res = f_lseek(zfp->filep, length);

--- a/subsys/fs/fcb/fcb.c
+++ b/subsys/fs/fcb/fcb.c
@@ -29,7 +29,7 @@ uint8_t fcb_get_align(const struct fcb *fcbp)
 	return align;
 }
 
-int fcb_flash_read(const struct fcb *fcbp, const struct flash_sector *sector, off_t off,
+int fcb_flash_read(const struct fcb *fcbp, const struct flash_sector *sector, k_off_t off,
 		   void *dst, size_t len)
 {
 	int rc;
@@ -51,7 +51,7 @@ int fcb_flash_read(const struct fcb *fcbp, const struct flash_sector *sector, of
 	return 0;
 }
 
-int fcb_flash_write(const struct fcb *fcbp, const struct flash_sector *sector, off_t off,
+int fcb_flash_write(const struct fcb *fcbp, const struct flash_sector *sector, k_off_t off,
 		    const void *src, size_t len)
 {
 	int rc;

--- a/subsys/fs/fcb/fcb_append.c
+++ b/subsys/fs/fcb/fcb_append.c
@@ -122,7 +122,7 @@ fcb_append_finish(struct fcb *fcb, struct fcb_entry *loc)
 {
 	int rc;
 	uint8_t em[fcb->f_align];
-	off_t off;
+	k_off_t off;
 
 	(void)memset(em, 0xFF, sizeof(em));
 

--- a/subsys/fs/fcb/fcb_elem_info.c
+++ b/subsys/fs/fcb/fcb_elem_info.c
@@ -122,7 +122,7 @@ int fcb_elem_info(struct fcb *_fcb, struct fcb_entry *loc)
 	int rc;
 	uint8_t em;
 	uint8_t fl_em;
-	off_t off;
+	size_t off;
 
 	rc = fcb_elem_endmarker(_fcb, loc, &em);
 	if (rc) {

--- a/subsys/fs/fs.c
+++ b/subsys/fs/fs.c
@@ -15,7 +15,7 @@
 #include <zephyr/fs/fs.h>
 #include <zephyr/fs/fs_sys.h>
 #include <zephyr/sys/check.h>
-
+#include <zephyr/sys/fdtable.h>
 
 #define LOG_LEVEL CONFIG_FS_LOG_LEVEL
 #include <zephyr/logging/log.h>
@@ -221,7 +221,7 @@ int fs_close(struct fs_file_t *zfp)
 	return rc;
 }
 
-ssize_t fs_read(struct fs_file_t *zfp, void *ptr, size_t size)
+k_ssize_t fs_read(struct fs_file_t *zfp, void *ptr, size_t size)
 {
 	int rc = -EINVAL;
 
@@ -241,7 +241,7 @@ ssize_t fs_read(struct fs_file_t *zfp, void *ptr, size_t size)
 	return rc;
 }
 
-ssize_t fs_write(struct fs_file_t *zfp, const void *ptr, size_t size)
+k_ssize_t fs_write(struct fs_file_t *zfp, const void *ptr, size_t size)
 {
 	int rc = -EINVAL;
 
@@ -261,7 +261,7 @@ ssize_t fs_write(struct fs_file_t *zfp, const void *ptr, size_t size)
 	return rc;
 }
 
-int fs_seek(struct fs_file_t *zfp, off_t offset, int whence)
+int fs_seek(struct fs_file_t *zfp, k_off_t offset, int whence)
 {
 	int rc = -ENOTSUP;
 
@@ -281,7 +281,7 @@ int fs_seek(struct fs_file_t *zfp, off_t offset, int whence)
 	return rc;
 }
 
-off_t fs_tell(struct fs_file_t *zfp)
+k_off_t fs_tell(struct fs_file_t *zfp)
 {
 	int rc = -ENOTSUP;
 
@@ -301,7 +301,7 @@ off_t fs_tell(struct fs_file_t *zfp)
 	return rc;
 }
 
-int fs_truncate(struct fs_file_t *zfp, off_t length)
+int fs_truncate(struct fs_file_t *zfp, k_off_t length)
 {
 	int rc = -EINVAL;
 

--- a/subsys/fs/fuse_fs_access.c
+++ b/subsys/fs/fuse_fs_access.c
@@ -41,7 +41,7 @@ static const char default_fuse_mountpoint[] = "flash";
 
 static const char *fuse_mountpoint;
 
-static ssize_t get_new_file_handle(void)
+static k_ssize_t get_new_file_handle(void)
 {
 	size_t idx;
 
@@ -161,7 +161,7 @@ static int fuse_fs_access_readmount(void *buf, fuse_fill_dir_t filler)
 }
 
 static int fuse_fs_access_readdir(const char *path, void *buf,
-			      fuse_fill_dir_t filler, off_t off,
+			      fuse_fill_dir_t filler, k_off_t off,
 			      struct fuse_file_info *fi)
 {
 	struct fs_dir_t dir;
@@ -252,7 +252,7 @@ static int fuse_fs_access_create(const char *path, mode_t mode,
 			     struct fuse_file_info *fi)
 {
 	int err;
-	ssize_t handle;
+	k_ssize_t handle;
 
 	ARG_UNUSED(mode);
 
@@ -298,7 +298,7 @@ static int fuse_fs_access_release(const char *path, struct fuse_file_info *fi)
 }
 
 static int fuse_fs_access_read(const char *path, char *buf, size_t size,
-		off_t off, struct fuse_file_info *fi)
+		k_off_t off, struct fuse_file_info *fi)
 {
 	int err;
 
@@ -319,7 +319,7 @@ static int fuse_fs_access_read(const char *path, char *buf, size_t size,
 }
 
 static int fuse_fs_access_write(const char *path, const char *buf, size_t size,
-		off_t off, struct fuse_file_info *fi)
+		k_off_t off, struct fuse_file_info *fi)
 {
 	int err;
 
@@ -339,7 +339,7 @@ static int fuse_fs_access_write(const char *path, const char *buf, size_t size,
 	return err;
 }
 
-static int fuse_fs_access_ftruncate(const char *path, off_t size,
+static int fuse_fs_access_ftruncate(const char *path, k_off_t size,
 				struct fuse_file_info *fi)
 {
 	int err;
@@ -355,7 +355,7 @@ static int fuse_fs_access_ftruncate(const char *path, off_t size,
 	return err;
 }
 
-static int fuse_fs_access_truncate(const char *path, off_t size)
+static int fuse_fs_access_truncate(const char *path, k_off_t size)
 {
 	int err;
 	static struct fs_file_t file;

--- a/subsys/fs/littlefs_fs.c
+++ b/subsys/fs/littlefs_fs.c
@@ -370,25 +370,25 @@ static int littlefs_rename(struct fs_mount_t *mountp, const char *from,
 	return lfs_to_errno(ret);
 }
 
-static ssize_t littlefs_read(struct fs_file_t *fp, void *ptr, size_t len)
+static k_ssize_t littlefs_read(struct fs_file_t *fp, void *ptr, size_t len)
 {
 	struct fs_littlefs *fs = fp->mp->fs_data;
 
 	fs_lock(fs);
 
-	ssize_t ret = lfs_file_read(&fs->lfs, LFS_FILEP(fp), ptr, len);
+	k_ssize_t ret = lfs_file_read(&fs->lfs, LFS_FILEP(fp), ptr, len);
 
 	fs_unlock(fs);
 	return lfs_to_errno(ret);
 }
 
-static ssize_t littlefs_write(struct fs_file_t *fp, const void *ptr, size_t len)
+static k_ssize_t littlefs_write(struct fs_file_t *fp, const void *ptr, size_t len)
 {
 	struct fs_littlefs *fs = fp->mp->fs_data;
 
 	fs_lock(fs);
 
-	ssize_t ret = lfs_file_write(&fs->lfs, LFS_FILEP(fp), ptr, len);
+	k_ssize_t ret = lfs_file_write(&fs->lfs, LFS_FILEP(fp), ptr, len);
 
 	fs_unlock(fs);
 	return lfs_to_errno(ret);
@@ -398,13 +398,13 @@ BUILD_ASSERT((FS_SEEK_SET == LFS_SEEK_SET)
 	     && (FS_SEEK_CUR == LFS_SEEK_CUR)
 	     && (FS_SEEK_END == LFS_SEEK_END));
 
-static int littlefs_seek(struct fs_file_t *fp, off_t off, int whence)
+static int littlefs_seek(struct fs_file_t *fp, k_off_t off, int whence)
 {
 	struct fs_littlefs *fs = fp->mp->fs_data;
 
 	fs_lock(fs);
 
-	off_t ret = lfs_file_seek(&fs->lfs, LFS_FILEP(fp), off, whence);
+	k_off_t ret = lfs_file_seek(&fs->lfs, LFS_FILEP(fp), off, whence);
 
 	fs_unlock(fs);
 
@@ -415,19 +415,19 @@ static int littlefs_seek(struct fs_file_t *fp, off_t off, int whence)
 	return lfs_to_errno(ret);
 }
 
-static off_t littlefs_tell(struct fs_file_t *fp)
+static k_off_t littlefs_tell(struct fs_file_t *fp)
 {
 	struct fs_littlefs *fs = fp->mp->fs_data;
 
 	fs_lock(fs);
 
-	off_t ret = lfs_file_tell(&fs->lfs, LFS_FILEP(fp));
+	k_off_t ret = lfs_file_tell(&fs->lfs, LFS_FILEP(fp));
 
 	fs_unlock(fs);
 	return ret;
 }
 
-static int littlefs_truncate(struct fs_file_t *fp, off_t length)
+static int littlefs_truncate(struct fs_file_t *fp, k_off_t length)
 {
 	struct fs_littlefs *fs = fp->mp->fs_data;
 
@@ -570,7 +570,7 @@ static int littlefs_statvfs(struct fs_mount_t *mountp,
 
 	fs_lock(fs);
 
-	ssize_t ret = lfs_fs_size(lfs);
+	k_ssize_t ret = lfs_fs_size(lfs);
 
 	fs_unlock(fs);
 

--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -104,7 +104,7 @@ static int nvs_flash_al_wrt(struct nvs_fs *fs, uint32_t addr, const void *data,
 {
 	const uint8_t *data8 = (const uint8_t *)data;
 	int rc = 0;
-	off_t offset;
+	k_off_t offset;
 	size_t blen;
 	uint8_t buf[NVS_BLOCK_SIZE];
 
@@ -146,7 +146,7 @@ static int nvs_flash_rd(struct nvs_fs *fs, uint32_t addr, void *data,
 			 size_t len)
 {
 	int rc;
-	off_t offset;
+	k_off_t offset;
 
 	offset = fs->offset;
 	offset += fs->sector_size * (addr >> ADDR_SECT_SHIFT);
@@ -331,7 +331,7 @@ static int nvs_flash_block_move(struct nvs_fs *fs, uint32_t addr, size_t len)
 static int nvs_flash_erase_sector(struct nvs_fs *fs, uint32_t addr)
 {
 	int rc;
-	off_t offset;
+	k_off_t offset;
 
 	addr &= ADDR_SECT_MASK;
 
@@ -1054,7 +1054,7 @@ int nvs_mount(struct nvs_fs *fs)
 	return 0;
 }
 
-ssize_t nvs_write(struct nvs_fs *fs, uint16_t id, const void *data, size_t len)
+k_ssize_t nvs_write(struct nvs_fs *fs, uint16_t id, const void *data, size_t len)
 {
 	int rc, gc_count;
 	size_t ate_size, data_size;
@@ -1191,7 +1191,7 @@ int nvs_delete(struct nvs_fs *fs, uint16_t id)
 	return nvs_write(fs, id, NULL, 0);
 }
 
-ssize_t nvs_read_hist(struct nvs_fs *fs, uint16_t id, void *data, size_t len,
+k_ssize_t nvs_read_hist(struct nvs_fs *fs, uint16_t id, void *data, size_t len,
 		      uint16_t cnt)
 {
 	int rc;
@@ -1286,7 +1286,7 @@ err:
 	return rc;
 }
 
-ssize_t nvs_read(struct nvs_fs *fs, uint16_t id, void *data, size_t len)
+k_ssize_t nvs_read(struct nvs_fs *fs, uint16_t id, void *data, size_t len)
 {
 	int rc;
 
@@ -1294,7 +1294,7 @@ ssize_t nvs_read(struct nvs_fs *fs, uint16_t id, void *data, size_t len)
 	return rc;
 }
 
-ssize_t nvs_calc_free_space(struct nvs_fs *fs)
+k_ssize_t nvs_calc_free_space(struct nvs_fs *fs)
 {
 
 	int rc;

--- a/subsys/fs/shell.c
+++ b/subsys/fs/shell.c
@@ -279,7 +279,7 @@ static int cmd_read(const struct shell *sh, size_t argc, char **argv)
 	struct fs_dirent dirent;
 	struct fs_file_t file;
 	int count;
-	off_t offset;
+	k_off_t offset;
 	int err;
 
 	create_abs_path(argv[1], path, sizeof(path));
@@ -331,7 +331,7 @@ static int cmd_read(const struct shell *sh, size_t argc, char **argv)
 	}
 
 	while (count > 0) {
-		ssize_t read;
+		k_ssize_t read;
 		uint8_t buf[16];
 		int i;
 
@@ -374,7 +374,7 @@ static int cmd_cat(const struct shell *sh, size_t argc, char **argv)
 	struct fs_dirent dirent;
 	struct fs_file_t file;
 	int err;
-	ssize_t read;
+	k_ssize_t read;
 
 	fs_file_t_init(&file);
 
@@ -449,7 +449,7 @@ static int cmd_write(const struct shell *sh, size_t argc, char **argv)
 	uint8_t buf_len;
 	int arg_offset;
 	struct fs_file_t file;
-	off_t offset = -1;
+	k_off_t offset = -1;
 	int err;
 
 	create_abs_path(argv[1], path, sizeof(path));

--- a/subsys/ipc/ipc_service/lib/icmsg_me.c
+++ b/subsys/ipc/ipc_service/lib/icmsg_me.c
@@ -21,16 +21,16 @@ static void *icmsg_buffer_to_user_buffer(const void *icmsg_buffer)
 	return (void *)(((char *)icmsg_buffer) + HEADER_SIZE);
 }
 
-static ssize_t icmsg_buffer_len_to_user_buffer_len(size_t icmsg_buffer_len)
+static k_ssize_t icmsg_buffer_len_to_user_buffer_len(size_t icmsg_buffer_len)
 {
 	if (icmsg_buffer_len < HEADER_SIZE) {
 		return -EINVAL;
 	}
 
-	return (ssize_t)(icmsg_buffer_len - HEADER_SIZE);
+	return (k_ssize_t)(icmsg_buffer_len - HEADER_SIZE);
 }
 
-static ssize_t user_buffer_len_to_icmsg_buffer_len(size_t user_buffer_len)
+static k_ssize_t user_buffer_len_to_icmsg_buffer_len(size_t user_buffer_len)
 {
 	size_t ret;
 
@@ -38,7 +38,7 @@ static ssize_t user_buffer_len_to_icmsg_buffer_len(size_t user_buffer_len)
 		return -EINVAL;
 	}
 
-	return (ssize_t)ret;
+	return (k_ssize_t)ret;
 }
 
 static void set_ept_id_in_send_buffer(uint8_t *send_buffer,
@@ -152,7 +152,7 @@ void icmsg_me_received_data(struct icmsg_me_data_t *data, icmsg_me_ept_id_t id,
 {
 	int r;
 	const struct ipc_ept_cfg *ept;
-	ssize_t user_buffer_len;
+	k_ssize_t user_buffer_len;
 
 	r = icmsg_me_get_ept_cfg(data, id, &ept);
 	if (r < 0) {
@@ -180,7 +180,7 @@ int icmsg_me_send(const struct icmsg_config_t *conf,
 {
 	int r;
 	int sent_bytes = 0;
-	ssize_t icmsg_buffer_len = user_buffer_len_to_icmsg_buffer_len(len);
+	k_ssize_t icmsg_buffer_len = user_buffer_len_to_icmsg_buffer_len(len);
 
 	if ((icmsg_buffer_len < 0) || (icmsg_buffer_len >= SEND_BUF_SIZE)) {
 		return -EBADMSG;

--- a/subsys/llext/llext.c
+++ b/subsys/llext/llext.c
@@ -23,7 +23,7 @@ static sys_slist_t _llext_list = SYS_SLIST_STATIC_INIT(&_llext_list);
 
 static struct k_mutex llext_lock = Z_MUTEX_INITIALIZER(llext_lock);
 
-ssize_t llext_find_section(struct llext_loader *ldr, const char *search_name)
+k_ssize_t llext_find_section(struct llext_loader *ldr, const char *search_name)
 {
 	/* Note that this API is used after llext_load(), so the ldr->sect_hdrs
 	 * cache is already freed. A direct search covers all situations.

--- a/subsys/logging/backends/log_backend_fs.c
+++ b/subsys/logging/backends/log_backend_fs.c
@@ -263,7 +263,7 @@ static int allocate_new_file(struct fs_file_t *file)
 	int curr_file_num;
 	struct fs_dirent ent;
 	char fname[MAX_PATH_LEN];
-	off_t file_size;
+	k_off_t file_size;
 
 	assert(file);
 

--- a/subsys/lorawan/nvm/lorawan_nvm_settings.c
+++ b/subsys/lorawan/nvm/lorawan_nvm_settings.c
@@ -18,7 +18,7 @@ struct lorawan_nvm_setting_descr {
 	const char *name;
 	const char *setting_name;
 	size_t size;
-	off_t offset;
+	k_off_t offset;
 	uint16_t flag;
 };
 

--- a/subsys/mgmt/hawkbit/hawkbit_device.c
+++ b/subsys/mgmt/hawkbit/hawkbit_device.c
@@ -20,7 +20,7 @@ bool hawkbit_get_device_identity(char *id, int id_max_len)
 static bool hawkbit_get_device_identity_default(char *id, int id_max_len)
 {
 	uint8_t hwinfo_id[DEVICE_ID_BIN_MAX_SIZE];
-	ssize_t length;
+	k_ssize_t length;
 
 	length = hwinfo_get_device_id(hwinfo_id, DEVICE_ID_BIN_MAX_SIZE);
 	if (length <= 0) {

--- a/subsys/mgmt/mcumgr/grp/fs_mgmt/src/fs_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/fs_mgmt/src/fs_mgmt.c
@@ -206,7 +206,7 @@ static int fs_mgmt_file_download(struct smp_streamer *ctxt)
 	uint8_t file_data[MCUMGR_GRP_FS_DL_CHUNK_SIZE];
 	char path[CONFIG_MCUMGR_GRP_FS_PATH_LEN + 1];
 	uint64_t off = ULLONG_MAX;
-	ssize_t bytes_read = 0;
+	k_ssize_t bytes_read = 0;
 	int rc;
 	zcbor_state_t *zse = ctxt->writer->zs;
 	zcbor_state_t *zsd = ctxt->reader->zs;
@@ -359,7 +359,7 @@ static int fs_mgmt_file_upload(struct smp_streamer *ctxt)
 	struct zcbor_string name = { 0 };
 	struct zcbor_string file_data = { 0 };
 	size_t decoded = 0;
-	ssize_t existing_file_size = 0;
+	k_ssize_t existing_file_size = 0;
 
 	struct zcbor_map_decode_key_val fs_upload_decode[] = {
 		ZCBOR_MAP_DECODE_KEY_DECODER("off", zcbor_uint64_decode, &off),

--- a/subsys/mgmt/mcumgr/grp/fs_mgmt/src/fs_mgmt_hash_checksum_crc32.c
+++ b/subsys/mgmt/mcumgr/grp/fs_mgmt/src/fs_mgmt_hash_checksum_crc32.c
@@ -21,7 +21,7 @@ static int fs_mgmt_hash_checksum_crc32(struct fs_file_t *file, uint8_t *output,
 {
 	/* Calculate IEEE CRC32 checksum of target file */
 	uint8_t buffer[CONFIG_MCUMGR_GRP_FS_CHECKSUM_HASH_CHUNK_SIZE];
-	ssize_t bytes_read = 0;
+	k_ssize_t bytes_read = 0;
 	size_t read_size = CONFIG_MCUMGR_GRP_FS_CHECKSUM_HASH_CHUNK_SIZE;
 	uint32_t crc32 = 0;
 

--- a/subsys/mgmt/mcumgr/grp/fs_mgmt/src/fs_mgmt_hash_checksum_sha256.c
+++ b/subsys/mgmt/mcumgr/grp/fs_mgmt/src/fs_mgmt_hash_checksum_sha256.c
@@ -37,7 +37,7 @@ static int fs_mgmt_hash_checksum_sha256(struct fs_file_t *file, uint8_t *output,
 					size_t *out_len, size_t len)
 {
 	int rc = MGMT_ERR_EUNKNOWN;
-	ssize_t bytes_read = 0;
+	k_ssize_t bytes_read = 0;
 	size_t read_size = CONFIG_MCUMGR_GRP_FS_CHECKSUM_HASH_CHUNK_SIZE;
 	uint8_t buffer[CONFIG_MCUMGR_GRP_FS_CHECKSUM_HASH_CHUNK_SIZE];
 	hash_ctx_t hash_ctx;

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
@@ -61,8 +61,8 @@ BUILD_ASSERT(FIXED_PARTITION_EXISTS(SLOT4_PARTITION) &&
 static int img_mgmt_flash_check_empty_inner(const struct flash_area *fa)
 {
 	uint32_t data[16];
-	off_t addr;
-	off_t end;
+	k_off_t addr;
+	k_off_t end;
 	int bytes_to_read;
 	int rc;
 	int i;
@@ -462,7 +462,7 @@ int img_mgmt_erase_image_data(unsigned int off, unsigned int num_bytes)
 		goto end_fa;
 	}
 	struct flash_pages_info page;
-	off_t page_offset = fa->fa_off + num_bytes - 1;
+	k_off_t page_offset = fa->fa_off + num_bytes - 1;
 
 	rc = flash_get_page_info_by_offs(dev, page_offset, &page);
 	if (rc != 0) {

--- a/subsys/mgmt/mcumgr/transport/src/smp_bt.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_bt.c
@@ -233,10 +233,8 @@ static void conn_param_smp_enable(struct bt_conn *conn)
 /**
  * Write handler for the SMP characteristic; processes an incoming SMP request.
  */
-static ssize_t smp_bt_chr_write(struct bt_conn *conn,
-				const struct bt_gatt_attr *attr,
-				const void *buf, uint16_t len, uint16_t offset,
-				uint8_t flags)
+static k_ssize_t smp_bt_chr_write(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+				  const void *buf, uint16_t len, uint16_t offset, uint8_t flags)
 {
 	struct conn_param_data *cpd = conn_param_data_get(conn);
 #ifdef CONFIG_MCUMGR_TRANSPORT_BT_REASSEMBLY

--- a/subsys/mgmt/updatehub/updatehub_device.c
+++ b/subsys/mgmt/updatehub/updatehub_device.c
@@ -13,7 +13,7 @@
 bool updatehub_get_device_identity(char *id, int id_max_len)
 {
 	uint8_t hwinfo_id[DEVICE_ID_BIN_MAX_SIZE];
-	ssize_t length;
+	k_ssize_t length;
 
 	length = hwinfo_get_device_id(hwinfo_id, DEVICE_ID_BIN_MAX_SIZE);
 	if (length <= 0) {

--- a/subsys/net/lib/coap/coap_server.c
+++ b/subsys/net/lib/coap/coap_server.c
@@ -16,7 +16,6 @@ LOG_MODULE_DECLARE(net_coap, CONFIG_COAP_LOG_LEVEL);
 #include <zephyr/net/coap_link_format.h>
 #include <zephyr/net/coap_mgmt.h>
 #include <zephyr/net/coap_service.h>
-#include <zephyr/posix/fcntl.h>
 
 #if defined(CONFIG_NET_TC_THREAD_COOPERATIVE)
 /* Lowest priority cooperative thread */
@@ -429,7 +428,7 @@ int coap_service_start(const struct coap_service *service)
 		goto end;
 	}
 
-	ret = zsock_fcntl(service->data->sock_fd, F_SETFL, O_NONBLOCK);
+	ret = zsock_fcntl(service->data->sock_fd, ZVFS_F_SETFL, ZVFS_O_NONBLOCK);
 	if (ret < 0) {
 		ret = -errno;
 		goto close;
@@ -732,7 +731,7 @@ static void coap_server_thread(void *p1, void *p2, void *p3)
 	}
 
 	for (int i = 0; i < 2; ++i) {
-		ret = zsock_fcntl(control_socks[i], F_SETFL, O_NONBLOCK);
+		ret = zsock_fcntl(control_socks[i], ZVFS_F_SETFL, ZVFS_O_NONBLOCK);
 
 		if (ret < 0) {
 			zsock_close(control_socks[0]);

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -32,7 +32,6 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <zephyr/net/socket.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/types.h>
-#include <zephyr/posix/fcntl.h>
 
 #if defined(CONFIG_LWM2M_DTLS_SUPPORT)
 #include <zephyr/net/tls_credentials.h>
@@ -1185,13 +1184,13 @@ int lwm2m_socket_start(struct lwm2m_ctx *client_ctx)
 		goto error;
 	}
 
-	flags = zsock_fcntl(client_ctx->sock_fd, F_GETFL, 0);
+	flags = zsock_fcntl(client_ctx->sock_fd, ZVFS_F_GETFL, 0);
 	if (flags == -1) {
 		ret = -errno;
 		LOG_ERR("zsock_fcntl(F_GETFL) failed (%d)", ret);
 		goto error;
 	}
-	ret = zsock_fcntl(client_ctx->sock_fd, F_SETFL, flags | O_NONBLOCK);
+	ret = zsock_fcntl(client_ctx->sock_fd, ZVFS_F_SETFL, flags | ZVFS_O_NONBLOCK);
 	if (ret == -1) {
 		ret = -errno;
 		LOG_ERR("zsock_fcntl(F_SETFL) failed (%d)", ret);
@@ -1307,14 +1306,14 @@ static int lwm2m_engine_init(void)
 		/* Last poll-handle is reserved for control socket */
 		sock_fds[MAX_POLL_FD - 1].fd = s[0];
 		control_sock = s[1];
-		ret = zsock_fcntl(s[0], F_SETFL, O_NONBLOCK);
+		ret = zsock_fcntl(s[0], ZVFS_F_SETFL, ZVFS_O_NONBLOCK);
 		if (ret) {
 			LOG_ERR("zsock_fcntl() %d", ret);
 			zsock_close(s[0]);
 			zsock_close(s[1]);
 			return ret;
 		}
-		ret = zsock_fcntl(s[1], F_SETFL, O_NONBLOCK);
+		ret = zsock_fcntl(s[1], ZVFS_F_SETFL, ZVFS_O_NONBLOCK);
 		if (ret) {
 			LOG_ERR("zsock_fcntl() %d", ret);
 			zsock_close(s[0]);

--- a/subsys/net/lib/mqtt_sn/mqtt_sn_transport_udp.c
+++ b/subsys/net/lib/mqtt_sn/mqtt_sn_transport_udp.c
@@ -15,8 +15,6 @@
 #include <zephyr/net/net_ip.h>
 #include <zephyr/net/socket.h>
 
-#include <zephyr/posix/fcntl.h>
-
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(net_mqtt_sn, CONFIG_MQTT_SN_LOG_LEVEL);
 

--- a/subsys/net/lib/sockets/socket_dispatcher.c
+++ b/subsys/net/lib/sockets/socket_dispatcher.c
@@ -137,7 +137,7 @@ static int sock_dispatch_default(struct dispatcher_context *ctx)
 	return sock_dispatch_socket(ctx, sock_family->handler);
 }
 
-static ssize_t sock_dispatch_read_vmeth(void *obj, void *buffer, size_t count)
+static k_ssize_t sock_dispatch_read_vmeth(void *obj, void *buffer, size_t count)
 {
 	int fd;
 	const struct fd_op_vtable *vtable;
@@ -156,8 +156,7 @@ static ssize_t sock_dispatch_read_vmeth(void *obj, void *buffer, size_t count)
 	return vtable->read(new_obj, buffer, count);
 }
 
-static ssize_t sock_dispatch_write_vmeth(void *obj, const void *buffer,
-					 size_t count)
+static k_ssize_t sock_dispatch_write_vmeth(void *obj, const void *buffer, size_t count)
 {
 	int fd;
 	const struct fd_op_vtable *vtable;
@@ -259,10 +258,8 @@ static int sock_dispatch_accept_vmeth(void *obj, struct sockaddr *addr,
 	return zsock_accept(fd, addr, addrlen);
 }
 
-static ssize_t sock_dispatch_sendto_vmeth(void *obj, const void *buf,
-					  size_t len, int flags,
-					  const struct sockaddr *addr,
-					  socklen_t addrlen)
+static k_ssize_t sock_dispatch_sendto_vmeth(void *obj, const void *buf, size_t len, int flags,
+					       const struct sockaddr *addr, socklen_t addrlen)
 {
 	int fd = sock_dispatch_default(obj);
 
@@ -273,8 +270,7 @@ static ssize_t sock_dispatch_sendto_vmeth(void *obj, const void *buf,
 	return zsock_sendto(fd, buf, len, flags, addr, addrlen);
 }
 
-static ssize_t sock_dispatch_sendmsg_vmeth(void *obj, const struct msghdr *msg,
-					   int flags)
+static k_ssize_t sock_dispatch_sendmsg_vmeth(void *obj, const struct msghdr *msg, int flags)
 {
 	int fd = sock_dispatch_default(obj);
 
@@ -285,10 +281,8 @@ static ssize_t sock_dispatch_sendmsg_vmeth(void *obj, const struct msghdr *msg,
 	return zsock_sendmsg(fd, msg, flags);
 }
 
-static ssize_t sock_dispatch_recvfrom_vmeth(void *obj, void *buf,
-					    size_t max_len, int flags,
-					    struct sockaddr *addr,
-					    socklen_t *addrlen)
+static k_ssize_t sock_dispatch_recvfrom_vmeth(void *obj, void *buf, size_t max_len, int flags,
+						 struct sockaddr *addr, socklen_t *addrlen)
 {
 	int fd = sock_dispatch_default(obj);
 

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -16,7 +16,6 @@ LOG_MODULE_REGISTER(net_sock, CONFIG_NET_SOCKETS_LOG_LEVEL);
 #include <zephyr/tracing/tracing.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/socket_types.h>
-#include <zephyr/posix/fcntl.h>
 #include <zephyr/internal/syscall_handler.h>
 #include <zephyr/sys/fdtable.h>
 #include <zephyr/sys/math_extras.h>
@@ -834,7 +833,7 @@ out:
 	return -1;
 }
 
-ssize_t zsock_sendto_ctx(struct net_context *ctx, const void *buf, size_t len,
+k_ssize_t zsock_sendto_ctx(struct net_context *ctx, const void *buf, size_t len,
 			 int flags,
 			 const struct sockaddr *dest_addr, socklen_t addrlen)
 {
@@ -891,7 +890,7 @@ ssize_t zsock_sendto_ctx(struct net_context *ctx, const void *buf, size_t len,
 	return status;
 }
 
-ssize_t z_impl_zsock_sendto(int sock, const void *buf, size_t len, int flags,
+k_ssize_t z_impl_zsock_sendto(int sock, const void *buf, size_t len, int flags,
 			   const struct sockaddr *dest_addr, socklen_t addrlen)
 {
 	int bytes_sent;
@@ -910,7 +909,7 @@ ssize_t z_impl_zsock_sendto(int sock, const void *buf, size_t len, int flags,
 }
 
 #ifdef CONFIG_USERSPACE
-ssize_t z_vrfy_zsock_sendto(int sock, const void *buf, size_t len, int flags,
+k_ssize_t z_vrfy_zsock_sendto(int sock, const void *buf, size_t len, int flags,
 			   const struct sockaddr *dest_addr, socklen_t addrlen)
 {
 	struct sockaddr_storage dest_addr_copy;
@@ -942,7 +941,7 @@ size_t msghdr_non_empty_iov_count(const struct msghdr *msg)
 	return non_empty_iov_count;
 }
 
-ssize_t zsock_sendmsg_ctx(struct net_context *ctx, const struct msghdr *msg,
+k_ssize_t zsock_sendmsg_ctx(struct net_context *ctx, const struct msghdr *msg,
 			  int flags)
 {
 	k_timeout_t timeout = K_FOREVER;
@@ -981,7 +980,7 @@ ssize_t zsock_sendmsg_ctx(struct net_context *ctx, const struct msghdr *msg,
 	return status;
 }
 
-ssize_t z_impl_zsock_sendmsg(int sock, const struct msghdr *msg, int flags)
+k_ssize_t z_impl_zsock_sendmsg(int sock, const struct msghdr *msg, int flags)
 {
 	int bytes_sent;
 
@@ -998,7 +997,7 @@ ssize_t z_impl_zsock_sendmsg(int sock, const struct msghdr *msg, int flags)
 }
 
 #ifdef CONFIG_USERSPACE
-static inline ssize_t z_vrfy_zsock_sendmsg(int sock,
+static inline k_ssize_t z_vrfy_zsock_sendmsg(int sock,
 					   const struct msghdr *msg,
 					   int flags)
 {
@@ -1426,7 +1425,7 @@ out:
 	return ret;
 }
 
-static inline ssize_t zsock_recv_dgram(struct net_context *ctx,
+static inline k_ssize_t zsock_recv_dgram(struct net_context *ctx,
 				       struct msghdr *msg,
 				       void *buf,
 				       size_t max_len,
@@ -1696,7 +1695,7 @@ static int zsock_fionread_ctx(struct net_context *ctx)
 	return MIN(ret, INT_MAX);
 }
 
-static ssize_t zsock_recv_stream_timed(struct net_context *ctx, struct msghdr *msg,
+static k_ssize_t zsock_recv_stream_timed(struct net_context *ctx, struct msghdr *msg,
 				       uint8_t *buf, size_t max_len,
 				       int flags, k_timeout_t timeout)
 {
@@ -1786,10 +1785,10 @@ again:
 	return recv_len;
 }
 
-static ssize_t zsock_recv_stream(struct net_context *ctx, struct msghdr *msg,
+static k_ssize_t zsock_recv_stream(struct net_context *ctx, struct msghdr *msg,
 				 void *buf, size_t max_len, int flags)
 {
-	ssize_t res;
+	k_ssize_t res;
 	size_t recv_len = 0;
 	k_timeout_t timeout = K_FOREVER;
 
@@ -1829,7 +1828,7 @@ static ssize_t zsock_recv_stream(struct net_context *ctx, struct msghdr *msg,
 	return recv_len;
 }
 
-ssize_t zsock_recvfrom_ctx(struct net_context *ctx, void *buf, size_t max_len,
+k_ssize_t zsock_recvfrom_ctx(struct net_context *ctx, void *buf, size_t max_len,
 			   int flags,
 			   struct sockaddr *src_addr, socklen_t *addrlen)
 {
@@ -1852,7 +1851,7 @@ ssize_t zsock_recvfrom_ctx(struct net_context *ctx, void *buf, size_t max_len,
 	return -1;
 }
 
-ssize_t z_impl_zsock_recvfrom(int sock, void *buf, size_t max_len, int flags,
+k_ssize_t z_impl_zsock_recvfrom(int sock, void *buf, size_t max_len, int flags,
 			     struct sockaddr *src_addr, socklen_t *addrlen)
 {
 	int bytes_received;
@@ -1871,11 +1870,11 @@ ssize_t z_impl_zsock_recvfrom(int sock, void *buf, size_t max_len, int flags,
 }
 
 #ifdef CONFIG_USERSPACE
-ssize_t z_vrfy_zsock_recvfrom(int sock, void *buf, size_t max_len, int flags,
+k_ssize_t z_vrfy_zsock_recvfrom(int sock, void *buf, size_t max_len, int flags,
 			      struct sockaddr *src_addr, socklen_t *addrlen)
 {
 	socklen_t addrlen_copy;
-	ssize_t ret;
+	k_ssize_t ret;
 
 	if (K_SYSCALL_MEMORY_WRITE(buf, max_len)) {
 		errno = EFAULT;
@@ -1902,7 +1901,7 @@ ssize_t z_vrfy_zsock_recvfrom(int sock, void *buf, size_t max_len, int flags,
 #include <zephyr/syscalls/zsock_recvfrom_mrsh.c>
 #endif /* CONFIG_USERSPACE */
 
-ssize_t zsock_recvmsg_ctx(struct net_context *ctx, struct msghdr *msg,
+k_ssize_t zsock_recvmsg_ctx(struct net_context *ctx, struct msghdr *msg,
 			  int flags)
 {
 	enum net_sock_type sock_type = net_context_get_type(ctx);
@@ -1936,7 +1935,7 @@ ssize_t zsock_recvmsg_ctx(struct net_context *ctx, struct msghdr *msg,
 	return -1;
 }
 
-ssize_t z_impl_zsock_recvmsg(int sock, struct msghdr *msg, int flags)
+k_ssize_t z_impl_zsock_recvmsg(int sock, struct msghdr *msg, int flags)
 {
 	int bytes_received;
 
@@ -1953,7 +1952,7 @@ ssize_t z_impl_zsock_recvmsg(int sock, struct msghdr *msg, int flags)
 }
 
 #ifdef CONFIG_USERSPACE
-ssize_t z_vrfy_zsock_recvmsg(int sock, struct msghdr *msg, int flags)
+k_ssize_t z_vrfy_zsock_recvmsg(int sock, struct msghdr *msg, int flags)
 {
 	struct msghdr msg_copy;
 	size_t iovlen;
@@ -3752,12 +3751,12 @@ static inline int z_vrfy_zsock_getsockname(int sock, struct sockaddr *addr,
 #include <zephyr/syscalls/zsock_getsockname_mrsh.c>
 #endif /* CONFIG_USERSPACE */
 
-static ssize_t sock_read_vmeth(void *obj, void *buffer, size_t count)
+static k_ssize_t sock_read_vmeth(void *obj, void *buffer, size_t count)
 {
 	return zsock_recvfrom_ctx(obj, buffer, count, 0, NULL, 0);
 }
 
-static ssize_t sock_write_vmeth(void *obj, const void *buffer, size_t count)
+static k_ssize_t sock_write_vmeth(void *obj, const void *buffer, size_t count)
 {
 	return zsock_sendto_ctx(obj, buffer, count, 0, NULL, 0);
 }
@@ -3772,19 +3771,19 @@ static int sock_ioctl_vmeth(void *obj, unsigned int request, va_list args)
 	switch (request) {
 
 	/* In Zephyr, fcntl() is just an alias of ioctl(). */
-	case F_GETFL:
+	case ZVFS_F_GETFL:
 		if (sock_is_nonblock(obj)) {
-		    return O_NONBLOCK;
+			return ZVFS_O_NONBLOCK;
 		}
 
 		return 0;
 
-	case F_SETFL: {
+	case ZVFS_F_SETFL: {
 		int flags;
 
 		flags = va_arg(args, int);
 
-		if (flags & O_NONBLOCK) {
+		if (flags & ZVFS_O_NONBLOCK) {
 			sock_set_flag(obj, SOCK_NONBLOCK, SOCK_NONBLOCK);
 		} else {
 			sock_set_flag(obj, SOCK_NONBLOCK, 0);
@@ -3869,25 +3868,25 @@ static int sock_accept_vmeth(void *obj, struct sockaddr *addr,
 	return zsock_accept_ctx(obj, addr, addrlen);
 }
 
-static ssize_t sock_sendto_vmeth(void *obj, const void *buf, size_t len,
+static k_ssize_t sock_sendto_vmeth(void *obj, const void *buf, size_t len,
 				 int flags, const struct sockaddr *dest_addr,
 				 socklen_t addrlen)
 {
 	return zsock_sendto_ctx(obj, buf, len, flags, dest_addr, addrlen);
 }
 
-static ssize_t sock_sendmsg_vmeth(void *obj, const struct msghdr *msg,
+static k_ssize_t sock_sendmsg_vmeth(void *obj, const struct msghdr *msg,
 				  int flags)
 {
 	return zsock_sendmsg_ctx(obj, msg, flags);
 }
 
-static ssize_t sock_recvmsg_vmeth(void *obj, struct msghdr *msg, int flags)
+static k_ssize_t sock_recvmsg_vmeth(void *obj, struct msghdr *msg, int flags)
 {
 	return zsock_recvmsg_ctx(obj, msg, flags);
 }
 
-static ssize_t sock_recvfrom_vmeth(void *obj, void *buf, size_t max_len,
+static k_ssize_t sock_recvfrom_vmeth(void *obj, void *buf, size_t max_len,
 				   int flags, struct sockaddr *src_addr,
 				   socklen_t *addrlen)
 {

--- a/subsys/net/lib/sockets/sockets_can.c
+++ b/subsys/net/lib/sockets/sockets_can.c
@@ -6,7 +6,6 @@
  */
 
 #include <stdbool.h>
-#include <zephyr/posix/fcntl.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_sock_can, CONFIG_NET_SOCKETS_LOG_LEVEL);
@@ -222,9 +221,8 @@ static int zcan_bind_ctx(struct net_context *ctx, const struct sockaddr *addr,
 	return 0;
 }
 
-ssize_t zcan_sendto_ctx(struct net_context *ctx, const void *buf, size_t len,
-			int flags, const struct sockaddr *dest_addr,
-			socklen_t addrlen)
+k_ssize_t zcan_sendto_ctx(struct net_context *ctx, const void *buf, size_t len, int flags,
+			     const struct sockaddr *dest_addr, socklen_t addrlen)
 {
 	struct sockaddr_can can_addr;
 	struct can_frame zframe;
@@ -272,10 +270,8 @@ ssize_t zcan_sendto_ctx(struct net_context *ctx, const void *buf, size_t len,
 	return len;
 }
 
-static ssize_t zcan_recvfrom_ctx(struct net_context *ctx, void *buf,
-				 size_t max_len, int flags,
-				 struct sockaddr *src_addr,
-				 socklen_t *addrlen)
+static k_ssize_t zcan_recvfrom_ctx(struct net_context *ctx, void *buf, size_t max_len, int flags,
+				      struct sockaddr *src_addr, socklen_t *addrlen)
 {
 	struct can_frame zframe;
 	size_t recv_len = 0;
@@ -363,13 +359,12 @@ static int zcan_setsockopt_ctx(struct net_context *ctx, int level, int optname,
 					    optval, optlen);
 }
 
-static ssize_t can_sock_read_vmeth(void *obj, void *buffer, size_t count)
+static k_ssize_t can_sock_read_vmeth(void *obj, void *buffer, size_t count)
 {
 	return zcan_recvfrom_ctx(obj, buffer, count, 0, NULL, 0);
 }
 
-static ssize_t can_sock_write_vmeth(void *obj, const void *buffer,
-				    size_t count)
+static k_ssize_t can_sock_write_vmeth(void *obj, const void *buffer, size_t count)
 {
 	return zcan_sendto_ctx(obj, buffer, count, 0, NULL, 0);
 }
@@ -495,17 +490,14 @@ static int can_sock_accept_vmeth(void *obj, struct sockaddr *addr,
 	return 0;
 }
 
-static ssize_t can_sock_sendto_vmeth(void *obj, const void *buf, size_t len,
-				     int flags,
-				     const struct sockaddr *dest_addr,
-				     socklen_t addrlen)
+static k_ssize_t can_sock_sendto_vmeth(void *obj, const void *buf, size_t len, int flags,
+					  const struct sockaddr *dest_addr, socklen_t addrlen)
 {
 	return zcan_sendto_ctx(obj, buf, len, flags, dest_addr, addrlen);
 }
 
-static ssize_t can_sock_recvfrom_vmeth(void *obj, void *buf, size_t max_len,
-				       int flags, struct sockaddr *src_addr,
-				       socklen_t *addrlen)
+static k_ssize_t can_sock_recvfrom_vmeth(void *obj, void *buf, size_t max_len, int flags,
+					    struct sockaddr *src_addr, socklen_t *addrlen)
 {
 	return zcan_recvfrom_ctx(obj, buf, max_len, flags,
 				 src_addr, addrlen);

--- a/subsys/net/lib/sockets/sockets_internal.h
+++ b/subsys/net/lib/sockets/sockets_internal.h
@@ -61,16 +61,16 @@ struct socket_op_vtable {
 		       socklen_t addrlen);
 	int (*listen)(void *obj, int backlog);
 	int (*accept)(void *obj, struct sockaddr *addr, socklen_t *addrlen);
-	ssize_t (*sendto)(void *obj, const void *buf, size_t len, int flags,
-			  const struct sockaddr *dest_addr, socklen_t addrlen);
-	ssize_t (*recvfrom)(void *obj, void *buf, size_t max_len, int flags,
-			    struct sockaddr *src_addr, socklen_t *addrlen);
+	k_ssize_t (*sendto)(void *obj, const void *buf, size_t len, int flags,
+			       const struct sockaddr *dest_addr, socklen_t addrlen);
+	k_ssize_t (*recvfrom)(void *obj, void *buf, size_t max_len, int flags,
+				 struct sockaddr *src_addr, socklen_t *addrlen);
 	int (*getsockopt)(void *obj, int level, int optname,
 			  void *optval, socklen_t *optlen);
 	int (*setsockopt)(void *obj, int level, int optname,
 			  const void *optval, socklen_t optlen);
-	ssize_t (*sendmsg)(void *obj, const struct msghdr *msg, int flags);
-	ssize_t (*recvmsg)(void *obj, struct msghdr *msg, int flags);
+	k_ssize_t (*sendmsg)(void *obj, const struct msghdr *msg, int flags);
+	k_ssize_t (*recvmsg)(void *obj, struct msghdr *msg, int flags);
 	int (*getpeername)(void *obj, struct sockaddr *addr,
 			   socklen_t *addrlen);
 	int (*getsockname)(void *obj, struct sockaddr *addr,

--- a/subsys/net/lib/sockets/sockets_net_mgmt.c
+++ b/subsys/net/lib/sockets/sockets_net_mgmt.c
@@ -5,7 +5,6 @@
  */
 
 #include <stdbool.h>
-#include <zephyr/posix/fcntl.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_sock_mgmt, CONFIG_NET_SOCKETS_LOG_LEVEL);
@@ -119,10 +118,8 @@ static int znet_mgmt_bind(struct net_mgmt_socket *mgmt,
 	return 0;
 }
 
-ssize_t znet_mgmt_sendto(struct net_mgmt_socket *mgmt,
-			 const void *buf, size_t len,
-			 int flags, const struct sockaddr *dest_addr,
-			 socklen_t addrlen)
+k_ssize_t znet_mgmt_sendto(struct net_mgmt_socket *mgmt, const void *buf, size_t len, int flags,
+			      const struct sockaddr *dest_addr, socklen_t addrlen)
 {
 	if (mgmt->proto == NET_MGMT_EVENT_PROTO) {
 		/* For net_mgmt events, we only listen and never send */
@@ -138,10 +135,8 @@ ssize_t znet_mgmt_sendto(struct net_mgmt_socket *mgmt,
 	return -1;
 }
 
-static ssize_t znet_mgmt_recvfrom(struct net_mgmt_socket *mgmt, void *buf,
-				  size_t max_len, int flags,
-				  struct sockaddr *src_addr,
-				  socklen_t *addrlen)
+static k_ssize_t znet_mgmt_recvfrom(struct net_mgmt_socket *mgmt, void *buf, size_t max_len,
+				       int flags, struct sockaddr *src_addr, socklen_t *addrlen)
 {
 	struct sockaddr_nm *nm_addr = (struct sockaddr_nm *)src_addr;
 	k_timeout_t timeout = mgmt->wait_timeout;
@@ -295,13 +290,12 @@ static int znet_mgmt_setsockopt(struct net_mgmt_socket *mgmt, int level,
 	return -1;
 }
 
-static ssize_t net_mgmt_sock_read(void *obj, void *buffer, size_t count)
+static k_ssize_t net_mgmt_sock_read(void *obj, void *buffer, size_t count)
 {
 	return znet_mgmt_recvfrom(obj, buffer, count, 0, NULL, 0);
 }
 
-static ssize_t net_mgmt_sock_write(void *obj, const void *buffer,
-				   size_t count)
+static k_ssize_t net_mgmt_sock_write(void *obj, const void *buffer, size_t count)
 {
 	return znet_mgmt_sendto(obj, buffer, count, 0, NULL, 0);
 }
@@ -340,18 +334,14 @@ static int net_mgmt_sock_accept(void *obj, struct sockaddr *addr,
 	return 0;
 }
 
-static ssize_t net_mgmt_sock_sendto(void *obj, const void *buf,
-				    size_t len, int flags,
-				    const struct sockaddr *dest_addr,
-				    socklen_t addrlen)
+static k_ssize_t net_mgmt_sock_sendto(void *obj, const void *buf, size_t len, int flags,
+					 const struct sockaddr *dest_addr, socklen_t addrlen)
 {
 	return znet_mgmt_sendto(obj, buf, len, flags, dest_addr, addrlen);
 }
 
-static ssize_t net_mgmt_sock_recvfrom(void *obj, void *buf,
-				      size_t max_len, int flags,
-				      struct sockaddr *src_addr,
-				      socklen_t *addrlen)
+static k_ssize_t net_mgmt_sock_recvfrom(void *obj, void *buf, size_t max_len, int flags,
+					   struct sockaddr *src_addr, socklen_t *addrlen)
 {
 	return znet_mgmt_recvfrom(obj, buf, max_len, flags,
 				  src_addr, addrlen);

--- a/subsys/net/lib/sockets/sockets_packet.c
+++ b/subsys/net/lib/sockets/sockets_packet.c
@@ -6,7 +6,6 @@
  */
 
 #include <stdbool.h>
-#include <zephyr/posix/fcntl.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_sock_packet, CONFIG_NET_SOCKETS_LOG_LEVEL);
@@ -234,9 +233,8 @@ static void zpacket_set_source_addr(struct net_context *ctx,
 	*addrlen = sizeof(struct sockaddr_ll);
 }
 
-ssize_t zpacket_sendto_ctx(struct net_context *ctx, const void *buf, size_t len,
-			   int flags, const struct sockaddr *dest_addr,
-			   socklen_t addrlen)
+k_ssize_t zpacket_sendto_ctx(struct net_context *ctx, const void *buf, size_t len, int flags,
+				const struct sockaddr *dest_addr, socklen_t addrlen)
 {
 	k_timeout_t timeout = K_FOREVER;
 	int status;
@@ -273,8 +271,7 @@ ssize_t zpacket_sendto_ctx(struct net_context *ctx, const void *buf, size_t len,
 	return status;
 }
 
-ssize_t zpacket_sendmsg_ctx(struct net_context *ctx, const struct msghdr *msg,
-			    int flags)
+k_ssize_t zpacket_sendmsg_ctx(struct net_context *ctx, const struct msghdr *msg, int flags)
 {
 	k_timeout_t timeout = K_FOREVER;
 	int status;
@@ -294,9 +291,8 @@ ssize_t zpacket_sendmsg_ctx(struct net_context *ctx, const struct msghdr *msg,
 	return status;
 }
 
-ssize_t zpacket_recvfrom_ctx(struct net_context *ctx, void *buf, size_t max_len,
-			     int flags, struct sockaddr *src_addr,
-			     socklen_t *addrlen)
+k_ssize_t zpacket_recvfrom_ctx(struct net_context *ctx, void *buf, size_t max_len, int flags,
+				  struct sockaddr *src_addr, socklen_t *addrlen)
 {
 	size_t recv_len = 0;
 	k_timeout_t timeout = K_FOREVER;
@@ -378,13 +374,12 @@ int zpacket_setsockopt_ctx(struct net_context *ctx, int level, int optname,
 					    optval, optlen);
 }
 
-static ssize_t packet_sock_read_vmeth(void *obj, void *buffer, size_t count)
+static k_ssize_t packet_sock_read_vmeth(void *obj, void *buffer, size_t count)
 {
 	return zpacket_recvfrom_ctx(obj, buffer, count, 0, NULL, 0);
 }
 
-static ssize_t packet_sock_write_vmeth(void *obj, const void *buffer,
-				       size_t count)
+static k_ssize_t packet_sock_write_vmeth(void *obj, const void *buffer, size_t count)
 {
 	return zpacket_sendto_ctx(obj, buffer, count, 0, NULL, 0);
 }
@@ -427,23 +422,19 @@ static int packet_sock_accept_vmeth(void *obj, struct sockaddr *addr,
 	return -EOPNOTSUPP;
 }
 
-static ssize_t packet_sock_sendto_vmeth(void *obj, const void *buf, size_t len,
-					int flags,
-					const struct sockaddr *dest_addr,
-					socklen_t addrlen)
+static k_ssize_t packet_sock_sendto_vmeth(void *obj, const void *buf, size_t len, int flags,
+					     const struct sockaddr *dest_addr, socklen_t addrlen)
 {
 	return zpacket_sendto_ctx(obj, buf, len, flags, dest_addr, addrlen);
 }
 
-static ssize_t packet_sock_sendmsg_vmeth(void *obj, const struct msghdr *msg,
-					 int flags)
+static k_ssize_t packet_sock_sendmsg_vmeth(void *obj, const struct msghdr *msg, int flags)
 {
 	return zpacket_sendmsg_ctx(obj, msg, flags);
 }
 
-static ssize_t packet_sock_recvfrom_vmeth(void *obj, void *buf, size_t max_len,
-					  int flags, struct sockaddr *src_addr,
-					  socklen_t *addrlen)
+static k_ssize_t packet_sock_recvfrom_vmeth(void *obj, void *buf, size_t max_len, int flags,
+					       struct sockaddr *src_addr, socklen_t *addrlen)
 {
 	return zpacket_recvfrom_ctx(obj, buf, max_len, flags,
 				    src_addr, addrlen);

--- a/subsys/net/lib/websocket/websocket.c
+++ b/subsys/net/lib/websocket/websocket.c
@@ -1116,21 +1116,18 @@ static int websocket_recv(struct websocket_context *ctx, uint8_t *buf,
 	return ret;
 }
 
-static ssize_t websocket_read_vmeth(void *obj, void *buffer, size_t count)
+static k_ssize_t websocket_read_vmeth(void *obj, void *buffer, size_t count)
 {
-	return (ssize_t)websocket_recv(obj, buffer, count, SYS_FOREVER_MS);
+	return (k_ssize_t)websocket_recv(obj, buffer, count, SYS_FOREVER_MS);
 }
 
-static ssize_t websocket_write_vmeth(void *obj, const void *buffer,
-				     size_t count)
+static k_ssize_t websocket_write_vmeth(void *obj, const void *buffer, size_t count)
 {
-	return (ssize_t)websocket_send(obj, buffer, count, SYS_FOREVER_MS);
+	return (k_ssize_t)websocket_send(obj, buffer, count, SYS_FOREVER_MS);
 }
 
-static ssize_t websocket_sendto_ctx(void *obj, const void *buf, size_t len,
-				    int flags,
-				    const struct sockaddr *dest_addr,
-				    socklen_t addrlen)
+static k_ssize_t websocket_sendto_ctx(void *obj, const void *buf, size_t len, int flags,
+					 const struct sockaddr *dest_addr, socklen_t addrlen)
 {
 	struct websocket_context *ctx = obj;
 	int32_t timeout = SYS_FOREVER_MS;
@@ -1142,12 +1139,11 @@ static ssize_t websocket_sendto_ctx(void *obj, const void *buf, size_t len,
 	ARG_UNUSED(dest_addr);
 	ARG_UNUSED(addrlen);
 
-	return (ssize_t)websocket_send(ctx, buf, len, timeout);
+	return (k_ssize_t)websocket_send(ctx, buf, len, timeout);
 }
 
-static ssize_t websocket_recvfrom_ctx(void *obj, void *buf, size_t max_len,
-				      int flags, struct sockaddr *src_addr,
-				      socklen_t *addrlen)
+static k_ssize_t websocket_recvfrom_ctx(void *obj, void *buf, size_t max_len, int flags,
+					   struct sockaddr *src_addr, socklen_t *addrlen)
 {
 	struct websocket_context *ctx = obj;
 	int32_t timeout = SYS_FOREVER_MS;
@@ -1159,7 +1155,7 @@ static ssize_t websocket_recvfrom_ctx(void *obj, void *buf, size_t max_len,
 	ARG_UNUSED(src_addr);
 	ARG_UNUSED(addrlen);
 
-	return (ssize_t)websocket_recv(ctx, buf, max_len, timeout);
+	return (k_ssize_t)websocket_recv(ctx, buf, max_len, timeout);
 }
 
 int websocket_register(int sock, uint8_t *recv_buf, size_t recv_buf_len)

--- a/subsys/retention/retention.c
+++ b/subsys/retention/retention.c
@@ -129,7 +129,7 @@ static int retention_init(const struct device *dev)
 #ifdef CONFIG_RETENTION_MUTEXES
 	struct retention_data *data = dev->data;
 #endif
-	ssize_t area_size;
+	k_ssize_t area_size;
 
 	if (!device_is_ready(config->parent)) {
 		LOG_ERR("Parent device is not ready");
@@ -185,7 +185,7 @@ int retention_is_valid(const struct device *dev)
 		/* Check magic header is present at the start of the section */
 		struct retention_data *data = dev->data;
 		uint8_t buffer[CONFIG_RETENTION_BUFFER_SIZE];
-		off_t pos = 0;
+		k_off_t pos = 0;
 
 		while (pos < config->prefix_len) {
 			uint16_t read_size = MIN((config->prefix_len - pos), sizeof(buffer));
@@ -219,7 +219,7 @@ int retention_is_valid(const struct device *dev)
 		/* Check the checksum validity, for this all the data must be read out */
 		uint32_t checksum = 0;
 		uint32_t expected_checksum = 0;
-		ssize_t data_size = config->size - config->checksum_size;
+		k_ssize_t data_size = config->size - config->checksum_size;
 
 		rc = retention_checksum(dev, &checksum);
 
@@ -264,7 +264,7 @@ finish:
 	return rc;
 }
 
-int retention_read(const struct device *dev, off_t offset, uint8_t *buffer, size_t size)
+int retention_read(const struct device *dev, k_off_t offset, uint8_t *buffer, size_t size)
 {
 	const struct retention_config *config = dev->config;
 	int rc;
@@ -284,7 +284,7 @@ int retention_read(const struct device *dev, off_t offset, uint8_t *buffer, size
 	return rc;
 }
 
-int retention_write(const struct device *dev, off_t offset, const uint8_t *buffer, size_t size)
+int retention_write(const struct device *dev, k_off_t offset, const uint8_t *buffer, size_t size)
 {
 	const struct retention_config *config = dev->config;
 	int rc;
@@ -367,7 +367,7 @@ int retention_clear(const struct device *dev)
 	struct retention_data *data = dev->data;
 	int rc = 0;
 	uint8_t buffer[CONFIG_RETENTION_BUFFER_SIZE];
-	off_t pos = 0;
+	k_off_t pos = 0;
 
 	memset(buffer, 0, sizeof(buffer));
 

--- a/subsys/settings/src/settings_fcb.c
+++ b/subsys/settings/src/settings_fcb.c
@@ -135,7 +135,7 @@ static bool settings_fcb_check_duplicate(struct settings_fcb *cf,
 	return false;
 }
 
-static int read_entry_len(const struct fcb_entry_ctx *entry_ctx, off_t off)
+static int read_entry_len(const struct fcb_entry_ctx *entry_ctx, k_off_t off)
 {
 	if (off >= entry_ctx->loc.fe_data_len) {
 		return 0;
@@ -196,7 +196,7 @@ static int settings_fcb_load(struct settings_store *cs,
 		true);
 }
 
-static int read_handler(void *ctx, off_t off, char *buf, size_t *len)
+static int read_handler(void *ctx, k_off_t off, char *buf, size_t *len)
 {
 	struct fcb_entry_ctx *entry_ctx = ctx;
 
@@ -311,7 +311,7 @@ static size_t get_len_cb(void *ctx)
 	return entry_ctx->loc.fe_data_len;
 }
 
-static int write_handler(void *ctx, off_t off, char const *buf, size_t len)
+static int write_handler(void *ctx, k_off_t off, char const *buf, size_t len)
 {
 	struct fcb_entry_ctx *entry_ctx = ctx;
 

--- a/subsys/settings/src/settings_file.c
+++ b/subsys/settings/src/settings_file.c
@@ -103,7 +103,7 @@ static bool settings_file_check_duplicate(
 	return false;
 }
 
-static int read_entry_len(const struct line_entry_ctx *entry_ctx, off_t off)
+static int read_entry_len(const struct line_entry_ctx *entry_ctx, k_off_t off)
 {
 	if (off >= entry_ctx->len) {
 		return 0;
@@ -443,11 +443,11 @@ static int settings_file_save(struct settings_store *cs, const char *name,
 	return settings_file_save_priv(cs, name, value, val_len);
 }
 
-static int read_handler(void *ctx, off_t off, char *buf, size_t *len)
+static int read_handler(void *ctx, k_off_t off, char *buf, size_t *len)
 {
 	struct line_entry_ctx *entry_ctx = ctx;
 	struct fs_file_t *file = entry_ctx->stor_ctx;
-	ssize_t r_len;
+	k_ssize_t r_len;
 	int rc;
 
 	/* 0 is reserved for reading the length-field only */
@@ -486,7 +486,7 @@ static size_t get_len_cb(void *ctx)
 	return entry_ctx->len;
 }
 
-static int write_handler(void *ctx, off_t off, char const *buf, size_t len)
+static int write_handler(void *ctx, k_off_t off, char const *buf, size_t len)
 {
 	struct line_entry_ctx *entry_ctx = ctx;
 	struct fs_file_t *file = entry_ctx->stor_ctx;

--- a/subsys/settings/src/settings_line.c
+++ b/subsys/settings/src/settings_line.c
@@ -15,14 +15,14 @@
 LOG_MODULE_DECLARE(settings, CONFIG_SETTINGS_LOG_LEVEL);
 
 struct settings_io_cb_s {
-	int (*read_cb)(void *ctx, off_t off, char *buf, size_t *len);
-	int (*write_cb)(void *ctx, off_t off, char const *buf, size_t len);
+	int (*read_cb)(void *ctx, k_off_t off, char *buf, size_t *len);
+	int (*write_cb)(void *ctx, k_off_t off, char const *buf, size_t len);
 	size_t (*get_len_cb)(void *ctx);
 	uint8_t rwbs;
 } static settings_io_cb;
 
 int settings_line_write(const char *name, const char *value, size_t val_len,
-			off_t w_loc, void *cb_arg)
+			k_off_t w_loc, void *cb_arg)
 {
 	size_t w_size, rem, add;
 
@@ -169,7 +169,7 @@ int settings_line_len_calc(const char *name, size_t val_len)
  * @retval 0 on success,
  * -ERCODE on storage errors
  */
-static int settings_line_raw_read_until(off_t seek, char *out, size_t len_req,
+static int settings_line_raw_read_until(k_off_t seek, char *out, size_t len_req,
 				 size_t *len_read, char const *until_char,
 				 void *cb_arg)
 {
@@ -177,7 +177,7 @@ static int settings_line_raw_read_until(off_t seek, char *out, size_t len_req,
 	char temp_buf[32]; /* buffer for fit read-block-size requirements */
 	size_t exp_size, read_size;
 	uint8_t rbs = settings_io_cb.rwbs;
-	off_t off;
+	k_off_t off;
 	int rc = -EINVAL;
 
 	if (len_req == 0) {
@@ -231,7 +231,7 @@ static int settings_line_raw_read_until(off_t seek, char *out, size_t len_req,
 	return 0;
 }
 
-int settings_line_raw_read(off_t seek, char *out, size_t len_req,
+int settings_line_raw_read(k_off_t seek, char *out, size_t len_req,
 			   size_t *len_read, void *cb_arg)
 {
 	return settings_line_raw_read_until(seek, out, len_req, len_read,
@@ -239,14 +239,14 @@ int settings_line_raw_read(off_t seek, char *out, size_t len_req,
 }
 
 /* off from value begin */
-int settings_line_val_read(off_t val_off, off_t off, char *out, size_t len_req,
+int settings_line_val_read(k_off_t val_off, k_off_t off, char *out, size_t len_req,
 			   size_t *len_read, void *cb_arg)
 {
 	return settings_line_raw_read(val_off + off, out, len_req, len_read,
 				      cb_arg);
 }
 
-size_t settings_line_val_get_len(off_t val_off, void *read_cb_ctx)
+size_t settings_line_val_get_len(k_off_t val_off, void *read_cb_ctx)
 {
 	size_t len;
 
@@ -272,8 +272,8 @@ int settings_line_name_read(char *out, size_t len_req, size_t *len_read,
 }
 
 
-int settings_line_entry_copy(void *dst_ctx, off_t dst_off, void *src_ctx,
-			     off_t src_off, size_t len)
+int settings_line_entry_copy(void *dst_ctx, k_off_t dst_off, void *src_ctx,
+			     k_off_t src_off, size_t len)
 {
 	int rc = -EINVAL;
 	char buf[16];
@@ -308,9 +308,9 @@ int settings_line_entry_copy(void *dst_ctx, off_t dst_off, void *src_ctx,
 	return rc;
 }
 
-void settings_line_io_init(int (*read_cb)(void *ctx, off_t off, char *buf,
+void settings_line_io_init(int (*read_cb)(void *ctx, k_off_t off, char *buf,
 					  size_t *len),
-			  int (*write_cb)(void *ctx, off_t off, char const *buf,
+			  int (*write_cb)(void *ctx, k_off_t off, char const *buf,
 					  size_t len),
 			  size_t (*get_len_cb)(void *ctx),
 			  uint8_t io_rwbs)
@@ -324,13 +324,13 @@ void settings_line_io_init(int (*read_cb)(void *ctx, off_t off, char *buf,
 
 /* val_off - offset of value-string within line entries */
 static int settings_line_cmp(char const *val, size_t val_len,
-			     void *val_read_cb_ctx, off_t val_off)
+			     void *val_read_cb_ctx, k_off_t val_off)
 {
 	size_t len_read, exp_len;
 	size_t rem;
 	char buf[16];
 	int rc = -EINVAL;
-	off_t off = 0;
+	k_off_t off = 0;
 
 	if (val_len == 0) {
 		return -EINVAL;
@@ -361,7 +361,7 @@ static int settings_line_cmp(char const *val, size_t val_len,
 }
 
 int settings_line_dup_check_cb(const char *name, void *val_read_cb_ctx,
-				off_t off, void *cb_arg)
+				k_off_t off, void *cb_arg)
 {
 	struct settings_line_dup_check_arg *cdca;
 	size_t len_read;
@@ -387,7 +387,7 @@ int settings_line_dup_check_cb(const char *name, void *val_read_cb_ctx,
 	return 0;
 }
 
-static ssize_t settings_line_read_cb(void *cb_arg, void *data, size_t len)
+static k_ssize_t settings_line_read_cb(void *cb_arg, void *data, size_t len)
 {
 	struct settings_line_read_value_cb_ctx *value_context = cb_arg;
 	size_t len_read;
@@ -404,7 +404,7 @@ static ssize_t settings_line_read_cb(void *cb_arg, void *data, size_t len)
 	return -1;
 }
 
-int settings_line_load_cb(const char *name, void *val_read_cb_ctx, off_t off,
+int settings_line_load_cb(const char *name, void *val_read_cb_ctx, k_off_t off,
 			  void *cb_arg)
 {
 	size_t len;

--- a/subsys/settings/src/settings_nvs.c
+++ b/subsys/settings/src/settings_nvs.c
@@ -40,15 +40,15 @@ static struct settings_store_itf settings_nvs_itf = {
 	.csi_storage_get = settings_nvs_storage_get
 };
 
-static ssize_t settings_nvs_read_fn(void *back_end, void *data, size_t len)
+static k_ssize_t settings_nvs_read_fn(void *back_end, void *data, size_t len)
 {
 	struct settings_nvs_read_fn_arg *rd_fn_arg;
-	ssize_t rc;
+	k_ssize_t rc;
 
 	rd_fn_arg = (struct settings_nvs_read_fn_arg *)back_end;
 
 	rc = nvs_read(rd_fn_arg->fs, rd_fn_arg->id, data, len);
-	if (rc > (ssize_t)len) {
+	if (rc > (k_ssize_t)len) {
 		/* nvs_read signals that not all bytes were read
 		 * align read len to what was requested
 		 */
@@ -128,7 +128,7 @@ static int settings_nvs_load(struct settings_store *cs,
 	struct settings_nvs_read_fn_arg read_fn_arg;
 	char name[SETTINGS_MAX_NAME_LEN + SETTINGS_EXTRA_LEN + 1];
 	char buf;
-	ssize_t rc1, rc2;
+	k_ssize_t rc1, rc2;
 	uint16_t name_id = NVS_NAMECNT_ID;
 
 #if CONFIG_SETTINGS_NVS_NAME_CACHE

--- a/subsys/settings/src/settings_priv.h
+++ b/subsys/settings/src/settings_priv.h
@@ -18,23 +18,23 @@ extern "C" {
 #endif
 
 int settings_line_write(const char *name, const char *value, size_t val_len,
-			off_t w_loc, void *cb_arg);
+			k_off_t w_loc, void *cb_arg);
 
 /* Get len of record without alignment to write-block-size */
 int settings_line_len_calc(const char *name, size_t val_len);
 
 int settings_line_dup_check_cb(const char *name, void *val_read_cb_ctx,
-				off_t off, void *cb_arg);
+				k_off_t off, void *cb_arg);
 
 int settings_line_load_cb(const char *name, void *val_read_cb_ctx,
-			   off_t off, void *cb_arg);
+			   k_off_t off, void *cb_arg);
 
 typedef int (*line_load_cb)(const char *name, void *val_read_cb_ctx,
-			     off_t off, void *cb_arg);
+			     k_off_t off, void *cb_arg);
 
 struct settings_line_read_value_cb_ctx {
 	void *read_cb_ctx;
-	off_t off;
+	k_off_t off;
 };
 
 struct settings_line_dup_check_arg {
@@ -48,7 +48,7 @@ struct settings_line_dup_check_arg {
 /* in storage line contex */
 struct line_entry_ctx {
 	void *stor_ctx;
-	off_t seek; /* offset of id-value pair within the file */
+	k_off_t seek; /* offset of id-value pair within the file */
 	size_t len; /* len of line without len value */
 };
 
@@ -68,14 +68,14 @@ int settings_next_line_ctx(struct line_entry_ctx *entry_ctx);
  * @retval 0 on success,
  * -ERCODE on storage errors
  */
-int settings_line_raw_read(off_t seek, char *out, size_t len_req,
+int settings_line_raw_read(k_off_t seek, char *out, size_t len_req,
 			   size_t *len_read, void *cb_arg);
 
 /*
  * @param val_off offset of the value-string.
  * @param off from val_off (so within the value-string)
  */
-int settings_line_val_read(off_t val_off, off_t off, char *out, size_t len_req,
+int settings_line_val_read(k_off_t val_off, k_off_t off, char *out, size_t len_req,
 			   size_t *len_read, void *cb_arg);
 
 /**
@@ -94,14 +94,14 @@ int settings_line_val_read(off_t val_off, off_t off, char *out, size_t len_req,
 int settings_line_name_read(char *out, size_t len_req, size_t *len_read,
 			    void *cb_arg);
 
-size_t settings_line_val_get_len(off_t val_off, void *read_cb_ctx);
+size_t settings_line_val_get_len(k_off_t val_off, void *read_cb_ctx);
 
-int settings_line_entry_copy(void *dst_ctx, off_t dst_off, void *src_ctx,
-			off_t src_off, size_t len);
+int settings_line_entry_copy(void *dst_ctx, k_off_t dst_off, void *src_ctx,
+			k_off_t src_off, size_t len);
 
-void settings_line_io_init(int (*read_cb)(void *ctx, off_t off, char *buf,
+void settings_line_io_init(int (*read_cb)(void *ctx, k_off_t off, char *buf,
 					  size_t *len),
-			  int (*write_cb)(void *ctx, off_t off, char const *buf,
+			  int (*write_cb)(void *ctx, k_off_t off, char const *buf,
 					  size_t len),
 			  size_t (*get_len_cb)(void *ctx),
 			  uint8_t io_rwbs);

--- a/subsys/settings/src/settings_runtime.c
+++ b/subsys/settings/src/settings_runtime.c
@@ -15,7 +15,7 @@ struct read_cb_arg {
 	size_t len;
 };
 
-static ssize_t settings_runtime_read_cb(void *cb_arg, void *data, size_t len)
+static k_ssize_t settings_runtime_read_cb(void *cb_arg, void *data, size_t len)
 {
 	struct read_cb_arg *arg = (struct read_cb_arg *)cb_arg;
 

--- a/subsys/settings/src/settings_shell.c
+++ b/subsys/settings/src/settings_shell.c
@@ -74,7 +74,7 @@ static int settings_read_callback(const char *key,
 				  void            *param)
 {
 	uint8_t buffer[SETTINGS_MAX_VAL_LEN];
-	ssize_t num_read_bytes = MIN(len, SETTINGS_MAX_VAL_LEN);
+	k_ssize_t num_read_bytes = MIN(len, SETTINGS_MAX_VAL_LEN);
 	struct settings_read_callback_params *params = param;
 
 	/* Process only the exact match and ignore descendants of the searched name */

--- a/subsys/shell/backends/shell_mqtt.c
+++ b/subsys/shell/backends/shell_mqtt.c
@@ -78,7 +78,7 @@ static void sh_mqtt_rx_rb_flush(void)
 bool __weak shell_mqtt_get_devid(char *id, int id_max_len)
 {
 	uint8_t hwinfo_id[DEVICE_ID_BIN_MAX_SIZE];
-	ssize_t length;
+	k_ssize_t length;
 
 	length = hwinfo_get_device_id(hwinfo_id, DEVICE_ID_BIN_MAX_SIZE);
 	if (length <= 0) {

--- a/subsys/storage/flash_map/flash_map.c
+++ b/subsys/storage/flash_map/flash_map.c
@@ -12,7 +12,6 @@
 
 #include <zephyr/types.h>
 #include <stddef.h>
-#include <sys/types.h>
 #include <zephyr/device.h>
 #include <zephyr/storage/flash_map.h>
 #include "flash_map_priv.h"
@@ -53,8 +52,7 @@ void flash_area_close(const struct flash_area *fa)
 	/* nothing to do for now */
 }
 
-int flash_area_read(const struct flash_area *fa, off_t off, void *dst,
-		    size_t len)
+int flash_area_read(const struct flash_area *fa, k_off_t off, void *dst, size_t len)
 {
 	if (!is_in_flash_area_bounds(fa, off, len)) {
 		return -EINVAL;
@@ -63,8 +61,7 @@ int flash_area_read(const struct flash_area *fa, off_t off, void *dst,
 	return flash_read(fa->fa_dev, fa->fa_off + off, dst, len);
 }
 
-int flash_area_write(const struct flash_area *fa, off_t off, const void *src,
-		     size_t len)
+int flash_area_write(const struct flash_area *fa, k_off_t off, const void *src, size_t len)
 {
 	if (!is_in_flash_area_bounds(fa, off, len)) {
 		return -EINVAL;
@@ -73,7 +70,7 @@ int flash_area_write(const struct flash_area *fa, off_t off, const void *src,
 	return flash_write(fa->fa_dev, fa->fa_off + off, (void *)src, len);
 }
 
-int flash_area_erase(const struct flash_area *fa, off_t off, size_t len)
+int flash_area_erase(const struct flash_area *fa, k_off_t off, size_t len)
 {
 	if (!is_in_flash_area_bounds(fa, off, len)) {
 		return -EINVAL;
@@ -82,7 +79,7 @@ int flash_area_erase(const struct flash_area *fa, off_t off, size_t len)
 	return flash_erase(fa->fa_dev, fa->fa_off + off, len);
 }
 
-int flash_area_flatten(const struct flash_area *fa, off_t off, size_t len)
+int flash_area_flatten(const struct flash_area *fa, k_off_t off, size_t len)
 {
 	if (!is_in_flash_area_bounds(fa, off, len)) {
 		return -EINVAL;

--- a/subsys/storage/flash_map/flash_map_priv.h
+++ b/subsys/storage/flash_map/flash_map_priv.h
@@ -31,7 +31,7 @@ static inline struct flash_area const *get_flash_area_from_id(int idx)
 
 
 static inline bool is_in_flash_area_bounds(const struct flash_area *fa,
-					   off_t off, size_t len)
+					   k_off_t off, size_t len)
 {
 	return (off >= 0) && ((off + len) <= fa->fa_size);
 }

--- a/subsys/storage/stream/stream_flash.c
+++ b/subsys/storage/stream/stream_flash.c
@@ -28,7 +28,7 @@ static int settings_direct_loader(const char *key, size_t len,
 	/* Handle the subtree if it is an exact key match. */
 	if (settings_name_next(key, NULL) == 0) {
 		size_t bytes_written = 0;
-		ssize_t cb_len = read_cb(cb_arg, &bytes_written,
+		k_ssize_t cb_len = read_cb(cb_arg, &bytes_written,
 				      sizeof(bytes_written));
 
 		if (cb_len != sizeof(ctx->bytes_written)) {
@@ -48,7 +48,7 @@ static int settings_direct_loader(const char *key, size_t len,
 #ifdef CONFIG_STREAM_FLASH_ERASE
 		int rc;
 		struct flash_pages_info page;
-		off_t offset = (off_t) (ctx->offset + ctx->bytes_written) - 1;
+		k_off_t offset = (k_off_t) (ctx->offset + ctx->bytes_written) - 1;
 
 		/* Update the last erased page to avoid deleting already
 		 * written data.
@@ -74,7 +74,7 @@ static int settings_direct_loader(const char *key, size_t len,
 
 #ifdef CONFIG_STREAM_FLASH_ERASE
 
-int stream_flash_erase_page(struct stream_flash_ctx *ctx, off_t off)
+int stream_flash_erase_page(struct stream_flash_ctx *ctx, k_off_t off)
 {
 #if defined(CONFIG_FLASH_HAS_EXPLICIT_ERASE)
 	int rc;

--- a/subsys/usb/device_next/usbd_ch9.c
+++ b/subsys/usb/device_next/usbd_ch9.c
@@ -527,11 +527,11 @@ static int sreq_get_desc_cfg(struct usbd_context *const uds_ctx,
 #define USBD_HWID_SN_MAX 32U
 
 /* Generate valid USB device serial number from hwid */
-static ssize_t get_sn_from_hwid(uint8_t sn[static USBD_HWID_SN_MAX])
+static k_ssize_t get_sn_from_hwid(uint8_t sn[static USBD_HWID_SN_MAX])
 {
 	static const char hex[] = "0123456789ABCDEF";
 	uint8_t hwid[USBD_HWID_SN_MAX / 2U];
-	ssize_t hwid_len = -ENOSYS;
+	k_ssize_t hwid_len = -ENOSYS;
 
 	if (IS_ENABLED(CONFIG_HWINFO)) {
 		hwid_len = hwinfo_get_device_id(hwid, sizeof(hwid));
@@ -545,7 +545,7 @@ static ssize_t get_sn_from_hwid(uint8_t sn[static USBD_HWID_SN_MAX])
 		return hwid_len;
 	}
 
-	for (ssize_t i = 0; i < hwid_len; i++) {
+	for (k_ssize_t i = 0; i < hwid_len; i++) {
 		sn[i * 2] = hex[hwid[i] >> 4];
 		sn[i * 2 + 1] = hex[hwid[i] & 0xF];
 	}
@@ -566,7 +566,7 @@ static void string_ascii7_to_utf16le(struct usbd_desc_node *const dn,
 	size_t i;
 
 	if (dn->str.utype == USBD_DUT_STRING_SERIAL_NUMBER && dn->str.use_hwinfo) {
-		ssize_t hwid_len = get_sn_from_hwid(hwid_sn);
+		k_ssize_t hwid_len = get_sn_from_hwid(hwid_sn);
 
 		if (hwid_len < 0) {
 			errno = -ENOTSUP;

--- a/tests/bluetooth/audio/ascs/src/main.c
+++ b/tests/bluetooth/audio/ascs/src/main.c
@@ -126,7 +126,7 @@ ZTEST_F(ascs_test_suite, test_sink_ase_read_state_idle)
 	const struct bt_gatt_attr *ase = fixture->ase_snk.attr;
 	struct bt_conn *conn = &fixture->conn;
 	struct test_ase_chrc_value_hdr hdr = { 0xff };
-	ssize_t ret;
+	k_ssize_t ret;
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_BT_ASCS_ASE_SNK);
 	zexpect_not_null(fixture->ase_snk.attr);

--- a/tests/bluetooth/audio/ascs/src/test_ase_control_params.c
+++ b/tests/bluetooth/audio/ascs/src/test_ase_control_params.c
@@ -81,7 +81,7 @@ ZTEST_SUITE(test_ase_control_params, NULL, test_ase_control_params_setup,
 ZTEST_F(test_ase_control_params, test_sink_ase_control_operation_zero_length_write)
 {
 	uint8_t buf[] = {};
-	ssize_t ret;
+	k_ssize_t ret;
 
 	ret = fixture->ase_cp->write(&fixture->conn, fixture->ase_cp, (void *)buf, 0, 0, 0);
 	zassert_true(ret < 0, "ase_cp_attr->write returned unexpected (err 0x%02x)",

--- a/tests/bluetooth/audio/ascs/src/test_ase_state_transition_invalid.c
+++ b/tests/bluetooth/audio/ascs/src/test_ase_state_transition_invalid.c
@@ -336,7 +336,7 @@ ZTEST_F(test_ase_state_transition_invalid, test_sink_client_state_streaming)
 static void expect_ase_state_releasing(struct bt_conn *conn, const struct bt_gatt_attr *ase)
 {
 	struct test_ase_chrc_value_hdr hdr = { 0xff };
-	ssize_t ret;
+	k_ssize_t ret;
 
 	zexpect_not_null(conn);
 	zexpect_not_null(ase);

--- a/tests/bluetooth/audio/ascs/src/test_common.c
+++ b/tests/bluetooth/audio/ascs/src/test_common.c
@@ -118,7 +118,7 @@ uint8_t test_ase_get(const struct bt_uuid *uuid, int num_ase, ...)
 uint8_t test_ase_id_get(const struct bt_gatt_attr *ase)
 {
 	struct test_ase_chrc_value_hdr hdr = { 0 };
-	ssize_t ret;
+	k_ssize_t ret;
 
 	ret = ase->read(NULL, ase, &hdr, sizeof(hdr), 0);
 	zassert_false(ret < 0, "ase->read returned unexpected (err 0x%02x)", BT_GATT_ERR(ret));
@@ -162,7 +162,7 @@ void test_ase_control_client_config_codec(struct bt_conn *conn, uint8_t ase_id,
 		0x00,           /* Codec_Specific_Configuration_Length[0] */
 	};
 
-	ssize_t ret;
+	k_ssize_t ret;
 
 	stream_allocated = stream;
 	mock_bap_unicast_server_cb_config_fake.custom_fake = unicast_server_cb_config_custom_fake;
@@ -190,7 +190,7 @@ void test_ase_control_client_config_qos(struct bt_conn *conn, uint8_t ase_id)
 		0x0A, 0x00,             /* Max_Transport_Latency[0] */
 		0x40, 0x9C, 0x00,       /* Presentation_Delay[0] */
 	};
-	ssize_t ret;
+	k_ssize_t ret;
 
 	ret = attr->write(conn, attr, (void *)buf, sizeof(buf), 0, 0);
 	zassert_false(ret < 0, "attr->write returned unexpected (err 0x%02x)", BT_GATT_ERR(ret));
@@ -205,7 +205,7 @@ void test_ase_control_client_enable(struct bt_conn *conn, uint8_t ase_id)
 		ase_id,                 /* ASE_ID[0] */
 		0x00,                   /* Metadata_Length[0] */
 	};
-	ssize_t ret;
+	k_ssize_t ret;
 
 	ret = attr->write(conn, attr, (void *)buf, sizeof(buf), 0, 0);
 	zassert_false(ret < 0, "attr->write returned unexpected (err 0x%02x)", BT_GATT_ERR(ret));
@@ -219,7 +219,7 @@ void test_ase_control_client_disable(struct bt_conn *conn, uint8_t ase_id)
 		0x01,                   /* Number_of_ASEs */
 		ase_id,                 /* ASE_ID[0] */
 	};
-	ssize_t ret;
+	k_ssize_t ret;
 
 	ret = attr->write(conn, attr, (void *)buf, sizeof(buf), 0, 0);
 	zassert_false(ret < 0, "attr->write returned unexpected (err 0x%02x)", BT_GATT_ERR(ret));
@@ -233,7 +233,7 @@ void test_ase_control_client_release(struct bt_conn *conn, uint8_t ase_id)
 		0x01,                   /* Number_of_ASEs */
 		ase_id,                 /* ASE_ID[0] */
 	};
-	ssize_t ret;
+	k_ssize_t ret;
 
 	ret = attr->write(conn, attr, (void *)buf, sizeof(buf), 0, 0);
 	zassert_false(ret < 0, "attr->write returned unexpected (err 0x%02x)", BT_GATT_ERR(ret));
@@ -249,7 +249,7 @@ void test_ase_control_client_update_metadata(struct bt_conn *conn, uint8_t ase_i
 		0x04,                   /* Metadata_Length[0] */
 		0x03, 0x02, 0x04, 0x00, /* Metadata[0] = Streaming Context (Media) */
 	};
-	ssize_t ret;
+	k_ssize_t ret;
 
 	ret = attr->write(conn, attr, (void *)buf, sizeof(buf), 0, 0);
 	zassert_false(ret < 0, "attr->write returned unexpected (err 0x%02x)", BT_GATT_ERR(ret));
@@ -263,7 +263,7 @@ void test_ase_control_client_receiver_start_ready(struct bt_conn *conn, uint8_t 
 		0x01,                   /* Number_of_ASEs */
 		ase_id,                 /* ASE_ID[0] */
 	};
-	ssize_t ret;
+	k_ssize_t ret;
 
 	ret = attr->write(conn, attr, (void *)buf, sizeof(buf), 0, 0);
 	zassert_false(ret < 0, "attr->write returned unexpected (err 0x%02x)", BT_GATT_ERR(ret));
@@ -277,7 +277,7 @@ void test_ase_control_client_receiver_stop_ready(struct bt_conn *conn, uint8_t a
 		0x01,                   /* Number_of_ASEs */
 		ase_id,                 /* ASE_ID[0] */
 	};
-	ssize_t ret;
+	k_ssize_t ret;
 
 	ret = attr->write(conn, attr, (void *)buf, sizeof(buf), 0, 0);
 	zassert_false(ret < 0, "attr->write returned unexpected (err 0x%02x)", BT_GATT_ERR(ret));

--- a/tests/bluetooth/gatt/src/main.c
+++ b/tests/bluetooth/gatt/src/main.c
@@ -39,8 +39,8 @@ static void test1_ccc_cfg_changed(const struct bt_gatt_attr *attr, uint16_t valu
 	nfy_enabled = (value == BT_GATT_CCC_NOTIFY) ? 1 : 0;
 }
 
-static ssize_t read_test(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-			void *buf, uint16_t len, uint16_t offset)
+static k_ssize_t read_test(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
+			   uint16_t len, uint16_t offset)
 {
 	const char *value = attr->user_data;
 
@@ -48,9 +48,8 @@ static ssize_t read_test(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 				 strlen(value));
 }
 
-static ssize_t write_test(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-			 const void *buf, uint16_t len, uint16_t offset,
-			 uint8_t flags)
+static k_ssize_t write_test(struct bt_conn *conn, const struct bt_gatt_attr *attr, const void *buf,
+			    uint16_t len, uint16_t offset, uint8_t flags)
 {
 	uint8_t *value = attr->user_data;
 
@@ -234,7 +233,7 @@ ZTEST(test_gatt, test_gatt_read)
 {
 	const struct bt_gatt_attr *attr;
 	uint8_t buf[256];
-	ssize_t ret;
+	k_ssize_t ret;
 
 	/* Find attribute by UUID */
 	attr = NULL;
@@ -256,7 +255,7 @@ ZTEST(test_gatt, test_gatt_write)
 {
 	const struct bt_gatt_attr *attr;
 	char *value = "    ";
-	ssize_t ret;
+	k_ssize_t ret;
 
 	/* Need our service to be registered */
 	zassert_false(bt_gatt_service_register(&test_svc),

--- a/tests/bluetooth/mesh/blob_io_flash/src/main.c
+++ b/tests/bluetooth/mesh/blob_io_flash/src/main.c
@@ -52,7 +52,7 @@ ZTEST(blob_io_flash, test_chunk_read)
 	struct bt_mesh_blob_block block = { 0 };
 	struct bt_mesh_blob_chunk chunk = { 0 };
 	size_t remaining = SLOT1_PARTITION_SIZE;
-	off_t block_idx = 0;
+	k_off_t block_idx = 0;
 	uint16_t chunk_idx = 0;
 	uint8_t chunk_data[CHUNK_SIZE];
 	uint8_t test_data[SLOT1_PARTITION_SIZE];
@@ -162,7 +162,7 @@ ZTEST(blob_io_flash, test_chunk_write)
 	struct bt_mesh_blob_block block = { 0 };
 	struct bt_mesh_blob_chunk chunk = { 0 };
 	size_t remaining = SLOT1_PARTITION_SIZE;
-	off_t block_idx = 0;
+	k_off_t block_idx = 0;
 	uint16_t chunk_idx = 0;
 	uint8_t chunk_data[CHUNK_SIZE];
 	/* 3 is maximum length of padding at the end of written chunk */

--- a/tests/bluetooth/tester/src/btp/bttester.h
+++ b/tests/bluetooth/tester/src/btp/bttester.h
@@ -44,7 +44,7 @@ void tester_rsp_buffer_allocate(size_t len, uint8_t **data);
 struct btp_handler {
 	uint8_t opcode;
 	uint8_t index;
-	ssize_t expect_len;
+	k_ssize_t expect_len;
 	uint8_t (*func)(const void *cmd, uint16_t cmd_len,
 			void *rsp, uint16_t *rsp_len);
 };

--- a/tests/bluetooth/tester/src/btp_gatt.c
+++ b/tests/bluetooth/tester/src/btp_gatt.c
@@ -352,7 +352,7 @@ enum {
 	GATT_VALUE_WRITE_AUTHOR_FLAG,
 };
 
-static ssize_t read_value(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t read_value(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			  void *buf, uint16_t len, uint16_t offset)
 {
 	const struct gatt_value *value = attr->user_data;
@@ -383,7 +383,7 @@ static void attr_value_changed_ev(uint16_t handle, const uint8_t *value, uint16_
 		    buf, sizeof(buf));
 }
 
-static ssize_t write_value(struct bt_conn *conn,
+static k_ssize_t write_value(struct bt_conn *conn,
 			   const struct bt_gatt_attr *attr, const void *buf,
 			   uint16_t len, uint16_t offset, uint8_t flags)
 {
@@ -2266,7 +2266,7 @@ static uint8_t get_attr_val_rp(const struct bt_gatt_attr *attr, uint16_t handle,
 	struct net_buf_simple *buf = u_data->buf;
 	struct bt_conn *conn = u_data->conn;
 	struct btp_gatt_get_attribute_value_rp *rp;
-	ssize_t read, to_read;
+	k_ssize_t read, to_read;
 
 	rp = net_buf_simple_add(buf, sizeof(*rp));
 	rp->value_length = 0x0000;

--- a/tests/bluetooth/tester/src/btp_ots.c
+++ b/tests/bluetooth/tester/src/btp_ots.c
@@ -214,9 +214,8 @@ static void ots_obj_selected(struct bt_ots *ots, struct bt_conn *conn,
 	LOG_DBG("id=%"PRIu64, id);
 }
 
-static ssize_t ots_obj_read(struct bt_ots *ots, struct bt_conn *conn,
-			    uint64_t id, void **data, size_t len,
-			    off_t offset)
+static k_ssize_t ots_obj_read(struct bt_ots *ots, struct bt_conn *conn, uint64_t id, void **data,
+			      size_t len, k_off_t offset)
 {
 	uint32_t obj_index = OTS_OBJ_ID_TO_OBJ_IDX(id);
 
@@ -235,9 +234,8 @@ static ssize_t ots_obj_read(struct bt_ots *ots, struct bt_conn *conn,
 	return len;
 }
 
-static ssize_t ots_obj_write(struct bt_ots *ots, struct bt_conn *conn,
-			     uint64_t id, const void *data, size_t len,
-			     off_t offset, size_t rem)
+static k_ssize_t ots_obj_write(struct bt_ots *ots, struct bt_conn *conn, uint64_t id,
+			       const void *data, size_t len, k_off_t offset, size_t rem)
 {
 	uint32_t obj_index = OTS_OBJ_ID_TO_OBJ_IDX(id);
 
@@ -259,7 +257,7 @@ static void ots_obj_name_written(struct bt_ots *ots, struct bt_conn *conn,
 }
 
 static int ots_obj_cal_checksum(struct bt_ots *ots, struct bt_conn *conn, uint64_t id,
-				off_t offset, size_t len, void **data)
+				k_off_t offset, size_t len, void **data)
 {
 	uint32_t obj_index = OTS_OBJ_ID_TO_OBJ_IDX(id);
 

--- a/tests/boards/espressif_esp32/cache_coex/src/cache_coex.c
+++ b/tests/boards/espressif_esp32/cache_coex/src/cache_coex.c
@@ -74,7 +74,7 @@ static void check_flash(void)
 	unfinished_tasks = false;
 }
 
-static int do_erase(off_t offset, size_t size)
+static int do_erase(k_off_t offset, size_t size)
 {
 	int rc;
 

--- a/tests/bsim/bluetooth/host/att/long_read/main.c
+++ b/tests/bsim/bluetooth/host/att/long_read/main.c
@@ -36,10 +36,10 @@ LOG_MODULE_REGISTER(main, LOG_LEVEL_DBG);
 	BT_UUID_DECLARE_128(0x3f, 0xa4, 0x7f, 0x44, 0x2e, 0x2a, 0x43, 0x05, 0xab, 0x38, 0x07,      \
 			    0x8d, 0x16, 0xbf, 0x99, 0xf1)
 
-static ssize_t read_mtu_validation_chrc(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t read_mtu_validation_chrc(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 					void *buf, uint16_t buf_len, uint16_t offset)
 {
-	ssize_t read_len;
+	k_ssize_t read_len;
 
 	LOG_INF("Server side buf_len %u", buf_len);
 

--- a/tests/bsim/bluetooth/host/att/open_close/src/main.c
+++ b/tests/bsim/bluetooth/host/att/open_close/src/main.c
@@ -36,7 +36,7 @@ LOG_MODULE_REGISTER(main, LOG_LEVEL_DBG);
 	BT_UUID_DECLARE_128(0x3f, 0xa4, 0x7f, 0x44, 0x2e, 0x2a, 0x43, 0x05, 0xab, 0x38, 0x07,      \
 			    0x8d, 0x16, 0xbf, 0x99, 0xf1)
 
-static ssize_t read_mtu_validation_chrc(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t read_mtu_validation_chrc(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 					void *buf, uint16_t buf_len, uint16_t offset)
 {
 

--- a/tests/bsim/bluetooth/host/att/pipeline/dut/src/main.c
+++ b/tests/bsim/bluetooth/host/att/pipeline/dut/src/main.c
@@ -167,7 +167,7 @@ static struct bt_conn *connect(void)
 	return conn;
 }
 
-static ssize_t read_from(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t read_from(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			 void *buf, uint16_t buf_len, uint16_t offset)
 {
 	static uint16_t counter;
@@ -183,7 +183,7 @@ static ssize_t read_from(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 	return sizeof(uint16_t);
 }
 
-static ssize_t written_to(struct bt_conn *conn,
+static k_ssize_t written_to(struct bt_conn *conn,
 			  const struct bt_gatt_attr *attr,
 			  const void *buf,
 			  uint16_t len,

--- a/tests/bsim/bluetooth/host/att/read_fill_buf/server/main.c
+++ b/tests/bsim/bluetooth/host/att/read_fill_buf/server/main.c
@@ -15,7 +15,7 @@
 
 LOG_MODULE_REGISTER(server, LOG_LEVEL_DBG);
 
-static ssize_t read_mtu_validation_chrc(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t read_mtu_validation_chrc(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 					void *buf, uint16_t buf_len, uint16_t offset)
 {
 	LOG_INF("buf_len %u", buf_len);

--- a/tests/bsim/bluetooth/host/att/retry_on_sec_err/server/main.c
+++ b/tests/bsim/bluetooth/host/att/retry_on_sec_err/server/main.c
@@ -17,7 +17,7 @@
 
 LOG_MODULE_REGISTER(server, LOG_LEVEL_DBG);
 
-static ssize_t read_chrc(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
+static k_ssize_t read_chrc(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
 			 uint16_t buf_len, uint16_t offset)
 {
 	return 0;

--- a/tests/bsim/bluetooth/host/att/sequential/dut/src/main.c
+++ b/tests/bsim/bluetooth/host/att/sequential/dut/src/main.c
@@ -142,7 +142,7 @@ static void connect(void)
 	/* No security support on the tinyhost unfortunately */
 }
 
-static ssize_t written_to(struct bt_conn *conn,
+static k_ssize_t written_to(struct bt_conn *conn,
 			  const struct bt_gatt_attr *attr,
 			  const void *buf,
 			  uint16_t len,

--- a/tests/bsim/bluetooth/host/gatt/authorization/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/gatt/authorization/src/gatt_server_test.c
@@ -58,7 +58,7 @@ struct test_chrc_ctx {
 	uint8_t data[CHRC_SIZE];
 };
 
-static ssize_t read_test_chrc(struct test_chrc_ctx *chrc_ctx,
+static k_ssize_t read_test_chrc(struct test_chrc_ctx *chrc_ctx,
 			      struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr,
 			      void *buf, uint16_t len, uint16_t offset)
@@ -70,7 +70,7 @@ static ssize_t read_test_chrc(struct test_chrc_ctx *chrc_ctx,
 				 sizeof(chrc_ctx->data));
 }
 
-static ssize_t write_test_chrc(struct test_chrc_ctx *chrc_ctx,
+static k_ssize_t write_test_chrc(struct test_chrc_ctx *chrc_ctx,
 			       const void *buf, uint16_t len,
 			       uint16_t offset, uint8_t flags)
 {
@@ -98,14 +98,14 @@ static ssize_t write_test_chrc(struct test_chrc_ctx *chrc_ctx,
 
 static struct test_chrc_ctx unhandled_chrc_ctx;
 
-static ssize_t read_test_unhandled_chrc(struct bt_conn *conn,
+static k_ssize_t read_test_unhandled_chrc(struct bt_conn *conn,
 					 const struct bt_gatt_attr *attr,
 					 void *buf, uint16_t len, uint16_t offset)
 {
 	return read_test_chrc(&unhandled_chrc_ctx, conn, attr, buf, len, offset);
 }
 
-static ssize_t write_test_unhandled_chrc(struct bt_conn *conn,
+static k_ssize_t write_test_unhandled_chrc(struct bt_conn *conn,
 					  const struct bt_gatt_attr *attr,
 					  const void *buf, uint16_t len,
 					  uint16_t offset, uint8_t flags)
@@ -117,14 +117,14 @@ static ssize_t write_test_unhandled_chrc(struct bt_conn *conn,
 
 static struct test_chrc_ctx unauthorized_chrc_ctx;
 
-static ssize_t read_test_unauthorized_chrc(struct bt_conn *conn,
+static k_ssize_t read_test_unauthorized_chrc(struct bt_conn *conn,
 					   const struct bt_gatt_attr *attr,
 					   void *buf, uint16_t len, uint16_t offset)
 {
 	return read_test_chrc(&unauthorized_chrc_ctx, conn, attr, buf, len, offset);
 }
 
-static ssize_t write_test_unauthorized_chrc(struct bt_conn *conn,
+static k_ssize_t write_test_unauthorized_chrc(struct bt_conn *conn,
 					    const struct bt_gatt_attr *attr,
 					    const void *buf, uint16_t len,
 					    uint16_t offset, uint8_t flags)
@@ -136,14 +136,14 @@ static ssize_t write_test_unauthorized_chrc(struct bt_conn *conn,
 
 static struct test_chrc_ctx authorized_chrc_ctx;
 
-static ssize_t read_test_authorized_chrc(struct bt_conn *conn,
+static k_ssize_t read_test_authorized_chrc(struct bt_conn *conn,
 					 const struct bt_gatt_attr *attr,
 					 void *buf, uint16_t len, uint16_t offset)
 {
 	return read_test_chrc(&authorized_chrc_ctx, conn, attr, buf, len, offset);
 }
 
-static ssize_t write_test_authorized_chrc(struct bt_conn *conn,
+static k_ssize_t write_test_authorized_chrc(struct bt_conn *conn,
 					  const struct bt_gatt_attr *attr,
 					  const void *buf, uint16_t len,
 					  uint16_t offset, uint8_t flags)
@@ -221,7 +221,7 @@ static bool authorized_chrc_operation_validate(void)
 	return true;
 }
 
-static ssize_t write_cp_chrc(struct bt_conn *conn,
+static k_ssize_t write_cp_chrc(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr,
 			     const void *buf, uint16_t len,
 			     uint16_t offset, uint8_t flags)

--- a/tests/bsim/bluetooth/host/gatt/caching/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/gatt/caching/src/gatt_server_test.c
@@ -66,7 +66,7 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 #define ARRAY_ITEM(i, _) i
 static const uint8_t chrc_data[] = { LISTIFY(CHRC_SIZE, ARRAY_ITEM, (,)) }; /* 1, 2, 3 ... */
 
-static ssize_t read_test_chrc(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
+static k_ssize_t read_test_chrc(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
 			      uint16_t len, uint16_t offset)
 {
 	printk("Characteristic read\n");

--- a/tests/bsim/bluetooth/host/gatt/general/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/gatt/general/src/gatt_server_test.c
@@ -55,7 +55,7 @@ static struct bt_conn_cb conn_callbacks = {
 static uint8_t chrc_data[CHRC_SIZE];
 static uint8_t long_chrc_data[LONG_CHRC_SIZE];
 
-static ssize_t read_test_chrc(struct bt_conn *conn,
+static k_ssize_t read_test_chrc(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr,
 			      void *buf, uint16_t len, uint16_t offset)
 {
@@ -63,7 +63,7 @@ static ssize_t read_test_chrc(struct bt_conn *conn,
 				 (void *)chrc_data, sizeof(chrc_data));
 }
 
-static ssize_t write_test_chrc(struct bt_conn *conn,
+static k_ssize_t write_test_chrc(struct bt_conn *conn,
 			       const struct bt_gatt_attr *attr,
 			       const void *buf, uint16_t len,
 			       uint16_t offset, uint8_t flags)
@@ -88,7 +88,7 @@ static ssize_t write_test_chrc(struct bt_conn *conn,
 	return len;
 }
 
-static ssize_t read_long_test_chrc(struct bt_conn *conn,
+static k_ssize_t read_long_test_chrc(struct bt_conn *conn,
 				   const struct bt_gatt_attr *attr,
 				   void *buf, uint16_t len, uint16_t offset)
 {
@@ -96,7 +96,7 @@ static ssize_t read_long_test_chrc(struct bt_conn *conn,
 				 (void *)long_chrc_data, sizeof(long_chrc_data));
 }
 
-static ssize_t write_long_test_chrc(struct bt_conn *conn,
+static k_ssize_t write_long_test_chrc(struct bt_conn *conn,
 				    const struct bt_gatt_attr *attr,
 				    const void *buf, uint16_t len,
 				    uint16_t offset, uint8_t flags)

--- a/tests/bsim/bluetooth/host/gatt/notify/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/gatt/notify/src/gatt_server_test.c
@@ -58,16 +58,16 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.disconnected = disconnected,
 };
 
-static ssize_t read_test_chrc(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
-			      uint16_t len, uint16_t offset)
+static k_ssize_t read_test_chrc(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
+				uint16_t len, uint16_t offset)
 {
 	printk("Read short\n");
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, (void *)chrc_data,
 				 sizeof(chrc_data));
 }
 
-static ssize_t read_long_test_chrc(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
-				   uint16_t len, uint16_t offset)
+static k_ssize_t read_long_test_chrc(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+				     void *buf, uint16_t len, uint16_t offset)
 {
 	printk("Read long\n");
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, (void *)long_chrc_data,

--- a/tests/bsim/bluetooth/host/gatt/settings/src/gatt_utils.c
+++ b/tests/bsim/bluetooth/host/gatt/settings/src/gatt_utils.c
@@ -30,7 +30,7 @@ static uint8_t test_value[] = { 'T', 'e', 's', 't', '\0' };
 
 DEFINE_FLAG(flag_client_read);
 
-static ssize_t read_test(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t read_test(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			void *buf, uint16_t len, uint16_t offset)
 {
 	const char *value = attr->user_data;
@@ -47,7 +47,7 @@ void wait_for_client_read(void)
 	WAIT_FOR_FLAG(flag_client_read);
 }
 
-static ssize_t write_test(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+static k_ssize_t write_test(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			 const void *buf, uint16_t len, uint16_t offset,
 			 uint8_t flags)
 {

--- a/tests/bsim/bluetooth/host/gatt/settings/src/settings.c
+++ b/tests/bsim/bluetooth/host/gatt/settings/src/settings.c
@@ -54,7 +54,7 @@ static int entry_check_and_copy(FILE *fin, FILE *fout, const char *name)
 	return 0;
 }
 
-static ssize_t settings_line_read_cb(void *cb_arg, void *data, size_t len)
+static k_ssize_t settings_line_read_cb(void *cb_arg, void *data, size_t len)
 {
 	struct line_read_ctx *valctx = (struct line_read_ctx *)cb_arg;
 

--- a/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/src/main.c
@@ -88,7 +88,7 @@ void sent_cb(struct bt_l2cap_chan *chan)
 	continue_sending(&test_ctx);
 }
 
-void recv_cb(struct bt_l2cap_chan *l2cap_chan, size_t sdu_len, off_t seg_offset,
+void recv_cb(struct bt_l2cap_chan *l2cap_chan, size_t sdu_len, k_off_t seg_offset,
 	     struct net_buf_simple *seg)
 {
 	LOG_DBG("sdu len %u frag offset %u frag len %u", sdu_len, seg_offset, seg->len);

--- a/tests/bsim/bluetooth/host/misc/disable/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/misc/disable/src/gatt_server_test.c
@@ -47,7 +47,7 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 static uint8_t chrc_data[CHRC_SIZE];
 static uint8_t long_chrc_data[LONG_CHRC_SIZE];
 
-static ssize_t read_test_chrc(struct bt_conn *conn,
+static k_ssize_t read_test_chrc(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr,
 			      void *buf, uint16_t len, uint16_t offset)
 {
@@ -55,7 +55,7 @@ static ssize_t read_test_chrc(struct bt_conn *conn,
 				 (void *)chrc_data, sizeof(chrc_data));
 }
 
-static ssize_t write_test_chrc(struct bt_conn *conn,
+static k_ssize_t write_test_chrc(struct bt_conn *conn,
 			       const struct bt_gatt_attr *attr,
 			       const void *buf, uint16_t len,
 			       uint16_t offset, uint8_t flags)
@@ -80,7 +80,7 @@ static ssize_t write_test_chrc(struct bt_conn *conn,
 	return len;
 }
 
-static ssize_t read_long_test_chrc(struct bt_conn *conn,
+static k_ssize_t read_long_test_chrc(struct bt_conn *conn,
 				   const struct bt_gatt_attr *attr,
 				   void *buf, uint16_t len, uint16_t offset)
 {
@@ -88,7 +88,7 @@ static ssize_t read_long_test_chrc(struct bt_conn *conn,
 				 (void *)long_chrc_data, sizeof(long_chrc_data));
 }
 
-static ssize_t write_long_test_chrc(struct bt_conn *conn,
+static k_ssize_t write_long_test_chrc(struct bt_conn *conn,
 				    const struct bt_gatt_attr *attr,
 				    const void *buf, uint16_t len,
 				    uint16_t offset, uint8_t flags)

--- a/tests/bsim/bluetooth/host/security/id_addr_update/peripheral/src/utils.c
+++ b/tests/bsim/bluetooth/host/security/id_addr_update/peripheral/src/utils.c
@@ -180,7 +180,7 @@ void wait_bas_ccc_subscription(void)
 	UNSET_FLAG(flag_bas_ccc_subscribed);
 }
 
-static ssize_t bas_read(struct bt_conn *conn,
+static k_ssize_t bas_read(struct bt_conn *conn,
 			const struct bt_gatt_attr *attr, void *buf,
 			uint16_t len, uint16_t offset)
 {

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_a_1.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_a_1.c
@@ -101,7 +101,7 @@ static uint8_t   value_v3_value = 0x03;
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v1(struct bt_conn *conn,
+static k_ssize_t read_value_v1(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr, void *buf,
 			     uint16_t len, uint16_t offset)
 {
@@ -123,7 +123,7 @@ static ssize_t read_value_v1(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_str_value(struct bt_conn *conn,
+static k_ssize_t read_str_value(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, void *buf,
 			      uint16_t len, uint16_t offset)
 {
@@ -146,7 +146,7 @@ static ssize_t read_str_value(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v2(struct bt_conn *conn,
+static k_ssize_t write_value_v2(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, const void *buf,
 			      uint16_t len, uint16_t offset, uint8_t flags)
 {
@@ -175,7 +175,7 @@ static ssize_t write_value_v2(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v2_1(struct bt_conn *conn,
+static k_ssize_t write_value_v2_1(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr,
 				const void *buf, uint16_t len, uint16_t offset,
 				uint8_t flags)
@@ -205,7 +205,7 @@ static ssize_t write_value_v2_1(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v3(struct bt_conn *conn,
+static k_ssize_t write_value_v3(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, const void *buf,
 			      uint16_t len, uint16_t offset, uint8_t flags)
 {

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_a_2.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_a_2.c
@@ -60,7 +60,7 @@ static uint8_t   value_v3_value = 0x03;
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v1(struct bt_conn *conn,
+static k_ssize_t read_value_v1(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr, void *buf,
 			     uint16_t len, uint16_t offset)
 {
@@ -82,7 +82,7 @@ static ssize_t read_value_v1(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_str_value(struct bt_conn *conn,
+static k_ssize_t read_str_value(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, void *buf,
 			      uint16_t len, uint16_t offset)
 {
@@ -105,7 +105,7 @@ static ssize_t read_str_value(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v2(struct bt_conn *conn,
+static k_ssize_t write_value_v2(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, const void *buf,
 			      uint16_t len, uint16_t offset, uint8_t flags)
 {
@@ -134,7 +134,7 @@ static ssize_t write_value_v2(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v3(struct bt_conn *conn,
+static k_ssize_t write_value_v3(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, const void *buf,
 			      uint16_t len, uint16_t offset, uint8_t flags)
 {

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_a_3.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_a_3.c
@@ -60,7 +60,7 @@ static uint8_t   value_v3_value = 0x03;
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v1(struct bt_conn *conn,
+static k_ssize_t read_value_v1(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr, void *buf,
 			     uint16_t len, uint16_t offset)
 {
@@ -82,7 +82,7 @@ static ssize_t read_value_v1(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_str_value(struct bt_conn *conn,
+static k_ssize_t read_str_value(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, void *buf,
 			      uint16_t len, uint16_t offset)
 {
@@ -105,7 +105,7 @@ static ssize_t read_str_value(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v2(struct bt_conn *conn,
+static k_ssize_t write_value_v2(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, const void *buf,
 			      uint16_t len, uint16_t offset, uint8_t flags)
 {
@@ -134,7 +134,7 @@ static ssize_t write_value_v2(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v3(struct bt_conn *conn,
+static k_ssize_t write_value_v3(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, const void *buf,
 			      uint16_t len, uint16_t offset, uint8_t flags)
 {

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_1_1.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_1_1.c
@@ -66,7 +66,7 @@ static uint8_t   long_des_v2d1_1_value[] = {
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v4(struct bt_conn *conn,
+static k_ssize_t read_value_v4(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr, void *buf,
 			     uint16_t len, uint16_t offset)
 {
@@ -89,7 +89,7 @@ static ssize_t read_value_v4(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v4(struct bt_conn *conn,
+static k_ssize_t write_value_v4(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, const void *buf,
 			      uint16_t len, uint16_t offset, uint8_t flags)
 {
@@ -117,7 +117,7 @@ static ssize_t write_value_v4(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v4_1(struct bt_conn *conn,
+static k_ssize_t read_value_v4_1(struct bt_conn *conn,
 			       const struct bt_gatt_attr *attr, void *buf,
 			       uint16_t len, uint16_t offset)
 {
@@ -140,7 +140,7 @@ static ssize_t read_value_v4_1(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v4_1(struct bt_conn *conn,
+static k_ssize_t write_value_v4_1(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr,
 				const void *buf, uint16_t len, uint16_t offset,
 				uint8_t flags)
@@ -170,7 +170,7 @@ static ssize_t write_value_v4_1(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_server_cha_con(struct bt_conn *conn,
+static k_ssize_t read_server_cha_con(struct bt_conn *conn,
 				   const struct bt_gatt_attr *attr, void *buf,
 				   uint16_t len, uint16_t offset)
 {
@@ -196,7 +196,7 @@ static ssize_t read_server_cha_con(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_server_cha_con(struct bt_conn *conn,
+static k_ssize_t write_server_cha_con(struct bt_conn *conn,
 				    const struct bt_gatt_attr *attr,
 				    const void *buf, uint16_t len, uint16_t offset,
 				    uint8_t flags)
@@ -228,7 +228,7 @@ static ssize_t write_server_cha_con(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v4_3(struct bt_conn *conn,
+static k_ssize_t read_value_v4_3(struct bt_conn *conn,
 			       const struct bt_gatt_attr *attr, void *buf,
 			       uint16_t len, uint16_t offset)
 {
@@ -250,7 +250,7 @@ static ssize_t read_value_v4_3(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_long_des_v2d1_1(struct bt_conn *conn,
+static k_ssize_t read_long_des_v2d1_1(struct bt_conn *conn,
 				    const struct bt_gatt_attr *attr, void *buf,
 				    uint16_t len, uint16_t offset)
 {

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_1_2.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_1_2.c
@@ -40,7 +40,7 @@ static uint8_t   value_v4_value = 0x04;
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v4(struct bt_conn *conn,
+static k_ssize_t read_value_v4(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr, void *buf,
 			     uint16_t len, uint16_t offset)
 {
@@ -63,7 +63,7 @@ static ssize_t read_value_v4(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v4(struct bt_conn *conn,
+static k_ssize_t write_value_v4(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, const void *buf,
 			      uint16_t len, uint16_t offset, uint8_t flags)
 {

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_1_3.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_1_3.c
@@ -40,7 +40,7 @@ static uint8_t   value_v4_value = 0x04;
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v4(struct bt_conn *conn,
+static k_ssize_t read_value_v4(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr, void *buf,
 			     uint16_t len, uint16_t offset)
 {
@@ -63,7 +63,7 @@ static ssize_t read_value_v4(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v4(struct bt_conn *conn,
+static k_ssize_t write_value_v4(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, const void *buf,
 			      uint16_t len, uint16_t offset, uint8_t flags)
 {

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_2_1.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_2_1.c
@@ -58,7 +58,7 @@ static bool   bAuthorized;
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v5(struct bt_conn *conn,
+static k_ssize_t read_value_v5(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr, void *buf,
 			     uint16_t len, uint16_t offset)
 {
@@ -81,7 +81,7 @@ static ssize_t read_value_v5(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v5(struct bt_conn *conn,
+static k_ssize_t write_value_v5(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, const void *buf,
 			      uint16_t len, uint16_t offset, uint8_t flags)
 {
@@ -112,7 +112,7 @@ static ssize_t write_value_v5(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_des_v5d4__128_bit_uuid(struct bt_conn *conn,
+static k_ssize_t read_des_v5d4__128_bit_uuid(struct bt_conn *conn,
 					   const struct bt_gatt_attr *attr,
 					   void *buf, uint16_t len, uint16_t offset)
 {

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_2_2.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_2_2.c
@@ -57,7 +57,7 @@ static const struct bt_gatt_cpf cha_format_value = {
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v5(struct bt_conn *conn,
+static k_ssize_t read_value_v5(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr, void *buf,
 			     uint16_t len, uint16_t offset)
 {
@@ -80,7 +80,7 @@ static ssize_t read_value_v5(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v5(struct bt_conn *conn,
+static k_ssize_t write_value_v5(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, const void *buf,
 			      uint16_t len, uint16_t offset, uint8_t flags)
 {
@@ -109,7 +109,7 @@ static ssize_t write_value_v5(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_des_v5d4__128_bit_uuid(struct bt_conn *conn,
+static k_ssize_t read_des_v5d4__128_bit_uuid(struct bt_conn *conn,
 					   const struct bt_gatt_attr *attr,
 					   void *buf, uint16_t len, uint16_t offset)
 {

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_2_3.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_2_3.c
@@ -57,7 +57,7 @@ static const struct bt_gatt_cpf cha_format_value = {
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v5(struct bt_conn *conn,
+static k_ssize_t read_value_v5(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr, void *buf,
 			     uint16_t len, uint16_t offset)
 {
@@ -80,7 +80,7 @@ static ssize_t read_value_v5(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v5(struct bt_conn *conn,
+static k_ssize_t write_value_v5(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, const void *buf,
 			      uint16_t len, uint16_t offset, uint8_t flags)
 {
@@ -109,7 +109,7 @@ static ssize_t write_value_v5(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_des_v5d4__128_bit_uuid(struct bt_conn *conn,
+static k_ssize_t read_des_v5d4__128_bit_uuid(struct bt_conn *conn,
 					   const struct bt_gatt_attr *attr,
 					   void *buf, uint16_t len, uint16_t offset)
 {

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_3_1.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_3_1.c
@@ -41,7 +41,7 @@ static bool   value_v6_ntf_active;
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v6(struct bt_conn *conn,
+static k_ssize_t read_value_v6(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr, void *buf,
 			     uint16_t len, uint16_t offset)
 {
@@ -64,7 +64,7 @@ static ssize_t read_value_v6(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v6(struct bt_conn *conn,
+static k_ssize_t write_value_v6(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, const void *buf,
 			      uint16_t len, uint16_t offset, uint8_t flags)
 {

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_3_2.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_3_2.c
@@ -43,7 +43,7 @@ static bool   value_v6_ind_active;
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v6(struct bt_conn *conn,
+static k_ssize_t read_value_v6(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr, void *buf,
 			     uint16_t len, uint16_t offset)
 {
@@ -66,7 +66,7 @@ static ssize_t read_value_v6(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v6(struct bt_conn *conn,
+static k_ssize_t write_value_v6(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, const void *buf,
 			      uint16_t len, uint16_t offset, uint8_t flags)
 {

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_3_3.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_3_3.c
@@ -43,7 +43,7 @@ static bool   value_v6_ind_active;
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v6(struct bt_conn *conn,
+static k_ssize_t read_value_v6(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr, void *buf,
 			     uint16_t len, uint16_t offset)
 {
@@ -66,7 +66,7 @@ static ssize_t read_value_v6(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v6(struct bt_conn *conn,
+static k_ssize_t write_value_v6(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, const void *buf,
 			      uint16_t len, uint16_t offset, uint8_t flags)
 {

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_4_1.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_4_1.c
@@ -41,7 +41,7 @@ static uint8_t   value_v7_value = 0x07;
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v7(struct bt_conn *conn,
+static k_ssize_t write_value_v7(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, const void *buf,
 			      uint16_t len, uint16_t offset, uint8_t flags)
 {

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_4_2.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_4_2.c
@@ -41,7 +41,7 @@ static uint8_t   value_v7_value = 0x07;
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v7(struct bt_conn *conn,
+static k_ssize_t write_value_v7(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, const void *buf,
 			      uint16_t len, uint16_t offset, uint8_t flags)
 {

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_4_3.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_4_3.c
@@ -41,7 +41,7 @@ static uint8_t   value_v7_value = 0x07;
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v7(struct bt_conn *conn,
+static k_ssize_t write_value_v7(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, const void *buf,
 			      uint16_t len, uint16_t offset, uint8_t flags)
 {

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_5_1.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_5_1.c
@@ -59,7 +59,7 @@ static bool   bAuthorized;
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v8(struct bt_conn *conn,
+static k_ssize_t read_value_v8(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr, void *buf,
 			     uint16_t len, uint16_t offset)
 {
@@ -82,7 +82,7 @@ static ssize_t read_value_v8(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v8(struct bt_conn *conn,
+static k_ssize_t write_value_v8(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, const void *buf,
 			      uint16_t len, uint16_t offset, uint8_t flags)
 {
@@ -110,7 +110,7 @@ static ssize_t write_value_v8(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_des_v8d1(struct bt_conn *conn,
+static k_ssize_t read_des_v8d1(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr, void *buf,
 			     uint16_t len, uint16_t offset)
 {
@@ -133,7 +133,7 @@ static ssize_t read_des_v8d1(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_des_v8d1(struct bt_conn *conn,
+static k_ssize_t write_des_v8d1(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, const void *buf,
 			      uint16_t len, uint16_t offset, uint8_t flags)
 {
@@ -161,7 +161,7 @@ static ssize_t write_des_v8d1(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_des_v8d2(struct bt_conn *conn,
+static k_ssize_t read_des_v8d2(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr, void *buf,
 			     uint16_t len, uint16_t offset)
 {
@@ -187,7 +187,7 @@ static ssize_t read_des_v8d2(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_des_v8d2(struct bt_conn *conn,
+static k_ssize_t write_des_v8d2(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, const void *buf,
 			      uint16_t len, uint16_t offset, uint8_t flags)
 {
@@ -217,7 +217,7 @@ static ssize_t write_des_v8d2(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_des_v8d3(struct bt_conn *conn,
+static k_ssize_t read_des_v8d3(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr, void *buf,
 			     uint16_t len, uint16_t offset)
 {
@@ -240,7 +240,7 @@ static ssize_t read_des_v8d3(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_des_v8d3(struct bt_conn *conn,
+static k_ssize_t write_des_v8d3(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, const void *buf,
 			      uint16_t len, uint16_t offset, uint8_t flags)
 {

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_5_2.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_5_2.c
@@ -40,7 +40,7 @@ static uint8_t   value_v8_value = 0x08;
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v8(struct bt_conn *conn,
+static k_ssize_t read_value_v8(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr, void *buf,
 			     uint16_t len, uint16_t offset)
 {

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_5_3.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_5_3.c
@@ -40,7 +40,7 @@ static uint8_t   value_v8_value = 0x08;
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v8(struct bt_conn *conn,
+static k_ssize_t read_value_v8(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr, void *buf,
 			     uint16_t len, uint16_t offset)
 {

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_c_1_1.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_c_1_1.c
@@ -63,7 +63,7 @@ static uint8_t   des_v9d3__128_bit_uuid_value = 0x33;
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v9__128_bit_uuid(struct bt_conn *conn,
+static k_ssize_t read_value_v9__128_bit_uuid(struct bt_conn *conn,
 					   const struct bt_gatt_attr *attr,
 					   void *buf, uint16_t len, uint16_t offset)
 {
@@ -86,7 +86,7 @@ static ssize_t read_value_v9__128_bit_uuid(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v9__128_bit_uuid(struct bt_conn *conn,
+static k_ssize_t write_value_v9__128_bit_uuid(struct bt_conn *conn,
 					    const struct bt_gatt_attr *attr,
 					    const void *buf, uint16_t len,
 					    uint16_t offset, uint8_t flags)
@@ -116,7 +116,7 @@ static ssize_t write_value_v9__128_bit_uuid(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_des_v9d2__128_bit_uuid(struct bt_conn *conn,
+static k_ssize_t read_des_v9d2__128_bit_uuid(struct bt_conn *conn,
 					   const struct bt_gatt_attr *attr,
 					   void *buf, uint16_t len, uint16_t offset)
 {
@@ -140,7 +140,7 @@ static ssize_t read_des_v9d2__128_bit_uuid(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_des_v9d2__128_bit_uuid(struct bt_conn *conn,
+static k_ssize_t write_des_v9d2__128_bit_uuid(struct bt_conn *conn,
 					    const struct bt_gatt_attr *attr,
 					    const void *buf, uint16_t len,
 					    uint16_t offset, uint8_t flags)
@@ -171,7 +171,7 @@ static ssize_t write_des_v9d2__128_bit_uuid(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_des_v9d3__128_bit_uuid(struct bt_conn *conn,
+static k_ssize_t write_des_v9d3__128_bit_uuid(struct bt_conn *conn,
 					    const struct bt_gatt_attr *attr,
 					    const void *buf, uint16_t len,
 					    uint16_t offset, uint8_t flags)

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_c_1_2.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_c_1_2.c
@@ -63,7 +63,7 @@ static struct bt_gatt_cep cha_ext_pro_value = { 0x0001 };
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v9__128_bit_uuid(struct bt_conn *conn,
+static k_ssize_t read_value_v9__128_bit_uuid(struct bt_conn *conn,
 					   const struct bt_gatt_attr *attr,
 					   void *buf, uint16_t len, uint16_t offset)
 {
@@ -86,7 +86,7 @@ static ssize_t read_value_v9__128_bit_uuid(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v9__128_bit_uuid(struct bt_conn *conn,
+static k_ssize_t write_value_v9__128_bit_uuid(struct bt_conn *conn,
 					    const struct bt_gatt_attr *attr,
 					    const void *buf, uint16_t len,
 					    uint16_t offset, uint8_t flags)
@@ -116,7 +116,7 @@ static ssize_t write_value_v9__128_bit_uuid(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_des_v9d2__128_bit_uuid(struct bt_conn *conn,
+static k_ssize_t read_des_v9d2__128_bit_uuid(struct bt_conn *conn,
 					   const struct bt_gatt_attr *attr,
 					   void *buf, uint16_t len, uint16_t offset)
 {
@@ -140,7 +140,7 @@ static ssize_t read_des_v9d2__128_bit_uuid(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_des_v9d2__128_bit_uuid(struct bt_conn *conn,
+static k_ssize_t write_des_v9d2__128_bit_uuid(struct bt_conn *conn,
 					    const struct bt_gatt_attr *attr,
 					    const void *buf, uint16_t len,
 					    uint16_t offset, uint8_t flags)
@@ -171,7 +171,7 @@ static ssize_t write_des_v9d2__128_bit_uuid(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_des_v9d3__128_bit_uuid(struct bt_conn *conn,
+static k_ssize_t write_des_v9d3__128_bit_uuid(struct bt_conn *conn,
 					    const struct bt_gatt_attr *attr,
 					    const void *buf, uint16_t len,
 					    uint16_t offset, uint8_t flags)

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_c_1_3.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_c_1_3.c
@@ -61,7 +61,7 @@ static uint8_t   des_v9d3__128_bit_uuid_value = 0x33;
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v9__128_bit_uuid(struct bt_conn *conn,
+static k_ssize_t read_value_v9__128_bit_uuid(struct bt_conn *conn,
 					   const struct bt_gatt_attr *attr,
 					   void *buf, uint16_t len, uint16_t offset)
 {
@@ -84,7 +84,7 @@ static ssize_t read_value_v9__128_bit_uuid(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v9__128_bit_uuid(struct bt_conn *conn,
+static k_ssize_t write_value_v9__128_bit_uuid(struct bt_conn *conn,
 					    const struct bt_gatt_attr *attr,
 					    const void *buf, uint16_t len,
 					    uint16_t offset, uint8_t flags)
@@ -114,7 +114,7 @@ static ssize_t write_value_v9__128_bit_uuid(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_des_v9d2__128_bit_uuid(struct bt_conn *conn,
+static k_ssize_t read_des_v9d2__128_bit_uuid(struct bt_conn *conn,
 					   const struct bt_gatt_attr *attr,
 					   void *buf, uint16_t len, uint16_t offset)
 {
@@ -138,7 +138,7 @@ static ssize_t read_des_v9d2__128_bit_uuid(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_des_v9d2__128_bit_uuid(struct bt_conn *conn,
+static k_ssize_t write_des_v9d2__128_bit_uuid(struct bt_conn *conn,
 					    const struct bt_gatt_attr *attr,
 					    const void *buf, uint16_t len,
 					    uint16_t offset, uint8_t flags)
@@ -169,7 +169,7 @@ static ssize_t write_des_v9d2__128_bit_uuid(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_des_v9d3__128_bit_uuid(struct bt_conn *conn,
+static k_ssize_t write_des_v9d3__128_bit_uuid(struct bt_conn *conn,
 					    const struct bt_gatt_attr *attr,
 					    const void *buf, uint16_t len,
 					    uint16_t offset, uint8_t flags)

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_c_2_1.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_c_2_1.c
@@ -163,7 +163,7 @@ static bool   bAuthorized;
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v10(struct bt_conn *conn,
+static k_ssize_t read_value_v10(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, void *buf,
 			      uint16_t len, uint16_t offset)
 {
@@ -185,7 +185,7 @@ static ssize_t read_value_v10(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_str_value(struct bt_conn *conn,
+static k_ssize_t read_str_value(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, void *buf,
 			      uint16_t len, uint16_t offset)
 {
@@ -208,7 +208,7 @@ static ssize_t read_str_value(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v2(struct bt_conn *conn,
+static k_ssize_t write_value_v2(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, const void *buf,
 			      uint16_t len, uint16_t offset, uint8_t flags)
 {
@@ -236,7 +236,7 @@ static ssize_t write_value_v2(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_long_des_v2d1(struct bt_conn *conn,
+static k_ssize_t read_long_des_v2d1(struct bt_conn *conn,
 				  const struct bt_gatt_attr *attr, void *buf,
 				  uint16_t len, uint16_t offset)
 {
@@ -259,7 +259,7 @@ static ssize_t read_long_des_v2d1(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_long_des_v2d1(struct bt_conn *conn,
+static k_ssize_t write_long_des_v2d1(struct bt_conn *conn,
 				   const struct bt_gatt_attr *attr,
 				   const void *buf, uint16_t len, uint16_t offset,
 				   uint8_t flags)
@@ -289,7 +289,7 @@ static ssize_t write_long_des_v2d1(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v2_1(struct bt_conn *conn,
+static k_ssize_t write_value_v2_1(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr,
 				const void *buf, uint16_t len, uint16_t offset,
 				uint8_t flags)
@@ -318,7 +318,7 @@ static ssize_t write_value_v2_1(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_long_des_v2d2(struct bt_conn *conn,
+static k_ssize_t read_long_des_v2d2(struct bt_conn *conn,
 				  const struct bt_gatt_attr *attr, void *buf,
 				  uint16_t len, uint16_t offset)
 {
@@ -341,7 +341,7 @@ static ssize_t read_long_des_v2d2(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_long_des_v2d2(struct bt_conn *conn,
+static k_ssize_t write_long_des_v2d2(struct bt_conn *conn,
 				   const struct bt_gatt_attr *attr,
 				   const void *buf, uint16_t len, uint16_t offset,
 				   uint8_t flags)
@@ -371,7 +371,7 @@ static ssize_t write_long_des_v2d2(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v2_2(struct bt_conn *conn,
+static k_ssize_t write_value_v2_2(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr,
 				const void *buf, uint16_t len, uint16_t offset,
 				uint8_t flags)
@@ -400,7 +400,7 @@ static ssize_t write_value_v2_2(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_long_des_v2d3(struct bt_conn *conn,
+static k_ssize_t read_long_des_v2d3(struct bt_conn *conn,
 				  const struct bt_gatt_attr *attr, void *buf,
 				  uint16_t len, uint16_t offset)
 {
@@ -423,7 +423,7 @@ static ssize_t read_long_des_v2d3(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_long_des_v2d3(struct bt_conn *conn,
+static k_ssize_t write_long_des_v2d3(struct bt_conn *conn,
 				   const struct bt_gatt_attr *attr,
 				   const void *buf, uint16_t len, uint16_t offset,
 				   uint8_t flags)
@@ -452,7 +452,7 @@ static ssize_t write_long_des_v2d3(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v2_3(struct bt_conn *conn,
+static k_ssize_t read_value_v2_3(struct bt_conn *conn,
 			       const struct bt_gatt_attr *attr, void *buf,
 			       uint16_t len, uint16_t offset)
 {
@@ -475,7 +475,7 @@ static ssize_t read_value_v2_3(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v2_3(struct bt_conn *conn,
+static k_ssize_t write_value_v2_3(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr,
 				const void *buf, uint16_t len, uint16_t offset,
 				uint8_t flags)
@@ -504,7 +504,7 @@ static ssize_t write_value_v2_3(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_long_des_v2d1_1(struct bt_conn *conn,
+static k_ssize_t read_long_des_v2d1_1(struct bt_conn *conn,
 				    const struct bt_gatt_attr *attr, void *buf,
 				    uint16_t len, uint16_t offset)
 {
@@ -527,7 +527,7 @@ static ssize_t read_long_des_v2d1_1(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_long_des_v2d1_1(struct bt_conn *conn,
+static k_ssize_t write_long_des_v2d1_1(struct bt_conn *conn,
 				     const struct bt_gatt_attr *attr,
 				     const void *buf, uint16_t len, uint16_t offset,
 				     uint8_t flags)
@@ -556,7 +556,7 @@ static ssize_t write_long_des_v2d1_1(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v2_4(struct bt_conn *conn,
+static k_ssize_t read_value_v2_4(struct bt_conn *conn,
 			       const struct bt_gatt_attr *attr, void *buf,
 			       uint16_t len, uint16_t offset)
 {
@@ -579,7 +579,7 @@ static ssize_t read_value_v2_4(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v2_4(struct bt_conn *conn,
+static k_ssize_t write_value_v2_4(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr,
 				const void *buf, uint16_t len, uint16_t offset,
 				uint8_t flags)
@@ -608,7 +608,7 @@ static ssize_t write_value_v2_4(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_long_des_v2d2_1(struct bt_conn *conn,
+static k_ssize_t read_long_des_v2d2_1(struct bt_conn *conn,
 				    const struct bt_gatt_attr *attr, void *buf,
 				    uint16_t len, uint16_t offset)
 {
@@ -631,7 +631,7 @@ static ssize_t read_long_des_v2d2_1(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_long_des_v2d2_1(struct bt_conn *conn,
+static k_ssize_t write_long_des_v2d2_1(struct bt_conn *conn,
 				     const struct bt_gatt_attr *attr,
 				     const void *buf, uint16_t len, uint16_t offset,
 				     uint8_t flags)
@@ -660,7 +660,7 @@ static ssize_t write_long_des_v2d2_1(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v2_5(struct bt_conn *conn,
+static k_ssize_t read_value_v2_5(struct bt_conn *conn,
 			       const struct bt_gatt_attr *attr, void *buf,
 			       uint16_t len, uint16_t offset)
 {
@@ -683,7 +683,7 @@ static ssize_t read_value_v2_5(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v2_5(struct bt_conn *conn,
+static k_ssize_t write_value_v2_5(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr,
 				const void *buf, uint16_t len, uint16_t offset,
 				uint8_t flags)
@@ -712,7 +712,7 @@ static ssize_t write_value_v2_5(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_long_des_v2d3_1(struct bt_conn *conn,
+static k_ssize_t read_long_des_v2d3_1(struct bt_conn *conn,
 				    const struct bt_gatt_attr *attr, void *buf,
 				    uint16_t len, uint16_t offset)
 {
@@ -735,7 +735,7 @@ static ssize_t read_long_des_v2d3_1(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_long_des_v2d3_1(struct bt_conn *conn,
+static k_ssize_t write_long_des_v2d3_1(struct bt_conn *conn,
 				     const struct bt_gatt_attr *attr,
 				     const void *buf, uint16_t len, uint16_t offset,
 				     uint8_t flags)
@@ -765,7 +765,7 @@ static ssize_t write_long_des_v2d3_1(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v2_6(struct bt_conn *conn,
+static k_ssize_t write_value_v2_6(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr,
 				const void *buf, uint16_t len, uint16_t offset,
 				uint8_t flags)
@@ -794,7 +794,7 @@ static ssize_t write_value_v2_6(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_long_des_v2d1_2(struct bt_conn *conn,
+static k_ssize_t read_long_des_v2d1_2(struct bt_conn *conn,
 				    const struct bt_gatt_attr *attr, void *buf,
 				    uint16_t len, uint16_t offset)
 {
@@ -817,7 +817,7 @@ static ssize_t read_long_des_v2d1_2(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_long_des_v2d1_2(struct bt_conn *conn,
+static k_ssize_t write_long_des_v2d1_2(struct bt_conn *conn,
 				     const struct bt_gatt_attr *attr,
 				     const void *buf, uint16_t len, uint16_t offset,
 				     uint8_t flags)
@@ -846,7 +846,7 @@ static ssize_t write_long_des_v2d1_2(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_str_auth_value(struct bt_conn *conn,
+static k_ssize_t read_str_auth_value(struct bt_conn *conn,
 				   const struct bt_gatt_attr *attr, void *buf,
 				   uint16_t len, uint16_t offset)
 {
@@ -871,7 +871,7 @@ static ssize_t read_str_auth_value(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v2_7(struct bt_conn *conn,
+static k_ssize_t write_value_v2_7(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr,
 				const void *buf, uint16_t len, uint16_t offset,
 				uint8_t flags)
@@ -902,7 +902,7 @@ static ssize_t write_value_v2_7(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_long_des_v2d2_2(struct bt_conn *conn,
+static k_ssize_t read_long_des_v2d2_2(struct bt_conn *conn,
 				    const struct bt_gatt_attr *attr, void *buf,
 				    uint16_t len, uint16_t offset)
 {
@@ -928,7 +928,7 @@ static ssize_t read_long_des_v2d2_2(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_long_des_v2d2_2(struct bt_conn *conn,
+static k_ssize_t write_long_des_v2d2_2(struct bt_conn *conn,
 				     const struct bt_gatt_attr *attr,
 				     const void *buf, uint16_t len, uint16_t offset,
 				     uint8_t flags)
@@ -960,7 +960,7 @@ static ssize_t write_long_des_v2d2_2(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v2_8(struct bt_conn *conn,
+static k_ssize_t write_value_v2_8(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr,
 				const void *buf, uint16_t len, uint16_t offset,
 				uint8_t flags)
@@ -989,7 +989,7 @@ static ssize_t write_value_v2_8(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_long_des_v2d3_2(struct bt_conn *conn,
+static k_ssize_t read_long_des_v2d3_2(struct bt_conn *conn,
 				    const struct bt_gatt_attr *attr, void *buf,
 				    uint16_t len, uint16_t offset)
 {
@@ -1012,7 +1012,7 @@ static ssize_t read_long_des_v2d3_2(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_long_des_v2d3_2(struct bt_conn *conn,
+static k_ssize_t write_long_des_v2d3_2(struct bt_conn *conn,
 				     const struct bt_gatt_attr *attr,
 				     const void *buf, uint16_t len, uint16_t offset,
 				     uint8_t flags)

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_c_2_2.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_c_2_2.c
@@ -77,7 +77,7 @@ static uint8_t   value_v2_5_value[] = {
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v10(struct bt_conn *conn,
+static k_ssize_t read_value_v10(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, void *buf,
 			      uint16_t len, uint16_t offset)
 {
@@ -99,7 +99,7 @@ static ssize_t read_value_v10(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_str_value(struct bt_conn *conn,
+static k_ssize_t read_str_value(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, void *buf,
 			      uint16_t len, uint16_t offset)
 {
@@ -122,7 +122,7 @@ static ssize_t read_str_value(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v2(struct bt_conn *conn,
+static k_ssize_t write_value_v2(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, const void *buf,
 			      uint16_t len, uint16_t offset, uint8_t flags)
 {
@@ -151,7 +151,7 @@ static ssize_t write_value_v2(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v2_1(struct bt_conn *conn,
+static k_ssize_t write_value_v2_1(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr,
 				const void *buf, uint16_t len, uint16_t offset,
 				uint8_t flags)
@@ -181,7 +181,7 @@ static ssize_t write_value_v2_1(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v2_2(struct bt_conn *conn,
+static k_ssize_t write_value_v2_2(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr,
 				const void *buf, uint16_t len, uint16_t offset,
 				uint8_t flags)
@@ -211,7 +211,7 @@ static ssize_t write_value_v2_2(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v2_3(struct bt_conn *conn,
+static k_ssize_t write_value_v2_3(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr,
 				const void *buf, uint16_t len, uint16_t offset,
 				uint8_t flags)
@@ -241,7 +241,7 @@ static ssize_t write_value_v2_3(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v2_4(struct bt_conn *conn,
+static k_ssize_t write_value_v2_4(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr,
 				const void *buf, uint16_t len, uint16_t offset,
 				uint8_t flags)
@@ -271,7 +271,7 @@ static ssize_t write_value_v2_4(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v2_5(struct bt_conn *conn,
+static k_ssize_t write_value_v2_5(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr,
 				const void *buf, uint16_t len, uint16_t offset,
 				uint8_t flags)

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_c_2_3.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_c_2_3.c
@@ -77,7 +77,7 @@ static uint8_t   value_v2_5_value[] = {
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v10(struct bt_conn *conn,
+static k_ssize_t read_value_v10(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, void *buf,
 			      uint16_t len, uint16_t offset)
 {
@@ -99,7 +99,7 @@ static ssize_t read_value_v10(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_str_value(struct bt_conn *conn,
+static k_ssize_t read_str_value(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, void *buf,
 			      uint16_t len, uint16_t offset)
 {
@@ -122,7 +122,7 @@ static ssize_t read_str_value(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v2(struct bt_conn *conn,
+static k_ssize_t write_value_v2(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, const void *buf,
 			      uint16_t len, uint16_t offset, uint8_t flags)
 {
@@ -151,7 +151,7 @@ static ssize_t write_value_v2(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v2_1(struct bt_conn *conn,
+static k_ssize_t write_value_v2_1(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr,
 				const void *buf, uint16_t len, uint16_t offset,
 				uint8_t flags)
@@ -181,7 +181,7 @@ static ssize_t write_value_v2_1(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v2_2(struct bt_conn *conn,
+static k_ssize_t write_value_v2_2(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr,
 				const void *buf, uint16_t len, uint16_t offset,
 				uint8_t flags)
@@ -211,7 +211,7 @@ static ssize_t write_value_v2_2(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v2_3(struct bt_conn *conn,
+static k_ssize_t write_value_v2_3(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr,
 				const void *buf, uint16_t len, uint16_t offset,
 				uint8_t flags)
@@ -241,7 +241,7 @@ static ssize_t write_value_v2_3(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v2_4(struct bt_conn *conn,
+static k_ssize_t write_value_v2_4(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr,
 				const void *buf, uint16_t len, uint16_t offset,
 				uint8_t flags)
@@ -271,7 +271,7 @@ static ssize_t write_value_v2_4(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v2_5(struct bt_conn *conn,
+static k_ssize_t write_value_v2_5(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr,
 				const void *buf, uint16_t len, uint16_t offset,
 				uint8_t flags)

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_d_1.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_d_1.c
@@ -51,7 +51,7 @@ static bool   bAuthorized;
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v12(struct bt_conn *conn,
+static k_ssize_t read_value_v12(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, void *buf,
 			      uint16_t len, uint16_t offset)
 {
@@ -73,7 +73,7 @@ static ssize_t read_value_v12(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v11__128_bit_uuid(struct bt_conn *conn,
+static k_ssize_t read_value_v11__128_bit_uuid(struct bt_conn *conn,
 					    const struct bt_gatt_attr *attr,
 					    void *buf, uint16_t len, uint16_t offset)
 {

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_d_2.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_d_2.c
@@ -50,7 +50,7 @@ static uint8_t   value_v12_value = 0x0C;
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v11__128_bit_uuid(struct bt_conn *conn,
+static k_ssize_t read_value_v11__128_bit_uuid(struct bt_conn *conn,
 					    const struct bt_gatt_attr *attr,
 					    void *buf, uint16_t len, uint16_t offset)
 {
@@ -72,7 +72,7 @@ static ssize_t read_value_v11__128_bit_uuid(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v12(struct bt_conn *conn,
+static k_ssize_t read_value_v12(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, void *buf,
 			      uint16_t len, uint16_t offset)
 {

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_d_3.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_d_3.c
@@ -50,7 +50,7 @@ static uint8_t   value_v11__128_bit_uuid_value = 0x0B;
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v12(struct bt_conn *conn,
+static k_ssize_t read_value_v12(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, void *buf,
 			      uint16_t len, uint16_t offset)
 {
@@ -72,7 +72,7 @@ static ssize_t read_value_v12(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v11__128_bit_uuid(struct bt_conn *conn,
+static k_ssize_t read_value_v11__128_bit_uuid(struct bt_conn *conn,
 					    const struct bt_gatt_attr *attr,
 					    void *buf, uint16_t len, uint16_t offset)
 {

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_e_2.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_e_2.c
@@ -40,7 +40,7 @@ static uint8_t   value_v13_value = 0x0D;
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v13(struct bt_conn *conn,
+static k_ssize_t read_value_v13(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, void *buf,
 			      uint16_t len, uint16_t offset)
 {

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_f_1.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_f_1.c
@@ -98,7 +98,7 @@ static uint8_t   value_v17_value = 0x12;
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_str_value(struct bt_conn *conn,
+static k_ssize_t read_str_value(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, void *buf,
 			      uint16_t len, uint16_t offset)
 {
@@ -120,7 +120,7 @@ static ssize_t read_str_value(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v15(struct bt_conn *conn,
+static k_ssize_t read_value_v15(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, void *buf,
 			      uint16_t len, uint16_t offset)
 {
@@ -143,7 +143,7 @@ static ssize_t read_value_v15(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v15(struct bt_conn *conn,
+static k_ssize_t write_value_v15(struct bt_conn *conn,
 			       const struct bt_gatt_attr *attr, const void *buf,
 			       uint16_t len, uint16_t offset, uint8_t flags)
 {
@@ -171,7 +171,7 @@ static ssize_t write_value_v15(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v6(struct bt_conn *conn,
+static k_ssize_t read_value_v6(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr, void *buf,
 			     uint16_t len, uint16_t offset)
 {
@@ -195,7 +195,7 @@ static ssize_t read_value_v6(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v6(struct bt_conn *conn,
+static k_ssize_t write_value_v6(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, const void *buf,
 			      uint16_t len, uint16_t offset, uint8_t flags)
 {
@@ -226,7 +226,7 @@ static ssize_t write_value_v6(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v7(struct bt_conn *conn,
+static k_ssize_t read_value_v7(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr, void *buf,
 			     uint16_t len, uint16_t offset)
 {
@@ -250,7 +250,7 @@ static ssize_t read_value_v7(struct bt_conn *conn,
  * @return       Number of bytes written, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t write_value_v7(struct bt_conn *conn,
+static k_ssize_t write_value_v7(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, const void *buf,
 			      uint16_t len, uint16_t offset, uint8_t flags)
 {
@@ -281,7 +281,7 @@ static ssize_t write_value_v7(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v16(struct bt_conn *conn,
+static k_ssize_t read_value_v16(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, void *buf,
 			      uint16_t len, uint16_t offset)
 {
@@ -308,7 +308,7 @@ static ssize_t read_value_v16(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_agg_format(struct bt_conn *conn,
+static k_ssize_t read_agg_format(struct bt_conn *conn,
 			       const struct bt_gatt_attr *attr, void *buf,
 			       uint16_t len, uint16_t offset)
 {
@@ -335,7 +335,7 @@ static ssize_t read_agg_format(struct bt_conn *conn,
  * @return       Number of bytes read, or in case of an error - BT_GATT_ERR()
  *               with a specific ATT error code.
  */
-static ssize_t read_value_v17(struct bt_conn *conn,
+static k_ssize_t read_value_v17(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, void *buf,
 			      uint16_t len, uint16_t offset)
 {

--- a/tests/bsim/bluetooth/mesh/src/psa_its_emul.c
+++ b/tests/bsim/bluetooth/mesh/src/psa_its_emul.c
@@ -50,7 +50,7 @@ static psa_its_item_t *get_item_by_uid(psa_storage_uid_t uid)
 
 static int itsemul_set(const char *name, size_t len_rd, settings_read_cb read_cb, void *cb_arg)
 {
-	ssize_t len;
+	k_ssize_t len;
 	uint64_t uid;
 	psa_its_item_t *p_item;
 

--- a/tests/bsim/bluetooth/mesh/src/test_beacon.c
+++ b/tests/bsim/bluetooth/mesh/src/test_beacon.c
@@ -467,7 +467,7 @@ static void beacon_create(struct net_buf_simple *buf, const uint8_t net_key[16],
 
 /* Test reception of invalid beacons. */
 static void corrupted_beacon_test(const uint8_t *offsets,
-				  ssize_t field_count,
+				  k_ssize_t field_count,
 				  struct net_buf_simple *buf)
 {
 	/* Send corrupted beacons  */

--- a/tests/bsim/bluetooth/mesh/src/test_persistence.c
+++ b/tests/bsim/bluetooth/mesh/src/test_persistence.c
@@ -343,7 +343,7 @@ int test_model_settings_set(const struct bt_mesh_model *model,
 			    settings_read_cb read_cb, void *cb_arg)
 {
 	uint8_t data[sizeof(test_mod_data)];
-	ssize_t result;
+	k_ssize_t result;
 
 	ASSERT_TRUE(name != NULL);
 	if (strncmp(name, TEST_MOD_DATA_NAME, strlen(TEST_MOD_DATA_NAME))) {
@@ -374,7 +374,7 @@ int test_vnd_model_settings_set(const struct bt_mesh_model *model,
 				settings_read_cb read_cb, void *cb_arg)
 {
 	uint8_t data[sizeof(vnd_test_mod_data)];
-	ssize_t result;
+	k_ssize_t result;
 
 	ASSERT_TRUE(name != NULL);
 	if (strncmp(name, TEST_VND_MOD_DATA_NAME, strlen(TEST_VND_MOD_DATA_NAME))) {

--- a/tests/drivers/eeprom/api/src/main.c
+++ b/tests/drivers/eeprom/api/src/main.c
@@ -3,9 +3,12 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <stddef.h>
+#include <stdint.h>
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/eeprom.h>
+#include <zephyr/types.h>
 #include <zephyr/ztest.h>
 
 /* There is no obvious way to pass this to tests, so use a global */
@@ -40,7 +43,7 @@ ZTEST_USER(eeprom, test_write_rewrite)
 	const uint8_t wr_buf2[sizeof(wr_buf1)] = { 0xAA, 0xBB, 0xCC, 0xDD };
 	uint8_t rd_buf[sizeof(wr_buf1)];
 	size_t size;
-	off_t address;
+	k_off_t address;
 	int rc;
 
 	size = eeprom_get_size(eeprom);
@@ -80,7 +83,7 @@ ZTEST_USER(eeprom, test_write_at_fixed_address)
 	const uint8_t wr_buf1[4] = { 0xFF, 0xEE, 0xDD, 0xCC };
 	uint8_t rd_buf[sizeof(wr_buf1)];
 	size_t size;
-	const off_t address = 0;
+	const k_off_t address = 0;
 	int rc;
 
 	size = eeprom_get_size(eeprom);
@@ -104,7 +107,7 @@ ZTEST_USER(eeprom, test_write_byte)
 	uint8_t rd = 0xff;
 	int rc;
 
-	for (off_t address = 0; address < 16; address++) {
+	for (k_off_t address = 0; address < 16; address++) {
 		rc = eeprom_write(eeprom, address, &wr, 1);
 		zassert_equal(0, rc, "Unexpected error code (%d)", rc);
 
@@ -123,7 +126,7 @@ ZTEST_USER(eeprom, test_write_at_increasing_address)
 	uint8_t rd_buf[sizeof(wr_buf1)];
 	int rc;
 
-	for (off_t address = 0; address < 4; address++) {
+	for (k_off_t address = 0; address < 4; address++) {
 		rc = eeprom_write(eeprom, address, wr_buf1, sizeof(wr_buf1));
 		zassert_equal(0, rc, "Unexpected error code (%d)", rc);
 

--- a/tests/drivers/eeprom/shell/src/main.c
+++ b/tests/drivers/eeprom/shell/src/main.c
@@ -4,12 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include <zephyr/drivers/eeprom.h>
 #include <zephyr/drivers/eeprom/eeprom_fake.h>
 #include <zephyr/fff.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/shell/shell_dummy.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/types.h>
 #include <zephyr/ztest.h>
 
 #define FAKE_EEPROM_NAME DEVICE_DT_NAME(DT_NODELABEL(fake_eeprom))
@@ -19,7 +23,7 @@ static const struct device *const fake_eeprom_dev = DEVICE_DT_GET(DT_NODELABEL(f
 static uint8_t data_capture[CONFIG_EEPROM_SHELL_BUFFER_SIZE];
 DEFINE_FFF_GLOBALS;
 
-static int eeprom_shell_test_write_capture_data(const struct device *dev, off_t offset,
+static int eeprom_shell_test_write_capture_data(const struct device *dev, k_off_t offset,
 						const void *data, size_t len)
 {
 	ARG_UNUSED(dev);
@@ -31,8 +35,8 @@ static int eeprom_shell_test_write_capture_data(const struct device *dev, off_t 
 	return 0;
 }
 
-static int eeprom_shell_test_read_captured_data(const struct device *dev, off_t offset,
-					void *data, size_t len)
+static int eeprom_shell_test_read_captured_data(const struct device *dev, k_off_t offset,
+						void *data, size_t len)
 {
 	ARG_UNUSED(dev);
 	ARG_UNUSED(offset);

--- a/tests/drivers/flash/common/src/main.c
+++ b/tests/drivers/flash/common/src/main.c
@@ -103,7 +103,7 @@ static void *flash_driver_setup(void)
 	if (IS_ENABLED(CONFIG_FLASH_HAS_EXPLICIT_ERASE) && ebw_required) {
 		bool is_buf_clear = true;
 
-		for (off_t i = 0; i < EXPECTED_SIZE; i++) {
+		for (k_off_t i = 0; i < EXPECTED_SIZE; i++) {
 			if (buf[i] != erase_value) {
 				is_buf_clear = false;
 				break;
@@ -150,11 +150,11 @@ ZTEST(flash_driver, test_read_unaligned_address)
 	zassert_equal(rc, 0, "Cannot write to flash");
 
 	/* read buffer length*/
-	for (off_t len = 0; len < 25; len++) {
+	for (k_off_t len = 0; len < 25; len++) {
 		/* address offset */
-		for (off_t ad_o = 0; ad_o < 4; ad_o++) {
+		for (k_off_t ad_o = 0; ad_o < 4; ad_o++) {
 			/* buffer offset; leave space for buffer guard */
-			for (off_t buf_o = 1; buf_o < 5; buf_o++) {
+			for (k_off_t buf_o = 1; buf_o < 5; buf_o++) {
 				/* buffer overflow protection */
 				buf[buf_o - 1] = canary;
 				buf[buf_o + len] = canary;
@@ -184,7 +184,7 @@ ZTEST(flash_driver, test_flash_fill)
 {
 	uint8_t buf[EXPECTED_SIZE];
 	int rc;
-	off_t i;
+	k_off_t i;
 
 	if (IS_ENABLED(CONFIG_FLASH_HAS_EXPLICIT_ERASE) && ebw_required) {
 		/* Erase a nb of pages aligned to the EXPECTED_SIZE */
@@ -225,7 +225,7 @@ ZTEST(flash_driver, test_flash_flatten)
 {
 	uint8_t buf[EXPECTED_SIZE];
 	int rc;
-	off_t i;
+	k_off_t i;
 
 	rc = flash_flatten(flash_dev, page_info.start_offset,
 			   (page_info.size *

--- a/tests/drivers/flash/erase_blocks/src/main.c
+++ b/tests/drivers/flash/erase_blocks/src/main.c
@@ -65,7 +65,7 @@ static bool test_flash_mem_is_set_to(const uint8_t *data, uint8_t to, size_t siz
 	return true;
 }
 
-static bool test_flash_is_erased(off_t offset, size_t size)
+static bool test_flash_is_erased(k_off_t offset, size_t size)
 {
 	static uint8_t test_erase_buffer[99];
 	const struct flash_parameters *parameters = flash_get_parameters(flash_controller);
@@ -85,7 +85,7 @@ static bool test_flash_is_erased(off_t offset, size_t size)
 			return false;
 		}
 
-		offset += (off_t)readsize;
+		offset += (k_off_t)readsize;
 	}
 
 	return true;
@@ -116,7 +116,7 @@ static void test_flash_before(void *f)
 		 "Failed to erase partition");
 }
 
-static void test_flash_write_block_at_offset(off_t offset, size_t size)
+static void test_flash_write_block_at_offset(k_off_t offset, size_t size)
 {
 	zassert_ok(flash_write(flash_controller, offset, test_write_block, size),
 		   "Failed to write block at offset %zu, of size %zu", (size_t)offset, size);
@@ -130,10 +130,10 @@ static void test_flash_write_block_at_offset(off_t offset, size_t size)
 static void test_flash_write_across_page_boundary(const struct flash_pages_info *info,
 						  size_t write_block_size)
 {
-	off_t page_boundary = info->start_offset;
+	k_off_t page_boundary = info->start_offset;
 	uint32_t page0_index = info->index - 1;
 	uint32_t page1_index = info->index;
-	off_t cross_write_start_offset = page_boundary - (off_t)write_block_size;
+	k_off_t cross_write_start_offset = page_boundary - (k_off_t)write_block_size;
 	size_t cross_write_size = write_block_size * 2;
 
 	LOG_INF("Writing across page boundary at %zu, between page index %u and %u",
@@ -174,7 +174,7 @@ ZTEST(flash_page_layout, test_write_across_page_boundaries_in_part)
 
 static void test_flash_erase_page(const struct flash_pages_info *info)
 {
-	off_t page_offset = info->start_offset;
+	k_off_t page_offset = info->start_offset;
 	size_t page_size = info->size;
 	size_t page_index = info->index;
 

--- a/tests/drivers/flash/stm32/src/main.c
+++ b/tests/drivers/flash/stm32/src/main.c
@@ -27,7 +27,7 @@ static const struct flash_parameters *flash_params;
 static uint32_t sector_mask;
 static uint8_t __aligned(4) expected[EXPECTED_SIZE];
 
-static int sector_mask_from_offset(const struct device *dev, off_t offset,
+static int sector_mask_from_offset(const struct device *dev, k_off_t offset,
 				   size_t size, uint32_t *mask)
 {
 	struct flash_pages_info start_page, end_page;
@@ -92,7 +92,7 @@ static void *flash_stm32_setup(void)
 	zassert_equal(rc, 0, "Cannot read flash");
 
 	/* Check if flash is cleared. */
-	for (off_t i = 0; i < EXPECTED_SIZE; i++) {
+	for (k_off_t i = 0; i < EXPECTED_SIZE; i++) {
 		if (buf[i] != flash_params->erase_value) {
 			is_buf_clear = false;
 			break;
@@ -137,7 +137,7 @@ ZTEST(flash_stm32, test_stm32_write_protection)
 	rc = flash_read(flash_dev, TEST_AREA_OFFSET, buf, EXPECTED_SIZE);
 	zassert_equal(rc, 0, "Cannot read flash");
 
-	for (off_t i = 0; i < EXPECTED_SIZE; i++) {
+	for (k_off_t i = 0; i < EXPECTED_SIZE; i++) {
 		zassert_true(buf[i] == flash_params->erase_value,
 			     "Buffer is not empty after write with protected "
 			     "sectors");

--- a/tests/drivers/flash_simulator/flash_sim_impl/src/main.c
+++ b/tests/drivers/flash_simulator/flash_sim_impl/src/main.c
@@ -4,9 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include <zephyr/ztest.h>
 #include <zephyr/drivers/flash.h>
 #include <zephyr/device.h>
+#include <zephyr/types.h>
 
 /* Warning: The test has been written for testing boards with single
  * instance of Flash Simulator device only.
@@ -60,10 +64,9 @@ static uint32_t pattern32_flat(void)
 	return p32_inc;
 }
 
-static void test_check_pattern32(off_t start, uint32_t (*pattern_gen)(void),
-				 size_t size)
+static void test_check_pattern32(k_off_t start, uint32_t (*pattern_gen)(void), size_t size)
 {
-	off_t off;
+	k_off_t off;
 	uint32_t val32, r_val32;
 	int rc;
 
@@ -80,7 +83,7 @@ static void test_check_pattern32(off_t start, uint32_t (*pattern_gen)(void),
 }
 
 /* ret < 0 is errno; ret == 1 is bad value in flash */
-static int test_check_erase(const struct device *dev, off_t offset, size_t size)
+static int test_check_erase(const struct device *dev, k_off_t offset, size_t size)
 {
 	uint8_t buf[FLASH_SIMULATOR_PROG_UNIT];
 	int rc;
@@ -126,7 +129,7 @@ static void test_init(void)
 
 ZTEST(flash_sim_api, test_read)
 {
-	off_t i;
+	k_off_t i;
 	int rc;
 
 	rc = flash_erase(flash_dev, FLASH_SIMULATOR_BASE_OFFSET,
@@ -148,7 +151,7 @@ ZTEST(flash_sim_api, test_read)
 
 static void test_write_read(void)
 {
-	off_t off;
+	k_off_t off;
 	uint32_t val32 = 0, r_val32;
 	int rc;
 
@@ -454,7 +457,7 @@ ZTEST(flash_sim_api, test_get_erase_value)
 
 ZTEST(flash_sim_api, test_flash_fill)
 {
-	off_t i;
+	k_off_t i;
 	int rc;
 	uint8_t buf[FLASH_SIMULATOR_PROG_UNIT];
 #if defined(CONFIG_FLASH_SIMULATOR_EXPLICIT_ERASE)

--- a/tests/drivers/hwinfo/api/src/main.c
+++ b/tests/drivers/hwinfo/api/src/main.c
@@ -3,10 +3,13 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <errno.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <zephyr/types.h>
 #include <zephyr/drivers/hwinfo.h>
 #include <zephyr/ztest.h>
-#include <strings.h>
-#include <errno.h>
 
 /*
  * @addtogroup t_hwinfo_get_device_id_api
@@ -30,7 +33,7 @@ ZTEST(hwinfo_device_id_api, test_device_id_get)
 {
 	uint8_t buffer_1[BUFFER_LENGTH];
 	uint8_t buffer_2[BUFFER_LENGTH];
-	ssize_t length_read_1, length_read_2;
+	int length_read_1, length_read_2;
 	int i;
 
 	length_read_1 = hwinfo_get_device_id(buffer_1, 1);
@@ -85,8 +88,8 @@ ZTEST(hwinfo_device_id_api, test_device_id_get)
 
 ZTEST(hwinfo_device_id_api, test_get_reset_cause)
 {
+	int ret;
 	uint32_t cause;
-	ssize_t ret;
 
 	/* Set `cause` to a known value prior to call. */
 	cause = 0xDEADBEEF;
@@ -123,8 +126,8 @@ ZTEST(hwinfo_device_id_api, test_get_reset_cause)
  */
 ZTEST(hwinfo_device_id_api, test_clear_reset_cause)
 {
+	int ret;
 	uint32_t cause_1, cause_2;
-	ssize_t ret;
 
 	ret = hwinfo_get_reset_cause(&cause_1);
 	if (ret == -ENOSYS) {
@@ -174,8 +177,8 @@ ZTEST(hwinfo_device_id_api, test_clear_reset_cause)
  */
 ZTEST(hwinfo_device_id_api, test_get_supported_reset_cause)
 {
+	int ret;
 	uint32_t supported;
-	ssize_t ret;
 
 	/* Set `supported` to a known value prior to call. */
 	supported = 0xDEADBEEF;

--- a/tests/drivers/mipi_dsi/api/src/main.c
+++ b/tests/drivers/mipi_dsi/api/src/main.c
@@ -23,7 +23,7 @@ ZTEST(mipi_dsi_api, test_generic)
 {
 	uint8_t rx_buf[2];
 	uint8_t param[2];
-	ssize_t ret;
+	k_ssize_t ret;
 
 	param[0] = MIPI_DCS_SET_DISPLAY_ON;
 	ret = mipi_dsi_generic_write(mipi_dev, CONFIG_MIPI_DSI_TEST_CHANNEL, param, 1);
@@ -52,7 +52,7 @@ ZTEST(mipi_dsi_api, test_dcs)
 {
 	uint8_t rx_buf[2];
 	uint8_t param[2];
-	ssize_t ret;
+	k_ssize_t ret;
 
 	ret = mipi_dsi_dcs_write(mipi_dev, CONFIG_MIPI_DSI_TEST_CHANNEL,
 				 MIPI_DCS_SET_DISPLAY_ON, NULL, 0);

--- a/tests/lib/c_lib/common/src/main.c
+++ b/tests/lib/c_lib/common/src/main.c
@@ -81,6 +81,7 @@ ZTEST(libc_common, test_limits)
 	zassert_true((long_max + long_one == LONG_MIN));
 }
 
+/* FIXME: ssize_t is a POSIX type, not a C type */
 static ssize_t foobar(void)
 {
 	return -1;

--- a/tests/lib/json/src/main.c
+++ b/tests/lib/json/src/main.c
@@ -228,7 +228,7 @@ ZTEST(lib_json_test, test_json_encoding)
 		"}";
 	char buffer[sizeof(encoded)];
 	int ret;
-	ssize_t len;
+	k_ssize_t len;
 
 	len = json_calc_encoded_len(test_descr, ARRAY_SIZE(test_descr), &ts);
 	zassert_equal(len, strlen(encoded), "encoded size mismatch");
@@ -518,7 +518,7 @@ ZTEST(lib_json_test, test_json_arr_obj_encoding)
 		"]";
 	char buffer[sizeof(encoded)];
 	int ret;
-	ssize_t len;
+	k_ssize_t len;
 
 	len = json_calc_encoded_arr_len(obj_array_descr, &oa);
 	zassert_equal(len, strlen(encoded), "encoded size mismatch");
@@ -1049,7 +1049,7 @@ ZTEST(lib_json_test, test_json_escape)
 			       "\\rquux"
 			       "\\tfred\\\"";
 	size_t len;
-	ssize_t ret;
+	k_ssize_t ret;
 
 	strncpy(buf, string, sizeof(buf) - 1);
 	len = strlen(buf);
@@ -1067,7 +1067,7 @@ ZTEST(lib_json_test, test_json_escape_one)
 	char buf[3] = {'\t', '\0', '\0'};
 	const char *expected = "\\t";
 	size_t len = strlen(buf);
-	ssize_t ret;
+	k_ssize_t ret;
 
 	ret = json_escape(buf, &len, sizeof(buf));
 	zassert_equal(ret, 0,
@@ -1081,7 +1081,7 @@ ZTEST(lib_json_test, test_json_escape_empty)
 {
 	char empty[] = "";
 	size_t len = sizeof(empty) - 1;
-	ssize_t ret;
+	k_ssize_t ret;
 
 	ret = json_escape(empty, &len, sizeof(empty));
 	zassert_equal(ret, 0, "Escaping empty string not successful");
@@ -1094,7 +1094,7 @@ ZTEST(lib_json_test, test_json_escape_no_op)
 	char nothing_to_escape[] = "hello,world:!";
 	const char *expected = "hello,world:!";
 	size_t len = sizeof(nothing_to_escape) - 1;
-	ssize_t ret;
+	k_ssize_t ret;
 
 	ret = json_escape(nothing_to_escape, &len, sizeof(nothing_to_escape));
 	zassert_equal(ret, 0, "Escape no-op not handled correctly");
@@ -1108,7 +1108,7 @@ ZTEST(lib_json_test, test_json_escape_bounds_check)
 {
 	char not_enough_memory[] = "\tfoo";
 	size_t len = sizeof(not_enough_memory) - 1;
-	ssize_t ret;
+	k_ssize_t ret;
 
 	ret = json_escape(not_enough_memory, &len, sizeof(not_enough_memory));
 	zassert_equal(ret, -ENOMEM, "Bounds check failed");
@@ -1124,8 +1124,7 @@ ZTEST(lib_json_test, test_json_encode_bounds_check)
 	};
 	/* Encodes to {"val":0}\0 for a total of 10 bytes */
 	uint8_t buf[10];
-	ssize_t ret = json_obj_encode_buf(descr, ARRAY_SIZE(descr),
-					  &str, buf, 10);
+	k_ssize_t ret = json_obj_encode_buf(descr, ARRAY_SIZE(descr), &str, buf, 10);
 	zassert_equal(ret, 0, "Encoding failed despite large enough buffer");
 	zassert_equal(strlen(buf), 9, "Encoded string length mismatch");
 

--- a/tests/net/ipv4_fragment/src/main.c
+++ b/tests/net/ipv4_fragment/src/main.c
@@ -20,7 +20,6 @@ LOG_MODULE_REGISTER(net_ipv4_test, CONFIG_NET_IPV4_LOG_LEVEL);
 #include <zephyr/net/buf.h>
 #include <zephyr/net/net_ip.h>
 #include <zephyr/net/net_if.h>
-#include <zephyr/posix/fcntl.h>
 #include <zephyr/net/socket.h>
 #include <net_private.h>
 #include <ipv4.h>

--- a/tests/net/socket/af_packet/src/main.c
+++ b/tests/net/socket/af_packet/src/main.c
@@ -11,7 +11,6 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_SOCKETS_LOG_LEVEL);
 #include <zephyr/sys/mutex.h>
 #include <zephyr/ztest_assert.h>
 
-#include <zephyr/posix/fcntl.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/ethernet.h>
 
@@ -157,16 +156,16 @@ static void setblocking(int fd, bool val)
 {
 	int fl, res;
 
-	fl = zsock_fcntl(fd, F_GETFL, 0);
+	fl = zsock_fcntl(fd, ZVFS_F_GETFL, 0);
 	zassert_not_equal(fl, -1, "Fail to set fcntl");
 
 	if (val) {
-		fl &= ~O_NONBLOCK;
+		fl &= ~ZVFS_O_NONBLOCK;
 	} else {
-		fl |= O_NONBLOCK;
+		fl |= ZVFS_O_NONBLOCK;
 	}
 
-	res = zsock_fcntl(fd, F_SETFL, fl);
+	res = zsock_fcntl(fd, ZVFS_F_SETFL, fl);
 	zassert_not_equal(res, -1, "Fail to set fcntl");
 }
 

--- a/tests/net/socket/af_packet_ipproto_raw/src/main.c
+++ b/tests/net/socket/af_packet_ipproto_raw/src/main.c
@@ -12,8 +12,6 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_SOCKETS_LOG_LEVEL);
 #include <zephyr/ztest.h>
 #include <zephyr/random/random.h>
 
-#include <zephyr/posix/fcntl.h>
-
 #include <zephyr/net/ethernet.h>
 #include <zephyr/net/dummy.h>
 #include <zephyr/net/net_if.h>

--- a/tests/net/socket/offload_dispatcher/src/main.c
+++ b/tests/net/socket/offload_dispatcher/src/main.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/posix/fcntl.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/net/dummy.h>
 #include <zephyr/net/net_if.h>
@@ -43,7 +42,7 @@ static struct test_socket_calls {
 
 static int test_sock = -1;
 
-static ssize_t offload_read(void *obj, void *buffer, size_t count)
+static k_ssize_t offload_read(void *obj, void *buffer, size_t count)
 {
 	ARG_UNUSED(obj);
 	ARG_UNUSED(buffer);
@@ -52,7 +51,7 @@ static ssize_t offload_read(void *obj, void *buffer, size_t count)
 	return 0;
 }
 
-static ssize_t offload_write(void *obj, const void *buffer, size_t count)
+static k_ssize_t offload_write(void *obj, const void *buffer, size_t count)
 {
 	ARG_UNUSED(obj);
 	ARG_UNUSED(buffer);
@@ -142,9 +141,8 @@ static int offload_accept(void *obj, struct sockaddr *addr, socklen_t *addrlen)
 	return 0;
 }
 
-static ssize_t offload_sendto(void *obj, const void *buf, size_t len,
-			      int flags, const struct sockaddr *dest_addr,
-			      socklen_t addrlen)
+static k_ssize_t offload_sendto(void *obj, const void *buf, size_t len, int flags,
+				   const struct sockaddr *dest_addr, socklen_t addrlen)
 {
 	struct test_socket_calls *ctx = obj;
 
@@ -159,7 +157,7 @@ static ssize_t offload_sendto(void *obj, const void *buf, size_t len,
 	return len;
 }
 
-static ssize_t offload_sendmsg(void *obj, const struct msghdr *msg, int flags)
+static k_ssize_t offload_sendmsg(void *obj, const struct msghdr *msg, int flags)
 {
 	struct test_socket_calls *ctx = obj;
 
@@ -171,9 +169,8 @@ static ssize_t offload_sendmsg(void *obj, const struct msghdr *msg, int flags)
 	return 0;
 }
 
-static ssize_t offload_recvfrom(void *obj, void *buf, size_t max_len,
-				int flags, struct sockaddr *src_addr,
-				socklen_t *addrlen)
+static k_ssize_t offload_recvfrom(void *obj, void *buf, size_t max_len, int flags,
+				     struct sockaddr *src_addr, socklen_t *addrlen)
 {
 	struct test_socket_calls *ctx = obj;
 
@@ -471,7 +468,7 @@ ZTEST(net_socket_offload_udp, test_fcntl_not_bound)
 {
 	int ret;
 
-	ret = zsock_fcntl(test_sock, F_SETFL, 0);
+	ret = zsock_fcntl(test_sock, ZVFS_F_SETFL, 0);
 	zassert_equal(0, ret, "fcntl() failed");
 	zassert_true(test_socket_ctx[OFFLOAD_1].socket_called,
 		     "Socket should've been dispatched");

--- a/tests/net/socket/socketpair/src/_main.h
+++ b/tests/net/socket/socketpair/src/_main.h
@@ -11,7 +11,6 @@
 #include <string.h>
 
 #include <zephyr/logging/log.h>
-#include <zephyr/posix/fcntl.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/ztest.h>

--- a/tests/net/socket/socketpair/src/fcntl.c
+++ b/tests/net/socket/socketpair/src/fcntl.c
@@ -11,19 +11,18 @@ ZTEST_USER_F(net_socketpair, test_fcntl)
 	int res;
 	int flags;
 
-	res = zsock_fcntl(fixture->sv[0], F_GETFL, 0);
-	zassert_not_equal(res, -1,
-		"fcntl(fixture->sv[0], F_GETFL) failed. errno: %d", errno);
+	res = zsock_fcntl(fixture->sv[0], ZVFS_F_GETFL, 0);
+	zassert_not_equal(res, -1, "fcntl(fixture->sv[0], ZVFS_F_GETFL) failed. errno: %d", errno);
 
 	flags = res;
-	zassert_equal(res & O_NONBLOCK, 0,
+	zassert_equal(res & ZVFS_O_NONBLOCK, 0,
 		"socketpair should block by default");
 
-	res = zsock_fcntl(fixture->sv[0], F_SETFL, flags | O_NONBLOCK);
+	res = zsock_fcntl(fixture->sv[0], ZVFS_F_SETFL, flags | ZVFS_O_NONBLOCK);
 	zassert_not_equal(res, -1,
-		"fcntl(fixture->sv[0], F_SETFL, flags | O_NONBLOCK) failed. errno: %d",
+		"fcntl(fixture->sv[0], ZVFS_F_SETFL, flags | ZVFS_O_NONBLOCK) failed. errno: %d",
 		errno);
 
-	res = zsock_fcntl(fixture->sv[0], F_GETFL, 0);
-	zassert_equal(res ^ flags, O_NONBLOCK, "expected O_NONBLOCK set");
+	res = zsock_fcntl(fixture->sv[0], ZVFS_F_GETFL, 0);
+	zassert_equal(res ^ flags, ZVFS_O_NONBLOCK, "expected ZVFS_O_NONBLOCK set");
 }

--- a/tests/net/socket/socketpair/src/nonblock.c
+++ b/tests/net/socket/socketpair/src/nonblock.c
@@ -18,11 +18,11 @@ ZTEST_USER_F(net_socketpair, test_write_nonblock)
 			zassert_equal(res, 1, "send() failed: %d", errno);
 		}
 
-		/* then set the O_NONBLOCK flag */
-		res = zsock_fcntl(fixture->sv[i], F_GETFL, 0);
+		/* then set the ZVFS_O_NONBLOCK flag */
+		res = zsock_fcntl(fixture->sv[i], ZVFS_F_GETFL, 0);
 		zassert_not_equal(res, -1, "fcntl() failed: %d", i, errno);
 
-		res = zsock_fcntl(fixture->sv[i], F_SETFL, res | O_NONBLOCK);
+		res = zsock_fcntl(fixture->sv[i], ZVFS_F_SETFL, res | ZVFS_O_NONBLOCK);
 		zassert_not_equal(res, -1, "fcntl() failed: %d", i, errno);
 
 		/* then, try to write one more byte */
@@ -39,11 +39,11 @@ ZTEST_USER_F(net_socketpair, test_read_nonblock)
 	char c;
 
 	for (size_t i = 0; i < 2; ++i) {
-		/* set the O_NONBLOCK flag */
-		res = zsock_fcntl(fixture->sv[i], F_GETFL, 0);
+		/* set the ZVFS_O_NONBLOCK flag */
+		res = zsock_fcntl(fixture->sv[i], ZVFS_F_GETFL, 0);
 		zassert_not_equal(res, -1, "fcntl() failed: %d", i, errno);
 
-		res = zsock_fcntl(fixture->sv[i], F_SETFL, res | O_NONBLOCK);
+		res = zsock_fcntl(fixture->sv[i], ZVFS_F_SETFL, res | ZVFS_O_NONBLOCK);
 		zassert_not_equal(res, -1, "fcntl() failed: %d", i, errno);
 
 		/* then, try to read one byte */

--- a/tests/net/socket/socketpair/src/poll.c
+++ b/tests/net/socket/socketpair/src/poll.c
@@ -49,20 +49,20 @@ ZTEST_USER_F(net_socketpair, test_poll_timeout)
 	test_socketpair_poll_timeout_common(fixture);
 }
 
-/* O_NONBLOCK should have no affect on poll(2) */
+/* ZVFS_O_NONBLOCK should have no affect on poll(2) */
 ZTEST_USER_F(net_socketpair, test_poll_timeout_nonblocking)
 {
 	int res;
 
-	res = zsock_fcntl(fixture->sv[0], F_GETFL, 0);
+	res = zsock_fcntl(fixture->sv[0], ZVFS_F_GETFL, 0);
 	zassert_not_equal(res, -1, "fcntl failed: %d", errno);
 
 	int flags = res;
 
-	res = zsock_fcntl(fixture->sv[0], F_SETFL, O_NONBLOCK | flags);
+	res = zsock_fcntl(fixture->sv[0], ZVFS_F_SETFL, ZVFS_O_NONBLOCK | flags);
 	zassert_not_equal(res, -1, "fcntl failed: %d", errno);
 
-	res = zsock_fcntl(fixture->sv[1], F_SETFL, O_NONBLOCK | flags);
+	res = zsock_fcntl(fixture->sv[1], ZVFS_F_SETFL, ZVFS_O_NONBLOCK | flags);
 	zassert_not_equal(res, -1, "fcntl failed: %d", errno);
 
 	test_socketpair_poll_timeout_common(fixture);

--- a/tests/net/socket/tcp/src/main.c
+++ b/tests/net/socket/tcp/src/main.c
@@ -8,7 +8,6 @@
 LOG_MODULE_REGISTER(net_test, CONFIG_NET_SOCKETS_LOG_LEVEL);
 
 #include <zephyr/ztest_assert.h>
-#include <zephyr/posix/fcntl.h>
 #include <zephyr/net/net_context.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/loopback.h>
@@ -1088,7 +1087,7 @@ ZTEST(net_socket_tcp, test_async_connect_timeout)
 	loopback_set_packet_drop_ratio(1.0f);
 
 	prepare_sock_tcp_v4(MY_IPV4_ADDR, ANY_PORT, &c_sock, &c_saddr);
-	test_fcntl(c_sock, F_SETFL, O_NONBLOCK);
+	test_fcntl(c_sock, ZVFS_F_SETFL, ZVFS_O_NONBLOCK);
 	s_saddr.sin_family = AF_INET;
 	s_saddr.sin_port = htons(SERVER_PORT);
 	rv = zsock_inet_pton(AF_INET, MY_IPV4_ADDR, &s_saddr.sin_addr);
@@ -1129,7 +1128,7 @@ ZTEST(net_socket_tcp, test_async_connect)
 
 	prepare_sock_tcp_v4(MY_IPV4_ADDR, ANY_PORT, &c_sock, &c_saddr);
 	prepare_sock_tcp_v4(MY_IPV4_ADDR, SERVER_PORT, &s_sock, &s_saddr);
-	test_fcntl(c_sock, F_SETFL, O_NONBLOCK);
+	test_fcntl(c_sock, ZVFS_F_SETFL, ZVFS_O_NONBLOCK);
 
 	test_bind(s_sock, (struct sockaddr *)&s_saddr, sizeof(s_saddr));
 	test_listen(s_sock);
@@ -1247,7 +1246,7 @@ ZTEST_USER(net_socket_tcp, test_v4_accept_timeout)
 	test_bind(s_sock, (struct sockaddr *)&s_saddr, sizeof(s_saddr));
 	test_listen(s_sock);
 
-	test_fcntl(s_sock, F_SETFL, O_NONBLOCK);
+	test_fcntl(s_sock, ZVFS_F_SETFL, ZVFS_O_NONBLOCK);
 
 	tstamp = k_uptime_get_32();
 	test_accept_timeout(s_sock, &new_sock, &addr, &addrlen);
@@ -2215,8 +2214,8 @@ ZTEST(net_socket_tcp, test_connect_and_wait_for_v4_select)
 
 	fd = zsock_socket(AF_INET, SOCK_STREAM, 0);
 
-	flags = zsock_fcntl(fd, F_GETFL, 0);
-	zsock_fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+	flags = zsock_fcntl(fd, ZVFS_F_GETFL, 0);
+	zsock_fcntl(fd, ZVFS_F_SETFL, flags | ZVFS_O_NONBLOCK);
 
 	zsock_inet_pton(AF_INET, "127.0.0.1", (void *)&v4addr);
 
@@ -2284,8 +2283,8 @@ ZTEST(net_socket_tcp, test_connect_and_wait_for_v4_poll)
 
 	fd = zsock_socket(AF_INET, SOCK_STREAM, 0);
 
-	flags = zsock_fcntl(fd, F_GETFL, 0);
-	zsock_fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+	flags = zsock_fcntl(fd, ZVFS_F_GETFL, 0);
+	zsock_fcntl(fd, ZVFS_F_SETFL, flags | ZVFS_O_NONBLOCK);
 
 	zsock_inet_pton(AF_INET, "127.0.0.1", (void *)&v4addr);
 

--- a/tests/net/socket/tls/src/main.c
+++ b/tests/net/socket/tls/src/main.c
@@ -8,7 +8,6 @@
 LOG_MODULE_REGISTER(net_test, CONFIG_NET_SOCKETS_LOG_LEVEL);
 
 #include <zephyr/ztest_assert.h>
-#include <zephyr/posix/fcntl.h>
 #include <zephyr/net/loopback.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/tls_credentials.h>
@@ -1047,7 +1046,7 @@ ZTEST(net_socket_tls, test_accept_non_block)
 			    IPPROTO_TLS_1_2);
 
 	test_config_psk(s_sock, -1);
-	test_fcntl(s_sock, F_SETFL, O_NONBLOCK);
+	test_fcntl(s_sock, ZVFS_F_SETFL, ZVFS_O_NONBLOCK);
 	test_bind(s_sock, (struct sockaddr *)&s_saddr, sizeof(s_saddr));
 	test_listen(s_sock);
 
@@ -1098,8 +1097,8 @@ ZTEST(net_socket_tls, test_recv_non_block)
 	zassert_equal(ret, -1, "recv()) should've failed");
 	zassert_equal(errno, EAGAIN, "Unexpected errno value: %d", errno);
 
-	/* Verify fcntl and O_NONBLOCK */
-	test_fcntl(new_sock, F_SETFL, O_NONBLOCK);
+	/* Verify fcntl and ZVFS_O_NONBLOCK */
+	test_fcntl(new_sock, ZVFS_F_SETFL, ZVFS_O_NONBLOCK);
 	ret = zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0);
 	zassert_equal(ret, -1, "recv() should've failed");
 	zassert_equal(errno, EAGAIN, "Unexpected errno value: %d", errno);
@@ -1195,8 +1194,8 @@ ZTEST(net_socket_tls, test_send_non_block)
 	zassert_equal(ret, -1, "send() should've failed");
 	zassert_equal(errno, EAGAIN, "Unexpected errno value: %d", errno);
 
-	/* Verify fcntl and O_NONBLOCK */
-	test_fcntl(c_sock, F_SETFL, O_NONBLOCK);
+	/* Verify fcntl and ZVFS_O_NONBLOCK */
+	test_fcntl(c_sock, ZVFS_F_SETFL, ZVFS_O_NONBLOCK);
 	ret = zsock_send(c_sock, TEST_STR_SMALL, strlen(TEST_STR_SMALL), 0);
 	zassert_equal(ret, -1, "send() should've failed");
 	zassert_equal(errno, EAGAIN, "Unexpected errno value: %d", errno);

--- a/tests/posix/fs/src/test_fs_dir.c
+++ b/tests/posix/fs/src/test_fs_dir.c
@@ -5,9 +5,9 @@
  */
 
 #include <stdio.h>
-#include <fcntl.h>
-#include <zephyr/posix/unistd.h>
+#include <zephyr/posix/fcntl.h>
 #include <zephyr/posix/dirent.h>
+#include <zephyr/posix/unistd.h>
 #include "test_fs.h"
 
 extern int test_file_write(void);

--- a/tests/posix/fs/src/test_fs_file.c
+++ b/tests/posix/fs/src/test_fs_file.c
@@ -5,7 +5,7 @@
  */
 
 #include <string.h>
-#include <fcntl.h>
+#include <zephyr/posix/fcntl.h>
 #include <zephyr/posix/unistd.h>
 #include "test_fs.h"
 

--- a/tests/subsys/dfu/mcuboot/src/main.c
+++ b/tests/subsys/dfu/mcuboot/src/main.c
@@ -27,7 +27,7 @@ ZTEST(mcuboot_interface, test_bank_erase)
 	const struct flash_area *fa;
 	uint32_t temp;
 	uint32_t temp2 = 0x5a5a5a5a;
-	off_t offs;
+	k_off_t offs;
 	int ret;
 
 	ret = flash_area_open(SLOT1_PARTITION_ID, &fa);

--- a/tests/subsys/fs/common/test_fs_basic.c
+++ b/tests/subsys/fs/common/test_fs_basic.c
@@ -143,7 +143,7 @@ static int seek_within_hello(const struct fs_mount_t *mp)
 	zassert_equal(stat.size, TESTFS_BUFFER_SIZE,
 		      "stat old hello bad size");
 
-	off_t pos = stat.size / 4;
+	k_off_t pos = stat.size / 4;
 
 	zassert_equal(fs_seek(&file, pos, FS_SEEK_SET),
 		      0,
@@ -159,24 +159,21 @@ static int seek_within_hello(const struct fs_mount_t *mp)
 	zassert_equal(fs_tell(&file), stat.size,
 		      "verify hello read middle tell failed");
 
-	zassert_equal(fs_seek(&file, -stat.size, FS_SEEK_CUR),
-		      0,
+	zassert_equal(fs_seek(&file, -(k_off_t)stat.size, FS_SEEK_CUR), 0,
 		      "verify hello seek back from cur failed");
 
 	zassert_equal(fs_tell(&file), 0U,
 		      "verify hello tell back from cur failed");
 
-	zassert_equal(fs_seek(&file, -pos, FS_SEEK_END),
-		      0,
+	zassert_equal(fs_seek(&file, -(k_off_t)pos, FS_SEEK_END), 0,
 		      "verify hello seek from end failed");
 
-	zassert_equal(fs_tell(&file), stat.size - pos,
+	zassert_equal(fs_tell(&file), (k_off_t)stat.size - pos,
 		      "verify hello tell from end failed");
 
-	zassert_equal(testfs_verify_incrementing(&file, stat.size - pos,
-						 TESTFS_BUFFER_SIZE),
-		      pos,
-		      "verify hello at post middle failed");
+	zassert_equal(
+		testfs_verify_incrementing(&file, (k_off_t)stat.size - pos, TESTFS_BUFFER_SIZE),
+		pos, "verify hello at post middle failed");
 
 	zassert_equal(fs_close(&file), 0,
 		      "verify close hello failed");
@@ -208,7 +205,7 @@ static int truncate_hello(const struct fs_mount_t *mp)
 	zassert_equal(stat.size, TESTFS_BUFFER_SIZE,
 		      "stat old hello bad size");
 
-	off_t pos = 3 * stat.size / 4;
+	k_off_t pos = 3 * stat.size / 4;
 
 	zassert_equal(fs_tell(&file), 0U,
 		      "truncate initial tell failed");

--- a/tests/subsys/fs/common/test_fs_open_flags.c
+++ b/tests/subsys/fs/common/test_fs_open_flags.c
@@ -91,7 +91,7 @@ static void ZUNLINK(struct test_state *ts, int line)
 }
 
 /* Check file position; expected is a position file should be at. */
-static void ZCHKPOS(struct test_state *ts, off_t expected, int line)
+static void ZCHKPOS(struct test_state *ts, k_off_t expected, int line)
 {
 	TC_PRINT("# %d: CHKPOS\n", line);
 	ZEQ(fs_tell(&ts->file), expected);

--- a/tests/subsys/fs/common/test_fs_util.c
+++ b/tests/subsys/fs/common/test_fs_util.c
@@ -100,7 +100,7 @@ int testfs_write_constant(struct fs_file_t *fp,
 			count = rem;
 		}
 
-		ssize_t rc = fs_write(fp, buffer, count);
+		k_ssize_t rc = fs_write(fp, buffer, count);
 
 		if (rc < 0) {
 			return rc;
@@ -170,7 +170,7 @@ int testfs_write_incrementing(struct fs_file_t *fp,
 			buffer[i] = value++;
 		}
 
-		ssize_t rc = fs_write(fp, buffer, count);
+		k_ssize_t rc = fs_write(fp, buffer, count);
 
 		if (rc < 0) {
 			return rc;

--- a/tests/subsys/fs/fat_fs_api/src/test_fat_file.c
+++ b/tests/subsys/fs/fat_fs_api/src/test_fat_file.c
@@ -38,7 +38,7 @@ static int test_file_open(void)
 
 int test_file_write(void)
 {
-	ssize_t brw;
+	k_ssize_t brw;
 	int res;
 
 	TC_PRINT("\nWrite tests:\n");
@@ -91,7 +91,7 @@ static int test_file_sync(void)
 
 static int test_file_read(void)
 {
-	ssize_t brw;
+	k_ssize_t brw;
 	int res;
 	char read_buff[80];
 	size_t sz = strlen(test_str);
@@ -131,9 +131,9 @@ static int test_file_read(void)
 static int test_file_truncate(void)
 {
 	int res;
-	off_t orig_pos;
+	k_off_t orig_pos;
 	char read_buff[80];
-	ssize_t brw;
+	k_ssize_t brw;
 
 	TC_PRINT("\nTruncate tests:\n");
 

--- a/tests/subsys/fs/fat_fs_api/src/test_fat_file_reentrant.c
+++ b/tests/subsys/fs/fat_fs_api/src/test_fat_file_reentrant.c
@@ -135,7 +135,7 @@ void tlock_mutex(void *p1, void *p2, void *p3)
 void tfile2_access(void *p1, void *p2, void *p3)
 {
 	int res;
-	ssize_t brw;
+	k_ssize_t brw;
 	struct fs_file_t filep2;
 
 	TC_PRINT("File 2 access thread started\n");

--- a/tests/subsys/fs/fat_fs_dual_drive/src/test_fat_file.c
+++ b/tests/subsys/fs/fat_fs_dual_drive/src/test_fat_file.c
@@ -39,7 +39,7 @@ static int test_file_open(const char *path)
 
 int test_file_write(void)
 {
-	ssize_t brw;
+	k_ssize_t brw;
 	int res;
 
 	TC_PRINT("Write tests:\n");
@@ -92,7 +92,7 @@ static int test_file_sync(void)
 
 static int test_file_read(void)
 {
-	ssize_t brw;
+	k_ssize_t brw;
 	int res;
 	char read_buff[80];
 	size_t sz = strlen(test_str);
@@ -132,9 +132,9 @@ static int test_file_read(void)
 static int test_file_truncate(void)
 {
 	int res;
-	off_t orig_pos;
+	k_off_t orig_pos;
 	char read_buff[80];
-	ssize_t brw;
+	k_ssize_t brw;
 
 	TC_PRINT("Truncate tests:\n");
 

--- a/tests/subsys/fs/fs_api/src/test_fs.c
+++ b/tests/subsys/fs/fs_api/src/test_fs.c
@@ -86,7 +86,7 @@ static int temp_rename(struct fs_mount_t *mountp, const char *from,
 	return 0;
 }
 
-static ssize_t temp_read(struct fs_file_t *zfp, void *ptr, size_t size)
+static k_ssize_t temp_read(struct fs_file_t *zfp, void *ptr, size_t size)
 {
 	unsigned int br;
 
@@ -105,7 +105,7 @@ static ssize_t temp_read(struct fs_file_t *zfp, void *ptr, size_t size)
 	return br;
 }
 
-static ssize_t temp_write(struct fs_file_t *zfp, const void *ptr, size_t size)
+static k_ssize_t temp_write(struct fs_file_t *zfp, const void *ptr, size_t size)
 {
 	unsigned int bw;
 
@@ -130,7 +130,7 @@ static ssize_t temp_write(struct fs_file_t *zfp, const void *ptr, size_t size)
 	return bw;
 }
 
-static int temp_seek(struct fs_file_t *zfp, off_t offset, int whence)
+static int temp_seek(struct fs_file_t *zfp, k_off_t offset, int whence)
 {
 
 	if (!zfp) {
@@ -158,7 +158,7 @@ static int temp_seek(struct fs_file_t *zfp, off_t offset, int whence)
 	return 0;
 }
 
-static off_t temp_tell(struct fs_file_t *zfp)
+static k_off_t temp_tell(struct fs_file_t *zfp)
 {
 	if (!zfp) {
 		return -EINVAL;
@@ -171,7 +171,7 @@ static off_t temp_tell(struct fs_file_t *zfp)
 	return cur - buffer;
 }
 
-static int temp_truncate(struct fs_file_t *zfp, off_t length)
+static int temp_truncate(struct fs_file_t *zfp, k_off_t length)
 {
 	if (!zfp) {
 		return -EINVAL;

--- a/tests/subsys/fs/fs_api/src/test_fs_dir_file.c
+++ b/tests/subsys/fs/fs_api/src/test_fs_dir_file.c
@@ -531,7 +531,7 @@ void test_file_open(void)
 
 static int _test_file_write(void)
 {
-	ssize_t brw;
+	k_ssize_t brw;
 	int ret;
 
 	TC_PRINT("\nWrite tests:\n");
@@ -597,7 +597,7 @@ void test_file_write(void)
 static int _test_file_sync(void)
 {
 	int ret;
-	ssize_t brw;
+	k_ssize_t brw;
 
 	TC_PRINT("\nSync tests:\n");
 
@@ -674,7 +674,7 @@ ZTEST(fs_api_dir_file, test_file_sync)
  */
 void test_file_read(void)
 {
-	ssize_t brw;
+	k_ssize_t brw;
 	char read_buff[80];
 	size_t sz = strlen(test_str);
 
@@ -733,9 +733,9 @@ void test_file_seek(void)
 static int _test_file_truncate(void)
 {
 	int ret;
-	off_t orig_pos;
+	k_off_t orig_pos;
 	char read_buff[80];
-	ssize_t brw;
+	k_ssize_t brw;
 
 	TC_PRINT("\nTruncate tests: max file size is 128byte\n");
 

--- a/tests/subsys/fs/multi-fs/src/test_common_file.c
+++ b/tests/subsys/fs/multi-fs/src/test_common_file.c
@@ -35,7 +35,7 @@ int test_file_open(struct fs_file_t *filep, const char *file_path)
 
 int test_file_write(struct fs_file_t *filep, const char *test_str)
 {
-	ssize_t brw;
+	k_ssize_t brw;
 	int res;
 
 	TC_PRINT("\nWrite tests:\n");
@@ -72,7 +72,7 @@ int test_file_write(struct fs_file_t *filep, const char *test_str)
 
 int test_file_read(struct fs_file_t *filep, const char *test_str)
 {
-	ssize_t brw;
+	k_ssize_t brw;
 	int res;
 	char read_buff[80];
 	size_t sz = strlen(test_str);

--- a/tests/subsys/fs/multi-fs/src/test_ram_backend.c
+++ b/tests/subsys/fs/multi-fs/src/test_ram_backend.c
@@ -18,11 +18,10 @@
 
 static uint8_t rambuf[TEST_PARTITION_SIZE];
 
-static int test_flash_ram_erase(const struct device *dev, off_t offset,
-				size_t len)
+static int test_flash_ram_erase(const struct device *dev, k_off_t offset, size_t len)
 {
 	struct flash_pages_info info;
-	off_t end_offset = offset + len;
+	k_off_t end_offset = offset + len;
 
 	zassert_true(offset >= 0, "invalid offset");
 	zassert_true(offset + len <= TEST_PARTITION_SIZE,
@@ -37,8 +36,8 @@ static int test_flash_ram_erase(const struct device *dev, off_t offset,
 	return 0;
 }
 
-static int test_flash_ram_write(const struct device *dev, off_t offset,
-						const void *data, size_t len)
+static int test_flash_ram_write(const struct device *dev, k_off_t offset, const void *data,
+				size_t len)
 {
 	zassert_true(offset >= 0, "invalid offset");
 	zassert_true(offset + len <= TEST_PARTITION_SIZE,
@@ -49,7 +48,7 @@ static int test_flash_ram_write(const struct device *dev, off_t offset,
 	return 0;
 }
 
-static int test_flash_ram_read(const struct device *dev, off_t offset,
+static int test_flash_ram_read(const struct device *dev, k_off_t offset,
 								void *data,
 								size_t len)
 {

--- a/tests/subsys/fs/nvs/src/main.c
+++ b/tests/subsys/fs/nvs/src/main.c
@@ -308,7 +308,7 @@ static void write_content(uint16_t max_id, uint16_t begin, uint16_t end,
 			     struct nvs_fs *fs)
 {
 	uint8_t buf[32];
-	ssize_t len;
+	k_ssize_t len;
 
 	for (uint16_t i = begin; i < end; i++) {
 		uint8_t id = (i % max_id);
@@ -325,7 +325,7 @@ static void check_content(uint16_t max_id, struct nvs_fs *fs)
 {
 	uint8_t rd_buf[32];
 	uint8_t buf[32];
-	ssize_t len;
+	k_ssize_t len;
 
 	for (uint16_t id = 0; id < max_id; id++) {
 		len = nvs_read(fs, id, rd_buf, sizeof(buf));
@@ -532,7 +532,7 @@ ZTEST_F(nvs, test_nvs_corrupted_sector_close_operation)
 ZTEST_F(nvs, test_nvs_full_sector)
 {
 	int err;
-	ssize_t len;
+	k_ssize_t len;
 	uint16_t filling_id = 0;
 	uint16_t i, data_read;
 
@@ -584,7 +584,7 @@ ZTEST_F(nvs, test_nvs_full_sector)
 ZTEST_F(nvs, test_delete)
 {
 	int err;
-	ssize_t len;
+	k_ssize_t len;
 	uint16_t filling_id, data_read;
 	uint32_t ate_wra, data_wra;
 
@@ -650,7 +650,7 @@ ZTEST_F(nvs, test_nvs_gc_corrupt_close_ate)
 {
 	struct nvs_ate ate, close_ate;
 	uint32_t data;
-	ssize_t len;
+	k_ssize_t len;
 	int err;
 #ifdef CONFIG_NVS_DATA_CRC
 	uint32_t data_crc;

--- a/tests/subsys/llext/simple/src/test_llext_simple.c
+++ b/tests/subsys/llext/simple/src/test_llext_simple.c
@@ -300,7 +300,7 @@ ZTEST(llext, test_find_section)
 	 */
 
 	int res;
-	ssize_t section_ofs;
+	k_ssize_t section_ofs;
 
 	struct llext_buf_loader buf_loader =
 		LLEXT_BUF_LOADER(find_section_ext, ARRAY_SIZE(find_section_ext));

--- a/tests/subsys/settings/fcb_init/src/settings_test_fcb_init.c
+++ b/tests/subsys/settings/fcb_init/src/settings_test_fcb_init.c
@@ -120,8 +120,7 @@ void test_prepare_storage(void)
 
 		(void)memset(new_val, (~ERASED_VAL) & 0xFF,
 			     FLASH_WRITE_BLOCK_SIZE);
-		err = flash_write(dev, (off_t)&prepared_mark, &new_val,
-				  sizeof(new_val));
+		err = flash_write(dev, (uintptr_t)&prepared_mark, &new_val, sizeof(new_val));
 		zassert_true(err == 0, "can't write prepared_mark");
 	}
 #else

--- a/tests/subsys/settings/file/include/settings_test_file.h
+++ b/tests/subsys/settings/file/include/settings_test_file.h
@@ -8,9 +8,12 @@
 #define _SETTINGS_TEST_FILE_H
 
 #include <stdio.h>
+#include <stdint.h>
 #include <string.h>
+
 #include <zephyr/ztest.h>
 #include <zephyr/fs/fs.h>
+#include <zephyr/types.h>
 
 #include <zephyr/settings/settings.h>
 
@@ -35,8 +38,7 @@ int ctest_get_call_state(void);
 
 void config_wipe_srcs(void);
 
-int fsutil_read_file(const char *path, off_t offset, size_t len, void *dst,
-		     size_t *out_len);
+int fsutil_read_file(const char *path, k_off_t offset, size_t len, void *dst, size_t *out_len);
 int fsutil_write_file(const char *path, const void *data, size_t len);
 int settings_test_file_strstr(const char *fname, char const *string,
 			      size_t str_len);

--- a/tests/subsys/settings/file/src/settings_test_file.c
+++ b/tests/subsys/settings/file/src/settings_test_file.c
@@ -6,6 +6,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <zephyr/types.h>
+
 #include "settings_test.h"
 #include "settings_priv.h"
 
@@ -142,12 +144,11 @@ void config_wipe_srcs(void)
 	settings_save_dst = NULL;
 }
 
-int fsutil_read_file(const char *path, off_t offset, size_t len, void *dst,
-		     size_t *out_len)
+int fsutil_read_file(const char *path, k_off_t offset, size_t len, void *dst, size_t *out_len)
 {
 	struct fs_file_t file;
 	int rc;
-	ssize_t r_len = 0;
+	k_ssize_t r_len = 0;
 
 	fs_file_t_init(&file);
 

--- a/tests/subsys/settings/functional/nvs/settings_test_nvs.c
+++ b/tests/subsys/settings/functional/nvs/settings_test_nvs.c
@@ -12,7 +12,7 @@ ZTEST(settings_functional, test_setting_storage_get)
 	int rc;
 	void *storage;
 	uint16_t data = 0x5a5a;
-	ssize_t nvs_rc;
+	k_ssize_t nvs_rc;
 
 	rc = settings_storage_get(&storage);
 	zassert_equal(0, rc, "Can't fetch storage reference (err=%d)", rc);

--- a/tests/subsys/storage/flash_map/src/main.c
+++ b/tests/subsys/storage/flash_map/src/main.c
@@ -40,7 +40,7 @@ ZTEST(flash_map, test_flash_area_get_sectors)
 	uint32_t sec_cnt;
 	int i;
 	int rc;
-	off_t off;
+	k_off_t off;
 	uint8_t wd[512];
 	uint8_t rd[512];
 	const struct device *flash_dev;

--- a/tests/subsys/storage/stream/stream_flash/src/main.c
+++ b/tests/subsys/storage/stream/stream_flash/src/main.c
@@ -286,17 +286,17 @@ ZTEST(lib_stream_flash, test_stream_flash_buf_size_greater_than_page_size)
 	zassert_true(rc < 0, "expected failure");
 }
 
-static int bad_read(const struct device *dev, off_t off, void *data, size_t len)
+static int bad_read(const struct device *dev, k_off_t off, void *data, size_t len)
 {
 	return -EINVAL;
 }
 
-static int fake_write(const struct device *dev, off_t off, const void *data, size_t len)
+static int fake_write(const struct device *dev, k_off_t off, const void *data, size_t len)
 {
 	return 0;
 }
 
-static int bad_write(const struct device *dev, off_t off, const void *data, size_t len)
+static int bad_write(const struct device *dev, k_off_t off, const void *data, size_t len)
 {
 	return -EINVAL;
 }
@@ -423,7 +423,7 @@ ZTEST(lib_stream_flash, test_stream_flash_buffered_write_whole_page)
 }
 
 /* Erase that never completes successfully */
-static int bad_erase(const struct device *dev, off_t offset, size_t size)
+static int bad_erase(const struct device *dev, k_off_t offset, size_t size)
 {
 	return -EINVAL;
 }
@@ -558,8 +558,8 @@ ZTEST(lib_stream_flash, test_stream_flash_progress_resume)
 	size_t bytes_written_old;
 	size_t bytes_written;
 #ifdef CONFIG_STREAM_FLASH_ERASE
-	off_t erase_offset_old;
-	off_t erase_offset;
+	k_off_t erase_offset_old;
+	k_off_t erase_offset;
 #endif
 
 	clear_all_progress();
@@ -624,8 +624,8 @@ ZTEST(lib_stream_flash, test_stream_flash_progress_clear)
 	size_t bytes_written_old;
 	size_t bytes_written;
 #ifdef CONFIG_STREAM_FLASH_ERASE
-	off_t erase_offset_old;
-	off_t erase_offset;
+	k_off_t erase_offset_old;
+	k_off_t erase_offset;
 #endif
 
 	clear_all_progress();


### PR DESCRIPTION
Although fdtable sat a layer below posix, as part of the base os, it was reaching up a layer for POSIX types, creating another dependency cycle.

Instead of forcing POSIX types to be used, simply add the native Zephyr types, `k_off_t` and `k_ssize_t`. Remove `<sys/types.h>` and `<fcntl.h>` inclusion below the POSIX layer, where appropriate.

Generally, it would be best to use only ISO or native zephyr types below POSIX.

(Would have fixed #75205 with a very small [workaround](https://gist.github.com/cfriedt/458a60d2827f230e709543fc33b73aa2))
Fixes #75513
Fixes #10436

Update:
To future-proof Zephyr in terms of file, disk, and device compatibility, a Kconfig option was added that allows the user to explicitly use a 64-bit `k_off_t`, even if the underlying hardware is only 32-bit.

> The question is whether we want future generations to pay off our debt + even more interest, or whether we are willing to pay the bill ourselves. This has already been ignored for 2 LTS releases.
> 
> Directly before an LTS release probably isn't a super appropriate time for a fix like this to go in, but then again, maybe it's the most appropriate time for it to go in 🤷‍♂️