### PR TITLE
samples: bt: ext_adv: don't terminate invalid conn

### DIFF
--- a/samples/bluetooth/extended_adv/advertiser/src/main.c
+++ b/samples/bluetooth/extended_adv/advertiser/src/main.c
@@ -135,10 +135,13 @@ int main(void)
 			app_st = BT_SAMPLE_ST_CONNECTED;
 
 			printk("Initiating disconnect within 5 seconds...\n");
-			k_sleep(K_SECONDS(5));
-
-			bt_conn_disconnect(default_conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
-
+			if (k_poll(&poll_evt, 1, K_SECONDS(5)) == 0) {
+				printk("Remote disconnected early...\n");
+				/* Don't clear event here as we want the loop to run immediately */
+			} else {
+				/* Connection still alive after 5 seconds, terminate it */
+				bt_conn_disconnect(default_conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+			}
 		} else if (atomic_test_and_clear_bit(evt_bitmask, BT_SAMPLE_EVT_DISCONNECTED) &&
 			   app_st == BT_SAMPLE_ST_CONNECTED) {
 


### PR DESCRIPTION
If the remote side has already terminated the connection (or the connection failed to establish), don't attempt to terminate an invalid connection object. Instead, start advertising again immediately.