### PR TITLE
Add flash support for NXP frdm_ke17z and frdm_ke17z512

### DIFF
--- a/boards/nxp/frdm_ke17z/frdm_ke17z.dts
+++ b/boards/nxp/frdm_ke17z/frdm_ke17z.dts
@@ -74,3 +74,31 @@
 &gpioe {
 	status = "okay";
 };
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x0 DT_SIZE_K(44)>;
+		};
+		/* The MCUBoot swap-move algorithm uses the last 2 sectors
+		 * of the primary slot0 for swap status and move.
+		 */
+		slot0_partition: partition@b000 {
+			label = "image-0";
+			reg = <0xb000 (DT_SIZE_K(98) + DT_SIZE_K(4))>;
+		};
+		slot1_partition: partition@24800 {
+			label = "image-1";
+			reg = <0x24800 DT_SIZE_K(98)>;
+		};
+		storage_partition: partition@3d000 {
+			label = "storage";
+			reg = <0x3d000 DT_SIZE_K(12)>;
+		};
+	};
+};

--- a/boards/nxp/frdm_ke17z512/frdm_ke17z512.dts
+++ b/boards/nxp/frdm_ke17z512/frdm_ke17z512.dts
@@ -86,3 +86,32 @@
 	pinctrl-0 = <&lpi2c1_default>;
 	pinctrl-names = "default";
 };
+
+&flash0 {
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(64)>;
+			read-only;
+		};
+		/* The MCUBoot swap-move algorithm uses the last 2 sectors
+		 * of the primary slot0 for swap status and move.
+		 */
+		slot0_partition: partition@10000 {
+			label = "image-0";
+			reg = <0x00010000 (DT_SIZE_K(202) + DT_SIZE_K(4))>;
+		};
+		slot1_partition: partition@43800 {
+			label = "image-1";
+			reg = <0x00043800 DT_SIZE_K(202)>;
+		};
+		storage_partition: partition@76000 {
+			label = "storage";
+			reg = <0x00076000 DT_SIZE_K(40)>;
+		};
+	};
+};

--- a/samples/subsys/fs/littlefs/sample.yaml
+++ b/samples/subsys/fs/littlefs/sample.yaml
@@ -25,6 +25,8 @@ tests:
       - stm32h747i_disco/stm32h747xx/m7
       - stm32h750b_dk
       - nrf54l15pdk/nrf54l15/cpuapp
+      - frdm_ke17z
+      - frdm_ke17z512
     integration_platforms:
       - nrf52840dk/nrf52840
   sample.filesystem.littlefs.blk:


### PR DESCRIPTION
Tested:
tests/kernel/xip
tests/drivers/flash/common
tests/subsys/fs/fs_api
samples/subsys/fs/littlefs

Report a bug https://github.com/zephyrproject-rtos/zephyr/issues/76321 that littleFs test case does not support non 4096b erase block size.