### PR TITLE
Bluetooth: A2DP: Check if pointer is valid

### DIFF
--- a/subsys/bluetooth/host/classic/a2dp.c
+++ b/subsys/bluetooth/host/classic/a2dp.c
@@ -252,13 +252,11 @@ static int a2dp_set_config_ind(struct bt_avdtp *session, struct bt_avdtp_sep *se
 			stream->remote_ep = NULL;
 			stream->codec_config = *cfg.codec_config;
 			ep->stream = stream;
-		}
-	}
 
-	ops = stream->ops;
-	if (*errcode == 0) {
-		if ((ops != NULL) && (stream->ops->configured != NULL)) {
-			stream->ops->configured(stream);
+			ops = stream->ops;
+			if ((ops != NULL) && (ops->configured != NULL)) {
+				ops->configured(stream);
+			}
 		}
 	}
 


### PR DESCRIPTION
Only access the pointer `stream` if it is valid.

Fixes #74735 
Fixes #74740