### PR TITLE
docs: ite: Replace old links

### DIFF
--- a/boards/ite/it82xx2_evb/doc/index.rst
+++ b/boards/ite/it82xx2_evb/doc/index.rst
@@ -220,7 +220,7 @@ Ubuntu
       $ sudo ~/itetool/ite -f build/zephyr/zephyr.bin
 
    .. note:: The source code of ITE tool can be downloaded here:
-    https://www.ite.com.tw/uploads/product_download/itedlb4-linux-v106.tar.bz2
+    https://www.ite.com.tw/upload/2024_01_23/6_20240123162336wu55j1Rjm4.bz2
 
 #. Split first and second terminal windows to view both of them.
    You should see ``"Hello World! it82xx2_evb"`` in the first terminal window.

--- a/boards/ite/it8xxx2_evb/doc/index.rst
+++ b/boards/ite/it8xxx2_evb/doc/index.rst
@@ -79,7 +79,7 @@ Hardware reworks
 
 Before using the it8xxx2_evb, some hardware rework is needed. The HW rework
 guide can be found in ITE's website.
-https://www.ite.com.tw/uploads/product_download/IT81302_MECC_Rework_Guide_0927.pdf
+https://www.ite.com.tw/upload/2024_01_15/6_20240115100309cgdjgcLzX3.pdf
 
 Programming and debugging on it83202
 ************************************
@@ -202,7 +202,7 @@ Ubuntu
       $ sudo ~/itetool/ite -f build/zephyr/zephyr.bin
 
    .. note:: The source code of ITE tool can be downloaded here:
-    https://www.ite.com.tw/uploads/product_download/itedlb4-linux-v106.tar.bz2
+    https://www.ite.com.tw/upload/2024_01_23/6_20240123162336wu55j1Rjm4.bz2
 
 #. Split first and second terminal windows to view both of them.
    You should see ``"Hello World! it8xxx2_evb"`` in the first terminal window.
@@ -224,5 +224,5 @@ References
 
 .. target-notes::
 
-.. _ITE's website: http://www.ite.com.tw/en/product/view?mid=149
+.. _ITE's website: https://www.ite.com.tw/en/product/cate2/IT81202
 .. _Zephyr Getting Started Guide: https://docs.zephyrproject.org/latest/getting_started/index.html


### PR DESCRIPTION
ITE website had rework, and some of the links don't work.