### PR TITLE
usb: device_next: Simple NCM driver for usb-next - documentation changes

### DIFF
--- a/doc/connectivity/usb/device_next/usb_device.rst
+++ b/doc/connectivity/usb/device_next/usb_device.rst
@@ -41,6 +41,8 @@ instance (`n`) and is used as an argument to the :c:func:`usbd_register_class`.
 +-----------------------------------+-------------------------+-------------------------+
 | USB CDC ECM class                 | Ethernet device         | :samp:`cdc_ecm_{n}`     |
 +-----------------------------------+-------------------------+-------------------------+
+| USB CDC NCM class                 | Ethernet device         | :samp:`cdc_ncm_{n}`     |
++-----------------------------------+-------------------------+-------------------------+
 | USB Mass Storage Class (MSC)      | :ref:`usbd_msc_device`  | :samp:`msc_{n}`         |
 +-----------------------------------+-------------------------+-------------------------+
 | USB Human Interface Devices (HID) | :ref:`usbd_hid_device`  | :samp:`hid_{n}`         |
@@ -74,8 +76,10 @@ configuration ``-DCONF_FILE=usbd_next_prj.conf`` either directly or via
 
 * :zephyr:code-sample:`zperf` To build the sample for the new device support,
   set the configuration overlay file
-  ``-DDEXTRA_CONF_FILE=overlay-usbd_next_ecm.conf`` and devicetree overlay file
+  ``-DDEXTRA_CONF_FILE=overlay-usbd_next.conf`` and devicetree overlay file
   ``-DDTC_OVERLAY_FILE="usbd_next_ecm.overlay`` either directly or via ``west``.
+  To build with NCM, set the configuration overlay file as above and the devicetree
+  overlay file to ``-DDTC_OVERLAY_FILE="usbd_next_ncm.overlay``.
 
 How to configure and enable USB device support
 **********************************************


### PR DESCRIPTION
This is a simple USB-NCM driver. It just has one NTB per direction and within the NTB only one datagram can be received/transmitted.

Main goal is existance of an NCM driver, performance will follow in further steps.

This PR contains documentation changes.

PR with actual code is #72310, sample updates are in #75632