### PR TITLE
soc: nxp: s32: split soc power code per series

### DIFF
--- a/soc/nxp/s32/Kconfig
+++ b/soc/nxp/s32/Kconfig
@@ -3,29 +3,6 @@
 
 if SOC_FAMILY_NXP_S32
 
-config NXP_S32_FUNC_RESET_THRESHOLD
-	int "Functional Reset Escalation threshold"
-	default 15
-	range 0 15
-	help
-	  If the value of this option is 0, the Functional reset escalation
-	  function is disabled. Any other value is the number of Functional
-	  resets that causes a Destructive reset, if the FRET register isn't
-	  written to beforehand.
-	  Default to maximum threshold (hardware reset value).
-
-config NXP_S32_DEST_RESET_THRESHOLD
-	int "Destructive Reset Escalation threshold"
-	default 0
-	range 0 15
-	help
-	  If the value of this field is 0, the Destructive reset escalation
-	  function is disabled. Any other value is the number of Destructive
-	  resets which keeps the chip in the reset state until the next power-on
-	  reset triggers a new reset sequence, if the DRET register isn't
-	  written to beforehand.
-	  Default to disabled (hardware reset value).
-
 rsource "*/Kconfig"
 
 endif # SOC_FAMILY_NXP_S32

--- a/soc/nxp/s32/common/CMakeLists.txt
+++ b/soc/nxp/s32/common/CMakeLists.txt
@@ -3,4 +3,3 @@
 
 zephyr_include_directories(.)
 zephyr_sources(osif.c)
-zephyr_sources_ifdef(CONFIG_SOC_SERIES_S32K3 power_soc.c)

--- a/soc/nxp/s32/common/Kconfig.power
+++ b/soc/nxp/s32/common/Kconfig.power
@@ -1,0 +1,25 @@
+# Copyright 2024 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+config NXP_S32_FUNC_RESET_THRESHOLD
+	int "Functional Reset Escalation threshold"
+	default 15
+	range 0 15
+	help
+	  If the value of this option is 0, the Functional reset escalation
+	  function is disabled. Any other value is the number of Functional
+	  resets that causes a Destructive reset, if the FRET register isn't
+	  written to beforehand.
+	  Default to maximum threshold (hardware reset value).
+
+config NXP_S32_DEST_RESET_THRESHOLD
+	int "Destructive Reset Escalation threshold"
+	default 0
+	range 0 15
+	help
+	  If the value of this field is 0, the Destructive reset escalation
+	  function is disabled. Any other value is the number of Destructive
+	  resets which keeps the chip in the reset state until the next power-on
+	  reset triggers a new reset sequence, if the DRET register isn't
+	  written to beforehand.
+	  Default to disabled (hardware reset value).

--- a/soc/nxp/s32/s32k3/CMakeLists.txt
+++ b/soc/nxp/s32/s32k3/CMakeLists.txt
@@ -5,7 +5,7 @@ zephyr_library()
 
 zephyr_include_directories(.)
 
-zephyr_library_sources(soc.c)
+zephyr_library_sources(soc.c power.c)
 zephyr_library_sources_ifdef(CONFIG_CPU_HAS_CUSTOM_FIXED_SOC_MPU_REGIONS mpu_regions.c)
 zephyr_linker_sources(SECTIONS sections.ld)
 zephyr_library_sources_ifdef(CONFIG_PLATFORM_SPECIFIC_INIT s32k3xx_startup.S)

--- a/soc/nxp/s32/s32k3/Kconfig
+++ b/soc/nxp/s32/s32k3/Kconfig
@@ -57,4 +57,6 @@ config NXP_S32_PMC_LMBCTLEN
 	  VRC_CTRL pin and is controlled by the PMC to regulate a voltage of
 	  1.5V on V15 pin.
 
+rsource "../common/Kconfig.power"
+
 endif # SOC_SERIES_S32K3

--- a/soc/nxp/s32/s32k3/power.c
+++ b/soc/nxp/s32/s32k3/power.c
@@ -71,13 +71,9 @@ static int nxp_s32_power_init(void)
 	};
 
 	const Power_Ip_PMC_ConfigType pmc_cfg = {
-#ifdef CONFIG_SOC_SERIES_S32K3
 		/* PMC Configuration Register (CONFIG) */
 		.ConfigRegister = PMC_CONFIG_LMEN(IS_ENABLED(CONFIG_NXP_S32_PMC_LMEN))
-			| PMC_CONFIG_LMBCTLEN(IS_ENABLED(CONFIG_NXP_S32_PMC_LMBCTLEN)),
-#else
-#error "SoC not supported"
-#endif
+				| PMC_CONFIG_LMBCTLEN(IS_ENABLED(CONFIG_NXP_S32_PMC_LMBCTLEN)),
 	};
 
 	const Power_Ip_HwIPsConfigType power_cfg = {

--- a/soc/nxp/s32/s32ze/Kconfig
+++ b/soc/nxp/s32/s32ze/Kconfig
@@ -27,4 +27,6 @@ config NXP_S32_RTU_INDEX
 	help
 	  This option indicates the index of the target RTU (Real-Time Unit) subsystem.
 
+rsource "../common/Kconfig.power"
+
 endif # SOC_SERIES_S32ZE


### PR DESCRIPTION
Power management initialization and SoC reset functionality is not generic enough to be shared across all NXP S32 family, hence split the code per series.