### PR TITLE
clang-format: add SpaceBeforeInheritanceColon False

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -96,6 +96,7 @@ IndentCaseLabels: false
 IndentGotoLabels: false
 IndentWidth: 8
 InsertBraces: true
+SpaceBeforeInheritanceColon: False
 SpaceBeforeParens: ControlStatementsExceptControlMacros
 SortIncludes: Never
 UseTab: ForContinuationAndIndentation


### PR DESCRIPTION
For clang-format to adhere to checkpatch, this flag needs to be set.

In the same vein as https://github.com/zephyrproject-rtos/zephyr/pull/76553.

Observed while developing a new NCS AT parser https://github.com/nrfconnect/sdk-nrf/pull/15120. A source file that uses `goto`s and is auto-formatted with `clang-format` will not comply to CI unless it also has the flag above.

Without the flag above, the following code section:

```
yy13:
	{
			if (remainder) *remainder = cursor;
			return (struct at_token){
				.start = at, .len = cursor - at - 1,
				.type = AT_TOKEN_TYPE_CMD_SET
			};
		}
```

Is formatted to:

```
yy13 : {
	if (remainder) {
		*remainder = cursor;
	}
	return (struct at_token){
		.start = at, .len = cursor - at - 1, .type = AT_TOKEN_TYPE_CMD_SET};
}
```

Which does not comply to CI due to a space after the `goto` label and before the colon.

Adding the flag above will format it to:

```
yy13: {
	if (remainder) {
		*remainder = cursor;
	}
	return (struct at_token){
		.start = at, .len = cursor - at - 1, .type = AT_TOKEN_TYPE_CMD_SET};
}
```

Which successfully complies with CI.