### PR TITLE
bl5340_dvk: Move MIPI_DBI interface back to spi4

### DIFF
--- a/boards/ezurio/bl5340_dvk/bl5340_dvk_nrf5340_cpuapp_common.dtsi
+++ b/boards/ezurio/bl5340_dvk/bl5340_dvk_nrf5340_cpuapp_common.dtsi
@@ -111,7 +111,7 @@
 		compatible = "zephyr,mipi-dbi-spi";
 		reset-gpios = <&gpio0 6 GPIO_ACTIVE_LOW>;
 		dc-gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
-		spi-dev = <&spi2>;
+		spi-dev = <&spi4>;
 		write-only;
 		#address-cells = <1>;
 		#size-cells = <0>;


### PR DESCRIPTION
Commit 3dbbb73 accidentally changed the MIPI_DBI spi interface from
spi4 to spi2 for this board during conversion to use the MIPI_DBI wrapper.

This does not work, and this change reverts it back to spi4.

Tested on actual boards (bl5340, bl5340pa).
Before this change LVGL demo displays nothing, after this change it works
fine again.

Signed-off-by: Daniel Berlin <dberlin@dberlin.org>

fixes: https://github.com/zephyrproject-rtos/zephyr/issues/75967
