### PR TITLE
logging: Fixes in dependencies around dictionary frontend

### DIFF
--- a/include/zephyr/logging/log_core.h
+++ b/include/zephyr/logging/log_core.h
@@ -251,7 +251,7 @@ static inline char z_log_minimal_level_to_char(int level)
 	} \
 	\
 	bool is_user_context = k_is_user_context(); \
-	if (!IS_ENABLED(CONFIG_LOG_FRONTEND) && IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) && \
+	if (IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) && \
 	    !is_user_context && _level > Z_LOG_RUNTIME_FILTER((_dsource)->filters)) { \
 		break; \
 	} \
@@ -335,7 +335,7 @@ static inline char z_log_minimal_level_to_char(int level)
 					    (const char *)(_data), (_len));\
 		break; \
 	} \
-	if (!IS_ENABLED(CONFIG_LOG_FRONTEND) && IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) && \
+	if (IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) && \
 	    !is_user_context && (_level) > Z_LOG_RUNTIME_FILTER(filters)) { \
 		break; \
 	} \

--- a/subsys/logging/Kconfig.filtering
+++ b/subsys/logging/Kconfig.filtering
@@ -5,7 +5,7 @@ menu "Logging levels filtering"
 
 config LOG_RUNTIME_FILTERING
 	bool "Runtime filtering reconfiguration"
-	depends on !LOG_FRONTEND_ONLY && !LOG_MODE_MINIMAL
+	depends on !LOG_MODE_MINIMAL
 	help
 	  Allow runtime configuration of maximal, independent severity
 	  level for instance.

--- a/subsys/logging/Kconfig.frontends
+++ b/subsys/logging/Kconfig.frontends
@@ -5,7 +5,7 @@ menu "Frontends"
 
 config LOG_FRONTEND_DICT_UART
 	bool "UART dictionary frontend"
-	select LOG_DICTIONARY_DB
+	select LOG_DICTIONARY_SUPPORT
 	select MPSC_PBUF
 	depends on UART_ASYNC_API || UART_INTERRUPT_DRIVEN
 	imply LOG_FMT_SECTION

--- a/subsys/logging/log_msg.c
+++ b/subsys/logging/log_msg.c
@@ -57,8 +57,10 @@ static bool frontend_runtime_filtering(const void *source, uint32_t level)
 		return true;
 	}
 
-	/* If only frontend is used and log got here it means that it was accepted. */
-	if (IS_ENABLED(CONFIG_LOG_FRONTEND_ONLY)) {
+	/* If only frontend is used and log got here it means that it was accepted
+	 * unless userspace is enabled then runtime filtering is done here.
+	 */
+	if (!IS_ENABLED(CONFIG_USERSPACE) && IS_ENABLED(CONFIG_LOG_FRONTEND_ONLY)) {
 		return true;
 	}
 

--- a/tests/subsys/logging/log_api/src/main.c
+++ b/tests/subsys/logging/log_api/src/main.c
@@ -80,6 +80,11 @@ static void flush_log(void)
 	}
 }
 
+static bool frontend_only(void)
+{
+	return NO_BACKENDS || IS_ENABLED(CONFIG_LOG_FRONTEND_ONLY);
+}
+
 static void log_setup(bool backend2_enable)
 {
 	stamp = TIMESTAMP_INIT_VAL;
@@ -98,7 +103,7 @@ static void log_setup(bool backend2_enable)
 	test_source_id = log_source_id_get(STRINGIFY(test));
 	test2_source_id = log_source_id_get(STRINGIFY(test2));
 
-	if (NO_BACKENDS) {
+	if (frontend_only()) {
 		return;
 	}
 
@@ -220,11 +225,6 @@ ZTEST(test_log_api, test_log_various_messages)
 #undef TEST_MSG_0
 #undef TEST_MSG_0_PREFIX
 #undef TEST_MSG_1
-}
-
-static bool frontend_only(void)
-{
-	return NO_BACKENDS || IS_ENABLED(CONFIG_LOG_FRONTEND_ONLY);
 }
 
 /*


### PR DESCRIPTION
#67107 added support for runtime filtering in frontends but guard for that was not removed from `LOG_RUNTIME_FILTERING`.

UART dictionary frontend was not selecting `LOG_DICTIONARY_SUPPORT` (it was selecting `LOG_DICTIONARY_DB` instead) and because of that `LOG_FMT_SECTION_STRIP` could not be enabled.