### PR TITLE
MAINTAINERS: move test docs to relevant areas

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -884,6 +884,7 @@ Documentation:
   files-exclude:
     - doc/releases/migration-guide-*
     - doc/releases/release-notes-*
+    - doc/develop/test/
   labels:
     - "area: Documentation"
 
@@ -4986,7 +4987,7 @@ Test Framework (Ztest):
     - tests/unit/util/
     - tests/subsys/testsuite/
     - samples/subsys/testsuite/
-    - doc/develop/test/ztest.rst
+    - doc/develop/test/
   labels:
     - "area: Testsuite"
   tests:


### PR DESCRIPTION
doc/develop/test should go under Twister/Testsuite.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
