### PR TITLE
subsys: net: http: Fix format specifier for size_t in debug log

### DIFF
--- a/subsys/net/lib/http/http_server_http1.c
+++ b/subsys/net/lib/http/http_server_http1.c
@@ -330,7 +330,7 @@ int handle_http1_static_fs_resource(struct http_resource_detail_static_fs *stati
 		}
 	}
 
-	LOG_DBG("found %s, file size: %d", fname, file_size);
+	LOG_DBG("found %s, file size: %zu", fname, file_size);
 
 	/* send HTTP header */
 	len = snprintk(http_response, sizeof(http_response), RESPONSE_TEMPLATE_STATIC_FS,


### PR DESCRIPTION
The file size variable in the debug log statement in http_server_http1.c
is of type size_t. The correct format specifier for size_t is %zu, not %d.
This change updates the format specifier to %zu to ensure correct logging
of the file size.

This fixes potential issues on platforms where size_t is not equivalent
to an int, ensuring the log output correctly represents the file size.

```
[160/188] Building C object zephyr/subsys/net/lib/http/CMakeFiles/subsys__net__lib__http.dir/http_server_http1.c.obj
FAILED: zephyr/subsys/net/lib/http/CMakeFiles/subsys__net__lib__http.dir/http_server_http1.c.obj 
ccache /home/mak/zephyr-sdk-0.16.5-1/sparc-zephyr-elf/bin/sparc-zephyr-elf-gcc -DKERNEL -DK_HEAP_MEM_POOL_SIZE=1024 -DPICOLIBC_LONG_LONG_PRINTF_SCANF -DTC_RUNID=2475212a492283a86206f01ef925bfc1 -D__LINUX_ERRNO_EXTENSIONS__ -D__ZEPHYR__=1 -I/home/mak/zephyrproject/zephyr/twister-out/qemu_leon3/tests/net/lib/prometheus/formatter/prometheus.formatter/zephyr/include/generated/zephyr -I/home/mak/zephyrproject/zephyr/include -I/home/mak/zephyrproject/zephyr/twister-out/qemu_leon3/tests/net/lib/prometheus/formatter/prometheus.formatter/zephyr/include/generated -I/home/mak/zephyrproject/zephyr/soc/gaisler/leon3 -I/home/mak/zephyrproject/zephyr/include/zephyr/posix -I/home/mak/zephyrproject/zephyr/soc/gaisler/leon3/. -I/home/mak/zephyrproject/zephyr/subsys/testsuite/include -I/home/mak/zephyrproject/zephyr/subsys/testsuite/coverage -I/home/mak/zephyrproject/zephyr/subsys/testsuite/ztest/include -I/home/mak/zephyrproject/zephyr/subsys/net/lib/prometheus/. -I/home/mak/zephyrproject/zephyr/subsys/net/ip -isystem /home/mak/zephyrproject/zephyr/lib/libc/common/include -Wshadow -fno-strict-aliasing -Werror -Os -imacros /home/mak/zephyrproject/zephyr/twister-out/qemu_leon3/tests/net/lib/prometheus/formatter/prometheus.formatter/zephyr/include/generated/zephyr/autoconf.h -fno-printf-return-value -fno-common -g -gdwarf-4 -fdiagnostics-color=always -msoft-float -mcpu=leon3 --sysroot=/home/mak/zephyr-sdk-0.16.5-1/sparc-zephyr-elf/sparc-zephyr-elf -imacros /home/mak/zephyrproject/zephyr/include/zephyr/toolchain/zephyr_stdint.h -Wall -Wformat -Wformat-security -Wno-format-zero-length -Wdouble-promotion -Wno-pointer-sign -Wpointer-arith -Wexpansion-to-defined -Wno-unused-but-set-variable -Werror=implicit-int -fno-pic -fno-pie -fno-asynchronous-unwind-tables -ftls-model=local-exec -fno-reorder-functions --param=min-pagesize=0 -fno-defer-pop -fmacro-prefix-map=/home/mak/zephyrproject/zephyr/tests/net/lib/prometheus/formatter=CMAKE_SOURCE_DIR -fmacro-prefix-map=/home/mak/zephyrproject/zephyr=ZEPHYR_BASE -fmacro-prefix-map=/home/mak/zephyrproject=WEST_TOPDIR -ffunction-sections -fdata-sections --specs=picolibc.specs -D_POSIX_THREADS -std=c99 -MD -MT zephyr/subsys/net/lib/http/CMakeFiles/subsys__net__lib__http.dir/http_server_http1.c.obj -MF zephyr/subsys/net/lib/http/CMakeFiles/subsys__net__lib__http.dir/http_server_http1.c.obj.d -o zephyr/subsys/net/lib/http/CMakeFiles/subsys__net__lib__http.dir/http_server_http1.c.obj -c /home/mak/zephyrproject/zephyr/subsys/net/lib/http/http_server_http1.c
In file included from /home/mak/zephyrproject/zephyr/include/zephyr/logging/log.h:11,
                 from /home/mak/zephyrproject/zephyr/subsys/net/lib/http/http_server_http1.c:20:
/home/mak/zephyrproject/zephyr/subsys/net/lib/http/http_server_http1.c: In function 'handle_http1_static_fs_resource':
/home/mak/zephyrproject/zephyr/subsys/net/lib/http/http_server_http1.c:333:17: error: format '%ld' expects argument of type 'long int', but argument 3 has type 'size_t' {aka 'unsigned int'} [-Werror=format=]
  333 |         LOG_DBG("found %s, file size: %ld", fname, file_size);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~         ~~~~~~~~~
      |                                                    |
      |                                                    size_t {aka unsigned int}
/home/mak/zephyrproject/zephyr/include/zephyr/logging/log_core.h:275:42: note: in definition of macro 'Z_LOG2'
  275 |                 z_log_printf_arg_checker(__VA_ARGS__); \
      |                                          ^~~~~~~~~~~
/home/mak/zephyrproject/zephyr/include/zephyr/logging/log.h:75:25: note: in expansion of macro 'Z_LOG'
   75 | #define LOG_DBG(...)    Z_LOG(LOG_LEVEL_DBG, __VA_ARGS__)
      |                         ^~~~~
/home/mak/zephyrproject/zephyr/subsys/net/lib/http/http_server_http1.c:333:9: note: in expansion of macro 'LOG_DBG'
  333 |         LOG_DBG("found %s, file size: %ld", fname, file_size);
      |         ^~~~~~~
/home/mak/zephyrproject/zephyr/subsys/net/lib/http/http_server_http1.c:333:41: note: format string is defined here
  333 |         LOG_DBG("found %s, file size: %ld", fname, file_size);
      |                                       ~~^
      |                                         |
      |                                         long int
      |                                       %d
```