### PR TITLE
doc: release 3.6: no CACHE_MANAGEMENT by default on stm32h7/f7

### DIFF
--- a/doc/releases/migration-guide-3.6.rst
+++ b/doc/releases/migration-guide-3.6.rst
@@ -46,6 +46,9 @@ Kernel
   :kconfig:option:`CONFIG_HEAP_MEM_POOL_IGNORE_MIN` option has been introduced (which defaults
   being disabled).
 
+* STM32H7 and STM32F7 should now activate the cache (Icache and Dcache) by setting explicitly
+  the  ``CONFIG_CACHE_MANAGEMENT`` to ``y``.
+
 Boards
 ******
 


### PR DESCRIPTION
Mentioning that stm32h7 and stm32F7 series do not have the CONFIG_CACHE_MANAGEMENT by default. The application must explicitely set CONFIG_CACHE_MANAGEMENT=y to activate the cache (Icache, Dcache) on those stm32 series.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/75487