### PR TITLE
drivers: can: loopback: set TX thread name and increase stack size

### DIFF
--- a/drivers/can/Kconfig.loopback
+++ b/drivers/can/Kconfig.loopback
@@ -22,7 +22,7 @@ config CAN_MAX_FILTER
 
 config CAN_LOOPBACK_TX_THREAD_STACK_SIZE
 	int "TX thread stack size"
-	default 256
+	default 512
 	help
 	  Stack size of the TX thread.
 	  The TX thread calls the callbacks of the receiver

--- a/drivers/can/can_loopback.c
+++ b/drivers/can/can_loopback.c
@@ -437,6 +437,8 @@ static int can_loopback_init(const struct device *dev)
 		return -1;
 	}
 
+	k_thread_name_set(tx_tid, dev->name);
+
 	return 0;
 }
 


### PR DESCRIPTION
Set TX thread name to aid in debugging and increase the default TX thread stack size for the CAN loopback driver from 256 to 512 bytes as the former has shown to be too little when using the loopback driver on real hardware.
