### PR TITLE
Enable MAX32672FTHR Display 

### DIFF
--- a/boards/adi/max32672fthr/Kconfig.defconfig
+++ b/boards/adi/max32672fthr/Kconfig.defconfig
@@ -1,0 +1,36 @@
+# MAX32672FTHR boards configuration
+
+# Copyright (c) 2024 Analog Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_MAX32672FTHR
+
+if DISPLAY
+
+if LVGL
+
+# LVGL should allocate buffers equal to size of display
+config LV_Z_VDB_SIZE
+	default 64
+
+# Default Dot Per Inch. [px/inch]
+# Used to initialize default sizes such as widgets sized, style paddings.
+config LV_DPI_DEF
+	default 128
+
+config LV_Z_BITS_PER_PIXEL
+	default 1
+
+# Use offloaded render thread
+config LV_Z_FLUSH_THREAD
+	default y
+
+choice LV_COLOR_DEPTH
+	default LV_COLOR_DEPTH_1  # 1 byte per pixel
+endchoice
+
+endif # LVGL
+
+endif # DISPLAY
+
+endif # BOARD_MAX32672FTHR

--- a/boards/adi/max32672fthr/max32672fthr.dts
+++ b/boards/adi/max32672fthr/max32672fthr.dts
@@ -20,6 +20,7 @@
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram3;
 		zephyr,flash = &flash0;
+		zephyr,display = &ssd1306;
 	};
 
 	leds {
@@ -108,4 +109,27 @@
 
 &trng {
 	status = "okay";
+};
+
+&i2c2 {
+	pinctrl-0 = <&i2c2a_scl_p0_18 &i2c2a_sda_p0_19>;
+	pinctrl-names = "default";
+	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
+
+	ssd1306: ssd1306@3d {
+		compatible = "solomon,ssd1306fb";
+		reg = <0x3d>;
+		width = <128>;
+		height = <32>;
+		segment-offset = <0>;
+		page-offset = <0>;
+		display-offset = <0>;
+		multiplex-ratio = <31>;
+		segment-remap;
+		com-invdir;
+		com-sequential;
+		prechargep = <0x22>;
+		inversion-on;
+	};
 };

--- a/dts/arm/adi/max32/max32672.dtsi
+++ b/dts/arm/adi/max32/max32672.dtsi
@@ -15,6 +15,10 @@
 	clock-frequency = <DT_FREQ_K(80)>;
 };
 
+&i2c2 {
+	clocks = <&gcr ADI_MAX32_CLOCK_BUS1 21>;
+};
+
 /delete-node/ &clk_iso;
 
 /* MAX32672 extra peripherals. */


### PR DESCRIPTION
[MAX32672FTHR ](https://github.com/zephyrproject-rtos/zephyr/blob/main/boards/adi/max32672fthr/doc/index.rst) board has [CFAL12832C-0091B](https://www.crystalfontz.com/product/cfal12832c0091bw-small-oled-white-monochrome) display which is Monochrome 128x32 I2C OLED graphic display.
This PR add board related LVGL stack definitions and updates [LVGL example](https://github.com/zephyrproject-rtos/zephyr/tree/main/samples/subsys/display/lvgl) to work with MAX32672fthr board.

MAX32672 I2C2 clock index is 21, updated.

Tested with [lvgl example](https://github.com/zephyrproject-rtos/zephyr/tree/main/samples/subsys/display/lvgl)
![image](https://github.com/user-attachments/assets/905059ae-bc1e-4959-b5f7-3c98913f0913)
