### PR TITLE
tests: drivers: spi: Add nordic,clock-enable to SCK in spi12x

### DIFF
--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay
@@ -7,8 +7,12 @@
 &pinctrl {
 	spi121_default_alt: spi121_default_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 7, 2)>,
-				<NRF_PSEL(SPIM_MISO, 7, 0)>,
+			psels = <NRF_PSEL(SPIM_SCK, 7, 2)>;
+			nordic,clock-enable;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(SPIM_MISO, 7, 0)>,
 				<NRF_PSEL(SPIM_MOSI, 7, 1)>;
 		};
 	};

--- a/tests/drivers/spi/spi_error_cases/boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay
+++ b/tests/drivers/spi/spi_error_cases/boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay
@@ -7,8 +7,11 @@
 &pinctrl {
 	spi121_default_alt: spi121_default_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 7, 2)>,
-				<NRF_PSEL(SPIM_MISO, 7, 0)>,
+			psels = <NRF_PSEL(SPIM_SCK, 7, 2)>;
+			nordic,clock-enable;
+		};
+		group2 {
+			psels = <NRF_PSEL(SPIM_MISO, 7, 0)>,
 				<NRF_PSEL(SPIM_MOSI, 7, 1)>;
 		};
 	};

--- a/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay
@@ -7,8 +7,11 @@
 &pinctrl {
 	spi120_default: spi120_default {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 7, 3)>,
-				<NRF_PSEL(SPIM_MISO, 7, 6)>,
+			psels = <NRF_PSEL(SPIM_SCK, 7, 3)>;
+			nordic,clock-enable;
+		};
+		group2 {
+			psels = <NRF_PSEL(SPIM_MISO, 7, 6)>,
 				<NRF_PSEL(SPIM_MOSI, 7, 7)>;
 		};
 	};


### PR DESCRIPTION
Fast SPI instances (spi12x) also requires clock pin property to be enabled for SCK pin.