### PR TITLE
scripts: nrf_common: Use cfg for SUIT paths

### DIFF
--- a/scripts/west_commands/runners/nrf_common.py
+++ b/scripts/west_commands/runners/nrf_common.py
@@ -265,14 +265,14 @@ class NrfBinaryRunner(ZephyrBinaryRunner):
             # This logic should be executed only once per build.
             # Use sysbuild board qualifiers to select the context, with which the artifacts will be programmed.
             if self.build_conf.get('CONFIG_BOARD_QUALIFIERS') == self.sysbuild_conf.get('SB_CONFIG_BOARD_QUALIFIERS'):
-                hex_path = Path(self.hex_)
+                mpi_hex_dir = Path(os.path.join(self.cfg.build_dir, 'zephyr'))
 
                 # Handle Manifest Provisioning Information
                 if self.build_conf.getboolean('CONFIG_SUIT_MPI_GENERATE'):
                     app_mpi_hex_file = os.fspath(
-                        hex_path.parent / self.build_conf.get('CONFIG_SUIT_MPI_APP_AREA_PATH'))
+                        mpi_hex_dir / self.build_conf.get('CONFIG_SUIT_MPI_APP_AREA_PATH'))
                     rad_mpi_hex_file = os.fspath(
-                        hex_path.parent / self.build_conf.get('CONFIG_SUIT_MPI_RAD_AREA_PATH'))
+                        mpi_hex_dir / self.build_conf.get('CONFIG_SUIT_MPI_RAD_AREA_PATH'))
                     self.op_program(app_mpi_hex_file, 'ERASE_NONE', None, defer=True, core='NRFDL_DEVICE_CORE_APPLICATION')
                     self.op_program(rad_mpi_hex_file, 'ERASE_NONE', None, defer=True, core='NRFDL_DEVICE_CORE_NETWORK')
 
@@ -281,7 +281,7 @@ class NrfBinaryRunner(ZephyrBinaryRunner):
                 # as well as the output HEX file.
                 if not self.build_conf.getboolean('CONFIG_SOC_NRF54H20_CPUAPP') and self.sysbuild_conf.get('SB_CONFIG_SUIT_ENVELOPE'):
                     app_root_envelope_hex_file = os.fspath(
-                        hex_path.parent / 'suit_installed_envelopes_application_merged.hex')
+                        mpi_hex_dir / 'suit_installed_envelopes_application_merged.hex')
                     self.op_program(app_root_envelope_hex_file, 'ERASE_NONE', None, defer=True, core='NRFDL_DEVICE_CORE_APPLICATION')
 
             if self.build_conf.getboolean('CONFIG_SOC_NRF54H20_CPUAPP'):


### PR DESCRIPTION
It is safer to base the SUIT artifacts path on the path of the configuration file than the HEX file that is being flashed. The latter may be overriden by several scripts that merge/transform the final firmware image.