### PR TITLE
drivers: sensor: qdec: fix QDEC overflow handling

### DIFF
--- a/drivers/sensor/nordic/qdec_nrfx/qdec_nrfx.c
+++ b/drivers/sensor/nordic/qdec_nrfx/qdec_nrfx.c
@@ -26,7 +26,9 @@ LOG_MODULE_REGISTER(qdec_nrfx, CONFIG_SENSOR_LOG_LEVEL);
 
 
 struct qdec_nrfx_data {
+	int32_t fetched_acc;
 	int32_t acc;
+	bool overflow;
 	sensor_trigger_handler_t data_ready_handler;
 	const struct sensor_trigger *data_ready_trigger;
 };
@@ -49,6 +51,8 @@ static void accumulate(struct qdec_nrfx_data *data, int32_t acc)
 
 	if (!overflow) {
 		data->acc += acc;
+	} else {
+		data->overflow = true;
 	}
 
 	irq_unlock(key);
@@ -70,6 +74,18 @@ static int qdec_nrfx_sample_fetch(const struct device *dev,
 
 	accumulate(data, acc);
 
+	unsigned int key = irq_lock();
+
+	data->fetched_acc = data->acc;
+	data->acc = 0;
+
+	irq_unlock(key);
+
+	if (data->overflow) {
+		data->overflow = false;
+		return -EOVERFLOW;
+	}
+
 	return 0;
 }
 
@@ -87,8 +103,7 @@ static int qdec_nrfx_channel_get(const struct device *dev,
 	}
 
 	key = irq_lock();
-	acc = data->acc;
-	data->acc = 0;
+	acc = data->fetched_acc;
 	irq_unlock(key);
 
 	val->val1 = (acc * FULL_ANGLE) / config->steps;
@@ -146,6 +161,10 @@ static void qdec_nrfx_event_handler(nrfx_qdec_event_t event, void *p_context)
 		if (handler) {
 			handler(dev, trig);
 		}
+		break;
+
+	case NRF_QDEC_EVENT_ACCOF:
+		dev_data->overflow = true;
 		break;
 
 	default:

--- a/tests/boards/nrf/qdec/src/main.c
+++ b/tests/boards/nrf/qdec/src/main.c
@@ -89,7 +89,7 @@ static void qenc_emulate_stop(void)
 }
 
 static void qenc_emulate_verify_reading(int emulator_period_ms, int emulation_duration_ms,
-					bool forward, bool overflow_possible)
+					bool forward, bool overflow_expected)
 {
 	int rc;
 	struct sensor_value val = {0};
@@ -107,13 +107,17 @@ static void qenc_emulate_verify_reading(int emulator_period_ms, int emulation_du
 	k_msleep(emulation_duration_ms);
 
 	rc = sensor_sample_fetch(qdec_dev);
-	zassert_true(rc == 0, "Failed to fetch sample (%d)", rc);
+
+	if (!overflow_expected) {
+		zassert_true(rc == 0, "Failed to fetch sample (%d)", rc);
+	} else {
+		zassert_true(rc == -EOVERFLOW, "Failed to detect overflow");
+	}
 
 	rc = sensor_channel_get(qdec_dev, SENSOR_CHAN_ROTATION, &val);
 	zassert_true(rc == 0, "Failed to get sample (%d)", rc);
 
-	TC_PRINT("QDEC reading: %d\n", val.val1);
-	if (!overflow_possible) {
+	if (!overflow_expected) {
 		zassert_within(val.val1, expected_reading, delta,
 			       "Expected reading: %d,  but got: %d", expected_reading, val.val1);
 	}
@@ -197,6 +201,9 @@ ZTEST(qdec_sensor, test_sensor_trigger_set)
 	rc = k_sem_take(&sem, K_MSEC(200));
 	zassert_true(rc == 0, "qdec handler should be triggered (%d)", rc);
 
+	rc = sensor_sample_fetch(qdec_dev);
+	zassert_true(rc == 0, "Failed to fetch sample (%d)", rc);
+
 	rc = sensor_channel_get(qdec_dev, SENSOR_CHAN_ROTATION, &val);
 	zassert_true(rc == 0, "Failed to fetch sample (%d)", rc);
 
@@ -241,7 +248,6 @@ ZTEST(qdec_sensor, test_qdec_readings)
 	qenc_emulate_verify_reading(10, 100, true, false);
 	qenc_emulate_verify_reading(2, 500, true, false);
 	qenc_emulate_verify_reading(10, 200, false, false);
-	/* may lead to overflows but currently driver does not detects that */
 	qenc_emulate_verify_reading(1, 1000, false, true);
 	qenc_emulate_verify_reading(1, 1000, true, true);
 }
@@ -313,18 +319,15 @@ ZTEST(qdec_sensor, test_sensor_channel_get)
 	/* subsequent calls of sensor_channel_get without calling sensor_sample_fetch
 	 * should yield the same value
 	 */
-	/* zassert_true(val_first.val1 == val_second.val1,
-	 *				"Expected the same readings: %d vs %d",
-	 *				val_first.val1,
-	 *				val_second.val1);
-	 */
-	TC_PRINT("Expected the same readings: %d vs %d - ignore!\n", val_first.val1,
-		 val_second.val1);
-	/* zassert_true(val_first.val2 == val_second.val2, "Expected the same readings: %d vs %d",
-	 *	     val_first.val2, val_second.val2);
-	 */
-	TC_PRINT("Expected the same readings: %d vs %d - ignore!\n", val_first.val2,
-		 val_second.val2);
+	zassert_true(val_first.val1 == val_second.val1,
+		     "Expected the same readings: %d vs %d",
+		     val_first.val1,
+		     val_second.val1);
+
+	zassert_true(val_first.val2 == val_second.val2,
+		     "Expected the same readings: %d vs %d",
+		     val_first.val2,
+		     val_second.val2);
 }
 
 /**


### PR DESCRIPTION
Fixed overflow handling in nrf QDEC sensor driver. It failed to inform user of an overflow in the ACC register, that caused the fetched sample to be invalid because of discarding data that would cause the overflow. 

Now, `qdec_nrfx_sample_fetch()` returns error code if an overflow occured, based on overflow field in qdec data structure.

Also, driver is now more adjusted to sensor driver API. It is guaranteed that two subsequent calls of `sensor_channel_get()` function for the same channels will yield the same value, if `sensor_sample_fetch()` has not been called in the meantime.