### PR TITLE
MAINTAINERS: disambiguate ARM area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4310,7 +4310,7 @@ West:
   files:
     - modules/cmsis/
   labels:
-    - "area: ARM"
+    - "area: CMSIS-Core"
 
 "West project: cmsis-dsp":
   status: maintained
@@ -4427,7 +4427,7 @@ West:
     - drivers/misc/ethos_u/
     - modules/hal_ethos_u/
   labels:
-    - "area: ARM"
+    - "platform: ARM"
 
 "West project: hal_gigadevice":
   status: maintained


### PR DESCRIPTION
Stop using "area: ARM" for everything related to ARM, use specific labels
instead.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
