### PR TITLE
fs: fatfs: extend fatfs module cfg to support GPT and multi partitions

### DIFF
--- a/modules/fatfs/zephyr_fatfs_config.h
+++ b/modules/fatfs/zephyr_fatfs_config.h
@@ -71,6 +71,11 @@
 #define FF_FS_TIMEOUT		K_FOREVER
 #endif /* defined(CONFIG_FS_FATFS_REENTRANT) */
 
+#if defined(CONFIG_FS_FATFS_LBA64)
+#undef FF_LBA64
+#define FF_LBA64		CONFIG_FS_FATFS_LBA64
+#endif /* defined(CONFIG_FS_FATFS_LBA64) */
+
 /*
  * These options are override from default values, but have no Kconfig
  * options.

--- a/modules/fatfs/zephyr_fatfs_config.h
+++ b/modules/fatfs/zephyr_fatfs_config.h
@@ -76,6 +76,11 @@
 #define FF_LBA64		CONFIG_FS_FATFS_LBA64
 #endif /* defined(CONFIG_FS_FATFS_LBA64) */
 
+#if defined(CONFIG_FS_FATFS_MULTI_PARTITION)
+#undef FF_MULTI_PARTITION
+#define FF_MULTI_PARTITION	CONFIG_FS_FATFS_MULTI_PARTITION
+#endif /* defined(CONFIG_FS_FATFS_MULTI_PARTITION) */
+
 /*
  * These options are override from default values, but have no Kconfig
  * options.

--- a/subsys/fs/Kconfig.fatfs
+++ b/subsys/fs/Kconfig.fatfs
@@ -237,6 +237,21 @@ config FS_FATFS_LBA64
 	  This option enables support for 64-bit LBA, which also
 	  enables GPT support.
 
+config FS_FATFS_MULTI_PARTITION
+	bool "Support for multiple volumes on the physical drive"
+	help
+	  When this function is enabled, each logical drive number can
+	  be bound to arbitrary physical drive and partition listed
+	  in the VolToPart[] of the fatfs module. The VolToPart[] is expected to be
+	  provided by Zephyr application.
+	  The mount points have to be numbered in this case.
+	  For example, 2 FAT partition on SD disk (3) in terms of Zephyr:
+	    {3, 1} - mount point "/0:"
+	    {3, 2} - mount point "/1:"
+	  When disabled (default), each logical drive number is bound to the same
+	  physical drive number and only an FAT volume found on the physical drive
+	  will be mounted.
+
 endmenu
 
 endif # FAT_FILESYSTEM_ELM

--- a/subsys/fs/Kconfig.fatfs
+++ b/subsys/fs/Kconfig.fatfs
@@ -230,6 +230,13 @@ config FS_FATFS_REENTRANT
 	  access for each volume. Will create a zephyr mutex object for each
 	  FatFs volume and a FatFs system mutex.
 
+config FS_FATFS_LBA64
+	bool "Support for 64-bit LBA"
+	depends on FS_FATFS_EXFAT
+	help
+	  This option enables support for 64-bit LBA, which also
+	  enables GPT support.
+
 endmenu
 
 endif # FAT_FILESYSTEM_ELM


### PR DESCRIPTION
This PR add two additional Kconfig options for **fatfs** module:
- CONFIG_FS_FATFS_LBA64 : enables support for 64-bit LBA, which also allows to enable  GUID Partition Table (GPT) support
- CONFIG_FS_MULTI_PARTITION : enables support for multiple volumes on the physical drive

This is required to support following use-case:
- platform is Raspberry Pi 5
- SD-card is formatted with GUID Partition Table (GPT) partition table
- FAT32 partition 0 is `bootfs` and should not be used by Zephyr app
- FAT32 partition 1 is allocated for Zephyr app

The sample  Zephyr app can be found in [1].

[1] https://github.com/xen-troops/zephyr-dom0-xt/tree/rpi5_dom0_dev