### PR TITLE
bugfix: twister: Fix twister to work with v1 boards

### DIFF
--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -408,7 +408,7 @@ class TestPlan:
         v1_boards = list_boards.find_boards(lb_args)
         v2_dirs = list_boards.find_v2_board_dirs(lb_args)
         for b in v1_boards:
-            board_dirs.add(b.dir)
+            board_dirs.add(b.directories)
         board_dirs.update(v2_dirs)
         logger.debug("Reading platform configuration files under %s..." % self.env.board_roots)
 


### PR DESCRIPTION
Soc variants PR changed a name of variable "dir" to "directories" for Board object. However, it wasn't aligned in twister code where v1 boards are discovered.