### PR TITLE
doc: fix 404 error with Zephyr project charter

### DIFF
--- a/doc/contribute/external.rst
+++ b/doc/contribute/external.rst
@@ -39,7 +39,7 @@ have not been approved by the `Open Source Initiative (OSI)`_. See the
    https://www.zephyrproject.org/governance/
 
 .. _Zephyr project charter:
-   https://www.zephyrproject.org/wp-content/uploads/sites/38/2023/08/LF-Zephyr-Charter-2023.08.21.pdf
+   https://www.zephyrproject.org/wp-content/uploads/2023/08/LF-Zephyr-Charter-2023.08.21.pdf
 
 .. _Open Source Initiative (OSI):
    https://opensource.org/licenses/alphabetical

--- a/doc/project/tsc.rst
+++ b/doc/project/tsc.rst
@@ -239,4 +239,4 @@ once cast, between the time a Motion is brought forth and the time at which
 results are announced.
 
 .. _Zephyr project charter:
-   https://www.zephyrproject.org/wp-content/uploads/sites/38/2023/08/LF-Zephyr-Charter-2023.08.21.pdf
+   https://www.zephyrproject.org/wp-content/uploads/2023/08/LF-Zephyr-Charter-2023.08.21.pdf


### PR DESCRIPTION
The project charter has apparently changed location on the main zephyrproject.org website.
This fixes a couple occurences of the old URL.

fixes #76433