### PR TITLE
Bugfixes for ISO Sync Receiver

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -7864,7 +7864,7 @@ static void le_big_sync_established(struct pdu_data *pdu,
 	sync_iso = node_rx->rx_ftr.param;
 	lll = &sync_iso->lll;
 
-	evt_size = sizeof(*sep) + (lll->num_bis * sizeof(uint16_t));
+	evt_size = sizeof(*sep) + (lll->stream_count * sizeof(uint16_t));
 
 	sep = meta_evt(buf, BT_HCI_EVT_LE_BIG_SYNC_ESTABLISHED, evt_size);
 	sep->big_handle = (uint8_t)node_rx->hdr.handle;

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -1445,6 +1445,24 @@ static void sync_lost(void *param)
 
 	/* Enqueue the sync lost towards ULL context */
 	ll_rx_put_sched(rx->hdr.link, rx);
+
+#if defined(CONFIG_BT_CTLR_SYNC_ISO)
+	if (sync->iso.sync_iso) {
+		/* ISO create BIG flag in the periodic advertising context is still set */
+		struct ll_sync_iso_set *sync_iso;
+
+		sync_iso = sync->iso.sync_iso;
+
+		rx = (void *)&sync_iso->node_rx_lost;
+		rx->hdr.handle = sync_iso->big_handle;
+		rx->hdr.type = NODE_RX_TYPE_SYNC_ISO;
+		rx->rx_ftr.param = sync_iso;
+		*((uint8_t *)rx->pdu) = BT_HCI_ERR_CONN_FAIL_TO_ESTAB;
+
+		/* Enqueue the sync iso lost towards ULL context */
+		ll_rx_put_sched(rx->hdr.link, rx);
+	}
+#endif /* CONFIG_BT_CTLR_SYNC_ISO */
 }
 
 #if defined(CONFIG_BT_CTLR_CHECK_SAME_PEER_SYNC)

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
@@ -712,6 +712,23 @@ void ull_sync_iso_done(struct node_rx_event_done *done)
 		elapsed_event = latency_event + 1U;
 	}
 
+	/* Check for establishmet failure */
+	if (done->extra.estab_failed) {
+		uint8_t handle;
+		uint32_t ret;
+
+		/* Stop Sync ISO Ticker directly. Establishment failure has been
+		 * notified.
+		 */
+		handle = sync_iso_handle_get(sync_iso);
+		ret = ticker_stop(TICKER_INSTANCE_ID_CTLR, TICKER_USER_ID_ULL_HIGH,
+				  (TICKER_ID_SCAN_SYNC_ISO_BASE +
+				  sync_iso_handle_to_index(handle)), NULL, NULL);
+		LL_ASSERT((ret == TICKER_STATUS_SUCCESS) ||
+			  (ret == TICKER_STATUS_BUSY));
+		return;
+	}
+
 	/* Sync drift compensation and new skip calculation
 	 */
 	ticks_drift_plus = 0U;


### PR DESCRIPTION
**Bluetooth: controller: Fix number of handles in le_big_sync_established**
Use lll->stream_count instead of lll->num_bis for returning the correct
number of handles.

**Bluetooth: controller: Stop Sync ISO ticker when establishment fails**
When an ISO stream fails to sync to a broadcaster within the first 6
events, the establishment fails (as expected). However, it did not stop
the ticker, and subsequently it was impossible to establish a new sync
after this.
Make asynchronous call to ticker_stop when establishment fails, and exit
done handling. Cleanup is handled via ll_rx_dequeue().

**Bluetooth: controller: Notify when BIG create fails due to timeout**
When periodic scanning reaches timeout and BIGinfo has not yet been
received, notify with BT_HCI_ERR_CONN_FAIL_TO_ESTAB for sync receiver.