### PR TITLE
drivers: clock_control: stm32h7: disable PLLs before configuration and guard for XIP

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -766,7 +766,36 @@ static int set_up_plls(void)
 		stm32_clock_switch_to_hsi();
 		LL_RCC_SetAHBPrescaler(LL_RCC_SYSCLK_DIV_1);
 	}
+
+#if defined(CONFIG_STM32_MEMMAP) && defined(CONFIG_BOOTLOADER_MCUBOOT)
+	/*
+	 * Don't disable PLL during application initialization
+	 * that runs in memmap mode when (Q/O)SPI uses PLL
+	 * as its clock source.
+	 */
+#if defined(OCTOSPI1) || defined(OCTOSPI2)
+	if (LL_RCC_GetOSPIClockSource(LL_RCC_OSPI_CLKSOURCE) != LL_RCC_OSPI_CLKSOURCE_PLL1Q) {
+		LL_RCC_PLL1_Disable();
+	}
+	if (LL_RCC_GetOSPIClockSource(LL_RCC_OSPI_CLKSOURCE) != LL_RCC_OSPI_CLKSOURCE_PLL2R) {
+		LL_RCC_PLL2_Disable();
+	}
+#elif defined(QUADSPI)
+	if (LL_RCC_GetQSPIClockSource(LL_RCC_QSPI_CLKSOURCE) != LL_RCC_QSPI_CLKSOURCE_PLL1Q) {
+		LL_RCC_PLL1_Disable();
+	}
+	if (LL_RCC_GetQSPIClockSource(LL_RCC_QSPI_CLKSOURCE) != LL_RCC_QSPI_CLKSOURCE_PLL2R) {
+		LL_RCC_PLL2_Disable();
+	}
+#else
 	LL_RCC_PLL1_Disable();
+	LL_RCC_PLL2_Disable();
+#endif
+#else
+	LL_RCC_PLL1_Disable();
+	LL_RCC_PLL2_Disable();
+#endif
+	LL_RCC_PLL3_Disable();
 
 	/* Configure PLL source */
 


### PR DESCRIPTION
Extends #57337 to disable every PLL before configuration.
That allows an application to reconfigure PLLs after being configured by a bootloader.
At the same time, always disable PLLs to allow the bootloader to configure them after a restart.

However, we don't want to disable the PLL clock if it is used by (Q|O)SPI when
executing from external memory.

Fixes #75653 in a non-invasive way.

Overall. it is possible to implement complete clock reconfiguration of the
(Q|O)SPI when it runs from PLL(1|2) in XIP.

The RM0468 states that RCC `OCTOSPISEL` can be modified on the fly/at runtime.
However, there are other open questions. Will (Q|O)SPI configured for PLL (_by a bootloader_)
work with external memory in all cases with reduced frequency (_when switched to HCLK for some time_)?

Moreover, the drivers will need to reconfigure the peripheral. For example, the prescaler requires
aborting memory map mode during execution from it. That and other aspects (_sfdp read_) will require
some refactoring.