### PR TITLE
net: socket: fix `sys/_timespec.h` not found error

### DIFF
--- a/include/zephyr/net/socket.h
+++ b/include/zephyr/net/socket.h
@@ -1403,21 +1403,11 @@ struct net_socket_register {
  * zephyr/net/socket.h header file.
  */
 #if defined(CONFIG_POSIX_API)
-#if !defined(ZEPHYR_INCLUDE_POSIX_ARPA_INET_H_)
-#include <zephyr/posix/arpa/inet.h>
-#endif
-#if !defined(ZEPHYR_INCLUDE_POSIX_NETDB_H_)
-#include <zephyr/posix/netdb.h>
-#endif
-#if !defined(ZEPHYR_INCLUDE_POSIX_UNISTD_H_)
-#include <zephyr/posix/unistd.h>
-#endif
-#if !defined(ZEPHYR_INCLUDE_POSIX_POLL_H_)
-#include <zephyr/posix/poll.h>
-#endif
-#if !defined(ZEPHYR_INCLUDE_POSIX_SYS_SOCKET_H_)
-#include <zephyr/posix/sys/socket.h>
-#endif
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <unistd.h>
+#include <poll.h>
+#include <sys/socket.h>
 #endif /* CONFIG_POSIX_API */
 
 #endif /* ZEPHYR_INCLUDE_NET_SOCKET_H_ */


### PR DESCRIPTION
fixes #75319