### PR TITLE
sensor: bme680: support power domains

### DIFF
--- a/drivers/sensor/bosch/bme680/bme680.c
+++ b/drivers/sensor/bosch/bme680/bme680.c
@@ -320,6 +320,10 @@ static int bme680_read_compensation(const struct device *dev)
 	uint8_t buff[BME680_LEN_COEFF_ALL];
 	int err = 0;
 
+	if (data->has_read_compensation) {
+		return 0;
+	}
+
 	err = bme680_reg_read(dev, BME680_REG_COEFF1, buff, BME680_LEN_COEFF1);
 	if (err < 0) {
 		return err;
@@ -373,6 +377,7 @@ static int bme680_read_compensation(const struct device *dev)
 	data->res_heat_range = ((buff[39] & BME680_MSK_RH_RANGE) >> 4);
 	data->range_sw_err = ((int8_t)(buff[41] & BME680_MSK_RANGE_SW_ERR)) / 16;
 
+	data->has_read_compensation = true;
 	return 0;
 }
 

--- a/drivers/sensor/bosch/bme680/bme680.h
+++ b/drivers/sensor/bosch/bme680/bme680.h
@@ -196,6 +196,7 @@ struct bme680_data {
 	uint8_t res_heat_range;
 	int8_t res_heat_val;
 	int8_t range_sw_err;
+	bool has_read_compensation;
 
 	/* Calculated sensor values. */
 	int32_t calc_temp;


### PR DESCRIPTION
Support the BME680 being on a power domain, which may not be powered at boot. For example, Nordic Thingy53.

Example of a power cycling workflow

```
	const struct device *bme = DEVICE_DT_GET_ANY(bosch_bme680);
	struct sensor_value value;
	int rc;

	for (;;) {
		LOG_INF("Uptime: %6d seconds", k_uptime_seconds());

		pm_device_runtime_get(bme);

		rc = sensor_sample_fetch(bme);
		LOG_INF("sensor_sample_fetch: %d", rc);
		rc = sensor_channel_get(bme, SENSOR_CHAN_AMBIENT_TEMP, &value);
		LOG_INF("Temperature: %d.%06d", value.val1, value.val2);

		k_sleep(K_SECONDS(1));
		pm_device_runtime_put(bme);

		k_sleep(K_SECONDS(4));
	}
```

```
[00:00:04.040,466] <inf> app: Uptime:      4 seconds
[00:00:04.040,527] <inf> power_domain_gpio: tck106ag is now ON
[00:00:04.042,846] <dbg> bme680: bme680_power_up: BME680 chip detected
[00:00:04.282,196] <dbg> bme680: bme680_sample_fetch: New data after 182 ms
[00:00:04.282,714] <inf> app: sensor_sample_fetch: 0
[00:00:04.282,714] <inf> app: Temperature: 21.570000
[00:00:05.282,806] <inf> power_domain_gpio: tck106ag is now OFF
[00:00:09.282,897] <inf> app: Uptime:      9 seconds
[00:00:09.283,050] <inf> power_domain_gpio: tck106ag is now ON
[00:00:09.285,339] <dbg> bme680: bme680_power_up: BME680 chip detected
[00:00:09.523,986] <dbg> bme680: bme680_sample_fetch: New data after 183 ms
[00:00:09.524,475] <inf> app: sensor_sample_fetch: 0
[00:00:09.524,475] <inf> app: Temperature: 21.650000
[00:00:10.524,597] <inf> power_domain_gpio: tck106ag is now OFF
```
