### PR TITLE
doc: porting_guide: fix ReStructuredText in Kconfig.plank

### DIFF
--- a/doc/hardware/porting/board_porting.rst
+++ b/doc/hardware/porting/board_porting.rst
@@ -536,8 +536,8 @@ files for a board named ``plank``:
      config BOARD_PLANK
              select SOC_SOC1
 
-  The Kconfig symbols :kconfig:option:`BOARD_<board>` and
-  :kconfig:option:`BOARD_<normalized_board_target>` are constructed by the build
+  The Kconfig symbols :samp:`BOARD_{board}` and
+  :samp:`BOARD_{normalized_board_target}` are constructed by the build
   system, therefore no type shall be defined in above code snippet.
 
 :file:`Kconfig`


### PR DESCRIPTION
Using <  > in the kconfig:option role was causing the <_board> section to be omitted from the rendered docs, and using the role was useless anyway as the option name was not a real one.
Use the fancy :samp: role instead to achieve the same goal.

before

<img width="843" alt="image" src="https://github.com/user-attachments/assets/7aea8579-428c-40ff-80b4-592c4f418d85">

after

<img width="805" alt="image" src="https://github.com/user-attachments/assets/b0e65e33-6c46-4ca6-ab1a-cc60dcc29a6d">

