### PR TITLE
sensor: bmm150: support power domains

### DIFF
--- a/drivers/sensor/bosch/bmm150/bmm150.h
+++ b/drivers/sensor/bosch/bmm150/bmm150.h
@@ -225,6 +225,8 @@ enum bmm150_presets {
 
 int bmm150_trigger_mode_init(const struct device *dev);
 
+int bmm150_trigger_mode_power_ctrl(const struct device *dev, bool enable);
+
 int bmm150_trigger_set(const struct device *dev,
 		       const struct sensor_trigger *trig,
 		       sensor_trigger_handler_t handler);


### PR DESCRIPTION
Support the BMM150 being on a power domain, which may not be powered at boot. For example, Nordic Thingy53.