### PR TITLE
modules: lvgl: fix initialization macro syntax

### DIFF
--- a/modules/lvgl/input/lvgl_common_input.c
+++ b/modules/lvgl/input/lvgl_common_input.c
@@ -73,7 +73,7 @@ int lvgl_input_register_driver(lv_indev_type_t indev_type, const struct device *
 		if (ret) {                                                                         \
 			return ret;                                                                \
 		}                                                                                  \
-	} while (0)
+	} while (0);
 
 int lvgl_init_input_devices(void)
 {


### PR DESCRIPTION
Adding a semicolon after the do-while loop in the LV_DEV_INIT() macro also supports multiple instantiation.

This resolves #75443.