### PR TITLE
drivers: wifi: esp_at: use memcpy() to copy SSID

### DIFF
--- a/drivers/wifi/esp_at/esp.c
+++ b/drivers/wifi/esp_at/esp.c
@@ -359,8 +359,8 @@ MODEM_CMD_DIRECT_DEFINE(on_cmd_cwlap)
 		return -EBADMSG;
 	}
 
-	strncpy(res.ssid, ssid, sizeof(res.ssid));
 	res.ssid_length = MIN(sizeof(res.ssid), strlen(ssid));
+	memcpy(res.ssid, ssid, res.ssid_length);
 
 	res.rssi = strtol(rssi, NULL, 10);
 


### PR DESCRIPTION
Target SSID buffer might not be NULL terminated, so use `memcpy()` instead of
`strncpy()` for copying it from temporary (AT response fragment) buffer.

Fixes: #74748