### PR TITLE
sensor: lps22hh: fix: Prevent overwriting values not fetched

### DIFF
--- a/drivers/sensor/st/lps22hh/lps22hh.c
+++ b/drivers/sensor/st/lps22hh/lps22hh.c
@@ -71,8 +71,13 @@ static int lps22hh_sample_fetch(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	data->sample_press = raw_press;
-	data->sample_temp = raw_temp;
+	/** Prevent overwriting values that weren't fetched */
+	if (chan == SENSOR_CHAN_PRESS || chan == SENSOR_CHAN_ALL) {
+		data->sample_press = raw_press;
+	}
+	if (chan == SENSOR_CHAN_AMBIENT_TEMP || chan == SENSOR_CHAN_ALL) {
+		data->sample_temp = raw_temp;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Previously both temperature and pressure were updated regardless of which one was requested.

Addresses the following Coverity issues:
CID 392519.
CID 392497.

Fixes #74779.
Fixes #74777.