### PR TITLE
intc: esp32c6: Fix for interrupt controller

### DIFF
--- a/drivers/interrupt_controller/intc_esp32c3.c
+++ b/drivers/interrupt_controller/intc_esp32c3.c
@@ -93,19 +93,34 @@ static uint32_t esp_intr_find_irq_for_source(uint32_t source)
 
 static uint32_t esp_intr_find_irq_for_source(uint32_t source)
 {
-	uint32_t irq = 0;
+	uint32_t irq = IRQ_NA;
+	uint32_t irq_free = IRQ_NA;
+	uint8_t *irq_ptr = NULL;
 
 	/* First allocate one source per IRQ, then two
 	 * if there are more sources than free IRQs
 	 */
 	for (int j = 0; j < ESP32C6_INTC_SRCS_PER_IRQ; j++) {
 		for (int i = 0; i < ESP32C6_INTC_AVAILABLE_IRQS; i++) {
-			if (esp_intr_irq_alloc[i][j] == IRQ_FREE) {
-				esp_intr_irq_alloc[i][j] = (uint8_t)source;
+			/* Find first free slot but keep searching to see
+			 * if source is already associated to an IRQ
+			 */
+			if (esp_intr_irq_alloc[i][j] == source) {
+				/* Source is already associated to an IRQ */
 				irq = i;
 				goto found;
+			} else if ((irq_free == IRQ_NA) && (esp_intr_irq_alloc[i][j] == IRQ_FREE)) {
+				irq_free = i;
+				irq_ptr = &esp_intr_irq_alloc[i][j];
 			}
 		}
+	}
+
+	if (irq_ptr != NULL) {
+		*irq_ptr = (uint8_t)source;
+		irq = irq_free;
+	} else {
+		return IRQ_NA;
 	}
 
 found:
@@ -182,9 +197,9 @@ int esp_intr_alloc(int source,
 		esp_intr_enabled_mask[0], esp_intr_enabled_mask[1], esp_intr_enabled_mask[2]);
 
 	irq_unlock(key);
-	irq_enable(source);
+	int ret = esp_intr_enable(source);
 
-	return 0;
+	return ret;
 }
 
 int esp_intr_disable(int source)
@@ -235,6 +250,13 @@ int esp_intr_enable(int source)
 
 	uint32_t key = irq_lock();
 	uint32_t irq = esp_intr_find_irq_for_source(source);
+
+#if defined(CONFIG_SOC_SERIES_ESP32C6)
+	if (irq == IRQ_NA) {
+		irq_unlock(key);
+		return -ENOMEM;
+	}
+#endif
 
 	esp_rom_intr_matrix_set(0, source, irq);
 


### PR DESCRIPTION
Fixes repeated allocation of interrupt sources by successive calls to esp_intr_alloc or esp_intr_enable for the same source.