### PR TITLE
input: analog_axis: add output inversion

### DIFF
--- a/drivers/input/input_analog_axis.c
+++ b/drivers/input/input_analog_axis.c
@@ -25,7 +25,8 @@ struct analog_axis_channel_config {
 	int16_t out_min;
 	int16_t out_max;
 	uint16_t axis;
-	bool invert;
+	bool invert_input;
+	bool invert_output;
 };
 
 struct analog_axis_channel_data {
@@ -187,7 +188,7 @@ static void analog_axis_loop(const struct device *dev)
 		struct analog_axis_calibration *cal = &cfg->calibration[i];
 		int32_t raw_val = bufs[i];
 
-		if (axis_cfg->invert) {
+		if (axis_cfg->invert_input) {
 			raw_val *= -1;
 		}
 
@@ -204,6 +205,10 @@ static void analog_axis_loop(const struct device *dev)
 		}
 
 		out = CLAMP(out, axis_cfg->out_min, axis_cfg->out_max);
+
+		if (axis_cfg->invert_output) {
+			out = axis_cfg->out_max - out;
+		}
 
 		if (axis_data->last_out != out) {
 			input_report_abs(dev, axis_cfg->axis, out, true, K_FOREVER);
@@ -327,7 +332,8 @@ static int analog_axis_pm_action(const struct device *dev,
 		.out_min = (int16_t)DT_PROP(node_id, out_min), \
 		.out_max = (int16_t)DT_PROP(node_id, out_max), \
 		.axis = DT_PROP(node_id, zephyr_axis), \
-		.invert = DT_PROP(node_id, invert), \
+		.invert_input = DT_PROP(node_id, invert_input), \
+		.invert_output = DT_PROP(node_id, invert_output), \
 	}
 
 #define ANALOG_AXIS_CHANNEL_CAL_DEF(node_id) \

--- a/dts/bindings/input/analog-axis.yaml
+++ b/dts/bindings/input/analog-axis.yaml
@@ -83,8 +83,13 @@ child-binding:
         The input code for the axis to report for the device, typically any of
         INPUT_ABS_*.
 
-    invert:
+    invert-input:
       type: boolean
       description: |
         If set, invert the raw ADC value before processing it. Useful for
         differential channels.
+
+    invert-output:
+      type: boolean
+      description: |
+        If set, invert the output value.

--- a/tests/drivers/build_all/input/app.overlay
+++ b/tests/drivers/build_all/input/app.overlay
@@ -140,7 +140,8 @@
 				in-min = <(-100)>;
 				in-max = <100>;
 				zephyr,axis = <0>;
-				invert;
+				invert-input;
+				invert-output;
 			};
 		};
 


### PR DESCRIPTION
The driver right now only allows inverting the input value, which can be useful for differential channels but is quite confusing for single ended ones. Implement a simple output inversion flag instead to make up for that.