### PR TITLE
dma: emul: Fix pm action signature

### DIFF
--- a/drivers/dma/dma_emul.c
+++ b/drivers/dma/dma_emul.c
@@ -526,7 +526,7 @@ static const struct dma_driver_api dma_emul_driver_api = {
 };
 
 #ifdef CONFIG_PM_DEVICE
-static int gpio_emul_pm_device_pm_action(const struct device *dev, enum pm_device_action action)
+static int dma_emul_pm_device_pm_action(const struct device *dev, enum pm_device_action action)
 {
 	ARG_UNUSED(dev);
 	ARG_UNUSED(action);


### PR DESCRIPTION
The signature for dma_emul pm action callback is wrong.