### PR TITLE
samples: drivers: mbox: fix nRF54H20 cpuapp<>cpuflpr channel regex

### DIFF
--- a/samples/drivers/mbox/sample.yaml
+++ b/samples/drivers/mbox/sample.yaml
@@ -56,7 +56,7 @@ tests:
       ordered: false
       regex:
         - "Ping \\(on channel 16\\)"
-        - "Pong \\(on channel 18\\)"
+        - "Pong \\(on channel 14\\)"
 
   sample.drivers.mbox.nrf54h20_rad_app:
     platform_allow:


### PR DESCRIPTION
Bellboard channel used by the sample is 14, not 18.