### PR TITLE
demand_paging: LRU eviction: avoid ping pong deadlock loop

### DIFF
--- a/subsys/demand_paging/eviction/lru.c
+++ b/subsys/demand_paging/eviction/lru.c
@@ -111,8 +111,10 @@ static void lru_pf_remove(uint32_t pf_idx)
 
 	lru_pf_unlink(pf_idx);
 
-	if (was_head && (LRU_PF_HEAD != 0)) {
-		/* make new head PF unaccessible */
+	/* make new head PF unaccessible if it exists and it is not alone */
+	if (was_head &&
+	    (LRU_PF_HEAD != 0) &&
+	    (lru_pf_queue[LRU_PF_HEAD].next != 0)) {
 		struct k_mem_page_frame *pf = idx_to_pf(LRU_PF_HEAD);
 		uintptr_t flags = arch_page_info_get(k_mem_page_frame_to_virt(pf), NULL, true);
 


### PR DESCRIPTION
If only 2 page frames are queued and code executing in one frame is
making an access to memory in the second frame then the access will trap
and k_mem_paging_eviction_accessed() will be called to move that frame
to the end of the queue ... marking the new head frame unaccessible.
But that newly unaccessible frame contains the code that has yet to be
resumed to perform its memory access. Since it is now unaccessible, a
trap is triggered, the frame is moved to the end of the queue and the
new head frame (the one we trapped for initially) is marked unaccessible.
Execution is resumed with the memory access which is unaccessible again
and the cycle repeats infinitely.

Fix this by not marking the new head unaccessible if there is only one
queued frame left in the queue.
