### PR TITLE
lib: os: printk hook cleanups

### DIFF
--- a/drivers/console/efi_console.c
+++ b/drivers/console/efi_console.c
@@ -16,7 +16,7 @@
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 #include <zephyr/sys/printk.h>
-
+#include <zephyr/sys/printk-hooks.h>
 
 extern int efi_console_putchar(int c);
 
@@ -41,10 +41,6 @@ static int console_out(int c)
 
 #if defined(CONFIG_STDOUT_CONSOLE)
 extern void __stdout_hook_install(int (*hook)(int));
-#endif
-
-#if defined(CONFIG_PRINTK)
-extern void __printk_hook_install(int (*fn)(int));
 #endif
 
 /**

--- a/drivers/console/ipm_console.c
+++ b/drivers/console/ipm_console.c
@@ -8,6 +8,7 @@
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 #include <zephyr/drivers/ipm.h>
+#include <zephyr/sys/printk-hooks.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(ipm_console, CONFIG_IPM_LOG_LEVEL);
@@ -43,25 +44,17 @@ static int console_out(int c)
 
 #if defined(CONFIG_STDOUT_CONSOLE)
 extern void __stdout_hook_install(int (*hook)(int));
-#else
-#define __stdout_hook_install(x)	\
-	do {    /* nothing */		\
-	} while ((0))
-#endif
-
-#if defined(CONFIG_PRINTK)
-extern void __printk_hook_install(int (*fn)(int));
-#else
-#define __printk_hook_install(x)	\
-	do {    /* nothing */		\
-	} while ((0))
 #endif
 
 /* Install printk/stdout hooks */
 static void ipm_console_hook_install(void)
 {
+#if defined(CONFIG_STDOUT_CONSOLE)
 	__stdout_hook_install(console_out);
+#endif
+#if defined(CONFIG_PRINTK)
 	__printk_hook_install(console_out);
+#endif
 }
 
 static int ipm_console_init(void)

--- a/drivers/console/ipm_console_sender.c
+++ b/drivers/console/ipm_console_sender.c
@@ -10,6 +10,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
+#include <zephyr/sys/printk-hooks.h>
 #include <zephyr/drivers/ipm.h>
 #include <zephyr/drivers/console/ipm_console.h>
 
@@ -30,7 +31,6 @@ static int consoleOut(int character)
 	return character;
 }
 
-extern void __printk_hook_install(int (*fn)(int));
 extern void __stdout_hook_install(int (*fn)(int));
 
 int ipm_console_sender_init(const struct device *d)

--- a/drivers/console/jailhouse_debug_console.c
+++ b/drivers/console/jailhouse_debug_console.c
@@ -5,6 +5,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
+#include <zephyr/sys/printk-hooks.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 
@@ -27,18 +28,6 @@ static int console_out(int c)
 
 #if defined(CONFIG_STDOUT_CONSOLE)
 extern void __stdout_hook_install(int (*hook)(int));
-#else
-#define __stdout_hook_install(x)		\
-	do {/* nothing */			\
-	} while ((0))
-#endif
-
-#if defined(CONFIG_PRINTK)
-extern void __printk_hook_install(int (*fn)(int));
-#else
-#define __printk_hook_install(x)		\
-	do {/* nothing */			\
-	} while ((0))
 #endif
 
 /**
@@ -47,8 +36,12 @@ extern void __printk_hook_install(int (*fn)(int));
  */
 static int jailhouse_console_init(void)
 {
+#if defined(CONFIG_STDOUT_CONSOLE)
 	__stdout_hook_install(console_out);
+#endif
+#if defined(CONFIG_PRINTK)
 	__printk_hook_install(console_out);
+#endif
 	return 0;
 }
 

--- a/drivers/console/posix_arch_console.c
+++ b/drivers/console/posix_arch_console.c
@@ -7,6 +7,7 @@
 
 #include <zephyr/init.h>
 #include <zephyr/arch/posix/posix_trace.h>
+#include <zephyr/sys/printk-hooks.h>
 
 #define _STDOUT_BUF_SIZE 256
 static char stdout_buff[_STDOUT_BUF_SIZE];
@@ -51,7 +52,6 @@ void posix_flush_stdout(void)
 static int posix_arch_console_init(void)
 {
 #ifdef CONFIG_PRINTK
-	extern void __printk_hook_install(int (*fn)(int));
 	__printk_hook_install(print_char);
 #endif
 #ifdef CONFIG_STDOUT_CONSOLE

--- a/drivers/console/ram_console.c
+++ b/drivers/console/ram_console.c
@@ -10,6 +10,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
+#include <zephyr/sys/printk-hooks.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 #include <zephyr/linker/devicetree_regions.h>
@@ -27,7 +28,6 @@
 #define RAM_CONSOLE_BUF_ATTR
 #endif
 
-extern void __printk_hook_install(int (*fn)(int));
 extern void __stdout_hook_install(int (*fn)(int));
 
 char ram_console_buf[CONFIG_RAM_CONSOLE_BUFFER_SIZE] RAM_CONSOLE_BUF_ATTR;

--- a/drivers/console/rtt_console.c
+++ b/drivers/console/rtt_console.c
@@ -11,11 +11,11 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
+#include <zephyr/sys/printk-hooks.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 #include <SEGGER_RTT.h>
 
-extern void __printk_hook_install(int (*fn)(int));
 extern void __stdout_hook_install(int (*fn)(int));
 
 static bool host_present;

--- a/drivers/console/uart_console.c
+++ b/drivers/console/uart_console.c
@@ -31,6 +31,7 @@
 #include <zephyr/linker/sections.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/printk.h>
+#include <zephyr/sys/printk-hooks.h>
 #include <zephyr/pm/device_runtime.h>
 #ifdef CONFIG_UART_CONSOLE_MCUMGR
 #include <zephyr/mgmt/mcumgr/transport/serial.h>
@@ -112,10 +113,6 @@ static int console_out(int c)
 
 #if defined(CONFIG_STDOUT_CONSOLE)
 extern void __stdout_hook_install(int (*hook)(int c));
-#endif
-
-#if defined(CONFIG_PRINTK)
-extern void __printk_hook_install(int (*fn)(int c));
 #endif
 
 #if defined(CONFIG_CONSOLE_HANDLER)

--- a/drivers/console/winstream_console.c
+++ b/drivers/console/winstream_console.c
@@ -7,6 +7,7 @@
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/winstream.h>
+#include <zephyr/sys/printk-hooks.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/cache.h>
 
@@ -48,24 +49,16 @@ int arch_printk_char_out(int c)
 
 #if defined(CONFIG_STDOUT_CONSOLE)
 extern void __stdout_hook_install(int (*hook)(int));
-#else
-#define __stdout_hook_install(x)		\
-	do {/* nothing */			\
-	} while ((0))
-#endif
-
-#if defined(CONFIG_PRINTK)
-extern void __printk_hook_install(int (*fn)(int));
-#else
-#define __printk_hook_install(x)		\
-	do {/* nothing */			\
-	} while ((0))
 #endif
 
 static void winstream_console_hook_install(void)
 {
+#if defined(CONFIG_STDOUT_CONSOLE)
 	__stdout_hook_install(arch_printk_char_out);
+#endif
+#if defined(CONFIG_PRINTK)
 	__printk_hook_install(arch_printk_char_out);
+#endif
 }
 
 

--- a/drivers/console/xtensa_sim_console.c
+++ b/drivers/console/xtensa_sim_console.c
@@ -6,6 +6,7 @@
 #include <xtensa/simcall.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>
+#include <zephyr/sys/printk-hooks.h>
 
 #if defined(CONFIG_PRINTK) || defined(CONFIG_STDOUT_CONSOLE)
 /**
@@ -35,18 +36,6 @@ int arch_printk_char_out(int c)
 
 #if defined(CONFIG_STDOUT_CONSOLE)
 extern void __stdout_hook_install(int (*hook)(int));
-#else
-#define __stdout_hook_install(x)		\
-	do {/* nothing */			\
-	} while ((0))
-#endif
-
-#if defined(CONFIG_PRINTK)
-extern void __printk_hook_install(int (*fn)(int));
-#else
-#define __printk_hook_install(x)		\
-	do {/* nothing */			\
-	} while ((0))
 #endif
 
 /**
@@ -54,8 +43,12 @@ extern void __printk_hook_install(int (*fn)(int));
  */
 static void xt_sim_console_hook_install(void)
 {
+#if defined(CONFIG_STDOUT_CONSOLE)
 	__stdout_hook_install(arch_printk_char_out);
+#endif
+#if defined(CONFIG_PRINTK)
 	__printk_hook_install(arch_printk_char_out);
+#endif
 }
 
 /**

--- a/drivers/serial/uart_hvc_xen.c
+++ b/drivers/serial/uart_hvc_xen.c
@@ -17,6 +17,7 @@
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/device_mmio.h>
+#include <zephyr/sys/printk-hooks.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(uart_hvc_xen, CONFIG_UART_LOG_LEVEL);
@@ -267,7 +268,6 @@ DEVICE_DT_DEFINE(DT_NODELABEL(xen_hvc), xen_console_init, NULL, &xen_hvc_data,
 		&xen_hvc_api);
 
 #ifdef CONFIG_XEN_EARLY_CONSOLEIO
-extern void __printk_hook_install(int (*fn)(int));
 extern void __stdout_hook_install(int (*fn)(int));
 
 int xen_consoleio_putc(int c)

--- a/include/zephyr/sys/printk-hooks.h
+++ b/include/zephyr/sys/printk-hooks.h
@@ -33,6 +33,6 @@ void __printk_hook_install(printk_hook_fn_t fn);
  *
  * @return a function pointer or NULL if no hook is set
  */
-void *__printk_get_hook(void);
+printk_hook_fn_t __printk_get_hook(void);
 
 #endif /* ZEPHYR_INCLUDE_SYS_PRINTK_HOOKS_H_ */

--- a/include/zephyr/sys/printk-hooks.h
+++ b/include/zephyr/sys/printk-hooks.h
@@ -8,13 +8,22 @@
 #define ZEPHYR_INCLUDE_SYS_PRINTK_HOOKS_H_
 
 /**
+ * @brief printk function handler
+ *
+ * @param c Character to output
+ *
+ * @returns The character passed as input.
+ */
+typedef int (*printk_hook_fn_t)(int c);
+
+/**
  * @brief Install the character output routine for printk
  *
  * To be called by the platform's console driver at init time. Installs a
  * routine that outputs one ASCII character at a time.
  * @param fn putc routine to install
  */
-void __printk_hook_install(int (*fn)(int c));
+void __printk_hook_install(printk_hook_fn_t fn);
 
 /**
  * @brief Get the current character output routine for printk

--- a/include/zephyr/sys/printk-hooks.h
+++ b/include/zephyr/sys/printk-hooks.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_SYS_PRINTK_HOOKS_H_
+#define ZEPHYR_INCLUDE_SYS_PRINTK_HOOKS_H_
+
+/**
+ * @brief Install the character output routine for printk
+ *
+ * To be called by the platform's console driver at init time. Installs a
+ * routine that outputs one ASCII character at a time.
+ * @param fn putc routine to install
+ */
+void __printk_hook_install(int (*fn)(int c));
+
+/**
+ * @brief Get the current character output routine for printk
+ *
+ * To be called by any console driver that would like to save
+ * current hook - if any - for later re-installation.
+ *
+ * @return a function pointer or NULL if no hook is set
+ */
+void *__printk_get_hook(void);
+
+#endif /* ZEPHYR_INCLUDE_SYS_PRINTK_HOOKS_H_ */

--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -53,9 +53,9 @@ __attribute__((weak)) int arch_printk_char_out(int c)
 }
 /* LCOV_EXCL_STOP */
 
-static int (*_char_out)(int c) = arch_printk_char_out;
+static printk_hook_fn_t _char_out = arch_printk_char_out;
 
-void __printk_hook_install(int (*fn)(int c))
+void __printk_hook_install(printk_hook_fn_t fn)
 {
 	_char_out = fn;
 }

--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -52,7 +52,7 @@ __attribute__((weak)) int arch_printk_char_out(int c)
 }
 /* LCOV_EXCL_STOP */
 
-int (*_char_out)(int c) = arch_printk_char_out;
+static int (*_char_out)(int c) = arch_printk_char_out;
 
 /**
  * @brief Install the character output routine for printk

--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -60,7 +60,7 @@ void __printk_hook_install(printk_hook_fn_t fn)
 	_char_out = fn;
 }
 
-void *__printk_get_hook(void)
+printk_hook_fn_t __printk_get_hook(void)
 {
 	return _char_out;
 }

--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -14,6 +14,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
+#include <zephyr/sys/printk-hooks.h>
 #include <stdarg.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/linker/sections.h>
@@ -54,26 +55,11 @@ __attribute__((weak)) int arch_printk_char_out(int c)
 
 static int (*_char_out)(int c) = arch_printk_char_out;
 
-/**
- * @brief Install the character output routine for printk
- *
- * To be called by the platform's console driver at init time. Installs a
- * routine that outputs one ASCII character at a time.
- * @param fn putc routine to install
- */
 void __printk_hook_install(int (*fn)(int c))
 {
 	_char_out = fn;
 }
 
-/**
- * @brief Get the current character output routine for printk
- *
- * To be called by any console driver that would like to save
- * current hook - if any - for later re-installation.
- *
- * @return a function pointer or NULL if no hook is set
- */
 void *__printk_get_hook(void)
 {
 	return _char_out;

--- a/subsys/bluetooth/host/monitor.c
+++ b/subsys/bluetooth/host/monitor.c
@@ -16,6 +16,7 @@
 #include <zephyr/init.h>
 #include <zephyr/drivers/uart_pipe.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/printk-hooks.h>
 #include <zephyr/drivers/uart.h>
 
 #include <zephyr/logging/log_backend.h>
@@ -260,7 +261,6 @@ static int monitor_console_out(int c)
 	return c;
 }
 
-extern void __printk_hook_install(int (*fn)(int));
 extern void __stdout_hook_install(int (*fn)(int));
 #endif /* !CONFIG_UART_CONSOLE && !CONFIG_RTT_CONSOLE && !CONFIG_LOG_PRINTK */
 

--- a/tests/kernel/common/src/printk.c
+++ b/tests/kernel/common/src/printk.c
@@ -5,14 +5,13 @@
  */
 
 #include <zephyr/ztest.h>
+#include <zephyr/sys/printk-hooks.h>
 
 #define BUF_SZ 1024
 
 static int pos;
 char pk_console[BUF_SZ];
 
-void __printk_hook_install(int (*fn)(int));
-void *__printk_get_hook(void);
 int (*_old_char_out)(int);
 
 #if defined(CONFIG_PICOLIBC)


### PR DESCRIPTION
Make `_char_out` static, cleanup the console driver code.

Will follow up on `__stdout_hook_install` separately (https://github.com/zephyrproject-rtos/zephyr/pull/76234).