### PR TITLE
I2C: Add common I2C context and refactor nRF TWI and TWIM to use it

### DIFF
--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -45,6 +45,10 @@ Device Drivers and Devicetree
 * The ``compatible`` of the LiteX uart controller has been renamed from
   ``litex,uart0`` to :dtcompatible:`litex,uart`. (:github:`74522`)
 
+* The kconfig option :kconfig:option:`CONFIG_I2C_NRFX_TRANSFER_TIMEOUT` has
+  been replaced by :kconfig:option:`CONFIG_I2C_CONTEXT_TRANSFER_TIMEOUT_MS`.
+  (:github:`76650`)
+
 Controller Area Network (CAN)
 =============================
 

--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -106,6 +106,9 @@ Drivers and Sensors
 
 * I2C
 
+  * The nRF TWI and TWIM device drivers now support the :c:func:`i2c_transfer_cb` and
+    :c:func:`i2c_transfer_signal` I2C device driver APIs. (:github:`76650`)
+
 * I2S
 
 * I3C

--- a/drivers/i2c/CMakeLists.txt
+++ b/drivers/i2c/CMakeLists.txt
@@ -6,6 +6,7 @@ zephyr_library()
 
 zephyr_library_sources(i2c_common.c)
 
+zephyr_library_sources_ifdef(CONFIG_I2C_CONTEXT i2c_context.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_RTIO i2c_rtio.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_SHELL		i2c_shell.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_BITBANG		i2c_bitbang.c)

--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -13,6 +13,19 @@ menuconfig I2C
 
 if I2C
 
+config I2C_CONTEXT
+	bool
+	help
+	  Support I2C context used internally by drivers
+
+if I2C_CONTEXT
+
+config I2C_CONTEXT_TRANSFER_TIMEOUT_MS
+	int "Transfer timeout in milliseconds"
+	default 500
+
+endif # I2C_CONTEXT
+
 config I2C_SHELL
 	bool "I2C Shell"
 	depends on SHELL

--- a/drivers/i2c/Kconfig.nrfx
+++ b/drivers/i2c/Kconfig.nrfx
@@ -18,6 +18,7 @@ config I2C_NRFX_TWI
 	def_bool y
 	depends on DT_HAS_NORDIC_NRF_TWI_ENABLED
 	select HAS_I2C_RTIO
+	select I2C_CONTEXT
 	select NRFX_TWI0 if HAS_HW_NRF_TWI0
 	select NRFX_TWI1 if HAS_HW_NRF_TWI1
 

--- a/drivers/i2c/Kconfig.nrfx
+++ b/drivers/i2c/Kconfig.nrfx
@@ -25,6 +25,7 @@ config I2C_NRFX_TWI
 config I2C_NRFX_TWIM
 	def_bool y
 	depends on DT_HAS_NORDIC_NRF_TWIM_ENABLED
+	select I2C_CONTEXT
 	select NRFX_TWIM0 if HAS_HW_NRF_TWIM0
 	select NRFX_TWIM1 if HAS_HW_NRF_TWIM1
 	select NRFX_TWIM2 if HAS_HW_NRF_TWIM2
@@ -42,13 +43,5 @@ config I2C_NRFX_TWIM
 	select NRFX_TWIM135 if HAS_HW_NRF_TWIM135
 	select NRFX_TWIM136 if HAS_HW_NRF_TWIM136
 	select NRFX_TWIM137 if HAS_HW_NRF_TWIM137
-
-config I2C_NRFX_TRANSFER_TIMEOUT
-	int "Transfer timeout [ms]"
-	default 500
-	help
-	  Timeout in milliseconds used for each I2C transfer.
-	  0 means that the driver should use the K_FOREVER value,
-	  i.e. it should wait as long as necessary.
 
 endif # I2C_NRFX

--- a/drivers/i2c/i2c_context.c
+++ b/drivers/i2c/i2c_context.c
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "i2c_context.h"
+
+#define CONTEXT_TRANSFER_TIMEOUT K_MSEC(CONFIG_I2C_CONTEXT_TRANSFER_TIMEOUT_MS)
+
+#if CONFIG_I2C_CALLBACK
+static void context_transfer_stop(struct i2c_context *ctx, int result)
+{
+	i2c_callback_t transfer_callback;
+	void *transfer_callback_userdata;
+
+	ctx->transfer_started = false;
+	ctx->transfer_result = result;
+
+	k_work_cancel_delayable(&ctx->transfer_timeout_dwork);
+
+	ctx->deinit_transfer_handler(ctx);
+
+	if (ctx->transfer_callback == NULL) {
+		k_sem_give(&ctx->transfer_sync);
+		return;
+	}
+
+	transfer_callback = ctx->transfer_callback;
+	transfer_callback_userdata = ctx->transfer_callback_userdata;
+
+	k_sem_give(&ctx->transfer_lock);
+
+	if (transfer_callback != NULL) {
+		transfer_callback(ctx->dev, result, transfer_callback_userdata);
+	}
+}
+
+static void context_start_transfer_handler(struct k_work *work)
+{
+	struct i2c_context *ctx = CONTAINER_OF(work, struct i2c_context, start_transfer_work);
+
+	ctx->transfer_started = true;
+
+	ctx->start_transfer_handler(ctx);
+}
+
+static void context_continue_transfer_handler(struct k_work *work)
+{
+	struct i2c_context *ctx = CONTAINER_OF(work, struct i2c_context, continue_transfer_work);
+
+	if (!ctx->transfer_started) {
+		return;
+	}
+
+	ctx->post_transfer_handler(ctx);
+
+	ctx->transfer_msg_idx++;
+
+	if (ctx->transfer_msg_idx == ctx->transfer_num_msgs) {
+		context_transfer_stop(ctx, 0);
+		return;
+	}
+
+	ctx->start_transfer_handler(ctx);
+}
+
+static void context_cancel_transfer_handler(struct k_work *work)
+{
+	struct i2c_context *ctx = CONTAINER_OF(work, struct i2c_context, cancel_transfer_work);
+
+	if (!ctx->transfer_started) {
+		return;
+	}
+
+	context_transfer_stop(ctx, -EIO);
+}
+
+static void context_transfer_timeout_handler(struct k_work *work)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct i2c_context *ctx = CONTAINER_OF(dwork, struct i2c_context, transfer_timeout_dwork);
+
+	if (!ctx->transfer_started) {
+		return;
+	}
+
+	context_transfer_stop(ctx, -ETIMEDOUT);
+}
+#endif
+
+void i2c_context_init(struct i2c_context *ctx,
+		      const struct device *dev,
+		      i2c_context_init_transfer_handler init_transfer_handler,
+		      i2c_context_start_transfer_handler start_transfer_handler,
+		      i2c_context_post_transfer_handler post_transfer_handler,
+		      i2c_context_deinit_transfer_handler deinit_transfer_handler)
+{
+	ctx->dev = dev;
+	ctx->init_transfer_handler = init_transfer_handler;
+	ctx->start_transfer_handler = start_transfer_handler;
+	ctx->post_transfer_handler = post_transfer_handler;
+	ctx->deinit_transfer_handler = deinit_transfer_handler;
+
+	k_sem_init(&ctx->transfer_lock, 1, 1);
+	k_sem_init(&ctx->transfer_sync, 0, 1);
+
+#if CONFIG_I2C_CALLBACK
+	k_work_init(&ctx->start_transfer_work, context_start_transfer_handler);
+	k_work_init(&ctx->continue_transfer_work, context_continue_transfer_handler);
+	k_work_init(&ctx->cancel_transfer_work, context_cancel_transfer_handler);
+	k_work_init_delayable(&ctx->transfer_timeout_dwork, context_transfer_timeout_handler);
+#endif
+}
+
+int i2c_context_start_transfer(struct i2c_context *ctx,
+			       struct i2c_msg *msgs,
+			       uint8_t num_msgs,
+			       uint16_t addr)
+{
+	int ret;
+
+	k_sem_take(&ctx->transfer_lock, K_FOREVER);
+
+	ctx->transfer_msgs = msgs;
+	ctx->transfer_num_msgs = num_msgs;
+	ctx->transfer_addr = addr;
+	ctx->transfer_msg_idx = 0;
+
+	ret = ctx->init_transfer_handler(ctx);
+
+	if (ret) {
+		k_sem_give(&ctx->transfer_lock);
+		return ret;
+	}
+
+#if CONFIG_I2C_CALLBACK
+	k_sem_reset(&ctx->transfer_sync);
+
+	k_work_submit(&ctx->start_transfer_work);
+	k_work_schedule(&ctx->transfer_timeout_dwork, CONTEXT_TRANSFER_TIMEOUT);
+
+	k_sem_take(&ctx->transfer_sync, K_FOREVER);
+#else
+	for (ctx->transfer_msg_idx = 0;
+	     ctx->transfer_msg_idx < ctx->transfer_num_msgs;
+	     ctx->transfer_msg_idx++) {
+		k_sem_reset(&ctx->transfer_sync);
+
+		ctx->start_transfer_handler(ctx);
+
+		if (k_sem_take(&ctx->transfer_sync, CONTEXT_TRANSFER_TIMEOUT)) {
+			ctx->transfer_result = -EIO;
+			break;
+		}
+
+		if (ctx->transfer_result) {
+			break;
+		}
+
+		ctx->post_transfer_handler(ctx);
+	}
+
+	ctx->deinit_transfer_handler(ctx);
+#endif
+
+	ret = ctx->transfer_result;
+	k_sem_give(&ctx->transfer_lock);
+	return ret;
+}
+
+#if CONFIG_I2C_CALLBACK
+int i2c_context_start_transfer_cb(struct i2c_context *ctx,
+				  struct i2c_msg *msgs,
+				  uint8_t num_msgs,
+				  uint16_t addr,
+				  i2c_callback_t cb,
+				  void *userdata)
+{
+	int ret;
+
+	if (k_sem_take(&ctx->transfer_lock, K_NO_WAIT)) {
+		return -EWOULDBLOCK;
+	}
+
+	ctx->transfer_msgs = msgs;
+	ctx->transfer_num_msgs = num_msgs;
+	ctx->transfer_addr = addr;
+	ctx->transfer_msg_idx = 0;
+	ctx->transfer_callback = cb;
+	ctx->transfer_callback_userdata = userdata;
+
+	ret = ctx->init_transfer_handler(ctx);
+
+	if (ret) {
+		k_sem_give(&ctx->transfer_lock);
+		return ret;
+	}
+
+	k_work_submit(&ctx->start_transfer_work);
+	k_work_schedule(&ctx->transfer_timeout_dwork, CONTEXT_TRANSFER_TIMEOUT);
+	return ret;
+}
+#endif
+
+void i2c_context_continue_transfer(struct i2c_context *ctx)
+{
+#if CONFIG_I2C_CALLBACK
+	k_work_submit(&ctx->continue_transfer_work);
+#else
+	ctx->transfer_result = 0;
+	k_sem_give(&ctx->transfer_sync);
+#endif
+}
+
+void i2c_context_cancel_transfer(struct i2c_context *ctx)
+{
+#if CONFIG_I2C_CALLBACK
+	k_work_submit(&ctx->cancel_transfer_work);
+#else
+	ctx->transfer_result = -EIO;
+	k_sem_give(&ctx->transfer_sync);
+#endif
+}

--- a/drivers/i2c/i2c_context.h
+++ b/drivers/i2c/i2c_context.h
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * The I2C context provides an event driven framework for I2C
+ * device driver transfer implementations.
+ *
+ * Drivers implementing this framework will work with both the
+ * synchronous i2c_transfer() API, and the asynchronous
+ * i2c_transfer_cb() and i2c_transfer_signal() APIs.
+ *
+ * If I2C_CALLBACK=n, the I2C context runs in context of the
+ * caller to i2c_transfer(). If I2C_CALLBACK=y, all
+ * i2c_transfer*() APIs run in the context of the system
+ * workqueue.
+ */
+
+#ifndef ZEPHYR_DRIVERS_I2C_I2C_CONTEXT_H_
+#define ZEPHYR_DRIVERS_I2C_I2C_CONTEXT_H_
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/i2c.h>
+
+struct i2c_context;
+
+typedef int (*i2c_context_init_transfer_handler)(struct i2c_context *ctx);
+typedef void (*i2c_context_start_transfer_handler)(struct i2c_context *ctx);
+typedef void (*i2c_context_post_transfer_handler)(struct i2c_context *ctx);
+typedef void (*i2c_context_deinit_transfer_handler)(struct i2c_context *ctx);
+
+struct i2c_context {
+	const struct device *dev;
+
+	i2c_context_init_transfer_handler init_transfer_handler;
+	i2c_context_start_transfer_handler start_transfer_handler;
+	i2c_context_post_transfer_handler post_transfer_handler;
+	i2c_context_deinit_transfer_handler deinit_transfer_handler;
+
+	struct k_sem transfer_lock;
+	struct k_sem transfer_sync;
+
+	struct i2c_msg *transfer_msgs;
+	uint8_t transfer_num_msgs;
+	uint16_t transfer_addr;
+	uint8_t transfer_msg_idx;
+	int transfer_result;
+
+#if CONFIG_I2C_CALLBACK
+	bool transfer_started;
+
+	struct k_work start_transfer_work;
+	struct k_work continue_transfer_work;
+	struct k_work cancel_transfer_work;
+	struct k_work_delayable transfer_timeout_dwork;
+
+	i2c_callback_t transfer_callback;
+	void *transfer_callback_userdata;
+#endif
+};
+
+void i2c_context_init(struct i2c_context *ctx,
+		      const struct device *dev,
+		      i2c_context_init_transfer_handler init_transfer_handler,
+		      i2c_context_start_transfer_handler start_transfer_handler,
+		      i2c_context_post_transfer_handler post_transfer_handler,
+		      i2c_context_deinit_transfer_handler deinit_transfer_handler);
+
+int i2c_context_start_transfer(struct i2c_context *ctx,
+			       struct i2c_msg *msgs,
+			       uint8_t num_msgs,
+			       uint16_t addr);
+
+#if CONFIG_I2C_CALLBACK
+int i2c_context_start_transfer_cb(struct i2c_context *ctx,
+				  struct i2c_msg *msgs,
+				  uint8_t num_msgs,
+				  uint16_t addr,
+				  i2c_callback_t cb,
+				  void *userdata);
+#endif
+
+void i2c_context_continue_transfer(struct i2c_context *ctx);
+
+void i2c_context_cancel_transfer(struct i2c_context *ctx);
+
+static inline const struct device *i2c_context_get_dev(struct i2c_context *ctx)
+{
+	return ctx->dev;
+}
+
+static inline struct i2c_msg *i2c_context_get_transfer_msgs(struct i2c_context *ctx)
+{
+	return ctx->transfer_msgs;
+}
+
+static inline uint8_t i2c_context_get_transfer_msg_idx(struct i2c_context *ctx)
+{
+	return ctx->transfer_msg_idx;
+}
+
+static inline void i2c_context_set_transfer_msg_idx(struct i2c_context *ctx, uint8_t idx)
+{
+	ctx->transfer_msg_idx = idx;
+}
+
+static inline uint8_t i2c_context_get_transfer_num_msgs(struct i2c_context *ctx)
+{
+	return ctx->transfer_num_msgs;
+}
+
+static inline uint16_t i2c_context_get_transfer_addr(struct i2c_context *ctx)
+{
+	return ctx->transfer_addr;
+}
+
+static inline int i2c_context_get_transfer_result(struct i2c_context *ctx)
+{
+	return ctx->transfer_result;
+}
+
+#endif /* ZEPHYR_DRIVERS_I2C_I2C_CONTEXT_H_ */


### PR DESCRIPTION
## Overview
Adds common I2C context for I2C controller device drivers which provides an event driven framework compatible with both the synchronous `i2c_transfer()` API and the asynchronous `i2c_transfer_cb()` and `i2c_transfer_signal()` APIs. This greatly simplifies device drivers by moving the transfer flow to a common module, making every driver capable of implementing the transfer_cb API.

## The I2C context
The I2C context provides callbacks which are executed in a safe context which device drivers shall implement, along with an API for the device drivers to start a transfer, and signal the result of a partial transfer (sending a single i2c_msg).

The I2C context runs in the calling context of `i2c_transfer()` if `CONFIG_I2C_CALLBACK=n`, like most drivers do now. If `CONFIG_I2C_CALLBACK=y`, the I2C context delegates all work to the system workqueue, allowing the entire transfer to be performed asynchronously, without any alteration to the device drivers.

## RTIO
RTIO (in the context of I2C) provides a queue to perform async I2C operations. Each of these operations can be directly fulfilled by an I2C API call:

- RTIO_OP_NOP -> Do nothing
- RTIO_OP_RX  -> call `i2c_read_cb()` (helper needs to be added)
- RTIO_OP_TX  -> call `i2c_write_cb()` (helper needs to be added)
- RTIO_OP_CALLBACK -> Call back
- RTIO_OP_TXRX -> call `i2c_write_read_cb()`
- RTIO_OP_I2C_RECOVER() -> i2c_recover() (may need async variant)
- RTIO_OP_I2C_CONFIGURE() -> i2c_configure() (may need async variant)

I2C controller device drivers can implement the I2C device driver API, and a higher level RTIO context can wrap the RTIO messages into `struct i2c_msg` and call i2c_transfer_cb(), using the callback to pass the transfer result to `i2c_rtio_complete`, like what is done for the `i2c_transfer_signal()` wrapper.

## Layers
The device driver implements the I2C APIs, `transfer`, `recover_bus` and `configure`. It uses the `i2c_context` to manage the transfer flow.

If `CONFIG_RTIO=n` and `CONFIG_I2C_CALLBACK=n`, the device driver uses no work queues or other async delegation, it simply runs from the context of the caller to any of its three APIs.

If `CONFIG_I2C_CALLBACK=y`, the device driver implements the `transfer_cb` API (which is free using the i2c_context). Calls to `transfer` and `transfer_cb` run in the context of the system workqueue.

If `CONFIG_RTIO=y`, `CONFIG_I2C_CALLBACK=y` is selected. The device driver implements the `i2c_rtio` context and `iodev_submit` API. Calls to `iodev_submit` are converted to calls to the `transfer_cb`, `recover_bus` and `configure` APIs.

This provides a clear layer separation from lowest complexity/size to highest complexity/size, while essentially requiring only that device drivers implement the `transfer_cb` to be compatible with RTIO.