### PR TITLE
boards: st: stm32h750 disco kit rd/wr the sdram2

### DIFF
--- a/boards/st/stm32h750b_dk/stm32h750b_dk.dts
+++ b/boards/st/stm32h750b_dk/stm32h750b_dk.dts
@@ -208,7 +208,7 @@
 		status = "okay";
 		power-up-delay = <100>;
 		num-auto-refresh = <8>;
-		mode-register = <0x220>;
+		mode-register = <0x230>;
 		refresh-rate = <0x603>;
 		bank@1 {
 			reg = <1>;
@@ -219,7 +219,7 @@
 				STM32_FMC_SDRAM_CAS_3
 				STM32_FMC_SDRAM_SDCLK_PERIOD_2
 				STM32_FMC_SDRAM_RBURST_ENABLE
-				STM32_FMC_SDRAM_RPIPE_0>;
+				STM32_FMC_SDRAM_RPIPE_1>;
 			st,sdram-timing = <2 7 4 7 2 2 2>;
 		};
 	};

--- a/boards/st/stm32h750b_dk/stm32h750b_dk.yaml
+++ b/boards/st/stm32h750b_dk/stm32h750b_dk.yaml
@@ -14,4 +14,5 @@ supported:
   - dma
   - flash
   - rtc
+  - memc
 vendor: st


### PR DESCRIPTION
Set the Mode Register definition of the SDRAM command Mode register to 0x230 when programming the CAS_LATENCY of the external memory mode.

That value hold by the **<****mode-register****>** property of the fmc-sdram node, represents the Mode register (MDR) bit-field to the  SRDAM Command Register (FMC_SDCMR)
The SDRAM_MODEREG_CAS_LATENCY which is bit [4:5] of the  is expected to be aligned with the  STM32_FMC_SDRAM_CAS_ bit field  of the st,sdram-control property. 

The STM32_FMC_SDRAM_CAS_3 is configuring the SDRAM memory bank during the HAL_SDRAM_Init().
The <mode-register> is sent to the SDRAM during the memory programming sequence, with  the FMC_SDRAM_CMD_LOAD_MODE command.

Note that a STM32_FMC_SDRAM_CAS_2 and <mode-register=0x220> are not valid for the stm32h750b_dk target board.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/75504