### PR TITLE
docs: release-notes: Add release entry for OSDP

### DIFF
--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -1859,6 +1859,13 @@ MCUboot
 
   * The MCUboot version in this release is version ``2.1.0+0-dev``.
 
+OSDP
+****
+
+* Fixed issue in CP secure channel handshake where R-MAC can be reverted to an
+  old one by a rogue PD sending an out-of-order secure channel response resulting
+  in a replay attack.
+
 Trusted Firmware-M
 ******************
 


### PR DESCRIPTION
Patch adds release notes for mgmt/osdp

Related to: #75933