### PR TITLE
drivers: spi: nrfx_spim: Add support for device runtime PM

### DIFF
--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf52840dk_nrf52840.overlay
@@ -50,6 +50,7 @@
 	pinctrl-names = "default", "sleep";
 	overrun-character = <0x00>;
 	cs-gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
+	zephyr,pm-device-runtime-auto;
 	dut_spi_dt: test-spi-dev@0 {
 		compatible = "vnd,spi-device";
 		spi-max-frequency = <DT_FREQ_M(8)>;

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_common.dtsi
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_common.dtsi
@@ -60,6 +60,7 @@
 	pinctrl-names = "default", "sleep";
 	overrun-character = <0x00>;
 	cs-gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+	zephyr,pm-device-runtime-auto;
 	dut_spi_dt: test-spi-dev@0 {
 		compatible = "vnd,spi-device";
 		reg = <0>;

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay
@@ -59,6 +59,7 @@
 	overrun-character = <0x00>;
 	memory-regions = <&dma_fast_region>;
 	cs-gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+	zephyr,pm-device-runtime-auto;
 	dut_spi_dt: test-spi-dev@0 {
 		compatible = "vnd,spi-device";
 		reg = <0>;

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -54,9 +54,11 @@
 	pinctrl-names = "default", "sleep";
 	overrun-character = <0x00>;
 	cs-gpios = <&gpio2 10 GPIO_ACTIVE_LOW>;
+	zephyr,pm-device-runtime-auto;
 	dut_spi_dt: test-spi-dev@0 {
 		compatible = "vnd,spi-device";
 		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(16)>;
 	};
 };
 

--- a/tests/drivers/spi/spi_controller_peripheral/testcase.yaml
+++ b/tests/drivers/spi/spi_controller_peripheral/testcase.yaml
@@ -63,3 +63,9 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
       - nrf54h20dk/nrf54h20/cpuppr
+
+  drivers.spi.pm_runtime:
+    extra_configs:
+      - CONFIG_PM_DEVICE=y
+      - CONFIG_PM_DEVICE_RUNTIME=y
+    filter: CONFIG_SOC_FAMILY_NORDIC_NRF

--- a/tests/drivers/spi/spi_loopback/boards/nrf51dk_nrf51822.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf51dk_nrf51822.overlay
@@ -7,6 +7,7 @@
 &spi1 {
 	overrun-character = <0x00>;
 	cs-gpios = <&gpio0 28 GPIO_ACTIVE_LOW>;
+	zephyr,pm-device-runtime-auto;
 	slow@0 {
 		compatible = "test-spi-loopback-slow";
 		reg = <0>;

--- a/tests/drivers/spi/spi_loopback/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf52840dk_nrf52840.overlay
@@ -8,6 +8,7 @@
 	overrun-character = <0x00>;
 	rx-delay = <1>;
 	cs-gpios = <&gpio0 28 GPIO_ACTIVE_LOW>;
+	zephyr,pm-device-runtime-auto;
 	slow@0 {
 		compatible = "test-spi-loopback-slow";
 		reg = <0>;

--- a/tests/drivers/spi/spi_loopback/boards/nrf52dk_nrf52832.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf52dk_nrf52832.overlay
@@ -7,6 +7,7 @@
 &spi1 {
 	overrun-character = <0x00>;
 	cs-gpios = <&gpio0 28 GPIO_ACTIVE_LOW>;
+	zephyr,pm-device-runtime-auto;
 	slow@0 {
 		compatible = "test-spi-loopback-slow";
 		reg = <0>;

--- a/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -7,4 +7,15 @@
 
 &spi130 {
 	memory-regions = <&cpuapp_dma_region>;
+	zephyr,pm-device-runtime-auto;
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_K(500)>;
+	};
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(8)>;
+	};
 };

--- a/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay
@@ -34,6 +34,7 @@
 	pinctrl-names = "default", "sleep";
 	overrun-character = <0x00>;
 	memory-regions = <&dma_fast_region>;
+	zephyr,pm-device-runtime-auto;
 	slow@0 {
 		compatible = "test-spi-loopback-slow";
 		reg = <0>;

--- a/tests/drivers/spi/spi_loopback/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -29,6 +29,7 @@
 	pinctrl-1 = <&spi00_sleep>;
 	pinctrl-names = "default", "sleep";
 	overrun-character = <0x00>;
+	zephyr,pm-device-runtime-auto;
 	slow@0 {
 		compatible = "test-spi-loopback-slow";
 		reg = <0>;

--- a/tests/drivers/spi/spi_loopback/boards/nrf9160dk_nrf9160.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf9160dk_nrf9160.overlay
@@ -7,6 +7,7 @@
 &spi3 {
 	overrun-character = <0x00>;
 	cs-gpios = <&gpio0 16 GPIO_ACTIVE_LOW>;
+	zephyr,pm-device-runtime-auto;
 	slow@0 {
 		compatible = "test-spi-loopback-slow";
 		reg = <0>;

--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -228,3 +228,8 @@ tests:
     filter: CONFIG_SOC_FAMILY_MAX32
     platform_allow:
       - apard32690/max32690/m4
+  drivers.spi.nrf_pm_runtime:
+    extra_configs:
+      - CONFIG_PM_DEVICE=y
+      - CONFIG_PM_DEVICE_RUNTIME=y
+    filter: CONFIG_SOC_FAMILY_NORDIC_NRF


### PR DESCRIPTION
Enable the device runtime power management on the SPIM shim.