### PR TITLE
Bluetooth: tester: Increase the adv buf size to consider the extend adv

### DIFF
--- a/tests/bluetooth/tester/src/btp_gap.c
+++ b/tests/bluetooth/tester/src/btp_gap.c
@@ -30,7 +30,11 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME, CONFIG_BTTESTER_LOG_LEVEL);
 #define CONTROLLER_NAME "btp_tester"
 
 #define BT_LE_AD_DISCOV_MASK (BT_LE_AD_LIMITED | BT_LE_AD_GENERAL)
+#if defined(CONFIG_BT_EXT_ADV)
+#define ADV_BUF_LEN (sizeof(struct btp_gap_device_found_ev) + 2 * CONFIG_BT_EXT_SCAN_BUF_SIZE)
+#else
 #define ADV_BUF_LEN (sizeof(struct btp_gap_device_found_ev) + 2 * 31)
+#endif
 
 static atomic_t current_settings;
 struct bt_conn_auth_cb cb;


### PR DESCRIPTION
[Description]
Device hang is observed when LE Scan
[Root Cause]
For le_ext_adv_report, Data[i] of one adv report is 0-229,
for the adv_buf of saving, it just is 73 bytes, so sometimes
the bytes of adv report is more than the adv_buf, resulted hang
[Fix]
consider the le ext adv case.
[Testing]
After modified, Device hang is not observed after stress
testing with LE Scan

Signed-off-by: Guotao Zhang <guotao.zhang@nxp.com>