### PR TITLE
scripts: west_commands: runners: propagate arguments

### DIFF
--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -284,13 +284,14 @@ def do_run_common(command, user_args, user_runner_args, domain_file=None):
         if len(entry.boards) == 0:
             del used_cmds[i]
 
+    prev_runner = None
     for d in domains:
-        do_run_common_image(command, user_args, user_runner_args,
-                            used_cmds, board_image_count, d.build_dir)
+        prev_runner = do_run_common_image(command, user_args, user_runner_args, used_cmds,
+                                          board_image_count, d.build_dir, prev_runner)
 
 
 def do_run_common_image(command, user_args, user_runner_args, used_cmds,
-                        board_image_count, build_dir=None,):
+                        board_image_count, build_dir=None, prev_runner=None):
     global re
     command_name = command.name
     if build_dir is None:
@@ -440,6 +441,10 @@ def do_run_common_image(command, user_args, user_runner_args, used_cmds,
     if unknown:
         log.die(f'runner {runner_name} received unknown arguments: {unknown}')
 
+    # Propagate useful args from previous domain invocations
+    if prev_runner is not None:
+        runner_cls.args_from_previous_runner(prev_runner, args)
+
     # Override args with any user_args. The latter must take
     # precedence, or e.g. --hex-file on the command line would be
     # ignored in favor of a board.cmake setting.
@@ -470,6 +475,7 @@ def do_run_common_image(command, user_args, user_runner_args, used_cmds,
         else:
             log.err('verbose mode enabled, dumping stack:', fatal=True)
             raise
+    return runner
 
 def get_build_dir(args, die_if_none=True):
     # Get the build directory for the given argument list and environment.

--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -625,6 +625,15 @@ class ZephyrBinaryRunner(abc.ABC):
         '''Hook for adding runner-specific options.'''
 
     @classmethod
+    def args_from_previous_runner(cls, previous_runner,
+                                  args: argparse.Namespace):
+        '''Update arguments from a previously created runner.
+
+        This is intended for propagating relevant user responses
+        between multiple runs of the same runner, for example a
+        JTAG serial number.'''
+
+    @classmethod
     def create(cls, cfg: RunnerConfig,
                args: argparse.Namespace) -> 'ZephyrBinaryRunner':
         '''Create an instance from command-line arguments.

--- a/scripts/west_commands/runners/nrf_common.py
+++ b/scripts/west_commands/runners/nrf_common.py
@@ -89,6 +89,12 @@ class NrfBinaryRunner(ZephyrBinaryRunner):
 
         parser.set_defaults(reset=True)
 
+    @classmethod
+    def args_from_previous_runner(cls, previous_runner, args):
+        # Propagate the chosen device ID to next runner
+        if args.dev_id is None:
+            args.dev_id = previous_runner.dev_id
+
     def ensure_snr(self):
         if not self.dev_id or "*" in self.dev_id:
             self.dev_id = self.get_board_snr(self.dev_id or "*")


### PR DESCRIPTION
Provide a mechanism to propagate useful arguments from one runner to the next. The primary use case for this is to propagate a JLink serial number, so that if it is queried from the terminal the user only needs to make the choice once.

Implements #76077.