### PR TITLE
drivers: serial: remove '&' when assigning `init_fn`

### DIFF
--- a/drivers/serial/serial_esp32_usb.c
+++ b/drivers/serial/serial_esp32_usb.c
@@ -274,6 +274,6 @@ static const DRAM_ATTR struct serial_esp32_usb_config serial_esp32_usb_cfg = {
 
 static struct serial_esp32_usb_data serial_esp32_usb_data_0;
 
-DEVICE_DT_INST_DEFINE(0, &serial_esp32_usb_init, NULL, &serial_esp32_usb_data_0,
+DEVICE_DT_INST_DEFINE(0, serial_esp32_usb_init, NULL, &serial_esp32_usb_data_0,
 		      &serial_esp32_usb_cfg, PRE_KERNEL_1,
 		      CONFIG_SERIAL_INIT_PRIORITY, &serial_esp32_usb_api);

--- a/drivers/serial/uart_cmsdk_apb.c
+++ b/drivers/serial/uart_cmsdk_apb.c
@@ -500,7 +500,7 @@ static struct uart_cmsdk_apb_dev_data uart_cmsdk_apb_dev_data_0 = {
 };
 
 DEVICE_DT_INST_DEFINE(0,
-		    &uart_cmsdk_apb_init,
+		    uart_cmsdk_apb_init,
 		    NULL,
 		    &uart_cmsdk_apb_dev_data_0,
 		    &uart_cmsdk_apb_dev_cfg_0, PRE_KERNEL_1,
@@ -565,7 +565,7 @@ static struct uart_cmsdk_apb_dev_data uart_cmsdk_apb_dev_data_1 = {
 };
 
 DEVICE_DT_INST_DEFINE(1,
-		    &uart_cmsdk_apb_init,
+		    uart_cmsdk_apb_init,
 		    NULL,
 		    &uart_cmsdk_apb_dev_data_1,
 		    &uart_cmsdk_apb_dev_cfg_1, PRE_KERNEL_1,
@@ -630,7 +630,7 @@ static struct uart_cmsdk_apb_dev_data uart_cmsdk_apb_dev_data_2 = {
 };
 
 DEVICE_DT_INST_DEFINE(2,
-		    &uart_cmsdk_apb_init,
+		    uart_cmsdk_apb_init,
 		    NULL,
 		    &uart_cmsdk_apb_dev_data_2,
 		    &uart_cmsdk_apb_dev_cfg_2, PRE_KERNEL_1,
@@ -695,7 +695,7 @@ static struct uart_cmsdk_apb_dev_data uart_cmsdk_apb_dev_data_3 = {
 };
 
 DEVICE_DT_INST_DEFINE(3,
-		    &uart_cmsdk_apb_init,
+		    uart_cmsdk_apb_init,
 		    NULL,
 		    &uart_cmsdk_apb_dev_data_3,
 		    &uart_cmsdk_apb_dev_cfg_3, PRE_KERNEL_1,
@@ -760,7 +760,7 @@ static struct uart_cmsdk_apb_dev_data uart_cmsdk_apb_dev_data_4 = {
 };
 
 DEVICE_DT_INST_DEFINE(4,
-		    &uart_cmsdk_apb_init,
+		    uart_cmsdk_apb_init,
 		    NULL,
 		    &uart_cmsdk_apb_dev_data_4,
 		    &uart_cmsdk_apb_dev_cfg_4, PRE_KERNEL_1,

--- a/drivers/serial/uart_ene_kb1200.c
+++ b/drivers/serial/uart_ene_kb1200.c
@@ -373,7 +373,7 @@ static void kb1200_uart_irq_init(void)
 		IF_ENABLED(CONFIG_UART_INTERRUPT_DRIVEN, (.irq_cfg_func = kb1200_uart_irq_init,))  \
 		.ser = (struct serial_regs *)DT_INST_REG_ADDR(n),                                  \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n)};                                        \
-	DEVICE_DT_INST_DEFINE(n, &kb1200_uart_init, NULL, &kb1200_uart_data_##n,                   \
+	DEVICE_DT_INST_DEFINE(n, kb1200_uart_init, NULL, &kb1200_uart_data_##n,                    \
 			      &kb1200_uart_config_##n, PRE_KERNEL_1, CONFIG_SERIAL_INIT_PRIORITY,  \
 			      &kb1200_uart_api);
 

--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -1042,7 +1042,7 @@ static const DRAM_ATTR struct uart_driver_api uart_esp32_api = {
 			},                                                                         \
 		ESP_UART_UHCI_INIT(idx)};                                                          \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(idx, &uart_esp32_init, NULL, &uart_esp32_data_##idx,                 \
+	DEVICE_DT_INST_DEFINE(idx, uart_esp32_init, NULL, &uart_esp32_data_##idx,                  \
 			      &uart_esp32_cfg_port_##idx, PRE_KERNEL_1,                            \
 			      CONFIG_SERIAL_INIT_PRIORITY, &uart_esp32_api);
 

--- a/drivers/serial/uart_gecko.c
+++ b/drivers/serial/uart_gecko.c
@@ -625,7 +625,7 @@ static const struct uart_driver_api uart_gecko_driver_api = {
 									       \
 	static struct uart_gecko_data uart_gecko_data_##idx;		       \
 									       \
-	DEVICE_DT_INST_DEFINE(idx, &uart_gecko_init, 			       \
+	DEVICE_DT_INST_DEFINE(idx, uart_gecko_init,			       \
 			    NULL, &uart_gecko_data_##idx,		       \
 			    &uart_gecko_cfg_##idx, PRE_KERNEL_1,	       \
 			    CONFIG_SERIAL_INIT_PRIORITY,		       \
@@ -678,7 +678,7 @@ DT_INST_FOREACH_STATUS_OKAY(GECKO_UART_INIT)
 									       \
 	static struct uart_gecko_data usart_gecko_data_##idx;		       \
 									       \
-	DEVICE_DT_INST_DEFINE(idx, &uart_gecko_init, NULL,		       \
+	DEVICE_DT_INST_DEFINE(idx, uart_gecko_init, NULL,		       \
 			    &usart_gecko_data_##idx,			       \
 			    &usart_gecko_cfg_##idx, PRE_KERNEL_1,	       \
 			    CONFIG_SERIAL_INIT_PRIORITY,		       \
@@ -706,7 +706,7 @@ DT_INST_FOREACH_STATUS_OKAY(GECKO_UART_INIT)
 									       \
 	static struct uart_gecko_data usart_gecko_data_##idx;		       \
 									       \
-	DEVICE_DT_INST_DEFINE(idx, &uart_gecko_init, NULL,		       \
+	DEVICE_DT_INST_DEFINE(idx, uart_gecko_init, NULL,		       \
 			    &usart_gecko_data_##idx,			       \
 			    &usart_gecko_cfg_##idx, PRE_KERNEL_1,	       \
 			    CONFIG_SERIAL_INIT_PRIORITY,		       \

--- a/drivers/serial/uart_ifx_cat1.c
+++ b/drivers/serial/uart_ifx_cat1.c
@@ -526,7 +526,7 @@ static const struct uart_driver_api ifx_cat1_uart_driver_api = {
 	};										     \
 											     \
 	DEVICE_DT_INST_DEFINE(n,							     \
-			      &ifx_cat1_uart_init, NULL,				     \
+			      ifx_cat1_uart_init, NULL,					     \
 			      &ifx_cat1_uart##n##_data,					     \
 			      &ifx_cat1_uart##n##_cfg, PRE_KERNEL_1,			     \
 			      CONFIG_SERIAL_INIT_PRIORITY,				     \

--- a/drivers/serial/uart_imx.c
+++ b/drivers/serial/uart_imx.c
@@ -326,7 +326,7 @@ static const struct uart_driver_api uart_imx_driver_api = {
 									\
 	PINCTRL_DT_INST_DEFINE(n);					\
 									\
-	DEVICE_DT_INST_DEFINE(n, &uart_imx_init, NULL,			\
+	DEVICE_DT_INST_DEFINE(n, uart_imx_init, NULL,			\
 			&imx_uart_##n##_data, &imx_uart_##n##_config,	\
 			PRE_KERNEL_1,					\
 			CONFIG_SERIAL_INIT_PRIORITY,			\

--- a/drivers/serial/uart_ite_it8xxx2.c
+++ b/drivers/serial/uart_ite_it8xxx2.c
@@ -198,7 +198,7 @@ static int uart_it8xxx2_init(const struct device *dev)
 	static struct uart_it8xxx2_data uart_it8xxx2_data_##inst;              \
 									       \
 	PM_DEVICE_DT_INST_DEFINE(inst, uart_it8xxx2_pm_action);                \
-	DEVICE_DT_INST_DEFINE(inst, &uart_it8xxx2_init,                        \
+	DEVICE_DT_INST_DEFINE(inst, uart_it8xxx2_init,                         \
 			      PM_DEVICE_DT_INST_GET(inst),                     \
 			      &uart_it8xxx2_data_##inst,                       \
 			      &uart_it8xxx2_cfg_##inst,                        \

--- a/drivers/serial/uart_mchp_xec.c
+++ b/drivers/serial/uart_mchp_xec.c
@@ -1097,7 +1097,7 @@ static const struct uart_driver_api uart_xec_driver_api = {
 		.uart_config.flow_ctrl = DEV_DATA_FLOW_CTRL(n),		\
 	};								\
 	PM_DEVICE_DT_INST_DEFINE(n, uart_xec_pm_action);		\
-	DEVICE_DT_INST_DEFINE(n, &uart_xec_init,			\
+	DEVICE_DT_INST_DEFINE(n, uart_xec_init,				\
 			      PM_DEVICE_DT_INST_GET(n),			\
 			      &uart_xec_dev_data_##n,			\
 			      &uart_xec_dev_cfg_##n,			\

--- a/drivers/serial/uart_mcux.c
+++ b/drivers/serial/uart_mcux.c
@@ -445,7 +445,7 @@ static const struct uart_mcux_config uart_mcux_##n##_config = {		\
 	PM_DEVICE_DT_INST_DEFINE(n, uart_mcux_pm_action);\
 									\
 	DEVICE_DT_INST_DEFINE(n,					\
-			    &uart_mcux_init,				\
+			    uart_mcux_init,				\
 			    PM_DEVICE_DT_INST_GET(n),			\
 			    &uart_mcux_##n##_data,			\
 			    &uart_mcux_##n##_config,			\

--- a/drivers/serial/uart_mcux_flexcomm.c
+++ b/drivers/serial/uart_mcux_flexcomm.c
@@ -1203,7 +1203,7 @@ static const struct mcux_flexcomm_config mcux_flexcomm_##n##_config = {		\
 	static const struct mcux_flexcomm_config mcux_flexcomm_##n##_config;	\
 										\
 	DEVICE_DT_INST_DEFINE(n,						\
-			    &mcux_flexcomm_init,				\
+			    mcux_flexcomm_init,					\
 			    NULL,						\
 			    &mcux_flexcomm_##n##_data,				\
 			    &mcux_flexcomm_##n##_config,			\

--- a/drivers/serial/uart_mcux_iuart.c
+++ b/drivers/serial/uart_mcux_iuart.c
@@ -341,7 +341,7 @@ static const struct mcux_iuart_config mcux_iuart_##n##_config = {	\
 	static const struct mcux_iuart_config mcux_iuart_##n##_config;\
 									\
 	DEVICE_DT_INST_DEFINE(n,					\
-			    &mcux_iuart_init,				\
+			    mcux_iuart_init,				\
 			    NULL,					\
 			    &mcux_iuart_##n##_data,			\
 			    &mcux_iuart_##n##_config,			\

--- a/drivers/serial/uart_mcux_lpsci.c
+++ b/drivers/serial/uart_mcux_lpsci.c
@@ -331,7 +331,7 @@ static const struct mcux_lpsci_config mcux_lpsci_##n##_config = {	\
 	static const struct mcux_lpsci_config mcux_lpsci_##n##_config;	\
 									\
 	DEVICE_DT_INST_DEFINE(n,					\
-			    &mcux_lpsci_init,				\
+			    mcux_lpsci_init,				\
 			    NULL,					\
 			    &mcux_lpsci_##n##_data,			\
 			    &mcux_lpsci_##n##_config,			\

--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -1376,7 +1376,7 @@ static const struct mcux_lpuart_config mcux_lpuart_##n##_config = {     \
 	LPUART_MCUX_DECLARE_CFG(n)					\
 									\
 	DEVICE_DT_INST_DEFINE(n,					\
-			    &mcux_lpuart_init,				\
+			    mcux_lpuart_init,				\
 			    NULL,					\
 			    &mcux_lpuart_##n##_data,			\
 			    &mcux_lpuart_##n##_config,			\

--- a/drivers/serial/uart_native_ptty.c
+++ b/drivers/serial/uart_native_ptty.c
@@ -203,14 +203,14 @@ static int np_uart_tty_poll_in(const struct device *dev,
 }
 
 DEVICE_DT_INST_DEFINE(0,
-	    &np_uart_0_init, NULL,
+	    np_uart_0_init, NULL,
 	    (void *)&native_uart_status_0, NULL,
 	    PRE_KERNEL_1, CONFIG_SERIAL_INIT_PRIORITY,
 	    &np_uart_driver_api_0);
 
 #if defined(CONFIG_UART_NATIVE_POSIX_PORT_1_ENABLE)
 DEVICE_DT_INST_DEFINE(1,
-	    &np_uart_1_init, NULL,
+	    np_uart_1_init, NULL,
 	    (void *)&native_uart_status_1, NULL,
 	    PRE_KERNEL_1, CONFIG_SERIAL_INIT_PRIORITY,
 	    &np_uart_driver_api_1);

--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -1147,7 +1147,7 @@ static int uart_npcx_init(const struct device *dev)
 		.baud_rate = DT_INST_PROP(i, current_speed),                                       \
 	};                                                                                         \
 	                                                                                           \
-	DEVICE_DT_INST_DEFINE(i, &uart_npcx_init, NULL, &uart_npcx_data_##i, &uart_npcx_cfg_##i,   \
+	DEVICE_DT_INST_DEFINE(i, uart_npcx_init, NULL, &uart_npcx_data_##i, &uart_npcx_cfg_##i,    \
 			      PRE_KERNEL_1, CONFIG_SERIAL_INIT_PRIORITY, &uart_npcx_driver_api);   \
 												   \
 	NPCX_UART_IRQ_CONFIG_FUNC(i)

--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -1958,7 +1958,7 @@ static const struct uart_driver_api uart_ns16550_driver_api = {
 	static struct uart_ns16550_dev_data uart_ns16550_dev_data_##n = {            \
 		UART_NS16550_COMMON_DEV_DATA_INITIALIZER(n)                          \
 	};                                                                           \
-	DEVICE_DT_INST_DEFINE(n, &uart_ns16550_init, NULL,                           \
+	DEVICE_DT_INST_DEFINE(n, uart_ns16550_init, NULL,                            \
 			      &uart_ns16550_dev_data_##n, &uart_ns16550_dev_cfg_##n, \
 			      PRE_KERNEL_1, CONFIG_SERIAL_INIT_PRIORITY,             \
 			      &uart_ns16550_driver_api);                             \
@@ -1976,7 +1976,7 @@ static const struct uart_driver_api uart_ns16550_driver_api = {
 	static struct uart_ns16550_dev_data uart_ns16550_dev_data_##n = {            \
 		UART_NS16550_COMMON_DEV_DATA_INITIALIZER(n)                          \
 	};                                                                           \
-	DEVICE_DT_INST_DEFINE(n, &uart_ns16550_init, NULL,                           \
+	DEVICE_DT_INST_DEFINE(n, uart_ns16550_init, NULL,                            \
 			      &uart_ns16550_dev_data_##n, &uart_ns16550_dev_cfg_##n, \
 			      PRE_KERNEL_1,            \
 			      CONFIG_SERIAL_INIT_PRIORITY,                           \

--- a/drivers/serial/uart_numaker.c
+++ b/drivers/serial/uart_numaker.c
@@ -442,7 +442,7 @@ static const struct uart_driver_api uart_numaker_driver_api = {
 			},                                                                         \
 	};                                                                                         \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(inst, &uart_numaker_init, NULL, &uart_numaker_data_##inst,           \
+	DEVICE_DT_INST_DEFINE(inst, uart_numaker_init, NULL, &uart_numaker_data_##inst,            \
 			      &uart_numaker_cfg_##inst, PRE_KERNEL_1, CONFIG_SERIAL_INIT_PRIORITY, \
 			      &uart_numaker_driver_api);
 

--- a/drivers/serial/uart_numicro.c
+++ b/drivers/serial/uart_numicro.c
@@ -200,7 +200,7 @@ static struct uart_numicro_data uart_numicro_data_##index = {		\
 };									\
 									\
 DEVICE_DT_INST_DEFINE(index,						\
-		    &uart_numicro_init,					\
+		    uart_numicro_init,					\
 		    NULL,						\
 		    &uart_numicro_data_##index,				\
 		    &uart_numicro_cfg_##index,				\

--- a/drivers/serial/uart_nxp_s32_linflexd.c
+++ b/drivers/serial/uart_nxp_s32_linflexd.c
@@ -379,7 +379,7 @@ static const struct uart_driver_api uart_nxp_s32_driver_api = {
 		return uart_nxp_s32_init(dev);					\
 	}									\
 	DEVICE_DT_INST_DEFINE(n,						\
-			&uart_nxp_s32_init_##n,					\
+			uart_nxp_s32_init_##n,					\
 			NULL,							\
 			COND_CODE_1(CONFIG_UART_INTERRUPT_DRIVEN,		\
 				   (&uart_nxp_s32_data_##n), (NULL)),		\

--- a/drivers/serial/uart_pl011.c
+++ b/drivers/serial/uart_pl011.c
@@ -668,7 +668,7 @@ void pl011_isr(const struct device *dev)
 			(DT_INST_PROP_BY_PHANDLE(n, clocks, clock_frequency)), (0)),    \
 	};							\
 								\
-	DEVICE_DT_INST_DEFINE(n, &pl011_init,			\
+	DEVICE_DT_INST_DEFINE(n, pl011_init,			\
 			NULL,					\
 			&pl011_data_port_##n,			\
 			&pl011_cfg_port_##n,			\
@@ -709,7 +709,7 @@ DT_INST_FOREACH_STATUS_OKAY(PL011_INIT)
 		.sbsa = true,					\
 	};							\
 								\
-	DEVICE_DT_INST_DEFINE(n, &pl011_init,			\
+	DEVICE_DT_INST_DEFINE(n, pl011_init,			\
 			NULL,					\
 			&pl011_data_sbsa_##n,			\
 			&pl011_cfg_sbsa_##n,			\

--- a/drivers/serial/uart_rpi_pico_pio.c
+++ b/drivers/serial/uart_rpi_pico_pio.c
@@ -192,7 +192,7 @@ static const struct uart_driver_api pio_uart_driver_api = {
 	};											\
 	static struct pio_uart_data pio_uart##idx##_data;					\
 												\
-	DEVICE_DT_INST_DEFINE(idx, &pio_uart_init, NULL, &pio_uart##idx##_data,			\
+	DEVICE_DT_INST_DEFINE(idx, pio_uart_init, NULL, &pio_uart##idx##_data,			\
 			      &pio_uart##idx##_config, POST_KERNEL,				\
 			      CONFIG_SERIAL_INIT_PRIORITY,					\
 			      &pio_uart_driver_api);

--- a/drivers/serial/uart_rv32m1_lpuart.c
+++ b/drivers/serial/uart_rv32m1_lpuart.c
@@ -345,7 +345,7 @@ static const struct uart_driver_api rv32m1_lpuart_driver_api = {
 	static const struct rv32m1_lpuart_config rv32m1_lpuart_##n##_cfg;\
 									\
 	DEVICE_DT_INST_DEFINE(n,					\
-			    &rv32m1_lpuart_init,			\
+			    rv32m1_lpuart_init,				\
 			    NULL,					\
 			    &rv32m1_lpuart_##n##_data,			\
 			    &rv32m1_lpuart_##n##_cfg,			\

--- a/drivers/serial/uart_rzt2m.c
+++ b/drivers/serial/uart_rzt2m.c
@@ -439,7 +439,7 @@ static void uart_rzt2m_isr(const struct device *dev)
 		.base = DT_INST_REG_ADDR(n),                                                       \
 		.irq_config_func = uart##n##_rzt2m_irq_config,                                     \
 		.pin_config = PINCTRL_DT_INST_DEV_CONFIG_GET(n)};                                  \
-	DEVICE_DT_INST_DEFINE(n, &rzt2m_uart_init, NULL, &rzt2m_uart_##n##data,                    \
+	DEVICE_DT_INST_DEFINE(n, rzt2m_uart_init, NULL, &rzt2m_uart_##n##data,                     \
 			      &rzt2m_uart_##n##_config, PRE_KERNEL_1, CONFIG_SERIAL_INIT_PRIORITY, \
 			      &rzt2m_uart_api);
 

--- a/drivers/serial/uart_sam.c
+++ b/drivers/serial/uart_sam.c
@@ -482,7 +482,7 @@ static const struct uart_driver_api uart_sam_driver_api = {
 									\
 	static const struct uart_sam_dev_cfg uart##n##_sam_config;	\
 									\
-	DEVICE_DT_INST_DEFINE(n, &uart_sam_init,			\
+	DEVICE_DT_INST_DEFINE(n, uart_sam_init,				\
 			    NULL, &uart##n##_sam_data,			\
 			    &uart##n##_sam_config, PRE_KERNEL_1,	\
 			    CONFIG_SERIAL_INIT_PRIORITY,		\

--- a/drivers/serial/uart_stellaris.c
+++ b/drivers/serial/uart_stellaris.c
@@ -593,7 +593,7 @@ static struct uart_stellaris_dev_data_t uart_stellaris_dev_data_0 = {
 };
 
 DEVICE_DT_INST_DEFINE(0,
-		    &uart_stellaris_init,
+		    uart_stellaris_init,
 		    NULL,
 		    &uart_stellaris_dev_data_0, &uart_stellaris_dev_cfg_0,
 		    PRE_KERNEL_1, CONFIG_SERIAL_INIT_PRIORITY,
@@ -632,7 +632,7 @@ static struct uart_stellaris_dev_data_t uart_stellaris_dev_data_1 = {
 };
 
 DEVICE_DT_INST_DEFINE(1,
-		    &uart_stellaris_init,
+		    uart_stellaris_init,
 		    NULL,
 		    &uart_stellaris_dev_data_1, &uart_stellaris_dev_cfg_1,
 		    PRE_KERNEL_1, CONFIG_SERIAL_INIT_PRIORITY,
@@ -671,7 +671,7 @@ static struct uart_stellaris_dev_data_t uart_stellaris_dev_data_2 = {
 };
 
 DEVICE_DT_INST_DEFINE(2,
-		    &uart_stellaris_init,
+		    uart_stellaris_init,
 		    NULL,
 		    &uart_stellaris_dev_data_2, &uart_stellaris_dev_cfg_2,
 		    PRE_KERNEL_1, CONFIG_SERIAL_INIT_PRIORITY,

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -2448,10 +2448,10 @@ static struct uart_stm32_data uart_stm32_data_##index = {		\
 	UART_DMA_CHANNEL(index, tx, TX, MEMORY, PERIPHERAL)		\
 };									\
 									\
-PM_DEVICE_DT_INST_DEFINE(index, uart_stm32_pm_action);		        \
+PM_DEVICE_DT_INST_DEFINE(index, uart_stm32_pm_action);			\
 									\
 DEVICE_DT_INST_DEFINE(index,						\
-		    &uart_stm32_init,					\
+		    uart_stm32_init,					\
 		    PM_DEVICE_DT_INST_GET(index),			\
 		    &uart_stm32_data_##index, &uart_stm32_cfg_##index,	\
 		    PRE_KERNEL_1, CONFIG_SERIAL_INIT_PRIORITY,		\

--- a/drivers/serial/uart_xmc4xxx.c
+++ b/drivers/serial/uart_xmc4xxx.c
@@ -1004,7 +1004,7 @@ XMC4XXX_IRQ_STRUCT_INIT(index)						\
 	.fifo_rx_size = DT_INST_ENUM_IDX(index, fifo_rx_size),          \
 };									\
 									\
-	DEVICE_DT_INST_DEFINE(index, &uart_xmc4xxx_init,		\
+	DEVICE_DT_INST_DEFINE(index, uart_xmc4xxx_init,			\
 			    NULL,					\
 			    &xmc4xxx_data_##index,			\
 			    &xmc4xxx_config_##index, PRE_KERNEL_1,	\

--- a/drivers/serial/usart_gd32.c
+++ b/drivers/serial/usart_gd32.c
@@ -331,7 +331,7 @@ static const struct uart_driver_api usart_gd32_driver_api = {
 		.parity = DT_INST_ENUM_IDX_OR(n, parity, UART_CFG_PARITY_NONE),	\
 		 GD32_USART_IRQ_HANDLER_FUNC_INIT(n)				\
 	};									\
-	DEVICE_DT_INST_DEFINE(n, &usart_gd32_init,				\
+	DEVICE_DT_INST_DEFINE(n, usart_gd32_init,				\
 			      NULL,						\
 			      &usart_gd32_data_##n,				\
 			      &usart_gd32_config_##n, PRE_KERNEL_1,		\

--- a/drivers/serial/usart_sam.c
+++ b/drivers/serial/usart_sam.c
@@ -579,7 +579,7 @@ static const struct uart_driver_api usart_sam_driver_api = {
 	static const struct usart_sam_dev_cfg usart##n##_sam_config;	\
 									\
 	DEVICE_DT_INST_DEFINE(n,					\
-			    &usart_sam_init, NULL,			\
+			    usart_sam_init, NULL,			\
 			    &usart##n##_sam_data,			\
 			    &usart##n##_sam_config, PRE_KERNEL_1,	\
 			    CONFIG_SERIAL_INIT_PRIORITY,		\


### PR DESCRIPTION
Remove address-of operator ('&') when assigning `init_fn` function pointer in `DEVICE_DT_INST_DEFINE` macro.

This change aims to maintain consistency among the drivers in `drivers/serial`, ensuring that all function pointer assignments follow the same pattern.