### PR TITLE
arm64: linker: move data section between rodata and bss

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -275,7 +275,7 @@ config LINKER_GENERIC_SECTIONS_PRESENT_AT_BOOT
 
 config LINKER_LAST_SECTION_ID
 	bool "Last section identifier"
-	default y
+	default y if !ARM64
 	depends on ARM || ARM64 || RISCV
 	help
 	  If enabled, the last section will contain an identifier.

--- a/include/zephyr/arch/arm64/scripts/linker.ld
+++ b/include/zephyr/arch/arm64/scripts/linker.ld
@@ -161,12 +161,10 @@ SECTIONS
         __exidx_end = .;
     } GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
-        __rodata_region_start = .;
+    MMU_ALIGN;
+    __rodata_region_start = .;
 
 #include <zephyr/linker/common-rom.ld>
-/* Located in generated directory. This file is populated by calling
- * zephyr_linker_sources(ROM_SECTIONS ...). Useful for grouping iterable RO structs.
- */
 #include <snippets-rom-sections.ld>
 #include <zephyr/linker/thread-local-storage.ld>
 
@@ -184,9 +182,6 @@ SECTIONS
         *(.got)
         *(.got.plt)
 
-/* Located in generated directory. This file is populated by the
- * zephyr_linker_sources() Cmake function.
- */
 #include <snippets-rodata.ld>
 
 #include <zephyr/linker/kobject-rom.ld>
@@ -194,8 +189,8 @@ SECTIONS
     } GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
 #include <zephyr/linker/cplusplus-rom.ld>
-    MMU_ALIGN;
 
+    MMU_ALIGN;
     __rodata_region_end = .;
     __rodata_region_size = __rodata_region_end - __rodata_region_start;
     __rom_region_end = .;
@@ -214,19 +209,32 @@ SECTIONS
 
     GROUP_START(RAMABLE_REGION)
 
+#ifdef CONFIG_XIP
     . = RAM_ADDR;
-    /* Align the start of image RAM with the
-     * minimum granularity required by MMU.
-     */
-    . = ALIGN(_region_min_align);
+#endif
+    MMU_ALIGN;
     _image_ram_start = .;
 #ifdef CONFIG_XIP
     z_mapped_start = .;
 #endif
 
-/* Located in generated directory. This file is populated by the
- * zephyr_linker_sources() Cmake function.
- */
+    __data_region_start = .;
+
+    SECTION_DATA_PROLOGUE(_DATA_SECTION_NAME,,)
+    {
+        MMU_ALIGN;
+	__data_start = .;
+        *(.data)
+        *(".data.*")
+        *(".kernel.*")
+
+#include <snippets-rwdata.ld>
+
+        __data_end = .;
+    } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+    __data_size = __data_end - __data_start;
+    __data_load_start = LOADADDR(_DATA_SECTION_NAME);
+
 #include <snippets-ram-sections.ld>
 
 #if defined(CONFIG_USERSPACE)
@@ -249,6 +257,15 @@ SECTIONS
     _app_smem_rom_start = LOADADDR(_APP_SMEM_SECTION_NAME);
 #endif  /* CONFIG_USERSPACE */
 
+#include <zephyr/linker/common-ram.ld>
+#include <zephyr/linker/kobject-data.ld>
+#include <zephyr/linker/cplusplus-ram.ld>
+
+#include <snippets-data-sections.ld>
+
+    __data_region_end = .;
+    __data_region_load_start = LOADADDR(_DATA_SECTION_NAME);
+
     SECTION_DATA_PROLOGUE(_BSS_SECTION_NAME,(NOLOAD), BSS_ALIGN)
     {
         . = ALIGN(8);
@@ -265,48 +282,10 @@ SECTIONS
 
 #include <zephyr/linker/common-noinit.ld>
 
-    SECTION_DATA_PROLOGUE(_DATA_SECTION_NAME,,)
-    {
-	__data_region_start = .;
-	__data_start = .;
-        *(.data)
-        *(".data.*")
-        *(".kernel.*")
-
-/* Located in generated directory. This file is populated by the
- * zephyr_linker_sources() Cmake function.
- */
-#include <snippets-rwdata.ld>
-
-        __data_end = .;
-
-    } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
-    __data_size = __data_end - __data_start;
-    __data_load_start = LOADADDR(_DATA_SECTION_NAME);
-
-    __data_region_load_start = LOADADDR(_DATA_SECTION_NAME);
-
-#include <zephyr/linker/common-ram.ld>
-#include <zephyr/linker/kobject-data.ld>
-#include <zephyr/linker/cplusplus-ram.ld>
-
-/* Located in generated directory. This file is populated by the
- * zephyr_linker_sources() Cmake function.
- */
-#include <snippets-data-sections.ld>
-
-    __data_region_end = .;
-
-
     /* Define linker symbols */
-
     __kernel_ram_end = RAM_ADDR + RAM_SIZE;
     __kernel_ram_size = __kernel_ram_end - __kernel_ram_start;
 
-
-/* Located in generated directory. This file is populated by the
- * zephyr_linker_sources() Cmake function.
- */
 #include <snippets-sections.ld>
 
 #define LAST_RAM_ALIGN MMU_ALIGN;


### PR DESCRIPTION
Having .data after .bss creates a big empty gap in zephyr.bin to provide
proper offset for the data section. Reversing them allows for dropping
.bss from zephyr.bin's output as it is typically done, saving precious
flash memory space.
