### PR TITLE
arch: riscv: handle PMP setting for _Fault handler

### DIFF
--- a/arch/riscv/core/fatal.c
+++ b/arch/riscv/core/fatal.c
@@ -226,6 +226,13 @@ void _Fault(struct arch_esf *esf)
 	unsigned int reason = K_ERR_CPU_EXCEPTION;
 
 	if (bad_stack_pointer(esf)) {
+#ifdef CONFIG_PMP_STACK_GUARD
+		/*
+		 * Remove the thread's PMP setting to prevent triggering a stack
+		 * overflow error again due to the previous configuration.
+		 */
+		z_riscv_pmp_stackguard_disable();
+#endif /* CONFIG_PMP_STACK_GUARD */
 		reason = K_ERR_STACK_CHK_FAIL;
 	}
 

--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -347,6 +347,21 @@ no_fp:	/* increment _current->arch.exception_depth */
 	 */
 	li t1, RISCV_EXC_ECALLU
 	beq t0, t1, is_user_syscall
+
+#ifdef CONFIG_PMP_STACK_GUARD
+	/*
+	 * Determine if we come from user space. If so, reconfigure the PMP for
+	 * kernel mode stack guard.
+	 */
+	csrr t0, mstatus
+	li t1, MSTATUS_MPP
+	and t0, t0, t1
+	bnez t0, 1f
+	lr a0, ___cpu_t_current_OFFSET(s0)
+	call z_riscv_pmp_stackguard_enable
+1:
+#endif /* CONFIG_PMP_STACK_GUARD */
+
 #endif /* CONFIG_USERSPACE */
 
 	/*

--- a/arch/riscv/include/pmp.h
+++ b/arch/riscv/include/pmp.h
@@ -10,6 +10,7 @@
 void z_riscv_pmp_init(void);
 void z_riscv_pmp_stackguard_prepare(struct k_thread *thread);
 void z_riscv_pmp_stackguard_enable(struct k_thread *thread);
+void z_riscv_pmp_stackguard_disable(void);
 void z_riscv_pmp_usermode_init(struct k_thread *thread);
 void z_riscv_pmp_usermode_prepare(struct k_thread *thread);
 void z_riscv_pmp_usermode_enable(struct k_thread *thread);


### PR DESCRIPTION
When `CONFIG_RISCV_ALWAYS_SWITCH_THROUGH_ECALL` is enabled, `do_swap()` from `_Fault` triggers a PMP error again if the fault is caused by a PMP violation. This PR handles the PMP settings for faults caused by PMP violations:

1. For kernel thread stack overflow:
Remove the previous thread's PMP configuration.

2. For user thread violates memory protection:
Configure the PMP for the thread's privileged stack.

Although this bug occurs only when `CONFIG_RISCV_ALWAYS_SWITCH_THROUGH_ECALL` is enabled, I think these fixes are also compatible when `CONFIG_RISCV_ALWAYS_SWITCH_THROUGH_ECALL` is disabled.

Fixes: #75959 