### PR TITLE
runners: jlink: flash hex file for debug session

### DIFF
--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -276,7 +276,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
             if command == 'debug':
                 client_cmd += ['-ex', 'monitor halt',
                                '-ex', 'monitor reset',
-                               '-ex', 'load']
+                               '-ex', f'load {self.hex_name}' if self.hex_name is not None else 'load']
                 if self.reset:
                     client_cmd += ['-ex', 'monitor reset']
             if not self.gdb_host:


### PR DESCRIPTION
If the bootloader relies on a signed HEX file, we can not write
the ELF file to flash. Instead the HEX file needs to be used.

Signed-off-by: David Schneider <david.schneider@chargepoint.com>