### PR TITLE
doc: doxygen: add kconfig_dep alias

### DIFF
--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -279,6 +279,9 @@ ALIASES                = "rst=\verbatim embed:rst:leading-asterisk" \
                          "req{1}=\ref ZEPH_\1 \"ZEPH-\1\"" \
                          "satisfy{1}=\xrefitem satisfy \"Satisfies requirement\" \"Requirement Implementation\" \1" \
                          "verify{1}=\xrefitem verify \"Verifies requirement\" \"Requirement Verification\" \1" \
+                         "kconfig_dep{1}=\attention Available only when the following Kconfig option is enabled: \kconfig{\1}." \
+                         "kconfig_dep{2}=\attention Available only when the following Kconfig options are enabled: \kconfig{\1}, \kconfig{\2}." \
+                         "kconfig_dep{3}=\attention Available only when the following Kconfig options are enabled: \kconfig{\1}, \kconfig{\2}, \kconfig{\3}." \
                          "funcprops=\par \"Function properties (list may not be complete)\"" \
                          "reschedule=\htmlonly reschedule \endhtmlonly \xmlonly <verbatim>embed:rst:inline :ref:`api_term_reschedule`</verbatim> \endxmlonly" \
                          "sleep=\htmlonly sleep \endhtmlonly \xmlonly <verbatim>embed:rst:inline :ref:`api_term_sleep`</verbatim> \endxmlonly" \


### PR DESCRIPTION
This new alias provides a handy shortcut for listing the Kconfig options that are required for a given symbol to be available.

The following Doxygen comment:

```c
/**
 * @brief Stream disabled callback
 *
 * Disabled callback is called whenever an Audio Stream has been disabled.
 *
 * @kconfig_dep{CONFIG_BT_BAP_UNICAST}
 *
 * @param stream Stream object that has been disabled.
 */
void (*disabled)(struct bt_bap_stream *stream);
```

Will now render as:
(note: don't mind the typo "follow" instead of "following" -- it's been fixed since that screenshot was taken)

<img width="778" alt="image" src="https://github.com/user-attachments/assets/e540d6f4-898d-4d5e-9b16-57fa354d65eb">

- https://builds.zephyrproject.io/zephyr/pr/76783/docs/connectivity/bluetooth/api/audio/bap.html#c.bt_bap_stream_ops.enabled
- https://builds.zephyrproject.io/zephyr/pr/76783/docs/doxygen/html/structbt__bap__stream__ops.html#a1c67137b439a87647994530710d9e075