### PR TITLE
drivers: watchdog: nrfx wdt without IRQs

### DIFF
--- a/drivers/watchdog/Kconfig.nrfx
+++ b/drivers/watchdog/Kconfig.nrfx
@@ -16,6 +16,11 @@ config WDT_NRFX
 	select NRFX_WDT130 if HAS_HW_NRF_WDT130
 	select NRFX_WDT131 if HAS_HW_NRF_WDT131
 	select NRFX_WDT132 if HAS_HW_NRF_WDT132
-
 	help
 	  Enable support for nrfx WDT driver for nRF MCU series.
+
+config WDT_NRFX_NO_IRQ
+	bool "nRF WDT nrfx driver without IRQ enabled"
+	depends on WDT_NRFX
+	help
+	  Disable use of WDT interrupt in driver.

--- a/modules/hal_nordic/nrfx/nrfx_config.h
+++ b/modules/hal_nordic/nrfx/nrfx_config.h
@@ -835,6 +835,9 @@
 #ifdef CONFIG_NRFX_WDT
 #define NRFX_WDT_ENABLED 1
 #endif
+#ifdef CONFIG_WDT_NRFX_NO_IRQ
+#define NRFX_WDT_CONFIG_NO_IRQ 1
+#endif
 #ifdef CONFIG_NRFX_WDT_LOG
 #define NRFX_WDT_CONFIG_LOG_ENABLED 1
 #endif


### PR DESCRIPTION
Add config option to build nrfx wdt driver with
NRFX_WDT_CONFIG_NO_IRQ enabled.