### PR TITLE
drivers: usb: udc: add USB device controller SoF report capability

### DIFF
--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -2030,6 +2030,7 @@ static int dwc2_driver_preinit(const struct device *dev)
 	k_mutex_init(&data->mutex);
 
 	data->caps.addr_before_status = true;
+	data->caps.sof = true;
 	data->caps.mps0 = UDC_MPS0_64;
 
 	(void)dwc2_quirk_caps(dev);

--- a/drivers/usb/udc/udc_nrf.c
+++ b/drivers/usb/udc/udc_nrf.c
@@ -799,6 +799,7 @@ static int udc_nrf_driver_init(const struct device *dev)
 	data->caps.out_ack = true;
 	data->caps.mps0 = UDC_NRF_MPS0;
 	data->caps.can_detect_vbus = true;
+	data->caps.sof = true;
 
 	return 0;
 }

--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -1121,6 +1121,7 @@ static int udc_stm32_driver_init0(const struct device *dev)
 
 	data->caps.rwup = true;
 	data->caps.out_ack = false;
+	data->caps.sof = true;
 	data->caps.mps0 = UDC_MPS0_64;
 
 	priv->dev = dev;

--- a/include/zephyr/drivers/usb/udc.h
+++ b/include/zephyr/drivers/usb/udc.h
@@ -44,6 +44,8 @@ struct udc_device_caps {
 	uint32_t addr_before_status : 1;
 	/** Controller can detect the state change of USB supply VBUS.*/
 	uint32_t can_detect_vbus : 1;
+	/** Controller reports Start of Frame (SoF) events.*/
+	uint32_t sof : 1;
 	/** Maximum packet size for control endpoint */
 	enum udc_mps0 mps0 : 2;
 };

--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -1057,6 +1057,15 @@ int usbd_config_maxpower(struct usbd_context *const uds_ctx,
 bool usbd_can_detect_vbus(struct usbd_context *const uds_ctx);
 
 /**
+ * @brief Check whether the controller reports Start of Frame (SoF) events.
+ *
+ * @param[in] uds_ctx Pointer to USB device support context
+ *
+ * @return true if controller reports SoF events, false otherwise
+ */
+bool usbd_reports_sof(struct usbd_context *const uds_ctx);
+
+/**
  * @}
  */
 

--- a/subsys/usb/device_next/usbd_device.c
+++ b/subsys/usb/device_next/usbd_device.c
@@ -310,3 +310,10 @@ bool usbd_can_detect_vbus(struct usbd_context *const uds_ctx)
 
 	return caps.can_detect_vbus;
 }
+
+bool usbd_reports_sof(struct usbd_context *const uds_ctx)
+{
+	const struct udc_device_caps caps = udc_caps(uds_ctx->dev);
+
+	return caps.sof;
+}


### PR DESCRIPTION
- Add capability for whether a USB device controller reports Start of Frame (SoF) events.
- Add `usbd_reports_sof()` wrapper function for determining whether the underlying USB device controller report Start of Frame (SoF) events.

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>