### PR TITLE
xtensa: add kconfig to allow non-preemptible interrupts

### DIFF
--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -157,6 +157,12 @@ endif    # XTENSA_CPU_HAS_HIFI
 
 endmenu  # Xtensa HiFi Options
 
+config XTENSA_INTERRUPT_NONPREEMPTABLE
+	bool "Xtensa exceptions and interrupts cannot be pre-empted"
+	help
+	  Allow use of medium and high priority interrupts without
+	  pre-empting low priority interrupts and exceptions.
+
 if CPU_HAS_MMU
 
 config XTENSA_MMU

--- a/arch/xtensa/include/xtensa_asm2_s.h
+++ b/arch/xtensa/include/xtensa_asm2_s.h
@@ -430,6 +430,22 @@ _xstack_returned_\@:
 	wur.THREADPTR a0
 #endif /* XCHAL_HAVE_THREADPTR && CONFIG_USERSPACE */
 
+#ifdef CONFIG_XTENSA_INTERRUPT_NONPREEMPTABLE
+
+	/* Setting the interrupt mask to the max non-debug level
+	 * to prevent lower priority interrupts being preempted by
+	 * high level interrupts until processing of that lower level
+	 * interrupt has completed.
+	 */
+	rsr.ps a0
+	movi a3, ~(PS_INTLEVEL_MASK)
+	and a0, a0, a3
+	movi a3, PS_INTLEVEL(ZSR_RFI_LEVEL)
+	or a0, a0, a3
+	wsr.ps a0
+
+#else
+
 	/* There's a gotcha with level 1 handlers: the INTLEVEL field
 	 * gets left at zero and not set like high priority interrupts
 	 * do.  That works fine for exceptions, but for L1 interrupts,
@@ -450,7 +466,9 @@ _xstack_returned_\@:
 	movi a3, PS_INTLEVEL(1)
 	or a0, a0, a3
 	wsr.ps a0
+
 _not_l1:
+#endif /* CONFIG_XTENSA_INTERRUPT_NONPREEMPTABLE */
 
 	/* Setting up the cross stack call below has states where the
 	 * resulting frames are invalid/non-reentrant, so we can't


### PR DESCRIPTION
This adds a kconfig to enable making the interrupts non-preemptible by other interrupts. Enabling this will set the INTLEVEL to the max non-debug level before clearing the EXCM bit.