### PR TITLE
Bluetooth: TBS: Add support for dynamic TBS

### DIFF
--- a/include/zephyr/bluetooth/audio/tbs.h
+++ b/include/zephyr/bluetooth/audio/tbs.h
@@ -126,6 +126,8 @@ extern "C" {
 #define BT_TBS_FEATURE_HOLD BIT(0)
 /** Join Call Control Point Opcode supported */
 #define BT_TBS_FEATURE_JOIN BIT(1)
+/** All Control Point Opcodes supported */
+#define BT_TBS_FEATURE_ALL  (BT_TBS_FEATURE_HOLD | BT_TBS_FEATURE_JOIN)
 /** @} */
 
 /**
@@ -246,8 +248,6 @@ typedef void (*bt_tbs_call_change_cb)(struct bt_conn *conn,
 
 /**
  * @brief Callback function for authorizing a client.
- *
- * Only used if BT_TBS_AUTHORIZATION is enabled.
  *
  * @param conn         The connection used.
  *
@@ -461,6 +461,98 @@ int bt_tbs_set_uri_scheme_list(uint8_t bearer_index, const char **uri_list,
  * @param cbs Pointer to the callback structure.
  */
 void bt_tbs_register_cb(struct bt_tbs_cb *cbs);
+
+struct bt_tbs_register_param {
+	/** The name of the provider, for example a cellular service provider */
+	char *provider_name;
+
+	/**
+	 * @brief The Uniform Caller Identifier of the bearer
+	 *
+	 * See the Uniform Caller Identifiers table in Bluetooth Assigned Numbers
+	 */
+	char *uci;
+
+	/**
+	 * The Uniform Resource Identifiers schemes supported by this bearer as an UTF-8 string
+	 *
+	 * See https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml for possible values.
+	 * If multiple values are used, these shall be comma separated, e.g. "tel,skype".
+	 */
+	char *uri_schemes_supported;
+
+	/**
+	 * @brief Whether this bearer shall be registered as a Generic Telephone Bearer server
+	 *
+	 * A GTBS shall be registered before any non-GTBS services. There can only be a single GTBS
+	 * registered.
+	 */
+	bool gtbs;
+
+	/**
+	 * @brief Whether the application will need to authorize changes to calls
+	 *
+	 * If set to false then the service will automatically accept write requests from clients.
+	 */
+	bool authorization_required;
+
+	/**
+	 * @brief The technology of the bearer
+	 *
+	 * See the BT_TBS_TECHNOLOGY_* values.
+	 */
+	uint8_t technology;
+
+	/**
+	 * @brief The optional supported features of the bearer
+	 *
+	 * See the BT_TBS_FEATURE_* values.
+	 */
+	uint8_t supported_features;
+};
+
+/**
+ * @brief Register a Telephone Bearer
+ *
+ * This will register a Telephone Bearer Service (TBS) (or a Generic Telephone Bearer service
+ * (GTBS)) with the provided parameters.
+ *
+ * As per the TBS specification, the GTBS shall be instantiated for the feature, and as such a GTBS
+ * shall always be registered before any TBS can be registered.
+ * Similarly, all TBS shall be unregistered before the GTBS can be unregistered with
+ * bt_tbs_unregister_bearer().
+ *
+ * @param param The parameters to initialize the bearer.
+
+ * @retval index The bearer index if return value is >= 0
+ * @retval -EINVAL @p param contains invalid data
+ * @retval -EALREADY @p param.gtbs is true and GTBS has already been registered
+ * @retval -EAGAIN @p param.gtbs is false and GTBS has not been registered
+ * @retval -ENOMEM @p param.gtbs is false and no more TBS can be registered (see
+ *         @kconfig{CONFIG_BT_TBS_BEARER_COUNT})
+ * @retval -ENOEXEC The service failed to be registered
+ */
+int bt_tbs_register_bearer(const struct bt_tbs_register_param *param);
+
+/**
+ * @brief Unregister a Telephone Bearer
+ *
+ * This will unregister a Telephone Bearer Service (TBS) (or a Generic Telephone Bearer service
+ * (GTBS)) with the provided parameters. The bearer shall be registered first by
+ * bt_tbs_register_bearer() before it can be unregistered.
+ *
+ * Similarly, all TBS shall be unregistered before the GTBS can be unregistered with.
+ *
+ * @param bearer_index The index of the bearer to unregister.
+ *
+ * @retval 0 Success
+ * @retval -EINVAL @p bearer_index is invalid
+ * @retval -EALREADY The bearer identified by @p bearer_index is not registered
+ * @retval -EAGAIN The bearer identified by @p bearer_index is GTBS and there are TBS instances
+ *                 registered.
+ * @retval -ENOEXEC The service failed to be unregistered
+ */
+int bt_tbs_unregister_bearer(uint8_t bearer_index);
 
 /** @brief Prints all calls of all services to the debug log */
 void bt_tbs_dbg_print_calls(void);

--- a/subsys/bluetooth/audio/Kconfig.tbs
+++ b/subsys/bluetooth/audio/Kconfig.tbs
@@ -22,70 +22,14 @@ config BT_TBS
 
 if BT_TBS
 
-config BT_TBS_PROVIDER_NAME
-	string "Telephone Bearer Service Provider Name"
-	default "Unknown"
-	help
-	  Sets the name of the service provider for the bearer.
-
-config BT_TBS_UCI
-	string "Telephone Bearer Service Uniform Caller Identifier (UCI)"
-	default "un000"
-	help
-	  Sets the UCI of the bearer. See
-		https://www.bluetooth.com/specifications/assigned-numbers/uniform-caller-identifiers/
-		for a table of valid UCIs.
-
-config BT_TBS_TECHNOLOGY
-	int "Telephone Bearer Service Technology"
-	range 1 10
-	help
-	  Sets the technology used for the bearer, e.g. GSM, LTE and 5G.
-	  1 : 3G
-	  2 : 4G
-	  3 : LTE
-	  4 : Wi-Fi
-	  5 : 5G
-	  6 : GSM
-	  7 : CDMA
-	  8 : 2G
-	  9 : WCDMA
-	  10: IP
-
-config BT_TBS_URI_SCHEMES_LIST
-	string "Telephone Bearer Service URI schemes Supported List"
-	default "tel,skype"
-	help
-	  Sets a list of URI schemes that are supported by the bearer,
-	  e.g. "tel" or "skype".
-	  Multiple values shall be comma (,) separated, e.g. "tel,skype".
-
-config BT_TBS_SIGNAL_STRENGTH_INTERVAL
-	int "Telephone Bearer Service Signal Strength Reporting Interval"
-	default 0
-	range 0 $(UINT8_MAX)
-	help
-	  Sets the interval of reporting the signal strength in seconds.
-		If the value is 0, the signal will not be reported.
-
-config BT_TBS_STATUS_FLAGS
-	int "Telephone Bearer Service Features and Status value"
-	default 0
-	range 0 3
-	help
-	  Bitfield to set feature and status flags.
-	  	Bit 0: In-band ringtone
-		Bit 1: Silent mode
-		Bits 2-15: Reserved for future use
-
 config BT_TBS_SUPPORTED_FEATURES
 	int "Telephone Bearer Service Supported Features"
 	default 1
 	range 0 3
 	help
 	  Bitfield to set supported features of the bearer.
-		Bit 0: Local Hold and Retrieve
-		Bit 1: Join calls within Telephone Bearer Service
+	  Bit 0: Local Hold and Retrieve
+	  Bit 1: Join calls within Telephone Bearer Service
 
 config BT_TBS_MAX_CALLS
 	int "Telephone Bearer Service Maximum Number Of Calls Supported"
@@ -107,12 +51,6 @@ config BT_TBS_MAX_SCHEME_LIST_LENGTH
 	range 0 512
 	help
 	  Sets the maximum length of the URI scheme list.
-
-config BT_TBS_AUTHORIZATION
-	bool "TBS authorization requirement"
-	help
-	  If set to true, then any writable characteristics will require
-	  authorization per connection.
 
 endif # BT_TBS
 

--- a/subsys/bluetooth/audio/shell/tbs.c
+++ b/subsys/bluetooth/audio/shell/tbs.c
@@ -12,6 +12,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <string.h>
 
 #include <zephyr/autoconf.h>
@@ -26,7 +27,6 @@
 #include "shell/bt.h"
 
 static struct bt_conn *tbs_authorized_conn;
-static bool cbs_registered;
 
 static bool tbs_authorize_cb(struct bt_conn *conn)
 {
@@ -59,12 +59,63 @@ static int cmd_tbs_authorize(const struct shell *sh, size_t argc, char *argv[])
 	return 0;
 }
 
-static int cmd_tbs_init(void)
+static int cmd_tbs_init(const struct shell *sh, size_t argc, char *argv[])
 {
-	if (!cbs_registered) {
-		bt_tbs_register_cb(&tbs_cbs);
-		cbs_registered = true;
+	static bool registered;
+
+	if (registered) {
+		shell_info(sh, "Already initialized");
+
+		return -ENOEXEC;
 	}
+
+	const struct bt_tbs_register_param gtbs_param = {
+		.provider_name = "Generic TBS",
+		.uci = "un000",
+		.uri_schemes_supported = "tel,skype",
+		.gtbs = true,
+		.authorization_required = false,
+		.technology = BT_TBS_TECHNOLOGY_3G,
+		.supported_features = CONFIG_BT_TBS_SUPPORTED_FEATURES,
+	};
+	int err;
+
+	err = bt_tbs_register_bearer(&gtbs_param);
+	if (err < 0) {
+		shell_error(sh, "Failed to register GTBS: %d", err);
+
+		return -ENOEXEC;
+	}
+
+	shell_info(sh, "Registered GTBS");
+
+	for (int i = 0; i < CONFIG_BT_TBS_BEARER_COUNT; i++) {
+		char prov_name[22]; /* Enough to store "Telephone Bearer #255" */
+		const struct bt_tbs_register_param tbs_param = {
+			.provider_name = prov_name,
+			.uci = "un000",
+			.uri_schemes_supported = "tel,skype",
+			.gtbs = false,
+			.authorization_required = false,
+			/* Set different technologies per bearer */
+			.technology = (i % BT_TBS_TECHNOLOGY_WCDMA) + 1,
+			.supported_features = CONFIG_BT_TBS_SUPPORTED_FEATURES,
+		};
+
+		snprintf(prov_name, sizeof(prov_name), "Telephone Bearer #%d", i);
+
+		err = bt_tbs_register_bearer(&tbs_param);
+		if (err < 0) {
+			shell_error(sh, "Failed to register TBS[%d]: %d", i, err);
+
+			return -ENOEXEC;
+		}
+
+		shell_info(sh, "Registered TBS[%d] with index %u", i, (uint8_t)err);
+	}
+
+	bt_tbs_register_cb(&tbs_cbs);
+	registered = true;
 
 	return 0;
 }

--- a/tests/bsim/bluetooth/audio/src/tbs_test.c
+++ b/tests/bsim/bluetooth/audio/src/tbs_test.c
@@ -8,6 +8,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
 
 #include <zephyr/autoconf.h>
 #include <zephyr/bluetooth/audio/tbs.h>
@@ -327,21 +328,84 @@ static void test_tbs_server_only(void)
 	test_set_status_flags();
 }
 
-static void test_main(void)
+static void init(void)
 {
+	const struct bt_tbs_register_param gtbs_param = {
+		.provider_name = "Generic TBS",
+		.uci = "un000",
+		.uri_schemes_supported = "tel,skype",
+		.gtbs = true,
+		.authorization_required = false,
+		.technology = BT_TBS_TECHNOLOGY_3G,
+		.supported_features = CONFIG_BT_TBS_SUPPORTED_FEATURES,
+	};
 	int err;
 
 	err = bt_enable(NULL);
 	if (err != 0) {
-		printk("Bluetooth init failed (err %d)\n", err);
+		FAIL("Bluetooth enable failed (err %d)\n", err);
+
 		return;
 	}
 
-	printk("Audio Client: Bluetooth initialized\n");
+	printk("Bluetooth initialized\n");
 
-	bt_conn_cb_register(&conn_callbacks);
-	bt_le_scan_cb_register(&common_scan_cb);
+	err = bt_conn_cb_register(&conn_callbacks);
+	if (err != 0) {
+		FAIL("Failed to register conn CBs (err %d)\n", err);
+
+		return;
+	}
+
+	err = bt_le_scan_cb_register(&common_scan_cb);
+	if (err != 0) {
+		FAIL("Failed to register scan CBs (err %d)\n", err);
+
+		return;
+	}
+
 	bt_tbs_register_cb(&tbs_cbs);
+
+	err = bt_tbs_register_bearer(&gtbs_param);
+	if (err < 0) {
+		FAIL("Failed to register GTBS (err %d)\n", err);
+
+		return;
+	}
+
+	printk("Registered GTBS\n");
+
+	for (int i = 0; i < CONFIG_BT_TBS_BEARER_COUNT; i++) {
+		char prov_name[22]; /* Enough to store "Telephone Bearer #255" */
+		const struct bt_tbs_register_param tbs_param = {
+			.provider_name = prov_name,
+			.uci = "un000",
+			.uri_schemes_supported = "tel,skype",
+			.gtbs = false,
+			.authorization_required = false,
+			/* Set different technologies per bearer */
+			.technology = (i % BT_TBS_TECHNOLOGY_WCDMA) + 1,
+			.supported_features = CONFIG_BT_TBS_SUPPORTED_FEATURES,
+		};
+
+		snprintf(prov_name, sizeof(prov_name), "Telephone Bearer #%d", i);
+
+		err = bt_tbs_register_bearer(&tbs_param);
+		if (err < 0) {
+			FAIL("Failed to register TBS[%d]: %d", i, err);
+
+			return;
+		}
+
+		printk("Registered TBS[%d] with index %u\n", i, (uint8_t)err);
+	}
+}
+
+static void test_main(void)
+{
+	int err;
+
+	init();
 
 	err = bt_le_scan_start(BT_LE_SCAN_PASSIVE, NULL);
 	if (err != 0) {
@@ -382,14 +446,7 @@ static void test_main(void)
 
 static void tbs_test_server_only(void)
 {
-	int err;
-
-	err = bt_enable(NULL);
-
-	if (err != 0) {
-		FAIL("Bluetooth init failed (err %d)\n", err);
-		return;
-	}
+	init();
 
 	test_tbs_server_only();
 


### PR DESCRIPTION
The TBS and GTBS instances can now be dynamically registered
and unregistered, which fits better for the use cases of TBS
where specific bearers can come and go depending on the
features of the device.
    
For example if a SIM card is inserted, then a device can
register a TBS for the provider and remove it again if the
SIM card is removed.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/41738