### PR TITLE
doc: release notes: add 1-Wire release notes for 3.7

### DIFF
--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -674,6 +674,13 @@ Regulator
   has been removed, users should remove this property from their devicetree if it is present.
   (:github:`70642`)
 
+W1
+==
+
+* The :dtcompatible:`zephyr,w1-gpio` 1-Wire master driver no longer defaults to enabling the
+  internal pull-up resistor of the GPIO pin. The configuration is now taken from the pin's
+  configuration flags specified in devicetree. (:github:`71789`)
+
 Watchdog
 ========
 

--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -1140,7 +1140,7 @@ Drivers and Sensors
 
   * Maxim
 
-    * Added DS18S20 1-wire temperature sensor driver (:dtcompatible:`maxim,ds18s20`).
+    * Added DS18S20 1-Wire temperature sensor driver (:dtcompatible:`maxim,ds18s20`).
     * Added MAX31790 fan speed and fan fault sensor
       (:dtcompatible:`maxim,max31790-fan-fault` and :dtcompatible:`maxim,max31790-fan-speed`).
 
@@ -1291,8 +1291,6 @@ Drivers and Sensors
   * Added support for the ov5640 camera
   * Added CSI-2 MIPI driver for NXP MCUX
   * Added support for DVP FPC 24-pins mt9m114 camera module shield
-
-* W1
 
 * Watchdog
 


### PR DESCRIPTION
No significant changes to 1-Wire master drivers for the 3.7 release. Only the changes in the pull-up configuration of the `zephyr,w1-gpio` driver added in the migration guide.