### PR TITLE
drivers: lora: sx126x: support rf switch control for RFO_LP in STM32WL

### DIFF
--- a/boards/st/nucleo_wl55jc/nucleo_wl55jc.dts
+++ b/boards/st/nucleo_wl55jc/nucleo_wl55jc.dts
@@ -179,11 +179,11 @@ stm32_lp_tick_source: &lptim1 {
 		dio3-tcxo-voltage = <SX126X_DIO3_TCXO_1V7>;
 		tcxo-power-startup-delay-ms = <5>;
 		/* High-power output is selected as a consequence of using
-		 * tx/rx-enable-gpio to control FE_CTRL1 and FE_CTRL2. Low-power
-		 * output would require both FE_CTRL1 and FE_CTRL2 to be high,
-		 * which is not currently supported by the driver.
+		 * tx/rx-enable-gpio to control FE_CTRL1 and FE_CTRL2.
+		 * Low-power output would require both FE_CTRL1 and FE_CTRL2 to be high.
 		 */
 		power-amplifier-output = "rfo-hp";
+		power-amplifier-output-selectable;
 		rfo-lp-max-power = <15>;
 		rfo-hp-max-power = <22>;
 	};

--- a/drivers/lora/sx126x.c
+++ b/drivers/lora/sx126x.c
@@ -253,20 +253,6 @@ void SX126xAntSwOff(void)
 #endif
 }
 
-static void sx126x_set_tx_enable(int value)
-{
-#if HAVE_GPIO_TX_ENABLE
-	gpio_pin_set_dt(&dev_config.tx_enable, value);
-#endif
-}
-
-static void sx126x_set_rx_enable(int value)
-{
-#if HAVE_GPIO_RX_ENABLE
-	gpio_pin_set_dt(&dev_config.rx_enable, value);
-#endif
-}
-
 RadioOperatingModes_t SX126xGetOperatingMode(void)
 {
 	return dev_data.mode;
@@ -278,21 +264,15 @@ void SX126xSetOperatingMode(RadioOperatingModes_t mode)
 
 	dev_data.mode = mode;
 
-	/* To avoid inadvertently putting the RF switch in an
-	 * undefined state, first disable the port we don't want to
-	 * use and then enable the other one.
-	 */
 	switch (mode) {
 	case MODE_TX:
-		sx126x_set_rx_enable(0);
-		sx126x_set_tx_enable(1);
+		sx126x_set_rf_switch(&dev_config, RF_SWITCH_TX);
 		break;
 
 	case MODE_RX:
 	case MODE_RX_DC:
 	case MODE_CAD:
-		sx126x_set_tx_enable(0);
-		sx126x_set_rx_enable(1);
+		sx126x_set_rf_switch(&dev_config, RF_SWITCH_RX);
 		break;
 
 	case MODE_SLEEP:
@@ -300,8 +280,7 @@ void SX126xSetOperatingMode(RadioOperatingModes_t mode)
 		sx126x_dio1_irq_disable(&dev_data);
 		__fallthrough;
 	default:
-		sx126x_set_rx_enable(0);
-		sx126x_set_tx_enable(0);
+		sx126x_set_rf_switch(&dev_config, RF_SWITCH_SLEEP);
 		break;
 	}
 }

--- a/drivers/lora/sx126x_common.h
+++ b/drivers/lora/sx126x_common.h
@@ -34,6 +34,7 @@
 	DT_INST_NODE_HAS_PROP(0, antenna_enable_gpios)
 #define HAVE_GPIO_TX_ENABLE	DT_INST_NODE_HAS_PROP(0, tx_enable_gpios)
 #define HAVE_GPIO_RX_ENABLE	DT_INST_NODE_HAS_PROP(0, rx_enable_gpios)
+#define HAVE_PA_OUTPUT_SELECTABLE DT_INST_NODE_HAS_PROP(0, power_amplifier_output_selectable)
 
 struct sx126x_config {
 	struct spi_dt_spec bus;
@@ -55,6 +56,12 @@ struct sx126x_data {
 	RadioOperatingModes_t mode;
 };
 
+enum sx126x_rf_switch {
+	RF_SWITCH_SLEEP,
+	RF_SWITCH_TX,
+	RF_SWITCH_RX,
+};
+
 void sx126x_reset(struct sx126x_data *dev_data);
 
 bool sx126x_is_busy(struct sx126x_data *dev_data);
@@ -64,6 +71,8 @@ uint32_t sx126x_get_dio1_pin_state(struct sx126x_data *dev_data);
 void sx126x_dio1_irq_enable(struct sx126x_data *dev_data);
 
 void sx126x_dio1_irq_disable(struct sx126x_data *dev_data);
+
+void sx126x_set_rf_switch(const struct sx126x_config *dev_config, enum sx126x_rf_switch mode);
 
 void sx126x_set_tx_params(int8_t power, RadioRampTimes_t ramp_time);
 

--- a/drivers/lora/sx126x_standalone.c
+++ b/drivers/lora/sx126x_standalone.c
@@ -61,6 +61,34 @@ static void sx126x_dio1_irq_callback(const struct device *dev,
 	}
 }
 
+void sx126x_set_rf_switch(const struct sx126x_config *dev_config, enum sx126x_rf_switch mode)
+{
+	/* To avoid inadvertently putting the RF switch in an
+	 * undefined state, first disable the port we don't want to
+	 * use and then enable the other one.
+	 */
+
+#if HAVE_GPIO_RX_ENABLE
+	if (mode != RF_SWITCH_RX) {
+		gpio_pin_set_dt(&dev_config->rx_enable, 0);
+	}
+#endif
+
+#if HAVE_GPIO_TX_ENABLE
+	if (mode == RF_SWITCH_TX) {
+		gpio_pin_set_dt(&dev_config->tx_enable, 1);
+	} else {
+		gpio_pin_set_dt(&dev_config->tx_enable, 0);
+	}
+#endif
+
+#if HAVE_GPIO_RX_ENABLE
+	if (mode == RF_SWITCH_RX) {
+		gpio_pin_set_dt(&dev_config->rx_enable, 1);
+	}
+#endif
+}
+
 void sx126x_set_tx_params(int8_t power, RadioRampTimes_t ramp_time)
 {
 	SX126xSetTxParams(power, ramp_time);

--- a/dts/bindings/lora/st,stm32wl-subghz-radio.yaml
+++ b/dts/bindings/lora/st,stm32wl-subghz-radio.yaml
@@ -22,6 +22,15 @@ properties:
       - "rfo-lp"
       - "rfo-hp"
 
+  power-amplifier-output-selectable:
+    type: boolean
+    description:
+      Indicates whether the power amplifier output is selectable. When set to true,
+      the board supports switching between different power amplifier outputs.
+      This is typically used in configurations where multiple power amplifier paths are
+      available, such as RFO_LP and RFO_HP. If not specified, the default value is false,
+      meaning the power amplifier output is fixed.
+
   rfo-lp-max-power:
     type: int
     default: 14


### PR DESCRIPTION
This commit provides support rf switch control for RFO_LP in STM32WL by:
- Replace individual TX and RX enable functions with a unified `sx126x_set_rf_switch` function.
- Update the `SX126xSetOperatingMode` function to use the new `sx126x_set_rf_switch` function.
- Add `power-amplifier-output-selectable` property in `st,stm32wl-subghz-radio.yaml` for compatibility with other STM32WL boards.