### PR TITLE
test: logging: dictionary: fix build error with minimal libc

### DIFF
--- a/tests/subsys/logging/dictionary/src/main.c
+++ b/tests/subsys/logging/dictionary/src/main.c
@@ -8,6 +8,7 @@
 #include <inttypes.h>
 #include <zephyr/kernel.h>
 #include <string.h>
+#include <stdio.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>


### PR DESCRIPTION
In `tests/subsys/logging/dictionary` we don't include stdio.h header but use standard stream definitions (i.e. `stdout`) which cause build issues (if the minimal libc is used).

Fixes: #75600