### PR TITLE
drivers: memc: fix Kconfig option MEMC_STM32

### DIFF
--- a/drivers/memc/Kconfig.stm32
+++ b/drivers/memc/Kconfig.stm32
@@ -4,7 +4,7 @@
 config MEMC_STM32
 	bool "STM32 Flexible Memory Controller (FMC)"
 	default y
-	depends on DT_HAS_ST_STM32_FMC_ENABLED
+	depends on DT_HAS_ST_STM32_FMC_ENABLED || DT_HAS_ST_STM32H7_FMC_ENABLED
 	help
 	  Enable STM32 Flexible Memory Controller.
 

--- a/soc/st/stm32/Kconfig.defconfig
+++ b/soc/st/stm32/Kconfig.defconfig
@@ -61,10 +61,6 @@ config PHY_INIT_PRIORITY
 	default 81
 	depends on NET_L2_ETHERNET && ETH_DRIVER
 
-config MEMC_STM32
-	default y
-	depends on MEMC
-
 # Get flash configuration for NS image from dts flash partition
 config USE_DT_CODE_PARTITION
 	default y if TRUSTED_EXECUTION_NONSECURE


### PR DESCRIPTION
This commit fixes a bug with the declaration of the Kconfig option MEMC_STM32.

The option is defined in two files:
- `drivers/memc/Kconfig.stm32`, wich depends on
   - `MEMC`
   - `DT_HAS_ST_STM32_FMC_ENABLED`
- `soc/st/stm32/Kconfig.defconfig`, wich depends on
   - `MEMC`
   - `SOC_FAMILY_STM32`

So, if you have `CONFIG_MEMC=y` in your Kconfig options and you are on a STM32 SoC, `CONFIG_MEMC_STM32` will be enabled, even if there is no STM32 FMC enabled.

This Kconfig option causes the driver for the STM32 FMC to be compiled, regardless of the presence of an enabled node for the FMC. However, the driver fails to compile if there is no FMC node in the devicetree. So, if you compile a project with `CONFIG_MEMC=y` on a board with an STM32 SoC and no enabled FMC, the build will fail.

This commit deletes the Kconfig declaration in the `Kconfig.defconfig`, as it isn't useful and is the one provoking the bug. It also add in the `Kconfig.stm32` the compatible `st,stm32h7-fmc`, wich use the same driver and so need to be enabled by the same Kconfig option.
