### PR TITLE
net: wifi: Current max rate and over run statistics

### DIFF
--- a/include/zephyr/net/net_stats.h
+++ b/include/zephyr/net/net_stats.h
@@ -623,6 +623,9 @@ struct net_stats_wifi {
 
 	/** Total number of unicast packets received and sent */
 	struct net_stats_pkts unicast;
+
+	/** Total number of dropped packets at received and sent*/
+	net_stats_t overrun_count;
 };
 
 #if defined(CONFIG_NET_STATISTICS_USER_API)

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -522,6 +522,8 @@ struct wifi_iface_status {
 	unsigned short beacon_interval;
 	/** is TWT capable? */
 	bool twt_capable;
+	/** The current 802.11 PHY data rate */
+	int current_phy_rate;
 };
 
 /** @brief Wi-Fi power save parameters */

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -877,6 +877,7 @@ static void print_wifi_stats(struct net_if *iface, struct net_stats_wifi *data,
 	PR("Beacons missed   : %u\n", data->sta_mgmt.beacons_miss);
 	PR("Unicast received : %u\n", data->unicast.rx);
 	PR("Unicast sent     : %u\n", data->unicast.tx);
+	PR("Overrun count    : %u\n", data->overrun_count);
 }
 #endif /* CONFIG_NET_STATISTICS_WIFI && CONFIG_NET_STATISTICS_USER_API */
 

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -850,6 +850,7 @@ static int cmd_wifi_status(const struct shell *sh, size_t argc, char *argv[])
 		PR("DTIM: %d\n", status.dtim_period);
 		PR("TWT: %s\n",
 		   status.twt_capable ? "Supported" : "Not supported");
+		PR("Current PHY rate : %d\n", status.current_phy_rate);
 	}
 
 	return 0;


### PR DESCRIPTION
Current PHY rate
It represents the current PHY rate of transfer of data in bits per second. It will a TX data rate.

Over run count
It represents the number of packets dropped either at received and sent due to lack of buffer memory to retain all packets on the network interface.