### PR TITLE
samples/synchronization: fix thread b pinning

### DIFF
--- a/samples/synchronization/src/main.c
+++ b/samples/synchronization/src/main.c
@@ -110,7 +110,16 @@ int main(void)
 #if PIN_THREADS
 	if (arch_num_cpus() > 1) {
 		k_thread_cpu_pin(&thread_a_data, 0);
+
+		/*
+		 * Thread b is a static thread that is spawned immediately. This means that the
+		 * following `k_thread_cpu_pin` call can fail with `-EINVAL` if the thread is
+		 * actively running. Let's suspend the thread and resume it after the affinity mask
+		 * is set.
+		 */
+		k_thread_suspend(thread_b);
 		k_thread_cpu_pin(thread_b, 1);
+		k_thread_resume(thread_b);
 	}
 #endif
 


### PR DESCRIPTION
This PR adds a brief thread b suspend while the sample sets thread b's affinity mask.

If the call to `k_thread_cpu_pin` is being made while the thread is actively running, then we get `-EINVAL` and the affinity mask is left unchanged.

Tested with:
```
west build -p -b qemu_riscv64/qemu_virt_riscv64/smp samples/synchronization -t run
```

Logs with the fix:
```
*** Booting Zephyr OS build v3.7.0-rc3-122-g1bad1a04f839 ***
thread_a: Hello World from cpu 0 on qemu_riscv64!
thread_b: Hello World from cpu 1 on qemu_riscv64!
thread_a: Hello World from cpu 0 on qemu_riscv64!
thread_b: Hello World from cpu 1 on qemu_riscv64!
thread_a: Hello World from cpu 0 on qemu_riscv64!
thread_b: Hello World from cpu 1 on qemu_riscv64!
thread_a: Hello World from cpu 0 on qemu_riscv64!
thread_b: Hello World from cpu 1 on qemu_riscv64!
thread_a: Hello World from cpu 0 on qemu_riscv64!
```

Logs without the fix (current main):
```
*** Booting Zephyr OS build v3.7.0-rc3-121-g51c39d7d3f40 ***
thread_a: Hello World from cpu 0 on qemu_riscv64!
thread_b: Hello World from cpu 0 on qemu_riscv64!
thread_a: Hello World from cpu 0 on qemu_riscv64!
thread_b: Hello World from cpu 0 on qemu_riscv64!
thread_a: Hello World from cpu 0 on qemu_riscv64!
thread_b: Hello World from cpu 1 on qemu_riscv64!
thread_a: Hello World from cpu 0 on qemu_riscv64!
thread_b: Hello World from cpu 0 on qemu_riscv64!
thread_a: Hello World from cpu 0 on qemu_riscv64!
thread_b: Hello World from cpu 1 on qemu_riscv64!
thread_a: Hello World from cpu 0 on qemu_riscv64!
```