### PR TITLE
arch: riscv: add IRQ vector set hook function for CLIC smclicshv extension

### DIFF
--- a/drivers/interrupt_controller/Kconfig.clic
+++ b/drivers/interrupt_controller/Kconfig.clic
@@ -6,6 +6,7 @@ config NUCLEI_ECLIC
 	default y
 	depends on DT_HAS_NUCLEI_ECLIC_ENABLED
 	select RISCV_SOC_HAS_CUSTOM_IRQ_HANDLING if !RISCV_VECTORED_MODE
+	select CLIC_SMCLICSHV_EXT if RISCV_VECTORED_MODE
 	help
 	  Interrupt controller for Nuclei SoC core.
 

--- a/drivers/interrupt_controller/Kconfig.clic
+++ b/drivers/interrupt_controller/Kconfig.clic
@@ -17,6 +17,13 @@ config NRFX_CLIC
 	help
 	  Interrupt controller for Nordic VPR cores.
 
+config CLIC_SMCLICSHV_EXT
+	bool
+	help
+	  The selective hardware vectoring extension gives users the flexibility
+	  to select the behavior for each interrupt. The CLIC driver needs to
+	  implement the riscv_clic_irq_vector_set() function.
+
 if NUCLEI_ECLIC
 
 config LEGACY_CLIC

--- a/drivers/interrupt_controller/Kconfig.clic
+++ b/drivers/interrupt_controller/Kconfig.clic
@@ -5,7 +5,7 @@ config NUCLEI_ECLIC
 	bool "Enhanced Core Local Interrupt Controller (ECLIC)"
 	default y
 	depends on DT_HAS_NUCLEI_ECLIC_ENABLED
-	select RISCV_SOC_HAS_CUSTOM_IRQ_HANDLING if !RISCV_VECTORED_MODE
+	select RISCV_SOC_HAS_CUSTOM_IRQ_HANDLING
 	select CLIC_SMCLICSHV_EXT if RISCV_VECTORED_MODE
 	help
 	  Interrupt controller for Nuclei SoC core.

--- a/drivers/interrupt_controller/intc_nuclei_eclic.S
+++ b/drivers/interrupt_controller/intc_nuclei_eclic.S
@@ -22,8 +22,6 @@ GTEXT(__soc_handle_irq)
 SECTION_FUNC(exception.other, __soc_handle_irq)
 	ret
 
-#if !defined(CONFIG_RISCV_VECTORED_MODE)
-
 GTEXT(__soc_handle_all_irqs)
 
 #ifdef CONFIG_TRACING
@@ -50,8 +48,10 @@ irq_loop:
 	call sys_trace_isr_enter
 #endif
 
-	/* Call corresponding registered function in _sw_isr_table. a0 is offset in words, table is
-	 * 2-word wide -> shift by one */
+	/* Call corresponding registered function in _sw_isr_table. a0 is offset in pointer with
+	 * the mtvt, sw irq table is 2-pointer wide -> shift by one. */
+	csrr t0, 0x307 /* mtvt */
+	sub a0, a0, t0
 	la t0, _sw_isr_table
 	slli a0, a0, (1)
 	add t0, t0, a0
@@ -65,17 +65,15 @@ irq_loop:
 	/* Call ISR function */
 	jalr ra, t1, 0
 
-	/* Read and clear mnxti to get highest current interrupt and enable interrupts. */
-	csrrci a0, 0x345, MSTATUS_IEN
-
 #ifdef CONFIG_TRACING_ISR
 	call sys_trace_isr_exit
 #endif
 
+	/* Read and clear mnxti to get highest current interrupt and enable interrupts. */
+	csrrci a0, 0x345, MSTATUS_IEN
 	bnez a0, irq_loop
 
 irq_done:
 	lw ra, 0(sp)
 	addi sp, sp, 16
 	ret
-#endif

--- a/drivers/interrupt_controller/intc_nuclei_eclic.c
+++ b/drivers/interrupt_controller/intc_nuclei_eclic.c
@@ -144,16 +144,9 @@ void riscv_clic_irq_priority_set(uint32_t irq, uint32_t pri, uint32_t flags)
 	ECLIC_CTRL[irq].INTCTRL = intctrl;
 
 	union CLICINTATTR intattr = {.w = 0};
-#if defined(CONFIG_RISCV_VECTORED_MODE) && !defined(CONFIG_LEGACY_CLIC)
-	/*
-	 * Set Selective Hardware Vectoring.
-	 * Legacy SiFive does not implement smclicshv extension and vectoring is
-	 * enabled in the mode bits of mtvec.
-	 */
-	intattr.b.shv = 1;
-#else
+
+	/* Set non-vectoring as default. */
 	intattr.b.shv = 0;
-#endif
 	intattr.b.trg = (uint8_t)(flags & CLIC_INTATTR_TRIG_Msk);
 	ECLIC_CTRL[irq].INTATTR = intattr;
 }

--- a/drivers/interrupt_controller/intc_nuclei_eclic.c
+++ b/drivers/interrupt_controller/intc_nuclei_eclic.c
@@ -159,6 +159,18 @@ void riscv_clic_irq_priority_set(uint32_t irq, uint32_t pri, uint32_t flags)
 }
 
 /**
+ * @brief Set vector mode of interrupt
+ */
+void riscv_clic_irq_vector_set(uint32_t irq)
+{
+	/* Set Selective Hardware Vectoring. */
+	union CLICINTATTR intattr = ECLIC_CTRL[irq].INTATTR;
+
+	intattr.b.shv = 1;
+	ECLIC_CTRL[irq].INTATTR = intattr;
+}
+
+/**
  * @brief Set pending bit of an interrupt
  */
 void riscv_clic_irq_set_pending(uint32_t irq)

--- a/include/zephyr/arch/riscv/irq.h
+++ b/include/zephyr/arch/riscv/irq.h
@@ -62,6 +62,12 @@ extern void z_riscv_irq_priority_set(unsigned int irq,
 #define z_riscv_irq_priority_set(i, p, f) /* Nothing */
 #endif /* CONFIG_RISCV_HAS_PLIC || CONFIG_RISCV_HAS_CLIC */
 
+#ifdef CONFIG_RISCV_HAS_CLIC
+extern void z_riscv_irq_vector_set(unsigned int irq);
+#else
+#define z_riscv_irq_vector_set(i) /* Nothing */
+#endif /* CONFIG_RISCV_HAS_CLIC */
+
 #define ARCH_IRQ_CONNECT(irq_p, priority_p, isr_p, isr_param_p, flags_p) \
 { \
 	Z_ISR_DECLARE(irq_p + CONFIG_RISCV_RESERVED_IRQ_ISR_TABLES_OFFSET, \
@@ -74,6 +80,7 @@ extern void z_riscv_irq_priority_set(unsigned int irq,
 	Z_ISR_DECLARE_DIRECT(irq_p + CONFIG_RISCV_RESERVED_IRQ_ISR_TABLES_OFFSET, \
 		      ISR_FLAG_DIRECT, isr_p); \
 	z_riscv_irq_priority_set(irq_p, priority_p, flags_p); \
+	z_riscv_irq_vector_set(irq_p); \
 }
 
 #define ARCH_ISR_DIRECT_HEADER() arch_isr_direct_header()

--- a/include/zephyr/drivers/interrupt_controller/riscv_clic.h
+++ b/include/zephyr/drivers/interrupt_controller/riscv_clic.h
@@ -43,4 +43,11 @@ int riscv_clic_irq_is_enabled(uint32_t irq);
  */
 void riscv_clic_irq_priority_set(uint32_t irq, uint32_t prio, uint32_t flags);
 
+/**
+ * @brief Set vector mode of interrupt
+ *
+ * @param irq interrupt ID
+ */
+void riscv_clic_irq_vector_set(uint32_t irq);
+
 #endif /* ZEPHYR_INCLUDE_DRIVERS_RISCV_CLIC_H_ */

--- a/soc/common/riscv-privileged/soc_common_irq.c
+++ b/soc/common/riscv-privileged/soc_common_irq.c
@@ -37,6 +37,15 @@ void z_riscv_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flag
 	riscv_clic_irq_priority_set(irq, prio, flags);
 }
 
+void z_riscv_irq_vector_set(unsigned int irq)
+{
+#if defined(CONFIG_CLIC_SMCLICSHV_EXT)
+	riscv_clic_irq_vector_set(irq);
+#else
+	ARG_UNUSED(irq);
+#endif
+}
+
 #else /* PLIC + HLINT/CLINT or HLINT/CLINT only */
 
 void arch_irq_enable(unsigned int irq)


### PR DESCRIPTION
The current RISC-V setup doesn't distinguish interrupt source configuration between `ARCH_IRQ_CONNECT` and `ARCH_IRQ_DIRECT_CONNECT`, which satisfies the RISC-V vectored interrupt mode in the CSR `mtvec`.

However, the CLIC smclicshv extension allows setting vectored mode for each interrupt individually. This PR adds `z_riscv_irq_vector_set()` and `riscv_clic_irq_vector_set()` to hook `ARCH_IRQ_DIRECT_CONNECT` for configuring vectored mode per interrupt source.

This PR also improves the Nuclei CLIC to use the non-vectored entry `__soc_handle_all_irqs` with `CONFIG_RISCV_VECTORED_MODE`. This entry handles all pending interrupts in one ISR by CLIC CSR `mnxti`, unlike the original version, which use RISC-V generic flow and handles one pending interrupt per ISR.

I tested these changes on the adp_xc7k/ae350_clic board in my project and on the Logan Nano board in the following test case:
- tests/kernel/interrupt/arch.interrupt
- tests/kernel/gen_isr_table/arch.interrupt.gen_isr_table.riscv_no_direct
- tests/kernel/gen_isr_table/arch.interrupt.gen_isr_table.riscv_direct



