### PR TITLE
net + posix: avoid host includes when building for native_sim

### DIFF
--- a/include/zephyr/net/socket.h
+++ b/include/zephyr/net/socket.h
@@ -1403,11 +1403,21 @@ struct net_socket_register {
  * zephyr/net/socket.h header file.
  */
 #if defined(CONFIG_POSIX_API)
-#include <arpa/inet.h>
-#include <netdb.h>
-#include <unistd.h>
-#include <poll.h>
-#include <sys/socket.h>
+#if !defined(ZEPHYR_INCLUDE_POSIX_ARPA_INET_H_)
+#include <zephyr/posix/arpa/inet.h>
+#endif
+#if !defined(ZEPHYR_INCLUDE_POSIX_NETDB_H_)
+#include <zephyr/posix/netdb.h>
+#endif
+#if !defined(ZEPHYR_INCLUDE_POSIX_UNISTD_H_)
+#include <zephyr/posix/unistd.h>
+#endif
+#if !defined(ZEPHYR_INCLUDE_POSIX_POLL_H_)
+#include <zephyr/posix/poll.h>
+#endif
+#if !defined(ZEPHYR_INCLUDE_POSIX_SYS_SOCKET_H_)
+#include <zephyr/posix/sys/socket.h>
+#endif
 #endif /* CONFIG_POSIX_API */
 
 #endif /* ZEPHYR_INCLUDE_NET_SOCKET_H_ */

--- a/include/zephyr/net/socket.h
+++ b/include/zephyr/net/socket.h
@@ -1401,6 +1401,11 @@ struct net_socket_register {
  * We have these includes here so that we do not need
  * to change the applications that were only including
  * zephyr/net/socket.h header file.
+ *
+ * Additionally, if non-zephyr-prefixed headers are used here,
+ * native_sim pulls in those from the host rather than Zephyr's.
+ *
+ * This should be removed when CONFIG_NET_SOCKETS_POSIX_NAMES is removed.
  */
 #if defined(CONFIG_POSIX_API)
 #if !defined(ZEPHYR_INCLUDE_POSIX_ARPA_INET_H_)

--- a/include/zephyr/posix/posix_types.h
+++ b/include/zephyr/posix/posix_types.h
@@ -21,6 +21,48 @@
 extern "C" {
 #endif
 
+#if !defined(_DEV_T_DECLARED) && !defined(__dev_t_defined)
+typedef int dev_t;
+#define _DEV_T_DECLARED
+#define __dev_t_defined
+#endif
+
+#if !defined(_INO_T_DECLARED) && !defined(__ino_t_defined)
+typedef int ino_t;
+#define _INO_T_DECLARED
+#define __ino_t_defined
+#endif
+
+#if !defined(_NLINK_T_DECLARED) && !defined(__nlink_t_defined)
+typedef unsigned short nlink_t;
+#define _NLINK_T_DECLARED
+#define __nlink_t_defined
+#endif
+
+#if !defined(_UID_T_DECLARED) && !defined(__uid_t_defined)
+typedef unsigned short uid_t;
+#define _UID_T_DECLARED
+#define __uid_t_defined
+#endif
+
+#if !defined(_GID_T_DECLARED) && !defined(__gid_t_defined)
+typedef unsigned short gid_t;
+#define _GID_T_DECLARED
+#define __gid_t_defined
+#endif
+
+#if !defined(_BLKSIZE_T_DECLARED) && !defined(__blksize_t_defined)
+typedef unsigned long blksize_t;
+#define _BLKSIZE_T_DECLARED
+#define __blksize_t_defined
+#endif
+
+#if !defined(_BLKCNT_T_DECLARED) && !defined(__blkcnt_t_defined)
+typedef unsigned long blkcnt_t;
+#define _BLKCNT_T_DECLARED
+#define __blkcnt_t_defined
+#endif
+
 #if !defined(CONFIG_ARCMWDT_LIBC)
 typedef int pid_t;
 #endif

--- a/include/zephyr/posix/posix_types.h
+++ b/include/zephyr/posix/posix_types.h
@@ -87,12 +87,10 @@ struct pthread_attr {
 	uint32_t details[2];
 };
 
-#if defined(CONFIG_MINIMAL_LIBC) || defined(CONFIG_PICOLIBC) || defined(CONFIG_ARMCLANG_STD_LIBC) \
-	|| defined(CONFIG_ARCMWDT_LIBC)
+#if !defined(CONFIG_NEWLIB_LIBC)
 typedef struct pthread_attr pthread_attr_t;
-#endif
-
 BUILD_ASSERT(sizeof(pthread_attr_t) >= sizeof(struct pthread_attr));
+#endif
 
 typedef uint32_t pthread_t;
 typedef uint32_t pthread_spinlock_t;
@@ -107,11 +105,10 @@ struct pthread_mutexattr {
 	unsigned char type: 2;
 	bool initialized: 1;
 };
-#if defined(CONFIG_MINIMAL_LIBC) || defined(CONFIG_PICOLIBC) || defined(CONFIG_ARMCLANG_STD_LIBC) \
-	|| defined(CONFIG_ARCMWDT_LIBC)
+#if !defined(CONFIG_NEWLIB_LIBC)
 typedef struct pthread_mutexattr pthread_mutexattr_t;
-#endif
 BUILD_ASSERT(sizeof(pthread_mutexattr_t) >= sizeof(struct pthread_mutexattr));
+#endif
 
 /* Condition variables */
 typedef uint32_t pthread_cond_t;
@@ -120,11 +117,10 @@ struct pthread_condattr {
 	clockid_t clock;
 };
 
-#if defined(CONFIG_MINIMAL_LIBC) || defined(CONFIG_PICOLIBC) || defined(CONFIG_ARMCLANG_STD_LIBC) \
-	|| defined(CONFIG_ARCMWDT_LIBC)
+#if !defined(CONFIG_NEWLIB_LIBC)
 typedef struct pthread_condattr pthread_condattr_t;
-#endif
 BUILD_ASSERT(sizeof(pthread_condattr_t) >= sizeof(struct pthread_condattr));
+#endif
 
 /* Barrier */
 typedef uint32_t pthread_barrier_t;
@@ -141,14 +137,12 @@ struct pthread_once {
 	bool flag;
 };
 
-#if defined(CONFIG_MINIMAL_LIBC) || defined(CONFIG_PICOLIBC) || defined(CONFIG_ARMCLANG_STD_LIBC) \
-	|| defined(CONFIG_ARCMWDT_LIBC)
+#if !defined(CONFIG_NEWLIB_LIBC)
 typedef uint32_t pthread_key_t;
 typedef struct pthread_once pthread_once_t;
-#endif
-
 /* Newlib typedefs pthread_once_t as a struct with two ints */
 BUILD_ASSERT(sizeof(pthread_once_t) >= sizeof(struct pthread_once));
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/posix/sys/stat.h
+++ b/include/zephyr/posix/sys/stat.h
@@ -36,8 +36,8 @@ extern "C" {
 
 #include <time.h>
 #include <sys/cdefs.h>
-#include <sys/types.h>
-#include <sys/_timespec.h>
+
+#include <zephyr/posix/posix_types.h>
 
 #ifndef _DEV_T_DECLARED
 typedef int dev_t;

--- a/include/zephyr/posix/sys/stat.h
+++ b/include/zephyr/posix/sys/stat.h
@@ -39,41 +39,6 @@ extern "C" {
 
 #include <zephyr/posix/posix_types.h>
 
-#ifndef _DEV_T_DECLARED
-typedef int dev_t;
-#define _DEV_T_DECLARED
-#endif
-
-#ifndef _INO_T_DECLARED
-typedef int ino_t;
-#define _INO_T_DECLARED
-#endif
-
-#ifndef _NLINK_T_DECLARED
-typedef unsigned short nlink_t;
-#define _NLINK_T_DECLARED
-#endif
-
-#ifndef _UID_T_DECLARED
-typedef unsigned short uid_t;
-#define _UID_T_DECLARED
-#endif
-
-#ifndef _GID_T_DECLARED
-typedef unsigned short gid_t;
-#define _GID_T_DECLARED
-#endif
-
-#ifndef _BLKSIZE_T_DECLARED
-typedef unsigned long blksize_t;
-#define _BLKSIZE_T_DECLARED
-#endif
-
-#ifndef _BLKCNT_T_DECLARED
-typedef unsigned long blkcnt_t;
-#define _BLKCNT_T_DECLARED
-#endif
-
 /* dj's stat defines _STAT_H_ */
 #ifndef _STAT_H_
 

--- a/tests/posix/net/testcase.yaml
+++ b/tests/posix/net/testcase.yaml
@@ -1,15 +1,22 @@
 common:
   depends_on: netif
-  # native_sim uses if_*() from the native libc
-  filter: not CONFIG_NATIVE_LIBC
-  integration_platforms:
-    - qemu_x86
   min_ram: 16
-  platform_allow:
-    - qemu_x86
   tags:
     - iface
     - net
     - posix
 tests:
-  portability.posix.net: {}
+  portability.posix.net:
+    # native_sim links to if_*() from the host libc which causes the test to crash immediately.
+    filter: not CONFIG_NATIVE_LIBC
+  portability.posix.net.cpp.native_sim:
+    # demonstrate that #75319 fixes the build error in #75849
+    tags:
+      - cpp
+    build_only: true
+    platform_allow:
+      - native_sim
+    extra_configs:
+      - CONFIG_CPP=y
+      - CONFIG_STD_CPP20=y
+      - CONFIG_REQUIRES_FULL_LIBCPP=y


### PR DESCRIPTION
A corner case involving C++, posix, networking, and native_sim was causing problems.

Even though C and C++ builds should include zephyr/posix/.. in the default search path with `CONFIG_POSIX_API=y`, for some reason, the native compiler pulls in /usr/include first anyway.

The stat.h header pulled in <sys/types.h> (which is normally fine) but due to the native build, it was pulling in /usr/include/sys/types.h, from the host toolchain.

Explicitly include <zephyr/posix/posix_types.h> instead of <sys/types.h> from stat.h, and continue using the workarounds for native builds (explicitly including zephyr/posix/arpa/net.h etc from net/sockets.h, etc).

The workaround must be left in the tree until the deprecated option `CONFIG_NET_SOCKETS_POSIX_NAMES` is removed, at which point Zephyr's POSIX API will be a consumer of the network subsystem, eliminating one of the few remaining dependency cycles in Zephyr.

Fixes #75319