### PR TITLE
net: context: Check null pointer in V6ONLY getsockopt

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -105,6 +105,10 @@ bool net_context_is_reuseport_set(struct net_context *context)
 bool net_context_is_v6only_set(struct net_context *context)
 {
 #if defined(CONFIG_NET_IPV4_MAPPING_TO_IPV6)
+	if (context == NULL) {
+		return false;
+	}
+
 	return context->options.ipv6_v6only;
 #else
 	ARG_UNUSED(context);


### PR DESCRIPTION
Make sure we are not accessing NULL pointer when checking if the IPv4 mapping to IPv6 is enabled.