### PR TITLE
net: lib: http_server: Fix HTTP1 POST request handling

### DIFF
--- a/include/zephyr/net/http/server.h
+++ b/include/zephyr/net/http/server.h
@@ -372,6 +372,9 @@ struct http_client_ctx {
 	/** Flag indicating that HTTP2 preface was sent. */
 	bool preface_sent : 1;
 
+	/** Flag indicating that HTTP1 headers were sent. */
+	bool http1_headers_sent : 1;
+
 	/** Flag indicating that upgrade header was present in the request. */
 	bool has_upgrade_header : 1;
 

--- a/subsys/net/lib/http/http_server_http1.c
+++ b/subsys/net/lib/http/http_server_http1.c
@@ -193,17 +193,13 @@ static int dynamic_post_req(struct http_resource_detail_dynamic *dynamic_detail,
 		return -ENOENT;
 	}
 
-	if (client->current_stream == NULL) {
-		return -ENOENT;
-	}
-
-	if (!client->current_stream->headers_sent) {
+	if (!client->http1_headers_sent) {
 		ret = SEND_RESPONSE(RESPONSE_TEMPLATE_CHUNKED,
 				    dynamic_detail->common.content_type);
 		if (ret < 0) {
 			return ret;
 		}
-		client->current_stream->headers_sent = true;
+		client->http1_headers_sent = true;
 	}
 
 	copy_len = MIN(remaining, dynamic_detail->data_buffer_len);


### PR DESCRIPTION
In previous batch of fixes it was overlooked that streams are HTTP2-specific concept. While for HTTP2 we need to track headers reply state for each individual stream, at HTTP1 level we need to track this at the client level. Hence, reintroduce respective flags to track headers reply state, but only for HTTP1.

Fixes #75713