### PR TITLE
kernel: Remove ALWAYS_INLINE from z_unpend_thread_no_timeout()

### DIFF
--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -57,7 +57,6 @@ void *z_get_next_switch_handle(void *interrupted);
 
 void z_time_slice(void);
 void z_reset_time_slice(struct k_thread *curr);
-void z_sched_abort(struct k_thread *thread);
 void z_sched_ipi(void);
 void z_sched_start(struct k_thread *thread);
 void z_ready_thread(struct k_thread *thread);

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -623,7 +623,7 @@ static inline void unpend_thread_no_timeout(struct k_thread *thread)
 	thread->base.pended_on = NULL;
 }
 
-ALWAYS_INLINE void z_unpend_thread_no_timeout(struct k_thread *thread)
+void z_unpend_thread_no_timeout(struct k_thread *thread)
 {
 	K_SPINLOCK(&_sched_spinlock) {
 		if (thread->base.pended_on != NULL) {


### PR DESCRIPTION
A little bit of kernel housekeeping.

1. Removes the declaration for z_sched_abort() as that routine no longer exists.

2. Removes the ALWAYS_INLINE attribute from the definition of the routine z_unpend_thread_no_timeout() to fix an unresolved symbol error that was occurring with some compilers.  (Fixes #75704)