### PR TITLE
Bluetooth: DIS: integrate app version into FW revision characteristic

### DIFF
--- a/subsys/bluetooth/services/Kconfig.dis
+++ b/subsys/bluetooth/services/Kconfig.dis
@@ -117,6 +117,8 @@ config BT_DIS_FW_REV
 config BT_DIS_FW_REV_STR
 	string "Firmware revision"
 	depends on BT_DIS_FW_REV
+	default "$(APP_VERSION_TWEAK_STRING)" if "$(VERSION_MAJOR)" != ""
+	default "0.0.0+0"
 	help
 	  Enable firmware revision characteristic in Device Information Service.
 


### PR DESCRIPTION
Integrated the application version feature of the build system with the default configuration of the Bluetooth DIS module and its Firmware Revision characteristic.