### PR TITLE
headers: move z_impl from public API header file to another file

### DIFF
--- a/include/zephyr/cache.h
+++ b/include/zephyr/cache.h
@@ -219,17 +219,6 @@ static ALWAYS_INLINE int sys_cache_instr_flush_and_invd_all(void)
  */
 __syscall_always_inline int sys_cache_data_flush_range(void *addr, size_t size);
 
-static ALWAYS_INLINE int z_impl_sys_cache_data_flush_range(void *addr, size_t size)
-{
-#if defined(CONFIG_CACHE_MANAGEMENT) && defined(CONFIG_DCACHE)
-	return cache_data_flush_range(addr, size);
-#endif
-	ARG_UNUSED(addr);
-	ARG_UNUSED(size);
-
-	return -ENOTSUP;
-}
-
 /**
  * @brief Flush an address range in the i-cache
  *
@@ -281,17 +270,6 @@ static ALWAYS_INLINE int sys_cache_instr_flush_range(void *addr, size_t size)
  * @retval -errno Negative errno for other failures.
  */
 __syscall_always_inline int sys_cache_data_invd_range(void *addr, size_t size);
-
-static ALWAYS_INLINE int z_impl_sys_cache_data_invd_range(void *addr, size_t size)
-{
-#if defined(CONFIG_CACHE_MANAGEMENT) && defined(CONFIG_DCACHE)
-	return cache_data_invd_range(addr, size);
-#endif
-	ARG_UNUSED(addr);
-	ARG_UNUSED(size);
-
-	return -ENOTSUP;
-}
 
 /**
  * @brief Invalidate an address range in the i-cache
@@ -345,17 +323,6 @@ static ALWAYS_INLINE int sys_cache_instr_invd_range(void *addr, size_t size)
  * @retval -errno Negative errno for other failures.
  */
 __syscall_always_inline int sys_cache_data_flush_and_invd_range(void *addr, size_t size);
-
-static ALWAYS_INLINE int z_impl_sys_cache_data_flush_and_invd_range(void *addr, size_t size)
-{
-#if defined(CONFIG_CACHE_MANAGEMENT) && defined(CONFIG_DCACHE)
-	return cache_data_flush_and_invd_range(addr, size);
-#endif
-	ARG_UNUSED(addr);
-	ARG_UNUSED(size);
-
-	return -ENOTSUP;
-}
 
 /**
  * @brief Flush and Invalidate an address range in the i-cache
@@ -550,6 +517,7 @@ static ALWAYS_INLINE void sys_cache_flush(void *addr, size_t size)
 }
 #endif
 
+#include <zephyr/cache/internal/cache_impl.h>
 #include <zephyr/syscalls/cache.h>
 #ifdef __cplusplus
 }

--- a/include/zephyr/cache/internal/cache_impl.h
+++ b/include/zephyr/cache/internal/cache_impl.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2015 Wind River Systems, Inc.
+ * Copyright (c) 2022 Carlo Caione <ccaione@baylibre.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Inline syscall implementation for cache APIs
+ */
+
+#ifndef ZEPHYR_INCLUDE_CACHE_H_
+#error "Should only be included by zephyr/cache.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_CACHE_INTERNAL_CACHE_IMPL_H_
+#define ZEPHYR_INCLUDE_CACHE_INTERNAL_CACHE_IMPL_H_
+
+#include <zephyr/kernel.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/debug/sparse.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static ALWAYS_INLINE int z_impl_sys_cache_data_flush_range(void *addr, size_t size)
+{
+#if defined(CONFIG_CACHE_MANAGEMENT) && defined(CONFIG_DCACHE)
+	return cache_data_flush_range(addr, size);
+#endif
+	ARG_UNUSED(addr);
+	ARG_UNUSED(size);
+
+	return -ENOTSUP;
+}
+
+static ALWAYS_INLINE int z_impl_sys_cache_data_invd_range(void *addr, size_t size)
+{
+#if defined(CONFIG_CACHE_MANAGEMENT) && defined(CONFIG_DCACHE)
+	return cache_data_invd_range(addr, size);
+#endif
+	ARG_UNUSED(addr);
+	ARG_UNUSED(size);
+
+	return -ENOTSUP;
+}
+
+static ALWAYS_INLINE int z_impl_sys_cache_data_flush_and_invd_range(void *addr, size_t size)
+{
+#if defined(CONFIG_CACHE_MANAGEMENT) && defined(CONFIG_DCACHE)
+	return cache_data_flush_and_invd_range(addr, size);
+#endif
+	ARG_UNUSED(addr);
+	ARG_UNUSED(size);
+
+	return -ENOTSUP;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_CACHE_INTERNAL_CACHE_IMPL_H_ */

--- a/include/zephyr/drivers/adc.h
+++ b/include/zephyr/drivers/adc.h
@@ -723,15 +723,6 @@ __subsystem struct adc_driver_api {
 __syscall int adc_channel_setup(const struct device *dev,
 				const struct adc_channel_cfg *channel_cfg);
 
-static inline int z_impl_adc_channel_setup(const struct device *dev,
-					   const struct adc_channel_cfg *channel_cfg)
-{
-	const struct adc_driver_api *api =
-				(const struct adc_driver_api *)dev->api;
-
-	return api->channel_setup(dev, channel_cfg);
-}
-
 /**
  * @brief Configure an ADC channel from a struct adc_dt_spec.
  *
@@ -774,15 +765,6 @@ static inline int adc_channel_setup_dt(const struct adc_dt_spec *spec)
 __syscall int adc_read(const struct device *dev,
 		       const struct adc_sequence *sequence);
 
-static inline int z_impl_adc_read(const struct device *dev,
-				  const struct adc_sequence *sequence)
-{
-	const struct adc_driver_api *api =
-				(const struct adc_driver_api *)dev->api;
-
-	return api->read(dev, sequence);
-}
-
 /**
  * @brief Set a read request from a struct adc_dt_spec.
  *
@@ -821,19 +803,6 @@ static inline int adc_read_dt(const struct adc_dt_spec *spec,
 __syscall int adc_read_async(const struct device *dev,
 			     const struct adc_sequence *sequence,
 			     struct k_poll_signal *async);
-
-
-#ifdef CONFIG_ADC_ASYNC
-static inline int z_impl_adc_read_async(const struct device *dev,
-					const struct adc_sequence *sequence,
-					struct k_poll_signal *async)
-{
-	const struct adc_driver_api *api =
-				(const struct adc_driver_api *)dev->api;
-
-	return api->read_async(dev, sequence, async);
-}
-#endif /* CONFIG_ADC_ASYNC */
 
 /**
  * @brief Get the internal reference voltage.
@@ -985,6 +954,7 @@ static inline bool adc_is_ready_dt(const struct adc_dt_spec *spec)
 }
 #endif
 
+#include <zephyr/drivers/adc/internal/adc_impl.h>
 #include <zephyr/syscalls/adc.h>
 
 #endif  /* ZEPHYR_INCLUDE_DRIVERS_ADC_H_ */

--- a/include/zephyr/drivers/adc/internal/adc_impl.h
+++ b/include/zephyr/drivers/adc/internal/adc_impl.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ * Copyright (c) 2015 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Inline syscall implementation for ADC API.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_ADC_H_
+#error "Should only be included by zephyr/drivers/adc.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_ADC_INTERNAL_ADC_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_ADC_INTERNAL_ADC_IMPL_H_
+
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_adc_channel_setup(const struct device *dev,
+					   const struct adc_channel_cfg *channel_cfg)
+{
+	const struct adc_driver_api *api =
+				(const struct adc_driver_api *)dev->api;
+
+	return api->channel_setup(dev, channel_cfg);
+}
+
+static inline int z_impl_adc_read(const struct device *dev,
+				  const struct adc_sequence *sequence)
+{
+	const struct adc_driver_api *api =
+				(const struct adc_driver_api *)dev->api;
+
+	return api->read(dev, sequence);
+}
+
+#ifdef CONFIG_ADC_ASYNC
+static inline int z_impl_adc_read_async(const struct device *dev,
+					const struct adc_sequence *sequence,
+					struct k_poll_signal *async)
+{
+	const struct adc_driver_api *api =
+				(const struct adc_driver_api *)dev->api;
+
+	return api->read_async(dev, sequence, async);
+}
+#endif /* CONFIG_ADC_ASYNC */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* ZEPHYR_INCLUDE_DRIVERS_ADC_INTERNAL_ADC_IMPL_H_ */

--- a/include/zephyr/drivers/auxdisplay.h
+++ b/include/zephyr/drivers/auxdisplay.h
@@ -322,17 +322,6 @@ __subsystem struct auxdisplay_driver_api {
  */
 __syscall int auxdisplay_display_on(const struct device *dev);
 
-static inline int z_impl_auxdisplay_display_on(const struct device *dev)
-{
-	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
-
-	if (!api->display_on) {
-		return -ENOSYS;
-	}
-
-	return api->display_on(dev);
-}
-
 /**
  * @brief		Turn display off.
  *
@@ -343,17 +332,6 @@ static inline int z_impl_auxdisplay_display_on(const struct device *dev)
  * @retval		-errno Negative errno code on other failure.
  */
 __syscall int auxdisplay_display_off(const struct device *dev);
-
-static inline int z_impl_auxdisplay_display_off(const struct device *dev)
-{
-	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
-
-	if (!api->display_off) {
-		return -ENOSYS;
-	}
-
-	return api->display_off(dev);
-}
 
 /**
  * @brief		Set cursor enabled status on an auxiliary display
@@ -368,18 +346,6 @@ static inline int z_impl_auxdisplay_display_off(const struct device *dev)
 __syscall int auxdisplay_cursor_set_enabled(const struct device *dev,
 					    bool enabled);
 
-static inline int z_impl_auxdisplay_cursor_set_enabled(const struct device *dev,
-						       bool enabled)
-{
-	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
-
-	if (!api->cursor_set_enabled) {
-		return -ENOSYS;
-	}
-
-	return api->cursor_set_enabled(dev, enabled);
-}
-
 /**
  * @brief		Set cursor blinking status on an auxiliary display
  *
@@ -392,18 +358,6 @@ static inline int z_impl_auxdisplay_cursor_set_enabled(const struct device *dev,
  */
 __syscall int auxdisplay_position_blinking_set_enabled(const struct device *dev,
 						       bool enabled);
-
-static inline int z_impl_auxdisplay_position_blinking_set_enabled(const struct device *dev,
-								  bool enabled)
-{
-	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
-
-	if (!api->position_blinking_set_enabled) {
-		return -ENOSYS;
-	}
-
-	return api->position_blinking_set_enabled(dev, enabled);
-}
 
 /**
  * @brief		Set cursor shift after character write and display shift
@@ -420,23 +374,6 @@ static inline int z_impl_auxdisplay_position_blinking_set_enabled(const struct d
  */
 __syscall int auxdisplay_cursor_shift_set(const struct device *dev,
 					  uint8_t direction, bool display_shift);
-
-static inline int z_impl_auxdisplay_cursor_shift_set(const struct device *dev,
-						     uint8_t direction,
-						     bool display_shift)
-{
-	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
-
-	if (!api->cursor_shift_set) {
-		return -ENOSYS;
-	}
-
-	if (direction >= AUXDISPLAY_DIRECTION_COUNT) {
-		return -EINVAL;
-	}
-
-	return api->cursor_shift_set(dev, direction, display_shift);
-}
 
 /**
  * @brief	Set cursor (and write position) on an auxiliary display
@@ -455,23 +392,6 @@ __syscall int auxdisplay_cursor_position_set(const struct device *dev,
 					     enum auxdisplay_position type,
 					     int16_t x, int16_t y);
 
-static inline int z_impl_auxdisplay_cursor_position_set(const struct device *dev,
-							enum auxdisplay_position type,
-							int16_t x, int16_t y)
-{
-	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
-
-	if (!api->cursor_position_set) {
-		return -ENOSYS;
-	} else if (type >= AUXDISPLAY_POSITION_COUNT) {
-		return -EINVAL;
-	} else if (type == AUXDISPLAY_POSITION_ABSOLUTE && (x < 0 || y < 0)) {
-		return -EINVAL;
-	}
-
-	return api->cursor_position_set(dev, type, x, y);
-}
-
 /**
  * @brief	Get current cursor on an auxiliary display
  *
@@ -486,18 +406,6 @@ static inline int z_impl_auxdisplay_cursor_position_set(const struct device *dev
  */
 __syscall int auxdisplay_cursor_position_get(const struct device *dev,
 					     int16_t *x, int16_t *y);
-
-static inline int z_impl_auxdisplay_cursor_position_get(const struct device *dev,
-							int16_t *x, int16_t *y)
-{
-	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
-
-	if (!api->cursor_position_get) {
-		return -ENOSYS;
-	}
-
-	return api->cursor_position_get(dev, x, y);
-}
 
 /**
  * @brief	Set display position on an auxiliary display
@@ -516,23 +424,6 @@ __syscall int auxdisplay_display_position_set(const struct device *dev,
 					      enum auxdisplay_position type,
 					      int16_t x, int16_t y);
 
-static inline int z_impl_auxdisplay_display_position_set(const struct device *dev,
-							 enum auxdisplay_position type,
-							 int16_t x, int16_t y)
-{
-	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
-
-	if (!api->display_position_set) {
-		return -ENOSYS;
-	} else if (type >= AUXDISPLAY_POSITION_COUNT) {
-		return -EINVAL;
-	} else if (type == AUXDISPLAY_POSITION_ABSOLUTE && (x < 0 || y < 0)) {
-		return -EINVAL;
-	}
-
-	return api->display_position_set(dev, type, x, y);
-}
-
 /**
  * @brief	Get current display position on an auxiliary display
  *
@@ -548,18 +439,6 @@ static inline int z_impl_auxdisplay_display_position_set(const struct device *de
 __syscall int auxdisplay_display_position_get(const struct device *dev,
 					      int16_t *x, int16_t *y);
 
-static inline int z_impl_auxdisplay_display_position_get(const struct device *dev,
-							 int16_t *x, int16_t *y)
-{
-	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
-
-	if (!api->display_position_get) {
-		return -ENOSYS;
-	}
-
-	return api->display_position_get(dev, x, y);
-}
-
 /**
  * @brief		Fetch capabilities (and details) of auxiliary display
  *
@@ -571,14 +450,6 @@ static inline int z_impl_auxdisplay_display_position_get(const struct device *de
  */
 __syscall int auxdisplay_capabilities_get(const struct device *dev,
 					  struct auxdisplay_capabilities *capabilities);
-
-static inline int z_impl_auxdisplay_capabilities_get(const struct device *dev,
-						     struct auxdisplay_capabilities *capabilities)
-{
-	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
-
-	return api->capabilities_get(dev, capabilities);
-}
 
 /**
  * @brief	Clear display of auxiliary display and return to home position (note that
@@ -592,13 +463,6 @@ static inline int z_impl_auxdisplay_capabilities_get(const struct device *dev,
  */
 __syscall int auxdisplay_clear(const struct device *dev);
 
-static inline int z_impl_auxdisplay_clear(const struct device *dev)
-{
-	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
-
-	return api->clear(dev);
-}
-
 /**
  * @brief		Get the current brightness level of an auxiliary display
  *
@@ -611,18 +475,6 @@ static inline int z_impl_auxdisplay_clear(const struct device *dev)
  */
 __syscall int auxdisplay_brightness_get(const struct device *dev,
 					uint8_t *brightness);
-
-static inline int z_impl_auxdisplay_brightness_get(const struct device *dev,
-						   uint8_t *brightness)
-{
-	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
-
-	if (!api->brightness_get) {
-		return -ENOSYS;
-	}
-
-	return api->brightness_get(dev, brightness);
-}
 
 /**
  * @brief		Update the brightness level of an auxiliary display
@@ -638,18 +490,6 @@ static inline int z_impl_auxdisplay_brightness_get(const struct device *dev,
 __syscall int auxdisplay_brightness_set(const struct device *dev,
 					uint8_t brightness);
 
-static inline int z_impl_auxdisplay_brightness_set(const struct device *dev,
-						   uint8_t brightness)
-{
-	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
-
-	if (!api->brightness_set) {
-		return -ENOSYS;
-	}
-
-	return api->brightness_set(dev, brightness);
-}
-
 /**
  * @brief		Get the backlight level details of an auxiliary display
  *
@@ -662,18 +502,6 @@ static inline int z_impl_auxdisplay_brightness_set(const struct device *dev,
  */
 __syscall int auxdisplay_backlight_get(const struct device *dev,
 				       uint8_t *backlight);
-
-static inline int z_impl_auxdisplay_backlight_get(const struct device *dev,
-						  uint8_t *backlight)
-{
-	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
-
-	if (!api->backlight_get) {
-		return -ENOSYS;
-	}
-
-	return api->backlight_get(dev, backlight);
-}
 
 /**
  * @brief		Update the backlight level of an auxiliary display
@@ -689,18 +517,6 @@ static inline int z_impl_auxdisplay_backlight_get(const struct device *dev,
 __syscall int auxdisplay_backlight_set(const struct device *dev,
 				       uint8_t backlight);
 
-static inline int z_impl_auxdisplay_backlight_set(const struct device *dev,
-						  uint8_t backlight)
-{
-	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
-
-	if (!api->backlight_set) {
-		return -ENOSYS;
-	}
-
-	return api->backlight_set(dev, backlight);
-}
-
 /**
  * @brief	Check if an auxiliary display driver is busy
  *
@@ -712,17 +528,6 @@ static inline int z_impl_auxdisplay_backlight_set(const struct device *dev,
  * @retval	-errno Negative errno code on other failure.
  */
 __syscall int auxdisplay_is_busy(const struct device *dev);
-
-static inline int z_impl_auxdisplay_is_busy(const struct device *dev)
-{
-	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
-
-	if (!api->is_busy) {
-		return -ENOSYS;
-	}
-
-	return api->is_busy(dev);
-}
 
 /**
  * @brief		Sets a custom character in the display, the custom character struct
@@ -747,18 +552,6 @@ static inline int z_impl_auxdisplay_is_busy(const struct device *dev)
 __syscall int auxdisplay_custom_character_set(const struct device *dev,
 					      struct auxdisplay_character *character);
 
-static inline int z_impl_auxdisplay_custom_character_set(const struct device *dev,
-							 struct auxdisplay_character *character)
-{
-	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
-
-	if (!api->custom_character_set) {
-		return -ENOSYS;
-	}
-
-	return api->custom_character_set(dev, character);
-}
-
 /**
  * @brief	Write data to auxiliary display screen at current position
  *
@@ -772,14 +565,6 @@ static inline int z_impl_auxdisplay_custom_character_set(const struct device *de
  */
 __syscall int auxdisplay_write(const struct device *dev, const uint8_t *data,
 			       uint16_t len);
-
-static inline int z_impl_auxdisplay_write(const struct device *dev,
-					  const uint8_t *data, uint16_t len)
-{
-	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
-
-	return api->write(dev, data, len);
-}
 
 /**
  * @brief	Send a custom command to the display (if supported by driver)
@@ -795,18 +580,6 @@ static inline int z_impl_auxdisplay_write(const struct device *dev,
 __syscall int auxdisplay_custom_command(const struct device *dev,
 					struct auxdisplay_custom_data *data);
 
-static inline int z_impl_auxdisplay_custom_command(const struct device *dev,
-						   struct auxdisplay_custom_data *data)
-{
-	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
-
-	if (!api->custom_command) {
-		return -ENOSYS;
-	}
-
-	return api->custom_command(dev, data);
-}
-
 #ifdef __cplusplus
 }
 #endif
@@ -815,6 +588,7 @@ static inline int z_impl_auxdisplay_custom_command(const struct device *dev,
  * @}
  */
 
+#include <zephyr/drivers/auxdisplay/internal/auxdisplay_impl.h>
 #include <zephyr/syscalls/auxdisplay.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_AUXDISPLAY_H_ */

--- a/include/zephyr/drivers/auxdisplay/internal/auxdisplay_impl.h
+++ b/include/zephyr/drivers/auxdisplay/internal/auxdisplay_impl.h
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2022-2023 Jamie McCrae
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Inline syscall implementation for auxiliary display driver API
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_AUXDISPLAY_H_
+#error "Should only be included by zephyr/drivers/auxdisplay.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_AUXDISPLAY_INTERNAL_AUXDISPLAY_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_AUXDISPLAY_INTERNAL_AUXDISPLAY_IMPL_H_
+
+#include <stdint.h>
+#include <stddef.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_auxdisplay_display_on(const struct device *dev)
+{
+	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
+
+	if (!api->display_on) {
+		return -ENOSYS;
+	}
+
+	return api->display_on(dev);
+}
+
+static inline int z_impl_auxdisplay_display_off(const struct device *dev)
+{
+	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
+
+	if (!api->display_off) {
+		return -ENOSYS;
+	}
+
+	return api->display_off(dev);
+}
+
+static inline int z_impl_auxdisplay_cursor_set_enabled(const struct device *dev,
+						       bool enabled)
+{
+	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
+
+	if (!api->cursor_set_enabled) {
+		return -ENOSYS;
+	}
+
+	return api->cursor_set_enabled(dev, enabled);
+}
+
+static inline int z_impl_auxdisplay_position_blinking_set_enabled(const struct device *dev,
+								  bool enabled)
+{
+	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
+
+	if (!api->position_blinking_set_enabled) {
+		return -ENOSYS;
+	}
+
+	return api->position_blinking_set_enabled(dev, enabled);
+}
+
+static inline int z_impl_auxdisplay_cursor_shift_set(const struct device *dev,
+						     uint8_t direction,
+						     bool display_shift)
+{
+	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
+
+	if (!api->cursor_shift_set) {
+		return -ENOSYS;
+	}
+
+	if (direction >= AUXDISPLAY_DIRECTION_COUNT) {
+		return -EINVAL;
+	}
+
+	return api->cursor_shift_set(dev, direction, display_shift);
+}
+
+static inline int z_impl_auxdisplay_cursor_position_set(const struct device *dev,
+							enum auxdisplay_position type,
+							int16_t x, int16_t y)
+{
+	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
+
+	if (!api->cursor_position_set) {
+		return -ENOSYS;
+	} else if (type >= AUXDISPLAY_POSITION_COUNT) {
+		return -EINVAL;
+	} else if (type == AUXDISPLAY_POSITION_ABSOLUTE && (x < 0 || y < 0)) {
+		return -EINVAL;
+	}
+
+	return api->cursor_position_set(dev, type, x, y);
+}
+
+static inline int z_impl_auxdisplay_cursor_position_get(const struct device *dev,
+							int16_t *x, int16_t *y)
+{
+	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
+
+	if (!api->cursor_position_get) {
+		return -ENOSYS;
+	}
+
+	return api->cursor_position_get(dev, x, y);
+}
+
+static inline int z_impl_auxdisplay_display_position_set(const struct device *dev,
+							 enum auxdisplay_position type,
+							 int16_t x, int16_t y)
+{
+	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
+
+	if (!api->display_position_set) {
+		return -ENOSYS;
+	} else if (type >= AUXDISPLAY_POSITION_COUNT) {
+		return -EINVAL;
+	} else if (type == AUXDISPLAY_POSITION_ABSOLUTE && (x < 0 || y < 0)) {
+		return -EINVAL;
+	}
+
+	return api->display_position_set(dev, type, x, y);
+}
+
+static inline int z_impl_auxdisplay_display_position_get(const struct device *dev,
+							 int16_t *x, int16_t *y)
+{
+	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
+
+	if (!api->display_position_get) {
+		return -ENOSYS;
+	}
+
+	return api->display_position_get(dev, x, y);
+}
+
+static inline int z_impl_auxdisplay_capabilities_get(const struct device *dev,
+						     struct auxdisplay_capabilities *capabilities)
+{
+	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
+
+	return api->capabilities_get(dev, capabilities);
+}
+
+static inline int z_impl_auxdisplay_clear(const struct device *dev)
+{
+	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
+
+	return api->clear(dev);
+}
+
+static inline int z_impl_auxdisplay_brightness_get(const struct device *dev,
+						   uint8_t *brightness)
+{
+	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
+
+	if (!api->brightness_get) {
+		return -ENOSYS;
+	}
+
+	return api->brightness_get(dev, brightness);
+}
+
+static inline int z_impl_auxdisplay_brightness_set(const struct device *dev,
+						   uint8_t brightness)
+{
+	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
+
+	if (!api->brightness_set) {
+		return -ENOSYS;
+	}
+
+	return api->brightness_set(dev, brightness);
+}
+
+static inline int z_impl_auxdisplay_backlight_get(const struct device *dev,
+						  uint8_t *backlight)
+{
+	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
+
+	if (!api->backlight_get) {
+		return -ENOSYS;
+	}
+
+	return api->backlight_get(dev, backlight);
+}
+
+static inline int z_impl_auxdisplay_backlight_set(const struct device *dev,
+						  uint8_t backlight)
+{
+	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
+
+	if (!api->backlight_set) {
+		return -ENOSYS;
+	}
+
+	return api->backlight_set(dev, backlight);
+}
+
+static inline int z_impl_auxdisplay_is_busy(const struct device *dev)
+{
+	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
+
+	if (!api->is_busy) {
+		return -ENOSYS;
+	}
+
+	return api->is_busy(dev);
+}
+
+static inline int z_impl_auxdisplay_custom_character_set(const struct device *dev,
+							 struct auxdisplay_character *character)
+{
+	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
+
+	if (!api->custom_character_set) {
+		return -ENOSYS;
+	}
+
+	return api->custom_character_set(dev, character);
+}
+
+static inline int z_impl_auxdisplay_write(const struct device *dev,
+					  const uint8_t *data, uint16_t len)
+{
+	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
+
+	return api->write(dev, data, len);
+}
+
+static inline int z_impl_auxdisplay_custom_command(const struct device *dev,
+						   struct auxdisplay_custom_data *data)
+{
+	struct auxdisplay_driver_api *api = (struct auxdisplay_driver_api *)dev->api;
+
+	if (!api->custom_command) {
+		return -ENOSYS;
+	}
+
+	return api->custom_command(dev, data);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_AUXDISPLAY_INTERNAL_AUXDISPLAY_IMPL_H_ */

--- a/include/zephyr/drivers/bbram.h
+++ b/include/zephyr/drivers/bbram.h
@@ -92,18 +92,6 @@ __subsystem struct bbram_driver_api {
  */
 __syscall int bbram_check_invalid(const struct device *dev);
 
-static inline int z_impl_bbram_check_invalid(const struct device *dev)
-{
-	const struct bbram_driver_api *api =
-		(const struct bbram_driver_api *)dev->api;
-
-	if (!api->check_invalid) {
-		return -ENOTSUP;
-	}
-
-	return api->check_invalid(dev);
-}
-
 /**
  * @brief Check for standby (Volt SBY) power failure.
  *
@@ -113,18 +101,6 @@ static inline int z_impl_bbram_check_invalid(const struct device *dev)
  * @return 0 if V SBY power domain is in normal operation.
  */
 __syscall int bbram_check_standby_power(const struct device *dev);
-
-static inline int z_impl_bbram_check_standby_power(const struct device *dev)
-{
-	const struct bbram_driver_api *api =
-		(const struct bbram_driver_api *)dev->api;
-
-	if (!api->check_standby_power) {
-		return -ENOTSUP;
-	}
-
-	return api->check_standby_power(dev);
-}
 
 /**
  * @brief Check for V CC1 power failure.
@@ -137,18 +113,6 @@ static inline int z_impl_bbram_check_standby_power(const struct device *dev)
  */
 __syscall int bbram_check_power(const struct device *dev);
 
-static inline int z_impl_bbram_check_power(const struct device *dev)
-{
-	const struct bbram_driver_api *api =
-		(const struct bbram_driver_api *)dev->api;
-
-	if (!api->check_power) {
-		return -ENOTSUP;
-	}
-
-	return api->check_power(dev);
-}
-
 /**
  * @brief Get the size of the BBRAM (in bytes).
  *
@@ -157,18 +121,6 @@ static inline int z_impl_bbram_check_power(const struct device *dev)
  * @return 0 for success, -EFAULT otherwise.
  */
 __syscall int bbram_get_size(const struct device *dev, size_t *size);
-
-static inline int z_impl_bbram_get_size(const struct device *dev, size_t *size)
-{
-	const struct bbram_driver_api *api =
-		(const struct bbram_driver_api *)dev->api;
-
-	if (!api->get_size) {
-		return -ENOTSUP;
-	}
-
-	return api->get_size(dev, size);
-}
 
 /**
  * @brief Read bytes from BBRAM.
@@ -182,19 +134,6 @@ static inline int z_impl_bbram_get_size(const struct device *dev, size_t *size)
 __syscall int bbram_read(const struct device *dev, size_t offset, size_t size,
 			 uint8_t *data);
 
-static inline int z_impl_bbram_read(const struct device *dev, size_t offset,
-				    size_t size, uint8_t *data)
-{
-	const struct bbram_driver_api *api =
-		(const struct bbram_driver_api *)dev->api;
-
-	if (!api->read) {
-		return -ENOTSUP;
-	}
-
-	return api->read(dev, offset, size, data);
-}
-
 /**
  * @brief Write bytes to BBRAM.
  *
@@ -206,19 +145,6 @@ static inline int z_impl_bbram_read(const struct device *dev, size_t offset,
  */
 __syscall int bbram_write(const struct device *dev, size_t offset, size_t size,
 			  const uint8_t *data);
-
-static inline int z_impl_bbram_write(const struct device *dev, size_t offset,
-				     size_t size, const uint8_t *data)
-{
-	const struct bbram_driver_api *api =
-		(const struct bbram_driver_api *)dev->api;
-
-	if (!api->write) {
-		return -ENOTSUP;
-	}
-
-	return api->write(dev, offset, size, data);
-}
 
 /**
  * @brief Set the emulated BBRAM driver's invalid state
@@ -261,6 +187,7 @@ int bbram_emul_set_power_state(const struct device *dev, bool failure);
  * @}
  */
 
+#include <zephyr/drivers/bbram/internal/bbram_impl.h>
 #include <zephyr/syscalls/bbram.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_BBRAM_H */

--- a/include/zephyr/drivers/bbram/internal/bbram_impl.h
+++ b/include/zephyr/drivers/bbram/internal/bbram_impl.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2021 Google Inc
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_BBRAM_H
+#error "Should only be included by zephyr/drivers/bbram.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_BBRAM_INTERNAL_BBRAM_IMPL_H
+#define ZEPHYR_INCLUDE_DRIVERS_BBRAM_INTERNAL_BBRAM_IMPL_H
+
+#include <errno.h>
+
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_bbram_check_invalid(const struct device *dev)
+{
+	const struct bbram_driver_api *api =
+		(const struct bbram_driver_api *)dev->api;
+
+	if (!api->check_invalid) {
+		return -ENOTSUP;
+	}
+
+	return api->check_invalid(dev);
+}
+
+static inline int z_impl_bbram_check_standby_power(const struct device *dev)
+{
+	const struct bbram_driver_api *api =
+		(const struct bbram_driver_api *)dev->api;
+
+	if (!api->check_standby_power) {
+		return -ENOTSUP;
+	}
+
+	return api->check_standby_power(dev);
+}
+
+static inline int z_impl_bbram_check_power(const struct device *dev)
+{
+	const struct bbram_driver_api *api =
+		(const struct bbram_driver_api *)dev->api;
+
+	if (!api->check_power) {
+		return -ENOTSUP;
+	}
+
+	return api->check_power(dev);
+}
+
+static inline int z_impl_bbram_get_size(const struct device *dev, size_t *size)
+{
+	const struct bbram_driver_api *api =
+		(const struct bbram_driver_api *)dev->api;
+
+	if (!api->get_size) {
+		return -ENOTSUP;
+	}
+
+	return api->get_size(dev, size);
+}
+
+static inline int z_impl_bbram_read(const struct device *dev, size_t offset,
+				    size_t size, uint8_t *data)
+{
+	const struct bbram_driver_api *api =
+		(const struct bbram_driver_api *)dev->api;
+
+	if (!api->read) {
+		return -ENOTSUP;
+	}
+
+	return api->read(dev, offset, size, data);
+}
+
+static inline int z_impl_bbram_write(const struct device *dev, size_t offset,
+				     size_t size, const uint8_t *data)
+{
+	const struct bbram_driver_api *api =
+		(const struct bbram_driver_api *)dev->api;
+
+	if (!api->write) {
+		return -ENOTSUP;
+	}
+
+	return api->write(dev, offset, size, data);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_BBRAM_INTERNAL_BBRAM_IMPL_H */

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -823,13 +823,6 @@ struct can_device_state {
  */
 __syscall int can_get_core_clock(const struct device *dev, uint32_t *rate);
 
-static inline int z_impl_can_get_core_clock(const struct device *dev, uint32_t *rate)
-{
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
-
-	return api->get_core_clock(dev, rate);
-}
-
 /**
  * @brief Get minimum supported bitrate
  *
@@ -839,13 +832,6 @@ static inline int z_impl_can_get_core_clock(const struct device *dev, uint32_t *
  * @return Minimum supported bitrate in bits/s
  */
 __syscall uint32_t can_get_bitrate_min(const struct device *dev);
-
-static inline uint32_t z_impl_can_get_bitrate_min(const struct device *dev)
-{
-	const struct can_driver_config *common = (const struct can_driver_config *)dev->config;
-
-	return common->min_bitrate;
-}
 
 /**
  * @brief Get minimum supported bitrate
@@ -877,13 +863,6 @@ __deprecated static inline int can_get_min_bitrate(const struct device *dev, uin
  */
 __syscall uint32_t can_get_bitrate_max(const struct device *dev);
 
-static inline uint32_t z_impl_can_get_bitrate_max(const struct device *dev)
-{
-	const struct can_driver_config *common = (const struct can_driver_config *)dev->config;
-
-	return common->max_bitrate;
-}
-
 /**
  * @brief Get maximum supported bitrate
  *
@@ -914,13 +893,6 @@ __deprecated static inline int can_get_max_bitrate(const struct device *dev, uin
  */
 __syscall const struct can_timing *can_get_timing_min(const struct device *dev);
 
-static inline const struct can_timing *z_impl_can_get_timing_min(const struct device *dev)
-{
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
-
-	return &api->timing_min;
-}
-
 /**
  * @brief Get the maximum supported timing parameter values.
  *
@@ -929,13 +901,6 @@ static inline const struct can_timing *z_impl_can_get_timing_min(const struct de
  * @return Pointer to the maximum supported timing parameter values.
  */
 __syscall const struct can_timing *can_get_timing_max(const struct device *dev);
-
-static inline const struct can_timing *z_impl_can_get_timing_max(const struct device *dev)
-{
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
-
-	return &api->timing_max;
-}
 
 /**
  * @brief Calculate timing parameters from bitrate and sample point
@@ -981,15 +946,6 @@ __syscall int can_calc_timing(const struct device *dev, struct can_timing *res,
  */
 __syscall const struct can_timing *can_get_timing_data_min(const struct device *dev);
 
-#ifdef CONFIG_CAN_FD_MODE
-static inline const struct can_timing *z_impl_can_get_timing_data_min(const struct device *dev)
-{
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
-
-	return &api->timing_data_min;
-}
-#endif /* CONFIG_CAN_FD_MODE */
-
 /**
  * @brief Get the maximum supported timing parameter values for the data phase.
  *
@@ -1004,15 +960,6 @@ static inline const struct can_timing *z_impl_can_get_timing_data_min(const stru
  *         CAN FD support is not implemented by the driver.
  */
 __syscall const struct can_timing *can_get_timing_data_max(const struct device *dev);
-
-#ifdef CONFIG_CAN_FD_MODE
-static inline const struct can_timing *z_impl_can_get_timing_data_max(const struct device *dev)
-{
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
-
-	return &api->timing_data_max;
-}
-#endif /* CONFIG_CAN_FD_MODE */
 
 /**
  * @brief Calculate timing parameters for the data phase
@@ -1141,13 +1088,6 @@ __syscall int can_set_timing(const struct device *dev,
  */
 __syscall int can_get_capabilities(const struct device *dev, can_mode_t *cap);
 
-static inline int z_impl_can_get_capabilities(const struct device *dev, can_mode_t *cap)
-{
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
-
-	return api->get_capabilities(dev, cap);
-}
-
 /**
  * @brief Get the CAN transceiver associated with the CAN controller
  *
@@ -1158,13 +1098,6 @@ static inline int z_impl_can_get_capabilities(const struct device *dev, can_mode
  *         NULL if no transceiver is associated.
  */
 __syscall const struct device *can_get_transceiver(const struct device *dev);
-
-static const struct device *z_impl_can_get_transceiver(const struct device *dev)
-{
-	const struct can_driver_config *common = (const struct can_driver_config *)dev->config;
-
-	return common->phy;
-}
 
 /**
  * @brief Start the CAN controller
@@ -1185,13 +1118,6 @@ static const struct device *z_impl_can_get_transceiver(const struct device *dev)
  */
 __syscall int can_start(const struct device *dev);
 
-static inline int z_impl_can_start(const struct device *dev)
-{
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
-
-	return api->start(dev);
-}
-
 /**
  * @brief Stop the CAN controller
  *
@@ -1209,13 +1135,6 @@ static inline int z_impl_can_start(const struct device *dev)
  */
 __syscall int can_stop(const struct device *dev);
 
-static inline int z_impl_can_stop(const struct device *dev)
-{
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
-
-	return api->stop(dev);
-}
-
 /**
  * @brief Set the CAN controller to the given operation mode
  *
@@ -1228,13 +1147,6 @@ static inline int z_impl_can_stop(const struct device *dev)
  */
 __syscall int can_set_mode(const struct device *dev, can_mode_t mode);
 
-static inline int z_impl_can_set_mode(const struct device *dev, can_mode_t mode)
-{
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
-
-	return api->set_mode(dev, mode);
-}
-
 /**
  * @brief Get the operation mode of the CAN controller
  *
@@ -1243,13 +1155,6 @@ static inline int z_impl_can_set_mode(const struct device *dev, can_mode_t mode)
  * @return Current operation mode.
  */
 __syscall can_mode_t can_get_mode(const struct device *dev);
-
-static inline can_mode_t z_impl_can_get_mode(const struct device *dev)
-{
-	const struct can_driver_data *common = (const struct can_driver_data *)dev->data;
-
-	return common->mode;
-}
 
 /**
  * @brief Set the bitrate of the CAN controller
@@ -1421,13 +1326,6 @@ __syscall int can_add_rx_filter_msgq(const struct device *dev, struct k_msgq *ms
  */
 __syscall void can_remove_rx_filter(const struct device *dev, int filter_id);
 
-static inline void z_impl_can_remove_rx_filter(const struct device *dev, int filter_id)
-{
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
-
-	return api->remove_rx_filter(dev, filter_id);
-}
-
 /**
  * @brief Get maximum number of RX filters
  *
@@ -1442,17 +1340,6 @@ static inline void z_impl_can_remove_rx_filter(const struct device *dev, int fil
  * @retval -ENOSYS If this function is not implemented by the driver.
  */
 __syscall int can_get_max_filters(const struct device *dev, bool ide);
-
-static inline int z_impl_can_get_max_filters(const struct device *dev, bool ide)
-{
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
-
-	if (api->get_max_filters == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->get_max_filters(dev, ide);
-}
 
 /** @} */
 
@@ -1478,14 +1365,6 @@ static inline int z_impl_can_get_max_filters(const struct device *dev, bool ide)
 __syscall int can_get_state(const struct device *dev, enum can_state *state,
 			    struct can_bus_err_cnt *err_cnt);
 
-static inline int z_impl_can_get_state(const struct device *dev, enum can_state *state,
-				       struct can_bus_err_cnt *err_cnt)
-{
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
-
-	return api->get_state(dev, state, err_cnt);
-}
-
 /**
  * @brief Recover from bus-off state
  *
@@ -1504,19 +1383,6 @@ static inline int z_impl_can_get_state(const struct device *dev, enum can_state 
  * @retval -ENOSYS If this function is not implemented by the driver.
  */
 __syscall int can_recover(const struct device *dev, k_timeout_t timeout);
-
-#ifdef CONFIG_CAN_MANUAL_RECOVERY_MODE
-static inline int z_impl_can_recover(const struct device *dev, k_timeout_t timeout)
-{
-	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
-
-	if (api->recover == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->recover(dev, timeout);
-}
-#endif /* CONFIG_CAN_MANUAL_RECOVERY_MODE */
 
 /**
  * @brief Set a callback for CAN controller state change events
@@ -1562,13 +1428,6 @@ static inline void can_set_state_change_callback(const struct device *dev,
  */
 __syscall uint32_t can_stats_get_bit_errors(const struct device *dev);
 
-#ifdef CONFIG_CAN_STATS
-static inline uint32_t z_impl_can_stats_get_bit_errors(const struct device *dev)
-{
-	return Z_CAN_GET_STATS(dev).bit_error;
-}
-#endif /* CONFIG_CAN_STATS */
-
 /**
  * @brief Get the bit0 error counter for a CAN device
  *
@@ -1584,13 +1443,6 @@ static inline uint32_t z_impl_can_stats_get_bit_errors(const struct device *dev)
  * @return bit0 error counter
  */
 __syscall uint32_t can_stats_get_bit0_errors(const struct device *dev);
-
-#ifdef CONFIG_CAN_STATS
-static inline uint32_t z_impl_can_stats_get_bit0_errors(const struct device *dev)
-{
-	return Z_CAN_GET_STATS(dev).bit0_error;
-}
-#endif /* CONFIG_CAN_STATS */
 
 /**
  * @brief Get the bit1 error counter for a CAN device
@@ -1608,13 +1460,6 @@ static inline uint32_t z_impl_can_stats_get_bit0_errors(const struct device *dev
  */
 __syscall uint32_t can_stats_get_bit1_errors(const struct device *dev);
 
-#ifdef CONFIG_CAN_STATS
-static inline uint32_t z_impl_can_stats_get_bit1_errors(const struct device *dev)
-{
-	return Z_CAN_GET_STATS(dev).bit1_error;
-}
-#endif /* CONFIG_CAN_STATS */
-
 /**
  * @brief Get the stuffing error counter for a CAN device
  *
@@ -1628,13 +1473,6 @@ static inline uint32_t z_impl_can_stats_get_bit1_errors(const struct device *dev
  * @return stuffing error counter
  */
 __syscall uint32_t can_stats_get_stuff_errors(const struct device *dev);
-
-#ifdef CONFIG_CAN_STATS
-static inline uint32_t z_impl_can_stats_get_stuff_errors(const struct device *dev)
-{
-	return Z_CAN_GET_STATS(dev).stuff_error;
-}
-#endif /* CONFIG_CAN_STATS */
 
 /**
  * @brief Get the CRC error counter for a CAN device
@@ -1650,13 +1488,6 @@ static inline uint32_t z_impl_can_stats_get_stuff_errors(const struct device *de
  */
 __syscall uint32_t can_stats_get_crc_errors(const struct device *dev);
 
-#ifdef CONFIG_CAN_STATS
-static inline uint32_t z_impl_can_stats_get_crc_errors(const struct device *dev)
-{
-	return Z_CAN_GET_STATS(dev).crc_error;
-}
-#endif /* CONFIG_CAN_STATS */
-
 /**
  * @brief Get the form error counter for a CAN device
  *
@@ -1670,13 +1501,6 @@ static inline uint32_t z_impl_can_stats_get_crc_errors(const struct device *dev)
  * @return form error counter
  */
 __syscall uint32_t can_stats_get_form_errors(const struct device *dev);
-
-#ifdef CONFIG_CAN_STATS
-static inline uint32_t z_impl_can_stats_get_form_errors(const struct device *dev)
-{
-	return Z_CAN_GET_STATS(dev).form_error;
-}
-#endif /* CONFIG_CAN_STATS */
 
 /**
  * @brief Get the acknowledge error counter for a CAN device
@@ -1692,13 +1516,6 @@ static inline uint32_t z_impl_can_stats_get_form_errors(const struct device *dev
  */
 __syscall uint32_t can_stats_get_ack_errors(const struct device *dev);
 
-#ifdef CONFIG_CAN_STATS
-static inline uint32_t z_impl_can_stats_get_ack_errors(const struct device *dev)
-{
-	return Z_CAN_GET_STATS(dev).ack_error;
-}
-#endif /* CONFIG_CAN_STATS */
-
 /**
  * @brief Get the RX overrun counter for a CAN device
  *
@@ -1713,13 +1530,6 @@ static inline uint32_t z_impl_can_stats_get_ack_errors(const struct device *dev)
  * @return RX overrun counter
  */
 __syscall uint32_t can_stats_get_rx_overruns(const struct device *dev);
-
-#ifdef CONFIG_CAN_STATS
-static inline uint32_t z_impl_can_stats_get_rx_overruns(const struct device *dev)
-{
-	return Z_CAN_GET_STATS(dev).rx_overrun;
-}
-#endif /* CONFIG_CAN_STATS */
 
 /** @} */
 
@@ -1801,6 +1611,7 @@ static inline bool can_frame_matches_filter(const struct can_frame *frame,
 }
 #endif
 
+#include <zephyr/drivers/can/internal/can_impl.h>
 #include <zephyr/syscalls/can.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_CAN_H_ */

--- a/include/zephyr/drivers/can/internal/can_impl.h
+++ b/include/zephyr/drivers/can/internal/can_impl.h
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2021 Vestas Wind Systems A/S
+ * Copyright (c) 2018 Karsten Koenig
+ * Copyright (c) 2018 Alexander Wachter
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Inline syscall implementation for Controller Area Network (CAN) driver APIs.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_CAN_H_
+#error "Should only be included by zephyr/drivers/can.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_CAN_INTERNAL_CAN_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_CAN_INTERNAL_CAN_IMPL_H_
+
+#include <errno.h>
+
+#include <zephyr/types.h>
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+#include <string.h>
+#include <zephyr/sys_clock.h>
+#include <zephyr/sys/util.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_can_get_core_clock(const struct device *dev, uint32_t *rate)
+{
+	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+
+	return api->get_core_clock(dev, rate);
+}
+
+static inline uint32_t z_impl_can_get_bitrate_min(const struct device *dev)
+{
+	const struct can_driver_config *common = (const struct can_driver_config *)dev->config;
+
+	return common->min_bitrate;
+}
+
+static inline uint32_t z_impl_can_get_bitrate_max(const struct device *dev)
+{
+	const struct can_driver_config *common = (const struct can_driver_config *)dev->config;
+
+	return common->max_bitrate;
+}
+
+static inline const struct can_timing *z_impl_can_get_timing_min(const struct device *dev)
+{
+	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+
+	return &api->timing_min;
+}
+
+static inline const struct can_timing *z_impl_can_get_timing_max(const struct device *dev)
+{
+	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+
+	return &api->timing_max;
+}
+
+#ifdef CONFIG_CAN_FD_MODE
+static inline const struct can_timing *z_impl_can_get_timing_data_min(const struct device *dev)
+{
+	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+
+	return &api->timing_data_min;
+}
+
+static inline const struct can_timing *z_impl_can_get_timing_data_max(const struct device *dev)
+{
+	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+
+	return &api->timing_data_max;
+}
+#endif /* CONFIG_CAN_FD_MODE */
+
+static inline int z_impl_can_get_capabilities(const struct device *dev, can_mode_t *cap)
+{
+	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+
+	return api->get_capabilities(dev, cap);
+}
+
+static const struct device *z_impl_can_get_transceiver(const struct device *dev)
+{
+	const struct can_driver_config *common = (const struct can_driver_config *)dev->config;
+
+	return common->phy;
+}
+
+static inline int z_impl_can_start(const struct device *dev)
+{
+	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+
+	return api->start(dev);
+}
+
+static inline int z_impl_can_stop(const struct device *dev)
+{
+	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+
+	return api->stop(dev);
+}
+
+static inline int z_impl_can_set_mode(const struct device *dev, can_mode_t mode)
+{
+	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+
+	return api->set_mode(dev, mode);
+}
+
+static inline can_mode_t z_impl_can_get_mode(const struct device *dev)
+{
+	const struct can_driver_data *common = (const struct can_driver_data *)dev->data;
+
+	return common->mode;
+}
+
+static inline void z_impl_can_remove_rx_filter(const struct device *dev, int filter_id)
+{
+	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+
+	return api->remove_rx_filter(dev, filter_id);
+}
+
+static inline int z_impl_can_get_max_filters(const struct device *dev, bool ide)
+{
+	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+
+	if (api->get_max_filters == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->get_max_filters(dev, ide);
+}
+
+static inline int z_impl_can_get_state(const struct device *dev, enum can_state *state,
+				       struct can_bus_err_cnt *err_cnt)
+{
+	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+
+	return api->get_state(dev, state, err_cnt);
+}
+
+#ifdef CONFIG_CAN_MANUAL_RECOVERY_MODE
+static inline int z_impl_can_recover(const struct device *dev, k_timeout_t timeout)
+{
+	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
+
+	if (api->recover == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->recover(dev, timeout);
+}
+#endif /* CONFIG_CAN_MANUAL_RECOVERY_MODE */
+
+#ifdef CONFIG_CAN_STATS
+static inline uint32_t z_impl_can_stats_get_bit_errors(const struct device *dev)
+{
+	return Z_CAN_GET_STATS(dev).bit_error;
+}
+
+static inline uint32_t z_impl_can_stats_get_bit0_errors(const struct device *dev)
+{
+	return Z_CAN_GET_STATS(dev).bit0_error;
+}
+
+static inline uint32_t z_impl_can_stats_get_bit1_errors(const struct device *dev)
+{
+	return Z_CAN_GET_STATS(dev).bit1_error;
+}
+
+static inline uint32_t z_impl_can_stats_get_stuff_errors(const struct device *dev)
+{
+	return Z_CAN_GET_STATS(dev).stuff_error;
+}
+
+static inline uint32_t z_impl_can_stats_get_crc_errors(const struct device *dev)
+{
+	return Z_CAN_GET_STATS(dev).crc_error;
+}
+
+static inline uint32_t z_impl_can_stats_get_form_errors(const struct device *dev)
+{
+	return Z_CAN_GET_STATS(dev).form_error;
+}
+
+static inline uint32_t z_impl_can_stats_get_ack_errors(const struct device *dev)
+{
+	return Z_CAN_GET_STATS(dev).ack_error;
+}
+
+static inline uint32_t z_impl_can_stats_get_rx_overruns(const struct device *dev)
+{
+	return Z_CAN_GET_STATS(dev).rx_overrun;
+}
+#endif /* CONFIG_CAN_STATS */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_CAN_INTERNAL_CAN_IMPL_H_ */

--- a/include/zephyr/drivers/charger.h
+++ b/include/zephyr/drivers/charger.h
@@ -349,14 +349,6 @@ __subsystem struct charger_driver_api {
 __syscall int charger_get_prop(const struct device *dev, const charger_prop_t prop,
 			       union charger_propval *val);
 
-static inline int z_impl_charger_get_prop(const struct device *dev, const charger_prop_t prop,
-					  union charger_propval *val)
-{
-	const struct charger_driver_api *api = (const struct charger_driver_api *)dev->api;
-
-	return api->get_property(dev, prop, val);
-}
-
 /**
  * @brief Set a battery charger property
  *
@@ -370,14 +362,6 @@ static inline int z_impl_charger_get_prop(const struct device *dev, const charge
 __syscall int charger_set_prop(const struct device *dev, const charger_prop_t prop,
 			       const union charger_propval *val);
 
-static inline int z_impl_charger_set_prop(const struct device *dev, const charger_prop_t prop,
-					  const union charger_propval *val)
-{
-	const struct charger_driver_api *api = (const struct charger_driver_api *)dev->api;
-
-	return api->set_property(dev, prop, val);
-}
-
 /**
  * @brief Enable or disable a charge cycle
  *
@@ -390,13 +374,6 @@ static inline int z_impl_charger_set_prop(const struct device *dev, const charge
  */
 __syscall int charger_charge_enable(const struct device *dev, const bool enable);
 
-static inline int z_impl_charger_charge_enable(const struct device *dev, const bool enable)
-{
-	const struct charger_driver_api *api = (const struct charger_driver_api *)dev->api;
-
-	return api->charge_enable(dev, enable);
-}
-
 /**
  * @}
  */
@@ -405,6 +382,7 @@ static inline int z_impl_charger_charge_enable(const struct device *dev, const b
 }
 #endif /* __cplusplus */
 
+#include <zephyr/drivers/charger/internal/charger_impl.h>
 #include <zephyr/syscalls/charger.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_CHARGER_H_ */

--- a/include/zephyr/drivers/charger/internal/charger_impl.h
+++ b/include/zephyr/drivers/charger/internal/charger_impl.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 Cirrus Logic, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Inline syscall implementation for Charger APIs
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_CHARGER_H_
+#error "Should only be included by zephyr/drivers/charger.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_CHARGER_INTERNAL_CHARGER_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_CHARGER_INTERNAL_CHARGER_IMPL_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+static inline int z_impl_charger_get_prop(const struct device *dev, const charger_prop_t prop,
+					  union charger_propval *val)
+{
+	const struct charger_driver_api *api = (const struct charger_driver_api *)dev->api;
+
+	return api->get_property(dev, prop, val);
+}
+
+static inline int z_impl_charger_set_prop(const struct device *dev, const charger_prop_t prop,
+					  const union charger_propval *val)
+{
+	const struct charger_driver_api *api = (const struct charger_driver_api *)dev->api;
+
+	return api->set_property(dev, prop, val);
+}
+
+static inline int z_impl_charger_charge_enable(const struct device *dev, const bool enable)
+{
+	const struct charger_driver_api *api = (const struct charger_driver_api *)dev->api;
+
+	return api->charge_enable(dev, enable);
+}
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_CHARGER_INTERNAL_CHARGER_IMPL_H_ */

--- a/include/zephyr/drivers/counter/internal/counter_impl.h
+++ b/include/zephyr/drivers/counter/internal/counter_impl.h
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ * Copyright (c) 2016 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Inline syscall implementation for counter and timer driver APIs.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_COUNTER_H_
+#error "Should only be included by zephyr/drivers/counter.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_COUNTER_INTERNAL_COUNTER_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_COUNTER_INTERNAL_COUNTER_IMPL_H_
+
+#include <errno.h>
+
+#include <zephyr/types.h>
+#include <stddef.h>
+#include <zephyr/device.h>
+#include <zephyr/sys_clock.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline bool z_impl_counter_is_counting_up(const struct device *dev)
+{
+	const struct counter_config_info *config =
+			(const struct counter_config_info *)dev->config;
+
+	return config->flags & COUNTER_CONFIG_INFO_COUNT_UP;
+}
+
+static inline uint8_t z_impl_counter_get_num_of_channels(const struct device *dev)
+{
+	const struct counter_config_info *config =
+			(const struct counter_config_info *)dev->config;
+
+	return config->channels;
+}
+
+static inline uint32_t z_impl_counter_get_frequency(const struct device *dev)
+{
+	const struct counter_config_info *config =
+			(const struct counter_config_info *)dev->config;
+	const struct counter_driver_api *api =
+				(struct counter_driver_api *)dev->api;
+
+	return api->get_freq ? api->get_freq(dev) : config->freq;
+}
+
+static inline uint32_t z_impl_counter_us_to_ticks(const struct device *dev,
+					       uint64_t us)
+{
+	uint64_t ticks = (us * z_impl_counter_get_frequency(dev)) / USEC_PER_SEC;
+
+	return (ticks > (uint64_t)UINT32_MAX) ? UINT32_MAX : ticks;
+}
+
+static inline uint64_t z_impl_counter_ticks_to_us(const struct device *dev,
+					       uint32_t ticks)
+{
+	return ((uint64_t)ticks * USEC_PER_SEC) / z_impl_counter_get_frequency(dev);
+}
+
+static inline uint32_t z_impl_counter_get_max_top_value(const struct device *dev)
+{
+	const struct counter_config_info *config =
+			(const struct counter_config_info *)dev->config;
+
+	return config->max_top_value;
+}
+
+static inline int z_impl_counter_start(const struct device *dev)
+{
+	const struct counter_driver_api *api =
+				(struct counter_driver_api *)dev->api;
+
+	return api->start(dev);
+}
+
+static inline int z_impl_counter_stop(const struct device *dev)
+{
+	const struct counter_driver_api *api =
+				(struct counter_driver_api *)dev->api;
+
+	return api->stop(dev);
+}
+
+static inline int z_impl_counter_get_value(const struct device *dev,
+					   uint32_t *ticks)
+{
+	const struct counter_driver_api *api =
+				(struct counter_driver_api *)dev->api;
+
+	return api->get_value(dev, ticks);
+}
+
+static inline int z_impl_counter_get_value_64(const struct device *dev,
+					   uint64_t *ticks)
+{
+	const struct counter_driver_api *api =
+				(struct counter_driver_api *)dev->api;
+
+	if (!api->get_value_64) {
+		return -ENOTSUP;
+	}
+
+	return api->get_value_64(dev, ticks);
+}
+
+static inline int z_impl_counter_set_channel_alarm(const struct device *dev,
+						   uint8_t chan_id,
+						   const struct counter_alarm_cfg *alarm_cfg)
+{
+	const struct counter_driver_api *api =
+				(struct counter_driver_api *)dev->api;
+
+	if (chan_id >= counter_get_num_of_channels(dev)) {
+		return -ENOTSUP;
+	}
+
+	return api->set_alarm(dev, chan_id, alarm_cfg);
+}
+
+static inline int z_impl_counter_cancel_channel_alarm(const struct device *dev,
+						      uint8_t chan_id)
+{
+	const struct counter_driver_api *api =
+				(struct counter_driver_api *)dev->api;
+
+	if (chan_id >= counter_get_num_of_channels(dev)) {
+		return -ENOTSUP;
+	}
+
+	return api->cancel_alarm(dev, chan_id);
+}
+
+static inline int z_impl_counter_set_top_value(const struct device *dev,
+					       const struct counter_top_cfg
+					       *cfg)
+{
+	const struct counter_driver_api *api =
+				(struct counter_driver_api *)dev->api;
+
+	if (cfg->ticks > counter_get_max_top_value(dev)) {
+		return -EINVAL;
+	}
+
+	return api->set_top_value(dev, cfg);
+}
+
+static inline int z_impl_counter_get_pending_int(const struct device *dev)
+{
+	const struct counter_driver_api *api =
+				(struct counter_driver_api *)dev->api;
+
+	return api->get_pending_int(dev);
+}
+
+static inline uint32_t z_impl_counter_get_top_value(const struct device *dev)
+{
+	const struct counter_driver_api *api =
+				(struct counter_driver_api *)dev->api;
+
+	return api->get_top_value(dev);
+}
+
+static inline int z_impl_counter_set_guard_period(const struct device *dev,
+						   uint32_t ticks, uint32_t flags)
+{
+	const struct counter_driver_api *api =
+				(struct counter_driver_api *)dev->api;
+
+	if (!api->set_guard_period) {
+		return -ENOTSUP;
+	}
+
+	return api->set_guard_period(dev, ticks, flags);
+}
+
+static inline uint32_t z_impl_counter_get_guard_period(const struct device *dev,
+							uint32_t flags)
+{
+	const struct counter_driver_api *api =
+				(struct counter_driver_api *)dev->api;
+
+	return (api->get_guard_period) ? api->get_guard_period(dev, flags) : 0;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_COUNTER_INTERNAL_COUNTER_IMPL_H_ */

--- a/include/zephyr/drivers/dac.h
+++ b/include/zephyr/drivers/dac.h
@@ -92,15 +92,6 @@ __subsystem struct dac_driver_api {
 __syscall int dac_channel_setup(const struct device *dev,
 				const struct dac_channel_cfg *channel_cfg);
 
-static inline int z_impl_dac_channel_setup(const struct device *dev,
-					   const struct dac_channel_cfg *channel_cfg)
-{
-	const struct dac_driver_api *api =
-				(const struct dac_driver_api *)dev->api;
-
-	return api->channel_setup(dev, channel_cfg);
-}
-
 /**
  * @brief Write a single value to a DAC channel
  *
@@ -114,15 +105,6 @@ static inline int z_impl_dac_channel_setup(const struct device *dev,
 __syscall int dac_write_value(const struct device *dev, uint8_t channel,
 			      uint32_t value);
 
-static inline int z_impl_dac_write_value(const struct device *dev,
-						uint8_t channel, uint32_t value)
-{
-	const struct dac_driver_api *api =
-				(const struct dac_driver_api *)dev->api;
-
-	return api->write_value(dev, channel, value);
-}
-
 /**
  * @}
  */
@@ -131,6 +113,7 @@ static inline int z_impl_dac_write_value(const struct device *dev,
 }
 #endif
 
+#include <zephyr/drivers/dac/internal/dac_impl.h>
 #include <zephyr/syscalls/dac.h>
 
 #endif  /* ZEPHYR_INCLUDE_DRIVERS_DAC_H_ */

--- a/include/zephyr/drivers/dac/internal/dac_impl.h
+++ b/include/zephyr/drivers/dac/internal/dac_impl.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2020 Libre Solar Technologies GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Inline syscall implementation for DAC APIs.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_DAC_H_
+#error "Should only be included by zephyr/drivers/dac.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_DAC_INTERNAL_DAC_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_DAC_INTERNAL_DAC_IMPL_H_
+
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_dac_channel_setup(const struct device *dev,
+					   const struct dac_channel_cfg *channel_cfg)
+{
+	const struct dac_driver_api *api =
+				(const struct dac_driver_api *)dev->api;
+
+	return api->channel_setup(dev, channel_cfg);
+}
+
+static inline int z_impl_dac_write_value(const struct device *dev,
+						uint8_t channel, uint32_t value)
+{
+	const struct dac_driver_api *api =
+				(const struct dac_driver_api *)dev->api;
+
+	return api->write_value(dev, channel, value);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* ZEPHYR_INCLUDE_DRIVERS_DAC_INTERNAL_DAC_IMPL_H_ */

--- a/include/zephyr/drivers/dma/internal/dma_impl.h
+++ b/include/zephyr/drivers/dma/internal/dma_impl.h
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2016 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Inline syscall implementation for DMA driver APIs.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_DMA_H_
+#error "Should only be included by zephyr/drivers/dma.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_DMA_INTERNAL_DMA_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_DMA_INTERNAL_DMA_IMPL_H_
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_dma_start(const struct device *dev, uint32_t channel)
+{
+	const struct dma_driver_api *api =
+		(const struct dma_driver_api *)dev->api;
+
+	return api->start(dev, channel);
+}
+
+static inline int z_impl_dma_stop(const struct device *dev, uint32_t channel)
+{
+	const struct dma_driver_api *api =
+		(const struct dma_driver_api *)dev->api;
+
+	return api->stop(dev, channel);
+}
+
+static inline int z_impl_dma_suspend(const struct device *dev, uint32_t channel)
+{
+	const struct dma_driver_api *api = (const struct dma_driver_api *)dev->api;
+
+	if (api->suspend == NULL) {
+		return -ENOSYS;
+	}
+	return api->suspend(dev, channel);
+}
+
+static inline int z_impl_dma_resume(const struct device *dev, uint32_t channel)
+{
+	const struct dma_driver_api *api = (const struct dma_driver_api *)dev->api;
+
+	if (api->resume == NULL) {
+		return -ENOSYS;
+	}
+	return api->resume(dev, channel);
+}
+
+static inline int z_impl_dma_request_channel(const struct device *dev,
+					     void *filter_param)
+{
+	int i = 0;
+	int channel = -EINVAL;
+	const struct dma_driver_api *api =
+		(const struct dma_driver_api *)dev->api;
+	/* dma_context shall be the first one in dev data */
+	struct dma_context *dma_ctx = (struct dma_context *)dev->data;
+
+	if (dma_ctx->magic != DMA_MAGIC) {
+		return channel;
+	}
+
+	for (i = 0; i < dma_ctx->dma_channels; i++) {
+		if (!atomic_test_and_set_bit(dma_ctx->atomic, i)) {
+			if (api->chan_filter &&
+			    !api->chan_filter(dev, i, filter_param)) {
+				atomic_clear_bit(dma_ctx->atomic, i);
+				continue;
+			}
+			channel = i;
+			break;
+		}
+	}
+
+	return channel;
+}
+
+static inline void z_impl_dma_release_channel(const struct device *dev,
+					      uint32_t channel)
+{
+	struct dma_context *dma_ctx = (struct dma_context *)dev->data;
+
+	if (dma_ctx->magic != DMA_MAGIC) {
+		return;
+	}
+
+	if ((int)channel < dma_ctx->dma_channels) {
+		atomic_clear_bit(dma_ctx->atomic, channel);
+	}
+
+}
+
+static inline int z_impl_dma_chan_filter(const struct device *dev,
+					      int channel, void *filter_param)
+{
+	const struct dma_driver_api *api =
+		(const struct dma_driver_api *)dev->api;
+
+	if (api->chan_filter) {
+		return api->chan_filter(dev, channel, filter_param);
+	}
+
+	return -ENOSYS;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_DMA_INTERNAL_DMA_IMPL_H_ */

--- a/include/zephyr/drivers/eeprom.h
+++ b/include/zephyr/drivers/eeprom.h
@@ -82,15 +82,6 @@ __subsystem struct eeprom_driver_api {
 __syscall int eeprom_read(const struct device *dev, off_t offset, void *data,
 			  size_t len);
 
-static inline int z_impl_eeprom_read(const struct device *dev, off_t offset,
-				     void *data, size_t len)
-{
-	const struct eeprom_driver_api *api =
-		(const struct eeprom_driver_api *)dev->api;
-
-	return api->read(dev, offset, data, len);
-}
-
 /**
  *  @brief Write data to EEPROM
  *
@@ -105,15 +96,6 @@ __syscall int eeprom_write(const struct device *dev, off_t offset,
 			   const void *data,
 			   size_t len);
 
-static inline int z_impl_eeprom_write(const struct device *dev, off_t offset,
-				      const void *data, size_t len)
-{
-	const struct eeprom_driver_api *api =
-		(const struct eeprom_driver_api *)dev->api;
-
-	return api->write(dev, offset, data, len);
-}
-
 /**
  *  @brief Get the size of the EEPROM in bytes
  *
@@ -123,14 +105,6 @@ static inline int z_impl_eeprom_write(const struct device *dev, off_t offset,
  */
 __syscall size_t eeprom_get_size(const struct device *dev);
 
-static inline size_t z_impl_eeprom_get_size(const struct device *dev)
-{
-	const struct eeprom_driver_api *api =
-		(const struct eeprom_driver_api *)dev->api;
-
-	return api->size(dev);
-}
-
 #ifdef __cplusplus
 }
 #endif
@@ -139,6 +113,7 @@ static inline size_t z_impl_eeprom_get_size(const struct device *dev)
  * @}
  */
 
+#include <zephyr/drivers/eeprom/internal/eeprom_impl.h>
 #include <zephyr/syscalls/eeprom.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_EEPROM_H_ */

--- a/include/zephyr/drivers/eeprom/internal/eeprom_impl.h
+++ b/include/zephyr/drivers/eeprom/internal/eeprom_impl.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2019 Vestas Wind Systems A/S
+ *
+ * Heavily based on drivers/flash.h which is:
+ * Copyright (c) 2017 Nordic Semiconductor ASA
+ * Copyright (c) 2016 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Inline syscall implementation for EEPROM driver APIs
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_EEPROM_H_
+#error "Should only be included by zephyr/drivers/eeprom.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_EEPROM_INTERNAL_EEPROM_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_EEPROM_INTERNAL_EEPROM_IMPL_H_
+
+#include <zephyr/types.h>
+#include <stddef.h>
+#include <sys/types.h>
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_eeprom_read(const struct device *dev, off_t offset,
+				     void *data, size_t len)
+{
+	const struct eeprom_driver_api *api =
+		(const struct eeprom_driver_api *)dev->api;
+
+	return api->read(dev, offset, data, len);
+}
+
+static inline int z_impl_eeprom_write(const struct device *dev, off_t offset,
+				      const void *data, size_t len)
+{
+	const struct eeprom_driver_api *api =
+		(const struct eeprom_driver_api *)dev->api;
+
+	return api->write(dev, offset, data, len);
+}
+
+static inline size_t z_impl_eeprom_get_size(const struct device *dev)
+{
+	const struct eeprom_driver_api *api =
+		(const struct eeprom_driver_api *)dev->api;
+
+	return api->size(dev);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_EEPROM_INTERNAL_EEPROM_IMPL_H_ */

--- a/include/zephyr/drivers/emul_fuel_gauge.h
+++ b/include/zephyr/drivers/emul_fuel_gauge.h
@@ -55,18 +55,6 @@ __subsystem struct fuel_gauge_emul_driver_api {
  * @retval -EINVAL if mV or mA are 0.
  */
 __syscall int emul_fuel_gauge_set_battery_charging(const struct emul *target, uint32_t uV, int uA);
-static inline int z_impl_emul_fuel_gauge_set_battery_charging(const struct emul *target,
-							      uint32_t uV, int uA)
-{
-	const struct fuel_gauge_emul_driver_api *backend_api =
-		(const struct fuel_gauge_emul_driver_api *)target->backend_api;
-
-	if (backend_api->set_battery_charging == 0) {
-		return -ENOTSUP;
-	}
-
-	return backend_api->set_battery_charging(target, uV, uA);
-}
 
 /**
  * @brief Check if the battery has been cut off.
@@ -78,21 +66,12 @@ static inline int z_impl_emul_fuel_gauge_set_battery_charging(const struct emul 
  * @retval -ENOTSUP if not supported by emulator.
  */
 __syscall int emul_fuel_gauge_is_battery_cutoff(const struct emul *target, bool *cutoff);
-static inline int z_impl_emul_fuel_gauge_is_battery_cutoff(const struct emul *target, bool *cutoff)
-{
-	const struct fuel_gauge_emul_driver_api *backend_api =
-		(const struct fuel_gauge_emul_driver_api *)target->backend_api;
-
-	if (backend_api->is_battery_cutoff == 0) {
-		return -ENOTSUP;
-	}
-	return backend_api->is_battery_cutoff(target, cutoff);
-}
 
 #ifdef __cplusplus
 }
 #endif
 
+#include <zephyr/drivers/fuel_gauge/internal/emul_fuel_gauge_impl.h>
 #include <zephyr/syscalls/emul_fuel_gauge.h>
 
 /**

--- a/include/zephyr/drivers/entropy.h
+++ b/include/zephyr/drivers/entropy.h
@@ -81,18 +81,6 @@ __syscall int entropy_get_entropy(const struct device *dev,
 				  uint8_t *buffer,
 				  uint16_t length);
 
-static inline int z_impl_entropy_get_entropy(const struct device *dev,
-					     uint8_t *buffer,
-					     uint16_t length)
-{
-	const struct entropy_driver_api *api =
-		(const struct entropy_driver_api *)dev->api;
-
-	__ASSERT(api->get_entropy != NULL,
-		"Callback pointer should not be NULL");
-	return api->get_entropy(dev, buffer, length);
-}
-
 /**
  * @brief Fills a buffer with entropy in a non-blocking or busy-wait manner.
  * 	  Callable from ISRs.
@@ -127,6 +115,7 @@ static inline int entropy_get_entropy_isr(const struct device *dev,
  * @}
  */
 
+#include <zephyr/drivers/entropy/internal/entropy_impl.h>
 #include <zephyr/syscalls/entropy.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_ENTROPY_H_ */

--- a/include/zephyr/drivers/entropy/internal/entropy_impl.h
+++ b/include/zephyr/drivers/entropy/internal/entropy_impl.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2016 ARM Ltd.
+ * Copyright (c) 2017 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Inline syscall implementation for entropy driver APIs.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_ENTROPY_H_
+#error "Should only be included by zephyr/drivers/entropy.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_ENTROPY_INTERNAL_ENTROPY_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_ENTROPY_INTERNAL_ENTROPY_IMPL_H_
+
+#include <errno.h>
+
+#include <zephyr/types.h>
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_entropy_get_entropy(const struct device *dev,
+					     uint8_t *buffer,
+					     uint16_t length)
+{
+	const struct entropy_driver_api *api =
+		(const struct entropy_driver_api *)dev->api;
+
+	__ASSERT(api->get_entropy != NULL,
+		"Callback pointer should not be NULL");
+	return api->get_entropy(dev, buffer, length);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_ENTROPY_INTERNAL_ENTROPY_IMPL_H_ */

--- a/include/zephyr/drivers/espi.h
+++ b/include/zephyr/drivers/espi.h
@@ -556,15 +556,6 @@ __subsystem struct espi_driver_api {
  */
 __syscall int espi_config(const struct device *dev, struct espi_cfg *cfg);
 
-static inline int z_impl_espi_config(const struct device *dev,
-				     struct espi_cfg *cfg)
-{
-	const struct espi_driver_api *api =
-		(const struct espi_driver_api *)dev->api;
-
-	return api->config(dev, cfg);
-}
-
 /**
  * @brief Query to see if it a channel is ready.
  *
@@ -579,15 +570,6 @@ static inline int z_impl_espi_config(const struct device *dev,
  */
 __syscall bool espi_get_channel_status(const struct device *dev,
 				       enum espi_channel ch);
-
-static inline bool z_impl_espi_get_channel_status(const struct device *dev,
-						  enum espi_channel ch)
-{
-	const struct espi_driver_api *api =
-		(const struct espi_driver_api *)dev->api;
-
-	return api->get_channel_status(dev, ch);
-}
 
 /**
  * @brief Sends memory, I/O or message read request over eSPI.
@@ -606,19 +588,6 @@ static inline bool z_impl_espi_get_channel_status(const struct device *dev,
 __syscall int espi_read_request(const struct device *dev,
 				struct espi_request_packet *req);
 
-static inline int z_impl_espi_read_request(const struct device *dev,
-					   struct espi_request_packet *req)
-{
-	const struct espi_driver_api *api =
-		(const struct espi_driver_api *)dev->api;
-
-	if (!api->read_request) {
-		return -ENOTSUP;
-	}
-
-	return api->read_request(dev, req);
-}
-
 /**
  * @brief Sends memory, I/O or message write request over eSPI.
  *
@@ -635,19 +604,6 @@ static inline int z_impl_espi_read_request(const struct device *dev,
  */
 __syscall int espi_write_request(const struct device *dev,
 				 struct espi_request_packet *req);
-
-static inline int z_impl_espi_write_request(const struct device *dev,
-					    struct espi_request_packet *req)
-{
-	const struct espi_driver_api *api =
-		(const struct espi_driver_api *)dev->api;
-
-	if (!api->write_request) {
-		return -ENOTSUP;
-	}
-
-	return api->write_request(dev, req);
-}
 
 /**
  * @brief Reads SOC data from a LPC peripheral with information
@@ -669,20 +625,6 @@ __syscall int espi_read_lpc_request(const struct device *dev,
 				    enum lpc_peripheral_opcode op,
 				    uint32_t *data);
 
-static inline int z_impl_espi_read_lpc_request(const struct device *dev,
-					       enum lpc_peripheral_opcode op,
-					       uint32_t *data)
-{
-	const struct espi_driver_api *api =
-		(const struct espi_driver_api *)dev->api;
-
-	if (!api->read_lpc_request) {
-		return -ENOTSUP;
-	}
-
-	return api->read_lpc_request(dev, op, data);
-}
-
 /**
  * @brief Writes data to a LPC peripheral which generates an eSPI transaction.
  *
@@ -702,20 +644,6 @@ __syscall int espi_write_lpc_request(const struct device *dev,
 				     enum lpc_peripheral_opcode op,
 				     uint32_t *data);
 
-static inline int z_impl_espi_write_lpc_request(const struct device *dev,
-						enum lpc_peripheral_opcode op,
-						uint32_t *data)
-{
-	const struct espi_driver_api *api =
-		(const struct espi_driver_api *)dev->api;
-
-	if (!api->write_lpc_request) {
-		return -ENOTSUP;
-	}
-
-	return api->write_lpc_request(dev, op, data);
-}
-
 /**
  * @brief Sends system/platform signal as a virtual wire packet.
  *
@@ -733,16 +661,6 @@ __syscall int espi_send_vwire(const struct device *dev,
 			      enum espi_vwire_signal signal,
 			      uint8_t level);
 
-static inline int z_impl_espi_send_vwire(const struct device *dev,
-					 enum espi_vwire_signal signal,
-					 uint8_t level)
-{
-	const struct espi_driver_api *api =
-		(const struct espi_driver_api *)dev->api;
-
-	return api->send_vwire(dev, signal, level);
-}
-
 /**
  * @brief Retrieves level status for a signal encapsulated in a virtual wire.
  *
@@ -759,16 +677,6 @@ __syscall int espi_receive_vwire(const struct device *dev,
 				 enum espi_vwire_signal signal,
 				 uint8_t *level);
 
-static inline int z_impl_espi_receive_vwire(const struct device *dev,
-					    enum espi_vwire_signal signal,
-					    uint8_t *level)
-{
-	const struct espi_driver_api *api =
-		(const struct espi_driver_api *)dev->api;
-
-	return api->receive_vwire(dev, signal, level);
-}
-
 /**
  * @brief Sends SMBus transaction (out-of-band) packet over eSPI bus.
  *
@@ -783,19 +691,6 @@ static inline int z_impl_espi_receive_vwire(const struct device *dev,
 __syscall int espi_send_oob(const struct device *dev,
 			    struct espi_oob_packet *pckt);
 
-static inline int z_impl_espi_send_oob(const struct device *dev,
-				       struct espi_oob_packet *pckt)
-{
-	const struct espi_driver_api *api =
-		(const struct espi_driver_api *)dev->api;
-
-	if (!api->send_oob) {
-		return -ENOTSUP;
-	}
-
-	return api->send_oob(dev, pckt);
-}
-
 /**
  * @brief Receives SMBus transaction (out-of-band) packet from eSPI bus.
  *
@@ -809,19 +704,6 @@ static inline int z_impl_espi_send_oob(const struct device *dev,
  */
 __syscall int espi_receive_oob(const struct device *dev,
 			       struct espi_oob_packet *pckt);
-
-static inline int z_impl_espi_receive_oob(const struct device *dev,
-					  struct espi_oob_packet *pckt)
-{
-	const struct espi_driver_api *api =
-		(const struct espi_driver_api *)dev->api;
-
-	if (!api->receive_oob) {
-		return -ENOTSUP;
-	}
-
-	return api->receive_oob(dev, pckt);
-}
 
 /**
  * @brief Sends a read request packet for shared flash.
@@ -839,19 +721,6 @@ static inline int z_impl_espi_receive_oob(const struct device *dev,
 __syscall int espi_read_flash(const struct device *dev,
 			      struct espi_flash_packet *pckt);
 
-static inline int z_impl_espi_read_flash(const struct device *dev,
-					 struct espi_flash_packet *pckt)
-{
-	const struct espi_driver_api *api =
-		(const struct espi_driver_api *)dev->api;
-
-	if (!api->flash_read) {
-		return -ENOTSUP;
-	}
-
-	return api->flash_read(dev, pckt);
-}
-
 /**
  * @brief Sends a write request packet for shared flash.
  *
@@ -868,19 +737,6 @@ static inline int z_impl_espi_read_flash(const struct device *dev,
 __syscall int espi_write_flash(const struct device *dev,
 			       struct espi_flash_packet *pckt);
 
-static inline int z_impl_espi_write_flash(const struct device *dev,
-					  struct espi_flash_packet *pckt)
-{
-	const struct espi_driver_api *api =
-		(const struct espi_driver_api *)dev->api;
-
-	if (!api->flash_write) {
-		return -ENOTSUP;
-	}
-
-	return api->flash_write(dev, pckt);
-}
-
 /**
  * @brief Sends a write request packet for shared flash.
  *
@@ -896,19 +752,6 @@ static inline int z_impl_espi_write_flash(const struct device *dev,
  */
 __syscall int espi_flash_erase(const struct device *dev,
 			       struct espi_flash_packet *pckt);
-
-static inline int z_impl_espi_flash_erase(const struct device *dev,
-					  struct espi_flash_packet *pckt)
-{
-	const struct espi_driver_api *api =
-		(const struct espi_driver_api *)dev->api;
-
-	if (!api->flash_erase) {
-		return -ENOTSUP;
-	}
-
-	return api->flash_erase(dev, pckt);
-}
 
 /**
  * Callback model
@@ -1051,5 +894,7 @@ static inline int espi_remove_callback(const struct device *dev,
 /**
  * @}
  */
+
+#include <zephyr/drivers/espi/internal/espi_impl.h>
 #include <zephyr/syscalls/espi.h>
 #endif /* ZEPHYR_INCLUDE_ESPI_H_ */

--- a/include/zephyr/drivers/espi/internal/espi_impl.h
+++ b/include/zephyr/drivers/espi/internal/espi_impl.h
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2019 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Inline syscall implementations for eSPI APIs
+ */
+
+#ifndef ZEPHYR_INCLUDE_ESPI_H_
+#error "Should only be included by zephyr/drivers/espi.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_ESPI_INTERNAL_ESPI_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_ESPI_INTERNAL_ESPI_IMPL_H_
+
+#include <errno.h>
+#include <stdint.h>
+
+#include <zephyr/types.h>
+#include <zephyr/device.h>
+#include <zephyr/sys/slist.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_espi_config(const struct device *dev,
+				     struct espi_cfg *cfg)
+{
+	const struct espi_driver_api *api =
+		(const struct espi_driver_api *)dev->api;
+
+	return api->config(dev, cfg);
+}
+
+static inline bool z_impl_espi_get_channel_status(const struct device *dev,
+						  enum espi_channel ch)
+{
+	const struct espi_driver_api *api =
+		(const struct espi_driver_api *)dev->api;
+
+	return api->get_channel_status(dev, ch);
+}
+
+static inline int z_impl_espi_read_request(const struct device *dev,
+					   struct espi_request_packet *req)
+{
+	const struct espi_driver_api *api =
+		(const struct espi_driver_api *)dev->api;
+
+	if (!api->read_request) {
+		return -ENOTSUP;
+	}
+
+	return api->read_request(dev, req);
+}
+
+static inline int z_impl_espi_write_request(const struct device *dev,
+					    struct espi_request_packet *req)
+{
+	const struct espi_driver_api *api =
+		(const struct espi_driver_api *)dev->api;
+
+	if (!api->write_request) {
+		return -ENOTSUP;
+	}
+
+	return api->write_request(dev, req);
+}
+
+static inline int z_impl_espi_read_lpc_request(const struct device *dev,
+					       enum lpc_peripheral_opcode op,
+					       uint32_t *data)
+{
+	const struct espi_driver_api *api =
+		(const struct espi_driver_api *)dev->api;
+
+	if (!api->read_lpc_request) {
+		return -ENOTSUP;
+	}
+
+	return api->read_lpc_request(dev, op, data);
+}
+
+static inline int z_impl_espi_write_lpc_request(const struct device *dev,
+						enum lpc_peripheral_opcode op,
+						uint32_t *data)
+{
+	const struct espi_driver_api *api =
+		(const struct espi_driver_api *)dev->api;
+
+	if (!api->write_lpc_request) {
+		return -ENOTSUP;
+	}
+
+	return api->write_lpc_request(dev, op, data);
+}
+
+static inline int z_impl_espi_send_vwire(const struct device *dev,
+					 enum espi_vwire_signal signal,
+					 uint8_t level)
+{
+	const struct espi_driver_api *api =
+		(const struct espi_driver_api *)dev->api;
+
+	return api->send_vwire(dev, signal, level);
+}
+
+static inline int z_impl_espi_receive_vwire(const struct device *dev,
+					    enum espi_vwire_signal signal,
+					    uint8_t *level)
+{
+	const struct espi_driver_api *api =
+		(const struct espi_driver_api *)dev->api;
+
+	return api->receive_vwire(dev, signal, level);
+}
+
+static inline int z_impl_espi_send_oob(const struct device *dev,
+				       struct espi_oob_packet *pckt)
+{
+	const struct espi_driver_api *api =
+		(const struct espi_driver_api *)dev->api;
+
+	if (!api->send_oob) {
+		return -ENOTSUP;
+	}
+
+	return api->send_oob(dev, pckt);
+}
+
+static inline int z_impl_espi_receive_oob(const struct device *dev,
+					  struct espi_oob_packet *pckt)
+{
+	const struct espi_driver_api *api =
+		(const struct espi_driver_api *)dev->api;
+
+	if (!api->receive_oob) {
+		return -ENOTSUP;
+	}
+
+	return api->receive_oob(dev, pckt);
+}
+
+static inline int z_impl_espi_read_flash(const struct device *dev,
+					 struct espi_flash_packet *pckt)
+{
+	const struct espi_driver_api *api =
+		(const struct espi_driver_api *)dev->api;
+
+	if (!api->flash_read) {
+		return -ENOTSUP;
+	}
+
+	return api->flash_read(dev, pckt);
+}
+
+static inline int z_impl_espi_write_flash(const struct device *dev,
+					  struct espi_flash_packet *pckt)
+{
+	const struct espi_driver_api *api =
+		(const struct espi_driver_api *)dev->api;
+
+	if (!api->flash_write) {
+		return -ENOTSUP;
+	}
+
+	return api->flash_write(dev, pckt);
+}
+
+static inline int z_impl_espi_flash_erase(const struct device *dev,
+					  struct espi_flash_packet *pckt)
+{
+	const struct espi_driver_api *api =
+		(const struct espi_driver_api *)dev->api;
+
+	if (!api->flash_erase) {
+		return -ENOTSUP;
+	}
+
+	return api->flash_erase(dev, pckt);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_ESPI_INTERNAL_ESPI_IMPL_H_ */

--- a/include/zephyr/drivers/espi/internal/espi_saf_impl.h
+++ b/include/zephyr/drivers/espi/internal/espi_saf_impl.h
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2019 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Inline syscall implementation for eSPI driver APIs
+ */
+
+#ifndef ZEPHYR_INCLUDE_ESPI_SAF_H_
+#error "Should only be included by zephyr/drivers/espi_saf.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_ESPI_INTERNAL_ESPI_SAF_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_ESPI_INTERNAL_ESPI_SAF_IMPL_H_
+
+#include <errno.h>
+
+#include <zephyr/types.h>
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_espi_saf_config(const struct device *dev,
+					 const struct espi_saf_cfg *cfg)
+{
+	const struct espi_saf_driver_api *api =
+		(const struct espi_saf_driver_api *)dev->api;
+
+	return api->config(dev, cfg);
+}
+
+static inline int z_impl_espi_saf_set_protection_regions(
+					const struct device *dev,
+					const struct espi_saf_protection *pr)
+{
+	const struct espi_saf_driver_api *api =
+		(const struct espi_saf_driver_api *)dev->api;
+
+	return api->set_protection_regions(dev, pr);
+}
+
+static inline int z_impl_espi_saf_activate(const struct device *dev)
+{
+	const struct espi_saf_driver_api *api =
+		(const struct espi_saf_driver_api *)dev->api;
+
+	return api->activate(dev);
+}
+
+static inline bool z_impl_espi_saf_get_channel_status(
+					const struct device *dev)
+{
+	const struct espi_saf_driver_api *api =
+		(const struct espi_saf_driver_api *)dev->api;
+
+	return api->get_channel_status(dev);
+}
+
+static inline int z_impl_espi_saf_flash_read(const struct device *dev,
+					     struct espi_saf_packet *pckt)
+{
+	const struct espi_saf_driver_api *api =
+		(const struct espi_saf_driver_api *)dev->api;
+
+	if (!api->flash_read) {
+		return -ENOTSUP;
+	}
+
+	return api->flash_read(dev, pckt);
+}
+
+static inline int z_impl_espi_saf_flash_write(const struct device *dev,
+					      struct espi_saf_packet *pckt)
+{
+	const struct espi_saf_driver_api *api =
+		(const struct espi_saf_driver_api *)dev->api;
+
+	if (!api->flash_write) {
+		return -ENOTSUP;
+	}
+
+	return api->flash_write(dev, pckt);
+}
+
+static inline int z_impl_espi_saf_flash_erase(const struct device *dev,
+					      struct espi_saf_packet *pckt)
+{
+	const struct espi_saf_driver_api *api =
+		(const struct espi_saf_driver_api *)dev->api;
+
+	if (!api->flash_erase) {
+		return -ENOTSUP;
+	}
+
+	return api->flash_erase(dev, pckt);
+}
+
+static inline int z_impl_espi_saf_flash_unsuccess(const struct device *dev,
+						  struct espi_saf_packet *pckt)
+{
+	const struct espi_saf_driver_api *api =
+		(const struct espi_saf_driver_api *)dev->api;
+
+	if (!api->flash_unsuccess) {
+		return -ENOTSUP;
+	}
+
+	return api->flash_unsuccess(dev, pckt);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_ESPI_INTERNAL_ESPI_SAF_IMPL_H_ */

--- a/include/zephyr/drivers/espi_saf.h
+++ b/include/zephyr/drivers/espi_saf.h
@@ -219,15 +219,6 @@ __subsystem struct espi_saf_driver_api {
 __syscall int espi_saf_config(const struct device *dev,
 			      const struct espi_saf_cfg *cfg);
 
-static inline int z_impl_espi_saf_config(const struct device *dev,
-					 const struct espi_saf_cfg *cfg)
-{
-	const struct espi_saf_driver_api *api =
-		(const struct espi_saf_driver_api *)dev->api;
-
-	return api->config(dev, cfg);
-}
-
 /**
  * @brief Set one or more SAF protection regions
  *
@@ -246,16 +237,6 @@ __syscall int espi_saf_set_protection_regions(
 				const struct device *dev,
 				const struct espi_saf_protection *pr);
 
-static inline int z_impl_espi_saf_set_protection_regions(
-					const struct device *dev,
-					const struct espi_saf_protection *pr)
-{
-	const struct espi_saf_driver_api *api =
-		(const struct espi_saf_driver_api *)dev->api;
-
-	return api->set_protection_regions(dev, pr);
-}
-
 /**
  * @brief Activate SAF block
  *
@@ -270,14 +251,6 @@ static inline int z_impl_espi_saf_set_protection_regions(
  */
 __syscall int espi_saf_activate(const struct device *dev);
 
-static inline int z_impl_espi_saf_activate(const struct device *dev)
-{
-	const struct espi_saf_driver_api *api =
-		(const struct espi_saf_driver_api *)dev->api;
-
-	return api->activate(dev);
-}
-
 /**
  * @brief Query to see if SAF is ready
  *
@@ -289,15 +262,6 @@ static inline int z_impl_espi_saf_activate(const struct device *dev)
  * @retval false otherwise.
  */
 __syscall bool espi_saf_get_channel_status(const struct device *dev);
-
-static inline bool z_impl_espi_saf_get_channel_status(
-					const struct device *dev)
-{
-	const struct espi_saf_driver_api *api =
-		(const struct espi_saf_driver_api *)dev->api;
-
-	return api->get_channel_status(dev);
-}
 
 /**
  * @brief Sends a read request packet for slave attached flash.
@@ -315,19 +279,6 @@ static inline bool z_impl_espi_saf_get_channel_status(
 __syscall int espi_saf_flash_read(const struct device *dev,
 				  struct espi_saf_packet *pckt);
 
-static inline int z_impl_espi_saf_flash_read(const struct device *dev,
-					     struct espi_saf_packet *pckt)
-{
-	const struct espi_saf_driver_api *api =
-		(const struct espi_saf_driver_api *)dev->api;
-
-	if (!api->flash_read) {
-		return -ENOTSUP;
-	}
-
-	return api->flash_read(dev, pckt);
-}
-
 /**
  * @brief Sends a write request packet for slave attached flash.
  *
@@ -343,19 +294,6 @@ static inline int z_impl_espi_saf_flash_read(const struct device *dev,
  */
 __syscall int espi_saf_flash_write(const struct device *dev,
 				   struct espi_saf_packet *pckt);
-
-static inline int z_impl_espi_saf_flash_write(const struct device *dev,
-					      struct espi_saf_packet *pckt)
-{
-	const struct espi_saf_driver_api *api =
-		(const struct espi_saf_driver_api *)dev->api;
-
-	if (!api->flash_write) {
-		return -ENOTSUP;
-	}
-
-	return api->flash_write(dev, pckt);
-}
 
 /**
  * @brief Sends a write request packet for slave attached flash.
@@ -373,19 +311,6 @@ static inline int z_impl_espi_saf_flash_write(const struct device *dev,
 __syscall int espi_saf_flash_erase(const struct device *dev,
 				   struct espi_saf_packet *pckt);
 
-static inline int z_impl_espi_saf_flash_erase(const struct device *dev,
-					      struct espi_saf_packet *pckt)
-{
-	const struct espi_saf_driver_api *api =
-		(const struct espi_saf_driver_api *)dev->api;
-
-	if (!api->flash_erase) {
-		return -ENOTSUP;
-	}
-
-	return api->flash_erase(dev, pckt);
-}
-
 /**
  * @brief Response unsuccessful completion for slave attached flash.
  *
@@ -401,19 +326,6 @@ static inline int z_impl_espi_saf_flash_erase(const struct device *dev,
  */
 __syscall int espi_saf_flash_unsuccess(const struct device *dev,
 				       struct espi_saf_packet *pckt);
-
-static inline int z_impl_espi_saf_flash_unsuccess(const struct device *dev,
-						  struct espi_saf_packet *pckt)
-{
-	const struct espi_saf_driver_api *api =
-		(const struct espi_saf_driver_api *)dev->api;
-
-	if (!api->flash_unsuccess) {
-		return -ENOTSUP;
-	}
-
-	return api->flash_unsuccess(dev, pckt);
-}
 
 /**
  * Callback model
@@ -557,5 +469,7 @@ static inline int espi_saf_remove_callback(const struct device *dev,
 /**
  * @}
  */
+
+#include <zephyr/drivers/espi/internal/espi_saf_impl.h>
 #include <zephyr/syscalls/espi_saf.h>
 #endif /* ZEPHYR_INCLUDE_ESPI_SAF_H_ */

--- a/include/zephyr/drivers/flash/internal/flash_impl.h
+++ b/include/zephyr/drivers/flash/internal/flash_impl.h
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2017-2024 Nordic Semiconductor ASA
+ * Copyright (c) 2016 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Inline syscall implementations for FLASH driver APIs.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_FLASH_H_
+#error "Should only be included by zephyr/drivers/flash.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_FLASH_INTERNAL_FLASH_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_FLASH_INTERNAL_FLASH_IMPL_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_flash_read(const struct device *dev, off_t offset,
+				    void *data,
+				    size_t len)
+{
+	const struct flash_driver_api *api =
+		(const struct flash_driver_api *)dev->api;
+
+	return api->read(dev, offset, data, len);
+}
+
+static inline int z_impl_flash_write(const struct device *dev, off_t offset,
+				     const void *data, size_t len)
+{
+	const struct flash_driver_api *api =
+		(const struct flash_driver_api *)dev->api;
+	int rc;
+
+	rc = api->write(dev, offset, data, len);
+
+	return rc;
+}
+
+static inline int z_impl_flash_erase(const struct device *dev, off_t offset,
+				     size_t size)
+{
+	int rc = -ENOSYS;
+
+	const struct flash_driver_api *api =
+		(const struct flash_driver_api *)dev->api;
+
+	if (api->erase != NULL) {
+		rc = api->erase(dev, offset, size);
+	}
+
+	return rc;
+}
+
+#if defined(CONFIG_FLASH_JESD216_API)
+static inline int z_impl_flash_sfdp_read(const struct device *dev,
+					 off_t offset,
+					 void *data, size_t len)
+{
+	int rv = -ENOTSUP;
+	const struct flash_driver_api *api =
+		(const struct flash_driver_api *)dev->api;
+
+	if (api->sfdp_read != NULL) {
+		rv = api->sfdp_read(dev, offset, data, len);
+	}
+	return rv;
+}
+
+static inline int z_impl_flash_read_jedec_id(const struct device *dev,
+					     uint8_t *id)
+{
+	int rv = -ENOTSUP;
+	const struct flash_driver_api *api =
+		(const struct flash_driver_api *)dev->api;
+
+	if (api->read_jedec_id != NULL) {
+		rv = api->read_jedec_id(dev, id);
+	}
+	return rv;
+}
+#endif /* CONFIG_FLASH_JESD216_API */
+
+static inline size_t z_impl_flash_get_write_block_size(const struct device *dev)
+{
+	const struct flash_driver_api *api =
+		(const struct flash_driver_api *)dev->api;
+
+	return api->get_parameters(dev)->write_block_size;
+}
+
+static inline const struct flash_parameters *z_impl_flash_get_parameters(const struct device *dev)
+{
+	const struct flash_driver_api *api =
+		(const struct flash_driver_api *)dev->api;
+
+	return api->get_parameters(dev);
+}
+
+static inline int z_impl_flash_ex_op(const struct device *dev, uint16_t code,
+				     const uintptr_t in, void *out)
+{
+#if defined(CONFIG_FLASH_EX_OP_ENABLED)
+	const struct flash_driver_api *api =
+		(const struct flash_driver_api *)dev->api;
+
+	if (api->ex_op == NULL) {
+		return -ENOTSUP;
+	}
+
+	return api->ex_op(dev, code, in, out);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(code);
+	ARG_UNUSED(in);
+	ARG_UNUSED(out);
+
+	return -ENOSYS;
+#endif /* CONFIG_FLASH_EX_OP_ENABLED */
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_FLASH_INTERNAL_FLASH_IMPL_H_ */

--- a/include/zephyr/drivers/fuel_gauge.h
+++ b/include/zephyr/drivers/fuel_gauge.h
@@ -261,18 +261,6 @@ __subsystem struct fuel_gauge_driver_api {
 __syscall int fuel_gauge_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 				  union fuel_gauge_prop_val *val);
 
-static inline int z_impl_fuel_gauge_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
-					     union fuel_gauge_prop_val *val)
-{
-	const struct fuel_gauge_driver_api *api = (const struct fuel_gauge_driver_api *)dev->api;
-
-	if (api->get_property == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->get_property(dev, prop, val);
-}
-
 /**
  * @brief Fetch multiple battery fuel-gauge properties. The default implementation is the same as
  * calling fuel_gauge_get_prop() multiple times. A driver may implement the `get_properties` field
@@ -290,22 +278,6 @@ static inline int z_impl_fuel_gauge_get_prop(const struct device *dev, fuel_gaug
 
 __syscall int fuel_gauge_get_props(const struct device *dev, fuel_gauge_prop_t *props,
 				   union fuel_gauge_prop_val *vals, size_t len);
-static inline int z_impl_fuel_gauge_get_props(const struct device *dev,
-					      fuel_gauge_prop_t *props,
-					      union fuel_gauge_prop_val *vals, size_t len)
-{
-	const struct fuel_gauge_driver_api *api = dev->api;
-
-	for (int i = 0; i < len; i++) {
-		int ret = api->get_property(dev, props[i], vals + i);
-
-		if (ret) {
-			return ret;
-		}
-	}
-
-	return 0;
-}
 
 /**
  * @brief Set a battery fuel-gauge property
@@ -319,17 +291,6 @@ static inline int z_impl_fuel_gauge_get_props(const struct device *dev,
 __syscall int fuel_gauge_set_prop(const struct device *dev, fuel_gauge_prop_t prop,
 				  union fuel_gauge_prop_val val);
 
-static inline int z_impl_fuel_gauge_set_prop(const struct device *dev, fuel_gauge_prop_t prop,
-					     union fuel_gauge_prop_val val)
-{
-	const struct fuel_gauge_driver_api *api = dev->api;
-
-	if (api->set_property == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->set_property(dev, prop, val);
-}
 /**
  * @brief Set a battery fuel-gauge property
  *
@@ -345,21 +306,6 @@ static inline int z_impl_fuel_gauge_set_prop(const struct device *dev, fuel_gaug
 __syscall int fuel_gauge_set_props(const struct device *dev, fuel_gauge_prop_t *props,
 				   union fuel_gauge_prop_val *vals, size_t len);
 
-static inline int z_impl_fuel_gauge_set_props(const struct device *dev,
-					      fuel_gauge_prop_t *props,
-					      union fuel_gauge_prop_val *vals, size_t len)
-{
-	for (int i = 0; i < len; i++) {
-		int ret = fuel_gauge_set_prop(dev, props[i], vals[i]);
-
-		if (ret) {
-			return ret;
-		}
-	}
-
-	return 0;
-}
-
 /**
  * @brief Fetch a battery fuel-gauge buffer property
  *
@@ -374,19 +320,6 @@ static inline int z_impl_fuel_gauge_set_props(const struct device *dev,
 __syscall int fuel_gauge_get_buffer_prop(const struct device *dev, fuel_gauge_prop_t prop_type,
 					 void *dst, size_t dst_len);
 
-static inline int z_impl_fuel_gauge_get_buffer_prop(const struct device *dev,
-						   fuel_gauge_prop_t prop_type,
-						   void *dst, size_t dst_len)
-{
-	const struct fuel_gauge_driver_api *api = (const struct fuel_gauge_driver_api *)dev->api;
-
-	if (api->get_buffer_property == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->get_buffer_property(dev, prop_type, dst, dst_len);
-}
-
 /**
  * @brief Have fuel gauge cutoff its associated battery.
  *
@@ -397,17 +330,6 @@ static inline int z_impl_fuel_gauge_get_buffer_prop(const struct device *dev,
  */
 __syscall int fuel_gauge_battery_cutoff(const struct device *dev);
 
-static inline int z_impl_fuel_gauge_battery_cutoff(const struct device *dev)
-{
-	const struct fuel_gauge_driver_api *api = (const struct fuel_gauge_driver_api *)dev->api;
-
-	if (api->battery_cutoff == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->battery_cutoff(dev);
-}
-
 /**
  * @}
  */
@@ -416,6 +338,7 @@ static inline int z_impl_fuel_gauge_battery_cutoff(const struct device *dev)
 }
 #endif /* __cplusplus */
 
+#include <zephyr/drivers/fuel_gauge/internal/fuel_gauge_impl.h>
 #include <zephyr/syscalls/fuel_gauge.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_BATTERY_H_ */

--- a/include/zephyr/drivers/fuel_gauge/internal/emul_fuel_gauge_impl.h
+++ b/include/zephyr/drivers/fuel_gauge/internal/emul_fuel_gauge_impl.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2023 Google LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Inline syscall implementation for fuel gauge emulators APIs.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_EMUL_FUEL_GAUGE_H_
+#error "Should only be included by zephyr/drivers/emul_fuel_gauge.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_FUEL_GAUGE_INTERNAL_EMUL_FUEL_GAUGE_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_FUEL_GAUGE_INTERNAL_EMUL_FUEL_GAUGE_IMPL_H_
+
+#include <errno.h>
+#include <stdint.h>
+#include <zephyr/drivers/emul.h>
+#include <zephyr/drivers/fuel_gauge.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_emul_fuel_gauge_set_battery_charging(const struct emul *target,
+							      uint32_t uV, int uA)
+{
+	const struct fuel_gauge_emul_driver_api *backend_api =
+		(const struct fuel_gauge_emul_driver_api *)target->backend_api;
+
+	if (backend_api->set_battery_charging == 0) {
+		return -ENOTSUP;
+	}
+
+	return backend_api->set_battery_charging(target, uV, uA);
+}
+
+static inline int z_impl_emul_fuel_gauge_is_battery_cutoff(const struct emul *target, bool *cutoff)
+{
+	const struct fuel_gauge_emul_driver_api *backend_api =
+		(const struct fuel_gauge_emul_driver_api *)target->backend_api;
+
+	if (backend_api->is_battery_cutoff == 0) {
+		return -ENOTSUP;
+	}
+	return backend_api->is_battery_cutoff(target, cutoff);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_FUEL_GAUGE_INTERNAL_EMUL_FUEL_GAUGE_IMPL_H_*/

--- a/include/zephyr/drivers/fuel_gauge/internal/fuel_gauge_impl.h
+++ b/include/zephyr/drivers/fuel_gauge/internal/fuel_gauge_impl.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2022 Google LLC
+ * Copyright 2023 Microsoft Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_BATTERY_H_
+#error "Should only be included by zephyr/drivers/fuel_gauge.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_FUEL_GAUGE_INTERNAL_FUEL_GAUGE_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_FUEL_GAUGE_INTERNAL_FUEL_GAUGE_IMPL_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <zephyr/device.h>
+
+static inline int z_impl_fuel_gauge_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
+					     union fuel_gauge_prop_val *val)
+{
+	const struct fuel_gauge_driver_api *api = (const struct fuel_gauge_driver_api *)dev->api;
+
+	if (api->get_property == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->get_property(dev, prop, val);
+}
+
+static inline int z_impl_fuel_gauge_get_props(const struct device *dev,
+					      fuel_gauge_prop_t *props,
+					      union fuel_gauge_prop_val *vals, size_t len)
+{
+	const struct fuel_gauge_driver_api *api = dev->api;
+
+	for (int i = 0; i < len; i++) {
+		int ret = api->get_property(dev, props[i], vals + i);
+
+		if (ret) {
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+static inline int z_impl_fuel_gauge_set_prop(const struct device *dev, fuel_gauge_prop_t prop,
+					     union fuel_gauge_prop_val val)
+{
+	const struct fuel_gauge_driver_api *api = dev->api;
+
+	if (api->set_property == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->set_property(dev, prop, val);
+}
+
+static inline int z_impl_fuel_gauge_set_props(const struct device *dev,
+					      fuel_gauge_prop_t *props,
+					      union fuel_gauge_prop_val *vals, size_t len)
+{
+	for (int i = 0; i < len; i++) {
+		int ret = fuel_gauge_set_prop(dev, props[i], vals[i]);
+
+		if (ret) {
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+static inline int z_impl_fuel_gauge_get_buffer_prop(const struct device *dev,
+						   fuel_gauge_prop_t prop_type,
+						   void *dst, size_t dst_len)
+{
+	const struct fuel_gauge_driver_api *api = (const struct fuel_gauge_driver_api *)dev->api;
+
+	if (api->get_buffer_property == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->get_buffer_property(dev, prop_type, dst, dst_len);
+}
+
+static inline int z_impl_fuel_gauge_battery_cutoff(const struct device *dev)
+{
+	const struct fuel_gauge_driver_api *api = (const struct fuel_gauge_driver_api *)dev->api;
+
+	if (api->battery_cutoff == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->battery_cutoff(dev);
+}
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_FUEL_GAUGE_INTERNAL_FUEL_GAUGE_IMPL_H_ */

--- a/include/zephyr/drivers/gnss.h
+++ b/include/zephyr/drivers/gnss.h
@@ -253,17 +253,6 @@ struct gnss_satellites_callback {
  */
 __syscall int gnss_set_fix_rate(const struct device *dev, uint32_t fix_interval_ms);
 
-static inline int z_impl_gnss_set_fix_rate(const struct device *dev, uint32_t fix_interval_ms)
-{
-	const struct gnss_driver_api *api = (const struct gnss_driver_api *)dev->api;
-
-	if (api->set_fix_rate == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->set_fix_rate(dev, fix_interval_ms);
-}
-
 /**
  * @brief Get the GNSS fix rate
  *
@@ -274,17 +263,6 @@ static inline int z_impl_gnss_set_fix_rate(const struct device *dev, uint32_t fi
  * @return -errno negative errno code on failure
  */
 __syscall int gnss_get_fix_rate(const struct device *dev, uint32_t *fix_interval_ms);
-
-static inline int z_impl_gnss_get_fix_rate(const struct device *dev, uint32_t *fix_interval_ms)
-{
-	const struct gnss_driver_api *api = (const struct gnss_driver_api *)dev->api;
-
-	if (api->get_fix_rate == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->get_fix_rate(dev, fix_interval_ms);
-}
 
 /**
  * @brief Set the GNSS periodic tracking configuration
@@ -298,18 +276,6 @@ static inline int z_impl_gnss_get_fix_rate(const struct device *dev, uint32_t *f
 __syscall int gnss_set_periodic_config(const struct device *dev,
 				       const struct gnss_periodic_config *config);
 
-static inline int z_impl_gnss_set_periodic_config(const struct device *dev,
-						  const struct gnss_periodic_config *config)
-{
-	const struct gnss_driver_api *api = (const struct gnss_driver_api *)dev->api;
-
-	if (api->set_periodic_config == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->set_periodic_config(dev, config);
-}
-
 /**
  * @brief Get the GNSS periodic tracking configuration
  *
@@ -321,18 +287,6 @@ static inline int z_impl_gnss_set_periodic_config(const struct device *dev,
  */
 __syscall int gnss_get_periodic_config(const struct device *dev,
 				       struct gnss_periodic_config *config);
-
-static inline int z_impl_gnss_get_periodic_config(const struct device *dev,
-						  struct gnss_periodic_config *config)
-{
-	const struct gnss_driver_api *api = (const struct gnss_driver_api *)dev->api;
-
-	if (api->get_periodic_config == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->get_periodic_config(dev, config);
-}
 
 /**
  * @brief Set the GNSS navigation mode
@@ -346,18 +300,6 @@ static inline int z_impl_gnss_get_periodic_config(const struct device *dev,
 __syscall int gnss_set_navigation_mode(const struct device *dev,
 				       enum gnss_navigation_mode mode);
 
-static inline int z_impl_gnss_set_navigation_mode(const struct device *dev,
-						  enum gnss_navigation_mode mode)
-{
-	const struct gnss_driver_api *api = (const struct gnss_driver_api *)dev->api;
-
-	if (api->set_navigation_mode == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->set_navigation_mode(dev, mode);
-}
-
 /**
  * @brief Get the GNSS navigation mode
  *
@@ -370,18 +312,6 @@ static inline int z_impl_gnss_set_navigation_mode(const struct device *dev,
 __syscall int gnss_get_navigation_mode(const struct device *dev,
 				       enum gnss_navigation_mode *mode);
 
-static inline int z_impl_gnss_get_navigation_mode(const struct device *dev,
-						  enum gnss_navigation_mode *mode)
-{
-	const struct gnss_driver_api *api = (const struct gnss_driver_api *)dev->api;
-
-	if (api->get_navigation_mode == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->get_navigation_mode(dev, mode);
-}
-
 /**
  * @brief Set enabled GNSS systems
  *
@@ -392,18 +322,6 @@ static inline int z_impl_gnss_get_navigation_mode(const struct device *dev,
  * @return -errno negative errno code on failure
  */
 __syscall int gnss_set_enabled_systems(const struct device *dev, gnss_systems_t systems);
-
-static inline int z_impl_gnss_set_enabled_systems(const struct device *dev,
-						  gnss_systems_t systems)
-{
-	const struct gnss_driver_api *api = (const struct gnss_driver_api *)dev->api;
-
-	if (api->set_enabled_systems == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->set_enabled_systems(dev, systems);
-}
 
 /**
  * @brief Get enabled GNSS systems
@@ -416,18 +334,6 @@ static inline int z_impl_gnss_set_enabled_systems(const struct device *dev,
  */
 __syscall int gnss_get_enabled_systems(const struct device *dev, gnss_systems_t *systems);
 
-static inline int z_impl_gnss_get_enabled_systems(const struct device *dev,
-						  gnss_systems_t *systems)
-{
-	const struct gnss_driver_api *api = (const struct gnss_driver_api *)dev->api;
-
-	if (api->get_enabled_systems == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->get_enabled_systems(dev, systems);
-}
-
 /**
  * @brief Get supported GNSS systems
  *
@@ -438,18 +344,6 @@ static inline int z_impl_gnss_get_enabled_systems(const struct device *dev,
  * @return -errno negative errno code on failure
  */
 __syscall int gnss_get_supported_systems(const struct device *dev, gnss_systems_t *systems);
-
-static inline int z_impl_gnss_get_supported_systems(const struct device *dev,
-						    gnss_systems_t *systems)
-{
-	const struct gnss_driver_api *api = (const struct gnss_driver_api *)dev->api;
-
-	if (api->get_supported_systems == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->get_supported_systems(dev, systems);
-}
 
 /**
  * @brief Register a callback structure for GNSS data published
@@ -493,6 +387,7 @@ static inline int z_impl_gnss_get_supported_systems(const struct device *dev,
 }
 #endif
 
+#include <zephyr/drivers/gnss/internal/gnss_impl.h>
 #include <zephyr/syscalls/gnss.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_GNSS_H_ */

--- a/include/zephyr/drivers/gnss/internal/gnss_impl.h
+++ b/include/zephyr/drivers/gnss/internal/gnss_impl.h
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2023 Trackunit Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file gnss.h
+ *
+ * @brief Inline syscall implementations for GNSS APIs.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_GNSS_H_
+#error "Should only be included by zephyr/drivers/gnss.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_GNSS_INTERNAL_GNSS_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_GNSS_INTERNAL_GNSS_IMPL_H_
+
+#include <errno.h>
+#include <stdint.h>
+
+#include <zephyr/types.h>
+#include <zephyr/device.h>
+#include <zephyr/data/navigation.h>
+#include <errno.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_gnss_set_fix_rate(const struct device *dev, uint32_t fix_interval_ms)
+{
+	const struct gnss_driver_api *api = (const struct gnss_driver_api *)dev->api;
+
+	if (api->set_fix_rate == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->set_fix_rate(dev, fix_interval_ms);
+}
+
+static inline int z_impl_gnss_get_fix_rate(const struct device *dev, uint32_t *fix_interval_ms)
+{
+	const struct gnss_driver_api *api = (const struct gnss_driver_api *)dev->api;
+
+	if (api->get_fix_rate == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->get_fix_rate(dev, fix_interval_ms);
+}
+
+static inline int z_impl_gnss_set_periodic_config(const struct device *dev,
+						  const struct gnss_periodic_config *config)
+{
+	const struct gnss_driver_api *api = (const struct gnss_driver_api *)dev->api;
+
+	if (api->set_periodic_config == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->set_periodic_config(dev, config);
+}
+
+static inline int z_impl_gnss_get_periodic_config(const struct device *dev,
+						  struct gnss_periodic_config *config)
+{
+	const struct gnss_driver_api *api = (const struct gnss_driver_api *)dev->api;
+
+	if (api->get_periodic_config == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->get_periodic_config(dev, config);
+}
+
+static inline int z_impl_gnss_set_navigation_mode(const struct device *dev,
+						  enum gnss_navigation_mode mode)
+{
+	const struct gnss_driver_api *api = (const struct gnss_driver_api *)dev->api;
+
+	if (api->set_navigation_mode == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->set_navigation_mode(dev, mode);
+}
+
+static inline int z_impl_gnss_get_navigation_mode(const struct device *dev,
+						  enum gnss_navigation_mode *mode)
+{
+	const struct gnss_driver_api *api = (const struct gnss_driver_api *)dev->api;
+
+	if (api->get_navigation_mode == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->get_navigation_mode(dev, mode);
+}
+
+static inline int z_impl_gnss_set_enabled_systems(const struct device *dev,
+						  gnss_systems_t systems)
+{
+	const struct gnss_driver_api *api = (const struct gnss_driver_api *)dev->api;
+
+	if (api->set_enabled_systems == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->set_enabled_systems(dev, systems);
+}
+
+static inline int z_impl_gnss_get_enabled_systems(const struct device *dev,
+						  gnss_systems_t *systems)
+{
+	const struct gnss_driver_api *api = (const struct gnss_driver_api *)dev->api;
+
+	if (api->get_enabled_systems == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->get_enabled_systems(dev, systems);
+}
+
+static inline int z_impl_gnss_get_supported_systems(const struct device *dev,
+						    gnss_systems_t *systems)
+{
+	const struct gnss_driver_api *api = (const struct gnss_driver_api *)dev->api;
+
+	if (api->get_supported_systems == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->get_supported_systems(dev, systems);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_GNSS_INTERNAL_GNSS_IMPL_H_ */

--- a/include/zephyr/drivers/gpio/internal/gpio_impl.h
+++ b/include/zephyr/drivers/gpio/internal/gpio_impl.h
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2019-2020 Nordic Semiconductor ASA
+ * Copyright (c) 2019 Piotr Mienkowski
+ * Copyright (c) 2017 ARM Ltd
+ * Copyright (c) 2015-2016 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Inline syscall implementation for GPIO APIs
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_GPIO_H_
+#error "Should only be included by zephyr/drivers/gpio.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_GPIO_INTERNAL_GPIO_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_GPIO_INTERNAL_GPIO_IMPL_H_
+
+#include <errno.h>
+
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/slist.h>
+
+#include <zephyr/types.h>
+#include <stddef.h>
+#include <zephyr/device.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_gpio_pin_interrupt_configure(const struct device *port,
+						      gpio_pin_t pin,
+						      gpio_flags_t flags)
+{
+	const struct gpio_driver_api *api =
+		(const struct gpio_driver_api *)port->api;
+	__unused const struct gpio_driver_config *const cfg =
+		(const struct gpio_driver_config *)port->config;
+	const struct gpio_driver_data *const data =
+		(const struct gpio_driver_data *)port->data;
+	enum gpio_int_trig trig;
+	enum gpio_int_mode mode;
+
+	if (api->pin_interrupt_configure == NULL) {
+		return -ENOSYS;
+	}
+
+	__ASSERT((flags & (GPIO_INT_DISABLE | GPIO_INT_ENABLE))
+		 != (GPIO_INT_DISABLE | GPIO_INT_ENABLE),
+		 "Cannot both enable and disable interrupts");
+
+	__ASSERT((flags & (GPIO_INT_DISABLE | GPIO_INT_ENABLE)) != 0U,
+		 "Must either enable or disable interrupts");
+
+	__ASSERT(((flags & GPIO_INT_ENABLE) == 0) ||
+		 ((flags & GPIO_INT_EDGE) != 0) ||
+		 ((flags & (GPIO_INT_LOW_0 | GPIO_INT_HIGH_1)) !=
+		  (GPIO_INT_LOW_0 | GPIO_INT_HIGH_1)),
+		 "Only one of GPIO_INT_LOW_0, GPIO_INT_HIGH_1 can be "
+		 "enabled for a level interrupt.");
+
+	__ASSERT(((flags & GPIO_INT_ENABLE) == 0) ||
+#ifdef CONFIG_GPIO_ENABLE_DISABLE_INTERRUPT
+			 ((flags & (GPIO_INT_LOW_0 | GPIO_INT_HIGH_1)) != 0) ||
+			 (flags & GPIO_INT_ENABLE_DISABLE_ONLY) != 0,
+#else
+			 ((flags & (GPIO_INT_LOW_0 | GPIO_INT_HIGH_1)) != 0),
+#endif /* CONFIG_GPIO_ENABLE_DISABLE_INTERRUPT */
+		 "At least one of GPIO_INT_LOW_0, GPIO_INT_HIGH_1 has to be "
+		 "enabled.");
+
+	__ASSERT((cfg->port_pin_mask & (gpio_port_pins_t)BIT(pin)) != 0U,
+		 "Unsupported pin");
+
+	if (((flags & GPIO_INT_LEVELS_LOGICAL) != 0) &&
+	    ((data->invert & (gpio_port_pins_t)BIT(pin)) != 0)) {
+		/* Invert signal bits */
+		flags ^= (GPIO_INT_LOW_0 | GPIO_INT_HIGH_1);
+	}
+
+	trig = (enum gpio_int_trig)(flags & (GPIO_INT_LOW_0 | GPIO_INT_HIGH_1 | GPIO_INT_WAKEUP));
+#ifdef CONFIG_GPIO_ENABLE_DISABLE_INTERRUPT
+	mode = (enum gpio_int_mode)(flags & (GPIO_INT_EDGE | GPIO_INT_DISABLE | GPIO_INT_ENABLE |
+					     GPIO_INT_ENABLE_DISABLE_ONLY));
+#else
+	mode = (enum gpio_int_mode)(flags & (GPIO_INT_EDGE | GPIO_INT_DISABLE | GPIO_INT_ENABLE));
+#endif /* CONFIG_GPIO_ENABLE_DISABLE_INTERRUPT */
+
+	return api->pin_interrupt_configure(port, pin, mode, trig);
+}
+
+static inline int z_impl_gpio_pin_configure(const struct device *port,
+					    gpio_pin_t pin,
+					    gpio_flags_t flags)
+{
+	const struct gpio_driver_api *api =
+		(const struct gpio_driver_api *)port->api;
+	__unused const struct gpio_driver_config *const cfg =
+		(const struct gpio_driver_config *)port->config;
+	struct gpio_driver_data *data =
+		(struct gpio_driver_data *)port->data;
+
+	__ASSERT((flags & GPIO_INT_MASK) == 0,
+		 "Interrupt flags are not supported");
+
+	__ASSERT((flags & (GPIO_PULL_UP | GPIO_PULL_DOWN)) !=
+		 (GPIO_PULL_UP | GPIO_PULL_DOWN),
+		 "Pull Up and Pull Down should not be enabled simultaneously");
+
+	__ASSERT(!((flags & GPIO_INPUT) && !(flags & GPIO_OUTPUT) && (flags & GPIO_SINGLE_ENDED)),
+		 "Input cannot be enabled for 'Open Drain', 'Open Source' modes without Output");
+
+	__ASSERT_NO_MSG((flags & GPIO_SINGLE_ENDED) != 0 ||
+			(flags & GPIO_LINE_OPEN_DRAIN) == 0);
+
+	__ASSERT((flags & (GPIO_OUTPUT_INIT_LOW | GPIO_OUTPUT_INIT_HIGH)) == 0
+		 || (flags & GPIO_OUTPUT) != 0,
+		 "Output needs to be enabled to be initialized low or high");
+
+	__ASSERT((flags & (GPIO_OUTPUT_INIT_LOW | GPIO_OUTPUT_INIT_HIGH))
+		 != (GPIO_OUTPUT_INIT_LOW | GPIO_OUTPUT_INIT_HIGH),
+		 "Output cannot be initialized low and high");
+
+	if (((flags & GPIO_OUTPUT_INIT_LOGICAL) != 0)
+	    && ((flags & (GPIO_OUTPUT_INIT_LOW | GPIO_OUTPUT_INIT_HIGH)) != 0)
+	    && ((flags & GPIO_ACTIVE_LOW) != 0)) {
+		flags ^= GPIO_OUTPUT_INIT_LOW | GPIO_OUTPUT_INIT_HIGH;
+	}
+
+	flags &= ~GPIO_OUTPUT_INIT_LOGICAL;
+
+	__ASSERT((cfg->port_pin_mask & (gpio_port_pins_t)BIT(pin)) != 0U,
+		 "Unsupported pin");
+
+	if ((flags & GPIO_ACTIVE_LOW) != 0) {
+		data->invert |= (gpio_port_pins_t)BIT(pin);
+	} else {
+		data->invert &= ~(gpio_port_pins_t)BIT(pin);
+	}
+
+	return api->pin_configure(port, pin, flags);
+}
+
+#ifdef CONFIG_GPIO_GET_DIRECTION
+static inline int z_impl_gpio_port_get_direction(const struct device *port, gpio_port_pins_t map,
+						 gpio_port_pins_t *inputs,
+						 gpio_port_pins_t *outputs)
+{
+	const struct gpio_driver_api *api = (const struct gpio_driver_api *)port->api;
+
+	if (api->port_get_direction == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->port_get_direction(port, map, inputs, outputs);
+}
+#endif /* CONFIG_GPIO_GET_DIRECTION */
+
+#ifdef CONFIG_GPIO_GET_CONFIG
+static inline int z_impl_gpio_pin_get_config(const struct device *port,
+					     gpio_pin_t pin,
+					     gpio_flags_t *flags)
+{
+	const struct gpio_driver_api *api =
+		(const struct gpio_driver_api *)port->api;
+
+	if (api->pin_get_config == NULL)
+		return -ENOSYS;
+
+	return api->pin_get_config(port, pin, flags);
+}
+#endif
+
+static inline int z_impl_gpio_port_get_raw(const struct device *port,
+					   gpio_port_value_t *value)
+{
+	const struct gpio_driver_api *api =
+		(const struct gpio_driver_api *)port->api;
+
+	return api->port_get_raw(port, value);
+}
+
+static inline int z_impl_gpio_port_set_masked_raw(const struct device *port,
+						  gpio_port_pins_t mask,
+						  gpio_port_value_t value)
+{
+	const struct gpio_driver_api *api =
+		(const struct gpio_driver_api *)port->api;
+
+	return api->port_set_masked_raw(port, mask, value);
+}
+
+static inline int z_impl_gpio_port_set_bits_raw(const struct device *port,
+						gpio_port_pins_t pins)
+{
+	const struct gpio_driver_api *api =
+		(const struct gpio_driver_api *)port->api;
+
+	return api->port_set_bits_raw(port, pins);
+}
+
+static inline int z_impl_gpio_port_clear_bits_raw(const struct device *port,
+						  gpio_port_pins_t pins)
+{
+	const struct gpio_driver_api *api =
+		(const struct gpio_driver_api *)port->api;
+
+	return api->port_clear_bits_raw(port, pins);
+}
+
+static inline int z_impl_gpio_port_toggle_bits(const struct device *port,
+					       gpio_port_pins_t pins)
+{
+	const struct gpio_driver_api *api =
+		(const struct gpio_driver_api *)port->api;
+
+	return api->port_toggle_bits(port, pins);
+}
+
+static inline int z_impl_gpio_get_pending_int(const struct device *dev)
+{
+	const struct gpio_driver_api *api =
+		(const struct gpio_driver_api *)dev->api;
+
+	if (api->get_pending_int == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->get_pending_int(dev);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_GPIO_INTERNAL_GPIO_IMPL_H_ */

--- a/include/zephyr/drivers/hwinfo.h
+++ b/include/zephyr/drivers/hwinfo.h
@@ -93,8 +93,6 @@ extern "C" {
  */
 __syscall ssize_t hwinfo_get_device_id(uint8_t *buffer, size_t length);
 
-ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length);
-
 /**
  * @brief Copy the device EUI64 to a buffer
  *
@@ -108,8 +106,6 @@ ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length);
  * @retval any negative value on driver specific errors.
  */
 __syscall int hwinfo_get_device_eui64(uint8_t *buffer);
-
-int z_impl_hwinfo_get_device_eui64(uint8_t *buffer);
 
 /**
  * @brief      Retrieve cause of device reset.
@@ -133,8 +129,6 @@ int z_impl_hwinfo_get_device_eui64(uint8_t *buffer);
  */
 __syscall int hwinfo_get_reset_cause(uint32_t *cause);
 
-int z_impl_hwinfo_get_reset_cause(uint32_t *cause);
-
 /**
  * @brief      Clear cause of device reset.
  *
@@ -145,8 +139,6 @@ int z_impl_hwinfo_get_reset_cause(uint32_t *cause);
  * @retval any negative value on driver specific errors.
  */
 __syscall int hwinfo_clear_reset_cause(void);
-
-int z_impl_hwinfo_clear_reset_cause(void);
 
 /**
  * @brief      Get supported reset cause flags
@@ -160,8 +152,6 @@ int z_impl_hwinfo_clear_reset_cause(void);
  * @retval any negative value on driver specific errors.
  */
 __syscall int hwinfo_get_supported_reset_cause(uint32_t *supported);
-
-int z_impl_hwinfo_get_supported_reset_cause(uint32_t *supported);
 
 /**
  * @}

--- a/include/zephyr/drivers/hwspinlock.h
+++ b/include/zephyr/drivers/hwspinlock.h
@@ -73,17 +73,6 @@ __subsystem struct hwspinlock_driver_api {
  */
 __syscall int hwspinlock_trylock(const struct device *dev, uint32_t id);
 
-static inline int z_impl_hwspinlock_trylock(const struct device *dev, uint32_t id)
-{
-	const struct hwspinlock_driver_api *api =
-		(const struct hwspinlock_driver_api *)dev->api;
-
-	if (api->trylock == NULL)
-		return -ENOSYS;
-
-	return api->trylock(dev, id);
-}
-
 /**
  * @brief Lock HW spinlock
  *
@@ -95,15 +84,6 @@ static inline int z_impl_hwspinlock_trylock(const struct device *dev, uint32_t i
  */
 __syscall void hwspinlock_lock(const struct device *dev, uint32_t id);
 
-static inline void z_impl_hwspinlock_lock(const struct device *dev, uint32_t id)
-{
-	const struct hwspinlock_driver_api *api =
-		(const struct hwspinlock_driver_api *)dev->api;
-
-	if (api->lock != NULL)
-		api->lock(dev, id);
-}
-
 /**
  * @brief Try to unlock HW spinlock
  *
@@ -114,15 +94,6 @@ static inline void z_impl_hwspinlock_lock(const struct device *dev, uint32_t id)
  * @param id  Spinlock identifier.
  */
 __syscall void hwspinlock_unlock(const struct device *dev, uint32_t id);
-
-static inline void z_impl_hwspinlock_unlock(const struct device *dev, uint32_t id)
-{
-	const struct hwspinlock_driver_api *api =
-		(const struct hwspinlock_driver_api *)dev->api;
-
-	if (api->unlock != NULL)
-		api->unlock(dev, id);
-}
 
 /**
  * @brief Get HW spinlock max ID
@@ -137,23 +108,13 @@ static inline void z_impl_hwspinlock_unlock(const struct device *dev, uint32_t i
  */
 __syscall uint32_t hwspinlock_get_max_id(const struct device *dev);
 
-static inline uint32_t z_impl_hwspinlock_get_max_id(const struct device *dev)
-{
-	const struct hwspinlock_driver_api *api =
-		(const struct hwspinlock_driver_api *)dev->api;
-
-	if (api->get_max_id == NULL)
-		return 0;
-
-	return api->get_max_id(dev);
-}
-
 #ifdef __cplusplus
 }
 #endif
 
 /** @} */
 
+#include <zephyr/drivers/hwspinlock/internal/hwspinlock_impl.h>
 #include <zephyr/syscalls/hwspinlock.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_HWSPINLOCK_H_ */

--- a/include/zephyr/drivers/hwspinlock/internal/hwspinlock_impl.h
+++ b/include/zephyr/drivers/hwspinlock/internal/hwspinlock_impl.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023 Sequans Communications
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_HWSPINLOCK_H_
+#error "Should only be included by zephyr/drivers/hwspinlock.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_HWSPINLOCK_INTERNAL_HWSPINLOCK_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_HWSPINLOCK_INTERNAL_HWSPINLOCK_IMPL_H_
+
+#include <errno.h>
+#include <zephyr/types.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_hwspinlock_trylock(const struct device *dev, uint32_t id)
+{
+	const struct hwspinlock_driver_api *api =
+		(const struct hwspinlock_driver_api *)dev->api;
+
+	if (api->trylock == NULL)
+		return -ENOSYS;
+
+	return api->trylock(dev, id);
+}
+
+static inline void z_impl_hwspinlock_lock(const struct device *dev, uint32_t id)
+{
+	const struct hwspinlock_driver_api *api =
+		(const struct hwspinlock_driver_api *)dev->api;
+
+	if (api->lock != NULL)
+		api->lock(dev, id);
+}
+
+static inline void z_impl_hwspinlock_unlock(const struct device *dev, uint32_t id)
+{
+	const struct hwspinlock_driver_api *api =
+		(const struct hwspinlock_driver_api *)dev->api;
+
+	if (api->unlock != NULL)
+		api->unlock(dev, id);
+}
+
+static inline uint32_t z_impl_hwspinlock_get_max_id(const struct device *dev)
+{
+	const struct hwspinlock_driver_api *api =
+		(const struct hwspinlock_driver_api *)dev->api;
+
+	if (api->get_max_id == NULL)
+		return 0;
+
+	return api->get_max_id(dev);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_HWSPINLOCK_INTERNAL_HWSPINLOCK_IMPL_H_ */

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -701,15 +701,6 @@ static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs
  */
 __syscall int i2c_configure(const struct device *dev, uint32_t dev_config);
 
-static inline int z_impl_i2c_configure(const struct device *dev,
-				       uint32_t dev_config)
-{
-	const struct i2c_driver_api *api =
-		(const struct i2c_driver_api *)dev->api;
-
-	return api->configure(dev, dev_config);
-}
-
 /**
  * @brief Get configuration of a host controller.
  *
@@ -731,17 +722,6 @@ static inline int z_impl_i2c_configure(const struct device *dev,
  * @retval -ENOSYS If get config is not implemented
  */
 __syscall int i2c_get_config(const struct device *dev, uint32_t *dev_config);
-
-static inline int z_impl_i2c_get_config(const struct device *dev, uint32_t *dev_config)
-{
-	const struct i2c_driver_api *api = (const struct i2c_driver_api *)dev->api;
-
-	if (api->get_config == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->get_config(dev, dev_config);
-}
 
 /**
  * @brief Perform data transfer to another I2C device in controller mode.
@@ -777,30 +757,6 @@ static inline int z_impl_i2c_get_config(const struct device *dev, uint32_t *dev_
 __syscall int i2c_transfer(const struct device *dev,
 			   struct i2c_msg *msgs, uint8_t num_msgs,
 			   uint16_t addr);
-
-static inline int z_impl_i2c_transfer(const struct device *dev,
-				      struct i2c_msg *msgs, uint8_t num_msgs,
-				      uint16_t addr)
-{
-	const struct i2c_driver_api *api =
-		(const struct i2c_driver_api *)dev->api;
-
-	if (!num_msgs) {
-		return 0;
-	}
-
-	msgs[num_msgs - 1].flags |= I2C_MSG_STOP;
-
-	int res =  api->transfer(dev, msgs, num_msgs, addr);
-
-	i2c_xfer_stats(dev, msgs, num_msgs);
-
-	if (IS_ENABLED(CONFIG_I2C_DUMP_MESSAGES)) {
-		i2c_dump_msgs_rw(dev, msgs, num_msgs, addr, true);
-	}
-
-	return res;
-}
 
 #if defined(CONFIG_I2C_CALLBACK) || defined(__DOXYGEN__)
 
@@ -1095,18 +1051,6 @@ static inline int i2c_transfer_dt(const struct i2c_dt_spec *spec,
  */
 __syscall int i2c_recover_bus(const struct device *dev);
 
-static inline int z_impl_i2c_recover_bus(const struct device *dev)
-{
-	const struct i2c_driver_api *api =
-		(const struct i2c_driver_api *)dev->api;
-
-	if (api->recover_bus == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->recover_bus(dev);
-}
-
 /**
  * @brief Registers the provided config as Target device of a controller.
  *
@@ -1188,14 +1132,6 @@ static inline int i2c_target_unregister(const struct device *dev,
  */
 __syscall int i2c_target_driver_register(const struct device *dev);
 
-static inline int z_impl_i2c_target_driver_register(const struct device *dev)
-{
-	const struct i2c_target_driver_api *api =
-		(const struct i2c_target_driver_api *)dev->api;
-
-	return api->driver_register(dev);
-}
-
 /**
  * @brief Instructs the I2C Target device to unregister itself from the I2C
  * Controller
@@ -1210,14 +1146,6 @@ static inline int z_impl_i2c_target_driver_register(const struct device *dev)
  * @retval -EINVAL If parameters are invalid
  */
 __syscall int i2c_target_driver_unregister(const struct device *dev);
-
-static inline int z_impl_i2c_target_driver_unregister(const struct device *dev)
-{
-	const struct i2c_target_driver_api *api =
-		(const struct i2c_target_driver_api *)dev->api;
-
-	return api->driver_unregister(dev);
-}
 
 /*
  * Derived i2c APIs -- all implemented in terms of i2c_transfer()
@@ -1648,6 +1576,7 @@ static inline int i2c_reg_update_byte_dt(const struct i2c_dt_spec *spec,
  * @}
  */
 
+#include <zephyr/drivers/i2c/internal/i2c_impl.h>
 #include <zephyr/syscalls/i2c.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_I2C_H_ */

--- a/include/zephyr/drivers/i2c/internal/i2c_impl.h
+++ b/include/zephyr/drivers/i2c/internal/i2c_impl.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2015 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Inline syscall implementations for I2C APIs
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_I2C_H_
+#error "Should only be included by zephyr/drivers/i2c.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_I2C_INTERNAL_I2C_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_I2C_INTERNAL_I2C_IMPL_H_
+
+#include <errno.h>
+#include <stdint.h>
+
+#include <zephyr/types.h>
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/slist.h>
+#include <zephyr/rtio/rtio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_i2c_configure(const struct device *dev,
+				       uint32_t dev_config)
+{
+	const struct i2c_driver_api *api =
+		(const struct i2c_driver_api *)dev->api;
+
+	return api->configure(dev, dev_config);
+}
+
+static inline int z_impl_i2c_get_config(const struct device *dev, uint32_t *dev_config)
+{
+	const struct i2c_driver_api *api = (const struct i2c_driver_api *)dev->api;
+
+	if (api->get_config == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->get_config(dev, dev_config);
+}
+
+static inline int z_impl_i2c_transfer(const struct device *dev,
+				      struct i2c_msg *msgs, uint8_t num_msgs,
+				      uint16_t addr)
+{
+	const struct i2c_driver_api *api =
+		(const struct i2c_driver_api *)dev->api;
+
+	if (!num_msgs) {
+		return 0;
+	}
+
+	msgs[num_msgs - 1].flags |= I2C_MSG_STOP;
+
+	int res =  api->transfer(dev, msgs, num_msgs, addr);
+
+	i2c_xfer_stats(dev, msgs, num_msgs);
+
+	if (IS_ENABLED(CONFIG_I2C_DUMP_MESSAGES)) {
+		i2c_dump_msgs_rw(dev, msgs, num_msgs, addr, true);
+	}
+
+	return res;
+}
+
+static inline int z_impl_i2c_recover_bus(const struct device *dev)
+{
+	const struct i2c_driver_api *api =
+		(const struct i2c_driver_api *)dev->api;
+
+	if (api->recover_bus == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->recover_bus(dev);
+}
+
+static inline int z_impl_i2c_target_driver_register(const struct device *dev)
+{
+	const struct i2c_target_driver_api *api =
+		(const struct i2c_target_driver_api *)dev->api;
+
+	return api->driver_register(dev);
+}
+
+static inline int z_impl_i2c_target_driver_unregister(const struct device *dev)
+{
+	const struct i2c_target_driver_api *api =
+		(const struct i2c_target_driver_api *)dev->api;
+
+	return api->driver_unregister(dev);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_I2C_INTERNAL_I2C_IMPL_H_ */

--- a/include/zephyr/drivers/i2s.h
+++ b/include/zephyr/drivers/i2s.h
@@ -357,16 +357,6 @@ __subsystem struct i2s_driver_api {
 __syscall int i2s_configure(const struct device *dev, enum i2s_dir dir,
 			    const struct i2s_config *cfg);
 
-static inline int z_impl_i2s_configure(const struct device *dev,
-				       enum i2s_dir dir,
-				       const struct i2s_config *cfg)
-{
-	const struct i2s_driver_api *api =
-		(const struct i2s_driver_api *)dev->api;
-
-	return api->configure(dev, dir, cfg);
-}
-
 /**
  * @brief Fetch configuration information of a host I2S controller
  *
@@ -526,16 +516,6 @@ __syscall int i2s_buf_write(const struct device *dev, void *buf, size_t size);
 __syscall int i2s_trigger(const struct device *dev, enum i2s_dir dir,
 			  enum i2s_trigger_cmd cmd);
 
-static inline int z_impl_i2s_trigger(const struct device *dev,
-				     enum i2s_dir dir,
-				     enum i2s_trigger_cmd cmd)
-{
-	const struct i2s_driver_api *api =
-		(const struct i2s_driver_api *)dev->api;
-
-	return api->trigger(dev, dir, cmd);
-}
-
 /**
  * @}
  */
@@ -544,6 +524,7 @@ static inline int z_impl_i2s_trigger(const struct device *dev,
 }
 #endif
 
+#include <zephyr/drivers/i2s/internal/i2s_impl.h>
 #include <zephyr/syscalls/i2s.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_I2S_H_ */

--- a/include/zephyr/drivers/i2s/internal/i2s_impl.h
+++ b/include/zephyr/drivers/i2s/internal/i2s_impl.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2017 Piotr Mienkowski
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Inline syscall implementation for I2S APIs.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_I2S_H_
+#error "Should only be included by zephyr/drivers/i2s.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_I2S_INTERNAL_I2S_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_I2S_INTERNAL_I2S_IMPL_H_
+
+#include <zephyr/types.h>
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_i2s_configure(const struct device *dev,
+				       enum i2s_dir dir,
+				       const struct i2s_config *cfg)
+{
+	const struct i2s_driver_api *api =
+		(const struct i2s_driver_api *)dev->api;
+
+	return api->configure(dev, dir, cfg);
+}
+
+static inline int z_impl_i2s_trigger(const struct device *dev,
+				     enum i2s_dir dir,
+				     enum i2s_trigger_cmd cmd)
+{
+	const struct i2s_driver_api *api =
+		(const struct i2s_driver_api *)dev->api;
+
+	return api->trigger(dev, dir, cmd);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_I2S_INTERNAL_I2S_IMPL_H_ */

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -1555,19 +1555,6 @@ static inline int i3c_do_daa(const struct device *dev)
 __syscall int i3c_do_ccc(const struct device *dev,
 			 struct i3c_ccc_payload *payload);
 
-static inline int z_impl_i3c_do_ccc(const struct device *dev,
-				    struct i3c_ccc_payload *payload)
-{
-	const struct i3c_driver_api *api =
-		(const struct i3c_driver_api *)dev->api;
-
-	if (api->do_ccc == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->do_ccc(dev, payload);
-}
-
 /**
  * @addtogroup i3c_transfer_api
  * @{
@@ -1601,15 +1588,6 @@ static inline int z_impl_i3c_do_ccc(const struct device *dev,
  */
 __syscall int i3c_transfer(struct i3c_device_desc *target,
 			   struct i3c_msg *msgs, uint8_t num_msgs);
-
-static inline int z_impl_i3c_transfer(struct i3c_device_desc *target,
-				      struct i3c_msg *msgs, uint8_t num_msgs)
-{
-	const struct i3c_driver_api *api =
-		(const struct i3c_driver_api *)target->bus->api;
-
-	return api->i3c_xfers(target->bus, target, msgs, num_msgs);
-}
 
 /** @} */
 
@@ -2095,6 +2073,7 @@ int i3c_device_basic_info_get(struct i3c_device_desc *target);
  * @}
  */
 
+#include <zephyr/drivers/i3c/internal/i3c_impl.h>
 #include <zephyr/syscalls/i3c.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_I3C_H_ */

--- a/include/zephyr/drivers/i3c/internal/i3c_impl.h
+++ b/include/zephyr/drivers/i3c/internal/i3c_impl.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 Intel Corporation
+ * Copyright 2023 Meta Platforms, Inc. and its affiliates
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Inline syscall implementations for I3C APIs
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_I3C_H_
+#error "Should only be included by zephyr/drivers/i3c.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_I3C_INTERNAL_I3C_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_I3C_INTERNAL_I3C_IMPL_H_
+
+#include <errno.h>
+#include <stdint.h>
+
+#include <zephyr/device.h>
+
+#include <zephyr/drivers/i3c/addresses.h>
+#include <zephyr/drivers/i3c/ccc.h>
+#include <zephyr/drivers/i3c.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_i3c_do_ccc(const struct device *dev,
+				    struct i3c_ccc_payload *payload)
+{
+	const struct i3c_driver_api *api =
+		(const struct i3c_driver_api *)dev->api;
+
+	if (api->do_ccc == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->do_ccc(dev, payload);
+}
+
+static inline int z_impl_i3c_transfer(struct i3c_device_desc *target,
+				      struct i3c_msg *msgs, uint8_t num_msgs)
+{
+	const struct i3c_driver_api *api =
+		(const struct i3c_driver_api *)target->bus->api;
+
+	return api->i3c_xfers(target->bus, target, msgs, num_msgs);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_I3C_INTERNAL_I3C_IMPL_H_ */

--- a/include/zephyr/drivers/ipm.h
+++ b/include/zephyr/drivers/ipm.h
@@ -146,16 +146,6 @@ __subsystem struct ipm_driver_api {
 __syscall int ipm_send(const struct device *ipmdev, int wait, uint32_t id,
 		       const void *data, int size);
 
-static inline int z_impl_ipm_send(const struct device *ipmdev, int wait,
-				  uint32_t id,
-				  const void *data, int size)
-{
-	const struct ipm_driver_api *api =
-		(const struct ipm_driver_api *)ipmdev->api;
-
-	return api->send(ipmdev, wait, id, data, size);
-}
-
 /**
  * @brief Register a callback function for incoming messages.
  *
@@ -185,15 +175,6 @@ static inline void ipm_register_callback(const struct device *ipmdev,
  */
 __syscall int ipm_max_data_size_get(const struct device *ipmdev);
 
-static inline int z_impl_ipm_max_data_size_get(const struct device *ipmdev)
-{
-	const struct ipm_driver_api *api =
-		(const struct ipm_driver_api *)ipmdev->api;
-
-	return api->max_data_size_get(ipmdev);
-}
-
-
 /**
  * @brief Return the maximum id value possible in an outbound message.
  *
@@ -206,14 +187,6 @@ static inline int z_impl_ipm_max_data_size_get(const struct device *ipmdev)
  */
 __syscall uint32_t ipm_max_id_val_get(const struct device *ipmdev);
 
-static inline uint32_t z_impl_ipm_max_id_val_get(const struct device *ipmdev)
-{
-	const struct ipm_driver_api *api =
-		(const struct ipm_driver_api *)ipmdev->api;
-
-	return api->max_id_val_get(ipmdev);
-}
-
 /**
  * @brief Enable interrupts and callbacks for inbound channels.
  *
@@ -224,15 +197,6 @@ static inline uint32_t z_impl_ipm_max_id_val_get(const struct device *ipmdev)
  * @retval -EINVAL If it isn't an inbound channel.
  */
 __syscall int ipm_set_enabled(const struct device *ipmdev, int enable);
-
-static inline int z_impl_ipm_set_enabled(const struct device *ipmdev,
-					 int enable)
-{
-	const struct ipm_driver_api *api =
-		(const struct ipm_driver_api *)ipmdev->api;
-
-	return api->set_enabled(ipmdev, enable);
-}
 
 /**
  * @brief Signal asynchronous command completion
@@ -250,18 +214,6 @@ static inline int z_impl_ipm_set_enabled(const struct device *ipmdev,
  */
 __syscall void ipm_complete(const struct device *ipmdev);
 
-static inline void z_impl_ipm_complete(const struct device *ipmdev)
-{
-#ifdef CONFIG_IPM_CALLBACK_ASYNC
-	const struct ipm_driver_api *api =
-		(const struct ipm_driver_api *)ipmdev->api;
-
-	if (api->complete != NULL) {
-		api->complete(ipmdev);
-	}
-#endif
-}
-
 #ifdef __cplusplus
 }
 #endif
@@ -270,6 +222,7 @@ static inline void z_impl_ipm_complete(const struct device *ipmdev)
  * @}
  */
 
+#include <zephyr/drivers/ipm/internal/ipm_impl.h>
 #include <zephyr/syscalls/ipm.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_IPM_H_ */

--- a/include/zephyr/drivers/ipm/internal/ipm_impl.h
+++ b/include/zephyr/drivers/ipm/internal/ipm_impl.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2015 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_IPM_H_
+#error "Should only be included by zephyr/drivers/ipm.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_IPM_INTERNAL_IPM_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_IPM_INTERNAL_IPM_IMPL_H_
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_ipm_send(const struct device *ipmdev, int wait,
+				  uint32_t id,
+				  const void *data, int size)
+{
+	const struct ipm_driver_api *api =
+		(const struct ipm_driver_api *)ipmdev->api;
+
+	return api->send(ipmdev, wait, id, data, size);
+}
+
+static inline int z_impl_ipm_max_data_size_get(const struct device *ipmdev)
+{
+	const struct ipm_driver_api *api =
+		(const struct ipm_driver_api *)ipmdev->api;
+
+	return api->max_data_size_get(ipmdev);
+}
+
+static inline uint32_t z_impl_ipm_max_id_val_get(const struct device *ipmdev)
+{
+	const struct ipm_driver_api *api =
+		(const struct ipm_driver_api *)ipmdev->api;
+
+	return api->max_id_val_get(ipmdev);
+}
+
+static inline int z_impl_ipm_set_enabled(const struct device *ipmdev,
+					 int enable)
+{
+	const struct ipm_driver_api *api =
+		(const struct ipm_driver_api *)ipmdev->api;
+
+	return api->set_enabled(ipmdev, enable);
+}
+
+static inline void z_impl_ipm_complete(const struct device *ipmdev)
+{
+#ifdef CONFIG_IPM_CALLBACK_ASYNC
+	const struct ipm_driver_api *api =
+		(const struct ipm_driver_api *)ipmdev->api;
+
+	if (api->complete != NULL) {
+		api->complete(ipmdev);
+	}
+#endif
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_IPM_INTERNAL_IPM_IMPL_H_ */

--- a/include/zephyr/drivers/kscan.h
+++ b/include/zephyr/drivers/kscan.h
@@ -81,14 +81,6 @@ __subsystem struct kscan_driver_api {
 __syscall int kscan_config(const struct device *dev,
 			     kscan_callback_t callback);
 
-static inline int z_impl_kscan_config(const struct device *dev,
-					kscan_callback_t callback)
-{
-	const struct kscan_driver_api *api =
-				(struct kscan_driver_api *)dev->api;
-
-	return api->config(dev, callback);
-}
 /**
  * @brief Enables callback.
  * @param dev Pointer to the device structure for the driver instance.
@@ -97,18 +89,6 @@ static inline int z_impl_kscan_config(const struct device *dev,
  * @retval Negative errno code if failure.
  */
 __syscall int kscan_enable_callback(const struct device *dev);
-
-static inline int z_impl_kscan_enable_callback(const struct device *dev)
-{
-	const struct kscan_driver_api *api =
-			(const struct kscan_driver_api *)dev->api;
-
-	if (api->enable_callback == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->enable_callback(dev);
-}
 
 /**
  * @brief Disables callback.
@@ -119,18 +99,6 @@ static inline int z_impl_kscan_enable_callback(const struct device *dev)
  */
 __syscall int kscan_disable_callback(const struct device *dev);
 
-static inline int z_impl_kscan_disable_callback(const struct device *dev)
-{
-	const struct kscan_driver_api *api =
-			(const struct kscan_driver_api *)dev->api;
-
-	if (api->disable_callback == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->disable_callback(dev);
-}
-
 #ifdef __cplusplus
 }
 #endif
@@ -139,6 +107,7 @@ static inline int z_impl_kscan_disable_callback(const struct device *dev)
  * @}
  */
 
+#include <zephyr/drivers/kscan/internal/kscan_impl.h>
 #include <zephyr/syscalls/kscan.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_KB_SCAN_H_ */

--- a/include/zephyr/drivers/kscan/internal/kscan_impl.h
+++ b/include/zephyr/drivers/kscan/internal/kscan_impl.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Inline syscall implementation for kscan APIs.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_KB_SCAN_H_
+#error "Should only be included by zephyr/drivers/kscan.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_KSCAN_INTERNAL_KSCAN_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_KSCAN_INTERNAL_KSCAN_IMPL_H_
+
+#include <errno.h>
+#include <zephyr/types.h>
+#include <stddef.h>
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_kscan_config(const struct device *dev,
+					kscan_callback_t callback)
+{
+	const struct kscan_driver_api *api =
+				(struct kscan_driver_api *)dev->api;
+
+	return api->config(dev, callback);
+}
+
+static inline int z_impl_kscan_enable_callback(const struct device *dev)
+{
+	const struct kscan_driver_api *api =
+			(const struct kscan_driver_api *)dev->api;
+
+	if (api->enable_callback == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->enable_callback(dev);
+}
+
+static inline int z_impl_kscan_disable_callback(const struct device *dev)
+{
+	const struct kscan_driver_api *api =
+			(const struct kscan_driver_api *)dev->api;
+
+	if (api->disable_callback == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->disable_callback(dev);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_KSCAN_INTERNAL_KSCAN_IMPL_H_ */

--- a/include/zephyr/drivers/led.h
+++ b/include/zephyr/drivers/led.h
@@ -138,18 +138,6 @@ __subsystem struct led_driver_api {
 __syscall int led_blink(const struct device *dev, uint32_t led,
 			    uint32_t delay_on, uint32_t delay_off);
 
-static inline int z_impl_led_blink(const struct device *dev, uint32_t led,
-				   uint32_t delay_on, uint32_t delay_off)
-{
-	const struct led_driver_api *api =
-		(const struct led_driver_api *)dev->api;
-
-	if (api->blink == NULL) {
-		return -ENOSYS;
-	}
-	return api->blink(dev, led, delay_on, delay_off);
-}
-
 /**
  * @brief Get LED information
  *
@@ -162,19 +150,6 @@ static inline int z_impl_led_blink(const struct device *dev, uint32_t led,
  */
 __syscall int led_get_info(const struct device *dev, uint32_t led,
 			   const struct led_info **info);
-
-static inline int z_impl_led_get_info(const struct device *dev, uint32_t led,
-				      const struct led_info **info)
-{
-	const struct led_driver_api *api =
-		(const struct led_driver_api *)dev->api;
-
-	if (api->get_info == NULL) {
-		*info = NULL;
-		return -ENOSYS;
-	}
-	return api->get_info(dev, led, info);
-}
 
 /**
  * @brief Set LED brightness
@@ -193,19 +168,6 @@ static inline int z_impl_led_get_info(const struct device *dev, uint32_t led,
  */
 __syscall int led_set_brightness(const struct device *dev, uint32_t led,
 				     uint8_t value);
-
-static inline int z_impl_led_set_brightness(const struct device *dev,
-					    uint32_t led,
-					    uint8_t value)
-{
-	const struct led_driver_api *api =
-		(const struct led_driver_api *)dev->api;
-
-	if (api->set_brightness == NULL) {
-		return -ENOSYS;
-	}
-	return api->set_brightness(dev, led, value);
-}
 
 /**
  * @brief Write/update a strip of LED channels
@@ -227,19 +189,6 @@ __syscall int led_write_channels(const struct device *dev,
 				 uint32_t start_channel,
 				 uint32_t num_channels, const uint8_t *buf);
 
-static inline int
-z_impl_led_write_channels(const struct device *dev, uint32_t start_channel,
-			  uint32_t num_channels, const uint8_t *buf)
-{
-	const struct led_driver_api *api =
-		(const struct led_driver_api *)dev->api;
-
-	if (api->write_channels == NULL) {
-		return -ENOSYS;
-	}
-	return api->write_channels(dev, start_channel, num_channels, buf);
-}
-
 /**
  * @brief Set a single LED channel
  *
@@ -254,12 +203,6 @@ z_impl_led_write_channels(const struct device *dev, uint32_t start_channel,
  */
 __syscall int led_set_channel(const struct device *dev,
 			      uint32_t channel, uint8_t value);
-
-static inline int z_impl_led_set_channel(const struct device *dev,
-					 uint32_t channel, uint8_t value)
-{
-	return z_impl_led_write_channels(dev, channel, 1, &value);
-}
 
 /**
  * @brief Set LED color
@@ -280,18 +223,6 @@ static inline int z_impl_led_set_channel(const struct device *dev,
 __syscall int led_set_color(const struct device *dev, uint32_t led,
 			    uint8_t num_colors, const uint8_t *color);
 
-static inline int z_impl_led_set_color(const struct device *dev, uint32_t led,
-				       uint8_t num_colors, const uint8_t *color)
-{
-	const struct led_driver_api *api =
-		(const struct led_driver_api *)dev->api;
-
-	if (api->set_color == NULL) {
-		return -ENOSYS;
-	}
-	return api->set_color(dev, led, num_colors, color);
-}
-
 /**
  * @brief Turn on an LED
  *
@@ -302,14 +233,6 @@ static inline int z_impl_led_set_color(const struct device *dev, uint32_t led,
  * @return 0 on success, negative on error
  */
 __syscall int led_on(const struct device *dev, uint32_t led);
-
-static inline int z_impl_led_on(const struct device *dev, uint32_t led)
-{
-	const struct led_driver_api *api =
-		(const struct led_driver_api *)dev->api;
-
-	return api->on(dev, led);
-}
 
 /**
  * @brief Turn off an LED
@@ -322,14 +245,6 @@ static inline int z_impl_led_on(const struct device *dev, uint32_t led)
  */
 __syscall int led_off(const struct device *dev, uint32_t led);
 
-static inline int z_impl_led_off(const struct device *dev, uint32_t led)
-{
-	const struct led_driver_api *api =
-		(const struct led_driver_api *)dev->api;
-
-	return api->off(dev, led);
-}
-
 /**
  * @}
  */
@@ -338,6 +253,7 @@ static inline int z_impl_led_off(const struct device *dev, uint32_t led)
 }
 #endif
 
+#include <zephyr/drivers/led/internal/led_impl.h>
 #include <zephyr/syscalls/led.h>
 
 #endif	/* ZEPHYR_INCLUDE_DRIVERS_LED_H_ */

--- a/include/zephyr/drivers/led/internal/led_impl.h
+++ b/include/zephyr/drivers/led/internal/led_impl.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2018 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Inline syscall implementation for LED driver APIs
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_LED_H_
+#error "Should only be included by zephyr/drivers/led.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_LED_INTERNAL_LED_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_LED_INTERNAL_LED_IMPL_H_
+
+#include <errno.h>
+
+#include <zephyr/types.h>
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_led_blink(const struct device *dev, uint32_t led,
+				   uint32_t delay_on, uint32_t delay_off)
+{
+	const struct led_driver_api *api =
+		(const struct led_driver_api *)dev->api;
+
+	if (api->blink == NULL) {
+		return -ENOSYS;
+	}
+	return api->blink(dev, led, delay_on, delay_off);
+}
+
+static inline int z_impl_led_get_info(const struct device *dev, uint32_t led,
+				      const struct led_info **info)
+{
+	const struct led_driver_api *api =
+		(const struct led_driver_api *)dev->api;
+
+	if (api->get_info == NULL) {
+		*info = NULL;
+		return -ENOSYS;
+	}
+	return api->get_info(dev, led, info);
+}
+
+static inline int z_impl_led_set_brightness(const struct device *dev,
+					    uint32_t led,
+					    uint8_t value)
+{
+	const struct led_driver_api *api =
+		(const struct led_driver_api *)dev->api;
+
+	if (api->set_brightness == NULL) {
+		return -ENOSYS;
+	}
+	return api->set_brightness(dev, led, value);
+}
+
+static inline int
+z_impl_led_write_channels(const struct device *dev, uint32_t start_channel,
+			  uint32_t num_channels, const uint8_t *buf)
+{
+	const struct led_driver_api *api =
+		(const struct led_driver_api *)dev->api;
+
+	if (api->write_channels == NULL) {
+		return -ENOSYS;
+	}
+	return api->write_channels(dev, start_channel, num_channels, buf);
+}
+
+static inline int z_impl_led_set_channel(const struct device *dev,
+					 uint32_t channel, uint8_t value)
+{
+	return z_impl_led_write_channels(dev, channel, 1, &value);
+}
+
+static inline int z_impl_led_set_color(const struct device *dev, uint32_t led,
+				       uint8_t num_colors, const uint8_t *color)
+{
+	const struct led_driver_api *api =
+		(const struct led_driver_api *)dev->api;
+
+	if (api->set_color == NULL) {
+		return -ENOSYS;
+	}
+	return api->set_color(dev, led, num_colors, color);
+}
+
+static inline int z_impl_led_on(const struct device *dev, uint32_t led)
+{
+	const struct led_driver_api *api =
+		(const struct led_driver_api *)dev->api;
+
+	return api->on(dev, led);
+}
+
+static inline int z_impl_led_off(const struct device *dev, uint32_t led)
+{
+	const struct led_driver_api *api =
+		(const struct led_driver_api *)dev->api;
+
+	return api->off(dev, led);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif	/* ZEPHYR_INCLUDE_DRIVERS_LED_INTERNAL_LED_IMPL_H_ */

--- a/include/zephyr/drivers/mbox.h
+++ b/include/zephyr/drivers/mbox.h
@@ -263,20 +263,6 @@ static inline bool mbox_is_ready_dt(const struct mbox_dt_spec *spec)
 __syscall int mbox_send(const struct device *dev, mbox_channel_id_t channel_id,
 			const struct mbox_msg *msg);
 
-static inline int z_impl_mbox_send(const struct device *dev,
-				   mbox_channel_id_t channel_id,
-				   const struct mbox_msg *msg)
-{
-	const struct mbox_driver_api *api =
-		(const struct mbox_driver_api *)dev->api;
-
-	if (api->send == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->send(dev, channel_id, msg);
-}
-
 /**
  * @brief Try to send a message over the MBOX device from a struct mbox_dt_spec.
  *
@@ -362,18 +348,6 @@ static inline int mbox_register_callback_dt(const struct mbox_dt_spec *spec,
  */
 __syscall int mbox_mtu_get(const struct device *dev);
 
-static inline int z_impl_mbox_mtu_get(const struct device *dev)
-{
-	const struct mbox_driver_api *api =
-		(const struct mbox_driver_api *)dev->api;
-
-	if (api->mtu_get == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->mtu_get(dev);
-}
-
 /**
  * @brief Return the maximum number of bytes possible in an outbound message
  *        from struct mbox_dt_spec.
@@ -415,20 +389,6 @@ static inline int mbox_mtu_get_dt(const struct mbox_dt_spec *spec)
 __syscall int mbox_set_enabled(const struct device *dev,
 			       mbox_channel_id_t channel_id, bool enabled);
 
-static inline int z_impl_mbox_set_enabled(const struct device *dev,
-					  mbox_channel_id_t channel_id,
-					  bool enabled)
-{
-	const struct mbox_driver_api *api =
-		(const struct mbox_driver_api *)dev->api;
-
-	if (api->set_enabled == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->set_enabled(dev, channel_id, enabled);
-}
-
 /**
  * @brief Enable (disable) interrupts and callbacks for inbound channels from a
  *        struct mbox_dt_spec.
@@ -456,18 +416,6 @@ static inline int mbox_set_enabled_dt(const struct mbox_dt_spec *spec,
  */
 __syscall uint32_t mbox_max_channels_get(const struct device *dev);
 
-static inline uint32_t z_impl_mbox_max_channels_get(const struct device *dev)
-{
-	const struct mbox_driver_api *api =
-		(const struct mbox_driver_api *)dev->api;
-
-	if (api->max_channels_get == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->max_channels_get(dev);
-}
-
 /**
  * @brief Return the maximum number of channels from a struct mbox_dt_spec.
  *
@@ -486,6 +434,7 @@ static inline int mbox_max_channels_get_dt(const struct mbox_dt_spec *spec)
 }
 #endif
 
+#include <zephyr/drivers/mbox/internal/mbox_impl.h>
 #include <zephyr/syscalls/mbox.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_MBOX_H_ */

--- a/include/zephyr/drivers/mbox/internal/mbox_impl.h
+++ b/include/zephyr/drivers/mbox/internal/mbox_impl.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2021 Carlo Caione <ccaione@baylibre.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_MBOX_H_
+#error "Should only be included by zephyr/drivers/mbox.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_MBOX_INTERNAL_MBOX_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_MBOX_INTERNAL_MBOX_IMPL_H_
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_mbox_send(const struct device *dev,
+				   mbox_channel_id_t channel_id,
+				   const struct mbox_msg *msg)
+{
+	const struct mbox_driver_api *api =
+		(const struct mbox_driver_api *)dev->api;
+
+	if (api->send == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->send(dev, channel_id, msg);
+}
+
+static inline int z_impl_mbox_mtu_get(const struct device *dev)
+{
+	const struct mbox_driver_api *api =
+		(const struct mbox_driver_api *)dev->api;
+
+	if (api->mtu_get == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->mtu_get(dev);
+}
+
+static inline int z_impl_mbox_set_enabled(const struct device *dev,
+					  mbox_channel_id_t channel_id,
+					  bool enabled)
+{
+	const struct mbox_driver_api *api =
+		(const struct mbox_driver_api *)dev->api;
+
+	if (api->set_enabled == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->set_enabled(dev, channel_id, enabled);
+}
+
+static inline uint32_t z_impl_mbox_max_channels_get(const struct device *dev)
+{
+	const struct mbox_driver_api *api =
+		(const struct mbox_driver_api *)dev->api;
+
+	if (api->max_channels_get == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->max_channels_get(dev);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_MBOX_INTERNAL_MBOX_IMPL_H_ */

--- a/include/zephyr/drivers/mdio.h
+++ b/include/zephyr/drivers/mdio.h
@@ -68,16 +68,6 @@ __subsystem struct mdio_driver_api {
  */
 __syscall void mdio_bus_enable(const struct device *dev);
 
-static inline void z_impl_mdio_bus_enable(const struct device *dev)
-{
-	const struct mdio_driver_api *api =
-		(const struct mdio_driver_api *)dev->api;
-
-	if (api->bus_enable != NULL) {
-		api->bus_enable(dev);
-	}
-}
-
 /**
  * @brief      Disable MDIO bus and tri-state drivers
  *
@@ -85,16 +75,6 @@ static inline void z_impl_mdio_bus_enable(const struct device *dev)
  *
  */
 __syscall void mdio_bus_disable(const struct device *dev);
-
-static inline void z_impl_mdio_bus_disable(const struct device *dev)
-{
-	const struct mdio_driver_api *api =
-		(const struct mdio_driver_api *)dev->api;
-
-	if (api->bus_disable != NULL) {
-		api->bus_disable(dev);
-	}
-}
 
 /**
  * @brief      Read from MDIO Bus
@@ -114,19 +94,6 @@ static inline void z_impl_mdio_bus_disable(const struct device *dev)
  */
 __syscall int mdio_read(const struct device *dev, uint8_t prtad, uint8_t regad,
 			uint16_t *data);
-
-static inline int z_impl_mdio_read(const struct device *dev, uint8_t prtad,
-				   uint8_t regad, uint16_t *data)
-{
-	const struct mdio_driver_api *api =
-		(const struct mdio_driver_api *)dev->api;
-
-	if (api->read == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->read(dev, prtad, regad, data);
-}
 
 
 /**
@@ -148,19 +115,6 @@ static inline int z_impl_mdio_read(const struct device *dev, uint8_t prtad,
 __syscall int mdio_write(const struct device *dev, uint8_t prtad, uint8_t regad,
 			 uint16_t data);
 
-static inline int z_impl_mdio_write(const struct device *dev, uint8_t prtad,
-				    uint8_t regad, uint16_t data)
-{
-	const struct mdio_driver_api *api =
-		(const struct mdio_driver_api *)dev->api;
-
-	if (api->write == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->write(dev, prtad, regad, data);
-}
-
 /**
  * @brief      Read from MDIO Bus using Clause 45 access
  *
@@ -180,20 +134,6 @@ static inline int z_impl_mdio_write(const struct device *dev, uint8_t prtad,
  */
 __syscall int mdio_read_c45(const struct device *dev, uint8_t prtad,
 			    uint8_t devad, uint16_t regad, uint16_t *data);
-
-static inline int z_impl_mdio_read_c45(const struct device *dev, uint8_t prtad,
-				       uint8_t devad, uint16_t regad,
-				       uint16_t *data)
-{
-	const struct mdio_driver_api *api =
-		(const struct mdio_driver_api *)dev->api;
-
-	if (api->read_c45 == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->read_c45(dev, prtad, devad, regad, data);
-}
 
 /**
  * @brief      Write to MDIO bus using Clause 45 access
@@ -215,20 +155,6 @@ static inline int z_impl_mdio_read_c45(const struct device *dev, uint8_t prtad,
 __syscall int mdio_write_c45(const struct device *dev, uint8_t prtad,
 			     uint8_t devad, uint16_t regad, uint16_t data);
 
-static inline int z_impl_mdio_write_c45(const struct device *dev, uint8_t prtad,
-					uint8_t devad, uint16_t regad,
-					uint16_t data)
-{
-	const struct mdio_driver_api *api =
-		(const struct mdio_driver_api *)dev->api;
-
-	if (api->write_c45 == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->write_c45(dev, prtad, devad, regad, data);
-}
-
 #ifdef __cplusplus
 }
 #endif
@@ -237,6 +163,7 @@ static inline int z_impl_mdio_write_c45(const struct device *dev, uint8_t prtad,
  * @}
  */
 
+#include <zephyr/drivers/mdio/internal/mdio_impl.h>
 #include <zephyr/syscalls/mdio.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_MDIO_H_ */

--- a/include/zephyr/drivers/mdio/internal/mdio_impl.h
+++ b/include/zephyr/drivers/mdio/internal/mdio_impl.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2021 IP-Logix Inc.
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Inline syscall implementation for MDIO driver APIs.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_MDIO_H_
+#error "Should only be included by zephyr/drivers/mdio.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_MDIO_INTERNAL_MDIO_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_MDIO_INTERNAL_MDIO_IMPL_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline void z_impl_mdio_bus_enable(const struct device *dev)
+{
+	const struct mdio_driver_api *api =
+		(const struct mdio_driver_api *)dev->api;
+
+	if (api->bus_enable != NULL) {
+		api->bus_enable(dev);
+	}
+}
+
+static inline void z_impl_mdio_bus_disable(const struct device *dev)
+{
+	const struct mdio_driver_api *api =
+		(const struct mdio_driver_api *)dev->api;
+
+	if (api->bus_disable != NULL) {
+		api->bus_disable(dev);
+	}
+}
+
+static inline int z_impl_mdio_read(const struct device *dev, uint8_t prtad,
+				   uint8_t regad, uint16_t *data)
+{
+	const struct mdio_driver_api *api =
+		(const struct mdio_driver_api *)dev->api;
+
+	if (api->read == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->read(dev, prtad, regad, data);
+}
+
+static inline int z_impl_mdio_write(const struct device *dev, uint8_t prtad,
+				    uint8_t regad, uint16_t data)
+{
+	const struct mdio_driver_api *api =
+		(const struct mdio_driver_api *)dev->api;
+
+	if (api->write == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->write(dev, prtad, regad, data);
+}
+
+static inline int z_impl_mdio_read_c45(const struct device *dev, uint8_t prtad,
+				       uint8_t devad, uint16_t regad,
+				       uint16_t *data)
+{
+	const struct mdio_driver_api *api =
+		(const struct mdio_driver_api *)dev->api;
+
+	if (api->read_c45 == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->read_c45(dev, prtad, devad, regad, data);
+}
+
+static inline int z_impl_mdio_write_c45(const struct device *dev, uint8_t prtad,
+					uint8_t devad, uint16_t regad,
+					uint16_t data)
+{
+	const struct mdio_driver_api *api =
+		(const struct mdio_driver_api *)dev->api;
+
+	if (api->write_c45 == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->write_c45(dev, prtad, devad, regad, data);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_MDIO_INTERNAL_MDIO_IMPL_H_ */

--- a/include/zephyr/drivers/misc/timeaware_gpio/internal/timeaware_gpio_impl.h
+++ b/include/zephyr/drivers/misc/timeaware_gpio/internal/timeaware_gpio_impl.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2023 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Inline syscall implementation for Time-aware GPIO driver APIs
+ */
+
+#ifndef ZEPHYR_DRIVERS_MISC_TIMEAWARE_GPIO_TIMEAWARE_GPIO
+#error "Should only be included by zephyr/drivers/misc/timeaware_gpio/timeaware_gpio.h"
+#endif
+
+#ifndef ZEPHYR_DRIVERS_MISC_TIMEAWARE_GPIO_TIMEAWARE_GPIO_INTERNAL_IMPL_H_
+#define ZEPHYR_DRIVERS_MISC_TIMEAWARE_GPIO_TIMEAWARE_GPIO_INTERNAL_IMPL_H_
+
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/slist.h>
+
+#include <zephyr/types.h>
+#include <stddef.h>
+#include <zephyr/device.h>
+#include <zephyr/internal/syscall_handler.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_tgpio_port_get_time(const struct device *dev, uint64_t *current_time)
+{
+	const struct tgpio_driver_api *api = (const struct tgpio_driver_api *)dev->api;
+
+	return api->get_time(dev, current_time);
+}
+
+static inline int z_impl_tgpio_port_get_cycles_per_second(const struct device *dev,
+							   uint32_t *cycles)
+{
+	const struct tgpio_driver_api *api = (const struct tgpio_driver_api *)dev->api;
+
+	return api->cyc_per_sec(dev, cycles);
+}
+
+static inline int z_impl_tgpio_pin_disable(const struct device *dev, uint32_t pin)
+{
+	const struct tgpio_driver_api *api = (const struct tgpio_driver_api *)dev->api;
+
+	return api->pin_disable(dev, pin);
+}
+
+static inline int z_impl_tgpio_pin_config_ext_timestamp(const struct device *dev, uint32_t pin,
+							 uint32_t event_polarity)
+{
+	const struct tgpio_driver_api *api = (const struct tgpio_driver_api *)dev->api;
+
+	return api->config_ext_ts(dev, pin, event_polarity);
+}
+
+static inline int z_impl_tgpio_pin_periodic_output(const struct device *dev, uint32_t pin,
+						    uint64_t start_time, uint64_t repeat_interval,
+						    bool periodic_enable)
+{
+	const struct tgpio_driver_api *api = (const struct tgpio_driver_api *)dev->api;
+
+	return api->set_perout(dev, pin, start_time, repeat_interval, periodic_enable);
+}
+
+static inline int z_impl_tgpio_pin_read_ts_ec(const struct device *dev, uint32_t pin,
+					       uint64_t *timestamp, uint64_t *event_count)
+{
+	const struct tgpio_driver_api *api = (const struct tgpio_driver_api *)dev->api;
+
+	return api->read_ts_ec(dev, pin, timestamp, event_count);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_DRIVERS_MISC_TIMEAWARE_GPIO_TIMEAWARE_GPIO_INTERNAL_IMPL_H_ */

--- a/include/zephyr/drivers/misc/timeaware_gpio/timeaware_gpio.h
+++ b/include/zephyr/drivers/misc/timeaware_gpio/timeaware_gpio.h
@@ -75,13 +75,6 @@ __subsystem struct tgpio_driver_api {
  */
 __syscall int tgpio_port_get_time(const struct device *dev, uint64_t *current_time);
 
-static inline int z_impl_tgpio_port_get_time(const struct device *dev, uint64_t *current_time)
-{
-	const struct tgpio_driver_api *api = (const struct tgpio_driver_api *)dev->api;
-
-	return api->get_time(dev, current_time);
-}
-
 /**
  * @brief Get current running rate
  *
@@ -92,14 +85,6 @@ static inline int z_impl_tgpio_port_get_time(const struct device *dev, uint64_t 
  */
 __syscall int tgpio_port_get_cycles_per_second(const struct device *dev, uint32_t *cycles);
 
-static inline int z_impl_tgpio_port_get_cycles_per_second(const struct device *dev,
-							   uint32_t *cycles)
-{
-	const struct tgpio_driver_api *api = (const struct tgpio_driver_api *)dev->api;
-
-	return api->cyc_per_sec(dev, cycles);
-}
-
 /**
  * @brief Disable operation on pin
  *
@@ -109,13 +94,6 @@ static inline int z_impl_tgpio_port_get_cycles_per_second(const struct device *d
  * @return 0 if successful, negative errno code on failure.
  */
 __syscall int tgpio_pin_disable(const struct device *dev, uint32_t pin);
-
-static inline int z_impl_tgpio_pin_disable(const struct device *dev, uint32_t pin)
-{
-	const struct tgpio_driver_api *api = (const struct tgpio_driver_api *)dev->api;
-
-	return api->pin_disable(dev, pin);
-}
 
 /**
  * @brief Enable/Continue operation on pin
@@ -128,14 +106,6 @@ static inline int z_impl_tgpio_pin_disable(const struct device *dev, uint32_t pi
  */
 __syscall int tgpio_pin_config_ext_timestamp(const struct device *dev, uint32_t pin,
 					      uint32_t event_polarity);
-
-static inline int z_impl_tgpio_pin_config_ext_timestamp(const struct device *dev, uint32_t pin,
-							 uint32_t event_polarity)
-{
-	const struct tgpio_driver_api *api = (const struct tgpio_driver_api *)dev->api;
-
-	return api->config_ext_ts(dev, pin, event_polarity);
-}
 
 /**
  * @brief Enable periodic pulse generation on a pin
@@ -152,15 +122,6 @@ __syscall int tgpio_pin_periodic_output(const struct device *dev, uint32_t pin,
 					 uint64_t start_time, uint64_t repeat_interval,
 					 bool periodic_enable);
 
-static inline int z_impl_tgpio_pin_periodic_output(const struct device *dev, uint32_t pin,
-						    uint64_t start_time, uint64_t repeat_interval,
-						    bool periodic_enable)
-{
-	const struct tgpio_driver_api *api = (const struct tgpio_driver_api *)dev->api;
-
-	return api->set_perout(dev, pin, start_time, repeat_interval, periodic_enable);
-}
-
 /**
  * @brief Read timestamp and event counter from TGPIO
  *
@@ -174,14 +135,6 @@ static inline int z_impl_tgpio_pin_periodic_output(const struct device *dev, uin
 __syscall int tgpio_pin_read_ts_ec(const struct device *dev, uint32_t pin, uint64_t *timestamp,
 				    uint64_t *event_count);
 
-static inline int z_impl_tgpio_pin_read_ts_ec(const struct device *dev, uint32_t pin,
-					       uint64_t *timestamp, uint64_t *event_count)
-{
-	const struct tgpio_driver_api *api = (const struct tgpio_driver_api *)dev->api;
-
-	return api->read_ts_ec(dev, pin, timestamp, event_count);
-}
-
 /**
  * @}
  */
@@ -190,6 +143,7 @@ static inline int z_impl_tgpio_pin_read_ts_ec(const struct device *dev, uint32_t
 }
 #endif
 
+#include <zephyr/drivers/misc/timeaware_gpio/internal/timeaware_gpio_impl.h>
 #include <zephyr/syscalls/timeaware_gpio.h>
 
 #endif /* ZEPHYR_DRIVERS_MISC_TIMEAWARE_GPIO_TIMEAWARE_GPIO */

--- a/include/zephyr/drivers/mspi.h
+++ b/include/zephyr/drivers/mspi.h
@@ -538,13 +538,6 @@ __subsystem struct mspi_driver_api {
  */
 __syscall int mspi_config(const struct mspi_dt_spec *spec);
 
-static inline int z_impl_mspi_config(const struct mspi_dt_spec *spec)
-{
-	const struct mspi_driver_api *api = (const struct mspi_driver_api *)spec->bus->api;
-
-	return api->config(spec);
-}
-
 /**
  * @brief Configure a MSPI controller with device specific parameters.
  *
@@ -577,16 +570,6 @@ __syscall int mspi_dev_config(const struct device *controller,
 			      const enum mspi_dev_cfg_mask param_mask,
 			      const struct mspi_dev_cfg *cfg);
 
-static inline int z_impl_mspi_dev_config(const struct device *controller,
-					 const struct mspi_dev_id *dev_id,
-					 const enum mspi_dev_cfg_mask param_mask,
-					 const struct mspi_dev_cfg *cfg)
-{
-	const struct mspi_driver_api *api = (const struct mspi_driver_api *)controller->api;
-
-	return api->dev_config(controller, dev_id, param_mask, cfg);
-}
-
 /**
  * @brief Query to see if it a channel is ready.
  *
@@ -599,13 +582,6 @@ static inline int z_impl_mspi_dev_config(const struct device *controller,
  * @retval 0 If MSPI channel is ready.
  */
 __syscall int mspi_get_channel_status(const struct device *controller, uint8_t ch);
-
-static inline int z_impl_mspi_get_channel_status(const struct device *controller, uint8_t ch)
-{
-	const struct mspi_driver_api *api = (const struct mspi_driver_api *)controller->api;
-
-	return api->get_channel_status(controller, ch);
-}
 
 /** @} */
 
@@ -642,19 +618,6 @@ __syscall int mspi_transceive(const struct device *controller,
 			      const struct mspi_dev_id *dev_id,
 			      const struct mspi_xfer *req);
 
-static inline int z_impl_mspi_transceive(const struct device *controller,
-					 const struct mspi_dev_id *dev_id,
-					 const struct mspi_xfer *req)
-{
-	const struct mspi_driver_api *api = (const struct mspi_driver_api *)controller->api;
-
-	if (!api->transceive) {
-		return -ENOTSUP;
-	}
-
-	return api->transceive(controller, dev_id, req);
-}
-
 /** @} */
 
 /**
@@ -680,19 +643,6 @@ __syscall int mspi_xip_config(const struct device *controller,
 			      const struct mspi_dev_id *dev_id,
 			      const struct mspi_xip_cfg *cfg);
 
-static inline int z_impl_mspi_xip_config(const struct device *controller,
-					 const struct mspi_dev_id *dev_id,
-					 const struct mspi_xip_cfg *cfg)
-{
-	const struct mspi_driver_api *api = (const struct mspi_driver_api *)controller->api;
-
-	if (!api->xip_config) {
-		return -ENOTSUP;
-	}
-
-	return api->xip_config(controller, dev_id, cfg);
-}
-
 /**
  * @brief Configure a MSPI scrambling settings.
  *
@@ -711,19 +661,6 @@ static inline int z_impl_mspi_xip_config(const struct device *controller,
 __syscall int mspi_scramble_config(const struct device *controller,
 				   const struct mspi_dev_id *dev_id,
 				   const struct mspi_scramble_cfg *cfg);
-
-static inline int z_impl_mspi_scramble_config(const struct device *controller,
-					      const struct mspi_dev_id *dev_id,
-					      const struct mspi_scramble_cfg *cfg)
-{
-	const struct mspi_driver_api *api = (const struct mspi_driver_api *)controller->api;
-
-	if (!api->scramble_config) {
-		return -ENOTSUP;
-	}
-
-	return api->scramble_config(controller, dev_id, cfg);
-}
 
 /**
  * @brief Configure a MSPI timing settings.
@@ -744,19 +681,6 @@ static inline int z_impl_mspi_scramble_config(const struct device *controller,
 __syscall int mspi_timing_config(const struct device *controller,
 				 const struct mspi_dev_id *dev_id,
 				 const uint32_t param_mask, void *cfg);
-
-static inline int z_impl_mspi_timing_config(const struct device *controller,
-					    const struct mspi_dev_id *dev_id,
-					    const uint32_t param_mask, void *cfg)
-{
-	const struct mspi_driver_api *api = (const struct mspi_driver_api *)controller->api;
-
-	if (!api->timing_config) {
-		return -ENOTSUP;
-	}
-
-	return api->timing_config(controller, dev_id, param_mask, cfg);
-}
 
 /** @} */
 
@@ -806,5 +730,6 @@ static inline int mspi_register_callback(const struct device *controller,
 /**
  * @}
  */
+#include <zephyr/drivers/mspi/internal/mspi_impl.h>
 #include <zephyr/syscalls/mspi.h>
 #endif /* ZEPHYR_INCLUDE_MSPI_H_ */

--- a/include/zephyr/drivers/mspi/internal/mspi_impl.h
+++ b/include/zephyr/drivers/mspi/internal/mspi_impl.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2024, Ambiq Micro Inc. <www.ambiq.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Inline syscall implementation for MSPI driver APIs
+ */
+
+#ifndef ZEPHYR_INCLUDE_MSPI_H_
+#error "Should only be included by zephyr/drivers/mspi.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_MSPI_INTERNAL_MSPI_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_MSPI_INTERNAL_MSPI_IMPL_H_
+
+#include <errno.h>
+
+#include <zephyr/types.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_mspi_config(const struct mspi_dt_spec *spec)
+{
+	const struct mspi_driver_api *api = (const struct mspi_driver_api *)spec->bus->api;
+
+	return api->config(spec);
+}
+
+static inline int z_impl_mspi_dev_config(const struct device *controller,
+					 const struct mspi_dev_id *dev_id,
+					 const enum mspi_dev_cfg_mask param_mask,
+					 const struct mspi_dev_cfg *cfg)
+{
+	const struct mspi_driver_api *api = (const struct mspi_driver_api *)controller->api;
+
+	return api->dev_config(controller, dev_id, param_mask, cfg);
+}
+
+static inline int z_impl_mspi_get_channel_status(const struct device *controller, uint8_t ch)
+{
+	const struct mspi_driver_api *api = (const struct mspi_driver_api *)controller->api;
+
+	return api->get_channel_status(controller, ch);
+}
+
+static inline int z_impl_mspi_transceive(const struct device *controller,
+					 const struct mspi_dev_id *dev_id,
+					 const struct mspi_xfer *req)
+{
+	const struct mspi_driver_api *api = (const struct mspi_driver_api *)controller->api;
+
+	if (!api->transceive) {
+		return -ENOTSUP;
+	}
+
+	return api->transceive(controller, dev_id, req);
+}
+
+static inline int z_impl_mspi_xip_config(const struct device *controller,
+					 const struct mspi_dev_id *dev_id,
+					 const struct mspi_xip_cfg *cfg)
+{
+	const struct mspi_driver_api *api = (const struct mspi_driver_api *)controller->api;
+
+	if (!api->xip_config) {
+		return -ENOTSUP;
+	}
+
+	return api->xip_config(controller, dev_id, cfg);
+}
+
+static inline int z_impl_mspi_scramble_config(const struct device *controller,
+					      const struct mspi_dev_id *dev_id,
+					      const struct mspi_scramble_cfg *cfg)
+{
+	const struct mspi_driver_api *api = (const struct mspi_driver_api *)controller->api;
+
+	if (!api->scramble_config) {
+		return -ENOTSUP;
+	}
+
+	return api->scramble_config(controller, dev_id, cfg);
+}
+
+static inline int z_impl_mspi_timing_config(const struct device *controller,
+					    const struct mspi_dev_id *dev_id,
+					    const uint32_t param_mask, void *cfg)
+{
+	const struct mspi_driver_api *api = (const struct mspi_driver_api *)controller->api;
+
+	if (!api->timing_config) {
+		return -ENOTSUP;
+	}
+
+	return api->timing_config(controller, dev_id, param_mask, cfg);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_MSPI_INTERNAL_MSPI_IMPL_H_ */

--- a/include/zephyr/drivers/peci.h
+++ b/include/zephyr/drivers/peci.h
@@ -273,15 +273,6 @@ __subsystem struct peci_driver_api {
  */
 __syscall int peci_config(const struct device *dev, uint32_t bitrate);
 
-static inline int z_impl_peci_config(const struct device *dev,
-				     uint32_t bitrate)
-{
-	struct peci_driver_api *api;
-
-	api = (struct peci_driver_api *)dev->api;
-	return api->config(dev, bitrate);
-}
-
 /**
  * @brief Enable PECI interface.
  *
@@ -292,14 +283,6 @@ static inline int z_impl_peci_config(const struct device *dev,
  */
 __syscall int peci_enable(const struct device *dev);
 
-static inline int z_impl_peci_enable(const struct device *dev)
-{
-	struct peci_driver_api *api;
-
-	api = (struct peci_driver_api *)dev->api;
-	return api->enable(dev);
-}
-
 /**
  * @brief Disable PECI interface.
  *
@@ -309,14 +292,6 @@ static inline int z_impl_peci_enable(const struct device *dev)
  * @retval Negative errno code if failure.
  */
 __syscall int peci_disable(const struct device *dev);
-
-static inline int z_impl_peci_disable(const struct device *dev)
-{
-	struct peci_driver_api *api;
-
-	api = (struct peci_driver_api *)dev->api;
-	return api->disable(dev);
-}
 
 /**
  * @brief Performs a PECI transaction.
@@ -330,16 +305,6 @@ static inline int z_impl_peci_disable(const struct device *dev)
 
 __syscall int peci_transfer(const struct device *dev, struct peci_msg *msg);
 
-static inline int z_impl_peci_transfer(const struct device *dev,
-				       struct peci_msg *msg)
-{
-	struct peci_driver_api *api;
-
-	api = (struct peci_driver_api *)dev->api;
-	return api->transfer(dev, msg);
-}
-
-
 #ifdef __cplusplus
 }
 #endif
@@ -348,6 +313,7 @@ static inline int z_impl_peci_transfer(const struct device *dev,
  * @}
  */
 
+#include <zephyr/drivers/peci/internal/peci_impl.h>
 #include <zephyr/syscalls/peci.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_PECI_H_ */

--- a/include/zephyr/drivers/peci/internal/peci_impl.h
+++ b/include/zephyr/drivers/peci/internal/peci_impl.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2020 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Inline syscall implementation for PECI driver APIs
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_PECI_H_
+#error "Should only be included by zephyr/drivers/peci.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_PECI_INTERNAL_PECI_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_PECI_INTERNAL_PECI_IMPL_H_
+
+#include <errno.h>
+#include <zephyr/types.h>
+#include <stddef.h>
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_peci_config(const struct device *dev,
+				     uint32_t bitrate)
+{
+	struct peci_driver_api *api;
+
+	api = (struct peci_driver_api *)dev->api;
+	return api->config(dev, bitrate);
+}
+
+static inline int z_impl_peci_enable(const struct device *dev)
+{
+	struct peci_driver_api *api;
+
+	api = (struct peci_driver_api *)dev->api;
+	return api->enable(dev);
+}
+
+static inline int z_impl_peci_disable(const struct device *dev)
+{
+	struct peci_driver_api *api;
+
+	api = (struct peci_driver_api *)dev->api;
+	return api->disable(dev);
+}
+
+static inline int z_impl_peci_transfer(const struct device *dev,
+				       struct peci_msg *msg)
+{
+	struct peci_driver_api *api;
+
+	api = (struct peci_driver_api *)dev->api;
+	return api->transfer(dev, msg);
+}
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_PECI_INTERNAL_PECI_IMPL_H_ */

--- a/include/zephyr/drivers/ps2.h
+++ b/include/zephyr/drivers/ps2.h
@@ -76,15 +76,6 @@ __subsystem struct ps2_driver_api {
 __syscall int ps2_config(const struct device *dev,
 			 ps2_callback_t callback_isr);
 
-static inline int z_impl_ps2_config(const struct device *dev,
-				    ps2_callback_t callback_isr)
-{
-	const struct ps2_driver_api *api =
-				(struct ps2_driver_api *)dev->api;
-
-	return api->config(dev, callback_isr);
-}
-
 /**
  * @brief Write to PS/2 device.
  *
@@ -96,14 +87,6 @@ static inline int z_impl_ps2_config(const struct device *dev,
  */
 __syscall int ps2_write(const struct device *dev, uint8_t value);
 
-static inline int z_impl_ps2_write(const struct device *dev, uint8_t value)
-{
-	const struct ps2_driver_api *api =
-			(const struct ps2_driver_api *)dev->api;
-
-	return api->write(dev, value);
-}
-
 /**
  * @brief Read slave-to-host values from PS/2 device.
  * @param dev Pointer to the device structure for the driver instance.
@@ -114,14 +97,6 @@ static inline int z_impl_ps2_write(const struct device *dev, uint8_t value)
  */
 __syscall int ps2_read(const struct device *dev,  uint8_t *value);
 
-static inline int z_impl_ps2_read(const struct device *dev, uint8_t *value)
-{
-	const struct ps2_driver_api *api =
-			(const struct ps2_driver_api *)dev->api;
-
-	return api->read(dev, value);
-}
-
 /**
  * @brief Enables callback.
  * @param dev Pointer to the device structure for the driver instance.
@@ -130,18 +105,6 @@ static inline int z_impl_ps2_read(const struct device *dev, uint8_t *value)
  * @retval Negative errno code if failure.
  */
 __syscall int ps2_enable_callback(const struct device *dev);
-
-static inline int z_impl_ps2_enable_callback(const struct device *dev)
-{
-	const struct ps2_driver_api *api =
-			(const struct ps2_driver_api *)dev->api;
-
-	if (api->enable_callback == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->enable_callback(dev);
-}
 
 /**
  * @brief Disables callback.
@@ -152,18 +115,6 @@ static inline int z_impl_ps2_enable_callback(const struct device *dev)
  */
 __syscall int ps2_disable_callback(const struct device *dev);
 
-static inline int z_impl_ps2_disable_callback(const struct device *dev)
-{
-	const struct ps2_driver_api *api =
-			(const struct ps2_driver_api *)dev->api;
-
-	if (api->disable_callback == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->disable_callback(dev);
-}
-
 #ifdef __cplusplus
 }
 #endif
@@ -172,6 +123,7 @@ static inline int z_impl_ps2_disable_callback(const struct device *dev)
  * @}
  */
 
+#include <zephyr/drivers/ps2/internal/ps2_impl.h>
 #include <zephyr/syscalls/ps2.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_PS2_H_ */

--- a/include/zephyr/drivers/ps2/internal/ps2_impl.h
+++ b/include/zephyr/drivers/ps2/internal/ps2_impl.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Inline syscall implementation for PS2 APIs.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_PS2_H_
+#error "Should only be included by zephyr/drivers/ps2.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_PS2_INTERNAL_PS2_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_PS2_INTERNAL_PS2_IMPL_H_
+
+#include <errno.h>
+#include <zephyr/types.h>
+#include <stddef.h>
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_ps2_config(const struct device *dev,
+				    ps2_callback_t callback_isr)
+{
+	const struct ps2_driver_api *api =
+				(struct ps2_driver_api *)dev->api;
+
+	return api->config(dev, callback_isr);
+}
+
+static inline int z_impl_ps2_write(const struct device *dev, uint8_t value)
+{
+	const struct ps2_driver_api *api =
+			(const struct ps2_driver_api *)dev->api;
+
+	return api->write(dev, value);
+}
+
+static inline int z_impl_ps2_read(const struct device *dev, uint8_t *value)
+{
+	const struct ps2_driver_api *api =
+			(const struct ps2_driver_api *)dev->api;
+
+	return api->read(dev, value);
+}
+
+static inline int z_impl_ps2_enable_callback(const struct device *dev)
+{
+	const struct ps2_driver_api *api =
+			(const struct ps2_driver_api *)dev->api;
+
+	if (api->enable_callback == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->enable_callback(dev);
+}
+
+static inline int z_impl_ps2_disable_callback(const struct device *dev)
+{
+	const struct ps2_driver_api *api =
+			(const struct ps2_driver_api *)dev->api;
+
+	if (api->disable_callback == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->disable_callback(dev);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_PS2_INTERNAL_PS2_IMPL_H_ */

--- a/include/zephyr/drivers/ptp_clock.h
+++ b/include/zephyr/drivers/ptp_clock.h
@@ -56,15 +56,6 @@ static inline int ptp_clock_set(const struct device *dev,
  */
 __syscall int ptp_clock_get(const struct device *dev, struct net_ptp_time *tm);
 
-static inline int z_impl_ptp_clock_get(const struct device *dev,
-				       struct net_ptp_time *tm)
-{
-	const struct ptp_clock_driver_api *api =
-		(const struct ptp_clock_driver_api *)dev->api;
-
-	return api->get(dev, tm);
-}
-
 /**
  * @brief Adjust the PTP clock time.
  *
@@ -101,6 +92,7 @@ static inline int ptp_clock_rate_adjust(const struct device *dev, double rate)
 }
 #endif
 
+#include <zephyr/drivers/ptp_clock/internal/ptp_clock_impl.h>
 #include <zephyr/syscalls/ptp_clock.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_PTP_CLOCK_H_ */

--- a/include/zephyr/drivers/ptp_clock/internal/ptp_clock_impl.h
+++ b/include/zephyr/drivers/ptp_clock/internal/ptp_clock_impl.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2018 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_PTP_CLOCK_H_
+#error "Should only be included by zephyr/drivers/ptp_clock.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_PTP_CLOCK_INTERNAL_PTP_CLOCK_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_PTP_CLOCK_INTERNAL_PTP_CLOCK_IMPL_H_
+
+#include <zephyr/kernel.h>
+#include <stdint.h>
+#include <zephyr/device.h>
+#include <zephyr/net/ptp_time.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_ptp_clock_get(const struct device *dev,
+				       struct net_ptp_time *tm)
+{
+	const struct ptp_clock_driver_api *api =
+		(const struct ptp_clock_driver_api *)dev->api;
+
+	return api->get(dev, tm);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_PTP_CLOCK_INTERNAL_PTP_CLOCK_IMPL_H_ */

--- a/include/zephyr/drivers/pwm.h
+++ b/include/zephyr/drivers/pwm.h
@@ -480,20 +480,6 @@ __syscall int pwm_set_cycles(const struct device *dev, uint32_t channel,
 			     uint32_t period, uint32_t pulse,
 			     pwm_flags_t flags);
 
-static inline int z_impl_pwm_set_cycles(const struct device *dev,
-					uint32_t channel, uint32_t period,
-					uint32_t pulse, pwm_flags_t flags)
-{
-	const struct pwm_driver_api *api =
-		(const struct pwm_driver_api *)dev->api;
-
-	if (pulse > period) {
-		return -EINVAL;
-	}
-
-	return api->set_cycles(dev, channel, period, pulse, flags);
-}
-
 /**
  * @brief Get the clock rate (cycles per second) for a single PWM output.
  *
@@ -507,16 +493,6 @@ static inline int z_impl_pwm_set_cycles(const struct device *dev,
  */
 __syscall int pwm_get_cycles_per_sec(const struct device *dev, uint32_t channel,
 				     uint64_t *cycles);
-
-static inline int z_impl_pwm_get_cycles_per_sec(const struct device *dev,
-						uint32_t channel,
-						uint64_t *cycles)
-{
-	const struct pwm_driver_api *api =
-		(const struct pwm_driver_api *)dev->api;
-
-	return api->get_cycles_per_sec(dev, channel, cycles);
-}
 
 /**
  * @brief Set the period and pulse width in nanoseconds for a single PWM output.
@@ -740,21 +716,6 @@ static inline int pwm_configure_capture(const struct device *dev,
  */
 __syscall int pwm_enable_capture(const struct device *dev, uint32_t channel);
 
-#ifdef CONFIG_PWM_CAPTURE
-static inline int z_impl_pwm_enable_capture(const struct device *dev,
-					    uint32_t channel)
-{
-	const struct pwm_driver_api *api =
-		(const struct pwm_driver_api *)dev->api;
-
-	if (api->enable_capture == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->enable_capture(dev, channel);
-}
-#endif /* CONFIG_PWM_CAPTURE */
-
 /**
  * @brief Disable PWM period/pulse width capture for a single PWM input.
  *
@@ -770,21 +731,6 @@ static inline int z_impl_pwm_enable_capture(const struct device *dev,
  * @retval -EIO if IO error occurred while disabling PWM capture
  */
 __syscall int pwm_disable_capture(const struct device *dev, uint32_t channel);
-
-#ifdef CONFIG_PWM_CAPTURE
-static inline int z_impl_pwm_disable_capture(const struct device *dev,
-					     uint32_t channel)
-{
-	const struct pwm_driver_api *api =
-		(const struct pwm_driver_api *)dev->api;
-
-	if (api->disable_capture == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->disable_capture(dev, channel);
-}
-#endif /* CONFIG_PWM_CAPTURE */
 
 /**
  * @brief Capture a single PWM period/pulse width in clock cycles for a single
@@ -948,6 +894,7 @@ static inline bool pwm_is_ready_dt(const struct pwm_dt_spec *spec)
  * @}
  */
 
+#include <zephyr/drivers/pwm/internal/pwm_impl.h>
 #include <zephyr/syscalls/pwm.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_PWM_H_ */

--- a/include/zephyr/drivers/pwm/internal/pwm_impl.h
+++ b/include/zephyr/drivers/pwm/internal/pwm_impl.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2016 Intel Corporation.
+ * Copyright (c) 2020-2021 Vestas Wind Systems A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Inline syscall implementations of PWM Driver APIs
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_PWM_H_
+#error "Should only be included by zephyr/drivers/pwm.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_PWM_INTERNAL_PWM_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_PWM_INTERNAL_PWM_IMPL_H_
+
+#include <errno.h>
+#include <stdint.h>
+
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_pwm_set_cycles(const struct device *dev,
+					uint32_t channel, uint32_t period,
+					uint32_t pulse, pwm_flags_t flags)
+{
+	const struct pwm_driver_api *api =
+		(const struct pwm_driver_api *)dev->api;
+
+	if (pulse > period) {
+		return -EINVAL;
+	}
+
+	return api->set_cycles(dev, channel, period, pulse, flags);
+}
+
+static inline int z_impl_pwm_get_cycles_per_sec(const struct device *dev,
+						uint32_t channel,
+						uint64_t *cycles)
+{
+	const struct pwm_driver_api *api =
+		(const struct pwm_driver_api *)dev->api;
+
+	return api->get_cycles_per_sec(dev, channel, cycles);
+}
+
+#ifdef CONFIG_PWM_CAPTURE
+static inline int z_impl_pwm_enable_capture(const struct device *dev,
+					    uint32_t channel)
+{
+	const struct pwm_driver_api *api =
+		(const struct pwm_driver_api *)dev->api;
+
+	if (api->enable_capture == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->enable_capture(dev, channel);
+}
+#endif /* CONFIG_PWM_CAPTURE */
+
+#ifdef CONFIG_PWM_CAPTURE
+static inline int z_impl_pwm_disable_capture(const struct device *dev,
+					     uint32_t channel)
+{
+	const struct pwm_driver_api *api =
+		(const struct pwm_driver_api *)dev->api;
+
+	if (api->disable_capture == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->disable_capture(dev, channel);
+}
+#endif /* CONFIG_PWM_CAPTURE */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_PWM_INTERNAL_PWM_IMPL_H_ */

--- a/include/zephyr/drivers/reset.h
+++ b/include/zephyr/drivers/reset.h
@@ -223,17 +223,6 @@ __subsystem struct reset_driver_api {
  */
 __syscall int reset_status(const struct device *dev, uint32_t id, uint8_t *status);
 
-static inline int z_impl_reset_status(const struct device *dev, uint32_t id, uint8_t *status)
-{
-	const struct reset_driver_api *api = (const struct reset_driver_api *)dev->api;
-
-	if (api->status == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->status(dev, id, status);
-}
-
 /**
  * @brief Get the reset status from a @p reset_dt_spec.
  *
@@ -266,17 +255,6 @@ static inline int reset_status_dt(const struct reset_dt_spec *spec, uint8_t *sta
  */
 __syscall int reset_line_assert(const struct device *dev, uint32_t id);
 
-static inline int z_impl_reset_line_assert(const struct device *dev, uint32_t id)
-{
-	const struct reset_driver_api *api = (const struct reset_driver_api *)dev->api;
-
-	if (api->line_assert == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->line_assert(dev, id);
-}
-
 /**
  * @brief Assert the reset state from a @p reset_dt_spec.
  *
@@ -308,17 +286,6 @@ static inline int reset_line_assert_dt(const struct reset_dt_spec *spec)
  */
 __syscall int reset_line_deassert(const struct device *dev, uint32_t id);
 
-static inline int z_impl_reset_line_deassert(const struct device *dev, uint32_t id)
-{
-	const struct reset_driver_api *api = (const struct reset_driver_api *)dev->api;
-
-	if (api->line_deassert == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->line_deassert(dev, id);
-}
-
 /**
  * @brief Deassert the reset state from a @p reset_dt_spec.
  *
@@ -349,17 +316,6 @@ static inline int reset_line_deassert_dt(const struct reset_dt_spec *spec)
  */
 __syscall int reset_line_toggle(const struct device *dev, uint32_t id);
 
-static inline int z_impl_reset_line_toggle(const struct device *dev, uint32_t id)
-{
-	const struct reset_driver_api *api = (const struct reset_driver_api *)dev->api;
-
-	if (api->line_toggle == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->line_toggle(dev, id);
-}
-
 /**
  * @brief Reset the device from a @p reset_dt_spec.
  *
@@ -384,6 +340,7 @@ static inline int reset_line_toggle_dt(const struct reset_dt_spec *spec)
 }
 #endif
 
+#include <zephyr/drivers/reset/internal/reset_impl.h>
 #include <zephyr/syscalls/reset.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_RESET_H_ */

--- a/include/zephyr/drivers/reset/internal/reset_impl.h
+++ b/include/zephyr/drivers/reset/internal/reset_impl.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2022 Andrei-Edward Popa <andrei.popa105@yahoo.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Inline syscall implementation for Reset Controller driver APIs
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_RESET_H_
+#error "Should only be included by zephyr/drivers/reset.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_RESET_INTERNAL_RESET_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_RESET_INTERNAL_RESET_IMPL_H_
+
+#include <errno.h>
+
+#include <zephyr/types.h>
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_reset_status(const struct device *dev, uint32_t id, uint8_t *status)
+{
+	const struct reset_driver_api *api = (const struct reset_driver_api *)dev->api;
+
+	if (api->status == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->status(dev, id, status);
+}
+
+static inline int z_impl_reset_line_assert(const struct device *dev, uint32_t id)
+{
+	const struct reset_driver_api *api = (const struct reset_driver_api *)dev->api;
+
+	if (api->line_assert == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->line_assert(dev, id);
+}
+
+static inline int z_impl_reset_line_deassert(const struct device *dev, uint32_t id)
+{
+	const struct reset_driver_api *api = (const struct reset_driver_api *)dev->api;
+
+	if (api->line_deassert == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->line_deassert(dev, id);
+}
+
+static inline int z_impl_reset_line_toggle(const struct device *dev, uint32_t id)
+{
+	const struct reset_driver_api *api = (const struct reset_driver_api *)dev->api;
+
+	if (api->line_toggle == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->line_toggle(dev, id);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_RESET_INTERNAL_RESET_IMPL_H_ */

--- a/include/zephyr/drivers/retained_mem.h
+++ b/include/zephyr/drivers/retained_mem.h
@@ -94,13 +94,6 @@ __subsystem struct retained_mem_driver_api {
  */
 __syscall ssize_t retained_mem_size(const struct device *dev);
 
-static inline ssize_t z_impl_retained_mem_size(const struct device *dev)
-{
-	struct retained_mem_driver_api *api = (struct retained_mem_driver_api *)dev->api;
-
-	return api->size(dev);
-}
-
 /**
  * @brief		Reads data from the Retained memory area.
  *
@@ -113,26 +106,6 @@ static inline ssize_t z_impl_retained_mem_size(const struct device *dev)
  */
 __syscall int retained_mem_read(const struct device *dev, off_t offset, uint8_t *buffer,
 				size_t size);
-
-static inline int z_impl_retained_mem_read(const struct device *dev, off_t offset,
-					   uint8_t *buffer, size_t size)
-{
-	struct retained_mem_driver_api *api = (struct retained_mem_driver_api *)dev->api;
-	size_t area_size;
-
-	/* Validate user-supplied parameters */
-	if (size == 0) {
-		return 0;
-	}
-
-	area_size = api->size(dev);
-
-	if (offset < 0 || size > area_size || (area_size - size) < (size_t)offset) {
-		return -EINVAL;
-	}
-
-	return api->read(dev, offset, buffer, size);
-}
 
 /**
  * @brief		Writes data to the Retained memory area - underlying data does not need to
@@ -148,26 +121,6 @@ static inline int z_impl_retained_mem_read(const struct device *dev, off_t offse
 __syscall int retained_mem_write(const struct device *dev, off_t offset, const uint8_t *buffer,
 				 size_t size);
 
-static inline int z_impl_retained_mem_write(const struct device *dev, off_t offset,
-					    const uint8_t *buffer, size_t size)
-{
-	struct retained_mem_driver_api *api = (struct retained_mem_driver_api *)dev->api;
-	size_t area_size;
-
-	/* Validate user-supplied parameters */
-	if (size == 0) {
-		return 0;
-	}
-
-	area_size = api->size(dev);
-
-	if (offset < 0 || size > area_size || (area_size - size) < (size_t)offset) {
-		return -EINVAL;
-	}
-
-	return api->write(dev, offset, buffer, size);
-}
-
 /**
  * @brief		Clears data in the retained memory area by setting it to 0x00.
  *
@@ -177,13 +130,6 @@ static inline int z_impl_retained_mem_write(const struct device *dev, off_t offs
  */
 __syscall int retained_mem_clear(const struct device *dev);
 
-static inline int z_impl_retained_mem_clear(const struct device *dev)
-{
-	struct retained_mem_driver_api *api = (struct retained_mem_driver_api *)dev->api;
-
-	return api->clear(dev);
-}
-
 /**
  * @}
  */
@@ -192,6 +138,7 @@ static inline int z_impl_retained_mem_clear(const struct device *dev)
 }
 #endif
 
+#include <zephyr/drivers/retained_mem/internal/retained_mem_impl.h>
 #include <zephyr/syscalls/retained_mem.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_RETAINED_MEM_ */

--- a/include/zephyr/drivers/retained_mem/internal/retained_mem_impl.h
+++ b/include/zephyr/drivers/retained_mem/internal/retained_mem_impl.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Inline syscall implementation for retained memory driver APIs
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_RETAINED_MEM_
+#error "Should only be included by zephyr/drivers/retained_mem.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_RETAINED_MEM_INTERNAL_RETAINED_MEM_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_RETAINED_MEM_INTERNAL_RETAINED_MEM_IMPL_H_
+
+#include <errno.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <sys/types.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline ssize_t z_impl_retained_mem_size(const struct device *dev)
+{
+	struct retained_mem_driver_api *api = (struct retained_mem_driver_api *)dev->api;
+
+	return api->size(dev);
+}
+
+static inline int z_impl_retained_mem_read(const struct device *dev, off_t offset,
+					   uint8_t *buffer, size_t size)
+{
+	struct retained_mem_driver_api *api = (struct retained_mem_driver_api *)dev->api;
+	size_t area_size;
+
+	/* Validate user-supplied parameters */
+	if (size == 0) {
+		return 0;
+	}
+
+	area_size = api->size(dev);
+
+	if (offset < 0 || size > area_size || (area_size - size) < (size_t)offset) {
+		return -EINVAL;
+	}
+
+	return api->read(dev, offset, buffer, size);
+}
+
+static inline int z_impl_retained_mem_write(const struct device *dev, off_t offset,
+					    const uint8_t *buffer, size_t size)
+{
+	struct retained_mem_driver_api *api = (struct retained_mem_driver_api *)dev->api;
+	size_t area_size;
+
+	/* Validate user-supplied parameters */
+	if (size == 0) {
+		return 0;
+	}
+
+	area_size = api->size(dev);
+
+	if (offset < 0 || size > area_size || (area_size - size) < (size_t)offset) {
+		return -EINVAL;
+	}
+
+	return api->write(dev, offset, buffer, size);
+}
+
+static inline int z_impl_retained_mem_clear(const struct device *dev)
+{
+	struct retained_mem_driver_api *api = (struct retained_mem_driver_api *)dev->api;
+
+	return api->clear(dev);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_RETAINED_MEM_INTERNAL_RETAINED_MEM_IMPL_H_ */

--- a/include/zephyr/drivers/rtc.h
+++ b/include/zephyr/drivers/rtc.h
@@ -197,13 +197,6 @@ __subsystem struct rtc_driver_api {
  */
 __syscall int rtc_set_time(const struct device *dev, const struct rtc_time *timeptr);
 
-static inline int z_impl_rtc_set_time(const struct device *dev, const struct rtc_time *timeptr)
-{
-	const struct rtc_driver_api *api = (const struct rtc_driver_api *)dev->api;
-
-	return api->set_time(dev, timeptr);
-}
-
 /**
  * @brief API for getting RTC time.
  *
@@ -215,13 +208,6 @@ static inline int z_impl_rtc_set_time(const struct device *dev, const struct rtc
  * @return -errno code if failure
  */
 __syscall int rtc_get_time(const struct device *dev, struct rtc_time *timeptr);
-
-static inline int z_impl_rtc_get_time(const struct device *dev, struct rtc_time *timeptr)
-{
-	const struct rtc_driver_api *api = (const struct rtc_driver_api *)dev->api;
-
-	return api->get_time(dev, timeptr);
-}
 
 /**
  * @name RTC Interface Alarm
@@ -245,18 +231,6 @@ static inline int z_impl_rtc_get_time(const struct device *dev, struct rtc_time 
  */
 __syscall int rtc_alarm_get_supported_fields(const struct device *dev, uint16_t id,
 					     uint16_t *mask);
-
-static inline int z_impl_rtc_alarm_get_supported_fields(const struct device *dev, uint16_t id,
-							uint16_t *mask)
-{
-	const struct rtc_driver_api *api = (const struct rtc_driver_api *)dev->api;
-
-	if (api->alarm_get_supported_fields == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->alarm_get_supported_fields(dev, id, mask);
-}
 
 /**
  * @brief API for setting RTC alarm time.
@@ -284,18 +258,6 @@ static inline int z_impl_rtc_alarm_get_supported_fields(const struct device *dev
 __syscall int rtc_alarm_set_time(const struct device *dev, uint16_t id, uint16_t mask,
 				 const struct rtc_time *timeptr);
 
-static inline int z_impl_rtc_alarm_set_time(const struct device *dev, uint16_t id, uint16_t mask,
-					    const struct rtc_time *timeptr)
-{
-	const struct rtc_driver_api *api = (const struct rtc_driver_api *)dev->api;
-
-	if (api->alarm_set_time == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->alarm_set_time(dev, id, mask, timeptr);
-}
-
 /**
  * @brief API for getting RTC alarm time.
  *
@@ -314,18 +276,6 @@ static inline int z_impl_rtc_alarm_set_time(const struct device *dev, uint16_t i
 __syscall int rtc_alarm_get_time(const struct device *dev, uint16_t id, uint16_t *mask,
 				 struct rtc_time *timeptr);
 
-static inline int z_impl_rtc_alarm_get_time(const struct device *dev, uint16_t id, uint16_t *mask,
-					    struct rtc_time *timeptr)
-{
-	const struct rtc_driver_api *api = (const struct rtc_driver_api *)dev->api;
-
-	if (api->alarm_get_time == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->alarm_get_time(dev, id, mask, timeptr);
-}
-
 /**
  * @brief API for testing if RTC alarm is pending.
  *
@@ -342,17 +292,6 @@ static inline int z_impl_rtc_alarm_get_time(const struct device *dev, uint16_t i
  * @return -errno code if failure
  */
 __syscall int rtc_alarm_is_pending(const struct device *dev, uint16_t id);
-
-static inline int z_impl_rtc_alarm_is_pending(const struct device *dev, uint16_t id)
-{
-	const struct rtc_driver_api *api = (const struct rtc_driver_api *)dev->api;
-
-	if (api->alarm_is_pending == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->alarm_is_pending(dev, id);
-}
 
 /**
  * @brief API for setting alarm callback.
@@ -382,18 +321,6 @@ static inline int z_impl_rtc_alarm_is_pending(const struct device *dev, uint16_t
  */
 __syscall int rtc_alarm_set_callback(const struct device *dev, uint16_t id,
 				     rtc_alarm_callback callback, void *user_data);
-
-static inline int z_impl_rtc_alarm_set_callback(const struct device *dev, uint16_t id,
-						rtc_alarm_callback callback, void *user_data)
-{
-	const struct rtc_driver_api *api = (const struct rtc_driver_api *)dev->api;
-
-	if (api->alarm_set_callback == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->alarm_set_callback(dev, id, callback, user_data);
-}
 
 #endif /* CONFIG_RTC_ALARM */
 /**
@@ -428,18 +355,6 @@ static inline int z_impl_rtc_alarm_set_callback(const struct device *dev, uint16
 __syscall int rtc_update_set_callback(const struct device *dev, rtc_update_callback callback,
 				      void *user_data);
 
-static inline int z_impl_rtc_update_set_callback(const struct device *dev,
-						 rtc_update_callback callback, void *user_data)
-{
-	const struct rtc_driver_api *api = (const struct rtc_driver_api *)dev->api;
-
-	if (api->update_set_callback == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->update_set_callback(dev, callback, user_data);
-}
-
 #endif /* CONFIG_RTC_UPDATE */
 /**
  * @}
@@ -471,17 +386,6 @@ static inline int z_impl_rtc_update_set_callback(const struct device *dev,
  */
 __syscall int rtc_set_calibration(const struct device *dev, int32_t calibration);
 
-static inline int z_impl_rtc_set_calibration(const struct device *dev, int32_t calibration)
-{
-	const struct rtc_driver_api *api = (const struct rtc_driver_api *)dev->api;
-
-	if (api->set_calibration == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->set_calibration(dev, calibration);
-}
-
 /**
  * @brief API for getting RTC calibration.
  *
@@ -493,17 +397,6 @@ static inline int z_impl_rtc_set_calibration(const struct device *dev, int32_t c
  * @return -errno code if failure
  */
 __syscall int rtc_get_calibration(const struct device *dev, int32_t *calibration);
-
-static inline int z_impl_rtc_get_calibration(const struct device *dev, int32_t *calibration)
-{
-	const struct rtc_driver_api *api = (const struct rtc_driver_api *)dev->api;
-
-	if (api->get_calibration == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->get_calibration(dev, calibration);
-}
 
 #endif /* CONFIG_RTC_CALIBRATION */
 /**
@@ -555,6 +448,7 @@ static inline int32_t rtc_calibration_from_frequency(uint32_t frequency)
 }
 #endif
 
+#include <zephyr/drivers/rtc/internal/rtc_impl.h>
 #include <zephyr/syscalls/rtc.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_RTC_H_ */

--- a/include/zephyr/drivers/rtc/internal/rtc_impl.h
+++ b/include/zephyr/drivers/rtc/internal/rtc_impl.h
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2023 Trackunit Corporation
+ * Copyright (c) 2023 Bjarki Arge Andreasen
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file drivers/rtc.h
+ *
+ * @brief Inline syscall implementations for RTC (real time clock) API
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_RTC_H_
+#error "Should only be included by zephyr/drivers/rtc.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_RTC_INTERNAL_RTC_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_RTC_INTERNAL_RTC_IMPL_H_
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <errno.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_rtc_set_time(const struct device *dev, const struct rtc_time *timeptr)
+{
+	const struct rtc_driver_api *api = (const struct rtc_driver_api *)dev->api;
+
+	return api->set_time(dev, timeptr);
+}
+
+static inline int z_impl_rtc_get_time(const struct device *dev, struct rtc_time *timeptr)
+{
+	const struct rtc_driver_api *api = (const struct rtc_driver_api *)dev->api;
+
+	return api->get_time(dev, timeptr);
+}
+
+#if defined(CONFIG_RTC_ALARM)
+
+static inline int z_impl_rtc_alarm_get_supported_fields(const struct device *dev, uint16_t id,
+							uint16_t *mask)
+{
+	const struct rtc_driver_api *api = (const struct rtc_driver_api *)dev->api;
+
+	if (api->alarm_get_supported_fields == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->alarm_get_supported_fields(dev, id, mask);
+}
+
+static inline int z_impl_rtc_alarm_set_time(const struct device *dev, uint16_t id, uint16_t mask,
+					    const struct rtc_time *timeptr)
+{
+	const struct rtc_driver_api *api = (const struct rtc_driver_api *)dev->api;
+
+	if (api->alarm_set_time == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->alarm_set_time(dev, id, mask, timeptr);
+}
+
+static inline int z_impl_rtc_alarm_get_time(const struct device *dev, uint16_t id, uint16_t *mask,
+					    struct rtc_time *timeptr)
+{
+	const struct rtc_driver_api *api = (const struct rtc_driver_api *)dev->api;
+
+	if (api->alarm_get_time == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->alarm_get_time(dev, id, mask, timeptr);
+}
+
+static inline int z_impl_rtc_alarm_is_pending(const struct device *dev, uint16_t id)
+{
+	const struct rtc_driver_api *api = (const struct rtc_driver_api *)dev->api;
+
+	if (api->alarm_is_pending == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->alarm_is_pending(dev, id);
+}
+
+static inline int z_impl_rtc_alarm_set_callback(const struct device *dev, uint16_t id,
+						rtc_alarm_callback callback, void *user_data)
+{
+	const struct rtc_driver_api *api = (const struct rtc_driver_api *)dev->api;
+
+	if (api->alarm_set_callback == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->alarm_set_callback(dev, id, callback, user_data);
+}
+
+#endif /* CONFIG_RTC_ALARM */
+
+#if defined(CONFIG_RTC_UPDATE)
+
+static inline int z_impl_rtc_update_set_callback(const struct device *dev,
+						 rtc_update_callback callback, void *user_data)
+{
+	const struct rtc_driver_api *api = (const struct rtc_driver_api *)dev->api;
+
+	if (api->update_set_callback == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->update_set_callback(dev, callback, user_data);
+}
+
+#endif /* CONFIG_RTC_UPDATE */
+
+#if defined(CONFIG_RTC_CALIBRATION)
+
+static inline int z_impl_rtc_set_calibration(const struct device *dev, int32_t calibration)
+{
+	const struct rtc_driver_api *api = (const struct rtc_driver_api *)dev->api;
+
+	if (api->set_calibration == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->set_calibration(dev, calibration);
+}
+
+static inline int z_impl_rtc_get_calibration(const struct device *dev, int32_t *calibration)
+{
+	const struct rtc_driver_api *api = (const struct rtc_driver_api *)dev->api;
+
+	if (api->get_calibration == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->get_calibration(dev, calibration);
+}
+
+#endif /* CONFIG_RTC_CALIBRATION */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_RTC_INTERNAL_RTC_IMPL_H_ */

--- a/include/zephyr/drivers/sdhc.h
+++ b/include/zephyr/drivers/sdhc.h
@@ -287,18 +287,6 @@ __subsystem struct sdhc_driver_api {
  */
 __syscall int sdhc_hw_reset(const struct device *dev);
 
-static inline int z_impl_sdhc_hw_reset(const struct device *dev)
-{
-	const struct sdhc_driver_api *api = (const struct sdhc_driver_api *)dev->api;
-
-	if (!api->reset) {
-		return -ENOSYS;
-	}
-
-	return api->reset(dev);
-}
-
-
 /**
  * @brief Send command to SDHC
  *
@@ -315,19 +303,6 @@ static inline int z_impl_sdhc_hw_reset(const struct device *dev)
 __syscall int sdhc_request(const struct device *dev, struct sdhc_command *cmd,
 			   struct sdhc_data *data);
 
-static inline int z_impl_sdhc_request(const struct device *dev,
-				      struct sdhc_command *cmd,
-				      struct sdhc_data *data)
-{
-	const struct sdhc_driver_api *api = (const struct sdhc_driver_api *)dev->api;
-
-	if (!api->request) {
-		return -ENOSYS;
-	}
-
-	return api->request(dev, cmd, data);
-}
-
 /**
  * @brief set I/O properties of SDHC
  *
@@ -342,18 +317,6 @@ static inline int z_impl_sdhc_request(const struct device *dev,
  */
 __syscall int sdhc_set_io(const struct device *dev, struct sdhc_io *io);
 
-static inline int z_impl_sdhc_set_io(const struct device *dev,
-				     struct sdhc_io *io)
-{
-	const struct sdhc_driver_api *api = (const struct sdhc_driver_api *)dev->api;
-
-	if (!api->set_io) {
-		return -ENOSYS;
-	}
-
-	return api->set_io(dev, io);
-}
-
 /**
  * @brief check for SDHC card presence
  *
@@ -366,18 +329,6 @@ static inline int z_impl_sdhc_set_io(const struct device *dev,
  * @retval -EIO I/O error
  */
 __syscall int sdhc_card_present(const struct device *dev);
-
-static inline int z_impl_sdhc_card_present(const struct device *dev)
-{
-	const struct sdhc_driver_api *api = (const struct sdhc_driver_api *)dev->api;
-
-	if (!api->get_card_present) {
-		return -ENOSYS;
-	}
-
-	return api->get_card_present(dev);
-}
-
 
 /**
  * @brief run SDHC tuning
@@ -392,17 +343,6 @@ static inline int z_impl_sdhc_card_present(const struct device *dev)
  */
 __syscall int sdhc_execute_tuning(const struct device *dev);
 
-static inline int z_impl_sdhc_execute_tuning(const struct device *dev)
-{
-	const struct sdhc_driver_api *api = (const struct sdhc_driver_api *)dev->api;
-
-	if (!api->execute_tuning) {
-		return -ENOSYS;
-	}
-
-	return api->execute_tuning(dev);
-}
-
 /**
  * @brief check if SD card is busy
  *
@@ -416,18 +356,6 @@ static inline int z_impl_sdhc_execute_tuning(const struct device *dev)
  */
 __syscall int sdhc_card_busy(const struct device *dev);
 
-static inline int z_impl_sdhc_card_busy(const struct device *dev)
-{
-	const struct sdhc_driver_api *api = (const struct sdhc_driver_api *)dev->api;
-
-	if (!api->card_busy) {
-		return -ENOSYS;
-	}
-
-	return api->card_busy(dev);
-}
-
-
 /**
  * @brief Get SD host controller properties
  *
@@ -440,18 +368,6 @@ static inline int z_impl_sdhc_card_busy(const struct device *dev)
  */
 __syscall int sdhc_get_host_props(const struct device *dev,
 				  struct sdhc_host_props *props);
-
-static inline int z_impl_sdhc_get_host_props(const struct device *dev,
-					     struct sdhc_host_props *props)
-{
-	const struct sdhc_driver_api *api = (const struct sdhc_driver_api *)dev->api;
-
-	if (!api->get_host_props) {
-		return -ENOSYS;
-	}
-
-	return api->get_host_props(dev, props);
-}
 
 /**
  * @brief Enable SDHC interrupt sources.
@@ -472,19 +388,6 @@ __syscall int sdhc_enable_interrupt(const struct device *dev,
 				    sdhc_interrupt_cb_t callback,
 				    int sources, void *user_data);
 
-static inline int z_impl_sdhc_enable_interrupt(const struct device *dev,
-					       sdhc_interrupt_cb_t callback,
-					       int sources, void *user_data)
-{
-	const struct sdhc_driver_api *api = (const struct sdhc_driver_api *)dev->api;
-
-	if (!api->enable_interrupt) {
-		return -ENOSYS;
-	}
-
-	return api->enable_interrupt(dev, callback, sources, user_data);
-}
-
 /**
  * @brief Disable SDHC interrupt sources
  *
@@ -499,18 +402,6 @@ static inline int z_impl_sdhc_enable_interrupt(const struct device *dev,
  */
 __syscall int sdhc_disable_interrupt(const struct device *dev, int sources);
 
-static inline int z_impl_sdhc_disable_interrupt(const struct device *dev,
-						int sources)
-{
-	const struct sdhc_driver_api *api = (const struct sdhc_driver_api *)dev->api;
-
-	if (!api->disable_interrupt) {
-		return -ENOSYS;
-	}
-
-	return api->disable_interrupt(dev, sources);
-}
-
 /**
  * @}
  */
@@ -519,5 +410,6 @@ static inline int z_impl_sdhc_disable_interrupt(const struct device *dev,
 }
 #endif
 
+#include <zephyr/drivers/sdhc/internal/sdhc_impl.h>
 #include <zephyr/syscalls/sdhc.h>
 #endif /* ZEPHYR_INCLUDE_DRIVERS_SDHC_H_ */

--- a/include/zephyr/drivers/sdhc/internal/sdhc_impl.h
+++ b/include/zephyr/drivers/sdhc/internal/sdhc_impl.h
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2022 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Inline syscall implementation for SDHC driver APIs.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SDHC_H_
+#error "Should only be included by zephyr/drivers/sdhc.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SDHC_INTERNAL_SDHC_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_SDHC_INTERNAL_SDHC_IMPL_H_
+
+#include <errno.h>
+#include <zephyr/device.h>
+#include <zephyr/sd/sd_spec.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_sdhc_hw_reset(const struct device *dev)
+{
+	const struct sdhc_driver_api *api = (const struct sdhc_driver_api *)dev->api;
+
+	if (!api->reset) {
+		return -ENOSYS;
+	}
+
+	return api->reset(dev);
+}
+
+static inline int z_impl_sdhc_request(const struct device *dev,
+				      struct sdhc_command *cmd,
+				      struct sdhc_data *data)
+{
+	const struct sdhc_driver_api *api = (const struct sdhc_driver_api *)dev->api;
+
+	if (!api->request) {
+		return -ENOSYS;
+	}
+
+	return api->request(dev, cmd, data);
+}
+
+static inline int z_impl_sdhc_set_io(const struct device *dev,
+				     struct sdhc_io *io)
+{
+	const struct sdhc_driver_api *api = (const struct sdhc_driver_api *)dev->api;
+
+	if (!api->set_io) {
+		return -ENOSYS;
+	}
+
+	return api->set_io(dev, io);
+}
+
+static inline int z_impl_sdhc_card_present(const struct device *dev)
+{
+	const struct sdhc_driver_api *api = (const struct sdhc_driver_api *)dev->api;
+
+	if (!api->get_card_present) {
+		return -ENOSYS;
+	}
+
+	return api->get_card_present(dev);
+}
+
+static inline int z_impl_sdhc_execute_tuning(const struct device *dev)
+{
+	const struct sdhc_driver_api *api = (const struct sdhc_driver_api *)dev->api;
+
+	if (!api->execute_tuning) {
+		return -ENOSYS;
+	}
+
+	return api->execute_tuning(dev);
+}
+
+static inline int z_impl_sdhc_card_busy(const struct device *dev)
+{
+	const struct sdhc_driver_api *api = (const struct sdhc_driver_api *)dev->api;
+
+	if (!api->card_busy) {
+		return -ENOSYS;
+	}
+
+	return api->card_busy(dev);
+}
+
+static inline int z_impl_sdhc_get_host_props(const struct device *dev,
+					     struct sdhc_host_props *props)
+{
+	const struct sdhc_driver_api *api = (const struct sdhc_driver_api *)dev->api;
+
+	if (!api->get_host_props) {
+		return -ENOSYS;
+	}
+
+	return api->get_host_props(dev, props);
+}
+
+static inline int z_impl_sdhc_enable_interrupt(const struct device *dev,
+					       sdhc_interrupt_cb_t callback,
+					       int sources, void *user_data)
+{
+	const struct sdhc_driver_api *api = (const struct sdhc_driver_api *)dev->api;
+
+	if (!api->enable_interrupt) {
+		return -ENOSYS;
+	}
+
+	return api->enable_interrupt(dev, callback, sources, user_data);
+}
+
+static inline int z_impl_sdhc_disable_interrupt(const struct device *dev,
+						int sources)
+{
+	const struct sdhc_driver_api *api = (const struct sdhc_driver_api *)dev->api;
+
+	if (!api->disable_interrupt) {
+		return -ENOSYS;
+	}
+
+	return api->disable_interrupt(dev, sources);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SDHC_INTERNAL_SDHC_IMPL_H_ */

--- a/include/zephyr/drivers/sensor/internal/sensor_impl.h
+++ b/include/zephyr/drivers/sensor/internal/sensor_impl.h
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2016 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Inline syscall implementations for Sensor driver APIs.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_H_
+#error "Should only be included by zephyr/drivers/sensor.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_INTERNAL_SENSOR_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_SENSOR_INTERNAL_SENSOR_IMPL_H_
+
+#include <errno.h>
+#include <stdlib.h>
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor_data_types.h>
+#include <zephyr/dsp/types.h>
+#include <zephyr/rtio/rtio.h>
+#include <zephyr/sys/iterable_sections.h>
+#include <zephyr/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_sensor_attr_set(const struct device *dev,
+					 enum sensor_channel chan,
+					 enum sensor_attribute attr,
+					 const struct sensor_value *val)
+{
+	const struct sensor_driver_api *api =
+		(const struct sensor_driver_api *)dev->api;
+
+	if (api->attr_set == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->attr_set(dev, chan, attr, val);
+}
+
+static inline int z_impl_sensor_attr_get(const struct device *dev,
+					 enum sensor_channel chan,
+					 enum sensor_attribute attr,
+					 struct sensor_value *val)
+{
+	const struct sensor_driver_api *api =
+		(const struct sensor_driver_api *)dev->api;
+
+	if (api->attr_get == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->attr_get(dev, chan, attr, val);
+}
+
+static inline int z_impl_sensor_sample_fetch(const struct device *dev)
+{
+	const struct sensor_driver_api *api =
+		(const struct sensor_driver_api *)dev->api;
+
+	return api->sample_fetch(dev, SENSOR_CHAN_ALL);
+}
+
+static inline int z_impl_sensor_sample_fetch_chan(const struct device *dev,
+						  enum sensor_channel type)
+{
+	const struct sensor_driver_api *api =
+		(const struct sensor_driver_api *)dev->api;
+
+	return api->sample_fetch(dev, type);
+}
+
+static inline int z_impl_sensor_channel_get(const struct device *dev,
+					    enum sensor_channel chan,
+					    struct sensor_value *val)
+{
+	const struct sensor_driver_api *api =
+		(const struct sensor_driver_api *)dev->api;
+
+	return api->channel_get(dev, chan, val);
+}
+
+#if defined(CONFIG_SENSOR_ASYNC_API)
+
+static inline int z_impl_sensor_get_decoder(const struct device *dev,
+					    const struct sensor_decoder_api **decoder)
+{
+	const struct sensor_driver_api *api = (const struct sensor_driver_api *)dev->api;
+
+	__ASSERT_NO_MSG(api != NULL);
+
+	if (api->get_decoder == NULL) {
+		*decoder = &__sensor_default_decoder;
+		return 0;
+	}
+
+	return api->get_decoder(dev, decoder);
+}
+
+static inline int z_impl_sensor_reconfigure_read_iodev(struct rtio_iodev *iodev,
+						       const struct device *sensor,
+						       const struct sensor_chan_spec *channels,
+						       size_t num_channels)
+{
+	struct sensor_read_config *cfg = (struct sensor_read_config *)iodev->data;
+
+	if (cfg->max < num_channels || cfg->is_streaming) {
+		return -ENOMEM;
+	}
+
+	cfg->sensor = sensor;
+	memcpy(cfg->channels, channels, num_channels * sizeof(struct sensor_chan_spec));
+	cfg->count = num_channels;
+	return 0;
+}
+
+#endif /* defined(CONFIG_SENSOR_ASYNC_API) */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_INTERNAL_SENSOR_API_H_ */

--- a/include/zephyr/drivers/sip_svc/internal/sip_svc_driver_impl.h
+++ b/include/zephyr/drivers/sip_svc/internal/sip_svc_driver_impl.h
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2023, Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_SIP_SVC_DRIVER_H_
+#error "Should only be included by zephyr/drivers/sip_svc/sip_svc_driver.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SIP_SVC_DRIVER_INTERNAL_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_SIP_SVC_DRIVER_INTERNAL_IMPL_H_
+
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/arch/arm64/arm-smccc.h>
+#include <zephyr/drivers/sip_svc/sip_svc_proto.h>
+#include <zephyr/sip_svc/sip_svc_controller.h>
+
+static inline void z_impl_sip_supervisory_call(const struct device *dev, unsigned long function_id,
+					       unsigned long arg0, unsigned long arg1,
+					       unsigned long arg2, unsigned long arg3,
+					       unsigned long arg4, unsigned long arg5,
+					       unsigned long arg6, struct arm_smccc_res *res)
+{
+	__ASSERT(dev, "dev shouldn't be NULL");
+	const struct svc_driver_api *api = DEV_API(dev);
+
+	__ASSERT(api->sip_supervisory_call, "sip_supervisory_call shouldn't be NULL");
+	__ASSERT(res, "response pointer shouldn't be NULL");
+
+	api->sip_supervisory_call(dev, function_id, arg0, arg1, arg2, arg3, arg4, arg5, arg6, res);
+}
+
+static inline bool z_impl_sip_svc_plat_func_id_valid(const struct device *dev, uint32_t command,
+						     uint32_t func_id)
+{
+	__ASSERT(dev, "dev shouldn't be NULL");
+	const struct svc_driver_api *api = DEV_API(dev);
+
+	__ASSERT(api->sip_svc_plat_func_id_valid,
+		 "sip_svc_plat_func_id_valid func shouldn't be NULL");
+
+	return api->sip_svc_plat_func_id_valid(dev, command, func_id);
+}
+
+static inline uint32_t z_impl_sip_svc_plat_format_trans_id(const struct device *dev,
+							   uint32_t client_idx, uint32_t trans_idx)
+{
+	__ASSERT(dev, "dev shouldn't be NULL");
+	const struct svc_driver_api *api = DEV_API(dev);
+
+	__ASSERT(api->sip_svc_plat_format_trans_id,
+		 "sip_svc_plat_format_trans_id func shouldn't be NULL");
+
+	return api->sip_svc_plat_format_trans_id(dev, client_idx, trans_idx);
+}
+
+static inline uint32_t z_impl_sip_svc_plat_get_trans_idx(const struct device *dev,
+							 uint32_t trans_id)
+{
+	__ASSERT(dev, "dev shouldn't be NULL");
+	const struct svc_driver_api *api = DEV_API(dev);
+
+	__ASSERT(api->sip_svc_plat_get_trans_idx,
+		 "sip_svc_plat_get_trans_idx func shouldn't be NULL");
+
+	return api->sip_svc_plat_get_trans_idx(dev, trans_id);
+}
+
+static inline void z_impl_sip_svc_plat_update_trans_id(const struct device *dev,
+						       struct sip_svc_request *request,
+						       uint32_t trans_id)
+{
+	__ASSERT(dev, "dev shouldn't be NULL");
+	const struct svc_driver_api *api = DEV_API(dev);
+
+	__ASSERT(api->sip_svc_plat_update_trans_id,
+		 "sip_svc_plat_update_trans_id func shouldn't be NULL");
+	__ASSERT(request, "request shouldn't be NULL");
+
+	return api->sip_svc_plat_update_trans_id(dev, request, trans_id);
+}
+
+static inline uint32_t z_impl_sip_svc_plat_get_error_code(const struct device *dev,
+							  struct arm_smccc_res *res)
+{
+	__ASSERT(dev, "dev shouldn't be NULL");
+	const struct svc_driver_api *api = DEV_API(dev);
+
+	__ASSERT(api->sip_svc_plat_get_error_code,
+		 "sip_svc_plat_get_error_code func shouldn't be NULL");
+	__ASSERT(res, "res shouldn't be NULL");
+
+	return api->sip_svc_plat_get_error_code(dev, res);
+}
+
+static inline int z_impl_sip_svc_plat_async_res_req(const struct device *dev, unsigned long *a0,
+						    unsigned long *a1, unsigned long *a2,
+						    unsigned long *a3, unsigned long *a4,
+						    unsigned long *a5, unsigned long *a6,
+						    unsigned long *a7, char *buf, size_t size)
+{
+	__ASSERT(dev, "dev shouldn't be NULL");
+	const struct svc_driver_api *api = DEV_API(dev);
+
+	__ASSERT(api->sip_svc_plat_async_res_req,
+		 "sip_svc_plat_async_res_req func shouldn't be NULL");
+	__ASSERT(a0, "a0 shouldn't be NULL");
+	__ASSERT(a1, "a1 shouldn't be NULL");
+	__ASSERT(a2, "a2 shouldn't be NULL");
+	__ASSERT(a3, "a3 shouldn't be NULL");
+	__ASSERT(a4, "a4 shouldn't be NULL");
+	__ASSERT(a5, "a5 shouldn't be NULL");
+	__ASSERT(a6, "a6 shouldn't be NULL");
+	__ASSERT(a7, "a7 shouldn't be NULL");
+	__ASSERT(((buf == NULL && size == 0) || (buf != NULL && size != 0)),
+		 "buf and size should represent a buffer");
+	return api->sip_svc_plat_async_res_req(dev, a0, a1, a2, a3, a4, a5, a6, a7, buf, size);
+}
+
+static inline int z_impl_sip_svc_plat_async_res_res(const struct device *dev,
+						    struct arm_smccc_res *res, char *buf,
+						    size_t *size, uint32_t *trans_id)
+{
+	__ASSERT(dev, "dev shouldn't be NULL");
+	const struct svc_driver_api *api = DEV_API(dev);
+
+	__ASSERT(api->sip_svc_plat_async_res_res,
+		 "sip_svc_plat_async_res_res func shouldn't be NULL");
+	__ASSERT(res, "res shouldn't be NULL");
+	__ASSERT(buf, "buf shouldn't be NULL");
+	__ASSERT(size, "size shouldn't be NULL");
+	__ASSERT(trans_id, "buf shouldn't be NULL");
+
+	return api->sip_svc_plat_async_res_res(dev, res, buf, size, trans_id);
+}
+
+static inline void z_impl_sip_svc_plat_free_async_memory(const struct device *dev,
+							 struct sip_svc_request *request)
+{
+	__ASSERT(dev, "dev shouldn't be NULL");
+	const struct svc_driver_api *api = DEV_API(dev);
+
+	__ASSERT(api->sip_svc_plat_free_async_memory,
+		 "sip_svc_plat_free_async_memory func shouldn't be NULL");
+	__ASSERT(request, "request shouldn't be NULL");
+
+	api->sip_svc_plat_free_async_memory(dev, request);
+}
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SIP_SVC_DRIVER_INTERNAL_IMPL_H_ */

--- a/include/zephyr/drivers/sip_svc/sip_svc_driver.h
+++ b/include/zephyr/drivers/sip_svc/sip_svc_driver.h
@@ -121,20 +121,6 @@ __syscall void sip_supervisory_call(const struct device *dev, unsigned long func
 				    unsigned long arg0, unsigned long arg1, unsigned long arg2,
 				    unsigned long arg3, unsigned long arg4, unsigned long arg5,
 				    unsigned long arg6, struct arm_smccc_res *res);
-static inline void z_impl_sip_supervisory_call(const struct device *dev, unsigned long function_id,
-					       unsigned long arg0, unsigned long arg1,
-					       unsigned long arg2, unsigned long arg3,
-					       unsigned long arg4, unsigned long arg5,
-					       unsigned long arg6, struct arm_smccc_res *res)
-{
-	__ASSERT(dev, "dev shouldn't be NULL");
-	const struct svc_driver_api *api = DEV_API(dev);
-
-	__ASSERT(api->sip_supervisory_call, "sip_supervisory_call shouldn't be NULL");
-	__ASSERT(res, "response pointer shouldn't be NULL");
-
-	api->sip_supervisory_call(dev, function_id, arg0, arg1, arg2, arg3, arg4, arg5, arg6, res);
-}
 
 /**
  * @brief Validate the function id for the supervisory call.
@@ -148,17 +134,6 @@ static inline void z_impl_sip_supervisory_call(const struct device *dev, unsigne
  */
 __syscall bool sip_svc_plat_func_id_valid(const struct device *dev, uint32_t command,
 					  uint32_t func_id);
-static inline bool z_impl_sip_svc_plat_func_id_valid(const struct device *dev, uint32_t command,
-						     uint32_t func_id)
-{
-	__ASSERT(dev, "dev shouldn't be NULL");
-	const struct svc_driver_api *api = DEV_API(dev);
-
-	__ASSERT(api->sip_svc_plat_func_id_valid,
-		 "sip_svc_plat_func_id_valid func shouldn't be NULL");
-
-	return api->sip_svc_plat_func_id_valid(dev, command, func_id);
-}
 
 /**
  * @brief Formats and generates the transaction id from client id.
@@ -171,17 +146,6 @@ static inline bool z_impl_sip_svc_plat_func_id_valid(const struct device *dev, u
  */
 __syscall uint32_t sip_svc_plat_format_trans_id(const struct device *dev, uint32_t client_idx,
 						uint32_t trans_idx);
-static inline uint32_t z_impl_sip_svc_plat_format_trans_id(const struct device *dev,
-							   uint32_t client_idx, uint32_t trans_idx)
-{
-	__ASSERT(dev, "dev shouldn't be NULL");
-	const struct svc_driver_api *api = DEV_API(dev);
-
-	__ASSERT(api->sip_svc_plat_format_trans_id,
-		 "sip_svc_plat_format_trans_id func shouldn't be NULL");
-
-	return api->sip_svc_plat_format_trans_id(dev, client_idx, trans_idx);
-}
 
 /**
  * @brief Retrieve client transaction id from packet transaction id.
@@ -192,17 +156,6 @@ static inline uint32_t z_impl_sip_svc_plat_format_trans_id(const struct device *
  * @retval client transaction id form Transaction id.
  */
 __syscall uint32_t sip_svc_plat_get_trans_idx(const struct device *dev, uint32_t trans_id);
-static inline uint32_t z_impl_sip_svc_plat_get_trans_idx(const struct device *dev,
-							 uint32_t trans_id)
-{
-	__ASSERT(dev, "dev shouldn't be NULL");
-	const struct svc_driver_api *api = DEV_API(dev);
-
-	__ASSERT(api->sip_svc_plat_get_trans_idx,
-		 "sip_svc_plat_get_trans_idx func shouldn't be NULL");
-
-	return api->sip_svc_plat_get_trans_idx(dev, trans_id);
-}
 
 /**
  * @brief Update transaction id for sip_svc_request for lower layer.
@@ -213,19 +166,6 @@ static inline uint32_t z_impl_sip_svc_plat_get_trans_idx(const struct device *de
  */
 __syscall void sip_svc_plat_update_trans_id(const struct device *dev,
 					    struct sip_svc_request *request, uint32_t trans_id);
-static inline void z_impl_sip_svc_plat_update_trans_id(const struct device *dev,
-						       struct sip_svc_request *request,
-						       uint32_t trans_id)
-{
-	__ASSERT(dev, "dev shouldn't be NULL");
-	const struct svc_driver_api *api = DEV_API(dev);
-
-	__ASSERT(api->sip_svc_plat_update_trans_id,
-		 "sip_svc_plat_update_trans_id func shouldn't be NULL");
-	__ASSERT(request, "request shouldn't be NULL");
-
-	return api->sip_svc_plat_update_trans_id(dev, request, trans_id);
-}
 
 /**
  * @brief Retrieve the error code from arm_smccc_res response.
@@ -237,18 +177,6 @@ static inline void z_impl_sip_svc_plat_update_trans_id(const struct device *dev,
  * @retval SIP_SVC_ID_INVALID on failure
  */
 __syscall uint32_t sip_svc_plat_get_error_code(const struct device *dev, struct arm_smccc_res *res);
-static inline uint32_t z_impl_sip_svc_plat_get_error_code(const struct device *dev,
-							  struct arm_smccc_res *res)
-{
-	__ASSERT(dev, "dev shouldn't be NULL");
-	const struct svc_driver_api *api = DEV_API(dev);
-
-	__ASSERT(api->sip_svc_plat_get_error_code,
-		 "sip_svc_plat_get_error_code func shouldn't be NULL");
-	__ASSERT(res, "res shouldn't be NULL");
-
-	return api->sip_svc_plat_get_error_code(dev, res);
-}
 
 /**
  * @brief Set arguments for polling supervisory call. For ASYNC polling of response.
@@ -271,29 +199,6 @@ __syscall int sip_svc_plat_async_res_req(const struct device *dev, unsigned long
 					 unsigned long *a1, unsigned long *a2, unsigned long *a3,
 					 unsigned long *a4, unsigned long *a5, unsigned long *a6,
 					 unsigned long *a7, char *buf, size_t size);
-static inline int z_impl_sip_svc_plat_async_res_req(const struct device *dev, unsigned long *a0,
-						    unsigned long *a1, unsigned long *a2,
-						    unsigned long *a3, unsigned long *a4,
-						    unsigned long *a5, unsigned long *a6,
-						    unsigned long *a7, char *buf, size_t size)
-{
-	__ASSERT(dev, "dev shouldn't be NULL");
-	const struct svc_driver_api *api = DEV_API(dev);
-
-	__ASSERT(api->sip_svc_plat_async_res_req,
-		 "sip_svc_plat_async_res_req func shouldn't be NULL");
-	__ASSERT(a0, "a0 shouldn't be NULL");
-	__ASSERT(a1, "a1 shouldn't be NULL");
-	__ASSERT(a2, "a2 shouldn't be NULL");
-	__ASSERT(a3, "a3 shouldn't be NULL");
-	__ASSERT(a4, "a4 shouldn't be NULL");
-	__ASSERT(a5, "a5 shouldn't be NULL");
-	__ASSERT(a6, "a6 shouldn't be NULL");
-	__ASSERT(a7, "a7 shouldn't be NULL");
-	__ASSERT(((buf == NULL && size == 0) || (buf != NULL && size != 0)),
-		 "buf and size should represent a buffer");
-	return api->sip_svc_plat_async_res_req(dev, a0, a1, a2, a3, a4, a5, a6, a7, buf, size);
-}
 
 /**
  * @brief Check the response of polling supervisory call and retrieve the response
@@ -310,22 +215,6 @@ static inline int z_impl_sip_svc_plat_async_res_req(const struct device *dev, un
  */
 __syscall int sip_svc_plat_async_res_res(const struct device *dev, struct arm_smccc_res *res,
 					 char *buf, size_t *size, uint32_t *trans_id);
-static inline int z_impl_sip_svc_plat_async_res_res(const struct device *dev,
-						    struct arm_smccc_res *res, char *buf,
-						    size_t *size, uint32_t *trans_id)
-{
-	__ASSERT(dev, "dev shouldn't be NULL");
-	const struct svc_driver_api *api = DEV_API(dev);
-
-	__ASSERT(api->sip_svc_plat_async_res_res,
-		 "sip_svc_plat_async_res_res func shouldn't be NULL");
-	__ASSERT(res, "res shouldn't be NULL");
-	__ASSERT(buf, "buf shouldn't be NULL");
-	__ASSERT(size, "size shouldn't be NULL");
-	__ASSERT(trans_id, "buf shouldn't be NULL");
-
-	return api->sip_svc_plat_async_res_res(dev, res, buf, size, trans_id);
-}
 
 /**
  * @brief Free the command buffer used for ASYNC packet after sending it to lower layers.
@@ -335,20 +224,8 @@ static inline int z_impl_sip_svc_plat_async_res_res(const struct device *dev,
  */
 __syscall void sip_svc_plat_free_async_memory(const struct device *dev,
 					      struct sip_svc_request *request);
-static inline void z_impl_sip_svc_plat_free_async_memory(const struct device *dev,
-							 struct sip_svc_request *request)
-{
-	__ASSERT(dev, "dev shouldn't be NULL");
-	const struct svc_driver_api *api = DEV_API(dev);
 
-	__ASSERT(api->sip_svc_plat_free_async_memory,
-		 "sip_svc_plat_free_async_memory func shouldn't be NULL");
-	__ASSERT(request, "request shouldn't be NULL");
-
-	api->sip_svc_plat_free_async_memory(dev, request);
-}
-
-
+#include <zephyr/drivers/sip_svc/internal/sip_svc_driver_impl.h>
 #include <zephyr/syscalls/sip_svc_driver.h>
 
 #endif /* ZEPHYR_INCLUDE_SIP_SVC_DRIVER_H_ */

--- a/include/zephyr/drivers/smbus.h
+++ b/include/zephyr/drivers/smbus.h
@@ -560,15 +560,6 @@ static inline void smbus_xfer_stats(const struct device *dev, uint8_t sent,
  */
 __syscall int smbus_configure(const struct device *dev, uint32_t dev_config);
 
-static inline int z_impl_smbus_configure(const struct device *dev,
-					 uint32_t dev_config)
-{
-	const struct smbus_driver_api *api =
-		(const struct smbus_driver_api *)dev->api;
-
-	return api->configure(dev, dev_config);
-}
-
 /**
  * @brief Get configuration of a SMBus host controller.
  *
@@ -590,19 +581,6 @@ static inline int z_impl_smbus_configure(const struct device *dev,
  * by the driver.
  */
 __syscall int smbus_get_config(const struct device *dev, uint32_t *dev_config);
-
-static inline int z_impl_smbus_get_config(const struct device *dev,
-					  uint32_t *dev_config)
-{
-	const struct smbus_driver_api *api =
-		(const struct smbus_driver_api *)dev->api;
-
-	if (api->get_config == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->get_config(dev, dev_config);
-}
 
 /**
  * @brief Add SMBUSALERT callback for a SMBus host controller.
@@ -642,19 +620,6 @@ static inline int smbus_smbalert_set_cb(const struct device *dev,
 __syscall int smbus_smbalert_remove_cb(const struct device *dev,
 				       struct smbus_callback *cb);
 
-static inline int z_impl_smbus_smbalert_remove_cb(const struct device *dev,
-						  struct smbus_callback *cb)
-{
-	const struct smbus_driver_api *api =
-		(const struct smbus_driver_api *)dev->api;
-
-	if (api->smbus_smbalert_remove_cb == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->smbus_smbalert_remove_cb(dev, cb);
-}
-
 /**
  * @brief Add Host Notify callback for a SMBus host controller.
  *
@@ -693,19 +658,6 @@ static inline int smbus_host_notify_set_cb(const struct device *dev,
 __syscall int smbus_host_notify_remove_cb(const struct device *dev,
 					  struct smbus_callback *cb);
 
-static inline int z_impl_smbus_host_notify_remove_cb(const struct device *dev,
-						     struct smbus_callback *cb)
-{
-	const struct smbus_driver_api *api =
-		(const struct smbus_driver_api *)dev->api;
-
-	if (api->smbus_host_notify_remove_cb == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->smbus_host_notify_remove_cb(dev, cb);
-}
-
 /**
  * @brief Perform SMBus Quick operation
  *
@@ -725,23 +677,6 @@ static inline int z_impl_smbus_host_notify_remove_cb(const struct device *dev,
 __syscall int smbus_quick(const struct device *dev, uint16_t addr,
 			  enum smbus_direction direction);
 
-static inline int z_impl_smbus_quick(const struct device *dev, uint16_t addr,
-				     enum smbus_direction direction)
-{
-	const struct smbus_driver_api *api =
-		(const struct smbus_driver_api *)dev->api;
-
-	if (api->smbus_quick == NULL) {
-		return -ENOSYS;
-	}
-
-	if (direction != SMBUS_MSG_READ && direction != SMBUS_MSG_WRITE) {
-		return -EINVAL;
-	}
-
-	return  api->smbus_quick(dev, addr, direction);
-}
-
 /**
  * @brief Perform SMBus Byte Write operation
  *
@@ -760,19 +695,6 @@ static inline int z_impl_smbus_quick(const struct device *dev, uint16_t addr,
 __syscall int smbus_byte_write(const struct device *dev, uint16_t addr,
 			       uint8_t byte);
 
-static inline int z_impl_smbus_byte_write(const struct device *dev,
-					  uint16_t addr, uint8_t byte)
-{
-	const struct smbus_driver_api *api =
-		(const struct smbus_driver_api *)dev->api;
-
-	if (api->smbus_byte_write == NULL) {
-		return -ENOSYS;
-	}
-
-	return  api->smbus_byte_write(dev, addr, byte);
-}
-
 /**
  * @brief Perform SMBus Byte Read operation
  *
@@ -790,19 +712,6 @@ static inline int z_impl_smbus_byte_write(const struct device *dev,
  */
 __syscall int smbus_byte_read(const struct device *dev, uint16_t addr,
 			      uint8_t *byte);
-
-static inline int z_impl_smbus_byte_read(const struct device *dev,
-					 uint16_t addr, uint8_t *byte)
-{
-	const struct smbus_driver_api *api =
-		(const struct smbus_driver_api *)dev->api;
-
-	if (api->smbus_byte_read == NULL) {
-		return -ENOSYS;
-	}
-
-	return  api->smbus_byte_read(dev, addr, byte);
-}
 
 /**
  * @brief Perform SMBus Byte Data Write operation
@@ -823,20 +732,6 @@ static inline int z_impl_smbus_byte_read(const struct device *dev,
 __syscall int smbus_byte_data_write(const struct device *dev, uint16_t addr,
 				    uint8_t cmd, uint8_t byte);
 
-static inline int z_impl_smbus_byte_data_write(const struct device *dev,
-					       uint16_t addr, uint8_t cmd,
-					       uint8_t byte)
-{
-	const struct smbus_driver_api *api =
-		(const struct smbus_driver_api *)dev->api;
-
-	if (api->smbus_byte_data_write == NULL) {
-		return -ENOSYS;
-	}
-
-	return  api->smbus_byte_data_write(dev, addr, cmd, byte);
-}
-
 /**
  * @brief Perform SMBus Byte Data Read operation
  *
@@ -855,20 +750,6 @@ static inline int z_impl_smbus_byte_data_write(const struct device *dev,
  */
 __syscall int smbus_byte_data_read(const struct device *dev, uint16_t addr,
 				   uint8_t cmd, uint8_t *byte);
-
-static inline int z_impl_smbus_byte_data_read(const struct device *dev,
-					      uint16_t addr, uint8_t cmd,
-					      uint8_t *byte)
-{
-	const struct smbus_driver_api *api =
-		(const struct smbus_driver_api *)dev->api;
-
-	if (api->smbus_byte_data_read == NULL) {
-		return -ENOSYS;
-	}
-
-	return  api->smbus_byte_data_read(dev, addr, cmd, byte);
-}
 
 /**
  * @brief Perform SMBus Word Data Write operation
@@ -889,20 +770,6 @@ static inline int z_impl_smbus_byte_data_read(const struct device *dev,
 __syscall int smbus_word_data_write(const struct device *dev, uint16_t addr,
 				    uint8_t cmd, uint16_t word);
 
-static inline int z_impl_smbus_word_data_write(const struct device *dev,
-					       uint16_t addr, uint8_t cmd,
-					       uint16_t word)
-{
-	const struct smbus_driver_api *api =
-		(const struct smbus_driver_api *)dev->api;
-
-	if (api->smbus_word_data_write == NULL) {
-		return -ENOSYS;
-	}
-
-	return  api->smbus_word_data_write(dev, addr, cmd, word);
-}
-
 /**
  * @brief Perform SMBus Word Data Read operation
  *
@@ -921,20 +788,6 @@ static inline int z_impl_smbus_word_data_write(const struct device *dev,
  */
 __syscall int smbus_word_data_read(const struct device *dev, uint16_t addr,
 				   uint8_t cmd, uint16_t *word);
-
-static inline int z_impl_smbus_word_data_read(const struct device *dev,
-					      uint16_t addr, uint8_t cmd,
-					      uint16_t *word)
-{
-	const struct smbus_driver_api *api =
-		(const struct smbus_driver_api *)dev->api;
-
-	if (api->smbus_word_data_read == NULL) {
-		return -ENOSYS;
-	}
-
-	return  api->smbus_word_data_read(dev, addr, cmd, word);
-}
 
 /**
  * @brief Perform SMBus Process Call operation
@@ -957,20 +810,6 @@ static inline int z_impl_smbus_word_data_read(const struct device *dev,
 __syscall int smbus_pcall(const struct device *dev, uint16_t addr,
 			  uint8_t cmd, uint16_t send_word, uint16_t *recv_word);
 
-static inline int z_impl_smbus_pcall(const struct device *dev,
-				     uint16_t addr, uint8_t cmd,
-				     uint16_t send_word, uint16_t *recv_word)
-{
-	const struct smbus_driver_api *api =
-		(const struct smbus_driver_api *)dev->api;
-
-	if (api->smbus_pcall == NULL) {
-		return -ENOSYS;
-	}
-
-	return  api->smbus_pcall(dev, addr, cmd, send_word, recv_word);
-}
-
 /**
  * @brief Perform SMBus Block Write operation
  *
@@ -991,24 +830,6 @@ static inline int z_impl_smbus_pcall(const struct device *dev,
 __syscall int smbus_block_write(const struct device *dev, uint16_t addr,
 				uint8_t cmd, uint8_t count, uint8_t *buf);
 
-static inline int z_impl_smbus_block_write(const struct device *dev,
-					   uint16_t addr, uint8_t cmd,
-					   uint8_t count, uint8_t *buf)
-{
-	const struct smbus_driver_api *api =
-		(const struct smbus_driver_api *)dev->api;
-
-	if (api->smbus_block_write == NULL) {
-		return -ENOSYS;
-	}
-
-	if (count < 1 || count > SMBUS_BLOCK_BYTES_MAX) {
-		return -EINVAL;
-	}
-
-	return  api->smbus_block_write(dev, addr, cmd, count, buf);
-}
-
 /**
  * @brief Perform SMBus Block Read operation
  *
@@ -1028,20 +849,6 @@ static inline int z_impl_smbus_block_write(const struct device *dev,
  */
 __syscall int smbus_block_read(const struct device *dev, uint16_t addr,
 			       uint8_t cmd, uint8_t *count, uint8_t *buf);
-
-static inline int z_impl_smbus_block_read(const struct device *dev,
-					  uint16_t addr, uint8_t cmd,
-					  uint8_t *count, uint8_t *buf)
-{
-	const struct smbus_driver_api *api =
-		(const struct smbus_driver_api *)dev->api;
-
-	if (api->smbus_block_read == NULL) {
-		return -ENOSYS;
-	}
-
-	return  api->smbus_block_read(dev, addr, cmd, count, buf);
-}
 
 /**
  * @brief Perform SMBus Block Process Call operation
@@ -1068,22 +875,6 @@ __syscall int smbus_block_pcall(const struct device *dev,
 				uint8_t snd_count, uint8_t *snd_buf,
 				uint8_t *rcv_count, uint8_t *rcv_buf);
 
-static inline int z_impl_smbus_block_pcall(const struct device *dev,
-					   uint16_t addr, uint8_t cmd,
-					   uint8_t snd_count, uint8_t *snd_buf,
-					   uint8_t *rcv_count, uint8_t *rcv_buf)
-{
-	const struct smbus_driver_api *api =
-		(const struct smbus_driver_api *)dev->api;
-
-	if (api->smbus_block_pcall == NULL) {
-		return -ENOSYS;
-	}
-
-	return  api->smbus_block_pcall(dev, addr, cmd, snd_count, snd_buf,
-				       rcv_count, rcv_buf);
-}
-
 #ifdef __cplusplus
 }
 #endif
@@ -1092,6 +883,7 @@ static inline int z_impl_smbus_block_pcall(const struct device *dev,
  * @}
  */
 
+#include <zephyr/drivers/smbus/internal/smbus_impl.h>
 #include <zephyr/syscalls/smbus.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_SMBUS_H_ */

--- a/include/zephyr/drivers/smbus/internal/smbus_impl.h
+++ b/include/zephyr/drivers/smbus/internal/smbus_impl.h
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2022 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Inline syscall implementation for SMBus Driver APIs
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SMBUS_H_
+#error "Should only be included by zephyr/drivers/smbus.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SMBUS_INTERNAL_SMBUS_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_SMBUS_INTERNAL_SMBUS_IMPL_H_
+
+#include <errno.h>
+#include <zephyr/sys/slist.h>
+#include <zephyr/types.h>
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_smbus_configure(const struct device *dev,
+					 uint32_t dev_config)
+{
+	const struct smbus_driver_api *api =
+		(const struct smbus_driver_api *)dev->api;
+
+	return api->configure(dev, dev_config);
+}
+
+static inline int z_impl_smbus_get_config(const struct device *dev,
+					  uint32_t *dev_config)
+{
+	const struct smbus_driver_api *api =
+		(const struct smbus_driver_api *)dev->api;
+
+	if (api->get_config == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->get_config(dev, dev_config);
+}
+
+static inline int z_impl_smbus_smbalert_remove_cb(const struct device *dev,
+						  struct smbus_callback *cb)
+{
+	const struct smbus_driver_api *api =
+		(const struct smbus_driver_api *)dev->api;
+
+	if (api->smbus_smbalert_remove_cb == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->smbus_smbalert_remove_cb(dev, cb);
+}
+
+static inline int z_impl_smbus_host_notify_remove_cb(const struct device *dev,
+						     struct smbus_callback *cb)
+{
+	const struct smbus_driver_api *api =
+		(const struct smbus_driver_api *)dev->api;
+
+	if (api->smbus_host_notify_remove_cb == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->smbus_host_notify_remove_cb(dev, cb);
+}
+
+static inline int z_impl_smbus_quick(const struct device *dev, uint16_t addr,
+				     enum smbus_direction direction)
+{
+	const struct smbus_driver_api *api =
+		(const struct smbus_driver_api *)dev->api;
+
+	if (api->smbus_quick == NULL) {
+		return -ENOSYS;
+	}
+
+	if (direction != SMBUS_MSG_READ && direction != SMBUS_MSG_WRITE) {
+		return -EINVAL;
+	}
+
+	return  api->smbus_quick(dev, addr, direction);
+}
+
+static inline int z_impl_smbus_byte_write(const struct device *dev,
+					  uint16_t addr, uint8_t byte)
+{
+	const struct smbus_driver_api *api =
+		(const struct smbus_driver_api *)dev->api;
+
+	if (api->smbus_byte_write == NULL) {
+		return -ENOSYS;
+	}
+
+	return  api->smbus_byte_write(dev, addr, byte);
+}
+
+static inline int z_impl_smbus_byte_read(const struct device *dev,
+					 uint16_t addr, uint8_t *byte)
+{
+	const struct smbus_driver_api *api =
+		(const struct smbus_driver_api *)dev->api;
+
+	if (api->smbus_byte_read == NULL) {
+		return -ENOSYS;
+	}
+
+	return  api->smbus_byte_read(dev, addr, byte);
+}
+
+static inline int z_impl_smbus_byte_data_write(const struct device *dev,
+					       uint16_t addr, uint8_t cmd,
+					       uint8_t byte)
+{
+	const struct smbus_driver_api *api =
+		(const struct smbus_driver_api *)dev->api;
+
+	if (api->smbus_byte_data_write == NULL) {
+		return -ENOSYS;
+	}
+
+	return  api->smbus_byte_data_write(dev, addr, cmd, byte);
+}
+
+static inline int z_impl_smbus_byte_data_read(const struct device *dev,
+					      uint16_t addr, uint8_t cmd,
+					      uint8_t *byte)
+{
+	const struct smbus_driver_api *api =
+		(const struct smbus_driver_api *)dev->api;
+
+	if (api->smbus_byte_data_read == NULL) {
+		return -ENOSYS;
+	}
+
+	return  api->smbus_byte_data_read(dev, addr, cmd, byte);
+}
+
+static inline int z_impl_smbus_word_data_write(const struct device *dev,
+					       uint16_t addr, uint8_t cmd,
+					       uint16_t word)
+{
+	const struct smbus_driver_api *api =
+		(const struct smbus_driver_api *)dev->api;
+
+	if (api->smbus_word_data_write == NULL) {
+		return -ENOSYS;
+	}
+
+	return  api->smbus_word_data_write(dev, addr, cmd, word);
+}
+
+static inline int z_impl_smbus_word_data_read(const struct device *dev,
+					      uint16_t addr, uint8_t cmd,
+					      uint16_t *word)
+{
+	const struct smbus_driver_api *api =
+		(const struct smbus_driver_api *)dev->api;
+
+	if (api->smbus_word_data_read == NULL) {
+		return -ENOSYS;
+	}
+
+	return  api->smbus_word_data_read(dev, addr, cmd, word);
+}
+
+static inline int z_impl_smbus_pcall(const struct device *dev,
+				     uint16_t addr, uint8_t cmd,
+				     uint16_t send_word, uint16_t *recv_word)
+{
+	const struct smbus_driver_api *api =
+		(const struct smbus_driver_api *)dev->api;
+
+	if (api->smbus_pcall == NULL) {
+		return -ENOSYS;
+	}
+
+	return  api->smbus_pcall(dev, addr, cmd, send_word, recv_word);
+}
+
+static inline int z_impl_smbus_block_write(const struct device *dev,
+					   uint16_t addr, uint8_t cmd,
+					   uint8_t count, uint8_t *buf)
+{
+	const struct smbus_driver_api *api =
+		(const struct smbus_driver_api *)dev->api;
+
+	if (api->smbus_block_write == NULL) {
+		return -ENOSYS;
+	}
+
+	if (count < 1 || count > SMBUS_BLOCK_BYTES_MAX) {
+		return -EINVAL;
+	}
+
+	return  api->smbus_block_write(dev, addr, cmd, count, buf);
+}
+
+static inline int z_impl_smbus_block_read(const struct device *dev,
+					  uint16_t addr, uint8_t cmd,
+					  uint8_t *count, uint8_t *buf)
+{
+	const struct smbus_driver_api *api =
+		(const struct smbus_driver_api *)dev->api;
+
+	if (api->smbus_block_read == NULL) {
+		return -ENOSYS;
+	}
+
+	return  api->smbus_block_read(dev, addr, cmd, count, buf);
+}
+
+static inline int z_impl_smbus_block_pcall(const struct device *dev,
+					   uint16_t addr, uint8_t cmd,
+					   uint8_t snd_count, uint8_t *snd_buf,
+					   uint8_t *rcv_count, uint8_t *rcv_buf)
+{
+	const struct smbus_driver_api *api =
+		(const struct smbus_driver_api *)dev->api;
+
+	if (api->smbus_block_pcall == NULL) {
+		return -ENOSYS;
+	}
+
+	return  api->smbus_block_pcall(dev, addr, cmd, snd_count, snd_buf,
+				       rcv_count, rcv_buf);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SMBUS_INTERNAL_SMBUS_IMPL_H_ */

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -727,21 +727,6 @@ __syscall int spi_transceive(const struct device *dev,
 			     const struct spi_buf_set *tx_bufs,
 			     const struct spi_buf_set *rx_bufs);
 
-static inline int z_impl_spi_transceive(const struct device *dev,
-					const struct spi_config *config,
-					const struct spi_buf_set *tx_bufs,
-					const struct spi_buf_set *rx_bufs)
-{
-	const struct spi_driver_api *api =
-		(const struct spi_driver_api *)dev->api;
-	int ret;
-
-	ret = api->transceive(dev, config, tx_bufs, rx_bufs);
-	spi_transceive_stats(dev, ret, tx_bufs, rx_bufs);
-
-	return ret;
-}
-
 /**
  * @brief Read/write data from an SPI bus specified in @p spi_dt_spec.
  *
@@ -1234,15 +1219,6 @@ out:
 __syscall int spi_release(const struct device *dev,
 			  const struct spi_config *config);
 
-static inline int z_impl_spi_release(const struct device *dev,
-				     const struct spi_config *config)
-{
-	const struct spi_driver_api *api =
-		(const struct spi_driver_api *)dev->api;
-
-	return api->release(dev, config);
-}
-
 /**
  * @brief Release the SPI device specified in @p spi_dt_spec.
  *
@@ -1267,6 +1243,7 @@ static inline int spi_release_dt(const struct spi_dt_spec *spec)
  * @}
  */
 
+#include <zephyr/drivers/spi/internal/spi_impl.h>
 #include <zephyr/syscalls/spi.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_SPI_H_ */

--- a/include/zephyr/drivers/spi/internal/spi_impl.h
+++ b/include/zephyr/drivers/spi/internal/spi_impl.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2015 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Inline syscall implementation for SPI driver APIs.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SPI_H_
+#error "Should only be included by zephyr/drivers/spi.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SPI_INTERNAL_SPI_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_SPI_INTERNAL_SPI_IMPL_H_
+
+#include <zephyr/types.h>
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_spi_transceive(const struct device *dev,
+					const struct spi_config *config,
+					const struct spi_buf_set *tx_bufs,
+					const struct spi_buf_set *rx_bufs)
+{
+	const struct spi_driver_api *api =
+		(const struct spi_driver_api *)dev->api;
+	int ret;
+
+	ret = api->transceive(dev, config, tx_bufs, rx_bufs);
+	spi_transceive_stats(dev, ret, tx_bufs, rx_bufs);
+
+	return ret;
+}
+
+static inline int z_impl_spi_release(const struct device *dev,
+				     const struct spi_config *config)
+{
+	const struct spi_driver_api *api =
+		(const struct spi_driver_api *)dev->api;
+
+	return api->release(dev, config);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SPI_INTERNAL_SPI_IMPL_H_ */

--- a/include/zephyr/drivers/syscon.h
+++ b/include/zephyr/drivers/syscon.h
@@ -75,18 +75,6 @@ __subsystem struct syscon_driver_api {
  */
 __syscall int syscon_get_base(const struct device *dev, uintptr_t *addr);
 
-static inline int z_impl_syscon_get_base(const struct device *dev, uintptr_t *addr)
-{
-	const struct syscon_driver_api *api = (const struct syscon_driver_api *)dev->api;
-
-	if (api == NULL) {
-		return -ENOTSUP;
-	}
-
-	return api->get_base(dev, addr);
-}
-
-
 /**
  * @brief Read from syscon register
  *
@@ -99,18 +87,6 @@ static inline int z_impl_syscon_get_base(const struct device *dev, uintptr_t *ad
  * @return 0 on success, negative on error
  */
 __syscall int syscon_read_reg(const struct device *dev, uint16_t reg, uint32_t *val);
-
-static inline int z_impl_syscon_read_reg(const struct device *dev, uint16_t reg, uint32_t *val)
-{
-	const struct syscon_driver_api *api = (const struct syscon_driver_api *)dev->api;
-
-	if (api == NULL) {
-		return -ENOTSUP;
-	}
-
-	return api->read(dev, reg, val);
-}
-
 
 /**
  * @brief Write to syscon register
@@ -125,17 +101,6 @@ static inline int z_impl_syscon_read_reg(const struct device *dev, uint16_t reg,
  */
 __syscall int syscon_write_reg(const struct device *dev, uint16_t reg, uint32_t val);
 
-static inline int z_impl_syscon_write_reg(const struct device *dev, uint16_t reg, uint32_t val)
-{
-	const struct syscon_driver_api *api = (const struct syscon_driver_api *)dev->api;
-
-	if (api == NULL) {
-		return -ENOTSUP;
-	}
-
-	return api->write(dev, reg, val);
-}
-
 /**
  * Get the size of the syscon register in bytes.
  *
@@ -145,13 +110,6 @@ static inline int z_impl_syscon_write_reg(const struct device *dev, uint16_t reg
  */
 __syscall int syscon_get_size(const struct device *dev, size_t *size);
 
-static inline int z_impl_syscon_get_size(const struct device *dev, size_t *size)
-{
-	const struct syscon_driver_api *api = (const struct syscon_driver_api *)dev->api;
-
-	return api->get_size(dev, size);
-}
-
 /**
  * @}
  */
@@ -160,6 +118,7 @@ static inline int z_impl_syscon_get_size(const struct device *dev, size_t *size)
 }
 #endif
 
+#include <zephyr/drivers/syscon/internal/syscon_impl.h>
 #include <zephyr/syscalls/syscon.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_SYSCON_H_ */

--- a/include/zephyr/drivers/syscon/internal/syscon_impl.h
+++ b/include/zephyr/drivers/syscon/internal/syscon_impl.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2021 Carlo Caione <ccaione@baylibre.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Inline syscall implementation for SYSCON driver APIs
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SYSCON_H_
+#error "Should only be included by zephyr/drivers/syscon.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SYSCON_INTERNAL_SYSCON_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_SYSCON_INTERNAL_SYSCON_IMPL_H_
+
+#include <errno.h>
+
+#include <zephyr/types.h>
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_syscon_get_base(const struct device *dev, uintptr_t *addr)
+{
+	const struct syscon_driver_api *api = (const struct syscon_driver_api *)dev->api;
+
+	if (api == NULL) {
+		return -ENOTSUP;
+	}
+
+	return api->get_base(dev, addr);
+}
+
+static inline int z_impl_syscon_read_reg(const struct device *dev, uint16_t reg, uint32_t *val)
+{
+	const struct syscon_driver_api *api = (const struct syscon_driver_api *)dev->api;
+
+	if (api == NULL) {
+		return -ENOTSUP;
+	}
+
+	return api->read(dev, reg, val);
+}
+
+static inline int z_impl_syscon_write_reg(const struct device *dev, uint16_t reg, uint32_t val)
+{
+	const struct syscon_driver_api *api = (const struct syscon_driver_api *)dev->api;
+
+	if (api == NULL) {
+		return -ENOTSUP;
+	}
+
+	return api->write(dev, reg, val);
+}
+
+static inline int z_impl_syscon_get_size(const struct device *dev, size_t *size)
+{
+	const struct syscon_driver_api *api = (const struct syscon_driver_api *)dev->api;
+
+	return api->get_size(dev, size);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SYSCON_INTERNAL_SYSCON_IMPL_H_ */

--- a/include/zephyr/drivers/tee.h
+++ b/include/zephyr/drivers/tee.h
@@ -364,17 +364,6 @@ __subsystem struct tee_driver_api {
  */
 __syscall int tee_get_version(const struct device *dev, struct tee_version_info *info);
 
-static inline int z_impl_tee_get_version(const struct device *dev, struct tee_version_info *info)
-{
-	const struct tee_driver_api *api = (const struct tee_driver_api *)dev->api;
-
-	if (!api->get_version) {
-		return -ENOSYS;
-	}
-
-	return api->get_version(dev, info);
-}
-
 /**
  * @brief Open session for Trusted Environment
  *
@@ -394,20 +383,6 @@ __syscall int tee_open_session(const struct device *dev, struct tee_open_session
 			       unsigned int num_param, struct tee_param *param,
 			       uint32_t *session_id);
 
-static inline int z_impl_tee_open_session(const struct device *dev,
-					  struct tee_open_session_arg *arg,
-					  unsigned int num_param, struct tee_param *param,
-					  uint32_t *session_id)
-{
-	const struct tee_driver_api *api = (const struct tee_driver_api *)dev->api;
-
-	if (!api->open_session) {
-		return -ENOSYS;
-	}
-
-	return api->open_session(dev, arg, num_param, param, session_id);
-}
-
 /**
  * @brief Close session for Trusted Environment
  *
@@ -421,17 +396,6 @@ static inline int z_impl_tee_open_session(const struct device *dev,
  * @retval 0       On success, negative on error
  */
 __syscall int tee_close_session(const struct device *dev, uint32_t session_id);
-
-static inline int z_impl_tee_close_session(const struct device *dev, uint32_t session_id)
-{
-	const struct tee_driver_api *api = (const struct tee_driver_api *)dev->api;
-
-	if (!api->close_session) {
-		return -ENOSYS;
-	}
-
-	return api->close_session(dev, session_id);
-}
 
 /**
  * @brief Cancel session or invoke function for Trusted Environment
@@ -447,18 +411,6 @@ static inline int z_impl_tee_close_session(const struct device *dev, uint32_t se
  * @retval 0       On success, negative on error
  */
 __syscall int tee_cancel(const struct device *dev, uint32_t session_id, uint32_t cancel_id);
-
-static inline int z_impl_tee_cancel(const struct device *dev, uint32_t session_id,
-				    uint32_t cancel_id)
-{
-	const struct tee_driver_api *api = (const struct tee_driver_api *)dev->api;
-
-	if (!api->cancel) {
-		return -ENOSYS;
-	}
-
-	return api->cancel(dev, session_id, cancel_id);
-}
 
 /**
  * @brief Invoke function for Trusted Environment Application
@@ -476,18 +428,6 @@ static inline int z_impl_tee_cancel(const struct device *dev, uint32_t session_i
  */
 __syscall int tee_invoke_func(const struct device *dev, struct tee_invoke_func_arg *arg,
 			      unsigned int num_param, struct tee_param *param);
-
-static inline int z_impl_tee_invoke_func(const struct device *dev, struct tee_invoke_func_arg *arg,
-					 unsigned int num_param, struct tee_param *param)
-{
-	const struct tee_driver_api *api = (const struct tee_driver_api *)dev->api;
-
-	if (!api->invoke_func) {
-		return -ENOSYS;
-	}
-
-	return api->invoke_func(dev, arg, num_param, param);
-}
 
 /**
  * @brief Helper function to allocate and register shared memory
@@ -536,13 +476,6 @@ int tee_rm_shm(const struct device *dev, struct tee_shm *shm);
 __syscall int tee_shm_register(const struct device *dev, void *addr, size_t size,
 			       uint32_t flags, struct tee_shm **shm);
 
-static inline int z_impl_tee_shm_register(const struct device *dev, void *addr, size_t size,
-					  uint32_t flags, struct tee_shm **shm)
-{
-	flags &= ~TEE_SHM_ALLOC;
-	return tee_add_shm(dev, addr, 0, size, flags | TEE_SHM_REGISTER, shm);
-}
-
 /**
  * @brief Unregister shared memory for Trusted Environment
  *
@@ -556,11 +489,6 @@ static inline int z_impl_tee_shm_register(const struct device *dev, void *addr, 
  * @retval 0       On success, negative on error
  */
 __syscall int tee_shm_unregister(const struct device *dev, struct tee_shm *shm);
-
-static inline int z_impl_tee_shm_unregister(const struct device *dev, struct tee_shm *shm)
-{
-	return tee_rm_shm(dev, shm);
-}
 
 /**
  * @brief Allocate shared memory region for Trusted Environment
@@ -579,12 +507,6 @@ static inline int z_impl_tee_shm_unregister(const struct device *dev, struct tee
 __syscall int tee_shm_alloc(const struct device *dev, size_t size, uint32_t flags,
 			    struct tee_shm **shm);
 
-static inline int z_impl_tee_shm_alloc(const struct device *dev, size_t size, uint32_t flags,
-				       struct tee_shm **shm)
-{
-	return tee_add_shm(dev, NULL, 0, size, flags | TEE_SHM_ALLOC | TEE_SHM_REGISTER, shm);
-}
-
 /**
  * @brief Free shared memory region for Trusted Environment
  *
@@ -598,11 +520,6 @@ static inline int z_impl_tee_shm_alloc(const struct device *dev, size_t size, ui
  * @retval 0       On success, negative on error
  */
 __syscall int tee_shm_free(const struct device *dev, struct tee_shm *shm);
-
-static inline int z_impl_tee_shm_free(const struct device *dev, struct tee_shm *shm)
-{
-	return tee_rm_shm(dev, shm);
-}
 
 /**
  * @brief Receive a request for TEE Supplicant
@@ -618,18 +535,6 @@ static inline int z_impl_tee_shm_free(const struct device *dev, struct tee_shm *
  */
 __syscall int tee_suppl_recv(const struct device *dev, uint32_t *func, unsigned int *num_params,
 			     struct tee_param *param);
-
-static inline int z_impl_tee_suppl_recv(const struct device *dev, uint32_t *func,
-					unsigned int *num_params, struct tee_param *param)
-{
-	const struct tee_driver_api *api = (const struct tee_driver_api *)dev->api;
-
-	if (!api->suppl_recv) {
-		return -ENOSYS;
-	}
-
-	return api->suppl_recv(dev, func, num_params, param);
-}
 
 /**
  * @brief Send a request for TEE Supplicant function
@@ -647,18 +552,6 @@ static inline int z_impl_tee_suppl_recv(const struct device *dev, uint32_t *func
 __syscall int tee_suppl_send(const struct device *dev, unsigned int ret, unsigned int num_params,
 			     struct tee_param *param);
 
-static inline int z_impl_tee_suppl_send(const struct device *dev, unsigned int ret,
-					unsigned int num_params, struct tee_param *param)
-{
-	const struct tee_driver_api *api = (const struct tee_driver_api *)dev->api;
-
-	if (!api->suppl_send) {
-		return -ENOSYS;
-	}
-
-	return api->suppl_send(dev, ret, num_params, param);
-}
-
 #ifdef __cplusplus
 }
 #endif
@@ -667,6 +560,7 @@ static inline int z_impl_tee_suppl_send(const struct device *dev, unsigned int r
  * @}
  */
 
+#include <zephyr/drivers/tee/internal/tee_impl.h>
 #include <zephyr/syscalls/tee.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_TEE_H_ */

--- a/include/zephyr/drivers/tee/internal/tee_impl.h
+++ b/include/zephyr/drivers/tee/internal/tee_impl.h
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2023 EPAM Systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Inline syscall implementation for tee driver APIs.
+ */
+
+/*
+ * Copyright (c) 2015-2016, Linaro Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_TEE_H_
+#error "Should only be included by zephyr/drivers/tee.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_TEE_INTERNAL_TEE_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_TEE_INTERNAL_TEE_IMPL_H_
+
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/util.h>
+
+static inline int z_impl_tee_get_version(const struct device *dev, struct tee_version_info *info)
+{
+	const struct tee_driver_api *api = (const struct tee_driver_api *)dev->api;
+
+	if (!api->get_version) {
+		return -ENOSYS;
+	}
+
+	return api->get_version(dev, info);
+}
+
+static inline int z_impl_tee_open_session(const struct device *dev,
+					  struct tee_open_session_arg *arg,
+					  unsigned int num_param, struct tee_param *param,
+					  uint32_t *session_id)
+{
+	const struct tee_driver_api *api = (const struct tee_driver_api *)dev->api;
+
+	if (!api->open_session) {
+		return -ENOSYS;
+	}
+
+	return api->open_session(dev, arg, num_param, param, session_id);
+}
+
+static inline int z_impl_tee_close_session(const struct device *dev, uint32_t session_id)
+{
+	const struct tee_driver_api *api = (const struct tee_driver_api *)dev->api;
+
+	if (!api->close_session) {
+		return -ENOSYS;
+	}
+
+	return api->close_session(dev, session_id);
+}
+
+static inline int z_impl_tee_cancel(const struct device *dev, uint32_t session_id,
+				    uint32_t cancel_id)
+{
+	const struct tee_driver_api *api = (const struct tee_driver_api *)dev->api;
+
+	if (!api->cancel) {
+		return -ENOSYS;
+	}
+
+	return api->cancel(dev, session_id, cancel_id);
+}
+
+static inline int z_impl_tee_invoke_func(const struct device *dev, struct tee_invoke_func_arg *arg,
+					 unsigned int num_param, struct tee_param *param)
+{
+	const struct tee_driver_api *api = (const struct tee_driver_api *)dev->api;
+
+	if (!api->invoke_func) {
+		return -ENOSYS;
+	}
+
+	return api->invoke_func(dev, arg, num_param, param);
+}
+
+static inline int z_impl_tee_shm_register(const struct device *dev, void *addr, size_t size,
+					  uint32_t flags, struct tee_shm **shm)
+{
+	flags &= ~TEE_SHM_ALLOC;
+	return tee_add_shm(dev, addr, 0, size, flags | TEE_SHM_REGISTER, shm);
+}
+
+static inline int z_impl_tee_shm_unregister(const struct device *dev, struct tee_shm *shm)
+{
+	return tee_rm_shm(dev, shm);
+}
+
+static inline int z_impl_tee_shm_alloc(const struct device *dev, size_t size, uint32_t flags,
+				       struct tee_shm **shm)
+{
+	return tee_add_shm(dev, NULL, 0, size, flags | TEE_SHM_ALLOC | TEE_SHM_REGISTER, shm);
+}
+
+static inline int z_impl_tee_shm_free(const struct device *dev, struct tee_shm *shm)
+{
+	return tee_rm_shm(dev, shm);
+}
+
+static inline int z_impl_tee_suppl_recv(const struct device *dev, uint32_t *func,
+					unsigned int *num_params, struct tee_param *param)
+{
+	const struct tee_driver_api *api = (const struct tee_driver_api *)dev->api;
+
+	if (!api->suppl_recv) {
+		return -ENOSYS;
+	}
+
+	return api->suppl_recv(dev, func, num_params, param);
+}
+
+static inline int z_impl_tee_suppl_send(const struct device *dev, unsigned int ret,
+					unsigned int num_params, struct tee_param *param)
+{
+	const struct tee_driver_api *api = (const struct tee_driver_api *)dev->api;
+
+	if (!api->suppl_send) {
+		return -ENOSYS;
+	}
+
+	return api->suppl_send(dev, ret, num_params, param);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_TEE_INTERNAL_TEE_IMPL_H_ */

--- a/include/zephyr/drivers/uart.h
+++ b/include/zephyr/drivers/uart.h
@@ -468,18 +468,6 @@ __subsystem struct uart_driver_api {
  */
 __syscall int uart_err_check(const struct device *dev);
 
-static inline int z_impl_uart_err_check(const struct device *dev)
-{
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	if (api->err_check == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->err_check(dev);
-}
-
 /**
  * @defgroup uart_polling Polling UART API
  * @{
@@ -505,19 +493,6 @@ static inline int z_impl_uart_err_check(const struct device *dev)
  */
 __syscall int uart_poll_in(const struct device *dev, unsigned char *p_char);
 
-static inline int z_impl_uart_poll_in(const struct device *dev,
-				      unsigned char *p_char)
-{
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	if (api->poll_in == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->poll_in(dev, p_char);
-}
-
 /**
  * @brief Read a 16-bit datum from the device for input.
  *
@@ -539,25 +514,6 @@ static inline int z_impl_uart_poll_in(const struct device *dev,
  */
 __syscall int uart_poll_in_u16(const struct device *dev, uint16_t *p_u16);
 
-static inline int z_impl_uart_poll_in_u16(const struct device *dev,
-					  uint16_t *p_u16)
-{
-#ifdef CONFIG_UART_WIDE_DATA
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	if (api->poll_in_u16 == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->poll_in_u16(dev, p_u16);
-#else
-	ARG_UNUSED(dev);
-	ARG_UNUSED(p_u16);
-	return -ENOTSUP;
-#endif
-}
-
 /**
  * @brief Write a character to the device for output.
  *
@@ -575,15 +531,6 @@ static inline int z_impl_uart_poll_in_u16(const struct device *dev,
 __syscall void uart_poll_out(const struct device *dev,
 			     unsigned char out_char);
 
-static inline void z_impl_uart_poll_out(const struct device *dev,
-					unsigned char out_char)
-{
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	api->poll_out(dev, out_char);
-}
-
 /**
  * @brief Write a 16-bit datum to the device for output.
  *
@@ -599,20 +546,6 @@ static inline void z_impl_uart_poll_out(const struct device *dev,
  * @param out_u16 Wide data to send.
  */
 __syscall void uart_poll_out_u16(const struct device *dev, uint16_t out_u16);
-
-static inline void z_impl_uart_poll_out_u16(const struct device *dev,
-					    uint16_t out_u16)
-{
-#ifdef CONFIG_UART_WIDE_DATA
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	api->poll_out_u16(dev, out_u16);
-#else
-	ARG_UNUSED(dev);
-	ARG_UNUSED(out_u16);
-#endif
-}
 
 /**
  * @}
@@ -635,24 +568,6 @@ static inline void z_impl_uart_poll_out_u16(const struct device *dev,
 __syscall int uart_configure(const struct device *dev,
 			     const struct uart_config *cfg);
 
-static inline int z_impl_uart_configure(const struct device *dev,
-					const struct uart_config *cfg)
-{
-#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
-	const struct uart_driver_api *api =
-				(const struct uart_driver_api *)dev->api;
-
-	if (api->configure == NULL) {
-		return -ENOSYS;
-	}
-	return api->configure(dev, cfg);
-#else
-	ARG_UNUSED(dev);
-	ARG_UNUSED(cfg);
-	return -ENOTSUP;
-#endif
-}
-
 /**
  * @brief Get UART configuration.
  *
@@ -669,25 +584,6 @@ static inline int z_impl_uart_configure(const struct device *dev,
  */
 __syscall int uart_config_get(const struct device *dev,
 			      struct uart_config *cfg);
-
-static inline int z_impl_uart_config_get(const struct device *dev,
-					 struct uart_config *cfg)
-{
-#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
-	const struct uart_driver_api *api =
-				(const struct uart_driver_api *)dev->api;
-
-	if (api->config_get == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->config_get(dev, cfg);
-#else
-	ARG_UNUSED(dev);
-	ARG_UNUSED(cfg);
-	return -ENOTSUP;
-#endif
-}
 
 /**
  * @addtogroup uart_interrupt
@@ -866,40 +762,12 @@ static inline int uart_fifo_read_u16(const struct device *dev,
  */
 __syscall void uart_irq_tx_enable(const struct device *dev);
 
-static inline void z_impl_uart_irq_tx_enable(const struct device *dev)
-{
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	if (api->irq_tx_enable != NULL) {
-		api->irq_tx_enable(dev);
-	}
-#else
-	ARG_UNUSED(dev);
-#endif
-}
-
 /**
  * @brief Disable TX interrupt in IER.
  *
  * @param dev UART device instance.
  */
 __syscall void uart_irq_tx_disable(const struct device *dev);
-
-static inline void z_impl_uart_irq_tx_disable(const struct device *dev)
-{
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	if (api->irq_tx_disable != NULL) {
-		api->irq_tx_disable(dev);
-	}
-#else
-	ARG_UNUSED(dev);
-#endif
-}
 
 /**
  * @brief Check if UART TX buffer can accept a new char
@@ -943,40 +811,12 @@ static inline int uart_irq_tx_ready(const struct device *dev)
  */
 __syscall void uart_irq_rx_enable(const struct device *dev);
 
-static inline void z_impl_uart_irq_rx_enable(const struct device *dev)
-{
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	if (api->irq_rx_enable != NULL) {
-		api->irq_rx_enable(dev);
-	}
-#else
-	ARG_UNUSED(dev);
-#endif
-}
-
 /**
  * @brief Disable RX interrupt.
  *
  * @param dev UART device instance.
  */
 __syscall void uart_irq_rx_disable(const struct device *dev);
-
-static inline void z_impl_uart_irq_rx_disable(const struct device *dev)
-{
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	if (api->irq_rx_disable != NULL) {
-		api->irq_rx_disable(dev);
-	}
-#else
-	ARG_UNUSED(dev);
-#endif
-}
 
 /**
  * @brief Check if UART TX block finished transmission
@@ -1055,40 +895,12 @@ static inline int uart_irq_rx_ready(const struct device *dev)
  */
 __syscall void uart_irq_err_enable(const struct device *dev);
 
-static inline void z_impl_uart_irq_err_enable(const struct device *dev)
-{
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	if (api->irq_err_enable) {
-		api->irq_err_enable(dev);
-	}
-#else
-	ARG_UNUSED(dev);
-#endif
-}
-
 /**
  * @brief Disable error interrupt.
  *
  * @param dev UART device instance.
  */
 __syscall void uart_irq_err_disable(const struct device *dev);
-
-static inline void z_impl_uart_irq_err_disable(const struct device *dev)
-{
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	if (api->irq_err_disable) {
-		api->irq_err_disable(dev);
-	}
-#else
-	ARG_UNUSED(dev);
-#endif
-}
 
 /**
  * @brief Check if any IRQs is pending.
@@ -1101,22 +913,6 @@ static inline void z_impl_uart_irq_err_disable(const struct device *dev)
  * @retval -ENOTSUP If API is not enabled.
  */
 __syscall int uart_irq_is_pending(const struct device *dev);
-
-static inline int z_impl_uart_irq_is_pending(const struct device *dev)
-{
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	if (api->irq_is_pending == NULL) {
-		return -ENOSYS;
-	}
-	return api->irq_is_pending(dev);
-#else
-	ARG_UNUSED(dev);
-	return -ENOTSUP;
-#endif
-}
 
 /**
  * @brief Start processing interrupts in ISR.
@@ -1144,22 +940,6 @@ static inline int z_impl_uart_irq_is_pending(const struct device *dev)
  * @retval -ENOTSUP If API is not enabled.
  */
 __syscall int uart_irq_update(const struct device *dev);
-
-static inline int z_impl_uart_irq_update(const struct device *dev)
-{
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	if (api->irq_update == NULL) {
-		return -ENOSYS;
-	}
-	return api->irq_update(dev);
-#else
-	ARG_UNUSED(dev);
-	return -ENOTSUP;
-#endif
-}
 
 /**
  * @brief Set the IRQ callback function pointer.
@@ -1283,24 +1063,6 @@ __syscall int uart_tx(const struct device *dev, const uint8_t *buf,
 		      size_t len,
 		      int32_t timeout);
 
-static inline int z_impl_uart_tx(const struct device *dev, const uint8_t *buf,
-				 size_t len, int32_t timeout)
-
-{
-#ifdef CONFIG_UART_ASYNC_API
-	const struct uart_driver_api *api =
-			(const struct uart_driver_api *)dev->api;
-
-	return api->tx(dev, buf, len, timeout);
-#else
-	ARG_UNUSED(dev);
-	ARG_UNUSED(buf);
-	ARG_UNUSED(len);
-	ARG_UNUSED(timeout);
-	return -ENOTSUP;
-#endif
-}
-
 /**
  * @brief Send given number of datum from buffer through UART.
  *
@@ -1321,25 +1083,6 @@ static inline int z_impl_uart_tx(const struct device *dev, const uint8_t *buf,
 __syscall int uart_tx_u16(const struct device *dev, const uint16_t *buf,
 			  size_t len, int32_t timeout);
 
-static inline int z_impl_uart_tx_u16(const struct device *dev,
-				     const uint16_t *buf,
-				     size_t len, int32_t timeout)
-
-{
-#if defined(CONFIG_UART_ASYNC_API) && defined(CONFIG_UART_WIDE_DATA)
-	const struct uart_driver_api *api =
-			(const struct uart_driver_api *)dev->api;
-
-	return api->tx_u16(dev, buf, len, timeout);
-#else
-	ARG_UNUSED(dev);
-	ARG_UNUSED(buf);
-	ARG_UNUSED(len);
-	ARG_UNUSED(timeout);
-	return -ENOTSUP;
-#endif
-}
-
 /**
  * @brief Abort current TX transmission.
  *
@@ -1353,19 +1096,6 @@ static inline int z_impl_uart_tx_u16(const struct device *dev,
  * @retval -errno Other negative errno value in case of failure.
  */
 __syscall int uart_tx_abort(const struct device *dev);
-
-static inline int z_impl_uart_tx_abort(const struct device *dev)
-{
-#ifdef CONFIG_UART_ASYNC_API
-	const struct uart_driver_api *api =
-			(const struct uart_driver_api *)dev->api;
-
-	return api->tx_abort(dev);
-#else
-	ARG_UNUSED(dev);
-	return -ENOTSUP;
-#endif
-}
 
 /**
  * @brief Start receiving data through UART.
@@ -1392,24 +1122,6 @@ __syscall int uart_rx_enable(const struct device *dev, uint8_t *buf,
 			     size_t len,
 			     int32_t timeout);
 
-static inline int z_impl_uart_rx_enable(const struct device *dev,
-					uint8_t *buf,
-					size_t len, int32_t timeout)
-{
-#ifdef CONFIG_UART_ASYNC_API
-	const struct uart_driver_api *api =
-				(const struct uart_driver_api *)dev->api;
-
-	return api->rx_enable(dev, buf, len, timeout);
-#else
-	ARG_UNUSED(dev);
-	ARG_UNUSED(buf);
-	ARG_UNUSED(len);
-	ARG_UNUSED(timeout);
-	return -ENOTSUP;
-#endif
-}
-
 /**
  * @brief Start receiving wide data through UART.
  *
@@ -1433,24 +1145,6 @@ static inline int z_impl_uart_rx_enable(const struct device *dev,
  */
 __syscall int uart_rx_enable_u16(const struct device *dev, uint16_t *buf,
 				 size_t len, int32_t timeout);
-
-static inline int z_impl_uart_rx_enable_u16(const struct device *dev,
-					    uint16_t *buf, size_t len,
-					    int32_t timeout)
-{
-#if defined(CONFIG_UART_ASYNC_API) && defined(CONFIG_UART_WIDE_DATA)
-	const struct uart_driver_api *api =
-				(const struct uart_driver_api *)dev->api;
-
-	return api->rx_enable_u16(dev, buf, len, timeout);
-#else
-	ARG_UNUSED(dev);
-	ARG_UNUSED(buf);
-	ARG_UNUSED(len);
-	ARG_UNUSED(timeout);
-	return -ENOTSUP;
-#endif
-}
 
 /**
  * @brief Provide receive buffer in response to #UART_RX_BUF_REQUEST event.
@@ -1542,19 +1236,6 @@ static inline int uart_rx_buf_rsp_u16(const struct device *dev, uint16_t *buf,
  */
 __syscall int uart_rx_disable(const struct device *dev);
 
-static inline int z_impl_uart_rx_disable(const struct device *dev)
-{
-#ifdef CONFIG_UART_ASYNC_API
-	const struct uart_driver_api *api =
-			(const struct uart_driver_api *)dev->api;
-
-	return api->rx_disable(dev);
-#else
-	ARG_UNUSED(dev);
-	return -ENOTSUP;
-#endif
-}
-
 /**
  * @}
  */
@@ -1574,25 +1255,6 @@ static inline int z_impl_uart_rx_disable(const struct device *dev)
 __syscall int uart_line_ctrl_set(const struct device *dev,
 				 uint32_t ctrl, uint32_t val);
 
-static inline int z_impl_uart_line_ctrl_set(const struct device *dev,
-					    uint32_t ctrl, uint32_t val)
-{
-#ifdef CONFIG_UART_LINE_CTRL
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	if (api->line_ctrl_set == NULL) {
-		return -ENOSYS;
-	}
-	return api->line_ctrl_set(dev, ctrl, val);
-#else
-	ARG_UNUSED(dev);
-	ARG_UNUSED(ctrl);
-	ARG_UNUSED(val);
-	return -ENOTSUP;
-#endif
-}
-
 /**
  * @brief Retrieve line control for UART.
  *
@@ -1607,25 +1269,6 @@ static inline int z_impl_uart_line_ctrl_set(const struct device *dev,
  */
 __syscall int uart_line_ctrl_get(const struct device *dev, uint32_t ctrl,
 				 uint32_t *val);
-
-static inline int z_impl_uart_line_ctrl_get(const struct device *dev,
-					    uint32_t ctrl, uint32_t *val)
-{
-#ifdef CONFIG_UART_LINE_CTRL
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	if (api->line_ctrl_get == NULL) {
-		return -ENOSYS;
-	}
-	return api->line_ctrl_get(dev, ctrl, val);
-#else
-	ARG_UNUSED(dev);
-	ARG_UNUSED(ctrl);
-	ARG_UNUSED(val);
-	return -ENOTSUP;
-#endif
-}
 
 /**
  * @brief Send extra command to driver.
@@ -1644,25 +1287,6 @@ static inline int z_impl_uart_line_ctrl_get(const struct device *dev,
  */
 __syscall int uart_drv_cmd(const struct device *dev, uint32_t cmd, uint32_t p);
 
-static inline int z_impl_uart_drv_cmd(const struct device *dev, uint32_t cmd,
-				      uint32_t p)
-{
-#ifdef CONFIG_UART_DRV_CMD
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	if (api->drv_cmd == NULL) {
-		return -ENOSYS;
-	}
-	return api->drv_cmd(dev, cmd, p);
-#else
-	ARG_UNUSED(dev);
-	ARG_UNUSED(cmd);
-	ARG_UNUSED(p);
-	return -ENOTSUP;
-#endif
-}
-
 #ifdef __cplusplus
 }
 #endif
@@ -1671,6 +1295,7 @@ static inline int z_impl_uart_drv_cmd(const struct device *dev, uint32_t cmd,
  * @}
  */
 
+#include <zephyr/drivers/uart/internal/uart_impl.h>
 #include <zephyr/syscalls/uart.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_UART_H_ */

--- a/include/zephyr/drivers/uart/internal/uart_impl.h
+++ b/include/zephyr/drivers/uart/internal/uart_impl.h
@@ -1,0 +1,409 @@
+/*
+ * Copyright (c) 2018-2019 Nordic Semiconductor ASA
+ * Copyright (c) 2015 Wind River Systems, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Inline syscall implementations for UART APIs
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_UART_H_
+#error "Should only be included by zephyr/drivers/uart.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_UART_INTERNAL_UART_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_UART_INTERNAL_UART_IMPL_H_
+
+#include <errno.h>
+#include <stddef.h>
+
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_uart_err_check(const struct device *dev)
+{
+	const struct uart_driver_api *api =
+		(const struct uart_driver_api *)dev->api;
+
+	if (api->err_check == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->err_check(dev);
+}
+
+static inline int z_impl_uart_poll_in(const struct device *dev,
+				      unsigned char *p_char)
+{
+	const struct uart_driver_api *api =
+		(const struct uart_driver_api *)dev->api;
+
+	if (api->poll_in == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->poll_in(dev, p_char);
+}
+
+static inline int z_impl_uart_poll_in_u16(const struct device *dev,
+					  uint16_t *p_u16)
+{
+#ifdef CONFIG_UART_WIDE_DATA
+	const struct uart_driver_api *api =
+		(const struct uart_driver_api *)dev->api;
+
+	if (api->poll_in_u16 == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->poll_in_u16(dev, p_u16);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(p_u16);
+	return -ENOTSUP;
+#endif
+}
+
+static inline void z_impl_uart_poll_out(const struct device *dev,
+					unsigned char out_char)
+{
+	const struct uart_driver_api *api =
+		(const struct uart_driver_api *)dev->api;
+
+	api->poll_out(dev, out_char);
+}
+
+static inline void z_impl_uart_poll_out_u16(const struct device *dev,
+					    uint16_t out_u16)
+{
+#ifdef CONFIG_UART_WIDE_DATA
+	const struct uart_driver_api *api =
+		(const struct uart_driver_api *)dev->api;
+
+	api->poll_out_u16(dev, out_u16);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(out_u16);
+#endif
+}
+
+static inline int z_impl_uart_configure(const struct device *dev,
+					const struct uart_config *cfg)
+{
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
+	const struct uart_driver_api *api =
+				(const struct uart_driver_api *)dev->api;
+
+	if (api->configure == NULL) {
+		return -ENOSYS;
+	}
+	return api->configure(dev, cfg);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(cfg);
+	return -ENOTSUP;
+#endif
+}
+
+static inline int z_impl_uart_config_get(const struct device *dev,
+					 struct uart_config *cfg)
+{
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
+	const struct uart_driver_api *api =
+				(const struct uart_driver_api *)dev->api;
+
+	if (api->config_get == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->config_get(dev, cfg);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(cfg);
+	return -ENOTSUP;
+#endif
+}
+
+static inline void z_impl_uart_irq_tx_enable(const struct device *dev)
+{
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	const struct uart_driver_api *api =
+		(const struct uart_driver_api *)dev->api;
+
+	if (api->irq_tx_enable != NULL) {
+		api->irq_tx_enable(dev);
+	}
+#else
+	ARG_UNUSED(dev);
+#endif
+}
+
+static inline void z_impl_uart_irq_tx_disable(const struct device *dev)
+{
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	const struct uart_driver_api *api =
+		(const struct uart_driver_api *)dev->api;
+
+	if (api->irq_tx_disable != NULL) {
+		api->irq_tx_disable(dev);
+	}
+#else
+	ARG_UNUSED(dev);
+#endif
+}
+
+static inline void z_impl_uart_irq_rx_enable(const struct device *dev)
+{
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	const struct uart_driver_api *api =
+		(const struct uart_driver_api *)dev->api;
+
+	if (api->irq_rx_enable != NULL) {
+		api->irq_rx_enable(dev);
+	}
+#else
+	ARG_UNUSED(dev);
+#endif
+}
+
+static inline void z_impl_uart_irq_rx_disable(const struct device *dev)
+{
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	const struct uart_driver_api *api =
+		(const struct uart_driver_api *)dev->api;
+
+	if (api->irq_rx_disable != NULL) {
+		api->irq_rx_disable(dev);
+	}
+#else
+	ARG_UNUSED(dev);
+#endif
+}
+
+static inline void z_impl_uart_irq_err_enable(const struct device *dev)
+{
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	const struct uart_driver_api *api =
+		(const struct uart_driver_api *)dev->api;
+
+	if (api->irq_err_enable) {
+		api->irq_err_enable(dev);
+	}
+#else
+	ARG_UNUSED(dev);
+#endif
+}
+
+static inline void z_impl_uart_irq_err_disable(const struct device *dev)
+{
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	const struct uart_driver_api *api =
+		(const struct uart_driver_api *)dev->api;
+
+	if (api->irq_err_disable) {
+		api->irq_err_disable(dev);
+	}
+#else
+	ARG_UNUSED(dev);
+#endif
+}
+
+static inline int z_impl_uart_irq_is_pending(const struct device *dev)
+{
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	const struct uart_driver_api *api =
+		(const struct uart_driver_api *)dev->api;
+
+	if (api->irq_is_pending == NULL) {
+		return -ENOSYS;
+	}
+	return api->irq_is_pending(dev);
+#else
+	ARG_UNUSED(dev);
+	return -ENOTSUP;
+#endif
+}
+
+static inline int z_impl_uart_irq_update(const struct device *dev)
+{
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	const struct uart_driver_api *api =
+		(const struct uart_driver_api *)dev->api;
+
+	if (api->irq_update == NULL) {
+		return -ENOSYS;
+	}
+	return api->irq_update(dev);
+#else
+	ARG_UNUSED(dev);
+	return -ENOTSUP;
+#endif
+}
+
+static inline int z_impl_uart_tx(const struct device *dev, const uint8_t *buf,
+				 size_t len, int32_t timeout)
+
+{
+#ifdef CONFIG_UART_ASYNC_API
+	const struct uart_driver_api *api =
+			(const struct uart_driver_api *)dev->api;
+
+	return api->tx(dev, buf, len, timeout);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(buf);
+	ARG_UNUSED(len);
+	ARG_UNUSED(timeout);
+	return -ENOTSUP;
+#endif
+}
+
+static inline int z_impl_uart_tx_u16(const struct device *dev,
+				     const uint16_t *buf,
+				     size_t len, int32_t timeout)
+
+{
+#if defined(CONFIG_UART_ASYNC_API) && defined(CONFIG_UART_WIDE_DATA)
+	const struct uart_driver_api *api =
+			(const struct uart_driver_api *)dev->api;
+
+	return api->tx_u16(dev, buf, len, timeout);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(buf);
+	ARG_UNUSED(len);
+	ARG_UNUSED(timeout);
+	return -ENOTSUP;
+#endif
+}
+
+static inline int z_impl_uart_tx_abort(const struct device *dev)
+{
+#ifdef CONFIG_UART_ASYNC_API
+	const struct uart_driver_api *api =
+			(const struct uart_driver_api *)dev->api;
+
+	return api->tx_abort(dev);
+#else
+	ARG_UNUSED(dev);
+	return -ENOTSUP;
+#endif
+}
+
+static inline int z_impl_uart_rx_enable(const struct device *dev,
+					uint8_t *buf,
+					size_t len, int32_t timeout)
+{
+#ifdef CONFIG_UART_ASYNC_API
+	const struct uart_driver_api *api =
+				(const struct uart_driver_api *)dev->api;
+
+	return api->rx_enable(dev, buf, len, timeout);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(buf);
+	ARG_UNUSED(len);
+	ARG_UNUSED(timeout);
+	return -ENOTSUP;
+#endif
+}
+
+static inline int z_impl_uart_rx_enable_u16(const struct device *dev,
+					    uint16_t *buf, size_t len,
+					    int32_t timeout)
+{
+#if defined(CONFIG_UART_ASYNC_API) && defined(CONFIG_UART_WIDE_DATA)
+	const struct uart_driver_api *api =
+				(const struct uart_driver_api *)dev->api;
+
+	return api->rx_enable_u16(dev, buf, len, timeout);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(buf);
+	ARG_UNUSED(len);
+	ARG_UNUSED(timeout);
+	return -ENOTSUP;
+#endif
+}
+
+static inline int z_impl_uart_rx_disable(const struct device *dev)
+{
+#ifdef CONFIG_UART_ASYNC_API
+	const struct uart_driver_api *api =
+			(const struct uart_driver_api *)dev->api;
+
+	return api->rx_disable(dev);
+#else
+	ARG_UNUSED(dev);
+	return -ENOTSUP;
+#endif
+}
+
+static inline int z_impl_uart_line_ctrl_set(const struct device *dev,
+					    uint32_t ctrl, uint32_t val)
+{
+#ifdef CONFIG_UART_LINE_CTRL
+	const struct uart_driver_api *api =
+		(const struct uart_driver_api *)dev->api;
+
+	if (api->line_ctrl_set == NULL) {
+		return -ENOSYS;
+	}
+	return api->line_ctrl_set(dev, ctrl, val);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(ctrl);
+	ARG_UNUSED(val);
+	return -ENOTSUP;
+#endif
+}
+
+static inline int z_impl_uart_line_ctrl_get(const struct device *dev,
+					    uint32_t ctrl, uint32_t *val)
+{
+#ifdef CONFIG_UART_LINE_CTRL
+	const struct uart_driver_api *api =
+		(const struct uart_driver_api *)dev->api;
+
+	if (api->line_ctrl_get == NULL) {
+		return -ENOSYS;
+	}
+	return api->line_ctrl_get(dev, ctrl, val);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(ctrl);
+	ARG_UNUSED(val);
+	return -ENOTSUP;
+#endif
+}
+
+static inline int z_impl_uart_drv_cmd(const struct device *dev, uint32_t cmd,
+				      uint32_t p)
+{
+#ifdef CONFIG_UART_DRV_CMD
+	const struct uart_driver_api *api =
+		(const struct uart_driver_api *)dev->api;
+
+	if (api->drv_cmd == NULL) {
+		return -ENOSYS;
+	}
+	return api->drv_cmd(dev, cmd, p);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(p);
+	return -ENOTSUP;
+#endif
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_UART_INTERNAL_UART_IMPL_H_ */

--- a/include/zephyr/drivers/usb/internal/usb_bc12_impl.h
+++ b/include/zephyr/drivers/usb/internal/usb_bc12_impl.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022 Google LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Inline syscall implementation for USB BC1.2 battery charging detect driver APIs.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_USB_USB_BC12_H_
+#error "Should only be included by zephyr/drivers/usb/usb_bc12.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_USB_INTERNAL_USB_BC12_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_USB_INTERNAL_USB_BC12_IMPL_H_
+
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_bc12_set_role(const struct device *dev, enum bc12_role role)
+{
+	const struct bc12_driver_api *api = (const struct bc12_driver_api *)dev->api;
+
+	return api->set_role(dev, role);
+}
+
+static inline int z_impl_bc12_set_result_cb(const struct device *dev, bc12_callback_t cb,
+					    void *user_data)
+{
+	const struct bc12_driver_api *api = (const struct bc12_driver_api *)dev->api;
+
+	return api->set_result_cb(dev, cb, user_data);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_USB_INTERNAL_USB_BC12_IMPL_H_ */

--- a/include/zephyr/drivers/usb/usb_bc12.h
+++ b/include/zephyr/drivers/usb/usb_bc12.h
@@ -149,13 +149,6 @@ __subsystem struct bc12_driver_api {
  */
 __syscall int bc12_set_role(const struct device *dev, enum bc12_role role);
 
-static inline int z_impl_bc12_set_role(const struct device *dev, enum bc12_role role)
-{
-	const struct bc12_driver_api *api = (const struct bc12_driver_api *)dev->api;
-
-	return api->set_role(dev, role);
-}
-
 /**
  * @brief Register a callback for BC1.2 results.
  *
@@ -168,14 +161,6 @@ static inline int z_impl_bc12_set_role(const struct device *dev, enum bc12_role 
  */
 __syscall int bc12_set_result_cb(const struct device *dev, bc12_callback_t cb, void *user_data);
 
-static inline int z_impl_bc12_set_result_cb(const struct device *dev, bc12_callback_t cb,
-					    void *user_data)
-{
-	const struct bc12_driver_api *api = (const struct bc12_driver_api *)dev->api;
-
-	return api->set_result_cb(dev, cb, user_data);
-}
-
 #ifdef __cplusplus
 }
 #endif
@@ -184,6 +169,7 @@ static inline int z_impl_bc12_set_result_cb(const struct device *dev, bc12_callb
  * @}
  */
 
+#include <zephyr/drivers/usb/internal/usb_bc12_impl.h>
 #include <zephyr/syscalls/usb_bc12.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_USB_USB_BC12_H_ */

--- a/include/zephyr/drivers/virtualization/internal/ivshmem_impl.h
+++ b/include/zephyr/drivers/virtualization/internal/ivshmem_impl.h
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_VIRTUALIZATION_IVSHMEM_H_
+#error "Should only be included by zephyr/drivers/virtualization/ivshmem.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_VIRTUALIZATION_INTERNAL_IVSHMEM_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_VIRTUALIZATION_INTERNAL_IVSHMEM_IMPL_H_
+
+static inline size_t z_impl_ivshmem_get_mem(const struct device *dev,
+					    uintptr_t *memmap)
+{
+	const struct ivshmem_driver_api *api =
+		(const struct ivshmem_driver_api *)dev->api;
+
+	return api->get_mem(dev, memmap);
+}
+
+static inline uint32_t z_impl_ivshmem_get_id(const struct device *dev)
+{
+	const struct ivshmem_driver_api *api =
+		(const struct ivshmem_driver_api *)dev->api;
+
+	return api->get_id(dev);
+}
+
+static inline uint16_t z_impl_ivshmem_get_vectors(const struct device *dev)
+{
+	const struct ivshmem_driver_api *api =
+		(const struct ivshmem_driver_api *)dev->api;
+
+	return api->get_vectors(dev);
+}
+
+static inline int z_impl_ivshmem_int_peer(const struct device *dev,
+					  uint32_t peer_id, uint16_t vector)
+{
+	const struct ivshmem_driver_api *api =
+		(const struct ivshmem_driver_api *)dev->api;
+
+	return api->int_peer(dev, peer_id, vector);
+}
+
+static inline int z_impl_ivshmem_register_handler(const struct device *dev,
+						  struct k_poll_signal *ksignal,
+						  uint16_t vector)
+{
+	const struct ivshmem_driver_api *api =
+		(const struct ivshmem_driver_api *)dev->api;
+
+	return api->register_handler(dev, ksignal, vector);
+}
+
+#ifdef CONFIG_IVSHMEM_V2
+
+static inline size_t z_impl_ivshmem_get_rw_mem_section(const struct device *dev,
+						       uintptr_t *memmap)
+{
+	const struct ivshmem_driver_api *api =
+		(const struct ivshmem_driver_api *)dev->api;
+
+	return api->get_rw_mem_section(dev, memmap);
+}
+
+static inline size_t z_impl_ivshmem_get_output_mem_section(const struct device *dev,
+							   uint32_t peer_id,
+							   uintptr_t *memmap)
+{
+	const struct ivshmem_driver_api *api =
+		(const struct ivshmem_driver_api *)dev->api;
+
+	return api->get_output_mem_section(dev, peer_id, memmap);
+}
+
+static inline uint32_t z_impl_ivshmem_get_state(const struct device *dev,
+						uint32_t peer_id)
+{
+	const struct ivshmem_driver_api *api =
+		(const struct ivshmem_driver_api *)dev->api;
+
+	return api->get_state(dev, peer_id);
+}
+
+static inline int z_impl_ivshmem_set_state(const struct device *dev,
+					   uint32_t state)
+{
+	const struct ivshmem_driver_api *api =
+		(const struct ivshmem_driver_api *)dev->api;
+
+	return api->set_state(dev, state);
+}
+
+static inline uint32_t z_impl_ivshmem_get_max_peers(const struct device *dev)
+{
+	const struct ivshmem_driver_api *api =
+		(const struct ivshmem_driver_api *)dev->api;
+
+	return api->get_max_peers(dev);
+}
+
+static inline uint16_t z_impl_ivshmem_get_protocol(const struct device *dev)
+{
+	const struct ivshmem_driver_api *api =
+		(const struct ivshmem_driver_api *)dev->api;
+
+	return api->get_protocol(dev);
+}
+
+static inline int z_impl_ivshmem_enable_interrupts(const struct device *dev,
+						   bool enable)
+{
+	const struct ivshmem_driver_api *api =
+		(const struct ivshmem_driver_api *)dev->api;
+
+	return api->enable_interrupts(dev, enable);
+}
+
+#endif /* CONFIG_IVSHMEM_V2 */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_VIRTUALIZATION_INTERNAL_IVSHMEM_IMPL_H_ */

--- a/include/zephyr/drivers/virtualization/ivshmem.h
+++ b/include/zephyr/drivers/virtualization/ivshmem.h
@@ -98,15 +98,6 @@ __subsystem struct ivshmem_driver_api {
 __syscall size_t ivshmem_get_mem(const struct device *dev,
 				 uintptr_t *memmap);
 
-static inline size_t z_impl_ivshmem_get_mem(const struct device *dev,
-					    uintptr_t *memmap)
-{
-	const struct ivshmem_driver_api *api =
-		(const struct ivshmem_driver_api *)dev->api;
-
-	return api->get_mem(dev, memmap);
-}
-
 /**
  * @brief Get our VM ID
  *
@@ -116,14 +107,6 @@ static inline size_t z_impl_ivshmem_get_mem(const struct device *dev,
  */
 __syscall uint32_t ivshmem_get_id(const struct device *dev);
 
-static inline uint32_t z_impl_ivshmem_get_id(const struct device *dev)
-{
-	const struct ivshmem_driver_api *api =
-		(const struct ivshmem_driver_api *)dev->api;
-
-	return api->get_id(dev);
-}
-
 /**
  * @brief Get the number of interrupt vectors we can use
  *
@@ -132,14 +115,6 @@ static inline uint32_t z_impl_ivshmem_get_id(const struct device *dev)
  * @return the number of available interrupt vectors
  */
 __syscall uint16_t ivshmem_get_vectors(const struct device *dev);
-
-static inline uint16_t z_impl_ivshmem_get_vectors(const struct device *dev)
-{
-	const struct ivshmem_driver_api *api =
-		(const struct ivshmem_driver_api *)dev->api;
-
-	return api->get_vectors(dev);
-}
 
 /**
  * @brief Interrupt another VM
@@ -152,15 +127,6 @@ static inline uint16_t z_impl_ivshmem_get_vectors(const struct device *dev)
  */
 __syscall int ivshmem_int_peer(const struct device *dev,
 			       uint32_t peer_id, uint16_t vector);
-
-static inline int z_impl_ivshmem_int_peer(const struct device *dev,
-					  uint32_t peer_id, uint16_t vector)
-{
-	const struct ivshmem_driver_api *api =
-		(const struct ivshmem_driver_api *)dev->api;
-
-	return api->int_peer(dev, peer_id, vector);
-}
 
 /**
  * @brief Register a vector notification (interrupt) handler
@@ -181,16 +147,6 @@ __syscall int ivshmem_register_handler(const struct device *dev,
 				       struct k_poll_signal *signal,
 				       uint16_t vector);
 
-static inline int z_impl_ivshmem_register_handler(const struct device *dev,
-						  struct k_poll_signal *signal,
-						  uint16_t vector)
-{
-	const struct ivshmem_driver_api *api =
-		(const struct ivshmem_driver_api *)dev->api;
-
-	return api->register_handler(dev, signal, vector);
-}
-
 #ifdef CONFIG_IVSHMEM_V2
 
 /**
@@ -203,15 +159,6 @@ static inline int z_impl_ivshmem_register_handler(const struct device *dev,
  */
 __syscall size_t ivshmem_get_rw_mem_section(const struct device *dev,
 					    uintptr_t *memmap);
-
-static inline size_t z_impl_ivshmem_get_rw_mem_section(const struct device *dev,
-						       uintptr_t *memmap)
-{
-	const struct ivshmem_driver_api *api =
-		(const struct ivshmem_driver_api *)dev->api;
-
-	return api->get_rw_mem_section(dev, memmap);
-}
 
 /**
  * @brief Get the ivshmem output section for a peer (ivshmem-v2 only)
@@ -226,16 +173,6 @@ __syscall size_t ivshmem_get_output_mem_section(const struct device *dev,
 						uint32_t peer_id,
 						uintptr_t *memmap);
 
-static inline size_t z_impl_ivshmem_get_output_mem_section(const struct device *dev,
-							   uint32_t peer_id,
-							   uintptr_t *memmap)
-{
-	const struct ivshmem_driver_api *api =
-		(const struct ivshmem_driver_api *)dev->api;
-
-	return api->get_output_mem_section(dev, peer_id, memmap);
-}
-
 /**
  * @brief Get the state value of a peer (ivshmem-v2 only)
  *
@@ -246,15 +183,6 @@ static inline size_t z_impl_ivshmem_get_output_mem_section(const struct device *
  */
 __syscall uint32_t ivshmem_get_state(const struct device *dev,
 				     uint32_t peer_id);
-
-static inline uint32_t z_impl_ivshmem_get_state(const struct device *dev,
-						uint32_t peer_id)
-{
-	const struct ivshmem_driver_api *api =
-		(const struct ivshmem_driver_api *)dev->api;
-
-	return api->get_state(dev, peer_id);
-}
 
 /**
  * @brief Set our state (ivshmem-v2 only)
@@ -267,15 +195,6 @@ static inline uint32_t z_impl_ivshmem_get_state(const struct device *dev,
 __syscall int ivshmem_set_state(const struct device *dev,
 				uint32_t state);
 
-static inline int z_impl_ivshmem_set_state(const struct device *dev,
-					   uint32_t state)
-{
-	const struct ivshmem_driver_api *api =
-		(const struct ivshmem_driver_api *)dev->api;
-
-	return api->set_state(dev, state);
-}
-
 /**
  * @brief Get the maximum number of peers supported (ivshmem-v2 only)
  *
@@ -285,14 +204,6 @@ static inline int z_impl_ivshmem_set_state(const struct device *dev,
  */
 __syscall uint32_t ivshmem_get_max_peers(const struct device *dev);
 
-static inline uint32_t z_impl_ivshmem_get_max_peers(const struct device *dev)
-{
-	const struct ivshmem_driver_api *api =
-		(const struct ivshmem_driver_api *)dev->api;
-
-	return api->get_max_peers(dev);
-}
-
 /**
  * @brief Get the protocol used by this ivshmem instance (ivshmem-v2 only)
  *
@@ -301,14 +212,6 @@ static inline uint32_t z_impl_ivshmem_get_max_peers(const struct device *dev)
  * @return the protocol
  */
 __syscall uint16_t ivshmem_get_protocol(const struct device *dev);
-
-static inline uint16_t z_impl_ivshmem_get_protocol(const struct device *dev)
-{
-	const struct ivshmem_driver_api *api =
-		(const struct ivshmem_driver_api *)dev->api;
-
-	return api->get_protocol(dev);
-}
 
 /**
  * @brief Set the interrupt enablement for our VM (ivshmem-v2 only)
@@ -321,15 +224,6 @@ static inline uint16_t z_impl_ivshmem_get_protocol(const struct device *dev)
 __syscall int ivshmem_enable_interrupts(const struct device *dev,
 					bool enable);
 
-static inline int z_impl_ivshmem_enable_interrupts(const struct device *dev,
-						   bool enable)
-{
-	const struct ivshmem_driver_api *api =
-		(const struct ivshmem_driver_api *)dev->api;
-
-	return api->enable_interrupts(dev, enable);
-}
-
 #endif /* CONFIG_IVSHMEM_V2 */
 
 #ifdef __cplusplus
@@ -340,6 +234,7 @@ static inline int z_impl_ivshmem_enable_interrupts(const struct device *dev,
  * @}
  */
 
+#include <zephyr/drivers/virtualization/internal/ivshmem_impl.h>
 #include <zephyr/syscalls/ivshmem.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_VIRTUALIZATION_IVSHMEM_H_ */

--- a/include/zephyr/drivers/w1.h
+++ b/include/zephyr/drivers/w1.h
@@ -112,22 +112,6 @@ __subsystem struct w1_driver_api {
 
 /** @cond INTERNAL_HIDDEN */
 __syscall int w1_change_bus_lock(const struct device *dev, bool lock);
-
-static inline int z_impl_w1_change_bus_lock(const struct device *dev, bool lock)
-{
-	struct w1_master_data *ctrl_data = (struct w1_master_data *)dev->data;
-	const struct w1_driver_api *api = (const struct w1_driver_api *)dev->api;
-
-	if (api->change_bus_lock) {
-		return api->change_bus_lock(dev, lock);
-	}
-
-	if (lock) {
-		return k_mutex_lock(&ctrl_data->bus_lock, K_FOREVER);
-	} else {
-		return k_mutex_unlock(&ctrl_data->bus_lock);
-	}
-}
 /** @endcond */
 
 /**
@@ -190,13 +174,6 @@ static inline int w1_unlock_bus(const struct device *dev)
  */
 __syscall int w1_reset_bus(const struct device *dev);
 
-static inline int z_impl_w1_reset_bus(const struct device *dev)
-{
-	const struct w1_driver_api *api = (const struct w1_driver_api *)dev->api;
-
-	return api->reset_bus(dev);
-}
-
 /**
  * @brief Read a single bit from the 1-Wire bus.
  *
@@ -206,13 +183,6 @@ static inline int z_impl_w1_reset_bus(const struct device *dev)
  * @retval -errno Negative error code on error.
  */
 __syscall int w1_read_bit(const struct device *dev);
-
-static inline int z_impl_w1_read_bit(const struct device *dev)
-{
-	const struct w1_driver_api *api = (const struct w1_driver_api *)dev->api;
-
-	return api->read_bit(dev);
-}
 
 /**
  * @brief Write a single bit to the 1-Wire bus.
@@ -225,13 +195,6 @@ static inline int z_impl_w1_read_bit(const struct device *dev)
  */
 __syscall int w1_write_bit(const struct device *dev, const bool bit);
 
-static inline int z_impl_w1_write_bit(const struct device *dev, bool bit)
-{
-	const struct w1_driver_api *api = (const struct w1_driver_api *)dev->api;
-
-	return api->write_bit(dev, bit);
-}
-
 /**
  * @brief Read a single byte from the 1-Wire bus.
  *
@@ -241,13 +204,6 @@ static inline int z_impl_w1_write_bit(const struct device *dev, bool bit)
  * @retval -errno  Negative error code on error.
  */
 __syscall int w1_read_byte(const struct device *dev);
-
-static inline int z_impl_w1_read_byte(const struct device *dev)
-{
-	const struct w1_driver_api *api = (const struct w1_driver_api *)dev->api;
-
-	return api->read_byte(dev);
-}
 
 /**
  * @brief Write a single byte to the 1-Wire bus.
@@ -259,13 +215,6 @@ static inline int z_impl_w1_read_byte(const struct device *dev)
  * @retval -errno Negative error code on error.
  */
 __syscall int w1_write_byte(const struct device *dev, uint8_t byte);
-
-static inline int z_impl_w1_write_byte(const struct device *dev, uint8_t byte)
-{
-	const struct w1_driver_api *api = (const struct w1_driver_api *)dev->api;
-
-	return api->write_byte(dev, byte);
-}
 
 /**
  * @brief Read a block of data from the 1-Wire bus.
@@ -302,14 +251,6 @@ __syscall int w1_write_block(const struct device *dev,
  */
 __syscall size_t w1_get_slave_count(const struct device *dev);
 
-static inline size_t z_impl_w1_get_slave_count(const struct device *dev)
-{
-	const struct w1_master_config *ctrl_cfg =
-		(const struct w1_master_config *)dev->config;
-
-	return ctrl_cfg->slave_count;
-}
-
 /**
  * @brief Configure parameters of the 1-Wire master.
  *
@@ -326,14 +267,6 @@ static inline size_t z_impl_w1_get_slave_count(const struct device *dev)
  */
 __syscall int w1_configure(const struct device *dev,
 			   enum w1_settings_type type, uint32_t value);
-
-static inline int z_impl_w1_configure(const struct device *dev,
-				      enum w1_settings_type type, uint32_t value)
-{
-	const struct w1_driver_api *api = (const struct w1_driver_api *)dev->api;
-
-	return api->configure(dev, type, value);
-}
 
 /**
  * @}
@@ -720,6 +653,8 @@ static inline uint16_t w1_crc16(const uint16_t seed, const uint8_t *src,
 /**
  * @}
  */
+
+#include <zephyr/drivers/w1/internal/w1_impl.h>
 #include <zephyr/syscalls/w1.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_W1_H_ */

--- a/include/zephyr/drivers/w1/internal/w1_impl.h
+++ b/include/zephyr/drivers/w1/internal/w1_impl.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2018 Roman Tataurov <diytronic@yandex.ru>
+ * Copyright (c) 2022 Thomas Stranger
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Inline syscall implementation for 1-Wire Driver APIs
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_W1_H_
+#error "Should only be included by zephyr/drivers/w1.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_W1_INTERNAL_W1_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_W1_INTERNAL_W1_IMPL_H_
+
+#include <zephyr/types.h>
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/crc.h>
+#include <zephyr/sys/byteorder.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_w1_change_bus_lock(const struct device *dev, bool lock)
+{
+	struct w1_master_data *ctrl_data = (struct w1_master_data *)dev->data;
+	const struct w1_driver_api *api = (const struct w1_driver_api *)dev->api;
+
+	if (api->change_bus_lock) {
+		return api->change_bus_lock(dev, lock);
+	}
+
+	if (lock) {
+		return k_mutex_lock(&ctrl_data->bus_lock, K_FOREVER);
+	} else {
+		return k_mutex_unlock(&ctrl_data->bus_lock);
+	}
+}
+
+static inline int z_impl_w1_reset_bus(const struct device *dev)
+{
+	const struct w1_driver_api *api = (const struct w1_driver_api *)dev->api;
+
+	return api->reset_bus(dev);
+}
+
+static inline int z_impl_w1_read_bit(const struct device *dev)
+{
+	const struct w1_driver_api *api = (const struct w1_driver_api *)dev->api;
+
+	return api->read_bit(dev);
+}
+
+static inline int z_impl_w1_write_bit(const struct device *dev, bool bit)
+{
+	const struct w1_driver_api *api = (const struct w1_driver_api *)dev->api;
+
+	return api->write_bit(dev, bit);
+}
+
+static inline int z_impl_w1_read_byte(const struct device *dev)
+{
+	const struct w1_driver_api *api = (const struct w1_driver_api *)dev->api;
+
+	return api->read_byte(dev);
+}
+
+static inline int z_impl_w1_write_byte(const struct device *dev, uint8_t byte)
+{
+	const struct w1_driver_api *api = (const struct w1_driver_api *)dev->api;
+
+	return api->write_byte(dev, byte);
+}
+
+static inline size_t z_impl_w1_get_slave_count(const struct device *dev)
+{
+	const struct w1_master_config *ctrl_cfg =
+		(const struct w1_master_config *)dev->config;
+
+	return ctrl_cfg->slave_count;
+}
+
+static inline int z_impl_w1_configure(const struct device *dev,
+				      enum w1_settings_type type, uint32_t value)
+{
+	const struct w1_driver_api *api = (const struct w1_driver_api *)dev->api;
+
+	return api->configure(dev, type, value);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_W1_INTERNAL_W1_IMPL_H_ */

--- a/include/zephyr/drivers/watchdog.h
+++ b/include/zephyr/drivers/watchdog.h
@@ -161,14 +161,6 @@ __subsystem struct wdt_driver_api {
  */
 __syscall int wdt_setup(const struct device *dev, uint8_t options);
 
-static inline int z_impl_wdt_setup(const struct device *dev, uint8_t options)
-{
-	const struct wdt_driver_api *api =
-		(const struct wdt_driver_api *)dev->api;
-
-	return api->setup(dev, options);
-}
-
 /**
  * @brief Disable watchdog instance.
  *
@@ -184,14 +176,6 @@ static inline int z_impl_wdt_setup(const struct device *dev, uint8_t options)
  * @retval -errno In case of any other failure.
  */
 __syscall int wdt_disable(const struct device *dev);
-
-static inline int z_impl_wdt_disable(const struct device *dev)
-{
-	const struct wdt_driver_api *api =
-		(const struct wdt_driver_api *)dev->api;
-
-	return api->disable(dev);
-}
 
 /**
  * @brief Install a new timeout.
@@ -239,20 +223,13 @@ static inline int wdt_install_timeout(const struct device *dev,
  */
 __syscall int wdt_feed(const struct device *dev, int channel_id);
 
-static inline int z_impl_wdt_feed(const struct device *dev, int channel_id)
-{
-	const struct wdt_driver_api *api =
-		(const struct wdt_driver_api *)dev->api;
-
-	return api->feed(dev, channel_id);
-}
-
 #ifdef __cplusplus
 }
 #endif
 
 /** @} */
 
+#include <zephyr/drivers/watchdog/internal/watchdog_impl.h>
 #include <zephyr/syscalls/watchdog.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_WATCHDOG_H_ */

--- a/include/zephyr/drivers/watchdog/internal/watchdog_impl.h
+++ b/include/zephyr/drivers/watchdog/internal/watchdog_impl.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2017 Nordic Semiconductor ASA
+ * Copyright (c) 2015 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_WATCHDOG_H_
+#error "Should only be included by zephyr/drivers/watchdog.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_WATCHDOG_INTERNAL_WATCHDOG_IMPL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_WATCHDOG_INTERNAL_WATCHDOG_IMPL_H_
+
+#include <zephyr/types.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_wdt_setup(const struct device *dev, uint8_t options)
+{
+	const struct wdt_driver_api *api =
+		(const struct wdt_driver_api *)dev->api;
+
+	return api->setup(dev, options);
+}
+
+static inline int z_impl_wdt_disable(const struct device *dev)
+{
+	const struct wdt_driver_api *api =
+		(const struct wdt_driver_api *)dev->api;
+
+	return api->disable(dev);
+}
+
+static inline int z_impl_wdt_feed(const struct device *dev, int channel_id)
+{
+	const struct wdt_driver_api *api =
+		(const struct wdt_driver_api *)dev->api;
+
+	return api->feed(dev, channel_id);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_WATCHDOG_INTERNAL_WATCHDOG_IMPL_H_ */

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -720,12 +720,6 @@ k_ticks_t z_timeout_remaining(const struct _timeout *timeout);
  */
 __syscall k_ticks_t k_thread_timeout_expires_ticks(const struct k_thread *thread);
 
-static inline k_ticks_t z_impl_k_thread_timeout_expires_ticks(
-						const struct k_thread *thread)
-{
-	return z_timeout_expires(&thread->base.timeout);
-}
-
 /**
  * @brief Get time remaining before a thread wakes up, in system ticks
  *
@@ -734,12 +728,6 @@ static inline k_ticks_t z_impl_k_thread_timeout_expires_ticks(
  * waiting, it returns zero.
  */
 __syscall k_ticks_t k_thread_timeout_remaining_ticks(const struct k_thread *thread);
-
-static inline k_ticks_t z_impl_k_thread_timeout_remaining_ticks(
-						const struct k_thread *thread)
-{
-	return z_timeout_remaining(&thread->base.timeout);
-}
 
 #endif /* CONFIG_SYS_CLOCK_EXISTS */
 
@@ -1715,12 +1703,6 @@ __syscall uint32_t k_timer_status_sync(struct k_timer *timer);
  */
 __syscall k_ticks_t k_timer_expires_ticks(const struct k_timer *timer);
 
-static inline k_ticks_t z_impl_k_timer_expires_ticks(
-				       const struct k_timer *timer)
-{
-	return z_timeout_expires(&timer->timeout);
-}
-
 /**
  * @brief Get time remaining before a timer next expires, in system ticks
  *
@@ -1732,12 +1714,6 @@ static inline k_ticks_t z_impl_k_timer_expires_ticks(
  * @return Remaining time until expiration, in ticks
  */
 __syscall k_ticks_t k_timer_remaining_ticks(const struct k_timer *timer);
-
-static inline k_ticks_t z_impl_k_timer_remaining_ticks(
-				       const struct k_timer *timer)
-{
-	return z_timeout_remaining(&timer->timeout);
-}
 
 /**
  * @brief Get time remaining before a timer next expires.
@@ -1771,15 +1747,6 @@ static inline uint32_t k_timer_remaining_get(struct k_timer *timer)
 __syscall void k_timer_user_data_set(struct k_timer *timer, void *user_data);
 
 /**
- * @internal
- */
-static inline void z_impl_k_timer_user_data_set(struct k_timer *timer,
-					       void *user_data)
-{
-	timer->user_data = user_data;
-}
-
-/**
  * @brief Retrieve the user-specific data from a timer.
  *
  * @param timer     Address of timer.
@@ -1787,11 +1754,6 @@ static inline void z_impl_k_timer_user_data_set(struct k_timer *timer,
  * @return The user data.
  */
 __syscall void *k_timer_user_data_get(const struct k_timer *timer);
-
-static inline void *z_impl_k_timer_user_data_get(const struct k_timer *timer)
-{
-	return timer->user_data;
-}
 
 /** @} */
 
@@ -2166,11 +2128,6 @@ bool k_queue_unique_append(struct k_queue *queue, void *data);
  * @return 0 if data is available.
  */
 __syscall int k_queue_is_empty(struct k_queue *queue);
-
-static inline int z_impl_k_queue_is_empty(struct k_queue *queue)
-{
-	return sys_sflist_is_empty(&queue->data_q) ? 1 : 0;
-}
 
 /**
  * @brief Peek element at the head of queue.
@@ -3301,14 +3258,6 @@ __syscall void k_sem_reset(struct k_sem *sem);
  * @return Current semaphore count.
  */
 __syscall unsigned int k_sem_count_get(struct k_sem *sem);
-
-/**
- * @internal
- */
-static inline unsigned int z_impl_k_sem_count_get(struct k_sem *sem)
-{
-	return sem->count;
-}
 
 /**
  * @brief Statically define and initialize a semaphore.
@@ -4758,11 +4707,6 @@ __syscall void  k_msgq_get_attrs(struct k_msgq *msgq,
 				 struct k_msgq_attrs *attrs);
 
 
-static inline uint32_t z_impl_k_msgq_num_free_get(struct k_msgq *msgq)
-{
-	return msgq->max_msgs - msgq->used_msgs;
-}
-
 /**
  * @brief Get the number of messages in a message queue.
  *
@@ -4773,11 +4717,6 @@ static inline uint32_t z_impl_k_msgq_num_free_get(struct k_msgq *msgq)
  * @return Number of messages.
  */
 __syscall uint32_t k_msgq_num_used_get(struct k_msgq *msgq);
-
-static inline uint32_t z_impl_k_msgq_num_used_get(struct k_msgq *msgq)
-{
-	return msgq->used_msgs;
-}
 
 /** @} */
 
@@ -6247,6 +6186,7 @@ void k_sys_runtime_stats_disable(void);
 #endif
 
 #include <zephyr/tracing/tracing.h>
+#include <zephyr/kernel/internal/kernel_impl.h>
 #include <zephyr/syscalls/kernel.h>
 
 #endif /* !_ASMLANGUAGE */

--- a/include/zephyr/kernel/internal/kernel_impl.h
+++ b/include/zephyr/kernel/internal/kernel_impl.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2016, Wind River Systems, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Inline syscall implementation for kernel APIs.
+ */
+
+#ifndef ZEPHYR_INCLUDE_KERNEL_H_
+#error "Should only be included by zephyr/kernel.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_KERNEL_INTERNAL_KERNEL_IMPL_H_
+#define ZEPHYR_INCLUDE_KERNEL_INTERNAL_KERNEL_IMPL_H_
+
+#if !defined(_ASMLANGUAGE)
+#include <zephyr/kernel_includes.h>
+#include <errno.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/tracing/tracing_macros.h>
+#include <zephyr/sys/mem_stats.h>
+#include <zephyr/sys/iterable_sections.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef CONFIG_SYS_CLOCK_EXISTS
+
+static inline k_ticks_t z_impl_k_thread_timeout_expires_ticks(
+						const struct k_thread *thread)
+{
+	return z_timeout_expires(&thread->base.timeout);
+}
+
+static inline k_ticks_t z_impl_k_thread_timeout_remaining_ticks(
+						const struct k_thread *thread)
+{
+	return z_timeout_remaining(&thread->base.timeout);
+}
+
+static inline k_ticks_t z_impl_k_timer_expires_ticks(
+				       const struct k_timer *timer)
+{
+	return z_timeout_expires(&timer->timeout);
+}
+
+static inline k_ticks_t z_impl_k_timer_remaining_ticks(
+				       const struct k_timer *timer)
+{
+	return z_timeout_remaining(&timer->timeout);
+}
+
+#endif /* CONFIG_SYS_CLOCK_EXISTS */
+
+static inline void z_impl_k_timer_user_data_set(struct k_timer *timer,
+					       void *user_data)
+{
+	timer->user_data = user_data;
+}
+
+static inline void *z_impl_k_timer_user_data_get(const struct k_timer *timer)
+{
+	return timer->user_data;
+}
+
+static inline int z_impl_k_queue_is_empty(struct k_queue *queue)
+{
+	return sys_sflist_is_empty(&queue->data_q) ? 1 : 0;
+}
+
+static inline unsigned int z_impl_k_sem_count_get(struct k_sem *sem)
+{
+	return sem->count;
+}
+
+static inline uint32_t z_impl_k_msgq_num_free_get(struct k_msgq *msgq)
+{
+	return msgq->max_msgs - msgq->used_msgs;
+}
+
+static inline uint32_t z_impl_k_msgq_num_used_get(struct k_msgq *msgq)
+{
+	return msgq->used_msgs;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !_ASMLANGUAGE */
+
+#endif /* ZEPHYR_INCLUDE_KERNEL_INTERNAL_KERNEL_IMPL_H_ */

--- a/include/zephyr/rtio/internal/rtio_impl.h
+++ b/include/zephyr/rtio/internal/rtio_impl.h
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2022 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Inline syscall implementation for RTIO APIs
+ */
+
+#ifndef ZEPHYR_INCLUDE_RTIO_RTIO_H_
+#error "Should only be included by zephyr/drivers/rtio/rtio.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_RTIO_INTERNAL_RTIO_IMPL_H_
+#define ZEPHYR_INCLUDE_RTIO_INTERNAL_RTIO_IMPL_H_
+
+#include <string.h>
+
+#include <zephyr/app_memory/app_memdomain.h>
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/sys/mem_blocks.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/iterable_sections.h>
+#include <zephyr/sys/mpsc_lockfree.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int z_impl_rtio_cqe_get_mempool_buffer(const struct rtio *r, struct rtio_cqe *cqe,
+						     uint8_t **buff, uint32_t *buff_len)
+{
+#ifdef CONFIG_RTIO_SYS_MEM_BLOCKS
+	if (RTIO_CQE_FLAG_GET(cqe->flags) == RTIO_CQE_FLAG_MEMPOOL_BUFFER) {
+		int blk_idx = RTIO_CQE_FLAG_MEMPOOL_GET_BLK_IDX(cqe->flags);
+		int blk_count = RTIO_CQE_FLAG_MEMPOOL_GET_BLK_CNT(cqe->flags);
+		uint32_t blk_size = rtio_mempool_block_size(r);
+
+		*buff = r->block_pool->buffer + blk_idx * blk_size;
+		*buff_len = blk_count * blk_size;
+		__ASSERT_NO_MSG(*buff >= r->block_pool->buffer);
+		__ASSERT_NO_MSG(*buff <
+				r->block_pool->buffer + blk_size * r->block_pool->info.num_blocks);
+		return 0;
+	}
+	return -EINVAL;
+#else
+	ARG_UNUSED(r);
+	ARG_UNUSED(cqe);
+	ARG_UNUSED(buff);
+	ARG_UNUSED(buff_len);
+
+	return -ENOTSUP;
+#endif
+}
+
+static inline void z_impl_rtio_release_buffer(struct rtio *r, void *buff, uint32_t buff_len)
+{
+#ifdef CONFIG_RTIO_SYS_MEM_BLOCKS
+	if (r == NULL || buff == NULL || r->block_pool == NULL || buff_len == 0) {
+		return;
+	}
+
+	rtio_block_pool_free(r, buff, buff_len);
+#else
+	ARG_UNUSED(r);
+	ARG_UNUSED(buff);
+	ARG_UNUSED(buff_len);
+#endif
+}
+
+static inline int z_impl_rtio_sqe_cancel(struct rtio_sqe *sqe)
+{
+	struct rtio_iodev_sqe *iodev_sqe = CONTAINER_OF(sqe, struct rtio_iodev_sqe, sqe);
+
+	do {
+		iodev_sqe->sqe.flags |= RTIO_SQE_CANCELED;
+		iodev_sqe = rtio_iodev_sqe_next(iodev_sqe);
+	} while (iodev_sqe != NULL);
+
+	return 0;
+}
+
+static inline int z_impl_rtio_sqe_copy_in_get_handles(struct rtio *r, const struct rtio_sqe *sqes,
+						      struct rtio_sqe **handle,
+						      size_t sqe_count)
+{
+	struct rtio_sqe *sqe;
+	uint32_t acquirable = rtio_sqe_acquirable(r);
+
+	if (acquirable < sqe_count) {
+		return -ENOMEM;
+	}
+
+	for (unsigned long i = 0; i < sqe_count; i++) {
+		sqe = rtio_sqe_acquire(r);
+		__ASSERT_NO_MSG(sqe != NULL);
+		if (handle != NULL && i == 0) {
+			*handle = sqe;
+		}
+		*sqe = sqes[i];
+	}
+
+	return 0;
+}
+
+static inline int z_impl_rtio_cqe_copy_out(struct rtio *r,
+					   struct rtio_cqe *cqes,
+					   size_t cqe_count,
+					   k_timeout_t timeout)
+{
+	size_t copied = 0;
+	struct rtio_cqe *cqe;
+	k_timepoint_t end = sys_timepoint_calc(timeout);
+
+	do {
+		cqe = K_TIMEOUT_EQ(timeout, K_FOREVER) ? rtio_cqe_consume_block(r)
+						       : rtio_cqe_consume(r);
+		if (cqe == NULL) {
+#ifdef CONFIG_BOARD_NATIVE_POSIX
+			/* Native posix fakes the clock and only moves it forward when sleeping. */
+			k_sleep(K_TICKS(1));
+#else
+			Z_SPIN_DELAY(1);
+#endif
+			continue;
+		}
+		cqes[copied++] = *cqe;
+		rtio_cqe_release(r, cqe);
+	} while (copied < cqe_count && !sys_timepoint_expired(end));
+
+	return copied;
+}
+
+static inline int z_impl_rtio_submit(struct rtio *r, uint32_t wait_count)
+{
+	int res = 0;
+
+#ifdef CONFIG_RTIO_SUBMIT_SEM
+	/* TODO undefined behavior if another thread calls submit of course
+	 */
+	if (wait_count > 0) {
+		__ASSERT(!k_is_in_isr(),
+			 "expected rtio submit with wait count to be called from a thread");
+
+		k_sem_reset(r->submit_sem);
+		r->submit_count = wait_count;
+	}
+#else
+	uintptr_t cq_count = (uintptr_t)atomic_get(&r->cq_count) + wait_count;
+#endif
+
+	/* Submit the queue to the executor which consumes submissions
+	 * and produces completions through ISR chains or other means.
+	 */
+	rtio_executor_submit(r);
+
+
+	/* TODO could be nicer if we could suspend the thread and not
+	 * wake up on each completion here.
+	 */
+#ifdef CONFIG_RTIO_SUBMIT_SEM
+
+	if (wait_count > 0) {
+		res = k_sem_take(r->submit_sem, K_FOREVER);
+		__ASSERT(res == 0,
+			 "semaphore was reset or timed out while waiting on completions!");
+	}
+#else
+	while ((uintptr_t)atomic_get(&r->cq_count) < cq_count) {
+		Z_SPIN_DELAY(10);
+		k_yield();
+	}
+#endif
+
+	return res;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_RTIO_INTERNAL_RTIO_IMPL_H_ */

--- a/include/zephyr/rtio/rtio.h
+++ b/include/zephyr/rtio/rtio.h
@@ -1067,33 +1067,6 @@ static inline uint32_t rtio_cqe_compute_flags(struct rtio_iodev_sqe *iodev_sqe)
 __syscall int rtio_cqe_get_mempool_buffer(const struct rtio *r, struct rtio_cqe *cqe,
 					  uint8_t **buff, uint32_t *buff_len);
 
-static inline int z_impl_rtio_cqe_get_mempool_buffer(const struct rtio *r, struct rtio_cqe *cqe,
-						     uint8_t **buff, uint32_t *buff_len)
-{
-#ifdef CONFIG_RTIO_SYS_MEM_BLOCKS
-	if (RTIO_CQE_FLAG_GET(cqe->flags) == RTIO_CQE_FLAG_MEMPOOL_BUFFER) {
-		int blk_idx = RTIO_CQE_FLAG_MEMPOOL_GET_BLK_IDX(cqe->flags);
-		int blk_count = RTIO_CQE_FLAG_MEMPOOL_GET_BLK_CNT(cqe->flags);
-		uint32_t blk_size = rtio_mempool_block_size(r);
-
-		*buff = r->block_pool->buffer + blk_idx * blk_size;
-		*buff_len = blk_count * blk_size;
-		__ASSERT_NO_MSG(*buff >= r->block_pool->buffer);
-		__ASSERT_NO_MSG(*buff <
-				r->block_pool->buffer + blk_size * r->block_pool->info.num_blocks);
-		return 0;
-	}
-	return -EINVAL;
-#else
-	ARG_UNUSED(r);
-	ARG_UNUSED(cqe);
-	ARG_UNUSED(buff);
-	ARG_UNUSED(buff_len);
-
-	return -ENOTSUP;
-#endif
-}
-
 void rtio_executor_submit(struct rtio *r);
 void rtio_executor_ok(struct rtio_iodev_sqe *iodev_sqe, int result);
 void rtio_executor_err(struct rtio_iodev_sqe *iodev_sqe, int result);
@@ -1232,21 +1205,6 @@ static inline int rtio_sqe_rx_buf(const struct rtio_iodev_sqe *iodev_sqe, uint32
  */
 __syscall void rtio_release_buffer(struct rtio *r, void *buff, uint32_t buff_len);
 
-static inline void z_impl_rtio_release_buffer(struct rtio *r, void *buff, uint32_t buff_len)
-{
-#ifdef CONFIG_RTIO_SYS_MEM_BLOCKS
-	if (r == NULL || buff == NULL || r->block_pool == NULL || buff_len == 0) {
-		return;
-	}
-
-	rtio_block_pool_free(r, buff, buff_len);
-#else
-	ARG_UNUSED(r);
-	ARG_UNUSED(buff);
-	ARG_UNUSED(buff_len);
-#endif
-}
-
 /**
  * Grant access to an RTIO context to a user thread
  */
@@ -1275,18 +1233,6 @@ static inline void rtio_access_grant(struct rtio *r, struct k_thread *t)
  */
 __syscall int rtio_sqe_cancel(struct rtio_sqe *sqe);
 
-static inline int z_impl_rtio_sqe_cancel(struct rtio_sqe *sqe)
-{
-	struct rtio_iodev_sqe *iodev_sqe = CONTAINER_OF(sqe, struct rtio_iodev_sqe, sqe);
-
-	do {
-		iodev_sqe->sqe.flags |= RTIO_SQE_CANCELED;
-		iodev_sqe = rtio_iodev_sqe_next(iodev_sqe);
-	} while (iodev_sqe != NULL);
-
-	return 0;
-}
-
 /**
  * @brief Copy an array of SQEs into the queue and get resulting handles back
  *
@@ -1304,29 +1250,6 @@ static inline int z_impl_rtio_sqe_cancel(struct rtio_sqe *sqe)
  */
 __syscall int rtio_sqe_copy_in_get_handles(struct rtio *r, const struct rtio_sqe *sqes,
 					   struct rtio_sqe **handle, size_t sqe_count);
-
-static inline int z_impl_rtio_sqe_copy_in_get_handles(struct rtio *r, const struct rtio_sqe *sqes,
-						      struct rtio_sqe **handle,
-						      size_t sqe_count)
-{
-	struct rtio_sqe *sqe;
-	uint32_t acquirable = rtio_sqe_acquirable(r);
-
-	if (acquirable < sqe_count) {
-		return -ENOMEM;
-	}
-
-	for (unsigned long i = 0; i < sqe_count; i++) {
-		sqe = rtio_sqe_acquire(r);
-		__ASSERT_NO_MSG(sqe != NULL);
-		if (handle != NULL && i == 0) {
-			*handle = sqe;
-		}
-		*sqe = sqes[i];
-	}
-
-	return 0;
-}
 
 /**
  * @brief Copy an array of SQEs into the queue
@@ -1368,33 +1291,6 @@ __syscall int rtio_cqe_copy_out(struct rtio *r,
 				struct rtio_cqe *cqes,
 				size_t cqe_count,
 				k_timeout_t timeout);
-static inline int z_impl_rtio_cqe_copy_out(struct rtio *r,
-					   struct rtio_cqe *cqes,
-					   size_t cqe_count,
-					   k_timeout_t timeout)
-{
-	size_t copied = 0;
-	struct rtio_cqe *cqe;
-	k_timepoint_t end = sys_timepoint_calc(timeout);
-
-	do {
-		cqe = K_TIMEOUT_EQ(timeout, K_FOREVER) ? rtio_cqe_consume_block(r)
-						       : rtio_cqe_consume(r);
-		if (cqe == NULL) {
-#ifdef CONFIG_BOARD_NATIVE_POSIX
-			/* Native posix fakes the clock and only moves it forward when sleeping. */
-			k_sleep(K_TICKS(1));
-#else
-			Z_SPIN_DELAY(1);
-#endif
-			continue;
-		}
-		cqes[copied++] = *cqe;
-		rtio_cqe_release(r, cqe);
-	} while (copied < cqe_count && !sys_timepoint_expired(end));
-
-	return copied;
-}
 
 /**
  * @brief Submit I/O requests to the underlying executor
@@ -1411,50 +1307,6 @@ static inline int z_impl_rtio_cqe_copy_out(struct rtio *r,
  */
 __syscall int rtio_submit(struct rtio *r, uint32_t wait_count);
 
-static inline int z_impl_rtio_submit(struct rtio *r, uint32_t wait_count)
-{
-	int res = 0;
-
-#ifdef CONFIG_RTIO_SUBMIT_SEM
-	/* TODO undefined behavior if another thread calls submit of course
-	 */
-	if (wait_count > 0) {
-		__ASSERT(!k_is_in_isr(),
-			 "expected rtio submit with wait count to be called from a thread");
-
-		k_sem_reset(r->submit_sem);
-		r->submit_count = wait_count;
-	}
-#else
-	uintptr_t cq_count = (uintptr_t)atomic_get(&r->cq_count) + wait_count;
-#endif
-
-	/* Submit the queue to the executor which consumes submissions
-	 * and produces completions through ISR chains or other means.
-	 */
-	rtio_executor_submit(r);
-
-
-	/* TODO could be nicer if we could suspend the thread and not
-	 * wake up on each completion here.
-	 */
-#ifdef CONFIG_RTIO_SUBMIT_SEM
-
-	if (wait_count > 0) {
-		res = k_sem_take(r->submit_sem, K_FOREVER);
-		__ASSERT(res == 0,
-			 "semaphore was reset or timed out while waiting on completions!");
-	}
-#else
-	while ((uintptr_t)atomic_get(&r->cq_count) < cq_count) {
-		Z_SPIN_DELAY(10);
-		k_yield();
-	}
-#endif
-
-	return res;
-}
-
 /**
  * @}
  */
@@ -1463,6 +1315,7 @@ static inline int z_impl_rtio_submit(struct rtio *r, uint32_t wait_count)
 }
 #endif
 
+#include <zephyr/rtio/internal/rtio_impl.h>
 #include <zephyr/syscalls/rtio.h>
 
 #endif /* ZEPHYR_INCLUDE_RTIO_RTIO_H_ */

--- a/include/zephyr/sys/internal/time_units_impl.h
+++ b/include/zephyr/sys/internal/time_units_impl.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_TIME_UNITS_H_
+#error "Should only be included by zephyr/sys/time_units.h"
+#endif
+
+#ifndef ZEPHYR_INCLUDE_SYS_INTERNAL_TIME_UNITS_IMPL_H_
+#define ZEPHYR_INCLUDE_SYS_INTERNAL_TIME_UNITS_IMPL_H_
+
+#include <zephyr/toolchain.h>
+#include <zephyr/sys/util.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME)
+static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
+{
+	extern int z_clock_hw_cycles_per_sec;
+
+	return z_clock_hw_cycles_per_sec;
+}
+#endif /* CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* ZEPHYR_INCLUDE_SYS_INTERNAL_TIME_UNITS_IMPL_H_ */

--- a/include/zephyr/sys/time_units.h
+++ b/include/zephyr/sys/time_units.h
@@ -47,13 +47,6 @@ extern "C" {
 
 #if defined(CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME)
 __syscall int sys_clock_hw_cycles_per_sec_runtime_get(void);
-
-static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
-{
-	extern int z_clock_hw_cycles_per_sec;
-
-	return z_clock_hw_cycles_per_sec;
-}
 #endif /* CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME */
 
 #if defined(__cplusplus) && (__cplusplus >= 201402L)
@@ -2070,6 +2063,7 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
 	z_tmcvt_64(t, Z_HZ_ticks, Z_HZ_cyc, Z_CCYC, true, false)
 
 #if defined(CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME)
+#include <zephyr/sys/internal/time_units_impl.h>
 #include <zephyr/syscalls/time_units.h>
 #endif
 


### PR DESCRIPTION
This moves all the inline z_impl_* functions from the public API header file into another file. These z_impl_* functions are implementation details that do not need to live within the public API header file. This de-clutters the public API header file.

The scancode check complains about BSD license in the TEE drivers. I am simply splitting the file so the copyright needs to be preserved.