### PR TITLE
debug: thread_analyzer: fix incorrect k_thread_foreach_unlocked argument

### DIFF
--- a/subsys/debug/thread_analyzer.c
+++ b/subsys/debug/thread_analyzer.c
@@ -176,12 +176,12 @@ void thread_analyzer_run(thread_analyzer_cb cb, unsigned int cpu)
 		if (IS_ENABLED(CONFIG_THREAD_ANALYZER_AUTO_SEPARATE_CORES))
 			k_thread_foreach_unlocked_filter_by_cpu(cpu, thread_analyze_cb, &ud);
 		else
-			k_thread_foreach_unlocked(thread_analyze_cb, cb);
+			k_thread_foreach_unlocked(thread_analyze_cb, &ud);
 	} else {
 		if (IS_ENABLED(CONFIG_THREAD_ANALYZER_AUTO_SEPARATE_CORES))
 			k_thread_foreach_filter_by_cpu(cpu, thread_analyze_cb, &ud);
 		else
-			k_thread_foreach(thread_analyze_cb, cb);
+			k_thread_foreach(thread_analyze_cb, &ud);
 	}
 
 	if (IS_ENABLED(CONFIG_THREAD_ANALYZER_ISR_STACK_USAGE)) {


### PR DESCRIPTION
Fix the second k_thread_foreach_unlocked argument, it's supposed to be an instance of ta_cb_user_data as that's what's it casted back to in thread_analyze_cb. Current code results in an exception and crash for single core applications.

This is a regression introduced in 1b6e0f64796.