### PR TITLE
boards: mpfs: update OpenOCD instructions for boards with  Microchip's PolarFire SoC

### DIFF
--- a/boards/beagle/beaglev_fire/doc/index.rst
+++ b/boards/beagle/beaglev_fire/doc/index.rst
@@ -57,7 +57,7 @@ from a different terminal, run:
 
 .. code-block:: bash
 
-   <softconsole_path>/openocd/bin/openocd --file \
+   <softconsole_path>/openocd/bin/openocd --command "set DEVICE MPFS" --file \
    <softconsole_path>/openocd/share/openocd/scripts/board/microsemi-riscv.cfg
 
 

--- a/boards/microchip/mpfs_icicle/doc/index.rst
+++ b/boards/microchip/mpfs_icicle/doc/index.rst
@@ -45,7 +45,7 @@ To establish an OpenOCD connection run:
 .. code-block:: bash
 
    sudo LD_LIBRARY_PATH=<softconsole_path>/openocd/bin \
-   <softconsole_path>/openocd/bin/openocd  --file \
+   <softconsole_path>/openocd/bin/openocd --command "set DEVICE MPFS" --file \
    <softconsole_path>/openocd/share/openocd/scripts/board/microsemi-riscv.cfg
 
 


### PR DESCRIPTION
There was a key argument left out of the arg string for OpenOCD. This PR addresses #76694 and #76695