### PR TITLE
boards: rw612: Fix RW boards wrong flash load size

### DIFF
--- a/boards/nxp/frdm_rw612/Kconfig.defconfig
+++ b/boards/nxp/frdm_rw612/Kconfig.defconfig
@@ -5,8 +5,13 @@
 
 if BOARD_FRDM_RW612
 
+DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
+DT_CHOSEN_Z_FLASH := zephyr,flash
+
 config FLASH_LOAD_SIZE
-	default 0x400000 if !BOOTLOADER_MCUBOOT && !NXP_MONOLITHIC_BT
+	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION)) \
+	        if (MCUBOOT || BOOTLOADER_MCUBOOT || (BT_NXP && !NXP_MONOLITHIC_BT))
+	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_FLASH))
 
 config NET_L2_ETHERNET
 	default y if DT_HAS_NXP_ENET_MAC_ENABLED && NETWORKING

--- a/boards/nxp/rd_rw612_bga/Kconfig.defconfig
+++ b/boards/nxp/rd_rw612_bga/Kconfig.defconfig
@@ -5,8 +5,13 @@
 
 if BOARD_RD_RW612_BGA
 
+DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
+DT_CHOSEN_Z_FLASH := zephyr,flash
+
 config FLASH_LOAD_SIZE
-	default 0x400000 if !BOOTLOADER_MCUBOOT && !NXP_MONOLITHIC_BT
+	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION)) \
+	        if (MCUBOOT || BOOTLOADER_MCUBOOT || (BT_NXP && !NXP_MONOLITHIC_BT))
+	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_FLASH))
 
 if LVGL
 


### PR DESCRIPTION
Fixing issues of flash load size for RW612 boards

1. Flash size is seemingly wrong on basic builds.

2. When building mcuboot, need to check both configs
   MCUBOOT and BOOTLOADER_MCUBOOT, as the former is
   used by mcuboot itself and the latter is used by the loaded app.
   This way, both of the images get the flash load size from the
   partitions definition.

3. Condition on BT_NXP seemed missing and NXP_MONOLOTHIC_BT seemed
   backwards.