### PR TITLE
MAINTAINERS: Exclude BT classic from BT host

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -398,6 +398,9 @@ Bluetooth Host:
     - subsys/bluetooth/shell/
     - tests/bluetooth/host*/
     - tests/bsim/bluetooth/host/
+  files-exclude:
+    - subsys/bluetooth/host/classic/
+    - include/zephyr/bluetooth/classic/
   labels:
     - "area: Bluetooth Host"
     - "area: Bluetooth"
@@ -475,6 +478,7 @@ Bluetooth Classic:
     - include/zephyr/bluetooth/classic/
   labels:
     - "area: Bluetooth Classic"
+    - "area: Bluetooth"
   tests:
     - bluetooth
 


### PR DESCRIPTION
Treat Bluetooth Classic similar to Bluetooth Mesh and Audio by not including it in the BT host, as most of the BT Host people are LE-only.