### PR TITLE
disk: sdmmc: devicetree naming

### DIFF
--- a/boards/adafruit/grand_central_m4_express/adafruit_grand_central_m4_express.dts
+++ b/boards/adafruit/grand_central_m4_express/adafruit_grand_central_m4_express.dts
@@ -72,6 +72,7 @@
 		mmc {
 			status = "okay";
 			compatible = "zephyr,sdmmc-disk";
+			disk-name = "SDMMC";
 		};
 	};
 };

--- a/boards/arduino/mkrzero/arduino_mkrzero.dts
+++ b/boards/arduino/mkrzero/arduino_mkrzero.dts
@@ -90,6 +90,7 @@
 		mmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";
+			disk-name = "SDMMC";
 		};
 	};
 };

--- a/boards/atmel/sam/sam4e_xpro/sam4e_xpro.dts
+++ b/boards/atmel/sam/sam4e_xpro/sam4e_xpro.dts
@@ -220,6 +220,7 @@
 	mmc {
 		compatible = "zephyr,sdmmc-disk";
 		status = "okay";
+		disk-name = "SDMMC";
 	};
 };
 

--- a/boards/espressif/esp_wrover_kit/esp_wrover_kit_procpu.dts
+++ b/boards/espressif/esp_wrover_kit/esp_wrover_kit_procpu.dts
@@ -202,6 +202,7 @@
 		mmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";
+			disk-name = "SDMMC";
 		};
 	};
 };

--- a/boards/ezurio/bl5340_dvk/bl5340_dvk_nrf5340_cpuapp_common.dtsi
+++ b/boards/ezurio/bl5340_dvk/bl5340_dvk_nrf5340_cpuapp_common.dtsi
@@ -230,6 +230,7 @@
 		mmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";
+			disk-name = "SDMMC";
 		};
 	};
 };

--- a/boards/ezurio/mg100/mg100.dts
+++ b/boards/ezurio/mg100/mg100.dts
@@ -151,6 +151,7 @@
 		mmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";
+			disk-name = "SDMMC";
 		};
 	};
 };

--- a/boards/hardkernel/odroid_go/odroid_go_procpu.dts
+++ b/boards/hardkernel/odroid_go/odroid_go_procpu.dts
@@ -144,6 +144,7 @@
 		mmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";
+			disk-name = "SDMMC";
 		};
 		spi-max-frequency = <20000000>;
 	};

--- a/boards/intel/socfpga/agilex5_socdk/intel_socfpga_agilex5_socdk.dts
+++ b/boards/intel/socfpga/agilex5_socdk/intel_socfpga_agilex5_socdk.dts
@@ -27,6 +27,7 @@
 		/*SD Disk Access */
 		compatible = "zephyr,sdmmc-disk";
 		status = "okay";
+		disk-name = "SDMMC";
 	};
 };
 

--- a/boards/m5stack/m5stack_core2/m5stack_core2_procpu.dts
+++ b/boards/m5stack/m5stack_core2/m5stack_core2_procpu.dts
@@ -217,6 +217,7 @@
 		mmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";
+			disk-name = "SDMMC";
 		};
 
 	};

--- a/boards/madmachine/mm_swiftio/mm_swiftio.dts
+++ b/boards/madmachine/mm_swiftio/mm_swiftio.dts
@@ -187,6 +187,7 @@
 	mmc {
 		compatible = "zephyr,sdmmc-disk";
 		status = "okay";
+		disk-name = "SDMMC";
 	};
 };
 

--- a/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_cpuapp_common.dtsi
+++ b/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_cpuapp_common.dtsi
@@ -198,6 +198,7 @@ arduino_spi: &spi4 {
 		sdmmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";
+			disk-name = "SDMMC";
 		};
 
 		spi-max-frequency = <8000000>;

--- a/boards/nxp/frdm_k64f/frdm_k64f.dts
+++ b/boards/nxp/frdm_k64f/frdm_k64f.dts
@@ -163,6 +163,7 @@ arduino_spi: &spi0 {
 		sdmmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";
+			disk-name = "SDMMC";
 		};
 		spi-max-frequency = <24000000>;
 	};

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.dts
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.dts
@@ -156,6 +156,7 @@
 	sdmmc {
 		compatible = "zephyr,sdmmc-disk";
 		status = "okay";
+		disk-name = "SDMMC";
 	};
 };
 

--- a/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0.dts
+++ b/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0.dts
@@ -120,6 +120,7 @@
 	mmc {
 		compatible = "zephyr,sdmmc-disk";
 		status = "okay";
+		disk-name = "SDMMC";
 	};
 };
 

--- a/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -205,6 +205,7 @@ zephyr_udc0: &usb1 {
 	sdmmc {
 		compatible = "zephyr,sdmmc-disk";
 		status = "okay";
+		disk-name = "SDMMC";
 	};
 };
 

--- a/boards/nxp/mimxrt1024_evk/mimxrt1024_evk.dts
+++ b/boards/nxp/mimxrt1024_evk/mimxrt1024_evk.dts
@@ -240,5 +240,6 @@ zephyr_udc0: &usb1 {
 	sdmmc {
 		compatible = "zephyr,sdmmc-disk";
 		status = "okay";
+		disk-name = "SDMMC";
 	};
 };

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -220,6 +220,7 @@ zephyr_udc0: &usb1 {
 	sdmmc {
 		compatible = "zephyr,sdmmc-disk";
 		status = "okay";
+		disk-name = "SDMMC";
 	};
 };
 

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -223,6 +223,7 @@ zephyr_udc0: &usb1 {
 	sdmmc {
 		compatible = "zephyr,sdmmc-disk";
 		status = "okay";
+		disk-name = "SDMMC";
 	};
 };
 

--- a/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6.dts
+++ b/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6.dts
@@ -420,6 +420,7 @@ zephyr_udc0: &usb1 {
 	sdmmc {
 		compatible = "zephyr,sdmmc-disk";
 		status = "okay";
+		disk-name = "SDMMC";
 	};
 };
 

--- a/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -274,6 +274,7 @@ zephyr_udc0: &usb1 {
 	sdmmc {
 		compatible = "zephyr,sdmmc-disk";
 		status = "okay";
+		disk-name = "SDMMC";
 	};
 };
 

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7.dts
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7.dts
@@ -118,6 +118,7 @@ nxp_mipi_i2c: &lpi2c5 {
 	sdmmc {
 		compatible = "zephyr,sdmmc-disk";
 		status = "okay";
+		disk-name = "SDMMC";
 	};
 };
 

--- a/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
+++ b/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
@@ -370,6 +370,7 @@ zephyr_udc0: &usbhs {
 	mmc {
 		compatible = "zephyr,mmc-disk";
 		status = "okay";
+		disk-name = "MMC";
 	};
 	pinctrl-0 = <&pinmux_usdhc>;
 	pinctrl-names = "default";

--- a/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
+++ b/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
@@ -342,6 +342,7 @@ i2s1: &flexcomm3 {
 	sdmmc {
 		compatible = "zephyr,sdmmc-disk";
 		status = "okay";
+		disk-name = "SDMMC";
 	};
 	pinctrl-0 = <&pinmux_usdhc>;
 	pinctrl-names = "default";

--- a/boards/nxp/vmu_rt1170/vmu_rt1170_mimxrt1176_cm7.dts
+++ b/boards/nxp/vmu_rt1170/vmu_rt1170_mimxrt1176_cm7.dts
@@ -458,6 +458,7 @@
 	sdmmc {
 		compatible = "zephyr,sdmmc-disk";
 		status = "okay";
+		disk-name = "SDMMC";
 	};
 };
 

--- a/boards/olimex/olimexino_stm32/olimexino_stm32.dts
+++ b/boards/olimex/olimexino_stm32/olimexino_stm32.dts
@@ -137,6 +137,7 @@ uext_serial: &usart1 {};
 		mmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";
+			disk-name = "SDMMC";
 		};
 	};
 };

--- a/boards/pjrc/teensy4/teensy41.dts
+++ b/boards/pjrc/teensy4/teensy41.dts
@@ -49,5 +49,6 @@
 	mmc {
 		compatible = "zephyr,sdmmc-disk";
 		status = "okay";
+		disk-name = "SDMMC";
 	};
 };

--- a/boards/renesas/rcar_h3ulcb/rcar_h3ulcb_r8a77951_a57.dts
+++ b/boards/renesas/rcar_h3ulcb/rcar_h3ulcb_r8a77951_a57.dts
@@ -67,6 +67,7 @@
 	disk {
 		compatible = "zephyr,sdmmc-disk";
 		status = "okay";
+		disk-name = "SDMMC";
 	};
 
 	vmmc-supply = <&vcc_sd0>;
@@ -94,6 +95,7 @@
 	disk {
 		compatible = "zephyr,mmc-disk";
 		status = "disabled";
+		disk-name = "MMC";
 	};
 	bus-width = <8>;
 	mmc-hs200-1_8v;

--- a/boards/renesas/rcar_salvator_xs/rcar_salvator_xs.dts
+++ b/boards/renesas/rcar_salvator_xs/rcar_salvator_xs.dts
@@ -47,6 +47,7 @@
 	disk {
 		compatible = "zephyr,mmc-disk";
 		status = "disabled";
+		disk-name = "MMC";
 	};
 	bus-width = <8>;
 	mmc-hs200-1_8v;

--- a/boards/renesas/rcar_spider_s4/rcar_spider_s4_r8a779f0_a55.dts
+++ b/boards/renesas/rcar_spider_s4/rcar_spider_s4_r8a779f0_a55.dts
@@ -42,6 +42,7 @@
 	disk {
 		compatible = "zephyr,mmc-disk";
 		status = "okay";
+		disk-name = "MMC";
 	};
 	bus-width = <8>;
 	mmc-hs200-1_8v;

--- a/boards/seeed/wio_terminal/wio_terminal.dts
+++ b/boards/seeed/wio_terminal/wio_terminal.dts
@@ -277,6 +277,7 @@
 		spi-max-frequency = <24000000>;
 		mmc {
 			compatible = "zephyr,sdmmc-disk";
+			disk-name = "SDMMC";
 		};
 	};
 };

--- a/boards/shields/adafruit_2_8_tft_touch_v2/dts/adafruit_2_8_tft_touch_v2.dtsi
+++ b/boards/shields/adafruit_2_8_tft_touch_v2/dts/adafruit_2_8_tft_touch_v2.dtsi
@@ -58,6 +58,7 @@
 		mmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";
+			disk-name = "SDMMC";
 		};
 	};
 };

--- a/boards/shields/adafruit_data_logger/adafruit_data_logger.overlay
+++ b/boards/shields/adafruit_data_logger/adafruit_data_logger.overlay
@@ -44,6 +44,7 @@
 		sdmmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";
+			disk-name = "SDMMC";
 		};
 	};
 };

--- a/boards/shields/seeed_xiao_expansion_board/seeed_xiao_expansion_board.overlay
+++ b/boards/shields/seeed_xiao_expansion_board/seeed_xiao_expansion_board.overlay
@@ -61,6 +61,7 @@
 		mmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";
+			disk-name = "SDMMC";
 		};
 		spi-max-frequency = <24000000>;
 	};

--- a/boards/shields/seeed_xiao_round_display/seeed_xiao_round_display.overlay
+++ b/boards/shields/seeed_xiao_round_display/seeed_xiao_round_display.overlay
@@ -89,6 +89,7 @@
 		mmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";
+			disk-name = "SDMMC";
 		};
 		spi-max-frequency = <DT_FREQ_M(24)>;
 	};

--- a/boards/shields/sparkfun_carrier_asset_tracker/sparkfun_carrier_asset_tracker.overlay
+++ b/boards/shields/sparkfun_carrier_asset_tracker/sparkfun_carrier_asset_tracker.overlay
@@ -36,6 +36,7 @@
 		mmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";
+			disk-name = "SDMMC";
 		};
 		spi-max-frequency = <DT_FREQ_M(8)>;
 	};

--- a/boards/shields/v2c_daplink/v2c_daplink.overlay
+++ b/boards/shields/v2c_daplink/v2c_daplink.overlay
@@ -42,6 +42,7 @@
 		mmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";
+			disk-name = "SDMMC";
 		};
 	};
 };

--- a/boards/shields/v2c_daplink/v2c_daplink_cfg.overlay
+++ b/boards/shields/v2c_daplink/v2c_daplink_cfg.overlay
@@ -34,6 +34,7 @@
 		mmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";
+			disk-name = "SDMMC";
 		};
 	};
 };

--- a/boards/shields/waveshare_epaper/dts/waveshare_epaper_common.dtsi
+++ b/boards/shields/waveshare_epaper/dts/waveshare_epaper_common.dtsi
@@ -17,6 +17,7 @@
 		mmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";
+			disk-name = "SDMMC";
 		};
 	};
 };

--- a/boards/sipeed/longan_nano/longan_nano-common.dtsi
+++ b/boards/sipeed/longan_nano/longan_nano-common.dtsi
@@ -171,6 +171,7 @@
 		mmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";
+			disk-name = "SDMMC";
 		};
 	};
 };

--- a/drivers/disk/Kconfig.mmc
+++ b/drivers/disk/Kconfig.mmc
@@ -15,13 +15,6 @@ config SD_INIT_PRIORITY
 	help
 	  MMC controller driver initialization priority.
 
-config MMC_VOLUME_NAME
-	string "MMC Disk mount point or drive name"
-	default "SD" if FAT_FILESYSTEM_ELM
-	default "MMC"
-	help
-	  Disk name as per file system naming guidelines.
-
 config MMC_SUBSYS
 	bool "MMC access via SD subsystem"
 	select MMC_STACK

--- a/drivers/disk/Kconfig.sdmmc
+++ b/drivers/disk/Kconfig.sdmmc
@@ -19,13 +19,6 @@ config SD_INIT_PRIORITY
 	help
 	  SDMMC controller driver initialization priority.
 
-config SDMMC_VOLUME_NAME
-	string "SDMMC Disk mount point or drive name"
-	default "SD" if FAT_FILESYSTEM_ELM
-	default "SDMMC"
-	help
-	  Disk name as per file system naming guidelines.
-
 config SDMMC_SUBSYS
 	bool "SDMMC access via SD subsystem"
 	select SDMMC_STACK

--- a/drivers/disk/sdmmc_stm32.c
+++ b/drivers/disk/sdmmc_stm32.c
@@ -85,6 +85,7 @@ struct stm32_sdmmc_priv {
 	struct stm32_pclken *pclken;
 	const struct pinctrl_dev_config *pcfg;
 	const struct reset_dt_spec reset;
+	struct disk_info info;
 
 #if STM32_SDMMC_USE_DMA
 	struct sdmmc_dma_stream dma_rx;
@@ -503,12 +504,6 @@ static const struct disk_operations stm32_sdmmc_ops = {
 	.ioctl = stm32_sdmmc_access_ioctl,
 };
 
-static struct disk_info stm32_sdmmc_info = {
-	.name = CONFIG_SDMMC_VOLUME_NAME,
-	.ops = &stm32_sdmmc_ops,
-};
-
-
 #ifdef CONFIG_SDMMC_STM32_EMMC
 static bool stm32_sdmmc_card_present(struct stm32_sdmmc_priv *priv)
 {
@@ -694,8 +689,8 @@ static int disk_stm32_sdmmc_init(const struct device *dev)
 		priv->status = DISK_STATUS_NOMEDIA;
 	}
 
-	stm32_sdmmc_info.dev = dev;
-	err = disk_access_register(&stm32_sdmmc_info);
+	priv->info.dev = dev;
+	err = disk_access_register(&priv->info);
 	if (err) {
 		goto err_pwr;
 	}
@@ -777,6 +772,10 @@ static struct stm32_sdmmc_priv stm32_sdmmc_priv_1 = {
 #if DT_INST_NODE_HAS_PROP(0, pwr_gpios)
 	.pe = GPIO_DT_SPEC_INST_GET(0, pwr_gpios),
 #endif
+	.info = {
+		.name = DT_INST_PROP(0, disk_name),
+		.ops = &stm32_sdmmc_ops,
+	},
 	.pclken = pclken_sdmmc,
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0),
 	.reset = RESET_DT_SPEC_INST_GET(0),

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -570,6 +570,7 @@
 			resets = <&rctl STM32_RESET(APB2, 11U)>;
 			interrupts = <49 0>;
 			status = "disabled";
+			disk-name = "SDMMC";
 		};
 	};
 

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -829,6 +829,7 @@
 			resets = <&rctl STM32_RESET(APB2, 11U)>;
 			interrupts = <49 0>;
 			status = "disabled";
+			disk-name = "SDMMC";
 		};
 
 		backup_sram: memory@40024000 {

--- a/dts/arm/st/f7/stm32f722.dtsi
+++ b/dts/arm/st/f7/stm32f722.dtsi
@@ -40,6 +40,7 @@
 			resets = <&rctl STM32_RESET(APB2, 7U)>;
 			interrupts = <103 0>;
 			status = "disabled";
+			disk-name = "SDMMC";
 		};
 	};
 

--- a/dts/arm/st/f7/stm32f765.dtsi
+++ b/dts/arm/st/f7/stm32f765.dtsi
@@ -89,6 +89,7 @@
 			resets = <&rctl STM32_RESET(APB2, 7U)>;
 			interrupts = <103 0>;
 			status = "disabled";
+			disk-name = "SDMMC";
 		};
 
 	};

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -467,6 +467,7 @@
 			resets = <&rctl STM32_RESET(AHB4, 11U)>;
 			interrupts = <79 0>;
 			status = "disabled";
+			disk-name = "SDMMC";
 		};
 	};
 

--- a/dts/arm/st/h5/stm32h563.dtsi
+++ b/dts/arm/st/h5/stm32h563.dtsi
@@ -18,6 +18,7 @@
 			resets = <&rctl STM32_RESET(AHB4, 12U)>;
 			interrupts = <102 0>;
 			status = "disabled";
+			disk-name = "SDMMC";
 		};
 	};
 };

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -997,6 +997,7 @@
 			resets = <&rctl STM32_RESET(AHB3, 16U)>;
 			interrupts = <49 0>;
 			status = "disabled";
+			disk-name = "SDMMC";
 		};
 
 		sdmmc2: sdmmc@48022400 {
@@ -1007,6 +1008,7 @@
 			resets = <&rctl STM32_RESET(AHB2, 9U)>;
 			interrupts = <124 0>;
 			status = "disabled";
+			disk-name = "SD2";
 		};
 
 		mac: ethernet@40028000 {

--- a/dts/arm/st/l4/stm32l431.dtsi
+++ b/dts/arm/st/l4/stm32l431.dtsi
@@ -118,6 +118,7 @@
 			resets = <&rctl STM32_RESET(APB2, 10U)>;
 			interrupts = <49 0>;
 			status = "disabled";
+			disk-name = "SDMMC";
 		};
 
 		dac1: dac@40007400 {

--- a/dts/arm/st/l4/stm32l433.dtsi
+++ b/dts/arm/st/l4/stm32l433.dtsi
@@ -66,6 +66,7 @@
 				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;
 			interrupts = <49 0>;
 			status = "disabled";
+			disk-name = "SDMMC";
 		};
 	};
 

--- a/dts/arm/st/l4/stm32l451.dtsi
+++ b/dts/arm/st/l4/stm32l451.dtsi
@@ -151,6 +151,7 @@
 			resets = <&rctl STM32_RESET(APB2, 10U)>;
 			interrupts = <49 0>;
 			status = "disabled";
+			disk-name = "SDMMC";
 		};
 
 		rtc@40002800 {

--- a/dts/arm/st/l4/stm32l471.dtsi
+++ b/dts/arm/st/l4/stm32l471.dtsi
@@ -242,6 +242,7 @@
 			resets = <&rctl STM32_RESET(APB2, 10U)>;
 			interrupts = <49 0>;
 			status = "disabled";
+			disk-name = "SDMMC";
 		};
 
 		dac1: dac@40007400 {

--- a/dts/arm/st/l4/stm32l4p5.dtsi
+++ b/dts/arm/st/l4/stm32l4p5.dtsi
@@ -344,6 +344,7 @@
 			resets = <&rctl STM32_RESET(AHB2, 22U)>;
 			interrupts = <49 0>;
 			status = "disabled";
+			disk-name = "SDMMC";
 		};
 
 		sdmmc2: sdmmc@50062800 {
@@ -354,6 +355,7 @@
 			resets = <&rctl STM32_RESET(AHB2, 23U)>;
 			interrupts = <47 0>;
 			status = "disabled";
+			disk-name = "SD2";
 		};
 
 		dac1: dac@40007400 {

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -402,6 +402,7 @@
 			resets = <&rctl STM32_RESET(AHB2, 22U)>;
 			interrupts = <78 0>;
 			status = "disabled";
+			disk-name = "SDMMC";
 		};
 
 		dac1: dac@40007400 {

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -750,6 +750,7 @@
 			resets = <&rctl STM32_RESET(AHB2L, 27U)>;
 			interrupts = <78 0>;
 			status = "disabled";
+			disk-name = "SDMMC";
 		};
 
 		sdmmc2: sdmmc@420c8c00 {
@@ -760,6 +761,7 @@
 			resets = <&rctl STM32_RESET(AHB2L, 28U)>;
 			interrupts = <79 0>;
 			status = "disabled";
+			disk-name = "SD2";
 		};
 
 		dac1: dac@46021800 {

--- a/dts/bindings/mmc/st,stm32-sdmmc.yaml
+++ b/dts/bindings/mmc/st,stm32-sdmmc.yaml
@@ -71,3 +71,9 @@ properties:
 
       For example
          dma-names = "tx", "rx";
+
+  disk-name:
+    type: string
+    required: true
+    description: |
+      Disk name.

--- a/dts/bindings/sd/zephyr,mmc-disk.yaml
+++ b/dts/bindings/sd/zephyr,mmc-disk.yaml
@@ -19,3 +19,8 @@ properties:
       - 1
       - 4
       - 8
+  disk-name:
+    type: string
+    required: true
+    description: |
+      Disk name.

--- a/dts/bindings/sd/zephyr,sdmmc-disk.yaml
+++ b/dts/bindings/sd/zephyr,sdmmc-disk.yaml
@@ -7,3 +7,10 @@ description: |
 compatible: "zephyr,sdmmc-disk"
 
 include: [sd-device.yaml]
+
+properties:
+  disk-name:
+    type: string
+    required: true
+    description: |
+      Disk name.

--- a/dts/x86/intel/alder_lake.dtsi
+++ b/dts/x86/intel/alder_lake.dtsi
@@ -350,6 +350,7 @@
 				compatible = "zephyr,mmc-disk";
 				bus-width = <8>;
 				status = "okay";
+				disk-name = "MMC";
 			};
 
 			status = "okay";

--- a/modules/fatfs/zephyr_fatfs_config.h
+++ b/modules/fatfs/zephyr_fatfs_config.h
@@ -4,6 +4,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <zephyr/devicetree.h>
+
 #if FFCONF_DEF != 80286
 #error "Configuration version mismatch"
 #endif
@@ -86,13 +88,21 @@
 #define FF_STR_VOLUME_ID 1
 
 /* By default FF_STR_VOLUME_ID in ffconf.h is 0, which means that
- * FF_VOLUME_STRS is not used. Zephyr uses FF_VOLUME_STRS, which
- * by default holds 8 possible strings representing mount points,
- * and FF_VOLUMES needs to reflect that, which means that dolt
- * value of 1 is overridden here with 8.
+ * FF_VOLUME_STRS is not used. Zephyr uses FF_VOLUME_STRS.
+ * The array of volume strings is automatically generated from devicetree.
  */
+
+#define _FF_DISK_NAME(node) DT_PROP(node, disk_name),
+
+#undef FF_VOLUME_STRS
+#define FF_VOLUME_STRS \
+	DT_FOREACH_STATUS_OKAY(zephyr_flash_disk, _FF_DISK_NAME) \
+	DT_FOREACH_STATUS_OKAY(zephyr_ram_disk, _FF_DISK_NAME) \
+	DT_FOREACH_STATUS_OKAY(zephyr_sdmmc_disk, _FF_DISK_NAME) \
+	DT_FOREACH_STATUS_OKAY(st_stm32_sdmmc, _FF_DISK_NAME)
+
 #undef FF_VOLUMES
-#define FF_VOLUMES 8
+#define FF_VOLUMES NUM_VA_ARGS_LESS_1(FF_VOLUME_STRS _)
 
 /*
  * Options provided below have been added to ELM FAT source code to

--- a/samples/subsys/fs/fs_sample/boards/hifive_unmatched.overlay
+++ b/samples/subsys/fs/fs_sample/boards/hifive_unmatched.overlay
@@ -14,6 +14,7 @@
 		mmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";
+			disk-name = "SDMMC";
 		};
 		spi-max-frequency = <20000000>;
 	};

--- a/samples/subsys/fs/fs_sample/boards/nrf52840_blip.overlay
+++ b/samples/subsys/fs/fs_sample/boards/nrf52840_blip.overlay
@@ -15,6 +15,7 @@
 		mmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";
+			disk-name = "SDMMC";
 		};
 		spi-max-frequency = <24000000>;
 	};

--- a/samples/subsys/fs/fs_sample/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/subsys/fs/fs_sample/boards/nrf52840dk_nrf52840.overlay
@@ -41,7 +41,7 @@
 		status="okay";
 		compatible = "zephyr,flash-disk";
 		partition = <&storage_partition>;
-		disk-name = "SD";
+		disk-name = "SDMMC";
 		/* cache-size == page erase size */
 		cache-size = <4096>;
 	};

--- a/samples/subsys/fs/fs_sample/boards/nrf52840dk_nrf52840_qspi.overlay
+++ b/samples/subsys/fs/fs_sample/boards/nrf52840dk_nrf52840_qspi.overlay
@@ -28,7 +28,7 @@
 		status="okay";
 		compatible = "zephyr,flash-disk";
 		partition = <&external_partition>;
-		disk-name = "SD";
+		disk-name = "SDMMC";
 		/* cache-size == page erase size */
 		cache-size = <4096>;
 	};

--- a/samples/subsys/fs/fs_sample/boards/nrf52840dk_nrf52840_ram_disk.overlay
+++ b/samples/subsys/fs/fs_sample/boards/nrf52840dk_nrf52840_ram_disk.overlay
@@ -11,7 +11,7 @@
 		/* Sample, to make things easier, mounts all FAT
 		 * systems at "SD".
 		 */
-		disk-name = "SD";
+		disk-name = "SDMMC";
 		/* Disk size is 64kB, 128 sectors of 512B, the minimal
 		 * required by FAT FS.
 		 */

--- a/samples/subsys/fs/fs_sample/boards/nrf52840dk_nrf52840_ram_disk_region.overlay
+++ b/samples/subsys/fs/fs_sample/boards/nrf52840dk_nrf52840_ram_disk_region.overlay
@@ -41,7 +41,7 @@
 		/* Sample, to make things easier, mounts all FAT
 		 * systems at "SD".
 		 */
-		disk-name = "SD";
+		disk-name = "SDMMC";
 		/* Disk size is 64kB, 128 sectors of 512B, the minimal
 		 * required by FAT FS.
 		 */

--- a/samples/subsys/fs/fs_sample/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
+++ b/samples/subsys/fs/fs_sample/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
@@ -39,7 +39,7 @@
 		status="okay";
 		compatible = "zephyr,flash-disk";
 		partition = <&storage_partition>;
-		disk-name = "SD";
+		disk-name = "SDMMC";
 		cache-size = <512>;
 	};
 };

--- a/samples/subsys/fs/fs_sample/boards/nucleo_f429zi.overlay
+++ b/samples/subsys/fs/fs_sample/boards/nucleo_f429zi.overlay
@@ -12,6 +12,7 @@
 		mmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";
+			disk-name = "SDMMC";
 		};
 		spi-max-frequency = <25000000>;
 		spi-clock-mode-cpol;

--- a/subsys/fs/shell.c
+++ b/subsys/fs/shell.c
@@ -39,10 +39,8 @@ static struct fs_mount_t fatfs_mnt = {
 /* TODO: Implement dynamic storage dev selection */
 #ifdef CONFIG_FS_LITTLEFS_BLK_DEV
 
-#if defined(CONFIG_DISK_DRIVER_SDMMC)
-#define DISK_NAME CONFIG_SDMMC_VOLUME_NAME
-#elif defined(CONFIG_DISK_DRIVER_MMC)
-#define DISK_NAME CONFIG_MMC_VOLUME_NAME
+#if defined(CONFIG_DISK_DRIVER_SDMMC) || defined(CONFIG_DISK_DRIVER_MMC)
+#define DISK_NAME "SDMMC"
 #else
 #error "No disk device defined, is your board supported?"
 #endif

--- a/tests/drivers/disk/disk_access/src/main.c
+++ b/tests/drivers/disk/disk_access/src/main.c
@@ -20,10 +20,8 @@
 #include <zephyr/drivers/loopback_disk.h>
 #endif
 
-#if defined(CONFIG_DISK_DRIVER_SDMMC)
-#define DISK_NAME_PHYS CONFIG_SDMMC_VOLUME_NAME
-#elif defined(CONFIG_DISK_DRIVER_MMC)
-#define DISK_NAME_PHYS CONFIG_MMC_VOLUME_NAME
+#if defined(CONFIG_DISK_DRIVER_SDMMC) || defined(CONFIG_DISK_DRIVER_MMC)
+#define DISK_NAME "SDMMC"
 #elif defined(CONFIG_DISK_DRIVER_FLASH)
 #define DISK_NAME_PHYS "NAND"
 #elif defined(CONFIG_NVME)

--- a/tests/drivers/disk/disk_performance/src/main.c
+++ b/tests/drivers/disk/disk_performance/src/main.c
@@ -12,10 +12,8 @@
 #include <zephyr/timing/timing.h>
 #include <zephyr/random/random.h>
 
-#if defined(CONFIG_DISK_DRIVER_SDMMC)
-#define DISK_NAME CONFIG_SDMMC_VOLUME_NAME
-#elif defined(CONFIG_DISK_DRIVER_MMC)
-#define DISK_NAME CONFIG_MMC_VOLUME_NAME
+#if defined(CONFIG_DISK_DRIVER_SDMMC) || defined(CONFIG_DISK_DRIVER_MMC)
+#define DISK_NAME "SDMMC"
 #elif defined(CONFIG_NVME)
 #define DISK_NAME "nvme0n0"
 #else

--- a/tests/lib/gui/lvgl/boards/stm32h747i_disco_stm32h747xx_m7.overlay
+++ b/tests/lib/gui/lvgl/boards/stm32h747i_disco_stm32h747xx_m7.overlay
@@ -7,6 +7,7 @@
 &sdmmc1 {
 	sdmmc {
 		compatible = "zephyr,sdmmc-disk";
+		disk-name = "SDMMC";
 	};
 };
 

--- a/tests/lib/gui/lvgl/src/main.c
+++ b/tests/lib/gui/lvgl/src/main.c
@@ -17,10 +17,8 @@
 
 #ifdef CONFIG_FS_LITTLEFS_BLK_DEV
 
-#ifdef CONFIG_DISK_DRIVER_SDMMC
-#define DISK_NAME CONFIG_SDMMC_VOLUME_NAME
-#elif defined(CONFIG_DISK_DRIVER_MMC)
-#define DISK_NAME CONFIG_MMC_VOLUME_NAME
+#if defined(CONFIG_DISK_DRIVER_SDMMC) || defined(CONFIG_DISK_DRIVER_MMC)
+#define DISK_NAME "SDMMC"
 #else
 #error "No disk device defined, is your board supported?"
 #endif /* CONFIG_DISK_DRIVER_SDMMC */

--- a/tests/subsys/fs/ext2/boards/hifive_unmatched.overlay
+++ b/tests/subsys/fs/ext2/boards/hifive_unmatched.overlay
@@ -14,6 +14,7 @@
 		mmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";
+			disk-name = "SDMMC";
 		};
 		spi-max-frequency = <20000000>;
 	};

--- a/tests/subsys/fs/fat_fs_api/src/test_fat.h
+++ b/tests/subsys/fs/fat_fs_api/src/test_fat.h
@@ -15,10 +15,8 @@
 #define DISK_NAME "RAM"
 #elif defined(CONFIG_DISK_DRIVER_FLASH)
 #define DISK_NAME DT_PROP(DT_NODELABEL(test_disk), disk_name)
-#elif defined(CONFIG_DISK_DRIVER_SDMMC)
-#define DISK_NAME CONFIG_SDMMC_VOLUME_NAME
-#elif defined(CONFIG_DISK_DRIVER_MMC)
-#define DISK_NAME CONFIG_MMC_VOLUME_NAME
+#elif defined(CONFIG_DISK_DRIVER_SDMMC) || defined(CONFIG_DISK_DRIVER_MMC)
+#define DISK_NAME "SDMMC"
 #else
 #error "Failed to select DISK access type"
 #endif


### PR DESCRIPTION
Add the `disk-name` property to the `zephyr,mmc-disk` `zephyr,sdmmc-disk` and `st,stm32-sdmmc` compatibles to enable labels to be agnostically retrieved through `DT_PROP(disk, disk_name)` regardless of the disk implementation.

The problem this is attempting to solve is that all usage of the "Disk Access" API is done through the name of the disk.
But given the following devicetree snippet, it is not possible to use the API because there is no way to generically get the disk name.
```
    chosen {
        my-disk = <&some_disk>;
    }
```
`DT_PROP(DT_CHOSEN(my_disk), disk_name)` works for the ram and flash disk implementations, but that's it.

One of the challenges preventing this was the FAT filesystem translation layer only accepting hardcoded strings, which is resolved in this PR.

Not addressed by this PR is the mess that is disk selection in tests and samples, which falls apart the instant any devicetree names are changed:
https://github.com/zephyrproject-rtos/zephyr/blob/2e012668e9045cd1ceadf225340237aba5400347/tests/drivers/disk/disk_access/src/main.c#L23-L38

Also not addressed, loopback devices (which probably need a devicetree node to simulate the fact they are emulating a hardware device) and the NVME driver, which uses dynamic names.