### PR TITLE
input: add a user_data pointer to the callback, add a custom name callback

### DIFF
--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -54,6 +54,14 @@ GNSS
 Input
 =====
 
+* :c:macro:`INPUT_CALLBACK_DEFINE` has now an extra ``user_data`` void pointer
+  argument that can be used to reference any user data structure. To restore
+  the current behavior it can be set to ``NULL``. A ``void *user_data``
+  argument has to be added to the callback function arguments.
+
+* The :dtcompatible:`analog-axis` ``invert`` property has been renamed to
+  ``invert-input`` (there's now an ``invert-output`` available as well).
+
 Interrupt Controller
 ====================
 

--- a/drivers/kscan/kscan_input.c
+++ b/drivers/kscan/kscan_input.c
@@ -23,8 +23,9 @@ struct kscan_input_data {
 	bool pressed;
 };
 
-static void kscan_input_cb(const struct device *dev, struct input_event *evt)
+static void kscan_input_cb(struct input_event *evt, void *user_data)
 {
+	const struct device *dev = user_data;
 	struct kscan_input_data *data = dev->data;
 
 	switch (evt->code) {
@@ -100,13 +101,9 @@ static const struct kscan_driver_api kscan_input_driver_api = {
 };
 
 #define KSCAN_INPUT_INIT(index) \
-	static void kscan_input_cb_##index(struct input_event *evt)            \
-	{                                                                      \
-		kscan_input_cb(DEVICE_DT_GET(DT_INST(index, DT_DRV_COMPAT)),   \
-			       evt);                                           \
-	}                                                                      \
 	INPUT_CALLBACK_DEFINE(DEVICE_DT_GET(DT_INST_PARENT(index)),            \
-			      kscan_input_cb_##index);                         \
+			      kscan_input_cb,                                  \
+			      (void *)DEVICE_DT_INST_GET(index));              \
 	static const struct kscan_input_config kscan_input_config_##index = {  \
 		.input_dev = DEVICE_DT_GET(DT_INST_PARENT(index)),             \
 	};                                                                     \

--- a/include/zephyr/input/input.h
+++ b/include/zephyr/input/input.h
@@ -124,7 +124,9 @@ struct input_callback {
 	/** @ref device pointer or NULL. */
 	const struct device *dev;
 	/** The callback function. */
-	void (*callback)(struct input_event *evt);
+	void (*callback)(struct input_event *evt, void *user_data);
+	/** User data pointer. */
+	void *user_data;
 };
 
 /**
@@ -136,12 +138,14 @@ struct input_callback {
  *
  * @param _dev @ref device pointer or NULL.
  * @param _callback The callback function.
+ * @param _user_data Pointer to user specified data.
  */
-#define INPUT_CALLBACK_DEFINE(_dev, _callback)                                 \
+#define INPUT_CALLBACK_DEFINE(_dev, _callback, _user_data)                     \
 	static const STRUCT_SECTION_ITERABLE(input_callback,                   \
 					     _input_callback__##_callback) = { \
 		.dev = _dev,                                                   \
 		.callback = _callback,                                         \
+		.user_data = _user_data,                                       \
 	}
 
 #ifdef __cplusplus

--- a/include/zephyr/input/input.h
+++ b/include/zephyr/input/input.h
@@ -130,6 +130,20 @@ struct input_callback {
 };
 
 /**
+ * @brief Register a callback structure for input events with a custom name.
+ *
+ * Same as @ref INPUT_CALLBACK_DEFINE but allows specifying a custom name
+ * for the callback structure. Useful if multiple callbacks are used for the
+ * same callback function.
+ */
+#define INPUT_CALLBACK_DEFINE_NAMED(_dev, _callback, _user_data, name)         \
+	static const STRUCT_SECTION_ITERABLE(input_callback, name) = {         \
+		.dev = _dev,                                                   \
+		.callback = _callback,                                         \
+		.user_data = _user_data,                                       \
+	}
+
+/**
  * @brief Register a callback structure for input events.
  *
  * The @p _dev field can be used to only invoke callback for events generated
@@ -141,12 +155,8 @@ struct input_callback {
  * @param _user_data Pointer to user specified data.
  */
 #define INPUT_CALLBACK_DEFINE(_dev, _callback, _user_data)                     \
-	static const STRUCT_SECTION_ITERABLE(input_callback,                   \
-					     _input_callback__##_callback) = { \
-		.dev = _dev,                                                   \
-		.callback = _callback,                                         \
-		.user_data = _user_data,                                       \
-	}
+	INPUT_CALLBACK_DEFINE_NAMED(_dev, _callback, _user_data,               \
+				    _input_callback__##_callback)
 
 #ifdef __cplusplus
 }

--- a/modules/lvgl/include/lvgl_common_input.h
+++ b/modules/lvgl/include/lvgl_common_input.h
@@ -36,11 +36,8 @@ int lvgl_init_input_devices(void);
 #define LVGL_KEY_VALID(key)     IN_RANGE(key, 0, UINT8_MAX)
 
 #define LVGL_INPUT_DEFINE(inst, type, msgq_size, process_evt_cb)                                   \
-	static void lvgl_input_cb_##_##inst(struct input_event *evt)                               \
-	{                                                                                          \
-		process_evt_cb(DEVICE_DT_INST_GET(inst), evt);                                     \
-	}                                                                                          \
-	INPUT_CALLBACK_DEFINE(LVGL_INPUT_DEVICE(inst), lvgl_input_cb_##_##inst);                   \
+	INPUT_CALLBACK_DEFINE(LVGL_INPUT_DEVICE(inst), process_evt_cb,                             \
+			      (void *)DEVICE_DT_INST_GET(inst));                                   \
 	K_MSGQ_DEFINE(lvgl_input_msgq_##type##_##inst, sizeof(lv_indev_data_t), msgq_size, 4)
 
 #ifdef __cplusplus

--- a/modules/lvgl/input/lvgl_button_input.c
+++ b/modules/lvgl/input/lvgl_button_input.c
@@ -20,8 +20,9 @@ struct lvgl_button_input_config {
 	const lv_coord_t *coordinates;
 };
 
-static void lvgl_button_process_event(const struct device *dev, struct input_event *evt)
+static void lvgl_button_process_event(struct input_event *evt, void *user_data)
 {
+	const struct device *dev = user_data;
 	struct lvgl_common_input_data *data = dev->data;
 	const struct lvgl_button_input_config *cfg = dev->config;
 	uint8_t i;

--- a/modules/lvgl/input/lvgl_encoder_input.c
+++ b/modules/lvgl/input/lvgl_encoder_input.c
@@ -19,8 +19,9 @@ struct lvgl_encoder_input_config {
 	int button_input_code;
 };
 
-static void lvgl_encoder_process_event(const struct device *dev, struct input_event *evt)
+static void lvgl_encoder_process_event(struct input_event *evt, void *user_data)
 {
+	const struct device *dev = user_data;
 	struct lvgl_common_input_data *data = dev->data;
 	const struct lvgl_encoder_input_config *cfg = dev->config;
 

--- a/modules/lvgl/input/lvgl_keypad_input.c
+++ b/modules/lvgl/input/lvgl_keypad_input.c
@@ -21,8 +21,9 @@ struct lvgl_keypad_input_config {
 	uint8_t num_codes;
 };
 
-static void lvgl_keypad_process_event(const struct device *dev, struct input_event *evt)
+static void lvgl_keypad_process_event(struct input_event *evt, void *user_data)
 {
+	const struct device *dev = user_data;
 	struct lvgl_common_input_data *data = dev->data;
 	const struct lvgl_keypad_input_config *cfg = dev->config;
 	uint8_t i;

--- a/modules/lvgl/input/lvgl_pointer_input.c
+++ b/modules/lvgl/input/lvgl_pointer_input.c
@@ -27,8 +27,9 @@ struct lvgl_pointer_input_data {
 	uint32_t point_y;
 };
 
-static void lvgl_pointer_process_event(const struct device *dev, struct input_event *evt)
+static void lvgl_pointer_process_event(struct input_event *evt, void *user_data)
 {
+	const struct device *dev = user_data;
 	const struct lvgl_pointer_input_config *cfg = dev->config;
 	struct lvgl_pointer_input_data *data = dev->data;
 	lv_disp_t *disp = lv_disp_get_default();

--- a/samples/subsys/usb/hid-keyboard/src/main.c
+++ b/samples/subsys/usb/hid-keyboard/src/main.c
@@ -55,9 +55,11 @@ static uint8_t __aligned(sizeof(void *)) report[KB_REPORT_COUNT];
 static uint32_t kb_duration;
 static bool kb_ready;
 
-static void input_cb(struct input_event *evt)
+static void input_cb(struct input_event *evt, void *user_data)
 {
 	struct kb_event kb_evt;
+
+	ARG_UNUSED(user_data);
 
 	kb_evt.code = evt->code;
 	kb_evt.value = evt->value;
@@ -66,7 +68,7 @@ static void input_cb(struct input_event *evt)
 	}
 }
 
-INPUT_CALLBACK_DEFINE(NULL, input_cb);
+INPUT_CALLBACK_DEFINE(NULL, input_cb, NULL);
 
 static void kb_iface_ready(const struct device *dev, const bool ready)
 {

--- a/samples/subsys/usb/hid-mouse/src/main.c
+++ b/samples/subsys/usb/hid-mouse/src/main.c
@@ -55,9 +55,11 @@ static ALWAYS_INLINE void rwup_if_suspended(void)
 	}
 }
 
-static void input_cb(struct input_event *evt)
+static void input_cb(struct input_event *evt, void *user_data)
 {
 	static uint8_t tmp[MOUSE_REPORT_COUNT];
+
+	ARG_UNUSED(user_data);
 
 	switch (evt->code) {
 	case INPUT_KEY_0:
@@ -95,7 +97,7 @@ static void input_cb(struct input_event *evt)
 
 }
 
-INPUT_CALLBACK_DEFINE(NULL, input_cb);
+INPUT_CALLBACK_DEFINE(NULL, input_cb, NULL);
 
 #if defined(CONFIG_USB_DEVICE_STACK_NEXT)
 static int enable_usb_device_next(void)

--- a/subsys/input/input.c
+++ b/subsys/input/input.c
@@ -22,7 +22,7 @@ static void input_process(struct input_event *evt)
 {
 	STRUCT_SECTION_FOREACH(input_callback, callback) {
 		if (callback->dev == NULL || callback->dev == evt->dev) {
-			callback->callback(evt);
+			callback->callback(evt, callback->user_data);
 		}
 	}
 }

--- a/subsys/input/input_keymap.c
+++ b/subsys/input/input_keymap.c
@@ -29,8 +29,9 @@ struct keymap_data {
 	bool pressed;
 };
 
-static void keymap_cb(const struct device *dev, struct input_event *evt)
+static void keymap_cb(struct input_event *evt, void *user_data)
 {
+	const struct device *dev = user_data;
 	const struct keymap_config *cfg = dev->config;
 	struct keymap_data *data = dev->data;
 	const uint16_t *codes = cfg->codes;
@@ -98,11 +99,8 @@ static int keymap_init(const struct device *dev)
 		KEYMAP_ENTRY_CODE(DT_PROP_BY_IDX(node_id, prop, idx)),
 
 #define INPUT_KEYMAP_DEFINE(inst)								\
-	static void keymap_cb_##inst(struct input_event *evt)					\
-	{											\
-		keymap_cb(DEVICE_DT_INST_GET(inst), evt);					\
-	}											\
-	INPUT_CALLBACK_DEFINE(DEVICE_DT_GET(DT_INST_PARENT(inst)), keymap_cb_##inst);		\
+	INPUT_CALLBACK_DEFINE(DEVICE_DT_GET(DT_INST_PARENT(inst)), keymap_cb,			\
+			      (void *)DEVICE_DT_INST_GET(inst));				\
 												\
 	DT_INST_FOREACH_PROP_ELEM(inst, keymap, KEYMAP_ENTRY_VALIDATE)				\
 												\

--- a/subsys/input/input_keymap.c
+++ b/subsys/input/input_keymap.c
@@ -99,8 +99,8 @@ static int keymap_init(const struct device *dev)
 		KEYMAP_ENTRY_CODE(DT_PROP_BY_IDX(node_id, prop, idx)),
 
 #define INPUT_KEYMAP_DEFINE(inst)								\
-	INPUT_CALLBACK_DEFINE(DEVICE_DT_GET(DT_INST_PARENT(inst)), keymap_cb,			\
-			      (void *)DEVICE_DT_INST_GET(inst));				\
+	INPUT_CALLBACK_DEFINE_NAMED(DEVICE_DT_GET(DT_INST_PARENT(inst)), keymap_cb,		\
+				    (void *)DEVICE_DT_INST_GET(inst), keymap_cb_##inst);	\
 												\
 	DT_INST_FOREACH_PROP_ELEM(inst, keymap, KEYMAP_ENTRY_VALIDATE)				\
 												\

--- a/subsys/input/input_longpress.c
+++ b/subsys/input/input_longpress.c
@@ -46,8 +46,9 @@ static void longpress_deferred(struct k_work *work)
 	entry->long_fired = true;
 }
 
-static void longpress_cb(const struct device *dev, struct input_event *evt)
+static void longpress_cb(struct input_event *evt, void *user_data)
 {
+	const struct device *dev = user_data;
 	const struct longpress_config *cfg = dev->config;
 	struct longpress_data_entry *entry;
 	int i;
@@ -105,15 +106,11 @@ static int longpress_init(const struct device *dev)
 #define INPUT_LONGPRESS_DEFINE(inst)                                                               \
 	BUILD_ASSERT((DT_INST_PROP_LEN(inst, input_codes) ==                                       \
 		      DT_INST_PROP_LEN_OR(inst, short_codes, 0)) ||                                \
-		     !DT_INST_NODE_HAS_PROP(inst, short_codes));                                   \
+		      !DT_INST_NODE_HAS_PROP(inst, short_codes));                                  \
 	BUILD_ASSERT(DT_INST_PROP_LEN(inst, input_codes) == DT_INST_PROP_LEN(inst, long_codes));   \
 	                                                                                           \
-	static void longpress_cb_##inst(struct input_event *evt)                                   \
-	{                                                                                          \
-		longpress_cb(DEVICE_DT_INST_GET(inst), evt);                                       \
-	}                                                                                          \
 	INPUT_CALLBACK_DEFINE(DEVICE_DT_GET_OR_NULL(DT_INST_PHANDLE(inst, input)),                 \
-			      longpress_cb_##inst);                                                \
+			      longpress_cb, (void *)DEVICE_DT_INST_GET(inst));                     \
 	                                                                                           \
 	static const uint16_t longpress_input_codes_##inst[] = DT_INST_PROP(inst, input_codes);    \
 	                                                                                           \

--- a/subsys/input/input_longpress.c
+++ b/subsys/input/input_longpress.c
@@ -109,8 +109,9 @@ static int longpress_init(const struct device *dev)
 		      !DT_INST_NODE_HAS_PROP(inst, short_codes));                                  \
 	BUILD_ASSERT(DT_INST_PROP_LEN(inst, input_codes) == DT_INST_PROP_LEN(inst, long_codes));   \
 	                                                                                           \
-	INPUT_CALLBACK_DEFINE(DEVICE_DT_GET_OR_NULL(DT_INST_PHANDLE(inst, input)),                 \
-			      longpress_cb, (void *)DEVICE_DT_INST_GET(inst));                     \
+	INPUT_CALLBACK_DEFINE_NAMED(DEVICE_DT_GET_OR_NULL(DT_INST_PHANDLE(inst, input)),           \
+				    longpress_cb, (void *)DEVICE_DT_INST_GET(inst),                \
+				    longpress_cb_##inst);                                          \
 	                                                                                           \
 	static const uint16_t longpress_input_codes_##inst[] = DT_INST_PROP(inst, input_codes);    \
 	                                                                                           \

--- a/subsys/input/input_utils.c
+++ b/subsys/input/input_utils.c
@@ -51,8 +51,10 @@ static bool input_dump_enabled(void)
 }
 #endif /* CONFIG_INPUT_SHELL */
 
-static void input_dump_cb(struct input_event *evt)
+static void input_dump_cb(struct input_event *evt, void *user_data)
 {
+	ARG_UNUSED(user_data);
+
 	if (!input_dump_enabled()) {
 		return;
 	}
@@ -64,7 +66,7 @@ static void input_dump_cb(struct input_event *evt)
 		evt->code,
 		evt->value);
 }
-INPUT_CALLBACK_DEFINE(NULL, input_dump_cb);
+INPUT_CALLBACK_DEFINE(NULL, input_dump_cb, NULL);
 #endif /* CONFIG_INPUT_EVENT_DUMP */
 
 #ifdef CONFIG_INPUT_SHELL
@@ -162,11 +164,13 @@ static void kbd_matrix_state_log_entry(char *header, kbd_row_t *data)
 		kbd_matrix_state_dev->name, header, kbd_matrix_buf, count);
 }
 
-static void kbd_matrix_state_log(struct input_event *evt)
+static void kbd_matrix_state_log(struct input_event *evt, void *user_data)
 {
 	const struct input_kbd_matrix_common_config *cfg;
 	static uint32_t row, col;
 	static bool val;
+
+	ARG_UNUSED(user_data);
 
 	if (kbd_matrix_state_dev == NULL || kbd_matrix_state_dev != evt->dev) {
 		return;
@@ -212,7 +216,7 @@ static void kbd_matrix_state_log(struct input_event *evt)
 
 	kbd_matrix_state_log_entry("state", kbd_matrix_state);
 }
-INPUT_CALLBACK_DEFINE(NULL, kbd_matrix_state_log);
+INPUT_CALLBACK_DEFINE(NULL, kbd_matrix_state_log, NULL);
 
 static int input_cmd_kbd_matrix_state_dump(const struct shell *sh,
 					   size_t argc, char *argv[])

--- a/tests/drivers/input/gpio_kbd_matrix/src/main.c
+++ b/tests/drivers/input/gpio_kbd_matrix/src/main.c
@@ -195,7 +195,7 @@ static int last_checked_event_count;
 	zassert_equal(_val, test_event_data.val); \
 }
 
-static void test_cb(struct input_event *evt)
+static void test_cb(struct input_event *evt, void *user_data)
 {
 	static int row, col, val;
 
@@ -220,7 +220,7 @@ static void test_cb(struct input_event *evt)
 			 test_event_data.event_count, row, col, val);
 	}
 }
-INPUT_CALLBACK_DEFINE(NULL, test_cb);
+INPUT_CALLBACK_DEFINE(NULL, test_cb, NULL);
 
 /* actual tests */
 

--- a/tests/drivers/input/gpio_keys/src/main.c
+++ b/tests/drivers/input/gpio_keys/src/main.c
@@ -35,7 +35,7 @@ ZTEST_SUITE(gpio_keys, NULL, NULL, NULL, NULL, NULL);
 static int event_count;
 static uint16_t last_code;
 static bool last_val;
-static void test_gpio_keys_cb_handler(struct input_event *evt)
+static void test_gpio_keys_cb_handler(struct input_event *evt, void *user_data)
 {
 	TC_PRINT("GPIO_KEY %s pressed, zephyr_code=%u, value=%d\n",
 		 evt->dev->name, evt->code, evt->value);
@@ -43,7 +43,7 @@ static void test_gpio_keys_cb_handler(struct input_event *evt)
 	last_code = evt->code;
 	last_val = evt->value;
 }
-INPUT_CALLBACK_DEFINE(test_gpio_keys_dev, test_gpio_keys_cb_handler);
+INPUT_CALLBACK_DEFINE(test_gpio_keys_dev, test_gpio_keys_cb_handler, NULL);
 
 /**
  * @brief TestPurpose: Verify gpio_keys_config pressed raw.

--- a/tests/drivers/input/kbd_matrix/src/main.c
+++ b/tests/drivers/input/kbd_matrix/src/main.c
@@ -103,7 +103,7 @@ static int last_checked_event_count;
 	zassert_equal(_val, test_event_data.val); \
 }
 
-static void test_cb(struct input_event *evt)
+static void test_cb(struct input_event *evt, void *user_data)
 {
 	static int row, col, val;
 
@@ -128,7 +128,7 @@ static void test_cb(struct input_event *evt)
 			 test_event_data.event_count, row, col, val);
 	}
 }
-INPUT_CALLBACK_DEFINE(test_dev, test_cb);
+INPUT_CALLBACK_DEFINE(test_dev, test_cb, NULL);
 
 #define WAIT_FOR_IDLE_TIMEOUT_US (5 * USEC_PER_SEC)
 

--- a/tests/subsys/input/api/src/main.c
+++ b/tests/subsys/input/api/src/main.c
@@ -17,7 +17,7 @@ static int message_count_unfiltered;
 static K_SEM_DEFINE(cb_start, 1, 1);
 static K_SEM_DEFINE(cb_done, 1, 1);
 
-static void input_cb_filtered(struct input_event *evt)
+static void input_cb_filtered(struct input_event *evt, void *user_data)
 {
 	TC_PRINT("%s: %d\n", __func__, message_count_filtered);
 
@@ -29,9 +29,9 @@ static void input_cb_filtered(struct input_event *evt)
 
 	k_sem_give(&cb_start);
 }
-INPUT_CALLBACK_DEFINE(&fake_dev, input_cb_filtered);
+INPUT_CALLBACK_DEFINE(&fake_dev, input_cb_filtered, NULL);
 
-static void input_cb_unfiltered(struct input_event *evt)
+static void input_cb_unfiltered(struct input_event *evt, void *user_data)
 {
 	TC_PRINT("%s: %d\n", __func__, message_count_unfiltered);
 
@@ -42,7 +42,7 @@ static void input_cb_unfiltered(struct input_event *evt)
 		k_sem_give(&cb_done);
 	}
 }
-INPUT_CALLBACK_DEFINE(NULL, input_cb_unfiltered);
+INPUT_CALLBACK_DEFINE(NULL, input_cb_unfiltered, NULL);
 
 ZTEST(input_api, test_sequence_thread)
 {
@@ -85,19 +85,19 @@ ZTEST(input_api, test_sequence_thread)
 
 #else /* CONFIG_INPUT_MODE_THREAD */
 
-static void input_cb_filtered(struct input_event *evt)
+static void input_cb_filtered(struct input_event *evt, void *user_data)
 {
 	if (evt->dev == &fake_dev) {
 		message_count_filtered++;
 	}
 }
-INPUT_CALLBACK_DEFINE(&fake_dev, input_cb_filtered);
+INPUT_CALLBACK_DEFINE(&fake_dev, input_cb_filtered, NULL);
 
-static void input_cb_unfiltered(struct input_event *evt)
+static void input_cb_unfiltered(struct input_event *evt, void *user_data)
 {
 	message_count_unfiltered++;
 }
-INPUT_CALLBACK_DEFINE(NULL, input_cb_unfiltered);
+INPUT_CALLBACK_DEFINE(NULL, input_cb_unfiltered, NULL);
 
 ZTEST(input_api, test_synchronous)
 {
@@ -118,11 +118,11 @@ ZTEST(input_api, test_synchronous)
 
 static struct input_event last_event;
 
-static void input_cb_last_event(struct input_event *evt)
+static void input_cb_last_event(struct input_event *evt, void *user_data)
 {
 	memcpy(&last_event, evt, sizeof(last_event));
 }
-INPUT_CALLBACK_DEFINE(NULL, input_cb_last_event);
+INPUT_CALLBACK_DEFINE(NULL, input_cb_last_event, NULL);
 
 ZTEST(input_api, test_report_apis)
 {

--- a/tests/subsys/input/api/src/main.c
+++ b/tests/subsys/input/api/src/main.c
@@ -42,7 +42,8 @@ static void input_cb_unfiltered(struct input_event *evt, void *user_data)
 		k_sem_give(&cb_done);
 	}
 }
-INPUT_CALLBACK_DEFINE(NULL, input_cb_unfiltered, NULL);
+INPUT_CALLBACK_DEFINE_NAMED(NULL, input_cb_unfiltered, NULL,
+			    input_cb_unfiltered_custom_name);
 
 ZTEST(input_api, test_sequence_thread)
 {

--- a/tests/subsys/input/longpress/src/main.c
+++ b/tests/subsys/input/longpress/src/main.c
@@ -22,7 +22,7 @@ DEVICE_DT_DEFINE(DT_INST(0, vnd_input_device), NULL, NULL, NULL, NULL,
 static int event_count;
 static struct input_event last_events[2];
 
-static void test_cb(struct input_event *evt)
+static void test_cb(struct input_event *evt, void *user_data)
 {
 	TC_PRINT("%s: %d %x %d\n", __func__, event_count, evt->code, evt->value);
 
@@ -30,11 +30,11 @@ static void test_cb(struct input_event *evt)
 	memcpy(&last_events[1], &last_events[0], sizeof(struct input_event));
 	memcpy(&last_events[0], evt, sizeof(struct input_event));
 }
-INPUT_CALLBACK_DEFINE(longpress_dev, test_cb);
+INPUT_CALLBACK_DEFINE(longpress_dev, test_cb, NULL);
 
 static int event_count_no_short;
 static struct input_event last_events_no_short[2];
-static void test_cb_no_short(struct input_event *evt)
+static void test_cb_no_short(struct input_event *evt, void *user_data)
 {
 	TC_PRINT("%s: %d %x %d\n", __func__, event_count_no_short, evt->code, evt->value);
 
@@ -42,7 +42,7 @@ static void test_cb_no_short(struct input_event *evt)
 	memcpy(&last_events_no_short[1], &last_events_no_short[0], sizeof(struct input_event));
 	memcpy(&last_events_no_short[0], evt, sizeof(struct input_event));
 }
-INPUT_CALLBACK_DEFINE(longpress_no_short_dev, test_cb_no_short);
+INPUT_CALLBACK_DEFINE(longpress_no_short_dev, test_cb_no_short, NULL);
 
 ZTEST(longpress, test_longpress_test)
 {


### PR DESCRIPTION
Add a user_data pointer to the callback structure and add a NAMED variant of the macro for multiple instance drivers.

This needs an update in the migration file as well, which is not there yet, will do it separately, I have something else to add there already anyway.