### PR TITLE
picolibc: guarantee the mutual exclusivity of `_USE_MODULE`/`_USE_TOOLCHAIN` in a `choice`

### DIFF
--- a/lib/libc/picolibc/Kconfig
+++ b/lib/libc/picolibc/Kconfig
@@ -3,9 +3,13 @@
 
 if PICOLIBC
 
+choice PICOLIBC_SOURCE
+	prompt "Source of Picolibc"
+	default PICOLIBC_USE_TOOLCHAIN if REQUIRES_FULL_LIBCPP || "$(TOOLCHAIN_HAS_PICOLIBC)" = "y"
+	default PICOLIBC_USE_MODULE
+
 config PICOLIBC_USE_MODULE
-	bool "Picolibc as module" if "$(TOOLCHAIN_HAS_PICOLIBC)" = "y"
-	default y if "$(TOOLCHAIN_HAS_PICOLIBC)" != "y"
+	bool "Picolibc from module"
 	depends on ZEPHYR_PICOLIBC_MODULE
 	depends on !GLIBCXX_LIBCPP
 	help
@@ -15,9 +19,14 @@ config PICOLIBC_USE_MODULE
 
 # force TLS when using toolchain with TLS support
 config PICOLIBC_USE_TOOLCHAIN
-	bool
-	default y if !PICOLIBC_USE_MODULE
+	bool "Picolibc from toolchain"
+	depends on "$(TOOLCHAIN_HAS_PICOLIBC)" = "y"
 	select THREAD_LOCAL_STORAGE if ARCH_HAS_THREAD_LOCAL_STORAGE && TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
+	help
+	  Use picolibc included with the toolchain.
+	  This is required when using a full C++ standard library (`REQUIRES_FULL_LIBCPP=y`).
+
+endchoice # PICOLIBC_SOURCE
 
 choice PICOLIBC_IO_LEVEL
 	prompt "Picolibc printf/scanf level"


### PR DESCRIPTION
> [!NOTE]
> Has commits from #75298, only the [last commit](https://github.com/zephyrproject-rtos/zephyr/pull/75483/commits/cc28ceaee63b44379d82d40e37ac94133acafdd1) is relevant in this PR

`PICOLIBC_USE_MODULE` & `PICOLIBC_USE_TOOLCHAIN` is mutually exclusive, we can guarantee that with a Kconfig choice instead of relying on the dependencies.