### PR TITLE
tests: exclude drivers/watchdog/wdt_basic_api from running on it8xxx2_evb

### DIFF
--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -16,6 +16,9 @@ tests:
       - s32z2xxdc2/s32z270/rtu1
       - s32z2xxdc2@D/s32z270/rtu0
       - s32z2xxdc2@D/s32z270/rtu1
+      # excluded it8xxx2_evb because test can't be automate,
+      # and needs external reset, git issue #75389
+      - it8xxx2_evb
   drivers.watchdog.stm32wwdg:
     filter: dt_compat_enabled("st,stm32-window-watchdog") or dt_compat_enabled("st,stm32-watchdog")
     extra_args: DTC_OVERLAY_FILE="boards/stm32_wwdg.overlay"


### PR DESCRIPTION
There is problem with executing this test, because of DBGR mode ,watchdog can't reset board by itself, and it needs cold reset. This proves that test is not automated, and should be exluded on this board. This topic was discussed here: #75389