### PR TITLE
cmake: Add LL_EXTENSION_BUILD to EDK flags

### DIFF
--- a/cmake/llext-edk.cmake
+++ b/cmake/llext-edk.cmake
@@ -119,8 +119,8 @@ endforeach()
 set(llext_cflags ${new_cflags})
 
 
-list(APPEND base_flags_make ${llext_cflags} ${imacros_make})
-list(APPEND base_flags_cmake ${llext_cflags} ${imacros_cmake})
+list(APPEND base_flags_make ${llext_cflags} ${imacros_make} -DLL_EXTENSION_BUILD)
+list(APPEND base_flags_cmake ${llext_cflags} ${imacros_cmake} -DLL_EXTENSION_BUILD)
 
 separate_arguments(include_dirs NATIVE_COMMAND ${INTERFACE_INCLUDE_DIRECTORIES})
 file(MAKE_DIRECTORY ${llext_edk_inc})


### PR DESCRIPTION
Since f3e5d9db3dca2421bd5b4015fbc270d3972376bd, one needs to define `LL_EXTENSION_BUILD` to enable exporting symbols from extensions. That patch added that for `add_llext_target`, but missed it for the EDK, thus breaking it. This patch fixes that.