### PR TITLE
Bluetooth: GATT: Document the bt_gatt_attr::user_data field

### DIFF
--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -173,7 +173,14 @@ struct bt_gatt_attr {
 	bt_gatt_attr_read_func_t read;
 	/** Attribute write callback */
 	bt_gatt_attr_write_func_t write;
-	/** Attribute user data */
+	/** @brief Attribute user data.
+	 *
+	 * When the attribute is a local attribute, this parameter contains
+	 * user provided data.
+	 * When the attribute is a remote attribute obtained through service discovery,
+	 * this parameter contains temporary information about the discovered attribute.
+	 * See @ref bt_gatt_discover_func_t for more details.
+	 */
 	void *user_data;
 	/** Attribute handle */
 	uint16_t handle;


### PR DESCRIPTION
This makes it more clear that this type be casted to other types during service discovery. Previously it was only documented by `bt_gatt_discover_func_t`.

Now it will be easier to find this documentation.