### PR TITLE
Fix printing from ztest

### DIFF
--- a/subsys/testsuite/ztest/include/zephyr/ztest_assert.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest_assert.h
@@ -18,6 +18,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include <zephyr/tc_util.h>
 #include <zephyr/ztest.h>
 
 #ifdef __cplusplus
@@ -34,7 +35,8 @@ void ztest_skip_failed_assumption(void);
 static inline bool z_zassert_(bool cond, const char *file, int line)
 {
 	if (cond == false) {
-		PRINT("\n    Assertion failed at %s:%d\n", ztest_relative_filename(file), line);
+		PRINT_DATA("\n    Assertion failed at %s:%d\n", ztest_relative_filename(file),
+			   line);
 		ztest_test_fail();
 		return false;
 	}
@@ -47,7 +49,8 @@ static inline bool z_zassert_(bool cond, const char *file, int line)
 static inline bool z_zassume_(bool cond, const char *file, int line)
 {
 	if (cond == false) {
-		PRINT("\n    Assumption failed at %s:%d\n", ztest_relative_filename(file), line);
+		PRINT_DATA("\n    Assumption failed at %s:%d\n", ztest_relative_filename(file),
+			   line);
 		ztest_skip_failed_assumption();
 		return false;
 	}
@@ -60,7 +63,8 @@ static inline bool z_zassume_(bool cond, const char *file, int line)
 static inline bool z_zexpect_(bool cond, const char *file, int line)
 {
 	if (cond == false) {
-		PRINT("\n    Expectation failed at %s:%d\n", ztest_relative_filename(file), line);
+		PRINT_DATA("\n    Expectation failed at %s:%d\n", ztest_relative_filename(file),
+			   line);
 		ztest_test_expect_fail();
 		return false;
 	}
@@ -79,8 +83,8 @@ static inline bool z_zassert(bool cond, const char *default_msg, const char *fil
 		va_list vargs;
 
 		va_start(vargs, msg);
-		PRINT("\n    Assertion failed at %s:%d: %s: %s\n", ztest_relative_filename(file),
-		      line, func, default_msg);
+		PRINT_DATA("\n    Assertion failed at %s:%d: %s: %s\n",
+			   ztest_relative_filename(file), line, func, default_msg);
 		vprintk(msg, vargs);
 		printk("\n");
 		va_end(vargs);
@@ -89,8 +93,8 @@ static inline bool z_zassert(bool cond, const char *default_msg, const char *fil
 	}
 #if CONFIG_ZTEST_ASSERT_VERBOSE == 2
 	else {
-		PRINT("\n   Assertion succeeded at %s:%d (%s)\n", ztest_relative_filename(file),
-		      line, func);
+		PRINT_DATA("\n   Assertion succeeded at %s:%d (%s)\n",
+			   ztest_relative_filename(file), line, func);
 	}
 #endif
 	return true;
@@ -103,8 +107,8 @@ static inline bool z_zassume(bool cond, const char *default_msg, const char *fil
 		va_list vargs;
 
 		va_start(vargs, msg);
-		PRINT("\n    Assumption failed at %s:%d: %s: %s\n", ztest_relative_filename(file),
-		      line, func, default_msg);
+		PRINT_DATA("\n    Assumption failed at %s:%d: %s: %s\n",
+			   ztest_relative_filename(file), line, func, default_msg);
 		vprintk(msg, vargs);
 		printk("\n");
 		va_end(vargs);
@@ -113,8 +117,8 @@ static inline bool z_zassume(bool cond, const char *default_msg, const char *fil
 	}
 #if CONFIG_ZTEST_ASSERT_VERBOSE == 2
 	else {
-		PRINT("\n   Assumption succeeded at %s:%d (%s)\n", ztest_relative_filename(file),
-		      line, func);
+		PRINT_DATA("\n   Assumption succeeded at %s:%d (%s)\n",
+			   ztest_relative_filename(file), line, func);
 	}
 #endif
 	return true;
@@ -127,8 +131,8 @@ static inline bool z_zexpect(bool cond, const char *default_msg, const char *fil
 		va_list vargs;
 
 		va_start(vargs, msg);
-		PRINT("\n    Expectation failed at %s:%d: %s: %s\n", ztest_relative_filename(file),
-		      line, func, default_msg);
+		PRINT_DATA("\n    Expectation failed at %s:%d: %s: %s\n",
+			   ztest_relative_filename(file), line, func, default_msg);
 		vprintk(msg, vargs);
 		printk("\n");
 		va_end(vargs);
@@ -137,8 +141,8 @@ static inline bool z_zexpect(bool cond, const char *default_msg, const char *fil
 	}
 #if CONFIG_ZTEST_ASSERT_VERBOSE == 2
 	else {
-		PRINT("\n   Expectation succeeded at %s:%d (%s)\n", ztest_relative_filename(file),
-		      line, func);
+		PRINT_DATA("\n   Expectation succeeded at %s:%d (%s)\n",
+			   ztest_relative_filename(file), line, func);
 	}
 #endif
 	return true;

--- a/subsys/testsuite/ztest/include/zephyr/ztest_assert.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest_assert.h
@@ -172,8 +172,9 @@ static inline bool z_zexpect(bool cond, const char *default_msg, const char *fil
 #define _zassert_base(cond, default_msg, msg, ...)                                                 \
 	do {                                                                                       \
 		bool _msg = (msg != NULL);                                                         \
-		bool _ret = z_zassert(cond, _msg ? ("(" default_msg ")") : (default_msg), __FILE__,\
-				      __LINE__, __func__, _msg ? msg : "", ##__VA_ARGS__);         \
+		bool _ret =                                                                        \
+			z_zassert(cond, _msg ? ("(" default_msg ")") : (default_msg), __FILE__,    \
+				  __LINE__, __func__, _msg ? msg : "", ##__VA_ARGS__);             \
 		(void)_msg;                                                                        \
 		if (!_ret) {                                                                       \
 			/* If kernel but without multithreading return. */                         \
@@ -209,8 +210,9 @@ static inline bool z_zexpect(bool cond, const char *default_msg, const char *fil
 #define _zassume_base(cond, default_msg, msg, ...)                                                 \
 	do {                                                                                       \
 		bool _msg = (msg != NULL);                                                         \
-		bool _ret = z_zassume(cond, _msg ? ("(" default_msg ")") : (default_msg), __FILE__,\
-				      __LINE__, __func__, _msg ? msg : "", ##__VA_ARGS__);         \
+		bool _ret =                                                                        \
+			z_zassume(cond, _msg ? ("(" default_msg ")") : (default_msg), __FILE__,    \
+				  __LINE__, __func__, _msg ? msg : "", ##__VA_ARGS__);             \
 		(void)_msg;                                                                        \
 		if (!_ret) {                                                                       \
 			/* If kernel but without multithreading return. */                         \
@@ -396,7 +398,7 @@ static inline bool z_zexpect(bool cond, const char *default_msg, const char *fil
  * @param s2 The second string
  * @param ... Optional message and variables to print if the expectation fails
  */
-#define zassert_str_equal(s1, s2, ...)                                                     \
+#define zassert_str_equal(s1, s2, ...)                                                             \
 	zassert(strcmp(s1, s2) == 0, #s1 " not equal to " #s2, ##__VA_ARGS__)
 
 /**
@@ -574,7 +576,7 @@ static inline bool z_zexpect(bool cond, const char *default_msg, const char *fil
  * @param s2 The second string
  * @param ... Optional message and variables to print if the expectation fails
  */
-#define zassume_str_equal(s1, s2, ...)                                                     \
+#define zassume_str_equal(s1, s2, ...)                                                             \
 	zassume(strcmp(s1, s2) == 0, #s1 " not equal to " #s2, ##__VA_ARGS__)
 
 /**
@@ -719,7 +721,7 @@ static inline bool z_zexpect(bool cond, const char *default_msg, const char *fil
  * @param s2 The second string
  * @param ... Optional message and variables to print if the expectation fails
  */
-#define zexpect_str_equal(s1, s2, ...)                                                     \
+#define zexpect_str_equal(s1, s2, ...)                                                             \
 	zexpect(strcmp(s1, s2) == 0, #s1 " not equal to " #s2, ##__VA_ARGS__)
 
 /**

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -92,10 +92,10 @@ static int cleanup_test(struct ztest_unit_test *test)
 #endif
 
 	if (!ret && mock_status == 1) {
-		PRINT("Test %s failed: Unused mock parameter values\n", test->name);
+		PRINT_DATA("Test %s failed: Unused mock parameter values\n", test->name);
 		ret = TC_FAIL;
 	} else if (!ret && mock_status == 2) {
-		PRINT("Test %s failed: Unused mock return values\n", test->name);
+		PRINT_DATA("Test %s failed: Unused mock return values\n", test->name);
 		ret = TC_FAIL;
 	} else {
 		;
@@ -414,17 +414,17 @@ void ztest_test_fail(void)
 {
 	switch (cur_phase) {
 	case TEST_PHASE_SETUP:
-		PRINT(" at %s function\n", get_friendly_phase_name(cur_phase));
+		PRINT_DATA(" at %s function\n", get_friendly_phase_name(cur_phase));
 		longjmp(test_suite_fail, 1);
 	case TEST_PHASE_BEFORE:
 	case TEST_PHASE_TEST:
-		PRINT(" at %s function\n", get_friendly_phase_name(cur_phase));
+		PRINT_DATA(" at %s function\n", get_friendly_phase_name(cur_phase));
 		longjmp(test_fail, 1);
 	case TEST_PHASE_AFTER:
 	case TEST_PHASE_TEARDOWN:
 	case TEST_PHASE_FRAMEWORK:
-		PRINT(" ERROR: cannot fail in test phase '%s()', bailing\n",
-		      get_friendly_phase_name(cur_phase));
+		PRINT_DATA(" ERROR: cannot fail in test phase '%s()', bailing\n",
+			   get_friendly_phase_name(cur_phase));
 		longjmp(stack_fail, 1);
 	}
 }
@@ -435,8 +435,8 @@ void ztest_test_pass(void)
 	if (cur_phase == TEST_PHASE_TEST) {
 		longjmp(test_pass, 1);
 	}
-	PRINT(" ERROR: cannot pass in test phase '%s()', bailing\n",
-	      get_friendly_phase_name(cur_phase));
+	PRINT_DATA(" ERROR: cannot pass in test phase '%s()', bailing\n",
+		   get_friendly_phase_name(cur_phase));
 	longjmp(stack_fail, 1);
 }
 EXPORT_SYMBOL(ztest_test_pass);
@@ -449,8 +449,8 @@ void ztest_test_skip(void)
 	case TEST_PHASE_TEST:
 		longjmp(test_skip, 1);
 	default:
-		PRINT(" ERROR: cannot skip in test phase '%s()', bailing\n",
-		      get_friendly_phase_name(cur_phase));
+		PRINT_DATA(" ERROR: cannot skip in test phase '%s()', bailing\n",
+			   get_friendly_phase_name(cur_phase));
 		longjmp(stack_fail, 1);
 	}
 }
@@ -462,17 +462,17 @@ void ztest_test_expect_fail(void)
 
 	switch (cur_phase) {
 	case TEST_PHASE_SETUP:
-		PRINT(" at %s function\n", get_friendly_phase_name(cur_phase));
+		PRINT_DATA(" at %s function\n", get_friendly_phase_name(cur_phase));
 		break;
 	case TEST_PHASE_BEFORE:
 	case TEST_PHASE_TEST:
-		PRINT(" at %s function\n", get_friendly_phase_name(cur_phase));
+		PRINT_DATA(" at %s function\n", get_friendly_phase_name(cur_phase));
 		break;
 	case TEST_PHASE_AFTER:
 	case TEST_PHASE_TEARDOWN:
 	case TEST_PHASE_FRAMEWORK:
-		PRINT(" ERROR: cannot fail in test phase '%s()', bailing\n",
-		      get_friendly_phase_name(cur_phase));
+		PRINT_DATA(" ERROR: cannot fail in test phase '%s()', bailing\n",
+			   get_friendly_phase_name(cur_phase));
 		longjmp(stack_fail, 1);
 	}
 }
@@ -572,8 +572,8 @@ void ztest_test_fail(void)
 		test_finalize();
 		break;
 	default:
-		PRINT(" ERROR: cannot fail in test phase '%s()', bailing\n",
-		      get_friendly_phase_name(cur_phase));
+		PRINT_DATA(" ERROR: cannot fail in test phase '%s()', bailing\n",
+			   get_friendly_phase_name(cur_phase));
 		test_status = ZTEST_STATUS_CRITICAL_ERROR;
 		break;
 	}
@@ -588,8 +588,8 @@ void ztest_test_pass(void)
 		test_finalize();
 		break;
 	default:
-		PRINT(" ERROR: cannot pass in test phase '%s()', bailing\n",
-		      get_friendly_phase_name(cur_phase));
+		PRINT_DATA(" ERROR: cannot pass in test phase '%s()', bailing\n",
+			   get_friendly_phase_name(cur_phase));
 		test_status = ZTEST_STATUS_CRITICAL_ERROR;
 		if (cur_phase == TEST_PHASE_BEFORE) {
 			test_finalize();
@@ -610,8 +610,8 @@ void ztest_test_skip(void)
 		test_finalize();
 		break;
 	default:
-		PRINT(" ERROR: cannot skip in test phase '%s()', bailing\n",
-		      get_friendly_phase_name(cur_phase));
+		PRINT_DATA(" ERROR: cannot skip in test phase '%s()', bailing\n",
+			   get_friendly_phase_name(cur_phase));
 		test_status = ZTEST_STATUS_CRITICAL_ERROR;
 		break;
 	}
@@ -807,7 +807,7 @@ static int z_ztest_run_test_suite_ptr(struct ztest_suite_node *suite, bool shuff
 
 #ifndef KERNEL
 	if (setjmp(stack_fail)) {
-		PRINT("TESTSUITE crashed.\n");
+		PRINT_DATA("TESTSUITE crashed.\n");
 		test_status = ZTEST_STATUS_CRITICAL_ERROR;
 		end_report();
 		exit(1);
@@ -1157,7 +1157,7 @@ void ztest_verify_all_test_suites_ran(void)
 		for (suite = _ztest_suite_node_list_start; suite < _ztest_suite_node_list_end;
 		     ++suite) {
 			if (suite->stats->run_count < 1) {
-				PRINT("ERROR: Test suite '%s' did not run.\n", suite->name);
+				PRINT_DATA("ERROR: Test suite '%s' did not run.\n", suite->name);
 				all_tests_run = false;
 			}
 		}
@@ -1165,9 +1165,10 @@ void ztest_verify_all_test_suites_ran(void)
 		for (test = _ztest_unit_test_list_start; test < _ztest_unit_test_list_end; ++test) {
 			suite = ztest_find_test_suite(test->test_suite_name);
 			if (suite == NULL) {
-				PRINT("ERROR: Test '%s' assigned to test suite '%s' which doesn't "
-				      "exist\n",
-				      test->name, test->test_suite_name);
+				PRINT_DATA("ERROR: Test '%s' assigned to test suite '%s' which "
+					   "doesn't "
+					   "exist\n",
+					   test->name, test->test_suite_name);
 				all_tests_run = false;
 			}
 		}
@@ -1180,7 +1181,7 @@ void ztest_verify_all_test_suites_ran(void)
 	for (test = _ztest_unit_test_list_start; test < _ztest_unit_test_list_end; ++test) {
 		if (test->stats->fail_count + test->stats->pass_count + test->stats->skip_count !=
 		    test->stats->run_count) {
-			PRINT("Bad stats for %s.%s\n", test->test_suite_name, test->name);
+			PRINT_DATA("Bad stats for %s.%s\n", test->test_suite_name, test->name);
 			test_status = 1;
 		}
 	}
@@ -1430,11 +1431,11 @@ int main(void)
 		}
 		state.boots += 1;
 		if (test_status == 0) {
-			PRINT("Reset board #%u to test again\n", state.boots);
+			PRINT_DATA("Reset board #%u to test again\n", state.boots);
 			k_msleep(10);
 			sys_reboot(SYS_REBOOT_COLD);
 		} else {
-			PRINT("Failed after %u attempts\n", state.boots);
+			PRINT_DATA("Failed after %u attempts\n", state.boots);
 			state.boots = 0;
 		}
 	}

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -107,12 +107,12 @@ static int cleanup_test(struct ztest_unit_test *test)
 #ifdef KERNEL
 
 #if defined(CONFIG_SMP) && (CONFIG_MP_MAX_NUM_CPUS > 1)
-#define MAX_NUM_CPUHOLD (CONFIG_MP_MAX_NUM_CPUS - 1)
+#define MAX_NUM_CPUHOLD  (CONFIG_MP_MAX_NUM_CPUS - 1)
 #define CPUHOLD_STACK_SZ (512 + CONFIG_TEST_EXTRA_STACK_SIZE)
 
 struct cpuhold_pool_item {
-	struct k_thread  thread;
-	bool             used;
+	struct k_thread thread;
+	bool used;
 };
 
 static struct cpuhold_pool_item cpuhold_pool_items[MAX_NUM_CPUHOLD + 1];
@@ -184,10 +184,8 @@ static void cpu_hold(void *arg1, void *arg2, void *arg3)
 		cpuhold_spawned = false;
 
 		cpuhold_pool_items[i].used = true;
-		k_thread_create(&cpuhold_pool_items[i].thread,
-				cpuhold_stacks[i], CPUHOLD_STACK_SZ,
-				cpu_hold, k_current_get(),
-				(void *)(uintptr_t)idx, NULL,
+		k_thread_create(&cpuhold_pool_items[i].thread, cpuhold_stacks[i], CPUHOLD_STACK_SZ,
+				cpu_hold, k_current_get(), (void *)(uintptr_t)idx, NULL,
 				K_HIGHEST_THREAD_PRIO, 0, K_NO_WAIT);
 
 		/*
@@ -217,7 +215,6 @@ static void cpu_hold(void *arg1, void *arg2, void *arg3)
 		k_thread_name_set(k_current_get(), tname);
 	}
 
-
 	uint32_t dt, start_ms = k_uptime_get_32();
 	unsigned int key = arch_irq_lock();
 
@@ -243,8 +240,7 @@ static void cpu_hold(void *arg1, void *arg2, void *arg3)
 	 * logic views it as one "job") and cause other test failures.
 	 */
 	dt = k_uptime_get_32() - start_ms;
-	zassert_true(dt < CONFIG_ZTEST_CPU_HOLD_TIME_MS,
-		     "1cpu test took too long (%d ms)", dt);
+	zassert_true(dt < CONFIG_ZTEST_CPU_HOLD_TIME_MS, "1cpu test took too long (%d ms)", dt);
 	arch_irq_unlock(key);
 }
 #endif /* CONFIG_SMP && (CONFIG_MP_MAX_NUM_CPUS > 1) */
@@ -268,10 +264,9 @@ void z_impl_z_test_1cpu_start(void)
 		__ASSERT_NO_MSG(j != -1);
 
 		cpuhold_pool_items[j].used = true;
-		k_thread_create(&cpuhold_pool_items[j].thread,
-				cpuhold_stacks[j], CPUHOLD_STACK_SZ,
-				cpu_hold, NULL, (void *)(uintptr_t)i, NULL,
-				K_HIGHEST_THREAD_PRIO, 0, K_NO_WAIT);
+		k_thread_create(&cpuhold_pool_items[j].thread, cpuhold_stacks[j], CPUHOLD_STACK_SZ,
+				cpu_hold, NULL, (void *)(uintptr_t)i, NULL, K_HIGHEST_THREAD_PRIO,
+				0, K_NO_WAIT);
 		k_sem_take(&cpuhold_sem, K_FOREVER);
 	}
 #endif
@@ -292,10 +287,16 @@ void z_impl_z_test_1cpu_stop(void)
 }
 
 #ifdef CONFIG_USERSPACE
-void z_vrfy_z_test_1cpu_start(void) { z_impl_z_test_1cpu_start(); }
+void z_vrfy_z_test_1cpu_start(void)
+{
+	z_impl_z_test_1cpu_start();
+}
 #include <zephyr/syscalls/z_test_1cpu_start_mrsh.c>
 
-void z_vrfy_z_test_1cpu_stop(void) { z_impl_z_test_1cpu_stop(); }
+void z_vrfy_z_test_1cpu_stop(void)
+{
+	z_impl_z_test_1cpu_stop();
+}
 #include <zephyr/syscalls/z_test_1cpu_stop_mrsh.c>
 #endif /* CONFIG_USERSPACE */
 #endif
@@ -671,10 +672,8 @@ static int run_test(struct ztest_suite_node *suite, struct ztest_unit_test *test
 	if (IS_ENABLED(CONFIG_MULTITHREADING)) {
 		get_start_time_cyc();
 		k_thread_create(&ztest_thread, ztest_thread_stack,
-				K_THREAD_STACK_SIZEOF(ztest_thread_stack),
-				test_cb, suite, test, data,
-				CONFIG_ZTEST_THREAD_PRIORITY,
-				K_INHERIT_PERMS, K_FOREVER);
+				K_THREAD_STACK_SIZEOF(ztest_thread_stack), test_cb, suite, test,
+				data, CONFIG_ZTEST_THREAD_PRIORITY, K_INHERIT_PERMS, K_FOREVER);
 
 		k_thread_access_grant(&ztest_thread, suite, test, suite->stats);
 		if (test->name != NULL) {
@@ -765,8 +764,8 @@ struct ztest_unit_test *z_ztest_get_next_test(const char *suite, struct ztest_un
 }
 
 #if CONFIG_ZTEST_SHUFFLE
-static void z_ztest_shuffle(bool shuffle, void *dest[], intptr_t start,
-			    size_t num_items, size_t element_size)
+static void z_ztest_shuffle(bool shuffle, void *dest[], intptr_t start, size_t num_items,
+			    size_t element_size)
 {
 	/* Initialize dest array */
 	for (size_t i = 0; i < num_items; ++i) {
@@ -789,8 +788,8 @@ static void z_ztest_shuffle(bool shuffle, void *dest[], intptr_t start,
 }
 #endif
 
-static int z_ztest_run_test_suite_ptr(struct ztest_suite_node *suite,
-				      bool shuffle, int suite_iter, int case_iter)
+static int z_ztest_run_test_suite_ptr(struct ztest_suite_node *suite, bool shuffle, int suite_iter,
+				      int case_iter)
 {
 	struct ztest_unit_test *test = NULL;
 	void *data = NULL;
@@ -836,8 +835,8 @@ static int z_ztest_run_test_suite_ptr(struct ztest_suite_node *suite,
 
 		memset(tests_to_run, 0, ZTEST_TEST_COUNT * sizeof(struct ztest_unit_test *));
 		z_ztest_shuffle(shuffle, (void **)tests_to_run,
-				(intptr_t)_ztest_unit_test_list_start,
-				ZTEST_TEST_COUNT, sizeof(struct ztest_unit_test));
+				(intptr_t)_ztest_unit_test_list_start, ZTEST_TEST_COUNT,
+				sizeof(struct ztest_unit_test));
 		for (size_t j = 0; j < ZTEST_TEST_COUNT; ++j) {
 			test = tests_to_run[j];
 			/* Make sure that the test belongs to this suite */
@@ -902,8 +901,8 @@ static int z_ztest_run_test_suite_ptr(struct ztest_suite_node *suite,
 
 int z_ztest_run_test_suite(const char *name, bool shuffle, int suite_iter, int case_iter)
 {
-	return z_ztest_run_test_suite_ptr(ztest_find_test_suite(name),
-					shuffle, suite_iter, case_iter);
+	return z_ztest_run_test_suite_ptr(ztest_find_test_suite(name), shuffle, suite_iter,
+					  case_iter);
 }
 
 #ifdef CONFIG_USERSPACE
@@ -979,12 +978,10 @@ static void __ztest_show_suite_summary_oneline(struct ztest_suite_node *suite)
 	}
 
 	TC_SUMMARY_PRINT("SUITE %s - %3d.%02d%% [%s]: pass = %d, fail = %d, "
-				"skip = %d, total = %d duration = %u.%03u seconds\n",
-				TC_RESULT_TO_STR(suite_result),
-				passrate_major, passrate_minor,
-				suite->name, distinct_pass, distinct_fail,
-				distinct_skip, distinct_total,
-				suite_duration_worst_ms / 1000, suite_duration_worst_ms % 1000);
+			 "skip = %d, total = %d duration = %u.%03u seconds\n",
+			 TC_RESULT_TO_STR(suite_result), passrate_major, passrate_minor,
+			 suite->name, distinct_pass, distinct_fail, distinct_skip, distinct_total,
+			 suite_duration_worst_ms / 1000, suite_duration_worst_ms % 1000);
 	flush_log();
 }
 
@@ -1010,20 +1007,18 @@ static void __ztest_show_suite_summary_verbose(struct ztest_suite_node *suite)
 		}
 
 		if (tc_result == TC_FLAKY) {
-			TC_SUMMARY_PRINT(" - %s - [%s.%s] - (Failed %d of %d attempts)"
-					 " - duration = %u.%03u seconds\n",
-					TC_RESULT_TO_STR(tc_result),
-					test->test_suite_name, test->name,
-					test->stats->run_count - test->stats->pass_count,
-					test->stats->run_count,
-					test->stats->duration_worst_ms / 1000,
-					test->stats->duration_worst_ms % 1000);
+			TC_SUMMARY_PRINT(
+				" - %s - [%s.%s] - (Failed %d of %d attempts)"
+				" - duration = %u.%03u seconds\n",
+				TC_RESULT_TO_STR(tc_result), test->test_suite_name, test->name,
+				test->stats->run_count - test->stats->pass_count,
+				test->stats->run_count, test->stats->duration_worst_ms / 1000,
+				test->stats->duration_worst_ms % 1000);
 		} else {
 			TC_SUMMARY_PRINT(" - %s - [%s.%s] duration = %u.%03u seconds\n",
-					TC_RESULT_TO_STR(tc_result),
-					test->test_suite_name, test->name,
-					test->stats->duration_worst_ms / 1000,
-					test->stats->duration_worst_ms % 1000);
+					 TC_RESULT_TO_STR(tc_result), test->test_suite_name,
+					 test->name, test->stats->duration_worst_ms / 1000,
+					 test->stats->duration_worst_ms % 1000);
 		}
 
 		if (flush_frequency % 3 == 0) {
@@ -1057,8 +1052,8 @@ static void __ztest_show_suite_summary(void)
 	flush_log();
 }
 
-static int __ztest_run_test_suite(struct ztest_suite_node *ptr,
-			const void *state, bool shuffle, int suite_iter, int case_iter)
+static int __ztest_run_test_suite(struct ztest_suite_node *ptr, const void *state, bool shuffle,
+				  int suite_iter, int case_iter)
 {
 	struct ztest_suite_stats *stats = ptr->stats;
 	int count = 0;
@@ -1100,26 +1095,26 @@ int z_impl_ztest_run_test_suites(const void *state, bool shuffle, int suite_iter
 		__ztest_init_unit_test_result_for_suite(suites_to_run[i]);
 	}
 	for (size_t i = 0; i < ZTEST_SUITE_COUNT; ++i) {
-		count += __ztest_run_test_suite(suites_to_run[i],
-				state, shuffle, suite_iter, case_iter);
+		count += __ztest_run_test_suite(suites_to_run[i], state, shuffle, suite_iter,
+						case_iter);
 		/* Stop running tests if we have a critical error or if we have a failure and
 		 * FAIL_FAST was set
 		 */
 		if (test_status == ZTEST_STATUS_CRITICAL_ERROR ||
-				(test_status == ZTEST_STATUS_HAS_FAILURE && FAIL_FAST)) {
+		    (test_status == ZTEST_STATUS_HAS_FAILURE && FAIL_FAST)) {
 			break;
 		}
 	}
 #else
 	for (struct ztest_suite_node *ptr = _ztest_suite_node_list_start;
-			ptr < _ztest_suite_node_list_end; ++ptr) {
+	     ptr < _ztest_suite_node_list_end; ++ptr) {
 		__ztest_init_unit_test_result_for_suite(ptr);
 		count += __ztest_run_test_suite(ptr, state, shuffle, suite_iter, case_iter);
 		/* Stop running tests if we have a critical error or if we have a failure and
 		 * FAIL_FAST was set
 		 */
 		if (test_status == ZTEST_STATUS_CRITICAL_ERROR ||
-				(test_status == ZTEST_STATUS_HAS_FAILURE && FAIL_FAST)) {
+		    (test_status == ZTEST_STATUS_HAS_FAILURE && FAIL_FAST)) {
 			break;
 		}
 	}
@@ -1274,8 +1269,8 @@ static int cmd_shuffle(const struct shell *sh, size_t argc, char **argv)
 	struct getopt_state *state;
 	int opt;
 	static struct option long_options[] = {{"suite_iter", required_argument, 0, 's'},
-		{"case_iter", required_argument, 0, 'c'},
-		{0, 0, 0, 0}};
+					       {"case_iter", required_argument, 0, 'c'},
+					       {0, 0, 0, 0}};
 	int opt_index = 0;
 	int val;
 	int opt_num = 0;
@@ -1290,7 +1285,7 @@ static int cmd_shuffle(const struct shell *sh, size_t argc, char **argv)
 			val = atoi(state->optarg);
 			if (val < 1) {
 				shell_fprintf(sh, SHELL_ERROR,
-					"Invalid number of suite interations\n");
+					      "Invalid number of suite interations\n");
 				return -ENOEXEC;
 			}
 			suite_iter = val;
@@ -1300,15 +1295,15 @@ static int cmd_shuffle(const struct shell *sh, size_t argc, char **argv)
 			val = atoi(state->optarg);
 			if (val < 1) {
 				shell_fprintf(sh, SHELL_ERROR,
-					"Invalid number of case interations\n");
+					      "Invalid number of case interations\n");
 				return -ENOEXEC;
 			}
 			case_iter = val;
 			opt_num++;
 			break;
 		default:
-			shell_fprintf(sh, SHELL_ERROR,
-				"Invalid option or option usage: %s\n", argv[opt_index + 1]);
+			shell_fprintf(sh, SHELL_ERROR, "Invalid option or option usage: %s\n",
+				      argv[opt_index + 1]);
 			return -ENOEXEC;
 		}
 	}
@@ -1327,11 +1322,11 @@ static int cmd_run_suite(const struct shell *sh, size_t argc, char **argv)
 	ztest_set_test_args(argv[1]);
 
 	for (struct ztest_suite_node *ptr = _ztest_suite_node_list_start;
-			ptr < _ztest_suite_node_list_end; ++ptr) {
+	     ptr < _ztest_suite_node_list_end; ++ptr) {
 		__ztest_init_unit_test_result_for_suite(ptr);
 		count += __ztest_run_test_suite(ptr, NULL, shuffle, 1, 1);
 		if (test_status == ZTEST_STATUS_CRITICAL_ERROR ||
-				(test_status == ZTEST_STATUS_HAS_FAILURE && FAIL_FAST)) {
+		    (test_status == ZTEST_STATUS_HAS_FAILURE && FAIL_FAST)) {
 			break;
 		}
 	}
@@ -1357,8 +1352,7 @@ static const struct ztest_suite_node *suite_lookup(size_t idx, const char *prefi
 
 	while (suite < suite_end) {
 		if ((suite->name != NULL) && (strlen(suite->name) != 0) &&
-				((prefix == NULL) ||
-				(strncmp(prefix, suite->name, strlen(prefix)) == 0))) {
+		    ((prefix == NULL) || (strncmp(prefix, suite->name, strlen(prefix)) == 0))) {
 			if (match_idx == idx) {
 				return suite;
 			}
@@ -1380,6 +1374,7 @@ static void testsuite_list_get(size_t idx, struct shell_static_entry *entry)
 	entry->subcmd = NULL;
 }
 
+/* clang-format off */
 	SHELL_STATIC_SUBCMD_SET_CREATE(
 		sub_ztest_cmds,
 		SHELL_CMD_ARG(run-all, NULL, "Run all tests", cmd_runall, 0, 0),
@@ -1396,6 +1391,7 @@ static void testsuite_list_get(size_t idx, struct shell_static_entry *entry)
 		SHELL_CMD_ARG(run-testcase, NULL, "Run testcase", cmd_run_suite, 2, 0),
 		SHELL_SUBCMD_SET_END /* Array terminated. */
 	);
+/* clang-format on */
 
 SHELL_CMD_REGISTER(ztest, &sub_ztest_cmds, "Ztest commands", NULL);
 #endif /* CONFIG_ZTEST_SHELL */

--- a/subsys/testsuite/ztest/src/ztest_mock.c
+++ b/subsys/testsuite/ztest/src/ztest_mock.c
@@ -76,9 +76,8 @@ int snprintk(char *str, size_t size, const char *fmt, ...)
  * FIXME: move to sys_io.h once the argument signature for bitmap has
  * been fixed to void* or similar GH-2825
  */
-#define BITS_PER_UL (8 * sizeof(unsigned long))
-#define DEFINE_BITFIELD(name, bits)                                            \
-	unsigned long(name)[DIV_ROUND_UP(bits, BITS_PER_UL)]
+#define BITS_PER_UL                 (8 * sizeof(unsigned long))
+#define DEFINE_BITFIELD(name, bits) unsigned long(name)[DIV_ROUND_UP(bits, BITS_PER_UL)]
 
 static inline int sys_bitfield_find_first_clear(const unsigned long *bitmap,
 						const unsigned int bits)
@@ -100,8 +99,8 @@ static inline int sys_bitfield_find_first_clear(const unsigned long *bitmap,
 			/* First bit is free */
 			return cnt * BITS_PER_UL;
 		} else {
-			const unsigned int bit = (cnt * BITS_PER_UL) +
-						 __builtin_ffsl(neg_bitmap) - 1;
+			const unsigned int bit =
+				(cnt * BITS_PER_UL) + __builtin_ffsl(neg_bitmap) - 1;
 			/* Ensure first free bit is within total bits count */
 			if (bit < bits) {
 				return bit;
@@ -124,8 +123,8 @@ static void free_parameter(struct parameter *param)
 		return;
 	}
 	__ASSERT(allocation_index < CONFIG_ZTEST_PARAMETER_COUNT,
-		 "param %p given to free is not in the static buffer %p:%u",
-		 param, params, CONFIG_ZTEST_PARAMETER_COUNT);
+		 "param %p given to free is not in the static buffer %p:%u", param, params,
+		 CONFIG_ZTEST_PARAMETER_COUNT);
 	sys_bitfield_clear_bit((mem_addr_t)params_allocation, allocation_index);
 }
 
@@ -134,8 +133,8 @@ static struct parameter *alloc_parameter(void)
 	int allocation_index;
 	struct parameter *param;
 
-	allocation_index = sys_bitfield_find_first_clear(
-		params_allocation, CONFIG_ZTEST_PARAMETER_COUNT);
+	allocation_index =
+		sys_bitfield_find_first_clear(params_allocation, CONFIG_ZTEST_PARAMETER_COUNT);
 	if (allocation_index == -1) {
 		printk("No more mock parameters available for allocation\n");
 		ztest_test_fail();
@@ -152,8 +151,8 @@ void z_init_mock(void)
 
 #endif
 
-static struct parameter *find_and_delete_value(struct parameter *param,
-					       const char *fn, const char *name)
+static struct parameter *find_and_delete_value(struct parameter *param, const char *fn,
+					       const char *name)
 {
 	struct parameter *value;
 
@@ -172,8 +171,7 @@ static struct parameter *find_and_delete_value(struct parameter *param,
 	return value;
 }
 
-static void insert_value(struct parameter *param, const char *fn,
-			 const char *name, uintptr_t val)
+static void insert_value(struct parameter *param, const char *fn, const char *name, uintptr_t val)
 {
 	struct parameter *value;
 
@@ -192,16 +190,15 @@ static void insert_value(struct parameter *param, const char *fn,
 	param->next = value;
 }
 
-static struct parameter parameter_list = { NULL, "", "", 0 };
-static struct parameter return_value_list = { NULL, "", "", 0 };
+static struct parameter parameter_list = {NULL, "", "", 0};
+static struct parameter return_value_list = {NULL, "", "", 0};
 
 void z_ztest_expect_value(const char *fn, const char *name, uintptr_t val)
 {
 	insert_value(&parameter_list, fn, name, val);
 }
 
-void z_ztest_check_expected_value(const char *fn, const char *name,
-				  uintptr_t val)
+void z_ztest_check_expected_value(const char *fn, const char *name, uintptr_t val)
 {
 	struct parameter *param;
 	uintptr_t expected;
@@ -219,8 +216,8 @@ void z_ztest_check_expected_value(const char *fn, const char *name,
 		/* We need to cast these values since the toolchain doesn't
 		 * provide inttypes.h
 		 */
-		PRINT("%s:%s received wrong value: Got %lu, expected %lu\n", fn,
-		      name, (unsigned long)val, (unsigned long)expected);
+		PRINT("%s:%s received wrong value: Got %lu, expected %lu\n", fn, name,
+		      (unsigned long)val, (unsigned long)expected);
 		ztest_test_fail();
 	}
 }
@@ -230,8 +227,7 @@ void z_ztest_expect_data(const char *fn, const char *name, void *val)
 	insert_value(&parameter_list, fn, name, (uintptr_t)val);
 }
 
-void z_ztest_check_expected_data(const char *fn, const char *name, void *data,
-				 uint32_t length)
+void z_ztest_check_expected_data(const char *fn, const char *name, void *data, uint32_t length)
 {
 	struct parameter *param;
 	void *expected;
@@ -254,8 +250,7 @@ void z_ztest_check_expected_data(const char *fn, const char *name, void *data,
 		PRINT("%s:%s received data while expected null pointer\n", fn, name);
 		ztest_test_fail();
 	} else if (data == NULL && expected != NULL) {
-		PRINT("%s:%s received null pointer while expected data\n", fn,
-		      name);
+		PRINT("%s:%s received null pointer while expected data\n", fn, name);
 		ztest_test_fail();
 	} else if (data != NULL) {
 		if (memcmp(data, expected, length) != 0) {
@@ -270,8 +265,7 @@ void z_ztest_return_data(const char *fn, const char *name, void *val)
 	insert_value(&parameter_list, fn, name, (uintptr_t)val);
 }
 
-void z_ztest_copy_return_data(const char *fn, const char *name, void *data,
-			      uint32_t length)
+void z_ztest_copy_return_data(const char *fn, const char *name, void *data, uint32_t length)
 {
 	struct parameter *param;
 	void *return_data;
@@ -302,8 +296,7 @@ void z_ztest_returns_value(const char *fn, uintptr_t value)
 uintptr_t z_ztest_get_return_value(const char *fn)
 {
 	uintptr_t value;
-	struct parameter *param =
-		find_and_delete_value(&return_value_list, fn, "");
+	struct parameter *param = find_and_delete_value(&return_value_list, fn, "");
 
 	if (!param) {
 		PRINT("Failed to find return value for function %s\n", fn);
@@ -332,14 +325,12 @@ int z_cleanup_mock(void)
 	int fail = 0;
 
 	if (parameter_list.next) {
-		PRINT("Parameter not used by mock: %s:%s\n",
-		      parameter_list.next->fn,
+		PRINT("Parameter not used by mock: %s:%s\n", parameter_list.next->fn,
 		      parameter_list.next->name);
 		fail = 1;
 	}
 	if (return_value_list.next) {
-		PRINT("Return value no used by mock: %s\n",
-		      return_value_list.next->fn);
+		PRINT("Return value no used by mock: %s\n", return_value_list.next->fn);
 		fail = 2;
 	}
 

--- a/subsys/testsuite/ztest/src/ztest_mock.c
+++ b/subsys/testsuite/ztest/src/ztest_mock.c
@@ -76,7 +76,7 @@ int snprintk(char *str, size_t size, const char *fmt, ...)
  * FIXME: move to sys_io.h once the argument signature for bitmap has
  * been fixed to void* or similar GH-2825
  */
-#define BITS_PER_UL (8 * sizeof(unsigned long int))
+#define BITS_PER_UL (8 * sizeof(unsigned long))
 #define DEFINE_BITFIELD(name, bits)                                            \
 	unsigned long(name)[DIV_ROUND_UP(bits, BITS_PER_UL)]
 

--- a/subsys/testsuite/ztest/src/ztest_mock.c
+++ b/subsys/testsuite/ztest/src/ztest_mock.c
@@ -33,7 +33,7 @@ static struct parameter *alloc_parameter(void)
 
 	param = calloc(1, sizeof(struct parameter));
 	if (!param) {
-		PRINT("Failed to allocate mock parameter\n");
+		PRINT_DATA("Failed to allocate mock parameter\n");
 		ztest_test_fail();
 	}
 
@@ -205,7 +205,7 @@ void z_ztest_check_expected_value(const char *fn, const char *name, uintptr_t va
 
 	param = find_and_delete_value(&parameter_list, fn, name);
 	if (!param) {
-		PRINT("Failed to find parameter %s for %s\n", name, fn);
+		PRINT_DATA("Failed to find parameter %s for %s\n", name, fn);
 		ztest_test_fail();
 	}
 
@@ -216,8 +216,8 @@ void z_ztest_check_expected_value(const char *fn, const char *name, uintptr_t va
 		/* We need to cast these values since the toolchain doesn't
 		 * provide inttypes.h
 		 */
-		PRINT("%s:%s received wrong value: Got %lu, expected %lu\n", fn, name,
-		      (unsigned long)val, (unsigned long)expected);
+		PRINT_DATA("%s:%s received wrong value: Got %lu, expected %lu\n", fn, name,
+			   (unsigned long)val, (unsigned long)expected);
 		ztest_test_fail();
 	}
 }
@@ -234,7 +234,7 @@ void z_ztest_check_expected_data(const char *fn, const char *name, void *data, u
 
 	param = find_and_delete_value(&parameter_list, fn, name);
 	if (!param) {
-		PRINT("Failed to find parameter %s for %s\n", name, fn);
+		PRINT_DATA("Failed to find parameter %s for %s\n", name, fn);
 		/* No return from this function but for coverity reasons
 		 * put a return after to avoid the warning of a null
 		 * dereference of param below.
@@ -247,14 +247,14 @@ void z_ztest_check_expected_data(const char *fn, const char *name, void *data, u
 	free_parameter(param);
 
 	if (expected == NULL && data != NULL) {
-		PRINT("%s:%s received data while expected null pointer\n", fn, name);
+		PRINT_DATA("%s:%s received data while expected null pointer\n", fn, name);
 		ztest_test_fail();
 	} else if (data == NULL && expected != NULL) {
-		PRINT("%s:%s received null pointer while expected data\n", fn, name);
+		PRINT_DATA("%s:%s received null pointer while expected data\n", fn, name);
 		ztest_test_fail();
 	} else if (data != NULL) {
 		if (memcmp(data, expected, length) != 0) {
-			PRINT("%s:%s data provided don't match\n", fn, name);
+			PRINT_DATA("%s:%s data provided don't match\n", fn, name);
 			ztest_test_fail();
 		}
 	}
@@ -271,14 +271,14 @@ void z_ztest_copy_return_data(const char *fn, const char *name, void *data, uint
 	void *return_data;
 
 	if (data == NULL) {
-		PRINT("%s:%s received null pointer\n", fn, name);
+		PRINT_DATA("%s:%s received null pointer\n", fn, name);
 		ztest_test_fail();
 		return;
 	}
 
 	param = find_and_delete_value(&parameter_list, fn, name);
 	if (!param) {
-		PRINT("Failed to find parameter %s for %s\n", name, fn);
+		PRINT_DATA("Failed to find parameter %s for %s\n", name, fn);
 		memset(data, 0, length);
 		ztest_test_fail();
 	} else {
@@ -299,7 +299,7 @@ uintptr_t z_ztest_get_return_value(const char *fn)
 	struct parameter *param = find_and_delete_value(&return_value_list, fn, "");
 
 	if (!param) {
-		PRINT("Failed to find return value for function %s\n", fn);
+		PRINT_DATA("Failed to find return value for function %s\n", fn);
 		ztest_test_fail();
 	}
 
@@ -325,12 +325,12 @@ int z_cleanup_mock(void)
 	int fail = 0;
 
 	if (parameter_list.next) {
-		PRINT("Parameter not used by mock: %s:%s\n", parameter_list.next->fn,
-		      parameter_list.next->name);
+		PRINT_DATA("Parameter not used by mock: %s:%s\n", parameter_list.next->fn,
+			   parameter_list.next->name);
 		fail = 1;
 	}
 	if (return_value_list.next) {
-		PRINT("Return value no used by mock: %s\n", return_value_list.next->fn);
+		PRINT_DATA("Return value no used by mock: %s\n", return_value_list.next->fn);
 		fail = 2;
 	}
 


### PR DESCRIPTION
The testsuite subsystem uses PRINT_DATA, which can be overridden by applications using CONFIG_ZTEST_TC_UTIL_USER_OVERRIDE.  Convert all calls of PRINT() to PRINT_DATA() in the ztest files for consistency.