### PR TITLE
net: sockets: tls: Fix poll update event check

### DIFF
--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -3240,9 +3240,11 @@ static int ztls_poll_update_ctx(struct tls_context *ctx,
 
 	if (pfd->events & ZSOCK_POLLIN) {
 		ret = ztls_poll_update_pollin(pfd->fd, ctx, pfd);
-		if (ret == -EAGAIN && pfd->revents != 0) {
+		if (ret == -EAGAIN && pfd->revents == 0) {
 			(*pev - 1)->state = K_POLL_STATE_NOT_READY;
 			goto exit;
+		} else {
+			ret = 0;
 		}
 	}
 exit:


### PR DESCRIPTION
In case POLLIN is set, and no new application data has been detected, the ztls_poll_update_ctx() should only return -EAGAIN if no other events are available for the socket. Otherwise, the function may end up busy-looping, in case for example POLLOUT is also monitored for the socket.

Current check verifying that was wrong, as it caused to function to return -EAGAIN even if some other events could've been reported for the socket.

Fixes #75909