### PR TITLE
mgmt: mcumgr: transport: Fix SMP header not being packed

### DIFF
--- a/subsys/mgmt/mcumgr/smp/src/smp.c
+++ b/subsys/mgmt/mcumgr/smp/src/smp.c
@@ -380,7 +380,7 @@ static void smp_on_err(struct smp_streamer *streamer, const struct smp_hdr *req_
  */
 int smp_process_request_packet(struct smp_streamer *streamer, void *vreq)
 {
-	struct smp_hdr req_hdr;
+	struct smp_hdr req_hdr = { 0 };
 	void *rsp;
 	struct net_buf *req = vreq;
 	bool valid_hdr = false;

--- a/subsys/mgmt/mcumgr/transport/include/mgmt/mcumgr/transport/smp_internal.h
+++ b/subsys/mgmt/mcumgr/transport/include/mgmt/mcumgr/transport/smp_internal.h
@@ -32,7 +32,7 @@ struct smp_hdr {
 	uint16_t nh_group;		/* MGMT_GROUP_ID_[...] */
 	uint8_t  nh_seq;		/* Sequence number */
 	uint8_t  nh_id;			/* Message ID within group */
-};
+} __packed;
 
 struct smp_transport;
 struct zephyr_smp_transport;


### PR DESCRIPTION
Fixes an issue with using SMP on devices that do not support unaligned memory access e.g. Cortex M0 which would result in a hard fault