### PR TITLE
samples/net/dhcpv4_client: Exclude native_posix due to EVENTFD

### DIFF
--- a/samples/net/dhcpv4_client/sample.yaml
+++ b/samples/net/dhcpv4_client/sample.yaml
@@ -4,6 +4,9 @@ tests:
   sample.net.dhcpv4_client:
     harness: net
     depends_on: netif
+    platform_exclude:
+      - native_posix/native/64
+      - native_posix
     tags:
       - net
       - http


### PR DESCRIPTION
EVENTFD is not anymore compatible with these targets so let's disable them with this sample to avoid a failure in twister otherwise.