### PR TITLE
samples:fs_sample: add required meta info for twister

### DIFF
--- a/samples/subsys/fs/fs_sample/sample.yaml
+++ b/samples/subsys/fs/fs_sample/sample.yaml
@@ -10,6 +10,12 @@ tests:
     harness: console
     harness_config:
       fixture: fixture_sdhc
+      type: multi_line
+      regex:
+        - "Block count"
+        - "Sector size"
+        - "Memory Size"
+        - "Disk mounted"
   sample.filesystem.fat_fs.overlay:
     platform_allow: nrf52840_blip
   sample.filesystem.fat_fs.adafruit_2_8_tft_touch_v2:
@@ -28,6 +34,12 @@ tests:
     harness: console
     harness_config:
       fixture: fixture_shield_adafruit_2_8_tft_touch_v2
+      type: multi_line
+      regex:
+        - "Block count"
+        - "Sector size"
+        - "Memory Size"
+        - "Disk mounted"
   sample.filesystem.fat_fs.nrf52840dk_nrf52840:
     build_only: true
     platform_allow: nrf52840dk/nrf52840


### PR DESCRIPTION
in harness_fixure definition, type and regex is must have