### PR TITLE
Bluetooth: Host: Fix recv_enabled field for PAST

### DIFF
--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -263,6 +263,10 @@ Bluetooth
     with the buffer pools for HCI fragments and L2CAP segments. All communication with the
     Controller is now exclusively done in the system workqueue context.
 
+  * :kconfig:option:`CONFIG_BT_PER_ADV_SYNC_TRANSFER_RECEIVER` and
+    :kconfig:option:`CONFIG_BT_PER_ADV_SYNC_TRANSFER_SENDER` now depend on
+    :kconfig:option:`CONFIG_BT_CONN` as they do not work without connections.
+
 * HCI Driver
 
   * Added support for Ambiq Apollo3 Blue series.

--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -154,11 +154,11 @@ config BT_DATA_LEN_UPDATE
 
 config BT_PER_ADV_SYNC_TRANSFER_RECEIVER
 	bool "Periodic Advertising Sync Transfer receiver"
-	depends on BT_PER_ADV_SYNC && (!BT_CTLR || BT_CTLR_SYNC_TRANSFER_RECEIVER_SUPPORT)
+	depends on BT_PER_ADV_SYNC && BT_CONN && (!BT_CTLR || BT_CTLR_SYNC_TRANSFER_RECEIVER_SUPPORT)
 
 config BT_PER_ADV_SYNC_TRANSFER_SENDER
 	bool "Periodic Advertising Sync Transfer sender"
-	depends on (BT_PER_ADV_SYNC || BT_PER_ADV) && (!BT_CTLR || BT_CTLR_SYNC_TRANSFER_SENDER_SUPPORT)
+	depends on (BT_PER_ADV_SYNC || BT_PER_ADV) && BT_CONN && (!BT_CTLR || BT_CTLR_SYNC_TRANSFER_SENDER_SUPPORT)
 
 config BT_SCA_UPDATE
 	bool "Sleep Clock Accuracy Update"

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2731,10 +2731,10 @@ static const struct event_handler meta_events[] = {
 		      sizeof(struct bt_hci_evt_le_per_advertising_report)),
 	EVENT_HANDLER(BT_HCI_EVT_LE_PER_ADV_SYNC_LOST, bt_hci_le_per_adv_sync_lost,
 		      sizeof(struct bt_hci_evt_le_per_adv_sync_lost)),
-#if defined(CONFIG_BT_CONN)
+#if defined(CONFIG_BT_PER_ADV_SYNC_TRANSFER_RECEIVER)
 	EVENT_HANDLER(BT_HCI_EVT_LE_PAST_RECEIVED, bt_hci_le_past_received,
 		      sizeof(struct bt_hci_evt_le_past_received)),
-#endif /* CONFIG_BT_CONN */
+#endif /* CONFIG_BT_PER_ADV_SYNC_TRANSFER_RECEIVER */
 #endif /* defined(CONFIG_BT_PER_ADV_SYNC) */
 #endif /* defined(CONFIG_BT_EXT_ADV) */
 #if defined(CONFIG_BT_ISO_UNICAST)

--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -1214,7 +1214,22 @@ void bt_hci_le_per_adv_sync_lost(struct net_buf *buf)
 	per_adv_sync_terminated(per_adv_sync, BT_HCI_ERR_UNSPECIFIED);
 }
 
-#if defined(CONFIG_BT_CONN)
+#if defined(CONFIG_BT_PER_ADV_SYNC_TRANSFER_RECEIVER)
+static uint8_t conn_past_modes[CONFIG_BT_MAX_CONN];
+static uint8_t default_past_mode;
+
+static void past_disconnected_cb(struct bt_conn *conn, uint8_t reason)
+{
+	/* The core spec does not explicit state that the mode of a connection handle is cleared on
+	 * disconnect, but let's assume it is.
+	 */
+	conn_past_modes[bt_conn_index(conn)] = BT_HCI_LE_PAST_MODE_NO_SYNC;
+}
+
+BT_CONN_CB_DEFINE(past_conn_callbacks) = {
+	.disconnected = past_disconnected_cb,
+};
+
 static void bt_hci_le_past_received_common(struct net_buf *buf)
 {
 #if defined(CONFIG_BT_PER_ADV_SYNC_RSP)
@@ -1282,7 +1297,18 @@ static void bt_hci_le_past_received_common(struct net_buf *buf)
 	sync_info.addr = &per_adv_sync->addr;
 	sync_info.sid = per_adv_sync->sid;
 	sync_info.service_data = sys_le16_to_cpu(evt->service_data);
-	sync_info.recv_enabled = true;
+
+	const uint8_t mode = conn_past_modes[bt_conn_index(sync_info.conn)];
+
+	if (mode == BT_HCI_LE_PAST_MODE_NO_SYNC) {
+		/* Use the default parameter mode as the conn specific mode is not set */
+		sync_info.recv_enabled =
+			default_past_mode == BT_HCI_LE_PAST_MODE_SYNC ||
+			default_past_mode == BT_HCI_LE_PAST_MODE_SYNC_FILTER_DUPLICATES;
+	} else {
+		sync_info.recv_enabled = mode == BT_HCI_LE_PAST_MODE_SYNC ||
+					 mode == BT_HCI_LE_PAST_MODE_SYNC_FILTER_DUPLICATES;
+	}
 
 #if defined(CONFIG_BT_PER_ADV_SYNC_RSP)
 	sync_info.num_subevents =  per_adv_sync->num_subevents;
@@ -1317,7 +1343,7 @@ void bt_hci_le_past_received_v2(struct net_buf *buf)
 	bt_hci_le_past_received_common(buf);
 }
 #endif /* CONFIG_BT_PER_ADV_SYNC_RSP */
-#endif /* CONFIG_BT_CONN */
+#endif /* CONFIG_BT_PER_ADV_SYNC_TRANSFER_RECEIVER */
 
 #if defined(CONFIG_BT_PER_ADV_SYNC_RSP)
 void bt_hci_le_per_adv_sync_established_v2(struct net_buf *buf)
@@ -2040,6 +2066,7 @@ int bt_le_per_adv_sync_transfer_subscribe(
 {
 	uint8_t cte_type = 0;
 	uint8_t mode = BT_HCI_LE_PAST_MODE_SYNC;
+	int err;
 
 	if (!BT_FEAT_LE_EXT_PER_ADV(bt_dev.le.features)) {
 		return -ENOTSUP;
@@ -2074,14 +2101,35 @@ int bt_le_per_adv_sync_transfer_subscribe(
 	}
 
 	if (conn) {
-		return past_param_set(conn, mode, param->skip, param->timeout, cte_type);
+		const uint8_t conn_idx = bt_conn_index(conn);
+		const uint8_t old_mode = conn_past_modes[conn_idx];
+
+		conn_past_modes[conn_idx] = mode;
+
+		err = past_param_set(conn, mode, param->skip, param->timeout, cte_type);
+		if (err != 0) {
+			/* Restore old mode */
+			conn_past_modes[conn_idx] = old_mode;
+		}
 	} else {
-		return default_past_param_set(mode, param->skip, param->timeout, cte_type);
+		const uint8_t old_mode = default_past_mode;
+
+		default_past_mode = mode;
+
+		err = default_past_param_set(mode, param->skip, param->timeout, cte_type);
+		if (err != 0) {
+			/* Restore old mode */
+			default_past_mode = old_mode;
+		}
 	}
+
+	return err;
 }
 
 int bt_le_per_adv_sync_transfer_unsubscribe(const struct bt_conn *conn)
 {
+	int err;
+
 	if (!BT_FEAT_LE_EXT_PER_ADV(bt_dev.le.features)) {
 		return -ENOTSUP;
 	} else if (!BT_FEAT_LE_PAST_RECV(bt_dev.le.features)) {
@@ -2089,12 +2137,28 @@ int bt_le_per_adv_sync_transfer_unsubscribe(const struct bt_conn *conn)
 	}
 
 	if (conn) {
-		return past_param_set(conn, BT_HCI_LE_PAST_MODE_NO_SYNC, 0,
-				      0x0a, 0);
+		const uint8_t conn_idx = bt_conn_index(conn);
+		const uint8_t old_mode = conn_past_modes[conn_idx];
+
+		conn_past_modes[conn_idx] = BT_HCI_LE_PAST_MODE_NO_SYNC;
+
+		err = past_param_set(conn, BT_HCI_LE_PAST_MODE_NO_SYNC, 0, 0x0a, 0);
+		if (err != 0) {
+			/* Restore old mode */
+			conn_past_modes[conn_idx] = old_mode;
+		}
 	} else {
-		return default_past_param_set(BT_HCI_LE_PAST_MODE_NO_SYNC, 0,
-					      0x0a, 0);
+		const uint8_t old_mode = default_past_mode;
+
+		default_past_mode = BT_HCI_LE_PAST_MODE_NO_SYNC;
+		err = default_past_param_set(BT_HCI_LE_PAST_MODE_NO_SYNC, 0, 0x0a, 0);
+		if (err != 0) {
+			/* Restore old mode */
+			default_past_mode = old_mode;
+		}
 	}
+
+	return err;
 }
 #endif /* CONFIG_BT_PER_ADV_SYNC_TRANSFER_RECEIVER */
 


### PR DESCRIPTION
When syncing to a PA using PAST then the sync_info.recv_enabled was always just set to true, regardless of what mode was set during the subscribe parameters.

The mode(s) are now stored in an array (with the default value as well) so that we can retrieve that information when the PA has synced via PAST.

It was considered to put the `mode` value into the `bt_conn` struct, but that would require an API change as the `bt_conn` parameter for the subcribe function uses `const`.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/69927