### PR TITLE
include: drivers: fix typo

### DIFF
--- a/include/zephyr/drivers/adc/adc_npcx_threshold.h
+++ b/include/zephyr/drivers/adc/adc_npcx_threshold.h
@@ -19,7 +19,7 @@ enum adc_npcx_threshold_param_type {
 	ADC_NPCX_THRESHOLD_PARAM_CHNSEL,
 	/* Sets relation between measured value and assetion threshold value.*/
 	ADC_NPCX_THRESHOLD_PARAM_L_H,
-	/* Sets the threshol value to which measured data is compared. */
+	/* Sets the threshold value to which measured data is compared. */
 	ADC_NPCX_THRESHOLD_PARAM_THVAL,
 	/* Sets worker queue thread to be notified */
 	ADC_NPCX_THRESHOLD_PARAM_WORK,
@@ -82,7 +82,7 @@ int adc_npcx_threshold_ctrl_set_param(const struct device *dev,
  *
  * @returns 0 on success, negative error code otherwise.
  *            all parameters must be configure prior enabling threshold
- *            interruption, otherwhise error will be returned.
+ *            interruption, otherwise error will be returned.
  */
 int adc_npcx_threshold_ctrl_enable(const struct device *dev, uint8_t th_sel,
 				   const bool enable);

--- a/include/zephyr/drivers/bluetooth.h
+++ b/include/zephyr/drivers/bluetooth.h
@@ -209,7 +209,7 @@ int bt_hci_transport_setup(const struct device *dev);
  *
  * @param dev The device structure for the bus connecting to the IC
  *
- * @return 0 on success, negative error value on faulure
+ * @return 0 on success, negative error value on failure
  */
 int bt_hci_transport_teardown(const struct device *dev);
 

--- a/include/zephyr/drivers/bluetooth/hci_driver.h
+++ b/include/zephyr/drivers/bluetooth/hci_driver.h
@@ -186,7 +186,7 @@ int bt_hci_transport_setup(const struct device *dev);
  *
  * @param dev The device structure for the bus connecting to the IC
  *
- * @return 0 on success, negative error value on faulure
+ * @return 0 on success, negative error value on failure
  */
 int bt_hci_transport_teardown(const struct device *dev);
 

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -598,7 +598,7 @@ struct can_device_state {
  * transmit either a dominant or a recessive bit.
  *
  * @note This error counter should only be incremented if the CAN controller is unable to
- * distinquish between failure to transmit a dominant versus failure to transmit a recessive bit. If
+ * distinguish between failure to transmit a dominant versus failure to transmit a recessive bit. If
  * the CAN controller supports distinguishing between the two, the `bit0` or `bit1` error counter
  * shall be incremented instead.
  *
@@ -703,7 +703,7 @@ struct can_device_state {
 /**
  * @brief Zero all statistics for a CAN device
  *
- * The driver is reponsible for resetting the statistics before starting the CAN
+ * The driver is responsible for resetting the statistics before starting the CAN
  * controller.
  *
  * @param dev_ Pointer to the device structure for the driver instance.
@@ -1170,7 +1170,7 @@ static const struct device *z_impl_can_get_transceiver(const struct device *dev)
  * @brief Start the CAN controller
  *
  * Bring the CAN controller out of `CAN_STATE_STOPPED`. This will reset the RX/TX error counters,
- * enable the CAN controller to participate in CAN communication, and enable the CAN tranceiver, if
+ * enable the CAN controller to participate in CAN communication, and enable the CAN transceiver, if
  * supported.
  *
  * Starting the CAN controller resets all the CAN controller statistics.

--- a/include/zephyr/drivers/clock_control/clock_control_numaker.h
+++ b/include/zephyr/drivers/clock_control/clock_control_numaker.h
@@ -22,7 +22,7 @@
 #define NUMAKER_SCC_SUBSYS_ID_PCC 1
 
 struct numaker_scc_subsys {
-	uint32_t subsys_id; /* SCC sybsystem ID */
+	uint32_t subsys_id; /* SCC subsystem ID */
 
 	/* Peripheral clock control configuration structure
 	 * clk_modidx is same as u32ModuleIdx in BSP CLK_SetModuleClock().

--- a/include/zephyr/drivers/dai.h
+++ b/include/zephyr/drivers/dai.h
@@ -268,7 +268,7 @@ struct dai_config {
 	size_t block_size;
 	/** DAI specific link configuration. */
 	uint16_t link_config;
-	/**< tdm slot goup number*/
+	/**< tdm slot group number*/
 	uint32_t  tdm_slot_group;
 };
 

--- a/include/zephyr/drivers/dma.h
+++ b/include/zephyr/drivers/dma.h
@@ -275,7 +275,7 @@ struct dma_config {
 struct dma_status {
 	/** Is the current DMA transfer busy or idle */
 	bool busy;
-	/** Direction fo the transfer */
+	/** Direction for the transfer */
 	enum dma_channel_direction dir;
 	/** Pending length to be transferred in bytes, HW specific */
 	uint32_t pending_length;

--- a/include/zephyr/drivers/dma/dma_stm32.h
+++ b/include/zephyr/drivers/dma/dma_stm32.h
@@ -23,7 +23,7 @@
 /* so decrease to set range from 0 from now on */
 #define STM32_DMA_STREAM_OFFSET 1
 #elif defined(CONFIG_DMA_STM32_V1) && defined(CONFIG_DMAMUX_STM32)
-/* typically on the stm32H7 serie, DMA V1 with mux */
+/* typically on the stm32H7 series, DMA V1 with mux */
 #define STM32_DMA_STREAM_OFFSET 1
 #else
 /* from DTS the dma stream id is in range 0..N-1 */

--- a/include/zephyr/drivers/emul.h
+++ b/include/zephyr/drivers/emul.h
@@ -182,7 +182,7 @@ struct emul {
 /**
  * @brief Utility macro to obtain an optional reference to an emulator
  *
- * If the node identifier referes to a node with status `okay`, this returns `EMUL_DT_GET(node_id)`.
+ * If the node identifier refers to a node with status `okay`, this returns `EMUL_DT_GET(node_id)`.
  * Otherwise, it returns `NULL`.
  *
  * @param node_id A devicetree node identifier

--- a/include/zephyr/drivers/emul_sensor.h
+++ b/include/zephyr/drivers/emul_sensor.h
@@ -32,7 +32,7 @@ __subsystem struct emul_sensor_driver_api {
 	/** Retrieve a range of sensor values to use with test. */
 	int (*get_sample_range)(const struct emul *target, struct sensor_chan_spec ch, q31_t *lower,
 				q31_t *upper, q31_t *epsilon, int8_t *shift);
-	/** Set the attribute value(s) of a given chanel. */
+	/** Set the attribute value(s) of a given channel. */
 	int (*set_attribute)(const struct emul *target, struct sensor_chan_spec ch,
 			     enum sensor_attribute attribute, const void *value);
 	/** Get metadata about an attribute. */
@@ -156,7 +156,7 @@ static inline int emul_sensor_backend_set_attribute(const struct emul *target,
  *   '-ENOTSUP'
  * @param[out] min The minimum value the attribute can be set to
  * @param[out] max The maximum value the attribute can be set to
- * @param[out] increment The value that the attribute increses by for every LSB
+ * @param[out] increment The value that the attribute increases by for every LSB
  * @param[out] shift The shift for \p min, \p max, and \p increment
  * @return 0 on SUCCESS
  * @return < 0 on error

--- a/include/zephyr/drivers/fuel_gauge.h
+++ b/include/zephyr/drivers/fuel_gauge.h
@@ -274,7 +274,7 @@ static inline int z_impl_fuel_gauge_get_prop(const struct device *dev, fuel_gaug
 }
 
 /**
- * @brief Fetch multiple battery fuel-gauge properies. The default implementation is the same as
+ * @brief Fetch multiple battery fuel-gauge properties. The default implementation is the same as
  * calling fuel_gauge_get_prop() multiple times. A driver may implement the `get_properties` field
  * of the fuel gauge driver APIs struct to override this implementation.
  *

--- a/include/zephyr/drivers/gnss.h
+++ b/include/zephyr/drivers/gnss.h
@@ -123,9 +123,9 @@ typedef int (*gnss_get_supported_systems_t)(const struct device *dev, gnss_syste
 
 /** GNSS fix status */
 enum gnss_fix_status {
-	/** No GNSS fix aqcuired */
+	/** No GNSS fix acquired */
 	GNSS_FIX_STATUS_NO_FIX = 0,
-	/** GNSS fix aqcuired */
+	/** GNSS fix acquired */
 	GNSS_FIX_STATUS_GNSS_FIX = 1,
 	/** Differential GNSS fix acquired */
 	GNSS_FIX_STATUS_DGNSS_FIX = 2,

--- a/include/zephyr/drivers/gpio.h
+++ b/include/zephyr/drivers/gpio.h
@@ -785,7 +785,7 @@ enum gpio_int_trig {
 	GPIO_INT_TRIG_HIGH = GPIO_INT_HIGH_1,
 	/* Trigger detection on pin rising or falling edge. */
 	GPIO_INT_TRIG_BOTH = GPIO_INT_LOW_0 | GPIO_INT_HIGH_1,
-	/* Trigger a system wakup. */
+	/* Trigger a system wakeup. */
 	GPIO_INT_TRIG_WAKE = GPIO_INT_WAKEUP,
 };
 

--- a/include/zephyr/drivers/i2c/rtio.h
+++ b/include/zephyr/drivers/i2c/rtio.h
@@ -34,7 +34,7 @@ struct i2c_rtio {
  *
  * @param _name Symbolic name of the context
  * @param _sq_sz Submission queue entry pool size
- * @param _cq_sz Completeion queue entry pool size
+ * @param _cq_sz Completion queue entry pool size
  */
 #define I2C_RTIO_DEFINE(_name, _sq_sz, _cq_sz)		\
 	RTIO_DEFINE(CONCAT(_name, _r), _sq_sz, _cq_sz);	\

--- a/include/zephyr/drivers/i2c/target/eeprom.h
+++ b/include/zephyr/drivers/i2c/target/eeprom.h
@@ -48,10 +48,10 @@ int eeprom_target_read(const struct device *dev, uint8_t *eeprom_data,
 		      unsigned int offset);
 
 /**
- * @brief Change the address of eeprom taget at runtime
+ * @brief Change the address of eeprom target at runtime
  *
  * @param dev Pointer to the device structure for the driver instance.
- * @param addr New address to assign to the eeprom target devide
+ * @param addr New address to assign to the eeprom target device
  *
  * @retval 0 Is successful
  * @retval -EINVAL If parameters are invalid

--- a/include/zephyr/drivers/i3c/ccc.h
+++ b/include/zephyr/drivers/i3c/ccc.h
@@ -713,7 +713,7 @@ union i3c_ccc_getmxds {
 
 		/**
 		 * Defining Byte 0x91: CRHDLY
-		 * - Bit[2]: Set Bus Actibity State
+		 * - Bit[2]: Set Bus Activity State
 		 * - Bit[1:0]: Controller Handoff Activity State
 		 */
 		uint8_t crhdly1;

--- a/include/zephyr/drivers/mfd/axp192.h
+++ b/include/zephyr/drivers/mfd/axp192.h
@@ -92,7 +92,7 @@ int mfd_axp192_gpio_func_get(const struct device *dev, uint8_t gpio, enum axp192
 
 /**
  * @brief Enable pull-down on specified GPIO pin. AXP192 only supports
- * pull-down on GPIO3..5. Pull-ups are not supprted.
+ * pull-down on GPIO3..5. Pull-ups are not supported.
  *
  * @param dev axp192 mfd device
  * @param gpio GPIO to control pull-downs

--- a/include/zephyr/drivers/misc/timeaware_gpio/timeaware_gpio.h
+++ b/include/zephyr/drivers/misc/timeaware_gpio/timeaware_gpio.h
@@ -86,7 +86,7 @@ static inline int z_impl_tgpio_port_get_time(const struct device *dev, uint64_t 
  * @brief Get current running rate
  *
  * @param dev TGPIO device
- * @param cycles pointer to store current running requency
+ * @param cycles pointer to store current running frequency
  *
  * @return 0 if successful, negative errno code on failure.
  */

--- a/include/zephyr/drivers/modem/hl7800.h
+++ b/include/zephyr/drivers/modem/hl7800.h
@@ -388,7 +388,7 @@ int32_t mdm_hl7800_get_local_time(struct tm *tm, int32_t *offset);
 #ifdef CONFIG_MODEM_HL7800_FW_UPDATE
 /**
  * @brief Update the HL7800 via XMODEM protocol.  During the firmware update
- * no other modem fuctions will be available.
+ * no other modem functions will be available.
  *
  * @param file_path Absolute path of the update file
  *
@@ -522,7 +522,7 @@ void mdm_hl7800_register_cts_callback(void (*func)(int state));
  * NOTE: This will cause the modem to reboot. This call returns before the reboot.
  *
  * @param bands Band bitmap in hexadecimal format without the 0x prefix.
- * Leading 0's for the value can be ommited.
+ * Leading 0's for the value can be omitted.
  *
  * @return int32_t negative errno, 0 on success
  */

--- a/include/zephyr/drivers/mspi.h
+++ b/include/zephyr/drivers/mspi.h
@@ -223,7 +223,7 @@ struct mspi_dev_id {
 struct mspi_cfg {
 	/** @brief mspi channel number */
 	uint8_t                 channel_num;
-	/** @brief Configure operaton mode */
+	/** @brief Configure operation mode */
 	enum mspi_op_mode       op_mode;
 	/** @brief Configure duplex mode */
 	enum mspi_duplex        duplex;
@@ -724,7 +724,7 @@ static inline int z_impl_mspi_scramble_config(const struct device *controller,
 }
 
 /**
- * @brief Configure a MSPI timing settigs.
+ * @brief Configure a MSPI timing settings.
  *
  * This routine provides a generic interface to configure MSPI controller
  * timing if necessary.
@@ -767,7 +767,7 @@ static inline int z_impl_mspi_timing_config(const struct device *controller,
  * @brief Register the mspi callback functions.
  *
  * This routines provides a generic interface to register mspi callback functions.
- * In generall it should be called before mspi_transceive.
+ * In generally it should be called before mspi_transceive.
  *
  * @param controller Pointer to the device structure for the driver instance.
  * @param dev_id Pointer to the device ID structure from a device.

--- a/include/zephyr/drivers/pcie/endpoint/pcie_ep.h
+++ b/include/zephyr/drivers/pcie/endpoint/pcie_ep.h
@@ -133,7 +133,7 @@ static inline void pcie_ep_conf_write(const struct device *dev,
  *		      lowmem outbound region
  *
  * @return Mapped size : If mapped size is less than requested size,
- *	   then requestor has to call the same API again to map
+ *	   then requester has to call the same API again to map
  *	   the unmapped host buffer after data transfer is done with
  *	   mapped size. This situation may arise because of the
  *	   mapping alignment requirements.

--- a/include/zephyr/drivers/pcie/pcie.h
+++ b/include/zephyr/drivers/pcie/pcie.h
@@ -214,7 +214,7 @@ struct pcie_scan_opt {
 
 /** Scan for PCIe devices.
  *
- * Scan the PCI bus (or busses) for available endpoints.
+ * Scan the PCI bus (or buses) for available endpoints.
  *
  * @param opt Options determining how to perform the scan.
  * @return 0 on success, negative POSIX error number on failure.

--- a/include/zephyr/drivers/usb/usb_bc12.h
+++ b/include/zephyr/drivers/usb/usb_bc12.h
@@ -39,7 +39,7 @@ extern "C" {
  * This is returned by the driver when either BC1.2 detection fails, or the
  * attached partner is a SDP (standard downstream port).
  *
- * The application may increase the current draw after determing the USB device
+ * The application may increase the current draw after determining the USB device
  * state of suspended/unconfigured/configured.
  *   Suspended: 2.5 mA
  *   Unconfigured: 100 mA

--- a/include/zephyr/drivers/usb_c/usbc_pd.h
+++ b/include/zephyr/drivers/usb_c/usbc_pd.h
@@ -134,7 +134,7 @@ extern "C" {
 #define PD_T_TYPEC_SEND_SOURCE_CAP_MIN_MS 100
 
 /**
- * @brief Maxmimum time a source shall wait before sending a
+ * @brief Maximum time a source shall wait before sending a
  *	  Source_Capabilities message while the following is true:
  *	  1) The Port is Attached.
  *	  2) The Source is not in an active connection with a PD Sink Port.
@@ -224,37 +224,37 @@ extern "C" {
 #define PD_T_SENDER_RESPONSE_MAX_MS 30
 
 /**
- * @brief Minimum SPR Mode time for a power suppply to transition to a new level
+ * @brief Minimum SPR Mode time for a power supply to transition to a new level
  *        See Table 6-68 Time Values
  */
 #define PD_T_SPR_PS_TRANSITION_MIN_MS 450
 
 /**
- * @brief Nominal SPR Mode time for a power suppply to transition to a new level
+ * @brief Nominal SPR Mode time for a power supply to transition to a new level
  *        See Table 6-68 Time Values
  */
 #define PD_T_SPR_PS_TRANSITION_NOM_MS 500
 
 /**
- * @brief Maximum SPR Mode time for a power suppply to transition to a new level
+ * @brief Maximum SPR Mode time for a power supply to transition to a new level
  *        See Table 6-68 Time Values
  */
 #define PD_T_SPR_PS_TRANSITION_MAX_MS 550
 
 /**
- * @brief Minimum EPR Mode time for a power suppply to transition to a new level
+ * @brief Minimum EPR Mode time for a power supply to transition to a new level
  *        See Table 6-68 Time Values
  */
 #define PD_T_EPR_PS_TRANSITION_MIN_MS 830
 
 /**
- * @brief Nominal EPR Mode time for a power suppply to transition to a new level
+ * @brief Nominal EPR Mode time for a power supply to transition to a new level
  *        See Table 6-68 Time Values
  */
 #define PD_T_EPR_PS_TRANSITION_NOM_MS 925
 
 /**
- * @brief Maximum EPR Mode time for a power suppply to transition to a new level
+ * @brief Maximum EPR Mode time for a power supply to transition to a new level
  *        See Table 6-68 Time Values
  */
 #define PD_T_EPR_PS_TRANSITION_MAX_MS 1020

--- a/include/zephyr/drivers/usb_c/usbc_vbus.h
+++ b/include/zephyr/drivers/usb_c/usbc_vbus.h
@@ -8,7 +8,7 @@
  * @brief USB-C VBUS device APIs
  *
  * This file contains the USB-C VBUS device APIs.
- * All USB-C VBUS measurment and control device drivers should
+ * All USB-C VBUS measurement and control device drivers should
  * implement the APIs described in this file.
  */
 
@@ -89,10 +89,10 @@ static inline int usbc_vbus_discharge(const struct device *dev, bool enable)
 }
 
 /**
- * @brief Controls a pin that enables VBUS measurments
+ * @brief Controls a pin that enables VBUS measurements
  *
  * @param dev     Runtime device structure
- * @param enable  enable VBUS measurments when true
+ * @param enable  enable VBUS measurements when true
  *
  * @retval 0 on success
  * @retval -EIO on failure

--- a/include/zephyr/drivers/w1.h
+++ b/include/zephyr/drivers/w1.h
@@ -422,7 +422,7 @@ static inline int z_impl_w1_configure(const struct device *dev,
 /** This flag can be passed to searches in order to not filter on family ID. */
 #define W1_SEARCH_ALL_FAMILIES		0x00
 
-/** Intitialize all w1_rom struct members to zero. */
+/** Initialize all w1_rom struct members to zero. */
 #define W1_ROM_INIT_ZERO					\
 	{							\
 		.family = 0, .serial = { 0 }, .crc = 0,		\
@@ -475,9 +475,9 @@ typedef void (*w1_search_callback_t)(struct w1_rom rom, void *user_data);
  *
  * This procedure allows the 1-Wire bus master to read the peripherals’
  * 64-bit ROM without using the Search ROM procedure.
- * This command can be used as long as not more than a sigle peripheral is
+ * This command can be used as long as not more than a single peripheral is
  * connected to the bus.
- * Otherwise data collisons occur and a faulty ROM is read.
+ * Otherwise data collisions occur and a faulty ROM is read.
  *
  * @param[in] dev  Pointer to the device structure for the driver instance.
  * @param[out] rom Pointer to the ROM structure.
@@ -512,7 +512,7 @@ int w1_read_rom(const struct device *dev, struct w1_rom *rom);
 int w1_match_rom(const struct device *dev, const struct w1_slave_config *config);
 
 /**
- * @brief Select the slave last addressed with a Match ROM or Search ROM commnad.
+ * @brief Select the slave last addressed with a Match ROM or Search ROM command.
  *
  * This routine allows the 1-Wire bus master to re-select a slave
  * device that was already addressed using a Match ROM or Search ROM command.
@@ -543,7 +543,7 @@ int w1_resume_command(const struct device *dev);
 int w1_skip_rom(const struct device *dev, const struct w1_slave_config *config);
 
 /**
- * @brief In single drop configurations use Skip Select command, otherweise use
+ * @brief In single drop configurations use Skip Select command, otherwise use
  *        Match ROM command.
  *
  * @param[in] dev    Pointer to the device structure for the driver instance.


### PR DESCRIPTION
Utilize a code spell-checking tool to scan for and correct spelling errors in all files within the `include/zephyr/drivers` directory.