### PR TITLE
ci: doc: re-introduce fail on warning in HTML build

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -253,7 +253,7 @@ jobs:
         fi
 
         DOC_TAG=${DOC_TAG} \
-        SPHINXOPTS="-q -j ${JOB_COUNT}" \
+        SPHINXOPTS="-q -j ${JOB_COUNT} -W" \
         LATEXMKOPTS="-quiet -halt-on-error" \
         make -C doc pdf
 


### PR DESCRIPTION
Commit 2c89bf57983782593dedc0f34f105fcde735677f inadvertedly removed fail on warning in the HTML build. This commit re-introduces it. Fixes #72605.