### PR TITLE
driver: clock_control: renesas_ra: Defining MSTP regs in devicetree

### DIFF
--- a/drivers/clock_control/clock_control_renesas_ra_cgc.c
+++ b/drivers/clock_control/clock_control_renesas_ra_cgc.c
@@ -12,6 +12,17 @@
 #include <zephyr/dt-bindings/clock/ra_clock.h>
 #include <zephyr/drivers/clock_control/renesas_ra_cgc.h>
 
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(pclkblock), okay)
+#define MSTP_REGS_ELEM(node_id, prop, idx)                                                         \
+	[DT_STRING_TOKEN_BY_IDX(node_id, prop, idx)] =                                             \
+		(volatile uint32_t *)DT_REG_ADDR_BY_IDX(node_id, idx),
+
+static volatile uint32_t *mstp_regs[] = {
+	DT_FOREACH_PROP_ELEM(DT_NODELABEL(pclkblock), reg_names, MSTP_REGS_ELEM)};
+#else
+static volatile uint32_t *mstp_regs[] = {};
+#endif
+
 static int clock_control_renesas_ra_on(const struct device *dev, clock_control_subsys_t sys)
 {
 	struct clock_control_ra_subsys_cfg *subsys_clk = (struct clock_control_ra_subsys_cfg *)sys;
@@ -19,7 +30,7 @@ static int clock_control_renesas_ra_on(const struct device *dev, clock_control_s
 	if (!dev || !sys) {
 		return -EINVAL;
 	}
-	WRITE_BIT(*subsys_clk->mstp, subsys_clk->stop_bit, false);
+	WRITE_BIT(*mstp_regs[subsys_clk->mstp], subsys_clk->stop_bit, false);
 	return 0;
 }
 
@@ -31,7 +42,7 @@ static int clock_control_renesas_ra_off(const struct device *dev, clock_control_
 		return -EINVAL;
 	}
 
-	WRITE_BIT(*subsys_clk->mstp, subsys_clk->stop_bit, true);
+	WRITE_BIT(*mstp_regs[subsys_clk->mstp], subsys_clk->stop_bit, true);
 	return 0;
 }
 

--- a/drivers/clock_control/clock_control_renesas_ra_cgc.c
+++ b/drivers/clock_control/clock_control_renesas_ra_cgc.c
@@ -90,7 +90,9 @@ static const struct clock_control_driver_api clock_control_reneas_ra_api = {
 #define INIT_PCLK(node_id)                                                                         \
 	IF_ENABLED(DT_NODE_HAS_COMPAT(node_id, renesas_ra_cgc_pclk),                               \
 		   (static const struct clock_control_ra_pclk_cfg node_id##_cfg =                  \
-			    {.clk_src = DT_PROP_OR(node_id, clk_src, RA_CLOCK_SOURCE_DISABLE),     \
+			    {.clk_src = DT_PROP_OR(node_id, clk_src,                               \
+						   DT_PROP_OR(DT_PARENT(node_id), sysclock_src,    \
+							      RA_CLOCK_SOURCE_DISABLE)),           \
 			     .clk_div = DT_PROP_OR(node_id, clk_div, RA_SYS_CLOCK_DIV_1)};         \
 		    DEVICE_DT_DEFINE(node_id, &clock_control_ra_init_pclk, NULL, NULL,             \
 				     &node_id##_cfg, PRE_KERNEL_1,                                 \

--- a/dts/arm/renesas/ra/ra2/r7fa2a1xh.dtsi
+++ b/dts/arm/renesas/ra/ra2/r7fa2a1xh.dtsi
@@ -22,6 +22,9 @@
 	};
 
 	clocks: clocks {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
 		xtal: clock-xtal {
 			compatible = "renesas,ra-cgc-external-clock";
 			clock-frequency = <DT_FREQ_M(12)>;
@@ -54,8 +57,12 @@
 			status = "disabled";
 		};
 
-		pclkblock: pclkblock {
+		pclkblock: pclkblock@4001e01c {
 			compatible = "renesas,ra-cgc-pclk-block";
+			reg = <0x4001e01c 4>, <0x40047000 4>, <0x40047004 4>,
+			      <0x40047008 4>;
+			reg-names = "MSTPA", "MSTPB","MSTPC",
+				    "MSTPD";
 			#clock-cells = <0>;
 			sysclock-src = <RA_CLOCK_SOURCE_HOCO>;
 			status = "okay";

--- a/dts/arm/renesas/ra/ra6/r7fa6e10x.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6e10x.dtsi
@@ -92,6 +92,9 @@
 	};
 
 	clocks: clocks {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
 		xtal: clock-xtal {
 			compatible = "renesas,ra-cgc-external-clock";
 			clock-frequency = <DT_FREQ_M(20)>;
@@ -146,8 +149,12 @@
 			status = "disabled";
 		};
 
-		pclkblock: pclkblock {
+		pclkblock: pclkblock@40084000 {
 			compatible = "renesas,ra-cgc-pclk-block";
+			reg = <0x40084000 4>, <0x40084004 4>, <0x40084008 4>,
+			      <0x4008400c 4>, <0x40084010 4>;
+			reg-names = "MSTPA", "MSTPB","MSTPC",
+				    "MSTPD", "MSTPE";
 			#clock-cells = <0>;
 			sysclock-src = <RA_CLOCK_SOURCE_PLL>;
 			status = "okay";

--- a/dts/arm/renesas/ra/ra6/r7fa6e2bx.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6e2bx.dtsi
@@ -33,6 +33,9 @@
 	};
 
 	clocks: clocks {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
 		xtal: clock-xtal {
 			compatible = "renesas,ra-cgc-external-clock";
 			clock-frequency = <DT_FREQ_M(20)>;
@@ -76,8 +79,12 @@
 			status = "disabled";
 		};
 
-		pclkblock: pclkblock {
+		pclkblock: pclkblock@40084000 {
 			compatible = "renesas,ra-cgc-pclk-block";
+			reg = <0x40084000 4>, <0x40084004 4>, <0x40084008 4>,
+			      <0x4008400c 4>, <0x40084010 4>;
+			reg-names = "MSTPA", "MSTPB","MSTPC",
+				    "MSTPD", "MSTPE";
 			#clock-cells = <0>;
 			sysclock-src = <RA_CLOCK_SOURCE_PLL>;
 			status = "okay";

--- a/dts/arm/renesas/ra/ra6/r7fa6m1ad3cfp.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m1ad3cfp.dtsi
@@ -27,6 +27,9 @@
 	};
 
 	clocks: clocks {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
 		xtal: clock-xtal {
 			compatible = "renesas,ra-cgc-external-clock";
 			clock-frequency = <DT_FREQ_M(12)>;
@@ -70,8 +73,12 @@
 			status = "disabled";
 		};
 
-		pclkblock: pclkblock {
+		pclkblock: pclkblock@4001e01c {
 			compatible = "renesas,ra-cgc-pclk-block";
+			reg = <0x4001e01c 4>, <0x40047000 4>, <0x40047004 4>,
+			      <0x40047008 4>;
+			reg-names = "MSTPA", "MSTPB","MSTPC",
+				    "MSTPD";
 			#clock-cells = <0>;
 			sysclock-src = <RA_CLOCK_SOURCE_PLL>;
 			status = "okay";

--- a/dts/arm/renesas/ra/ra6/r7fa6m2ax.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m2ax.dtsi
@@ -58,6 +58,9 @@
 	};
 
 	clocks: clocks {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
 		xtal: clock-xtal {
 			compatible = "renesas,ra-cgc-external-clock";
 			clock-frequency = <DT_FREQ_M(12)>;
@@ -101,8 +104,12 @@
 			status = "disabled";
 		};
 
-		pclkblock: pclkblock {
+		pclkblock: pclkblock@4001e01c {
 			compatible = "renesas,ra-cgc-pclk-block";
+			reg = <0x4001e01c 4>, <0x40047000 4>, <0x40047004 4>,
+			      <0x40047008 4>;
+			reg-names = "MSTPA", "MSTPB","MSTPC",
+				    "MSTPD";
 			#clock-cells = <0>;
 			sysclock-src = <RA_CLOCK_SOURCE_PLL>;
 			status = "okay";

--- a/dts/arm/renesas/ra/ra6/r7fa6m3ax.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m3ax.dtsi
@@ -98,6 +98,9 @@
 	};
 
 	clocks: clocks {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
 		xtal: clock-xtal {
 			compatible = "renesas,ra-cgc-external-clock";
 			clock-frequency = <DT_FREQ_M(24)>;
@@ -141,8 +144,12 @@
 			status = "disabled";
 		};
 
-		pclkblock: pclkblock {
+		pclkblock: pclkblock@4001e01c {
 			compatible = "renesas,ra-cgc-pclk-block";
+			reg = <0x4001e01c 4>, <0x40047000 4>, <0x40047004 4>,
+			      <0x40047008 4>;
+			reg-names = "MSTPA", "MSTPB","MSTPC",
+				    "MSTPD";
 			#clock-cells = <0>;
 			sysclock-src = <RA_CLOCK_SOURCE_PLL>;
 			status = "okay";

--- a/dts/arm/renesas/ra/ra6/r7fa6m4ax.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m4ax.dtsi
@@ -128,6 +128,9 @@
 	};
 
 	clocks: clocks {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
 		xtal: clock-xtal {
 			compatible = "renesas,ra-cgc-external-clock";
 			clock-frequency = <DT_FREQ_M(24)>;
@@ -182,8 +185,12 @@
 			status = "disabled";
 		};
 
-		pclkblock: pclkblock {
+		pclkblock: pclkblock@40084000 {
 			compatible = "renesas,ra-cgc-pclk-block";
+			reg = <0x40084000 4>, <0x40084004 4>, <0x40084008 4>,
+			      <0x4008400c 4>, <0x40084010 4>;
+			reg-names = "MSTPA", "MSTPB","MSTPC",
+				    "MSTPD", "MSTPE";
 			#clock-cells = <0>;
 			sysclock-src = <RA_CLOCK_SOURCE_PLL>;
 			status = "okay";

--- a/dts/arm/renesas/ra/ra6/r7fa6m5xh.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m5xh.dtsi
@@ -188,6 +188,9 @@
 	};
 
 	clocks: clocks {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
 		xtal: clock-xtal {
 			compatible = "renesas,ra-cgc-external-clock";
 			clock-frequency = <DT_FREQ_M(24)>;
@@ -242,8 +245,12 @@
 			status = "disabled";
 		};
 
-		pclkblock: pclkblock {
+		pclkblock: pclkblock@40084000 {
 			compatible = "renesas,ra-cgc-pclk-block";
+			reg = <0x40084000 4>, <0x40084004 4>, <0x40084008 4>,
+			      <0x4008400c 4>, <0x40084010 4>;
+			reg-names = "MSTPA", "MSTPB","MSTPC",
+				    "MSTPD", "MSTPE";
 			#clock-cells = <0>;
 			sysclock-src = <RA_CLOCK_SOURCE_PLL>;
 			status = "okay";

--- a/dts/arm/renesas/ra/ra8/r7fa8d1xh.dtsi
+++ b/dts/arm/renesas/ra/ra8/r7fa8d1xh.dtsi
@@ -9,6 +9,9 @@
 
 / {
 	clocks: clocks {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
 		xtal: clock-xtal {
 			compatible = "renesas,ra-cgc-external-clock";
 			clock-frequency = <DT_FREQ_M(20)>;
@@ -75,8 +78,12 @@
 			status = "disabled";
 		};
 
-		pclkblock: pclkblock {
+		pclkblock: pclkblock@40203000 {
 			compatible = "renesas,ra-cgc-pclk-block";
+			reg = <0x40203000 4>, <0x40203004 4>, <0x40203008 4>,
+			      <0x4020300c 4>, <0x40203010 4>;
+			reg-names = "MSTPA", "MSTPB","MSTPC",
+				    "MSTPD", "MSTPE";
 			#clock-cells = <0>;
 			sysclock-src = <RA_CLOCK_SOURCE_PLL1P>;
 			status = "okay";

--- a/dts/arm/renesas/ra/ra8/r7fa8m1xh.dtsi
+++ b/dts/arm/renesas/ra/ra8/r7fa8m1xh.dtsi
@@ -9,6 +9,9 @@
 
 / {
 	clocks: clocks {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
 		xtal: clock-xtal {
 			compatible = "renesas,ra-cgc-external-clock";
 			clock-frequency = <DT_FREQ_M(20)>;
@@ -75,8 +78,12 @@
 			status = "disabled";
 		};
 
-		pclkblock: pclkblock {
+		pclkblock: pclkblock@40203000 {
 			compatible = "renesas,ra-cgc-pclk-block";
+			reg = <0x40203000 4>, <0x40203004 4>, <0x40203008 4>,
+			      <0x4020300c 4>, <0x40203010 4>;
+			reg-names = "MSTPA", "MSTPB","MSTPC",
+				    "MSTPD", "MSTPE";
 			#clock-cells = <0>;
 			sysclock-src = <RA_CLOCK_SOURCE_PLL1P>;
 			status = "okay";

--- a/dts/arm/renesas/ra/ra8/r7fa8t1xh.dtsi
+++ b/dts/arm/renesas/ra/ra8/r7fa8t1xh.dtsi
@@ -9,6 +9,9 @@
 
 / {
 	clocks: clocks {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
 		xtal: clock-xtal {
 			compatible = "renesas,ra-cgc-external-clock";
 			clock-frequency = <DT_FREQ_M(24)>;
@@ -75,8 +78,12 @@
 			status = "disabled";
 		};
 
-		pclkblock: pclkblock {
+		pclkblock: pclkblock@40203000 {
 			compatible = "renesas,ra-cgc-pclk-block";
+			reg = <0x40203000 4>, <0x40203004 4>, <0x40203008 4>,
+			      <0x4020300c 4>, <0x40203010 4>;
+			reg-names = "MSTPA", "MSTPB","MSTPC",
+				    "MSTPD", "MSTPE";
 			#clock-cells = <0>;
 			sysclock-src = <RA_CLOCK_SOURCE_PLL1P>;
 			status = "okay";

--- a/include/zephyr/drivers/clock_control/renesas_ra_cgc.h
+++ b/include/zephyr/drivers/clock_control/renesas_ra_cgc.h
@@ -15,7 +15,7 @@ struct clock_control_ra_pclk_cfg {
 };
 
 struct clock_control_ra_subsys_cfg {
-	volatile uint32_t *mstp;
+	uint32_t mstp;
 	uint32_t stop_bit;
 };
 

--- a/include/zephyr/dt-bindings/clock/ra_clock.h
+++ b/include/zephyr/dt-bindings/clock/ra_clock.h
@@ -137,10 +137,10 @@
 #define RA_SDADC_CLOCK_DIV_12 7
 #define RA_SDADC_CLOCK_DIV_16 8
 
-#define MSTPA 0x40203000
-#define MSTPB 0x40203004
-#define MSTPC 0x40203008
-#define MSTPD 0x4020300C
-#define MSTPE 0x40203010
+#define MSTPA 0
+#define MSTPB 1
+#define MSTPC 2
+#define MSTPD 3
+#define MSTPE 4
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_RA_H_ */


### PR DESCRIPTION
Allows MSTP register addresses to be changed in the device tree
to support different configuration SoCs.

When omitting the clk_src definition in a child node of a pclkblock,
it uses the source of the parent node.

~The impact is still limited, so we are currently correcting the names.~

- - -

Since I don't have an RA8M1 environment, I verified this PR with RA4M1 only.