### PR TITLE
ipc: ipc_service: pbuf: Add option to disable cache management

### DIFF
--- a/tests/subsys/ipc/pbuf/prj.conf
+++ b/tests/subsys/ipc/pbuf/prj.conf
@@ -5,3 +5,9 @@ CONFIG_ZTEST_SHUFFLE=y
 CONFIG_IPC_SERVICE=y
 CONFIG_IPC_SERVICE_ICMSG=y
 CONFIG_PBUF=y
+# pbuf is designed to run writer and reader code on two CPUs.
+# The write function cannot be preempted by the read function in a CPU,
+# or the cache management could result in data corruption.
+# In the tests, the reader and the writer are executed on a single CPU.
+# Disable data cache management to prevent potential data corruption.
+CONFIG_CACHE_MANAGEMENT=n


### PR DESCRIPTION
When packet buffer has producer and consumer on the same core then cache management shall not be used as it will eventually lead to data corruption. Add option to disable cache management and use that in the test which is executed on a single core.