### PR TITLE
drivers: mdio: Clear interrupt signal in ISR

### DIFF
--- a/drivers/mdio/mdio_nxp_enet.c
+++ b/drivers/mdio/mdio_nxp_enet.c
@@ -170,6 +170,8 @@ static void nxp_enet_mdio_isr_cb(const struct device *dev)
 {
 	struct nxp_enet_mdio_data *data = dev->data;
 
+	data->base->EIR |= ENET_EIR_MII_MASK;
+
 	/* Signal that operation finished */
 	k_sem_give(&data->mdio_sem);
 


### PR DESCRIPTION
Apparently, disabling the intterupt is not enough, because without clearing the flag, some errors are occurring.

Fixes #76446