### PR TITLE
net: sockets: Remove async service support

### DIFF
--- a/include/zephyr/net/socket_service.h
+++ b/include/zephyr/net/socket_service.h
@@ -89,17 +89,12 @@ extern void net_socket_service_callback(struct k_work *work);
 #define NET_SOCKET_SERVICE_OWNER
 #endif
 
-#define NET_SOCKET_SERVICE_CALLBACK_MODE(_flag)				\
-	IF_ENABLED(_flag,						\
-		   (.work = Z_WORK_INITIALIZER(net_socket_service_callback),))
-
-#define __z_net_socket_service_define(_name, _work_q, _cb, _count, _async, ...) \
+#define __z_net_socket_service_define(_name, _work_q, _cb, _count, ...) \
 	static int __z_net_socket_svc_get_idx(_name);			\
 	static struct net_socket_service_event				\
 			__z_net_socket_svc_get_name(_name)[_count] = {	\
 		[0 ... ((_count) - 1)] = {				\
 			.event.fd = -1, /* Invalid socket */		\
-			NET_SOCKET_SERVICE_CALLBACK_MODE(_async)	\
 			.callback = _cb,				\
 		}							\
 	};								\
@@ -113,44 +108,6 @@ extern void net_socket_service_callback(struct k_work *work);
 	}
 
 /** @endcond */
-
-/**
- * @brief Statically define a network socket service.
- *        The user callback is called asynchronously for this service meaning that
- *        the service API will not wait until the user callback returns before continuing
- *        with next socket service.
- *
- * The socket service can be accessed outside the module where it is defined using:
- *
- * @code extern struct net_socket_service_desc <name>; @endcode
- *
- * @note This macro cannot be used together with a static keyword.
- *       If such a use-case is desired, use NET_SOCKET_SERVICE_ASYNC_DEFINE_STATIC
- *       instead.
- *
- * @param name Name of the service.
- * @param work_q Pointer to workqueue where the work is done. Can be null in which case
- *        system workqueue is used.
- * @param cb Callback function that is called for socket activity.
- * @param count How many pollable sockets is needed for this service.
- */
-#define NET_SOCKET_SERVICE_ASYNC_DEFINE(name, work_q, cb, count)	\
-	__z_net_socket_service_define(name, work_q, cb, count, 1)
-
-/**
- * @brief Statically define a network socket service in a private (static) scope.
- *        The user callback is called asynchronously for this service meaning that
- *        the service API will not wait until the user callback returns before continuing
- *        with next socket service.
- *
- * @param name Name of the service.
- * @param work_q Pointer to workqueue where the work is done. Can be null in which case
- *        system workqueue is used.
- * @param cb Callback function that is called for socket activity.
- * @param count How many pollable sockets is needed for this service.
- */
-#define NET_SOCKET_SERVICE_ASYNC_DEFINE_STATIC(name, work_q, cb, count) \
-	__z_net_socket_service_define(name, work_q, cb, count, 1, static)
 
 /**
  * @brief Statically define a network socket service.
@@ -173,7 +130,7 @@ extern void net_socket_service_callback(struct k_work *work);
  * @param count How many pollable sockets is needed for this service.
  */
 #define NET_SOCKET_SERVICE_SYNC_DEFINE(name, work_q, cb, count)	\
-	__z_net_socket_service_define(name, work_q, cb, count, 0)
+	__z_net_socket_service_define(name, work_q, cb, count)
 
 /**
  * @brief Statically define a network socket service in a private (static) scope.
@@ -188,7 +145,7 @@ extern void net_socket_service_callback(struct k_work *work);
  * @param count How many pollable sockets is needed for this service.
  */
 #define NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(name, work_q, cb, count)	\
-	__z_net_socket_service_define(name, work_q, cb, count, 0, static)
+	__z_net_socket_service_define(name, work_q, cb, count, static)
 
 /**
  * @brief Register pollable sockets.

--- a/subsys/net/lib/sockets/sockets_service.c
+++ b/subsys/net/lib/sockets/sockets_service.c
@@ -151,18 +151,8 @@ static int call_work(struct zsock_pollfd *pev, struct k_work_q *work_q,
 	 */
 	pev->fd = -1;
 
-	if (work->handler == NULL) {
-		/* Synchronous call */
-		net_socket_service_callback(work);
-	} else {
-		if (work_q != NULL) {
-			ret = k_work_submit_to_queue(work_q, work);
-		} else {
-			ret = k_work_submit(work);
-		}
-
-		k_yield();
-	}
+	/* Synchronous call */
+	net_socket_service_callback(work);
 
 	return ret;
 

--- a/tests/net/socket/service/src/main.c
+++ b/tests/net/socket/service/src/main.c
@@ -55,10 +55,6 @@ static void tcp_server_handler(struct k_work *work)
 	Z_SPIN_DELAY(100);
 }
 
-NET_SOCKET_SERVICE_ASYNC_DEFINE(udp_service_async, NULL, server_handler, 2);
-NET_SOCKET_SERVICE_ASYNC_DEFINE(tcp_service_small_async, NULL, tcp_server_handler, 1);
-NET_SOCKET_SERVICE_ASYNC_DEFINE_STATIC(tcp_service_async, NULL, tcp_server_handler, 2);
-
 NET_SOCKET_SERVICE_SYNC_DEFINE(udp_service_sync, NULL, server_handler, 2);
 NET_SOCKET_SERVICE_SYNC_DEFINE(tcp_service_small_sync, NULL, tcp_server_handler, 1);
 NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(tcp_service_sync, NULL, tcp_server_handler, 2);
@@ -188,12 +184,6 @@ ZTEST(net_socket_service, test_service_sync)
 {
 	run_test_service(&udp_service_sync, &tcp_service_small_sync,
 			 &tcp_service_sync);
-}
-
-ZTEST(net_socket_service, test_service_async)
-{
-	run_test_service(&udp_service_async, &tcp_service_small_async,
-			 &tcp_service_async);
 }
 
 ZTEST_SUITE(net_socket_service, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
As found in PR #75525, we should not modify the polled fd array in multiple places. Because of this fix, the async version of the socket service could start to trigger while it is being handled by the async handler. This basically means that the async version cannot work as intended so remove its support.