### PR TITLE
boards: adi: Enable commonly-used I2C nodes by default

### DIFF
--- a/boards/adi/max32655evkit/max32655evkit_max32655_m4.dts
+++ b/boards/adi/max32655evkit/max32655evkit_max32655_m4.dts
@@ -95,3 +95,9 @@
 &trng {
 	status = "okay";
 };
+
+&i2c0 {
+	status = "okay";
+	pinctrl-0 = <&i2c0_scl_p0_10 &i2c0_sda_p0_11>;
+	pinctrl-names = "default";
+};

--- a/boards/adi/max32655fthr/max32655fthr_max32655_m4.dts
+++ b/boards/adi/max32655fthr/max32655fthr_max32655_m4.dts
@@ -129,3 +129,9 @@
 &trng {
 	status = "okay";
 };
+
+&i2c2 {
+	status = "okay";
+	pinctrl-0 = <&i2c2_scl_p0_30 &i2c2_sda_p0_31>;
+	pinctrl-names = "default";
+};

--- a/boards/adi/max32670evkit/max32670evkit.dts
+++ b/boards/adi/max32670evkit/max32670evkit.dts
@@ -75,3 +75,9 @@
 &trng {
 	status = "okay";
 };
+
+&i2c0 {
+	status = "okay";
+	pinctrl-0 = <&i2c0_scl_p0_6 &i2c0_sda_p0_7>;
+	pinctrl-names = "default";
+};

--- a/boards/adi/max32672evkit/max32672evkit.dts
+++ b/boards/adi/max32672evkit/max32672evkit.dts
@@ -75,3 +75,9 @@
 &trng {
 	status = "okay";
 };
+
+&i2c0 {
+	status = "okay";
+	pinctrl-0 = <&i2c0a_scl_p0_6 &i2c0a_sda_p0_7>;
+	pinctrl-names = "default";
+};

--- a/boards/adi/max32680evkit/max32680evkit_max32680_m4.dts
+++ b/boards/adi/max32680evkit/max32680evkit_max32680_m4.dts
@@ -85,3 +85,15 @@
 &trng {
 	status = "okay";
 };
+
+&i2c0 {
+	status = "okay";
+	pinctrl-0 = <&i2c0a_scl_p0_10 &i2c0a_sda_p0_11>;
+	pinctrl-names = "default";
+};
+
+&i2c1 {
+	status = "okay";
+	pinctrl-0 = <&i2c1a_scl_p0_16 &i2c1a_sda_p0_17>;
+	pinctrl-names = "default";
+};

--- a/boards/adi/max32690evkit/max32690evkit_max32690_m4.dts
+++ b/boards/adi/max32690evkit/max32690evkit_max32690_m4.dts
@@ -91,3 +91,9 @@
 &trng {
 	status = "okay";
 };
+
+&i2c0 {
+	status = "okay";
+	pinctrl-0 = <&i2c0a_scl_p2_8 &i2c0a_sda_p2_7>;
+	pinctrl-names = "default";
+};

--- a/tests/drivers/i2c/i2c_target_api/boards/max32655evkit_max32655_m4.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/max32655evkit_max32655_m4.overlay
@@ -5,10 +5,6 @@
  */
 
 &i2c0 {
-	status = "okay";
-	pinctrl-0 = <&i2c0_scl_p0_10 &i2c0_sda_p0_11>;
-	pinctrl-names = "default";
-
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;

--- a/tests/drivers/i2c/i2c_target_api/boards/max32670evkit.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/max32670evkit.overlay
@@ -5,10 +5,6 @@
  */
 
 &i2c0 {
-	status = "okay";
-	pinctrl-0 = <&i2c0_scl_p0_6 &i2c0_sda_p0_7>;
-	pinctrl-names = "default";
-
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;

--- a/tests/drivers/i2c/i2c_target_api/boards/max32672evkit.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/max32672evkit.overlay
@@ -5,10 +5,6 @@
  */
 
 &i2c0 {
-	status = "okay";
-	pinctrl-0 = <&i2c0a_scl_p0_6 &i2c0a_sda_p0_7>;
-	pinctrl-names = "default";
-
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;

--- a/tests/drivers/i2c/i2c_target_api/boards/max32680evkit_max32680_m4.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/max32680evkit_max32680_m4.overlay
@@ -5,10 +5,6 @@
  */
 
 &i2c0 {
-	status = "okay";
-	pinctrl-0 = <&i2c0a_scl_p0_10 &i2c0a_sda_p0_11>;
-	pinctrl-names = "default";
-
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
@@ -18,10 +14,6 @@
 };
 
 &i2c1 {
-	status = "okay";
-	pinctrl-0 = <&i2c1a_scl_p0_16 &i2c1a_sda_p0_17>;
-	pinctrl-names = "default";
-
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;

--- a/tests/drivers/i2c/i2c_target_api/boards/max32690evkit_max32690_m4.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/max32690evkit_max32690_m4.overlay
@@ -5,10 +5,6 @@
  */
 
 &i2c0 {
-	status = "okay";
-	pinctrl-0 = <&i2c0a_scl_p2_8 &i2c0a_sda_p2_7>;
-	pinctrl-names = "default";
-
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;


### PR DESCRIPTION
Enable commonly-accessible I2C and define their pins at board-level devicetree so that they will not have to be redefined in an overlay file for each different project.

Thanks @ubieda for the suggestion.
FYI @ozersa.