### PR TITLE
drivers: hwinfo: Add support for generating device id from device addr

### DIFF
--- a/drivers/hwinfo/Kconfig
+++ b/drivers/hwinfo/Kconfig
@@ -67,7 +67,7 @@ config HWINFO_NRF
 	bool "NRF device ID"
 	default y
 	depends on SOC_FAMILY_NORDIC_NRF
-	depends on NRF_SOC_SECURE_SUPPORTED
+	depends on SOC_SERIES_NRF54HX || NRF_SOC_SECURE_SUPPORTED
 	help
 	  Enable Nordic NRF hwinfo driver.
 


### PR DESCRIPTION
In some ICs (including nRF54H20) the DEVICEID register is not part of FICR, and thus it is not accessible to applications. Use instead the device address, along with a couple of bytes from ER and IR, to generated a unique device id.

At the same time update the pointer to the hal_nordic repo to pull in https://github.com/zephyrproject-rtos/hal_nordic/pull/196.