### PR TITLE
soc: nxp: s32k1: obtain system clock freq from dt

### DIFF
--- a/boards/nxp/ucans32k1sic/ucans32k1sic.dts
+++ b/boards/nxp/ucans32k1sic/ucans32k1sic.dts
@@ -98,6 +98,10 @@
 	};
 };
 
+&cpu0 {
+	clock-frequency = <80000000>;
+};
+
 &gpioa {
 	status = "okay";
 };

--- a/boards/nxp/ucans32k1sic/ucans32k1sic_defconfig
+++ b/boards/nxp/ucans32k1sic/ucans32k1sic_defconfig
@@ -3,9 +3,6 @@
 
 CONFIG_BUILD_OUTPUT_HEX=y
 
-# Use Systick as system clock
-CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC=80000000
-
 # Run from internal program flash
 CONFIG_XIP=y
 

--- a/dts/arm/nxp/nxp_s32k1xx.dtsi
+++ b/dts/arm/nxp/nxp_s32k1xx.dtsi
@@ -17,7 +17,7 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		cpu@0 {
+		cpu0: cpu@0 {
 			device_type = "cpu";
 			reg = <0>;
 		};

--- a/soc/nxp/s32/s32k1/Kconfig.defconfig
+++ b/soc/nxp/s32/s32k1/Kconfig.defconfig
@@ -6,7 +6,7 @@
 if SOC_SERIES_S32K1
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	default 80000000
+	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency) if CORTEX_M_SYSTICK
 
 config NUM_IRQS
 	default 239 if CPU_CORTEX_M4


### PR DESCRIPTION
In S32K1 devices, Arm Systick clock frequency is equal to the CPU core clock frequency, and its value can be obtained from devicetree.