### PR TITLE
maintainers: Fixes for Renesas RA Platforms

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3686,7 +3686,7 @@ Renesas RA Platforms:
     - dts/bindings/*/*renesas,ra*
     - soc/renesas/ra/
   labels:
-    - "platforms: Renesas RA"
+    - "platform: Renesas RA"
   description: >-
     Renesas RA SOCs, dts files, and related drivers. Boards based
     on Renesas RA SoCs.

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3679,6 +3679,7 @@ Renesas RA Platforms:
     - thaoluonguw
   files:
     - boards/arduino/uno_r4/
+    - boards/renesas/*ra8*/
     - drivers/*/*renesas_ra*
     - drivers/pinctrl/renesas/ra/
     - dts/arm/renesas/ra/


### PR DESCRIPTION
Fix label for Renesas RA Platforms and add boards' files.