### PR TITLE
west: blobs: verify fetched blobs after downloading

### DIFF
--- a/scripts/west_commands/blobs.py
+++ b/scripts/west_commands/blobs.py
@@ -122,7 +122,7 @@ class Blobs(WestCommand):
     def fetch(self, args):
         blobs = self.get_blobs(args)
         for blob in blobs:
-            if blob['status'] == 'A':
+            if blob['status'] == zephyr_module.BLOB_PRESENT:
                 log.dbg('Blob {module}: {abspath} is up to date'.format(**blob))
                 continue
             log.inf('Fetching blob {module}: {abspath}'.format(**blob))
@@ -131,7 +131,7 @@ class Blobs(WestCommand):
     def clean(self, args):
         blobs = self.get_blobs(args)
         for blob in blobs:
-            if blob['status'] == 'D':
+            if blob['status'] == zephyr_module.BLOB_NOT_PRESENT:
                 log.dbg('Blob {module}: {abspath} not in filesystem'.format(**blob))
                 continue
             log.inf('Deleting blob {module}: {status} {abspath}'.format(**blob))

--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -345,7 +345,7 @@ def kconfig_snippet(meta, path, kconfig_file=None, blobs=False, sysbuild=False):
 
 def process_kconfig(module, meta):
     blobs = process_blobs(module, meta)
-    taint_blobs = len(tuple(filter(lambda b: b['status'] != 'D', blobs))) != 0
+    taint_blobs = any(b['status'] != BLOB_NOT_PRESENT for b in blobs)
     section = meta.get('build', dict())
     module_path = PurePath(module)
     module_yml = module_path.joinpath('zephyr/module.yml')


### PR DESCRIPTION
**Problem description**

Running `west blobs fetch` does not verify the digest of downloaded files.

Fixes #76185

**Proposed change**

Call `zephyr_module.get_blob_status()` (again) after downloading, and warn the user if the blob status is `BLOB_OUTDATED` (digests don't match).

Note: The proposed error message is intended to not be scary, and assumes incorrect metadata (URL or digest) rather than a *compromised* download:

```
$ west blobs fetch hal_espressif
Fetching blob hal_espressif: path/to/zephyr/modules/hal/espressif/zephyr/blobs/lib/esp32c3/libbtdm_app.a
ERROR: The checksum of the downloaded file does not match that in the blob metadata:
- if it is not certain that the download was successful,
  try running 'west blobs fetch hal_espressif'
  to re-download the file
- if the error persists, please consider contacting
  the maintainers of the module so that they can check
  the corresponding blob metadata

Module: hal_espressif
Blob:   lib/esp32c3/libbtdm_app.a
URL:    https://github.com/espressif/esp32c3-bt-lib/raw/b438f60a295183e7c67eb42ae05f4580f4b1ced0/esp32c3/libbtdm_app.a
Info:   Binary libraries supporting the ESP32 series RF subsystems
```

Thanks.