### PR TITLE
dts: bindings: Fix license identifiers in a few files provided by Nordic

### DIFF
--- a/dts/bindings/flash_controller/nordic,rram-controller.yaml
+++ b/dts/bindings/flash_controller/nordic,rram-controller.yaml
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2023 Nordic Semiconductor ASA
 #
-# SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+# SPDX-License-Identifier: Apache-2.0
 #
 
 description: |

--- a/dts/bindings/misc/nordic,nrf-dppic-local.yaml
+++ b/dts/bindings/misc/nordic,nrf-dppic-local.yaml
@@ -1,5 +1,5 @@
 # Copyright (c) 2024 Nordic Semiconductor ASA
-# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+# SPDX-License-Identifier: Apache-2.0
 
 description: |
   Nordic Local DPPIC


### PR DESCRIPTION
Correct license identifiers in two files copied from internal Nordic repositories that were not properly adjusted for Zephyr:
- dts/bindings/flash_controller/nordic,rram-controller.yaml (added in commit 3a8ee7df9166600cf37636f9406229f777ff64eb)
- dts/bindings/misc/nordic,nrf-dppic-local.yaml (added in commit 796d09d2a650c3726ea9569397119dae5d2c7711)