### PR TITLE
github: add template text as comments

### DIFF
--- a/.github/ISSUE_TEMPLATE/001_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/001_bug_report.md
@@ -6,8 +6,8 @@ labels: bug
 assignees: ''
 
 ---
-
-**Notes (delete this)**
+<!--
+**Notes**
 Github Discussions (https://github.com/zephyrproject-rtos/zephyr/discussions)
 are available to first verify that the issue is a genuine Zephyr bug and not a
 consequence of Zephyr services misuse.
@@ -16,8 +16,10 @@ This issue list is only for bugs in the main Zephyr code base
 (https://github.com/zephyrproject-rtos/zephyr/). If the bug is for a project
 fork (such as NCS) specific feature, please open an issue in the fork project
 instead.
+-->
 
 **Describe the bug**
+<!--
 A clear and concise description of what the bug is.
 
 Please also mention any information which could help others to understand
@@ -27,31 +29,43 @@ the problem you're facing:
  - Is this a regression? If yes, have you been able to "git bisect" it to a
    specific commit?
  - ...
+-->
 
 **To Reproduce**
+<!--
 Steps to reproduce the behavior:
 1. mkdir build; cd build
 2. cmake -DBOARD=board\_xyz
 3. make
 4. See error
+-->
 
 **Expected behavior**
+<!--
 A clear and concise description of what you expected to happen.
+-->
 
 **Impact**
+<!--
 What impact does this issue have on your progress (e.g., annoyance, showstopper)
+-->
 
 **Logs and console output**
+<!--
 If applicable, add console logs or other types of debug information
 e.g Wireshark capture or Logic analyzer capture (upload in zip archive).
 copy-and-paste text and put a code fence (\`\`\`) before and after, to help
 explain the issue. (if unable to obtain text log, add a screenshot)
+-->
 
 **Environment (please complete the following information):**
+
  - OS: (e.g. Linux, MacOS, Windows)
  - Toolchain (e.g Zephyr SDK, ...)
  - Commit SHA or Version used
 
 **Additional context**
+<!--
 Add any other context that could be relevant to your issue, such as pin setting,
 target configuration, ...
+-->

--- a/.github/ISSUE_TEMPLATE/002_enhancement.md
+++ b/.github/ISSUE_TEMPLATE/002_enhancement.md
@@ -8,13 +8,21 @@ assignees: ''
 ---
 
 **Is your enhancement proposal related to a problem? Please describe.**
+<!--
 A clear and concise description of what the problem is.
+-->
 
 **Describe the solution you'd like**
+<!--
 A clear and concise description of what you want to happen.
+-->
 
 **Describe alternatives you've considered**
+<!--
 A clear and concise description of any alternative solutions or features you've considered.
+-->
 
 **Additional context**
+<!--
 Add any other context or graphics (drag-and-drop an image) about the feature request here.
+-->

--- a/.github/ISSUE_TEMPLATE/003_rfc-proposal.md
+++ b/.github/ISSUE_TEMPLATE/003_rfc-proposal.md
@@ -9,43 +9,52 @@ assignees: ''
 
 ## Introduction
 
+<!--
 This section targets end users, TSC members, maintainers and anyone else that might
 need a quick explanation of your proposed change.
+-->
 
 ### Problem description
-
+<!--
 Why do we want this change and what problem are we trying to address?
+-->
 
 ### Proposed change
-
+<!--
 A brief summary of the proposed change - the 10,000 ft view on what it will
 change once this change is implemented.
+-->
 
 ## Detailed RFC
-
+<!--
 In this section of the document the target audience is the dev team. Upon
 reading this section each engineer should have a rather clear picture of what
 needs to be done in order to implement the described feature.
+-->
 
 ### Proposed change (Detailed)
-
+<!--
 This section is freeform - you should describe your change in as much detail
 as possible. Please also ensure to include any context or background info here.
 For example, do we have existing components which can be reused or altered.
 
 By reading this section, each team member should be able to know what exactly
 you're planning to change and how.
+-->
 
 ### Dependencies
-
+<!--
 Highlight how the change may affect the rest of the project (new components,
 modifications in other areas), or other teams/projects.
+-->
 
 ### Concerns and Unresolved Questions
-
+<!--
 List any concerns, unknowns, and generally unresolved questions etc.
+-->
 
 ## Alternatives
-
+<!--
 List any alternatives considered, and the reasons for choosing this option
 over them.
+-->

--- a/.github/ISSUE_TEMPLATE/004_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/004_feature_request.md
@@ -8,13 +8,21 @@ assignees: ''
 ---
 
 **Is your feature request related to a problem? Please describe.**
+<!--
 A clear and concise description of what the problem is.
+-->
 
 **Describe the solution you'd like**
+<!--
 A clear and concise description of what you want to happen.
+-->
 
 **Describe alternatives you've considered**
+<!--
 A clear and concise description of any alternative solutions or features you've considered.
+-->
 
 **Additional context**
+<!--
 Add any other context or graphics (drag-and-drop an image) about the feature request here.
+-->


### PR DESCRIPTION
Instead of including the boilerplate text and showing it in the created
issue, use comments that are still displayed when editing, but not shown
in the final issue, avoiding confusing and mixup between actual issue
and template text.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
