### PR TITLE
Drivers: Fuel_Gauge: MAX17048: added units to fuel_gauge sample output and Output of voltage is now shown in microVolts

### DIFF
--- a/drivers/fuel_gauge/max17048/max17048.c
+++ b/drivers/fuel_gauge/max17048/max17048.c
@@ -31,7 +31,7 @@ LOG_MODULE_REGISTER(MAX17048);
 struct max17048_data {
 	/* Charge as percentage */
 	uint8_t charge;
-	/* Voltage as mV */
+ 	/* Voltage as uV */
 	uint32_t voltage;
 
 	/* Time in minutes */

--- a/drivers/fuel_gauge/max17048/max17048.c
+++ b/drivers/fuel_gauge/max17048/max17048.c
@@ -32,7 +32,7 @@ struct max17048_data {
 	/* Charge as percentage */
 	uint8_t charge;
 	/* Voltage as mV */
-	uint16_t voltage;
+	uint32_t voltage;
 
 	/* Time in minutes */
 	uint16_t time_to_full;
@@ -72,9 +72,10 @@ int max17048_adc(const struct device *i2c_dev, uint16_t *response)
 /**
  * Battery voltage
  */
-int max17048_voltage(const struct device *i2c_dev, uint16_t *response)
+int max17048_voltage(const struct device *i2c_dev, uint32_t *response)
 {
-	int rc = max17048_adc(i2c_dev, response);
+    	uint16_t raw_voltage;
+    	int rc = max17048_adc(i2c_dev, &raw_voltage);
 
 	if (rc < 0) {
 		return rc;
@@ -85,12 +86,10 @@ int max17048_voltage(const struct device *i2c_dev, uint16_t *response)
 	 * MAX17048-MAX17049.pdf
 	 * Page 10, Table 2. Register Summary: 78.125µV/cell
 	 * Max17048 only supports one cell so we just have to multiply the value by 78.125 to
-	 * obtain µV and then divide the value to obtain V.
-	 * But to avoid floats, instead of using 78.125 we will use 78125 and use this value as
-	 * milli volts instead of volts.
+	 * obtain µV
 	 */
 
-	*response = (uint16_t)((uint32_t)*response * 78125L / 1000000L);
+	*response = (uint32_t)raw_voltage * 78.125;
 	return 0;
 }
 
@@ -120,7 +119,7 @@ int max17048_percent(const struct device *i2c_dev, uint8_t *response)
  * Percentage of the total battery capacity per hour, positive is charging or
  * negative if discharging
  */
-int max17048_crate(const struct device *i2c_dev, int16_t *response)
+int max17048_crate(const struct device *i2c_dev, uint16_t *response)
 {
 	int rc = max17048_read_register(i2c_dev, REGISTER_CRATE, response);
 

--- a/drivers/fuel_gauge/max17048/max17048.c
+++ b/drivers/fuel_gauge/max17048/max17048.c
@@ -74,8 +74,8 @@ int max17048_adc(const struct device *i2c_dev, uint16_t *response)
  */
 int max17048_voltage(const struct device *i2c_dev, uint32_t *response)
 {
-    	uint16_t raw_voltage;
-    	int rc = max17048_adc(i2c_dev, &raw_voltage);
+	uint16_t raw_voltage;
+	int rc = max17048_adc(i2c_dev, &raw_voltage);
 
 	if (rc < 0) {
 		return rc;

--- a/samples/fuel_gauge/max17048/src/main.c
+++ b/samples/fuel_gauge/max17048/src/main.c
@@ -52,13 +52,13 @@ int main(void)
 		if (ret < 0) {
 			printk("Error: cannot get properties\n");
 		} else {
-			printk("Time to empty %d\n", vals[0].runtime_to_empty);
+			printk("Time to empty %d minutes\n", vals[0].runtime_to_empty);
 
-			printk("Time to full %d\n", vals[1].runtime_to_full);
+			printk("Time to full %d minutes\n", vals[1].runtime_to_full);
 
 			printk("Charge %d%%\n", vals[2].relative_state_of_charge);
 
-			printk("Voltage %d\n", vals[3].voltage);
+			printk("Voltage %d uV\n", vals[3].voltage);
 		}
 
 		k_sleep(K_MSEC(5000));


### PR DESCRIPTION
previously sample output was without any units
The voltage parameter was supposed to give output in microvolts
actual output was in millivolts
made changes to provide output in microvolts.