### PR TITLE
dts: bindings: dac: ad569x: Remove unused properties

### DIFF
--- a/dts/bindings/dac/adi,ad569x-base.yaml
+++ b/dts/bindings/dac/adi,ad569x-base.yaml
@@ -7,16 +7,6 @@ properties:
   "#io-channel-cells":
     const: 1
 
-  resolution:
-    type: int
-    required: true
-    description: DAC resolution.
-
-  voltage-reference-mv:
-    type: int
-    required: true
-    description: DAC reference voltage in mV.
-
   voltage-reference:
     type: string
     default: "internal"

--- a/tests/drivers/build_all/dac/app.overlay
+++ b/tests/drivers/build_all/dac/app.overlay
@@ -81,8 +81,6 @@
 				status = "okay";
 				compatible = "adi,ad5691";
 				reg = <0x4a>;
-				resolution = <12>;
-				voltage-reference-mv = <2500>;
 				#io-channel-cells = < 1 >;
 			};
 
@@ -90,8 +88,6 @@
 				status = "okay";
 				compatible = "adi,ad5692";
 				reg = <0x4b>;
-				resolution = <14>;
-				voltage-reference-mv = <2500>;
 				#io-channel-cells = < 1 >;
 			};
 
@@ -99,8 +95,6 @@
 				status = "okay";
 				compatible = "adi,ad5693";
 				reg = <0x4c>;
-				resolution = <16>;
-				voltage-reference-mv = <2500>;
 				#io-channel-cells = < 1 >;
 			};
 		};


### PR DESCRIPTION
These properties are not used by the driver at all, but are inconveniently marked as required. Lets just remove them.