### PR TITLE
tests: drivers: nrf_grtc: Add nRF54H20 PPR target

### DIFF
--- a/tests/drivers/timer/nrf_grtc_timer/testcase.yaml
+++ b/tests/drivers/timer/nrf_grtc_timer/testcase.yaml
@@ -7,3 +7,4 @@ tests:
       - nrf54l15bsim/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
+      - nrf54h20dk/nrf54h20/cpuppr


### PR DESCRIPTION
Add nRF54H20 cpu PPR target to GRTC tests.