### PR TITLE
Bluetooth: mesh: Add split build configuration for sample

### DIFF
--- a/samples/bluetooth/mesh/README.rst
+++ b/samples/bluetooth/mesh/README.rst
@@ -44,9 +44,13 @@ For other boards, build and flash the application as follows:
 Refer to your :ref:`board's documentation <boards>` for alternative
 flash instructions if your board doesn't support the ``flash`` target.
 
-To run the application on an :ref:`nrf5340dk_nrf5340`, a Bluetooth controller application
-must also run on the network core. The :ref:`bluetooth-hci-ipc-sample` sample
-application may be used. Build this sample with configuration
+Additional kconfig options need to be set on the Bluetooth controller
+application if it runs on a separate board or SoC core. Build the controller
+application (i.e. ``hci_xx`` sample of your choosing) with the
+:zephyr_file:`samples/bluetooth/mesh/controller.conf`.
+
+For the :ref:`nrf5340dk_nrf5340` specifically, build and flash the
+:ref:`bluetooth-hci-ipc-sample` application with this configuration
 :zephyr_file:`samples/bluetooth/hci_ipc/nrf5340_cpunet_bt_mesh-bt_ll_sw_split.conf`
 to enable mesh support.
 

--- a/samples/bluetooth/mesh/controller.conf
+++ b/samples/bluetooth/mesh/controller.conf
@@ -1,0 +1,18 @@
+# This configuration fragment enables mesh support for a controller
+# that is running on a different board/module/cpu.
+
+# Controller
+CONFIG_BT_LL_SW_SPLIT=y
+
+# Disable unused Bluetooth features
+CONFIG_BT_CTLR_DUP_FILTER_LEN=0
+CONFIG_BT_CTLR_LE_ENC=n
+CONFIG_BT_CTLR_LE_PING=n
+CONFIG_BT_DATA_LEN_UPDATE=n
+CONFIG_BT_PHY_UPDATE=n
+CONFIG_BT_CTLR_MIN_USED_CHAN=n
+CONFIG_BT_CTLR_PRIVACY=n
+
+CONFIG_BT_OBSERVER=y
+CONFIG_BT_BROADCASTER=y
+CONFIG_BT_EXT_ADV=y


### PR DESCRIPTION
Add a build configuration that enables mesh when building one of the hci_something applications.

Also direct users to it from the README.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/75614