### PR TITLE
modules: hal_nordic: nrfs: fix buffer used in nrfs send

### DIFF
--- a/modules/hal_nordic/nrfs/backends/nrfs_backend_ipc_service.c
+++ b/modules/hal_nordic/nrfs/backends/nrfs_backend_ipc_service.c
@@ -24,9 +24,6 @@ K_MSGQ_DEFINE(ipc_transmit_msgq, sizeof(struct ipc_data_packet),
 
 static struct k_work backend_send_work;
 
-static struct ipc_data_packet rx_data;
-static struct ipc_data_packet tx_data;
-
 static void ipc_sysctrl_ept_bound(void *priv);
 static void ipc_sysctrl_ept_recv(const void *data, size_t size, void *priv);
 
@@ -102,6 +99,8 @@ static void ipc_sysctrl_ept_bound(void *priv)
 
 static void ipc_sysctrl_ept_recv(const void *data, size_t size, void *priv)
 {
+	struct ipc_data_packet rx_data;
+
 	__ASSERT(size <= MAX_PACKET_DATA_SIZE, "Received data is too long. Config error.");
 	if (size <= MAX_PACKET_DATA_SIZE) {
 		rx_data.channel_id = IPC_CPUSYS_CHANNEL_ID;
@@ -119,11 +118,12 @@ static void ipc_sysctrl_ept_recv(const void *data, size_t size, void *priv)
 
 static void nrfs_backend_send_work(struct k_work *item)
 {
-	static struct ipc_data_packet data_to_send;
+	struct ipc_data_packet data_to_send;
 
 	LOG_DBG("Sending data from workqueue");
 	while (k_msgq_get(&ipc_transmit_msgq, &data_to_send, K_NO_WAIT) == 0) {
-		ipc_service_send(&ipc_cpusys_channel_config.ipc_ept, &tx_data.data, tx_data.size);
+		ipc_service_send(&ipc_cpusys_channel_config.ipc_ept, &data_to_send.data,
+				 data_to_send.size);
 	}
 }
 
@@ -179,6 +179,7 @@ nrfs_err_t nrfs_backend_send_ex(void *message, size_t size, k_timeout_t timeout,
 
 	if (size <= MAX_PACKET_DATA_SIZE) {
 		int err;
+		struct ipc_data_packet tx_data;
 
 		tx_data.channel_id = IPC_CPUSYS_CHANNEL_ID;
 		tx_data.size	   = size;


### PR DESCRIPTION
In function nrfs_backend_send_work tx_data buffer was used in function ipc_service_send instead of
data_to_send. This is fixed and also tx_data and rx_data are moved to coresponding functions preventing such issues in future.