### PR TITLE
Revert "arch: riscv: stacktrace: fix output without `ra` on the stack top"

### DIFF
--- a/arch/riscv/core/stacktrace.c
+++ b/arch/riscv/core/stacktrace.c
@@ -90,10 +90,7 @@ static bool in_stack_bound(uintptr_t addr, const struct k_thread *const thread,
 static bool in_fatal_stack_bound(uintptr_t addr, const struct k_thread *const thread,
 				 const struct arch_esf *esf)
 {
-	const uintptr_t align =
-		COND_CODE_1(CONFIG_FRAME_POINTER, (ARCH_STACK_PTR_ALIGN), (sizeof(uintptr_t)));
-
-	if (!IS_ALIGNED(addr, align)) {
+	if (!IS_ALIGNED(addr, sizeof(uintptr_t))) {
 		return false;
 	}
 
@@ -137,53 +134,22 @@ static void walk_stackframe(stack_trace_callback_fn cb, void *cookie, const stru
 		ra = csf->ra;
 	}
 
-	for (int i = 0; (i < MAX_STACK_FRAMES) && vrfy(fp, thread, esf) && (fp > last_fp); i++) {
-		if (in_text_region(ra) && !cb(cookie, ra)) {
-			break;
-		}
-		last_fp = fp;
-
-		/* Unwind to the previous frame */
-		frame = (struct stackframe *)fp - 1;
-
-		if ((i == 0) && (esf != NULL)) {
-			/* Print `esf->ra` if we are at the top of the stack */
-			if (in_text_region(esf->ra) && !cb(cookie, esf->ra)) {
+	for (int i = 0; (i < MAX_STACK_FRAMES) && vrfy(fp, thread, esf) && (fp > last_fp);) {
+		if (in_text_region(ra)) {
+			if (!cb(cookie, ra)) {
 				break;
 			}
-			/**
-			 * For the first stack frame, the `ra` is not stored in the frame if the
-			 * preempted function doesn't call any other function, we can observe:
-			 *
-			 *                     .-------------.
-			 *   frame[0]->fp ---> | frame[0] fp |
-			 *                     :-------------:
-			 *   frame[0]->ra ---> | frame[1] fp |
-			 *                     | frame[1] ra |
-			 *                     :~~~~~~~~~~~~~:
-			 *                     | frame[N] fp |
-			 *
-			 * Instead of:
-			 *
-			 *                     .-------------.
-			 *   frame[0]->fp ---> | frame[0] fp |
-			 *   frame[0]->ra ---> | frame[1] ra |
-			 *                     :-------------:
-			 *                     | frame[1] fp |
-			 *                     | frame[1] ra |
-			 *                     :~~~~~~~~~~~~~:
-			 *                     | frame[N] fp |
-			 *
-			 * Check if `frame->ra` actually points to a `fp`, and adjust accordingly
+			/*
+			 * Increment the iterator only if `ra` is within the text region to get the
+			 * most out of it
 			 */
-			if (vrfy(frame->ra, thread, esf)) {
-				fp = frame->ra;
-				frame = (struct stackframe *)fp;
-			}
+			i++;
 		}
-
-		fp = frame->fp;
+		last_fp = fp;
+		/* Unwind to the previous frame */
+		frame = (struct stackframe *)fp - 1;
 		ra = frame->ra;
+		fp = frame->fp;
 	}
 }
 #else  /* !CONFIG_FRAME_POINTER */

--- a/tests/arch/common/stack_unwind/testcase.yaml
+++ b/tests/arch/common/stack_unwind/testcase.yaml
@@ -7,6 +7,7 @@ tests:
   arch.common.stack_unwind.riscv_fp:
     arch_allow: riscv
     integration_platforms:
+      - qemu_riscv32e
       - qemu_riscv32
       - qemu_riscv64
     extra_configs:
@@ -20,6 +21,7 @@ tests:
   arch.common.stack_unwind.riscv_sp:
     arch_allow: riscv
     integration_platforms:
+      - qemu_riscv32e
       - qemu_riscv32
       - qemu_riscv64
     harness_config:
@@ -58,6 +60,7 @@ tests:
       - riscv
       - arm64
     integration_platforms:
+      - qemu_riscv32e
       - qemu_riscv32
       - qemu_riscv64
       - qemu_cortex_a53


### PR DESCRIPTION
This reverts commit 9698df9dc42b43711f7644217408f6a9cddfe37b.

It broke `qemu_riscv32e` on:
tests/arch/common/stack_unwind/arch.common.stack_unwind.symtab

Additionally, add `qemu_riscv32e` to the test since it is kinda special, to make sure that we don't repeat this

Fixes #76792