### PR TITLE
scripts: west_commands: build: Fix empty testcase

### DIFF
--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -294,9 +294,9 @@ class Build(Forceable):
             tests = y.get('tests')
             if not tests:
                 log.die(f"No tests found in {yf}")
-            item = tests.get(test_item)
-            if not item:
+            if test_item not in tests:
                 log.die(f"Test item {test_item} not found in {yf}")
+            item = tests.get(test_item)
 
             sysbuild = False
             extra_dtc_overlay_files = []


### PR DESCRIPTION
An empty but specified testcase does not build, check if the test key exists instead.

Before:
```shell
$ west build -p -b qemu_x86 tests/net/lib/http_server/tls -T net.http.server.tls
FATAL ERROR: Test item net.http.server.tls not found in tests/net/lib/http_server/tls/testcase.yaml
```

With this change, the test builds as expected.