### PR TITLE
drivers: mdio: shell: add support for stm32 mdio

### DIFF
--- a/drivers/mdio/mdio_shell.c
+++ b/drivers/mdio/mdio_shell.c
@@ -37,6 +37,8 @@ LOG_MODULE_REGISTER(mdio_shell, CONFIG_LOG_DEFAULT_LEVEL);
 #define DT_DRV_COMPAT nxp_enet_qos_mdio
 #elif DT_HAS_COMPAT_STATUS_OKAY(litex_liteeth_mdio)
 #define DT_DRV_COMPAT litex_liteeth_mdio
+#elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_mdio)
+#define DT_DRV_COMPAT st_stm32_mdio
 #else
 #error "No known devicetree compatible match for MDIO shell"
 #endif


### PR DESCRIPTION
Add support for access mdio registers with the mdio shell on stm32.

I test it on a nucleo-h563zi dev board and with this patch I can use the mdio shell to access the mdio registers on the phy of this board.