### PR TITLE
test: bluetooth: Correct profile names MBT and DFU

### DIFF
--- a/tests/bluetooth/qualification/ICS_Zephyr_Bluetooth_Host.pts
+++ b/tests/bluetooth/qualification/ICS_Zephyr_Bluetooth_Host.pts
@@ -9765,7 +9765,7 @@
       </item>
     </profile>
     <profile>
-      <name>MBT</name>
+      <name>MBTM</name>
       <item>
         <table>10</table>
         <row>1</row>
@@ -9796,7 +9796,7 @@
       </item>
     </profile>
     <profile>
-      <name>DFU</name>
+      <name>DFUM</name>
       <item>
         <table>3</table>
         <row>3</row>


### PR DESCRIPTION
Profile names MBT and DFU are updated as MBTM and DFUM respectively, according to TCRL 2024-1.