### PR TITLE
drivers/sensor/tdk icm42688_rtio: Fix build error

### DIFF
--- a/drivers/sensor/tdk/icm42688/icm42688_rtio.c
+++ b/drivers/sensor/tdk/icm42688/icm42688_rtio.c
@@ -84,7 +84,7 @@ void icm42688_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
 	if (!cfg->is_streaming) {
 		icm42688_submit_one_shot(dev, iodev_sqe);
 	} else if (IS_ENABLED(CONFIG_ICM42688_STREAM)) {
-		icm42688_submit_stream(dev, iodev_sqe);
+		(void) icm42688_submit_stream(dev, iodev_sqe);
 	} else {
 		rtio_iodev_sqe_err(iodev_sqe, -ENOTSUP);
 	}

--- a/drivers/sensor/tdk/icm42688/icm42688_rtio.h
+++ b/drivers/sensor/tdk/icm42688/icm42688_rtio.h
@@ -12,7 +12,7 @@
 
 void icm42688_submit(const struct device *sensor, struct rtio_iodev_sqe *iodev_sqe);
 
-void icm42688_submit_stream(const struct device *sensor, struct rtio_iodev_sqe *iodev_sqe);
+int icm42688_submit_stream(const struct device *sensor, struct rtio_iodev_sqe *iodev_sqe);
 
 void icm42688_fifo_event(const struct device *dev);
 


### PR DESCRIPTION
Fix function prototype return type in header to match definition.

Fixes the following build error detected by CI:
```
icm42688_rtio_stream.c:16:5: error: conflicting types for
  'icm42688_submit_stream';  have 'int(const struct..
   16 | int icm42688_submit_stream(const struct device
      |     ^~~~~~~~~~~~~~~~~~~~~~
icm42688_rtio.h:15:6: note: previous declaration of
'icm42688_submit_stream' with type 'void(const struct...
```