### PR TITLE
MAX32690: Enable sysclk-prescaler property

### DIFF
--- a/dts/arm/adi/max32/max32690.dtsi
+++ b/dts/arm/adi/max32/max32690.dtsi
@@ -21,10 +21,6 @@
 	erase-block-size = <16384>;
 };
 
-&gcr {
-	/delete-property/ sysclk-prescaler;
-};
-
 &pinctrl {
 	reg = <0x40008000 0x3220>;
 


### PR DESCRIPTION
MAX32690 Support sysclk-prescaler as per of [MAX32690-UG](https://www.analog.com/media/en/technical-documentation/user-guides/ug7618.pdf). This PR enables it for MAX32690 too.

![image](https://github.com/zephyrproject-rtos/zephyr/assets/46590392/795cacfb-abda-48e2-a392-7730d97ba188)

Depends on: https://github.com/zephyrproject-rtos/hal_adi/pull/4