### PR TITLE
Bluetooth: ISO/BAP: Refactor BIS bitfield

### DIFF
--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -27,6 +27,7 @@
 #include <zephyr/bluetooth/buf.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/hci.h>
+#include <zephyr/sys/util_macro.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -46,6 +47,16 @@ extern "C" {
  *  @return Needed buffer size to match the requested ISO SDU MTU.
  */
 #define BT_ISO_SDU_BUF_SIZE(mtu) BT_BUF_ISO_SIZE(mtu)
+
+/**
+ * Convert BIS index to bit
+ *
+ * The BIS indexes start from 0x01, so the lowest allowed bit is
+ * BIT(0) that represents index 0x01. To synchronize to e.g. BIS
+ * indexes 0x01 and 0x02, the bitfield value should be BIT(0) | BIT(1).
+ * As a general notation, to sync to BIS index N use BIT(N - 1).
+ */
+#define BT_ISO_BIS_INDEX_BIT(x) (BIT((x) - 1))
 
 /** Value to set the ISO data path over HCi. */
 #define BT_ISO_DATA_PATH_HCI        0x00
@@ -548,9 +559,10 @@ struct bt_iso_big_sync_param {
 	/**
 	 * @brief Bitfield of the BISes to sync to
 	 *
-	 * The BIS indexes start from 0x01, so the lowest allowed bit is
-	 * BIT(1) that represents index 0x01. To synchronize to e.g. BIS
-	 * indexes 0x01 and 0x02, the bitfield value should be BIT(1) | BIT(2).
+	 * Use @ref BT_ISO_BIS_INDEX_BIT to convert BIS indexes to a bitfield.
+	 *
+	 * To synchronize to e.g. BIS indexes 0x01 and 0x02, this can be set to
+	 * BT_ISO_BIS_INDEX_BIT(0x01) | BT_ISO_BIS_INDEX_BIT(0x02).
 	 */
 	uint32_t bis_bitfield;
 

--- a/samples/bluetooth/bap_broadcast_assistant/src/main.c
+++ b/samples/bluetooth/bap_broadcast_assistant/src/main.c
@@ -181,7 +181,7 @@ static bool add_pa_sync_base_subgroup_bis_cb(const struct bt_bap_base_subgroup_b
 {
 	struct bt_bap_bass_subgroup *subgroup_param = user_data;
 
-	subgroup_param->bis_sync |= BIT(bis->index);
+	subgroup_param->bis_sync |= BT_ISO_BIS_INDEX_BIT(bis->index);
 
 	return true;
 }

--- a/samples/bluetooth/iso_broadcast_benchmark/src/receiver.c
+++ b/samples/bluetooth/iso_broadcast_benchmark/src/receiver.c
@@ -372,9 +372,9 @@ static int create_big_sync(struct bt_iso_big **big, struct bt_le_per_adv_sync *s
 					    BT_ISO_SYNC_TIMEOUT_MIN,
 					    BT_ISO_SYNC_TIMEOUT_MAX);
 	big_sync_param.num_bis = bis_count;
-	/* BIS indexes start from 0x01, so add one to `i` */
+	/* BIS indexes start from 0x01 */
 	for (int i = 1; i <= big_sync_param.num_bis; i++) {
-		big_sync_param.bis_bitfield |= BIT(i);
+		big_sync_param.bis_bitfield |= BT_ISO_BIS_INDEX_BIT(i);
 	}
 
 	LOG_INF("Syncing to BIG");

--- a/samples/bluetooth/iso_receive/src/main.c
+++ b/samples/bluetooth/iso_receive/src/main.c
@@ -276,7 +276,7 @@ static struct bt_iso_chan *bis[] = {
 static struct bt_iso_big_sync_param big_sync_param = {
 	.bis_channels = bis,
 	.num_bis = BIS_ISO_CHAN_COUNT,
-	.bis_bitfield = (BIT_MASK(BIS_ISO_CHAN_COUNT) << 1),
+	.bis_bitfield = (BIT_MASK(BIS_ISO_CHAN_COUNT)),
 	.mse = BT_ISO_SYNC_MSE_ANY, /* any number of subevents */
 	.sync_timeout = 100, /* in 10 ms units */
 };

--- a/subsys/bluetooth/audio/bap_base.c
+++ b/subsys/bluetooth/audio/bap_base.c
@@ -593,7 +593,7 @@ static bool base_subgroup_bis_cb(const struct bt_bap_base_subgroup_bis *bis, voi
 {
 	uint32_t *base_bis_index_bitfield = user_data;
 
-	*base_bis_index_bitfield |= BIT(bis->index);
+	*base_bis_index_bitfield |= BT_ISO_BIS_INDEX_BIT(bis->index);
 
 	return true;
 }

--- a/subsys/bluetooth/audio/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/bap_broadcast_assistant.c
@@ -1219,12 +1219,7 @@ int bt_bap_broadcast_assistant_add_src(struct bt_conn *conn,
 
 		subgroup = net_buf_simple_add(&att_buf, subgroup_size);
 
-		if (param->subgroups[i].bis_sync != BT_BAP_BIS_SYNC_NO_PREF) {
-			/* The BIS Index bitfield to be sent must use BIT(0) for BIS Index 1 */
-			subgroup->bis_sync = param->subgroups[i].bis_sync >> 1;
-		} else {
-			subgroup->bis_sync = BT_BAP_BIS_SYNC_NO_PREF;
-		}
+		subgroup->bis_sync = param->subgroups[i].bis_sync;
 
 		CHECKIF(param->pa_sync == 0 && subgroup->bis_sync != 0) {
 			LOG_DBG("Only syncing to BIS is not allowed");
@@ -1324,12 +1319,7 @@ int bt_bap_broadcast_assistant_mod_src(struct bt_conn *conn,
 		}
 		subgroup = net_buf_simple_add(&att_buf, subgroup_size);
 
-		if (param->subgroups[i].bis_sync != BT_BAP_BIS_SYNC_NO_PREF) {
-			/* The BIS Index bitfield to be sent must use BIT(0) for BIS Index 1 */
-			subgroup->bis_sync = param->subgroups[i].bis_sync >> 1;
-		} else {
-			subgroup->bis_sync = BT_BAP_BIS_SYNC_NO_PREF;
-		}
+		subgroup->bis_sync = param->subgroups[i].bis_sync;
 
 		CHECKIF(param->pa_sync == 0 && subgroup->bis_sync != 0) {
 			LOG_DBG("Only syncing to BIS is not allowed");

--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -602,7 +602,7 @@ static bool base_subgroup_bis_index_cb(const struct bt_bap_base_subgroup_bis *bi
 	sink_subgroup = &data->subgroups[data->subgroup_count];
 
 	sink_bis->index = bis->index;
-	sink_subgroup->bis_indexes |= BIT(bis->index);
+	sink_subgroup->bis_indexes |= BT_ISO_BIS_INDEX_BIT(bis->index);
 
 #if CONFIG_BT_AUDIO_CODEC_CFG_MAX_DATA_SIZE > 0
 
@@ -1169,13 +1169,8 @@ int bt_bap_broadcast_sink_sync(struct bt_bap_broadcast_sink *sink, uint32_t inde
 		return -EINVAL;
 	}
 
-	CHECKIF(indexes_bitfield == 0) {
-		LOG_DBG("indexes_bitfield is 0");
-		return -EINVAL;
-	}
-
-	CHECKIF(indexes_bitfield & BIT(0)) {
-		LOG_DBG("BIT(0) is not a valid BIS index");
+	CHECKIF(indexes_bitfield == 0U || indexes_bitfield > BIT_MASK(BT_ISO_BIS_INDEX_MAX)) {
+		LOG_DBG("Invalid indexes_bitfield: 0x%08X", indexes_bitfield);
 		return -EINVAL;
 	}
 
@@ -1217,7 +1212,7 @@ int bt_bap_broadcast_sink_sync(struct bt_bap_broadcast_sink *sink, uint32_t inde
 
 	stream_count = 0;
 	for (int i = 1; i < BT_ISO_MAX_GROUP_ISO_COUNT; i++) {
-		if ((indexes_bitfield & BIT(i)) != 0) {
+		if ((indexes_bitfield & BT_ISO_BIS_INDEX_BIT(i)) != 0) {
 			struct bt_audio_codec_cfg *codec_cfg =
 				codec_cfg_from_base_by_index(sink, i);
 

--- a/subsys/bluetooth/audio/bap_internal.h
+++ b/subsys/bluetooth/audio/bap_internal.h
@@ -16,6 +16,7 @@
 #include <zephyr/bluetooth/audio/bap.h>
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/iso.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/types.h>
 
@@ -135,7 +136,7 @@ static inline bool valid_bis_syncs(uint32_t bis_sync)
 		return true;
 	}
 
-	if (bis_sync > BIT_MASK(31)) { /* Max BIS index */
+	if (bis_sync > BIT_MASK(BT_ISO_MAX_GROUP_ISO_COUNT)) {
 		return false;
 	}
 

--- a/subsys/bluetooth/audio/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/bap_scan_delegator.c
@@ -205,7 +205,7 @@ static void net_buf_put_recv_state(const struct bass_recv_state_internal *recv_s
 	for (int i = 0; i < state->num_subgroups; i++) {
 		const struct bt_bap_bass_subgroup *subgroup = &state->subgroups[i];
 
-		(void)net_buf_simple_add_le32(&read_buf, subgroup->bis_sync >> 1);
+		(void)net_buf_simple_add_le32(&read_buf, subgroup->bis_sync);
 		(void)net_buf_simple_add_u8(&read_buf, subgroup->metadata_len);
 		(void)net_buf_simple_add_mem(&read_buf, subgroup->metadata,
 					     subgroup->metadata_len);
@@ -602,10 +602,6 @@ static int scan_delegator_add_source(struct bt_conn *conn,
 		}
 
 		internal_state->requested_bis_sync[i] = net_buf_simple_pull_le32(buf);
-		if (internal_state->requested_bis_sync[i] != BT_BAP_BIS_SYNC_NO_PREF) {
-			/* Received BIS Index bitfield uses BIT(0) for BIS Index 1 */
-			internal_state->requested_bis_sync[i] <<= 1;
-		}
 
 		if (internal_state->requested_bis_sync[i] &&
 		    pa_sync == BT_BAP_BASS_PA_REQ_NO_SYNC) {
@@ -768,10 +764,6 @@ static int scan_delegator_mod_src(struct bt_conn *conn,
 		old_bis_sync_req = internal_state->requested_bis_sync[i];
 
 		internal_state->requested_bis_sync[i] = net_buf_simple_pull_le32(buf);
-		if (internal_state->requested_bis_sync[i] != BT_BAP_BIS_SYNC_NO_PREF) {
-			/* Received BIS Index bitfield uses BIT(0) for BIS Index 1 */
-			internal_state->requested_bis_sync[i] <<= 1;
-		}
 
 		if (internal_state->requested_bis_sync[i] &&
 		    pa_sync == BT_BAP_BASS_PA_REQ_NO_SYNC) {

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -3477,7 +3477,7 @@ static int cmd_sync_broadcast(const struct shell *sh, size_t argc, char *argv[])
 				return -ENOEXEC;
 			}
 
-			bis_bitfield |= BIT(val);
+			bis_bitfield |= BT_ISO_BIS_INDEX_BIT(val);
 			stream_cnt++;
 		}
 	}

--- a/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
@@ -879,7 +879,7 @@ static inline bool add_pa_sync_base_subgroup_bis_cb(const struct bt_bap_base_sub
 {
 	struct bt_bap_bass_subgroup *subgroup_param = user_data;
 
-	subgroup_param->bis_sync |= BIT(bis->index);
+	subgroup_param->bis_sync |= BT_ISO_BIS_INDEX_BIT(bis->index);
 
 	return true;
 }
@@ -995,7 +995,7 @@ static int cmd_bap_broadcast_assistant_add_pa_sync(const struct shell *sh,
 			return -ENOEXEC;
 		}
 
-		bis_bitfield_req |= BIT(index);
+		bis_bitfield_req |= BT_ISO_BIS_INDEX_BIT(index);
 	}
 
 	param.subgroups = subgroup_params;

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -3296,7 +3296,7 @@ static int hci_le_big_create_sync(const struct bt_le_per_adv_sync *sync, struct 
 	req->num_bis = big->num_bis;
 	/* Transform from bitfield to array */
 	for (int i = 1; i <= BT_ISO_MAX_GROUP_ISO_COUNT; i++) {
-		if (param->bis_bitfield & BIT(i)) {
+		if (param->bis_bitfield & BT_ISO_BIS_INDEX_BIT(i)) {
 			if (bit_idx == big->num_bis) {
 				LOG_DBG("BIG cannot contain %u BISes", bit_idx + 1);
 				return -EINVAL;
@@ -3340,7 +3340,7 @@ int bt_iso_big_sync(struct bt_le_per_adv_sync *sync, struct bt_iso_big_sync_para
 		return -EINVAL;
 	}
 
-	CHECKIF(param->bis_bitfield <= BIT(0)) {
+	CHECKIF(param->bis_bitfield == 0U || param->bis_bitfield > BIT_MASK(BT_ISO_BIS_INDEX_MAX)) {
 		LOG_DBG("Invalid BIS bitfield 0x%08x", param->bis_bitfield);
 		return -EINVAL;
 	}

--- a/subsys/bluetooth/shell/iso.c
+++ b/subsys/bluetooth/shell/iso.c
@@ -813,7 +813,7 @@ static int cmd_big_sync(const struct shell *sh, size_t argc, char *argv[])
 		return -ENOEXEC;
 	}
 
-	if (bis_bitfield > BIT_MASK(BT_ISO_BIS_INDEX_MAX)) {
+	if (bis_bitfield == 0U || bis_bitfield > BIT_MASK(BT_ISO_BIS_INDEX_MAX)) {
 		shell_error(sh, "Invalid bis_bitfield: %lu", bis_bitfield);
 
 		return -ENOEXEC;

--- a/tests/bluetooth/audio/bap_base/src/main.c
+++ b/tests/bluetooth/audio/bap_base/src/main.c
@@ -221,7 +221,7 @@ ZTEST_F(bap_base_test_suite, test_base_get_bis_indexes)
 
 	ret = bt_bap_base_get_bis_indexes(base, &bis_indexes);
 	zassert_equal(ret, 0, "Unexpected return value: %d", ret);
-	zassert_equal(bis_indexes, 0x00000006 /* Bit 1 and 2 */,
+	zassert_equal(bis_indexes, 0x00000003 /* Bit 1 and 2 */,
 		      "Unexpected BIS index value: 0x%08X", bis_indexes);
 }
 

--- a/tests/bluetooth/audio/cap_commander/src/test_broadcast_reception.c
+++ b/tests/bluetooth/audio/cap_commander/src/test_broadcast_reception.c
@@ -92,7 +92,7 @@ static void test_start_param_init(void *f)
 	fixture->start_param.count = ARRAY_SIZE(fixture->start_member_params);
 
 	for (size_t i = 0; i < ARRAY_SIZE(fixture->start_subgroups); i++) {
-		fixture->start_subgroups[i].bis_sync = 1 << i;
+		fixture->start_subgroups[i].bis_sync = i;
 		fixture->start_subgroups[i].metadata_len = 0;
 	}
 

--- a/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
@@ -609,7 +609,7 @@ static bool base_subgroup_bis_cb(const struct bt_bap_base_subgroup_bis *bis, voi
 	struct bt_audio_codec_cfg *codec_cfg = &parse_data->codec_cfg;
 	struct btp_bap_broadcast_remote_source *broadcaster = parse_data->broadcaster;
 
-	parse_data->bis_bitfield |= BIT(bis->index);
+	parse_data->bis_bitfield |= BT_ISO_BIS_INDEX_BIT(bis->index);
 
 	if (parse_data->stream_cnt < ARRAY_SIZE(broadcaster->streams)) {
 		struct btp_bap_broadcast_stream *stream =

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_assistant_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_assistant_test.c
@@ -452,7 +452,7 @@ static void test_bass_mod_source(void)
 	mod_src_param.pa_sync = true;
 	mod_src_param.subgroups = &subgroup;
 	mod_src_param.pa_interval = g_broadcaster_info.interval;
-	subgroup.bis_sync = BIT(1) | BIT(2); /* Indexes 1 and 2 */
+	subgroup.bis_sync = BT_ISO_BIS_INDEX_BIT(1) | BT_ISO_BIS_INDEX_BIT(2); /* Indexes 1 and 2 */
 	subgroup.metadata_len = 0;
 
 	err = bt_bap_broadcast_assistant_mod_src(default_conn, &mod_src_param);
@@ -482,7 +482,7 @@ static void test_bass_mod_source_long_meta(void)
 	mod_src_param.pa_sync = true;
 	mod_src_param.subgroups = &subgroup;
 	mod_src_param.pa_interval = g_broadcaster_info.interval;
-	subgroup.bis_sync = BIT(1) | BIT(2);
+	subgroup.bis_sync = BT_ISO_BIS_INDEX_BIT(1) | BT_ISO_BIS_INDEX_BIT(2);
 
 	subgroup.metadata_len = sizeof(metadata);
 	memcpy(subgroup.metadata, metadata, sizeof(metadata));

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
@@ -804,7 +804,7 @@ static void test_broadcast_sync_inval(void)
 		return;
 	}
 
-	bis_index = BIT(0);
+	bis_index = BT_ISO_BIS_INDEX_BIT(BT_ISO_BIS_INDEX_MAX + 1);
 	err = bt_bap_broadcast_sink_sync(g_sink, bis_index, streams, NULL);
 	if (err == 0) {
 		FAIL("bt_bap_broadcast_sink_sync did not fail with invalid BIS indexes: 0x%08X\n",
@@ -821,7 +821,7 @@ static void test_broadcast_sync_inval(void)
 	memcpy(tmp_streams, streams, sizeof(streams));
 	bis_index = 0U;
 	for (size_t i = 0U; i < ARRAY_SIZE(tmp_streams); i++) {
-		bis_index |= BIT(i + BT_ISO_BIS_INDEX_MIN);
+		bis_index |= BT_ISO_BIS_INDEX_BIT(i);
 	}
 
 	err = bt_bap_broadcast_sink_sync(g_sink, bis_index, tmp_streams, NULL);
@@ -833,7 +833,7 @@ static void test_broadcast_sync_inval(void)
 
 	bis_index = 0U;
 	for (size_t i = 0U; i < CONFIG_BT_BAP_BROADCAST_SNK_STREAM_COUNT + 1; i++) {
-		bis_index |= BIT(i + BT_ISO_BIS_INDEX_MIN);
+		bis_index |= BT_ISO_BIS_INDEX_BIT(i);
 	}
 
 	err = bt_bap_broadcast_sink_sync(g_sink, bis_index, tmp_streams, NULL);

--- a/tests/bsim/bluetooth/audio/src/bap_scan_delegator_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_scan_delegator_test.c
@@ -16,6 +16,7 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/byteorder.h>
 #include <zephyr/bluetooth/gap.h>
+#include <zephyr/bluetooth/iso.h>
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/kernel.h>
 #include <zephyr/net/buf.h>
@@ -650,7 +651,7 @@ static int sync_broadcast(struct sync_state *state)
 
 	/* We don't actually need to sync to the BIG/BISes */
 	err = bt_bap_scan_delegator_set_bis_sync_state(state->src_id,
-						       (uint32_t []){ BIT(1) });
+						       (uint32_t[]){BT_ISO_BIS_INDEX_BIT(1)});
 	if (err) {
 		return err;
 	}

--- a/tests/bsim/bluetooth/host/iso/bis/src/bis_receiver.c
+++ b/tests/bsim/bluetooth/host/iso/bis/src/bis_receiver.c
@@ -223,7 +223,7 @@ static void sync_big(struct bt_le_per_adv_sync *sync, uint8_t cnt, struct bt_iso
 	struct bt_iso_chan *bis_channels[CONFIG_BT_ISO_MAX_CHAN];
 	struct bt_iso_big_sync_param param = {
 		.sync_timeout = interval_to_sync_timeout(broadcaster_info.interval),
-		.bis_bitfield = BIT_MASK(cnt) << 1U, /* BIS indexes start from 1, thus shift by 1 */
+		.bis_bitfield = BIT_MASK(cnt),
 		.bis_channels = bis_channels,
 		.mse = BT_ISO_SYNC_MSE_MIN,
 		.encryption = false,

--- a/tests/bsim/bluetooth/ll/bis/src/main.c
+++ b/tests/bsim/bluetooth/ll/bis/src/main.c
@@ -907,7 +907,7 @@ static void test_iso_recv_main(void)
 	bis_iso_qos.rx = &iso_rx_qos;
 	big_param.bis_channels = bis_channels;
 	big_param.num_bis = BIS_ISO_CHAN_COUNT;
-	big_param.bis_bitfield = BIT(1); /* BIS 1 selected */
+	big_param.bis_bitfield = BT_ISO_BIS_INDEX_BIT(1); /* BIS 1 selected */
 	big_param.mse = 1;
 	big_param.sync_timeout = 100; /* 1000 ms */
 	big_param.encryption = false;
@@ -1124,7 +1124,7 @@ static void test_iso_recv_vs_dp_main(void)
 	bis_iso_qos.rx = &iso_rx_qos;
 	big_param.bis_channels = bis_channels;
 	big_param.num_bis = BIS_ISO_CHAN_COUNT;
-	big_param.bis_bitfield = BIT(1); /* BIS 1 selected */
+	big_param.bis_bitfield = BT_ISO_BIS_INDEX_BIT(1); /* BIS 1 selected */
 	big_param.mse = 1;
 	big_param.sync_timeout = 100; /* 1000 ms */
 	big_param.encryption = false;


### PR DESCRIPTION
Refactors teh BIS bitfield values used for ISO
and BAP.

Previously BIT(1) meant BIS index 1, which was a Zephyr choice in the early days of ISO, as the BT Core spec did not use a bitfield for BIS indexes.

Later the BASS specification came along and defined that BIT(0) meant BIS index 1, which meant that we had to shift BIS bitfields between BAP and ISO.

This commit refactors the ISO layer to use BIT(0) for Index 1 now, which means that there is no longer a need for conversion between the BAP and ISO layers, and that we can use a value range defined by a BT Core spec (BASS).

fixes https://github.com/zephyrproject-rtos/zephyr/issues/64838