### PR TITLE
samples: button: add a note about the input subsystem and samples

### DIFF
--- a/samples/basic/button/README.rst
+++ b/samples/basic/button/README.rst
@@ -10,6 +10,10 @@ Overview
 A simple button demo showcasing the use of GPIO input with interrupts.
 The sample prints a message to the console each time a button is pressed.
 
+.. NOTE:: If you are looking into an implementation of button events with
+   debouncing, check out :ref:`input` and :zephyr:code-sample:`input-dump`
+   instead.
+
 Requirements
 ************
 


### PR DESCRIPTION
The button sample is really a gpio interrupt sample, one may easily miss the debounced driver and think it's not provided.

Add a note in the basic button sample documentation to refer to the input subsystem doc and sample.