### PR TITLE
tests: posix + libc/thrd: one tier0 integration platform per arch, improved libc coverage

### DIFF
--- a/tests/lib/c_lib/thrd/testcase.yaml
+++ b/tests/lib/c_lib/thrd/testcase.yaml
@@ -1,12 +1,15 @@
 common:
   tags:
-    - clib c11 threads
+    - clib
+    - c11
+    - threads
+    # For now, the implementation of C11 threads uses POSIX under the hood.
+    - posix
+  # 1 tier0 platform per supported architecture
+  platform_key:
+    - arch
+    - simulation
   filter: not CONFIG_NATIVE_APPLICATION
-  integration_platforms:
-    - qemu_x86
-  platform_exclude:
-    - native_posix
-    - native_posix/native/64
 tests:
   libraries.libc.c11_threads.minimal:
     tags: minimal_libc
@@ -44,8 +47,6 @@ tests:
       - CONFIG_NEWLIB_LIBC=y
   libraries.libc.c11_threads.newlib_nano:
     filter: CONFIG_NEWLIB_LIBC_SUPPORTED and CONFIG_HAS_NEWLIB_LIBC_NANO
-    arch_exclude:
-      - posix
     tags: newlib
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y

--- a/tests/posix/common/testcase.yaml
+++ b/tests/posix/common/testcase.yaml
@@ -1,32 +1,29 @@
 common:
-  filter: not CONFIG_NATIVE_LIBC
-  platform_exclude:
-    - native_posix
-    - native_posix/native/64
   tags: posix
   min_ram: 64
   timeout: 240
+  # 1 tier0 platform per supported architecture
+  platform_key:
+    - arch
+    - simulation
+  platform_exclude:
+    - native_posix
+    - native_posix/native/64
+    # consistently overflows flash
+    - qemu_nios2
+  filter: not CONFIG_NATIVE_LIBC
 tests:
-  portability.posix.common:
-    platform_exclude:
-      - nsim/nsim_sem/mpu_stack_guard
-      - intel_ehl_crb
+  portability.posix.common: {}
+  portability.posix.common.minimal:
     extra_configs:
-      - CONFIG_NEWLIB_LIBC=n
-    integration_platforms:
-      - qemu_x86
+      - CONFIG_MINIMAL_LIBC=y
   portability.posix.common.newlib:
     platform_exclude:
-      - nsim/nsim_sem/mpu_stack_guard
       - intel_ehl_crb
       - lpcxpresso55s06
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
-    arch_exclude:
-      - posix
-    integration_platforms:
-      - qemu_x86
   portability.posix.common.armclang_std_libc:
     toolchain_allow: armclang
     extra_configs:
@@ -37,51 +34,28 @@ tests:
       - CONFIG_ARCMWDT_LIBC=y
   portability.posix.common.tls:
     platform_exclude:
-      - nsim/nsim_sem/mpu_stack_guard
       - intel_ehl_crb
     filter: CONFIG_ARCH_HAS_THREAD_LOCAL_STORAGE and CONFIG_TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
     extra_configs:
       - CONFIG_NEWLIB_LIBC=n
       - CONFIG_THREAD_LOCAL_STORAGE=y
-    integration_platforms:
-      - qemu_x86
   portability.posix.common.tls.newlib:
     platform_exclude:
-      - nsim/nsim_sem/mpu_stack_guard
       - intel_ehl_crb
       - lpcxpresso55s06
     filter: TOOLCHAIN_HAS_NEWLIB == 1 and CONFIG_ARCH_HAS_THREAD_LOCAL_STORAGE and
       CONFIG_TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
-    arch_exclude:
-      - posix
-    integration_platforms:
-      - qemu_x86
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
       - CONFIG_THREAD_LOCAL_STORAGE=y
-  portability.posix.common.nsim:
-    platform_allow: nsim/nsim_sem/mpu_stack_guard
-    extra_configs:
-      - CONFIG_NEWLIB_LIBC=n
-      - CONFIG_TEST_HW_STACK_PROTECTION=n
-  portability.posix.common.newlib.nsim:
-    platform_allow: nsim/nsim_sem/mpu_stack_guard
-    filter: TOOLCHAIN_HAS_NEWLIB == 1
-    extra_configs:
-      - CONFIG_NEWLIB_LIBC=y
-      - CONFIG_TEST_HW_STACK_PROTECTION=n
   portability.posix.common.picolibc:
     tags: picolibc
     filter: CONFIG_PICOLIBC_SUPPORTED
-    integration_platforms:
-      - qemu_x86
     extra_configs:
       - CONFIG_PICOLIBC=y
   portability.posix.common.no_spin_validate:
     extra_configs:
       - CONFIG_SPIN_VALIDATE=n
-    integration_platforms:
-      - mps2/an385
   portability.posix.common.signal.strsignal_no_desc:
     extra_configs:
       - CONFIG_POSIX_SIGNAL_STRING_DESC=n
@@ -89,17 +63,11 @@ tests:
     extra_configs:
       - CONFIG_POSIX_RTSIG_MAX=1024
   portability.posix.common.dynamic_stack:
-    integration_platforms:
-      - qemu_x86
-      - qemu_riscv64
     extra_configs:
       - CONFIG_DYNAMIC_THREAD=y
       - CONFIG_THREAD_STACK_INFO=y
       - CONFIG_HEAP_MEM_POOL_SIZE=16384
   portability.posix.common.static_stack:
-    integration_platforms:
-      - qemu_x86
-      - qemu_riscv64
     extra_configs:
       - CONFIG_DYNAMIC_THREAD=n
       - CONFIG_THREAD_STACK_INFO=n

--- a/tests/posix/eventfd/testcase.yaml
+++ b/tests/posix/eventfd/testcase.yaml
@@ -3,7 +3,32 @@ common:
   tags:
     - posix
     - eventfd
-  integration_platforms:
-    - qemu_x86
+  # 1 tier0 platform per supported architecture
+  platform_key:
+    - arch
+    - simulation
 tests:
   portability.posix.eventfd: {}
+  portability.posix.eventfd.minimal:
+    extra_configs:
+      - CONFIG_MINIMAL_LIBC=y
+  portability.posix.eventfd.newlib:
+    platform_exclude:
+      - intel_ehl_crb
+      - lpcxpresso55s06
+    filter: TOOLCHAIN_HAS_NEWLIB == 1
+    extra_configs:
+      - CONFIG_NEWLIB_LIBC=y
+  portability.posix.eventfd.armclang_std_libc:
+    toolchain_allow: armclang
+    extra_configs:
+      - CONFIG_ARMCLANG_STD_LIBC=y
+  portability.posix.eventfd.arcmwdtlib:
+    toolchain_allow: arcmwdt
+    extra_configs:
+      - CONFIG_ARCMWDT_LIBC=y
+  portability.posix.eventfd.picolibc:
+    tags: picolibc
+    filter: CONFIG_PICOLIBC_SUPPORTED
+    extra_configs:
+      - CONFIG_PICOLIBC=y

--- a/tests/posix/fs/testcase.yaml
+++ b/tests/posix/fs/testcase.yaml
@@ -12,48 +12,37 @@ common:
   min_ram: 128
   modules:
     - fatfs
+  # 1 tier0 platform per supported architecture
+  platform_key:
+    - arch
+    - simulation
 tests:
-  portability.posix.fs:
+  portability.posix.fs: {}
+  portability.posix.fs.minimal:
     extra_configs:
-      - CONFIG_NEWLIB_LIBC=n
-    integration_platforms:
-      - qemu_x86
+      - CONFIG_MINIMAL_LIBC=y
   portability.posix.fs.newlib:
     filter: TOOLCHAIN_HAS_NEWLIB == 1
-    arch_exclude:
-      - posix
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
-    integration_platforms:
-      - qemu_x86
   portability.posix.fs.tls:
     filter: CONFIG_ARCH_HAS_THREAD_LOCAL_STORAGE and CONFIG_TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
     extra_configs:
       - CONFIG_NEWLIB_LIBC=n
       - CONFIG_THREAD_LOCAL_STORAGE=y
-    integration_platforms:
-      - qemu_x86
   portability.posix.fs.tls.newlib:
     filter: TOOLCHAIN_HAS_NEWLIB == 1 and CONFIG_ARCH_HAS_THREAD_LOCAL_STORAGE and
       CONFIG_TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
-    arch_exclude:
-      - posix
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
       - CONFIG_THREAD_LOCAL_STORAGE=y
-    integration_platforms:
-      - qemu_x86
   portability.posix.fs.picolibc:
     tags: picolibc
     filter: CONFIG_PICOLIBC_SUPPORTED
     extra_configs:
       - CONFIG_PICOLIBC=y
-    integration_platforms:
-      - qemu_x86
   portability.posix.fs.tls.picolibc:
     tags: picolibc
     filter: CONFIG_PICOLIBC_SUPPORTED
     extra_configs:
       - CONFIG_PICOLIBC=y
-    integration_platforms:
-      - qemu_x86

--- a/tests/posix/getentropy/testcase.yaml
+++ b/tests/posix/getentropy/testcase.yaml
@@ -1,18 +1,33 @@
 common:
   filter: dt_chosen_enabled("zephyr,entropy") and CONFIG_ENTROPY_HAS_DRIVER and
     not CONFIG_NATIVE_LIBC
-  integration_platforms:
-    - native_sim
   tags:
     - posix
     - getentropy
+  # 1 tier0 platform per supported architecture
+  platform_key:
+    - arch
+    - simulation
 tests:
-  portability.posix.getentropy: {}
+  portability.posix.getentropy:
+    extra_configs:
+      - CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=256
+  portability.posix.getentropy.armclang_std_libc:
+    toolchain_allow: armclang
+    extra_configs:
+      - CONFIG_ARMCLANG_STD_LIBC=y
+  portability.posix.getentropy.arcmwdtlib:
+    toolchain_allow: arcmwdt
+    extra_configs:
+      - CONFIG_ARCMWDT_LIBC=y
+  portability.posix.getentropy.minimal:
+    extra_configs:
+      - CONFIG_MINIMAL_LIBC=y
+      - CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=256
   portability.posix.getentropy.newlib:
-    filter: CONFIG_NEWLIB_LIBC_SUPPORTED
+    filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
-      - CONFIG_NEWLIB_LIBC_MIN_REQUIRED_HEAP_SIZE=4096
   portability.posix.getentropy.picolibc:
     tags: picolibc
     filter: CONFIG_PICOLIBC_SUPPORTED

--- a/tests/posix/getopt/testcase.yaml
+++ b/tests/posix/getopt/testcase.yaml
@@ -3,12 +3,17 @@ common:
   tags:
     - posix
     - getopt
-  integration_platforms:
-    - qemu_x86
+  # 1 tier0 platform per supported architecture
+  platform_key:
+    - arch
+    - simulation
 tests:
   portability.posix.getopt:
     min_flash: 64
     min_ram: 32
+  portability.posix.getopt.minimal:
+    extra_configs:
+      - CONFIG_MINIMAL_LIBC=y
   portability.posix.getopt.newlib:
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:

--- a/tests/posix/headers/testcase.yaml
+++ b/tests/posix/headers/testcase.yaml
@@ -3,48 +3,46 @@ common:
   tags:
     - posix
   min_ram: 32
+  # 1 tier0 platform per supported architecture
+  platform_key:
+    - arch
+    - simulation
 tests:
   portability.posix.headers.with_posix_api:
     extra_configs:
       - CONFIG_POSIX_API=y
-    integration_platforms:
-      - qemu_x86
   portability.posix.headers.without_posix_api:
     extra_configs:
       - CONFIG_POSIX_API=n
-    integration_platforms:
-      - qemu_x86
+  portability.posix.headers.minimal.with_posix_api:
+    extra_configs:
+      - CONFIG_POSIX_API=y
+  portability.posix.headers.minimal.without_posix_api:
+    extra_configs:
+      - CONFIG_POSIX_API=n
   portability.posix.headers.picolibc.with_posix_api:
     tags: picolibc
     filter: CONFIG_PICOLIBC_SUPPORTED
     extra_configs:
       - CONFIG_POSIX_API=y
       - CONFIG_PICOLIBC=y
-    integration_platforms:
-      - qemu_x86
   portability.posix.headers.picolibc.without_posix_api:
     tags: picolibc
     filter: CONFIG_PICOLIBC_SUPPORTED
     extra_configs:
       - CONFIG_POSIX_API=n
       - CONFIG_PICOLIBC=y
-    integration_platforms:
-      - qemu_x86
   portability.posix.headers.newlib.with_posix_api:
     tags: newlib
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_POSIX_API=y
       - CONFIG_NEWLIB_LIBC=y
-    integration_platforms:
-      - qemu_x86
   portability.posix.headers.newlib.without_posix_api:
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_POSIX_API=n
       - CONFIG_NEWLIB_LIBC=y
-    integration_platforms:
-      - qemu_x86
   portability.posix.headers.arcmwdtlib.with_posix_api:
     toolchain_allow: arcmwdt
     extra_configs:

--- a/tests/posix/net/testcase.yaml
+++ b/tests/posix/net/testcase.yaml
@@ -5,18 +5,35 @@ common:
     - iface
     - net
     - posix
+  # 1 tier0 platform per supported architecture (dependent on netif support)
+  integration_platforms:
+    - mps2/an385
+    - qemu_x86
+  # native_posix and native_sim link to if_*() from the host libc which causes the test to crash
+  # immediately.
+  filter: not CONFIG_NATIVE_LIBC
 tests:
   portability.posix.net:
-    # native_sim links to if_*() from the host libc which causes the test to crash immediately.
-    filter: not CONFIG_NATIVE_LIBC
-  portability.posix.net.cpp.native_sim:
-    # demonstrate that #75319 fixes the build error in #75849
-    tags:
-      - cpp
-    build_only: true
-    platform_allow:
-      - native_sim
     extra_configs:
-      - CONFIG_CPP=y
-      - CONFIG_STD_CPP20=y
-      - CONFIG_REQUIRES_FULL_LIBCPP=y
+      - CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=256
+  portability.posix.net.armclang_std_libc:
+    toolchain_allow: armclang
+    extra_configs:
+      - CONFIG_ARMCLANG_STD_LIBC=y
+  portability.posix.net.arcmwdtlib:
+    toolchain_allow: arcmwdt
+    extra_configs:
+      - CONFIG_ARCMWDT_LIBC=y
+  portability.posix.net.minimal:
+    extra_configs:
+      - CONFIG_MINIMAL_LIBC=y
+      - CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=256
+  portability.posix.net.newlib:
+    filter: TOOLCHAIN_HAS_NEWLIB == 1
+    extra_configs:
+      - CONFIG_NEWLIB_LIBC=y
+  portability.posix.net.picolibc:
+    tags: picolibc
+    filter: CONFIG_PICOLIBC_SUPPORTED
+    extra_configs:
+      - CONFIG_PICOLIBC=y

--- a/tests/posix/pthread_pressure/testcase.yaml
+++ b/tests/posix/pthread_pressure/testcase.yaml
@@ -4,7 +4,10 @@ common:
   arch_exclude:
     - posix
   integration_platforms:
+    - qemu_cortex_a53/qemu_cortex_a53/smp
     - qemu_riscv64/qemu_virt_riscv64/smp
+    - qemu_riscv32/qemu_virt_riscv32/smp
+    - qemu_x86_64
 tests:
   portability.posix.pthread_pressure:
     extra_configs:

--- a/tests/posix/shm/testcase.yaml
+++ b/tests/posix/shm/testcase.yaml
@@ -3,11 +3,10 @@ common:
   tags:
     - posix
     - shm
-  integration_platforms:
-    - qemu_x86
-    - qemu_x86_64
-    - qemu_cortex_a53
-    - qemu_riscv64
+  # 1 tier0 platform per supported architecture
+  platform_key:
+    - arch
+    - simulation
   platform_exclude:
     # linker_zephyr_pre0.cmd:140: syntax error (??)
     - qemu_xtensa


### PR DESCRIPTION
The intent of this change is to mitigate the possibility of regressions in POSIX and related areas due to lack of test coverage between multiple architectures and multiple C libraries. There is unfortunately a compromise to make between fast CI and sufficient test coverage.

If it makes sense to reduce the scope in certain areas, please feel free to make suggestions.

Add one tier0 integration platform per supported architecture, and increase libc coverage.

> [!NOTE]  
> Depending on other suite constraints, only certain tier0 platforms may be used for certain suites (e.g. `netif` dependency)