### PR TITLE
net: Add version information to public network APIs 

### DIFF
--- a/include/zephyr/net/buf.h
+++ b/include/zephyr/net/buf.h
@@ -23,6 +23,8 @@ extern "C" {
 /**
  * @brief Network buffer library
  * @defgroup net_buf Network Buffer Library
+ * @since 1.0
+ * @version 1.0.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/capture.h
+++ b/include/zephyr/net/capture.h
@@ -23,6 +23,8 @@ extern "C" {
 /**
  * @brief Network packet capture support functions
  * @defgroup net_capture Network packet capture
+ * @since 2.6
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/coap_client.h
+++ b/include/zephyr/net/coap_client.h
@@ -15,6 +15,8 @@
 /**
  * @brief CoAP client API
  * @defgroup coap_client CoAP client API
+ * @since 3.4
+ * @version 0.1.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/coap_mgmt.h
+++ b/include/zephyr/net/coap_mgmt.h
@@ -21,6 +21,8 @@ extern "C" {
 /**
  * @brief CoAP Manager Events
  * @defgroup coap_mgmt CoAP Manager Events
+ * @since 3.6
+ * @version 0.1.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/coap_service.h
+++ b/include/zephyr/net/coap_service.h
@@ -23,6 +23,8 @@ extern "C" {
 /**
  * @brief CoAP Service API
  * @defgroup coap_service CoAP service API
+ * @since 3.6
+ * @version 0.1.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/conn_mgr_connectivity.h
+++ b/include/zephyr/net/conn_mgr_connectivity.h
@@ -255,7 +255,9 @@ int conn_mgr_if_set_timeout(struct net_if *iface, int timeout);
 /**
  * @brief Connection Manager Bulk API
  * @defgroup conn_mgr_connectivity_bulk Connection Manager Connectivity Bulk API
- * @ingroup networking
+ * @since 3.4
+ * @version 0.1.0
+ * @ingroup conn_mgr_connectivity
  * @{
  */
 

--- a/include/zephyr/net/conn_mgr_connectivity_impl.h
+++ b/include/zephyr/net/conn_mgr_connectivity_impl.h
@@ -26,7 +26,9 @@ extern "C" {
 /**
  * @brief Connection Manager Connectivity Implementation API
  * @defgroup conn_mgr_connectivity_impl Connection Manager Connectivity Implementation API
- * @ingroup networking
+ * @since 3.4
+ * @version 0.1.0
+ * @ingroup conn_mgr_connectivity
  * @{
  */
 

--- a/include/zephyr/net/conn_mgr_monitor.h
+++ b/include/zephyr/net/conn_mgr_monitor.h
@@ -21,6 +21,8 @@ extern "C" {
 /**
  * @brief Connection Manager API
  * @defgroup conn_mgr Connection Manager API
+ * @since 2.0
+ * @version 0.1.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/dhcpv4.h
+++ b/include/zephyr/net/dhcpv4.h
@@ -21,6 +21,8 @@ extern "C" {
 /**
  * @brief DHCPv4
  * @defgroup dhcpv4 DHCPv4
+ * @since 1.7
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/dhcpv4_server.h
+++ b/include/zephyr/net/dhcpv4_server.h
@@ -21,6 +21,8 @@ extern "C" {
 /**
  * @brief DHCPv4 server
  * @defgroup dhcpv4_server DHCPv4 server
+ * @since 3.6
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/dhcpv6.h
+++ b/include/zephyr/net/dhcpv6.h
@@ -18,6 +18,8 @@ extern "C" {
 /**
  * @brief DHCPv6
  * @defgroup dhcpv6 DHCPv6
+ * @since 3.5
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/dns_resolve.h
+++ b/include/zephyr/net/dns_resolve.h
@@ -25,6 +25,8 @@ extern "C" {
 /**
  * @brief DNS resolving library
  * @defgroup dns_resolve DNS Resolve Library
+ * @since 1.8
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/dns_sd.h
+++ b/include/zephyr/net/dns_sd.h
@@ -29,6 +29,8 @@ extern "C" {
  * @see <a href="https://tools.ietf.org/html/rfc6763">RFC 6763</a>
  *
  * @defgroup dns_sd DNS Service Discovery
+ * @since 2.5
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/dsa.h
+++ b/include/zephyr/net/dsa.h
@@ -17,6 +17,8 @@
 /**
  * @brief DSA definitions and helpers
  * @defgroup DSA Distributed Switch Architecture definitions and helpers
+ * @since 2.5
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/dummy.h
+++ b/include/zephyr/net/dummy.h
@@ -23,6 +23,8 @@ extern "C" {
 /**
  * @brief Dummy L2/driver support functions
  * @defgroup dummy Dummy L2/driver Support Functions
+ * @since 1.14
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -41,6 +41,8 @@ extern "C" {
 /**
  * @brief Ethernet support functions
  * @defgroup ethernet Ethernet Support Functions
+ * @since 1.0
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/ethernet_bridge.h
+++ b/include/zephyr/net/ethernet_bridge.h
@@ -25,6 +25,8 @@ extern "C" {
 /**
  * @brief Ethernet Bridging API
  * @defgroup eth_bridge Ethernet Bridging API
+ * @since 2.7
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/ethernet_mgmt.h
+++ b/include/zephyr/net/ethernet_mgmt.h
@@ -22,6 +22,8 @@ extern "C" {
 /**
  * @brief Ethernet library
  * @defgroup ethernet_mgmt Ethernet Library
+ * @since 1.12
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/ethernet_vlan.h
+++ b/include/zephyr/net/ethernet_vlan.h
@@ -16,6 +16,8 @@
 /**
  * @brief VLAN definitions and helpers
  * @defgroup vlan_api Virtual LAN definitions and helpers
+ * @since 1.12
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/gptp.h
+++ b/include/zephyr/net/gptp.h
@@ -16,6 +16,8 @@
 /**
  * @brief generic Precision Time Protocol (gPTP) support
  * @defgroup gptp gPTP support
+ * @since 1.13
+ * @version 0.1.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/hostname.h
+++ b/include/zephyr/net/hostname.h
@@ -18,6 +18,8 @@ extern "C" {
 /**
  * @brief Network hostname configuration library
  * @defgroup net_hostname Network Hostname Library
+ * @since 1.10
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/http/hpack.h
+++ b/include/zephyr/net/http/hpack.h
@@ -18,6 +18,8 @@
 /**
  * @brief HTTP HPACK
  * @defgroup http_hpack HTTP HPACK
+ * @since 3.7
+ * @version 0.1.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/http/method.h
+++ b/include/zephyr/net/http/method.h
@@ -14,6 +14,8 @@
 /**
  * @brief HTTP request methods
  * @defgroup http_methods HTTP request methods
+ * @since 3.3
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/http/server.h
+++ b/include/zephyr/net/http/server.h
@@ -14,6 +14,8 @@
  * @brief HTTP server API
  *
  * @defgroup http_server HTTP server API
+ * @since 3.7
+ * @version 0.1.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/http/service.h
+++ b/include/zephyr/net/http/service.h
@@ -13,6 +13,8 @@
  * @brief HTTP service API
  *
  * @defgroup http_service HTTP service API
+ * @since 3.4
+ * @version 0.1.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/http/status.h
+++ b/include/zephyr/net/http/status.h
@@ -14,6 +14,8 @@
 /**
  * @brief HTTP response status codes
  * @defgroup http_status_codes HTTP response status codes
+ * @since 3.3
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/icmp.h
+++ b/include/zephyr/net/icmp.h
@@ -9,6 +9,8 @@
  * @brief ICMP sending and receiving.
  *
  * @defgroup icmp Send and receive IPv4 or IPv6 ICMP Echo Request messages.
+ * @since 3.5
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/igmp.h
+++ b/include/zephyr/net/igmp.h
@@ -14,6 +14,8 @@
 /**
  * @brief IGMP (Internet Group Management Protocol)
  * @defgroup igmp IGMP API
+ * @since 2.6
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/lldp.h
+++ b/include/zephyr/net/lldp.h
@@ -16,6 +16,8 @@
 /**
  * @brief LLDP definitions and helpers
  * @defgroup lldp Link Layer Discovery Protocol definitions and helpers
+ * @since 1.13
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/lwm2m_path.h
+++ b/include/zephyr/net/lwm2m_path.h
@@ -13,6 +13,8 @@
  * @brief LwM2M path helper macros
  *
  * @defgroup lwm2m_path_helpers LwM2M path helper macros
+ * @since 2.5
+ * @version 0.8.0
  * @ingroup lwm2m_api
  * @{
  */

--- a/include/zephyr/net/mdio.h
+++ b/include/zephyr/net/mdio.h
@@ -15,6 +15,8 @@
 /**
  * @brief Definitions for IEEE 802.3 management interface
  * @defgroup ethernet_mdio IEEE 802.3 management interface
+ * @since 3.5
+ * @version 0.8.0
  * @ingroup ethernet
  * @{
  */

--- a/include/zephyr/net/mii.h
+++ b/include/zephyr/net/mii.h
@@ -15,6 +15,8 @@
 /**
  * @brief Ethernet MII (media independent interface) functions
  * @defgroup ethernet_mii Ethernet MII Support Functions
+ * @since 1.7
+ * @version 0.8.0
  * @ingroup ethernet
  * @{
  */

--- a/include/zephyr/net/mqtt_sn.h
+++ b/include/zephyr/net/mqtt_sn.h
@@ -13,6 +13,8 @@
  * Targets protocol version 1.2.
  *
  * @defgroup mqtt_sn_socket MQTT-SN Client library
+ * @since 3.3
+ * @version 0.1.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/net_config.h
+++ b/include/zephyr/net/net_config.h
@@ -22,6 +22,8 @@ extern "C" {
 /**
  * @brief Network configuration library
  * @defgroup net_config Network Configuration Library
+ * @since 1.8
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/net_context.h
+++ b/include/zephyr/net/net_context.h
@@ -17,6 +17,8 @@
 /**
  * @brief Application network context
  * @defgroup net_context Application network context
+ * @since 1.0
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/net_core.h
+++ b/include/zephyr/net/net_core.h
@@ -39,6 +39,8 @@ extern "C" {
 /**
  * @brief Network core library
  * @defgroup net_core Network Core Library
+ * @since 1.0
+ * @version 1.0.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -15,6 +15,8 @@
 /**
  * @brief Network Interface abstraction layer
  * @defgroup net_if Network Interface abstraction layer
+ * @since 1.5
+ * @version 1.0.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/net_ip.h
+++ b/include/zephyr/net/net_ip.h
@@ -16,6 +16,8 @@
 /**
  * @brief IPv4/IPv6 primitives and helpers
  * @defgroup ip_4_6 IPv4/IPv6 primitives and helpers
+ * @since 1.0
+ * @version 1.0.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/net_l2.h
+++ b/include/zephyr/net/net_l2.h
@@ -24,6 +24,8 @@ extern "C" {
 /**
  * @brief Network Layer 2 abstraction layer
  * @defgroup net_l2 Network L2 Abstraction Layer
+ * @since 1.5
+ * @version 1.0.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/net_linkaddr.h
+++ b/include/zephyr/net/net_linkaddr.h
@@ -23,6 +23,8 @@ extern "C" {
 /**
  * @brief Network link address library
  * @defgroup net_linkaddr Network Link Address Library
+ * @since 1.0
+ * @version 1.0.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/net_mgmt.h
+++ b/include/zephyr/net/net_mgmt.h
@@ -24,6 +24,8 @@ extern "C" {
 /**
  * @brief Network Management
  * @defgroup net_mgmt Network Management
+ * @since 1.7
+ * @version 1.0.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/net_offload.h
+++ b/include/zephyr/net/net_offload.h
@@ -15,6 +15,8 @@
 /**
  * @brief Network offloading interface
  * @defgroup net_offload Network Offloading Interface
+ * @since 1.7
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/net_pkt.h
+++ b/include/zephyr/net/net_pkt.h
@@ -40,6 +40,8 @@ extern "C" {
 /**
  * @brief Network packet management library
  * @defgroup net_pkt Network Packet Library
+ * @since 1.5
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/net_pkt_filter.h
+++ b/include/zephyr/net/net_pkt_filter.h
@@ -27,6 +27,8 @@ extern "C" {
 /**
  * @brief Network Packet Filter API
  * @defgroup net_pkt_filter Network Packet Filter API
+ * @since 3.0
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */
@@ -209,6 +211,8 @@ bool npf_remove_all_rules(struct npf_rule_list *rules);
 
 /**
  * @defgroup npf_basic_cond Basic Filter Conditions
+ * @since 3.0
+ * @version 0.8.0
  * @ingroup net_pkt_filter
  * @{
  */
@@ -386,6 +390,8 @@ extern npf_test_fn_t npf_ip_src_addr_unmatch;
 /**
  * @defgroup npf_eth_cond Ethernet Filter Conditions
  * @ingroup net_pkt_filter
+ * @since 3.0
+ * @version 0.8.0
  * @{
  */
 

--- a/include/zephyr/net/net_stats.h
+++ b/include/zephyr/net/net_stats.h
@@ -25,6 +25,8 @@ extern "C" {
 /**
  * @brief Network statistics library
  * @defgroup net_stats Network Statistics Library
+ * @since 1.5
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/net_time.h
+++ b/include/zephyr/net/net_time.h
@@ -14,6 +14,8 @@
  * https://github.com/torvalds/linux/blob/master/[tools/]include/linux/time64.h
  *
  * @defgroup net_time Network time representation.
+ * @since 3.5
+ * @version 0.1.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/net_timeout.h
+++ b/include/zephyr/net/net_timeout.h
@@ -17,6 +17,8 @@
 /**
  * @brief Network long timeout primitives and helpers
  * @defgroup net_timeout Network long timeout primitives and helpers
+ * @since 1.14
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/offloaded_netdev.h
+++ b/include/zephyr/net/offloaded_netdev.h
@@ -25,6 +25,8 @@ extern "C" {
 /**
  * @brief Offloaded Net Devices
  * @defgroup offloaded_netdev Offloaded Net Devices
+ * @since 3.4
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/openthread.h
+++ b/include/zephyr/net/openthread.h
@@ -14,6 +14,8 @@
 /**
  * @brief OpenThread Layer 2 abstraction layer
  * @defgroup openthread OpenThread L2 abstraction layer
+ * @since 1.11
+ * @version 0.8.0
  * @ingroup ieee802154
  * @{
  */

--- a/include/zephyr/net/phy.h
+++ b/include/zephyr/net/phy.h
@@ -16,6 +16,8 @@
 /**
  * @brief Ethernet PHY Interface
  * @defgroup ethernet_phy Ethernet PHY Interface
+ * @since 2.7
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/ppp.h
+++ b/include/zephyr/net/ppp.h
@@ -24,6 +24,8 @@ extern "C" {
 /**
  * @brief Point-to-point (PPP) L2/driver support functions
  * @defgroup ppp PPP L2/driver Support Functions
+ * @since 2.0
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/promiscuous.h
+++ b/include/zephyr/net/promiscuous.h
@@ -17,6 +17,8 @@
 /**
  * @brief Promiscuous mode support.
  * @defgroup promiscuous Promiscuous mode
+ * @since 1.13
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/ptp.h
+++ b/include/zephyr/net/ptp.h
@@ -17,6 +17,8 @@
 /**
  * @brief Precision Time Protocol (PTP) support
  * @defgroup ptp PTP support
+ * @since 3.7
+ * @version 0.1.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/ptp_time.h
+++ b/include/zephyr/net/ptp_time.h
@@ -18,6 +18,8 @@
 /**
  * @brief Precision Time Protocol time specification
  * @defgroup ptp_time PTP time
+ * @since 1.13
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/sntp.h
+++ b/include/zephyr/net/sntp.h
@@ -22,6 +22,8 @@ extern "C" {
 /**
  * @brief Simple Network Time Protocol API
  * @defgroup sntp SNTP
+ * @since 1.10
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/socket.h
+++ b/include/zephyr/net/socket.h
@@ -18,6 +18,8 @@
 /**
  * @brief BSD Sockets compatible API
  * @defgroup bsd_sockets BSD Sockets compatible API
+ * @since 1.9
+ * @version 1.0.0
  * @ingroup networking
  * @{
  */
@@ -93,8 +95,10 @@ extern "C" {
 /** @} */
 
 /**
- *  @defgroup secure_sockets_options Socket options for TLS
- *  @{
+ * @defgroup secure_sockets_options Socket options for TLS
+ * @since 1.13
+ * @version 0.8.0
+ * @{
  */
 /**
  * @name Socket options for TLS

--- a/include/zephyr/net/socket_net_mgmt.h
+++ b/include/zephyr/net/socket_net_mgmt.h
@@ -25,6 +25,8 @@ extern "C" {
 /**
  * @brief Socket NET_MGMT library
  * @defgroup socket_net_mgmt Socket NET_MGMT library
+ * @since 2.0
+ * @version 0.1.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/socket_net_mgmt.h
+++ b/include/zephyr/net/socket_net_mgmt.h
@@ -24,7 +24,7 @@ extern "C" {
 
 /**
  * @brief Socket NET_MGMT library
- * @defgroup socket_net_mgmt Network Core Library
+ * @defgroup socket_net_mgmt Socket NET_MGMT library
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/socket_service.h
+++ b/include/zephyr/net/socket_service.h
@@ -18,6 +18,8 @@
 /**
  * @brief BSD socket service API
  * @defgroup bsd_socket_service BSD socket service API
+ * @since 3.6
+ * @version 0.1.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/socketcan.h
+++ b/include/zephyr/net/socketcan.h
@@ -23,7 +23,7 @@ extern "C" {
 
 /**
  * @brief SocketCAN library
- * @defgroup socket_can Network Core Library
+ * @defgroup socket_can SocketCAN library
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/socketcan.h
+++ b/include/zephyr/net/socketcan.h
@@ -24,6 +24,8 @@ extern "C" {
 /**
  * @brief SocketCAN library
  * @defgroup socket_can SocketCAN library
+ * @since 1.14
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/socketcan_utils.h
+++ b/include/zephyr/net/socketcan_utils.h
@@ -22,8 +22,7 @@ extern "C" {
 
 /**
  * @brief SocketCAN utilities
- * @defgroup socket_can Network Core Library
- * @ingroup networking
+ * @addtogroup socket_can
  * @{
  */
 

--- a/include/zephyr/net/tftp.h
+++ b/include/zephyr/net/tftp.h
@@ -9,6 +9,8 @@
  * @brief TFTP Client Implementation
  *
  * @defgroup tftp_client TFTP Client library
+ * @since 2.3
+ * @version 0.1.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/tls_credentials.h
+++ b/include/zephyr/net/tls_credentials.h
@@ -16,6 +16,8 @@
 /**
  * @brief TLS credentials management
  * @defgroup tls_credentials TLS credentials management
+ * @since 1.13
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/trickle.h
+++ b/include/zephyr/net/trickle.h
@@ -26,6 +26,8 @@ extern "C" {
 /**
  * @brief Trickle algorithm library
  * @defgroup trickle Trickle Algorithm Library
+ * @since 1.7
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/virtual.h
+++ b/include/zephyr/net/virtual.h
@@ -29,6 +29,8 @@ extern "C" {
 /**
  * @brief Virtual network interface support functions
  * @defgroup virtual Virtual Network Interface Support Functions
+ * @since 2.6
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/virtual_mgmt.h
+++ b/include/zephyr/net/virtual_mgmt.h
@@ -22,6 +22,8 @@ extern "C" {
 /**
  * @brief Virtual interface library
  * @defgroup virtual_mgmt Virtual Interface Library
+ * @since 2.6
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/websocket.h
+++ b/include/zephyr/net/websocket.h
@@ -26,6 +26,8 @@ extern "C" {
 /**
  * @brief Websocket API
  * @defgroup websocket Websocket API
+ * @since 1.12
+ * @version 0.1.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/wifi.h
+++ b/include/zephyr/net/wifi.h
@@ -11,8 +11,10 @@
  */
 
 /**
- * @defgroup wifi_mgmt Wi-Fi Management
  * @brief Wi-Fi Management API.
+ * @defgroup wifi_mgmt Wi-Fi Management
+ * @since 1.12
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/wifi_nm.h
+++ b/include/zephyr/net/wifi_nm.h
@@ -22,6 +22,8 @@
 /**
  * @brief Wi-Fi Network manager API
  * @defgroup wifi_nm Wi-Fi Network Manager API
+ * @since 3.5
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/zperf.h
+++ b/include/zephyr/net/zperf.h
@@ -10,6 +10,8 @@
  *
  * @brief Zperf API
  * @defgroup zperf Zperf API
+ * @since 3.3
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */


### PR DESCRIPTION
The purpose of this PR is to fill out the blanks in the Networking area of the [API Overview page](https://docs.zephyrproject.org/latest/develop/api/overview.html).

Add \since and \version doxygen tags to the networking APIs, so that they render correctly on the API overview page.

The version used for \since tag was determined, based on the commit that introduced the header or in individual cases, when the API was introduced as a part of a larger header (mostly apply for the oldest, core network APIs).

The version of the API was set as follows:
* components that use EXPERIMENTAL Kconfig symbol were assigned with 0.1.0
* The oldest, "core" networking APIs were marked as "stable" (1.0.0).
* Everything else ended up as "unstable" (0.8.0).

Additinally, a small cleanup was made regarding duplicate "Network Core Library" entries on the page.