### PR TITLE
data retention in RAM with stm32h7

### DIFF
--- a/dts/bindings/retention/zephyr,retention.yaml
+++ b/dts/bindings/retention/zephyr,retention.yaml
@@ -49,6 +49,17 @@ properties:
   reg:
     required: true
 
+  write32:
+    description: |
+      An optional property to indicates that retention memory requires
+      write in 32bit words. With some sram, especially on the stm32h74x/h750 mcus,
+      when an incomplete word is written to an retention ram and a reset occurs,
+      the last incomplete word is not really written. This is due to the ECC behavior.
+      This property must be set to ensure that an incomplete word is written to retention ram,
+      It will write an additional dummy incomplete word to the same RAM at a different address
+      before issuing a reset.
+    type: boolean
+
   prefix:
     description: |
       An optional magic prefix, which indicates that the data has been set

--- a/subsys/retention/retention.c
+++ b/subsys/retention/retention.c
@@ -402,6 +402,13 @@ int retention_write(const struct device *dev, off_t offset, const uint8_t *buffe
 #endif /* ANY_HAS_PREFIX */
 
 finish:
+#if defined(ANY_HAS_WRITE32)
+	/* Validate any incomplete word by writing it again */
+	rc = retained_mem_write(config->parent,
+			(config->offset + config->prefix_len + (size_t)offset),
+			buffer,
+			size);
+#endif /* ANY_HAS_WRITE32 */
 	retention_lock_release(dev);
 
 	return rc;


### PR DESCRIPTION
Following issue https://github.com/zephyrproject-rtos/zephyr/issues/76237

It appears that when writing to the SRAM (SRAM or DTCM as well)  of the stm32h74x/h75x before a reset, an incomplete 32-bit word is not really written.
This is due to the ECC mechanism, as the [RM0433](https://www.st.com/content/ccc/resource/technical/document/reference_manual/group0/c9/a3/76/fa/55/46/45/fa/DM00314099/files/DM00314099.pdf/jcr:content/translations/en.DM00314099.pdf) explains.
"_When an incomplete word is written to an internal SRAM and a reset occurs, the last
incomplete word is not really written. This is due to the ECC behavior. To ensure that an
incomplete word is written to SRAM, write an additional dummy incomplete word to the
same RAM at a different address before issuing a reset._"

In order to add this specific action to the retention driver, a new DTS boolean property is introduced  <write32> in the zephyr.retention.yaml bindings. This property is mainly targeting stm32 mcus.
With this property, any incomplete word write operation, like writing checksum CRC8 or CRC16 or a prefix, will be completed by another write to validate the data in ram.
