### PR TITLE
doc: posix: options: alphabetic order, heading levels

### DIFF
--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -367,7 +367,7 @@ to ``ENOSYS`` :ref:`†<posix_undefined_behaviour>`.
     setsockopt(),yes
     shutdown(),yes
     socket(),yes
-    sockatmark(),yes (will fail with ``ENOSYS``:ref:`†<posix_undefined_behaviour>`)
+    sockatmark(),yes :ref:`†<posix_undefined_behaviour>`
     socketpair(),yes
 
 .. _posix_option_group_pipe:
@@ -743,6 +743,10 @@ _POSIX_MONOTONIC_CLOCK
 _POSIX_PRIORITY_SCHEDULING
 ++++++++++++++++++++++++++
 
+As processes are not yet supported in Zephyr, the functions ``sched_rr_get_interval()``,
+``sched_setparam()``, and ``sched_setscheduler()`` are expected to fail setting ``errno``
+to ``ENOSYS``:ref:`†<posix_undefined_behaviour>`.
+
 .. csv-table:: _POSIX_PRIORITY_SCHEDULING
    :header: API, Supported
    :widths: 50,10
@@ -751,9 +755,9 @@ _POSIX_PRIORITY_SCHEDULING
     sched_get_priority_min(),yes
     sched_getparam(),yes
     sched_getscheduler(),yes
-    sched_rr_get_interval(),yes (will fail with ``ENOSYS``:ref:`†<posix_undefined_behaviour>`)
-    sched_setparam(),yes (will fail with ``ENOSYS``:ref:`†<posix_undefined_behaviour>`)
-    sched_setscheduler(),yes (will fail with ``ENOSYS``:ref:`†<posix_undefined_behaviour>`)
+    sched_rr_get_interval(),yes :ref:`†<posix_undefined_behaviour>`
+    sched_setparam(),yes :ref:`†<posix_undefined_behaviour>`
+    sched_setscheduler(),yes :ref:`†<posix_undefined_behaviour>`
     sched_yield(),yes
 
 .. _posix_option_raw_sockets:

--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -11,6 +11,8 @@ POSIX Option Groups
 POSIX_BARRIERS
 ++++++++++++++
 
+Enable this option group with :kconfig:option:`CONFIG_POSIX_BARRIERS`.
+
 .. csv-table:: POSIX_BARRIERS
    :header: API, Supported
    :widths: 50,10
@@ -75,6 +77,8 @@ to :ref:`details<language_support>`.
 POSIX_C_LIB_EXT
 +++++++++++++++
 
+Enable this option group with :kconfig:option:`CONFIG_POSIX_C_LIB_EXT`.
+
 .. csv-table:: POSIX_C_LIB_EXT
    :header: API, Supported
    :widths: 50,10
@@ -100,6 +104,8 @@ POSIX_C_LIB_EXT
 POSIX_CLOCK_SELECTION
 +++++++++++++++++++++
 
+Enable this option group with :kconfig:option:`CONFIG_POSIX_CLOCK_SELECTION`.
+
 .. csv-table:: POSIX_CLOCK_SELECTION
    :header: API, Supported
    :widths: 50,10
@@ -112,6 +118,8 @@ POSIX_CLOCK_SELECTION
 
 POSIX_DEVICE_IO
 +++++++++++++++
+
+Enable this option group with :kconfig:option:`CONFIG_POSIX_DEVICE_IO`.
 
 .. csv-table:: POSIX_DEVICE_IO
    :header: API, Supported
@@ -172,7 +180,7 @@ POSIX_DEVICE_IO
 POSIX_FD_MGMT
 +++++++++++++
 
-This table lists service support status in Zephyr for `POSIX_FD_MGMT`:
+Enable this option group with :kconfig:option:`CONFIG_POSIX_FD_MGMT`.
 
 .. csv-table:: POSIX_FD_MGMT
    :header: API, Supported
@@ -196,8 +204,6 @@ This table lists service support status in Zephyr for `POSIX_FD_MGMT`:
 POSIX_FILE_LOCKING
 ++++++++++++++++++
 
-This table lists service support status in Zephyr for `POSIX_FD_MGMT`:
-
 .. csv-table:: POSIX_FILE_LOCKING
    :header: API, Supported
    :widths: 50,10
@@ -214,6 +220,8 @@ This table lists service support status in Zephyr for `POSIX_FD_MGMT`:
 
 POSIX_FILE_SYSTEM
 +++++++++++++++++
+
+Enable this option group with :kconfig:option:`CONFIG_POSIX_FILE_SYSTEM`.
 
 .. csv-table:: POSIX_FILE_SYSTEM
    :header: API, Supported
@@ -251,6 +259,8 @@ POSIX_FILE_SYSTEM
 POSIX_MAPPED_FILES
 ++++++++++++++++++
 
+Enable this option group with :kconfig:option:`CONFIG_POSIX_MAPPED_FILES`.
+
 .. csv-table:: POSIX_MAPPED_FILES
    :header: API, Supported
    :widths: 50,10
@@ -264,6 +274,8 @@ POSIX_MAPPED_FILES
 POSIX_MEMORY_PROTECTION
 +++++++++++++++++++++++
 
+Enable this option group with :kconfig:option:`CONFIG_POSIX_MEMORY_PROTECTION`.
+
 .. csv-table:: POSIX_MEMORY_PROTECTION
    :header: API, Supported
    :widths: 50,10
@@ -274,6 +286,8 @@ POSIX_MEMORY_PROTECTION
 
 POSIX_MULTI_PROCESS
 +++++++++++++++++++
+
+Enable this option group with :kconfig:option:`CONFIG_POSIX_MULTI_PROCESS`.
 
 .. csv-table:: POSIX_MULTI_PROCESS
    :header: API, Supported
@@ -311,6 +325,8 @@ POSIX_NETWORKING
 
 The function ``sockatmark()`` is not yet supported and is expected to fail setting ``errno``
 to ``ENOSYS`` :ref:`†<posix_undefined_behaviour>`.
+
+Enable this option group with :kconfig:option:`CONFIG_POSIX_NETWORKING`.
 
 .. csv-table:: POSIX_NETWORKING
    :header: API, Supported
@@ -386,6 +402,8 @@ POSIX_PIPE
 POSIX_REALTIME_SIGNALS
 ++++++++++++++++++++++
 
+Enable this option group with :kconfig:option:`CONFIG_POSIX_REALTIME_SIGNALS`.
+
 .. csv-table:: POSIX_REALTIME_SIGNALS
    :header: API, Supported
    :widths: 50,10
@@ -398,6 +416,8 @@ POSIX_REALTIME_SIGNALS
 
 POSIX_SEMAPHORES
 ++++++++++++++++
+
+Enable this option group with :kconfig:option:`CONFIG_POSIX_SEMAPHORES`.
 
 .. csv-table:: POSIX_SEMAPHORES
    :header: API, Supported
@@ -433,6 +453,8 @@ POSIX_SIGNALS
 Signal services are a basic mechanism within POSIX-based systems and are
 required for error and event handling.
 
+Enable this option group with :kconfig:option:`CONFIG_POSIX_SIGNALS`.
+
 .. csv-table:: POSIX_SIGNALS
    :header: API, Supported
    :widths: 50,10
@@ -463,6 +485,8 @@ POSIX_SINGLE_PROCESS
 The POSIX_SINGLE_PROCESS option group contains services for single
 process applications.
 
+Enable this option group with :kconfig:option:`CONFIG_POSIX_SINGLE_PROCESS`.
+
 .. csv-table:: POSIX_SINGLE_PROCESS
    :header: API, Supported
    :widths: 50,10
@@ -480,6 +504,8 @@ process applications.
 
 POSIX_SPIN_LOCKS
 ++++++++++++++++
+
+Enable this option group with :kconfig:option:`CONFIG_POSIX_SPIN_LOCKS`.
 
 .. csv-table:: POSIX_SPIN_LOCKS
    :header: API, Supported
@@ -500,6 +526,8 @@ The basic assumption in this profile is that the system
 consists of a single (implicit) process with multiple threads. Therefore, the
 standard requires all basic thread services, except those related to
 multiple processes.
+
+Enable this option group with :kconfig:option:`CONFIG_POSIX_THREADS`.
 
 .. csv-table:: POSIX_THREADS_BASE
    :header: API, Supported
@@ -559,7 +587,7 @@ multiple processes.
 POSIX_THREADS_EXT
 +++++++++++++++++
 
-This table lists service support status in Zephyr:
+Enable this option group with :kconfig:option:`CONFIG_POSIX_THREADS_EXT`.
 
 .. csv-table:: POSIX_THREADS_EXT
    :header: API, Supported
@@ -574,6 +602,8 @@ This table lists service support status in Zephyr:
 
 POSIX_TIMERS
 ++++++++++++
+
+Enable this option group with :kconfig:option:`CONFIG_POSIX_TIMERS`.
 
 .. csv-table:: POSIX_TIMERS
    :header: API, Supported
@@ -594,6 +624,8 @@ POSIX_TIMERS
 XSI_SYSTEM_LOGGING
 ++++++++++++++++++
 
+Enable this option group with :kconfig:option:`CONFIG_XSI_SYSTEM_LOGGING`.
+
 .. csv-table:: XSI_SYSTEM_LOGGING
    :header: API, Supported
    :widths: 50,10
@@ -612,7 +644,7 @@ The XSI_THREADS_EXT option group is required because it provides
 functions to control a thread's stack. This is considered useful for any
 real-time application.
 
-This table lists service support status in Zephyr:
+Enable this option group with :kconfig:option:`CONFIG_XSI_THREADS_EXT`.
 
 .. csv-table:: XSI_THREADS_EXT
    :header: API, Supported
@@ -637,6 +669,8 @@ Functions part of the ``_POSIX_ASYNCHRONOUS_IO`` Option are not implemented in Z
 provided so that conformant applications can still link. These functions will fail, setting
 ``errno`` to ``ENOSYS``:ref:`†<posix_undefined_behaviour>`.
 
+Enable this option with :kconfig:option:`CONFIG_POSIX_ASYNCHRONOUS_IO`.
+
 .. csv-table:: _POSIX_ASYNCHRONOUS_IO
    :header: API, Supported
    :widths: 50,10
@@ -655,6 +689,8 @@ provided so that conformant applications can still link. These functions will fa
 _POSIX_CPUTIME
 ++++++++++++++
 
+Enable this option with :kconfig:option:`CONFIG_POSIX_CPUTIME`.
+
 .. csv-table:: _POSIX_CPUTIME
    :header: API, Supported
    :widths: 50,10
@@ -665,6 +701,8 @@ _POSIX_CPUTIME
 
 _POSIX_FSYNC
 ++++++++++++
+
+Enable this option with :kconfig:option:`CONFIG_POSIX_FSYNC`.
 
 .. csv-table:: _POSIX_FSYNC
    :header: API, Supported
@@ -681,6 +719,8 @@ Internet Protocol Version 6 is supported.
 
 For more information, please refer to :ref:`Networking <networking>`.
 
+Enable this option with :kconfig:option:`CONFIG_POSIX_IPV6`.
+
 .. _posix_option_memlock:
 
 _POSIX_MEMLOCK
@@ -689,6 +729,8 @@ _POSIX_MEMLOCK
 Zephyr's :ref:`Demand Paging API <memory_management_api_demand_paging>` does not yet support
 pinning or unpinning all virtual memory regions. The functions below are expected to fail and
 set ``errno`` to ``ENOSYS`` :ref:`†<posix_undefined_behaviour>`.
+
+Enable this option with :kconfig:option:`CONFIG_POSIX_MEMLOCK`.
 
 .. csv-table:: _POSIX_MEMLOCK
    :header: API, Supported
@@ -702,6 +744,8 @@ set ``errno`` to ``ENOSYS`` :ref:`†<posix_undefined_behaviour>`.
 _POSIX_MEMLOCK_RANGE
 ++++++++++++++++++++
 
+Enable this option with :kconfig:option:`CONFIG_POSIX_MEMLOCK_RANGE`.
+
 .. csv-table:: _POSIX_MEMLOCK_RANGE
    :header: API, Supported
    :widths: 50,10
@@ -713,6 +757,8 @@ _POSIX_MEMLOCK_RANGE
 
 _POSIX_MESSAGE_PASSING
 ++++++++++++++++++++++
+
+Enable this option with :kconfig:option:`CONFIG_POSIX_MESSAGE_PASSING`.
 
 .. csv-table:: _POSIX_MESSAGE_PASSING
    :header: API, Supported
@@ -732,6 +778,8 @@ _POSIX_MESSAGE_PASSING
 _POSIX_MONOTONIC_CLOCK
 ++++++++++++++++++++++
 
+Enable this option with :kconfig:option:`CONFIG_POSIX_MONOTONIC_CLOCK`.
+
 .. csv-table:: _POSIX_MONOTONIC_CLOCK
    :header: API, Supported
    :widths: 50,10
@@ -746,6 +794,8 @@ _POSIX_PRIORITY_SCHEDULING
 As processes are not yet supported in Zephyr, the functions ``sched_rr_get_interval()``,
 ``sched_setparam()``, and ``sched_setscheduler()`` are expected to fail setting ``errno``
 to ``ENOSYS``:ref:`†<posix_undefined_behaviour>`.
+
+Enable this option with :kconfig:option:`CONFIG_POSIX_PRIORITY_SCHEDULING`.
 
 .. csv-table:: _POSIX_PRIORITY_SCHEDULING
    :header: API, Supported
@@ -769,10 +819,14 @@ Raw sockets are supported.
 
 For more information, please refer to :kconfig:option:`CONFIG_NET_SOCKETS_PACKET`.
 
+Enable this option with :kconfig:option:`CONFIG_POSIX_RAW_SOCKETS`.
+
 .. _posix_option_reader_writer_locks:
 
 _POSIX_READER_WRITER_LOCKS
 ++++++++++++++++++++++++++
+
+Enable this option with :kconfig:option:`CONFIG_POSIX_READER_WRITER_LOCKS`.
 
 .. csv-table:: _POSIX_READER_WRITER_LOCKS
    :header: API, Supported
@@ -795,6 +849,8 @@ _POSIX_READER_WRITER_LOCKS
 _POSIX_SHARED_MEMORY_OBJECTS
 ++++++++++++++++++++++++++++
 
+Enable this option with :kconfig:option:`CONFIG_POSIX_SHARED_MEMORY_OBJECTS`.
+
 .. csv-table:: _POSIX_SHARED_MEMORY_OBJECTS
    :header: API, Supported
    :widths: 50,10
@@ -809,6 +865,8 @@ _POSIX_SHARED_MEMORY_OBJECTS
 _POSIX_SYNCHRONIZED_IO
 ++++++++++++++++++++++
 
+Enable this option with :kconfig:option:`CONFIG_POSIX_SYNCHRONIZED_IO`.
+
 .. csv-table:: _POSIX_SYNCHRONIZED_IO
    :header: API, Supported
    :widths: 50,10
@@ -822,6 +880,8 @@ _POSIX_SYNCHRONIZED_IO
 _POSIX_THREAD_ATTR_STACKADDR
 ++++++++++++++++++++++++++++
 
+Enable this option with :kconfig:option:`CONFIG_POSIX_THREAD_ATTR_STACKADDR`.
+
 .. csv-table:: _POSIX_THREAD_ATTR_STACKADDR
    :header: API, Supported
    :widths: 50,10
@@ -833,6 +893,8 @@ _POSIX_THREAD_ATTR_STACKADDR
 
 _POSIX_THREAD_ATTR_STACKSIZE
 ++++++++++++++++++++++++++++
+
+Enable this option with :kconfig:option:`CONFIG_POSIX_THREAD_ATTR_STACKSIZE`.
 
 .. csv-table:: _POSIX_THREAD_ATTR_STACKSIZE
    :header: API, Supported
@@ -846,6 +908,8 @@ _POSIX_THREAD_ATTR_STACKSIZE
 _POSIX_THREAD_CPUTIME
 +++++++++++++++++++++
 
+Enable this option with :kconfig:option:`CONFIG_POSIX_THREAD_CPUTIME`.
+
 .. csv-table:: _POSIX_THREAD_CPUTIME
    :header: API, Supported
    :widths: 50,10
@@ -858,6 +922,8 @@ _POSIX_THREAD_CPUTIME
 _POSIX_THREAD_PRIO_INHERIT
 ++++++++++++++++++++++++++
 
+Enable this option with :kconfig:option:`CONFIG_POSIX_THREAD_PRIO_INHERIT`.
+
 .. csv-table:: _POSIX_THREAD_PRIO_INHERIT
    :header: API, Supported
    :widths: 50,10
@@ -869,6 +935,8 @@ _POSIX_THREAD_PRIO_INHERIT
 
 _POSIX_THREAD_PRIO_PROTECT
 ++++++++++++++++++++++++++
+
+Enable this option with :kconfig:option:`CONFIG_POSIX_THREAD_PRIO_PROTECT`.
 
 .. csv-table:: _POSIX_THREAD_PRIO_PROTECT
    :header: API, Supported
@@ -885,6 +953,8 @@ _POSIX_THREAD_PRIO_PROTECT
 
 _POSIX_THREAD_PRIORITY_SCHEDULING
 +++++++++++++++++++++++++++++++++
+
+Enable this option with :kconfig:option:`CONFIG_POSIX_THREAD_PRIORITY_SCHEDULING`.
 
 .. csv-table:: _POSIX_THREAD_PRIORITY_SCHEDULING
    :header: API, Supported
@@ -904,6 +974,8 @@ _POSIX_THREAD_PRIORITY_SCHEDULING
 
 _POSIX_THREAD_SAFE_FUNCTIONS
 ++++++++++++++++++++++++++++
+
+Enable this option with :kconfig:option:`CONFIG_POSIX_THREAD_SAFE_FUNCTIONS`.
 
 .. csv-table:: _POSIX_THREAD_SAFE_FUNCTIONS
     :header: API, Supported
@@ -934,6 +1006,8 @@ _POSIX_THREAD_SAFE_FUNCTIONS
 _POSIX_TIMEOUTS
 +++++++++++++++
 
+Enable this option with :kconfig:option:`CONFIG_POSIX_TIMEOUTS`.
+
 .. csv-table:: _POSIX_TIMEOUTS
    :header: API, Supported
    :widths: 50,10
@@ -955,6 +1029,8 @@ With the exception of ``ioctl()``, functions in the ``_XOPEN_STREAMS`` option gr
 implemented in Zephyr but are provided so that conformant applications can still link.
 Unimplemented functions in this option group will fail, setting ``errno`` to ``ENOSYS``
 :ref:`†<posix_undefined_behaviour>`.
+
+Enable this option with :kconfig:option:`CONFIG_XOPEN_STREAMS`.
 
 .. csv-table:: _XOPEN_STREAMS
    :header: API, Supported

--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -3,6 +3,494 @@
 Subprofiling Option Groups
 ##########################
 
+POSIX Option Groups
+===================
+
+.. _posix_option_group_barriers:
+
+POSIX_BARRIERS
+==============
+
+.. csv-table:: POSIX_BARRIERS
+   :header: API, Supported
+   :widths: 50,10
+
+    pthread_barrier_destroy(),yes
+    pthread_barrier_init(),yes
+    pthread_barrier_wait(),yes
+    pthread_barrierattr_destroy(),yes
+    pthread_barrierattr_init(),yes
+
+.. _posix_option_group_c_lang_jump:
+
+POSIX_C_LANG_JUMP
+=================
+
+The ``POSIX_C_LANG_JUMP`` Option Group is included in the ISO C standard.
+
+.. note::
+   When using Newlib, Picolibc, or other C libraries conforming to the ISO C Standard, the
+   ``POSIX_C_LANG_JUMP`` Option Group is considered supported.
+
+.. csv-table:: POSIX_C_LANG_JUMP
+   :header: API, Supported
+   :widths: 50,10
+
+    setjmp(), yes
+    longjmp(), yes
+
+.. _posix_option_group_c_lang_math:
+
+POSIX_C_LANG_MATH
+=================
+
+The ``POSIX_C_LANG_MATH`` Option Group is included in the ISO C standard.
+
+.. note::
+   When using Newlib, Picolibc, or other C libraries conforming to the ISO C Standard, the
+   ``POSIX_C_LANG_MATH`` Option Group is considered supported.
+
+Please refer to `Subprofiling Considerations`_ for details on the ``POSIX_C_LANG_MATH`` Option
+Group.
+
+.. _posix_option_group_c_lang_support:
+
+POSIX_C_LANG_SUPPORT
+====================
+
+The POSIX_C_LANG_SUPPORT option group contains the general ISO C Library.
+
+.. note::
+   When using Newlib, Picolibc, or other C libraries conforming to the ISO C Standard, the entire
+   ``POSIX_C_LANG_SUPPORT`` Option Group is considered supported.
+
+Please refer to `Subprofiling Considerations`_ for details on the ``POSIX_C_LANG_SUPPORT`` Option
+Group.
+
+For more information on developing Zephyr applications in the C programming language, please refer
+to :ref:`details<language_support>`.
+
+.. _posix_option_group_c_lib_ext:
+
+POSIX_C_LIB_EXT
+===============
+
+.. csv-table:: POSIX_C_LIB_EXT
+   :header: API, Supported
+   :widths: 50,10
+
+    fnmatch(), yes
+    getopt(), yes
+    getsubopt(),
+    optarg, yes
+    opterr, yes
+    optind, yes
+    optopt, yes
+    stpcpy(),
+    stpncpy(),
+    strcasecmp(),
+    strdup(),
+    strfmon(),
+    strncasecmp(), yes
+    strndup(),
+    strnlen(), yes
+
+.. _posix_option_group_clock_selection:
+
+POSIX_CLOCK_SELECTION
+=====================
+
+.. csv-table:: POSIX_CLOCK_SELECTION
+   :header: API, Supported
+   :widths: 50,10
+
+    pthread_condattr_getclock(),yes
+    pthread_condattr_setclock(),yes
+    clock_nanosleep(),yes
+
+.. _posix_option_group_device_io:
+
+POSIX_DEVICE_IO
+===============
+
+.. csv-table:: POSIX_DEVICE_IO
+   :header: API, Supported
+   :widths: 50,10
+
+    FD_CLR(),yes
+    FD_ISSET(),yes
+    FD_SET(),yes
+    FD_ZERO(),yes
+    clearerr(),yes
+    close(),yes
+    fclose(),
+    fdopen(),
+    feof(),
+    ferror(),
+    fflush(),
+    fgetc(),
+    fgets(),
+    fileno(),
+    fopen(),
+    fprintf(),yes
+    fputc(),yes
+    fputs(),yes
+    fread(),
+    freopen(),
+    fscanf(),
+    fwrite(),yes
+    getc(),
+    getchar(),
+    gets(),
+    open(),yes
+    perror(),yes
+    poll(),yes
+    printf(),yes
+    pread(),
+    pselect(),
+    putc(),yes
+    putchar(),yes
+    puts(),yes
+    pwrite(),
+    read(),yes
+    scanf(),
+    select(),yes
+    setbuf(),
+    setvbuf(),
+    stderr,
+    stdin,
+    stdout,
+    ungetc(),
+    vfprintf(),yes
+    vfscanf(),
+    vprintf(),yes
+    vscanf(),
+    write(),yes
+
+.. _posix_option_group_fd_mgmt:
+
+POSIX_FD_MGMT
+=============
+
+This table lists service support status in Zephyr for `POSIX_FD_MGMT`:
+
+.. csv-table:: POSIX_FD_MGMT
+   :header: API, Supported
+   :widths: 50,10
+
+    dup(),
+    dup2(),
+    fcntl(),
+    fgetpos(),
+    fseek(),
+    fseeko(),
+    fsetpos(),
+    ftell(),
+    ftello(),
+    ftruncate(),yes
+    lseek(),
+    rewind(),
+
+.. _posix_option_group_file_locking:
+
+POSIX_FILE_LOCKING
+==================
+
+This table lists service support status in Zephyr for `POSIX_FD_MGMT`:
+
+.. csv-table:: POSIX_FILE_LOCKING
+   :header: API, Supported
+   :widths: 50,10
+
+    flockfile(),
+    ftrylockfile(),
+    funlockfile(),
+    getc_unlocked(),
+    getchar_unlocked(),
+    putc_unlocked(),
+    putchar_unlocked(),
+
+.. _posix_option_group_file_system:
+
+POSIX_FILE_SYSTEM
+=================
+
+.. csv-table:: POSIX_FILE_SYSTEM
+   :header: API, Supported
+   :widths: 50,10
+
+    access(),
+    chdir(),
+    closedir(), yes
+    creat(),
+    fchdir(),
+    fpathconf(),
+    fstat(), yes
+    fstatvfs(),
+    getcwd(),
+    link(),
+    mkdir(), yes
+    mkstemp(),
+    opendir(), yes
+    pathconf(),
+    readdir(), yes
+    remove(),
+    rename(), yes
+    rewinddir(),
+    rmdir(),
+    stat(), yes
+    statvfs(),
+    tmpfile(),
+    tmpnam(),
+    truncate(),
+    unlink(), yes
+    utime(),
+
+.. _posix_option_group_mapped_files:
+
+POSIX_MAPPED_FILES
+==================
+
+.. csv-table:: POSIX_MAPPED_FILES
+   :header: API, Supported
+   :widths: 50,10
+
+    mmap(),yes
+    msync(),yes
+    munmap(),yes
+
+.. _posix_option_group_memory_protection:
+
+POSIX_MEMORY_PROTECTION
+=======================
+
+.. csv-table:: POSIX_MEMORY_PROTECTION
+   :header: API, Supported
+   :widths: 50,10
+
+    mprotect(), yes :ref:`†<posix_undefined_behaviour>`
+
+.. _posix_option_group_multi_process:
+
+POSIX_MULTI_PROCESS
+===================
+
+.. csv-table:: POSIX_MULTI_PROCESS
+   :header: API, Supported
+   :widths: 50,10
+
+    _Exit(), yes
+    _exit(), yes
+    assert(), yes
+    atexit(),:ref:`†<posix_undefined_behaviour>`
+    clock(),
+    execl(),:ref:`†<posix_undefined_behaviour>`
+    execle(),:ref:`†<posix_undefined_behaviour>`
+    execlp(),:ref:`†<posix_undefined_behaviour>`
+    execv(),:ref:`†<posix_undefined_behaviour>`
+    execve(),:ref:`†<posix_undefined_behaviour>`
+    execvp(),:ref:`†<posix_undefined_behaviour>`
+    exit(), yes
+    fork(),:ref:`†<posix_undefined_behaviour>`
+    getpgrp(),:ref:`†<posix_undefined_behaviour>`
+    getpgid(),:ref:`†<posix_undefined_behaviour>`
+    getpid(), yes :ref:`†<posix_undefined_behaviour>`
+    getppid(),:ref:`†<posix_undefined_behaviour>`
+    getsid(),:ref:`†<posix_undefined_behaviour>`
+    setsid(),:ref:`†<posix_undefined_behaviour>`
+    sleep(),yes
+    times(),
+    wait(),:ref:`†<posix_undefined_behaviour>`
+    waitid(),:ref:`†<posix_undefined_behaviour>`
+    waitpid(),:ref:`†<posix_undefined_behaviour>`
+
+.. _posix_option_group_networking:
+
+POSIX_NETWORKING
+================
+
+The function ``sockatmark()`` is not yet supported and is expected to fail setting ``errno``
+to ``ENOSYS`` :ref:`†<posix_undefined_behaviour>`.
+
+.. csv-table:: POSIX_NETWORKING
+   :header: API, Supported
+   :widths: 50,10
+
+    accept(),yes
+    bind(),yes
+    connect(),yes
+    endhostent(),yes
+    endnetent(),yes
+    endprotoent(),yes
+    endservent(),yes
+    freeaddrinfo(),yes
+    gai_strerror(),yes
+    getaddrinfo(),yes
+    gethostent(),yes
+    gethostname(),yes
+    getnameinfo(),yes
+    getnetbyaddr(),yes
+    getnetbyname(),yes
+    getnetent(),yes
+    getpeername(),yes
+    getprotobyname(),yes
+    getprotobynumber(),yes
+    getprotoent(),yes
+    getservbyname(),yes
+    getservbyport(),yes
+    getservent(),yes
+    getsockname(),yes
+    getsockopt(),yes
+    htonl(),yes
+    htons(),yes
+    if_freenameindex(),yes
+    if_indextoname(),yes
+    if_nameindex(),yes
+    if_nametoindex(),yes
+    inet_addr(),yes
+    inet_ntoa(),yes
+    inet_ntop(),yes
+    inet_pton(),yes
+    listen(),yes
+    ntohl(),yes
+    ntohs(),yes
+    recv(),yes
+    recvfrom(),yes
+    recvmsg(),yes
+    send(),yes
+    sendmsg(),yes
+    sendto(),yes
+    sethostent(),yes
+    setnetent(),yes
+    setprotoent(),yes
+    setservent(),yes
+    setsockopt(),yes
+    shutdown(),yes
+    socket(),yes
+    sockatmark(),yes (will fail with ``ENOSYS``:ref:`†<posix_undefined_behaviour>`)
+    socketpair(),yes
+
+.. _posix_option_group_pipe:
+
+POSIX_PIPE
+==========
+
+.. csv-table:: POSIX_PIPE
+   :header: API, Supported
+   :widths: 50,10
+
+    pipe(),
+
+.. _posix_option_group_realtime_signals:
+
+POSIX_REALTIME_SIGNALS
+======================
+
+.. csv-table:: POSIX_REALTIME_SIGNALS
+   :header: API, Supported
+   :widths: 50,10
+
+    sigqueue(),
+    sigtimedwait(),
+    sigwaitinfo(),
+
+.. _posix_option_group_semaphores:
+
+POSIX_SEMAPHORES
+================
+
+.. csv-table:: POSIX_SEMAPHORES
+   :header: API, Supported
+   :widths: 50,10
+
+    sem_close(),yes
+    sem_destroy(),yes
+    sem_getvalue(),yes
+    sem_init(),yes
+    sem_open(),yes
+    sem_post(),yes
+    sem_trywait(),yes
+    sem_unlink(),yes
+    sem_wait(),yes
+
+.. _posix_option_group_signal_jump:
+
+POSIX_SIGNAL_JUMP
+=================
+
+.. csv-table:: POSIX_SIGNAL_JUMP
+   :header: API, Supported
+   :widths: 50,10
+
+    siglongjmp(),
+    sigsetjmp(),
+
+.. _posix_option_group_signals:
+
+POSIX_SIGNALS
+=============
+
+Signal services are a basic mechanism within POSIX-based systems and are
+required for error and event handling.
+
+.. csv-table:: POSIX_SIGNALS
+   :header: API, Supported
+   :widths: 50,10
+
+    abort(),yes
+    alarm(),
+    kill(),
+    pause(),
+    raise(),
+    sigaction(),
+    sigaddset(),yes
+    sigdelset(),yes
+    sigemptyset(),yes
+    sigfillset(),yes
+    sigismember(),yes
+    signal(),
+    sigpending(),
+    sigprocmask(),yes
+    sigsuspend(),
+    sigwait(),
+    strsignal(),yes
+
+.. _posix_option_group_single_process:
+
+POSIX_SINGLE_PROCESS
+====================
+
+The POSIX_SINGLE_PROCESS option group contains services for single
+process applications.
+
+.. csv-table:: POSIX_SINGLE_PROCESS
+   :header: API, Supported
+   :widths: 50,10
+
+    confstr(),yes
+    environ,yes
+    errno,yes
+    getenv(),yes
+    setenv(),yes
+    sysconf(),yes
+    uname(),yes
+    unsetenv(),yes
+
+.. _posix_option_group_spin_locks:
+
+POSIX_SPIN_LOCKS
+================
+
+.. csv-table:: POSIX_SPIN_LOCKS
+   :header: API, Supported
+   :widths: 50,10
+
+    pthread_spin_destroy(),yes
+    pthread_spin_init(),yes
+    pthread_spin_lock(),yes
+    pthread_spin_trylock(),yes
+    pthread_spin_unlock(),yes
+
 .. _posix_option_group_threads_base:
 
 POSIX_THREADS_BASE
@@ -82,6 +570,39 @@ This table lists service support status in Zephyr:
     pthread_mutexattr_gettype(),yes
     pthread_mutexattr_settype(),yes
 
+.. _posix_option_group_timers:
+
+POSIX_TIMERS
+============
+
+.. csv-table:: POSIX_TIMERS
+   :header: API, Supported
+   :widths: 50,10
+
+    clock_getres(),yes
+    clock_gettime(),yes
+    clock_settime(),yes
+    nanosleep(),yes
+    timer_create(),yes
+    timer_delete(),yes
+    timer_gettime(),yes
+    timer_getoverrun(),yes
+    timer_settime(),yes
+
+.. _posix_option_group_xsi_system_logging:
+
+XSI_SYSTEM_LOGGING
+==================
+
+.. csv-table:: XSI_SYSTEM_LOGGING
+   :header: API, Supported
+   :widths: 50,10
+
+    closelog(),yes
+    openlog(),yes
+    setlogmask(),yes
+    syslog(),yes
+
 .. _posix_option_group_xsi_threads_ext:
 
 XSI_THREADS_EXT
@@ -102,525 +623,10 @@ This table lists service support status in Zephyr:
     pthread_getconcurrency(),yes
     pthread_setconcurrency(),yes
 
-.. _posix_option_group_xsi_system_logging:
-
-XSI_SYSTEM_LOGGING
-==================
-
-.. csv-table:: XSI_SYSTEM_LOGGING
-   :header: API, Supported
-   :widths: 50,10
-
-    closelog(),yes
-    openlog(),yes
-    setlogmask(),yes
-    syslog(),yes
-
-.. _posix_option_group_c_lang_jump:
-
-POSIX_C_LANG_JUMP
-=================
-
-The ``POSIX_C_LANG_JUMP`` Option Group is included in the ISO C standard.
-
-.. note::
-   When using Newlib, Picolibc, or other C libraries conforming to the ISO C Standard, the
-   ``POSIX_C_LANG_JUMP`` Option Group is considered supported.
-
-.. csv-table:: POSIX_C_LANG_JUMP
-   :header: API, Supported
-   :widths: 50,10
-
-    setjmp(), yes
-    longjmp(), yes
-
-.. _posix_option_group_c_lang_math:
-
-POSIX_C_LANG_MATH
-=================
-
-The ``POSIX_C_LANG_MATH`` Option Group is included in the ISO C standard.
-
-.. note::
-   When using Newlib, Picolibc, or other C libraries conforming to the ISO C Standard, the
-   ``POSIX_C_LANG_MATH`` Option Group is considered supported.
-
-Please refer to `Subprofiling Considerations`_ for details on the ``POSIX_C_LANG_MATH`` Option
-Group.
-
-.. _posix_option_group_c_lang_support:
-
-POSIX_C_LANG_SUPPORT
-====================
-
-The POSIX_C_LANG_SUPPORT option group contains the general ISO C Library.
-
-.. note::
-   When using Newlib, Picolibc, or other C libraries conforming to the ISO C Standard, the entire
-   ``POSIX_C_LANG_SUPPORT`` Option Group is considered supported.
-
-Please refer to `Subprofiling Considerations`_ for details on the ``POSIX_C_LANG_SUPPORT`` Option
-Group.
-
-For more information on developing Zephyr applications in the C programming language, please refer
-to :ref:`details<language_support>`.
-
-.. _posix_option_group_c_lib_ext:
-
-POSIX_C_LIB_EXT
-===============
-
-.. csv-table:: POSIX_C_LIB_EXT
-   :header: API, Supported
-   :widths: 50,10
-
-    fnmatch(), yes
-    getopt(), yes
-    getsubopt(),
-    optarg, yes
-    opterr, yes
-    optind, yes
-    optopt, yes
-    stpcpy(),
-    stpncpy(),
-    strcasecmp(),
-    strdup(),
-    strfmon(),
-    strncasecmp(), yes
-    strndup(),
-    strnlen(), yes
-
-.. _posix_option_group_realtime_signals:
-
-POSIX_REALTIME_SIGNALS
-======================
-
-.. csv-table:: POSIX_REALTIME_SIGNALS
-   :header: API, Supported
-   :widths: 50,10
-
-    sigqueue(),
-    sigtimedwait(),
-    sigwaitinfo(),
-
-.. _posix_option_group_signal_jump:
-
-POSIX_SIGNAL_JUMP
-=================
-
-.. csv-table:: POSIX_SIGNAL_JUMP
-   :header: API, Supported
-   :widths: 50,10
-
-    siglongjmp(),
-    sigsetjmp(),
-
-.. _posix_option_group_single_process:
-
-POSIX_SINGLE_PROCESS
-====================
-
-The POSIX_SINGLE_PROCESS option group contains services for single
-process applications.
-
-.. csv-table:: POSIX_SINGLE_PROCESS
-   :header: API, Supported
-   :widths: 50,10
-
-    confstr(),yes
-    environ,yes
-    errno,yes
-    getenv(),yes
-    setenv(),yes
-    sysconf(),yes
-    uname(),yes
-    unsetenv(),yes
-
-.. _posix_option_group_signals:
-
-POSIX_SIGNALS
-=============
-
-Signal services are a basic mechanism within POSIX-based systems and are
-required for error and event handling.
-
-.. csv-table:: POSIX_SIGNALS
-   :header: API, Supported
-   :widths: 50,10
-
-    abort(),yes
-    alarm(),
-    kill(),
-    pause(),
-    raise(),
-    sigaction(),
-    sigaddset(),yes
-    sigdelset(),yes
-    sigemptyset(),yes
-    sigfillset(),yes
-    sigismember(),yes
-    signal(),
-    sigpending(),
-    sigprocmask(),yes
-    sigsuspend(),
-    sigwait(),
-    strsignal(),yes
-
-.. _posix_option_group_device_io:
-
-POSIX_DEVICE_IO
-===============
-
-.. csv-table:: POSIX_DEVICE_IO
-   :header: API, Supported
-   :widths: 50,10
-
-    FD_CLR(),yes
-    FD_ISSET(),yes
-    FD_SET(),yes
-    FD_ZERO(),yes
-    clearerr(),yes
-    close(),yes
-    fclose(),
-    fdopen(),
-    feof(),
-    ferror(),
-    fflush(),
-    fgetc(),
-    fgets(),
-    fileno(),
-    fopen(),
-    fprintf(),yes
-    fputc(),yes
-    fputs(),yes
-    fread(),
-    freopen(),
-    fscanf(),
-    fwrite(),yes
-    getc(),
-    getchar(),
-    gets(),
-    open(),yes
-    perror(),yes
-    poll(),yes
-    printf(),yes
-    pread(),
-    pselect(),
-    putc(),yes
-    putchar(),yes
-    puts(),yes
-    pwrite(),
-    read(),yes
-    scanf(),
-    select(),yes
-    setbuf(),
-    setvbuf(),
-    stderr,
-    stdin,
-    stdout,
-    ungetc(),
-    vfprintf(),yes
-    vfscanf(),
-    vprintf(),yes
-    vscanf(),
-    write(),yes
-
-.. _posix_option_group_barriers:
-
-POSIX_BARRIERS
-==============
-
-.. csv-table:: POSIX_BARRIERS
-   :header: API, Supported
-   :widths: 50,10
-
-    pthread_barrier_destroy(),yes
-    pthread_barrier_init(),yes
-    pthread_barrier_wait(),yes
-    pthread_barrierattr_destroy(),yes
-    pthread_barrierattr_init(),yes
-
-.. _posix_option_group_clock_selection:
-
-POSIX_CLOCK_SELECTION
-=====================
-
-.. csv-table:: POSIX_CLOCK_SELECTION
-   :header: API, Supported
-   :widths: 50,10
-
-    pthread_condattr_getclock(),yes
-    pthread_condattr_setclock(),yes
-    clock_nanosleep(),yes
-
-.. _posix_option_group_file_system:
-
-POSIX_FILE_SYSTEM
-=================
-
-.. csv-table:: POSIX_FILE_SYSTEM
-   :header: API, Supported
-   :widths: 50,10
-
-    access(),
-    chdir(),
-    closedir(), yes
-    creat(),
-    fchdir(),
-    fpathconf(),
-    fstat(), yes
-    fstatvfs(),
-    getcwd(),
-    link(),
-    mkdir(), yes
-    mkstemp(),
-    opendir(), yes
-    pathconf(),
-    readdir(), yes
-    remove(),
-    rename(), yes
-    rewinddir(),
-    rmdir(),
-    stat(), yes
-    statvfs(),
-    tmpfile(),
-    tmpnam(),
-    truncate(),
-    unlink(), yes
-    utime(),
-
-.. _posix_option_group_mapped_files:
-
-POSIX_MAPPED_FILES
-==================
-
-.. csv-table:: POSIX_MAPPED_FILES
-   :header: API, Supported
-   :widths: 50,10
-
-    mmap(),yes
-    msync(),yes
-    munmap(),yes
-
-.. _posix_option_group_networking:
-
-POSIX_NETWORKING
-================
-
-.. csv-table:: POSIX_NETWORKING
-   :header: API, Supported
-   :widths: 50,10
-
-    accept(),yes
-    bind(),yes
-    connect(),yes
-    endhostent(),yes
-    endnetent(),yes
-    endprotoent(),yes
-    endservent(),yes
-    freeaddrinfo(),yes
-    gai_strerror(),yes
-    getaddrinfo(),yes
-    gethostent(),yes
-    gethostname(),yes
-    getnameinfo(),yes
-    getnetbyaddr(),yes
-    getnetbyname(),yes
-    getnetent(),yes
-    getpeername(),yes
-    getprotobyname(),yes
-    getprotobynumber(),yes
-    getprotoent(),yes
-    getservbyname(),yes
-    getservbyport(),yes
-    getservent(),yes
-    getsockname(),yes
-    getsockopt(),yes
-    htonl(),yes
-    htons(),yes
-    if_freenameindex(),yes
-    if_indextoname(),yes
-    if_nameindex(),yes
-    if_nametoindex(),yes
-    inet_addr(),yes
-    inet_ntoa(),yes
-    inet_ntop(),yes
-    inet_pton(),yes
-    listen(),yes
-    ntohl(),yes
-    ntohs(),yes
-    recv(),yes
-    recvfrom(),yes
-    recvmsg(),yes
-    send(),yes
-    sendmsg(),yes
-    sendto(),yes
-    sethostent(),yes
-    setnetent(),yes
-    setprotoent(),yes
-    setservent(),yes
-    setsockopt(),yes
-    shutdown(),yes
-    socket(),yes
-    sockatmark(),yes (will fail with ``ENOSYS``:ref:`†<posix_undefined_behaviour>`)
-    socketpair(),yes
-
-.. _posix_option_group_pipe:
-
-POSIX_PIPE
-==========
-
-.. csv-table:: POSIX_PIPE
-   :header: API, Supported
-   :widths: 50,10
-
-    pipe(),
-
-.. _posix_option_group_semaphores:
-
-POSIX_SEMAPHORES
-================
-
-.. csv-table:: POSIX_SEMAPHORES
-   :header: API, Supported
-   :widths: 50,10
-
-    sem_close(),yes
-    sem_destroy(),yes
-    sem_getvalue(),yes
-    sem_init(),yes
-    sem_open(),yes
-    sem_post(),yes
-    sem_trywait(),yes
-    sem_unlink(),yes
-    sem_wait(),yes
-
-.. _posix_option_group_spin_locks:
-
-POSIX_SPIN_LOCKS
-================
-
-.. csv-table:: POSIX_SPIN_LOCKS
-   :header: API, Supported
-   :widths: 50,10
-
-    pthread_spin_destroy(),yes
-    pthread_spin_init(),yes
-    pthread_spin_lock(),yes
-    pthread_spin_trylock(),yes
-    pthread_spin_unlock(),yes
-
-.. _posix_option_group_timers:
-
-POSIX_TIMERS
-============
-
-.. csv-table:: POSIX_TIMERS
-   :header: API, Supported
-   :widths: 50,10
-
-    clock_getres(),yes
-    clock_gettime(),yes
-    clock_settime(),yes
-    nanosleep(),yes
-    timer_create(),yes
-    timer_delete(),yes
-    timer_gettime(),yes
-    timer_getoverrun(),yes
-    timer_settime(),yes
-
-.. _posix_option_group_fd_mgmt:
-
-POSIX_FD_MGMT
-=============
-
-This table lists service support status in Zephyr for `POSIX_FD_MGMT`:
-
-.. csv-table:: POSIX_FD_MGMT
-   :header: API, Supported
-   :widths: 50,10
-
-    dup(),
-    dup2(),
-    fcntl(),
-    fgetpos(),
-    fseek(),
-    fseeko(),
-    fsetpos(),
-    ftell(),
-    ftello(),
-    ftruncate(),yes
-    lseek(),
-    rewind(),
-
-.. _posix_option_group_file_locking:
-
-POSIX_FILE_LOCKING
-==================
-
-This table lists service support status in Zephyr for `POSIX_FD_MGMT`:
-
-.. csv-table:: POSIX_FILE_LOCKING
-   :header: API, Supported
-   :widths: 50,10
-
-    flockfile(),
-    ftrylockfile(),
-    funlockfile(),
-    getc_unlocked(),
-    getchar_unlocked(),
-    putc_unlocked(),
-    putchar_unlocked(),
-
-.. _posix_option_group_memory_protection:
-
-POSIX_MEMORY_PROTECTION
-=======================
-
-.. csv-table:: POSIX_MEMORY_PROTECTION
-   :header: API, Supported
-   :widths: 50,10
-
-    mprotect(), yes :ref:`†<posix_undefined_behaviour>`
-
-.. _posix_option_group_multi_process:
-
-POSIX_MULTI_PROCESS
-===================
-
-.. csv-table:: POSIX_MULTI_PROCESS
-   :header: API, Supported
-   :widths: 50,10
-
-    _Exit(), yes
-    _exit(), yes
-    assert(), yes
-    atexit(),:ref:`†<posix_undefined_behaviour>`
-    clock(),
-    execl(),:ref:`†<posix_undefined_behaviour>`
-    execle(),:ref:`†<posix_undefined_behaviour>`
-    execlp(),:ref:`†<posix_undefined_behaviour>`
-    execv(),:ref:`†<posix_undefined_behaviour>`
-    execve(),:ref:`†<posix_undefined_behaviour>`
-    execvp(),:ref:`†<posix_undefined_behaviour>`
-    exit(), yes
-    fork(),:ref:`†<posix_undefined_behaviour>`
-    getpgrp(),:ref:`†<posix_undefined_behaviour>`
-    getpgid(),:ref:`†<posix_undefined_behaviour>`
-    getpid(), yes :ref:`†<posix_undefined_behaviour>`
-    getppid(),:ref:`†<posix_undefined_behaviour>`
-    getsid(),:ref:`†<posix_undefined_behaviour>`
-    setsid(),:ref:`†<posix_undefined_behaviour>`
-    sleep(),yes
-    times(),
-    wait(),:ref:`†<posix_undefined_behaviour>`
-    waitid(),:ref:`†<posix_undefined_behaviour>`
-    waitpid(),:ref:`†<posix_undefined_behaviour>`
-
 .. _posix_options:
 
-Additional POSIX Options
-========================
+POSIX Options
+=============
 
 .. _posix_option_asynchronous_io:
 
@@ -819,18 +825,6 @@ _POSIX_THREAD_ATTR_STACKADDR
     pthread_attr_getstackaddr(),yes
     pthread_attr_setstackaddr(),yes
 
-.. _posix_option_thread_cputime:
-
-_POSIX_THREAD_CPUTIME
-+++++++++++++++++++++
-
-.. csv-table:: _POSIX_THREAD_CPUTIME
-   :header: API, Supported
-   :widths: 50,10
-
-    CLOCK_THREAD_CPUTIME_ID,yes
-    pthread_getcpuclockid(),yes
-
 .. _posix_option_thread_attr_stacksize:
 
 _POSIX_THREAD_ATTR_STACKSIZE
@@ -843,24 +837,17 @@ _POSIX_THREAD_ATTR_STACKSIZE
     pthread_attr_getstacksize(),yes
     pthread_attr_setstacksize(),yes
 
-.. _posix_option_thread_priority_scheduling:
+.. _posix_option_thread_cputime:
 
-_POSIX_THREAD_PRIORITY_SCHEDULING
-+++++++++++++++++++++++++++++++++
+_POSIX_THREAD_CPUTIME
++++++++++++++++++++++
 
-.. csv-table:: _POSIX_THREAD_PRIORITY_SCHEDULING
+.. csv-table:: _POSIX_THREAD_CPUTIME
    :header: API, Supported
    :widths: 50,10
 
-    pthread_attr_getinheritsched(),yes
-    pthread_attr_getschedpolicy(),yes
-    pthread_attr_getscope(),yes
-    pthread_attr_setinheritsched(),yes
-    pthread_attr_setschedpolicy(),yes
-    pthread_attr_setscope(),yes
-    pthread_getschedparam(),yes
-    pthread_setschedparam(),yes
-    pthread_setschedprio(),yes
+    CLOCK_THREAD_CPUTIME_ID,yes
+    pthread_getcpuclockid(),yes
 
 .. _posix_option_thread_prio_inherit:
 
@@ -889,6 +876,25 @@ _POSIX_THREAD_PRIO_PROTECT
     pthread_mutexattr_getprotocol(),yes
     pthread_mutexattr_setprioceiling(),
     pthread_mutexattr_setprotocol(),yes
+
+.. _posix_option_thread_priority_scheduling:
+
+_POSIX_THREAD_PRIORITY_SCHEDULING
++++++++++++++++++++++++++++++++++
+
+.. csv-table:: _POSIX_THREAD_PRIORITY_SCHEDULING
+   :header: API, Supported
+   :widths: 50,10
+
+    pthread_attr_getinheritsched(),yes
+    pthread_attr_getschedpolicy(),yes
+    pthread_attr_getscope(),yes
+    pthread_attr_setinheritsched(),yes
+    pthread_attr_setschedpolicy(),yes
+    pthread_attr_setscope(),yes
+    pthread_getschedparam(),yes
+    pthread_setschedparam(),yes
+    pthread_setschedprio(),yes
 
 .. _posix_thread_safe_functions:
 

--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -1,7 +1,7 @@
-.. _posix_option_groups:
+POSIX Option and Option Group Details
+#####################################
 
-Subprofiling Option Groups
-##########################
+.. _posix_option_groups:
 
 POSIX Option Groups
 ===================
@@ -9,7 +9,7 @@ POSIX Option Groups
 .. _posix_option_group_barriers:
 
 POSIX_BARRIERS
-==============
+++++++++++++++
 
 .. csv-table:: POSIX_BARRIERS
    :header: API, Supported
@@ -24,7 +24,7 @@ POSIX_BARRIERS
 .. _posix_option_group_c_lang_jump:
 
 POSIX_C_LANG_JUMP
-=================
++++++++++++++++++
 
 The ``POSIX_C_LANG_JUMP`` Option Group is included in the ISO C standard.
 
@@ -42,7 +42,7 @@ The ``POSIX_C_LANG_JUMP`` Option Group is included in the ISO C standard.
 .. _posix_option_group_c_lang_math:
 
 POSIX_C_LANG_MATH
-=================
++++++++++++++++++
 
 The ``POSIX_C_LANG_MATH`` Option Group is included in the ISO C standard.
 
@@ -56,7 +56,7 @@ Group.
 .. _posix_option_group_c_lang_support:
 
 POSIX_C_LANG_SUPPORT
-====================
+++++++++++++++++++++
 
 The POSIX_C_LANG_SUPPORT option group contains the general ISO C Library.
 
@@ -73,7 +73,7 @@ to :ref:`details<language_support>`.
 .. _posix_option_group_c_lib_ext:
 
 POSIX_C_LIB_EXT
-===============
++++++++++++++++
 
 .. csv-table:: POSIX_C_LIB_EXT
    :header: API, Supported
@@ -98,7 +98,7 @@ POSIX_C_LIB_EXT
 .. _posix_option_group_clock_selection:
 
 POSIX_CLOCK_SELECTION
-=====================
++++++++++++++++++++++
 
 .. csv-table:: POSIX_CLOCK_SELECTION
    :header: API, Supported
@@ -111,7 +111,7 @@ POSIX_CLOCK_SELECTION
 .. _posix_option_group_device_io:
 
 POSIX_DEVICE_IO
-===============
++++++++++++++++
 
 .. csv-table:: POSIX_DEVICE_IO
    :header: API, Supported
@@ -170,7 +170,7 @@ POSIX_DEVICE_IO
 .. _posix_option_group_fd_mgmt:
 
 POSIX_FD_MGMT
-=============
++++++++++++++
 
 This table lists service support status in Zephyr for `POSIX_FD_MGMT`:
 
@@ -194,7 +194,7 @@ This table lists service support status in Zephyr for `POSIX_FD_MGMT`:
 .. _posix_option_group_file_locking:
 
 POSIX_FILE_LOCKING
-==================
+++++++++++++++++++
 
 This table lists service support status in Zephyr for `POSIX_FD_MGMT`:
 
@@ -213,7 +213,7 @@ This table lists service support status in Zephyr for `POSIX_FD_MGMT`:
 .. _posix_option_group_file_system:
 
 POSIX_FILE_SYSTEM
-=================
++++++++++++++++++
 
 .. csv-table:: POSIX_FILE_SYSTEM
    :header: API, Supported
@@ -249,7 +249,7 @@ POSIX_FILE_SYSTEM
 .. _posix_option_group_mapped_files:
 
 POSIX_MAPPED_FILES
-==================
+++++++++++++++++++
 
 .. csv-table:: POSIX_MAPPED_FILES
    :header: API, Supported
@@ -262,7 +262,7 @@ POSIX_MAPPED_FILES
 .. _posix_option_group_memory_protection:
 
 POSIX_MEMORY_PROTECTION
-=======================
++++++++++++++++++++++++
 
 .. csv-table:: POSIX_MEMORY_PROTECTION
    :header: API, Supported
@@ -273,7 +273,7 @@ POSIX_MEMORY_PROTECTION
 .. _posix_option_group_multi_process:
 
 POSIX_MULTI_PROCESS
-===================
++++++++++++++++++++
 
 .. csv-table:: POSIX_MULTI_PROCESS
    :header: API, Supported
@@ -307,7 +307,7 @@ POSIX_MULTI_PROCESS
 .. _posix_option_group_networking:
 
 POSIX_NETWORKING
-================
+++++++++++++++++
 
 The function ``sockatmark()`` is not yet supported and is expected to fail setting ``errno``
 to ``ENOSYS`` :ref:`†<posix_undefined_behaviour>`.
@@ -373,7 +373,7 @@ to ``ENOSYS`` :ref:`†<posix_undefined_behaviour>`.
 .. _posix_option_group_pipe:
 
 POSIX_PIPE
-==========
+++++++++++
 
 .. csv-table:: POSIX_PIPE
    :header: API, Supported
@@ -384,7 +384,7 @@ POSIX_PIPE
 .. _posix_option_group_realtime_signals:
 
 POSIX_REALTIME_SIGNALS
-======================
+++++++++++++++++++++++
 
 .. csv-table:: POSIX_REALTIME_SIGNALS
    :header: API, Supported
@@ -397,7 +397,7 @@ POSIX_REALTIME_SIGNALS
 .. _posix_option_group_semaphores:
 
 POSIX_SEMAPHORES
-================
+++++++++++++++++
 
 .. csv-table:: POSIX_SEMAPHORES
    :header: API, Supported
@@ -416,7 +416,7 @@ POSIX_SEMAPHORES
 .. _posix_option_group_signal_jump:
 
 POSIX_SIGNAL_JUMP
-=================
++++++++++++++++++
 
 .. csv-table:: POSIX_SIGNAL_JUMP
    :header: API, Supported
@@ -428,7 +428,7 @@ POSIX_SIGNAL_JUMP
 .. _posix_option_group_signals:
 
 POSIX_SIGNALS
-=============
++++++++++++++
 
 Signal services are a basic mechanism within POSIX-based systems and are
 required for error and event handling.
@@ -458,7 +458,7 @@ required for error and event handling.
 .. _posix_option_group_single_process:
 
 POSIX_SINGLE_PROCESS
-====================
+++++++++++++++++++++
 
 The POSIX_SINGLE_PROCESS option group contains services for single
 process applications.
@@ -479,7 +479,7 @@ process applications.
 .. _posix_option_group_spin_locks:
 
 POSIX_SPIN_LOCKS
-================
+++++++++++++++++
 
 .. csv-table:: POSIX_SPIN_LOCKS
    :header: API, Supported
@@ -494,7 +494,7 @@ POSIX_SPIN_LOCKS
 .. _posix_option_group_threads_base:
 
 POSIX_THREADS_BASE
-==================
+++++++++++++++++++
 
 The basic assumption in this profile is that the system
 consists of a single (implicit) process with multiple threads. Therefore, the
@@ -557,7 +557,7 @@ multiple processes.
 .. _posix_option_group_posix_threads_ext:
 
 POSIX_THREADS_EXT
-=================
++++++++++++++++++
 
 This table lists service support status in Zephyr:
 
@@ -573,7 +573,7 @@ This table lists service support status in Zephyr:
 .. _posix_option_group_timers:
 
 POSIX_TIMERS
-============
+++++++++++++
 
 .. csv-table:: POSIX_TIMERS
    :header: API, Supported
@@ -592,7 +592,7 @@ POSIX_TIMERS
 .. _posix_option_group_xsi_system_logging:
 
 XSI_SYSTEM_LOGGING
-==================
+++++++++++++++++++
 
 .. csv-table:: XSI_SYSTEM_LOGGING
    :header: API, Supported
@@ -606,7 +606,7 @@ XSI_SYSTEM_LOGGING
 .. _posix_option_group_xsi_threads_ext:
 
 XSI_THREADS_EXT
-===============
++++++++++++++++
 
 The XSI_THREADS_EXT option group is required because it provides
 functions to control a thread's stack. This is considered useful for any


### PR DESCRIPTION
* reorder posix options and option groups so that they are
  in alphabetical order in documentation.
* decrement header level of option group items so that they
  are not listed in the outline
* make column size consistent
* note which Kconfig option is used to activate each POSIX Option or Option Group to address [this comment](https://github.com/zephyrproject-rtos/zephyr/pull/76112#discussion_r1684577823).

[Doc Preview](https://builds.zephyrproject.io/zephyr/pr/76114/docs/services/portability/posix/index.html)