### PR TITLE
input: paw32xx: only reschedule the handler if motion is asserted

### DIFF
--- a/drivers/input/input_paw32xx.c
+++ b/drivers/input/input_paw32xx.c
@@ -221,8 +221,10 @@ static void paw32xx_motion_work_handler(struct k_work *work)
 	input_report_rel(data->dev, cfg->axis_x, x, false, K_FOREVER);
 	input_report_rel(data->dev, cfg->axis_y, y, true, K_FOREVER);
 
-	/* Trigger one more scan in case more data is available. */
-	k_work_submit(&data->motion_work);
+	/* Trigger one more scan if more data is available. */
+	if (gpio_pin_get_dt(&cfg->motion_gpio)) {
+		k_work_submit(&data->motion_work);
+	}
 }
 
 static void paw32xx_motion_handler(const struct device *gpio_dev,


### PR DESCRIPTION
The motion event handler is currently setup to always retrigger until there's no more motion data from the sensor. Change that to only retrigger if the motion pin is asserted when the handler has finished running, this saves a bunch of unnecessary spi transactions.

Ideally this driver would use a level interrupt, but I'd rather avoid that as that is unsupported by many gpio controllers.