### PR TITLE
net: l2: ieee802154: mgmt: allow beacon payload

### DIFF
--- a/include/zephyr/net/ieee802154_mgmt.h
+++ b/include/zephyr/net/ieee802154_mgmt.h
@@ -330,6 +330,11 @@ struct ieee802154_req_params {
 	uint8_t len;
 	/** Link quality information, between 0 and 255 */
 	uint8_t lqi;
+
+	/** Additional payload of the beacon if any.*/
+	uint8_t *beacon_payload;
+	/** Length of the additional payload. */
+	size_t beacon_payload_len;
 };
 
 /**

--- a/subsys/net/l2/ieee802154/ieee802154_frame.h
+++ b/subsys/net/l2/ieee802154/ieee802154_frame.h
@@ -472,6 +472,20 @@ ieee802154_validate_aux_security_hdr(uint8_t *buf, uint8_t **p_buf, uint8_t *len
 struct ieee802154_fcf_seq *ieee802154_validate_fc_seq(uint8_t *buf, uint8_t **p_buf,
 						      uint8_t *length);
 
+/**
+ * @brief Calculate the beacon header length.
+ *
+ * @details Returns the length of the MAC payload without the beacon payload,
+ * see section 7.3.1.1, figure 7-5.
+ *
+ * @param buf pointer to the MAC payload
+ * @param length buffer length
+ *
+ * @retval -EINVAL The header is invalid.
+ * @return the length of the beacon header
+ */
+int ieee802514_beacon_header_length(uint8_t *buf, uint8_t length);
+
 bool ieee802154_validate_frame(uint8_t *buf, uint8_t length, struct ieee802154_mpdu *mpdu);
 
 void ieee802154_compute_header_and_authtag_len(struct net_if *iface, struct net_linkaddr *dst,

--- a/subsys/net/l2/ieee802154/ieee802154_mgmt.c
+++ b/subsys/net/l2/ieee802154/ieee802154_mgmt.c
@@ -37,6 +37,7 @@ enum net_verdict ieee802154_handle_beacon(struct net_if *iface,
 					  uint8_t lqi)
 {
 	struct ieee802154_context *ctx = net_if_l2_data(iface);
+	int beacon_hdr_len;
 
 	NET_DBG("Beacon received");
 
@@ -63,6 +64,10 @@ enum net_verdict ieee802154_handle_beacon(struct net_if *iface,
 				mpdu->mhr.src_addr->plain.addr.ext_addr,
 				IEEE802154_EXT_ADDR_LENGTH);
 	}
+
+	beacon_hdr_len = ieee802514_beacon_header_length(mpdu->payload, mpdu->payload_length);
+	ctx->scan_ctx->beacon_payload_len = mpdu->payload_length - beacon_hdr_len;
+	ctx->scan_ctx->beacon_payload = (uint8_t *)mpdu->payload + beacon_hdr_len;
 
 	net_mgmt_event_notify(NET_EVENT_IEEE802154_SCAN_RESULT, iface);
 


### PR DESCRIPTION
The standard does allow for a optional beacon payload, which gets lost during scan, that could be interesting for the application to access in the NET_EVENT_IEEE802154_SCAN_RESULT callback.

See section 7.3.1.6 in IEEE Std 802.15.4 for more information about
the beacon payload field. And section 7.3.1 and figure 7-5 about general
beacon frame format.

In my case, I try to get the MAC-Address of the beacon response frames.