### PR TITLE
samples: logging: disable usermode for bytesensi_l

### DIFF
--- a/samples/subsys/logging/logger/sample.yaml
+++ b/samples/subsys/logging/logger/sample.yaml
@@ -54,6 +54,8 @@ tests:
       - bl654_dvk
       - decawave_dwm1001_dev
       - segger_trb_stm32f407
+      - bytesensi_l
+      - bl654_dvk/nrf52840/pa
     arch_exclude:
       - posix
     tags:


### PR DESCRIPTION
This fixes https://github.com/zephyrproject-rtos/zephyr/issues/75617