### PR TITLE
tests: debug/thread_analyzer: add some build tests

### DIFF
--- a/tests/subsys/debug/thread_analyzer/CMakeLists.txt
+++ b/tests/subsys/debug/thread_analyzer/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(thread_analyzer_tests)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/subsys/debug/thread_analyzer/prj.conf
+++ b/tests/subsys/debug/thread_analyzer/prj.conf
@@ -1,0 +1,5 @@
+CONFIG_THREAD_ANALYZER=y
+CONFIG_THREAD_ANALYZER_AUTO=y
+
+# log immediate mode requires a bit more stack to print
+CONFIG_THREAD_ANALYZER_AUTO_STACK_SIZE=2048

--- a/tests/subsys/debug/thread_analyzer/src/main.c
+++ b/tests/subsys/debug/thread_analyzer/src/main.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+
+#define EXTRA_THREAD_STACKSIZE 2048
+
+struct k_thread extra_thread;
+K_THREAD_STACK_DEFINE(extra_stack, EXTRA_THREAD_STACKSIZE);
+
+static void thread_entry(void *p1, void *p2, void *p3)
+{
+	/* This thread does not have a name so thread analyzer will display
+	 * the memory address of the thread struct, which is needed for
+	 * the twister console harness to match (even if CONFIG_THREAD_NAME=y).
+	 */
+	while (true) {
+		k_sleep(K_SECONDS(300));
+	}
+}
+
+int main(void)
+{
+	k_thread_create(&extra_thread, extra_stack, EXTRA_THREAD_STACKSIZE,
+			thread_entry, NULL, NULL, NULL, K_PRIO_PREEMPT(0),
+			IS_ENABLED(CONFIG_USERSPACE) ? K_USER : 0,
+			K_MSEC(0));
+	return 0;
+}

--- a/tests/subsys/debug/thread_analyzer/testcase.yaml
+++ b/tests/subsys/debug/thread_analyzer/testcase.yaml
@@ -1,0 +1,55 @@
+common:
+  integration_platforms:
+    - mps2/an385
+    - qemu_x86_64
+  tags:
+    - debug
+    - thread_analyzer
+  platform_exclude:
+    # native_sim prints nothing from thread analyzer so skips it for now.
+    - native_sim
+tests:
+  debug.thread_analyzer.printk:
+    extra_configs:
+      - CONFIG_THREAD_ANALYZER_USE_PRINTK=y
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - "(.*)0x([0-9a-fA-F]+)([ ]+) : STACK: unused [0-9]+ usage [0-9]+ / [0-9]+ (.*)"
+        - "(.*)ISR0([ ]+) : STACK: unused [0-9]+ usage [0-9]+ / [0-9]+ (.*)"
+  debug.thread_analyzer.printk.userspace:
+    filter: CONFIG_ARCH_HAS_USERSPACE
+    extra_configs:
+      - CONFIG_THREAD_ANALYZER_USE_PRINTK=y
+      - CONFIG_USERSPACE=y
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - "(.*)0x([0-9a-fA-F]+)([ ]+) : STACK: unused [0-9]+ usage [0-9]+ / [0-9]+ (.*)"
+        - "(.*)ISR0([ ]+) : STACK: unused [0-9]+ usage [0-9]+ / [0-9]+ (.*)"
+  debug.thread_analyzer.log_backend:
+    extra_configs:
+      - CONFIG_THREAD_ANALYZER_USE_LOG=y
+      - CONFIG_LOG=y
+      - CONFIG_LOG_MODE_IMMEDIATE=y
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - "(.*)0x([0-9a-fA-F]+)([ ]+) : STACK: unused [0-9]+ usage [0-9]+ / [0-9]+ (.*)"
+        - "(.*)ISR0([ ]+) : STACK: unused [0-9]+ usage [0-9]+ / [0-9]+ (.*)"
+  debug.thread_analyzer.log_backend.userspace:
+    filter: CONFIG_ARCH_HAS_USERSPACE
+    extra_configs:
+      - CONFIG_USERSPACE=y
+      - CONFIG_THREAD_ANALYZER_USE_LOG=y
+      - CONFIG_LOG=y
+      - CONFIG_LOG_MODE_IMMEDIATE=y
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - "(.*)0x([0-9a-fA-F]+)([ ]+) : STACK: unused [0-9]+ usage [0-9]+ / [0-9]+ (.*)"
+        - "(.*)ISR0([ ]+) : STACK: unused [0-9]+ usage [0-9]+ / [0-9]+ (.*)"


### PR DESCRIPTION
Add some build tests for thread_analyzer to catch build issues at CI. The files originated from the userspace hello world sample.

This is build only for now as the ordering of the threads being displayed is not consistent among platforms. So it is difficult to use console harness to test outputs.