### PR TITLE
kernel: Remove ISR restriction from k_thread_priority_set()

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -904,12 +904,12 @@ __syscall int k_thread_priority_get(k_tid_t thread);
  * Rescheduling can occur immediately depending on the priority @a thread is
  * set to:
  *
- * - If its priority is raised above the priority of the caller of this
- * function, and the caller is preemptible, @a thread will be scheduled in.
+ * - If its priority is raised above the priority of a currently scheduled
+ * preemptible thread, @a thread will be scheduled in.
  *
- * - If the caller operates on itself, it lowers its priority below that of
- * other threads in the system, and the caller is preemptible, the thread of
- * highest priority will be scheduled in.
+ * - If the caller lowers the priority of a currently scheduled preemptible
+ * thread below that of other threads in the system, the thread of the highest
+ * priority will be scheduled in.
  *
  * Priority can be assigned in the range of -CONFIG_NUM_COOP_PRIORITIES to
  * CONFIG_NUM_PREEMPT_PRIORITIES-1, where -CONFIG_NUM_COOP_PRIORITIES is the

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1038,7 +1038,6 @@ void z_impl_k_thread_priority_set(k_tid_t thread, int prio)
 	 * keep track of it) and idle cannot change its priority.
 	 */
 	Z_ASSERT_VALID_PRIO(prio, NULL);
-	__ASSERT(!arch_is_in_isr(), "");
 
 	bool need_sched = z_thread_prio_set((struct k_thread *)thread, prio);
 

--- a/tests/kernel/threads/thread_apis/src/test_threads_set_priority.c
+++ b/tests/kernel/threads/thread_apis/src/test_threads_set_priority.c
@@ -6,12 +6,31 @@
 
 #include <zephyr/ztest.h>
 
+#include <zephyr/irq_offload.h>
+
 #include "tests_thread_apis.h"
 
 static int thread2_data;
 
 K_SEM_DEFINE(sem_thread2, 0, 1);
 K_SEM_DEFINE(sem_thread1, 0, 1);
+
+struct isr_arg {
+	k_tid_t thread;
+	int     prio;
+};
+
+static struct isr_arg prio_args;
+
+/**
+ * @brief Test ISR used to change a thread's priority
+ */
+static void test_isr(const void *arg)
+{
+	const struct isr_arg *data = arg;
+
+	k_thread_priority_set(data->thread, data->prio);
+}
 
 /**
  *
@@ -103,4 +122,80 @@ ZTEST(threads_lifecycle, test_threads_priority_set)
 	zassert_equal(thread2_data, thread2_prio,
 		      "Expected priority to be changed to %d, not %d\n",
 		      thread2_prio, thread2_data);
+
+	k_thread_join(thread2_id, K_FOREVER);
+}
+
+/**
+ * @ingroup kernel_thread_tests
+ * @brief Test the k_thread_priority_set() API from an ISR
+ *
+ * @see k_thread_priority_set(), k_thread_priority_get()
+ */
+ZTEST(threads_lifecycle, test_isr_threads_priority_set_)
+{
+	int rv;
+	int prio = k_thread_priority_get(k_current_get());
+
+	/* Lower the priority of the current thread (thread1) */
+	prio_args.thread = k_current_get();
+	prio_args.prio = prio + 2;
+	irq_offload(test_isr, &prio_args);
+	rv = k_thread_priority_get(k_current_get());
+	zassert_equal(rv, prio + 2,
+		      "Expected priority to be changed to %d, not %d\n",
+		      prio + 2, rv);
+
+	/* Raise the priority of the current thread (thread1) */
+	prio_args.prio = prio - 2;
+	irq_offload(test_isr, &prio_args);
+	rv = k_thread_priority_get(k_current_get());
+	zassert_equal(rv, prio - 2,
+		      "Expected priority to be changed to %d, not %d\n",
+		      prio - 2, rv);
+
+	/* Restore the priority of the current thread (thread1) */
+	prio_args.prio = prio;
+	irq_offload(test_isr, &prio_args);
+	rv = k_thread_priority_get(k_current_get());
+	zassert_equal(rv, prio,
+		      "Expected priority to be changed to %d, not %d\n",
+		      prio, rv);
+
+	/* create thread with lower priority */
+	int thread2_prio = prio + 1;
+
+	k_tid_t thread2_id = k_thread_create(&tdata, tstack, STACK_SIZE,
+					     thread2_set_prio_test,
+					     NULL, NULL, NULL, thread2_prio, 0,
+					     K_NO_WAIT);
+
+	/* Lower the priority of thread2 */
+	prio_args.thread = thread2_id;
+	prio_args.prio = thread2_prio + 2;
+	irq_offload(test_isr, &prio_args);
+	k_sem_give(&sem_thread2);
+	k_sem_take(&sem_thread1, K_FOREVER);
+	zassert_equal(thread2_data, thread2_prio + 2,
+		      "Expected priority to be changed to %d, not %d\n",
+		      thread2_prio + 2, thread2_data);
+
+	/* Raise the priority of thread2 */
+	prio_args.prio = thread2_prio - 2;
+	irq_offload(test_isr, &prio_args);
+	k_sem_give(&sem_thread2);
+	k_sem_take(&sem_thread1, K_FOREVER);
+	zassert_equal(thread2_data, thread2_prio - 2,
+		      "Expected priority to be changed to %d, not %d\n",
+		      thread2_prio - 2, thread2_data);
+
+	/* Restore the priority of thread2 */
+	prio_args.prio = thread2_prio;
+	irq_offload(test_isr, &prio_args);
+	k_sem_give(&sem_thread2);
+	k_sem_take(&sem_thread1, K_FOREVER);
+	zassert_equal(thread2_data, thread2_prio,
+		      "Expected priority to be changed to %d, not %d\n",
+		      thread2_prio, thread2_data);
+	k_thread_join(thread2_id, K_FOREVER);
 }


### PR DESCRIPTION
This removes the ISR restriction from k_thread_priority_set(). This is a restriction that has been there since the first commit. However, unless I have missed / forgotten something, I have been unable to determine a technical reason why this was the case. As such, I am proposing removing that restriction.