### PR TITLE
modules: hal_nordic: defines NRF_CONFIG_NFCT_PINS_AS_GPIOS for nRF54L15

### DIFF
--- a/modules/hal_nordic/nrfx/CMakeLists.txt
+++ b/modules/hal_nordic/nrfx/CMakeLists.txt
@@ -140,7 +140,10 @@ dt_nodelabel(uicr_path NODELABEL "uicr")
 if(DEFINED uicr_path)
   dt_prop(nfct_pins_as_gpios PATH ${uicr_path} PROPERTY "nfct-pins-as-gpios")
   if(${nfct_pins_as_gpios})
-    zephyr_library_compile_definitions(CONFIG_NFCT_PINS_AS_GPIOS)
+    zephyr_library_compile_definitions(
+      CONFIG_NFCT_PINS_AS_GPIOS
+      NRF_CONFIG_NFCT_PINS_AS_GPIOS
+    )
   endif()
 
   dt_prop(gpio_as_nreset PATH ${uicr_path} PROPERTY "gpio-as-nreset")


### PR DESCRIPTION
Currently, the NFCT pins cannot be used as GPIOs on the nRF54L15 MCU because the Nordic HAL for this MCU uses the new upcoming `NRF_CONFIG_` style configuration settings for this MCU.
To support all nRF5x MCUs, the old configuration is still required because Nordic didn't update their MDK entirely to the new style.