### PR TITLE
dts: bindings: nordic: Require pinctrl-names together with pinctrl-0

### DIFF
--- a/dts/bindings/audio/nordic,nrf-pdm.yaml
+++ b/dts/bindings/audio/nordic,nrf-pdm.yaml
@@ -17,6 +17,9 @@ properties:
   pinctrl-0:
     required: true
 
+  pinctrl-names:
+    required: true
+
   clock-source:
     type: string
     default: "PCLK32M_HFXO"

--- a/dts/bindings/can/nordic,nrf-can.yaml
+++ b/dts/bindings/can/nordic,nrf-can.yaml
@@ -19,3 +19,6 @@ properties:
 
   pinctrl-0:
     required: true
+
+  pinctrl-names:
+    required: true

--- a/dts/bindings/flash_controller/nordic,nrf-qspi.yaml
+++ b/dts/bindings/flash_controller/nordic,nrf-qspi.yaml
@@ -39,3 +39,6 @@ properties:
 
   pinctrl-0:
     required: true
+
+  pinctrl-names:
+    required: true

--- a/dts/bindings/i2c/nordic,nrf-twi-common.yaml
+++ b/dts/bindings/i2c/nordic,nrf-twi-common.yaml
@@ -16,6 +16,9 @@ properties:
   pinctrl-0:
     required: true
 
+  pinctrl-names:
+    required: true
+
   easydma-maxcnt-bits:
     type: int
     required: true

--- a/dts/bindings/i2s/nordic,nrf-i2s.yaml
+++ b/dts/bindings/i2s/nordic,nrf-i2s.yaml
@@ -17,6 +17,9 @@ properties:
   pinctrl-0:
     required: true
 
+  pinctrl-names:
+    required: true
+
   clock-source:
     type: string
     default: "PCLK32M_HFXO"

--- a/dts/bindings/pwm/nordic,nrf-pwm.yaml
+++ b/dts/bindings/pwm/nordic,nrf-pwm.yaml
@@ -11,6 +11,9 @@ properties:
   pinctrl-0:
     required: true
 
+  pinctrl-names:
+    required: true
+
   center-aligned:
     type: boolean
     description: Set this to use center-aligned (up and down) counter mode.

--- a/dts/bindings/sensor/nordic,nrf-qdec.yaml
+++ b/dts/bindings/sensor/nordic,nrf-qdec.yaml
@@ -17,6 +17,9 @@ properties:
   pinctrl-0:
     required: true
 
+  pinctrl-names:
+    required: true
+
   enable-pin:
     type: int
     description: |

--- a/dts/bindings/serial/nordic,nrf-uart-common.yaml
+++ b/dts/bindings/serial/nordic,nrf-uart-common.yaml
@@ -10,6 +10,9 @@ properties:
   pinctrl-0:
     required: true
 
+  pinctrl-names:
+    required: true
+
   disable-rx:
     type: boolean
     description: |

--- a/dts/bindings/spi/nordic,nrf-spi-common.yaml
+++ b/dts/bindings/spi/nordic,nrf-spi-common.yaml
@@ -15,6 +15,9 @@ properties:
   pinctrl-0:
     required: true
 
+  pinctrl-names:
+    required: true
+
   max-frequency:
     type: int
     required: true


### PR DESCRIPTION
... so that a clear devicetree error is reported when the pinctrl-names property is missing, not a quite cryptic compilation error about an undeclared PINCTRL_STATE_*_UPPER_TOKEN symbol in pinctrl.h.