### PR TITLE
native/posix arch: Add option to force 64bit time_t with glibc

### DIFF
--- a/arch/posix/CMakeLists.txt
+++ b/arch/posix/CMakeLists.txt
@@ -64,7 +64,14 @@ else() # Linux.x86_64
     check_set_compiler_property(APPEND PROPERTY fpsse2 "SHELL:-msse2 -mfpmath=sse")
     zephyr_compile_options($<TARGET_PROPERTY:compiler,fpsse2>)
     target_compile_options(native_simulator INTERFACE "$<TARGET_PROPERTY:compiler,fpsse2>")
-  endif ()
+
+    # Let's request from the host C library (glibc) that time_t be a 64bit type for x86 32bit builds
+    # so we avoid the year 2038 issue.
+    # https://sourceware.org/glibc/wiki/Y2038ProofnessDesign
+    if (CONFIG_ARCH_POSIX_FORCE_64BIT_TIME_T AND CONFIG_EXTERNAL_LIBC)
+      zephyr_compile_options(-D_TIME_BITS=64 -D_FILE_OFFSET_BITS=64)
+    endif()
+  endif()
 endif()
 
 zephyr_compile_options(

--- a/arch/posix/Kconfig
+++ b/arch/posix/Kconfig
@@ -41,6 +41,23 @@ config ARCH_POSIX_TRAP_ON_FATAL
 	  Raise a SIGTRAP signal on fatal error before exiting.
 	  This automatically suspends the target if a debugger is attached.
 
+config ARCH_POSIX_FORCE_64BIT_TIME_T
+	bool "Set _TIME_BITS=64"
+	help
+	  This is a workaround option which will force the host glibc to use the 64bit time_t API
+	  also when building the 32bit variant for x86.
+	  Enabling this option avoids the Y2038 issue.
+	  Note only the embedded code time_t is forced to be 64bits.
+	  Note this would cause trouble if linking from the embedded side into another pre-compiled
+	  library whose interface uses a 32bit time_t.
+	  When this option is set you must *not* link to another library in the host side in which the
+	  embedded code directly calls any API which uses time_t or a derived type, when that host library
+	  has been built with the default time_t size of 32bits. This includes code which may be built
+	  with the native_simulator runner, and libraries provided by your OS distribution.
+	  Note glibc supports _TIME_BITS since glibc 2.34. Earlier version will just ignore this.
+	  This option is only relevant when building with CONFIG_EXTERNAL_LIBC and not setting
+	  CONFIG_64BIT.
+
 rsource "Kconfig.natsim_optional"
 
 endmenu


### PR DESCRIPTION
Add an option to allow forcing the 64 bit time_t API implementation
from glibc ( https://sourceware.org/glibc/wiki/Y2038ProofnessDesign )
by explicitly defining _TIME_BITS=64

_TIME_BITS support was added in glibc 2.34 but it should, hopefully,
be safe to set it even if glibc does not support it as it should just
be ignored.

Note that as this changes the time_t definition, linking to other
precompiled libraries whose ABI uses a time_t of 32bits would cause
trouble.
For those, the users would need to either recompile that libray with the
same _TIME_BITS=64 or leave CONFIG_ARCH_POSIX_FORCE_64BIT_TIME_T=n.

Relates to #90029
See https://github.com/zephyrproject-rtos/zephyr/issues/90029#issuecomment-3012377380 for the motivation for this change, as well as for why this PR was kept on draft for ~1year.