### PR TITLE
clang-format: IndentGotoLabels false

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -84,6 +84,7 @@ IncludeCategories:
   - Regex: '.*'
     Priority: 3
 IndentCaseLabels: false
+IndentGotoLabels: false
 IndentWidth: 8
 InsertBraces: true
 SpaceBeforeParens: ControlStatementsExceptControlMacros


### PR DESCRIPTION
In order for clang-format to adhere to checkpatch rules, this flag needs to be set.

Looking at goto labels in the code, they are not indented.
Not having this flag, causes (at least locally) clang-format on save to indent goto labels.
This then causes a checkpatch error: `-:10: WARNING:INDENTED_LABEL: labels should not be indented`
