### PR TITLE
logging: Trigger logging thread when above threshold

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -616,6 +616,11 @@ void z_log_dropped(bool buffered)
 	if (buffered) {
 		atomic_dec(&buffered_cnt);
 	}
+
+	if (IS_ENABLED(CONFIG_LOG_PROCESS_THREAD)) {
+		k_timer_stop(&log_process_thread_timer);
+		k_sem_give(&log_process_thread_sem);
+	}
 }
 
 uint32_t z_log_dropped_read_and_clear(void)


### PR DESCRIPTION
Trigger logging thread also when above CONFIG_LOG_PROCESS_TRIGGER_THRESHOLD.
Fixes #75736 