### PR TITLE
bluetooth: fix typo in (include/zephyr/bluetooth, subsys/bluetooth/)

### DIFF
--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -1091,7 +1091,7 @@ struct bt_bap_unicast_group_stream_pair_param {
 	/** Pointer to a receiving stream parameters. */
 	struct bt_bap_unicast_group_stream_param *rx_param;
 
-	/** Pointer to a transmiting stream parameters. */
+	/** Pointer to a transmitting stream parameters. */
 	struct bt_bap_unicast_group_stream_param *tx_param;
 };
 
@@ -1169,7 +1169,7 @@ int bt_bap_unicast_group_create(struct bt_bap_unicast_group_param *param,
  *
  * @param unicast_group  Pointer to the unicast group
  * @param params         Array of stream parameters with streams being added to the group.
- * @param num_param      Number of paramers in @p params.
+ * @param num_param      Number of parameters in @p params.
  *
  * @return 0 in case of success or negative value in case of error.
  */
@@ -1347,7 +1347,7 @@ struct bt_bap_unicast_client_cb {
 			   const struct bt_audio_codec_cap *codec_cap);
 
 	/**
-	 * @brief Remote Audio Stream Endoint (ASE) discovered
+	 * @brief Remote Audio Stream Endpoint (ASE) discovered
 	 *
 	 * Called when an ASE has been discovered as part of the discovery procedure.
 	 *
@@ -2039,7 +2039,7 @@ struct bt_bap_scan_delegator_mod_src_param {
  * to modify and even remove it.
  *
  * If @kconfig{CONFIG_BT_BAP_BROADCAST_SINK} is enabled, any Broadcast Sink
- * sources are autonomously modifed.
+ * sources are autonomously modified.
  *
  * @param param The parameters for adding the new source
  *

--- a/include/zephyr/bluetooth/audio/csip.h
+++ b/include/zephyr/bluetooth/audio/csip.h
@@ -448,7 +448,7 @@ typedef bool (*bt_csip_set_coordinator_ordered_access_t)(
  * (if present). Once this procedure is finished or an error occurs,
  * @ref bt_csip_set_coordinator_cb.ordered_access will be called.
  *
- * This procedure only works if all the members have the lock characterstic,
+ * This procedure only works if all the members have the lock characteristic,
  * and all either has rank = 0 or unique ranks.
  *
  * If any of the members are in the locked state, the procedure will be

--- a/include/zephyr/bluetooth/classic/a2dp.h
+++ b/include/zephyr/bluetooth/classic/a2dp.h
@@ -351,7 +351,7 @@ enum {
  *  @param a2dp a2dp connection object identifying a2dp connection to queried remote.
  *  @param info Object pointing to the information of the callbacked endpoint.
  *  @param ep If the user want to use this found endpoint, user can set value to it
- *  to get the ednpoint that can be used futher in other A2DP APIs. It is NULL if info
+ *  to get the endpoint that can be used further in other A2DP APIs. It is NULL if info
  *  is NULL (no more endpoint is found).
  *
  *  @return BT_A2DP_DISCOVER_EP_STOP in case of no more need to continue discovery
@@ -370,7 +370,7 @@ struct bt_a2dp_discover_param {
 	 *  it save endpoint info internally.
 	 */
 	struct bt_avdtp_sep_info *seps_info;
-	/** The max count of seps (strem endpoint) that can be got in this call route */
+	/** The max count of seps (stream endpoint) that can be got in this call route */
 	uint8_t sep_count;
 };
 
@@ -418,7 +418,7 @@ struct bt_a2dp_cb {
 	 *  Called when the codec configure operation is completed.
 	 *
 	 *  @param[in] stream    Pointer to stream object.
-	 *  @param[in] rsp_err_code the remote responsed error code
+	 *  @param[in] rsp_err_code the remote responded error code
 	 *                          bt_a2dp_err_code or bt_avdtp_err_code
 	 */
 	void (*config_rsp)(struct bt_a2dp_stream *stream, uint8_t rsp_err_code);
@@ -441,7 +441,7 @@ struct bt_a2dp_cb {
 	 *  (open cmd and create the stream l2cap channel).
 	 *
 	 *  @param[in] stream    Pointer to stream object.
-	 *  @param[in] rsp_err_code the remote responsed error code
+	 *  @param[in] rsp_err_code the remote responded error code
 	 *                          bt_a2dp_err_code or bt_avdtp_err_code
 	 */
 	void (*establish_rsp)(struct bt_a2dp_stream *stream, uint8_t rsp_err_code);
@@ -464,7 +464,7 @@ struct bt_a2dp_cb {
 	 *  (release cmd and release the l2cap channel)
 	 *
 	 *  @param[in] stream    Pointer to stream object.
-	 *  @param[in] rsp_err_code the remote responsed error code
+	 *  @param[in] rsp_err_code the remote responded error code
 	 *                          bt_a2dp_err_code or bt_avdtp_err_code
 	 */
 	void (*release_rsp)(struct bt_a2dp_stream *stream, uint8_t rsp_err_code);
@@ -486,7 +486,7 @@ struct bt_a2dp_cb {
 	 *  Called when the start operation is completed.
 	 *
 	 *  @param[in] stream    Pointer to stream object.
-	 *  @param[in] rsp_err_code the remote responsed error code
+	 *  @param[in] rsp_err_code the remote responded error code
 	 *                          bt_a2dp_err_code or bt_avdtp_err_code
 	 */
 	void (*start_rsp)(struct bt_a2dp_stream *stream, uint8_t rsp_err_code);
@@ -508,7 +508,7 @@ struct bt_a2dp_cb {
 	 *  Called when the suspend operation is completed.
 	 *
 	 *  @param[in] stream    Pointer to stream object.
-	 *  @param[in] rsp_err_code the remote responsed error code
+	 *  @param[in] rsp_err_code the remote responded error code
 	 *                          bt_a2dp_err_code or bt_avdtp_err_code
 	 */
 	void (*suspend_rsp)(struct bt_a2dp_stream *stream, uint8_t rsp_err_code);
@@ -530,7 +530,7 @@ struct bt_a2dp_cb {
 	 *  Called when the reconfig operation is completed.
 	 *
 	 *  @param[in] stream    Pointer to stream object.
-	 *  @param[in] rsp_err_code the remote responsed error code
+	 *  @param[in] rsp_err_code the remote responded error code
 	 *                          bt_a2dp_err_code or bt_avdtp_err_code
 	 */
 	void (*reconfig_rsp)(struct bt_a2dp_stream *stream, uint8_t rsp_err_code);
@@ -662,7 +662,7 @@ struct bt_a2dp_stream_ops {
 	/** @brief the media streaming data, only for sink
 	 *
 	 *  @param buf the data buf
-	 *  @param seq_num the seqence number
+	 *  @param seq_num the sequence number
 	 *  @param ts the time stamp
 	 */
 	void (*recv)(struct bt_a2dp_stream *stream,

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -234,7 +234,7 @@ void bt_conn_unref(struct bt_conn *conn);
 
 /** @brief Iterate through all bt_conn objects.
  *
- * Iterates trough all bt_conn objects that are alive in the Host allocator.
+ * Iterates through all bt_conn objects that are alive in the Host allocator.
  *
  * To find established connections, combine this with @ref bt_conn_get_info.
  * Check that @ref bt_conn_info.state is @ref BT_CONN_STATE_CONNECTED.

--- a/include/zephyr/bluetooth/mesh/cfg_cli.h
+++ b/include/zephyr/bluetooth/mesh/cfg_cli.h
@@ -1696,7 +1696,7 @@ struct bt_mesh_comp_p1_elem {
 	size_t nsig;
 	/** The number of vendor models in this element */
 	size_t nvnd;
-	/** Buffer containig SIG and Vendor Model Items */
+	/** Buffer containing SIG and Vendor Model Items */
 	struct net_buf_simple *_buf;
 };
 

--- a/include/zephyr/bluetooth/mesh/dfd_srv.h
+++ b/include/zephyr/bluetooth/mesh/dfd_srv.h
@@ -254,7 +254,7 @@ struct bt_mesh_dfd_srv {
  *  callback has completed or failed. The @p status param should be set to one of the following
  *  values:
  *
- *  * @c BT_MESH_DFD_SUCCESS if the check was succesfull and a new firmware ID was found.
+ *  * @c BT_MESH_DFD_SUCCESS if the check was successful and a new firmware ID was found.
  *  * @c BT_MESH_DFD_ERR_URI_MALFORMED if the URI is not formatted correctly.
  *  * @c BT_MESH_DFD_ERR_URI_NOT_SUPPORTED if the URI scheme is not supported by the node.
  *  * @c BT_MESH_DFD_ERR_URI_UNREACHABLE if the URI can't be reached.
@@ -279,7 +279,7 @@ int bt_mesh_dfd_srv_oob_check_complete(struct bt_mesh_dfd_srv *srv,
 
 /** @brief Call when an OOB store has completed or failed
  *
- *  This should be called by the application after an OOB store started after a succesfull call to
+ *  This should be called by the application after an OOB store started after a successful call to
  *  @c bt_mesh_dfd_srv_oob_check_complete has completed successfully or failed.
  *
  *  @param srv          Firmware Distribution Server model instance.

--- a/include/zephyr/bluetooth/mesh/dfu_metadata.h
+++ b/include/zephyr/bluetooth/mesh/dfu_metadata.h
@@ -75,7 +75,7 @@ struct bt_mesh_dfu_metadata {
 int bt_mesh_dfu_metadata_decode(struct net_buf_simple *buf,
 				struct bt_mesh_dfu_metadata *metadata);
 
-/** @brief Encode a firmare metadata into a network buffer.
+/** @brief Encode a firmware metadata into a network buffer.
  *
  *  @param metadata Firmware metadata to be encoded.
  *  @param buf Buffer to store the encoded metadata.

--- a/include/zephyr/bluetooth/mesh/op_agg_cli.h
+++ b/include/zephyr/bluetooth/mesh/op_agg_cli.h
@@ -60,7 +60,7 @@ bool bt_mesh_op_agg_cli_seq_is_started(void);
 
 /** @brief Get Opcodes Aggregator context tailroom.
  *
- *  @return Remaning tailroom of Opcodes Aggregator SDU.
+ *  @return Remaining tailroom of Opcodes Aggregator SDU.
  */
 size_t bt_mesh_op_agg_cli_seq_tailroom(void);
 

--- a/include/zephyr/bluetooth/uuid.h
+++ b/include/zephyr/bluetooth/uuid.h
@@ -3893,11 +3893,11 @@ struct bt_uuid_128 {
 #define BT_UUID_GATT_PHY_ASDESC \
 	BT_UUID_DECLARE_16(BT_UUID_GATT_PHY_ASDESC_VAL)
 /**
- *  @brief GATT Characteristic Preffered Units UUID Value
+ *  @brief GATT Characteristic Preferred Units UUID Value
  */
 #define BT_UUID_GATT_PREF_U_VAL 0x2b46
 /**
- *  @brief GATT Characteristic Preffered Units
+ *  @brief GATT Characteristic Preferred Units
  */
 #define BT_UUID_GATT_PREF_U \
 	BT_UUID_DECLARE_16(BT_UUID_GATT_PREF_U_VAL)

--- a/subsys/bluetooth/audio/shell/audio.h
+++ b/subsys/bluetooth/audio/shell/audio.h
@@ -299,7 +299,7 @@ static inline char *context_bit_to_str(enum bt_audio_context context)
 	case BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED:
 		return "Unspecified";
 	case BT_AUDIO_CONTEXT_TYPE_CONVERSATIONAL:
-		return "Converstation";
+		return "Conversational";
 	case BT_AUDIO_CONTEXT_TYPE_MEDIA:
 		return "Media";
 	case BT_AUDIO_CONTEXT_TYPE_GAME:

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -3954,7 +3954,7 @@ static int cmd_print_ase_info(const struct shell *sh, size_t argc, char *argv[])
 }
 #endif /* CONFIG_BT_BAP_UNICAST_SERVER */
 
-/* 31 is a unit separater - without t the tab is seemingly ignored*/
+/* 31 is a unit separator - without t the tab is seemingly ignored*/
 #define HELP_SEP "\n\31\t"
 
 #define HELP_CFG_DATA                                                                              \

--- a/subsys/bluetooth/host/classic/Kconfig
+++ b/subsys/bluetooth/host/classic/Kconfig
@@ -1,4 +1,4 @@
-# Bluetooth Calssic configuration options
+# Bluetooth Classic configuration options
 
 # Copyright (c) 2016-2020 Nordic Semiconductor ASA
 # Copyright (c) 2015-2016 Intel Corporation
@@ -56,7 +56,7 @@ config BT_RFCOMM_DLC_STACK_SIZE
 	default 256
 	help
 	  Stack size of DLC for RFCOMM. This is the context from which
-	  all datas of upper layer are sent and disconnect
+	  all data of upper layer are sent and disconnect
 	  callback to the upper layer. The default value is sufficient
 	  for basic operation, but if the application needs to do
 	  advanced things in its callbacks that require extra stack

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -3228,7 +3228,7 @@ static uint8_t smp_pairing_rsp(struct bt_smp *smp, struct net_buf *buf)
 		return err;
 	}
 
-	/* the OR operation evaluated by "if" statement bellow seems redundant
+	/* the OR operation evaluated by "if" statement below seems redundant
 	 * when CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY is enabled, because in
 	 * that case the SMP_FLAG_SC will always be set to false. But it's
 	 * needed in order to inform the compiler that the inside of the "if"

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -2902,7 +2902,7 @@ static int cmd_read_local_tx_power(const struct shell *sh, size_t argc, char *ar
 		}
 		err = bt_conn_le_get_tx_power_level(default_conn, &tx_power_level);
 		if (err) {
-			shell_print(sh, "Command returned error error %d", err);
+			shell_print(sh, "Command returned error %d", err);
 			return err;
 		}
 		if (tx_power_level.current_level == unachievable_current_level) {
@@ -4493,7 +4493,7 @@ static int cmd_encrypted_ad_add_ad(const struct shell *sh, size_t argc, char *ar
 	 */
 	if (len != ad_len + 2) {
 		shell_error(sh,
-			    "Failed to add data. Data need to be formated as specified in the "
+			    "Failed to add data. Data need to be formatted as specified in the "
 			    "Core Spec. Only one non-encrypted AD payload can be added at a time.");
 		return -ENOEXEC;
 	}

--- a/subsys/bluetooth/shell/bt.h
+++ b/subsys/bluetooth/shell/bt.h
@@ -37,7 +37,7 @@ extern struct bt_le_per_adv_sync *per_adv_syncs[CONFIG_BT_PER_ADV_SYNC_MAX];
 void conn_addr_str(struct bt_conn *conn, char *addr, size_t len);
 
 /**
- * @brief Compares two strings without case sensitivy
+ * @brief Compares two strings without case sensitivity
  *
  * @param substr The substring
  * @param str The string to find the substring in


### PR DESCRIPTION
Utilize a code spell-checking tool to scan for and correct spelling errors in all files within 
the `include/zephyr/bluetooth` and `subsys/bluetooth`