### PR TITLE
modules: Kconfig.stm32: remove duplicate Kconfig symbol for RAMCFG

### DIFF
--- a/modules/Kconfig.stm32
+++ b/modules/Kconfig.stm32
@@ -447,11 +447,6 @@ config USE_STM32_HAL_RAMECC
 	help
 	  Enable STM32Cube RAM ECC monitoring (RAMECC) HAL module driver
 
-config USE_STM32_HAL_RAMCFG
-	bool
-	help
-	  Enable STM32Cube RAM config (RAMCFG) HAL module driver
-
 config USE_STM32_HAL_RNG
 	bool
 	help


### PR DESCRIPTION
Remove the duplicate `USE_STM32_HAL_RAMCFG` Kconfig symbol definition from Kconfig.stm32, which was introduced by accident in PR #66181, commit 6ed002ddae64043778e4cca9f05f12c4f4dff455.