### PR TITLE
drivers: intc: eirq_nxp_s32: allow the same callback to be set

### DIFF
--- a/drivers/interrupt_controller/intc_eirq_nxp_s32.c
+++ b/drivers/interrupt_controller/intc_eirq_nxp_s32.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 NXP
+ * Copyright 2022-2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -48,6 +48,10 @@ int eirq_nxp_s32_set_callback(const struct device *dev, uint8_t line,
 	struct eirq_nxp_s32_data *data = dev->data;
 
 	__ASSERT(line < NXP_S32_NUM_CHANNELS, "Interrupt line is out of range");
+
+	if ((data->cb[line].cb == cb) && (data->cb[line].data == arg)) {
+		return 0;
+	}
 
 	if (data->cb[line].cb) {
 		return -EBUSY;

--- a/drivers/interrupt_controller/intc_wkpu_nxp_s32.c
+++ b/drivers/interrupt_controller/intc_wkpu_nxp_s32.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NXP
+ * Copyright 2023-2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -42,6 +42,10 @@ int wkpu_nxp_s32_set_callback(const struct device *dev, uint8_t line,
 	struct wkpu_nxp_s32_data *data = dev->data;
 
 	__ASSERT(line < NXP_S32_NUM_CHANNELS, "Interrupt line is out of range");
+
+	if ((data->cb[line].cb == cb) && (data->cb[line].data == arg)) {
+		return 0;
+	}
 
 	if (data->cb[line].cb) {
 		return -EBUSY;


### PR DESCRIPTION
Allow setting the same callback as long as the same data is used (e.g the same GPIO port)
This fixes: https://github.com/zephyrproject-rtos/zephyr/issues/75748

```
SUITE SKIP -   0.00% [after_flash_gpio_config_trigger]: pass = 0, fail = 0, skip = 2, total = 2 duration = 0.006 seconds
 - SKIP - [after_flash_gpio_config_trigger.test_gpio_config_trigger] duration = 0.003 seconds
 - SKIP - [after_flash_gpio_config_trigger.test_gpio_config_twice_trigger] duration = 0.003 seconds

SUITE PASS - 100.00% [gpio_port]: pass = 1, fail = 0, skip = 0, total = 1 duration = 0.026 seconds
 - PASS - [gpio_port.test_gpio_port] duration = 0.026 seconds

SUITE PASS - 100.00% [gpio_port_cb_mgmt]: pass = 3, fail = 0, skip = 0, total = 3 duration = 9.746 seconds
 - PASS - [gpio_port_cb_mgmt.test_gpio_callback_add_remove] duration = 3.615 seconds
 - PASS - [gpio_port_cb_mgmt.test_gpio_callback_enable_disable] duration = 3.617 seconds
 - PASS - [gpio_port_cb_mgmt.test_gpio_callback_self_remove] duration = 2.514 seconds

SUITE PASS - 100.00% [gpio_port_cb_vari]: pass = 1, fail = 0, skip = 0, total = 1 duration = 5.562 seconds
 - PASS - [gpio_port_cb_vari.test_gpio_callback_variants] duration = 5.562 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```