### PR TITLE
modules: hal_nordic: nrf-regtool: enforce in-tree devicetree package

### DIFF
--- a/modules/hal_nordic/nrf-regtool/nrf-regtoolConfig.cmake
+++ b/modules/hal_nordic/nrf-regtool/nrf-regtoolConfig.cmake
@@ -12,7 +12,9 @@ function(nrf_regtool_generate_hex_from_dts peripheral)
 
   set(generated_hex_file ${PROJECT_BINARY_DIR}/${generated_hex_name})
   execute_process(
-    COMMAND ${NRF_REGTOOL} ${verbosity} generate
+    COMMAND
+    ${CMAKE_COMMAND} -E env PYTHONPATH=${ZEPHYR_BASE}/scripts/dts/python-devicetree/src
+    ${NRF_REGTOOL} ${verbosity} generate
     --peripheral ${peripheral}
     --svd-file ${SOC_SVD_FILE}
     --dts-file ${ZEPHYR_DTS}


### PR DESCRIPTION
It looks like nrf-regtool depends on the
https://pypi.org/project/devicetree/ Python package, which contains an old copy (https://github.com/zephyrproject-rtos/python-devicetree) of the in-tree devicetree package.

Because no major changes have happened in the devicetree scripts, this likely went unnoticed. However, I realized today that such an old package cannot parse bindings with multiple buses (e.g. in I3C, where we have `bus: [i3c, i2c]`).

While a proper solution is discussed, inject `PYTHONPATH` with the in-tree library.