### PR TITLE
Bluetooth: Audio: Add helpers for assisted listening stream

### DIFF
--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -80,6 +80,14 @@ Bluetooth
 
   * :c:func:`bt_tbs_client_register_cb` now supports multiple listeners and may now return an error.
 
+  * Added APIs for getting and setting the assisted listening stream values in codec capabilities
+    and codec configuration:
+
+    * :c:func:`bt_audio_codec_cfg_meta_get_assisted_listening_stream`
+    * :c:func:`bt_audio_codec_cfg_meta_set_assisted_listening_stream`
+    * :c:func:`bt_audio_codec_cap_meta_get_assisted_listening_stream`
+    * :c:func:`bt_audio_codec_cap_meta_set_assisted_listening_stream`
+
 * Host
 
   * Added API :c:func:`bt_gatt_get_uatt_mtu` to get current Unenhanced ATT MTU of a given

--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -419,6 +419,12 @@ enum bt_audio_active_state {
 	BT_AUDIO_ACTIVE_STATE_ENABLED        = 0x01,
 };
 
+/** Assisted Listening Stream defined by the Generic Audio assigned numbers (bluetooth.com). */
+enum bt_audio_assisted_listening_stream {
+	/** Unspecified audio enhancement */
+	BT_AUDIO_ASSISTED_LISTENING_STREAM_UNSPECIFIED = 0x00,
+};
+
 /**
  * @brief Codec metadata type IDs
  *
@@ -435,7 +441,7 @@ enum bt_audio_metadata_type {
 	 *
 	 * See the BT_AUDIO_CONTEXT_* for valid values.
 	 */
-	BT_AUDIO_METADATA_TYPE_PREF_CONTEXT        = 0x01,
+	BT_AUDIO_METADATA_TYPE_PREF_CONTEXT = 0x01,
 
 	/**
 	 * @brief Streaming audio context.
@@ -447,10 +453,10 @@ enum bt_audio_metadata_type {
 	 *
 	 * See the BT_AUDIO_CONTEXT_* for valid values.
 	 */
-	BT_AUDIO_METADATA_TYPE_STREAM_CONTEXT      = 0x02,
+	BT_AUDIO_METADATA_TYPE_STREAM_CONTEXT = 0x02,
 
 	/** UTF-8 encoded title or summary of stream content */
-	BT_AUDIO_METADATA_TYPE_PROGRAM_INFO        = 0x03,
+	BT_AUDIO_METADATA_TYPE_PROGRAM_INFO = 0x03,
 
 	/**
 	 * @brief Language
@@ -458,30 +464,37 @@ enum bt_audio_metadata_type {
 	 * 3 octet lower case language code defined by ISO 639-3
 	 * Possible values can be found at https://iso639-3.sil.org/code_tables/639/data
 	 */
-	BT_AUDIO_METADATA_TYPE_LANG                = 0x04,
+	BT_AUDIO_METADATA_TYPE_LANG = 0x04,
 
 	/** Array of 8-bit CCID values */
-	BT_AUDIO_METADATA_TYPE_CCID_LIST           = 0x05,
+	BT_AUDIO_METADATA_TYPE_CCID_LIST = 0x05,
 
 	/**
 	 * @brief Parental rating
 	 *
 	 * See @ref bt_audio_parental_rating for valid values.
 	 */
-	BT_AUDIO_METADATA_TYPE_PARENTAL_RATING     = 0x06,
+	BT_AUDIO_METADATA_TYPE_PARENTAL_RATING = 0x06,
 
 	/** UTF-8 encoded URI for additional Program information */
-	BT_AUDIO_METADATA_TYPE_PROGRAM_INFO_URI    = 0x07,
+	BT_AUDIO_METADATA_TYPE_PROGRAM_INFO_URI = 0x07,
 
 	/**
 	 * @brief Audio active state
 	 *
 	 * See @ref bt_audio_active_state for valid values.
 	 */
-	BT_AUDIO_METADATA_TYPE_AUDIO_STATE         = 0x08,
+	BT_AUDIO_METADATA_TYPE_AUDIO_STATE = 0x08,
 
 	/** Broadcast Audio Immediate Rendering flag  */
 	BT_AUDIO_METADATA_TYPE_BROADCAST_IMMEDIATE = 0x09,
+
+	/**
+	 * @brief Assisted listening stream
+	 *
+	 * See @ref bt_audio_assisted_listening_stream for valid values.
+	 */
+	BT_AUDIO_METADATA_TYPE_ASSISTED_LISTENING_STREAM = 0x0A,
 
 	/** Extended metadata */
 	BT_AUDIO_METADATA_TYPE_EXTENDED            = 0xFE,
@@ -1572,6 +1585,34 @@ int bt_audio_codec_cfg_meta_set_bcast_audio_immediate_rend_flag(
 	struct bt_audio_codec_cfg *codec_cfg);
 
 /**
+ * @brief Extract assisted listening stream
+ *
+ * See @ref BT_AUDIO_METADATA_TYPE_ASSISTED_LISTENING_STREAM for more information about this value.
+ *
+ * @param codec_cfg The codec data to search in.
+ *
+ * @retval value The assisted listening stream value if positive or 0
+ * @retval -EINVAL if arguments are invalid
+ * @retval -ENODATA if not found
+ * @retval -EBADMSG if found value has invalid size
+ */
+int bt_audio_codec_cfg_meta_get_assisted_listening_stream(
+	const struct bt_audio_codec_cfg *codec_cfg);
+
+/**
+ * @brief Set the assisted listening stream value of a codec configuration metadata.
+ *
+ * @param codec_cfg The codec configuration to set data for.
+ * @param val       The assisted listening stream value to set.
+ *
+ * @retval length The data_len of @p codec_cap on success
+ * @retval -EINVAL if arguments are invalid
+ * @retval -ENOMEM if the new value could not set or added due to memory
+ */
+int bt_audio_codec_cfg_meta_set_assisted_listening_stream(
+	struct bt_audio_codec_cfg *codec_cfg, enum bt_audio_assisted_listening_stream val);
+
+/**
  * @brief Extract extended metadata
  *
  * See @ref BT_AUDIO_METADATA_TYPE_EXTENDED for more information about this value.
@@ -2113,6 +2154,34 @@ int bt_audio_codec_cap_meta_get_bcast_audio_immediate_rend_flag(
  */
 int bt_audio_codec_cap_meta_set_bcast_audio_immediate_rend_flag(
 	struct bt_audio_codec_cap *codec_cap);
+
+/**
+ * @brief Extract assisted listening stream
+ *
+ * See @ref BT_AUDIO_METADATA_TYPE_ASSISTED_LISTENING_STREAM for more information about this value.
+ *
+ * @param codec_cap The codec data to search in.
+ *
+ * @retval value The assisted listening stream value if positive or 0
+ * @retval -EINVAL if arguments are invalid
+ * @retval -ENODATA if not found
+ * @retval -EBADMSG if found value has invalid size
+ */
+int bt_audio_codec_cap_meta_get_assisted_listening_stream(
+	const struct bt_audio_codec_cap *codec_cap);
+
+/**
+ * @brief Set the assisted listening stream value of a codec capability metadata.
+ *
+ * @param codec_cap The codec capability to set data for.
+ * @param val       The assisted listening stream value to set.
+ *
+ * @retval length The data_len of @p codec_cap on success
+ * @retval -EINVAL if arguments are invalid
+ * @retval -ENOMEM if the new value could not set or added due to memory
+ */
+int bt_audio_codec_cap_meta_set_assisted_listening_stream(
+	struct bt_audio_codec_cap *codec_cap, enum bt_audio_assisted_listening_stream val);
 
 /**
  * @brief Extract extended metadata

--- a/subsys/bluetooth/audio/codec.c
+++ b/subsys/bluetooth/audio/codec.c
@@ -1056,6 +1056,52 @@ static int codec_meta_set_bcast_audio_immediate_rend_flag(uint8_t meta[], size_t
 				  BT_AUDIO_METADATA_TYPE_BROADCAST_IMMEDIATE, NULL, 0);
 }
 
+static int codec_meta_get_assisted_listening_stream(const uint8_t meta[], size_t meta_len)
+{
+	const uint8_t *data;
+	int ret;
+
+	CHECKIF(meta == NULL) {
+		LOG_DBG("meta is NULL");
+		return -EINVAL;
+	}
+
+	ret = codec_meta_get_val(meta, meta_len, BT_AUDIO_METADATA_TYPE_ASSISTED_LISTENING_STREAM,
+				 &data);
+	if (data == NULL) {
+		return -ENODATA;
+	}
+
+	if (ret != sizeof(uint8_t)) {
+		return -EBADMSG;
+	}
+
+	return data[0];
+}
+
+static int codec_meta_set_assisted_listening_stream(uint8_t meta[], size_t meta_len,
+						    size_t meta_size,
+						    enum bt_audio_assisted_listening_stream val)
+{
+	uint8_t val_u8;
+
+	CHECKIF(meta == NULL) {
+		LOG_DBG("meta is NULL");
+		return -EINVAL;
+	}
+
+	if (val != BT_AUDIO_ASSISTED_LISTENING_STREAM_UNSPECIFIED) {
+		LOG_DBG("Invalid value: %d", val);
+		return -EINVAL;
+	}
+
+	val_u8 = (uint8_t)val;
+
+	return codec_meta_set_val(meta, meta_len, meta_size,
+				  BT_AUDIO_METADATA_TYPE_ASSISTED_LISTENING_STREAM, &val_u8,
+				  sizeof(val_u8));
+}
+
 static int codec_meta_get_extended(const uint8_t meta[], size_t meta_len,
 				   const uint8_t **extended_meta)
 {
@@ -1426,6 +1472,31 @@ int bt_audio_codec_cfg_meta_set_bcast_audio_immediate_rend_flag(
 	return ret;
 }
 
+int bt_audio_codec_cfg_meta_get_assisted_listening_stream(
+	const struct bt_audio_codec_cfg *codec_cfg)
+{
+	CHECKIF(codec_cfg == NULL) {
+		LOG_DBG("codec_cfg is NULL");
+		return -EINVAL;
+	}
+
+	return codec_meta_get_assisted_listening_stream(codec_cfg->meta, codec_cfg->meta_len);
+}
+
+int bt_audio_codec_cfg_meta_set_assisted_listening_stream(
+	struct bt_audio_codec_cfg *codec_cfg, enum bt_audio_assisted_listening_stream val)
+{
+	int ret;
+
+	ret = codec_meta_set_assisted_listening_stream(codec_cfg->meta, codec_cfg->meta_len,
+						       ARRAY_SIZE(codec_cfg->meta), val);
+	if (ret >= 0) {
+		codec_cfg->meta_len = ret;
+	}
+
+	return ret;
+}
+
 int bt_audio_codec_cfg_meta_get_extended(const struct bt_audio_codec_cfg *codec_cfg,
 					 const uint8_t **extended_meta)
 {
@@ -1747,6 +1818,31 @@ int bt_audio_codec_cap_meta_set_bcast_audio_immediate_rend_flag(
 
 	ret = codec_meta_set_bcast_audio_immediate_rend_flag(codec_cap->meta, codec_cap->meta_len,
 							     ARRAY_SIZE(codec_cap->meta));
+	if (ret >= 0) {
+		codec_cap->meta_len = ret;
+	}
+
+	return ret;
+}
+
+int bt_audio_codec_cap_meta_get_assisted_listening_stream(
+	const struct bt_audio_codec_cap *codec_cap)
+{
+	CHECKIF(codec_cap == NULL) {
+		LOG_DBG("codec_cap is NULL");
+		return -EINVAL;
+	}
+
+	return codec_meta_get_assisted_listening_stream(codec_cap->meta, codec_cap->meta_len);
+}
+
+int bt_audio_codec_cap_meta_set_assisted_listening_stream(
+	struct bt_audio_codec_cap *codec_cap, enum bt_audio_assisted_listening_stream val)
+{
+	int ret;
+
+	ret = codec_meta_set_assisted_listening_stream(codec_cap->meta, codec_cap->meta_len,
+						       ARRAY_SIZE(codec_cap->meta), val);
 	if (ret >= 0) {
 		codec_cap->meta_len = ret;
 	}

--- a/tests/bluetooth/audio/codec/src/main.c
+++ b/tests/bluetooth/audio/codec/src/main.c
@@ -930,6 +930,35 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_bcast_audio_immed
 	zassert_equal(ret, 0, "Unexpected return value %d", ret);
 }
 
+ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_assisted_listening_stream)
+{
+	const struct bt_audio_codec_cfg codec_cfg = BT_AUDIO_CODEC_CFG(
+		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_ASSISTED_LISTENING_STREAM,
+				     BT_AUDIO_ASSISTED_LISTENING_STREAM_UNSPECIFIED)});
+	int ret;
+
+	ret = bt_audio_codec_cfg_meta_get_assisted_listening_stream(&codec_cfg);
+	zassert_equal(ret, 0x00, "Unexpected return value %d", ret);
+}
+
+ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_set_assisted_listening_stream)
+{
+	struct bt_audio_codec_cfg codec_cfg =
+		BT_AUDIO_CODEC_CFG(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {}, {});
+	int ret;
+
+	ret = bt_audio_codec_cfg_meta_get_assisted_listening_stream(&codec_cfg);
+	zassert_equal(ret, -ENODATA, "Unexpected return value %d", ret);
+
+	ret = bt_audio_codec_cfg_meta_set_assisted_listening_stream(
+		&codec_cfg, BT_AUDIO_ASSISTED_LISTENING_STREAM_UNSPECIFIED);
+	zassert_true(ret > 0, "Unexpected return value %d", ret);
+
+	ret = bt_audio_codec_cfg_meta_get_assisted_listening_stream(&codec_cfg);
+	zassert_equal(ret, 0x00, "Unexpected return value %d", ret);
+}
+
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cfg_meta_get_extended)
 {
 	const uint8_t expected_data[] = {0x00, 0x01, 0x02, 0x03};
@@ -1813,6 +1842,35 @@ ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_set_bcast_audio_immed
 
 	ret = bt_audio_codec_cap_meta_get_bcast_audio_immediate_rend_flag(&codec_cap);
 	zassert_equal(ret, 0, "Unexpected return value %d", ret);
+}
+
+ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_get_assisted_listening_stream)
+{
+	const struct bt_audio_codec_cap codec_cap = BT_AUDIO_CODEC_CAP(
+		BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {},
+		{BT_AUDIO_CODEC_DATA(BT_AUDIO_METADATA_TYPE_ASSISTED_LISTENING_STREAM,
+				     BT_AUDIO_ASSISTED_LISTENING_STREAM_UNSPECIFIED)});
+	int ret;
+
+	ret = bt_audio_codec_cap_meta_get_assisted_listening_stream(&codec_cap);
+	zassert_equal(ret, 0x00, "Unexpected return value %d", ret);
+}
+
+ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_set_assisted_listening_stream)
+{
+	struct bt_audio_codec_cap codec_cap =
+		BT_AUDIO_CODEC_CAP(BT_HCI_CODING_FORMAT_LC3, 0x0000, 0x0000, {}, {});
+	int ret;
+
+	ret = bt_audio_codec_cap_meta_get_assisted_listening_stream(&codec_cap);
+	zassert_equal(ret, -ENODATA, "Unexpected return value %d", ret);
+
+	ret = bt_audio_codec_cap_meta_set_assisted_listening_stream(
+		&codec_cap, BT_AUDIO_ASSISTED_LISTENING_STREAM_UNSPECIFIED);
+	zassert_true(ret > 0, "Unexpected return value %d", ret);
+
+	ret = bt_audio_codec_cap_meta_get_assisted_listening_stream(&codec_cap);
+	zassert_equal(ret, 0x00, "Unexpected return value %d", ret);
 }
 
 ZTEST(audio_codec_test_suite, test_bt_audio_codec_cap_meta_get_extended)


### PR DESCRIPTION
Added helper functions to set and get assisted listening stream values for codec capabilities and codec configs.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/68595