### PR TITLE
drivers: led: lp5569: add charge-pump configuration + enable-gpios

### DIFF
--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -139,6 +139,8 @@ Drivers and Sensors
 
   * lp5569: added ``charge-pump-mode`` property to configure the charge pump of the lp5569.
 
+  * lp5569: added ``enable-gpios`` property to describe the EN/PWM GPIO of the lp5569.
+
 * LED Strip
 
 * LoRa

--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -137,6 +137,8 @@ Drivers and Sensors
 
 * LED
 
+  * lp5569: added ``charge-pump-mode`` property to configure the charge pump of the lp5569.
+
 * LED Strip
 
 * LoRa

--- a/drivers/led/lp5569.c
+++ b/drivers/led/lp5569.c
@@ -13,6 +13,7 @@
  * The LP5569 is a 9-channel LED driver that communicates over I2C.
  */
 
+#include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/led.h>
 #include <zephyr/device.h>
@@ -37,6 +38,7 @@ LOG_MODULE_REGISTER(lp5569, CONFIG_LED_LOG_LEVEL);
 
 struct lp5569_config {
 	struct i2c_dt_spec bus;
+	struct gpio_dt_spec enable_gpio;
 	const uint8_t cp_mode;
 };
 
@@ -83,6 +85,25 @@ static int lp5569_enable(const struct device *dev)
 	if (!i2c_is_ready_dt(&config->bus)) {
 		LOG_ERR("I2C device not ready");
 		return -ENODEV;
+	}
+
+	/* flip the enable pin if specified */
+	if (config->enable_gpio.port) {
+		if (!gpio_is_ready_dt(&config->enable_gpio)) {
+			LOG_ERR("Enable GPIO not ready");
+			return -ENODEV;
+		}
+
+		ret = gpio_pin_configure_dt(&config->enable_gpio,
+					    GPIO_OUTPUT_ACTIVE);
+		if (ret < 0) {
+			LOG_ERR("Failed to configure enable_gpio, err: %d",
+				ret);
+			return ret;
+		}
+
+		/* datasheet 7.9: t_en max 3 ms for chip initialization */
+		k_msleep(3);
 	}
 
 	ret = i2c_reg_write_byte_dt(&config->bus, LP5569_CONFIG,
@@ -159,6 +180,7 @@ static const struct led_driver_api lp5569_led_api = {
 #define LP5569_DEFINE(id)						\
 	static const struct lp5569_config lp5569_config_##id = {	\
 		.bus = I2C_DT_SPEC_INST_GET(id),			\
+		.enable_gpio = GPIO_DT_SPEC_INST_GET_OR(id, enable_gpios, {0}), \
 		.cp_mode = DT_ENUM_IDX(DT_DRV_INST(id), charge_pump_mode),	\
 	};								\
 									\

--- a/drivers/led/lp5569.c
+++ b/drivers/led/lp5569.c
@@ -30,12 +30,14 @@ LOG_MODULE_REGISTER(lp5569, CONFIG_LED_LOG_LEVEL);
 
 #define LP5569_MISC			0x2F
 #define LP5569_POWERSAVE_EN		BIT(5)
+#define LP5569_CP_MODE_SHIFT		3
 
 /* PWM base Register for controlling the duty-cycle */
 #define LP5569_LED0_PWM			0x16
 
 struct lp5569_config {
 	struct i2c_dt_spec bus;
+	const uint8_t cp_mode;
 };
 
 static int lp5569_led_set_brightness(const struct device *dev, uint32_t led,
@@ -91,7 +93,8 @@ static int lp5569_enable(const struct device *dev)
 	}
 
 	ret = i2c_reg_write_byte_dt(&config->bus, LP5569_MISC,
-				    LP5569_POWERSAVE_EN);
+				    LP5569_POWERSAVE_EN |
+				    (config->cp_mode << LP5569_CP_MODE_SHIFT));
 	if (ret < 0) {
 		LOG_ERR("LED reg update failed");
 		return ret;
@@ -156,6 +159,7 @@ static const struct led_driver_api lp5569_led_api = {
 #define LP5569_DEFINE(id)						\
 	static const struct lp5569_config lp5569_config_##id = {	\
 		.bus = I2C_DT_SPEC_INST_GET(id),			\
+		.cp_mode = DT_ENUM_IDX(DT_DRV_INST(id), charge_pump_mode),	\
 	};								\
 									\
 	PM_DEVICE_DT_INST_DEFINE(id, lp5569_pm_action);			\

--- a/drivers/led/lp5569.c
+++ b/drivers/led/lp5569.c
@@ -23,18 +23,18 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(lp5569, CONFIG_LED_LOG_LEVEL);
 
-#define LP5569_NUM_LEDS			9
+#define LP5569_NUM_LEDS 9
 
 /* General Registers */
-#define LP5569_CONFIG			0x00
-#define LP5569_CHIP_EN			BIT(6)
+#define LP5569_CONFIG  0x00
+#define LP5569_CHIP_EN BIT(6)
 
-#define LP5569_MISC			0x2F
-#define LP5569_POWERSAVE_EN		BIT(5)
-#define LP5569_CP_MODE_SHIFT		3
+#define LP5569_MISC          0x2F
+#define LP5569_POWERSAVE_EN  BIT(5)
+#define LP5569_CP_MODE_SHIFT 3
 
 /* PWM base Register for controlling the duty-cycle */
-#define LP5569_LED0_PWM			0x16
+#define LP5569_LED0_PWM 0x16
 
 struct lp5569_config {
 	struct i2c_dt_spec bus;
@@ -42,8 +42,7 @@ struct lp5569_config {
 	const uint8_t cp_mode;
 };
 
-static int lp5569_led_set_brightness(const struct device *dev, uint32_t led,
-				     uint8_t brightness)
+static int lp5569_led_set_brightness(const struct device *dev, uint32_t led, uint8_t brightness)
 {
 	const struct lp5569_config *config = dev->config;
 	uint8_t val;
@@ -94,11 +93,9 @@ static int lp5569_enable(const struct device *dev)
 			return -ENODEV;
 		}
 
-		ret = gpio_pin_configure_dt(&config->enable_gpio,
-					    GPIO_OUTPUT_ACTIVE);
+		ret = gpio_pin_configure_dt(&config->enable_gpio, GPIO_OUTPUT_ACTIVE);
 		if (ret < 0) {
-			LOG_ERR("Failed to configure enable_gpio, err: %d",
-				ret);
+			LOG_ERR("Failed to configure enable_gpio, err: %d", ret);
 			return ret;
 		}
 
@@ -106,8 +103,7 @@ static int lp5569_enable(const struct device *dev)
 		k_msleep(3);
 	}
 
-	ret = i2c_reg_write_byte_dt(&config->bus, LP5569_CONFIG,
-				    LP5569_CHIP_EN);
+	ret = i2c_reg_write_byte_dt(&config->bus, LP5569_CONFIG, LP5569_CHIP_EN);
 	if (ret < 0) {
 		LOG_ERR("Enable LP5569 failed");
 		return ret;
@@ -115,7 +111,7 @@ static int lp5569_enable(const struct device *dev)
 
 	ret = i2c_reg_write_byte_dt(&config->bus, LP5569_MISC,
 				    LP5569_POWERSAVE_EN |
-				    (config->cp_mode << LP5569_CP_MODE_SHIFT));
+					    (config->cp_mode << LP5569_CP_MODE_SHIFT));
 	if (ret < 0) {
 		LOG_ERR("LED reg update failed");
 		return ret;
@@ -139,8 +135,7 @@ static int lp5569_init(const struct device *dev)
 }
 
 #ifdef CONFIG_PM_DEVICE
-static int lp5569_pm_action(const struct device *dev,
-			    enum pm_device_action action)
+static int lp5569_pm_action(const struct device *dev, enum pm_device_action action)
 {
 	const struct lp5569_config *config = dev->config;
 	int ret;
@@ -156,8 +151,7 @@ static int lp5569_pm_action(const struct device *dev,
 		break;
 	case PM_DEVICE_ACTION_TURN_OFF:
 	case PM_DEVICE_ACTION_SUSPEND:
-		ret = i2c_reg_update_byte_dt(&config->bus, LP5569_CONFIG,
-					   LP5569_CHIP_EN, 0);
+		ret = i2c_reg_update_byte_dt(&config->bus, LP5569_CONFIG, LP5569_CHIP_EN, 0);
 		if (ret < 0) {
 			LOG_ERR("Disable LP5569 failed");
 			return ret;
@@ -177,20 +171,17 @@ static const struct led_driver_api lp5569_led_api = {
 	.off = lp5569_led_off,
 };
 
-#define LP5569_DEFINE(id)						\
-	static const struct lp5569_config lp5569_config_##id = {	\
-		.bus = I2C_DT_SPEC_INST_GET(id),			\
-		.enable_gpio = GPIO_DT_SPEC_INST_GET_OR(id, enable_gpios, {0}), \
-		.cp_mode = DT_ENUM_IDX(DT_DRV_INST(id), charge_pump_mode),	\
-	};								\
-									\
-	PM_DEVICE_DT_INST_DEFINE(id, lp5569_pm_action);			\
-									\
-	DEVICE_DT_INST_DEFINE(id, &lp5569_init,				\
-			      PM_DEVICE_DT_INST_GET(id),		\
-			      NULL,					\
-			      &lp5569_config_##id, POST_KERNEL,		\
-			      CONFIG_LED_INIT_PRIORITY,			\
+#define LP5569_DEFINE(id)                                                                          \
+	static const struct lp5569_config lp5569_config_##id = {                                   \
+		.bus = I2C_DT_SPEC_INST_GET(id),                                                   \
+		.enable_gpio = GPIO_DT_SPEC_INST_GET_OR(id, enable_gpios, {0}),                    \
+		.cp_mode = DT_ENUM_IDX(DT_DRV_INST(id), charge_pump_mode),                         \
+	};                                                                                         \
+                                                                                                   \
+	PM_DEVICE_DT_INST_DEFINE(id, lp5569_pm_action);                                            \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(id, &lp5569_init, PM_DEVICE_DT_INST_GET(id), NULL,                   \
+			      &lp5569_config_##id, POST_KERNEL, CONFIG_LED_INIT_PRIORITY,          \
 			      &lp5569_led_api);
 
 DT_INST_FOREACH_STATUS_OKAY(LP5569_DEFINE)

--- a/dts/bindings/led/ti,lp5569.yaml
+++ b/dts/bindings/led/ti,lp5569.yaml
@@ -5,6 +5,11 @@ compatible: "ti,lp5569"
 include: i2c-device.yaml
 
 properties:
+  enable-gpios:
+    type: phandle-array
+    description: |
+      GPIO used to enable the lp5569.
+
   charge-pump-mode:
     type: string
     default: "disabled"

--- a/dts/bindings/led/ti,lp5569.yaml
+++ b/dts/bindings/led/ti,lp5569.yaml
@@ -3,3 +3,18 @@ description: TI LP5569 LED
 compatible: "ti,lp5569"
 
 include: i2c-device.yaml
+
+properties:
+  charge-pump-mode:
+    type: string
+    default: "disabled"
+    enum:
+      - "disabled"
+      - "1x"
+      - "1x5"
+      - "auto"
+    description: |
+      If provided, configures the internal charge-pump mode in the MISC
+      register. This can be useful to supply a higher voltage to the LEDs, than
+      what the lp5569 is being supplied.
+      The default corresponds to the reset value of the register.


### PR DESCRIPTION
[drivers: led: lp5569: add charge pump configuration](https://github.com/zephyrproject-rtos/zephyr/commit/6cbcd23c3811f8065b285c2f2c5f4a26cf4ad288)
The lp5569 controller contains an internal charge pump which can be useful
for driving LEDs with a forward voltage greater than the lp5569 supply.
Taking advantage of the charge pump can alleviate the need for an external
boost converter.

Add a dts property, charge-pump-mode, to the ti,lp5569 binding with which
the cp_mode bits of the MISC register will be configured.

Following the datasheet, the possible configurations are:
    0x00 -> disabled (default)
    0x01 -> 1x mode
    0x10 -> 1.5x mode
    0x11 -> auto mode

[drivers: led: lp5569: add enable-gpios](https://github.com/zephyrproject-rtos/zephyr/commit/74c99cc5c31c2a3eed0da054a3272981bef6f1d5)
The lp5569 features a double functioning pin for enable and pwm control.
The chip, however, uses the first rising edge to initialize and get ready
for i2c communication, and then the pin alters function to pwm mode.

Add support for providing enable-gpios to the lp5569 in the dts, which
will make sure to assert the pin and wait for the chip to initialize
before attempting further configuration of the chip.