### PR TITLE
drivers: dac: dac_ad56xx: Fix channel range check

### DIFF
--- a/drivers/dac/dac_ad56xx.c
+++ b/drivers/dac/dac_ad56xx.c
@@ -106,7 +106,7 @@ static int ad56xx_write_value(const struct device *dev, uint8_t channel, uint32_
 		return -EINVAL;
 	}
 
-	if (channel > config->channel_count) {
+	if (channel >= config->channel_count) {
 		LOG_ERR("invalid channel %i", channel);
 		return -EINVAL;
 	}


### PR DESCRIPTION
An off by one error in the channel range check results in an out of bound access to the channel lookup array.