### PR TITLE
bluetooth: Fix various plm issues

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -568,6 +568,7 @@ config BT_CTLR_LE_PATH_LOSS_MONITORING
 	bool "LE Path Loss Monitoring Feature"
 	depends on BT_CTLR_LE_PATH_LOSS_MONITORING_SUPPORT
 	default y if BT_PATH_LOSS_MONITORING
+	select BT_CTLR_LE_POWER_CONTROL
 	help
 	  Enable support for LE Path Loss Monitoring feature that is defined in the
 	  Bluetooth Core specification, Version 5.4 | Vol 6, Part B, Section 4.6.32.

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2986,7 +2986,7 @@ void notify_path_loss_threshold_report(struct bt_conn *conn,
 {
 	struct bt_conn_cb *callback;
 
-	SYS_SLIST_FOR_EACH_CONTAINER(&callback_list, callback, _node) {
+	SYS_SLIST_FOR_EACH_CONTAINER(&conn_cbs, callback, _node) {
 		if (callback->path_loss_threshold_report) {
 			callback->path_loss_threshold_report(conn, &report);
 		}

--- a/tests/bluetooth/shell/testcase.yaml
+++ b/tests/bluetooth/shell/testcase.yaml
@@ -29,6 +29,13 @@ tests:
     platform_allow:
       - native_posix
     build_only: true
+  bluetooth.shell.path_loss_monitoring:
+    extra_configs:
+      - CONFIG_BT_PATH_LOSS_MONITORING=y
+      - CONFIG_BT_CTLR=n
+    platform_allow:
+      - native_posix
+    build_only: true
   bluetooth.shell.subrating:
     extra_configs:
       - CONFIG_BT_SUBRATING=y


### PR DESCRIPTION
- callback_list was renamed to conn_cbs in commit 3eb975d. However plm callback was missed due to it not being built anywhere.
- Path loss monitoring was not being enabled anywhere, meaning that issues could be merged in without catching the issue. This commit adds a test case to build the shell with path loss monitoring enabled to catch issues.
- Path loss monitoring does not work without LE Power Control also enabled in the controller, so update the dependencies in the kconfigs to reflect this.