### PR TITLE
net: l2: ethernet: add function to get phy of a ethernet device

### DIFF
--- a/drivers/ethernet/eth_esp32.c
+++ b/drivers/ethernet/eth_esp32.c
@@ -353,6 +353,12 @@ err:
 	return res;
 }
 
+static const struct device *eth_esp32_phy_get(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+	return eth_esp32_phy_dev;
+}
+
 static void eth_esp32_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
@@ -381,6 +387,7 @@ static const struct ethernet_api eth_esp32_api = {
 	.iface_api.init		= eth_esp32_iface_init,
 	.get_capabilities	= eth_esp32_caps,
 	.set_config		= eth_esp32_set_config,
+	.get_phy		= eth_esp32_phy_get,
 	.send			= eth_esp32_send,
 };
 

--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
@@ -561,10 +561,18 @@ static int eth_nxp_enet_qos_mac_init(const struct device *dev)
 	return ret;
 }
 
+static const struct device *eth_nxp_enet_qos_get_phy(const struct device *dev)
+{
+	const struct nxp_enet_qos_mac_config *config = dev->config;
+
+	return config->phy_dev;
+}
+
 static const struct ethernet_api api_funcs = {
 	.iface_api.init = eth_nxp_enet_qos_iface_init,
 	.send = eth_nxp_enet_qos_tx,
 	.get_capabilities = eth_nxp_enet_qos_get_capabilities,
+	.get_phy = eth_nxp_enet_qos_get_phy,
 };
 
 #define NXP_ENET_QOS_NODE_HAS_MAC_ADDR_CHECK(n)						\

--- a/drivers/ethernet/eth_nxp_s32_gmac.c
+++ b/drivers/ethernet/eth_nxp_s32_gmac.c
@@ -134,6 +134,13 @@ static void phy_link_state_changed(const struct device *pdev,
 	}
 }
 
+static const struct device *eth_nxp_s32_get_phy(const struct device *dev)
+{
+	const struct eth_nxp_s32_config *cfg = dev->config;
+
+	return cfg->phy_dev;
+}
+
 #if defined(CONFIG_SOC_SERIES_S32K3)
 static int select_phy_interface(Gmac_Ip_MiiModeType mode)
 {
@@ -589,6 +596,7 @@ static void eth_nxp_s32_rx_irq(const struct device *dev)
 static const struct ethernet_api eth_api = {
 	.iface_api.init = eth_nxp_s32_iface_init,
 	.get_capabilities = eth_nxp_s32_get_capabilities,
+	.get_phy = eth_nxp_s32_get_phy,
 	.start = eth_nxp_s32_start,
 	.stop = eth_nxp_s32_stop,
 	.send = eth_nxp_s32_tx,

--- a/drivers/ethernet/eth_nxp_s32_netc_psi.c
+++ b/drivers/ethernet/eth_nxp_s32_netc_psi.c
@@ -76,6 +76,13 @@ static void phy_link_state_changed(const struct device *pdev,
 	}
 }
 
+static const struct device *nxp_s32_eth_get_phy(const struct device *dev)
+{
+	const struct nxp_s32_eth_config *cfg = dev->config;
+
+	return cfg->phy_dev;
+}
+
 /* Configure ETHx_EXT_RX_CLK @ 125 MHz as source of ETH_x_RGMII_RX_CLK */
 static int nxp_s32_eth_configure_cgm(uint8_t port_idx)
 {
@@ -204,6 +211,7 @@ static void nxp_s32_eth_iface_init(struct net_if *iface)
 static const struct ethernet_api nxp_s32_eth_api = {
 	.iface_api.init = nxp_s32_eth_iface_init,
 	.get_capabilities = nxp_s32_eth_get_capabilities,
+	.get_phy = nxp_s32_eth_get_phy,
 	.set_config = nxp_s32_eth_set_config,
 	.send = nxp_s32_eth_tx
 };

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -1792,6 +1792,13 @@ static void phy_link_state_changed(const struct device *pdev,
 	}
 }
 
+static const struct device *eth_sam_gmac_get_phy(const struct device *dev)
+{
+	const struct eth_sam_dev_cfg *const cfg = dev->config;
+
+	return cfg->phy_dev;
+}
+
 static void eth0_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
@@ -2097,6 +2104,7 @@ static const struct ethernet_api eth_api = {
 	.get_capabilities = eth_sam_gmac_get_capabilities,
 	.set_config = eth_sam_gmac_set_config,
 	.get_config = eth_sam_gmac_get_config,
+	.get_phy = eth_sam_gmac_get_phy,
 	.send = eth_tx,
 
 #if defined(CONFIG_PTP_CLOCK_SAM_GMAC)

--- a/drivers/ethernet/eth_smsc91x.c
+++ b/drivers/ethernet/eth_smsc91x.c
@@ -663,6 +663,13 @@ static int smsc_init(struct smsc_data *sc)
 	return 0;
 }
 
+static const struct device *eth_get_phy(const struct device *dev)
+{
+	const struct eth_config *cfg = dev->config;
+
+	return cfg->phy_dev;
+}
+
 static void phy_link_state_changed(const struct device *phy_dev, struct phy_link_state *state,
 				   void *user_data)
 {
@@ -769,6 +776,7 @@ static void eth_initialize(struct net_if *iface)
 static const struct ethernet_api api_funcs = {
 	.iface_api.init   = eth_initialize,
 	.get_capabilities = eth_smsc_get_caps,
+	.get_phy          = eth_get_phy,
 	.set_config       = eth_smsc_set_config,
 	.send             = eth_tx,
 };

--- a/drivers/ethernet/eth_xmc4xxx.c
+++ b/drivers/ethernet/eth_xmc4xxx.c
@@ -635,6 +635,13 @@ static void phy_link_state_changed(const struct device *phy_dev, struct phy_link
 	}
 }
 
+static const struct device *eth_xmc4xxx_get_phy(const struct device *dev)
+{
+	const struct eth_xmc4xxx_config *dev_cfg = dev->config;
+
+	return config->phy_dev;
+}
+
 static void eth_xmc4xxx_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
@@ -959,6 +966,7 @@ static const struct ethernet_api eth_xmc4xxx_api = {
 	.iface_api.init = eth_xmc4xxx_iface_init,
 	.send = eth_xmc4xxx_send,
 	.set_config = eth_xmc4xxx_set_config,
+	.get_phy = eth_xmc4xxx_get_phy,
 	.get_capabilities = eth_xmc4xxx_capabilities,
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
 	.get_stats = eth_xmc4xxx_stats,

--- a/drivers/ethernet/nxp_enet/eth_nxp_enet.c
+++ b/drivers/ethernet/nxp_enet/eth_nxp_enet.c
@@ -608,6 +608,13 @@ static void eth_nxp_enet_isr(const struct device *dev)
 	irq_unlock(irq_lock_key);
 }
 
+static const struct device *eth_nxp_enet_get_phy(const struct device *dev)
+{
+	const struct nxp_enet_mac_config *config = dev->config;
+
+	return config->phy_dev;
+}
+
 /* Note this is not universally unique, it just is probably unique on a network */
 static inline void nxp_enet_unique_mac(uint8_t *mac_addr)
 {
@@ -820,6 +827,7 @@ static int eth_nxp_enet_device_pm_action(const struct device *dev, enum pm_devic
 static const struct ethernet_api api_funcs = {
 	.iface_api.init		= eth_nxp_enet_iface_init,
 	.get_capabilities	= eth_nxp_enet_get_capabilities,
+	.get_phy                = eth_nxp_enet_get_phy,
 	.set_config		= eth_nxp_enet_set_config,
 	.send			= NXP_ENET_SEND_FUNC,
 #if defined(CONFIG_PTP_CLOCK)

--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -572,6 +572,9 @@ struct ethernet_api {
 	const struct device *(*get_ptp_clock)(const struct device *dev);
 #endif /* CONFIG_PTP_CLOCK */
 
+	/** Return PHY device that is tied to this ethernet device */
+	const struct device *(*get_phy)(const struct device *dev);
+
 	/** Send a network packet */
 	int (*send)(const struct device *dev, struct net_pkt *pkt);
 };
@@ -1296,6 +1299,16 @@ int net_eth_txinjection_mode(struct net_if *iface, bool enable);
  */
 int net_eth_mac_filter(struct net_if *iface, struct net_eth_addr *mac,
 		       enum ethernet_filter_type type, bool enable);
+
+/**
+ * @brief Return the PHY device that is tied to this ethernet network interface.
+ *
+ * @param iface Network interface
+ *
+ * @return Pointer to PHY device if found, NULL if not found.
+ */
+const struct device *net_eth_get_phy(struct net_if *iface);
+
 /**
  * @brief Return PTP clock that is tied to this ethernet network interface.
  *

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -834,6 +834,26 @@ void net_eth_carrier_off(struct net_if *iface)
 	}
 }
 
+const struct device *net_eth_get_phy(struct net_if *iface)
+{
+	const struct device *dev = net_if_get_device(iface);
+	const struct ethernet_api *api = dev->api;
+
+	if (!api) {
+		return NULL;
+	}
+
+	if (net_if_l2(iface) != &NET_L2_GET_NAME(ETHERNET)) {
+		return NULL;
+	}
+
+	if (!api->get_phy) {
+		return NULL;
+	}
+
+	return api->get_phy(net_if_get_device(iface));
+}
+
 #if defined(CONFIG_PTP_CLOCK)
 const struct device *net_eth_get_ptp_clock(struct net_if *iface)
 {


### PR DESCRIPTION
- add the `get_phy` function to the ethernet api to get the phy device of a ethernet device, also add a function to access this from the iface
- use the the new functions to show info about the ethernet phy in `net iface`. Also show the link speed.
- implement the get_phy function for the existing ethernet drivers