### PR TITLE
net: ipv4: Fix tx_pkts slab leak in send_ipv4_fragment

### DIFF
--- a/subsys/net/ip/ipv4_fragment.c
+++ b/subsys/net/ip/ipv4_fragment.c
@@ -467,7 +467,7 @@ static int send_ipv4_fragment(struct net_pkt *pkt, uint16_t rand_id, uint16_t fi
 
 	ipv4_hdr = (struct net_ipv4_hdr *)net_pkt_get_data(frag_pkt, &ipv4_access);
 	if (!ipv4_hdr) {
-		return -ENOBUFS;
+		goto fail;
 	}
 
 	memcpy(ipv4_hdr->id, &rand_id, sizeof(rand_id));


### PR DESCRIPTION
In the send_ipv4_fragment function, if net_pkt_get_data returns
fail, a tx_pkts slab leak will occur. If leak exceeds the
maximum number CONFIG_NET_PKT_TX_COUNT of tx_pkts slab, tx_ptks
will be used up, and the related modules(dhcp, ping and so on)
of net cannot alloc tx_pkt slab, and will sleep and can not
return successfully until available slab.
dhcp work or ping work cannot be executed beacause can't alloc
memory, and ping command cannot return, console also fails to
input commands, and the console hang problem occurs.