### PR TITLE
twister: Fix inconsistency among DT compat filters

### DIFF
--- a/scripts/pylib/twister/expr_parser.py
+++ b/scripts/pylib/twister/expr_parser.py
@@ -227,7 +227,7 @@ def ast_expr(ast, env, edt):
     elif ast[0] == "dt_compat_enabled":
         compat = ast[1][0]
         for node in edt.nodes:
-            if compat in node.compats and node.status == "okay":
+            if (node.matching_compat == compat or compat in node.compats) and node.status == "okay":
                 return True
         return False
     elif ast[0] == "dt_alias_exists":
@@ -247,7 +247,8 @@ def ast_expr(ast, env, edt):
             parent = node.parent
             if parent is None:
                 continue
-            if node.status == "okay" and alias in node.aliases and parent.matching_compat == compat:
+            if node.status == "okay" and alias in node.aliases and \
+                    (parent.matching_compat == compat or compat in parent.compats):
                 return True
         return False
     elif ast[0] == "dt_label_with_parent_compat_enabled":
@@ -258,7 +259,8 @@ def ast_expr(ast, env, edt):
             parent = node.parent
         else:
             return False
-        return parent is not None and parent.status == 'okay' and parent.matching_compat == compat
+        return parent is not None and parent.status == 'okay' and \
+            (parent.matching_compat == compat or compat in parent.compats)
     elif ast[0] == "dt_chosen_enabled":
         chosen = ast[1][0]
         node = edt.chosen_node(chosen)

--- a/scripts/pylib/twister/expr_parser.py
+++ b/scripts/pylib/twister/expr_parser.py
@@ -240,30 +240,16 @@ def ast_expr(ast, env, edt):
         # Checks if the DT has an enabled alias node whose parent has
         # a given compatible. For matching things like gpio-leds child
         # nodes, which do not have compatibles themselves.
-        #
-        # The legacy "dt_compat_enabled_with_alias" form is still
-        # accepted but is now deprecated and causes a warning. This is
-        # meant to give downstream users some time to notice and
-        # adjust. Its argument order only made sense under the (bad)
-        # assumption that the gpio-leds child node has the same compatible
 
         alias = ast[1][0]
         compat = ast[1][1]
-
-        return ast_handle_dt_enabled_alias_with_parent_compat(edt, alias,
-                                                              compat)
-    elif ast[0] == "dt_compat_enabled_with_alias":
-        compat = ast[1][0]
-        alias = ast[1][1]
-
-        _logger.warning('dt_compat_enabled_with_alias("%s", "%s"): '
-                        'this is deprecated, use '
-                        'dt_enabled_alias_with_parent_compat("%s", "%s") '
-                        'instead',
-                        compat, alias, alias, compat)
-
-        return ast_handle_dt_enabled_alias_with_parent_compat(edt, alias,
-                                                              compat)
+        for node in edt.nodes:
+            parent = node.parent
+            if parent is None:
+                continue
+            if node.status == "okay" and alias in node.aliases and parent.matching_compat == compat:
+                return True
+        return False
     elif ast[0] == "dt_label_with_parent_compat_enabled":
         compat = ast[1][1]
         label = ast[1][0]
@@ -285,20 +271,6 @@ def ast_expr(ast, env, edt):
         if node and node.status == "okay":
             return True
         return False
-
-def ast_handle_dt_enabled_alias_with_parent_compat(edt, alias, compat):
-    # Helper shared with the now deprecated
-    # dt_compat_enabled_with_alias version.
-
-    for node in edt.nodes:
-        parent = node.parent
-        if parent is None:
-            continue
-        if (node.status == "okay" and alias in node.aliases and
-                    parent.matching_compat == compat):
-            return True
-
-    return False
 
 mutex = threading.Lock()
 


### PR DESCRIPTION
This small change concerns the following filter functions:

   1. `dt_compat_enabled(C)`:
      There's a node with compatible `C` and status "okay".

   2. `dt_enabled_alias_with_parent_compat(A, C)`:
      There's a node with alias `A` and status "okay", and its parent
      has compatible `C`.

   3. `dt_label_with_parent_compat_enabled(L, C)`:
      There's a node with label `L`, and its parent has compatible `C` and status "okay".

All three functions involve checking whether some node or its parent has a given compatible, but the way this has been checked is inconsistent. Function (1) has done it with this Python conditional:

```py
   compat in node.compats
```

while (2) and (3) have used:

```py
   parent.matching_compat == compat
```

The first check works well with nodes that have multiple compatibles, and it is more aligned with the notion of "has_compat" as seen in the devicetree macros for C, CMake, and Kconfig.

Arguably, `matching_compat` shouldn't have been used here, because it is actually a property of a node's binding, moreso than of the node itself. In practice, it's usually equal to the first compatible for which edtlib has found a binding, which at first glance is just more constrained than the `node.compats` check. However, there also exist obscure cases where the `node.compats` are empty, while the `node.matching_compat` is not.

For now, the three functions can use a combined check, to improve consistency and utility while avoiding breakage:

```py
   node.matching_compat == compat or compat in node.compats
```
