### PR TITLE
net: lib: http_server: Close sockets on server core errors

### DIFF
--- a/subsys/net/lib/http/Kconfig
+++ b/subsys/net/lib/http/Kconfig
@@ -123,6 +123,16 @@ config HTTP_SERVER_RESOURCE_WILDCARD
 	  This means that instead of specifying multiple resources with exact
 	  string matches, one resource handler could handle multiple URLs.
 
+config HTTP_SERVER_RESTART_DELAY
+	int "Delay before re-initialization when restarting server"
+	default 1000
+	range 1 60000
+	help
+	  In case server restarts for any reason, the server re-initialization
+	  will be delayed by this value (miliseconds). The delay is needed to
+	  allow any existing connections to finalize to avoid binding errors
+	  during initialization.
+
 endif
 
 # Hidden option to avoid having multiple individual options that are ORed together

--- a/subsys/net/lib/http/http_server_core.c
+++ b/subsys/net/lib/http/http_server_core.c
@@ -56,6 +56,8 @@ static struct http_server_ctx server_ctx;
 static K_SEM_DEFINE(server_start, 0, 1);
 static bool server_running;
 
+static void close_client_connection(struct http_client_ctx *client);
+
 int http_server_init(struct http_server_ctx *ctx)
 {
 	int proto;
@@ -241,7 +243,7 @@ static int accept_new_client(int server_fd)
 	return new_socket;
 }
 
-static int close_all_sockets(struct http_server_ctx *ctx)
+static void close_all_sockets(struct http_server_ctx *ctx)
 {
 	zsock_close(ctx->fds[0].fd); /* close eventfd */
 	ctx->fds[0].fd = -1;
@@ -251,11 +253,17 @@ static int close_all_sockets(struct http_server_ctx *ctx)
 			continue;
 		}
 
-		zsock_close(ctx->fds[i].fd);
+		if (i < ctx->listen_fds) {
+			zsock_close(ctx->fds[i].fd);
+		} else {
+			struct http_client_ctx *client =
+				&server_ctx.clients[i - ctx->listen_fds];
+
+			close_client_connection(client);
+		}
+
 		ctx->fds[i].fd = -1;
 	}
-
-	return 0;
 }
 
 static void client_release_resources(struct http_client_ctx *client)
@@ -479,7 +487,7 @@ static int http_server_run(struct http_server_ctx *ctx)
 		if (ret < 0) {
 			ret = -errno;
 			LOG_DBG("poll failed (%d)", ret);
-			return ret;
+			goto closing;
 		}
 
 		if (ret == 0) {
@@ -490,6 +498,7 @@ static int http_server_run(struct http_server_ctx *ctx)
 		if (ret == 1 && ctx->fds[0].revents) {
 			eventfd_read(ctx->fds[0].fd, &value);
 			LOG_DBG("Received stop event. exiting ..");
+			ret = 0;
 			goto closing;
 		}
 
@@ -523,7 +532,8 @@ static int http_server_run(struct http_server_ctx *ctx)
 
 				/* Listening socket error, abort. */
 				LOG_ERR("Listening socket error, aborting.");
-				return -sock_error;
+				ret = -sock_error;
+				goto closing;
 
 			}
 
@@ -614,7 +624,8 @@ static int http_server_run(struct http_server_ctx *ctx)
 
 closing:
 	/* Close all client connections and the server socket */
-	return close_all_sockets(ctx);
+	close_all_sockets(ctx);
+	return ret;
 }
 
 /* Compare two strings where the terminator is either "\0" or "?" */

--- a/subsys/net/lib/http/http_server_core.c
+++ b/subsys/net/lib/http/http_server_core.c
@@ -211,6 +211,8 @@ int http_server_init(struct http_server_ctx *ctx)
 
 	if (failed >= svc_count) {
 		LOG_ERR("All services failed (%d)", failed);
+		/* Close eventfd socket */
+		zsock_close(ctx->fds[0].fd);
 		return -ESRCH;
 	}
 
@@ -761,13 +763,17 @@ static void http_server_thread(void *p1, void *p2, void *p3)
 			ret = http_server_init(&server_ctx);
 			if (ret < 0) {
 				LOG_ERR("Failed to initialize HTTP2 server");
-				return;
+				goto again;
 			}
 
 			ret = http_server_run(&server_ctx);
-			if (server_running) {
-				LOG_INF("Re-starting server (%d)", ret);
+			if (!server_running) {
+				continue;
 			}
+
+again:
+			LOG_INF("Re-starting server (%d)", ret);
+			k_sleep(K_MSEC(CONFIG_HTTP_SERVER_RESTART_DELAY));
 		}
 	}
 }


### PR DESCRIPTION
In case of fatal errors (during poll() or when handling listening socket), the server operation is restarted. It was missed however, that sockets opened for the server should be closed in such case. This i commit fixes it.

Fixes #75658