### PR TITLE
drivers: flash: spi_nor: Print flash size properly when < 1 MiByte

### DIFF
--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -1097,7 +1097,10 @@ static int spi_nor_process_bfp(const struct device *dev,
 	struct jesd216_erase_type *etp = data->erase_types;
 	const size_t flash_size = jesd216_bfp_density(bfp) / 8U;
 
-	LOG_INF("%s: %u MiBy flash", dev->name, (uint32_t)(flash_size >> 20));
+	LOG_INF("%s: %u %ciBy flash", dev->name,
+		(flash_size < (1024U * 1024U)) ? (uint32_t)(flash_size >> 10)
+					       : (uint32_t)(flash_size >> 20),
+		(flash_size < (1024U * 1024U)) ? 'k' : 'M');
 
 	/* Copy over the erase types, preserving their order.  (The
 	 * Sector Map Parameter table references them by index.)


### PR DESCRIPTION
When using SPI-NOR SFDP autodeteection, the flash size printed to the log is rounded to 1 MiByte. If flash is smaller than 1 MiByte it is printed as 0 MiByte.

With this patch smaller flash sizes are printed in kiByte, for instance 512 kiByte is printed correctly.