### PR TITLE
release notes: Updated Bluetooth sections

### DIFF
--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -279,33 +279,6 @@ Device Drivers and Devicetree
 Analog-to-Digital Converter (ADC)
 =================================
 
-Bluetooth HCI
-=============
-
- * A new HCI driver API was introduced (:github:`72323`) and the old one deprecated. The new API
-   follows the normal Zephyr driver model, with devicetree nodes, etc. The host now
-   selects which driver instance to use as the controller by looking for a ``zephyr,bt-hci``
-   chosen property. The devicetree bindings for all HCI drivers derive from a common
-   ``bt-hci.yaml`` base binding.
-
-  * As part of the new HCI driver API, the ``zephyr,bt-uart`` chosen property is no longer used,
-    rather the UART HCI drivers select their UART by looking for the parent devicetree node of the
-    HCI driver instance node.
-  * As part of the new HCI driver API, the ``zephyr,bt-hci-ipc`` chosen property is only used for
-    the controller side, whereas the HCI driver now relies on nodes with the compatible string
-    ``zephyr,bt-hci-ipc``.
-  * The ``BT_NO_DRIVER`` Kconfig option was removed. HCI drivers are no-longer behind a Kconfig
-    choice, rather they can now be enabled and disabled independently, mostly based on their
-    respective devicetree node being enabled or not.
-  * The ``BT_HCI_VS_EXT`` Kconfig option was deleted and the feature is now included in the
-    :kconfig:option:`CONFIG_BT_HCI_VS` Kconfig option.
-  * The ``BT_HCI_VS_EVT`` Kconfig option was removed, since vendor event support is implicit if
-    the :kconfig:option:`CONFIG_BT_HCI_VS` option is enabled.
-  * The bt_read_static_addr() API was removed. This wasn't really a completely public API, but
-    since it was exposed by the public hci_driver.h header file the removal is mentioned here.
-    Enable the :kconfig:option:`CONFIG_BT_HCI_VS` Kconfig option instead, and use vendor specific
-    HCI commands API to get the Controller's Bluetooth static address when available.
-
 Charger
 =======
 
@@ -713,6 +686,33 @@ Watchdog
 
 Bluetooth
 *********
+
+Bluetooth HCI
+=============
+
+ * A new HCI driver API was introduced (:github:`72323`) and the old one deprecated. The new API
+   follows the normal Zephyr driver model, with devicetree nodes, etc. The host now
+   selects which driver instance to use as the controller by looking for a ``zephyr,bt-hci``
+   chosen property. The devicetree bindings for all HCI drivers derive from a common
+   ``bt-hci.yaml`` base binding.
+
+  * As part of the new HCI driver API, the ``zephyr,bt-uart`` chosen property is no longer used,
+    rather the UART HCI drivers select their UART by looking for the parent devicetree node of the
+    HCI driver instance node.
+  * As part of the new HCI driver API, the ``zephyr,bt-hci-ipc`` chosen property is only used for
+    the controller side, whereas the HCI driver now relies on nodes with the compatible string
+    ``zephyr,bt-hci-ipc``.
+  * The ``BT_NO_DRIVER`` Kconfig option was removed. HCI drivers are no-longer behind a Kconfig
+    choice, rather they can now be enabled and disabled independently, mostly based on their
+    respective devicetree node being enabled or not.
+  * The ``BT_HCI_VS_EXT`` Kconfig option was deleted and the feature is now included in the
+    :kconfig:option:`CONFIG_BT_HCI_VS` Kconfig option.
+  * The ``BT_HCI_VS_EVT`` Kconfig option was removed, since vendor event support is implicit if
+    the :kconfig:option:`CONFIG_BT_HCI_VS` option is enabled.
+  * The bt_read_static_addr() API was removed. This wasn't really a completely public API, but
+    since it was exposed by the public hci_driver.h header file the removal is mentioned here.
+    Enable the :kconfig:option:`CONFIG_BT_HCI_VS` Kconfig option instead, and use vendor specific
+    HCI commands API to get the Controller's Bluetooth static address when available.
 
 Bluetooth Mesh
 ==============

--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -297,6 +297,7 @@ Kernel
 
 Bluetooth
 *********
+
 * Audio
 
   * Removed ``err`` from :c:struct:`bt_bap_broadcast_assistant_cb.recv_state_removed` as it was
@@ -341,10 +342,15 @@ Bluetooth
     :kconfig:option:`CONFIG_BT_PER_ADV_SYNC_TRANSFER_SENDER` now depend on
     :kconfig:option:`CONFIG_BT_CONN` as they do not work without connections.
 
-* HCI Driver
+* HCI Drivers
 
+  * Completely redesigned HCI driver interface. See the Bluetooth HCI section in
+    :ref:`migration_3.7` for more information.
   * Added support for Ambiq Apollo3 Blue series.
   * Added support for NXP platforms.
+  * Added support for Infineon CYW208XX.
+  * Added support for Renesas SmartBond DA1469x.
+  * Removed unmaintained B91 driver.
 
 Boards & SoC Support
 ********************


### PR DESCRIPTION
Update the Bluetooth sections in the release notes and migration guide for 3.7.