### PR TITLE
drivers: i2c: add an option to skip auto-sending stop on last message

### DIFF
--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -54,6 +54,20 @@ config I2C_CALLBACK
 	help
 	  API and implementations of i2c_transfer_cb.
 
+config I2C_ALLOW_NO_STOP_TRANSACTIONS
+	bool "Allows I2C transfers with no STOP on the last transaction [DEPRECATED]"
+	depends on !I2C_NRFX_TWI
+	depends on !I2C_NRFX_TWIM
+	depends on !I2C_STM32
+	depends on !I2C_GD32
+	depends on !I2C_ESP32
+	depends on !I2C_DW
+	select DEPRECATED
+	help
+	  Allow I2C transactions with no STOP on the last message. This is
+	  unsupported and can leave the bus in an unexpected state. The option
+	  will be removed in Zephyr 4.1.
+
 config I2C_RTIO
 	bool "I2C RTIO API"
 	select EXPERIMENTAL

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -801,7 +801,9 @@ static inline int z_impl_i2c_transfer(const struct device *dev,
 		return 0;
 	}
 
-	msgs[num_msgs - 1].flags |= I2C_MSG_STOP;
+	if (!IS_ENABLED(CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS)) {
+		msgs[num_msgs - 1].flags |= I2C_MSG_STOP;
+	}
 
 	int res =  api->transfer(dev, msgs, num_msgs, addr);
 
@@ -857,7 +859,9 @@ static inline int i2c_transfer_cb(const struct device *dev,
 		return 0;
 	}
 
-	msgs[num_msgs - 1].flags |= I2C_MSG_STOP;
+	if (!IS_ENABLED(CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS)) {
+		msgs[num_msgs - 1].flags |= I2C_MSG_STOP;
+	}
 
 	return api->transfer_cb(dev, msgs, num_msgs, addr, cb, userdata);
 }


### PR DESCRIPTION
Hey folks, bumped into a bit of an issue with some legacy code after https://github.com/zephyrproject-rtos/zephyr/pull/75801. I understand the motivation but I suspect I may not be the only one depending on this and some use case is particularly hard to convert: I happen to have some code that really wants to build the transactions a bit at a time. :-(

How about a flag to restore the old behavior with a note that things may break real bad?

---

The I2C transfer API has been recently changed to always automatically set a STOP on the last message, which was well documented but implemented only by few drivers.

Unfortunately, while documented, this is a change in the current behavior and it turns out that some applications depended on it for some complex operations.

Add a flag to allow to explicitly request skipping the last message stop and request the previous behavior, with a note that that may result in leaving the bus in an unexpected state.