### PR TITLE
arch: riscv: add an option for empty spurious interrupt handler

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -111,6 +111,7 @@ config RISCV
 	select ARCH_IS_SET
 	select ARCH_SUPPORTS_COREDUMP
 	select ARCH_SUPPORTS_ROM_START if !SOC_FAMILY_ESPRESSIF_ESP32
+	select ARCH_SUPPORTS_EMPTY_IRQ_SPURIOUS
 	select ARCH_HAS_CODE_DATA_RELOCATION
 	select ARCH_HAS_THREAD_LOCAL_STORAGE
 	select ARCH_HAS_STACKWALK
@@ -597,6 +598,14 @@ config SIMPLIFIED_EXCEPTION_CODES
 	  down to the generic K_ERR_CPU_EXCEPTION, which makes testing code
 	  much more portable.
 
+config EMPTY_IRQ_SPURIOUS
+	bool "Create empty spurious interrupt handler"
+	depends on ARCH_SUPPORTS_EMPTY_IRQ_SPURIOUS
+	help
+	  This option changes body of spurious interrupt handler. When enabled,
+	  handler contains only an infinite while loop, when disabled, handler
+	  contains the whole Zephyr fault handling procedure.
+
 endmenu # Interrupt configuration
 
 config INIT_ARCH_HW_AT_BOOT
@@ -657,6 +666,9 @@ config ARCH_SUPPORTS_ARCH_HW_INIT
 	bool
 
 config ARCH_SUPPORTS_ROM_START
+	bool
+
+config ARCH_SUPPORTS_EMPTY_IRQ_SPURIOUS
 	bool
 
 config ARCH_HAS_EXTRA_EXCEPTION_INFO

--- a/arch/riscv/core/irq_manage.c
+++ b/arch/riscv/core/irq_manage.c
@@ -19,6 +19,12 @@ LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 FUNC_NORETURN void z_irq_spurious(const void *unused)
 {
+#ifdef CONFIG_EMPTY_IRQ_SPURIOUS
+	while (1) {
+	}
+
+	CODE_UNREACHABLE;
+#else
 	unsigned long mcause;
 
 	ARG_UNUSED(unused);
@@ -37,6 +43,7 @@ FUNC_NORETURN void z_irq_spurious(const void *unused)
 	}
 #endif
 	z_riscv_fatal_error(K_ERR_SPURIOUS_IRQ, NULL);
+#endif /* CONFIG_EMPTY_IRQ_SPURIOUS */
 }
 
 #ifdef CONFIG_DYNAMIC_INTERRUPTS


### PR DESCRIPTION
Add the possibility to disable fault handling in spurious interrupt handler on RISCs and replacce it with an infinite loop.