### PR TITLE
drivers: flash_ flash_simulator: Add semihosting implementation

### DIFF
--- a/drivers/flash/Kconfig.simulator
+++ b/drivers/flash/Kconfig.simulator
@@ -94,4 +94,21 @@ config FLASH_SIMULATOR_STAT_PAGE_COUNT
 	  This is why it's not possible to calculate the number of pages with
 	  preprocessor using DT properties.
 
+config FLASH_SIMULATOR_SEMIHOST
+	bool "Use semihosting for simulated flash"
+	select SEMIHOST
+	help
+	  Enabling this function leverages semihosting feature available on RISC-V and ARM
+	  and allows to simulate flash storage greater than RAM. The simulated flash memory
+	  is stored on a host computer as a binary file.
+
+if FLASH_SIMULATOR_SEMIHOST
+config FLASH_SIMULATOR_SEMIHOST_FILENAME
+	string "Name of binary file used as simulated flash"
+	default "flash_simulator.bin"
+
+config FLASH_SIMULATION_SEMIHOST_ERASE_AT_BOOT
+	bool "Erase flash content at the system initialization"
+endif
+
 endif # FLASH_SIMULATOR

--- a/drivers/flash/flash_simulator.c
+++ b/drivers/flash/flash_simulator.c
@@ -16,6 +16,9 @@
 #include <zephyr/random/random.h>
 #include <zephyr/stats/stats.h>
 #include <string.h>
+#ifdef CONFIG_FLASH_SIMULATOR_SEMIHOST
+#include <zephyr/arch/common/semihost.h>
+#endif
 
 #ifdef CONFIG_ARCH_POSIX
 
@@ -147,15 +150,16 @@ static const char *flash_file_path;
 static bool flash_erase_at_start;
 static bool flash_rm_at_exit;
 static bool flash_in_ram;
-#else
-#if DT_NODE_HAS_PROP(DT_PARENT(SOC_NV_FLASH_NODE), memory_region)
+#elif defined(CONFIG_FLASH_SIMULATOR_SEMIHOST)
+static int flash_fd = -1;
+static char flash_erase_buf[FLASH_SIMULATOR_ERASE_UNIT];
+#elif DT_NODE_HAS_PROP(DT_PARENT(SOC_NV_FLASH_NODE), memory_region)
 #define FLASH_SIMULATOR_MREGION \
 	LINKER_DT_NODE_REGION_NAME( \
 	DT_PHANDLE(DT_PARENT(SOC_NV_FLASH_NODE), memory_region))
 static uint8_t mock_flash[FLASH_SIMULATOR_FLASH_SIZE] Z_GENERIC_SECTION(FLASH_SIMULATOR_MREGION);
 #else
 static uint8_t mock_flash[FLASH_SIMULATOR_FLASH_SIZE];
-#endif
 #endif /* CONFIG_ARCH_POSIX */
 
 static DEVICE_API(flash, flash_sim_api);
@@ -169,6 +173,50 @@ static const struct flash_parameters flash_sim_parameters = {
 #endif
 	},
 };
+
+#ifdef CONFIG_FLASH_SIMULATOR_SEMIHOST
+static int flash_semihost_erase(off_t offset, size_t len)
+{
+	if (semihost_seek(flash_fd, offset) < 0) {
+		return -EIO;
+	}
+
+	for (int i = offset; i < offset + len; i += FLASH_SIMULATOR_ERASE_UNIT) {
+
+		if (semihost_write(flash_fd, flash_erase_buf, FLASH_SIMULATOR_ERASE_UNIT) < 0) {
+			return -EIO;
+		}
+	}
+
+	return 0;
+}
+
+#if defined(CONFIG_FLASH_SIMULATOR_EXPLICIT_ERASE)
+static void flash_semihost_write_byte_expl_erase(off_t offset, uint8_t *data)
+{
+	uint8_t tmp;
+
+	semihost_read(flash_fd, &tmp, 1);
+	semihost_seek(flash_fd, offset);
+#if FLASH_SIMULATOR_ERASE_VALUE == 0xFF
+	tmp &= *data;
+#else
+	tmp |= *data;
+#endif
+	semihost_write(flash_fd, &tmp, 1);
+}
+#endif /* CONFIG_FLASH_SIMULATOR_EXPLICIT_ERASE */
+
+static void flash_semihost_write_byte(off_t offset, uint8_t *data)
+{
+	semihost_seek(flash_fd, offset);
+#if defined(CONFIG_FLASH_SIMULATOR_EXPLICIT_ERASE)
+	flash_semihost_write_byte_expl_erase(offset, data);
+#else
+	semihost_write(flash_fd, data, 1);
+#endif /* CONFIG_FLASH_SIMULATOR_EXPLICIT_ERASE */
+}
+#endif /* CONFIG_FLASH_SIMULATOR_SEMIHOST */
 
 static int flash_range_is_valid(const struct device *dev, off_t offset,
 				size_t len)
@@ -202,7 +250,12 @@ static int flash_sim_read(const struct device *dev, const off_t offset,
 
 	FLASH_SIM_STATS_INC(flash_sim_stats, flash_read_calls);
 
+#ifdef CONFIG_FLASH_SIMULATOR_SEMIHOST
+	semihost_seek(flash_fd, offset);
+	semihost_read(flash_fd, data, len);
+#else
 	memcpy(data, MOCK_FLASH(offset), len);
+#endif
 	FLASH_SIM_STATS_INCN(flash_sim_stats, bytes_read, len);
 
 #ifdef CONFIG_FLASH_SIMULATOR_SIMULATE_TIMING
@@ -231,6 +284,10 @@ static int flash_sim_write(const struct device *dev, const off_t offset,
 
 	FLASH_SIM_STATS_INC(flash_sim_stats, flash_write_calls);
 
+#ifdef CONFIG_FLASH_SIMULATOR_SEMIHOST
+	semihost_seek(flash_fd, offset);
+#endif
+
 #if defined(CONFIG_FLASH_SIMULATOR_EXPLICIT_ERASE)
 	/* check if any unit has been already programmed */
 	memset(buf, FLASH_SIMULATOR_ERASE_VALUE, sizeof(buf));
@@ -238,7 +295,14 @@ static int flash_sim_write(const struct device *dev, const off_t offset,
 	memcpy(buf, MOCK_FLASH(offset), sizeof(buf));
 #endif
 	for (uint32_t i = 0; i < len; i += FLASH_SIMULATOR_PROG_UNIT) {
+#if defined(CONFIG_FLASH_SIMULATOR_SEMIHOST)
+		uint8_t tmp[FLASH_SIMULATOR_PROG_UNIT];
+
+		semihost_read(flash_fd, tmp, sizeof(buf));
+		if (memcmp(buf, tmp, sizeof(buf))) {
+#else
 		if (memcmp(buf, MOCK_FLASH(offset + i), sizeof(buf))) {
+#endif
 			FLASH_SIM_STATS_INC(flash_sim_stats, double_writes);
 #if !CONFIG_FLASH_SIMULATOR_DOUBLE_WRITES
 			return -EIO;
@@ -274,7 +338,9 @@ static int flash_sim_write(const struct device *dev, const off_t offset,
 #endif /* CONFIG_FLASH_SIMULATOR_STATS */
 
 		/* only pull bits to zero */
-#if defined(CONFIG_FLASH_SIMULATOR_EXPLICIT_ERASE)
+#ifdef CONFIG_FLASH_SIMULATOR_SEMIHOST
+		flash_semihost_write_byte(offset + i, (uint8_t *)data + i);
+#elif defined(CONFIG_FLASH_SIMULATOR_EXPLICIT_ERASE)
 #if FLASH_SIMULATOR_ERASE_VALUE == 0xFF
 		*(MOCK_FLASH(offset + i)) &= *((uint8_t *)data + i);
 #else
@@ -282,7 +348,7 @@ static int flash_sim_write(const struct device *dev, const off_t offset,
 #endif
 #else
 		*(MOCK_FLASH(offset + i)) = *((uint8_t *)data + i);
-#endif
+#endif /* CONFIG_FLASH_SIMULATOR_SEMIHOST / CONFIG_FLASH_SIMULATOR_EXPLICIT_ERASE */
 	}
 
 	FLASH_SIM_STATS_INCN(flash_sim_stats, bytes_written, len);
@@ -302,8 +368,11 @@ static void unit_erase(const uint32_t unit)
 	const off_t unit_addr = unit * FLASH_SIMULATOR_ERASE_UNIT;
 
 	/* erase the memory unit by setting it to erase value */
-	memset(MOCK_FLASH(unit_addr), FLASH_SIMULATOR_ERASE_VALUE,
-	       FLASH_SIMULATOR_ERASE_UNIT);
+#ifdef CONFIG_FLASH_SIMULATOR_SEMIHOST
+	flash_semihost_erase(unit_addr, FLASH_SIMULATOR_ERASE_UNIT);
+#else
+	memset(MOCK_FLASH(unit_addr), FLASH_SIMULATOR_ERASE_VALUE, FLASH_SIMULATOR_ERASE_UNIT);
+#endif
 }
 
 static int flash_sim_erase(const struct device *dev, const off_t offset,
@@ -413,8 +482,26 @@ static int flash_mock_init(const struct device *dev)
 	}
 }
 
-#else
-#if DT_NODE_HAS_PROP(DT_PARENT(SOC_NV_FLASH_NODE), memory_region)
+#elif defined(CONFIG_FLASH_SIMULATOR_SEMIHOST)
+static int flash_mock_init(const struct device *dev)
+{
+	flash_fd = semihost_open(CONFIG_FLASH_SIMULATOR_SEMIHOST_FILENAME, SEMIHOST_OPEN_AB_PLUS);
+
+	if (flash_fd < 0) {
+		return -EIO;
+	}
+
+	memset(flash_erase_buf, FLASH_SIMULATOR_ERASE_VALUE, FLASH_SIMULATOR_ERASE_UNIT);
+
+#ifdef CONFIG_FLASH_SIMULATION_SEMIHOST_ERASE_AT_BOOT
+	if (flash_semihost_erase(FLASH_SIMULATOR_BASE_OFFSET, FLASH_SIMULATOR_FLASH_SIZE) < 0) {
+		return -EIO;
+	}
+#endif
+	return 0;
+}
+
+#elif DT_NODE_HAS_PROP(DT_PARENT(SOC_NV_FLASH_NODE), memory_region)
 static int flash_mock_init(const struct device *dev)
 {
 	ARG_UNUSED(dev);
@@ -427,7 +514,6 @@ static int flash_mock_init(const struct device *dev)
 	memset(mock_flash, FLASH_SIMULATOR_ERASE_VALUE, ARRAY_SIZE(mock_flash));
 	return 0;
 }
-#endif /* DT_NODE_HAS_PROP(DT_PARENT(SOC_NV_FLASH_NODE), memory_region) */
 #endif /* CONFIG_ARCH_POSIX */
 
 static int flash_init(const struct device *dev)
@@ -495,7 +581,11 @@ void *z_impl_flash_simulator_get_memory(const struct device *dev,
 	ARG_UNUSED(dev);
 
 	*mock_size = FLASH_SIMULATOR_FLASH_SIZE;
+#ifdef CONFIG_FLASH_SIMULATOR_SEMIHOST
+	return &flash_fd;
+#else
 	return mock_flash;
+#endif
 }
 
 #ifdef CONFIG_USERSPACE

--- a/tests/drivers/flash_simulator/flash_sim_impl/boards/flash_simulation.overlay
+++ b/tests/drivers/flash_simulator/flash_sim_impl/boards/flash_simulation.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024 BayLibre SAS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+
+/ {
+	sim_flash_controller: sim_flash_controller {
+		compatible = "zephyr,sim-flash";
+
+		#address-cells = <1>;
+		#size-cells = <1>;
+		erase-value = <0xff>;
+
+		flash_sim0: flash_sim@0 {
+			compatible = "soc-nv-flash";
+			reg = <0x00000000 DT_SIZE_M(1)>;
+
+			erase-block-size = <1024>;
+			write-block-size = <4>;
+		};
+	};
+};

--- a/tests/drivers/flash_simulator/flash_sim_impl/boards/qemu_cortex_a53.overlay
+++ b/tests/drivers/flash_simulator/flash_sim_impl/boards/qemu_cortex_a53.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2024 BayLibre SAS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "flash_simulation.overlay"

--- a/tests/drivers/flash_simulator/flash_sim_impl/boards/qemu_cortex_m3.overlay
+++ b/tests/drivers/flash_simulator/flash_sim_impl/boards/qemu_cortex_m3.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2024 BayLibre SAS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "flash_simulation.overlay"

--- a/tests/drivers/flash_simulator/flash_sim_impl/boards/qemu_riscv32.overlay
+++ b/tests/drivers/flash_simulator/flash_sim_impl/boards/qemu_riscv32.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2024 BayLibre SAS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "flash_simulation.overlay"

--- a/tests/drivers/flash_simulator/flash_sim_impl/testcase.yaml
+++ b/tests/drivers/flash_simulator/flash_sim_impl/testcase.yaml
@@ -20,6 +20,14 @@ tests:
       - nucleo_f411re
     integration_platforms:
       - qemu_x86
+  drivers.flash.flash_simulator.semihost:
+    extra_args: CONFIG_FLASH_SIMULATOR_SEMIHOST=y
+    platform_allow:
+      - qemu_cortex_a53
+      - qemu_cortex_m3
+      - qemu_riscv32
+    integration_platforms:
+      - qemu_cortex_a53
   drivers.flash.flash_simulator.qemu_erase_value_0x00:
     extra_args: DTC_OVERLAY_FILE=boards/qemu_x86_ev_0x00.overlay
     platform_allow: qemu_x86


### PR DESCRIPTION
Semihosting is a mechanism that enables code running on ARM or RISC-V
to use the I/O facilities on a host computer that is running a debugger
or simulation.

Enabling this function allows to simulate flash storage greater than RAM
and without sacrificing RAM space.  Another benefit is that you can
prepare your binary image of the flash in advance what opens new
possibilities over existing implementation.