### PR TITLE
doc: release-notes-3.7: add Task Watchdog section

### DIFF
--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -1812,6 +1812,10 @@ Libraries / Subsystems
 
   * Fixed FAT driver leaving disk in initialized state after unmount.
 
+* Task Watchdog
+
+  * Added shell (mainly for testing purposes during development).
+
 * POSIX API
 
   * Improved Kconfig options to reflect standard POSIX Options and Option Groups.


### PR DESCRIPTION
Mention the newly added shell for the task watchdog subsystem.