### PR TITLE
drivers: intc: nxp: convert wkpu to native driver

### DIFF
--- a/drivers/interrupt_controller/Kconfig.nxp_s32
+++ b/drivers/interrupt_controller/Kconfig.nxp_s32
@@ -1,6 +1,6 @@
 # Configuration for NXP S32 external interrupt controller
 
-# Copyright 2022-2023 NXP
+# Copyright 2022-2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 config NXP_S32_EIRQ
@@ -34,6 +34,17 @@ config NXP_S32_WKPU
 	bool "Wake-up Unit interrupt controller driver for NXP S32 MCUs"
 	default y
 	depends on DT_HAS_NXP_S32_WKPU_ENABLED
-	select NOCACHE_MEMORY
 	help
 	  Wake-up Unit interrupt controller driver for NXP S32 MCUs
+
+if NXP_S32_WKPU
+
+config NXP_S32_WKPU_SOURCES_MAX
+	int
+	range 32 64
+	default 64 if SOC_SERIES_S32K3
+	help
+	  Number of WKPU external and internal sources per controller. This is
+	  a SoC integration option.
+
+endif # NXP_S32_WKPU

--- a/drivers/interrupt_controller/intc_wkpu_nxp_s32.c
+++ b/drivers/interrupt_controller/intc_wkpu_nxp_s32.c
@@ -10,22 +10,35 @@
 #include <zephyr/device.h>
 #include <zephyr/irq.h>
 #include <zephyr/sys/sys_io.h>
+#include <zephyr/sys/math_extras.h>
 #include <zephyr/drivers/interrupt_controller/intc_wkpu_nxp_s32.h>
 
-#include <Wkpu_Ip_Irq.h>
+/* NMI Status Flag Register */
+#define WKPU_NSR       0x0
+/* NMI Configuration Register */
+#define WKPU_NCR       0x8
+/* Wakeup/Interrupt Status Flag Register */
+#define WKPU_WISR(n)   (0x14 + 0x40 * (n))
+/* Interrupt Request Enable Register */
+#define WKPU_IRER(n)   (0x18 + 0x40 * (n))
+/* Wakeup Request Enable Register */
+#define WKPU_WRER(n)   (0x1c + 0x40 * (n))
+/* Wakeup/Interrupt Rising-Edge Event Enable Register */
+#define WKPU_WIREER(n) (0x28 + 0x40 * (n))
+/* Wakeup/Interrupt Falling-Edge Event Enable Register */
+#define WKPU_WIFEER(n) (0x2c + 0x40 * (n))
+/* Wakeup/Interrupt Filter Enable Register */
+#define WKPU_WIFER(n)  (0x30 + 0x40 * (n))
 
-#define NXP_S32_NUM_CHANNELS		WKPU_IP_NUM_OF_CHANNELS
-#define NXP_S32_NUM_CHANNELS_DEBRACKET	__DEBRACKET WKPU_IP_NUM_OF_CHANNELS
+/* Handy accessors */
+#define REG_READ(r)     sys_read32(config->base + (r))
+#define REG_WRITE(r, v) sys_write32((v), config->base + (r))
 
 struct wkpu_nxp_s32_config {
-	uint8_t instance;
-
-	const WKPU_Type *base;
-
-	const Wkpu_Ip_IrqConfigType *wkpu_cfg;
+	mem_addr_t base;
+	uint64_t filter_enable;
 };
 
-/* Wrapper callback for each WKPU line, from low level driver callback to GPIO callback */
 struct wkpu_nxp_s32_cb {
 	wkpu_nxp_s32_callback_t cb;
 	uint8_t pin;
@@ -36,60 +49,109 @@ struct wkpu_nxp_s32_data {
 	struct wkpu_nxp_s32_cb *cb;
 };
 
-int wkpu_nxp_s32_set_callback(const struct device *dev, uint8_t line,
-				wkpu_nxp_s32_callback_t cb, uint8_t pin, void *arg)
+static void wkpu_nxp_s32_interrupt_handler(const struct device *dev)
+{
+	const struct wkpu_nxp_s32_config *config = dev->config;
+	struct wkpu_nxp_s32_data *data = dev->data;
+	uint64_t pending = wkpu_nxp_s32_get_pending(dev);
+	uint64_t irq_mask;
+	int irq;
+
+	while (pending) {
+		irq_mask = LSB_GET(pending);
+		irq = u64_count_trailing_zeros(irq_mask);
+
+		/* Clear status flag */
+		REG_WRITE(WKPU_WISR(irq / 32U), REG_READ(WKPU_WISR(irq / 32U)) | irq_mask);
+
+		if (data->cb[irq].cb != NULL) {
+			data->cb[irq].cb(data->cb[irq].pin, data->cb[irq].data);
+		}
+
+		pending ^= irq_mask;
+	}
+}
+
+int wkpu_nxp_s32_set_callback(const struct device *dev, uint8_t irq, uint8_t pin,
+			      wkpu_nxp_s32_callback_t cb, void *arg)
 {
 	struct wkpu_nxp_s32_data *data = dev->data;
 
-	__ASSERT(line < NXP_S32_NUM_CHANNELS, "Interrupt line is out of range");
+	__ASSERT_NO_MSG(irq < CONFIG_NXP_S32_WKPU_SOURCES_MAX);
 
-	if ((data->cb[line].cb == cb) && (data->cb[line].data == arg)) {
+	if ((data->cb[irq].cb == cb) && (data->cb[irq].data == arg)) {
 		return 0;
 	}
 
-	if (data->cb[line].cb) {
+	if (data->cb[irq].cb) {
 		return -EBUSY;
 	}
 
-	data->cb[line].cb   = cb;
-	data->cb[line].pin  = pin;
-	data->cb[line].data = arg;
+	data->cb[irq].cb = cb;
+	data->cb[irq].pin = pin;
+	data->cb[irq].data = arg;
 
 	return 0;
 }
 
-void wkpu_nxp_s32_unset_callback(const struct device *dev, uint8_t line)
+void wkpu_nxp_s32_unset_callback(const struct device *dev, uint8_t irq)
 {
 	struct wkpu_nxp_s32_data *data = dev->data;
 
-	__ASSERT(line < NXP_S32_NUM_CHANNELS, "Interrupt line is out of range");
+	__ASSERT_NO_MSG(irq < CONFIG_NXP_S32_WKPU_SOURCES_MAX);
 
-	data->cb[line].cb    = NULL;
-	data->cb[line].pin   = 0;
-	data->cb[line].data  = NULL;
+	data->cb[irq].cb = NULL;
+	data->cb[irq].pin = 0;
+	data->cb[irq].data = NULL;
 }
 
-void wkpu_nxp_s32_enable_interrupt(const struct device *dev, uint8_t line,
-				   Wkpu_Ip_EdgeType edge_type)
+void wkpu_nxp_s32_enable_interrupt(const struct device *dev, uint8_t irq,
+				   enum wkpu_nxp_s32_trigger trigger)
 {
 	const struct wkpu_nxp_s32_config *config = dev->config;
+	uint32_t mask = BIT(irq % 32U);
+	uint8_t reg_idx = irq / 32U;
+	uint32_t reg_val;
 
-	__ASSERT(line < NXP_S32_NUM_CHANNELS, "Interrupt line is out of range");
+	__ASSERT_NO_MSG(irq < CONFIG_NXP_S32_WKPU_SOURCES_MAX);
 
-	Wkpu_Ip_SetActivationCondition(config->instance, line, edge_type);
-	Wkpu_Ip_EnableNotification(line);
-	Wkpu_Ip_EnableInterrupt(config->instance, line);
+	/* Configure trigger */
+	reg_val = REG_READ(WKPU_WIREER(reg_idx));
+	if ((trigger == WKPU_NXP_S32_RISING_EDGE) || (trigger == WKPU_NXP_S32_BOTH_EDGES)) {
+		reg_val |= mask;
+	} else {
+		reg_val &= ~mask;
+	}
+	REG_WRITE(WKPU_WIREER(reg_idx), reg_val);
+
+	reg_val = REG_READ(WKPU_WIFEER(reg_idx));
+	if ((trigger == WKPU_NXP_S32_FALLING_EDGE) || (trigger == WKPU_NXP_S32_BOTH_EDGES)) {
+		reg_val |= mask;
+	} else {
+		reg_val &= ~mask;
+	}
+	REG_WRITE(WKPU_WIFEER(reg_idx), reg_val);
+
+	/* Clear status flag and unmask interrupt */
+	REG_WRITE(WKPU_WISR(reg_idx), REG_READ(WKPU_WISR(reg_idx)) | mask);
+	REG_WRITE(WKPU_IRER(reg_idx), REG_READ(WKPU_IRER(reg_idx)) | mask);
 }
 
-void wkpu_nxp_s32_disable_interrupt(const struct device *dev, uint8_t line)
+void wkpu_nxp_s32_disable_interrupt(const struct device *dev, uint8_t irq)
 {
 	const struct wkpu_nxp_s32_config *config = dev->config;
+	uint32_t mask = BIT(irq % 32U);
+	uint8_t reg_idx = irq / 32U;
 
-	__ASSERT(line < NXP_S32_NUM_CHANNELS, "Interrupt line is out of range");
+	__ASSERT_NO_MSG(irq < CONFIG_NXP_S32_WKPU_SOURCES_MAX);
 
-	Wkpu_Ip_DisableInterrupt(config->instance, line);
-	Wkpu_Ip_DisableNotification(line);
-	Wkpu_Ip_SetActivationCondition(config->instance, line, WKPU_IP_NONE_EDGE);
+	/* Disable triggers */
+	REG_WRITE(WKPU_WIREER(reg_idx), REG_READ(WKPU_WIREER(reg_idx)) & ~mask);
+	REG_WRITE(WKPU_WIFEER(reg_idx), REG_READ(WKPU_WIFEER(reg_idx)) & ~mask);
+
+	/* Clear status flag and mask interrupt */
+	REG_WRITE(WKPU_WISR(reg_idx), REG_READ(WKPU_WISR(reg_idx)) | mask);
+	REG_WRITE(WKPU_IRER(reg_idx), REG_READ(WKPU_IRER(reg_idx)) & ~mask);
 }
 
 uint64_t wkpu_nxp_s32_get_pending(const struct device *dev)
@@ -97,102 +159,69 @@ uint64_t wkpu_nxp_s32_get_pending(const struct device *dev)
 	const struct wkpu_nxp_s32_config *config = dev->config;
 	uint64_t flags;
 
-	flags = config->base->WISR & config->base->IRER;
-#if defined(WKPU_IP_64_CH_USED) && (WKPU_IP_64_CH_USED == STD_ON)
-	flags |= ((uint64_t)(config->base->WISR_64 & config->base->IRER_64)) << 32U;
-#endif
+	flags = REG_READ(WKPU_WISR(0U)) & REG_READ(WKPU_IRER(0U));
+	if (CONFIG_NXP_S32_WKPU_SOURCES_MAX > 32U) {
+		flags |= ((uint64_t)(REG_READ(WKPU_WISR(1U)) & REG_READ(WKPU_IRER(1U)))) << 32U;
+	}
 
 	return flags;
-}
-
-static void wkpu_nxp_s32_callback(const struct device *dev, uint8 line)
-{
-	const struct wkpu_nxp_s32_data *data = dev->data;
-
-	if (data->cb[line].cb != NULL) {
-		data->cb[line].cb(data->cb[line].pin, data->cb[line].data);
-	}
 }
 
 static int wkpu_nxp_s32_init(const struct device *dev)
 {
 	const struct wkpu_nxp_s32_config *config = dev->config;
 
-	if (Wkpu_Ip_Init(config->instance, config->wkpu_cfg)) {
-		return -EINVAL;
+	/* Disable triggers, clear status flags and mask all interrupts */
+	REG_WRITE(WKPU_WIREER(0U), 0U);
+	REG_WRITE(WKPU_WIFEER(0U), 0U);
+	REG_WRITE(WKPU_WISR(0U), 0xffffffff);
+	REG_WRITE(WKPU_IRER(0U), 0U);
+
+	/* Configure glitch filters */
+	REG_WRITE(WKPU_WIFER(0U), (uint32_t)config->filter_enable);
+
+	if (CONFIG_NXP_S32_WKPU_SOURCES_MAX > 32U) {
+		REG_WRITE(WKPU_WIREER(1U), 0U);
+		REG_WRITE(WKPU_WIFEER(1U), 0U);
+		REG_WRITE(WKPU_WISR(1U), 0xffffffff);
+		REG_WRITE(WKPU_IRER(1U), 0U);
+		REG_WRITE(WKPU_WIFER(1U), (uint32_t)(config->filter_enable >> 32U));
 	}
 
 	return 0;
 }
 
-#define WKPU_NXP_S32_CALLBACK(line, n)								\
-	void nxp_s32_wkpu_##n##wkpu_line_##line##_callback(void)				\
-	{											\
-		const struct device *dev = DEVICE_DT_INST_GET(n);				\
-												\
-		wkpu_nxp_s32_callback(dev, line);						\
-	}
+#define WKPU_NXP_S32_FILTER_CONFIG(idx, n)                                                         \
+	COND_CODE_1(DT_PROP(DT_INST_CHILD(n, irq_##idx), filter_enable), (BIT(idx)), (0U))
 
-#define WKPU_NXP_S32_CHANNEL_CONFIG(idx, n)							\
-	{											\
-		.hwChannel = idx,								\
-		.filterEn = DT_INST_PROP_OR(DT_INST_CHILD(n, line_##idx), filter_enable, 0),	\
-		.edgeEvent = WKPU_IP_NONE_EDGE,							\
-		.WkpuChannelNotification = nxp_s32_wkpu_##n##wkpu_line_##idx##_callback,	\
-		.callback = NULL,								\
-		.callbackParam = 0U								\
-	}
-
-#define WKPU_NXP_S32_CHANNELS_CONFIG(n)								\
-	static const Wkpu_Ip_ChannelConfigType wkpu_##n##_channel_nxp_s32_cfg[] = {		\
-		LISTIFY(NXP_S32_NUM_CHANNELS_DEBRACKET,	WKPU_NXP_S32_CHANNEL_CONFIG, (,), n)	\
-	}
-
-#define WKPU_NXP_S32_INSTANCE_CONFIG(n)								\
-	static const Wkpu_Ip_IrqConfigType wkpu_##n##_nxp_s32_cfg = {				\
-		.numChannels	 = NXP_S32_NUM_CHANNELS,					\
-		.pChannelsConfig = &wkpu_##n##_channel_nxp_s32_cfg,				\
-	}
-
-#define WKPU_NXP_S32_CONFIG(n)									\
-	LISTIFY(NXP_S32_NUM_CHANNELS_DEBRACKET, WKPU_NXP_S32_CALLBACK, (), n)			\
-	WKPU_NXP_S32_CHANNELS_CONFIG(n);							\
-	WKPU_NXP_S32_INSTANCE_CONFIG(n);
-
-#define WKPU_NXP_S32_INIT_DEVICE(n)								\
-	WKPU_NXP_S32_CONFIG(n)									\
-	static const struct wkpu_nxp_s32_config wkpu_nxp_s32_conf_##n = {			\
-		.instance = n,									\
-		.base = (WKPU_Type *)DT_INST_REG_ADDR(n),					\
-		.wkpu_cfg = (Wkpu_Ip_IrqConfigType *)&wkpu_##n##_nxp_s32_cfg,			\
-	};											\
-	static struct wkpu_nxp_s32_cb wkpu_nxp_s32_cb_##n[NXP_S32_NUM_CHANNELS];		\
-	static struct wkpu_nxp_s32_data wkpu_nxp_s32_data_##n = {				\
-		.cb = wkpu_nxp_s32_cb_##n,							\
-	};											\
-	static int wkpu_nxp_s32_init##n(const struct device *dev)				\
-	{											\
-		int err;									\
-												\
-		err = wkpu_nxp_s32_init(dev);							\
-		if (err) {									\
-			return err;								\
-		}										\
-												\
-		IRQ_CONNECT(DT_INST_IRQ(n, irq), DT_INST_IRQ(n, priority),			\
-			WKPU_EXT_IRQ_SINGLE_ISR, NULL,						\
-			COND_CODE_1(CONFIG_GIC, (DT_INST_IRQ(n, flags)), (0)));			\
-		irq_enable(DT_INST_IRQ(n, irq));						\
-												\
-		return 0;									\
-	}											\
-	DEVICE_DT_INST_DEFINE(n,								\
-		wkpu_nxp_s32_init##n,								\
-		NULL,										\
-		&wkpu_nxp_s32_data_##n,								\
-		&wkpu_nxp_s32_conf_##n,								\
-		PRE_KERNEL_2,									\
-		CONFIG_INTC_INIT_PRIORITY,							\
-		NULL);
+#define WKPU_NXP_S32_INIT_DEVICE(n)                                                                \
+	static const struct wkpu_nxp_s32_config wkpu_nxp_s32_conf_##n = {                          \
+		.base = DT_INST_REG_ADDR(n),                                                       \
+		.filter_enable = LISTIFY(CONFIG_NXP_S32_WKPU_SOURCES_MAX,                          \
+					 WKPU_NXP_S32_FILTER_CONFIG, (|), n),                      \
+	};                                                                                         \
+	static struct wkpu_nxp_s32_cb wkpu_nxp_s32_cb_##n[CONFIG_NXP_S32_WKPU_SOURCES_MAX];        \
+	static struct wkpu_nxp_s32_data wkpu_nxp_s32_data_##n = {                                  \
+		.cb = wkpu_nxp_s32_cb_##n,                                                         \
+	};                                                                                         \
+	static int wkpu_nxp_s32_init_##n(const struct device *dev)                                 \
+	{                                                                                          \
+		int err;                                                                           \
+                                                                                                   \
+		err = wkpu_nxp_s32_init(dev);                                                      \
+		if (err) {                                                                         \
+			return err;                                                                \
+		}                                                                                  \
+                                                                                                   \
+		IRQ_CONNECT(DT_INST_IRQ(n, irq), DT_INST_IRQ(n, priority),                         \
+			    wkpu_nxp_s32_interrupt_handler, DEVICE_DT_INST_GET(n),                 \
+			    COND_CODE_1(CONFIG_GIC, (DT_INST_IRQ(n, flags)), (0U)));               \
+		irq_enable(DT_INST_IRQ(n, irq));                                                   \
+                                                                                                   \
+		return 0;                                                                          \
+	}                                                                                          \
+	DEVICE_DT_INST_DEFINE(n, wkpu_nxp_s32_init_##n, NULL, &wkpu_nxp_s32_data_##n,              \
+			      &wkpu_nxp_s32_conf_##n, PRE_KERNEL_2, CONFIG_INTC_INIT_PRIORITY,     \
+			      NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(WKPU_NXP_S32_INIT_DEVICE)

--- a/dts/bindings/interrupt-controller/nxp,s32-wkpu.yaml
+++ b/dts/bindings/interrupt-controller/nxp,s32-wkpu.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 NXP
+# Copyright 2023-2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 description: NXP S32 Wake-up Unit
@@ -13,11 +13,11 @@ properties:
 
 child-binding:
   description: |
-    NXP S32 WKPU interrupt line configuration. Specific requirements for each
+    NXP S32 WKPU external interrupt configuration. Specific requirements for each
     interrupt line can be specified by adding children nodes to this controller,
-    labeled `line_<line_number>`. For example:
+    labeled `irq_<irq_number>`. For example:
 
-      line_0: line_0 {
+      irq_0: irq_0 {
           filter-enable;
       };
 

--- a/include/zephyr/drivers/interrupt_controller/intc_wkpu_nxp_s32.h
+++ b/include/zephyr/drivers/interrupt_controller/intc_wkpu_nxp_s32.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NXP
+ * Copyright 2023-2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,57 +11,67 @@
 #ifndef ZEPHYR_DRIVERS_INTERRUPT_CONTROLLER_INTC_WKPU_NXP_S32_H_
 #define ZEPHYR_DRIVERS_INTERRUPT_CONTROLLER_INTC_WKPU_NXP_S32_H_
 
-#include <Wkpu_Ip.h>
-
-/* Wrapper callback for WKPU line */
+/** NXP WKPU callback */
 typedef void (*wkpu_nxp_s32_callback_t)(uint8_t pin, void *arg);
+
+/**
+ * @brief NXP WKPU pin activation type
+ */
+enum wkpu_nxp_s32_trigger {
+	/** Interrupt triggered on rising edge */
+	WKPU_NXP_S32_RISING_EDGE,
+	/** Interrupt triggered on falling edge */
+	WKPU_NXP_S32_FALLING_EDGE,
+	/** Interrupt triggered on either edge */
+	WKPU_NXP_S32_BOTH_EDGES,
+};
 
 /**
  * @brief Unset WKPU callback for line
  *
  * @param dev WKPU device
- * @param line WKPU line
+ * @param irq WKPU interrupt number
  */
-void wkpu_nxp_s32_unset_callback(const struct device *dev, uint8_t line);
+void wkpu_nxp_s32_unset_callback(const struct device *dev, uint8_t irq);
 
 /**
  * @brief Set WKPU callback for line
  *
  * @param dev  WKPU device
- * @param line WKPU line
- * @param cb   Callback
+ * @param irq  WKPU interrupt number
  * @param pin  GPIO pin
+ * @param cb   Callback
  * @param arg  Callback data
  *
  * @retval 0 on SUCCESS
  * @retval -EBUSY if callback for the line is already set
  */
-int wkpu_nxp_s32_set_callback(const struct device *dev, uint8_t line,
-			      wkpu_nxp_s32_callback_t cb, uint8_t pin, void *arg);
+int wkpu_nxp_s32_set_callback(const struct device *dev, uint8_t irq, uint8_t pin,
+			      wkpu_nxp_s32_callback_t cb,  void *arg);
 
 /**
  * @brief Set edge event and enable interrupt for WKPU line
  *
  * @param dev  WKPU device
- * @param line WKPU line
- * @param edge_type Type of edge event
+ * @param irq  WKPU interrupt number
+ * @param trigger pin activation trigger
  */
-void wkpu_nxp_s32_enable_interrupt(const struct device *dev, uint8_t line,
-				   Wkpu_Ip_EdgeType edge_type);
+void wkpu_nxp_s32_enable_interrupt(const struct device *dev, uint8_t irq,
+				   enum wkpu_nxp_s32_trigger trigger);
 
 /**
  * @brief Disable interrupt for WKPU line
  *
  * @param dev  WKPU device
- * @param line WKPU line
+ * @param irq  WKPU interrupt number
  */
-void wkpu_nxp_s32_disable_interrupt(const struct device *dev, uint8_t line);
+void wkpu_nxp_s32_disable_interrupt(const struct device *dev, uint8_t irq);
 
 /**
  * @brief Get pending interrupt for WKPU device
  *
  * @param dev WKPU device
- * @return A mask contains pending flags
+ * @return A bitmask containing pending interrupts
  */
 uint64_t wkpu_nxp_s32_get_pending(const struct device *dev);
 

--- a/west.yml
+++ b/west.yml
@@ -198,7 +198,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 343395b08fa5151246e147f5e6a523c7d6bdc724
+      revision: 220a4b285d226483a846e41d95abf8ab415b83e3
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Convert NXP WKPU to a native driver, all existing functionalities are retained.
Tested with `west twister --tag gpio` for `mr_canhubk3` board.