### PR TITLE
drivers: espi: ite: Receive vwire level without checking the valid bit

### DIFF
--- a/drivers/espi/espi_it8xxx2.c
+++ b/drivers/espi/espi_it8xxx2.c
@@ -723,18 +723,12 @@ static int espi_it8xxx2_receive_vwire(const struct device *dev,
 		(struct espi_vw_regs *)config->base_espi_vw;
 	uint8_t vw_index = vw_channel_list[signal].vw_index;
 	uint8_t level_mask = vw_channel_list[signal].level_mask;
-	uint8_t valid_mask = vw_channel_list[signal].valid_mask;
 
 	if (signal > ARRAY_SIZE(vw_channel_list)) {
 		return -EIO;
 	}
 
-	if (vw_reg->VW_INDEX[vw_index] & valid_mask) {
-		*level = !!(vw_reg->VW_INDEX[vw_index] & level_mask);
-	} else {
-		/* Not valid */
-		*level = 0;
-	}
+	*level = !!(vw_reg->VW_INDEX[vw_index] & level_mask);
 
 	return 0;
 }


### PR DESCRIPTION
If the valid bit is set to '0', the corresponding virtual wire will retain its previous value and will not be updated by the current virtual wire packet.

The virtual wire value will be reset to its default by an eSPI reset. Therefore, this commit skips the check for the valid bit when receiving the level.

When a similar index with a single event valid is sent in a separate packet, the previous valid bit will be cleared. However, since it was previously valid, at the moment it will appear as non-valid and return '0' as a non-valid value.

Thus, we return the level directly without checking the valid bit, as the virtual wire will reset to its default value upon an eSPI reset.