### PR TITLE
ci: compliance: add a PR description check step

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -1,6 +1,12 @@
 name: Compliance Checks
 
-on: pull_request
+on:
+  pull_request:
+    types:
+    - edited
+    - opened
+    - reopened
+    - synchronize
 
 jobs:
   check_compliance:
@@ -52,6 +58,14 @@ jobs:
         west config manifest.group-filter -- +ci,-optional
         west update -o=--depth=1 -n 2>&1 1> west.update.log || west update -o=--depth=1 -n 2>&1 1> west.update2.log
 
+    - name: Check for PR description
+      if: ${{ github.event.pull_request.body == '' }}
+      continue-on-error: true
+      id: pr_description
+      run: |
+        echo "Pull request description cannot be empty."
+        exit 1
+
     - name: Run Compliance Tests
       continue-on-error: true
       id: compliance
@@ -94,5 +108,12 @@ jobs:
         done
 
         if [ "${exit}" == "1" ]; then
+          echo "Compliance error, check for error messages in the \"Run Compliance Tests\" step"
+          echo "You can run this step locally with the ./scripts/ci/check_compliance.py script."
+          exit 1;
+        fi
+
+        if [ "${{ steps.pr_description.outcome }}" == "failure" ]; then
+          echo "PR description cannot be empty"
           exit 1;
         fi


### PR DESCRIPTION
Add an extra workflow step to block PRs with an empty description so that these gets flagged automatically and reviewers don't have to ask for it.

Add a message in the actual fail step as well so it's easier for the user to figure out what went wrong, even in the existing compliance check case.

--

Test run: https://github.com/zephyrproject-rtos/zephyr/actions/runs/9896115700/job/27337556338

Goes with zephyrproject-rtos/zephyr#75115