### PR TITLE
RISCV: fix PMP stack guard not active during boot

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -30,7 +30,6 @@ config RISCV_GP
 config RISCV_ALWAYS_SWITCH_THROUGH_ECALL
 	bool "Do not use mret outside a trap handler context"
 	depends on MULTITHREADING
-	depends on !RISCV_PMP
 	help
 	  Use mret instruction only when in a trap handler.
 	  This is for RISC-V implementations that require every mret to be


### PR DESCRIPTION
Before this, stack protection would be effective only after switching to
the first thread.

Even before the first thread is created, the kernel init code uses the
IRQ stack to set things up. Let's make sure this is safeguarded as well.

This also fixes the incompatibility between `CONFIG_RISCV_PMP` and
`CONFIG_RISCV_ALWAYS_SWITCH_THROUGH_ECALL`, the later needing an exception
call to switch to the first thread and exception code assuming stack
guard is already set up in the PMP.
