### PR TITLE
drivers: udc_stm32: remove wrong header and fix udc_ep_enable()

### DIFF
--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -20,7 +20,6 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/sys/util.h>
-#include <zephyr/usb/usb_device.h>
 
 #include "udc_common.h"
 
@@ -630,44 +629,43 @@ static int udc_stm32_host_wakeup(const struct device *dev)
 	return 0;
 }
 
-static inline int eptype2hal(enum usb_dc_ep_transfer_type eptype)
+static int udc_stm32_ep_enable(const struct device *dev,
+			       struct udc_ep_config *ep_cfg)
 {
-	switch (eptype) {
-	case USB_DC_EP_CONTROL:
-		return EP_TYPE_CTRL;
-	case USB_DC_EP_ISOCHRONOUS:
-		return EP_TYPE_ISOC;
-	case USB_DC_EP_BULK:
-		return EP_TYPE_BULK;
-	case USB_DC_EP_INTERRUPT:
-		return EP_TYPE_INTR;
+	struct udc_stm32_data *priv = udc_get_private(dev);
+	HAL_StatusTypeDef status;
+	uint8_t ep_type;
+	int ret;
+
+	LOG_DBG("Enable ep 0x%02x", ep_cfg->addr);
+
+	switch (ep_cfg->attributes & USB_EP_TRANSFER_TYPE_MASK) {
+	case USB_EP_TYPE_CONTROL:
+		ep_type = EP_TYPE_CTRL;
+		break;
+	case USB_EP_TYPE_BULK:
+		ep_type = EP_TYPE_BULK;
+		break;
+	case USB_EP_TYPE_INTERRUPT:
+		ep_type = EP_TYPE_INTR;
+		break;
+	case USB_EP_TYPE_ISO:
+		ep_type = EP_TYPE_ISOC;
+		break;
 	default:
 		return -EINVAL;
 	}
 
-	return -EINVAL;
-}
-
-static int udc_stm32_ep_enable(const struct device *dev,
-			       struct udc_ep_config *ep)
-{
-	enum usb_dc_ep_transfer_type type = ep->attributes & USB_EP_TRANSFER_TYPE_MASK;
-	struct udc_stm32_data *priv = udc_get_private(dev);
-	HAL_StatusTypeDef status;
-	int ret;
-
-	LOG_DBG("Enable ep 0x%02x", ep->addr);
-
-	ret = udc_stm32_ep_mem_config(dev, ep, true);
+	ret = udc_stm32_ep_mem_config(dev, ep_cfg, true);
 	if (ret) {
 		return ret;
 	}
 
-	status = HAL_PCD_EP_Open(&priv->pcd, ep->addr, ep->mps,
-				 eptype2hal(type));
+	status = HAL_PCD_EP_Open(&priv->pcd, ep_cfg->addr, ep_cfg->mps,
+				 ep_type);
 	if (status != HAL_OK) {
 		LOG_ERR("HAL_PCD_EP_Open failed(0x%02x), %d",
-			ep->addr, (int)status);
+			ep_cfg->addr, (int)status);
 		return -EIO;
 	}
 


### PR DESCRIPTION
Driver includes wrong header zephyr/usb/usb_device.h and uses defines from include/zephyr/drivers/usb/usb_dc.h.
Also fix udc_ep_enable() implementation in general. HAL_PCD_EP_Open() takes the ep_type parameter as uint8_t integer type and the shim driver should not just pass int type.
It is recommended that drivers use ep_cfg or cfg for struct udc_ep_config, fix this as well.