### PR TITLE
sdhc: sdhc_spi: compile-time determine if `sdhc_ones` needed

### DIFF
--- a/dts/bindings/spi/nordic,nrf-spi-common.yaml
+++ b/dts/bindings/spi/nordic,nrf-spi-common.yaml
@@ -23,12 +23,10 @@ properties:
       property must be set at SoC level DTS files.
 
   overrun-character:
-    type: int
     default: 0xff
     description: |
-      The overrun character (ORC) is used when all bytes from the TX buffer
-      are sent, but the transfer continues due to RX. Defaults to 0xff
-      (line high), the most common value used in SPI transfers.
+      Configurable, defaults to 0xff (line high), the most common value used
+      in SPI transfers.
 
   easydma-maxcnt-bits:
     type: int

--- a/dts/bindings/spi/spi-controller.yaml
+++ b/dts/bindings/spi/spi-controller.yaml
@@ -57,3 +57,8 @@ properties:
       If this property is not defined, no chip select GPIOs are set.
       SPI controllers with dedicated CS pins do not need to define
       the cs-gpios property.
+  overrun-character:
+    type: int
+    description: |
+      The overrun character (ORC) is used when all bytes from the TX buffer
+      are sent, but the transfer continues due to RX.

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -419,6 +419,40 @@ struct spi_dt_spec {
 	SPI_DT_SPEC_GET(DT_DRV_INST(inst), operation_, delay_)
 
 /**
+ * @brief Value that will never compare true with any valid overrun character
+ */
+#define SPI_MOSI_OVERRUN_UNKNOWN 0x100
+
+/**
+ * @brief The value sent on MOSI when all TX bytes are sent, but RX continues
+ *
+ * For drivers where the MOSI line state when receiving is important, this value
+ * can be queried at compile-time to determine whether allocating a constant
+ * array is necessary.
+ *
+ * @param node_id Devicetree node identifier for the SPI device to query
+ *
+ * @retval SPI_MOSI_OVERRUN_UNKNOWN if controller does not export the value
+ * @retval byte default MOSI value otherwise
+ */
+#define SPI_MOSI_OVERRUN_DT(node_id) \
+	DT_PROP_OR(node_id, overrun_character, SPI_MOSI_OVERRUN_UNKNOWN)
+
+/**
+ * @brief The value sent on MOSI when all TX bytes are sent, but RX continues
+ *
+ * This is equivalent to
+ * <tt>SPI_MOSI_OVERRUN_DT(DT_DRV_INST(inst))</tt>.
+ *
+ * @param inst Devicetree instance number
+ *
+ * @retval SPI_MOSI_OVERRUN_UNKNOWN if controller does not export the value
+ * @retval byte default MOSI value otherwise
+ */
+#define SPI_MOSI_OVERRUN_DT_INST(inst) \
+	DT_INST_PROP_OR(inst, overrun_character, SPI_MOSI_OVERRUN_UNKNOWN)
+
+/**
  * @brief SPI buffer structure
  */
 struct spi_buf {


### PR DESCRIPTION
Move the `overrun-character` property from the common Nordic SPI binding to the `spi-controller` base binding. This gives users of the SPI interface a way to query what the default value is at compile-time, and potentially avoid allocation of large constant buffers.

Expose the new common property `overrun-character` from the devicetree nodes, falling back to the `SPI_MOSI_OVERRUN_UNKNOWN` value.

Use the new `SPI_MOSI_OVERRUN_DT` macro to determine at compile-time whether the 512 byte array of `sdhc_ones` is required.

This PR does not attempt to peruse datasheets to determine the default MOSI values clocked out by the dozens of SPI drivers in tree, only to make it trivial for contributors to expose that information in the future.