### PR TITLE
Add uart driver support for NXP frdm_ke17z512

### DIFF
--- a/boards/nxp/frdm_ke17z512/frdm_ke17z512-pinctrl.dtsi
+++ b/boards/nxp/frdm_ke17z512/frdm_ke17z512-pinctrl.dtsi
@@ -38,4 +38,13 @@
 			slew-rate = "slow";
 		};
 	};
+
+	uart1_default: uart1_default {
+		group0 {
+			pinmux = <SCI1_RX_PTC16>,
+				<SCI1_TX_PTC17>;
+			drive-strength = "low";
+			slew-rate = "slow";
+		};
+	};
 };

--- a/dts/arm/nxp/nxp_ke17z512.dtsi
+++ b/dts/arm/nxp/nxp_ke17z512.dtsi
@@ -43,5 +43,23 @@
 				write-block-size = <8>;
 			};
 		};
+
+		uart0: uart@4006d000 {
+			compatible = "nxp,kinetis-uart";
+			reg = <0x4006d000 0x1000>;
+			interrupts = <21 0>;
+			interrupt-names = "status";
+			clocks = <&scg KINETIS_SCG_BUS_CLK>;
+			status = "disabled";
+		};
+
+		uart1: uart@4006e000 {
+			compatible = "nxp,kinetis-uart";
+			reg = <0x4006e000 0x1000>;
+			interrupts = <30 0>;
+			interrupt-names = "status";
+			clocks = <&scg KINETIS_SCG_BUS_CLK>;
+			status = "disabled";
+		};
 	};
 };

--- a/tests/drivers/uart/uart_basic_api/boards/frdm_ke17z512_uart.overlay
+++ b/tests/drivers/uart/uart_basic_api/boards/frdm_ke17z512_uart.overlay
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,shell-uart = &uart1;
+	};
+};
+
+/* This configuration is to test "UART" driver
+ * UART1_RX_PTC16(J4->10)
+ * UART1_TX_PTC17(J4->12)
+ */
+
+&uart1 {
+	status = "okay";
+	pinctrl-0 = <&uart1_default>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+};

--- a/tests/drivers/uart/uart_basic_api/testcase.yaml
+++ b/tests/drivers/uart/uart_basic_api/testcase.yaml
@@ -47,3 +47,13 @@ tests:
     filter: CONFIG_UART_CONSOLE
     depends_on: usb_device
     harness: keyboard
+  drivers.uart.basic_api.shell_ke17z9_uart:
+    tags:
+      - drivers
+      - uart
+    filter: CONFIG_UART_CONSOLE
+    harness: keyboard
+    platform_allow: frdm_ke17z512
+    extra_args:
+      - CONF_FILE=prj_shell.conf
+      - DTC_OVERLAY_FILE="boards/frdm_ke17z512_uart.overlay"


### PR DESCRIPTION
Tested `tests/drivers/uart/uart_basic_api` sample.