### PR TITLE
drivers: espi: host_subs: npcx: fix LDN register definition of PM channel

### DIFF
--- a/drivers/espi/host_subs_npcx.c
+++ b/drivers/espi/host_subs_npcx.c
@@ -199,12 +199,12 @@ struct host_sub_npcx_data host_sub_data;
 #define EC_CFG_LDN_HCMD  0x12 /* PM Channel 2 */
 
 /* Index of EC (4E/4F) Configuration Register */
-#define EC_CFG_IDX_LDN             0x07
-#define EC_CFG_IDX_CTRL            0x30
-#define EC_CFG_IDX_CMD_IO_ADDR_H   0x60
-#define EC_CFG_IDX_CMD_IO_ADDR_L   0x61
-#define EC_CFG_IDX_DATA_IO_ADDR_H  0x62
-#define EC_CFG_IDX_DATA_IO_ADDR_L  0x63
+#define EC_CFG_IDX_LDN            0x07
+#define EC_CFG_IDX_CTRL           0x30
+#define EC_CFG_IDX_DATA_IO_ADDR_H 0x60
+#define EC_CFG_IDX_DATA_IO_ADDR_L 0x61
+#define EC_CFG_IDX_CMD_IO_ADDR_H  0x62
+#define EC_CFG_IDX_CMD_IO_ADDR_L  0x63
 
 /* LDN Activation Enable */
 #define EC_CFG_IDX_CTRL_LDN_ENABLE 0x01
@@ -1029,15 +1029,15 @@ void npcx_host_init_subs_host_domain(void)
 		host_c2h_write_io_cfg_reg(EC_CFG_IDX_LDN, EC_CFG_LDN_HCMD);
 #if defined(CONFIG_ESPI_PERIPHERAL_HOST_CMD_DATA_PORT_NUM)
 		/* Configure IO address of CMD portt (default: 0x200) */
-		host_c2h_write_io_cfg_reg(EC_CFG_IDX_CMD_IO_ADDR_H,
+		host_c2h_write_io_cfg_reg(EC_CFG_IDX_DATA_IO_ADDR_H,
 		 (CONFIG_ESPI_PERIPHERAL_HOST_CMD_DATA_PORT_NUM >> 8) & 0xff);
-		host_c2h_write_io_cfg_reg(EC_CFG_IDX_CMD_IO_ADDR_L,
+		host_c2h_write_io_cfg_reg(EC_CFG_IDX_DATA_IO_ADDR_L,
 		 CONFIG_ESPI_PERIPHERAL_HOST_CMD_DATA_PORT_NUM & 0xff);
 		/* Configure IO address of Data portt (default: 0x204) */
-		host_c2h_write_io_cfg_reg(EC_CFG_IDX_DATA_IO_ADDR_H,
+		host_c2h_write_io_cfg_reg(EC_CFG_IDX_CMD_IO_ADDR_H,
 		 ((CONFIG_ESPI_PERIPHERAL_HOST_CMD_DATA_PORT_NUM + 4) >> 8)
 		 & 0xff);
-		host_c2h_write_io_cfg_reg(EC_CFG_IDX_DATA_IO_ADDR_L,
+		host_c2h_write_io_cfg_reg(EC_CFG_IDX_CMD_IO_ADDR_L,
 		 (CONFIG_ESPI_PERIPHERAL_HOST_CMD_DATA_PORT_NUM + 4) & 0xff);
 #endif
 		/* Enable 'Host Command' io port (PM Channel 2) */


### PR DESCRIPTION
The register offset definition of the I/O port Data Base Address register (0x60, 0x61) and Command/Status Base Address register (0x62, 0x63) are reversed. This commit fixes it to avoid confusion.