### PR TITLE
tests: drivers: spi: spi_controller_peripheral: Fix nrf54h20_cpurad

### DIFF
--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_cpurad.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_cpurad.overlay
@@ -5,6 +5,11 @@
  */
 #include "nrf54h20dk_nrf54h20_common.dtsi"
 
+/* Increase dma region to fit dmm heap. */
+&cpurad_dma_region {
+	reg = <0x1e80 0x100>;
+};
+
 &spi130 {
 	memory-regions = <&cpurad_dma_region>;
 };


### PR DESCRIPTION
Add more memory to dma region for cpurad as otherwise it fails during initialization due to not enough memory for dmm heap.

Fixes #74404.