### PR TITLE
drivers: intc_ite_it8xxx2: disable debug mode then reset for tests

### DIFF
--- a/drivers/interrupt_controller/intc_ite_it8xxx2.c
+++ b/drivers/interrupt_controller/intc_ite_it8xxx2.c
@@ -250,6 +250,37 @@ static void intc_irq0_handler(const void *arg)
 
 void soc_interrupt_init(void)
 {
+#ifdef CONFIG_ZTEST
+	/*
+	 * After flashed EC image, we needed to manually press the reset button
+	 * on it8xxx2_evb, then run the test. Now, without pressing the button,
+	 * we can disable debug mode and trigger a watchdog hard reset then
+	 * run tests.
+	 */
+	struct wdt_it8xxx2_regs *const wdt_regs = WDT_IT8XXX2_REGS_BASE;
+	struct gctrl_it8xxx2_regs *const gctrl_regs = GCTRL_IT8XXX2_REGS_BASE;
+
+	if (gctrl_regs->GCTRL_DBGROS & IT8XXX2_GCTRL_SMB_DBGR) {
+		/* Disable debug mode through i2c */
+		IT8XXX2_SMB_SLVISELR |= BIT(4);
+		/* Enable ETWD reset */
+		wdt_regs->ETWCFG = 0;
+		wdt_regs->ET1PSR = IT8XXX2_WDT_ETPS_1P024_KHZ;
+		wdt_regs->ETWCFG = (IT8XXX2_WDT_EWDKEYEN | IT8XXX2_WDT_EWDSRC);
+		/* Enable ETWD hardware reset */
+		gctrl_regs->GCTRL_ETWDUARTCR |= IT8XXX2_GCTRL_ETWD_HW_RST_EN;
+		/* Trigger ETWD reset */
+		wdt_regs->EWDKEYR = 0;
+
+		/* Spin and wait for reboot */
+		while (1)
+			;
+	} else {
+		/* Disable ETWD hardware reset */
+		gctrl_regs->GCTRL_ETWDUARTCR &= ~IT8XXX2_GCTRL_ETWD_HW_RST_EN;
+	}
+#endif
+
 	/* Ensure interrupts of soc are disabled at default */
 	for (int i = 0; i < ARRAY_SIZE(reg_enable); i++)
 		*reg_enable[i] = 0;

--- a/soc/ite/ec/common/chip_chipregs.h
+++ b/soc/ite/ec/common/chip_chipregs.h
@@ -347,6 +347,9 @@ struct kscan_it8xxx2_regs {
  * (1Fxxh) External Timer & External Watchdog (ETWD)
  *
  */
+#define WDT_IT8XXX2_REGS_BASE \
+	((struct wdt_it8xxx2_regs *)DT_REG_ADDR(DT_NODELABEL(twd0)))
+
 #ifndef __ASSEMBLER__
 struct wdt_it8xxx2_regs {
 	/* 0x000: Reserved1 */
@@ -1542,8 +1545,10 @@ struct gctrl_it8xxx2_regs {
 	volatile uint8_t reserved_00_01[2];
 	/* 0x02: Chip Version */
 	volatile uint8_t GCTRL_ECHIPVER;
-	/* 0x03-0x05: Reserved_03_05 */
-	volatile uint8_t reserved_03_05[3];
+	/* 0x03: DBGR Operate Status */
+	volatile uint8_t GCTRL_DBGROS;
+	/* 0x04-0x05: Reserved_04_05 */
+	volatile uint8_t reserved_04_05[2];
 	/* 0x06: Reset Status */
 	volatile uint8_t GCTRL_RSTS;
 	/* 0x07-0x09: Reserved_07_09 */
@@ -1630,6 +1635,8 @@ struct gctrl_it8xxx2_regs {
 #endif /* !__ASSEMBLER__ */
 
 /* GCTRL register fields */
+/* 0x03: DBGR Operate Status */
+#define IT8XXX2_GCTRL_SMB_DBGR		BIT(0)
 /* 0x06: Reset Status */
 #define IT8XXX2_GCTRL_LRS		(BIT(1) | BIT(0))
 #define IT8XXX2_GCTRL_IWDTR		BIT(1)


### PR DESCRIPTION
After flashed EC image, we needed to manually press the reset button on it8xxx2_evb. Now, without pressing the button, we can disable debug mode and trigger a watchdog hard reset for running tests.

After flash EC, running below tests can pass (without pressing the button): 
west build -p always -b it8xxx2_evb tests/drivers/watchdog/wdt_basic_api 
west build -p always -b it8xxx2_evb tests/kernel/timer/timer_api 
west build -p always -b it8xxx2_evb tests/kernel/fatal/exception