### PR TITLE
intel_adsp/ace: power: pad the hpsram_mask passed to power_down

### DIFF
--- a/soc/intel/intel_adsp/ace/power.c
+++ b/soc/intel/intel_adsp/ace/power.c
@@ -340,18 +340,20 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 			sys_cache_data_flush_range((void *)imr_layout, sizeof(*imr_layout));
 #endif /* CONFIG_ADSP_IMR_CONTEXT_SAVE */
 #ifdef CONFIG_ADSP_POWER_DOWN_HPSRAM
-			/* This assumes a single HPSRAM segment */
-			static uint32_t hpsram_mask;
+			const int dcache_words = XCHAL_DCACHE_LINESIZE / sizeof(uint32_t);
+			uint32_t hpsram_mask[dcache_words] __aligned(XCHAL_DCACHE_LINESIZE);
+
+			hpsram_mask[0] = 0;
 			/* turn off all HPSRAM banks - get a full bitmap */
 			uint32_t ebb_banks = ace_hpsram_get_bank_count();
-			hpsram_mask = (1 << ebb_banks) - 1;
+			hpsram_mask[0] = (1 << ebb_banks) - 1;
 #define HPSRAM_MASK_ADDR sys_cache_cached_ptr_get(&hpsram_mask)
 #else
 #define HPSRAM_MASK_ADDR NULL
 #endif /* CONFIG_ADSP_POWER_DOWN_HPSRAM */
-			/* do power down - this function won't return */
 			ret = pm_device_runtime_put(INTEL_ADSP_HST_DOMAIN_DEV);
 			__ASSERT_NO_MSG(ret == 0);
+			/* do power down - this function won't return */
 			power_down(true, HPSRAM_MASK_ADDR, true);
 		} else {
 			power_gate_entry(cpu);


### PR DESCRIPTION
This PR contains only a cherry-pick of the fix that was proposed and reviewed earlier in this https://github.com/zephyrproject-rtos/zephyr/pull/75285 PR. The reason I am pushing it again is that the [change](https://github.com/zephyrproject-rtos/zephyr/pull/75108) that was merged does not completely fix the problem.

Recently, the same issue that we identified on the MTL could be observed in another PR on SOF in builds for LNL (the problem stopped reproducing after a rebase and so far has not reappeared on LNL). The same issue still reproduces on PTL and without some kind of fix, we are unable to add tests to CI that check if this type of power flow works. The change proposed by @kv2019i is so far the only solution that reliably fixes this problem on all platforms.

I apologize for taking so long with the explanations, I had to focus on other tasks.