### PR TITLE
gnss: API for retrieving PPS timestamp

### DIFF
--- a/samples/drivers/gnss/src/main.c
+++ b/samples/drivers/gnss/src/main.c
@@ -15,8 +15,16 @@ LOG_MODULE_REGISTER(gnss_sample, CONFIG_GNSS_LOG_LEVEL);
 
 static void gnss_data_cb(const struct device *dev, const struct gnss_data *data)
 {
+	uint64_t timepulse_ns;
+	k_ticks_t timepulse;
+
 	if (data->info.fix_status != GNSS_FIX_STATUS_NO_FIX) {
-		printf("Got a fix!\n");
+		if (gnss_get_latest_timepulse(dev, &timepulse) == 0) {
+			timepulse_ns = k_ticks_to_ns_near64(timepulse);
+			printf("Got a fix @ %lld ns\n", timepulse_ns);
+		} else {
+			printf("Got a fix!\n");
+		}
 	}
 }
 GNSS_DATA_CALLBACK_DEFINE(GNSS_MODEM, gnss_data_cb);


### PR DESCRIPTION
Add an API function for retrieving the timestamp of the latest PPS timepulse at the highest resolution we have available, the kernel tick count. Added the timepulse information to the GNSS sample.

In the true spirit of the GNSS API, the timepulse pin behaviour is "Whatever the modem does by default" :)

I don't have any hardware with in-tree drivers, but the updated sample works with my OOT driver with a PPS GPIO.

<details><summary>Output log at transition from no PPS to PPS</summary>
<p>

```
Got a fix!
13 satellites reported (of which 7 tracked)!
sam_m10@42: gnss_info: {satellites_cnt: 6, hdop: 4.160, fix_status: GNSS_FIX, fix_quality: GNSS_SPS}
sam_m10@42: navigation_data: {latitude: ********, longitude : **********, bearing 0.000, speed 0.047, altitude: 52.908}
sam_m10@42: gnss_time: {hour: 1, minute: 6, millisecond 39000, month_day 30, month: 7, century_year: 24}
sam_m10@42: gnss_satellite: {prn: 8, snr: 30, elevation 15, azimuth 139, system: GPS, is_tracked: 1}
sam_m10@42: gnss_satellite: {prn: 13, snr: 27, elevation 165, azimuth 0, system: GPS, is_tracked: 0}
sam_m10@42: gnss_satellite: {prn: 14, snr: 35, elevation 61, azimuth 233, system: GPS, is_tracked: 1}
sam_m10@42: gnss_satellite: {prn: 30, snr: 43, elevation 63, azimuth 169, system: GPS, is_tracked: 1}
sam_m10@42: gnss_satellite: {prn: 128, snr: 0, elevation 9, azimuth 280, system: SBAS, is_tracked: 0}
sam_m10@42: gnss_satellite: {prn: 129, snr: 0, elevation 47, azimuth 313, system: SBAS, is_tracked: 0}
sam_m10@42: gnss_satellite: {prn: 133, snr: 0, elevation 2, azimuth 84, system: SBAS, is_tracked: 0}
sam_m10@42: gnss_satellite: {prn: 137, snr: 0, elevation 47, azimuth 313, system: SBAS, is_tracked: 0}
sam_m10@42: gnss_satellite: {prn: 6, snr: 36, elevation 165, azimuth 0, system: GALILEO, is_tracked: 1}
sam_m10@42: gnss_satellite: {prn: 2, snr: 38, elevation 60, azimuth 291, system: QZSS, is_tracked: 1}
sam_m10@42: gnss_satellite: {prn: 14, snr: 34, elevation 28, azimuth 138, system: GLONASS, is_tracked: 1}
sam_m10@42: gnss_satellite: {prn: 15, snr: 40, elevation 42, azimuth 203, system: GLONASS, is_tracked: 1}
sam_m10@42: gnss_satellite: {prn: 255, snr: 36, elevation 165, azimuth 0, system: GLONASS, is_tracked: 0}
Got a fix @ 48705 ms
13 satellites reported (of which 7 tracked)!
sam_m10@42: gnss_info: {satellites_cnt: 6, hdop: 4.160, fix_status: GNSS_FIX, fix_quality: GNSS_SPS}
sam_m10@42: navigation_data: {latitude: **********, longitude : **********, bearing 0.000, speed 0.029, altitude: 53.044}
sam_m10@42: gnss_time: {hour: 1, minute: 6, millisecond 40000, month_day 30, month: 7, century_year: 24}
sam_m10@42: gnss_satellite: {prn: 8, snr: 30, elevation 15, azimuth 139, system: GPS, is_tracked: 1}
sam_m10@42: gnss_satellite: {prn: 13, snr: 27, elevation 165, azimuth 0, system: GPS, is_tracked: 0}
sam_m10@42: gnss_satellite: {prn: 14, snr: 35, elevation 61, azimuth 233, system: GPS, is_tracked: 1}
sam_m10@42: gnss_satellite: {prn: 30, snr: 43, elevation 63, azimuth 169, system: GPS, is_tracked: 1}
sam_m10@42: gnss_satellite: {prn: 128, snr: 0, elevation 9, azimuth 280, system: SBAS, is_tracked: 0}
sam_m10@42: gnss_satellite: {prn: 129, snr: 0, elevation 47, azimuth 313, system: SBAS, is_tracked: 0}
sam_m10@42: gnss_satellite: {prn: 133, snr: 0, elevation 2, azimuth 84, system: SBAS, is_tracked: 0}
sam_m10@42: gnss_satellite: {prn: 137, snr: 0, elevation 47, azimuth 313, system: SBAS, is_tracked: 0}
sam_m10@42: gnss_satellite: {prn: 6, snr: 35, elevation 165, azimuth 0, system: GALILEO, is_tracked: 1}
sam_m10@42: gnss_satellite: {prn: 2, snr: 38, elevation 60, azimuth 291, system: QZSS, is_tracked: 1}
sam_m10@42: gnss_satellite: {prn: 14, snr: 34, elevation 28, azimuth 138, system: GLONASS, is_tracked: 1}
sam_m10@42: gnss_satellite: {prn: 15, snr: 40, elevation 42, azimuth 203, system: GLONASS, is_tracked: 1}
sam_m10@42: gnss_satellite: {prn: 255, snr: 36, elevation 165, azimuth 0, system: GLONASS, is_tracked: 0}
Got a fix @ 49705 ms
13 satellites reported (of which 7 tracked)!
sam_m10@42: gnss_info: {satellites_cnt: 6, hdop: 4.160, fix_status: GNSS_FIX, fix_quality: GNSS_SPS}
sam_m10@42: navigation_data: {latitude: **********, longitude : ***********, bearing 0.000, speed 0.022, altitude: 53.191}
sam_m10@42: gnss_time: {hour: 1, minute: 6, millisecond 41000, month_day 30, month: 7, century_year: 24}
sam_m10@42: gnss_satellite: {prn: 8, snr: 30, elevation 15, azimuth 139, system: GPS, is_tracked: 1}
sam_m10@42: gnss_satellite: {prn: 13, snr: 26, elevation 165, azimuth 0, system: GPS, is_tracked: 0}
sam_m10@42: gnss_satellite: {prn: 14, snr: 34, elevation 61, azimuth 233, system: GPS, is_tracked: 1}
sam_m10@42: gnss_satellite: {prn: 30, snr: 43, elevation 63, azimuth 169, system: GPS, is_tracked: 1}
sam_m10@42: gnss_satellite: {prn: 128, snr: 0, elevation 9, azimuth 280, system: SBAS, is_tracked: 0}
sam_m10@42: gnss_satellite: {prn: 129, snr: 0, elevation 47, azimuth 313, system: SBAS, is_tracked: 0}
sam_m10@42: gnss_satellite: {prn: 133, snr: 0, elevation 2, azimuth 84, system: SBAS, is_tracked: 0}
sam_m10@42: gnss_satellite: {prn: 137, snr: 0, elevation 47, azimuth 313, system: SBAS, is_tracked: 0}
sam_m10@42: gnss_satellite: {prn: 6, snr: 35, elevation 165, azimuth 0, system: GALILEO, is_tracked: 1}
sam_m10@42: gnss_satellite: {prn: 2, snr: 39, elevation 60, azimuth 291, system: QZSS, is_tracked: 1}
sam_m10@42: gnss_satellite: {prn: 14, snr: 34, elevation 28, azimuth 138, system: GLONASS, is_tracked: 1}
sam_m10@42: gnss_satellite: {prn: 15, snr: 40, elevation 42, azimuth 203, system: GLONASS, is_tracked: 1}
sam_m10@42: gnss_satellite: {prn: 255, snr: 37, elevation 165, azimuth 0, system: GLONASS, is_tracked: 0}

```

</p>
</details> 

Example driver implementation:
```
static int ubx_m10_i2c_get_latest_timepulse(const struct device *dev, k_ticks_t *timestamp)
{
	const struct ubx_m10_i2c_config *cfg = dev->config;
	struct ubx_m10_i2c_data *data = dev->data;

	if (cfg->timepulse_gpio.port == NULL) {
		/* No timepulse pin connected */
		return -ENOTSUP;
	}
	if (data->latest_timepulse == 0) {
		/* Timepulse interrupt has not occured yet */
		return -EAGAIN;
	}
	*timestamp = data->latest_timepulse;
	return 0;
}

static void timepulse_gpio_callback(const struct device *dev, struct gpio_callback *cb,
				    uint32_t pins)
{
	struct ubx_m10_i2c_data *data = CONTAINER_OF(cb, struct ubx_m10_i2c_data, timepulse_cb);

	data->latest_timepulse = k_uptime_ticks();
	LOG_DBG("");
}
```

