### PR TITLE
Bluetooth: controller: Send TX PDU release with no DP to vendor function

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/ull/ull_iso_vendor.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/ull/ull_iso_vendor.c
@@ -9,7 +9,21 @@
 
 #include <zephyr/bluetooth/hci_types.h>
 #include "isoal.h"
+
+#include "util/util.h"
+#include "util/memq.h"
+
+#include "hal/ccm.h"
+
+#include "pdu_df.h"
+#include "lll/pdu_vendor.h"
+#include "pdu.h"
+#include "lll.h"
+#include "lll_conn.h"
+
 #include "ull_iso_types.h"
+#include "ull_conn_internal.h"
+#include "ull_internal.h"
 
 /* FIXME: Implement vendor specific data path configuration */
 static bool dummy;
@@ -42,7 +56,6 @@ bool ll_data_path_source_create(uint16_t handle,
 uint8_t ll_configure_data_path(uint8_t data_path_dir, uint8_t data_path_id,
 			       uint8_t vs_config_len, uint8_t *vs_config)
 {
-	ARG_UNUSED(data_path_dir);
 	ARG_UNUSED(data_path_id);
 	ARG_UNUSED(vs_config_len);
 	ARG_UNUSED(vs_config);
@@ -53,4 +66,14 @@ uint8_t ll_configure_data_path(uint8_t data_path_dir, uint8_t data_path_id,
 	}
 
 	return 0;
+}
+
+void ll_data_path_tx_pdu_release(uint16_t handle, struct node_tx_iso *node_tx)
+{
+	/* FIXME: ll_tx_ack_put is not LLL callable as it is
+	 * used by ACL connections in ULL context to dispatch
+	 * ack.
+	 */
+	ll_tx_ack_put(handle, (void *)node_tx);
+	ll_rx_sched();
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_iso_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso_internal.h
@@ -47,3 +47,6 @@ bool ll_data_path_source_create(uint16_t handle,
 				isoal_source_pdu_write_cb *pdu_write,
 				isoal_source_pdu_emit_cb *pdu_emit,
 				isoal_source_pdu_release_cb *pdu_release);
+
+/* Must be implemented by vendor if vendor-specific data path is supported */
+void ll_data_path_tx_pdu_release(uint16_t handle, struct node_tx_iso *node_tx);


### PR DESCRIPTION
If a race condition occurs between stopping CIS stream and tearing down data path, releasing TX PDUs was not possible for vendor data path, as the DP configuration is gone.

In that case, call a new vendor specific function for cleaning up and returning PDUs to correct pool.