### PR TITLE
Bluetooth: Shell: Fix native shell build

### DIFF
--- a/tests/bluetooth/shell/snippets/xterm-native-shell/xterm-native-shell.overlay
+++ b/tests/bluetooth/shell/snippets/xterm-native-shell/xterm-native-shell.overlay
@@ -14,6 +14,11 @@
 	/delete-property/ pinctrl-0;
 	/delete-property/ pinctrl-1;
 	/delete-property/ pinctrl-names;
+
+	bt_hci_uart: bt_hci_uart {
+		compatible = "zephyr,bt-hci-uart";
+		status = "disabled";
+	};
 };
 
 &uart0 {

--- a/tests/bluetooth/shell/testcase.yaml
+++ b/tests/bluetooth/shell/testcase.yaml
@@ -397,3 +397,12 @@ tests:
       - CONFIG_RING_BUFFER=n
       - CONFIG_USB_DEVICE_STACK=n
       - CONFIG_USB_DEVICE_AUDIO=n
+  bluetooth.native_shell:
+    build_only: true
+    extra_args:
+      - EXTRA_CONF_FILE=snippets/xterm-native-shell/xterm-native-shell.conf
+      - EXTRA_DTC_OVERLAY_FILE=snippets/xterm-native-shell/xterm-native-shell.overlay
+    platform_allow:
+      - nrf52_bsim
+    integration_platforms:
+      - nrf52_bsim


### PR DESCRIPTION
Following changes in HCI drivers
(https://github.com/zephyrproject-rtos/zephyr/pull/72323) the build for the snippet allowing to have the Bluetooth shell run with BabbleSim was broken.

Fix the snippet by disabling the HCI UART driver.

Add a twister test case that will build the snippet in CI to avoid silent breaking.