### PR TITLE
llext: add support for init arrays

### DIFF
--- a/include/zephyr/llext/elf.h
+++ b/include/zephyr/llext/elf.h
@@ -206,6 +206,9 @@ struct elf64_shdr {
 #define SHT_NOBITS 0x8          /**< Program data with no file image */
 #define SHT_REL 0x9             /**< Relocation entries without addends */
 #define SHT_DYNSYM 0xB          /**< Dynamic linking symbol table */
+#define SHT_INIT_ARRAY 0xe      /**< Array of pointers to init functions */
+#define SHT_FINI_ARRAY 0xf      /**< Array of pointers to termination functions */
+#define SHT_PREINIT_ARRAY 0x10  /**< Array of pointers to early init functions */
 
 /** ELF section flags */
 #define SHF_WRITE 0x1           /**< Section is writable */

--- a/include/zephyr/llext/llext.h
+++ b/include/zephyr/llext/llext.h
@@ -50,6 +50,9 @@ enum llext_mem {
 	LLEXT_MEM_SYMTAB,       /**< Symbol table */
 	LLEXT_MEM_STRTAB,       /**< Symbol name strings */
 	LLEXT_MEM_SHSTRTAB,     /**< Section name strings */
+	LLEXT_MEM_PREINIT,      /**< Array of early init functions */
+	LLEXT_MEM_INIT,         /**< Array of init functions */
+	LLEXT_MEM_FINI,         /**< Array of termination functions */
 
 	LLEXT_MEM_COUNT,        /**< Number of regions managed by LLEXT */
 };


### PR DESCRIPTION
Add support for the `.preinit_array` and `.init_array` sections in ELF files. These sections are arrays of function pointers that are filled by the compiler with the addresses of functions, such as C++ constructors, that need to be called at startup by the loader.

Supporting the `.fini_array section` requires more changes and is not currently implemented.

A test for this feature and several other C++-related changes will be forthcoming. 