### PR TITLE
drivers: mipi_dbi: reduce the RAM overhead

### DIFF
--- a/drivers/mipi_dbi/mipi_dbi_nxp_lcdic.c
+++ b/drivers/mipi_dbi/mipi_dbi_nxp_lcdic.c
@@ -660,7 +660,7 @@ static int mipi_dbi_lcdic_init(const struct device *dev)
 	return 0;
 }
 
-static struct mipi_dbi_driver_api mipi_dbi_lcdic_driver_api = {
+static const struct mipi_dbi_driver_api mipi_dbi_lcdic_driver_api = {
 	.command_write = mipi_dbi_lcdic_write_cmd,
 	.write_display = mipi_dbi_lcdic_write_display,
 	.reset = mipi_dbi_lcdic_reset,

--- a/drivers/mipi_dbi/mipi_dbi_smartbond.c
+++ b/drivers/mipi_dbi/mipi_dbi_smartbond.c
@@ -536,7 +536,7 @@ static int mipi_dbi_smartbond_init(const struct device *dev)
 	return ret;
 }
 
-static struct mipi_dbi_driver_api mipi_dbi_smartbond_driver_api = {
+static const struct mipi_dbi_driver_api mipi_dbi_smartbond_driver_api = {
 #if MIPI_DBI_SMARTBOND_IS_RESET_AVAILABLE
 	.reset = mipi_dbi_smartbond_reset,
 #endif

--- a/drivers/mipi_dbi/mipi_dbi_spi.c
+++ b/drivers/mipi_dbi/mipi_dbi_spi.c
@@ -23,9 +23,9 @@ struct mipi_dbi_spi_config {
 };
 
 struct mipi_dbi_spi_data {
+	struct k_mutex lock;
 	/* Used for 3 wire mode */
 	uint16_t spi_byte;
-	struct k_mutex lock;
 };
 
 /* Expands to 1 if the node does not have the `write-only` property */
@@ -313,7 +313,7 @@ static int mipi_dbi_spi_init(const struct device *dev)
 	return 0;
 }
 
-static struct mipi_dbi_driver_api mipi_dbi_spi_driver_api = {
+static const struct mipi_dbi_driver_api mipi_dbi_spi_driver_api = {
 	.reset = mipi_dbi_spi_reset,
 	.command_write = mipi_dbi_spi_command_write,
 	.write_display = mipi_dbi_spi_write_display,


### PR DESCRIPTION
Constify the config and reorder the data fields for better packing. This reduces the RAM usage of `mipi_dbi_spi` by 20 bytes.