### PR TITLE
rw612 wifi monolithic support

### DIFF
--- a/modules/Kconfig.mcux
+++ b/modules/Kconfig.mcux
@@ -375,6 +375,12 @@ config NXP_FW_LOADER
 	   The firmware loader is used to load firmwares to embedded tranceivers.
 	   It is needed to enable connectivity features.
 
+config NXP_MONOLITHIC_WIFI
+	bool "WiFi firmware monolithic build"
+	help
+	   If enabled, the WiFi firmware used by the device will be linked with the
+	   application directly.
+
 config NXP_MONOLITHIC_BT
 	bool "BT firmware monolithic build"
 	help

--- a/soc/nxp/rw/Kconfig.defconfig
+++ b/soc/nxp/rw/Kconfig.defconfig
@@ -105,6 +105,9 @@ config HEAP_MEM_POOL_SIZE
 
 endif # BT
 
+config NXP_MONOLITHIC_WIFI
+	default y if WIFI
+
 config NXP_MONOLITHIC_BT
 	default y if BT
 

--- a/soc/nxp/rw/firmwares.ld
+++ b/soc/nxp/rw/firmwares.ld
@@ -4,6 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* For RW612, fw_cpu1 is used for wifi firmware.
+ * Place the wifi and ble firmwares in rodata section. If both binaries
+ * are placed next to each other, the firmware loader will detect the
+ * second binary as part of the first one, leading to initialization
+ * issue, so add a padding of one word */
+#if defined(CONFIG_NXP_MONOLITHIC_WIFI)
+. = ALIGN(4);
+KEEP(*(.fw_cpu1))
+. += 4;
+#endif
+
 #if defined(CONFIG_NXP_MONOLITHIC_BT)
 . = ALIGN(4);
 KEEP(*(.fw_cpu2_ble))


### PR DESCRIPTION
mcux: add Kconfig to configure NXP WiFi monolithic feature
soc: rw6xx: Enable NXP_WIFI_MONOLITHIC
boards: rd_rw612_bga: flash size with monolithic feature