### PR TITLE
ztest: replace `shell_fprintf(sh, SHELL_ERROR, ...)` with `shell_error`

### DIFF
--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -948,7 +948,7 @@ static void __ztest_show_suite_summary_oneline(struct ztest_suite_node *suite)
 	struct ztest_unit_test *test = NULL;
 	unsigned int suite_duration_worst_ms = 0;
 
-	/** summary of disctinct run  */
+	/** summary of distinct run  */
 	while (((test = z_ztest_get_next_test(suite->name, test)) != NULL)) {
 		distinct_total++;
 		suite_duration_worst_ms += test->stats->duration_worst_ms;
@@ -1022,7 +1022,7 @@ static void __ztest_show_suite_summary_verbose(struct ztest_suite_node *suite)
 		}
 
 		if (flush_frequency % 3 == 0) {
-			/** Reduce the flush frequencey a bit to speed up the output */
+			/** Reduce the flush frequency a bit to speed up the output */
 			flush_log();
 		}
 		flush_frequency++;
@@ -1286,7 +1286,7 @@ static int cmd_shuffle(const struct shell *sh, size_t argc, char **argv)
 			val = atoi(state->optarg);
 			if (val < 1) {
 				shell_fprintf(sh, SHELL_ERROR,
-					      "Invalid number of suite interations\n");
+					      "Invalid number of suite iterations\n");
 				return -ENOEXEC;
 			}
 			suite_iter = val;
@@ -1296,7 +1296,7 @@ static int cmd_shuffle(const struct shell *sh, size_t argc, char **argv)
 			val = atoi(state->optarg);
 			if (val < 1) {
 				shell_fprintf(sh, SHELL_ERROR,
-					      "Invalid number of case interations\n");
+					      "Invalid number of case iterations\n");
 				return -ENOEXEC;
 			}
 			case_iter = val;

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -1285,8 +1285,7 @@ static int cmd_shuffle(const struct shell *sh, size_t argc, char **argv)
 		case 's':
 			val = atoi(state->optarg);
 			if (val < 1) {
-				shell_fprintf(sh, SHELL_ERROR,
-					      "Invalid number of suite iterations\n");
+				shell_error(sh, "Invalid number of suite iterations");
 				return -ENOEXEC;
 			}
 			suite_iter = val;
@@ -1295,16 +1294,15 @@ static int cmd_shuffle(const struct shell *sh, size_t argc, char **argv)
 		case 'c':
 			val = atoi(state->optarg);
 			if (val < 1) {
-				shell_fprintf(sh, SHELL_ERROR,
-					      "Invalid number of case iterations\n");
+				shell_error(sh, "Invalid number of case iterations");
 				return -ENOEXEC;
 			}
 			case_iter = val;
 			opt_num++;
 			break;
 		default:
-			shell_fprintf(sh, SHELL_ERROR, "Invalid option or option usage: %s\n",
-				      argv[opt_index + 1]);
+			shell_error(sh, "Invalid option or option usage: %s",
+				    argv[opt_index + 1]);
 			return -ENOEXEC;
 		}
 	}


### PR DESCRIPTION
This PR is separated into two commits as follows:
- Fix typo
- Replace `shell_fprintf(sh, SHELL_ERROR, ...)` with `shell_error`,
  which is the main purpose of this PR.

