### PR TITLE
samples: usb: mass: filter by supported disk types

### DIFF
--- a/samples/subsys/usb/mass/CMakeLists.txt
+++ b/samples/subsys/usb/mass/CMakeLists.txt
@@ -4,12 +4,6 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mass)
 
-if((NOT CONFIG_DISK_DRIVER_FLASH) AND
-   (NOT CONFIG_DISK_DRIVER_RAM) AND
-   (NOT CONFIG_DISK_DRIVER_SDMMC))
-	message( FATAL_ERROR "No disk access settings detected." )
-endif()
-
 include(${ZEPHYR_BASE}/samples/subsys/usb/common/common.cmake)
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/samples/subsys/usb/mass/sample.yaml
+++ b/samples/subsys/usb/mass/sample.yaml
@@ -117,6 +117,7 @@ tests:
         - "The device is put in USB mass storage mode."
   sample.usb.mass_sdhc_fatfs:
     min_ram: 32
+    filter: dt_compat_enabled("zephyr,sdmmc-disk")
     modules:
       - fatfs
     depends_on:
@@ -138,6 +139,7 @@ tests:
         - "The device is put in USB mass storage mode."
   sample.usb_device_next.mass_sdhc_fatfs:
     min_ram: 32
+    filter: dt_compat_enabled("zephyr,sdmmc-disk")
     modules:
       - fatfs
     depends_on:

--- a/samples/subsys/usb/mass/src/main.c
+++ b/samples/subsys/usb/mass/src/main.c
@@ -30,6 +30,12 @@ LOG_MODULE_REGISTER(main);
 FS_LITTLEFS_DECLARE_DEFAULT_CONFIG(storage);
 #endif
 
+#if !defined(CONFIG_DISK_DRIVER_FLASH) && \
+	!defined(CONFIG_DISK_DRIVER_RAM) && \
+	!defined(CONFIG_DISK_DRIVER_SDMMC)
+#error No supported disk driver enabled
+#endif
+
 #define STORAGE_PARTITION		storage_partition
 #define STORAGE_PARTITION_ID		FIXED_PARTITION_ID(STORAGE_PARTITION)
 


### PR DESCRIPTION
Move the check for valid disk drivers to compile time to enable twister to run the configure step without errors.
Some boards claim `sdhc` support but use the `zephyr,mmc-disk` instead of `zephyr,sdmmc-disk` compatible, with the former not being compatible with this sample.

Fixes #76405.