### PR TITLE
Bluetooth: Use API to obtain value handle from characteristic

### DIFF
--- a/samples/bluetooth/periodic_adv_rsp/src/main.c
+++ b/samples/bluetooth/periodic_adv_rsp/src/main.c
@@ -205,7 +205,7 @@ static uint8_t discover_func(struct bt_conn *conn, const struct bt_gatt_attr *at
 	printk("UUID %s\n", str);
 
 	if (!bt_uuid_cmp(chrc->uuid, &pawr_char_uuid.uuid)) {
-		pawr_attr_handle = chrc->value_handle;
+		pawr_attr_handle = bt_gatt_attr_value_handle(attr);
 
 		printk("Characteristic handle: %d\n", pawr_attr_handle);
 

--- a/subsys/bluetooth/audio/aics_client.c
+++ b/subsys/bluetooth/audio/aics_client.c
@@ -581,30 +581,30 @@ static uint8_t aics_discover_func(struct bt_conn *conn, const struct bt_gatt_att
 
 		chrc = (struct bt_gatt_chrc *)attr->user_data;
 		if (inst->cli.start_handle == 0) {
-			inst->cli.start_handle = chrc->value_handle;
+			inst->cli.start_handle = bt_gatt_attr_value_handle(attr);
 		}
-		inst->cli.end_handle = chrc->value_handle;
+		inst->cli.end_handle = bt_gatt_attr_value_handle(attr);
 
 		if (!bt_uuid_cmp(chrc->uuid, BT_UUID_AICS_STATE)) {
 			LOG_DBG("Audio Input state");
-			inst->cli.state_handle = chrc->value_handle;
+			inst->cli.state_handle = bt_gatt_attr_value_handle(attr);
 			sub_params = &inst->cli.state_sub_params;
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_AICS_GAIN_SETTINGS)) {
 			LOG_DBG("Gain settings");
-			inst->cli.gain_handle = chrc->value_handle;
+			inst->cli.gain_handle = bt_gatt_attr_value_handle(attr);
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_AICS_INPUT_TYPE)) {
 			LOG_DBG("Input type");
-			inst->cli.type_handle = chrc->value_handle;
+			inst->cli.type_handle = bt_gatt_attr_value_handle(attr);
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_AICS_INPUT_STATUS)) {
 			LOG_DBG("Input status");
-			inst->cli.status_handle = chrc->value_handle;
+			inst->cli.status_handle = bt_gatt_attr_value_handle(attr);
 			sub_params = &inst->cli.status_sub_params;
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_AICS_CONTROL)) {
 			LOG_DBG("Control point");
-			inst->cli.control_handle = chrc->value_handle;
+			inst->cli.control_handle = bt_gatt_attr_value_handle(attr);
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_AICS_DESCRIPTION)) {
 			LOG_DBG("Description");
-			inst->cli.desc_handle = chrc->value_handle;
+			inst->cli.desc_handle = bt_gatt_attr_value_handle(attr);
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
 				sub_params = &inst->cli.desc_sub_params;
 			}
@@ -618,7 +618,7 @@ static uint8_t aics_discover_func(struct bt_conn *conn, const struct bt_gatt_att
 			int err;
 
 			sub_params->value = BT_GATT_CCC_NOTIFY;
-			sub_params->value_handle = chrc->value_handle;
+			sub_params->value_handle = bt_gatt_attr_value_handle(attr);
 			/*
 			 * TODO: Don't assume that CCC is at handle + 2;
 			 * do proper discovery;

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -3214,7 +3214,7 @@ static uint8_t unicast_client_cp_discover_func(struct bt_conn *conn,
 	}
 
 	chrc = attr->user_data;
-	value_handle = chrc->value_handle;
+	value_handle = bt_gatt_attr_value_handle(attr);
 	memset(discover, 0, sizeof(*discover));
 
 	LOG_DBG("conn %p attr %p handle 0x%04x", conn, attr, value_handle);
@@ -3344,7 +3344,7 @@ static uint8_t unicast_client_ase_discover_cb(struct bt_conn *conn,
 	}
 
 	chrc = attr->user_data;
-	value_handle = chrc->value_handle;
+	value_handle = bt_gatt_attr_value_handle(attr);
 	memset(discover, 0, sizeof(*discover));
 
 	client = &uni_cli_insts[bt_conn_index(conn)];
@@ -3510,7 +3510,7 @@ static uint8_t unicast_client_pacs_avail_ctx_discover_cb(struct bt_conn *conn,
 
 	chrc = attr->user_data;
 	chrc_properties = chrc->properties;
-	value_handle = chrc->value_handle;
+	value_handle = bt_gatt_attr_value_handle(attr);
 	memset(discover, 0, sizeof(*discover));
 
 	LOG_DBG("conn %p attr %p handle 0x%04x", conn, attr, value_handle);
@@ -3706,7 +3706,7 @@ static uint8_t unicast_client_pacs_location_discover_cb(struct bt_conn *conn,
 	}
 
 	chrc = attr->user_data;
-	value_handle = chrc->value_handle;
+	value_handle = bt_gatt_attr_value_handle(attr);
 	memset(discover, 0, sizeof(*discover));
 
 	LOG_DBG("conn %p attr %p handle 0x%04x", conn, attr, value_handle);
@@ -3816,7 +3816,7 @@ static uint8_t unicast_client_pacs_context_discover_cb(struct bt_conn *conn,
 	}
 
 	chrc = attr->user_data;
-	value_handle = chrc->value_handle;
+	value_handle = bt_gatt_attr_value_handle(attr);
 	memset(discover, 0, sizeof(*discover));
 
 	LOG_DBG("conn %p attr %p handle 0x%04x dir %s", conn, attr, value_handle,
@@ -4008,7 +4008,7 @@ static uint8_t unicast_client_pac_discover_cb(struct bt_conn *conn,
 	}
 
 	chrc = attr->user_data;
-	value_handle = chrc->value_handle;
+	value_handle = bt_gatt_attr_value_handle(attr);
 	memset(discover, 0, sizeof(*discover));
 
 	LOG_DBG("conn %p attr %p handle 0x%04x dir %s", conn, attr, value_handle,

--- a/subsys/bluetooth/audio/csip_set_coordinator.c
+++ b/subsys/bluetooth/audio/csip_set_coordinator.c
@@ -719,13 +719,13 @@ static uint8_t discover_func(struct bt_conn *conn,
 		chrc = (struct bt_gatt_chrc *)attr->user_data;
 		if (bt_uuid_cmp(chrc->uuid, BT_UUID_CSIS_SIRK) == 0) {
 			LOG_DBG("SIRK");
-			client->cur_inst->sirk_handle = chrc->value_handle;
+			client->cur_inst->sirk_handle = bt_gatt_attr_value_handle(attr);
 			sub_params = &client->cur_inst->sirk_sub_params;
 			sub_params->disc_params = &client->cur_inst->sirk_sub_disc_params;
 			notify_handler = sirk_notify_func;
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_CSIS_SET_SIZE) == 0) {
 			LOG_DBG("Set size");
-			client->cur_inst->set_size_handle = chrc->value_handle;
+			client->cur_inst->set_size_handle = bt_gatt_attr_value_handle(attr);
 			sub_params = &client->cur_inst->size_sub_params;
 			sub_params->disc_params = &client->cur_inst->size_sub_disc_params;
 			notify_handler = size_notify_func;
@@ -733,7 +733,7 @@ static uint8_t discover_func(struct bt_conn *conn,
 			struct bt_csip_set_coordinator_set_info *set_info;
 
 			LOG_DBG("Set lock");
-			client->cur_inst->set_lock_handle = chrc->value_handle;
+			client->cur_inst->set_lock_handle = bt_gatt_attr_value_handle(attr);
 			sub_params = &client->cur_inst->lock_sub_params;
 			sub_params->disc_params = &client->cur_inst->lock_sub_disc_params;
 			notify_handler = lock_notify_func;
@@ -742,7 +742,7 @@ static uint8_t discover_func(struct bt_conn *conn,
 			set_info->lockable = true;
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_CSIS_RANK) == 0) {
 			LOG_DBG("Set rank");
-			client->cur_inst->rank_handle = chrc->value_handle;
+			client->cur_inst->rank_handle = bt_gatt_attr_value_handle(attr);
 		}
 
 		if (sub_params != NULL && notify_handler != NULL) {
@@ -759,7 +759,7 @@ static uint8_t discover_func(struct bt_conn *conn,
 				/* With ccc_handle == 0 it will use auto discovery */
 				sub_params->ccc_handle = 0;
 				sub_params->end_handle = client->cur_inst->end_handle;
-				sub_params->value_handle = chrc->value_handle;
+				sub_params->value_handle = bt_gatt_attr_value_handle(attr);
 				sub_params->notify = notify_handler;
 				atomic_set_bit(sub_params->flags, BT_GATT_SUBSCRIBE_FLAG_VOLATILE);
 

--- a/subsys/bluetooth/audio/mcc.c
+++ b/subsys/bluetooth/audio/mcc.c
@@ -1410,30 +1410,30 @@ static uint8_t discover_otc_char_func(struct bt_conn *conn,
 		chrc = (struct bt_gatt_chrc *)attr->user_data;
 		if (!bt_uuid_cmp(chrc->uuid, BT_UUID_OTS_FEATURE)) {
 			LOG_DBG("OTS Features");
-			mcs_inst->otc.feature_handle = chrc->value_handle;
+			mcs_inst->otc.feature_handle = bt_gatt_attr_value_handle(attr);
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_OTS_NAME)) {
 			LOG_DBG("Object Name");
-			mcs_inst->otc.obj_name_handle = chrc->value_handle;
+			mcs_inst->otc.obj_name_handle = bt_gatt_attr_value_handle(attr);
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_OTS_TYPE)) {
 			LOG_DBG("Object Type");
-			mcs_inst->otc.obj_type_handle = chrc->value_handle;
+			mcs_inst->otc.obj_type_handle = bt_gatt_attr_value_handle(attr);
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_OTS_SIZE)) {
 			LOG_DBG("Object Size");
-			mcs_inst->otc.obj_size_handle = chrc->value_handle;
+			mcs_inst->otc.obj_size_handle = bt_gatt_attr_value_handle(attr);
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_OTS_ID)) {
 			LOG_DBG("Object ID");
-			mcs_inst->otc.obj_id_handle = chrc->value_handle;
+			mcs_inst->otc.obj_id_handle = bt_gatt_attr_value_handle(attr);
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_OTS_PROPERTIES)) {
 			LOG_DBG("Object properties %d", chrc->value_handle);
-			mcs_inst->otc.obj_properties_handle = chrc->value_handle;
+			mcs_inst->otc.obj_properties_handle = bt_gatt_attr_value_handle(attr);
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_OTS_ACTION_CP)) {
 			LOG_DBG("Object Action Control Point");
-			mcs_inst->otc.oacp_handle = chrc->value_handle;
+			mcs_inst->otc.oacp_handle = bt_gatt_attr_value_handle(attr);
 			sub_params = &mcs_inst->otc.oacp_sub_params;
 			sub_params->disc_params = &mcs_inst->otc.oacp_sub_disc_params;
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_OTS_LIST_CP)) {
 			LOG_DBG("Object List Control Point");
-			mcs_inst->otc.olcp_handle = chrc->value_handle;
+			mcs_inst->otc.olcp_handle = bt_gatt_attr_value_handle(attr);
 			sub_params = &mcs_inst->otc.olcp_sub_params;
 			sub_params->disc_params = &mcs_inst->otc.olcp_sub_disc_params;
 		}
@@ -1443,7 +1443,7 @@ static uint8_t discover_otc_char_func(struct bt_conn *conn,
 			sub_params->ccc_handle = 0;
 			sub_params->end_handle = mcs_inst->otc.end_handle;
 			sub_params->value = BT_GATT_CCC_INDICATE;
-			sub_params->value_handle = chrc->value_handle;
+			sub_params->value_handle = bt_gatt_attr_value_handle(attr);
 			sub_params->notify = bt_ots_client_indicate_handler;
 			atomic_set_bit(sub_params->flags, BT_GATT_SUBSCRIBE_FLAG_VOLATILE);
 
@@ -1790,7 +1790,7 @@ static uint8_t discover_mcs_char_func(struct bt_conn *conn,
 
 		if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_PLAYER_NAME)) {
 			LOG_DBG("Player name, UUID: %s", bt_uuid_str(chrc->uuid));
-			mcs_inst->player_name_handle = chrc->value_handle;
+			mcs_inst->player_name_handle = bt_gatt_attr_value_handle(attr);
 			/* Use discovery params pointer as subscription flag */
 			mcs_inst->player_name_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
@@ -1799,16 +1799,16 @@ static uint8_t discover_mcs_char_func(struct bt_conn *conn,
 #ifdef CONFIG_BT_MCC_OTS
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_ICON_OBJ_ID)) {
 			LOG_DBG("Icon Object, UUID: %s", bt_uuid_str(chrc->uuid));
-			mcs_inst->icon_obj_id_handle = chrc->value_handle;
+			mcs_inst->icon_obj_id_handle = bt_gatt_attr_value_handle(attr);
 #endif /* CONFIG_BT_MCC_OTS */
 #if defined(CONFIG_BT_MCC_READ_MEDIA_PLAYER_ICON_URL)
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_ICON_URL)) {
 			LOG_DBG("Icon URL, UUID: %s", bt_uuid_str(chrc->uuid));
-			mcs_inst->icon_url_handle = chrc->value_handle;
+			mcs_inst->icon_url_handle = bt_gatt_attr_value_handle(attr);
 #endif /* defined(CONFIG_BT_MCC_READ_MEDIA_PLAYER_ICON_URL) */
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_TRACK_CHANGED)) {
 			LOG_DBG("Track Changed, UUID: %s", bt_uuid_str(chrc->uuid));
-			mcs_inst->track_changed_handle = chrc->value_handle;
+			mcs_inst->track_changed_handle = bt_gatt_attr_value_handle(attr);
 			mcs_inst->track_changed_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
 				mcs_inst->track_changed_sub_params.value = BT_GATT_CCC_NOTIFY;
@@ -1816,7 +1816,7 @@ static uint8_t discover_mcs_char_func(struct bt_conn *conn,
 #if defined(CONFIG_BT_MCC_READ_TRACK_TITLE)
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_TRACK_TITLE)) {
 			LOG_DBG("Track Title, UUID: %s", bt_uuid_str(chrc->uuid));
-			mcs_inst->track_title_handle = chrc->value_handle;
+			mcs_inst->track_title_handle = bt_gatt_attr_value_handle(attr);
 #if defined(BT_MCC_READ_TRACK_TITLE_ENABLE_SUBSCRIPTION)
 			mcs_inst->track_title_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
@@ -1827,7 +1827,7 @@ static uint8_t discover_mcs_char_func(struct bt_conn *conn,
 #if defined(CONFIG_BT_MCC_READ_TRACK_DURATION)
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_TRACK_DURATION)) {
 			LOG_DBG("Track Duration, UUID: %s", bt_uuid_str(chrc->uuid));
-			mcs_inst->track_duration_handle = chrc->value_handle;
+			mcs_inst->track_duration_handle = bt_gatt_attr_value_handle(attr);
 			mcs_inst->track_duration_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
 				mcs_inst->track_duration_sub_params.value = BT_GATT_CCC_NOTIFY;
@@ -1836,7 +1836,7 @@ static uint8_t discover_mcs_char_func(struct bt_conn *conn,
 #if defined(CONFIG_BT_MCC_READ_TRACK_POSITION) || defined(CONFIG_BT_MCC_SET_TRACK_POSITION)
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_TRACK_POSITION)) {
 			LOG_DBG("Track Position, UUID: %s", bt_uuid_str(chrc->uuid));
-			mcs_inst->track_position_handle = chrc->value_handle;
+			mcs_inst->track_position_handle = bt_gatt_attr_value_handle(attr);
 #if defined(CONFIG_BT_MCC_READ_TRACK_POSITION)
 			mcs_inst->track_position_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
@@ -1847,7 +1847,7 @@ static uint8_t discover_mcs_char_func(struct bt_conn *conn,
 #if defined(CONFIG_BT_MCC_READ_PLAYBACK_SPEED) || defined(CONFIG_BT_MCC_SET_PLAYBACK_SPEED)
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_PLAYBACK_SPEED)) {
 			LOG_DBG("Playback Speed, UUID: %s", bt_uuid_str(chrc->uuid));
-			mcs_inst->playback_speed_handle = chrc->value_handle;
+			mcs_inst->playback_speed_handle = bt_gatt_attr_value_handle(attr);
 #if defined(CONFIG_BT_MCC_READ_PLAYBACK_SPEED)
 			mcs_inst->playback_speed_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
@@ -1860,7 +1860,7 @@ static uint8_t discover_mcs_char_func(struct bt_conn *conn,
 #if defined(CONFIG_BT_MCC_READ_SEEKING_SPEED)
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_SEEKING_SPEED)) {
 			LOG_DBG("Seeking Speed, UUID: %s", bt_uuid_str(chrc->uuid));
-			mcs_inst->seeking_speed_handle = chrc->value_handle;
+			mcs_inst->seeking_speed_handle = bt_gatt_attr_value_handle(attr);
 			mcs_inst->seeking_speed_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
 				mcs_inst->seeking_speed_sub_params.value = BT_GATT_CCC_NOTIFY;
@@ -1869,10 +1869,10 @@ static uint8_t discover_mcs_char_func(struct bt_conn *conn,
 #ifdef CONFIG_BT_MCC_OTS
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_TRACK_SEGMENTS_OBJ_ID)) {
 			LOG_DBG("Track Segments Object, UUID: %s", bt_uuid_str(chrc->uuid));
-			mcs_inst->segments_obj_id_handle = chrc->value_handle;
+			mcs_inst->segments_obj_id_handle = bt_gatt_attr_value_handle(attr);
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_CURRENT_TRACK_OBJ_ID)) {
 			LOG_DBG("Current Track Object, UUID: %s", bt_uuid_str(chrc->uuid));
-			mcs_inst->current_track_obj_id_handle = chrc->value_handle;
+			mcs_inst->current_track_obj_id_handle = bt_gatt_attr_value_handle(attr);
 			mcs_inst->current_track_obj_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
 				mcs_inst->current_track_obj_sub_params.value =
@@ -1880,14 +1880,14 @@ static uint8_t discover_mcs_char_func(struct bt_conn *conn,
 			}
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_NEXT_TRACK_OBJ_ID)) {
 			LOG_DBG("Next Track Object, UUID: %s", bt_uuid_str(chrc->uuid));
-			mcs_inst->next_track_obj_id_handle = chrc->value_handle;
+			mcs_inst->next_track_obj_id_handle = bt_gatt_attr_value_handle(attr);
 			mcs_inst->next_track_obj_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
 				mcs_inst->next_track_obj_sub_params.value = BT_GATT_CCC_NOTIFY;
 			}
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_PARENT_GROUP_OBJ_ID)) {
 			LOG_DBG("Parent Group Object, UUID: %s", bt_uuid_str(chrc->uuid));
-			mcs_inst->parent_group_obj_id_handle = chrc->value_handle;
+			mcs_inst->parent_group_obj_id_handle = bt_gatt_attr_value_handle(attr);
 			mcs_inst->parent_group_obj_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
 				mcs_inst->parent_group_obj_sub_params.value =
@@ -1895,7 +1895,7 @@ static uint8_t discover_mcs_char_func(struct bt_conn *conn,
 			}
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_CURRENT_GROUP_OBJ_ID)) {
 			LOG_DBG("Group Object, UUID: %s", bt_uuid_str(chrc->uuid));
-			mcs_inst->current_group_obj_id_handle = chrc->value_handle;
+			mcs_inst->current_group_obj_id_handle = bt_gatt_attr_value_handle(attr);
 			mcs_inst->current_group_obj_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
 				mcs_inst->current_group_obj_sub_params.value =
@@ -1905,7 +1905,7 @@ static uint8_t discover_mcs_char_func(struct bt_conn *conn,
 #if defined(CONFIG_BT_MCC_READ_PLAYING_ORDER) || defined(CONFIG_BT_MCC_SET_PLAYING_ORDER)
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_PLAYING_ORDER)) {
 			LOG_DBG("Playing Order, UUID: %s", bt_uuid_str(chrc->uuid));
-			mcs_inst->playing_order_handle = chrc->value_handle;
+			mcs_inst->playing_order_handle = bt_gatt_attr_value_handle(attr);
 #if defined(CONFIG_BT_MCC_READ_PLAYING_ORDER)
 			mcs_inst->playing_order_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
@@ -1916,12 +1916,12 @@ static uint8_t discover_mcs_char_func(struct bt_conn *conn,
 #if defined(CONFIG_BT_MCC_READ_PLAYING_ORDER_SUPPORTED)
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_PLAYING_ORDERS)) {
 			LOG_DBG("Playing Orders supported, UUID: %s", bt_uuid_str(chrc->uuid));
-			mcs_inst->playing_orders_supported_handle = chrc->value_handle;
+			mcs_inst->playing_orders_supported_handle = bt_gatt_attr_value_handle(attr);
 #endif /* defined(CONFIG_BT_MCC_READ_PLAYING_ORDER_SUPPORTED) */
 #if defined(CONFIG_BT_MCC_READ_MEDIA_STATE)
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_MEDIA_STATE)) {
 			LOG_DBG("Media State, UUID: %s", bt_uuid_str(chrc->uuid));
-			mcs_inst->media_state_handle = chrc->value_handle;
+			mcs_inst->media_state_handle = bt_gatt_attr_value_handle(attr);
 			mcs_inst->media_state_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
 				mcs_inst->media_state_sub_params.value = BT_GATT_CCC_NOTIFY;
@@ -1929,7 +1929,7 @@ static uint8_t discover_mcs_char_func(struct bt_conn *conn,
 #endif /* defined(CONFIG_BT_MCC_READ_MEDIA_STATE) */
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_MEDIA_CONTROL_POINT)) {
 			LOG_DBG("Media Control Point, UUID: %s", bt_uuid_str(chrc->uuid));
-			mcs_inst->cp_handle = chrc->value_handle;
+			mcs_inst->cp_handle = bt_gatt_attr_value_handle(attr);
 			mcs_inst->cp_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
 				mcs_inst->cp_sub_params.value = BT_GATT_CCC_NOTIFY;
@@ -1938,7 +1938,7 @@ static uint8_t discover_mcs_char_func(struct bt_conn *conn,
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_MEDIA_CONTROL_OPCODES)) {
 			LOG_DBG("Media control opcodes supported, UUID: %s",
 			       bt_uuid_str(chrc->uuid));
-			mcs_inst->opcodes_supported_handle = chrc->value_handle;
+			mcs_inst->opcodes_supported_handle = bt_gatt_attr_value_handle(attr);
 			mcs_inst->opcodes_supported_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
 				mcs_inst->opcodes_supported_sub_params.value =
@@ -1948,14 +1948,14 @@ static uint8_t discover_mcs_char_func(struct bt_conn *conn,
 #ifdef CONFIG_BT_MCC_OTS
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_SEARCH_CONTROL_POINT)) {
 			LOG_DBG("Search control point, UUID: %s", bt_uuid_str(chrc->uuid));
-			mcs_inst->scp_handle = chrc->value_handle;
+			mcs_inst->scp_handle = bt_gatt_attr_value_handle(attr);
 			mcs_inst->scp_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
 				mcs_inst->scp_sub_params.value = BT_GATT_CCC_NOTIFY;
 			}
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_SEARCH_RESULTS_OBJ_ID)) {
 			LOG_DBG("Search Results object, UUID: %s", bt_uuid_str(chrc->uuid));
-			mcs_inst->search_results_obj_id_handle = chrc->value_handle;
+			mcs_inst->search_results_obj_id_handle = bt_gatt_attr_value_handle(attr);
 			mcs_inst->search_results_obj_sub_params.disc_params = NULL;
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
 				mcs_inst->search_results_obj_sub_params.value =
@@ -1965,7 +1965,7 @@ static uint8_t discover_mcs_char_func(struct bt_conn *conn,
 #if defined(CONFIG_BT_MCC_READ_CONTENT_CONTROL_ID)
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_CCID)) {
 			LOG_DBG("Content Control ID, UUID: %s", bt_uuid_str(chrc->uuid));
-			mcs_inst->content_control_id_handle = chrc->value_handle;
+			mcs_inst->content_control_id_handle = bt_gatt_attr_value_handle(attr);
 #endif /* defined(CONFIG_BT_MCC_READ_CONTENT_CONTROL_ID) */
 		}
 

--- a/subsys/bluetooth/audio/micp_mic_ctlr.c
+++ b/subsys/bluetooth/audio/micp_mic_ctlr.c
@@ -413,7 +413,7 @@ static uint8_t micp_discover_func(struct bt_conn *conn,
 
 		if (bt_uuid_cmp(chrc->uuid, BT_UUID_MICS_MUTE) == 0) {
 			LOG_DBG("Mute");
-			mic_ctlr->mute_handle = chrc->value_handle;
+			mic_ctlr->mute_handle = bt_gatt_attr_value_handle(attr);
 			sub_params = &mic_ctlr->mute_sub_params;
 			sub_params->disc_params = &mic_ctlr->mute_sub_disc_params;
 		}
@@ -425,7 +425,7 @@ static uint8_t micp_discover_func(struct bt_conn *conn,
 			sub_params->ccc_handle = 0;
 			sub_params->end_handle = mic_ctlr->end_handle;
 			sub_params->value = BT_GATT_CCC_NOTIFY;
-			sub_params->value_handle = chrc->value_handle;
+			sub_params->value_handle = bt_gatt_attr_value_handle(attr);
 			sub_params->notify = mute_notify_handler;
 			atomic_set_bit(sub_params->flags, BT_GATT_SUBSCRIBE_FLAG_VOLATILE);
 

--- a/subsys/bluetooth/audio/tbs_client.c
+++ b/subsys/bluetooth/audio/tbs_client.c
@@ -1434,102 +1434,102 @@ static uint8_t discover_func(struct bt_conn *conn,
 		if (bt_uuid_cmp(chrc->uuid, BT_UUID_TBS_CALL_STATE) == 0) {
 			LOG_DBG("Call state");
 			sub_params = &current_inst->call_state_sub_params;
-			sub_params->value_handle = chrc->value_handle;
+			sub_params->value_handle = bt_gatt_attr_value_handle(attr);
 			sub_params->disc_params = &current_inst->call_state_sub_disc_params;
 #if defined(CONFIG_BT_TBS_CLIENT_BEARER_PROVIDER_NAME)
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_TBS_PROVIDER_NAME) == 0) {
 			LOG_DBG("Provider name");
 			sub_params = &current_inst->name_sub_params;
-			sub_params->value_handle = chrc->value_handle;
+			sub_params->value_handle = bt_gatt_attr_value_handle(attr);
 			sub_params->disc_params = &current_inst->name_sub_disc_params;
 #endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_PROVIDER_NAME) */
 #if defined(CONFIG_BT_TBS_CLIENT_BEARER_UCI)
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_TBS_UCI) == 0) {
 			LOG_DBG("Bearer UCI");
-			current_inst->bearer_uci_handle = chrc->value_handle;
+			current_inst->bearer_uci_handle = bt_gatt_attr_value_handle(attr);
 #endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_UCI) */
 #if defined(CONFIG_BT_TBS_CLIENT_BEARER_TECHNOLOGY)
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_TBS_TECHNOLOGY) == 0) {
 			LOG_DBG("Technology");
 			sub_params = &current_inst->technology_sub_params;
-			sub_params->value_handle = chrc->value_handle;
+			sub_params->value_handle = bt_gatt_attr_value_handle(attr);
 			sub_params->disc_params = &current_inst->technology_sub_disc_params;
 #endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_TECHNOLOGY) */
 #if defined(CONFIG_BT_TBS_CLIENT_BEARER_URI_SCHEMES_SUPPORTED_LIST)
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_TBS_URI_LIST) == 0) {
 			LOG_DBG("URI Scheme List");
-			current_inst->uri_list_handle = chrc->value_handle;
+			current_inst->uri_list_handle = bt_gatt_attr_value_handle(attr);
 #endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_URI_SCHEMES_SUPPORTED_LIST) */
 #if defined(CONFIG_BT_TBS_CLIENT_BEARER_SIGNAL_STRENGTH)
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_TBS_SIGNAL_STRENGTH) == 0) {
 			LOG_DBG("Signal strength");
 			sub_params = &current_inst->signal_strength_sub_params;
-			sub_params->value_handle = chrc->value_handle;
+			sub_params->value_handle = bt_gatt_attr_value_handle(attr);
 			sub_params->disc_params = &current_inst->signal_strength_sub_disc_params;
 #endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_SIGNAL_STRENGTH) */
 #if defined(CONFIG_BT_TBS_CLIENT_READ_BEARER_SIGNAL_INTERVAL) \
 || defined(CONFIG_BT_TBS_CLIENT_SET_BEARER_SIGNAL_INTERVAL)
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_TBS_SIGNAL_INTERVAL) == 0) {
 			LOG_DBG("Signal strength reporting interval");
-			current_inst->signal_interval_handle = chrc->value_handle;
+			current_inst->signal_interval_handle = bt_gatt_attr_value_handle(attr);
 #endif /* defined(CONFIG_BT_TBS_CLIENT_READ_BEARER_SIGNAL_INTERVAL) */
 /* || defined(CONFIG_BT_TBS_CLIENT_SET_BEARER_SIGNAL_INTERVAL) */
 #if defined(CONFIG_BT_TBS_CLIENT_BEARER_LIST_CURRENT_CALLS)
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_TBS_LIST_CURRENT_CALLS) == 0) {
 			LOG_DBG("Current calls");
 			sub_params = &current_inst->current_calls_sub_params;
-			sub_params->value_handle = chrc->value_handle;
+			sub_params->value_handle = bt_gatt_attr_value_handle(attr);
 			sub_params->disc_params = &current_inst->current_calls_sub_disc_params;
 #endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_LIST_CURRENT_CALLS) */
 #if defined(CONFIG_BT_TBS_CLIENT_CCID)
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_CCID) == 0) {
 			LOG_DBG("CCID");
-			current_inst->ccid_handle = chrc->value_handle;
+			current_inst->ccid_handle = bt_gatt_attr_value_handle(attr);
 #endif /* defined(CONFIG_BT_TBS_CLIENT_CCID) */
 #if defined(CONFIG_BT_TBS_CLIENT_INCOMING_URI)
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_TBS_INCOMING_URI) == 0) {
 			LOG_DBG("Incoming target URI");
 			sub_params = &current_inst->in_target_uri_sub_params;
-			sub_params->value_handle = chrc->value_handle;
+			sub_params->value_handle = bt_gatt_attr_value_handle(attr);
 			sub_params->disc_params = &current_inst->in_target_uri_sub_disc_params;
 #endif /* defined(CONFIG_BT_TBS_CLIENT_INCOMING_URI) */
 #if defined(CONFIG_BT_TBS_CLIENT_STATUS_FLAGS)
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_TBS_STATUS_FLAGS) == 0) {
 			LOG_DBG("Status flags");
 			sub_params = &current_inst->status_flags_sub_params;
-			sub_params->value_handle = chrc->value_handle;
+			sub_params->value_handle = bt_gatt_attr_value_handle(attr);
 			sub_params->disc_params = &current_inst->status_sub_disc_params;
 #endif /* defined(CONFIG_BT_TBS_CLIENT_STATUS_FLAGS) */
 #if defined(CONFIG_BT_TBS_CLIENT_CP_PROCEDURES)
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_TBS_CALL_CONTROL_POINT) == 0) {
 			LOG_DBG("Call control point");
 			sub_params = &current_inst->call_cp_sub_params;
-			sub_params->value_handle = chrc->value_handle;
+			sub_params->value_handle = bt_gatt_attr_value_handle(attr);
 			sub_params->disc_params = &current_inst->call_cp_sub_disc_params;
 #endif /* defined(CONFIG_BT_TBS_CLIENT_CP_PROCEDURES) */
 #if defined(CONFIG_BT_TBS_CLIENT_OPTIONAL_OPCODES)
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_TBS_OPTIONAL_OPCODES) == 0) {
 			LOG_DBG("Supported opcodes");
-			current_inst->optional_opcodes_handle = chrc->value_handle;
+			current_inst->optional_opcodes_handle = bt_gatt_attr_value_handle(attr);
 #endif /* defined(CONFIG_BT_TBS_CLIENT_OPTIONAL_OPCODES) */
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_TBS_TERMINATE_REASON) == 0) {
 			LOG_DBG("Termination reason");
-			current_inst->termination_reason_handle = chrc->value_handle;
+			current_inst->termination_reason_handle = bt_gatt_attr_value_handle(attr);
 			sub_params = &current_inst->termination_sub_params;
-			sub_params->value_handle = chrc->value_handle;
+			sub_params->value_handle = bt_gatt_attr_value_handle(attr);
 			sub_params->disc_params = &current_inst->termination_sub_disc_params;
 #if defined(CONFIG_BT_TBS_CLIENT_CALL_FRIENDLY_NAME)
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_TBS_FRIENDLY_NAME) == 0) {
 			LOG_DBG("Incoming friendly name");
 			sub_params = &current_inst->friendly_name_sub_params;
-			sub_params->value_handle = chrc->value_handle;
+			sub_params->value_handle = bt_gatt_attr_value_handle(attr);
 			sub_params->disc_params = &current_inst->friendly_name_sub_disc_params;
 #endif /* defined(CONFIG_BT_TBS_CLIENT_CALL_FRIENDLY_NAME) */
 #if defined(CONFIG_BT_TBS_CLIENT_INCOMING_CALL)
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_TBS_INCOMING_CALL) == 0) {
 			LOG_DBG("Incoming call");
 			sub_params = &current_inst->incoming_call_sub_params;
-			sub_params->value_handle = chrc->value_handle;
+			sub_params->value_handle = bt_gatt_attr_value_handle(attr);
 			sub_params->disc_params = &current_inst->incoming_call_sub_disc_params;
 #endif /* defined(CONFIG_BT_TBS_CLIENT_INCOMING_CALL) */
 		}

--- a/subsys/bluetooth/audio/vcp_vol_ctlr.c
+++ b/subsys/bluetooth/audio/vcp_vol_ctlr.c
@@ -464,22 +464,22 @@ static uint8_t vcs_discover_func(struct bt_conn *conn,
 
 		if (bt_uuid_cmp(chrc->uuid, BT_UUID_VCS_STATE) == 0) {
 			LOG_DBG("Volume state");
-			vol_ctlr->state_handle = chrc->value_handle;
+			vol_ctlr->state_handle = bt_gatt_attr_value_handle(attr);
 			sub_params = &vol_ctlr->state_sub_params;
 			sub_params->disc_params = &vol_ctlr->state_sub_disc_params;
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_VCS_CONTROL) == 0) {
 			LOG_DBG("Control Point");
-			vol_ctlr->control_handle = chrc->value_handle;
+			vol_ctlr->control_handle = bt_gatt_attr_value_handle(attr);
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_VCS_FLAGS) == 0) {
 			LOG_DBG("Flags");
-			vol_ctlr->flag_handle = chrc->value_handle;
+			vol_ctlr->flag_handle = bt_gatt_attr_value_handle(attr);
 			sub_params = &vol_ctlr->flag_sub_params;
 			sub_params->disc_params = &vol_ctlr->flag_sub_disc_params;
 		}
 
 		if (sub_params != NULL) {
 			sub_params->value = BT_GATT_CCC_NOTIFY;
-			sub_params->value_handle = chrc->value_handle;
+			sub_params->value_handle = bt_gatt_attr_value_handle(attr);
 			sub_params->ccc_handle = 0;
 			sub_params->end_handle = vol_ctlr->end_handle;
 			sub_params->notify = vcp_vol_ctlr_notify_handler;

--- a/subsys/bluetooth/audio/vocs_client.c
+++ b/subsys/bluetooth/audio/vocs_client.c
@@ -378,17 +378,17 @@ static uint8_t vocs_discover_func(struct bt_conn *conn, const struct bt_gatt_att
 
 		chrc = (struct bt_gatt_chrc *)attr->user_data;
 		if (inst->start_handle == 0) {
-			inst->start_handle = chrc->value_handle;
+			inst->start_handle = bt_gatt_attr_value_handle(attr);
 		}
-		inst->end_handle = chrc->value_handle;
+		inst->end_handle = bt_gatt_attr_value_handle(attr);
 
 		if (!bt_uuid_cmp(chrc->uuid, BT_UUID_VOCS_STATE)) {
 			LOG_DBG("Volume offset state");
-			inst->state_handle = chrc->value_handle;
+			inst->state_handle = bt_gatt_attr_value_handle(attr);
 			sub_params = &inst->state_sub_params;
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_VOCS_LOCATION)) {
 			LOG_DBG("Location");
-			inst->location_handle = chrc->value_handle;
+			inst->location_handle = bt_gatt_attr_value_handle(attr);
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
 				sub_params = &inst->location_sub_params;
 			}
@@ -397,10 +397,10 @@ static uint8_t vocs_discover_func(struct bt_conn *conn, const struct bt_gatt_att
 			}
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_VOCS_CONTROL)) {
 			LOG_DBG("Control point");
-			inst->control_handle = chrc->value_handle;
+			inst->control_handle = bt_gatt_attr_value_handle(attr);
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_VOCS_DESCRIPTION)) {
 			LOG_DBG("Description");
-			inst->desc_handle = chrc->value_handle;
+			inst->desc_handle = bt_gatt_attr_value_handle(attr);
 			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
 				sub_params = &inst->desc_sub_params;
 			}
@@ -413,7 +413,7 @@ static uint8_t vocs_discover_func(struct bt_conn *conn, const struct bt_gatt_att
 			int err;
 
 			sub_params->value = BT_GATT_CCC_NOTIFY;
-			sub_params->value_handle = chrc->value_handle;
+			sub_params->value_handle = bt_gatt_attr_value_handle(attr);
 			/*
 			 * TODO: Don't assume that CCC is at handle + 2;
 			 * do proper discovery;

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -1956,7 +1956,7 @@ uint16_t bt_gatt_attr_value_handle(const struct bt_gatt_attr *attr)
 	if (attr != NULL && bt_uuid_cmp(attr->uuid, BT_UUID_GATT_CHRC) == 0) {
 		struct bt_gatt_chrc *chrc = attr->user_data;
 
-		handle = chrc->value_handle;
+		handle = bt_gatt_attr_value_handle(attr);
 		if (handle == 0) {
 			/* Fall back to Zephyr value handle policy */
 			handle = bt_gatt_attr_get_handle(attr) + 1U;

--- a/subsys/bluetooth/services/ias/ias_client.c
+++ b/subsys/bluetooth/services/ias/ias_client.c
@@ -110,7 +110,7 @@ static uint8_t bt_ias_alert_lvl_disc_cb(struct bt_conn *conn,
 
 	chrc = (struct bt_gatt_chrc *)attr->user_data;
 
-	client_by_conn(conn)->alert_level_handle = chrc->value_handle;
+	client_by_conn(conn)->alert_level_handle = bt_gatt_attr_value_handle(attr);
 	discover_complete(conn, 0);
 
 	return BT_GATT_ITER_STOP;

--- a/tests/bsim/bluetooth/host/att/eatt_notif/src/server_test.c
+++ b/tests/bsim/bluetooth/host/att/eatt_notif/src/server_test.c
@@ -95,7 +95,7 @@ static uint8_t discover_func(struct bt_conn *conn,
 
 		if (bt_uuid_cmp(chrc->uuid, TEST_CHRC_UUID) == 0) {
 			printk("Found chrc value\n");
-			chrc_handle = chrc->value_handle;
+			chrc_handle = bt_gatt_attr_value_handle(attr);
 			params->type = BT_GATT_DISCOVER_DESCRIPTOR;
 		}
 	}

--- a/tests/bsim/bluetooth/host/gatt/authorization/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/gatt/authorization/src/gatt_client_test.c
@@ -137,16 +137,16 @@ static uint8_t discover_func(struct bt_conn *conn,
 
 		if (bt_uuid_cmp(chrc->uuid, TEST_UNHANDLED_CHRC_UUID) == 0) {
 			printk("Found unhandled chrc\n");
-			unhandled_chrc_handle = chrc->value_handle;
+			unhandled_chrc_handle = bt_gatt_attr_value_handle(attr);
 		} else if (bt_uuid_cmp(chrc->uuid, TEST_UNAUTHORIZED_CHRC_UUID) == 0) {
 			printk("Found unauthorized\n");
-			unauthorized_chrc_handle = chrc->value_handle;
+			unauthorized_chrc_handle = bt_gatt_attr_value_handle(attr);
 		} else if (bt_uuid_cmp(chrc->uuid, TEST_AUTHORIZED_CHRC_UUID) == 0) {
 			printk("Found authorized chrc\n");
-			authorized_chrc_handle = chrc->value_handle;
+			authorized_chrc_handle = bt_gatt_attr_value_handle(attr);
 		} else if (bt_uuid_cmp(chrc->uuid, TEST_CP_CHRC_UUID) == 0) {
 			printk("Found CP chrc\n");
-			cp_chrc_handle = chrc->value_handle;
+			cp_chrc_handle = bt_gatt_attr_value_handle(attr);
 		}
 	}
 

--- a/tests/bsim/bluetooth/host/gatt/caching/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/gatt/caching/src/gatt_client_test.c
@@ -142,11 +142,11 @@ static uint8_t discover_func(struct bt_conn *conn, const struct bt_gatt_attr *at
 
 		if (bt_uuid_cmp(chrc->uuid, TEST_CHRC_UUID) == 0) {
 			printk("Found chrc\n");
-			chrc_handle = chrc->value_handle;
+			chrc_handle = bt_gatt_attr_value_handle(attr);
 
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_GATT_CLIENT_FEATURES) == 0) {
 			printk("Found csf\n");
-			csf_handle = chrc->value_handle;
+			csf_handle = bt_gatt_attr_value_handle(attr);
 		}
 	}
 

--- a/tests/bsim/bluetooth/host/gatt/general/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/gatt/general/src/gatt_client_test.c
@@ -151,16 +151,16 @@ static uint8_t discover_func(struct bt_conn *conn,
 
 		if (bt_uuid_cmp(chrc->uuid, TEST_CHRC_UUID) == 0) {
 			printk("Found chrc\n");
-			chrc_handle = chrc->value_handle;
+			chrc_handle = bt_gatt_attr_value_handle(attr);
 		} else if (bt_uuid_cmp(chrc->uuid, TEST_LONG_CHRC_UUID) == 0) {
 			printk("Found long_chrc\n");
-			long_chrc_handle = chrc->value_handle;
+			long_chrc_handle = bt_gatt_attr_value_handle(attr);
 		} else if (bt_uuid_cmp(chrc->uuid, TEST_ENC_CHRC_UUID) == 0) {
 			printk("Found enc_chrc_handle\n");
-			enc_chrc_handle = chrc->value_handle;
+			enc_chrc_handle = bt_gatt_attr_value_handle(attr);
 		} else if (bt_uuid_cmp(chrc->uuid, TEST_LESC_CHRC_UUID) == 0) {
 			printk("Found lesc_chrc_handle\n");
-			lesc_chrc_handle = chrc->value_handle;
+			lesc_chrc_handle = bt_gatt_attr_value_handle(attr);
 		}
 	}
 

--- a/tests/bsim/bluetooth/host/gatt/notify/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/gatt/notify/src/gatt_client_test.c
@@ -139,10 +139,10 @@ static uint8_t discover_func(struct bt_conn *conn, const struct bt_gatt_attr *at
 
 		if (bt_uuid_cmp(chrc->uuid, TEST_CHRC_UUID) == 0) {
 			printk("Found chrc\n");
-			chrc_handle = chrc->value_handle;
+			chrc_handle = bt_gatt_attr_value_handle(attr);
 		} else if (bt_uuid_cmp(chrc->uuid, TEST_LONG_CHRC_UUID) == 0) {
 			printk("Found long_chrc\n");
-			long_chrc_handle = chrc->value_handle;
+			long_chrc_handle = bt_gatt_attr_value_handle(attr);
 		}
 	}
 

--- a/tests/bsim/bluetooth/host/gatt/notify_multiple/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/gatt/notify_multiple/src/gatt_client_test.c
@@ -157,13 +157,13 @@ static uint8_t discover_func(struct bt_conn *conn, const struct bt_gatt_attr *at
 
 		if (bt_uuid_cmp(chrc->uuid, TEST_CHRC_UUID) == 0) {
 			printk("Found chrc\n");
-			chrc_handle = chrc->value_handle;
+			chrc_handle = bt_gatt_attr_value_handle(attr);
 		} else if (bt_uuid_cmp(chrc->uuid, TEST_LONG_CHRC_UUID) == 0) {
 			printk("Found long_chrc\n");
-			long_chrc_handle = chrc->value_handle;
+			long_chrc_handle = bt_gatt_attr_value_handle(attr);
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_GATT_CLIENT_FEATURES) == 0) {
 			printk("Found csf\n");
-			csf_handle = chrc->value_handle;
+			csf_handle = bt_gatt_attr_value_handle(attr);
 		}
 	}
 

--- a/tests/bsim/bluetooth/host/gatt/sc_indicate/src/central.c
+++ b/tests/bsim/bluetooth/host/gatt/sc_indicate/src/central.c
@@ -95,7 +95,7 @@ static uint8_t discover_func(struct bt_conn *conn,
 			int err;
 
 			LOG_DBG("found sc");
-			gatt_handles[SC] = chrc->value_handle;
+			gatt_handles[SC] = bt_gatt_attr_value_handle(attr);
 
 			params->uuid = &ccc_uuid.uuid;
 			params->start_handle = attr->handle + 2;

--- a/tests/bsim/bluetooth/host/gatt/settings/src/gatt_utils.c
+++ b/tests/bsim/bluetooth/host/gatt/settings/src/gatt_utils.c
@@ -146,15 +146,15 @@ static uint8_t discover_func(struct bt_conn *conn, const struct bt_gatt_attr *at
 
 		if (bt_uuid_cmp(chrc->uuid, BT_UUID_GATT_CLIENT_FEATURES) == 0) {
 			printk("Found client supported features\n");
-			gatt_handles[CLIENT_FEATURES] = chrc->value_handle;
+			gatt_handles[CLIENT_FEATURES] = bt_gatt_attr_value_handle(attr);
 
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_GATT_SC) == 0) {
 			printk("Found service changed\n");
-			gatt_handles[SERVICE_CHANGED] = chrc->value_handle;
+			gatt_handles[SERVICE_CHANGED] = bt_gatt_attr_value_handle(attr);
 
 		} else if (bt_uuid_cmp(chrc->uuid, &test_chrc_uuid.uuid) == 0) {
 			printk("Found test characteristic\n");
-			gatt_handles[TEST_CHAR] = chrc->value_handle;
+			gatt_handles[TEST_CHAR] = bt_gatt_attr_value_handle(attr);
 		}
 	}
 

--- a/tests/bsim/bluetooth/host/misc/disable/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/misc/disable/src/gatt_client_test.c
@@ -136,10 +136,10 @@ static uint8_t discover_func(struct bt_conn *conn,
 
 		if (bt_uuid_cmp(chrc->uuid, TEST_CHRC_UUID) == 0) {
 			printk("Found chrc\n");
-			chrc_handle = chrc->value_handle;
+			chrc_handle = bt_gatt_attr_value_handle(attr);
 		} else if (bt_uuid_cmp(chrc->uuid, TEST_LONG_CHRC_UUID) == 0) {
 			printk("Found long_chrc\n");
-			long_chrc_handle = chrc->value_handle;
+			long_chrc_handle = bt_gatt_attr_value_handle(attr);
 		}
 	}
 


### PR DESCRIPTION
Samples, services, and tests where relying on that
bt_gatt_attr.user_data was pointing to a bt_gatt_chrc.

This is not documented, so code should not rely on it.

Instead of casting user_data to a type, the application should use
bt_gatt_attr_value_handle instead().

The API was initially added in
https://github.com/zephyrproject-rtos/zephyr/pull/16952

Note: We still need to use the cast as there is no way to obtain
the UUID or properties of a service attribute. Maybe we should add
APIs for that?