### PR TITLE
net: ipv6: Improve routing between interfaces

### DIFF
--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -452,6 +452,18 @@ static uint8_t extension_to_bitmap(uint8_t header, uint8_t ext_bitmap)
 	}
 }
 
+static inline bool is_src_non_tentative_itself(struct in6_addr *src)
+{
+	struct net_if_addr *ifaddr;
+
+	ifaddr = net_if_ipv6_addr_lookup(src, NULL);
+	if (ifaddr != NULL && ifaddr->addr_state != NET_ADDR_TENTATIVE) {
+		return true;
+	}
+
+	return false;
+}
+
 enum net_verdict net_ipv6_input(struct net_pkt *pkt, bool is_loopback)
 {
 	NET_PKT_DATA_ACCESS_CONTIGUOUS_DEFINE(ipv6_access, struct net_ipv6_hdr);
@@ -508,8 +520,6 @@ enum net_verdict net_ipv6_input(struct net_pkt *pkt, bool is_loopback)
 	}
 
 	if (!is_loopback) {
-		struct net_if_addr *ifaddr;
-
 		if (net_ipv6_is_addr_loopback((struct in6_addr *)hdr->dst) ||
 		    net_ipv6_is_addr_loopback((struct in6_addr *)hdr->src)) {
 			NET_DBG("DROP: ::1 packet");
@@ -529,9 +539,10 @@ enum net_verdict net_ipv6_input(struct net_pkt *pkt, bool is_loopback)
 		/* We need to pass the packet through in case our address is
 		 * tentative, as receiving a packet with a tentative address as
 		 * source means that duplicate address has been detected.
+		 * This check is done later on if routing features are enabled.
 		 */
-		ifaddr = net_if_ipv6_addr_lookup((struct in6_addr *)hdr->src, NULL);
-		if (ifaddr != NULL && ifaddr->addr_state != NET_ADDR_TENTATIVE) {
+		if (!IS_ENABLED(CONFIG_NET_ROUTING) && !IS_ENABLED(CONFIG_NET_ROUTE_MCAST) &&
+		    is_src_non_tentative_itself((struct in6_addr *)hdr->src)) {
 			NET_DBG("DROP: src addr is %s", "mine");
 			goto drop;
 		}
@@ -594,6 +605,12 @@ enum net_verdict net_ipv6_input(struct net_pkt *pkt, bool is_loopback)
 					   (struct in6_addr *)hdr->dst);
 			goto drop;
 		}
+	}
+
+	if ((IS_ENABLED(CONFIG_NET_ROUTING) || IS_ENABLED(CONFIG_NET_ROUTE_MCAST)) &&
+	    !is_loopback && is_src_non_tentative_itself((struct in6_addr *)hdr->src)) {
+		NET_DBG("DROP: src addr is %s", "mine");
+		goto drop;
 	}
 
 	if (net_ipv6_is_addr_mcast((struct in6_addr *)hdr->dst) &&

--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -573,7 +573,7 @@ enum net_verdict net_ipv6_input(struct net_pkt *pkt, bool is_loopback)
 	}
 
 	if (!net_ipv6_is_addr_mcast((struct in6_addr *)hdr->dst)) {
-		if (!net_ipv6_is_my_addr((struct in6_addr *)hdr->dst)) {
+		if (!net_if_ipv6_addr_lookup_by_iface(pkt_iface, (struct in6_addr *)hdr->dst)) {
 			if (ipv6_route_packet(pkt, hdr) == NET_OK) {
 				return NET_OK;
 			}

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -950,10 +950,12 @@ try_send:
 	net_ipv6_nbr_unlock();
 
 #if defined(CONFIG_NET_IPV6_ND)
-	/* We need to send NS and wait for NA before sending the packet. */
+	/* We need to send NS and wait for NA before sending the packet. If the packet was
+	 * forwarded from another interface do not use the original source address.
+	 */
 	ret = net_ipv6_send_ns(net_pkt_iface(pkt), pkt,
-			       (struct in6_addr *)ip_hdr->src, NULL, nexthop,
-			       false);
+			       net_pkt_forwarding(pkt) ? NULL : (struct in6_addr *)ip_hdr->src,
+			       NULL, nexthop, false);
 	if (ret < 0) {
 		/* In case of an error, the NS send function will unref
 		 * the pkt.

--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -255,12 +255,13 @@ static inline int check_ip(struct net_pkt *pkt)
 		}
 
 		/* If the destination address is our own, then route it
-		 * back to us.
+		 * back to us (if it is not already forwarded).
 		 */
-		if (net_ipv6_is_addr_loopback(
+		if ((net_ipv6_is_addr_loopback(
 				(struct in6_addr *)NET_IPV6_HDR(pkt)->dst) ||
 		    net_ipv6_is_my_addr(
-				(struct in6_addr *)NET_IPV6_HDR(pkt)->dst)) {
+				(struct in6_addr *)NET_IPV6_HDR(pkt)->dst)) &&
+		    !net_pkt_forwarding(pkt)) {
 			struct in6_addr addr;
 
 			/* Swap the addresses so that in receiving side


### PR DESCRIPTION
This PR includes few fixes for routing IPv6 packet between interfaces. Every change is described in in commit's message.