### PR TITLE
da1469x: Fixes entropy and gpio drivers

### DIFF
--- a/drivers/entropy/entropy_smartbond.c
+++ b/drivers/entropy/entropy_smartbond.c
@@ -94,6 +94,7 @@ static void trng_enable(bool enable)
 	} else {
 		CRG_TOP->CLK_AMBA_REG &= ~CRG_TOP_CLK_AMBA_REG_TRNG_CLK_ENABLE_Msk;
 		TRNG->TRNG_CTRL_REG = 0;
+		NVIC_ClearPendingIRQ(IRQN);
 
 		entropy_smartbond_pm_policy_state_lock_put();
 	}

--- a/drivers/gpio/gpio_smartbond.c
+++ b/drivers/gpio/gpio_smartbond.c
@@ -242,7 +242,9 @@ static int gpio_smartbond_pin_interrupt_configure(const struct device *dev,
 		config->wkup_regs->clear = pin_mask;
 		data->both_edges_pins &= ~pin_mask;
 #if CONFIG_PM
-		da1469x_pdc_del(pdc_ix);
+		if (pdc_ix >= 0) {
+			da1469x_pdc_del(pdc_ix);
+		}
 #endif
 	} else {
 		if (trig == GPIO_INT_TRIG_BOTH) {

--- a/drivers/gpio/gpio_smartbond.c
+++ b/drivers/gpio/gpio_smartbond.c
@@ -17,8 +17,6 @@
 #include <da1469x_pdc.h>
 #include <da1469x_pd.h>
 
-#define GPIO_MODE_RESET		0x200
-
 #define GPIO_PUPD_INPUT		0
 #define GPIO_PUPD_INPUT_PU	1
 #define GPIO_PUPD_INPUT_PD	2
@@ -117,8 +115,8 @@ static int gpio_smartbond_pin_configure(const struct device *dev,
 	const struct gpio_smartbond_config *config = dev->config;
 
 	if (flags == GPIO_DISCONNECTED) {
-		/* Reset to default value */
-		config->mode_regs[pin] = GPIO_MODE_RESET;
+		/* Set pin as input with no resistors selected */
+		config->mode_regs[pin] = GPIO_PUPD_INPUT << GPIO_P0_00_MODE_REG_PUPD_Pos;
 		return 0;
 	}
 

--- a/drivers/gpio/gpio_smartbond.c
+++ b/drivers/gpio/gpio_smartbond.c
@@ -164,7 +164,8 @@ static int gpio_smartbond_port_set_masked_raw(const struct device *dev,
 {
 	const struct gpio_smartbond_config *config = dev->config;
 
-	config->data_regs->data = value & mask;
+	config->data_regs->set = value & mask;
+	config->data_regs->reset = ~value & mask;
 
 	return 0;
 }

--- a/tests/drivers/gpio/gpio_basic_api/boards/da1469x_dk_pro.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/da1469x_dk_pro.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	resources {
+		compatible = "test-gpio-basic-api";
+		out-gpios = <&gpio0 2 0>;
+		in-gpios = <&gpio0 3 0>;
+	};
+};


### PR DESCRIPTION
entropy_smartbond:

- Clear pending interrupts after disabling TRNG to avoid smartbond_trng_isr getting called with TRNG disabled.

gpio_smartbond:

- Set pin to input with no resistors selected when it is configured as GPIO_DISCONNECTED.
- Remove pdc entry only if it exists when CONFIG_PM is set.
- Writing directly to Px_DATA_REG modifies pins which are not indicated by mask, causing gpio_basic_api test to fail.
   Use Px_SET_DATA_REG and Px_RESET_DATA_REG to modify only pins indicated by mask.

Fixes #77269