### PR TITLE
Drivers: Counter: Added flag for counting up

### DIFF
--- a/drivers/counter/timer_dtmr_cmsdk_apb.c
+++ b/drivers/counter/timer_dtmr_cmsdk_apb.c
@@ -177,7 +177,7 @@ static int dtmr_cmsdk_apb_init(const struct device *dev)
 		.info = {						\
 			.max_top_value = UINT32_MAX,			\
 			.freq = 24000000U,				\
-			.flags = 0,					\
+			.flags = COUNTER_CONFIG_INFO_COUNT_UP,		\
 			.channels = 0U,					\
 		},							\
 		.dtimer = DTIMER_CMSDK_REG(inst),			\

--- a/drivers/counter/timer_tmr_cmsdk_apb.c
+++ b/drivers/counter/timer_tmr_cmsdk_apb.c
@@ -173,7 +173,7 @@ static int tmr_cmsdk_apb_init(const struct device *dev)
 		.info = {						\
 			.max_top_value = UINT32_MAX,			\
 			.freq = 24000000U,				\
-			.flags = 0,					\
+			.flags = COUNTER_CONFIG_INFO_COUNT_UP,		\
 			.channels = 0U,					\
 		},							\
 		.timer = ((volatile struct timer_cmsdk_apb *)DT_INST_REG_ADDR(inst)), \


### PR DESCRIPTION
Tmr and dtmr drivers were missing a flag which tells the counter_is_conting_up function that the counter is counting up. So I've added the flag

Fixes: #76785