### PR TITLE
Do not use SYS_INIT in arch/

### DIFF
--- a/arch/arc/core/cache.c
+++ b/arch/arc/core/cache.c
@@ -227,4 +227,8 @@ static int init_dcache(void)
 	return 0;
 }
 
-SYS_INIT(init_dcache, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+
+void arch_cache_init(void)
+{
+	init_dcache();
+}

--- a/arch/arc/core/irq_offload.c
+++ b/arch/arc/core/irq_offload.c
@@ -54,7 +54,7 @@ void arch_irq_offload(irq_offload_routine_t routine, const void *parameter)
 }
 
 /* need to be executed on every core in the system */
-int arc_irq_offload_init(void)
+void arch_irq_offload_init(void)
 {
 
 	IRQ_CONNECT(IRQ_OFFLOAD_LINE, IRQ_OFFLOAD_PRIO, arc_irq_offload_handler, NULL, 0);
@@ -64,8 +64,4 @@ int arc_irq_offload_init(void)
 	 * with generic irq_enable() but via z_arc_v2_irq_unit_int_enable().
 	 */
 	z_arc_v2_irq_unit_int_enable(IRQ_OFFLOAD_LINE);
-
-	return 0;
 }
-
-SYS_INIT(arc_irq_offload_init, POST_KERNEL, 0);

--- a/arch/arc/core/mpu/arc_mpu_common_internal.h
+++ b/arch/arc/core/mpu/arc_mpu_common_internal.h
@@ -238,7 +238,7 @@ int arc_core_mpu_buffer_validate(const void *addr, size_t size, int write)
  * This function provides the default configuration mechanism for the Memory
  * Protection Unit (MPU).
  */
-static int arc_mpu_init(void)
+void arc_mpu_init(void)
 {
 
 	uint32_t num_regions = get_num_regions();
@@ -246,7 +246,6 @@ static int arc_mpu_init(void)
 	if (mpu_config.num_regions > num_regions) {
 		__ASSERT(0, "Request to configure: %u regions (supported: %u)\n",
 			 mpu_config.num_regions, num_regions);
-		return -EINVAL;
 	}
 
 	/* Disable MPU */
@@ -278,10 +277,7 @@ static int arc_mpu_init(void)
 
 	/* Enable MPU */
 	arc_core_mpu_enable();
-
-	return 0;
 }
 
-SYS_INIT(arc_mpu_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 
 #endif /* ZEPHYR_ARCH_ARC_CORE_MPU_ARC_MPU_COMMON_INTERNAL_H_ */

--- a/arch/arc/core/mpu/arc_mpu_v4_internal.h
+++ b/arch/arc/core/mpu/arc_mpu_v4_internal.h
@@ -814,7 +814,7 @@ int arc_core_mpu_buffer_validate(const void *addr, size_t size, int write)
  * This function provides the default configuration mechanism for the Memory
  * Protection Unit (MPU).
  */
-static int arc_mpu_init(void)
+void arc_mpu_init(void)
 {
 	uint32_t num_regions;
 	uint32_t i;
@@ -826,7 +826,7 @@ static int arc_mpu_init(void)
 		__ASSERT(0,
 		"Request to configure: %u regions (supported: %u)\n",
 		mpu_config.num_regions, num_regions);
-		return -EINVAL;
+		return;
 	}
 
 	static_regions_num = 0U;
@@ -851,7 +851,7 @@ static int arc_mpu_init(void)
 			MPU_DYNAMIC_REGION_AREAS_NUM) {
 				LOG_ERR("not enough dynamic regions %d",
 				 dynamic_regions_num);
-				return -EINVAL;
+				return;
 			}
 
 			dyn_reg_info[dynamic_regions_num].index = i;
@@ -886,10 +886,8 @@ static int arc_mpu_init(void)
 	/* Enable MPU */
 	arc_core_mpu_enable();
 
-	return 0;
+	return;
 }
 
-SYS_INIT(arc_mpu_init, PRE_KERNEL_1,
-	 CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 
 #endif /* ZEPHYR_ARCH_ARC_CORE_MPU_ARC_MPU_V4_INTERNAL_H_ */

--- a/arch/arc/core/prep_c.c
+++ b/arch/arc/core/prep_c.c
@@ -116,6 +116,7 @@ static void dev_state_zero(void)
 
 extern FUNC_NORETURN void z_cstart(void);
 extern void arc_mpu_init(void);
+extern void arc_secureshield_init(void);
 
 /**
  * @brief Prepare to and run C code
@@ -143,6 +144,9 @@ void z_prep_c(void)
 #endif
 #ifdef CONFIG_ARC_MPU
 	arc_mpu_init();
+#endif
+#ifdef CONFIG_ARC_SECURE_FIRMWARE
+	arc_secureshield_init();
 #endif
 	z_cstart();
 	CODE_UNREACHABLE;

--- a/arch/arc/core/prep_c.c
+++ b/arch/arc/core/prep_c.c
@@ -115,6 +115,8 @@ static void dev_state_zero(void)
 #endif
 
 extern FUNC_NORETURN void z_cstart(void);
+extern void arc_mpu_init(void);
+
 /**
  * @brief Prepare to and run C code
  *
@@ -138,6 +140,9 @@ void z_prep_c(void)
 	z_data_copy();
 #if CONFIG_ARCH_CACHE
 	arch_cache_init();
+#endif
+#ifdef CONFIG_ARC_MPU
+	arc_mpu_init();
 #endif
 	z_cstart();
 	CODE_UNREACHABLE;

--- a/arch/arc/core/prep_c.c
+++ b/arch/arc/core/prep_c.c
@@ -24,6 +24,7 @@
 #include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <zephyr/platform/hooks.h>
+#include <zephyr/arch/cache.h>
 
 /* XXX - keep for future use in full-featured cache APIs */
 #if 0
@@ -135,6 +136,9 @@ void z_prep_c(void)
 	dev_state_zero();
 #endif
 	z_data_copy();
+#if CONFIG_ARCH_CACHE
+	arch_cache_init();
+#endif
 	z_cstart();
 	CODE_UNREACHABLE;
 }

--- a/arch/arc/core/secureshield/arc_sjli.c
+++ b/arch/arc/core/secureshield/arc_sjli.c
@@ -48,7 +48,7 @@ static void sjli_table_init(void)
 /*
  * @brief initialization of secureshield related functions.
  */
-static int arc_secureshield_init(void)
+void arc_secureshield_init(void)
 {
 	sjli_table_init();
 
@@ -60,9 +60,4 @@ static int arc_secureshield_init(void)
 	 *
 	 */
 	__asm__ volatile("sflag  0x20");
-
-	return 0;
 }
-
-SYS_INIT(arc_secureshield_init, PRE_KERNEL_1,
-		CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/arch/arc/include/arc_irq_offload.h
+++ b/arch/arc/include/arc_irq_offload.h
@@ -9,11 +9,9 @@
 
 #ifdef CONFIG_IRQ_OFFLOAD
 
-int arc_irq_offload_init(const struct device *unused);
-
 static inline void arc_irq_offload_init_smp(void)
 {
-	arc_irq_offload_init(NULL);
+	arch_irq_offload_init();
 }
 
 #else

--- a/arch/arm/core/cortex_a_r/cache.c
+++ b/arch/arm/core/cortex_a_r/cache.c
@@ -217,3 +217,7 @@ int arch_icache_flush_and_invd_range(void *start_addr, size_t size)
 }
 
 #endif
+
+void arch_cache_init(void)
+{
+}

--- a/arch/arm/core/cortex_a_r/prep_c.c
+++ b/arch/arm/core/cortex_a_r/prep_c.c
@@ -22,6 +22,7 @@
 #include <zephyr/sys/barrier.h>
 #include <zephyr/arch/arm/cortex_a_r/lib_helpers.h>
 #include <zephyr/platform/hooks.h>
+#include <zephyr/arch/cache.h>
 
 #if defined(CONFIG_ARMV7_R) || defined(CONFIG_ARMV7_A)
 #include <cortex_a_r/stack.h>
@@ -164,6 +165,9 @@ void z_prep_c(void)
 	z_arm_init_stacks();
 #endif
 	z_arm_interrupt_init();
+#if CONFIG_ARCH_CACHE
+	arch_cache_init();
+#endif
 #ifdef CONFIG_ARM_MPU
 	z_arm_mpu_init();
 	z_arm_configure_static_mpu_regions();

--- a/arch/arm/core/cortex_m/cache.c
+++ b/arch/arm/core/cortex_m/cache.c
@@ -110,3 +110,7 @@ int arch_icache_flush_and_invd_range(void *start_addr, size_t size)
 {
 	return -ENOTSUP;
 }
+
+void arch_cache_init(void)
+{
+}

--- a/arch/arm/core/cortex_m/debug.c
+++ b/arch/arm/core/cortex_m/debug.c
@@ -58,7 +58,7 @@ BUILD_ASSERT(!(CONFIG_CORTEX_M_NULL_POINTER_EXCEPTION_PAGE_SIZE &
 	(CONFIG_CORTEX_M_NULL_POINTER_EXCEPTION_PAGE_SIZE - 1)),
 	"the size of the partition must be power of 2");
 
-static int z_arm_debug_enable_null_pointer_detection(void)
+int z_arm_debug_enable_null_pointer_detection(void)
 {
 
 	z_arm_dwt_init();
@@ -117,8 +117,5 @@ static int z_arm_debug_enable_null_pointer_detection(void)
 
 	return 0;
 }
-
-SYS_INIT(z_arm_debug_enable_null_pointer_detection, PRE_KERNEL_1,
-	 CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 
 #endif /* CONFIG_NULL_POINTER_EXCEPTION_DETECTION_DWT */

--- a/arch/arm/core/cortex_m/prep_c.c
+++ b/arch/arm/core/cortex_m/prep_c.c
@@ -21,6 +21,7 @@
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/sys/barrier.h>
 #include <zephyr/platform/hooks.h>
+#include <zephyr/arch/cache.h>
 
 #if defined(__GNUC__)
 /*
@@ -198,6 +199,9 @@ void z_prep_c(void)
 #else
 	z_arm_interrupt_init();
 #endif /* CONFIG_ARM_CUSTOM_INTERRUPT_CONTROLLER */
+#if CONFIG_ARCH_CACHE
+	arch_cache_init();
+#endif
 	z_cstart();
 	CODE_UNREACHABLE;
 }

--- a/arch/arm/core/cortex_m/prep_c.c
+++ b/arch/arm/core/cortex_m/prep_c.c
@@ -202,6 +202,10 @@ void z_prep_c(void)
 #if CONFIG_ARCH_CACHE
 	arch_cache_init();
 #endif
+
+#ifdef CONFIG_NULL_POINTER_EXCEPTION_DETECTION_DWT
+	z_arm_debug_enable_null_pointer_detection();
+#endif
 	z_cstart();
 	CODE_UNREACHABLE;
 }

--- a/arch/arm/core/irq_offload.c
+++ b/arch/arm/core/irq_offload.c
@@ -42,3 +42,7 @@ void arch_irq_offload(irq_offload_routine_t routine, const void *parameter)
 	offload_routine = NULL;
 	k_sched_unlock();
 }
+
+void arch_irq_offload_init(void)
+{
+}

--- a/arch/arm64/core/irq_offload.c
+++ b/arch/arm64/core/irq_offload.c
@@ -23,3 +23,7 @@ void arch_irq_offload(irq_offload_routine_t routine, const void *parameter)
 			  : [svid] "i" (_SVC_CALL_IRQ_OFFLOAD),
 			    "r" (x0), "r" (x1));
 }
+
+void arch_irq_offload_init(void)
+{
+}

--- a/arch/arm64/core/prep_c.c
+++ b/arch/arm64/core/prep_c.c
@@ -17,6 +17,7 @@
 #include <kernel_internal.h>
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/platform/hooks.h>
+#include <zephyr/arch/cache.h>
 
 extern void z_arm64_mm_init(bool is_primary_core);
 
@@ -57,6 +58,9 @@ extern FUNC_NORETURN void arch_secondary_cpu_init(void);
 void z_arm64_secondary_prep_c(void)
 {
 	arch_secondary_cpu_init();
+#if CONFIG_ARCH_CACHE
+	arch_cache_init();
+#endif
 
 	CODE_UNREACHABLE;
 }

--- a/arch/arm64/core/xen/enlighten.c
+++ b/arch/arm64/core/xen/enlighten.c
@@ -42,7 +42,7 @@ static int xen_map_shared_info(const shared_info_t *shared_page)
 	return HYPERVISOR_memory_op(XENMEM_add_to_physmap, &xatp);
 }
 
-static int xen_enlighten_init(void)
+int xen_enlighten_init(void)
 {
 	int ret = 0;
 	shared_info_t *info = (shared_info_t *) shared_info_buf;
@@ -66,5 +66,3 @@ static int xen_enlighten_init(void)
 
 	return 0;
 }
-
-SYS_INIT(xen_enlighten_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);

--- a/arch/arm64/include/kernel_arch_func.h
+++ b/arch/arm64/include/kernel_arch_func.h
@@ -28,8 +28,13 @@ extern "C" {
 
 #ifndef _ASMLANGUAGE
 
+extern void xen_enlighten_init(void);
+
 static ALWAYS_INLINE void arch_kernel_init(void)
 {
+#ifdef CONFIG_XEN
+	xen_enlighten_init();
+#endif
 }
 
 static inline void arch_switch(void *switch_to, void **switched_from)

--- a/arch/mips/core/irq_offload.c
+++ b/arch/mips/core/irq_offload.c
@@ -48,3 +48,7 @@ void arch_irq_offload(irq_offload_routine_t routine, const void *parameter)
 
 	irq_unlock(key);
 }
+
+void arch_irq_offload_init(void)
+{
+}

--- a/arch/mips/core/prep_c.c
+++ b/arch/mips/core/prep_c.c
@@ -12,6 +12,7 @@
 #include <kernel_internal.h>
 #include <zephyr/irq.h>
 #include <zephyr/platform/hooks.h>
+#include <zephyr/arch/cache.h>
 
 static void interrupt_init(void)
 {
@@ -51,6 +52,9 @@ void z_prep_c(void)
 	z_bss_zero();
 
 	interrupt_init();
+#if CONFIG_ARCH_CACHE
+	arch_cache_init();
+#endif
 
 	z_cstart();
 	CODE_UNREACHABLE;

--- a/arch/nios2/core/irq_offload.c
+++ b/arch/nios2/core/irq_offload.c
@@ -41,3 +41,7 @@ void arch_irq_offload(irq_offload_routine_t routine, const void *parameter)
 
 	irq_unlock(key);
 }
+
+void arch_irq_offload_init(void)
+{
+}

--- a/arch/nios2/core/prep_c.c
+++ b/arch/nios2/core/prep_c.c
@@ -22,6 +22,7 @@
 #include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <zephyr/platform/hooks.h>
+#include <zephyr/arch/cache.h>
 
 /**
  * @brief Prepare to and run C code
@@ -49,6 +50,9 @@ void z_prep_c(void)
 	 */
 	z_nios2_dcache_flush_all();
 #endif
+#endif
+#if CONFIG_ARCH_CACHE
+	arch_cache_init();
 #endif
 	z_cstart();
 	CODE_UNREACHABLE;

--- a/arch/posix/core/irq.c
+++ b/arch/posix/core/irq.c
@@ -14,6 +14,10 @@ void arch_irq_offload(irq_offload_routine_t routine, const void *parameter)
 {
 	posix_irq_offload(routine, parameter);
 }
+
+void arch_irq_offload_init(void)
+{
+}
 #endif
 
 void arch_irq_enable(unsigned int irq)

--- a/arch/riscv/core/irq_offload.c
+++ b/arch/riscv/core/irq_offload.c
@@ -11,3 +11,7 @@ void arch_irq_offload(irq_offload_routine_t routine, const void *parameter)
 {
 	arch_syscall_invoke2((uintptr_t)routine, (uintptr_t)parameter, RV_ECALL_IRQ_OFFLOAD);
 }
+
+void arch_irq_offload_init(void)
+{
+}

--- a/arch/riscv/core/prep_c.c
+++ b/arch/riscv/core/prep_c.c
@@ -20,6 +20,7 @@
 #include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <zephyr/platform/hooks.h>
+#include <zephyr/arch/cache.h>
 
 #if defined(CONFIG_RISCV_SOC_INTERRUPT_INIT)
 void soc_interrupt_init(void);
@@ -42,6 +43,9 @@ void z_prep_c(void)
 	z_data_copy();
 #if defined(CONFIG_RISCV_SOC_INTERRUPT_INIT)
 	soc_interrupt_init();
+#endif
+#if CONFIG_ARCH_CACHE
+	arch_cache_init();
 #endif
 	z_cstart();
 	CODE_UNREACHABLE;

--- a/arch/sparc/core/irq_offload.c
+++ b/arch/sparc/core/irq_offload.c
@@ -39,3 +39,7 @@ void arch_irq_offload(irq_offload_routine_t routine, const void *parameter)
 
 	irq_unlock(key);
 }
+
+void arch_irq_offload_init(void)
+{
+}

--- a/arch/sparc/core/prep_c.c
+++ b/arch/sparc/core/prep_c.c
@@ -11,6 +11,7 @@
 
 #include <kernel_internal.h>
 #include <zephyr/platform/hooks.h>
+#include <zephyr/arch/cache.h>
 
 /**
  * @brief Prepare to and run C code
@@ -24,6 +25,9 @@ void z_prep_c(void)
 	soc_prep_hook();
 #endif
 	z_data_copy();
+#if CONFIG_ARCH_CACHE
+	arch_cache_init();
+#endif
 	z_cstart();
 	CODE_UNREACHABLE;
 }

--- a/arch/x86/core/cache.c
+++ b/arch/x86/core/cache.c
@@ -119,3 +119,7 @@ int arch_dcache_flush_and_invd_range(void *start_addr, size_t size)
 {
 	return arch_dcache_flush_range(start_addr, size);
 }
+
+void arch_cache_init(void)
+{
+}

--- a/arch/x86/core/ia32/irq_offload.c
+++ b/arch/x86/core/ia32/irq_offload.c
@@ -47,3 +47,7 @@ void arch_irq_offload(irq_offload_routine_t routine, const void *parameter)
 
 	irq_unlock(key);
 }
+
+void arch_irq_offload_init(void)
+{
+}

--- a/arch/x86/core/intel64/irq_offload.c
+++ b/arch/x86/core/intel64/irq_offload.c
@@ -44,11 +44,7 @@ void arch_irq_offload(irq_offload_routine_t routine, const void *parameter)
 	arch_irq_unlock(key);
 }
 
-int irq_offload_init(void)
+void arch_irq_offload_init(void)
 {
 	x86_irq_funcs[CONFIG_IRQ_OFFLOAD_VECTOR - IV_IRQS] = dispatcher;
-
-	return 0;
 }
-
-SYS_INIT(irq_offload_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/arch/x86/core/prep_c.c
+++ b/arch/x86/core/prep_c.c
@@ -19,6 +19,10 @@ extern void x86_64_irq_init(void);
 __pinned_data x86_boot_arg_t x86_cpu_boot_arg;
 #endif
 
+
+
+extern int spec_ctrl_init(void);
+
 /* Early global initialization functions, C domain. This runs only on the first
  * CPU for SMP systems.
  */
@@ -79,6 +83,9 @@ FUNC_NORETURN void z_prep_c(void *arg)
 #endif
 #if CONFIG_ARCH_CACHE
 	arch_cache_init();
+#endif
+#if defined(CONFIG_X86_DISABLE_SSBD) || defined(CONFIG_X86_ENABLE_EXTENDED_IBRS)
+	spec_ctrl_init();
 #endif
 
 	z_cstart();

--- a/arch/x86/core/prep_c.c
+++ b/arch/x86/core/prep_c.c
@@ -10,6 +10,7 @@
 #include <zephyr/arch/x86/efi.h>
 #include <x86_mmu.h>
 #include <zephyr/platform/hooks.h>
+#include <zephyr/arch/cache.h>
 
 extern FUNC_NORETURN void z_cstart(void);
 extern void x86_64_irq_init(void);
@@ -75,6 +76,9 @@ FUNC_NORETURN void z_prep_c(void *arg)
 	for (int i = 0; i < num_cpus; i++) {
 		z_x86_set_stack_guard(z_interrupt_stacks[i]);
 	}
+#endif
+#if CONFIG_ARCH_CACHE
+	arch_cache_init();
 #endif
 
 	z_cstart();

--- a/arch/x86/core/spec_ctrl.c
+++ b/arch/x86/core/spec_ctrl.c
@@ -17,7 +17,7 @@
  */
 
 #if defined(CONFIG_X86_DISABLE_SSBD) || defined(CONFIG_X86_ENABLE_EXTENDED_IBRS)
-static int spec_ctrl_init(void)
+int spec_ctrl_init(void)
 {
 
 	uint32_t enable_bits = 0U;
@@ -43,5 +43,4 @@ static int spec_ctrl_init(void)
 	return 0;
 }
 
-SYS_INIT(spec_ctrl_init, PRE_KERNEL_1, 0);
 #endif /* CONFIG_X86_DISABLE_SSBD || CONFIG_X86_ENABLE_EXTENDED_IBRS */

--- a/arch/xtensa/core/irq_offload.c
+++ b/arch/xtensa/core/irq_offload.c
@@ -37,3 +37,7 @@ void arch_irq_offload(irq_offload_routine_t routine, const void *parameter)
 			 :: "r"(intenable), "r"(BIT(ZSR_IRQ_OFFLOAD_INT)));
 	arch_irq_unlock(key);
 }
+
+void arch_irq_offload_init(void)
+{
+}

--- a/arch/xtensa/core/prep_c.c
+++ b/arch/xtensa/core/prep_c.c
@@ -6,6 +6,7 @@
 #include <zephyr/kernel.h>
 #include <kernel_internal.h>
 #include <zephyr/platform/hooks.h>
+#include <zephyr/arch/cache.h>
 
 extern FUNC_NORETURN void z_cstart(void);
 
@@ -70,6 +71,9 @@ void z_prep_c(void)
 	    ((uintptr_t)sp >= (uintptr_t)stack_end)) {
 		memset(stack_start, 0xAA, stack_sz);
 	}
+#endif
+#if CONFIG_ARCH_CACHE
+	arch_cache_init();
 #endif
 
 #ifdef CONFIG_XTENSA_MMU

--- a/include/zephyr/arch/arch_interface.h
+++ b/include/zephyr/arch/arch_interface.h
@@ -455,6 +455,13 @@ bool arch_irq_is_used(unsigned int irq);
  * @param parameter Value to pass to the function when invoked
  */
 void arch_irq_offload(irq_offload_routine_t routine, const void *parameter);
+
+
+/**
+ * Initialize the architecture-specific portion of the irq_offload subsystem
+ */
+void arch_irq_offload_init(void);
+
 #endif /* CONFIG_IRQ_OFFLOAD */
 
 /** @} */

--- a/include/zephyr/arch/arm64/cache.h
+++ b/include/zephyr/arch/arm64/cache.h
@@ -236,6 +236,10 @@ static ALWAYS_INLINE void arch_icache_disable(void)
 
 #endif /* CONFIG_ICACHE */
 
+static ALWAYS_INLINE void arch_cache_init(void)
+{
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/arch/cache.h
+++ b/include/zephyr/arch/cache.h
@@ -349,6 +349,9 @@ void *arch_cache_uncached_ptr_get(void __sparse_cache *ptr);
 #define cache_uncached_ptr(ptr) arch_cache_uncached_ptr_get(ptr)
 #endif /* CONFIG_CACHE_DOUBLEMAP */
 
+
+void arch_cache_init(void);
+
 /**
  * @}
  */

--- a/include/zephyr/arch/xtensa/cache.h
+++ b/include/zephyr/arch/xtensa/cache.h
@@ -331,6 +331,10 @@ static inline void *arch_cache_uncached_ptr_get(void *ptr)
 }
 #endif
 
+static ALWAYS_INLINE void arch_cache_init(void)
+{
+}
+
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -516,6 +516,9 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 #endif /* CONFIG_MMU */
 	z_sys_post_kernel = true;
 
+#if CONFIG_IRQ_OFFLOAD
+	arch_irq_offload_init();
+#endif
 	z_sys_init_run_level(INIT_LEVEL_POST_KERNEL);
 #if CONFIG_SOC_LATE_INIT_HOOK
 	soc_late_init_hook();


### PR DESCRIPTION
Attempt to get rid of SYS_INIT usage and misuse in arch/ and to align all architecture and unify the boot the process.

- **cache: add new interface arch_cache_init() for initializing cache**
- **arc: start mpu in prep_c, do not use SYS_INIT**
- **arc: start secureshield in prep_c, do not use SYS_INIT**
- **arm: init null pointer detection in prep_c, do not use SYS_INIT**
- **arch: initialize irq_offload during boot, do not use SYS_INIT**
- **x86: init spec_ctrl in prep_c, do not use SYS_INIT**
- **arch: arm64: init xen in arch_kernel_init()**
