### PR TITLE
drivers: adc: adc_mcux_adc12: enable support for channel>=16 on S32K14X

### DIFF
--- a/boards/nxp/frdm_ke17z/frdm_ke17z.dts
+++ b/boards/nxp/frdm_ke17z/frdm_ke17z.dts
@@ -102,6 +102,7 @@
 &adc0 {
 	status = "okay";
 	sample-time = <12>;
+	vref-mv = <3300>;
 	pinctrl-0 = <&adc0_default>;
 	pinctrl-names = "default";
 };

--- a/boards/nxp/frdm_ke17z512/frdm_ke17z512.dts
+++ b/boards/nxp/frdm_ke17z512/frdm_ke17z512.dts
@@ -102,6 +102,7 @@
 &adc0 {
 	status = "okay";
 	sample-time = <12>;
+	vref-mv = <3300>;
 	pinctrl-0 = <&adc0_default>;
 	pinctrl-names = "default";
 };

--- a/boards/nxp/twr_ke18f/twr_ke18f.dts
+++ b/boards/nxp/twr_ke18f/twr_ke18f.dts
@@ -283,6 +283,7 @@
 &adc0 {
 	status = "okay";
 	sample-time = <12>;
+	vref-mv = <3300>;
 	pinctrl-0 = <&adc0_default>;
 	pinctrl-names = "default";
 };

--- a/boards/nxp/ucans32k1sic/doc/index.rst
+++ b/boards/nxp/ucans32k1sic/doc/index.rst
@@ -53,6 +53,7 @@ FTM           on-chip     pwm
 FlexCAN       on-chip     can
 Watchdog      on-chip     watchdog
 RTC           on-chip     counter
+ADC           on-chip     adc
 ============  ==========  ================================
 
 The default configuration can be found in the Kconfig file

--- a/boards/nxp/ucans32k1sic/ucans32k1sic.dts
+++ b/boards/nxp/ucans32k1sic/ucans32k1sic.dts
@@ -192,3 +192,15 @@
 	phys = <&can_phy1>;
 	status = "okay";
 };
+
+&adc0 {
+	sample-time = <65>;
+	vref-mv = <3300>;
+	status = "okay";
+};
+
+&adc1 {
+	sample-time = <65>;
+	vref-mv = <3300>;
+	status = "okay";
+};

--- a/boards/nxp/ucans32k1sic/ucans32k1sic.yaml
+++ b/boards/nxp/ucans32k1sic/ucans32k1sic.yaml
@@ -21,3 +21,4 @@ supported:
   - can
   - watchdog
   - counter
+  - adc

--- a/drivers/adc/adc_mcux_adc12.c
+++ b/drivers/adc/adc_mcux_adc12.c
@@ -166,6 +166,15 @@ static void mcux_adc12_start_channel(const struct device *dev)
 	LOG_DBG("Starting channel %d", data->channel_id);
 	channel_config.enableInterruptOnConversionCompleted = true;
 	channel_config.channelNumber = data->channel_id;
+#if defined(CONFIG_SOC_S32K146) || defined(CONFIG_SOC_S32K148)
+	if (data->channel_id >= 16) {
+		/*
+		 * channels 16..31 are encoded as 100000b..101111b in
+		 * SC1[ADCH] field
+		 */
+		channel_config.channelNumber += 16;
+	}
+#endif
 	ADC12_SetChannelConfig(config->base, channel_group, &channel_config);
 }
 

--- a/dts/arm/nxp/nxp_s32k1xx.dtsi
+++ b/dts/arm/nxp/nxp_s32k1xx.dtsi
@@ -326,5 +326,27 @@
 			clock-frequency = <32000>;
 			prescaler = <32000>;
 		};
+
+		adc0: adc@4003b000 {
+			compatible = "nxp,kinetis-adc12";
+			reg = <0x4003b000 0x1000>;
+			interrupts = <39 0>;
+			clk-source = <0>;
+			clk-divider = <1>;
+			clocks = <&clock NXP_S32_ADC0_CLK>;
+			#io-channel-cells = <1>;
+			status = "disabled";
+		};
+
+		adc1: adc@40027000 {
+			compatible = "nxp,kinetis-adc12";
+			reg = <0x40027000 0x1000>;
+			interrupts = <40 0>;
+			clk-source = <0>;
+			clk-divider = <1>;
+			clocks = <&clock NXP_S32_ADC1_CLK>;
+			#io-channel-cells = <1>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/bindings/adc/nxp,kinetis-adc12.yaml
+++ b/dts/bindings/adc/nxp,kinetis-adc12.yaml
@@ -33,6 +33,11 @@ properties:
     required: true
     description: sample time in clock cycles
 
+  vref-mv:
+    type: int
+    required: true
+    description: Indicates the reference voltage of the ADC in mV.
+
   "#io-channel-cells":
     const: 1
 

--- a/samples/drivers/adc/adc_dt/boards/ucans32k1sic.overlay
+++ b/samples/drivers/adc/adc_dt/boards/ucans32k1sic.overlay
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2024 Accenture
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/adc/adc.h>
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 12>;
+	};
+};
+
+&pinctrl {
+	adc0_default: adc0_default {
+		group_1 {
+			pinmux = <ADC0_SE12_PTC14>;
+			drive-strength = "low";
+		};
+	};
+};
+
+&adc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@c {
+		reg = <12>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	pinctrl-0 = <&adc0_default>;
+	pinctrl-names = "default";
+};

--- a/samples/drivers/adc/adc_dt/sample.yaml
+++ b/samples/drivers/adc/adc_dt/sample.yaml
@@ -33,6 +33,7 @@ tests:
       - longan_nano/gd32vf103/lite
       - rd_rw612_bga
       - frdm_mcxn947/mcxn947/cpu0
+      - ucans32k1sic
     integration_platforms:
       - nucleo_l073rz
       - nrf52840dk/nrf52840

--- a/samples/drivers/adc/adc_sequence/boards/ucans32k1sic.overlay
+++ b/samples/drivers/adc/adc_sequence/boards/ucans32k1sic.overlay
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2024 Accenture
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/adc/adc.h>
+
+/ {
+	aliases {
+		adc0 = &adc0;
+	};
+};
+
+&pinctrl {
+	adc0_default: adc0_default {
+		group_1 {
+			pinmux = <ADC0_SE12_PTC14>;
+			drive-strength = "low";
+		};
+	};
+};
+
+&adc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@c {
+		reg = <12>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	pinctrl-0 = <&adc0_default>;
+	pinctrl-names = "default";
+};

--- a/samples/drivers/adc/adc_sequence/sample.yaml
+++ b/samples/drivers/adc/adc_sequence/sample.yaml
@@ -11,6 +11,7 @@ tests:
       - nrf52840dk/nrf52840
       - nrf54l15pdk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
+      - ucans32k1sic
     integration_platforms:
       - nrf52840dk/nrf52840
     harness: console

--- a/soc/nxp/s32/s32k1/Kconfig
+++ b/soc/nxp/s32/s32k1/Kconfig
@@ -18,6 +18,7 @@ config SOC_SERIES_S32K1
 	select HAS_MCUX_FLEXCAN
 	select HAS_MCUX_WDOG32
 	select HAS_MCUX_RTC
+	select HAS_MCUX_ADC12
 
 config SOC_S32K116
 	select CPU_CORTEX_M0PLUS

--- a/tests/drivers/adc/adc_api/boards/ucans32k1sic.overlay
+++ b/tests/drivers/adc/adc_api/boards/ucans32k1sic.overlay
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 Accenture
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/adc/adc.h>
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 12>;
+	};
+};
+
+&pinctrl {
+	adc0_default: adc0_default {
+		group_1 {
+			pinmux = <ADC0_SE12_PTC14>;
+			drive-strength = "low";
+		};
+	};
+};
+
+&adc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@c {
+		reg = <12>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	pinctrl-0 = <&adc0_default>;
+	pinctrl-names = "default";
+};
+
+&adc1 {
+	status = "disabled";
+};

--- a/west.yml
+++ b/west.yml
@@ -198,7 +198,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 00fd3f5a3b1b7fc3a715b1e96cb2d5036b5cc27e
+      revision: 466000a80e6eb5bbcb691bae936ec5654a7796d4
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Enable support for ADC on s32k1 platform.
Enable ADC on UCANS32K1SIC eval board.

Enable support for channels >= 16 on devices S32K146 and S32K148. Channels >= 16 are encoded as 100000b..101111b in SC1[ADCH] field.

We are getting everything ready to support ADC on the S32K146/8 (https://github.com/zephyrproject-rtos/hal_nxp/pull/407).