### PR TITLE
tests: timer: behavior_external: fix MAX_STD_DEV

### DIFF
--- a/tests/kernel/timer/timer_behavior/pytest/test_timer.py
+++ b/tests/kernel/timer/timer_behavior/pytest/test_timer.py
@@ -37,10 +37,10 @@ def do_analysis(test, stats, stats_count, config, sys_clock_hw_cycles_per_sec):
     max_bound = (test_period + period_max_drift * test_period +
                  expected_period_drift) / 1_000_000
 
-    cyc_us = 1000000 / sys_clock_hw_cycles_per_sec
+    min_cyc = 1. / sys_clock_hw_cycles_per_sec
     max_stddev = int(config['TIMER_TEST_MAX_STDDEV']) / 1_000_000
     # Max STDDEV cannot be lower than clock single cycle
-    max_stddev = max(cyc_us, max_stddev)
+    max_stddev = max(min_cyc, max_stddev)
 
     max_drift_ppm = int(config['TIMER_EXTERNAL_TEST_MAX_DRIFT_PPM'])
     time_diff = stats['total_time'] - seconds - expected_total_drift
@@ -65,7 +65,7 @@ def do_analysis(test, stats, stats_count, config, sys_clock_hw_cycles_per_sec):
                 f', "min_bound_us":{min_bound * 1_000_000:.6f}'
                 f', "max_bound_us":{max_bound * 1_000_000:.6f}'
                 f', "expected_period_cycles":{expected_period:.0f}'
-                f', "MAX_STD_DEV":{max_stddev:.6f}'
+                f', "MAX_STD_DEV":{max_stddev * 1_000_000:.0f}'
                 f', "sys_clock_hw_cycles_per_sec":{sys_clock_hw_cycles_per_sec}, ' +
                 ', '.join(['"CONFIG_{}":{}'.format(k, str(config[k]).rstrip()) for k in [
                                             'SYS_CLOCK_HW_CYCLES_PER_SEC',

--- a/tests/kernel/timer/timer_behavior/src/jitter_drift.c
+++ b/tests/kernel/timer/timer_behavior/src/jitter_drift.c
@@ -285,7 +285,7 @@ static void do_test_using(void (*sample_collection_fn)(void), const char *mechan
 		 ", \"CONFIG_SYS_CLOCK_TICKS_PER_SEC\":%d"
 		 ", \"CONFIG_TIMER_TEST_PERIOD\":%d"
 		 ", \"CONFIG_TIMER_TEST_SAMPLES\":%d"
-		 ", \"MAX STD DEV\":%d"
+		 ", \"MAX_STD_DEV\":%d"
 		 "}\n",
 		 mechanism,
 		 CONFIG_TIMER_TEST_SAMPLES - periodic_rollovers, periodic_rollovers,


### PR DESCRIPTION
Fix `MAX_STD_DEV` calculation and recording at the timer behavior external test.

See also #74939 review [comment](https://github.com/zephyrproject-rtos/zephyr/pull/74939/files#r1670746799).

Recording before the fix:
```
'mechanism': 'builtin_external', ... 'MAX_STD_DEV': 0.008333, ...
'mechanism': 'builtin', ... 'MAX STD DEV': 10, ...
```
Recording after the fix:
```
'mechanism': 'builtin_external', ... 'MAX_STD_DEV': 10, ...
'mechanism': 'builtin', ... 'MAX_STD_DEV': 10, ...
```
