### PR TITLE
boards: frdm_rw612: Fix flash size

### DIFF
--- a/boards/nxp/frdm_rw612/frdm_rw612.dts
+++ b/boards/nxp/frdm_rw612/frdm_rw612.dts
@@ -60,7 +60,7 @@
 	w25q512jvfiq: w25q512jvfiq@0 {
 		compatible = "nxp,imx-flexspi-nor";
 		reg = <0>;
-		size = <(DT_SIZE_M(512) / 8)>;
+		size = <DT_SIZE_M(64 * 8)>;
 		status = "okay";
 		erase-block-size = <4096>;
 		write-block-size = <1>;


### PR DESCRIPTION
Flash size property is in bits, not bytes. The size of this flash is 512 Mbits, fix this mistake.