### PR TITLE
soc: nxp: imxrt: exclude mpu_regions.c when ARM_MPU disabled

### DIFF
--- a/soc/nxp/imxrt/CMakeLists.txt
+++ b/soc/nxp/imxrt/CMakeLists.txt
@@ -16,7 +16,7 @@ if(CONFIG_SOC_SERIES_IMXRT10XX OR CONFIG_SOC_SERIES_IMXRT11XX)
   if(CONFIG_EXTERNAL_MEM_CONFIG_DATA)
     set(boot_hdr_xmcd_data_section ".boot_hdr.xmcd_data")
   endif()
-  zephyr_sources(mpu_regions.c)
+  zephyr_sources_ifdef(CONFIG_ARM_MPU mpu_regions.c)
   zephyr_linker_section_configure(
     SECTION .rom_start
     INPUT ".boot_hdr.conf"


### PR DESCRIPTION
Option NXP_IMX_RT_USER_MPU_REGIONS exclude soc file mpu_regions.c and allow user define custom mpu_regions in custom file. 

Fixes #70920

For test this PR i use:

- file prj.conf:
```
...
CONFIG_FLASH_SIZE=5120 
CONFIG_FLASH_BASE_ADDRESS=0x80100000
CONFIG_SRAM_SIZE=26624
CONFIG_SRAM_BASE_ADDRESS=0x80600000
...
```

- file with custom MPU regions:
```
#include <zephyr/devicetree.h>
#include <zephyr/arch/arm/mpu/arm_mpu.h>

#define REGION_RAM_EXEC_ATTR(size) \
{ \
	(NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_SHAREABLE | \
	 size | P_RW_U_NA_Msk) \
}

static const struct arm_mpu_region mpu_regions[] = {
	/* Region 1 */
	MPU_REGION_ENTRY("SRAM_0",
			 CONFIG_SRAM_BASE_ADDRESS,
			 REGION_RAM_EXEC_ATTR(REGION_32M)),
};

const struct arm_mpu_config mpu_config = {
	.num_regions = ARRAY_SIZE(mpu_regions),
	.mpu_regions = mpu_regions,
};
```