### PR TITLE
Enable Display for MAX32 Boards

### DIFF
--- a/boards/adi/max32672evkit/Kconfig.defconfig
+++ b/boards/adi/max32672evkit/Kconfig.defconfig
@@ -1,0 +1,29 @@
+# MAX32672EVKIT boards configuration
+
+# Copyright (c) 2024 Analog Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_MAX32672EVKIT
+
+if DISPLAY
+
+config MIPI_DBI_SPI_3WIRE
+	default y
+
+if LVGL
+
+config LV_Z_BITS_PER_PIXEL
+	default 16
+
+choice LV_COLOR_DEPTH
+	default LV_COLOR_DEPTH_16  # 16 bit per pixel
+endchoice
+
+config LV_COLOR_16_SWAP
+	default y
+
+endif # LVGL
+
+endif # DISPLAY
+
+endif # BOARD_MAX32672EVKIT

--- a/boards/adi/max32672evkit/max32672evkit.dts
+++ b/boards/adi/max32672evkit/max32672evkit.dts
@@ -10,6 +10,7 @@
 #include <adi/max32/max32672-pinctrl.dtsi>
 #include <zephyr/dt-bindings/gpio/adi-max32-gpio.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/mipi_dbi/mipi_dbi.h>
 
 / {
 	model = "Analog Devices MAX32672EVKIT";
@@ -20,6 +21,7 @@
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram3;
 		zephyr,flash = &flash0;
+		zephyr,display = &st7735;
 	};
 
 	leds {
@@ -49,6 +51,42 @@
 		led1 = &led2;
 		sw0 = &pb1;
 		watchdog0 = &wdt0;
+	};
+
+	mipi_dbi {
+		compatible = "zephyr,mipi-dbi-spi";
+		/* Enable D/C line for 4wire mode */
+		/* dc-gpios = <&gpio0 19 (GPIO_ACTIVE_HIGH | MAX32_GPIO_VSEL_VDDIOH)>; */
+		spi-dev = <&spi0>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		status = "okay";
+
+		st7735: st7735@0 {
+			compatible = "sitronix,st7735r";
+			mipi-max-frequency = <DT_FREQ_M(6)>;
+			mipi-mode = <MIPI_DBI_MODE_SPI_3WIRE>;
+
+			reg = <0>;
+			width = <130>;
+			height = <132>;
+			x-offset = <0>;
+			y-offset = <0>;
+			madctl = <0xc0>;
+			colmod = <0x05>;
+			vmctr1 = <0x51>;
+			pwctr1 = [02 02];
+			pwctr2 = [c5];
+			pwctr3 = [0d 00];
+			pwctr4 = [8d 1a];
+			pwctr5 = [8d ee];
+			frmctr1 = [02 35 36];
+			frmctr2 = [02 35 36];
+			frmctr3 = [02 35 36 02 35 36];
+			gamctrp1 = [0a 1c 0c 14 33 2b 24 28 27 25 2c 39 00 05 03 0d];
+			gamctrn1 = [0a 1c 0c 14 33 2b 24 28 27 25 2d 3a 00 05 03 0d];
+		};
 	};
 };
 
@@ -95,4 +133,19 @@
 	status = "okay";
 	pinctrl-0 = <&spi1a_mosi_p0_15 &spi1a_miso_p0_14 &spi1a_sck_p0_16 &spi1a_ss0_p0_17>;
 	pinctrl-names = "default";
+};
+
+&spi0a_mosi_p0_3 {
+	power-source=<MAX32_VSEL_VDDIOH>;
+};
+
+&spi0a_sck_p0_4 {
+	power-source=<MAX32_VSEL_VDDIOH>;
+};
+
+&spi0 {
+	status = "okay";
+	pinctrl-0 = <&spi0a_mosi_p0_3 &spi0a_miso_p0_2 &spi0a_sck_p0_4>;
+	pinctrl-names = "default";
+	cs-gpios = <&gpio0 5 (GPIO_ACTIVE_LOW | MAX32_VSEL_VDDIOH)>;
 };

--- a/boards/adi/max32680evkit/Kconfig.defconfig
+++ b/boards/adi/max32680evkit/Kconfig.defconfig
@@ -1,0 +1,29 @@
+# MAX32680EVKIT boards configuration
+
+# Copyright (c) 2024 Analog Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_MAX32680EVKIT
+
+if DISPLAY
+
+config MIPI_DBI_SPI_3WIRE
+	default y
+
+if LVGL
+
+config LV_Z_BITS_PER_PIXEL
+	default 16
+
+choice LV_COLOR_DEPTH
+	default LV_COLOR_DEPTH_16  # 16 bit per pixel
+endchoice
+
+config LV_COLOR_16_SWAP
+	default y
+
+endif # LVGL
+
+endif # DISPLAY
+
+endif # BOARD_MAX32680EVKIT

--- a/boards/adi/max32680evkit/max32680evkit_max32680_m4.dts
+++ b/boards/adi/max32680evkit/max32680evkit_max32680_m4.dts
@@ -10,6 +10,7 @@
  #include <adi/max32/max32680-pinctrl.dtsi>
  #include <zephyr/dt-bindings/gpio/adi-max32-gpio.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/mipi_dbi/mipi_dbi.h>
 
 / {
 	 model = "Analog Devices MAX32680EVKIT";
@@ -20,6 +21,7 @@
 		 zephyr,shell-uart = &uart1;
 		 zephyr,sram = &sram2;
 		 zephyr,flash = &flash0;
+		 zephyr,display = &st7735;
 	 };
 
 	 leds {
@@ -56,6 +58,42 @@
 		sw1 = &pb2;
 		watchdog0 = &wdt0;
 	 };
+
+	 mipi_dbi {
+		compatible = "zephyr,mipi-dbi-spi";
+		/* Enable D/C line for 4wire mode */
+		/* dc-gpios = <&gpio1 7 (GPIO_ACTIVE_LOW | MAX32_GPIO_VSEL_VDDIOH)>; */
+		spi-dev = <&spi0>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		status = "okay";
+
+		st7735: st7735@0 {
+			compatible = "sitronix,st7735r";
+			mipi-max-frequency = <DT_FREQ_M(6)>;
+			mipi-mode = <MIPI_DBI_MODE_SPI_3WIRE>;
+
+			reg = <0>;
+			width = <130>;
+			height = <132>;
+			x-offset = <0>;
+			y-offset = <0>;
+			madctl = <0xc0>;
+			colmod = <0x05>;
+			vmctr1 = <0x51>;
+			pwctr1 = [02 02];
+			pwctr2 = [c5];
+			pwctr3 = [0d 00];
+			pwctr4 = [8d 1a];
+			pwctr5 = [8d ee];
+			frmctr1 = [02 35 36];
+			frmctr2 = [02 35 36];
+			frmctr3 = [02 35 36 02 35 36];
+			gamctrp1 = [0a 1c 0c 14 33 2b 24 28 27 25 2c 39 00 05 03 0d];
+			gamctrn1 = [0a 1c 0c 14 33 2b 24 28 27 25 2d 3a 00 05 03 0d];
+		};
+	};
 };
 
 &uart1 {
@@ -111,4 +149,19 @@
 	status = "okay";
 	pinctrl-0 = <&spi0a_mosi_p0_5 &spi0a_miso_p0_6 &spi0a_sck_p0_7 &spi0a_ss0_p0_4>;
 	pinctrl-names = "default";
+};
+
+&spi0a_mosi_p0_5 {
+	power-source=<MAX32_VSEL_VDDIOH>;
+};
+
+&spi0a_sck_p0_7 {
+	power-source=<MAX32_VSEL_VDDIOH>;
+};
+
+&spi0 {
+	status = "okay";
+	pinctrl-0 = <&spi0a_mosi_p0_5 &spi0a_miso_p0_6 &spi0a_sck_p0_7>;
+	pinctrl-names = "default";
+	cs-gpios = <&gpio0 4 (GPIO_ACTIVE_LOW | MAX32_VSEL_VDDIOH)>;
 };

--- a/boards/adi/max32690evkit/Kconfig.defconfig
+++ b/boards/adi/max32690evkit/Kconfig.defconfig
@@ -1,0 +1,29 @@
+# MAX32690EVKIT boards configuration
+
+# Copyright (c) 2024 Analog Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_MAX32690EVKIT
+
+if DISPLAY
+
+config MIPI_DBI_SPI_3WIRE
+	default y
+
+if LVGL
+
+config LV_Z_BITS_PER_PIXEL
+	default 16
+
+choice LV_COLOR_DEPTH
+	default LV_COLOR_DEPTH_16  # 16 bit per pixel
+endchoice
+
+config LV_COLOR_16_SWAP
+	default y
+
+endif # LVGL
+
+endif # DISPLAY
+
+endif # BOARD_MAX32690EVKIT

--- a/boards/adi/max32690evkit/max32690evkit_max32690_m4.dts
+++ b/boards/adi/max32690evkit/max32690evkit_max32690_m4.dts
@@ -10,6 +10,7 @@
 #include <adi/max32/max32690-pinctrl.dtsi>
 #include <zephyr/dt-bindings/gpio/adi-max32-gpio.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/mipi_dbi/mipi_dbi.h>
 
 / {
 	model = "Analog Devices MAX32690EVKIT";
@@ -20,6 +21,7 @@
 		zephyr,shell-uart = &uart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,display = &st7735;
 	};
 
 	leds {
@@ -49,6 +51,50 @@
 		sw0 = &pb0;
 		watchdog0 = &wdt0;
 	 };
+
+	mipi_dbi {
+		compatible = "zephyr,mipi-dbi-spi";
+		spi-dev = <&spibb0>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		status = "okay";
+
+		st7735: st7735@0 {
+			compatible = "sitronix,st7735r";
+			mipi-max-frequency = <DT_FREQ_M(6)>;
+			mipi-mode = <MIPI_DBI_MODE_SPI_3WIRE>;
+
+			reg = <0>;
+			width = <130>;
+			height = <132>;
+			x-offset = <0>;
+			y-offset = <0>;
+			madctl = <0xc0>;
+			colmod = <0x05>;
+			vmctr1 = <0x51>;
+			pwctr1 = [02 02];
+			pwctr2 = [c5];
+			pwctr3 = [0d 00];
+			pwctr4 = [8d 1a];
+			pwctr5 = [8d ee];
+			frmctr1 = [02 35 36];
+			frmctr2 = [02 35 36];
+			frmctr3 = [02 35 36 02 35 36];
+			gamctrp1 = [0a 1c 0c 14 33 2b 24 28 27 25 2c 39 00 05 03 0d];
+			gamctrn1 = [0a 1c 0c 14 33 2b 24 28 27 25 2d 3a 00 05 03 0d];
+		};
+	};
+
+	spibb0: spibb0 {
+		compatible = "zephyr,spi-bitbang";
+		status="okay";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		clk-gpios = <&gpio2 25 (GPIO_ACTIVE_HIGH | MAX32_GPIO_VSEL_VDDIOH)>;
+		mosi-gpios = <&gpio2 24 (GPIO_ACTIVE_HIGH | MAX32_GPIO_VSEL_VDDIOH)>;
+		cs-gpios = <&gpio2 11 (GPIO_ACTIVE_LOW | MAX32_GPIO_VSEL_VDDIOH)>;
+	};
 };
 
 &clk_ipo {

--- a/drivers/mipi_dbi/mipi_dbi_spi.c
+++ b/drivers/mipi_dbi/mipi_dbi_spi.c
@@ -42,8 +42,9 @@ uint32_t var = MIPI_DBI_SPI_READ_REQUIRED;
  * (first bit sent in each word) indicates if the word is a command or
  * data. Typically 0 indicates a command and 1 indicates data, but some
  * displays may vary.
+ * Index starts from 0 so that BIT(8) means 9th bit.
  */
-#define MIPI_DBI_DC_BIT BIT(9)
+#define MIPI_DBI_DC_BIT BIT(8)
 
 static int mipi_dbi_spi_write_helper(const struct device *dev,
 				     const struct mipi_dbi_config *dbi_config,

--- a/drivers/spi/spi_bitbang.c
+++ b/drivers/spi/spi_bitbang.c
@@ -231,7 +231,8 @@ static int spi_bitbang_transceive_async(const struct device *dev,
 				    const struct spi_config *spi_cfg,
 				    const struct spi_buf_set *tx_bufs,
 				    const struct spi_buf_set *rx_bufs,
-				    struct k_poll_signal *async)
+				    spi_callback_t cb,
+				    void *userdata)
 {
 	return -ENOTSUP;
 }


### PR DESCRIPTION
This PR enables display for with LVGL stack  
- MAX32672EVKIT
- MAX32680EVKIT 
- MAX32690EVKIT 
boards.
These boards have CFAF128128B1-0145T display which is 128x128 graphic display.

Also this PR includes fix for MPI DBI driver 3Wire mode.

Tested with  [samples/subsys/display/lvgl](https://github.com/zephyrproject-rtos/zephyr/tree/main/samples/subsys/display/lvgl)

MAX32672EVKIT test
![image](https://github.com/user-attachments/assets/460c7b52-0a43-46db-bbc5-6f126f7e9476)

MAX32680EVKIT test
![image](https://github.com/user-attachments/assets/e70c1b9f-7e7c-4e1e-8ed6-9abc04204720)

MAX32690EVKIT test
![image](https://github.com/user-attachments/assets/0a97c370-8ba0-486c-8ee1-7f3a0ffc3987)

Depends on:  https://github.com/zephyrproject-rtos/zephyr/pull/75660

4pixel on Y axis and 2 pixel on X axis were not updated, as per of display controller datasheet, X and Y line increased to 130 and 132 pixel.
The issue fixed, see below

![image](https://github.com/user-attachments/assets/be75921b-662d-47bc-9112-859731919162)

![image](https://github.com/user-attachments/assets/063fb5fc-5a5e-4e09-8ca7-4a0017cf9be0)
