### PR TITLE
soc: renesas: ra: Do not enable CONFIG_SOC_OPTION_SETTING_MEMORY globally

### DIFF
--- a/soc/renesas/ra/ra4m1/Kconfig
+++ b/soc/renesas/ra/ra4m1/Kconfig
@@ -10,6 +10,10 @@ config SOC_SERIES_RA4M1
 	select TIMER_READS_ITS_FREQUENCY_AT_RUNTIME
 	select XIP
 
+if SOC_SERIES_RA4M1
+
 config SOC_OPTION_SETTING_MEMORY
 	bool "Option Setting Memory"
 	default y
+
+endif


### PR DESCRIPTION
RA4M1-specific options were being applied system-wide because conditions were not set properly.
This change fixes this problem.