### PR TITLE
drivers: udc: add opaque pointer to store upper layer private data

### DIFF
--- a/drivers/usb/udc/udc_common.c
+++ b/drivers/usb/udc/udc_common.c
@@ -739,13 +739,14 @@ udc_disable_error:
 	return ret;
 }
 
-int udc_init(const struct device *dev, udc_event_cb_t event_cb)
+int udc_init(const struct device *dev,
+	     udc_event_cb_t event_cb, const void *const event_ctx)
 {
 	const struct udc_api *api = dev->api;
 	struct udc_data *data = dev->data;
 	int ret;
 
-	if (event_cb == NULL) {
+	if (event_cb == NULL || event_ctx == NULL) {
 		return -EINVAL;
 	}
 
@@ -757,6 +758,7 @@ int udc_init(const struct device *dev, udc_event_cb_t event_cb)
 	}
 
 	data->event_cb = event_cb;
+	data->event_ctx = event_ctx;
 
 	ret = api->init(dev);
 	if (ret == 0) {

--- a/subsys/usb/device_next/usbd_core.c
+++ b/subsys/usb/device_next/usbd_core.c
@@ -187,16 +187,16 @@ static void usbd_thread(void *p1, void *p2, void *p3)
 	ARG_UNUSED(p2);
 	ARG_UNUSED(p3);
 
+	struct usbd_context *uds_ctx;
 	struct udc_event event;
 
 	while (true) {
 		k_msgq_get(&usbd_msgq, &event, K_FOREVER);
 
-		STRUCT_SECTION_FOREACH(usbd_context, uds_ctx) {
-			if (uds_ctx->dev == event.dev) {
-				usbd_event_handler(uds_ctx, &event);
-			}
-		}
+		uds_ctx = (void *)udc_get_event_ctx(event.dev);
+		__ASSERT(uds_ctx != NULL && usbd_is_initialized(uds_ctx),
+			 "USB device is not initialized");
+		usbd_event_handler(uds_ctx, &event);
 	}
 }
 
@@ -204,7 +204,7 @@ int usbd_device_init_core(struct usbd_context *const uds_ctx)
 {
 	int ret;
 
-	ret = udc_init(uds_ctx->dev, usbd_event_carrier);
+	ret = udc_init(uds_ctx->dev, usbd_event_carrier, uds_ctx);
 	if (ret != 0) {
 		LOG_ERR("Failed to init device driver");
 		return ret;


### PR DESCRIPTION
Add an opaque pointer to store upper layer private data and initialize it with the USB device context during controller initialization. Use the pointer in event processing to get the correct context.

Fixes: #74291