### PR TITLE
logging: remove z_log_minimal_vprintk

### DIFF
--- a/include/zephyr/logging/log_core.h
+++ b/include/zephyr/logging/log_core.h
@@ -157,19 +157,12 @@ extern "C" {
 /****************** Definitions used by minimal logging *********************/
 /*****************************************************************************/
 void z_log_minimal_hexdump_print(int level, const void *data, size_t size);
-void z_log_minimal_vprintk(const char *fmt, va_list ap);
 void z_log_minimal_printk(const char *fmt, ...);
 
 #define Z_LOG_TO_PRINTK(_level, fmt, ...) do { \
 	z_log_minimal_printk("%c: " fmt "\n", \
 			     z_log_minimal_level_to_char(_level), \
 			     ##__VA_ARGS__); \
-} while (false)
-
-#define Z_LOG_TO_VPRINTK(_level, fmt, valist) do { \
-	z_log_minimal_printk("%c: ", z_log_minimal_level_to_char(_level)); \
-	z_log_minimal_vprintk(fmt, valist); \
-	z_log_minimal_printk("\n"); \
 } while (false)
 
 static inline char z_log_minimal_level_to_char(int level)

--- a/subsys/logging/log_minimal.c
+++ b/subsys/logging/log_minimal.c
@@ -22,11 +22,6 @@ void z_log_minimal_printk(const char *fmt, ...)
 }
 EXPORT_SYMBOL(z_log_minimal_printk);
 
-void z_log_minimal_vprintk(const char *fmt, va_list ap)
-{
-	vprintk(fmt, ap);
-}
-
 static void minimal_hexdump_line_print(const char *data, size_t length)
 {
 	for (size_t i = 0U; i < HEXDUMP_BYTES_IN_LINE; i++) {


### PR DESCRIPTION
Remove unused log minimal vprintk wrapper and implementation.

Signed-off-by: Noah Pendleton <noah.pendleton@gmail.com>
