### PR TITLE
run the task_wdt on the nucleo stm32f0  target

### DIFF
--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -219,6 +219,7 @@
 		iwdg: watchdog@40003000 {
 			compatible = "st,stm32-watchdog";
 			reg = <0x40003000 0x400>;
+			status = "disabled";
 		};
 
 		wwdg: watchdog@40002c00 {

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -429,6 +429,7 @@
 		iwdg: watchdog@40003000 {
 			compatible = "st,stm32-watchdog";
 			reg = <0x40003000 0x400>;
+			status = "disabled";
 		};
 
 		lptim1: timers@40007c00 {

--- a/samples/subsys/task_wdt/boards/nucleo_f091rc.overlay
+++ b/samples/subsys/task_wdt/boards/nucleo_f091rc.overlay
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * stm32F0 has a WWDG clock by APB1 where the APB1 prescaler is 1..16
+ * Adjust the APB1 clock to match the WDG timeout.
+ */
+
+&rcc {
+	/delete-property/ apb1-prescaler;
+	apb1-prescaler = <16>;
+};
+
+&iwdg {
+	status = "disabled";
+};
+
+&wwdg {
+	status = "okay";
+};


### PR DESCRIPTION
Adjust the APB1 frequency to clock the Window watchdog so that the samples/subsys/task_wdt can run on the nucleo_f091rc target board

Add the `status = "disabled"` to the stm32xx.dtsi that had not for their  iwdg node
