### PR TITLE
 usb: device_next: add usbd_device_set_bcd_device()

### DIFF
--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -959,8 +959,8 @@ enum usbd_speed usbd_caps_speed(const struct usbd_context *const uds_ctx);
  *
  * @return 0 on success, other values on fail.
  */
-int usbd_device_set_bcd(struct usbd_context *const uds_ctx,
-			const enum usbd_speed speed, const uint16_t bcd);
+int usbd_device_set_bcd_usb(struct usbd_context *const uds_ctx,
+			    const enum usbd_speed speed, const uint16_t bcd);
 
 /**
  * @brief Set USB device descriptor value idVendor

--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -985,6 +985,17 @@ int usbd_device_set_pid(struct usbd_context *const uds_ctx,
 			const uint16_t pid);
 
 /**
+ * @brief Set USB device descriptor value bcdDevice
+ *
+ * @param[in] uds_ctx Pointer to USB device support context
+ * @param[in] bcd     bcdDevice value
+ *
+ * @return 0 on success, other values on fail.
+ */
+int usbd_device_set_bcd_device(struct usbd_context *const uds_ctx,
+			       const uint16_t bcd);
+
+/**
  * @brief Set USB device descriptor code triple Base Class, SubClass, and Protocol
  *
  * @param[in] uds_ctx    Pointer to USB device support context

--- a/samples/subsys/usb/common/sample_usbd_init.c
+++ b/samples/subsys/usb/common/sample_usbd_init.c
@@ -159,8 +159,8 @@ struct usbd_context *sample_usbd_init_device(usbd_msg_cb_t msg_cb)
 	}
 
 	if (IS_ENABLED(CONFIG_SAMPLE_USBD_20_EXTENSION_DESC)) {
-		(void)usbd_device_set_bcd(&sample_usbd, USBD_SPEED_FS, 0x0201);
-		(void)usbd_device_set_bcd(&sample_usbd, USBD_SPEED_HS, 0x0201);
+		(void)usbd_device_set_bcd_usb(&sample_usbd, USBD_SPEED_FS, 0x0201);
+		(void)usbd_device_set_bcd_usb(&sample_usbd, USBD_SPEED_HS, 0x0201);
 
 		err = usbd_add_descriptor(&sample_usbd, &sample_usbext);
 		if (err) {

--- a/subsys/usb/device_next/usbd_device.c
+++ b/subsys/usb/device_next/usbd_device.c
@@ -121,6 +121,30 @@ set_pid_exit:
 	return ret;
 }
 
+int usbd_device_set_bcd_device(struct usbd_context *const uds_ctx,
+			       const uint16_t bcd)
+{
+	struct usb_device_descriptor *fs_desc, *hs_desc;
+	int ret = 0;
+
+	usbd_device_lock(uds_ctx);
+
+	if (usbd_is_enabled(uds_ctx)) {
+		ret = -EALREADY;
+		goto set_bcd_device_exit;
+	}
+
+	fs_desc = get_device_descriptor(uds_ctx, USBD_SPEED_FS);
+	fs_desc->bcdDevice = sys_cpu_to_le16(bcd);
+
+	hs_desc = get_device_descriptor(uds_ctx, USBD_SPEED_HS);
+	hs_desc->bcdDevice = sys_cpu_to_le16(bcd);
+
+set_bcd_device_exit:
+	usbd_device_unlock(uds_ctx);
+	return ret;
+}
+
 int usbd_device_set_code_triple(struct usbd_context *const uds_ctx,
 				const enum usbd_speed speed,
 				const uint8_t base_class,

--- a/subsys/usb/device_next/usbd_device.c
+++ b/subsys/usb/device_next/usbd_device.c
@@ -52,8 +52,8 @@ get_device_descriptor(struct usbd_context *const uds_ctx,
 	}
 }
 
-int usbd_device_set_bcd(struct usbd_context *const uds_ctx,
-			const enum usbd_speed speed, const uint16_t bcd)
+int usbd_device_set_bcd_usb(struct usbd_context *const uds_ctx,
+			    const enum usbd_speed speed, const uint16_t bcd)
 {
 	struct usb_device_descriptor *desc;
 	int ret = 0;

--- a/subsys/usb/device_next/usbd_shell.c
+++ b/subsys/usb/device_next/usbd_shell.c
@@ -285,14 +285,14 @@ static int cmd_select(const struct shell *sh, size_t argc, char **argv)
 	return -ENODEV;
 }
 
-static int cmd_device_bcd(const struct shell *sh, size_t argc,
-			  char *argv[])
+static int cmd_device_bcd_usb(const struct shell *sh, size_t argc,
+			      char *argv[])
 {
 	uint16_t bcd;
 	int ret;
 
 	bcd = strtol(argv[2], NULL, 16);
-	ret = usbd_device_set_bcd(my_uds_ctx, current_cmd_speed, bcd);
+	ret = usbd_device_set_bcd_usb(my_uds_ctx, current_cmd_speed, bcd);
 	if (ret) {
 		shell_error(sh, "dev: failed to set device bcdUSB to %x", bcd);
 	} else {
@@ -568,9 +568,9 @@ SHELL_STATIC_SUBCMD_SET_CREATE(device_cmds,
 	SHELL_CMD_ARG(vid, NULL,
 		      "<idVendor> sets device Vendor ID",
 		      cmd_device_vid, 2, 0),
-	SHELL_CMD_ARG(bcd, &dsub_config_speed,
-		      "<speed> <bcdUSB> sets device release number",
-		      cmd_device_bcd, 3, 0),
+	SHELL_CMD_ARG(bcd_usb, &dsub_config_speed,
+		      "<speed> <bcdUSB> sets device USB specification version",
+		      cmd_device_bcd_usb, 3, 0),
 	SHELL_CMD_ARG(triple, &dsub_config_speed,
 		      "<speed> <Base Class> <SubClass> <Protocol> sets device code triple",
 		      cmd_device_code_triple, 5, 0),


### PR DESCRIPTION
- Rename `usbd_device_set_bcd()` to `usbd_device_set_bcd_usb()` to make room for other BCD encoded values being set.
- Add `usbd_device_set_bcd_device()` for setting the `bcdDevice` device descriptor value. The default `bcdDevice` is set to the version of Zephyr being used, which may or may not be what a downstream USB device wants it to be.