### PR TITLE
Bluetooth: A2DP: SBC: Implement remain a2dp sbc interface

### DIFF
--- a/include/zephyr/bluetooth/classic/a2dp_codec_sbc.h
+++ b/include/zephyr/bluetooth/classic/a2dp_codec_sbc.h
@@ -117,6 +117,38 @@ uint8_t bt_a2dp_sbc_get_channel_num(struct bt_a2dp_codec_sbc_params *sbc_codec);
  */
 uint32_t bt_a2dp_sbc_get_sampling_frequency(struct bt_a2dp_codec_sbc_params *sbc_codec);
 
+/** @brief get subband num of a2dp sbc config.
+ *
+ *  @param sbc_codec The a2dp sbc parameter.
+ *
+ *  @return the subband num.
+ */
+uint8_t bt_a2dp_sbc_get_subband_num(struct bt_a2dp_codec_sbc_params *sbc_codec);
+
+/** @brief get block length of a2dp sbc config.
+ *
+ *  @param sbc_codec The a2dp sbc parameter.
+ *
+ *  @return the block length.
+ */
+uint8_t bt_a2dp_sbc_get_block_length(struct bt_a2dp_codec_sbc_params *sbc_codec);
+
+/** @brief get channel mode of a2dp sbc config.
+ *
+ *  @param sbc_codec The a2dp sbc parameter.
+ *
+ *  @return the channel mode.
+ */
+enum sbc_ch_mode bt_a2dp_sbc_get_channel_mode(struct bt_a2dp_codec_sbc_params *sbc_codec);
+
+/** @brief get allocation method of a2dp sbc config.
+ *
+ *  @param sbc_codec The a2dp sbc parameter.
+ *
+ *  @return the allocation method.
+ */
+enum sbc_alloc_mthd bt_a2dp_sbc_get_allocation_method(struct bt_a2dp_codec_sbc_params *sbc_codec);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/bluetooth/host/classic/a2dp_codec_sbc.c
+++ b/subsys/bluetooth/host/classic/a2dp_codec_sbc.c
@@ -14,7 +14,7 @@
 
 #include <zephyr/bluetooth/classic/a2dp_codec_sbc.h>
 #include <zephyr/bluetooth/classic/a2dp.h>
-
+#include <zephyr/libsbc/sbc.h>
 
 uint8_t bt_a2dp_sbc_get_channel_num(struct bt_a2dp_codec_sbc_params *sbc_codec)
 {
@@ -47,5 +47,63 @@ uint32_t bt_a2dp_sbc_get_sampling_frequency(struct bt_a2dp_codec_sbc_params *sbc
 		return 48000U;
 	} else {
 		return 0U;
+	}
+}
+
+uint8_t bt_a2dp_sbc_get_subband_num(struct bt_a2dp_codec_sbc_params *sbc_codec)
+{
+	__ASSERT_NO_MSG(sbc_codec != NULL);
+
+	if (sbc_codec->config[1] & A2DP_SBC_SUBBAND_4) {
+		return 4U;
+	} else if (sbc_codec->config[1] & A2DP_SBC_SUBBAND_8) {
+		return 8U;
+	} else {
+		return 0U;
+	}
+}
+
+uint8_t bt_a2dp_sbc_get_block_length(struct bt_a2dp_codec_sbc_params *sbc_codec)
+{
+	__ASSERT_NO_MSG(sbc_codec != NULL);
+
+	if (sbc_codec->config[1] & A2DP_SBC_BLK_LEN_4) {
+		return 4U;
+	} else if (sbc_codec->config[1] & A2DP_SBC_BLK_LEN_8) {
+		return 8U;
+	} else if (sbc_codec->config[1] & A2DP_SBC_BLK_LEN_12) {
+		return 12U;
+	} else if (sbc_codec->config[1] & A2DP_SBC_BLK_LEN_16) {
+		return 16U;
+	} else {
+		return 0U;
+	}
+}
+
+enum sbc_ch_mode bt_a2dp_sbc_get_channel_mode(struct bt_a2dp_codec_sbc_params *sbc_codec)
+{
+	__ASSERT_NO_MSG(sbc_codec != NULL);
+
+	if (sbc_codec->config[0] & A2DP_SBC_CH_MODE_MONO) {
+		return SBC_CH_MODE_MONO;
+	} else if (sbc_codec->config[0] & A2DP_SBC_CH_MODE_DUAL) {
+		return SBC_CH_MODE_DUAL_CHANNEL;
+	} else if (sbc_codec->config[0] & A2DP_SBC_CH_MODE_STREO) {
+		return SBC_CH_MODE_STEREO;
+	} else if (sbc_codec->config[0] & A2DP_SBC_CH_MODE_JOINT) {
+		return SBC_CH_MODE_JOINT_STEREO;
+	} else {
+		return SBC_CH_MODE_MONO;
+	}
+}
+
+enum sbc_alloc_mthd bt_a2dp_sbc_get_allocation_method(struct bt_a2dp_codec_sbc_params *sbc_codec)
+{
+	__ASSERT_NO_MSG(sbc_codec != NULL);
+
+	if (sbc_codec->config[1] & A2DP_SBC_ALLOC_MTHD_SNR) {
+		return SBC_ALLOC_MTHD_SNR;
+	} else {
+		return SBC_ALLOC_MTHD_LOUDNESS;
 	}
 }


### PR DESCRIPTION
add bt_a2dp_sbc_get_subband_num, bt_a2dp_sbc_get_block_length, bt_a2dp_sbc_get_channel_mode and bt_a2dp_sbc_get_allocation_method