### PR TITLE
sensor: lis2dux12: fix: CID 363712: Initialize mode-fs

### DIFF
--- a/drivers/sensor/st/lis2dux12/lis2dux12_trigger.c
+++ b/drivers/sensor/st/lis2dux12/lis2dux12_trigger.c
@@ -164,7 +164,7 @@ int lis2dux12_trigger_set(const struct device *dev, const struct sensor_trigger 
 	const struct lis2dux12_config *cfg = dev->config;
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
 	lis2dux12_xl_data_t xldata;
-	lis2dux12_md_t mode;
+	lis2dux12_md_t mode = {.fs = cfg->range};
 	int ret;
 
 	if (!cfg->trig_enabled) {


### PR DESCRIPTION
Following the same pattern used in `lis2dux12_sample_fetch_accel`.

Fixes #74754