### PR TITLE
sensor: tsl2591: fix: Address CID 353644 & 353654

### DIFF
--- a/drivers/sensor/ams/tsl2591/tsl2591.c
+++ b/drivers/sensor/ams/tsl2591/tsl2591.c
@@ -136,7 +136,7 @@ static int tsl2591_channel_get(const struct device *dev, enum sensor_channel cha
 			       struct sensor_value *val)
 {
 	const struct tsl2591_data *data = dev->data;
-	int64_t cpl = data->atime * data->again;
+	int64_t cpl = (int64_t)data->atime * (int64_t)data->again;
 	int64_t strength;
 
 	/* Unfortunately, datasheet does not provide a lux conversion formula for this particular


### PR DESCRIPTION
Coverity is concerned about potential overflow from implicit sign extension in multiplication operation (since operands are implicitly promoted to `int32_t`, which two `uint16_t`'s could theoretically overflow when multiplied together before the result is cast to `int64_t`). Although this shouldn't happen in practice due to the range of values operands can take on, perform explicit cast to `int64_t` on operands just to be on the safe side.

Fixes #74750 
Fixes #74752