### PR TITLE
NXP drivers: dma: dma_mcux_pxp: Add flip feature

### DIFF
--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -193,6 +193,11 @@ zephyr_udc0: &usb1 {
 	tx-cal-45-dm-ohms = <6>;
 };
 
+&csi {
+	pinctrl-0 = <&pinmux_csi>;
+	pinctrl-names = "default";
+};
+
 &flexpwm2_pwm3 {
 	status = "okay";
 	pinctrl-0 = <&pinmux_flexpwm2_3>;
@@ -297,3 +302,7 @@ arduino_spi: &lpspi1 {
 &pit0 {
 	status = "okay";
 };
+
+dvp_fpc24_i2c: &lpi2c1 {};
+
+dvp_fpc24_interface: &csi {};

--- a/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -336,6 +336,10 @@ zephyr_udc0: &usb1 {
 	pinctrl-names = "default";
 };
 
+&pxp {
+	status = "okay";
+};
+
 dvp_fpc24_i2c: &lpi2c1 {};
 
 dvp_fpc24_interface: &csi {};

--- a/boards/shields/dvp_fpc24_mt9m114/boards/mimxrt1060_evkb.overlay
+++ b/boards/shields/dvp_fpc24_mt9m114/boards/mimxrt1060_evkb.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&dvp_fpc24_interface {
+	source = <&mt9m114>;
+};

--- a/drivers/display/Kconfig.mcux_elcdif
+++ b/drivers/display/Kconfig.mcux_elcdif
@@ -1,4 +1,4 @@
-# Copyright 2019,2023 NXP
+# Copyright 2019,2023-2024 NXP
 # Copyright (c) 2022, Basalte bv
 # SPDX-License-Identifier: Apache-2.0
 
@@ -102,6 +102,33 @@ config MCUX_ELCDIF_PXP_ROTATE_270
 	help
 	  Rotate display counter-clockwise by 270 degrees
 	  For LVGL, this corresponds to a rotation of 90 degrees
+
+endchoice
+
+choice MCUX_ELCDIF_PXP_FLIP_DIRECTION
+	default MCUX_ELCDIF_PXP_FLIP_DISABLE
+	prompt "Flip direction of PXP"
+	help
+	  Set flip direction of PXP. The ELCDIF cannot detect the correct
+	  rotation angle based on the call to display_write, so the user should
+	  configure it here. In order for PXP flip to work, calls to
+	  display_write MUST supply a framebuffer equal in size to screen width
+	  and height (without flip applied).  Note that the width and
+	  height settings of the screen in devicetree should not be modified
+	  from their values in the default screen orientation when using this
+	  functionality.
+
+config MCUX_ELCDIF_PXP_FLIP_DISABLE
+	bool "Do not flip display"
+
+config MCUX_ELCDIF_PXP_FLIP_HORIZONTAL
+	bool "Flip display horizontally"
+
+config MCUX_ELCDIF_PXP_FLIP_VERTICAL
+	bool "Flip display vertically"
+
+config MCUX_ELCDIF_PXP_FLIP_BOTH
+	bool "Flib display both horizontally and vertically"
 
 endchoice
 

--- a/drivers/dma/dma_mcux_pxp.c
+++ b/drivers/dma/dma_mcux_pxp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NXP
+ * Copyright 2023-2024 NXP
  * All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -57,6 +57,7 @@ static int dma_mcux_pxp_configure(const struct device *dev, uint32_t channel,
 	pxp_output_buffer_config_t output_buffer_cfg;
 	uint8_t bytes_per_pixel;
 	pxp_rotate_degree_t rotate;
+	pxp_flip_mode_t flip;
 
 	ARG_UNUSED(channel);
 	if (config->channel_direction != MEMORY_TO_MEMORY) {
@@ -107,6 +108,25 @@ static int dma_mcux_pxp_configure(const struct device *dev, uint32_t channel,
 	default:
 		return -ENOTSUP;
 	}
+	/*
+	 * Use the DMA linked_channel value to get the flip settings.
+	 */
+	switch ((config->linked_channel & DMA_MCUX_PXP_FLIP_MASK) >> DMA_MCUX_PXP_FLIP_SHIFT) {
+	case DMA_MCUX_PXP_FLIP_DISABLE:
+		flip = kPXP_FlipDisable;
+		break;
+	case DMA_MCUX_PXP_FLIP_HORIZONTAL:
+		flip = kPXP_FlipHorizontal;
+		break;
+	case DMA_MCUX_PXP_FLIP_VERTICAL:
+		flip = kPXP_FlipVertical;
+		break;
+	case DMA_MCUX_PXP_FLIP_BOTH:
+		flip = kPXP_FlipBoth;
+		break;
+	default:
+		return -ENOTSUP;
+	}
 	DCACHE_CleanByRange((uint32_t)config->head_block->source_address,
 			    config->head_block->block_size);
 
@@ -139,7 +159,7 @@ static int dma_mcux_pxp_configure(const struct device *dev, uint32_t channel,
 	PXP_SetProcessSurfacePosition(dev_config->base, 0U, 0U, output_buffer_cfg.width,
 				      output_buffer_cfg.height);
 	/* Setup rotation */
-	PXP_SetRotateConfig(dev_config->base, kPXP_RotateProcessSurface, rotate, kPXP_FlipDisable);
+	PXP_SetRotateConfig(dev_config->base, kPXP_RotateProcessSurface, rotate, flip);
 
 	dev_data->ps_buf_addr = config->head_block->source_address;
 	dev_data->ps_buf_size = config->head_block->block_size;

--- a/include/zephyr/drivers/dma/dma_mcux_pxp.h
+++ b/include/zephyr/drivers/dma/dma_mcux_pxp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NXP
+ * Copyright 2023-2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -37,5 +37,21 @@
 #define DMA_MCUX_PXP_FMT_RGB565   0
 #define DMA_MCUX_PXP_FMT_RGB888   1
 #define DMA_MCUX_PXP_FMT_ARGB8888 2
+
+#define DMA_MCUX_PXP_FLIP_MASK  0x3
+#define DMA_MCUX_PXP_FLIP_SHIFT 0x0
+
+/*
+ * In order to configure the PXP to flip, the user should
+ * supply a flip setting as the DMA linked_channel parameter, like so:
+ * linked_channel |= DMA_MCUX_PXP_FLIP(DMA_MCUX_PXP_FLIP_HORIZONTAL)
+ */
+
+#define DMA_MCUX_PXP_FLIP(x) ((x << DMA_MCUX_PXP_FLIP_SHIFT) & DMA_MCUX_PXP_FLIP_MASK)
+
+#define DMA_MCUX_PXP_FLIP_DISABLE    0
+#define DMA_MCUX_PXP_FLIP_HORIZONTAL 1
+#define DMA_MCUX_PXP_FLIP_VERTICAL   2
+#define DMA_MCUX_PXP_FLIP_BOTH       3
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_DMA_MCUX_PXP_H_ */

--- a/samples/subsys/video/capture/boards/mimxrt1060_evkb.conf
+++ b/samples/subsys/video/capture/boards/mimxrt1060_evkb.conf
@@ -1,0 +1,4 @@
+# Leverage PXP to mirror image by flipping
+CONFIG_DMA=y
+CONFIG_MCUX_ELCDIF_PXP=y
+CONFIG_MCUX_ELCDIF_PXP_FLIP_HORIZONTAL=y

--- a/samples/subsys/video/capture/boards/mimxrt1064_evk.conf
+++ b/samples/subsys/video/capture/boards/mimxrt1064_evk.conf
@@ -1,0 +1,4 @@
+# Leverage PXP to mirror image by flipping
+CONFIG_DMA=y
+CONFIG_MCUX_ELCDIF_PXP=y
+CONFIG_MCUX_ELCDIF_PXP_FLIP_HORIZONTAL=y


### PR DESCRIPTION
Update PXP driver to flip horizontally and/or vertically.  Also updated display_mcux_elcdif driver to flip when writing to display. Tested with sample/subsys/video/capture.