### PR TITLE
net: lwm2m: Allow SenML-CBOR floats decoded as int

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rw_senml_cbor.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_senml_cbor.c
@@ -615,7 +615,17 @@ static int get_float(struct lwm2m_input_context *in, double *value)
 		return -EINVAL;
 	}
 
-	*value = fd->current->record_union.union_vf;
+	switch (fd->current->record_union.record_union_choice) {
+	case union_vi_c:
+		*value = (double)fd->current->record_union.union_vi;
+		break;
+	case union_vf_c:
+		*value = fd->current->record_union.union_vf;
+		break;
+	default:
+		return -EINVAL;
+	}
+
 	fd->current = NULL;
 
 	return 0;


### PR DESCRIPTION
SenML is technically a JSON based format which can be encoded as a CBOR. SenML-CBOR specification in
RFC 8428 section 6 states that numbers can be decoded as an integer.

Also RFC 7049 section 4.2 states that JSON numbers without fractional part can be decoded as an integer.

I have seen with one commercial LwM2M platform that the decoder  they use, sends floating point values as integers, if there is no fractional part.

So LwM2M engine cannot assume from the path that
the incomming number is either float or int. Accept both.