### PR TITLE
kconfig: zephyr: Set default BUILD_NO_GAP_FILL to Y

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -692,6 +692,7 @@ config CLEANUP_INTERMEDIATE_FILES
 	  (Software Bill of Material generation), and maybe others.
 
 config BUILD_NO_GAP_FILL
+	default y
 	bool "Don't fill gaps in generated hex/bin/s19 files."
 
 config BUILD_OUTPUT_HEX


### PR DESCRIPTION
Set default BUILD_NO_GAP_FILL to Y.
It fixes generation of huge .hex files, even they can have many gigabytes. 
.elf files do not have filled gaps, so no any need to fill gaps for .hex.