### PR TITLE
kernel: reduce `k_spin_unlock` calls using `if-else if-else` structure

### DIFF
--- a/kernel/obj_core.c
+++ b/kernel/obj_core.c
@@ -125,77 +125,65 @@ int k_obj_type_walk_unlocked(struct k_obj_type *type,
 int k_obj_core_stats_register(struct k_obj_core *obj_core, void *stats,
 			      size_t stats_len)
 {
-	k_spinlock_key_t  key = k_spin_lock(&lock);
+	int rv;
+	k_spinlock_key_t key = k_spin_lock(&lock);
 
 	if (obj_core->type->stats_desc == NULL) {
-
 		/* Object type not configured for statistics. */
-
-		k_spin_unlock(&lock, key);
-		return -ENOTSUP;
-	}
-
-	if (obj_core->type->stats_desc->raw_size != stats_len) {
-
+		rv = -ENOTSUP;
+	} else if (obj_core->type->stats_desc->raw_size != stats_len) {
 		/* Buffer size mismatch */
-
-		k_spin_unlock(&lock, key);
-		return -EINVAL;
+		rv = -EINVAL;
+	} else {
+		obj_core->stats = stats;
+		rv = 0;
 	}
 
-	obj_core->stats = stats;
 	k_spin_unlock(&lock, key);
 
-	return 0;
+	return rv;
 }
 
 int k_obj_core_stats_deregister(struct k_obj_core *obj_core)
 {
-	k_spinlock_key_t  key = k_spin_lock(&lock);
+	int rv;
+	k_spinlock_key_t key = k_spin_lock(&lock);
 
 	if (obj_core->type->stats_desc == NULL) {
-
 		/* Object type not configured  for statistics. */
-
-		k_spin_unlock(&lock, key);
-		return -ENOTSUP;
+		rv = -ENOTSUP;
+	} else {
+		obj_core->stats = NULL;
+		rv = 0;
 	}
 
-	obj_core->stats = NULL;
 	k_spin_unlock(&lock, key);
 
-	return 0;
+	return rv;
 }
 
 int k_obj_core_stats_raw(struct k_obj_core *obj_core, void *stats,
 			 size_t stats_len)
 {
-	int  rv;
+	int rv;
 	struct k_obj_core_stats_desc *desc;
 
-	k_spinlock_key_t  key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&lock);
 
 	desc = obj_core->type->stats_desc;
 	if ((desc == NULL) || (desc->raw == NULL)) {
-
 		/* The object type is not configured for this operation */
-
-		k_spin_unlock(&lock, key);
-		return -ENOTSUP;
-	}
-
-	if ((desc->raw_size != stats_len) || (obj_core->stats == NULL)) {
-
+		rv = -ENOTSUP;
+	} else if ((desc->raw_size != stats_len) || (obj_core->stats == NULL)) {
 		/*
 		 * Either the size of the stats buffer is wrong or
 		 * the kernel object was not registered for statistics.
 		 */
-
-		k_spin_unlock(&lock, key);
-		return -EINVAL;
+		rv = -EINVAL;
+	} else {
+		rv = desc->raw(obj_core, stats);
 	}
 
-	rv = desc->raw(obj_core, stats);
 	k_spin_unlock(&lock, key);
 
 	return rv;
@@ -204,32 +192,25 @@ int k_obj_core_stats_raw(struct k_obj_core *obj_core, void *stats,
 int k_obj_core_stats_query(struct k_obj_core *obj_core, void *stats,
 			   size_t stats_len)
 {
-	int  rv;
+	int rv;
 	struct k_obj_core_stats_desc *desc;
 
-	k_spinlock_key_t  key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&lock);
 
 	desc = obj_core->type->stats_desc;
 	if ((desc == NULL) || (desc->query == NULL)) {
-
 		/* The object type is not configured for this operation */
-
-		k_spin_unlock(&lock, key);
-		return -ENOTSUP;
-	}
-
-	if ((desc->query_size != stats_len) || (obj_core->stats == NULL)) {
-
+		rv = -ENOTSUP;
+	} else if ((desc->query_size != stats_len) || (obj_core->stats == NULL)) {
 		/*
 		 * Either the size of the stats buffer is wrong or
 		 * the kernel object was not registered for statistics.
 		 */
-
-		k_spin_unlock(&lock, key);
-		return -EINVAL;
+		rv = -EINVAL;
+	} else {
+		rv = desc->query(obj_core, stats);
 	}
 
-	rv = desc->query(obj_core, stats);
 	k_spin_unlock(&lock, key);
 
 	return rv;
@@ -237,29 +218,22 @@ int k_obj_core_stats_query(struct k_obj_core *obj_core, void *stats,
 
 int k_obj_core_stats_reset(struct k_obj_core *obj_core)
 {
-	int  rv;
+	int rv;
 	struct k_obj_core_stats_desc *desc;
 
 	k_spinlock_key_t  key = k_spin_lock(&lock);
 
 	desc = obj_core->type->stats_desc;
 	if ((desc == NULL) || (desc->reset == NULL)) {
-
 		/* The object type is not configured for this operation */
-
-		k_spin_unlock(&lock, key);
-		return -ENOTSUP;
-	}
-
-	if (obj_core->stats == NULL) {
-
+		rv = -ENOTSUP;
+	} else if (obj_core->stats == NULL) {
 		/* This kernel object is not configured for statistics */
-
-		k_spin_unlock(&lock, key);
-		return -EINVAL;
+		rv = -EINVAL;
+	} else {
+		rv = desc->reset(obj_core);
 	}
 
-	rv = desc->reset(obj_core);
 	k_spin_unlock(&lock, key);
 
 	return rv;
@@ -267,29 +241,22 @@ int k_obj_core_stats_reset(struct k_obj_core *obj_core)
 
 int k_obj_core_stats_disable(struct k_obj_core *obj_core)
 {
-	int  rv;
+	int rv;
 	struct k_obj_core_stats_desc *desc;
 
-	k_spinlock_key_t  key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&lock);
 
 	desc = obj_core->type->stats_desc;
 	if ((desc == NULL) || (desc->disable == NULL)) {
-
 		/* The object type is not configured for this operation */
-
-		k_spin_unlock(&lock, key);
-		return -ENOTSUP;
-	}
-
-	if (obj_core->stats == NULL) {
-
+		rv = -ENOTSUP;
+	} else if (obj_core->stats == NULL) {
 		/* This kernel object is not configured for statistics */
-
-		k_spin_unlock(&lock, key);
-		return -EINVAL;
+		rv = -EINVAL;
+	} else {
+		rv = desc->disable(obj_core);
 	}
 
-	rv = desc->disable(obj_core);
 	k_spin_unlock(&lock, key);
 
 	return rv;
@@ -297,29 +264,22 @@ int k_obj_core_stats_disable(struct k_obj_core *obj_core)
 
 int k_obj_core_stats_enable(struct k_obj_core *obj_core)
 {
-	int  rv;
+	int rv;
 	struct k_obj_core_stats_desc *desc;
 
-	k_spinlock_key_t  key = k_spin_lock(&lock);
+	k_spinlock_key_t key = k_spin_lock(&lock);
 
 	desc = obj_core->type->stats_desc;
 	if ((desc == NULL) || (desc->enable == NULL)) {
-
 		/* The object type is not configured for this operation */
-
-		k_spin_unlock(&lock, key);
-		return -ENOTSUP;
-	}
-
-	if (obj_core->stats == NULL) {
-
+		rv = -ENOTSUP;
+	} else if (obj_core->stats == NULL) {
 		/* This kernel object is not configured for statistics */
-
-		k_spin_unlock(&lock, key);
-		return -EINVAL;
+		rv = -EINVAL;
+	} else {
+		rv = desc->enable(obj_core);
 	}
 
-	rv = desc->enable(obj_core);
 	k_spin_unlock(&lock, key);
 
 	return rv;


### PR DESCRIPTION
Reduce `k_spin_unlock` calls in `k_obj_core_stats_xxx` functions by consolidating error handling into an `if-else if-else` structure and using a single return variable `rv`.