### PR TITLE
Bluetooth: Mesh: add Kconfig options for BLOB chunk size

### DIFF
--- a/include/zephyr/bluetooth/mesh/blob_srv.h
+++ b/include/zephyr/bluetooth/mesh/blob_srv.h
@@ -127,7 +127,7 @@ struct bt_mesh_blob_srv_cb {
 		       const struct bt_mesh_blob_io **io);
 };
 
-/** @brief BLOB Transfer Server instance. */
+/** @brief BLOB Transfer Server model instance. */
 struct bt_mesh_blob_srv {
 	/** Event handler callbacks. */
 	const struct bt_mesh_blob_srv_cb *cb;

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -895,6 +895,18 @@ config BT_MESH_BLOB_REPORT_TIMEOUT
 	help
 	  The timer value that Pull BLOB Transfer Server uses to report missed chunks.
 
+config BT_MESH_RX_BLOB_CHUNK_SIZE
+	depends on !BT_MESH_ALIGN_CHUNK_SIZE_TO_MAX_SEGMENT
+	int "BLOB Server chunk size"
+	default 8
+	range 8 377
+	help
+	  Set the chunk size for the BLOB Server.
+	  The actual maximum chunk size depends on how many segments are
+	  possible and will be clamped to the max possible if set above.
+	  see also: BT_MESH_RX_SEG_MAX,
+	  and the maximum SDU a node can receive.
+
 endif # BT_MESH_BLOB_SRV
 
 menuconfig BT_MESH_BLOB_CLI
@@ -911,10 +923,26 @@ config BT_MESH_BLOB_CLI_BLOCK_RETRIES
 	  Controls the number of times the client will attempt to resend missing
 	  chunks to the BLOB receivers for every block.
 
-endif
+config BT_MESH_TX_BLOB_CHUNK_SIZE
+	depends on !BT_MESH_ALIGN_CHUNK_SIZE_TO_MAX_SEGMENT
+	int "BLOB Client chunk size"
+	default 8
+	range 1 377
+	help
+	  Set the chunk size for the BLOB Client.
+	  The actual maximum chunk size depends on how many segments are
+	  possible and will be clamped to the max possible if set above.
+	  see also: BT_MESH_TX_SEG_MAX,
+	  and the maximum SDU a node can receive.
+
+endif # BT_MESH_BLOB_CLI
 
 menu "BLOB models common configuration"
 	visible if BT_MESH_BLOB_SRV || BT_MESH_BLOB_CLI
+
+config BT_MESH_ALIGN_CHUNK_SIZE_TO_MAX_SEGMENT
+	bool "Align chunk size to max segmented message size"
+	default y
 
 config BT_MESH_BLOB_CHUNK_COUNT_MAX
 	int "Maximum chunk count per block"

--- a/subsys/bluetooth/mesh/blob.h
+++ b/subsys/bluetooth/mesh/blob.h
@@ -27,6 +27,20 @@
 #define BLOB_CHUNK_SIZE_MAX(sdu_max) ((sdu_max) - BLOB_CHUNK_SDU_OVERHEAD)
 #define BLOB_CHUNK_SDU_LEN(chunk_size) (BLOB_CHUNK_SDU_OVERHEAD + (chunk_size))
 
+#if CONFIG_BT_MESH_ALIGN_CHUNK_SIZE_TO_MAX_SEGMENT ||                                              \
+	CONFIG_BT_MESH_RX_BLOB_CHUNK_SIZE > BLOB_CHUNK_SIZE_MAX(BT_MESH_RX_SDU_MAX)
+#define BLOB_RX_CHUNK_SIZE BLOB_CHUNK_SIZE_MAX(BT_MESH_RX_SDU_MAX)
+#else
+#define BLOB_RX_CHUNK_SIZE CONFIG_BT_MESH_RX_BLOB_CHUNK_SIZE
+#endif
+
+#if CONFIG_BT_MESH_ALIGN_CHUNK_SIZE_TO_MAX_SEGMENT ||                                              \
+	CONFIG_BT_MESH_TX_BLOB_CHUNK_SIZE > BLOB_CHUNK_SIZE_MAX(BT_MESH_TX_SDU_MAX)
+#define BLOB_TX_CHUNK_SIZE BLOB_CHUNK_SIZE_MAX(BT_MESH_TX_SDU_MAX)
+#else
+#define BLOB_TX_CHUNK_SIZE CONFIG_BT_MESH_TX_BLOB_CHUNK_SIZE
+#endif
+
 /* Utility macros for calculating log2 of a number at compile time.
  * Used to determine the log2 representation of the block size, which
  * is configured as a raw number, but encoded as log2.

--- a/subsys/bluetooth/mesh/blob_cli.c
+++ b/subsys/bluetooth/mesh/blob_cli.c
@@ -19,8 +19,6 @@ LOG_MODULE_REGISTER(bt_mesh_blob_cli);
 	SYS_SLIST_FOR_EACH_CONTAINER((sys_slist_t *)&(cli)->inputs->targets,   \
 				     target, n)
 
-#define CHUNK_SIZE_MAX BLOB_CHUNK_SIZE_MAX(BT_MESH_TX_SDU_MAX)
-
 /* The Maximum BLOB Poll Interval - T_MBPI */
 #define BLOB_POLL_TIME_MAX_SECS 30
 
@@ -1496,7 +1494,7 @@ int bt_mesh_blob_cli_caps_get(struct bt_mesh_blob_cli *cli,
 	cli->caps.min_block_size_log = 0x06;
 	cli->caps.max_block_size_log = 0x20;
 	cli->caps.max_chunks = CONFIG_BT_MESH_BLOB_CHUNK_COUNT_MAX;
-	cli->caps.max_chunk_size = CHUNK_SIZE_MAX;
+	cli->caps.max_chunk_size = BLOB_TX_CHUNK_SIZE;
 	cli->caps.max_size = 0xffffffff;
 	cli->caps.mtu_size = 0xffff;
 	cli->caps.modes = BT_MESH_BLOB_XFER_MODE_ALL;
@@ -1521,9 +1519,9 @@ int bt_mesh_blob_cli_send(struct bt_mesh_blob_cli *cli,
 		return -EBUSY;
 	}
 
-	if (!(xfer->mode & BT_MESH_BLOB_XFER_MODE_ALL) ||
-	    xfer->block_size_log < 0x06 || xfer->block_size_log > 0x20 ||
-	    xfer->chunk_size < 8 || xfer->chunk_size > CHUNK_SIZE_MAX) {
+	if (!(xfer->mode & BT_MESH_BLOB_XFER_MODE_ALL) || xfer->block_size_log < 0x06 ||
+	    xfer->block_size_log > 0x20 || xfer->chunk_size < 8 ||
+	    xfer->chunk_size > BLOB_TX_CHUNK_SIZE) {
 		LOG_ERR("Incompatible transfer parameters");
 		return -EINVAL;
 	}

--- a/subsys/bluetooth/mesh/blob_io_flash.c
+++ b/subsys/bluetooth/mesh/blob_io_flash.c
@@ -117,8 +117,7 @@ static int wr_chunk(const struct bt_mesh_blob_io *io,
 					chunk->data, chunk->size);
 	}
 
-	uint8_t buf[ROUND_UP(BLOB_CHUNK_SIZE_MAX(BT_MESH_RX_SDU_MAX),
-			  WRITE_BLOCK_SIZE)];
+	uint8_t buf[ROUND_UP(BLOB_RX_CHUNK_SIZE, WRITE_BLOCK_SIZE)];
 	off_t area_offset = flash->offset + block->offset + chunk->offset;
 	int i = 0;
 

--- a/subsys/bluetooth/mesh/blob_srv.c
+++ b/subsys/bluetooth/mesh/blob_srv.c
@@ -16,7 +16,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_mesh_blob_srv);
 
-#define CHUNK_SIZE_MAX BLOB_CHUNK_SIZE_MAX(BT_MESH_RX_SDU_MAX)
 #define MTU_SIZE_MAX (BT_MESH_RX_SDU_MAX - BT_MESH_MIC_SHORT)
 
 /* The Receive BLOB Timeout Timer */
@@ -53,9 +52,8 @@ static inline uint32_t block_count_get(const struct bt_mesh_blob_srv *srv)
 
 static inline uint32_t max_chunk_size(const struct bt_mesh_blob_srv *srv)
 {
-	return MIN((srv->state.mtu_size - 2 -
-		    BT_MESH_MODEL_OP_LEN(BT_MESH_BLOB_OP_CHUNK)),
-		   CHUNK_SIZE_MAX);
+	return MIN((srv->state.mtu_size - 2 - BT_MESH_MODEL_OP_LEN(BT_MESH_BLOB_OP_CHUNK)),
+		   BLOB_RX_CHUNK_SIZE);
 }
 
 static inline uint32_t max_chunk_count(const struct bt_mesh_blob_srv *srv)
@@ -822,7 +820,7 @@ static int handle_info_get(const struct bt_mesh_model *mod, struct bt_mesh_msg_c
 	net_buf_simple_add_u8(&rsp, BLOB_BLOCK_SIZE_LOG_MIN);
 	net_buf_simple_add_u8(&rsp, BLOB_BLOCK_SIZE_LOG_MAX);
 	net_buf_simple_add_le16(&rsp, CONFIG_BT_MESH_BLOB_CHUNK_COUNT_MAX);
-	net_buf_simple_add_le16(&rsp, CHUNK_SIZE_MAX);
+	net_buf_simple_add_le16(&rsp, BLOB_RX_CHUNK_SIZE);
 	net_buf_simple_add_le32(&rsp, CONFIG_BT_MESH_BLOB_SIZE_MAX);
 	net_buf_simple_add_le16(&rsp, MTU_SIZE_MAX);
 	net_buf_simple_add_u8(&rsp, BT_MESH_BLOB_XFER_MODE_ALL);


### PR DESCRIPTION
The MBT server, as the MBT client currently sets the maximum chunk size according to maximum supported segments in the accesss layer. This might be suboptimal for some use cases.
The added Kconfig options give customers the option to fine tune it themselves.