### PR TITLE
soc: nordic: introduce CONFIG_NRF_PLATFORM_HALTIUM

### DIFF
--- a/soc/nordic/Kconfig
+++ b/soc/nordic/Kconfig
@@ -170,4 +170,11 @@ config NRF_TRACE_PORT
 	  Unit) for tracing using a hardware probe. If disabled, the trace
 	  pins will be used as GPIO.
 
+config NRF_PLATFORM_HALTIUM
+	bool
+	help
+	  SoC series based on the Nordic nRF Haltium platform need to select
+	  this option. This allows to easily enable common functionality on
+	  SoCs based on the Haltium platform.
+
 endif # SOC_FAMILY_NORDIC_NRF

--- a/soc/nordic/nrf54h/Kconfig
+++ b/soc/nordic/nrf54h/Kconfig
@@ -7,6 +7,7 @@ config SOC_SERIES_NRF54HX
 	select HAS_NRFS
 	select HAS_NRFX
 	select HAS_NORDIC_DRIVERS
+	select NRF_PLATFORM_HALTIUM
 
 config SOC_NRF54H20_CPUAPP
 	select ARM


### PR DESCRIPTION
Some new Nordic nRF SoCs are based on a common platform, named 'Haltium'. Introduce a selectable Kconfig option available for series to flag they are part of such common platform. This will allow to easily enable common code shared across all Haltium based products.