### PR TITLE
drivers: serial: uart_altera_jtag: select required Kconfigs

### DIFF
--- a/drivers/serial/Kconfig.altera_jtag
+++ b/drivers/serial/Kconfig.altera_jtag
@@ -5,6 +5,8 @@ config UART_ALTERA_JTAG
 	bool "Nios II/NiosV JTAG UART driver"
 	default y
 	depends on DT_HAS_ALTR_JTAG_UART_ENABLED
+	select POSIX_API
+	select POSIX_TIMERS
 	select SERIAL_HAS_DRIVER
 	help
 	  Enable the Altera JTAG UART driver, built in to many Nios II/NiosV CPU


### PR DESCRIPTION
This driver seems to be depending on things that it is not enabling, enable them.

fixes #75837, but:

```
-- Including generated dts.cmake file: /Users/ycsin/zephyrproject/zephyr/twister-out/qemu_nios2/tests/kernel/common/kernel.common.minimallibc/zephyr/dts.cmake

warning: MAX_THREAD_BYTES (defined at arch/Kconfig:377) was assigned the value '3' but got the value
''. Check these unsatisfied dependencies: USERSPACE (=n). See
http://docs.zephyrproject.org/latest/kconfig.html#CONFIG_MAX_THREAD_BYTES and/or look up
MAX_THREAD_BYTES in the menuconfig/guiconfig interface. The Application Development Primer, Setting
Configuration Values, and Kconfig - Tips and Best Practices sections of the manual might be helpful
too.


warning: BOUNDS_CHECK_BYPASS_MITIGATION (defined at kernel/Kconfig:942) was assigned the value 'y'
but got the value 'n'. Check these unsatisfied dependencies: USERSPACE (=n). See
http://docs.zephyrproject.org/latest/kconfig.html#CONFIG_BOUNDS_CHECK_BYPASS_MITIGATION and/or look
up BOUNDS_CHECK_BYPASS_MITIGATION in the menuconfig/guiconfig interface. The Application Development
Primer, Setting Configuration Values, and Kconfig - Tips and Best Practices sections of the manual
might be helpful too.
```