### PR TITLE
boards: nordic: nrf9160dk: Correct board check for nrf52840_reset

### DIFF
--- a/boards/nordic/nrf9160dk/CMakeLists.txt
+++ b/boards/nordic/nrf9160dk/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2019 Nordic Semiconductor ASA.
 # SPDX-License-Identifier: Apache-2.0
 
-if(CONFIG_BOARD_NRF9160DK_NRF9160)
+if(CONFIG_BOARD_NRF9160DK_NRF9160 OR CONFIG_BOARD_NRF9160DK_NRF9160_NS)
   zephyr_library()
   zephyr_library_sources(nrf52840_reset.c)
 elseif(CONFIG_BOARD_NRF9160DK_NRF52840)


### PR DESCRIPTION
With HWMv2 CONFIG_BOARD_NRF9160DK_NRF9160 is not defined when building the non-secure target, so it has to be specified.