### PR TITLE
ztest: shell: Fix compilation error for NEWLIB_LIBC

### DIFF
--- a/subsys/testsuite/ztest/src/ztest_shell.c
+++ b/subsys/testsuite/ztest/src/ztest_shell.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdlib.h>
 #include <zephyr/ztest.h>
 
 


### PR DESCRIPTION
Fix compilation error "implicit declaration of function 'free'" in case of `CONFIG_NEWLIB_LIBC`.

Noticed by @niedzwiecki-dawid - https://github.com/zephyrproject-rtos/zephyr/pull/75370#issuecomment-2233180579