### PR TITLE
boards: croxel: cx1825: Add sensor aliases on Device-Tree

### DIFF
--- a/boards/croxel/croxel_cx1825/croxel_cx1825_nrf52840.dts
+++ b/boards/croxel/croxel_cx1825/croxel_cx1825_nrf52840.dts
@@ -51,6 +51,9 @@
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
 		watchdog0 = &wdt0;
+		dht0 = &hts221;
+		accel0 = &lis3dh;
+		prox-sensor0 = &apds9960;
 	};
 };
 


### PR DESCRIPTION
To work with Sensor Samples without additional tweaks.