### PR TITLE
arch: riscv: stacktrace: fix user thread stack bound check

### DIFF
--- a/arch/riscv/core/stacktrace.c
+++ b/arch/riscv/core/stacktrace.c
@@ -58,12 +58,12 @@ static inline bool in_user_thread_stack_bound(uintptr_t addr, const struct k_thr
 
 	/* See: zephyr/include/zephyr/arch/riscv/arch.h */
 	if (IS_ENABLED(CONFIG_PMP_POWER_OF_TWO_ALIGNMENT)) {
-		start = thread->arch.priv_stack_start - CONFIG_PRIVILEGED_STACK_SIZE;
-		end = thread->arch.priv_stack_start;
+		start = thread->arch.priv_stack_start + Z_RISCV_STACK_GUARD_SIZE;
 	} else {
 		start = thread->stack_info.start - CONFIG_PRIVILEGED_STACK_SIZE;
-		end = thread->stack_info.start;
 	}
+	end = Z_STACK_PTR_ALIGN(thread->arch.priv_stack_start + K_KERNEL_STACK_RESERVED +
+				CONFIG_PRIVILEGED_STACK_SIZE);
 
 	return (addr >= start) && (addr < end);
 }


### PR DESCRIPTION
According to the riscv's `arch.h`:

```
 +------------+ <- thread.arch.priv_stack_start
 | Guard      | } Z_RISCV_STACK_GUARD_SIZE
 +------------+
 | Priv Stack | } CONFIG_PRIVILEGED_STACK_SIZE
 +------------+ <- thread.arch.priv_stack_start +
                   CONFIG_PRIVILEGED_STACK_SIZE +
                   Z_RISCV_STACK_GUARD_SIZE
```

The start of the privilege stack should be:

  `thread.arch.priv_stack_start + Z_RISCV_STACK_GUARD_SIZE`

Instead of

  `thread.arch.priv_stack_start - CONFIG_PRIVILEGED_STACK_SIZE`

For the `end`, use the same equation of `top_of_priv_stack` in the `arch_user_mode_enter()`