### PR TITLE
bluetooth: Add host support for LE Connection Subrating feature

### DIFF
--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -196,6 +196,57 @@ struct bt_conn_le_data_len_param {
 	BT_CONN_LE_DATA_LEN_PARAM(BT_GAP_DATA_LEN_MAX, \
 				  BT_GAP_DATA_TIME_MAX)
 
+/** Connection subrating parameters for LE connections */
+struct bt_conn_le_subrate_param {
+	/** Minimum subrate factor. */
+	uint16_t subrate_min;
+	/** Maximum subrate factor. */
+	uint16_t subrate_max;
+	/** Maximum Peripheral latency in units of subrated connection intervals. */
+	uint16_t max_latency;
+	/** Minimum number of underlying connection events to remain active
+	 *  after a packet containing a Link Layer PDU with a non-zero Length
+	 *  field is sent or received.
+	 */
+	uint16_t continuation_number;
+	/** Connection Supervision timeout (N * 10 ms).
+	 *  If using @ref bt_conn_le_subrate_set_defaults, this is the
+	 *  maximum supervision timeout allowed in requests by a peripheral.
+	 */
+	uint16_t supervision_timeout;
+};
+
+/** Subrating information for LE connections */
+struct bt_conn_le_subrating_info {
+	/** Connection subrate factor. */
+	uint16_t factor;
+	/** Number of underlying connection events to remain active after
+	 *  a packet containing a Link Layer PDU with a non-zero Length
+	 *  field is sent or received.
+	 */
+	uint16_t continuation_number;
+};
+
+/** Updated subrating connection parameters for LE connections */
+struct bt_conn_le_subrate_changed {
+	/** HCI Status from LE Subrate Changed event.
+	 *  The remaining parameters will be unchanged if status is not
+	 *  BT_HCI_ERR_SUCCESS.
+	 */
+	uint8_t status;
+	/** Connection subrate factor. */
+	uint16_t factor;
+	/** Number of underlying connection events to remain active after
+	 *  a packet containing a Link Layer PDU with a non-zero Length
+	 *  field is sent or received.
+	 */
+	uint16_t continuation_number;
+	/** Peripheral latency in units of subrated connection intervals. */
+	uint16_t peripheral_latency;
+	/** Connection Supervision timeout (N * 10 ms). */
+	uint16_t supervision_timeout;
+};
+
 /** Connection Type */
 enum __packed bt_conn_type {
 	/** LE Connection Type */
@@ -310,6 +361,11 @@ struct bt_conn_le_info {
 	/* Connection maximum single fragment parameters */
 	const struct bt_conn_le_data_len_info *data_len;
 #endif /* defined(CONFIG_BT_USER_DATA_LEN_UPDATE) */
+
+#if defined(CONFIG_BT_SUBRATING)
+	/* Connection subrating parameters */
+	const struct bt_conn_le_subrating_info *subrate;
+#endif /* defined(CONFIG_BT_SUBRATING) */
 };
 
 /** @brief Convert connection interval to milliseconds
@@ -675,6 +731,36 @@ int bt_conn_le_set_path_loss_mon_param(struct bt_conn *conn,
  * @return Zero on success or (negative) error code on failure.
  */
 int bt_conn_le_set_path_loss_mon_enable(struct bt_conn *conn, bool enable);
+
+/** @brief Set Default Connection Subrating Parameters.
+ *
+ *  Change the default subrating parameters for all future
+ *  ACL connections where the local device is the central.
+ *  This command does not affect any existing connection.
+ *  Parameters set for specific connection will always have precedence.
+ *
+ *  @note To use this API @kconfig{CONFIG_BT_SUBRATING} and
+ *        @kconfig{CONFIG_BT_CENTRAL} must be set.
+ *
+ *  @param params Subrating parameters.
+ *
+ *  @return Zero on success or (negative) error code on failure.
+ */
+int bt_conn_le_subrate_set_defaults(const struct bt_conn_le_subrate_param *params);
+
+/** @brief Request New Subrating Parameters.
+ *
+ *  Request a change to the subrating parameters of a connection.
+ *
+ *  @note To use this API @kconfig{CONFIG_BT_SUBRATING} must be set.
+ *
+ *  @param conn   Connection object.
+ *  @param params Subrating parameters.
+ *
+ *  @return Zero on success or (negative) error code on failure.
+ */
+int bt_conn_le_subrate_request(struct bt_conn *conn,
+			       const struct bt_conn_le_subrate_param *params);
 
 /** @brief Update the connection parameters.
  *
@@ -1243,6 +1329,21 @@ struct bt_conn_cb {
 	void (*path_loss_threshold_report)(struct bt_conn *conn,
 				const struct bt_conn_le_path_loss_threshold_report *report);
 #endif /* CONFIG_BT_PATH_LOSS_MONITORING */
+
+#if defined(CONFIG_BT_SUBRATING)
+	/** @brief LE Subrate Changed event.
+	 *
+	 *  This callback notifies the application that the subrating parameters
+	 *  of the connection may have changed.
+	 *  The connection subrating parameters will be unchanged
+	 *  if status is not BT_HCI_ERR_SUCCESS.
+	 *
+	 *  @param conn   Connection object.
+	 *  @param params New subrating parameters.
+	 */
+	void (*subrate_changed)(struct bt_conn *conn,
+				const struct bt_conn_le_subrate_changed *params);
+#endif /* CONFIG_BT_SUBRATING */
 
 	/** @internal Internally used field for list handling */
 	sys_snode_t _node;

--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -704,6 +704,26 @@ struct bt_hci_cp_le_set_path_loss_reporting_enable {
 #define BT_HCI_LE_PATH_LOSS_REPORTING_ENABLE        0x01
 #define BT_HCI_OP_LE_SET_PATH_LOSS_REPORTING_ENABLE BT_OP(BT_OGF_LE, 0x0079) /* 0x2079 */
 
+struct bt_hci_cp_le_set_default_subrate {
+	uint16_t subrate_min;
+	uint16_t subrate_max;
+	uint16_t max_latency;
+	uint16_t continuation_number;
+	uint16_t supervision_timeout;
+} __packed;
+
+struct bt_hci_cp_le_subrate_request {
+	uint16_t handle;
+	uint16_t subrate_min;
+	uint16_t subrate_max;
+	uint16_t max_latency;
+	uint16_t continuation_number;
+	uint16_t supervision_timeout;
+} __packed;
+
+#define BT_HCI_OP_LE_SET_DEFAULT_SUBRATE BT_OP(BT_OGF_LE, 0x007D) /* 0x207D */
+#define BT_HCI_OP_LE_SUBRATE_REQUEST     BT_OP(BT_OGF_LE, 0x007E) /* 0x207E */
+
 #define BT_HCI_CTL_TO_HOST_FLOW_DISABLE         0x00
 #define BT_HCI_CTL_TO_HOST_FLOW_ENABLE          0x01
 #define BT_HCI_OP_SET_CTL_TO_HOST_FLOW          BT_OP(BT_OGF_BASEBAND, 0x0031) /* 0x0c31 */
@@ -3098,6 +3118,16 @@ struct bt_hci_evt_le_biginfo_adv_report {
 	uint8_t  encryption;
 } __packed;
 
+#define BT_HCI_EVT_LE_SUBRATE_CHANGE            0x23
+struct bt_hci_evt_le_subrate_change {
+	uint8_t status;
+	uint16_t handle;
+	uint16_t subrate_factor;
+	uint16_t peripheral_latency;
+	uint16_t continuation_number;
+	uint16_t supervision_timeout;
+} __packed;
+
 /* Event mask bits */
 
 #define BT_EVT_BIT(n) (1ULL << (n))
@@ -3178,6 +3208,7 @@ struct bt_hci_evt_le_biginfo_adv_report {
 #define BT_EVT_MASK_LE_PATH_LOSS_THRESHOLD       BT_EVT_BIT(31)
 #define BT_EVT_MASK_LE_TRANSMIT_POWER_REPORTING  BT_EVT_BIT(32)
 #define BT_EVT_MASK_LE_BIGINFO_ADV_REPORT        BT_EVT_BIT(33)
+#define BT_EVT_MASK_LE_SUBRATE_CHANGE            BT_EVT_BIT(34)
 
 #define BT_EVT_MASK_LE_PER_ADV_SYNC_ESTABLISHED_V2 BT_EVT_BIT(35)
 #define BT_EVT_MASK_LE_PER_ADVERTISING_REPORT_V2   BT_EVT_BIT(36)

--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -181,6 +181,14 @@ config BT_PATH_LOSS_MONITORING
 	  Enable support for LE Path Loss Monitoring feature that is defined in the
 	  Bluetooth Core specification, Version 5.4 | Vol 6, Part B, Section 4.6.32.
 
+config BT_SUBRATING
+	bool "LE Connection Subrating [EXPERIMENTAL]"
+	select EXPERIMENTAL
+	depends on !BT_CTLR || BT_CTLR_SUBRATING_SUPPORT
+	help
+	  Enable support for LE Connection Subrating feature that is defined in the
+	  Bluetooth Core specification, Version 5.4 | Vol 6, Part B, Section 4.6.35.
+
 endif # BT_CONN
 
 rsource "Kconfig.iso"

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -1032,6 +1032,7 @@ config BT_CTLR_SUBRATING
 	bool "LE Connection Subrating"
 	depends on BT_CTLR_SUBRATING_SUPPORT
 	select BT_CTLR_SET_HOST_FEATURE
+	default y if BT_SUBRATING
 	help
 	  Enable support for Bluetooth v5.3 LE Connection Subrating
 	  in the Controller.

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2754,6 +2754,9 @@ int bt_conn_get_info(const struct bt_conn *conn, struct bt_conn_info *info)
 #if defined(CONFIG_BT_USER_DATA_LEN_UPDATE)
 		info->le.data_len = &conn->le.data_len;
 #endif
+#if defined(CONFIG_BT_SUBRATING)
+		info->le.subrate = &conn->le.subrate;
+#endif
 		if (conn->le.keys && (conn->le.keys->flags & BT_KEYS_SC)) {
 			info->security.flags |= BT_SECURITY_FLAG_SC;
 		}
@@ -3037,6 +3040,109 @@ int bt_conn_le_set_path_loss_mon_enable(struct bt_conn *conn, bool reporting_ena
 	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_SET_PATH_LOSS_REPORTING_ENABLE, buf, NULL);
 }
 #endif /* CONFIG_BT_PATH_LOSS_MONITORING */
+
+#if defined(CONFIG_BT_SUBRATING)
+void notify_subrate_change(struct bt_conn *conn,
+			   const struct bt_conn_le_subrate_changed params)
+{
+	struct bt_conn_cb *callback;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&conn_cbs, callback, _node) {
+		if (callback->subrate_changed) {
+			callback->subrate_changed(conn, &params);
+		}
+	}
+
+	STRUCT_SECTION_FOREACH(bt_conn_cb, cb)
+	{
+		if (cb->subrate_changed) {
+			cb->subrate_changed(conn, &params);
+		}
+	}
+}
+
+static bool le_subrate_common_params_valid(const struct bt_conn_le_subrate_param *param)
+{
+	/* All limits according to BT Core spec 5.4 [Vol 4, Part E, 7.8.123] */
+
+	if (param->subrate_min < 0x0001 || param->subrate_min > 0x01F4 ||
+	    param->subrate_max < 0x0001 || param->subrate_max > 0x01F4 ||
+	    param->subrate_min > param->subrate_max) {
+		return false;
+	}
+
+	if (param->max_latency > 0x01F3 ||
+	    param->subrate_max * (param->max_latency + 1) > 500) {
+		return false;
+	}
+
+	if (param->continuation_number > 0x01F3 ||
+	    param->continuation_number >= param->subrate_max) {
+		return false;
+	}
+
+	if (param->supervision_timeout < 0x000A ||
+	    param->supervision_timeout > 0xC80) {
+		return false;
+	}
+
+	return true;
+}
+
+int bt_conn_le_subrate_set_defaults(const struct bt_conn_le_subrate_param *params)
+{
+	struct bt_hci_cp_le_set_default_subrate *cp;
+	struct net_buf *buf;
+
+	if (!IS_ENABLED(CONFIG_BT_CENTRAL)) {
+		return -ENOTSUP;
+	}
+
+	if (!le_subrate_common_params_valid(params)) {
+		return -EINVAL;
+	}
+
+	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_DEFAULT_SUBRATE, sizeof(*cp));
+	if (!buf) {
+		return -ENOBUFS;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+	cp->subrate_min = sys_cpu_to_le16(params->subrate_min);
+	cp->subrate_max = sys_cpu_to_le16(params->subrate_max);
+	cp->max_latency = sys_cpu_to_le16(params->max_latency);
+	cp->continuation_number = sys_cpu_to_le16(params->continuation_number);
+	cp->supervision_timeout = sys_cpu_to_le16(params->supervision_timeout);
+
+	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_SET_DEFAULT_SUBRATE, buf, NULL);
+}
+
+int bt_conn_le_subrate_request(struct bt_conn *conn,
+			       const struct bt_conn_le_subrate_param *params)
+{
+	struct bt_hci_cp_le_subrate_request *cp;
+	struct net_buf *buf;
+
+	if (!le_subrate_common_params_valid(params)) {
+		return -EINVAL;
+	}
+
+	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SUBRATE_REQUEST, sizeof(*cp));
+	if (!buf) {
+		return -ENOBUFS;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+	cp->handle = sys_cpu_to_le16(conn->handle);
+	cp->subrate_min = sys_cpu_to_le16(params->subrate_min);
+	cp->subrate_max = sys_cpu_to_le16(params->subrate_max);
+	cp->max_latency = sys_cpu_to_le16(params->max_latency);
+	cp->continuation_number = sys_cpu_to_le16(params->continuation_number);
+	cp->supervision_timeout = sys_cpu_to_le16(params->supervision_timeout);
+
+	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_SUBRATE_REQUEST, buf, NULL);
+}
+#endif /* CONFIG_BT_SUBRATING */
 
 int bt_conn_le_param_update(struct bt_conn *conn,
 			    const struct bt_le_conn_param *param)

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -114,6 +114,10 @@ struct bt_conn_le {
 #if defined(CONFIG_BT_USER_DATA_LEN_UPDATE)
 	struct bt_conn_le_data_len_info data_len;
 #endif
+
+#if defined(CONFIG_BT_SUBRATING)
+	struct bt_conn_le_subrating_info subrate;
+#endif
 };
 
 #if defined(CONFIG_BT_CLASSIC)
@@ -478,6 +482,9 @@ void notify_tx_power_report(struct bt_conn *conn,
 
 void notify_path_loss_threshold_report(struct bt_conn *conn,
 				       struct bt_conn_le_path_loss_threshold_report report);
+
+void notify_subrate_change(struct bt_conn *conn,
+			   struct bt_conn_le_subrate_changed params);
 
 #if defined(CONFIG_BT_SMP)
 /* If role specific LTK is present */

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1392,6 +1392,10 @@ static void update_conn(struct bt_conn *conn, const bt_addr_le_t *id_addr,
 	conn->le.data_len.rx_max_len = BT_GAP_DATA_LEN_DEFAULT;
 	conn->le.data_len.rx_max_time = BT_GAP_DATA_TIME_DEFAULT;
 #endif
+#if defined(CONFIG_BT_SUBRATING)
+	conn->le.subrate.factor = 1; /* No subrating. */
+	conn->le.subrate.continuation_number = 0;
+#endif
 }
 
 void bt_hci_le_enh_conn_complete(struct bt_hci_evt_le_enh_conn_complete *evt)
@@ -2663,6 +2667,41 @@ void bt_hci_le_path_loss_threshold_event(struct net_buf *buf)
 }
 #endif /* CONFIG_BT_PATH_LOSS_MONITORING */
 
+#if defined(CONFIG_BT_SUBRATING)
+void bt_hci_le_subrate_change_event(struct net_buf *buf)
+{
+	struct bt_hci_evt_le_subrate_change *evt;
+	struct bt_conn_le_subrate_changed params;
+	struct bt_conn *conn;
+
+	evt = net_buf_pull_mem(buf, sizeof(*evt));
+
+	conn = bt_conn_lookup_handle(sys_le16_to_cpu(evt->handle), BT_CONN_TYPE_LE);
+	if (!conn) {
+		LOG_ERR("Unknown conn handle 0x%04X for subrating event",
+		       sys_le16_to_cpu(evt->handle));
+		return;
+	}
+
+	if (evt->status == BT_HCI_ERR_SUCCESS) {
+		conn->le.subrate.factor = sys_le16_to_cpu(evt->subrate_factor);
+		conn->le.subrate.continuation_number = sys_le16_to_cpu(evt->continuation_number);
+		conn->le.latency = sys_le16_to_cpu(evt->peripheral_latency);
+		conn->le.timeout = sys_le16_to_cpu(evt->supervision_timeout);
+	}
+
+	params.status = evt->status;
+	params.factor = conn->le.subrate.factor;
+	params.continuation_number = conn->le.subrate.continuation_number;
+	params.peripheral_latency = conn->le.latency;
+	params.supervision_timeout = conn->le.timeout;
+
+	notify_subrate_change(conn, params);
+
+	bt_conn_unref(conn);
+}
+#endif /* CONFIG_BT_SUBRATING */
+
 static const struct event_handler vs_events[] = {
 #if defined(CONFIG_BT_DF_VS_CL_IQ_REPORT_16_BITS_IQ_SAMPLES)
 	EVENT_HANDLER(BT_HCI_EVT_VS_LE_CONNECTIONLESS_IQ_REPORT,
@@ -2815,6 +2854,10 @@ static const struct event_handler meta_events[] = {
 #if defined(CONFIG_BT_PATH_LOSS_MONITORING)
 	EVENT_HANDLER(BT_HCI_EVT_LE_PATH_LOSS_THRESHOLD, bt_hci_le_path_loss_threshold_event,
 		      sizeof(struct bt_hci_evt_le_path_loss_threshold)),
+#endif /* CONFIG_BT_PATH_LOSS_MONITORING */
+#if defined(CONFIG_BT_SUBRATING)
+	EVENT_HANDLER(BT_HCI_EVT_LE_SUBRATE_CHANGE, bt_hci_le_subrate_change_event,
+		      sizeof(struct bt_hci_evt_le_subrate_change)),
 #endif /* CONFIG_BT_PATH_LOSS_MONITORING */
 #if defined(CONFIG_BT_PER_ADV_SYNC_RSP)
 	EVENT_HANDLER(BT_HCI_EVT_LE_PER_ADVERTISING_REPORT_V2, bt_hci_le_per_adv_report_v2,
@@ -3334,6 +3377,11 @@ static int le_set_event_mask(void)
 		if (IS_ENABLED(CONFIG_BT_PATH_LOSS_MONITORING)) {
 			mask |= BT_EVT_MASK_LE_PATH_LOSS_THRESHOLD;
 		}
+
+		if (IS_ENABLED(CONFIG_BT_SUBRATING) &&
+		    BT_FEAT_LE_CONN_SUBRATING(bt_dev.le.features)) {
+			mask |= BT_EVT_MASK_LE_SUBRATE_CHANGE;
+		}
 	}
 
 	if (IS_ENABLED(CONFIG_BT_SMP) &&
@@ -3617,6 +3665,15 @@ static int le_init(void)
 		}
 	}
 #endif /* CONFIG_BT_DF */
+
+	if (IS_ENABLED(CONFIG_BT_SUBRATING) &&
+	    BT_FEAT_LE_CONN_SUBRATING(bt_dev.le.features)) {
+		/* Connection Subrating (Host Support) */
+		err = le_set_host_feature(BT_LE_FEAT_BIT_CONN_SUBRATING_HOST_SUPP, 1);
+		if (err) {
+			return err;
+		}
+	}
 
 	return  le_set_event_mask();
 }

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -974,6 +974,27 @@ void path_loss_threshold_report(struct bt_conn *conn,
 }
 #endif
 
+#if defined(CONFIG_BT_SUBRATING)
+void subrate_changed(struct bt_conn *conn,
+		     const struct bt_conn_le_subrate_changed *params)
+{
+	if (params->status == BT_HCI_ERR_SUCCESS) {
+		shell_print(ctx_shell, "Subrate parameters changed: "
+			    "Subrate Factor: %d "
+			    "Continuation Number: %d "
+			    "Peripheral latency: 0x%04x "
+			    "Supervision timeout: 0x%04x (%d ms)",
+			    params->factor,
+			    params->continuation_number,
+			    params->peripheral_latency,
+			    params->supervision_timeout,
+			    params->supervision_timeout * 10);
+	} else {
+		shell_print(ctx_shell, "Subrate change failed (HCI status 0x%02x)", params->status);
+	}
+}
+#endif
+
 static struct bt_conn_cb conn_callbacks = {
 	.connected = connected,
 	.disconnected = disconnected,
@@ -999,6 +1020,9 @@ static struct bt_conn_cb conn_callbacks = {
 #endif
 #if defined(CONFIG_BT_PATH_LOSS_MONITORING)
 	.path_loss_threshold_report = path_loss_threshold_report,
+#endif
+#if defined(CONFIG_BT_SUBRATING)
+	.subrate_changed = subrate_changed,
 #endif
 };
 #endif /* CONFIG_BT_CONN */
@@ -3019,6 +3043,74 @@ static int cmd_set_path_loss_reporting_enable(const struct shell *sh, size_t arg
 }
 #endif
 
+#if defined(CONFIG_BT_SUBRATING)
+static int cmd_subrate_set_defaults(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err = 0;
+
+	for (size_t argn = 1; argn < argc; argn++) {
+		(void)shell_strtoul(argv[argn], 10, &err);
+
+		if (err) {
+			shell_help(sh);
+			shell_error(sh, "Could not parse input number %d", argn);
+			return SHELL_CMD_HELP_PRINTED;
+		}
+	}
+
+	const struct bt_conn_le_subrate_param params = {
+		.subrate_min = shell_strtoul(argv[1], 10, &err),
+		.subrate_max = shell_strtoul(argv[2], 10, &err),
+		.max_latency = shell_strtoul(argv[3], 10, &err),
+		.continuation_number = shell_strtoul(argv[4], 10, &err),
+		.supervision_timeout = shell_strtoul(argv[5], 10, &err) * 100, /* 10ms units */
+	};
+
+	err = bt_conn_le_subrate_set_defaults(&params);
+	if (err) {
+		shell_error(sh, "bt_conn_le_subrate_set_defaults returned error %d", err);
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
+
+static int cmd_subrate_request(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err = 0;
+
+	if (default_conn == NULL) {
+		shell_error(sh, "Conn handle error, at least one connection is required.");
+		return -ENOEXEC;
+	}
+
+	for (size_t argn = 1; argn < argc; argn++) {
+		(void)shell_strtoul(argv[argn], 10, &err);
+
+		if (err) {
+			shell_help(sh);
+			shell_error(sh, "Could not parse input number %d", argn);
+			return SHELL_CMD_HELP_PRINTED;
+		}
+	}
+
+	const struct bt_conn_le_subrate_param params = {
+		.subrate_min = shell_strtoul(argv[1], 10, &err),
+		.subrate_max = shell_strtoul(argv[2], 10, &err),
+		.max_latency = shell_strtoul(argv[3], 10, &err),
+		.continuation_number = shell_strtoul(argv[4], 10, &err),
+		.supervision_timeout = shell_strtoul(argv[5], 10, &err) * 100, /* 10ms units */
+	};
+
+	err = bt_conn_le_subrate_request(default_conn, &params);
+	if (err) {
+		shell_error(sh, "bt_conn_le_subrate_request returned error %d", err);
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
+#endif
 
 #if defined(CONFIG_BT_CONN)
 #if defined(CONFIG_BT_CENTRAL)
@@ -3315,6 +3407,12 @@ static int cmd_info(const struct shell *sh, size_t argc, char *argv[])
 			    info.le.data_len->tx_max_time,
 			    info.le.data_len->rx_max_len,
 			    info.le.data_len->rx_max_time);
+#endif
+#if defined(CONFIG_BT_SUBRATING)
+		shell_print(ctx_shell, "LE Subrating: Subrate Factor: %d"
+			    " Continuation Number: %d",
+			    info.le.subrate->factor,
+			    info.le.subrate->continuation_number);
 #endif
 	}
 
@@ -4715,6 +4813,16 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
 		      cmd_set_path_loss_reporting_parameters, 6, 0),
 	SHELL_CMD_ARG(path-loss-monitoring-enable, NULL, "<enable: true, false>",
 		      cmd_set_path_loss_reporting_enable, 2, 0),
+#endif
+#if defined(CONFIG_BT_SUBRATING)
+	SHELL_CMD_ARG(subrate-set-defaults, NULL,
+		"<min subrate factor> <max subrate factor> <max peripheral latency> "
+		"<min continuation number> <supervision timeout (seconds)>",
+		cmd_subrate_set_defaults, 6, 0),
+	SHELL_CMD_ARG(subrate-request, NULL,
+		"<min subrate factor> <max subrate factor> <max peripheral latency> "
+		"<min continuation number> <supervision timeout (seconds)>",
+		cmd_subrate_request, 6, 0),
 #endif
 #if defined(CONFIG_BT_BROADCASTER)
 	SHELL_CMD_ARG(advertise, NULL,

--- a/tests/bluetooth/shell/testcase.yaml
+++ b/tests/bluetooth/shell/testcase.yaml
@@ -29,6 +29,13 @@ tests:
     platform_allow:
       - native_posix
     build_only: true
+  bluetooth.shell.subrating:
+    extra_configs:
+      - CONFIG_BT_SUBRATING=y
+      - CONFIG_BT_CTLR=n
+    platform_allow:
+      - native_posix
+    build_only: true
   bluetooth.shell.cdc_acm:
     extra_args:
       - OVERLAY_CONFIG=cdc_acm.conf


### PR DESCRIPTION
The PR adds support for LE Connection Subrating as defined in Core 5.4 Vol 6, Part B, Section 5.1.19.
As this is primarily a controller feature, the host support is mostly a wrapper around the relevant HCI commands.

Subrating also allows updating connection's peripheral latency and supervision timeout without doing a connection parameter update - this will update the stored parameters inside `bt_conn_le` in the link.

Also added a new Kconfig to cover host subrating support and added subrating functionality to the Bluetooth shell.