### PR TITLE
doc: misc fixes of C domain usage

### DIFF
--- a/doc/develop/api/design_guidelines.rst
+++ b/doc/develop/api/design_guidelines.rst
@@ -31,7 +31,7 @@ specifying the signature of a callback:
 An exception to providing ``user_data`` as the last parameter may be
 allowed when the callback itself was provided through a structure that
 will be embedded in another structure.  An example of such a case is
-:c:type:`gpio_callback`, normally defined within a data structure
+:c:struct:`gpio_callback`, normally defined within a data structure
 specific to the code that also defines the callback function.  In those
 cases further context can accessed by the callback indirectly by
 :c:macro:`CONTAINER_OF`.
@@ -45,7 +45,7 @@ Examples
     void handle_timeout(struct k_timer *timer)
     { ... }
 
-  The assumption here, as with :c:type:`gpio_callback`, is that the
+  The assumption here, as with :c:struct:`gpio_callback`, is that the
   timer is embedded in a structure reachable from
   :c:macro:`CONTAINER_OF` that can provide additional context to the
   callback.
@@ -62,7 +62,7 @@ Examples
   This provides more complete useful information, including which
   counter channel timed-out and the counter value at which the timeout
   occurred, as well as user context which may or may not be the
-  :c:type:`counter_alarm_cfg` used to register the callback, depending
+  :c:struct:`counter_alarm_cfg` used to register the callback, depending
   on user needs.
 
 Conditional Data and APIs

--- a/doc/develop/languages/c/picolibc.rst
+++ b/doc/develop/languages/c/picolibc.rst
@@ -133,7 +133,7 @@ Thread Local Storage
 
 Picolibc uses Thread Local Storage (TLS) (where supported) for data
 which is supposed to remain local to each thread, like
-:c:var:`errno`. This means that TLS support is enabled when using
+:c:macro:`errno`. This means that TLS support is enabled when using
 Picolibc. As all TLS variables are allocated out of the thread stack
 area, this can affect stack size requirements by a few bytes.
 

--- a/doc/releases/release-notes-3.5.rst
+++ b/doc/releases/release-notes-3.5.rst
@@ -2094,7 +2094,7 @@ Libraries / Subsystems
     :kconfig:option:`CONFIG_MCUMGR_MGMT_HANDLER_USER_DATA` is enabled.
 
   * Added optional ``force`` parameter to os mgmt reset command, this can be checked in the
-    :c:enum:`MGMT_EVT_OP_OS_MGMT_RESET` notification callback whose data structure is
+    :c:enumerator:`MGMT_EVT_OP_OS_MGMT_RESET` notification callback whose data structure is
     :c:struct:`os_mgmt_reset_data`.
 
   * Added configurable number of SMP encoding levels via

--- a/doc/releases/release-notes-3.6.rst
+++ b/doc/releases/release-notes-3.6.rst
@@ -1007,7 +1007,7 @@ Libraries / Subsystems
     MCUboot or currently running application slot.
 
   * Fixed an issue whereby messages that were too large to be sent over the UDP transport would
-    wrongly return :c:enum:`MGMT_ERR_EINVAL` instead of :c:enum:`MGMT_ERR_EMSGSIZE`.
+    wrongly return :c:enumerator:`MGMT_ERR_EINVAL` instead of :c:enumerator:`MGMT_ERR_EMSGSIZE`.
 
   * Fixed an issue where confirming an image in Direct XIP mode would always confirm the image in
     the primary slot even when executing from the secondary slot. Now the currently active image is

--- a/doc/services/file_system/index.rst
+++ b/doc/services/file_system/index.rst
@@ -14,7 +14,7 @@ mechanisms.
 In Zephyr, any file system implementation or library can be plugged into or
 pulled out through a file system registration API.  Each file system
 implementation must have a globally unique integer identifier; use
-:c:macro:`FS_TYPE_EXTERNAL_BASE` to avoid clashes with in-tree identifiers.
+:c:enumerator:`FS_TYPE_EXTERNAL_BASE` to avoid clashes with in-tree identifiers.
 
 .. code-block:: c
 

--- a/doc/services/resource_management/index.rst
+++ b/doc/services/resource_management/index.rst
@@ -80,8 +80,8 @@ state.
    case is asynchronous.  The on-off client structure may be an
    appropriate solution for the generic API.  Where drivers that can
    guarantee synchronous context-independent transitions a driver may
-   use :c:type:`onoff_sync_service` and its supporting API rather than
-   :c:type:`onoff_manager`, with only a small reduction in functionality
+   use :c:struct:`onoff_sync_service` and its supporting API rather than
+   :c:struct:`onoff_manager`, with only a small reduction in functionality
    (primarily no support for the monitor API).
 
 .. doxygengroup:: resource_mgmt_onoff_apis

--- a/doc/services/storage/flash_map/flash_map.rst
+++ b/doc/services/storage/flash_map/flash_map.rst
@@ -78,7 +78,7 @@ Numeric flash area ID is obtained by passing DTS node label to
 :c:macro:`FIXED_PARTITION_ID()`; for example to obtain ID number
 for ``slot0_partition``, user would invoke ``FIXED_PARTITION_ID(slot0_partition)``.
 
-All :c:macro:`FIXED_PARTITION_` macros take DTS node labels as partition
+All :code:`FIXED_PARTITION_*` macros take DTS node labels as partition
 identifiers.
 
 Users do not have to obtain a :c:struct:`flash_area` object pointer


### PR DESCRIPTION
Fix several incorrect object types in C domain that Breathe don't seem to care about but other tooling might be more strict