### PR TITLE
soc: st: stm32f765xx: Correct total number of IRQS.

### DIFF
--- a/soc/st/stm32/stm32f7x/Kconfig.defconfig.stm32f765xx
+++ b/soc/st/stm32/stm32f7x/Kconfig.defconfig.stm32f765xx
@@ -6,7 +6,7 @@
 if SOC_STM32F765XX
 
 config NUM_IRQS
-	default 100
+	default 110
 
 config CPU_HAS_FPU_DOUBLE_PRECISION
 	default y


### PR DESCRIPTION
The total number of IRQs for this chip is 110. Refer to the reference manual table 46 for IRQs.