### PR TITLE
boards: disco_l475_iot1: fix arduino_i2c config

### DIFF
--- a/boards/st/disco_l475_iot1/arduino_r3_connector.dtsi
+++ b/boards/st/disco_l475_iot1/arduino_r3_connector.dtsi
@@ -35,6 +35,6 @@
 	};
 };
 
-arduino_i2c: &i2c1 {};
+arduino_i2c: &i2c3 {};
 arduino_spi: &spi1 {};
 arduino_serial: &uart4 {};


### PR DESCRIPTION
disco l475 board exposes I2C3 on standard Arduino Uno pins A4/A5, not I2C1.

![image](https://github.com/user-attachments/assets/2376b9df-45db-4968-972a-4ed608a485fd)
