### PR TITLE
boards: nrf53*: sysbuild `DOMAIN_CPUNET_BOARD`

### DIFF
--- a/boards/ezurio/bl5340_dvk/Kconfig.sysbuild
+++ b/boards/ezurio/bl5340_dvk/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+# Sysbuild configuration
+# Copyright (c) 2024 Embeint Inc
+
+config DOMAIN_CPUNET_BOARD
+	string
+	default "bl5340_dvk/nrf5340/cpunet"
+	help
+	  The board which will be used for CPUNET domain when creating a multi
+	  image application where one or more images should be located on
+	  another board. For example hci_ipc for Bluetooth applications.

--- a/boards/nordic/nrf5340_audio_dk/Kconfig.sysbuild
+++ b/boards/nordic/nrf5340_audio_dk/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+# Sysbuild configuration
+# Copyright (c) 2024 Embeint Inc
+
+config DOMAIN_CPUNET_BOARD
+	string
+	default "nrf5340_audio_dk/nrf5340/cpunet"
+	help
+	  The board which will be used for CPUNET domain when creating a multi
+	  image application where one or more images should be located on
+	  another board. For example hci_ipc for Bluetooth applications.

--- a/boards/nordic/nrf5340dk/Kconfig.sysbuild
+++ b/boards/nordic/nrf5340dk/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+# Sysbuild configuration
+# Copyright (c) 2024 Embeint Inc
+
+config DOMAIN_CPUNET_BOARD
+	string
+	default "nrf5340dk/nrf5340/cpunet"
+	help
+	  The board which will be used for CPUNET domain when creating a multi
+	  image application where one or more images should be located on
+	  another board. For example hci_ipc for Bluetooth applications.

--- a/boards/nordic/thingy53/Kconfig.sysbuild
+++ b/boards/nordic/thingy53/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+# Sysbuild configuration
+# Copyright (c) 2024 Embeint Inc
+
+config DOMAIN_CPUNET_BOARD
+	string
+	default "thingy53/nrf5340/cpunet"
+	help
+	  The board which will be used for CPUNET domain when creating a multi
+	  image application where one or more images should be located on
+	  another board. For example hci_ipc for Bluetooth applications.

--- a/boards/panasonic/pan1783/Kconfig.sysbuild
+++ b/boards/panasonic/pan1783/Kconfig.sysbuild
@@ -1,0 +1,12 @@
+# Sysbuild configuration
+# Copyright (c) 2024 Embeint Inc
+
+config DOMAIN_CPUNET_BOARD
+	string
+	default "pan1783_evb/nrf5340/cpunet" if BOARD_PAN1783_EVB
+	default "pan1783a_evb/nrf5340/cpunet" if BOARD_PAN1783A_EVB
+	default "pan1783a_pa_evb/nrf5340/cpunet" if BOARD_PAN1783A_PA_EVB
+	help
+	  The board which will be used for CPUNET domain when creating a multi
+	  image application where one or more images should be located on
+	  another board. For example hci_ipc for Bluetooth applications.

--- a/boards/raytac/mdbt53_db_40/Kconfig.sysbuild
+++ b/boards/raytac/mdbt53_db_40/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+# Sysbuild configuration
+# Copyright (c) 2024 Embeint Inc
+
+config DOMAIN_CPUNET_BOARD
+	string
+	default "raytac_mdbt53_db_40/nrf5340/cpunet"
+	help
+	  The board which will be used for CPUNET domain when creating a multi
+	  image application where one or more images should be located on
+	  another board. For example hci_ipc for Bluetooth applications.

--- a/boards/raytac/mdbt53v_db_40/Kconfig.sysbuild
+++ b/boards/raytac/mdbt53v_db_40/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+# Sysbuild configuration
+# Copyright (c) 2024 Embeint Inc
+
+config DOMAIN_CPUNET_BOARD
+	string
+	default "raytac_mdbt53v_db_40/nrf5340/cpunet"
+	help
+	  The board which will be used for CPUNET domain when creating a multi
+	  image application where one or more images should be located on
+	  another board. For example hci_ipc for Bluetooth applications.


### PR DESCRIPTION
Make the `DOMAIN_CPUNET_BOARD` symbol available to sysbuild, which enables its usage in `ExternalZephyrProject_Add`.

These symbols are duplicated from the main board `Kconfig` file, which is not evaluated by sysbuild.