### PR TITLE
Bluetooth: host: Send host num completes as early as possible

### DIFF
--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -187,7 +187,12 @@ struct acl_data {
 	struct bt_buf_data buf_data;
 
 	/* Index into the bt_conn storage array */
-	uint8_t  index;
+	uint8_t index;
+
+	/** Host has already sent a Host Number of Completed Packets
+	 *  for this buffer.
+	 */
+	bool host_ncp_sent;
 
 	/** ACL connection handle */
 	uint16_t handle;

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -228,6 +228,11 @@ static void handle_vs_event(uint8_t event, struct net_buf *buf,
 	/* Other possible errors are handled by handle_event_common function */
 }
 
+void bt_acl_set_ncp_sent(struct net_buf *packet, bool value)
+{
+	acl(packet)->host_ncp_sent = value;
+}
+
 void bt_send_one_host_num_completed_packets(uint16_t handle)
 {
 	if (!IS_ENABLED(CONFIG_BT_HCI_ACL_FLOW_CONTROL)) {
@@ -265,6 +270,10 @@ void bt_hci_host_num_completed_packets(struct net_buf *buf)
 	uint8_t index = acl(buf)->index;
 
 	net_buf_destroy(buf);
+
+	if (acl(buf)->host_ncp_sent) {
+		return;
+	}
 
 	/* Do nothing if controller to host flow control is not supported */
 	if (!BT_CMD_TEST(bt_dev.supported_commands, 10, 5)) {

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -598,3 +598,5 @@ void bt_hci_le_per_adv_subevent_data_request(struct net_buf *buf);
 void bt_hci_le_per_adv_response_report(struct net_buf *buf);
 
 void bt_tx_irq_raise(void);
+void bt_send_one_host_num_completed_packets(uint16_t handle);
+void bt_acl_set_ncp_sent(struct net_buf *packet, bool value);


### PR DESCRIPTION
The Softdevice Controller now sends the disconnect event only after
receiving all Host Num Completes for the packets it sent to the host.
This is done for security reasons.

In our current reassembly logic, it does not really matter when we
withhold the num complete.

Before this patch, it's the first fragment that is withheld, and after
the patch it will be the last fragment that is withheld until the host
is done processing.

The flow control properties are maintained, just in a different way.