### PR TITLE
posix: can: if name from command-line

### DIFF
--- a/boards/native/native_sim/doc/index.rst
+++ b/boards/native/native_sim/doc/index.rst
@@ -500,9 +500,13 @@ The following peripherals are currently provided with this board:
     :ref:`its section <nsim_per_disp_sdl>`.
 
 **CAN controller**
-  It is possible to use a host CAN controller with the native SockerCAN Linux driver. It can be
+  It is possible to use a host CAN controller with the native SocketCAN Linux driver. It can be
   enabled with :kconfig:option:`CONFIG_CAN_NATIVE_LINUX` and configured with the device tree binding
   :dtcompatible:`zephyr,native-linux-can`.
+
+  It is possible to specify which CAN interface will be used by the app using the ``--can-if``
+  command-line option. This option overrides **every** Linux SocketCAN driver instance to use the specified
+  interface.
 
 .. _native_ptty_uart:
 

--- a/dts/bindings/can/zephyr,native-linux-can.yaml
+++ b/dts/bindings/can/zephyr,native-linux-can.yaml
@@ -11,4 +11,7 @@ properties:
   host-interface:
     type: string
     required: true
-    description: Linux host interface name (e.g. zcan0, vcan0, can0, ...)
+    description: |
+      Linux host interface name (e.g. zcan0, vcan0, can0, ...).
+      This property can be overridden using the --can-if command-line
+      option. Note that it applies for every instance of this driver.


### PR DESCRIPTION
This commit introduces the ability to set the CAN
interface from command-line. This is helpful
if we want to run multiple instances of the app
with different CAN interfaces without making
separate compilations for each instance.

This PR is a continuation of #75243