### PR TITLE
drivers: dac: dac_ad569x: Fix reset error return

### DIFF
--- a/drivers/dac/dac_ad569x.c
+++ b/drivers/dac/dac_ad569x.c
@@ -99,7 +99,7 @@ static int ad569x_sw_reset(const struct device *dev)
 
 	if (reg != 0) {
 		LOG_ERR("failed to reset DAC output");
-		ret = -EIO;
+		return -EIO;
 	}
 
 	return 0;


### PR DESCRIPTION
The intention here appears to be to return an error. Use an early return to implement this.