### PR TITLE
drivers: mdio_nxp_enet: Fix busy wait

### DIFF
--- a/drivers/ethernet/nxp_enet/eth_nxp_enet.c
+++ b/drivers/ethernet/nxp_enet/eth_nxp_enet.c
@@ -264,6 +264,8 @@ static void eth_nxp_enet_iface_init(struct net_if *iface)
 	net_eth_carrier_off(data->iface);
 
 	config->irq_config_func();
+
+	nxp_enet_driver_cb(config->mdio, NXP_ENET_MDIO, NXP_ENET_INTERRUPT_ENABLED, NULL);
 }
 
 static enum ethernet_hw_caps eth_nxp_enet_get_capabilities(const struct device *dev)

--- a/drivers/mdio/Kconfig.nxp_enet
+++ b/drivers/mdio/Kconfig.nxp_enet
@@ -13,9 +13,9 @@ if MDIO_NXP_ENET
 
 config MDIO_NXP_ENET_TIMEOUT
 	int "NXP ENET MDIO Timeout time"
-	default 1
+	default 250
 	help
-	  Time in milliseconds before an MDIO transaction that has not
+	  Time in microseconds before an MDIO transaction that has not
 	  finished is considered to have timed out.
 
 endif # MDIO_NXP_ENET


### PR DESCRIPTION
Fix the busy wait in the MDIO driver that was causing timing problems in systems with real time requirements performing tasks more frequently than about a millisecond.

Restructure the code to be less redundant and change the busy wait kconfig to microseconds instead of millliseconds. Also actually signal to the mdio driver that it can use the interrupt instead of busy waiting, this seems to have been forgotten.

Fixes #75624