### PR TITLE
Add wdog support for frdm_ke17z and frdm_ke17z512

### DIFF
--- a/boards/nxp/frdm_ke17z/doc/index.rst
+++ b/boards/nxp/frdm_ke17z/doc/index.rst
@@ -67,6 +67,8 @@ features:
 +-----------+------------+-------------------------------------+
 | ACMP      | on-chip    | sensor                              |
 +-----------+------------+-------------------------------------+
+| WATCHDOG  | on-chip    | watchdog                            |
++-----------+------------+-------------------------------------+
 
 The default configuration can be found in the defconfig file:
 :zephyr_file:`boards/nxp/frdm_ke17z/frdm_ke17z_defconfig`.

--- a/boards/nxp/frdm_ke17z/frdm_ke17z.dts
+++ b/boards/nxp/frdm_ke17z/frdm_ke17z.dts
@@ -15,6 +15,7 @@
 	compatible = "nxp,frdm-ke17z", "nxp,ke17z", "nxp,mke17z7";
 
 	aliases {
+		watchdog0 = &wdog;
 		led0 = &red_led;
 		led1 = &green_led;
 		led2 = &blue_led;
@@ -120,5 +121,9 @@
 };
 
 &edma {
+	status = "okay";
+};
+
+&wdog {
 	status = "okay";
 };

--- a/boards/nxp/frdm_ke17z/frdm_ke17z.yaml
+++ b/boards/nxp/frdm_ke17z/frdm_ke17z.yaml
@@ -14,4 +14,5 @@ supported:
   - i2c
   - spi
   - dma
+  - watchdog
 vendor: nxp

--- a/boards/nxp/frdm_ke17z512/doc/index.rst
+++ b/boards/nxp/frdm_ke17z512/doc/index.rst
@@ -67,6 +67,8 @@ features:
 +-----------+------------+-------------------------------------+
 | DMA       | on-chip    | dma                                 |
 +-----------+------------+-------------------------------------+
+| WATCHDOG  | on-chip    | watchdog                            |
++-----------+------------+-------------------------------------+
 
 The default configuration can be found in the defconfig file:
 ``boards/nxp/frdm_ke17z512/frdm_ke17z512_defconfig``.

--- a/boards/nxp/frdm_ke17z512/frdm_ke17z512.dts
+++ b/boards/nxp/frdm_ke17z512/frdm_ke17z512.dts
@@ -22,6 +22,7 @@
 	};
 
 	aliases {
+		watchdog0 = &wdog;
 		led0 = &red_led;
 		led1 = &green_led;
 		led2 = &blue_led;
@@ -127,5 +128,9 @@
 };
 
 &edma {
+	status = "okay";
+};
+
+&wdog {
 	status = "okay";
 };

--- a/boards/nxp/frdm_ke17z512/frdm_ke17z512.yaml
+++ b/boards/nxp/frdm_ke17z512/frdm_ke17z512.yaml
@@ -20,4 +20,5 @@ supported:
   - i2c
   - spi
   - dma
+  - watchdog
 vendor: nxp

--- a/dts/arm/nxp/nxp_ke1xz.dtsi
+++ b/dts/arm/nxp/nxp_ke1xz.dtsi
@@ -168,6 +168,26 @@
 			clocks = <&pcc 0x134 KINETIS_PCC_SRC_NONE_OR_EXT>;
 		};
 
+		pmc: pmc@4007d000 {
+			reg = <0x4007d000 0x1000>;
+
+			lpo: lpo128k {
+				compatible = "fixed-clock";
+				clock-frequency = <128000>;
+				#clock-cells = <0>;
+			};
+		};
+
+		wdog: watchdog@40052000 {
+			compatible = "nxp,kinetis-wdog32";
+			reg = <0x40052000 0x1000>;
+			interrupts = <28 0>;
+			clocks = <&lpo>;
+			clk-source = <1>;
+			clk-divider = <256>;
+			status = "disabled";
+		};
+
 		gpios0: gpios0@400ff000 {
 			compatible = "nxp,gpio-cluster";
 			interrupts = <7 2>;


### PR DESCRIPTION
Add wdog configuration to test 'tests/drivers/watchdog/wdt_basic_api' case.