### PR TITLE
ztest: shell: Fix memory leaks processing test arguments

### DIFF
--- a/subsys/testsuite/ztest/src/ztest_shell.c
+++ b/subsys/testsuite/ztest/src/ztest_shell.c
@@ -37,11 +37,15 @@ void z_ztest_run_all(const void *state, bool shuffle, int suite_iter, int case_i
 
 void ztest_reset_test_args(void)
 {
+	if (test_args != NULL) {
+		free((void *)test_args);
+	}
 	test_args = NULL;
 }
 
 void ztest_set_test_args(char *args)
 {
+	ztest_reset_test_args();
 	test_args = strdup(args);
 }
 
@@ -95,6 +99,7 @@ static bool z_ztest_testargs_contains(const char *suite_name, const char *test_n
 
 		suite_test_pair = strtok_r(NULL, ",", &last_suite_test_pair);
 	}
+	free((void *)test_args_local);
 	return found;
 }
 
@@ -122,6 +127,9 @@ bool z_ztest_should_suite_run(const void *state, struct ztest_suite_node *suite)
 		run_suite = suite->predicate(state);
 	}
 
+	if (test_args_local != NULL) {
+		free((void *)test_args_local);
+	}
 	return run_suite;
 }
 


### PR DESCRIPTION
Fix Ztest shell memory leaks when it process test arguments.

Fixes: #75322 