### PR TITLE
net: coap_client: allow application to add block2 option to requests

### DIFF
--- a/doc/connectivity/networking/api/coap_client.rst
+++ b/doc/connectivity/networking/api/coap_client.rst
@@ -79,6 +79,34 @@ The following is an example of a very simple response handling function:
         }
     }
 
+CoAP options may also be added to the request by the application. The following is an example of
+the application adding a Block2 option to the initial request, to suggest a maximum block size to
+the server for a resource that it expects to be large enough to require a blockwise transfer (see
+RFC7959 Figure 3: Block-Wise GET with Early Negotiation).
+
+.. code-block:: c
+
+    static struct coap_client;
+    struct coap_client_request req = { 0 };
+
+    /* static, since options must remain valid throughout the whole execution of the request */
+    static struct coap_client_option block2_option;
+
+    coap_client_init(&client, NULL);
+    block2_option = coap_client_option_initial_block2();
+
+    req.method = COAP_METHOD_GET;
+    req.confirmable = true;
+    req.path = "test";
+    req.fmt = COAP_CONTENT_FORMAT_TEXT_PLAIN;
+    req.cb = response_cb;
+    req.options = &block2_option;
+    req.num_options = 1;
+    req.payload = NULL;
+    req.len = 0;
+
+    ret = coap_client_req(&client, sock, &address, &req, -1);
+
 API Reference
 *************
 

--- a/include/zephyr/net/coap_client.h
+++ b/include/zephyr/net/coap_client.h
@@ -160,6 +160,28 @@ int coap_client_req(struct coap_client *client, int sock, const struct sockaddr 
 void coap_client_cancel_requests(struct coap_client *client);
 
 /**
+ * @brief Initialise a Block2 option to be added to a request
+ *
+ * If the application expects a request to require a blockwise transfer, it may pre-emptively
+ * suggest a maximum block size to the server - see RFC7959 Figure 3: Block-Wise GET with Early
+ * Negotiation.
+ *
+ * This helper function returns a Block2 option to send with the initial request.
+ *
+ * @return CoAP client initial Block2 option structure
+ */
+static inline struct coap_client_option coap_client_option_initial_block2(void)
+{
+	struct coap_client_option block2 = {
+		.code = COAP_OPTION_BLOCK2,
+		.len = 1,
+		.value[0] = coap_bytes_to_block_size(CONFIG_COAP_CLIENT_BLOCK_SIZE),
+	};
+
+	return block2;
+}
+
+/**
  * @}
  */
 


### PR DESCRIPTION
As noted by @SeppoTakalo in the discussion around https://github.com/zephyrproject-rtos/zephyr/issues/76089, if an application adds a Block2 option to a `coap_client` request, this results in duplicate Block2 options in every request of a blockwise transfer after the first one, since the CoAP client appends its own Block2 option with updated NUM and SZX fields.

This PR allows an application to add a Block2 option to an initial request for a resource, which will be ignored by the CoAP client for all subsequent blockwise requests in favour of the updated Block2 option populated inside the client.

I've also added a helper function to correctly populate the Block2 option to send in the initial request, so that the application developer doesn't need to know the details of the Block2 option format, and updated the CoAP client documentation to mention that CoAP options can be added by the application.