### PR TITLE
ci: twister: blackbox: do not fetch hal modules

### DIFF
--- a/.github/workflows/twister_tests_blackbox.yml
+++ b/.github/workflows/twister_tests_blackbox.yml
@@ -43,6 +43,8 @@ jobs:
         echo "$HOME/.local/bin" >> $GITHUB_PATH
 
         west init -l . || true
+        # we do not depend on any hals, tools or bootloader, save some time and space...
+        west config manifest.group-filter -- -hal,-tools,-bootloader
         west config --global update.narrow true
         west update --path-cache /github/cache/zephyrproject 2>&1 1> west.update.log || west update --path-cache /github/cache/zephyrproject 2>&1 1> west.update.log || ( rm -rf ../modules ../bootloader ../tools && west update --path-cache /github/cache/zephyrproject)
         west forall -c 'git reset --hard HEAD'

--- a/scripts/tests/twister_blackbox/test_addon.py
+++ b/scripts/tests/twister_blackbox/test_addon.py
@@ -159,7 +159,7 @@ class TestAddon:
 
     @mock.patch.object(TestPlan, 'TESTSUITE_FILENAME', testsuite_filename_mock)
     def test_extra_args(self, caplog, out_path):
-        test_platforms = ['qemu_x86', 'frdm_k64f']
+        test_platforms = ['qemu_x86', 'intel_adl_crb']
         path = os.path.join(TEST_DATA, 'tests', 'dummy', 'agnostic', 'group2')
         args = ['--outdir', out_path, '-T', path] + \
                ['--extra-args', 'USE_CCACHE=0', '--extra-args', 'DUMMY=1'] + \

--- a/scripts/tests/twister_blackbox/test_config.py
+++ b/scripts/tests/twister_blackbox/test_config.py
@@ -31,7 +31,7 @@ class TestConfig:
 
     @mock.patch.object(TestPlan, 'TESTSUITE_FILENAME', testsuite_filename_mock)
     def test_alt_config_root(self, out_path):
-        test_platforms = ['qemu_x86', 'frdm_k64f']
+        test_platforms = ['qemu_x86', 'intel_adl_crb']
         path = os.path.join(TEST_DATA, 'tests', 'dummy')
         alt_config_root = os.path.join(TEST_DATA, 'alt-test-configs', 'dummy')
         args = ['-i', '--outdir', out_path, '-T', path, '-y'] + \
@@ -67,7 +67,7 @@ class TestConfig:
     )
     @mock.patch.object(TestPlan, 'TESTSUITE_FILENAME', testsuite_filename_mock)
     def test_level(self, out_path, level, expected_tests):
-        test_platforms = ['qemu_x86', 'frdm_k64f']
+        test_platforms = ['qemu_x86', 'intel_adl_crb']
         path = os.path.join(TEST_DATA, 'tests', 'dummy')
         config_path = os.path.join(TEST_DATA, 'test_config.yaml')
         args = ['-i','--outdir', out_path, '-T', path, '--level', level, '-y',

--- a/scripts/tests/twister_blackbox/test_data/tests/dummy/device/group/test_data.yaml
+++ b/scripts/tests/twister_blackbox/test_data/tests/dummy/device/group/test_data.yaml
@@ -1,6 +1,6 @@
 tests:
   dummy.device.group:
-    platform_allow: frdm_k64f
+    platform_allow: intel_adl_crb
     integration_platforms:
-      - frdm_k64f
+      - intel_adl_crb
     tags: device

--- a/scripts/tests/twister_blackbox/test_data/twister-quarantine-list.yml
+++ b/scripts/tests/twister_blackbox/test_data/twister-quarantine-list.yml
@@ -4,9 +4,9 @@
     test all platforms
 
 - platforms:
-  - frdm_k64f
+  - intel_adl_crb
   comment: >
-    test frdm_k64f
+    test intel_adl_crb
 
 - scenarios:
   - dummy.agnostic.group1.subgroup2

--- a/scripts/tests/twister_blackbox/test_error.py
+++ b/scripts/tests/twister_blackbox/test_error.py
@@ -67,7 +67,7 @@ class TestError:
     )
     @mock.patch.object(TestPlan, 'TESTSUITE_FILENAME', testsuite_filename_mock)
     def test_test(self, out_path, testroot, test, expected_exception):
-        test_platforms = ['qemu_x86', 'frdm_k64f']
+        test_platforms = ['qemu_x86', 'intel_adl_crb']
         args = []
         if testroot:
             args = ['-T', testroot]

--- a/scripts/tests/twister_blackbox/test_filter.py
+++ b/scripts/tests/twister_blackbox/test_filter.py
@@ -24,9 +24,7 @@ class TestFilter:
             'x86',
             [
                 r'(it8xxx2_evb).*?(SKIPPED: Command line testsuite arch filter)',
-                r'(frdm_k64f).*?(SKIPPED: Command line testsuite arch filter)',
                 r'(DEBUG\s+- adding qemu_x86)',
-                r'(DEBUG\s+- adding intel_ish_5_4_1)'
             ],
         ),
         (
@@ -34,16 +32,14 @@ class TestFilter:
             [
                 r'(it8xxx2_evb).*?(SKIPPED: Command line testsuite arch filter)',
                 r'(qemu_x86).*?(SKIPPED: Command line testsuite arch filter)',
-                r'(intel_ish_5_4_1).*?(SKIPPED: Command line testsuite arch filter)',
-                r'(DEBUG\s+- adding frdm_k64f)'
+                r'(hsdk).*?(SKIPPED: Command line testsuite arch filter)',
             ]
         ),
         (
             'riscv',
             [
                 r'(qemu_x86).*?(SKIPPED: Command line testsuite arch filter)',
-                r'(frdm_k64f).*?(SKIPPED: Command line testsuite arch filter)',
-                r'(intel_ish_5_4_1).*?(SKIPPED: Command line testsuite arch filter)',
+                r'(hsdk).*?(SKIPPED: Command line testsuite arch filter)',
                 r'(DEBUG\s+- adding it8xxx2_evb)'
             ]
         )
@@ -53,9 +49,8 @@ class TestFilter:
             'nxp',
             [
                 r'(it8xxx2_evb).*?(SKIPPED: Not a selected vendor platform)',
-                r'(intel_ish_5_4_1).*?(SKIPPED: Not a selected vendor platform)',
+                r'(hsdk).*?(SKIPPED: Not a selected vendor platform)',
                 r'(qemu_x86).*?(SKIPPED: Not a selected vendor platform)',
-                r'(DEBUG\s+- adding frdm_k64f)'
             ],
         ),
         (
@@ -63,16 +58,15 @@ class TestFilter:
             [
                 r'(it8xxx2_evb).*?(SKIPPED: Not a selected vendor platform)',
                 r'(qemu_x86).*?(SKIPPED: Not a selected vendor platform)',
-                r'(frdm_k64f).*?(SKIPPED: Not a selected vendor platform)',
-                r'(DEBUG\s+- adding intel_ish_5_4_1)'
+                r'(DEBUG\s+- adding intel_adl_crb)'
             ]
         ),
         (
             'ite',
             [
                 r'(qemu_x86).*?(SKIPPED: Not a selected vendor platform)',
-                r'(frdm_k64f).*?(SKIPPED: Not a selected vendor platform)',
-                r'(intel_ish_5_4_1).*?(SKIPPED: Not a selected vendor platform)',
+                r'(intel_adl_crb).*?(SKIPPED: Not a selected vendor platform)',
+                r'(hsdk).*?(SKIPPED: Not a selected vendor platform)',
                 r'(DEBUG\s+- adding it8xxx2_evb)'
             ]
         )
@@ -103,7 +97,7 @@ class TestFilter:
     )
     @mock.patch.object(TestPlan, 'TESTSUITE_FILENAME', testsuite_filename_mock)
     def test_exclude_tag(self, out_path, tag, expected_test_count):
-        test_platforms = ['qemu_x86', 'frdm_k64f']
+        test_platforms = ['qemu_x86', 'intel_adl_crb']
         path = os.path.join(TEST_DATA, 'tests', 'dummy')
         args = ['-i', '--outdir', out_path, '-T', path, '-y'] + \
                ['--exclude-tag', tag] + \
@@ -129,7 +123,7 @@ class TestFilter:
 
     @mock.patch.object(TestPlan, 'TESTSUITE_FILENAME', testsuite_filename_mock)
     def test_enable_slow(self, out_path):
-        test_platforms = ['qemu_x86', 'frdm_k64f']
+        test_platforms = ['qemu_x86', 'intel_adl_crb']
         path = os.path.join(TEST_DATA, 'tests', 'dummy', 'agnostic')
         alt_config_root = os.path.join(TEST_DATA, 'alt-test-configs', 'dummy', 'agnostic')
         args = ['-i', '--outdir', out_path, '-T', path] + \
@@ -157,7 +151,7 @@ class TestFilter:
 
     @mock.patch.object(TestPlan, 'TESTSUITE_FILENAME', testsuite_filename_mock)
     def test_enable_slow_only(self, out_path):
-        test_platforms = ['qemu_x86', 'frdm_k64f']
+        test_platforms = ['qemu_x86', 'intel_adl_crb']
         path = os.path.join(TEST_DATA, 'tests', 'dummy', 'agnostic')
         alt_config_root = os.path.join(TEST_DATA, 'alt-test-configs', 'dummy', 'agnostic')
         args = ['-i', '--outdir', out_path, '-T', path] + \
@@ -196,7 +190,7 @@ class TestFilter:
     @mock.patch.object(TestPlan, 'TESTSUITE_FILENAME', testsuite_filename_mock)
     def test_arch(self, capfd, out_path, arch, expected):
         path = os.path.join(TEST_DATA, 'tests', 'no_filter')
-        test_platforms = ['qemu_x86', 'intel_ish_5_4_1', 'frdm_k64f', 'it8xxx2_evb']
+        test_platforms = ['qemu_x86', 'hsdk', 'intel_adl_crb', 'it8xxx2_evb']
         args = ['--outdir', out_path, '-T', path, '-vv'] + \
                ['--arch', arch] + \
                [val for pair in zip(
@@ -229,7 +223,7 @@ class TestFilter:
     @mock.patch.object(TestPlan, 'TESTSUITE_FILENAME', testsuite_filename_mock)
     def test_vendor(self, capfd, out_path, vendor, expected):
         path = os.path.join(TEST_DATA, 'tests', 'no_filter')
-        test_platforms = ['qemu_x86', 'intel_ish_5_4_1', 'frdm_k64f', 'it8xxx2_evb']
+        test_platforms = ['qemu_x86', 'hsdk', 'intel_adl_crb', 'it8xxx2_evb']
         args = ['--outdir', out_path, '-T', path, '-vv'] + \
                ['--vendor', vendor] + \
                [val for pair in zip(

--- a/scripts/tests/twister_blackbox/test_footprint.py
+++ b/scripts/tests/twister_blackbox/test_footprint.py
@@ -56,7 +56,7 @@ class TestFootprint:
     )
     def test_compare_report(self, caplog, out_path, old_ram_multiplier, expect_delta_log):
         # First run
-        test_platforms = ['frdm_k64f']
+        test_platforms = ['intel_adl_crb']
         path = os.path.join(TEST_DATA, 'tests', 'dummy', 'device', 'group')
         args = ['-i', '--outdir', out_path, '-T', path] + \
                ['--enable-size-report'] + \
@@ -89,7 +89,7 @@ class TestFootprint:
         )
 
         # Second run
-        test_platforms = ['frdm_k64f']
+        test_platforms = ['intel_adl_crb']
         path = os.path.join(TEST_DATA, 'tests', 'dummy')
         args = ['-i', '--outdir', out_path, '-T', path] + \
                ['--compare-report', report_path] + \
@@ -117,7 +117,7 @@ class TestFootprint:
 
     def test_footprint_from_buildlog(self, out_path):
         # First run
-        test_platforms = ['frdm_k64f']
+        test_platforms = ['intel_adl_crb']
         path = os.path.join(TEST_DATA, 'tests', 'dummy', 'device', 'group')
         args = ['-i', '--outdir', out_path, '-T', path] + \
                [] + \
@@ -142,7 +142,7 @@ class TestFootprint:
                     old_values += [ts[self.RAM_KEY]]
 
         # Second run
-        test_platforms = ['frdm_k64f']
+        test_platforms = ['intel_adl_crb']
         path = os.path.join(TEST_DATA, 'tests', 'dummy', 'device', 'group')
         args = ['-i', '--outdir', out_path, '-T', path] + \
                ['--footprint-from-buildlog'] + \
@@ -182,7 +182,7 @@ class TestFootprint:
     def test_footprint_threshold(self, caplog, out_path, old_ram_multiplier,
                                  threshold, expect_delta_log):
         # First run
-        test_platforms = ['frdm_k64f']
+        test_platforms = ['intel_adl_crb']
         path = os.path.join(TEST_DATA, 'tests', 'dummy', 'device', 'group')
         args = ['-i', '--outdir', out_path, '-T', path] + \
                ['--enable-size-report'] + \
@@ -215,7 +215,7 @@ class TestFootprint:
         )
 
         # Second run
-        test_platforms = ['frdm_k64f']
+        test_platforms = ['intel_adl_crb']
         path = os.path.join(TEST_DATA, 'tests', 'dummy')
         args = ['-i', '--outdir', out_path, '-T', path] + \
                [f'--footprint-threshold={threshold}'] + \
@@ -251,7 +251,7 @@ class TestFootprint:
     )
     def test_show_footprint(self, caplog, out_path, flags, old_ram_multiplier, expect_delta_log):
         # First run
-        test_platforms = ['frdm_k64f']
+        test_platforms = ['intel_adl_crb']
         path = os.path.join(TEST_DATA, 'tests', 'dummy', 'device', 'group')
         args = ['-i', '--outdir', out_path, '-T', path] + \
                ['--enable-size-report'] + \
@@ -284,7 +284,7 @@ class TestFootprint:
         )
 
         # Second run
-        test_platforms = ['frdm_k64f']
+        test_platforms = ['intel_adl_crb']
         path = os.path.join(TEST_DATA, 'tests', 'dummy')
         args = ['-i', '--outdir', out_path, '-T', path] + \
                flags + \
@@ -324,7 +324,7 @@ class TestFootprint:
     )
     def test_last_metrics(self, caplog, out_path, old_ram_multiplier, expect_delta_log):
         # First run
-        test_platforms = ['frdm_k64f']
+        test_platforms = ['intel_adl_crb']
         path = os.path.join(TEST_DATA, 'tests', 'dummy', 'device', 'group')
         args = ['-i', '--outdir', out_path, '-T', path] + \
                ['--enable-size-report'] + \
@@ -357,7 +357,7 @@ class TestFootprint:
         )
 
         # Second run
-        test_platforms = ['frdm_k64f']
+        test_platforms = ['intel_adl_crb']
         path = os.path.join(TEST_DATA, 'tests', 'dummy')
         args = ['-i', '--outdir', out_path, '-T', path] + \
                ['--last-metrics'] + \
@@ -388,7 +388,7 @@ class TestFootprint:
         clear_log_in_test()
 
         # Third run
-        test_platforms = ['frdm_k64f']
+        test_platforms = ['intel_adl_crb']
         path = os.path.join(TEST_DATA, 'tests', 'dummy')
         args = ['-i', '--outdir', out_path, '-T', path] + \
                ['--compare-report', report_path] + \
@@ -421,7 +421,7 @@ class TestFootprint:
     )
     def test_all_deltas(self, caplog, out_path, old_ram_multiplier, expect_delta_log):
         # First run
-        test_platforms = ['frdm_k64f']
+        test_platforms = ['intel_adl_crb']
         path = os.path.join(TEST_DATA, 'tests', 'dummy', 'device', 'group')
         args = ['-i', '--outdir', out_path, '-T', path] + \
                ['--enable-size-report'] + \
@@ -454,7 +454,7 @@ class TestFootprint:
         )
 
         # Second run
-        test_platforms = ['frdm_k64f']
+        test_platforms = ['intel_adl_crb']
         path = os.path.join(TEST_DATA, 'tests', 'dummy')
         args = ['-i', '--outdir', out_path, '-T', path] + \
                ['--all-deltas'] + \

--- a/scripts/tests/twister_blackbox/test_outfile.py
+++ b/scripts/tests/twister_blackbox/test_outfile.py
@@ -44,7 +44,7 @@ class TestOutfile:
         ids=['clobber', 'do not clobber', 'do not clean', 'do not clobber, do not clean']
     )
     def test_clobber_output(self, out_path, flag_section, clobber, expect_straggler):
-        test_platforms = ['qemu_x86', 'frdm_k64f']
+        test_platforms = ['qemu_x86', 'intel_adl_crb']
         path = os.path.join(TEST_DATA, 'tests', 'dummy')
         args = ['-i', '--outdir', out_path, '-T', path, '-y'] + \
                flag_section + \
@@ -80,7 +80,7 @@ class TestOutfile:
             assert straggler_name not in out_contents
 
     def test_runtime_artifact_cleanup(self, out_path):
-        test_platforms = ['qemu_x86', 'frdm_k64f']
+        test_platforms = ['qemu_x86', 'intel_adl_crb']
         path = os.path.join(TEST_DATA, 'samples', 'hello_world')
         args = ['-i', '--outdir', out_path, '-T', path] + \
                ['--runtime-artifact-cleanup'] + \
@@ -177,7 +177,7 @@ class TestOutfile:
                 assert len(flag_value) < len(unshortened_pipe_path), 'Pipe path not shortened.'
 
     def test_prep_artifacts_for_testing(self, out_path):
-        test_platforms = ['qemu_x86', 'frdm_k64f']
+        test_platforms = ['qemu_x86', 'intel_adl_crb']
         path = os.path.join(TEST_DATA, 'samples', 'hello_world')
         relative_test_path = os.path.relpath(path, ZEPHYR_BASE)
         zephyr_out_path = os.path.join(out_path, 'qemu_x86', relative_test_path,

--- a/scripts/tests/twister_blackbox/test_output.py
+++ b/scripts/tests/twister_blackbox/test_output.py
@@ -46,7 +46,7 @@ class TestOutput:
         ids=['no-detailed-test-id', 'detailed-test-id']
     )
     def test_detailed_test_id(self, out_path, flag, expect_paths):
-        test_platforms = ['qemu_x86', 'frdm_k64f']
+        test_platforms = ['qemu_x86', 'intel_adl_crb']
         path = os.path.join(TEST_DATA, 'tests', 'dummy')
         args = ['-i', '--outdir', out_path, '-T', path, '-y'] + \
                [flag] + \
@@ -74,7 +74,7 @@ class TestOutput:
         assert all([testsuite.startswith(expected_start)for _, testsuite, _ in filtered_j])
 
     def test_inline_logs(self, out_path):
-        test_platforms = ['qemu_x86', 'frdm_k64f']
+        test_platforms = ['qemu_x86', 'intel_adl_crb']
         path = os.path.join(TEST_DATA, 'tests', 'always_build_error', 'dummy')
         args = ['--outdir', out_path, '-T', path] + \
                [val for pair in zip(

--- a/scripts/tests/twister_blackbox/test_platform.py
+++ b/scripts/tests/twister_blackbox/test_platform.py
@@ -23,7 +23,7 @@ class TestPlatform:
     TESTDATA_1 = [
         (
             os.path.join(TEST_DATA, 'tests', 'dummy', 'agnostic'),
-            ['qemu_x86', 'qemu_x86_64', 'frdm_k64f'],
+            ['qemu_x86', 'qemu_x86_64', 'intel_adl_crb'],
             {
                 'selected_test_scenarios': 3,
                 'selected_test_instances': 9,
@@ -42,7 +42,7 @@ class TestPlatform:
         ),
         (
             os.path.join(TEST_DATA, 'tests', 'dummy', 'device'),
-            ['qemu_x86', 'qemu_x86_64', 'frdm_k64f'],
+            ['qemu_x86', 'qemu_x86_64', 'intel_adl_crb'],
             {
                 'selected_test_scenarios': 1,
                 'selected_test_instances': 3,
@@ -102,7 +102,7 @@ class TestPlatform:
         assert str(sys_exit.value) == expected_returncode
 
     def test_force_platform(self, out_path):
-        test_platforms = ['qemu_x86', 'frdm_k64f']
+        test_platforms = ['qemu_x86', 'intel_adl_crb']
         path = os.path.join(TEST_DATA, 'tests', 'dummy')
         args = ['-i', '--outdir', out_path, '-T', path, '-y'] + \
                ['--force-platform'] + \

--- a/scripts/tests/twister_blackbox/test_printouts.py
+++ b/scripts/tests/twister_blackbox/test_printouts.py
@@ -83,7 +83,7 @@ class TestPrintOuts:
     TESTDATA_4 = [
         (
             os.path.join(TEST_DATA, 'tests', 'dummy'),
-            ['qemu_x86', 'qemu_x86_64', 'frdm_k64f']
+            ['qemu_x86', 'qemu_x86_64', 'intel_adl_crb']
         )
     ]
 
@@ -271,7 +271,7 @@ class TestPrintOuts:
 
     @mock.patch.object(TestPlan, 'SAMPLE_FILENAME', sample_filename_mock)
     def test_size(self, capfd, out_path):
-        test_platforms = ['qemu_x86', 'frdm_k64f']
+        test_platforms = ['qemu_x86', 'intel_adl_crb']
         path = os.path.join(TEST_DATA, 'samples', 'hello_world')
         args = ['-i', '--outdir', out_path, '-T', path] + \
                [val for pair in zip(

--- a/scripts/tests/twister_blackbox/test_quarantine.py
+++ b/scripts/tests/twister_blackbox/test_quarantine.py
@@ -32,7 +32,7 @@ class TestQuarantine:
 
     @mock.patch.object(TestPlan, 'TESTSUITE_FILENAME', testsuite_filename_mock)
     def test_quarantine_verify(self, out_path):
-        test_platforms = ['qemu_x86', 'frdm_k64f']
+        test_platforms = ['qemu_x86', 'intel_adl_crb']
         path = os.path.join(TEST_DATA, 'tests', 'dummy')
         quarantine_path = os.path.join(TEST_DATA, 'twister-quarantine-list.yml')
         args = ['-i', '--outdir', out_path, '-T', path, '-y'] + \
@@ -63,7 +63,7 @@ class TestQuarantine:
         [
             (
                 os.path.join(TEST_DATA, 'tests', 'dummy', 'agnostic'),
-                ['qemu_x86', 'qemu_x86_64', 'frdm_k64f'],
+                ['qemu_x86', 'qemu_x86_64', 'intel_adl_crb'],
                 os.path.join(TEST_DATA, 'twister-quarantine-list.yml'),
             ),
         ],
@@ -89,10 +89,10 @@ class TestQuarantine:
         sys.stderr.write(err)
 
         frdm_match = re.search('agnostic/group2/dummy.agnostic.group2 SKIPPED: Quarantine: test '
-                               'frdm_k64f', err)
+                               'intel_adl_crb', err)
         frdm_match2 = re.search(
             'agnostic/group1/subgroup2/dummy.agnostic.group1.subgroup2 SKIPPED: Quarantine: test '
-            'frdm_k64f',
+            'intel_adl_crb',
             err)
         qemu_64_match = re.search(
             'agnostic/group1/subgroup2/dummy.agnostic.group1.subgroup2 SKIPPED: Quarantine: test '

--- a/scripts/tests/twister_blackbox/test_report.py
+++ b/scripts/tests/twister_blackbox/test_report.py
@@ -349,18 +349,18 @@ class TestReport:
             (
                 os.path.join(TEST_DATA, 'tests', 'dummy'),
                 ['--detailed-skipped-report'],
-                {'qemu_x86': 5, 'frdm_k64f': 1}
+                {'qemu_x86': 5, 'intel_adl_crb': 1}
             ),
             (
                 os.path.join(TEST_DATA, 'tests', 'dummy'),
                 ['--detailed-skipped-report', '--report-filtered'],
-                {'qemu_x86': 6, 'frdm_k64f': 6}
+                {'qemu_x86': 6, 'intel_adl_crb': 6}
             ),
         ],
         ids=['dummy tests', 'dummy tests with filtered']
     )
     def test_detailed_skipped_report(self, out_path, test_path, flags, expected_testcase_counts):
-        test_platforms = ['qemu_x86', 'frdm_k64f']
+        test_platforms = ['qemu_x86', 'intel_adl_crb']
         args = ['-i', '--outdir', out_path, '-T', test_path] + \
                flags + \
                [val for pair in zip(
@@ -396,7 +396,7 @@ class TestReport:
         ids=['no filtered', 'with filtered']
     )
     def test_report_filtered(self, out_path, test_path, report_filtered, expected_filtered_count):
-        test_platforms = ['qemu_x86', 'frdm_k64f']
+        test_platforms = ['qemu_x86', 'intel_adl_crb']
         args = ['-i', '--outdir', out_path, '-T', test_path] + \
                (['--report-filtered'] if report_filtered else []) + \
                [val for pair in zip(
@@ -420,7 +420,7 @@ class TestReport:
             f'Expected {expected_filtered_count} filtered statuses, got {filtered_status_count}.'
 
     def test_enable_size_report(self, out_path):
-        test_platforms = ['qemu_x86', 'frdm_k64f']
+        test_platforms = ['qemu_x86', 'intel_adl_crb']
         path = os.path.join(TEST_DATA, 'tests', 'dummy', 'device', 'group')
         args = ['-i', '--outdir', out_path, '-T', path] + \
                ['--enable-size-report'] + \

--- a/scripts/tests/twister_blackbox/test_runner.py
+++ b/scripts/tests/twister_blackbox/test_runner.py
@@ -24,7 +24,7 @@ class TestRunner:
     TESTDATA_1 = [
         (
             os.path.join(TEST_DATA, 'tests', 'dummy', 'agnostic'),
-            ['qemu_x86', 'qemu_x86_64', 'frdm_k64f'],
+            ['qemu_x86', 'qemu_x86_64', 'intel_adl_crb'],
             {
                 'executed_on_platform': 0,
                 'only_built': 6
@@ -32,7 +32,7 @@ class TestRunner:
         ),
         (
             os.path.join(TEST_DATA, 'tests', 'dummy', 'device'),
-            ['qemu_x86', 'qemu_x86_64', 'frdm_k64f'],
+            ['qemu_x86', 'qemu_x86_64', 'intel_adl_crb'],
             {
                 'executed_on_platform': 0,
                 'only_built': 1
@@ -42,7 +42,7 @@ class TestRunner:
     TESTDATA_2 = [
         (
             os.path.join(TEST_DATA, 'tests', 'dummy', 'agnostic'),
-            ['qemu_x86', 'qemu_x86_64', 'frdm_k64f'],
+            ['qemu_x86', 'qemu_x86_64', 'intel_adl_crb'],
             {
                 'selected_test_scenarios': 3,
                 'selected_test_instances': 6,

--- a/scripts/tests/twister_blackbox/test_shuffle.py
+++ b/scripts/tests/twister_blackbox/test_shuffle.py
@@ -50,7 +50,7 @@ class TestShuffle:
     )
     @mock.patch.object(TestPlan, 'TESTSUITE_FILENAME', testsuite_filename_mock)
     def test_shuffle_tests(self, out_path, seed, ratio, expected_order):
-        test_platforms = ['qemu_x86', 'frdm_k64f']
+        test_platforms = ['qemu_x86', 'intel_adl_crb']
         path = os.path.join(TEST_DATA, 'tests', 'dummy')
         args = ['-i', '--outdir', out_path, '-T', path, '-y'] + \
                ['--shuffle-tests', '--shuffle-tests-seed', seed] + \

--- a/scripts/tests/twister_blackbox/test_testlist.py
+++ b/scripts/tests/twister_blackbox/test_testlist.py
@@ -31,7 +31,7 @@ class TestTestlist:
 
     @mock.patch.object(TestPlan, 'TESTSUITE_FILENAME', testsuite_filename_mock)
     def test_save_tests(self, out_path):
-        test_platforms = ['qemu_x86', 'frdm_k64f']
+        test_platforms = ['qemu_x86', 'intel_adl_crb']
         path = os.path.join(TEST_DATA, 'tests', 'dummy', 'agnostic')
         saved_tests_file_path = os.path.realpath(os.path.join(out_path, '..', 'saved-tests.json'))
         args = ['-i', '--outdir', out_path, '-T', path, '-y'] + \

--- a/scripts/tests/twister_blackbox/test_testplan.py
+++ b/scripts/tests/twister_blackbox/test_testplan.py
@@ -56,7 +56,7 @@ class TestTestPlan:
     )
     @mock.patch.object(TestPlan, 'TESTSUITE_FILENAME', testsuite_filename_mock)
     def test_subtest(self, out_path, test, expected_exception, expected_subtest_count):
-        test_platforms = ['qemu_x86', 'frdm_k64f']
+        test_platforms = ['qemu_x86', 'intel_adl_crb']
         path = os.path.join(TEST_DATA, 'tests', 'dummy')
         args = ['-i', '--outdir', out_path, '-T', path, '--sub-test', test, '-y'] + \
                [val for pair in zip(
@@ -89,7 +89,7 @@ class TestTestPlan:
     )
     @mock.patch.object(TestPlan, 'TESTSUITE_FILENAME', testsuite_filename_mock)
     def test_filter(self, out_path, filter, expected_count):
-        test_platforms = ['qemu_x86', 'frdm_k64f']
+        test_platforms = ['qemu_x86', 'intel_adl_crb']
         path = os.path.join(TEST_DATA, 'tests', 'dummy')
         args = ['-i', '--outdir', out_path, '-T', path, '--filter', filter, '-y'] + \
                [val for pair in zip(
@@ -120,7 +120,7 @@ class TestTestPlan:
     @mock.patch.object(TestPlan, 'TESTSUITE_FILENAME', testsuite_filename_mock)
     @mock.patch.object(TestPlan, 'SAMPLE_FILENAME', '')
     def test_integration(self, out_path, integration, expected_count):
-        test_platforms = ['qemu_x86', 'frdm_k64f']
+        test_platforms = ['qemu_x86', 'intel_adl_crb']
         path = os.path.join(TEST_DATA, 'tests', 'dummy')
         args = ['-i', '--outdir', out_path, '-T', path, '-y'] + \
                (['--integration'] if integration else []) + \

--- a/scripts/tests/twister_blackbox/test_tooling.py
+++ b/scripts/tests/twister_blackbox/test_tooling.py
@@ -37,7 +37,7 @@ class TestTooling:
     )
     @mock.patch.object(TestPlan, 'TESTSUITE_FILENAME', testsuite_filename_mock)
     def test_jobs(self, out_path, jobs):
-        test_platforms = ['qemu_x86', 'frdm_k64f']
+        test_platforms = ['qemu_x86', 'intel_adl_crb']
         path = os.path.join(TEST_DATA, 'tests', 'dummy', 'agnostic', 'group2')
         args = ['-i', '--outdir', out_path, '-T', path] + \
                ['--jobs', jobs] + \

--- a/west.yml
+++ b/west.yml
@@ -289,6 +289,8 @@ manifest:
     - name: mcuboot
       revision: fb2cf0ec3da3687b93f28e556ab682bdd4b85223
       path: bootloader/mcuboot
+      groups:
+        - bootloader
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t
       groups:


### PR DESCRIPTION
Do not fetch optional modules while running this action.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
