### PR TITLE
drivers: sensor: wsen_itds: fix device ID mismatch return value

### DIFF
--- a/drivers/sensor/wsen/wsen_itds/itds.c
+++ b/drivers/sensor/wsen/wsen_itds/itds.c
@@ -333,7 +333,7 @@ static int itds_init(const struct device *dev)
 
 	if (rval != ITDS_DEVICE_ID) {
 		LOG_ERR("device ID mismatch: %x", rval);
-		return ret;
+		return -EIO;
 	}
 
 	ret = i2c_reg_update_byte_dt(&cfg->i2c, ITDS_REG_CTRL2,


### PR DESCRIPTION
During driver initialization, zero is returned if an unexpected device ID is read because the returned variable is not written to after a previous non-zero check. Return -EIO instead to indicate an error occurred.

Detected with the following Coccinelle script:

```cocci
@@
identifier I;
@@

*if (I) {
     ...
     return ...;
 }

 if (...) {
     ... when != I
         when any
*    return I;
 }
```

Fixes #75479.