### PR TITLE
STM32: handle disabled ADCs more cleanly in internal sensor drivers

### DIFF
--- a/boards/st/nucleo_h753zi/nucleo_h753zi.dts
+++ b/boards/st/nucleo_h753zi/nucleo_h753zi.dts
@@ -242,7 +242,3 @@ zephyr_udc0: &usbotg_fs {
 
 	};
 };
-
-&vbat {
-	status = "okay";
-};

--- a/boards/st/stm32h735g_disco/stm32h735g_disco.dts
+++ b/boards/st/stm32h735g_disco/stm32h735g_disco.dts
@@ -206,10 +206,6 @@
 	};
 };
 
-&vbat {
-	status = "okay";
-};
-
 &fdcan1 {
 	pinctrl-0 = <&fdcan1_rx_ph14 &fdcan1_tx_ph13>;
 	pinctrl-names = "default";

--- a/drivers/sensor/st/stm32_temp/Kconfig
+++ b/drivers/sensor/st/stm32_temp/Kconfig
@@ -6,9 +6,11 @@
 config STM32_TEMP
 	bool "STM32 Temperature Sensor"
 	default y
+	depends on SOC_FAMILY_STM32
+	depends on DT_HAS_ST_STM32_ADC_ENABLED
 	depends on DT_HAS_ST_STM32_TEMP_ENABLED || \
 		   DT_HAS_ST_STM32_TEMP_CAL_ENABLED || \
 		   DT_HAS_ST_STM32C0_TEMP_CAL_ENABLED
-	depends on (ADC && SOC_FAMILY_STM32)
+	select ADC
 	help
 	  Enable driver for STM32 temperature sensor.

--- a/drivers/sensor/st/stm32_vbat/stm32_vbat.c
+++ b/drivers/sensor/st/stm32_vbat/stm32_vbat.c
@@ -124,14 +124,17 @@ static int stm32_vbat_init(const struct device *dev)
 	return 0;
 }
 
-#define STM32_VBAT_GET_ADC_OR_NULL(inst)                                                           \
-	COND_CODE_1(DT_NODE_HAS_STATUS(DT_INST_IO_CHANNELS_CTLR(inst), okay),                      \
-		    (DEVICE_DT_GET(DT_INST_IO_CHANNELS_CTLR(inst))), (NULL))
+#define ASSERT_VBAT_ADC_ENABLED(inst)	\
+	BUILD_ASSERT(DT_NODE_HAS_STATUS(DT_INST_IO_CHANNELS_CTLR(inst), okay),			\
+		"ADC instance '" DT_NODE_FULL_NAME(DT_INST_IO_CHANNELS_CTLR(inst)) "' needed "	\
+		"by Vbat sensor '" DT_NODE_FULL_NAME(DT_DRV_INST(inst)) "' is not enabled")
 
 #define STM32_VBAT_DEFINE(inst)									\
+	ASSERT_VBAT_ADC_ENABLED(inst);								\
+												\
 	static struct stm32_vbat_data stm32_vbat_dev_data_##inst = {				\
-		.adc = STM32_VBAT_GET_ADC_OR_NULL(inst),					\
-		.adc_base = (ADC_TypeDef *)DT_REG_ADDR(DT_INST_IO_CHANNELS_CTLR(0)),		\
+		.adc = DEVICE_DT_GET(DT_INST_IO_CHANNELS_CTLR(inst)),				\
+		.adc_base = (ADC_TypeDef *)DT_REG_ADDR(DT_INST_IO_CHANNELS_CTLR(inst)),		\
 		.adc_cfg = {									\
 			.gain = ADC_GAIN_1,							\
 			.reference = ADC_REF_INTERNAL,						\

--- a/drivers/sensor/st/stm32_vref/Kconfig
+++ b/drivers/sensor/st/stm32_vref/Kconfig
@@ -6,6 +6,7 @@
 config STM32_VREF
 	bool "STM32 VREF Sensor"
 	default y
+	depends on DT_HAS_ST_STM32_ADC_ENABLED
 	depends on DT_HAS_ST_STM32_VREF_ENABLED
 	depends on SOC_FAMILY_STM32 && !SOC_SERIES_STM32F1X
 	select ADC

--- a/drivers/sensor/st/stm32_vref/stm32_vref.c
+++ b/drivers/sensor/st/stm32_vref/stm32_vref.c
@@ -96,9 +96,7 @@ static int stm32_vref_channel_get(const struct device *dev, enum sensor_channel 
 	}
 
 /*
- * ERRATA: STM32H5X: bus fault errors occur when reading engineering bytes with
- * icache enabled.
- * See https://github.com/zephyrproject-rtos/zephyr/commit/065a8f2
+ * STM32H5X: accesses to flash RO region must be done with caching disabled.
  */
 #if defined(CONFIG_SOC_SERIES_STM32H5X)
 	LL_ICACHE_Disable();

--- a/dts/bindings/adc/st,stm32-adc.yaml
+++ b/dts/bindings/adc/st,stm32-adc.yaml
@@ -21,12 +21,6 @@ properties:
   "#io-channel-cells":
     const: 1
 
-  pinctrl-0:
-    required: true
-
-  pinctrl-names:
-    required: true
-
   st,adc-clock-source:
     type: int
     required: true


### PR DESCRIPTION
This PR intends to fix #72914 and make detecting such mistakes easier.

As piggybacking changes, ba90cd530adf17cbfb4c290a1204c6d79473c87b also makes the `pinctrl-0` property of STM32 ADC no longer required; indeed, it is possible to enable the ADC only for usage of internal sensors - in this case, no GPIO pin needs to be switched to ANALOG alternate function.