### PR TITLE
modem: ubx: fix incoming byte processing

### DIFF
--- a/drivers/gnss/gnss_u_blox_m10.c
+++ b/drivers/gnss/gnss_u_blox_m10.c
@@ -752,6 +752,11 @@ static int ubx_m10_set_enabled_systems(const struct device *dev, gnss_systems_t 
 	/* Prepare payload (payload) for sending CFG-GNSS for enabling the gnss systems. */
 	payload = malloc(sizeof(*payload) +
 		sizeof(struct ubx_cfg_gnss_payload_config_block) * UBX_M10_GNSS_SUPP_SYS_CNT);
+	if (!payload) {
+		ret = -ENOMEM;
+		goto unlock;
+	}
+
 	payload->num_config_blocks = UBX_M10_GNSS_SUPP_SYS_CNT;
 
 	ubx_cfg_gnss_payload_default(payload);

--- a/drivers/gnss/gnss_u_blox_m10.c
+++ b/drivers/gnss/gnss_u_blox_m10.c
@@ -734,7 +734,6 @@ static int ubx_m10_set_enabled_systems(const struct device *dev, gnss_systems_t 
 	for (int i = 0; i < payload->num_config_blocks; ++i) {
 		ret = ubx_m10_ubx_gnss_id_to_gnss_system(dev, payload->config_blocks[i].gnss_id);
 		if (ret < 0) {
-			ret = -EINVAL;
 			goto unlock;
 		}
 

--- a/subsys/modem/modem_ubx.c
+++ b/subsys/modem/modem_ubx.c
@@ -269,7 +269,9 @@ static void modem_ubx_process_handler(struct k_work *item)
 		return;
 	}
 
-	for (int i = 0; i < ret; i++) {
+	const size_t length = ret;
+
+	for (int i = 0; i < length; i++) {
 		ret = modem_ubx_process_received_byte(ubx, ubx->receive_buf[i]);
 		if (ret == 0) { /* Frame matched successfully. Terminate the script. */
 			break;


### PR DESCRIPTION
`ret` holds the amount of bytes received from the modem. However during processing of the bytes its value is overwritten by the return value of `modem_ubx_process_received_byte`, in practice discarding all but the first byte read.

To prevent this, store the length in a separate variable.

Handle malloc returning NULL pointer, set err and return from function.
