### PR TITLE
boards: nordic: nrf9161dk: remove duplicate flash

### DIFF
--- a/boards/nordic/nrf9161dk/nrf9161dk_nrf9161_common_0_7_0.dtsi
+++ b/boards/nordic/nrf9161dk/nrf9161dk_nrf9161_common_0_7_0.dtsi
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* Remove v0.9.0 variant flash */
+/delete-node/ &gd25wb256;
+
 &spi3 {
 	gd25lb256: gd25lb256e3ir@1 {
 		compatible = "jedec,spi-nor";


### PR DESCRIPTION
Remove the flash node defined in the default `v0.9.0` variant before adding a new node for the `v0.7.0` variant. Fixes two instances of `jedec,spi-nor` being present in the final dts.