### PR TITLE
clock_control: stm32: Configure MCO through devicetree instead of Kconfig

### DIFF
--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -111,6 +111,8 @@ Boards & SoC Support
   * :ref:`native_posix<native_posix>` has been deprecated in favour of
     :ref:`native_sim<native_sim>`.
   * Support for Google Kukui EC board (``google_kukui``) has been dropped.
+  * STM32: Deprecated MCO configuration via Kconfig in favour of setting it through devicetree.
+    See ``samples/boards/stm32/mco`` sample.
 
 * Added support for the following shields:
 

--- a/drivers/clock_control/CMakeLists.txt
+++ b/drivers/clock_control/CMakeLists.txt
@@ -46,6 +46,7 @@ endif()
 
 if(CONFIG_CLOCK_CONTROL_STM32_CUBE)
   zephyr_library_sources_ifdef(CONFIG_CLOCK_STM32_MUX clock_stm32_mux.c)
+  zephyr_library_sources_ifdef(CONFIG_CLOCK_STM32_MCO clock_stm32_mco.c)
 if(CONFIG_SOC_SERIES_STM32MP1X)
   zephyr_library_sources(clock_stm32_ll_mp1.c)
 elseif(CONFIG_SOC_SERIES_STM32H7X)

--- a/drivers/clock_control/Kconfig.stm32
+++ b/drivers/clock_control/Kconfig.stm32
@@ -92,7 +92,14 @@ config STM32WB0_LSI_RUNTIME_MEASUREMENT_INTERVAL
 
 endmenu # DT_HAS_ST_STM32WB0_LSI_CLOCK_ENABLED
 
-# Micro-controller Clock output configuration options
+# Micro-controller Clock Output (MCO) configuration options
+config CLOCK_STM32_MCO
+	bool
+	default y
+	depends on DT_HAS_ST_STM32_CLOCK_MCO_ENABLED || DT_HAS_ST_STM32F1_CLOCK_MCO_ENABLED
+	# MCO configuration via Kconfig takes priority over Device Tree.
+	# Prevent DT-based MCO driver from compiling when Kconfig is used.
+	depends on CLOCK_STM32_MCO1_SRC_NOCLOCK && CLOCK_STM32_MCO2_SRC_NOCLOCK
 
 choice
 	prompt "STM32 MCO1 Clock Source"

--- a/drivers/clock_control/Kconfig.stm32
+++ b/drivers/clock_control/Kconfig.stm32
@@ -97,7 +97,7 @@ config CLOCK_STM32_MCO
 	bool
 	default y
 	depends on DT_HAS_ST_STM32_CLOCK_MCO_ENABLED || DT_HAS_ST_STM32F1_CLOCK_MCO_ENABLED
-	# MCO configuration via Kconfig takes priority over Device Tree.
+	# Although deprecated, MCO configuration via Kconfig takes priority over Device Tree.
 	# Prevent DT-based MCO driver from compiling when Kconfig is used.
 	depends on CLOCK_STM32_MCO1_SRC_NOCLOCK && CLOCK_STM32_MCO2_SRC_NOCLOCK
 
@@ -113,8 +113,10 @@ config CLOCK_STM32_MCO1_SRC_NOCLOCK
 config CLOCK_STM32_MCO1_SRC_EXT_HSE
 	bool "EXT_HSE"
 	depends on SOC_STM32F10X_CONNECTIVITY_LINE_DEVICE
+	select DEPRECATED
 	help
 	  Use EXT_HSE as source of MCO1
+	  This option is deprecated, please use devicetree instead.
 
 config CLOCK_STM32_MCO1_SRC_LSE
 	bool "LSE"
@@ -125,8 +127,10 @@ config CLOCK_STM32_MCO1_SRC_LSE
 	           SOC_SERIES_STM32H7RSX || \
 	           SOC_SERIES_STM32H5X || \
 	           SOC_SERIES_STM32U5X
+	select DEPRECATED
 	help
 	  Use LSE as source of MCO1
+	  This option is deprecated, please use devicetree instead.
 
 config CLOCK_STM32_MCO1_SRC_HSE
 	bool "HSE"
@@ -138,33 +142,43 @@ config CLOCK_STM32_MCO1_SRC_HSE
 	           SOC_SERIES_STM32H7RSX || \
 	           SOC_SERIES_STM32H5X || \
 	           SOC_SERIES_STM32U5X
+	select DEPRECATED
 	help
 	  Use HSE as source of MCO1
+	  This option is deprecated, please use devicetree instead.
 
 config CLOCK_STM32_MCO1_SRC_LSI
 	bool "LSI"
 	depends on SOC_SERIES_STM32L4X || \
 	           SOC_SERIES_STM32U5X
+	select DEPRECATED
 	help
 	  Use LSI as source of MCO1
+	  This option is deprecated, please use devicetree instead.
 
 config CLOCK_STM32_MCO1_SRC_MSI
 	bool "MSI"
 	depends on SOC_SERIES_STM32L4X
+	select DEPRECATED
 	help
 	  Use MSI as source of MCO1
+	  This option is deprecated, please use devicetree instead.
 
 config CLOCK_STM32_MCO1_SRC_MSIK
 	bool "MSIK"
 	depends on SOC_SERIES_STM32U5X
+	select DEPRECATED
 	help
 	  Use MSIK as source of MCO1
+	  This option is deprecated, please use devicetree instead.
 
 config CLOCK_STM32_MCO1_SRC_MSIS
 	bool "MSIS"
 	depends on SOC_SERIES_STM32U5X
+	select DEPRECATED
 	help
 	  Use MSIS as source of MCO1
+	  This option is deprecated, please use devicetree instead.
 
 config CLOCK_STM32_MCO1_SRC_HSI
 	bool "HSI"
@@ -174,15 +188,19 @@ config CLOCK_STM32_MCO1_SRC_HSI
 	           SOC_SERIES_STM32H7X || \
 	           SOC_SERIES_STM32H7RSX || \
 	           SOC_SERIES_STM32H5X
+	select DEPRECATED
 	help
 	  Use HSI as source of MCO1
+	  This option is deprecated, please use devicetree instead.
 
 config CLOCK_STM32_MCO1_SRC_HSI16
 	bool "HSI16"
 	depends on SOC_SERIES_STM32L4X || \
 		   SOC_SERIES_STM32U5X
+	select DEPRECATED
 	help
 	  Use HSI16 as source of MCO1
+	  This option is deprecated, please use devicetree instead.
 
 config CLOCK_STM32_MCO1_SRC_HSI48
 	bool "HSI48"
@@ -191,8 +209,10 @@ config CLOCK_STM32_MCO1_SRC_HSI48
 	           SOC_SERIES_STM32H7RSX || \
 	           SOC_SERIES_STM32H5X || \
 	           SOC_SERIES_STM32U5X
+	select DEPRECATED
 	help
 	  Use HSI48 as source of MCO1
+	  This option is deprecated, please use devicetree instead.
 
 config CLOCK_STM32_MCO1_SRC_PLLCLK
 	bool "PLLCLK"
@@ -200,48 +220,63 @@ config CLOCK_STM32_MCO1_SRC_PLLCLK
 	           SOC_SERIES_STM32F7X || \
 		   SOC_SERIES_STM32L4X || \
 		   SOC_SERIES_STM32U5X
+	select DEPRECATED
 	help
 	  Use PLLCLK as source of MCO1
+	  This option is deprecated, please use devicetree instead.
 
 config CLOCK_STM32_MCO1_SRC_PLLQCLK
 	bool "PLLQ"
 	depends on SOC_SERIES_STM32H7X || \
 	           SOC_SERIES_STM32H7RSX || \
 	           SOC_SERIES_STM32H5X
+	select DEPRECATED
 	help
 	  Use PLLQ as source of MCO1
+	  This option is deprecated, please use devicetree instead.
 
 config CLOCK_STM32_MCO1_SRC_PLLCLK_DIV2
 	bool "PLLCLK_DIV2"
 	depends on SOC_SERIES_STM32F1X
+	select DEPRECATED
 	help
 	  Use PLLCLK/2 as source of MCO1
+	  This option is deprecated, please use devicetree instead.
 
 config CLOCK_STM32_MCO1_SRC_PLL2CLK
 	bool "PLL2CLK"
 	depends on SOC_STM32F10X_CONNECTIVITY_LINE_DEVICE
+	select DEPRECATED
 	help
 	  Use PLL2CLK as source of MCO1
+	  This option is deprecated, please use devicetree instead.
 
 config CLOCK_STM32_MCO1_SRC_PLLI2SCLK
 	bool "PLLI2SCLK"
 	depends on SOC_STM32F10X_CONNECTIVITY_LINE_DEVICE
+	select DEPRECATED
 	help
 	  Use PLLI2SCLK as source of MCO1
+	  This option is deprecated, please use devicetree instead.
 
 config CLOCK_STM32_MCO1_SRC_PLLI2SCLK_DIV2
 	bool "PLLI2SCLK_DIV2"
 	depends on SOC_STM32F10X_CONNECTIVITY_LINE_DEVICE
+	select DEPRECATED
 	help
 	  Use PLLI2SCLK/2 as source of MCO1
+	  This option is deprecated, please use devicetree instead.
 
 config CLOCK_STM32_MCO1_SRC_SYSCLK
 	bool "SYSCLK"
 	depends on SOC_SERIES_STM32F1X || \
 	           SOC_SERIES_STM32L4X || \
 	           SOC_SERIES_STM32U5X
+	select DEPRECATED
 	help
 	  Use SYSCLK as source of MCO1
+	  This option is deprecated, please use devicetree instead.
+
 endchoice
 
 config CLOCK_STM32_MCO1_DIV
@@ -261,6 +296,7 @@ config CLOCK_STM32_MCO1_DIV
 	range 1   16 if SOC_SERIES_STM32L4X || SOC_SERIES_STM32U5X
 	help
 	  Prescaler for MCO1 output clock
+	  This option is deprecated, please use devicetree instead.
 
 choice
 	prompt "STM32 MCO2 Clock Source"
@@ -278,14 +314,18 @@ config CLOCK_STM32_MCO2_SRC_SYSCLK
 	           SOC_SERIES_STM32H7X || \
 	           SOC_SERIES_STM32H7RSX || \
 	           SOC_SERIES_STM32H5X
+	select DEPRECATED
 	help
 	  Use SYSCLK as source of MCO2
+	  This option is deprecated, please use devicetree instead.
 
 config CLOCK_STM32_MCO2_SRC_PLLI2S
 	bool "PLLI2S"
 	depends on SOC_SERIES_STM32F4X || SOC_SERIES_STM32F7X
+	select DEPRECATED
 	help
 	  Use PLLI2S as source of MCO2
+	  This option is deprecated, please use devicetree instead.
 
 config CLOCK_STM32_MCO2_SRC_HSE
 	bool "HSE"
@@ -294,8 +334,10 @@ config CLOCK_STM32_MCO2_SRC_HSE
 	           SOC_SERIES_STM32H7X || \
 	           SOC_SERIES_STM32H7RSX || \
 	           SOC_SERIES_STM32H5X
+	select DEPRECATED
 	help
 	  Use HSE as source of MCO2
+	  This option is deprecated, please use devicetree instead.
 
 config CLOCK_STM32_MCO2_SRC_LSI
 	bool "LSI"
@@ -304,36 +346,46 @@ config CLOCK_STM32_MCO2_SRC_LSI
 	           SOC_SERIES_STM32H5X
 	help
 	  Use LSI as source of MCO2
+	  This option is deprecated, please use devicetree instead.
 
 config CLOCK_STM32_MCO2_SRC_CSI
 	bool "CSI"
 	depends on SOC_SERIES_STM32H7X || \
 	           SOC_SERIES_STM32H7RSX || \
 	           SOC_SERIES_STM32H5X
+	select DEPRECATED
 	help
 	  Use CSI as source of MCO2
+	  This option is deprecated, please use devicetree instead.
 
 config CLOCK_STM32_MCO2_SRC_PLLCLK
 	bool "PLLCLK"
 	depends on SOC_SERIES_STM32F4X || SOC_SERIES_STM32F7X
+	select DEPRECATED
 	help
 	  Use PLLCLK as source of MCO2
+	  This option is deprecated, please use devicetree instead.
 
 config CLOCK_STM32_MCO2_SRC_PLLPCLK
 	bool "PLLPCLK"
 	depends on SOC_SERIES_STM32H7X || \
 	           SOC_SERIES_STM32H7RSX || \
 	           SOC_SERIES_STM32H5X
+	select DEPRECATED
 	help
 	  Use PLLPCLK as source of MC02
+	  This option is deprecated, please use devicetree instead.
 
 config CLOCK_STM32_MCO2_SRC_PLL2PCLK
 	bool "PLL2PCLK"
 	depends on SOC_SERIES_STM32H7X || \
 	           SOC_SERIES_STM32H7RSX || \
 	           SOC_SERIES_STM32H5X
+	select DEPRECATED
 	help
 	  Use PLL2PCLK as source of MC02
+	  This option is deprecated, please use devicetree instead.
+
 endchoice
 
 config CLOCK_STM32_MCO2_DIV

--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -133,6 +133,13 @@ int enabled_clock(uint32_t src_clk)
 		}
 		break;
 #endif /* STM32_SRC_HSE */
+#if defined(STM32_SRC_EXT_HSE)
+	case STM32_SRC_EXT_HSE:
+		/* EXT_HSE is the raw OSC_IN signal, so it is always
+		 * available, regardless of the clocks configuration.
+		 */
+		break;
+#endif /* STM32_SRC_HSE */
 #if defined(STM32_SRC_HSI)
 	case STM32_SRC_HSI:
 		if (!IS_ENABLED(STM32_HSI_ENABLED)) {
@@ -210,6 +217,20 @@ int enabled_clock(uint32_t src_clk)
 		}
 		break;
 #endif /* STM32_SRC_PLLI2S_R */
+#if defined(STM32_SRC_PLL2CLK)
+	case STM32_SRC_PLL2CLK:
+		if (!IS_ENABLED(STM32_PLL2_ENABLED)) {
+			r = -ENOTSUP;
+		}
+		break;
+#endif
+#if defined(STM32_SRC_PLL3CLK)
+	case STM32_SRC_PLL3CLK:
+		if (!IS_ENABLED(STM32_PLL3_ENABLED)) {
+			r = -ENOTSUP;
+		}
+		break;
+#endif
 	default:
 		return -ENOTSUP;
 	}

--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -113,8 +113,7 @@ static uint32_t get_msi_frequency(void)
 }
 
 /** @brief Verifies clock is part of active clock configuration */
-__unused
-static int enabled_clock(uint32_t src_clk)
+int enabled_clock(uint32_t src_clk)
 {
 	int r = 0;
 

--- a/drivers/clock_control/clock_stm32_ll_common.h
+++ b/drivers/clock_control/clock_stm32_ll_common.h
@@ -50,6 +50,7 @@ void config_plli2s(void);
 #endif
 void config_enable_default_clocks(void);
 void config_regulator_voltage(uint32_t hclk_freq);
+int enabled_clock(uint32_t src_clk);
 
 /* functions exported to the soc power.c */
 int stm32_clock_control_init(const struct device *dev);

--- a/drivers/clock_control/clock_stm32_ll_h5.c
+++ b/drivers/clock_control/clock_stm32_ll_h5.c
@@ -117,7 +117,7 @@ static uint32_t get_sysclk_frequency(void)
 }
 
 /** @brief Verifies clock is part of active clock configuration */
-static int enabled_clock(uint32_t src_clk)
+int enabled_clock(uint32_t src_clk)
 {
 	if ((src_clk == STM32_SRC_SYSCLK) ||
 	    ((src_clk == STM32_SRC_HSE) && IS_ENABLED(STM32_HSE_ENABLED)) ||

--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -360,7 +360,7 @@ static uint32_t get_vco_output_range(uint32_t vco_input_range)
 #endif /* ! CONFIG_CPU_CORTEX_M4 */
 
 /** @brief Verifies clock is part of active clock configuration */
-static int enabled_clock(uint32_t src_clk)
+int enabled_clock(uint32_t src_clk)
 {
 
 	if ((src_clk == STM32_SRC_SYSCLK) ||

--- a/drivers/clock_control/clock_stm32_ll_u5.c
+++ b/drivers/clock_control/clock_stm32_ll_u5.c
@@ -121,7 +121,7 @@ static uint32_t get_sysclk_frequency(void)
 }
 
 /** @brief Verifies clock is part of active clock configuration */
-static int enabled_clock(uint32_t src_clk)
+int enabled_clock(uint32_t src_clk)
 {
 	if ((src_clk == STM32_SRC_SYSCLK) ||
 	    ((src_clk == STM32_SRC_HSE) && IS_ENABLED(STM32_HSE_ENABLED)) ||

--- a/drivers/clock_control/clock_stm32_ll_wba.c
+++ b/drivers/clock_control/clock_stm32_ll_wba.c
@@ -41,8 +41,7 @@ static uint32_t get_bus_clock(uint32_t clock, uint32_t prescaler)
 }
 
 /** @brief Verifies clock is part of active clock configuration */
-__unused
-static int enabled_clock(uint32_t src_clk)
+int enabled_clock(uint32_t src_clk)
 {
 	if ((src_clk == STM32_SRC_SYSCLK) ||
 	    ((src_clk == STM32_SRC_HSE) && IS_ENABLED(STM32_HSE_ENABLED)) ||

--- a/drivers/clock_control/clock_stm32_mco.c
+++ b/drivers/clock_control/clock_stm32_mco.c
@@ -1,0 +1,84 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (C) 2024, Joakim Andersson
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/pinctrl.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/drivers/clock_control/stm32_clock_control.h>
+#include "clock_stm32_ll_common.h"
+
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_clock_mco)
+#define DT_DRV_COMPAT st_stm32_clock_mco
+#define HAS_PRESCALER 1
+#elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32f1_clock_mco)
+#define DT_DRV_COMPAT st_stm32f1_clock_mco
+#endif
+
+struct stm32_mco_config {
+	const struct pinctrl_dev_config *pcfg;
+#if defined(HAS_PRESCALER)
+	uint32_t prescaler;
+#endif
+	/* clock subsystem driving this peripheral */
+	const struct stm32_pclken pclken[1];
+};
+
+static int stm32_mco_init(const struct device *dev)
+{
+	const struct stm32_mco_config *config = dev->config;
+	const struct stm32_pclken *pclken = &config->pclken[0];
+	int err;
+
+	err = enabled_clock(pclken->bus);
+	if (err < 0) {
+		/* Attempt to configure a src clock not available or not valid */
+		return err;
+	}
+
+	/* MCO source */
+	sys_clear_bits(
+		DT_REG_ADDR(DT_NODELABEL(rcc)) + STM32_MCO_CFGR_REG_GET(pclken->enr),
+		STM32_MCO_CFGR_MASK_GET(pclken->enr) <<
+			STM32_MCO_CFGR_SHIFT_GET(pclken->enr));
+	sys_set_bits(
+		DT_REG_ADDR(DT_NODELABEL(rcc)) + STM32_MCO_CFGR_REG_GET(pclken->enr),
+		STM32_MCO_CFGR_VAL_GET(pclken->enr) <<
+			STM32_MCO_CFGR_SHIFT_GET(pclken->enr));
+
+#if defined(HAS_PRESCALER)
+	/* MCO prescaler */
+	sys_clear_bits(
+		DT_REG_ADDR(DT_NODELABEL(rcc)) + STM32_MCO_CFGR_REG_GET(config->prescaler),
+		STM32_MCO_CFGR_MASK_GET(config->prescaler) <<
+			STM32_MCO_CFGR_SHIFT_GET(config->prescaler));
+	sys_set_bits(
+		DT_REG_ADDR(DT_NODELABEL(rcc)) + STM32_MCO_CFGR_REG_GET(config->prescaler),
+		STM32_MCO_CFGR_VAL_GET(config->prescaler) <<
+			STM32_MCO_CFGR_SHIFT_GET(config->prescaler));
+#endif
+
+	return pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+}
+
+#define STM32_MCO_INIT(inst)                                            \
+									\
+PINCTRL_DT_INST_DEFINE(inst);                                           \
+									\
+const static struct stm32_mco_config stm32_mco_config_##inst = {        \
+	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),                   \
+	.pclken = STM32_DT_INST_CLOCKS(inst),                           \
+	IF_ENABLED(HAS_PRESCALER,                                       \
+		(.prescaler = DT_PROP(DT_DRV_INST(inst), prescaler),))  \
+};                                                                      \
+									\
+DEVICE_DT_INST_DEFINE(inst, stm32_mco_init, NULL,                       \
+	NULL,                                                           \
+	&stm32_mco_config_##inst,                                       \
+	PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,               \
+	NULL);
+
+DT_INST_FOREACH_STATUS_OKAY(STM32_MCO_INIT);

--- a/drivers/clock_control/clock_stm32f1.c
+++ b/drivers/clock_control/clock_stm32f1.c
@@ -23,6 +23,15 @@
 
 #if defined(STM32_PLL_ENABLED)
 
+uint32_t get_pllout_frequency(void)
+{
+	/* Stub implementation for compatibility with clock_stm32_ll_common.
+	 * The PLL domain clock is only used for MCO configuration, but the
+	 * MCO driver never queries the PLL output clock frequency.
+	 */
+	return 0;
+}
+
 /*
  * Select PLL source for STM32F1 Connectivity line devices (STM32F105xx and
  * STM32F107xx).

--- a/dts/arm/st/c0/stm32c0.dtsi
+++ b/dts/arm/st/c0/stm32c0.dtsi
@@ -67,6 +67,18 @@
 		};
 	};
 
+	mcos {
+		mco1: mco1 {
+			compatible = "st,stm32-clock-mco";
+			status = "disabled";
+		};
+
+		mco2: mco2 {
+			compatible = "st,stm32-clock-mco";
+			status = "disabled";
+		};
+	};
+
 	soc {
 		flash: flash-controller@40022000 {
 			compatible = "st,stm32-flash-controller";

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -72,6 +72,13 @@
 		};
 	};
 
+	mcos {
+		mco1: mco1 {
+			compatible = "st,stm32f1-clock-mco";
+			status = "disabled";
+		};
+	};
+
 	soc {
 
 		flash: flash-controller@40022000 {

--- a/dts/arm/st/f1/stm32f105.dtsi
+++ b/dts/arm/st/f1/stm32f105.dtsi
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/clock/stm32f10x_clock.h>
 #include <st/f1/stm32f1.dtsi>
 
 / {

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -92,6 +92,18 @@
 		};
 	};
 
+	mcos {
+		mco1: mco1 {
+			compatible = "st,stm32-clock-mco";
+			status = "disabled";
+		};
+
+		mco2: mco2 {
+			compatible = "st,stm32-clock-mco";
+			status = "disabled";
+		};
+	};
+
 	soc {
 		flash: flash-controller@40023c00 {
 			compatible = "st,stm32-flash-controller", "st,stm32f4-flash-controller";

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -88,6 +88,18 @@
 		};
 	};
 
+	mcos {
+		mco1: mco1 {
+			compatible = "st,stm32-clock-mco";
+			status = "disabled";
+		};
+
+		mco2: mco2 {
+			compatible = "st,stm32-clock-mco";
+			status = "disabled";
+		};
+	};
+
 	soc {
 		fmc: memory-controller@a0000000 {
 			compatible = "st,stm32-fmc";

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -98,6 +98,18 @@
 		};
 	};
 
+	mcos {
+		mco1: mco1 {
+			compatible = "st,stm32-clock-mco";
+			status = "disabled";
+		};
+
+		mco2: mco2 {
+			compatible = "st,stm32-clock-mco";
+			status = "disabled";
+		};
+	};
+
 	soc {
 		flash: flash-controller@40022000 {
 			compatible = "st,stm32-flash-controller", "st,stm32l5-flash-controller";

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -127,6 +127,18 @@
 		};
 	};
 
+	mcos {
+		mco1: mco1 {
+			compatible = "st,stm32-clock-mco";
+			status = "disabled";
+		};
+
+		mco2: mco2 {
+			compatible = "st,stm32-clock-mco";
+			status = "disabled";
+		};
+	};
+
 	soc {
 		flash: flash-controller@52002000 {
 			compatible = "st,stm32-flash-controller", "st,stm32h7-flash-controller";

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -158,6 +158,18 @@
 		};
 	};
 
+	mcos {
+		mco1: mco1 {
+			compatible = "st,stm32-clock-mco";
+			status = "disabled";
+		};
+
+		mco2: mco2 {
+			compatible = "st,stm32-clock-mco";
+			status = "disabled";
+		};
+	};
+
 	soc {
 		flash: flash-controller@52002000 {
 			compatible = "st,stm32-flash-controller", "st,stm32h7-flash-controller";

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -106,6 +106,13 @@
 		};
 	};
 
+	mcos {
+		mco1: mco1 {
+			compatible = "st,stm32-clock-mco";
+			status = "disabled";
+		};
+	};
+
 	soc {
 		flash: flash-controller@40022000 {
 			compatible = "st,stm32-flash-controller", "st,stm32l4-flash-controller";

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -148,6 +148,13 @@
 		};
 	};
 
+	mcos {
+		mco1: mco1 {
+			compatible = "st,stm32-clock-mco";
+			status = "disabled";
+		};
+	};
+
 	soc {
 		flash: flash-controller@40022000 {
 			compatible = "st,stm32-flash-controller", "st,stm32l5-flash-controller";

--- a/dts/bindings/clock/st,stm32-clock-mco.yaml
+++ b/dts/bindings/clock/st,stm32-clock-mco.yaml
@@ -1,0 +1,39 @@
+#
+# Copyright (c) 2024, Joakim Andersson
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+compatible: "st,stm32-clock-mco"
+
+description: |
+        STM32 Microcontroller Clock Output (MCO)
+
+        Used to output a clock signal from the MCU to a GPIO pin.
+        The selected signal goes through a configurable prescaler before output.
+
+        Example:
+                &mco1 {
+                        clocks = <&rcc STM32_SRC_LSE MCO1_SEL(7)>;
+                        prescaler = <MCO1_PRE(1)>;
+                        pinctrl-0 = <&rcc_mco_pa8>;
+                        pinctrl-names = "default";
+                        status = "okay";
+                };
+
+include: [base.yaml, pinctrl-device.yaml]
+
+properties:
+
+  clocks:
+    required: true
+
+  prescaler:
+    type: int
+    required: true
+
+  pinctrl-0:
+    required: true
+
+  pinctrl-names:
+    required: true

--- a/dts/bindings/clock/st,stm32f1-clock-mco.yaml
+++ b/dts/bindings/clock/st,stm32f1-clock-mco.yaml
@@ -1,0 +1,38 @@
+#
+# Copyright (c) 2024, Joakim Andersson
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+compatible: "st,stm32f1-clock-mco"
+
+description: |
+        STM32 F1 series Microcontroller Clock Output (MCO)
+
+        The STM32F1 MCO is similar to other series but has no configurable
+        prescaler before the output. However, note that certain inputs of
+        the MCO are fitted with a fixed prescaler, making it possible to
+        output a slowed down variation of certain clocks.
+
+        Example:
+                &mco1 {
+                        clocks = <&rcc STM32_SRC_LSE MCO1_SEL(7)>;
+                        pinctrl-0 = <&rcc_mco_pa8>;
+                        pinctrl-names = "default";
+                        status = "okay";
+                };
+
+        Note: in the `clocks` property, the domain clock source cell should
+        use the value representing the base clock, regardless of whether or
+        not the selected input is fitted with a prescaler.
+
+        Example:
+                /* PLL3 clock divided by 2 */
+                clocks = <&rcc STM32_SRC_PLL3CLK MCO1_SEL(9)>;
+                /* PLL3 clock */
+                clocks = <&rcc STM32_SRC_PLL3CLK MCO1_SEL(11)>;
+
+include:
+  - name: st,stm32-clock-mco.yaml
+    property-blocklist:
+      - prescaler

--- a/include/zephyr/drivers/clock_control/stm32_clock_control.h
+++ b/include/zephyr/drivers/clock_control/stm32_clock_control.h
@@ -17,7 +17,11 @@
 #elif defined(CONFIG_SOC_SERIES_STM32F0X)
 #include <zephyr/dt-bindings/clock/stm32f0_clock.h>
 #elif defined(CONFIG_SOC_SERIES_STM32F1X)
+#if defined(CONFIG_SOC_STM32F10X_CONNECTIVITY_LINE_DEVICE)
+#include <zephyr/dt-bindings/clock/stm32f10x_clock.h>
+#else
 #include <zephyr/dt-bindings/clock/stm32f1_clock.h>
+#endif
 #elif defined(CONFIG_SOC_SERIES_STM32F3X)
 #include <zephyr/dt-bindings/clock/stm32f3_clock.h>
 #elif defined(CONFIG_SOC_SERIES_STM32F2X) || \

--- a/include/zephyr/drivers/clock_control/stm32_clock_control.h
+++ b/include/zephyr/drivers/clock_control/stm32_clock_control.h
@@ -493,6 +493,38 @@ struct stm32_pclken {
 #define STM32_CLOCK_VAL_GET(clock) \
 	(((clock) >> STM32_CLOCK_VAL_SHIFT) & STM32_CLOCK_VAL_MASK)
 
+/**
+ * @brief Obtain register field from MCO configuration.
+ *
+ * @param mco_cfgr MCO configuration bit field value.
+ */
+#define STM32_MCO_CFGR_REG_GET(mco_cfgr) \
+	(((mco_cfgr) >> STM32_MCO_CFGR_REG_SHIFT) & STM32_MCO_CFGR_REG_MASK)
+
+/**
+ * @brief Obtain position field from MCO configuration.
+ *
+ * @param mco_cfgr MCO configuration bit field value.
+ */
+#define STM32_MCO_CFGR_SHIFT_GET(mco_cfgr) \
+	(((mco_cfgr) >> STM32_MCO_CFGR_SHIFT_SHIFT) & STM32_MCO_CFGR_SHIFT_MASK)
+
+/**
+ * @brief Obtain mask field from MCO configuration.
+ *
+ * @param mco_cfgr MCO configuration bit field value.
+ */
+#define STM32_MCO_CFGR_MASK_GET(mco_cfgr) \
+	(((mco_cfgr) >> STM32_MCO_CFGR_MASK_SHIFT) & STM32_MCO_CFGR_MASK_MASK)
+
+/**
+ * @brief Obtain value field from MCO configuration.
+ *
+ * @param mco_cfgr MCO configuration bit field value.
+ */
+#define STM32_MCO_CFGR_VAL_GET(mco_cfgr) \
+	(((mco_cfgr) >> STM32_MCO_CFGR_VAL_SHIFT) & STM32_MCO_CFGR_VAL_MASK)
+
 #if defined(STM32_HSE_CSS)
 /**
  * @brief Called if the HSE clock security system detects a clock fault.

--- a/include/zephyr/dt-bindings/clock/stm32_common_clocks.h
+++ b/include/zephyr/dt-bindings/clock/stm32_common_clocks.h
@@ -15,4 +15,34 @@
 /** Dummy: Add a specifier when no selection is possible */
 #define NO_SEL			0xFF
 
+/** STM32 MCO configuration values */
+#define STM32_MCO_CFGR_REG_MASK     0xFFFFU
+#define STM32_MCO_CFGR_REG_SHIFT    0U
+#define STM32_MCO_CFGR_SHIFT_MASK   0x3FU
+#define STM32_MCO_CFGR_SHIFT_SHIFT  16U
+#define STM32_MCO_CFGR_MASK_MASK    0x1FU
+#define STM32_MCO_CFGR_MASK_SHIFT   22U
+#define STM32_MCO_CFGR_VAL_MASK     0x1FU
+#define STM32_MCO_CFGR_VAL_SHIFT    27U
+
+/**
+ * @brief STM32 MCO configuration register bit field
+ *
+ * @param reg    Offset to RCC register holding MCO configuration
+ * @param shift    Position of field within RCC register (= field LSB's index)
+ * @param mask    Mask of register field in RCC register
+ * @param val    Clock configuration field value (0~0x1F)
+ *
+ * @note 'reg' range:    0x0~0xFFFF    [ 00 : 15 ]
+ * @note 'shift' range:    0~63        [ 16 : 21 ]
+ * @note 'mask' range:    0x00~0x1F    [ 22 : 26 ]
+ * @note 'val' range:    0x00~0x1F    [ 27 : 31 ]
+ *
+ */
+#define STM32_MCO_CFGR(val, mask, shift, reg)                        \
+	((((reg) & STM32_MCO_CFGR_REG_MASK) << STM32_MCO_CFGR_REG_SHIFT) |        \
+	 (((shift) & STM32_MCO_CFGR_SHIFT_MASK) << STM32_MCO_CFGR_SHIFT_SHIFT) |    \
+	 (((mask) & STM32_MCO_CFGR_MASK_MASK) << STM32_MCO_CFGR_MASK_SHIFT) |        \
+	 (((val) & STM32_MCO_CFGR_VAL_MASK) << STM32_MCO_CFGR_VAL_SHIFT))
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32_COMMON_CLOCKS_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32c0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32c0_clock.h
@@ -63,6 +63,9 @@
 /** @brief RCC_CSR1 register offset */
 #define CSR1_REG		0x5C
 
+/** @brief RCC_CFGRx register offset */
+#define CFGR1_REG               0x08
+
 /** @brief Device domain clocks selection helpers */
 /** CCIPR devices */
 #define USART1_SEL(val)		STM32_CLOCK(val, 3, 0, CCIPR_REG)
@@ -71,5 +74,11 @@
 #define ADC_SEL(val)		STM32_CLOCK(val, 3, 30, CCIPR_REG)
 /** CSR1 devices */
 #define RTC_SEL(val)		STM32_CLOCK(val, 3, 8, CSR1_REG)
+
+/** CFGR1 devices */
+#define MCO1_SEL(val)           STM32_MCO_CFGR(val, 0x7, 24, CFGR1_REG)
+#define MCO1_PRE(val)           STM32_MCO_CFGR(val, 0x7, 28, CFGR1_REG)
+#define MCO2_SEL(val)           STM32_MCO_CFGR(val, 0x7, 16, CFGR1_REG)
+#define MCO2_PRE(val)           STM32_MCO_CFGR(val, 0x7, 20, CFGR1_REG)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32C0_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f0_clock.h
@@ -59,6 +59,7 @@
 	 (((val) & STM32_CLOCK_VAL_MASK) << STM32_CLOCK_VAL_SHIFT))
 
 /** @brief RCC_CFGRx register offset */
+#define CFGR1_REG               0x04
 #define CFGR3_REG		0x30
 
 /** @brief RCC_BDCR register offset */
@@ -74,5 +75,9 @@
 #define USART3_SEL(val)		STM32_CLOCK(val, 3, 18, CFGR3_REG)
 /** BDCR devices */
 #define RTC_SEL(val)		STM32_CLOCK(val, 3, 8, BDCR_REG)
+
+/** CFGR1 devices */
+#define MCO1_SEL(val)           STM32_MCO_CFGR(val, 0xF, 24, CFGR1_REG)
+#define MCO1_PRE(val)           STM32_MCO_CFGR(val, 0x7, 28, CFGR1_REG)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F0_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f10x_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f10x_clock.h
@@ -1,0 +1,21 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (C) 2024, Joakim Andersson
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F10X_CLOCK_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F10X_CLOCK_H_
+
+#include "stm32_common_clocks.h"
+/* Ensure correct order by including generic F1 definitions first. */
+#include "stm32f1_clock.h"
+
+/** Fixed clocks  */
+/* Low speed clocks defined in stm32_common_clocks.h */
+/* Common clocks with stm32f1x defined in stm32f1_clock.h */
+#define STM32_SRC_PLL2CLK           (STM32_SRC_PLLCLK + 1)
+#define STM32_SRC_PLL3CLK           (STM32_SRC_PLL2CLK + 1)
+#define STM32_SRC_EXT_HSE           (STM32_SRC_PLL3CLK + 1)
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F10X_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f10x_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f10x_clock.h
@@ -18,4 +18,9 @@
 #define STM32_SRC_PLL3CLK           (STM32_SRC_PLL2CLK + 1)
 #define STM32_SRC_EXT_HSE           (STM32_SRC_PLL3CLK + 1)
 
+/** CFGR1 devices */
+#undef MCO1_SEL /* Need to redefine generic F1 MCO_SEL for connectivity line devices. */
+#define MCO1_SEL(val)           STM32_MCO_CFGR(val, 0xF, 24, CFGR1_REG)
+/* No MCO prescaler support on STM32F1 series. */
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F10X_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f1_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f1_clock.h
@@ -23,9 +23,9 @@
 
 /** Fixed clocks  */
 /* Low speed clocks defined in stm32_common_clocks.h */
-#define STM32_SRC_HSI		(STM32_SRC_LSI + 1)
-#define STM32_SRC_HSE		(STM32_SRC_HSI + 1)
-
+#define STM32_SRC_HSI           (STM32_SRC_LSI + 1)
+#define STM32_SRC_HSE           (STM32_SRC_HSI + 1)
+#define STM32_SRC_PLLCLK        (STM32_SRC_HSE + 1)
 
 #define STM32_CLOCK_REG_MASK    0xFFU
 #define STM32_CLOCK_REG_SHIFT   0U

--- a/include/zephyr/dt-bindings/clock/stm32f1_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f1_clock.h
@@ -55,7 +55,8 @@
 	 (((mask) & STM32_CLOCK_MASK_MASK) << STM32_CLOCK_MASK_SHIFT) |		\
 	 (((val) & STM32_CLOCK_VAL_MASK) << STM32_CLOCK_VAL_SHIFT))
 
-/** @brief RCC_CFGR2 register offset */
+/** @brief RCC_CFGRx register offset */
+#define CFGR1_REG               0x04
 #define CFGR2_REG		0x2C
 
 /** @brief RCC_BDCR register offset */
@@ -67,5 +68,9 @@
 #define I2S3_SEL(val)		STM32_CLOCK(val, 1, 18, CFGR2_REG)
 /** BDCR devices */
 #define RTC_SEL(val)		STM32_CLOCK(val, 3, 8, BDCR_REG)
+
+/** CFGR1 devices */
+#define MCO1_SEL(val)           STM32_MCO_CFGR(val, 0x7, 24, CFGR1_REG)
+/* No MCO prescaler support on STM32F1 series. */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F1_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f3_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f3_clock.h
@@ -69,6 +69,8 @@
 /** @brief Device domain clocks selection helpers) */
 /** CFGR devices */
 #define I2S_SEL(val)		STM32_CLOCK(val, 1, 23, CFGR_REG)
+#define MCO1_SEL(val)           STM32_MCO_CFGR(val, 0x7, 24, CFGR_REG)
+#define MCO1_PRE(val)           STM32_MCO_CFGR(val, 0x7, 28, CFGR_REG)
 /** CFGR3 devices */
 #define USART1_SEL(val)		STM32_CLOCK(val, 3, 0, CFGR3_REG)
 #define I2C1_SEL(val)		STM32_CLOCK(val, 1, 4, CFGR3_REG)

--- a/include/zephyr/dt-bindings/clock/stm32f4_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f4_clock.h
@@ -66,7 +66,7 @@
 	 (((mask) & STM32_CLOCK_MASK_MASK) << STM32_CLOCK_MASK_SHIFT) |		\
 	 (((val) & STM32_CLOCK_VAL_MASK) << STM32_CLOCK_VAL_SHIFT))
 
-/** @brief RCC_CFGR register offset */
+/** @brief RCC_CFGRx register offset */
 #define CFGR_REG		0x08
 /** @brief RCC_BDCR register offset */
 #define BDCR_REG		0x70
@@ -74,6 +74,10 @@
 /** @brief Device domain clocks selection helpers */
 /** CFGR devices */
 #define I2S_SEL(val)		STM32_CLOCK(val, 1, 23, CFGR_REG)
+#define MCO1_SEL(val)           STM32_MCO_CFGR(val, 0x3, 21, CFGR_REG)
+#define MCO1_PRE(val)           STM32_MCO_CFGR(val, 0x7, 24, CFGR_REG)
+#define MCO2_SEL(val)           STM32_MCO_CFGR(val, 0x3, 30, CFGR_REG)
+#define MCO2_PRE(val)           STM32_MCO_CFGR(val, 0x7, 27, CFGR_REG)
 /** BDCR devices */
 #define RTC_SEL(val)		STM32_CLOCK(val, 3, 8, BDCR_REG)
 

--- a/include/zephyr/dt-bindings/clock/stm32f7_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f7_clock.h
@@ -30,12 +30,15 @@
 /** Fixed clocks  */
 /* Low speed clocks defined in stm32_common_clocks.h */
 #define STM32_SRC_HSI		(STM32_SRC_LSI + 1)
+#define STM32_SRC_HSE           (STM32_SRC_HSI + 1)
 /** PLL clock outputs */
-#define STM32_SRC_PLL_P		(STM32_SRC_HSI + 1)
+#define STM32_SRC_PLL_P		(STM32_SRC_HSE + 1)
 #define STM32_SRC_PLL_Q		(STM32_SRC_PLL_P + 1)
 #define STM32_SRC_PLL_R		(STM32_SRC_PLL_Q + 1)
 /** Peripheral bus clock */
 #define STM32_SRC_PCLK		(STM32_SRC_PLL_R + 1)
+
+#define STM32_SRC_PLLI2S_R      (STM32_SRC_PCLK + 1)
 
 
 #define STM32_CLOCK_REG_MASK    0xFFU

--- a/include/zephyr/dt-bindings/clock/stm32f7_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f7_clock.h
@@ -75,6 +75,10 @@
 /** @brief Device domain clocks selection helpers */
 /** CFGR devices */
 #define I2S_SEL(val)		STM32_CLOCK(val, 1, 23, CFGR_REG)
+#define MCO1_SEL(val)           STM32_MCO_CFGR(val, 0x3, 21, CFGR_REG)
+#define MCO1_PRE(val)           STM32_MCO_CFGR(val, 0x7, 24, CFGR_REG)
+#define MCO2_SEL(val)           STM32_MCO_CFGR(val, 0x3, 30, CFGR_REG)
+#define MCO2_PRE(val)           STM32_MCO_CFGR(val, 0x7, 27, CFGR_REG)
 /** BDCR devices */
 #define RTC_SEL(val)		STM32_CLOCK(val, 3, 8, BDCR_REG)
 

--- a/include/zephyr/dt-bindings/clock/stm32h5_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32h5_clock.h
@@ -84,6 +84,9 @@
 /** @brief RCC_BDCR register offset */
 #define BDCR_REG		0xF0
 
+/** @brief RCC_CFGRx register offset */
+#define CFGR1_REG               0x1C
+
 /** @brief Device domain clocks selection helpers */
 /** CCIPR1 devices */
 #define USART1_SEL(val)		STM32_CLOCK(val, 7, 0, CCIPR1_REG)
@@ -141,5 +144,11 @@
 
 /** BDCR devices */
 #define RTC_SEL(val)		STM32_CLOCK(val, 3, 8, BDCR_REG)
+
+/** CFGR1 devices */
+#define MCO1_SEL(val)           STM32_MCO_CFGR(val, 0x7, 22, CFGR1_REG)
+#define MCO1_PRE(val)           STM32_MCO_CFGR(val, 0xF, 18, CFGR1_REG)
+#define MCO2_SEL(val)           STM32_MCO_CFGR(val, 0x7, 25, CFGR1_REG)
+#define MCO2_PRE(val)           STM32_MCO_CFGR(val, 0xF, 29, CFGR1_REG)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32H5_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32h7_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32h7_clock.h
@@ -95,6 +95,9 @@
 /** @brief RCC_BDCR register offset */
 #define BDCR_REG		0x70
 
+/** @brief RCC_CFGRx register offset */
+#define CFGR_REG                0x10
+
 /** @brief Device domain clocks selection helpers (RM0399.pdf) */
 /** D1CCIPR devices */
 #define FMC_SEL(val)		STM32_CLOCK(val, 3, 0, D1CCIPR_REG)
@@ -132,5 +135,10 @@
 #define SPI6_SEL(val)		STM32_CLOCK(val, 7, 28, D3CCIPR_REG)
 /** BDCR devices */
 #define RTC_SEL(val)		STM32_CLOCK(val, 3, 8, BDCR_REG)
+/** CFGR devices */
+#define MCO1_SEL(val)           STM32_MCO_CFGR(val, 0xF, 22, CFGR_REG)
+#define MCO1_PRE(val)           STM32_MCO_CFGR(val, 0x7, 18, CFGR_REG)
+#define MCO2_SEL(val)           STM32_MCO_CFGR(val, 0xF, 29, CFGR_REG)
+#define MCO2_PRE(val)           STM32_MCO_CFGR(val, 0x7, 25, CFGR_REG)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32H7_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32h7rs_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32h7rs_clock.h
@@ -91,6 +91,9 @@
 /** @brief RCC_BDCR register offset */
 #define BDCR_REG		0x70
 
+/** @brief RCC_CFGRx register offset */
+#define CFGR_REG                0x10
+
 /** @brief Device domain clocks selection helpers (RM0477.pdf) */
 
 /* TODO to be completed */
@@ -127,5 +130,11 @@
 
 /** BDCR devices */
 #define RTC_SEL(val)		STM32_CLOCK(val, 3, 8, BDCR_REG)
+
+/** CFGR devices */
+#define MCO1_SEL(val)           STM32_MCO_CFGR(val, 0x7, 22, CFGR_REG)
+#define MCO1_PRE(val)           STM32_MCO_CFGR(val, 0xF, 18, CFGR_REG)
+#define MCO2_SEL(val)           STM32_MCO_CFGR(val, 0x7, 29, CFGR_REG)
+#define MCO2_PRE(val)           STM32_MCO_CFGR(val, 0xF, 25, CFGR_REG)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32H7RS_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32l4_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32l4_clock.h
@@ -72,6 +72,9 @@
 /** @brief RCC_BDCR register offset */
 #define BDCR_REG		0x90
 
+/** @brief RCC_CFGRx register offset */
+#define CFGR_REG                0x08
+
 /** @brief Device domain clocks selection helpers */
 /** CCIPR devices */
 #define USART1_SEL(val)		STM32_CLOCK(val, 3, 0, CCIPR_REG)
@@ -102,5 +105,8 @@
 #define OSPI_SEL(val)		STM32_CLOCK(val, 3, 20, CCIPR2_REG)
 /** BDCR devices */
 #define RTC_SEL(val)		STM32_CLOCK(val, 3, 8, BDCR_REG)
+/** CFGR devices */
+#define MCO1_SEL(val)           STM32_MCO_CFGR(val, 0xF, 24, CFGR_REG)
+#define MCO1_PRE(val)           STM32_MCO_CFGR(val, 0x7, 28, CFGR_REG)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32L4_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32u5_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32u5_clock.h
@@ -83,6 +83,9 @@
 /** @brief RCC_BDCR register offset */
 #define BDCR_REG		0xF0
 
+/** @brief RCC_CFGRx register offset */
+#define CFGR1_REG               0x1C
+
 /** @brief Device domain clocks selection helpers */
 /** CCIPR1 devices */
 #define USART1_SEL(val)		STM32_CLOCK(val, 3, 0, CCIPR1_REG)
@@ -126,5 +129,9 @@
 #define ADF1_SEL(val)		STM32_CLOCK(val, 7, 16, CCIPR3_REG)
 /** BDCR devices */
 #define RTC_SEL(val)		STM32_CLOCK(val, 3, 8, BDCR_REG)
+
+/** CFGR1 devices */
+#define MCO1_SEL(val)           STM32_MCO_CFGR(val, 0xF, 24, CFGR1_REG)
+#define MCO1_PRE(val)           STM32_MCO_CFGR(val, 0x7, 28, CFGR1_REG)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32U5_CLOCK_H_ */

--- a/samples/boards/st/mco/README.rst
+++ b/samples/boards/st/mco/README.rst
@@ -14,7 +14,7 @@ Requirements
 ************
 
 The SoC should support MCO functionality and use a pin that has the MCO alternate function.
-To support another board, add an overlay in boards folder.
+To support another board, add a dts overlay file in boards folder.
 Make sure that the output clock is enabled in dts overlay file.
 
 

--- a/samples/boards/st/mco/boards/nucleo_u5a5zj_q.overlay
+++ b/samples/boards/st/mco/boards/nucleo_u5a5zj_q.overlay
@@ -3,10 +3,20 @@
 	status = "okay";
 };
 
-/ {
-	zephyr,user {
-		/* Select MCO pin to use. */
-		pinctrl-0 = <&rcc_mco_pa8>;
-		pinctrl-names = "default";
-	};
+/* See reference manual (RM0456):
+ *   0b0111: LSE clock selected
+ */
+#define MCO1_SEL_LSE 7
+
+/* See reference manual (RM0456):
+ *   0b001: MCO divided by 2
+ */
+#define MCO1_PRE_DIV_2 1
+
+&mco1 {
+	status = "okay";
+	clocks = <&rcc STM32_SRC_LSE MCO1_SEL(MCO1_SEL_LSE)>;
+	prescaler = <MCO1_PRE(MCO1_PRE_DIV_2)>;
+	pinctrl-0 = <&rcc_mco_pa8>;
+	pinctrl-names = "default";
 };

--- a/samples/boards/st/mco/boards/stm32f746g_disco.overlay
+++ b/samples/boards/st/mco/boards/stm32f746g_disco.overlay
@@ -1,0 +1,44 @@
+/* The clock that is output must be enabled. */
+&clk_lse {
+	status = "okay";
+};
+
+&clk_hse {
+	status = "okay";
+};
+
+/* See reference manual (RM0385):
+ *   0b01: LSE oscillator selected
+ */
+#define MCO1_SEL_LSE 1
+
+/* See reference manual (RM0385):
+ *   0b100: division by 2
+ */
+#define MCO1_PRE_DIV_2 4
+
+&mco1 {
+	status = "okay";
+	clocks = <&rcc STM32_SRC_LSE MCO1_SEL(MCO1_SEL_LSE)>;
+	prescaler = <MCO1_PRE(MCO1_PRE_DIV_2)>;
+	pinctrl-0 = <&rcc_mco_1_pa8>; /* D10 (CN7) */
+	pinctrl-names = "default";
+};
+
+/* See reference manual (RM0385):
+ *   0b10: HSE oscillator clock selected
+ */
+#define MCO2_SEL_HSE 2
+
+/* See reference manual (RM0385):
+ *   0b111: division by 5
+ */
+#define MCO2_PRE_DIV_5 7
+
+&mco2 {
+	status = "okay";
+	clocks = <&rcc STM32_SRC_HSE MCO2_SEL(MCO2_SEL_HSE)>;
+	prescaler = <MCO2_PRE(MCO2_PRE_DIV_5)>;
+	pinctrl-0 = <&rcc_mco_2_pc9>; /* uSD_D1 (CN3 pin 8) */
+	pinctrl-names = "default";
+};

--- a/samples/boards/st/mco/prj.conf
+++ b/samples/boards/st/mco/prj.conf
@@ -1,3 +1,1 @@
-# Set MCO1 source to desired clock.
-CONFIG_CLOCK_STM32_MCO1_SRC_LSE=y
-CONFIG_CLOCK_STM32_MCO1_DIV=1
+# Empty

--- a/samples/boards/st/mco/sample.yaml
+++ b/samples/boards/st/mco/sample.yaml
@@ -2,5 +2,5 @@ sample:
   name: STM32 microcontroller clock output (MCO) example
 tests:
   sample.board.stm32.mco:
-    platform_allow: nucleo_u5a5zj_q
+    platform_allow: nucleo_u5a5zj_q stm32f746g_disco
     tags: board

--- a/samples/boards/st/mco/src/main.c
+++ b/samples/boards/st/mco/src/main.c
@@ -25,6 +25,16 @@ int main(void)
 		return -1;
 	}
 
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(mco2), okay)
+	dev = DEVICE_DT_GET(DT_NODELABEL(mco2));
+	if (device_is_ready(dev)) {
+		printk("MCO2 device successfully configured\n");
+	} else {
+		printk("MCO2 device not ready\n");
+		return -1;
+	}
+#endif
+
 	printk("\nDisplayed the status of all MCO devices - end of example.\n");
 	return 0;
 }

--- a/samples/boards/st/mco/src/main.c
+++ b/samples/boards/st/mco/src/main.c
@@ -7,15 +7,24 @@
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/pinctrl.h>
 
-/* Define the pinctrl information for the MCO pin. */
-PINCTRL_DT_DEFINE(DT_PATH(zephyr_user));
-
 int main(void)
 {
-	/* Configure the MCO pin using pinctrl in order to set the alternate function of the pin. */
-	const struct pinctrl_dev_config *pcfg = PINCTRL_DT_DEV_CONFIG_GET(DT_PATH(zephyr_user));
-	(void)pinctrl_apply_state(pcfg, PINCTRL_STATE_DEFAULT);
+	const struct device *dev;
 
-	printk("\nMCO pin configured, end of example.\n");
+	/* This sample demonstrates MCO usage via Device Tree.
+	 * MCO configuration is performed in the Device Tree overlay files.
+	 * Each MCO will be enabled automatically by the driver during device
+	 * initialization. This sample checks that all MCOs are ready - if so,
+	 * the selected clock should be visible on the chosen GPIO pin.
+	 */
+	dev = DEVICE_DT_GET(DT_NODELABEL(mco1));
+	if (device_is_ready(dev)) {
+		printk("MCO1 device successfully configured\n");
+	} else {
+		printk("MCO1 device not ready\n");
+		return -1;
+	}
+
+	printk("\nDisplayed the status of all MCO devices - end of example.\n");
 	return 0;
 }


### PR DESCRIPTION
Deprecated setting MCO source and prescalor in Kconfig in favour of setting it through devicetree.