### PR TITLE
ci: doc-build: compress HTML docs more efficiently

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -149,9 +149,9 @@ jobs:
 
     - name: compress-docs
       run: |
-        tar cfJ html-output.tar.xz --directory=doc/_build html
-        tar cfJ api-output.tar.xz --directory=doc/_build html/doxygen/html
-        tar cfJ api-coverage.tar.xz coverage-report
+        tar --use-compress-program="xz -T0" -cf html-output.tar.xz --directory=doc/_build html
+        tar --use-compress-program="xz -T0" -cf api-output.tar.xz --directory=doc/_build html/doxygen/html
+        tar --use-compress-program="xz -T0" -cf api-coverage.tar.xz coverage-report
 
     - name: upload-build
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Compressing doc build to upload it to AWS S3 is talking several minutes.
Use -T0 to run xz in parallel mode to speed up the process, which should speed up the compression step by a ~10x factor based on local tests