### PR TITLE
boards: add missing deprecated board entry for adafruit feather

### DIFF
--- a/boards/deprecated.cmake
+++ b/boards/deprecated.cmake
@@ -29,8 +29,11 @@ set(actinius_icarus_som_dk_ns_DEPRECATED
 set(actinius_icarus_som_ns_DEPRECATED
     actinius_icarus_som/nrf9160/ns
 )
+set(adafruit_feather_DEPRECATED
+    adafruit_feather_nrf52840_express
+)
 set(adafruit_feather_nrf52840_DEPRECATED
-    adafruit_feather
+    adafruit_feather_nrf52840_express
 )
 set(adafruit_itsybitsy_nrf52840_DEPRECATED
     adafruit_itsybitsy


### PR DESCRIPTION
The adafruit feather nrf52840 express board was recently renamed from adafruit feather, but the board deprecation entry was missed.

The previuos board name also was an update to a hwmv1 board name, which this also updates.