### PR TITLE
xtensa: include xtensa-types.h for xt-clang

### DIFF
--- a/arch/xtensa/include/xtensa_asm2_context.h
+++ b/arch/xtensa/include/xtensa_asm2_context.h
@@ -6,6 +6,10 @@
 #ifndef ZEPHYR_ARCH_XTENSA_INCLUDE_XTENSA_ASM2_CONTEXT_H_
 #define ZEPHYR_ARCH_XTENSA_INCLUDE_XTENSA_ASM2_CONTEXT_H_
 
+#if defined(__XT_CLANG__)
+#include <xtensa/xtensa-types.h>
+#endif
+
 #include <xtensa/corebits.h>
 #include <xtensa/config/core-isa.h>
 #include <xtensa/config/tie.h>


### PR DESCRIPTION
Newer Xtensa toolchain needs to include xtensa-types.h so that macros in tie.h can be used without compilation errors. The exact verison needing this is unknown but first encountered in RJ-2023.2. Tested with older toolchain and that did not cause any compilation errors so just include xtensa-types.h if xt-clang is used. Haven't seen newer toolchains being generated with xcc, so skip that for now.

Note that Zephyr SDK and the public HAL in Zephyr do not provide this file.