### PR TITLE
power_domain: gpio: raw follower GPIOs

### DIFF
--- a/dts/bindings/power-domain/power-domain-gpio.yaml
+++ b/dts/bindings/power-domain/power-domain-gpio.yaml
@@ -19,6 +19,24 @@ properties:
       selector.  The Linux enable-active-high and gpio-open-drain
       properties are not valid for Zephyr devicetree files.
 
+  raw-follower-gpios:
+    type: phandle-array
+    description: |
+      Extra list of GPIOs that 'follow' the state of the power domain.
+      These GPIOs are set to physical level '0' when the domain transitions
+      to SUSPENDED, and set to physical level '1' when the domain transitions
+      to ACTIVE. The logical levels (ACTIVE_HIGH/ACTIVE_LOW) are not modified
+      by this action (through gpio_pin_configure).
+
+      This behaviour is intended to be used when an SPI device is on a power
+      domain and the CS pin is explicitly driven high and low by the SoC,
+      instead of having an external pull-up to the voltage rail. The idle
+      state of the CS pin needs to be high, but when the power domain goes down
+      the CS pin needs to go low to avoid back-powering the device.
+
+      This property is NOT needed when the CS pins have an external pullup
+      to the voltage rail that is being switched.
+
   startup-delay-us:
     type: int
     default: 0


### PR DESCRIPTION
Extra list of GPIOs that 'follow' the state of the power domain. These GPIOs are set to physical level '0' when the domain transitions to SUSPENDED, and set to physical level '1' when the domain transitions to ACTIVE. The logical levels (ACTIVE_HIGH/ACTIVE_LOW) are not modified by this action (through gpio_pin_configure).

This behaviour is intended to be used when an SPI device is on a power domain and the CS pin is explicitly driven high and low by the SoC, instead of having an external pull-up to the voltage rail. The idle state of the CS pin needs to be high, but when the power domain goes down the CS pin needs to go low to avoid back-powering the device.

This property is NOT needed when the CS pins have an external pullup to the voltage rail that is being switched.

The BMI270 sensor on the Nordic Thingy53 is an example of this hardware setup.

Alternate solutions were considered:

1. Device drivers handles the problem.

Would require modification in every single SPI device driver to properly handle this, even if abstracted with a `spi_handle_power_down/up()` helper function.
 
2. Handling in SPI drivers

SPI drivers have no link to the devices, only devices link back to the SPI drivers. Even if such a link is added, the SPI drivers have no reason to be notified of power domain transitions of arbitrary devices, and don't store CS pin configuration in any case.

3. Automatic handling in the power domain driver

While the power domains end up with a list of devices on them, this is only populated at link-time, not compile-time. As a result, the power domain would need some way to query the CS pin configuration at runtime, for arbitrary devices which may or may not be SPI devices. This sounds like a thorny problem.

4. Design better hardware without this problem

Sadly the Thingy53 already exists in the world and is a Zephyr supported platform.
