### PR TITLE
boards: riscv: neorv32: Add platform and model name

### DIFF
--- a/boards/others/neorv32/neorv32.dts
+++ b/boards/others/neorv32/neorv32.dts
@@ -11,6 +11,9 @@
 #include <mem.h>
 
 / {
+	model = "NEORV32";
+	compatible = "neorv32";
+
 	aliases {
 		led0 = &led0;
 		led1 = &led1;


### PR DESCRIPTION
NEORV32 doesn't provide platform and model name in it's dts file. This makes hard for some tools to determine with what board they're working with. Fixed it by adding model and platform name in it's dts file.