### PR TITLE
doc: releases: 3.7.0: minor clean-ups

### DIFF
--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -294,13 +294,13 @@ Bluetooth HCI
       choice, rather they can now be enabled and disabled independently, mostly based on their
       respective devicetree node being enabled or not.
    * The ``BT_HCI_VS_EXT`` Kconfig option was deleted and the feature is now included in the
-      :kconfig:option:`BT_HCI_VS` Kconfig option.
+      :kconfig:option:`CONFIG_BT_HCI_VS` Kconfig option.
    * The ``BT_HCI_VS_EVT`` Kconfig option was removed, since vendor event support is implicit if
-      the :kconfig:option:`BT_HCI_VS` option is enabled.
+      the :kconfig:option:`CONFIG_BT_HCI_VS` option is enabled.
    * The bt_read_static_addr() API was removed. This wasn't really a completely public API, but
       since it was exposed by the public hci_driver.h header file the removal is mentioned here.
-      Enable the :kconfig:option:`BT_HCI_VS` Kconfig option instead, and use vendor specific HCI
-      commands API to get the Controller's Bluetooth static address when available.
+      Enable the :kconfig:option:`CONFIG_BT_HCI_VS` Kconfig option instead, and use vendor specific
+      HCI commands API to get the Controller's Bluetooth static address when available.
 
 Charger
 =======
@@ -316,8 +316,9 @@ Controller Area Network (CAN)
 
 * Removed the following deprecated CAN controller devicetree properties. Out-of-tree boards using
   these properties can switch to using the ``bitrate``, ``sample-point``, ``bitrate-data``, and
-  ``sample-point-data`` devicetree properties (or rely on :kconfig:option:`CAN_DEFAULT_BITRATE` and
-  :kconfig:option:`CAN_DEFAULT_BITRATE_DATA`) for specifying the initial CAN bitrate:
+  ``sample-point-data`` devicetree properties (or rely on
+  :kconfig:option:`CONFIG_CAN_DEFAULT_BITRATE` and
+  :kconfig:option:`CONFIG_CAN_DEFAULT_BITRATE_DATA`) for specifying the initial CAN bitrate:
 
   * ``sjw``
   * ``prop-seg``

--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -411,10 +411,6 @@ Drivers and Sensors
 
 * CAN
 
-  * Added :c:func:`can_get_bitrate_min` and :c:func:`can_get_bitrate_max` for retrieving the minimum
-    and maximum supported bitrate for a given CAN controller/CAN transceiver combination, reflecting
-    that retrieving the bitrate limits can no longer fail. Deprecated the existing
-    :c:func:`can_get_min_bitrate` and :c:func:`can_get_max_bitrate` API functions.
   * Extended support for automatic sample point location to also cover :c:func:`can_calc_timing` and
     :c:func:`can_calc_timing_data`.
   * Added optional ``min-bitrate`` devicetree property for CAN transceivers.
@@ -423,8 +419,10 @@ Drivers and Sensors
     transceiver.
   * Added support for specifying the minimum bitrate supported by a CAN controller in the internal
     ``CAN_DT_DRIVER_CONFIG_GET`` and ``CAN_DT_DRIVER_CONFIG_INST_GET`` macros.
-  * Added a new CAN controller API function :c:func:`can_get_bitrate_min` for getting the minimum
-    supported bitrate of a CAN controller/transceiver combination.
+  * Added :c:func:`can_get_bitrate_min` and :c:func:`can_get_bitrate_max` for retrieving the minimum
+    and maximum supported bitrate for a given CAN controller/CAN transceiver combination, reflecting
+    that retrieving the bitrate limits can no longer fail. Deprecated the existing
+    :c:func:`can_get_max_bitrate` API function.
   * Updated the CAN timing functions to take the minimum supported bitrate into consideration when
     validating the bitrate.
   * Made the ``sample-point`` and ``sample-point-data`` devicetree properties optional.


### PR DESCRIPTION
Added a few missing CONFIG_ prefixes to Kconfig option references, reshuffled the CAN release notes a bit to account for the can_get_min_bitrate() being both introduced and deprecated within one release cycle.