### PR TITLE
net: lib: coap_client: Replace send_mutex with more generic lock 

### DIFF
--- a/include/zephyr/net/coap_client.h
+++ b/include/zephyr/net/coap_client.h
@@ -107,7 +107,7 @@ struct coap_client {
 	struct sockaddr address;
 	socklen_t socklen;
 	bool response_ready;
-	struct k_mutex send_mutex;
+	struct k_mutex lock;
 	uint8_t send_buf[MAX_COAP_MSG_LEN];
 	uint8_t recv_buf[MAX_COAP_MSG_LEN];
 	struct coap_client_internal_request requests[CONFIG_COAP_CLIENT_MAX_REQUESTS];

--- a/subsys/net/lib/coap/coap_client.c
+++ b/subsys/net/lib/coap/coap_client.c
@@ -86,7 +86,7 @@ static int coap_client_schedule_poll(struct coap_client *client, int sock,
 	return 0;
 }
 
-bool has_ongoing_request(struct coap_client *client)
+static bool has_ongoing_request(struct coap_client *client)
 {
 	for (int i = 0; i < CONFIG_COAP_CLIENT_MAX_REQUESTS; i++) {
 		if (client->requests[i].request_ongoing == true) {
@@ -97,7 +97,7 @@ bool has_ongoing_request(struct coap_client *client)
 	return false;
 }
 
-struct coap_client_internal_request *get_free_request(struct coap_client *client)
+static struct coap_client_internal_request *get_free_request(struct coap_client *client)
 {
 	for (int i = 0; i < CONFIG_COAP_CLIENT_MAX_REQUESTS; i++) {
 		if (client->requests[i].request_ongoing == false) {
@@ -588,21 +588,8 @@ static int send_ack(struct coap_client *client, const struct coap_packet *req,
 	return 0;
 }
 
-struct coap_client_internal_request *get_request_with_id(struct coap_client *client,
-							 uint16_t message_id)
-{
-	for (int i = 0; i < CONFIG_COAP_CLIENT_MAX_REQUESTS; i++) {
-		if (client->requests[i].request_ongoing == true &&
-		    client->requests[i].pending.id == message_id) {
-			return &client->requests[i];
-		}
-	}
-
-	return NULL;
-}
-
-struct coap_client_internal_request *get_request_with_token(struct coap_client *client,
-							    const struct coap_packet *resp)
+static struct coap_client_internal_request *get_request_with_token(
+	struct coap_client *client, const struct coap_packet *resp)
 {
 
 	uint8_t response_token[COAP_TOKEN_MAX_LEN];
@@ -871,7 +858,7 @@ void coap_client_cancel_requests(struct coap_client *client)
 	k_sleep(K_MSEC(COAP_PERIODIC_TIMEOUT));
 }
 
-void coap_client_recv(void *coap_cl, void *a, void *b)
+static void coap_client_recv(void *coap_cl, void *a, void *b)
 {
 	int ret;
 


### PR DESCRIPTION
Introduce a more generic mutex for protecting coap_client structure.

This allows to avoid a certain race condition when sending consecutive
CoAP requests. The case was, that when a CoAP receive thread notified
the application that a complete response was received, and the
application wanted to send another request from the application thread,
the consecutive call to coap_client_req() might've failed if the
application thread has higher priority than the CoAP receive thread
because of the request context cleanup is done after calling the
application callback.
Having a mutex, which is locked while processing the response, and when
attempting to send a new request allows to synchronize threads as
expected.

As this new mutex seemed redundant with the more specialized send_mutex
already present in the coap_client, the latter was removed (i. e.
transmission is also protected with the new mutex).

Fixes #76084