### PR TITLE
scripts: ci: testplan: Allow tag exclusion by exe

### DIFF
--- a/scripts/ci/tags.yaml
+++ b/scripts/ci/tags.yaml
@@ -34,6 +34,10 @@
 #         Like 'files-regex', but any matching files will be excluded from the
 #         tag.
 #
+#     needs-exe:
+#         The name of an executable that must be present for this tag
+#         to be considered at all.
+#
 # All tags must have a 'files' and/or 'files-regex' key.
 
 # 1. Avoid putting include/ in entries as any include/ change we want


### PR DESCRIPTION
Allow tags to have a `needs-exe` option that gives a command to be run to ensure the tag can be built.  If the command isn't present or returns false, then always exclude the given tag.