### PR TITLE
Bluetooth: Controller: Fix missing invalid aux offset check

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -129,6 +129,7 @@ uint8_t lll_scan_aux_setup(struct pdu_adv *pdu, uint8_t pdu_phy,
 	uint32_t aux_offset_us;
 	uint32_t overhead_us;
 	uint8_t *pri_dptr;
+	uint32_t pdu_us;
 	uint8_t phy;
 
 	LL_ASSERT(pdu->type == PDU_ADV_TYPE_EXT_IND);
@@ -183,6 +184,12 @@ uint8_t lll_scan_aux_setup(struct pdu_adv *pdu, uint8_t pdu_phy,
 	/* Calculate the aux offset from start of the scan window */
 	aux_offset_us = (uint32_t)PDU_ADV_AUX_PTR_OFFSET_GET(aux_ptr) * window_size_us;
 
+	/* Skip reception if invalid aux offset */
+	pdu_us = PDU_AC_US(pdu->len, pdu_phy, pdu_phy_flags_rx);
+	if (aux_offset_us < pdu_us) {
+		return 0U;
+	}
+
 	/* Calculate the window widening that needs to be deducted */
 	if (aux_ptr->ca) {
 		window_widening_us = SCA_DRIFT_50_PPM_US(aux_offset_us);
@@ -233,7 +240,7 @@ uint8_t lll_scan_aux_setup(struct pdu_adv *pdu, uint8_t pdu_phy,
 	ftr->radio_end_us = radio_tmr_end_get() -
 			    radio_rx_chain_delay_get(pdu_phy,
 						     pdu_phy_flags_rx) -
-			    PDU_AC_US(pdu->len, pdu_phy, pdu_phy_flags_rx);
+			    pdu_us;
 
 	radio_isr_set(setup_cb, node_rx);
 	radio_disable();

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -338,6 +338,7 @@ void lll_scan_aux_isr_aux_setup(void *param)
 	aux_start_us -= EVENT_JITTER_US;
 
 	start_us = radio_tmr_start_us(0, aux_start_us);
+	LL_ASSERT(start_us == (aux_start_us + 1U));
 
 	/* Setup header complete timeout */
 	hcto = start_us;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -738,6 +738,7 @@ static void isr_aux_setup(void *param)
 	aux_start_us -= EVENT_JITTER_US;
 
 	start_us = radio_tmr_start_us(0, aux_start_us);
+	LL_ASSERT(start_us == (aux_start_us + 1U));
 
 	/* Setup header complete timeout */
 	hcto = start_us;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
@@ -1046,10 +1046,7 @@ isr_rx_next_subevent:
 
 		start_us = hcto;
 		hcto = radio_tmr_start_us(0U, start_us);
-		/* FIXME: Assertion check disabled until investigation as to
-		 *        why there is high ISR latency causing assertion here.
-		 */
-		/* LL_ASSERT(hcto == (start_us + 1U)); */
+		LL_ASSERT(hcto == (start_us + 1U));
 
 		/* Add 8 us * subevents so far, as radio was setup to listen
 		 * 4 us early and subevents could have a 4 us drift each until


### PR DESCRIPTION
Fix missing invalid aux offset check that was being caught
in a development assertion check. If aux offset where less
than the PDU time of the primary channel PDU, radio was
redundantly being setup delayed for reception that was
being caught in an assertion check.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>