### PR TITLE
tests: net: http_server: Remove harness requirement

### DIFF
--- a/tests/net/lib/http_server/core/testcase.yaml
+++ b/tests/net/lib/http_server/core/testcase.yaml
@@ -1,5 +1,4 @@
 common:
-  harness: net
   min_ram: 80
   tags:
     - http

--- a/tests/net/lib/http_server/crime/testcase.yaml
+++ b/tests/net/lib/http_server/crime/testcase.yaml
@@ -1,5 +1,4 @@
 common:
-  harness: net
   min_ram: 60
   tags:
     - http

--- a/tests/net/lib/http_server/hpack/testcase.yaml
+++ b/tests/net/lib/http_server/hpack/testcase.yaml
@@ -1,5 +1,4 @@
 common:
-  harness: net
   depends_on: netif
   min_ram: 60
   tags:

--- a/tests/net/lib/http_server/tls/testcase.yaml
+++ b/tests/net/lib/http_server/tls/testcase.yaml
@@ -1,5 +1,4 @@
 common:
-  harness: net
   min_ram: 192
   tags:
     - http


### PR DESCRIPTION
The HTTP server tests are self-contained, they do not require network environment to execute, hence should not specify "harness: net".

The consequence of specifying the harness was that HTTP server tests in the CI were only built, and not executed, which doesn't make much sense.