### PR TITLE
gpio: axp192_gpio: Proper support for GPIO5 and Coverty fix

### DIFF
--- a/boards/m5stack/m5stack_core2/m5stack_core2_procpu.dts
+++ b/boards/m5stack/m5stack_core2/m5stack_core2_procpu.dts
@@ -157,7 +157,7 @@
 			compatible = "x-powers,axp192-gpio";
 			gpio-controller;
 			#gpio-cells = <2>;
-			ngpios = <6>;
+			ngpios = <7>;
 			status = "okay";
 
 			pwr_led: axp192_gpio1 {
@@ -179,7 +179,7 @@
 	bus_5v: bus_5v {
 		compatible = "regulator-fixed";
 		regulator-name = "bus_5v";
-		enable-gpios = <&axp192_gpio 5 GPIO_ACTIVE_HIGH>;
+		enable-gpios = <&axp192_gpio 6 GPIO_ACTIVE_HIGH>;
 	};
 
 	ft5336_touch: ft5336@38 {

--- a/boards/m5stack/m5stickc_plus/m5stickc_plus_procpu.dts
+++ b/boards/m5stack/m5stickc_plus/m5stickc_plus_procpu.dts
@@ -158,7 +158,7 @@
 			compatible = "x-powers,axp192-gpio";
 			gpio-controller;
 			#gpio-cells = <2>;
-			ngpios = <6>;
+			ngpios = <7>;
 			status = "okay";
 		};
 	};

--- a/dts/bindings/gpio/x-powers,axp192-gpio.yaml
+++ b/dts/bindings/gpio/x-powers,axp192-gpio.yaml
@@ -12,7 +12,8 @@ description: AXP192 GPIO Controller
     [2] GPIO2
     [3] GPIO3
     [4] GPIO4
-    [5] EXTEN
+    [5] GPIO5/NRSTO
+    [6] EXTEN
 
 compatible: "x-powers,axp192-gpio"
 
@@ -24,7 +25,7 @@ properties:
 
   ngpios:
     required: true
-    const: 6
+    const: 7
     description: |
       Number of GPIOs available on axp192.
 

--- a/include/zephyr/drivers/mfd/axp192.h
+++ b/include/zephyr/drivers/mfd/axp192.h
@@ -40,7 +40,7 @@ enum axp192_gpio_func {
 /**
  * @brief Maximum number of GPIOs supported by AXP192 PMIC.
  */
-#define AXP192_GPIO_MAX_NUM 6U
+#define AXP192_GPIO_MAX_NUM 7U
 
 /**
  * @defgroup mdf_interface_axp192 MFD AXP192 interface
@@ -54,7 +54,8 @@ enum axp192_gpio_func {
  *  [2]: GPIO2
  *  [3]: GPIO3
  *  [4]: GPIO4
- *  [5]: EXTEN
+ *  [5]: GPIO5/N_RSTO
+ *  [6]: EXTEN
  *
  * @ingroup mfd_interfaces
  * @{

--- a/tests/drivers/build_all/gpio/app.overlay
+++ b/tests/drivers/build_all/gpio/app.overlay
@@ -207,7 +207,7 @@
 					compatible = "x-powers,axp192-gpio";
 					gpio-controller;
 					#gpio-cells = <2>;
-					ngpios = <6>;
+					ngpios = <7>;
 				};
 			};
 


### PR DESCRIPTION
This modification adds proper support for GPIO5/N_RSTO. EXTEN
gpio is moving to gpio6.
This also fixes Coverity issue [#74751](https://github.com/MrMarteng/zephyr/issues/74751)

Signed-off-by: Martin Kiepfer <mrmarteng@teleschirm.org>