### PR TITLE
net: l2: ieee802154: mgmt: allow beacons without association bit

### DIFF
--- a/include/zephyr/net/ieee802154_mgmt.h
+++ b/include/zephyr/net/ieee802154_mgmt.h
@@ -330,6 +330,8 @@ struct ieee802154_req_params {
 	uint8_t len;
 	/** Link quality information, between 0 and 255 */
 	uint8_t lqi;
+	/** Flag if association is permitted by the coordinator */
+	bool association_permitted;
 
 	/** Additional payload of the beacon if any.*/
 	uint8_t *beacon_payload;

--- a/subsys/net/l2/ieee802154/ieee802154_mgmt.c
+++ b/subsys/net/l2/ieee802154/ieee802154_mgmt.c
@@ -45,9 +45,7 @@ enum net_verdict ieee802154_handle_beacon(struct net_if *iface,
 		return NET_DROP;
 	}
 
-	if (!mpdu->beacon->sf.association) {
-		return NET_DROP;
-	}
+	ctx->scan_ctx->association_permitted = mpdu->beacon->sf.association;
 
 	k_sem_take(&ctx->scan_ctx_lock, K_FOREVER);
 

--- a/subsys/net/l2/ieee802154/ieee802154_shell.c
+++ b/subsys/net/l2/ieee802154/ieee802154_shell.c
@@ -214,9 +214,10 @@ static void scan_result_cb(struct net_mgmt_event_callback *cb,
 	char buf[64];
 
 	shell_fprintf(cb_shell, SHELL_NORMAL,
-		      "\nChannel: %u\tPAN ID: %u\tCoordinator Address: %s\t "
-		      "LQI: %u\n", params.channel, params.pan_id,
-		      print_coordinator_address(buf, sizeof(buf)), params.lqi);
+		      "Channel: %u\tPAN ID: %u\tCoordinator Address: %s\t "
+		      "LQI: %u Associable: %s\n", params.channel, params.pan_id,
+		      print_coordinator_address(buf, sizeof(buf)), params.lqi,
+		      params.association_permitted ? "yes" : "no");
 }
 
 static int cmd_ieee802154_scan(const struct shell *sh,

--- a/tests/net/ieee802154/l2/src/ieee802154_shell_test.c
+++ b/tests/net/ieee802154/l2/src/ieee802154_shell_test.c
@@ -134,8 +134,10 @@ static void test_scan_shell_cmd(void)
 
 	/* The beacon placed into the RX queue will be received and handled as
 	 * soon as this command yields waiting for beacons.
+	 * Scan should be as short as possible, because after 1 second an IPv6
+	 * Router Solicitation package will be placed into the TX queue
 	 */
-	ret = shell_execute_cmd(NULL, "ieee802154 scan active 11 500");
+	ret = shell_execute_cmd(NULL, "ieee802154 scan active 11 10");
 	zassert_equal(0, ret, "Active scan failed: %d", ret);
 
 	zassert_equal(0, k_sem_take(&scan_lock, K_NO_WAIT), "Active scan: did not receive beacon.");


### PR DESCRIPTION
The Association permit bit shall be set to zero if the coordinator does not accept association requests.
Not accepting association request ist not a reason to filter the beacons from this coordinator during network scan. It is still a network, just one you cannot associate with.