### PR TITLE
watchdog: wdt_nrfx: return errors, not assertions

### DIFF
--- a/drivers/watchdog/wdt_nrfx.c
+++ b/drivers/watchdog/wdt_nrfx.c
@@ -209,10 +209,7 @@ static void wdt_event_handler(const struct device *dev, nrf_wdt_event_t event_ty
 		}							       \
 		return 0;						       \
 	}								       \
-	static struct wdt_nrfx_data wdt_##idx##_data = {		       \
-		.m_timeout = 0,						       \
-		.m_allocated_channels = 0,				       \
-	};								       \
+	static struct wdt_nrfx_data wdt_##idx##_data;			       \
 	static const struct wdt_nrfx_config wdt_##idx##z_config = {	       \
 		.wdt = NRFX_WDT_INSTANCE(idx),				       \
 	};								       \

--- a/drivers/watchdog/wdt_nrfx.c
+++ b/drivers/watchdog/wdt_nrfx.c
@@ -96,6 +96,10 @@ static int wdt_nrf_install_timeout(const struct device *dev,
 	nrfx_err_t err_code;
 	nrfx_wdt_channel_id channel_id;
 
+	if (data->enabled) {
+		return -EBUSY;
+	}
+
 	if (cfg->flags != WDT_FLAG_RESET_SOC) {
 		return -ENOTSUP;
 	}


### PR DESCRIPTION
Return an error code if `wdt_feed` is called before `wdt_setup`, instead
of triggering the state assertion inside of `nrfx_wdt_channel_feed`.

Return the documented error if `wdt_install_timeout` is called after
`wdt_setup`, instead of triggering the state assertion inside of
`nrfx_wdt_channel_alloc`.

Don't zero initialise the static data structure, as statics are
explicitly initialised to 0 per the C standard, and checkpatch normally
complains about the pattern.