### PR TITLE
soc: nrf54h20: Add missing soc_nv_flash compatible

### DIFF
--- a/dts/common/nordic/nrf54h20.dtsi
+++ b/dts/common/nordic/nrf54h20.dtsi
@@ -106,7 +106,7 @@
 		#size-cells = <1>;
 
 		mram1x: mram@e000000 {
-			compatible = "nordic,mram";
+			compatible = "nordic,mram", "soc-nv-flash";
 			reg = <0xe000000 DT_SIZE_K(2048)>;
 			erase-block-size = <4096>;
 			write-block-size = <16>;


### PR DESCRIPTION
This adds missing soc-nf-flash compatible to mram1x memory. Now this memory can be used with NVS drivers.