### PR TITLE
drivers: eswifi: Fix memory buffer allocation in off_read_work

### DIFF
--- a/drivers/wifi/eswifi/eswifi_socket.c
+++ b/drivers/wifi/eswifi/eswifi_socket.c
@@ -133,32 +133,39 @@ static void eswifi_off_read_work(struct k_work *work)
 
 	__select_socket(eswifi, socket->index);
 
-	len = __read_data(eswifi, 1460, &data); /* 1460 is max size */
-	if (len < 0) {
-		__stop_socket(eswifi, socket);
-
-		if (socket->recv_cb) {
-			/* send EOF (null pkt) */
-			goto do_recv_cb;
-		}
-	}
-
-	if (!len || !socket->recv_cb) {
-		goto done;
-	}
-
-	LOG_DBG("payload sz = %d", len);
-
-	pkt = net_pkt_rx_alloc_with_buffer(eswifi->iface, len,
+	/* Verify if we can allocate a rx packet before reading data to prevent leaks */
+	pkt = net_pkt_rx_alloc_with_buffer(eswifi->iface, 1460,
 					   AF_UNSPEC, 0, K_NO_WAIT);
 	if (!pkt) {
 		LOG_ERR("Cannot allocate rx packet");
 		goto done;
 	}
 
+	len = __read_data(eswifi, 1460, &data); /* 1460 is max size */
+	if (len < 0) {
+		__stop_socket(eswifi, socket);
+
+		if (socket->recv_cb) {
+			/* send EOF (null pkt) */
+			net_pkt_unref(pkt);
+			pkt = NULL;
+			goto do_recv_cb;
+		}
+	}
+
+	if (!len || !socket->recv_cb) {
+		net_pkt_unref(pkt);
+		goto done;
+	}
+
+	LOG_DBG("payload sz = %d", len);
+
 	if (net_pkt_write(pkt, data, len) < 0) {
 		LOG_WRN("Incomplete buffer copy");
 	}
+
+	/* Resize the packet */
+	net_pkt_trim_buffer(pkt);
 
 	net_pkt_cursor_init(pkt);
 


### PR DESCRIPTION
When receiving data over the eswifi module, we currently read the data first, then allocate a buffer, and finally write the data into the buffer. The issue is that if we can't allocate the buffer, the data that was read is lost. To fix this, we should first attempt to allocate the buffer before reading any data. If we can't allocate the buffer, we should not proceed with reading the data.