### PR TITLE
boards: esp32-wroom: dts: Add blue LED description

### DIFF
--- a/boards/espressif/esp32_devkitc_wroom/esp32_devkitc_wroom_procpu.dts
+++ b/boards/espressif/esp32_devkitc_wroom/esp32_devkitc_wroom_procpu.dts
@@ -15,6 +15,7 @@
 	compatible = "espressif,esp32";
 
 	aliases {
+		led0 = &blue_led;
 		uart-0 = &uart0;
 		i2c-0 = &i2c0;
 		sw0 = &button0;
@@ -37,6 +38,15 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,bt-hci = &esp32_bt_hci;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		blue_led: led_0 {
+			gpios =  <&gpio0 2 GPIO_ACTIVE_HIGH>;
+			label = "Blue - LED0";
+		};
 	};
 };
 


### PR DESCRIPTION
Sample application `blinky` does not compile, as no led0 description, required by the sample, is present for esp32_devkitc_wroom

There is one issue #29394 that has a comment requesting how to build blinky on esp32, and then #36412 (which is closed)

Adding blue LED description makes sample application compilation successful and board blinking blue color: "I'm blue da ba dee..."

Testing:
`west build -p always -b esp32_devkitc_wroom samples/basic/blinky`
`west flash`

Error logs:
```
# west build -p always -b esp32_devkitc_wroom samples/basic/blinky
-- west build: making build dir /wonderland/projects/zephyr/zephyr/build pristine
-- west build: generating a build system
Loading Zephyr default modules (Zephyr base).
-- Application: /wonderland/projects/zephyr/zephyr/samples/basic/blinky
-- CMake version: 3.25.1
-- Found Python3: /wonderland/projects/zephyr/.venv/bin/python3 (found suitable version "3.11.4", minimum required is "3.8") found components: Interpreter 
-- Cache files will be written to: /wonderland/.cache/zephyr
-- Zephyr version: 3.7.99 (/wonderland/projects/zephyr/zephyr)
-- Found west (found suitable version "1.2.0", minimum required is "0.14.0")
CMake Warning at /wonderland/projects/zephyr/zephyr/cmake/modules/boards.cmake:110 (message):
  Deprecated BOARD=esp32_devkitc_wroom specified, board automatically changed
  to: esp32_devkitc_wroom/esp32/procpu.
Call Stack (most recent call first):
  /wonderland/projects/zephyr/zephyr/cmake/modules/zephyr_default.cmake:132 (include)
  /wonderland/projects/zephyr/zephyr/share/zephyr-package/cmake/ZephyrConfig.cmake:66 (include)
  /wonderland/projects/zephyr/zephyr/share/zephyr-package/cmake/ZephyrConfig.cmake:92 (include_boilerplate)
  CMakeLists.txt:4 (find_package)


-- Board: esp32_devkitc_wroom, qualifiers: esp32/procpu
-- ZEPHYR_TOOLCHAIN_VARIANT not set, trying to locate Zephyr SDK
-- Found host-tools: zephyr 0.16.8 (/wonderland/projects/zephyr/sdk/zephyr-sdk-0.16.8)
-- Found toolchain: zephyr 0.16.8 (/wonderland/projects/zephyr/sdk/zephyr-sdk-0.16.8)
-- Found Dtc: /wonderland/projects/zephyr/sdk/zephyr-sdk-0.16.8/sysroots/x86_64-pokysdk-linux/usr/bin/dtc (found suitable version "1.6.0", minimum required is "1.4.6") 
-- Found BOARD.dts: /wonderland/projects/zephyr/zephyr/boards/espressif/esp32_devkitc_wroom/esp32_devkitc_wroom_procpu.dts
-- Generated zephyr.dts: /wonderland/projects/zephyr/zephyr/build/zephyr/zephyr.dts
-- Generated devicetree_generated.h: /wonderland/projects/zephyr/zephyr/build/zephyr/include/generated/zephyr/devicetree_generated.h
-- Including generated dts.cmake file: /wonderland/projects/zephyr/zephyr/build/zephyr/dts.cmake
Parsing /wonderland/projects/zephyr/zephyr/Kconfig
Loaded configuration '/wonderland/projects/zephyr/zephyr/boards/espressif/esp32_devkitc_wroom/esp32_devkitc_wroom_procpu_defconfig'
Merged configuration '/wonderland/projects/zephyr/zephyr/samples/basic/blinky/prj.conf'
Configuration saved to '/wonderland/projects/zephyr/zephyr/build/zephyr/.config'
Kconfig header saved to '/wonderland/projects/zephyr/zephyr/build/zephyr/include/generated/zephyr/autoconf.h'
-- Found GnuLd: /wonderland/projects/zephyr/sdk/zephyr-sdk-0.16.8/xtensa-espressif_esp32_zephyr-elf/xtensa-espressif_esp32_zephyr-elf/bin/ld.bfd (found version "2.38") 
-- The C compiler identification is GNU 12.2.0
-- The CXX compiler identification is GNU 12.2.0
-- The ASM compiler identification is GNU
-- Found assembler: /wonderland/projects/zephyr/sdk/zephyr-sdk-0.16.8/xtensa-espressif_esp32_zephyr-elf/bin/xtensa-espressif_esp32_zephyr-elf-gcc
esptool path: /wonderland/projects/zephyr/modules/hal/espressif/tools/esptool_py/esptool.py
-- Using ccache: /usr/bin/ccache
-- Configuring done
-- Generating done
-- Build files have been written to: /wonderland/projects/zephyr/zephyr/build
-- west build: building application
[3/198] Preparing syscall dependency handling

[4/198] Generating include/generated/zephyr/version.h
-- Zephyr version: 3.7.99 (/wonderland/projects/zephyr/zephyr), build: v3.7.0-712-gaf314643a32d
[143/198] Building C object CMakeFiles/app.dir/src/main.c.obj
FAILED: CMakeFiles/app.dir/src/main.c.obj 
ccache /wonderland/projects/zephyr/sdk/zephyr-sdk-0.16.8/xtensa-espressif_esp32_zephyr-elf/bin/xtensa-espressif_esp32_zephyr-elf-gcc -DCONFIG_APP_BUILD_USE_FLASH_SECTIONS -DESP_PLATFORM -DKERNEL -DK_HEAP_MEM_POOL_SIZE=4096 -DPICOLIBC_LONG_LONG_PRINTF_SCANF -D__LINUX_ERRNO_EXTENSIONS__ -D__ZEPHYR__=1 -I/wonderland/projects/zephyr/zephyr/build/zephyr/include/generated/zephyr -I/wonderland/projects/zephyr/zephyr/include -I/wonderland/projects/zephyr/zephyr/build/zephyr/include/generated -I/wonderland/projects/zephyr/zephyr/soc/espressif -I/wonderland/projects/zephyr/zephyr/soc/espressif/common/include -I/wonderland/projects/zephyr/zephyr/soc/espressif/esp32/. -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/include/bt -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../esp_shared/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../esp_shared/components/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../port/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/efuse/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/efuse/private_include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/efuse/esp32/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/efuse/esp32/private_include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/esp_common/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/esp_hw_support/dma -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/esp_hw_support/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/esp_hw_support/include/esp_private -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/esp_hw_support/include/hal -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/esp_hw_support/include/soc -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/esp_hw_support/include/soc/esp32 -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/esp_hw_support/port/esp32 -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/esp_hw_support/port/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/esp_rom/esp32 -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/esp_rom/esp32/ld -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/esp_rom/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/esp_rom/include/esp32 -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/esp_system/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/esp_system/include/esp_private -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/esp_system/port/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/esp_system/port/include/private -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/hal/esp32/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/hal/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/hal/platform_port/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/log/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/soc/esp32/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/soc/esp32/include/soc -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/soc/esp32/ld -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/soc/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/xtensa/esp32/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/xtensa/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/xtensa/include/esp_private -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/xtensa/include/xtensa -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/esp_timer/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/esp_timer/private_include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/driver/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/driver/deprecated -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/driver/gpio/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/driver/uart/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/driver/touch_sensor/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/driver/touch_sensor/esp32/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/driver/spi/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/spi_flash/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/spi_flash/include/spi_flash -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/esp_pm/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/bootloader_support/bootloader_flash/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/bootloader_support/private_include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/bootloader_support/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/heap/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/esp_psram/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/esp_mm/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/esp_wifi/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/esp_event/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/esp_event/private_include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/esp_phy/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/esp_phy/include/esp32 -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/esp_phy/esp32/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/esp_wifi/esp32/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/esp_netif/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/wpa_supplicant/esp_supplicant/src -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/wpa_supplicant/esp_supplicant/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/wpa_supplicant/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/wpa_supplicant/include/esp_supplicant -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/wpa_supplicant/port/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/wpa_supplicant/src -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/wpa_supplicant/src/crypto -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/wpa_supplicant/src/eap_peer -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/wpa_supplicant/src/utils -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/esp_coex/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../../components/mbedtls/port/include -I/wonderland/projects/zephyr/modules/hal/espressif/zephyr/esp32/../port/include/boot -isystem /wonderland/projects/zephyr/zephyr/lib/libc/common/include -fno-strict-aliasing -Os -imacros /wonderland/projects/zephyr/zephyr/build/zephyr/include/generated/zephyr/autoconf.h -fno-printf-return-value -fno-common -g -gdwarf-4 -fdiagnostics-color=always --sysroot=/wonderland/projects/zephyr/sdk/zephyr-sdk-0.16.8/xtensa-espressif_esp32_zephyr-elf/xtensa-espressif_esp32_zephyr-elf -imacros /wonderland/projects/zephyr/zephyr/include/zephyr/toolchain/zephyr_stdint.h -Wall -Wformat -Wformat-security -Wno-format-zero-length -Wdouble-promotion -Wno-pointer-sign -Wpointer-arith -Wexpansion-to-defined -Wno-unused-but-set-variable -Werror=implicit-int -fno-pic -fno-pie -fno-asynchronous-unwind-tables -fno-reorder-functions --param=min-pagesize=0 -fno-defer-pop -fmacro-prefix-map=/wonderland/projects/zephyr/zephyr/samples/basic/blinky=CMAKE_SOURCE_DIR -fmacro-prefix-map=/wonderland/projects/zephyr/zephyr=ZEPHYR_BASE -fmacro-prefix-map=/wonderland/projects/zephyr=WEST_TOPDIR -ffunction-sections -fdata-sections -mlongcalls --specs=picolibc.specs -Wno-unused-variable -Wno-maybe-uninitialized -std=c99 -MD -MT CMakeFiles/app.dir/src/main.c.obj -MF CMakeFiles/app.dir/src/main.c.obj.d -o CMakeFiles/app.dir/src/main.c.obj -c /wonderland/projects/zephyr/zephyr/samples/basic/blinky/src/main.c
In file included from /wonderland/projects/zephyr/zephyr/include/zephyr/toolchain/gcc.h:98,
                 from /wonderland/projects/zephyr/zephyr/include/zephyr/toolchain.h:50,
                 from /wonderland/projects/zephyr/zephyr/include/zephyr/kernel_includes.h:23,
                 from /wonderland/projects/zephyr/zephyr/include/zephyr/kernel.h:17,
                 from /wonderland/projects/zephyr/zephyr/samples/basic/blinky/src/main.c:8:
/wonderland/projects/zephyr/zephyr/include/zephyr/device.h:92:41: error: '__device_dts_ord_DT_N_ALIAS_led0_P_gpios_IDX_0_PH_ORD' undeclared here (not in a function)
   92 | #define DEVICE_NAME_GET(dev_id) _CONCAT(__device_, dev_id)
      |                                         ^~~~~~~~~
/wonderland/projects/zephyr/zephyr/include/zephyr/toolchain/common.h:137:26: note: in definition of macro '_DO_CONCAT'
  137 | #define _DO_CONCAT(x, y) x ## y
      |                          ^
/wonderland/projects/zephyr/zephyr/include/zephyr/device.h:92:33: note: in expansion of macro '_CONCAT'
   92 | #define DEVICE_NAME_GET(dev_id) _CONCAT(__device_, dev_id)
      |                                 ^~~~~~~
/wonderland/projects/zephyr/zephyr/include/zephyr/device.h:229:37: note: in expansion of macro 'DEVICE_NAME_GET'
  229 | #define DEVICE_DT_NAME_GET(node_id) DEVICE_NAME_GET(Z_DEVICE_DT_DEV_ID(node_id))
      |                                     ^~~~~~~~~~~~~~~
/wonderland/projects/zephyr/zephyr/include/zephyr/device.h:246:34: note: in expansion of macro 'DEVICE_DT_NAME_GET'
  246 | #define DEVICE_DT_GET(node_id) (&DEVICE_DT_NAME_GET(node_id))
      |                                  ^~~~~~~~~~~~~~~~~~
/wonderland/projects/zephyr/zephyr/include/zephyr/drivers/gpio.h:333:25: note: in expansion of macro 'DEVICE_DT_GET'
  333 |                 .port = DEVICE_DT_GET(DT_GPIO_CTLR_BY_IDX(node_id, prop, idx)),\
      |                         ^~~~~~~~~~~~~
/wonderland/projects/zephyr/zephyr/include/zephyr/drivers/gpio.h:369:9: note: in expansion of macro 'GPIO_DT_SPEC_GET_BY_IDX'
  369 |         GPIO_DT_SPEC_GET_BY_IDX(node_id, prop, 0)
      |         ^~~~~~~~~~~~~~~~~~~~~~~
/wonderland/projects/zephyr/zephyr/samples/basic/blinky/src/main.c:21:40: note: in expansion of macro 'GPIO_DT_SPEC_GET'
   21 | static const struct gpio_dt_spec led = GPIO_DT_SPEC_GET(LED0_NODE, gpios);
      |                                        ^~~~~~~~~~~~~~~~
In file included from /wonderland/projects/zephyr/zephyr/include/zephyr/arch/xtensa/arch.h:18,
                 from /wonderland/projects/zephyr/zephyr/include/zephyr/arch/cpu.h:27,
                 from /wonderland/projects/zephyr/zephyr/include/zephyr/kernel_includes.h:36:
/wonderland/projects/zephyr/zephyr/include/zephyr/devicetree.h:240:32: error: 'DT_N_ALIAS_led0_P_gpios_IDX_0_VAL_pin' undeclared here (not in a function)
  240 | #define DT_ALIAS(alias) DT_CAT(DT_N_ALIAS_, alias)
      |                                ^~~~~~~~~~~
/wonderland/projects/zephyr/zephyr/include/zephyr/devicetree.h:4792:9: note: in definition of macro 'DT_CAT7'
 4792 |         a1 ## a2 ## a3 ## a4 ## a5 ## a6 ## a7
      |         ^~
/wonderland/projects/zephyr/zephyr/include/zephyr/devicetree/gpio.h:110:9: note: in expansion of macro 'DT_PHA_BY_IDX'
  110 |         DT_PHA_BY_IDX(node_id, gpio_pha, idx, pin)
      |         ^~~~~~~~~~~~~
/wonderland/projects/zephyr/zephyr/include/zephyr/drivers/gpio.h:334:24: note: in expansion of macro 'DT_GPIO_PIN_BY_IDX'
  334 |                 .pin = DT_GPIO_PIN_BY_IDX(node_id, prop, idx),                 \
      |                        ^~~~~~~~~~~~~~~~~~
/wonderland/projects/zephyr/zephyr/include/zephyr/drivers/gpio.h:369:9: note: in expansion of macro 'GPIO_DT_SPEC_GET_BY_IDX'
  369 |         GPIO_DT_SPEC_GET_BY_IDX(node_id, prop, 0)
      |         ^~~~~~~~~~~~~~~~~~~~~~~
/wonderland/projects/zephyr/zephyr/samples/basic/blinky/src/main.c:21:40: note: in expansion of macro 'GPIO_DT_SPEC_GET'
   21 | static const struct gpio_dt_spec led = GPIO_DT_SPEC_GET(LED0_NODE, gpios);
      |                                        ^~~~~~~~~~~~~~~~
/wonderland/projects/zephyr/zephyr/include/zephyr/devicetree.h:240:25: note: in expansion of macro 'DT_CAT'
  240 | #define DT_ALIAS(alias) DT_CAT(DT_N_ALIAS_, alias)
      |                         ^~~~~~
/wonderland/projects/zephyr/zephyr/samples/basic/blinky/src/main.c:15:19: note: in expansion of macro 'DT_ALIAS'
   15 | #define LED0_NODE DT_ALIAS(led0)
      |                   ^~~~~~~~
/wonderland/projects/zephyr/zephyr/samples/basic/blinky/src/main.c:21:57: note: in expansion of macro 'LED0_NODE'
   21 | static const struct gpio_dt_spec led = GPIO_DT_SPEC_GET(LED0_NODE, gpios);
      |                                                         ^~~~~~~~~
[156/198] Building C object zephyr/drivers/gpio/CMakeFiles/drivers__gpio.dir/gpio_esp32.c.obj
ninja: build stopped: subcommand failed.
FATAL ERROR: command exited with status 1: /usr/bin/cmake --build /wonderland/projects/zephyr/zephyr/build
```

Just for the references the board that was used for testing (I don't know if such links are acceptable here):
[Amazon ESP-WROOM-32](https://www.amazon.com/ESP-WROOM-32-Development-Microcontroller-Integrated-Compatible/dp/B08D5ZD528/ref=vse_cards_0?_encoding=UTF8)

[Pinout description](https://randomnerdtutorials.com/esp32-pinout-reference-gpios/) (GPIO2 is builtin LED)