### PR TITLE
Fix usage of instructions while entering and exiting an exception on Cortex A/R

### DIFF
--- a/arch/arm/core/cortex_a_r/isr_wrapper.S
+++ b/arch/arm/core/cortex_a_r/isr_wrapper.S
@@ -339,6 +339,15 @@ z_arm_cortex_ar_irq_done:
 	str r0, [r2, #___cpu_t_nested_OFFSET]
 	/* Do not context switch if exiting a nested interrupt */
 	cmp r0, #0
+	/* Note that this function is only called from `z_arm_svc`,
+	 *	while handling irq_offload, with below modes set:
+	 *	```
+	 *		if (cpu interrupts are nested)
+	 *			mode=MODE_SYS
+	 *		else
+	 *			mode=MODE_IRQ
+	 *	```
+	 */
 	bhi __EXIT_INT
 
 	/* retrieve pointer to the current thread */

--- a/arch/arm/core/cortex_a_r/macro_priv.inc
+++ b/arch/arm/core/cortex_a_r/macro_priv.inc
@@ -33,8 +33,7 @@
 	 */
 	srsdb sp!, #MODE_SYS
 	cps #MODE_SYS
-	stmdb sp, {r0-r3, r12, lr}^
-	sub sp, #24
+	push {r0-r3, r12, lr}
 
 	/* TODO: EXTRA_EXCEPTION_INFO */
 	mov r0, sp

--- a/arch/arm/core/cortex_a_r/vector_table.S
+++ b/arch/arm/core/cortex_a_r/vector_table.S
@@ -41,6 +41,11 @@ SECTION_SUBSEC_FUNC(exc_vector_table,_vector_table_section,_vector_table)
 GTEXT(z_arm_cortex_ar_exit_exc)
 SECTION_SUBSEC_FUNC(TEXT, _HandlerModeExit, z_arm_cortex_ar_exit_exc)
 
+	/* Note:
+	 * This function is expected to be *always* called with
+	 * processor mode set to MODE_SYS.
+	 */
+
 	/* decrement exception depth */
 	get_cpu r2
 	ldrb r1, [r2, #_cpu_offset_to_exc_depth]
@@ -51,7 +56,6 @@ SECTION_SUBSEC_FUNC(TEXT, _HandlerModeExit, z_arm_cortex_ar_exit_exc)
 	 * Restore r0-r3, r12, lr, lr_und and spsr_und from the exception stack
 	 * and return to the current thread.
 	 */
-	ldmia sp, {r0-r3, r12, lr}^
-	add sp, #24
+	pop {r0-r3, r12, lr}
 	rfeia sp!
 #endif


### PR DESCRIPTION

This PR fixes potential unpredictable behavior, caused by using the ^ form of stmdb and ldmia while entering and exiting an exception respectively in SYSTEM mode, on Cortex-A/R with SMP enabled.

### Change:
- Use "push" instead of "stmdb" to save user mode registers on stack while in SYS mode.
  - As reported in discussion/#75339, since the processor is already in SYS mode after entering `z_arm_cortex_ar_enter_exc()` , the user mode register can be accessed directly without the ^ form of the instruction. The solution suggested to fix this is to use `stmdb sp!, {r0-r3, r12, lr}` which can save the user registers, update the SP and avoid an extra instruction. `"push {}"` is used instead because it is the preferred mnemonic instruction over `stmdb`.

- Use "pop" instead of "ldmia" to restore user mode registers while exiting from z_arm_cortex_ar_exit_exc
  - Since processor mode is always set to system (MODE_SYS) after entering `z_arm_cortex_ar_exit_exc()`, the user mode register can be accessed directly without the ^ form of the instruction. Also, LDMIA instruction is UNPREDICTABLE in SYStem mode so we use `pop`.

Signed-off-by: Sudan Landge [sudan.landge@arm.com](mailto:sudan.landge@arm.com)