### PR TITLE
shell command to dump isr_table entries, ISR name and ARG in PLIC shell cmd

### DIFF
--- a/arch/common/CMakeLists.txt
+++ b/arch/common/CMakeLists.txt
@@ -18,6 +18,11 @@ if(CONFIG_GEN_ISR_TABLES)
 endif()
 
 zephyr_library_sources_ifdef(
+  CONFIG_ISR_TABLE_SHELL
+  isr_tables_shell.c
+)
+
+zephyr_library_sources_ifdef(
   CONFIG_MULTI_LEVEL_INTERRUPTS
   multilevel_irq.c
   )

--- a/arch/common/Kconfig
+++ b/arch/common/Kconfig
@@ -30,3 +30,10 @@ config LEGACY_MULTI_LEVEL_TABLE_GENERATION
 	help
 	  A make-shift Kconfig to continue generating the multi-level interrupt LUT
 	  with the legacy way using DT macros.
+
+config ISR_TABLE_SHELL
+	bool "Shell command to dump the ISR tables"
+	depends on GEN_SW_ISR_TABLE
+	depends on SHELL
+	help
+	  This option enables a shell command to dump the ISR tables.

--- a/arch/common/isr_tables_shell.c
+++ b/arch/common/isr_tables_shell.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2024 Meta Platforms.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/debug/symtab.h>
+#include <zephyr/shell/shell.h>
+#include <zephyr/sw_isr_table.h>
+
+static void dump_isr_table_entry(const struct shell *sh, int idx, struct _isr_table_entry *entry)
+{
+
+	if ((entry->isr == z_irq_spurious) || (entry->isr == NULL)) {
+		return;
+	}
+#ifdef CONFIG_SYMTAB
+	const char *name = symtab_find_symbol_name((uintptr_t)entry->isr, NULL);
+
+	shell_print(sh, "%4d: %s(%p)", idx, name, entry->arg);
+#else
+	shell_print(sh, "%4d: %p(%p)", idx, entry->isr, entry->arg);
+#endif /* CONFIG_SYMTAB */
+}
+
+static int cmd_sw_isr_table(const struct shell *sh, size_t argc, char **argv)
+{
+	shell_print(sh, "_sw_isr_table[%d]\n", IRQ_TABLE_SIZE);
+
+	for (int idx = 0; idx < IRQ_TABLE_SIZE; idx++) {
+		dump_isr_table_entry(sh, idx, &_sw_isr_table[idx]);
+	}
+
+	return 0;
+}
+
+#ifdef CONFIG_SHARED_INTERRUPTS
+static int cmd_shared_sw_isr_table(const struct shell *sh, size_t argc, char **argv)
+{
+	shell_print(sh, "z_shared_sw_isr_table[%d][%d]\n", IRQ_TABLE_SIZE,
+		    CONFIG_SHARED_IRQ_MAX_NUM_CLIENTS);
+
+	for (int idx = 0; idx < IRQ_TABLE_SIZE; idx++) {
+		for (int c = 0; c < z_shared_sw_isr_table[idx].client_num; c++) {
+			dump_isr_table_entry(sh, idx, &z_shared_sw_isr_table[idx].clients[c]);
+		}
+	}
+
+	return 0;
+}
+#endif /* CONFIG_SHARED_INTERRUPTS */
+
+SHELL_STATIC_SUBCMD_SET_CREATE(isr_table_cmds,
+			       SHELL_CMD_ARG(sw_isr_table, NULL,
+					     "Dump _sw_isr_table.\n"
+					     "Usage: isr_table sw_isr_table",
+					     cmd_sw_isr_table, 1, 0),
+#ifdef CONFIG_SHARED_INTERRUPTS
+			       SHELL_CMD_ARG(shared_sw_isr_table, NULL,
+					     "Dump z_shared_sw_isr_table.\n"
+					     "Usage: isr_table shared_sw_isr_table",
+					     cmd_shared_sw_isr_table, 1, 0),
+#endif /* CONFIG_SHARED_INTERRUPTS */
+			       SHELL_SUBCMD_SET_END);
+
+SHELL_CMD_ARG_REGISTER(isr_table, &isr_table_cmds, "ISR tables shell command",
+		       NULL, 0, 0);

--- a/drivers/interrupt_controller/intc_plic.c
+++ b/drivers/interrupt_controller/intc_plic.c
@@ -17,6 +17,7 @@
 
 #include "sw_isr_common.h"
 
+#include <zephyr/debug/symtab.h>
 #include <zephyr/kernel.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/device.h>
@@ -450,6 +451,7 @@ static int cmd_get_stats(const struct shell *sh, size_t argc, char *argv[])
 		return ret;
 	}
 
+	const struct plic_config *config = dev->config;
 	const struct plic_data *data = dev->data;
 	struct plic_stats stat = data->stats;
 
@@ -458,11 +460,19 @@ static int cmd_get_stats(const struct shell *sh, size_t argc, char *argv[])
 		shell_print(sh, "IRQ line with > %d hits:", min_hit);
 	}
 
-	shell_print(sh, "   IRQ\t      Hits");
-	shell_print(sh, "==================");
+	shell_print(sh, "   IRQ        Hits\tISR(ARG)");
 	for (int i = 0; i < stat.irq_count_len; i++) {
 		if (stat.irq_count[i] > min_hit) {
-			shell_print(sh, "%6d\t%10d", i, stat.irq_count[i]);
+#ifdef CONFIG_SYMTAB
+			const char *name =
+				symtab_find_symbol_name((uintptr_t)config->isr_table[i].isr, NULL);
+
+			shell_print(sh, "  %4d  %10d\t%s(%p)", i, stat.irq_count[i], name,
+				    config->isr_table[i].arg);
+#else
+			shell_print(sh, "  %4d  %10d\t%p(%p)", i, stat.irq_count[i],
+				    (void *)config->isr_table[i].isr, config->isr_table[i].arg);
+#endif /* CONFIG_SYMTAB */
 		}
 	}
 	shell_print(sh, "");


### PR DESCRIPTION
- Updated PLIC shell cmd to print the ISR & ARG, symbol name will be printed when `CONFIG_SYMTAB` is enabled
- Added shell cmd to dump the sw isr tables, symbol name will be printed when `CONFIG_SYMTAB` is enabled

`CONFIG_SYMTAB=n`
```
uart:~$ plic stats get interrupt-controller@c000000
   IRQ        Hits	ISR(ARG)
    10         541	0x800054ee(0x80008170)

uart:~$ isr_table sw_isr_table
_sw_isr_table[1035]

   7: 0x800056e2(0)
  11: 0x80005048(0x80008148)
  22: 0x800054ee(0x80008170)
```

`CONFIG_SYMTAB=y`
```
uart:~$ plic stats get interrupt-controller@c000000
   IRQ        Hits	ISR(ARG)
    10         114	uart_ns16550_isr(0x80008230)

uart:~$ isr_table sw_isr_table
_sw_isr_table[1035]

   7: timer_isr(0)
  11: plic_irq_handler(0x80008188)
  22: uart_ns16550_isr(0x800081b0)
```
