### PR TITLE
pytest: add "--skip-flash" option

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/device_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/device_adapter.py
@@ -78,7 +78,10 @@ class DeviceAdapter(abc.ABC):
         self._device_run.set()
         self._start_reader_thread()
 
-        if self.device_config.flash_before:
+        if self.device_config.skip_flash:
+            logger.info('Skip flashing')
+            self.connect()
+        elif self.device_config.flash_before:
             # For hardware devices with shared USB or software USB, connect after flashing.
             # Retry for up to 10 seconds for USB-CDC based devices to enumerate.
             self._flash_and_run()

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
@@ -121,6 +121,12 @@ def pytest_addoption(parser: pytest.Parser):
         '--twister-fixture', action='append', dest='fixtures', metavar='FIXTURE', default=[],
         help='Twister fixture supported by this platform. May be given multiple times.'
     )
+    twister_harness_group.addoption(
+        '--skip-flash',
+        default=False,
+        help='Skip flashing.',
+        action='store_true',
+    )
 
 
 def pytest_configure(config: pytest.Config):

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/twister_harness_config.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/twister_harness_config.py
@@ -35,6 +35,7 @@ class DeviceConfig:
     post_flash_script: Path | None = None
     fixtures: list[str] = None
     app_build_dir: Path | None = None
+    skip_flash: bool = False
 
     def __post_init__(self):
         domains = self.build_dir / 'domains.yaml'
@@ -79,6 +80,7 @@ class TwisterHarnessConfig:
             post_script=_cast_to_path(config.option.post_script),
             post_flash_script=_cast_to_path(config.option.post_flash_script),
             fixtures=config.option.fixtures,
+            skip_flash=config.option.skip_flash,
         )
 
         devices.append(device_from_cli)


### PR DESCRIPTION
The pytest is always trying to flash when running on real HW (--device-type=hardware). 

On ARM64 Cortex-A platform like RPI5 there no way to implement flashing through pytest framework now: the Zephyr binary has to be stored on SD-card and loaded by bootloader (especially if no HW debugger available).

This PR adds "--skip-flash" option which still will allow to run pytest with shell interface manually, after platform is booted and shell is ready.

The related Discord discussion is [1].

With this feature the below test sequence become possible with ARM64 (in my case RPI5 platform):
- boot RPI5 with Zephyr application which have SHELL interface enabled;
- close tty, for example "/dev/ttyACM0"
- enable access to tty "sudo chmod a+rw dev/ttyACM0" (if needed)
- Setup Zephyr environment
- go to Zephyr application folder
- run pytest

Run pytest example:
```
cd <Zephyr proj>
source zephyr-env.sh
export PYTHONPATH=${ZEPHYR_BASE}/scripts/pylib/pytest-twister-harness/src:${PYTHONPATH}

cd <Zephyr application>
pytest --twister-harness --device-type=hardware \
    --device-serial=/dev/ttyACM0 \
    --build-dir=../build/rpi_5/zephyr-dom0-xt \
    -p twister_harness.plugin --log-level=DEBUG --log-cli-level=DEBUG
```

**Note.** pytest may not always detect SHELL cmd line, so just run
`echo aa > /dev/ttyACM0`
from another terminal while pytest is running and waiting for cmd line.

The Zephyr application which uses this feature can be found in [2] and pytest tests commit [3].

[1] https://discord.com/channels/720317445772017664/1233080559866089493/1239579773613899817
[2] https://github.com/xen-troops/zephyr-dom0-xt/tree/rpi5_dom0_dev
[3] https://github.com/xen-troops/zephyr-dom0-xt/commit/9a98afb17b6a23eed23f59403f2d6d64e2c9e68e