### PR TITLE
Bluetooth: controller: Add lll_sync_iso_flush interface to LLL

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_sync_iso.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_sync_iso.h
@@ -90,6 +90,7 @@ int lll_sync_iso_init(void);
 int lll_sync_iso_reset(void);
 void lll_sync_iso_create_prepare(void *param);
 void lll_sync_iso_prepare(void *param);
+void lll_sync_iso_flush(uint8_t handle, struct lll_sync_iso *lll);
 
 extern uint8_t ull_sync_iso_lll_index_get(struct lll_sync_iso *lll);
 extern struct lll_sync_iso_stream *ull_sync_iso_lll_stream_get(uint16_t handle);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
@@ -101,6 +101,12 @@ void lll_sync_iso_prepare(void *param)
 	prepare_bh(param);
 }
 
+void lll_sync_iso_flush(uint8_t handle, struct lll_sync_iso *lll)
+{
+	ARG_UNUSED(handle);
+	ARG_UNUSED(lll);
+}
+
 static int init_reset(void)
 {
 	return 0;

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_types.h
@@ -111,6 +111,9 @@ struct ll_sync_iso_set {
 	/* Periodic Advertising Sync that contained the BIGInfo */
 	struct ll_sync_set *sync;
 
+	/* Pointer to semaphore used for LLL flushing */
+	struct k_sem *flush_sem;
+
 	/* Periodic Advertising Sync timeout */
 	uint16_t timeout;
 	uint16_t volatile timeout_reload; /* Non-zero when sync established */


### PR DESCRIPTION
When the ISO sync receiver has been disabled (terminted), ULL now calls lll_sync_iso_flush in lower link layer, to allow cleanup and releasing of resources.

Make sure ISO sync LLL flush is also called when terminating a stream from local side (app). Add blocking mayfly call to lll_sync_iso_flush in ll_big_sync_terminate.