### PR TITLE
[backport v3.5-branch] Bluetooth: host: sched-lock `bt_recv()`

### DIFF
--- a/drivers/bluetooth/hci/rpmsg.c
+++ b/drivers/bluetooth/hci/rpmsg.c
@@ -229,19 +229,7 @@ static void bt_rpmsg_rx(const uint8_t *data, size_t len)
 
 	if (buf) {
 		LOG_DBG("Calling bt_recv(%p)", buf);
-
-		/* The IPC service does not guarantee that the handler thread
-		 * is cooperative. In particular, the OpenAMP implementation is
-		 * preemtible by default. OTOH, the HCI driver interface requires
-		 * that the bt_recv() function is called from a cooperative
-		 * thread.
-		 *
-		 * Calling `k_sched lock()` has the effect of making the current
-		 * thread cooperative.
-		 */
-		k_sched_lock();
 		bt_recv(buf);
-		k_sched_unlock();
 
 		LOG_HEXDUMP_DBG(buf->data, buf->len, "RX buf payload:");
 	}

--- a/include/zephyr/drivers/bluetooth/hci_driver.h
+++ b/include/zephyr/drivers/bluetooth/hci_driver.h
@@ -89,8 +89,6 @@ static inline uint8_t bt_hci_evt_get_flags(uint8_t evt)
  * for so-called high priority HCI events, which should instead be delivered to
  * the host stack through bt_recv_prio().
  *
- * @note This function must only be called from a cooperative thread.
- *
  * @param buf Network buffer containing data from the controller.
  *
  * @return 0 on success or negative error number on failure.

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3758,7 +3758,7 @@ static void rx_queue_put(struct net_buf *buf)
 }
 #endif /* !CONFIG_BT_RECV_BLOCKING */
 
-int bt_recv(struct net_buf *buf)
+static int bt_recv_unsafe(struct net_buf *buf)
 {
 	bt_monitor_send(bt_monitor_opcode(buf), buf->data, buf->len);
 
@@ -3807,6 +3807,17 @@ int bt_recv(struct net_buf *buf)
 		net_buf_unref(buf);
 		return -EINVAL;
 	}
+}
+
+int bt_recv(struct net_buf *buf)
+{
+	int err;
+
+	k_sched_lock();
+	err = bt_recv_unsafe(buf);
+	k_sched_unlock();
+
+	return err;
 }
 
 int bt_recv_prio(struct net_buf *buf)


### PR DESCRIPTION
`bt_recv` is invoked from the BT long work queue, which is preemptible. The host uses cooperative scheduling to ensure thread safety.

Fixes https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-jmr9-xw2v-5vf4