### PR TITLE
net: openthread: Handle deprecated IPv6 addresses correctly

### DIFF
--- a/subsys/net/l2/openthread/openthread_utils.c
+++ b/subsys/net/l2/openthread/openthread_utils.c
@@ -154,6 +154,11 @@ void add_ipv6_addr_to_zephyr(struct openthread_context *context)
 
 		if_addr->is_mesh_local = is_mesh_local(
 					context, address->mAddress.mFields.m8);
+
+		/* Mark address as deprecated if it is not preferred. */
+		if (!address->mPreferred) {
+			if_addr->addr_state = NET_ADDR_DEPRECATED;
+		}
 	}
 }
 
@@ -195,7 +200,7 @@ void add_ipv6_addr_to_ot(struct openthread_context *context,
 			context, ipv6->unicast[i].address.in6_addr.s6_addr);
 
 	addr.mValid = true;
-	addr.mPreferred = true;
+	addr.mPreferred = (if_addr->addr_state == NET_ADDR_PREFERRED);
 	addr.mPrefixLength = 64;
 
 	if (if_addr->addr_type == NET_ADDR_AUTOCONF) {


### PR DESCRIPTION
This PR fixes an issue where deprecated IPv6 addresses were not being correctly marked. In some cases, deprecated addresses might have been used as source addresses.