### PR TITLE
intel: adsp: make SRAM power-off configurable

### DIFF
--- a/soc/intel/intel_adsp/Kconfig
+++ b/soc/intel/intel_adsp/Kconfig
@@ -93,11 +93,11 @@ config ADSP_INIT_HPSRAM
 	  Need to init HP SRAM.
 
 config ADSP_POWER_DOWN_HPSRAM
-	bool
+	bool "Switch off HP SRAM during power down"
 	default n if ZTEST
 	default y
 	help
-	 Switch off HP SRAM during power down.
+	 Switch off HP SRAM during power down. Platform-configurable.
 
 config ADSP_DISABLE_L2CACHE_AT_BOOT
 	bool

--- a/soc/intel/intel_adsp/ace/power.c
+++ b/soc/intel/intel_adsp/ace/power.c
@@ -339,18 +339,20 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 					(void *)rom_entry;
 			sys_cache_data_flush_range((void *)imr_layout, sizeof(*imr_layout));
 #endif /* CONFIG_ADSP_IMR_CONTEXT_SAVE */
+#ifdef CONFIG_ADSP_POWER_DOWN_HPSRAM
 			/* This assumes a single HPSRAM segment */
 			static uint32_t hpsram_mask;
-#ifdef CONFIG_ADSP_POWER_DOWN_HPSRAM
 			/* turn off all HPSRAM banks - get a full bitmap */
 			uint32_t ebb_banks = ace_hpsram_get_bank_count();
 			hpsram_mask = (1 << ebb_banks) - 1;
+#define HPSRAM_MASK_ADDR sys_cache_cached_ptr_get(&hpsram_mask)
+#else
+#define HPSRAM_MASK_ADDR NULL
 #endif /* CONFIG_ADSP_POWER_DOWN_HPSRAM */
 			/* do power down - this function won't return */
 			ret = pm_device_runtime_put(INTEL_ADSP_HST_DOMAIN_DEV);
 			__ASSERT_NO_MSG(ret == 0);
-			power_down(true, sys_cache_cached_ptr_get(&hpsram_mask),
-				   true);
+			power_down(true, HPSRAM_MASK_ADDR, true);
 		} else {
 			power_gate_entry(cpu);
 		}

--- a/soc/intel/intel_adsp/ace/power_down.S
+++ b/soc/intel/intel_adsp/ace/power_down.S
@@ -60,16 +60,19 @@ power_down:
 	ipfl pfl_reg, 128
 	ipfl pfl_reg, 192
 
+	/* move some values to registries before switching off whole memory */
+	/* load address of DIPCTDR register */
+	movi p_ipc_regs, IPC_HOST_BASE
+	movi u32_ipc_response_mask, 0x20000000
+
+	beqz pu32_hpsram_mask, _PD_DISABLE_LPSRAM
 	/*
 	 * This assumes a single HPSRAM segment although the code below is
 	 * generic and uses MAX_MEMORY_SEGMENTS for their number
 	 */
 	mov  pfl_reg, pu32_hpsram_mask
 	dpfl pfl_reg, 0
-	/* move some values to registries before switching off whole memory */
-	/* load address of DIPCTDR register */
-	movi p_ipc_regs, IPC_HOST_BASE
-	movi u32_ipc_response_mask, 0x20000000
+
 _PD_DISABLE_LPSRAM:
 /**
  * effectively executes:
@@ -81,8 +84,7 @@ _PD_DISABLE_LPSRAM:
 	m_ace_lpsram_power_down_entire temp_reg0, temp_reg1, temp_reg2, temp_reg3
 
 _PD_DISABLE_HPSRAM:
-	/* if value in memory pointed by pu32_hpsram_mask = 0
-	 (hpsram_pwrgating_mask) - do not disable hpsram. */
+	/* if value pu32_hpsram_mask = 0 - do not disable hpsram. */
 	beqz pu32_hpsram_mask, _PD_SEND_IPC
 	/**
 	 * effectively executes:


### PR DESCRIPTION
Currently the code suggests, that setting the SRAM disabling mask to 0 skips powering off SRAM, whereas in fact it's the address of the mask variable that's checked for NULL. Make this consistent and let platforms select whether SRAM power down should be selected.