### PR TITLE
nxp: s32k3: fix EDMA driver support on `mr_canhubk3`

### DIFF
--- a/soc/nxp/s32/s32k3/Kconfig
+++ b/soc/nxp/s32/s32k3/Kconfig
@@ -21,6 +21,7 @@ config SOC_SERIES_S32K3
 	select HAS_MCUX_LPI2C
 	select HAS_MCUX_LPSPI
 	select HAS_MCUX_CACHE
+	select HAS_MCUX_EDMA
 
 if SOC_SERIES_S32K3
 

--- a/tests/drivers/spi/spi_loopback/boards/mr_canhubk3.conf
+++ b/tests/drivers/spi/spi_loopback/boards/mr_canhubk3.conf
@@ -1,5 +1,0 @@
-# Copyright 2023 NXP
-# SPDX-License-Identifier: Apache-2.0
-
-CONFIG_SPI_MCUX_LPSPI_DMA=y
-CONFIG_SPI_ASYNC=n

--- a/west.yml
+++ b/west.yml
@@ -198,7 +198,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 150b98fb2632d2660c8eedb5f992bcc72661fdc1
+      revision: 42ea394cbd2d8632339bbecb1efffffa696d11e6
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
- Update manifest to pull fixes for `mr_canhubk3` DMA driver. Fixes #76708
- Add missing EDMA kconfig option. This option is used by some tests to filter by EDMA support.
- Remove overlay for mr_canhubk3. This overlay is no longer needed, as presently there are more test scenarios covering all combinations of DMA and SPY_ASYNC support for LPSPI peripheral.