### PR TITLE
Bluetooth: Kconfig: Increase BT_HCI_TX_STACK_SIZE for ISO_BROADCAST

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -48,7 +48,7 @@ config BT_HCI_TX_STACK_SIZE
 	default 512 if BT_H4
 	default 512 if BT_H5
 	default 416 if BT_SPI
-	default 1152 if BT_CTLR && BT_LL_SW_SPLIT && (NO_OPTIMIZATIONS || BT_ISO_BROADCAST)
+	default 1280 if BT_CTLR && BT_LL_SW_SPLIT && (NO_OPTIMIZATIONS || BT_ISO_BROADCAST)
 	default 1024 if BT_CTLR && BT_LL_SW_SPLIT && BT_CENTRAL
 	default 768 if BT_CTLR && BT_LL_SW_SPLIT
 	default 512 if BT_USERCHAN


### PR DESCRIPTION
When using an encrypted broadcast, the previous value is no longer enough and caused a stack overflow.

Slightly increased the value.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/75435