### PR TITLE
drivers: i2c: i2c_nrfx_twi: enforce stop after scatter/gather

### DIFF
--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -57,6 +57,13 @@ static int i2c_nrfx_twi_transfer(const struct device *dev,
 		bool more_msgs = ((i < (num_msgs - 1)) &&
 				  !(msgs[i + 1].flags & I2C_MSG_RESTART));
 
+		if (i == (num_msgs - 1)) {
+			/* Enforce STOP after last message in the
+			 * scatter/gather transaction.
+			 */
+			msgs[i].flags |= I2C_MSG_STOP;
+		}
+
 		ret = i2c_nrfx_twi_msg_transfer(dev, msgs[i].flags,
 						msgs[i].buf,
 						msgs[i].len, addr,


### PR DESCRIPTION
The I2C API specification requires a STOP condition be enforced on the bus after all messages in a scatter/gather transaction have been transmitted using i2c_transfer().

The i2c_nrfx_twi.c device device driver has been updated to match the specified behavior.

Fixes: #69488

Tested with the following scatter/gather transaction:
```
	const uint16_t addr = 0x0A;
	uint8_t write_buf[] = {1};

	struct i2c_msg msg[3];

	msg[0].buf = write_buf;
	msg[0].len = 1;
	msg[0].flags = I2C_MSG_WRITE; /* I2C_MSG_STOP needs to be set here if only msg[0] is sent */

	msg[1].buf = read_buf;
	msg[1].len = 3;
	msg[1].flags = I2C_MSG_RESTART | I2C_MSG_READ;

	msg[2].buf = read_buf + 3;
	msg[2].len = 1;
	msg[2].flags = I2C_MSG_READ; /* I2C_MSG_STOP must be set here */
```

Output before this PR (using Analog Discovery 2 I2C Protocol analyzer):
```
i2c_transfer(dev, msg, 3, addr);
```
```
Start, h14 [ h0A | WR ], h01,
Restart, h15 [ h0A | RD ], h04, h05, h06,
```
and
```
i2c_transfer(dev, msg, 1, addr);
```
```
Start, h14 [ h0A | WR ], h01,
```
both are missing the STOP condition.

Output after this PR
```
i2c_transfer(dev, msg, 3, addr);
```
```
Start, h14 [ h0A | WR ], h01, 
Restart, h15 [ h0A | RD ], h04, h05, h06, h07 NAK, Stop
```
and
```
i2c_transfer(dev, msg, 1, addr);
```
```
Start, h14 [ h0A | WR ], h01, Stop
```
Now stopped and able to be sent right after each other as the bus is in the correct STOPPED state.
