### PR TITLE
doc: boards NXP VMU RT1170 remove broken links

### DIFF
--- a/boards/nxp/vmu_rt1170/doc/index.rst
+++ b/boards/nxp/vmu_rt1170/doc/index.rst
@@ -68,8 +68,6 @@ Hardware
 For more information about the MIMXRT1176 SoC and VMU RT1170 board, see
 these references:
 
-- `VMU RT1170 Website`_
-- `VMU RT1170 User Guide`_
 - `VMU RT1170 Schematics`_
 - `i.MX RT1170 Datasheet`_
 - `i.MX RT1170 Reference Manual`_
@@ -540,12 +538,6 @@ should see the following message in the terminal:
 
    ***** Booting Zephyr OS v3.4.0-xxxx-xxxxxxxxxxxxx *****
    Hello World! vmu_rt1170
-
-.. _VMU RT1170 Website:
-   https://www.nxp.com/part/VMU-RT1170
-
-.. _VMU RT1170 User Guide:
-   https://cognipilot.org/cerebri/boards/nxp_vmu_rt1170/
 
 .. _VMU RT1170 Schematics:
    https://github.com/CogniPilot/NXP-VMU_RT117x-HW


### PR DESCRIPTION
Referencing issue https://github.com/zephyrproject-rtos/zephyr/issues/75795

NXP and CogniPilot have removed documentation from their web pages.

Delete the broken links.

