### PR TITLE
doc: release-notes-3.7: Add Ezurio release notes

### DIFF
--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -404,6 +404,7 @@ Boards & SoC Support
     that controls the network core Force-OFF signal with a module that uses an
     on-off manager to keep track of the network core use and exposes its API
     in ``<nrf53_cpunet_mgmt.h>``.
+  * Laird Connectivity boards are rebranded to Ezurio.
 
 * Added support for these following shields:
 


### PR DESCRIPTION
Laird Connectivity boards were rebranded to Ezurio.