### PR TITLE
modules: hal_nxp: Fix i2s define mistake

### DIFF
--- a/modules/hal_nxp/CMakeLists.txt
+++ b/modules/hal_nxp/CMakeLists.txt
@@ -28,8 +28,8 @@ if(CONFIG_HAS_MCUX OR CONFIG_HAS_IMX_HAL OR CONFIG_HAS_NXP_S32_HAL)
   endif()
 
   add_subdirectory_ifdef(CONFIG_BT_H4_NXP_CTLR bt_controller)
-endif()
 
-if(CONFIG_I2S_MCUX_SAI)
-  zephyr_compile_definitions(MCUX_SDK_SAI_ALLOW_NULL_FIFO_WATERMARK=1)
+  if(CONFIG_I2S_MCUX_SAI)
+    zephyr_compile_definitions(MCUX_SDK_SAI_ALLOW_NULL_FIFO_WATERMARK=1)
+  endif()
 endif()


### PR DESCRIPTION
The commands should be within the if command checking for CONFIG_HAS_MCUX, fix.