### PR TITLE
doc: fix return/retval usage

### DIFF
--- a/drivers/flash/soc_flash_nrf.h
+++ b/drivers/flash/soc_flash_nrf.h
@@ -48,9 +48,9 @@ struct flash_context {
  * Callback which executes the flash operation.
  *
  * @param context pointer to flash_context structure.
- * @retval @ref FLASH_OP_DONE once operation was done, @ref FLASH_OP_ONGOING if
- *         operation needs more time for execution and a negative error code if
- *         operation was aborted.
+ * @retval @ref FLASH_OP_DONE once operation was done
+ * @retval @ref FLASH_OP_ONGOING if operation needs more time for execution
+ * @retval -errno negative error code if operation was aborted.
  */
 typedef int (*flash_op_handler_t) (void *context);
 

--- a/drivers/gnss/gnss_nmea0183.h
+++ b/drivers/gnss/gnss_nmea0183.h
@@ -168,7 +168,7 @@ int gnss_nmea0183_parse_gsv_header(const char **argv, uint16_t argc,
  * @param satellites Destination for parsed satellites from NMEA0183 GGA message
  * @param size Size of destination for parsed satellites from NMEA0183 GGA message
  *
- * @retval Number of parsed space-vehicles stored at destination if successful
+ * @return Number of parsed space-vehicles stored at destination if successful
  * @retval -ENOMEM if all space-vehicles in message could not be stored at destination
  * @retval -EINVAL if input is invalid
  */

--- a/drivers/modem/modem_cmd_handler.h
+++ b/drivers/modem/modem_cmd_handler.h
@@ -128,7 +128,7 @@ struct modem_cmd_handler_data {
  *
  * @param  data: command handler data reference
  *
- * @retval last handled error.
+ * @return last handled error.
  */
 int modem_cmd_handler_get_error(struct modem_cmd_handler_data *data);
 

--- a/drivers/modem/modem_context.h
+++ b/drivers/modem/modem_context.h
@@ -89,7 +89,8 @@ int modem_context_sprint_ip_addr(const struct sockaddr *addr, char *buf, size_t 
  * @param  addr: sockaddr
  * @param  port: store port
  *
- * @retval 0 if ok, < 0 if error.
+ * @retval 0 if ok
+ * @retval <0 if error.
  */
 int modem_context_get_addr_port(const struct sockaddr *addr, uint16_t *port);
 
@@ -98,7 +99,7 @@ int modem_context_get_addr_port(const struct sockaddr *addr, uint16_t *port);
  *
  * @param  id: modem context id.
  *
- * @retval modem context or NULL.
+ * @return modem context or NULL.
  */
 struct modem_context *modem_context_from_id(int id);
 
@@ -107,7 +108,7 @@ struct modem_context *modem_context_from_id(int id);
  *
  * @param  dev: device used by the modem iface.
  *
- * @retval Modem context or NULL.
+ * @return Modem context or NULL.
  */
 struct modem_context *modem_context_from_iface_dev(const struct device *dev);
 

--- a/drivers/modem/modem_receiver.h
+++ b/drivers/modem/modem_receiver.h
@@ -45,7 +45,7 @@ struct mdm_receiver_context {
  *
  * @param  id: receiver context id.
  *
- * @retval Receiver context or NULL.
+ * @return Receiver context or NULL.
  */
 struct mdm_receiver_context *mdm_receiver_context_from_id(int id);
 

--- a/include/zephyr/arch/common/semihost.h
+++ b/include/zephyr/arch/common/semihost.h
@@ -154,7 +154,7 @@ long semihost_close(long fd);
  *
  * @param fd handle returned by @ref semihost_open.
  *
- * @retval positive file size on success.
+ * @retval size positive file size on success.
  * @retval -1 on failure.
  */
 long semihost_flen(long fd);

--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -743,9 +743,9 @@ struct bt_audio_codec_cfg {
  *                  true to continue parsing, or false to stop parsing.
  * @param user_data User data to be passed to the callback.
  *
- * @retval 0 if all entries were parsed.
- * @retval -EINVAL if the data is incorrectly encoded
- * @retval -ECANCELED if parsing was prematurely cancelled by the callback
+ * @retval 0 all entries were parsed.
+ * @retval -EINVAL the data is incorrectly encoded
+ * @retval -ECANCELED parsing was prematurely cancelled by the callback
  */
 int bt_audio_data_parse(const uint8_t ltv[], size_t size,
 			bool (*func)(struct bt_data *data, void *user_data), void *user_data);
@@ -1036,8 +1036,8 @@ struct bt_audio_codec_qos_pref {
  *
  * @param freq The assigned numbers frequency to convert.
  *
- * @retval -EINVAL if arguments are invalid.
- * @retval The converted frequency value in Hz.
+ * @return The converted frequency value in Hz.
+ * @retval -EINVAL arguments are invalid.
  */
 int bt_audio_codec_cfg_freq_to_freq_hz(enum bt_audio_codec_cfg_freq freq);
 
@@ -1046,8 +1046,8 @@ int bt_audio_codec_cfg_freq_to_freq_hz(enum bt_audio_codec_cfg_freq freq);
  *
  * @param freq_hz The frequency value to convert.
  *
- * @retval -EINVAL if arguments are invalid.
- * @retval The assigned numbers frequency (@ref bt_audio_codec_cfg_freq).
+ * @return The assigned numbers frequency (@ref bt_audio_codec_cfg_freq).
+ * @retval -EINVAL arguments are invalid.
  */
 int bt_audio_codec_cfg_freq_hz_to_freq(uint32_t freq_hz);
 
@@ -1056,10 +1056,10 @@ int bt_audio_codec_cfg_freq_hz_to_freq(uint32_t freq_hz);
  *
  * @param codec_cfg The codec configuration to extract data from.
  *
- * @retval A @ref bt_audio_codec_cfg_freq value
- * @retval -EINVAL if arguments are invalid
- * @retval -ENODATA if not found
- * @retval -EBADMSG if found value has invalid size or value
+ * @return A @ref bt_audio_codec_cfg_freq value
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENODATA not found
+ * @retval -EBADMSG found value has invalid size or value
  */
 int bt_audio_codec_cfg_get_freq(const struct bt_audio_codec_cfg *codec_cfg);
 
@@ -1069,9 +1069,9 @@ int bt_audio_codec_cfg_get_freq(const struct bt_audio_codec_cfg *codec_cfg);
  * @param codec_cfg The codec configuration to set data for.
  * @param freq      The assigned numbers frequency to set.
  *
- * @retval The data_len of @p codec_cfg on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the new value could not set or added due to memory
+ * @return The data_len of @p codec_cfg on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the new value could not set or added due to memory
  */
 int bt_audio_codec_cfg_set_freq(struct bt_audio_codec_cfg *codec_cfg,
 				enum bt_audio_codec_cfg_freq freq);
@@ -1081,8 +1081,8 @@ int bt_audio_codec_cfg_set_freq(struct bt_audio_codec_cfg *codec_cfg,
  *
  * @param frame_dur The assigned numbers frame duration to convert.
  *
- * @retval -EINVAL if arguments are invalid.
- * @retval The converted frame duration value in microseconds.
+ * @return The converted frame duration value in microseconds.
+ * @retval -EINVAL arguments are invalid.
  */
 int bt_audio_codec_cfg_frame_dur_to_frame_dur_us(enum bt_audio_codec_cfg_frame_dur frame_dur);
 
@@ -1091,8 +1091,8 @@ int bt_audio_codec_cfg_frame_dur_to_frame_dur_us(enum bt_audio_codec_cfg_frame_d
  *
  * @param frame_dur_us The frame duration in microseconds to convert.
  *
- * @retval -EINVAL if arguments are invalid.
- * @retval The assigned numbers frame duration (@ref bt_audio_codec_cfg_frame_dur).
+ * @return The assigned numbers frame duration (@ref bt_audio_codec_cfg_frame_dur).
+ * @retval -EINVAL arguments are invalid.
  */
 int bt_audio_codec_cfg_frame_dur_us_to_frame_dur(uint32_t frame_dur_us);
 
@@ -1101,10 +1101,10 @@ int bt_audio_codec_cfg_frame_dur_us_to_frame_dur(uint32_t frame_dur_us);
  *
  * @param codec_cfg The codec configuration to extract data from.
  *
- * @retval A @ref bt_audio_codec_cfg_frame_dur value
- * @retval -EINVAL if arguments are invalid
- * @retval -ENODATA if not found
- * @retval -EBADMSG if found value has invalid size or value
+ * @return A @ref bt_audio_codec_cfg_frame_dur value
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENODATA not found
+ * @retval -EBADMSG found value has invalid size or value
  */
 int bt_audio_codec_cfg_get_frame_dur(const struct bt_audio_codec_cfg *codec_cfg);
 
@@ -1114,9 +1114,9 @@ int bt_audio_codec_cfg_get_frame_dur(const struct bt_audio_codec_cfg *codec_cfg)
  * @param codec_cfg  The codec configuration to set data for.
  * @param frame_dur  The assigned numbers frame duration to set.
  *
- * @retval The data_len of @p codec_cfg on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the new value could not set or added due to memory
+ * @return The data_len of @p codec_cfg on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the new value could not set or added due to memory
  */
 int bt_audio_codec_cfg_set_frame_dur(struct bt_audio_codec_cfg *codec_cfg,
 				     enum bt_audio_codec_cfg_frame_dur frame_dur);
@@ -1136,10 +1136,10 @@ int bt_audio_codec_cfg_set_frame_dur(struct bt_audio_codec_cfg *codec_cfg,
  *        @ref BT_AUDIO_LOCATION_MONO_AUDIO if the type is not found when @p codec_cfg.id is @ref
  *        BT_HCI_CODING_FORMAT_LC3.
  *
- * @retval 0 if value is found and stored in the pointer provided
- * @retval -EINVAL if arguments are invalid
- * @retval -ENODATA if not found
- * @retval -EBADMSG if found value has invalid size or value
+ * @retval 0 value is found and stored in the pointer provided
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENODATA not found
+ * @retval -EBADMSG found value has invalid size or value
  */
 int bt_audio_codec_cfg_get_chan_allocation(const struct bt_audio_codec_cfg *codec_cfg,
 					   enum bt_audio_location *chan_allocation,
@@ -1151,9 +1151,9 @@ int bt_audio_codec_cfg_get_chan_allocation(const struct bt_audio_codec_cfg *code
  * @param codec_cfg       The codec configuration to set data for.
  * @param chan_allocation The channel allocation to set.
  *
- * @retval The data_len of @p codec_cfg on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the new value could not set or added due to memory
+ * @return The data_len of @p codec_cfg on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the new value could not set or added due to memory
  */
 int bt_audio_codec_cfg_set_chan_allocation(struct bt_audio_codec_cfg *codec_cfg,
 					   enum bt_audio_location chan_allocation);
@@ -1172,10 +1172,10 @@ int bt_audio_codec_cfg_set_chan_allocation(struct bt_audio_codec_cfg *codec_cfg,
  *
  * @param codec_cfg The codec configuration to extract data from.
  *
- * @retval Frame length in octets
- * @retval -EINVAL if arguments are invalid
- * @retval -ENODATA if not found
- * @retval -EBADMSG if found value has invalid size or value
+ * @return Frame length in octets
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENODATA not found
+ * @retval -EBADMSG found value has invalid size or value
  */
 int bt_audio_codec_cfg_get_octets_per_frame(const struct bt_audio_codec_cfg *codec_cfg);
 
@@ -1185,9 +1185,9 @@ int bt_audio_codec_cfg_get_octets_per_frame(const struct bt_audio_codec_cfg *cod
  * @param codec_cfg        The codec configuration to set data for.
  * @param octets_per_frame The octets per codec frame to set.
  *
- * @retval The data_len of @p codec_cfg on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the new value could not set or added due to memory
+ * @return The data_len of @p codec_cfg on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the new value could not set or added due to memory
  */
 int bt_audio_codec_cfg_set_octets_per_frame(struct bt_audio_codec_cfg *codec_cfg,
 					    uint16_t octets_per_frame);
@@ -1207,10 +1207,10 @@ int bt_audio_codec_cfg_set_octets_per_frame(struct bt_audio_codec_cfg *codec_cfg
  * @param fallback_to_default If true this function will return the default value of 1
  *         if the type is not found when @p codec_cfg.id is @ref BT_HCI_CODING_FORMAT_LC3.
  *
- * @retval The count of codec frame blocks in each SDU.
- * @retval -EINVAL if arguments are invalid
- * @retval -ENODATA if not found
- * @retval -EBADMSG if found value has invalid size or value
+ * @return The count of codec frame blocks in each SDU.
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENODATA not found
+ * @retval -EBADMSG found value has invalid size or value
  */
 int bt_audio_codec_cfg_get_frame_blocks_per_sdu(const struct bt_audio_codec_cfg *codec_cfg,
 						bool fallback_to_default);
@@ -1221,9 +1221,9 @@ int bt_audio_codec_cfg_get_frame_blocks_per_sdu(const struct bt_audio_codec_cfg 
  * @param codec_cfg    The codec configuration to set data for.
  * @param frame_blocks The frame blocks per SDU to set.
  *
- * @retval The data_len of @p codec_cfg on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the new value could not set or added due to memory
+ * @return The data_len of @p codec_cfg on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the new value could not set or added due to memory
  */
 int bt_audio_codec_cfg_set_frame_blocks_per_sdu(struct bt_audio_codec_cfg *codec_cfg,
 						uint8_t frame_blocks);
@@ -1235,9 +1235,9 @@ int bt_audio_codec_cfg_set_frame_blocks_per_sdu(struct bt_audio_codec_cfg *codec
  * @param[in] type The type id to look for
  * @param[out] data Pointer to the data-pointer to update when item is found
  *
- * @retval Length of found @p data (may be 0)
- * @retval -EINVAL if arguments are invalid
- * @retval -ENODATA if not found
+ * @return Length of found @p data (may be 0)
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENODATA not found
  */
 int bt_audio_codec_cfg_get_val(const struct bt_audio_codec_cfg *codec_cfg,
 			       enum bt_audio_codec_cfg_type type, const uint8_t **data);
@@ -1250,9 +1250,9 @@ int bt_audio_codec_cfg_get_val(const struct bt_audio_codec_cfg *codec_cfg,
  * @param data       Pointer to the data-pointer to set
  * @param data_len   Length of @p data
  *
- * @retval The data_len of @p codec_cfg on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the new value could not set or added due to memory
+ * @return The data_len of @p codec_cfg on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the new value could not set or added due to memory
  */
 int bt_audio_codec_cfg_set_val(struct bt_audio_codec_cfg *codec_cfg,
 			       enum bt_audio_codec_cfg_type type, const uint8_t *data,
@@ -1266,8 +1266,8 @@ int bt_audio_codec_cfg_set_val(struct bt_audio_codec_cfg *codec_cfg,
  * @param codec_cfg  The codec data to set the value in.
  * @param type       The type id to unset.
  *
- * @retval The data_len of @p codec_cfg on success
- * @retval -EINVAL if arguments are invalid
+ * @return The data_len of @p codec_cfg on success
+ * @retval -EINVAL arguments are invalid
  */
 int bt_audio_codec_cfg_unset_val(struct bt_audio_codec_cfg *codec_cfg,
 				 enum bt_audio_codec_cfg_type type);
@@ -1280,9 +1280,9 @@ int bt_audio_codec_cfg_unset_val(struct bt_audio_codec_cfg *codec_cfg,
  * @param[in]  type      The type id to look for
  * @param[out] data      Pointer to the data-pointer to update when item is found
  *
- * @retval Length of found @p data (may be 0)
- * @retval -EINVAL if arguments are invalid
- * @retval -ENODATA if not found
+ * @return Length of found @p data (may be 0)
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENODATA not found
  */
 int bt_audio_codec_cfg_meta_get_val(const struct bt_audio_codec_cfg *codec_cfg, uint8_t type,
 				    const uint8_t **data);
@@ -1295,9 +1295,9 @@ int bt_audio_codec_cfg_meta_get_val(const struct bt_audio_codec_cfg *codec_cfg, 
  * @param data       Pointer to the data-pointer to set.
  * @param data_len   Length of @p data.
  *
- * @retval The meta_len of @p codec_cfg on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the new value could not set or added due to memory
+ * @return The meta_len of @p codec_cfg on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the new value could not set or added due to memory
  */
 int bt_audio_codec_cfg_meta_set_val(struct bt_audio_codec_cfg *codec_cfg,
 				    enum bt_audio_metadata_type type, const uint8_t *data,
@@ -1311,8 +1311,8 @@ int bt_audio_codec_cfg_meta_set_val(struct bt_audio_codec_cfg *codec_cfg,
  * @param codec_cfg  The codec data to set the value in.
  * @param type       The type id to unset.
  *
- * @retval The meta_len of @p codec_cfg on success
- * @retval -EINVAL if arguments are invalid
+ * @return The meta_len of @p codec_cfg on success
+ * @retval -EINVAL arguments are invalid
  */
 int bt_audio_codec_cfg_meta_unset_val(struct bt_audio_codec_cfg *codec_cfg,
 				      enum bt_audio_metadata_type type);
@@ -1326,10 +1326,10 @@ int bt_audio_codec_cfg_meta_unset_val(struct bt_audio_codec_cfg *codec_cfg,
  *        @ref BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED if the type is not found when @p codec_cfg.id is
  *        @ref BT_HCI_CODING_FORMAT_LC3.
  *
- * @retval The preferred context type if positive or 0
- * @retval -EINVAL if arguments are invalid
- * @retval -ENODATA if not found
- * @retval -EBADMSG if found value has invalid size
+ * @return The preferred context type if positive or 0
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENODATA not found
+ * @retval -EBADMSG found value has invalid size
  */
 int bt_audio_codec_cfg_meta_get_pref_context(const struct bt_audio_codec_cfg *codec_cfg,
 					     bool fallback_to_default);
@@ -1340,9 +1340,9 @@ int bt_audio_codec_cfg_meta_get_pref_context(const struct bt_audio_codec_cfg *co
  * @param codec_cfg The codec configuration to set data for.
  * @param ctx       The preferred context to set.
  *
- * @retval The data_len of @p codec_cfg on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the new value could not set or added due to memory
+ * @return The data_len of @p codec_cfg on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the new value could not set or added due to memory
  */
 int bt_audio_codec_cfg_meta_set_pref_context(struct bt_audio_codec_cfg *codec_cfg,
 					     enum bt_audio_context ctx);
@@ -1354,10 +1354,10 @@ int bt_audio_codec_cfg_meta_set_pref_context(struct bt_audio_codec_cfg *codec_cf
  *
  * @param codec_cfg The codec data to search in.
  *
- * @retval The stream context type if positive or 0
- * @retval -EINVAL if arguments are invalid
- * @retval -ENODATA if not found
- * @retval -EBADMSG if found value has invalid size
+ * @return The stream context type if positive or 0
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENODATA not found
+ * @retval -EBADMSG found value has invalid size
  */
 int bt_audio_codec_cfg_meta_get_stream_context(const struct bt_audio_codec_cfg *codec_cfg);
 
@@ -1367,9 +1367,9 @@ int bt_audio_codec_cfg_meta_get_stream_context(const struct bt_audio_codec_cfg *
  * @param codec_cfg The codec configuration to set data for.
  * @param ctx       The stream context to set.
  *
- * @retval The data_len of @p codec_cfg on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the new value could not set or added due to memory
+ * @return The data_len of @p codec_cfg on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the new value could not set or added due to memory
  */
 int bt_audio_codec_cfg_meta_set_stream_context(struct bt_audio_codec_cfg *codec_cfg,
 					       enum bt_audio_context ctx);
@@ -1382,9 +1382,9 @@ int bt_audio_codec_cfg_meta_set_stream_context(struct bt_audio_codec_cfg *codec_
  * @param[in]  codec_cfg    The codec data to search in.
  * @param[out] program_info Pointer to the UTF-8 formatted program info.
  *
- * @retval The length of the @p program_info (may be 0)
- * @retval -EINVAL if arguments are invalid
- * @retval -ENODATA if not found
+ * @return The length of the @p program_info (may be 0)
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENODATA not found
  */
 int bt_audio_codec_cfg_meta_get_program_info(const struct bt_audio_codec_cfg *codec_cfg,
 					     const uint8_t **program_info);
@@ -1396,9 +1396,9 @@ int bt_audio_codec_cfg_meta_get_program_info(const struct bt_audio_codec_cfg *co
  * @param program_info     The program info to set.
  * @param program_info_len The length of @p program_info.
  *
- * @retval The data_len of @p codec_cfg on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the new value could not set or added due to memory
+ * @return The data_len of @p codec_cfg on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the new value could not set or added due to memory
  */
 int bt_audio_codec_cfg_meta_set_program_info(struct bt_audio_codec_cfg *codec_cfg,
 					     const uint8_t *program_info, size_t program_info_len);
@@ -1411,10 +1411,10 @@ int bt_audio_codec_cfg_meta_set_program_info(struct bt_audio_codec_cfg *codec_cf
  * @param[in]  codec_cfg The codec data to search in.
  * @param[out] lang      Pointer to the language bytes (of length BT_AUDIO_LANG_SIZE)
  *
- * @retval The language if positive or 0
- * @retval -EINVAL if arguments are invalid
- * @retval -ENODATA if not found
- * @retval -EBADMSG if found value has invalid size
+ * @return The language if positive or 0
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENODATA not found
+ * @retval -EBADMSG found value has invalid size
  */
 int bt_audio_codec_cfg_meta_get_lang(const struct bt_audio_codec_cfg *codec_cfg,
 				     const uint8_t **lang);
@@ -1425,9 +1425,9 @@ int bt_audio_codec_cfg_meta_get_lang(const struct bt_audio_codec_cfg *codec_cfg,
  * @param codec_cfg   The codec configuration to set data for.
  * @param lang        The 24-bit language to set.
  *
- * @retval The data_len of @p codec_cfg on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the new value could not set or added due to memory
+ * @return The data_len of @p codec_cfg on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the new value could not set or added due to memory
  */
 int bt_audio_codec_cfg_meta_set_lang(struct bt_audio_codec_cfg *codec_cfg,
 				     const uint8_t lang[BT_AUDIO_LANG_SIZE]);
@@ -1440,9 +1440,9 @@ int bt_audio_codec_cfg_meta_set_lang(struct bt_audio_codec_cfg *codec_cfg,
  * @param[in]  codec_cfg The codec data to search in.
  * @param[out] ccid_list Pointer to the array containing 8-bit CCIDs.
  *
- * @retval The length of the @p ccid_list (may be 0)
- * @retval -EINVAL if arguments are invalid
- * @retval -ENODATA if not found
+ * @return The length of the @p ccid_list (may be 0)
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENODATA not found
  */
 int bt_audio_codec_cfg_meta_get_ccid_list(const struct bt_audio_codec_cfg *codec_cfg,
 					  const uint8_t **ccid_list);
@@ -1454,9 +1454,9 @@ int bt_audio_codec_cfg_meta_get_ccid_list(const struct bt_audio_codec_cfg *codec
  * @param ccid_list     The program info to set.
  * @param ccid_list_len The length of @p ccid_list.
  *
- * @retval The data_len of @p codec_cfg on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the new value could not set or added due to memory
+ * @return The data_len of @p codec_cfg on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the new value could not set or added due to memory
  */
 int bt_audio_codec_cfg_meta_set_ccid_list(struct bt_audio_codec_cfg *codec_cfg,
 					  const uint8_t *ccid_list, size_t ccid_list_len);
@@ -1468,10 +1468,10 @@ int bt_audio_codec_cfg_meta_set_ccid_list(struct bt_audio_codec_cfg *codec_cfg,
  *
  * @param codec_cfg The codec data to search in.
  *
- * @retval The parental rating if positive or 0
- * @retval -EINVAL if arguments are invalid
- * @retval -ENODATA if not found
- * @retval -EBADMSG if found value has invalid size
+ * @return The parental rating if positive or 0
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENODATA not found
+ * @retval -EBADMSG found value has invalid size
  */
 int bt_audio_codec_cfg_meta_get_parental_rating(const struct bt_audio_codec_cfg *codec_cfg);
 
@@ -1481,9 +1481,9 @@ int bt_audio_codec_cfg_meta_get_parental_rating(const struct bt_audio_codec_cfg 
  * @param codec_cfg       The codec configuration to set data for.
  * @param parental_rating The parental rating to set.
  *
- * @retval The data_len of @p codec_cfg on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the new value could not set or added due to memory
+ * @return The data_len of @p codec_cfg on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the new value could not set or added due to memory
  */
 int bt_audio_codec_cfg_meta_set_parental_rating(struct bt_audio_codec_cfg *codec_cfg,
 						enum bt_audio_parental_rating parental_rating);
@@ -1496,9 +1496,9 @@ int bt_audio_codec_cfg_meta_set_parental_rating(struct bt_audio_codec_cfg *codec
  * @param[in]  codec_cfg The codec data to search in.
  * @param[out] program_info_uri Pointer to the UTF-8 formatted program info URI.
  *
- * @retval The length of the @p ccid_list (may be 0)
- * @retval -EINVAL if arguments are invalid
- * @retval -ENODATA if not found
+ * @return The length of the @p ccid_list (may be 0)
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENODATA not found
  */
 int bt_audio_codec_cfg_meta_get_program_info_uri(const struct bt_audio_codec_cfg *codec_cfg,
 						 const uint8_t **program_info_uri);
@@ -1510,9 +1510,9 @@ int bt_audio_codec_cfg_meta_get_program_info_uri(const struct bt_audio_codec_cfg
  * @param program_info_uri     The program info URI to set.
  * @param program_info_uri_len The length of @p program_info_uri.
  *
- * @retval The data_len of @p codec_cfg on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the new value could not set or added due to memory
+ * @return The data_len of @p codec_cfg on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the new value could not set or added due to memory
  */
 int bt_audio_codec_cfg_meta_set_program_info_uri(struct bt_audio_codec_cfg *codec_cfg,
 						 const uint8_t *program_info_uri,
@@ -1525,10 +1525,10 @@ int bt_audio_codec_cfg_meta_set_program_info_uri(struct bt_audio_codec_cfg *code
  *
  * @param codec_cfg The codec data to search in.
  *
- * @retval The preferred context type if positive or 0
- * @retval -EINVAL if arguments are invalid
- * @retval -ENODATA if not found
- * @retval -EBADMSG if found value has invalid size
+ * @return The preferred context type if positive or 0
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENODATA not found
+ * @retval -EBADMSG found value has invalid size
  */
 int bt_audio_codec_cfg_meta_get_audio_active_state(const struct bt_audio_codec_cfg *codec_cfg);
 
@@ -1538,9 +1538,9 @@ int bt_audio_codec_cfg_meta_get_audio_active_state(const struct bt_audio_codec_c
  * @param codec_cfg The codec configuration to set data for.
  * @param state     The audio active state to set.
  *
- * @retval The data_len of @p codec_cfg on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the new value could not set or added due to memory
+ * @return The data_len of @p codec_cfg on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the new value could not set or added due to memory
  */
 int bt_audio_codec_cfg_meta_set_audio_active_state(struct bt_audio_codec_cfg *codec_cfg,
 						   enum bt_audio_active_state state);
@@ -1552,9 +1552,9 @@ int bt_audio_codec_cfg_meta_set_audio_active_state(struct bt_audio_codec_cfg *co
  *
  * @param codec_cfg The codec data to search in.
  *
- * @retval 0 if the flag was found
- * @retval -EINVAL if arguments are invalid
- * @retval -ENODATA if not the flag was not found
+ * @retval 0 the flag was found
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENODATA the flag was not found
  */
 int bt_audio_codec_cfg_meta_get_bcast_audio_immediate_rend_flag(
 	const struct bt_audio_codec_cfg *codec_cfg);
@@ -1564,9 +1564,9 @@ int bt_audio_codec_cfg_meta_get_bcast_audio_immediate_rend_flag(
  *
  * @param codec_cfg The codec configuration to set data for.
  *
- * @retval The data_len of @p codec_cfg on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the new value could not set or added due to memory
+ * @return The data_len of @p codec_cfg on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the new value could not set or added due to memory
  */
 int bt_audio_codec_cfg_meta_set_bcast_audio_immediate_rend_flag(
 	struct bt_audio_codec_cfg *codec_cfg);
@@ -1579,9 +1579,9 @@ int bt_audio_codec_cfg_meta_set_bcast_audio_immediate_rend_flag(
  * @param[in]  codec_cfg     The codec data to search in.
  * @param[out] extended_meta Pointer to the extended metadata.
  *
- * @retval The length of the @p ccid_list (may be 0)
- * @retval -EINVAL if arguments are invalid
- * @retval -ENODATA if not found
+ * @return The length of the @p ccid_list (may be 0)
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENODATA not found
  */
 int bt_audio_codec_cfg_meta_get_extended(const struct bt_audio_codec_cfg *codec_cfg,
 					 const uint8_t **extended_meta);
@@ -1593,9 +1593,9 @@ int bt_audio_codec_cfg_meta_get_extended(const struct bt_audio_codec_cfg *codec_
  * @param extended_meta     The extended metadata to set.
  * @param extended_meta_len The length of @p extended_meta.
  *
- * @retval The data_len of @p codec_cfg on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the new value could not set or added due to memory
+ * @return The data_len of @p codec_cfg on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the new value could not set or added due to memory
  */
 int bt_audio_codec_cfg_meta_set_extended(struct bt_audio_codec_cfg *codec_cfg,
 					 const uint8_t *extended_meta, size_t extended_meta_len);
@@ -1608,9 +1608,9 @@ int bt_audio_codec_cfg_meta_set_extended(struct bt_audio_codec_cfg *codec_cfg,
  * @param[in]  codec_cfg   The codec data to search in.
  * @param[out] vendor_meta Pointer to the vendor specific metadata.
  *
- * @retval The length of the @p ccid_list (may be 0)
- * @retval -EINVAL if arguments are invalid
- * @retval -ENODATA if not found
+ * @return The length of the @p ccid_list (may be 0)
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENODATA not found
  */
 int bt_audio_codec_cfg_meta_get_vendor(const struct bt_audio_codec_cfg *codec_cfg,
 				       const uint8_t **vendor_meta);
@@ -1622,9 +1622,9 @@ int bt_audio_codec_cfg_meta_get_vendor(const struct bt_audio_codec_cfg *codec_cf
  * @param vendor_meta     The vendor specific metadata to set.
  * @param vendor_meta_len The length of @p vendor_meta.
  *
- * @retval The data_len of @p codec_cfg on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the new value could not set or added due to memory
+ * @return The data_len of @p codec_cfg on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the new value could not set or added due to memory
  */
 int bt_audio_codec_cfg_meta_set_vendor(struct bt_audio_codec_cfg *codec_cfg,
 				       const uint8_t *vendor_meta, size_t vendor_meta_len);
@@ -1647,9 +1647,9 @@ int bt_audio_codec_cfg_meta_set_vendor(struct bt_audio_codec_cfg *codec_cfg,
  * @param[in]  type The type id to look for
  * @param[out] data Pointer to the data-pointer to update when item is found
  *
- * @retval Length of found @p data (may be 0)
- * @retval -EINVAL if arguments are invalid
- * @retval -ENODATA if not found
+ * @return Length of found @p data (may be 0)
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENODATA not found
  */
 int bt_audio_codec_cap_get_val(const struct bt_audio_codec_cap *codec_cap,
 			       enum bt_audio_codec_cap_type type, const uint8_t **data);
@@ -1662,9 +1662,9 @@ int bt_audio_codec_cap_get_val(const struct bt_audio_codec_cap *codec_cap,
  * @param data       Pointer to the data-pointer to set
  * @param data_len   Length of @p data
  *
- * @retval The data_len of @p codec_cap on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the new value could not set or added due to memory
+ * @return The data_len of @p codec_cap on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the new value could not set or added due to memory
  */
 int bt_audio_codec_cap_set_val(struct bt_audio_codec_cap *codec_cap,
 			       enum bt_audio_codec_cap_type type, const uint8_t *data,
@@ -1678,8 +1678,8 @@ int bt_audio_codec_cap_set_val(struct bt_audio_codec_cap *codec_cap,
  * @param codec_cap  The codec data to set the value in.
  * @param type       The type id to unset.
  *
- * @retval The data_len of @p codec_cap on success
- * @retval -EINVAL if arguments are invalid
+ * @return The data_len of @p codec_cap on success
+ * @retval -EINVAL arguments are invalid
  */
 int bt_audio_codec_cap_unset_val(struct bt_audio_codec_cap *codec_cap,
 				 enum bt_audio_codec_cap_type type);
@@ -1689,10 +1689,10 @@ int bt_audio_codec_cap_unset_val(struct bt_audio_codec_cap *codec_cap,
  *
  * @param codec_cap The codec capabilities to extract data from.
  *
- * @retval Bitfield of supported frequencies (@ref bt_audio_codec_cap_freq) if 0 or positive
- * @retval -EINVAL if arguments are invalid
- * @retval -ENODATA if not found
- * @retval -EBADMSG if found value has invalid size or value
+ * @return Bitfield of supported frequencies (@ref bt_audio_codec_cap_freq) if 0 or positive
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENODATA not found
+ * @retval -EBADMSG found value has invalid size or value
  */
 int bt_audio_codec_cap_get_freq(const struct bt_audio_codec_cap *codec_cap);
 
@@ -1702,9 +1702,9 @@ int bt_audio_codec_cap_get_freq(const struct bt_audio_codec_cap *codec_cap);
  * @param codec_cap The codec capabilities to set data for.
  * @param freq      The supported frequencies to set.
  *
- * @retval The data_len of @p codec_cap on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the new value could not set or added due to memory
+ * @return The data_len of @p codec_cap on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the new value could not set or added due to memory
  */
 int bt_audio_codec_cap_set_freq(struct bt_audio_codec_cap *codec_cap,
 				enum bt_audio_codec_cap_freq freq);
@@ -1714,10 +1714,10 @@ int bt_audio_codec_cap_set_freq(struct bt_audio_codec_cap *codec_cap,
  *
  * @param codec_cap The codec capabilities to extract data from.
  *
- * @retval Bitfield of supported frame durations if 0 or positive
- * @retval -EINVAL if arguments are invalid
- * @retval -ENODATA if not found
- * @retval -EBADMSG if found value has invalid size or value
+ * @return Bitfield of supported frame durations if 0 or positive
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENODATA not found
+ * @retval -EBADMSG found value has invalid size or value
  */
 int bt_audio_codec_cap_get_frame_dur(const struct bt_audio_codec_cap *codec_cap);
 
@@ -1727,9 +1727,9 @@ int bt_audio_codec_cap_get_frame_dur(const struct bt_audio_codec_cap *codec_cap)
  * @param codec_cap The codec capabilities to set data for.
  * @param frame_dur The frame duration to set.
  *
- * @retval The data_len of @p codec_cap on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the new value could not set or added due to memory
+ * @return The data_len of @p codec_cap on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the new value could not set or added due to memory
  */
 int bt_audio_codec_cap_set_frame_dur(struct bt_audio_codec_cap *codec_cap,
 				     enum bt_audio_codec_cap_frame_dur frame_dur);
@@ -1741,10 +1741,10 @@ int bt_audio_codec_cap_set_frame_dur(struct bt_audio_codec_cap *codec_cap,
  * @param fallback_to_default If true this function will provide the default value of 1
  *        if the type is not found when @p codec_cap.id is @ref BT_HCI_CODING_FORMAT_LC3.
  *
- * @retval Number of supported channel counts if 0 or positive
- * @retval -EINVAL if arguments are invalid
- * @retval -ENODATA if not found
- * @retval -EBADMSG if found value has invalid size or value
+ * @return Number of supported channel counts if 0 or positive
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENODATA not found
+ * @retval -EBADMSG found value has invalid size or value
  */
 int bt_audio_codec_cap_get_supported_audio_chan_counts(const struct bt_audio_codec_cap *codec_cap,
 						       bool fallback_to_default);
@@ -1755,9 +1755,9 @@ int bt_audio_codec_cap_get_supported_audio_chan_counts(const struct bt_audio_cod
  * @param codec_cap The codec capabilities to set data for.
  * @param chan_count The channel count frequency to set.
  *
- * @retval The data_len of @p codec_cap on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the new value could not set or added due to memory
+ * @return The data_len of @p codec_cap on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the new value could not set or added due to memory
  */
 int bt_audio_codec_cap_set_supported_audio_chan_counts(
 	struct bt_audio_codec_cap *codec_cap, enum bt_audio_codec_cap_chan_count chan_count);
@@ -1768,10 +1768,10 @@ int bt_audio_codec_cap_set_supported_audio_chan_counts(
  * @param[in]  codec_cap   The codec capabilities to extract data from.
  * @param[out] codec_frame Struct to place the resulting values in
  *
- * @retval 0 on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENODATA if not found
- * @retval -EBADMSG if found value has invalid size or value
+ * @retval 0 success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENODATA not found
+ * @retval -EBADMSG found value has invalid size or value
  */
 int bt_audio_codec_cap_get_octets_per_frame(
 	const struct bt_audio_codec_cap *codec_cap,
@@ -1783,9 +1783,9 @@ int bt_audio_codec_cap_get_octets_per_frame(
  * @param codec_cap   The codec capabilities to set data for.
  * @param codec_frame The octets per codec frame to set.
  *
- * @retval The data_len of @p codec_cap on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the new value could not set or added due to memory
+ * @return The data_len of @p codec_cap on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the new value could not set or added due to memory
  */
 int bt_audio_codec_cap_set_octets_per_frame(
 	struct bt_audio_codec_cap *codec_cap,
@@ -1798,10 +1798,10 @@ int bt_audio_codec_cap_set_octets_per_frame(
  * @param fallback_to_default If true this function will provide the default value of 1
  *        if the type is not found when @p codec_cap.id is @ref BT_HCI_CODING_FORMAT_LC3.
  *
- * @retval Maximum number of codec frames per SDU supported
- * @retval -EINVAL if arguments are invalid
- * @retval -ENODATA if not found
- * @retval -EBADMSG if found value has invalid size or value
+ * @return Maximum number of codec frames per SDU supported
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENODATA not found
+ * @retval -EBADMSG found value has invalid size or value
  */
 int bt_audio_codec_cap_get_max_codec_frames_per_sdu(const struct bt_audio_codec_cap *codec_cap,
 						    bool fallback_to_default);
@@ -1812,9 +1812,9 @@ int bt_audio_codec_cap_get_max_codec_frames_per_sdu(const struct bt_audio_codec_
  * @param codec_cap            The codec capabilities to set data for.
  * @param codec_frames_per_sdu The maximum codec frames per SDU to set.
  *
- * @retval The data_len of @p codec_cap on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the new value could not set or added due to memory
+ * @return The data_len of @p codec_cap on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the new value could not set or added due to memory
  */
 int bt_audio_codec_cap_set_max_codec_frames_per_sdu(struct bt_audio_codec_cap *codec_cap,
 						    uint8_t codec_frames_per_sdu);
@@ -1826,9 +1826,9 @@ int bt_audio_codec_cap_set_max_codec_frames_per_sdu(struct bt_audio_codec_cap *c
  * @param[in]  type      The type id to look for
  * @param[out] data      Pointer to the data-pointer to update when item is found
  *
- * @retval Length of found @p data (may be 0)
- * @retval -EINVAL if arguments are invalid
- * @retval -ENODATA if not found
+ * @return Length of found @p data (may be 0)
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENODATA not found
  */
 int bt_audio_codec_cap_meta_get_val(const struct bt_audio_codec_cap *codec_cap, uint8_t type,
 				    const uint8_t **data);
@@ -1841,9 +1841,9 @@ int bt_audio_codec_cap_meta_get_val(const struct bt_audio_codec_cap *codec_cap, 
  * @param data       Pointer to the data-pointer to set.
  * @param data_len   Length of @p data.
  *
- * @retval The meta_len of @p codec_cap on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the new value could not set or added due to memory
+ * @return The meta_len of @p codec_cap on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the new value could not set or added due to memory
  */
 int bt_audio_codec_cap_meta_set_val(struct bt_audio_codec_cap *codec_cap,
 				    enum bt_audio_metadata_type type, const uint8_t *data,
@@ -1857,8 +1857,8 @@ int bt_audio_codec_cap_meta_set_val(struct bt_audio_codec_cap *codec_cap,
  * @param codec_cap  The codec data to set the value in.
  * @param type       The type id to unset.
  *
- * @retval The meta_len of @p codec_cap on success
- * @retval -EINVAL if arguments are invalid
+ * @return The meta_len of @p codec_cap on success
+ * @retval -EINVAL arguments are invalid
  */
 int bt_audio_codec_cap_meta_unset_val(struct bt_audio_codec_cap *codec_cap,
 				      enum bt_audio_metadata_type type);
@@ -1870,10 +1870,10 @@ int bt_audio_codec_cap_meta_unset_val(struct bt_audio_codec_cap *codec_cap,
  *
  * @param codec_cap The codec data to search in.
  *
- * @retval The preferred context type if positive or 0
- * @retval -EINVAL if arguments are invalid
- * @retval -ENODATA if not found
- * @retval -EBADMSG if found value has invalid size
+ * @return The preferred context type if positive or 0
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENODATA not found
+ * @retval -EBADMSG found value has invalid size
  */
 int bt_audio_codec_cap_meta_get_pref_context(const struct bt_audio_codec_cap *codec_cap);
 
@@ -1883,9 +1883,9 @@ int bt_audio_codec_cap_meta_get_pref_context(const struct bt_audio_codec_cap *co
  * @param codec_cap The codec capability to set data for.
  * @param ctx       The preferred context to set.
  *
- * @retval The data_len of @p codec_cap on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the new value could not set or added due to memory
+ * @return The data_len of @p codec_cap on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the new value could not set or added due to memory
  */
 int bt_audio_codec_cap_meta_set_pref_context(struct bt_audio_codec_cap *codec_cap,
 					     enum bt_audio_context ctx);
@@ -1897,10 +1897,10 @@ int bt_audio_codec_cap_meta_set_pref_context(struct bt_audio_codec_cap *codec_ca
  *
  * @param codec_cap The codec data to search in.
  *
- * @retval The stream context type if positive or 0
- * @retval -EINVAL if arguments are invalid
- * @retval -ENODATA if not found
- * @retval -EBADMSG if found value has invalid size
+ * @return The stream context type if positive or 0
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENODATA not found
+ * @retval -EBADMSG found value has invalid size
  */
 int bt_audio_codec_cap_meta_get_stream_context(const struct bt_audio_codec_cap *codec_cap);
 
@@ -1910,9 +1910,9 @@ int bt_audio_codec_cap_meta_get_stream_context(const struct bt_audio_codec_cap *
  * @param codec_cap The codec capability to set data for.
  * @param ctx       The stream context to set.
  *
- * @retval The data_len of @p codec_cap on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the new value could not set or added due to memory
+ * @return The data_len of @p codec_cap on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the new value could not set or added due to memory
  */
 int bt_audio_codec_cap_meta_set_stream_context(struct bt_audio_codec_cap *codec_cap,
 					       enum bt_audio_context ctx);
@@ -1925,9 +1925,9 @@ int bt_audio_codec_cap_meta_set_stream_context(struct bt_audio_codec_cap *codec_
  * @param[in]  codec_cap    The codec data to search in.
  * @param[out] program_info Pointer to the UTF-8 formatted program info.
  *
- * @retval The length of the @p program_info (may be 0)
- * @retval -EINVAL if arguments are invalid
- * @retval -ENODATA if not found
+ * @return The length of the @p program_info (may be 0)
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENODATA not found
  */
 int bt_audio_codec_cap_meta_get_program_info(const struct bt_audio_codec_cap *codec_cap,
 					     const uint8_t **program_info);
@@ -1939,9 +1939,9 @@ int bt_audio_codec_cap_meta_get_program_info(const struct bt_audio_codec_cap *co
  * @param program_info     The program info to set.
  * @param program_info_len The length of @p program_info.
  *
- * @retval The data_len of @p codec_cap on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the new value could not set or added due to memory
+ * @return The data_len of @p codec_cap on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the new value could not set or added due to memory
  */
 int bt_audio_codec_cap_meta_set_program_info(struct bt_audio_codec_cap *codec_cap,
 					     const uint8_t *program_info, size_t program_info_len);
@@ -1954,10 +1954,10 @@ int bt_audio_codec_cap_meta_set_program_info(struct bt_audio_codec_cap *codec_ca
  * @param[in]  codec_cap The codec data to search in.
  * @param[out] lang      Pointer to the language bytes (of length BT_AUDIO_LANG_SIZE)
  *
- * @retval 0 On success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENODATA if not found
- * @retval -EBADMSG if found value has invalid size
+ * @retval 0 success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENODATA not found
+ * @retval -EBADMSG found value has invalid size
  */
 int bt_audio_codec_cap_meta_get_lang(const struct bt_audio_codec_cap *codec_cap,
 				     const uint8_t **lang);
@@ -1968,9 +1968,9 @@ int bt_audio_codec_cap_meta_get_lang(const struct bt_audio_codec_cap *codec_cap,
  * @param codec_cap   The codec capability to set data for.
  * @param lang        The 24-bit language to set.
  *
- * @retval The data_len of @p codec_cap on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the new value could not set or added due to memory
+ * @return The data_len of @p codec_cap on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the new value could not set or added due to memory
  */
 int bt_audio_codec_cap_meta_set_lang(struct bt_audio_codec_cap *codec_cap,
 				     const uint8_t lang[BT_AUDIO_LANG_SIZE]);
@@ -1983,9 +1983,9 @@ int bt_audio_codec_cap_meta_set_lang(struct bt_audio_codec_cap *codec_cap,
  * @param[in]  codec_cap The codec data to search in.
  * @param[out] ccid_list Pointer to the array containing 8-bit CCIDs.
  *
- * @retval The length of the @p ccid_list (may be 0)
- * @retval -EINVAL if arguments are invalid
- * @retval -ENODATA if not found
+ * @return The length of the @p ccid_list (may be 0)
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENODATA not found
  */
 int bt_audio_codec_cap_meta_get_ccid_list(const struct bt_audio_codec_cap *codec_cap,
 					  const uint8_t **ccid_list);
@@ -1997,9 +1997,9 @@ int bt_audio_codec_cap_meta_get_ccid_list(const struct bt_audio_codec_cap *codec
  * @param ccid_list     The program info to set.
  * @param ccid_list_len The length of @p ccid_list.
  *
- * @retval The data_len of @p codec_cap on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the new value could not set or added due to memory
+ * @return The data_len of @p codec_cap on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the new value could not set or added due to memory
  */
 int bt_audio_codec_cap_meta_set_ccid_list(struct bt_audio_codec_cap *codec_cap,
 					  const uint8_t *ccid_list, size_t ccid_list_len);
@@ -2011,10 +2011,10 @@ int bt_audio_codec_cap_meta_set_ccid_list(struct bt_audio_codec_cap *codec_cap,
  *
  * @param codec_cap The codec data to search in.
  *
- * @retval The parental rating if positive or 0
- * @retval -EINVAL if arguments are invalid
- * @retval -ENODATA if not found
- * @retval -EBADMSG if found value has invalid size
+ * @return The parental rating if positive or 0
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENODATA not found
+ * @retval -EBADMSG found value has invalid size
  */
 int bt_audio_codec_cap_meta_get_parental_rating(const struct bt_audio_codec_cap *codec_cap);
 
@@ -2024,9 +2024,9 @@ int bt_audio_codec_cap_meta_get_parental_rating(const struct bt_audio_codec_cap 
  * @param codec_cap       The codec capability to set data for.
  * @param parental_rating The parental rating to set.
  *
- * @retval The data_len of @p codec_cap on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the new value could not set or added due to memory
+ * @return The data_len of @p codec_cap on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the new value could not set or added due to memory
  */
 int bt_audio_codec_cap_meta_set_parental_rating(struct bt_audio_codec_cap *codec_cap,
 						enum bt_audio_parental_rating parental_rating);
@@ -2039,9 +2039,9 @@ int bt_audio_codec_cap_meta_set_parental_rating(struct bt_audio_codec_cap *codec
  * @param[in]  codec_cap        The codec data to search in.
  * @param[out] program_info_uri Pointer to the UTF-8 formatted program info URI.
  *
- * @retval The length of the @p ccid_list (may be 0)
- * @retval -EINVAL if arguments are invalid
- * @retval -ENODATA if not found
+ * @return The length of the @p ccid_list (may be 0)
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENODATA not found
  */
 int bt_audio_codec_cap_meta_get_program_info_uri(const struct bt_audio_codec_cap *codec_cap,
 						 const uint8_t **program_info_uri);
@@ -2053,9 +2053,9 @@ int bt_audio_codec_cap_meta_get_program_info_uri(const struct bt_audio_codec_cap
  * @param program_info_uri     The program info URI to set.
  * @param program_info_uri_len The length of @p program_info_uri.
  *
- * @retval The data_len of @p codec_cap on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the new value could not set or added due to memory
+ * @return The data_len of @p codec_cap on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the new value could not set or added due to memory
  */
 int bt_audio_codec_cap_meta_set_program_info_uri(struct bt_audio_codec_cap *codec_cap,
 						 const uint8_t *program_info_uri,
@@ -2068,10 +2068,10 @@ int bt_audio_codec_cap_meta_set_program_info_uri(struct bt_audio_codec_cap *code
  *
  * @param codec_cap The codec data to search in.
  *
- * @retval The preferred context type if positive or 0
- * @retval -EINVAL if arguments are invalid
- * @retval -ENODATA if not found
- * @retval -EBADMSG if found value has invalid size
+ * @return The preferred context type if positive or 0
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENODATA not found
+ * @retval -EBADMSG found value has invalid size
  */
 int bt_audio_codec_cap_meta_get_audio_active_state(const struct bt_audio_codec_cap *codec_cap);
 
@@ -2081,9 +2081,9 @@ int bt_audio_codec_cap_meta_get_audio_active_state(const struct bt_audio_codec_c
  * @param codec_cap The codec capability to set data for.
  * @param state     The audio active state to set.
  *
- * @retval The data_len of @p codec_cap on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the new value could not set or added due to memory
+ * @return The data_len of @p codec_cap on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the new value could not set or added due to memory
  */
 int bt_audio_codec_cap_meta_set_audio_active_state(struct bt_audio_codec_cap *codec_cap,
 						   enum bt_audio_active_state state);
@@ -2095,9 +2095,9 @@ int bt_audio_codec_cap_meta_set_audio_active_state(struct bt_audio_codec_cap *co
  *
  * @param codec_cap The codec data to search in.
  *
- * @retval 0 if the flag was found
- * @retval -EINVAL if arguments are invalid
- * @retval -ENODATA if not the flag was not found
+ * @retval 0 the flag was found
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENODATA the flag was not found
  */
 int bt_audio_codec_cap_meta_get_bcast_audio_immediate_rend_flag(
 	const struct bt_audio_codec_cap *codec_cap);
@@ -2107,9 +2107,9 @@ int bt_audio_codec_cap_meta_get_bcast_audio_immediate_rend_flag(
  *
  * @param codec_cap The codec capability to set data for.
  *
- * @retval The data_len of @p codec_cap on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the new value could not set or added due to memory
+ * @return The data_len of @p codec_cap on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the new value could not set or added due to memory
  */
 int bt_audio_codec_cap_meta_set_bcast_audio_immediate_rend_flag(
 	struct bt_audio_codec_cap *codec_cap);
@@ -2122,9 +2122,9 @@ int bt_audio_codec_cap_meta_set_bcast_audio_immediate_rend_flag(
  * @param[in]  codec_cap     The codec data to search in.
  * @param[out] extended_meta Pointer to the extended metadata.
  *
- * @retval The length of the @p ccid_list (may be 0)
- * @retval -EINVAL if arguments are invalid
- * @retval -ENODATA if not found
+ * @return The length of the @p ccid_list (may be 0)
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENODATA not found
  */
 int bt_audio_codec_cap_meta_get_extended(const struct bt_audio_codec_cap *codec_cap,
 					 const uint8_t **extended_meta);
@@ -2136,9 +2136,9 @@ int bt_audio_codec_cap_meta_get_extended(const struct bt_audio_codec_cap *codec_
  * @param extended_meta     The extended metadata to set.
  * @param extended_meta_len The length of @p extended_meta.
  *
- * @retval The data_len of @p codec_cap on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the new value could not set or added due to memory
+ * @return The data_len of @p codec_cap on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the new value could not set or added due to memory
  */
 int bt_audio_codec_cap_meta_set_extended(struct bt_audio_codec_cap *codec_cap,
 					 const uint8_t *extended_meta, size_t extended_meta_len);
@@ -2151,9 +2151,9 @@ int bt_audio_codec_cap_meta_set_extended(struct bt_audio_codec_cap *codec_cap,
  * @param[in]  codec_cap   The codec data to search in.
  * @param[out] vendor_meta Pointer to the vendor specific metadata.
  *
- * @retval The length of the @p ccid_list (may be 0)
- * @retval -EINVAL if arguments are invalid
- * @retval -ENODATA if not found
+ * @return The length of the @p ccid_list (may be 0)
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENODATA not found
  */
 int bt_audio_codec_cap_meta_get_vendor(const struct bt_audio_codec_cap *codec_cap,
 				       const uint8_t **vendor_meta);
@@ -2165,9 +2165,9 @@ int bt_audio_codec_cap_meta_get_vendor(const struct bt_audio_codec_cap *codec_ca
  * @param vendor_meta     The vendor specific metadata to set.
  * @param vendor_meta_len The length of @p vendor_meta.
  *
- * @retval The data_len of @p codec_cap on success
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the new value could not set or added due to memory
+ * @return The data_len of @p codec_cap on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the new value could not set or added due to memory
  */
 int bt_audio_codec_cap_meta_set_vendor(struct bt_audio_codec_cap *codec_cap,
 				       const uint8_t *vendor_meta, size_t vendor_meta_len);

--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -439,7 +439,7 @@ struct bt_bap_ep_info {
  * @param info The structure object to be filled with the info.
  *
  * @retval 0 in case of success
- * @retval -EINVAL if @p ep or @p info are NULL
+ * @retval -EINVAL @p ep or @p info are NULL
  */
 int bt_bap_ep_get_info(const struct bt_bap_ep *ep, struct bt_bap_ep_info *info);
 
@@ -749,12 +749,12 @@ int bt_bap_stream_disable(struct bt_bap_stream *stream);
  * @param stream Stream object
  *
  * @retval 0 in case of success
- * @retval -EINVAL if the stream, endpoint, ISO channel or connection is NULL
- * @retval -EBADMSG if the stream or ISO channel is in an invalid state for connection
- * @retval -EOPNOTSUPP if the role of the stream is not @ref BT_HCI_ROLE_CENTRAL
- * @retval -EALREADY if the ISO channel is already connecting or connected
- * @retval -EBUSY if another ISO channel is connecting
- * @retval -ENOEXEC if otherwise rejected by the ISO layer
+ * @retval -EINVAL the stream, endpoint, ISO channel or connection is NULL
+ * @retval -EBADMSG the stream or ISO channel is in an invalid state for connection
+ * @retval -EOPNOTSUPP the role of the stream is not @ref BT_HCI_ROLE_CENTRAL
+ * @retval -EALREADY the ISO channel is already connecting or connected
+ * @retval -EBUSY another ISO channel is connecting
+ * @retval -ENOEXEC otherwise rejected by the ISO layer
  */
 int bt_bap_stream_connect(struct bt_bap_stream *stream);
 
@@ -860,10 +860,10 @@ int bt_bap_stream_send_ts(struct bt_bap_stream *stream, struct net_buf *buf, uin
  * @param[in]  stream Stream object.
  * @param[out] info   Transmit info object.
  *
- * @retval 0 on success
- * @retval -EINVAL if the stream is invalid, if the stream is not configured for sending or if it is
+ * @return Any return value from bt_iso_chan_get_tx_sync()
+ * @retval 0 success
+ * @retval -EINVAL the stream is invalid, if the stream is not configured for sending or if it is
  *         not connected with a isochronous stream
- * @retval Any return value from bt_iso_chan_get_tx_sync()
  */
 int bt_bap_stream_get_tx_sync(struct bt_bap_stream *stream, struct bt_iso_tx_info *info);
 
@@ -1450,8 +1450,8 @@ struct bt_bap_base_subgroup_bis {
  *
  * @param ad The periodic advertising data
  *
+ * @return Pointer to a bt_bap_base structure
  * @retval NULL if the data does not contain a BASE
- * @retval Pointer to a bt_bap_base structure
  */
 const struct bt_bap_base *bt_bap_base_get_base_from_ad(const struct bt_data *ad);
 
@@ -1460,8 +1460,8 @@ const struct bt_bap_base *bt_bap_base_get_base_from_ad(const struct bt_data *ad)
  *
  * @param base The BASE pointer
  *
- * @retval -EINVAL if arguments are invalid
- * @retval The size of the BASE
+ * @return The size of the BASE
+ * @retval -EINVAL arguments are invalid
  */
 int bt_bap_base_get_size(const struct bt_bap_base *base);
 
@@ -1470,8 +1470,8 @@ int bt_bap_base_get_size(const struct bt_bap_base *base);
  *
  * @param base The BASE pointer
  *
- * @retval -EINVAL if arguments are invalid
- * @retval The 24-bit presentation delay value
+ * @return The 24-bit presentation delay value
+ * @retval -EINVAL arguments are invalid
  */
 int bt_bap_base_get_pres_delay(const struct bt_bap_base *base);
 
@@ -1480,8 +1480,8 @@ int bt_bap_base_get_pres_delay(const struct bt_bap_base *base);
  *
  * @param base The BASE pointer
  *
- * @retval -EINVAL if arguments are invalid
- * @retval The 8-bit subgroup count value
+ * @return The 8-bit subgroup count value
+ * @retval -EINVAL arguments are invalid
  */
 int bt_bap_base_get_subgroup_count(const struct bt_bap_base *base);
 
@@ -1491,8 +1491,8 @@ int bt_bap_base_get_subgroup_count(const struct bt_bap_base *base);
  * @param[in]  base        The BASE pointer
  * @param[out] bis_indexes 32-bit BIS index bitfield that will be populated
  *
- * @retval -EINVAL if arguments are invalid
- * @retval 0 on success
+ * @retval -EINVAL arguments are invalid
+ * @retval 0 success
  */
 int bt_bap_base_get_bis_indexes(const struct bt_bap_base *base, uint32_t *bis_indexes);
 
@@ -1503,9 +1503,9 @@ int bt_bap_base_get_bis_indexes(const struct bt_bap_base *base, uint32_t *bis_in
  * @param func      Callback function. Return true to continue iterating, or false to stop.
  * @param user_data Userdata supplied to @p func
  *
- * @retval -EINVAL if arguments are invalid
- * @retval -ECANCELED if iterating over the subgroups stopped prematurely by @p func
- * @retval 0 if all subgroups were iterated
+ * @retval -EINVAL arguments are invalid
+ * @retval -ECANCELED iterating over the subgroups stopped prematurely by @p func
+ * @retval 0 all subgroups were iterated
  */
 int bt_bap_base_foreach_subgroup(const struct bt_bap_base *base,
 				 bool (*func)(const struct bt_bap_base_subgroup *subgroup,
@@ -1518,8 +1518,8 @@ int bt_bap_base_foreach_subgroup(const struct bt_bap_base *base,
  * @param[in]  subgroup The subgroup pointer
  * @param[out] codec_id Pointer to the struct where the results are placed
  *
- * @retval -EINVAL if arguments are invalid
- * @retval 0 on success
+ * @retval -EINVAL arguments are invalid
+ * @retval 0 success
  */
 int bt_bap_base_get_subgroup_codec_id(const struct bt_bap_base_subgroup *subgroup,
 				      struct bt_bap_base_codec_id *codec_id);
@@ -1530,8 +1530,8 @@ int bt_bap_base_get_subgroup_codec_id(const struct bt_bap_base_subgroup *subgrou
  * @param[in]  subgroup The subgroup pointer
  * @param[out] data     Pointer that will point to the resulting codec configuration data
  *
- * @retval -EINVAL if arguments are invalid
- * @retval 0 on success
+ * @retval -EINVAL arguments are invalid
+ * @retval 0 success
  */
 int bt_bap_base_get_subgroup_codec_data(const struct bt_bap_base_subgroup *subgroup,
 					uint8_t **data);
@@ -1542,8 +1542,8 @@ int bt_bap_base_get_subgroup_codec_data(const struct bt_bap_base_subgroup *subgr
  * @param[in]  subgroup The subgroup pointer
  * @param[out] meta     Pointer that will point to the resulting codec metadata
  *
- * @retval -EINVAL if arguments are invalid
- * @retval 0 on success
+ * @retval -EINVAL arguments are invalid
+ * @retval 0 success
  */
 int bt_bap_base_get_subgroup_codec_meta(const struct bt_bap_base_subgroup *subgroup,
 					uint8_t **meta);
@@ -1554,9 +1554,9 @@ int bt_bap_base_get_subgroup_codec_meta(const struct bt_bap_base_subgroup *subgr
  * @param[in]  subgroup  The subgroup pointer
  * @param[out] codec_cfg Pointer to the struct where the results are placed
  *
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the @p codec_cfg cannot store the @p subgroup codec data
- * @retval 0 on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the @p codec_cfg cannot store the @p subgroup codec data
+ * @retval 0 success
  */
 int bt_bap_base_subgroup_codec_to_codec_cfg(const struct bt_bap_base_subgroup *subgroup,
 					    struct bt_audio_codec_cfg *codec_cfg);
@@ -1566,8 +1566,8 @@ int bt_bap_base_subgroup_codec_to_codec_cfg(const struct bt_bap_base_subgroup *s
  *
  * @param subgroup The subgroup pointer
  *
- * @retval -EINVAL if arguments are invalid
- * @retval The 8-bit BIS count value
+ * @return The 8-bit BIS count value
+ * @retval -EINVAL arguments are invalid
  */
 int bt_bap_base_get_subgroup_bis_count(const struct bt_bap_base_subgroup *subgroup);
 
@@ -1577,8 +1577,8 @@ int bt_bap_base_get_subgroup_bis_count(const struct bt_bap_base_subgroup *subgro
  * @param[in]  subgroup    The subgroup pointer
  * @param[out] bis_indexes 32-bit BIS index bitfield that will be populated
  *
- * @retval -EINVAL if arguments are invalid
- * @retval 0 on success
+ * @retval -EINVAL arguments are invalid
+ * @retval 0 success
  */
 int bt_bap_base_subgroup_get_bis_indexes(const struct bt_bap_base_subgroup *subgroup,
 					 uint32_t *bis_indexes);
@@ -1590,9 +1590,9 @@ int bt_bap_base_subgroup_get_bis_indexes(const struct bt_bap_base_subgroup *subg
  * @param func      Callback function. Return true to continue iterating, or false to stop.
  * @param user_data Userdata supplied to @p func
  *
- * @retval -EINVAL if arguments are invalid
- * @retval -ECANCELED if iterating over the subgroups stopped prematurely by @p func
- * @retval 0 if all BIS were iterated
+ * @retval -EINVAL arguments are invalid
+ * @retval -ECANCELED iterating over the subgroups stopped prematurely by @p func
+ * @retval 0 all BIS were iterated
  */
 int bt_bap_base_subgroup_foreach_bis(const struct bt_bap_base_subgroup *subgroup,
 				     bool (*func)(const struct bt_bap_base_subgroup_bis *bis,
@@ -1608,9 +1608,9 @@ int bt_bap_base_subgroup_foreach_bis(const struct bt_bap_base_subgroup *subgroup
  * @param[in]  bis       The BIS pointer
  * @param[out] codec_cfg Pointer to the struct where the results are placed
  *
- * @retval -EINVAL if arguments are invalid
- * @retval -ENOMEM if the @p codec_cfg cannot store the @p subgroup codec data
- * @retval 0 on success
+ * @retval -EINVAL arguments are invalid
+ * @retval -ENOMEM the @p codec_cfg cannot store the @p subgroup codec data
+ * @retval 0 success
  */
 int bt_bap_base_subgroup_bis_codec_to_codec_cfg(const struct bt_bap_base_subgroup_bis *bis,
 						struct bt_audio_codec_cfg *codec_cfg);
@@ -1898,7 +1898,7 @@ struct bt_bap_broadcast_sink_cb {
  * @param cb  Broadcast sink callback structure.
  *
  * @retval 0 in case of success
- * @retval -EINVAL if @p cb is NULL
+ * @retval -EINVAL @p cb is NULL
  */
 int bt_bap_broadcast_sink_register_cb(struct bt_bap_broadcast_sink_cb *cb);
 
@@ -2289,9 +2289,9 @@ int bt_bap_broadcast_assistant_scan_stop(struct bt_conn *conn);
  *
  * @param cb	The callback structure.
  *
- * @retval 0 on success
- * @retval -EINVAL if @p cb is NULL
- * @retval -EALREADY if @p cb was already registered
+ * @retval 0 success
+ * @retval -EINVAL @p cb is NULL
+ * @retval -EALREADY @p cb was already registered
  */
 int bt_bap_broadcast_assistant_register_cb(struct bt_bap_broadcast_assistant_cb *cb);
 
@@ -2300,9 +2300,9 @@ int bt_bap_broadcast_assistant_register_cb(struct bt_bap_broadcast_assistant_cb 
  *
  * @param cb   The callback structure.
  *
- * @retval 0 on success
- * @retval -EINVAL if @p cb is NULL
- * @retval -EALREADY if @p cb was not registered
+ * @retval 0 success
+ * @retval -EINVAL @p cb is NULL
+ * @retval -EALREADY @p cb was not registered
  */
 int bt_bap_broadcast_assistant_unregister_cb(struct bt_bap_broadcast_assistant_cb *cb);
 

--- a/include/zephyr/bluetooth/audio/cap.h
+++ b/include/zephyr/bluetooth/audio/cap.h
@@ -198,8 +198,8 @@ void bt_cap_stream_ops_register(struct bt_cap_stream *stream, struct bt_bap_stre
  * @param seq_num  Packet Sequence number. This value shall be incremented for each call to this
  *                 function and at least once per SDU interval for a specific channel.
  *
- * @retval -EINVAL if stream object is NULL
- * @retval Any return value from bt_bap_stream_send()
+ * @return Any return value from bt_bap_stream_send()
+ * @retval -EINVAL stream object is NULL
  */
 int bt_cap_stream_send(struct bt_cap_stream *stream, struct net_buf *buf, uint16_t seq_num);
 
@@ -217,8 +217,8 @@ int bt_cap_stream_send(struct bt_cap_stream *stream, struct net_buf *buf, uint16
  * @param ts       Timestamp of the SDU in microseconds (us). This value can be used to transmit
  *                 multiple SDUs in the same SDU interval in a CIG or BIG.
  *
- * @retval -EINVAL if stream object is NULL
- * @retval Any return value from bt_bap_stream_send()
+ * @return Any return value from bt_bap_stream_send()
+ * @retval -EINVAL stream object is NULL
  */
 int bt_cap_stream_send_ts(struct bt_cap_stream *stream, struct net_buf *buf, uint16_t seq_num,
 			  uint32_t ts);
@@ -233,8 +233,8 @@ int bt_cap_stream_send_ts(struct bt_cap_stream *stream, struct net_buf *buf, uin
  * @param[in]  stream Stream object.
  * @param[out] info   Transmit info object.
  *
- * @retval -EINVAL if stream object is NULL
- * @retval Any return value from bt_bap_stream_get_tx_sync()
+ * @return Any return value from bt_bap_stream_get_tx_sync()
+ * @retval -EINVAL stream object is NULL
  */
 int bt_cap_stream_get_tx_sync(struct bt_cap_stream *stream, struct bt_iso_tx_info *info);
 
@@ -400,8 +400,8 @@ int bt_cap_initiator_unicast_audio_stop(const struct bt_cap_unicast_audio_stop_p
  * The respective callbacks of the procedure will be called as part of this with the connection
  * pointer set to 0 and the err value set to -ECANCELED.
  *
- * @retval 0 on success
- * @retval -EALREADY if no procedure is active
+ * @retval 0 success
+ * @retval -EALREADY no procedure is active
  */
 int bt_cap_initiator_unicast_audio_cancel(void);
 
@@ -881,8 +881,8 @@ int bt_cap_commander_discover(struct bt_conn *conn);
  * The respective callbacks of the procedure will be called as part of this with the connection
  * pointer set to NULL and the err value set to -ECANCELED.
  *
- * @retval 0 on success
- * @retval -EALREADY if no procedure is active
+ * @retval 0 success
+ * @retval -EALREADY no procedure is active
  */
 int bt_cap_commander_cancel(void);
 

--- a/include/zephyr/bluetooth/audio/csip.h
+++ b/include/zephyr/bluetooth/audio/csip.h
@@ -345,7 +345,7 @@ int bt_csip_set_coordinator_discover(struct bt_conn *conn);
  *
  * @param conn     Connection pointer.
  *
- * @retval Pointer to a Coordinated Set Identification Profile Set Coordinator instance
+ * @return Pointer to a Coordinated Set Identification Profile Set Coordinator instance
  * @retval NULL if @p conn is NULL or if the connection has not done discovery yet
  */
 struct bt_csip_set_coordinator_set_member *
@@ -440,7 +440,8 @@ bool bt_csip_set_coordinator_is_set_member(const uint8_t sirk[BT_CSIP_SIRK_SIZE]
  *
  * @param cb   Pointer to the callback structure.
  *
- * @return Return 0 on success, or an errno value on error.
+ * @retval 0 success
+ * @retval -errno error
  */
 int bt_csip_set_coordinator_register_cb(struct bt_csip_set_coordinator_cb *cb);
 
@@ -452,8 +453,8 @@ int bt_csip_set_coordinator_register_cb(struct bt_csip_set_coordinator_cb *cb);
  *                   done on the members in ascending order.
  * @param count      Number of members in @p members.
  *
- * @return true if the procedures can be successfully done, or false to stop the
- *         procedure.
+ * @retval true the procedures can be successfully done
+ * @retval false stop the procedure.
  */
 typedef bool (*bt_csip_set_coordinator_ordered_access_t)(
 	const struct bt_csip_set_coordinator_set_info *set_info,

--- a/include/zephyr/bluetooth/audio/gmap.h
+++ b/include/zephyr/bluetooth/audio/gmap.h
@@ -184,9 +184,9 @@ struct bt_gmap_cb {
  *
  * @param cb The callback structure.
  *
- * @retval -EINVAL if @p cb is NULL
- * @retval -EALREADY if callbacks have already be registered
- * @retval 0 on success
+ * @retval -EINVAL @p cb is NULL
+ * @retval -EALREADY callbacks have already be registered
+ * @retval 0 success
  */
 int bt_gmap_cb_register(const struct bt_gmap_cb *cb);
 
@@ -199,10 +199,10 @@ int bt_gmap_cb_register(const struct bt_gmap_cb *cb);
  *
  * @param conn Bluetooth connection object.
  *
- * @retval -EINVAL if @p conn is NULL
- * @retval -EBUSY if discovery is already in progress for @p conn
- * @retval -ENOEXEC if discovery failed to initiate
- * @retval 0 on success
+ * @retval -EINVAL @p conn is NULL
+ * @retval -EBUSY discovery is already in progress for @p conn
+ * @retval -ENOEXEC discovery failed to initiate
+ * @retval 0 success
  */
 int bt_gmap_discover(struct bt_conn *conn);
 
@@ -215,7 +215,7 @@ int bt_gmap_discover(struct bt_conn *conn);
  *
  * @retval -EINVAL on invalid arguments
  * @retval -ENOEXEC on service register failure
- * @retval 0 on success
+ * @retval 0 success
  */
 int bt_gmap_register(enum bt_gmap_role role, struct bt_gmap_feat features);
 
@@ -230,12 +230,12 @@ int bt_gmap_register(enum bt_gmap_role role, struct bt_gmap_feat features);
  * @param features Features of the roles. If a role is not in the @p role parameter, then the
  *                 feature value for that role is simply ignored.
  *
- * @retval -ENOEXEC if the service has not yet been registered
+ * @retval -ENOEXEC the service has not yet been registered
  * @retval -EINVAL on invalid arguments
- * @retval -EALREADY if the @p role and @p features are the same as existing ones
+ * @retval -EALREADY the @p role and @p features are the same as existing ones
  * @retval -ENOENT on service unregister failure
  * @retval -ECANCELED on service re-register failure
- * @retval 0 on success
+ * @retval 0 success
  */
 int bt_gmap_set_role(enum bt_gmap_role role, struct bt_gmap_feat features);
 

--- a/include/zephyr/bluetooth/audio/has.h
+++ b/include/zephyr/bluetooth/audio/has.h
@@ -319,9 +319,9 @@ struct bt_has_preset_ops {
 	 * @param sync Whether the server must relay this change to the other member of the
 	 *             Binaural Hearing Aid Set.
 	 *
-	 * @return 0 in case of success or negative value in case of error.
-	 * @return -EBUSY if operation cannot be performed at the time.
-	 * @return -EINPROGRESS in case where user has to confirm once the requested preset
+	 * @retval 0 success.
+	 * @retval -EBUSY operation cannot be performed at the time.
+	 * @retval -EINPROGRESS user has to confirm once the requested preset
 	 *                      becomes active by calling @ref bt_has_preset_active_set.
 	 */
 	int (*select)(uint8_t index, bool sync);
@@ -440,8 +440,8 @@ enum {
  * @param name Preset name.
  * @param user_data Data given.
  *
- * @return BT_HAS_PRESET_ITER_CONTINUE if should continue to the next preset.
- * @return BT_HAS_PRESET_ITER_STOP to stop.
+ * @retval BT_HAS_PRESET_ITER_CONTINUE continue to the next preset.
+ * @retval BT_HAS_PRESET_ITER_STOP stop.
  */
 typedef uint8_t (*bt_has_preset_func_t)(uint8_t index, enum bt_has_properties properties,
 					const char *name, void *user_data);

--- a/include/zephyr/bluetooth/audio/micp.h
+++ b/include/zephyr/bluetooth/audio/micp.h
@@ -262,7 +262,7 @@ int bt_micp_mic_ctlr_conn_get(const struct bt_micp_mic_ctlr *mic_ctlr,
  *
  * @param conn     Connection pointer.
  *
- * @retval Pointer to a Microphone Control Profile Microphone Controller instance
+ * @return Pointer to a Microphone Control Profile Microphone Controller instance
  * @retval NULL if @p conn is NULL or if the connection has not done discovery yet
  */
 struct bt_micp_mic_ctlr *bt_micp_mic_ctlr_get_by_conn(const struct bt_conn *conn);

--- a/include/zephyr/bluetooth/audio/pacs.h
+++ b/include/zephyr/bluetooth/audio/pacs.h
@@ -52,8 +52,8 @@ struct bt_pacs_cap {
  * @param cap Capability found.
  * @param user_data Data given.
  *
- * @return true to continue to the next capability
- * @return false to stop the iteration
+ * @retval true continue to the next capability
+ * @retval false stop the iteration
  */
 typedef bool (*bt_pacs_cap_foreach_func_t)(const struct bt_pacs_cap *cap,
 					   void *user_data);

--- a/include/zephyr/bluetooth/audio/pbp.h
+++ b/include/zephyr/bluetooth/audio/pbp.h
@@ -81,11 +81,11 @@ int bt_pbp_get_announcement(const uint8_t meta[], size_t meta_len,
  * @param[out] meta     Pointer to the metadata present in the advertising data
  *
  * @return parsed metadata length on success.
- * @retval -EINVAL if @p data, @p features or @p meta are NULL.
- * @retval -ENOENT if @p data is not of type @ref BT_DATA_SVC_DATA16 or if the UUID in the service
+ * @retval -EINVAL @p data, @p features or @p meta are NULL.
+ * @retval -ENOENT @p data is not of type @ref BT_DATA_SVC_DATA16 or if the UUID in the service
  * data is not @ref BT_UUID_PBA.
- * @retval -EMSGSIZE if @p data is not large enough to contain a PBP announcement.
- * @retval -EBADMSG if the @p data contains invalid data.
+ * @retval -EMSGSIZE @p data is not large enough to contain a PBP announcement.
+ * @retval -EBADMSG the @p data contains invalid data.
  */
 int bt_pbp_parse_announcement(struct bt_data *data, enum bt_pbp_announcement_feature *features,
 			      uint8_t **meta);

--- a/include/zephyr/bluetooth/audio/vcp.h
+++ b/include/zephyr/bluetooth/audio/vcp.h
@@ -410,9 +410,9 @@ struct bt_vcp_vol_ctlr_cb {
  *
  * @param cb   The callback structure.
  *
- * @retval 0 on success
- * @retval -EINVAL if @p cb is NULL
- * @retval -EALREADY if @p cb was already registered
+ * @retval 0 success
+ * @retval -EINVAL @p cb is NULL
+ * @retval -EALREADY @p cb was already registered
  */
 int bt_vcp_vol_ctlr_cb_register(struct bt_vcp_vol_ctlr_cb *cb);
 
@@ -421,9 +421,9 @@ int bt_vcp_vol_ctlr_cb_register(struct bt_vcp_vol_ctlr_cb *cb);
  *
  * @param cb   The callback structure.
  *
- * @retval 0 on success
- * @retval -EINVAL if @p cb is NULL
- * @retval -EALREADY if @p cb was not registered
+ * @retval 0 success
+ * @retval -EINVAL @p cb is NULL
+ * @retval -EALREADY @p cb was not registered
  */
 int bt_vcp_vol_ctlr_cb_unregister(struct bt_vcp_vol_ctlr_cb *cb);
 
@@ -455,7 +455,7 @@ int bt_vcp_vol_ctlr_discover(struct bt_conn *conn,
  *
  * @param conn     Connection pointer.
  *
- * @retval Pointer to a Volume Control Profile Volume Controller instance
+ * @return Pointer to a Volume Control Profile Volume Controller instance
  * @retval NULL if @p conn is NULL or if the connection has not done discovery yet
  */
 struct bt_vcp_vol_ctlr *bt_vcp_vol_ctlr_get_by_conn(const struct bt_conn *conn);

--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -1147,10 +1147,10 @@ struct bt_le_per_adv_param {
  * @param sd Data to be used in scan response packets.
  * @param sd_len Number of elements in sd
  *
- * @return Zero on success or (negative) error code otherwise.
- * @return -ENOMEM No free connection objects available for connectable
+ * @retval 0 success.
+ * @retval -ENOMEM No free connection objects available for connectable
  *                 advertiser.
- * @return -ECONNREFUSED When connectable advertising is requested and there
+ * @retval -ECONNREFUSED When connectable advertising is requested and there
  *                       is already maximum number of connections established
  *                       in the controller.
  *                       This error code is only guaranteed when using Zephyr
@@ -2666,7 +2666,8 @@ void bt_foreach_bond(uint8_t id, void (*func)(const struct bt_bond_info *info,
  *  @param vs_config_len  Length of additional vendor specific configuration data
  *  @param vs_config      Pointer to additional vendor specific configuration data
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 success.
+ *  @retval -errno negative error code on failure.
  */
 int bt_configure_data_path(uint8_t dir, uint8_t id, uint8_t vs_config_len,
 			   const uint8_t *vs_config);
@@ -2698,7 +2699,8 @@ struct bt_le_per_adv_sync_subevent_params {
  *  @param per_adv_sync   The periodic advertising sync object.
  *  @param params         Parameters.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 success.
+ *  @retval -errno negative error code on failure.
  */
 int bt_le_per_adv_sync_subevent(struct bt_le_per_adv_sync *per_adv_sync,
 				struct bt_le_per_adv_sync_subevent_params *params);

--- a/include/zephyr/bluetooth/classic/hfp_ag.h
+++ b/include/zephyr/bluetooth/classic/hfp_ag.h
@@ -91,7 +91,8 @@ struct bt_hfp_ag_cb {
 	 *  @param location AG memory location
 	 *  @param number Dailing number
 	 *
-	 *  @return 0 in case of success or negative value in case of error.
+	 *  @retval 0 success.
+	 *  @retval -errno negative error code on failure.
 	 */
 	int (*memory_dial)(struct bt_hfp_ag *ag, const char *location, char **number);
 
@@ -169,7 +170,8 @@ struct bt_hfp_ag_cb {
  *
  *  @param cb callback structure.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 success.
+ *  @retval -errno negative error code on failure.
  */
 int bt_hfp_ag_register(struct bt_hfp_ag_cb *cb);
 
@@ -181,7 +183,8 @@ int bt_hfp_ag_register(struct bt_hfp_ag_cb *cb);
  *  @param ag Created HFP AG object.
  *  @param channel Peer rfcomm channel to be connected.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 success.
+ *  @retval -errno negative error code on failure.
  */
 int bt_hfp_ag_connect(struct bt_conn *conn, struct bt_hfp_ag **ag, uint8_t channel);
 
@@ -191,7 +194,8 @@ int bt_hfp_ag_connect(struct bt_conn *conn, struct bt_hfp_ag **ag, uint8_t chann
  *
  *  @param ag HFP AG object.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 success.
+ *  @retval -errno negative error code on failure.
  */
 int bt_hfp_ag_disconnect(struct bt_hfp_ag *ag);
 
@@ -202,7 +206,8 @@ int bt_hfp_ag_disconnect(struct bt_hfp_ag *ag);
  *  @param ag HFP AG object.
  *  @param number Dailing number.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 success.
+ *  @retval -errno negative error code on failure.
  */
 int bt_hfp_ag_remote_incoming(struct bt_hfp_ag *ag, const char *number);
 
@@ -212,7 +217,8 @@ int bt_hfp_ag_remote_incoming(struct bt_hfp_ag *ag, const char *number);
  *
  *  @param ag HFP AG object.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 success.
+ *  @retval -errno negative error code on failure.
  */
 int bt_hfp_ag_reject(struct bt_hfp_ag *ag);
 
@@ -222,7 +228,8 @@ int bt_hfp_ag_reject(struct bt_hfp_ag *ag);
  *
  *  @param ag HFP AG object.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 success.
+ *  @retval -errno negative error code on failure.
  */
 int bt_hfp_ag_accept(struct bt_hfp_ag *ag);
 
@@ -232,7 +239,8 @@ int bt_hfp_ag_accept(struct bt_hfp_ag *ag);
  *
  *  @param ag HFP AG object.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 success.
+ *  @retval -errno negative error code on failure.
  */
 int bt_hfp_ag_terminate(struct bt_hfp_ag *ag);
 
@@ -243,7 +251,8 @@ int bt_hfp_ag_terminate(struct bt_hfp_ag *ag);
  *  @param ag HFP AG object.
  *  @param number Dailing number.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 success.
+ *  @retval -errno negative error code on failure.
  */
 int bt_hfp_ag_outgoing(struct bt_hfp_ag *ag, const char *number);
 
@@ -253,7 +262,8 @@ int bt_hfp_ag_outgoing(struct bt_hfp_ag *ag, const char *number);
  *
  *  @param ag HFP AG object.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 success.
+ *  @retval -errno negative error code on failure.
  */
 int bt_hfp_ag_remote_ringing(struct bt_hfp_ag *ag);
 
@@ -263,7 +273,8 @@ int bt_hfp_ag_remote_ringing(struct bt_hfp_ag *ag);
  *
  *  @param ag HFP AG object.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 success.
+ *  @retval -errno negative error code on failure.
  */
 int bt_hfp_ag_remote_reject(struct bt_hfp_ag *ag);
 
@@ -273,7 +284,8 @@ int bt_hfp_ag_remote_reject(struct bt_hfp_ag *ag);
  *
  *  @param ag HFP AG object.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 success.
+ *  @retval -errno negative error code on failure.
  */
 int bt_hfp_ag_remote_accept(struct bt_hfp_ag *ag);
 
@@ -283,7 +295,8 @@ int bt_hfp_ag_remote_accept(struct bt_hfp_ag *ag);
  *
  *  @param ag HFP AG object.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 success.
+ *  @retval -errno negative error code on failure.
  */
 int bt_hfp_ag_remote_terminate(struct bt_hfp_ag *ag);
 

--- a/include/zephyr/bluetooth/classic/hfp_hf.h
+++ b/include/zephyr/bluetooth/classic/hfp_hf.h
@@ -164,7 +164,8 @@ struct bt_hfp_hf_cb {
  *
  *  @param cb callback structure.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 success.
+ *  @retval -errno negative error code on failure.
  */
 int bt_hfp_hf_register(struct bt_hfp_hf_cb *cb);
 
@@ -175,7 +176,8 @@ int bt_hfp_hf_register(struct bt_hfp_hf_cb *cb);
  *  @param conn Connection object.
  *  @param cmd AT command to be sent.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 success.
+ *  @retval -errno negative error code on failure.
  */
 int bt_hfp_hf_send_cmd(struct bt_conn *conn, enum bt_hfp_hf_at_cmd cmd);
 

--- a/include/zephyr/bluetooth/classic/rfcomm.h
+++ b/include/zephyr/bluetooth/classic/rfcomm.h
@@ -120,7 +120,8 @@ struct bt_rfcomm_server {
 	 *  @param conn The connection that is requesting authorization
 	 *  @param dlc Pointer to received the allocated dlc
 	 *
-	 *  @return 0 in case of success or negative value in case of error.
+	 *  @retval 0 success.
+	 *  @retval -errno negative error code on failure.
 	 */
 	int (*accept)(struct bt_conn *conn, struct bt_rfcomm_dlc **dlc);
 
@@ -135,7 +136,8 @@ struct bt_rfcomm_server {
  *
  *  @param server Server structure.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 success.
+ *  @retval -errno negative error code on failure.
  */
 int bt_rfcomm_server_register(struct bt_rfcomm_server *server);
 
@@ -149,7 +151,8 @@ int bt_rfcomm_server_register(struct bt_rfcomm_server *server);
  *  @param dlc Dlc object.
  *  @param channel Server channel to connect to.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 success.
+ *  @retval -errno negative error code on failure.
  */
 int bt_rfcomm_dlc_connect(struct bt_conn *conn, struct bt_rfcomm_dlc *dlc,
 			  uint8_t channel);
@@ -173,7 +176,8 @@ int bt_rfcomm_dlc_send(struct bt_rfcomm_dlc *dlc, struct net_buf *buf);
  *
  *  @param dlc Dlc object.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 success.
+ *  @retval -errno negative error code on failure.
  */
 int bt_rfcomm_dlc_disconnect(struct bt_rfcomm_dlc *dlc);
 

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -652,8 +652,8 @@ int bt_conn_get_info(const struct bt_conn *conn, struct bt_conn_info *info);
  *  been established. The application can be notified about when the remote
  *  information is available through the remote_info_available callback.
  *
- *  @return Zero on success or (negative) error code on failure.
- *  @return -EBUSY The remote information is not yet available.
+ *  @retval 0 success.
+ *  @retval -EBUSY The remote information is not yet available.
  */
 int bt_conn_get_remote_info(struct bt_conn *conn,
 			    struct bt_conn_remote_info *remote_info);
@@ -663,8 +663,8 @@ int bt_conn_get_remote_info(struct bt_conn *conn,
  *  @param conn           Connection object.
  *  @param tx_power_level Transmit power level descriptor.
  *
- *  @return Zero on success or (negative) error code on failure.
- *  @return -ENOBUFS HCI command buffer is not available.
+ *  @retval 0 success.
+ *  @retval -ENOBUFS HCI command buffer is not available.
  */
 int bt_conn_le_get_tx_power_level(struct bt_conn *conn,
 				  struct bt_conn_le_tx_power *tx_power_level);
@@ -674,7 +674,7 @@ int bt_conn_le_get_tx_power_level(struct bt_conn *conn,
  *  @param conn           Connection object.
  *  @param tx_power       Transmit power level descriptor.
  *
- *  @return Zero on success or (negative) error code on failure.
+ *  @retval 0 success.
  *  @retval -ENOBUFS HCI command buffer is not available.
  */
 int bt_conn_le_enhanced_get_tx_power_level(struct bt_conn *conn,
@@ -685,7 +685,7 @@ int bt_conn_le_enhanced_get_tx_power_level(struct bt_conn *conn,
  *  @param conn           Connection object.
  *  @param phy            PHY information.
  *
- *  @return Zero on success or (negative) error code on failure.
+ *  @retval 0 success.
  *  @retval -ENOBUFS HCI command buffer is not available.
  */
 int bt_conn_le_get_remote_tx_power_level(struct bt_conn *conn,
@@ -990,8 +990,8 @@ int bt_conn_le_create_synced(const struct bt_le_ext_adv *adv,
  *  @param create_param Create connection parameters
  *  @param conn_param   Initial connection parameters.
  *
- *  @return Zero on success or (negative) error code on failure.
- *  @return -ENOMEM No free connection object available.
+ *  @retval 0 success.
+ *  @retval -ENOMEM No free connection object available.
  */
 int bt_conn_le_create_auto(const struct bt_conn_le_create_param *create_param,
 			   const struct bt_le_conn_param *conn_param);

--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -473,7 +473,8 @@ int bt_gatt_authorization_cb_register(const struct bt_gatt_authorization_cb *cb)
  *
  *  @param svc Service containing the available attributes
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 success.
+ *  @retval -errno negative error code on failure.
  *  @return -EAGAIN if ``bt_init()`` has been called but ``settings_load()`` hasn't yet.
  */
 int bt_gatt_service_register(struct bt_gatt_service *svc);
@@ -482,7 +483,8 @@ int bt_gatt_service_register(struct bt_gatt_service *svc);
  *
  *  @param svc Service to be unregistered.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 success.
+ *  @retval -errno negative error code on failure.
  */
 int bt_gatt_service_unregister(struct bt_gatt_service *svc);
 
@@ -506,8 +508,8 @@ enum {
  *  @param handle Attribute handle found.
  *  @param user_data Data given.
  *
- *  @return ``BT_GATT_ITER_CONTINUE`` if should continue to the next attribute.
- *  @return ``BT_GATT_ITER_STOP`` to stop.
+ *  @retval BT_GATT_ITER_CONTINUE continue to the next attribute.
+ *  @retval BT_GATT_ITER_STOP stop.
  */
 typedef uint8_t (*bt_gatt_attr_func_t)(const struct bt_gatt_attr *attr,
 				       uint16_t handle,
@@ -1128,7 +1130,8 @@ struct bt_gatt_notify_params {
  *  @param conn Connection object.
  *  @param params Notification parameters.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 success.
+ *  @retval -errno negative error code on failure.
  */
 int bt_gatt_notify_cb(struct bt_conn *conn,
 		      struct bt_gatt_notify_params *params);
@@ -1205,7 +1208,8 @@ int bt_gatt_notify_multiple(struct bt_conn *conn,
  *  @param data Pointer to Attribute data.
  *  @param len Attribute value length.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 success.
+ *  @retval -errno negative error code on failure.
  */
 static inline int bt_gatt_notify(struct bt_conn *conn,
 				 const struct bt_gatt_attr *attr,
@@ -1242,7 +1246,8 @@ static inline int bt_gatt_notify(struct bt_conn *conn,
  *  @param data Pointer to Attribute data.
  *  @param len  Attribute value length.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 success.
+ *  @retval -errno negative error code on failure.
  */
 static inline int bt_gatt_notify_uuid(struct bt_conn *conn,
 				      const struct bt_uuid *uuid,
@@ -1333,7 +1338,8 @@ struct bt_gatt_indicate_params {
  *  @param conn Connection object.
  *  @param params Indicate parameters.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 success.
+ *  @retval -errno negative error code on failure.
  */
 int bt_gatt_indicate(struct bt_conn *conn,
 		     struct bt_gatt_indicate_params *params);
@@ -1990,7 +1996,8 @@ int bt_gatt_subscribe(struct bt_conn *conn,
  *  @param peer   Remote address.
  *  @param params Subscribe parameters.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 success.
+ *  @retval -errno negative error code on failure.
  */
 int bt_gatt_resubscribe(uint8_t id, const bt_addr_le_t *peer,
 			struct bt_gatt_subscribe_params *params);

--- a/include/zephyr/bluetooth/hci.h
+++ b/include/zephyr/bluetooth/hci.h
@@ -156,7 +156,7 @@ int bt_hci_get_adv_sync_handle(const struct bt_le_per_adv_sync *sync, uint16_t *
  *
  * @param handle The periodic sync set handle
  *
- * @retval The corresponding periodic advertising sync set object on success,
+ * @return The corresponding periodic advertising sync set object on success,
  *         NULL if it does not exist.
  */
 struct bt_le_per_adv_sync *bt_hci_per_adv_sync_lookup_handle(uint16_t handle);

--- a/include/zephyr/bluetooth/l2cap.h
+++ b/include/zephyr/bluetooth/l2cap.h
@@ -342,7 +342,8 @@ struct bt_l2cap_chan_ops {
 	 *  @param chan The channel receiving data.
 	 *  @param buf Buffer containing incoming data.
 	 *
-	 *  @return 0 in case of success or negative value in case of error.
+	 *  @retval 0 success.
+	 *  @retval -errno negative error code on failure.
 	 *  @return -EINPROGRESS in case where user has to confirm once the data
 	 *                       has been processed by calling
 	 *                       @ref bt_l2cap_chan_recv_complete passing back
@@ -466,10 +467,11 @@ struct bt_l2cap_server {
 	 *  @param server Pointer to the server structure this callback relates to
 	 *  @param chan Pointer to received the allocated channel
 	 *
-	 *  @return 0 in case of success or negative value in case of error.
-	 *  @return -ENOMEM if no available space for new channel.
-	 *  @return -EACCES if application did not authorize the connection.
-	 *  @return -EPERM if encryption key size is too short.
+	 *  @retval 0 success.
+	 *  @retval -errno negative error code on failure.
+	 *  @retval -ENOMEM no available space for new channel.
+	 *  @retval -EACCES application did not authorize the connection.
+	 *  @retval -EPERM encryption key size is too short.
 	 */
 	int (*accept)(struct bt_conn *conn, struct bt_l2cap_server *server,
 		      struct bt_l2cap_chan **chan);
@@ -494,7 +496,8 @@ struct bt_l2cap_server {
  *
  *  @param server Server structure.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 success.
+ *  @retval -errno negative error code on failure.
  */
 int bt_l2cap_server_register(struct bt_l2cap_server *server);
 
@@ -506,7 +509,8 @@ int bt_l2cap_server_register(struct bt_l2cap_server *server);
  *
  *  @param server Server structure.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 success.
+ *  @retval -errno negative error code on failure.
  */
 int bt_l2cap_br_server_register(struct bt_l2cap_server *server);
 
@@ -520,7 +524,8 @@ int bt_l2cap_br_server_register(struct bt_l2cap_server *server);
  *  @param chans Array of channel objects.
  *  @param psm Channel PSM to connect to.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 success.
+ *  @retval -errno negative error code on failure.
  */
 int bt_l2cap_ecred_chan_connect(struct bt_conn *conn,
 				struct bt_l2cap_chan **chans, uint16_t psm);
@@ -535,7 +540,8 @@ int bt_l2cap_ecred_chan_connect(struct bt_conn *conn,
  *               first 5 are silently ignored.
  *  @param mtu Channel MTU to reconfigure to.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 success.
+ *  @retval -errno negative error code on failure.
  */
 int bt_l2cap_ecred_chan_reconfigure(struct bt_l2cap_chan **chans, uint16_t mtu);
 
@@ -555,7 +561,8 @@ int bt_l2cap_ecred_chan_reconfigure(struct bt_l2cap_chan **chans, uint16_t mtu);
  *  @param chan Channel object.
  *  @param psm Channel PSM to connect to.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 success.
+ *  @retval -errno negative error code on failure.
  */
 int bt_l2cap_chan_connect(struct bt_conn *conn, struct bt_l2cap_chan *chan,
 			  uint16_t psm);
@@ -569,7 +576,8 @@ int bt_l2cap_chan_connect(struct bt_conn *conn, struct bt_l2cap_chan *chan,
  *
  *  @param chan Channel object.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 success.
+ *  @retval -errno negative error code on failure.
  */
 int bt_l2cap_chan_disconnect(struct bt_l2cap_chan *chan);
 
@@ -607,15 +615,15 @@ int bt_l2cap_chan_disconnect(struct bt_l2cap_chan *chan);
  *  @note Buffer ownership is transferred to the stack in case of success, in
  *  case of an error the caller retains the ownership of the buffer.
  *
- *  @return 0 in case of success or negative value in case of error.
- *  @return -EINVAL if `buf` or `chan` is NULL.
- *  @return -EINVAL if `chan` is not either BR/EDR or LE credit-based.
- *  @return -EINVAL if buffer doesn't have enough bytes reserved to fit header.
- *  @return -EINVAL if buffer's reference counter != 1
- *  @return -EMSGSIZE if `buf` is larger than `chan`'s MTU.
- *  @return -ENOTCONN if underlying conn is disconnected.
- *  @return -ESHUTDOWN if L2CAP channel is disconnected.
- *  @return -other (from lower layers) if chan is BR/EDR.
+ *  @retval 0 success.
+ *  @retval -EINVAL `buf` or `chan` is NULL.
+ *  @retval -EINVAL `chan` is not either BR/EDR or LE credit-based.
+ *  @retval -EINVAL buffer doesn't have enough bytes reserved to fit header.
+ *  @retval -EINVAL buffer's reference counter != 1
+ *  @retval -EMSGSIZE `buf` is larger than `chan`'s MTU.
+ *  @retval -ENOTCONN underlying conn is disconnected.
+ *  @retval -ESHUTDOWN L2CAP channel is disconnected.
+ *  @retval -other (from lower layers) if chan is BR/EDR.
  */
 int bt_l2cap_chan_send(struct bt_l2cap_chan *chan, struct net_buf *buf);
 
@@ -638,7 +646,8 @@ int bt_l2cap_chan_send(struct bt_l2cap_chan *chan, struct net_buf *buf);
  *
  *  Must not be called while the channel is in @ref BT_L2CAP_CONNECTING state.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 success.
+ *  @retval -errno negative error code on failure.
  */
 int bt_l2cap_chan_give_credits(struct bt_l2cap_chan *chan, uint16_t additional_credits);
 
@@ -652,7 +661,8 @@ int bt_l2cap_chan_give_credits(struct bt_l2cap_chan *chan, uint16_t additional_c
  * @param chan Channel object.
  * @param buf Buffer containing the data.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 success.
+ *  @retval -errno negative error code on failure.
  */
 int bt_l2cap_chan_recv_complete(struct bt_l2cap_chan *chan,
 				struct net_buf *buf);

--- a/include/zephyr/bluetooth/mesh/access.h
+++ b/include/zephyr/bluetooth/mesh/access.h
@@ -995,7 +995,8 @@ int bt_mesh_model_publish(const struct bt_mesh_model *model);
  *
  * @param model Mesh Model that supports publication.
  *
- * @return true if this is a retransmission, false if this is a first publication.
+ * @retval true this is a retransmission
+ * @retval false this is a first publication.
  */
 static inline bool bt_mesh_model_pub_is_retransmission(const struct bt_mesh_model *model)
 {

--- a/include/zephyr/bluetooth/mesh/cfg_cli.h
+++ b/include/zephyr/bluetooth/mesh/cfg_cli.h
@@ -1829,8 +1829,8 @@ struct bt_mesh_comp_p2_record *bt_mesh_comp_p2_record_pull(struct net_buf_simple
  * @param dst_arr Destination array for the unpacked list.
  * @param dst_cnt Size of the destination array.
  *
- * @return 0 on success.
- * @return -EMSGSIZE if dst_arr size is to small to parse full message.
+ * @retval 0 success.
+ * @retval -EMSGSIZE dst_arr size is too small to parse full message.
  */
 int bt_mesh_key_idx_unpack_list(struct net_buf_simple *buf, uint16_t *dst_arr, size_t *dst_cnt);
 

--- a/include/zephyr/bluetooth/services/hrs.h
+++ b/include/zephyr/bluetooth/services/hrs.h
@@ -46,8 +46,8 @@ struct bt_hrs_cb {
  * @param cb Pointer to callbacks structure. Must point to memory that remains valid
  * until unregistered.
  *
- * @return 0 on success
- * @return -EINVAL in case @p cb is NULL
+ * @retval 0 success
+ * @retval -EINVAL @p cb is NULL
  */
 int bt_hrs_cb_register(struct bt_hrs_cb *cb);
 
@@ -57,9 +57,9 @@ int bt_hrs_cb_register(struct bt_hrs_cb *cb);
  *
  * @param cb Pointer to callbacks structure
  *
- * @return 0 on success
- * @return -EINVAL in case @p cb is NULL
- * @return -ENOENT in case the @p cb was not found in registered callbacks
+ * @retval 0 success
+ * @retval -EINVAL @p cb is NULL
+ * @retval -ENOENT @p cb was not found in registered callbacks
  */
 int bt_hrs_cb_unregister(struct bt_hrs_cb *cb);
 
@@ -69,7 +69,8 @@ int bt_hrs_cb_unregister(struct bt_hrs_cb *cb);
  *
  *  @param heartrate The heartrate measurement in beats per minute.
  *
- *  @return Zero in case of success and error code in case of error.
+ *  @retval 0 success
+ *  @retval -errno error code
  */
 int bt_hrs_notify(uint16_t heartrate);
 

--- a/include/zephyr/bluetooth/services/nus.h
+++ b/include/zephyr/bluetooth/services/nus.h
@@ -71,8 +71,8 @@ struct bt_nus_cb {
  *           lifetime of the application.
  * @param ctx User context to be provided through the callback.
  *
- * @return 0 on success
- * @return -EINVAL in case @p cb is NULL
+ * @retval 0 success
+ * @retval -EINVAL @p cb is NULL
  */
 int bt_nus_inst_cb_register(struct bt_nus_inst *inst, struct bt_nus_cb *cb, void *ctx);
 
@@ -85,10 +85,11 @@ int bt_nus_inst_cb_register(struct bt_nus_inst *inst, struct bt_nus_cb *cb, void
  * @param data Pointer to buffer with bytes to send.
  * @param len Length in bytes of data to send.
  *
- * @return 0 on success, negative error code if failed.
- * @return -EAGAIN when Bluetooth stack has not been enabled.
- * @return -ENOTCONN when either no connection has been established or no peers
+ * @retval 0 success
+ * @retval -EAGAIN Bluetooth stack has not been enabled.
+ * @retval -ENOTCONN Either no connection has been established or no peers
  *         have subscribed.
+ * @retval -errno other negative error code on fail
  */
 int bt_nus_inst_send(struct bt_conn *conn,
 		     struct bt_nus_inst *inst,
@@ -101,8 +102,9 @@ int bt_nus_inst_send(struct bt_conn *conn,
  *           lifetime of the application.
  * @param ctx User context to be provided through the callback.
  *
- * @return 0 on success, negative error code if failed.
- * @return -EINVAL in case @p cb is NULL
+ * @retval 0 success
+ * @retval -EINVAL @p cb is NULL
+ * @retval -errno other negative error code on fail
  */
 static inline int bt_nus_cb_register(struct bt_nus_cb *cb, void *ctx)
 {
@@ -117,10 +119,11 @@ static inline int bt_nus_cb_register(struct bt_nus_cb *cb, void *ctx)
  * @param data Pointer to buffer with bytes to send.
  * @param len Length in bytes of data to send.
  *
- * @return 0 on success, negative error code if failed.
- * @return -EAGAIN when Bluetooth stack has not been enabled.
- * @return -ENOTCONN when either no connection has been established or no peers
- *         have subscribed.
+ * @retval 0 success
+ * @retval -EAGAIN Bluetooth stack has not been enabled.
+ * @retval -ENOTCONN Either no connection has been established or no peers
+ *        have subscribed.
+ * @retval -errno other negative error code on fail
  */
 static inline int bt_nus_send(struct bt_conn *conn, const void *data, uint16_t len)
 {

--- a/include/zephyr/bluetooth/services/ots.h
+++ b/include/zephyr/bluetooth/services/ots.h
@@ -615,11 +615,11 @@ struct bt_ots_cb {
 	 *  @param created_desc  Created object descriptor that shall be filled by the
 	 *                       receiver of this callback.
 	 *
-	 *  @return 0 in case of success or negative value in case of error.
-	 *  @return -ENOTSUP if object type is not supported
-	 *  @return -ENOMEM if no available space for new object.
-	 *  @return -EINVAL if an invalid parameter is provided
-	 *  @return other negative values are treated as a generic operation failure
+	 *  @retval 0 success.
+	 *  @retval -ENOTSUP object type is not supported
+	 *  @retval -ENOMEM no available space for new object.
+	 *  @retval -EINVAL an invalid parameter is provided
+	 *  @retval -errno other negative values representing generic operation failure
 	 */
 	int (*obj_created)(struct bt_ots *ots, struct bt_conn *conn, uint64_t id,
 			   const struct bt_ots_obj_add_param *add_param,
@@ -636,14 +636,14 @@ struct bt_ots_cb {
 	 *              this request came from the server.
 	 *  @param id   Object ID.
 	 *
-	 *  @retval When an error is indicated by using a negative value, the
+	 *  @retval 0 success.
+	 *  @note   When an error is indicated by using a negative value, the
 	 *          object delete procedure is aborted and a corresponding failed
 	 *          status is returned to the client.
-	 *  @return 0 in case of success.
-	 *  @return -EBUSY if the object is locked. This is generally not expected
+	 *  @retval -EBUSY the object is locked. This is generally not expected
 	 *          to be returned by the application as the OTS layer tracks object
 	 *          accesses. An object locked status is returned to the client.
-	 *  @return Other negative values in case of error. A generic operation
+	 *  @retval -errno Other negative values in case of error. A generic operation
 	 *          failed status is returned to the client.
 	 */
 	int (*obj_deleted)(struct bt_ots *ots, struct bt_conn *conn,
@@ -703,11 +703,10 @@ struct bt_ots_cb {
 	 *  @param offset Object data offset.
 	 *  @param rem    Remaining length in the write operation.
 	 *
-	 *  @return Number of bytes written in case of success, if the number
-	 *          of bytes written does not match len, -EIO is returned to
-	 *          the L2CAP layer.
-	 *  @return A negative value in case of an error.
-	 *  @return -EINPROGRESS has a special meaning and is unsupported at
+	 *  @retval nbytes Number of bytes written.
+	 *  @retval -EIO the number of bytes written does not match len.
+	 *  @retval -errno negative error code on failure.
+	 *  @retval -EINPROGRESS has a special meaning and is unsupported at
 	 *          the moment. It should not be returned.
 	 */
 	ssize_t (*obj_write)(struct bt_ots *ots, struct bt_conn *conn, uint64_t id,
@@ -766,8 +765,8 @@ struct bt_ots_init_param {
  *  @param ots      OTS instance.
  *  @param param    Object addition parameters.
  *
- *  @return ID of created object in case of success.
- *  @return negative value in case of error.
+ *  @retval id ID of created object in case of success.
+ *  @retval -errno negative value in case of error.
  */
 int bt_ots_obj_add(struct bt_ots *ots, const struct bt_ots_obj_add_param *param);
 
@@ -781,7 +780,8 @@ int bt_ots_obj_add(struct bt_ots *ots, const struct bt_ots_obj_add_param *param)
  *  @param ots OTS instance.
  *  @param id  ID of the object to be deleted (uint48).
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 success.
+ *  @retval -errno negative error code on failure.
  */
 int bt_ots_obj_delete(struct bt_ots *ots, uint64_t id);
 
@@ -801,7 +801,8 @@ void *bt_ots_svc_decl_get(struct bt_ots *ots);
  *  @param ots      OTS instance.
  *  @param ots_init OTS initialization descriptor.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 success.
+ *  @retval -errno negative error code on failure.
  */
 int bt_ots_init(struct bt_ots *ots, struct bt_ots_init_param *ots_init);
 

--- a/include/zephyr/canbus/isotp.h
+++ b/include/zephyr/canbus/isotp.h
@@ -275,7 +275,7 @@ void isotp_unbind(struct isotp_recv_ctx *rctx);
  * @param len     Size of the buffer.
  * @param timeout Timeout for incoming data.
  *
- * @retval Number of bytes copied on success
+ * @return Number of bytes copied on success
  * @retval ISOTP_RECV_TIMEOUT when "timeout" timed out
  * @retval ISOTP_N_* on error
  */
@@ -295,7 +295,7 @@ int isotp_recv(struct isotp_recv_ctx *rctx, uint8_t *data, size_t len, k_timeout
  * @param buffer  Pointer where the net_buf pointer is written to.
  * @param timeout Timeout for incoming data.
  *
- * @retval Remaining data length for this transfer if BS > 0, 0 for BS = 0
+ * @return Remaining data length for this transfer if BS > 0, 0 for BS = 0
  * @retval ISOTP_RECV_TIMEOUT when "timeout" timed out
  * @retval ISOTP_N_* on error
  */

--- a/include/zephyr/data/navigation.h
+++ b/include/zephyr/data/navigation.h
@@ -23,9 +23,9 @@
  * point relative to a sphere (commonly Earth)
  */
 struct navigation_data {
-	/** Latitudal position in nanodegrees (0 to +-180E9) */
+	/** Latitudinal position in nanodegrees (0 to +-180E9) */
 	int64_t latitude;
-	/** Longitudal position in nanodegrees (0 to +-180E9) */
+	/** Longitudinal position in nanodegrees (0 to +-180E9) */
 	int64_t longitude;
 	/** Bearing angle in millidegrees (0 to 360E3) */
 	uint32_t bearing;
@@ -43,8 +43,8 @@ struct navigation_data {
  * @param p1 First navigation point
  * @param p2 Second navigation point
  *
- * @return 0 if successful
- * @return -EINVAL if either navigation point is invalid
+ * @retval 0 success
+ * @return -EINVAL either navigation point is invalid
  */
 int navigation_distance(uint64_t *distance, const struct navigation_data *p1,
 			const struct navigation_data *p2);
@@ -56,8 +56,8 @@ int navigation_distance(uint64_t *distance, const struct navigation_data *p1,
  * @param from First navigation point
  * @param to Second navigation point
  *
- * @return 0 if successful
- * @return -EINVAL if either navigation point is invalid
+ * @retval 0 success
+ * @return -EINVAL either navigation point is invalid
  */
 int navigation_bearing(uint32_t *bearing, const struct navigation_data *from,
 		       const struct navigation_data *to);

--- a/include/zephyr/drivers/adc/adc_emul.h
+++ b/include/zephyr/drivers/adc/adc_emul.h
@@ -53,8 +53,8 @@ extern "C" {
  * @param data User data which was passed on @ref adc_emul_value_func_set
  * @param result The result value which will be set as input for ADC @p chan
  *
- * @return 0 on success
- * @return other as error code which ends ADC context
+ * @retval 0 success
+ * @retval -errno negative error code which ends ADC context
  */
 typedef int (*adc_emul_value_func)(const struct device *dev, unsigned int chan,
 				   void *data, uint32_t *result);
@@ -66,8 +66,8 @@ typedef int (*adc_emul_value_func)(const struct device *dev, unsigned int chan,
  * @param chan The channel of ADC which input is assigned
  * @param value New voltage in mV to assign to @p chan input
  *
- * @return 0 on success
- * @return -EINVAL if an invalid argument is provided
+ * @retval 0 success
+ * @retval -EINVAL an invalid argument was provided
  */
 int adc_emul_const_value_set(const struct device *dev, unsigned int chan,
 			     uint32_t value);
@@ -81,8 +81,8 @@ int adc_emul_const_value_set(const struct device *dev, unsigned int chan,
  * @param func New function to assign to @p chan
  * @param data Pointer to data passed to @p func on call
  *
- * @return 0 on success
- * @return -EINVAL if an invalid argument is provided
+ * @retval 0 success
+ * @retval -EINVAL an invalid argument was provided
  */
 int adc_emul_value_func_set(const struct device *dev, unsigned int chan,
 			    adc_emul_value_func func, void *data);
@@ -94,8 +94,8 @@ int adc_emul_value_func_set(const struct device *dev, unsigned int chan,
  * @param ref Reference config which is changed
  * @param value New reference voltage in mV
  *
- * @return 0 on success
- * @return -EINVAL if an invalid argument is provided
+ * @retval 0 success
+ * @retval -EINVAL an invalid argument was provided
  */
 int adc_emul_ref_voltage_set(const struct device *dev, enum adc_reference ref,
 			     uint16_t value);

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -1105,7 +1105,7 @@ __syscall int can_set_bitrate_data(const struct device *dev, uint32_t bitrate_da
  * @param bitrate Target bitrate.
  *
  * @retval 0 or positive bitrate error.
- * @retval Negative error code on error.
+ * @retval -errno Negative error code on error.
  */
 __deprecated int can_calc_prescaler(const struct device *dev, struct can_timing *timing,
 				    uint32_t bitrate);
@@ -1437,7 +1437,7 @@ static inline void z_impl_can_remove_rx_filter(const struct device *dev, int fil
  * @param ide Get the maximum standard (11-bit) CAN ID filters if false, or extended (29-bit) CAN ID
  *            filters if true.
  *
- * @retval Positive number of maximum concurrent filters.
+ * @return Positive number of maximum concurrent filters.
  * @retval -EIO General input/output error.
  * @retval -ENOSYS If this function is not implemented by the driver.
  */
@@ -1734,7 +1734,7 @@ static inline uint32_t z_impl_can_stats_get_rx_overruns(const struct device *dev
  *
  * @param dlc Data Length Code (DLC).
  *
- * @retval Number of bytes.
+ * @return Number of bytes.
  */
 static inline uint8_t can_dlc_to_bytes(uint8_t dlc)
 {
@@ -1749,7 +1749,7 @@ static inline uint8_t can_dlc_to_bytes(uint8_t dlc)
  *
  * @param num_bytes Number of bytes.
  *
- * @retval Data Length Code (DLC).
+ * @return Data Length Code (DLC).
  */
 static inline uint8_t can_bytes_to_dlc(uint8_t num_bytes)
 {

--- a/include/zephyr/drivers/can/can_sja1000.h
+++ b/include/zephyr/drivers/can/can_sja1000.h
@@ -94,7 +94,7 @@ typedef void (*can_sja1000_write_reg_t)(const struct device *dev, uint8_t reg, u
  *
  * @param dev Pointer to the device structure for the driver instance.
  * @param reg Register offset
- * @retval Register value
+ * @return Register value
  */
 typedef uint8_t (*can_sja1000_read_reg_t)(const struct device *dev, uint8_t reg);
 

--- a/include/zephyr/drivers/cellular.h
+++ b/include/zephyr/drivers/cellular.h
@@ -137,7 +137,7 @@ __subsystem struct cellular_driver_api {
  * @retval 0 if successful.
  * @retval -EINVAL if any provided cellular network configuration is invalid or unsupported.
  * @retval -ENOTSUP if API is not supported by cellular network device.
- * @retval Negative errno-code otherwise.
+ * @retval -errno Negative errno-code otherwise.
  */
 static inline int cellular_configure_networks(const struct device *dev,
 					      const struct cellular_network *networks, uint8_t size)
@@ -160,7 +160,7 @@ static inline int cellular_configure_networks(const struct device *dev,
  *
  * @retval 0 if successful.
  * @retval -ENOTSUP if API is not supported by cellular network device.
- * @retval Negative errno-code otherwise.
+ * @retval -errno Negative errno-code otherwise.
  */
 static inline int cellular_get_supported_networks(const struct device *dev,
 						  const struct cellular_network **networks,
@@ -185,7 +185,7 @@ static inline int cellular_get_supported_networks(const struct device *dev,
  * @retval 0 if successful.
  * @retval -ENOTSUP if API is not supported by cellular network device.
  * @retval -ENODATA if device is not in a state where signal can be polled
- * @retval Negative errno-code otherwise.
+ * @retval -errno Negative errno-code otherwise.
  */
 static inline int cellular_get_signal(const struct device *dev,
 				      const enum cellular_signal_type type, int16_t *value)
@@ -210,7 +210,7 @@ static inline int cellular_get_signal(const struct device *dev,
  * @retval 0 if successful.
  * @retval -ENOTSUP if API is not supported by cellular network device.
  * @retval -ENODATA if modem does not provide info requested
- * @retval Negative errno-code from chat module otherwise.
+ * @retval -errno Negative errno-code from chat module otherwise.
  */
 static inline int cellular_get_modem_info(const struct device *dev,
 					  const enum cellular_modem_info_type type, char *info,
@@ -235,7 +235,7 @@ static inline int cellular_get_modem_info(const struct device *dev,
  * @retval 0 if successful.
  * @retval -ENOSYS if API is not supported by cellular network device.
  * @retval -ENODATA if modem does not provide info requested
- * @retval Negative errno-code from chat module otherwise.
+ * @retval -errno Negative errno-code from chat module otherwise.
  */
 static inline int cellular_get_registration_status(const struct device *dev,
 						   enum cellular_access_technology tech,

--- a/include/zephyr/drivers/clock_control.h
+++ b/include/zephyr/drivers/clock_control.h
@@ -165,7 +165,7 @@ static inline int clock_control_off(const struct device *dev,
  * @retval -EALREADY if clock was already started and is starting or running.
  * @retval -ENOTSUP If the requested mode of operation is not supported.
  * @retval -ENOSYS if the interface is not implemented.
- * @retval other negative errno on vendor specific error.
+ * @retval -errno other negative errno on vendor specific error.
  */
 static inline int clock_control_async_on(const struct device *dev,
 					 clock_control_subsys_t sys,
@@ -243,7 +243,7 @@ static inline int clock_control_get_rate(const struct device *dev,
  * @retval -EALREADY if clock was already in the given rate.
  * @retval -ENOTSUP If the requested mode of operation is not supported.
  * @retval -ENOSYS if the interface is not implemented.
- * @retval other negative errno on vendor specific error.
+ * @retval -errno other negative errno on vendor specific error.
  */
 static inline int clock_control_set_rate(const struct device *dev,
 		clock_control_subsys_t sys,

--- a/include/zephyr/drivers/coredump.h
+++ b/include/zephyr/drivers/coredump.h
@@ -108,8 +108,8 @@ __subsystem struct coredump_driver_api {
  * @param dev    Pointer to the device structure for the driver instance.
  * @param region Struct describing memory to be collected
  *
- * @return true if registration succeeded
- * @return false if registration failed
+ * @retval true registration succeeded
+ * @retval false registration failed
  */
 static inline bool coredump_device_register_memory(const struct device *dev,
 	struct coredump_mem_region_node *region)
@@ -127,8 +127,8 @@ static inline bool coredump_device_register_memory(const struct device *dev,
  * @param dev    Pointer to the device structure for the driver instance.
  * @param region Struct describing memory to be collected
  *
- * @return true if unregistration succeeded
- * @return false if unregistration failed
+ * @retval true unregistration succeeded
+ * @retval false unregistration failed
  */
 static inline bool coredump_device_unregister_memory(const struct device *dev,
 	struct coredump_mem_region_node *region)
@@ -145,8 +145,8 @@ static inline bool coredump_device_unregister_memory(const struct device *dev,
  * @param dev      Pointer to the device structure for the driver instance.
  * @param callback Callback to be invoked at dump time
  *
- * @return true if registration succeeded
- * @return false if registration failed
+ * @retval true registration succeeded
+ * @retval false registration failed
  */
 static inline bool coredump_device_register_callback(const struct device *dev,
 	coredump_dump_callback_t callback)

--- a/include/zephyr/drivers/counter.h
+++ b/include/zephyr/drivers/counter.h
@@ -358,7 +358,7 @@ static inline uint32_t z_impl_counter_get_max_top_value(const struct device *dev
  * @param dev Pointer to the device structure for the driver instance.
  *
  * @retval 0 If successful.
- * @retval Negative errno code if failure.
+ * @retval -errno Negative errno code if failure.
  */
 __syscall int counter_start(const struct device *dev);
 
@@ -395,7 +395,7 @@ static inline int z_impl_counter_stop(const struct device *dev)
  * @param ticks Pointer to where to store the current counter value
  *
  * @retval 0 If successful.
- * @retval Negative error code on failure getting the counter value
+ * @retval -errno Negative error code on failure getting the counter value
  */
 __syscall int counter_get_value(const struct device *dev, uint32_t *ticks);
 
@@ -414,7 +414,7 @@ static inline int z_impl_counter_get_value(const struct device *dev,
  * @param ticks Pointer to where to store the current counter value
  *
  * @retval 0 If successful.
- * @retval Negative error code on failure getting the counter value
+ * @retval -errno Negative error code on failure getting the counter value
  */
 __syscall int counter_get_value_64(const struct device *dev, uint64_t *ticks);
 

--- a/include/zephyr/drivers/dai.h
+++ b/include/zephyr/drivers/dai.h
@@ -426,8 +426,8 @@ static inline int dai_config_get(const struct device *dev,
  * @param dir Stream direction: RX or TX as defined by DAI_DIR_*
  * @param stream_id Stream id: some drivers may have stream specific
  *        properties, this id specifies the stream.
- * @retval Pointer to the structure containing properties,
- *         or NULL if error or no properties
+ * @return Pointer to the structure containing properties
+ * @retval NULL if error or no properties
  */
 static inline const struct dai_properties *dai_get_properties(const struct device *dev,
 							      enum dai_dir dir,
@@ -559,7 +559,7 @@ static inline int dai_ts_get(const struct device *dev, struct dai_ts_cfg *cfg,
  *
  * @retval 0 If successful.
  * @retval -ENOSYS If the configuration update operation is not implemented.
- * @retval Negative errno code if failure.
+ * @retval -errno Negative errno code if failure.
  */
 static inline int dai_config_update(const struct device *dev,
 									const void *bespoke_cfg,

--- a/include/zephyr/drivers/display.h
+++ b/include/zephyr/drivers/display.h
@@ -284,8 +284,8 @@ static inline int display_read(const struct device *dev, const uint16_t x,
  *
  * @param dev Pointer to device structure
  *
- * @retval Pointer to frame buffer or NULL if direct framebuffer access
- * is not supported
+ * @return Pointer to frame buffer
+ * @retval NULL if direct framebuffer access is not supported
  *
  */
 static inline void *display_get_framebuffer(const struct device *dev)

--- a/include/zephyr/drivers/dma.h
+++ b/include/zephyr/drivers/dma.h
@@ -376,7 +376,7 @@ __subsystem struct dma_driver_api {
  *                selected channel
  *
  * @retval 0 if successful.
- * @retval Negative errno code if failure.
+ * @retval -errno Negative errno code if failure.
  */
 static inline int dma_config(const struct device *dev, uint32_t channel,
 			     struct dma_config *config)
@@ -398,7 +398,7 @@ static inline int dma_config(const struct device *dev, uint32_t channel,
  * @param size    size of DMA transfer
  *
  * @retval 0 if successful.
- * @retval Negative errno code if failure.
+ * @retval -errno Negative errno code if failure.
  */
 #ifdef CONFIG_DMA_64BIT
 static inline int dma_reload(const struct device *dev, uint32_t channel,
@@ -435,7 +435,7 @@ static inline int dma_reload(const struct device *dev, uint32_t channel,
  *                be processed
  *
  * @retval 0 if successful.
- * @retval Negative errno code if failure.
+ * @retval -errno Negative errno code if failure.
  */
 __syscall int dma_start(const struct device *dev, uint32_t channel);
 
@@ -463,7 +463,7 @@ static inline int z_impl_dma_start(const struct device *dev, uint32_t channel)
  *                being processed
  *
  * @retval 0 if successful.
- * @retval Negative errno code if failure.
+ * @retval -errno Negative errno code if failure.
  */
 __syscall int dma_stop(const struct device *dev, uint32_t channel);
 
@@ -544,7 +544,7 @@ static inline int z_impl_dma_resume(const struct device *dev, uint32_t channel)
  * @param filter_param filter function parameter
  *
  * @retval dma channel if successful.
- * @retval Negative errno code if failure.
+ * @retval -errno Negative errno code if failure.
  */
 __syscall int dma_request_channel(const struct device *dev,
 				  void *filter_param);
@@ -616,7 +616,7 @@ static inline void z_impl_dma_release_channel(const struct device *dev,
  * @param channel  channel number
  * @param filter_param filter attribute
  *
- * @retval Negative errno code if not support
+ * @retval -errno Negative errno code if not support
  *
  */
 __syscall int dma_chan_filter(const struct device *dev,
@@ -649,7 +649,7 @@ static inline int z_impl_dma_chan_filter(const struct device *dev,
  * @param stat   a non-NULL dma_status object for storing DMA status
  *
  * @retval non-negative if successful.
- * @retval Negative errno code if failure.
+ * @retval -errno Negative errno code if failure.
  */
 static inline int dma_get_status(const struct device *dev, uint32_t channel,
 				 struct dma_status *stat)
@@ -679,7 +679,7 @@ static inline int dma_get_status(const struct device *dev, uint32_t channel,
  * @param value   A non-NULL pointer to the variable where the read value is to be placed
  *
  * @retval non-negative if successful.
- * @retval Negative errno code if failure.
+ * @retval -errno Negative errno code if failure.
  */
 static inline int dma_get_attribute(const struct device *dev, uint32_t type, uint32_t *value)
 {
@@ -703,7 +703,7 @@ static inline int dma_get_attribute(const struct device *dev, uint32_t type, uin
  *
  * @param size: width of bus (in bytes)
  *
- * @retval common DMA index to be placed into registers.
+ * @return common DMA index to be placed into registers.
  */
 static inline uint32_t dma_width_index(uint32_t size)
 {
@@ -732,7 +732,7 @@ static inline uint32_t dma_width_index(uint32_t size)
  *
  * @param burst: number of bytes to be sent in a single burst
  *
- * @retval common DMA index to be placed into registers.
+ * @return common DMA index to be placed into registers.
  */
 static inline uint32_t dma_burst_index(uint32_t burst)
 {

--- a/include/zephyr/drivers/emul.h
+++ b/include/zephyr/drivers/emul.h
@@ -201,8 +201,8 @@ struct emul {
  * @brief Set up a list of emulators
  *
  * @param dev Device the emulators are attached to (e.g. an I2C controller)
- * @return 0 if OK
- * @return negative value on error
+ * @retval 0 sucess
+ * @retval -errno negative value on error
  */
 int emul_init_for_bus(const struct device *dev);
 

--- a/include/zephyr/drivers/emul_bbram.h
+++ b/include/zephyr/drivers/emul_bbram.h
@@ -42,9 +42,9 @@ __subsystem struct emul_bbram_driver_api {
  * @param offset Offset within the memory to set
  * @param count Number of bytes to write
  * @param data The data to write
- * @return 0 if successful
- * @return -ENOTSUP if no backend API or if the set_data function isn't implemented
- * @return -ERANGE if the destination address is out of range.
+ * @retval 0 success
+ * @retval -ENOTSUP no backend API or if the set_data function isn't implemented
+ * @retval -ERANGE the destination address is out of range.
  */
 static inline int emul_bbram_backend_set_data(const struct emul *target, size_t offset,
 					      size_t count, const uint8_t *data)
@@ -69,9 +69,9 @@ static inline int emul_bbram_backend_set_data(const struct emul *target, size_t 
  * @param offset Offset within the memory to get
  * @param count Number of bytes to read
  * @param data The data buffer to hold the result
- * @return 0 if successful
- * @return -ENOTSUP if no backend API or if the get_data function isn't implemented
- * @return -ERANGE if the address is out of range.
+ * @retval 0 success
+ * @retval -ENOTSUP no backend API or if the get_data function isn't implemented
+ * @retval -ERANGE the address is out of range.
  */
 static inline int emul_bbram_backend_get_data(const struct emul *target, size_t offset,
 					      size_t count, uint8_t *data)

--- a/include/zephyr/drivers/emul_sensor.h
+++ b/include/zephyr/drivers/emul_sensor.h
@@ -64,9 +64,9 @@ static inline bool emul_sensor_backend_is_supported(const struct emul *target)
  * @param value Expected value in fixed-point format using standard SI unit for sensor type
  * @param shift Shift value (scaling factor) applied to \p value
  *
- * @return 0 if successful
- * @return -ENOTSUP if no backend API or if channel not supported by emul
- * @return -ERANGE if provided value is not in the sensor's supported range
+ * @retval 0 success
+ * @retval -ENOTSUP no backend API or if channel not supported by emul
+ * @retval -ERANGE provided value is not in the sensor's supported range
  */
 static inline int emul_sensor_backend_set_channel(const struct emul *target,
 						  struct sensor_chan_spec ch, const q31_t *value,
@@ -97,8 +97,8 @@ static inline int emul_sensor_backend_set_channel(const struct emul *target,
  * @param[out] shift The shift value (scaling factor) associated with \p lower, \p upper, and
  *             \p epsilon.
  *
- * @return 0 if successful
- * @return -ENOTSUP if no backend API or if channel not supported by emul
+ * @retval 0 success
+ * @retval -ENOTSUP no backend API or if channel not supported by emul
  *
  */
 static inline int emul_sensor_backend_get_sample_range(const struct emul *target,
@@ -124,8 +124,8 @@ static inline int emul_sensor_backend_get_sample_range(const struct emul *target
  * @param[in] ch The channel to request info for. If \p ch is unsupported, return `-ENOTSUP`
  * @param[in] attribute The attribute to set
  * @param[in] value the value to use (cast according to the channel/attribute pair)
- * @return 0 is successful
- * @return < 0 on error
+ * @retval 0 success
+ * @retval -errno negative error code on failure
  */
 static inline int emul_sensor_backend_set_attribute(const struct emul *target,
 						    struct sensor_chan_spec ch,
@@ -158,8 +158,8 @@ static inline int emul_sensor_backend_set_attribute(const struct emul *target,
  * @param[out] max The maximum value the attribute can be set to
  * @param[out] increment The value that the attribute increases by for every LSB
  * @param[out] shift The shift for \p min, \p max, and \p increment
- * @return 0 on SUCCESS
- * @return < 0 on error
+ * @retval 0 success
+ * @retval -errno negative error code on failure
  */
 static inline int emul_sensor_backend_get_attribute_metadata(const struct emul *target,
 							     struct sensor_chan_spec ch,

--- a/include/zephyr/drivers/entropy.h
+++ b/include/zephyr/drivers/entropy.h
@@ -101,7 +101,7 @@ static inline int z_impl_entropy_get_entropy(const struct device *dev,
  * @param buffer Buffer to fill with entropy.
  * @param length Buffer length.
  * @param flags Flags to modify the behavior of the call.
- * @retval number of bytes filled with entropy or -error.
+ * @return number of bytes filled with entropy or -error.
  */
 static inline int entropy_get_entropy_isr(const struct device *dev,
 					  uint8_t *buffer,

--- a/include/zephyr/drivers/espi_emul.h
+++ b/include/zephyr/drivers/espi_emul.h
@@ -68,7 +68,7 @@ typedef int (*emul_espi_api_get_vw)(const struct emul *target, enum espi_vwire_s
  *
  * @param target The device Emulator instance
  *
- * @retval The address of the memory.
+ * @return The address of the memory.
  */
 typedef uintptr_t (*emul_espi_api_get_acpi_shm)(const struct emul *target);
 #endif
@@ -81,8 +81,8 @@ typedef uintptr_t (*emul_espi_api_get_acpi_shm)(const struct emul *target);
  *
  * @param dev eSPI emulation controller device
  * @param chipsel Chip-select value
- * @return espi_emul to use
- * @return NULL if not found
+ * @retval espi_emul Emulator to use
+ * @retval NULL emulator not found
  */
 typedef struct espi_emul *(*emul_find_emul)(const struct device *dev, unsigned int chipsel);
 

--- a/include/zephyr/drivers/ethernet/eth_adin2111.h
+++ b/include/zephyr/drivers/ethernet/eth_adin2111.h
@@ -136,7 +136,7 @@ int eth_adin2111_broadcast_filter(const struct device *dev, bool enable);
  * @param[in] dev ADIN2111 device.
  * @param port_idx Port index.
  *
- * @retval a struct net_if pointer, or NULL on error.
+ * @return a struct net_if pointer, or NULL on error.
  */
 struct net_if *eth_adin2111_get_iface(const struct device *dev, const uint16_t port_idx);
 

--- a/include/zephyr/drivers/flash.h
+++ b/include/zephyr/drivers/flash.h
@@ -466,7 +466,7 @@ void flash_page_foreach(const struct device *dev, flash_page_cb cb,
  *
  * @retval 0 on success
  * @retval -ENOTSUP if the flash driver does not support SFDP access
- * @retval negative values for other errors.
+ * @retval -errno negative values for other errors.
  */
 __syscall int flash_sfdp_read(const struct device *dev, off_t offset,
 			      void *data, size_t len);
@@ -494,7 +494,7 @@ static inline int z_impl_flash_sfdp_read(const struct device *dev,
  *
  * @retval 0 on successful store of 3-byte JEDEC id
  * @retval -ENOTSUP if flash driver doesn't support this function
- * @retval negative values for other errors
+ * @retval -errno negative values for other errors
  */
 __syscall int flash_read_jedec_id(const struct device *dev, uint8_t *id);
 
@@ -578,7 +578,7 @@ static inline const struct flash_parameters *z_impl_flash_get_parameters(const s
  *  @retval 0 on success.
  *  @retval -ENOTSUP if given device doesn't support extended operation.
  *  @retval -ENOSYS if support for extended operations is not enabled in Kconfig
- *  @retval negative value on extended operation errors.
+ *  @retval -errno negative value on extended operation errors.
  */
 __syscall int flash_ex_op(const struct device *dev, uint16_t code,
 			  const uintptr_t in, void *out);

--- a/include/zephyr/drivers/flash/flash_simulator.h
+++ b/include/zephyr/drivers/flash/flash_simulator.h
@@ -26,7 +26,7 @@ extern "C" {
  * @param[in]  dev flash simulator device pointer.
  * @param[out] mock_size size of the ram buffer.
  *
- * @retval pointer to the ram buffer
+ * @return pointer to the ram buffer
  */
 __syscall void *flash_simulator_get_memory(const struct device *dev,
 					   size_t *mock_size);

--- a/include/zephyr/drivers/fpga.h
+++ b/include/zephyr/drivers/fpga.h
@@ -117,7 +117,7 @@ static inline int fpga_load(const struct device *dev, uint32_t *image_ptr,
  * @param dev FPGA device structure.
  *
  * @retval 0 if successful.
- * @retval negative errno code on failure.
+ * @retval -errno negative errno code on failure.
  */
 static inline int fpga_on(const struct device *dev)
 {
@@ -158,7 +158,7 @@ static inline const char *fpga_get_info(const struct device *dev)
  * @param dev FPGA device structure.
  *
  * @retval 0 if successful.
- * @retval negative errno code on failure.
+ * @retval -errno negative errno code on failure.
  */
 static inline int fpga_off(const struct device *dev)
 {

--- a/include/zephyr/drivers/gnss.h
+++ b/include/zephyr/drivers/gnss.h
@@ -248,8 +248,8 @@ struct gnss_satellites_callback {
  * @param dev Device instance
  * @param fix_interval_ms Fix interval to set in milliseconds
  *
- * @return 0 if successful
- * @return -errno negative errno code on failure
+ * @retval 0 success
+ * @retval -errno negative errno code on failure
  */
 __syscall int gnss_set_fix_rate(const struct device *dev, uint32_t fix_interval_ms);
 
@@ -270,8 +270,8 @@ static inline int z_impl_gnss_set_fix_rate(const struct device *dev, uint32_t fi
  * @param dev Device instance
  * @param fix_interval_ms Destination for fix interval in milliseconds
  *
- * @return 0 if successful
- * @return -errno negative errno code on failure
+ * @retval 0 success
+ * @retval -errno negative errno code on failure
  */
 __syscall int gnss_get_fix_rate(const struct device *dev, uint32_t *fix_interval_ms);
 
@@ -292,8 +292,8 @@ static inline int z_impl_gnss_get_fix_rate(const struct device *dev, uint32_t *f
  * @param dev Device instance
  * @param config Periodic tracking configuration to set
  *
- * @return 0 if successful
- * @return -errno negative errno code on failure
+ * @retval 0 success
+ * @retval -errno negative errno code on failure
  */
 __syscall int gnss_set_periodic_config(const struct device *dev,
 				       const struct gnss_periodic_config *config);
@@ -316,8 +316,8 @@ static inline int z_impl_gnss_set_periodic_config(const struct device *dev,
  * @param dev Device instance
  * @param config Destination for periodic tracking configuration
  *
- * @return 0 if successful
- * @return -errno negative errno code on failure
+ * @retval 0 success
+ * @retval -errno negative errno code on failure
  */
 __syscall int gnss_get_periodic_config(const struct device *dev,
 				       struct gnss_periodic_config *config);
@@ -340,8 +340,8 @@ static inline int z_impl_gnss_get_periodic_config(const struct device *dev,
  * @param dev Device instance
  * @param mode Navigation mode to set
  *
- * @return 0 if successful
- * @return -errno negative errno code on failure
+ * @retval 0 success
+ * @retval -errno negative errno code on failure
  */
 __syscall int gnss_set_navigation_mode(const struct device *dev,
 				       enum gnss_navigation_mode mode);
@@ -364,8 +364,8 @@ static inline int z_impl_gnss_set_navigation_mode(const struct device *dev,
  * @param dev Device instance
  * @param mode Destination for navigation mode
  *
- * @return 0 if successful
- * @return -errno negative errno code on failure
+ * @retval 0 success
+ * @retval -errno negative errno code on failure
  */
 __syscall int gnss_get_navigation_mode(const struct device *dev,
 				       enum gnss_navigation_mode *mode);
@@ -388,8 +388,8 @@ static inline int z_impl_gnss_get_navigation_mode(const struct device *dev,
  * @param dev Device instance
  * @param systems Systems to enable
  *
- * @return 0 if successful
- * @return -errno negative errno code on failure
+ * @retval 0 success
+ * @retval -errno negative errno code on failure
  */
 __syscall int gnss_set_enabled_systems(const struct device *dev, gnss_systems_t systems);
 
@@ -411,8 +411,8 @@ static inline int z_impl_gnss_set_enabled_systems(const struct device *dev,
  * @param dev Device instance
  * @param systems Destination for enabled systems
  *
- * @return 0 if successful
- * @return -errno negative errno code on failure
+ * @retval 0 success
+ * @retval -errno negative errno code on failure
  */
 __syscall int gnss_get_enabled_systems(const struct device *dev, gnss_systems_t *systems);
 
@@ -434,8 +434,8 @@ static inline int z_impl_gnss_get_enabled_systems(const struct device *dev,
  * @param dev Device instance
  * @param systems Destination for supported systems
  *
- * @return 0 if successful
- * @return -errno negative errno code on failure
+ * @retval 0 success
+ * @retval -errno negative errno code on failure
  */
 __syscall int gnss_get_supported_systems(const struct device *dev, gnss_systems_t *systems);
 

--- a/include/zephyr/drivers/gpio/gpio_emul.h
+++ b/include/zephyr/drivers/gpio/gpio_emul.h
@@ -50,8 +50,8 @@ extern "C" {
  * @param pins The mask of pins that have changed
  * @param values New values to assign to @p pins
  *
- * @return 0 on success
- * @return -EINVAL if an invalid argument is provided
+ * @retval 0 success
+ * @retval -EINVAL an invalid argument was provided
  */
 int gpio_emul_input_set_masked(const struct device *port, gpio_port_pins_t pins,
 			      gpio_port_value_t values);
@@ -63,8 +63,8 @@ int gpio_emul_input_set_masked(const struct device *port, gpio_port_pins_t pins,
  * @param pin The pin to modify
  * @param value New values to assign to @p pin
  *
- * @return 0 on success
- * @return -EINVAL if an invalid argument is provided
+ * @retval 0 success
+ * @retval -EINVAL an invalid argument was provided
  */
 static inline int gpio_emul_input_set(const struct device *port, gpio_pin_t pin,
 				     int value)
@@ -79,8 +79,8 @@ static inline int gpio_emul_input_set(const struct device *port, gpio_pin_t pin,
  * @param pins The mask of pins that have changed
  * @param values A pointer to where the value of @p pins will be stored
  *
- * @return 0 on success
- * @return -EINVAL if an invalid argument is provided
+ * @retval 0 success
+ * @retval -EINVAL an invalid argument was provided
  */
 int gpio_emul_output_get_masked(const struct device *port, gpio_port_pins_t pins,
 			       gpio_port_value_t *values);
@@ -91,8 +91,8 @@ int gpio_emul_output_get_masked(const struct device *port, gpio_port_pins_t pins
  * @param port The emulated GPIO port
  * @param pin The pin to read
  *
- * @return 0 or 1 on success
- * @return -EINVAL if an invalid argument is provided
+ * @retval 0 success
+ * @retval -EINVAL an invalid argument was provided
  */
 static inline int gpio_emul_output_get(const struct device *port, gpio_pin_t pin)
 {
@@ -116,8 +116,8 @@ static inline int gpio_emul_output_get(const struct device *port, gpio_pin_t pin
  * @param pin The pin to retrieve @p flags for
  * @param flags a pointer to where the flags for @p pin will be stored
  *
- * @return 0 on success
- * @return -EINVAL if an invalid argument is provided
+ * @retval 0 success
+ * @retval -EINVAL an invalid argument was provided
  */
 int gpio_emul_flags_get(const struct device *port, gpio_pin_t pin, gpio_flags_t *flags);
 

--- a/include/zephyr/drivers/hwinfo.h
+++ b/include/zephyr/drivers/hwinfo.h
@@ -87,9 +87,9 @@ extern "C" {
  * @param buffer  Buffer to write the ID to.
  * @param length  Max length of the buffer.
  *
- * @retval size of the device ID copied.
+ * @return size of the device ID copied.
  * @retval -ENOSYS if there is no implementation for the particular device.
- * @retval any negative value on driver specific errors.
+ * @retval -errno any negative value on driver specific errors.
  */
 __syscall ssize_t hwinfo_get_device_id(uint8_t *buffer, size_t length);
 
@@ -103,9 +103,9 @@ ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length);
  *
  * @param buffer  Buffer of 8 bytes to write the ID to.
  *
- * @retval zero if successful.
+ * @retval 0 if successful.
  * @retval -ENOSYS if there is no implementation for the particular device.
- * @retval any negative value on driver specific errors.
+ * @retval -errno any negative value on driver specific errors.
  */
 __syscall int hwinfo_get_device_eui64(uint8_t *buffer);
 
@@ -127,9 +127,9 @@ int z_impl_hwinfo_get_device_eui64(uint8_t *buffer);
  * Successive calls to this routine will return the same value, unless
  * `hwinfo_clear_reset_cause` has been called.
  *
- * @retval zero if successful.
+ * @retval 0 if successful.
  * @retval -ENOSYS if there is no implementation for the particular device.
- * @retval any negative value on driver specific errors.
+ * @retval -errno any negative value on driver specific errors.
  */
 __syscall int hwinfo_get_reset_cause(uint32_t *cause);
 
@@ -140,9 +140,9 @@ int z_impl_hwinfo_get_reset_cause(uint32_t *cause);
  *
  * Clears reset cause flags.
  *
- * @retval zero if successful.
+ * @retval 0 if successful.
  * @retval -ENOSYS if there is no implementation for the particular device.
- * @retval any negative value on driver specific errors.
+ * @retval -errno any negative value on driver specific errors.
  */
 __syscall int hwinfo_clear_reset_cause(void);
 
@@ -155,9 +155,9 @@ int z_impl_hwinfo_clear_reset_cause(void);
  *
  * Retrieves all `reset_cause` flags that are supported by this device.
  *
- * @retval zero if successful.
+ * @retval 0 if successful.
  * @retval -ENOSYS if there is no implementation for the particular device.
- * @retval any negative value on driver specific errors.
+ * @retval -errno any negative value on driver specific errors.
  */
 __syscall int hwinfo_get_supported_reset_cause(uint32_t *supported);
 

--- a/include/zephyr/drivers/hwspinlock.h
+++ b/include/zephyr/drivers/hwspinlock.h
@@ -132,7 +132,7 @@ static inline void z_impl_hwspinlock_unlock(const struct device *dev, uint32_t i
  *
  * @param dev HW spinlock device instance.
  *
- * @retval HW spinlock max ID.
+ * @return HW spinlock max ID.
  * @retval 0 if the function is not implemented by the driver.
  */
 __syscall uint32_t hwspinlock_get_max_id(const struct device *dev);

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -474,8 +474,8 @@ static inline bool i2c_is_ready_dt(const struct i2c_dt_spec *spec)
  * @brief Check if the current message is a read operation
  *
  * @param msg The message to check
- * @return true if the I2C message is sa read operation
- * @return false if the I2C message is a write operation
+ * @retval true the I2C message is sa read operation
+ * @retval false the I2C message is a write operation
  */
 static inline bool i2c_is_read_op(struct i2c_msg *msg)
 {
@@ -895,7 +895,7 @@ static inline int i2c_transfer_cb_dt(const struct i2c_dt_spec *spec,
  * @param userdata Userdata passed to callback.
  *
  * @retval 0 if successful
- * @retval negative on error.
+ * @retval -errno negative error code on error.
  */
 static inline int i2c_write_read_cb(const struct device *dev, struct i2c_msg *msgs,
 				 uint8_t num_msgs, uint16_t addr, const void *write_buf,
@@ -1329,7 +1329,7 @@ static inline int i2c_read_dt(const struct i2c_dt_spec *spec,
  * @param num_read Number of bytes to read
  *
  * @retval 0 if successful
- * @retval negative on error.
+ * @retval -errno negative error code on error.
  */
 static inline int i2c_write_read(const struct device *dev, uint16_t addr,
 				 const void *write_buf, size_t num_write,

--- a/include/zephyr/drivers/i2s.h
+++ b/include/zephyr/drivers/i2s.h
@@ -372,8 +372,8 @@ static inline int z_impl_i2s_configure(const struct device *dev,
  *
  * @param dev Pointer to the device structure for the driver instance
  * @param dir Stream direction: RX or TX as defined by I2S_DIR_*
- * @retval Pointer to the structure containing configuration parameters,
- *         or NULL if un-configured
+ * @return Pointer to the structure containing configuration parameters
+ * @retval NULL if host is un-configured
  */
 static inline const struct i2s_config *i2s_config_get(const struct device *dev,
 						      enum i2s_dir dir)

--- a/include/zephyr/drivers/i3c/ibi.h
+++ b/include/zephyr/drivers/i3c/ibi.h
@@ -101,13 +101,13 @@ struct i3c_ibi_work {
 
 	union {
 		/**
-		 * Use for @see I3C_IBI_HOTJOIN.
+		 * Use for I3C_IBI_HOTJOIN.
 		 */
 		const struct device *controller;
 
 		/**
-		 * Use for @see I3C_IBI_TARGET_INTR,
-		 * and @see I3C_IBI_CONTROLLER_ROLE_REQUEST.
+		 * Use for I3C_IBI_TARGET_INTR,
+		 * and I3C_IBI_CONTROLLER_ROLE_REQUEST.
 		 */
 		struct i3c_device_desc *target;
 	};
@@ -146,7 +146,6 @@ struct i3c_ibi_work {
 typedef int (*i3c_target_ibi_cb_t)(struct i3c_device_desc *target,
 				   struct i3c_ibi_payload *payload);
 
-
 /**
  * @brief Queue an IBI work item for future processing.
  *
@@ -162,7 +161,7 @@ typedef int (*i3c_target_ibi_cb_t)(struct i3c_device_desc *target,
  * @retval 0 If work item is successfully queued.
  * @retval -ENOMEM If no more free internal node to
  *                 store IBI work item.
- * @retval Others @see k_work_submit_to_queue
+ * @retval -errno See k_work_submit_to_queue() for other possible error codes.
  */
 int i3c_ibi_work_enqueue(struct i3c_ibi_work *ibi_work);
 
@@ -179,7 +178,7 @@ int i3c_ibi_work_enqueue(struct i3c_ibi_work *ibi_work);
  * @retval 0 If work item is successfully queued.
  * @retval -ENOMEM If no more free internal node to
  *                 store IBI work item.
- * @retval Others @see k_work_submit_to_queue
+ * @retval -errno See k_work_submit_to_queue() for other possible error codes.
  */
 int i3c_ibi_work_enqueue_target_irq(struct i3c_device_desc *target,
 				    uint8_t *payload, size_t payload_len);
@@ -195,7 +194,7 @@ int i3c_ibi_work_enqueue_target_irq(struct i3c_device_desc *target,
  * @retval 0 If work item is successfully queued.
  * @retval -ENOMEM If no more free internal node to
  *                 store IBI work item.
- * @retval Others @see k_work_submit_to_queue
+ * @retval -errno See k_work_submit_to_queue() for other possible error codes.
  */
 int i3c_ibi_work_enqueue_hotjoin(const struct device *dev);
 
@@ -211,7 +210,7 @@ int i3c_ibi_work_enqueue_hotjoin(const struct device *dev);
  * @retval 0 If work item is successfully queued.
  * @retval -ENOMEM If no more free internal node to
  *                 store IBI work item.
- * @retval Others @see k_work_submit_to_queue
+ * @retval -errno See k_work_submit_to_queue() for other possible error codes.
  */
 int i3c_ibi_work_enqueue_cb(const struct device *dev,
 			    k_work_handler_t work_cb);

--- a/include/zephyr/drivers/i3c/target_device.h
+++ b/include/zephyr/drivers/i3c/target_device.h
@@ -236,7 +236,7 @@ __subsystem struct i3c_target_driver_api {
  * @param len Length of the buffer
  * @param hdr_mode HDR mode see @c I3C_MSG_HDR_MODE*
  *
- * @retval Total number of bytes written
+ * @return Total number of bytes written
  * @retval -ENOTSUP Not in Target Mode or HDR Mode not supported
  * @retval -ENOSPC No space in Tx FIFO
  * @retval -ENOSYS If target mode is not implemented

--- a/include/zephyr/drivers/kscan.h
+++ b/include/zephyr/drivers/kscan.h
@@ -76,7 +76,7 @@ __subsystem struct kscan_driver_api {
  * event such as key pressed/released.
  *
  * @retval 0 If successful.
- * @retval Negative errno code if failure.
+ * @retval -errno Negative errno code if failure.
  */
 __syscall int kscan_config(const struct device *dev,
 			     kscan_callback_t callback);
@@ -94,7 +94,7 @@ static inline int z_impl_kscan_config(const struct device *dev,
  * @param dev Pointer to the device structure for the driver instance.
  *
  * @retval 0 If successful.
- * @retval Negative errno code if failure.
+ * @retval -errno Negative errno code if failure.
  */
 __syscall int kscan_enable_callback(const struct device *dev);
 
@@ -115,7 +115,7 @@ static inline int z_impl_kscan_enable_callback(const struct device *dev)
  * @param dev Pointer to the device structure for the driver instance.
  *
  * @retval 0 If successful.
- * @retval Negative errno code if failure.
+ * @retval -errno Negative errno code if failure.
  */
 __syscall int kscan_disable_callback(const struct device *dev);
 

--- a/include/zephyr/drivers/mbox.h
+++ b/include/zephyr/drivers/mbox.h
@@ -451,8 +451,8 @@ static inline int mbox_set_enabled_dt(const struct mbox_dt_spec *spec,
  *
  * @param dev MBOX device instance.
  *
- * @return >0     Maximum possible number of supported channels on success
- * @return -errno Negative errno on error.
+ * @retval >0 Maximum possible number of supported channels.
+ * @retval -errno Negative errno on error.
  */
 __syscall uint32_t mbox_max_channels_get(const struct device *dev);
 

--- a/include/zephyr/drivers/mfd/ad559x.h
+++ b/include/zephyr/drivers/mfd/ad559x.h
@@ -49,7 +49,7 @@ bool mfd_ad559x_has_pointer_byte_map(const struct device *dev);
  * @param[in] len Number of bytes to be read
  *
  * @retval 0 if success
- * @retval negative errno if failure
+ * @retval -errno negative errno if failure
  */
 int mfd_ad559x_read_raw(const struct device *dev, uint8_t *val, size_t len);
 
@@ -61,7 +61,7 @@ int mfd_ad559x_read_raw(const struct device *dev, uint8_t *val, size_t len);
  * @param[in] len Number of bytes to be written
  *
  * @retval 0 if success
- * @retval negative errno if failure
+ * @retval -errno negative errno if failure
  */
 int mfd_ad559x_write_raw(const struct device *dev, uint8_t *val, size_t len);
 
@@ -74,7 +74,7 @@ int mfd_ad559x_write_raw(const struct device *dev, uint8_t *val, size_t len);
  * @param[in] val Pointer to data buffer
  *
  * @retval 0 if success
- * @retval negative errno if failure
+ * @retval -errno negative errno if failure
  */
 int mfd_ad559x_read_reg(const struct device *dev, uint8_t reg, uint8_t reg_data, uint16_t *val);
 
@@ -86,7 +86,7 @@ int mfd_ad559x_read_reg(const struct device *dev, uint8_t reg, uint8_t reg_data,
  * @param[in] val Data to be written
  *
  * @retval 0 if success
- * @retval negative errno if failure
+ * @retval -errno negative errno if failure
  */
 int mfd_ad559x_write_reg(const struct device *dev, uint8_t reg, uint16_t val);
 
@@ -98,7 +98,7 @@ int mfd_ad559x_write_reg(const struct device *dev, uint8_t reg, uint16_t val);
  * @param[out] result ADC channel value read
  *
  * @retval 0 if success
- * @retval negative errno if failure
+ * @retval -errno negative errno if failure
  */
 int mfd_ad559x_read_adc_chan(const struct device *dev, uint8_t channel, uint16_t *result);
 
@@ -110,7 +110,7 @@ int mfd_ad559x_read_adc_chan(const struct device *dev, uint8_t channel, uint16_t
  * @param[in] value DAC channel value
  *
  * @retval 0 if success
- * @retval negative errno if failure
+ * @retval -errno negative errno if failure
  */
 int mfd_ad559x_write_dac_chan(const struct device *dev, uint8_t channel, uint16_t value);
 
@@ -122,7 +122,7 @@ int mfd_ad559x_write_dac_chan(const struct device *dev, uint8_t channel, uint16_
  * @param[in] value DAC channel value
  *
  * @retval 0 if success
- * @retval negative errno if failure
+ * @retval -errno negative errno if failure
  */
 int mfd_ad559x_gpio_port_get_raw(const struct device *dev, uint8_t gpio, uint16_t *value);
 /**

--- a/include/zephyr/drivers/misc/timeaware_gpio/timeaware_gpio.h
+++ b/include/zephyr/drivers/misc/timeaware_gpio/timeaware_gpio.h
@@ -70,8 +70,8 @@ __subsystem struct tgpio_driver_api {
  * @param dev TGPIO device
  * @param current_time Pointer to store timer value in cycles
  *
- * @return 0 if successful
- * @return negative errno code on failure.
+ * @retval 0 success
+ * @retval -errno negative errno code on failure.
  */
 __syscall int tgpio_port_get_time(const struct device *dev, uint64_t *current_time);
 
@@ -88,7 +88,8 @@ static inline int z_impl_tgpio_port_get_time(const struct device *dev, uint64_t 
  * @param dev TGPIO device
  * @param cycles pointer to store current running frequency
  *
- * @return 0 if successful, negative errno code on failure.
+ * @retval 0 success
+ * @retval -errno negative errno code on failure.
  */
 __syscall int tgpio_port_get_cycles_per_second(const struct device *dev, uint32_t *cycles);
 
@@ -106,7 +107,8 @@ static inline int z_impl_tgpio_port_get_cycles_per_second(const struct device *d
  * @param dev TGPIO device
  * @param pin TGPIO pin
  *
- * @return 0 if successful, negative errno code on failure.
+ * @retval 0 success
+ * @retval -errno negative errno code on failure.
  */
 __syscall int tgpio_pin_disable(const struct device *dev, uint32_t pin);
 
@@ -124,7 +126,8 @@ static inline int z_impl_tgpio_pin_disable(const struct device *dev, uint32_t pi
  * @param pin TGPIO pin
  * @param event_polarity TGPIO pin event polarity
  *
- * @return 0 if successful, negative errno code on failure.
+ * @retval 0 success
+ * @retval -errno negative errno code on failure.
  */
 __syscall int tgpio_pin_config_ext_timestamp(const struct device *dev, uint32_t pin,
 					      uint32_t event_polarity);
@@ -146,7 +149,8 @@ static inline int z_impl_tgpio_pin_config_ext_timestamp(const struct device *dev
  * @param repeat_interval repeat interval between two pulses in hw cycles
  * @param periodic_enable enables periodic mode if 'true' is passed.
  *
- * @return 0 if successful, negative errno code on failure.
+ * @retval 0 success
+ * @retval -errno negative errno code on failure.
  */
 __syscall int tgpio_pin_periodic_output(const struct device *dev, uint32_t pin,
 					 uint64_t start_time, uint64_t repeat_interval,
@@ -169,7 +173,8 @@ static inline int z_impl_tgpio_pin_periodic_output(const struct device *dev, uin
  * @param timestamp timestamp of the last pulse received
  * @param event_count number of pulses received since the pin is enabled
  *
- * @return 0 if successful, negative errno code on failure.
+ * @retval 0 success
+ * @retval -errno negative errno code on failure.
  */
 __syscall int tgpio_pin_read_ts_ec(const struct device *dev, uint32_t pin, uint64_t *timestamp,
 				    uint64_t *event_count);

--- a/include/zephyr/drivers/modem/hl7800.h
+++ b/include/zephyr/drivers/modem/hl7800.h
@@ -333,19 +333,21 @@ char *mdm_hl7800_get_imsi(void);
 /**
  * @brief Update the Access Point Name in the modem.
  *
- * @retval 0 on success, negative on failure.
+ * @retval 0 on success
+ * @retval -errno negative error code on failure
  */
 int32_t mdm_hl7800_update_apn(char *access_point_name);
 
 /**
  * @brief Update the Radio Access Technology (mode).
  *
- * @retval 0 on success, negative on failure.
+ * @retval 0 on success
+ * @retval -errno negative error code on failure
  */
 int32_t mdm_hl7800_update_rat(enum mdm_hl7800_radio_mode value);
 
 /**
- * @retval true if RAT value is valid
+ * @return true if RAT value is valid
  */
 bool mdm_hl7800_valid_rat(uint8_t value);
 
@@ -364,7 +366,8 @@ int mdm_hl7800_register_event_callback(struct mdm_hl7800_callback_agent *agent);
  *
  * @param agent event callback agent
  *
- * @retval 0 on success, negative on failure
+ * @retval 0 on success
+ * @retval -errno negative error code on failure
  */
 int mdm_hl7800_unregister_event_callback(struct mdm_hl7800_callback_agent *agent);
 
@@ -381,7 +384,7 @@ void mdm_hl7800_generate_status_events(void);
  *
  * @param tm time structure
  * @param offset The amount the local time is offset from GMT/UTC in seconds.
- * @return int32_t 0 if successful
+ * @retval 0 on success
  */
 int32_t mdm_hl7800_get_local_time(struct tm *tm, int32_t *offset);
 
@@ -400,14 +403,16 @@ int32_t mdm_hl7800_update_fw(char *file_path);
 /**
  * @brief Read the operator index from the modem.
  *
- * @retval negative error code, 0 on success
+ * @retval operator_index on success
+ * @retval -errno negative error code on failure
  */
 int32_t mdm_hl7800_get_operator_index(void);
 
 /**
  * @brief Get modem functionality
  *
- * @return int32_t negative errno on failure, else mdm_hl7800_functionality
+ * @retval mdm_hl7800_functionality on success
+ * @retval -errno negative error code on failure
  */
 int32_t mdm_hl7800_get_functionality(void);
 
@@ -419,7 +424,8 @@ int32_t mdm_hl7800_get_functionality(void);
  * MODEM_HL7800_BOOT_IN_AIRPLANE_MODE.
  *
  * @param mode
- * @return int32_t negative errno, 0 on success
+ * @retval 0 on success
+ * @retval -errno negative error code on failure
  */
 int32_t mdm_hl7800_set_functionality(enum mdm_hl7800_functionality mode);
 
@@ -431,7 +437,8 @@ int32_t mdm_hl7800_set_functionality(enum mdm_hl7800_functionality mode);
  * @note Airplane mode isn't cleared when the modem is reset.
  *
  * @param rate in seconds to query location
- * @return int32_t negative errno, 0 on success
+ * @retval 0 on success
+ * @retval -errno negative error code on failure
  */
 int32_t mdm_hl7800_set_gps_rate(uint32_t rate);
 
@@ -443,7 +450,8 @@ int32_t mdm_hl7800_set_gps_rate(uint32_t rate);
  * information into non-volatile memory, then this command
  * only needs to be run once.
  *
- * @return int32_t negative errno, 0 on success
+ * @retval 0 on success
+ * @retval -errno negative error code on failure
  */
 int32_t mdm_hl7800_polte_register(void);
 
@@ -452,7 +460,8 @@ int32_t mdm_hl7800_polte_register(void);
  *
  * @param user from polte.io or register command callback
  * @param password from polte.io register command callback
- * @return int32_t negative errno, 0 on success
+ * @retval 0 on success
+ * @retval -errno negative error code on failure
  */
 int32_t mdm_hl7800_polte_enable(char *user, char *password);
 
@@ -464,7 +473,8 @@ int32_t mdm_hl7800_polte_enable(char *user, char *password);
  * requires 20-120 seconds to be generated and it contains the
  * location information (or indicates server failure).
  *
- * @return int32_t negative errno, 0 on success
+ * @retval 0 on success
+ * @retval -errno negative error code on failure
  */
 int32_t mdm_hl7800_polte_locate(void);
 
@@ -474,7 +484,8 @@ int32_t mdm_hl7800_polte_locate(void);
  *
  * HL7800_EVENT_SITE_SURVEY is generated for each response received from modem.
  *
- * @retval negative error code, 0 on success
+ * @retval 0 on success
+ * @retval -errno negative error code on failure
  */
 int32_t mdm_hl7800_perform_site_survey(void);
 
@@ -482,7 +493,8 @@ int32_t mdm_hl7800_perform_site_survey(void);
  * @brief Set desired sleep level. Requires MODEM_HL7800_LOW_POWER_MODE
  *
  * @param level (sleep, lite hibernate, or hibernate)
- * @return int negative errno, 0 on success
+ * @retval 0 on success
+ * @retval -errno negative error code on failure
  */
 int mdm_hl7800_set_desired_sleep_level(enum mdm_hl7800_sleep level);
 
@@ -524,7 +536,8 @@ void mdm_hl7800_register_cts_callback(void (*func)(int state));
  * @param bands Band bitmap in hexadecimal format without the 0x prefix.
  * Leading 0's for the value can be omitted.
  *
- * @return int32_t negative errno, 0 on success
+ * @retval 0 on success
+ * @retval -errno negative error code on failure
  */
 int32_t mdm_hl7800_set_bands(const char *bands);
 
@@ -536,7 +549,7 @@ int32_t mdm_hl7800_set_bands(const char *bands);
  *
  * @param level 0 (None) - 4 (Debug)
  *
- * @retval new log level
+ * @return new log level
  */
 uint32_t mdm_hl7800_log_filter_set(uint32_t level);
 

--- a/include/zephyr/drivers/peci.h
+++ b/include/zephyr/drivers/peci.h
@@ -269,7 +269,7 @@ __subsystem struct peci_driver_api {
  * @param bitrate the selected bitrate expressed in Kbps.
  *
  * @retval 0 If successful.
- * @retval Negative errno code if failure.
+ * @retval -errno Negative errno code if failure.
  */
 __syscall int peci_config(const struct device *dev, uint32_t bitrate);
 
@@ -288,7 +288,7 @@ static inline int z_impl_peci_config(const struct device *dev,
  * @param dev Pointer to the device structure for the driver instance.
  *
  * @retval 0 If successful.
- * @retval Negative errno code if failure.
+ * @retval -errno Negative errno code if failure.
  */
 __syscall int peci_enable(const struct device *dev);
 
@@ -306,7 +306,7 @@ static inline int z_impl_peci_enable(const struct device *dev)
  * @param dev Pointer to the device structure for the driver instance.
  *
  * @retval 0 If successful.
- * @retval Negative errno code if failure.
+ * @retval -errno Negative errno code if failure.
  */
 __syscall int peci_disable(const struct device *dev);
 
@@ -325,7 +325,7 @@ static inline int z_impl_peci_disable(const struct device *dev)
  * @param msg Structure representing a PECI transaction.
  *
  * @retval 0 If successful.
- * @retval Negative errno code if failure.
+ * @retval -errno Negative errno code if failure.
  */
 
 __syscall int peci_transfer(const struct device *dev, struct peci_msg *msg);

--- a/include/zephyr/drivers/pm_cpu_ops.h
+++ b/include/zephyr/drivers/pm_cpu_ops.h
@@ -35,7 +35,7 @@ extern "C" {
  * This call is intended for use in hotplug. A core that is powered down by
  * cpu_off can only be powered up again in response to a cpu_on
  *
- * @retval The call does not return when successful
+ * @retval none The call does not return when successful
  * @retval -ENOTSUP If the operation is not supported
  */
 int pm_cpu_off(void);

--- a/include/zephyr/drivers/ps2.h
+++ b/include/zephyr/drivers/ps2.h
@@ -71,7 +71,7 @@ __subsystem struct ps2_driver_api {
  * command or when a mouse/keyboard send data to the client application.
  *
  * @retval 0 If successful.
- * @retval Negative errno code if failure.
+ * @retval -errno Negative errno code if failure.
  */
 __syscall int ps2_config(const struct device *dev,
 			 ps2_callback_t callback_isr);
@@ -92,7 +92,7 @@ static inline int z_impl_ps2_config(const struct device *dev,
  * @param value Data for the PS2 device.
  *
  * @retval 0 If successful.
- * @retval Negative errno code if failure.
+ * @retval -errno Negative errno code if failure.
  */
 __syscall int ps2_write(const struct device *dev, uint8_t value);
 
@@ -110,7 +110,7 @@ static inline int z_impl_ps2_write(const struct device *dev, uint8_t value)
  * @param value Pointer used for reading the PS/2 device.
  *
  * @retval 0 If successful.
- * @retval Negative errno code if failure.
+ * @retval -errno Negative errno code if failure.
  */
 __syscall int ps2_read(const struct device *dev,  uint8_t *value);
 
@@ -127,7 +127,7 @@ static inline int z_impl_ps2_read(const struct device *dev, uint8_t *value)
  * @param dev Pointer to the device structure for the driver instance.
  *
  * @retval 0 If successful.
- * @retval Negative errno code if failure.
+ * @retval -errno Negative errno code if failure.
  */
 __syscall int ps2_enable_callback(const struct device *dev);
 
@@ -148,7 +148,7 @@ static inline int z_impl_ps2_enable_callback(const struct device *dev)
  * @param dev Pointer to the device structure for the driver instance.
  *
  * @retval 0 If successful.
- * @retval Negative errno code if failure.
+ * @retval -errno Negative errno code if failure.
  */
 __syscall int ps2_disable_callback(const struct device *dev);
 

--- a/include/zephyr/drivers/regulator.h
+++ b/include/zephyr/drivers/regulator.h
@@ -280,8 +280,8 @@ int regulator_common_init(const struct device *dev, bool is_enabled);
  * @brief Check if regulator is expected to be enabled at init time.
  *
  * @param dev Regulator device instance
- * @return true If regulator needs to be enabled at init time.
- * @return false If regulator does not need to be enabled at init time.
+ * @retval true Regulator needs to be enabled at init time.
+ * @retval false Regulator does not need to be enabled at init time.
  */
 static inline bool regulator_common_is_init_enabled(const struct device *dev)
 {

--- a/include/zephyr/drivers/rtc.h
+++ b/include/zephyr/drivers/rtc.h
@@ -191,9 +191,9 @@ __subsystem struct rtc_driver_api {
  * @param dev Device instance
  * @param timeptr The time to set
  *
- * @return 0 if successful
- * @return -EINVAL if RTC time is invalid or exceeds hardware capabilities
- * @return -errno code if failure
+ * @retval 0 successful
+ * @retval -EINVAL RTC time is invalid or exceeds hardware capabilities
+ * @retval -errno other negative error code on failure
  */
 __syscall int rtc_set_time(const struct device *dev, const struct rtc_time *timeptr);
 
@@ -210,9 +210,9 @@ static inline int z_impl_rtc_set_time(const struct device *dev, const struct rtc
  * @param dev Device instance
  * @param timeptr Destination for the time
  *
- * @return 0 if successful
- * @return -ENODATA if RTC time has not been set
- * @return -errno code if failure
+ * @retval 0 successful
+ * @retval -ENODATA RTC time has not been set
+ * @retval -errno other negative error code on failure
  */
 __syscall int rtc_get_time(const struct device *dev, struct rtc_time *timeptr);
 
@@ -238,10 +238,10 @@ static inline int z_impl_rtc_get_time(const struct device *dev, struct rtc_time 
  *
  * @note Bits in the mask param are defined here @ref RTC_ALARM_TIME_MASK.
  *
- * @return 0 if successful
- * @return -EINVAL if id is out of range or time is invalid
- * @return -ENOTSUP if API is not supported by hardware
- * @return -errno code if failure
+ * @retval 0 successful
+ * @retval -EINVAL id is out of range or time is invalid
+ * @retval -ENOTSUP API is not supported by hardware
+ * @retval -errno negative error code if failure
  */
 __syscall int rtc_alarm_get_supported_fields(const struct device *dev, uint16_t id,
 					     uint16_t *mask);
@@ -276,10 +276,10 @@ static inline int z_impl_rtc_alarm_get_supported_fields(const struct device *dev
  * @note Only the enabled fields in the timeptr param need to be configured
  * @note Bits in the mask param are defined here @ref RTC_ALARM_TIME_MASK
  *
- * @return 0 if successful
- * @return -EINVAL if id is out of range or time is invalid
- * @return -ENOTSUP if API is not supported by hardware
- * @return -errno code if failure
+ * @retval 0 successful
+ * @retval -EINVAL id is out of range or time is invalid
+ * @retval -ENOTSUP API is not supported by hardware
+ * @retval -errno other negative error code on failure
  */
 __syscall int rtc_alarm_set_time(const struct device *dev, uint16_t id, uint16_t mask,
 				 const struct rtc_time *timeptr);
@@ -306,10 +306,10 @@ static inline int z_impl_rtc_alarm_set_time(const struct device *dev, uint16_t i
  *
  * @note Bits in the mask param are defined here @ref RTC_ALARM_TIME_MASK
  *
- * @return 0 if successful
- * @return -EINVAL if id is out of range
- * @return -ENOTSUP if API is not supported by hardware
- * @return -errno code if failure
+ * @retval 0 successful
+ * @retval -EINVAL id is out of range
+ * @retval -ENOTSUP API is not supported by hardware
+ * @retval -errno other negative error code on failure
  */
 __syscall int rtc_alarm_get_time(const struct device *dev, uint16_t id, uint16_t *mask,
 				 struct rtc_time *timeptr);
@@ -335,11 +335,11 @@ static inline int z_impl_rtc_alarm_get_time(const struct device *dev, uint16_t i
  * @param dev Device instance
  * @param id Id of the alarm to test
  *
- * @return 1 if alarm was pending
- * @return 0 if alarm was not pending
- * @return -EINVAL if id is out of range
- * @return -ENOTSUP if API is not supported by hardware
- * @return -errno code if failure
+ * @retval 1 alarm was pending
+ * @retval 0 alarm was not pending
+ * @retval -EINVAL id is out of range
+ * @retval -ENOTSUP API is not supported by hardware
+ * @retval -errno other negative error code on failure
  */
 __syscall int rtc_alarm_is_pending(const struct device *dev, uint16_t id);
 
@@ -375,10 +375,10 @@ static inline int z_impl_rtc_alarm_is_pending(const struct device *dev, uint16_t
  * @param callback Callback called when alarm occurs
  * @param user_data Optional user data passed to callback
  *
- * @return 0 if successful
- * @return -EINVAL if id is out of range
- * @return -ENOTSUP if API is not supported by hardware
- * @return -errno code if failure
+ * @retval 0 successful
+ * @retval -EINVAL id is out of range
+ * @retval -ENOTSUP API is not supported by hardware
+ * @retval -errno other negative error code on failure
  */
 __syscall int rtc_alarm_set_callback(const struct device *dev, uint16_t id,
 				     rtc_alarm_callback callback, void *user_data);
@@ -421,9 +421,9 @@ static inline int z_impl_rtc_alarm_set_callback(const struct device *dev, uint16
  * @param callback Callback called when update occurs
  * @param user_data Optional user data passed to callback
  *
- * @return 0 if successful
- * @return -ENOTSUP if API is not supported by hardware
- * @return -errno code if failure
+ * @retval 0 successful
+ * @retval -ENOTSUP API is not supported by hardware
+ * @retval -errno other negative error code on failure
  */
 __syscall int rtc_update_set_callback(const struct device *dev, rtc_update_callback callback,
 				      void *user_data);
@@ -464,10 +464,10 @@ static inline int z_impl_rtc_update_set_callback(const struct device *dev,
  * @param dev Device instance
  * @param calibration Calibration to set in parts per billion
  *
- * @return 0 if successful
- * @return -EINVAL if calibration is out of range
- * @return -ENOTSUP if API is not supported by hardware
- * @return -errno code if failure
+ * @retval 0 successful
+ * @retval -EINVAL calibration is out of range
+ * @retval -ENOTSUP API is not supported by hardware
+ * @retval -errno other negative error code on failure
  */
 __syscall int rtc_set_calibration(const struct device *dev, int32_t calibration);
 
@@ -488,9 +488,9 @@ static inline int z_impl_rtc_set_calibration(const struct device *dev, int32_t c
  * @param dev Device instance
  * @param calibration Destination for calibration in parts per billion
  *
- * @return 0 if successful
- * @return -ENOTSUP if API is not supported by hardware
- * @return -errno code if failure
+ * @retval 0 successful
+ * @retval -ENOTSUP API is not supported by hardware
+ * @retval -errno other negative error code on failure
  */
 __syscall int rtc_get_calibration(const struct device *dev, int32_t *calibration);
 

--- a/include/zephyr/drivers/rtc/mcp7940n.h
+++ b/include/zephyr/drivers/rtc/mcp7940n.h
@@ -189,8 +189,8 @@ enum mcp7940n_alarm_trigger {
  * @param dev the MCP7940N device pointer.
  * @param unix_time Unix time to set the rtc to.
  *
- * @retval return 0 on success, or a negative error code from an I2C
- * transaction or invalid parameter.
+ * @retval 0 on success
+ * @retval -errno negative error code from an I2C transaction or invalid parameter.
  */
 int mcp7940n_rtc_set_time(const struct device *dev, time_t unix_time);
 

--- a/include/zephyr/drivers/sdhc.h
+++ b/include/zephyr/drivers/sdhc.h
@@ -336,9 +336,9 @@ static inline int z_impl_sdhc_request(const struct device *dev,
  * power to the SD card.
  * @param dev: SDHC device
  * @param io: I/O properties
- * @return 0 I/O was configured correctly
- * @return -ENOTSUP controller does not support these I/O settings
- * @return -EIO controller could not configure I/O settings
+ * @retval 0 I/O was configured correctly
+ * @retval -ENOTSUP controller does not support these I/O settings
+ * @retval -EIO controller could not configure I/O settings
  */
 __syscall int sdhc_set_io(const struct device *dev, struct sdhc_io *io);
 

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -467,8 +467,8 @@ struct sensor_decoder_api {
 	 * @param[in]  buffer The buffer provided on the @ref rtio context.
 	 * @param[in]  channel The channel to get the count for
 	 * @param[out] frame_count The number of frames on the buffer (at least 1)
-	 * @return 0 on success
-	 * @return -ENOTSUP if the channel/channel_idx aren't found
+	 * @retval 0 success
+	 * @retval -ENOTSUP the channel/channel_idx aren't found
 	 */
 	int (*get_frame_count)(const uint8_t *buffer, struct sensor_chan_spec channel,
 			       uint16_t *frame_count);
@@ -482,8 +482,8 @@ struct sensor_decoder_api {
 	 * @param[in]  channel The channel to query
 	 * @param[out] base_size The size of decoding the first frame
 	 * @param[out] frame_size The additional size of every additional frame
-	 * @return 0 on success
-	 * @return -ENOTSUP if the channel is not supported
+	 * @retval 0 success
+	 * @retval -ENOTSUP the channel is not supported
 	 */
 	int (*get_size_info)(struct sensor_chan_spec channel, size_t *base_size,
 			     size_t *frame_size);
@@ -509,9 +509,9 @@ struct sensor_decoder_api {
 	 * @param[in,out] fit The current frame iterator
 	 * @param[in]     max_count The maximum number of channels to decode.
 	 * @param[out]    data_out The decoded data
-	 * @return 0 no more samples to decode
-	 * @return >0 the number of decoded frames
-	 * @return <0 on error
+	 * @retval 0 no more samples to decode
+	 * @retval nb_frames number of decoded frames (>0)
+	 * @retval -errno negative error code on failure
 	 */
 	int (*decode)(const uint8_t *buffer, struct sensor_chan_spec channel, uint32_t *fit,
 		      uint16_t max_count, void *data_out);
@@ -943,8 +943,8 @@ struct __attribute__((__packed__)) sensor_data_generic_header {
  *
  * @param[in] dev The sensor device
  * @param[in] decoder Pointer to the decoder which will be set upon success
- * @return 0 on success
- * @return < 0 on error
+ * @retval 0 success
+ * @retval -errno negative error code on failure
  */
 __syscall int sensor_get_decoder(const struct device *dev,
 				 const struct sensor_decoder_api **decoder);
@@ -979,8 +979,8 @@ static inline int z_impl_sensor_get_decoder(const struct device *dev,
  * @param[in] sensor The sensor to read from
  * @param[in] channels One or more channels to read
  * @param[in] num_channels The number of channels in @p channels
- * @return 0 on success
- * @return < 0 on error
+ * @retval 0 success
+ * @retval -errno negative error code on failure
  */
 __syscall int sensor_reconfigure_read_iodev(struct rtio_iodev *iodev, const struct device *sensor,
 					    const struct sensor_chan_spec *channels,
@@ -1037,8 +1037,8 @@ static inline int sensor_stream(struct rtio_iodev *iodev, struct rtio *ctx, void
  * @param[in] ctx The RTIO context to service the read
  * @param[in] buf Pointer to memory to read sample data into
  * @param[in] buf_len Size in bytes of the given memory that are valid to read into
- * @return 0 on success
- * @return < 0 on error
+ * @retval 0 success
+ * @retval -errno negative error code on failure
  */
 static inline int sensor_read(struct rtio_iodev *iodev, struct rtio *ctx, uint8_t *buf,
 			      size_t buf_len)
@@ -1079,8 +1079,8 @@ static inline int sensor_read(struct rtio_iodev *iodev, struct rtio *ctx, uint8_
  * @param[in] iodev The iodev created by @ref SENSOR_DT_READ_IODEV
  * @param[in] ctx The RTIO context to service the read
  * @param[in] userdata Optional userdata that will be available when the read is complete
- * @return 0 on success
- * @return < 0 on error
+ * @retval 0 success
+ * @retval -errno negative error code on failure
  */
 static inline int sensor_read_async_mempool(struct rtio_iodev *iodev, struct rtio *ctx,
 					    void *userdata)

--- a/include/zephyr/drivers/serial/uart_async_to_irq.h
+++ b/include/zephyr/drivers/serial/uart_async_to_irq.h
@@ -123,7 +123,7 @@ int uart_async_to_irq_init(struct uart_async_to_irq_data *data,
  *
  * @retval 0 on successful operation.
  * @retval -EINVAL if adaption layer has wrong configuration.
- * @retval negative value Error reported by the UART API.
+ * @retval -errno negative value Error reported by the UART API.
  */
 int uart_async_to_irq_rx_enable(const struct device *dev);
 
@@ -133,7 +133,7 @@ int uart_async_to_irq_rx_enable(const struct device *dev);
  *
  * @retval 0 on successful operation.
  * @retval -EINVAL if adaption layer has wrong configuration.
- * @retval negative value Error reported by the UART API.
+ * @retval -errno negative value Error reported by the UART API.
  */
 int uart_async_to_irq_rx_disable(const struct device *dev);
 

--- a/include/zephyr/drivers/sip_svc/sip_svc_driver.h
+++ b/include/zephyr/drivers/sip_svc/sip_svc_driver.h
@@ -167,7 +167,7 @@ static inline bool z_impl_sip_svc_plat_func_id_valid(const struct device *dev, u
  * @param client_idx client index.
  * @param trans_idx transaction index.
  *
- * @retval transaction id, which is used for tracking each transaction.
+ * @return transaction id, which is used for tracking each transaction.
  */
 __syscall uint32_t sip_svc_plat_format_trans_id(const struct device *dev, uint32_t client_idx,
 						uint32_t trans_idx);

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -662,8 +662,8 @@ __subsystem struct spi_driver_api {
  * @brief Check if SPI CS is controlled using a GPIO.
  *
  * @param config SPI configuration.
- * @return true If CS is controlled using a GPIO.
- * @return false If CS is controlled by hardware or any other means.
+ * @retval true CS is controlled using a GPIO.
+ * @retval false CS is controlled by hardware or any other means.
  */
 static inline bool spi_cs_is_gpio(const struct spi_config *config)
 {
@@ -674,8 +674,8 @@ static inline bool spi_cs_is_gpio(const struct spi_config *config)
  * @brief Check if SPI CS in @ref spi_dt_spec is controlled using a GPIO.
  *
  * @param spec SPI specification from devicetree.
- * @return true If CS is controlled using a GPIO.
- * @return false If CS is controlled by hardware or any other means.
+ * @retval true CS is controlled using a GPIO.
+ * @retval false CS is controlled by hardware or any other means.
  */
 static inline bool spi_cs_is_gpio_dt(const struct spi_dt_spec *spec)
 {
@@ -1060,7 +1060,7 @@ static inline bool spi_is_ready_iodev(const struct rtio_iodev *spi_iodev)
  * @param[in] rx_bufs receive buffer set
  * @param[out] last_sqe last sqe submitted, NULL if not enough memory
  *
- * @retval Number of submission queue entries
+ * @return Number of submission queue entries
  * @retval -ENOMEM out of memory
  */
 static inline int spi_rtio_copy(struct rtio *r,

--- a/include/zephyr/drivers/timer/nrf_rtc_timer.h
+++ b/include/zephyr/drivers/timer/nrf_rtc_timer.h
@@ -38,7 +38,7 @@ typedef void (*z_nrf_rtc_timer_compare_handler_t)(int32_t id,
  *
  * Channel 0 is used for the system clock.
  *
- * @retval Non-negative indicates allocated channel ID.
+ * @retval channel_id Non-negative indicates allocated channel ID.
  * @retval -ENOMEM if channel cannot be allocated.
  */
 int32_t z_nrf_rtc_timer_chan_alloc(void);
@@ -180,7 +180,7 @@ void z_nrf_rtc_timer_abort(int32_t chan);
  * @p t can be absolute or relative. @p t cannot be further into the future
  * from now than the RTC range (e.g. 512 seconds if RTC is running at 32768 Hz).
  *
- * @retval Positive value represents @p t in RTC tick value.
+ * @return Positive value that represents @p t in RTC tick value.
  * @retval -EINVAL if @p t is out of range.
  */
 uint64_t z_nrf_rtc_timer_get_ticks(k_timeout_t t);
@@ -192,7 +192,7 @@ uint64_t z_nrf_rtc_timer_get_ticks(k_timeout_t t);
  * application cpu system tick. Function can only be used on network cpu. It
  * requires @kconfig{CONFIG_NRF53_SYNC_RTC} being enabled.
  *
- * @retval Non-negative offset given in RTC ticks.
+ * @return Non-negative offset given in RTC ticks.
  * @retval -ENOSYS if operation is not supported.
  * @retval -EBUSY if synchronization is not yet completed.
  */

--- a/include/zephyr/drivers/uart/serial_test.h
+++ b/include/zephyr/drivers/uart/serial_test.h
@@ -27,7 +27,7 @@ extern "C" {
  * @param data Address of data.
  * @param size Data size (in bytes).
  *
- * @retval Number of bytes written.
+ * @return Number of bytes written.
  */
 int serial_vnd_queue_in_data(const struct device *dev, const unsigned char *data, uint32_t size);
 
@@ -56,7 +56,7 @@ uint32_t serial_vnd_out_data_size_get(const struct device *dev);
  * @param data Address of the output buffer. Can be NULL to discard data.
  * @param size Data size (in bytes).
  *
- * @retval Number of bytes written to the output buffer.
+ * @return Number of bytes written to the output buffer.
  */
 uint32_t serial_vnd_read_out_data(const struct device *dev, unsigned char *data, uint32_t size);
 
@@ -76,7 +76,7 @@ uint32_t serial_vnd_read_out_data(const struct device *dev, unsigned char *data,
  * @param data Address of the output buffer. Cannot be NULL.
  * @param size Data size (in bytes).
  *
- * @retval Number of bytes written to the output buffer.
+ * @return Number of bytes written to the output buffer.
  */
 uint32_t serial_vnd_peek_out_data(const struct device *dev, unsigned char *data, uint32_t size);
 

--- a/include/zephyr/drivers/usb_c/usbc_tcpc.h
+++ b/include/zephyr/drivers/usb_c/usbc_tcpc.h
@@ -466,7 +466,8 @@ static inline int tcpc_set_roles(const struct device *dev,
  * @param dev Runtime device structure
  * @param buf pointer where the pd_buf pointer is written, NULL if only checking the status
  *
- * @retval Greater or equal to 0 is the number of bytes received if buf parameter is provided
+ * @retval bytes_received Greater or equal to 0 is the number of bytes received if buf parameter is
+ * provided
  * @retval 0 if there is a message pending and buf parameter is NULL
  * @retval -EIO on failure
  * @retval -ENODATA if no message is pending

--- a/include/zephyr/input/input.h
+++ b/include/zephyr/input/input.h
@@ -64,8 +64,8 @@ struct input_event {
  * @param timeout Timeout for reporting the event, ignored if
  *                @kconfig{CONFIG_INPUT_MODE_SYNCHRONOUS} is used.
  * @retval 0 if the message has been processed.
- * @retval negative if @kconfig{CONFIG_INPUT_MODE_THREAD} is enabled and the
- *         message failed to be enqueued.
+ * @retval -errno negative error code if @kconfig{CONFIG_INPUT_MODE_THREAD} is
+ *         enabled and the message failed to be enqueued.
  */
 int input_report(const struct device *dev,
 		 uint8_t type, uint16_t code, int32_t value, bool sync,

--- a/include/zephyr/input/input_hid.h
+++ b/include/zephyr/input/input_hid.h
@@ -20,7 +20,7 @@
  * safely be casted to a uint8_t type.
  *
  * @param input_code Event code (see @ref INPUT_KEY_CODES).
- * @retval the HID code corresponding to the input code.
+ * @retval hid_code the HID code corresponding to the input code.
  * @retval -1 if there's no HID code for the specified input code.
  */
 int16_t input_to_hid_code(uint16_t input_code);
@@ -32,7 +32,7 @@ int16_t input_to_hid_code(uint16_t input_code);
  * output or 0.
  *
  * @param input_code Event code (see @ref INPUT_KEY_CODES).
- * @retval the HID modifier corresponding to the input code.
+ * @retval hid_modifier the HID modifier corresponding to the input code.
  * @retval 0 if there's no HID modifier for the specified input code.
  */
 uint8_t input_to_hid_modifier(uint16_t input_code);

--- a/include/zephyr/ipc/icmsg.h
+++ b/include/zephyr/ipc/icmsg.h
@@ -80,7 +80,7 @@ struct icmsg_data_t {
  *
  *  @retval 0 on success.
  *  @retval -EALREADY when the instance is already opened.
- *  @retval other errno codes from dependent modules.
+ *  @retval -errno other errno codes from dependent modules.
  */
 int icmsg_open(const struct icmsg_config_t *conf,
 	       struct icmsg_data_t *dev_data,
@@ -98,7 +98,7 @@ int icmsg_open(const struct icmsg_config_t *conf,
  *                         instance.
  *
  *  @retval 0 on success.
- *  @retval other errno codes from dependent modules.
+ *  @retval -errno other errno codes from dependent modules.
  */
 int icmsg_close(const struct icmsg_config_t *conf,
 		struct icmsg_data_t *dev_data);
@@ -113,13 +113,13 @@ int icmsg_close(const struct icmsg_config_t *conf,
  *  @param[in] len Size of data in the @p msg buffer.
  *
  *
- *  @retval Number of sent bytes.
+ *  @return Number of sent bytes.
  *  @retval -EBUSY when the instance has not finished handshake with the remote
  *                 instance.
  *  @retval -ENODATA when the requested data to send is empty.
  *  @retval -EBADMSG when the requested data to send is too big.
  *  @retval -ENOBUFS when there are no TX buffers available.
- *  @retval other errno codes from dependent modules.
+ *  @retval -errno other errno codes from dependent modules.
  */
 int icmsg_send(const struct icmsg_config_t *conf,
 	       struct icmsg_data_t *dev_data,

--- a/include/zephyr/ipc/icmsg_me.h
+++ b/include/zephyr/ipc/icmsg_me.h
@@ -41,7 +41,6 @@ struct icmsg_me_data_t {
 	uint8_t send_buffer[CONFIG_IPC_SERVICE_BACKEND_ICMSG_ME_SEND_BUF_SIZE] __aligned(4);
 };
 
-
 /** @brief Initialize an icmsg_me instance
  *
  *  This function is intended to be called during system initialization.
@@ -57,7 +56,7 @@ struct icmsg_me_data_t {
  *                     is active.
  *
  *  @retval 0 on success.
- *  @retval other errno codes from dependent modules.
+ *  @retval -errno other errno codes from dependent modules.
  */
 int icmsg_me_init(const struct icmsg_config_t *conf,
 		  struct icmsg_me_data_t *data);
@@ -85,7 +84,7 @@ int icmsg_me_init(const struct icmsg_config_t *conf,
  *
  *
  *  @retval 0 on success.
- *  @retval other errno codes from dependent modules.
+ *  @retval -errno other errno codes from dependent modules.
  */
 int icmsg_me_open(const struct icmsg_config_t *conf,
 		  struct icmsg_me_data_t *data,
@@ -241,7 +240,7 @@ void icmsg_me_reset_ept_cfg(struct icmsg_me_data_t *data, icmsg_me_ept_id_t id);
  *
  *  @retval 0 on success.
  *  @retval -EBADMSG when the requested data to send is too big.
- *  @retval other errno codes from dependent modules.
+ *  @retval -errno other errno codes from dependent modules.
  */
 int icmsg_me_send(const struct icmsg_config_t *conf,
 		  struct icmsg_me_data_t *data, icmsg_me_ept_id_t id,

--- a/include/zephyr/ipc/ipc_rpmsg.h
+++ b/include/zephyr/ipc/ipc_rpmsg.h
@@ -103,7 +103,7 @@ struct ipc_rpmsg_instance {
  *
  *  @retval -EINVAL When some parameter is missing.
  *  @retval 0 If successful.
- *  @retval Other errno codes depending on the OpenAMP implementation.
+ *  @retval -errno Other errno codes depending on the OpenAMP implementation.
  */
 int ipc_rpmsg_init(struct ipc_rpmsg_instance *instance,
 		   unsigned int role,
@@ -137,7 +137,7 @@ int ipc_rpmsg_deinit(struct ipc_rpmsg_instance *instance,
  *
  *  @retval -EINVAL When some parameter is missing.
  *  @retval 0 If successful.
- *  @retval Other errno codes depending on the OpenAMP implementation.
+ *  @retval -errno Other errno codes depending on the OpenAMP implementation.
  */
 int ipc_rpmsg_register_ept(struct ipc_rpmsg_instance *instance, unsigned int role,
 			   struct ipc_rpmsg_ept *ept);

--- a/include/zephyr/ipc/ipc_service.h
+++ b/include/zephyr/ipc/ipc_service.h
@@ -215,7 +215,7 @@ struct ipc_ept_cfg {
  *  @retval -EALREADY when the instance is already opened (or being opened).
  *
  *  @retval 0 on success or when not implemented on the backend (not needed).
- *  @retval other errno codes depending on the implementation of the backend.
+ *  @retval -errno other errno codes depending on the implementation of the backend.
  */
 int ipc_service_open_instance(const struct device *instance);
 
@@ -234,7 +234,7 @@ int ipc_service_open_instance(const struct device *instance);
  *           deregistered
  *
  *  @retval 0 on success or when not implemented on the backend (not needed).
- *  @retval other errno codes depending on the implementation of the backend.
+ *  @retval -errno other errno codes depending on the implementation of the backend.
  */
 int ipc_service_close_instance(const struct device *instance);
 
@@ -256,7 +256,7 @@ int ipc_service_close_instance(const struct device *instance);
  *  @retval -EBUSY when the instance is busy.
  *
  *  @retval 0 on success.
- *  @retval other errno codes depending on the implementation of the backend.
+ *  @retval -errno other errno codes depending on the implementation of the backend.
  */
 int ipc_service_register_endpoint(const struct device *instance,
 				  struct ipc_ept *ept,
@@ -276,7 +276,7 @@ int ipc_service_register_endpoint(const struct device *instance,
  *  @retval -EBUSY when the instance is busy.
  *
  *  @retval 0 on success.
- *  @retval other errno codes depending on the implementation of the backend.
+ *  @retval -errno other errno codes depending on the implementation of the backend.
  */
 int ipc_service_deregister_endpoint(struct ipc_ept *ept);
 
@@ -296,7 +296,7 @@ int ipc_service_deregister_endpoint(struct ipc_ept *ept);
  *  @retval -ENOMEM when no memory / buffers are available.
  *
  *  @retval bytes number of bytes sent.
- *  @retval other errno codes depending on the implementation of the backend.
+ *  @retval -errno other errno codes depending on the implementation of the backend.
  */
 int ipc_service_send(struct ipc_ept *ept, const void *data, size_t len);
 
@@ -314,7 +314,7 @@ int ipc_service_send(struct ipc_ept *ept, const void *data, size_t len);
  *  @retval -ENOTSUP when the operation is not supported by backend.
  *
  *  @retval size TX buffer size on success.
- *  @retval other errno codes depending on the implementation of the backend.
+ *  @retval -errno other errno codes depending on the implementation of the backend.
  */
 int ipc_service_get_tx_buffer_size(struct ipc_ept *ept);
 
@@ -363,7 +363,7 @@ int ipc_service_get_tx_buffer_size(struct ipc_ept *ept);
  *		    contains the maximum allowed size).
  *
  *  @retval 0 on success.
- *  @retval other errno codes depending on the implementation of the backend.
+ *  @retval -errno other errno codes depending on the implementation of the backend.
  */
 int ipc_service_get_tx_buffer(struct ipc_ept *ept, void **data, uint32_t *size, k_timeout_t wait);
 
@@ -385,7 +385,7 @@ int ipc_service_get_tx_buffer(struct ipc_ept *ept, void **data, uint32_t *size, 
  *		   ipc_service_get_tx_buffer
  *
  *  @retval 0 on success.
- *  @retval other errno codes depending on the implementation of the backend.
+ *  @retval -errno other errno codes depending on the implementation of the backend.
  */
 int ipc_service_drop_tx_buffer(struct ipc_ept *ept, const void *data);
 
@@ -419,7 +419,7 @@ int ipc_service_drop_tx_buffer(struct ipc_ept *ept, const void *data);
  *  @retval -EBUSY when the instance is busy.
  *
  *  @retval bytes number of bytes sent.
- *  @retval other errno codes depending on the implementation of the backend.
+ *  @retval -errno other errno codes depending on the implementation of the backend.
  */
 int ipc_service_send_nocopy(struct ipc_ept *ept, const void *data, size_t len);
 
@@ -444,7 +444,7 @@ int ipc_service_send_nocopy(struct ipc_ept *ept, const void *data, size_t len);
  *  @retval -ENOTSUP when this is not supported by backend.
  *
  *  @retval 0 on success.
- *  @retval other errno codes depending on the implementation of the backend.
+ *  @retval -errno other errno codes depending on the implementation of the backend.
  */
 int ipc_service_hold_rx_buffer(struct ipc_ept *ept, void *data);
 
@@ -470,7 +470,7 @@ int ipc_service_hold_rx_buffer(struct ipc_ept *ept, void *data);
  *		   ipc_service_hold_rx_buffer
  *
  *  @retval 0 on success.
- *  @retval other errno codes depending on the implementation of the backend.
+ *  @retval -errno other errno codes depending on the implementation of the backend.
  */
 int ipc_service_release_rx_buffer(struct ipc_ept *ept, void *data);
 

--- a/include/zephyr/ipc/ipc_service_backend.h
+++ b/include/zephyr/ipc/ipc_service_backend.h
@@ -34,7 +34,7 @@ struct ipc_service_backend {
 	 *  @retval -EALREADY when the instance is already opened.
 	 *
 	 *  @retval 0 on success
-	 *  @retval other errno codes depending on the implementation of the
+	 *  @retval -errno other errno codes depending on the implementation of the
 	 *	    backend.
 	 */
 	int (*open_instance)(const struct device *instance);
@@ -46,7 +46,7 @@ struct ipc_service_backend {
 	 *  @retval -EALREADY when the instance is not already inited.
 	 *
 	 *  @retval 0 on success
-	 *  @retval other errno codes depending on the implementation of the
+	 *  @retval -errno other errno codes depending on the implementation of the
 	 *	    backend.
 	 */
 	int (*close_instance)(const struct device *instance);
@@ -65,7 +65,7 @@ struct ipc_service_backend {
 	 *  @retval -ENOMEM when no memory / buffers are available.
 	 *
 	 *  @retval bytes number of bytes sent.
-	 *  @retval other errno codes depending on the implementation of the
+	 *  @retval -errno other errno codes depending on the implementation of the
 	 *	    backend.
 	 */
 	int (*send)(const struct device *instance, void *token,
@@ -81,7 +81,7 @@ struct ipc_service_backend {
 	 *  @retval -EBUSY when the instance is busy or not ready.
 	 *
 	 *  @retval 0 on success
-	 *  @retval other errno codes depending on the implementation of the
+	 *  @retval -errno other errno codes depending on the implementation of the
 	 *	    backend.
 	 */
 	int (*register_endpoint)(const struct device *instance,
@@ -98,7 +98,7 @@ struct ipc_service_backend {
 	 *  @retval -EBUSY when the instance is busy or not ready.
 	 *
 	 *  @retval 0 on success
-	 *  @retval other errno codes depending on the implementation of the
+	 *  @retval -errno other errno codes depending on the implementation of the
 	 *      backend.
 	 */
 	int (*deregister_endpoint)(const struct device *instance, void *token);
@@ -113,7 +113,7 @@ struct ipc_service_backend {
 	 *  @retval -ENOTSUP when the operation is not supported.
 	 *
 	 *  @retval size TX buffer size on success.
-	 *  @retval other errno codes depending on the implementation of the
+	 *  @retval -errno other errno codes depending on the implementation of the
 	 *	    backend.
 	 */
 	int (*get_tx_buffer_size)(const struct device *instance, void *token);
@@ -135,7 +135,7 @@ struct ipc_service_backend {
 	 *		    contains the maximum allowed size).
 	 *
 	 *  @retval 0 on success
-	 *  @retval other errno codes depending on the implementation of the
+	 *  @retval -errno other errno codes depending on the implementation of the
 	 *	    backend.
 	 */
 	int (*get_tx_buffer)(const struct device *instance, void *token,
@@ -153,7 +153,7 @@ struct ipc_service_backend {
 	 *  @retval -EALREADY when the buffer was already dropped.
 	 *
 	 *  @retval 0 on success
-	 *  @retval other errno codes depending on the implementation of the
+	 *  @retval -errno other errno codes depending on the implementation of the
 	 *	    backend.
 	 */
 	int (*drop_tx_buffer)(const struct device *instance, void *token,
@@ -175,7 +175,7 @@ struct ipc_service_backend {
 	 *  @retval -EBUSY when the instance is busy or not ready.
 	 *
 	 *  @retval bytes number of bytes sent.
-	 *  @retval other errno codes depending on the implementation of the
+	 *  @retval -errno other errno codes depending on the implementation of the
 	 *	    backend.
 	 */
 	int (*send_nocopy)(const struct device *instance, void *token,
@@ -193,7 +193,7 @@ struct ipc_service_backend {
 	 *  @retval -ENOTSUP when this function is not supported.
 	 *
 	 *  @retval 0 on success
-	 *  @retval other errno codes depending on the implementation of the
+	 *  @retval -errno other errno codes depending on the implementation of the
 	 *	    backend.
 	 */
 	int (*hold_rx_buffer)(const struct device *instance, void *token,
@@ -211,7 +211,7 @@ struct ipc_service_backend {
 	 *  @retval -ENOTSUP when this function is not supported.
 	 *
 	 *  @retval 0 on success
-	 *  @retval other errno codes depending on the implementation of the
+	 *  @retval -errno other errno codes depending on the implementation of the
 	 *	    backend.
 	 */
 	int (*release_rx_buffer)(const struct device *instance, void *token,

--- a/include/zephyr/ipc/ipc_static_vrings.h
+++ b/include/zephyr/ipc/ipc_static_vrings.h
@@ -102,7 +102,7 @@ struct ipc_static_vrings {
  *  @retval -EINVAL When some parameter is missing.
  *  @retval -ENOMEM When memory is not enough for VQs allocation.
  *  @retval 0 If successful.
- *  @retval Other errno codes depending on the OpenAMP implementation.
+ *  @retval -errno Other errno codes depending on the OpenAMP implementation.
  */
 int ipc_static_vrings_init(struct ipc_static_vrings *vr, unsigned int role);
 
@@ -114,7 +114,7 @@ int ipc_static_vrings_init(struct ipc_static_vrings *vr, unsigned int role);
  *  @param role Host / Remote role.
  *
  *  @retval 0 If successful.
- *  @retval Other errno codes depending on the OpenAMP implementation.
+ *  @retval -errno Other errno codes depending on the OpenAMP implementation.
  */
 int ipc_static_vrings_deinit(struct ipc_static_vrings *vr, unsigned int role);
 

--- a/include/zephyr/ipc/pbuf.h
+++ b/include/zephyr/ipc/pbuf.h
@@ -176,11 +176,11 @@ int pbuf_init(struct pbuf *pb);
  * @param pb	A buffer to which to write.
  * @param buf	Pointer to the data to be written to the buffer.
  * @param len	Number of bytes to be written to the buffer. Must be positive.
- * @retval int	Number of bytes written, negative error code on fail.
- *		-EINVAL, if any of input parameter is incorrect.
- *		-ENOMEM, if len is bigger than the buffer can fit.
+ * @return	Number of bytes written
+ * @retval 	-EINVAL, if any of input parameter is incorrect.
+ * @retval 	-ENOMEM, if len is bigger than the buffer can fit.
+ * @retval 	-errno other negative error code on fail.
  */
-
 int pbuf_write(struct pbuf *pb, const char *buf, uint16_t len);
 
 /**
@@ -193,11 +193,11 @@ int pbuf_write(struct pbuf *pb, const char *buf, uint16_t len);
  * @param buf	Data pointer to which read data will be written.
  *		If NULL, len of stored message is returned.
  * @param len	Number of bytes to be read from the buffer.
- * @retval int	Bytes read, negative error code on fail.
- *		Bytes to be read, if buf == NULL.
- *		-EINVAL, if any of input parameter is incorrect.
- *		-ENOMEM, if message can not fit in provided buf.
- *		-EAGAIN, if not whole message is ready yet.
+ * @return	Bytes read (if buf != NULL) or to be read (if buf == NULL).
+ * @retval	-EINVAL if any of input parameter is incorrect.
+ * @retval	-ENOMEM if message can not fit in provided buf.
+ * @retval	-EAGAIN if not whole message is ready yet.
+ * @retval	-errno other negative error code on fail.
  */
 int pbuf_read(struct pbuf *pb, char *buf, uint16_t len);
 

--- a/include/zephyr/ipc/pbuf.h
+++ b/include/zephyr/ipc/pbuf.h
@@ -73,9 +73,8 @@ struct pbuf_data {
 					 */
 };
 
-
 /**
- * @brief Scure packed buffer.
+ * @brief Secure packed buffer.
  *
  * The packet buffer implements lightweight unidirectional packet
  * buffer with read/write semantics on top of a memory region shared
@@ -177,9 +176,9 @@ int pbuf_init(struct pbuf *pb);
  * @param buf	Pointer to the data to be written to the buffer.
  * @param len	Number of bytes to be written to the buffer. Must be positive.
  * @return	Number of bytes written
- * @retval 	-EINVAL, if any of input parameter is incorrect.
- * @retval 	-ENOMEM, if len is bigger than the buffer can fit.
- * @retval 	-errno other negative error code on fail.
+ * @retval	-EINVAL, if any of input parameter is incorrect.
+ * @retval	-ENOMEM, if len is bigger than the buffer can fit.
+ * @retval	-errno other negative error code on fail.
  */
 int pbuf_write(struct pbuf *pb, const char *buf, uint16_t len);
 

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -337,7 +337,7 @@ void k_thread_foreach_unlocked_filter_by_cpu(unsigned int cpu,
  * @param size Stack size in bytes.
  * @param flags Stack creation flags, or 0.
  *
- * @retval the allocated thread stack on success.
+ * @return the allocated thread stack on success.
  * @retval NULL on failure.
  *
  * @see CONFIG_DYNAMIC_THREAD
@@ -488,12 +488,12 @@ static inline void k_thread_heap_assign(struct k_thread *thread,
  * @param thread Thread to inspect stack information
  * @param unused_ptr Output parameter, filled in with the unused stack space
  *	of the target thread in bytes.
- * @return 0 on success
- * @return -EBADF Bad thread object (user mode only)
- * @return -EPERM No permissions on thread object (user mode only)
- * #return -ENOTSUP Forbidden by hardware policy
- * @return -EINVAL Thread is uninitialized or exited (user mode only)
- * @return -EFAULT Bad memory address for unused_ptr (user mode only)
+ * @retval 0 success
+ * @retval -EBADF Bad thread object (user mode only)
+ * @retval -EPERM No permissions on thread object (user mode only)
+ * #retval -ENOTSUP Forbidden by hardware policy
+ * @retval -EINVAL Thread is uninitialized or exited (user mode only)
+ * @retval -EFAULT Bad memory address for unused_ptr (user mode only)
  */
 __syscall int k_thread_stack_space_get(const struct k_thread *thread,
 				       size_t *unused_ptr);
@@ -1148,8 +1148,8 @@ void k_thread_time_slice_set(struct k_thread *th, int32_t slice_ticks,
  *
  * @funcprops \isr_ok
  *
- * @return false if invoked by a thread.
- * @return true if invoked by an ISR.
+ * @retval false invoked by a thread.
+ * @retval true invoked by an ISR.
  */
 bool k_is_in_isr(void);
 
@@ -1166,8 +1166,8 @@ bool k_is_in_isr(void);
  *
  * @funcprops \isr_ok
  *
- * @return 0 if invoked by an ISR or by a cooperative thread.
- * @return Non-zero if invoked by a preemptible thread.
+ * @retval 0 if invoked by an ISR or by a cooperative thread.
+ * @retval Non-zero if invoked by a preemptible thread.
  */
 __syscall int k_is_preempt_thread(void);
 
@@ -1179,8 +1179,8 @@ __syscall int k_is_preempt_thread(void);
  *
  * @funcprops \isr_ok
  *
- * @return true if invoked before post-kernel initialization
- * @return false if invoked during/after post-kernel initialization
+ * @retval true if invoked before post-kernel initialization
+ * @retval false if invoked during/after post-kernel initialization
  */
 static inline bool k_is_pre_kernel(void)
 {
@@ -1278,7 +1278,8 @@ __syscall int k_thread_name_set(k_tid_t thread, const char *str);
  * Get the name of a thread
  *
  * @param thread Thread ID
- * @retval Thread name, or NULL if configuration not enabled
+ * @return Thread name
+ * @retval NULL if @kconfig{CONFIG_THREAD_NAME} is not enabled
  */
 const char *k_thread_name_get(k_tid_t thread);
 
@@ -1306,7 +1307,7 @@ __syscall int k_thread_name_copy(k_tid_t thread, char *buf,
  * @param buf Buffer into which to copy state strings
  * @param buf_size Size of the buffer
  *
- * @retval Pointer to @a buf if data was copied, else a pointer to "".
+ * @return Pointer to @a buf if data was copied, else a pointer to "".
  */
 const char *k_thread_state_str(k_tid_t thread_id, char *buf, size_t buf_size);
 
@@ -2162,8 +2163,8 @@ bool k_queue_unique_append(struct k_queue *queue, void *data);
  *
  * @param queue Address of the queue.
  *
- * @return Non-zero if the queue is empty.
- * @return 0 if data is available.
+ * @retval !=0 the queue is empty.
+ * @retval 0 data is available.
  */
 __syscall int k_queue_is_empty(struct k_queue *queue);
 
@@ -2278,9 +2279,9 @@ __syscall int k_futex_wait(struct k_futex *futex, int expected,
  * @param futex Futex to wake up pending threads.
  * @param wake_all If true, wake up all pending threads; If false,
  *                 wakeup the highest priority thread.
+ * @return Number of threads that were woken up.
  * @retval -EACCES Caller does not have access to the futex address.
  * @retval -EINVAL Futex parameter address not recognized by the kernel.
- * @retval Number of threads that were woken up.
  */
 __syscall int k_futex_wake(struct k_futex *futex, bool wake_all);
 
@@ -2339,7 +2340,7 @@ __syscall void k_event_init(struct k_event *event);
  * @param event Address of the event object
  * @param events Set of events to post to @a event
  *
- * @retval Previous value of the events in @a event
+ * @return Previous value of the events in @a event
  */
 __syscall uint32_t k_event_post(struct k_event *event, uint32_t events);
 
@@ -2356,7 +2357,7 @@ __syscall uint32_t k_event_post(struct k_event *event, uint32_t events);
  * @param event Address of the event object
  * @param events Set of events to set in @a event
  *
- * @retval Previous value of the events in @a event
+ * @return Previous value of the events in @a event
  */
 __syscall uint32_t k_event_set(struct k_event *event, uint32_t events);
 
@@ -2372,7 +2373,7 @@ __syscall uint32_t k_event_set(struct k_event *event, uint32_t events);
  * @param events Set of events to set/clear in @a event
  * @param events_mask Mask to be applied to @a events
  *
- * @retval Previous value of the events in @a events_mask
+ * @return Previous value of the events in @a events_mask
  */
 __syscall uint32_t k_event_set_masked(struct k_event *event, uint32_t events,
 				  uint32_t events_mask);
@@ -2385,7 +2386,7 @@ __syscall uint32_t k_event_set_masked(struct k_event *event, uint32_t events,
  * @param event Address of the event object
  * @param events Set of events to clear in @a event
  *
- * @retval Previous value of the events in @a event
+ * @return Previous value of the events in @a event
  */
 __syscall uint32_t k_event_clear(struct k_event *event, uint32_t events);
 
@@ -2407,7 +2408,7 @@ __syscall uint32_t k_event_clear(struct k_event *event, uint32_t events);
  * @param timeout Waiting period for the desired set of events or one of the
  *                special values K_NO_WAIT and K_FOREVER.
  *
- * @retval set of matching events upon success
+ * @return set of matching events upon success
  * @retval 0 if matching events were not received within the specified time
  */
 __syscall uint32_t k_event_wait(struct k_event *event, uint32_t events,
@@ -2431,7 +2432,7 @@ __syscall uint32_t k_event_wait(struct k_event *event, uint32_t events,
  * @param timeout Waiting period for the desired set of events or one of the
  *                special values K_NO_WAIT and K_FOREVER.
  *
- * @retval set of matching events upon success
+ * @return set of matching events upon success
  * @retval 0 if matching events were not received within the specified time
  */
 __syscall uint32_t k_event_wait_all(struct k_event *event, uint32_t events,
@@ -2443,7 +2444,7 @@ __syscall uint32_t k_event_wait_all(struct k_event *event, uint32_t events,
  * @param event Address of the event object
  * @param events_mask Set of desired events to test
  *
- * @retval Current value of events in @a events_mask
+ * @return Current value of events in @a events_mask
  */
 static inline uint32_t k_event_test(struct k_event *event, uint32_t events_mask)
 {
@@ -2643,8 +2644,8 @@ struct k_fifo {
  *
  * @param fifo Address of the FIFO queue.
  *
- * @return Non-zero if the FIFO queue is empty.
- * @return 0 if data is available.
+ * @retval !=0 the FIFO queue is empty.
+ * @retval 0 data is available.
  */
 #define k_fifo_is_empty(fifo) \
 	k_queue_is_empty(&(fifo)->_queue)
@@ -3508,7 +3509,7 @@ int k_work_cancel(struct k_work *work);
  * one completes.  On architectures with CONFIG_KERNEL_COHERENCE the object
  * must be allocated in coherent memory.
  *
- * @retval true if work was pending (call had to wait for cancellation of a
+ * @retval true work was pending (call had to wait for cancellation of a
  * running handler to complete, or scheduled or submitted operations were
  * cancelled);
  * @retval false otherwise
@@ -3867,7 +3868,7 @@ int k_work_cancel_delayable(struct k_work_delayable *dwork);
  * one completes.  On architectures with CONFIG_KERNEL_COHERENCE the object
  * must be allocated in coherent memory.
  *
- * @retval true if work was not idle (call had to wait for cancellation of a
+ * @retval true work was not idle (call had to wait for cancellation of a
  * running handler to complete, or scheduled or submitted operations were
  * cancelled);
  * @retval false otherwise
@@ -5105,8 +5106,8 @@ __syscall int k_pipe_get(struct k_pipe *pipe, void *data,
  *
  * @param pipe Address of the pipe.
  *
- * @retval a number n such that 0 <= n <= @ref k_pipe.size; the
- *         result is zero for unbuffered pipes.
+ * @retval n number of bytes that may be read from @a pipe (0 <= n <= @ref k_pipe.size)
+ * @retval 0 for unbuffered pipes.
  */
 __syscall size_t k_pipe_read_avail(struct k_pipe *pipe);
 
@@ -5115,8 +5116,8 @@ __syscall size_t k_pipe_read_avail(struct k_pipe *pipe);
  *
  * @param pipe Address of the pipe.
  *
- * @retval a number n such that 0 <= n <= @ref k_pipe.size; the
- *         result is zero for unbuffered pipes.
+ * @retval n number of bytes that may be written to @a pipe (0 <= n <= @ref k_pipe.size)
+ * @retval 0 for unbuffered pipes.
  */
 __syscall size_t k_pipe_write_avail(struct k_pipe *pipe);
 
@@ -6180,7 +6181,8 @@ __syscall int k_float_enable(struct k_thread *thread, unsigned int options);
  *
  * @param thread ID of thread.
  * @param stats Pointer to struct to copy statistics into.
- * @return -EINVAL if null pointers, otherwise 0
+ * @retval 0 success
+ * @retval -EINVAL if null pointers
  */
 int k_thread_runtime_stats_get(k_tid_t thread,
 			       k_thread_runtime_stats_t *stats);
@@ -6189,7 +6191,8 @@ int k_thread_runtime_stats_get(k_tid_t thread,
  * @brief Get the runtime statistics of all threads
  *
  * @param stats Pointer to struct to copy statistics into.
- * @return -EINVAL if null pointers, otherwise 0
+ * @retval 0 success
+ * @retval -EINVAL if null pointers
  */
 int k_thread_runtime_stats_all_get(k_thread_runtime_stats_t *stats);
 
@@ -6198,7 +6201,8 @@ int k_thread_runtime_stats_all_get(k_thread_runtime_stats_t *stats);
  *
  * @param cpu The cpu number
  * @param stats Pointer to struct to copy statistics into.
- * @return -EINVAL if null pointers, otherwise 0
+ * @retval 0 success
+ * @retval -EINVAL if null pointers
  */
 int k_thread_runtime_stats_cpu_get(int cpu, k_thread_runtime_stats_t *stats);
 
@@ -6209,7 +6213,8 @@ int k_thread_runtime_stats_cpu_get(int cpu, k_thread_runtime_stats_t *stats);
  * thread.
  *
  * @param thread ID of thread
- * @return -EINVAL if invalid thread ID, otherwise 0
+ * @retval 0 success
+ * @retval -EINVAL invalid thread ID
  */
 int k_thread_runtime_stats_enable(k_tid_t thread);
 
@@ -6220,7 +6225,8 @@ int k_thread_runtime_stats_enable(k_tid_t thread);
  * thread.
  *
  * @param thread ID of thread
- * @return -EINVAL if invalid thread ID, otherwise 0
+ * @retval 0 success
+ * @retval -EINVAL invalid thread ID
  */
 int k_thread_runtime_stats_disable(k_tid_t thread);
 

--- a/include/zephyr/kernel/mm.h
+++ b/include/zephyr/kernel/mm.h
@@ -202,7 +202,7 @@ static inline void k_mem_unmap(void *addr, size_t size)
  * @param[in]  addr Region base address
  * @param[in]  size Region size
  * @param[in]  align What to align the address and size to
- * @retval offset between aligned_addr and addr
+ * @return offset between aligned_addr and addr
  */
 size_t k_mem_region_align(uintptr_t *aligned_addr, size_t *aligned_size,
 			  uintptr_t addr, size_t size, size_t align);

--- a/include/zephyr/kernel/mm/demand_paging.h
+++ b/include/zephyr/kernel/mm/demand_paging.h
@@ -330,8 +330,8 @@ void k_mem_paging_eviction_init(void);
  * @param pf Virtual address to obtain a storage location
  * @param [out] location storage location token
  * @param page_fault Whether this request was for a page fault
- * @return 0 Success
- * @return -ENOMEM Backing store is full
+ * @retval 0 Success
+ * @retval -ENOMEM Backing store is full
  */
 int k_mem_paging_backing_store_location_get(struct k_mem_page_frame *pf,
 					    uintptr_t *location,

--- a/include/zephyr/kernel/obj_core.h
+++ b/include/zephyr/kernel/obj_core.h
@@ -136,7 +136,7 @@ struct k_obj_core {
  * @param id A means to identify the object type
  * @param off Offset of object core within the structure
  *
- * @retval Pointer to initialized object type
+ * @return Pointer to initialized object type
  */
 struct k_obj_type *z_obj_type_init(struct k_obj_type *type,
 				   uint32_t id, size_t off);
@@ -149,8 +149,8 @@ struct k_obj_type *z_obj_type_init(struct k_obj_type *type,
  *
  * @param type_id  Type ID associated with object type
  *
+ * @retval ptr Pointer to object type if found
  * @retval NULL if object type not found
- * @retval Pointer to object type if found
  */
 struct k_obj_type *k_obj_type_find(uint32_t type_id);
 

--- a/include/zephyr/logging/log_ctrl.h
+++ b/include/zephyr/logging/log_ctrl.h
@@ -221,7 +221,8 @@ void log_backend_disable(struct log_backend const *const backend);
  *
  * @param[in] backend_name Name of the backend as defined by the LOG_BACKEND_DEFINE.
  *
- * @retval Pointer to the backend instance if found, NULL if backend is not found.
+ * @return Pointer to the backend instance if found
+ * @retval NULL if backend is not found.
  */
 const struct log_backend *log_backend_get_by_name(const char *backend_name);
 
@@ -229,7 +230,8 @@ const struct log_backend *log_backend_get_by_name(const char *backend_name);
  *
  * @param log_type Log format.
  *
- * @retval Pointer to the last backend that failed, NULL for success.
+ * @return Pointer to the last backend for which the operation failed.
+ * @retval NULL for success.
  */
 const struct log_backend *log_format_set_all_active_backends(size_t log_type);
 

--- a/include/zephyr/mem_mgmt/mem_attr.h
+++ b/include/zephyr/mem_mgmt/mem_attr.h
@@ -72,7 +72,7 @@ struct mem_attr_region_t {
  *
  * @param region Pointer to pointer to the list of memory regions.
  *
- * @retval Number of memory regions returned in the parameter.
+ * @return Number of memory regions returned in the parameter.
  */
 size_t mem_attr_get_regions(const struct mem_attr_region_t **region);
 

--- a/include/zephyr/mgmt/ec_host_cmd/backend.h
+++ b/include/zephyr/mgmt/ec_host_cmd/backend.h
@@ -116,21 +116,21 @@ struct ec_host_cmd_backend_api {
  *
  * @param dev Pointer to eSPI device instance.
  *
- * @retval The eSPI backend pointer.
+ * @return The eSPI backend pointer.
  */
 struct ec_host_cmd_backend *ec_host_cmd_backend_get_espi(const struct device *dev);
 
 /**
  * @brief Get the SHI NPCX Host Command backend pointer
  *
- * @retval the SHI NPCX backend pointer
+ * @return the SHI NPCX backend pointer
  */
 struct ec_host_cmd_backend *ec_host_cmd_backend_get_shi_npcx(void);
 
 /**
  * @brief Get the SHI ITE Host Command backend pointer
  *
- * @retval the SHI ITE backend pointer
+ * @return the SHI ITE backend pointer
  */
 struct ec_host_cmd_backend *ec_host_cmd_backend_get_shi_ite(void);
 
@@ -142,7 +142,7 @@ struct ec_host_cmd_backend *ec_host_cmd_backend_get_shi_ite(void);
  *
  * @param dev Pointer to UART device instance.
  *
- * @retval The UART backend pointer.
+ * @return The UART backend pointer.
  */
 struct ec_host_cmd_backend *ec_host_cmd_backend_get_uart(const struct device *dev);
 
@@ -154,7 +154,7 @@ struct ec_host_cmd_backend *ec_host_cmd_backend_get_uart(const struct device *de
  *
  * @param cs Chip select pin..
  *
- * @retval The SPI backend pointer.
+ * @return The SPI backend pointer.
  */
 struct ec_host_cmd_backend *ec_host_cmd_backend_get_spi(struct gpio_dt_spec *cs);
 

--- a/include/zephyr/mgmt/ec_host_cmd/ec_host_cmd.h
+++ b/include/zephyr/mgmt/ec_host_cmd/ec_host_cmd.h
@@ -319,7 +319,7 @@ void ec_host_cmd_set_user_cb(ec_host_cmd_user_cb_t cb, void *user_data);
  * It allows the application code to get inside information for any reason e.g.
  * the host command thread id.
  *
- * @retval A pointer to the main host command structure
+ * @return A pointer to the main host command structure
  */
 const struct ec_host_cmd *ec_host_cmd_get_hc(void);
 
@@ -354,7 +354,8 @@ bool ec_host_cmd_send_in_progress_ended(void);
  *
  * Saving status of Host Commands that send response data is not supported.
  *
- * @retval The final status or EC_HOST_CMD_UNAVAILABLE if not available.
+ * @return The final status of the last command
+ * @retval EC_HOST_CMD_UNAVAILABLE if not available.
  */
 enum ec_host_cmd_status ec_host_cmd_send_in_progress_status(void);
 

--- a/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt_client.h
+++ b/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt_client.h
@@ -135,8 +135,8 @@ void img_mgmt_client_init(struct img_mgmt_client *client, struct smp_client_obje
  * @param image_hash	Pointer to HASH for image must be SHA256 hash of entire upload
  *			if present (32 bytes). Use NULL when HASH from image is not available.
  *
- * @return 0 on success.
- * @return @ref mcumgr_err_t code on failure.
+ * @retval 0 success.
+ * @retval err @ref mcumgr_err_t code on failure.
  */
 int img_mgmt_client_upload_init(struct img_mgmt_client *client, size_t image_size,
 				uint32_t image_num, const char *image_hash);
@@ -149,8 +149,8 @@ int img_mgmt_client_upload_init(struct img_mgmt_client *client, size_t image_siz
  * @param length	Length of data
  * @param res_buf	Pointer for command response structure.
  *
- * @return 0 on success.
- * @return @ref mcumgr_err_t code on failure.
+ * @retval 0 success.
+ * @retval err @ref mcumgr_err_t code on failure.
  */
 int img_mgmt_client_upload(struct img_mgmt_client *client, const uint8_t *data, size_t length,
 			   struct mcumgr_image_upload *res_buf);
@@ -163,8 +163,8 @@ int img_mgmt_client_upload(struct img_mgmt_client *client, const uint8_t *data, 
  * @param confirm	Set false for test and true for confirmation.
  * @param res_buf	Pointer for command response structure.
  *
- * @return 0 on success.
- * @return @ref mcumgr_err_t code on failure.
+ * @retval 0 success.
+ * @retval err @ref mcumgr_err_t code on failure.
  */
 
 int img_mgmt_client_state_write(struct img_mgmt_client *client, char *hash, bool confirm,
@@ -176,8 +176,8 @@ int img_mgmt_client_state_write(struct img_mgmt_client *client, char *hash, bool
  * @param client	IMG mgmt client object
  * @param res_buf	Pointer for command response structure.
  *
- * @return 0 on success.
- * @return @ref mcumgr_err_t code on failure.
+ * @retval 0 success.
+ * @retval err @ref mcumgr_err_t code on failure.
  */
 int img_mgmt_client_state_read(struct img_mgmt_client *client, struct mcumgr_image_state *res_buf);
 
@@ -187,8 +187,8 @@ int img_mgmt_client_state_read(struct img_mgmt_client *client, struct mcumgr_ima
  * @param client	IMG mgmt client object
  * @param slot		Slot number
  *
- * @return 0 on success.
- * @return @ref mcumgr_err_t code on failure.
+ * @retval 0 success.
+ * @retval err @ref mcumgr_err_t code on failure.
  */
 
 int img_mgmt_client_erase(struct img_mgmt_client *client, uint32_t slot);

--- a/include/zephyr/mgmt/mcumgr/grp/os_mgmt/os_mgmt_client.h
+++ b/include/zephyr/mgmt/mcumgr/grp/os_mgmt/os_mgmt_client.h
@@ -47,8 +47,8 @@ void os_mgmt_client_init(struct os_mgmt_client *client, struct smp_client_object
  * @param echo_string Echo string
  * @param max_len Max length of @p echo_string
  *
- * @return 0 on success.
- * @return @ref mcumgr_err_t code on failure.
+ * @retval 0 success.
+ * @retval err @ref mcumgr_err_t code on failure.
  */
 int os_mgmt_client_echo(struct os_mgmt_client *client, const char *echo_string, size_t max_len);
 
@@ -57,8 +57,8 @@ int os_mgmt_client_echo(struct os_mgmt_client *client, const char *echo_string, 
  *
  * @param client OS mgmt client object
  *
- * @return 0 on success.
- * @return @ref mcumgr_err_t code on failure.
+ * @retval 0 success.
+ * @retval err @ref mcumgr_err_t code on failure.
  */
 int os_mgmt_client_reset(struct os_mgmt_client *client);
 

--- a/include/zephyr/mgmt/mcumgr/smp/smp_client.h
+++ b/include/zephyr/mgmt/mcumgr/smp/smp_client.h
@@ -55,8 +55,8 @@ int smp_client_object_init(struct smp_client_object *smp_client, int smp_type);
  * @param nb net_buf for response
  * @param user_data same user data that was provided as part of the request
  *
- * @return 0 on success.
- * @return @ref mcumgr_err_t code on failure.
+ * @retval 0 success.
+ * @retval err @ref mcumgr_err_t code on failure.
  */
 typedef int (*smp_client_res_fn)(struct net_buf *nb, void *user_data);
 
@@ -66,8 +66,8 @@ typedef int (*smp_client_res_fn)(struct net_buf *nb, void *user_data);
  * @param nb response net_buf
  * @param res_hdr Parsed SMP header
  *
- * @return 0 on success.
- * @return @ref mcumgr_err_t code on failure.
+ * @retval 0 success.
+ * @retval err @ref mcumgr_err_t code on failure.
  */
 int smp_client_single_response(struct net_buf *nb, const struct smp_hdr *res_hdr);
 
@@ -80,8 +80,8 @@ int smp_client_single_response(struct net_buf *nb, const struct smp_hdr *res_hdr
  * @param op SMP operation type
  * @param version SMP MCUmgr version
  *
- * @return      A newly-allocated buffer net_buf on success
- * @return	NULL on failure.
+ * @retval      net_buf Newly-allocated buffer net_buf
+ * @retval      NULL failure.
  */
 struct net_buf *smp_client_buf_allocation(struct smp_client_object *smp_client, uint16_t group,
 					  uint8_t command_id, uint8_t op,
@@ -103,8 +103,8 @@ void smp_client_buf_free(struct net_buf *nb);
  * @param timeout_in_sec	Timeout in seconds for send process. Client will retry transport
  *				based CONFIG_SMP_CMD_RETRY_TIME
  *
- * @return 0 on success.
- * @return @ref mcumgr_err_t code on failure.
+ * @retval 0 success.
+ * @retval err @ref mcumgr_err_t code on failure.
  */
 int smp_client_send_cmd(struct smp_client_object *smp_client, struct net_buf *nb,
 			smp_client_res_fn cb, void *user_data, int timeout_in_sec);

--- a/include/zephyr/mgmt/mcumgr/transport/smp_dummy.h
+++ b/include/zephyr/mgmt/mcumgr/transport/smp_dummy.h
@@ -60,14 +60,14 @@ void smp_dummy_add_data(void);
 /**
  * @brief Gets current send buffer position
  *
- * @retval Current send buffer position (in bytes)
+ * @return Current send buffer position (in bytes)
  */
 uint16_t smp_dummy_get_send_pos(void);
 
 /**
  * @brief Gets current receive buffer position
  *
- * @retval Current receive buffer position (in bytes)
+ * @return Current receive buffer position (in bytes)
  */
 uint16_t smp_dummy_get_receive_pos(void);
 

--- a/include/zephyr/mgmt/updatehub.h
+++ b/include/zephyr/mgmt/updatehub.h
@@ -50,11 +50,11 @@ __syscall void updatehub_autohandler(void);
 /**
  * @brief The UpdateHub probe verify if there is some update to be performed.
  *
- * @return UPDATEHUB_HAS_UPDATE has an update available.
- * @return UPDATEHUB_NO_UPDATE no update available.
- * @return UPDATEHUB_NETWORKING_ERROR fail to connect to the UpdateHub server.
- * @return UPDATEHUB_INCOMPATIBLE_HARDWARE if Incompatible hardware.
- * @return UPDATEHUB_METADATA_ERROR fail to parse or to encode the metadata.
+ * @retval UPDATEHUB_HAS_UPDATE an update is available.
+ * @retval UPDATEHUB_NO_UPDATE no update available.
+ * @retval UPDATEHUB_NETWORKING_ERROR failed to connect to the UpdateHub server.
+ * @retval UPDATEHUB_INCOMPATIBLE_HARDWARE incompatible hardware.
+ * @retval UPDATEHUB_METADATA_ERROR failed to parse or to encode the metadata.
  */
 __syscall enum updatehub_response updatehub_probe(void);
 
@@ -65,11 +65,11 @@ __syscall enum updatehub_response updatehub_probe(void);
  * be made, will perform the installation of the new image and the hardware
  * will rebooting.
  *
- * @return Return UPDATEHUB_OK if success
- * @return UPDATEHUB_NETWORKING_ERROR if fail to connect to the server.
- * @return UPDATEHUB_DOWNLOAD_ERROR fail while downloading the update package.
- * @return UPDATEHUB_INSTALL_ERROR fail while installing the update package.
- * @return UPDATEHUB_FLASH_INIT_ERROR fail to initialize the flash.
+ * @retval UPDATEHUB_OK success
+ * @retval UPDATEHUB_NETWORKING_ERROR failed to connect to the server.
+ * @retval UPDATEHUB_DOWNLOAD_ERROR failed while downloading the update package.
+ * @retval UPDATEHUB_INSTALL_ERROR failed while installing the update package.
+ * @retval UPDATEHUB_FLASH_INIT_ERROR failed to initialize the flash.
  */
 __syscall enum updatehub_response updatehub_update(void);
 
@@ -79,14 +79,16 @@ __syscall enum updatehub_response updatehub_update(void);
  * @details Must be used before the UpdateHub probe. It should be one of first
  * actions after reboot.
  *
- * @return Return 0 if success otherwise a negative 'errno' value.
+ * @retval 0 success
+ * @retval -errno negative error code
  */
 __syscall int updatehub_confirm(void);
 
 /**
  * @brief Request system to reboot.
  *
- * @return Return 0 if success otherwise a negative 'errno' value.
+ * @retval 0 success
+ * @retval -errno negative error code
  */
 __syscall int updatehub_reboot(void);
 

--- a/include/zephyr/modem/pipe.h
+++ b/include/zephyr/modem/pipe.h
@@ -130,7 +130,7 @@ void modem_pipe_attach(struct modem_pipe *pipe, modem_pipe_api_callback callback
  * @param buf Data to transmit
  * @param size Number of bytes to transmit
  *
- * @retval Number of bytes placed in pipe
+ * @return Number of bytes placed in pipe
  * @retval -EPERM if pipe is closed
  * @retval -errno code on error
  *
@@ -145,7 +145,7 @@ int modem_pipe_transmit(struct modem_pipe *pipe, const uint8_t *buf, size_t size
  * @param buf Destination for received data; must not be already in use in a modem module.
  * @param size Capacity of destination for received data
  *
- * @retval Number of bytes received from pipe
+ * @return Number of bytes received from pipe
  * @retval -EPERM if pipe is closed
  * @retval -errno code on error
  *

--- a/include/zephyr/modem/pipelink.h
+++ b/include/zephyr/modem/pipelink.h
@@ -81,7 +81,7 @@ bool modem_pipelink_is_connected(struct modem_pipelink *link);
 /**
  * @brief Get pipe from pipelink
  * @param link Pipelink instance
- * @retval Pointer to pipe if pipelink has been initialized
+ * @retval ptr Pointer to pipe if pipelink has been initialized
  * @retval NULL if pipelink has not been initialized
  */
 struct modem_pipe *modem_pipelink_get_pipe(struct modem_pipelink *link);

--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -812,8 +812,8 @@ int coap_remove_descriptive_block_option(struct coap_packet *cpkt);
  * @brief Check if BLOCK1 or BLOCK2 option has more flag set
  *
  * @param cpkt Packet to be checked.
- * @return true If more flag is set in BLOCK1 or BLOCK2
- * @return false If MORE flag is not set or BLOCK header not found.
+ * @retval true MORE flag is set in BLOCK1 or BLOCK2
+ * @retval false MORE flag is not set or BLOCK header not found.
  */
 bool coap_block_has_more(struct coap_packet *cpkt);
 

--- a/include/zephyr/net/coap_service.h
+++ b/include/zephyr/net/coap_service.h
@@ -222,9 +222,9 @@ int coap_service_stop(const struct coap_service *service);
  * @note This function is suitable for a @p service defined with @ref COAP_SERVICE_DEFINE.
  *
  * @param service Pointer to CoAP service
- * @retval 1 if the service is running
- * @retval 0 if the service is stopped
- * @retval negative in case of an error.
+ * @retval 1 the service is running
+ * @retval 0 the service is stopped
+ * @retval -errno negative error code in case of an error.
  */
 int coap_service_is_running(const struct coap_service *service);
 

--- a/include/zephyr/net/conn_mgr_connectivity.h
+++ b/include/zephyr/net/conn_mgr_connectivity.h
@@ -112,9 +112,9 @@ enum conn_mgr_if_flag {
  *
  * @param iface Pointer to network interface
  * @retval 0 on success.
- * @retval -ESHUTDOWN if the iface is not admin-up.
- * @retval -ENOTSUP if the iface does not have a connectivity implementation.
- * @retval implementation-specific status code otherwise.
+ * @retval -ESHUTDOWN the iface is not admin-up.
+ * @retval -ENOTSUP the iface does not have a connectivity implementation.
+ * @retval status implementation-specific status code otherwise.
  */
 int conn_mgr_if_connect(struct net_if *iface);
 
@@ -129,8 +129,8 @@ int conn_mgr_if_connect(struct net_if *iface);
  * @param iface Pointer to network interface
  *
  * @retval 0 on success.
- * @retval -ENOTSUP if the iface does not have a connectivity implementation.
- * @retval implementation-specific status code otherwise.
+ * @retval -ENOTSUP the iface does not have a connectivity implementation.
+ * @retval status implementation-specific status code otherwise.
  */
 int conn_mgr_if_disconnect(struct net_if *iface);
 
@@ -156,12 +156,12 @@ bool conn_mgr_if_is_bound(struct net_if *iface);
  *		  Some settings may affect multiple ifaces.
  * @param optval Pointer to the value to be assigned to the option.
  * @param optlen Length (in bytes) of the value to be assigned to the option.
- * @retval 0 if successful.
- * @retval -ENOTSUP if conn_mgr_if_set_opt not implemented by the iface.
- * @retval -ENOBUFS if optlen is too long.
- * @retval -EINVAL if NULL optval pointer provided.
- * @retval -ENOPROTOOPT if the optname is not recognized.
- * @retval implementation-specific error code otherwise.
+ * @retval 0 success.
+ * @retval -ENOTSUP conn_mgr_if_set_opt not implemented by the iface.
+ * @retval -ENOBUFS optlen is too long.
+ * @retval -EINVAL NULL optval pointer provided.
+ * @retval -ENOPROTOOPT the optname is not recognized.
+ * @retval status implementation-specific error code otherwise.
  */
 int conn_mgr_if_set_opt(struct net_if *iface, int optname, const void *optval, size_t optlen);
 
@@ -183,13 +183,13 @@ int conn_mgr_if_set_opt(struct net_if *iface, int optname, const void *optval, s
  *		 optlen will always be set to the total number of bytes written, regardless of
  *		 whether an error is returned, even if zero bytes were written.
  *
- * @retval 0 if successful.
- * @retval -ENOTSUP if conn_mgr_if_get_opt is not implemented by the iface.
- * @retval -ENOBUFS if retrieval buffer is too small.
- * @retval -EINVAL if invalid retrieval buffer length is provided, or if NULL optval or
+ * @retval 0 success.
+ * @retval -ENOTSUP conn_mgr_if_get_opt is not implemented by the iface.
+ * @retval -ENOBUFS retrieval buffer is too small.
+ * @retval -EINVAL invalid retrieval buffer length is provided, or if NULL optval or
  *		   optlen pointer provided.
- * @retval -ENOPROTOOPT if the optname is not recognized.
- * @retval implementation-specific error code otherwise.
+ * @retval -ENOPROTOOPT the optname is not recognized.
+ * @retval status implementation-specific error code otherwise.
  */
 int conn_mgr_if_get_opt(struct net_if *iface, int optname, void *optval, size_t *optlen);
 
@@ -217,8 +217,8 @@ bool conn_mgr_if_get_flag(struct net_if *iface, enum conn_mgr_if_flag flag);
  * @param flag - The flag to set.
  * @param value - Whether the flag should be enabled or disabled.
  * @retval 0 on success.
- * @retval -EINVAL if the flag does not exist.
- * @retval -ENOTSUP if the provided iface is not bound to a connectivity implementation.
+ * @retval -EINVAL the flag does not exist.
+ * @retval -ENOTSUP the provided iface is not bound to a connectivity implementation.
  */
 int conn_mgr_if_set_flag(struct net_if *iface, enum conn_mgr_if_flag flag, bool value);
 
@@ -244,7 +244,7 @@ int conn_mgr_if_get_timeout(struct net_if *iface);
  * @param timeout - The timeout value to set (in seconds).
  *		    Pass @ref CONN_MGR_IF_NO_TIMEOUT to disable the timeout.
  * @retval 0 on success.
- * @retval -ENOTSUP if the provided iface is not bound to a connectivity implementation.
+ * @retval -ENOTSUP the provided iface is not bound to a connectivity implementation.
  */
 int conn_mgr_if_set_timeout(struct net_if *iface, int timeout);
 

--- a/include/zephyr/net/dsa.h
+++ b/include/zephyr/net/dsa.h
@@ -201,8 +201,8 @@ struct dsa_api {
  * @param      iface      Master port
  * @param[in]  slave_num  Slave port number
  *
- * @return     network interface of the slave if successful
- * @return     NULL if slave port does not exist
+ * @retval     iface network interface of the slave port
+ * @retval     NULL slave port does not exist
  */
 struct net_if *dsa_get_slave_port(struct net_if *iface, int slave_num);
 

--- a/include/zephyr/net/ieee802154_radio.h
+++ b/include/zephyr/net/ieee802154_radio.h
@@ -1397,8 +1397,8 @@ struct ieee802154_attr_value {
  * driver's channel range or ranges.
  * @param value The pointer to the value struct provided by the user.
  *
- * @retval 0 if the attribute could be resolved
- * @retval -ENOENT if the attribute could not be resolved
+ * @retval 0 the attribute could be resolved
+ * @retval -ENOENT the attribute could not be resolved
  */
 static inline int ieee802154_attr_get_channel_page_and_range(
 	enum ieee802154_attr attr,

--- a/include/zephyr/net/net_context.h
+++ b/include/zephyr/net/net_context.h
@@ -1085,10 +1085,10 @@ int net_context_listen(struct net_context *context,
  *                   * >0: this function will wait the specified ms.
  * @param user_data  Data passed to the callback function.
  *
- * @return           0 on success.
- * @return           -EINVAL if an invalid parameter is passed as an argument.
- * @return           -ENOTSUP if the operation is not supported or implemented.
- * @return           -ETIMEDOUT if the connect operation times out.
+ * @retval           0 success.
+ * @retval           -EINVAL an invalid parameter is passed as an argument.
+ * @retval           -ENOTSUP the operation is not supported or implemented.
+ * @retval           -ETIMEDOUT the connect operation times out.
  */
 int net_context_connect(struct net_context *context,
 			const struct sockaddr *addr,
@@ -1384,8 +1384,8 @@ static inline void net_context_setup_pools(struct net_context *context,
  * @param local_port the port to check
  * @param local_addr the network address
  *
- * @return true if the port is bound
- * @return false if the port is not bound
+ * @retval true the port is bound
+ * @retval false the port is not bound
  */
 bool net_context_port_in_use(enum net_ip_protocol ip_proto,
 	uint16_t local_port, const struct sockaddr *local_addr);

--- a/include/zephyr/net/net_offload.h
+++ b/include/zephyr/net/net_offload.h
@@ -227,9 +227,9 @@ static inline int net_offload_listen(struct net_if *iface,
  *                   * >0: this function will wait the specified ms.
  * @param user_data  Data passed to the callback function.
  *
- * @return           0 on success.
- * @return           -EINVAL if an invalid parameter is passed as an argument.
- * @return           -ENOTSUP if the operation is not supported or implemented.
+ * @retval           0 success.
+ * @retval           -EINVAL an invalid parameter is passed as an argument.
+ * @retval           -ENOTSUP the operation is not supported or implemented.
  */
 static inline int net_offload_connect(struct net_if *iface,
 				      struct net_context *context,

--- a/include/zephyr/net/net_pkt.h
+++ b/include/zephyr/net/net_pkt.h
@@ -2076,7 +2076,7 @@ void net_pkt_trim_buffer(struct net_pkt *pkt);
  * @param length Number of bytes to be removed
  *
  * @retval 0       On success.
- * @retval -EINVAL If packet length is shorter than @a length.
+ * @retval -EINVAL packet length is shorter than @a length.
  */
 int net_pkt_remove_tail(struct net_pkt *pkt, size_t length);
 

--- a/include/zephyr/net/net_timeout.h
+++ b/include/zephyr/net/net_timeout.h
@@ -129,7 +129,7 @@ int64_t net_timeout_deadline(const struct net_timeout *timeout,
  * be calculated.  This should be recently captured value from
  * k_uptime_get_32().
  *
- * @retval 0 if the timeout has completed.
+ * @retval 0 the timeout has completed.
  * @retval positive the remaining duration of the timeout, in seconds.
  */
 uint32_t net_timeout_remaining(const struct net_timeout *timeout,
@@ -149,7 +149,7 @@ uint32_t net_timeout_remaining(const struct net_timeout *timeout,
  * be calculated.  This should be recently captured value from
  * k_uptime_get_32().
  *
- * @retval 0 if the timeout has completed
+ * @retval 0 the timeout has completed
  * @retval positive the maximum delay until the state of this timeout should
  * be re-evaluated, in milliseconds.
  */

--- a/include/zephyr/net/phy.h
+++ b/include/zephyr/net/phy.h
@@ -131,9 +131,9 @@ __subsystem struct ethphy_driver_api {
  * @param[in]  dev     PHY device structure
  * @param      speeds  OR'd link speeds to be advertised by the PHY
  *
- * @retval 0 If successful.
- * @retval -EIO If communication with PHY failed.
- * @retval -ENOTSUP If not supported.
+ * @retval 0 success.
+ * @retval -EIO communication with PHY failed.
+ * @retval -ENOTSUP not supported.
  */
 static inline int phy_configure_link(const struct device *dev,
 				     enum phy_link_speed speeds)
@@ -154,8 +154,8 @@ static inline int phy_configure_link(const struct device *dev,
  * @param[in]  dev    PHY device structure
  * @param      state  Pointer to receive PHY state
  *
- * @retval 0 If successful.
- * @retval -EIO If communication with PHY failed.
+ * @retval 0 success.
+ * @retval -EIO communication with PHY failed.
  */
 static inline int phy_get_link_state(const struct device *dev,
 				     struct phy_link_state *state)
@@ -177,8 +177,8 @@ static inline int phy_get_link_state(const struct device *dev,
  * @param      callback   Callback handler
  * @param      user_data  Pointer to data specified by user.
  *
- * @retval 0 If successful.
- * @retval -ENOTSUP If not supported.
+ * @retval 0 success.
+ * @retval -ENOTSUP not supported.
  */
 static inline int phy_link_callback_set(const struct device *dev,
 					phy_callback_t callback,
@@ -199,8 +199,8 @@ static inline int phy_link_callback_set(const struct device *dev,
  * @param[in]  reg_addr  Register address
  * @param      value     Pointer to receive read value
  *
- * @retval 0 If successful.
- * @retval -EIO If communication with PHY failed.
+ * @retval 0 success.
+ * @retval -EIO communication with PHY failed.
  */
 static inline int phy_read(const struct device *dev, uint16_t reg_addr,
 			   uint32_t *value)
@@ -220,8 +220,8 @@ static inline int phy_read(const struct device *dev, uint16_t reg_addr,
  * @param[in]  reg_addr  Register address
  * @param[in]  value     Value to write
  *
- * @retval 0 If successful.
- * @retval -EIO If communication with PHY failed.
+ * @retval 0 success.
+ * @retval -EIO communication with PHY failed.
  */
 static inline int phy_write(const struct device *dev, uint16_t reg_addr,
 			    uint32_t value)

--- a/include/zephyr/net/tftp.h
+++ b/include/zephyr/net/tftp.h
@@ -144,11 +144,11 @@ struct tftpc {
  * @param remote_file Name of the remote file to get.
  * @param mode        TFTP Client "mode" setting.
  *
- * @retval The size of data being received if the operation completed successfully.
+ * @return The size of data being received if the operation completed successfully.
  * @retval TFTPC_BUFFER_OVERFLOW if the file is larger than the user buffer.
  * @retval TFTPC_REMOTE_ERROR if the server failed to process our request.
  * @retval TFTPC_RETRIES_EXHAUSTED if the client timed out waiting for server.
- * @retval -EINVAL if `client` is NULL.
+ * @retval -EINVAL `client` is NULL.
  *
  * @note This function blocks until the transfer is completed or network error happens. The
  *       integrity of the `client` structure must be ensured until the function returns.
@@ -165,10 +165,10 @@ int tftp_get(struct tftpc *client,
  * @param user_buf    Data buffer containing the data to put.
  * @param user_buf_size Length of the data to put.
  *
- * @retval The size of data being sent if the operation completed successfully.
+ * @return The size of data being sent if the operation completed successfully.
  * @retval TFTPC_REMOTE_ERROR if the server failed to process our request.
  * @retval TFTPC_RETRIES_EXHAUSTED if the client timed out waiting for server.
- * @retval -EINVAL if `client` or `user_buf` is NULL or if `user_buf_size` is zero.
+ * @retval -EINVAL `client` or `user_buf` is NULL or if `user_buf_size` is zero.
  *
  * @note This function blocks until the transfer is completed or network error happens. The
  *       integrity of the `client` structure must be ensured until the function returns.

--- a/include/zephyr/net/wifi_nm.h
+++ b/include/zephyr/net/wifi_nm.h
@@ -125,10 +125,10 @@ bool wifi_nm_iface_is_sap(struct net_if *iface);
  * @param nm Pointer to Network manager instance
  * @param iface Managed interface
  *
- * @retval 0 If successful.
- * @retval -EINVAL If invalid parameters were passed.
- * @retval -ENOTSUP If the interface is not a Wi-Fi interface.
- * @retval -ENOMEM If the maximum number of managed interfaces has been reached.
+ * @retval 0 success.
+ * @retval -EINVAL invalid parameters were passed.
+ * @retval -ENOTSUP the interface is not a Wi-Fi interface.
+ * @retval -ENOMEM the maximum number of managed interfaces has been reached.
  */
 int wifi_nm_register_mgd_iface(struct wifi_nm_instance *nm, struct net_if *iface);
 
@@ -139,10 +139,10 @@ int wifi_nm_register_mgd_iface(struct wifi_nm_instance *nm, struct net_if *iface
  * @param type Wi-Fi type
  * @param iface Managed interface
  *
- * @retval 0 If successful.
- * @retval -EINVAL If invalid parameters were passed.
- * @retval -ENOTSUP If the interface is not a Wi-Fi interface.
- * @retval -ENOMEM If the maximum number of managed interfaces has been reached.
+ * @retval 0 success.
+ * @retval -EINVAL invalid parameters were passed.
+ * @retval -ENOTSUP the interface is not a Wi-Fi interface.
+ * @retval -ENOMEM the maximum number of managed interfaces has been reached.
  */
 int wifi_nm_register_mgd_type_iface(struct wifi_nm_instance *nm,
 		enum wifi_nm_iface_type type, struct net_if *iface);

--- a/include/zephyr/pm/device.h
+++ b/include/zephyr/pm/device.h
@@ -114,7 +114,7 @@ enum pm_device_action {
  *
  * @retval 0 If successful.
  * @retval -ENOTSUP If the requested action is not supported.
- * @retval Errno Other negative errno on failure.
+ * @retval -errno Other negative errno on failure.
  */
 typedef int (*pm_device_action_cb_t)(const struct device *dev,
 				     enum pm_device_action action);
@@ -422,7 +422,7 @@ const char *pm_device_state_str(enum pm_device_state state);
  * @retval -EBUSY If device is changing its state.
  * @retval -ENOSYS If device does not support PM.
  * @retval -EPERM If device has power state locked.
- * @retval Errno Other negative errno on failure.
+ * @retval -errno Other negative errno on failure.
  */
 int pm_device_action_run(const struct device *dev,
 		enum pm_device_action action);

--- a/include/zephyr/posix/pthread.h
+++ b/include/zephyr/posix/pthread.h
@@ -488,7 +488,7 @@ void __z_pthread_cleanup_pop(int execute);
  * @retval 0 Success
  * @retval ESRCH Thread does not exist
  * @retval EINVAL Name buffer is NULL
- * @retval Negative value if kernel function error
+ * @retval -errno other negative value if kernel function error
  *
  */
 int pthread_setname_np(pthread_t thread, const char *name);
@@ -506,7 +506,7 @@ int pthread_setname_np(pthread_t thread, const char *name);
  * @retval 0 Success
  * @retval ESRCH Thread does not exist
  * @retval EINVAL Name buffer is NULL
- * @retval Negative value if kernel function error
+ * @retval -errno other negative value if kernel function error
  */
 int pthread_getname_np(pthread_t thread, char *name, size_t len);
 

--- a/include/zephyr/rtio/rtio.h
+++ b/include/zephyr/rtio/rtio.h
@@ -375,8 +375,8 @@ extern struct k_mem_partition rtio_partition;
  * @brief Get the mempool block size of the RTIO context
  *
  * @param[in] r The RTIO context
- * @return The size of each block in the context's mempool
- * @return 0 if the context doesn't have a mempool
+ * @retval size The size of each block in the context's mempool
+ * @retval 0 the context doesn't have a mempool
  */
 static inline size_t rtio_mempool_block_size(const struct rtio *r)
 {
@@ -847,8 +847,8 @@ static inline uint32_t rtio_sqe_acquirable(struct rtio *r)
  *
  * @param iodev_sqe Submission queue entry
  *
- * @retval NULL if current sqe is last in transaction
- * @retval struct rtio_sqe * if available
+ * @return Next submission queue entry if available
+ * @retval NULL current sqe is last in transaction
  */
 static inline struct rtio_iodev_sqe *rtio_txn_next(const struct rtio_iodev_sqe *iodev_sqe)
 {
@@ -859,14 +859,13 @@ static inline struct rtio_iodev_sqe *rtio_txn_next(const struct rtio_iodev_sqe *
 	}
 }
 
-
 /**
  * @brief Get the next sqe in the chain
  *
  * @param iodev_sqe Submission queue entry
  *
- * @retval NULL if current sqe is last in chain
- * @retval struct rtio_sqe * if available
+ * @return Next submission queue entry
+ * @retval NULL current sqe is last in chain
  */
 static inline struct rtio_iodev_sqe *rtio_chain_next(const struct rtio_iodev_sqe *iodev_sqe)
 {
@@ -882,8 +881,8 @@ static inline struct rtio_iodev_sqe *rtio_chain_next(const struct rtio_iodev_sqe
  *
  * @param iodev_sqe Submission queue entry
  *
- * @retval NULL if current sqe is last in chain
- * @retval struct rtio_iodev_sqe * if available
+ * @return Next submission queue entry if available
+ * @retval NULL current sqe is last in chain
  */
 static inline struct rtio_iodev_sqe *rtio_iodev_sqe_next(const struct rtio_iodev_sqe *iodev_sqe)
 {
@@ -1060,9 +1059,9 @@ static inline uint32_t rtio_cqe_compute_flags(struct rtio_iodev_sqe *iodev_sqe)
  * @param[in] cqe The CQE handling the event.
  * @param[out] buff Pointer to the mempool buffer
  * @param[out] buff_len Length of the allocated buffer
- * @return 0 on success
- * @return -EINVAL if the buffer wasn't allocated for this cqe
- * @return -ENOTSUP if memory blocks are disabled
+ * @retval 0 success
+ * @retval -EINVAL the buffer wasn't allocated for this cqe
+ * @retval -ENOTSUP memory blocks are disabled
  */
 __syscall int rtio_cqe_get_mempool_buffer(const struct rtio *r, struct rtio_cqe *cqe,
 					  uint8_t **buff, uint32_t *buff_len);
@@ -1173,8 +1172,8 @@ static inline void rtio_cqe_submit(struct rtio *r, int result, void *userdata, u
  * @param[out] buf        Where to store the pointer to the buffer
  * @param[out] buf_len    Where to store the size of the buffer
  *
- * @return 0 if @p buf and @p buf_len were successfully filled
- * @return -ENOMEM Not enough memory for @p min_buf_len
+ * @retval 0 @p buf and @p buf_len were successfully filled
+ * @retval -ENOMEM Not enough memory for @p min_buf_len
  */
 static inline int rtio_sqe_rx_buf(const struct rtio_iodev_sqe *iodev_sqe, uint32_t min_buf_len,
 				  uint32_t max_buf_len, uint8_t **buf, uint32_t *buf_len)
@@ -1270,8 +1269,8 @@ static inline void rtio_access_grant(struct rtio *r, struct k_thread *t)
  * result.
  *
  * @param[in] sqe The SQE to cancel
- * @return 0 if the SQE was flagged for cancellation
- * @return <0 on error
+ * @retval 0 the SQE was flagged for cancellation
+ * @retval -errno negative error code
  */
 __syscall int rtio_sqe_cancel(struct rtio_sqe *sqe);
 

--- a/include/zephyr/rtio/work.h
+++ b/include/zephyr/rtio/work.h
@@ -50,8 +50,8 @@ struct rtio_work_req {
  * @details This allocation utilizes its internal memory slab with
  * pre-allocated elements.
  *
- * @return Pointer to allocated item if successful.
- * @return NULL if allocation failed.
+ * @retval ptr Pointer to allocated item.
+ * @retval NULL Allocation failed.
  */
 struct rtio_work_req *rtio_work_req_alloc(void);
 

--- a/include/zephyr/settings/settings.h
+++ b/include/zephyr/settings/settings.h
@@ -610,12 +610,13 @@ int settings_runtime_commit(const char *name);
  * Get the storage instance used by zephyr.
  *
  * The type of storage object instance depends on the settings backend used.
- * It might pointer to: `struct nvs_fs`, `struct fcb` or string witch file name
+ * It might pointer to: `struct nvs_fs`, `struct fcb` or string which file name
  * depends on settings backend type used.
  *
- * @retval Pointer to which reference to the storage object can be stored.
+ * @param[out] storage Pointer to which reference to the storage object can be stored.
  *
- * @retval 0 on success, negative error code on failure.
+ * @retval 0 success.
+ * @retval -errno negative error code on failure.
  */
 int settings_storage_get(void **storage);
 

--- a/include/zephyr/shell/shell.h
+++ b/include/zephyr/shell/shell.h
@@ -1149,8 +1149,8 @@ void shell_process(const struct shell *sh);
  * @param[in] sh	Pointer to the shell instance.
  * @param[in] prompt	New shell prompt.
  *
- * @return 0		Success.
- * @return -EINVAL	Pointer to new prompt is not correct.
+ * @retval 0		Success.
+ * @retval -EINVAL	Pointer to new prompt is not correct.
  */
 int shell_prompt_change(const struct shell *sh, const char *prompt);
 
@@ -1298,7 +1298,7 @@ int shell_mode_delete_set(const struct shell *sh, bool val);
  *
  * @param[in] sh Pointer to the shell instance
  *
- * @retval return value of previous command
+ * @return the return value of the most recently executed shell command
  */
 int shell_get_return_value(const struct shell *sh);
 

--- a/include/zephyr/shell/shell_backend.h
+++ b/include/zephyr/shell/shell_backend.h
@@ -50,7 +50,8 @@ static inline int shell_backend_count_get(void)
  *
  * @param[in] backend_name Name of the backend as defined by the SHELL_DEFINE.
  *
- * @retval Pointer to the backend instance if found, NULL if backend is not found.
+ * @retval ptr Pointer to the backend instance if found
+ * @retval NULL if backend is not found.
  */
 const struct shell *shell_backend_get_by_name(const char *backend_name);
 

--- a/include/zephyr/sip_svc/sip_svc.h
+++ b/include/zephyr/sip_svc/sip_svc.h
@@ -149,7 +149,7 @@ int sip_svc_close(void *ctrl, uint32_t c_token, struct sip_svc_request *pre_clos
  * @param cb Callback. SMC/SVC return value will be passed to client via
  *           context in struct sip_svc_response format in callback.
  *
- * @retval transaction id on success.
+ * @retval trans_id transaction id on success.
  * @retval -EINVAL invalid arguments.
  * @retval -EOPNOTSUPP invalid command id or function id.
  * @retval -ESRCH invalid client state.
@@ -170,7 +170,7 @@ int sip_svc_send(void *ctrl, uint32_t c_token, struct sip_svc_request *req, sip_
  * @param ctrl Pointer to controller instance which provides ARM SiP service.
  * @param c_token Client's token
  *
- * @retval Address pointer to the client private data.
+ * @return Address pointer to the client private data.
  * @retval NULL invalid arguments and failure to get lock.
  */
 void *sip_svc_get_priv_data(void *ctrl, uint32_t c_token);
@@ -180,7 +180,7 @@ void *sip_svc_get_priv_data(void *ctrl, uint32_t c_token);
  *
  * @param method Pointer to controller instance which provides ARM SiP service.
  *
- * @retval Valid pointer.
+ * @retval ptr Valid pointer.
  * @retval NULL invalid arguments and on providing unsupported method name.
  */
 void *sip_svc_get_controller(char *method);

--- a/include/zephyr/sys/cbprintf.h
+++ b/include/zephyr/sys/cbprintf.h
@@ -511,7 +511,7 @@ int cbvprintf_package(void *packaged,
  *
  * @param strl_len Number of elements in @p strl array.
  *
- * @retval Positive output package size.
+ * @return Positive output package size.
  * @retval -ENOSPC if @p packaged was not null and the space required to store
  * exceed @p len.
  */
@@ -571,7 +571,7 @@ static inline int z_cbprintf_cpy(const void *buf, size_t len, void *ctx)
  *
  * @param strl_len Number of elements in @p strl array.
  *
- * @retval Positive Output package size.
+ * @return Positive output package size.
  * @retval -ENOSPC if @p packaged was not null and the space required to store
  * exceed @p len.
  */

--- a/include/zephyr/sys/device_mmio.h
+++ b/include/zephyr/sys/device_mmio.h
@@ -236,7 +236,7 @@ struct z_device_mmio_rom {
  * be used in this case.
  *
  * @param dev device instance object
- * @retval struct device_mmio_rom * pointer to storage location
+ * @return pointer to storage location
  */
 #define DEVICE_MMIO_ROM_PTR(dev) \
 	((struct z_device_mmio_rom *)((dev)->config))
@@ -430,7 +430,7 @@ struct z_device_mmio_rom {
  *
  * @param dev device instance object
  * @param name Member name within config
- * @retval struct device_mmio_rom * pointer to storage location
+ * @return pointer to storage location
  */
 #define DEVICE_MMIO_NAMED_ROM_PTR(dev, name) (&(DEV_CFG(dev)->name))
 

--- a/include/zephyr/sys/hash_map.h
+++ b/include/zephyr/sys/hash_map.h
@@ -307,11 +307,11 @@ static inline size_t sys_hashmap_num_buckets(const struct sys_hashmap *map)
  * as part of the load factor when growing the hash table.
  *
  * @param map Hashmap to examine
- * @param grow true if an entry is to be added. false if an entry has been removed
+ * @param grow true if an entry is to be added, false if an entry has been removed
  * @param num_reserved the number of reserved entries
  * @param[out] new_num_buckets variable Hashmap size
- * @return true if the Hashmap should be rehashed
- * @return false if the Hashmap should not be rehashed
+ * @retval true the Hashmap should be rehashed
+ * @retval false the Hashmap should not be rehashed
  */
 static inline bool sys_hashmap_should_rehash(const struct sys_hashmap *map, bool grow,
 					     size_t num_reserved, size_t *new_num_buckets)

--- a/include/zephyr/sys/hash_map_api.h
+++ b/include/zephyr/sys/hash_map_api.h
@@ -62,8 +62,8 @@ struct sys_hashmap_iterator {
  * @brief Check if a Hashmap iterator has a next entry
  *
  * @param it Hashmap iterator
- * @return true if there is a next entry
- * @return false if there is no next entry
+ * @retval true There is a next entry
+ * @retval false There is no next entry
  */
 static inline bool sys_hashmap_iterator_has_next(const struct sys_hashmap_iterator *it)
 {

--- a/include/zephyr/sys/internal/kobject_internal.h
+++ b/include/zephyr/sys/internal/kobject_internal.h
@@ -113,9 +113,9 @@ static inline void k_object_init(const void *obj)
  *
  * @param align Required memory alignment for the allocated object
  * @param size Size of the allocated object
- * @return NULL on insufficient memory
- * @return A pointer to the associated k_object that is installed in the
+ * @retval ptr A pointer to the associated k_object that is installed in the
  *	kernel object tables
+ * @retval NULL insufficient memory
  *
  * @note This is an internal API. Do not use unless you are extending
  *       functionality in the Zephyr tree.
@@ -137,9 +137,9 @@ struct k_object *k_object_create_dynamic_aligned(size_t align, size_t size);
  * in the returned k_object's 'name' member) to k_object_free().
  *
  * @param size Size of the allocated object
- * @return NULL on insufficient memory
- * @return A pointer to the associated k_object that is installed in the
+ * @retval ptr A pointer to the associated k_object that is installed in the
  *	kernel object tables
+ * @retval NULL insufficient memory
  *
  * @note This is an internal API. Do not use unless you are extending
  *       functionality in the Zephyr tree.

--- a/include/zephyr/sys/ring_buffer.h
+++ b/include/zephyr/sys/ring_buffer.h
@@ -326,7 +326,7 @@ int ring_buf_put_finish(struct ring_buf *buf, uint32_t size);
  * @param data Address of data.
  * @param size Data size (in bytes).
  *
- * @retval Number of bytes written.
+ * @return Number of bytes written.
  */
 uint32_t ring_buf_put(struct ring_buf *buf, const uint8_t *data, uint32_t size);
 
@@ -400,7 +400,7 @@ int ring_buf_get_finish(struct ring_buf *buf, uint32_t size);
  * @param data Address of the output buffer. Can be NULL to discard data.
  * @param size Data size (in bytes).
  *
- * @retval Number of bytes written to the output buffer.
+ * @return Number of bytes written to the output buffer.
  */
 uint32_t ring_buf_get(struct ring_buf *buf, uint8_t *data, uint32_t size);
 
@@ -428,7 +428,7 @@ uint32_t ring_buf_get(struct ring_buf *buf, uint8_t *data, uint32_t size);
  * @param data Address of the output buffer. Cannot be NULL.
  * @param size Data size (in bytes).
  *
- * @retval Number of bytes written to the output buffer.
+ * @return Number of bytes written to the output buffer.
  */
 uint32_t ring_buf_peek(struct ring_buf *buf, uint8_t *data, uint32_t size);
 

--- a/include/zephyr/sys/spsc_pbuf.h
+++ b/include/zephyr/sys/spsc_pbuf.h
@@ -140,7 +140,7 @@ static inline uint32_t spsc_pbuf_capacity(struct spsc_pbuf *pb)
  *				bytes of data (one is reserved for written
  *				messages length).
  * @param flags			Option flags. See @ref SPSC_PBUF_FLAGS.
- * @retval struct spsc_pbuf*	Pointer to the created buffer. The pointer
+ * @retval "struct spsc_pbuf*"	Pointer to the created buffer. The pointer
  *				points to the same address as buf.
  * @retval NULL			Invalid buffer alignment.
  */
@@ -155,9 +155,10 @@ struct spsc_pbuf *spsc_pbuf_init(void *buf, size_t blen, uint32_t flags);
  * @param buf	Pointer to the data to be written to the buffer.
  * @param len	Number of bytes to be written to the buffer. Must be positive
  *		but less than @ref SPSC_PBUF_MAX_LEN.
- * @retval int	Number of bytes written, negative error code on fail.
- *		-EINVAL, if len == 0.
- *		-ENOMEM, if len is bigger than the buffer can fit.
+ * @return	Number of bytes written.
+ * @retval 	-EINVAL if len == 0.
+ * @retval 	-ENOMEM if len is bigger than the buffer can fit.
+ * @retval 	-errno other negative error code on fail.
  */
 int spsc_pbuf_write(struct spsc_pbuf *pb, const char *buf, uint16_t len);
 
@@ -235,8 +236,8 @@ int spsc_pbuf_read(struct spsc_pbuf *pb, char *buf, uint16_t len);
  * @param[in,out] buf	A location where claimed packet address is written.
  *                      It is 32 bit word aligned and points to the continuous memory.
  *
+ * @return Length of the claimed packet.
  * @retval 0 No packets in the buffer.
- * @retval positive packet length.
  */
 uint16_t spsc_pbuf_claim(struct spsc_pbuf *pb, char **buf);
 

--- a/include/zephyr/sys/timeutil.h
+++ b/include/zephyr/sys/timeutil.h
@@ -180,9 +180,9 @@ struct timeutil_sync_state {
  * strictly after the base instant in both the reference and local
  * time scales.
  *
- * @retval 0 if installation succeeded in providing a new base
- * @retval 1 if installation provided a new latest instant
- * @retval -EINVAL if the new instant is not compatible with the base instant
+ * @retval 0 installation succeeded in providing a new base
+ * @retval 1 installation provided a new latest instant
+ * @retval -EINVAL the new instant is not compatible with the base instant
  */
 int timeutil_sync_state_update(struct timeutil_sync_state *tsp,
 			       const struct timeutil_sync_instant *inst);
@@ -208,8 +208,8 @@ int timeutil_sync_state_update(struct timeutil_sync_state *tsp,
  * between reference and local timescale instants.  Setting the base
  * clears the captured latest value.
  *
- * @return 0 if skew was updated
- * @return -EINVAL if skew was not valid
+ * @retval 0 skew was updated
+ * @retval -EINVAL skew was not valid
  */
 int timeutil_sync_state_set_skew(struct timeutil_sync_state *tsp, float skew,
 				 const struct timeutil_sync_instant *base);
@@ -244,8 +244,8 @@ float timeutil_sync_estimate_skew(const struct timeutil_sync_state *tsp);
  * produces an error.  If interpolation fails the referenced object is
  * not modified.
  *
- * @retval 0 if interpolated using a skew of 1
- * @retval 1 if interpolated using a skew not equal to 1
+ * @retval 0 interpolated using a skew of 1
+ * @retval 1 interpolated using a skew not equal to 1
  * @retval -EINVAL
  *   * the times synchronization state is not adequately initialized
  *   * @p refp is null
@@ -269,8 +269,8 @@ int timeutil_sync_ref_from_local(const struct timeutil_sync_state *tsp,
  * time 0 is provided without error.  If interpolation fails the
  * referenced object is not modified.
  *
- * @retval 0 if successful with a skew of 1
- * @retval 1 if successful with a skew not equal to 1
+ * @retval 0 successful with a skew of 1
+ * @retval 1 successful with a skew not equal to 1
  * @retval -EINVAL
  *   * the time synchronization state is not adequately initialized
  *   * @p refp is null
@@ -293,8 +293,8 @@ int timeutil_sync_local_from_ref(const struct timeutil_sync_state *tsp,
  * representation; this represents a clock running at less than 1/3
  * its nominal rate.
  *
- * @return skew error represented as parts-per-billion, or INT32_MIN
- * if the skew cannot be represented in the return type.
+ * @retval skew_err skew error represented as parts-per-billion
+ * @retval INT32_MIN the skew cannot be represented in the return type.
  */
 int32_t timeutil_sync_skew_to_ppb(float skew);
 

--- a/include/zephyr/sys_clock.h
+++ b/include/zephyr/sys_clock.h
@@ -229,7 +229,7 @@ typedef struct { uint64_t tick; } k_timepoint_t;
  *
  * @param timeout Timeout value relative to current time (may also be
  *                `K_FOREVER` or `K_NO_WAIT`).
- * @retval Timepoint value corresponding to given timeout
+ * @return Timepoint value corresponding to given timeout
  *
  * @see sys_timepoint_timeout()
  * @see sys_timepoint_expired()
@@ -245,7 +245,7 @@ k_timepoint_t sys_timepoint_calc(k_timeout_t timeout);
  * `K_FOREVER` is returned.
  *
  * @param timepoint Timepoint for which a timeout value is wanted.
- * @retval Corresponding timeout value.
+ * @return Corresponding timeout value.
  *
  * @see sys_timepoint_calc()
  */

--- a/include/zephyr/usb_c/usbc.h
+++ b/include/zephyr/usb_c/usbc.h
@@ -374,7 +374,7 @@ void usbc_set_dpm_data(const struct device *dev, void *dpm_data);
  *
  * @param dev Runtime device structure
  *
- * @retval pointer to dpm data that was set with usbc_set_dpm_data
+ * @return pointer to dpm data that was set with usbc_set_dpm_data()
  * @retval NULL if dpm data was not set
  */
 void *usbc_get_dpm_data(const struct device *dev);

--- a/kernel/include/kernel_arch_interface.h
+++ b/kernel/include/kernel_arch_interface.h
@@ -525,7 +525,7 @@ enum arch_page_location arch_page_location_get(void *addr, uintptr_t *location);
  *                   ARCH_DATA_PAGE_LOADED state. This is not touched if
  *                   ARCH_DATA_PAGE_NOT_MAPPED.
  * @param clear_accessed Whether to clear ARCH_DATA_PAGE_ACCESSED state
- * @retval Value with ARCH_DATA_PAGE_* bits set reflecting the data page
+ * @return Value with ARCH_DATA_PAGE_* bits set reflecting the data page
  *         configuration
  */
 uintptr_t arch_page_info_get(void *addr, uintptr_t *location,

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -235,8 +235,8 @@ static inline bool z_sched_wake_all(_wait_q_t *wait_q, int swap_retval,
  *                indefinitely.
  * @param data Storage location for data pointer set when thread was woken up.
  *             May be NULL if not used.
- * @retval Return value set by whatever woke us up, or -EAGAIN if the timeout
- *         expired without being woken up.
+ * @return Return value set by whatever woke us up
+ * @retval -EAGAIN if the timeout expired without being woken up.
  */
 int z_sched_wait(struct k_spinlock *lock, k_spinlock_key_t key,
 		 _wait_q_t *wait_q, k_timeout_t timeout, void **data);

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -380,7 +380,7 @@ static int submit_to_queue_locked(struct k_work *work,
  * @param queuep pointer to a queue reference.
  * @param work the work structure to be submitted
  *
- * @retval see submit_to_queue_locked()
+ * @return see submit_to_queue_locked()
  */
 int z_work_submit_to_queue(struct k_work_q *queue,
 		  struct k_work *work)

--- a/samples/bluetooth/cap_acceptor/src/cap_acceptor.h
+++ b/samples/bluetooth/cap_acceptor/src/cap_acceptor.h
@@ -43,7 +43,7 @@ int init_cap_acceptor_unicast(struct peer_config *peer);
  *
  * @param dir Audio direction of the stream to allocate
  *
- * @retval Pointer to the allocated CAP stream
+ * @retval ptr Pointer to the allocated CAP stream
  * @retval NULL if no more CAP streams for the @p dir could be allocated
  */
 struct bt_cap_stream *stream_alloc(enum bt_audio_dir dir);

--- a/soc/intel/intel_adsp/common/include/intel_adsp_hda.h
+++ b/soc/intel/intel_adsp/common/include/intel_adsp_hda.h
@@ -419,7 +419,7 @@ static inline void intel_adsp_hda_set_buffer_segment_ptr(uint32_t base, uint32_t
  * @param regblock_size Register block size
  * @param sid Stream ID
  *
- * @retval buffer segment ptr
+ * @return buffer segment ptr
  */
 static inline uint32_t intel_adsp_hda_get_buffer_segment_ptr(uint32_t base, uint32_t regblock_size,
 							     uint32_t sid)
@@ -500,7 +500,7 @@ static inline void intel_adsp_hda_clear_buffer_interrupt(uint32_t base, uint32_t
  * @param regblock_size Register block size
  * @param sid Stream ID
  *
- * @retval interrupt status
+ * @return interrupt status
  */
 static inline uint32_t intel_adsp_hda_check_buffer_interrupt(uint32_t base, uint32_t regblock_size,
 							     uint32_t sid)

--- a/soc/nuvoton/npcx/common/soc_gpio.h
+++ b/soc/nuvoton/npcx/common/soc_gpio.h
@@ -21,7 +21,7 @@ extern "C" {
  *
  * @param port GPIO device index
  *
- * @retval Pointer to structure device
+ * @retval ptr Pointer to structure device
  * @retval NULL Invalid parameter of GPIO port index
  */
 const struct device *npcx_get_gpio_dev(int port);

--- a/subsys/bluetooth/audio/ccid_internal.h
+++ b/subsys/bluetooth/audio/ccid_internal.h
@@ -31,8 +31,8 @@ uint8_t bt_ccid_get_value(void);
  *
  * @param ccid The CCID the search for
  *
+ * @retval ptr A pointer to a GATT attribute if found
  * @retval NULL if none was found
- * @retval A pointer to a GATT attribute if found
  */
 const struct bt_gatt_attr *bt_ccid_find_attr(uint8_t ccid);
 

--- a/subsys/fs/ext2/ext2_bitmap.h
+++ b/subsys/fs/ext2/ext2_bitmap.h
@@ -57,7 +57,7 @@ int32_t ext2_bitmap_find_free(uint8_t *bm, uint32_t size);
  * @param bm Pointer to bitmap
  * @param size Size of bitmap in bits
  *
- * @retval Number of set bits in bitmap;
+ * @return Number of set bits in bitmap;
  */
 uint32_t ext2_bitmap_count_set(uint8_t *bm, uint32_t size);
 

--- a/subsys/net/lib/dns/dns_cache.h
+++ b/subsys/net/lib/dns/dns_cache.h
@@ -51,7 +51,7 @@ struct dns_cache {
  *
  * @param cache Cache to be flushed
  * @retval 0 on success
- * @retval On error, a negative value is returned.
+ * @retval -errno On error, a negative value is returned.
  */
 int dns_cache_flush(struct dns_cache *cache);
 
@@ -66,7 +66,7 @@ int dns_cache_flush(struct dns_cache *cache);
  * @param ttl Time to live for the entry in seconds. This usually represents
  * the TTL of the RR.
  * @retval 0 on success
- * @retval On error, a negative value is returned.
+ * @retval -errno On error, a negative value is returned.
  */
 int dns_cache_add(struct dns_cache *cache, char const *query, struct dns_addrinfo const *addrinfo,
 		  uint32_t ttl);
@@ -77,7 +77,7 @@ int dns_cache_add(struct dns_cache *cache, char const *query, struct dns_addrinf
  * @param cache Cache where the entries should be removed.
  * @param query Query which should be searched for.
  * @retval 0 on success
- * @retval On error, a negative value is returned.
+ * @retval -errno On error, a negative value is returned.
  */
 int dns_cache_remove(struct dns_cache *cache, char const *query);
 
@@ -90,7 +90,7 @@ int dns_cache_remove(struct dns_cache *cache, char const *query);
  * @param addrinfo_array_len Array size of the dns_addrinfo array
  * @retval on success the amount of dns_addrinfo written into the addrinfo array will be returned.
  * A cache miss will therefore return a 0.
- * @retval On error a negative value is returned.
+ * @retval -errno On error a negative value is returned.
  * -ENOSR means there was not enough space in the addrinfo array to accommodate all cache hits the
  * array will however be filled with valid data.
  */

--- a/subsys/net/lib/dns/dns_pack.h
+++ b/subsys/net/lib/dns/dns_pack.h
@@ -378,7 +378,7 @@ int dns_unpack_response_header(struct dns_msg_t *msg, int src_id);
  * @param id Transaction Identifier
  * @param qtype Query type: AA, AAAA. See enum dns_rr_type
  * @retval 0 on success
- * @retval On error, a negative value is returned.
+ * @retval -errno On error, a negative value is returned.
  *         See: dns_msg_pack_query_header and  dns_msg_pack_qname.
  */
 int dns_msg_pack_query(uint8_t *buf, uint16_t *len, uint16_t size,

--- a/subsys/net/lib/mqtt/mqtt_os.h
+++ b/subsys/net/lib/mqtt/mqtt_os.h
@@ -64,7 +64,7 @@ static inline void mqtt_mutex_unlock(struct mqtt_client *client)
 
 /**@brief Method to get the sys tick or a wall clock in millisecond resolution.
  *
- * @retval Current wall clock or sys tick value in milliseconds.
+ * @return Current wall clock or sys tick value in milliseconds.
  */
 static inline uint32_t mqtt_sys_tick_in_ms_get(void)
 {
@@ -75,7 +75,7 @@ static inline uint32_t mqtt_sys_tick_in_ms_get(void)
  *
  * @param[in] last_activity The value since elapsed time is requested.
  *
- * @retval Time elapsed since last_activity time.
+ * @return Time elapsed since last_activity time.
  */
 static inline uint32_t mqtt_elapsed_time_in_ms_get(uint32_t last_activity)
 {

--- a/subsys/tracing/include/tracing_buffer.h
+++ b/subsys/tracing/include/tracing_buffer.h
@@ -68,7 +68,7 @@ int tracing_buffer_put_finish(uint32_t size);
  * @param data Address of data.
  * @param size Data size (in bytes).
  *
- * @retval Number of bytes written to tracing buffer.
+ * @return Number of bytes written to tracing buffer.
  */
 uint32_t tracing_buffer_put(uint8_t *data, uint32_t size);
 
@@ -100,7 +100,7 @@ int tracing_buffer_get_finish(uint32_t size);
  * @param data Address of the output buffer.
  * @param size Data size (in bytes).
  *
- * @retval Number of bytes written to the output buffer.
+ * @return Number of bytes written to the output buffer.
  */
 uint32_t tracing_buffer_get(uint8_t *data, uint32_t size);
 

--- a/subsys/usb/usb_c/usbc_pe_common_internal.h
+++ b/subsys/usb/usb_c/usbc_pe_common_internal.h
@@ -410,7 +410,7 @@ bool policy_present_contract_is_valid(const struct device *dev, const uint32_t p
  * @brief Get a Request Data Object from the DPM
  *
  * @param dev Pointer to the device structure for the driver instance
- * @retval the RDO from the DPM
+ * @return the RDO from the DPM
  */
 uint32_t policy_get_request_data_object(const struct device *dev);
 

--- a/tests/subsys/testsuite/fff_fake_contexts/include/zephyr/called_API.h
+++ b/tests/subsys/testsuite/fff_fake_contexts/include/zephyr/called_API.h
@@ -27,9 +27,9 @@ struct called_API_info;
  *
  * @param instance_out Session instance handle for caller to use.
  *
- * @return zero(0) upon success, with *instance_out updated.
- * @return -EINVAL if invalid parameter(s)
- * @return -E2BIG  if more calls were made than expected.
+ * @retval 0 success, *instance_out is updated.
+ * @retval -EINVAL invalid parameter(s)
+ * @retval -E2BIG  more calls were made than expected.
  */
 int called_API_open(const struct called_API_info **instance_out);
 
@@ -44,9 +44,9 @@ int called_API_open(const struct called_API_info **instance_out);
  *
  * @param instance Session instance handle provided by called_API_open
  *
- * @return zero(0) upon success, with instance invalidated.
- * @return -EINVAL if invalid parameter(s)
- * @return -E2BIG  if more calls were made than expected.
+ * @retval 0 success, *instance_out is invalidated.
+ * @retval -EINVAL invalid parameter(s)
+ * @retval -E2BIG  more calls were made than expected.
  */
 int called_API_close(const struct called_API_info *instance);
 


### PR DESCRIPTION
Use `@return` to describe the output value
Use `@retval` to describe *special* return values
