### PR TITLE
Prevent null-deref to fix seg fault in cbvprintf on strlen(NULL)

### DIFF
--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -1622,11 +1622,15 @@ int z_cbvprintf_impl(cbprintf_cb __out, void *ctx, const char *fp,
 			bps = (const char *)value->ptr;
 
 			size_t len;
-
-			if (precision >= 0) {
-				len = strnlen(bps, precision);
+			if (bps != NULL) {
+				if (precision >= 0) {
+					len = strnlen(bps, precision);
+				} else {
+					len = strlen(bps);
+				}
 			} else {
-				len = strlen(bps);
+				bps = "(nil)";
+				len = 5;
 			}
 
 			bpe = bps + len;


### PR DESCRIPTION
Fix for https://github.com/zephyrproject-rtos/zephyr/issues/76509