### PR TITLE
west: runners: esp32: respect --esp-device during erase

### DIFF
--- a/scripts/west_commands/runners/esp32.py
+++ b/scripts/west_commands/runners/esp32.py
@@ -105,14 +105,15 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
         # Add Python interpreter
         cmd_flash = [sys.executable, self.espidf, '--chip', 'auto']
 
+        if self.device is not None:
+            cmd_flash.extend(['--port', self.device])
+
         if self.erase is True:
             cmd_erase = cmd_flash + ['erase_flash']
             self.check_call(cmd_erase)
 
         if self.no_stub is True:
             cmd_flash.extend(['--no-stub'])
-        if self.device is not None:
-            cmd_flash.extend(['--port', self.device])
         cmd_flash.extend(['--baud', self.baud])
         cmd_flash.extend(['--before', 'default_reset'])
         if self.reset:


### PR DESCRIPTION
When `--erase` was specified, esp32 runner was autodetecting serial port to
be used, regardless of `--esp-device` argument.

Append `--port SERIAL_DEVICE` parameter earlier, so that erase command
invocation uses explicitly specified serial device.