### PR TITLE
Bluetooth: BR: SM: Fix ltk derive issue

### DIFF
--- a/subsys/bluetooth/host/classic/l2cap_br_interface.h
+++ b/subsys/bluetooth/host/classic/l2cap_br_interface.h
@@ -7,6 +7,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* Need a name different than bt_l2cap_fixed_chan for a different section */
+struct bt_l2cap_br_fixed_chan {
+	uint16_t		cid;
+	int (*accept)(struct bt_conn *conn, struct bt_l2cap_chan **chan);
+};
+
+#define BT_L2CAP_BR_CHANNEL_DEFINE(_name, _cid, _accept)		\
+	const STRUCT_SECTION_ITERABLE(bt_l2cap_br_fixed_chan, _name) = { \
+				.cid = _cid,			\
+				.accept = _accept,		\
+			}
+
 /* Initialize BR/EDR L2CAP signal layer */
 void bt_l2cap_br_init(void);
 
@@ -51,3 +63,7 @@ void bt_l2cap_br_recv(struct bt_conn *conn, struct net_buf *buf);
 struct net_buf *l2cap_br_data_pull(struct bt_conn *conn,
 				   size_t amount,
 				   size_t *length);
+
+/* Find L2CAP BR channel by using specific cid on specific connection */
+struct bt_l2cap_chan *bt_l2cap_br_lookup_tx_cid(struct bt_conn *conn,
+						uint16_t cid);

--- a/subsys/bluetooth/host/classic/l2cap_br_internal.h
+++ b/subsys/bluetooth/host/classic/l2cap_br_internal.h
@@ -131,18 +131,6 @@ struct bt_l2cap_info_rsp {
 	uint8_t  data[0];
 } __packed;
 
-/* Need a name different than bt_l2cap_fixed_chan for a different section */
-struct bt_l2cap_br_fixed_chan {
-	uint16_t		cid;
-	int (*accept)(struct bt_conn *conn, struct bt_l2cap_chan **chan);
-};
-
-#define BT_L2CAP_BR_CHANNEL_DEFINE(_name, _cid, _accept)		\
-	const STRUCT_SECTION_ITERABLE(bt_l2cap_br_fixed_chan, _name) = { \
-				.cid = _cid,			\
-				.accept = _accept,		\
-			}
-
 #define BR_CHAN(_ch) CONTAINER_OF(_ch, struct bt_l2cap_br_chan, chan)
 
 /* Add channel to the connection */

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -37,7 +37,6 @@
 #include "keys.h"
 #include "conn_internal.h"
 #include "l2cap_internal.h"
-#include "classic/l2cap_br_interface.h"
 #include "smp.h"
 
 #define LOG_LEVEL CONFIG_BT_SMP_LOG_LEVEL
@@ -710,7 +709,7 @@ static void smp_check_complete(struct bt_conn *conn, uint8_t dist_complete)
 	if (conn->type == BT_CONN_TYPE_BR) {
 		struct bt_smp_br *smp;
 
-		chan = bt_l2cap_le_lookup_tx_cid(conn, BT_L2CAP_CID_BR_SMP);
+		chan = bt_l2cap_br_lookup_tx_cid(conn, BT_L2CAP_CID_BR_SMP);
 		__ASSERT(chan, "No SMP channel found");
 
 		smp = CONTAINER_OF(chan, struct bt_smp_br, chan.chan);
@@ -1462,7 +1461,7 @@ static int smp_br_error(struct bt_smp_br *smp, uint8_t reason)
 	 * SMP timer is not restarted for PairingFailed so don't use
 	 * smp_br_send
 	 */
-	if (bt_l2cap_br_send_cb(smp->chan.chan.conn, BT_L2CAP_CID_SMP, buf,
+	if (bt_l2cap_br_send_cb(smp->chan.chan.conn, BT_L2CAP_CID_BR_SMP, buf,
 				NULL, NULL)) {
 		net_buf_unref(buf);
 	}
@@ -6037,8 +6036,8 @@ static int bt_smp_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 
 BT_L2CAP_CHANNEL_DEFINE(smp_fixed_chan, BT_L2CAP_CID_SMP, bt_smp_accept, NULL);
 #if defined(CONFIG_BT_CLASSIC)
-BT_L2CAP_CHANNEL_DEFINE(smp_br_fixed_chan, BT_L2CAP_CID_BR_SMP,
-			bt_smp_br_accept, NULL);
+BT_L2CAP_BR_CHANNEL_DEFINE(smp_br_fixed_chan, BT_L2CAP_CID_BR_SMP,
+			bt_smp_br_accept);
 #endif /* CONFIG_BT_CLASSIC */
 
 int bt_smp_init(void)


### PR DESCRIPTION
The BR SMP fixed channel BR/EDR Security Manager (CID 0x0007) cannot be set in L2CAP Information Response. It is caused by the invalid fix channel definition used.

Move macro `BT_L2CAP_BR_CHANNEL_DEFINE` to `l2cap_br_interface.h`, that the macro can be accessed in smp.c. And remove duplicated header file include `#include "classic/l2cap_br_interface.h"` from smp.c.

Define fixed channel, BR/EDR Security Manager (CID 0x0007), by using `BT_L2CAP_BR_CHANNEL_DEFINE`.

Fix the smp L2CAP channel of BR cannot be found issue. Use `bt_l2cap_br_lookup_tx_cid` to get the BR SMP L2CAP channel instead of using `bt_l2cap_le_lookup_tx_cid`.

Fix the invalid SMP L2CAP channel used when the BR smp failed.