### PR TITLE
west.yml: MCUboot synchronization from upstream

### DIFF
--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -1259,6 +1259,18 @@ MCUboot
 
   * Added defines for ``SOC_FLASH_0_ID`` and ``SPI_FLASH_0_ID``
 
+  * Fixed ASN.1 support for mbedtls version >= 3.1
+
+  * Fixed bootutil signed/unsigned comparison in ``boot_read_enc_key``
+
+  * Updated imgtool version.py to take command line arguments
+
+  * Added imgtool improvements to dumpinfo
+
+  * Fixed various imgtool dumpinfo issues
+
+  * Fixed imgtool verify command for edcsa-p384 signed images
+
   * The MCUboot version in this release is version ``2.1.0+0-dev``.
 
 Trusted Firmware-M

--- a/west.yml
+++ b/west.yml
@@ -287,7 +287,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 898a1ca64a759541d9fcc37fef921db93d99ad70
+      revision: fb2cf0ec3da3687b93f28e556ab682bdd4b85223
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  fb2cf0ec3da3687b93f28e556ab682bdd4b85223

Brings following Zephyr relevant fixes:
  - 89807992 boot: zephyr: Fix build for nrf9160dk
  - 2f5a7f47 boot: zephyr: Fix build for thingy53
  - c9e4ab8b boot: zephyr: Fix build for thingy52
  - 1d79ef35 boot: Fix ASN.1 for mbedtls >= 3.1
  - 86acda9e ext: fiat: Use user-defined assert macro
  - 9ae634f3 bootutil: Fix signed/unsigned comparison in boot_read_enc_key
  - 533fef2a imgtool: Update version.py to take command line arguments
  - 316a139c imgtool: dumpinfo improvements
  - f3a57028 imgtool: Various dumpinfo fixes
  - d16a613f imgtool: Assert "measurement value" is last in boot_record.py
  - 36f8bf30 imgtool: Fix verify command for edcsa-p384 signed images
  - 2712f743 imgtool: Add missing requirements to requirements.txt file
  - 45d379e7 zephyr: boards: Add files needed for NXP FRDM MCXN947 QSPI variant
  - 3113df8f imgtool: initial sanity test
  - a4cb878c imgtool: Fixed missing dependency to 'pyyaml' (for dumpinfo)
  - faf2dd1f imgtool: fixed keys/general.py to pass existing unittests

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.


Fixes #73301