### PR TITLE
sensor: veml7700: coverity-fix: Simplify unsigned comparison

### DIFF
--- a/drivers/sensor/vishay/veml7700/veml7700.c
+++ b/drivers/sensor/vishay/veml7700/veml7700.c
@@ -92,14 +92,14 @@ struct veml7700_data {
 	uint32_t int_flags;
 };
 
-static bool is_veml7700_gain_in_range(int32_t gain_selection)
+static bool is_veml7700_gain_in_range(uint32_t gain_selection)
 {
-	return ((gain_selection >= 0U) && (gain_selection < VEML7700_ALS_GAIN_ELEM_COUNT));
+	return (gain_selection < VEML7700_ALS_GAIN_ELEM_COUNT);
 }
 
-static bool is_veml7700_it_in_range(int32_t it_selection)
+static bool is_veml7700_it_in_range(uint32_t it_selection)
 {
-	return ((it_selection >= 0U) && (it_selection < VEML7700_ALS_IT_ELEM_COUNT));
+	return (it_selection < VEML7700_ALS_IT_ELEM_COUNT);
 }
 
 /**


### PR DESCRIPTION
### Description:
Simplifying check in VEML7700 that only used enum's with no possible negative values.

Addressing Coverity issues:
- CID 363733.
- CID 363719.

Filled both Coverity Items with the following information:
- Classification: Bug,
- Severity: Minor.
- Action: Fix Submitted.
- Description:
> Fix on: https://github.com/zephyrproject-rtos/zephyr/pull/75410


Fixes #74759.
Fixes #74755.
