### PR TITLE
Bluetooth: host: Use correct user_data size for hci_rx_pool

### DIFF
--- a/subsys/bluetooth/host/buf.c
+++ b/subsys/bluetooth/host/buf.c
@@ -59,7 +59,7 @@ NET_BUF_POOL_FIXED_DEFINE(evt_pool, CONFIG_BT_BUF_EVT_RX_COUNT,
 			  NULL);
 #else
 NET_BUF_POOL_FIXED_DEFINE(hci_rx_pool, BT_BUF_RX_COUNT,
-			  BT_BUF_RX_SIZE, sizeof(struct bt_buf_data),
+			  BT_BUF_RX_SIZE, sizeof(struct acl_data),
 			  NULL);
 #endif /* CONFIG_BT_HCI_ACL_FLOW_CONTROL */
 


### PR DESCRIPTION
First commit from #75779 without any change.
Following one of the maintainers recommendation to merge this for 3.7 in https://github.com/zephyrproject-rtos/zephyr/pull/75779#issuecomment-2226358257

--------

`struct acl_data` is used even when Host flow control is not enabled. It is written to through the `acl(buf)` accessor in `conn.c:hci_acl()`.