### PR TITLE
code_relocation: Add option to specify load memory segment 

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1388,9 +1388,10 @@ endmacro()
 # - NOKEEP: suppress the generation of KEEP() statements in the linker script,
 #   to allow any unused code in the given files/library to be discarded.
 # - PHDR [program_header]: add program header. Used on Xtensa platforms.
+# - LMEM [load_memory]: load memory segment
 function(zephyr_code_relocate)
   set(options NOCOPY NOKEEP)
-  set(single_args LIBRARY LOCATION PHDR)
+  set(single_args LIBRARY LOCATION PHDR LMEM)
   set(multi_args FILES)
   cmake_parse_arguments(CODE_REL "${options}" "${single_args}"
     "${multi_args}" ${ARGN})
@@ -1457,7 +1458,10 @@ function(zephyr_code_relocate)
     list(APPEND flag_list NOKEEP)
   endif()
   if(CODE_REL_PHDR)
-    set(CODE_REL_LOCATION "${CODE_REL_LOCATION}\ :${CODE_REL_PHDR}")
+    set(CODE_REL_LOCATION "${CODE_REL_LOCATION}:PHDR=${CODE_REL_PHDR}")
+  endif()
+  if(CODE_REL_LMEM)
+    set(CODE_REL_LOCATION "${CODE_REL_LOCATION}:LMEM=${CODE_REL_LMEM}")
   endif()
   # We use the "|" character to separate code relocation directives, instead of
   # using set_property(APPEND) to produce a ";"-separated CMake list. This way,
@@ -1467,7 +1471,7 @@ function(zephyr_code_relocate)
     PROPERTY COMPILE_DEFINITIONS)
   set_property(TARGET code_data_relocation_target
     PROPERTY COMPILE_DEFINITIONS
-    "${code_rel_str}|${CODE_REL_LOCATION}:${flag_list}:${file_list}")
+    "${code_rel_str}|${CODE_REL_LOCATION}:FLAGS=${flag_list}:FILES=${file_list}")
 endfunction()
 
 # Usage:

--- a/samples/application_development/code_relocation_nocopy/CMakeLists.txt
+++ b/samples/application_development/code_relocation_nocopy/CMakeLists.txt
@@ -16,3 +16,6 @@ zephyr_code_relocate(FILES src/ext_code.c LOCATION RAM_DATA)
 
 # sram_code instead runs entirely from SRAM after being copied there.
 zephyr_code_relocate(FILES src/sram_code.c LOCATION RAM)
+
+# sram_code_from_extflash instead runs entirely from SRAM after being copied there from extflash
+zephyr_code_relocate(FILES src/sram_code_from_extflash.c LOCATION RAM LMEM EXTFLASH)

--- a/samples/application_development/code_relocation_nocopy/src/main.c
+++ b/samples/application_development/code_relocation_nocopy/src/main.c
@@ -41,6 +41,7 @@ void disable_mpu_rasr_xn(void)
 
 extern void function_in_ext_flash(void);
 extern void function_in_sram(void);
+extern void function_in_sram_from_extflash(void);
 
 int main(void)
 {
@@ -52,6 +53,7 @@ int main(void)
 
 	function_in_ext_flash();
 	function_in_sram();
+	function_in_sram_from_extflash();
 
 	printk("Hello World! %s\n", CONFIG_BOARD);
 	return 0;

--- a/samples/application_development/code_relocation_nocopy/src/sram_code_from_extflash.c
+++ b/samples/application_development/code_relocation_nocopy/src/sram_code_from_extflash.c
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2022 Carlo Caione <ccaione@baylibre.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/sys/printk.h>
+
+void function_in_sram_from_extflash(void)
+{
+	printk("Address of %s %p\n", __func__, &function_in_sram_from_extflash);
+}


### PR DESCRIPTION
Currently there is no way to select a load memory segment other than ROMABLE_REGION. This introduces an optional argument (LMEM) to zephyr_code_relocate(). An example usecase is provided.