### PR TITLE
Reintroduce webp images in PDF as they're now supported in Sphinx

### DIFF
--- a/doc/develop/tools/clion.rst
+++ b/doc/develop/tools/clion.rst
@@ -58,12 +58,10 @@ not happen, go to :menuselection:`Settings --> Build, Execution, Deployment --> 
 #. Click :menuselection:`Add environment --> From file` and select
    ``..\.venv\Scripts\activate.bat``.
 
-   .. only:: html
-
-      .. figure:: img/clion_toolchain_mingw.webp
-         :width: 600px
-         :align: center
-         :alt: MinGW toolchain with environment script
+   .. figure:: img/clion_toolchain_mingw.webp
+      :width: 600px
+      :align: center
+      :alt: MinGW toolchain with environment script
 
    Click :guilabel:`Apply` to save the changes.
 
@@ -74,12 +72,10 @@ not happen, go to :menuselection:`Settings --> Build, Execution, Deployment --> 
 
       -DBOARD=nrf52840dk/nrf52840
 
-   .. only:: html
-
-      .. figure:: img/clion_cmakeprofile.webp
-         :width: 600px
-         :align: center
-         :alt: CMake profile
+   .. figure:: img/clion_cmakeprofile.webp
+      :width: 600px
+      :align: center
+      :alt: CMake profile
 
 #. Click :guilabel:`Apply` to save the changes.
 
@@ -170,21 +166,17 @@ your setup is different, make sure to adjust the configuration settings accordin
         * - :guilabel:`TCP/IP port`
           - Auto
 
-   .. only:: html
-
-      .. figure:: img/clion_gdbserverconfig.webp
-         :width: 500px
-         :align: center
-         :alt: Embedded GDB server configuration
+    .. figure:: img/clion_gdbserverconfig.webp
+       :width: 500px
+       :align: center
+       :alt: Embedded GDB server configuration
 
 #. Click :guilabel:`Next` to set the Segger J-Link parameters.
 
-   .. only:: html
-
-      .. figure:: img/clion_segger_settings.webp
-         :width: 500px
-         :align: center
-         :alt: Segger J-Link parameters
+    .. figure:: img/clion_segger_settings.webp
+       :width: 500px
+       :align: center
+       :alt: Segger J-Link parameters
 
 #. Click :guilabel:`Create` when ready.
 
@@ -201,12 +193,10 @@ Start debugging
    Zephyr tasks are listed in the :guilabel:`Threads & Variables` pane. You can switch between them
    and inspect the variables for each task.
 
-   .. only:: html
-
-      .. figure:: img/clion_debug_threads.webp
-         :width: 800px
-         :align: center
-         :alt: Viewing Zephyr tasks during a debug session
+    .. figure:: img/clion_debug_threads.webp
+       :width: 800px
+       :align: center
+       :alt: Viewing Zephyr tasks during a debug session
 
    Refer to `CLion web help`_ for detailed description of the IDE debug capabilities.
 


### PR DESCRIPTION
EDIT: this PR now only re-introduces webp support, since admonitions nested inside tables work just fine with new Sphinx maintenance release as can be seen at https://docs.zephyrproject.org/latest/zephyr.pdf

* Now that Sphinx 7.4 is out, it is possible to use webp images in the PDF documentation (they're converted to png).
* ~~Don't use admonitions inside tables as they can cause PDF build to fail.~~


For the anecdote, Sphinx 7.4 (which just came out) is providing much better styling of adminitions in the PDF output.
Before / after below:

<img width="705" alt="image" src="https://github.com/user-attachments/assets/b1725da6-dbd1-4223-8c27-446e24935a9a">

<img width="694" alt="image" src="https://github.com/user-attachments/assets/722890eb-f23e-4d03-b7b0-d1505c1fa93a">
