### PR TITLE
sd: lower log level for boot message

### DIFF
--- a/subsys/sd/sd.c
+++ b/subsys/sd/sd.c
@@ -56,7 +56,7 @@ static int sd_send_interface_condition(struct sd_card *card)
 		resp = cmd.response[0];
 	}
 	if ((resp & 0xFF) != SD_IF_COND_CHECK) {
-		LOG_INF("Legacy card detected, no CMD8 support");
+		LOG_DBG("Legacy card detected, no CMD8 support");
 		/* Retry probe */
 		return SD_RETRY;
 	}


### PR DESCRIPTION
This log message does not need to be repeated 10 times at the INFO level when the same information is provided after all the retries are done:
```
[00:00:00.259,796] <inf> sd: Legacy card detected, no CMD8 support
[00:00:00.260,589] <inf> sd: Legacy card detected, no CMD8 support
[00:00:00.261,352] <inf> sd: Legacy card detected, no CMD8 support
[00:00:00.262,145] <inf> sd: Legacy card detected, no CMD8 support
[00:00:00.262,908] <inf> sd: Legacy card detected, no CMD8 support
[00:00:00.263,671] <inf> sd: Legacy card detected, no CMD8 support
[00:00:00.264,465] <inf> sd: Legacy card detected, no CMD8 support
[00:00:00.265,228] <inf> sd: Legacy card detected, no CMD8 support
[00:00:00.265,991] <inf> sd: Legacy card detected, no CMD8 support
[00:00:00.266,784] <inf> sd: Legacy card detected, no CMD8 support
[00:00:00.267,547] <inf> sd: Legacy card detected, no CMD8 support
[00:00:00.267,578] <inf> sd: Card does not support CMD8, assuming legacy card
```
to
```
[00:00:00.267,578] <inf> sd: Card does not support CMD8, assuming legacy card
```