### PR TITLE
dts: npx: Fix sramx offset for LPC55S06

### DIFF
--- a/dts/arm/nxp/nxp_lpc55S06_ns.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S06_ns.dtsi
@@ -20,7 +20,7 @@
 
 &sramx {
 	compatible = "zephyr,memory-region", "mmio-sram";
-	reg = <0x40000000 DT_SIZE_K(16)>;
+	reg = <0x04000000 DT_SIZE_K(16)>;
 	zephyr,memory-region = "SRAMX";
 };
 


### PR DESCRIPTION
The current value is wrong and overlaps with `syscon`.