### PR TITLE
soc: riscv: litex: use value from dts

### DIFF
--- a/soc/litex/litex_vexriscv/Kconfig.defconfig
+++ b/soc/litex/litex_vexriscv/Kconfig.defconfig
@@ -4,7 +4,7 @@
 if SOC_LITEX_VEXRISCV
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	default 100000000
+	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
 
 config NUM_IRQS
 	default 12


### PR DESCRIPTION
use value from dts for CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC.

originally part of #74693, but but actually needed in multiply litex drivers. (everywhere where a frequency has to be set.)