### PR TITLE
soc: silabs: Include series-specific Kconfig

### DIFF
--- a/soc/silabs/Kconfig
+++ b/soc/silabs/Kconfig
@@ -2,9 +2,9 @@
 # Copyright (c) 2018 Gil Benkoe
 # SPDX-License-Identifier: Apache-2.0
 
-rsource "*/*/Kconfig"
-
 if SOC_FAMILY_SILABS_S0 || SOC_FAMILY_SILABS_S1 || SOC_FAMILY_SILABS_S2
+
+rsource "*/Kconfig"
 
 config SOC_GECKO_SDID
 	int

--- a/soc/silabs/silabs_s0/Kconfig
+++ b/soc/silabs/silabs_s0/Kconfig
@@ -5,3 +5,9 @@
 config SOC_FAMILY_SILABS_S0
 	select HAS_SEGGER_RTT if ZEPHYR_SEGGER_MODULE
 	select BUILD_OUTPUT_HEX
+
+if SOC_FAMILY_SILABS_S0
+
+rsource "*/Kconfig"
+
+endif # SOC_FAMILY_SILABS_S0

--- a/soc/silabs/silabs_s1/Kconfig
+++ b/soc/silabs/silabs_s1/Kconfig
@@ -5,3 +5,9 @@
 config SOC_FAMILY_SILABS_S1
 	select HAS_SEGGER_RTT if ZEPHYR_SEGGER_MODULE
 	select BUILD_OUTPUT_HEX
+
+if SOC_FAMILY_SILABS_S1
+
+rsource "*/Kconfig"
+
+endif # SOC_FAMILY_SILABS_S1

--- a/soc/silabs/silabs_s2/Kconfig
+++ b/soc/silabs/silabs_s2/Kconfig
@@ -5,3 +5,9 @@
 config SOC_FAMILY_SILABS_S2
 	select HAS_SEGGER_RTT if ZEPHYR_SEGGER_MODULE
 	select BUILD_OUTPUT_HEX
+
+if SOC_FAMILY_SILABS_S2
+
+rsource "*/Kconfig"
+
+endif # SOC_FAMILY_SILABS_S2


### PR DESCRIPTION
The series-specific Kconfig files were not included, leading to RTT not being considered available.

Make the inclusion of series and SoC family Kconfig files explicit.

Fixes #75511.