### PR TITLE
Bluetooth: BAP: Add PAST Kconfig dependency for BASS

### DIFF
--- a/subsys/bluetooth/audio/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/bap_broadcast_assistant.c
@@ -37,6 +37,7 @@
 #include <zephyr/sys/check.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
 #include <zephyr/types.h>
 
 #include <zephyr/logging/log.h>
@@ -182,13 +183,17 @@ static bool past_available(const struct bt_conn *conn,
 			   const bt_addr_le_t *adv_addr,
 			   uint8_t sid)
 {
-	LOG_DBG("%p remote %s PAST, local %s PAST", (void *)conn,
-		BT_FEAT_LE_PAST_RECV(conn->le.features) ? "supports" : "does not support",
-		BT_FEAT_LE_PAST_SEND(bt_dev.le.features) ? "supports" : "does not support");
+	if (IS_ENABLED(CONFIG_BT_PER_ADV_SYNC_TRANSFER_SENDER)) {
+		LOG_DBG("%p remote %s PAST, local %s PAST", (void *)conn,
+			BT_FEAT_LE_PAST_RECV(conn->le.features) ? "supports" : "does not support",
+			BT_FEAT_LE_PAST_SEND(bt_dev.le.features) ? "supports" : "does not support");
 
-	return BT_FEAT_LE_PAST_RECV(conn->le.features) &&
-	       BT_FEAT_LE_PAST_SEND(bt_dev.le.features) &&
-	       bt_le_per_adv_sync_lookup_addr(adv_addr, sid) != NULL;
+		return BT_FEAT_LE_PAST_RECV(conn->le.features) &&
+		       BT_FEAT_LE_PAST_SEND(bt_dev.le.features) &&
+		       bt_le_per_adv_sync_lookup_addr(adv_addr, sid) != NULL;
+	} else {
+		return false;
+	}
 }
 
 static int parse_recv_state(const void *data, uint16_t length,

--- a/subsys/bluetooth/audio/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/bap_scan_delegator.c
@@ -36,6 +36,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/check.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
 
 LOG_MODULE_REGISTER(bt_bap_scan_delegator, CONFIG_BT_BAP_SCAN_DELEGATOR_LOG_LEVEL);
 
@@ -457,14 +458,18 @@ static struct bt_le_per_adv_sync_cb pa_sync_cb =  {
 
 static bool supports_past(struct bt_conn *conn, uint8_t pa_sync_val)
 {
-	LOG_DBG("%p remote %s PAST, local %s PAST (req %u)", (void *)conn,
-		BT_FEAT_LE_PAST_SEND(conn->le.features) ? "supports" : "does not support",
-		BT_FEAT_LE_PAST_RECV(bt_dev.le.features) ? "supports" : "does not support",
-		pa_sync_val);
+	if (IS_ENABLED(CONFIG_BT_PER_ADV_SYNC_TRANSFER_RECEIVER)) {
+		LOG_DBG("%p remote %s PAST, local %s PAST (req %u)", (void *)conn,
+			BT_FEAT_LE_PAST_SEND(conn->le.features) ? "supports" : "does not support",
+			BT_FEAT_LE_PAST_RECV(bt_dev.le.features) ? "supports" : "does not support",
+			pa_sync_val);
 
-	return pa_sync_val == BT_BAP_BASS_PA_REQ_SYNC_PAST &&
-	       BT_FEAT_LE_PAST_SEND(conn->le.features) &&
-	       BT_FEAT_LE_PAST_RECV(bt_dev.le.features);
+		return pa_sync_val == BT_BAP_BASS_PA_REQ_SYNC_PAST &&
+		       BT_FEAT_LE_PAST_SEND(conn->le.features) &&
+		       BT_FEAT_LE_PAST_RECV(bt_dev.le.features);
+	} else {
+		return false;
+	}
 }
 
 static int pa_sync_request(struct bt_conn *conn,


### PR DESCRIPTION
The broadcast assistant will only be able to send
BT_BAP_BASS_PA_REQ_SYNC_PAST if
CONFIG_BT_PER_ADV_SYNC_TRANSFER_SENDER is enabled.

Similarly the scan delegator will only set
past_supported = true if
CONFIG_BT_PER_ADV_SYNC_TRANSFER_RECEIVER is enabled.