### PR TITLE
boards: shield: Support touch for the NXP LCD-PAR-S035 LCD on MCXN947

### DIFF
--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
@@ -52,6 +52,18 @@
 			status = "disabled";
 		};
 	};
+
+	nxp_flexio_connector: flexio-connector {
+		compatible = "gpio-nexus";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map =	<
+			0  0 &gpio4 6 0 /* Pin 6, INT */
+			1  0 &gpio4 0 0 /* Pin 0, BOGUS RESET */
+		>;
+	};
+
 };
 
 &flexcomm1_lpspi1 {
@@ -59,7 +71,7 @@
 	pinctrl-names = "default";
 };
 
-&flexcomm2_lpi2c2 {
+flexio_i2c: &flexcomm2_lpi2c2 {
 	pinctrl-0 = <&pinmux_flexcomm2_lpi2c>;
 	pinctrl-names = "default";
 	clock-frequency = <I2C_BITRATE_STANDARD>;

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
@@ -54,12 +54,12 @@
 	};
 
 	nxp_flexio_connector: flexio-connector {
-		compatible = "gpio-nexus";
+		compatible = "nxp,flexio-lcd";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map =	<
-			0  0 &gpio4 6 0 /* Pin 6, INT */
+			0  0 &gpio4 6 0 /* Pin 5, INT */
 			1  0 &gpio4 0 0 /* Pin 0, BOGUS RESET */
 		>;
 	};

--- a/boards/shields/lcd_par_s035/Kconfig.defconfig
+++ b/boards/shields/lcd_par_s035/Kconfig.defconfig
@@ -4,6 +4,11 @@
 if SHIELD_LCD_PAR_S035
 if LVGL
 
+# Configure LVGL to use touchscreen with KSCAN API
+
+config INPUT
+	default y
+
 # Enable double buffering
 config LV_Z_DOUBLE_VDB
 	default y

--- a/boards/shields/lcd_par_s035/boards/frdm_mcxn947_mcxn947_cpu0.overlay
+++ b/boards/shields/lcd_par_s035/boards/frdm_mcxn947_mcxn947_cpu0.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2024, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+&flexio_i2c {
+	status = "okay";
+	gt911_lcd_par_s035: gt911-lcd_par_s035@5d {
+		compatible = "goodix,gt911";
+		reg = <0x5d>;
+		irq-gpios = <&nxp_flexio_connector 0 GPIO_ACTIVE_HIGH>;
+		/delete-property/ reset-gpios;
+		alt-addr = <0x14>;
+	};
+};

--- a/boards/shields/lcd_par_s035/boards/frdm_mcxn947_mcxn947_cpu0.overlay
+++ b/boards/shields/lcd_par_s035/boards/frdm_mcxn947_mcxn947_cpu0.overlay
@@ -8,9 +8,6 @@
 &flexio_i2c {
 	status = "okay";
 	gt911_lcd_par_s035: gt911-lcd_par_s035@5d {
-		compatible = "goodix,gt911";
-		reg = <0x5d>;
-		irq-gpios = <&nxp_flexio_connector 0 GPIO_ACTIVE_HIGH>;
 		/delete-property/ reset-gpios;
 		alt-addr = <0x14>;
 	};

--- a/boards/shields/lcd_par_s035/lcd_par_s035_8080.overlay
+++ b/boards/shields/lcd_par_s035/lcd_par_s035_8080.overlay
@@ -10,6 +10,13 @@
 	chosen {
 		zephyr,display = &st7796s;
 	};
+
+	lvgl_pointer {
+		compatible = "zephyr,lvgl-pointer-input";
+		input = <&gt911_lcd_par_s035>;
+		swap-xy;
+		invert-y;
+	};
 };
 
 &nxp_flexio_lcd {
@@ -37,5 +44,15 @@
 		ngc = [F0 09 0D 09 08 23 2E 33 46 38 13 13 2C 32];
 		madctl = <0x28>;
 		color-invert;
+	};
+};
+
+&flexio_i2c {
+	status = "okay";
+	gt911_lcd_par_s035: gt911-lcd_par_s035@5d {
+		compatible = "goodix,gt911";
+		reg = <0x5d>;
+		irq-gpios = <&nxp_flexio_connector 0 GPIO_ACTIVE_HIGH>; // INT
+		reset-gpios = <&nxp_flexio_connector 1 GPIO_ACTIVE_HIGH>; // RESET
 	};
 };

--- a/dts/bindings/gpio/nxp,flexio-lcd.yaml
+++ b/dts/bindings/gpio/nxp,flexio-lcd.yaml
@@ -1,0 +1,41 @@
+# Copyright 2024 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+
+compatible: "nxp,flexio-lcd"
+
+description: |
+    GPIO pins exposed on NXP FlexIO LCD interface. These pins are
+    exposed on a 32 pin. The pins have the
+    following assignments:
+
+      Pin Number    Usage
+      1             VDD (3v3)
+      2             GND
+      3             FC2_I2C_SCL-FXIO_HDR
+      4             FC2_I2C_SDA-FXIO_HDR
+      5             LCD_INT
+      6             LCD_GPIO
+      7             LCD_RST
+      8             LCD_DC
+      9             LCD_CS
+      10            LCD_WR
+      11            LCD_RD
+      12            LCD_TE
+      13-15         FXIO_HDR
+      16            D19
+      17            D20
+      18            D21
+      19            D22
+      20            D23
+      21            D24
+      22            D25
+      23            D26
+      24            D27
+      25            D28
+      26            D29
+      27            D30
+      28            D31
+      29-32         NC
+
+include: [gpio-nexus.yaml, base.yaml]


### PR DESCRIPTION
NXP LCD-PAR-S035 LCD supports touch: enable it
The reset pin of the LCD and the touch controller are shared so we set alt-addr to select GT911 I2C address by probing