### PR TITLE
Add fgpio driver support for NXP frdm_ke17z and frdm_ke17z512

### DIFF
--- a/dts/arm/nxp/nxp_ke1xz.dtsi
+++ b/dts/arm/nxp/nxp_ke1xz.dtsi
@@ -193,6 +193,24 @@
 				#gpio-cells = <2>;
 				nxp,kinetis-port = <&porte>;
 			};
+
+			fgpioa: gpio@f8000000 {
+				compatible = "nxp,kinetis-gpio";
+				status = "disabled";
+				reg = <0xf8000000 0x40>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				nxp,kinetis-port = <&porta>;
+			};
+
+			fgpioe: gpio@f8000100 {
+				compatible = "nxp,kinetis-gpio";
+				status = "disabled";
+				reg = <0xf8000100 0x40>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				nxp,kinetis-port = <&porte>;
+			};
 		};
 
 		gpios1: gpios1@400ff040 {
@@ -225,6 +243,33 @@
 				compatible = "nxp,kinetis-gpio";
 				status = "disabled";
 				reg = <0xc0 0x40>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				nxp,kinetis-port = <&portd>;
+			};
+
+			fgpiob: gpio@f8000040 {
+				compatible = "nxp,kinetis-gpio";
+				status = "disabled";
+				reg = <0xf8000040 0x40>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				nxp,kinetis-port = <&portb>;
+			};
+
+			fgpioc: gpio@f8000080 {
+				compatible = "nxp,kinetis-gpio";
+				status = "disabled";
+				reg = <0xf8000080 0x40>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				nxp,kinetis-port = <&portc>;
+			};
+
+			fgpiod: gpio@f80000c0 {
+				compatible = "nxp,kinetis-gpio";
+				status = "disabled";
+				reg = <0xf80000c0 0x40>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				nxp,kinetis-port = <&portd>;

--- a/tests/drivers/gpio/gpio_basic_api/boards/frdm_ke17z_fgpio.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/frdm_ke17z_fgpio.overlay
@@ -7,11 +7,11 @@
 / {
 	resources {
 		compatible = "test-gpio-basic-api";
-		out-gpios = <&gpioc 6 0>; /* Arduino D0 J1-2 */
-		in-gpios  = <&gpioc 7 0>; /* Arduino D1 J1-4 */
+		out-gpios = <&fgpioa 14 0>; /* J1-16 */
+		in-gpios  = <&fgpioa 17 0>; /* J1-14 */
 	};
 };
 
-&gpioc {
+&fgpioa{
 	status = "okay";
 };

--- a/tests/drivers/gpio/gpio_basic_api/testcase.yaml
+++ b/tests/drivers/gpio/gpio_basic_api/testcase.yaml
@@ -20,3 +20,13 @@ tests:
   drivers.gpio.mr_canhubk3_wkpu:
     platform_allow: mr_canhubk3
     extra_args: "DTC_OVERLAY_FILE=boards/mr_canhubk3_wkpu.overlay"
+
+  drivers.gpio.2pin_ke17z_fgpio:
+    min_flash: 34
+    filter: dt_compat_enabled("test-gpio-basic-api")
+    platform_allow:
+      - frdm_ke17z
+      - frdm_ke17z512
+    extra_args: "DTC_OVERLAY_FILE=boards/frdm_ke17z_fgpio.overlay"
+    harness_config:
+      fixture: fgpio_loopback


### PR DESCRIPTION
Tested `tests/drivers/gpio/gpio_basic_api` sample.