### PR TITLE
Driver: i2c_ll_stm32_v2: Remove log msg on boot

### DIFF
--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -1115,11 +1115,11 @@ int stm32_i2c_configure_timing(const struct device *dev, uint32_t clock)
 	} while (presc < 16);
 
 	if (presc >= 16U) {
-		LOG_DBG("I2C:failed to find prescaler value");
+		LOG_ERR("I2C:failed to find prescaler value");
 		return -EINVAL;
 	}
 
-	LOG_INF("I2C TIMING = 0x%x", timing);
+	LOG_DBG("I2C TIMING = 0x%x", timing);
 	LL_I2C_SetTiming(i2c, timing);
 
 	return 0;


### PR DESCRIPTION
Converts the `<inf> i2c_ll_stm32_v2: I2C TIMING` message displayed by the driver to a `LOG_DBG`.

Also makes an actual error message a `LOG_ERR` instead of a `LOG_DBG`.