### PR TITLE
MAINTAINERS: add maintainer and collaborator for DAP controller

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -595,6 +595,22 @@ CMSIS API layer:
     - portability.cmsis_rtos_v1
     - portability.cmsis_rtos_v2
 
+DAP:
+  status: maintained
+  maintainers:
+    - jfischer-no
+  collaborators:
+    - maxd-nordic
+  files:
+    - include/zephyr/drivers/swdp.h
+    - drivers/dp/
+    - subsys/dap/
+    - samples/subsys/dap/
+  description: >-
+    Debug Access Port controller
+  labels:
+    - "area: dap"
+
 DSP subsystem:
   status: maintained
   maintainers:

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4073,7 +4073,6 @@ USB:
     - tests/drivers/usb/
     - tests/drivers/udc/
     - doc/connectivity/usb/
-    - scripts/generate_usb_vif/
   labels:
     - "area: USB"
   tests:
@@ -4095,6 +4094,7 @@ USB-C:
     - subsys/usb/usb_c/
     - doc/connectivity/usb/pd/
     - doc/hardware/peripherals/usbc_vbus.rst
+    - scripts/generate_usb_vif/
   labels:
     - "area: USB-C"
   tests:


### PR DESCRIPTION
Add maintainer and collaborator for DP drivers and DAP controller.
Followup on the commit https://github.com/zephyrproject-rtos/zephyr/commit/7c9259abbceb84880906e4d8e594308db0ae00f0
("dap: add CMSIS-DAP compatible controller")

Also, move generate_usb_vif to USB-C section. Script was introduced by USB-C people.