### PR TITLE
Misc clean-up Zephyr 3.7 release notes and migration guide

### DIFF
--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -71,10 +71,10 @@ Kernel
 Boards
 ******
 
-* Reordered D1 and D0 in the `pro_micro` connector gpio-map for SparkFun Pro Micro RP2040 to match
+* Reordered D1 and D0 in the ``pro_micro`` connector gpio-map for SparkFun Pro Micro RP2040 to match
   original Pro Micro definition. Out-of-tree shields must be updated to reflect this change. (:github:`69994`)
 * ITE: Rename all SoC variant Kconfig options, e.g., ``CONFIG_SOC_IT82202_AX`` is renamed to
-  ``CONFIG_SOC_IT82202AX``.
+  :kconfig:option:`CONFIG_SOC_IT82202AX`.
   All symbols are renamed as follows: ``SOC_IT81202BX``, ``SOC_IT81202CX``, ``SOC_IT81302BX``,
   ``SOC_IT81302CX``, ``SOC_IT82002AW``, ``SOC_IT82202AX``, ``SOC_IT82302AX``.
   And, rename the ``SOC_SERIES_ITE_IT8XXX2`` to ``SOC_SERIES_IT8XXX2``. (:github:`71680`)
@@ -85,7 +85,7 @@ Boards
 * LiteX: Renamed the ``compatible`` of the LiteX VexRiscV interrupt controller node from
   ``vexriscv-intc0`` to :dtcompatible:`litex,vexriscv-intc0`. (:github:`73211`)
 
-* `lairdconnect` boards are now `ezurio` boards. Laird Connectivity has rebranded to `Ezurio <https://www.ezurio.com/laird-connectivity>`_.
+* ``lairdconnect`` boards are now ``ezurio`` boards. Laird Connectivity has rebranded to `Ezurio <https://www.ezurio.com/laird-connectivity>`_.
 
 Modules
 *******
@@ -126,7 +126,7 @@ Trusted Firmware-M
 * The default MCUboot signature type has been changed from RSA-3072 to EC-P256.
   This affects builds that have MCUboot enabled in TF-M (:kconfig:option:`CONFIG_TFM_BL2`).
   If you wish to keep using RSA-3072, you need to set :kconfig:option:`CONFIG_TFM_MCUBOOT_SIGNATURE_TYPE`
-  to `"RSA-3072"`. Otherwise, make sure to have your own signing keys of the signature type in use.
+  to ``"RSA-3072"``. Otherwise, make sure to have your own signing keys of the signature type in use.
 
 zcbor
 =====
@@ -142,7 +142,7 @@ LVGL
 Device Drivers and Devicetree
 *****************************
 
-* The :dtcompatible:`nxp,kinetis-pit` pit driver has changed it's compatible
+* The :dtcompatible:`nxp,kinetis-pit` pit driver has changed its compatible
   to :dtcompatible:`nxp,pit` and has been updated to support multiple channels.
   To configure the individual channels, you must add a child node with the
   compatible :dtcompatible:`nxp,pit-channel` and configure as below.
@@ -263,8 +263,8 @@ Device Drivers and Devicetree
         gyro-odr = <ICM42688_GYRO_ODR_2000>;
     };
 
-* `st,lis2mdl` property `spi-full-duplex` changed to `duplex =
-  SPI_FULL_DUPLEX`. Full duplex is now the default.
+* ``st,lis2mdl`` property ``spi-full-duplex`` changed to ``duplex =
+  SPI_FULL_DUPLEX``. Full duplex is now the default.
 
 * The DT property ``nxp,reference-supply`` of :dtcompatible:`nxp,lpc-lpadc` driver has
   been removed, users should remove this property from their devicetree if it is present.
@@ -327,11 +327,11 @@ Controller Area Network (CAN)
   * ``sjw``
   * ``prop-seg``
   * ``phase-seg1``
-  * ``phase-seg1``
+  * ``phase-seg2``
   * ``sjw-data``
   * ``prop-seg-data``
   * ``phase-seg1-data``
-  * ``phase-seg1-data``
+  * ``phase-seg2-data``
 
   The ``bus-speed`` and ``bus-speed-data`` CAN controller devicetree properties have been
   deprecated.
@@ -410,9 +410,9 @@ Display
 
 * ST7735R based displays now use the MIPI DBI driver class. These displays
   must now be declared within a MIPI DBI driver wrapper device, which will
-  manage interfacing with the display. Note that the `cmd-data-gpios` pin has
+  manage interfacing with the display. Note that the ``cmd-data-gpios`` pin has
   changed polarity with this update, to align better with the new
-  `dc-gpios` name. For an example, see below:
+  ``dc-gpios`` name. For an example, see below:
 
   .. code-block:: devicetree
 
@@ -591,7 +591,7 @@ Enhanced Serial Peripheral Interface (eSPI)
   ``ESPI_VWIRE_SIGNAL_TARGET_BOOT_STS``, ``ESPI_VWIRE_SIGNAL_TARGET_BOOT_DONE`` and
   ``ESPI_VWIRE_SIGNAL_TARGET_GPIO_<NUMBER>`` respectively to reflect the new terminology
   in eSPI 1.5 specification. (:github:`68492`)
-  The KConfig ``CONFIG_ESPI_SLAVE`` was renamed to ``CONFIG_ESPI_TARGET``, similarly
+  The Kconfig ``CONFIG_ESPI_SLAVE`` was renamed to ``CONFIG_ESPI_TARGET``, similarly
   ``CONFIG_ESPI_SAF`` was renamed as ``CONFIG_ESPI_TAF`` (:github:`73887`)
 
 Flash
@@ -868,14 +868,14 @@ Networking
   one IPv4 address / network interface, the netmask must be specified
   for each IPv4 address separately. (:github:`68419`)
 
-* Virtual network interface API no longer has the `input` callback. The input callback was
+* Virtual network interface API no longer has the ``input`` callback. The input callback was
   used to read the inner IPv4/IPv6 packets in an IP tunnel. This incoming tunnel read is now
-  implemented in `recv` callback. (:github:`70549`)
+  implemented in the ``recv`` callback. (:github:`70549`)
 
 * Virtual LAN (VLAN) implementation is changed to use the Virtual network interfaces.
-  There are no API changes, but the type of a VLAN network interface is changed from `ETHERNET`
-  to `VIRTUAL`. This could require changes to the code that sets the VLAN tags to a network
-  interface. For example in the `net_eth_is_vlan_enabled()` API, the 2nd interface parameter
+  There are no API changes, but the type of a VLAN network interface is changed from ``ETHERNET``
+  to ``VIRTUAL``. This could require changes to the code that sets the VLAN tags to a network
+  interface. For example in the :c:func:`net_eth_is_vlan_enabled()` API, the 2nd interface parameter
   must point to the main Ethernet interface, and not to the VLAN interface. (:github:`70345`)
 
 * Modified the ``wifi connect`` command to use key-value format for the arguments. In the
@@ -886,11 +886,11 @@ Networking
   ``wifi -h`` will give more information about the usage of connect command.
   (:github:`70024`)
 
-* The Kconfig ``CONFIG_NET_TCP_ACK_TIMEOUT`` has been deprecated. Its usage was
+* The Kconfig :kconfig:option:`CONFIG_NET_TCP_ACK_TIMEOUT` has been deprecated. Its usage was
   limited to TCP handshake only, and in such case the total timeout should depend
   on the total retransmission timeout (as in other cases) making the config
-  redundant and confusing. Use ``CONFIG_NET_TCP_INIT_RETRANSMISSION_TIMEOUT`` and
-  ``CONFIG_NET_TCP_RETRY_COUNT`` instead to control the total timeout at the
+  redundant and confusing. Use :kconfig:option:`CONFIG_NET_TCP_INIT_RETRANSMISSION_TIMEOUT` and
+  :kconfig:option:`CONFIG_NET_TCP_RETRY_COUNT` instead to control the total timeout at the
   TCP level. (:github:`70731`)
 
 * In LwM2M API, the callback type :c:type:`lwm2m_engine_set_data_cb_t` has now an additional

--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -288,23 +288,23 @@ Bluetooth HCI
    chosen property. The devicetree bindings for all HCI drivers derive from a common
    ``bt-hci.yaml`` base binding.
 
-   * As part of the new HCI driver API, the ``zephyr,bt-uart`` chosen property is no longer used,
-      rather the UART HCI drivers select their UART by looking for the parent devicetree node of the
-      HCI driver instance node.
-   * As part of the new HCI driver API, the ``zephyr,bt-hci-ipc`` chosen property is only used for
-      the controller side, whereas the HCI driver now relies on nodes with the compatible string
-      ``zephyr,bt-hci-ipc``.
-   * The ``BT_NO_DRIVER`` Kconfig option was removed. HCI drivers are no-longer behind a Kconfig
-      choice, rather they can now be enabled and disabled independently, mostly based on their
-      respective devicetree node being enabled or not.
-   * The ``BT_HCI_VS_EXT`` Kconfig option was deleted and the feature is now included in the
-      :kconfig:option:`CONFIG_BT_HCI_VS` Kconfig option.
-   * The ``BT_HCI_VS_EVT`` Kconfig option was removed, since vendor event support is implicit if
-      the :kconfig:option:`CONFIG_BT_HCI_VS` option is enabled.
-   * The bt_read_static_addr() API was removed. This wasn't really a completely public API, but
-      since it was exposed by the public hci_driver.h header file the removal is mentioned here.
-      Enable the :kconfig:option:`CONFIG_BT_HCI_VS` Kconfig option instead, and use vendor specific
-      HCI commands API to get the Controller's Bluetooth static address when available.
+  * As part of the new HCI driver API, the ``zephyr,bt-uart`` chosen property is no longer used,
+    rather the UART HCI drivers select their UART by looking for the parent devicetree node of the
+    HCI driver instance node.
+  * As part of the new HCI driver API, the ``zephyr,bt-hci-ipc`` chosen property is only used for
+    the controller side, whereas the HCI driver now relies on nodes with the compatible string
+    ``zephyr,bt-hci-ipc``.
+  * The ``BT_NO_DRIVER`` Kconfig option was removed. HCI drivers are no-longer behind a Kconfig
+    choice, rather they can now be enabled and disabled independently, mostly based on their
+    respective devicetree node being enabled or not.
+  * The ``BT_HCI_VS_EXT`` Kconfig option was deleted and the feature is now included in the
+    :kconfig:option:`CONFIG_BT_HCI_VS` Kconfig option.
+  * The ``BT_HCI_VS_EVT`` Kconfig option was removed, since vendor event support is implicit if
+    the :kconfig:option:`CONFIG_BT_HCI_VS` option is enabled.
+  * The bt_read_static_addr() API was removed. This wasn't really a completely public API, but
+    since it was exposed by the public hci_driver.h header file the removal is mentioned here.
+    Enable the :kconfig:option:`CONFIG_BT_HCI_VS` Kconfig option instead, and use vendor specific
+    HCI commands API to get the Controller's Bluetooth static address when available.
 
 Charger
 =======

--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -43,7 +43,7 @@ Major enhancements with this release include:
 An overview of the changes required or recommended when migrating your application from Zephyr
 v3.6.0 to Zephyr v3.7.0 can be found in the separate :ref:`migration guide<migration_3.7>`.
 
-While you may refer to release notes from previous 3.x releases for a full description, other major
+While you may refer to release notes from previous 3.x releases for a full change log, other major
 enhancements and changes since previous LTS release, Zephyr 2.7.0, include:
 
 * Added support for Picolibc as the new default C library.
@@ -73,7 +73,7 @@ enhancements and changes since previous LTS release, Zephyr 2.7.0, include:
   * The following deprecated or experimental features have been removed:
 
     * 6LoCAN
-    * civetweb module. See Zephyr 3.7's new HTTP server as a replacement.
+    * civetweb module. See Zephyr 3.7's new :ref:`http_server_interface` as a replacement.
     * tinycbor module. You may use zcbor as a replacement.
 
 The following sections provide detailed lists of changes by component.
@@ -145,8 +145,8 @@ Deprecated in this release
     * :c:macro:`BT_LE_EXT_ADV_NCONN_NAME`
     * :c:macro:`BT_LE_EXT_ADV_CODED_NCONN_NAME`
 
-   Application developer will now need to set the advertised name themselves by updating the advertising data
-   or the scan response data.
+   Application developers will now need to set the advertised name themselves by updating the
+   advertising data or the scan response data.
 
 * CAN
 
@@ -267,7 +267,7 @@ Architectures
 Kernel
 ******
 
-  * Added :c:func:`k_uptime_seconds` function to simplify `k_uptime_get() / 1000` usage.
+  * Added :c:func:`k_uptime_seconds` function to simplify ``k_uptime_get() / 1000`` usage.
 
   * Added :c:func:`k_realloc`, that uses kernel heap to implement traditional :c:func:`realloc`
     semantics.
@@ -355,7 +355,7 @@ Boards & SoC Support
   * Added support for STM32H7R/S SoC series.
   * Added support for NXP mke15z7, mke17z7, mke17z9, MCXNx4x, RW61x
   * Added support for Analog Devices MAX32 SoC series.
-  * Added support for Infineon Technologies AIROC:tm: CYW20829 Bluetooth LE SoC series.
+  * Added support for Infineon Technologies AIROC |trade| CYW20829 Bluetooth LE SoC series.
   * Added support for MediaTek MT8195 Audio DSPs
   * Added support for Nuvoton Numaker M2L31X SoC series.
   * Added support for the Microchip PolarFire ICICLE Kit SMP variant.
@@ -1606,9 +1606,9 @@ Devicetree
 Kconfig
 *******
 
-* Added a `substring` kconfig preprocessor function.
-* Added a `dt_node_ph_prop_path` kconfig preprocessor function.
-* Added a `dt_compat_any_has_prop` kconfig preprocessor function.
+* Added a ``substring`` kconfig preprocessor function.
+* Added a ``dt_node_ph_prop_path`` kconfig preprocessor function.
+* Added a ``dt_compat_any_has_prop`` kconfig preprocessor function.
 
 Libraries / Subsystems
 **********************

--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -12,29 +12,33 @@ This release is the last non-maintenance 3.x release and, as such, will be the n
 
 Major enhancements with this release include:
 
-* A new, completely overhauled hardware model has been introduced. This change the way both SoCs and
-  boards are named, defined and constructed in Zephyr.
+* A new, completely :ref:`overhauled hardware model <hw_model_v2>` has been introduced.
+  It changes the way both SoCs and boards are named, defined and constructed in Zephyr.
   Additional information can be found in the :ref:`board_porting_guide`.
-* A long-awaited HTTP server library, and associated service API, allow to easily implement HTTP/1.1
-  and HTTP/2 servers in Zephyr. Resources can be registered statically or at runtime, and WebSocket
-  support is included.
-* POSIX support has been extended, with most Options of the IEEE 1003-2017
+* A long-awaited :ref:`HTTP Server <http_server_interface>` library, and associated service API,
+  allow to easily implement HTTP/1.1 and HTTP/2 servers in Zephyr. Resources can be registered
+  statically or dynamically, and WebSocket support is included.
+* :ref:`POSIX support <posix_support>` has been extended, with most Options of the IEEE 1003-2017
   :ref:`System Interfaces <posix_system_interfaces_required>` receiving support, as well as most
   Options and Option groups required for :ref:`PSE51 <posix_aep_pse51>`,
   :ref:`PSE52 <posix_aep_pse52>`, and :ref:`PSE53 <posix_aep_pse53>`.
 * Bluetooth Host has been extended with support for the Nordic UART Service (NUS), Hands-free Audio
   Gateway (AG), Advanced Audio Distribution Profile (A2DP), and Audio/Video Distribution Transport
   Protocol (AVDTP).
-* Sensor abstraction model has been overhauled to adopt a read-then-decode approach that enables
-  more types of sensors and data flows than the previous fetch/get APIs.
-* A new LLEXT Extension Development Kit (EDK) makes it easier to develop and integrate custom
-  extensions into Zephyr, including outside of the Zephyr tree.
-* Native simulator now supports leveraging native host networking stack without having to rely on
-  complex setup of the host environment.
+* Sensor abstraction model has been overhauled to adopt a
+  :ref:`read-then-decode approach <sensor-read-and-decode>` that enables more types of sensors and
+  data flows than the previous fetch/get APIs.
+* A new :ref:`LLEXT Extension Developer Kit (EDK) <llext_build_edk>` makes it easier to develop and
+  integrate custom extensions into Zephyr, including outside of the Zephyr tree.
+* :ref:`Native simulator <native_sim>` now supports leveraging native host networking stack without
+  having to rely on complex setup of the host environment.
 * Trusted Firmware-M (TF-M) 2.1.0 and Mbed TLS 3.6.0 have been integrated into Zephyr.
-  Both of these versions are LTS releases.
+  Both of these versions are LTS releases. What's more, :ref:`psa_crypto` has been adopted as a replacement
+  for TinyCrypt and provides enhanced security and performance.
+* A new experimental implementation of the :ref:`Precision Time Protocol <ptp_interface>` (PTP, IEEE
+  1588) allows to synchronize time across devices with sub-microsecond accuracy.
 * New documentation pages have been introduced to help developers setup their local development
-  environment with Visual Studio Code and CLion.
+  environment for :ref:`vscode_ide` and :ref:`clion_ide`.
 
 An overview of the changes required or recommended when migrating your application from Zephyr
 v3.6.0 to Zephyr v3.7.0 can be found in the separate :ref:`migration guide<migration_3.7>`.

--- a/doc/services/llext/build.rst
+++ b/doc/services/llext/build.rst
@@ -130,8 +130,8 @@ Anything else after ``COMMAND`` will be passed to ``add_custom_command()`` as-is
 
 .. _llext_build_edk:
 
-LLEXT Extension Development Kit
-*******************************
+LLEXT Extension Development Kit (EDK)
+*************************************
 
 When building extensions as a standalone project, outside of the main Zephyr
 build system, it's important to have access to the same set of generated


### PR DESCRIPTION
- reworked "release highlights" (added PTP, PSA Crypto) and added hyperlinks to relevant sections
- basic restructuredtext/sphinx fixups
- fixed typos / spelling mistakes

This builds on PR #76104 for convenience and to have one less chance of potential merge conflicts. 

If that helps, I can also add to this PR the "final" clean-up consisting in removing sections with empty headers.
