### PR TITLE
net: wifi: Fix the nm type check error

### DIFF
--- a/subsys/net/l2/wifi/wifi_nm.c
+++ b/subsys/net/l2/wifi/wifi_nm.c
@@ -66,12 +66,12 @@ unsigned char wifi_nm_get_type_iface(struct net_if *iface)
 
 bool wifi_nm_iface_is_sta(struct net_if *iface)
 {
-	return wifi_nm_get_type_iface(iface) & WIFI_TYPE_STA;
+	return wifi_nm_get_type_iface(iface) & (1 << WIFI_TYPE_STA);
 }
 
 bool wifi_nm_iface_is_sap(struct net_if *iface)
 {
-	return wifi_nm_get_type_iface(iface) & WIFI_TYPE_SAP;
+	return wifi_nm_get_type_iface(iface) & (1 << WIFI_TYPE_SAP);
 }
 
 int wifi_nm_register_mgd_iface(struct wifi_nm_instance *nm, struct net_if *iface)


### PR DESCRIPTION
Fix the NM iface type check error, should use (1 << WIFI_TYPE_STA), 
instead of WIFI_TYPE_STA. Same for WIFI_TYPE_SAP.