### PR TITLE
tests: do not get ZEPHYR_BASE from ENV

### DIFF
--- a/tests/bsim/bluetooth/host/gatt/ccc_store/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/gatt/ccc_store/CMakeLists.txt
@@ -24,5 +24,5 @@ zephyr_include_directories(
         $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
         $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
 
-        $ENV{ZEPHYR_BASE}/subsys/bluetooth/host/
+        ${ZEPHYR_BASE}/subsys/bluetooth/host/
 )

--- a/tests/bsim/bluetooth/host/security/ccc_update/CMakeLists.txt
+++ b/tests/bsim/bluetooth/host/security/ccc_update/CMakeLists.txt
@@ -24,5 +24,5 @@ zephyr_include_directories(
         $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
         $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
 
-        $ENV{ZEPHYR_BASE}/subsys/bluetooth/host/
+        ${ZEPHYR_BASE}/subsys/bluetooth/host/
 )

--- a/tests/drivers/sensor/ina230/CMakeLists.txt
+++ b/tests/drivers/sensor/ina230/CMakeLists.txt
@@ -10,4 +10,4 @@ target_sources(app PRIVATE ${app_sources})
 
 # Include the INA23x driver path and unit-test path for private header inclusion
 zephyr_include_directories(./src)
-zephyr_include_directories($ENV{ZEPHYR_BASE}/drivers/sensor/ti/ina23x)
+zephyr_include_directories(${ZEPHYR_BASE}/drivers/sensor/ti/ina23x)

--- a/tests/drivers/sensor/ina237/CMakeLists.txt
+++ b/tests/drivers/sensor/ina237/CMakeLists.txt
@@ -10,4 +10,4 @@ target_sources(app PRIVATE ${app_sources})
 
 # Include the INA23x driver path and unit-test path for private header inclusion
 zephyr_include_directories(./src)
-zephyr_include_directories($ENV{ZEPHYR_BASE}/drivers/sensor/ti/ina23x)
+zephyr_include_directories(${ZEPHYR_BASE}/drivers/sensor/ti/ina23x)

--- a/tests/misc/llext-edk/CMakeLists.txt
+++ b/tests/misc/llext-edk/CMakeLists.txt
@@ -6,4 +6,4 @@ project(llext_edk_test LANGUAGES C)
 
 target_sources(app PRIVATE src/main.c)
 zephyr_include_directories(include)
-zephyr_include_directories($ENV{ZEPHYR_BASE}/boards/native/common)
+zephyr_include_directories(${ZEPHYR_BASE}/boards/native/common)


### PR DESCRIPTION
find_package() already deals with finding ZEPHYR_BASE, so do not rely on
it being set in ENV, use the variable directly adter find_package() was
called.

Fixes #75387

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
