### PR TITLE
gdbstub: fix compilation error on ARM & improve test coverage

### DIFF
--- a/include/zephyr/arch/arm/gdbstub.h
+++ b/include/zephyr/arch/arm/gdbstub.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_INCLUDE_ARCH_ARM_AARCH32_GDBSTUB_H_
 #define ZEPHYR_INCLUDE_ARCH_ARM_AARCH32_GDBSTUB_H_
 
-#include <zephyr/arch/arm/exc.h>
+#include <zephyr/arch/arm/exception.h>
 
 #ifndef _ASMLANGUAGE
 

--- a/tests/subsys/debug/gdbstub/testcase.yaml
+++ b/tests/subsys/debug/gdbstub/testcase.yaml
@@ -11,6 +11,13 @@ common:
   filter: CONFIG_ARCH_HAS_GDBSTUB
 
 tests:
+  # Basic build-only test for all platforms supporting gdbstub
+  debug.gdbstub.build_only:
+    platform_allow:
+      - qemu_x86
+      - qemu_cortex_a9
+    build_only: true
+
   # Connect to Zephyr gdbstub and run a simple GDB script
   debug.gdbstub.breakpoints:
     platform_allow:

--- a/tests/subsys/debug/gdbstub/testcase.yaml
+++ b/tests/subsys/debug/gdbstub/testcase.yaml
@@ -4,10 +4,17 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+common:
+  tags:
+    - debug
+    - gdbstub
+  filter: CONFIG_ARCH_HAS_GDBSTUB
+
 tests:
   # Connect to Zephyr gdbstub and run a simple GDB script
   debug.gdbstub.breakpoints:
-    platform_allow: qemu_x86
+    platform_allow:
+      - qemu_x86
     harness: pytest
     harness_config:
       pytest_root:
@@ -19,9 +26,6 @@ tests:
         - "test_breakpoints.gdbinit"
         - "--gdb_target_remote"
         - "tcp::5678"
-    tags:
-      - debug
-      - gdbstub
     extra_configs:
       # Make sure the gdbstub port chosen is unique for this test to avoid conflicts
       # when Twister runs tests in parallel on the same host.
@@ -33,7 +37,8 @@ tests:
   # Use non-default QEMU gdbstub port 1235 for this test to avoid conflicts
   # with some other test on QEMU running in parallel.
   debug.gdbstub_qemu.breakpoints:
-    platform_allow: qemu_x86
+    platform_allow:
+      - qemu_x86
     harness: pytest
     harness_config:
       pytest_root:
@@ -45,9 +50,6 @@ tests:
         - "test_breakpoints.gdbinit"
         - "--gdb_target_remote"
         - "tcp::1235"
-    tags:
-      - debug
-      - gdbstub
     extra_configs:
       # Turn off Zephyr's gdbstub for this test case.
       - CONFIG_GDBSTUB=n


### PR DESCRIPTION
See each commit for details

Log:
```
$ west build -b qemu_cortex_a9 -p auto zephyr/tests/subsys/debug/gdbstub/
-- west build: generating a build system
Loading Zephyr default modules (Zephyr base).
-- Application: /home/ycsin/zephyrproject/zephyr/tests/subsys/debug/gdbstub
-- CMake version: 3.27.7
-- Found Python3: /home/ycsin/zephyrproject/.venv/bin/python3 (found suitable version "3.10.12", minimum required is "3.8") found components: Interpreter 
-- Cache files will be written to: /home/ycsin/.cache/zephyr
-- Zephyr version: 3.7.0-rc3 (/home/ycsin/zephyrproject/zephyr)
-- Found west (found suitable version "1.2.0", minimum required is "0.14.0")
-- Board: qemu_cortex_a9, qualifiers: xc7z007s
-- ZEPHYR_TOOLCHAIN_VARIANT not set, trying to locate Zephyr SDK
-- Found host-tools: zephyr 0.16.8 (/home/ycsin/zephyr-sdk-0.16.8)
-- Found toolchain: zephyr 0.16.8 (/home/ycsin/zephyr-sdk-0.16.8)
-- Found Dtc: /home/ycsin/zephyr-sdk-0.16.8/sysroots/x86_64-pokysdk-linux/usr/bin/dtc (found suitable version "1.6.0", minimum required is "1.4.6") 
-- Found BOARD.dts: /home/ycsin/zephyrproject/zephyr/boards/qemu/cortex_a9/qemu_cortex_a9.dts
-- Found devicetree overlay: /home/ycsin/zephyrproject/zephyr/tests/subsys/debug/gdbstub/boards/qemu_cortex_a9.overlay
-- Generated zephyr.dts: /home/ycsin/zephyrproject/build/zephyr/zephyr.dts
-- Generated devicetree_generated.h: /home/ycsin/zephyrproject/build/zephyr/include/generated/zephyr/devicetree_generated.h
-- Including generated dts.cmake file: /home/ycsin/zephyrproject/build/zephyr/dts.cmake

warning: KOBJECT_TEXT_AREA (defined at arch/arm64/core/Kconfig:128, arch/Kconfig:320) was assigned
the value '4096' but got the value ''. Check these unsatisfied dependencies: (ARM64 ||
ARCH_HAS_USERSPACE) (=n). See
http://docs.zephyrproject.org/latest/kconfig.html#CONFIG_KOBJECT_TEXT_AREA and/or look up
KOBJECT_TEXT_AREA in the menuconfig/guiconfig interface. The Application Development Primer, Setting
Configuration Values, and Kconfig - Tips and Best Practices sections of the manual might be helpful
too.


warning: USERSPACE (defined at arch/Kconfig:289) was assigned the value 'y' but got the value 'n'.
Check these unsatisfied dependencies: ARCH_HAS_USERSPACE (=n). See
http://docs.zephyrproject.org/latest/kconfig.html#CONFIG_USERSPACE and/or look up USERSPACE in the
menuconfig/guiconfig interface. The Application Development Primer, Setting Configuration Values,
and Kconfig - Tips and Best Practices sections of the manual might be helpful too.

Parsing /home/ycsin/zephyrproject/zephyr/Kconfig
Loaded configuration '/home/ycsin/zephyrproject/zephyr/boards/qemu/cortex_a9/qemu_cortex_a9_defconfig'
Merged configuration '/home/ycsin/zephyrproject/zephyr/tests/subsys/debug/gdbstub/prj.conf'
Configuration saved to '/home/ycsin/zephyrproject/build/zephyr/.config'
Kconfig header saved to '/home/ycsin/zephyrproject/build/zephyr/include/generated/zephyr/autoconf.h'
-- Found GnuLd: /home/ycsin/zephyr-sdk-0.16.8/arm-zephyr-eabi/arm-zephyr-eabi/bin/ld.bfd (found version "2.38") 
-- The C compiler identification is GNU 12.2.0
-- The CXX compiler identification is GNU 12.2.0
-- The ASM compiler identification is GNU
-- Found assembler: /home/ycsin/zephyr-sdk-0.16.8/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc
-- Using ccache: /usr/bin/ccache
-- Configuring done (10.3s)
-- Generating done (0.1s)
-- Build files have been written to: /home/ycsin/zephyrproject/build
-- west build: building application
[1/117] Preparing syscall dependency handling

[2/117] Generating include/generated/zephyr/version.h
-- Zephyr version: 3.7.0-rc3 (/home/ycsin/zephyrproject/zephyr), build: v3.7.0-rc3-98-g5681d422fe49
[8/117] Building C object zephyr/CMakeFiles/offsets.dir/arch/arm/core/offsets/offsets.c.obj
FAILED: zephyr/CMakeFiles/offsets.dir/arch/arm/core/offsets/offsets.c.obj 
ccache /home/ycsin/zephyr-sdk-0.16.8/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc -DKERNEL -DK_HEAP_MEM_POOL_SIZE=0 -DPICOLIBC_LONG_LONG_PRINTF_SCANF -D__LINUX_ERRNO_EXTENSIONS__ -D__PROGRAM_START -D__ZEPHYR__=1 -I/home/ycsin/zephyrproject/zephyr/kernel/include -I/home/ycsin/zephyrproject/zephyr/arch/arm/include -I/home/ycsin/zephyrproject/build/zephyr/include/generated/zephyr -I/home/ycsin/zephyrproject/zephyr/include -I/home/ycsin/zephyrproject/build/zephyr/include/generated -I/home/ycsin/zephyrproject/zephyr/soc/xlnx/zynq7000 -I/home/ycsin/zephyrproject/zephyr/soc/xlnx/zynq7000/xc7zxxxs/. -I/home/ycsin/zephyrproject/zephyr/soc/xlnx/zynq7000/common -I/home/ycsin/zephyrproject/modules/hal/cmsis/CMSIS/Core_A/Include -I/home/ycsin/zephyrproject/zephyr/modules/cmsis/. -isystem /home/ycsin/zephyrproject/zephyr/lib/libc/common/include -fno-strict-aliasing -O0 -imacros /home/ycsin/zephyrproject/build/zephyr/include/generated/zephyr/autoconf.h -fno-printf-return-value -fno-common -g -gdwarf-4 -fdiagnostics-color=always -mcpu=cortex-a9 -mabi=aapcs -mfp16-format=ieee -mtp=soft --sysroot=/home/ycsin/zephyr-sdk-0.16.8/arm-zephyr-eabi/arm-zephyr-eabi -imacros /home/ycsin/zephyrproject/zephyr/include/zephyr/toolchain/zephyr_stdint.h -Wall -Wformat -Wformat-security -Wno-format-zero-length -Wdouble-promotion -Wno-pointer-sign -Wpointer-arith -Wexpansion-to-defined -Wno-unused-but-set-variable -Werror=implicit-int -fno-pic -fno-pie -fno-asynchronous-unwind-tables -ftls-model=local-exec -fno-reorder-functions --param=min-pagesize=0 -fno-defer-pop -fmacro-prefix-map=/home/ycsin/zephyrproject/zephyr/tests/subsys/debug/gdbstub=CMAKE_SOURCE_DIR -fmacro-prefix-map=/home/ycsin/zephyrproject/zephyr=ZEPHYR_BASE -fmacro-prefix-map=/home/ycsin/zephyrproject=WEST_TOPDIR -ffunction-sections -fdata-sections --specs=picolibc.specs -std=c99 -fno-lto -MD -MT zephyr/CMakeFiles/offsets.dir/arch/arm/core/offsets/offsets.c.obj -MF zephyr/CMakeFiles/offsets.dir/arch/arm/core/offsets/offsets.c.obj.d -o zephyr/CMakeFiles/offsets.dir/arch/arm/core/offsets/offsets.c.obj -c /home/ycsin/zephyrproject/zephyr/arch/arm/core/offsets/offsets.c
In file included from /home/ycsin/zephyrproject/zephyr/include/zephyr/arch/arm/arch.h:36,
                 from /home/ycsin/zephyrproject/zephyr/include/zephyr/arch/cpu.h:19,
                 from /home/ycsin/zephyrproject/zephyr/include/zephyr/kernel_includes.h:36,
                 from /home/ycsin/zephyrproject/zephyr/include/zephyr/kernel.h:17,
                 from /home/ycsin/zephyrproject/zephyr/arch/arm/core/offsets/offsets_aarch32.c:28,
                 from /home/ycsin/zephyrproject/zephyr/arch/arm/core/offsets/offsets.c:9:
/home/ycsin/zephyrproject/zephyr/include/zephyr/arch/arm/gdbstub.h:10:10: fatal error: zephyr/arch/arm/exc.h: No such file or directory
   10 | #include <zephyr/arch/arm/exc.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
ninja: build stopped: subcommand failed.
FATAL ERROR: command exited with status 1: /usr/bin/cmake --build /home/ycsin/zephyrproject/build
```