### PR TITLE
arch: riscv: update `ARCH_STACK_PTR_ALIGN` on RV32E to 4 bytes

### DIFF
--- a/include/zephyr/arch/riscv/arch.h
+++ b/include/zephyr/arch/riscv/arch.h
@@ -30,8 +30,13 @@
 #include <zephyr/arch/riscv/csr.h>
 #include <zephyr/arch/riscv/exception.h>
 
+#ifdef CONFIG_RISCV_ISA_RV32E
+/* Stack alignment for RV32E is 4 bytes */
+#define ARCH_STACK_PTR_ALIGN  4
+#else
 /* stacks, for RISCV architecture stack should be 16byte-aligned */
 #define ARCH_STACK_PTR_ALIGN  16
+#endif
 
 #define Z_RISCV_STACK_PMP_ALIGN \
 	MAX(CONFIG_PMP_GRANULARITY, ARCH_STACK_PTR_ALIGN)

--- a/tests/arch/common/stack_unwind/testcase.yaml
+++ b/tests/arch/common/stack_unwind/testcase.yaml
@@ -7,6 +7,7 @@ tests:
   arch.common.stack_unwind.riscv_fp:
     arch_allow: riscv
     integration_platforms:
+      - qemu_riscv32e
       - qemu_riscv32
       - qemu_riscv64
     extra_configs:
@@ -20,6 +21,7 @@ tests:
   arch.common.stack_unwind.riscv_sp:
     arch_allow: riscv
     integration_platforms:
+      - qemu_riscv32e
       - qemu_riscv32
       - qemu_riscv64
     harness_config:
@@ -58,6 +60,7 @@ tests:
       - riscv
       - arm64
     integration_platforms:
+      - qemu_riscv32e
       - qemu_riscv32
       - qemu_riscv64
       - qemu_cortex_a53


### PR DESCRIPTION
https://github.com/zephyrproject-rtos/zephyr/blob/d590c18672845e63fc1b49d917113d52b2e1d771/arch/riscv/core/isr.S#L520-L525

```
*** Booting Zephyr OS build v3.7.0-680-gf65c0eed176a ***
Hello World! qemu_riscv32e
1: func1
2: func2
3: func1
4: func2
5: func1
6: func2
E:      a0: 00000003    t0: 00000000
E:      a1: 80008ac7    t1: 00000000
E:      a2: 8000baf8    t2: 00000009
E:      a3: 8000a110
E:      a4: 00000000
E:      a5: 00000004
E:      sp: 8000bb04
E:      ra: 80000718
E:    mepc: 80000726
E: mstatus: 00021880
E:
E:      s0: 8000a2a4
E:      s1: 00000006
E:
E: call trace:
E:       0: ra: 80000726 [func2+0x30]
E:       1: ra: 80000718 [func2+0x22]
E:       2: ra: 8000075e [func1+0x28]
E:       3: ra: 8000072c [func2+0x36]
E:       4: ra: 8000075e [func1+0x28]
E:       5: ra: 8000072c [func2+0x36]
E:       6: ra: 8000075e [func1+0x28]
E:       7: ra: 80000788 [main+0x20]
E:       8: ra: 80002ab2 [bg_thread_main+0x26]
E:
E: >>> ZEPHYR FATAL ERROR 3: Kernel oops on CPU 0
E: Current thread: 0x8000a110 (main)
E: Halting system
```

Fixes #76792

```
(.venv) ycsin@ycsin-mba zephyr % west twister -p qemu_riscv32e -T tests/arch/common -T tests/arch/riscv -T tests/kernel
INFO    - Using Ninja..
INFO    - Zephyr version: v3.7.0-681-g24d80a8ec32b
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testsuite list...
INFO    - Writing JSON report /Users/ycsin/zephyrproject/zephyr/twister-out/testplan.json
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - Total complete:  202/ 202  100%  skipped:   78, failed:    0, error:    0
INFO    - 202 test scenarios (202 test instances) selected, 78 configurations skipped (56 by static filter, 22 at runtime).
INFO    - 124 of 202 test configurations passed (100.00%), 0 failed, 0 errored, 78 skipped with 0 warnings in 6712.91 seconds
INFO    - In total 1357 test cases were executed, 737 skipped on 1 out of total 1 platforms (100.00%)
INFO    - 122 test configurations executed on platforms, 2 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing JSON report /Users/ycsin/zephyrproject/zephyr/twister-out/twister.json
INFO    - Writing xunit report /Users/ycsin/zephyrproject/zephyr/twister-out/twister.xml...
INFO    - Writing xunit report /Users/ycsin/zephyrproject/zephyr/twister-out/twister_report.xml...
INFO    - Run completed
```