### PR TITLE
tests: drivers: uart: uart_async_api: Rework to allow testing of multiple instances

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -590,6 +590,9 @@ static void uarte_periph_enable(const struct device *dev)
 
 	(void)data;
 	nrf_uarte_enable(uarte);
+#ifdef CONFIG_SOC_NRF54H20_GPD
+	nrf_gpd_retain_pins_set(config->pcfg, false);
+#endif
 #if UARTE_BAUDRATE_RETENTION_WORKAROUND
 	nrf_uarte_baudrate_set(uarte,
 		COND_CODE_1(CONFIG_UART_USE_RUNTIME_CONFIGURE,
@@ -702,6 +705,11 @@ static void uarte_disable_locked(const struct device *dev, uint32_t dis_mask)
 	}
 #endif
 
+#ifdef CONFIG_SOC_NRF54H20_GPD
+	const struct uarte_nrfx_config *cfg = dev->config;
+
+	nrf_gpd_retain_pins_set(cfg->pcfg, true);
+#endif
 	nrf_uarte_disable(get_uarte_instance(dev));
 }
 
@@ -2103,9 +2111,6 @@ static void uarte_pm_resume(const struct device *dev)
 
 	if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME) || !LOW_POWER_ENABLED(cfg)) {
 		uarte_periph_enable(dev);
-#ifdef CONFIG_SOC_NRF54H20_GPD
-		nrf_gpd_retain_pins_set(cfg->pcfg, false);
-#endif
 	}
 }
 

--- a/tests/drivers/uart/uart_async_api/boards/nrf54h20dk_nrf54h20_common.dtsi
+++ b/tests/drivers/uart/uart_async_api/boards/nrf54h20dk_nrf54h20_common.dtsi
@@ -3,8 +3,11 @@
 &pinctrl {
 	uart137_default_alt: uart137_default_alt {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 0, 6)>,
-				<NRF_PSEL(UART_RX, 0, 7)>;
+			psels = <NRF_PSEL(UART_TX, 0, 6)>;
+		};
+		group2 {
+			psels = <NRF_PSEL(UART_RX, 0, 7)>;
+			bias-pull-up;
 		};
 	};
 
@@ -15,12 +18,36 @@
 			low-power-enable;
 		};
 	};
+	uart120_default_alt: uart120_default_alt {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 7, 7)>;
+		};
+		group2 {
+			psels = <NRF_PSEL(UART_RX, 7, 4)>;
+			bias-pull-up;
+		};
+	};
+
+	uart120_sleep_alt: uart120_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 7, 7)>,
+				<NRF_PSEL(UART_RX, 7, 4)>;
+			low-power-enable;
+		};
+	};
 };
 
 dut: &uart137 {
 	status = "okay";
 	pinctrl-0 = <&uart137_default_alt>;
 	pinctrl-1 = <&uart137_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	current-speed = <115200>;
+};
+
+dut2: &uart120 {
+	pinctrl-0 = <&uart120_default_alt>;
+	pinctrl-1 = <&uart120_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 	current-speed = <115200>;
 };

--- a/tests/drivers/uart/uart_async_api/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -5,3 +5,12 @@
 &dut {
 	memory-regions = <&cpuapp_dma_region>;
 };
+
+&dut2 {
+	status = "okay";
+	memory-regions = <&dma_fast_region>;
+};
+
+&dma_fast_region {
+	status = "okay";
+};

--- a/tests/drivers/uart/uart_async_api/src/test_uart_async.c
+++ b/tests/drivers/uart/uart_async_api/src/test_uart_async.c
@@ -31,12 +31,17 @@ struct dut_data {
 	const char *name;
 };
 
-static ZTEST_DMEM struct dut_data duts[] = {
+ZTEST_DMEM struct dut_data duts[] = {
 	{
 		.dev = DEVICE_DT_GET(UART_NODE),
 		.name = DT_NODE_FULL_NAME(UART_NODE),
 	},
-	/* More instances can be added here. */
+#if DT_NODE_EXISTS(DT_NODELABEL(dut2)) && DT_NODE_HAS_STATUS(DT_NODELABEL(dut2), okay)
+	{
+		.dev = DEVICE_DT_GET(DT_NODELABEL(dut2)),
+		.name = DT_NODE_FULL_NAME(DT_NODELABEL(dut2)),
+	},
+#endif
 };
 
 static ZTEST_BMEM const struct device *uart_dev;

--- a/tests/drivers/uart/uart_async_api/src/test_uart_async.c
+++ b/tests/drivers/uart/uart_async_api/src/test_uart_async.c
@@ -24,12 +24,12 @@ K_SEM_DEFINE(rx_buf_coherency, 0, 255);
 K_SEM_DEFINE(rx_buf_released, 0, 1);
 K_SEM_DEFINE(rx_disabled, 0, 1);
 
-ZTEST_BMEM volatile bool failed_in_isr;
+static ZTEST_BMEM volatile bool failed_in_isr;
 static ZTEST_BMEM const struct device *const uart_dev =
 	DEVICE_DT_GET(UART_NODE);
 
 static void read_abort_timeout(struct k_timer *timer);
-K_TIMER_DEFINE(read_abort_timer, read_abort_timeout, NULL);
+static K_TIMER_DEFINE(read_abort_timer, read_abort_timeout, NULL);
 
 
 static void init_test(void)
@@ -100,7 +100,7 @@ struct test_data {
 #if NOCACHE_MEM
 static struct test_data tdata __used __NOCACHE;
 #else
-ZTEST_BMEM struct test_data tdata;
+static ZTEST_BMEM struct test_data tdata;
 #endif /* NOCACHE_MEM */
 
 static void test_single_read_callback(const struct device *dev,
@@ -331,14 +331,14 @@ static __aligned(32) uint8_t chained_read_buf_0[8] __used __NOCACHE;
 static __aligned(32) uint8_t chained_read_buf_1[8] __used __NOCACHE;
 static __aligned(32) uint8_t chained_cpy_buf[10] __used __NOCACHE;
 #else
-ZTEST_BMEM uint8_t chained_read_buf_0[8];
-ZTEST_BMEM uint8_t chained_read_buf_1[8];
-ZTEST_BMEM uint8_t chained_cpy_buf[10];
+static ZTEST_BMEM uint8_t chained_read_buf_0[8];
+static ZTEST_BMEM uint8_t chained_read_buf_1[8];
+static ZTEST_BMEM uint8_t chained_cpy_buf[10];
 #endif /* NOCACHE_MEM */
-ZTEST_BMEM volatile uint8_t rx_data_idx;
-ZTEST_BMEM uint8_t rx_buf_idx;
+static ZTEST_BMEM volatile uint8_t rx_data_idx;
+static ZTEST_BMEM uint8_t rx_buf_idx;
 
-ZTEST_BMEM uint8_t *read_ptr;
+static ZTEST_BMEM uint8_t *read_ptr;
 
 static uint8_t *chained_read_buf[2] = {chained_read_buf_0, chained_read_buf_1};
 
@@ -422,9 +422,9 @@ ZTEST_USER(uart_async_chain_read, test_chained_read)
 #if NOCACHE_MEM
 static __aligned(32) uint8_t double_buffer[2][12] __used __NOCACHE;
 #else
-ZTEST_BMEM uint8_t double_buffer[2][12];
+static ZTEST_BMEM uint8_t double_buffer[2][12];
 #endif /* NOCACHE_MEM */
-ZTEST_DMEM uint8_t *next_buf = double_buffer[1];
+static ZTEST_DMEM uint8_t *next_buf = double_buffer[1];
 
 static void test_double_buffer_callback(const struct device *dev,
 				 struct uart_event *evt, void *user_data)
@@ -497,10 +497,10 @@ ZTEST_USER(uart_async_double_buf, test_double_buffer)
 static __aligned(32) uint8_t test_read_abort_rx_buf[2][100] __used __NOCACHE;
 static __aligned(32) uint8_t test_read_abort_read_buf[100] __used __NOCACHE;
 #else
-ZTEST_BMEM uint8_t test_read_abort_rx_buf[2][100];
-ZTEST_BMEM uint8_t test_read_abort_read_buf[100];
+static ZTEST_BMEM uint8_t test_read_abort_rx_buf[2][100];
+static ZTEST_BMEM uint8_t test_read_abort_read_buf[100];
 #endif /* NOCACHE_MEM */
-ZTEST_BMEM int test_read_abort_rx_cnt;
+static ZTEST_BMEM int test_read_abort_rx_cnt;
 
 static void test_read_abort_callback(const struct device *dev,
 			      struct uart_event *evt, void *user_data)
@@ -613,12 +613,12 @@ ZTEST_USER(uart_async_read_abort, test_read_abort)
 
 }
 
-ZTEST_BMEM volatile size_t sent;
-ZTEST_BMEM volatile size_t received;
+static ZTEST_BMEM volatile size_t sent;
+static ZTEST_BMEM volatile size_t received;
 #if NOCACHE_MEM
 static __aligned(32) uint8_t test_rx_buf[2][100] __used __NOCACHE;
 #else
-ZTEST_BMEM uint8_t test_rx_buf[2][100];
+static ZTEST_BMEM uint8_t test_rx_buf[2][100];
 #endif /* NOCACHE_MEM */
 
 static void test_write_abort_callback(const struct device *dev,
@@ -776,12 +776,12 @@ ZTEST_USER(uart_async_timeout, test_forever_timeout)
 
 
 #if NOCACHE_MEM
-const uint8_t chained_write_tx_bufs[2][10] = {"Message 1", "Message 2"};
+static const uint8_t chained_write_tx_bufs[2][10] = {"Message 1", "Message 2"};
 #else
-ZTEST_DMEM uint8_t chained_write_tx_bufs[2][10] = {"Message 1", "Message 2"};
+static ZTEST_DMEM uint8_t chained_write_tx_bufs[2][10] = {"Message 1", "Message 2"};
 #endif /* NOCACHE_MEM */
-ZTEST_DMEM bool chained_write_next_buf = true;
-ZTEST_BMEM volatile uint8_t tx_sent;
+static ZTEST_DMEM bool chained_write_next_buf = true;
+static ZTEST_BMEM volatile uint8_t tx_sent;
 
 static void test_chained_write_callback(const struct device *dev,
 				 struct uart_event *evt, void *user_data)
@@ -863,12 +863,12 @@ static __aligned(32) uint8_t long_rx_buf[RX_LONG_BUFFER] __used __NOCACHE;
 static __aligned(32) uint8_t long_rx_buf2[RX_LONG_BUFFER] __used __NOCACHE;
 static __aligned(32) uint8_t long_tx_buf[TX_LONG_BUFFER] __used __NOCACHE;
 #else
-ZTEST_BMEM uint8_t long_rx_buf[RX_LONG_BUFFER];
-ZTEST_BMEM uint8_t long_rx_buf2[RX_LONG_BUFFER];
-ZTEST_BMEM uint8_t long_tx_buf[TX_LONG_BUFFER];
+static ZTEST_BMEM uint8_t long_rx_buf[RX_LONG_BUFFER];
+static ZTEST_BMEM uint8_t long_rx_buf2[RX_LONG_BUFFER];
+static ZTEST_BMEM uint8_t long_tx_buf[TX_LONG_BUFFER];
 #endif /* NOCACHE_MEM */
-ZTEST_BMEM volatile uint8_t evt_num;
-ZTEST_BMEM size_t long_received[2];
+static ZTEST_BMEM volatile uint8_t evt_num;
+static ZTEST_BMEM size_t long_received[2];
 
 static void test_long_buffers_callback(const struct device *dev,
 				struct uart_event *evt, void *user_data)

--- a/tests/drivers/uart/uart_async_api/src/test_uart_async.c
+++ b/tests/drivers/uart/uart_async_api/src/test_uart_async.c
@@ -25,24 +25,26 @@ K_SEM_DEFINE(rx_buf_released, 0, 1);
 K_SEM_DEFINE(rx_disabled, 0, 1);
 
 static ZTEST_BMEM volatile bool failed_in_isr;
-static ZTEST_BMEM const struct device *const uart_dev =
-	DEVICE_DT_GET(UART_NODE);
+
+struct dut_data {
+	const struct device *dev;
+	const char *name;
+};
+
+static ZTEST_DMEM struct dut_data duts[] = {
+	{
+		.dev = DEVICE_DT_GET(UART_NODE),
+		.name = DT_NODE_FULL_NAME(UART_NODE),
+	},
+	/* More instances can be added here. */
+};
+
+static ZTEST_BMEM const struct device *uart_dev;
+static ZTEST_BMEM const char *uart_name;
 
 static void read_abort_timeout(struct k_timer *timer);
 static K_TIMER_DEFINE(read_abort_timer, read_abort_timeout, NULL);
 
-
-static void init_test(void)
-{
-	__ASSERT_NO_MSG(device_is_ready(uart_dev));
-	uart_rx_disable(uart_dev);
-	uart_tx_abort(uart_dev);
-	k_sem_reset(&tx_done);
-	k_sem_reset(&tx_aborted);
-	k_sem_reset(&rx_rdy);
-	k_sem_reset(&rx_buf_released);
-	k_sem_reset(&rx_disabled);
-}
 
 #ifdef CONFIG_USERSPACE
 static void set_permissions(void)
@@ -50,14 +52,22 @@ static void set_permissions(void)
 	k_thread_access_grant(k_current_get(), &tx_done, &tx_aborted,
 			      &rx_rdy, &rx_buf_coherency, &rx_buf_released,
 			      &rx_disabled, uart_dev, &read_abort_timer);
+
+	for (size_t i = 0; i < ARRAY_SIZE(duts); i++) {
+		k_thread_access_grant(k_current_get(), duts[i].dev);
+	}
 }
 #endif
 
-static void uart_async_test_init(void)
+static void uart_async_test_init(int idx)
 {
 	static bool initialized;
 
+	uart_dev = duts[idx].dev;
+	uart_name = duts[idx].name;
+
 	__ASSERT_NO_MSG(device_is_ready(uart_dev));
+	TC_PRINT("UART instance:%s\n", uart_name);
 	uart_rx_disable(uart_dev);
 	uart_tx_abort(uart_dev);
 	k_sem_reset(&tx_done);
@@ -79,7 +89,6 @@ static void uart_async_test_init(void)
 #endif
 
 	if (!initialized) {
-		init_test();
 		initialized = true;
 #ifdef CONFIG_USERSPACE
 		set_permissions();
@@ -143,11 +152,13 @@ static void test_single_read_callback(const struct device *dev,
 	}
 }
 
-ZTEST_BMEM volatile uint32_t tx_aborted_count;
+static ZTEST_BMEM volatile uint32_t tx_aborted_count;
 
 static void *single_read_setup(void)
 {
-	uart_async_test_init();
+	static int idx;
+
+	uart_async_test_init(idx++);
 
 	memset(&tdata, 0, sizeof(tdata));
 	tdata.supply_second_buffer = true;
@@ -228,7 +239,9 @@ ZTEST_USER(uart_async_single_read, test_single_read)
 
 static void *multiple_rx_enable_setup(void)
 {
-	uart_async_test_init();
+	static int idx;
+
+	uart_async_test_init(idx++);
 
 	memset(&tdata, 0, sizeof(tdata));
 	/* Reuse the callback from the single_read test case, as this test case
@@ -375,7 +388,9 @@ static void test_chained_read_callback(const struct device *dev,
 
 static void *chained_read_setup(void)
 {
-	uart_async_test_init();
+	static int idx;
+
+	uart_async_test_init(idx++);
 
 	uart_callback_set(uart_dev, test_chained_read_callback, NULL);
 
@@ -455,7 +470,9 @@ static void test_double_buffer_callback(const struct device *dev,
 
 static void *double_buffer_setup(void)
 {
-	uart_async_test_init();
+	static int idx;
+
+	uart_async_test_init(idx++);
 
 	uart_callback_set(uart_dev, test_double_buffer_callback, NULL);
 
@@ -501,6 +518,7 @@ static ZTEST_BMEM uint8_t test_read_abort_rx_buf[2][100];
 static ZTEST_BMEM uint8_t test_read_abort_read_buf[100];
 #endif /* NOCACHE_MEM */
 static ZTEST_BMEM int test_read_abort_rx_cnt;
+static ZTEST_BMEM bool test_read_abort_rx_buf_req_once;
 
 static void test_read_abort_callback(const struct device *dev,
 			      struct uart_event *evt, void *user_data)
@@ -515,14 +533,12 @@ static void test_read_abort_callback(const struct device *dev,
 		break;
 	case UART_RX_BUF_REQUEST:
 	{
-		static bool once;
-
-		if (!once) {
+		if (!test_read_abort_rx_buf_req_once) {
 			k_sem_give(&rx_buf_coherency);
 			uart_rx_buf_rsp(dev,
 					test_read_abort_rx_buf[1],
 					sizeof(test_read_abort_rx_buf[1]));
-			once = true;
+			test_read_abort_rx_buf_req_once = true;
 		}
 		break;
 	}
@@ -558,8 +574,11 @@ static void read_abort_timeout(struct k_timer *timer)
 
 static void *read_abort_setup(void)
 {
-	uart_async_test_init();
+	static int idx;
 
+	uart_async_test_init(idx++);
+
+	test_read_abort_rx_buf_req_once = false;
 	failed_in_isr = false;
 	uart_callback_set(uart_dev, test_read_abort_callback, NULL);
 
@@ -654,7 +673,9 @@ static void test_write_abort_callback(const struct device *dev,
 
 static void *write_abort_setup(void)
 {
-	uart_async_test_init();
+	static int idx;
+
+	uart_async_test_init(idx++);
 
 	uart_callback_set(uart_dev, test_write_abort_callback, NULL);
 
@@ -727,7 +748,9 @@ static void test_forever_timeout_callback(const struct device *dev,
 
 static void *forever_timeout_setup(void)
 {
-	uart_async_test_init();
+	static int idx;
+
+	uart_async_test_init(idx++);
 
 	uart_callback_set(uart_dev, test_forever_timeout_callback, NULL);
 
@@ -816,8 +839,12 @@ static void test_chained_write_callback(const struct device *dev,
 
 static void *chained_write_setup(void)
 {
-	uart_async_test_init();
+	static int idx;
 
+	uart_async_test_init(idx++);
+
+	tx_sent = 0;
+	chained_write_next_buf = true;
 	uart_callback_set(uart_dev, test_chained_write_callback, NULL);
 
 	return NULL;
@@ -869,11 +896,11 @@ static ZTEST_BMEM uint8_t long_tx_buf[TX_LONG_BUFFER];
 #endif /* NOCACHE_MEM */
 static ZTEST_BMEM volatile uint8_t evt_num;
 static ZTEST_BMEM size_t long_received[2];
+static ZTEST_BMEM uint8_t *long_next_buffer;
 
 static void test_long_buffers_callback(const struct device *dev,
 				struct uart_event *evt, void *user_data)
 {
-	static uint8_t *next_buffer = long_rx_buf2;
 
 	switch (evt->type) {
 	case UART_TX_DONE:
@@ -895,8 +922,8 @@ static void test_long_buffers_callback(const struct device *dev,
 		k_sem_give(&rx_disabled);
 		break;
 	case UART_RX_BUF_REQUEST:
-		uart_rx_buf_rsp(dev, next_buffer, RX_LONG_BUFFER);
-		next_buffer = (next_buffer == long_rx_buf2) ? long_rx_buf : long_rx_buf2;
+		uart_rx_buf_rsp(dev, long_next_buffer, RX_LONG_BUFFER);
+		long_next_buffer = (long_next_buffer == long_rx_buf2) ? long_rx_buf : long_rx_buf2;
 		break;
 	default:
 		break;
@@ -905,8 +932,12 @@ static void test_long_buffers_callback(const struct device *dev,
 
 static void *long_buffers_setup(void)
 {
-	uart_async_test_init();
+	static int idx;
 
+	uart_async_test_init(idx++);
+
+	evt_num = 0;
+	long_next_buffer = long_rx_buf2;
 	uart_callback_set(uart_dev, test_long_buffers_callback, NULL);
 
 	return NULL;
@@ -988,3 +1019,12 @@ ZTEST_SUITE(uart_async_write_abort, NULL, write_abort_setup,
 
 ZTEST_SUITE(uart_async_timeout, NULL, forever_timeout_setup,
 		NULL, NULL, NULL);
+
+void test_main(void)
+{
+	/* Run all suites for each dut UART. Setup function for each suite is picking
+	 * next UART from the array.
+	 */
+	ztest_run_all(NULL, false, ARRAY_SIZE(duts), 1);
+	ztest_verify_all_test_suites_ran();
+}


### PR DESCRIPTION
Test is using a single instance but Nordic has SoCs which has UART instances that are a bit different and we would like to test multiple of them in the test.

Reworked the test to have an array of DUT instances with only one currently added.

Due to userspace setup test is using the approach where each test is in separate suite so it is not that obvious how to may it mutli-instance and maybe there is a better way than I took.