### PR TITLE
drivers/spi/spi_xlnx_axi_quadspi: Build fix w CONFIG_SPI_ASYNC

### DIFF
--- a/drivers/spi/spi_xlnx_axi_quadspi.c
+++ b/drivers/spi/spi_xlnx_axi_quadspi.c
@@ -486,6 +486,8 @@ static void xlnx_quadspi_isr(const struct device *dev)
 		 * work in the ISR, so just post the event.
 		 */
 #ifdef CONFIG_SPI_ASYNC
+		struct spi_context *ctx = &data->ctx;
+
 		if (ctx->asynchronous) {
 			xlnx_quadspi_read_fifo(dev);
 			xlnx_quadspi_start_tx(dev);


### PR DESCRIPTION
Fix a build error when CONFIG_SPI_ASYNC is set.
The issue was detected by CI

```
spi_xlnx_axi_quadspi.c: In function 'xlnx_quadspi_isr':
spi_xlnx_axi_quadspi.c:489:21: error: 'ctx' undeclared
  489 |                 if (ctx->asynchronous) {
      |                     ^~~
```