### PR TITLE
github: Update security page for v3.7.0 release

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -11,9 +11,9 @@ updates:
 At this time, with the latest release of v3.6, the supported
 versions are:
 
-  - v2.7: Current LTS
-  - v3.5: Prior release
-  - v3.6: Current release
+  - v3.7: Current LTS
+  - v3.6: Prior release
+  - v2.7: Prior LTS
 
 ## Reporting process
 


### PR DESCRIPTION
Updates the GitHub security page with the current supported versions after the v3.7.0 release.