### PR TITLE
MAINTAINERS: STM32 Platforms: collaborators: remove ajarmouni-st

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3677,7 +3677,6 @@ STM32 Platforms:
   maintainers:
     - erwango
   collaborators:
-    - ajarmouni-st
     - FRASTM
     - gautierg-st
     - GeorgeCGV


### PR DESCRIPTION
Starting next week, I will no longer be active on this work account, & I will no longer be available to contribute to STM32 in Zephyr. I will be reachable on my personal account: @JarmouniA