### PR TITLE
debug: thread_analyzer: fix casting pointer to int warning

### DIFF
--- a/subsys/debug/thread_analyzer.c
+++ b/subsys/debug/thread_analyzer.c
@@ -208,7 +208,7 @@ void thread_analyzer_print(unsigned int cpu)
 void thread_analyzer_auto(void *a, void *b, void *c)
 {
 	unsigned int cpu = IS_ENABLED(CONFIG_THREAD_ANALYZER_AUTO_SEPARATE_CORES) ?
-		(unsigned int) a : 0;
+		(unsigned int)(uintptr_t) a : 0;
 
 	for (;;) {
 		thread_analyzer_print(cpu);


### PR DESCRIPTION
In thread_analyzer_auto(), it casts one function argument directly into unsigned int. However, on 64-bit platforms, the compiler complains about casting from pointer of different size (-Wpointer-to-int-cast). So cast it first to uintptr_t before casting it into unsigned int.