### PR TITLE
drivers: counter: nxp_sys_timer: support late and short relative alarms 

### DIFF
--- a/tests/drivers/counter/counter_basic_api/boards/mr_canhubk3.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/mr_canhubk3.overlay
@@ -10,6 +10,6 @@
 };
 
 &stm1 {
-	prescaler = <8>;
+	prescaler = <64>;
 	status = "okay";
 };

--- a/tests/drivers/counter/counter_basic_api/boards/s32z2xxdc2_s32z270_rtu0.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/s32z2xxdc2_s32z270_rtu0.overlay
@@ -10,17 +10,17 @@
 };
 
 &stm1 {
-	prescaler = <2>;
+	prescaler = <8>;
 	status = "okay";
 };
 
 &stm2 {
-	prescaler = <4>;
+	prescaler = <32>;
 	status = "okay";
 };
 
 &stm3 {
-	prescaler = <8>;
+	prescaler = <64>;
 	status = "okay";
 };
 

--- a/tests/drivers/counter/counter_basic_api/boards/s32z2xxdc2_s32z270_rtu1.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/s32z2xxdc2_s32z270_rtu1.overlay
@@ -10,17 +10,17 @@
 };
 
 &stm1 {
-	prescaler = <2>;
+	prescaler = <8>;
 	status = "okay";
 };
 
 &stm2 {
-	prescaler = <4>;
+	prescaler = <16>;
 	status = "okay";
 };
 
 &stm3 {
-	prescaler = <8>;
+	prescaler = <32>;
 	status = "okay";
 };
 


### PR DESCRIPTION
Support short relative and late alarms for NXP System Timer Module counter driver. The late alarm detection algorithm is based on existing counter drivers.

To test it, increase the counter timer prescaler for some instances of this counter in `tests/drivers/counter/counter_basic_api`, so that late alarms and short relative alarms are exercised.

```
INFO    - 2754/2755 s32z2xxdc2@D/s32z270/rtu0 samples/drivers/counter/alarm/sample.drivers.counter.alarm PASSED (device: AU05H438, 10.791s)
INFO    - 2755/2755 s32z2xxdc2@D/s32z270/rtu0 tests/drivers/counter/counter_basic_api/drivers.counter.basic_api PASSED (device: AU05H438, 25.618s)
INFO    - 2754/2755 mr_canhubk3               samples/drivers/counter/alarm/sample.drivers.counter.alarm PASSED (device: AB0O4EZU, 10.000s)
INFO    - 2755/2755 mr_canhubk3               tests/drivers/counter/counter_basic_api/drivers.counter.basic_api PASSED (device: AB0O4EZU, 13.674s)
```

> [!IMPORTANT]  
> depends on https://github.com/zephyrproject-rtos/zephyr/pull/76696 for `arm_gic_irq_set_pending()`