### PR TITLE
doc: Bluetooth: Update LE Audio and iso in the BT features page

### DIFF
--- a/doc/connectivity/bluetooth/features.rst
+++ b/doc/connectivity/bluetooth/features.rst
@@ -47,6 +47,7 @@ grown to be mature and feature-rich, as can be seen in the section below.
     real-time specifics so that they can be encapsulated in a hardware-specific
     module
   * Support for Controller (HCI) builds over different physical transports
+  * Isochronous channels
 
 * :ref:`Bluetooth Host <bluetooth_le_host>`
 
@@ -92,27 +93,5 @@ grown to be mature and feature-rich, as can be seen in the section below.
     * Local controller support as a virtual HCI driver
 
   * Verified with multiple popular controllers
-
-* :ref:`LE Audio in Host and Controller <bluetooth_le_audio_arch>`
-
   * Isochronous channels
-
-    * Full Host support
-    * Initial Controller support
-
-  * Generic Audio Framework
-
-    * Basic Audio Profile
-
-      * Unicast server and client
-      * Broadcast source and sink
-      * Broadcast assistant
-      * Scan delegator
-
-    * Common Audio Profile
-
-      * Acceptor
-
-    * Volume Control Profile, Microphone Control Profile
-    * Call Control Profile, Media Control Profile
-    * Coordinated Set Identification Profile
+  * :ref:`LE Audio <bluetooth_le_audio_arch>`


### PR DESCRIPTION
Added Isochronous channels to the controller
Moved Isochronous channels from LE Audio to the host 
Changed the LE Audio to refer to the page where
the feature is more detailed described.