### PR TITLE
I2C API Enforce stop condition after last message in `i2c_transfer` wrapper

### DIFF
--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -694,11 +694,6 @@ static int i2c_dw_transfer(const struct device *dev,
 			dw->xfr_flags |= I2C_MSG_RESTART;
 		}
 
-		/* Send STOP if this is the last message */
-		if (msg_left == 1U) {
-			dw->xfr_flags |= I2C_MSG_STOP;
-		}
-
 		dw->state &= ~(I2C_DW_CMD_SEND | I2C_DW_CMD_RECV);
 
 		if ((dw->xfr_flags & I2C_MSG_RW_MASK) == I2C_MSG_WRITE) {

--- a/drivers/i2c/i2c_esp32.c
+++ b/drivers/i2c/i2c_esp32.c
@@ -654,9 +654,6 @@ static int IRAM_ATTR i2c_esp32_transfer(const struct device *dev, struct i2c_msg
 				ret = -EINVAL;
 				break;
 			}
-		} else {
-			/* make sure the last message contains stop event */
-			current->flags |= I2C_MSG_STOP;
 		}
 
 		current++;

--- a/drivers/i2c/i2c_gd32.c
+++ b/drivers/i2c/i2c_gd32.c
@@ -433,9 +433,6 @@ static int i2c_gd32_transfer(const struct device *dev,
 			if (current->flags & I2C_MSG_STOP) {
 				return -EINVAL;
 			}
-		} else {
-			/* Last message flags implicitly contain I2C_MSG_STOP flag. */
-			current->flags |= I2C_MSG_STOP;
 		}
 
 		if ((current->buf == NULL) ||

--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -176,9 +176,6 @@ static int i2c_stm32_transfer(const struct device *dev, struct i2c_msg *msg,
 				ret = -EINVAL;
 				break;
 			}
-		} else {
-			/* Stop condition is required for the last message */
-			current->flags |= I2C_MSG_STOP;
 		}
 
 		current++;

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -785,6 +785,12 @@ static inline int z_impl_i2c_transfer(const struct device *dev,
 	const struct i2c_driver_api *api =
 		(const struct i2c_driver_api *)dev->api;
 
+	if (!num_msgs) {
+		return 0;
+	}
+
+	msgs[num_msgs - 1].flags |= I2C_MSG_STOP;
+
 	int res =  api->transfer(dev, msgs, num_msgs, addr);
 
 	i2c_xfer_stats(dev, msgs, num_msgs);
@@ -821,13 +827,14 @@ static inline int z_impl_i2c_transfer(const struct device *dev,
  * @retval -EWOULDBLOCK If the device is temporarily busy doing another transfer
  */
 static inline int i2c_transfer_cb(const struct device *dev,
-				 struct i2c_msg *msgs,
-				 uint8_t num_msgs,
-				 uint16_t addr,
-				 i2c_callback_t cb,
-				 void *userdata)
+				  struct i2c_msg *msgs,
+				  uint8_t num_msgs,
+				  uint16_t addr,
+				  i2c_callback_t cb,
+				  void *userdata)
 {
-	const struct i2c_driver_api *api = (const struct i2c_driver_api *)dev->api;
+	const struct i2c_driver_api *api =
+		(const struct i2c_driver_api *)dev->api;
 
 	if (api->transfer_cb == NULL) {
 		return -ENOSYS;

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -840,6 +840,13 @@ static inline int i2c_transfer_cb(const struct device *dev,
 		return -ENOSYS;
 	}
 
+	if (!num_msgs) {
+		cb(dev, 0, userdata);
+		return 0;
+	}
+
+	msgs[num_msgs - 1].flags |= I2C_MSG_STOP;
+
 	return api->transfer_cb(dev, msgs, num_msgs, addr, cb, userdata);
 }
 


### PR DESCRIPTION
The I2C API specifies that the last message of a transfer implies a STOP condition. This requirement has been offloaded to each device driver to implement, which results in many in-tree drivers (more than half of them) not following this requirement.

Since the STOP is implied by the API, we can ensure the STOP bit of the last message is set before passing the messages to the device drivers for transfer. This ensures all device drivers implicitly follow this requirement, allowing us to remove this now duplicate code from the in-tree device drivers which currently do this internally.

We can additionally prevent calls to the `transfer` and `transfer_cb` APIs if `num_msgs` is 0, which is a check we need to do anyway before setting the last messages STOP bit, allowing us to return early if there is nothing to transmit, as is described by the API as well: "@a num_msgs may be zero,in which case no transfer occurs."