### PR TITLE
drivers: eeprom: emulator: correct improper exponentiation

### DIFF
--- a/drivers/eeprom/eeprom_emulator.c
+++ b/drivers/eeprom/eeprom_emulator.c
@@ -733,7 +733,7 @@ static const struct eeprom_driver_api eeprom_emu_api = {
 		(DT_GPARENT(part)), (DT_PARENT(part))), write_block_size)
 
 #define PART_CBS(part, size) (PART_WBS(part) < 4) ? \
-	((size > (2^16)) ? 8 : 4) : PART_WBS(part)
+	((size > KB(64)) ? 8 : 4) : PART_WBS(part)
 
 #define PART_DEV_ID(part) \
 	COND_CODE_1(DT_NODE_HAS_COMPAT(DT_GPARENT(part), soc_nv_flash), \


### PR DESCRIPTION
The top-level comment in the EEPROM emulator driver source states that a uint16_t is used to store changes if the EEPROM size is smaller than 64kB, or uint32_t otherwise. However, the 64kB threshold is represented as 2^16 in the actual code, which is a bitwise XOR instead of an exponent. This causes a uint16_t to be used only if the size is less than or equal to 18 bytes. Correct this by using KB(64) instead of 2^16.

Fixes #75476.