### PR TITLE
Bluetooth: Implement Secondary_Advertising_Max_Skip in controller

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_types.h
@@ -36,6 +36,7 @@ struct ll_adv_set {
 #if defined(CONFIG_BT_CTLR_HCI_ADV_HANDLE_MAPPING)
 	uint8_t  hci_handle;
 #endif
+	uint8_t  max_skip;
 	uint16_t event_counter;
 	uint16_t max_events;
 	uint32_t remain_duration_us;

--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -1216,6 +1216,8 @@ static int le_ext_adv_param_set(struct bt_le_ext_adv *adv,
 
 	cp->sid = param->sid;
 
+	cp->sec_adv_max_skip = param->secondary_max_skip;
+
 	cp->props = sys_cpu_to_le16(props);
 	err = bt_hci_cmd_send_sync(BT_HCI_OP_LE_SET_EXT_ADV_PARAM, buf, &rsp);
 	if (err) {


### PR DESCRIPTION
Fix the host side not setting sec_adv_max_skip

Behaviour is unchanged for max_skip == 0

For max_skip > 0, use a slightly different calculation to ensure we can pass LL/DDI/ADV/BV-28-C