### PR TITLE
flash: nrf_qspi_nor: don't auto call `pm_device_runtime_enable`

### DIFF
--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -1110,16 +1110,6 @@ static int qspi_nor_init(const struct device *dev)
 		(void)nrfx_qspi_deactivate();
 	}
 
-#ifdef CONFIG_PM_DEVICE_RUNTIME
-	int rc2 = pm_device_runtime_enable(dev);
-
-	if (rc2 < 0) {
-		LOG_ERR("Failed to enable runtime power management: %d", rc2);
-	} else {
-		LOG_DBG("Runtime power management enabled");
-	}
-#endif
-
 #ifdef CONFIG_NORDIC_QSPI_NOR_XIP
 	if (rc == 0) {
 		/* Enable XIP mode for QSPI NOR flash, this will prevent the

--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -297,14 +297,12 @@ static inline void qspi_clock_div_restore(void)
 static void qspi_acquire(const struct device *dev)
 {
 	struct qspi_nor_data *dev_data = dev->data;
+	int rc;
 
-#if defined(CONFIG_PM_DEVICE_RUNTIME)
-	int rc = pm_device_runtime_get(dev);
-
+	rc = pm_device_runtime_get(dev);
 	if (rc < 0) {
 		LOG_ERR("pm_device_runtime_get failed: %d", rc);
 	}
-#endif
 #if defined(CONFIG_MULTITHREADING)
 	/* In multithreading, the driver can call qspi_acquire more than once
 	 * before calling qspi_release. Keeping count, so QSPI is deactivated
@@ -326,6 +324,7 @@ static void qspi_release(const struct device *dev)
 {
 	struct qspi_nor_data *dev_data = dev->data;
 	bool deactivate = true;
+	int rc;
 
 #if defined(CONFIG_MULTITHREADING)
 	/* The last thread to finish using the driver deactivates the QSPI */
@@ -344,13 +343,10 @@ static void qspi_release(const struct device *dev)
 
 	qspi_unlock(dev);
 
-#if defined(CONFIG_PM_DEVICE_RUNTIME)
-	int rc = pm_device_runtime_put(dev);
-
+	rc = pm_device_runtime_put(dev);
 	if (rc < 0) {
 		LOG_ERR("pm_device_runtime_put failed: %d", rc);
 	}
-#endif
 }
 
 static inline void qspi_wait_for_completion(const struct device *dev,


### PR DESCRIPTION
The `count` semaphore was being used as an atomic counter, so replace
it with an atomic variable, which is a simpler solution and enables
removing the conditionals with `PM_DEVICE_RUNTIME`.

The `pm_device_runtime_get` and `pm_device_runtime_put` functions work
correctly regardless of whether `PM_DEVICE_RUNTIME` is enabled or not.

Device drivers should not be calling `pm_device_runtime_enable` on
themselves, it should be left up to the application. If automatic
enabling is desired, `zephyr,pm-device-runtime-auto` exists as a
devicetree property.