### PR TITLE
net: sockets: services: Don't modify pollfd array from other threads

### DIFF
--- a/subsys/net/lib/sockets/sockets_service.c
+++ b/subsys/net/lib/sockets/sockets_service.c
@@ -45,7 +45,6 @@ void net_socket_service_foreach(net_socket_service_cb_t cb, void *user_data)
 static void cleanup_svc_events(const struct net_socket_service_desc *svc)
 {
 	for (int i = 0; i < svc->pev_len; i++) {
-		ctx.events[get_idx(svc) + i].fd = -1;
 		svc->pev[i].event.fd = -1;
 		svc->pev[i].event.events = 0;
 	}
@@ -86,10 +85,6 @@ int z_impl_net_socket_service_register(const struct net_socket_service_desc *svc
 		for (i = 0; i < len; i++) {
 			svc->pev[i].event = fds[i];
 			svc->pev[i].user_data = user_data;
-		}
-
-		for (i = 0; i < svc->pev_len; i++) {
-			ctx.events[get_idx(svc) + i] = svc->pev[i].event;
 		}
 	}
 


### PR DESCRIPTION
pollfd array used with zsock_poll() should not be modified while inside zsock_poll() function as this could lead to unexpected results. For instance, k_poll already monitoring some kernel primitive could report an event, but it will not be processed if the monitored socket file descriptor in the pollfd array was set to -1. In result, zsock_poll() may unexpectedly quit prematurely, returning 0 events, even if it was requested to wait infinitely.

The pollfd arrays used by zsock_poll() (ctx.events) is reinitialized when the service thread is restarted so modifying it directly when registering/unregistering service is not really needed. It's enough if those functions notify the eventfd socket used to restart the services thread.

Fixes #75474