### PR TITLE
net: coap: Fix underlying type for block number

### DIFF
--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -104,6 +104,12 @@ Bluetooth Crypto
 Networking
 **********
 
+* The CoAP public API functions :c:func:`coap_get_block1_option` and
+  :c:func:`coap_get_block2_option` have changed. The ``block_number`` pointer
+  type has changed from ``uint8_t *`` to ``uint32_t *``. Additionally,
+  :c:func:`coap_get_block2_option` now accepts an additional ``bool *has_more``
+  parameter, to store the value of the more flag. (:github:`76052`)
+
 Other Subsystems
 ****************
 

--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -892,16 +892,17 @@ int coap_get_block1_option(const struct coap_packet *cpkt, bool *has_more, uint3
 /**
  * @brief Get values from CoAP block2 option.
  *
- * Decode block number and block size from option. Ignore the has_more flag
- * as it should always be zero on queries.
+ * Decode block number, more flag and block size from option.
  *
  * @param cpkt Packet to be inspected
+ * @param has_more Is set to the value of the more flag
  * @param block_number Is set to the number of the block
  *
  * @return Integer value of the block size in case of success
  * or negative in case of error.
  */
-int coap_get_block2_option(const struct coap_packet *cpkt, uint32_t *block_number);
+int coap_get_block2_option(const struct coap_packet *cpkt, bool *has_more,
+			   uint32_t *block_number);
 
 /**
  * @brief Retrieves BLOCK{1,2} and SIZE{1,2} from @a cpkt and updates

--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -887,7 +887,7 @@ int coap_get_option_int(const struct coap_packet *cpkt, uint16_t code);
  * @return Integer value of the block size in case of success
  * or negative in case of error.
  */
-int coap_get_block1_option(const struct coap_packet *cpkt, bool *has_more, uint8_t *block_number);
+int coap_get_block1_option(const struct coap_packet *cpkt, bool *has_more, uint32_t *block_number);
 
 /**
  * @brief Get values from CoAP block2 option.
@@ -901,7 +901,7 @@ int coap_get_block1_option(const struct coap_packet *cpkt, bool *has_more, uint8
  * @return Integer value of the block size in case of success
  * or negative in case of error.
  */
-int coap_get_block2_option(const struct coap_packet *cpkt, uint8_t *block_number);
+int coap_get_block2_option(const struct coap_packet *cpkt, uint32_t *block_number);
 
 /**
  * @brief Retrieves BLOCK{1,2} and SIZE{1,2} from @a cpkt and updates

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -1342,7 +1342,7 @@ int coap_get_option_int(const struct coap_packet *cpkt, uint16_t code)
 	return val;
 }
 
-int coap_get_block1_option(const struct coap_packet *cpkt, bool *has_more, uint8_t *block_number)
+int coap_get_block1_option(const struct coap_packet *cpkt, bool *has_more, uint32_t *block_number)
 {
 	int ret = coap_get_option_int(cpkt, COAP_OPTION_BLOCK1);
 
@@ -1356,7 +1356,7 @@ int coap_get_block1_option(const struct coap_packet *cpkt, bool *has_more, uint8
 	return ret;
 }
 
-int coap_get_block2_option(const struct coap_packet *cpkt, uint8_t *block_number)
+int coap_get_block2_option(const struct coap_packet *cpkt, uint32_t *block_number)
 {
 	int ret = coap_get_option_int(cpkt, COAP_OPTION_BLOCK2);
 

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -1356,7 +1356,8 @@ int coap_get_block1_option(const struct coap_packet *cpkt, bool *has_more, uint3
 	return ret;
 }
 
-int coap_get_block2_option(const struct coap_packet *cpkt, uint32_t *block_number)
+int coap_get_block2_option(const struct coap_packet *cpkt, bool *has_more,
+			   uint32_t *block_number)
 {
 	int ret = coap_get_option_int(cpkt, COAP_OPTION_BLOCK2);
 
@@ -1364,6 +1365,7 @@ int coap_get_block2_option(const struct coap_packet *cpkt, uint32_t *block_numbe
 		return ret;
 	}
 
+	*has_more = GET_MORE(ret);
 	*block_number = GET_NUM(ret);
 	ret = 1 << (GET_BLOCK_SIZE(ret) + 4);
 	return ret;

--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -2650,7 +2650,7 @@ static void handle_ongoing_block2_tx(struct lwm2m_message *msg, struct coap_pack
 {
 #if defined(CONFIG_LWM2M_COAP_BLOCK_TRANSFER)
 	int r;
-	uint8_t block;
+	uint32_t block;
 	enum coap_block_size block_size;
 
 	r = coap_get_block2_option(cpkt, &block);
@@ -2688,8 +2688,8 @@ void lwm2m_udp_receive(struct lwm2m_ctx *client_ctx, uint8_t *buf, uint16_t buf_
 	int r;
 #if defined(CONFIG_LWM2M_COAP_BLOCK_TRANSFER)
 	bool more_blocks = false;
-	uint8_t block_num;
-	uint8_t last_block_num;
+	uint32_t block_num;
+	uint32_t last_block_num;
 #endif
 	bool has_block2;
 

--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -2650,10 +2650,11 @@ static void handle_ongoing_block2_tx(struct lwm2m_message *msg, struct coap_pack
 {
 #if defined(CONFIG_LWM2M_COAP_BLOCK_TRANSFER)
 	int r;
+	bool more;
 	uint32_t block;
 	enum coap_block_size block_size;
 
-	r = coap_get_block2_option(cpkt, &block);
+	r = coap_get_block2_option(cpkt, &more, &block);
 	if (r < 0) {
 		LOG_ERR("Failed to parse BLOCK2");
 		return;


### PR DESCRIPTION
The block number in block1/2 options can be encoded on up to 20 bits according to RFC 7959, therefore the underlying type used in helper functions to retrieve the block number should be large enough to hold the result. Therefore, replace the container for block number with uint32_t instead of uint8_t.

Fixes #76000

TODO:
- [x] Add a note in the migration guide, when available.