### PR TITLE
Updated Init Clocks for LPTMR

### DIFF
--- a/boards/nxp/frdm_mcxn947/board.c
+++ b/boards/nxp/frdm_mcxn947/board.c
@@ -299,8 +299,28 @@ static int frdm_mcxn947_init(void)
 #endif
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(lptmr0), okay)
+
+/*
+ * Clock Select Decides what input source the lptmr will clock from
+ *
+ * 0 <- 12MHz FRO
+ * 1 <- 16K FRO
+ * 2 <- 32K OSC
+ * 3 <- Output from the OSC_SYS
+ */
+#if DT_PROP(DT_NODELABEL(lptmr0), clk_source) == 0x0
+	CLOCK_SetupClockCtrl(kCLOCK_FRO12MHZ_ENA);
+#elif DT_PROP(DT_NODELABEL(lptmr0), clk_source) == 0x1
 	CLOCK_SetupClk16KClocking(kCLOCK_Clk16KToVsys);
-#endif
+#elif DT_PROP(DT_NODELABEL(lptmr0), clk_source) == 0x2
+	CLOCK_SetupOsc32KClocking(kCLOCK_Osc32kToVsys);
+#elif DT_PROP(DT_NODELABEL(lptmr0), clk_source) == 0x3
+	/* Value here should not exceed 25MHZ when using lptmr */
+	CLOCK_SetupExtClocking(MHZ(24));
+	CLOCK_SetupClockCtrl(kCLOCK_CLKIN_ENA_FM_USBH_LPT);
+#endif /* DT_PROP(DT_NODELABEL(lptmr0), clk_source) */
+
+#endif /* DT_NODE_HAS_STATUS(DT_NODELABEL(lptmr0), okay) */
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(flexio0), okay)
 	CLOCK_SetClkDiv(kCLOCK_DivFlexioClk, 1u);

--- a/dts/bindings/counter/nxp,lptmr.yaml
+++ b/dts/bindings/counter/nxp,lptmr.yaml
@@ -20,7 +20,13 @@ properties:
   clk-source:
     type: int
     required: true
-    description: Prescaler clock source (0 to 3)
+    enum: [0, 1, 2, 3]
+    description: |
+      Selects the clock to be used by the LPMTR prescaler/glitch filter.
+      In time counter mode, this field selects the input clock to the prescaler.
+      In pulse counter mode, this field selects the input clock to the glitch filter.
+      The clock connections vary by device, see the device reference manual for
+      more details.
 
   input-pin:
     type: int


### PR DESCRIPTION
The LPTMR allows the user to select and Input clock, however said input clock must be
initialized before the user can select it. This PR updates the code to reflect this.