### PR TITLE
xen: Make XEN_INTERFACE_VERSION configurable

### DIFF
--- a/arch/arm64/core/xen/CMakeLists.txt
+++ b/arch/arm64/core/xen/CMakeLists.txt
@@ -4,8 +4,5 @@
 # Needed to separate definitions in common Xen headers
 zephyr_compile_options($<$<COMPILE_LANGUAGE:ASM>:-D__ASSEMBLY__>)
 
-# Xen interface version used in headers for correct definition
-zephyr_compile_options(-D__XEN_INTERFACE_VERSION__=0x00040e00)
-
 zephyr_library_sources(hypercall.S)
 zephyr_library_sources(enlighten.c)

--- a/arch/arm64/core/xen/Kconfig
+++ b/arch/arm64/core/xen/Kconfig
@@ -25,3 +25,11 @@ config XEN_DOM0LESS
 	help
 	  Configures Zephyr as DomU, that can be started on Dom0less
 	  setup.
+
+config XEN_INTERFACE_VERSION
+	hex "Xen interface version"
+	default 0x00040e00
+	depends on XEN
+	help
+	  Xen interface version to use. This is the version of the
+	  interface that Zephyr will use to communicate with the hypervisor.

--- a/include/zephyr/xen/public/grant_table.h
+++ b/include/zephyr/xen/public/grant_table.h
@@ -126,7 +126,7 @@ typedef uint32_t grant_ref_t;
  * Version 1 of the grant table entry structure is maintained purely
  * for backwards compatibility.  New guests should use version 2.
  */
-#if __XEN_INTERFACE_VERSION__ < 0x0003020a
+#if CONFIG_XEN_INTERFACE_VERSION < 0x0003020a
 #define grant_entry_v1 grant_entry
 #define grant_entry_v1_t grant_entry_t
 #endif
@@ -232,13 +232,13 @@ typedef struct grant_entry_v1 grant_entry_v1_t;
 #define GNTTABOP_copy				5
 #define GNTTABOP_query_size			6
 #define GNTTABOP_unmap_and_replace		7
-#if __XEN_INTERFACE_VERSION__ >= 0x0003020a
+#if CONFIG_XEN_INTERFACE_VERSION >= 0x0003020a
 #define GNTTABOP_set_version			8
 #define GNTTABOP_get_status_frames		9
 #define GNTTABOP_get_version			10
 #define GNTTABOP_swap_grant_ref			11
 #define GNTTABOP_cache_flush			12
-#endif /* __XEN_INTERFACE_VERSION__ */
+#endif /* CONFIG_XEN_INTERFACE_VERSION */
 /* ` } */
 
 /*
@@ -315,7 +315,7 @@ struct gnttab_setup_table {
 
 	/* OUT parameters. */
 	int16_t status; /* => enum grant_status */
-#if __XEN_INTERFACE_VERSION__ < 0x00040300
+#if CONFIG_XEN_INTERFACE_VERSION < 0x00040300
 	XEN_GUEST_HANDLE(ulong) frame_list;
 #else
 	XEN_GUEST_HANDLE(xen_pfn_t) frame_list;

--- a/include/zephyr/xen/public/memory.h
+++ b/include/zephyr/xen/public/memory.h
@@ -53,7 +53,7 @@ struct xen_memory_reservation {
 	xen_ulong_t	nr_extents;
 	unsigned int	extent_order;
 
-#if __XEN_INTERFACE_VERSION__ >= 0x00030209
+#if CONFIG_XEN_INTERFACE_VERSION >= 0x00030209
 	/* XENMEMF flags. */
 	unsigned int	mem_flags;
 #else
@@ -80,7 +80,7 @@ struct xen_add_to_physmap_batch {
 	/* Number of pages to go through */
 	uint16_t size;
 
-#if __XEN_INTERFACE_VERSION__ < 0x00040700
+#if CONFIG_XEN_INTERFACE_VERSION < 0x00040700
 	domid_t foreign_domid; /* IFF gmfn_foreign. Should be 0 for other spaces. */
 #else
 	union xen_add_to_physmap_batch_extra {

--- a/include/zephyr/xen/public/xen.h
+++ b/include/zephyr/xen/public/xen.h
@@ -41,7 +41,7 @@ DEFINE_XEN_GUEST_HANDLE(char);
 __DEFINE_XEN_GUEST_HANDLE(uchar, unsigned char);
 DEFINE_XEN_GUEST_HANDLE(int);
 __DEFINE_XEN_GUEST_HANDLE(uint,  unsigned int);
-#if __XEN_INTERFACE_VERSION__ < 0x00040300
+#if CONFIG_XEN_INTERFACE_VERSION < 0x00040300
 DEFINE_XEN_GUEST_HANDLE(long);
 __DEFINE_XEN_GUEST_HANDLE(ulong, unsigned long);
 #endif
@@ -216,7 +216,7 @@ DEFINE_XEN_GUEST_HANDLE(xen_ulong_t);
 
 typedef uint16_t domid_t;
 
-#if __XEN_INTERFACE_VERSION__ < 0x00040400
+#if CONFIG_XEN_INTERFACE_VERSION < 0x00040400
 /*
  * Event channel endpoints per domain (when using the 2-level ABI):
  *  1024 if a long is 32 bits; 4096 if a long is 64 bits.
@@ -248,7 +248,7 @@ struct vcpu_time_info {
 	 */
 	uint32_t	tsc_to_system_mul;
 	int8_t		tsc_shift;
-#if __XEN_INTERFACE_VERSION__ > 0x040600
+#if CONFIG_XEN_INTERFACE_VERSION > 0x040600
 	uint8_t		flags;
 	uint8_t		pad1[2];
 #else


### PR DESCRIPTION
Add Kconfig option to specify Xen interface version to use. This will make it easier to switch between different versions of Xen.