### PR TITLE
tests: drivers: pwm: extend test coverage

### DIFF
--- a/tests/drivers/pwm/pwm_api/src/test_pwm.c
+++ b/tests/drivers/pwm/pwm_api/src/test_pwm.c
@@ -80,6 +80,7 @@
 #define DEFAULT_PWM_PORT 2 /* PWM on EXT2 connector, pin 8 */
 #elif defined CONFIG_PWM_NRFX
 #define DEFAULT_PWM_PORT 0
+#define INVALID_PWM_PORT 9
 #elif defined CONFIG_BOARD_ADAFRUIT_ITSYBITSY_M4_EXPRESS
 #define DEFAULT_PWM_PORT 2 /* TCC1/WO[2] on PA18 (D7) */
 #elif defined CONFIG_BOARD_MIMXRT685_EVK
@@ -174,3 +175,20 @@ ZTEST_USER(pwm_basic, test_pwm_cycle)
 				0, UNIT_CYCLES) == TC_PASS, NULL);
 	k_sleep(K_MSEC(1000));
 }
+
+#if defined INVALID_PWM_PORT
+ZTEST_USER(pwm_basic, test_pwm_invalid_port)
+{
+	const struct device *pwm_dev = get_pwm_device();
+
+	TC_PRINT("[PWM]: %" PRIu8 ", [period]: %" PRIu32 ", [pulse]: %" PRIu32 "\n",
+		INVALID_PWM_PORT, DEFAULT_PERIOD_CYCLE, DEFAULT_PULSE_CYCLE);
+
+	zassert_true(device_is_ready(pwm_dev), "PWM device is not ready");
+
+	zassert_equal(pwm_set_cycles(pwm_dev, INVALID_PWM_PORT, DEFAULT_PERIOD_CYCLE,
+				     DEFAULT_PULSE_CYCLE, 0),
+		      -EINVAL, "Invalid PWM port\n");
+
+}
+#endif


### PR DESCRIPTION
Extend nrf pwm driver test coverage by testing invalid port number