### PR TITLE
soc: riscv: andestech: fixed ae350 hardware configuration issues

### DIFF
--- a/soc/andestech/ae350/Kconfig
+++ b/soc/andestech/ae350/Kconfig
@@ -116,4 +116,15 @@ config SOC_ANDES_V5_IOCP
 		between cache and external non-caching master, such as DMA
 		controller.
 
+config SOC_ANDES_V5_EXCSLVL
+	bool "Andes V5 Exception Additional Save Levels (EXCSLVL)"
+	select RISCV_SOC_CONTEXT_SAVE if PMP_STACK_GUARD
+	default y
+	help
+		This option enables the Andes V5 Exception Additional Save
+		Levels (EXCSLVL). When this feature is supported, there is
+		additional CSRs to save/restore one or two levels of
+		NMI/exception state when NMI/exception entry and exit.
+		e.g. mstatus.MPIE => msavestatus.MPIE1 => msavestatus.MPIE2
+
 endif # SOC_SERIES_ANDES_AE350

--- a/soc/andestech/ae350/soc_context.h
+++ b/soc/andestech/ae350/soc_context.h
@@ -16,8 +16,8 @@
 /* Andes V5 specific registers. */
 #if defined(CONFIG_SOC_ANDES_V5_PFT) && defined(CONFIG_SOC_ANDES_V5_HWDSP)
 	#define SOC_ESF_MEMBERS				\
-		uint32_t mxstatus;			\
-		uint32_t ucode				\
+		unsigned long mxstatus;			\
+		unsigned long ucode			\
 
 	#define SOC_ESF_INIT				\
 		0,					\
@@ -25,14 +25,14 @@
 
 #elif defined(CONFIG_SOC_ANDES_V5_PFT)
 	#define SOC_ESF_MEMBERS				\
-		uint32_t mxstatus
+		unsigned long mxstatus
 
 	#define SOC_ESF_INIT				\
 		0
 
 #elif defined(CONFIG_SOC_ANDES_V5_HWDSP)
 	#define SOC_ESF_MEMBERS				\
-		uint32_t ucode
+		unsigned long ucode
 
 	#define SOC_ESF_INIT				\
 		0

--- a/soc/andestech/ae350/soc_irq.S
+++ b/soc/andestech/ae350/soc_irq.S
@@ -47,6 +47,16 @@ SECTION_FUNC(exception.other, __soc_restore_context)
 #ifdef CONFIG_SOC_ANDES_V5_HWDSP
 	csrw NDS_UCODE, t1
 #endif
+
+#if defined(CONFIG_SOC_ANDES_V5_EXCSLVL) && defined(CONFIG_PMP_STACK_GUARD)
+	/*
+	 * PMP stack guard manages mstatus.MPRV and mstatus.MPP via software.
+	 * Clear msavestatus.MPP1 to prevent the hardware from disabling the PMP
+	 * stack guard by restoring mstatus.MPP.
+	 */
+	csrci NDS_MSAVESTATUS, (0x3 << 1)
+#endif
+
 	ret
 
 #endif /* CONFIG_RISCV_SOC_CONTEXT_SAVE */

--- a/soc/andestech/ae350/soc_irq.S
+++ b/soc/andestech/ae350/soc_irq.S
@@ -11,6 +11,22 @@
 
 #ifdef CONFIG_RISCV_SOC_CONTEXT_SAVE
 
+	.macro lr, rd, mem
+#ifdef CONFIG_RISCV_ISA_RV64I
+	ld \rd, \mem
+#else
+	lw \rd, \mem
+#endif
+	.endm
+
+	.macro sr, rs, mem
+#ifdef CONFIG_RISCV_ISA_RV64I
+	sd \rs, \mem
+#else
+	sw \rs, \mem
+#endif
+	.endm
+
 /* Exports */
 GTEXT(__soc_save_context)
 GTEXT(__soc_restore_context)
@@ -25,20 +41,20 @@ SECTION_FUNC(exception.other, __soc_save_context)
 #endif
 
 #ifdef CONFIG_SOC_ANDES_V5_PFT
-	sw t0, __soc_esf_t_mxstatus_OFFSET(a0)
+	sr t0, __soc_esf_t_mxstatus_OFFSET(a0)
 #endif
 #ifdef CONFIG_SOC_ANDES_V5_HWDSP
-	sw t1, __soc_esf_t_ucode_OFFSET(a0)
+	sr t1, __soc_esf_t_ucode_OFFSET(a0)
 #endif
 	ret
 
 SECTION_FUNC(exception.other, __soc_restore_context)
 
 #ifdef CONFIG_SOC_ANDES_V5_PFT
-	lw t0, __soc_esf_t_mxstatus_OFFSET(a0)
+	lr t0, __soc_esf_t_mxstatus_OFFSET(a0)
 #endif
 #ifdef CONFIG_SOC_ANDES_V5_HWDSP
-	lw t1, __soc_esf_t_ucode_OFFSET(a0)
+	lr t1, __soc_esf_t_ucode_OFFSET(a0)
 #endif
 
 #ifdef CONFIG_SOC_ANDES_V5_PFT

--- a/soc/andestech/ae350/soc_v5.h
+++ b/soc/andestech/ae350/soc_v5.h
@@ -9,6 +9,7 @@
 
 /* Control and Status Registers (CSRs) available for Andes V5 SoCs */
 #define NDS_MMISC_CTL                0x7D0
+#define NDS_MSAVESTATUS              0x7D6
 #define NDS_MCACHE_CTL               0x7CA
 #define NDS_MXSTATUS                 0x7C4
 #define NDS_MCCTLBEGINADDR           0x7CB


### PR DESCRIPTION
This PR fixed 2 hardware issues in Andes AE350 platform.

1. AE350 platform supports RV32/RV64 CPU configuration, but the SoC context only save/restore CSRs for RV32 width. 
This fix saves/restores CSRs with the `unsigned long` type and handle both RV32/RV64 widths properly.

2. Some Andes CPUs have the "Exception Additional Save Level" feature which add more CSRs to save multi-level exception states. However, the new CSR `msavestatus.MPP1` field updates `mstatus.MPP` when MRET and pollute the PMP stack guard configuration.
This fix clears `msavestatus.MPP1` before MRET to keep PMP stack guard functionality after exception exit.