### PR TITLE
Bluetooth: Controller: Fix scoring for scan_aux events

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_scan.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_scan.h
@@ -32,6 +32,9 @@ struct lll_scan {
 
 	uint16_t duration_reload;
 	uint16_t duration_expire;
+#if defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
+	uint8_t scan_aux_score;
+#endif /* CONFIG_BT_CTLR_JIT_SCHEDULING */
 	uint8_t  phy:3;
 	uint8_t  is_adv_ind:1;
 	uint8_t  is_aux_sched:1;

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -228,7 +228,8 @@ uint8_t ll_scan_enable(uint8_t enable)
 	}
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
 
-#if defined(CONFIG_BT_CTLR_PRIVACY)
+#if (defined(CONFIG_BT_CTLR_ADV_EXT) && defined(CONFIG_BT_CTLR_JIT_SCHEDULING)) || \
+	defined(CONFIG_BT_CTLR_PRIVACY)
 	struct lll_scan *lll;
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_ADV_EXT) && is_coded_phy) {
@@ -240,6 +241,7 @@ uint8_t ll_scan_enable(uint8_t enable)
 		own_addr_type = scan->own_addr_type;
 	}
 
+#if defined(CONFIG_BT_CTLR_PRIVACY)
 	ull_filter_scan_update(lll->filter_policy);
 
 	lll->rl_idx = FILTER_IDX_NONE;
@@ -253,6 +255,11 @@ uint8_t ll_scan_enable(uint8_t enable)
 		lll->rpa_gen = 1;
 	}
 #endif /* CONFIG_BT_CTLR_PRIVACY */
+
+#if defined(CONFIG_BT_CTLR_ADV_EXT) && defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
+	lll->scan_aux_score = 0;
+#endif /* CONFIG_BT_CTLR_ADV_EXT && CONFIG_BT_CTLR_JIT_SCHEDULING */
+#endif /* (CONFIG_BT_CTLR_ADV_EXT && CONFIG_BT_CTLR_JIT_SCHEDULING) || CONFIG_BT_CTLR_PRIVACY */
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 #if defined(CONFIG_BT_CTLR_PHY_CODED)

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -546,6 +546,11 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_pdu *rx)
 		lll_hdr_init(lll_aux, aux);
 
 		aux->parent = lll ? (void *)lll : (void *)sync_lll;
+#if defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
+		if (lll) {
+			lll_aux->hdr.score = lll->scan_aux_score;
+		}
+#endif /* CONFIG_BT_CTLR_JIT_SCHEDULING */
 
 #if defined(CONFIG_BT_CTLR_SYNC_PERIODIC)
 		aux->rx_incomplete = rx_incomplete;
@@ -1266,6 +1271,9 @@ static void flush(void *param)
 	scan = ull_scan_is_valid_get(scan);
 	if (!IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC) || scan) {
 		lll->lll_aux = NULL;
+#if defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
+		lll->scan_aux_score = aux->lll.hdr.score;
+#endif /* CONFIG_BT_CTLR_JIT_SCHEDULING */
 	} else {
 		struct lll_sync *sync_lll;
 		struct ll_sync_set *sync;


### PR DESCRIPTION
Score was never increased for scan_aux events since they are one-shot events; Fixed by keeping the scan_aux score as part of the scan structure