### PR TITLE
twister: Skip scanning non-ztest tests in Twister

### DIFF
--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -542,12 +542,19 @@ class TestPlan:
                 try:
                     parsed_data = TwisterConfigParser(suite_yaml_path, self.suite_schema)
                     parsed_data.load()
-                    subcases, ztest_suite_names = scan_testsuite_path(suite_path)
+                    subcases = None
+                    ztest_suite_names = None
 
                     for name in parsed_data.scenarios.keys():
                         suite_dict = parsed_data.get_scenario(name)
                         suite = TestSuite(root, suite_path, name, data=suite_dict, detailed_test_id=self.options.detailed_test_id)
-                        suite.add_subcases(suite_dict, subcases, ztest_suite_names)
+                        if suite.harness in ['ztest', 'test']:
+                            if subcases is None:
+                                # scan it only once per testsuite
+                                subcases, ztest_suite_names = scan_testsuite_path(suite_path)
+                            suite.add_subcases(suite_dict, subcases, ztest_suite_names)
+                        else:
+                            suite.add_subcases(suite_dict)
                         if testsuite_filter:
                             scenario = os.path.basename(suite.name)
                             if suite.name and (suite.name in testsuite_filter or scenario in testsuite_filter):

--- a/scripts/pylib/twister/twisterlib/testsuite.py
+++ b/scripts/pylib/twister/twisterlib/testsuite.py
@@ -423,21 +423,22 @@ class TestSuite(DisablePyTestCollectionMixin):
         if self.harness == 'console' and not self.harness_config:
             raise Exception('Harness config error: console harness defined without a configuration.')
 
-    def add_subcases(self, data, parsed_subcases, suite_names):
+    def add_subcases(self, data, parsed_subcases=None, suite_names=None):
         testcases = data.get("testcases", [])
         if testcases:
             for tc in testcases:
                 self.add_testcase(name=f"{self.id}.{tc}")
         else:
-            # only add each testcase once
-            for sub in set(parsed_subcases):
-                name = "{}.{}".format(self.id, sub)
-                self.add_testcase(name)
-
             if not parsed_subcases:
                 self.add_testcase(self.id, freeform=True)
+            else:
+                # only add each testcase once
+                for sub in set(parsed_subcases):
+                    name = "{}.{}".format(self.id, sub)
+                    self.add_testcase(name)
 
-        self.ztest_suite_names = suite_names
+        if suite_names:
+            self.ztest_suite_names = suite_names
 
     def add_testcase(self, name, freeform=False):
         tc = TestCase(name=name, testsuite=self)

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -1504,6 +1504,7 @@ def test_projectbuilder_process(
     instance_mock.run = instance_run
     instance_mock.handler = mock.Mock()
     instance_mock.handler.ready = instance_handler_ready
+    instance_mock.testsuite.harness = 'test'
     env_mock = mock.Mock()
 
     pb = ProjectBuilder(instance_mock, env_mock, mocked_jobserver)


### PR DESCRIPTION
Twister scans C-files to find testcases that are implemented using ZTest framework. Also runs scanning of Elf files after building. Skip scanning files if it is not required.

With this changes Twister will skip unnecessary scanning of files (to save time and resources) - for `console` and `pytest` harnesses.
In downstream projects, there are also scenarios using `harness: console` on ZTest project (maybe it is wrong, but such a tests exists, e.g.: https://github.com/nrfconnect/sdk-nrf/blob/main/tests/subsys/bootloader/bl_validation_neg/testcase.yaml )
After scanning files there are added testcases to testsuite, however those testcases are not updated (because a console harness is used) and those testcases are wrongly added to test report.
