### PR TITLE
code_relocation: Allow processing of object files

### DIFF
--- a/scripts/build/gen_relocate_app.py
+++ b/scripts/build/gen_relocate_app.py
@@ -489,8 +489,12 @@ def parse_args():
 
 # return the absolute path for the object file.
 def get_obj_filename(searchpath, filename):
-    # get the object file name which is almost always pended with .obj
-    obj_filename = filename.split("/")[-1] + ".obj"
+    # if the file suffix is .o or .obj, look for that file
+    # otherwise get the object file name which is almost always pended with .obj
+    if filename.endswith(".o") or filename.endswith(".obj"):
+        obj_filename = filename.split("/")[-1]
+    else:
+        obj_filename = filename.split("/")[-1] + ".obj"
 
     for dirpath, _, files in os.walk(searchpath):
         for filename1 in files:


### PR DESCRIPTION
This change allows the relocation script to process object files by checking the suffix and only assuming it's a source file if it does not end in ".o" or ".obj".

The motivation behind this change is that I am trying to relocate code which is in a prebuilt static library archive. In order to do so, I am unarchiving the library and passing the object files for relocation.