### PR TITLE
doc: release-notes-3.7: fix LED strip release notes

### DIFF
--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -865,7 +865,8 @@ Drivers and Sensors
   * Added device completion to LED shell commands and made the ``get_info`` command display
     colors as strings.
 
-  * Added driver for Lumissil Microsystems (a division of ISSI) IS31FL3194 controller.
+  * Added driver for Lumissil Microsystems (a division of ISSI) IS31FL3194 controller
+    (:dtcompatible:`issi,is31fl3194`).
 
 * LED Strip
 
@@ -884,8 +885,8 @@ Drivers and Sensors
     :dtcompatible:`worldsemi,ws2812-gpio` and :dtcompatible:`worldsemi,ws2812-rpi_pico-pio`
     devicetree bindings have been renamed to ``gpios``.
 
-  * Removed :kconfig:option:`CONFIG_WS2812_STRIP` and :kconfig:option:`CONFIG_WS2812_STRIP_DRIVER`
-    Kconfig options. They became useless after refactoring.
+  * Removed ``CONFIG_WS2812_STRIP`` and ``CONFIG_WS2812_STRIP_DRIVER`` Kconfig options. They became
+    useless after refactoring.
 
   * Added driver for Texas Instruments TLC59731 RGB controller.
 


### PR DESCRIPTION
This patch fixes two broken links in the LED strip release note. :kconfig:option: cannot be used with removed Kconfig options. This results in broken links. Let's use the code's inline markup delimiter instead.

It also adds a missing link to the DT compatible of the IS31FL3194 controller.