### PR TITLE
tests: Bluetooth: CAP: Enable previously failing 44.1 kHz tests

### DIFF
--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_11_i.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_11_i.sh
@@ -40,8 +40,8 @@ Execute_AC_11_I 24_1_1 24_1_1
 Execute_AC_11_I 24_2_1 24_2_1
 Execute_AC_11_I 32_1_1 32_1_1
 Execute_AC_11_I 32_2_1 32_2_1
-# Execute_AC_11_I 441_1_1 441_1_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
-# Execute_AC_11_I 441_2_1 441_2_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
+Execute_AC_11_I 441_1_1 441_1_1
+Execute_AC_11_I 441_2_1 441_2_1
 Execute_AC_11_I 48_1_1 48_1_1
 Execute_AC_11_I 48_2_1 48_2_1
 Execute_AC_11_I 48_3_1 48_3_1

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_11_ii.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_11_ii.sh
@@ -44,8 +44,8 @@ Execute_AC_11_II 24_1_1 24_1_1
 Execute_AC_11_II 24_2_1 24_2_1
 Execute_AC_11_II 32_1_1 32_1_1
 Execute_AC_11_II 32_2_1 32_2_1
-# Execute_AC_11_II 441_1_1 441_1_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
-# Execute_AC_11_II 441_2_1 441_2_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
+Execute_AC_11_II 441_1_1 441_1_1
+Execute_AC_11_II 441_2_1 441_2_1
 Execute_AC_11_II 48_1_1 48_1_1
 Execute_AC_11_II 48_2_1 48_2_1
 Execute_AC_11_II 48_3_1 48_3_1

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_5.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_5.sh
@@ -39,8 +39,8 @@ Execute_AC_5 24_1_1 24_1_1
 Execute_AC_5 24_2_1 24_2_1
 Execute_AC_5 32_1_1 32_1_1
 Execute_AC_5 32_2_1 32_2_1
-# Execute_AC_5 441_1_1 441_1_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
-# Execute_AC_5 441_2_1 441_2_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
+Execute_AC_5 441_1_1 441_1_1
+Execute_AC_5 441_2_1 441_2_1
 Execute_AC_5 48_1_1 48_1_1
 Execute_AC_5 48_2_1 48_2_1
 Execute_AC_5 48_3_1 48_3_1

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_6_i.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_6_i.sh
@@ -38,8 +38,8 @@ Execute_AC_6_I 24_1_1
 Execute_AC_6_I 24_2_1
 Execute_AC_6_I 32_1_1
 Execute_AC_6_I 32_2_1
-# Execute_AC_6_I 441_1_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
-# Execute_AC_6_I 441_2_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
+Execute_AC_6_I 441_1_1
+Execute_AC_6_I 441_2_1
 Execute_AC_6_I 48_1_1
 Execute_AC_6_I 48_2_1
 Execute_AC_6_I 48_3_1

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_6_ii.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_6_ii.sh
@@ -44,8 +44,8 @@ Execute_AC_6_II 24_1_1
 Execute_AC_6_II 24_2_1
 Execute_AC_6_II 32_1_1
 Execute_AC_6_II 32_2_1
-# Execute_AC_6_II 441_1_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
-# Execute_AC_6_II 441_2_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
+Execute_AC_6_II 441_1_1
+Execute_AC_6_II 441_2_1
 Execute_AC_6_II 48_1_1
 Execute_AC_6_II 48_2_1
 Execute_AC_6_II 48_3_1

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_7_ii.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_7_ii.sh
@@ -44,8 +44,8 @@ Execute_AC_7_II 24_1_1 24_1_1
 Execute_AC_7_II 24_2_1 24_2_1
 Execute_AC_7_II 32_1_1 32_1_1
 Execute_AC_7_II 32_2_1 32_2_1
-# Execute_AC_7_II 441_1_1 441_1_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
-# Execute_AC_7_II 441_2_1 441_2_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
+Execute_AC_7_II 441_1_1 441_1_1
+Execute_AC_7_II 441_2_1 441_2_1
 Execute_AC_7_II 48_1_1 48_1_1
 Execute_AC_7_II 48_2_1 48_2_1
 Execute_AC_7_II 48_3_1 48_3_1

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_8_i.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_8_i.sh
@@ -40,8 +40,8 @@ Execute_AC_8_I 24_1_1 24_1_1
 Execute_AC_8_I 24_2_1 24_2_1
 Execute_AC_8_I 32_1_1 32_1_1
 Execute_AC_8_I 32_2_1 32_2_1
-# Execute_AC_8_I 441_1_1 441_1_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
-# Execute_AC_8_I 441_2_1 441_2_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
+Execute_AC_8_I 441_1_1 441_1_1
+Execute_AC_8_I 441_2_1 441_2_1
 Execute_AC_8_I 48_1_1 48_1_1
 Execute_AC_8_I 48_2_1 48_2_1
 Execute_AC_8_I 48_3_1 48_3_1

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_8_ii.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_8_ii.sh
@@ -44,8 +44,8 @@ Execute_AC_8_II 24_1_1 24_1_1
 Execute_AC_8_II 24_2_1 24_2_1
 Execute_AC_8_II 32_1_1 32_1_1
 Execute_AC_8_II 32_2_1 32_2_1
-# Execute_AC_8_II 441_1_1 441_1_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
-# Execute_AC_8_II 441_2_1 441_2_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
+Execute_AC_8_II 441_1_1 441_1_1
+Execute_AC_8_II 441_2_1 441_2_1
 Execute_AC_8_II 48_1_1 48_1_1
 Execute_AC_8_II 48_2_1 48_2_1
 Execute_AC_8_II 48_3_1 48_3_1

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_9_i.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_9_i.sh
@@ -40,8 +40,8 @@ Execute_AC_9_I 24_1_1
 Execute_AC_9_I 24_2_1
 Execute_AC_9_I 32_1_1
 Execute_AC_9_I 32_2_1
-# Execute_AC_9_I 441_1_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
-# Execute_AC_9_I 441_2_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
+Execute_AC_9_I 441_1_1
+Execute_AC_9_I 441_2_1
 Execute_AC_9_I 48_1_1
 Execute_AC_9_I 48_2_1
 Execute_AC_9_I 48_3_1

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_9_ii.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_9_ii.sh
@@ -44,8 +44,8 @@ Execute_AC_9_II 24_1_1
 Execute_AC_9_II 24_2_1
 Execute_AC_9_II 32_1_1
 Execute_AC_9_II 32_2_1
-# Execute_AC_9_II 441_1_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
-# Execute_AC_9_II 441_2_1 # ASSERTION FAIL [iso_interval_us >= cig->c_sdu_interval]
+Execute_AC_9_II 441_1_1
+Execute_AC_9_II 441_2_1
 Execute_AC_9_II 48_1_1
 Execute_AC_9_II 48_2_1
 Execute_AC_9_II 48_3_1


### PR DESCRIPTION
Enable the CAP AC tests for 44.1 KHz.