### PR TITLE
[RFC] Update mirrored display handling for ILI9xxx displays.

### DIFF
--- a/drivers/display/display_ili9xxx.h
+++ b/drivers/display/display_ili9xxx.h
@@ -56,17 +56,7 @@
 /** Reset wait time (ms), ref 15.4 of ILI9XXX manual. */
 #define ILI9XXX_RESET_WAIT_TIME 5
 
-enum madctl_cmd_set {
-	CMD_SET_1,	/* Default for most of ILI9xxx display controllers */
-	CMD_SET_2,	/* Used by ILI9342c */
-};
-
-struct ili9xxx_quirks {
-	enum madctl_cmd_set cmd_set;
-};
-
 struct ili9xxx_config {
-	const struct ili9xxx_quirks *quirks;
 	const struct device *mipi_dev;
 	struct mipi_dbi_config dbi_config;
 	uint8_t pixel_format;
@@ -74,6 +64,8 @@ struct ili9xxx_config {
 	uint16_t x_resolution;
 	uint16_t y_resolution;
 	bool inversion;
+	bool x_mirrored;
+	bool y_mirrored;
 	const void *regs;
 	int (*regs_init_fn)(const struct device *dev);
 };

--- a/dts/bindings/display/ilitek,ili9xxx-common.yaml
+++ b/dts/bindings/display/ilitek,ili9xxx-common.yaml
@@ -29,6 +29,16 @@ properties:
     description:
       Display rotation (CW) in degrees.
       If not defined, rotation is off by default.
+  
+  x-mirrored:
+    type: boolean
+    description:
+      Display content is mirrored along the x-axis.
+
+  y-mirrored:
+    type: boolean
+    description:
+      Display content is mirrored along the y-axis.
 
   display-inversion:
     type: boolean


### PR DESCRIPTION
This PR removes the quirks from the ili9xxx display driver and replaces it with proper x- and y-mirroring. All ili display drivers have the same options and the same meaning.

The old set 2 configuration is the default configuration without mirroring and the set 1 configuration had an x-mirror enabled. The required mirroring is not dependent on the type of driver IC but on the way how the pixel matrix is connected to the driver IC.

With the change a user can define a orientation, x-mirrored and y-mirrored config value and still can change the orientation via the api respecting the mirrored options.

This is some what a breaking change as the default behavior without x- or y-mirrored set is changed.

See https://cdn-shop.adafruit.com/datasheets/ILI9341.pdf page 209 for reference.

I did this change, because I have a board with a ILI9341 and the image was mirrored. So I would need this change to be able to use the driver.