### PR TITLE
linker: section_tags: fix missing include

### DIFF
--- a/include/zephyr/linker/section_tags.h
+++ b/include/zephyr/linker/section_tags.h
@@ -13,6 +13,8 @@
 
 #if !defined(_ASMLANGUAGE)
 
+#include <zephyr/linker/sections.h>
+
 #define __noinit		__in_section_unique(_NOINIT_SECTION_NAME)
 #define __noinit_named(name)	__in_section_unique_named(_NOINIT_SECTION_NAME, name)
 #define __irq_vector_table	Z_GENERIC_SECTION(_IRQ_VECTOR_TABLE_SECTION_NAME)


### PR DESCRIPTION
Fixes #76254.

Using section tags like `__dtcm_noinit_section` should resolve to:
```
__attribute__((section(".dtcm_noinit"), used))
```
However, due to a missing include, they resolve to:
```
__attribute__((section("_DTCM_NOINIT_SECTION_NAME"), used))
```
... failing to move the variable to the proper section and causing the following warning:
```
ld.bfd.exe: warning: orphan section `_DTCM_NOINIT_SECTION_NAME' from `app/libapp.a(main.c.obj)' being placed in section `_DTCM_NOINIT_SECTION_NAME'
```