### PR TITLE
soc: nxp: imxrt: Register log module to soc.c

### DIFF
--- a/soc/nxp/imxrt/imxrt11xx/soc.c
+++ b/soc/nxp/imxrt/imxrt11xx/soc.c
@@ -7,6 +7,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>
+#include <zephyr/logging/log.h>
 #include <soc.h>
 #include <zephyr/linker/sections.h>
 #include <zephyr/linker/linker-defs.h>
@@ -15,6 +16,9 @@
 #include <fsl_gpc.h>
 #include <fsl_pmu.h>
 #include <fsl_dcdc.h>
+
+LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
+
 #ifdef CONFIG_NXP_IMXRT_BOOT_HEADER
 #include <fsl_flexspi_nor_boot.h>
 #endif

--- a/soc/nxp/imxrt/imxrt11xx/soc.c
+++ b/soc/nxp/imxrt/imxrt11xx/soc.c
@@ -19,16 +19,15 @@
 #include <fsl_flexspi_nor_boot.h>
 #endif
 #include <zephyr/dt-bindings/clock/imx_ccm_rev2.h>
-#if  defined(CONFIG_SECOND_CORE_MCUX) && defined(CONFIG_CPU_CORTEX_M7)
+#if defined(CONFIG_SECOND_CORE_MCUX) && defined(CONFIG_CPU_CORTEX_M7)
 #include <zephyr_image_info.h>
 /* Memcpy macro to copy segments from secondary core image stored in flash
  * to RAM section that secondary core boots from.
  * n is the segment number, as defined in zephyr_image_info.h
  */
-#define MEMCPY_SEGMENT(n, _)							\
-	memcpy((uint32_t *)((SEGMENT_LMA_ADDRESS_ ## n) - ADJUSTED_LMA),	\
-		(uint32_t *)(SEGMENT_LMA_ADDRESS_ ## n),			\
-		(SEGMENT_SIZE_ ## n))
+#define MEMCPY_SEGMENT(n, _)                                                                       \
+	memcpy((uint32_t *)((SEGMENT_LMA_ADDRESS_##n) - ADJUSTED_LMA),                             \
+	       (uint32_t *)(SEGMENT_LMA_ADDRESS_##n), (SEGMENT_SIZE_##n))
 #endif
 #if CONFIG_USB_DC_NXP_EHCI
 #include "usb_phy.h"
@@ -38,18 +37,17 @@
 
 #include <cmsis_core.h>
 
-#define DUAL_CORE_MU_ENABLED \
-	(CONFIG_SECOND_CORE_MCUX && CONFIG_IPM && CONFIG_IPM_IMX)
+#define DUAL_CORE_MU_ENABLED (CONFIG_SECOND_CORE_MCUX && CONFIG_IPM && CONFIG_IPM_IMX)
 
 #if DUAL_CORE_MU_ENABLED
 /* Dual core mode is enabled, and messaging unit is present */
 #include <fsl_mu.h>
 #define BOOT_FLAG 0x1U
-#define MU_BASE (MU_Type *)DT_REG_ADDR(DT_INST(0, nxp_imx_mu))
+#define MU_BASE   (MU_Type *)DT_REG_ADDR(DT_INST(0, nxp_imx_mu))
 #endif
 
 #if CONFIG_USB_DC_NXP_EHCI /* USB PHY configuration */
-#define BOARD_USB_PHY_D_CAL (0x07U)
+#define BOARD_USB_PHY_D_CAL     (0x07U)
 #define BOARD_USB_PHY_TXCAL45DP (0x06U)
 #define BOARD_USB_PHY_TXCAL45DM (0x06U)
 #endif
@@ -67,18 +65,15 @@
  * Check that the ARM PLL has a multiplier and divider set
  */
 BUILD_ASSERT(DT_NODE_HAS_PROP(DT_NODELABEL(arm_pll), clock_mult),
-			      "ARM PLL must have clock-mult property");
+	     "ARM PLL must have clock-mult property");
 BUILD_ASSERT(DT_NODE_HAS_PROP(DT_NODELABEL(arm_pll), clock_div),
-			      "ARM PLL must have clock-div property");
+	     "ARM PLL must have clock-div property");
 #endif
-
 
 static const clock_arm_pll_config_t armPllConfig = {
 	.postDivider = CONCAT(kCLOCK_PllPostDiv,
-			      DT_PROP_OR(DT_NODELABEL(arm_pll), clock_div,
-			      DEFAULT_POSTDIV)),
-	.loopDivider = DT_PROP_OR(DT_NODELABEL(arm_pll), clock_mult,
-				  DEFAULT_LOOPDIV) * 2,
+			      DT_PROP_OR(DT_NODELABEL(arm_pll), clock_div, DEFAULT_POSTDIV)),
+	.loopDivider = DT_PROP_OR(DT_NODELABEL(arm_pll), clock_mult, DEFAULT_LOOPDIV) * 2,
 };
 #endif
 
@@ -121,11 +116,11 @@ static const clock_video_pll_config_t videoPllConfig = {
 #endif
 
 #if CONFIG_USB_DC_NXP_EHCI
-	usb_phy_config_struct_t usbPhyConfig = {
-		BOARD_USB_PHY_D_CAL,
-		BOARD_USB_PHY_TXCAL45DP,
-		BOARD_USB_PHY_TXCAL45DM,
-	};
+usb_phy_config_struct_t usbPhyConfig = {
+	BOARD_USB_PHY_D_CAL,
+	BOARD_USB_PHY_TXCAL45DP,
+	BOARD_USB_PHY_TXCAL45DM,
+};
 #endif
 
 #ifdef CONFIG_NXP_IMXRT_BOOT_HEADER
@@ -144,15 +139,15 @@ const __imx_boot_data_section BOOT_DATA_T boot_data = {
 extern char __start[];
 const __imx_boot_ivt_section ivt image_vector_table = {
 	.hdr = IVT_HEADER,
-	.entry = (uint32_t) __start,
+	.entry = (uint32_t)__start,
 	.reserved1 = IVT_RSVD,
 #ifdef CONFIG_DEVICE_CONFIGURATION_DATA
-	.dcd = (uint32_t) dcd_data,
+	.dcd = (uint32_t)dcd_data,
 #else
-	.dcd = (uint32_t) NULL,
+	.dcd = (uint32_t)NULL,
 #endif
-	.boot_data = (uint32_t) &boot_data,
-	.self = (uint32_t) &image_vector_table,
+	.boot_data = (uint32_t)&boot_data,
+	.self = (uint32_t)&image_vector_table,
 	.csf = (uint32_t)CSF_ADDRESS,
 	.reserved2 = IVT_RSVD,
 };
@@ -189,13 +184,13 @@ static ALWAYS_INLINE void clock_init(void)
 	pmu_static_lpsr_dig_config_t lpsrDigConfig;
 
 	if ((ANADIG_LDO_SNVS->PMU_LDO_LPSR_ANA &
-		ANADIG_LDO_SNVS_PMU_LDO_LPSR_ANA_BYPASS_MODE_EN_MASK) == 0UL) {
+	     ANADIG_LDO_SNVS_PMU_LDO_LPSR_ANA_BYPASS_MODE_EN_MASK) == 0UL) {
 		PMU_StaticGetLpsrAnaLdoDefaultConfig(&lpsrAnaConfig);
 		PMU_StaticLpsrAnaLdoInit(ANADIG_LDO_SNVS, &lpsrAnaConfig);
 	}
 
 	if ((ANADIG_LDO_SNVS->PMU_LDO_LPSR_DIG &
-		ANADIG_LDO_SNVS_PMU_LDO_LPSR_DIG_BYPASS_MODE_MASK) == 0UL) {
+	     ANADIG_LDO_SNVS_PMU_LDO_LPSR_DIG_BYPASS_MODE_MASK) == 0UL) {
 		PMU_StaticGetLpsrDigLdoDefaultConfig(&lpsrDigConfig);
 		lpsrDigConfig.targetVoltage = kPMU_LpsrDigTargetStableVoltage1P117V;
 		PMU_StaticLpsrDigLdoInit(ANADIG_LDO_SNVS, &lpsrDigConfig);
@@ -219,15 +214,14 @@ static ALWAYS_INLINE void clock_init(void)
 	CLOCK_OSC_EnableOsc48MDiv2(true);
 
 	/* Config OSC 24M */
-	ANADIG_OSC->OSC_24M_CTRL |= ANADIG_OSC_OSC_24M_CTRL_OSC_EN(1) |
-				    ANADIG_OSC_OSC_24M_CTRL_BYPASS_EN(0) |
-				    ANADIG_OSC_OSC_24M_CTRL_BYPASS_CLK(0) |
-				    ANADIG_OSC_OSC_24M_CTRL_LP_EN(1) |
-				    ANADIG_OSC_OSC_24M_CTRL_OSC_24M_GATE(0);
+	ANADIG_OSC->OSC_24M_CTRL |=
+		ANADIG_OSC_OSC_24M_CTRL_OSC_EN(1) | ANADIG_OSC_OSC_24M_CTRL_BYPASS_EN(0) |
+		ANADIG_OSC_OSC_24M_CTRL_BYPASS_CLK(0) | ANADIG_OSC_OSC_24M_CTRL_LP_EN(1) |
+		ANADIG_OSC_OSC_24M_CTRL_OSC_24M_GATE(0);
 
 	/* Wait for 24M OSC to be stable. */
 	while (ANADIG_OSC_OSC_24M_CTRL_OSC_24M_STABLE_MASK !=
-		(ANADIG_OSC->OSC_24M_CTRL & ANADIG_OSC_OSC_24M_CTRL_OSC_24M_STABLE_MASK)) {
+	       (ANADIG_OSC->OSC_24M_CTRL & ANADIG_OSC_OSC_24M_CTRL_OSC_24M_STABLE_MASK)) {
 	}
 
 	rootCfg.div = 1;
@@ -413,7 +407,6 @@ static ALWAYS_INLINE void clock_init(void)
 	CLOCK_SetRootClock(kCLOCK_Root_Lpi2c6, &rootCfg);
 #endif
 
-
 #if CONFIG_ETH_MCUX || CONFIG_ETH_NXP_ENET
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(enet), okay)
 	/* 50 MHz ENET clock */
@@ -426,8 +419,8 @@ static ALWAYS_INLINE void clock_init(void)
 	IOMUXC_GPR->GPR4 |= IOMUXC_GPR_GPR4_ENET_TX_CLK_SEL(0x1U);
 #else
 	/* Set ENET_REF_CLK as an output driven by ENET1_CLK_ROOT */
-	IOMUXC_GPR->GPR4 |= (IOMUXC_GPR_GPR4_ENET_REF_CLK_DIR(0x01U) |
-		IOMUXC_GPR_GPR4_ENET_TX_CLK_SEL(0x1U));
+	IOMUXC_GPR->GPR4 |=
+		(IOMUXC_GPR_GPR4_ENET_REF_CLK_DIR(0x01U) | IOMUXC_GPR_GPR4_ENET_TX_CLK_SEL(0x1U));
 #endif
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(enet1g), okay)
@@ -438,7 +431,7 @@ static ALWAYS_INLINE void clock_init(void)
 	CLOCK_SetRootClock(kCLOCK_Root_Enet2, &rootCfg);
 	/* Set ENET1G TX_CLK to be driven by ENET2_CLK_ROOT and output on TX_CLK_IO pad */
 	IOMUXC_GPR->GPR5 = (IOMUXC_GPR_GPR5_ENET1G_RGMII_EN(0x01U) |
-		(IOMUXC_GPR->GPR5 & ~IOMUXC_GPR_GPR5_ENET1G_TX_CLK_SEL(0x01U)));
+			    (IOMUXC_GPR->GPR5 & ~IOMUXC_GPR_GPR5_ENET1G_TX_CLK_SEL(0x01U)));
 	/* Set ENET1G_REF_CLK as an input driven by PHY */
 	IOMUXC_GPR->GPR5 &= ~IOMUXC_GPR_GPR5_ENET1G_REF_CLK_DIR(0x01U);
 #else
@@ -455,7 +448,7 @@ static ALWAYS_INLINE void clock_init(void)
 #else
 	/* Set ENET1G_REF_CLK as an output driven by ENET2_CLK_ROOT */
 	IOMUXC_GPR->GPR5 |= (IOMUXC_GPR_GPR5_ENET1G_REF_CLK_DIR(0x01U) |
-		IOMUXC_GPR_GPR5_ENET1G_TX_CLK_SEL(0x1U));
+			     IOMUXC_GPR_GPR5_ENET1G_TX_CLK_SEL(0x1U));
 #endif
 #endif
 #endif
@@ -527,8 +520,8 @@ static ALWAYS_INLINE void clock_init(void)
 	 * calculate LCDIF clock.
 	 */
 	rootCfg.div = ((SYS_PLL2_FREQ /
-			DT_PROP(DT_CHILD(DT_NODELABEL(lcdif), display_timings),
-			clock_frequency)) + 1);
+			DT_PROP(DT_CHILD(DT_NODELABEL(lcdif), display_timings), clock_frequency)) +
+		       1);
 	CLOCK_SetRootClock(kCLOCK_Root_Lcdif, &rootCfg);
 #endif
 
@@ -538,23 +531,21 @@ static ALWAYS_INLINE void clock_init(void)
 	CLOCK_SetRootClock(kCLOCK_Root_Gpt1, &rootCfg);
 #endif
 
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(usb1), okay) &&\
-	(CONFIG_USB_DC_NXP_EHCI || CONFIG_UDC_NXP_EHCI)
-	CLOCK_EnableUsbhs0PhyPllClock(kCLOCK_Usb480M,
-		DT_PROP_BY_PHANDLE(DT_NODELABEL(usb1), clocks, clock_frequency));
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(usb1), okay) && (CONFIG_USB_DC_NXP_EHCI || CONFIG_UDC_NXP_EHCI)
+	CLOCK_EnableUsbhs0PhyPllClock(
+		kCLOCK_Usb480M, DT_PROP_BY_PHANDLE(DT_NODELABEL(usb1), clocks, clock_frequency));
 	CLOCK_EnableUsbhs0Clock(kCLOCK_Usb480M,
-		DT_PROP_BY_PHANDLE(DT_NODELABEL(usb1), clocks, clock_frequency));
+				DT_PROP_BY_PHANDLE(DT_NODELABEL(usb1), clocks, clock_frequency));
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(usb1), okay) && CONFIG_USB_DC_NXP_EHCI
 	USB_EhciPhyInit(kUSB_ControllerEhci0, CPU_XTAL_CLK_HZ, &usbPhyConfig);
 #endif
 #endif
 
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(usb2), okay) &&\
-	(CONFIG_USB_DC_NXP_EHCI || CONFIG_UDC_NXP_EHCI)
-	CLOCK_EnableUsbhs1PhyPllClock(kCLOCK_Usb480M,
-		DT_PROP_BY_PHANDLE(DT_NODELABEL(usb2), clocks, clock_frequency));
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(usb2), okay) && (CONFIG_USB_DC_NXP_EHCI || CONFIG_UDC_NXP_EHCI)
+	CLOCK_EnableUsbhs1PhyPllClock(
+		kCLOCK_Usb480M, DT_PROP_BY_PHANDLE(DT_NODELABEL(usb2), clocks, clock_frequency));
 	CLOCK_EnableUsbhs1Clock(kCLOCK_Usb480M,
-		DT_PROP_BY_PHANDLE(DT_NODELABEL(usb2), clocks, clock_frequency));
+				DT_PROP_BY_PHANDLE(DT_NODELABEL(usb2), clocks, clock_frequency));
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(usb1), okay) && CONFIG_USB_DC_NXP_EHCI
 	USB_EhciPhyInit(kUSB_ControllerEhci1, CPU_XTAL_CLK_HZ, &usbPhyConfig);
 #endif
@@ -578,9 +569,8 @@ static ALWAYS_INLINE void clock_init(void)
 #endif
 #endif
 
-#if !(DT_NODE_HAS_COMPAT(DT_CHOSEN(zephyr_flash), nxp_imx_flexspi)) && \
-	defined(CONFIG_MEMC_MCUX_FLEXSPI) && \
-	DT_NODE_HAS_STATUS(DT_NODELABEL(flexspi), okay)
+#if !(DT_NODE_HAS_COMPAT(DT_CHOSEN(zephyr_flash), nxp_imx_flexspi)) &&                             \
+	defined(CONFIG_MEMC_MCUX_FLEXSPI) && DT_NODE_HAS_STATUS(DT_NODELABEL(flexspi), okay)
 	/* Configure FLEXSPI1 using OSC_RC_48M_DIV2 */
 	rootCfg.mux = kCLOCK_FLEXSPI1_ClockRoot_MuxOscRc48MDiv2;
 	rootCfg.div = 1;
@@ -606,8 +596,8 @@ static ALWAYS_INLINE void clock_init(void)
 }
 
 #if CONFIG_I2S_MCUX_SAI
-void imxrt_audio_codec_pll_init(uint32_t clock_name, uint32_t clk_src,
-					uint32_t clk_pre_div, uint32_t clk_src_div)
+void imxrt_audio_codec_pll_init(uint32_t clock_name, uint32_t clk_src, uint32_t clk_pre_div,
+				uint32_t clk_src_div)
 {
 	ARG_UNUSED(clk_pre_div);
 
@@ -643,13 +633,13 @@ void imxrt_pre_init_display_interface(void)
 
 	/* Power on and isolation off. */
 	PGMC_BPC4->BPC_POWER_CTRL |= (PGMC_BPC_BPC_POWER_CTRL_PSW_ON_SOFT_MASK |
-				PGMC_BPC_BPC_POWER_CTRL_ISO_OFF_SOFT_MASK);
+				      PGMC_BPC_BPC_POWER_CTRL_ISO_OFF_SOFT_MASK);
 
 	/* Assert MIPI reset. */
 	IOMUXC_GPR->GPR62 &= ~(IOMUXC_GPR_GPR62_MIPI_DSI_PCLK_SOFT_RESET_N_MASK |
-			IOMUXC_GPR_GPR62_MIPI_DSI_ESC_SOFT_RESET_N_MASK |
-			IOMUXC_GPR_GPR62_MIPI_DSI_BYTE_SOFT_RESET_N_MASK |
-			IOMUXC_GPR_GPR62_MIPI_DSI_DPI_SOFT_RESET_N_MASK);
+			       IOMUXC_GPR_GPR62_MIPI_DSI_ESC_SOFT_RESET_N_MASK |
+			       IOMUXC_GPR_GPR62_MIPI_DSI_BYTE_SOFT_RESET_N_MASK |
+			       IOMUXC_GPR_GPR62_MIPI_DSI_DPI_SOFT_RESET_N_MASK);
 
 	/* setup clock */
 	const clock_root_config_t mipiEscClockConfig = {
@@ -679,14 +669,14 @@ void imxrt_pre_init_display_interface(void)
 
 	/* Deassert PCLK and ESC reset. */
 	IOMUXC_GPR->GPR62 |= (IOMUXC_GPR_GPR62_MIPI_DSI_PCLK_SOFT_RESET_N_MASK |
-			IOMUXC_GPR_GPR62_MIPI_DSI_ESC_SOFT_RESET_N_MASK);
+			      IOMUXC_GPR_GPR62_MIPI_DSI_ESC_SOFT_RESET_N_MASK);
 }
 
 void imxrt_post_init_display_interface(void)
 {
 	/* deassert BYTE and DBI reset */
 	IOMUXC_GPR->GPR62 |= (IOMUXC_GPR_GPR62_MIPI_DSI_BYTE_SOFT_RESET_N_MASK |
-			IOMUXC_GPR_GPR62_MIPI_DSI_DPI_SOFT_RESET_N_MASK);
+			      IOMUXC_GPR_GPR62_MIPI_DSI_DPI_SOFT_RESET_N_MASK);
 }
 
 #endif
@@ -704,7 +694,7 @@ void imxrt_post_init_display_interface(void)
 
 static int imxrt_init(void)
 {
-#if  defined(CONFIG_SECOND_CORE_MCUX) && defined(CONFIG_CPU_CORTEX_M7)
+#if defined(CONFIG_SECOND_CORE_MCUX) && defined(CONFIG_CPU_CORTEX_M7)
 	/**
 	 * Copy CM4 core from flash to memory. Note that depending on where the
 	 * user decided to store CM4 code, this is likely going to read from the
@@ -726,7 +716,6 @@ static int imxrt_init(void)
 	/* Set boot flag in messaging unit to indicate boot to primary core */
 	MU_SetFlags(MU_BASE, BOOT_FLAG);
 #endif
-
 
 #if defined(CONFIG_SOC_MIMXRT1176_CM7) || defined(CONFIG_SOC_MIMXRT1166_CM7)
 	sys_cache_instr_enable();
@@ -753,7 +742,7 @@ void z_arm_platform_init(void)
 
 SYS_INIT(imxrt_init, PRE_KERNEL_1, 0);
 
-#if  defined(CONFIG_SECOND_CORE_MCUX) && defined(CONFIG_CPU_CORTEX_M7)
+#if defined(CONFIG_SECOND_CORE_MCUX) && defined(CONFIG_CPU_CORTEX_M7)
 /**
  * @brief Kickoff secondary core.
  *

--- a/soc/nxp/imxrt/imxrt5xx/cm33/soc.c
+++ b/soc/nxp/imxrt/imxrt5xx/cm33/soc.c
@@ -15,10 +15,13 @@
 #include <zephyr/init.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/linker/sections.h>
+#include <zephyr/logging/log.h>
 #include <soc.h>
 #include "fsl_power.h"
 #include "fsl_clock.h"
 #include <fsl_cache.h>
+
+LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 
 #ifdef CONFIG_FLASH_MCUX_FLEXSPI_XIP
 #include "flash_clock_setup.h"

--- a/soc/nxp/imxrt/imxrt5xx/cm33/soc.c
+++ b/soc/nxp/imxrt/imxrt5xx/cm33/soc.c
@@ -30,17 +30,17 @@
 #endif
 
 /* Board System oscillator settling time in us */
-#define BOARD_SYSOSC_SETTLING_US                        100U
+#define BOARD_SYSOSC_SETTLING_US 100U
 /* Board xtal frequency in Hz */
-#define BOARD_XTAL_SYS_CLK_HZ                      24000000U
+#define BOARD_XTAL_SYS_CLK_HZ    24000000U
 /* Core clock frequency: 198000000Hz */
-#define CLOCK_INIT_CORE_CLOCK                     198000000U
+#define CLOCK_INIT_CORE_CLOCK    198000000U
 
-#define CTIMER_CLOCK_SOURCE(node_id) \
+#define CTIMER_CLOCK_SOURCE(node_id)                                                               \
 	TO_CTIMER_CLOCK_SOURCE(DT_CLOCKS_CELL(node_id, name), DT_PROP(node_id, clk_source))
 #define TO_CTIMER_CLOCK_SOURCE(inst, val) TO_CLOCK_ATTACH_ID(inst, val)
-#define TO_CLOCK_ATTACH_ID(inst, val) CLKCTL1_TUPLE_MUXA(CT32BIT##inst##FCLKSEL_OFFSET, val)
-#define CTIMER_CLOCK_SETUP(node_id) CLOCK_AttachClk(CTIMER_CLOCK_SOURCE(node_id));
+#define TO_CLOCK_ATTACH_ID(inst, val)     CLKCTL1_TUPLE_MUXA(CT32BIT##inst##FCLKSEL_OFFSET, val)
+#define CTIMER_CLOCK_SETUP(node_id)       CLOCK_AttachClk(CTIMER_CLOCK_SOURCE(node_id));
 
 const clock_sys_pll_config_t g_sysPllConfig_clock_init = {
 	/* OSC clock */
@@ -50,8 +50,7 @@ const clock_sys_pll_config_t g_sysPllConfig_clock_init = {
 	/* Denominator of the SYSPLL0 fractional loop divider is 1 */
 	.denominator = 1,
 	/* Divide by 22 */
-	.sys_pll_mult = kCLOCK_SysPllMult22
-};
+	.sys_pll_mult = kCLOCK_SysPllMult22};
 
 const clock_audio_pll_config_t g_audioPllConfig_clock_init = {
 	/* OSC clock */
@@ -61,22 +60,13 @@ const clock_audio_pll_config_t g_audioPllConfig_clock_init = {
 	/* Denominator of the Audio PLL fractional loop divider is 1 */
 	.denominator = 27000,
 	/* Divide by 22 */
-	.audio_pll_mult = kCLOCK_AudioPllMult22
-};
+	.audio_pll_mult = kCLOCK_AudioPllMult22};
 
 const clock_frg_clk_config_t g_frg0Config_clock_init = {
-	.num = 0,
-	.sfg_clock_src = kCLOCK_FrgPllDiv,
-	.divider = 255U,
-	.mult = 0
-};
+	.num = 0, .sfg_clock_src = kCLOCK_FrgPllDiv, .divider = 255U, .mult = 0};
 
 const clock_frg_clk_config_t g_frg12Config_clock_init = {
-	.num = 12,
-	.sfg_clock_src = kCLOCK_FrgMainClk,
-	.divider = 255U,
-	.mult = 167
-};
+	.num = 12, .sfg_clock_src = kCLOCK_FrgMainClk, .divider = 255U, .mult = 167};
 
 #if CONFIG_USB_DC_NXP_LPCIP3511
 /* USB PHY condfiguration */
@@ -106,29 +96,28 @@ extern void z_arm_pendsv(void);
 extern void sys_clock_isr(void);
 extern void z_arm_exc_spurious(void);
 
-__imx_boot_ivt_section void (* const image_vector_table[])(void)  = {
-	(void (*)())(z_main_stack + CONFIG_MAIN_STACK_SIZE),  /* 0x00 */
-	z_arm_reset,				/* 0x04 */
-	z_arm_nmi,					/* 0x08 */
-	z_arm_hard_fault,			/* 0x0C */
-	z_arm_mpu_fault,			/* 0x10 */
-	z_arm_bus_fault,			/* 0x14 */
-	z_arm_usage_fault,			/* 0x18 */
+__imx_boot_ivt_section void (*const image_vector_table[])(void) = {
+	(void (*)())(z_main_stack + CONFIG_MAIN_STACK_SIZE), /* 0x00 */
+	z_arm_reset,                                         /* 0x04 */
+	z_arm_nmi,                                           /* 0x08 */
+	z_arm_hard_fault,                                    /* 0x0C */
+	z_arm_mpu_fault,                                     /* 0x10 */
+	z_arm_bus_fault,                                     /* 0x14 */
+	z_arm_usage_fault,                                   /* 0x18 */
 #if defined(CONFIG_ARM_SECURE_FIRMWARE)
-	z_arm_secure_fault,			/* 0x1C */
+	z_arm_secure_fault, /* 0x1C */
 #else
 	z_arm_exc_spurious,
-#endif /* CONFIG_ARM_SECURE_FIRMWARE */
-	(void (*)())_flash_used,	/* 0x20, imageLength. */
-	0,				/* 0x24, imageType (Plain Image) */
-	0,				/* 0x28, authBlockOffset/crcChecksum */
-	z_arm_svc,		/* 0x2C */
-	z_arm_debug_monitor,	/* 0x30 */
-	(void (*)())image_vector_table,		/* 0x34, imageLoadAddress. */
-	z_arm_pendsv,						/* 0x38 */
-#if defined(CONFIG_SYS_CLOCK_EXISTS) && \
-		defined(CONFIG_CORTEX_M_SYSTICK_INSTALL_ISR)
-	sys_clock_isr,						/* 0x3C */
+#endif                                  /* CONFIG_ARM_SECURE_FIRMWARE */
+	(void (*)())_flash_used,        /* 0x20, imageLength. */
+	0,                              /* 0x24, imageType (Plain Image) */
+	0,                              /* 0x28, authBlockOffset/crcChecksum */
+	z_arm_svc,                      /* 0x2C */
+	z_arm_debug_monitor,            /* 0x30 */
+	(void (*)())image_vector_table, /* 0x34, imageLoadAddress. */
+	z_arm_pendsv,                   /* 0x38 */
+#if defined(CONFIG_SYS_CLOCK_EXISTS) && defined(CONFIG_CORTEX_M_SYSTICK_INSTALL_ISR)
+	sys_clock_isr, /* 0x3C */
 #else
 	z_arm_exc_spurious,
 #endif
@@ -204,13 +193,13 @@ void z_arm_platform_init(void)
 	 * set the stack pointer, since we are about to push to
 	 * the stack when we call SystemInit
 	 */
-	 /* Clear stack limit registers */
-	 __set_MSPLIM(0);
-	 __set_PSPLIM(0);
+	/* Clear stack limit registers */
+	__set_MSPLIM(0);
+	__set_PSPLIM(0);
 	/* Disable MPU */
-	 MPU->CTRL &= ~MPU_CTRL_ENABLE_Msk;
-	 /* Set stack pointer */
-	 __set_MSP((uint32_t)(z_main_stack + CONFIG_MAIN_STACK_SIZE));
+	MPU->CTRL &= ~MPU_CTRL_ENABLE_Msk;
+	/* Set stack pointer */
+	__set_MSP((uint32_t)(z_main_stack + CONFIG_MAIN_STACK_SIZE));
 #endif /* !CONFIG_NXP_IMXRT_BOOT_HEADER */
 	/* This is provided by the SDK */
 	SystemInit();
@@ -281,12 +270,12 @@ void __weak rt5xx_clock_init(void)
 	/* Switch SYSTICK_CLK to MAIN_CLK_DIV */
 	CLOCK_AttachClk(kMAIN_CLK_DIV_to_SYSTICK_CLK);
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(flexcomm0), nxp_lpc_usart, okay)
-	#ifdef CONFIG_FLEXCOMM0_CLK_SRC_FRG
-		/* Switch FLEXCOMM0 to FRG */
-		CLOCK_AttachClk(kFRG_to_FLEXCOMM0);
-	#elif defined(CONFIG_FLEXCOMM0_CLK_SRC_FRO)
-		CLOCK_AttachClk(kFRO_DIV4_to_FLEXCOMM0);
-	#endif
+#ifdef CONFIG_FLEXCOMM0_CLK_SRC_FRG
+	/* Switch FLEXCOMM0 to FRG */
+	CLOCK_AttachClk(kFRG_to_FLEXCOMM0);
+#elif defined(CONFIG_FLEXCOMM0_CLK_SRC_FRO)
+	CLOCK_AttachClk(kFRO_DIV4_to_FLEXCOMM0);
+#endif
 #endif
 #if CONFIG_USB_DC_NXP_LPCIP3511
 	usb_device_clock_init();
@@ -333,21 +322,21 @@ void __weak rt5xx_clock_init(void)
 	 *
 	 * The root clock used here is the AUX0 PLL (PLL0 PFD2).
 	 */
-	CLOCK_SetClkDiv(kCLOCK_DivDcPixelClk,
+	CLOCK_SetClkDiv(
+		kCLOCK_DivDcPixelClk,
 		((CLOCK_GetSysPfdFreq(kCLOCK_Pfd2) /
-		DT_PROP(DT_CHILD(DT_NODELABEL(lcdif), display_timings),
-			clock_frequency)) + 1));
+		  DT_PROP(DT_CHILD(DT_NODELABEL(lcdif), display_timings), clock_frequency)) +
+		 1));
 
 	CLOCK_EnableClock(kCLOCK_DisplayCtrl);
 	RESET_ClearPeripheralReset(kDISP_CTRL_RST_SHIFT_RSTn);
 
 	CLOCK_EnableClock(kCLOCK_AxiSwitch);
 	RESET_ClearPeripheralReset(kAXI_SWITCH_RST_SHIFT_RSTn);
-#if defined(CONFIG_MEMC) && DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(flexspi2), \
-	nxp_imx_flexspi, okay)
+#if defined(CONFIG_MEMC) && DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(flexspi2), nxp_imx_flexspi, okay)
 	/* Enable write-through for FlexSPI1 space */
 	CACHE64_POLSEL0->REG1_TOP = 0x27FFFC00U;
-	CACHE64_POLSEL0->POLSEL   = 0x11U;
+	CACHE64_POLSEL0->POLSEL = 0x11U;
 #endif
 #endif
 
@@ -478,13 +467,13 @@ void __weak imxrt_pre_init_display_interface(void)
 	 */
 	CLOCK_AttachClk(kAUX1_PLL_to_MIPI_DPHY_CLK);
 	CLOCK_InitSysPfd(kCLOCK_Pfd3,
-		((CLOCK_GetSysPllFreq() * 18ull) /
-		((unsigned long long)(DT_PROP(DT_NODELABEL(mipi_dsi), phy_clock)))));
+			 ((CLOCK_GetSysPllFreq() * 18ull) /
+			  ((unsigned long long)(DT_PROP(DT_NODELABEL(mipi_dsi), phy_clock)))));
 	CLOCK_SetClkDiv(kCLOCK_DivDphyClk, 1);
 #elif defined(CONFIG_MIPI_DPHY_CLK_SRC_FRO)
 	CLOCK_AttachClk(kFRO_DIV1_to_MIPI_DPHY_CLK);
 	CLOCK_SetClkDiv(kCLOCK_DivDphyClk,
-		(CLK_FRO_CLK / DT_PROP(DT_NODELABEL(mipi_dsi), phy_clock)));
+			(CLK_FRO_CLK / DT_PROP(DT_NODELABEL(mipi_dsi), phy_clock)));
 #endif
 	/* Clear DSI control reset (Note that DPHY reset is cleared later)*/
 	RESET_ClearPeripheralReset(kMIPI_DSI_CTRL_RST_SHIFT_RSTn);
@@ -504,7 +493,6 @@ void __weak imxrt_deinit_display_interface(void)
 	/* Remove clock from DPHY */
 	CLOCK_AttachClk(kNONE_to_MIPI_DPHY_CLK);
 }
-
 
 #endif
 

--- a/soc/nxp/imxrt/imxrt6xx/cm33/soc.c
+++ b/soc/nxp/imxrt/imxrt6xx/cm33/soc.c
@@ -36,41 +36,36 @@
 #endif
 
 /* Core clock frequency: 250105263Hz */
-#define CLOCK_INIT_CORE_CLOCK                     250105263U
+#define CLOCK_INIT_CORE_CLOCK 250105263U
 
-#define SYSTEM_IS_XIP_FLEXSPI() \
-	((((uint32_t)nxp_rt600_init >= 0x08000000U) &&		\
-	  ((uint32_t)nxp_rt600_init < 0x10000000U)) ||		\
-	 (((uint32_t)nxp_rt600_init >= 0x18000000U) &&		\
-	  ((uint32_t)nxp_rt600_init < 0x20000000U)))
+#define SYSTEM_IS_XIP_FLEXSPI()                                                                    \
+	((((uint32_t)nxp_rt600_init >= 0x08000000U) &&                                             \
+	  ((uint32_t)nxp_rt600_init < 0x10000000U)) ||                                             \
+	 (((uint32_t)nxp_rt600_init >= 0x18000000U) && ((uint32_t)nxp_rt600_init < 0x20000000U)))
 
-#define CTIMER_CLOCK_SOURCE(node_id) \
+#define CTIMER_CLOCK_SOURCE(node_id)                                                               \
 	TO_CTIMER_CLOCK_SOURCE(DT_CLOCKS_CELL(node_id, name), DT_PROP(node_id, clk_source))
 #define TO_CTIMER_CLOCK_SOURCE(inst, val) TO_CLOCK_ATTACH_ID(inst, val)
-#define TO_CLOCK_ATTACH_ID(inst, val) CLKCTL1_TUPLE_MUXA(CT32BIT##inst##FCLKSEL_OFFSET, val)
-#define CTIMER_CLOCK_SETUP(node_id) CLOCK_AttachClk(CTIMER_CLOCK_SOURCE(node_id));
+#define TO_CLOCK_ATTACH_ID(inst, val)     CLKCTL1_TUPLE_MUXA(CT32BIT##inst##FCLKSEL_OFFSET, val)
+#define CTIMER_CLOCK_SETUP(node_id)       CLOCK_AttachClk(CTIMER_CLOCK_SOURCE(node_id));
 
 #ifdef CONFIG_INIT_SYS_PLL
-const clock_sys_pll_config_t g_sysPllConfig = {
-	.sys_pll_src  = kCLOCK_SysPllXtalIn,
-	.numerator	  = 0,
-	.denominator  = 1,
-	.sys_pll_mult = kCLOCK_SysPllMult22
-};
+const clock_sys_pll_config_t g_sysPllConfig = {.sys_pll_src = kCLOCK_SysPllXtalIn,
+					       .numerator = 0,
+					       .denominator = 1,
+					       .sys_pll_mult = kCLOCK_SysPllMult22};
 #endif
 
 #ifdef CONFIG_INIT_AUDIO_PLL
-const clock_audio_pll_config_t g_audioPllConfig = {
-	.audio_pll_src	= kCLOCK_AudioPllXtalIn,
-	.numerator		= 5040,
-	.denominator	= 27000,
-	.audio_pll_mult = kCLOCK_AudioPllMult22
-};
+const clock_audio_pll_config_t g_audioPllConfig = {.audio_pll_src = kCLOCK_AudioPllXtalIn,
+						   .numerator = 5040,
+						   .denominator = 27000,
+						   .audio_pll_mult = kCLOCK_AudioPllMult22};
 #endif
 
 #if CONFIG_USB_DC_NXP_LPCIP3511 || CONFIG_UDC_NXP_IP3511
 /* USB PHY condfiguration */
-#define BOARD_USB_PHY_D_CAL (0x0CU)
+#define BOARD_USB_PHY_D_CAL     (0x0CU)
 #define BOARD_USB_PHY_TXCAL45DP (0x06U)
 #define BOARD_USB_PHY_TXCAL45DM (0x06U)
 #endif
@@ -95,29 +90,28 @@ extern void z_arm_pendsv(void);
 extern void sys_clock_isr(void);
 extern void z_arm_exc_spurious(void);
 
-__imx_boot_ivt_section void (* const image_vector_table[])(void)  = {
-	(void (*)())(z_main_stack + CONFIG_MAIN_STACK_SIZE),  /* 0x00 */
-	z_arm_reset,				/* 0x04 */
-	z_arm_nmi,					/* 0x08 */
-	z_arm_hard_fault,			/* 0x0C */
-	z_arm_mpu_fault,			/* 0x10 */
-	z_arm_bus_fault,			/* 0x14 */
-	z_arm_usage_fault,			/* 0x18 */
+__imx_boot_ivt_section void (*const image_vector_table[])(void) = {
+	(void (*)())(z_main_stack + CONFIG_MAIN_STACK_SIZE), /* 0x00 */
+	z_arm_reset,                                         /* 0x04 */
+	z_arm_nmi,                                           /* 0x08 */
+	z_arm_hard_fault,                                    /* 0x0C */
+	z_arm_mpu_fault,                                     /* 0x10 */
+	z_arm_bus_fault,                                     /* 0x14 */
+	z_arm_usage_fault,                                   /* 0x18 */
 #if defined(CONFIG_ARM_SECURE_FIRMWARE)
-	z_arm_secure_fault,			/* 0x1C */
+	z_arm_secure_fault, /* 0x1C */
 #else
 	z_arm_exc_spurious,
-#endif /* CONFIG_ARM_SECURE_FIRMWARE */
-	(void (*)())_flash_used,	/* 0x20, imageLength. */
-	0,				/* 0x24, imageType (Plain Image) */
-	0,				/* 0x28, authBlockOffset/crcChecksum */
-	z_arm_svc,		/* 0x2C */
-	z_arm_debug_monitor,	/* 0x30 */
-	(void (*)())image_vector_table,		/* 0x34, imageLoadAddress. */
-	z_arm_pendsv,						/* 0x38 */
-#if defined(CONFIG_SYS_CLOCK_EXISTS) && \
-	defined(CONFIG_CORTEX_M_SYSTICK_INSTALL_ISR)
-	sys_clock_isr,						/* 0x3C */
+#endif                                  /* CONFIG_ARM_SECURE_FIRMWARE */
+	(void (*)())_flash_used,        /* 0x20, imageLength. */
+	0,                              /* 0x24, imageType (Plain Image) */
+	0,                              /* 0x28, authBlockOffset/crcChecksum */
+	z_arm_svc,                      /* 0x2C */
+	z_arm_debug_monitor,            /* 0x30 */
+	(void (*)())image_vector_table, /* 0x34, imageLoadAddress. */
+	z_arm_pendsv,                   /* 0x38 */
+#if defined(CONFIG_SYS_CLOCK_EXISTS) && defined(CONFIG_CORTEX_M_SYSTICK_INSTALL_ISR)
+	sys_clock_isr, /* 0x3C */
 #else
 	z_arm_exc_spurious,
 #endif
@@ -329,15 +323,12 @@ static ALWAYS_INLINE void clock_init(void)
 
 #if (DT_NODE_HAS_STATUS(DT_NODELABEL(usdhc0), okay) && CONFIG_IMX_USDHC)
 
-void imxrt_usdhc_pinmux(uint16_t nusdhc, bool init,
-	uint32_t speed, uint32_t strength)
+void imxrt_usdhc_pinmux(uint16_t nusdhc, bool init, uint32_t speed, uint32_t strength)
 {
-
 }
 
 void imxrt_usdhc_dat3_pull(bool pullup)
 {
-
 }
 #endif
 
@@ -374,13 +365,13 @@ void z_arm_platform_init(void)
 	 * set the stack pointer, since we are about to push to
 	 * the stack when we call SystemInit
 	 */
-	 /* Clear stack limit registers */
-	 __set_MSPLIM(0);
-	 __set_PSPLIM(0);
+	/* Clear stack limit registers */
+	__set_MSPLIM(0);
+	__set_PSPLIM(0);
 	/* Disable MPU */
-	 MPU->CTRL &= ~MPU_CTRL_ENABLE_Msk;
-	 /* Set stack pointer */
-	 __set_MSP((uint32_t)(z_main_stack + CONFIG_MAIN_STACK_SIZE));
+	MPU->CTRL &= ~MPU_CTRL_ENABLE_Msk;
+	/* Set stack pointer */
+	__set_MSP((uint32_t)(z_main_stack + CONFIG_MAIN_STACK_SIZE));
 #endif /* !CONFIG_NXP_IMXRT_BOOT_HEADER */
 	/* This is provided by the SDK */
 	SystemInit();

--- a/soc/nxp/imxrt/imxrt6xx/cm33/soc.c
+++ b/soc/nxp/imxrt/imxrt6xx/cm33/soc.c
@@ -15,6 +15,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>
+#include <zephyr/logging/log.h>
 #include <soc.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/linker/sections.h>
@@ -25,6 +26,8 @@
 #include <fsl_common.h>
 #include <fsl_device_registers.h>
 #include <fsl_cache.h>
+
+LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 
 #ifdef CONFIG_FLASH_MCUX_FLEXSPI_XIP
 #include "flash_clock_setup.h"


### PR DESCRIPTION
These changes fix a failing build on a IMXRT11xx, IMXRT5xx/CM33, and
IMXRT6xx/CM33 when debug logging is enabled. 

The error can be reproduced by running the following command: 
```
west build -p -b mimxrt1170_evk//cm7 samples/hello_world -DCONFIG_PM=y -DCONFIG_LOG=y -DCONFIG_LOG_DEFAULT_LEVEL=4
```