### PR TITLE
User defined hashmap key equality function

### DIFF
--- a/include/zephyr/sys/hash_map.h
+++ b/include/zephyr/sys/hash_map.h
@@ -76,7 +76,7 @@ extern "C" {
  * @param ... Variant-specific details for @p _config_type.
  */
 #define SYS_HASHMAP_DEFINE_STATIC_ADVANCED(_name, _api, _config_type, _data_type, _hash_func,      \
-					   _eq_funct, _alloc_func, ...)                            \
+					   _eq_func, _alloc_func, ...)                             \
 	static const struct _config_type _name##_config = __VA_ARGS__;                             \
 	static struct _data_type _name##_data;                                                     \
 	static struct sys_hashmap _name = {                                                        \

--- a/include/zephyr/sys/hash_map.h
+++ b/include/zephyr/sys/hash_map.h
@@ -33,7 +33,7 @@ extern "C" {
  *
  * Declare a Hashmap with control over advanced parameters.
  *
- * @note The allocator @p _alloc is used for allocating internal Hashmap
+ * @note The allocator @p _alloc_func is used for allocating internal Hashmap
  * entries and does not interact with any user-provided keys or values.
  *
  * @param _name Name of the Hashmap.
@@ -61,7 +61,7 @@ extern "C" {
  *
  * Declare a Hashmap statically with control over advanced parameters.
  *
- * @note The allocator @p _alloc is used for allocating internal Hashmap
+ * @note The allocator @p _alloc_func is used for allocating internal Hashmap
  * entries and does not interact with any user-provided keys or values.
  *
  * @param _name Name of the Hashmap.
@@ -177,6 +177,7 @@ static inline void sys_hashmap_clear(struct sys_hashmap *map, sys_hashmap_callba
  * @param key Key to associate with @p value
  * @param value Value to associate with @p key
  * @param old_value Location to store the value previously associated with @p key or `NULL`
+ *
  * @retval 0 if @p value was inserted for an existing key, in which case @p old_value will contain
  * the previous value
  * @retval 1 if a new entry was inserted for the @p key - @p value pair
@@ -285,6 +286,7 @@ static inline uint8_t sys_hashmap_load_factor(const struct sys_hashmap *map)
  * @brief Query the number of buckets used in @p map
  *
  * @param map Hashmap to query
+ *
  * @return Number of buckets used in @p map
  */
 static inline size_t sys_hashmap_num_buckets(const struct sys_hashmap *map)
@@ -310,6 +312,7 @@ static inline size_t sys_hashmap_num_buckets(const struct sys_hashmap *map)
  * @param grow true if an entry is to be added. false if an entry has been removed
  * @param num_reserved the number of reserved entries
  * @param[out] new_num_buckets variable Hashmap size
+ *
  * @return true if the Hashmap should be rehashed
  * @return false if the Hashmap should not be rehashed
  */

--- a/include/zephyr/sys/hash_map_api.h
+++ b/include/zephyr/sys/hash_map_api.h
@@ -72,6 +72,21 @@ static inline bool sys_hashmap_iterator_has_next(const struct sys_hashmap_iterat
 }
 
 /**
+ * @brief Equality function defined for elements of @ref sys_hashmap
+ *
+ * The Hashmap equality function allows storing arbitrary data in the uint64_t keys of the map.
+ * Similarly to what happens in other hashmap implementation by defining a custom hash and equality
+ * function you can store and retrieve elements of virtually every type.
+ *
+ * @param left Left element of the comparison.
+ * @param right Right element of the comparison.
+ *
+ * @retval true if left and right are equal
+ * @retval false if left and right are not equal
+ */
+typedef bool (*sys_hashmap_equal_t)(uint64_t left, uint64_t right);
+
+/**
  * @brief Allocator interface for @ref sys_hashmap
  *
  * The Hashmap allocator can be any allocator that behaves similarly to `realloc()` with the
@@ -127,6 +142,8 @@ typedef void (*sys_hashmap_clear_t)(struct sys_hashmap *map, sys_hashmap_callbac
  * @param key Key to associate with @p value
  * @param value Value to associate with @p key
  * @param old_value Location to store the value previously associated with @p key or `NULL`
+ * @param old_key Location to store a potential key that has the same hash
+ * and is equal to the key passed when checked using @ref sys_hashmap `eq_func`
  *
  * @retval 0 if @p value was inserted for an existing key, in which case @p old_value will contain
  * the previous value
@@ -134,21 +151,27 @@ typedef void (*sys_hashmap_clear_t)(struct sys_hashmap *map, sys_hashmap_callbac
  * @retval -ENOMEM if memory allocation failed
  */
 typedef int (*sys_hashmap_insert_t)(struct sys_hashmap *map, uint64_t key, uint64_t value,
-				    uint64_t *old_value);
+				    uint64_t *old_value, uint64_t *old_key);
 
 /**
  * @brief Remove an entry from a @ref sys_hashmap
  *
- * Erase the entry associated with key @p key, if one exists.
+ * Erase the entry associated with key @p key, if one exists. Returns references to the
+ * old value and the old key. The addition of the `eq_func` in @ref sys_hashmap
+ * could mean that the key used to access an entry is different from the key stored.
+ * The @p stored_key will hold a reference to the old key if present.
  *
  * @param map Hashmap to remove from
  * @param key Key to remove from @p map
  * @param value Location to store a potential value associated with @p key or `NULL`
+ * @param old_key Location to store a potential key that has the same hash
+ * and is equal to the key passed when checked using @ref sys_hashmap `eq_func`
  *
  * @retval true if @p map was modified as a result of this operation.
  * @retval false if @p map does not contain a value associated with @p key.
  */
-typedef bool (*sys_hashmap_remove_t)(struct sys_hashmap *map, uint64_t key, uint64_t *value);
+typedef bool (*sys_hashmap_remove_t)(struct sys_hashmap *map, uint64_t key, uint64_t *value,
+				     uint64_t *old_key);
 
 /**
  * @brief Get a value from a @ref sys_hashmap
@@ -215,8 +238,9 @@ struct sys_hashmap_config {
  */
 #define SYS_HASHMAP_CONFIG(_max_size, _load_factor)                                                \
 	{                                                                                          \
-		.max_size = (size_t)_max_size, .load_factor = (uint8_t)_load_factor,               \
-		.initial_n_buckets = NHPOT(DIV_ROUND_UP(100, _load_factor)),                   \
+		.max_size = (size_t)_max_size,                                                     \
+		.load_factor = (uint8_t)_load_factor,                                              \
+		.initial_n_buckets = NHPOT(DIV_ROUND_UP(100, _load_factor)),                       \
 	}
 
 /**

--- a/include/zephyr/sys/hash_map_api.h
+++ b/include/zephyr/sys/hash_map_api.h
@@ -62,6 +62,7 @@ struct sys_hashmap_iterator {
  * @brief Check if a Hashmap iterator has a next entry
  *
  * @param it Hashmap iterator
+ *
  * @return true if there is a next entry
  * @return false if there is no next entry
  */
@@ -126,6 +127,7 @@ typedef void (*sys_hashmap_clear_t)(struct sys_hashmap *map, sys_hashmap_callbac
  * @param key Key to associate with @p value
  * @param value Value to associate with @p key
  * @param old_value Location to store the value previously associated with @p key or `NULL`
+ *
  * @retval 0 if @p value was inserted for an existing key, in which case @p old_value will contain
  * the previous value
  * @retval 1 if a new entry was inserted for the @p key - @p value pair

--- a/include/zephyr/sys/hash_map_cxx.h
+++ b/include/zephyr/sys/hash_map_cxx.h
@@ -10,7 +10,8 @@
  * @brief C++ Hashmap
  *
  * This is a C wrapper around `std::unordered_map`. It is mainly used for
- * benchmarking purposes.
+ * benchmarking purposes. It doesn't make use of the custom hashing function
+ * or the custom equality function.
  *
  * @note Enable with @kconfig{CONFIG_SYS_HASH_MAP_CXX}
  */
@@ -37,12 +38,15 @@ extern "C" {
  *
  * @param _name Name of the Hashmap.
  * @param _hash_func Hash function pointer of type @ref sys_hash_func32_t. Currently ignored.
+ * @param _eq_func Equality function to compare hashmap keys @ref sys_hashmap_equal_t.
+ * Currently ignored.
  * @param _alloc_func Allocator function pointer of type @ref sys_hashmap_allocator_t.
  * @param ... Variant-specific details for @ref sys_hashmap_config.
  */
-#define SYS_HASHMAP_CXX_DEFINE_ADVANCED(_name, _hash_func, _alloc_func, ...)                       \
+#define SYS_HASHMAP_CXX_DEFINE_ADVANCED(_name, _hash_func, _eq_func, _alloc_func, ...)             \
 	SYS_HASHMAP_DEFINE_ADVANCED(_name, &sys_hashmap_cxx_api, sys_hashmap_config,               \
-				    sys_hashmap_data, _hash_func, _alloc_func, __VA_ARGS__)
+				    sys_hashmap_data, _hash_func, _eq_func, _alloc_func,           \
+				    __VA_ARGS__)
 
 /**
  * @brief Declare a C++ Hashmap (advanced)
@@ -54,12 +58,15 @@ extern "C" {
  *
  * @param _name Name of the Hashmap.
  * @param _hash_func Hash function pointer of type @ref sys_hash_func32_t. Currently ignored.
+ * @param _eq_func Equality function to compare hashmap keys @ref sys_hashmap_equal_t.
+ * Currently ignored.
  * @param _alloc_func Allocator function pointer of type @ref sys_hashmap_allocator_t.
  * @param ... Details for @ref sys_hashmap_config.
  */
-#define SYS_HASHMAP_CXX_DEFINE_STATIC_ADVANCED(_name, _hash_func, _alloc_func, ...)                \
+#define SYS_HASHMAP_CXX_DEFINE_STATIC_ADVANCED(_name, _hash_func, _eq_func, _alloc_func, ...)      \
 	SYS_HASHMAP_DEFINE_STATIC_ADVANCED(_name, &sys_hashmap_cxx_api, sys_hashmap_config,        \
-					   sys_hashmap_data, _hash_func, _alloc_func, __VA_ARGS__)
+					   sys_hashmap_data, _hash_func, _eq_func, _alloc_func,    \
+					   __VA_ARGS__)
 
 /**
  * @brief Declare a C++ Hashmap statically
@@ -70,7 +77,8 @@ extern "C" {
  */
 #define SYS_HASHMAP_CXX_DEFINE_STATIC(_name)                                                       \
 	SYS_HASHMAP_CXX_DEFINE_STATIC_ADVANCED(                                                    \
-		_name, sys_hash32, SYS_HASHMAP_DEFAULT_ALLOCATOR,                                  \
+		_name, sys_hash32, SYS_HASHMAP_DEFAULT_EQUALITY_FUNCTION,                          \
+		SYS_HASHMAP_DEFAULT_ALLOCATOR,                                                     \
 		SYS_HASHMAP_CONFIG(SIZE_MAX, SYS_HASHMAP_DEFAULT_LOAD_FACTOR))
 
 /**
@@ -82,16 +90,18 @@ extern "C" {
  */
 #define SYS_HASHMAP_CXX_DEFINE(_name)                                                              \
 	SYS_HASHMAP_CXX_DEFINE_ADVANCED(                                                           \
-		_name, sys_hash32, SYS_HASHMAP_DEFAULT_ALLOCATOR,                                  \
+		_name, sys_hash32, SYS_HASHMAP_DEFAULT_EQUALITY_FUNCTION,                          \
+		SYS_HASHMAP_DEFAULT_ALLOCATOR,                                                     \
 		SYS_HASHMAP_CONFIG(SIZE_MAX, SYS_HASHMAP_DEFAULT_LOAD_FACTOR))
 
 #ifdef CONFIG_SYS_HASH_MAP_CHOICE_CXX
-#define SYS_HASHMAP_DEFAULT_DEFINE(_name)	 SYS_HASHMAP_CXX_DEFINE(_name)
+#define SYS_HASHMAP_DEFAULT_DEFINE(_name)        SYS_HASHMAP_CXX_DEFINE(_name)
 #define SYS_HASHMAP_DEFAULT_DEFINE_STATIC(_name) SYS_HASHMAP_CXX_DEFINE_STATIC(_name)
-#define SYS_HASHMAP_DEFAULT_DEFINE_ADVANCED(_name, _hash_func, _alloc_func, ...)                   \
-	SYS_HASHMAP_CXX_DEFINE_ADVANCED(_name, _hash_func, _alloc_func, __VA_ARGS__)
-#define SYS_HASHMAP_DEFAULT_DEFINE_STATIC_ADVANCED(_name, _hash_func, _alloc_func, ...)            \
-	SYS_HASHMAP_CXX_DEFINE_STATIC_ADVANCED(_name, _hash_func, _alloc_func, __VA_ARGS__)
+#define SYS_HASHMAP_DEFAULT_DEFINE_ADVANCED(_name, _hash_func, _eq_func, _alloc_func, ...)         \
+	SYS_HASHMAP_CXX_DEFINE_ADVANCED(_name, _hash_func, _eq_func, _alloc_func, __VA_ARGS__)
+#define SYS_HASHMAP_DEFAULT_DEFINE_STATIC_ADVANCED(_name, _hash_func, _eq_func, _alloc_func, ...)  \
+	SYS_HASHMAP_CXX_DEFINE_STATIC_ADVANCED(_name, _hash_func, _eq_func, _alloc_func,           \
+					       __VA_ARGS__)
 #endif
 
 extern const struct sys_hashmap_api sys_hashmap_cxx_api;

--- a/include/zephyr/sys/hash_map_cxx.h
+++ b/include/zephyr/sys/hash_map_cxx.h
@@ -36,7 +36,7 @@ extern "C" {
  * entries and does not interact with any user-provided keys or values.
  *
  * @param _name Name of the Hashmap.
- * @param _hash_func Hash function pointer of type @ref sys_hash_func32_t.
+ * @param _hash_func Hash function pointer of type @ref sys_hash_func32_t. Currently ignored.
  * @param _alloc_func Allocator function pointer of type @ref sys_hashmap_allocator_t.
  * @param ... Variant-specific details for @ref sys_hashmap_config.
  */
@@ -53,7 +53,7 @@ extern "C" {
  * entries and does not interact with any user-provided keys or values.
  *
  * @param _name Name of the Hashmap.
- * @param _hash_func Hash function pointer of type @ref sys_hash_func32_t.
+ * @param _hash_func Hash function pointer of type @ref sys_hash_func32_t. Currently ignored.
  * @param _alloc_func Allocator function pointer of type @ref sys_hashmap_allocator_t.
  * @param ... Details for @ref sys_hashmap_config.
  */

--- a/include/zephyr/sys/hash_map_oa_lp.h
+++ b/include/zephyr/sys/hash_map_oa_lp.h
@@ -41,12 +41,14 @@ struct sys_hashmap_oa_lp_data {
  *
  * @param _name Name of the Hashmap.
  * @param _hash_func Hash function pointer of type @ref sys_hash_func32_t.
+ * @param _eq_func Equality function to compare hashmap keys @ref sys_hashmap_equal_t.
  * @param _alloc_func Allocator function pointer of type @ref sys_hashmap_allocator_t.
  * @param ... Variant-specific details for @ref sys_hashmap_config.
  */
-#define SYS_HASHMAP_OA_LP_DEFINE_ADVANCED(_name, _hash_func, _alloc_func, ...)                     \
+#define SYS_HASHMAP_OA_LP_DEFINE_ADVANCED(_name, _hash_func, _eq_func, _alloc_func, ...)           \
 	SYS_HASHMAP_DEFINE_ADVANCED(_name, &sys_hashmap_oa_lp_api, sys_hashmap_config,             \
-				    sys_hashmap_oa_lp_data, _hash_func, _alloc_func, __VA_ARGS__)
+				    sys_hashmap_oa_lp_data, _hash_func, _eq_func, _alloc_func,     \
+				    __VA_ARGS__)
 
 /**
  * @brief Declare a Open Addressing Linear Probe Hashmap (advanced)
@@ -58,13 +60,14 @@ struct sys_hashmap_oa_lp_data {
  *
  * @param _name Name of the Hashmap.
  * @param _hash_func Hash function pointer of type @ref sys_hash_func32_t.
+ * @param _eq_func Equality function to compare hashmap keys @ref sys_hashmap_equal_t.
  * @param _alloc_func Allocator function pointer of type @ref sys_hashmap_allocator_t.
  * @param ... Details for @ref sys_hashmap_config.
  */
-#define SYS_HASHMAP_OA_LP_DEFINE_STATIC_ADVANCED(_name, _hash_func, _alloc_func, ...)              \
+#define SYS_HASHMAP_OA_LP_DEFINE_STATIC_ADVANCED(_name, _hash_func, _eq_func, _alloc_func, ...)    \
 	SYS_HASHMAP_DEFINE_STATIC_ADVANCED(_name, &sys_hashmap_oa_lp_api, sys_hashmap_config,      \
-					   sys_hashmap_oa_lp_data, _hash_func, _alloc_func,        \
-					   __VA_ARGS__)
+					   sys_hashmap_oa_lp_data, _hash_func, _eq_func,           \
+					   _alloc_func, __VA_ARGS__)
 
 /**
  * @brief Declare a Open Addressing Linear Probe Hashmap statically
@@ -75,7 +78,8 @@ struct sys_hashmap_oa_lp_data {
  */
 #define SYS_HASHMAP_OA_LP_DEFINE_STATIC(_name)                                                     \
 	SYS_HASHMAP_OA_LP_DEFINE_STATIC_ADVANCED(                                                  \
-		_name, sys_hash32, SYS_HASHMAP_DEFAULT_ALLOCATOR,                                  \
+		_name, sys_hash32, SYS_HASHMAP_DEFAULT_EQUALITY_FUNCTION,                          \
+		SYS_HASHMAP_DEFAULT_ALLOCATOR,                                                     \
 		SYS_HASHMAP_CONFIG(SIZE_MAX, SYS_HASHMAP_DEFAULT_LOAD_FACTOR))
 
 /**
@@ -87,16 +91,18 @@ struct sys_hashmap_oa_lp_data {
  */
 #define SYS_HASHMAP_OA_LP_DEFINE(_name)                                                            \
 	SYS_HASHMAP_OA_LP_DEFINE_ADVANCED(                                                         \
-		_name, sys_hash32, SYS_HASHMAP_DEFAULT_ALLOCATOR,                                  \
+		_name, sys_hash32, SYS_HASHMAP_DEFAULT_EQUALITY_FUNCTION,                          \
+		SYS_HASHMAP_DEFAULT_ALLOCATOR,                                                     \
 		SYS_HASHMAP_CONFIG(SIZE_MAX, SYS_HASHMAP_DEFAULT_LOAD_FACTOR))
 
 #ifdef CONFIG_SYS_HASH_MAP_CHOICE_OA_LP
-#define SYS_HASHMAP_DEFAULT_DEFINE(_name)	 SYS_HASHMAP_OA_LP_DEFINE(_name)
+#define SYS_HASHMAP_DEFAULT_DEFINE(_name)        SYS_HASHMAP_OA_LP_DEFINE(_name)
 #define SYS_HASHMAP_DEFAULT_DEFINE_STATIC(_name) SYS_HASHMAP_OA_LP_DEFINE_STATIC(_name)
-#define SYS_HASHMAP_DEFAULT_DEFINE_ADVANCED(_name, _hash_func, _alloc_func, ...)                   \
-	SYS_HASHMAP_OA_LP_DEFINE_ADVANCED(_name, _hash_func, _alloc_func, __VA_ARGS__)
-#define SYS_HASHMAP_DEFAULT_DEFINE_STATIC_ADVANCED(_name, _hash_func, _alloc_func, ...)            \
-	SYS_HASHMAP_OA_LP_DEFINE_STATIC_ADVANCED(_name, _hash_func, _alloc_func, __VA_ARGS__)
+#define SYS_HASHMAP_DEFAULT_DEFINE_ADVANCED(_name, _hash_func, _eq_func, _alloc_func, ...)         \
+	SYS_HASHMAP_OA_LP_DEFINE_ADVANCED(_name, _hash_func, _eq_func, _alloc_func, __VA_ARGS__)
+#define SYS_HASHMAP_DEFAULT_DEFINE_STATIC_ADVANCED(_name, _hash_func, _eq_func, _alloc_func, ...)  \
+	SYS_HASHMAP_OA_LP_DEFINE_STATIC_ADVANCED(_name, _hash_func, _eq_func, _alloc_func,         \
+						 __VA_ARGS__)
 #endif
 
 extern const struct sys_hashmap_api sys_hashmap_oa_lp_api;

--- a/include/zephyr/sys/hash_map_sc.h
+++ b/include/zephyr/sys/hash_map_sc.h
@@ -37,12 +37,14 @@ extern "C" {
  *
  * @param _name Name of the Hashmap.
  * @param _hash_func Hash function pointer of type @ref sys_hash_func32_t.
+ * @param _eq_func Equality function to compare hashmap keys @ref sys_hashmap_equal_t.
  * @param _alloc_func Allocator function pointer of type @ref sys_hashmap_allocator_t.
  * @param ... Details for @ref sys_hashmap_config.
  */
-#define SYS_HASHMAP_SC_DEFINE_ADVANCED(_name, _hash_func, _alloc_func, ...)                        \
+#define SYS_HASHMAP_SC_DEFINE_ADVANCED(_name, _hash_func, _eq_func, _alloc_func, ...)              \
 	SYS_HASHMAP_DEFINE_ADVANCED(_name, &sys_hashmap_sc_api, sys_hashmap_config,                \
-				    sys_hashmap_data, _hash_func, _alloc_func, __VA_ARGS__)
+				    sys_hashmap_data, _hash_func, _eq_func, _alloc_func,           \
+				    __VA_ARGS__)
 
 /**
  * @brief Declare a Separate Chaining Hashmap (advanced)
@@ -54,12 +56,14 @@ extern "C" {
  *
  * @param _name Name of the Hashmap.
  * @param _hash_func Hash function pointer of type @ref sys_hash_func32_t.
+ * @param _eq_func Equality function to compare hashmap keys @ref sys_hashmap_equal_t.
  * @param _alloc_func Allocator function pointer of type @ref sys_hashmap_allocator_t.
  * @param ... Details for @ref sys_hashmap_config.
  */
-#define SYS_HASHMAP_SC_DEFINE_STATIC_ADVANCED(_name, _hash_func, _alloc_func, ...)                 \
+#define SYS_HASHMAP_SC_DEFINE_STATIC_ADVANCED(_name, _hash_func, _eq_func, _alloc_func, ...)       \
 	SYS_HASHMAP_DEFINE_STATIC_ADVANCED(_name, &sys_hashmap_sc_api, sys_hashmap_config,         \
-					   sys_hashmap_data, _hash_func, _alloc_func, __VA_ARGS__)
+					   sys_hashmap_data, _hash_func, _eq_func, _alloc_func,    \
+					   __VA_ARGS__)
 
 /**
  * @brief Declare a Separate Chaining Hashmap statically
@@ -70,7 +74,8 @@ extern "C" {
  */
 #define SYS_HASHMAP_SC_DEFINE_STATIC(_name)                                                        \
 	SYS_HASHMAP_SC_DEFINE_STATIC_ADVANCED(                                                     \
-		_name, sys_hash32, SYS_HASHMAP_DEFAULT_ALLOCATOR,                                  \
+		_name, sys_hash32, SYS_HASHMAP_DEFAULT_EQUALITY_FUNCTION,                          \
+		SYS_HASHMAP_DEFAULT_ALLOCATOR,                                                     \
 		SYS_HASHMAP_CONFIG(SIZE_MAX, SYS_HASHMAP_DEFAULT_LOAD_FACTOR))
 
 /**
@@ -82,16 +87,18 @@ extern "C" {
  */
 #define SYS_HASHMAP_SC_DEFINE(_name)                                                               \
 	SYS_HASHMAP_SC_DEFINE_ADVANCED(                                                            \
-		_name, sys_hash32, SYS_HASHMAP_DEFAULT_ALLOCATOR,                                  \
+		_name, sys_hash32, SYS_HASHMAP_DEFAULT_EQUALITY_FUNCTION,                          \
+		SYS_HASHMAP_DEFAULT_ALLOCATOR,                                                     \
 		SYS_HASHMAP_CONFIG(SIZE_MAX, SYS_HASHMAP_DEFAULT_LOAD_FACTOR))
 
 #ifdef CONFIG_SYS_HASH_MAP_CHOICE_SC
-#define SYS_HASHMAP_DEFAULT_DEFINE(_name)	 SYS_HASHMAP_SC_DEFINE(_name)
+#define SYS_HASHMAP_DEFAULT_DEFINE(_name)        SYS_HASHMAP_SC_DEFINE(_name)
 #define SYS_HASHMAP_DEFAULT_DEFINE_STATIC(_name) SYS_HASHMAP_SC_DEFINE_STATIC(_name)
-#define SYS_HASHMAP_DEFAULT_DEFINE_ADVANCED(_name, _hash_func, _alloc_func, ...)                   \
-	SYS_HASHMAP_SC_DEFINE_ADVANCED(_name, _hash_func, _alloc_func, __VA_ARGS__)
-#define SYS_HASHMAP_DEFAULT_DEFINE_STATIC_ADVANCED(_name, _hash_func, _alloc_func, ...)            \
-	SYS_HASHMAP_SC_DEFINE_STATIC_ADVANCED(_name, _hash_func, _alloc_func, __VA_ARGS__)
+#define SYS_HASHMAP_DEFAULT_DEFINE_ADVANCED(_name, _hash_func, _eq_func, _alloc_func, ...)         \
+	SYS_HASHMAP_SC_DEFINE_ADVANCED(_name, _hash_func, _eq_func, _alloc_func, __VA_ARGS__)
+#define SYS_HASHMAP_DEFAULT_DEFINE_STATIC_ADVANCED(_name, _hash_func, _eq_func, _alloc_func, ...)  \
+	SYS_HASHMAP_SC_DEFINE_STATIC_ADVANCED(_name, _hash_func, _eq_func, _alloc_func, __VA_ARGS__)
+
 #endif
 
 extern const struct sys_hashmap_api sys_hashmap_sc_api;

--- a/lib/hash/hash_map_cxx.cpp
+++ b/lib/hash/hash_map_cxx.cpp
@@ -67,7 +67,7 @@ static void sys_hashmap_cxx_clear(struct sys_hashmap *map, sys_hashmap_callback_
 }
 
 static int sys_hashmap_cxx_insert(struct sys_hashmap *map, uint64_t key, uint64_t value,
-				  uint64_t *old_value)
+				  uint64_t *old_value, uint64_t *old_key)
 {
 	cxx_map *umap = static_cast<cxx_map *>(map->data->buckets);
 
@@ -78,15 +78,20 @@ static int sys_hashmap_cxx_insert(struct sys_hashmap *map, uint64_t key, uint64_
 	}
 
 	auto it = umap->find(key);
-	if (it != umap->end() && old_value != nullptr) {
-		*old_value = it->second;
+	if (it != umap->end()) {
+		if (old_value != nullptr) {
+			*old_value = it->second;
+		}
+		if (old_key != nullptr) {
+			*old_key = it->first;
+		}
 		it->second = value;
 		return 0;
 	}
 
 	try {
 		(*umap)[key] = value;
-	} catch(...) {
+	} catch (...) {
 		return -ENOMEM;
 	}
 
@@ -96,7 +101,8 @@ static int sys_hashmap_cxx_insert(struct sys_hashmap *map, uint64_t key, uint64_
 	return 1;
 }
 
-static bool sys_hashmap_cxx_remove(struct sys_hashmap *map, uint64_t key, uint64_t *value)
+static bool sys_hashmap_cxx_remove(struct sys_hashmap *map, uint64_t key, uint64_t *value,
+				   uint64_t *old_key)
 {
 	cxx_map *umap = static_cast<cxx_map *>(map->data->buckets);
 
@@ -111,6 +117,9 @@ static bool sys_hashmap_cxx_remove(struct sys_hashmap *map, uint64_t key, uint64
 
 	if (value != nullptr) {
 		*value = it->second;
+	}
+	if (old_key != nullptr) {
+		*old_key = it->first;
 	}
 
 	umap->erase(key);

--- a/samples/basic/hash_map/src/main.c
+++ b/samples/basic/hash_map/src/main.c
@@ -36,7 +36,7 @@ int main(void)
 	do {
 		for (i = 0; i < CONFIG_TEST_LIB_HASH_MAP_MAX_ENTRIES; ++i) {
 
-			ires = sys_hashmap_insert(&map, i, i, NULL);
+			ires = sys_hashmap_insert(&map, i, i, NULL, NULL);
 			if (ires < 0) {
 				break;
 			}
@@ -54,7 +54,7 @@ int main(void)
 
 		for (i = 0; i < stats.max_size; ++i) {
 
-			ires = sys_hashmap_insert(&map, i, stats.max_size - i, NULL);
+			ires = sys_hashmap_insert(&map, i, stats.max_size - i, NULL, NULL);
 			__ASSERT(ires == 0, "Failed to replace %zu", i);
 			++stats.n_replace;
 
@@ -66,7 +66,7 @@ int main(void)
 		}
 
 		for (i = stats.max_size; i > 0; --i) {
-			bres = sys_hashmap_remove(&map, i - 1, NULL);
+			bres = sys_hashmap_remove(&map, i - 1, NULL, NULL);
 			__ASSERT(bres, "Failed to remove %zu", i - 1);
 			++stats.n_remove;
 

--- a/tests/lib/hash_map/CMakeLists.txt
+++ b/tests/lib/hash_map/CMakeLists.txt
@@ -8,3 +8,4 @@ project(hash_map)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
+target_include_directories(app PRIVATE src)

--- a/tests/lib/hash_map/Kconfig
+++ b/tests/lib/hash_map/Kconfig
@@ -21,4 +21,12 @@ config TEST_LIB_HASH_MAP_MAX_ENTRIES
 	  For native_sim, the number of entries can be configured
 	  independently of the arena size since the native libc is used.
 
+config TEST_USE_CUSTOM_EQ_FUNC
+	bool "Use a custom equality function"
+	depends on BASE64
+	help
+	  Run tests on an hashmap using a custom equality function.
+	  This helps to cover edgecases specific to hashmaps that have the eq_func
+	  different from the default one that performs a simple == comparison.
+
 source "Kconfig.zephyr"

--- a/tests/lib/hash_map/src/_main.c
+++ b/tests/lib/hash_map/src/_main.c
@@ -4,32 +4,68 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <stdlib.h>
-
-#include <zephyr/ztest.h>
-#include <zephyr/sys/hash_map.h>
-
 #include "_main.h"
 
-SYS_HASHMAP_DEFINE(map);
-SYS_HASHMAP_DEFAULT_DEFINE_ADVANCED(custom_load_factor_map, sys_hash32,
-				    SYS_HASHMAP_DEFAULT_EQUALITY_FUNCTION,
+#include <stdint.h>
+
+#include <zephyr/sys/hash_map.h>
+#include <zephyr/ztest.h>
+
+#ifdef CONFIG_TEST_USE_CUSTOM_EQ_FUNC
+/* only valid pointers to char array must be stored in these maps, anything else will break */
+#define EQ_FUNC eq_string
+#define HASH_FUNC hash_string
+#else
+#define EQ_FUNC SYS_HASHMAP_DEFAULT_EQUALITY_FUNCTION
+#define HASH_FUNC sys_hash32
+#endif
+
+SYS_HASHMAP_DEFAULT_DEFINE_ADVANCED(map, HASH_FUNC, EQ_FUNC,
+				    SYS_HASHMAP_DEFAULT_ALLOCATOR,
+				    SYS_HASHMAP_CONFIG(SIZE_MAX, SYS_HASHMAP_DEFAULT_LOAD_FACTOR));
+SYS_HASHMAP_DEFAULT_DEFINE_ADVANCED(custom_load_factor_map, HASH_FUNC,
+				    EQ_FUNC,
 				    SYS_HASHMAP_DEFAULT_ALLOCATOR,
 				    SYS_HASHMAP_CONFIG(SIZE_MAX, CUSTOM_LOAD_FACTOR));
 
+static char **indices;
+
+char *get_string_index(uint64_t key)
+{
+	return indices[key];
+}
+
 static void *setup(void)
 {
+#if defined(CONFIG_TEST_USE_CUSTOM_EQ_FUNC)
+	printk("Running using custom equality function (CONFIG_TEST_USE_CUSTOM_EQ_FUNC set)\n");
+	indices = calloc(MANY, sizeof(char *));
+	for (uint64_t i = 0; i < MANY; ++i) {
+		indices[i] = alloc_string_index(i);
+	}
+#endif
+
 	printk("CONFIG_TEST_LIB_HASH_MAP_MAX_ENTRIES: %u\n", CONFIG_TEST_LIB_HASH_MAP_MAX_ENTRIES);
 
 	return NULL;
+}
+
+static void teardown(void *arg)
+{
+#if defined(CONFIG_TEST_USE_CUSTOM_EQ_FUNC)
+	for (size_t i = 0; i < MANY; ++i) {
+		free(indices[i]);
+	}
+	free(indices);
+#endif
 }
 
 static void after(void *arg)
 {
 	ARG_UNUSED(arg);
 
-	(void)sys_hashmap_clear(&map, NULL, NULL);
-	(void)sys_hashmap_clear(&custom_load_factor_map, NULL, NULL);
+	(void) sys_hashmap_clear(&map, NULL, NULL);
+	(void) sys_hashmap_clear(&custom_load_factor_map, NULL, NULL);
 }
 
-ZTEST_SUITE(hash_map, NULL, setup, NULL, after, NULL);
+ZTEST_SUITE(hash_map, NULL, setup, NULL, after, teardown);

--- a/tests/lib/hash_map/src/_main.c
+++ b/tests/lib/hash_map/src/_main.c
@@ -12,7 +12,9 @@
 #include "_main.h"
 
 SYS_HASHMAP_DEFINE(map);
-SYS_HASHMAP_DEFAULT_DEFINE_ADVANCED(custom_load_factor_map, sys_hash32, realloc,
+SYS_HASHMAP_DEFAULT_DEFINE_ADVANCED(custom_load_factor_map, sys_hash32,
+				    SYS_HASHMAP_DEFAULT_EQUALITY_FUNCTION,
+				    SYS_HASHMAP_DEFAULT_ALLOCATOR,
 				    SYS_HASHMAP_CONFIG(SIZE_MAX, CUSTOM_LOAD_FACTOR));
 
 static void *setup(void)

--- a/tests/lib/hash_map/src/_main.h
+++ b/tests/lib/hash_map/src/_main.h
@@ -14,6 +14,43 @@
 
 extern struct sys_hashmap map;
 extern struct sys_hashmap custom_load_factor_map;
-extern struct sys_hashmap custom_hash_equality_map;
+
+uint32_t hash_string(const void *uint64_ptr_key, size_t len);
+bool eq_string(uint64_t key_left, uint64_t key_right);
+char *get_string_index(uint64_t key);
+
+#ifdef CONFIG_TEST_USE_CUSTOM_EQ_FUNC
+#include "string_map_helper.h"
+#define KEY_TYPE char *
+#define ALLOC_KEY(key) (alloc_string_index(key))
+#define FREE_KEY(key) (free(key))
+#define GET_KEY(key) (get_string_index(key))
+#define KEY_FORMAT "%s"
+#define GET_FUNC_NAME string_map_get
+#define INSERT_FUNC_NAME string_map_insert
+#define CONTAINS_KEY_FUNC_NAME string_map_contains_key
+#define REMOVE_FUNC_NAME string_map_remove
+#define FOREACH_FUNC_NAME string_map_foreach
+#define CLEAR_FUNC_NAME string_map_clear
+#else
+#define KEY_TYPE uint64_t
+#define ALLOC_KEY(key) (key)
+#define FREE_KEY(key) ((void) key)
+#define GET_KEY(key) (key)
+#define KEY_FORMAT "%zu"
+#define GET_FUNC_NAME sys_hashmap_get
+#define INSERT_FUNC_NAME sys_hashmap_insert
+#define CONTAINS_KEY_FUNC_NAME sys_hashmap_contains_key
+#define REMOVE_FUNC_NAME sys_hashmap_remove
+#define FOREACH_FUNC_NAME sys_hashmap_foreach
+#define CLEAR_FUNC_NAME sys_hashmap_clear
+#endif
+
+#define GET_FUNC(map, key, value) (GET_FUNC_NAME(map, GET_KEY(key), value))
+#define INSERT_FUNC(map, key, value, old_value, old_key)                                           \
+	(INSERT_FUNC_NAME(map, GET_KEY(key), value, old_value, old_key))
+#define CONTAINS_KEY_FUNC(map, key) (CONTAINS_KEY_FUNC_NAME(map, GET_KEY(key)))
+#define REMOVE_FUNC(map, key, old_value, old_key)                                                  \
+	(REMOVE_FUNC_NAME(map, GET_KEY(key), old_value, old_key))
 
 #endif

--- a/tests/lib/hash_map/src/_main.h
+++ b/tests/lib/hash_map/src/_main.h
@@ -9,10 +9,11 @@
 
 #include <zephyr/sys/hash_map.h>
 
-#define MANY		   CONFIG_TEST_LIB_HASH_MAP_MAX_ENTRIES
+#define MANY               CONFIG_TEST_LIB_HASH_MAP_MAX_ENTRIES
 #define CUSTOM_LOAD_FACTOR 42
 
 extern struct sys_hashmap map;
 extern struct sys_hashmap custom_load_factor_map;
+extern struct sys_hashmap custom_hash_equality_map;
 
 #endif

--- a/tests/lib/hash_map/src/clear.c
+++ b/tests/lib/hash_map/src/clear.c
@@ -12,10 +12,13 @@
 ZTEST(hash_map, test_clear_no_callback)
 {
 	const size_t N = 10;
+	BUILD_ASSERT(N <= MANY, "N has to be <= than MANY to"
+							 " be able to use preallocated string keys");
 
 	zassert_true(sys_hashmap_is_empty(&map));
+
 	for (size_t i = 0; i < N; ++i) {
-		zassert_equal(1, sys_hashmap_insert(&map, i, i, NULL, NULL));
+		zassert_equal(1, INSERT_FUNC(&map, i, i, NULL, NULL));
 	}
 
 	zassert_equal(N, sys_hashmap_size(&map));
@@ -24,6 +27,16 @@ ZTEST(hash_map, test_clear_no_callback)
 	zassert_true(sys_hashmap_is_empty(&map));
 }
 
+#ifdef CONFIG_TEST_USE_CUSTOM_EQ_FUNC
+static void clear_callback(char *key, uint64_t value, void *cookie)
+{
+	bool *cleared = (bool *)cookie;
+	uint64_t uint_key = get_key_index(key);
+
+	zassert_true(uint_key < 10);
+	cleared[uint_key] = true;
+}
+#else
 static void clear_callback(uint64_t key, uint64_t value, void *cookie)
 {
 	bool *cleared = (bool *)cookie;
@@ -31,22 +44,26 @@ static void clear_callback(uint64_t key, uint64_t value, void *cookie)
 	zassert_true(key < 10);
 	cleared[key] = true;
 }
+#endif
 
 ZTEST(hash_map, test_clear_callback)
 {
 	bool cleared[10] = {0};
+	BUILD_ASSERT(ARRAY_SIZE(cleared) <= MANY, "the size has to be <= than MANY"
+							 " to be able to use preallocated string keys");
 
 	zassert_true(sys_hashmap_is_empty(&map));
+
 	for (size_t i = 0; i < ARRAY_SIZE(cleared); ++i) {
-		zassert_equal(1, sys_hashmap_insert(&map, i, i, NULL, NULL));
+		zassert_equal(1, INSERT_FUNC(&map, i, i, NULL, NULL));
 	}
 
 	zassert_equal(ARRAY_SIZE(cleared), sys_hashmap_size(&map));
 
-	sys_hashmap_clear(&map, clear_callback, cleared);
+	CLEAR_FUNC_NAME(&map, clear_callback, cleared);
 	zassert_true(sys_hashmap_is_empty(&map));
 
 	for (size_t i = 0; i < ARRAY_SIZE(cleared); ++i) {
-		zassert_true(cleared[i], "entry %zu was not cleared", i + 1);
+		zassert_true(cleared[i], "entry " KEY_FORMAT " was not cleared", GET_KEY(i + 1));
 	}
 }

--- a/tests/lib/hash_map/src/clear.c
+++ b/tests/lib/hash_map/src/clear.c
@@ -15,7 +15,7 @@ ZTEST(hash_map, test_clear_no_callback)
 
 	zassert_true(sys_hashmap_is_empty(&map));
 	for (size_t i = 0; i < N; ++i) {
-		zassert_equal(1, sys_hashmap_insert(&map, i, i, NULL));
+		zassert_equal(1, sys_hashmap_insert(&map, i, i, NULL, NULL));
 	}
 
 	zassert_equal(N, sys_hashmap_size(&map));
@@ -38,7 +38,7 @@ ZTEST(hash_map, test_clear_callback)
 
 	zassert_true(sys_hashmap_is_empty(&map));
 	for (size_t i = 0; i < ARRAY_SIZE(cleared); ++i) {
-		zassert_equal(1, sys_hashmap_insert(&map, i, i, NULL));
+		zassert_equal(1, sys_hashmap_insert(&map, i, i, NULL, NULL));
 	}
 
 	zassert_equal(ARRAY_SIZE(cleared), sys_hashmap_size(&map));

--- a/tests/lib/hash_map/src/empty.c
+++ b/tests/lib/hash_map/src/empty.c
@@ -17,6 +17,6 @@ ZTEST(hash_map, test_empty)
 	zassert_true(sys_hashmap_is_empty(&map));
 
 	/* test size 1 */
-	zassume_equal(1, sys_hashmap_insert(&map, 1, 1, NULL, NULL));
+	zassume_equal(1, INSERT_FUNC(&map, 1, 1, NULL, NULL));
 	zassert_false(sys_hashmap_is_empty(&map));
 }

--- a/tests/lib/hash_map/src/empty.c
+++ b/tests/lib/hash_map/src/empty.c
@@ -17,6 +17,6 @@ ZTEST(hash_map, test_empty)
 	zassert_true(sys_hashmap_is_empty(&map));
 
 	/* test size 1 */
-	zassume_equal(1, sys_hashmap_insert(&map, 1, 1, NULL));
+	zassume_equal(1, sys_hashmap_insert(&map, 1, 1, NULL, NULL));
 	zassert_false(sys_hashmap_is_empty(&map));
 }

--- a/tests/lib/hash_map/src/foreach.c
+++ b/tests/lib/hash_map/src/foreach.c
@@ -4,11 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdint.h>
+
 #include <zephyr/ztest.h>
 #include <zephyr/sys/hash_map.h>
 
 #include "_main.h"
 
+#ifdef CONFIG_TEST_USE_CUSTOM_EQ_FUNC
+static void foreach_callback(char *key, uint64_t value, void *cookie)
+{
+	bool *called = (bool *)cookie;
+	uint64_t uint_key = get_key_index(key);
+
+	zassert_true(uint_key < 10);
+	called[uint_key] = true;
+}
+#else
 static void foreach_callback(uint64_t key, uint64_t value, void *cookie)
 {
 	bool *called = (bool *)cookie;
@@ -16,21 +28,25 @@ static void foreach_callback(uint64_t key, uint64_t value, void *cookie)
 	zassert_true(key < 10);
 	called[key] = true;
 }
+#endif
 
 ZTEST(hash_map, test_foreach)
 {
 	bool called[10] = {0};
 
+	BUILD_ASSERT(ARRAY_SIZE(called) <= MANY, "the size has to be <= than MANY"
+							" to be able to use preallocated string keys");
+
 	zassert_true(sys_hashmap_is_empty(&map));
 
 	for (size_t i = 0; i < ARRAY_SIZE(called); ++i) {
-		zassert_equal(1, sys_hashmap_insert(&map, i, i, NULL, NULL));
+		zassert_equal(1, INSERT_FUNC(&map, i, i, NULL, NULL));
 	}
 
 	zassert_equal(ARRAY_SIZE(called), sys_hashmap_size(&map));
 
-	sys_hashmap_foreach(&map, foreach_callback, called);
+	FOREACH_FUNC_NAME(&map, foreach_callback, called);
 	for (size_t i = 0; i < ARRAY_SIZE(called); ++i) {
-		zassert_true(called[i], "entry %zu was not called", i + 1);
+		zassert_true(called[i], "entry " KEY_FORMAT " was not called", GET_KEY(i + 1));
 	}
 }

--- a/tests/lib/hash_map/src/foreach.c
+++ b/tests/lib/hash_map/src/foreach.c
@@ -24,7 +24,7 @@ ZTEST(hash_map, test_foreach)
 	zassert_true(sys_hashmap_is_empty(&map));
 
 	for (size_t i = 0; i < ARRAY_SIZE(called); ++i) {
-		zassert_equal(1, sys_hashmap_insert(&map, i, i, NULL));
+		zassert_equal(1, sys_hashmap_insert(&map, i, i, NULL, NULL));
 	}
 
 	zassert_equal(ARRAY_SIZE(called), sys_hashmap_size(&map));

--- a/tests/lib/hash_map/src/get.c
+++ b/tests/lib/hash_map/src/get.c
@@ -9,24 +9,26 @@
 
 #include "_main.h"
 
-ZTEST(hash_map, test_get_true)
-{
+ZTEST(hash_map, test_get_true) {
 	int ret;
 	uint64_t value = 0x42;
 
 	zassert_true(sys_hashmap_is_empty(&map));
-	zassert_equal(1, sys_hashmap_insert(&map, 0, 0, NULL, NULL));
-	zassert_true(sys_hashmap_get(&map, 0, NULL));
-	zassert_true(sys_hashmap_get(&map, 0, &value));
+
+	zassert_equal(1, INSERT_FUNC(&map, 0, 0, NULL, NULL));
+	zassert_true(GET_FUNC(&map, 0, NULL));
+	zassert_true(GET_FUNC(&map, 0, &value));
 	zassert_equal(0, value);
 
 	for (size_t i = 1; i < MANY; ++i) {
-		ret = sys_hashmap_insert(&map, i, i, NULL, NULL);
-		zassert_equal(1, ret, "failed to insert (%zu, %zu): %d", i, i, ret);
+		ret = INSERT_FUNC(&map, i, i, NULL, NULL);
+
+		zassert_equal(1, ret, "failed to insert (" KEY_FORMAT ", %zu): %d",
+									GET_KEY(i), i, ret);
 	}
 
 	for (size_t i = 0; i < MANY; ++i) {
-		zassert_true(sys_hashmap_get(&map, i, NULL));
+		zassert_true(GET_FUNC(&map, i, NULL));
 	}
 }
 
@@ -37,13 +39,21 @@ ZTEST(hash_map, test_get_false)
 
 	zassert_true(sys_hashmap_is_empty(&map));
 
-	zassert_false(sys_hashmap_get(&map, 73, &value));
+	KEY_TYPE key_empty = ALLOC_KEY(73);
+
+	zassert_false(GET_FUNC_NAME(&map, key_empty, &value));
 	zassert_equal(value, 0x42);
+	FREE_KEY(key_empty);
 
 	for (size_t i = 0; i < MANY; ++i) {
-		ret = sys_hashmap_insert(&map, i, i, NULL, NULL);
-		zassert_equal(1, ret, "failed to insert (%zu, %zu): %d", i, i, ret);
+		ret = INSERT_FUNC(&map, i, i, NULL, NULL);
+
+		zassert_equal(1, ret, "failed to insert (" KEY_FORMAT ", %zu): %d",
+									GET_KEY(i), i, ret);
 	}
 
-	zassert_false(sys_hashmap_get(&map, 0x4242424242424242ULL, NULL));
+	KEY_TYPE key_not_exist = ALLOC_KEY(0x4242424242424242ULL);
+
+	zassert_false(GET_FUNC_NAME(&map, key_not_exist, NULL));
+	FREE_KEY(key_not_exist);
 }

--- a/tests/lib/hash_map/src/get.c
+++ b/tests/lib/hash_map/src/get.c
@@ -15,13 +15,13 @@ ZTEST(hash_map, test_get_true)
 	uint64_t value = 0x42;
 
 	zassert_true(sys_hashmap_is_empty(&map));
-	zassert_equal(1, sys_hashmap_insert(&map, 0, 0, NULL));
+	zassert_equal(1, sys_hashmap_insert(&map, 0, 0, NULL, NULL));
 	zassert_true(sys_hashmap_get(&map, 0, NULL));
 	zassert_true(sys_hashmap_get(&map, 0, &value));
 	zassert_equal(0, value);
 
 	for (size_t i = 1; i < MANY; ++i) {
-		ret = sys_hashmap_insert(&map, i, i, NULL);
+		ret = sys_hashmap_insert(&map, i, i, NULL, NULL);
 		zassert_equal(1, ret, "failed to insert (%zu, %zu): %d", i, i, ret);
 	}
 
@@ -41,7 +41,7 @@ ZTEST(hash_map, test_get_false)
 	zassert_equal(value, 0x42);
 
 	for (size_t i = 0; i < MANY; ++i) {
-		ret = sys_hashmap_insert(&map, i, i, NULL);
+		ret = sys_hashmap_insert(&map, i, i, NULL, NULL);
 		zassert_equal(1, ret, "failed to insert (%zu, %zu): %d", i, i, ret);
 	}
 

--- a/tests/lib/hash_map/src/insert.c
+++ b/tests/lib/hash_map/src/insert.c
@@ -15,13 +15,20 @@ ZTEST(hash_map, test_insert_no_replacement)
 {
 	zassert_true(sys_hashmap_is_empty(&map));
 
-	zassert_equal(1, sys_hashmap_insert(&map, 1, 1, NULL, NULL));
-	zassert_equal(1, sys_hashmap_size(&map));
-	zassert_true(sys_hashmap_contains_key(&map, 1));
+	KEY_TYPE key1 = ALLOC_KEY(1);
 
-	zassert_equal(1, sys_hashmap_insert(&map, 2, 2, NULL, NULL));
+	zassert_equal(1, INSERT_FUNC_NAME(&map, key1, 1, NULL, NULL));
+	zassert_equal(1, sys_hashmap_size(&map));
+	zassert_true(CONTAINS_KEY_FUNC_NAME(&map, key1));
+
+	KEY_TYPE key2 = ALLOC_KEY(2);
+
+	zassert_equal(1, INSERT_FUNC_NAME(&map, key2, 2, NULL, NULL));
 	zassert_equal(2, sys_hashmap_size(&map));
-	zassert_true(sys_hashmap_contains_key(&map, 2));
+	zassert_true(CONTAINS_KEY_FUNC_NAME(&map, key2));
+
+	FREE_KEY(key1);
+	FREE_KEY(key2);
 }
 
 ZTEST(hash_map, test_insert_replacement)
@@ -30,15 +37,20 @@ ZTEST(hash_map, test_insert_replacement)
 
 	zassert_true(sys_hashmap_is_empty(&map));
 
-	zassert_equal(1, sys_hashmap_insert(&map, 1, 1, NULL, NULL));
+	KEY_TYPE key1 = ALLOC_KEY(1);
+
+	zassert_equal(1, INSERT_FUNC_NAME(&map, key1, 1, NULL, NULL));
 	zassert_equal(1, sys_hashmap_size(&map));
-	zassert_true(sys_hashmap_contains_key(&map, 1));
+	zassert_true(CONTAINS_KEY_FUNC_NAME(&map, key1));
 
 	old_value = 0x42;
-	zassert_equal(0, sys_hashmap_insert(&map, 1, 2, &old_value, NULL));
+
+	zassert_equal(0, INSERT_FUNC_NAME(&map, key1, 2, &old_value, NULL));
 	zassert_equal(1, old_value);
 	zassert_equal(1, sys_hashmap_size(&map));
-	zassert_true(sys_hashmap_contains_key(&map, 1));
+	zassert_true(CONTAINS_KEY_FUNC_NAME(&map, key1));
+
+	FREE_KEY(key1);
 }
 
 ZTEST(hash_map, test_insert_many)
@@ -48,12 +60,14 @@ ZTEST(hash_map, test_insert_many)
 	zassert_true(sys_hashmap_is_empty(&map));
 
 	for (size_t i = 0; i < MANY; ++i) {
-		ret = sys_hashmap_insert(&map, i, i, NULL, NULL);
-		zassert_equal(1, ret, "failed to insert (%zu, %zu): %d", i, i, ret);
+		ret = INSERT_FUNC(&map, i, i, NULL, NULL);
+
+		zassert_equal(1, ret, "failed to insert (" KEY_FORMAT ", %zu): %d",
+									GET_KEY(i), i, ret);
 		zassert_equal(i + 1, sys_hashmap_size(&map));
 	}
 
 	for (size_t i = 0; i < MANY; ++i) {
-		zassert_true(sys_hashmap_contains_key(&map, i));
+		zassert_true(CONTAINS_KEY_FUNC(&map, i));
 	}
 }

--- a/tests/lib/hash_map/src/insert.c
+++ b/tests/lib/hash_map/src/insert.c
@@ -15,11 +15,11 @@ ZTEST(hash_map, test_insert_no_replacement)
 {
 	zassert_true(sys_hashmap_is_empty(&map));
 
-	zassert_equal(1, sys_hashmap_insert(&map, 1, 1, NULL));
+	zassert_equal(1, sys_hashmap_insert(&map, 1, 1, NULL, NULL));
 	zassert_equal(1, sys_hashmap_size(&map));
 	zassert_true(sys_hashmap_contains_key(&map, 1));
 
-	zassert_equal(1, sys_hashmap_insert(&map, 2, 2, NULL));
+	zassert_equal(1, sys_hashmap_insert(&map, 2, 2, NULL, NULL));
 	zassert_equal(2, sys_hashmap_size(&map));
 	zassert_true(sys_hashmap_contains_key(&map, 2));
 }
@@ -30,12 +30,12 @@ ZTEST(hash_map, test_insert_replacement)
 
 	zassert_true(sys_hashmap_is_empty(&map));
 
-	zassert_equal(1, sys_hashmap_insert(&map, 1, 1, NULL));
+	zassert_equal(1, sys_hashmap_insert(&map, 1, 1, NULL, NULL));
 	zassert_equal(1, sys_hashmap_size(&map));
 	zassert_true(sys_hashmap_contains_key(&map, 1));
 
 	old_value = 0x42;
-	zassert_equal(0, sys_hashmap_insert(&map, 1, 2, &old_value));
+	zassert_equal(0, sys_hashmap_insert(&map, 1, 2, &old_value, NULL));
 	zassert_equal(1, old_value);
 	zassert_equal(1, sys_hashmap_size(&map));
 	zassert_true(sys_hashmap_contains_key(&map, 1));
@@ -48,7 +48,7 @@ ZTEST(hash_map, test_insert_many)
 	zassert_true(sys_hashmap_is_empty(&map));
 
 	for (size_t i = 0; i < MANY; ++i) {
-		ret = sys_hashmap_insert(&map, i, i, NULL);
+		ret = sys_hashmap_insert(&map, i, i, NULL, NULL);
 		zassert_equal(1, ret, "failed to insert (%zu, %zu): %d", i, i, ret);
 		zassert_equal(i + 1, sys_hashmap_size(&map));
 	}

--- a/tests/lib/hash_map/src/load_factor.c
+++ b/tests/lib/hash_map/src/load_factor.c
@@ -18,14 +18,14 @@ ZTEST(hash_map, test_load_factor_default)
 	zassert_equal(0, sys_hashmap_load_factor(&map));
 
 	for (size_t i = 0; i < MANY; ++i) {
-		ret = sys_hashmap_insert(&map, i, i, NULL, NULL);
+		ret = INSERT_FUNC(&map, i, i, NULL, NULL);
 		zassert_equal(1, ret, "failed to insert (%zu, %zu): %d", i, i, ret);
 		load_factor = sys_hashmap_load_factor(&map);
 		zassert_true(load_factor > 0 && load_factor <= SYS_HASHMAP_DEFAULT_LOAD_FACTOR);
 	}
 
 	for (size_t i = MANY; i > 0; --i) {
-		zassert_equal(true, sys_hashmap_remove(&map, i - 1, NULL, NULL));
+		zassert_equal(true, REMOVE_FUNC(&map, i - 1, NULL, NULL));
 		load_factor = sys_hashmap_load_factor(&map);
 		zassert_true(load_factor <= SYS_HASHMAP_DEFAULT_LOAD_FACTOR);
 	}
@@ -43,14 +43,14 @@ ZTEST(hash_map, test_load_factor_custom)
 	zassert_equal(0, sys_hashmap_load_factor(hmap));
 
 	for (size_t i = 0; i < MANY; ++i) {
-		ret = sys_hashmap_insert(hmap, i, i, NULL, NULL);
+		ret = INSERT_FUNC(hmap, i, i, NULL, NULL);
 		zassert_equal(1, ret, "failed to insert (%zu, %zu): %d", i, i, ret);
 		load_factor = sys_hashmap_load_factor(hmap);
 		zassert_true(load_factor > 0 && load_factor <= CUSTOM_LOAD_FACTOR);
 	}
 
 	for (size_t i = MANY; i > 0; --i) {
-		zassert_equal(true, sys_hashmap_remove(hmap, i - 1, NULL, NULL));
+		zassert_equal(true, REMOVE_FUNC(hmap, i - 1, NULL, NULL));
 		load_factor = sys_hashmap_load_factor(hmap);
 		zassert_true(load_factor <= CUSTOM_LOAD_FACTOR);
 	}

--- a/tests/lib/hash_map/src/load_factor.c
+++ b/tests/lib/hash_map/src/load_factor.c
@@ -18,14 +18,14 @@ ZTEST(hash_map, test_load_factor_default)
 	zassert_equal(0, sys_hashmap_load_factor(&map));
 
 	for (size_t i = 0; i < MANY; ++i) {
-		ret = sys_hashmap_insert(&map, i, i, NULL);
+		ret = sys_hashmap_insert(&map, i, i, NULL, NULL);
 		zassert_equal(1, ret, "failed to insert (%zu, %zu): %d", i, i, ret);
 		load_factor = sys_hashmap_load_factor(&map);
 		zassert_true(load_factor > 0 && load_factor <= SYS_HASHMAP_DEFAULT_LOAD_FACTOR);
 	}
 
 	for (size_t i = MANY; i > 0; --i) {
-		zassert_equal(true, sys_hashmap_remove(&map, i - 1, NULL));
+		zassert_equal(true, sys_hashmap_remove(&map, i - 1, NULL, NULL));
 		load_factor = sys_hashmap_load_factor(&map);
 		zassert_true(load_factor <= SYS_HASHMAP_DEFAULT_LOAD_FACTOR);
 	}
@@ -43,14 +43,14 @@ ZTEST(hash_map, test_load_factor_custom)
 	zassert_equal(0, sys_hashmap_load_factor(hmap));
 
 	for (size_t i = 0; i < MANY; ++i) {
-		ret = sys_hashmap_insert(hmap, i, i, NULL);
+		ret = sys_hashmap_insert(hmap, i, i, NULL, NULL);
 		zassert_equal(1, ret, "failed to insert (%zu, %zu): %d", i, i, ret);
 		load_factor = sys_hashmap_load_factor(hmap);
 		zassert_true(load_factor > 0 && load_factor <= CUSTOM_LOAD_FACTOR);
 	}
 
 	for (size_t i = MANY; i > 0; --i) {
-		zassert_equal(true, sys_hashmap_remove(hmap, i - 1, NULL));
+		zassert_equal(true, sys_hashmap_remove(hmap, i - 1, NULL, NULL));
 		load_factor = sys_hashmap_load_factor(hmap);
 		zassert_true(load_factor <= CUSTOM_LOAD_FACTOR);
 	}

--- a/tests/lib/hash_map/src/remove.c
+++ b/tests/lib/hash_map/src/remove.c
@@ -14,13 +14,13 @@ ZTEST(hash_map, test_remove_true)
 	int ret;
 
 	for (size_t i = 0; i < MANY; ++i) {
-		ret = sys_hashmap_insert(&map, i, i, NULL, NULL);
+		ret = INSERT_FUNC(&map, i, i, NULL, NULL);
 		zassert_equal(1, ret, "failed to insert (%zu, %zu): %d", i, i, ret);
 		zassert_equal(i + 1, sys_hashmap_size(&map));
 	}
 
 	for (size_t i = MANY; i > 0; --i) {
-		zassert_equal(true, sys_hashmap_remove(&map, i - 1, NULL, NULL));
+		zassert_equal(true, REMOVE_FUNC(&map, i - 1, NULL, NULL));
 		zassert_equal(i - 1, sys_hashmap_size(&map));
 	}
 
@@ -31,9 +31,15 @@ ZTEST(hash_map, test_remove_true)
 
 ZTEST(hash_map, test_remove_false)
 {
-	zassert_true(sys_hashmap_is_empty(&map));
-	zassert_false(sys_hashmap_remove(&map, 42, NULL, NULL));
+	KEY_TYPE key_rem = ALLOC_KEY(42);
+	KEY_TYPE key_insert = ALLOC_KEY(1);
 
-	zassert_equal(1, sys_hashmap_insert(&map, 1, 1, NULL, NULL));
-	zassert_false(sys_hashmap_remove(&map, 42, NULL, NULL));
+	zassert_true(sys_hashmap_is_empty(&map));
+	zassert_false(REMOVE_FUNC_NAME(&map, key_rem, NULL, NULL));
+
+	zassert_equal(1, INSERT_FUNC_NAME(&map, key_insert, 1, NULL, NULL));
+	zassert_false(REMOVE_FUNC_NAME(&map, key_rem, NULL, NULL));
+
+	FREE_KEY(key_rem);
+	FREE_KEY(key_insert);
 }

--- a/tests/lib/hash_map/src/remove.c
+++ b/tests/lib/hash_map/src/remove.c
@@ -14,13 +14,13 @@ ZTEST(hash_map, test_remove_true)
 	int ret;
 
 	for (size_t i = 0; i < MANY; ++i) {
-		ret = sys_hashmap_insert(&map, i, i, NULL);
+		ret = sys_hashmap_insert(&map, i, i, NULL, NULL);
 		zassert_equal(1, ret, "failed to insert (%zu, %zu): %d", i, i, ret);
 		zassert_equal(i + 1, sys_hashmap_size(&map));
 	}
 
 	for (size_t i = MANY; i > 0; --i) {
-		zassert_equal(true, sys_hashmap_remove(&map, i - 1, NULL));
+		zassert_equal(true, sys_hashmap_remove(&map, i - 1, NULL, NULL));
 		zassert_equal(i - 1, sys_hashmap_size(&map));
 	}
 
@@ -32,8 +32,8 @@ ZTEST(hash_map, test_remove_true)
 ZTEST(hash_map, test_remove_false)
 {
 	zassert_true(sys_hashmap_is_empty(&map));
-	zassert_false(sys_hashmap_remove(&map, 42, NULL));
+	zassert_false(sys_hashmap_remove(&map, 42, NULL, NULL));
 
-	zassert_equal(1, sys_hashmap_insert(&map, 1, 1, NULL));
-	zassert_false(sys_hashmap_remove(&map, 42, NULL));
+	zassert_equal(1, sys_hashmap_insert(&map, 1, 1, NULL, NULL));
+	zassert_false(sys_hashmap_remove(&map, 42, NULL, NULL));
 }

--- a/tests/lib/hash_map/src/size.c
+++ b/tests/lib/hash_map/src/size.c
@@ -13,9 +13,16 @@ ZTEST(hash_map, test_size)
 {
 	zassert_equal(0, sys_hashmap_size(&map));
 
-	zassume_equal(1, sys_hashmap_insert(&map, 1, 1, NULL, NULL));
+	KEY_TYPE key1 = ALLOC_KEY(1);
+
+	zassume_equal(1, INSERT_FUNC_NAME(&map, key1, 1, NULL, NULL));
 	zassert_equal(1, sys_hashmap_size(&map));
 
-	zassume_equal(1, sys_hashmap_insert(&map, 2, 2, NULL, NULL));
+	KEY_TYPE key2 = ALLOC_KEY(2);
+
+	zassume_equal(1, INSERT_FUNC_NAME(&map, key2, 2, NULL, NULL));
 	zassert_equal(2, sys_hashmap_size(&map));
+
+	FREE_KEY(key1);
+	FREE_KEY(key2);
 }

--- a/tests/lib/hash_map/src/size.c
+++ b/tests/lib/hash_map/src/size.c
@@ -13,9 +13,9 @@ ZTEST(hash_map, test_size)
 {
 	zassert_equal(0, sys_hashmap_size(&map));
 
-	zassume_equal(1, sys_hashmap_insert(&map, 1, 1, NULL));
+	zassume_equal(1, sys_hashmap_insert(&map, 1, 1, NULL, NULL));
 	zassert_equal(1, sys_hashmap_size(&map));
 
-	zassume_equal(1, sys_hashmap_insert(&map, 2, 2, NULL));
+	zassume_equal(1, sys_hashmap_insert(&map, 2, 2, NULL, NULL));
 	zassert_equal(2, sys_hashmap_size(&map));
 }

--- a/tests/lib/hash_map/src/string_cmp.c
+++ b/tests/lib/hash_map/src/string_cmp.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025 SecoMind
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "_main.h"
+
+#include <zephyr/sys/base64.h>
+#include <zephyr/sys/hash_map.h>
+
+#include <string.h>
+
+uint32_t hash_string(const void *uint64_ptr_key, size_t len)
+{
+	__ASSERT(len == sizeof(uint64_t),
+		 "Received an invalid length for the hasmap key, expected only uint64_t");
+
+	uint64_t key_pointer = {0};
+
+	memcpy(&key_pointer, uint64_ptr_key, sizeof(uint64_t));
+
+	const char *key_string = UINT_TO_POINTER(key_pointer);
+	size_t key_string_len = strlen(key_string);
+
+	return sys_hash32(key_string, key_string_len);
+}
+
+bool eq_string(uint64_t key_left, uint64_t key_right)
+{
+	if (key_left == key_right) {
+		return true;
+	} else if (key_left == 0 || key_right == 0) {
+		return false;
+	}
+
+	const char *key_left_string = UINT_TO_POINTER(key_left);
+	const char *key_right_string = UINT_TO_POINTER(key_right);
+
+	return strcmp(key_left_string, key_right_string) == 0;
+}

--- a/tests/lib/hash_map/src/string_map_helper.h
+++ b/tests/lib/hash_map/src/string_map_helper.h
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2025 SecoMind
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef TEST_STRING_MAP_HELPER
+#define TEST_STRING_MAP_HELPER
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <zephyr/sys/base64.h>
+#include <zephyr/sys/hash_map.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/util.h>
+
+/**
+ * @brief Callback interface for @ref sys_hashmap
+ *
+ * This callback is used by some Hashmap methods.
+ * This callback is used in maps which use a string (char *) as key
+ *
+ * @param key Key corresponding to @p value
+ * @param value Value corresponding to @p key
+ * @param cookie User-specified variable
+ */
+typedef void (*string_map_callback_t)(char *key, uint64_t value, void *cookie);
+
+struct string_map_foreach_user_data {
+	void *cookie;
+	string_map_callback_t callback;
+};
+
+/*
+ * Copyright (c) 2025 SecoMind
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "string_map_helper.h"
+
+static inline bool string_map_get(const struct sys_hashmap *map, const char *key, uint64_t *value)
+{
+	return sys_hashmap_get(map, POINTER_TO_UINT(key), value);
+}
+
+static inline bool string_map_contains_key(const struct sys_hashmap *map, const char *key)
+{
+	return string_map_get(map, key, NULL);
+}
+
+static inline bool string_map_remove(struct sys_hashmap *map, const char *key, uint64_t *value,
+				     char **old_key)
+{
+	uint64_t uint_old_key = 0;
+	bool res = 0;
+
+	res = sys_hashmap_remove(map, POINTER_TO_UINT(key), value, &uint_old_key);
+
+	if (old_key && uint_old_key) {
+		/* NOLINTNEXTLINE(performance-no-int-to-ptr) */
+		*old_key = UINT_TO_POINTER(uint_old_key);
+	}
+
+	return res;
+}
+
+static inline int string_map_insert(struct sys_hashmap *map, const char *key, uint64_t value,
+				    uint64_t *old_value,
+				    char **old_key)
+{
+	uint64_t uint_old_key = 0;
+	int res = 0;
+
+	res = sys_hashmap_insert(map, POINTER_TO_UINT(key), POINTER_TO_UINT(value), old_value,
+				 &uint_old_key);
+
+	if (old_key && uint_old_key) {
+		/* NOLINTNEXTLINE(performance-no-int-to-ptr) */
+		*old_key = UINT_TO_POINTER(uint_old_key);
+	}
+
+	return res;
+}
+
+static inline void string_map_free_callback(uint64_t key, uint64_t value, void *cookie)
+{
+	/* NOLINTNEXTLINE(performance-no-int-to-ptr) */
+	char *key_string = UINT_TO_POINTER(key);
+
+	free(key_string);
+}
+
+static inline void string_map_callback(uint64_t key, uint64_t value, void *cookie)
+{
+	struct string_map_foreach_user_data *user_data =
+		(struct string_map_foreach_user_data *) cookie;
+	char *key_string = UINT_TO_POINTER(key);
+
+	user_data->callback(key_string, value, user_data->cookie);
+}
+
+static inline void string_map_foreach(const struct sys_hashmap *map, string_map_callback_t cb,
+				      void *cookie)
+{
+	struct string_map_foreach_user_data user_data = (struct string_map_foreach_user_data){
+		.cookie = cookie,
+		.callback = cb,
+	};
+
+	sys_hashmap_foreach(map, string_map_callback, &user_data);
+}
+
+static inline void string_map_clear(struct sys_hashmap *map, string_map_callback_t cb,
+				    void *cookie)
+{
+	struct string_map_foreach_user_data user_data = (struct string_map_foreach_user_data) {
+		.cookie = cookie,
+		.callback = cb,
+	};
+
+	sys_hashmap_clear(map, string_map_callback, &user_data);
+}
+
+/* uses base64 encode to generate a unique NULL terminated string from a number */
+static inline char *alloc_string_index(uint64_t key)
+{
+	size_t len = 0;
+
+	base64_encode(NULL, 0, &len, (const uint8_t *) &key, sizeof(key));
+	uint8_t *string_index = calloc(len, sizeof(uint8_t));
+
+	(void) base64_encode(string_index, len, &len, (const uint8_t *) &key, sizeof(key));
+	return string_index;
+}
+
+/* uses base64 decode to retrieve the number key */
+static inline uint64_t get_key_index(char *key)
+{
+	size_t len = 0;
+	uint64_t res = 0;
+
+	(void) base64_decode((uint8_t *) &res, sizeof(uint64_t), &len, key, strlen(key));
+	return res;
+}
+
+#endif /* TEST_STRING_MAP_HELPER */

--- a/tests/lib/hash_map/testcase.yaml
+++ b/tests/lib/hash_map/testcase.yaml
@@ -13,11 +13,25 @@ tests:
       - CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=8192
       - CONFIG_SYS_HASH_MAP_CHOICE_SC=y
       - CONFIG_SYS_HASH_FUNC32_CHOICE_DJB2=y
+  libraries.hash_map.separate_chaining.custom_eq.djb2:
+    extra_configs:
+      - CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=8192
+      - CONFIG_SYS_HASH_MAP_CHOICE_SC=y
+      - CONFIG_SYS_HASH_FUNC32_CHOICE_DJB2=y
+      - CONFIG_TEST_USE_CUSTOM_EQ_FUNC=y
+      - CONFIG_BASE64=y
   libraries.hash_map.open_addressing.djb2:
     extra_configs:
       - CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=8192
       - CONFIG_SYS_HASH_MAP_CHOICE_OA_LP=y
       - CONFIG_SYS_HASH_FUNC32_CHOICE_DJB2=y
+  libraries.hash_map.open_addressing.custom_eq.djb2:
+    extra_configs:
+      - CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=8192
+      - CONFIG_SYS_HASH_MAP_CHOICE_OA_LP=y
+      - CONFIG_SYS_HASH_FUNC32_CHOICE_DJB2=y
+      - CONFIG_TEST_USE_CUSTOM_EQ_FUNC=y
+      - CONFIG_BASE64=y
   libraries.hash_map.cxx.djb2:
     filter: CONFIG_FULL_LIBCPP_SUPPORTED
     extra_configs:


### PR DESCRIPTION
Following issue #76238 I wanted to give an example of this possibly breaking change. It could be made into a nonbreaking change if needed.
I think one of the main reasons this didn't get implemented is that embedded systems usually don't deal with large enough amounts of data for a hashmap to make sense.
But if the feature is not too invasive and does not create problems this could be useful to some.
Thanks in advance for taking the time to review the PR.