### PR TITLE
fs: add `CONFIG_FILE_SYSTEM_LIB_LINK` option

### DIFF
--- a/subsys/fs/CMakeLists.txt
+++ b/subsys/fs/CMakeLists.txt
@@ -1,18 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
-if(CONFIG_FILE_SYSTEM)
+if(CONFIG_FILE_SYSTEM_LIB_LINK)
   zephyr_interface_library_named(FS)
 
-  zephyr_library()
-  zephyr_library_include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-  zephyr_library_sources(fs.c fs_impl.c)
-  zephyr_library_sources_ifdef(CONFIG_FAT_FILESYSTEM_ELM   fat_fs.c)
-  zephyr_library_sources_ifdef(CONFIG_FILE_SYSTEM_LITTLEFS littlefs_fs.c)
-  zephyr_library_sources_ifdef(CONFIG_FILE_SYSTEM_SHELL    shell.c)
+  if(CONFIG_FILE_SYSTEM)
+    zephyr_library()
+    zephyr_library_include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+    zephyr_library_sources(fs.c fs_impl.c)
+    zephyr_library_sources_ifdef(CONFIG_FAT_FILESYSTEM_ELM   fat_fs.c)
+    zephyr_library_sources_ifdef(CONFIG_FILE_SYSTEM_LITTLEFS littlefs_fs.c)
+    zephyr_library_sources_ifdef(CONFIG_FILE_SYSTEM_SHELL    shell.c)
 
-  zephyr_library_compile_definitions_ifdef(CONFIG_FILE_SYSTEM_LITTLEFS
-                                           LFS_CONFIG=zephyr_lfs_config.h
-  )
+    zephyr_library_compile_definitions_ifdef(CONFIG_FILE_SYSTEM_LITTLEFS
+                                            LFS_CONFIG=zephyr_lfs_config.h
+    )
+  endif()
 
   add_subdirectory_ifdef(CONFIG_FILE_SYSTEM_EXT2 ext2)
 

--- a/subsys/fs/Kconfig
+++ b/subsys/fs/Kconfig
@@ -4,8 +4,19 @@
 
 menu "File Systems"
 
+config FILE_SYSTEM_LIB_LINK
+	bool "Link file system libraries into build"
+	help
+	  Link in the underlying file system libraries. This can be
+	  enabled without CONFIG_FILE_SYSTEM to enable applications
+	  to work directly with the underlying file system libraries.
+	  This can be useful to avoid linking in the entire filesystem
+	  implementation via `struct fs_file_system_t` if only a subset
+	  is used.
+
 config FILE_SYSTEM
 	bool "File system support"
+	select FILE_SYSTEM_LIB_LINK
 	help
 	  Enables support for file system.
 


### PR DESCRIPTION
Add an option that links in the underlying file system libraries as usual, but doesn't compile in the Zephyr file system abstraction layer.

This can be useful to avoid linking in the entire filesystem implementation through the `fs_file_system_t` API struct if only a subset of the functions are used, and the user is operating on the file system through the underlying library API anyway.