### PR TITLE
Improve gnss driver of u-blox-m10

### DIFF
--- a/drivers/gnss/gnss_u_blox_m10.c
+++ b/drivers/gnss/gnss_u_blox_m10.c
@@ -223,9 +223,6 @@ static int ubx_m10_modem_ubx_run_script(const struct device *dev,
 	}
 
 	ret = modem_ubx_run_script(&data->ubx, modem_ubx_script_tx);
-	if (ret < 0) {
-		goto reset_modem_module;
-	}
 
 reset_modem_module:
 	ret |= ubx_m10_modem_module_change(dev, 1);
@@ -264,9 +261,6 @@ static int ubx_m10_modem_ubx_script_init(const struct device *dev, void *payload
 
 	ret = ubx_create_and_validate_frame(data->request_buf, sizeof(data->request_buf), msg_cls,
 					    msg_id, payload, payld_sz);
-	if (ret < 0) {
-		return ret;
-	}
 
 	return ret;
 }
@@ -289,9 +283,6 @@ static int ubx_m10_ubx_cfg_rate(const struct device *dev)
 	}
 
 	ret = ubx_m10_modem_ubx_run_script(dev, &(data->script));
-	if (ret < 0) {
-		goto unlock;
-	}
 
 unlock:
 	k_spin_unlock(&data->lock, key);
@@ -325,9 +316,6 @@ static int ubx_m10_ubx_cfg_prt_set(const struct device *dev, uint32_t target_bau
 	 * (in order to receive response as well), which we are not doing right now.
 	 */
 	ret = ubx_m10_modem_ubx_run_script(dev, &(data->script));
-	if (ret < 0) {
-		goto unlock;
-	}
 
 unlock:
 	k_spin_unlock(&data->lock, key);
@@ -476,7 +464,7 @@ static int ubx_m10_configure_gnss_device_baudrate(const struct device *dev)
 
 static int ubx_m10_configure_messages(const struct device *dev)
 {
-	int ret;
+	int ret = 0;
 	k_spinlock_key_t key;
 	struct ubx_m10_data *data = dev->data;
 	struct ubx_cfg_msg_payload payload;
@@ -885,9 +873,6 @@ static int ubx_m10_set_fix_rate(const struct device *dev, uint32_t fix_interval_
 	}
 
 	ret = ubx_m10_modem_ubx_run_script(dev, &(data->script));
-	if (ret < 0) {
-		goto unlock;
-	}
 
 unlock:
 	k_spin_unlock(&data->lock, key);
@@ -964,7 +949,6 @@ static int ubx_m10_configure(const struct device *dev)
 	ret = ubx_m10_configure_messages(dev);
 	if (ret < 0) {
 		LOG_ERR("Configuring messages failed. Returned %d.", ret);
-		goto reset;
 	}
 
 reset:

--- a/drivers/gnss/gnss_u_blox_m10.c
+++ b/drivers/gnss/gnss_u_blox_m10.c
@@ -398,7 +398,6 @@ static int ubx_m10_set_uart_baudrate(const struct device *dev, uint32_t baudrate
 	}
 
 reset_and_unlock:
-	ubx_m10_init_pipe(dev);
 	ret |= ubx_m10_resume(dev);
 	if (ret < 0) {
 		goto unlock;

--- a/drivers/gnss/gnss_u_blox_m10.c
+++ b/drivers/gnss/gnss_u_blox_m10.c
@@ -951,9 +951,6 @@ static int ubx_m10_configure(const struct device *dev)
 
 reset:
 	ret = ubx_m10_ubx_cfg_rst(dev, UBX_CFG_RST_RESET_MODE_CONTROLLED_GNSS_START);
-	if (ret < 0) {
-		goto reset;
-	}
 
 	return ret;
 }

--- a/drivers/gnss/gnss_u_blox_m10.c
+++ b/drivers/gnss/gnss_u_blox_m10.c
@@ -393,17 +393,10 @@ static int ubx_m10_set_uart_baudrate(const struct device *dev, uint32_t baudrate
 	uart_cfg.baudrate = baudrate;
 
 	ret = uart_configure(config->uart, &uart_cfg);
-	if (ret < 0) {
-		goto reset_and_unlock;
-	}
 
 reset_and_unlock:
 	ret |= ubx_m10_resume(dev);
-	if (ret < 0) {
-		goto unlock;
-	}
 
-unlock:
 	k_spin_unlock(&data->lock, key);
 
 	return ret;

--- a/drivers/gnss/gnss_u_blox_m10.c
+++ b/drivers/gnss/gnss_u_blox_m10.c
@@ -42,8 +42,6 @@ LOG_MODULE_REGISTER(ubx_m10, CONFIG_GNSS_LOG_LEVEL);
 
 #define UBX_M10_GNSS_SYS_CNT		8
 #define UBX_M10_GNSS_SUPP_SYS_CNT	6
-/* The datasheet of the device doesn't specify boot time. But 1 sec helped significantly. */
-#define UBX_M10_BOOT_TIME_MS		1000
 
 struct ubx_m10_config {
 	const struct device *uart;
@@ -963,8 +961,6 @@ reset:
 static int ubx_m10_init(const struct device *dev)
 {
 	int ret;
-
-	k_sleep(K_MSEC(UBX_M10_BOOT_TIME_MS));
 
 	ret = ubx_m10_init_nmea0183_match(dev);
 	if (ret < 0) {


### PR DESCRIPTION
During baudrate probing of the uart the initialization structure
is overwritten with the symptom of an oops message
produced while isr is taking place. 
Also fix some more minor issues found during debugging sessions.