### PR TITLE
drivers: input: cst816s: Configure before enabling interrupts on init

### DIFF
--- a/drivers/input/input_cst816s.c
+++ b/drivers/input/input_cst816s.c
@@ -221,13 +221,18 @@ static int cst816s_chip_init(const struct device *dev)
 static int cst816s_init(const struct device *dev)
 {
 	struct cst816s_data *data = dev->data;
+	int ret;
 
 	data->dev = dev;
 	k_work_init(&data->work, cst816s_work_handler);
 
+	ret = cst816s_chip_init(dev);
+	if (ret < 0) {
+		return ret;
+	}
+
 #ifdef CONFIG_INPUT_CST816S_INTERRUPT
 	const struct cst816s_config *config = dev->config;
-	int ret;
 
 	if (!gpio_is_ready_dt(&config->int_gpio)) {
 		LOG_ERR("GPIO port %s not ready", config->int_gpio.port->name);
@@ -259,7 +264,7 @@ static int cst816s_init(const struct device *dev)
 		      K_MSEC(CONFIG_INPUT_CST816S_PERIOD));
 #endif
 
-	return cst816s_chip_init(dev);
+	return ret;
 }
 
 #define CST816S_DEFINE(index)                                                                      \


### PR DESCRIPTION
While using a `esp32s3_touch_lcd_1_28/esp32s3/procpu` sample found that on boot I get an i2c error:

```
[00:00:00.494,000] <err> i2c_esp32: I2C transfer error: -14
[00:00:00.494,000] <err> cst816s: Could not read x data
*** Booting Zephyr OS build v3.7.0-rc1-1192-g8f5619537813 ***
```

Reason for this is that the interrupt is enabled and configured before the `CST816S_REG_IRQ_CTL` is setup correctly.