### PR TITLE
twister: DeviceHandler DUT selection improvements and fixes

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -475,7 +475,7 @@ class DeviceHandler(Handler):
                 d.counter_increment()
                 avail = True
                 logger.debug(f"Retain DUT:{d.platform}, Id:{d.id}, "
-                             f"counter:{d.counter}")
+                             f"counter:{d.counter}, failures:{d.failures}")
             d.lock.release()
             if avail:
                 return d
@@ -486,8 +486,10 @@ class DeviceHandler(Handler):
         return None
 
     def make_dut_available(self, dut):
+        if self.instance.status in [TwisterStatus.ERROR, TwisterStatus.FAIL]:
+            dut.failures_increment()
         logger.debug(f"Release DUT:{dut.platform}, Id:{dut.id}, "
-                     f"counter:{dut.counter}")
+                     f"counter:{dut.counter}, failures:{dut.failures}")
         dut.available = 1
 
     @staticmethod

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -472,8 +472,10 @@ class DeviceHandler(Handler):
             avail = False
             if d.available:
                 d.available = 0
-                d.counter += 1
+                d.counter_increment()
                 avail = True
+                logger.debug(f"Retain DUT:{d.platform}, Id:{d.id}, "
+                             f"counter:{d.counter}")
             d.lock.release()
             if avail:
                 return d

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -755,7 +755,8 @@ class DeviceHandler(Handler):
                 logger.debug(f"Attach serial device {serial_device} @ {hardware.baud} baud")
                 ser.port = serial_device
                 ser.open()
-            except serial.SerialException:
+            except serial.SerialException as e:
+                self._handle_serial_exception(e, hardware, serial_pty, ser_pty_process)
                 return
 
         if not flash_error:

--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -96,6 +96,10 @@ class DUT(object):
         with self._counter.get_lock():
             self._counter.value = value
 
+    def counter_increment(self, value=1):
+        with self._counter.get_lock():
+            self._counter.value += value
+
     def to_dict(self):
         d = {}
         exclude = ['_available', '_counter', 'match']

--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -58,6 +58,7 @@ class DUT(object):
         self.serial_pty = serial_pty
         self._counter = Value("i", 0)
         self._available = Value("i", 1)
+        self._failures = Value("i", 0)
         self.connected = connected
         self.pre_script = pre_script
         self.id = id
@@ -100,9 +101,23 @@ class DUT(object):
         with self._counter.get_lock():
             self._counter.value += value
 
+    @property
+    def failures(self):
+        with self._failures.get_lock():
+            return self._failures.value
+
+    @failures.setter
+    def failures(self, value):
+        with self._failures.get_lock():
+            self._failures.value = value
+
+    def failures_increment(self, value=1):
+        with self._failures.get_lock():
+            self._failures.value += value
+
     def to_dict(self):
         d = {}
-        exclude = ['_available', '_counter', 'match']
+        exclude = ['_available', '_counter', '_failures', 'match']
         v = vars(self)
         for k in v.keys():
             if k not in exclude and v[k]:
@@ -208,10 +223,10 @@ class HardwareMap:
     def summary(self, selected_platforms):
         print("\nHardware distribution summary:\n")
         table = []
-        header = ['Board', 'ID', 'Counter']
+        header = ['Board', 'ID', 'Counter', 'Failures']
         for d in self.duts:
             if d.connected and d.platform in selected_platforms:
-                row = [d.platform, d.id, d.counter]
+                row = [d.platform, d.id, d.counter, d.failures]
                 table.append(row)
         print(tabulate(table, headers=header, tablefmt="github"))
 

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -354,7 +354,7 @@ class Pytest(Harness):
         self.source_dir = instance.testsuite.source_dir
         self.report_file = os.path.join(self.running_dir, 'report.xml')
         self.pytest_log_file_path = os.path.join(self.running_dir, 'twister_harness.log')
-        self.reserved_serial = None
+        self.reserved_dut = None
         self._output = []
 
     def pytest_run(self, timeout):
@@ -366,8 +366,8 @@ class Pytest(Harness):
             self.status = TwisterStatus.FAIL
             self.instance.reason = str(pytest_exception)
         finally:
-            if self.reserved_serial:
-                self.instance.handler.make_device_available(self.reserved_serial)
+            if self.reserved_dut:
+                self.instance.handler.make_dut_available(self.reserved_dut)
         self.instance.record(self.recording)
         self._update_test_status()
 
@@ -438,7 +438,7 @@ class Pytest(Harness):
         # update the instance with the device id to have it in the summary report
         self.instance.dut = hardware.id
 
-        self.reserved_serial = hardware.serial_pty or hardware.serial
+        self.reserved_dut = hardware
         if hardware.serial_pty:
             command.append(f'--device-serial-pty={hardware.serial_pty}')
         else:

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -366,10 +366,10 @@ class Pytest(Harness):
             self.status = TwisterStatus.FAIL
             self.instance.reason = str(pytest_exception)
         finally:
+            self.instance.record(self.recording)
+            self._update_test_status()
             if self.reserved_dut:
                 self.instance.handler.make_dut_available(self.reserved_dut)
-        self.instance.record(self.recording)
-        self._update_test_status()
 
     def generate_command(self):
         config = self.instance.testsuite.harness_config

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -738,12 +738,14 @@ TESTDATA_10 = [
                 fixtures=[],
                 platform='dummy_platform',
                 available=1,
+                counter_increment=mock.Mock(),
                 counter=0
             ),
             mock.Mock(
                 fixtures=['dummy fixture'],
                 platform='another_platform',
                 available=1,
+                counter_increment=mock.Mock(),
                 counter=0
             ),
             mock.Mock(
@@ -752,6 +754,7 @@ TESTDATA_10 = [
                 serial_pty=None,
                 serial=None,
                 available=1,
+                counter_increment=mock.Mock(),
                 counter=0
             ),
             mock.Mock(
@@ -759,6 +762,7 @@ TESTDATA_10 = [
                 platform='dummy_platform',
                 serial_pty=mock.Mock(),
                 available=1,
+                counter_increment=mock.Mock(),
                 counter=0
             )
         ],
@@ -778,24 +782,28 @@ TESTDATA_10 = [
                 fixtures=['dummy fixture'],
                 platform='dummy_platform',
                 serial_pty=mock.Mock(),
+                counter_increment=mock.Mock(),
                 available=0
             ),
             mock.Mock(
                 fixtures=['another fixture'],
                 platform='dummy_platform',
                 serial_pty=mock.Mock(),
+                counter_increment=mock.Mock(),
                 available=0
             ),
             mock.Mock(
                 fixtures=['dummy fixture'],
                 platform='dummy_platform',
                 serial=mock.Mock(),
+                counter_increment=mock.Mock(),
                 available=0
             ),
             mock.Mock(
                 fixtures=['another fixture'],
                 platform='dummy_platform',
                 serial=mock.Mock(),
+                counter_increment=mock.Mock(),
                 available=0
             )
         ],
@@ -826,7 +834,7 @@ def test_devicehandler_device_is_available(
 
         assert device == duts[expected]
         assert device.available == 0
-        assert device.counter == 1
+        device.counter_increment.assert_called_once()
     elif expected is None:
         device = handler.device_is_available(mocked_instance)
 

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -1189,6 +1189,7 @@ def test_devicehandler_create_serial_connection(
 
     dut = DUT()
     dut.available = 0
+    dut.failures = 0
 
     hardware_baud = 14400
     flash_timeout = 60
@@ -1203,11 +1204,13 @@ def test_devicehandler_create_serial_connection(
 
     if expected_result:
         assert result is not None
+        assert dut.failures == 0
 
     if expected_exception:
         assert handler.instance.status == TwisterStatus.FAIL
         assert handler.instance.reason == 'Serial Device Error'
         assert dut.available == 1
+        assert dut.failures == 1
         missing_mock.assert_called_once_with('blocked', 'Serial Device Error')
 
     if terminate_ser_pty_process:

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -738,6 +738,7 @@ TESTDATA_10 = [
                 fixtures=[],
                 platform='dummy_platform',
                 available=1,
+                failures=0,
                 counter_increment=mock.Mock(),
                 counter=0
             ),
@@ -745,6 +746,7 @@ TESTDATA_10 = [
                 fixtures=['dummy fixture'],
                 platform='another_platform',
                 available=1,
+                failures=0,
                 counter_increment=mock.Mock(),
                 counter=0
             ),
@@ -754,6 +756,7 @@ TESTDATA_10 = [
                 serial_pty=None,
                 serial=None,
                 available=1,
+                failures=0,
                 counter_increment=mock.Mock(),
                 counter=0
             ),
@@ -762,11 +765,72 @@ TESTDATA_10 = [
                 platform='dummy_platform',
                 serial_pty=mock.Mock(),
                 available=1,
+                failures=0,
+                counter_increment=mock.Mock(),
+                counter=0
+            ),
+            mock.Mock(
+                fixtures=['dummy fixture'],
+                platform='dummy_platform',
+                serial_pty=mock.Mock(),
+                available=1,
+                failures=0,
                 counter_increment=mock.Mock(),
                 counter=0
             )
         ],
         3
+    ),
+    (
+        'dummy_platform',
+        'dummy fixture',
+        [
+            mock.Mock(
+                fixtures=[],
+                platform='dummy_platform',
+                available=1,
+                failures=0,
+                counter_increment=mock.Mock(),
+                counter=0
+            ),
+            mock.Mock(
+                fixtures=['dummy fixture'],
+                platform='another_platform',
+                available=1,
+                failures=0,
+                counter_increment=mock.Mock(),
+                counter=0
+            ),
+            mock.Mock(
+                fixtures=['dummy fixture'],
+                platform='dummy_platform',
+                serial_pty=None,
+                serial=None,
+                available=1,
+                failures=0,
+                counter_increment=mock.Mock(),
+                counter=0
+            ),
+            mock.Mock(
+                fixtures=['dummy fixture'],
+                platform='dummy_platform',
+                serial_pty=mock.Mock(),
+                available=1,
+                failures=1,
+                counter_increment=mock.Mock(),
+                counter=0
+            ),
+            mock.Mock(
+                fixtures=['dummy fixture'],
+                platform='dummy_platform',
+                serial_pty=mock.Mock(),
+                available=1,
+                failures=0,
+                counter_increment=mock.Mock(),
+                counter=0
+            )
+        ],
+        4
     ),
     (
         'dummy_platform',
@@ -783,6 +847,7 @@ TESTDATA_10 = [
                 platform='dummy_platform',
                 serial_pty=mock.Mock(),
                 counter_increment=mock.Mock(),
+                failures=0,
                 available=0
             ),
             mock.Mock(
@@ -790,6 +855,7 @@ TESTDATA_10 = [
                 platform='dummy_platform',
                 serial_pty=mock.Mock(),
                 counter_increment=mock.Mock(),
+                failures=0,
                 available=0
             ),
             mock.Mock(
@@ -797,6 +863,7 @@ TESTDATA_10 = [
                 platform='dummy_platform',
                 serial=mock.Mock(),
                 counter_increment=mock.Mock(),
+                failures=0,
                 available=0
             ),
             mock.Mock(
@@ -804,6 +871,7 @@ TESTDATA_10 = [
                 platform='dummy_platform',
                 serial=mock.Mock(),
                 counter_increment=mock.Mock(),
+                failures=0,
                 available=0
             )
         ],
@@ -814,7 +882,9 @@ TESTDATA_10 = [
 @pytest.mark.parametrize(
     'platform_name, fixture, duts, expected',
     TESTDATA_10,
-    ids=['one good dut', 'exception - no duts', 'no available duts']
+    ids=['two good duts, select the first one',
+         'two duts, the first was failed once, select the second not failed',
+         'exception - no duts', 'no available duts']
 )
 def test_devicehandler_device_is_available(
     mocked_instance,

--- a/scripts/tests/twister/test_hardwaremap.py
+++ b/scripts/tests/twister/test_hardwaremap.py
@@ -213,10 +213,10 @@ def test_hardwaremap_summary(capfd, mocked_hm):
     expected = """
 Hardware distribution summary:
 
-| Board   |   ID |   Counter |
-|---------|------|-----------|
-| p1      |    1 |         0 |
-| p7      |    7 |         0 |
+| Board   |   ID |   Counter |   Failures |
+|---------|------|-----------|------------|
+| p1      |    1 |         0 |          0 |
+| p7      |    7 |         0 |          0 |
 """
 
     out, err = capfd.readouterr()


### PR DESCRIPTION
Several improvements and fixes for how Twister DeviceHandler selects and releases a DUT having multiple candidates for a test instance execution and taking into account failures.
See individual commits for details.