### PR TITLE
storage/stream_flash: Fix write_block_size too small

### DIFF
--- a/include/zephyr/storage/stream_flash.h
+++ b/include/zephyr/storage/stream_flash.h
@@ -65,8 +65,8 @@ struct stream_flash_ctx {
 #ifdef CONFIG_STREAM_FLASH_ERASE
 	off_t last_erased_page_start_offset; /* Last erased offset */
 #endif
+	size_t write_block_size;	/* Offset/size device write alignment */
 	uint8_t erase_value;
-	uint8_t write_block_size;	/* Offset/size device write alignment */
 };
 
 /**


### PR DESCRIPTION
Fix for platforms with write-block-size >= 256 bytes.

Fixes #76029

**Rationale for 3.7.0 milestone**
This is the fix for bug that hard faults applications using stream flash on devices that have write-block-size >=256.

**Rationale for Release Blocker label**
The bug has been introduced during this release, somewhere in May, it is not worth letting it pass through release gates and fix it later.