### PR TITLE
drivers: serial: lpc11u6x: allow to configure data polarity

### DIFF
--- a/drivers/serial/uart_lpc11u6x.c
+++ b/drivers/serial/uart_lpc11u6x.c
@@ -380,6 +380,11 @@ static void lpc11u6x_uart0_isr_config(const struct device *dev);
 
 PINCTRL_DT_DEFINE(DT_NODELABEL(uart0));
 
+BUILD_ASSERT(DT_PROP(DT_NODELABEL(uart0), rx_invert) == 0,
+	     "rx-invert not supported for UART0");
+BUILD_ASSERT(DT_PROP(DT_NODELABEL(uart0), tx_invert) == 0,
+	     "tx-invert not supported for UART0");
+
 static const struct lpc11u6x_uart0_config uart0_config = {
 	.uart0 = (struct lpc11u6x_uart0_regs *)
 	DT_REG_ADDR(DT_NODELABEL(uart0)),
@@ -566,6 +571,13 @@ static int lpc11u6x_uartx_configure(const struct device *dev,
 
 	if (cfg->flow_ctrl != UART_CFG_FLOW_CTRL_NONE) {
 		return -ENOTSUP;
+	}
+
+	if (dev_cfg->rx_invert) {
+		flags |= LPC11U6X_UARTX_CFG_RXPOL(1);
+	}
+	if (dev_cfg->tx_invert) {
+		flags |= LPC11U6X_UARTX_CFG_TXPOL(1);
 	}
 
 	/* Disable UART */
@@ -786,6 +798,13 @@ static int lpc11u6x_uartx_init(const struct device *dev)
 	data->data_bits = UART_CFG_DATA_BITS_8;
 	data->flow_ctrl = UART_CFG_FLOW_CTRL_NONE;
 
+	if (cfg->rx_invert) {
+		cfg->base->cfg |= LPC11U6X_UARTX_CFG_RXPOL(1);
+	}
+	if (cfg->tx_invert) {
+		cfg->base->cfg |= LPC11U6X_UARTX_CFG_TXPOL(1);
+	}
+
 	/* Enable UART */
 	cfg->base->cfg = (cfg->base->cfg & LPC11U6X_UARTX_CFG_MASK) |
 		LPC11U6X_UARTX_CFG_ENABLE;
@@ -845,6 +864,8 @@ static const struct lpc11u6x_uartx_config uart_cfg_##idx = {	              \
 	.clkid = DT_PHA_BY_IDX(DT_NODELABEL(uart##idx), clocks, 0, clkid),    \
 	.pincfg = PINCTRL_DT_DEV_CONFIG_GET(DT_NODELABEL(uart##idx)),         \
 	.baudrate = DT_PROP(DT_NODELABEL(uart##idx), current_speed),	      \
+	.rx_invert = DT_PROP(DT_NODELABEL(uart##idx), rx_invert),	      \
+	.tx_invert = DT_PROP(DT_NODELABEL(uart##idx), tx_invert),	      \
 };									      \
 									      \
 static struct lpc11u6x_uartx_data uart_data_##idx;                            \

--- a/drivers/serial/uart_lpc11u6x.h
+++ b/drivers/serial/uart_lpc11u6x.h
@@ -58,6 +58,9 @@
 #define LPC11U6X_UARTX_CFG_STOP_1BIT             (0x0 << 6)
 #define LPC11U6X_UARTX_CFG_STOP_2BIT             (0x1 << 6)
 
+#define LPC11U6X_UARTX_CFG_RXPOL(x)              (((x) & 0x1) << 22)
+#define LPC11U6X_UARTX_CFG_TXPOL(x)              (((x) & 0x1) << 23)
+
 #define LPC11U6X_UARTX_CFG_MASK                  (0x00FCDAFD)
 
 #define LPC11U6X_UARTX_STAT_RXRDY                (1 << 0)
@@ -170,6 +173,8 @@ struct lpc11u6x_uartx_config {
 	const struct device *clock_dev;
 	uint32_t baudrate;
 	uint32_t clkid;
+	bool rx_invert;
+	bool tx_invert;
 	const struct pinctrl_dev_config *pincfg;
 };
 

--- a/dts/bindings/serial/nxp,lpc11u6x-uart.yaml
+++ b/dts/bindings/serial/nxp,lpc11u6x-uart.yaml
@@ -2,7 +2,7 @@ description: LPC11U6X UART
 
 compatible: "nxp,lpc11u6x-uart"
 
-include: [uart-controller.yaml, pinctrl-device.yaml]
+include: [uart-controller.yaml, uart-controller-pin-inversion.yaml, pinctrl-device.yaml]
 
 properties:
   reg:


### PR DESCRIPTION
This patch adds support for the rx-invert and tx-invert device-tree properties to the uart_lpc11u6x driver for USARTs 1, 2, 3 and 4.

Note that this feature is not supported by USART 0.