### PR TITLE
Updated lptmr to support multi instance.

### DIFF
--- a/dts/arm/nxp/nxp_mcxn94x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn94x_common.dtsi
@@ -907,6 +907,17 @@
 		resolution = <32>;
 	};
 
+	lptmr1: lptmr@4b000 {
+		compatible = "nxp,lptmr";
+		reg = <0x4b000 0x1000>;
+		interrupts = <144 0>;
+		clock-frequency = <16000>;
+		prescaler = <1>;
+		clk-source = <1>;
+		resolution = <32>;
+	};
+
+
 	flexio0: flexio@105000 {
 		compatible = "nxp,flexio";
 		reg = <0x105000 0x1000>;

--- a/dts/bindings/counter/nxp,lptmr.yaml
+++ b/dts/bindings/counter/nxp,lptmr.yaml
@@ -13,9 +13,11 @@ properties:
 
   clock-frequency:
     required: true
+    description: Counter clock frequency
 
   prescaler:
     required: true
+    description: The frequency of the counter is divided by this value.
 
   clk-source:
     type: int
@@ -30,13 +32,40 @@ properties:
 
   input-pin:
     type: int
-    description: Pulse counter input pin (0 to 3).
+    description: |
+      When LPTMR is in Pulse mode, this value
+      will be used to determine the "rising-edge
+      source pin" to increment the lptmr counter.
 
   active-low:
     type: boolean
-    description: Pulse counter input pin is active-low
+    description: |
+      When LPTMR is in Pulse mode, this value
+      will set the counter to active low.
 
   resolution:
     type: int
     required: true
-    description: Represents the width of the timer in bits.
+    description: Represents the width of the counter in bits.
+
+  prescale-glitch-filter:
+    type: int
+    default: 1
+    enum: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+    description: |
+      When in prescaler mode, the counter is incremented every
+        2 ^ [prescaler-glitch-filter] clock cycles.
+      When in pulse mode, the counter is incremented every
+        2 ^ [prescaler-glitch-filter] rising edges detected
+        by the pin configured from the input-pin value.
+        Note, that the pulse mode cannot be 2 ^ 16.
+
+  timer-mode-sel:
+    type: int
+    enum: [0, 1]
+    default: 0
+    description: |
+      This value determines rather the LPTMR is configured
+      for Time-Counter mode or for Pulse mode.
+      0 <- LPTMR is configured for Time Counter Mode.
+      1 <- LPTMR is configured for Pulse Mode.


### PR DESCRIPTION
Updated the counter_mcux_lptmr driver to support multiple instances of the lptmr peripheral. 
Also added a new binding property to identify if the user is using
counter-mode since we were previously using the
prescaler value to check this, which could be wrong if used as a division value for getting the freq.