### PR TITLE
boards: rak: Change to use sw controlled cs for rak11720

### DIFF
--- a/boards/rak/rak11720/rak11720.dts
+++ b/boards/rak/rak11720/rak11720.dts
@@ -90,6 +90,7 @@
 	compatible = "ambiq,spi";
 	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
+	cs-gpios = <&gpio0_31 1 GPIO_ACTIVE_LOW>;
 	clock-frequency = <DT_FREQ_M(1)>;
 	status = "okay";
 };

--- a/boards/rak/rak11720/rak11720_apollo3-pinctrl.dtsi
+++ b/boards/rak/rak11720/rak11720_apollo3-pinctrl.dtsi
@@ -69,66 +69,30 @@
 		group1 {
 			pinmux = <M0SCK_P5>, <M0MISO_P6>, <M0MOSI_P7>;
 		};
-		group2 {
-			pinmux = <NCE1_P1>;
-			drive-push-pull;
-			ambiq,iom-nce-module = <0>;
-			ambiq,iom-num = <0>;
-		};
 	};
 	spi1_default: spi1_default {
 		group1 {
 			pinmux = <M1SCK_P8>, <M1MISO_P9>, <M1MOSI_P10>;
-		};
-		group2 {
-			pinmux = <NCE11_P11>;
-			drive-push-pull;
-			ambiq,iom-nce-module = <1>;
-			ambiq,iom-num = <1>;
 		};
 	};
 	spi2_default: spi2_default {
 		group1 {
 			pinmux = <M2SCK_P27>, <M2MISO_P25>, <M2MOSI_P28>;
 		};
-		group2 {
-			pinmux = <NCE15_P15>;
-			drive-push-pull;
-			ambiq,iom-nce-module = <3>;
-			ambiq,iom-num = <2>;
-		};
 	};
 	spi3_default: spi3_default {
 		group1 {
 			pinmux = <M3SCK_P42>, <M3MISO_P43>, <M3MOSI_P38>;
-		};
-		group2 {
-			pinmux = <NCE12_P12>;
-			drive-push-pull;
-			ambiq,iom-nce-module = <0>;
-			ambiq,iom-num = <3>;
 		};
 	};
 	spi4_default: spi4_default {
 		group1 {
 			pinmux = <M4SCK_P39>, <M4MISO_P40>, <M4MOSI_P44>;
 		};
-		group2 {
-			pinmux = <NCE13_P13>;
-			drive-push-pull;
-			ambiq,iom-nce-module = <1>;
-			ambiq,iom-num = <4>;
-		};
 	};
 	spi5_default: spi5_default {
 		group1 {
 			pinmux = <M5SCK_P48>, <M5MISO_P49>, <M5MOSI_P47>;
-		};
-		group2 {
-			pinmux = <NCE16_P16>;
-			drive-push-pull;
-			ambiq,iom-nce-module = <0>;
-			ambiq,iom-num = <5>;
 		};
 	};
 


### PR DESCRIPTION
Added support for newly added Ambiq spi driver sw controlled spi cs pins.