### PR TITLE
shell: backends: uart: add option to force tx blocking

### DIFF
--- a/subsys/shell/backends/Kconfig.backends
+++ b/subsys/shell/backends/Kconfig.backends
@@ -75,6 +75,11 @@ config SHELL_BACKEND_SERIAL_API_ASYNC
 
 endchoice
 
+config SHELL_BACKEND_SERIAL_FORCE_TX_BLOCKING_MODE
+	bool "Force blocking mode for TX"
+	help
+	  Force blocking mode for TX.
+
 config SHELL_BACKEND_SERIAL_TX_RING_BUFFER_SIZE
 	int "Set TX ring buffer size"
 	default 8

--- a/subsys/shell/backends/shell_uart.c
+++ b/subsys/shell/backends/shell_uart.c
@@ -346,7 +346,8 @@ static int enable(const struct shell_transport *transport, bool blocking_tx)
 {
 	struct shell_uart_common *sh_uart = (struct shell_uart_common *)transport->ctx;
 
-	sh_uart->blocking_tx = blocking_tx;
+	sh_uart->blocking_tx =
+		blocking_tx || IS_ENABLED(CONFIG_SHELL_BACKEND_SERIAL_FORCE_TX_BLOCKING_MODE);
 
 	if (IS_ENABLED(CONFIG_SHELL_BACKEND_SERIAL_API_INTERRUPT_DRIVEN) && blocking_tx) {
 		uart_irq_tx_disable(sh_uart->dev);


### PR DESCRIPTION
This adds a kconfig option to force tx blocking on serial. This way only rx will use the interrupt.