### PR TITLE
Fix net mgmt blocks syswq and synchronous does not build without event info

### DIFF
--- a/subsys/net/ip/net_mgmt.c
+++ b/subsys/net/ip/net_mgmt.c
@@ -116,7 +116,7 @@ static void mgmt_event_work_handler(struct k_work *work)
 
 	ARG_UNUSED(work);
 
-	while (k_msgq_get(&event_msgq, &mgmt_event, K_FOREVER) == 0) {
+	while (k_msgq_get(&event_msgq, &mgmt_event, K_NO_WAIT) == 0) {
 		NET_DBG("Handling events, forwarding it relevantly");
 
 		mgmt_run_callbacks(&mgmt_event);

--- a/subsys/net/ip/net_mgmt.c
+++ b/subsys/net/ip/net_mgmt.c
@@ -131,9 +131,15 @@ static void mgmt_event_work_handler(struct k_work *work)
 static inline void mgmt_push_event(uint32_t event, struct net_if *iface,
 				   const void *info, size_t length)
 {
+#ifndef CONFIG_NET_MGMT_EVENT_INFO
+	ARG_UNUSED(info);
+	ARG_UNUSED(length);
+#endif /* CONFIG_NET_MGMT_EVENT_INFO */
 	const struct mgmt_event_entry mgmt_event = {
+#if defined(CONFIG_NET_MGMT_EVENT_INFO)
 		.info = info,
 		.info_length = length,
+#endif /* CONFIG_NET_MGMT_EVENT_INFO */
 		.event = event,
 		.iface = iface,
 	};


### PR DESCRIPTION
If the network events should be handled by the system work queue (`CONFIG_NET_MGMT_EVENT_SYSTEM_WORKQUEUE`), after the first event it blocked the system work queue forever. This caused problems as dsa_ksz8xxx uses the system work queue to poll for link status changes.
As `mgmt_push_event` always submits the work to the queue, the blocking in the work handler is not needed.

If the synchrounous callback (`CONFIG_NET_MGMT_EVENT_DIRECT`) was selected without event info (`CONFIG_NET_MGMT_EVENT_INFO`), it didn't build.