### PR TITLE
doc: Fix typo in SPSC lockfree queue docs

### DIFF
--- a/doc/kernel/data_structures/spsc_lockfree.rst
+++ b/doc/kernel/data_structures/spsc_lockfree.rst
@@ -3,7 +3,7 @@
 Single Producer Single Consumer Lock Free Queue
 ===============================================
 
-A :dfn:`Single Producer Single Consumer Lock Free Queue (MPSC)` is a lock free
+A :dfn:`Single Producer Single Consumer Lock Free Queue (SPSC)` is a lock free
 atomic ring buffer based queue.
 
 API Reference


### PR DESCRIPTION
SPSC was typoed as MPSC in the SPSC queue docs.

Fixes #75953