### PR TITLE
drivers: nsos: add missing 'break' in switch statements

### DIFF
--- a/drivers/net/nsos_adapt.c
+++ b/drivers/net/nsos_adapt.c
@@ -625,6 +625,7 @@ int nsos_adapt_getsockopt(int fd, int nsos_mid_level, int nsos_mid_optname,
 			return nsos_adapt_getsockopt_int(fd, SOL_SOCKET, SO_KEEPALIVE,
 							 nsos_mid_optval, nsos_mid_optlen);
 		}
+		break;
 
 	case NSOS_MID_IPPROTO_TCP:
 		switch (nsos_mid_optname) {
@@ -641,6 +642,7 @@ int nsos_adapt_getsockopt(int fd, int nsos_mid_level, int nsos_mid_optname,
 			return nsos_adapt_getsockopt_int(fd, IPPROTO_TCP, TCP_KEEPCNT,
 							 nsos_mid_optval, nsos_mid_optlen);
 		}
+		break;
 
 	case NSOS_MID_IPPROTO_IPV6:
 		switch (nsos_mid_optname) {
@@ -648,6 +650,7 @@ int nsos_adapt_getsockopt(int fd, int nsos_mid_level, int nsos_mid_optname,
 			return nsos_adapt_getsockopt_int(fd, IPPROTO_IPV6, IPV6_V6ONLY,
 							 nsos_mid_optval, nsos_mid_optlen);
 		}
+		break;
 	}
 
 	return -NSOS_MID_EOPNOTSUPP;
@@ -727,6 +730,7 @@ int nsos_adapt_setsockopt(int fd, int nsos_mid_level, int nsos_mid_optname,
 			return nsos_adapt_setsockopt_int(fd, SOL_SOCKET, SO_KEEPALIVE,
 							 nsos_mid_optval, nsos_mid_optlen);
 		}
+		break;
 
 	case NSOS_MID_IPPROTO_TCP:
 		switch (nsos_mid_optname) {
@@ -743,6 +747,7 @@ int nsos_adapt_setsockopt(int fd, int nsos_mid_level, int nsos_mid_optname,
 			return nsos_adapt_setsockopt_int(fd, IPPROTO_TCP, TCP_KEEPCNT,
 							 nsos_mid_optval, nsos_mid_optlen);
 		}
+		break;
 
 	case NSOS_MID_IPPROTO_IPV6:
 		switch (nsos_mid_optname) {
@@ -750,6 +755,7 @@ int nsos_adapt_setsockopt(int fd, int nsos_mid_level, int nsos_mid_optname,
 			return nsos_adapt_setsockopt_int(fd, IPPROTO_IPV6, IPV6_V6ONLY,
 							 nsos_mid_optval, nsos_mid_optlen);
 		}
+		break;
 	}
 
 	return -NSOS_MID_EOPNOTSUPP;

--- a/drivers/net/nsos_sockets.c
+++ b/drivers/net/nsos_sockets.c
@@ -1095,6 +1095,7 @@ static int nsos_getsockopt(void *obj, int level, int optname,
 						   NSOS_MID_SOL_SOCKET, NSOS_MID_SO_KEEPALIVE,
 						   optval, optlen);
 		}
+		break;
 
 	case IPPROTO_TCP:
 		switch (optname) {
@@ -1115,6 +1116,7 @@ static int nsos_getsockopt(void *obj, int level, int optname,
 						   NSOS_MID_IPPROTO_TCP, NSOS_MID_TCP_KEEPCNT,
 						   optval, optlen);
 		}
+		break;
 
 	case IPPROTO_IPV6:
 		switch (optname) {
@@ -1123,6 +1125,7 @@ static int nsos_getsockopt(void *obj, int level, int optname,
 						   NSOS_MID_IPPROTO_IPV6, NSOS_MID_IPV6_V6ONLY,
 						   optval, optlen);
 		}
+		break;
 	}
 
 	errno = EOPNOTSUPP;
@@ -1261,6 +1264,7 @@ static int nsos_setsockopt(void *obj, int level, int optname,
 						   NSOS_MID_SOL_SOCKET, NSOS_MID_SO_KEEPALIVE,
 						   optval, optlen);
 		}
+		break;
 
 	case IPPROTO_TCP:
 		switch (optname) {
@@ -1281,6 +1285,7 @@ static int nsos_setsockopt(void *obj, int level, int optname,
 						   NSOS_MID_IPPROTO_TCP, NSOS_MID_TCP_KEEPCNT,
 						   optval, optlen);
 		}
+		break;
 
 	case IPPROTO_IPV6:
 		switch (optname) {
@@ -1289,6 +1294,7 @@ static int nsos_setsockopt(void *obj, int level, int optname,
 						   NSOS_MID_IPPROTO_IPV6, NSOS_MID_IPV6_V6ONLY,
 						   optval, optlen);
 		}
+		break;
 	}
 
 	errno = EOPNOTSUPP;


### PR DESCRIPTION
There are 2-level switch statements (one switch inside another) which were
not properly terminated with 'break' statements, leading to implicit
fallthrough. Fix that.

Fixes: #74763
Fixes: #74765
Fixes: #74766
Fixes: #74768
Fixes: #74769
Fixes: #74771
Fixes: #74772
Fixes: #74774