### PR TITLE
tests: counter: counter_basic_api: Added testcase wihtout alarms

### DIFF
--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -138,7 +138,6 @@ static const struct device *const period_devs[] = {
 };
 
 typedef void (*counter_test_func_t)(const struct device *dev);
-
 typedef bool (*counter_capability_func_t)(const struct device *dev);
 
 static inline uint32_t get_counter_period_us(const struct device *dev)
@@ -678,6 +677,95 @@ ZTEST(counter_basic, test_all_channels)
 {
 	test_all_instances(test_all_channels_instance,
 			   single_channel_alarm_capable);
+}
+
+static void test_valid_function_without_alarm(const struct device *dev)
+{
+	int err;
+	uint32_t ticks;
+	uint32_t ticks_expected;
+	uint32_t ticks_tol;
+	uint32_t wait_for_us;
+	uint32_t freq = counter_get_frequency(dev);
+
+	/* For timers which cannot count to at least 2 ms before overflow
+	 * the test is skipped by test_all_instances function because sufficient
+	 * accuracy of the test cannot be achieved.
+	 */
+
+	zassert_true(freq != 0, "%s: counter could not get frequency", dev->name);
+
+	/* Set time of counting based on counter frequency to
+	 * ensure convenient run time and accuracy of the test.
+	 */
+	if (freq < 1000) {
+		/* Ensure to have 1 tick for 1 sec clock */
+		wait_for_us = 1100000;
+		ticks_expected = counter_us_to_ticks(dev, wait_for_us);
+	} else if (freq < 1000000) {
+		/* Calculate wait time for convenient ticks count */
+		ticks_expected = 1000;
+		wait_for_us = (ticks_expected * 1000000) / freq;
+	} else {
+		/* Wait long enough for high frequency clocks to minimize
+		 * impact of latencies and k_busy_wait function accuracy.
+		 */
+		wait_for_us = 1000;
+		ticks_expected = counter_us_to_ticks(dev, wait_for_us);
+	}
+
+	/* Set 10% or 2 ticks tolerance, whichever is greater */
+	ticks_tol = ticks_expected / 10;
+	ticks_tol = ticks_tol < 2 ? 2 : ticks_tol;
+
+	if (!counter_is_counting_up(dev)) {
+		ticks_expected = counter_get_top_value(dev) - ticks_expected;
+	}
+
+	err = counter_start(dev);
+	zassert_equal(0, err, "%s: counter failed to start", dev->name);
+
+	k_busy_wait(wait_for_us);
+
+	err = counter_get_value(dev, &ticks);
+
+	zassert_equal(0, err, "%s: could not get counter value", dev->name);
+	zassert_between_inclusive(
+		ticks, ticks_expected > ticks_tol ? ticks_expected - ticks_tol : 0,
+		ticks_expected + ticks_tol, "%s: counter ticks not in tolerance", dev->name);
+
+	/* ticks count is always within ticks_tol for RTC, therefor
+	 * check, if ticks are greater than 0.
+	 */
+	zassert_true((ticks > 0), "%s: counter did not count", dev->name);
+
+	err = counter_stop(dev);
+	zassert_equal(0, err, "%s: counter failed to stop", dev->name);
+}
+
+static bool ms_period_capable(const struct device *dev)
+{
+	uint32_t freq_khz;
+	uint32_t max_time_ms;
+
+	/* Assume 2 ms counter periode can be set for frequency below 1 kHz*/
+	if (counter_get_frequency(dev) < 1000) {
+		return true;
+	}
+
+	freq_khz = counter_get_frequency(dev) / 1000;
+	max_time_ms = counter_get_top_value(dev) / freq_khz;
+
+	if (max_time_ms >= 2) {
+		return true;
+	}
+
+	return false;
+}
+
+ZTEST(counter_basic, test_valid_function_without_alarm)
+{
+	test_all_instances(test_valid_function_without_alarm, ms_period_capable);
 }
 
 /**


### PR DESCRIPTION
Some counter drivers do not support alarms, so I added testcase which starts the counter, checks if the value is in range after certain time and stops the counter, to check if the counter is running correctly.