### PR TITLE
drivers: usb_dc_rpi_pico: set AVAILABLE bit separately

### DIFF
--- a/drivers/usb/device/usb_dc_rpi_pico.c
+++ b/drivers/usb/device/usb_dc_rpi_pico.c
@@ -94,10 +94,10 @@ static struct udc_rpi_ep_state *udc_rpi_get_ep_state(uint8_t ep)
 	return ep_state_base + USB_EP_GET_IDX(ep);
 }
 
-static int udc_rpi_start_xfer(uint8_t ep, const void *data, size_t len)
+static int udc_rpi_start_xfer(uint8_t ep, const void *data, const size_t len)
 {
 	struct udc_rpi_ep_state *ep_state = udc_rpi_get_ep_state(ep);
-	uint32_t val = len | USB_BUF_CTRL_AVAIL;
+	uint32_t val = len;
 
 	if (*ep_state->buf_ctl & USB_BUF_CTRL_AVAIL) {
 		LOG_WRN("ep 0x%02x was already armed", ep);
@@ -121,6 +121,14 @@ static int udc_rpi_start_xfer(uint8_t ep, const void *data, size_t len)
 
 	ep_state->next_pid ^= 1u;
 	*ep_state->buf_ctl = val;
+	/*
+	 * By default, clk_sys runs at 125MHz, wait 3 nop instructions before
+	 * setting the AVAILABLE bit. See 4.1.2.5.1. Concurrent access.
+	 */
+	arch_nop();
+	arch_nop();
+	arch_nop();
+	*ep_state->buf_ctl = val | USB_BUF_CTRL_AVAIL;
 
 	return 0;
 }


### PR DESCRIPTION
The DPSRAM ports can run at different clocks, this is the default configuration, follow the advice in the datasheet and wait 3 nop instructions before setting the AVAILABLE bit.

It can be observed that when the controller is continuously sending data to the host, it rarely has a 0-byte transaction instead of a short packet. The reason for this is not easy to find, it also seems to depend on the runtime of individual components. This may fix the problem, but there is no sure proof that this is the solution.