### PR TITLE
drivers: ethernet: nxp_enet: Fused MAC address fixes

### DIFF
--- a/drivers/ethernet/nxp_enet/eth_nxp_enet.c
+++ b/drivers/ethernet/nxp_enet/eth_nxp_enet.c
@@ -641,20 +641,25 @@ static inline void nxp_enet_fused_mac(uint8_t *mac_addr)
 #ifdef CONFIG_SOC_FAMILY_NXP_IMXRT
 	uint32_t mac_addr_fuse[2] = {0};
 
-	OCOTP_ReadFuseShadowRegisterExt((OCOTP_Type *)OCOTP_BASE,
 #if defined(CONFIG_SOC_SERIES_IMXRT10XX)
-		0x620,
+	OCOTP_Init((OCOTP_Type *)OCOTP_BASE, CLOCK_GetIpgFreq());
+	/* OTP bank 4, word 2: MAC0 */
+	OCOTP_ReadFuseShadowRegisterExt((OCOTP_Type *)OCOTP_BASE,
+		0x22, &mac_addr_fuse[0], 1);
+	/* OTP bank 4, word 3: MAC1*/
+	OCOTP_ReadFuseShadowRegisterExt((OCOTP_Type *)OCOTP_BASE,
+		0x23, &mac_addr_fuse[1], 1);
 #elif defined(CONFIG_SOC_SERIES_IMXRT11XX)
-		0xA90,
+	OCOTP_Init((OCOTP_Type *)OCOTP_BASE, 0);
+	OCOTP_ReadFuseShadowRegisterExt((OCOTP_Type *)OCOTP_BASE,
+		0x28, &mac_addr_fuse[0], 2);
 #endif
-		mac_addr_fuse, 2);
-
 	mac_addr[0] = mac_addr_fuse[0] & 0x000000FF;
-	mac_addr[1] = mac_addr_fuse[0] & 0x0000FF00;
-	mac_addr[2] = mac_addr_fuse[0] & 0x00FF0000;
-	mac_addr[3] = mac_addr_fuse[0] & 0xFF000000;
-	mac_addr[4] = mac_addr_fuse[1] & 0x00FF;
-	mac_addr[5] = mac_addr_fuse[1] & 0xFF00;
+	mac_addr[1] = (mac_addr_fuse[0] & 0x0000FF00) >> 8;
+	mac_addr[2] = (mac_addr_fuse[0] & 0x00FF0000) >> 16;
+	mac_addr[3] = (mac_addr_fuse[0] & 0xFF000000) >> 24;
+	mac_addr[4] = (mac_addr_fuse[1] & 0x00FF);
+	mac_addr[5] = (mac_addr_fuse[1] & 0xFF00) >> 8;
 #else
 	ARG_UNUSED(mac_addr);
 #endif


### PR DESCRIPTION
Add required initialisation of OCOTP.

The IMXRT10XX variants don't support fuseWords to be greater than 1.

Fill in mac_addr buffer correctly.

I derived the MAC0 fuse map address from the datasheet, MCUXpresso Secure Provisioning Tool and a sample of the RT1064.

In the datasheet is mentioned: 
![image](https://github.com/zephyrproject-rtos/zephyr/assets/32935830/2b4a39a6-e886-4b59-8cda-f1b5b98bf50c)

In the MCUXpresso Secure Provisioning Tool is mentioned: 
![image](https://github.com/zephyrproject-rtos/zephyr/assets/32935830/b0169958-2759-4688-ada2-91917ee5422c)

In a sample is mentioned:
https://github.com/JayHeng/imxrt-level2-boot/blob/master/boards/evkmimxrt1060/driver_examples/ocotp/ocotp_example.c#L28

I am not able to test it, but the MCUXpresso Secure Provisioning Tool mentions for the RT1176 that the fuse map address of MAC1 is 40 (0x28).
![image](https://github.com/zephyrproject-rtos/zephyr/assets/32935830/97d941d4-ada6-440f-81a9-75dfb2462c1c)
