### PR TITLE
LLEXT EDK: add compile definitions to the EDK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2133,12 +2133,15 @@ endif()
 set(llext_edk_file ${PROJECT_BINARY_DIR}/${CONFIG_LLEXT_EDK_NAME}.tar.xz)
 
 # TODO maybe generate flags for C CXX ASM
+zephyr_get_compile_definitions_for_lang(C zephyr_defs)
 zephyr_get_compile_options_for_lang(C zephyr_flags)
 
 # Filter out non LLEXT and LLEXT_EDK flags - and add required ones
-llext_filter_zephyr_flags(LLEXT_REMOVE_FLAGS ${zephyr_flags} llext_edk_cflags)
-llext_filter_zephyr_flags(LLEXT_EDK_REMOVE_FLAGS ${llext_edk_cflags} llext_edk_cflags)
+llext_filter_zephyr_flags(LLEXT_REMOVE_FLAGS ${zephyr_flags} llext_filt_flags)
+llext_filter_zephyr_flags(LLEXT_EDK_REMOVE_FLAGS ${llext_filt_flags} llext_filt_flags)
 
+set(llext_edk_cflags ${zephyr_defs} -DLL_EXTENSION_BUILD)
+list(APPEND llext_edk_cflags ${llext_filt_flags})
 list(APPEND llext_edk_cflags ${LLEXT_APPEND_FLAGS})
 list(APPEND llext_edk_cflags ${LLEXT_EDK_APPEND_FLAGS})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2162,7 +2162,7 @@ add_custom_command(
         -DAPPLICATION_SOURCE_DIR=${APPLICATION_SOURCE_DIR}
         -DINTERFACE_INCLUDE_DIRECTORIES="$<TARGET_PROPERTY:zephyr_interface,INTERFACE_INCLUDE_DIRECTORIES>"
         -Dllext_edk_file=${llext_edk_file}
-        -Dllext_cflags="${llext_edk_cflags}"
+        -Dllext_edk_cflags="${llext_edk_cflags}"
         -Dllext_edk_name=${CONFIG_LLEXT_EDK_NAME}
         -DWEST_TOPDIR=${WEST_TOPDIR}
         -DZEPHYR_BASE=${ZEPHYR_BASE}

--- a/cmake/llext-edk.cmake
+++ b/cmake/llext-edk.cmake
@@ -118,8 +118,8 @@ foreach(flag ${llext_edk_cflags})
 endforeach()
 set(llext_edk_cflags ${new_cflags})
 
-list(APPEND base_flags_make ${llext_edk_cflags} ${imacros_make} -DLL_EXTENSION_BUILD)
-list(APPEND base_flags_cmake ${llext_edk_cflags} ${imacros_cmake} -DLL_EXTENSION_BUILD)
+list(APPEND base_flags_make ${llext_edk_cflags} ${imacros_make})
+list(APPEND base_flags_cmake ${llext_edk_cflags} ${imacros_cmake})
 
 separate_arguments(include_dirs NATIVE_COMMAND ${INTERFACE_INCLUDE_DIRECTORIES})
 file(MAKE_DIRECTORY ${llext_edk_inc})

--- a/cmake/llext-edk.cmake
+++ b/cmake/llext-edk.cmake
@@ -18,7 +18,7 @@
 #   from. It should simply be the INTERFACE_INCLUDE_DIRECTORIES property of the
 #   zephyr_interface target.
 # - llext_edk_file: Output file name for the tarball.
-# - llext_cflags: Additional flags to be added to the generated flags.
+# - llext_edk_cflags: Flags to be used for source compile commands.
 # - ZEPHYR_BASE: Path to the zephyr base directory.
 # - WEST_TOPDIR: Path to the west top directory.
 # - APPLICATION_SOURCE_DIR: Path to the application source directory.
@@ -93,10 +93,10 @@ string(REGEX REPLACE "[^a-zA-Z0-9]" "_" llext_edk_name_sane ${llext_edk_name})
 string(TOUPPER ${llext_edk_name_sane} llext_edk_name_sane)
 set(install_dir_var "${llext_edk_name_sane}_INSTALL_DIR")
 
-separate_arguments(llext_cflags NATIVE_COMMAND ${llext_cflags})
+separate_arguments(llext_edk_cflags NATIVE_COMMAND ${llext_edk_cflags})
 
 set(make_relative FALSE)
-foreach(flag ${llext_cflags})
+foreach(flag ${llext_edk_cflags})
     if (flag STREQUAL "-imacros")
         set(make_relative TRUE)
     elseif (make_relative)
@@ -116,11 +116,10 @@ foreach(flag ${llext_cflags})
         list(APPEND new_cflags ${flag})
     endif()
 endforeach()
-set(llext_cflags ${new_cflags})
+set(llext_edk_cflags ${new_cflags})
 
-
-list(APPEND base_flags_make ${llext_cflags} ${imacros_make} -DLL_EXTENSION_BUILD)
-list(APPEND base_flags_cmake ${llext_cflags} ${imacros_cmake} -DLL_EXTENSION_BUILD)
+list(APPEND base_flags_make ${llext_edk_cflags} ${imacros_make} -DLL_EXTENSION_BUILD)
+list(APPEND base_flags_cmake ${llext_edk_cflags} ${imacros_cmake} -DLL_EXTENSION_BUILD)
 
 separate_arguments(include_dirs NATIVE_COMMAND ${INTERFACE_INCLUDE_DIRECTORIES})
 file(MAKE_DIRECTORY ${llext_edk_inc})


### PR DESCRIPTION
The LLEXT EDK was not exporting common Zephyr compile definitions (`-Dxxx` arguments). This patch adds the missing compile definitions before the other compile flags, as it is done in the Zephyr build system.
The same patch also adds the `-DLL_EXTENSION_BUILD` flag to this list, instead of providing a special case for it at a later stage.

A separate refactor, local to `cmake/llext-edk.cmake` and with no logic changes, renames the `llext_cflags` variable to `llext_edk_cflags` so that it matches the same variable in the main Zephyr `CMakeLists.txt`. 