### PR TITLE
divers: clock_control: npcx: HFCBCD3 in CDCG is only available in npcx4

### DIFF
--- a/drivers/clock_control/clock_control_npcx.c
+++ b/drivers/clock_control/clock_control_npcx.c
@@ -232,7 +232,9 @@ static int npcx_clock_control_init(const struct device *dev)
 	inst_cdcg->HFCBCD  = VAL_HFCBCD;
 	inst_cdcg->HFCBCD1 = VAL_HFCBCD1;
 	inst_cdcg->HFCBCD2 = VAL_HFCBCD2;
+#if defined(CONFIG_SOC_SERIES_NPCX4)
 	inst_cdcg->HFCBCD3 = VAL_HFCBCD3;
+#endif
 
 	/*
 	 * Power-down (turn off clock) the modules initially for better


### PR DESCRIPTION
Update clock_control initial.
HFCBCD3 in CDCG is only available in npcx4.