### PR TITLE
doc: release-notes/3.7: demand paging, thread stack size and Intel audio DSP

### DIFF
--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -335,6 +335,7 @@ Boards & SoC Support
 
 * Made these changes in other SoC series:
 
+  * Intel ACE Audio DSP: Use dedicated registers to report boot status instead of arbitrary memory.
   * ITE: Rename the Kconfig symbol for all ITE SoC variants.
   * STM32: Enabled ART Accelerator, I-cache, D-cache and prefetch on compatible series.
   * STM32H5: Added support for Stop mode and :kconfig:option:`CONFIG_PM`.

--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -266,6 +266,12 @@ Kernel
     has the special ``zephyr,deferred-init`` property set. The device can be
     initialized later in time by using :c:func:`device_init`.
 
+  * The declaration of statically allocated thread stacks have been updated to utilize
+    :c:macro:`K_THREAD_STACK_LEN` for both single thread stack declaration and array thread
+    stack declarations. This ensures correct alignment for all thread stacks. For user
+    threads, this may increase the size of the statically allocated stack objects depending
+    on architecture alignment requirements.
+
 Bluetooth
 *********
 * Audio

--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -1306,6 +1306,14 @@ Libraries / Subsystems
    * By enabling :kconfig:option:`CONFIG_SYMTAB`, the symbol table will be
      generated with Zephyr link stage executable on supported architectures.
 
+* Demand Paging
+
+  * NRU (Not Recently Used) eviction algorithm has updated its selection logic to avoid
+    picking the same page to evict constantly. The updated login now searches for a new
+    candidate linearly after the last evicted page.
+
+  * Added LRU (Least Recently Used) eviction algorithm.
+
 * Management
 
   * hawkBit


### PR DESCRIPTION
Adding some bits on the release notes about:

* Eviction algorithms on demand paging.
* Size for statically allocated thread stacks.
* The boot process visible to the host of the Intel Audio DSP has changed.