### PR TITLE
testsuite: coverage: Correct value of GCOV_COUNTERS for gcc 14

### DIFF
--- a/subsys/testsuite/coverage/coverage.h
+++ b/subsys/testsuite/coverage/coverage.h
@@ -30,7 +30,9 @@
 #ifndef _COVERAGE_H_
 #define _COVERAGE_H_
 
-#if (__GNUC__ >= 10)
+#if (__GNUC__ >= 14)
+#define GCOV_COUNTERS 9U
+#elif (__GNUC__ >= 10)
 #define GCOV_COUNTERS 8U
 #elif (__GNUC__ >= 8)
 #define GCOV_COUNTERS 9U


### PR DESCRIPTION
number of counters have changed in gcc 14 by commit https://github.com/gcc-mirror/gcc/commit/08a52331803

Specifically, a new counter was added in gcc/gcov-counter.def:
```
/* Conditions.  The counter is interpreted as a bit-set.  */
DEF_GCOV_COUNTER(GCOV_COUNTER_CONDS, "conditions", _ior)
```

which in turn updates the value of GCOV_COUNTERS that is defined in gcov-io.h like this:
```
enum {
#include "gcov-counter.def"
GCOV_COUNTERS
};
```