### PR TITLE
drivers: spi: remove '&' when assigning `init_fn`

### DIFF
--- a/drivers/spi/spi_esp32_spim.c
+++ b/drivers/spi/spi_esp32_spim.c
@@ -539,7 +539,7 @@ static const struct spi_driver_api spi_api = {
 		.clock_source = SPI_CLK_SRC_DEFAULT,	\
 	};	\
 		\
-	DEVICE_DT_INST_DEFINE(idx, &spi_esp32_init,	\
+	DEVICE_DT_INST_DEFINE(idx, spi_esp32_init,	\
 			      NULL, &spi_data_##idx,	\
 			      &spi_config_##idx, POST_KERNEL,	\
 			      CONFIG_SPI_INIT_PRIORITY, &spi_api);

--- a/drivers/spi/spi_gd32.c
+++ b/drivers/spi/spi_gd32.c
@@ -679,7 +679,7 @@ int spi_gd32_init(const struct device *dev)
 		IF_ENABLED(CONFIG_SPI_GD32_DMA, (.dma = DMAS_DECL(idx),))      \
 		IF_ENABLED(CONFIG_SPI_GD32_INTERRUPT,			       \
 			   (.irq_configure = spi_gd32_irq_configure_##idx)) }; \
-	DEVICE_DT_INST_DEFINE(idx, &spi_gd32_init, NULL,		       \
+	DEVICE_DT_INST_DEFINE(idx, spi_gd32_init, NULL,			       \
 			      &spi_gd32_data_##idx, &spi_gd32_config_##idx,    \
 			      POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,	       \
 			      &spi_gd32_driver_api);

--- a/drivers/spi/spi_ifx_cat1.c
+++ b/drivers/spi/spi_ifx_cat1.c
@@ -340,7 +340,7 @@ static int ifx_cat1_spi_init(const struct device *dev)
 		},                                                                                 \
 		.irq_priority = DT_INST_IRQ(n, priority),                                          \
 	};                                                                                         \
-	DEVICE_DT_INST_DEFINE(n, &ifx_cat1_spi_init, NULL, &spi_cat1_data_##n,                     \
+	DEVICE_DT_INST_DEFINE(n, ifx_cat1_spi_init, NULL, &spi_cat1_data_##n,                      \
 			      &spi_cat1_config_##n, POST_KERNEL,                                   \
 			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &ifx_cat1_spi_api);
 

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -1399,7 +1399,7 @@ static struct spi_stm32_data spi_stm32_dev_data_##id = {		\
 									\
 PM_DEVICE_DT_INST_DEFINE(id, spi_stm32_pm_action);			\
 									\
-DEVICE_DT_INST_DEFINE(id, &spi_stm32_init, PM_DEVICE_DT_INST_GET(id),	\
+DEVICE_DT_INST_DEFINE(id, spi_stm32_init, PM_DEVICE_DT_INST_GET(id),	\
 		    &spi_stm32_dev_data_##id, &spi_stm32_cfg_##id,	\
 		    POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,		\
 		    &api_funcs);					\

--- a/drivers/spi/spi_mchp_mss_qspi.c
+++ b/drivers/spi/spi_mchp_mss_qspi.c
@@ -590,7 +590,7 @@ static const struct spi_driver_api mss_qspi_driver_api = {
 		SPI_CONTEXT_INIT_SYNC(mss_qspi_data_##n, ctx),	\
 	};								\
 									\
-	DEVICE_DT_INST_DEFINE(n, &mss_qspi_init,			\
+	DEVICE_DT_INST_DEFINE(n, mss_qspi_init,				\
 			    NULL,					\
 			    &mss_qspi_data_##n,			\
 			    &mss_qspi_config_##n, POST_KERNEL,	\

--- a/drivers/spi/spi_mcux_dspi.c
+++ b/drivers/spi/spi_mcux_dspi.c
@@ -913,7 +913,7 @@ static const struct spi_driver_api spi_mcux_driver_api = {
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(id),		\
 	};								\
 	DEVICE_DT_INST_DEFINE(id,					\
-			    &spi_mcux_init,				\
+			    spi_mcux_init,				\
 			    NULL,					\
 			    &spi_mcux_data_##id,			\
 			    &spi_mcux_config_##id,			\

--- a/drivers/spi/spi_mcux_ecspi.c
+++ b/drivers/spi/spi_mcux_ecspi.c
@@ -327,7 +327,7 @@ static const struct spi_driver_api spi_mcux_driver_api = {
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx)				\
 	};											\
 												\
-	DEVICE_DT_INST_DEFINE(n, &spi_mcux_init, NULL,						\
+	DEVICE_DT_INST_DEFINE(n, spi_mcux_init, NULL,						\
 			      &spi_mcux_data_##n, &spi_mcux_config_##n,				\
 			      POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,				\
 			      &spi_mcux_driver_api);						\

--- a/drivers/spi/spi_mcux_flexcomm.c
+++ b/drivers/spi/spi_mcux_flexcomm.c
@@ -885,7 +885,7 @@ static void spi_mcux_config_func_##id(const struct device *dev) \
 		SPI_DMA_CHANNELS(id)		\
 	};								\
 	DEVICE_DT_INST_DEFINE(id,					\
-			    &spi_mcux_init,				\
+			    spi_mcux_init,				\
 			    NULL,					\
 			    &spi_mcux_data_##id,			\
 			    &spi_mcux_config_##id,			\

--- a/drivers/spi/spi_mcux_flexio.c
+++ b/drivers/spi/spi_mcux_flexio.c
@@ -429,7 +429,7 @@ static const struct spi_driver_api spi_mcux_driver_api = {
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx)	\
 	};								\
 									\
-	DEVICE_DT_INST_DEFINE(n, &spi_mcux_init, NULL,			\
+	DEVICE_DT_INST_DEFINE(n, spi_mcux_init, NULL,			\
 				&spi_mcux_flexio_data_##n,		\
 				&spi_mcux_flexio_config_##n, POST_KERNEL, \
 				CONFIG_SPI_INIT_PRIORITY,		\

--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -966,10 +966,10 @@ static const struct spi_driver_api spi_mcux_driver_api = {
 									\
 	};								\
 									\
-	DEVICE_DT_INST_DEFINE(n, &spi_mcux_init, NULL,			\
-				&spi_mcux_data_##n,				\
-				&spi_mcux_config_##n, POST_KERNEL,		\
-				CONFIG_SPI_INIT_PRIORITY,			\
+	DEVICE_DT_INST_DEFINE(n, spi_mcux_init, NULL,			\
+				&spi_mcux_data_##n,			\
+				&spi_mcux_config_##n, POST_KERNEL,	\
+				CONFIG_SPI_INIT_PRIORITY,		\
 				&spi_mcux_driver_api);			\
 									\
 	static void spi_mcux_config_func_##n(const struct device *dev)	\

--- a/drivers/spi/spi_numaker.c
+++ b/drivers/spi/spi_numaker.c
@@ -356,7 +356,7 @@ done:
 		.clk_dev = DEVICE_DT_GET(DT_PARENT(DT_INST_CLOCKS_CTLR(inst))),                    \
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),                                    \
 	};                                                                                         \
-	DEVICE_DT_INST_DEFINE(inst, &spi_numaker_init, NULL, &spi_numaker_data_##inst,             \
+	DEVICE_DT_INST_DEFINE(inst, spi_numaker_init, NULL, &spi_numaker_data_##inst,              \
 			      &spi_numaker_config_##inst, POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,   \
 			      &spi_numaker_driver_api);
 

--- a/drivers/spi/spi_nxp_s32.c
+++ b/drivers/spi/spi_nxp_s32.c
@@ -705,7 +705,7 @@ static const struct spi_driver_api spi_nxp_s32_driver_api = {
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx)			\
 	};										\
 	DEVICE_DT_INST_DEFINE(n,							\
-			&spi_nxp_s32_init, NULL,					\
+			spi_nxp_s32_init, NULL,						\
 			&spi_nxp_s32_data_##n, &spi_nxp_s32_config_##n,			\
 			POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,				\
 			&spi_nxp_s32_driver_api);

--- a/drivers/spi/spi_psoc6.c
+++ b/drivers/spi/spi_psoc6.c
@@ -425,7 +425,7 @@ static const struct spi_driver_api spi_psoc6_driver_api = {
 		SPI_CONTEXT_INIT_SYNC(spi_psoc6_dev_data_##n, ctx),	\
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx)	\
 	};								\
-	DEVICE_DT_INST_DEFINE(n, &spi_psoc6_init, NULL,			\
+	DEVICE_DT_INST_DEFINE(n, spi_psoc6_init, NULL,			\
 			      &spi_psoc6_dev_data_##n,			\
 			      &spi_psoc6_config_##n, POST_KERNEL,	\
 			      CONFIG_SPI_INIT_PRIORITY,			\

--- a/drivers/spi/spi_rv32m1_lpspi.c
+++ b/drivers/spi/spi_rv32m1_lpspi.c
@@ -326,7 +326,7 @@ static const struct spi_driver_api spi_mcux_driver_api = {
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx)	\
 	};								\
 									\
-	DEVICE_DT_INST_DEFINE(n, &spi_mcux_init, NULL,			\
+	DEVICE_DT_INST_DEFINE(n, spi_mcux_init, NULL,			\
 			    &spi_mcux_data_##n,				\
 			    &spi_mcux_config_##n,			\
 			    POST_KERNEL,				\

--- a/drivers/spi/spi_sam0.c
+++ b/drivers/spi/spi_sam0.c
@@ -744,7 +744,7 @@ static const struct spi_sam0_config spi_sam0_config_##n = {		\
 		SPI_CONTEXT_INIT_SYNC(spi_sam0_dev_data_##n, ctx),	\
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx)	\
 	};								\
-	DEVICE_DT_INST_DEFINE(n, &spi_sam0_init, NULL,			\
+	DEVICE_DT_INST_DEFINE(n, spi_sam0_init, NULL,			\
 			    &spi_sam0_dev_data_##n,			\
 			    &spi_sam0_config_##n, POST_KERNEL,		\
 			    CONFIG_SPI_INIT_PRIORITY,			\

--- a/drivers/spi/spi_sedi.c
+++ b/drivers/spi/spi_sedi.c
@@ -398,13 +398,13 @@ static int spi_sedi_device_ctrl(const struct device *dev,
 		SPI_CONTEXT_INIT_LOCK(spi_##num##_data, ctx),	               \
 		SPI_CONTEXT_INIT_SYNC(spi_##num##_data, ctx),	               \
 	};								       \
-	const static struct spi_sedi_config spi_##num##_config = {	               \
+	const static struct spi_sedi_config spi_##num##_config = {	       \
 		DEVICE_MMIO_ROM_INIT(DT_DRV_INST(num)),                        \
 		.spi_device = num, .irq_config = spi_##num##_irq_init,         \
 	};								       \
 	PM_DEVICE_DEFINE(spi_##num, spi_sedi_device_ctrl);		       \
 	DEVICE_DT_INST_DEFINE(num,					       \
-			      &spi_sedi_init,				       \
+			      spi_sedi_init,				       \
 			      PM_DEVICE_GET(spi_##num),		               \
 			      &spi_##num##_data,			       \
 			      &spi_##num##_config,			       \

--- a/drivers/spi/spi_xec_qmspi.c
+++ b/drivers/spi/spi_xec_qmspi.c
@@ -700,7 +700,7 @@ static struct spi_qmspi_data spi_qmspi_0_dev_data = {
 };
 
 DEVICE_DT_INST_DEFINE(0,
-		    &qmspi_init, NULL, &spi_qmspi_0_dev_data,
+		    qmspi_init, NULL, &spi_qmspi_0_dev_data,
 		    &spi_qmspi_0_config, POST_KERNEL,
 		    CONFIG_SPI_INIT_PRIORITY, &spi_qmspi_driver_api);
 

--- a/drivers/spi/spi_xec_qmspi_ldma.c
+++ b/drivers/spi/spi_xec_qmspi_ldma.c
@@ -1067,7 +1067,7 @@ static const struct spi_driver_api spi_qmspi_xec_driver_api = {
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(i),		\
 	};								\
 	PM_DEVICE_DT_INST_DEFINE(i, qmspi_xec_pm_action);		\
-	DEVICE_DT_INST_DEFINE(i, &qmspi_xec_init,			\
+	DEVICE_DT_INST_DEFINE(i, qmspi_xec_init,			\
 		PM_DEVICE_DT_INST_GET(i),				\
 		&qmspi_xec_data_##i, &qmspi_xec_config_##i,		\
 		POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,			\

--- a/drivers/spi/spi_xmc4xxx.c
+++ b/drivers/spi/spi_xmc4xxx.c
@@ -684,7 +684,7 @@ static const struct spi_driver_api spi_xmc4xxx_driver_api = {
 		XMC4XXX_IRQ_HANDLER_STRUCT_INIT(index)                                             \
 		XMC4XXX_IRQ_DMA_STRUCT_INIT(index)};                                               \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(index, &spi_xmc4xxx_init, NULL, &xmc4xxx_data_##index,               \
+	DEVICE_DT_INST_DEFINE(index, spi_xmc4xxx_init, NULL, &xmc4xxx_data_##index,                \
 			      &xmc4xxx_config_##index, POST_KERNEL,                                \
 			      CONFIG_SPI_INIT_PRIORITY, &spi_xmc4xxx_driver_api);
 


### PR DESCRIPTION
Remove address-of operator ('&') when assigning `init_fn` function pointer in `DEVICE_DT_INST_DEFINE` macro.

This change aims to maintain consistency among the drivers in `drivers/spi`, ensuring that all function pointer assignments follow the same pattern.