### PR TITLE
licensing: mention GPL licensed openocd file

### DIFF
--- a/doc/LICENSING.rst
+++ b/doc/LICENSING.rst
@@ -30,3 +30,6 @@ licensing in this document.
   *Origin:* GCC, the GNU Compiler Collection
 
   *Licensing:* `GPLv2 License`_ with Runtime Library Exception
+
+*boards/ene/kb1200_evb/support/openocd.cfg*
+  *Licensing:* `GPLv2 License`_


### PR DESCRIPTION
Let's mention this GPL licensed file, even that it is just a configuration file.