### PR TITLE
jwt: remove jwt_payload_len function

### DIFF
--- a/include/zephyr/data/jwt.h
+++ b/include/zephyr/data/jwt.h
@@ -110,12 +110,6 @@ int jwt_sign(struct jwt_builder *builder,
 	     const char *der_key,
 	     size_t der_key_len);
 
-
-static inline size_t jwt_payload_len(struct jwt_builder *builder)
-{
-	return (builder->buf - builder->base);
-}
-
 #ifdef __cplusplus
 }
 #endif

--- a/tests/subsys/jwt/src/main.c
+++ b/tests/subsys/jwt/src/main.c
@@ -54,7 +54,7 @@ ZTEST(jwt_tests, test_jwt)
 	zassert_equal(build.overflowed, false, "Not overflow");
 
 	printk("JWT:\n%s\n", buf);
-	printk("len: %zd\n", jwt_payload_len(&build));
+	printk("len: %zd\n", strlen(buf));
 }
 
 ZTEST_SUITE(jwt_tests, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
The function jwt_payload_len doesn't return payload length but returns used data in builder->buf

If jwt_payload_len is called after jwt_init_builder, header length will be returned
If jwt_payload_len is called after jwt_add_payload, header+payload length will be returned
If jwt_payload_len is called after jwt_sign, header+payload+sign length will be returned

So, this commit removes the function and uses strlen instead