### PR TITLE
net: lib: dhcpv4: add possibility to parse multiple DNS servers received from DHCP server

### DIFF
--- a/subsys/net/lib/dhcpv4/dhcpv4.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4.c
@@ -1056,33 +1056,57 @@ static bool dhcpv4_parse_options(struct net_pkt *pkt,
 #if defined(CONFIG_DNS_RESOLVER)
 		case DHCPV4_OPTIONS_DNS_SERVER: {
 			struct dns_resolve_context *ctx;
-			struct sockaddr_in dns;
-			const struct sockaddr *dns_servers[] = {
-				(struct sockaddr *)&dns, NULL
-			};
+			struct sockaddr_in dnses[CONFIG_DNS_RESOLVER_MAX_SERVERS] = { 0 };
+			const struct sockaddr *dns_servers[CONFIG_DNS_RESOLVER_MAX_SERVERS];
+			const uint8_t addr_size = 4U;
 			int status;
+
+			for (uint8_t i = 0; i < CONFIG_DNS_RESOLVER_MAX_SERVERS; i++) {
+				dns_servers[i] = (struct sockaddr *)&dnses[i];
+			}
 
 			/* DNS server option may present 1 or more
 			 * addresses. Each 4 bytes in length. DNS
 			 * servers should be listed in order
-			 * of preference.  Hence we choose the first
-			 * and skip the rest.
+			 * of preference. Hence how many we parse
+			 * depends on CONFIG_DNS_RESOLVER_MAX_SERVERS
 			 */
-			if (length % 4 != 0U) {
+			if (length % addr_size != 0U) {
 				NET_ERR("options_dns, bad length");
 				return false;
 			}
 
-			(void)memset(&dns, 0, sizeof(dns));
+			const uint8_t provided_servers_cnt = length / addr_size;
+			uint8_t dns_servers_cnt = 0;
 
-			if (net_pkt_read(pkt, dns.sin_addr.s4_addr, 4) ||
-			    net_pkt_skip(pkt, length - 4U)) {
+			if (provided_servers_cnt > CONFIG_DNS_RESOLVER_MAX_SERVERS) {
+				NET_WARN("DHCP server provided more DNS servers than can be saved");
+				dns_servers_cnt = CONFIG_DNS_RESOLVER_MAX_SERVERS;
+			} else {
+				for (uint8_t i = provided_servers_cnt;
+					 i < CONFIG_DNS_RESOLVER_MAX_SERVERS; i++) {
+					dns_servers[i] = NULL;
+				}
+
+				dns_servers_cnt = provided_servers_cnt;
+			}
+
+			for (uint8_t i = 0; i < dns_servers_cnt; i++) {
+				if (net_pkt_read(pkt, dnses[i].sin_addr.s4_addr, addr_size)) {
+					NET_ERR("options_dns, short packet");
+					return false;
+				}
+			}
+
+			if (net_pkt_skip(pkt, length - dns_servers_cnt * addr_size)) {
 				NET_ERR("options_dns, short packet");
 				return false;
 			}
 
 			ctx = dns_resolve_get_default();
-			dns.sin_family = AF_INET;
+			for (uint8_t i = 0; i < dns_servers_cnt; i++) {
+				dnses[i].sin_family = AF_INET;
+			}
 			status = dns_resolve_reconfigure(ctx, NULL, dns_servers);
 			if (status < 0) {
 				NET_DBG("options_dns, failed to set "


### PR DESCRIPTION
Currently if we receive multiple DNS servers via DHCP options, only the first one is used,
regardless of CONFIG_DNS_RESOLVER_MAX_SERVERS constant.

Parse multiple servers and save as many DNS server addresses as fits in CONFIG_DNS_RESOLVER_MAX_SERVERS