### PR TITLE
flash: nrf_qspi_nor: wait for erase to complete

### DIFF
--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -487,11 +487,12 @@ static int qspi_rdsr(const struct device *dev, uint8_t sr_num)
 }
 
 /* Wait until RDSR confirms write is not in progress. */
-static int qspi_wait_while_writing(const struct device *dev)
+static int qspi_wait_while_writing(const struct device *dev, k_timeout_t poll_period)
 {
 	int rc;
 
 	do {
+		k_sleep(poll_period);
 		rc = qspi_rdsr(dev, 1);
 	} while ((rc >= 0)
 		 && ((rc & SPI_NOR_WIP_BIT) != 0U));
@@ -562,7 +563,7 @@ static int qspi_wrsr(const struct device *dev, uint8_t sr_val, uint8_t sr_num)
 	 * corrupted.  Wait.
 	 */
 	if (rc == 0) {
-		rc = qspi_wait_while_writing(dev);
+		rc = qspi_wait_while_writing(dev, K_NO_WAIT);
 	}
 
 	return rc;
@@ -607,6 +608,16 @@ static int qspi_erase(const struct device *dev, uint32_t addr, uint32_t size)
 		if (res == NRFX_SUCCESS) {
 			addr += adj;
 			size -= adj;
+
+			/* Erasing flash pages takes a significant period of time and the
+			 * flash memory is unavailable to perform additional operations
+			 * until done.
+			 */
+			rc = qspi_wait_while_writing(dev, K_MSEC(10));
+			if (rc < 0) {
+				LOG_ERR("wait error at 0x%lx size %zu", (long)addr, size);
+				break;
+			}
 		} else {
 			LOG_ERR("erase error at 0x%lx size %zu", (long)addr, size);
 			rc = qspi_get_zephyr_ret_code(res);


### PR DESCRIPTION
Wait until the erase operation triggered by `qspi_erase` completes before returning. This aligns with the behaviour of other flash drivers like `spi_nor` and `soc_flash_nrf`.

A delay is added to the `qspi_wait_while_writing` to prevent the check from monopolising the CPU.