### PR TITLE
kernel kconfig: Do not enable STATIC_INIT_GNU w the old native_posix

### DIFF
--- a/include/zephyr/linker/common-rom/common-rom-init.ld
+++ b/include/zephyr/linker/common-rom/common-rom-init.ld
@@ -60,7 +60,7 @@
 		__zephyr_init_array_end = .;
 	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
-#elif defined(CONFIG_TOOLCHAIN_SUPPORTS_STATIC_INIT_GNU)
+#elif defined(CONFIG_TOOLCHAIN_SUPPORTS_STATIC_INIT_GNU) && !defined(CONFIG_NATIVE_APPLICATION)
 	/*
 	 * If the code to invoke constructors is not enabled,
 	 * make sure there aren't any in the application

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -991,7 +991,7 @@ config TOOLCHAIN_SUPPORTS_STATIC_INIT_GNU
 
 config STATIC_INIT_GNU
 	bool "Support GNU-compatible initializers and constructors"
-	default y if CPP || NATIVE_BUILD || COVERAGE
+	default y if CPP || NATIVE_LIBRARY || COVERAGE
 	depends on TOOLCHAIN_SUPPORTS_STATIC_INIT_GNU
 	depends on !CMAKE_LINKER_GENERATOR
 	help


### PR DESCRIPTION
native_posix (unlike native_sim) or its brethren (NATIVE_APPLICATION) link together the "runner" code and the embedded code in one pass. This means that when CONFIG_STATIC_INIT_GNU is set, any host library code (like the llvm fuzzer) constructors will get postponed to the Zephyr initialization.
These libraries are unlikely to work if we do this. (the llvm fuzzer does not)

So let's instead not enable STATIC_INIT_GNU for these targets. This means possible embedded library constructors will continue to be picked during the link and be still called during the native runner initialization instead of during the Zephyr OS initialization as they were just before we introduced STATIC_INIT_GNU in
6e977ae2d54c4f5443f752ce3a88f22043dcbf07

Note that native_posix will be deprecated shortly and its users are strongly encouraged to move to native_sim.

Fixes #75407
Related to #74682