### PR TITLE
boards: *nrf52840: fix `usb_cdc` support

### DIFF
--- a/boards/ct/ctcc/ctcc_nrf52840.yaml
+++ b/boards/ct/ctcc/ctcc_nrf52840.yaml
@@ -9,7 +9,6 @@ toolchain:
 supported:
   - ble
   - gpio
-  - usb_cdc
   - usb_device
   - watchdog
 vendor: ct

--- a/boards/sparkfun/micromod/micromod_nrf52840.yaml
+++ b/boards/sparkfun/micromod/micromod_nrf52840.yaml
@@ -17,7 +17,6 @@ supported:
   - pwm
   - adc
   - usb_device
-  - usb_cdc
   - watchdog
   - micromod_gpio
   - micromod_uart


### PR DESCRIPTION
`usb_cdc` as a supported tag was removed with #73273, and as nrf52840 based platforms they support the `usbd` tag introduced in #73269.