### PR TITLE
soc: nordic: common: dmm: fix region alignment getter

### DIFF
--- a/soc/nordic/common/dmm.c
+++ b/soc/nordic/common/dmm.c
@@ -23,7 +23,7 @@
 	{.dt_addr = DT_REG_ADDR(node_id),                                                          \
 	 .dt_size = DT_REG_SIZE(node_id),                                                          \
 	 .dt_attr = DT_PROP(node_id, zephyr_memory_attr),                                          \
-	 .dt_align = DMM_ALIGN_SIZE(node_id),                                                      \
+	 .dt_align = DMM_REG_ALIGN_SIZE(node_id),                                                  \
 	 .dt_allc = &_BUILD_LINKER_END_VAR(node_id)},
 
 /* Generate declarations of linker variables used to determine size of preallocated variables

--- a/tests/boards/nrf/dmm/src/main.c
+++ b/tests/boards/nrf/dmm/src/main.c
@@ -23,6 +23,11 @@
 	COND_CODE_1(DT_NODE_HAS_PROP(node_id, memory_regions),	\
 		    (DT_REG_SIZE(DT_PHANDLE(node_id, memory_regions))), (0))
 
+#if CONFIG_DCACHE
+BUILD_ASSERT(DMM_ALIGN_SIZE(DUT_CACHE) == CONFIG_DCACHE_LINE_SIZE);
+BUILD_ASSERT(DMM_ALIGN_SIZE(DUT_NOCACHE) == 1);
+#endif
+
 struct dmm_test_region {
 	void *mem_reg;
 	uintptr_t start;


### PR DESCRIPTION
Getting the required alignment size for memory region node and device node needs to be handled by a separate macro. Otherwise alignment of single byte is reported for any region. Add a test that checks for this particular issue.

Fixes #75431