### PR TITLE
scripts: west_commands: nrfjprog: Add support for --qspiini

### DIFF
--- a/scripts/west_commands/runners/nrfjprog.py
+++ b/scripts/west_commands/runners/nrfjprog.py
@@ -33,7 +33,7 @@ class NrfJprogBinaryRunner(NrfBinaryRunner):
 
     @classmethod
     def tool_opt_help(cls) -> str:
-        return 'Additional options for nrfjprog, e.g. "--recover"'
+        return 'Additional options for nrfjprog, e.g. "--clockspeed"'
 
     @classmethod
     def do_create(cls, cfg, args):

--- a/scripts/west_commands/runners/nrfjprog.py
+++ b/scripts/west_commands/runners/nrfjprog.py
@@ -18,6 +18,15 @@ VerifyError = 55
 class NrfJprogBinaryRunner(NrfBinaryRunner):
     '''Runner front-end for nrfjprog.'''
 
+    def __init__(self, cfg, family, softreset, dev_id, erase=False,
+                 reset=True, tool_opt=[], force=False, recover=False,
+                 qspi_ini=None):
+
+        super().__init__(cfg, family, softreset, dev_id, erase, reset,
+                         tool_opt, force, recover)
+
+        self.qspi_ini = qspi_ini
+
     @classmethod
     def name(cls):
         return 'nrfjprog'
@@ -32,7 +41,12 @@ class NrfJprogBinaryRunner(NrfBinaryRunner):
                                     args.dev_id, erase=args.erase,
                                     reset=args.reset,
                                     tool_opt=args.tool_opt, force=args.force,
-                                    recover=args.recover)
+                                    recover=args.recover, qspi_ini=args.qspi_ini)
+    @classmethod
+    def do_add_parser(cls, parser):
+        super().do_add_parser(parser)
+        parser.add_argument('--qspiini', required=False, dest='qspi_ini',
+                            help='path to an .ini file with qspi configuration')
 
     def do_get_boards(self):
         snrs = self.check_output(['nrfjprog', '--ids'])
@@ -81,6 +95,9 @@ class NrfJprogBinaryRunner(NrfBinaryRunner):
             if _op.get('verify'):
                 # In the future there might be multiple verify modes
                 cmd.append('--verify')
+            if self.qspi_ini:
+                cmd.append('--qspiini')
+                cmd.append(self.qspi_ini)
         elif op_type == 'recover':
             cmd.append('--recover')
         elif op_type == 'reset':


### PR DESCRIPTION
Allow for users to provide a --qspiini parameter that is passed directly to the nrfjprog executable but only in the --program operation. This is required since e073210ec299516476c2b1f1a6b270fb5f7839ca enabled the -O/--tool-opt for all operations, but --qspiini is only allowed combined with --program.