### PR TITLE
sys: util_macro: pairwise list iteration

### DIFF
--- a/include/zephyr/sys/util_loops.h
+++ b/include/zephyr/sys/util_loops.h
@@ -1079,6 +1079,265 @@
 
 #define Z_BYPASS(x) x
 
+/* Will result in compile-time errors */
+#define Z_PAIRWISE_ERROR(z_call, sep, fixed_arg0, fixed_arg1, ...) \
+	Odd number of arguments to pairwise function
+
+#define Z_PAIRWISE_FOR_LOOP_0(z_call, sep, fixed_arg0, fixed_arg1, ...)
+
+#define Z_PAIRWISE_FOR_LOOP_2(z_call, sep, fixed_arg0, fixed_arg1, y, x, ...) \
+	Z_PAIRWISE_FOR_LOOP_0(z_call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+	z_call(0, x, y, fixed_arg0, fixed_arg1)
+
+#define Z_PAIRWISE_FOR_LOOP_4(z_call, sep, fixed_arg0, fixed_arg1, y, x, ...) \
+	Z_PAIRWISE_FOR_LOOP_2(z_call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+	__DEBRACKET sep \
+	z_call(1, x, y, fixed_arg0, fixed_arg1)
+
+#define Z_PAIRWISE_FOR_LOOP_6(z_call, sep, fixed_arg0, fixed_arg1, y, x, ...) \
+	Z_PAIRWISE_FOR_LOOP_4(z_call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+	__DEBRACKET sep \
+	z_call(2, x, y, fixed_arg0, fixed_arg1)
+
+#define Z_PAIRWISE_FOR_LOOP_8(z_call, sep, fixed_arg0, fixed_arg1, y, x, ...) \
+	Z_PAIRWISE_FOR_LOOP_6(z_call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+	__DEBRACKET sep \
+	z_call(3, x, y, fixed_arg0, fixed_arg1)
+
+#define Z_PAIRWISE_FOR_LOOP_10(z_call, sep, fixed_arg0, fixed_arg1, y, x, ...) \
+	Z_PAIRWISE_FOR_LOOP_8(z_call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+	__DEBRACKET sep \
+	z_call(4, x, y, fixed_arg0, fixed_arg1)
+
+#define Z_PAIRWISE_FOR_LOOP_12(z_call, sep, fixed_arg0, fixed_arg1, y, x, ...) \
+	Z_PAIRWISE_FOR_LOOP_10(z_call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+	__DEBRACKET sep \
+	z_call(5, x, y, fixed_arg0, fixed_arg1)
+
+#define Z_PAIRWISE_FOR_LOOP_14(z_call, sep, fixed_arg0, fixed_arg1, y, x, ...) \
+	Z_PAIRWISE_FOR_LOOP_12(z_call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+	__DEBRACKET sep \
+	z_call(6, x, y, fixed_arg0, fixed_arg1)
+
+#define Z_PAIRWISE_FOR_LOOP_16(z_call, sep, fixed_arg0, fixed_arg1, y, x, ...) \
+	Z_PAIRWISE_FOR_LOOP_14(z_call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+	__DEBRACKET sep \
+	z_call(7, x, y, fixed_arg0, fixed_arg1)
+
+#define Z_PAIRWISE_FOR_LOOP_18(z_call, sep, fixed_arg0, fixed_arg1, y, x, ...) \
+	Z_PAIRWISE_FOR_LOOP_16(z_call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+	__DEBRACKET sep \
+	z_call(8, x, y, fixed_arg0, fixed_arg1)
+
+#define Z_PAIRWISE_FOR_LOOP_20(z_call, sep, fixed_arg0, fixed_arg1, y, x, ...) \
+	Z_PAIRWISE_FOR_LOOP_18(z_call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+	__DEBRACKET sep \
+	z_call(9, x, y, fixed_arg0, fixed_arg1)
+
+#define Z_PAIRWISE_FOR_LOOP_22(z_call, sep, fixed_arg0, fixed_arg1, y, x, ...) \
+	Z_PAIRWISE_FOR_LOOP_20(z_call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+	__DEBRACKET sep \
+	z_call(10, x, y, fixed_arg0, fixed_arg1)
+
+#define Z_PAIRWISE_FOR_LOOP_24(z_call, sep, fixed_arg0, fixed_arg1, y, x, ...) \
+	Z_PAIRWISE_FOR_LOOP_22(z_call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+	__DEBRACKET sep \
+	z_call(11, x, y, fixed_arg0, fixed_arg1)
+
+#define Z_PAIRWISE_FOR_LOOP_26(z_call, sep, fixed_arg0, fixed_arg1, y, x, ...) \
+	Z_PAIRWISE_FOR_LOOP_24(z_call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+	__DEBRACKET sep \
+	z_call(12, x, y, fixed_arg0, fixed_arg1)
+
+#define Z_PAIRWISE_FOR_LOOP_28(z_call, sep, fixed_arg0, fixed_arg1, y, x, ...) \
+	Z_PAIRWISE_FOR_LOOP_26(z_call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+	__DEBRACKET sep \
+	z_call(13, x, y, fixed_arg0, fixed_arg1)
+
+#define Z_PAIRWISE_FOR_LOOP_30(z_call, sep, fixed_arg0, fixed_arg1, y, x, ...) \
+	Z_PAIRWISE_FOR_LOOP_28(z_call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+	__DEBRACKET sep \
+	z_call(14, x, y, fixed_arg0, fixed_arg1)
+
+#define Z_PAIRWISE_FOR_LOOP_32(z_call, sep, fixed_arg0, fixed_arg1, y, x, ...) \
+	Z_PAIRWISE_FOR_LOOP_30(z_call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+	__DEBRACKET sep \
+	z_call(15, x, y, fixed_arg0, fixed_arg1)
+
+#define Z_PAIRWISE_FOR_LOOP_34(z_call, sep, fixed_arg0, fixed_arg1, y, x, ...) \
+	Z_PAIRWISE_FOR_LOOP_32(z_call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+	__DEBRACKET sep \
+	z_call(16, x, y, fixed_arg0, fixed_arg1)
+
+#define Z_PAIRWISE_FOR_LOOP_36(z_call, sep, fixed_arg0, fixed_arg1, y, x, ...) \
+	Z_PAIRWISE_FOR_LOOP_34(z_call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+	__DEBRACKET sep \
+	z_call(17, x, y, fixed_arg0, fixed_arg1)
+
+#define Z_PAIRWISE_FOR_LOOP_38(z_call, sep, fixed_arg0, fixed_arg1, y, x, ...) \
+	Z_PAIRWISE_FOR_LOOP_36(z_call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+	__DEBRACKET sep \
+	z_call(18, x, y, fixed_arg0, fixed_arg1)
+
+#define Z_PAIRWISE_FOR_LOOP_40(z_call, sep, fixed_arg0, fixed_arg1, y, x, ...) \
+	Z_PAIRWISE_FOR_LOOP_38(z_call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+	__DEBRACKET sep \
+	z_call(19, x, y, fixed_arg0, fixed_arg1)
+
+#define Z_PAIRWISE_FOR_LOOP_42(z_call, sep, fixed_arg0, fixed_arg1, y, x, ...) \
+	Z_PAIRWISE_FOR_LOOP_40(z_call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+	__DEBRACKET sep \
+	z_call(20, x, y, fixed_arg0, fixed_arg1)
+
+#define Z_PAIRWISE_FOR_LOOP_44(z_call, sep, fixed_arg0, fixed_arg1, y, x, ...) \
+	Z_PAIRWISE_FOR_LOOP_42(z_call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+	__DEBRACKET sep \
+	z_call(21, x, y, fixed_arg0, fixed_arg1)
+
+#define Z_PAIRWISE_FOR_LOOP_46(z_call, sep, fixed_arg0, fixed_arg1, y, x, ...) \
+	Z_PAIRWISE_FOR_LOOP_44(z_call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+	__DEBRACKET sep \
+	z_call(22, x, y, fixed_arg0, fixed_arg1)
+
+#define Z_PAIRWISE_FOR_LOOP_48(z_call, sep, fixed_arg0, fixed_arg1, y, x, ...) \
+	Z_PAIRWISE_FOR_LOOP_46(z_call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+	__DEBRACKET sep \
+	z_call(23, x, y, fixed_arg0, fixed_arg1)
+
+#define Z_PAIRWISE_FOR_LOOP_50(z_call, sep, fixed_arg0, fixed_arg1, y, x, ...) \
+	Z_PAIRWISE_FOR_LOOP_48(z_call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+	__DEBRACKET sep \
+	z_call(24, x, y, fixed_arg0, fixed_arg1)
+
+#define Z_PAIRWISE_FOR_LOOP_52(z_call, sep, fixed_arg0, fixed_arg1, y, x, ...) \
+	Z_PAIRWISE_FOR_LOOP_50(z_call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+	__DEBRACKET sep \
+	z_call(25, x, y, fixed_arg0, fixed_arg1)
+
+#define Z_PAIRWISE_FOR_LOOP_54(z_call, sep, fixed_arg0, fixed_arg1, y, x, ...) \
+	Z_PAIRWISE_FOR_LOOP_52(z_call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+	__DEBRACKET sep \
+	z_call(26, x, y, fixed_arg0, fixed_arg1)
+
+#define Z_PAIRWISE_FOR_LOOP_56(z_call, sep, fixed_arg0, fixed_arg1, y, x, ...) \
+	Z_PAIRWISE_FOR_LOOP_54(z_call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+	__DEBRACKET sep \
+	z_call(27, x, y, fixed_arg0, fixed_arg1)
+
+#define Z_PAIRWISE_FOR_LOOP_58(z_call, sep, fixed_arg0, fixed_arg1, y, x, ...) \
+	Z_PAIRWISE_FOR_LOOP_56(z_call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+	__DEBRACKET sep \
+	z_call(28, x, y, fixed_arg0, fixed_arg1)
+
+#define Z_PAIRWISE_FOR_LOOP_60(z_call, sep, fixed_arg0, fixed_arg1, y, x, ...) \
+	Z_PAIRWISE_FOR_LOOP_58(z_call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+	__DEBRACKET sep \
+	z_call(29, x, y, fixed_arg0, fixed_arg1)
+
+#define Z_PAIRWISE_FOR_LOOP_62(z_call, sep, fixed_arg0, fixed_arg1, y, x, ...) \
+	Z_PAIRWISE_FOR_LOOP_60(z_call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+	__DEBRACKET sep \
+	z_call(30, x, y, fixed_arg0, fixed_arg1)
+
+#define Z_PAIRWISE_FOR_LOOP_64(z_call, sep, fixed_arg0, fixed_arg1, y, x, ...) \
+	Z_PAIRWISE_FOR_LOOP_62(z_call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
+	__DEBRACKET sep \
+	z_call(31, x, y, fixed_arg0, fixed_arg1)
+
+#define Z_PAIRWISE_FOR_EACH_ENGINE(x, sep, fixed_arg0, fixed_arg1, ...) \
+	Z_FOR_LOOP_GET_ARG(__VA_ARGS__, \
+		Z_PAIRWISE_FOR_LOOP_64, \
+		Z_PAIRWISE_ERROR, \
+		Z_PAIRWISE_FOR_LOOP_62, \
+		Z_PAIRWISE_ERROR, \
+		Z_PAIRWISE_FOR_LOOP_60, \
+		Z_PAIRWISE_ERROR, \
+		Z_PAIRWISE_FOR_LOOP_58, \
+		Z_PAIRWISE_ERROR, \
+		Z_PAIRWISE_FOR_LOOP_56, \
+		Z_PAIRWISE_ERROR, \
+		Z_PAIRWISE_FOR_LOOP_54, \
+		Z_PAIRWISE_ERROR, \
+		Z_PAIRWISE_FOR_LOOP_52, \
+		Z_PAIRWISE_ERROR, \
+		Z_PAIRWISE_FOR_LOOP_50, \
+		Z_PAIRWISE_ERROR, \
+		Z_PAIRWISE_FOR_LOOP_48, \
+		Z_PAIRWISE_ERROR, \
+		Z_PAIRWISE_FOR_LOOP_46, \
+		Z_PAIRWISE_ERROR, \
+		Z_PAIRWISE_FOR_LOOP_44, \
+		Z_PAIRWISE_ERROR, \
+		Z_PAIRWISE_FOR_LOOP_42, \
+		Z_PAIRWISE_ERROR, \
+		Z_PAIRWISE_FOR_LOOP_40, \
+		Z_PAIRWISE_ERROR, \
+		Z_PAIRWISE_FOR_LOOP_38, \
+		Z_PAIRWISE_ERROR, \
+		Z_PAIRWISE_FOR_LOOP_36, \
+		Z_PAIRWISE_ERROR, \
+		Z_PAIRWISE_FOR_LOOP_34, \
+		Z_PAIRWISE_ERROR, \
+		Z_PAIRWISE_FOR_LOOP_32, \
+		Z_PAIRWISE_ERROR, \
+		Z_PAIRWISE_FOR_LOOP_30, \
+		Z_PAIRWISE_ERROR, \
+		Z_PAIRWISE_FOR_LOOP_28, \
+		Z_PAIRWISE_ERROR, \
+		Z_PAIRWISE_FOR_LOOP_26, \
+		Z_PAIRWISE_ERROR, \
+		Z_PAIRWISE_FOR_LOOP_24, \
+		Z_PAIRWISE_ERROR, \
+		Z_PAIRWISE_FOR_LOOP_22, \
+		Z_PAIRWISE_ERROR, \
+		Z_PAIRWISE_FOR_LOOP_20, \
+		Z_PAIRWISE_ERROR, \
+		Z_PAIRWISE_FOR_LOOP_18, \
+		Z_PAIRWISE_ERROR, \
+		Z_PAIRWISE_FOR_LOOP_16, \
+		Z_PAIRWISE_ERROR, \
+		Z_PAIRWISE_FOR_LOOP_14, \
+		Z_PAIRWISE_ERROR, \
+		Z_PAIRWISE_FOR_LOOP_12, \
+		Z_PAIRWISE_ERROR, \
+		Z_PAIRWISE_FOR_LOOP_10, \
+		Z_PAIRWISE_ERROR, \
+		Z_PAIRWISE_FOR_LOOP_8, \
+		Z_PAIRWISE_ERROR, \
+		Z_PAIRWISE_FOR_LOOP_6, \
+		Z_PAIRWISE_ERROR, \
+		Z_PAIRWISE_FOR_LOOP_4, \
+		Z_PAIRWISE_ERROR, \
+		Z_PAIRWISE_FOR_LOOP_2, \
+		Z_PAIRWISE_ERROR, \
+		Z_PAIRWISE_FOR_LOOP_0)(x, sep, fixed_arg0, fixed_arg1, __VA_ARGS__)
+
+#define Z_PAIRWISE_FOR_EACH_IDX_FIXED_ARG_EXEC(idx, x, y, fixed_arg0, fixed_arg1) \
+	fixed_arg0(idx, x, y, fixed_arg1)
+
+#define Z_PAIRWISE_FOR_EACH_IDX_FIXED_ARG(F, sep, fixed_arg, ...) \
+	Z_PAIRWISE_FOR_EACH_ENGINE(Z_PAIRWISE_FOR_EACH_IDX_FIXED_ARG_EXEC, sep, \
+				   F, fixed_arg, __VA_ARGS__)
+
+#define Z_PAIRWISE_FOR_EACH_FIXED_ARG_EXEC(idx, x, y, fixed_arg0, fixed_arg1) \
+	fixed_arg0(x, y, fixed_arg1)
+
+#define Z_PAIRWISE_FOR_EACH_FIXED_ARG(F, sep, fixed_arg, ...) \
+	Z_PAIRWISE_FOR_EACH_ENGINE(Z_PAIRWISE_FOR_EACH_FIXED_ARG_EXEC, sep, \
+				   F, fixed_arg, __VA_ARGS__)
+
+#define Z_PAIRWISE_FOR_EACH_IDX_EXEC(idx, x, y, fixed_arg0, fixed_arg1) \
+	fixed_arg0(idx, x, y)
+
+#define Z_PAIRWISE_FOR_EACH_IDX(F, sep, ...) \
+	Z_PAIRWISE_FOR_EACH_ENGINE(Z_PAIRWISE_FOR_EACH_IDX_EXEC, sep, F, _, __VA_ARGS__)
+
+#define Z_PAIRWISE_FOR_EACH_EXEC(idx, x, y, fixed_arg0, fixed_arg1) \
+	fixed_arg0(x, y)
+
+#define Z_PAIRWISE_FOR_EACH(F, sep, ...) \
+	Z_PAIRWISE_FOR_EACH_ENGINE(Z_PAIRWISE_FOR_EACH_EXEC, sep, F, _, __VA_ARGS__)
+
 /* Set of UTIL_LISTIFY particles */
 #include "util_listify.h"
 

--- a/include/zephyr/sys/util_macro.h
+++ b/include/zephyr/sys/util_macro.h
@@ -613,6 +613,118 @@ extern "C" {
 #define FOR_EACH_IDX_FIXED_ARG(F, sep, fixed_arg, ...) \
 	Z_FOR_EACH_IDX_FIXED_ARG(F, sep, fixed_arg, REVERSE_ARGS(__VA_ARGS__))
 
+/**
+ * @brief Call a macro @p F on each pair of arguments with a given
+ *        separator between each call.
+ *
+ * Example:
+ *
+ *     #define F(x, y) {x, y}
+ *     PAIRWISE_FOR_EACH(F, (,), 4, 5, 6, 7);
+ *
+ * This expands to:
+ *
+ *     {4, 5},{6, 7};
+ *
+ * @warning Variable argument list must be of even length.
+ *
+ * @param F Macro to invoke
+ * @param sep Separator (e.g. comma or semicolon). Must be in parentheses;
+ *            this is required to enable providing a comma as separator.
+ * @param ... Variable argument list. The macro @p F is invoked as
+ *            <tt>F(index, pair[0], pair[1])</tt> for each pair of
+ *            elements in the list.
+ */
+#define PAIRWISE_FOR_EACH(F, sep, ...) \
+	Z_PAIRWISE_FOR_EACH(F, sep, REVERSE_ARGS(__VA_ARGS__))
+
+/**
+ * @brief Call macro @p F on each pair of arguments, with the pairs's index
+ *        as an additional parameter.
+ *
+ * This is like PAIRWISE_FOR_EACH(), except @p F should be a macro which takes
+ * three arguments: <tt>F(index, variable_arg0, variable_arg1)</tt>.
+ *
+ * Example:
+ *
+ *     #define F(idx, x, y) int a##idx = {x, y}
+ *     PAIRWISE_FOR_EACH_IDX(F, (;), 4, 5, 6, 7);
+ *
+ * This expands to:
+ *
+ *     int a0 = {4, 5};
+ *     int a1 = {6, 7};
+ *
+ * @warning Variable argument list must be of even length.
+ *
+ * @param F Macro to invoke
+ * @param sep Separator (e.g. comma or semicolon). Must be in parentheses;
+ *            this is required to enable providing a comma as separator.
+ * @param ... Variable argument list. The macro @p F is invoked as
+ *            <tt>F(index, pair[0], pair[1])</tt> for each pair of
+ *            elements in the list.
+ */
+#define PAIRWISE_FOR_EACH_IDX(F, sep, ...) \
+	Z_PAIRWISE_FOR_EACH_IDX(F, sep, REVERSE_ARGS(__VA_ARGS__))
+
+/**
+ * @brief Call macro @p F on each pair of arguments, with an additional fixed
+ *	  argument as a parameter.
+ *
+ * This is like PAIRWISE_FOR_EACH(), except @p F should be a macro which takes two
+ * arguments: <tt>F(x, y, fixed_arg)</tt>.
+ *
+ * Example:
+ *
+ *     static void func(int val1, int val2, void *dev);
+ *     PAIRWISE_FOR_EACH_FIXED_ARG(func, (;), dev, 4, 5, 6, 7);
+ *
+ * This expands to:
+ *
+ *     func(4, 5, dev);
+ *     func(5, 6, dev);
+ *
+ * @warning Variable argument list must be of even length.
+ *
+ * @param F Macro to invoke
+ * @param sep Separator (e.g. comma or semicolon). Must be in parentheses;
+ *            this is required to enable providing a comma as separator.
+ * @param fixed_arg Fixed argument passed to @p F as the second macro parameter.
+ * @param ... Variable argument list. The macro @p F is invoked as
+ *            <tt>F(pair[0], pair[1], fixed_arg)</tt> for each pair of
+ *            elements in the list.
+ */
+#define PAIRWISE_FOR_EACH_FIXED_ARG(F, sep, fixed_arg, ...) \
+	Z_PAIRWISE_FOR_EACH_FIXED_ARG(F, sep, fixed_arg, REVERSE_ARGS(__VA_ARGS__))
+
+/**
+ * @brief Calls macro @p F for each each pair of arguments with an index and
+ *        fixed argument
+ *
+ * This is like the combination of PAIRWISE_FOR_EACH_IDX() with
+ * PAIRWISE_FOR_EACH_FIXED_ARG().
+ *
+ * Example:
+ *
+ *     #define F(idx, x, y, fixed_arg) int fixed_arg##idx = {x, y}
+ *     FOR_EACH_IDX_FIXED_ARG(F, (;), a, 4, 5, 6, 7);
+ *
+ * This expands to:
+ *
+ *     int a0 = {4, 5};
+ *     int a1 = {6, 7};
+ *
+ * @param F Macro to invoke
+ * @param sep Separator (e.g. comma or semicolon). Must be in parentheses;
+ *            This is required to enable providing a comma as separator.
+ * @param fixed_arg Fixed argument passed to @p F as the third macro parameter.
+ * @param ... Variable list of arguments. The macro @p F is invoked as
+ *            <tt>F(index, pair[0], pair[1], fixed_arg)</tt> for each pair of
+ *            elements in the list.
+ */
+#define PAIRWISE_FOR_EACH_IDX_FIXED_ARG(F, sep, fixed_arg, ...) \
+	Z_PAIRWISE_FOR_EACH_IDX_FIXED_ARG(F, sep, fixed_arg, REVERSE_ARGS(__VA_ARGS__))
+
 /** @brief Reverse arguments order.
  *
  * @param ... Variable argument list.

--- a/tests/unit/util/main.c
+++ b/tests/unit/util/main.c
@@ -379,6 +379,90 @@ ZTEST(util, test_FOR_EACH_IDX_FIXED_ARG) {
 	zassert_equal(a2, 3, "Unexpected value %d", a2);
 }
 
+ZTEST(util, test_PAIRWISE_FOR_EACH) {
+	#undef FOO
+	#define FOO(x, y) {x, y}
+
+	struct paired_struct {
+		int x;
+		int y;
+	} test[] = {PAIRWISE_FOR_EACH(FOO, (,), 4, 5, 6, 7)};
+
+	zassert_equal(2, ARRAY_SIZE(test));
+	zassert_equal(4, test[0].x);
+	zassert_equal(5, test[0].y);
+	zassert_equal(6, test[1].x);
+	zassert_equal(7, test[1].y);
+}
+
+
+ZTEST(util, test_PAIRWISE_FOR_EACH_IDX) {
+	#undef FOO
+	#define FOO(idx, x, y) {idx, x, y}
+
+	struct paired_struct {
+		int idx;
+		int x;
+		int y;
+	} test[] = {PAIRWISE_FOR_EACH_IDX(FOO, (,), 4, 5, 6, 7)};
+
+	zassert_equal(2, ARRAY_SIZE(test));
+	zassert_equal(0, test[0].idx);
+	zassert_equal(1, test[1].idx);
+	zassert_equal(4, test[0].x);
+	zassert_equal(5, test[0].y);
+	zassert_equal(6, test[1].x);
+	zassert_equal(7, test[1].y);
+}
+
+ZTEST(util, test_PAIRWISE_FOR_EACH_FIXED_ARG) {
+	#undef FOO
+	#define FOO(x, y, fixed) {x, y, fixed}
+
+	struct paired_struct {
+		int x;
+		int y;
+		int fixed;
+	} test[] = {PAIRWISE_FOR_EACH_FIXED_ARG(FOO, (,), 100, 4, 5, 6, 7, 8, 9)};
+
+	zassert_equal(3, ARRAY_SIZE(test));
+	zassert_equal(4, test[0].x);
+	zassert_equal(5, test[0].y);
+	zassert_equal(6, test[1].x);
+	zassert_equal(7, test[1].y);
+	zassert_equal(8, test[2].x);
+	zassert_equal(9, test[2].y);
+	zassert_equal(100, test[0].fixed);
+	zassert_equal(100, test[1].fixed);
+	zassert_equal(100, test[2].fixed);
+}
+
+ZTEST(util, test_PAIRWISE_FOR_EACH_IDX_FIXED_ARG) {
+	#undef FOO
+	#define FOO(idx, x, y, fixed) {idx, x, y, fixed}
+
+	struct paired_struct {
+		int idx;
+		int x;
+		int y;
+		int fixed;
+	} test[] = {PAIRWISE_FOR_EACH_IDX_FIXED_ARG(FOO, (,), 150, 4, 5, 6, 7, 8, 9)};
+
+	zassert_equal(3, ARRAY_SIZE(test));
+	zassert_equal(0, test[0].idx);
+	zassert_equal(1, test[1].idx);
+	zassert_equal(2, test[2].idx);
+	zassert_equal(4, test[0].x);
+	zassert_equal(5, test[0].y);
+	zassert_equal(6, test[1].x);
+	zassert_equal(7, test[1].y);
+	zassert_equal(8, test[2].x);
+	zassert_equal(9, test[2].y);
+	zassert_equal(150, test[0].fixed);
+	zassert_equal(150, test[1].fixed);
+	zassert_equal(150, test[2].fixed);
+}
+
 ZTEST(util, test_IS_EMPTY) {
 	#define test_IS_EMPTY_REAL_EMPTY
 	#define test_IS_EMPTY_NOT_EMPTY XXX_DO_NOT_REPLACE_XXX


### PR DESCRIPTION
Add a new family of argument list iteration macros, based on `FOR_EACH_*`, that instead of calling a macro on every argument, calls a macro on each pair of arguments. Naming follows the same convention as `FOR_EACH_*`, prefixed with `PAIRWISE_`. Resulting in `PAIRWISE_FOR_EACH(...)`, etc.

The primary value in this family of macros is the ability to iterate over values of multiple types, in particular parameterizing a macro argument:
```
 #define M1(arg) {.const = "x", .val = arg}
 #define M2(arg) {.const = "y", .val = arg}
 #define M3(arg) {.const = "z", .val = arg}

 #define M_EVAL(macro, arg) macro(arg)

struct t some_struct[] = {
    PAIRWISE_FOR_EACH(M_EVAL, (,) M1, 1, M2, 12, M3, -10),
};
```

The above functionality is not possible with the existing `FOR_EACH_*` family of macros without defining an individual wrapper for each of `M1`, `M2` and `M3` that contains the variable value.