### PR TITLE
drivers: mipi_dbi: reduce ROM usage by changing the reset time to k_timeout_t

### DIFF
--- a/drivers/mipi_dbi/mipi_dbi_nxp_flexio_lcdif.c
+++ b/drivers/mipi_dbi/mipi_dbi_nxp_flexio_lcdif.c
@@ -336,7 +336,7 @@ static int mipi_dbi_flexio_lcdif_command_write(const struct device *dev,
 
 }
 
-static int mipi_dbi_flexio_lcdif_reset(const struct device *dev, uint32_t delay)
+static int mipi_dbi_flexio_lcdif_reset(const struct device *dev, k_timeout_t delay)
 {
 	int err;
 	const struct mcux_flexio_lcdif_config *config = dev->config;
@@ -357,7 +357,7 @@ static int mipi_dbi_flexio_lcdif_reset(const struct device *dev, uint32_t delay)
 		return err;
 	}
 
-	k_msleep(delay);
+	k_sleep(delay);
 
 	err = gpio_pin_set_dt(&config->reset, 1);
 	if (err < 0) {

--- a/drivers/mipi_dbi/mipi_dbi_nxp_lcdic.c
+++ b/drivers/mipi_dbi/mipi_dbi_nxp_lcdic.c
@@ -558,12 +558,13 @@ out:
 	return ret;
 }
 
-static int mipi_dbi_lcdic_reset(const struct device *dev, uint32_t delay)
+static int mipi_dbi_lcdic_reset(const struct device *dev, k_timeout_t delay)
 {
 	const struct mipi_dbi_lcdic_config *config = dev->config;
 	LCDIC_Type *base = config->base;
 	uint32_t lcdic_freq;
 	uint8_t rst_width, pulse_cnt;
+	uint32_t delay_ms = k_ticks_to_ms_ceil32(delay);
 
 	/* Calculate delay based off timer0 ratio. Formula given
 	 * by RM is as follows:
@@ -574,8 +575,7 @@ static int mipi_dbi_lcdic_reset(const struct device *dev, uint32_t delay)
 				   &lcdic_freq)) {
 		return -EIO;
 	}
-	rst_width = (delay * (lcdic_freq)) /
-			((1 << LCDIC_TIMER0_RATIO) * MSEC_PER_SEC);
+	rst_width = (delay_ms * (lcdic_freq)) / ((1 << LCDIC_TIMER0_RATIO) * MSEC_PER_SEC);
 	/* If rst_width is larger than max value supported by hardware,
 	 * increase the pulse count (rounding up)
 	 */

--- a/drivers/mipi_dbi/mipi_dbi_smartbond.c
+++ b/drivers/mipi_dbi/mipi_dbi_smartbond.c
@@ -123,7 +123,7 @@ static void mipi_dbi_smartbond_send_single_frame(const struct device *dev)
 }
 
 #if MIPI_DBI_SMARTBOND_IS_RESET_AVAILABLE
-static int mipi_dbi_smartbond_reset(const struct device *dev, uint32_t delay)
+static int mipi_dbi_smartbond_reset(const struct device *dev, k_timeout_t delay)
 {
 	const struct mipi_dbi_smartbond_config *config = dev->config;
 	int ret;
@@ -138,7 +138,7 @@ static int mipi_dbi_smartbond_reset(const struct device *dev, uint32_t delay)
 		LOG_ERR("Cannot drive reset signal");
 		return ret;
 	}
-	k_msleep(delay);
+	k_sleep(delay);
 
 	return gpio_pin_set_dt(&config->reset, 0);
 }

--- a/drivers/mipi_dbi/mipi_dbi_spi.c
+++ b/drivers/mipi_dbi/mipi_dbi_spi.c
@@ -250,7 +250,7 @@ static inline bool mipi_dbi_has_pin(const struct gpio_dt_spec *spec)
 	return spec->port != NULL;
 }
 
-static int mipi_dbi_spi_reset(const struct device *dev, uint32_t delay)
+static int mipi_dbi_spi_reset(const struct device *dev, k_timeout_t delay)
 {
 	const struct mipi_dbi_spi_config *config = dev->config;
 	int ret;
@@ -263,7 +263,7 @@ static int mipi_dbi_spi_reset(const struct device *dev, uint32_t delay)
 	if (ret < 0) {
 		return ret;
 	}
-	k_msleep(delay);
+	k_sleep(delay);
 	return gpio_pin_set_dt(&config->reset, 0);
 }
 

--- a/include/zephyr/drivers/mipi_dbi.h
+++ b/include/zephyr/drivers/mipi_dbi.h
@@ -138,7 +138,7 @@ __subsystem struct mipi_dbi_driver_api {
 			     const uint8_t *framebuf,
 			     struct display_buffer_descriptor *desc,
 			     enum display_pixel_format pixfmt);
-	int (*reset)(const struct device *dev, uint32_t delay);
+	int (*reset)(const struct device *dev, k_timeout_t delay);
 	int (*release)(const struct device *dev,
 		       const struct mipi_dbi_config *config);
 };
@@ -247,13 +247,13 @@ static inline int mipi_dbi_write_display(const struct device *dev,
  *
  * Resets the attached display controller.
  * @param dev mipi dbi controller
- * @param delay duration to set reset signal for, in milliseconds
+ * @param delay_ms duration to set reset signal for, in milliseconds
  * @retval 0 reset succeeded
  * @retval -EIO I/O error
  * @retval -ENOSYS not implemented
  * @retval -ENOTSUP not supported
  */
-static inline int mipi_dbi_reset(const struct device *dev, uint32_t delay)
+static inline int mipi_dbi_reset(const struct device *dev, uint32_t delay_ms)
 {
 	const struct mipi_dbi_driver_api *api =
 		(const struct mipi_dbi_driver_api *)dev->api;
@@ -261,7 +261,7 @@ static inline int mipi_dbi_reset(const struct device *dev, uint32_t delay)
 	if (api->reset == NULL) {
 		return -ENOSYS;
 	}
-	return api->reset(dev, delay);
+	return api->reset(dev, K_MSEC(delay_ms));
 }
 
 /**


### PR DESCRIPTION
Calling k_msleep() leads to a int64_t division, causing udivdi3 and similar to be linked in.

Keep the outer API the same, but switch to k_timeout_t before passing to the inner API. This saves 1916 B of ROM.