### PR TITLE
flash: add missing `FLASH_HAS_PAGE_LAYOUT` dependency

### DIFF
--- a/subsys/fs/fcb/Kconfig
+++ b/subsys/fs/fcb/Kconfig
@@ -10,6 +10,7 @@
 config FCB
 	bool "Flash Circular Buffer support"
 	depends on FLASH_MAP
+	depends on FLASH_HAS_PAGE_LAYOUT
 	select CRC
 	select FLASH_PAGE_LAYOUT
 	help

--- a/subsys/fs/nvs/Kconfig
+++ b/subsys/fs/nvs/Kconfig
@@ -6,6 +6,7 @@
 config NVS
 	bool "Non-volatile Storage"
 	depends on FLASH
+	depends on FLASH_HAS_PAGE_LAYOUT
 	select CRC
 	select FLASH_PAGE_LAYOUT
 	help

--- a/subsys/lorawan/services/Kconfig
+++ b/subsys/lorawan/services/Kconfig
@@ -56,6 +56,7 @@ config LORAWAN_APP_CLOCK_SYNC_PERIODICITY
 
 config LORAWAN_FRAG_TRANSPORT
 	bool "Fragmented Data Block Transport"
+	depends on FLASH_HAS_PAGE_LAYOUT
 	select FLASH_MAP
 	select FLASH_PAGE_LAYOUT
 	select IMG_MANAGER

--- a/subsys/storage/stream/Kconfig
+++ b/subsys/storage/stream/Kconfig
@@ -6,6 +6,7 @@
 
 menuconfig STREAM_FLASH
 	bool "Stream to flash"
+	depends on FLASH_HAS_PAGE_LAYOUT
 	select FLASH_PAGE_LAYOUT
 	help
 	  Enable support of stream to flash API


### PR DESCRIPTION
Fix subsystems that rely on `FLASH_PAGE_LAYOUT` and unilaterally `select` the symbol without considering its dependency.

If `FLASH_HAS_PAGE_LAYOUT` doesn't exist, the subsystems won't work.