### PR TITLE
net: dns_sd: add missing header file and fix code samples in documentation

### DIFF
--- a/include/zephyr/net/dns_sd.h
+++ b/include/zephyr/net/dns_sd.h
@@ -131,18 +131,15 @@ extern "C" {
  * Example (with TXT):
  * @code{.c}
  * #include <zephyr/net/dns_sd.h>
- * static const bar_txt[] = {
+ * static const char bar_txt[] = {
  *   "\x06" "path=/"
  *   "\x0f" "this=is the way"
  *   "\x0e" "foo or=foo not"
  *   "\x17" "this=has\0embedded\0nulls"
  *   "\x04" "true"
  * };
- * // Possibly use an ephemeral port
- * // Possibly only assign bar_port when the service is running
- * static uint16_t bar_port;
  * DNS_SD_REGISTER_TCP_SERVICE(bar, CONFIG_NET_HOSTNAME,
- *   "_bar", "local", bar_txt, &bar_port);
+ *   "_bar", "local", bar_txt, 4242);
  * @endcode
  *
  * TXT records begin with a single length byte (hex-encoded)
@@ -177,10 +174,8 @@ extern "C" {
  * Example (no TXT):
  * @code{.c}
  * #include <zephyr/net/dns_sd.h>
- * #include <zephyr/sys/byteorder.h>
- * static const foo_port = sys_cpu_to_be16(4242);
  * DNS_SD_REGISTER_UDP_SERVICE(foo, CONFIG_NET_HOSTNAME,
- *   "_foo", DNS_SD_EMPTY_TXT, &foo_port);
+ *   "_foo", "local", DNS_SD_EMPTY_TXT, 4242);
  * @endcode
  *
  * @param id variable name for the DNS-SD service record

--- a/include/zephyr/net/dns_sd.h
+++ b/include/zephyr/net/dns_sd.h
@@ -13,6 +13,7 @@
 
 #include <stdint.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/iterable_sections.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Service registration macros in `dns_sd.h` require `iterable_sections.h` to compile.

In code samples within `dns_sd.h`, macros for registering TCP and UDP services accept a port as a number, not a pointer. Also added missing parameter to UDP service macro, and missing type of `bar_txt`.