### PR TITLE
drivers: i3c: add KConfig to perform rstact during bus init

### DIFF
--- a/drivers/i3c/Kconfig
+++ b/drivers/i3c/Kconfig
@@ -105,6 +105,13 @@ config I3C_CONTROLLER_INIT_PRIORITY
 	  may not be addressable until addresses are assigned by
 	  the controller.
 
+config I3C_INIT_RSTACT
+	bool "Perform Reset Action During Bus Initialization"
+	default y
+	help
+	  This determines whether the bus initialization routine
+	  sends a reset action command to I3C targets.
+
 comment "Device Drivers"
 
 rsource "Kconfig.nxp"

--- a/drivers/i3c/i3c_common.c
+++ b/drivers/i3c/i3c_common.c
@@ -637,6 +637,7 @@ int i3c_bus_init(const struct device *dev, const struct i3c_dev_list *dev_list)
 	bool need_daa = true;
 	struct i3c_ccc_events i3c_events;
 
+#ifdef CONFIG_I3C_INIT_RSTACT
 	/*
 	 * Reset all connected targets. Also reset dynamic
 	 * addresses for all devices as we have no idea what
@@ -659,6 +660,7 @@ int i3c_bus_init(const struct device *dev, const struct i3c_dev_list *dev_list)
 			LOG_DBG("Broadcast RSTACT (peripehral) was NACK.");
 		}
 	}
+#endif
 
 	if (i3c_ccc_do_rstdaa_all(dev) != 0) {
 		LOG_DBG("Broadcast RSTDAA was NACK.");


### PR DESCRIPTION
Sometimes, performing a rstact which will reset all devices during init on the bus may not be ideal. Add a KConfig to easily turn off.