### PR TITLE
drivers: flash_stm32_qspi: fix DT accessor for flash size

### DIFF
--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -2593,7 +2593,7 @@ static const struct flash_stm32_ospi_config flash_stm32_ospi_cfg = {
 		       .enr = DT_CLOCKS_CELL_BY_NAME(STM32_OSPI_NODE, ospi_mgr, bits)},
 #endif
 	.irq_config = flash_stm32_ospi_irq_config_func,
-	.flash_size = DT_INST_REG_ADDR_BY_IDX(0, 1),
+	.flash_size = DT_INST_REG_SIZE(0),
 	.max_frequency = DT_INST_PROP(0, ospi_max_frequency),
 	.data_mode = DT_INST_PROP(0, spi_bus_width), /* SPI or OPI */
 	.data_rate = DT_INST_PROP(0, data_rate), /* DTR or STR */

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -1617,7 +1617,7 @@ static const struct flash_stm32_qspi_config flash_stm32_qspi_cfg = {
 		.bus = DT_CLOCKS_CELL(STM32_QSPI_NODE, bus)
 	},
 	.irq_config = flash_stm32_qspi_irq_config_func,
-	.flash_size = DT_INST_REG_ADDR_BY_IDX(0, 1) << STM32_QSPI_DOUBLE_FLASH,
+	.flash_size = DT_INST_REG_SIZE(0) << STM32_QSPI_DOUBLE_FLASH,
 	.max_frequency = DT_INST_PROP(0, qspi_max_frequency),
 	.pcfg = PINCTRL_DT_DEV_CONFIG_GET(STM32_QSPI_NODE),
 #if STM32_QSPI_RESET_GPIO

--- a/dts/arm/st/f4/stm32f412.dtsi
+++ b/dts/arm/st/f4/stm32f412.dtsi
@@ -215,7 +215,7 @@
 		quadspi: spi@a0001000 {
 			compatible = "st,stm32-qspi";
 			#address-cells = <0x1>;
-			#size-cells = <0x0>;
+			#size-cells = <0x1>;
 			reg = <0xa0001000 0x400>;
 			interrupts = <92 0>;
 			clocks = <&rcc STM32_CLOCK(AHB3, 1U)>;

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -857,7 +857,7 @@
 		quadspi: spi@a0001000 {
 			compatible = "st,stm32-qspi";
 			#address-cells = <0x1>;
-			#size-cells = <0x0>;
+			#size-cells = <0x1>;
 			reg = <0xa0001000 0x34>;
 			interrupts = <92 0>;
 			clocks = <&rcc STM32_CLOCK(AHB3, 1U)>;

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -1068,7 +1068,7 @@
 		quadspi: spi@52005000 {
 			compatible = "st,stm32-qspi";
 			#address-cells = <0x1>;
-			#size-cells = <0x0>;
+			#size-cells = <0x1>;
 			reg = <0x52005000 0x34>;
 			interrupts = <92 0>;
 			clocks = <&rcc STM32_CLOCK(AHB3, 14U)>;

--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -101,7 +101,7 @@
 			clocks = <&rcc STM32_CLOCK(AHB3, 14U)>,
 				<&rcc STM32_SRC_PLL1_Q OSPI_SEL(1)>;
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			status = "disabled";
 		};
 
@@ -113,7 +113,7 @@
 			clocks = <&rcc STM32_CLOCK(AHB3, 19U)>,
 				<&rcc STM32_SRC_PLL1_Q OSPI_SEL(1)>;
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/h7/stm32h7a3.dtsi
+++ b/dts/arm/st/h7/stm32h7a3.dtsi
@@ -64,7 +64,7 @@
 			clocks = <&rcc STM32_CLOCK(AHB3, 14U)>,
 				<&rcc STM32_SRC_PLL1_Q OSPI_SEL(1)>;
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			status = "disabled";
 		};
 
@@ -76,7 +76,7 @@
 			clocks = <&rcc STM32_CLOCK(AHB3, 19U)>,
 				<&rcc STM32_SRC_PLL1_Q OSPI_SEL(1)>;
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -266,7 +266,7 @@
 		quadspi: spi@a0001000 {
 			compatible = "st,stm32-qspi";
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			reg = <0xa0001000 0x400>;
 			interrupts = <71 0>;
 			clocks = <&rcc STM32_CLOCK(AHB3, 8U)>;

--- a/dts/arm/st/l4/stm32l4p5.dtsi
+++ b/dts/arm/st/l4/stm32l4p5.dtsi
@@ -373,7 +373,7 @@
 				<&rcc STM32_CLOCK(AHB2, 20U)>;
 
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			status = "disabled";
 		};
 
@@ -387,7 +387,7 @@
 				<&rcc STM32_CLOCK(AHB2, 20U)>;
 
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -440,7 +440,7 @@
 			clocks = <&rcc STM32_CLOCK(AHB3, 8U)>,
 					<&rcc STM32_SRC_SYSCLK OSPI_SEL(0)>;
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -705,7 +705,7 @@
 				<&rcc STM32_SRC_SYSCLK OCTOSPI_SEL(0)>,
 				<&rcc STM32_CLOCK(AHB2, 21U)>;
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			status = "disabled";
 		};
 
@@ -718,7 +718,7 @@
 				<&rcc STM32_SRC_SYSCLK OCTOSPI_SEL(0)>,
 				<&rcc STM32_CLOCK(AHB2, 21U)>;
 			#address-cells = <1>;
-			#size-cells = <0>;
+			#size-cells = <1>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -496,7 +496,7 @@
 		quadspi: spi@a0001000 {
 			compatible = "st,stm32-qspi";
 			#address-cells = <0x1>;
-			#size-cells = <0x0>;
+			#size-cells = <0x1>;
 			reg = <0xa0001000 0x400>;
 			interrupts = <0x32 0x0>;
 			clocks = <&rcc STM32_CLOCK(AHB3, 8U)>;


### PR DESCRIPTION
The flash size is the second part (size) of the first reg value, not the first part (address) of a nonexistent second reg value.

This was introduced in #68274, and I don't understand how it has ever worked. I'm getting the following errors:

```
$PRJDIR/build/zephyr/include/generated/zephyr/devicetree_generated.h:14745:39: error: 'DT_N_S_soc_S_quadspi_a0001000_S_flash_90000000_REG_IDX_1_VAL_ADDRESS' undeclared here (not in a function); did you mean 'DT_N_S_soc_S_quadspi_a0001000_S_flash_90000000_REG_IDX_0_VAL_ADDRESS'?
14745 | #define DT_N_INST_0_st_stm32_qspi_nor DT_N_S_soc_S_quadspi_a0001000_S_flash_90000000
      |                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
$PRJDIR/zephyr/include/zephyr/devicetree.h:4785:33: note: in definition of macro 'DT_CAT4'
 4785 | #define DT_CAT4(a1, a2, a3, a4) a1 ## a2 ## a3 ## a4
      |                                 ^~
$PRJDIR/zephyr/include/zephyr/devicetree.h:4125:44: note: in expansion of macro 'DT_REG_ADDR_BY_IDX'
 4125 | #define DT_INST_REG_ADDR_BY_IDX(inst, idx) DT_REG_ADDR_BY_IDX(DT_DRV_INST(inst), idx)
      |                                            ^~~~~~~~~~~~~~~~~~
$PRJDIR/zephyr/include/zephyr/sys/util_internal.h:105:36: note: in expansion of macro 'DT_N_INST_0_st_stm32_qspi_nor'
  105 | #define UTIL_PRIMITIVE_CAT(a, ...) a##__VA_ARGS__
      |                                    ^
$PRJDIR/zephyr/include/zephyr/sys/util_internal.h:104:26: note: in expansion of macro 'UTIL_PRIMITIVE_CAT'
  104 | #define UTIL_CAT(a, ...) UTIL_PRIMITIVE_CAT(a, __VA_ARGS__)
      |                          ^~~~~~~~~~~~~~~~~~
$PRJDIR/zephyr/include/zephyr/devicetree.h:336:31: note: in expansion of macro 'UTIL_CAT'
  336 | #define DT_INST(inst, compat) UTIL_CAT(DT_N_INST, DT_DASH(inst, compat))
      |                               ^~~~~~~~
$PRJDIR/zephyr/include/zephyr/devicetree.h:3604:27: note: in expansion of macro 'DT_INST'
 3604 | #define DT_DRV_INST(inst) DT_INST(inst, DT_DRV_COMPAT)
      |                           ^~~~~~~
$PRJDIR/zephyr/include/zephyr/devicetree.h:4125:63: note: in expansion of macro 'DT_DRV_INST'
 4125 | #define DT_INST_REG_ADDR_BY_IDX(inst, idx) DT_REG_ADDR_BY_IDX(DT_DRV_INST(inst), idx)
      |                                                               ^~~~~~~~~~~
$PRJDIR/zephyr/drivers/flash/flash_stm32_qspi.c:1567:23: note: in expansion of macro 'DT_INST_REG_ADDR_BY_IDX'
 1567 |         .flash_size = DT_INST_REG_ADDR_BY_IDX(0, 1),
      |                       ^~~~~~~~~~~~~~~~~~~~~~~
```
