### PR TITLE
Fixes return value of i2s_stm32_write by returning queue_put() return and fix I2S format channel count.

### DIFF
--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -471,9 +471,7 @@ static int i2s_stm32_write(const struct device *dev, void *mem_block,
 	}
 
 	/* Add data to the end of the TX queue */
-	queue_put(&dev_data->tx.mem_block_queue, mem_block, size);
-
-	return 0;
+	return queue_put(&dev_data->tx.mem_block_queue, mem_block, size);
 }
 
 static const struct i2s_driver_api i2s_stm32_driver_api = {

--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -182,8 +182,10 @@ static int i2s_stm32_configure(const struct device *dev, enum i2s_dir dir,
 	 * When I2S data format is selected parameter channels is ignored,
 	 * number of words in a frame is always 2.
 	 */
-	const uint32_t num_channels = i2s_cfg->format & I2S_FMT_DATA_FORMAT_MASK
-				      ? 2U : i2s_cfg->channels;
+	const uint32_t num_channels =
+		((i2s_cfg->format & I2S_FMT_DATA_FORMAT_MASK) == I2S_FMT_DATA_FORMAT_I2S)
+			? 2U
+			: i2s_cfg->channels;
 	struct stream *stream;
 	uint32_t bit_clk_freq;
 	bool enable_mck;


### PR DESCRIPTION
Fixes return value of i2s_stm32_write by returning queue_put() return and fix I2S format channel count.