### PR TITLE
drivers: nsos: fix resource leak in nsos_adapt_accept() error path

### DIFF
--- a/drivers/net/nsos_adapt.c
+++ b/drivers/net/nsos_adapt.c
@@ -421,6 +421,7 @@ int nsos_adapt_accept(int fd, struct nsos_mid_sockaddr *addr_mid, size_t *addrle
 
 	err = sockaddr_to_nsos_mid(addr, addrlen, addr_mid, addrlen_mid);
 	if (err) {
+		close(ret);
 		return err;
 	}
 


### PR DESCRIPTION
Close file descriptor returned by accept() in error path of
nsos_adapt_accept(), so that file descriptor is not leaked.

Fixes: #74753