### PR TITLE
soc/espressif/esp32c6: Do not set HAS_PM or HAS_POWEROFF

### DIFF
--- a/soc/espressif/esp32c6/Kconfig
+++ b/soc/espressif/esp32c6/Kconfig
@@ -14,8 +14,6 @@ config SOC_SERIES_ESP32C6
 	select RISCV_ISA_EXT_ZICSR
 	select HAS_ESPRESSIF_HAL
 	select XIP if !MCUBOOT
-	select HAS_PM
-	select HAS_POWEROFF
 
 if SOC_SERIES_ESP32C6
 


### PR DESCRIPTION
The source files required for this features are not present in the tree.
So if CONFIG_PM or CONFIG_POWEROFF are enabled, there would be a cmake failure.

Let's just indicate these features are not supported in kconfig.

Fixes #75878