### PR TITLE
drivers: memc: remove experimental label

### DIFF
--- a/drivers/memc/Kconfig
+++ b/drivers/memc/Kconfig
@@ -4,8 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig MEMC
-	bool "Memory controller drivers [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "Memory controller drivers"
 	help
 	  Add support for memory controllers
 


### PR DESCRIPTION
 Remove experimental label as this category was introduced 4yrs ago and it now contains several drivers.