### PR TITLE
net: ptp: Misc clock sync bugs

### DIFF
--- a/subsys/net/lib/ptp/clock.c
+++ b/subsys/net/lib/ptp/clock.c
@@ -538,7 +538,7 @@ void ptp_clock_synchronize(uint64_t ingress, uint64_t egress)
 	LOG_DBG("Offset %lldns", offset);
 	ptp_clk.current_ds.offset_from_tt = clock_ns_to_timeinterval(offset);
 
-	ptp_clock_adjust(ptp_clk.phc, offset);
+	ptp_clock_adjust(ptp_clk.phc, -offset);
 }
 
 void ptp_clock_delay(uint64_t egress, uint64_t ingress)


### PR DESCRIPTION
- Offset should be *subtracted* from current clock value, not added.
- net_ptp_time artithmetic is wrong in `ptp_clock_synchronize()`