### PR TITLE
net: lib: sockets: socketpairs: Update socketpair mem alloc

### DIFF
--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -378,16 +378,28 @@ config NET_SOCKETPAIR_STATIC
 
 config NET_SOCKETPAIR_HEAP
 	bool "Use heap for allocating socketpairs"
-	depends on HEAP_MEM_POOL_SIZE != 0
 
 endchoice
 
 if NET_SOCKETPAIR_STATIC
+
 config NET_SOCKETPAIR_MAX
 	int "How many socketpairs to pre-allocate"
+	default 6 if WIFI_NM_WPA_SUPPLICANT
 	default 1
-endif
-endif
+
+endif # NET_SOCKETPAIR_STATIC
+
+if NET_SOCKETPAIR_HEAP
+
+config HEAP_MEM_POOL_ADD_SIZE_SOCKETPAIR
+	int
+	default 32000 if WIFI_NM_WPA_SUPPLICANT
+	default 256
+
+endif # NET_SOCKETPAIR_HEAP
+
+endif # NET_SOCKETPAIR
 
 config NET_SOCKETS_NET_MGMT
 	bool "Network management socket support [EXPERIMENTAL]"


### PR DESCRIPTION
The memory allocation for socketpairs is not conformant to the new MEM_POOL_ADD_SIZE_ mechanism for allocating heap memory.

Specifically CONFIG_NET_SOCKETPAIR_HEAP can not be selected unless the user has specified CONFIG_HEAP_MEM_POOL_SIZE. We should be using MEM_POOL_ADD_SIZE_ to add to the heap if the user wants to use it for socketpair allocation.

Additionally increase the size of pre-allocated sockets to 6 from 1 when using WIFI_NM_WPA_SUPPLICANT.