### PR TITLE
drivers: intc: gic: implement set pending interrupt

### DIFF
--- a/drivers/interrupt_controller/intc_gic.c
+++ b/drivers/interrupt_controller/intc_gic.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2018 Marvell
  * Copyright (c) 2018 Lexmark International, Inc.
  * Copyright (c) 2019 Stephanos Ioannidis <root@stephanos.io>
+ * Copyright 2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -77,6 +78,16 @@ bool arm_gic_irq_is_pending(unsigned int irq)
 	enabler = sys_read32(GICD_ISPENDRn + int_grp * 4);
 
 	return (enabler & (1 << int_off)) != 0;
+}
+
+void arm_gic_irq_set_pending(unsigned int irq)
+{
+	int int_grp, int_off;
+
+	int_grp = irq / 32;
+	int_off = irq % 32;
+
+	sys_write32((1 << int_off), (GICD_ISPENDRn + int_grp * 4));
 }
 
 void arm_gic_irq_clear_pending(unsigned int irq)

--- a/drivers/interrupt_controller/intc_gicv3.c
+++ b/drivers/interrupt_controller/intc_gicv3.c
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Broadcom
+ * Copyright 2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -225,6 +226,14 @@ bool arm_gic_irq_is_pending(unsigned int intid)
 	val = sys_read32(ISPENDR(GET_DIST_BASE(intid), idx));
 
 	return (val & mask) != 0;
+}
+
+void arm_gic_irq_set_pending(unsigned int intid)
+{
+	uint32_t mask = BIT(intid & (GIC_NUM_INTR_PER_REG - 1));
+	uint32_t idx = intid / GIC_NUM_INTR_PER_REG;
+
+	sys_write32(mask, ISPENDR(GET_DIST_BASE(intid), idx));
 }
 
 void arm_gic_irq_clear_pending(unsigned int intid)

--- a/include/zephyr/drivers/interrupt_controller/gic.h
+++ b/include/zephyr/drivers/interrupt_controller/gic.h
@@ -303,6 +303,13 @@ bool arm_gic_irq_is_enabled(unsigned int irq);
 bool arm_gic_irq_is_pending(unsigned int irq);
 
 /**
+ * @brief Set interrupt as pending
+ *
+ * @param irq interrupt ID
+ */
+void arm_gic_irq_set_pending(unsigned int irq);
+
+/**
  * @brief Clear the pending irq
  *
  * @param irq interrupt ID


### PR DESCRIPTION
Implement a function to set pending interrupts for Arm GIC.

> [!NOTE]  
> Used in https://github.com/zephyrproject-rtos/zephyr/pull/76697