### PR TITLE
MAINTAINERS: Remove generic Bluetooth group

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -297,46 +297,6 @@ Binary Descriptors:
   tests:
     - bindesc
 
-Bluetooth:
-  status: maintained
-  maintainers:
-    - jhedberg
-  collaborators:
-    - hermabe
-    - Vudentz
-    - asbjornsabo
-    - sjanc
-  files:
-    - doc/connectivity/bluetooth/
-    - include/zephyr/bluetooth/
-    - samples/bluetooth/
-    - subsys/bluetooth/
-    - subsys/bluetooth/common/
-    - tests/bluetooth/
-    - tests/bsim/bluetooth/
-  files-exclude:
-    - include/zephyr/bluetooth/mesh/
-    - subsys/bluetooth/controller/
-    - subsys/bluetooth/host/
-    - subsys/bluetooth/mesh/
-    - samples/bluetooth/mesh/
-    - subsys/bluetooth/audio/
-    - include/zephyr/bluetooth/audio/
-    - tests/bsim/bluetooth/audio/
-    - tests/bsim/bluetooth/host/
-    - tests/bsim/bluetooth/ll/
-    - tests/bluetooth/controller/
-    - tests/bluetooth/host*/
-    - tests/bluetooth/mesh_*/
-    - tests/bluetooth/mesh/
-    - tests/bluetooth/audio/
-    - tests/bsim/bluetooth/mesh/
-    - tests/bluetooth/shell/audio*
-  labels:
-    - "area: Bluetooth"
-  tests:
-    - bluetooth
-
 Bluetooth HCI:
   status: maintained
   maintainers:
@@ -353,6 +313,7 @@ Bluetooth HCI:
     - include/zephyr/drivers/bluetooth/
     - drivers/bluetooth/
     - samples/bluetooth/hci_*/
+    - tests/bsim/bluetooth/hci_uart/
   labels:
     - "area: Bluetooth Host"
     - "area: Bluetooth"
@@ -372,9 +333,20 @@ Bluetooth controller:
     - wopu-ot
     - erbr-ot
   files:
+    - doc/connectivity/bluetooth/bluetooth-ctlr-arch.rst
+    - doc/connectivity/bluetooth/img/ctlr*
+    - doc/connectivity/bluetooth/api/controller.rst
+    - include/zephyr/bluetooth/controller.h
+    - subsys/bluetooth/common/
     - subsys/bluetooth/controller/
+    - subsys/bluetooth/crypto/
+    - subsys/bluetooth/shell/ll.c
+    - subsys/bluetooth/shell/ll.h
+    - subsys/bluetooth/shell/ticker.c
     - tests/bluetooth/controller/
     - tests/bsim/bluetooth/ll/
+    - tests/bluetooth/ctrl*/
+    - tests/bluetooth/ll_settings/
   labels:
     - "area: Bluetooth Controller"
     - "area: Bluetooth"
@@ -393,14 +365,62 @@ Bluetooth Host:
     - sjanc
     - theob-pro
   files:
+    - doc/connectivity/bluetooth/
+    - include/zephyr/bluetooth/
+    - samples/bluetooth/
+    - subsys/bluetooth/common/
+    - subsys/bluetooth/crypto/
     - subsys/bluetooth/host/
+    - subsys/bluetooth/lib/
     - subsys/bluetooth/services/
     - subsys/bluetooth/shell/
-    - tests/bluetooth/host*/
-    - tests/bsim/bluetooth/host/
+    - subsys/bluetooth/CMakeLists.txt
+    - subsys/bluetooth/Kconfig*
+    - tests/bluetooth/
+    - tests/bsim/bluetooth/
   files-exclude:
     - subsys/bluetooth/host/classic/
+    - include/zephyr/bluetooth/audio/
     - include/zephyr/bluetooth/classic/
+    - include/zephyr/bluetooth/audio/
+    - include/zephyr/bluetooth/iso.h
+    - include/zephyr/bluetooth/controller.h
+    - include/zephyr/bluetooth/mesh.h
+    - include/zephyr/bluetooth/testing.h
+    - doc/connectivity/bluetooth/bluetooth-ctlr-arch.rst
+    - doc/connectivity/bluetooth/autopts/
+    - doc/connectivity/bluetooth/img/ctlr*
+    - doc/connectivity/bluetooth/api/audio/
+    - doc/connectivity/bluetooth/api/mesh/
+    - doc/connectivity/bluetooth/api/shell/iso.rst
+    - doc/connectivity/bluetooth/api/controller.rst
+    - samples/bluetooth/bap*/
+    - samples/bluetooth/cap*/
+    - samples/bluetooth/hap*/
+    - samples/bluetooth/hci_*/
+    - samples/bluetooth/pbp*/
+    - samples/bluetooth/tmap*/
+    - samples/bluetooth/*_iso/
+    - samples/bluetooth/iso_*/
+    - samples/bluetooth/mesh*/
+    - subsys/bluetooth/shell/bredr.c
+    - subsys/bluetooth/shell/iso.c
+    - subsys/bluetooth/shell/ll.c
+    - subsys/bluetooth/shell/ll.h
+    - subsys/bluetooth/shell/ticker.c
+    - subsys/bluetooth/Kconfig.iso
+    - tests/bluetooth/audio/
+    - tests/bluetooth/controller/
+    - tests/bluetooth/ctrl*/
+    - tests/bluetooth/ll_settings/
+    - tests/bluetooth/mesh*/
+    - tests/bluetooth/qualification/
+    - tests/bluetooth/tester/
+    - tests/bsim/bluetooth/audio/
+    - tests/bsim/bluetooth/audio_samples/
+    - tests/bsim/bluetooth/hci_uart/
+    - tests/bsim/bluetooth/ll/
+    - tests/bsim/bluetooth/mesh/
   labels:
     - "area: Bluetooth Host"
     - "area: Bluetooth"
@@ -418,11 +438,14 @@ Bluetooth Mesh:
     - HaavardRei
     - omkar3141
   files:
-    - subsys/bluetooth/mesh/
+    - doc/connectivity/bluetooth/api/mesh/
     - include/zephyr/bluetooth/mesh/
+    - include/zephyr/bluetooth/mesh.h
+    - include/zephyr/bluetooth/testing.h
+    - samples/bluetooth/mesh*/
+    - subsys/bluetooth/mesh/
     - tests/bluetooth/mesh*/
     - tests/bsim/bluetooth/mesh/
-    - samples/bluetooth/mesh/
   labels:
     - "area: Bluetooth Mesh"
     - "area: Bluetooth"
@@ -474,10 +497,48 @@ Bluetooth Classic:
     - jhedberg
     - sjanc
   files:
+    - subsys/bluetooth/common/
     - subsys/bluetooth/host/classic/
+    - subsys/bluetooth/shell/bredr.c
     - include/zephyr/bluetooth/classic/
   labels:
     - "area: Bluetooth Classic"
+    - "area: Bluetooth"
+  tests:
+    - bluetooth
+
+Bluetooth ISO:
+  status: maintained
+  maintainers:
+    - Thalley
+  collaborators:
+    - jhedberg
+  files:
+    - include/zephyr/bluetooth/iso.h
+    - doc/connectivity/bluetooth/api/shell/iso.rst
+    - samples/bluetooth/*_iso/
+    - samples/bluetooth/iso_*/
+    - subsys/bluetooth/shell/iso.c
+    - subsys/bluetooth/Kconfig.iso
+  labels:
+    - "area: Bluetooth ISO"
+    - "area: Bluetooth"
+  tests:
+    - bluetooth
+
+Bluetooth Qualification:
+  status: maintained
+  maintainers:
+    - sjanc
+  collaborators:
+    - Thalley
+    - jhedberg
+  files:
+    - doc/connectivity/bluetooth/autopts/
+    - tests/bluetooth/qualification/
+    - tests/bluetooth/tester/
+  labels:
+    - "area: Bluetooth Qualification"
     - "area: Bluetooth"
   tests:
     - bluetooth


### PR DESCRIPTION
The group covered way to many files with way too few people. The content of the group has been split into several other groups where we can better assign the correct people.