### PR TITLE
twister: Add coverage-exclude flag

### DIFF
--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -239,10 +239,14 @@ class Lcov(CoverageTool):
             branch_coverage = "lcov_branch_coverage=1"
             parallel = []
 
+        excludes = []
+        for ignore in self.ignores:
+            excludes += ["--exclude", ignore]
+
         cmd = [
             "lcov", "--gcov-tool", self.gcov_tool,
             "--rc", branch_coverage,
-        ] + parallel + args
+        ] + parallel + args + excludes
         return self.run_command(cmd, coveragelog)
 
     def _generate(self, outdir, coveragelog):
@@ -425,6 +429,8 @@ def run_coverage(testplan, options):
     coverage_tool.add_ignore_file('generated')
     coverage_tool.add_ignore_directory('tests')
     coverage_tool.add_ignore_directory('samples')
+    for exclude in options.coverage_exclude:
+        coverage_tool.add_ignore_directory(exclude)
     # Ignore branch coverage on LOG_* and LOG_HEXDUMP_* macros
     # Branch misses are due to the implementation of Z_LOG2 and cannot be avoided
     coverage_tool.add_ignore_branch_pattern(r"^\s*LOG_(?:HEXDUMP_)?(?:DBG|INF|WRN|ERR)\(.*")

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -319,6 +319,9 @@ structure in the main Zephyr tree: boards/<vendor>/<board_name>/""")
                              " Valid options for 'lcov' tool are: " +
                              ','.join(supported_coverage_formats['lcov']) + " (html,lcov - default).")
 
+    parser.add_argument("--coverage-exclude", action="append", default=[],
+                        help="Exclude patterns for coverage report")
+
     parser.add_argument("--test-config", action="store", default=os.path.join(ZEPHYR_BASE, "tests", "test_config.yaml"),
         help="Path to file with plans and test configurations.")
 

--- a/scripts/tests/twister/test_environment.py
+++ b/scripts/tests/twister/test_environment.py
@@ -236,8 +236,11 @@ TESTDATA_2 = [
     ids=['show footprint', 'compare report']
 )
 def test_parse_arguments(zephyr_base, additional_args):
-    args = ['--coverage', '--platform', 'dummy_platform'] + \
-           additional_args + ['--', 'dummy_extra_1', 'dummy_extra_2']
+    args = (
+        ["--coverage", "--platform", "dummy_platform", "--coverage-exclude", "my/dir"]
+        + additional_args
+        + ["--", "dummy_extra_1", "dummy_extra_2"]
+    )
 
     with mock.patch('sys.argv', ['twister'] + args):
         parser = twisterlib.environment.add_parse_arguments()
@@ -252,6 +255,8 @@ def test_parse_arguments(zephyr_base, additional_args):
     assert options.enable_coverage
 
     assert options.coverage_platform == ['dummy_platform']
+
+    assert options.coverage_exclude == ['my/dir']
 
     assert options.extra_test_args == ['dummy_extra_1', 'dummy_extra_2']
 


### PR DESCRIPTION
Allow passing exclude flags for coverage into twister. This helps projects filter out library code by adding these to the commandline.

Example:
  To filter a directory third_party/my/lib add
  `--coverage-exclude third_party/my/lib`