### PR TITLE
S32Z: Add I2C driver over I3C HW IP

### DIFF
--- a/boards/nxp/s32z2xxdc2/doc/index.rst
+++ b/boards/nxp/s32z2xxdc2/doc/index.rst
@@ -53,6 +53,8 @@ The boards support the following hardware features:
 +-----------+------------+-------------------------------------+
 | CANEXCEL  | on-chip    | can                                 |
 +-----------+------------+-------------------------------------+
+| I3C       | on-chip    | i2c                                 |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not currently supported by the port.
 

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270.dtsi
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270.dtsi
@@ -5,6 +5,14 @@
  */
 
 #include "s32z2xxdc2_s32z270_pinctrl.dtsi"
+#include <zephyr/dt-bindings/i2c/i2c.h>
+
+/ {
+	aliases {
+		watchdog0 = &swt0;
+		eeprom-0 = &eeprom0;
+	};
+};
 
 &swt0 {
 	status = "okay";
@@ -40,4 +48,23 @@
 &can1 {
 	pinctrl-0 = <&can1_default>;
 	pinctrl-names = "default";
+};
+
+&i3c2 {
+	pinctrl-0 = <&i3c2_default>;
+	pinctrl-names = "default";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	baudrate-cfg = <I2C_BITRATE_STANDARD 500000 6000000>,
+			<I2C_BITRATE_FAST 1000000 6000000>,
+			<I2C_BITRATE_FAST_PLUS 1000000 6000000>;
+	status = "okay";
+
+	eeprom0: eeprom@50 {
+		compatible = "atmel,at24";
+		reg = <0x50>;
+		size = <128>;
+		pagesize = <8>;
+		address-width = <8>;
+		timeout = <5>;
+	};
 };

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_pinctrl.dtsi
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_pinctrl.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 NXP
+ * Copyright 2022-2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -83,6 +83,16 @@
 		group2 {
 			pinmux = <PM10_CANXL_1_TX>;
 			output-enable;
+		};
+	};
+
+	i3c2_default: i3c2_default {
+		group1 {
+			pinmux = <(PJ11_I3C_2_SDA0_I | PJ11_I3C_2_SDA0_O)>,
+				<(PJ10_I3C_2_SCL_I | PJ10_I3C_2_SCL_O)>;
+			input-enable;
+			output-enable;
+			drive-open-drain;
 		};
 	};
 };

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu0.dts
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu0.dts
@@ -16,10 +16,6 @@
 		zephyr,sram = &sram0;
 		zephyr,canbus = &can0;
 	};
-
-	aliases {
-		watchdog0 = &swt0;
-	};
 };
 
 &mru0 {

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu0.yaml
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu0.yaml
@@ -16,4 +16,6 @@ supported:
   - can
   - spi
   - counter
+  - i2c
+  - eeprom
 vendor: nxp

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu0_D.yaml
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu0_D.yaml
@@ -16,4 +16,6 @@ supported:
   - can
   - spi
   - counter
+  - i2c
+  - eeprom
 vendor: nxp

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu1.dts
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu1.dts
@@ -18,10 +18,6 @@
 		zephyr,shell-uart = &uart0;
 		zephyr,canbus = &can0;
 	};
-
-	aliases {
-		watchdog0 = &swt0;
-	};
 };
 
 &mru4 {

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu1.yaml
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu1.yaml
@@ -16,4 +16,6 @@ supported:
   - can
   - spi
   - counter
+  - i2c
+  - eeprom
 vendor: nxp

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu1_D.yaml
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu1_D.yaml
@@ -16,4 +16,6 @@ supported:
   - can
   - spi
   - counter
+  - i2c
+  - eeprom
 vendor: nxp

--- a/drivers/i2c/CMakeLists.txt
+++ b/drivers/i2c/CMakeLists.txt
@@ -80,6 +80,7 @@ zephyr_library_sources_ifdef(CONFIG_I2C_ENE_KB1200	i2c_ene_kb1200.c)
 zephyr_library_sources_ifdef(CONFIG_GPIO_I2C_SWITCH	gpio_i2c_switch.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_NUMAKER		i2c_numaker.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_MAX32		i2c_max32.c)
+zephyr_library_sources_ifdef(CONFIG_I2C_NXP_S32_I3C		i2c_nxp_s32_i3c.c)
 
 zephyr_library_sources_ifdef(CONFIG_I2C_STM32_V1
 	i2c_ll_stm32_v1.c

--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -129,6 +129,7 @@ source "drivers/i2c/Kconfig.numaker"
 source "drivers/i2c/Kconfig.mcux"
 source "drivers/i2c/Kconfig.ene"
 source "drivers/i2c/Kconfig.max32"
+source "drivers/i2c/Kconfig.nxp_s32"
 
 config I2C_INIT_PRIORITY
 	int "Init priority"

--- a/drivers/i2c/Kconfig.nxp_s32
+++ b/drivers/i2c/Kconfig.nxp_s32
@@ -1,0 +1,20 @@
+# Copyright 2024 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+config I2C_NXP_S32_I3C
+	bool "NXP S32 I2C driver over I3C peripheral"
+	default y if DT_HAS_NXP_S32_I2C_I3C_ENABLED
+	help
+	  Enable I2C support over I3C peripheral on NXP S32 SoCs
+
+if I2C_NXP_S32_I3C
+
+config I2C_NXP_S32_I3C_TRANSFER_TIMEOUT
+	int "Transfer timeout [ms]"
+	default 0
+	help
+	  Timeout in milliseconds used for each I2C transfer. 0 means that the
+	  driver should use the K_FOREVER value, i.e. it should wait as long as
+	  necessary.
+
+endif

--- a/drivers/i2c/i2c_nxp_s32_i3c.c
+++ b/drivers/i2c/i2c_nxp_s32_i3c.c
@@ -1,0 +1,437 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/devicetree.h>
+
+#include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/clock_control.h>
+
+#define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(i2c_nxp_s32_i3c);
+
+#include <I3c_Ip.h>
+#include <I3c_Ip_Irq.h>
+
+#include "i2c-priv.h"
+
+#define DT_DRV_COMPAT nxp_s32_i2c_i3c
+
+#if CONFIG_I2C_NXP_S32_I3C_TRANSFER_TIMEOUT
+#define I3C_NXP_S32_TIMEOUT_MS	K_MSEC(CONFIG_I2C_NXP_S32_I3C_TRANSFER_TIMEOUT)
+#else
+#define I3C_NXP_S32_TIMEOUT_MS	K_FOREVER
+#endif
+
+struct i3c_nxp_s32_config {
+	uint8_t instance;
+	uint8_t num_baudrate;
+	uint32_t bitrate;
+	const struct device *clock_dev;
+	clock_control_subsys_t clock_subsys;
+	const struct pinctrl_dev_config *pincfg;
+
+	I3c_Ip_MasterConfigType *master_cfg;
+
+	I3c_Ip_MasterBaudRateType *baudrate_cfg;
+
+	void (*irq_config_func)(const struct device *dev);
+};
+
+struct i3c_nxp_s32_data {
+	uint32_t functional_clk;
+	uint32_t curr_config;
+	struct k_sem lock;
+	struct k_sem transfer_done;
+	I3c_Ip_TransferConfigType transfer_cfg;
+
+#ifdef CONFIG_I2C_CALLBACK
+	uint32_t num_msgs;
+	uint32_t msg;
+	struct i2c_msg *msgs;
+	i2c_callback_t callback;
+	void *userdata;
+#endif
+};
+
+static int i3c_nxp_s32_configure(const struct device *dev, uint32_t dev_config)
+{
+	const struct i3c_nxp_s32_config *config = dev->config;
+	struct i3c_nxp_s32_data *data = dev->data;
+
+	uint32_t idx;
+	uint32_t i2c_bus_speed;
+
+	if (!(dev_config & I2C_MODE_CONTROLLER)) {
+		LOG_ERR("Target mode is not supported\n");
+		return -ENOTSUP;
+	}
+
+	switch (I2C_SPEED_GET(dev_config)) {
+	case I2C_SPEED_STANDARD:
+		i2c_bus_speed = I2C_BITRATE_STANDARD;
+		break;
+	case I2C_SPEED_FAST:
+		i2c_bus_speed = I2C_BITRATE_FAST;
+		break;
+	case I2C_SPEED_FAST_PLUS:
+		i2c_bus_speed = I2C_BITRATE_FAST_PLUS;
+		break;
+	case I2C_SPEED_DT:
+		i2c_bus_speed = config->bitrate;
+		break;
+	case I2C_SPEED_HIGH:
+		__fallthrough;
+	case I2C_SPEED_ULTRA:
+		__fallthrough;
+	default:
+		return -ENOTSUP;
+	}
+
+	for (idx = 0U; idx < config->num_baudrate; idx++) {
+		if (config->baudrate_cfg[idx].I2cBaudRate == i2c_bus_speed) {
+			break;
+		}
+	}
+
+	if (idx == config->num_baudrate) {
+		LOG_ERR("Missing baudrate configuration for I2C speed %d\n", i2c_bus_speed);
+		return -EINVAL;
+	}
+
+	k_sem_take(&data->lock, K_FOREVER);
+
+	if (I3c_Ip_MasterSetBaudRate(config->instance, data->functional_clk,
+				     &config->baudrate_cfg[idx], I3C_IP_BUS_TYPE_I2C)) {
+		LOG_ERR("Cannot configure baudrate as the controller is not in idle state\n");
+		k_sem_give(&data->lock);
+		return -EBUSY;
+	}
+
+#if (LOG_LEVEL == LOG_LEVEL_DBG)
+	I3c_Ip_MasterBaudRateType baudrate_cfg;
+
+	I3c_Ip_MasterGetBaudRate(config->instance, data->functional_clk, &baudrate_cfg);
+
+	LOG_DBG("Push-pull baudrate = %d, Open-drain baudrate = %d, I2C baudrate = %d\n",
+		baudrate_cfg.PushPullBaudRate, baudrate_cfg.OpenDrainBaudRate,
+		baudrate_cfg.I2cBaudRate);
+#endif
+
+	data->curr_config = dev_config;
+
+	k_sem_give(&data->lock);
+
+	return 0;
+}
+
+static int i3c_nxp_s32_configure_get(const struct device *dev, uint32_t *dev_config)
+{
+	struct i3c_nxp_s32_data *data = dev->data;
+
+	k_sem_take(&data->lock, K_FOREVER);
+
+	*dev_config = data->curr_config;
+
+	k_sem_give(&data->lock);
+
+	return 0;
+}
+
+static int i3c_nxp_s32_transfer_one_msg(const struct device *dev, struct i2c_msg *msg)
+{
+	const struct i3c_nxp_s32_config *config = dev->config;
+	struct i3c_nxp_s32_data *data = dev->data;
+
+	I3c_Ip_StatusType status;
+
+	if (!!(msg->flags & I2C_MSG_ADDR_10_BITS)) {
+		return -ENOTSUP;
+	}
+
+	data->transfer_cfg.SendStop = ((msg->flags & I2C_MSG_STOP) ? true : false);
+	data->transfer_cfg.Direction = ((msg->flags & I2C_MSG_READ) ? I3C_IP_READ : I3C_IP_WRITE);
+
+	if (data->transfer_cfg.Direction == I3C_IP_READ) {
+		status = I3c_Ip_MasterReceive(config->instance, msg->buf,
+					      msg->len, &data->transfer_cfg);
+	} else {
+		status = I3c_Ip_MasterSend(config->instance, msg->buf,
+					   msg->len, &data->transfer_cfg);
+	}
+
+	return (status == I3C_IP_STATUS_SUCCESS) ? 0 : -EIO;
+}
+
+static int i3c_nxp_s32_transfer(const struct device *dev, struct i2c_msg *msgs,
+				uint8_t num_msgs, uint16_t addr)
+{
+	const struct i3c_nxp_s32_config *config = dev->config;
+	struct i3c_nxp_s32_data *data = dev->data;
+
+	struct i2c_msg *current_msg;
+
+	int ret = 0;
+
+	k_sem_take(&data->lock, K_FOREVER);
+
+	current_msg = msgs;
+	data->transfer_cfg.SlaveAddress = addr;
+
+	for (int i = 0; i < num_msgs; i++) {
+
+		ret = i3c_nxp_s32_transfer_one_msg(dev, current_msg);
+		if (ret) {
+			break;
+		}
+
+		ret = k_sem_take(&data->transfer_done, I3C_NXP_S32_TIMEOUT_MS);
+		if (ret) {
+			break;
+		}
+
+		if (I3c_Ip_MasterGetTransferStatus(config->instance, NULL) ==
+		    I3C_IP_STATUS_ERROR) {
+			ret = -EIO;
+			break;
+		}
+
+		current_msg++;
+	}
+
+	k_sem_give(&data->lock);
+
+	return ret;
+}
+
+#ifdef CONFIG_I2C_CALLBACK
+static void i3c_nxp_s32_transfer_async_done(const struct device *dev, int result)
+{
+	struct i3c_nxp_s32_data *data = dev->data;
+	i2c_callback_t callback = data->callback;
+	void *userdata = data->userdata;
+
+	k_sem_give(&data->lock);
+
+	callback(dev, result, userdata);
+}
+
+static int i3c_nxp_s32_transfer_async(const struct device *dev, struct i2c_msg *msgs,
+				      uint8_t num_msgs, uint16_t addr,
+				      i2c_callback_t cb, void *userdata)
+{
+	struct i3c_nxp_s32_data *data = dev->data;
+
+	if (!cb) {
+		LOG_ERR("Callback must be added for I2C async");
+		return -EINVAL;
+	}
+
+	if (k_sem_take(&data->lock, K_NO_WAIT)) {
+		return -EWOULDBLOCK;
+	}
+
+	data->msgs = msgs;
+	data->num_msgs = num_msgs;
+	data->msg = 0U;
+	data->callback = cb;
+	data->userdata = userdata;
+
+	data->transfer_cfg.SlaveAddress = addr;
+
+	/* Transfer the first message */
+	if (i3c_nxp_s32_transfer_one_msg(dev, &data->msgs[data->msg++])) {
+		i3c_nxp_s32_transfer_async_done(dev, -EIO);
+		return -EIO;
+	}
+
+	return 0;
+}
+#endif
+
+void i3c_nxp_s32_master_isr(const struct device *dev)
+{
+	const struct i3c_nxp_s32_config *config = dev->config;
+	struct i3c_nxp_s32_data *data = dev->data;
+
+	I3c_Ip_StatusType status;
+
+	I3c_Ip_IRQHandler(config->instance);
+
+	status = I3c_Ip_MasterGetTransferStatus(config->instance, NULL);
+
+	if ((status == I3C_IP_STATUS_SUCCESS) || (status == I3C_IP_STATUS_ERROR)) {
+#ifdef CONFIG_I2C_CALLBACK
+		if (data->callback) {
+			if (status == I3C_IP_STATUS_ERROR) {
+				i3c_nxp_s32_transfer_async_done(dev, -EIO);
+			} else if (data->msg == data->num_msgs) {
+				i3c_nxp_s32_transfer_async_done(dev, 0);
+			} else {
+				if (i3c_nxp_s32_transfer_one_msg(dev, &data->msgs[data->msg++])) {
+					i3c_nxp_s32_transfer_async_done(dev, -EIO);
+				}
+			}
+		} else
+#endif
+		{
+			k_sem_give(&data->transfer_done);
+		}
+	}
+}
+
+static int i3c_nxp_s32_init(const struct device *dev)
+{
+	const struct i3c_nxp_s32_config *config = dev->config;
+	struct i3c_nxp_s32_data *data = dev->data;
+
+	uint32_t bitrate_cfg;
+	int ret;
+
+	if (!device_is_ready(config->clock_dev)) {
+		LOG_ERR("Clock control device not ready");
+		return -ENODEV;
+	}
+
+	ret = clock_control_get_rate(config->clock_dev,
+				     config->clock_subsys,
+				     &data->functional_clk);
+	if (ret != 0) {
+		LOG_ERR("Failed to get I3C functional clock frequency");
+		return ret;
+	}
+
+	ret = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
+	if (ret != 0) {
+		LOG_ERR("Failed to configure I3C pins");
+		return ret;
+	}
+
+	I3c_Ip_MasterInit(config->instance, config->master_cfg);
+
+	k_sem_init(&data->lock, 1U, 1U);
+	k_sem_init(&data->transfer_done, 0U, 1U);
+
+	config->irq_config_func(dev);
+
+	if (config->bitrate == I2C_BITRATE_STANDARD ||
+		config->bitrate == I2C_BITRATE_FAST ||
+		config->bitrate == I2C_BITRATE_FAST_PLUS) {
+		bitrate_cfg = i2c_map_dt_bitrate(config->bitrate);
+	} else {
+		bitrate_cfg = I2C_SPEED_DT << I2C_SPEED_SHIFT;
+	}
+
+	ret = i3c_nxp_s32_configure(dev, I2C_MODE_CONTROLLER | bitrate_cfg);
+	if (ret < 0) {
+		LOG_ERR("Failed to configure I2C bitrate");
+		return ret;
+	}
+
+	return 0;
+}
+
+static const struct i2c_driver_api i3c_nxp_s32_driver_api = {
+	.configure = i3c_nxp_s32_configure,
+	.transfer = i3c_nxp_s32_transfer,
+	.get_config = i3c_nxp_s32_configure_get,
+
+#ifdef CONFIG_I2C_CALLBACK
+	.transfer_cb = i3c_nxp_s32_transfer_async
+#endif
+};
+
+#define I3C_NXP_S32_DECLARE_INTERRUPT(n)						\
+	static void i2c_s32_config_func_##n(const struct device *dev)			\
+	{										\
+		IRQ_CONNECT(DT_INST_IRQN(n),						\
+		DT_INST_IRQ(n, priority),						\
+		i3c_nxp_s32_master_isr,							\
+		DEVICE_DT_INST_GET(n),							\
+		DT_INST_IRQ(n, flags));							\
+		irq_enable(DT_INST_IRQN(n));						\
+	}
+
+#define I3C_NXP_S32_CONFIG_INTERRUPT(n)							\
+	.irq_config_func = i2c_s32_config_func_##n
+
+#define I3C_NXP_S32_INSTANCE_CHECK(indx, n)						\
+	((DT_INST_REG_ADDR(n) == IP_I3C_##indx##_BASE) ? indx : 0)
+
+#define I3C_NXP_S32_GET_INSTANCE(n)							\
+	LISTIFY(__DEBRACKET I3C_INSTANCE_COUNT, I3C_NXP_S32_INSTANCE_CHECK, (|), n)
+
+#define I3C_NXP_S32_CONFIG(n)								\
+	static I3c_Ip_MasterStateType i3c_nxp_s32_state_##n =				\
+	{										\
+		.BufferSize = 0U,							\
+		.TxDataBuffer = NULL_PTR,						\
+		.RxDataBuffer = NULL_PTR,						\
+		.Status = I3C_IP_STATUS_SUCCESS,					\
+		.TransferOption =							\
+			{								\
+				.SlaveAddress = 0U,					\
+				.SendStop = FALSE,					\
+				.Direction = I3C_IP_WRITE,				\
+				.TransferSize = I3C_IP_TRANSFER_BYTES,			\
+				.BusType = I3C_IP_BUS_TYPE_I2C				\
+			},								\
+		.TransferType = I3C_IP_USING_INTERRUPTS,				\
+		.OpenDrainStop = FALSE,							\
+		.MasterCallback = NULL_PTR,						\
+		.MasterCallbackParam = 0,						\
+	};										\
+											\
+	static const I3c_Ip_MasterConfigType i3c_nxp_s32_master_config##n =		\
+	{										\
+		.MasterEnable = I3C_IP_MASTER_ON,					\
+		.DisableTimeout = DT_INST_PROP(n, disable_timeout),			\
+		.I2cBaud = 11U,								\
+		.OpenDrainBaud = 8U,							\
+		.PushPullBaud = 10U,							\
+		.PushPullLow = 0U,							\
+		.OpenDrainHighPP = FALSE,						\
+		.Skew = 0U,								\
+		.MasterState = &i3c_nxp_s32_state_##n,					\
+	};
+
+#define I3C_NXP_S32_BAUDRATE(n)								\
+	static uint32_t i3c_nxp_s32_baud_cfg_##n[] = DT_INST_PROP(n, baudrate_cfg);
+
+#define I3C_NXP_S32_INIT_DEVICE(n)							\
+	I3C_NXP_S32_DECLARE_INTERRUPT(n)						\
+	I3C_NXP_S32_CONFIG(n)								\
+	I3C_NXP_S32_BAUDRATE(n)								\
+	PINCTRL_DT_INST_DEFINE(n);							\
+	static struct i3c_nxp_s32_data i3c_nxp_s32_data##n = {				\
+		.transfer_cfg = {							\
+			.TransferSize = I3C_IP_TRANSFER_BYTES,				\
+			.BusType = I3C_IP_BUS_TYPE_I2C,					\
+		},									\
+	};										\
+	static const struct i3c_nxp_s32_config i3c_nxp_s32_config##n = {		\
+		.instance = I3C_NXP_S32_GET_INSTANCE(n),				\
+		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),			\
+		.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),	\
+		.master_cfg  = (I3c_Ip_MasterConfigType *)&i3c_nxp_s32_master_config##n,\
+		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),				\
+		.baudrate_cfg = (I3c_Ip_MasterBaudRateType *)i3c_nxp_s32_baud_cfg_##n,	\
+		.num_baudrate = ARRAY_SIZE(i3c_nxp_s32_baud_cfg_##n) / 3U,		\
+		.bitrate = DT_INST_PROP(n, clock_frequency),				\
+		I3C_NXP_S32_CONFIG_INTERRUPT(n)						\
+	};										\
+	DEVICE_DT_INST_DEFINE(n,							\
+			i3c_nxp_s32_init,						\
+			NULL,								\
+			&i3c_nxp_s32_data##n,						\
+			&i3c_nxp_s32_config##n,						\
+			POST_KERNEL,							\
+			CONFIG_I2C_INIT_PRIORITY,					\
+			&i3c_nxp_s32_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(I3C_NXP_S32_INIT_DEVICE)

--- a/dts/arm/nxp/nxp_s32z27x_r52.dtsi
+++ b/dts/arm/nxp/nxp_s32z27x_r52.dtsi
@@ -718,5 +718,35 @@
 			interrupt-names = "rx_tx_mru", "error";
 			clocks = <&clock NXP_S32_P5_CANXL_PE_CLK>;
 		};
+
+		i3c0: i2c@401d0000 {
+			compatible = "nxp,s32-i2c-i3c";
+			reg = <0x401d0000 0x10000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			interrupts = <GIC_SPI 252 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_P0_REG_INTF_CLK>;
+			status = "disabled";
+		};
+
+		i3c1: i2c@409d0000 {
+			compatible = "nxp,s32-i2c-i3c";
+			reg = <0x409d0000 0x10000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			interrupts = <GIC_SPI 253 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_P1_REG_INTF_CLK>;
+			status = "disabled";
+		};
+
+		i3c2: i2c@421d0000 {
+			compatible = "nxp,s32-i2c-i3c";
+			reg = <0x421d0000 0x10000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			interrupts = <GIC_SPI 254 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_P4_REG_INTF_CLK>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/bindings/i2c/nxp,s32-i2c-i3c.yaml
+++ b/dts/bindings/i2c/nxp,s32-i2c-i3c.yaml
@@ -1,0 +1,57 @@
+# Copyright 2024 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: NXP S32 I2C controller over I3C peripheral
+
+compatible: "nxp,s32-i2c-i3c"
+
+include: [i2c-controller.yaml, pinctrl-device.yaml]
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true
+
+  pinctrl-0:
+    required: true
+
+  pinctrl-names:
+    required: true
+
+  clocks:
+    required: true
+
+  baudrate-cfg:
+    type: array
+    required: true
+    description: |
+      An array of pre-computed baudrates needed for the controller to setting
+      up I2C speed for I2C communication. For each used I2C rate, three elements
+      need to be provided in the order: I2C, Open-Drain and Push-pull baudrate.
+      These baudrates should be calculated by user based on Functional Clock and
+      as required by application.
+
+      For example: I3C instance 0 with Functional Clock is 134Mhz and application
+      intends to use STANDARD, FAST and FAST_PLUS speed:
+
+        &i3c0 = {
+          baudrate-cfg = <I2C_BITRATE_STANDARD 500000 6000000>,
+                          <I2C_BITRATE_FAST 1000000 6000000>,
+                          <I2C_BITRATE_FAST_PLUS 1000000 6000000>;
+        }
+
+      The baudrate configuration does not need to be declared for unused I2C speeds.
+
+  disable-timeout:
+    type: boolean
+    description: disable timeout to prevent application errors
+
+  high-keeper:
+    type: string
+    default: HIGH_KEEPER_NONE
+    enum:
+      - HIGH_KEEPER_NONE
+      - PASSIVE_SDA_SCL
+    description: indicates how high-keeper is supposed to be support

--- a/west.yml
+++ b/west.yml
@@ -198,7 +198,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 862e001504bd6e0a4feade6a718e9f973116849c
+      revision: pull/408/head
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
The I3C IP on S32Z device only support I2C mode, this PR introduces I2C driver for this device.
Due to some internal issues, the IP does not support I3C functionality, only I2C

Tested with tests\drivers\eeprom