### PR TITLE
arm: clear UNALIGN_TRP bit in CCR register

### DIFF
--- a/arch/arm/core/cortex_m/fault.c
+++ b/arch/arm/core/cortex_m/fault.c
@@ -1192,5 +1192,7 @@ void z_arm_fault_init(void)
 #endif /* CONFIG_BUILTIN_STACK_GUARD */
 #ifdef CONFIG_TRAP_UNALIGNED_ACCESS
 	SCB->CCR |= SCB_CCR_UNALIGN_TRP_Msk;
+#else
+	SCB->CCR &= ~SCB_CCR_UNALIGN_TRP_Msk;
 #endif /* CONFIG_TRAP_UNALIGNED_ACCESS */
 }


### PR DESCRIPTION
Clear the UNALIGN_TRP bit in the CCR register, if the config CONFIG_TRAP_UNALIGNED_ACCESS is not set.

Despite the fact that the reset value of UNALIGN_TRP is 0, always clear the bit. It is useful in double image systems. The new image can't rely on settings left by the previous image.