### PR TITLE
Bluetooth: TBS: Remove BT_TBS_TECHNOLOGY_IP

### DIFF
--- a/include/zephyr/bluetooth/audio/tbs.h
+++ b/include/zephyr/bluetooth/audio/tbs.h
@@ -64,7 +64,6 @@
 #define BT_TBS_TECHNOLOGY_CDMA                     0x07
 #define BT_TBS_TECHNOLOGY_2G                       0x08
 #define BT_TBS_TECHNOLOGY_WCDMA                    0x09
-#define BT_TBS_TECHNOLOGY_IP                       0x0a
 
 /**
  * @brief The GTBS index denotes whenever a callback is from a

--- a/subsys/bluetooth/audio/tbs.c
+++ b/subsys/bluetooth/audio/tbs.c
@@ -1990,8 +1990,7 @@ int bt_tbs_set_bearer_technology(uint8_t bearer_index, uint8_t new_technology)
 {
 	struct service_inst *inst = inst_lookup_index(bearer_index);
 
-	if (new_technology < BT_TBS_TECHNOLOGY_3G ||
-	    new_technology > BT_TBS_TECHNOLOGY_IP) {
+	if (new_technology < BT_TBS_TECHNOLOGY_3G || new_technology > BT_TBS_TECHNOLOGY_WCDMA) {
 		return -EINVAL;
 	} else if (inst == NULL) {
 		return -EINVAL;

--- a/subsys/bluetooth/audio/tbs_internal.h
+++ b/subsys/bluetooth/audio/tbs_internal.h
@@ -144,8 +144,6 @@ static inline const char *bt_tbs_technology_str(uint8_t status)
 		return "2G";
 	case BT_TBS_TECHNOLOGY_WCDMA:
 		return "WCDMA";
-	case BT_TBS_TECHNOLOGY_IP:
-		return "IP";
 	default:
 		return "unknown technology";
 	}


### PR DESCRIPTION
BT_TBS_TECHNOLOGY_IP is not a valid technology value for TBS since it's not defined by the spec.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/75646