### PR TITLE
tests: drivers: adc_api: use proper printf format

### DIFF
--- a/tests/drivers/adc/adc_api/src/test_adc.c
+++ b/tests/drivers/adc/adc_api/src/test_adc.c
@@ -104,7 +104,7 @@ static void check_samples(int expected_count)
 	for (i = 0; i < BUFFER_SIZE; i++) {
 		int16_t sample_value = m_sample_buffer[i];
 
-		TC_PRINT("0x%04x ", sample_value);
+		TC_PRINT("0x%04hx ", sample_value);
 		if (i < expected_count) {
 			zassert_not_equal(INVALID_ADC_VALUE, sample_value,
 				"[%u] should be filled", i);


### PR DESCRIPTION
This commit changes the `tests/drivers/adc/adc_api` test to use the proper printf format specifier when printing the ADC samplings. This ensures that all values are printed on 16-bit. Without this specifier, negative values are sign-extended and printed on full integer size (e.g., 0x8000 -> "0xFFFF8000").

Example log before patch:
```
*** Booting Zephyr OS build v3.7.0-rc1-541-g92e00b76ead7 ***
Running TESTSUITE adc_basic
===================================================================
START - test_adc_asynchronous_call
Samples read: 0x0000 0x0000 0x0000 0x0000 0x0000 0xffff8000 
 PASS - test_adc_asynchronous_call in 0.006 seconds
===================================================================
START - test_adc_invalid_request
E: invalid resolution 0 (must be 16)
E: invalid resolution 0 (must be 16)
Samples read: 0x0000 0xffff8000 0xffff8000 0xffff8000 0xffff8000 0xffff8000 
 PASS - test_adc_invalid_request in 0.014 seconds
===================================================================
START - test_adc_repeated_samplings
repeated_samplings_callback: done 1
Samples read: 0x0000 0xffffecc0 0xffff8000 0xffff8000 0xffff8000 0xffff8000 
repeated_samplings_callback: done 2
Samples read: 0x0000 0xffffecc0 0x0000 0xffffec60 0xffff8000 0xffff8000 
repeated_samplings_callback: done 3
Samples read: 0x0000 0xffffecc0 0x0000 0xffffec30 0xffff8000 0xffff8000 
repeated_samplings_callback: done 4
Samples read: 0x0000 0xffffecc0 0x0000 0xffffec40 0xffff8000 0xffff8000 
repeated_samplings_callback: done 5
Samples read: 0x0000 0xffffecc0 0x0000 0xffffec40 0xffff8000 0xffff8000 
repeated_samplings_callback: done 6
Samples read: 0x0000 0xffffecc0 0x0000 0xffffec30 0xffff8000 0xffff8000 
repeated_samplings_callback: done 7
Samples read: 0x0000 0xffffecc0 0x0000 0xffffec40 0xffff8000 0xffff8000 
repeated_samplings_callback: done 8
Samples read: 0x0000 0xffffecc0 0x0000 0xffffec40 0xffff8000 0xffff8000 
repeated_samplings_callback: done 9
Samples read: 0x0000 0xffffecc0 0x0000 0xffffec30 0xffff8000 0xffff8000 
repeated_samplings_callback: done 10
Samples read: 0x0000 0xffffecc0 0x0000 0xffffec40 0xffff8000 0xffff8000 
 PASS - test_adc_repeated_samplings in 0.097 seconds
===================================================================
START - test_adc_sample_one_channel
Samples read: 0x0000 0xffff8000 0xffff8000 0xffff8000 0xffff8000 0xffff8000 
 PASS - test_adc_sample_one_channel in 0.007 seconds
===================================================================
START - test_adc_sample_two_channels
Samples read: 0x0000 0xffffecb0 0x6080 0xffff8000 0xffff8000 0xffff8000 
 PASS - test_adc_sample_two_channels in 0.007 seconds
===================================================================
START - test_adc_sample_with_interval
sample_with_interval_callback: sampling 0
sample_with_interval_callback: sampling 1
sample_with_interval_callback: sampling 2
sample_with_interval_callback: sampling 3
sample_with_interval_callback: sampling 4
Samples read: 0x0000 0x0000 0x0000 0x0000 0x0000 0xffff8000 
 PASS - test_adc_sample_with_interval in 0.410 seconds
===================================================================
TESTSUITE adc_basic succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [adc_basic]: pass = 6, fail = 0, skip = 0, total = 6 duration = 0.541 seconds
 - PASS - [adc_basic.test_adc_asynchronous_call] duration = 0.006 seconds
 - PASS - [adc_basic.test_adc_invalid_request] duration = 0.014 seconds
 - PASS - [adc_basic.test_adc_repeated_samplings] duration = 0.097 seconds
 - PASS - [adc_basic.test_adc_sample_one_channel] duration = 0.007 seconds
 - PASS - [adc_basic.test_adc_sample_two_channels] duration = 0.007 seconds
 - PASS - [adc_basic.test_adc_sample_with_interval] duration = 0.410 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```

Example log after patch:
```
*** Booting Zephyr OS build v3.7.0-rc1-541-g92e00b76ead7 ***
Running TESTSUITE adc_basic
===================================================================
START - test_adc_asynchronous_call
Samples read: 0x0000 0x0000 0x0000 0x0000 0x0000 0x8000 
 PASS - test_adc_asynchronous_call in 0.006 seconds
===================================================================
START - test_adc_invalid_request
E: invalid resolution 0 (must be 16)
E: invalid resolution 0 (must be 16)
Samples read: 0x0000 0x8000 0x8000 0x8000 0x8000 0x8000 
 PASS - test_adc_invalid_request in 0.012 seconds
===================================================================
START - test_adc_repeated_samplings
repeated_samplings_callback: done 1
Samples read: 0x0000 0xeca0 0x8000 0x8000 0x8000 0x8000 
repeated_samplings_callback: done 2
Samples read: 0x0000 0xeca0 0x0000 0xec60 0x8000 0x8000 
repeated_samplings_callback: done 3
Samples read: 0x0000 0xeca0 0x0000 0xec60 0x8000 0x8000 
repeated_samplings_callback: done 4
Samples read: 0x0000 0xeca0 0x0000 0xec40 0x8000 0x8000 
repeated_samplings_callback: done 5
Samples read: 0x0000 0xeca0 0x0000 0xec50 0x8000 0x8000 
repeated_samplings_callback: done 6
Samples read: 0x0000 0xeca0 0x0000 0xec50 0x8000 0x8000 
repeated_samplings_callback: done 7
Samples read: 0x0000 0xeca0 0x0000 0xec50 0x8000 0x8000 
repeated_samplings_callback: done 8
Samples read: 0x0000 0xeca0 0x0000 0xec60 0x8000 0x8000 
repeated_samplings_callback: done 9
Samples read: 0x0000 0xeca0 0x0000 0xec50 0x8000 0x8000 
repeated_samplings_callback: done 10
Samples read: 0x0000 0xeca0 0x0000 0xec60 0x8000 0x8000 
 PASS - test_adc_repeated_samplings in 0.083 seconds
===================================================================
START - test_adc_sample_one_channel
Samples read: 0x0000 0x8000 0x8000 0x8000 0x8000 0x8000 
 PASS - test_adc_sample_one_channel in 0.006 seconds
===================================================================
START - test_adc_sample_two_channels
Samples read: 0x0000 0xecc0 0x5ff0 0x8000 0x8000 0x8000 
 PASS - test_adc_sample_two_channels in 0.006 seconds
===================================================================
START - test_adc_sample_with_interval
sample_with_interval_callback: sampling 0
sample_with_interval_callback: sampling 1
sample_with_interval_callback: sampling 2
sample_with_interval_callback: sampling 3
sample_with_interval_callback: sampling 4
Samples read: 0x0000 0x0000 0x0000 0x0000 0x0000 0x8000 
 PASS - test_adc_sample_with_interval in 0.409 seconds
===================================================================
TESTSUITE adc_basic succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [adc_basic]: pass = 6, fail = 0, skip = 0, total = 6 duration = 0.522 seconds
 - PASS - [adc_basic.test_adc_asynchronous_call] duration = 0.006 seconds
 - PASS - [adc_basic.test_adc_invalid_request] duration = 0.012 seconds
 - PASS - [adc_basic.test_adc_repeated_samplings] duration = 0.083 seconds
 - PASS - [adc_basic.test_adc_sample_one_channel] duration = 0.006 seconds
 - PASS - [adc_basic.test_adc_sample_two_channels] duration = 0.006 seconds
 - PASS - [adc_basic.test_adc_sample_with_interval] duration = 0.409 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```