### PR TITLE
net: mqtt: Fix possible socket leak with websocket transport

### DIFF
--- a/subsys/net/lib/mqtt/mqtt_transport_websocket.c
+++ b/subsys/net/lib/mqtt/mqtt_transport_websocket.c
@@ -174,8 +174,7 @@ int mqtt_client_websocket_disconnect(struct mqtt_client *client)
 
 	ret = websocket_disconnect(client->transport.websocket.sock);
 	if (ret < 0) {
-		NET_ERR("Websocket disconnect failed (%d)", ret);
-		return ret;
+		NET_DBG("Websocket disconnect failed (%d)", ret);
 	}
 
 	if (client->transport.type == MQTT_TRANSPORT_NON_SECURE_WEBSOCKET) {


### PR DESCRIPTION
In case underlying TCP/TLS connection is already down, the websocket_disconnect() call is expected to fail, as it involves communication. Therefore, mqtt_client_websocket_disconnect() should not quit early in such cases, as it could lead to an underlying socket leak.

Fixes #75334