### PR TITLE
Fix Odroid Go boot error

### DIFF
--- a/boards/hardkernel/odroid_go/Kconfig.defconfig
+++ b/boards/hardkernel/odroid_go/Kconfig.defconfig
@@ -15,7 +15,7 @@ config ESP_SPIRAM
 	default y if !MCUBOOT
 
 choice SPIRAM_TYPE
-	default SPIRAM_TYPE_ESPPSRAM64
+	default SPIRAM_TYPE_ESPPSRAM32
 endchoice
 
 config HEAP_MEM_POOL_ADD_SIZE_BOARD


### PR DESCRIPTION
Hi,

Odroid Go is not booting in 3.7.0. The issue lies in a misconfiguration that was probably accidentally introduced in the conversion to hardware model v2, in https://github.com/zephyrproject-rtos/zephyr/commit/c1067c16d2. (Unsure as there is no info in the commit body on this change.) ~The second two commits are more cosmetic, as the SiP is shown as `SOC_PART_NUMBER = "ESP32_WROVER_E_N16R2"` in menuconfig, though it should be `SOC_PART_NUMBER = "ESP32_WROVER_E_N16R4"`.~ (Edit: moved into #76506)

Best,
Gero

Fixes: #76447