### PR TITLE
kernel: timeout: Ensure that there are no premature timeouts

### DIFF
--- a/include/zephyr/drivers/timer/system_timer.h
+++ b/include/zephyr/drivers/timer/system_timer.h
@@ -33,7 +33,7 @@ extern "C" {
  *
  * Informs the system clock driver that the next needed call to
  * sys_clock_announce() will not be until the specified number of ticks
- * from the current time have elapsed.  Note that spurious calls
+ * relative to the last announcement.  Note that spurious calls
  * to sys_clock_announce() are allowed (i.e. it's legal to announce
  * every tick and implement this function as a noop), the requirement
  * is that one tick announcement should occur within one tick BEFORE
@@ -102,7 +102,7 @@ void sys_clock_announce(int32_t ticks);
 /**
  * @brief Ticks elapsed since last sys_clock_announce() call
  *
- * Queries the clock driver for the current time elapsed since the
+ * Queries the clock driver for the current time elapsed (rounded up) since the
  * last call to sys_clock_announce() was made.  The kernel will call
  * this with appropriate locking, the driver needs only provide an
  * instantaneous answer.

--- a/tests/kernel/timer/timer_behavior/src/jitter_drift.c
+++ b/tests/kernel/timer/timer_behavior/src/jitter_drift.c
@@ -333,8 +333,15 @@ static void do_test_using(void (*sample_collection_fn)(void), const char *mechan
 		     "Standard deviation (in microseconds) outside expected bound");
 
 	/* Validate the timer drift (accuracy over time) is within a configurable bound */
-	zassert_true(abs(time_diff_us) < CONFIG_TIMER_TEST_MAX_DRIFT,
+	if (strcmp(mechanism, "builtin") == 0) {
+		/* There should be no drift only when periodic timer is used but when new timer
+		 * is started from the callback of the previous timer then new time setting is
+		 * relative to that moment and not to the expiration of previous timer and drift
+		 * will occur.
+		 */
+		zassert_true(abs(time_diff_us) < CONFIG_TIMER_TEST_MAX_DRIFT,
 		     "Drift (in microseconds) outside expected bound");
+	}
 }
 
 ZTEST(timer_jitter_drift, test_jitter_drift_timer_period)

--- a/tests/kernel/timer/timer_behavior/src/main.c
+++ b/tests/kernel/timer/timer_behavior/src/main.c
@@ -6,9 +6,202 @@
 
 #include <zephyr/ztest.h>
 
+#define REPEAT 8
+
+static const k_timeout_t test_timeout = K_MSEC(10);
+static int64_t exp_cyc;
+
+enum timer_premature_test_mode {
+	FROM_THREAD,
+	FROM_IRQ,
+	FROM_IRQ_POST_DELAY,
+};
+
+/* Test data structure. */
+struct test_data {
+	struct k_timer timer;
+	uint32_t delay;
+	struct k_sem sem;
+
+	/* In relative timeouts it hold timestamp when k_timer_start was called. */
+	uint32_t start_ts;
+
+	/* Ticks value when next time shall expire. */
+	k_ticks_t ticks;
+
+	/* Counting down number of iterations. */
+	uint32_t iter;
+
+	/* Run details when test failed. */
+	uint32_t error_val;
+	uint32_t error_iter;
+
+	/* Test mode. */
+	enum timer_premature_test_mode mode;
+
+	/* if true absolute timers are used. */
+	bool abs;
+};
+
+static void timer_start(struct test_data *data)
+{
+	k_timeout_t t;
+
+	if (data->abs) {
+		/* Get absolute timeout for test ticks from now. */
+		data->ticks = k_cyc_to_ticks_near32(k_cycle_get_32()) + test_timeout.ticks;
+		t = K_TIMEOUT_ABS_TICKS(data->ticks);
+	} else {
+		/* Store the moment when clock is started. */
+		data->start_ts = k_cycle_get_32();
+		t = test_timeout;
+	}
+
+	k_timer_start(&data->timer, t, K_NO_WAIT);
+}
+
+/* Expiration callback */
+static void test_premature_handler(struct k_timer *timer)
+{
+	static const uint32_t delay_inc = k_ticks_to_us_near32(2) / REPEAT;
+	struct test_data *data = CONTAINER_OF(timer, struct test_data, timer);
+	int64_t now = k_cycle_get_32();
+	int64_t diff = now - data->start_ts;
+	bool ok;
+
+	/* Check if timer did not expire prematurely. */
+	if (data->abs) {
+		ok = k_cyc_to_ticks_near32(now) >= (uint32_t)data->ticks;
+	} else {
+		ok = diff >= exp_cyc;
+	}
+
+	if (!ok) {
+		/* Timeout occurred earlier than expected. Don't use zassert
+		 * here because we are in the interrupt context.
+		 */
+		data->error_val = diff;
+		data->error_iter = REPEAT - data->iter;
+		data->iter = 0;
+	} else {
+		data->iter--;
+	}
+
+	/* Busy wait simulates delay between kernel timeout expiration and the moment
+	 * when next timer is started. In real life application it may occur due to
+	 * multiple timers expiring simultaneously, some processing happens in
+	 * the timer handler or higher priority interrupt preempting current context.
+	 */
+	if (data->mode != FROM_IRQ_POST_DELAY) {
+		k_busy_wait(data->delay);
+	}
+
+	data->delay += delay_inc;
+
+	if (data->iter == 0) {
+		/* Test end. Wake up test thread. */
+		k_sem_give(&data->sem);
+	} else if ((data->mode == FROM_IRQ) || (data->mode == FROM_IRQ_POST_DELAY)) {
+		timer_start(data);
+		if (data->mode == FROM_IRQ_POST_DELAY) {
+			/* Simulated delay. */
+			k_busy_wait(data->delay);
+		}
+	}
+}
+
+/* Test starts same single shot timer number of times. Depending on the test mode
+ * next timer is started from thread or from the expiration callback.
+ *
+ * @param mode Test mode.
+ * @param abs If true then absolute timers are started else relative.
+ */
+static void test_timer_premature(enum timer_premature_test_mode mode, bool abs)
+{
+	int err;
+	static struct test_data tdata;
+
+	memset(&tdata, 0, sizeof(tdata));
+	tdata.abs = abs;
+	tdata.mode = mode;
+	tdata.iter = REPEAT;
+	exp_cyc = k_ticks_to_cyc_near64(test_timeout.ticks);
+	k_timer_init(&tdata.timer, test_premature_handler, NULL);
+	k_sem_init(&tdata.sem, 0, 1);
+
+	if (mode == FROM_THREAD) {
+		for (int i = 0; i < REPEAT; i++) {
+			timer_start(&tdata);
+			k_msleep(k_ticks_to_ms_ceil64(test_timeout.ticks) + 5);
+		}
+	} else {
+		timer_start(&tdata);
+	}
+
+	uint64_t ticks = test_timeout.ticks;
+	uint32_t total_timeout = (uint32_t)k_ticks_to_ms_ceil64(ticks) * REPEAT + 10;
+
+	err = k_sem_take(&tdata.sem, K_MSEC(total_timeout));
+	zassert_equal(err, 0);
+
+	zassert_equal(tdata.error_val, 0,
+		"Test failed, on %d iteration timer expired earlier than expected %d, exp:%d",
+		tdata.error_iter, tdata.error_val, exp_cyc);
+
+}
+
+/* Relative timer started from the expiration handler with variable delay added
+ * after timer start.
+ */
+ZTEST(timer_premature, test_timer_from_irq_post_delay)
+{
+	test_timer_premature(FROM_IRQ_POST_DELAY, false);
+}
+
+/* Relative timer started from the expiration handler with variable delay added
+ * before timer start.
+ */
+ZTEST(timer_premature, test_timer_from_irq)
+{
+	test_timer_premature(FROM_IRQ, false);
+}
+
+/* Relative timer started from the thread.
+ */
+ZTEST(timer_premature, test_timer_from_thread)
+{
+	test_timer_premature(FROM_THREAD, false);
+}
+
+/* Absolute timer started from the expiration handler with variable delay added
+ * after timer start.
+ */
+ZTEST(timer_premature, test_abs_timer_from_irq_post_delay)
+{
+	test_timer_premature(FROM_IRQ_POST_DELAY, true);
+}
+
+/* Absolute timer started from the expiration handler with variable delay added
+ * before timer start.
+ */
+ZTEST(timer_premature, test_abs_timer_from_irq)
+{
+	test_timer_premature(FROM_IRQ, true);
+}
+
+/* Absolute timer started from the thread.
+ */
+ZTEST(timer_premature, test_abs_timer_from_thread)
+{
+	test_timer_premature(FROM_THREAD, true);
+}
+
+ZTEST_SUITE(timer_premature, NULL, NULL, NULL, NULL, NULL);
+
 void test_main(void)
 {
 	ztest_run_test_suite(timer_jitter_drift, false, 1, 1);
+	ztest_run_test_suite(timer_premature, false, 1, 1);
 #ifndef CONFIG_TIMER_EXTERNAL_TEST
 	ztest_run_test_suite(timer_tick_train, false, 1, 1);
 #endif


### PR DESCRIPTION
I've noticed that it is possible that timer will expire prematurely if it is started from the timer expiration handler. I assume that it is unacceptable as timer must never expire before requested timeout (absolute or relative). The reason for that is that when `z_add_timeout` is called from the expiration handler then requested ticks are not adjusted by ticks elapsed from the latest announcement so essentially it becomes relative to the announcement and not to the moment when user calls `k_timer_start` in the handler so timer will expire earlier than expected depending on the distance between announcement and `k_timer_start` and it may vary depending on higher interrupt preemption, multiple timers expiring simultaneously or some processing done in the handler before staring next timer.

Let me try to explain current status.
Current timeouts are "floating" because they do not have common anchor. They will expire more or less when expected but IMO due to this floating it requires more calculation and can result in premature expiration. It is floating because system_clock API `sys_clock_set_timeout(ticks)` is taking ticks which are relative to `now`. Flow is following:
- `z_add_timeout` is called with relative ticks
- ticks are incremented by the number of ticks elapsed from the latest announcement (to allow comparison with other timeouts). This step is not performed if called from within the expiration handler (due to that timer may expire prematurely).
- when next pending timeout is scheduled we take this delta ticks value and decrement it by number of ticks elapsed from latest announcement to get ticks relative to `now`. Note that elapsed time here and in the previous step may differ. We need to calculate it twice and do some rounding to ticks.
- Timer driver is setting timeout for request ticks from `now` (may need to round it to the tick boundary).

There are 3 different `now`s used for ticks calculation and that is what is meant by "floating" without anchor. The only anchor known to the kernel/timeout and system timer is the last announcement then why not to use it.
 
My proposal is to change `sys_clock_set_timeout(ticks)` to use ticks relative to the last announcement. That simplifies the driver (because it knows when last announcement occurred) and kernel timeout (because ticks calculated during `z_add_timeout` don't need to be adjusted any more).

I've added a tests for premature timeouts to `tests/kernel/timer/timer_behavior`.
I've also modified test with jitter drift because it was actually validating current behavior by expected that calling a chain of timeouts restarted from the expiration handler will take `n` * `timeout` without any aggregated error. This assumption is true for periodic timer where we can expect no aggregated error but when relative timer is started from the expiration handler then there will be a cumulative delay.

PR is mainly opened for discussion since it is a change that would require all system clock timers adjustment and currently it is only done for Nordic RTC and GRTC drivers (where it proved to work better by passing all tests and simplified driver implementation).