### PR TITLE
MAINTAINERS: add AndesTech Platforms section

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -291,6 +291,21 @@ Ambiq Platforms:
   labels:
     - "platform: Ambiq"
 
+AndesTech Platforms:
+  status: maintained
+  maintainers:
+    - jimmyzhe
+  collaborators:
+    - kevinwang821020
+  files:
+    - boards/andestech/
+    - drivers/*/*andes*
+    - dts/bindings/*/*andestech*
+    - dts/riscv/andes/
+    - soc/andestech/
+  labels:
+    - "platform: Andes Technology"
+
 BeagleBoard Platforms:
   status: maintained
   maintainers:


### PR DESCRIPTION
The AndesTech board/soc/dts files are currently orphaned and Andes group is willing to maintain the Andes platform.

Migrate Andes related paths from CODEOWNERS to MAINTAINERS.yml and add myself as a maintainer and @kevinwang821020, @wtlee1995 as collaborators.
Remove @cwshu since he is no longer maintaining the Andes platform.