### PR TITLE
driver: interrupt_controller: nuclei_eclic: fixed interrupt level and CLIC enable

### DIFF
--- a/drivers/interrupt_controller/Kconfig.clic
+++ b/drivers/interrupt_controller/Kconfig.clic
@@ -5,7 +5,6 @@ config NUCLEI_ECLIC
 	bool "Enhanced Core Local Interrupt Controller (ECLIC)"
 	default y
 	depends on DT_HAS_NUCLEI_ECLIC_ENABLED
-	select MULTI_LEVEL_INTERRUPTS
 	select RISCV_SOC_HAS_CUSTOM_IRQ_HANDLING if !RISCV_VECTORED_MODE
 	help
 	  Interrupt controller for Nuclei SoC core.

--- a/drivers/interrupt_controller/intc_nuclei_eclic.c
+++ b/drivers/interrupt_controller/intc_nuclei_eclic.c
@@ -83,9 +83,6 @@ struct CLICCTRL {
 	volatile uint8_t INTCTRL;
 };
 
-/** ECLIC Mode mask for MTVT CSR Register */
-#define ECLIC_MODE_MTVEC_Msk   3U
-
 /** CLIC INTATTR: TRIG Mask */
 #define CLIC_INTATTR_TRIG_Msk  0x3U
 
@@ -177,8 +174,6 @@ static int nuclei_eclic_init(const struct device *dev)
 	for (int i = 0; i < ECLIC_CTRL_SIZE; i++) {
 		ECLIC_CTRL[i] = (struct CLICCTRL) { 0 };
 	}
-
-	csr_write(mtvec, ((csr_read(mtvec) & 0xFFFFFFC0) | ECLIC_MODE_MTVEC_Msk));
 
 	nlbits = ECLIC_CFG.b.nlbits;
 	intctlbits = ECLIC_INFO.b.intctlbits;

--- a/soc/gd/gd32/gd32vf103/Kconfig.defconfig.gd32vf103
+++ b/soc/gd/gd32/gd32vf103/Kconfig.defconfig.gd32vf103
@@ -24,9 +24,6 @@ config NUM_IRQS
 	default 87 if  NUCLEI_ECLIC
 	default 16 if !NUCLEI_ECLIC
 
-config 2ND_LEVEL_INTERRUPTS
-	default y
-
 config ARCH_IRQ_VECTOR_TABLE_ALIGN
 	default 512 if NUCLEI_ECLIC
 


### PR DESCRIPTION
This PR fixes two issues in the Nuclei CLIC driver:

1. Incorrect CLIC interrupt level configuration:
The CLIC interrupt level controls preemption between IRQs, while multi-level interrupts in Zephyr are for nested controllers. Removed the incorrect setting of the CLIC interrupt level.

2. Redundant CLIC mode enable:
The RISC-V CLIC enable is already handled in [vector.S](https://github.com/zephyrproject-rtos/zephyr/blob/dcfc3e7872542038abc51da7d6a468ac76e71613/soc/common/riscv-privileged/vector.S#L46C1-L47C1) in the RISC-V common code. Removed the redundant CLIC mode enable.