### PR TITLE
twister:pytest: Use configured shell prompt in pytest-harness

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/fixtures.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/fixtures.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+from pathlib import Path
 from typing import Generator, Type
 
 import pytest
@@ -13,6 +14,7 @@ from twister_harness.device.factory import DeviceFactory
 from twister_harness.twister_harness_config import DeviceConfig, TwisterHarnessConfig
 from twister_harness.helpers.shell import Shell
 from twister_harness.helpers.mcumgr import MCUmgr
+from twister_harness.helpers.utils import find_in_config
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +60,9 @@ def dut(request: pytest.FixtureRequest, device_object: DeviceAdapter) -> Generat
 def shell(dut: DeviceAdapter) -> Shell:
     """Return ready to use shell interface"""
     shell = Shell(dut, timeout=20.0)
+    if prompt := find_in_config(Path(dut.device_config.app_build_dir) / 'zephyr' / '.config',
+                                'CONFIG_SHELL_PROMPT_UART'):
+        shell.prompt = prompt
     logger.info('Wait for prompt')
     if not shell.wait_for_prompt():
         pytest.fail('Prompt not found')

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/helpers/utils.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/helpers/utils.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import logging
+import re
+
+from pathlib import Path
+
+
+logger = logging.getLogger(__name__)
+
+
+def find_in_config(config_file: Path | str, config_key: str) -> str:
+    """Find key in config file"""
+    re_key = re.compile(rf'{config_key}=(.+)')
+    with open(config_file) as f:
+        lines = f.readlines()
+    for line in lines:
+        if m := re_key.match(line):
+            logger.debug('Found matching key: %s' % line.strip())
+            return m.group(1).strip('"\'')
+    logger.debug('Not found key: %s' % config_key)
+    return ''
+
+
+def match_lines(output_lines: list[str], searched_lines: list[str]) -> None:
+    """Check all lines exist in the output"""
+    for sl in searched_lines:
+        assert any(sl in line for line in output_lines)
+
+
+def match_no_lines(output_lines: list[str], searched_lines: list[str]) -> None:
+    """Check lines not found in the output"""
+    for sl in searched_lines:
+        assert all(sl not in line for line in output_lines)

--- a/tests/boot/with_mcumgr/pytest/test_downgrade_prevention.py
+++ b/tests/boot/with_mcumgr/pytest/test_downgrade_prevention.py
@@ -7,13 +7,12 @@ import logging
 
 from pathlib import Path
 from twister_harness import DeviceAdapter, Shell, MCUmgr
-from utils import (
+from twister_harness.helpers.utils import (
     find_in_config,
     match_lines,
-    match_no_lines,
-    check_with_shell_command,
-    check_with_mcumgr_command,
+    match_no_lines
 )
+from utils import check_with_shell_command, check_with_mcumgr_command
 from test_upgrade import create_signed_image
 
 

--- a/tests/boot/with_mcumgr/pytest/test_upgrade.py
+++ b/tests/boot/with_mcumgr/pytest/test_upgrade.py
@@ -8,14 +8,13 @@ import logging
 
 from pathlib import Path
 from twister_harness import DeviceAdapter, Shell, MCUmgr
-from west_sign_wrapper import west_sign_with_imgtool
-from utils import (
+from twister_harness.helpers.utils import (
     find_in_config,
     match_lines,
-    match_no_lines,
-    check_with_shell_command,
-    check_with_mcumgr_command,
+    match_no_lines
 )
+from utils import check_with_shell_command, check_with_mcumgr_command
+from west_sign_wrapper import west_sign_with_imgtool
 
 logger = logging.getLogger(__name__)
 

--- a/tests/boot/with_mcumgr/pytest/utils.py
+++ b/tests/boot/with_mcumgr/pytest/utils.py
@@ -4,37 +4,12 @@
 from __future__ import annotations
 
 import logging
-import re
 
-from pathlib import Path
 from twister_harness import Shell, MCUmgr
 from twister_harness.helpers.shell import ShellMCUbootCommandParsed
 
 
 logger = logging.getLogger(__name__)
-
-
-def find_in_config(config_file: Path | str, config_key: str) -> str:
-    re_key = re.compile(rf'{config_key}=(.+)')
-    with open(config_file) as f:
-        lines = f.readlines()
-    for line in lines:
-        if m := re_key.match(line):
-            logger.debug('Found matching key: %s' % line.strip())
-            return m.group(1).strip('"\'')
-    return ''
-
-
-def match_lines(output_lines: list[str], searched_lines: list[str]) -> None:
-    """Check all lines exist in the output"""
-    for sl in searched_lines:
-        assert any(sl in line for line in output_lines)
-
-
-def match_no_lines(output_lines: list[str], searched_lines: list[str]) -> None:
-    """Check lines not found in the output"""
-    for sl in searched_lines:
-        assert all(sl not in line for line in output_lines)
 
 
 def check_with_shell_command(shell: Shell, version: str, swap_type: str | None = None) -> None:


### PR DESCRIPTION
Read CONFIG_SHELL_PROMPT_UART from config file and use them in shell fixture in pytest-harness package.

Moved helper methods from tests/boot/with_mcumgr to pytest-harness package. It can be reused by other tests.

Feature mentioned in discord channel: https://discord.com/channels/720317445772017664/991025779993370654/1261295314225336411


