### PR TITLE
arch: arm: cortex_m: add ip & lr to the clobber list

### DIFF
--- a/arch/arm/core/cortex_m/thread.c
+++ b/arch/arm/core/cortex_m/thread.c
@@ -588,7 +588,7 @@ void arch_switch_to_main_thread(struct k_thread *main_thread, char *stack_ptr,
 	"bx    r4\n"		/* We don’t intend to return, so there is no need to link. */
 	: "+r" (_main)
 	: "r" (stack_ptr)
-	: "r0", "r1", "r2", "r3", "r4");
+	: "r0", "r1", "r2", "r3", "r4", "ip", "lr");
 
 	CODE_UNREACHABLE;
 }
@@ -659,7 +659,7 @@ FUNC_NORETURN void z_arm_switch_to_main_no_multithreading(
 #ifdef CONFIG_BUILTIN_STACK_GUARD
 	, [_psplim]"r" (psplim)
 #endif
-	: "r0", "r1", "r2", "r3"
+	: "r0", "r1", "r2", "ip", "lr"
 	);
 
 	CODE_UNREACHABLE; /* LCOV_EXCL_LINE */


### PR DESCRIPTION
Calls to other function may clobber ip & lr too so these register need to be added to the clobberlist.

fixes #75586