### PR TITLE
drivers: clock_control: litex: remove redundant entry

### DIFF
--- a/drivers/clock_control/clock_control_litex.c
+++ b/drivers/clock_control/clock_control_litex.c
@@ -328,7 +328,7 @@ static uint64_t litex_clk_calc_global_frequency(uint32_t mul, uint32_t div)
 {
 	uint64_t f;
 
-	f = (uint64_t)ldev->sys_clk_freq * (uint64_t)mul;
+	f = CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC * (uint64_t)mul;
 	f /= div;
 
 	return f;
@@ -1318,7 +1318,7 @@ static int litex_clk_calc_all_params(void)
 								 mul--) {
 			int below, above, all_valid = true;
 
-			vco_freq = (uint64_t)ldev->sys_clk_freq * (uint64_t)mul;
+			vco_freq = CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC * (uint64_t)mul;
 			vco_freq /= div;
 			below = vco_freq < (ldev->vco.min
 					     * (1 + ldev->vco_margin));
@@ -1354,12 +1354,12 @@ int litex_clk_check_rate_range(struct litex_clk_clkout *lcko, uint32_t rate)
 		margin = litex_clk_pow(10, lcko->margin.exp);
 	}
 
-	max = (uint64_t)ldev->sys_clk_freq * (uint64_t)ldev->clkfbout.max;
+	max = CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC * (uint64_t)ldev->clkfbout.max;
 	div = ldev->divclk.min * lcko->clkout_div.min;
 	max /= div;
 	max += m;
 
-	min = ldev->sys_clk_freq * ldev->clkfbout.min;
+	min = CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC * ldev->clkfbout.min;
 	div = ldev->divclk.max * lcko->clkout_div.max;
 	min /= div;
 
@@ -1702,8 +1702,6 @@ static int litex_clk_dts_global_read(void)
 {
 	int ret;
 
-	ldev->sys_clk_freq = SYS_CLOCK_FREQUENCY;
-
 	ldev->nclkout = litex_clk_dts_cnt_clocks();
 
 	clkouts = k_malloc(sizeof(struct litex_clk_clkout) * ldev->nclkout);
@@ -1789,7 +1787,6 @@ static const struct litex_clk_device ldev_init = {
 	.divclk = {DIVCLK_DIVIDE_MIN, DIVCLK_DIVIDE_MAX},
 	.clkfbout = {CLKFBOUT_MULT_MIN, CLKFBOUT_MULT_MAX},
 	.vco = {VCO_FREQ_MIN, VCO_FREQ_MAX},
-	.sys_clk_freq = SYS_CLOCK_FREQUENCY,
 	.vco_margin = VCO_MARGIN,
 	.nclkout = NCLKOUT
 };

--- a/drivers/clock_control/clock_control_litex.h
+++ b/drivers/clock_control/clock_control_litex.h
@@ -45,7 +45,6 @@
 /* Devicetree global defines */
 #define LOCK_TIMEOUT		DT_PROP(MMCM, litex_lock_timeout)
 #define DRDY_TIMEOUT		DT_PROP(MMCM, litex_drdy_timeout)
-#define SYS_CLOCK_FREQUENCY	DT_PROP(MMCM, litex_sys_clock_frequency)
 #define DIVCLK_DIVIDE_MIN	DT_PROP(MMCM, litex_divclk_divide_min)
 #define DIVCLK_DIVIDE_MAX	DT_PROP(MMCM, litex_divclk_divide_max)
 #define CLKFBOUT_MULT_MIN	DT_PROP(MMCM, litex_clkfbout_mult_min)
@@ -243,7 +242,6 @@ struct litex_clk_device {
 	struct litex_clk_range clkfbout;	/* clkfbout_mult_frange */
 	struct litex_clk_range vco;		/* vco_freq_range */
 	uint8_t *update_clkout;			/* which clkout needs update */
-	uint32_t sys_clk_freq;			/* input frequency */
 	uint32_t vco_margin;
 	uint32_t nclkout;
 };

--- a/dts/bindings/clock/litex,clk.yaml
+++ b/dts/bindings/clock/litex,clk.yaml
@@ -40,11 +40,6 @@ properties:
     type: int
     description: |
       Number of ms to wait for MMCM to assert DRDY signal
-  litex,sys-clock-frequency:
-    required: true
-    type: int
-    description: |
-      System clock frequency
   litex,divclk-divide-min:
     required: true
     type: int

--- a/dts/riscv/riscv32-litex-vexriscv.dtsi
+++ b/dts/riscv/riscv32-litex-vexriscv.dtsi
@@ -318,7 +318,6 @@
 			clock-output-names = "CLK_0", "CLK_1";
 			litex,lock-timeout = <10>;
 			litex,drdy-timeout = <10>;
-			litex,sys-clock-frequency = <100000000>;
 			litex,divclk-divide-min = <1>;
 			litex,divclk-divide-max = <107>;
 			litex,clkfbout-mult-min = <2>;


### PR DESCRIPTION
remove litex,sys-clock-frequency from litex,clk, because we already define that in the clock-frequency of cpu0. 
This can be accessed via CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC.