### PR TITLE
toolchain: arcmwdt: fix incorrect __STDC_LIB_EXT1__ macro presence in case of minimal libc

### DIFF
--- a/cmake/compiler/arcmwdt/compiler_flags.cmake
+++ b/cmake/compiler/arcmwdt/compiler_flags.cmake
@@ -116,7 +116,7 @@ set_compiler_property(PROPERTY warning_error_misra_sane -Werror=vla)
 set_compiler_property(PROPERTY cstd -std=)
 
 if (NOT CONFIG_ARCMWDT_LIBC)
-  set_compiler_property(PROPERTY nostdinc -Hno_default_include -Hnoarcexlib)
+  set_compiler_property(PROPERTY nostdinc -Hno_default_include -Hnoarcexlib -U__STDC_LIB_EXT1__)
   set_compiler_property(APPEND PROPERTY nostdinc_include ${NOSTDINC})
 endif()
 


### PR DESCRIPTION
Don't provide `__STDC_LIB_EXT1__` macro (Extensions to the C Library, Part 1: Bounds-checking interfaces) if we use minimal libc - as we don't have functions from this extension implemented in minimal libc.

Fixes: #75745