### PR TITLE
libc, console: declare __stdout_hook_install in libc-hooks.h

### DIFF
--- a/drivers/console/efi_console.c
+++ b/drivers/console/efi_console.c
@@ -17,6 +17,7 @@
 #include <zephyr/init.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/printk-hooks.h>
+#include <zephyr/sys/libc-hooks.h>
 
 extern int efi_console_putchar(int c);
 
@@ -37,10 +38,6 @@ static int console_out(int c)
 	return efi_console_putchar(c);
 }
 
-#endif
-
-#if defined(CONFIG_STDOUT_CONSOLE)
-extern void __stdout_hook_install(int (*hook)(int));
 #endif
 
 /**

--- a/drivers/console/ipm_console.c
+++ b/drivers/console/ipm_console.c
@@ -9,6 +9,7 @@
 #include <zephyr/init.h>
 #include <zephyr/drivers/ipm.h>
 #include <zephyr/sys/printk-hooks.h>
+#include <zephyr/sys/libc-hooks.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(ipm_console, CONFIG_IPM_LOG_LEVEL);
@@ -41,10 +42,6 @@ static int console_out(int c)
 
 	return c;
 }
-
-#if defined(CONFIG_STDOUT_CONSOLE)
-extern void __stdout_hook_install(int (*hook)(int));
-#endif
 
 /* Install printk/stdout hooks */
 static void ipm_console_hook_install(void)

--- a/drivers/console/ipm_console_sender.c
+++ b/drivers/console/ipm_console_sender.c
@@ -17,7 +17,7 @@
 
 static const struct device *ipm_console_device;
 
-static int consoleOut(int character)
+static int console_out(int character)
 {
 	if (character == '\r') {
 		return character;
@@ -46,10 +46,10 @@ int ipm_console_sender_init(const struct device *d)
 	}
 
 	if (config_info->flags & IPM_CONSOLE_STDOUT) {
-		__stdout_hook_install(consoleOut);
+		__stdout_hook_install(console_out);
 	}
 	if (config_info->flags & IPM_CONSOLE_PRINTK) {
-		__printk_hook_install(consoleOut);
+		__printk_hook_install(console_out);
 	}
 
 	return 0;

--- a/drivers/console/ipm_console_sender.c
+++ b/drivers/console/ipm_console_sender.c
@@ -11,6 +11,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/printk-hooks.h>
+#include <zephyr/sys/libc-hooks.h>
 #include <zephyr/drivers/ipm.h>
 #include <zephyr/drivers/console/ipm_console.h>
 
@@ -30,8 +31,6 @@ static int consoleOut(int character)
 
 	return character;
 }
-
-extern void __stdout_hook_install(int (*fn)(int));
 
 int ipm_console_sender_init(const struct device *d)
 {

--- a/drivers/console/jailhouse_debug_console.c
+++ b/drivers/console/jailhouse_debug_console.c
@@ -6,6 +6,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/printk-hooks.h>
+#include <zephyr/sys/libc-hooks.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 
@@ -24,10 +25,6 @@ static int console_out(int c)
 			  : "+r" (x0), "+r" (x1) : : );
 	return c;
 }
-#endif
-
-#if defined(CONFIG_STDOUT_CONSOLE)
-extern void __stdout_hook_install(int (*hook)(int));
 #endif
 
 /**

--- a/drivers/console/posix_arch_console.c
+++ b/drivers/console/posix_arch_console.c
@@ -8,6 +8,7 @@
 #include <zephyr/init.h>
 #include <zephyr/arch/posix/posix_trace.h>
 #include <zephyr/sys/printk-hooks.h>
+#include <zephyr/sys/libc-hooks.h>
 
 #define _STDOUT_BUF_SIZE 256
 static char stdout_buff[_STDOUT_BUF_SIZE];
@@ -55,7 +56,6 @@ static int posix_arch_console_init(void)
 	__printk_hook_install(print_char);
 #endif
 #ifdef CONFIG_STDOUT_CONSOLE
-	extern void __stdout_hook_install(int (*fn)(int));
 	__stdout_hook_install(print_char);
 #endif
 	return 0;

--- a/drivers/console/ram_console.c
+++ b/drivers/console/ram_console.c
@@ -11,6 +11,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/printk-hooks.h>
+#include <zephyr/sys/libc-hooks.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 #include <zephyr/linker/devicetree_regions.h>
@@ -27,8 +28,6 @@
 #else
 #define RAM_CONSOLE_BUF_ATTR
 #endif
-
-extern void __stdout_hook_install(int (*fn)(int));
 
 char ram_console_buf[CONFIG_RAM_CONSOLE_BUFFER_SIZE] RAM_CONSOLE_BUF_ATTR;
 char *ram_console;

--- a/drivers/console/rtt_console.c
+++ b/drivers/console/rtt_console.c
@@ -12,11 +12,10 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/printk-hooks.h>
+#include <zephyr/sys/libc-hooks.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 #include <SEGGER_RTT.h>
-
-extern void __stdout_hook_install(int (*fn)(int));
 
 static bool host_present;
 

--- a/drivers/console/semihost_console.c
+++ b/drivers/console/semihost_console.c
@@ -7,8 +7,7 @@
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 #include <zephyr/arch/common/semihost.h>
-
-extern void __stdout_hook_install(int (*fn)(int));
+#include <zephyr/sys/libc-hooks.h>
 
 int arch_printk_char_out(int _c)
 {
@@ -18,7 +17,6 @@ int arch_printk_char_out(int _c)
 
 static int semihost_console_init(void)
 {
-
 	/*
 	 * The printk output callback is arch_printk_char_out by default and
 	 * is installed at link time. That makes printk() usable very early.

--- a/drivers/console/uart_console.c
+++ b/drivers/console/uart_console.c
@@ -32,6 +32,7 @@
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/printk-hooks.h>
+#include <zephyr/sys/libc-hooks.h>
 #include <zephyr/pm/device_runtime.h>
 #ifdef CONFIG_UART_CONSOLE_MCUMGR
 #include <zephyr/mgmt/mcumgr/transport/serial.h>
@@ -109,10 +110,6 @@ static int console_out(int c)
 	return c;
 }
 
-#endif
-
-#if defined(CONFIG_STDOUT_CONSOLE)
-extern void __stdout_hook_install(int (*hook)(int c));
 #endif
 
 #if defined(CONFIG_CONSOLE_HANDLER)

--- a/drivers/console/winstream_console.c
+++ b/drivers/console/winstream_console.c
@@ -8,6 +8,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/winstream.h>
 #include <zephyr/sys/printk-hooks.h>
+#include <zephyr/sys/libc-hooks.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/cache.h>
 
@@ -46,10 +47,6 @@ int arch_printk_char_out(int c)
 	winstream_console_trace_out(&s, 1);
 	return 0;
 }
-
-#if defined(CONFIG_STDOUT_CONSOLE)
-extern void __stdout_hook_install(int (*hook)(int));
-#endif
 
 static void winstream_console_hook_install(void)
 {

--- a/drivers/console/xtensa_sim_console.c
+++ b/drivers/console/xtensa_sim_console.c
@@ -7,6 +7,7 @@
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 #include <zephyr/sys/printk-hooks.h>
+#include <zephyr/sys/libc-hooks.h>
 
 #if defined(CONFIG_PRINTK) || defined(CONFIG_STDOUT_CONSOLE)
 /**
@@ -32,10 +33,6 @@ int arch_printk_char_out(int c)
 				: "memory");
 	return c;
 }
-#endif
-
-#if defined(CONFIG_STDOUT_CONSOLE)
-extern void __stdout_hook_install(int (*hook)(int));
 #endif
 
 /**

--- a/drivers/serial/uart_hvc_xen.c
+++ b/drivers/serial/uart_hvc_xen.c
@@ -18,6 +18,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/device_mmio.h>
 #include <zephyr/sys/printk-hooks.h>
+#include <zephyr/sys/libc-hooks.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(uart_hvc_xen, CONFIG_UART_LOG_LEVEL);
@@ -268,8 +269,6 @@ DEVICE_DT_DEFINE(DT_NODELABEL(xen_hvc), xen_console_init, NULL, &xen_hvc_data,
 		&xen_hvc_api);
 
 #ifdef CONFIG_XEN_EARLY_CONSOLEIO
-extern void __stdout_hook_install(int (*fn)(int));
-
 int xen_consoleio_putc(int c)
 {
 	char symbol = (char) c;

--- a/include/zephyr/sys/libc-hooks.h
+++ b/include/zephyr/sys/libc-hooks.h
@@ -44,6 +44,8 @@ __syscall size_t zephyr_fwrite(const void *ZRESTRICT ptr, size_t size,
 
 #endif /* CONFIG_NEWLIB_LIBC */
 
+void __stdout_hook_install(int (*hook)(int));
+
 #ifdef CONFIG_USERSPACE
 #ifdef CONFIG_COMMON_LIBC_MALLOC
 

--- a/subsys/bluetooth/host/monitor.c
+++ b/subsys/bluetooth/host/monitor.c
@@ -17,6 +17,7 @@
 #include <zephyr/drivers/uart_pipe.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/printk-hooks.h>
+#include <zephyr/sys/libc-hooks.h>
 #include <zephyr/drivers/uart.h>
 
 #include <zephyr/logging/log_backend.h>
@@ -260,8 +261,6 @@ static int monitor_console_out(int c)
 
 	return c;
 }
-
-extern void __stdout_hook_install(int (*fn)(int));
 #endif /* !CONFIG_UART_CONSOLE && !CONFIG_RTT_CONSOLE && !CONFIG_LOG_PRINTK */
 
 #ifndef CONFIG_LOG_MODE_MINIMAL


### PR DESCRIPTION
Declare __stdout_hook_install in libc-hooks.h and use it in the console drivers rather than redeclare it every time.