### PR TITLE
lis2dux12: fix mode argument when setting odr

### DIFF
--- a/drivers/sensor/st/lis2dux12/lis2dux12.c
+++ b/drivers/sensor/st/lis2dux12/lis2dux12.c
@@ -30,7 +30,7 @@ static int lis2dux12_set_odr(const struct device *dev, uint8_t odr)
 	struct lis2dux12_data *data = dev->data;
 	const struct lis2dux12_config *cfg = dev->config;
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
-	lis2dux12_md_t mode = {.odr = odr};
+	lis2dux12_md_t mode = {.odr = odr, .fs = data->range};
 
 	data->odr = odr;
 	return lis2dux12_mode_set(ctx, &mode);


### PR DESCRIPTION
In lis2dux12_set_odr(), the call to stmemsc module lis2dux12_mode_set() API is done with the .fs field left uninitialized, so setting the underlying device regs in an unproper way.

Suggested by: @ubieda 

Depends to #76279 and must be rebased once that will be merged.
