### PR TITLE
3.7 Release notes and migration guide 2nd polish pass

### DIFF
--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -263,7 +263,7 @@ Device Drivers and Devicetree
         gyro-odr = <ICM42688_GYRO_ODR_2000>;
     };
 
-* ``st,lis2mdl`` property ``spi-full-duplex`` changed to ``duplex =
+* :dtcompatible:`st,lis2mdl` property ``spi-full-duplex`` changed to ``duplex =
   SPI_FULL_DUPLEX``. Full duplex is now the default.
 
 * The DT property ``nxp,reference-supply`` of :dtcompatible:`nxp,lpc-lpadc` driver has
@@ -564,8 +564,8 @@ Enhanced Serial Peripheral Interface (eSPI)
   ``ESPI_VWIRE_SIGNAL_TARGET_BOOT_STS``, ``ESPI_VWIRE_SIGNAL_TARGET_BOOT_DONE`` and
   ``ESPI_VWIRE_SIGNAL_TARGET_GPIO_<NUMBER>`` respectively to reflect the new terminology
   in eSPI 1.5 specification. (:github:`68492`)
-  The Kconfig ``CONFIG_ESPI_SLAVE`` was renamed to ``CONFIG_ESPI_TARGET``, similarly
-  ``CONFIG_ESPI_SAF`` was renamed as ``CONFIG_ESPI_TAF`` (:github:`73887`)
+  The Kconfig ``CONFIG_ESPI_SLAVE`` was renamed to  :kconfig:option:`CONFIG_ESPI_TARGET`, similarly
+  ``CONFIG_ESPI_SAF`` was renamed as :kconfig:option:`CONFIG_ESPI_TAF` (:github:`73887`)
 
 Flash
 =====

--- a/doc/releases/migration-guide-3.7.rst
+++ b/doc/releases/migration-guide-3.7.rst
@@ -117,9 +117,6 @@ Mbed TLS
   as there is any PSA crypto provider available in the system
   (i.e. :kconfig:option:`CONFIG_MBEDTLS_PSA_CRYPTO_CLIENT` is set). (:github:`72243`)
 
-MCUboot
-=======
-
 Trusted Firmware-M
 ==================
 
@@ -127,9 +124,6 @@ Trusted Firmware-M
   This affects builds that have MCUboot enabled in TF-M (:kconfig:option:`CONFIG_TFM_BL2`).
   If you wish to keep using RSA-3072, you need to set :kconfig:option:`CONFIG_TFM_MCUBOOT_SIGNATURE_TYPE`
   to ``"RSA-3072"``. Otherwise, make sure to have your own signing keys of the signature type in use.
-
-zcbor
-=====
 
 LVGL
 ====
@@ -275,9 +269,6 @@ Device Drivers and Devicetree
  * The DT properties ``mc,interface-type``, ``mc,reset-gpio``, and ``mc,interrupt-gpio`` of
    the :dtcompatible:`microchip,ksz8081` phy binding have changed to
    ``microchip,interface-type``, ``reset-gpios``, and ``int-gpios``, respectively (:github:`73725`)
-
-Analog-to-Digital Converter (ADC)
-=================================
 
 Charger
 =======
@@ -567,12 +558,6 @@ Enhanced Serial Peripheral Interface (eSPI)
   The Kconfig ``CONFIG_ESPI_SLAVE`` was renamed to  :kconfig:option:`CONFIG_ESPI_TARGET`, similarly
   ``CONFIG_ESPI_SAF`` was renamed as :kconfig:option:`CONFIG_ESPI_TAF` (:github:`73887`)
 
-Flash
-=====
-
-General Purpose I/O (GPIO)
-==========================
-
 GNSS
 ====
 
@@ -662,9 +647,6 @@ Serial
 
 * The Raspberry Pi UART driver ``uart_rpi_pico`` has been removed.
   Use ``uart_pl011`` (:dtcompatible:`arm,pl011`) instead. (:github:`71074`)
-
-Timer
-=====
 
 Regulator
 =========
@@ -944,9 +926,6 @@ hawkBit
   :kconfig:option:`CONFIG_SETTINGS` needs to be enabled to use hawkBit, as it now uses the
   settings subsystem to store the hawkBit configuration. (:github:`68806`)
 
-LoRaWAN
-=======
-
 MCUmgr
 ======
 
@@ -975,9 +954,6 @@ POSIX API
 
     $ python ${ZEPHYR_BASE}/scripts/utils/migrate_posix_kconfigs.py -r root_path
 
-Shell
-=====
-
 State Machine Framework
 =======================
 
@@ -1003,12 +979,6 @@ UpdateHub
   It still defaults to using Mbed TLS (with a smaller footprint than previously) unless the
   board is built with TF-M or :kconfig:option:`CONFIG_MBEDTLS_PSA_CRYPTO_C` is enabled. (:github:`73511`)
 
-ZBus
-====
-
-Userspace
-*********
-
 Architectures
 *************
 
@@ -1028,6 +998,3 @@ Architectures
   * LLVM fuzzing support has been refactored. A test application now needs to provide its own
     ``LLVMFuzzerTestOneInput()`` hook instead of relying on a board provided one. Check
     ``samples/subsys/debug/fuzz/`` for an example. (:github:`71378`)
-
-Xtensa
-======

--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -175,7 +175,6 @@ Deprecated in this release
 
     * :kconfig:option:`CONFIG_EVENTFD_MAX` (:kconfig:option:`CONFIG_ZVFS_EVENTFD_MAX`)
     * :kconfig:option:`CONFIG_FNMATCH` (:kconfig:option:`CONFIG_POSIX_C_LIB_EXT`)
-    * :kconfig:option:`CONFIG_GETENTROPY` (:kconfig:option:`CONFIG_POSIX_C_LIB_EXT`)
     * :kconfig:option:`CONFIG_GETOPT` (:kconfig:option:`CONFIG_POSIX_C_LIB_EXT`)
     * :kconfig:option:`CONFIG_MAX_PTHREAD_COUNT` (:kconfig:option:`CONFIG_POSIX_THREAD_THREADS_MAX`)
     * :kconfig:option:`CONFIG_MAX_PTHREAD_KEY_COUNT` (:kconfig:option:`CONFIG_POSIX_THREAD_KEYS_MAX`)
@@ -184,8 +183,6 @@ Deprecated in this release
     * :kconfig:option:`CONFIG_POSIX_CLOCK` (:kconfig:option:`CONFIG_POSIX_CLOCK_SELECTION`,
       :kconfig:option:`CONFIG_POSIX_CPUTIME`, :kconfig:option:`CONFIG_POSIX_MONOTONIC_CLOCK`,
       :kconfig:option:`CONFIG_POSIX_TIMERS`, and :kconfig:option:`CONFIG_POSIX_TIMEOUTS`)
-    * :kconfig:option:`CONFIG_POSIX_CONFSTR` (:kconfig:option:`CONFIG_POSIX_SINGLE_PROCESS`)
-    * :kconfig:option:`CONFIG_POSIX_ENV` (:kconfig:option:`CONFIG_POSIX_SINGLE_PROCESS`)
     * :kconfig:option:`CONFIG_POSIX_FS` (:kconfig:option:`CONFIG_POSIX_FILE_SYSTEM`)
     * :kconfig:option:`CONFIG_POSIX_MAX_FDS` (:kconfig:option:`CONFIG_POSIX_OPEN_MAX` and
       :kconfig:option:`CONFIG_ZVFS_OPEN_MAX`)
@@ -195,7 +192,6 @@ Deprecated in this release
     * :kconfig:option:`CONFIG_POSIX_PUTMSG` (:kconfig:option:`CONFIG_XOPEN_STREAMS`)
     * :kconfig:option:`CONFIG_POSIX_SIGNAL` (:kconfig:option:`CONFIG_POSIX_SIGNALS`)
     * :kconfig:option:`CONFIG_POSIX_SYSCONF` (:kconfig:option:`CONFIG_POSIX_SINGLE_PROCESS`)
-    * :kconfig:option:`CONFIG_POSIX_SYSLOG` (:kconfig:option:`CONFIG_XSI_SYSTEM_LOGGING`)
     * :kconfig:option:`CONFIG_POSIX_UNAME` (:kconfig:option:`CONFIG_POSIX_SINGLE_PROCESS`)
     * :kconfig:option:`CONFIG_PTHREAD` (:kconfig:option:`CONFIG_POSIX_THREADS`)
     * :kconfig:option:`CONFIG_PTHREAD_BARRIER` (:kconfig:option:`CONFIG_POSIX_BARRIERS`)

--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -30,8 +30,8 @@ Major enhancements with this release include:
   data flows than the previous fetch/get APIs.
 * A new :ref:`LLEXT Extension Developer Kit (EDK) <llext_build_edk>` makes it easier to develop and
   integrate custom extensions into Zephyr, including outside of the Zephyr tree.
-* :ref:`Native simulator <native_sim>` now supports leveraging native host networking stack without
-  having to rely on complex setup of the host environment.
+* :ref:`Native simulator <native_sim>` now supports leveraging the native host networking stack
+  without having to rely on a complex setup of the host environment.
 * Trusted Firmware-M (TF-M) 2.1.0 and Mbed TLS 3.6.0 have been integrated into Zephyr.
   Both of these versions are LTS releases. What's more, :ref:`psa_crypto` has been adopted as a replacement
   for TinyCrypt and provides enhanced security and performance.
@@ -288,7 +288,7 @@ Kernel
     has the special ``zephyr,deferred-init`` property set. The device can be
     initialized later in time by using :c:func:`device_init`.
 
-  * The declaration of statically allocated thread stacks have been updated to utilize
+  * The declaration of statically allocated thread stacks has been updated to utilize
     :c:macro:`K_THREAD_STACK_LEN` for both single thread stack declaration and array thread
     stack declarations. This ensures correct alignment for all thread stacks. For user
     threads, this may increase the size of the statically allocated stack objects depending
@@ -329,8 +329,8 @@ Bluetooth
     allowing multiple serial endpoints to be used for different purposes.
 
   * Implemented Hands-free Audio Gateway (AG), enabled by the :kconfig:option:`CONFIG_BT_HFP_AG`.
-    It works as a device that is the gateway of the audio. Typical device acting as Audio
-    Gateway is cellular phone. It controls the device (Hands-free Unit), that is the remote
+    It works as a device that is the gateway of the audio. The typical device acting as Audio
+    Gateway is a cellular phone. It controls the device (Hands-free Unit), that is the remote
     audio input and output mechanism.
 
   * Implemented Advanced Audio Distribution Profile (A2DP) and Audio/Video Distribution Transport
@@ -490,7 +490,7 @@ Boards & SoC Support
 Build system and Infrastructure
 *******************************
 
-  * CI-enabled blackbox tests were added in order to verify correctness of the vast majority of Twister flags.
+  * CI-enabled blackbox tests were added to verify the correctness of most Twister flags.
 
   * A ``socs`` folder for applications has been introduced that allows for Kconfig fragments and
     devicetree overlays that should apply to any board target using a particular SoC and board
@@ -500,8 +500,8 @@ Build system and Infrastructure
     (:github:`69748`).
 
   * Deprecated the global CSTD cmake property in favor of the :kconfig:option:`CONFIG_STD_C`
-    choice to select the C Standard version. Additionally subsystems can select a minimum
-    required C Standard version, with for example :kconfig:option:`CONFIG_REQUIRES_STD_C11`.
+    choice to select the C Standard version. Additionally, subsystems can select a minimum
+    required C Standard version, with, for example, :kconfig:option:`CONFIG_REQUIRES_STD_C11`.
 
   * Fixed issue with passing UTF-8 configs to applications using sysbuild (:github:`74152`).
 
@@ -754,7 +754,7 @@ Drivers and Sensors
 
 * eSPI
 
-  * Renamed eSPI virtual wire direction macros, enum values and KConfig to match the new
+  * Renamed eSPI virtual wire direction macros, enum values and Kconfig to match the new
     terminology in eSPI 1.5 specification.
 
 * Ethernet
@@ -815,12 +815,12 @@ Drivers and Sensors
   * ESP32 ethernet driver changes
 
     * Added support to esp32 ethernet driver to set the MAC address during runtime.
-    * Updated esp32 ethernet driver to work with the version 5.1 of hal_espressif.
+    * Updated esp32 ethernet driver to work with version 5.1 of hal_espressif.
     * Fixed build of esp32 ethernet driver when :kconfig:option:`CONFIG_NET_STATISTICS` is enabled.
     * Fixed ESP32 ethernet driver not clocking external PHY correctly over GPIO.
   * Other ethernet driver changes
 
-    * Added link status detection to the w5500 ethernet driver, configurable via kconfig.
+    * Added link status detection to the w5500 ethernet driver, configurable via Kconfig.
     * Added ability to set MAC address at runtime with eth_liteeth driver.
     * Fixed issue in the eth_stellaris driver where it was previously not taken into account
       that the number of interrupts received by the driver may be less than the number of
@@ -910,7 +910,7 @@ Drivers and Sensors
 * I2S
 
   * Added support for STM32H5 series.
-  * Extended the mcux flexcomm driver to support additional channels and formats.
+  * Extended the MCUX Flexcomm driver to support additional channels and formats.
   * Added support for Nordic nRF54L Series.
   * Fixed divider calculations in the nRF I2S driver.
 
@@ -974,8 +974,8 @@ Drivers and Sensors
 
 * MDIO
 
-  * Made the bus_enable and bus_disable functions optional for drivers to implement,
-    and removed empty implementation from many drivers.
+  * Made the ``bus_enable`` and ``bus_disable`` functions optional for drivers to
+    implement, and removed empty implementation from many drivers.
   * Added NXP ENET QOS MDIO controller driver.
   * Fixed but with NXP ENET MDIO driver blocking the system workqueue.
   * :kconfig:option:`CONFIG_MDIO_NXP_ENET_TIMEOUT` units change to microseconds.
@@ -1013,7 +1013,7 @@ Drivers and Sensors
   * Added new set of shell commands for sending AT commands directly to a modem using the
     newly implemented modem pipelinks. The implementation of the new shell commands is
     both functional and together with the ``MODEM_CELLULAR`` driver will provide an
-    example of how implement and use the modem pipelink module.
+    example of how to implement and use the modem pipelink module.
 
 * PCIE
 
@@ -1430,7 +1430,7 @@ Networking
   * Fixed IPv6 hop limit handling for multicast packets.
   * Improved IPv6 Neighbor Discovery test coverage.
   * Fixed a bug, where Neighbor Advertisement packets reporting Duplicate address
-    detection conflict were dropped.
+    detection conflicts were dropped.
   * Other minor fixes and improvements.
 
 * LwM2M:
@@ -1454,7 +1454,7 @@ Networking
 
 * Misc:
 
-  * Improved overall networking API doxygen documentation.
+  * Improved overall networking API Doxygen documentation.
   * Converted TFTP library to use ``zsock_*`` API.
   * Added SNTP :c:func:`sntp_simple_addr` API function to perform SNTP query
     when the server IP address is already known.
@@ -1469,10 +1469,10 @@ Networking
   * Fixed cloning of zero sized network buffers.
   * Added net_buf APIs to handle 40 bit data format.
   * Added receive callback for dummy L2, applicable in certain use cases
-    (for example packet capture).
+    (for example, packet capture).
   * Implemented pseudo interface, a.k.a "any" interface for packet capture use
     case.
-  * Added cooded mode capture support. This allows non-IP based network data capture.
+  * Added cooked mode capture support. This allows non-IP based network data capture.
   * Generate network events when starting or stopping packet capture.
   * Removed obsolete and unused ``tcp_first_msg`` :c:struct:`net_pkt` flag.
   * Added new :zephyr:code-sample:`secure-mqtt-sensor-actuator` sample.
@@ -1506,8 +1506,8 @@ Networking
 
 * OpenThread
 
- * Removed deprecated ``openthread_set_state_changed_cb()`` function.
- * Added implementation of BLE TCAT advertisement API.
+  * Removed deprecated ``openthread_set_state_changed_cb()`` function.
+  * Added implementation of BLE TCAT advertisement API.
 
 * PPP
 
@@ -1564,7 +1564,7 @@ Networking
   * Fixed a possible TCP context leak in case initial SYN packet transmission failed.
   * Deprecated :kconfig:option:`CONFIG_NET_TCP_ACK_TIMEOUT` as it was redundant with other configs.
   * Improved debug logs, so that they're easier to follow under heavy load.
-  * ISN generation now uses SHA-256 instead of MD5. Moreover it now relies on PSA APIs
+  * ISN generation now uses SHA-256 instead of MD5. Moreover, it now relies on PSA APIs
     instead of legacy Mbed TLS functions for hash computation.
   * Improved ACK reply logic in case no PSH flag is present to reduce redundant ACKs.
 
@@ -1615,7 +1615,7 @@ Networking
 USB
 ***
 
-* new USB device stack:
+* New USB device stack:
 
   * Added support for HID devices
   * Introduced speed-specific configurations and made high-speed support
@@ -1640,9 +1640,9 @@ Devicetree
 Kconfig
 *******
 
-* Added a ``substring`` kconfig preprocessor function.
-* Added a ``dt_node_ph_prop_path`` kconfig preprocessor function.
-* Added a ``dt_compat_any_has_prop`` kconfig preprocessor function.
+* Added a ``substring`` Kconfig preprocessor function.
+* Added a ``dt_node_ph_prop_path`` Kconfig preprocessor function.
+* Added a ``dt_compat_any_has_prop`` Kconfig preprocessor function.
 
 Libraries / Subsystems
 **********************
@@ -1755,7 +1755,7 @@ Libraries / Subsystems
 
   * Device power management was de-coupled from system power management. The new
     :kconfig:option:`CONFIG_PM_DEVICE_SYSTEM_MANAGED` option is used to enable
-    whether or not devices must be suspended when the system sleeps.
+    whether devices must be suspended when the system sleeps.
 
   * Make it possible to disable system device power management individually per
     power state using ``zephyr,pm-device-disabled``. This allows targets tuning which
@@ -1786,7 +1786,8 @@ Libraries / Subsystems
 
 * FPGA
 
-  * Improve handling of drivers missing reset, load, get_status, and get_info methods.
+  * Improve handling of drivers missing ``reset``, ``load``, ``get_status``, and ``get_info``
+    methods.
   * Add support for Agilex and Agilex 5.
 
 * Random
@@ -2040,7 +2041,7 @@ Tests and Samples
   * Added snippet for easily enabling UART over Bluetooth LE by passing ``-S nus-console`` during
     ``west build``. This snippet sets the :kconfig:option:`CONFIG_BT_ZEPHYR_NUS_AUTO_START_BLUETOOTH`
     which allows non-Bluetooth samples that use the UART APIs to run without modifications
-    (e.g: Console and Logging examples).
+    (e.g.: Console and Logging examples).
 
   * Removed ``GSM_PPP`` specific configuration overlays from samples ``net/cloud/tagoio`` and
     ``net/mgmt/updatehub``. The ``GSM_PPP`` device driver has been deprecated and removed. The new

--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -624,10 +624,6 @@ Drivers and Sensors
 
   * Added support for Nuvoton Numaker M2L31X series.
 
-* Auxiliary Display
-
-* Audio
-
 * Battery
 
   * Added ``re-charge-voltage-microvolt`` property to the ``battery`` binding. This allows to set
@@ -684,8 +680,6 @@ Drivers and Sensors
   * Added driver for LPTMR to NXP MCXN947
   * Added the ``resolution`` property in ``nxp,lptmr`` binding to represent the maximum width
     in bits the LPTMR peripheral uses for its counter.
-
-* Crypto
 
 * DAC
 
@@ -919,8 +913,6 @@ Drivers and Sensors
   * Improvements and bug fixes on :dtcompatible:`nxp,mcux-i3c`, including handling the bus
     being busy more gracefully instead of simply returning errors.
 
-* IEEE 802.15.4
-
 * Input
 
   * New drivers: :dtcompatible:`adc-keys`, :dtcompatible:`chipsemi,chsc6x`,
@@ -1016,8 +1008,6 @@ Drivers and Sensors
   * ``pcie_bdf_lookup`` and ``pcie_probe`` have been removed since they have been
     deprecated since v3.3.0.
 
-* MEMC
-
 * MIPI-DBI
 
   * Added release API
@@ -1085,8 +1075,6 @@ Drivers and Sensors
   * Added reset controller driver for NXP RSTCTL.
   * Added support for Nuvoton Numaker M2L31X series.
 
-* Retained memory
-
 * RTC
 
   * Added Raspberry Pi Pico RTC driver.
@@ -1099,8 +1087,6 @@ Drivers and Sensors
   * Added tests and fixed bugs related to chained callback requests.
   * Wrapper around p4wq (rtio workq) created to go from blocking to non-blocking behavior in cases
     where native asynchronous RTIO functionality is unavailable.
-
-* SMBUS
 
 * SDHC
 
@@ -1736,8 +1722,6 @@ Libraries / Subsystems
   * Added ``modem_stats`` module which tracks the usage of buffers throughout the modem
     subsystem.
 
-* Picolibc
-
 * Power management
 
   * Devices can now declare which system power states cause power loss.
@@ -1791,8 +1775,6 @@ Libraries / Subsystems
   * Besides the existing :c:func:`sys_rand32_get` function, :c:func:`sys_rand8_get`,
     :c:func:`sys_rand16_get` and :c:func:`sys_rand64_get` are now also available.
     These functions are all implemented on top of :c:func:`sys_rand_get`.
-
-* Retention
 
 * SD
 
@@ -2004,9 +1986,6 @@ Trusted Firmware-M
 * Support for MCUboot signature types other than RSA-3072 has been added.
   The type can be chosen with the :kconfig:option:`CONFIG_TFM_MCUBOOT_SIGNATURE_TYPE` Kconfig option.
   Using EC-P256, the new default, reduces flash usage by several KBs compared to RSA.
-
-zcbor
-*****
 
 LVGL
 ****


### PR DESCRIPTION
Following #76113
Let's do a 2nd pass correcting a few minor issues and remove empty headings.

And as ac52bd629d705811858c8bb38ca7a43e4e81182b removed from the
tree some kconfig options which weren't there for a full release.
Let's also not mention them in the release notes so we avoid broken links.
    
