### PR TITLE
MAINTAINERS: Remove thalley from Bluetooth group

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -301,7 +301,6 @@ Bluetooth:
   collaborators:
     - hermabe
     - Vudentz
-    - Thalley
     - asbjornsabo
     - sjanc
   files:


### PR DESCRIPTION
Thalley is not working with BT mesh nor BT classic and shouldn't be assigned as reviewer for those.