### PR TITLE
drivers: video: introduce CONFIG_VIDEO_LOG_LEVEL

### DIFF
--- a/drivers/video/Kconfig
+++ b/drivers/video/Kconfig
@@ -13,6 +13,10 @@ menuconfig VIDEO
 
 if VIDEO
 
+module = VIDEO
+module-str = video
+source "subsys/logging/Kconfig.template.log_config"
+
 config VIDEO_INIT_PRIORITY
 	int "Video initialization priority"
 	default 60

--- a/drivers/video/Kconfig.stm32_dcmi
+++ b/drivers/video/Kconfig.stm32_dcmi
@@ -16,7 +16,3 @@ config VIDEO_STM32_DCMI
 	select USE_STM32_HAL_DMA_EX if $(DT_STM32_DCMI_HAS_DMA)
 	help
 	  Enable driver for STM32 Digital camera interface periheral.
-
-module = STM32_DCMI
-module-str = stm32_dcmi
-source "subsys/logging/Kconfig.template.log_config"

--- a/drivers/video/mt9m114.c
+++ b/drivers/video/mt9m114.c
@@ -6,17 +6,15 @@
  */
 
 #define DT_DRV_COMPAT aptina_mt9m114
+
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
-
+#include <zephyr/logging/log.h>
 #include <zephyr/sys/byteorder.h>
-
 #include <zephyr/drivers/video.h>
 #include <zephyr/drivers/i2c.h>
 
-#define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
-#include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(mt9m114);
+LOG_MODULE_REGISTER(video_mt9m114, CONFIG_VIDEO_LOG_LEVEL);
 
 #define MT9M114_CHIP_ID_VAL 0x2481
 

--- a/drivers/video/ov2640.c
+++ b/drivers/video/ov2640.c
@@ -5,16 +5,15 @@
  */
 
 #define DT_DRV_COMPAT ovti_ov2640
+
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
-
+#include <zephyr/logging/log.h>
 #include <zephyr/drivers/video.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/gpio.h>
 
-#define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
-#include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(ov2640);
+LOG_MODULE_REGISTER(video_ov2640, CONFIG_VIDEO_LOG_LEVEL);
 
 /* DSP register bank FF=0x00*/
 #define QS                  0x44

--- a/drivers/video/ov5640.c
+++ b/drivers/video/ov5640.c
@@ -6,17 +6,15 @@
 
 #define DT_DRV_COMPAT ovti_ov5640
 
+#include <zephyr/kernel.h>
 #include <zephyr/device.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/byteorder.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/video.h>
-#include <zephyr/kernel.h>
 
-#define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
-#include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(ov5640);
-
-#include <zephyr/sys/byteorder.h>
+LOG_MODULE_REGISTER(video_ov5640, CONFIG_VIDEO_LOG_LEVEL);
 
 #define CHIP_ID_REG 0x300a
 #define CHIP_ID_VAL 0x5640

--- a/drivers/video/ov7670.c
+++ b/drivers/video/ov7670.c
@@ -9,10 +9,9 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/video.h>
-
-#define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(ov7670);
+
+LOG_MODULE_REGISTER(video_ov7670, CONFIG_VIDEO_LOG_LEVEL);
 
 /* Initialization register structure */
 struct ov7670_reg {

--- a/drivers/video/ov7725.c
+++ b/drivers/video/ov7725.c
@@ -5,18 +5,16 @@
  */
 
 #define DT_DRV_COMPAT ovti_ov7725
+
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
-
 #include <zephyr/sys/byteorder.h>
-
+#include <zephyr/logging/log.h>
 #include <zephyr/drivers/video.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/gpio.h>
 
-#define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
-#include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(ov7725);
+LOG_MODULE_REGISTER(video_ov7725, CONFIG_VIDEO_LOG_LEVEL);
 
 #define OV7725_REVISION  0x7721U
 

--- a/drivers/video/video_common.c
+++ b/drivers/video/video_common.c
@@ -3,8 +3,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <zephyr/kernel.h>
 
+#include <zephyr/kernel.h>
 #include <zephyr/drivers/video.h>
 
 K_HEAP_DEFINE(video_buffer_pool,

--- a/drivers/video/video_mcux_csi.c
+++ b/drivers/video/video_mcux_csi.c
@@ -7,16 +7,15 @@
 #define DT_DRV_COMPAT nxp_imx_csi
 
 #include <zephyr/kernel.h>
+#include <zephyr/irq.h>
+#include <zephyr/drivers/video.h>
+#include <zephyr/drivers/pinctrl.h>
 
 #include <fsl_csi.h>
 
 #ifdef CONFIG_HAS_MCUX_CACHE
 #include <fsl_cache.h>
 #endif
-
-#include <zephyr/drivers/video.h>
-#include <zephyr/drivers/pinctrl.h>
-#include <zephyr/irq.h>
 
 struct video_mcux_csi_config {
 	CSI_Type *base;

--- a/drivers/video/video_mcux_mipi_csi2rx.c
+++ b/drivers/video/video_mcux_mipi_csi2rx.c
@@ -6,14 +6,13 @@
 
 #define DT_DRV_COMPAT nxp_mipi_csi2rx
 
-#include <fsl_mipi_csi2rx.h>
-
 #include <zephyr/drivers/video.h>
 #include <zephyr/kernel.h>
-
-#define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(mipi_csi);
+
+#include <fsl_mipi_csi2rx.h>
+
+LOG_MODULE_REGISTER(video_mipi_csi2rx, CONFIG_VIDEO_LOG_LEVEL);
 
 /*
  * Two data lanes are set by default as 2-lanes camera sensors are

--- a/drivers/video/video_stm32_dcmi.c
+++ b/drivers/video/video_stm32_dcmi.c
@@ -7,10 +7,12 @@
 #define DT_DRV_COMPAT st_stm32_dcmi
 
 #include <errno.h>
+
 #include <zephyr/kernel.h>
+#include <zephyr/irq.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/drivers/video.h>
 #include <zephyr/drivers/pinctrl.h>
-#include <zephyr/irq.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/dma.h>
@@ -18,8 +20,7 @@
 
 #include <stm32_ll_dma.h>
 
-#include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(video_stm32_dcmi, CONFIG_STM32_DCMI_LOG_LEVEL);
+LOG_MODULE_REGISTER(video_stm32_dcmi, CONFIG_VIDEO_LOG_LEVEL);
 
 K_HEAP_DEFINE(video_stm32_buffer_pool, CONFIG_VIDEO_BUFFER_POOL_SZ_MAX);
 

--- a/drivers/video/video_sw_generator.c
+++ b/drivers/video/video_sw_generator.c
@@ -3,13 +3,14 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#define DT_DRV_COMPAT zephyr_sw_generator
+
 #include <zephyr/kernel.h>
-
 #include <zephyr/drivers/video.h>
-
-#define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(video_sw_generator);
+
+LOG_MODULE_REGISTER(video_sw_generator, CONFIG_VIDEO_LOG_LEVEL);
 
 #define VIDEO_PATTERN_COLOR_BAR 0
 #define VIDEO_PATTERN_FPS       30


### PR DESCRIPTION
Zephyr drivers have typically one log level defined per class. The video drivers were making exception. This adds the missing log level for video drivers.

Since all headers had to be modified, this also:

- Update the log initialization to the new syntax  defined in commit 5e346812aca93570c544042c99122a059b35e48b

- Sort the `#include` list to something like #41543