### PR TITLE
twister: Expand overflow regex to match lld's output

### DIFF
--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -304,7 +304,7 @@ class CMake:
                     log.write(log_msg)
 
             if log_msg:
-                overflow_found = re.findall("region `(FLASH|ROM|RAM|ICCM|DCCM|SRAM|dram\\d_\\d_seg)' overflowed by", log_msg)
+                overflow_found = re.findall("region [`'](FLASH|ROM|RAM|ICCM|DCCM|SRAM|dram\\d_\\d_seg)':? overflowed by", log_msg)
                 imgtool_overflow_found = re.findall(r"Error: Image size \(.*\) \+ trailer \(.*\) exceeds requested size", log_msg)
                 if overflow_found and not self.options.overflow_as_errors:
                     logger.debug("Test skipped due to {} Overflow".format(overflow_found[0]))


### PR DESCRIPTION
Twister tries to match the linker's output to detect and (by default) skip tests that produce MEMORY region overflows when building. However, lld and GNU ld produce slightly different error messages when reporting MEMORY region overflows. For example, lld might produce the following:

```
ld.lld: error: section 'noinit' will not fit in region 'RAM': overflowed by 6624 bytes
```

Whereas GNU ld might produce the following:

```
ld.bfd: zephyr/zephyr_pre0.elf section `noinit' will not fit in region `RAM'
ld.bfd: region `RAM' overflowed by 6640 bytes
```

(Please note that these error messages were manually wrapped across lines in the commit message--the "real" error messages are shown above)

As such, twister's overflow regex will not match for lld and twister will report these cases as build failures rather than skipping them by default. To fix this, expand the overflow regex to accomodate lld's output.