### PR TITLE
boards: nrfbsim: Fix testargs with non host libC

### DIFF
--- a/boards/native/nrf_bsim/nsi_if.c
+++ b/boards/native/nrf_bsim/nsi_if.c
@@ -14,6 +14,7 @@
 #include "phy_sync_ctrl.h"
 #include "nsi_hw_scheduler.h"
 #include "nsi_cpu_ctrl.h"
+#include "nsi_host_trampolines.h"
 
 /*
  * These hooks are to be named nsif_cpu<cpu_number>_<hook_name>, for example nsif_cpu0_boot
@@ -55,8 +56,8 @@ NATIVE_SIMULATOR_IF void nsif_cpun_save_test_arg(char *argv)
 {
 	if (test_args.test_case_argc >= test_args.allocated_size) {
 		test_args.allocated_size += TESTCASAE_ARGV_ALLOCSIZE;
-		test_args.test_case_argv = realloc(test_args.test_case_argv,
-						   test_args.allocated_size * sizeof(char *));
+		test_args.test_case_argv = nsi_host_realloc(test_args.test_case_argv,
+						test_args.allocated_size * sizeof(char *));
 		if (test_args.test_case_argv == NULL) { /* LCOV_EXCL_BR_LINE */
 			bs_trace_error_line("Can't allocate memory\n"); /* LCOV_EXCL_LINE */
 		}
@@ -70,7 +71,7 @@ NATIVE_SIMULATOR_IF void nsif_cpun_save_test_arg(char *argv)
 static void test_args_free(void)
 {
 	if (test_args.test_case_argv) {
-		free(test_args.test_case_argv);
+		nsi_host_free(test_args.test_case_argv);
 		test_args.test_case_argv = NULL;
 	}
 }

--- a/tests/subsys/ipc/pbuf/testcase.yaml
+++ b/tests/subsys/ipc/pbuf/testcase.yaml
@@ -1,5 +1,8 @@
 tests:
   ipc.icmsg_pbuf:
+    # For native(POSIX arch) targets, let's skip those which do not produce an executable
+    # (amp targets which need more images)
+    filter: not CONFIG_ARCH_POSIX or CONFIG_BUILD_OUTPUT_EXE
     integration_platforms:
       - native_sim
     timeout: 120


### PR DESCRIPTION
Ensure that we call the host libC when allocating space for a possible set of test arguments even if we are building Zephyr with an embedded libC.

This fixes a bug, where a test which uses the bsim test args facility and builds with an embedded libC instead of the host libC would fail at runtime.

---

Added an extra commit to add a filter for the test which caused twister to crash.
In short: when building images which use IPC for the nrf5340bsim//cpunet the build will (purposely) only build that core image elf, but not link the final executable. This is because to build the final executable one needs the app core image (which contains the IPC buffer).
twister when building for native targets expects the final exe to run the test, and if it does not find it, it dies badly. Let's add a filter to ensure this test only runs for native targets if the exe has been produced. For non posix arch targets the filter is always true.