### PR TITLE
doc: release: 3.7: Add known issue with nRF51x SoC series Bluetooth

### DIFF
--- a/doc/connectivity/bluetooth/features.rst
+++ b/doc/connectivity/bluetooth/features.rst
@@ -42,7 +42,7 @@ grown to be mature and feature-rich, as can be seen in the section below.
   * Concurrent multi-protocol support ready
   * Intelligent scheduling of roles to minimize overlap
   * Portable design to any open BLE radio, currently supports Nordic
-    Semiconductor nRF51 and nRF52, as well as proprietary radios
+    Semiconductor nRF52x and nRF53x SoC Series, as well as proprietary radios
   * Supports little and big endian architectures, and abstracts the hard
     real-time specifics so that they can be encapsulated in a hardware-specific
     module

--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -1315,3 +1315,11 @@ Tests and Samples
     based on the ``MODEM_CELLULAR`` device driver.
 
   * BT LE Coded PHY is now runtime tested in CI with the nrf5x bsim targets.
+
+Issue Related Items
+*******************
+
+Known Issues
+============
+
+- :github:`74345` - Bluetooth: Non functional on nRF51 with fault


### PR DESCRIPTION
Add known issues section with broken Bluetooth support for nRF51x SoC series boards.

Related to #74345.