### PR TITLE
Blueotooth: Audio: Cap broadcast reception stop shell cmd

### DIFF
--- a/doc/connectivity/bluetooth/api/audio/shell/cap.rst
+++ b/doc/connectivity/bluetooth/api/audio/shell/cap.rst
@@ -257,15 +257,20 @@ the optionally included CSIS instance by calling (:code:`cap_commander discover`
    cap_commander --help
    cap_commander - Bluetooth CAP commander shell commands
    Subcommands:
-     discover                :Discover CAS
-     cancel                  :CAP commander cancel current procedure
-     change_volume           :Change volume on all connections <volume>
-     change_volume_mute      :Change volume mute state on all connections <mute>
-     change_volume_offset    :Change volume offset per connection <volume_offset
-                              [volume_offset [...]]>
-     change_microphone_mute  :Change microphone mute state on all connections <mute>
-     change_microphone_gain  :Change microphone gain per connection <gain
-                              [gain [...]]>
+     discover                  :Discover CAS
+     cancel                    :CAP commander cancel current procedure
+     change_volume             :Change volume on all connections <volume>
+     change_volume_mute        :Change volume mute state on all connections <mute>
+     change_volume_offset      :Change volume offset per connection <volume_offset
+                                [volume_offset [...]]>
+     change_microphone_mute    :Change microphone mute state on all connections <mute>
+     change_microphone_gain    :Change microphone gain per connection <gain
+                                [gain [...]]>
+     broadcast_reception_start : Start broadcast reception with
+                                 source <address: XX:XX:XX:XX:XX:XX>
+                                 <type: public/random> <adv_sid> <broadcast_id>
+                                 [<pa_interval>] [<sync_bis>] [<metadata>]
+     broadcast_reception_stop  : Stop broadcast reception <src_id [...]>
 
 
 Before being able to perform any stream operation, the device must also perform the
@@ -437,8 +442,8 @@ and index 1 gets the second offset, etc.:
    Gain set for inst 0x20014188
    Microphone gain change completed
 
-Starting a broadcast reception
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Starting and stopping broadcast reception
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: console
 
@@ -451,3 +456,7 @@ Starting a broadcast reception
    BASS discover done with 1 recv states
    uart:~$ cap_commander broadcast_reception_start <device B> 0 4
    Starting broadcast reception on 1 connection(s)
+   Broadcast reception start completed
+   uart:~$ cap_commander broadcast_reception_stop 0
+   Stopping broadcast reception on 1 connection(s)
+   Broadcast reception stop completed

--- a/subsys/bluetooth/audio/shell/cap_commander.c
+++ b/subsys/bluetooth/audio/shell/cap_commander.c
@@ -103,6 +103,17 @@ static void cap_broadcast_reception_start_cb(struct bt_conn *conn, int err)
 
 	shell_print(ctx_shell, "Broadcast reception start completed");
 }
+
+static void cap_broadcast_reception_stop_cb(struct bt_conn *conn, int err)
+{
+	if (err != 0) {
+		shell_error(ctx_shell, "Broadcast reception stop failed (%d) for conn %p", err,
+			    (void *)conn);
+		return;
+	}
+
+	shell_print(ctx_shell, "Broadcast reception stop completed");
+}
 #endif
 
 static struct bt_cap_commander_cb cbs = {
@@ -122,6 +133,7 @@ static struct bt_cap_commander_cb cbs = {
 #endif /* CONFIG_BT_MICP_MIC_CTLR */
 #if defined(CONFIG_BT_BAP_BROADCAST_ASSISTANT)
 	.broadcast_reception_start = cap_broadcast_reception_start_cb,
+	.broadcast_reception_stop = cap_broadcast_reception_stop_cb,
 #endif /* CONFIG_BT_BAP_BROADCAST_ASSISTANT */
 };
 
@@ -662,6 +674,83 @@ static int cmd_cap_commander_broadcast_reception_start(const struct shell *sh, s
 
 	return 0;
 }
+
+static int cmd_cap_commander_broadcast_reception_stop(const struct shell *sh, size_t argc,
+						      char *argv[])
+{
+	struct bt_cap_commander_broadcast_reception_stop_member_param
+		member_params[CONFIG_BT_MAX_CONN] = {0};
+	const size_t cap_args = argc - 1; /* First argument is the command itself */
+	struct bt_cap_commander_broadcast_reception_stop_param param = {
+		.type = BT_CAP_SET_TYPE_AD_HOC,
+		.param = member_params,
+	};
+
+	struct bt_conn *connected_conns[CONFIG_BT_MAX_CONN] = {0};
+	size_t conn_cnt = 0U;
+	int err = 0;
+
+	if (default_conn == NULL) {
+		shell_error(sh, "Not connected");
+		return -ENOEXEC;
+	}
+
+	/* TODO: Add support for coordinated sets */
+
+	/* Populate the array of connected connections */
+	bt_conn_foreach(BT_CONN_TYPE_LE, populate_connected_conns, (void *)connected_conns);
+	for (size_t i = 0; i < ARRAY_SIZE(connected_conns); i++) {
+		struct bt_conn *conn = connected_conns[i];
+
+		if (conn == NULL) {
+			break;
+		}
+
+		conn_cnt++;
+	}
+
+	if (cap_args > conn_cnt) {
+		shell_error(sh, "Cannot use %zu arguments for %zu connections", argc, conn_cnt);
+
+		return -ENOEXEC;
+	}
+
+	for (size_t i = 0U; i < cap_args; i++) {
+		const char *arg = argv[i + 1];
+		unsigned long src_id;
+
+		src_id = shell_strtoul(arg, 0, &err);
+		if (err != 0) {
+			shell_error(sh, "Could not parse src_id: %d", err);
+
+			return -ENOEXEC;
+		}
+
+		if (src_id > UINT8_MAX) {
+			shell_error(sh, "Invalid src_id: %lu", src_id);
+
+			return -ENOEXEC;
+		}
+
+		/* TODO: Allow for multiple subgroups */
+		member_params[i].num_subgroups = 1;
+		member_params[i].src_id = src_id;
+		member_params[i].member.member = connected_conns[i];
+		param.count++;
+	}
+
+	shell_print(sh, "Stopping broadcast reception on %zu connection(s)", param.count);
+
+	err = bt_cap_commander_broadcast_reception_stop(&param);
+	if (err != 0) {
+		shell_print(sh, "Failed to initiate broadcast reception stop: %d", err);
+
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
+
 #endif /* CONFIG_BT_BAP_BROADCAST_ASSISTANT */
 
 static int cmd_cap_commander(const struct shell *sh, size_t argc, char **argv)
@@ -710,6 +799,11 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      "<broadcast_id> [<pa_interval>] [<sync_bis>] "
 		      "[<metadata>]",
 		      cmd_cap_commander_broadcast_reception_start, 5, 3),
+	SHELL_CMD_ARG(broadcast_reception_stop, NULL,
+		      "Stop broadcast reception "
+		      "<src_id [...]>",
+		      cmd_cap_commander_broadcast_reception_stop, 2, 0),
+
 #endif /* CONFIG_BT_BAP_BROADCAST_ASSISTANT */
 	SHELL_SUBCMD_SET_END);
 


### PR DESCRIPTION
Implementation for support of the CAP 'broadcast reception stop' procedure in
the bluetooth shell