### PR TITLE
boards: renesas: ek_ra8m1: added mikrobus_serial node label

### DIFF
--- a/boards/renesas/ek_ra8m1/ek_ra8m1-pinctrl.dtsi
+++ b/boards/renesas/ek_ra8m1/ek_ra8m1-pinctrl.dtsi
@@ -4,6 +4,18 @@
  */
 
 &pinctrl {
+	sci3_default: sci3_default {
+		group1 {
+			/* tx */
+			psels = <RA_PSEL(RA_PSEL_SCI_3, 3, 10)>;
+			drive-strength = "medium";
+		};
+		group2 {
+			/* rx */
+			psels = <RA_PSEL(RA_PSEL_SCI_3, 3, 9)>;
+		};
+	};
+
 	sci9_default: sci9_default {
 		group1 {
 			/* tx */

--- a/boards/renesas/ek_ra8m1/ek_ra8m1.dts
+++ b/boards/renesas/ek_ra8m1/ek_ra8m1.dts
@@ -37,6 +37,29 @@
 		};
 	};
 
+	mikrobus_header: mikrobus-connector {
+		compatible = "mikro-bus";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map =	<0 0 &ioport0 4 0>,	/* AN  */
+				<1 0 &ioport5 2 0>,	/* RST */
+				<2 0 &ioport4 13 0>,	/* CS   */
+				<3 0 &ioport4 12 0>,	/* SCK  */
+				<4 0 &ioport4 10 0>,	/* MISO */
+				<5 0 &ioport4 11 0>,	/* MOSI */
+							/* +3.3V */
+							/* GND */
+				<6 0 &ioport9 7 0>,	/* PWM  */
+				<7 0 &ioport0 10 0>,	/* INT  */
+				<8 0 &ioport3 9 0>,	/* RX   */
+				<9 0 &ioport3 10 0>,	/* TX   */
+				<10 0 &ioport4 0 0>,	/* SCL  */
+				<11 0 &ioport4 1 0>;	/* SDA  */
+							/* +5V */
+							/* GND */
+	};
+
 	aliases {
 		led0 = &led1;
 	};
@@ -72,7 +95,15 @@
 	status = "okay";
 };
 
+&ioport0 {
+	status = "okay";
+};
+
 &ioport1 {
+	status = "okay";
+};
+
+&ioport3 {
 	status = "okay";
 };
 
@@ -80,8 +111,26 @@
 	status = "okay";
 };
 
+&ioport5 {
+	status = "okay";
+};
+
 &ioport6 {
 	status = "okay";
+};
+
+&ioport9 {
+	status = "okay";
+};
+
+&sci3 {
+	pinctrl-0 = <&sci3_default>;
+	pinctrl-names = "default";
+	status = "okay";
+	uart3: uart {
+		current-speed = <115200>;
+		status = "okay";
+	};
 };
 
 &sci9 {
@@ -93,3 +142,5 @@
 		status = "okay";
 	};
 };
+
+mikrobus_serial: &uart3 {};


### PR DESCRIPTION
Added mikrobus_serial node label to EK-RA8M1 device tree board definition, allowing compatible shield boards to be used.