### PR TITLE
soc: nxp: s32: fix siul2 instance for input pinmuxing

### DIFF
--- a/include/zephyr/dt-bindings/pinctrl/nxp-s32-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/nxp-s32-pinctrl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 NXP
+ * Copyright 2022, 2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -16,19 +16,22 @@
  * - 3..6:   Input mux Source Signal Selection (IMCR.SSS)
  * - 7..15:  Input Multiplexed Signal Configuration Register (IMCR) index
  * - 16..24: Multiplexed Signal Configuration Register (MSCR) index
- * - 25..27: SIUL2 instance index (0..7)
- * - 28..31: Reserved for future use
+ * - 25..27: MSCR SIUL2 instance index (0..7)
+ * - 28..30: IMCR SIUL2 instance index (0..7)
+ * - 31:     Reserved for future use
  */
-#define NXP_S32_MSCR_SSS_SHIFT	0U
-#define NXP_S32_MSCR_SSS_MASK	BIT_MASK(3)
-#define NXP_S32_IMCR_SSS_SHIFT	3U
-#define NXP_S32_IMCR_SSS_MASK	BIT_MASK(4)
-#define NXP_S32_IMCR_IDX_SHIFT	7U
-#define NXP_S32_IMCR_IDX_MASK	BIT_MASK(9)
-#define NXP_S32_MSCR_IDX_SHIFT	16U
-#define NXP_S32_MSCR_IDX_MASK	BIT_MASK(9)
-#define NXP_S32_SIUL2_IDX_SHIFT	25U
-#define NXP_S32_SIUL2_IDX_MASK	BIT_MASK(3)
+#define NXP_S32_MSCR_SSS_SHIFT       0U
+#define NXP_S32_MSCR_SSS_MASK        BIT_MASK(3)
+#define NXP_S32_IMCR_SSS_SHIFT       3U
+#define NXP_S32_IMCR_SSS_MASK        BIT_MASK(4)
+#define NXP_S32_IMCR_IDX_SHIFT       7U
+#define NXP_S32_IMCR_IDX_MASK        BIT_MASK(9)
+#define NXP_S32_MSCR_IDX_SHIFT       16U
+#define NXP_S32_MSCR_IDX_MASK        BIT_MASK(9)
+#define NXP_S32_MSCR_SIUL2_IDX_SHIFT 25U
+#define NXP_S32_MSCR_SIUL2_IDX_MASK  BIT_MASK(3)
+#define NXP_S32_IMCR_SIUL2_IDX_SHIFT 28U
+#define NXP_S32_IMCR_SIUL2_IDX_MASK  BIT_MASK(3)
 
 #define NXP_S32_PINMUX_MSCR_SSS(cfg)	\
 	(((cfg) & NXP_S32_MSCR_SSS_MASK) << NXP_S32_MSCR_SSS_SHIFT)
@@ -42,8 +45,11 @@
 #define NXP_S32_PINMUX_MSCR_IDX(cfg)	\
 	(((cfg) & NXP_S32_MSCR_IDX_MASK) << NXP_S32_MSCR_IDX_SHIFT)
 
-#define NXP_S32_PINMUX_SIUL2_IDX(cfg)	\
-	(((cfg) & NXP_S32_SIUL2_IDX_MASK) << NXP_S32_SIUL2_IDX_SHIFT)
+#define NXP_S32_PINMUX_MSCR_SIUL2_IDX(cfg)	\
+	(((cfg) & NXP_S32_MSCR_SIUL2_IDX_MASK) << NXP_S32_MSCR_SIUL2_IDX_SHIFT)
+
+#define NXP_S32_PINMUX_IMCR_SIUL2_IDX(cfg)	\
+	(((cfg) & NXP_S32_IMCR_SIUL2_IDX_MASK) << NXP_S32_IMCR_SIUL2_IDX_SHIFT)
 
 #define NXP_S32_PINMUX_GET_MSCR_SSS(cfg)	\
 	(((cfg) >> NXP_S32_MSCR_SSS_SHIFT) & NXP_S32_MSCR_SSS_MASK)
@@ -57,21 +63,28 @@
 #define NXP_S32_PINMUX_GET_MSCR_IDX(cfg)	\
 	(((cfg) >> NXP_S32_MSCR_IDX_SHIFT) & NXP_S32_MSCR_IDX_MASK)
 
-#define NXP_S32_PINMUX_GET_SIUL2_IDX(cfg)	\
-	(((cfg) >> NXP_S32_SIUL2_IDX_SHIFT) & NXP_S32_SIUL2_IDX_MASK)
+#define NXP_S32_PINMUX_GET_MSCR_SIUL2_IDX(cfg)	\
+	(((cfg) >> NXP_S32_MSCR_SIUL2_IDX_SHIFT) & NXP_S32_MSCR_SIUL2_IDX_MASK)
+
+#define NXP_S32_PINMUX_GET_IMCR_SIUL2_IDX(cfg)	\
+	(((cfg) >> NXP_S32_IMCR_SIUL2_IDX_SHIFT) & NXP_S32_IMCR_SIUL2_IDX_MASK)
 
 /**
  * @brief Utility macro to build NXP S32 pinmux property for pinctrl nodes.
  *
- * @param siul2_idx SIUL2 instance index
+ * @param mscr_siul2_idx MSCR SIUL2 instance index
+ * @param imcr_siul2_idx IMCR SIUL2 instance index
  * @param mscr_idx Multiplexed Signal Configuration Register (MSCR) index
  * @param mscr_sss Output mux Source Signal Selection (MSCR.SSS)
  * @param imcr_idx Input Multiplexed Signal Configuration Register (IMCR) index
  * @param imcr_sss Input mux Source Signal Selection (IMCR.SSS)
  */
-#define NXP_S32_PINMUX(siul2_idx, mscr_idx, mscr_sss, imcr_idx, imcr_sss)		\
-	(NXP_S32_PINMUX_SIUL2_IDX(siul2_idx) | NXP_S32_PINMUX_MSCR_IDX(mscr_idx)	\
-	 | NXP_S32_PINMUX_MSCR_SSS(mscr_sss) | NXP_S32_PINMUX_IMCR_IDX(imcr_idx)	\
-	 | NXP_S32_PINMUX_IMCR_SSS(imcr_sss))
+#define NXP_S32_PINMUX(mscr_siul2_idx, imcr_siul2_idx, mscr_idx, mscr_sss, imcr_idx, imcr_sss)     \
+	(NXP_S32_PINMUX_MSCR_SIUL2_IDX(mscr_siul2_idx) |                                           \
+	 NXP_S32_PINMUX_IMCR_SIUL2_IDX(imcr_siul2_idx) |                                           \
+	 NXP_S32_PINMUX_MSCR_IDX(mscr_idx) |                                                       \
+	 NXP_S32_PINMUX_MSCR_SSS(mscr_sss) |                                                       \
+	 NXP_S32_PINMUX_IMCR_IDX(imcr_idx) |                                                       \
+	 NXP_S32_PINMUX_IMCR_SSS(imcr_sss))
 
 #endif	/* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_NXP_NXP_S32_PINCTRL_H_ */

--- a/soc/nxp/s32/s32k3/pinctrl_soc.h
+++ b/soc/nxp/s32/s32k3/pinctrl_soc.h
@@ -41,7 +41,7 @@
 
 #define NXP_S32_PINMUX_INIT(group, value)                                                          \
 	.mscr = {                                                                                  \
-		.inst = NXP_S32_PINMUX_GET_SIUL2_IDX(value),                                       \
+		.inst = NXP_S32_PINMUX_GET_MSCR_SIUL2_IDX(value),                                  \
 		.idx = NXP_S32_PINMUX_GET_MSCR_IDX(value),                                         \
 		.val = SIUL2_MSCR_SSS(NXP_S32_PINMUX_GET_MSCR_SSS(value)) |                        \
 		       SIUL2_MSCR_OBE(DT_PROP(group, output_enable)) |                             \
@@ -54,7 +54,7 @@
 		       SIUL2_MSCR_INV(DT_PROP(group, nxp_invert))                                  \
 	},                                                                                         \
 	.imcr = {                                                                                  \
-		.inst = NXP_S32_PINMUX_GET_SIUL2_IDX(value),                                       \
+		.inst = NXP_S32_PINMUX_GET_IMCR_SIUL2_IDX(value),                                  \
 		.idx = NXP_S32_PINMUX_GET_IMCR_IDX(value),                                         \
 		.val = SIUL2_IMCR_SSS(NXP_S32_PINMUX_GET_IMCR_SSS(value)),                         \
 	}

--- a/soc/nxp/s32/s32ze/pinctrl_soc.h
+++ b/soc/nxp/s32/s32ze/pinctrl_soc.h
@@ -43,7 +43,7 @@
 
 #define NXP_S32_PINMUX_INIT(group, value)                                                          \
 	.mscr = {                                                                                  \
-		.inst = NXP_S32_PINMUX_GET_SIUL2_IDX(value),                                       \
+		.inst = NXP_S32_PINMUX_GET_MSCR_SIUL2_IDX(value),                                  \
 		.idx = NXP_S32_PINMUX_GET_MSCR_IDX(value),                                         \
 		.val = SIUL2_MSCR_SSS(NXP_S32_PINMUX_GET_MSCR_SSS(value)) |                        \
 		       SIUL2_MSCR_OBE(DT_PROP(group, output_enable)) |                             \
@@ -56,7 +56,7 @@
 				      DT_PROP(group, output_enable))                               \
 	},                                                                                         \
 	.imcr = {                                                                                  \
-		.inst = NXP_S32_PINMUX_GET_SIUL2_IDX(value),                                       \
+		.inst = NXP_S32_PINMUX_GET_IMCR_SIUL2_IDX(value),                                  \
 		.idx = NXP_S32_PINMUX_GET_IMCR_IDX(value),                                         \
 		.val = SIUL2_IMCR_SSS(NXP_S32_PINMUX_GET_IMCR_SSS(value)),                         \
 	}

--- a/west.yml
+++ b/west.yml
@@ -198,7 +198,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 272f84ca60afc759d81ed94100e78b37a859d3ff
+      revision: 343395b08fa5151246e147f5e6a523c7d6bdc724
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Split SIUL2 instance index for the MSCR and IMCR registers as required by some pins. Pinmux macros definitions in hal_nxp must be updated accordingly.

Fixes #76147