### PR TITLE
watchdog: cmsdk_apb: fix period calculation

### DIFF
--- a/boards/arm/mps2/mps2_an385.yaml
+++ b/boards/arm/mps2/mps2_an385.yaml
@@ -11,6 +11,7 @@ supported:
   - counter
   - netif:serial-net
   - gpio
+  - watchdog
 testing:
   default: true
 vendor: arm

--- a/drivers/watchdog/wdt_cmsdk_apb.c
+++ b/drivers/watchdog/wdt_cmsdk_apb.c
@@ -67,6 +67,7 @@ const struct device *wdog_r;
 
 /* watchdog reload value in clock cycles */
 static unsigned int reload_cycles = CMSDK_APB_WDOG_RELOAD;
+static uint8_t assigned_channels;
 static uint8_t flags;
 
 static void (*user_cb)(const struct device *dev, int channel_id);
@@ -102,6 +103,8 @@ static int wdog_cmsdk_apb_disable(const struct device *dev)
 	/* Stop the watchdog counter with INTEN bit */
 	wdog->ctrl = ~(CMSDK_APB_WDOG_CTRL_RESEN | CMSDK_APB_WDOG_CTRL_INTEN);
 
+	assigned_channels = 0;
+
 	return 0;
 }
 
@@ -116,6 +119,9 @@ static int wdog_cmsdk_apb_install_timeout(const struct device *dev,
 	if (config->window.max == 0) {
 		return -EINVAL;
 	}
+	if (assigned_channels == 1) {
+		return -ENOMEM;
+	}
 
 	/* Reload value */
 	reload_cycles = config->window.max * clk_freq_khz;
@@ -126,6 +132,7 @@ static int wdog_cmsdk_apb_install_timeout(const struct device *dev,
 	/* Configure only the callback */
 	user_cb = config->callback;
 
+	assigned_channels++;
 	return 0;
 }
 

--- a/drivers/watchdog/wdt_cmsdk_apb.c
+++ b/drivers/watchdog/wdt_cmsdk_apb.c
@@ -113,6 +113,10 @@ static int wdog_cmsdk_apb_install_timeout(const struct device *dev,
 
 	ARG_UNUSED(dev);
 
+	if (config->window.max == 0) {
+		return -EINVAL;
+	}
+
 	/* Reload value */
 	reload_cycles = config->window.max * clk_freq_khz;
 	flags = config->flags;

--- a/drivers/watchdog/wdt_cmsdk_apb.c
+++ b/drivers/watchdog/wdt_cmsdk_apb.c
@@ -65,8 +65,8 @@ struct wdog_cmsdk_apb {
 /* Keep reference of the device to pass it to the callback */
 const struct device *wdog_r;
 
-/* watchdog reload value in sec */
-static unsigned int reload_s = CMSDK_APB_WDOG_RELOAD;
+/* watchdog reload value in clock cycles */
+static unsigned int reload_cycles = CMSDK_APB_WDOG_RELOAD;
 static uint8_t flags;
 
 static void (*user_cb)(const struct device *dev, int channel_id);
@@ -109,15 +109,15 @@ static int wdog_cmsdk_apb_install_timeout(const struct device *dev,
 					  const struct wdt_timeout_cfg *config)
 {
 	volatile struct wdog_cmsdk_apb *wdog = WDOG_STRUCT;
+	uint32_t clk_freq_khz = DT_INST_PROP_BY_PHANDLE(0, clocks, clock_frequency) / 1000;
 
 	ARG_UNUSED(dev);
 
 	/* Reload value */
-	reload_s = config->window.max *
-			   DT_INST_PROP_BY_PHANDLE(0, clocks, clock_frequency);
+	reload_cycles = config->window.max * clk_freq_khz;
 	flags = config->flags;
 
-	wdog->load = reload_s;
+	wdog->load = reload_cycles;
 
 	/* Configure only the callback */
 	user_cb = config->callback;
@@ -136,7 +136,7 @@ static int wdog_cmsdk_apb_feed(const struct device *dev, int channel_id)
 	wdog->intclr = CMSDK_APB_WDOG_INTCLR;
 
 	/* Reload */
-	wdog->load = reload_s;
+	wdog->load = reload_cycles;
 
 	return 0;
 }
@@ -185,7 +185,7 @@ static int wdog_cmsdk_apb_init(const struct device *dev)
 	wdog_cmsdk_apb_unlock(dev);
 
 	/* set default reload value */
-	wdog->load = reload_s;
+	wdog->load = reload_cycles;
 
 #ifdef CONFIG_RUNTIME_NMI
 	/* Configure the interrupts */


### PR DESCRIPTION
The previous calculation was multiplying the timeout in milliseconds by the clock frequency, giving a cycle count 1000x larger than it should be. Fix the calculation and rename `reload_s` to `reload_cycles`, as the cycle count is what this actually contains.

Validate the maximum timeout window, as required by the API tests.

The CMSDK watchdog hardware only supports a single timeout channel. Return the documented error if more than one timeout is requested to be installed.

Validate driver in CI by adding the `watchdog` tag to the `mps2/an385` platform, which uses the driver.