### PR TITLE
ci: scripts: do not count PRs labeled as bug in snapshot

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4999,6 +4999,7 @@ Continuous Integration:
   files:
     - .github/
     - scripts/ci/
+    - scripts/make_bugs_pickle.py
     - .checkpatch.conf
     - scripts/gitlint/
     - scripts/set_assignees.py

--- a/scripts/ci/twister_ignore.txt
+++ b/scripts/ci/twister_ignore.txt
@@ -46,6 +46,7 @@ scripts/checkpatch/*
 scripts/checkpatch.pl
 scripts/ci/pylintrc
 scripts/footprint/*
+scripts/make_bugs_pickle.py
 scripts/set_assignees.py
 scripts/gitlint/zephyr_commit_rules.py
 scripts/west_commands/runners/canopen_program.py

--- a/scripts/make_bugs_pickle.py
+++ b/scripts/make_bugs_pickle.py
@@ -53,7 +53,7 @@ def open_out_file(args: argparse.Namespace) -> BinaryIO:
 
 def main() -> None:
     args = parse_args()
-    open_bugs = get_open_bugs()
+    open_bugs = [issue for issue in get_open_bugs() if not issue.pull_request]
 
     with open_out_file(args) as out_file:
         pickle.dump(open_bugs, out_file)


### PR DESCRIPTION
Doing duplicates count of bugs, a PR fixing a bug is not a bug report.
Many PRs fixing an open bug are labeled with 'bug' and thuse are being
counted twice.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
