### PR TITLE
doc: doxygen: some minor fixes

### DIFF
--- a/doc/_doxygen/groups.dox
+++ b/doc/_doxygen/groups.dox
@@ -68,6 +68,7 @@
 
 @brief Modem APIs
 @defgroup modem Modem APIs
+@ingroup connectivity
 @since 3.5
 @version 0.1.0
 @{

--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -925,7 +925,6 @@ INPUT                  = @ZEPHYR_BASE@/doc/_doxygen/mainpage.md \
                          @ZEPHYR_BASE@/doc/_doxygen/groups.dox \
                          @ZEPHYR_BASE@/kernel/include/kernel_arch_interface.h \
                          @ZEPHYR_BASE@/include/zephyr/arch/cache.h \
-                         @ZEPHYR_BASE@/include/zephyr/sys/arch_interface.h \
                          @ZEPHYR_BASE@/include/zephyr/sys/atomic.h \
                          @ZEPHYR_BASE@/include/ \
                          @ZEPHYR_BASE@/lib/libc/minimal/include/ \

--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -1105,7 +1105,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE = mainpage.md
+USE_MDFILE_AS_MAINPAGE = @ZEPHYR_BASE@/doc/_doxygen/mainpage.md
 
 # The Fortran standard specifies that for fixed formatted Fortran code all
 # characters from position 72 are to be considered as comment. A common

--- a/include/zephyr/bindesc.h
+++ b/include/zephyr/bindesc.h
@@ -27,6 +27,7 @@ extern "C" {
 /**
  * @brief Binary Descriptor Definition
  * @defgroup bindesc_define Bindesc Define
+ * @ingroup os_services
  * @{
  */
 

--- a/include/zephyr/debug/mipi_stp_decoder.h
+++ b/include/zephyr/debug/mipi_stp_decoder.h
@@ -15,7 +15,7 @@ extern "C" {
 
 /**
  * @defgroup mipi_stp_decoder_apis STP Decoder API
- * @ingroup coresight_apis
+ * @ingroup os_services
  * @{
  */
 

--- a/include/zephyr/debug/symtab.h
+++ b/include/zephyr/debug/symtab.h
@@ -15,6 +15,7 @@ extern "C" {
 
 /**
  * @defgroup symtab_apis Symbol Table API
+ * @ingroup os_services
  * @{
  */
 

--- a/include/zephyr/drivers/tee.h
+++ b/include/zephyr/drivers/tee.h
@@ -46,7 +46,7 @@
 /**
  * @brief Trusted Execution Environment Interface
  * @defgroup tee_interface TEE Interface
- * @ingroup security
+ * @ingroup io_interfaces
  * @{
  *
  * The generic interface to work with Trusted Execution Environment (TEE).

--- a/include/zephyr/dt-bindings/sensor/icm42688.h
+++ b/include/zephyr/dt-bindings/sensor/icm42688.h
@@ -8,6 +8,7 @@
 
 /**
  * @defgroup ICM42688 Invensense (TDK) ICM42688 DT Options
+ * @ingroup sensor_interface
  * @{
  */
 

--- a/include/zephyr/net/dns_sd.h
+++ b/include/zephyr/net/dns_sd.h
@@ -126,7 +126,7 @@ extern "C" {
  * The service can be referenced using the @p id variable.
  *
  * Example (with TXT):
- * @code{c}
+ * @code{.c}
  * #include <zephyr/net/dns_sd.h>
  * static const bar_txt[] = {
  *   "\x06" "path=/"
@@ -140,7 +140,7 @@ extern "C" {
  * static uint16_t bar_port;
  * DNS_SD_REGISTER_TCP_SERVICE(bar, CONFIG_NET_HOSTNAME,
  *   "_bar", "local", bar_txt, &bar_port);
- * @endcode{c}
+ * @endcode
  *
  * TXT records begin with a single length byte (hex-encoded)
  * and contain key=value pairs. Thus, the length of the key-value pair
@@ -172,13 +172,13 @@ extern "C" {
  * The service can be referenced using the @p id variable.
  *
  * Example (no TXT):
- * @code{c}
+ * @code{.c}
  * #include <zephyr/net/dns_sd.h>
  * #include <zephyr/sys/byteorder.h>
  * static const foo_port = sys_cpu_to_be16(4242);
  * DNS_SD_REGISTER_UDP_SERVICE(foo, CONFIG_NET_HOSTNAME,
  *   "_foo", DNS_SD_EMPTY_TXT, &foo_port);
- * @endcode{c}
+ * @endcode
  *
  * @param id variable name for the DNS-SD service record
  * @param instance name of the service instance such as "My TFTP Server"

--- a/lib/libc/armstdc/include/errno.h
+++ b/lib/libc/armstdc/include/errno.h
@@ -35,7 +35,6 @@
  *        'C Library ABI for the Arm® Architecture, 2021Q1'
  *
  * @defgroup system_errno Error numbers
- * @ingroup c_std_lib
  * @{
  */
 

--- a/lib/libc/armstdc/src/errno.c
+++ b/lib/libc/armstdc/src/errno.c
@@ -18,7 +18,6 @@
  *        'C Library ABI for the Arm® Architecture, 2021Q1'
  *
  * @defgroup system_errno Error numbers
- * @ingroup c_std_lib
  * @{
  */
 

--- a/lib/libc/minimal/include/errno.h
+++ b/lib/libc/minimal/include/errno.h
@@ -25,7 +25,6 @@
  *        Error codes returned by functions.
  *        Includes a list of those defined by IEEE Std 1003.1-2017.
  * @defgroup system_errno Error numbers
- * @ingroup c_std_lib
  * @{
  */
 


### PR DESCRIPTION
Some minor doxygen fixes. Note that we probably need to rethink grouping, there are some areas that do not have a suitable candidate right now. For now, let's remove them from the top level at least.