### PR TITLE
coredump: use memmove instead of memcpy

### DIFF
--- a/subsys/debug/coredump/coredump_backend_flash_partition.c
+++ b/subsys/debug/coredump/coredump_backend_flash_partition.c
@@ -525,7 +525,7 @@ static void coredump_flash_backend_buffer_output(uint8_t *buf, size_t buflen)
 			copy_sz = remaining;
 		}
 
-		(void)memcpy(tmp_buf, ptr, copy_sz);
+		(void)memmove(tmp_buf, ptr, copy_sz);
 
 		for (i = 0; i < copy_sz; i++) {
 			backend_ctx.checksum += tmp_buf[i];


### PR DESCRIPTION
With `CONFIG_DEBUG_COREDUMP_MEMORY_DUMP_LINKER_RAM`, `buffer_output()` is called on the entire RAM memory area. This includes the stack for the coredump thread, which is where `tmp_buf` is stored. Eventually, it will copy (parts of) `tmp_buf` into `tmp_buf` itself, which invokes Undefined Behaviour in `memcpy()`:

> The memory areas must not overlap.  Use memmove(3) if the memory areas do
> overlap.
\- memcpy(3)

With picolibc, this is detected in `__memcpy_chk()` and causes a fault in `__chk_fail()`.