### PR TITLE
modules: mbedtls: properly guard PSA_CRYPTO_C

### DIFF
--- a/modules/mbedtls/Kconfig.tls-generic
+++ b/modules/mbedtls/Kconfig.tls-generic
@@ -484,6 +484,7 @@ endchoice
 
 config MBEDTLS_PSA_CRYPTO_C
 	bool "Platform Security Architecture cryptography API"
+	depends on !BUILD_WITH_TFM
 	default y if UOSCORE || UEDHOC
 
 config MBEDTLS_USE_PSA_CRYPTO

--- a/modules/mbedtls/configs/config-tls-generic.h
+++ b/modules/mbedtls/configs/config-tls-generic.h
@@ -514,8 +514,4 @@
 #include CONFIG_MBEDTLS_USER_CONFIG_FILE
 #endif
 
-#if defined(CONFIG_BUILD_WITH_TFM)
-#undef MBEDTLS_PSA_CRYPTO_C
-#endif
-
 #endif /* MBEDTLS_CONFIG_H */


### PR DESCRIPTION
Instead of silently `#undef`ing PSA_CRYPTO_C when TF-M is in use, enforce that rule at the Kconfig level.