### PR TITLE
logging: Keep module names if runtime filtering is used

### DIFF
--- a/subsys/logging/log_mgmt.c
+++ b/subsys/logging/log_mgmt.c
@@ -243,6 +243,15 @@ static const char *link_source_name_get(uint8_t domain_id, uint32_t source_id)
 const char *log_source_name_get(uint32_t domain_id, uint32_t source_id)
 {
 	if (z_log_is_local_domain(domain_id)) {
+		/* If logging strings are removed from binary then source names are
+		 * also removed and name pointers in the source data structure are
+		 * invalid unless runtime filtering is enabled.
+		 */
+		if (IS_ENABLED(CONFIG_LOG_FMT_SECTION_STRIP) &&
+		    !IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING)) {
+			return NULL;
+		}
+
 		if (source_id < log_src_cnt_get(domain_id)) {
 			return TYPE_SECTION_START(log_const)[source_id].name;
 		} else {


### PR DESCRIPTION
I realized that #75446 and #75166 were wrong. Module names shall never be set to NULL because it means that those names would be lost and we want to keep them in binary or in elf file from which dictionary database can get them.

Module names shall be kept in the binary (not in the section that is removed) when they may be accessed by the runtime application and that is when application is formatting the logs or when dictionary logging is used with runtime filtering enabled.
