### PR TITLE
kernel: fatal: Fix NO_OPTIMIZATIONS build (logging + no multithreading)

### DIFF
--- a/kernel/fatal.c
+++ b/kernel/fatal.c
@@ -110,8 +110,9 @@ void z_fatal_error(unsigned int reason, const struct arch_esf *esf)
 	}
 #endif /* CONFIG_ARCH_HAS_NESTED_EXCEPTION_DETECTION */
 
-	LOG_ERR("Current thread: %p (%s)", thread,
-		thread_name_get(thread));
+	if (IS_ENABLED(CONFIG_MULTITHREADING)) {
+		LOG_ERR("Current thread: %p (%s)", thread, thread_name_get(thread));
+	}
 
 	coredump(reason, esf, thread);
 


### PR DESCRIPTION
When logging is on and optimization and multithreading is off then build fails to link because unoptimized compiler/linker seems to not look beyond the function and it fails trying to link `k_thread_name_get`. Reworking the code to make it known to the compiler without optimization that k_thread_name_get is not needed and not logging current thread name in that case.

#74395 is needed as well to compile logging and no_multithreading without optimization.

Note that even then it compiles code stuck during the initialization (#75586).