### PR TITLE
subsys: mcumgr: add missing sizecheck before memcpy

### DIFF
--- a/subsys/mgmt/mcumgr/transport/src/smp.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp.c
@@ -72,6 +72,10 @@ void *smp_alloc_rsp(const void *req, void *arg)
 
 	req_nb = req;
 
+	if (req_nb->user_data_size > CONFIG_MCUMGR_TRANSPORT_NETBUF_USER_DATA_SIZE) {
+		return NULL;
+	}
+
 	rsp_nb = smp_packet_alloc();
 	if (rsp_nb == NULL) {
 		return NULL;


### PR DESCRIPTION
CVE-2023-4262 points out this vulnerability
A partial fix was committed in 061a87aff8650ba55bc698dbe7f00a08a4abb6e5 
This fixes the remainder of the vulnerabilities by checking the response will fit into the buffer pool allocation