### PR TITLE
tests: drivers: adc_accuracy

### DIFF
--- a/tests/drivers/adc/adc_accuracy_test/boards/ek_ra8m1.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/ek_ra8m1.overlay
@@ -8,6 +8,7 @@
 	zephyr,user {
 		io-channels = <&adc0 0>;
 		reference_mv = <3300>;
+		expected_accuracy = <32>;
 	};
 };
 

--- a/tests/drivers/adc/adc_accuracy_test/boards/frdm_kl25z.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/frdm_kl25z.overlay
@@ -8,6 +8,7 @@
 	zephyr,user {
 		io-channels = <&adc0 12>;
 		reference_mv = <1100>;
+		expected_accuracy = <32>;
 	};
 };
 

--- a/tests/drivers/adc/adc_accuracy_test/boards/frdm_mcxc242.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/frdm_mcxc242.overlay
@@ -10,6 +10,7 @@
 	zephyr,user {
 		io-channels = <&adc0 1>;
 		reference_mv = <1650>;
+		expected_accuracy = <32>;
 	};
 };
 

--- a/tests/drivers/adc/adc_accuracy_test/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/nrf52840dk_nrf52840.overlay
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ */
+
+
+/ {
+	zephyr,user {
+		io-channels = <&adc 0>;
+		reference_mv = <3000>;
+	};
+};
+
+&adc {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1_6";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_AIN1>; /* P0.03 */
+		zephyr,resolution = <14>;
+	};
+
+};

--- a/tests/drivers/adc/adc_accuracy_test/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/nrf52840dk_nrf52840.overlay
@@ -9,6 +9,7 @@
 	zephyr,user {
 		io-channels = <&adc 0>;
 		reference_mv = <3000>;
+		expected_accuracy = <32>;
 	};
 };
 

--- a/tests/drivers/adc/adc_accuracy_test/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -8,6 +8,7 @@
 	zephyr,user {
 		io-channels = <&adc 0>;
 		reference_mv = <1800>;
+		expected_accuracy = <64>;
 	};
 };
 

--- a/tests/drivers/adc/adc_accuracy_test/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc 0>;
+		reference_mv = <1800>;
+	};
+};
+
+&adc {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1_2";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_AIN4>;
+		zephyr,resolution = <14>;
+	};
+};

--- a/tests/drivers/adc/adc_accuracy_test/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc 0>;
+		reference_mv = <1800>;
+	};
+};
+
+&adc {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1_2";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <NRF_SAADC_AIN2>;
+		zephyr,resolution = <14>;
+	};
+};

--- a/tests/drivers/adc/adc_accuracy_test/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -8,6 +8,7 @@
 	zephyr,user {
 		io-channels = <&adc 0>;
 		reference_mv = <1800>;
+		expected_accuracy = <64>;
 	};
 };
 

--- a/tests/drivers/adc/adc_accuracy_test/src/ref_volt.c
+++ b/tests/drivers/adc/adc_accuracy_test/src/ref_volt.c
@@ -20,6 +20,7 @@ static int test_ref_to_adc(void)
 	struct adc_sequence sequence = {
 		.buffer      = &sample_buffer,
 		.buffer_size = sizeof(sample_buffer),
+		.calibrate = true,
 	};
 
 	const struct adc_dt_spec *adc_channel = get_adc_channel();

--- a/tests/drivers/adc/adc_accuracy_test/src/ref_volt.c
+++ b/tests/drivers/adc/adc_accuracy_test/src/ref_volt.c
@@ -8,6 +8,7 @@
 #include <zephyr/ztest.h>
 
 #define REF_V DT_PROP(DT_PATH(zephyr_user), reference_mv)
+#define EXP_ACC DT_PROP(DT_PATH(zephyr_user), expected_accuracy)
 
 extern const struct adc_dt_spec *get_adc_channel(void);
 
@@ -31,7 +32,7 @@ static int test_ref_to_adc(void)
 	ret = adc_raw_to_millivolts_dt(adc_channel, &sample_buffer);
 	zassert_equal(ret, 0, "adc_raw_to_millivolts_dt() failed with code %d",
 		      ret);
-	zassert_within(sample_buffer, REF_V, 32,
+	zassert_within(sample_buffer, REF_V, EXP_ACC,
 		"Value %d mV read from ADC does not match expected range (%d mV).",
 		sample_buffer, REF_V);
 

--- a/tests/drivers/adc/adc_accuracy_test/testcase.yaml
+++ b/tests/drivers/adc/adc_accuracy_test/testcase.yaml
@@ -21,3 +21,4 @@ tests:
       - ek_ra8m1
       - frdm_mcxc242
       - nrf52840dk/nrf52840
+      - nrf54h20dk/nrf54h20/cpuapp

--- a/tests/drivers/adc/adc_accuracy_test/testcase.yaml
+++ b/tests/drivers/adc/adc_accuracy_test/testcase.yaml
@@ -20,3 +20,4 @@ tests:
       - frdm_kl25z
       - ek_ra8m1
       - frdm_mcxc242
+      - nrf52840dk/nrf52840

--- a/tests/drivers/adc/adc_accuracy_test/testcase.yaml
+++ b/tests/drivers/adc/adc_accuracy_test/testcase.yaml
@@ -21,4 +21,5 @@ tests:
       - ek_ra8m1
       - frdm_mcxc242
       - nrf52840dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp

--- a/tests/drivers/adc/adc_api/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/adc/adc_api/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -34,7 +34,7 @@
 
 	channel@2 {
 		reg = <2>;
-		zephyr,gain = "ADC_GAIN_1_2";
+		zephyr,gain = "ADC_GAIN_2_3";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME(ADC_ACQ_TIME_MICROSECONDS, 10)>;
 		zephyr,input-positive = <NRF_SAADC_AIN2>;

--- a/tests/drivers/adc/adc_api/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/adc/adc_api/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -34,7 +34,7 @@
 
 	channel@2 {
 		reg = <2>;
-		zephyr,gain = "ADC_GAIN_2_5";
+		zephyr,gain = "ADC_GAIN_2_3";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME(ADC_ACQ_TIME_MICROSECONDS, 10)>;
 		zephyr,input-positive = <NRF_SAADC_AIN2>;


### PR DESCRIPTION
Add overlays and enable test for nrf52840dk/nrf54h20dk/nrf54l15dk.