### PR TITLE
scripts: west_commands: Fix west boards for SoC and arch in modules

### DIFF
--- a/scripts/west_commands/boards.py
+++ b/scripts/west_commands/boards.py
@@ -73,16 +73,21 @@ class Boards(WestCommand):
         else:
             name_re = None
 
-        args.arch_roots = [ZEPHYR_BASE]
-        args.soc_roots = [ZEPHYR_BASE]
-        modules_board_roots = [ZEPHYR_BASE]
+        module_settings = {
+            'arch_root': [ZEPHYR_BASE],
+            'board_root': [ZEPHYR_BASE],
+            'soc_root': [ZEPHYR_BASE],
+        }
 
         for module in zephyr_module.parse_modules(ZEPHYR_BASE, self.manifest):
-            board_root = module.meta.get('build', {}).get('settings', {}).get('board_root')
-            if board_root is not None:
-                modules_board_roots.append(Path(module.project) / board_root)
+            for key in module_settings:
+                root = module.meta.get('build', {}).get('settings', {}).get(key)
+                if root is not None:
+                    module_settings[key].append(Path(module.project) / root)
 
-        args.board_roots += modules_board_roots
+        args.arch_roots += module_settings['arch_root']
+        args.board_roots += module_settings['board_root']
+        args.soc_roots += module_settings['soc_root']
 
         for board in list_boards.find_boards(args):
             if name_re is not None and not name_re.search(board.name):


### PR DESCRIPTION
Fixes #71761

The `west boards` command parses extra BOARD_ROOTs from Zephyr modules, so that the boards defined in those modules are automatically listed.

In HWMv2, OOT boards can be described in terms of OOT SoCs, which means that extra SOC_ROOTs must also be provided. Otherwise, an error message will be displayed when attempting to list all boards. Therefore, every Zephyr module SOC_ROOT should be included as well.

In HWMv1 (deprecated), OOT boards can be defined in terms of OOT archs, but module ARCH_ROOTs had never been included automatically. The fix for this is long overdue, but it's included for symmetry.