### PR TITLE
Bluetooth: shell: Unregister the previous scan callback to avoid register repeatedly before register

### DIFF
--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -1138,6 +1138,8 @@ static void bt_ready(int err)
 	}
 
 #if defined(CONFIG_BT_OBSERVER)
+	/* Unregister to avoid register repeatedly */
+	bt_le_scan_cb_unregister(&scan_callbacks);
 	bt_le_scan_cb_register(&scan_callbacks);
 #endif
 

--- a/tests/bluetooth/tester/src/btp_gap.c
+++ b/tests/bluetooth/tester/src/btp_gap.c
@@ -30,7 +30,8 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME, CONFIG_BTTESTER_LOG_LEVEL);
 #define CONTROLLER_NAME "btp_tester"
 
 #define BT_LE_AD_DISCOV_MASK (BT_LE_AD_LIMITED | BT_LE_AD_GENERAL)
-#define ADV_BUF_LEN (sizeof(struct btp_gap_device_found_ev) + 2 * 31)
+/*consider ext_adv case*/
+#define ADV_BUF_LEN (sizeof(struct btp_gap_device_found_ev) + 2 * 229)
 
 static atomic_t current_settings;
 struct bt_conn_auth_cb cb;


### PR DESCRIPTION
1.[Description]
tests: tester: Device hang is observed when LE Scan
[Root Cause]
For le_ext_adv_report, Data[i] of one adv report is 0-229, for the adv_buf of saving, it just is 73 bytes, so sometimes the bytes of adv report is more than the adv_buf, resulted hang
[Fix]
Increase the adv_buf size.
[Testing]
After modified, Device hang is not observed after stress testing with LE Scan

2.[Description]
tests: shell: Restart bt will register the same scan callback twice.
Callback next node point to itself,when scan, callback function
loop infinitely
[Root Cause]
After bt_disable, then bt_init, register scan_cb two times,
[Fix]
Unregister the previous callback to avoid register repeatedly.
[Testing]
After modified, test bt init,bt scan on,bt scan off,bt disable as loop, issue doesn't repoduce.

Signed-off-by: Guotao Zhang guotao.zhang@nxp.com