### PR TITLE
Add support for Rust to the CI builds.

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -195,9 +195,17 @@ jobs:
           west config --global update.narrow true
           west update --path-cache /repo-cache/zephyrproject 2>&1 1> west.update.log || west update --path-cache /repo-cache/zephyrproject 2>&1 1> west.update.log || ( rm -rf ../modules ../bootloader ../tools && west update --path-cache /repo-cache/zephyrproject)
           west forall -c 'git reset --hard HEAD'
-          for target in `cat lib/rust/targets.txt`; do rustup target install $target; done
 
           echo "ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/zephyr-sdk-$( cat SDK_VERSION )" >> $GITHUB_ENV
+
+      - name: Setup Rust target environment
+        run: |
+          # Ensure that all supported targets have been downloaded.
+          # If the container is up-to-date, this won't do anything,
+          # but keeps updates to Zephyr from having to coordinate with
+          # container changes.
+          rustc --version
+          for target in `cat lib/rust/targets.txt`; do rustup target install $target; done
 
       - name: Check Environment
         run: |

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -188,12 +188,14 @@ jobs:
             git log  --pretty=oneline | head -n 10
           fi
           echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
           west init -l . || true
           west config manifest.group-filter -- +ci,+optional
           west config --global update.narrow true
           west update --path-cache /repo-cache/zephyrproject 2>&1 1> west.update.log || west update --path-cache /repo-cache/zephyrproject 2>&1 1> west.update.log || ( rm -rf ../modules ../bootloader ../tools && west update --path-cache /repo-cache/zephyrproject)
           west forall -c 'git reset --hard HEAD'
+          for target in `cat lib/rust/targets.txt`; do rustup target install $target; done
 
           echo "ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/zephyr-sdk-$( cat SDK_VERSION )" >> $GITHUB_ENV
 

--- a/lib/rust/targets.txt
+++ b/lib/rust/targets.txt
@@ -1,0 +1,7 @@
+riscv32i-unknown-none-elf
+riscv64imac-unknown-none-elf
+thumbv6m-none-eabi
+thumbv7em-none-eabi
+thumbv7m-none-eabi
+thumbv8m.main-none-eabi
+x86_64-unknown-none


### PR DESCRIPTION
The rust toolchain is already in the path, it just needs to be added to the path.

There is also a workaround to install the target support, which is needed until these are added to the docker images.