### PR TITLE
dts: binding: refine nxp rdc property

### DIFF
--- a/dts/bindings/adc/nxp,vf610-adc.yaml
+++ b/dts/bindings/adc/nxp,vf610-adc.yaml
@@ -5,7 +5,7 @@ description: Vf610 Adc
 
 compatible: "nxp,vf610-adc"
 
-include: adc-controller.yaml
+include: [adc-controller.yaml, "nxp,rdc-policy.yaml"]
 
 properties:
   reg:
@@ -29,22 +29,6 @@ properties:
 
   "#io-channel-cells":
     const: 1
-
-  rdc:
-    type: int
-    required: true
-    description: |
-      Set the RDC permission for this peripheral: the RDC controls which
-      processor can access to this peripheral. User can select to assign this
-      peripheral to the M4 processor, A9 processor or both with R/W or RW
-      permissions. To set wanted permission a user should use the helper
-      macro RDC_DOMAIN_PERM(domain,permission) where domain must be one of
-      M4_DOMAIN_ID or A9_DOMAIN_ID and permission one among
-      RDC_DOMAIN_PERM_NONE, RDC_DOMAIN_PERM_W, RDC_DOMAIN_PERM_R,
-      RDC_DOMAIN_PERM_RW. Example to allow both processor to read/write to
-      this peripheral a user should put:
-      rdc = <(RDC_DOMAIN_PERM(A9_DOMAIN_ID, RDC_DOMAIN_PERM_RW) |
-              RDC_DOMAIN_PERM(M4_DOMAIN_ID, RDC_DOMAIN_PERM_RW))>;
 
 io-channel-cells:
   - input

--- a/dts/bindings/arm/nxp,imx-epit.yaml
+++ b/dts/bindings/arm/nxp,imx-epit.yaml
@@ -1,11 +1,11 @@
-# Copyright (c) 2018, NXP
+# Copyright 2018, 2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 description: i.MX Enhanced Periodic Interrupt Timer (EPIT)
 
 compatible: "nxp,imx-epit"
 
-include: base.yaml
+include: [base.yaml, "nxp,rdc-policy.yaml"]
 
 properties:
   reg:
@@ -18,8 +18,3 @@ properties:
     type: int
     required: true
     description: Set the EPIT prescaler between 0 and 4095
-
-  rdc:
-    type: int
-    required: true
-    description: Set the RDC permission for this peripheral

--- a/dts/bindings/ethernet/nxp,enet1g.yaml
+++ b/dts/bindings/ethernet/nxp,enet1g.yaml
@@ -5,7 +5,7 @@ description: NXP ENET1G IP Module
 
 compatible: "nxp,enet1g"
 
-include: ["base.yaml"]
+include: ["base.yaml", "nxp,rdc-policy.yaml"]
 
 properties:
   reg:
@@ -13,7 +13,3 @@ properties:
 
   clocks:
     required: true
-
-  rdc:
-    type: int
-    description: Set the RDC(Resource Domain Controller) domain permission for this peripheral

--- a/dts/bindings/gpio/nxp,imx-gpio.yaml
+++ b/dts/bindings/gpio/nxp,imx-gpio.yaml
@@ -1,19 +1,15 @@
-# Copyright (c) 2017, NXP
+# Copyright 2017, 2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 description: i.MX GPIO node
 
 compatible: "nxp,imx-gpio"
 
-include: [gpio-controller.yaml, base.yaml]
+include: [gpio-controller.yaml, base.yaml, "nxp,rdc-policy.yaml"]
 
 properties:
   reg:
     required: true
-
-  rdc:
-    type: int
-    description: Set the RDC permission for this peripheral
 
   pinmux:
     type: phandles

--- a/dts/bindings/gpio/nxp,imx-rgpio.yaml
+++ b/dts/bindings/gpio/nxp,imx-rgpio.yaml
@@ -1,19 +1,15 @@
-# Copyright 2024, NXP
+# Copyright 2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 description: i.MX RGPIO node
 
 compatible: "nxp,imx-rgpio"
 
-include: [gpio-controller.yaml, base.yaml]
+include: [gpio-controller.yaml, base.yaml, "nxp,rdc-policy.yaml"]
 
 properties:
   reg:
     required: true
-
-  rdc:
-    type: int
-    description: Set the RDC permission for this peripheral
 
   pinmux:
     type: phandles

--- a/dts/bindings/i2c/fsl,imx21-i2c.yaml
+++ b/dts/bindings/i2c/fsl,imx21-i2c.yaml
@@ -5,7 +5,7 @@ description: i.MX I2C node
 
 compatible: "fsl,imx21-i2c"
 
-include: [i2c-controller.yaml, pinctrl-device.yaml]
+include: [i2c-controller.yaml, pinctrl-device.yaml, "nxp,rdc-policy.yaml"]
 
 properties:
   reg:
@@ -13,8 +13,3 @@ properties:
 
   interrupts:
     required: true
-
-  rdc:
-    type: int
-    required: true
-    description: Set the RDC permission for this peripheral

--- a/dts/bindings/ipm/nxp,imx-mu.yaml
+++ b/dts/bindings/ipm/nxp,imx-mu.yaml
@@ -1,11 +1,11 @@
-# Copyright (c) 2018, NXP
+# Copyright 2018, 2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 description: i.MX Messaging Unit
 
 compatible: "nxp,imx-mu"
 
-include: base.yaml
+include: [base.yaml, "nxp,rdc-policy.yaml"]
 
 properties:
   reg:
@@ -13,8 +13,3 @@ properties:
 
   interrupts:
     required: true
-
-  rdc:
-    type: int
-    required: true
-    description: Set the RDC permission for this peripheral

--- a/dts/bindings/misc/nxp,rdc-policy.yaml
+++ b/dts/bindings/misc/nxp,rdc-policy.yaml
@@ -1,0 +1,16 @@
+# Copyright 2024 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+properties:
+  rdc:
+    type: int
+    description: |
+      Set the RDC permission for specified peripheral: Resource Domain Controller (RDC)
+      supports flexible configuration on IP’s access permission, each individual IP can,
+      for example, be configured as A-core only or M-core only. This property uses some
+      macros defined in 'include/zephyr/dt-bindings/rdc/imx_rdc.h' to configure current
+      peripheral's access permission.
+      For example to allow both A53 and M7 Core to have read/write permission to current
+      peripheral:
+      rdc = <(RDC_DOMAIN_PERM(A53_DOMAIN_ID, RDC_DOMAIN_PERM_RW)|\
+              RDC_DOMAIN_PERM(M7_DOMAIN_ID, RDC_DOMAIN_PERM_RW))>;

--- a/dts/bindings/pwm/fsl,imx27-pwm.yaml
+++ b/dts/bindings/pwm/fsl,imx27-pwm.yaml
@@ -10,7 +10,7 @@ description: |
 
 compatible: "fsl,imx27-pwm"
 
-include: [pwm-controller.yaml, pinctrl-device.yaml, base.yaml]
+include: [pwm-controller.yaml, pinctrl-device.yaml, base.yaml, "nxp,rdc-policy.yaml"]
 
 properties:
   reg:
@@ -23,11 +23,6 @@ properties:
     type: int
     required: true
     description: Set the PWM prescale between 0 and 4096
-
-  rdc:
-    type: int
-    required: true
-    description: Set the RDC permission for this peripheral
 
   "#pwm-cells":
     const: 2

--- a/dts/bindings/serial/nxp,imx-iuart.yaml
+++ b/dts/bindings/serial/nxp,imx-iuart.yaml
@@ -3,7 +3,7 @@ description: |
 
 compatible: "nxp,imx-iuart"
 
-include: [uart-controller.yaml, pinctrl-device.yaml]
+include: [uart-controller.yaml, pinctrl-device.yaml, "nxp,rdc-policy.yaml"]
 
 properties:
   reg:
@@ -17,7 +17,3 @@ properties:
 
   pinctrl-names:
     required: true
-
-  rdc:
-    type: int
-    description: Set the RDC permission for this peripheral

--- a/dts/bindings/serial/nxp,imx-uart.yaml
+++ b/dts/bindings/serial/nxp,imx-uart.yaml
@@ -1,11 +1,11 @@
-# Copyright (c) 2017, NXP
+# Copyright 2017, 2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 description: iMX UART
 
 compatible: "nxp,imx-uart"
 
-include: [uart-controller.yaml, pinctrl-device.yaml]
+include: [uart-controller.yaml, pinctrl-device.yaml, "nxp,rdc-policy.yaml"]
 
 properties:
   reg:
@@ -18,11 +18,6 @@ properties:
     type: int
     required: true
     description: Set the UART Port to modem mode 0 (dce) 64 (dte)
-
-  rdc:
-    type: int
-    required: true
-    description: Set the RDC permission for this peripheral
 
   pinctrl-0:
     required: true


### PR DESCRIPTION
Define rdc property in a yaml file and include it in the peripheral's dts binding.