### PR TITLE
use prep_c for xtensa to align with other architectures

### DIFF
--- a/arch/xtensa/core/CMakeLists.txt
+++ b/arch/xtensa/core/CMakeLists.txt
@@ -12,6 +12,7 @@ zephyr_library_sources(
   irq_manage.c
   thread.c
   vector_handlers.c
+  prep_c.c
   )
 
 zephyr_library_sources_ifdef(CONFIG_XTENSA_USE_CORE_CRT1 crt1.S)

--- a/arch/xtensa/core/crt1.S
+++ b/arch/xtensa/core/crt1.S
@@ -4,7 +4,7 @@
  */
 
 /*
- * Control arrives here at _start from the reset vector or from crt0-app.S.
+ * Control arrives here at _start from the reset vector.
  */
 
 #include <xtensa/coreasm.h>
@@ -52,7 +52,7 @@ _start:
 	/*
 	 *  _start is typically NOT at the beginning of the text segment --
 	 *  it is always called from either the reset vector (__start) or other
-	 *  code that does equivalent initialization (such as crt0-app.S).
+	 *  code that does equivalent initialization.
 	 *
 	 *  Assumptions on entry to _start:
 	 *	- low (level-one) and medium priority interrupts are disabled

--- a/arch/xtensa/core/crt1.S
+++ b/arch/xtensa/core/crt1.S
@@ -22,7 +22,7 @@
  */
 
 .global __start
-.type	z_cstart, @function
+.type	z_prep_c, @function
 
 
 /* Macros to abstract away ABI differences */
@@ -189,6 +189,6 @@ _start:
 #endif /* !XCHAL_HAVE_BOOTLOADER */
 
 	/* Enter C domain, never returns from here */
-	CALL	z_cstart
+	CALL	z_prep_c
 
 	.size	_start, . - _start

--- a/arch/xtensa/core/prep_c.c
+++ b/arch/xtensa/core/prep_c.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2024 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/kernel.h>
+#include <kernel_internal.h>
+
+extern FUNC_NORETURN void z_cstart(void);
+
+/**
+ *
+ * @brief Prepare to and run C code
+ *
+ * This routine prepares for the execution of and runs C code.
+ *
+ */
+void z_prep_c(void)
+{
+	z_cstart();
+	CODE_UNREACHABLE;
+}

--- a/arch/xtensa/core/prep_c.c
+++ b/arch/xtensa/core/prep_c.c
@@ -8,6 +8,9 @@
 
 extern FUNC_NORETURN void z_cstart(void);
 
+/* defined by the SoC in case of CONFIG_SOC_HAS_RUNTIME_NUM_CPUS=y */
+extern void soc_num_cpus_init(void);
+
 /**
  *
  * @brief Prepare to and run C code
@@ -17,6 +20,10 @@ extern FUNC_NORETURN void z_cstart(void);
  */
 void z_prep_c(void)
 {
+#if CONFIG_SOC_HAS_RUNTIME_NUM_CPUS
+	soc_num_cpus_init();
+#endif
+
 	_cpu_t *cpu0 = &_kernel.cpus[0];
 
 #ifdef CONFIG_KERNEL_COHERENCE

--- a/arch/xtensa/core/prep_c.c
+++ b/arch/xtensa/core/prep_c.c
@@ -17,6 +17,57 @@ extern FUNC_NORETURN void z_cstart(void);
  */
 void z_prep_c(void)
 {
+	_cpu_t *cpu0 = &_kernel.cpus[0];
+
+#ifdef CONFIG_KERNEL_COHERENCE
+	/* Make sure we don't have live data for unexpected cached
+	 * regions due to boot firmware
+	 */
+	sys_cache_data_flush_and_invd_all();
+
+	/* Our cache top stash location might have junk in it from a
+	 * pre-boot environment.  Must be zero or valid!
+	 */
+	XTENSA_WSR(ZSR_FLUSH_STR, 0);
+#endif
+
+	cpu0->nested = 0;
+
+	/* The asm2 scheme keeps the kernel pointer in a scratch SR
+	 * (see zsr.h for generation specifics) for easy access.  That
+	 * saves 4 bytes of immediate value to store the address when
+	 * compared to the legacy scheme.  But in SMP this record is a
+	 * per-CPU thing and having it stored in a SR already is a big
+	 * win.
+	 */
+	XTENSA_WSR(ZSR_CPU_STR, cpu0);
+
+#ifdef CONFIG_INIT_STACKS
+	char *stack_start = K_KERNEL_STACK_BUFFER(z_interrupt_stacks[0]);
+	size_t stack_sz = K_KERNEL_STACK_SIZEOF(z_interrupt_stacks[0]);
+	char *stack_end = stack_start + stack_sz;
+
+	uint32_t sp;
+
+	__asm__ volatile("mov %0, sp" : "=a"(sp));
+
+	/* Only clear the interrupt stack if the current stack pointer
+	 * is not within the interrupt stack. Or else we would be
+	 * wiping the in-use stack.
+	 */
+	if (((uintptr_t)sp < (uintptr_t)stack_start) ||
+	    ((uintptr_t)sp >= (uintptr_t)stack_end)) {
+		memset(stack_start, 0xAA, stack_sz);
+	}
+#endif
+
+#ifdef CONFIG_XTENSA_MMU
+	xtensa_mmu_init();
+#endif
+
+#ifdef CONFIG_XTENSA_MPU
+	xtensa_mpu_init();
+#endif
 	z_cstart();
 	CODE_UNREACHABLE;
 }

--- a/arch/xtensa/include/kernel_arch_func.h
+++ b/arch/xtensa/include/kernel_arch_func.h
@@ -25,57 +25,7 @@ K_KERNEL_STACK_ARRAY_DECLARE(z_interrupt_stacks, CONFIG_MP_MAX_NUM_CPUS,
 
 static ALWAYS_INLINE void arch_kernel_init(void)
 {
-	_cpu_t *cpu0 = &_kernel.cpus[0];
 
-#ifdef CONFIG_KERNEL_COHERENCE
-	/* Make sure we don't have live data for unexpected cached
-	 * regions due to boot firmware
-	 */
-	sys_cache_data_flush_and_invd_all();
-
-	/* Our cache top stash location might have junk in it from a
-	 * pre-boot environment.  Must be zero or valid!
-	 */
-	XTENSA_WSR(ZSR_FLUSH_STR, 0);
-#endif
-
-	cpu0->nested = 0;
-
-	/* The asm2 scheme keeps the kernel pointer in a scratch SR
-	 * (see zsr.h for generation specifics) for easy access.  That
-	 * saves 4 bytes of immediate value to store the address when
-	 * compared to the legacy scheme.  But in SMP this record is a
-	 * per-CPU thing and having it stored in a SR already is a big
-	 * win.
-	 */
-	XTENSA_WSR(ZSR_CPU_STR, cpu0);
-
-#ifdef CONFIG_INIT_STACKS
-	char *stack_start = K_KERNEL_STACK_BUFFER(z_interrupt_stacks[0]);
-	size_t stack_sz = K_KERNEL_STACK_SIZEOF(z_interrupt_stacks[0]);
-	char *stack_end = stack_start + stack_sz;
-
-	uint32_t sp;
-
-	__asm__ volatile("mov %0, sp" : "=a"(sp));
-
-	/* Only clear the interrupt stack if the current stack pointer
-	 * is not within the interrupt stack. Or else we would be
-	 * wiping the in-use stack.
-	 */
-	if (((uintptr_t)sp < (uintptr_t)stack_start) ||
-	    ((uintptr_t)sp >= (uintptr_t)stack_end)) {
-		memset(stack_start, 0xAA, stack_sz);
-	}
-#endif
-
-#ifdef CONFIG_XTENSA_MMU
-	xtensa_mmu_init();
-#endif
-
-#ifdef CONFIG_XTENSA_MPU
-	xtensa_mpu_init();
-#endif
 }
 
 void xtensa_switch(void *switch_to, void **switched_from);

--- a/soc/espressif/esp32/soc.c
+++ b/soc/espressif/esp32/soc.c
@@ -47,7 +47,7 @@ extern int _ext_ram_bss_start;
 extern int _ext_ram_bss_end;
 #endif
 
-extern void z_cstart(void);
+extern void z_prep_c(void);
 extern void esp_reset_reason_init(void);
 
 #ifdef CONFIG_SOC_ENABLE_APPCPU
@@ -120,7 +120,7 @@ void IRAM_ATTR __esp_platform_start(void)
 
 	/* Initialize the architecture CPU pointer.  Some of the
 	 * initialization code wants a valid _current before
-	 * arch_kernel_init() is invoked.
+	 * z_prep_c() is invoked.
 	 */
 	__asm__ __volatile__("wsr.MISC0 %0; rsync" : : "r"(&_kernel.cpus[0]));
 
@@ -188,7 +188,7 @@ void IRAM_ATTR __esp_platform_start(void)
 	esp_intr_initialize();
 
 	/* Start Zephyr */
-	z_cstart();
+	z_prep_c();
 
 	CODE_UNREACHABLE;
 }

--- a/soc/espressif/esp32/soc_appcpu.c
+++ b/soc/espressif/esp32/soc_appcpu.c
@@ -33,7 +33,7 @@
 #include <esp_app_format.h>
 #include <zephyr/sys/printk.h>
 
-extern void z_cstart(void);
+extern void z_prep_c(void);
 
 /*
  * This is written in C rather than assembly since, during the port bring up,
@@ -69,13 +69,13 @@ void __app_cpu_start(void)
 
 	/* Initialize the architecture CPU pointer.  Some of the
 	 * initialization code wants a valid _current before
-	 * arch_kernel_init() is invoked.
+	 * z_prep_c() is invoked.
 	 */
 	__asm__ __volatile__("wsr.MISC0 %0; rsync" : : "r"(&_kernel.cpus[0]));
 
 	esp_intr_initialize();
 	/* Start Zephyr */
-	z_cstart();
+	z_prep_c();
 
 	CODE_UNREACHABLE;
 }

--- a/soc/espressif/esp32s2/soc.c
+++ b/soc/espressif/esp32s2/soc.c
@@ -39,6 +39,7 @@
 
 extern void rtc_clk_cpu_freq_set_xtal(void);
 extern void esp_reset_reason_init(void);
+extern void z_prep_c(void);
 
 #if CONFIG_ESP_SPIRAM
 extern int _ext_ram_bss_start;
@@ -143,7 +144,7 @@ void __attribute__((section(".iram1"))) __esp_platform_start(void)
 
 	esp_intr_initialize();
 	/* Start Zephyr */
-	z_cstart();
+	z_prep_c();
 
 	CODE_UNREACHABLE;
 }

--- a/soc/espressif/esp32s3/soc.c
+++ b/soc/espressif/esp32s3/soc.c
@@ -52,7 +52,7 @@ extern int _ext_ram_bss_start;
 extern int _ext_ram_bss_end;
 #endif
 
-extern void z_cstart(void);
+extern void z_prep_c(void);
 extern void esp_reset_reason_init(void);
 
 #ifdef CONFIG_SOC_ENABLE_APPCPU
@@ -212,7 +212,7 @@ void IRAM_ATTR __esp_platform_start(void)
 	esp_intr_initialize();
 
 	/* Start Zephyr */
-	z_cstart();
+	z_prep_c();
 
 	CODE_UNREACHABLE;
 }

--- a/soc/espressif/esp32s3/soc_appcpu.c
+++ b/soc/espressif/esp32s3/soc_appcpu.c
@@ -33,7 +33,7 @@
 #include <esp_app_format.h>
 #include <esp_clk_internal.h>
 
-extern void z_cstart(void);
+extern void z_prep_c(void);
 
 static void core_intr_matrix_clear(void)
 {
@@ -72,7 +72,7 @@ void IRAM_ATTR __app_cpu_start(void)
 	esp_intr_initialize();
 
 	/* Start Zephyr */
-	z_cstart();
+	z_prep_c();
 
 	CODE_UNREACHABLE;
 }

--- a/soc/intel/intel_adsp/ace/multiprocessing.c
+++ b/soc/intel/intel_adsp/ace/multiprocessing.c
@@ -73,15 +73,13 @@ static void ipc_isr(void *arg)
 
 unsigned int soc_num_cpus;
 
-static __imr int soc_num_cpus_init(void)
+__imr void soc_num_cpus_init(void)
 {
 	/* Need to set soc_num_cpus early to arch_num_cpus() works properly */
 	soc_num_cpus = ((sys_read32(DFIDCCP) >> CAP_INST_SHIFT) & CAP_INST_MASK) + 1;
 	soc_num_cpus = MIN(CONFIG_MP_MAX_NUM_CPUS, soc_num_cpus);
 
-	return 0;
 }
-SYS_INIT(soc_num_cpus_init, EARLY, 1);
 
 void soc_mp_init(void)
 {

--- a/soc/intel/intel_adsp/common/boot.c
+++ b/soc/intel/intel_adsp/common/boot.c
@@ -157,6 +157,6 @@ __imr void boot_core0(void)
 	xtensa_vecbase_lock();
 
 	/* Zephyr! */
-	extern FUNC_NORETURN void z_cstart(void);
-	z_cstart();
+	extern FUNC_NORETURN void z_prep_c(void);
+	z_prep_c();
 }

--- a/soc/mediatek/mtk_adsp/soc.c
+++ b/soc/mediatek/mtk_adsp/soc.c
@@ -171,5 +171,5 @@ void c_boot(void)
 	val = 0xffffffff;
 	__asm__ volatile("wsr %0, INTCLEAR" :: "r"(val));
 
-	z_cstart();
+	z_prep_c();
 }


### PR DESCRIPTION
- **xtensa: remove mention of crt0-app.S**
- **xtensa: introduce prep_c for xtensa**
- **xtensa: adapt soc code to use prep_c**
- **xtensa: move arch_kernel_init code into prep_c**
