### PR TITLE
samples: net: cellular_modem: fix division by zero in sample_echo_packet

### DIFF
--- a/samples/net/cellular_modem/src/main.c
+++ b/samples/net/cellular_modem/src/main.c
@@ -197,8 +197,10 @@ int sample_echo_packet(struct sockaddr *ai_addr, socklen_t ai_addrlen, uint16_t 
 	printk("Successfully sent and received %u of %u packets\n", packets_sent,
 	       SAMPLE_TEST_ECHO_PACKETS);
 
-	printk("Average time per successful echo: %u ms\n",
-	       accumulated_ms / packets_sent);
+	if (packets_sent > 0) {
+		printk("Average time per successful echo: %u ms\n",
+		accumulated_ms / packets_sent);
+	}
 
 	printk("Close UDP socket\n");
 


### PR DESCRIPTION
A hard fault occurs when the `sample_echo_packet` function attempts to print the average time per successful echo and no packets have been sent, resulting in a division by zero error. This fix adds a check to ensure that `packets_sent` is greater than 0 before performing the division. This prevents the system from halting due to a usage fault.

Logs before the fix:
```
...
Failed to receive echoed sample test packet (11)
Successfully sent and received 0 of 16 packets
[00:03:26.841,000] <err> os: ***** USAGE FAULT *****
[00:03:26.841,000] <err> os:   Division by zero
[00:03:26.841,000] <err> os: r0/a1:  0x00000001  r1/a2:  0x00000000  r2/a3:  0x00000002
[00:03:26.841,000] <err> os: r3/a4:  0x20002060 r12/ip:  0x000027f9 r14/lr:  0x00000abd
[00:03:26.841,000] <err> os:  xpsr:  0x81000000
[00:03:26.841,000] <err> os: Faulting instruction address (r15/pc): 0x00000abc
[00:03:26.841,000] <err> os: >>> ZEPHYR FATAL ERROR 30: Unknown error on CPU 0
[00:03:26.841,000] <err> os: Current thread: 0x20004008 (main)
[00:03:26.933,000] <err> os: Halting system
uart:~$ 
```
