### PR TITLE
samples: ipc: icmsg: fix unbalanced nRF53 cpunet enable calls

### DIFF
--- a/samples/subsys/ipc/ipc_service/icmsg/src/main.c
+++ b/samples/subsys/ipc/ipc_service/icmsg/src/main.c
@@ -112,6 +112,11 @@ int main(void)
 
 	LOG_INF("IPC-service HOST demo started");
 
+#if defined(CONFIG_SOC_NRF5340_CPUAPP)
+	LOG_INF("Run network core");
+	nrf53_cpunet_enable(true);
+#endif
+
 	ipc0_instance = DEVICE_DT_GET(DT_NODELABEL(ipc0));
 
 	ret = ipc_service_open_instance(ipc0_instance);


### PR DESCRIPTION
It looks like sample called nrf53_cpunet_enable(false) before any nrf53_cpunet_enable(true), resulting in asserts due to unbalanced calls (error propagated from onoff service).

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/74521