### PR TITLE
posix: shm: fix build error with minimal libc

### DIFF
--- a/lib/posix/options/shm.c
+++ b/lib/posix/options/shm.c
@@ -5,6 +5,7 @@
  */
 
 #include <string.h>
+#include <stdio.h>
 
 #include <kernel_arch_interface.h>
 #include <zephyr/kernel.h>


### PR DESCRIPTION
In `lib/posix/options/shm.c` we don't include `stdio.h` header but use standard `SEEK_xxx` definitions (i.e. `SEEK_SET`) which cause build issues (if the minimal libc is used).

Fixes: #75613