### PR TITLE
samples: modules: canopennode: add bootloader argument

### DIFF
--- a/samples/modules/canopennode/README.rst
+++ b/samples/modules/canopennode/README.rst
@@ -409,7 +409,7 @@ for the FRDM-K64F as follows:
       :board: frdm_k64f
       :goals: build
       :west-args: --sysbuild
-      :gen-args: -Dcanopennode_CONF_FILE=prj_img_mgmt.conf
+      :gen-args: -Dcanopennode_CONF_FILE=prj_img_mgmt.conf -DSB_CONFIG_BOOTLOADER_MCUBOOT=y
       :compact:
 
 #. Flash the newly built MCUboot and CANopen sample binaries using west:


### PR DESCRIPTION
The README "Testing CANopen Program Download" section needs a sysbuild MCUboot option. Otherwise only the application is built and the test will fail.

This has probably been missing since commit
238d113185c041e951c7f3636b5cdc98cbf2d9d9.