### PR TITLE
Fix I2S_Speed Test with Watermark Definition

### DIFF
--- a/modules/hal_nxp/CMakeLists.txt
+++ b/modules/hal_nxp/CMakeLists.txt
@@ -29,3 +29,7 @@ if(CONFIG_HAS_MCUX OR CONFIG_HAS_IMX_HAL OR CONFIG_HAS_NXP_S32_HAL)
 
   add_subdirectory_ifdef(CONFIG_BT_H4_NXP_CTLR bt_controller)
 endif()
+
+if(CONFIG_I2S_MCUX_SAI)
+  zephyr_compile_definitions(MCUX_SDK_SAI_ALLOW_NULL_FIFO_WATERMARK=1)
+endif()


### PR DESCRIPTION
Added definition MCUX_SDK_SAI_ALLOW_NULL_FIFO_WATERMARK to fix I2S_Speed test on MIMXRT1170_evk/mimxrt1176/cm7.
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/70051