### PR TITLE
boards: nucleo_u5a5zj_q: Fix storage address

### DIFF
--- a/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q.dts
+++ b/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q.dts
@@ -58,7 +58,7 @@
 		};
 		storage_partition: partition@3e2000 {
 			label = "storage";
-			reg = <0x003f0000 DT_SIZE_K(120)>;
+			reg = <0x003e2000 DT_SIZE_K(120)>;
 		};
 
 	};


### PR DESCRIPTION
Fix start address of storage partition.
Address did not match reg address of devicetree node, and the size of the storage partition would make it exceed flash region.