### PR TITLE
drivers: flash: Do not select NRFX_RRAMC while building with TF-M

### DIFF
--- a/drivers/flash/Kconfig.nrf_rram
+++ b/drivers/flash/Kconfig.nrf_rram
@@ -8,7 +8,7 @@ menuconfig SOC_FLASH_NRF_RRAM
 	bool "Nordic Semiconductor flash driver for nRF RRAM"
 	default y
 	depends on DT_HAS_NORDIC_RRAM_CONTROLLER_ENABLED
-	select NRFX_RRAMC
+	select NRFX_RRAMC if !BUILD_WITH_TFM
 	select FLASH_HAS_DRIVER_ENABLED
 	select FLASH_HAS_PAGE_LAYOUT
 	select FLASH_HAS_NO_EXPLICIT_ERASE


### PR DESCRIPTION
RRAMC peripheral is a secure-only peripheral, and the application cannot use it directly. While building an application with TF-M enabled and SOC_FLASH_NRF_RRAM the NRFX_RRAMC selection must be forbidden.