### PR TITLE
drivers: ethernet: Update STM32 Ethernet driver to decouple MDIO support

### DIFF
--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -56,12 +56,16 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #define PHY_ADDR	CONFIG_ETH_STM32_HAL_PHY_ADDRESS
 
-#if defined(CONFIG_SOC_SERIES_STM32H7X) || defined(CONFIG_SOC_SERIES_STM32H5X)
+#if defined(CONFIG_MDIO)
 
 #define DEVICE_PHY_BY_NAME(n) \
 	    DEVICE_DT_GET(DT_CHILD(DT_INST_CHILD(n, mdio), ethernet_phy_0))
 
 static const struct device *eth_stm32_phy_dev = DEVICE_PHY_BY_NAME(0);
+
+#endif
+
+#if defined(CONFIG_SOC_SERIES_STM32H7X) || defined(CONFIG_SOC_SERIES_STM32H5X)
 
 #define PHY_BSR  ((uint16_t)0x0001U)  /*!< Transceiver Basic Status Register */
 #define PHY_LINKED_STATUS  ((uint16_t)0x0004U)  /*!< Valid link established */


### PR DESCRIPTION
Moved the definition of the phy device from depending on stm32hx series SOC to its own #if...#else...#endif. This way mdio support can be enabled on any stm32 soc that supports it by defining the mdio node in the devicetree.

I have tested this in a custom board.

#76048 adds support for the MDIO shell commands.