### PR TITLE
arc: nsim: vpx5: fix SoC config issue which leads to cmake error

### DIFF
--- a/soc/snps/nsim/arc_classic/soc.yml
+++ b/soc/snps/nsim/arc_classic/soc.yml
@@ -15,7 +15,7 @@ family:
           - name: nsim_hs5x_smp
           - name: nsim_hs6x
           - name: nsim_hs6x_smp
-      - name: nsim_vpx
+      - name: nsim_vpx5
         socs:
           - name: nsim_vpx5
       - name: nsim_sem

--- a/soc/snps/nsim/arc_classic/vpx5/Kconfig
+++ b/soc/snps/nsim/arc_classic/vpx5/Kconfig
@@ -1,2 +1,5 @@
 # Copyright (c) 2024 Synopsys, Inc.
 # SPDX-License-Identifier: Apache-2.0
+
+config SOC_SERIES_NSIM_VPX5
+	select ARC


### PR DESCRIPTION
After recent nsim SoCs & boards reorganization the `SOC_SERIES_*` config is missing for vpx5 SoC which leads to cmake errors when building against nsim/nsim_vpx5 configuration.

Fixes: #72862
Fixes: #75898