### PR TITLE
arch: riscv: stacktrace: make `CONFIG_EXCEPTION_STACK_TRACE` optional

### DIFF
--- a/arch/common/CMakeLists.txt
+++ b/arch/common/CMakeLists.txt
@@ -104,3 +104,4 @@ if(CONFIG_COVERAGE)
 endif()
 
 zephyr_library_sources_ifdef(CONFIG_SEMIHOST semihost.c)
+zephyr_library_sources_ifdef(CONFIG_ARCH_HAS_STACKWALK stacktrace.c)

--- a/arch/common/stacktrace.c
+++ b/arch/common/stacktrace.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 Meta Platforms
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
+
+void __weak arch_stack_walk(stack_trace_callback_fn callback_fn, void *cookie,
+			    const struct k_thread *thread, const struct arch_esf *esf)
+{
+	ARG_UNUSED(callback_fn);
+	ARG_UNUSED(cookie);
+	ARG_UNUSED(thread);
+	ARG_UNUSED(esf);
+
+	LOG_DBG("Enable CONFIG_EXCEPTION_STACK_TRACE for %s()", __func__);
+}


### PR DESCRIPTION
Users should be able to enable `CONFIG_KERNEL_SHELL` without `CONFIG_EXCEPTION_STACK_TRACE`, i.e.:

```
west build -b qemu_riscv64 -p auto zephyr/samples/hello_world -- \
  -DCONFIG_SHELL=y \
  -DCONFIG_EXCEPTION_STACK_TRACE=n
```

Compile a weak `arch_stack_walk()` placeholder, which can be replaced by the arch-defined version when the conditions are met.

Fixes #76706