### PR TITLE
build: Prefix missed generated syscall includes

### DIFF
--- a/drivers/flash/flash_handlers.c
+++ b/drivers/flash/flash_handlers.c
@@ -56,7 +56,7 @@ int z_vrfy_flash_fill(const struct device *dev, uint8_t val, off_t offset,
 	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_FLASH));
 	return z_impl_flash_fill(dev, val, offset, size);
 }
-#include <syscalls/flash_fill_mrsh.c>
+#include <zephyr/syscalls/flash_fill_mrsh.c>
 
 int z_vrfy_flash_flatten(const struct device *dev, off_t offset, size_t size)
 {
@@ -64,7 +64,7 @@ int z_vrfy_flash_flatten(const struct device *dev, off_t offset, size_t size)
 	return z_impl_flash_flatten(dev, offset, size);
 }
 
-#include <syscalls/flash_flatten_mrsh.c>
+#include <zephyr/syscalls/flash_flatten_mrsh.c>
 
 #ifdef CONFIG_FLASH_PAGE_LAYOUT
 static inline int z_vrfy_flash_get_page_info_by_offs(const struct device *dev,

--- a/include/zephyr/drivers/mspi.h
+++ b/include/zephyr/drivers/mspi.h
@@ -804,5 +804,5 @@ static inline int mspi_register_callback(const struct device *controller,
 /**
  * @}
  */
-#include <syscalls/mspi.h>
+#include <zephyr/syscalls/mspi.h>
 #endif /* ZEPHYR_INCLUDE_MSPI_H_ */

--- a/include/zephyr/drivers/tee.h
+++ b/include/zephyr/drivers/tee.h
@@ -667,6 +667,6 @@ static inline int z_impl_tee_suppl_send(const struct device *dev, unsigned int r
  * @}
  */
 
-#include <syscalls/tee.h>
+#include <zephyr/syscalls/tee.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_TEE_H_ */

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -125,7 +125,7 @@ static inline const struct device *z_vrfy_device_get_by_dt_nodelabel(const char 
 
 	return z_impl_device_get_by_dt_nodelabel(nl_copy);
 }
-#include <syscalls/device_get_by_dt_nodelabel_mrsh.c>
+#include <zephyr/syscalls/device_get_by_dt_nodelabel_mrsh.c>
 #endif /* CONFIG_USERSPACE */
 #endif /* CONFIG_DEVICE_DT_METADATA */
 


### PR DESCRIPTION
PR #63973 namespaced generated headers with `zephyr/`, including generated syscall headers.

Since then, some new generated syscall header includes have been added without the `zephyr/` prefix, breaking builds when
`CONFIG_LEGACY_GENERATED_INCLUDE_PATH` is disabled.

This PR adds the `zephyr/` prefix to includes for generated syscall headers where it has been missed.