### PR TITLE
Fix stack pointer in core dumps

### DIFF
--- a/arch/arm/core/cortex_a_r/swap_helper.S
+++ b/arch/arm/core/cortex_a_r/swap_helper.S
@@ -336,7 +336,7 @@ _context_switch:
 
 _oops:
     /*
-     * Pass the exception frame to z_do_kernel_oops.  r0 contains the
+     * Pass the exception frame to z_do_kernel_oops.  r1 contains the
      * exception reason.
      */
     cps #MODE_SYS

--- a/arch/arm/core/cortex_a_r/swap_helper.S
+++ b/arch/arm/core/cortex_a_r/swap_helper.S
@@ -336,12 +336,14 @@ _context_switch:
 
 _oops:
     /*
-     * Pass the exception frame to z_do_kernel_oops.  r1 contains the
-     * exception reason.
+     * Pass the exception frame to z_do_kernel_oops.
      */
     cps #MODE_SYS
     mov r0, sp
     cps #MODE_SVC
+    /* zero callee_regs and EXC_RETURN (only used on Cortex-M) */
+    mov r1, #0
+    mov r2, #0
     bl z_do_kernel_oops
     b z_arm_int_exit
 

--- a/arch/arm/core/cortex_a_r/switch.S
+++ b/arch/arm/core/cortex_a_r/switch.S
@@ -150,7 +150,7 @@ offload:
 
 _oops:
     /*
-     * Pass the exception frame to z_do_kernel_oops.  r0 contains the
+     * Pass the exception frame to z_do_kernel_oops.  r1 contains the
      * exception reason.
      */
     mov r0, sp

--- a/arch/arm/core/cortex_a_r/switch.S
+++ b/arch/arm/core/cortex_a_r/switch.S
@@ -150,10 +150,12 @@ offload:
 
 _oops:
     /*
-     * Pass the exception frame to z_do_kernel_oops.  r1 contains the
-     * exception reason.
+     * Pass the exception frame to z_do_kernel_oops.
      */
     mov r0, sp
+    /* zero callee_regs and EXC_RETURN (only used on Cortex-M) */
+    mov r1, #0
+    mov r2, #0
     bl z_do_kernel_oops
 
 inv:

--- a/arch/arm/core/cortex_m/fault.c
+++ b/arch/arm/core/cortex_m/fault.c
@@ -1113,7 +1113,7 @@ void z_arm_fault(uint32_t msp, uint32_t psp, uint32_t exc_return,
 		"ESF could not be retrieved successfully. Shall never occur.");
 
 #ifdef CONFIG_DEBUG_COREDUMP
-	z_arm_coredump_fault_sp = POINTER_TO_UINT(esf);
+	z_arm_coredump_fault_sp = POINTER_TO_UINT(esf) + z_arm_get_hw_esf_size(exc_return);
 #endif
 
 	reason = fault_handle(esf, fault, &recoverable);

--- a/arch/arm/core/cortex_m/swap_helper.S
+++ b/arch/arm/core/cortex_m/swap_helper.S
@@ -313,6 +313,7 @@ _oops:
     push {r1, r2}
     push {r4-r11}
     mov  r1, sp /* pointer to _callee_saved_t */
+    mov r2, lr /* EXC_RETURN */
 #endif /* CONFIG_ARMV7_M_ARMV8_M_MAINLINE */
 #endif /* CONFIG_EXTRA_EXCEPTION_INFO */
     bl z_do_kernel_oops

--- a/arch/arm/core/cortex_m/thread.c
+++ b/arch/arm/core/cortex_m/thread.c
@@ -28,11 +28,6 @@
 #define FP_GUARD_EXTRA_SIZE	0
 #endif
 
-#ifndef EXC_RETURN_FTYPE
-/* bit [4] allocate stack for floating-point context: 0=done 1=skipped  */
-#define EXC_RETURN_FTYPE           (0x00000010UL)
-#endif
-
 /* Default last octet of EXC_RETURN, for threads that have not run yet.
  * The full EXC_RETURN value will be e.g. 0xFFFFFFBC.
  */

--- a/arch/arm/core/fatal.c
+++ b/arch/arm/core/fatal.c
@@ -101,11 +101,13 @@ void z_arm_fatal_error(unsigned int reason, const struct arch_esf *esf)
  *
  * @param esf exception frame
  * @param callee_regs Callee-saved registers (R4-R11)
+ * @param exc_return EXC_RETURN value stored in lr on exception entry
  */
-void z_do_kernel_oops(const struct arch_esf *esf, _callee_saved_t *callee_regs)
+void z_do_kernel_oops(const struct arch_esf *esf, _callee_saved_t *callee_regs, uint32_t exc_return)
 {
 #if !(defined(CONFIG_EXTRA_EXCEPTION_INFO) && defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE))
 	ARG_UNUSED(callee_regs);
+	ARG_UNUSED(exc_return);
 #endif
 	/* Stacked R0 holds the exception reason. */
 	unsigned int reason = esf->basic.r0;
@@ -126,6 +128,10 @@ void z_do_kernel_oops(const struct arch_esf *esf, _callee_saved_t *callee_regs)
 	}
 
 #endif /* CONFIG_USERSPACE */
+
+#ifdef CONFIG_DEBUG_COREDUMP
+	z_arm_coredump_fault_sp = POINTER_TO_UINT(esf) + z_arm_get_hw_esf_size(exc_return);
+#endif
 
 #if !defined(CONFIG_EXTRA_EXCEPTION_INFO)
 	z_arm_fatal_error(reason, esf);


### PR DESCRIPTION
The register set in the coredump contains the register values from just before the trap (these are pushed by hardware as the exception stack frame/ESF). Thus, the SP register also needs to point to the stack location from *before* the ESF was pushed; this is simply the location of the ESF plus the size of the ESF.