### PR TITLE
sample: usb: allow samples to be built on all platforms with 'usbd'

### DIFF
--- a/samples/subsys/usb/cdc_acm/sample.yaml
+++ b/samples/subsys/usb/cdc_acm/sample.yaml
@@ -14,11 +14,12 @@ tests:
     depends_on: usbd
     tags: usb
     extra_args: CONF_FILE="usbd_next_prj.conf"
-    platform_allow:
+    integration_platforms:
       - nrf52840dk/nrf52840
       - nrf54h20dk/nrf54h20/cpuapp
       - frdm_k64f
-      - 96b_carbon/stm32f401xe
+      - stm32f723e_disco
+      - nucleo_f413zh
       - mimxrt685_evk/mimxrt685s/cm33
       - mimxrt1060_evk
     harness: console

--- a/samples/subsys/usb/hid-keyboard/sample.yaml
+++ b/samples/subsys/usb/hid-keyboard/sample.yaml
@@ -6,10 +6,14 @@ common:
   depends_on:
     - usbd
     - gpio
-  platform_allow:
+  integration_platforms:
     - nrf52840dk/nrf52840
     - nrf54h20dk/nrf54h20/cpuapp
     - frdm_k64f
+    - stm32f723e_disco
+    - nucleo_f413zh
+    - mimxrt685_evk/mimxrt685s/cm33
+    - mimxrt1060_evk
 tests:
   sample.usbd.hid-keyboard:
     tags: usb

--- a/samples/subsys/usb/hid-mouse/sample.yaml
+++ b/samples/subsys/usb/hid-mouse/sample.yaml
@@ -15,10 +15,14 @@ tests:
   sample.usb_device_next.hid-mouse:
     depends_on:
       - usbd
-    platform_allow:
+    integration_platforms:
       - nrf52840dk/nrf52840
       - nrf54h20dk/nrf54h20/cpuapp
       - frdm_k64f
+      - stm32f723e_disco
+      - nucleo_f413zh
+      - mimxrt685_evk/mimxrt685s/cm33
+      - mimxrt1060_evk
     extra_args:
       - CONF_FILE="usbd_next_prj.conf"
       - EXTRA_DTC_OVERLAY_FILE="usbd_next.overlay"

--- a/samples/subsys/usb/mass/sample.yaml
+++ b/samples/subsys/usb/mass/sample.yaml
@@ -22,10 +22,12 @@ tests:
   sample.usb_device_next.mass_ram_none:
     min_ram: 128
     depends_on: usbd
-    platform_allow:
+    integration_platforms:
       - nrf52840dk/nrf52840
       - nrf54h20dk/nrf54h20/cpuapp
       - frdm_k64f
+      - stm32f723e_disco
+      - nucleo_f413zh
       - mimxrt685_evk/mimxrt685s/cm33
       - mimxrt1060_evk
     extra_args:

--- a/samples/subsys/usb/shell/sample.yaml
+++ b/samples/subsys/usb/shell/sample.yaml
@@ -5,7 +5,7 @@ common:
     - usbd
 tests:
   sample.usbd.shell:
-    platform_allow:
+    integration_platforms:
       - nrf52840dk/nrf52840
       - nrf54h20dk/nrf54h20/cpuapp
       - frdm_k64f


### PR DESCRIPTION
Replace platform_allow with integration_platforms, what allow CI to build samples on all platforms with test feature 'usbd' but still limits number of platforms when it is invoked with the --integration option. Replace/add some platforms that already have test feature 'usbd'.