### PR TITLE
correct layout size for stm32 qspi driver with Dual flash 

### DIFF
--- a/samples/drivers/jesd216/src/main.c
+++ b/samples/drivers/jesd216/src/main.c
@@ -145,7 +145,7 @@ static void summarize_dw11(const struct jesd216_param_header *php,
 	       dw11.page_prog_us,
 	       dw11.typ_max_factor * dw11.page_prog_us);
 
-	printf("Page size: %u By\n", dw11.page_size);
+	printf("Page program size: %u By\n", dw11.page_size);
 }
 
 static void summarize_dw12(const struct jesd216_param_header *php,
@@ -338,7 +338,7 @@ int main(void)
 			const struct jesd216_bfp *bfp = (struct jesd216_bfp *)dw;
 
 			dump_bfp(php, bfp);
-			printf("size = <%u>;\n", (uint32_t)jesd216_bfp_density(bfp));
+			printf("size = <%u> bits;\n", (uint32_t)jesd216_bfp_density(bfp));
 			printf("sfdp-bfp =");
 		} else {
 			printf("sfdp-%04x =", id);


### PR DESCRIPTION
This PR is correcting the flash_size and erase_size of a dual qspi-flash configuration.

As the ref man of the stm32H747 [RM399](https://www.st.com/content/ccc/resource/technical/document/reference_manual/group0/82/40/1a/07/c9/16/40/35/DM00176879/files/DM00176879.pdf/jcr:content/translations/en.DM00176879.pdf) explains:
_The Flash memory size, as specified in FSIZE[4:0] (QUADSPI_DCR[20:16]), should reflect
the total Flash memory capacity, which is double the size of one individual component._

When  QSPI configuration is the dual-flash, the total   flash size and erase size are doubled by the STM32_QSPI_DOUBLE_FLASH multiplier.

For the stm32h747i_disco with dual 64MB qspi-NOR flash devices, the layout reports erase_size = 8192 
and 16384 pages x 8192 bytes per pages  = 134217728 bytes (2 x 64MB)

The size of **one qspi-NOR** device is still reported by its SFDP with
`Flash density: 67108864 bytes`
`size = <536870912> bits; `
`4-KiBy erase: uniform ` 
