### PR TITLE
twister: pytest: Allow using pytest-args from command file and yaml

### DIFF
--- a/doc/develop/test/pytest.rst
+++ b/doc/develop/test/pytest.rst
@@ -97,6 +97,8 @@ There are two ways for passing extra arguments to the called pytest subprocess:
       -s samples/subsys/testsuite/pytest/shell/sample.pytest.shell \
       --pytest-args='-k test_shell_print_version'
 
+   The command line arguments will extend those from the .yaml file. If the same argument is
+   present in both places, the one from the command line will take precedence.
 
 Fixtures
 ********

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -234,7 +234,7 @@ Artificially long but functional example:
     parser.add_argument(
         "--pytest-args", action="append",
         help="""Pass additional arguments to the pytest subprocess. This parameter
-        will override the pytest_args from the harness_config in YAML file.
+        will extend the pytest_args from the harness_config in YAML file.
         """)
 
     valgrind_asan_group.add_argument(

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -421,12 +421,8 @@ class Pytest(Harness):
 
         if handler.options.pytest_args:
             command.extend(handler.options.pytest_args)
-            if pytest_args_yaml:
-                logger.warning(f'The pytest_args ({handler.options.pytest_args}) specified '
-                               'in the command line will override the pytest_args defined '
-                               f'in the YAML file {pytest_args_yaml}')
-        else:
-            command.extend(pytest_args_yaml)
+
+        command.extend(pytest_args_yaml)
 
         return command
 

--- a/scripts/tests/twister/pytest_integration/test_harness_pytest.py
+++ b/scripts/tests/twister/pytest_integration/test_harness_pytest.py
@@ -74,7 +74,7 @@ def test_pytest_command_extra_args(testinstance: TestInstance):
 
 def test_pytest_command_extra_args_in_options(testinstance: TestInstance):
     pytest_harness = Pytest()
-    pytest_args_from_yaml = '-k test_from_yaml'
+    pytest_args_from_yaml = '--extra-option'
     pytest_args_from_cmd = ['-k', 'test_from_cmd']
     testinstance.testsuite.harness_config['pytest_args'] = [pytest_args_from_yaml]
     testinstance.handler.options.pytest_args = pytest_args_from_cmd
@@ -82,7 +82,7 @@ def test_pytest_command_extra_args_in_options(testinstance: TestInstance):
     command = pytest_harness.generate_command()
     assert pytest_args_from_cmd[0] in command
     assert pytest_args_from_cmd[1] in command
-    assert pytest_args_from_yaml not in command
+    assert pytest_args_from_yaml in command
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Extend pytest-args from configuration yaml file with args from command line instead of overwriting.

Some tests are using `pytest-args` in yaml file. Now, after adding `--pytest-args` to command line, args from yaml file are overwritten (with a warning message).
With current change it is possible to filter pytest scenarios, without overwriting yaml configuration. It can be also useful in testing application with different parameters, or to filter it out in CI using predefined markers.

one can tests with:
`scripts/twister -c -vv  -p qemu_x86 -T tests/subsys/logging/dictionary -s logging.dictionary.fpu --pytest-args="-k test_logging_dictionary"`
or
`scripts/twister -c -vv  -p qemu_x86 -T tests/subsys/debug/gdbstub -s debug.gdbstub.breakpoints --pytest-args="-m not slow"`