### PR TITLE
Bluetooth: host: fix send L2CAP segment with invalid callback

### DIFF
--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -946,6 +946,11 @@ struct net_buf *l2cap_data_pull(struct bt_conn *conn,
 				     l2cap_chan_sdu_sent,
 				     UINT_TO_POINTER(lechan->tx.cid));
 		}
+	} else {
+		if (L2CAP_LE_CID_IS_DYN(lechan->tx.cid)) {
+			LOG_DBG("clean callback");
+			make_closure(pdu->user_data, NULL, NULL);
+		}
 	}
 
 	if (last_frag) {


### PR DESCRIPTION
For k-frame sdu's first or middle segment, callback function no assignment, callback point to invalid value. tx_notify function call invlid callback fuction lead to hang. Clean pdu user_data if isn't the last segment.

The call function follow is that:
(1) Get buf but not memset user_date to null.
send_data (btp_l2cap.c) -> buf = net_buf_alloc(&data_pool, K_FOREVER);
(2) Tx process.
bt_conn_tx_processor (conn.c) -> buf = conn->tx_data_pull(conn, SIZE_MAX, &buf_len);
(3) Assign tx callback for last segment. but not for first or middle segment.
l2cap_data_pull (l2cap.c) -> make_closure(pdu->user_data, l2cap_chan_sdu_sent, UINT_TO_POINTER(lechan->tx.cid)); 
(4) Call callback
tx_notify (conn.c) -> if (cb) { cb(conn, user_data, 0); }
cb isn't null for first or middle segment, but is an invalid function, system hang.