### PR TITLE
doc: toolchains: zephyr: remove mentions to M1

### DIFF
--- a/doc/develop/toolchains/zephyr_sdk.rst
+++ b/doc/develop/toolchains/zephyr_sdk.rst
@@ -151,7 +151,7 @@ Zephyr SDK installation
             curl -L -O |sdk-url-macos|
             curl -L |sdk-url-macos-sha| | shasum --check --ignore-missing
 
-         If your host architecture is 64-bit ARM (Apple Silicon, also known as M1), replace
+         If your host architecture is 64-bit ARM (Apple Silicon), replace
          ``x86_64`` with ``aarch64`` in order to download the 64-bit ARM macOS SDK.
 
       #. Extract the Zephyr SDK bundle archive:


### PR DESCRIPTION
Apple has released other processors, e.g. M2 or M3, so Apple Silicon is no longer a synonym of M1.