### PR TITLE
drivers: adc: fix missing ref_internal in adc_sam0

### DIFF
--- a/drivers/adc/adc_sam0.c
+++ b/drivers/adc/adc_sam0.c
@@ -506,6 +506,7 @@ static int adc_sam0_read_async(const struct device *dev,
 static const struct adc_driver_api adc_sam0_api = {
 	.channel_setup = adc_sam0_channel_setup,
 	.read = adc_sam0_read,
+	.ref_internal = 1000U,			/* Fixed 1.0 V reference */
 #ifdef CONFIG_ADC_ASYNC
 	.read_async = adc_sam0_read_async,
 #endif


### PR DESCRIPTION
The `.ref_internal` field in the `adc_driver_api` struct was previously unset. Now it's set to the proper value, 1 V.