### PR TITLE
modules: tf-m: fix CMake warnings

### DIFF
--- a/soc/nordic/CMakeLists.txt
+++ b/soc/nordic/CMakeLists.txt
@@ -39,10 +39,6 @@ if(CONFIG_BUILD_WITH_TFM)
     )
 
   set_property(TARGET zephyr_property_target
-    APPEND PROPERTY TFM_CMAKE_OPTIONS -DZEPHYR_BASE=${ZEPHYR_BASE}
-    )
-
-  set_property(TARGET zephyr_property_target
     APPEND PROPERTY TFM_CMAKE_OPTIONS -DNRF_NS_STORAGE=${CONFIG_TFM_NRF_NS_STORAGE}
     )
 endif()

--- a/west.yml
+++ b/west.yml
@@ -327,7 +327,7 @@ manifest:
       groups:
         - crypto
     - name: trusted-firmware-m
-      revision: f8d3a903578192d226ac1552f383d95b94ee8780
+      revision: 826c4a97053264d45a4fd76755f947b6b3a573f3
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
Fixes

```
CMake Warning at cmake/version.cmake:23 (message):
  Actual TF-M version is not available from Git repository.  Settled to
  v2.1.0
Call Stack (most recent call first):
  CMakeLists.txt:13 (include)
```

and

```
CMake Warning:
  Manually-specified variables were not used by the project:

    ZEPHYR_BASE
```