### PR TITLE
drivers: hwinfo: add the HWINFO_HAS_DRIVER Kconfig option

### DIFF
--- a/drivers/hwinfo/Kconfig
+++ b/drivers/hwinfo/Kconfig
@@ -14,6 +14,11 @@ module = HWINFO
 module-str = HWINFO
 source "subsys/logging/Kconfig.template.log_config"
 
+config HWINFO_HAS_DRIVER
+	bool
+	help
+	  This is an option enabled by individual drivers to signal that there is a hwinfo driver.
+
 config HWINFO_SHELL
 	bool "HWINFO Shell"
 	depends on SHELL
@@ -24,6 +29,7 @@ menuconfig HWINFO_CC13XX_CC26XX
 	bool "TI SimpleLink CC13xx/CC26xx hwinfo driver"
 	default y
 	depends on SOC_SERIES_CC13X2_CC26X2 || SOC_SERIES_CC13X2X7_CC26X2X7
+	select HWINFO_HAS_DRIVER
 	help
 	  Enable TI SimpleLink CC13xx/CC26xx hwinfo driver.
 
@@ -54,12 +60,13 @@ config HWINFO_CC13XX_CC26XX_USE_BLE_MAC
 
 endchoice
 
-endif
+endif # HWINFO_CC13XX_CC26XX
 
 config HWINFO_STM32
 	bool "STM32 hwinfo"
 	default y
 	depends on SOC_FAMILY_STM32
+	select HWINFO_HAS_DRIVER
 	help
 	  Enable STM32 hwinfo driver.
 
@@ -68,6 +75,7 @@ config HWINFO_NRF
 	default y
 	depends on SOC_FAMILY_NORDIC_NRF
 	depends on SOC_SERIES_NRF54HX || NRF_SOC_SECURE_SUPPORTED
+	select HWINFO_HAS_DRIVER
 	help
 	  Enable Nordic NRF hwinfo driver.
 
@@ -75,6 +83,7 @@ config HWINFO_MCUX_RCM
 	bool "NXP kinetis reset cause"
 	default y
 	depends on HAS_MCUX_RCM
+	select HWINFO_HAS_DRIVER
 	help
 	  Enable NXP kinetis mcux RCM hwinfo driver.
 
@@ -82,6 +91,7 @@ config HWINFO_MCUX_SIM
 	bool "NXP kinetis SIM device ID"
 	default y
 	depends on HAS_MCUX_SIM
+	select HWINFO_HAS_DRIVER
 	help
 	  Enable NXP kinetis mcux SIM hwinfo driver.
 
@@ -89,6 +99,7 @@ config HWINFO_MCUX_SRC
 	bool "NXP SRC reset cause"
 	default y
 	depends on HAS_MCUX_SRC
+	select HWINFO_HAS_DRIVER
 	help
 	  Enable NXP i.MX mcux SRC hwinfo driver.
 
@@ -96,6 +107,7 @@ config HWINFO_MCUX_SRC_V2
 	bool "NXP SRC reset cause (multicore devices)"
 	default y
 	depends on HAS_MCUX_SRC_V2
+	select HWINFO_HAS_DRIVER
 	help
 	  Enable version 2 multicore NXP i.MX mcux SRC hwinfo driver.
 
@@ -103,6 +115,7 @@ config HWINFO_MCUX_SYSCON
 	bool "NXP LPC device ID"
 	default y
 	depends on DT_HAS_NXP_LPC_UID_ENABLED
+	select HWINFO_HAS_DRIVER
 	help
 	  Enable NXP LPC mcux hwinfo driver.
 
@@ -110,6 +123,7 @@ config HWINFO_IMXRT
 	bool "NXP i.mx RT device ID"
 	default y
 	depends on SOC_SERIES_IMXRT10XX || SOC_SERIES_IMXRT11XX
+	select HWINFO_HAS_DRIVER
 	help
 	  Enable NXP i.mx RT hwinfo driver.
 
@@ -117,6 +131,7 @@ config HWINFO_RPI_PICO
 	bool "Raspberry Pi Pico hwinfo driver"
 	default y
 	depends on SOC_SERIES_RP2XXX
+	select HWINFO_HAS_DRIVER
 	select PICOSDK_USE_FLASH
 	help
 	  Enable Raspberry Pi Pico hwinfo driver.
@@ -125,6 +140,7 @@ config HWINFO_SAM_RSTC
 	bool "Atmel SAM reset cause"
 	default y
 	depends on SOC_FAMILY_ATMEL_SAM && !SOC_SERIES_SAM4L
+	select HWINFO_HAS_DRIVER
 	help
 	  Enable Atmel SAM reset cause hwinfo driver.
 
@@ -132,6 +148,7 @@ config HWINFO_SAM
 	bool "Atmel SAM device ID"
 	default y
 	depends on SOC_FAMILY_ATMEL_SAM && !SOC_SERIES_SAM4L
+	select HWINFO_HAS_DRIVER
 	help
 	  Enable Atmel SAM device ID hwinfo driver.
 
@@ -139,6 +156,7 @@ config HWINFO_SAM4L
 	bool "Atmel SAM4L device ID"
 	default y
 	depends on SOC_SERIES_SAM4L
+	select HWINFO_HAS_DRIVER
 	help
 	  Enable Atmel SAM4L hwinfo driver.
 
@@ -146,6 +164,7 @@ config HWINFO_SAM0
 	bool "Atmel SAM0 device ID"
 	default y
 	depends on SOC_FAMILY_ATMEL_SAM0
+	select HWINFO_HAS_DRIVER
 	help
 	  Enable Atmel SAM0 hwinfo driver.
 
@@ -153,6 +172,7 @@ config HWINFO_SMARTBOND
 	bool "Smartbond device reset cause"
 	default y
 	depends on SOC_FAMILY_RENESAS_SMARTBOND
+	select HWINFO_HAS_DRIVER
 	help
 	  Enable Smartbond reset cause hwinfo driver.
 
@@ -160,6 +180,7 @@ config HWINFO_ESP32
 	bool "ESP32 device ID"
 	default y
 	depends on SOC_FAMILY_ESPRESSIF_ESP32
+	select HWINFO_HAS_DRIVER
 	help
 	  Enable ESP32 hwinfo driver.
 
@@ -167,6 +188,7 @@ config HWINFO_LITEX
 	bool "LiteX device ID"
 	default y
 	depends on SOC_LITEX_VEXRISCV
+	select HWINFO_HAS_DRIVER
 	help
 	  Enable LiteX hwinfo driver
 
@@ -174,6 +196,7 @@ config HWINFO_PSOC6
 	bool "Cypress PSoC-6 unique device ID"
 	default y
 	depends on SOC_FAMILY_PSOC6_LEGACY
+	select HWINFO_HAS_DRIVER
 	help
 	  Enable Cypress PSoC-6 hwinfo driver.
 
@@ -183,6 +206,7 @@ config HWINFO_GECKO
 	depends on SOC_FAMILY_SILABS_S0 || SOC_FAMILY_SILABS_S1 || SOC_FAMILY_SILABS_S2
 	depends on !SOC_SERIES_EFR32MG21
 	depends on !SOC_SERIES_EFR32BG22
+	select HWINFO_HAS_DRIVER
 	select SOC_GECKO_RMU
 	help
 	  Enable Silabs GECKO hwinfo driver.
@@ -192,6 +216,7 @@ config HWINFO_ANDES
 	default y
 	depends on SOC_FAMILY_ANDES_V5
 	depends on SYSCON
+	select HWINFO_HAS_DRIVER
 	help
 	  Enable Andes hwinfo driver
 
@@ -199,6 +224,7 @@ config HWINFO_RW61X
 	bool "RW61X hwinfo"
 	default y
 	depends on SOC_SERIES_RW6XX
+	select HWINFO_HAS_DRIVER
 	help
 	  Enable RW61X hwinfo driver
 
@@ -206,6 +232,7 @@ config HWINFO_AMBIQ
 	bool "AMBIQ hwinfo"
 	default y
 	depends on SOC_SERIES_APOLLO4X
+	select HWINFO_HAS_DRIVER
 	select AMBIQ_HAL
 	select AMBIQ_HAL_USE_HWINFO
 	help
@@ -215,6 +242,7 @@ config HWINFO_NUMAKER
 	bool "NuMaker hwinfo"
 	default y
 	depends on SOC_SERIES_M46X
+	select HWINFO_HAS_DRIVER
 	select HAS_NUMAKER_FMC
 	help
 	  Enable Nuvoton NuMaker hwinfo driver
@@ -223,6 +251,7 @@ config HWINFO_NUMAKER_RMC
 	bool "NuMaker hwinfo backed up by RMC"
 	default y
 	depends on SOC_SERIES_M2L31X
+	select HWINFO_HAS_DRIVER
 	select HAS_NUMAKER_RMC
 	help
 	  Enable Nuvoton NuMaker hwinfo driver backed up by RMC


### PR DESCRIPTION
Introduce a Kconfig option to signal whether a HW info driver is available when HWINFO is enabled.