### PR TITLE
implement a2dp remain todo/interfaces

### DIFF
--- a/doc/connectivity/bluetooth/shell/classic/a2dp.rst
+++ b/doc/connectivity/bluetooth/shell/classic/a2dp.rst
@@ -14,6 +14,8 @@ Here is a example connecting two devices:
  * Source or Sink establish the stream. using :code:`a2dp establish`.
  * Source or Sink start the media. using :code:`a2dp start`.
  * Source test the media sending. using :code:`a2dp send_media` to send one test packet data.
+ * Source or Sink suspend the media. using :code:`a2dp suspend`.
+ * Source or Sink release the media. using :code:`a2dp release`.
 
 .. tabs::
 
@@ -58,6 +60,12 @@ Here is a example connecting two devices:
                         uart:~$ a2dp send_media
                         frames num: 1, data length: 160
                         data: 1, 2, 3, 4, 5, 6 ......
+                        uart:~$ a2dp suspend
+                        success to suspend
+                        stream suspended
+                        uart:~$ a2dp release
+                        success to release
+                        stream released
 
         .. group-tab:: Device B (Audio Sink Side)
 
@@ -74,7 +82,6 @@ Here is a example connecting two devices:
                         a2dp connected
                         <after a2dp configure of source side>
                         receive requesting config and accept
-                        SBC configure success
                         sample rate 44100Hz
                         stream configured
                         <after a2dp establish of source side>
@@ -86,4 +93,10 @@ Here is a example connecting two devices:
                         <after a2dp send_media of source side>
                         received, num of frames: 1, data length: 160
                         data: 1, 2, 3, 4, 5, 6 ......
+                        <after a2dp suspend of source side>
+                        receive requesting suspend and accept
+                        stream suspended
+                        <after a2dp release of source side>
+                        receive requesting release and accept
+                        stream released
                         ...

--- a/include/zephyr/bluetooth/classic/a2dp.h
+++ b/include/zephyr/bluetooth/classic/a2dp.h
@@ -30,34 +30,33 @@ extern "C" {
 /** MPEG2,4 IE length */
 #define BT_A2DP_MPEG_2_4_IE_LENGTH (6u)
 /** The max IE (Codec Info Element) length */
-#define A2DP_MAX_IE_LENGTH (8U)
+#define A2DP_MAX_IE_LENGTH         (8U)
 
 /** @brief define the audio endpoint
  *  @param _role BT_AVDTP_SOURCE or BT_AVDTP_SINK.
  *  @param _codec value of enum bt_a2dp_codec_id.
  *  @param _capability the codec capability.
  */
-#define BT_A2DP_EP_INIT(_role, _codec, _capability)\
-{\
-	.codec_type = _codec,\
-	.sep = {.sep_info = {.media_type = BT_AVDTP_AUDIO, .tsep = _role}},\
-	.codec_cap = _capability,\
-	.stream = NULL,\
-}
+#define BT_A2DP_EP_INIT(_role, _codec, _capability)                                                \
+	{                                                                                          \
+		.codec_type = _codec,                                                              \
+		.sep = {.sep_info = {.media_type = BT_AVDTP_AUDIO, .tsep = _role}},                \
+		.codec_cap = _capability, .stream = NULL,                                          \
+	}
 
 /** @brief define the audio sink endpoint
  *  @param _codec value of enum bt_a2dp_codec_id.
  *  @param _capability the codec capability.
  */
-#define BT_A2DP_SINK_EP_INIT(_codec, _capability)\
-BT_A2DP_EP_INIT(BT_AVDTP_SINK, _codec, _capability)
+#define BT_A2DP_SINK_EP_INIT(_codec, _capability)                                                  \
+	BT_A2DP_EP_INIT(BT_AVDTP_SINK, _codec, _capability)
 
 /** @brief define the audio source endpoint
  *  @param _codec value of enum bt_a2dp_codec_id.
  *  @param _capability the codec capability.
  */
-#define BT_A2DP_SOURCE_EP_INIT(_codec, _capability)\
-BT_A2DP_EP_INIT(BT_AVDTP_SOURCE, _codec, _capability)
+#define BT_A2DP_SOURCE_EP_INIT(_codec, _capability)                                                \
+	BT_A2DP_EP_INIT(BT_AVDTP_SOURCE, _codec, _capability)
 
 /** @brief define the SBC sink endpoint that can be used as
  * bt_a2dp_register_endpoint's parameter.
@@ -80,13 +79,14 @@ BT_A2DP_EP_INIT(BT_AVDTP_SOURCE, _codec, _capability)
  *  @param _max_bitpool sbc codec max bit pool. for example: 35
  *  @
  */
-#define BT_A2DP_SBC_SINK_EP(_name, _freq, _ch_mode, _blk_len, _subband,\
-_alloc_mthd, _min_bitpool, _max_bitpool)\
-static struct bt_a2dp_codec_ie bt_a2dp_ep_cap_ie##_name =\
-{.len = BT_A2DP_SBC_IE_LENGTH, .codec_ie = {_freq | _ch_mode,\
-_blk_len | _subband | _alloc_mthd, _min_bitpool, _max_bitpool}};\
-static struct bt_a2dp_ep _name = BT_A2DP_SINK_EP_INIT(BT_A2DP_SBC,\
-(&bt_a2dp_ep_cap_ie##_name))
+#define BT_A2DP_SBC_SINK_EP(_name, _freq, _ch_mode, _blk_len, _subband, _alloc_mthd, _min_bitpool, \
+			    _max_bitpool)                                                          \
+	static struct bt_a2dp_codec_ie bt_a2dp_ep_cap_ie##_name = {                                \
+		.len = BT_A2DP_SBC_IE_LENGTH,                                                      \
+		.codec_ie = {_freq | _ch_mode, _blk_len | _subband | _alloc_mthd, _min_bitpool,    \
+			     _max_bitpool}};                                                       \
+	static struct bt_a2dp_ep _name =                                                           \
+		BT_A2DP_SINK_EP_INIT(BT_A2DP_SBC, (&bt_a2dp_ep_cap_ie##_name))
 
 /** @brief define the SBC source endpoint that can be used as bt_a2dp_register_endpoint's
  * parameter.
@@ -108,13 +108,14 @@ static struct bt_a2dp_ep _name = BT_A2DP_SINK_EP_INIT(BT_A2DP_SBC,\
  *  @param _min_bitpool sbc codec min bit pool. for example: 18
  *  @param _max_bitpool sbc codec max bit pool. for example: 35
  */
-#define BT_A2DP_SBC_SOURCE_EP(_name, _freq, _ch_mode, _blk_len, _subband,\
-_alloc_mthd, _min_bitpool, _max_bitpool)\
-static struct bt_a2dp_codec_ie bt_a2dp_ep_cap_ie##_name =\
-{.len = BT_A2DP_SBC_IE_LENGTH, .codec_ie = {_freq | _ch_mode,\
-_blk_len | _subband | _alloc_mthd, _min_bitpool, _max_bitpool}};\
-static struct bt_a2dp_ep _name = BT_A2DP_SOURCE_EP_INIT(BT_A2DP_SBC,\
-&bt_a2dp_ep_cap_ie##_name)
+#define BT_A2DP_SBC_SOURCE_EP(_name, _freq, _ch_mode, _blk_len, _subband, _alloc_mthd,             \
+			      _min_bitpool, _max_bitpool)                                          \
+	static struct bt_a2dp_codec_ie bt_a2dp_ep_cap_ie##_name = {                                \
+		.len = BT_A2DP_SBC_IE_LENGTH,                                                      \
+		.codec_ie = {_freq | _ch_mode, _blk_len | _subband | _alloc_mthd, _min_bitpool,    \
+			     _max_bitpool}};                                                       \
+	static struct bt_a2dp_ep _name =                                                           \
+		BT_A2DP_SOURCE_EP_INIT(BT_A2DP_SBC, &bt_a2dp_ep_cap_ie##_name)
 
 /** @brief define the default SBC sink endpoint that can be used as
  * bt_a2dp_register_endpoint's parameter.
@@ -124,14 +125,17 @@ static struct bt_a2dp_ep _name = BT_A2DP_SOURCE_EP_INIT(BT_A2DP_SBC,\
  *
  *  @param _name the endpoint variable name.
  */
-#define BT_A2DP_SBC_SINK_EP_DEFAULT(_name)\
-static struct bt_a2dp_codec_ie bt_a2dp_ep_cap_ie##_name =\
-{.len = BT_A2DP_SBC_IE_LENGTH, .codec_ie = {A2DP_SBC_SAMP_FREQ_44100 |\
-A2DP_SBC_SAMP_FREQ_48000 | A2DP_SBC_CH_MODE_MONO | A2DP_SBC_CH_MODE_STREO |\
-A2DP_SBC_CH_MODE_JOINT, A2DP_SBC_BLK_LEN_16 |\
-A2DP_SBC_SUBBAND_8 | A2DP_SBC_ALLOC_MTHD_LOUDNESS, 18U, 35U}};\
-static struct bt_a2dp_ep _name = BT_A2DP_SINK_EP_INIT(BT_A2DP_SBC,\
-&bt_a2dp_ep_cap_ie##_name)
+#define BT_A2DP_SBC_SINK_EP_DEFAULT(_name)                                                         \
+	static struct bt_a2dp_codec_ie bt_a2dp_ep_cap_ie##_name = {                                \
+		.len = BT_A2DP_SBC_IE_LENGTH,                                                      \
+		.codec_ie = {A2DP_SBC_SAMP_FREQ_44100 | A2DP_SBC_SAMP_FREQ_48000 |                 \
+				     A2DP_SBC_CH_MODE_MONO | A2DP_SBC_CH_MODE_STREO |              \
+				     A2DP_SBC_CH_MODE_JOINT,                                       \
+			     A2DP_SBC_BLK_LEN_16 | A2DP_SBC_SUBBAND_8 |                            \
+				     A2DP_SBC_ALLOC_MTHD_LOUDNESS,                                 \
+			     18U, 35U}};                                                           \
+	static struct bt_a2dp_ep _name =                                                           \
+		BT_A2DP_SINK_EP_INIT(BT_A2DP_SBC, &bt_a2dp_ep_cap_ie##_name)
 
 /** @brief define the default SBC source endpoint that can be used as bt_a2dp_register_endpoint's
  * parameter.
@@ -141,14 +145,18 @@ static struct bt_a2dp_ep _name = BT_A2DP_SINK_EP_INIT(BT_A2DP_SBC,\
  *
  *  @param _name the endpoint variable name.
  */
-#define BT_A2DP_SBC_SOURCE_EP_DEFAULT(_name)\
-static struct bt_a2dp_codec_ie bt_a2dp_ep_cap_ie##_name =\
-{.len = BT_A2DP_SBC_IE_LENGTH, .codec_ie = {A2DP_SBC_SAMP_FREQ_44100 | \
-A2DP_SBC_SAMP_FREQ_48000 | A2DP_SBC_CH_MODE_MONO | A2DP_SBC_CH_MODE_STREO | \
-A2DP_SBC_CH_MODE_JOINT, A2DP_SBC_BLK_LEN_16 | A2DP_SBC_SUBBAND_8 | A2DP_SBC_ALLOC_MTHD_LOUDNESS,\
-18U, 35U},};\
-static struct bt_a2dp_ep _name = BT_A2DP_SOURCE_EP_INIT(BT_A2DP_SBC,\
-&bt_a2dp_ep_cap_ie##_name)
+#define BT_A2DP_SBC_SOURCE_EP_DEFAULT(_name)                                                       \
+	static struct bt_a2dp_codec_ie bt_a2dp_ep_cap_ie##_name = {                                \
+		.len = BT_A2DP_SBC_IE_LENGTH,                                                      \
+		.codec_ie = {A2DP_SBC_SAMP_FREQ_44100 | A2DP_SBC_SAMP_FREQ_48000 |                 \
+				     A2DP_SBC_CH_MODE_MONO | A2DP_SBC_CH_MODE_STREO |              \
+				     A2DP_SBC_CH_MODE_JOINT,                                       \
+			     A2DP_SBC_BLK_LEN_16 | A2DP_SBC_SUBBAND_8 |                            \
+				     A2DP_SBC_ALLOC_MTHD_LOUDNESS,                                 \
+			     18U, 35U},                                                            \
+	};                                                                                         \
+	static struct bt_a2dp_ep _name =                                                           \
+		BT_A2DP_SOURCE_EP_INIT(BT_A2DP_SBC, &bt_a2dp_ep_cap_ie##_name)
 
 /** @brief define the SBC default configuration.
  *
@@ -166,23 +174,34 @@ static struct bt_a2dp_ep _name = BT_A2DP_SOURCE_EP_INIT(BT_A2DP_SBC,\
  *  @param _min_bitpool_cfg sbc codec min bit pool. for example: 18
  *  @param _max_bitpool_cfg sbc codec max bit pool. for example: 35
  */
-#define BT_A2DP_SBC_EP_CFG(_name, _freq_cfg, _ch_mode_cfg, _blk_len_cfg, _subband_cfg,\
-_alloc_mthd_cfg, _min_bitpool_cfg, _max_bitpool_cfg)\
-static struct bt_a2dp_codec_ie bt_a2dp_codec_ie##_name = {\
-.len = BT_A2DP_SBC_IE_LENGTH, .codec_ie = {_freq_cfg | _ch_mode_cfg,\
-_blk_len_cfg | _subband_cfg | _alloc_mthd_cfg, _min_bitpool_cfg, _max_bitpool_cfg},};\
-struct bt_a2dp_codec_cfg _name = {.codec_config = &bt_a2dp_codec_ie##_name,}
+#define BT_A2DP_SBC_EP_CFG(_name, _freq_cfg, _ch_mode_cfg, _blk_len_cfg, _subband_cfg,             \
+			   _alloc_mthd_cfg, _min_bitpool_cfg, _max_bitpool_cfg)                    \
+	static struct bt_a2dp_codec_ie bt_a2dp_codec_ie##_name = {                                 \
+		.len = BT_A2DP_SBC_IE_LENGTH,                                                      \
+		.codec_ie = {_freq_cfg | _ch_mode_cfg,                                             \
+			     _blk_len_cfg | _subband_cfg | _alloc_mthd_cfg, _min_bitpool_cfg,      \
+			     _max_bitpool_cfg},                                                    \
+	};                                                                                         \
+	struct bt_a2dp_codec_cfg _name = {                                                         \
+		.codec_config = &bt_a2dp_codec_ie##_name,                                          \
+	}
 
 /** @brief define the SBC default configuration.
  *
  *  @param _name unique structure name postfix.
  *  @param _freq_cfg the frequency to configure the remote same codec type endpoint.
  */
-#define BT_A2DP_SBC_EP_CFG_DEFAULT(_name, _freq_cfg)\
-static struct bt_a2dp_codec_ie bt_a2dp_codec_ie##_name = {\
-.len = BT_A2DP_SBC_IE_LENGTH, .codec_ie = {_freq_cfg | A2DP_SBC_CH_MODE_JOINT,\
-A2DP_SBC_BLK_LEN_16 | A2DP_SBC_SUBBAND_8 | A2DP_SBC_ALLOC_MTHD_LOUDNESS, 18U, 35U},};\
-struct bt_a2dp_codec_cfg _name = {.codec_config = &bt_a2dp_codec_ie##_name,}
+#define BT_A2DP_SBC_EP_CFG_DEFAULT(_name, _freq_cfg)                                               \
+	static struct bt_a2dp_codec_ie bt_a2dp_codec_ie##_name = {                                 \
+		.len = BT_A2DP_SBC_IE_LENGTH,                                                      \
+		.codec_ie = {_freq_cfg | A2DP_SBC_CH_MODE_JOINT,                                   \
+			     A2DP_SBC_BLK_LEN_16 | A2DP_SBC_SUBBAND_8 |                            \
+				     A2DP_SBC_ALLOC_MTHD_LOUDNESS,                                 \
+			     18U, 35U},                                                            \
+	};                                                                                         \
+	struct bt_a2dp_codec_cfg _name = {                                                         \
+		.codec_config = &bt_a2dp_codec_ie##_name,                                          \
+	}
 
 /**
  * @brief A2DP error code
@@ -358,8 +377,8 @@ enum {
  *  for next endpoint. By returning BT_A2DP_DISCOVER_EP_STOP user allows this
  *  discovery continuation.
  */
-typedef uint8_t (*bt_a2dp_discover_ep_cb)(struct bt_a2dp *a2dp,
-		struct bt_a2dp_ep_info *info, struct bt_a2dp_ep **ep);
+typedef uint8_t (*bt_a2dp_discover_ep_cb)(struct bt_a2dp *a2dp, struct bt_a2dp_ep_info *info,
+					  struct bt_a2dp_ep **ep);
 
 struct bt_a2dp_discover_param {
 	/** discover callback */
@@ -411,8 +430,8 @@ struct bt_a2dp_cb {
 	 * @return 0 in case of success or negative value in case of error.
 	 */
 	int (*config_req)(struct bt_a2dp *a2dp, struct bt_a2dp_ep *ep,
-			struct bt_a2dp_codec_cfg *codec_cfg, struct bt_a2dp_stream **stream,
-			uint8_t *rsp_err_code);
+			  struct bt_a2dp_codec_cfg *codec_cfg, struct bt_a2dp_stream **stream,
+			  uint8_t *rsp_err_code);
 	/** @brief Callback function for bt_a2dp_stream_config()
 	 *
 	 *  Called when the codec configure operation is completed.
@@ -665,8 +684,8 @@ struct bt_a2dp_stream_ops {
 	 *  @param seq_num the sequence number
 	 *  @param ts the time stamp
 	 */
-	void (*recv)(struct bt_a2dp_stream *stream,
-		struct net_buf *buf, uint16_t seq_num, uint32_t ts);
+	void (*recv)(struct bt_a2dp_stream *stream, struct net_buf *buf, uint16_t seq_num,
+		     uint32_t ts);
 #endif
 #if defined(CONFIG_BT_A2DP_SOURCE)
 	/**
@@ -711,8 +730,8 @@ void bt_a2dp_stream_cb_register(struct bt_a2dp_stream *stream, struct bt_a2dp_st
  *  @return 0 in case of success and error code in case of error.
  */
 int bt_a2dp_stream_config(struct bt_a2dp *a2dp, struct bt_a2dp_stream *stream,
-		struct bt_a2dp_ep *local_ep, struct bt_a2dp_ep *remote_ep,
-		struct bt_a2dp_codec_cfg *config);
+			  struct bt_a2dp_ep *local_ep, struct bt_a2dp_ep *remote_ep,
+			  struct bt_a2dp_codec_cfg *config);
 
 /** @brief establish a2dp streamer.
  *
@@ -785,8 +804,8 @@ uint32_t bt_a2dp_get_mtu(struct bt_a2dp_stream *stream);
  *
  *  @return 0 in case of success and error code in case of error.
  */
-int bt_a2dp_stream_send(struct bt_a2dp_stream *stream,  struct net_buf *buf,
-			uint16_t seq_num, uint32_t ts);
+int bt_a2dp_stream_send(struct bt_a2dp_stream *stream, struct net_buf *buf, uint16_t seq_num,
+			uint32_t ts);
 #endif
 
 #ifdef __cplusplus

--- a/include/zephyr/bluetooth/classic/a2dp.h
+++ b/include/zephyr/bluetooth/classic/a2dp.h
@@ -545,6 +545,28 @@ struct bt_a2dp_cb {
 	 *                          bt_a2dp_err_code or bt_avdtp_err_code
 	 */
 	void (*suspend_rsp)(struct bt_a2dp_stream *stream, uint8_t rsp_err_code);
+	/**
+	 * @brief Stream abort request callback
+	 *
+	 * The callback is called whenever an stream is requested to be
+	 * aborted.
+	 *
+	 *  @param[in] stream    Pointer to stream object.
+	 *  @param[out] rsp_err_code  give the error code if response error.
+	 *                          bt_a2dp_err_code or bt_avdtp_err_code
+	 *
+	 * @return 0 in case of success or negative value in case of error.
+	 */
+	int (*abort_req)(struct bt_a2dp_stream *stream, uint8_t *rsp_err_code);
+	/** @brief Callback function for bt_a2dp_stream_abort()
+	 *
+	 *  Called when the abort operation is completed.
+	 *
+	 *  @param[in] stream    Pointer to stream object.
+	 *  @param[in] rsp_err_code the remote responded error code
+	 *                          bt_a2dp_err_code or bt_avdtp_err_code
+	 */
+	void (*abort_rsp)(struct bt_a2dp_stream *stream, uint8_t rsp_err_code);
 };
 
 /** @brief A2DP Connect.
@@ -662,6 +684,15 @@ struct bt_a2dp_stream_ops {
 	 * @param stream Stream object that has been suspended.
 	 */
 	void (*suspended)(struct bt_a2dp_stream *stream);
+	/**
+	 * @brief Stream abort callback
+	 *
+	 * The callback is called whenever an Audio Stream has been aborted.
+	 * After aborted, the stream becomes invalid.
+	 *
+	 * @param stream Stream object that has been aborted.
+	 */
+	void (*aborted)(struct bt_a2dp_stream *stream);
 #if defined(CONFIG_BT_A2DP_SINK)
 	/** @brief the media streaming data, only for sink
 	 *
@@ -769,6 +800,17 @@ int bt_a2dp_stream_suspend(struct bt_a2dp_stream *stream);
  *  @return 0 in case of success and error code in case of error.
  */
 int bt_a2dp_stream_reconfig(struct bt_a2dp_stream *stream, struct bt_a2dp_codec_cfg *config);
+
+/** @brief abort a2dp streamer.
+ *
+ * This function sends the AVDTP_ABORT command.
+ * After abort, the stream becomes invalid.
+ *
+ *  @param stream The stream object.
+ *
+ *  @return 0 in case of success and error code in case of error.
+ */
+int bt_a2dp_stream_abort(struct bt_a2dp_stream *stream);
 
 /** @brief get the stream l2cap mtu
  *

--- a/include/zephyr/bluetooth/classic/avdtp.h
+++ b/include/zephyr/bluetooth/classic/avdtp.h
@@ -87,11 +87,11 @@ enum bt_avdtp_media_type {
  */
 struct bt_avdtp_sep_info {
 	/** End Point usage status */
-	uint8_t inuse:1;
+	uint8_t inuse: 1;
 	/** Stream End Point ID that is the identifier of the stream endpoint */
-	uint8_t id:6;
+	uint8_t id: 6;
 	/** Reserved */
-	uint8_t reserved:1;
+	uint8_t reserved: 1;
 	/** Stream End-point Type that indicates if the stream end-point is SNK or SRC */
 	enum bt_avdtp_sep_type tsep;
 	/** Media-type of the End Point
@@ -127,8 +127,7 @@ struct bt_avdtp_sep {
 	/** Media Transport Channel*/
 	struct bt_l2cap_br_chan chan;
 	/** the endpoint media data */
-	void (*media_data_cb)(struct bt_avdtp_sep *sep,
-				struct net_buf *buf);
+	void (*media_data_cb)(struct bt_avdtp_sep *sep, struct net_buf *buf);
 	/** avdtp session */
 	struct bt_avdtp *session;
 	/** SEP state */

--- a/include/zephyr/bluetooth/classic/avdtp.h
+++ b/include/zephyr/bluetooth/classic/avdtp.h
@@ -128,6 +128,8 @@ struct bt_avdtp_sep {
 	struct bt_l2cap_br_chan chan;
 	/** the endpoint media data */
 	void (*media_data_cb)(struct bt_avdtp_sep *sep, struct net_buf *buf);
+	/* semaphore for lock/unlock */
+	struct k_sem sem_lock;
 	/** avdtp session */
 	struct bt_avdtp *session;
 	/** SEP state */

--- a/subsys/bluetooth/host/classic/a2dp.c
+++ b/subsys/bluetooth/host/classic/a2dp.c
@@ -29,17 +29,17 @@
 
 #define A2DP_AVDTP(_avdtp) CONTAINER_OF(_avdtp, struct bt_a2dp, session)
 #define DISCOVER_REQ(_req) CONTAINER_OF(_req, struct bt_avdtp_discover_params, req)
-#define DISCOVER_PARAM(_discover_param) CONTAINER_OF(_discover_param, struct bt_a2dp,\
-						discover_param)
+#define DISCOVER_PARAM(_discover_param)                                                            \
+	CONTAINER_OF(_discover_param, struct bt_a2dp, discover_param)
 #define GET_CAP_REQ(_req) CONTAINER_OF(_req, struct bt_avdtp_get_capabilities_params, req)
-#define GET_CAP_PARAM(_get_cap_param) CONTAINER_OF(_get_cap_param, struct bt_a2dp,\
-						get_capabilities_param)
+#define GET_CAP_PARAM(_get_cap_param)                                                              \
+	CONTAINER_OF(_get_cap_param, struct bt_a2dp, get_capabilities_param)
 #define SET_CONF_REQ(_req) CONTAINER_OF(_req, struct bt_avdtp_set_configuration_params, req)
-#define SET_CONF_PARAM(_set_conf_param) CONTAINER_OF(_set_conf_param, struct bt_a2dp,\
-						set_config_param)
-#define OPEN_REQ(_req) CONTAINER_OF(_req, struct bt_avdtp_open_params, req)
-#define OPEN_PARAM(_open_param) CONTAINER_OF(_open_param, struct bt_a2dp, open_param)
-#define START_REQ(_req) CONTAINER_OF(_req, struct bt_avdtp_start_params, req)
+#define SET_CONF_PARAM(_set_conf_param)                                                            \
+	CONTAINER_OF(_set_conf_param, struct bt_a2dp, set_config_param)
+#define OPEN_REQ(_req)            CONTAINER_OF(_req, struct bt_avdtp_open_params, req)
+#define OPEN_PARAM(_open_param)   CONTAINER_OF(_open_param, struct bt_a2dp, open_param)
+#define START_REQ(_req)           CONTAINER_OF(_req, struct bt_avdtp_start_params, req)
 #define START_PARAM(_start_param) CONTAINER_OF(_start_param, struct bt_a2dp, start_param)
 
 #include "host/hci_core.h"
@@ -75,7 +75,7 @@ struct bt_a2dp {
 static struct bt_a2dp_cb *a2dp_cb;
 K_MUTEX_DEFINE(a2dp_mutex);
 
-#define A2DP_LOCK() k_mutex_lock(&a2dp_mutex, K_FOREVER)
+#define A2DP_LOCK()   k_mutex_lock(&a2dp_mutex, K_FOREVER)
 #define A2DP_UNLOCK() k_mutex_unlock(&a2dp_mutex)
 
 /* Connections */
@@ -106,8 +106,7 @@ static struct bt_a2dp *get_new_connection(struct bt_conn *conn)
 			return &connection[i];
 		}
 
-		if (!connection[i].session.br_chan.chan.conn &&
-			free == A2DP_NO_SPACE) {
+		if (!connection[i].session.br_chan.chan.conn && free == A2DP_NO_SPACE) {
 			free = i;
 			break;
 		}
@@ -160,7 +159,7 @@ static int a2dp_discovery_ind(struct bt_avdtp *session, uint8_t *errcode)
 }
 
 static int a2dp_get_capabilities_ind(struct bt_avdtp *session, struct bt_avdtp_sep *sep,
-		struct net_buf *rsp_buf, uint8_t *errcode)
+				     struct net_buf *rsp_buf, uint8_t *errcode)
 {
 	struct bt_a2dp_ep *ep;
 
@@ -182,8 +181,8 @@ static int a2dp_get_capabilities_ind(struct bt_avdtp *session, struct bt_avdtp_s
 	return 0;
 }
 
-static int a2dp_set_config_ind(struct bt_avdtp *session, struct bt_avdtp_sep *sep,
-		uint8_t int_seid, struct net_buf *buf, uint8_t *errcode)
+static int a2dp_set_config_ind(struct bt_avdtp *session, struct bt_avdtp_sep *sep, uint8_t int_seid,
+			       struct net_buf *buf, uint8_t *errcode)
 {
 	struct bt_a2dp *a2dp = A2DP_AVDTP(session);
 	struct bt_a2dp_ep *ep;
@@ -202,9 +201,8 @@ static int a2dp_set_config_ind(struct bt_avdtp *session, struct bt_avdtp_sep *se
 
 	/* parse the configuration */
 	codec_info_element_len = 4U;
-	err = bt_avdtp_parse_capability_codec(buf,
-				&codec_type, &codec_info_element,
-				&codec_info_element_len);
+	err = bt_avdtp_parse_capability_codec(buf, &codec_type, &codec_info_element,
+					      &codec_info_element_len);
 	if (err) {
 		*errcode = BT_AVDTP_BAD_ACP_SEID;
 		return -1;
@@ -222,10 +220,10 @@ static int a2dp_set_config_ind(struct bt_avdtp *session, struct bt_avdtp_sep *se
 		sbc_set = (struct bt_a2dp_codec_sbc_params *)codec_info_element;
 		sbc = (struct bt_a2dp_codec_sbc_params *)&ep->codec_cap->codec_ie[0];
 		if (((BT_A2DP_SBC_SAMP_FREQ(sbc_set) & BT_A2DP_SBC_SAMP_FREQ(sbc)) == 0) ||
-			((BT_A2DP_SBC_CHAN_MODE(sbc_set) & BT_A2DP_SBC_CHAN_MODE(sbc)) == 0) ||
-			((BT_A2DP_SBC_BLK_LEN(sbc_set) & BT_A2DP_SBC_BLK_LEN(sbc)) == 0) ||
-			((BT_A2DP_SBC_SUB_BAND(sbc_set) & BT_A2DP_SBC_SUB_BAND(sbc)) == 0) ||
-			((BT_A2DP_SBC_ALLOC_MTHD(sbc_set) & BT_A2DP_SBC_ALLOC_MTHD(sbc)) == 0)) {
+		    ((BT_A2DP_SBC_CHAN_MODE(sbc_set) & BT_A2DP_SBC_CHAN_MODE(sbc)) == 0) ||
+		    ((BT_A2DP_SBC_BLK_LEN(sbc_set) & BT_A2DP_SBC_BLK_LEN(sbc)) == 0) ||
+		    ((BT_A2DP_SBC_SUB_BAND(sbc_set) & BT_A2DP_SBC_SUB_BAND(sbc)) == 0) ||
+		    ((BT_A2DP_SBC_ALLOC_MTHD(sbc_set) & BT_A2DP_SBC_ALLOC_MTHD(sbc)) == 0)) {
 			*errcode = BT_AVDTP_BAD_ACP_SEID;
 			return -1;
 		}
@@ -239,8 +237,8 @@ static int a2dp_set_config_ind(struct bt_avdtp *session, struct bt_avdtp_sep *se
 		cfg.codec_config = &codec_config;
 		cfg.codec_config->len = codec_info_element_len;
 		memcpy(&cfg.codec_config->codec_ie[0], codec_info_element,
-			(codec_info_element_len > A2DP_MAX_IE_LENGTH ?
-			A2DP_MAX_IE_LENGTH : codec_info_element_len));
+		       (codec_info_element_len > A2DP_MAX_IE_LENGTH ? A2DP_MAX_IE_LENGTH
+								    : codec_info_element_len));
 		err = a2dp_cb->config_req(a2dp, ep, &cfg, &stream, &rsp_err_code);
 		if (err) {
 			*errcode = rsp_err_code;
@@ -263,9 +261,7 @@ static int a2dp_set_config_ind(struct bt_avdtp *session, struct bt_avdtp_sep *se
 }
 
 #if defined(CONFIG_BT_A2DP_SINK)
-static void bt_a2dp_media_data_callback(
-		struct bt_avdtp_sep *sep,
-		struct net_buf *buf)
+static void bt_a2dp_media_data_callback(struct bt_avdtp_sep *sep, struct net_buf *buf)
 {
 	struct bt_avdtp_media_hdr *media_hdr;
 	struct bt_a2dp_ep *ep;
@@ -279,9 +275,8 @@ static void bt_a2dp_media_data_callback(
 
 	media_hdr = net_buf_pull_mem(buf, sizeof(*media_hdr));
 
-	stream->ops->recv(stream, buf,
-		sys_get_be16((uint8_t *)&media_hdr->sequence_number),
-		sys_get_be32((uint8_t *)&media_hdr->time_stamp));
+	stream->ops->recv(stream, buf, sys_get_be16((uint8_t *)&media_hdr->sequence_number),
+			  sys_get_be32((uint8_t *)&media_hdr->time_stamp));
 }
 #endif
 
@@ -484,16 +479,15 @@ static int bt_a2dp_get_capabilities_cb(struct bt_avdtp_req *req)
 
 	LOG_DBG("GET CAPABILITIES result:%d", a2dp->get_capabilities_param.status);
 	if (a2dp->get_capabilities_param.status) {
-		if ((a2dp->discover_cb_param != NULL) &&
-		(a2dp->discover_cb_param->cb != NULL)) {
+		if ((a2dp->discover_cb_param != NULL) && (a2dp->discover_cb_param->cb != NULL)) {
 			a2dp->discover_cb_param->cb(a2dp, NULL, NULL);
 			a2dp->discover_cb_param = NULL;
 		}
 		return 0;
 	}
 
-	err = bt_avdtp_parse_capability_codec(a2dp->get_capabilities_param.buf,
-			&codec_type, &codec_info_element, &codec_info_element_len);
+	err = bt_avdtp_parse_capability_codec(a2dp->get_capabilities_param.buf, &codec_type,
+					      &codec_info_element, &codec_info_element_len);
 	if (err) {
 		LOG_DBG("codec capability parsing fail");
 		return 0;
@@ -509,8 +503,7 @@ static int bt_a2dp_get_capabilities_cb(struct bt_avdtp_req *req)
 
 		info->codec_type = codec_type;
 		info->sep_info = a2dp->discover_cb_param->seps_info[a2dp->get_cap_index];
-		memcpy(&info->codec_cap.codec_ie,
-			codec_info_element, codec_info_element_len);
+		memcpy(&info->codec_cap.codec_ie, codec_info_element, codec_info_element_len);
 		info->codec_cap.len = codec_info_element_len;
 		user_ret = a2dp->discover_cb_param->cb(a2dp, info, &ep);
 		if (ep != NULL) {
@@ -547,16 +540,15 @@ static int bt_a2dp_get_sep_caps(struct bt_a2dp *a2dp)
 		a2dp->get_cap_index++;
 	}
 
-	for (; a2dp->get_cap_index < a2dp->peer_seps_count;
-			a2dp->get_cap_index++) {
+	for (; a2dp->get_cap_index < a2dp->peer_seps_count; a2dp->get_cap_index++) {
 		if (a2dp->discover_cb_param->seps_info[a2dp->get_cap_index].media_type ==
-			BT_AVDTP_AUDIO) {
+		    BT_AVDTP_AUDIO) {
 			a2dp->get_capabilities_param.req.func = bt_a2dp_get_capabilities_cb;
 			a2dp->get_capabilities_param.buf = NULL;
 			a2dp->get_capabilities_param.stream_endpoint_id =
 				a2dp->discover_cb_param->seps_info[a2dp->get_cap_index].id;
 			err = bt_avdtp_get_capabilities(&a2dp->session,
-				&a2dp->get_capabilities_param);
+							&a2dp->get_capabilities_param);
 			if (err) {
 				LOG_DBG("AVDTP get codec_cap failed");
 				a2dp->discover_cb_param->cb(a2dp, NULL, NULL);
@@ -595,11 +587,8 @@ static int bt_a2dp_discover_cb(struct bt_avdtp_req *req)
 				break;
 			}
 			a2dp->peer_seps_count++;
-			LOG_DBG("id:%d, inuse:%d, media_type:%d, tsep:%d, ",
-				sep_info->id,
-				sep_info->inuse,
-				sep_info->media_type,
-				sep_info->tsep);
+			LOG_DBG("id:%d, inuse:%d, media_type:%d, tsep:%d, ", sep_info->id,
+				sep_info->inuse, sep_info->media_type, sep_info->tsep);
 		} while (a2dp->peer_seps_count < a2dp->discover_cb_param->sep_count);
 
 		/* trigger the getting capability */
@@ -684,11 +673,11 @@ void bt_a2dp_stream_cb_register(struct bt_a2dp_stream *stream, struct bt_a2dp_st
 }
 
 int bt_a2dp_stream_config(struct bt_a2dp *a2dp, struct bt_a2dp_stream *stream,
-		struct bt_a2dp_ep *local_ep, struct bt_a2dp_ep *remote_ep,
-		struct bt_a2dp_codec_cfg *config)
+			  struct bt_a2dp_ep *local_ep, struct bt_a2dp_ep *remote_ep,
+			  struct bt_a2dp_codec_cfg *config)
 {
-	if ((a2dp == NULL) || (stream == NULL) || (local_ep == NULL) ||
-		(remote_ep == NULL) || (config == NULL)) {
+	if ((a2dp == NULL) || (stream == NULL) || (local_ep == NULL) || (remote_ep == NULL) ||
+	    (config == NULL)) {
 		return -EINVAL;
 	}
 
@@ -724,8 +713,9 @@ int bt_a2dp_stream_establish(struct bt_a2dp_stream *stream)
 
 	a2dp = stream->a2dp;
 	a2dp->open_param.req.func = bt_a2dp_open_cb;
-	a2dp->open_param.acp_stream_ep_id = stream->remote_ep != NULL ?
-		stream->remote_ep->sep.sep_info.id : stream->remote_ep_id;
+	a2dp->open_param.acp_stream_ep_id = stream->remote_ep != NULL
+						    ? stream->remote_ep->sep.sep_info.id
+						    : stream->remote_ep_id;
 	a2dp->open_param.sep = &stream->local_ep->sep;
 	return bt_avdtp_open(&a2dp->session, &a2dp->open_param);
 }
@@ -746,8 +736,9 @@ int bt_a2dp_stream_start(struct bt_a2dp_stream *stream)
 
 	a2dp = stream->a2dp;
 	a2dp->start_param.req.func = bt_a2dp_start_cb;
-	a2dp->start_param.acp_stream_ep_id = stream->remote_ep != NULL ?
-		stream->remote_ep->sep.sep_info.id : stream->remote_ep_id;
+	a2dp->start_param.acp_stream_ep_id = stream->remote_ep != NULL
+						     ? stream->remote_ep->sep.sep_info.id
+						     : stream->remote_ep_id;
 	a2dp->start_param.sep = &stream->local_ep->sep;
 	return bt_avdtp_start(&a2dp->session, &a2dp->start_param);
 }
@@ -774,8 +765,8 @@ uint32_t bt_a2dp_get_mtu(struct bt_a2dp_stream *stream)
 }
 
 #if defined(CONFIG_BT_A2DP_SOURCE)
-int bt_a2dp_stream_send(struct bt_a2dp_stream *stream,  struct net_buf *buf,
-			uint16_t seq_num, uint32_t ts)
+int bt_a2dp_stream_send(struct bt_a2dp_stream *stream, struct net_buf *buf, uint16_t seq_num,
+			uint32_t ts)
 {
 	struct bt_avdtp_media_hdr *media_hdr;
 

--- a/subsys/bluetooth/host/classic/a2dp.c
+++ b/subsys/bluetooth/host/classic/a2dp.c
@@ -25,7 +25,7 @@
 
 #include "common/assert.h"
 
-#define A2DP_SBC_PAYLOAD_TYPE (0x60u)
+#define A2DP_SBC_PAYLOAD_TYPE (0x60U)
 
 #define A2DP_AVDTP(_avdtp) CONTAINER_OF(_avdtp, struct bt_a2dp, session)
 #define DISCOVER_REQ(_req) CONTAINER_OF(_req, struct bt_avdtp_discover_params, req)
@@ -37,10 +37,8 @@
 #define SET_CONF_REQ(_req) CONTAINER_OF(_req, struct bt_avdtp_set_configuration_params, req)
 #define SET_CONF_PARAM(_set_conf_param)                                                            \
 	CONTAINER_OF(_set_conf_param, struct bt_a2dp, set_config_param)
-#define OPEN_REQ(_req)            CONTAINER_OF(_req, struct bt_avdtp_open_params, req)
-#define OPEN_PARAM(_open_param)   CONTAINER_OF(_open_param, struct bt_a2dp, open_param)
-#define START_REQ(_req)           CONTAINER_OF(_req, struct bt_avdtp_start_params, req)
-#define START_PARAM(_start_param) CONTAINER_OF(_start_param, struct bt_a2dp, start_param)
+#define CTRL_REQ(_req)          CONTAINER_OF(_req, struct bt_avdtp_ctrl_params, req)
+#define CTRL_PARAM(_ctrl_param) CONTAINER_OF(_ctrl_param, struct bt_a2dp, ctrl_param)
 
 #include "host/hci_core.h"
 #include "host/conn_internal.h"
@@ -65,62 +63,27 @@ struct bt_a2dp {
 	struct bt_a2dp_discover_param *discover_cb_param;
 	struct bt_avdtp_get_capabilities_params get_capabilities_param;
 	struct bt_avdtp_set_configuration_params set_config_param;
-	struct bt_avdtp_open_params open_param;
-	struct bt_avdtp_start_params start_param;
+	struct bt_avdtp_ctrl_params ctrl_param;
 	uint8_t get_cap_index;
 	enum bt_a2dp_internal_state a2dp_state;
 	uint8_t peer_seps_count;
 };
 
 static struct bt_a2dp_cb *a2dp_cb;
-K_MUTEX_DEFINE(a2dp_mutex);
-
-#define A2DP_LOCK()   k_mutex_lock(&a2dp_mutex, K_FOREVER)
-#define A2DP_UNLOCK() k_mutex_unlock(&a2dp_mutex)
-
 /* Connections */
 static struct bt_a2dp connection[CONFIG_BT_MAX_CONN];
 
 static int bt_a2dp_get_sep_caps(struct bt_a2dp *a2dp);
 
-static void a2dp_reset(struct bt_a2dp *a2dp)
+static struct bt_a2dp *a2dp_get_connection(struct bt_conn *conn)
 {
-	(void)memset(a2dp, 0, sizeof(struct bt_a2dp));
-}
+	struct bt_a2dp *a2dp = &connection[bt_conn_index(conn)];
 
-static struct bt_a2dp *get_new_connection(struct bt_conn *conn)
-{
-	int8_t i, free;
-
-	free = A2DP_NO_SPACE;
-
-	if (!conn) {
-		LOG_ERR("Invalid Input (err: %d)", -EINVAL);
-		return NULL;
+	if (a2dp->session.br_chan.chan.conn == NULL) {
+		/* Clean the memory area before returning */
+		(void)memset(a2dp, 0, sizeof(struct bt_a2dp));
 	}
-
-	/* Find a space */
-	for (i = 0; i < CONFIG_BT_MAX_CONN; i++) {
-		if (connection[i].session.br_chan.chan.conn == conn) {
-			LOG_DBG("Conn already exists");
-			return &connection[i];
-		}
-
-		if (!connection[i].session.br_chan.chan.conn && free == A2DP_NO_SPACE) {
-			free = i;
-			break;
-		}
-	}
-
-	if (free == A2DP_NO_SPACE) {
-		LOG_DBG("More connection cannot be supported");
-		return NULL;
-	}
-
-	/* Clean the memory area before returning */
-	a2dp_reset(&connection[free]);
-
-	return &connection[free];
+	return a2dp;
 }
 
 /* The AVDTP L2CAP signal channel established */
@@ -163,6 +126,7 @@ static int a2dp_get_capabilities_ind(struct bt_avdtp *session, struct bt_avdtp_s
 {
 	struct bt_a2dp_ep *ep;
 
+	__ASSERT(sep, "Invalid sep");
 	*errcode = 0;
 	/* Service Category: Media Transport */
 	net_buf_add_u8(rsp_buf, BT_AVDTP_SERVICE_MEDIA_TRANSPORT);
@@ -171,9 +135,9 @@ static int a2dp_get_capabilities_ind(struct bt_avdtp *session, struct bt_avdtp_s
 	net_buf_add_u8(rsp_buf, BT_AVDTP_SERVICE_MEDIA_CODEC);
 	ep = CONTAINER_OF(sep, struct bt_a2dp_ep, sep);
 	/* Length Of Service Capability */
-	net_buf_add_u8(rsp_buf, ep->codec_cap->len + 2u);
+	net_buf_add_u8(rsp_buf, ep->codec_cap->len + 2U);
 	/* Media Type */
-	net_buf_add_u8(rsp_buf, sep->sep_info.media_type << 4u);
+	net_buf_add_u8(rsp_buf, sep->sep_info.media_type << 4U);
 	/* Media Codec Type */
 	net_buf_add_u8(rsp_buf, ep->codec_type);
 	/* Codec Info Element */
@@ -181,16 +145,20 @@ static int a2dp_get_capabilities_ind(struct bt_avdtp *session, struct bt_avdtp_s
 	return 0;
 }
 
-static int a2dp_set_config_ind(struct bt_avdtp *session, struct bt_avdtp_sep *sep, uint8_t int_seid,
-			       struct net_buf *buf, uint8_t *errcode)
+static int a2dp_process_config_ind(struct bt_avdtp *session, struct bt_avdtp_sep *sep,
+				   uint8_t int_seid, struct net_buf *buf, uint8_t *errcode,
+				   bool reconfig)
 {
 	struct bt_a2dp *a2dp = A2DP_AVDTP(session);
 	struct bt_a2dp_ep *ep;
-	struct bt_a2dp_stream *stream;
+	struct bt_a2dp_stream *stream = NULL;
 	struct bt_a2dp_stream_ops *ops;
 	uint8_t codec_type;
 	uint8_t *codec_info_element;
 	uint16_t codec_info_element_len;
+	struct bt_a2dp_codec_cfg cfg;
+	struct bt_a2dp_codec_ie codec_config;
+	uint8_t rsp_err_code;
 	int err;
 
 	*errcode = 0;
@@ -205,7 +173,7 @@ static int a2dp_set_config_ind(struct bt_avdtp *session, struct bt_avdtp_sep *se
 					      &codec_info_element_len);
 	if (err) {
 		*errcode = BT_AVDTP_BAD_ACP_SEID;
-		return -1;
+		return -EINVAL;
 	}
 
 	if (codec_type == BT_A2DP_SBC) {
@@ -214,7 +182,7 @@ static int a2dp_set_config_ind(struct bt_avdtp *session, struct bt_avdtp_sep *se
 
 		if (codec_info_element_len != 4U) {
 			*errcode = BT_AVDTP_BAD_ACP_SEID;
-			return -1;
+			return -EINVAL;
 		}
 
 		sbc_set = (struct bt_a2dp_codec_sbc_params *)codec_info_element;
@@ -225,39 +193,75 @@ static int a2dp_set_config_ind(struct bt_avdtp *session, struct bt_avdtp_sep *se
 		    ((BT_A2DP_SBC_SUB_BAND(sbc_set) & BT_A2DP_SBC_SUB_BAND(sbc)) == 0) ||
 		    ((BT_A2DP_SBC_ALLOC_MTHD(sbc_set) & BT_A2DP_SBC_ALLOC_MTHD(sbc)) == 0)) {
 			*errcode = BT_AVDTP_BAD_ACP_SEID;
-			return -1;
+			return -EINVAL;
 		}
 	}
 
-	if ((a2dp_cb != NULL) && (a2dp_cb->config_req != NULL)) {
-		struct bt_a2dp_codec_cfg cfg;
-		struct bt_a2dp_codec_ie codec_config;
-		uint8_t rsp_err_code;
+	/* For reconfig, ep->stream must already be valid, callback can be NULL as default accept.
+	 * For !reconfig, config_req must be set to get stream from upper layer
+	 */
+	if (reconfig) {
+		stream = ep->stream;
+		if (stream == NULL) {
+			*errcode = BT_AVDTP_BAD_ACP_SEID;
+			return -EINVAL;
+		}
 
-		cfg.codec_config = &codec_config;
-		cfg.codec_config->len = codec_info_element_len;
-		memcpy(&cfg.codec_config->codec_ie[0], codec_info_element,
-		       (codec_info_element_len > A2DP_MAX_IE_LENGTH ? A2DP_MAX_IE_LENGTH
-								    : codec_info_element_len));
+		if (a2dp_cb == NULL || a2dp_cb->reconfig_req == NULL) {
+			goto process_done;
+		}
+	} else if (a2dp_cb == NULL || a2dp_cb->config_req == NULL) {
+		*errcode = BT_AVDTP_BAD_ACP_SEID;
+		return -EINVAL;
+	}
+
+	cfg.codec_config = &codec_config;
+	cfg.codec_config->len = codec_info_element_len;
+	memcpy(&cfg.codec_config->codec_ie[0], codec_info_element,
+	       (codec_info_element_len > BT_A2DP_MAX_IE_LENGTH ? BT_A2DP_MAX_IE_LENGTH
+							       : codec_info_element_len));
+	if (!reconfig) {
 		err = a2dp_cb->config_req(a2dp, ep, &cfg, &stream, &rsp_err_code);
-		if (err) {
-			*errcode = rsp_err_code;
-		} else if (stream != NULL) {
+		if (!err && stream) {
 			stream->a2dp = a2dp;
 			stream->local_ep = ep;
 			stream->remote_ep_id = int_seid;
 			stream->remote_ep = NULL;
 			stream->codec_config = *cfg.codec_config;
 			ep->stream = stream;
-
-			ops = stream->ops;
-			if ((ops != NULL) && (ops->configured != NULL)) {
-				ops->configured(stream);
-			}
+		} else {
+			*errcode = rsp_err_code != 0 ? rsp_err_code : BT_AVDTP_BAD_ACP_SEID;
+		}
+	} else {
+		err = a2dp_cb->reconfig_req(stream, &cfg, &rsp_err_code);
+		if (err) {
+			*errcode = rsp_err_code;
 		}
 	}
 
-	return (*errcode == 0) ? 0 : -1;
+process_done:
+	if (*errcode == 0) {
+		ops = stream->ops;
+		if ((ops != NULL) && (ops->configured != NULL)) {
+			ops->configured(stream);
+		}
+	}
+
+	return (*errcode == 0) ? 0 : -EINVAL;
+}
+
+static int a2dp_set_config_ind(struct bt_avdtp *session, struct bt_avdtp_sep *sep, uint8_t int_seid,
+			       struct net_buf *buf, uint8_t *errcode)
+{
+	__ASSERT(sep, "Invalid sep");
+	return a2dp_process_config_ind(session, sep, int_seid, buf, errcode, false);
+}
+
+static int a2dp_re_config_ind(struct bt_avdtp *session, struct bt_avdtp_sep *sep, uint8_t int_seid,
+			      struct net_buf *buf, uint8_t *errcode)
+{
+	__ASSERT(sep, "Invalid sep");
+	return a2dp_process_config_ind(session, sep, int_seid, buf, errcode, true);
 }
 
 #if defined(CONFIG_BT_A2DP_SINK)
@@ -267,8 +271,9 @@ static void bt_a2dp_media_data_callback(struct bt_avdtp_sep *sep, struct net_buf
 	struct bt_a2dp_ep *ep;
 	struct bt_a2dp_stream *stream;
 
+	__ASSERT(sep, "Invalid sep");
 	ep = CONTAINER_OF(sep, struct bt_a2dp_ep, sep);
-	if ((ep == NULL) || (ep->stream == NULL)) {
+	if (ep->stream == NULL || buf->len < sizeof(*media_hdr)) {
 		return;
 	}
 	stream = ep->stream;
@@ -280,166 +285,70 @@ static void bt_a2dp_media_data_callback(struct bt_avdtp_sep *sep, struct net_buf
 }
 #endif
 
-static int a2dp_open_ind(struct bt_avdtp *session, struct bt_avdtp_sep *sep, uint8_t *errcode)
+typedef int (*bt_a2dp_ctrl_req_cb)(struct bt_a2dp_stream *stream, uint8_t *rsp_err_code);
+typedef void (*bt_a2dp_ctrl_done_cb)(struct bt_a2dp_stream *stream);
+
+static int a2dp_ctrl_ind(struct bt_avdtp *session, struct bt_avdtp_sep *sep, uint8_t *errcode,
+			 bt_a2dp_ctrl_req_cb req_cb, bt_a2dp_ctrl_done_cb done_cb,
+			 bool clear_stream)
 {
 	struct bt_a2dp_ep *ep;
 	struct bt_a2dp_stream *stream;
-	struct bt_a2dp_stream_ops *ops;
 
 	*errcode = 0;
 	ep = CONTAINER_OF(sep, struct bt_a2dp_ep, sep);
 	if (ep->stream == NULL) {
 		*errcode = BT_AVDTP_BAD_ACP_SEID;
-		return -1;
+		return -EINVAL;
 	}
 	stream = ep->stream;
 
-	if ((a2dp_cb != NULL) && (a2dp_cb->establish_req != NULL)) {
+	if (req_cb != NULL) {
 		uint8_t rsp_err_code;
 		int err;
 
-		err = a2dp_cb->establish_req(stream, &rsp_err_code);
+		err = req_cb(stream, &rsp_err_code);
 		if (err) {
 			*errcode = rsp_err_code;
 		}
 	}
 
-	ops = stream->ops;
 	if (*errcode == 0) {
-		if ((ops != NULL) && (stream->ops->established != NULL)) {
-			stream->ops->established(stream);
+		if (clear_stream) {
+			ep->stream = NULL;
+		}
+
+		if (done_cb != NULL) {
+			done_cb(stream);
 		}
 	}
 
-	return (*errcode == 0) ? 0 : -1;
+	return (*errcode == 0) ? 0 : -EINVAL;
+}
+
+static int a2dp_open_ind(struct bt_avdtp *session, struct bt_avdtp_sep *sep, uint8_t *errcode)
+{
+	struct bt_a2dp_ep *ep = CONTAINER_OF(sep, struct bt_a2dp_ep, sep);
+	bt_a2dp_ctrl_req_cb req_cb;
+	bt_a2dp_ctrl_done_cb done_cb;
+
+	__ASSERT(sep, "Invalid sep");
+	req_cb = a2dp_cb != NULL ? a2dp_cb->establish_req : NULL;
+	done_cb = (ep->stream != NULL && ep->stream->ops != NULL) ? ep->stream->ops->established
+								  : NULL;
+	return a2dp_ctrl_ind(session, sep, errcode, req_cb, done_cb, false);
 }
 
 static int a2dp_start_ind(struct bt_avdtp *session, struct bt_avdtp_sep *sep, uint8_t *errcode)
 {
-	struct bt_a2dp_ep *ep;
-	struct bt_a2dp_stream *stream;
-	struct bt_a2dp_stream_ops *ops;
+	struct bt_a2dp_ep *ep = CONTAINER_OF(sep, struct bt_a2dp_ep, sep);
+	bt_a2dp_ctrl_req_cb req_cb;
+	bt_a2dp_ctrl_done_cb done_cb;
 
-	*errcode = 0;
-	ep = CONTAINER_OF(sep, struct bt_a2dp_ep, sep);
-	if (ep->stream == NULL) {
-		*errcode = BT_AVDTP_BAD_ACP_SEID;
-		return -1;
-	}
-	stream = ep->stream;
-
-	if ((a2dp_cb != NULL) && (a2dp_cb->start_req != NULL)) {
-		uint8_t rsp_err_code;
-		int err;
-
-		err = a2dp_cb->start_req(stream, &rsp_err_code);
-		if (err) {
-			*errcode = rsp_err_code;
-		}
-	}
-
-	ops = stream->ops;
-	if (*errcode == 0) {
-		if ((ops != NULL) && (stream->ops->started != NULL)) {
-			stream->ops->started(stream);
-		}
-	}
-
-	return (*errcode == 0) ? 0 : -1;
-}
-
-static int a2dp_close_ind(struct bt_avdtp *session, struct bt_avdtp_sep *sep, uint8_t *errcode)
-{
-	struct bt_a2dp_ep *ep;
-	struct bt_a2dp_stream *stream;
-	struct bt_a2dp_stream_ops *ops;
-
-	*errcode = 0;
-	ep = CONTAINER_OF(sep, struct bt_a2dp_ep, sep);
-	if (ep->stream == NULL) {
-		*errcode = BT_AVDTP_BAD_ACP_SEID;
-		return -1;
-	}
-	stream = ep->stream;
-
-	if ((a2dp_cb != NULL) && (a2dp_cb->release_req != NULL)) {
-		uint8_t rsp_err_code;
-		int err;
-
-		err = a2dp_cb->release_req(stream, &rsp_err_code);
-		if (err) {
-			*errcode = rsp_err_code;
-		}
-	}
-
-	ops = stream->ops;
-	if (*errcode == 0) {
-		if ((ops != NULL) && (stream->ops->released != NULL)) {
-			stream->ops->released(stream);
-		}
-	}
-
-	return (*errcode == 0) ? 0 : -1;
-}
-
-static int a2dp_suspend_ind(struct bt_avdtp *session, struct bt_avdtp_sep *sep, uint8_t *errcode)
-{
-	struct bt_a2dp_ep *ep;
-	struct bt_a2dp_stream *stream;
-	struct bt_a2dp_stream_ops *ops;
-
-	*errcode = 0;
-	ep = CONTAINER_OF(sep, struct bt_a2dp_ep, sep);
-	if (ep->stream == NULL) {
-		*errcode = BT_AVDTP_BAD_ACP_SEID;
-		return -1;
-	}
-	stream = ep->stream;
-
-	if ((a2dp_cb != NULL) && (a2dp_cb->suspend_req != NULL)) {
-		uint8_t rsp_err_code;
-		int err;
-
-		err = a2dp_cb->suspend_req(stream, &rsp_err_code);
-		if (err) {
-			*errcode = rsp_err_code;
-		}
-	}
-
-	ops = stream->ops;
-	if (*errcode == 0) {
-		if ((ops != NULL) && (stream->ops->suspended != NULL)) {
-			stream->ops->suspended(stream);
-		}
-	}
-
-	return (*errcode == 0) ? 0 : -1;
-}
-
-static int bt_a2dp_open_cb(struct bt_avdtp_req *req)
-{
-	struct bt_a2dp *a2dp = OPEN_PARAM(OPEN_REQ(req));
-	struct bt_a2dp_ep *ep;
-	struct bt_a2dp_stream *stream;
-	struct bt_a2dp_stream_ops *ops;
-
-	ep = CONTAINER_OF(a2dp->open_param.sep, struct bt_a2dp_ep, sep);
-	if (ep->stream == NULL) {
-		return -1;
-	}
-	stream = ep->stream;
-
-	LOG_DBG("OPEN result:%d", a2dp->open_param.status);
-
-	if ((a2dp_cb != NULL) && (a2dp_cb->establish_rsp != NULL)) {
-		a2dp_cb->establish_rsp(stream, a2dp->open_param.status);
-	}
-
-	ops = stream->ops;
-	if ((!a2dp->open_param.status) && (ops->established != NULL)) {
-		ops->established(stream);
-	}
-	return 0;
+	__ASSERT(sep, "Invalid sep");
+	req_cb = a2dp_cb != NULL ? a2dp_cb->start_req : NULL;
+	done_cb = (ep->stream != NULL && ep->stream->ops != NULL) ? ep->stream->ops->started : NULL;
+	return a2dp_ctrl_ind(session, sep, errcode, req_cb, done_cb, false);
 }
 
 static int bt_a2dp_set_config_cb(struct bt_avdtp_req *req)
@@ -451,18 +360,21 @@ static int bt_a2dp_set_config_cb(struct bt_avdtp_req *req)
 
 	ep = CONTAINER_OF(a2dp->set_config_param.sep, struct bt_a2dp_ep, sep);
 	if (ep->stream == NULL) {
-		return -1;
+		return -EINVAL;
+	}
+	if ((ep->stream == NULL) || (SET_CONF_REQ(req) != &a2dp->set_config_param)) {
+		return -EINVAL;
 	}
 	stream = ep->stream;
 
-	LOG_DBG("SET CONFIGURATION result:%d", a2dp->set_config_param.status);
+	LOG_DBG("SET CONFIGURATION result:%d", req->status);
 
 	if ((a2dp_cb != NULL) && (a2dp_cb->config_rsp != NULL)) {
-		a2dp_cb->config_rsp(stream, a2dp->set_config_param.status);
+		a2dp_cb->config_rsp(stream, req->status);
 	}
 
 	ops = stream->ops;
-	if ((!a2dp->set_config_param.status) && (ops->configured != NULL)) {
+	if ((!req->status) && (ops->configured != NULL)) {
 		ops->configured(stream);
 	}
 	return 0;
@@ -477,8 +389,12 @@ static int bt_a2dp_get_capabilities_cb(struct bt_avdtp_req *req)
 	uint8_t codec_type;
 	uint8_t user_ret;
 
-	LOG_DBG("GET CAPABILITIES result:%d", a2dp->get_capabilities_param.status);
-	if (a2dp->get_capabilities_param.status) {
+	if (GET_CAP_REQ(req) != &a2dp->get_capabilities_param) {
+		return -EINVAL;
+	}
+
+	LOG_DBG("GET CAPABILITIES result:%d", req->status);
+	if (req->status) {
 		if ((a2dp->discover_cb_param != NULL) && (a2dp->discover_cb_param->cb != NULL)) {
 			a2dp->discover_cb_param->cb(a2dp, NULL, NULL);
 			a2dp->discover_cb_param = NULL;
@@ -493,12 +409,12 @@ static int bt_a2dp_get_capabilities_cb(struct bt_avdtp_req *req)
 		return 0;
 	}
 
-	if (codec_info_element_len > A2DP_MAX_IE_LENGTH) {
-		codec_info_element_len = A2DP_MAX_IE_LENGTH;
+	if (codec_info_element_len > BT_A2DP_MAX_IE_LENGTH) {
+		codec_info_element_len = BT_A2DP_MAX_IE_LENGTH;
 	}
 
 	if ((a2dp->discover_cb_param != NULL) && (a2dp->discover_cb_param->cb != NULL)) {
-		struct bt_a2dp_ep *ep;
+		struct bt_a2dp_ep *ep = NULL;
 		struct bt_a2dp_ep_info *info = &a2dp->discover_cb_param->info;
 
 		info->codec_type = codec_type;
@@ -557,7 +473,7 @@ static int bt_a2dp_get_sep_caps(struct bt_a2dp *a2dp)
 			return 0;
 		}
 	}
-	return -1;
+	return -EINVAL;
 }
 
 static int bt_a2dp_discover_cb(struct bt_avdtp_req *req)
@@ -566,12 +482,12 @@ static int bt_a2dp_discover_cb(struct bt_avdtp_req *req)
 	struct bt_avdtp_sep_info *sep_info;
 	int err;
 
-	LOG_DBG("DISCOVER result:%d", DISCOVER_REQ(req)->status);
+	LOG_DBG("DISCOVER result:%d", req->status);
 	if (a2dp->discover_cb_param == NULL) {
 		return -EINVAL;
 	}
 	a2dp->peer_seps_count = 0U;
-	if (!(DISCOVER_REQ(req)->status)) {
+	if (!(req->status)) {
 		if (a2dp->discover_cb_param->sep_count == 0) {
 			if (a2dp->discover_cb_param->cb != NULL) {
 				a2dp->discover_cb_param->cb(a2dp, NULL, NULL);
@@ -610,32 +526,6 @@ static int bt_a2dp_discover_cb(struct bt_avdtp_req *req)
 	return 0;
 }
 
-static int bt_a2dp_start_cb(struct bt_avdtp_req *req)
-{
-	struct bt_a2dp *a2dp = START_PARAM(START_REQ(req));
-	struct bt_a2dp_ep *ep;
-	struct bt_a2dp_stream *stream;
-	struct bt_a2dp_stream_ops *ops;
-
-	ep = CONTAINER_OF(a2dp->start_param.sep, struct bt_a2dp_ep, sep);
-	if (ep->stream == NULL) {
-		return -1;
-	}
-	stream = ep->stream;
-
-	LOG_DBG("START result:%d", a2dp->start_param.status);
-
-	if ((a2dp_cb != NULL) && (a2dp_cb->start_rsp != NULL)) {
-		a2dp_cb->start_rsp(stream, a2dp->start_param.status);
-	}
-
-	ops = stream->ops;
-	if ((!a2dp->start_param.status) && (ops->started != NULL)) {
-		ops->started(stream);
-	}
-	return 0;
-}
-
 int bt_a2dp_discover(struct bt_a2dp *a2dp, struct bt_a2dp_discover_param *param)
 {
 	int err;
@@ -668,8 +558,24 @@ int bt_a2dp_discover(struct bt_a2dp *a2dp, struct bt_a2dp_discover_param *param)
 
 void bt_a2dp_stream_cb_register(struct bt_a2dp_stream *stream, struct bt_a2dp_stream_ops *ops)
 {
-	BT_ASSERT(stream);
+	__ASSERT_NO_MSG(stream);
 	stream->ops = ops;
+}
+
+static inline void bt_a2dp_stream_config_set_param(struct bt_a2dp *a2dp,
+						   struct bt_a2dp_codec_cfg *config,
+						   bt_avdtp_func_t cb, uint8_t remote_id,
+						   uint8_t int_id, uint8_t codec_type,
+						   struct bt_avdtp_sep *sep)
+{
+	a2dp->set_config_param.req.func = cb;
+	a2dp->set_config_param.acp_stream_ep_id = remote_id;
+	a2dp->set_config_param.int_stream_endpoint_id = int_id;
+	a2dp->set_config_param.media_type = BT_AVDTP_AUDIO;
+	a2dp->set_config_param.media_codec_type = codec_type;
+	a2dp->set_config_param.codec_specific_ie_len = config->codec_config->len;
+	a2dp->set_config_param.codec_specific_ie = &config->codec_config->codec_ie[0];
+	a2dp->set_config_param.sep = sep;
 }
 
 int bt_a2dp_stream_config(struct bt_a2dp *a2dp, struct bt_a2dp_stream *stream,
@@ -692,73 +598,125 @@ int bt_a2dp_stream_config(struct bt_a2dp *a2dp, struct bt_a2dp_stream *stream,
 	stream->a2dp = a2dp;
 	local_ep->stream = stream;
 	remote_ep->stream = stream;
-	a2dp->set_config_param.req.func = bt_a2dp_set_config_cb;
-	a2dp->set_config_param.acp_stream_ep_id = remote_ep->sep.sep_info.id;
-	a2dp->set_config_param.int_stream_endpoint_id = local_ep->sep.sep_info.id;
-	a2dp->set_config_param.media_type = BT_AVDTP_AUDIO;
-	a2dp->set_config_param.media_codec_type = local_ep->codec_type;
-	a2dp->set_config_param.codec_specific_ie_len = config->codec_config->len;
-	a2dp->set_config_param.codec_specific_ie = &config->codec_config->codec_ie[0];
-	a2dp->set_config_param.sep = &local_ep->sep;
+	bt_a2dp_stream_config_set_param(a2dp, config, bt_a2dp_set_config_cb,
+					remote_ep->sep.sep_info.id, local_ep->sep.sep_info.id,
+					local_ep->codec_type, &local_ep->sep);
 	return bt_avdtp_set_configuration(&a2dp->session, &a2dp->set_config_param);
+}
+
+typedef void (*bt_a2dp_rsp_cb)(struct bt_a2dp_stream *stream, uint8_t rsp_err_code);
+typedef void (*bt_a2dp_done_cb)(struct bt_a2dp_stream *stream);
+
+static int bt_a2dp_ctrl_cb(struct bt_avdtp_req *req, bt_a2dp_rsp_cb rsp_cb, bt_a2dp_done_cb done_cb,
+			   bool clear_stream)
+{
+	struct bt_a2dp *a2dp = CTRL_PARAM(CTRL_REQ(req));
+	struct bt_a2dp_ep *ep;
+	struct bt_a2dp_stream *stream;
+
+	ep = CONTAINER_OF(a2dp->ctrl_param.sep, struct bt_a2dp_ep, sep);
+	if ((ep->stream == NULL) || (CTRL_REQ(req) != &a2dp->ctrl_param)) {
+		return -EINVAL;
+	}
+	stream = ep->stream;
+	if (clear_stream) {
+		ep->stream = NULL;
+	}
+
+	LOG_DBG("ctrl result:%d", req->status);
+
+	if (rsp_cb != NULL) {
+		rsp_cb(stream, req->status);
+	}
+
+	if ((!req->status) && (done_cb != NULL)) {
+		done_cb(stream);
+	}
+	return 0;
+}
+
+static int bt_a2dp_open_cb(struct bt_avdtp_req *req)
+{
+	struct bt_a2dp_ep *ep = CONTAINER_OF(CTRL_REQ(req)->sep, struct bt_a2dp_ep, sep);
+	bt_a2dp_rsp_cb rsp_cb = a2dp_cb != NULL ? a2dp_cb->establish_rsp : NULL;
+	bt_a2dp_done_cb done_cb = (ep->stream != NULL && ep->stream->ops != NULL)
+					  ? ep->stream->ops->established
+					  : NULL;
+
+	return bt_a2dp_ctrl_cb(req, rsp_cb, done_cb, false);
+}
+
+static int bt_a2dp_start_cb(struct bt_avdtp_req *req)
+{
+	struct bt_a2dp_ep *ep = CONTAINER_OF(CTRL_REQ(req)->sep, struct bt_a2dp_ep, sep);
+	bt_a2dp_rsp_cb rsp_cb = a2dp_cb != NULL ? a2dp_cb->start_rsp : NULL;
+	bt_a2dp_done_cb done_cb =
+		(ep->stream != NULL && ep->stream->ops != NULL) ? ep->stream->ops->started : NULL;
+
+	return bt_a2dp_ctrl_cb(req, rsp_cb, done_cb, false);
+}
+
+static int bt_a2dp_stream_ctrl_pre(struct bt_a2dp_stream *stream, bt_avdtp_func_t cb)
+{
+	struct bt_a2dp *a2dp;
+
+	if ((stream == NULL) || (stream->local_ep == NULL) || (stream->a2dp == NULL)) {
+		return -EINVAL;
+	}
+
+	a2dp = stream->a2dp;
+	a2dp->ctrl_param.req.func = cb;
+	a2dp->ctrl_param.acp_stream_ep_id = stream->remote_ep != NULL
+						    ? stream->remote_ep->sep.sep_info.id
+						    : stream->remote_ep_id;
+	a2dp->ctrl_param.sep = &stream->local_ep->sep;
+	return 0;
 }
 
 int bt_a2dp_stream_establish(struct bt_a2dp_stream *stream)
 {
-	struct bt_a2dp *a2dp;
+	int err;
+	struct bt_a2dp *a2dp = stream->a2dp;
 
-	if ((stream == NULL) || (stream->local_ep == NULL) || (stream->a2dp == NULL)) {
-		return -EINVAL;
+	err = bt_a2dp_stream_ctrl_pre(stream, bt_a2dp_open_cb);
+	if (err) {
+		return err;
 	}
-
-	a2dp = stream->a2dp;
-	a2dp->open_param.req.func = bt_a2dp_open_cb;
-	a2dp->open_param.acp_stream_ep_id = stream->remote_ep != NULL
-						    ? stream->remote_ep->sep.sep_info.id
-						    : stream->remote_ep_id;
-	a2dp->open_param.sep = &stream->local_ep->sep;
-	return bt_avdtp_open(&a2dp->session, &a2dp->open_param);
-}
-
-int bt_a2dp_stream_release(struct bt_a2dp_stream *stream)
-{
-	/* todo: see the API description in a2dp.h */
-	return -ENOTSUP;
+	return bt_avdtp_open(&a2dp->session, &a2dp->ctrl_param);
 }
 
 int bt_a2dp_stream_start(struct bt_a2dp_stream *stream)
 {
-	struct bt_a2dp *a2dp;
+	int err;
+	struct bt_a2dp *a2dp = stream->a2dp;
 
-	if ((stream == NULL) || (stream->local_ep == NULL) || (stream->a2dp == NULL)) {
-		return -EINVAL;
+	err = bt_a2dp_stream_ctrl_pre(stream, bt_a2dp_start_cb);
+	if (err) {
+		return err;
 	}
-
-	a2dp = stream->a2dp;
-	a2dp->start_param.req.func = bt_a2dp_start_cb;
-	a2dp->start_param.acp_stream_ep_id = stream->remote_ep != NULL
-						     ? stream->remote_ep->sep.sep_info.id
-						     : stream->remote_ep_id;
-	a2dp->start_param.sep = &stream->local_ep->sep;
-	return bt_avdtp_start(&a2dp->session, &a2dp->start_param);
-}
-
-int bt_a2dp_stream_suspend(struct bt_a2dp_stream *stream)
-{
-	/* todo: see the API description in a2dp.h */
-	return -ENOTSUP;
+	return bt_avdtp_start(&a2dp->session, &a2dp->ctrl_param);
 }
 
 int bt_a2dp_stream_reconfig(struct bt_a2dp_stream *stream, struct bt_a2dp_codec_cfg *config)
 {
-	/* todo: see the API description in a2dp.h */
-	return -ENOTSUP;
+	uint8_t remote_id;
+
+	if ((stream == NULL) || (config == NULL)) {
+		return -EINVAL;
+	}
+
+	remote_id = stream->remote_ep != NULL ? stream->remote_ep->sep.sep_info.id
+					      : stream->remote_ep_id;
+	bt_a2dp_stream_config_set_param(stream->a2dp, config, bt_a2dp_set_config_cb, remote_id,
+					stream->local_ep->sep.sep_info.id,
+					stream->local_ep->codec_type, &stream->local_ep->sep);
+	return bt_avdtp_reconfigure(&stream->a2dp->session, &stream->a2dp->set_config_param);
 }
 
 uint32_t bt_a2dp_get_mtu(struct bt_a2dp_stream *stream)
 {
 	if ((stream == NULL) || (stream->local_ep == NULL)) {
-		return -EINVAL;
+		return 0;
 	}
 
 	return bt_avdtp_get_media_mtu(&stream->local_ep->sep);
@@ -770,16 +728,17 @@ int bt_a2dp_stream_send(struct bt_a2dp_stream *stream, struct net_buf *buf, uint
 {
 	struct bt_avdtp_media_hdr *media_hdr;
 
-	if (stream == NULL) {
+	if (stream == NULL || stream->local_ep == NULL) {
 		return -EINVAL;
 	}
 
 	media_hdr = net_buf_push(buf, sizeof(struct bt_avdtp_media_hdr));
+	memset(media_hdr, 0, sizeof(struct bt_avdtp_media_hdr));
 	if (stream->local_ep->codec_type == BT_A2DP_SBC) {
 		media_hdr->playload_type = A2DP_SBC_PAYLOAD_TYPE;
 	}
 
-	memset(media_hdr, 0, sizeof(struct bt_avdtp_media_hdr));
+	media_hdr->RTP_version = BT_AVDTP_RTP_VERSION;
 	media_hdr->synchronization_source = 0U;
 	/* update time_stamp in the buf */
 	sys_put_be32(ts, (uint8_t *)&media_hdr->time_stamp);
@@ -797,17 +756,16 @@ static const struct bt_avdtp_ops_cb signaling_avdtp_ops = {
 	.discovery_ind = a2dp_discovery_ind,
 	.get_capabilities_ind = a2dp_get_capabilities_ind,
 	.set_configuration_ind = a2dp_set_config_ind,
+	.re_configuration_ind = a2dp_re_config_ind,
 	.open_ind = a2dp_open_ind,
 	.start_ind = a2dp_start_ind,
-	.close_ind = a2dp_close_ind,
-	.suspend_ind = a2dp_suspend_ind,
 };
 
 int a2dp_accept(struct bt_conn *conn, struct bt_avdtp **session)
 {
 	struct bt_a2dp *a2dp;
 
-	a2dp = get_new_connection(conn);
+	a2dp = a2dp_get_connection(conn);
 	if (!a2dp) {
 		return -ENOMEM;
 	}
@@ -848,10 +806,8 @@ struct bt_a2dp *bt_a2dp_connect(struct bt_conn *conn)
 	struct bt_a2dp *a2dp;
 	int err;
 
-	A2DP_LOCK();
-	a2dp = get_new_connection(conn);
+	a2dp = a2dp_get_connection(conn);
 	if (!a2dp) {
-		A2DP_UNLOCK();
 		LOG_ERR("Cannot allocate memory");
 		return NULL;
 	}
@@ -861,32 +817,28 @@ struct bt_a2dp *bt_a2dp_connect(struct bt_conn *conn)
 	a2dp->session.ops = &signaling_avdtp_ops;
 	err = bt_avdtp_connect(conn, &(a2dp->session));
 	if (err < 0) {
-		/* If error occurs, undo the saving and return the error */
-		a2dp_reset(a2dp);
-		A2DP_UNLOCK();
 		LOG_DBG("AVDTP Connect failed");
 		return NULL;
 	}
 
-	A2DP_UNLOCK();
 	LOG_DBG("Connect request sent");
 	return a2dp;
 }
 
 int bt_a2dp_disconnect(struct bt_a2dp *a2dp)
 {
-	/* todo: see the API description in a2dp.h */
-	return -ENOTSUP;
+	__ASSERT_NO_MSG(a2dp);
+	return bt_avdtp_disconnect(&a2dp->session);
 }
 
-int bt_a2dp_register_ep(struct bt_a2dp_ep *ep, uint8_t media_type, uint8_t role)
+int bt_a2dp_register_ep(struct bt_a2dp_ep *ep, uint8_t media_type, uint8_t sep_type)
 {
 	int err;
 
-	BT_ASSERT(ep);
+	__ASSERT_NO_MSG(ep);
 
 #if defined(CONFIG_BT_A2DP_SINK)
-	if (role == BT_AVDTP_SINK) {
+	if (sep_type == BT_AVDTP_SINK) {
 		ep->sep.media_data_cb = bt_a2dp_media_data_callback;
 	} else {
 		ep->sep.media_data_cb = NULL;
@@ -894,9 +846,7 @@ int bt_a2dp_register_ep(struct bt_a2dp_ep *ep, uint8_t media_type, uint8_t role)
 #else
 	ep->sep.media_data_cb = NULL;
 #endif
-	A2DP_LOCK();
-	err = bt_avdtp_register_sep(media_type, role, &(ep->sep));
-	A2DP_UNLOCK();
+	err = bt_avdtp_register_sep(media_type, sep_type, &(ep->sep));
 	if (err < 0) {
 		return err;
 	}

--- a/subsys/bluetooth/host/classic/avdtp_internal.h
+++ b/subsys/bluetooth/host/classic/avdtp_internal.h
@@ -47,11 +47,11 @@
 #define BT_AVDTP_DELAYREPORT          0x0d
 
 /* @brief AVDTP STREAM STATE */
-#define BT_AVDTP_STREAM_STATE_IDLE        0x01
-#define BT_AVDTP_STREAM_STATE_CONFIGURED  0x02
-#define BT_AVDTP_STREAM_STATE_OPEN        0x03
-#define BT_AVDTP_STREAM_STATE_STREAMING   0x04
-#define BT_AVDTP_STREAM_STATE_CLOSING     0x05
+#define BT_AVDTP_STREAM_STATE_IDLE       0x01
+#define BT_AVDTP_STREAM_STATE_CONFIGURED 0x02
+#define BT_AVDTP_STREAM_STATE_OPEN       0x03
+#define BT_AVDTP_STREAM_STATE_STREAMING  0x04
+#define BT_AVDTP_STREAM_STATE_CLOSING    0x05
 
 /* @brief AVDTP Media TYPE */
 #define BT_AVDTP_SERVICE_CAT_MEDIA_TRANSPORT    0x01
@@ -93,19 +93,19 @@ struct bt_avdtp_sep_info;
 /** @brief AVDTP SEID Information AVDTP_SPEC V13 Table 8.8 */
 struct bt_avdtp_sep_data {
 #ifdef CONFIG_LITTLE_ENDIAN
-	uint8_t rfa0:1;
-	uint8_t inuse:1;
-	uint8_t id:6;
-	uint8_t rfa1:3;
-	uint8_t tsep:1;
-	uint8_t media_type:4;
+	uint8_t rfa0: 1;
+	uint8_t inuse: 1;
+	uint8_t id: 6;
+	uint8_t rfa1: 3;
+	uint8_t tsep: 1;
+	uint8_t media_type: 4;
 #else
-	uint8_t id:6;
-	uint8_t inuse:1;
-	uint8_t rfa0:1;
-	uint8_t media_type:4;
-	uint8_t tsep:1;
-	uint8_t rfa1:3;
+	uint8_t id: 6;
+	uint8_t inuse: 1;
+	uint8_t rfa0: 1;
+	uint8_t media_type: 4;
+	uint8_t tsep: 1;
+	uint8_t rfa1: 3;
 #endif
 } __packed;
 
@@ -124,19 +124,19 @@ struct bt_avdtp_single_sig_hdr {
 
 struct bt_avdtp_media_hdr {
 #ifdef CONFIG_LITTLE_ENDIAN
-	uint8_t CSRC_count:4;
-	uint8_t header_extension:1;
-	uint8_t padding:1;
-	uint8_t RTP_version:2;
-	uint8_t playload_type:7;
-	uint8_t marker:1;
+	uint8_t CSRC_count: 4;
+	uint8_t header_extension: 1;
+	uint8_t padding: 1;
+	uint8_t RTP_version: 2;
+	uint8_t playload_type: 7;
+	uint8_t marker: 1;
 #else
-	uint8_t RTP_version:2;
-	uint8_t padding:1;
-	uint8_t header_extension:1;
-	uint8_t CSRC_count:4;
-	uint8_t marker:1;
-	uint8_t playload_type:7;
+	uint8_t RTP_version: 2;
+	uint8_t padding: 1;
+	uint8_t header_extension: 1;
+	uint8_t CSRC_count: 4;
+	uint8_t marker: 1;
+	uint8_t playload_type: 7;
 #endif
 	uint16_t sequence_number;
 	uint32_t time_stamp;
@@ -191,26 +191,21 @@ struct bt_avdtp_ops_cb {
 
 	int (*discovery_ind)(struct bt_avdtp *session, uint8_t *errcode);
 
-	int (*get_capabilities_ind)(struct bt_avdtp *session,
-		struct bt_avdtp_sep *sep, struct net_buf *rsp_buf, uint8_t *errcode);
+	int (*get_capabilities_ind)(struct bt_avdtp *session, struct bt_avdtp_sep *sep,
+				    struct net_buf *rsp_buf, uint8_t *errcode);
 
 	int (*set_configuration_ind)(struct bt_avdtp *session, struct bt_avdtp_sep *sep,
-		uint8_t int_seid, struct net_buf *buf, uint8_t *errcode);
+				     uint8_t int_seid, struct net_buf *buf, uint8_t *errcode);
 
-	int (*open_ind)(struct bt_avdtp *session,
-		struct bt_avdtp_sep *sep, uint8_t *errcode);
+	int (*open_ind)(struct bt_avdtp *session, struct bt_avdtp_sep *sep, uint8_t *errcode);
 
-	int (*close_ind)(struct bt_avdtp *session,
-		struct bt_avdtp_sep *sep, uint8_t *errcode);
+	int (*close_ind)(struct bt_avdtp *session, struct bt_avdtp_sep *sep, uint8_t *errcode);
 
-	int (*start_ind)(struct bt_avdtp *session,
-		struct bt_avdtp_sep *sep, uint8_t *errcode);
+	int (*start_ind)(struct bt_avdtp *session, struct bt_avdtp_sep *sep, uint8_t *errcode);
 
-	int (*suspend_ind)(struct bt_avdtp *session,
-		struct bt_avdtp_sep *sep, uint8_t *errcode);
+	int (*suspend_ind)(struct bt_avdtp *session, struct bt_avdtp_sep *sep, uint8_t *errcode);
 
-	int (*abort_ind)(struct bt_avdtp *session,
-		struct bt_avdtp_sep *sep, uint8_t *errcode);
+	int (*abort_ind)(struct bt_avdtp *session, struct bt_avdtp_sep *sep, uint8_t *errcode);
 };
 
 /** @brief Global AVDTP session structure. */
@@ -240,39 +235,34 @@ int bt_avdtp_connect(struct bt_conn *conn, struct bt_avdtp *session);
 int bt_avdtp_disconnect(struct bt_avdtp *session);
 
 /* AVDTP SEP register function */
-int bt_avdtp_register_sep(uint8_t media_type, uint8_t role,
-				struct bt_avdtp_sep *sep);
+int bt_avdtp_register_sep(uint8_t media_type, uint8_t sep_type, struct bt_avdtp_sep *sep);
 
 /* AVDTP Discover Request */
-int bt_avdtp_discover(struct bt_avdtp *session,
-		      struct bt_avdtp_discover_params *param);
+int bt_avdtp_discover(struct bt_avdtp *session, struct bt_avdtp_discover_params *param);
 
 /* Parse the sep of discovered result */
 int bt_avdtp_parse_sep(struct net_buf *buf, struct bt_avdtp_sep_info *sep_info);
 
 /* AVDTP Get Capabilities */
 int bt_avdtp_get_capabilities(struct bt_avdtp *session,
-		      struct bt_avdtp_get_capabilities_params *param);
+			      struct bt_avdtp_get_capabilities_params *param);
 
 /* Parse the codec type of capabilities */
 int bt_avdtp_parse_capability_codec(struct net_buf *buf, uint8_t *codec_type,
-				uint8_t **codec_info_element, uint16_t *codec_info_element_len);
+				    uint8_t **codec_info_element, uint16_t *codec_info_element_len);
 
 /* AVDTP Set Configuration */
 int bt_avdtp_set_configuration(struct bt_avdtp *session,
-		      struct bt_avdtp_set_configuration_params *param);
+			       struct bt_avdtp_set_configuration_params *param);
 
 /* AVDTP reconfigure */
-int bt_avdtp_reconfigure(struct bt_avdtp *session,
-		      struct bt_avdtp_set_configuration_params *param);
+int bt_avdtp_reconfigure(struct bt_avdtp *session, struct bt_avdtp_set_configuration_params *param);
 
 /* AVDTP OPEN */
-int bt_avdtp_open(struct bt_avdtp *session,
-		      struct bt_avdtp_open_params *param);
+int bt_avdtp_open(struct bt_avdtp *session, struct bt_avdtp_ctrl_params *param);
 
 /* AVDTP START */
-int bt_avdtp_start(struct bt_avdtp *session,
-		      struct bt_avdtp_start_params *param);
+int bt_avdtp_start(struct bt_avdtp *session, struct bt_avdtp_ctrl_params *param);
 
 /* AVDTP send data */
 int bt_avdtp_send_media_data(struct bt_avdtp_sep *sep, struct net_buf *buf);

--- a/subsys/bluetooth/host/classic/avdtp_internal.h
+++ b/subsys/bluetooth/host/classic/avdtp_internal.h
@@ -202,6 +202,9 @@ struct bt_avdtp_ops_cb {
 	int (*suspend_ind)(struct bt_avdtp *session, struct bt_avdtp_sep *sep, uint8_t *errcode);
 
 	int (*abort_ind)(struct bt_avdtp *session, struct bt_avdtp_sep *sep, uint8_t *errcode);
+
+	/* stream l2cap is closed */
+	int (*stream_l2cap_disconnected)(struct bt_avdtp *session, struct bt_avdtp_sep *sep);
 };
 
 /** @brief Global AVDTP session structure. */
@@ -258,8 +261,17 @@ int bt_avdtp_reconfigure(struct bt_avdtp *session, struct bt_avdtp_set_configura
 /* AVDTP OPEN */
 int bt_avdtp_open(struct bt_avdtp *session, struct bt_avdtp_ctrl_params *param);
 
+/* AVDTP CLOSE */
+int bt_avdtp_close(struct bt_avdtp *session, struct bt_avdtp_ctrl_params *param);
+
 /* AVDTP START */
 int bt_avdtp_start(struct bt_avdtp *session, struct bt_avdtp_ctrl_params *param);
+
+/* AVDTP SUSPEND */
+int bt_avdtp_suspend(struct bt_avdtp *session, struct bt_avdtp_ctrl_params *param);
+
+/* AVDTP ABORT */
+int bt_avdtp_abort(struct bt_avdtp *session, struct bt_avdtp_ctrl_params *param);
 
 /* AVDTP send data */
 int bt_avdtp_send_media_data(struct bt_avdtp_sep *sep, struct net_buf *buf);


### PR DESCRIPTION
Implement the remain A2DP todo/interfaces as follow:

Implement the bt_a2dp_stream_reconfig: Modify reconfig_req callback to
pass codec_cfg to application. Remove reconfig_rsp callback,
config_rsp is used. Remove reconfigured callback, configured callback is used.

Implement the bt_a2dp_stream_release: The release_req,
release_rsp and released callbacks are already defined,
implement them in this change.

Implement the bt_a2dp_stream_suspend: The suspend_req,
suspend_rsp and suspended callbacks are already defined,
implement them in this change.

Add and implement the bt_a2dp_stream_abort: Add abort_req,
abort_rsp and aborted callbacks.

Implement bt_a2dp_disconnect.

Simplify the codes: (1) use the same bt_avdtp_ctrl_params to process open,
start, suspend, close and abort operations. (2) use same a2dp_ctrl_ind to
process open, start, suspend, close and abort operations. (3) use the same
bt_a2dp_ctrl_cb to process open, start, suspend, close and abort operations.
(4) use the same bt_avdtp_ctrl to process open, start, suspend, close and
abort operations. (5) move the status to common struct bt_avdtp_req.

Add shell test.