### PR TITLE
drivers: adc: adc_nrfx_saadc: Patch neg single ended readings

### DIFF
--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -396,6 +396,10 @@ Drivers and Sensors
     ``nxp,references`` in ``nxp,lpc-lpadc`` binding. The NXP LPADC driver now supports passing
     the reference voltage value by using ``nxp,references``.
 
+  * Fixed issue which allowed negative ADC readings in single-ended mode using the ``adc_nrfx_saadc.c``
+    device driver. Note that this fix prevents the nRF54H and nRF54L series from performing
+    8-bit resolution single-ended readings due to hardware limitations.
+
 * Auxiliary Display
 
 * Audio

--- a/drivers/adc/adc_nrfx_saadc.c
+++ b/drivers/adc/adc_nrfx_saadc.c
@@ -97,8 +97,6 @@ static struct driver_data m_data = {
 	ADC_CONTEXT_INIT_SYNC(m_data, ctx),
 #if defined(ADC_BUFFER_IN_RAM)
 	.samples_buffer = adc_samples_buffer,
-	.user_buffer = NULL,
-	.active_channels = 0,
 #endif
 };
 
@@ -576,9 +574,7 @@ static int start_read(const struct device *dev,
 
 	adc_context_start_read(&m_data.ctx, sequence);
 
-	error = adc_context_wait_for_completion(&m_data.ctx);
-
-	return error;
+	return adc_context_wait_for_completion(&m_data.ctx);
 }
 
 /* Implementation of the ADC driver API function: adc_read. */

--- a/drivers/sensor/voltage_divider/voltage.c
+++ b/drivers/sensor/voltage_divider/voltage.c
@@ -59,9 +59,6 @@ static int get(const struct device *dev, enum sensor_channel chan, struct sensor
 
 	if (config->voltage.port.channel_cfg.differential) {
 		raw_val = (int16_t)data->raw;
-	} else if (config->voltage.port.resolution < 16) {
-		/* Can be removed when issue #71119 is resolved */
-		raw_val = (int16_t)data->raw;
 	} else {
 		raw_val = data->raw;
 	}


### PR DESCRIPTION
The NRF SAADC produces negative values in single ended mode if the positive input is below 0V (ground). This behavior does not match the ADC device driver API, which states that in single ended mode, the readings must be positive [0 .. 2^resolution - 1].

This commit extends the adc_nrfx_saadc device driver to track which channels in a sequence are configured to be single ended, to then adjust negative readings for these channels to be 0.

### Tests
Build adc_sequence sample with a modified board overlay which has one single ended and one differential channel configured.  The differential channel has the negative input tied to GND. The sample has also been modified to print signed values.

The positive inputs are then varied from -100mV to +100mV. The single ended channel should only show positive values, the differential channel should show negative and positive values. 

The test includes a nRF52840 for which all resolutions should be valid, and a nRF54L15 for which attempting to use 8-bit resolution on a single ended channel should fail to start the ADC read.

Fixes: #71119

#### nRF52840 (reference 600mV)
* 8 bit
  * differential
    * 100mV  = 21
    * -100mV = -22
  * single ended
    * 100mV = 65
    * -100mV = 0
* 10 bit
  * differential
    * 100mV  = 85
    * -100mV = -88
  * single ended
    * 100mV = 270
    * -100mV = 0
* 12 bit
  * differential
    * +100mV  = 340
    * -100mV = -340
  * single ended
    * +100mV = 1040
    * -100mV = 0
* 14 bit
  * differential
    * +100mV  = 1378
    * -100mV = -1368
  * single ended
    * +100mV = 4448
    * -100mV = 0

#### nRF54L15 (reference 900mV)
* 8 bit
  * differential
    * 100mV  = 15
    * -100mV = -15
    * 1000mV = 127
    * -1000mV = -128
  * single ended (fails to start as expected since sample size and res are both 8-bit)
    * 100mV = NA
    * -100mV = NA
* 10 bit
  * differential
    * 100mV  = 60
    * -100mV = -60
  * single ended
    * 100mV = 108
    * -100mV = 0
* 12 bit
  * differential
    * +100mV  = 228
    * -100mV = -230
  * single ended
    * +100mV = 420
    * -100mV = 0
* 14 bit
  * differential
    * +100mV  = 944
    * -100mV = -920
  * single ended
    * +100mV = 2128
    * -100mV = 0

