### PR TITLE
drivers: pinctrl: rp2040: oe-override option

### DIFF
--- a/drivers/pinctrl/pinctrl_rpi_pico.c
+++ b/drivers/pinctrl/pinctrl_rpi_pico.c
@@ -19,6 +19,7 @@ static void pinctrl_configure_pin(const pinctrl_soc_pin_t *pin)
 				GPIO_SLEW_RATE_FAST : GPIO_SLEW_RATE_SLOW));
 	gpio_set_input_hysteresis_enabled(pin->pin_num, pin->schmitt_enable);
 	gpio_set_input_enabled(pin->pin_num, pin->input_enable);
+	gpio_set_oeover(pin->pin_num, pin->oe_override);
 }
 
 int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,

--- a/dts/bindings/pinctrl/raspberrypi,pico-pinctrl.yaml
+++ b/dts/bindings/pinctrl/raspberrypi,pico-pinctrl.yaml
@@ -121,3 +121,22 @@ child-binding:
         description: |
           The slew rate of a pin. 0 corresponds to slow, and 1 corresponds to fast.
           The default value is 0 (slow), as this is the power on reset value.
+      raspberrypi,oe-override:
+        type: int
+        enum:
+          - 0
+          - 1
+          - 2
+          - 3
+        default: 0
+        description: |
+          Override output-enable for a pin.
+
+          - 0 (RP2_GPIO_OVERRIDE_NORMAL) - drive output enable from selected
+              peripheral signal.
+          - 1 (RP2_GPIO_OVERRIDE_INVERT) - drive output enable from inverse of
+              selected peripheral signal.
+          - 2 (RP2_GPIO_OVERRIDE_LOW) - disable output.
+          - 3 (RP2_GPIO_OVERRIDE_HIGH) - enable output.
+
+          The default value is 0, as this is the power on reset value.

--- a/include/zephyr/dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h
@@ -25,6 +25,11 @@
 #define RP2_PIN_NUM_POS 4
 #define RP2_PIN_NUM_MASK 0x1f
 
+#define RP2_GPIO_OVERRIDE_NORMAL 0
+#define RP2_GPIO_OVERRIDE_INVERT 1
+#define RP2_GPIO_OVERRIDE_LOW 2
+#define RP2_GPIO_OVERRIDE_HIGH 3
+
 #define RP2040_PINMUX(pin_num, alt_func) (pin_num << RP2_PIN_NUM_POS |	\
 					alt_func << RP2_ALT_FUNC_POS)
 

--- a/soc/raspberrypi/rp2xxx/pinctrl_soc.h
+++ b/soc/raspberrypi/rp2xxx/pinctrl_soc.h
@@ -29,6 +29,8 @@ struct rpi_pinctrl_soc_pin {
 	uint32_t input_enable : 1;
 	/** Enable the internal schmitt trigger */
 	uint32_t schmitt_enable : 1;
+	/** Output-enable override */
+	uint32_t oe_override : 2;
 };
 
 typedef struct rpi_pinctrl_soc_pin pinctrl_soc_pin_t;
@@ -50,6 +52,7 @@ typedef struct rpi_pinctrl_soc_pin pinctrl_soc_pin_t;
 		DT_PROP(node_id, bias_pull_down),				\
 		DT_PROP(node_id, input_enable),					\
 		DT_PROP(node_id, input_schmitt_enable),				\
+		DT_PROP(node_id, raspberrypi_oe_override),				\
 	},
 
 /**


### PR DESCRIPTION
This change adds the device tree property for specifying oe-override (output-enable override behavior), as well as defines for possible values of the property.

RP2040 GPIOs can be configured to automatically invert the output-enable signal from the selected peripheral function. This is useful for tasks like writing efficient PIO code, such as in the i2c example in the rp2040 datasheet.

I've manually tested the functionality with value set to INVERT. Not sure if there's any automated tests I should update too.