### PR TITLE
github: workflows: Update manifest action to detect impostor commits

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -26,12 +26,13 @@ jobs:
           west init -l . || true
 
       - name: Manifest
-        uses: zephyrproject-rtos/action-manifest@v1.2.2
+        uses: zephyrproject-rtos/action-manifest@1.3.0
         with:
           github-token: ${{ secrets.ZB_GITHUB_TOKEN }}
           manifest-path: 'west.yml'
           checkout-path: 'zephyrproject/zephyr'
           use-tree-checkout: 'true'
+          check-impostor-commits: 'true'
           label-prefix: 'manifest-'
           verbosity-level: '1'
           labels: 'manifest'


### PR DESCRIPTION
See additional info in:
https://github.com/zephyrproject-rtos/action-manifest/pull/12

Test PR showing detection of an impostor commmit:
https://github.com/zephyrproject-rtos/zephyr-testing/pull/283

Preview of detection output:
<kbd> <img width="898" alt="image" src="https://github.com/user-attachments/assets/730e7fc8-4d59-46d9-9ab4-b26c4129da9c"> </kbd> 
