### PR TITLE
net: ethernet: check vlan iface existence

### DIFF
--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -284,6 +284,13 @@ static enum net_verdict ethernet_recv(struct net_if *iface,
 					  net_eth_get_vlan_iface(iface,
 						       net_pkt_vlan_tag(pkt)));
 
+			/* If we receive a packet with a VLAN tag, for that we don't
+			 * have a VLAN interface, drop the packet.
+			 */
+			if (net_if_l2(net_pkt_iface(pkt)) == NULL) {
+				goto drop;
+			}
+
 			/* We could call VLAN interface directly but then the
 			 * interface statistics would not get updated so route
 			 * the call via Virtual L2 layer.


### PR DESCRIPTION
Drop a packet, if it has a VLAN tag, for
that we don't have a VLAN interface.

In line 284 `net_eth_get_vlan_iface(iface, net_pkt_vlan_tag(pkt))` can be `NULL` if we don't have a matching vlan interface for a received packet. Without my fix this would lead to a fatal error in line 298, as this `net_if_l2(net_pkt_iface(pkt))->recv` would be illegal.