### PR TITLE
arch: riscv: allow RISCV_ALWAYS_SWITCH_THROUGH_ECALL use PMP and FPU sharing

### DIFF
--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -398,6 +398,22 @@ is_kernel_syscall:
 	bne t0, t1, skip_schedule
 	lr a0, __struct_arch_esf_a0_OFFSET(sp)
 	lr a1, __struct_arch_esf_a1_OFFSET(sp)
+
+#ifdef CONFIG_FPU_SHARING
+	/*
+	 * When an ECALL is used for a context-switch, the current thread has
+	 * been updated to the next thread.
+	 * Add the exception_depth back to the previous thread.
+	 */
+	lb t1, _thread_offset_to_exception_depth(a0)
+	add t1, t1, -1
+	sb t1, _thread_offset_to_exception_depth(a0)
+
+	lb t1, _thread_offset_to_exception_depth(a1)
+	add t1, t1, 1
+	sb t1, _thread_offset_to_exception_depth(a1)
+#endif
+
 	j reschedule
 skip_schedule:
 #endif


### PR DESCRIPTION
When `CONFIG_RISCV_ALWAYS_SWITCH_THROUGH_ECALL` is enabled, `CONFIG_RISCV_PMP` is filtered out and `CONFIG_FPU_SHARING` calculates `exception_depth` incorrectly.

1. For `CONFIG_RISCV_PMP`, delay the PMP enable until the next thread's PMP configuration is ready. 
This prevents Ecall switching from triggering PMP errors due to inappropriate PMP configuration when Ecall switching is called from the first context switch (thread configuration is not ready) or stack overflow handler (wrong configuration from the previous thread).

2. For `CONFIG_FPU_SHARING`, increment the `exception_depth` back to the previous thread because the current thread has been updated to the next thread before Ecall switching.
This ensures compatibility with the FPU `exception_depth` mechanism when `CONFIG_RISCV_ALWAYS_SWITCH_THROUGH_ECALL=n`.
