### PR TITLE
tests: stray kconfig test

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -790,6 +790,7 @@ Missing SoC names or CONFIG_SOC vs soc.yml out of sync:
         grep_stdout = git("grep", "--line-number", "-I", "--null",
                           "--perl-regexp", regex, "--", ":!/doc/releases",
                           ":!/doc/security/vulnerabilities.rst",
+                          ":!/tests/kconfig/stray/test.config",
                           cwd=Path(GIT_TOP))
 
         # splitlines() supports various line terminators

--- a/tests/kconfig/stray/CMakeLists.txt
+++ b/tests/kconfig/stray/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(stray_kconfig)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/kconfig/stray/prj.conf
+++ b/tests/kconfig/stray/prj.conf
@@ -1,0 +1,1 @@
+# nothing here

--- a/tests/kconfig/stray/pytest/conftest.py
+++ b/tests/kconfig/stray/pytest/conftest.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2024 Intel Corporation.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+# add option "--cmdopt" to pytest, or it will report "unknown option"
+# this option is passed from twister.
+def pytest_addoption(parser):
+    parser.addoption(
+        '--test_kconfig'
+    )
+
+@pytest.fixture()
+def test_kconfig(request):
+    return request.config.getoption('--test_kconfig')

--- a/tests/kconfig/stray/pytest/test_sample.py
+++ b/tests/kconfig/stray/pytest/test_sample.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2020 Intel Corporation.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+import pytest
+from twister_harness import DeviceAdapter
+
+ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
+sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts", "pylib", "twister"))
+from twisterlib.cmakecache import CMakeCache
+
+
+def test_case(dut: DeviceAdapter, test_kconfig):
+    build_dir = dut.device_config.build_dir
+    cmake_cache = CMakeCache.from_file(os.path.join(build_dir, 'CMakeCache.txt'))
+    source_dir = cmake_cache.get('APPLICATION_SOURCE_DIR', None)
+    assert source_dir
+    expected = []
+    enforced = [
+        "CONFIG_COMPILER_WARNINGS_AS_ERRORS=y\n",
+    ]
+
+    with open(os.path.join(source_dir, test_kconfig), "r") as f:
+        for line in f:
+            if line.startswith("CONFIG_"):
+                expected.append(line)
+    with open(os.path.join(build_dir, "zephyr", ".config"), "r") as f:
+        for line in f:
+            if line.startswith("CONFIG_") and line not in expected and line not in enforced:
+                assert False, f"Stray Kconfig option found: {line}"
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/tests/kconfig/stray/src/main.c
+++ b/tests/kconfig/stray/src/main.c
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2012-2014 Wind River Systems, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+
+int main(void)
+{
+	printf("Hello World! %s\n", CONFIG_BOARD_TARGET);
+
+	return 0;
+}

--- a/tests/kconfig/stray/test.config
+++ b/tests/kconfig/stray/test.config
@@ -1,0 +1,1337 @@
+# CONFIG_INPUT is not set
+# CONFIG_WIFI is not set
+# CONFIG_MIPI_DSI is not set
+CONFIG_SERIAL=y
+# CONFIG_UART_INTERRUPT_DRIVEN is not set
+# CONFIG_I2C is not set
+# CONFIG_SPI is not set
+# CONFIG_MODEM is not set
+# CONFIG_BUILD_OUTPUT_BIN is not set
+CONFIG_QEMU_TARGET=y
+CONFIG_HAS_COVERAGE_SUPPORT=y
+CONFIG_KERNEL_VM_SIZE=0x800000
+CONFIG_MULTIBOOT=y
+CONFIG_MULTIBOOT_INFO=y
+CONFIG_MULTIBOOT_MEMMAP=y
+CONFIG_QEMU_ICOUNT=y
+CONFIG_QEMU_ICOUNT_SHIFT=5
+CONFIG_X86_PC_COMPATIBLE=y
+# CONFIG_HAVE_CUSTOM_LINKER_SCRIPT is not set
+CONFIG_X86_EXTRA_PAGE_TABLE_PAGES=0
+CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC=25000000
+CONFIG_FLASH_SIZE=4096
+CONFIG_FLASH_BASE_ADDRESS=0x500000
+CONFIG_MP_MAX_NUM_CPUS=1
+CONFIG_SYS_CLOCK_TICKS_PER_SEC=100
+CONFIG_ROM_START_OFFSET=0
+# CONFIG_PINCTRL is not set
+CONFIG_UART_NS16550=y
+# CONFIG_UART_NS16550_TI_K3 is not set
+# CONFIG_BUILD_NO_GAP_FILL is not set
+# CONFIG_XIP is not set
+CONFIG_MAIN_STACK_SIZE=1024
+CONFIG_IDLE_STACK_SIZE=320
+# CONFIG_SRAM_VECTOR_TABLE is not set
+# CONFIG_COUNTER is not set
+# CONFIG_PM_DEVICE is not set
+CONFIG_TICKLESS_KERNEL=y
+# CONFIG_FPU is not set
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=1024
+# CONFIG_CACHE_MANAGEMENT is not set
+# CONFIG_UART_NS16550_ACCESS_WORD_ONLY is not set
+# CONFIG_REGULATOR is not set
+# CONFIG_HW_STACK_PROTECTION is not set
+# CONFIG_FLASH is not set
+CONFIG_HEAP_MEM_POOL_SIZE=0
+CONFIG_SERIAL_INIT_PRIORITY=50
+# CONFIG_GPIO is not set
+# CONFIG_TINYCRYPT is not set
+# CONFIG_MBEDTLS is not set
+# CONFIG_MEMC is not set
+CONFIG_KERNEL_ENTRY="__start"
+# CONFIG_DYNAMIC_INTERRUPTS is not set
+# CONFIG_CACHE is not set
+CONFIG_DCACHE=y
+# CONFIG_LOG is not set
+CONFIG_SOC="atom"
+# CONFIG_RESET is not set
+# CONFIG_BUILD_OUTPUT_HEX is not set
+# CONFIG_CLOCK_CONTROL is not set
+CONFIG_UART_USE_RUNTIME_CONFIGURE=y
+# CONFIG_SYSCON is not set
+# CONFIG_INTC_MTK_ADSP is not set
+# CONFIG_MTK_ADSP_TIMER is not set
+CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=16384
+# CONFIG_GEN_ISR_TABLES is not set
+# CONFIG_REBOOT is not set
+# CONFIG_PCIE_MMIO_CFG is not set
+CONFIG_X86_VERY_EARLY_CONSOLE=y
+CONFIG_SRAM_OFFSET=0x100000
+CONFIG_GDT_DYNAMIC=y
+CONFIG_GDT_RESERVED_NUM_ENTRIES=0
+# CONFIG_POWER_DOMAIN is not set
+CONFIG_CPU_HAS_MMU=y
+CONFIG_CONSOLE=y
+CONFIG_ISR_STACK_SIZE=2048
+CONFIG_KERNEL_VM_OFFSET=0x100000
+# CONFIG_WATCHDOG is not set
+CONFIG_PRIVILEGED_STACK_SIZE=4096
+
+#
+# Devicetree Info
+#
+CONFIG_DT_HAS_FIXED_PARTITIONS_ENABLED=y
+CONFIG_DT_HAS_INTEL_E1000_ENABLED=y
+CONFIG_DT_HAS_INTEL_HPET_ENABLED=y
+CONFIG_DT_HAS_INTEL_IOAPIC_ENABLED=y
+CONFIG_DT_HAS_INTEL_LOAPIC_ENABLED=y
+CONFIG_DT_HAS_INTEL_X86_ENABLED=y
+CONFIG_DT_HAS_KVASER_PCICAN_ENABLED=y
+CONFIG_DT_HAS_MOTOROLA_MC146818_ENABLED=y
+CONFIG_DT_HAS_NS16550_ENABLED=y
+CONFIG_DT_HAS_PCIE_CONTROLLER_ENABLED=y
+CONFIG_DT_HAS_SOC_NV_FLASH_ENABLED=y
+CONFIG_DT_HAS_ZEPHYR_BT_HCI_UART_ENABLED=y
+CONFIG_DT_HAS_ZEPHYR_EMU_EEPROM_ENABLED=y
+CONFIG_DT_HAS_ZEPHYR_IEEE802154_UART_PIPE_ENABLED=y
+CONFIG_DT_HAS_ZEPHYR_SIM_EEPROM_ENABLED=y
+CONFIG_DT_HAS_ZEPHYR_SIM_FLASH_ENABLED=y
+# end of Devicetree Info
+
+#
+# Modules
+#
+
+#
+# Available modules.
+#
+
+#
+# canopennode (/home/nashif/zephyrproject/modules/lib/canopennode)
+#
+CONFIG_ZEPHYR_CANOPENNODE_MODULE=y
+# end of canopennode (/home/nashif/zephyrproject/modules/lib/canopennode)
+
+#
+# chre (/home/nashif/zephyrproject/modules/lib/chre)
+#
+CONFIG_ZEPHYR_CHRE_MODULE=y
+# CONFIG_CHRE is not set
+# end of chre (/home/nashif/zephyrproject/modules/lib/chre)
+
+#
+# lz4 (/home/nashif/zephyrproject/modules/lib/lz4)
+#
+CONFIG_ZEPHYR_LZ4_MODULE=y
+# CONFIG_LZ4 is not set
+# end of lz4 (/home/nashif/zephyrproject/modules/lib/lz4)
+
+#
+# nanopb (/home/nashif/zephyrproject/modules/lib/nanopb)
+#
+CONFIG_ZEPHYR_NANOPB_MODULE=y
+# CONFIG_NANOPB is not set
+# end of nanopb (/home/nashif/zephyrproject/modules/lib/nanopb)
+
+CONFIG_ZEPHYR_PSA_ARCH_TESTS_MODULE=y
+
+#
+# sof (/home/nashif/zephyrproject/modules/audio/sof)
+#
+# CONFIG_DEBUG is not set
+CONFIG_ZEPHYR_SOF_MODULE=y
+# end of sof (/home/nashif/zephyrproject/modules/audio/sof)
+
+CONFIG_ZEPHYR_TF_M_TESTS_MODULE=y
+
+#
+# tflite-micro (/home/nashif/zephyrproject/optional/modules/lib/tflite-micro)
+#
+# CONFIG_TENSORFLOW_LITE_MICRO is not set
+CONFIG_ZEPHYR_TFLITE_MICRO_MODULE=y
+# end of tflite-micro (/home/nashif/zephyrproject/optional/modules/lib/tflite-micro)
+
+#
+# thrift (/home/nashif/zephyrproject/optional/modules/lib/thrift)
+#
+CONFIG_ZEPHYR_THRIFT_MODULE=y
+# end of thrift (/home/nashif/zephyrproject/optional/modules/lib/thrift)
+
+#
+# zscilib (/home/nashif/zephyrproject/modules/lib/zscilib)
+#
+# CONFIG_ZSL is not set
+CONFIG_ZEPHYR_ZSCILIB_MODULE=y
+# end of zscilib (/home/nashif/zephyrproject/modules/lib/zscilib)
+
+#
+# acpica (/home/nashif/zephyrproject/modules/lib/acpica)
+#
+
+#
+# ACPI driver support
+#
+# CONFIG_ACPI is not set
+# end of ACPI driver support
+
+CONFIG_ZEPHYR_ACPICA_MODULE=y
+# end of acpica (/home/nashif/zephyrproject/modules/lib/acpica)
+
+#
+# cmsis (/home/nashif/zephyrproject/modules/hal/cmsis)
+#
+CONFIG_ZEPHYR_CMSIS_MODULE=y
+# end of cmsis (/home/nashif/zephyrproject/modules/hal/cmsis)
+
+#
+# cmsis-dsp (/home/nashif/zephyrproject/modules/lib/cmsis-dsp)
+#
+CONFIG_ZEPHYR_CMSIS_DSP_MODULE=y
+# CONFIG_CMSIS_DSP is not set
+# end of cmsis-dsp (/home/nashif/zephyrproject/modules/lib/cmsis-dsp)
+
+#
+# cmsis-nn (/home/nashif/zephyrproject/modules/lib/cmsis-nn)
+#
+CONFIG_ZEPHYR_CMSIS_NN_MODULE=y
+# end of cmsis-nn (/home/nashif/zephyrproject/modules/lib/cmsis-nn)
+
+#
+# fatfs (/home/nashif/zephyrproject/modules/fs/fatfs)
+#
+CONFIG_ZEPHYR_FATFS_MODULE=y
+# end of fatfs (/home/nashif/zephyrproject/modules/fs/fatfs)
+
+CONFIG_ZEPHYR_ADI_MODULE=y
+CONFIG_ZEPHYR_ALTERA_MODULE=y
+
+#
+# hal_ambiq (/home/nashif/zephyrproject/modules/hal/ambiq)
+#
+CONFIG_ZEPHYR_HAL_AMBIQ_MODULE=y
+# end of hal_ambiq (/home/nashif/zephyrproject/modules/hal/ambiq)
+
+CONFIG_ZEPHYR_ATMEL_MODULE=y
+
+#
+# hal_espressif (/home/nashif/zephyrproject/modules/hal/espressif)
+#
+CONFIG_ZEPHYR_HAL_ESPRESSIF_MODULE=y
+# end of hal_espressif (/home/nashif/zephyrproject/modules/hal/espressif)
+
+#
+# hal_ethos_u (/home/nashif/zephyrproject/modules/hal/ethos_u)
+#
+# CONFIG_ARM_ETHOS_U is not set
+CONFIG_ZEPHYR_HAL_ETHOS_U_MODULE=y
+# end of hal_ethos_u (/home/nashif/zephyrproject/modules/hal/ethos_u)
+
+#
+# hal_gigadevice (/home/nashif/zephyrproject/modules/hal/gigadevice)
+#
+CONFIG_ZEPHYR_HAL_GIGADEVICE_MODULE=y
+# end of hal_gigadevice (/home/nashif/zephyrproject/modules/hal/gigadevice)
+
+#
+# hal_infineon (/home/nashif/zephyrproject/modules/hal/infineon)
+#
+CONFIG_ZEPHYR_HAL_INFINEON_MODULE=y
+# CONFIG_USE_INFINEON_ABSTRACTION_RTOS is not set
+# end of hal_infineon (/home/nashif/zephyrproject/modules/hal/infineon)
+
+#
+# hal_intel (/home/nashif/zephyrproject/modules/hal/intel)
+#
+
+#
+# Intel HAL Zephyr Configuration
+#
+# end of Intel HAL Zephyr Configuration
+
+CONFIG_ZEPHYR_HAL_INTEL_MODULE=y
+# end of hal_intel (/home/nashif/zephyrproject/modules/hal/intel)
+
+CONFIG_ZEPHYR_MICROCHIP_MODULE=y
+
+#
+# hal_nordic (/home/nashif/zephyrproject/modules/hal/nordic)
+#
+CONFIG_ZEPHYR_HAL_NORDIC_MODULE=y
+# end of hal_nordic (/home/nashif/zephyrproject/modules/hal/nordic)
+
+CONFIG_ZEPHYR_NUVOTON_MODULE=y
+
+#
+# hal_nxp (/home/nashif/zephyrproject/modules/hal/nxp)
+#
+CONFIG_ZEPHYR_HAL_NXP_MODULE=y
+# end of hal_nxp (/home/nashif/zephyrproject/modules/hal/nxp)
+
+CONFIG_ZEPHYR_OPENISA_MODULE=y
+CONFIG_ZEPHYR_QUICKLOGIC_MODULE=y
+CONFIG_ZEPHYR_HAL_RENESAS_MODULE=y
+
+#
+# hal_rpi_pico (/home/nashif/zephyrproject/modules/hal/rpi_pico)
+#
+CONFIG_ZEPHYR_HAL_RPI_PICO_MODULE=y
+# end of hal_rpi_pico (/home/nashif/zephyrproject/modules/hal/rpi_pico)
+
+#
+# hal_silabs (/home/nashif/zephyrproject/modules/hal/silabs)
+#
+CONFIG_ZEPHYR_HAL_SILABS_MODULE=y
+# end of hal_silabs (/home/nashif/zephyrproject/modules/hal/silabs)
+
+#
+# hal_st (/home/nashif/zephyrproject/modules/hal/st)
+#
+CONFIG_ZEPHYR_HAL_ST_MODULE=y
+# end of hal_st (/home/nashif/zephyrproject/modules/hal/st)
+
+CONFIG_ZEPHYR_STM32_MODULE=y
+
+#
+# hal_telink (/home/nashif/zephyrproject/modules/hal/telink)
+#
+CONFIG_ZEPHYR_HAL_TELINK_MODULE=y
+# end of hal_telink (/home/nashif/zephyrproject/modules/hal/telink)
+
+CONFIG_ZEPHYR_TI_MODULE=y
+CONFIG_ZEPHYR_HAL_WURTHELEKTRONIK_MODULE=y
+CONFIG_ZEPHYR_XTENSA_MODULE=y
+
+#
+# hostap (/home/nashif/zephyrproject/modules/lib/hostap)
+#
+# CONFIG_WIFI_NM_WPA_SUPPLICANT is not set
+CONFIG_ZEPHYR_HOSTAP_MODULE=y
+# end of hostap (/home/nashif/zephyrproject/modules/lib/hostap)
+
+CONFIG_ZEPHYR_LIBMETAL_MODULE=y
+
+#
+# liblc3 (/home/nashif/zephyrproject/modules/lib/liblc3)
+#
+CONFIG_ZEPHYR_LIBLC3_MODULE=y
+# end of liblc3 (/home/nashif/zephyrproject/modules/lib/liblc3)
+
+#
+# littlefs (/home/nashif/zephyrproject/modules/fs/littlefs)
+#
+CONFIG_ZEPHYR_LITTLEFS_MODULE=y
+# end of littlefs (/home/nashif/zephyrproject/modules/fs/littlefs)
+
+#
+# loramac-node (/home/nashif/zephyrproject/modules/lib/loramac-node)
+#
+CONFIG_ZEPHYR_LORAMAC_NODE_MODULE=y
+# CONFIG_HAS_SEMTECH_RADIO_DRIVERS is not set
+# end of loramac-node (/home/nashif/zephyrproject/modules/lib/loramac-node)
+
+#
+# lvgl (/home/nashif/zephyrproject/modules/lib/gui/lvgl)
+#
+CONFIG_ZEPHYR_LVGL_MODULE=y
+# end of lvgl (/home/nashif/zephyrproject/modules/lib/gui/lvgl)
+
+#
+# mbedtls (/home/nashif/zephyrproject/modules/crypto/mbedtls)
+#
+CONFIG_ZEPHYR_MBEDTLS_MODULE=y
+# end of mbedtls (/home/nashif/zephyrproject/modules/crypto/mbedtls)
+
+CONFIG_ZEPHYR_MCUBOOT_MODULE=y
+CONFIG_ZEPHYR_MIPI_SYS_T_MODULE=y
+CONFIG_ZEPHYR_NRF_HW_MODELS_MODULE=y
+CONFIG_ZEPHYR_OPEN_AMP_MODULE=y
+
+#
+# openthread (/home/nashif/zephyrproject/modules/lib/openthread)
+#
+# CONFIG_OPENTHREAD is not set
+CONFIG_ZEPHYR_OPENTHREAD_MODULE=y
+# end of openthread (/home/nashif/zephyrproject/modules/lib/openthread)
+
+#
+# percepio (/home/nashif/zephyrproject/modules/debug/percepio)
+#
+
+#
+# Percepio Tracealyzer support can be enabled from the tracing subsystem
+#
+# CONFIG_PERCEPIO_DFM is not set
+CONFIG_ZEPHYR_PERCEPIO_MODULE=y
+# end of percepio (/home/nashif/zephyrproject/modules/debug/percepio)
+
+#
+# picolibc (/home/nashif/zephyrproject/modules/lib/picolibc)
+#
+# CONFIG_PICOLIBC_MODULE is not set
+CONFIG_ZEPHYR_PICOLIBC_MODULE=y
+# end of picolibc (/home/nashif/zephyrproject/modules/lib/picolibc)
+
+#
+# segger (/home/nashif/zephyrproject/modules/debug/segger)
+#
+CONFIG_ZEPHYR_SEGGER_MODULE=y
+# end of segger (/home/nashif/zephyrproject/modules/debug/segger)
+
+CONFIG_ZEPHYR_TINYCRYPT_MODULE=y
+
+#
+# trusted-firmware-m (/home/nashif/zephyrproject/modules/tee/tf-m/trusted-firmware-m)
+#
+CONFIG_ZEPHYR_TRUSTED_FIRMWARE_M_MODULE=y
+# end of trusted-firmware-m (/home/nashif/zephyrproject/modules/tee/tf-m/trusted-firmware-m)
+
+#
+# trusted-firmware-a (/home/nashif/zephyrproject/modules/tee/tf-a/trusted-firmware-a)
+#
+CONFIG_ZEPHYR_TRUSTED_FIRMWARE_A_MODULE=y
+# CONFIG_BUILD_WITH_TFA is not set
+# end of trusted-firmware-a (/home/nashif/zephyrproject/modules/tee/tf-a/trusted-firmware-a)
+
+#
+# uoscore-uedhoc (/home/nashif/zephyrproject/modules/lib/uoscore-uedhoc)
+#
+CONFIG_ZEPHYR_UOSCORE_UEDHOC_MODULE=y
+# end of uoscore-uedhoc (/home/nashif/zephyrproject/modules/lib/uoscore-uedhoc)
+
+#
+# zcbor (/home/nashif/zephyrproject/modules/lib/zcbor)
+#
+CONFIG_ZEPHYR_ZCBOR_MODULE=y
+# CONFIG_ZCBOR is not set
+# end of zcbor (/home/nashif/zephyrproject/modules/lib/zcbor)
+
+# CONFIG_LIBMETAL is not set
+# CONFIG_LVGL is not set
+# CONFIG_HAS_MEC_HAL is not set
+# CONFIG_HAS_MPFS_HAL is not set
+# CONFIG_HAS_MEC5_HAL is not set
+# CONFIG_OPENAMP is not set
+# CONFIG_SOF is not set
+# CONFIG_MIPI_SYST_LIB is not set
+# CONFIG_HAS_TELINK_DRIVERS is not set
+# CONFIG_BOOTLOADER_MCUBOOT is not set
+# CONFIG_MCUBOOT_BOOTUTIL_LIB is not set
+
+#
+# Unavailable modules, please install those via the project manifest.
+#
+# end of Modules
+
+CONFIG_BOARD="qemu_x86"
+CONFIG_BOARD_REVISION=""
+CONFIG_BOARD_TARGET="qemu_x86/atom"
+# CONFIG_NET_DRIVERS is not set
+CONFIG_BOARD_QEMU_X86=y
+CONFIG_BOARD_QEMU_X86_ATOM=y
+CONFIG_BOARD_QUALIFIERS="atom"
+
+#
+# Board Options
+#
+# CONFIG_QEMU_ICOUNT_SLEEP is not set
+CONFIG_QEMU_GDBSERVER_LISTEN_DEV="tcp::1234"
+CONFIG_QEMU_EXTRA_FLAGS=""
+# end of Board Options
+
+#
+# Hardware Configuration
+#
+CONFIG_SOC_ATOM=y
+# CONFIG_MFD is not set
+# CONFIG_BUILD_OUTPUT_INFO_HEADER is not set
+CONFIG_MMU_PAGE_SIZE=0x1000
+# end of Hardware Configuration
+
+#
+# X86 Architecture Options
+#
+CONFIG_ARCH="x86"
+CONFIG_CPU_ATOM=y
+# CONFIG_X86_64 is not set
+
+#
+# x86 Features
+#
+CONFIG_X86_CPU_HAS_MMX=y
+CONFIG_X86_CPU_HAS_SSE=y
+CONFIG_X86_CPU_HAS_SSE2=y
+CONFIG_X86_CPU_HAS_SSE3=y
+# end of x86 Features
+
+CONFIG_MAX_IRQ_LINES=128
+CONFIG_PIC_DISABLE=y
+CONFIG_X86_MEMMAP=y
+CONFIG_X86_MEMMAP_ENTRIES=64
+CONFIG_X86_MMU=y
+CONFIG_NESTED_INTERRUPTS=y
+
+#
+# Memory Layout Options
+#
+CONFIG_IDT_NUM_VECTORS=256
+CONFIG_SET_GDT=y
+# end of Memory Layout Options
+
+#
+# Processor Capabilities
+#
+CONFIG_X86_PAE=y
+
+#
+# Architecture Floating Point Options
+#
+CONFIG_X86_FP_USE_SOFT_FLOAT=y
+# end of Architecture Floating Point Options
+# end of Processor Capabilities
+
+CONFIG_X86_EXCEPTION_STACK_TRACE=y
+CONFIG_X86_USE_THREAD_LOCAL_STORAGE=y
+# end of X86 Architecture Options
+
+CONFIG_KOBJECT_TEXT_AREA=256
+CONFIG_X86=y
+CONFIG_ARCH_IS_SET=y
+
+#
+# General Architecture Options
+#
+CONFIG_LITTLE_ENDIAN=y
+CONFIG_SRAM_SIZE=32768
+CONFIG_SRAM_BASE_ADDRESS=0x0
+# CONFIG_USERSPACE is not set
+CONFIG_KOBJECT_DATA_AREA_RESERVE_EXTRA_PERCENT=100
+CONFIG_KOBJECT_RODATA_AREA_EXTRA_BYTES=16
+# CONFIG_STACK_GROWS_UP is not set
+# CONFIG_FRAME_POINTER is not set
+
+#
+# Interrupt Configuration
+#
+CONFIG_EXCEPTION_DEBUG=y
+# CONFIG_SIMPLIFIED_EXCEPTION_CODES is not set
+# end of Interrupt Configuration
+# end of General Architecture Options
+
+CONFIG_ARCH_HAS_TIMING_FUNCTIONS=y
+CONFIG_ARCH_HAS_STACK_PROTECTION=y
+CONFIG_ARCH_HAS_USERSPACE=y
+CONFIG_ARCH_SUPPORTS_COREDUMP=y
+CONFIG_ARCH_SUPPORTS_ROM_START=y
+CONFIG_ARCH_HAS_GDBSTUB=y
+CONFIG_ARCH_HAS_THREAD_LOCAL_STORAGE=y
+CONFIG_ARCH_HAS_STACK_CANARIES_TLS=y
+CONFIG_ARCH_SUPPORTS_MEM_MAPPED_STACKS=y
+CONFIG_CPU_HAS_FPU=y
+CONFIG_ARCH_HAS_DEMAND_PAGING=y
+CONFIG_ARCH_HAS_RESERVED_PAGE_FRAMES=y
+CONFIG_CPU_HAS_DCACHE=y
+CONFIG_SRAM_REGION_PERMISSIONS=y
+
+#
+# DSP Options
+#
+# end of DSP Options
+
+#
+# Floating Point Options
+#
+# end of Floating Point Options
+
+#
+# Cache Options
+#
+# end of Cache Options
+
+CONFIG_TOOLCHAIN_HAS_BUILTIN_FFS=y
+# CONFIG_ARCH_CPU_IDLE_CUSTOM is not set
+
+#
+# General Kernel Options
+#
+CONFIG_MULTITHREADING=y
+CONFIG_NUM_COOP_PRIORITIES=16
+CONFIG_NUM_PREEMPT_PRIORITIES=15
+CONFIG_MAIN_THREAD_PRIORITY=0
+CONFIG_COOP_ENABLED=y
+CONFIG_PREEMPT_ENABLED=y
+CONFIG_PRIORITY_CEILING=-127
+CONFIG_NUM_METAIRQ_PRIORITIES=0
+# CONFIG_SCHED_DEADLINE is not set
+CONFIG_THREAD_STACK_INFO=y
+# CONFIG_THREAD_STACK_MEM_MAPPED is not set
+# CONFIG_THREAD_CUSTOM_DATA is not set
+# CONFIG_DYNAMIC_THREAD is not set
+# CONFIG_SCHED_DUMB is not set
+CONFIG_SCHED_SCALABLE=y
+# CONFIG_SCHED_MULTIQ is not set
+CONFIG_WAITQ_SCALABLE=y
+# CONFIG_WAITQ_DUMB is not set
+
+#
+# Misc Kernel related options
+#
+CONFIG_LIBC_ERRNO=y
+CONFIG_ERRNO=y
+CONFIG_CURRENT_THREAD_USE_TLS=y
+# end of Misc Kernel related options
+
+#
+# Kernel Debugging and Metrics
+#
+# CONFIG_INIT_STACKS is not set
+CONFIG_BOOT_BANNER=y
+CONFIG_BOOT_BANNER_STRING="Booting Zephyr OS build"
+CONFIG_BOOT_DELAY=0
+# CONFIG_BOOT_CLEAR_SCREEN is not set
+# CONFIG_THREAD_MONITOR is not set
+# CONFIG_THREAD_NAME is not set
+# CONFIG_THREAD_RUNTIME_STATS is not set
+# end of Kernel Debugging and Metrics
+
+# CONFIG_OBJ_CORE is not set
+
+#
+# System Work Queue Options
+#
+CONFIG_SYSTEM_WORKQUEUE_PRIORITY=-1
+# CONFIG_SYSTEM_WORKQUEUE_NO_YIELD is not set
+# end of System Work Queue Options
+
+#
+# Barrier Operations
+#
+# end of Barrier Operations
+
+#
+# Atomic Operations
+#
+CONFIG_ATOMIC_OPERATIONS_BUILTIN=y
+# end of Atomic Operations
+
+#
+# Timer API Options
+#
+CONFIG_TIMESLICING=y
+CONFIG_TIMESLICE_SIZE=0
+CONFIG_TIMESLICE_PRIORITY=0
+# CONFIG_TIMESLICE_PER_THREAD is not set
+# end of Timer API Options
+
+#
+# Other Kernel Object Options
+#
+# CONFIG_POLL is not set
+# CONFIG_MEM_SLAB_TRACE_MAX_UTILIZATION is not set
+CONFIG_NUM_MBOX_ASYNC_MSGS=10
+# CONFIG_EVENTS is not set
+# CONFIG_PIPES is not set
+CONFIG_KERNEL_MEM_POOL=y
+# CONFIG_HEAP_MEM_POOL_IGNORE_MIN is not set
+# end of Other Kernel Object Options
+
+CONFIG_SYS_CLOCK_EXISTS=y
+CONFIG_TIMEOUT_64BIT=y
+CONFIG_SYS_CLOCK_MAX_TIMEOUT_DAYS=365
+
+#
+# Security Options
+#
+# CONFIG_STACK_CANARIES is not set
+CONFIG_STACK_POINTER_RANDOM=0
+# end of Security Options
+
+#
+# Memory Domains
+#
+# end of Memory Domains
+
+#
+# SMP Options
+#
+CONFIG_MP_NUM_CPUS=1
+# CONFIG_TICKET_SPINLOCKS is not set
+# end of SMP Options
+
+CONFIG_TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE=y
+CONFIG_THREAD_LOCAL_STORAGE=y
+CONFIG_TOOLCHAIN_SUPPORTS_STATIC_INIT_GNU=y
+# CONFIG_STATIC_INIT_GNU is not set
+# end of General Kernel Options
+
+#
+# Device Options
+#
+# CONFIG_DEVICE_DEPS is not set
+# CONFIG_DEVICE_MUTABLE is not set
+# CONFIG_DEVICE_DT_METADATA is not set
+# end of Device Options
+
+#
+# Initialization Priorities
+#
+CONFIG_KERNEL_INIT_PRIORITY_OBJECTS=30
+CONFIG_KERNEL_INIT_PRIORITY_LIBC=35
+CONFIG_KERNEL_INIT_PRIORITY_DEFAULT=40
+CONFIG_KERNEL_INIT_PRIORITY_DEVICE=50
+CONFIG_APPLICATION_INIT_PRIORITY=90
+# end of Initialization Priorities
+
+#
+# Virtual Memory Support
+#
+CONFIG_KERNEL_VM_SUPPORT=y
+CONFIG_KERNEL_VM_BASE=0x0
+# CONFIG_KERNEL_DIRECT_MAP is not set
+CONFIG_MMU=y
+# CONFIG_DEMAND_PAGING is not set
+# end of Virtual Memory Support
+
+#
+# Device Drivers
+#
+# CONFIG_ADC is not set
+# CONFIG_AUDIO is not set
+# CONFIG_AUXDISPLAY is not set
+# CONFIG_BBRAM is not set
+# CONFIG_CAN is not set
+# CONFIG_CHARGER is not set
+CONFIG_CONSOLE_INPUT_MAX_LINE_LEN=128
+CONFIG_CONSOLE_HAS_DRIVER=y
+# CONFIG_CONSOLE_HANDLER is not set
+CONFIG_CONSOLE_INIT_PRIORITY=60
+CONFIG_UART_CONSOLE=y
+# CONFIG_UART_CONSOLE_DEBUG_SERVER_HOOKS is not set
+# CONFIG_UART_CONSOLE_MCUMGR is not set
+# CONFIG_RAM_CONSOLE is not set
+# CONFIG_IPM_CONSOLE_SENDER is not set
+# CONFIG_IPM_CONSOLE_RECEIVER is not set
+# CONFIG_UART_MCUMGR is not set
+# CONFIG_EFI_CONSOLE is not set
+# CONFIG_COREDUMP_DEVICE is not set
+# CONFIG_CRYPTO is not set
+# CONFIG_DAC is not set
+# CONFIG_DAI is not set
+# CONFIG_DISK_DRIVERS is not set
+# CONFIG_DISPLAY is not set
+# CONFIG_DMA is not set
+# CONFIG_DP_DRIVER is not set
+# CONFIG_EDAC is not set
+# CONFIG_EEPROM is not set
+# CONFIG_ENTROPY_GENERATOR is not set
+# CONFIG_ESPI is not set
+# CONFIG_FPGA is not set
+# CONFIG_FUEL_GAUGE is not set
+# CONFIG_GNSS is not set
+# CONFIG_HWINFO is not set
+# CONFIG_HWSPINLOCK is not set
+# CONFIG_I2S is not set
+# CONFIG_I3C is not set
+
+#
+# Interrupt controller drivers
+#
+CONFIG_INTC_INIT_PRIORITY=40
+CONFIG_LOAPIC=y
+# CONFIG_X2APIC is not set
+# CONFIG_LOAPIC_SPURIOUS_VECTOR is not set
+CONFIG_IOAPIC=y
+CONFIG_IOAPIC_MASK_RTE=y
+# end of Interrupt controller drivers
+
+# CONFIG_IPM is not set
+# CONFIG_KSCAN is not set
+# CONFIG_LED is not set
+# CONFIG_LED_STRIP is not set
+# CONFIG_LORA is not set
+# CONFIG_MBOX is not set
+# CONFIG_MDIO is not set
+# CONFIG_MIPI_DBI is not set
+
+#
+# Miscellaneous Drivers
+#
+# CONFIG_TIMEAWARE_GPIO is not set
+# end of Miscellaneous Drivers
+
+# CONFIG_MM_DRV is not set
+# CONFIG_MSPI is not set
+# CONFIG_PCIE is not set
+# CONFIG_PCIE_ENDPOINT is not set
+# CONFIG_PECI is not set
+# CONFIG_PM_CPU_OPS is not set
+# CONFIG_PS2 is not set
+# CONFIG_PTP_CLOCK is not set
+# CONFIG_PWM is not set
+# CONFIG_RETAINED_MEM is not set
+# CONFIG_RTC is not set
+# CONFIG_SDHC is not set
+# CONFIG_SENSOR is not set
+
+#
+# Capabilities
+#
+CONFIG_SERIAL_HAS_DRIVER=y
+CONFIG_SERIAL_SUPPORT_INTERRUPT=y
+# CONFIG_UART_LINE_CTRL is not set
+# CONFIG_UART_DRV_CMD is not set
+# CONFIG_UART_WIDE_DATA is not set
+# CONFIG_UART_PIPE is not set
+# CONFIG_UART_ASYNC_RX_HELPER is not set
+
+#
+# Serial Drivers
+#
+# CONFIG_UART_NS16550_INTEL_LPSS_DMA is not set
+CONFIG_UART_NS16550_VARIANT_NS16550=y
+# CONFIG_UART_NS16550_VARIANT_NS16750 is not set
+# CONFIG_UART_NS16550_VARIANT_NS16950 is not set
+# CONFIG_UART_NS16550_ITE_HIGH_SPEED_BUADRATE is not set
+
+#
+# NS16550 Workarounds
+#
+# end of NS16550 Workarounds
+
+# CONFIG_SMBUS is not set
+
+#
+# Timer drivers
+#
+CONFIG_TIMER_HAS_64BIT_CYCLE_COUNTER=y
+CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME=y
+# CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE is not set
+CONFIG_SYSTEM_CLOCK_INIT_PRIORITY=0
+CONFIG_TICKLESS_CAPABLE=y
+CONFIG_HPET_TIMER=y
+# CONFIG_APIC_TIMER is not set
+# CONFIG_APIC_TSC_DEADLINE_TIMER is not set
+# CONFIG_APIC_TIMER_TSC is not set
+# end of Timer drivers
+
+# CONFIG_USB_BC12 is not set
+# CONFIG_UDC_DRIVER is not set
+# CONFIG_UHC_DRIVER is not set
+# CONFIG_UVB is not set
+# CONFIG_USB_DEVICE_DRIVER is not set
+# CONFIG_USBC_TCPC_DRIVER is not set
+# CONFIG_USBC_VBUS_DRIVER is not set
+# CONFIG_USBC_PPC_DRIVER is not set
+# CONFIG_VIDEO is not set
+# CONFIG_VIRTUALIZATION is not set
+# CONFIG_W1 is not set
+# CONFIG_TEE is not set
+# end of Device Drivers
+
+# CONFIG_REQUIRES_FULL_LIBC is not set
+# CONFIG_REQUIRES_FLOAT_PRINTF is not set
+CONFIG_FULL_LIBC_SUPPORTED=y
+CONFIG_MINIMAL_LIBC_SUPPORTED=y
+CONFIG_NEWLIB_LIBC_SUPPORTED=y
+CONFIG_PICOLIBC_SUPPORTED=y
+
+#
+# C Library
+#
+# CONFIG_MINIMAL_LIBC is not set
+CONFIG_PICOLIBC=y
+# CONFIG_NEWLIB_LIBC is not set
+# CONFIG_EXTERNAL_LIBC is not set
+CONFIG_HAS_NEWLIB_LIBC_NANO=y
+CONFIG_COMMON_LIBC_ABORT=y
+CONFIG_COMMON_LIBC_MALLOC=y
+CONFIG_COMMON_LIBC_CALLOC=y
+CONFIG_COMMON_LIBC_REALLOCARRAY=y
+# CONFIG_PICOLIBC_USE_MODULE is not set
+CONFIG_PICOLIBC_USE_TOOLCHAIN=y
+# CONFIG_PICOLIBC_IO_FLOAT is not set
+CONFIG_PICOLIBC_IO_LONG_LONG=y
+CONFIG_STDOUT_CONSOLE=y
+CONFIG_NEED_LIBC_MEM_PARTITION=y
+# end of C Library
+
+#
+# C++ Language Support
+#
+# CONFIG_CPP is not set
+# end of C++ Language Support
+
+# CONFIG_CRC is not set
+
+#
+# Additional libraries
+#
+
+#
+# Hash Function Support
+#
+# CONFIG_SYS_HASH_FUNC32 is not set
+# end of Hash Function Support
+
+#
+# Hashmap (Hash Table) Support
+#
+# CONFIG_SYS_HASH_MAP is not set
+# end of Hashmap (Hash Table) Support
+
+#
+# Heap and Memory Allocation
+#
+# CONFIG_SYS_HEAP_STRESS is not set
+# CONFIG_SYS_HEAP_INFO is not set
+CONFIG_SYS_HEAP_ALLOC_LOOPS=3
+# CONFIG_SYS_HEAP_RUNTIME_STATS is not set
+# CONFIG_SYS_HEAP_LISTENER is not set
+# CONFIG_SYS_HEAP_SMALL_ONLY is not set
+# CONFIG_SYS_HEAP_BIG_ONLY is not set
+CONFIG_SYS_HEAP_AUTO=y
+# CONFIG_MULTI_HEAP is not set
+# CONFIG_SHARED_MULTI_HEAP is not set
+# end of Heap and Memory Allocation
+
+#
+# Memory Blocks
+#
+# CONFIG_SYS_MEM_BLOCKS is not set
+# end of Memory Blocks
+
+#
+# OS Support Library
+#
+# CONFIG_FDTABLE is not set
+CONFIG_ZVFS_OPEN_MAX=4
+# CONFIG_PRINTK_SYNC is not set
+# CONFIG_MPSC_PBUF is not set
+# CONFIG_SPSC_PBUF is not set
+CONFIG_CBPRINTF_COMPLETE=y
+# CONFIG_CBPRINTF_NANO is not set
+CONFIG_CBPRINTF_FULL_INTEGRAL=y
+# CONFIG_CBPRINTF_REDUCED_INTEGRAL is not set
+# CONFIG_CBPRINTF_FP_SUPPORT is not set
+# CONFIG_CBPRINTF_FP_A_SUPPORT is not set
+# CONFIG_CBPRINTF_LIBC_SUBSTS is not set
+# CONFIG_CBPRINTF_PACKAGE_LONGDOUBLE is not set
+# CONFIG_CBPRINTF_STATIC_PACKAGE_CHECK_ALIGNMENT is not set
+CONFIG_CBPRINTF_CONVERT_CHECK_PTR=y
+# CONFIG_ZVFS is not set
+# end of OS Support Library
+
+#
+# POSIX API Support
+#
+
+#
+# POSIX Options
+#
+# CONFIG_POSIX_API is not set
+CONFIG_POSIX_AEP_CHOICE_NONE=y
+# CONFIG_POSIX_AEP_CHOICE_BASE is not set
+# CONFIG_POSIX_AEP_CHOICE_PSE51 is not set
+# CONFIG_POSIX_AEP_CHOICE_PSE52 is not set
+# CONFIG_POSIX_AEP_CHOICE_PSE53 is not set
+# CONFIG_POSIX_ASYNCHRONOUS_IO is not set
+# CONFIG_POSIX_BARRIERS is not set
+# CONFIG_POSIX_C_LIB_EXT is not set
+
+#
+# POSIX device I/O
+#
+# CONFIG_POSIX_DEVICE_IO is not set
+CONFIG_POSIX_OPEN_MAX=4
+# end of POSIX device I/O
+
+# CONFIG_POSIX_FD_MGMT is not set
+# CONFIG_POSIX_FILE_SYSTEM is not set
+
+#
+# POSIX memory
+#
+CONFIG_POSIX_PAGE_SIZE=0x1000
+# CONFIG_POSIX_SHARED_MEMORY_OBJECTS is not set
+# CONFIG_POSIX_MAPPED_FILES is not set
+# CONFIG_POSIX_MEMORY_PROTECTION is not set
+# end of POSIX memory
+
+# CONFIG_POSIX_MESSAGE_PASSING is not set
+# CONFIG_POSIX_SINGLE_PROCESS is not set
+# CONFIG_POSIX_MULTI_PROCESS is not set
+# CONFIG_POSIX_THREADS is not set
+# CONFIG_POSIX_READER_WRITER_LOCKS is not set
+
+#
+# POSIX scheduler options
+#
+# CONFIG_POSIX_PRIORITY_SCHEDULING is not set
+# end of POSIX scheduler options
+
+# CONFIG_POSIX_SEMAPHORES is not set
+
+#
+# POSIX signals
+#
+# CONFIG_POSIX_REALTIME_SIGNALS is not set
+# CONFIG_POSIX_SIGNALS is not set
+# end of POSIX signals
+
+# CONFIG_POSIX_SPIN_LOCKS is not set
+
+#
+# POSIX synchronized I/O
+#
+# CONFIG_POSIX_FSYNC is not set
+# CONFIG_POSIX_SYNCHRONIZED_IO is not set
+# end of POSIX synchronized I/O
+
+# CONFIG_POSIX_TIMERS is not set
+
+#
+# X/Open system interfaces
+#
+# CONFIG_XOPEN_STREAMS is not set
+# CONFIG_XSI_SYSTEM_LOGGING is not set
+# CONFIG_XSI_THREADS_EXT is not set
+# end of X/Open system interfaces
+
+#
+# Miscellaneous POSIX-related options
+#
+# CONFIG_EVENTFD is not set
+# end of Miscellaneous POSIX-related options
+
+#
+# Deprecated POSIX options
+#
+CONFIG_EVENTFD_MAX=0
+# CONFIG_FNMATCH is not set
+# CONFIG_GETENTROPY is not set
+# CONFIG_GETOPT is not set
+CONFIG_MAX_PTHREAD_COUNT=0
+CONFIG_MAX_PTHREAD_KEY_COUNT=0
+CONFIG_MAX_TIMER_COUNT=0
+CONFIG_MSG_COUNT_MAX=0
+# CONFIG_POSIX_CLOCK is not set
+# CONFIG_POSIX_CONFSTR is not set
+# CONFIG_POSIX_ENV is not set
+# CONFIG_POSIX_FS is not set
+CONFIG_POSIX_LIMITS_RTSIG_MAX=0
+CONFIG_POSIX_MAX_FDS=4
+CONFIG_POSIX_MAX_OPEN_FILES=4
+# CONFIG_POSIX_MQUEUE is not set
+# CONFIG_POSIX_PUTMSG is not set
+# CONFIG_POSIX_SIGNAL is not set
+# CONFIG_POSIX_SYSCONF is not set
+# CONFIG_POSIX_SYSLOG is not set
+# CONFIG_POSIX_UNAME is not set
+# CONFIG_PTHREAD is not set
+# CONFIG_PTHREAD_BARRIER is not set
+# CONFIG_PTHREAD_COND is not set
+# CONFIG_PTHREAD_IPC is not set
+# CONFIG_PTHREAD_KEY is not set
+# CONFIG_PTHREAD_MUTEX is not set
+# CONFIG_PTHREAD_RWLOCK is not set
+# CONFIG_PTHREAD_SPINLOCK is not set
+# CONFIG_TIMER is not set
+CONFIG_TIMER_DELAYTIMER_MAX=0
+CONFIG_SEM_NAMELEN_MAX=0
+CONFIG_SEM_VALUE_MAX=0
+# end of Deprecated POSIX options
+# end of POSIX Options
+
+#
+# POSIX Shell Utilities
+#
+# end of POSIX Shell Utilities
+# end of POSIX API Support
+
+# CONFIG_OPENAMP_RSC_TABLE is not set
+# CONFIG_SMF is not set
+CONFIG_LIBGCC_RTLIB=y
+
+#
+# Utility Library
+#
+# CONFIG_JSON_LIBRARY is not set
+# CONFIG_RING_BUFFER is not set
+# CONFIG_NOTIFY is not set
+# CONFIG_BASE64 is not set
+# CONFIG_ONOFF is not set
+# CONFIG_WINSTREAM is not set
+# CONFIG_UTF8 is not set
+# end of Utility Library
+# end of Additional libraries
+
+#
+# Subsystems and OS Services
+#
+# CONFIG_BINDESC is not set
+# CONFIG_BT is not set
+
+#
+# Controller Area Network (CAN) bus subsystem
+#
+# end of Controller Area Network (CAN) bus subsystem
+
+# CONFIG_CONSOLE_SUBSYS is not set
+# CONFIG_DAP is not set
+
+#
+# System Monitoring Options
+#
+# CONFIG_THREAD_ANALYZER is not set
+# end of System Monitoring Options
+
+#
+# Debugging Options
+#
+# CONFIG_STACK_USAGE is not set
+# CONFIG_STACK_SENTINEL is not set
+CONFIG_PRINTK=y
+CONFIG_EARLY_CONSOLE=y
+# CONFIG_ASSERT is not set
+# CONFIG_FORCE_NO_ASSERT is not set
+CONFIG_ASSERT_VERBOSE=y
+# CONFIG_ASSERT_NO_FILE_INFO is not set
+# CONFIG_ASSERT_NO_COND_INFO is not set
+# CONFIG_ASSERT_NO_MSG_INFO is not set
+# CONFIG_ASSERT_TEST is not set
+# CONFIG_OVERRIDE_FRAME_POINTER_DEFAULT is not set
+CONFIG_DEBUG_INFO=y
+CONFIG_EXCEPTION_STACK_TRACE=y
+CONFIG_EXCEPTION_STACK_TRACE_MAX_FRAMES=8
+# CONFIG_EXCEPTION_STACK_TRACE_SYMTAB is not set
+# CONFIG_DEBUG_THREAD_INFO is not set
+# CONFIG_DEBUG_COREDUMP is not set
+# CONFIG_SYMTAB is not set
+# end of Debugging Options
+
+# CONFIG_GDBSTUB is not set
+# CONFIG_MIPI_STP_DECODER is not set
+# CONFIG_DISK_ACCESS is not set
+# CONFIG_DSP is not set
+# CONFIG_EMUL is not set
+# CONFIG_CHARACTER_FRAMEBUFFER is not set
+
+#
+# File Systems
+#
+# CONFIG_FILE_SYSTEM is not set
+# end of File Systems
+
+#
+# Inter Processor Communication
+#
+# CONFIG_RPMSG_SERVICE is not set
+# CONFIG_IPC_SERVICE is not set
+# end of Inter Processor Communication
+
+# CONFIG_JWT is not set
+# CONFIG_LLEXT is not set
+
+#
+# Linkable loadable Extension Development Kit (EDK)
+#
+CONFIG_LLEXT_EDK_NAME="llext-edk"
+# CONFIG_LLEXT_EDK_USERSPACE_ONLY is not set
+# end of Linkable loadable Extension Development Kit (EDK)
+
+#
+# Logging
+#
+# CONFIG_LOG_OUTPUT is not set
+# end of Logging
+
+# CONFIG_MEM_ATTR is not set
+
+#
+# Device Management
+#
+
+#
+# Host command handler subsystem
+#
+# CONFIG_EC_HOST_CMD is not set
+# end of Host command handler subsystem
+
+# CONFIG_OSDP is not set
+# end of Device Management
+
+# CONFIG_MODBUS is not set
+# CONFIG_MODEM_MODULES is not set
+
+#
+# Networking
+#
+# CONFIG_NET_BUF is not set
+# CONFIG_NETWORKING is not set
+# end of Networking
+
+#
+# Power Management
+#
+# end of Power Management
+
+#
+# Portability
+#
+# end of Portability
+
+#
+# Random Number Generators
+#
+CONFIG_TEST_RANDOM_GENERATOR=y
+CONFIG_TIMER_RANDOM_INITIAL_STATE=123456789
+CONFIG_TIMER_RANDOM_GENERATOR=y
+# end of Random Number Generators
+
+# CONFIG_RTIO is not set
+
+#
+# SD
+#
+# CONFIG_MMC_STACK is not set
+# CONFIG_SDMMC_STACK is not set
+# CONFIG_SDIO_STACK is not set
+# end of SD
+
+# CONFIG_SETTINGS is not set
+# CONFIG_SHELL is not set
+# CONFIG_STATS is not set
+
+#
+# Storage
+#
+# CONFIG_STREAM_FLASH is not set
+# end of Storage
+
+# CONFIG_TASK_WDT is not set
+
+#
+# Testing
+#
+# CONFIG_ZTEST is not set
+# CONFIG_ZTEST_MOCKING is not set
+# CONFIG_ZTRESS is not set
+# CONFIG_TEST is not set
+# CONFIG_COVERAGE is not set
+# CONFIG_FORCE_COVERAGE is not set
+# CONFIG_TEST_USERSPACE is not set
+# CONFIG_TEST_FLASH_DRIVERS is not set
+# end of Testing
+
+# CONFIG_TIMING_FUNCTIONS is not set
+# CONFIG_TRACING is not set
+# CONFIG_USB_DEVICE_STACK is not set
+# CONFIG_USB_DEVICE_STACK_NEXT is not set
+# CONFIG_USB_HOST_STACK is not set
+# CONFIG_USBC_STACK is not set
+# CONFIG_ZBUS is not set
+# CONFIG_MODULES is not set
+# end of Subsystems and OS Services
+
+CONFIG_TOOLCHAIN_ZEPHYR_0_16=y
+CONFIG_TOOLCHAIN_ZEPHYR_SUPPORTS_THREAD_LOCAL_STORAGE=y
+CONFIG_TOOLCHAIN_ZEPHYR_SUPPORTS_GNU_EXTENSIONS=y
+
+#
+# Build and Link Features
+#
+
+#
+# Linker Options
+#
+# CONFIG_LINKER_ORPHAN_SECTION_PLACE is not set
+CONFIG_LINKER_ORPHAN_SECTION_WARN=y
+# CONFIG_LINKER_ORPHAN_SECTION_ERROR is not set
+CONFIG_ROM_END_OFFSET=0
+CONFIG_LD_LINKER_SCRIPT_SUPPORTED=y
+CONFIG_LD_LINKER_TEMPLATE=y
+CONFIG_LINKER_SORT_BY_ALIGNMENT=y
+CONFIG_HAS_SRAM_OFFSET=y
+
+#
+# Linker Sections
+#
+# CONFIG_LINKER_USE_BOOT_SECTION is not set
+# CONFIG_LINKER_USE_PINNED_SECTION is not set
+CONFIG_LINKER_GENERIC_SECTIONS_PRESENT_AT_BOOT=y
+CONFIG_LINKER_USE_RELAX=y
+# end of Linker Sections
+
+CONFIG_LINKER_ITERABLE_SUBALIGN=4
+# end of Linker Options
+
+#
+# Compiler Options
+#
+# CONFIG_STD_C90 is not set
+CONFIG_STD_C99=y
+# CONFIG_STD_C11 is not set
+# CONFIG_STD_C17 is not set
+# CONFIG_STD_C23 is not set
+CONFIG_TOOLCHAIN_SUPPORTS_GNU_EXTENSIONS=y
+# CONFIG_GNU_C_EXTENSIONS is not set
+# CONFIG_CODING_GUIDELINE_CHECK is not set
+# CONFIG_COMPILER_FREESTANDING is not set
+CONFIG_SIZE_OPTIMIZATIONS=y
+# CONFIG_SIZE_OPTIMIZATIONS_AGGRESSIVE is not set
+# CONFIG_SPEED_OPTIMIZATIONS is not set
+# CONFIG_DEBUG_OPTIMIZATIONS is not set
+# CONFIG_NO_OPTIMIZATIONS is not set
+# CONFIG_LTO is not set
+# CONFIG_COMPILER_WARNINGS_AS_ERRORS is not set
+# CONFIG_COMPILER_SAVE_TEMPS is not set
+CONFIG_COMPILER_TRACK_MACRO_EXPANSION=y
+CONFIG_COMPILER_COLOR_DIAGNOSTICS=y
+# CONFIG_FORTIFY_SOURCE_NONE is not set
+CONFIG_FORTIFY_SOURCE_COMPILE_TIME=y
+# CONFIG_FORTIFY_SOURCE_RUN_TIME is not set
+CONFIG_COMPILER_OPT=""
+# CONFIG_MISRA_SANE is not set
+# end of Compiler Options
+
+# CONFIG_ASSERT_ON_ERRORS is not set
+# CONFIG_NO_RUNTIME_CHECKS is not set
+CONFIG_RUNTIME_ERROR_CHECKS=y
+
+#
+# Build Options
+#
+CONFIG_KERNEL_BIN_NAME="zephyr"
+CONFIG_OUTPUT_STAT=y
+# CONFIG_OUTPUT_SYMBOLS is not set
+# CONFIG_OUTPUT_DISASSEMBLY is not set
+CONFIG_OUTPUT_PRINT_MEMORY_USAGE=y
+# CONFIG_CLEANUP_INTERMEDIATE_FILES is not set
+# CONFIG_BUILD_OUTPUT_EXE is not set
+# CONFIG_BUILD_OUTPUT_S19 is not set
+# CONFIG_BUILD_OUTPUT_STRIPPED is not set
+# CONFIG_BUILD_OUTPUT_COMPRESS_DEBUG_SECTIONS is not set
+# CONFIG_BUILD_ALIGN_LMA is not set
+# CONFIG_APPLICATION_DEFINED_SYSCALL is not set
+# CONFIG_MAKEFILE_EXPORTS is not set
+# CONFIG_BUILD_OUTPUT_META is not set
+CONFIG_BUILD_OUTPUT_STRIP_PATHS=y
+CONFIG_CHECK_INIT_PRIORITIES=y
+# CONFIG_EMIT_ALL_SYSCALLS is not set
+# end of Build Options
+
+CONFIG_WARN_DEPRECATED=y
+# CONFIG_WARN_EXPERIMENTAL is not set
+CONFIG_ENFORCE_ZEPHYR_STDINT=y
+# end of Build and Link Features
+
+#
+# Boot Options
+#
+# CONFIG_BOOTLOADER_BOSSA is not set
+# end of Boot Options
+
+#
+# Compatibility
+#
+CONFIG_LEGACY_GENERATED_INCLUDE_PATH=y
+# end of Compatibility

--- a/tests/kconfig/stray/testcase.yaml
+++ b/tests/kconfig/stray/testcase.yaml
@@ -1,0 +1,13 @@
+common:
+  tags: kconfig
+  platform_allow:
+    - qemu_x86
+tests:
+  configuration.preset:
+    harness: pytest
+    harness_config:
+      pytest_root:
+        - "pytest/test_sample.py"
+      pytest_args:
+        - "--test_kconfig"
+        - "test.config"


### PR DESCRIPTION
A test to check for feature Kconfig options showing up without being
enabled, i.e. config options leaking because of missing guards in the
area where they are introduced.

The baseline test.config is the output from

 west build -b qemu_x86 samples/hello_world/

It does have many kconfig options that should not be there, so this
needs to be updated once we have fixed some of the existing leakage.


Signed-off-by: Anas Nashif <anas.nashif@intel.com>
