### PR TITLE
 soc: it8xxx2: linker: Move library to RAM to enhance performance

### DIFF
--- a/soc/ite/ec/it8xxx2/Kconfig
+++ b/soc/ite/ec/it8xxx2/Kconfig
@@ -183,6 +183,20 @@ config SOC_IT8XXX2_EXCEPTIONS_IN_RAM
 	  Flash. This can significantly improve performance when under I-cache
 	  pressure.
 
+config SOC_IT8XXX2_LIBRARY_TO_RAM
+	bool
+	help
+	  If this is selected it means that there is a library that needs to be excluded
+	  from the text section.
+
+config SOC_IT8XXX2_SERIAL_IN_RAM
+	bool "Place serial handling code in RAM"
+	select SOC_IT8XXX2_USE_ILM
+	select SOC_IT8XXX2_LIBRARY_TO_RAM
+	help
+	  Place serial handling (Include uart_ns16550.c and uart_ite_it8xxx2.c) code
+	  in ILM. This can improve performance.
+
 config SOC_IT8XXX2_SHA256_HW_ACCELERATE
 	bool "HW SHA256 calculation"
 	help

--- a/soc/ite/ec/it8xxx2/Kconfig
+++ b/soc/ite/ec/it8xxx2/Kconfig
@@ -204,6 +204,13 @@ config SOC_IT8XXX2_KERNEL_IN_RAM
 	help
 	  Place kernel handling code in ILM. This can significantly improve performance.
 
+config SOC_IT8XXX2_ZEPHYR_IN_RAM
+	bool "Place zephyr handling code in RAM"
+	select SOC_IT8XXX2_USE_ILM
+	select SOC_IT8XXX2_LIBRARY_TO_RAM
+	help
+	  Place zephyr handling code in ILM. This can significantly improve performance.
+
 config SOC_IT8XXX2_SHA256_HW_ACCELERATE
 	bool "HW SHA256 calculation"
 	help

--- a/soc/ite/ec/it8xxx2/Kconfig
+++ b/soc/ite/ec/it8xxx2/Kconfig
@@ -197,6 +197,13 @@ config SOC_IT8XXX2_SERIAL_IN_RAM
 	  Place serial handling (Include uart_ns16550.c and uart_ite_it8xxx2.c) code
 	  in ILM. This can improve performance.
 
+config SOC_IT8XXX2_KERNEL_IN_RAM
+	bool "Place kernel handling code in RAM"
+	select SOC_IT8XXX2_USE_ILM
+	select SOC_IT8XXX2_LIBRARY_TO_RAM
+	help
+	  Place kernel handling code in ILM. This can significantly improve performance.
+
 config SOC_IT8XXX2_SHA256_HW_ACCELERATE
 	bool "HW SHA256 calculation"
 	help

--- a/soc/ite/ec/it8xxx2/linker.ld
+++ b/soc/ite/ec/it8xxx2/linker.ld
@@ -165,9 +165,34 @@ SECTIONS
 		KEEP(*(".openocd_debug.*"))
 
 		__text_region_start = .;
-
+#ifndef CONFIG_SOC_IT8XXX2_LIBRARY_TO_RAM
 		*(.text)
 		*(".text.*")
+#endif
+
+#ifdef CONFIG_SOC_IT8XXX2_LIBRARY_TO_RAM
+		*(EXCLUDE_FILE (
+#endif
+#ifdef CONFIG_SOC_IT8XXX2_SERIAL_IN_RAM
+			*libdrivers__serial.a:*
+#endif
+#ifdef CONFIG_SOC_IT8XXX2_LIBRARY_TO_RAM
+		)
+			.text
+		)
+#endif
+
+#ifdef CONFIG_SOC_IT8XXX2_LIBRARY_TO_RAM
+		*(EXCLUDE_FILE (
+#endif
+#ifdef CONFIG_SOC_IT8XXX2_SERIAL_IN_RAM
+			*libdrivers__serial.a:*
+#endif
+#ifdef CONFIG_SOC_IT8XXX2_LIBRARY_TO_RAM
+		)
+			.text.*
+		)
+#endif
 		*(.gnu.linkonce.t.*)
 #include <zephyr/linker/kobject-text.ld>
 
@@ -189,6 +214,11 @@ SECTIONS
 #ifdef CONFIG_SOC_IT8XXX2_EXCEPTIONS_IN_RAM
 		KEEP(*(".exception.entry.*"))
 		*(".exception.other.*")
+#endif
+#ifdef CONFIG_SOC_IT8XXX2_SERIAL_IN_RAM
+		*libdrivers__serial.a:*(.text .text.*)
+		*libdrivers__serial.a:*(.rodata .rodata.*)
+		*libdrivers__serial.a:*(.srodata .srodata.*)
 #endif
 		__ilm_flash_end = .;
 		/* ILM mapping is always a multiple of 4k size; ensure following

--- a/soc/ite/ec/it8xxx2/linker.ld
+++ b/soc/ite/ec/it8xxx2/linker.ld
@@ -176,6 +176,9 @@ SECTIONS
 #ifdef CONFIG_SOC_IT8XXX2_SERIAL_IN_RAM
 			*libdrivers__serial.a:*
 #endif
+#ifdef CONFIG_SOC_IT8XXX2_KERNEL_IN_RAM
+			*libkernel.a:*
+#endif
 #ifdef CONFIG_SOC_IT8XXX2_LIBRARY_TO_RAM
 		)
 			.text
@@ -187,6 +190,9 @@ SECTIONS
 #endif
 #ifdef CONFIG_SOC_IT8XXX2_SERIAL_IN_RAM
 			*libdrivers__serial.a:*
+#endif
+#ifdef CONFIG_SOC_IT8XXX2_KERNEL_IN_RAM
+			*libkernel.a:*
 #endif
 #ifdef CONFIG_SOC_IT8XXX2_LIBRARY_TO_RAM
 		)
@@ -219,6 +225,11 @@ SECTIONS
 		*libdrivers__serial.a:*(.text .text.*)
 		*libdrivers__serial.a:*(.rodata .rodata.*)
 		*libdrivers__serial.a:*(.srodata .srodata.*)
+#endif
+#ifdef CONFIG_SOC_IT8XXX2_KERNEL_IN_RAM
+		*libkernel.a:*(.text .text.*)
+		*libkernel.a:*(.rodata .rodata.*)
+		*libkernel.a:*(.srodata .srodata.*)
 #endif
 		__ilm_flash_end = .;
 		/* ILM mapping is always a multiple of 4k size; ensure following

--- a/soc/ite/ec/it8xxx2/linker.ld
+++ b/soc/ite/ec/it8xxx2/linker.ld
@@ -179,6 +179,9 @@ SECTIONS
 #ifdef CONFIG_SOC_IT8XXX2_KERNEL_IN_RAM
 			*libkernel.a:*
 #endif
+#ifdef CONFIG_SOC_IT8XXX2_ZEPHYR_IN_RAM
+			*libzephyr.a:*
+#endif
 #ifdef CONFIG_SOC_IT8XXX2_LIBRARY_TO_RAM
 		)
 			.text
@@ -193,6 +196,9 @@ SECTIONS
 #endif
 #ifdef CONFIG_SOC_IT8XXX2_KERNEL_IN_RAM
 			*libkernel.a:*
+#endif
+#ifdef CONFIG_SOC_IT8XXX2_ZEPHYR_IN_RAM
+			*libzephyr.a:*
 #endif
 #ifdef CONFIG_SOC_IT8XXX2_LIBRARY_TO_RAM
 		)
@@ -230,6 +236,11 @@ SECTIONS
 		*libkernel.a:*(.text .text.*)
 		*libkernel.a:*(.rodata .rodata.*)
 		*libkernel.a:*(.srodata .srodata.*)
+#endif
+#ifdef CONFIG_SOC_IT8XXX2_ZEPHYR_IN_RAM
+		*libzephyr.a:*(.text .text.*)
+		*libzephyr.a:*(.rodata .rodata.*)
+		*libzephyr.a:*(.srodata .srodata.*)
 #endif
 		__ilm_flash_end = .;
 		/* ILM mapping is always a multiple of 4k size; ensure following


### PR DESCRIPTION
Three new configuration options are added, including serial, kernel and zephyr libraries, and placed into ILM as RAM code to improve performance.