### PR TITLE
drivers: wifi: esp_at: support listening UDP sockets in active mode

### DIFF
--- a/drivers/wifi/esp_at/esp.c
+++ b/drivers/wifi/esp_at/esp.c
@@ -288,12 +288,12 @@ static int esp_pull_quoted(char **str, char *str_end, char **unquoted)
 static int esp_pull(char **str, char *str_end)
 {
 	while (*str < str_end) {
-		if (**str == ',' || **str == '\r' || **str == '\n') {
+		if (**str == ',' || **str == ':' || **str == '\r' || **str == '\n') {
 			char last_c = **str;
 
 			**str = '\0';
 
-			if (last_c == ',') {
+			if (last_c == ',' || last_c == ':') {
 				(*str)++;
 			}
 

--- a/drivers/wifi/esp_at/esp_offload.c
+++ b/drivers/wifi/esp_at/esp_offload.c
@@ -544,7 +544,7 @@ MODEM_CMD_DIRECT_DEFINE(on_cmd_ciprecvdata)
 	struct sockaddr_in *recv_addr =
 			(struct sockaddr_in *) &sock->context->remote;
 
-	recv_addr->sin_port = ntohs(port);
+	recv_addr->sin_port = htons(port);
 	recv_addr->sin_family = AF_INET;
 
 	/* IP addr comes within quotation marks, which is disliked by


### PR DESCRIPTION
So far receving was possible in active mode, but IP and port information
was not fetched nor propagated to application layer. Support fetching that
information even in active mode, so that using `bind()` with `recvfrom()` is
working accordingly with UDP server listen flow.