### PR TITLE
soc: arm: nxp lpc55xx: fix nxp,ctimer-pwm init procedure (attach clock)

### DIFF
--- a/soc/nxp/lpc/lpc55xxx/soc.c
+++ b/soc/nxp/lpc/lpc55xxx/soc.c
@@ -269,6 +269,8 @@ static ALWAYS_INLINE void clock_init(void)
 
 DT_FOREACH_STATUS_OKAY(nxp_lpc_ctimer, CTIMER_CLOCK_SETUP)
 
+DT_FOREACH_STATUS_OKAY(nxp_ctimer_pwm, CTIMER_CLOCK_SETUP)
+
 #if (DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(flexcomm6), nxp_lpc_i2s, okay))
 #if defined(CONFIG_SOC_LPC55S36)
 	CLOCK_SetClkDiv(kCLOCK_DivFlexcom6Clk, 0U, true);


### PR DESCRIPTION
Currently, when using an `nxp,ctimer-pwm` DTS node, Zephyr boot will crash the system, because it's trying to access registers of the CTIMER peripheral that are not clocked.
This is very annoying to debug, too, since the system completely locks up and SWD access is difficult.

This patchs fixes that for the LPC55xx SoCs.

Fixes #77096