### PR TITLE
Nrfx 5891 run zephyr system timer tests for n rf54 l20

### DIFF
--- a/tests/drivers/timer/nrf_grtc_timer/testcase.yaml
+++ b/tests/drivers/timer/nrf_grtc_timer/testcase.yaml
@@ -8,3 +8,4 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
       - nrf54h20dk/nrf54h20/cpuppr
+      - nrf54l20pdk/nrf54l20/cpuapp


### PR DESCRIPTION
Run GRTC tests for nRF54L20 platform.
