### PR TITLE
Mbed-TLS update: do not include/enable legacy symbols in psa-client-only builds

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -282,7 +282,7 @@ manifest:
       revision: 2b498e6f36d6b82ae1da12c8b7742e318624ecf5
       path: modules/lib/gui/lvgl
     - name: mbedtls
-      revision: 2f24831ee13d399ce019c4632b0bcd440a713f7c
+      revision: pull/58/head
       path: modules/crypto/mbedtls
       groups:
         - crypto


### PR DESCRIPTION
## Description

Prior to https://github.com/zephyrproject-rtos/mbedtls/pull/58 when Mbed TLS was built in "pure client mode', i.e. `MBEDTLS_PSA_CRYPTO_CLIENT && !MBEDTLS_PSA_CRYPTO_C`, legacy modules could erroneously be included into the build with the intent to get some builtin support for PSA functions. However this builtin support was not needed in that case because, as we said, Mbed TLS was built as PSA client which means that the PSA core was not required.
https://github.com/zephyrproject-rtos/mbedtls/pull/58 resolves this by removing the builtin support when this is not required.

## Effects of https://github.com/zephyrproject-rtos/mbedtls/pull/58

- TF-M builds the Mbed TLS's PSA core (i.e. `MBEDTLS_PSA_CRYPTO_C` is set) so https://github.com/zephyrproject-rtos/mbedtls/pull/58 has no effect because builtin support is required in this case.
- NS does not build the PSA core (i.e. `MBEDTLS_PSA_CRYPTO_C` is _not_ set) so https://github.com/zephyrproject-rtos/mbedtls/pull/58 removed unnecessary files from the build. In this way we don't rely on the linker to discard them for being unused, we directly remove them from the build, which is cleaner.

## Notes

This PR updates Mbed TLS version in order to include changes introduced by https://github.com/zephyrproject-rtos/mbedtls/pull/58. The manifest will be updated once the referenced PR will be merged.