### PR TITLE
requirements: bump pyelftools to >=0.29

### DIFF
--- a/scripts/requirements-base.txt
+++ b/scripts/requirements-base.txt
@@ -4,7 +4,7 @@
 # part of the recommended workflow
 
 # used by various build scripts
-pyelftools>=0.27
+pyelftools>=0.29
 
 # used by dts generation to parse binding YAMLs, also used by
 # twister to parse YAMLs, by west, zephyr_module,...


### PR DESCRIPTION
The minimum version of pyelftools is 0.29 to make it working with `scripts/footprint/size_report`.
Version 0.28 has the same issue of 0.27 regarding `ram_report`. So we bump to the following version that works.

Fixes #75605