### PR TITLE
llext: disable verbose for SLID generation scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1898,7 +1898,6 @@ if (CONFIG_LLEXT AND CONFIG_LLEXT_EXPORT_BUILTINS_BY_SLID)
     ${ZEPHYR_BASE}/scripts/build/llext_prepare_exptab.py
     --elf-file ${PROJECT_BINARY_DIR}/${KERNEL_ELF_NAME}
     --slid-listing ${PROJECT_BINARY_DIR}/slid_listing.txt
-    -vvv
   )
 
 endif()

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -5444,7 +5444,6 @@ function(add_llext_target target_name)
       ${PYTHON_EXECUTABLE}
       ${ZEPHYR_BASE}/scripts/build/llext_inject_slids.py
       --elf-file ${llext_pkg_output}
-      -vvv
     )
   else()
     set(slid_inject_cmd ${CMAKE_COMMAND} -E true)


### PR DESCRIPTION
This commit removes the `-vvv` argument from the SLID generation scripts' command line when building Zephyr or an extension with Kconfig `CONFIG_LLEXT_EXPORT_BUILTINS_BY_SLID` enabled.
The argument was mistakenly kept when initial support for SLID linking was merged, as leftover from debugging the feature...

This removes a lot of noise in the build log (usually ~250 lines), and is fine to do because the printed information is also saved in build artifacts (as of now, in `slid_listing.txt`).