### PR TITLE
MAINTAINERS: Fix NXP Drivers missing some drivers

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3408,6 +3408,9 @@ NXP Drivers:
     - manuargue
     - dbaluta
     - MarkWangChinese
+  files-regex:
+    - ^drivers/.*nxp.*
+    - ^drivers/.*mcux.*
   files:
     - drivers/*/*imx*
     - drivers/*/*lpc*.c


### PR DESCRIPTION
Some NXP drivers were not being associated with any NXP maintainer areas. Fix by using regex to include them.