### PR TITLE
docs: settings: clarify conditions for csi_save_start and csi_save_end

### DIFF
--- a/doc/services/settings/index.rst
+++ b/doc/services/settings/index.rst
@@ -72,11 +72,11 @@ backend.
 
 **csi_save_start**
     This gets called when starting a save of all current settings using
-    :c:func:`settings_save()`.
+    :c:func:`settings_save()` or :c:func:`settings_save_subtree()`.
 
 **csi_save_end**
     This gets called after having saved of all current settings using
-    :c:func:`settings_save()`.
+    :c:func:`settings_save()` or :c:func:`settings_save_subtree()`.
 
 Zephyr Storage Backends
 ***********************


### PR DESCRIPTION
Clarify that the actual calls to these backend functions are made from `settings_save_subtree()`, which is called by `settings_save()` or can be used directly.