### PR TITLE
Bluetooth: Expose APIs that convert handles to host objects

### DIFF
--- a/include/zephyr/bluetooth/hci.h
+++ b/include/zephyr/bluetooth/hci.h
@@ -140,6 +140,15 @@ struct bt_le_ext_adv *bt_hci_adv_lookup_handle(uint8_t handle);
  */
 int bt_hci_get_adv_sync_handle(const struct bt_le_per_adv_sync *sync, uint16_t *sync_handle);
 
+/** @brief Get periodic advertising sync given an periodic advertising sync handle.
+ *
+ * @param handle The periodic sync set handle
+ *
+ * @retval The corresponding periodic advertising sync set object on success,
+ *         NULL if it does not exist.
+ */
+struct bt_le_per_adv_sync *bt_hci_per_adv_sync_lookup_handle(uint16_t handle);
+
 /** @brief Obtain the version string given a core version number.
  *
  * The core version of a controller can be obtained by issuing

--- a/include/zephyr/bluetooth/hci.h
+++ b/include/zephyr/bluetooth/hci.h
@@ -122,6 +122,15 @@ int bt_hci_get_conn_handle(const struct bt_conn *conn, uint16_t *conn_handle);
  */
 int bt_hci_get_adv_handle(const struct bt_le_ext_adv *adv, uint8_t *adv_handle);
 
+/** @brief Get advertising set given an advertising handle
+ *
+ * @param handle The advertising handle
+ *
+ * @returns The corresponding advertising set on success,
+ *          NULL if it does not exist.
+ */
+struct bt_le_ext_adv *bt_hci_adv_lookup_handle(uint8_t handle);
+
 /** @brief Get periodic advertising sync handle.
  *
  * @param sync Periodic advertising sync set.

--- a/include/zephyr/bluetooth/hci.h
+++ b/include/zephyr/bluetooth/hci.h
@@ -113,6 +113,18 @@ int bt_hci_cmd_send_sync(uint16_t opcode, struct net_buf *buf,
  */
 int bt_hci_get_conn_handle(const struct bt_conn *conn, uint16_t *conn_handle);
 
+/** @brief Get connection given a connection handle.
+ *
+ * The caller gets a new reference to the connection object which must be
+ * released with bt_conn_unref() once done using the object.
+ *
+ * @param handle The connection handle
+ *
+ * @returns The corresponding connection object on success.
+ *          NULL if it does not exist.
+ */
+struct bt_conn *bt_hci_conn_lookup_handle(uint16_t handle);
+
 /** @brief Get advertising handle for an advertising set.
  *
  * @param adv Advertising set.

--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -246,7 +246,7 @@ static void adv_delete(struct bt_le_ext_adv *adv)
 }
 
 #if defined(CONFIG_BT_BROADCASTER)
-static struct bt_le_ext_adv *bt_adv_lookup_handle(uint8_t handle)
+struct bt_le_ext_adv *bt_hci_adv_lookup_handle(uint8_t handle)
 {
 	if (handle < ARRAY_SIZE(adv_pool) &&
 	    atomic_test_bit(adv_pool[handle].flags, BT_ADV_CREATED)) {
@@ -2020,7 +2020,7 @@ void bt_hci_le_per_adv_subevent_data_request(struct net_buf *buf)
 	}
 
 	evt = net_buf_pull_mem(buf, sizeof(struct bt_hci_evt_le_per_adv_subevent_data_request));
-	adv = bt_adv_lookup_handle(evt->adv_handle);
+	adv = bt_hci_adv_lookup_handle(evt->adv_handle);
 	if (!adv) {
 		LOG_ERR("Unknown advertising handle %d", evt->adv_handle);
 
@@ -2050,7 +2050,7 @@ void bt_hci_le_per_adv_response_report(struct net_buf *buf)
 	}
 
 	evt = net_buf_pull_mem(buf, sizeof(struct bt_hci_evt_le_per_adv_response_report));
-	adv = bt_adv_lookup_handle(evt->adv_handle);
+	adv = bt_hci_adv_lookup_handle(evt->adv_handle);
 	if (!adv) {
 		LOG_ERR("Unknown advertising handle %d", evt->adv_handle);
 
@@ -2150,7 +2150,7 @@ void bt_hci_le_adv_set_terminated(struct net_buf *buf)
 #endif
 
 	evt = (void *)buf->data;
-	adv = bt_adv_lookup_handle(evt->adv_handle);
+	adv = bt_hci_adv_lookup_handle(evt->adv_handle);
 	conn_handle = sys_le16_to_cpu(evt->conn_handle);
 
 	LOG_DBG("status 0x%02x adv_handle %u conn_handle 0x%02x num %u", evt->status,
@@ -2262,7 +2262,7 @@ void bt_hci_le_scan_req_received(struct net_buf *buf)
 	struct bt_le_ext_adv *adv;
 
 	evt = (void *)buf->data;
-	adv = bt_adv_lookup_handle(evt->handle);
+	adv = bt_hci_adv_lookup_handle(evt->handle);
 
 	LOG_DBG("handle %u peer %s", evt->handle, bt_addr_le_str(&evt->addr));
 

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1366,6 +1366,11 @@ found:
 	return NULL;
 }
 
+struct bt_conn *bt_hci_conn_lookup_handle(uint16_t handle)
+{
+	return bt_conn_lookup_handle(handle, BT_CONN_TYPE_ALL);
+}
+
 void bt_conn_foreach(enum bt_conn_type type,
 		     void (*func)(struct bt_conn *conn, void *data),
 		     void *data)

--- a/subsys/bluetooth/host/direction.c
+++ b/subsys/bluetooth/host/direction.c
@@ -383,7 +383,7 @@ int hci_df_prepare_connectionless_iq_report(struct net_buf *buf,
 
 	evt = net_buf_pull_mem(buf, sizeof(*evt));
 
-	per_adv_sync = bt_hci_get_per_adv_sync(sys_le16_to_cpu(evt->sync_handle));
+	per_adv_sync = bt_hci_per_adv_sync_lookup_handle(sys_le16_to_cpu(evt->sync_handle));
 
 	if (!per_adv_sync) {
 		LOG_ERR("Unknown handle 0x%04X for iq samples report",
@@ -431,7 +431,7 @@ int hci_df_vs_prepare_connectionless_iq_report(struct net_buf *buf,
 
 	evt = net_buf_pull_mem(buf, sizeof(*evt));
 
-	per_adv_sync = bt_hci_get_per_adv_sync(sys_le16_to_cpu(evt->sync_handle));
+	per_adv_sync = bt_hci_per_adv_sync_lookup_handle(sys_le16_to_cpu(evt->sync_handle));
 
 	if (!per_adv_sync) {
 		LOG_ERR("Unknown handle 0x%04X for iq samples report",

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1683,7 +1683,7 @@ static void le_enh_conn_complete_v2(struct net_buf *buf)
 		/* Created via PAwR sync, no adv set terminated event, needs separate handling */
 		struct bt_le_per_adv_sync *sync;
 
-		sync = bt_hci_get_per_adv_sync(evt->sync_handle);
+		sync = bt_hci_per_adv_sync_lookup_handle(evt->sync_handle);
 		if (!sync) {
 			LOG_ERR("Unknown sync handle %d", evt->sync_handle);
 

--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -784,7 +784,7 @@ void bt_periodic_sync_disable(void)
 	}
 }
 
-struct bt_le_per_adv_sync *bt_hci_get_per_adv_sync(uint16_t handle)
+struct bt_le_per_adv_sync *bt_hci_per_adv_sync_lookup_handle(uint16_t handle)
 {
 	for (int i = 0; i < ARRAY_SIZE(per_adv_sync_pool); i++) {
 		if (per_adv_sync_pool[i].handle == handle &&
@@ -845,7 +845,7 @@ static void bt_hci_le_per_adv_report_common(struct net_buf *buf)
 
 	evt = net_buf_pull_mem(buf, sizeof(*evt));
 
-	per_adv_sync = bt_hci_get_per_adv_sync(sys_le16_to_cpu(evt->handle));
+	per_adv_sync = bt_hci_per_adv_sync_lookup_handle(sys_le16_to_cpu(evt->handle));
 
 	if (!per_adv_sync) {
 		LOG_ERR("Unknown handle 0x%04X for periodic advertising report",
@@ -1202,7 +1202,7 @@ void bt_hci_le_per_adv_sync_lost(struct net_buf *buf)
 		(struct bt_hci_evt_le_per_adv_sync_lost *)buf->data;
 	struct bt_le_per_adv_sync *per_adv_sync;
 
-	per_adv_sync = bt_hci_get_per_adv_sync(sys_le16_to_cpu(evt->handle));
+	per_adv_sync = bt_hci_per_adv_sync_lookup_handle(sys_le16_to_cpu(evt->handle));
 
 	if (!per_adv_sync) {
 		LOG_ERR("Unknown handle 0x%04Xfor periodic adv sync lost",
@@ -1367,7 +1367,7 @@ void bt_hci_le_biginfo_adv_report(struct net_buf *buf)
 
 	evt = net_buf_pull_mem(buf, sizeof(*evt));
 
-	per_adv_sync = bt_hci_get_per_adv_sync(sys_le16_to_cpu(evt->sync_handle));
+	per_adv_sync = bt_hci_per_adv_sync_lookup_handle(sys_le16_to_cpu(evt->sync_handle));
 
 	if (!per_adv_sync) {
 		LOG_ERR("Unknown handle 0x%04X for periodic advertising report",

--- a/subsys/bluetooth/host/scan.h
+++ b/subsys/bluetooth/host/scan.h
@@ -11,6 +11,4 @@ bool bt_id_scan_random_addr_check(void);
 
 int bt_le_scan_set_enable(uint8_t enable);
 
-struct bt_le_per_adv_sync *bt_hci_get_per_adv_sync(uint16_t handle);
-
 void bt_periodic_sync_disable(void);


### PR DESCRIPTION
When implementing vendor specific HCI APIs and events, we want to be able to convert between host objects, handles and back again. Currently, the translation from handle to object is unavailable to application developers. 

This PR suggests to expose functions like these.

The current PR only exposes the existing internal APIs. We should probably rename them:

To be decided: 
* Naming of them. Internally we sometimes use `lookup_handle()`, in other places `get_<obj_type>()`. 
  We already have some public APIs using `lookup`, but that
* Where to put the new APIs and their prefix. Should they be added to hci.h or not where the translation object to handle is found?

Suggested naming:
* bt_hci_adv_lookup_handle()`
* bt_hci_per_adv_sync_lookup_handle()`
* bt_hci_conn_lookup_handle()`




