### PR TITLE
net: lib: zperf: Fix incorrect zperf UDP TX result

### DIFF
--- a/subsys/net/lib/zperf/zperf_internal.h
+++ b/subsys/net/lib/zperf/zperf_internal.h
@@ -57,6 +57,7 @@ struct zperf_udp_datagram {
 	int32_t id;
 	uint32_t tv_sec;
 	uint32_t tv_usec;
+	int32_t id2;
 } __packed;
 
 BUILD_ASSERT(sizeof(struct zperf_udp_datagram) <= PACKET_SIZE_MAX, "Invalid PACKET_SIZE_MAX");


### PR DESCRIPTION
The inconsistent definition of the structure udp_datagram in zperf code and iperf-2.1.9 software resulted in parsing errors on the client side. structure zperf_udp_datagram lack of a value id2.

the incorrect zperf UDP TX result as below:
Upload completed!
LAST PACKET NOT RECEIVED!!!
Statistics: server (client)
Duration: 19.50 s (10.00 s)
Num packets: 0 (77768)
Num packets out order: 2
Num packets lost: 2321
Jitter: 7.64 m
Rate: 0 Kbps (91.71 Mbps)

Added variable id2 to structure zperf_udp_datagram. the correct zperf UDP TX result is as below:
Upload completed!
Statistics: server (client)
Duration: 10.00 s (10.00 s)
Num packets: 77985 (77985)
Num packets out order: 0
Num packets lost: 1
Jitter: 231 us
Rate: 91.69 Mbps (91.71 Mbps)