### PR TITLE
west.yml: remove two redundant repo-path

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -210,7 +210,6 @@ manifest:
     - name: hal_quicklogic
       revision: bad894440fe72c814864798c8e3a76d13edffb6c
       path: modules/hal/quicklogic
-      repo-path: hal_quicklogic
       groups:
         - hal
     - name: hal_renesas
@@ -259,7 +258,6 @@ manifest:
       groups:
         - hal
     - name: hostap
-      repo-path: hostap
       path: modules/lib/hostap
       revision: a90df86d7c596a5367ff70c2b50c7f599e6636f3
     - name: libmetal


### PR DESCRIPTION
The repo-path field is meant to override the repository name if it's different than the module name, drop two cases where repo-path has no effect.