### PR TITLE
Drivers: Sensor: mc3419: Added LPF Configuration using DT properties

### DIFF
--- a/drivers/sensor/mc3419/Kconfig
+++ b/drivers/sensor/mc3419/Kconfig
@@ -35,14 +35,4 @@ config MC3419_THREAD_STACK_SIZE
 
 endif # MC3419_TRIGGER
 
-config MC3419_DECIMATION_RATE
-	int "Enable decimation rate"
-	range 0 15
-	default 15
-	help
-	 This helps in producing slower interrupt. Internal Data
-	 Rate is divide by this decimation rate. If decimation rate
-	 is 0 then internal data rate is equal to output data rate,
-	 then it produce interrupt floods.
-
 endif # MC3419

--- a/drivers/sensor/mc3419/mc3419.c
+++ b/drivers/sensor/mc3419/mc3419.c
@@ -143,8 +143,7 @@ static int mc3419_set_odr(const struct device *dev,
 	}
 
 	LOG_DBG("Set ODR Rate to 0x%x", data_rate);
-	ret = i2c_reg_write_byte_dt(&cfg->i2c, MC3419_REG_SAMPLE_RATE_2,
-				    CONFIG_MC3419_DECIMATION_RATE);
+	ret = i2c_reg_write_byte_dt(&cfg->i2c, MC3419_REG_SAMPLE_RATE_2, cfg->decimation_rate);
 	if (ret < 0) {
 		LOG_ERR("Failed to set decimation rate (%d)", ret);
 		return ret;
@@ -304,9 +303,11 @@ static const struct sensor_driver_api mc3419_api = {
 #endif
 
 #define MC3419_DEFINE(idx)                                                                         \
+                                                                                                   \
 	static const struct mc3419_config mc3419_config_##idx = {                                  \
 		.i2c = I2C_DT_SPEC_INST_GET(idx),                                                  \
 		.lpf_fc_sel = DT_INST_PROP(idx, lpf_fc_sel),                                       \
+		.decimation_rate = DT_INST_PROP(idx, decimation_rate),                             \
 		MC3419_CFG_IRQ(idx)};                                                              \
 	static struct mc3419_driver_data mc3419_data_##idx;                                        \
 	SENSOR_DEVICE_DT_INST_DEFINE(idx, mc3419_init, NULL, &mc3419_data_##idx,                   \

--- a/drivers/sensor/mc3419/mc3419.c
+++ b/drivers/sensor/mc3419/mc3419.c
@@ -271,6 +271,12 @@ static int mc3419_init(const struct device *dev)
 	}
 #endif
 
+	ret = i2c_reg_update_byte_dt(&cfg->i2c, MC3419_REG_RANGE_SELECT_CTRL, MC3419_LPF_MASK,
+				     cfg->lpf_fc_sel);
+	if (ret < 0) {
+		LOG_ERR("Failed to configure LPF (%d)", ret);
+		return ret;
+	}
 	/* Leave the sensor in default power on state, will be
 	 * enabled by configure attr or setting trigger.
 	 */
@@ -297,18 +303,14 @@ static const struct sensor_driver_api mc3419_api = {
 #define MC3419_CFG_IRQ(idx)
 #endif
 
-#define MC3419_DEFINE(idx)						\
-	static const struct mc3419_config mc3419_config_##idx = {	\
-		.i2c = I2C_DT_SPEC_INST_GET(idx),			\
-		MC3419_CFG_IRQ(idx)					\
-	};								\
-	static struct mc3419_driver_data mc3419_data_##idx;		\
-	SENSOR_DEVICE_DT_INST_DEFINE(idx,				\
-				mc3419_init, NULL,			\
-				&mc3419_data_##idx,			\
-				&mc3419_config_##idx,			\
-				POST_KERNEL,				\
-				CONFIG_SENSOR_INIT_PRIORITY,		\
-				&mc3419_api);
+#define MC3419_DEFINE(idx)                                                                         \
+	static const struct mc3419_config mc3419_config_##idx = {                                  \
+		.i2c = I2C_DT_SPEC_INST_GET(idx),                                                  \
+		.lpf_fc_sel = DT_INST_PROP(idx, lpf_fc_sel),                                       \
+		MC3419_CFG_IRQ(idx)};                                                              \
+	static struct mc3419_driver_data mc3419_data_##idx;                                        \
+	SENSOR_DEVICE_DT_INST_DEFINE(idx, mc3419_init, NULL, &mc3419_data_##idx,                   \
+				     &mc3419_config_##idx, POST_KERNEL,                            \
+				     CONFIG_SENSOR_INIT_PRIORITY, &mc3419_api);
 
 DT_INST_FOREACH_STATUS_OKAY(MC3419_DEFINE)

--- a/drivers/sensor/mc3419/mc3419.h
+++ b/drivers/sensor/mc3419/mc3419.h
@@ -29,6 +29,7 @@
 #define MC3419_REG_ANY_MOTION_THRES	0x43
 
 #define MC3419_RANGE_MASK		GENMASK(6, 4)
+#define MC3419_LPF_MASK                 GENMASK(3, 0)
 #define MC3419_DATA_READY_MASK		BIT(7)
 #define MC3419_ANY_MOTION_MASK		BIT(2)
 #define MC3419_INT_CLEAR		0x00
@@ -71,6 +72,7 @@ struct mc3419_config {
 	struct gpio_dt_spec int_gpio;
 	bool int_cfg;
 #endif
+	uint8_t lpf_fc_sel;
 };
 
 struct mc3419_driver_data {

--- a/drivers/sensor/mc3419/mc3419.h
+++ b/drivers/sensor/mc3419/mc3419.h
@@ -73,6 +73,7 @@ struct mc3419_config {
 	bool int_cfg;
 #endif
 	uint8_t lpf_fc_sel;
+	uint8_t decimation_rate;
 };
 
 struct mc3419_driver_data {

--- a/dts/bindings/sensor/memsic,mc3419.yaml
+++ b/dts/bindings/sensor/memsic,mc3419.yaml
@@ -11,6 +11,7 @@ description: |
       ...
 
       lpf-fc-sel = <MC3419_LPF_DISABLE>;
+      decimation-rate = <MC3419_DECIMATE_IDR_BY_1>;
     };
 
 compatible: "memsic,mc3419"
@@ -49,3 +50,32 @@ properties:
       | 13        | MC3419_LPF_EN_WITH_IDR_BY_16_FC     |
       +-----------+-------------------------------------+
       Default is LPF disabled (reset value of the register).
+
+  decimation-rate:
+    type: int
+    default: 0
+    enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+    description: |
+      This helps in producing slower Output Data Rate (ODR) from given Input Data Rate (IDR).
+      Possible values are listed below. Either use Int value or Macro Name in node definition.
+      +-----------+-------------------------------+
+      | Int value | Macro Name                    |
+      +-----------+-------------------------------+
+      | 0         | MC3419_DECIMATE_IDR_BY_1      |
+      | 1         | MC3419_DECIMATE_IDR_BY_2      |
+      | 2         | MC3419_DECIMATE_IDR_BY_4      |
+      | 3         | MC3419_DECIMATE_IDR_BY_5      |
+      | 4         | MC3419_DECIMATE_IDR_BY_8      |
+      | 5         | MC3419_DECIMATE_IDR_BY_10     |
+      | 6         | MC3419_DECIMATE_IDR_BY_16     |
+      | 7         | MC3419_DECIMATE_IDR_BY_20     |
+      | 8         | MC3419_DECIMATE_IDR_BY_40     |
+      | 9         | MC3419_DECIMATE_IDR_BY_67     |
+      | 10        | MC3419_DECIMATE_IDR_BY_80     |
+      | 11        | MC3419_DECIMATE_IDR_BY_100    |
+      | 12        | MC3419_DECIMATE_IDR_BY_200    |
+      | 13        | MC3419_DECIMATE_IDR_BY_250    |
+      | 14        | MC3419_DECIMATE_IDR_BY_500    |
+      | 15        | MC3419_DECIMATE_IDR_BY_1000   |
+      +-----------+-------------------------------+
+      Default is Decimation 0 (reset value of the register).

--- a/dts/bindings/sensor/memsic,mc3419.yaml
+++ b/dts/bindings/sensor/memsic,mc3419.yaml
@@ -1,7 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2023 Linumiz
 
-description: MC3419 3-axis accel sensor
+description: |
+    MC3419 3-axis accel sensor
+
+    Example:
+    #include <zephyr/dt-bindings/sensor/mc3419.h>
+
+    mc3419: mc3419@0 {
+      ...
+
+      lpf-fc-sel = <MC3419_LPF_DISABLE>;
+    };
 
 compatible: "memsic,mc3419"
 
@@ -21,3 +31,21 @@ properties:
       has two interrupt pins.By default the interrupt are routed
       to interrupt pin 1, by enabled this property interrupt are
       routed to interrupt pin 2.
+
+  lpf-fc-sel:
+    type: int
+    default: 0
+    enum: [0, 9, 10, 11, 13]
+    description: |
+      Enable and select LPF cutoff frequency for a given IDR (Input Data Rate).
+      Possible values are listed below. Either use Int value or Macro Name in node definition.
+      +-----------+-------------------------------------+
+      | int value | Macro Name                          |
+      +-----------+-------------------------------------+
+      | 0         | MC3419_LPF_DISABLE                  |
+      | 9         | MC3419_LPF_EN_WITH_IDR_BY_4p255_FC  |
+      | 10        | MC3419_LPF_EN_WITH_IDR_BY_6_FC      |
+      | 11        | MC3419_LPF_EN_WITH_IDR_BY_12_FC     |
+      | 13        | MC3419_LPF_EN_WITH_IDR_BY_16_FC     |
+      +-----------+-------------------------------------+
+      Default is LPF disabled (reset value of the register).

--- a/include/zephyr/dt-bindings/sensor/mc3419.h
+++ b/include/zephyr/dt-bindings/sensor/mc3419.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 Croxel Inc
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MEMSIC_MC3419_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_MEMSIC_MC3419_H_
+
+/**
+ * @defgroup MC3419 memsic DT Options
+ * @ingroup sensor_interface
+ * @{
+ */
+
+/**
+ * @defgroup MC3419_LPF_CONFIGS Lowe pass filter configurations
+ * @{
+ */
+#define MC3419_LPF_DISABLE                 0
+#define MC3419_LPF_EN_WITH_IDR_BY_4p255_FC 9
+#define MC3419_LPF_EN_WITH_IDR_BY_6_FC     10
+#define MC3419_LPF_EN_WITH_IDR_BY_12_FC    11
+#define MC3419_LPF_EN_WITH_IDR_BY_16_FC    13
+/** @} */
+
+/** @} */
+
+#endif /*ZEPHYR_INCLUDE_DT_BINDINGS_MEMSIC_MC3419_H_ */

--- a/include/zephyr/dt-bindings/sensor/mc3419.h
+++ b/include/zephyr/dt-bindings/sensor/mc3419.h
@@ -7,7 +7,7 @@
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MEMSIC_MC3419_H_
 
 /**
- * @defgroup MC3419 memsic DT Options
+ * @defgroup MC3419 Memsic DT Options
  * @ingroup sensor_interface
  * @{
  */
@@ -21,6 +21,28 @@
 #define MC3419_LPF_EN_WITH_IDR_BY_6_FC     10
 #define MC3419_LPF_EN_WITH_IDR_BY_12_FC    11
 #define MC3419_LPF_EN_WITH_IDR_BY_16_FC    13
+/** @} */
+
+/**
+ * @defgroup MC3419_DECIMATION_RATES decimate sampling rate by provided rate
+ * @{
+ */
+#define MC3419_DECIMATE_IDR_BY_1    0
+#define MC3419_DECIMATE_IDR_BY_2    1
+#define MC3419_DECIMATE_IDR_BY_4    2
+#define MC3419_DECIMATE_IDR_BY_5    3
+#define MC3419_DECIMATE_IDR_BY_8    4
+#define MC3419_DECIMATE_IDR_BY_10   5
+#define MC3419_DECIMATE_IDR_BY_16   6
+#define MC3419_DECIMATE_IDR_BY_20   7
+#define MC3419_DECIMATE_IDR_BY_40   8
+#define MC3419_DECIMATE_IDR_BY_67   9
+#define MC3419_DECIMATE_IDR_BY_80   10
+#define MC3419_DECIMATE_IDR_BY_100  11
+#define MC3419_DECIMATE_IDR_BY_200  12
+#define MC3419_DECIMATE_IDR_BY_250  13
+#define MC3419_DECIMATE_IDR_BY_500  14
+#define MC3419_DECIMATE_IDR_BY_1000 15
 /** @} */
 
 /** @} */


### PR DESCRIPTION
For applications that rely on low noise/variance in accelerometer sample reading. Application can take advantage of integrated LPF Thus this PR adds LPF configuration capability to the mc3419 driver