### PR TITLE
net: lib: call socket poll if could not send data completely in http or ws (websocket)

### DIFF
--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -29,12 +29,30 @@ LOG_MODULE_REGISTER(net_http_client, CONFIG_NET_HTTP_LOG_LEVEL);
 #define HTTP_CONTENT_LEN_SIZE 11
 #define MAX_SEND_BUF_LEN 192
 
-static int sendall(int sock, const void *buf, size_t len)
+static int sendall(int sock, const void *buf, size_t len,
+			const k_timepoint_t req_end_timepoint)
 {
 	while (len) {
 		ssize_t out_len = zsock_send(sock, buf, len, 0);
 
-		if (out_len < 0) {
+		if ((out_len == 0) || (out_len < 0 && errno == EAGAIN)) {
+			struct zsock_pollfd pfd;
+			int pollres;
+			k_ticks_t req_timeout_ticks =
+				sys_timepoint_timeout(req_end_timepoint).ticks;
+			int req_timeout_ms = k_ticks_to_ms_floor32(req_timeout_ticks);
+
+			pfd.fd = sock;
+			pfd.events = ZSOCK_POLLOUT;
+			pollres = zsock_poll(&pfd, 1, req_timeout_ms);
+			if (pollres == 0) {
+				return -ETIMEDOUT;
+			} else if (pollres > 0) {
+				continue;
+			} else {
+				return -errno;
+			}
+		} else if (out_len < 0) {
 			return -errno;
 		}
 
@@ -47,6 +65,7 @@ static int sendall(int sock, const void *buf, size_t len)
 
 static int http_send_data(int sock, char *send_buf,
 			  size_t send_buf_max_len, size_t *send_buf_pos,
+			  const k_timepoint_t req_end_timepoint,
 			  ...)
 {
 	const char *data;
@@ -55,7 +74,7 @@ static int http_send_data(int sock, char *send_buf,
 	int end_of_data, remaining_len;
 	int sent = 0;
 
-	va_start(va, send_buf_pos);
+	va_start(va, req_end_timepoint);
 
 	data = va_arg(va, const char *);
 
@@ -80,7 +99,7 @@ static int http_send_data(int sock, char *send_buf,
 				LOG_HEXDUMP_DBG(send_buf, end_of_send,
 						"Data to send");
 
-				ret = sendall(sock, send_buf, end_of_send);
+				ret = sendall(sock, send_buf, end_of_send, req_end_timepoint);
 				if (ret < 0) {
 					NET_DBG("Cannot send %d bytes (%d)",
 						end_of_send, ret);
@@ -119,13 +138,14 @@ err:
 	return ret;
 }
 
-static int http_flush_data(int sock, const char *send_buf, size_t send_buf_len)
+static int http_flush_data(int sock, const char *send_buf, size_t send_buf_len,
+				const k_timepoint_t req_end_timepoint)
 {
 	int ret;
 
 	LOG_HEXDUMP_DBG(send_buf, send_buf_len, "Data to send");
 
-	ret = sendall(sock, send_buf, send_buf_len);
+	ret = sendall(sock, send_buf, send_buf_len, req_end_timepoint);
 	if (ret < 0) {
 		return ret;
 	}
@@ -439,29 +459,23 @@ static void http_report_progress(struct http_request *req)
 	}
 }
 
-static int http_wait_data(int sock, struct http_request *req, int32_t timeout)
+static int http_wait_data(int sock, struct http_request *req, const k_timepoint_t req_end_timepoint)
 {
 	int total_received = 0;
 	size_t offset = 0;
 	int received, ret;
 	struct zsock_pollfd fds[1];
 	int nfds = 1;
-	int32_t remaining_time = timeout;
-	int64_t timestamp = k_uptime_get();
 
 	fds[0].fd = sock;
 	fds[0].events = ZSOCK_POLLIN;
 
 	do {
-		if (timeout > 0) {
-			remaining_time -= (int32_t)k_uptime_delta(&timestamp);
-			if (remaining_time < 0) {
-				/* timeout, make poll return immediately */
-				remaining_time = 0;
-			}
-		}
+		k_ticks_t req_timeout_ticks =
+			sys_timepoint_timeout(req_end_timepoint).ticks;
+		int req_timeout_ms = k_ticks_to_ms_floor32(req_timeout_ticks);
 
-		ret = zsock_poll(fds, nfds, remaining_time);
+		ret = zsock_poll(fds, nfds, req_timeout_ms);
 		if (ret == 0) {
 			LOG_DBG("Timeout");
 			ret = -ETIMEDOUT;
@@ -548,6 +562,8 @@ int http_client_req(int sock, struct http_request *req,
 	int total_sent = 0;
 	int ret, total_recv, i;
 	const char *method;
+	k_timeout_t req_timeout = K_MSEC(timeout);
+	k_timepoint_t req_end_timepoint = sys_timepoint_calc(req_timeout);
 
 	if (sock < 0 || req == NULL || req->response == NULL ||
 	    req->recv_buf == NULL || req->recv_buf_len == 0) {
@@ -566,8 +582,9 @@ int http_client_req(int sock, struct http_request *req,
 	method = http_method_str(req->method);
 
 	ret = http_send_data(sock, send_buf, send_buf_max_len, &send_buf_pos,
-			     method, " ", req->url, " ", req->protocol,
-			     HTTP_CRLF, NULL);
+				req_end_timepoint, method,
+				" ", req->url, " ", req->protocol,
+				HTTP_CRLF, NULL);
 	if (ret < 0) {
 		goto out;
 	}
@@ -576,8 +593,8 @@ int http_client_req(int sock, struct http_request *req,
 
 	if (req->port) {
 		ret = http_send_data(sock, send_buf, send_buf_max_len,
-				     &send_buf_pos, "Host", ": ", req->host,
-				     ":", req->port, HTTP_CRLF, NULL);
+					&send_buf_pos, req_end_timepoint, "Host", ": ", req->host,
+					":", req->port, HTTP_CRLF, NULL);
 
 		if (ret < 0) {
 			goto out;
@@ -586,7 +603,7 @@ int http_client_req(int sock, struct http_request *req,
 		total_sent += ret;
 	} else {
 		ret = http_send_data(sock, send_buf, send_buf_max_len,
-				     &send_buf_pos, "Host", ": ", req->host,
+				     &send_buf_pos, req_end_timepoint, "Host", ": ", req->host,
 				     HTTP_CRLF, NULL);
 
 		if (ret < 0) {
@@ -597,7 +614,7 @@ int http_client_req(int sock, struct http_request *req,
 	}
 
 	if (req->optional_headers_cb) {
-		ret = http_flush_data(sock, send_buf, send_buf_pos);
+		ret = http_flush_data(sock, send_buf, send_buf_pos, req_end_timepoint);
 		if (ret < 0) {
 			goto out;
 		}
@@ -615,7 +632,7 @@ int http_client_req(int sock, struct http_request *req,
 		for (i = 0; req->optional_headers && req->optional_headers[i];
 		     i++) {
 			ret = http_send_data(sock, send_buf, send_buf_max_len,
-					     &send_buf_pos,
+					     &send_buf_pos, req_end_timepoint,
 					     req->optional_headers[i], NULL);
 			if (ret < 0) {
 				goto out;
@@ -627,7 +644,7 @@ int http_client_req(int sock, struct http_request *req,
 
 	for (i = 0; req->header_fields && req->header_fields[i]; i++) {
 		ret = http_send_data(sock, send_buf, send_buf_max_len,
-				     &send_buf_pos, req->header_fields[i],
+				     &send_buf_pos, req_end_timepoint, req->header_fields[i],
 				     NULL);
 		if (ret < 0) {
 			goto out;
@@ -638,7 +655,7 @@ int http_client_req(int sock, struct http_request *req,
 
 	if (req->content_type_value) {
 		ret = http_send_data(sock, send_buf, send_buf_max_len,
-				     &send_buf_pos, "Content-Type", ": ",
+				     &send_buf_pos, req_end_timepoint, "Content-Type", ": ",
 				     req->content_type_value, HTTP_CRLF, NULL);
 		if (ret < 0) {
 			goto out;
@@ -659,12 +676,13 @@ int http_client_req(int sock, struct http_request *req,
 			}
 
 			ret = http_send_data(sock, send_buf, send_buf_max_len,
-					     &send_buf_pos, "Content-Length", ": ",
-					     content_len_str, HTTP_CRLF,
-					     HTTP_CRLF, NULL);
+						&send_buf_pos, req_end_timepoint,
+						"Content-Length", ": ",
+						content_len_str, HTTP_CRLF,
+						HTTP_CRLF, NULL);
 		} else {
 			ret = http_send_data(sock, send_buf, send_buf_max_len,
-				     &send_buf_pos, HTTP_CRLF, NULL);
+				     &send_buf_pos, req_end_timepoint, HTTP_CRLF, NULL);
 		}
 
 		if (ret < 0) {
@@ -673,7 +691,7 @@ int http_client_req(int sock, struct http_request *req,
 
 		total_sent += ret;
 
-		ret = http_flush_data(sock, send_buf, send_buf_pos);
+		ret = http_flush_data(sock, send_buf, send_buf_pos, req_end_timepoint);
 		if (ret < 0) {
 			goto out;
 		}
@@ -697,7 +715,7 @@ int http_client_req(int sock, struct http_request *req,
 				length = req->payload_len;
 			}
 
-			ret = sendall(sock, req->payload, length);
+			ret = sendall(sock, req->payload, length, req_end_timepoint);
 			if (ret < 0) {
 				goto out;
 			}
@@ -706,7 +724,7 @@ int http_client_req(int sock, struct http_request *req,
 		}
 	} else {
 		ret = http_send_data(sock, send_buf, send_buf_max_len,
-				     &send_buf_pos, HTTP_CRLF, NULL);
+				     &send_buf_pos, req_end_timepoint, HTTP_CRLF, NULL);
 		if (ret < 0) {
 			goto out;
 		}
@@ -715,7 +733,7 @@ int http_client_req(int sock, struct http_request *req,
 	}
 
 	if (send_buf_pos > 0) {
-		ret = http_flush_data(sock, send_buf, send_buf_pos);
+		ret = http_flush_data(sock, send_buf, send_buf_pos, req_end_timepoint);
 		if (ret < 0) {
 			goto out;
 		}
@@ -729,7 +747,7 @@ int http_client_req(int sock, struct http_request *req,
 				&req->internal.parser_settings);
 
 	/* Request is sent, now wait data to be received */
-	total_recv = http_wait_data(sock, req, timeout);
+	total_recv = http_wait_data(sock, req, req_end_timepoint);
 	if (total_recv < 0) {
 		NET_DBG("Wait data failure (%d)", total_recv);
 		ret = total_recv;


### PR DESCRIPTION
Revived [PR](https://github.com/zephyrproject-rtos/zephyr/pull/45633) 
+ introduce changes suggested by @jukkar there (respect timeout supplied by the user).

In fact timeouts might not be completely respected if net_context timeout is big enough, but it is still better than nothing.

In http_client and websocket, if we couldn't send all (or any data) via the socket,
invoke poll instead of blindly retrying and flooding the socket.

This fix is especially relevant after adding https://github.com/zephyrproject-rtos/zephyr/pull/45626
