### PR TITLE
 input: kbd_matrix: add power management support

### DIFF
--- a/drivers/input/input_gpio_kbd_matrix.c
+++ b/drivers/input/input_gpio_kbd_matrix.c
@@ -330,7 +330,9 @@ static const struct input_kbd_matrix_api gpio_kbd_matrix_api = {
 												\
 	static struct gpio_kbd_matrix_data gpio_kbd_matrix_data_##n;				\
 												\
-	DEVICE_DT_INST_DEFINE(n, gpio_kbd_matrix_init, NULL,					\
+	PM_DEVICE_DT_INST_DEFINE(n, input_kbd_matrix_pm_action);				\
+												\
+	DEVICE_DT_INST_DEFINE(n, gpio_kbd_matrix_init, PM_DEVICE_DT_INST_GET(n),		\
 			      &gpio_kbd_matrix_data_##n, &gpio_kbd_matrix_cfg_##n,		\
 			      POST_KERNEL, CONFIG_INPUT_INIT_PRIORITY,				\
 			      NULL);

--- a/drivers/input/input_ite_it8xxx2_kbd.c
+++ b/drivers/input/input_ite_it8xxx2_kbd.c
@@ -252,9 +252,15 @@ static const struct it8xxx2_kbd_config it8xxx2_kbd_cfg_0 = {
 
 static struct it8xxx2_kbd_data it8xxx2_kbd_data_0;
 
-DEVICE_DT_INST_DEFINE(0, &it8xxx2_kbd_init, NULL,
+PM_DEVICE_DT_INST_DEFINE(0, input_kbd_matrix_pm_action);
+
+DEVICE_DT_INST_DEFINE(0, &it8xxx2_kbd_init, PM_DEVICE_DT_INST_GET(0),
 		      &it8xxx2_kbd_data_0, &it8xxx2_kbd_cfg_0,
 		      POST_KERNEL, CONFIG_INPUT_INIT_PRIORITY, NULL);
+
+BUILD_ASSERT(!IS_ENABLED(CONFIG_PM_DEVICE_SYSTEM_MANAGED) ||
+	     IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME),
+	     "CONFIG_PM_DEVICE_RUNTIME must be enabled when using CONFIG_PM_DEVICE_SYSTEM_MANAGED");
 
 BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 1,
 	     "only one ite,it8xxx2-kbd compatible node can be supported");

--- a/drivers/input/input_kbd_matrix.c
+++ b/drivers/input/input_kbd_matrix.c
@@ -12,6 +12,9 @@
 #include <zephyr/kernel.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/device_runtime.h>
+#include <zephyr/sys/atomic.h>
 #include <zephyr/sys/util.h>
 
 LOG_MODULE_REGISTER(input_kbd_matrix, CONFIG_INPUT_LOG_LEVEL);
@@ -80,6 +83,17 @@ static void input_kbd_matrix_drive_column(const struct device *dev, int col)
 #endif
 }
 
+static bool input_kbd_matrix_is_suspended(const struct device *dev)
+{
+#ifdef CONFIG_PM_DEVICE
+	struct input_kbd_matrix_common_data *data = dev->data;
+
+	return atomic_get(&data->suspended) == 1;
+#else
+	return false;
+#endif
+}
+
 static bool input_kbd_matrix_scan(const struct device *dev)
 {
 	const struct input_kbd_matrix_common_config *cfg = dev->config;
@@ -92,6 +106,11 @@ static bool input_kbd_matrix_scan(const struct device *dev)
 		    cfg->actual_key_mask[col] == 0) {
 			continue;
 		}
+
+		if (input_kbd_matrix_is_suspended(dev)) {
+			cfg->matrix_new_state[col] = 0;
+			continue;
+		};
 
 		input_kbd_matrix_drive_column(dev, col);
 
@@ -293,14 +312,16 @@ static void input_kbd_matrix_polling_thread(void *arg1, void *unused2, void *unu
 	ARG_UNUSED(unused3);
 
 	while (true) {
-		input_kbd_matrix_drive_column(dev, INPUT_KBD_MATRIX_COLUMN_DRIVE_ALL);
-		api->set_detect_mode(dev, true);
+		if (!input_kbd_matrix_is_suspended(dev)) {
+			input_kbd_matrix_drive_column(dev, INPUT_KBD_MATRIX_COLUMN_DRIVE_ALL);
+			api->set_detect_mode(dev, true);
 
-		/* Check the rows again after enabling the interrupt to catch
-		 * any potential press since the last read.
-		 */
-		if (api->read_row(dev) != 0) {
-			input_kbd_matrix_poll_start(dev);
+			/* Check the rows again after enabling the interrupt to catch
+			 * any potential press since the last read.
+			 */
+			if (api->read_row(dev) != 0) {
+				input_kbd_matrix_poll_start(dev);
+			}
 		}
 
 		k_sem_take(&data->poll_lock, K_FOREVER);
@@ -313,9 +334,33 @@ static void input_kbd_matrix_polling_thread(void *arg1, void *unused2, void *unu
 	}
 }
 
+#ifdef CONFIG_PM_DEVICE
+int input_kbd_matrix_pm_action(const struct device *dev,
+			       enum pm_device_action action)
+{
+	struct input_kbd_matrix_common_data *data = dev->data;
+
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
+		atomic_set(&data->suspended, 1);
+		break;
+	case PM_DEVICE_ACTION_RESUME:
+		atomic_set(&data->suspended, 0);
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	input_kbd_matrix_poll_start(dev);
+
+	return 0;
+}
+#endif
+
 int input_kbd_matrix_common_init(const struct device *dev)
 {
 	struct input_kbd_matrix_common_data *data = dev->data;
+	int ret;
 
 	k_sem_init(&data->poll_lock, 0, 1);
 
@@ -325,6 +370,12 @@ int input_kbd_matrix_common_init(const struct device *dev)
 			CONFIG_INPUT_KBD_MATRIX_THREAD_PRIORITY, 0, K_NO_WAIT);
 
 	k_thread_name_set(&data->thread, dev->name);
+
+	ret = pm_device_runtime_enable(dev);
+	if (ret < 0) {
+		LOG_ERR("Failed to enable runtime power management");
+		return ret;
+	}
 
 	return 0;
 }

--- a/drivers/input/input_npcx_kbd.c
+++ b/drivers/input/input_npcx_kbd.c
@@ -226,9 +226,15 @@ static const struct npcx_kbd_config npcx_kbd_cfg_0 = {
 
 static struct npcx_kbd_data npcx_kbd_data_0;
 
-DEVICE_DT_INST_DEFINE(0, npcx_kbd_init, NULL,
+PM_DEVICE_DT_INST_DEFINE(0, input_kbd_matrix_pm_action);
+
+DEVICE_DT_INST_DEFINE(0, npcx_kbd_init, PM_DEVICE_DT_INST_GET(0),
 		      &npcx_kbd_data_0, &npcx_kbd_cfg_0,
 		      POST_KERNEL, CONFIG_INPUT_INIT_PRIORITY, NULL);
+
+BUILD_ASSERT(!IS_ENABLED(CONFIG_PM_DEVICE_SYSTEM_MANAGED) ||
+	     IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME),
+	     "CONFIG_PM_DEVICE_RUNTIME must be enabled when using CONFIG_PM_DEVICE_SYSTEM_MANAGED");
 
 BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 1,
 	     "only one nuvoton,npcx-kbd compatible node can be supported");

--- a/drivers/input/input_xec_kbd.c
+++ b/drivers/input/input_xec_kbd.c
@@ -143,6 +143,11 @@ static int xec_kbd_pm_action(const struct device *dev, enum pm_device_action act
 	struct kscan_regs *regs = cfg->regs;
 	int ret;
 
+	ret = input_kbd_matrix_pm_action(dev, action);
+	if (ret < 0) {
+		return ret;
+	}
+
 	if (cfg->wakeup_source) {
 		return 0;
 	}

--- a/include/zephyr/input/input_kbd_matrix.h
+++ b/include/zephyr/input/input_kbd_matrix.h
@@ -16,6 +16,8 @@
 
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/sys/atomic.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys_clock.h>
 #include <zephyr/toolchain.h>
@@ -248,6 +250,9 @@ struct input_kbd_matrix_common_data {
 	uint8_t scan_cycles_idx;
 
 	struct k_sem poll_lock;
+#ifdef CONFIG_PM_DEVICE
+	atomic_t suspended;
+#endif
 
 	struct k_thread thread;
 
@@ -304,6 +309,20 @@ void input_kbd_matrix_drive_column_hook(const struct device *dev, int col);
  * @retval -errno Negative errno in case of failure.
  */
 int input_kbd_matrix_common_init(const struct device *dev);
+
+#ifdef CONFIG_PM_DEVICE
+/**
+ * @brief Common power management action handler.
+ *
+ * This handles PM actions for a keyboard matrix device, meant to be used as
+ * argument of @ref PM_DEVICE_DT_INST_DEFINE.
+ *
+ * @param dev Keyboard matrix device instance.
+ * @param action The power management action to handle.
+ */
+int input_kbd_matrix_pm_action(const struct device *dev,
+			       enum pm_device_action action);
+#endif
 
 /** @} */
 


### PR DESCRIPTION
Add power management support to the keyboard matrix library. This provides a generic pm_action function that changes the keyboard matrix scan in two places when suspended:
- reset the state to 0 for all columns
- do not enable key press detection

This ensures that any key that was pressed when the device is suspended is released, and no other scan happens until the device is resumed.

--

Tested with the gpio-keys driver on all three modes and on ite and npcx (I don't have the hw for xec).