### PR TITLE
dts: nxp: fix various DTC warnings

### DIFF
--- a/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
+++ b/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
@@ -414,11 +414,11 @@ zephyr_udc0: &usbhs {
 				label = "image-0";
 				reg = <0x00020000 (DT_SIZE_M(3) + DT_SIZE_K(98 * 4))>;
 			};
-			slot1_partition: partition@322000 {
+			slot1_partition: partition@382000 {
 				label = "image-1";
 				reg = <0x00382000 DT_SIZE_M(3)>;
 			};
-			storage_partition: partition@622000 {
+			storage_partition: partition@682000 {
 				label = "storage";
 				reg = <0x00682000 (DT_SIZE_M(58) - DT_SIZE_K(520))>;
 			};

--- a/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
+++ b/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
@@ -275,11 +275,11 @@ i2s1: &flexcomm3 {
 				label = "image-0";
 				reg = <0x00020000 (DT_SIZE_M(3) + DT_SIZE_K(98 * 4))>;
 			};
-			slot1_partition: partition@322000 {
+			slot1_partition: partition@382000 {
 				label = "image-1";
 				reg = <0x00382000 DT_SIZE_M(3)>;
 			};
-			storage_partition: partition@622000 {
+			storage_partition: partition@682000 {
 				label = "storage";
 				reg = <0x00682000 (DT_SIZE_M(58) - DT_SIZE_K(520))>;
 			};

--- a/dts/arm/nxp/nxp_rt5xx.dtsi
+++ b/dts/arm/nxp/nxp_rt5xx.dtsi
@@ -16,14 +16,6 @@
 		peripheral: peripheral@50000000 {
 			ranges = <0x0 0x50000000 0x10000000>;
 		};
-
-		flexspi: spi@134000 {
-			reg = <0x50134000 0x1000>, <0x18000000 DT_SIZE_M(128)>;
-		};
-
-		flexspi2: spi@13C000 {
-			reg = <0x5013C000 0x1000>, <0x38000000 DT_SIZE_M(128)>;
-		};
 	};
 };
 

--- a/dts/arm/nxp/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt5xx_common.dtsi
@@ -115,6 +115,14 @@
 	 * modes (0x50000000).
 	 */
 
+	flexspi: spi@134000 {
+		reg = <0x134000 0x1000>, <0x18000000 DT_SIZE_M(128)>;
+	};
+
+	flexspi2: spi@13c000 {
+		reg = <0x13c000 0x1000>, <0x38000000 DT_SIZE_M(128)>;
+	};
+
 	clkctl0: clkctl@1000 {
 		/* FIXME This chip does NOT have a syscon */
 		compatible = "nxp,lpc-syscon";

--- a/dts/arm/nxp/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt5xx_common.dtsi
@@ -569,9 +569,9 @@
 		min-bus-freq = <400000>;
 	};
 
-	lpadc0: lpadc@13A0000 {
+	lpadc0: lpadc@13a000 {
 		compatible = "nxp,lpc-lpadc";
-		reg = <0x13A000 0x304>;
+		reg = <0x13a000 0x304>;
 		interrupts = <22 0>;
 		status = "disabled";
 		clk-divider = <1>;

--- a/dts/arm/nxp/nxp_rt5xx_ns.dtsi
+++ b/dts/arm/nxp/nxp_rt5xx_ns.dtsi
@@ -16,14 +16,6 @@
 		peripheral: peripheral@40000000 {
 			ranges = <0x0 0x40000000 0x10000000>;
 		};
-
-		flexspi: spi@134000 {
-			reg = <0x40134000 0x1000>, <0x08000000 DT_SIZE_M(128)>;
-		};
-
-		flexspi2: spi@13C000 {
-			reg = <0x4013C000 0x1000>, <0x28000000 DT_SIZE_M(128)>;
-		};
 	};
 };
 

--- a/dts/arm/nxp/nxp_rt6xx.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx.dtsi
@@ -16,9 +16,6 @@
 		peripheral: peripheral@50000000 {
 			ranges = <0x0 0x50000000 0x10000000>;
 		};
-		flexspi: spi@134000 {
-			reg = <0x50134000 0x1000>,<0x18000000 DT_SIZE_M(128)>;
-		};
 	};
 };
 

--- a/dts/arm/nxp/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx_common.dtsi
@@ -68,9 +68,9 @@
 		reg = <0x1b000 DT_SIZE_K(1428)>;
 	};
 
-	sram0: memory@20180000 {
+	sram0: memory@180000 {
 		compatible = "mmio-sram";
-		reg = <0x20180000 DT_SIZE_K(3072)>;
+		reg = <0x180000 DT_SIZE_K(3072)>;
 	};
 
 	sram1: memory@40140000 {
@@ -98,6 +98,10 @@
 	 * addresses differ between non-secure (0x40000000) and secure
 	 * modes (0x50000000).
 	 */
+
+	flexspi: spi@134000 {
+		reg = <0x134000 0x1000>, <0x18000000 DT_SIZE_M(128)>;
+	};
 
 	clkctl0: clkctl@1000 {
 		/* FIXME This chip does NOT have a syscon */

--- a/dts/arm/nxp/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx_common.dtsi
@@ -410,9 +410,9 @@
 		min-bus-freq = <400000>;
 	};
 
-	lpadc0: lpadc@13A0000 {
+	lpadc0: lpadc@13a000 {
 		compatible = "nxp,lpc-lpadc";
-		reg = <0x13A000 0x304>;
+		reg = <0x13a000 0x304>;
 		interrupts = <22 0>;
 		status = "disabled";
 		clk-divider = <1>;

--- a/dts/arm/nxp/nxp_rt6xx_ns.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx_ns.dtsi
@@ -16,9 +16,6 @@
 		peripheral: peripheral@40000000 {
 			ranges = <0x0 0x40000000 0x10000000>;
 		};
-		flexspi: spi@134000 {
-			reg = <0x40134000 0x1000>, <0x08000000 DT_SIZE_M(128)>;
-		};
 	};
 };
 

--- a/dts/arm/nxp/nxp_rw6xx.dtsi
+++ b/dts/arm/nxp/nxp_rw6xx.dtsi
@@ -17,10 +17,6 @@
 		peripheral: peripheral@50000000 {
 			ranges = <0x0 0x50000000 0x10000000>;
 		};
-
-		flexspi: spi@134000 {
-			reg = <0x50134000 0x1000>, <0x18000000 DT_SIZE_M(128)>;
-		};
 	};
 };
 

--- a/dts/arm/nxp/nxp_rw6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rw6xx_common.dtsi
@@ -112,6 +112,10 @@
 	#address-cells = <1>;
 	#size-cells = <1>;
 
+	flexspi: spi@134000 {
+		reg = <0x134000 0x1000>, <0x18000000 DT_SIZE_M(128)>;
+	};
+
 	clkctl0: clkctl@1000 {
 		/* FIXME This chip does NOT have a syscon */
 		compatible = "nxp,lpc-syscon";

--- a/dts/arm/nxp/nxp_rw6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rw6xx_common.dtsi
@@ -73,9 +73,9 @@
 	#address-cells = <1>;
 	#size-cells = <1>;
 
-	sram_data: memory@20000000 {
+	sram_data: memory@40000 {
 		compatible = "mmio-sram";
-		reg = <0x20040000 DT_SIZE_K(960)>;
+		reg = <0x40000 DT_SIZE_K(960)>;
 	};
 
 	sram_code: memory@0 {

--- a/dts/arm/nxp/nxp_rw6xx_ns.dtsi
+++ b/dts/arm/nxp/nxp_rw6xx_ns.dtsi
@@ -17,10 +17,6 @@
 		peripheral: peripheral@40000000 {
 			ranges = <0x0 0x40000000 0x10000000>;
 		};
-
-		flexspi: spi@134000 {
-			reg = <0x40134000 0x1000>, <0x08000000 DT_SIZE_M(128)>;
-		};
 	};
 };
 


### PR DESCRIPTION
Fix DTC warnings caused by DT node definitions being inaccurate.