### PR TITLE
drivers: i2c: configure sleep pins for Smartbond I2C

### DIFF
--- a/boards/renesas/da14695_dk_usb/da14695_dk_usb-pinctrl.dtsi
+++ b/boards/renesas/da14695_dk_usb/da14695_dk_usb-pinctrl.dtsi
@@ -44,10 +44,27 @@
 		};
 	};
 
+	/omit-if-no-ref/ i2c_sleep: i2c_sleep {
+		group1 {
+			pinmux = <SMARTBOND_PINMUX(GPIO, 0, 31)>,
+				<SMARTBOND_PINMUX(GPIO, 0, 30)>;
+			bias-pull-up;
+
+		};
+	};
+
 	i2c2_default: i2c2_default {
 		group1 {
 			pinmux = <SMARTBOND_PINMUX(I2C2_SDA, 0, 19)>,
 				<SMARTBOND_PINMUX(I2C2_SCL, 0, 18)>;
+			bias-pull-up;
+		};
+	};
+
+	/omit-if-no-ref/ i2c2_sleep: i2c2_sleep {
+		group1 {
+			pinmux = <SMARTBOND_PINMUX(GPIO, 0, 28)>,
+				<SMARTBOND_PINMUX(GPIO, 0, 29)>;
 			bias-pull-up;
 		};
 	};

--- a/boards/renesas/da14695_dk_usb/da14695_dk_usb.dts
+++ b/boards/renesas/da14695_dk_usb/da14695_dk_usb.dts
@@ -189,13 +189,15 @@ zephyr_udc0: &usbd {
 &i2c {
 	status = "okay";
 	pinctrl-0 = <&i2c_default>;
-	pinctrl-names = "default";
+	pinctrl-1 = <&i2c_sleep>;
+	pinctrl-names = "default", "sleep";
 };
 
 &i2c2 {
 	status = "okay";
 	pinctrl-0 = <&i2c2_default>;
-	pinctrl-names = "default";
+	pinctrl-1 = <&i2c2_sleep>;
+	pinctrl-names = "default", "sleep";
 };
 
 &spi {


### PR DESCRIPTION
Adds missing i2c_sleep pins configuration definition required to properly support power management operations for Smartbond I2C controller on da14695_dk_usb board.