### PR TITLE
drivers: i3c: common: Do not treat GETCAPS failure as error for 1.0 d…

### DIFF
--- a/drivers/i3c/i3c_common.c
+++ b/drivers/i3c/i3c_common.c
@@ -561,6 +561,8 @@ int i3c_device_basic_info_get(struct i3c_device_desc *target)
 		memcpy(&target->getcaps, &caps, sizeof(target->getcaps));
 	} else if ((ret != 0) && (target->bcr & I3C_BCR_ADV_CAPABILITIES)) {
 		goto out;
+	} else {
+		ret = 0;
 	}
 
 	target->dcr = dcr.dcr;


### PR DESCRIPTION
If it's a I3C v1.0 device without any HDR modes do not treat as an error if GETCAPS gives no valid response.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/76519