### PR TITLE
west: add the hal_wch

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4763,6 +4763,14 @@ West:
   labels:
     - "platform: TI"
 
+"West project: hal_wch":
+  status: maintained
+  maintainers:
+    - nzmichaelh
+    - kholia
+  files:
+    - modules/hal_wch/
+
 "West project: hal_wurthelektronik":
   status: maintained
   maintainers:

--- a/modules/hal_wch/Kconfig
+++ b/modules/hal_wch/Kconfig
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2024 Dhiru Kholia
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# file is empty and kept as a place holder if/when Kconfig is needed

--- a/west.yml
+++ b/west.yml
@@ -247,6 +247,11 @@ manifest:
       path: modules/hal/ti
       groups:
         - hal
+    - name: hal_wch
+      revision: 1de9d3e406726702ce7cfc504509a02ecc463554
+      path: modules/hal/wch
+      groups:
+        - hal
     - name: hal_wurthelektronik
       revision: e5bcb2eac1bb9639ce13b4dafc78eb254e014342
       path: modules/hal/wurthelektronik


### PR DESCRIPTION
The hal_wch is based on the https://github.com/cnlohr/ch32v003fun work.

Context:

- https://github.com/zephyrproject-rtos/zephyr/issues/76261
- https://github.com/zephyrproject-rtos/zephyr/issues/76261#issuecomment-2260101347
- https://github.com/zephyrproject-rtos/zephyr/pull/73761

I believe we need to host this `hal_wch` in the `https://github.com/zephyrproject-rtos/` namespace at some point.

CC @nzmichaelh @fabiobaltieri @cnlohr.

