### PR TITLE
doc/releases/release-note-3.7: add notes for Renesas RZ/T2M SoC

### DIFF
--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -382,6 +382,8 @@ Boards & SoC Support
     * Added support for :c:func:`sys_arch_reboot()`.
     * :kconfig:option:`CONFIG_RISCV_ISA_EXT_A` is no longer erroneously y-selected.
 
+  * Renesas RZ/T2M: Added default values for System Clock Control register.
+
 * Added support for these boards:
 
   * Added support for :ref:`Ambiq Apollo3 Blue board <apollo3_evb>`: ``apollo3_evb``.
@@ -846,6 +848,7 @@ Drivers and Sensors
     from Power Off state on STM32 L4, U5, WB, & WL SoC series.
   * Added driver for Analog Devices MAX32 SoC series.
   * Added support for Nuvoton Numaker M2L31X series.
+  * Added interrupt support to the Renesas RZ/T2M GPIO driver (:dtcompatible:`renesas,rzt2m-gpio`).
 
 * Hardware info
 


### PR DESCRIPTION
This PR adds release notes for the Renesas RZ/T2M SoC.