### PR TITLE
shell: backends: rtt: Set panic_mode flag

### DIFF
--- a/subsys/shell/backends/shell_rtt.c
+++ b/subsys/shell/backends/shell_rtt.c
@@ -85,6 +85,9 @@ static int enable(const struct shell_transport *transport, bool blocking)
 	struct shell_rtt *sh_rtt = (struct shell_rtt *)transport->ctx;
 
 	if (blocking) {
+		if (IS_ENABLED(CONFIG_LOG_MODE_DEFERRED) && IS_ENABLED(CONFIG_SHELL_LOG_BACKEND)) {
+			panic_mode = true;
+		}
 		k_timer_stop(&sh_rtt->timer);
 	}
 


### PR DESCRIPTION
A bug was introduced when fb17d0e365 introduced host presence detection. Panic_mode flag was added which indicates that RTT should work in synchronous, blocking mode but it was not set when backend was switched to panic mode.

See https://github.com/zephyrproject-rtos/zephyr/pull/68941#discussion_r1543194507