### PR TITLE
rtio: workq: bug-fix: Initialize Work item before using

### DIFF
--- a/subsys/rtio/rtio_workq.c
+++ b/subsys/rtio/rtio_workq.c
@@ -42,6 +42,10 @@ struct rtio_work_req *rtio_work_req_alloc(void)
 		return NULL;
 	}
 
+	/** Initialize work item before using it as it comes
+	 * from a Memory slab (no-init region).
+	 */
+	req->work.thread = NULL;
 	(void)k_sem_init(&req->work.done_sem, 1, 1);
 
 	return req;


### PR DESCRIPTION
### Description
This PR initializes the RTIO Work items before using, as they come from a mem-slab (no-init region).

Fixes #75822.

### Testing

Verified the issue before and after the patch, proving being effective:

- Build and Flash STM32 Nucleo G0B1RE:
``` console
west build -b nucleo_g0b1re tests/subys/rtio/workq
west flash && screen /dev/ttyACM0
```
- Console output
``` console
*** Booting Zephyr OS build v3.7.0-rc2-466-g38a19e0a1e79 ***
Running TESTSUITE rtio_work
===================================================================
START - test_used_count_keeps_track_of_alloc_items
 PASS - test_used_count_keeps_track_of_alloc_items in 0.001 seconds
===================================================================
START - test_work_decouples_submission
        - work_handler() called!: 1
 PASS - test_work_decouples_submission in 0.003 seconds
===================================================================
START - test_work_supports_batching_submissions
        - work_handler() called!: 1
        - work_handler() called!: 2
        - work_handler() called!: 3
 PASS - test_work_supports_batching_submissions in 0.008 seconds
===================================================================
START - test_work_supports_preempting_on_higher_prio_submissions
        - work_handler() called!: 1
        - work_handler() called!: 2
        - work_handler() called!: 3
 PASS - test_work_supports_preempting_on_higher_prio_submissions in 0.009 seconds
===================================================================
TESTSUITE rtio_work succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [rtio_work]: pass = 4, fail = 0, skip = 0, total = 4 duration = 0.021 seconds
 - PASS - [rtio_work.test_used_count_keeps_track_of_alloc_items] duration = 0.001 seconds
 - PASS - [rtio_work.test_work_decouples_submission] duration = 0.003 seconds
 - PASS - [rtio_work.test_work_supports_batching_submissions] duration = 0.008 seconds
 - PASS - [rtio_work.test_work_supports_preempting_on_higher_prio_submissions] duration = 0.009 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```