### PR TITLE
mailmap: missing entry for Manuel Argüelles

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -61,6 +61,7 @@ Lixin Guo <lixinx.guo@intel.com>
 Łukasz Mazur <lukasz.mazur@hidglobal.com>
 Manuel Argüelles <manuel.arguelles@nxp.com>
 Manuel Argüelles <manuel.arguelles@nxp.com> <manuel.arguelles@coredumplabs.com>
+Manuel Argüelles <manuel.arguelles@nxp.com> <marguelles.dev@gmail.com>
 Marc Herbert <marc.herbert@intel.com> <46978960+marc-hb@users.noreply.github.com>
 Marin Jurjević <marin.jurjevic@hotmail.com>
 Mariusz Ryndzionek <mariusz.ryndzionek@firmwave.com>


### PR DESCRIPTION
Map contributions done using my private email address to my current work email address.