### PR TITLE
manifest: Update hostap to fix EAP server registration

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -259,7 +259,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: a90df86d7c596a5367ff70c2b50c7f599e6636f3
+      revision: pull/23/head
     - name: libmetal
       revision: a6851ba6dba8c9e87d00c42f171a822f7a29639b
       path: modules/hal/libmetal


### PR DESCRIPTION
Fix the duplicated registration of eap server method, as when hostapd enabled, eap_server_register_methods() will also call the eap server related functions.