### PR TITLE
ci: manifest: fix wrong version being used for action-manifest

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -26,7 +26,7 @@ jobs:
           west init -l . || true
 
       - name: Manifest
-        uses: zephyrproject-rtos/action-manifest@1.3.0
+        uses: zephyrproject-rtos/action-manifest@v1.3.0
         with:
           github-token: ${{ secrets.ZB_GITHUB_TOKEN }}
           manifest-path: 'west.yml'


### PR DESCRIPTION
A typo in "1.3.0" tag is causing CI to fail since the actual tag is "v1.3.0"