### PR TITLE
net: coap_client: fix incorrect handling of responses longer than CONFIG_COAP_CLIENT_MESSAGE_SIZE

### DIFF
--- a/subsys/net/lib/coap/coap_client.c
+++ b/subsys/net/lib/coap/coap_client.c
@@ -774,6 +774,13 @@ static int handle_response(struct coap_client *client, const struct coap_packet 
 		}
 	}
 
+	/* Until the last block of a transfer, limit data size sent to the application to the block
+	 * size, to avoid data above block size being repeated when the next block is received.
+	 */
+	if (blockwise_transfer && !last_block) {
+		payload_len = MIN(payload_len, CONFIG_COAP_CLIENT_BLOCK_SIZE);
+	}
+
 	/* Call user callback */
 	if (internal_req->coap_request.cb) {
 		if (!atomic_set(&internal_req->in_callback, 1)) {


### PR DESCRIPTION
Resolves https://github.com/zephyrproject-rtos/zephyr/issues/76089

Add the `MSG_TRUNC` flag to the `recv` options, so that the CoAP client is aware when the received UDP packet has been truncated. This info is used along with the presence of a Block2 option in the response to determine whether a blockwise transfer is needed to fetch the rest of the resource.

Additionally the size of the CoAP payload passed to the application callback is limited to the block size if a blockwise transfer is in progress. This avoids any overlapping data being sent to the application in the event that the first response of a blockwise transfer uses a larger block size than the client can handle, and therefore contains some data that is also part of the following block.

The behaviour now is:
1) Response is longer than `CONFIG_COAP_CLIENT_MESSAGE_SIZE` but still fits into the receive buffer with no truncation --> no change to behaviour, whole payload delivered to application callback.
2) Response is longer than `CONFIG_COAP_CLIENT_MESSAGE_SIZE` and longer than the CoAP client's receive buffer --> Only the first `CONFIG_COAP_CLIENT_MESSAGE_SIZE` bytes are delivered to the application callback, and the remaining data is fetched via blockwise transfer.