### PR TITLE
drivers: ethernet: eth_xmc4xxx: fix get_phy

### DIFF
--- a/drivers/ethernet/eth_xmc4xxx.c
+++ b/drivers/ethernet/eth_xmc4xxx.c
@@ -639,7 +639,7 @@ static const struct device *eth_xmc4xxx_get_phy(const struct device *dev)
 {
 	const struct eth_xmc4xxx_config *dev_cfg = dev->config;
 
-	return config->phy_dev;
+	return dev_cfg->phy_dev;
 }
 
 static void eth_xmc4xxx_iface_init(struct net_if *iface)


### PR DESCRIPTION
This fixes the eth_xmc4xxx_get_phy function.

Fixes: #76402