### PR TITLE
drivers: dac: dac_ad569x: Add bit shift for 14/12-bit variants

### DIFF
--- a/drivers/dac/dac_ad569x.c
+++ b/drivers/dac/dac_ad569x.c
@@ -119,6 +119,8 @@ static int ad569x_write_value(const struct device *dev, uint8_t channel, uint32_
 		return -EINVAL;
 	}
 
+	value <<= 16 - config->resolution;
+
 	return ad569x_write(dev, AD569X_CMD_WRITE_AND_UPDATE, value);
 }
 


### PR DESCRIPTION
The 14/12-bit variants (AD5692R/AD5691R) require the data to be in the upper bits of the two byte data field of the write command. See table 12 and the associated footnotes in the AD5693R/AD5692R/AD5691R/AD5693 datasheet.