### PR TITLE
linker: fix device deferred init for MWDT toolchain

### DIFF
--- a/include/zephyr/linker/common-rom/common-rom-kernel-devices.ld
+++ b/include/zephyr/linker/common-rom/common-rom-kernel-devices.ld
@@ -41,7 +41,7 @@
 	 */
 	SECTION_PROLOGUE(.text.z_shared_isr,,)
 	{
-		KEEP(*(.text.z_shared_isr))
+		KEEP(*(.text.z_shared_isr*))
 	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 #endif
 

--- a/include/zephyr/linker/common-rom/common-rom-kernel-devices.ld
+++ b/include/zephyr/linker/common-rom/common-rom-kernel-devices.ld
@@ -19,7 +19,7 @@
 		CREATE_OBJ_LEVEL(init, SMP)
 		__init_end = .;
 		__deferred_init_list_start = .;
-		KEEP(*(.z_deferred_init))
+		KEEP(*(.z_deferred_init*))
 		__deferred_init_list_end = .;
 	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 


### PR DESCRIPTION
MWDT toolchain adds additional suffix to sections name in case of ffunction-sections / fdata-sections are enabled.

Let's pick a single set of rules and syntax that work for all toolchain.

As I'm here let's also fix the similar issue for shared interrupts.

Fixes: #75675