### PR TITLE
Adds read-only property for the I2C EEPROM Target

### DIFF
--- a/drivers/i2c/target/eeprom_target.c
+++ b/drivers/i2c/target/eeprom_target.c
@@ -24,6 +24,7 @@ struct i2c_eeprom_target_data {
 	uint32_t buffer_idx;
 	uint32_t idx_write_cnt;
 	uint8_t address_width;
+	bool read_only;
 };
 
 struct i2c_eeprom_target_config {
@@ -115,22 +116,26 @@ static int eeprom_target_write_received(struct i2c_target_config *config,
 						struct i2c_eeprom_target_data,
 						config);
 
-	LOG_DBG("eeprom: write done, val=0x%x", val);
-
-	/* In case EEPROM wants to be R/O, return !0 here could trigger
-	 * a NACK to the I2C controller, support depends on the
-	 * I2C controller support
-	 */
-
 	if (data->idx_write_cnt < (data->address_width >> 3)) {
+		LOG_DBG("eeprom: write addr, val=0x%x", val);
+
 		if (data->idx_write_cnt == 0) {
 			data->buffer_idx = 0;
 		}
 
 		data->buffer_idx = val | (data->buffer_idx << 8);
 		data->idx_write_cnt++;
-	} else {
+	} else if (!data->read_only) {
+		LOG_DBG("eeprom: write data, val=0x%x", val);
+
 		data->buffer[data->buffer_idx++] = val;
+	} else {
+		LOG_DBG("eeprom: write attempt to read-only EEPROM");
+
+		/* In case the EEPROM is read-only, an error code is returned
+		 * to trigger a NACK on I2C controllers that support it.
+		 */
+		return -EIO;
 	}
 
 	data->buffer_idx = data->buffer_idx % data->buffer_size;
@@ -249,34 +254,25 @@ static int i2c_eeprom_target_init(const struct device *dev)
 	return 0;
 }
 
-#define I2C_EEPROM_INIT(inst)						\
-	static struct i2c_eeprom_target_data				\
-		i2c_eeprom_target_##inst##_dev_data = {			\
-			.address_width = DT_INST_PROP_OR(inst,		\
-					address_width, 8),		\
-		};							\
-									\
-	static uint8_t							\
-	i2c_eeprom_target_##inst##_buffer[(DT_INST_PROP(inst, size))];	\
-									\
-	BUILD_ASSERT(DT_INST_PROP(inst, size) <=			\
-			(1 << DT_INST_PROP_OR(inst, address_width, 8)), \
-			"size must be <= than 2^address_width");	\
-									\
-	static const struct i2c_eeprom_target_config			\
-		i2c_eeprom_target_##inst##_cfg = {			\
-		.bus = I2C_DT_SPEC_INST_GET(inst),			\
-		.buffer_size = DT_INST_PROP(inst, size),		\
-		.buffer = i2c_eeprom_target_##inst##_buffer		\
-	};								\
-									\
-	DEVICE_DT_INST_DEFINE(inst,					\
-			    &i2c_eeprom_target_init,			\
-			    NULL,			\
-			    &i2c_eeprom_target_##inst##_dev_data,	\
-			    &i2c_eeprom_target_##inst##_cfg,		\
-			    POST_KERNEL,				\
-			    CONFIG_I2C_TARGET_INIT_PRIORITY,		\
-			    &api_funcs);
+#define I2C_EEPROM_INIT(inst)                                                                      \
+	static struct i2c_eeprom_target_data i2c_eeprom_target_##inst##_dev_data = {               \
+		.address_width = DT_INST_PROP_OR(inst, address_width, 8),                          \
+		.read_only = DT_INST_PROP_OR(inst, read_only, 8),                                  \
+	};                                                                                         \
+                                                                                                   \
+	static uint8_t i2c_eeprom_target_##inst##_buffer[(DT_INST_PROP(inst, size))];              \
+                                                                                                   \
+	BUILD_ASSERT(DT_INST_PROP(inst, size) <= (1 << DT_INST_PROP_OR(inst, address_width, 8)),   \
+		     "size must be <= than 2^address_width");                                      \
+                                                                                                   \
+	static const struct i2c_eeprom_target_config i2c_eeprom_target_##inst##_cfg = {            \
+		.bus = I2C_DT_SPEC_INST_GET(inst),                                                 \
+		.buffer_size = DT_INST_PROP(inst, size),                                           \
+		.buffer = i2c_eeprom_target_##inst##_buffer};                                      \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(inst, &i2c_eeprom_target_init, NULL,                                 \
+			      &i2c_eeprom_target_##inst##_dev_data,                                \
+			      &i2c_eeprom_target_##inst##_cfg, POST_KERNEL,                        \
+			      CONFIG_I2C_TARGET_INIT_PRIORITY, &api_funcs);
 
 DT_INST_FOREACH_STATUS_OKAY(I2C_EEPROM_INIT)

--- a/dts/bindings/mtd/zephyr,i2c-target-eeprom.yaml
+++ b/dts/bindings/mtd/zephyr,i2c-target-eeprom.yaml
@@ -13,3 +13,6 @@ properties:
     description: |
       Number of address bits used to address the EEPROM. If not specified
       the EEPROM is assumed to have a 8-bit address.
+  read-only:
+    type: boolean
+    description: set this property if the EERPOM is read-only.

--- a/tests/drivers/i2c/i2c_target_api/boards/frdm_ke17z512.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/frdm_ke17z512.overlay
@@ -15,6 +15,13 @@
 		reg = <0x54>;
 		size = <256>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 &lpi2c1 {

--- a/tests/drivers/i2c/i2c_target_api/boards/frdm_mcxn236.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/frdm_mcxn236.overlay
@@ -41,6 +41,13 @@
 		size = <1024>;
 		address-width = <16>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 &flexcomm5_lpi2c5 {

--- a/tests/drivers/i2c/i2c_target_api/boards/frdm_mcxn947_mcxn947_cpu0.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/frdm_mcxn947_mcxn947_cpu0.overlay
@@ -40,6 +40,13 @@
 		reg = <0x54>;
 		size = <256>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 &flexcomm2_lpi2c2 {

--- a/tests/drivers/i2c/i2c_target_api/boards/frdm_mcxn947_mcxn947_cpu0_qspi.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/frdm_mcxn947_mcxn947_cpu0_qspi.overlay
@@ -40,6 +40,13 @@
 		reg = <0x54>;
 		size = <1024>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 &flexcomm2_lpi2c2 {

--- a/tests/drivers/i2c/i2c_target_api/boards/it8xxx2_evb.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/it8xxx2_evb.overlay
@@ -30,4 +30,11 @@
 		reg = <0x52>;
 		size = <256>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/max32655evkit_max32655_m4.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/max32655evkit_max32655_m4.overlay
@@ -11,6 +11,13 @@
 		address-width = <16>;
 		size = <1024>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 &i2c1 {

--- a/tests/drivers/i2c/i2c_target_api/boards/max32662evkit.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/max32662evkit.overlay
@@ -14,6 +14,13 @@
 		reg = <0x54>;
 		size = <256>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 &i2c1 {

--- a/tests/drivers/i2c/i2c_target_api/boards/max32666evkit_max32666_cpu0.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/max32666evkit_max32666_cpu0.overlay
@@ -11,6 +11,13 @@
 		address-width = <16>;
 		size = <1024>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 &i2c2 {

--- a/tests/drivers/i2c/i2c_target_api/boards/max32670evkit.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/max32670evkit.overlay
@@ -11,6 +11,13 @@
 		address-width = <16>;
 		size = <1024>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 &i2c1 {

--- a/tests/drivers/i2c/i2c_target_api/boards/max32672evkit.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/max32672evkit.overlay
@@ -11,6 +11,13 @@
 		address-width = <16>;
 		size = <1024>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 &i2c1 {

--- a/tests/drivers/i2c/i2c_target_api/boards/max32675evkit.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/max32675evkit.overlay
@@ -15,6 +15,13 @@
 		address-width = <16>;
 		size = <1024>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 &i2c2 {

--- a/tests/drivers/i2c/i2c_target_api/boards/max32680evkit_max32680_m4.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/max32680evkit_max32680_m4.overlay
@@ -11,6 +11,13 @@
 		address-width = <16>;
 		size = <1024>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 &i2c1 {

--- a/tests/drivers/i2c/i2c_target_api/boards/max32690evkit_max32690_m4.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/max32690evkit_max32690_m4.overlay
@@ -11,6 +11,13 @@
 		address-width = <16>;
 		size = <1024>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 &i2c2 {

--- a/tests/drivers/i2c/i2c_target_api/boards/mec1501modular_assy6885.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/mec1501modular_assy6885.overlay
@@ -11,6 +11,13 @@
 		address-width = <16>;
 		size = <1024>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 

--- a/tests/drivers/i2c/i2c_target_api/boards/mimxrt1040_evk.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/mimxrt1040_evk.overlay
@@ -19,6 +19,13 @@
 		reg = <0x54>;
 		size = <256>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 &lpi2c3 {

--- a/tests/drivers/i2c/i2c_target_api/boards/mimxrt1060_evk.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/mimxrt1060_evk.overlay
@@ -27,6 +27,13 @@
 		reg = <0x54>;
 		size = <256>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 &lpi2c3 {

--- a/tests/drivers/i2c/i2c_target_api/boards/mimxrt1170_evk_mimxrt1176_cm7.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/mimxrt1170_evk_mimxrt1176_cm7.overlay
@@ -13,6 +13,13 @@
 		reg = <0x54>;
 		size = <256>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 &lpi2c5 {

--- a/tests/drivers/i2c/i2c_target_api/boards/mimxrt1170_evkb_mimxrt1176_cm4.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/mimxrt1170_evkb_mimxrt1176_cm4.overlay
@@ -13,6 +13,13 @@
 		reg = <0x54>;
 		size = <256>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 &lpi2c5 {

--- a/tests/drivers/i2c/i2c_target_api/boards/mimxrt1170_evkb_mimxrt1176_cm7.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/mimxrt1170_evkb_mimxrt1176_cm7.overlay
@@ -13,6 +13,13 @@
 		reg = <0x54>;
 		size = <256>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 &lpi2c5 {

--- a/tests/drivers/i2c/i2c_target_api/boards/mimxrt1180_evk_mimxrt1189_cm33.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/mimxrt1180_evk_mimxrt1189_cm33.overlay
@@ -13,6 +13,13 @@
 		reg = <0x54>;
 		size = <256>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 &lpi2c3 {

--- a/tests/drivers/i2c/i2c_target_api/boards/mimxrt1180_evk_mimxrt1189_cm7.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/mimxrt1180_evk_mimxrt1189_cm7.overlay
@@ -13,6 +13,13 @@
 		reg = <0x54>;
 		size = <256>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 &lpi2c3 {

--- a/tests/drivers/i2c/i2c_target_api/boards/mr_canhubk3.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/mr_canhubk3.overlay
@@ -13,6 +13,13 @@
 		reg = <0x54>;
 		size = <256>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 &lpi2c1 {

--- a/tests/drivers/i2c/i2c_target_api/boards/npcx9m6f_evb.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/npcx9m6f_evb.overlay
@@ -13,6 +13,13 @@
 		address-width = <16>;
 		size = <1024>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 &i2c2_0 {

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_f091rc.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_f091rc.overlay
@@ -16,6 +16,13 @@
 		reg = <0x54>;
 		size = <256>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_f207zg.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_f207zg.overlay
@@ -16,6 +16,13 @@
 		reg = <0x54>;
 		size = <256>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 &i2c2 {

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_f401re.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_f401re.overlay
@@ -16,6 +16,13 @@
 		reg = <0x54>;
 		size = <256>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 &i2c3 {

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_f429zi.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_f429zi.overlay
@@ -16,6 +16,13 @@
 		reg = <0x54>;
 		size = <256>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 &i2c2 {

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_f746zg.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_f746zg.overlay
@@ -19,6 +19,13 @@
 		reg = <0x54>;
 		size = <256>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 &i2c2 {

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_g071rb.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_g071rb.overlay
@@ -19,6 +19,13 @@
 		reg = <0x54>;
 		size = <256>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 &i2c2 {

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_g474re.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_g474re.overlay
@@ -16,6 +16,13 @@
 		reg = <0x54>;
 		size = <256>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 &i2c3 {

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_h563zi.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_h563zi.overlay
@@ -23,6 +23,13 @@
 		address-width = <16>;
 		size = <1024>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 &i2c1 {

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_l073rz.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_l073rz.overlay
@@ -16,6 +16,13 @@
 		reg = <0x54>;
 		size = <256>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_l152re.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_l152re.overlay
@@ -16,6 +16,13 @@
 		reg = <0x54>;
 		size = <256>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_l476rg.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_l476rg.overlay
@@ -20,6 +20,13 @@
 		address-width = <16>;
 		size = <1024>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 &i2c3 {

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_u083rc.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_u083rc.overlay
@@ -19,6 +19,13 @@
 		reg = <0x54>;
 		size = <256>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 &i2c2 {

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_wb55rg.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_wb55rg.overlay
@@ -16,6 +16,13 @@
 		reg = <0x54>;
 		size = <256>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 &i2c3 {

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_wl55jc.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_wl55jc.overlay
@@ -28,4 +28,11 @@
 		reg = <0x54>;
 		size = <256>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/numaker_m2l31ki.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/numaker_m2l31ki.overlay
@@ -27,6 +27,13 @@
 		address-width = <16>;
 		size = <1024>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 &i2c0 {

--- a/tests/drivers/i2c/i2c_target_api/boards/numaker_pfm_m467.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/numaker_pfm_m467.overlay
@@ -27,6 +27,13 @@
 		address-width = <16>;
 		size = <1024>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 &i2c3 {

--- a/tests/drivers/i2c/i2c_target_api/boards/rpi_pico.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/rpi_pico.overlay
@@ -4,6 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+ /*
+  * Short Pin P4 to PA14, and P5 to P15, for the test to pass.
+  */
+
 &pinctrl {
 	i2c1_default: i2c1_default {
 		group1 {
@@ -19,6 +23,13 @@
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
 		size = <256>;
+	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
 	};
 };
 

--- a/tests/drivers/i2c/i2c_target_api/boards/sltb010a.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/sltb010a.overlay
@@ -11,4 +11,11 @@
 		reg = <0x56>;
 		size = <256>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };

--- a/tests/drivers/i2c/i2c_target_api/boards/stm32f072b_disco.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/stm32f072b_disco.overlay
@@ -6,6 +6,13 @@
 		reg = <0x54>;
 		size = <256>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 

--- a/tests/drivers/i2c/i2c_target_api/boards/stm32f3_disco.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/stm32f3_disco.overlay
@@ -18,6 +18,13 @@
 		reg = <0x54>;
 		size = <256>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 &i2c2 {

--- a/tests/drivers/i2c/i2c_target_api/boards/stm32h573i_dk.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/stm32h573i_dk.overlay
@@ -19,6 +19,13 @@
 		reg = <0x54>;
 		size = <256>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 &i2c2 {

--- a/tests/drivers/i2c/i2c_target_api/boards/stm32u083c_dk.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/stm32u083c_dk.overlay
@@ -19,6 +19,13 @@
 		reg = <0x54>;
 		size = <256>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 
 };
 

--- a/tests/drivers/i2c/i2c_target_api/boards/xmc47_relax_kit.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/xmc47_relax_kit.overlay
@@ -32,6 +32,13 @@
 		reg = <0x54>;
 		size = <256>;
 	};
+	eeprom2: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <4096>;
+		address-width = <16>;
+		read-only;
+	};
 };
 
 &arduino_i2c {


### PR DESCRIPTION
In case the EEPROM data stored in the buffer shall be not writable from the I2C interface, the read-only property can now be set in the device tree. 