### PR TITLE
logging: Fix missing CONFIG_ prefix

### DIFF
--- a/include/zephyr/logging/log.h
+++ b/include/zephyr/logging/log.h
@@ -328,7 +328,7 @@ void z_log_vprintk(const char *fmt, va_list ap);
 		log_source_const_data,								\
 		Z_LOG_ITEM_CONST_DATA(_name)) =							\
 	{											\
-		.name = IS_ENABLED(LOG_FMT_SECTION_STRIP) ? NULL :				\
+		.name = IS_ENABLED(CONFIG_LOG_FMT_SECTION_STRIP) ? NULL :			\
 			COND_CODE_1(CONFIG_LOG_FMT_SECTION,					\
 				(UTIL_CAT(_name, _str)), (STRINGIFY(_name))),			\
 		.level = (_level)								\


### PR DESCRIPTION
Fix missing CONFIG_ prefix for log format section strip check. Logging was still operating on invalid flash addresses.

Fixes #75161