### PR TITLE
twister: pytest: use test timeout as the default base timeout

### DIFF
--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -383,6 +383,10 @@ class Pytest(Harness):
             '--log-cli-format=%(levelname)s: %(message)s'
         ])
 
+        # Use the test timeout as the base timeout for pytest
+        base_timeout = handler.get_test_timeout()
+        command.append(f'--base-timeout={base_timeout}')
+
         if handler.type_str == 'device':
             command.extend(
                 self._generate_parameters_for_hardware(handler)


### PR DESCRIPTION
The default base timeout for pytest is statically set by the TwisterHarnessConfig class to be 60 seconds. However, sometimes it takes longer than 60s before the app starts to run, especially on emulator/simulator where it takes quite some time to start. So pass the test timeout as the base timeout via pytest command line argument.