### PR TITLE
drivers: flash: stm32h7: Fix unused variable warning

### DIFF
--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -228,9 +228,10 @@ static struct flash_stm32_sector_t get_sector(const struct device *dev,
 {
 	struct flash_stm32_sector_t sector;
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
-	off_t temp_offset = offset + (CONFIG_FLASH_BASE_ADDRESS & 0xffffff);
 
 #ifdef DUAL_BANK
+	off_t temp_offset = offset + (CONFIG_FLASH_BASE_ADDRESS & 0xffffff);
+
 	bool bank_swap;
 	/* Check whether bank1/2 are swapped */
 	bank_swap = (READ_BIT(FLASH->OPTCR, FLASH_OPTCR_SWAP_BANK)


### PR DESCRIPTION
This variable is only used under DUAL_BANK condition and a warning is generated in !DUAL_BANK case, so move its definition accordingly.

Fixes https://github.com/zephyrproject-rtos/zephyr/actions/runs/10168465527/job/28139906422?pr=75857#step:12:1555