### PR TITLE
doc: release-notes-3.7: Add info for bt_foreach_bond and HCI Driver

### DIFF
--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -349,15 +349,19 @@ Bluetooth
     :kconfig:option:`CONFIG_BT_PER_ADV_SYNC_TRANSFER_SENDER` now depend on
     :kconfig:option:`CONFIG_BT_CONN` as they do not work without connections.
 
+  * Improve :c:func:`bt_foreach_bond` to support Bluetooth Classic key traversal.
+
 * HCI Drivers
 
   * Completely redesigned HCI driver interface. See the Bluetooth HCI section in
     :ref:`migration_3.7` for more information.
   * Added support for Ambiq Apollo3 Blue series.
-  * Added support for NXP platforms.
+  * Added support for NXP RW61x.
   * Added support for Infineon CYW208XX.
   * Added support for Renesas SmartBond DA1469x.
   * Removed unmaintained B91 driver.
+  * Added support for NXP IW612 on boards mimxrt1170_evkb and mimxrt1040_evk.
+    It can be enabled by :kconfig:option:`CONFIG_BT_NXP_NW612`.
 
 Boards & SoC Support
 ********************


### PR DESCRIPTION
Add information support for BR key traversal by bt_foreach_bond.
Add information support for NXP IW612 Chipset.