### PR TITLE
drivers: rtc: fake: Patch alarm and update fakes

### DIFF
--- a/drivers/rtc/rtc_fake.c
+++ b/drivers/rtc/rtc_fake.c
@@ -20,19 +20,19 @@ DEFINE_FAKE_VALUE_FUNC(int, rtc_fake_get_time, const struct device *, struct rtc
 
 #ifdef CONFIG_RTC_ALARM
 DEFINE_FAKE_VALUE_FUNC(int, rtc_fake_alarm_get_supported_fields, const struct device *, uint16_t,
-		       uint16_t);
+		       uint16_t *);
 DEFINE_FAKE_VALUE_FUNC(int, rtc_fake_alarm_set_time, const struct device *, uint16_t, uint16_t,
-		       constr struct rtc_time *);
-DEFINE_FAKE_VALUE_FUNC(int, rtc_fake_alarm_get_time, const struct device *, uint16_t, uint16_t,
+		       const struct rtc_time *);
+DEFINE_FAKE_VALUE_FUNC(int, rtc_fake_alarm_get_time, const struct device *, uint16_t, uint16_t *,
 		       struct rtc_time *);
 DEFINE_FAKE_VALUE_FUNC(int, rtc_fake_alarm_is_pending, const struct device *, uint16_t);
-DEFINE_FAKE_VALUE_FUNC(int, rtc_fake_alarm_set_callback, const struct device *uint16_t,
+DEFINE_FAKE_VALUE_FUNC(int, rtc_fake_alarm_set_callback, const struct device *, uint16_t,
 		       rtc_alarm_callback, void *);
 #endif /* CONFIG_RTC_ALARM */
 
 #ifdef CONFIG_RTC_UPDATE
-DEFINE_FAKE_VALUE_FUNC(int, rtc_fake_update_set_callback, const struct device *rtc_alarm_callback,
-		       void *);
+DEFINE_FAKE_VALUE_FUNC(int, rtc_fake_update_set_callback, const struct device *,
+		       rtc_update_callback, void *);
 #endif /* CONFIG_RTC_UPDATE */
 
 #ifdef CONFIG_RTC_CALIBRATION

--- a/include/zephyr/drivers/rtc/rtc_fake.h
+++ b/include/zephyr/drivers/rtc/rtc_fake.h
@@ -19,19 +19,19 @@ DECLARE_FAKE_VALUE_FUNC(int, rtc_fake_get_time, const struct device *, struct rt
 
 #ifdef CONFIG_RTC_ALARM
 DECLARE_FAKE_VALUE_FUNC(int, rtc_fake_alarm_get_supported_fields, const struct device *, uint16_t,
-			uint16_t);
+			uint16_t *);
 DECLARE_FAKE_VALUE_FUNC(int, rtc_fake_alarm_set_time, const struct device *, uint16_t, uint16_t,
-			constr struct rtc_time *);
-DECLARE_FAKE_VALUE_FUNC(int, rtc_fake_alarm_get_time, const struct device *, uint16_t, uint16_t,
+			const struct rtc_time *);
+DECLARE_FAKE_VALUE_FUNC(int, rtc_fake_alarm_get_time, const struct device *, uint16_t, uint16_t *,
 			struct rtc_time *);
 DECLARE_FAKE_VALUE_FUNC(int, rtc_fake_alarm_is_pending, const struct device *, uint16_t);
-DECLARE_FAKE_VALUE_FUNC(int, rtc_fake_alarm_set_callback, const struct device *uint16_t,
+DECLARE_FAKE_VALUE_FUNC(int, rtc_fake_alarm_set_callback, const struct device *, uint16_t,
 			rtc_alarm_callback, void *);
 #endif /* CONFIG_RTC_ALARM */
 
 #ifdef CONFIG_RTC_UPDATE
-DECLARE_FAKE_VALUE_FUNC(int, rtc_fake_update_set_callback, const struct device *rtc_alarm_callback,
-			void *);
+DECLARE_FAKE_VALUE_FUNC(int, rtc_fake_update_set_callback, const struct device *,
+			rtc_update_callback, void *);
 #endif /* CONFIG_RTC_UPDATE */
 
 #ifdef CONFIG_RTC_CALIBRATION


### PR DESCRIPTION
The RTC alarm and update fakes where not defined correctly. This commit adjusts them to match the RTC API.