### PR TITLE
fs: fcb: rename variables differently than struct tag

### DIFF
--- a/include/zephyr/fs/fcb.h
+++ b/include/zephyr/fs/fcb.h
@@ -158,11 +158,11 @@ struct fcb {
  * Initialize FCB instance.
  *
  * @param[in] f_area_id ID of flash area where fcb storage resides.
- * @param[in,out] fcb   FCB instance structure.
+ * @param[in,out] fcbp  FCB instance structure.
  *
  * @return 0 on success, non-zero on failure.
  */
-int fcb_init(int f_area_id, struct fcb *fcb);
+int fcb_init(int f_area_id, struct fcb *fcbp);
 
 /**
  * Appends an entry to circular buffer.
@@ -172,24 +172,24 @@ int fcb_init(int f_area_id, struct fcb *fcb);
  * flash_area_write() to fcb flash_area.
  * When you're finished, call fcb_append_finish() with loc as argument.
  *
- * @param[in] fcb FCB instance structure.
+ * @param[in] fcbp FCB instance structure.
  * @param[in] len Length of data which are expected to be written as the entry
  *            payload.
  * @param[out] loc entry location information
  *
  * @return 0 on success, non-zero on failure.
  */
-int fcb_append(struct fcb *fcb, uint16_t len, struct fcb_entry *loc);
+int fcb_append(struct fcb *fcbp, uint16_t len, struct fcb_entry *loc);
 
 /**
  * Finishes entry append operation.
  *
- * @param[in] fcb FCB instance structure.
+ * @param[in] fcbp FCB instance structure.
  * @param[in] append_loc entry location information
  *
  * @return 0 on success, non-zero on failure.
  */
-int fcb_append_finish(struct fcb *fcb, struct fcb_entry *append_loc);
+int fcb_append_finish(struct fcb *fcbp, struct fcb_entry *append_loc);
 
 /**
  * FCB Walk callback function type.
@@ -213,7 +213,7 @@ typedef int (*fcb_walk_cb)(struct fcb_entry_ctx *loc_ctx, void *arg);
  *
  * @param[in] sector     fcb sector to be walked. If null, traverse entire
  *                       storage.
- * @param[in] fcb        FCB instance structure.
+ * @param[in] fcbp       FCB instance structure.
  * @param[in] cb         pointer to the function which gets called for every
  *                       entry. If cb wants to stop the walk, it should return
  *                       non-zero value.
@@ -223,8 +223,7 @@ typedef int (*fcb_walk_cb)(struct fcb_entry_ctx *loc_ctx, void *arg);
  * @return 0 on success, negative on failure (or transferred form callback
  *         return-value), positive transferred form callback return-value
  */
-int fcb_walk(struct fcb *fcb, struct flash_sector *sector, fcb_walk_cb cb,
-	     void *cb_arg);
+int fcb_walk(struct fcb *fcbp, struct flash_sector *sector, fcb_walk_cb cb, void *cb_arg);
 
 /**
  * Get next fcb entry location.
@@ -237,12 +236,12 @@ int fcb_walk(struct fcb *fcb, struct flash_sector *sector, fcb_walk_cb cb,
  * FCB storage. loc->fe_sector is set and loc->fe_elem_off is 0 function fetches
  * the first entry location in the fcb sector.
  *
- * @param[in] fcb FCB instance structure.
+ * @param[in] fcbp FCB instance structure.
  * @param[in,out] loc entry location information
  *
  * @return 0 on success, non-zero on failure.
  */
-int fcb_getnext(struct fcb *fcb, struct fcb_entry *loc);
+int fcb_getnext(struct fcb *fcbp, struct fcb_entry *loc);
 
 /**
  * Rotate fcb sectors
@@ -250,9 +249,9 @@ int fcb_getnext(struct fcb *fcb, struct fcb_entry *loc);
  * Function erases the data from oldest sector. Upon that the next sector
  * becomes the oldest. Active sector is also switched if needed.
  *
- * @param[in] fcb FCB instance structure.
+ * @param[in] fcbp FCB instance structure.
  */
-int fcb_rotate(struct fcb *fcb);
+int fcb_rotate(struct fcb *fcbp);
 
 /**
  * Start using the scratch block.
@@ -260,50 +259,49 @@ int fcb_rotate(struct fcb *fcb);
  * Take one of the scratch blocks into use. So a scratch sector becomes
  * active sector to which entries can be appended.
  *
- * @param[in] fcb FCB instance structure.
+ * @param[in] fcbp FCB instance structure.
  *
  * @return 0 on success, non-zero on failure.
  */
-int fcb_append_to_scratch(struct fcb *fcb);
+int fcb_append_to_scratch(struct fcb *fcbp);
 
 /**
  * Get free sector count.
  *
- * @param[in] fcb FCB instance structure.
+ * @param[in] fcbp FCB instance structure.
  *
  * @return Number of free sectors.
  */
-int fcb_free_sector_cnt(struct fcb *fcb);
+int fcb_free_sector_cnt(struct fcb *fcbp);
 
 /**
  * Check whether FCB has any data.
  *
- * @param[in] fcb FCB instance structure.
+ * @param[in] fcbp FCB instance structure.
  *
  * @return Positive value if fcb is empty, otherwise 0.
  */
-int fcb_is_empty(struct fcb *fcb);
+int fcb_is_empty(struct fcb *fcbp);
 
 /**
  * Finds the fcb entry that gives back up to n entries at the end.
  *
- * @param[in]               fcb FCB instance structure.
+ * @param[in] fcbp          FCB instance structure.
  * @param[in] entries       number of fcb entries the user wants to get
  * @param[out] last_n_entry last_n_entry the fcb_entry to be returned
  *
  * @return 0 on there are any fcbs available; -ENOENT otherwise
  */
-int fcb_offset_last_n(struct fcb *fcb, uint8_t entries,
-		      struct fcb_entry *last_n_entry);
+int fcb_offset_last_n(struct fcb *fcbp, uint8_t entries, struct fcb_entry *last_n_entry);
 
 /**
  * Clear fcb instance storage.
  *
- * @param[in] fcb FCB instance structure.
+ * @param[in] fcbp FCB instance structure.
  *
  * @return 0 on success; non-zero on failure
  */
-int fcb_clear(struct fcb *fcb);
+int fcb_clear(struct fcb *fcbp);
 
 /**
  * @}
@@ -319,7 +317,7 @@ int fcb_clear(struct fcb *fcb);
 /**
  * Read raw data from the fcb flash sector.
  *
- * @param[in] fcb    FCB instance structure.
+ * @param[in] fcbp   FCB instance structure.
  * @param[in] sector FCB sector.
  * @param[in] off    Read offset form sector begin.
  * @param[out] dst   Destination buffer.
@@ -327,13 +325,13 @@ int fcb_clear(struct fcb *fcb);
  *
  * @return  0 on success, negative errno code on fail.
  */
-int fcb_flash_read(const struct fcb *fcb, const struct flash_sector *sector,
-		   off_t off, void *dst, size_t len);
+int fcb_flash_read(const struct fcb *fcbp, const struct flash_sector *sector, off_t off,
+		   void *dst, size_t len);
 
 /**
  * Write raw data to the fcb flash sector.
  *
- * @param[in] fcb    FCB instance structure.
+ * @param[in] fcbp   FCB instance structure.
  * @param[in] sector FCB sector.
  * @param[in] off    Write offset form sector begin.
  * @param[in] src    Source buffer.
@@ -341,8 +339,8 @@ int fcb_flash_read(const struct fcb *fcb, const struct flash_sector *sector,
  *
  * @return  0 on success, negative errno code on fail.
  */
-int fcb_flash_write(const struct fcb *fcb, const struct flash_sector *sector,
-		    off_t off, const void *src, size_t len);
+int fcb_flash_write(const struct fcb *fcbp, const struct flash_sector *sector, off_t off,
+		    const void *src, size_t len);
 
 /**
  * @}

--- a/subsys/fs/fcb/fcb.c
+++ b/subsys/fs/fcb/fcb.c
@@ -5,32 +5,32 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "fcb_priv.h"
+
+#include <errno.h>
 #include <limits.h>
 #include <stdlib.h>
+#include <string.h>
 
-#include <zephyr/fs/fcb.h>
-#include "fcb_priv.h"
-#include "string.h"
-#include <errno.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/flash.h>
+#include <zephyr/fs/fcb.h>
 
-uint8_t
-fcb_get_align(const struct fcb *fcb)
+uint8_t fcb_get_align(const struct fcb *fcbp)
 {
 	uint8_t align;
 
-	if (fcb->fap == NULL) {
+	if (fcbp->fap == NULL) {
 		return 0;
 	}
 
-	align = flash_area_align(fcb->fap);
+	align = flash_area_align(fcbp->fap);
 
 	return align;
 }
 
-int fcb_flash_read(const struct fcb *fcb, const struct flash_sector *sector,
-		   off_t off, void *dst, size_t len)
+int fcb_flash_read(const struct fcb *fcbp, const struct flash_sector *sector, off_t off,
+		   void *dst, size_t len)
 {
 	int rc;
 
@@ -38,11 +38,11 @@ int fcb_flash_read(const struct fcb *fcb, const struct flash_sector *sector,
 		return -EINVAL;
 	}
 
-	if (fcb->fap == NULL) {
+	if (fcbp->fap == NULL) {
 		return -EIO;
 	}
 
-	rc = flash_area_read(fcb->fap, sector->fs_off + off, dst, len);
+	rc = flash_area_read(fcbp->fap, sector->fs_off + off, dst, len);
 
 	if (rc != 0) {
 		return -EIO;
@@ -51,8 +51,8 @@ int fcb_flash_read(const struct fcb *fcb, const struct flash_sector *sector,
 	return 0;
 }
 
-int fcb_flash_write(const struct fcb *fcb, const struct flash_sector *sector,
-		    off_t off, const void *src, size_t len)
+int fcb_flash_write(const struct fcb *fcbp, const struct flash_sector *sector, off_t off,
+		    const void *src, size_t len)
 {
 	int rc;
 
@@ -60,11 +60,11 @@ int fcb_flash_write(const struct fcb *fcb, const struct flash_sector *sector,
 		return -EINVAL;
 	}
 
-	if (fcb->fap == NULL) {
+	if (fcbp->fap == NULL) {
 		return -EIO;
 	}
 
-	rc = flash_area_write(fcb->fap, sector->fs_off + off, src, len);
+	rc = flash_area_write(fcbp->fap, sector->fs_off + off, src, len);
 
 	if (rc != 0) {
 		return -EIO;
@@ -73,16 +73,15 @@ int fcb_flash_write(const struct fcb *fcb, const struct flash_sector *sector,
 	return 0;
 }
 
-int
-fcb_erase_sector(const struct fcb *fcb, const struct flash_sector *sector)
+int fcb_erase_sector(const struct fcb *fcbp, const struct flash_sector *sector)
 {
 	int rc;
 
-	if (fcb->fap == NULL) {
+	if (fcbp->fap == NULL) {
 		return -EIO;
 	}
 
-	rc = flash_area_flatten(fcb->fap, sector->fs_off, sector->fs_size);
+	rc = flash_area_flatten(fcbp->fap, sector->fs_off, sector->fs_size);
 	if (rc != 0) {
 		return -EIO;
 	}
@@ -90,8 +89,7 @@ fcb_erase_sector(const struct fcb *fcb, const struct flash_sector *sector)
 	return 0;
 }
 
-int
-fcb_init(int f_area_id, struct fcb *fcb)
+int fcb_init(int f_area_id, struct fcb *fcbp)
 {
 	struct flash_sector *sector;
 	int rc;
@@ -102,27 +100,27 @@ fcb_init(int f_area_id, struct fcb *fcb)
 	struct fcb_disk_area fda;
 	const struct flash_parameters *fparam;
 
-	if (!fcb->f_sectors || fcb->f_sector_cnt - fcb->f_scratch_cnt < 1) {
+	if (!fcbp->f_sectors || fcbp->f_sector_cnt - fcbp->f_scratch_cnt < 1) {
 		return -EINVAL;
 	}
 
-	rc = flash_area_open(f_area_id, &fcb->fap);
+	rc = flash_area_open(f_area_id, &fcbp->fap);
 	if (rc != 0) {
 		return -EINVAL;
 	}
 
-	fparam = flash_get_parameters(fcb->fap->fa_dev);
-	fcb->f_erase_value = fparam->erase_value;
+	fparam = flash_get_parameters(fcbp->fap->fa_dev);
+	fcbp->f_erase_value = fparam->erase_value;
 
-	align = fcb_get_align(fcb);
+	align = fcb_get_align(fcbp);
 	if (align == 0U) {
 		return -EINVAL;
 	}
 
 	/* Fill last used, first used */
-	for (i = 0; i < fcb->f_sector_cnt; i++) {
-		sector = &fcb->f_sectors[i];
-		rc = fcb_sector_hdr_read(fcb, sector, &fda);
+	for (i = 0; i < fcbp->f_sector_cnt; i++) {
+		sector = &fcbp->f_sectors[i];
+		rc = fcb_sector_hdr_read(fcbp, sector, &fda);
 		if (rc < 0) {
 			return rc;
 		}
@@ -146,21 +144,21 @@ fcb_init(int f_area_id, struct fcb *fcb)
 		/*
 		 * No initialized areas.
 		 */
-		oldest_sector = newest_sector = &fcb->f_sectors[0];
-		rc = fcb_sector_hdr_init(fcb, oldest_sector, 0);
+		oldest_sector = newest_sector = &fcbp->f_sectors[0];
+		rc = fcb_sector_hdr_init(fcbp, oldest_sector, 0);
 		if (rc) {
 			return rc;
 		}
 		newest = oldest = 0;
 	}
-	fcb->f_align = align;
-	fcb->f_oldest = oldest_sector;
-	fcb->f_active.fe_sector = newest_sector;
-	fcb->f_active.fe_elem_off = fcb_len_in_flash(fcb, sizeof(struct fcb_disk_area));
-	fcb->f_active_id = newest;
+	fcbp->f_align = align;
+	fcbp->f_oldest = oldest_sector;
+	fcbp->f_active.fe_sector = newest_sector;
+	fcbp->f_active.fe_elem_off = fcb_len_in_flash(fcbp, sizeof(struct fcb_disk_area));
+	fcbp->f_active_id = newest;
 
 	while (1) {
-		rc = fcb_getnext_in_sector(fcb, &fcb->f_active);
+		rc = fcb_getnext_in_sector(fcbp, &fcbp->f_active);
 		if (rc == -ENOTSUP) {
 			rc = 0;
 			break;
@@ -169,31 +167,29 @@ fcb_init(int f_area_id, struct fcb *fcb)
 			break;
 		}
 	}
-	k_mutex_init(&fcb->f_mtx);
+	k_mutex_init(&fcbp->f_mtx);
 	return rc;
 }
 
-int
-fcb_free_sector_cnt(struct fcb *fcb)
+int fcb_free_sector_cnt(struct fcb *fcbp)
 {
 	int i;
 	struct flash_sector *fa;
 
-	fa = fcb->f_active.fe_sector;
-	for (i = 0; i < fcb->f_sector_cnt; i++) {
-		fa = fcb_getnext_sector(fcb, fa);
-		if (fa == fcb->f_oldest) {
+	fa = fcbp->f_active.fe_sector;
+	for (i = 0; i < fcbp->f_sector_cnt; i++) {
+		fa = fcb_getnext_sector(fcbp, fa);
+		if (fa == fcbp->f_oldest) {
 			break;
 		}
 	}
 	return i;
 }
 
-int
-fcb_is_empty(struct fcb *fcb)
+int fcb_is_empty(struct fcb *fcbp)
 {
-	return (fcb->f_active.fe_sector == fcb->f_oldest &&
-	  fcb->f_active.fe_elem_off == fcb_len_in_flash(fcb, sizeof(struct fcb_disk_area)));
+	return (fcbp->f_active.fe_sector == fcbp->f_oldest &&
+		fcbp->f_active.fe_elem_off == fcb_len_in_flash(fcbp, sizeof(struct fcb_disk_area)));
 }
 
 /**
@@ -217,36 +213,33 @@ fcb_is_empty(struct fcb *fcb)
  * to correctly use the first bit of byte to figure out how many bytes are there
  * and if there is any data at all or both bytes are equal to erase value.
  */
-int
-fcb_put_len(const struct fcb *fcb, uint8_t *buf, uint16_t len)
+int fcb_put_len(const struct fcb *fcbp, uint8_t *buf, uint16_t len)
 {
 	if (len < 0x80) {
-		buf[0] = len ^ ~fcb->f_erase_value;
+		buf[0] = len ^ ~fcbp->f_erase_value;
 		return 1;
 	} else if (len <= FCB_MAX_LEN) {
-		buf[0] = (len | 0x80) ^ ~fcb->f_erase_value;
-		buf[1] = (len >> 7) ^ ~fcb->f_erase_value;
+		buf[0] = (len | 0x80) ^ ~fcbp->f_erase_value;
+		buf[1] = (len >> 7) ^ ~fcbp->f_erase_value;
 		return 2;
 	} else {
 		return -EINVAL;
 	}
 }
 
-int
-fcb_get_len(const struct fcb *fcb, uint8_t *buf, uint16_t *len)
+int fcb_get_len(const struct fcb *fcbp, uint8_t *buf, uint16_t *len)
 {
 	int rc;
 	uint8_t buf0_xor;
 	uint8_t buf1_xor;
 
-	buf0_xor = buf[0] ^ ~fcb->f_erase_value;
+	buf0_xor = buf[0] ^ ~fcbp->f_erase_value;
 	if (buf0_xor & 0x80) {
-		if ((buf[0] == fcb->f_erase_value) &&
-		    (buf[1] == fcb->f_erase_value)) {
+		if ((buf[0] == fcbp->f_erase_value) && (buf[1] == fcbp->f_erase_value)) {
 			return -ENOTSUP;
 		}
 
-		buf1_xor = buf[1] ^ ~fcb->f_erase_value;
+		buf1_xor = buf[1] ^ ~fcbp->f_erase_value;
 		*len = (uint16_t)((buf0_xor & 0x7f) | ((uint16_t)buf1_xor << 7));
 		rc = 2;
 	} else {
@@ -259,18 +252,17 @@ fcb_get_len(const struct fcb *fcb, uint8_t *buf, uint16_t *len)
 /**
  * Initialize erased sector for use.
  */
-int
-fcb_sector_hdr_init(struct fcb *fcb, struct flash_sector *sector, uint16_t id)
+int fcb_sector_hdr_init(struct fcb *fcbp, struct flash_sector *sector, uint16_t id)
 {
 	struct fcb_disk_area fda;
 	int rc;
 
-	fda.fd_magic = fcb_flash_magic(fcb);
-	fda.fd_ver = fcb->f_version;
-	fda._pad = fcb->f_erase_value;
+	fda.fd_magic = fcb_flash_magic(fcbp);
+	fda.fd_ver = fcbp->f_version;
+	fda._pad = fcbp->f_erase_value;
 	fda.fd_id = id;
 
-	rc = fcb_flash_write(fcb, sector, 0, &fda, sizeof(fda));
+	rc = fcb_flash_write(fcbp, sector, 0, &fda, sizeof(fda));
 	if (rc != 0) {
 		return -EIO;
 	}
@@ -283,8 +275,7 @@ fcb_sector_hdr_init(struct fcb *fcb, struct flash_sector *sector, uint16_t id)
  * Returns 0 if sector is unused;
  * Returns 1 if sector has data.
  */
-int fcb_sector_hdr_read(struct fcb *fcb, struct flash_sector *sector,
-			struct fcb_disk_area *fdap)
+int fcb_sector_hdr_read(struct fcb *fcbp, struct flash_sector *sector, struct fcb_disk_area *fdap)
 {
 	struct fcb_disk_area fda;
 	int rc;
@@ -292,14 +283,14 @@ int fcb_sector_hdr_read(struct fcb *fcb, struct flash_sector *sector,
 	if (!fdap) {
 		fdap = &fda;
 	}
-	rc = fcb_flash_read(fcb, sector, 0, fdap, sizeof(*fdap));
+	rc = fcb_flash_read(fcbp, sector, 0, fdap, sizeof(*fdap));
 	if (rc) {
 		return -EIO;
 	}
-	if (fdap->fd_magic == MK32(fcb->f_erase_value)) {
+	if (fdap->fd_magic == MK32(fcbp->f_erase_value)) {
 		return 0;
 	}
-	if (fdap->fd_magic != fcb_flash_magic(fcb)) {
+	if (fdap->fd_magic != fcb_flash_magic(fcbp)) {
 		return -ENOMSG;
 	}
 	return 1;
@@ -312,9 +303,7 @@ int fcb_sector_hdr_read(struct fcb *fcb, struct flash_sector *sector,
  * @param2 ptr to the fcb_entry to be returned
  * @return 0 on there are any fcbs aviable; -ENOENT otherwise
  */
-int
-fcb_offset_last_n(struct fcb *fcb, uint8_t entries,
-		struct fcb_entry *last_n_entry)
+int fcb_offset_last_n(struct fcb *fcbp, uint8_t entries, struct fcb_entry *last_n_entry)
 {
 	struct fcb_entry loc;
 	int i;
@@ -327,14 +316,14 @@ fcb_offset_last_n(struct fcb *fcb, uint8_t entries,
 
 	i = 0;
 	(void)memset(&loc, 0, sizeof(loc));
-	while (!fcb_getnext(fcb, &loc)) {
+	while (!fcb_getnext(fcbp, &loc)) {
 		if (i == 0) {
 			/* Start from the beginning of fcb entries */
 			*last_n_entry = loc;
 		}
 		/* Update last_n_entry after n entries and keep updating */
 		else if (i > (entries - 1)) {
-			rc = fcb_getnext(fcb, last_n_entry);
+			rc = fcb_getnext(fcbp, last_n_entry);
 
 			if (rc) {
 				/* A fcb history must have been erased,
@@ -354,14 +343,13 @@ fcb_offset_last_n(struct fcb *fcb, uint8_t entries,
  * @param fcb
  * @return 0 on success; non-zero on failure
  */
-int
-fcb_clear(struct fcb *fcb)
+int fcb_clear(struct fcb *fcbp)
 {
 	int rc;
 
 	rc = 0;
-	while (!fcb_is_empty(fcb)) {
-		rc = fcb_rotate(fcb);
+	while (!fcb_is_empty(fcbp)) {
+		rc = fcb_rotate(fcbp);
 		if (rc) {
 			break;
 		}

--- a/subsys/fs/fcb/fcb_priv.h
+++ b/subsys/fs/fcb/fcb_priv.h
@@ -8,6 +8,10 @@
 #ifndef __FCB_PRIV_H_
 #define __FCB_PRIV_H_
 
+#include <stdint.h>
+
+#include <zephyr/fs/fcb.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -35,11 +39,11 @@ extern "C" {
  *
  * @return uin32_t formatted magic value
  */
-static inline uint32_t fcb_flash_magic(const struct fcb *fcb)
+static inline uint32_t fcb_flash_magic(const struct fcb *fcbp)
 {
-	const uint8_t ev = fcb->f_erase_value;
+	const uint8_t ev = fcbp->f_erase_value;
 
-	return (fcb->f_magic ^ ~MK32(ev));
+	return (fcbp->f_magic ^ ~MK32(ev));
 }
 
 struct fcb_disk_area {
@@ -49,32 +53,30 @@ struct fcb_disk_area {
 	uint16_t fd_id;
 };
 
-int fcb_put_len(const struct fcb *fcb, uint8_t *buf, uint16_t len);
-int fcb_get_len(const struct fcb *fcb, uint8_t *buf, uint16_t *len);
+int fcb_put_len(const struct fcb *fcbp, uint8_t *buf, uint16_t len);
+int fcb_get_len(const struct fcb *fcbp, uint8_t *buf, uint16_t *len);
 
-static inline int fcb_len_in_flash(struct fcb *fcb, uint16_t len)
+static inline int fcb_len_in_flash(struct fcb *fcbp, uint16_t len)
 {
-	if (fcb->f_align <= 1U) {
+	if (fcbp->f_align <= 1U) {
 		return len;
 	}
-	return (len + (fcb->f_align - 1U)) & ~(fcb->f_align - 1U);
+	return (len + (fcbp->f_align - 1U)) & ~(fcbp->f_align - 1U);
 }
 
-const struct flash_area *fcb_open_flash(const struct fcb *fcb);
-uint8_t fcb_get_align(const struct fcb *fcb);
-int fcb_erase_sector(const struct fcb *fcb, const struct flash_sector *sector);
+const struct flash_area *fcb_open_flash(const struct fcb *fcbp);
+uint8_t fcb_get_align(const struct fcb *fcbp);
+int fcb_erase_sector(const struct fcb *fcbp, const struct flash_sector *sector);
 
-int fcb_getnext_in_sector(struct fcb *fcb, struct fcb_entry *loc);
-struct flash_sector *fcb_getnext_sector(struct fcb *fcb,
-					struct flash_sector *sector);
-int fcb_getnext_nolock(struct fcb *fcb, struct fcb_entry *loc);
+int fcb_getnext_in_sector(struct fcb *fcbp, struct fcb_entry *loc);
+struct flash_sector *fcb_getnext_sector(struct fcb *fcbp, struct flash_sector *sector);
+int fcb_getnext_nolock(struct fcb *fcbp, struct fcb_entry *loc);
 
-int fcb_elem_info(struct fcb *fcb, struct fcb_entry *loc);
-int fcb_elem_endmarker(struct fcb *fcb, struct fcb_entry *loc, uint8_t *crc8p);
+int fcb_elem_info(struct fcb *fcbp, struct fcb_entry *loc);
+int fcb_elem_endmarker(struct fcb *fcbp, struct fcb_entry *loc, uint8_t *crc8p);
 
-int fcb_sector_hdr_init(struct fcb *fcb, struct flash_sector *sector, uint16_t id);
-int fcb_sector_hdr_read(struct fcb *fcb, struct flash_sector *sector,
-			struct fcb_disk_area *fdap);
+int fcb_sector_hdr_init(struct fcb *fcbp, struct flash_sector *sector, uint16_t id);
+int fcb_sector_hdr_read(struct fcb *fcbp, struct flash_sector *sector, struct fcb_disk_area *fdap);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Even just making minor edits to fcb, warnings are triggered from Coding Guidelines of the form

```shell
Violation to rule 5.7 (Tag name should be unique) tag: fcb
```

Rename pointer variable names to fcbp.