### PR TITLE
scripts: ci: test_plan: use find_modules only when commits are provided

### DIFF
--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -149,7 +149,7 @@ class Filters:
             os.remove(fname)
 
     def find_modules(self):
-        if 'west.yml' in self.modified_files:
+        if 'west.yml' in self.modified_files and args.commits is not None:
             print(f"Manifest file 'west.yml' changed")
             print("=========")
             old_manifest_content = repo_to_scan.git.show(f"{args.commits[:-2]}:west.yml")


### PR DESCRIPTION
Current implementation will not work if comits were not provided. ie. use case with list of changed files will fail as args.commits is None.