### PR TITLE
test CONFIG_DEVICE_DT_METADATA=y with usespace enabled

### DIFF
--- a/kernel/device.c
+++ b/kernel/device.c
@@ -117,7 +117,7 @@ const struct device *z_impl_device_get_by_dt_nodelabel(const char *nodelabel)
 #ifdef CONFIG_USERSPACE
 static inline const struct device *z_vrfy_device_get_by_dt_nodelabel(const char *nodelabel)
 {
-	const char nl_copy[Z_DEVICE_MAX_NODELABEL_LEN];
+	char nl_copy[Z_DEVICE_MAX_NODELABEL_LEN];
 
 	if (k_usermode_string_copy(nl_copy, (char *)nodelabel, sizeof(nl_copy)) != 0) {
 		return NULL;

--- a/tests/kernel/device/testcase.yaml
+++ b/tests/kernel/device/testcase.yaml
@@ -8,6 +8,11 @@ tests:
     integration_platforms:
       - native_sim
     platform_exclude: xenvm
+  kernel.device.metadata:
+    platform_allow:
+      - qemu_x86
+    extra_configs:
+      - CONFIG_DEVICE_DT_METADATA=y
   kernel.device.minimallibc:
     integration_platforms:
       - native_sim


### PR DESCRIPTION
- **tests: device: test CONFIG_DEVICE_DT_METADATA=y**
- **device: remove const qualifier from node label copy**

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/76747
