### PR TITLE
tests: posix: headers: fix build error when minimal libc is used

### DIFF
--- a/lib/libc/minimal/include/signal.h
+++ b/lib/libc/minimal/include/signal.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2024 Synopsys
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_SIGNAL_H_
+#define ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_SIGNAL_H_
+
+#include <zephyr/posix/signal.h>
+
+#endif /* ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_SIGNAL_H_ */


### PR DESCRIPTION
The `tests/posix/headers/portability.posix.headers.without_posix_api` test fails to build in case of toolchain which uses minimal libc by default (for example ARC MWDT toolchain).

It can be easily fixed by providing sighal.h handler in minimal libc

Fixes: #75612