### PR TITLE
drivers/sensor/st: Fix wrong data byte swap for be

### DIFF
--- a/drivers/sensor/st/hts221/hts221.c
+++ b/drivers/sensor/st/hts221/hts221.c
@@ -9,7 +9,6 @@
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/init.h>
 #include <zephyr/sys/__assert.h>
-#include <zephyr/sys/byteorder.h>
 #include <string.h>
 #include <zephyr/logging/log.h>
 
@@ -82,8 +81,8 @@ static int hts221_sample_fetch(const struct device *dev,
 		return status;
 	}
 
-	data->rh_sample = sys_le16_to_cpu(buf[0] | (buf[1] << 8));
-	data->t_sample = sys_le16_to_cpu(buf[2] | (buf[3] << 8));
+	data->rh_sample = buf[0] | (buf[1] << 8);
+	data->t_sample = buf[2] | (buf[3] << 8);
 
 	return 0;
 }
@@ -105,12 +104,12 @@ static int hts221_read_conversion_data(const struct device *dev)
 
 	data->h0_rh_x2 = buf[0];
 	data->h1_rh_x2 = buf[1];
-	data->t0_degc_x8 = sys_le16_to_cpu(buf[2] | ((buf[5] & 0x3) << 8));
-	data->t1_degc_x8 = sys_le16_to_cpu(buf[3] | ((buf[5] & 0xC) << 6));
-	data->h0_t0_out = sys_le16_to_cpu(buf[6] | (buf[7] << 8));
-	data->h1_t0_out = sys_le16_to_cpu(buf[10] | (buf[11] << 8));
-	data->t0_out = sys_le16_to_cpu(buf[12] | (buf[13] << 8));
-	data->t1_out = sys_le16_to_cpu(buf[14] | (buf[15] << 8));
+	data->t0_degc_x8 = buf[2] | ((buf[5] & 0x3) << 8);
+	data->t1_degc_x8 = buf[3] | ((buf[5] & 0xC) << 6);
+	data->h0_t0_out = buf[6] | (buf[7] << 8);
+	data->h1_t0_out = buf[10] | (buf[11] << 8);
+	data->t0_out = buf[12] | (buf[13] << 8);
+	data->t1_out = buf[14] | (buf[15] << 8);
 
 	return 0;
 }

--- a/drivers/sensor/st/iis2dh/iis2dh.c
+++ b/drivers/sensor/st/iis2dh/iis2dh.c
@@ -12,7 +12,6 @@
 
 #include <zephyr/init.h>
 #include <zephyr/sys/__assert.h>
-#include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/drivers/sensor.h>
@@ -213,9 +212,9 @@ static int iis2dh_sample_fetch(const struct device *dev,
 		return -EIO;
 	}
 
-	iis2dh->acc[0] = sys_le16_to_cpu(buf[0]);
-	iis2dh->acc[1] = sys_le16_to_cpu(buf[1]);
-	iis2dh->acc[2] = sys_le16_to_cpu(buf[2]);
+	iis2dh->acc[0] = buf[0];
+	iis2dh->acc[1] = buf[1];
+	iis2dh->acc[2] = buf[2];
 
 	return 0;
 }

--- a/drivers/sensor/st/iis2dlpc/iis2dlpc.c
+++ b/drivers/sensor/st/iis2dlpc/iis2dlpc.c
@@ -12,7 +12,6 @@
 
 #include <zephyr/init.h>
 #include <zephyr/sys/__assert.h>
-#include <zephyr/sys/byteorder.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/drivers/sensor.h>
 
@@ -244,9 +243,9 @@ static int iis2dlpc_sample_fetch(const struct device *dev,
 		shift = IIS2DLPC_SHIFT_PMOTHER;
 	}
 
-	iis2dlpc->acc[0] = sys_le16_to_cpu(buf[0]) >> shift;
-	iis2dlpc->acc[1] = sys_le16_to_cpu(buf[1]) >> shift;
-	iis2dlpc->acc[2] = sys_le16_to_cpu(buf[2]) >> shift;
+	iis2dlpc->acc[0] = buf[0] >> shift;
+	iis2dlpc->acc[1] = buf[1] >> shift;
+	iis2dlpc->acc[2] = buf[2] >> shift;
 
 	return 0;
 }

--- a/drivers/sensor/st/iis2iclx/iis2iclx.c
+++ b/drivers/sensor/st/iis2iclx/iis2iclx.c
@@ -15,7 +15,6 @@
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 #include <string.h>
-#include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/logging/log.h>
 
@@ -204,8 +203,8 @@ static int iis2iclx_sample_fetch_accel(const struct device *dev)
 		return -EIO;
 	}
 
-	data->acc[0] = sys_le16_to_cpu(buf[0]);
-	data->acc[1] = sys_le16_to_cpu(buf[1]);
+	data->acc[0] = buf[0];
+	data->acc[1] = buf[1];
 
 	return 0;
 }
@@ -222,7 +221,7 @@ static int iis2iclx_sample_fetch_temp(const struct device *dev)
 		return -EIO;
 	}
 
-	data->temp_sample = sys_le16_to_cpu(buf);
+	data->temp_sample = buf;
 
 	return 0;
 }

--- a/drivers/sensor/st/iis2iclx/iis2iclx_shub.c
+++ b/drivers/sensor/st/iis2iclx/iis2iclx_shub.c
@@ -12,7 +12,6 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/i2c.h>
-#include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/kernel.h>
@@ -171,8 +170,8 @@ static int hts221_read_conv_data(const struct device *dev,
 
 	ht->y0 = buf[0] / 2;
 	ht->y1 = buf[1] / 2;
-	ht->x0 = sys_le16_to_cpu(buf[6] | (buf[7] << 8));
-	ht->x1 = sys_le16_to_cpu(buf[10] | (buf[11] << 8));
+	ht->x0 = buf[6] | (buf[7] << 8);
+	ht->x1 = buf[10] | (buf[11] << 8);
 
 	return 0;
 }

--- a/drivers/sensor/st/iis2mdc/iis2mdc.c
+++ b/drivers/sensor/st/iis2mdc/iis2mdc.c
@@ -12,7 +12,6 @@
 
 #include <zephyr/init.h>
 #include <zephyr/sys/__assert.h>
-#include <zephyr/sys/byteorder.h>
 #include <zephyr/drivers/sensor.h>
 #include <string.h>
 #include <zephyr/logging/log.h>
@@ -63,7 +62,7 @@ static int iis2mdc_set_hard_iron(const struct device *dev,
 	int16_t offset[3];
 
 	for (i = 0U; i < 3; i++) {
-		offset[i] = sys_cpu_to_le16(val->val1);
+		offset[i] = val->val1;
 		val++;
 	}
 
@@ -185,9 +184,9 @@ static int iis2mdc_sample_fetch_mag(const struct device *dev)
 		return -EIO;
 	}
 
-	iis2mdc->mag[0] = sys_le16_to_cpu(raw_mag[0]);
-	iis2mdc->mag[1] = sys_le16_to_cpu(raw_mag[1]);
-	iis2mdc->mag[2] = sys_le16_to_cpu(raw_mag[2]);
+	iis2mdc->mag[0] = raw_mag[0];
+	iis2mdc->mag[1] = raw_mag[1];
+	iis2mdc->mag[2] = raw_mag[2];
 
 	return 0;
 }
@@ -205,7 +204,7 @@ static int iis2mdc_sample_fetch_temp(const struct device *dev)
 	}
 
 	/* formula is temp = 25 + (temp / 8) C */
-	temp = sys_le16_to_cpu(raw_temp);
+	temp = raw_temp;
 	iis2mdc->temp_sample = 2500 + (temp * 100) / 8;
 
 	return 0;

--- a/drivers/sensor/st/iis3dhhc/iis3dhhc.c
+++ b/drivers/sensor/st/iis3dhhc/iis3dhhc.c
@@ -13,7 +13,6 @@
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>
-#include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/logging/log.h>
 
@@ -30,9 +29,9 @@ static int iis3dhhc_sample_fetch(const struct device *dev,
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL);
 
 	iis3dhhc_acceleration_raw_get(data->ctx, raw_accel);
-	data->acc[0] = sys_le16_to_cpu(raw_accel[0]);
-	data->acc[1] = sys_le16_to_cpu(raw_accel[1]);
-	data->acc[2] = sys_le16_to_cpu(raw_accel[2]);
+	data->acc[0] = raw_accel[0];
+	data->acc[1] = raw_accel[1];
+	data->acc[2] = raw_accel[2];
 
 	return 0;
 }

--- a/drivers/sensor/st/ism330dhcx/ism330dhcx.c
+++ b/drivers/sensor/st/ism330dhcx/ism330dhcx.c
@@ -15,7 +15,6 @@
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 #include <string.h>
-#include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/logging/log.h>
@@ -309,9 +308,9 @@ static int ism330dhcx_sample_fetch_accel(const struct device *dev)
 		return -EIO;
 	}
 
-	data->acc[0] = sys_le16_to_cpu(buf[0]);
-	data->acc[1] = sys_le16_to_cpu(buf[1]);
-	data->acc[2] = sys_le16_to_cpu(buf[2]);
+	data->acc[0] = buf[0];
+	data->acc[1] = buf[1];
+	data->acc[2] = buf[2];
 
 	return 0;
 }
@@ -326,9 +325,9 @@ static int ism330dhcx_sample_fetch_gyro(const struct device *dev)
 		return -EIO;
 	}
 
-	data->gyro[0] = sys_le16_to_cpu(buf[0]);
-	data->gyro[1] = sys_le16_to_cpu(buf[1]);
-	data->gyro[2] = sys_le16_to_cpu(buf[2]);
+	data->gyro[0] = buf[0];
+	data->gyro[1] = buf[1];
+	data->gyro[2] = buf[2];
 
 	return 0;
 }
@@ -344,7 +343,7 @@ static int ism330dhcx_sample_fetch_temp(const struct device *dev)
 		return -EIO;
 	}
 
-	data->temp_sample = sys_le16_to_cpu(buf);
+	data->temp_sample = buf;
 
 	return 0;
 }

--- a/drivers/sensor/st/ism330dhcx/ism330dhcx_shub.c
+++ b/drivers/sensor/st/ism330dhcx/ism330dhcx_shub.c
@@ -12,7 +12,6 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/i2c.h>
-#include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/kernel.h>
@@ -165,8 +164,8 @@ static int ism330dhcx_hts221_read_conv_data(const struct device *dev, uint8_t i2
 
 	ht->y0 = buf[0] / 2;
 	ht->y1 = buf[1] / 2;
-	ht->x0 = sys_le16_to_cpu(buf[6] | (buf[7] << 8));
-	ht->x1 = sys_le16_to_cpu(buf[10] | (buf[11] << 8));
+	ht->x0 = buf[6] | (buf[7] << 8);
+	ht->x1 = buf[10] | (buf[11] << 8);
 
 	return 0;
 }

--- a/drivers/sensor/st/lis2ds12/lis2ds12.c
+++ b/drivers/sensor/st/lis2ds12/lis2ds12.c
@@ -15,7 +15,6 @@
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 #include <string.h>
-#include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/dt-bindings/sensor/lis2ds12.h>
@@ -175,9 +174,9 @@ static int lis2ds12_sample_fetch_accel(const struct device *dev)
 		return -EIO;
 	}
 
-	data->sample_x = sys_le16_to_cpu(buf[0]);
-	data->sample_y = sys_le16_to_cpu(buf[1]);
-	data->sample_z = sys_le16_to_cpu(buf[2]);
+	data->sample_x = buf[0];
+	data->sample_y = buf[1];
+	data->sample_z = buf[2];
 
 	return 0;
 }

--- a/drivers/sensor/st/lis2dux12/lis2dux12.c
+++ b/drivers/sensor/st/lis2dux12/lis2dux12.c
@@ -15,7 +15,6 @@
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 #include <string.h>
-#include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/logging/log.h>
@@ -198,9 +197,9 @@ static int lis2dux12_sample_fetch_accel(const struct device *dev)
 		return -EIO;
 	}
 
-	data->sample_x = sys_le16_to_cpu(xzy_data.raw[0]);
-	data->sample_y = sys_le16_to_cpu(xzy_data.raw[1]);
-	data->sample_z = sys_le16_to_cpu(xzy_data.raw[2]);
+	data->sample_x = xzy_data.raw[0];
+	data->sample_y = xzy_data.raw[1];
+	data->sample_z = xzy_data.raw[2];
 
 	return 0;
 }
@@ -220,7 +219,7 @@ static int lis2dux12_sample_fetch_temp(const struct device *dev)
 		return -EIO;
 	}
 
-	data->sample_temp = sys_le16_to_cpu(temp_data.heat.deg_c);
+	data->sample_temp = temp_data.heat.deg_c;
 
 	return 0;
 }

--- a/drivers/sensor/st/lis2dw12/lis2dw12.c
+++ b/drivers/sensor/st/lis2dw12/lis2dw12.c
@@ -13,7 +13,6 @@
 #include <zephyr/init.h>
 #include <stdlib.h>
 #include <zephyr/sys/__assert.h>
-#include <zephyr/sys/byteorder.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/drivers/sensor.h>
 
@@ -332,9 +331,9 @@ static int lis2dw12_sample_fetch(const struct device *dev,
 		shift = LIS2DW12_SHIFT_PMOTHER;
 	}
 
-	lis2dw12->acc[0] = sys_le16_to_cpu(buf[0]) >> shift;
-	lis2dw12->acc[1] = sys_le16_to_cpu(buf[1]) >> shift;
-	lis2dw12->acc[2] = sys_le16_to_cpu(buf[2]) >> shift;
+	lis2dw12->acc[0] = buf[0] >> shift;
+	lis2dw12->acc[1] = buf[1] >> shift;
+	lis2dw12->acc[2] = buf[2] >> shift;
 
 	return 0;
 }

--- a/drivers/sensor/st/lis2mdl/lis2mdl.c
+++ b/drivers/sensor/st/lis2mdl/lis2mdl.c
@@ -12,7 +12,6 @@
 
 #include <zephyr/init.h>
 #include <zephyr/sys/__assert.h>
-#include <zephyr/sys/byteorder.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/pm/device.h>
 #include <string.h>
@@ -74,7 +73,7 @@ static int lis2mdl_set_hard_iron(const struct device *dev,
 	int16_t offset[3];
 
 	for (i = 0U; i < 3; i++) {
-		offset[i] = sys_cpu_to_le16(val->val1);
+		offset[i] = val->val1;
 		val++;
 	}
 
@@ -229,9 +228,9 @@ static int lis2mdl_sample_fetch_mag(const struct device *dev)
 			LOG_ERR("Failed to read raw data");
 			return rc;
 		}
-		lis2mdl->mag[0] = sys_le16_to_cpu(raw_mag[0]);
-		lis2mdl->mag[1] = sys_le16_to_cpu(raw_mag[1]);
-		lis2mdl->mag[2] = sys_le16_to_cpu(raw_mag[2]);
+		lis2mdl->mag[0] = raw_mag[0];
+		lis2mdl->mag[1] = raw_mag[1];
+		lis2mdl->mag[2] = raw_mag[2];
 
 		if (cfg->cancel_offset) {
 			/* The second measurement is needed when offset
@@ -247,9 +246,9 @@ static int lis2mdl_sample_fetch_mag(const struct device *dev)
 				LOG_ERR("Failed to read raw data");
 				return rc;
 			}
-			lis2mdl->mag[0] += sys_le16_to_cpu(raw_mag[0]);
-			lis2mdl->mag[1] += sys_le16_to_cpu(raw_mag[1]);
-			lis2mdl->mag[2] += sys_le16_to_cpu(raw_mag[2]);
+			lis2mdl->mag[0] += raw_mag[0];
+			lis2mdl->mag[1] += raw_mag[1];
+			lis2mdl->mag[2] += raw_mag[2];
 			lis2mdl->mag[0] /= 2;
 			lis2mdl->mag[1] /= 2;
 			lis2mdl->mag[2] /= 2;
@@ -262,9 +261,9 @@ static int lis2mdl_sample_fetch_mag(const struct device *dev)
 			LOG_ERR("Failed to read sample");
 			return rc;
 		}
-		lis2mdl->mag[0] = sys_le16_to_cpu(raw_mag[0]);
-		lis2mdl->mag[1] = sys_le16_to_cpu(raw_mag[1]);
-		lis2mdl->mag[2] = sys_le16_to_cpu(raw_mag[2]);
+		lis2mdl->mag[0] = raw_mag[0];
+		lis2mdl->mag[1] = raw_mag[1];
+		lis2mdl->mag[2] = raw_mag[2];
 	}
 	return 0;
 }
@@ -282,7 +281,7 @@ static int lis2mdl_sample_fetch_temp(const struct device *dev)
 		return -EIO;
 	}
 
-	lis2mdl->temp_sample = (sys_le16_to_cpu(raw_temp));
+	lis2mdl->temp_sample = raw_temp;
 
 	return 0;
 }

--- a/drivers/sensor/st/lsm6dso/lsm6dso.c
+++ b/drivers/sensor/st/lsm6dso/lsm6dso.c
@@ -15,7 +15,6 @@
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 #include <string.h>
-#include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/logging/log.h>
 
@@ -525,12 +524,12 @@ static inline int lsm6dso_magn_get_channel(enum sensor_channel chan,
 	}
 
 
-	sample[0] = sys_le16_to_cpu((int16_t)(data->ext_data[idx][0] |
-				    (data->ext_data[idx][1] << 8)));
-	sample[1] = sys_le16_to_cpu((int16_t)(data->ext_data[idx][2] |
-				    (data->ext_data[idx][3] << 8)));
-	sample[2] = sys_le16_to_cpu((int16_t)(data->ext_data[idx][4] |
-				    (data->ext_data[idx][5] << 8)));
+	sample[0] = (int16_t)(data->ext_data[idx][0] |
+			     (data->ext_data[idx][1] << 8));
+	sample[1] = (int16_t)(data->ext_data[idx][2] |
+			     (data->ext_data[idx][3] << 8));
+	sample[2] = (int16_t)(data->ext_data[idx][4] |
+			     (data->ext_data[idx][5] << 8));
 
 	switch (chan) {
 	case SENSOR_CHAN_MAGN_X:
@@ -568,8 +567,8 @@ static inline void lsm6dso_hum_convert(struct sensor_value *val,
 		return;
 	}
 
-	raw_val = sys_le16_to_cpu((int16_t)(data->ext_data[idx][0] |
-					  (data->ext_data[idx][1] << 8)));
+	raw_val = (int16_t)(data->ext_data[idx][0] |
+			   (data->ext_data[idx][1] << 8));
 
 	/* find relative humidty by linear interpolation */
 	rh = (ht->y1 - ht->y0) * raw_val + ht->x1 * ht->y0 - ht->x0 * ht->y1;
@@ -592,9 +591,9 @@ static inline void lsm6dso_press_convert(struct sensor_value *val,
 		return;
 	}
 
-	raw_val = sys_le32_to_cpu((int32_t)(data->ext_data[idx][0] |
-					  (data->ext_data[idx][1] << 8) |
-					  (data->ext_data[idx][2] << 16)));
+	raw_val = (int32_t)(data->ext_data[idx][0] |
+			   (data->ext_data[idx][1] << 8) |
+			   (data->ext_data[idx][2] << 16));
 
 	/* Pressure sensitivity is 4096 LSB/hPa */
 	/* Convert raw_val to val in kPa */
@@ -615,8 +614,8 @@ static inline void lsm6dso_temp_convert(struct sensor_value *val,
 		return;
 	}
 
-	raw_val = sys_le16_to_cpu((int16_t)(data->ext_data[idx][3] |
-					  (data->ext_data[idx][4] << 8)));
+	raw_val = (int16_t)(data->ext_data[idx][3] |
+			   (data->ext_data[idx][4] << 8));
 
 	/* Temperature sensitivity is 100 LSB/deg C */
 	val->val1 = raw_val / 100;

--- a/drivers/sensor/st/lsm6dso/lsm6dso_shub.c
+++ b/drivers/sensor/st/lsm6dso/lsm6dso_shub.c
@@ -12,7 +12,6 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/i2c.h>
-#include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/kernel.h>
@@ -155,8 +154,8 @@ static int lsm6dso_hts221_read_conv_data(const struct device *dev,
 
 	ht->y0 = buf[0] / 2;
 	ht->y1 = buf[1] / 2;
-	ht->x0 = sys_le16_to_cpu(buf[6] | (buf[7] << 8));
-	ht->x1 = sys_le16_to_cpu(buf[10] | (buf[11] << 8));
+	ht->x0 = buf[6] | (buf[7] << 8);
+	ht->x1 = buf[10] | (buf[11] << 8);
 
 	return 0;
 }

--- a/drivers/sensor/st/lsm6dso16is/lsm6dso16is.c
+++ b/drivers/sensor/st/lsm6dso16is/lsm6dso16is.c
@@ -15,7 +15,6 @@
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 #include <string.h>
-#include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/logging/log.h>
 
@@ -556,12 +555,12 @@ static inline int lsm6dso16is_magn_get_channel(enum sensor_channel chan,
 	}
 
 
-	sample[0] = sys_le16_to_cpu((int16_t)(data->ext_data[idx][0] |
-				    (data->ext_data[idx][1] << 8)));
-	sample[1] = sys_le16_to_cpu((int16_t)(data->ext_data[idx][2] |
-				    (data->ext_data[idx][3] << 8)));
-	sample[2] = sys_le16_to_cpu((int16_t)(data->ext_data[idx][4] |
-				    (data->ext_data[idx][5] << 8)));
+	sample[0] = (int16_t)(data->ext_data[idx][0] |
+			     (data->ext_data[idx][1] << 8));
+	sample[1] = (int16_t)(data->ext_data[idx][2] |
+			     (data->ext_data[idx][3] << 8));
+	sample[2] = (int16_t)(data->ext_data[idx][4] |
+			     (data->ext_data[idx][5] << 8));
 
 	switch (chan) {
 	case SENSOR_CHAN_MAGN_X:
@@ -599,8 +598,8 @@ static inline void lsm6dso16is_hum_convert(struct sensor_value *val,
 		return;
 	}
 
-	raw_val = sys_le16_to_cpu((int16_t)(data->ext_data[idx][0] |
-					  (data->ext_data[idx][1] << 8)));
+	raw_val = (int16_t)(data->ext_data[idx][0] |
+			   (data->ext_data[idx][1] << 8));
 
 	/* find relative humidty by linear interpolation */
 	rh = (ht->y1 - ht->y0) * raw_val + ht->x1 * ht->y0 - ht->x0 * ht->y1;
@@ -623,9 +622,9 @@ static inline void lsm6dso16is_press_convert(struct sensor_value *val,
 		return;
 	}
 
-	raw_val = sys_le32_to_cpu((int32_t)(data->ext_data[idx][0] |
-					  (data->ext_data[idx][1] << 8) |
-					  (data->ext_data[idx][2] << 16)));
+	raw_val = (int32_t)(data->ext_data[idx][0] |
+			   (data->ext_data[idx][1] << 8) |
+			   (data->ext_data[idx][2] << 16));
 
 	/* Pressure sensitivity is 4096 LSB/hPa */
 	/* Convert raw_val to val in kPa */
@@ -646,8 +645,8 @@ static inline void lsm6dso16is_temp_convert(struct sensor_value *val,
 		return;
 	}
 
-	raw_val = sys_le16_to_cpu((int16_t)(data->ext_data[idx][3] |
-					  (data->ext_data[idx][4] << 8)));
+	raw_val = (int16_t)(data->ext_data[idx][3] |
+			   (data->ext_data[idx][4] << 8));
 
 	/* Temperature sensitivity is 100 LSB/deg C */
 	val->val1 = raw_val / 100;

--- a/drivers/sensor/st/lsm6dso16is/lsm6dso16is_shub.c
+++ b/drivers/sensor/st/lsm6dso16is/lsm6dso16is_shub.c
@@ -12,7 +12,6 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/i2c.h>
-#include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/kernel.h>
@@ -156,8 +155,8 @@ static int lsm6dso16is_hts221_read_conv_data(const struct device *dev,
 
 	ht->y0 = buf[0] / 2;
 	ht->y1 = buf[1] / 2;
-	ht->x0 = sys_le16_to_cpu(buf[6] | (buf[7] << 8));
-	ht->x1 = sys_le16_to_cpu(buf[10] | (buf[11] << 8));
+	ht->x0 = buf[6] | (buf[7] << 8);
+	ht->x1 = buf[10] | (buf[11] << 8);
 
 	return 0;
 }

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.c
@@ -15,7 +15,6 @@
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 #include <string.h>
-#include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/logging/log.h>
 
@@ -602,12 +601,12 @@ static inline int lsm6dsv16x_magn_get_channel(enum sensor_channel chan,
 	}
 
 
-	sample[0] = sys_le16_to_cpu((int16_t)(data->ext_data[idx][0] |
-				    (data->ext_data[idx][1] << 8)));
-	sample[1] = sys_le16_to_cpu((int16_t)(data->ext_data[idx][2] |
-				    (data->ext_data[idx][3] << 8)));
-	sample[2] = sys_le16_to_cpu((int16_t)(data->ext_data[idx][4] |
-				    (data->ext_data[idx][5] << 8)));
+	sample[0] = (int16_t)(data->ext_data[idx][0] |
+			     (data->ext_data[idx][1] << 8));
+	sample[1] = (int16_t)(data->ext_data[idx][2] |
+			     (data->ext_data[idx][3] << 8));
+	sample[2] = (int16_t)(data->ext_data[idx][4] |
+			     (data->ext_data[idx][5] << 8));
 
 	switch (chan) {
 	case SENSOR_CHAN_MAGN_X:
@@ -645,8 +644,8 @@ static inline void lsm6dsv16x_hum_convert(struct sensor_value *val,
 		return;
 	}
 
-	raw_val = sys_le16_to_cpu((int16_t)(data->ext_data[idx][0] |
-					  (data->ext_data[idx][1] << 8)));
+	raw_val = (int16_t)(data->ext_data[idx][0] |
+			   (data->ext_data[idx][1] << 8));
 
 	/* find relative humidty by linear interpolation */
 	rh = (ht->y1 - ht->y0) * raw_val + ht->x1 * ht->y0 - ht->x0 * ht->y1;
@@ -669,9 +668,9 @@ static inline void lsm6dsv16x_press_convert(struct sensor_value *val,
 		return;
 	}
 
-	raw_val = sys_le32_to_cpu((int32_t)(data->ext_data[idx][0] |
-					  (data->ext_data[idx][1] << 8) |
-					  (data->ext_data[idx][2] << 16)));
+	raw_val = (int32_t)(data->ext_data[idx][0] |
+			   (data->ext_data[idx][1] << 8) |
+			   (data->ext_data[idx][2] << 16));
 
 	/* Pressure sensitivity is 4096 LSB/hPa */
 	/* Convert raw_val to val in kPa */
@@ -692,8 +691,8 @@ static inline void lsm6dsv16x_temp_convert(struct sensor_value *val,
 		return;
 	}
 
-	raw_val = sys_le16_to_cpu((int16_t)(data->ext_data[idx][3] |
-					  (data->ext_data[idx][4] << 8)));
+	raw_val = (int16_t)(data->ext_data[idx][3] |
+			   (data->ext_data[idx][4] << 8));
 
 	/* Temperature sensitivity is 100 LSB/deg C */
 	val->val1 = raw_val / 100;

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_shub.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_shub.c
@@ -12,7 +12,6 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/i2c.h>
-#include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/kernel.h>
@@ -156,8 +155,8 @@ static int lsm6dsv16x_hts221_read_conv_data(const struct device *dev,
 
 	ht->y0 = buf[0] / 2;
 	ht->y1 = buf[1] / 2;
-	ht->x0 = sys_le16_to_cpu(buf[6] | (buf[7] << 8));
-	ht->x1 = sys_le16_to_cpu(buf[10] | (buf[11] << 8));
+	ht->x0 = buf[6] | (buf[7] << 8);
+	ht->x1 = buf[10] | (buf[11] << 8);
 
 	return 0;
 }


### PR DESCRIPTION
A 16-bit value built using byte shifts and ORs from a given
couple of lsb and msb bytes will result to be the same on both
little-endian and big-endian architectures, e.g.

    uint8_t lsb, msb;
    int16_t val;

    /* val is the same number on both le and be archs, but has
       different layout in memory */
    val = (msb << 8) | lsb;

All the xyz_raw_get() APIs of stmemsc sensor module build the sensor
data using the above method and DO NOT hence require (it actually leads
to wrong values on big-endian machines) to use any le/be swap routines,
such as sys_le16_to_cpu().

Fix https://github.com/zephyrproject-rtos/zephyr/issues/75758