### PR TITLE
drivers: i3c: allow i3c kconfigs to be included by i2c

### DIFF
--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -8,6 +8,8 @@
 #
 menuconfig I2C
 	bool "Inter-Integrated Circuit (I2C) bus drivers"
+	# Select I3C as I3C also includes the I2C API
+	select I3C
 	help
 	  Enable I2C Driver Configuration
 


### PR DESCRIPTION
I3C is backwards compatible with I2C. It is possible to only use an I3C IP with only I2C devices. This can be an issue where devices will do a `select I2C`, but they won't enable the I3C driver as the isn't already a single I3C device defined in the devicetree with it's `select I3C`.

This adds a `select I3C` which will also allow for the I3C drivers to be found if only I2C devices are on a device tree such as here: https://github.com/zephyrproject-rtos/zephyr/blob/af314643a32db3452dd77f20dee2807197b179cf/drivers/eeprom/Kconfig#L58