### PR TITLE
tests: arch: common: stack_unwind: fix symtab test

### DIFF
--- a/tests/arch/common/stack_unwind/testcase.yaml
+++ b/tests/arch/common/stack_unwind/testcase.yaml
@@ -63,11 +63,12 @@ tests:
       - qemu_cortex_a53
     extra_configs:
       - CONFIG_FRAME_POINTER=y
+      - CONFIG_EXCEPTION_STACK_TRACE_SYMTAB=y
     harness_config:
       type: multi_line
       regex:
-        - "[func1+\\w+]"
-        - "[func2+\\w+]"
-        - "[func1+\\w+]"
-        - "[func2+\\w+]"
-        - "[func1+\\w+]"
+        - "\\[func1\\+0x\\w+\\]"
+        - "\\[func2\\+0x\\w+\\]"
+        - "\\[func1\\+0x\\w+\\]"
+        - "\\[func2\\+0x\\w+\\]"
+        - "\\[func1\\+0x\\w+\\]"


### PR DESCRIPTION
The symtab test should have the `CONFIG_EXCEPTION_STACK_TRACE_SYMTAB` enabled. This was not caught in the CI previously as the regex was also wrong, '[' and ']' are regex syntax and should be escaped.