### PR TITLE
dts: fix warnings in nxp_rt11xx.dtsi

### DIFF
--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -831,13 +831,13 @@
 			status = "disabled";
 		};
 
-		usbphy1: usbphy@0x40434000 {
+		usbphy1: usbphy@40434000 {
 			compatible = "nxp,usbphy";
 			reg = <0x40434000 0x1000>;
 			status = "disabled";
 		};
 
-		usbphy2: usbphy@0x40438000 {
+		usbphy2: usbphy@40438000 {
 			compatible = "nxp,usbphy";
 			reg = <0x40438000 0x1000>;
 			status = "disabled";


### PR DESCRIPTION
Building a project based on the rt11xx produces the following warning:

```
Warning (simple_bus_reg): /soc/usbphy@0x40434000: simple-bus unit address format error, expected "40434000"
Warning (simple_bus_reg): /soc/usbphy@0x40438000: simple-bus unit address format error, expected "40438000"
```

It is caused by a typo in the device tree, which this PR fixes.
