### PR TITLE
hostap: add CONFIG_RRM_MSR_REPORT_LEN

### DIFF
--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -412,6 +412,11 @@ config RRM
 	default y
 	depends on WIFI_NM_WPA_SUPPLICANT_RRM
 
+config RRM_MSR_REPORT_LEN
+	int "RRM measurement report frame length"
+	default 1500
+	depends on WIFI_NM_WPA_SUPPLICANT_RRM
+
 config WMM_AC
 	bool
 

--- a/west.yml
+++ b/west.yml
@@ -261,7 +261,7 @@ manifest:
     - name: hostap
       repo-path: hostap
       path: modules/lib/hostap
-      revision: a90df86d7c596a5367ff70c2b50c7f599e6636f3
+      revision: pull/24/head
     - name: libmetal
       revision: a6851ba6dba8c9e87d00c42f171a822f7a29639b
       path: modules/hal/libmetal


### PR DESCRIPTION
For MBO beacon report test case, if there are too many matched neighbor AP, the RRM measurement report frame length may exceed 2K bytes by default, and this packet will be dropped in wifi driver as it's too long and exceeds the drive buffer size. Now add this custom length config to avoid the packet got dropped.