### PR TITLE
drivers: flash: shell: add "flash copy" command

### DIFF
--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -5,18 +5,32 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include <zephyr/kernel.h>
 #include <zephyr/devicetree.h>
-
+#include <zephyr/drivers/flash.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/sys/util.h>
 
-#include <stdlib.h>
-#include <string.h>
-#include <zephyr/drivers/flash.h>
-
 /* Buffer is only needed for bytes that follow command and offset */
 #define BUF_ARRAY_CNT (CONFIG_SHELL_ARGC_MAX - 2)
+
+#define FLASH_LOAD_BUF_MAX 256
+
+static const struct device *flash_load_dev;
+static uint32_t flash_load_buf_size;
+static uint32_t flash_load_addr;
+static uint32_t flash_load_total;
+static uint32_t flash_load_written;
+static uint32_t flash_load_chunk;
+
+static uint32_t flash_load_boff;
+static uint8_t flash_load_buf[FLASH_LOAD_BUF_MAX];
 
 /* This only issues compilation error when it would not be possible
  * to extract at least one byte from command line arguments, yet
@@ -161,6 +175,40 @@ static int cmd_write(const struct shell *sh, size_t argc, char *argv[])
 		shell_error(sh, "Verification ERROR!");
 		return -EIO;
 	}
+
+	return 0;
+}
+
+static int cmd_copy(const struct shell *sh, size_t argc, char *argv[])
+{
+	int ret;
+	uint32_t size = 0;
+	uint32_t src_offset = 0;
+	uint32_t dst_offset = 0;
+	const struct device *src_dev = NULL;
+	const struct device *dst_dev = NULL;
+
+	if (argc < 5) {
+		shell_error(sh, "missing parameters");
+		return -EINVAL;
+	}
+
+	src_dev = device_get_binding(argv[1]);
+	dst_dev = device_get_binding(argv[2]);
+	src_offset = strtoul(argv[3], NULL, 0);
+	dst_offset = strtoul(argv[4], NULL, 0);
+	/* size will be padded to write_size bytes */
+	size = strtoul(argv[5], NULL, 0);
+
+	ret = flash_copy(src_dev, src_offset, dst_dev, dst_offset, size, flash_load_buf,
+			 sizeof(flash_load_buf));
+	if (ret < 0) {
+		shell_error(sh, "%s failed: %d", "flash_copy()", ret);
+		return -EIO;
+	}
+
+	shell_print(sh, "Copied %u bytes from %s:%x to %s:%x", size, argv[1], src_offset, argv[2],
+		    dst_offset);
 
 	return 0;
 }
@@ -544,18 +592,6 @@ static int set_bypass(const struct shell *sh, shell_bypass_cb_t bypass)
 	return 0;
 }
 
-#define FLASH_LOAD_BUF_MAX 256
-
-static const struct device *flash_load_dev;
-static uint32_t flash_load_buf_size;
-static uint32_t flash_load_addr;
-static uint32_t flash_load_total;
-static uint32_t flash_load_written;
-static uint32_t flash_load_chunk;
-
-static uint32_t flash_load_boff;
-static uint8_t flash_load_buf[FLASH_LOAD_BUF_MAX];
-
 static void bypass_cb(const struct shell *sh, uint8_t *recv, size_t len)
 {
 	uint32_t left_to_read = flash_load_total - flash_load_written - flash_load_boff;
@@ -711,6 +747,9 @@ static void device_name_get(size_t idx, struct shell_static_entry *entry)
 }
 
 SHELL_STATIC_SUBCMD_SET_CREATE(flash_cmds,
+	SHELL_CMD_ARG(copy, &dsub_device_name,
+		"<src_device> <dst_device> <src_offset> <dst_offset> <size>",
+		cmd_copy, 5, 5),
 	SHELL_CMD_ARG(erase, &dsub_device_name,
 		"[<device>] <page address> [<size>]",
 		cmd_erase, 2, 2),

--- a/drivers/flash/flash_util.c
+++ b/drivers/flash/flash_util.c
@@ -6,10 +6,17 @@
 
 
 #include <errno.h>
+#include <limits.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+/* FIXME: use k_off_t instead of off_t */
+#include <sys/types.h>
 
 #include <zephyr/drivers/flash.h>
+#include <zephyr/internal/syscall_handler.h>
 #include <zephyr/logging/log.h>
-#include <string.h>
+#include <zephyr/sys/math_extras.h>
 
 LOG_MODULE_REGISTER(flash, CONFIG_FLASH_LOG_LEVEL);
 
@@ -80,3 +87,116 @@ int z_impl_flash_flatten(const struct device *dev, off_t offset, size_t size)
 	return -ENOSYS;
 #endif
 }
+
+/* note: caller must first check for positivity (>=0) */
+static inline bool off_add_overflow(off_t offset, off_t size, off_t *result)
+{
+	BUILD_ASSERT((sizeof(off_t) == sizeof(uint32_t)) || (sizeof(off_t) == sizeof(uint64_t)));
+
+	if (sizeof(off_t) == sizeof(uint32_t)) {
+		uint32_t end;
+
+		/* account for signedness of off_t due to lack of s32_add_overflow() */
+		if (u32_add_overflow((uint32_t)offset, (uint32_t)size, &end) || (end > INT32_MAX)) {
+			return true;
+		}
+	} else if (sizeof(off_t) == sizeof(uint64_t)) {
+		uint64_t end;
+
+		/* account for signedness of off_t due to lack of s64_add_overflow() */
+		if (u64_add_overflow((uint64_t)offset, (uint64_t)size, &end) || (end > INT64_MAX)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/* note: caller must first check for overflow */
+static inline bool flash_ranges_overlap(off_t a_start, off_t a_size, off_t b_start, off_t b_size)
+{
+	off_t a_end = a_start + a_size;
+	off_t b_end = b_start + b_size;
+
+	return (a_start < b_end) && (a_end > b_start);
+}
+
+int z_impl_flash_copy(const struct device *src_dev, off_t src_offset, const struct device *dst_dev,
+		      off_t dst_offset, off_t size, uint8_t *buf, size_t buf_size)
+{
+	int ret;
+	off_t end;
+	size_t write_size;
+
+	if ((src_offset < 0) || (dst_offset < 0) || (size < 0) || (buf == NULL) ||
+	    (buf_size == 0) || off_add_overflow(src_offset, size, &end) ||
+	    off_add_overflow(dst_offset, size, &end)) {
+		LOG_DBG("invalid argument");
+		return -EINVAL;
+	}
+
+	if (src_dev == dst_dev) {
+		if (src_offset == dst_offset) {
+			return 0;
+		}
+
+		if (flash_ranges_overlap(src_offset, size, dst_offset, size) != 0) {
+			return -EINVAL;
+		}
+	}
+
+	if (!device_is_ready(src_dev)) {
+		LOG_DBG("%s device not ready", "src");
+		return -ENODEV;
+	}
+
+	if (!device_is_ready(dst_dev)) {
+		LOG_DBG("%s device not ready", "dst");
+		return -ENODEV;
+	}
+
+	write_size = flash_get_write_block_size(dst_dev);
+	if ((buf_size < write_size) || ((buf_size % write_size) != 0)) {
+		LOG_DBG("buf size %zu is incompatible with write_size of %zu", buf_size,
+			write_size);
+		return -EINVAL;
+	}
+
+	for (uint32_t offs = 0, N = size, bytes_read = 0, bytes_left = N; offs < N;
+	     offs += bytes_read, bytes_left -= bytes_read) {
+
+		if (bytes_left < write_size) {
+			const struct flash_driver_api *api =
+				(const struct flash_driver_api *)dst_dev->api;
+			const struct flash_parameters *params = api->get_parameters(dst_dev);
+
+			memset(buf, params->erase_value, write_size);
+		}
+		bytes_read = MIN(MAX(bytes_left, write_size), buf_size);
+		ret = flash_read(src_dev, src_offset + offs, buf, bytes_read);
+		if (ret < 0) {
+			LOG_DBG("%s() failed at offset %lx: %d", "flash_read",
+				(long)(src_offset + offs), ret);
+			return ret;
+		}
+
+		ret = flash_write(dst_dev, dst_offset + offs, buf, bytes_read);
+		if (ret < 0) {
+			LOG_DBG("%s() failed at offset %lx: %d", "flash_write",
+				(long)(src_offset + offs), ret);
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+#ifdef CONFIG_USERSPACE
+int z_vrfy_flash_copy(const struct device *src_dev, off_t src_offset, const struct device *dst_dev,
+		      off_t dst_offset, off_t size, uint8_t *buf, size_t buf_size)
+{
+	K_OOPS(K_SYSCALL_MEMORY_WRITE(buf, buf_size));
+	return z_impl_flash_copy(src_dev, src_offset, dst_dev, dst_offset, size, buf, buf_size);
+}
+#include <zephyr/syscalls/flash_copy_mrsh.c>
+#endif

--- a/include/zephyr/drivers/flash.h
+++ b/include/zephyr/drivers/flash.h
@@ -583,6 +583,37 @@ static inline const struct flash_parameters *z_impl_flash_get_parameters(const s
 __syscall int flash_ex_op(const struct device *dev, uint16_t code,
 			  const uintptr_t in, void *out);
 
+/**
+ * @brief Copy flash memory from one device to another.
+ *
+ * Copy a region of flash memory from one place to another. The source and
+ * destination flash devices may be the same or different devices. However,
+ * this function will fail if the source and destination devices are the same
+ * if memory regions overlap and are not identical.
+ *
+ * The caller must supply a buffer of suitable size and ensure that the
+ * destination is erased beforehand, if necessary.
+ *
+ * @note If the source and destination devices are the same, and the source
+ * and destination offsets are also the same, this function succeeds without
+ * performing any copy operation.
+ *
+ * @param src_dev Source flash device.
+ * @param dst_dev Destination flash device.
+ * @param src_offset Offset within the source flash device.
+ * @param dst_offset Offset within the destination flash device.
+ * @param size Size of the region to copy, in bytes.
+ * @param[out] buf Pointer to a buffer of size @a buf_size.
+ * @param buf_size Size of the buffer pointed to by @a buf.
+ *
+ * @retval 0 on success
+ * @retval -EINVAL if an argument is invalid.
+ * @retval -EIO if an I/O error occurs.
+ * @retval -ENODEV if either @a src_dev or @a dst_dev are not ready.
+ */
+__syscall int flash_copy(const struct device *src_dev, off_t src_offset,
+			 const struct device *dst_dev, off_t dst_offset, off_t size, uint8_t *buf,
+			 size_t buf_size);
 /*
  *  Extended operation interface provides flexible way for supporting flash
  *  controller features. Code space is divided equally into Zephyr codes

--- a/tests/drivers/flash/common/src/main.c
+++ b/tests/drivers/flash/common/src/main.c
@@ -55,9 +55,11 @@ static uint8_t __aligned(4) expected[EXPECTED_SIZE];
 static uint8_t erase_value;
 static bool ebw_required;
 
-static void *flash_driver_setup(void)
+static void flash_driver_before(void *arg)
 {
 	int rc;
+
+	ARG_UNUSED(arg);
 
 	TC_PRINT("Test will run on device %s\n", flash_dev->name);
 	zassert_true(device_is_ready(flash_dev));
@@ -120,8 +122,6 @@ static void *flash_driver_setup(void)
 			zassert_equal(rc, 0, "Flash memory not properly erased");
 		}
 	}
-
-	return NULL;
 }
 
 ZTEST(flash_driver, test_read_unaligned_address)
@@ -374,4 +374,4 @@ ZTEST(flash_driver, test_flash_page_layout)
 		     test_cb_data.page_counter, test_cb_data.exit_page);
 }
 
-ZTEST_SUITE(flash_driver, NULL, flash_driver_setup, NULL, NULL, NULL);
+ZTEST_SUITE(flash_driver, NULL, NULL, flash_driver_before, NULL, NULL);

--- a/tests/drivers/flash/common/src/main.c
+++ b/tests/drivers/flash/common/src/main.c
@@ -374,4 +374,78 @@ ZTEST(flash_driver, test_flash_page_layout)
 		     test_cb_data.page_counter, test_cb_data.exit_page);
 }
 
+static void test_flash_copy_inner(const struct device *src_dev, off_t src_offset,
+				  const struct device *dst_dev, off_t dst_offset, off_t size,
+				  uint8_t *buf, size_t buf_size, int expected_result)
+{
+	int actual_result;
+
+	if ((expected_result == 0) && (size != 0) && (src_offset != dst_offset)) {
+		/* prepare for successful copy */
+		zassert_ok(flash_flatten(flash_dev, page_info.start_offset, page_info.size));
+		zassert_ok(flash_fill(flash_dev, 0xaa, page_info.start_offset, page_info.size));
+		zassert_ok(flash_flatten(flash_dev, page_info.start_offset + page_info.size,
+					 page_info.size));
+	}
+
+	/* perform copy (if args are valid) */
+	actual_result = flash_copy(src_dev, src_offset, dst_dev, dst_offset, size, buf, buf_size);
+	zassert_equal(actual_result, expected_result,
+		      "flash_copy(%p, %lx, %p, %lx, %zu, %p, %zu) failed: expected: %d actual: %d",
+		      src_dev, src_offset, dst_dev, dst_offset, size, buf, buf_size,
+		      expected_result, actual_result);
+
+	if ((expected_result == 0) && (size != 0) && (src_offset != dst_offset)) {
+		/* verify a successful copy */
+		zassert_ok(flash_read(flash_dev, TEST_AREA_OFFSET, expected, EXPECTED_SIZE));
+		for (int i = 0; i < EXPECTED_SIZE; i++) {
+			zassert_equal(buf[i], 0xaa, "incorrect data (%02x) at %d", buf[i], i);
+		}
+	}
+}
+
+ZTEST(flash_driver, test_flash_copy)
+{
+	uint8_t buf[EXPECTED_SIZE];
+	const off_t off_max = (sizeof(off_t) == sizeof(int32_t)) ? INT32_MAX : INT64_MAX;
+
+	/*
+	 * Rather than explicitly testing 128+ permutations of input,
+	 * merge redundant cases:
+	 *  - src_dev or dst_dev are invalid
+	 *  - src_offset or dst_offset are invalid
+	 *  - src_offset + size or dst_offset + size overflow
+	 *  - buf is NULL
+	 *  - buf size is invalid
+	 */
+	test_flash_copy_inner(NULL, -1, NULL, -1, -1, NULL, 0, -EINVAL);
+	test_flash_copy_inner(NULL, -1, NULL, -1, -1, NULL, sizeof(buf), -EINVAL);
+	test_flash_copy_inner(NULL, -1, NULL, -1, -1, buf, sizeof(buf), -EINVAL);
+	test_flash_copy_inner(NULL, -1, NULL, -1, page_info.size, buf, sizeof(buf), -EINVAL);
+	test_flash_copy_inner(NULL, -1, NULL, -1, page_info.size, buf, sizeof(buf), -EINVAL);
+	test_flash_copy_inner(NULL, page_info.start_offset, NULL,
+			      page_info.start_offset + page_info.size, page_info.size, buf,
+			      sizeof(buf), -ENODEV);
+	test_flash_copy_inner(flash_dev, page_info.start_offset, flash_dev,
+			      page_info.start_offset + page_info.size, page_info.size, buf,
+			      sizeof(buf), 0);
+
+	/* zero-sized copy should succeed */
+	test_flash_copy_inner(flash_dev, page_info.start_offset, flash_dev,
+			      page_info.start_offset + page_info.size, 0, buf, sizeof(buf), 0);
+
+	/* copy with same offset should succeed */
+	test_flash_copy_inner(flash_dev, page_info.start_offset, flash_dev, page_info.start_offset,
+			      page_info.size, buf, sizeof(buf), 0);
+
+	/* copy with integer overflow should fail */
+	test_flash_copy_inner(flash_dev, off_max, flash_dev, page_info.start_offset, 42, buf,
+			      sizeof(buf), -EINVAL);
+
+	/* copy with overlapping ranges should fail */
+	test_flash_copy_inner(flash_dev, page_info.start_offset, flash_dev,
+			      page_info.start_offset + 32, page_info.size - 32, buf, sizeof(buf),
+			      -EINVAL);
+}
+
 ZTEST_SUITE(flash_driver, NULL, NULL, flash_driver_before, NULL, NULL);


### PR DESCRIPTION
Add a `flash copy` command, capable of copying a region in one flash device to a region on the same or another flash device. The caller is responsible for erasing the destination prior to copying, if that is necessary.

This is useful for evaluating mcuboot on devices with little on-chip resources that are not capable of running more elaborate image management services (e.g. via bluetooth or networking).

Additionally, it's useful for evaluating mcuboot on devices with one or more images stored on external spi flash.

The `flash copy` command syntax is
```shell
flash copy <src_dev> <dst_dev> <src_offs> <dest_offs> <size>
```

E.g.
```shell
flash copy flash@0 flash-controller@abcd1234 0x1234 0x5678 21012
Copied 21012 bytes from flash@0:1234 to flash-controller@abcd1234:5678
```