### PR TITLE
boards: nordic: nrf54l15pdk: PWM is supported by cpuflpr

### DIFF
--- a/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15_cpuflpr.yaml
+++ b/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15_cpuflpr.yaml
@@ -14,5 +14,6 @@ supported:
   - counter
   - gpio
   - i2c
+  - pwm
   - spi
   - watchdog


### PR DESCRIPTION
Add PWM to the list of supported peripherals.