### PR TITLE
boards: bl5430_dvk: Fix SPI device used for mipi display.

### DIFF
--- a/boards/ezurio/bl5340_dvk/bl5340_dvk_nrf5340_cpuapp_common.dtsi
+++ b/boards/ezurio/bl5340_dvk/bl5340_dvk_nrf5340_cpuapp_common.dtsi
@@ -111,7 +111,7 @@
 		compatible = "zephyr,mipi-dbi-spi";
 		reset-gpios = <&gpio0 6 GPIO_ACTIVE_LOW>;
 		dc-gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
-		spi-dev = <&spi2>;
+		spi-dev = <&spi4>;
 		write-only;
 		#address-cells = <1>;
 		#size-cells = <0>;


### PR DESCRIPTION
Sets the correct SPI device to use when using MIPI display.

Fixes: #75991