### PR TITLE
drivers: sensor: add microchip mcp9843 driver 

### DIFF
--- a/drivers/sensor/microchip/CMakeLists.txt
+++ b/drivers/sensor/microchip/CMakeLists.txt
@@ -5,6 +5,7 @@
 add_subdirectory_ifdef(CONFIG_MCP9600 mcp9600)
 add_subdirectory_ifdef(CONFIG_MCP970X mcp970x)
 add_subdirectory_ifdef(CONFIG_MCP9808 mcp9808)
+add_subdirectory_ifdef(CONFIG_MCP9843 mcp9843)
 add_subdirectory_ifdef(CONFIG_TACH_XEC mchp_tach_xec)
 add_subdirectory_ifdef(CONFIG_TCN75A tcn75a)
 # zephyr-keep-sorted-stop

--- a/drivers/sensor/microchip/Kconfig
+++ b/drivers/sensor/microchip/Kconfig
@@ -6,5 +6,6 @@ source "drivers/sensor/microchip/mchp_tach_xec/Kconfig"
 source "drivers/sensor/microchip/mcp9600/Kconfig"
 source "drivers/sensor/microchip/mcp970x/Kconfig"
 source "drivers/sensor/microchip/mcp9808/Kconfig"
+source "drivers/sensor/microchip/mcp9843/Kconfig"
 source "drivers/sensor/microchip/tcn75a/Kconfig"
 # zephyr-keep-sorted-stop

--- a/drivers/sensor/microchip/mcp9843/CMakeLists.txt
+++ b/drivers/sensor/microchip/mcp9843/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Copyright 2024 Vogl Electronic GmbH
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+zephyr_library_sources(mcp9843.c)

--- a/drivers/sensor/microchip/mcp9843/Kconfig
+++ b/drivers/sensor/microchip/mcp9843/Kconfig
@@ -1,0 +1,10 @@
+# Copyright 2024 Vogl Electronic GmbH
+# SPDX-License-Identifier: Apache-2.0
+
+config MCP9843
+	bool "MCP9843 temperature sensor"
+	default y
+	depends on DT_HAS_MICROCHIP_MCP9843_ENABLED
+	select I2C
+	help
+	  Enable MCP9843 temperature sensor support.

--- a/drivers/sensor/microchip/mcp9843/mcp9843.c
+++ b/drivers/sensor/microchip/mcp9843/mcp9843.c
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2024 Vogl Electronic GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT microchip_mcp9843
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/byteorder.h>
+
+LOG_MODULE_REGISTER(MCP9843, CONFIG_SENSOR_LOG_LEVEL);
+
+#define MCP9843_REG_AMBIENT_TEMP 0x05
+#define MCP9843_REG_ID_REVISION  0x07
+#define MCP9843_REG_RESOLUTION   0x08
+
+#define MCP9843_TEMP_SCALE_CEL 16
+
+struct mcp9843_data {
+	uint8_t temp_buf[2];
+};
+
+struct mcp9843_config {
+	const struct i2c_dt_spec bus;
+	uint8_t resolution;
+};
+
+static int mcp9843_reg_read(const struct device *dev, uint8_t start, uint8_t *buf, int size)
+{
+	const struct mcp9843_config *cfg = dev->config;
+
+	return i2c_burst_read_dt(&cfg->bus, start, buf, size);
+}
+
+static int mcp9843_set_temperature_resolution(const struct device *dev, uint8_t resolution)
+{
+	const struct mcp9843_config *cfg = dev->config;
+
+	return i2c_reg_write_byte_dt(&cfg->bus, MCP9843_REG_RESOLUTION, resolution);
+}
+
+static int mcp9843_sample_fetch(const struct device *dev, enum sensor_channel chan)
+{
+	struct mcp9843_data *data = dev->data;
+	uint8_t buf[2];
+	int ret;
+
+	if (chan != SENSOR_CHAN_ALL && chan != SENSOR_CHAN_AMBIENT_TEMP) {
+		LOG_ERR("Unsupported sensor channel");
+		return -ENOTSUP;
+	}
+
+	ret = mcp9843_reg_read(dev, MCP9843_REG_AMBIENT_TEMP, buf, sizeof(buf));
+	if (ret < 0) {
+		LOG_ERR("Failed to read data");
+		return ret;
+	}
+
+	data->temp_buf[0] = buf[0];	
+	data->temp_buf[1] = buf[1];
+
+	return 0;
+}
+
+static int mcp9843_channel_get(const struct device *dev, enum sensor_channel chan,
+			       struct sensor_value *val)
+{
+	struct mcp9843_data *data = dev->data;
+	int temp;
+
+	if (chan != SENSOR_CHAN_AMBIENT_TEMP) {
+		return -ENOTSUP;
+	}
+
+
+	data->temp_buf[0] &= 0x1F; /* mask out flags */
+
+	if ((data->temp_buf[0] & 0x10) == 0x10) {
+		/* negative temperature */
+		data->temp_buf[0] &= 0x0F;
+		temp = sys_get_be16(data->temp_buf) - 4096;
+	} else {
+		/* positive temperature */
+		temp = sys_get_be16(data->temp_buf);
+	}
+
+	val->val1 = temp / MCP9843_TEMP_SCALE_CEL;
+	val->val2 = (temp * 1000000 / MCP9843_TEMP_SCALE_CEL) % 1000000;
+
+	return 0;
+}
+
+static const struct sensor_driver_api mcp9843_api = {
+	.sample_fetch = mcp9843_sample_fetch,
+	.channel_get = mcp9843_channel_get,
+};
+
+static int mcp9843_init(const struct device *dev)
+{
+	const struct mcp9843_config *cfg = dev->config;
+	uint8_t buf[2];
+	int ret;
+
+	if (!i2c_is_ready_dt(&cfg->bus)) {
+		LOG_ERR("mcp9843 i2c bus %s not ready", cfg->bus.bus->name);
+		return -ENODEV;
+	}
+
+	ret = mcp9843_reg_read(dev, MCP9843_REG_ID_REVISION, buf, sizeof(buf));
+	if (ret < 0) {
+		LOG_ERR("Failed to read chip id");
+		return ret;
+	}
+	LOG_DBG("id: 0x%02x version: 0x%02x", buf[0], buf[1]);
+
+	ret = mcp9843_set_temperature_resolution(dev, cfg->resolution);
+	if (ret < 0) {
+		LOG_ERR("Failed to set temperature resolution");
+		return ret;
+	}
+
+	return ret;
+}
+
+#define MCP9843_DEFINE(n)                                                                          \
+	static struct mcp9843_data mcp9843_data_##n;                                               \
+                                                                                                   \
+	static const struct mcp9843_config mcp9843_config_##n = {                                  \
+		.bus = I2C_DT_SPEC_INST_GET(n),                                                    \
+		.resolution = DT_INST_PROP(n, resolution),                                         \
+	};                                                                                         \
+                                                                                                   \
+	SENSOR_DEVICE_DT_INST_DEFINE(n, mcp9843_init, NULL, &mcp9843_data_##n,                     \
+				     &mcp9843_config_##n, POST_KERNEL,                             \
+				     CONFIG_SENSOR_INIT_PRIORITY, &mcp9843_api);
+
+DT_INST_FOREACH_STATUS_OKAY(MCP9843_DEFINE)

--- a/dts/bindings/sensor/microchip,mcp9843.yaml
+++ b/dts/bindings/sensor/microchip,mcp9843.yaml
@@ -1,0 +1,28 @@
+# Copyright (c) 2024 Vogl Electronic GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Microchip MCP9842/98243 I2C Thermocouple EMF to Temperature Converter. See
+  https://www.microchip.com/wwwproducts/en/MCP9600.
+
+compatible: "microchip,mcp9843"
+
+include: [sensor-device.yaml, i2c-device.yaml]
+
+properties:
+  resolution:
+    type: int
+    default: 1
+    description: |
+      Sensor resolution. Default is 0.25°C (0b01),
+      which is the power-up default.
+      0 = 0.5°C
+      1 = 0.25°C
+      2 = 0.125°C
+      3 = 0.0625°C
+    enum:
+      - 0
+      - 1
+      - 2
+      - 3

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -1082,3 +1082,9 @@ test_i2c_icm42670: icm42670@92 {
 	gyro-hz = <800>;
 	gyro-fs = <2000>;
 };
+
+test_i2c_mcp9843@93 {
+	compatible = "microchip,mcp9843";
+	reg = <0x93>;
+	resolution = <3>;
+};


### PR DESCRIPTION
add driver for microchip mcp9843, which is a temperature sensor.
