### PR TITLE
tests: logging/dictionary: pytest only looks at last output

### DIFF
--- a/tests/subsys/logging/dictionary/pytest/test_logging_dictionary.py
+++ b/tests/subsys/logging/dictionary/pytest/test_logging_dictionary.py
@@ -43,7 +43,12 @@ def process_logs(dut: DeviceAdapter, build_dir):
     # timeout earlier with per-test timeout.
     handler_output = dut.readlines_until(regex = '.*##ZLOGV1##[0-9]+', timeout = 600.0)
 
-    encoded_logs = handler_output[-1]
+    # Join all the output lines together
+    handler_output = ''.join(ho.strip() for ho in handler_output)
+
+    # Find the last dictionary logging block and extract it
+    ridx = handler_output.rfind("##ZLOGV1##")
+    encoded_logs = handler_output[ridx:]
 
     encoded_log_file = os.path.join(build_dir, "encoded.log")
     with open(encoded_log_file, 'w', encoding='utf-8') as fp:


### PR DESCRIPTION
There are instances where on hardware tests would result in multiple dictionary logging blocks. This is usually due to flashing and running via twister in separate steps. Once flashing is done, the device starts running and sending logging string to output, but twister is not ready to read them, thus leaving the strings in the host's UART buffer. Then twister starts its testing run by resetting the device which results in another dictionary logging block to show up. So the pytest script has to be updated to only look at the last dictionay logging block.