### PR TITLE
usb: device_next: add device configuration change notification

### DIFF
--- a/include/zephyr/usb/usbd_msg.h
+++ b/include/zephyr/usb/usbd_msg.h
@@ -40,6 +40,8 @@ enum usbd_msg_type {
 	USBD_MSG_SUSPEND,
 	/** Bus reset detected */
 	USBD_MSG_RESET,
+	/** Device changed configuration */
+	USBD_MSG_CONFIGURATION,
 	/** Non-correctable UDC error message  */
 	USBD_MSG_UDC_ERROR,
 	/** Unrecoverable device stack error message  */
@@ -61,6 +63,7 @@ static const char *const usbd_msg_type_list[] = {
 	"Device resumed",
 	"Device suspended",
 	"Bus reset",
+	"New device configuration",
 	"Controller error",
 	"Stack error",
 	"CDC ACM line coding",

--- a/samples/subsys/usb/hid-keyboard/src/main.c
+++ b/samples/subsys/usb/hid-keyboard/src/main.c
@@ -147,6 +147,10 @@ static void msg_cb(struct usbd_context *const usbd_ctx,
 {
 	LOG_INF("USBD message: %s", usbd_msg_type_string(msg->type));
 
+	if (msg->type == USBD_MSG_CONFIGURATION) {
+		LOG_INF("\tConfiguration value %d", msg->status);
+	}
+
 	if (usbd_can_detect_vbus(usbd_ctx)) {
 		if (msg->type == USBD_MSG_VBUS_READY) {
 			if (usbd_enable(usbd_ctx)) {

--- a/subsys/usb/device_next/usbd_ch9.c
+++ b/subsys/usb/device_next/usbd_ch9.c
@@ -19,6 +19,7 @@
 #include "usbd_class.h"
 #include "usbd_class_api.h"
 #include "usbd_interface.h"
+#include "usbd_msg.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(usbd_ch9, CONFIG_USBD_LOG_LEVEL);
@@ -169,6 +170,10 @@ static int sreq_set_configuration(struct usbd_context *const uds_ctx)
 		uds_ctx->ch9_data.state = USBD_STATE_ADDRESS;
 	} else {
 		uds_ctx->ch9_data.state = USBD_STATE_CONFIGURED;
+	}
+
+	if (ret == 0) {
+		usbd_msg_pub_simple(uds_ctx, USBD_MSG_CONFIGURATION, setup->wValue);
 	}
 
 	return ret;


### PR DESCRIPTION
Notify only if the device configuration has changed. Pass only the configuration value as the message status, the actual device speed can be obtained with usbd_bus_speed().