### PR TITLE
samples: drivers: mbox: fix regex when using channels 0/1

### DIFF
--- a/samples/drivers/mbox/sample.yaml
+++ b/samples/drivers/mbox/sample.yaml
@@ -19,10 +19,8 @@ tests:
       type: multi_line
       ordered: false
       regex:
-        - "Ping \\(on channel 0\\)"
         - "Pong \\(on channel 0\\)"
         - "Ping \\(on channel 1\\)"
-        - "Pong \\(on channel 1\\)"
 
   sample.drivers.mbox.nrf54h20_app_ppr:
     platform_allow:
@@ -62,10 +60,8 @@ tests:
       type: multi_line
       ordered: false
       regex:
-        - "Ping \\(on channel 0\\)"
         - "Pong \\(on channel 0\\)"
         - "Ping \\(on channel 1\\)"
-        - "Pong \\(on channel 1\\)"
 
   sample.drivers.mbox.nrf54l15:
     platform_allow:


### PR DESCRIPTION
The sample will print a ping-pong message indefinitely on both, application (or main) core and remote core. When twister is run in device testing mode, only one terminal is evaluated (application), so the regex just needs to account for the application core output, not remote.

Fixes #70307