### PR TITLE
modules: mbedtls: remove Kconfig options for TLS 1.0 and 1.1

### DIFF
--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -30,6 +30,9 @@ Modules
 Mbed TLS
 ========
 
+* The Kconfig options ``CONFIG_MBEDTLS_TLS_VERSION_1_0`` and ``CONFIG_MBEDTLS_TLS_VERSION_1_1``
+  have been removed because Mbed TLS doesn't support TLS 1.0 and 1.1 anymore since v3.0. (:github:`76833`)
+
 Trusted Firmware-M
 ==================
 

--- a/modules/mbedtls/Kconfig.tls-generic
+++ b/modules/mbedtls/Kconfig.tls-generic
@@ -4,43 +4,30 @@
 # Copyright (c) 2018 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-menu "TLS configuration"
+menu "Mbed TLS configuration"
 	depends on MBEDTLS_BUILTIN && MBEDTLS_CFG_FILE = "config-tls-generic.h"
 
-menu "Supported TLS version"
-
-config MBEDTLS_TLS_VERSION_1_0
-	bool "Support for TLS 1.0"
-	select MBEDTLS_CIPHER
-	select MBEDTLS_MD5
-	select MBEDTLS_SHA1
-	select MBEDTLS_MD
-
-config MBEDTLS_TLS_VERSION_1_1
-	bool "Support for TLS 1.1 (DTLS 1.0)"
-	select MBEDTLS_CIPHER
-	select MBEDTLS_MD5
-	select MBEDTLS_SHA1
-	select MBEDTLS_MD
+menu "TLS"
 
 config MBEDTLS_TLS_VERSION_1_2
 	bool "Support for TLS 1.2 (DTLS 1.2)"
 	select MBEDTLS_CIPHER
 	select MBEDTLS_MD
 
+if MBEDTLS_TLS_VERSION_1_2
+
 config MBEDTLS_DTLS
 	bool "Support for DTLS"
-	depends on MBEDTLS_TLS_VERSION_1_1 || MBEDTLS_TLS_VERSION_1_2
 
 config MBEDTLS_SSL_EXPORT_KEYS
 	bool "Support for exporting SSL key block and master secret"
-	depends on MBEDTLS_TLS_VERSION_1_0 || MBEDTLS_TLS_VERSION_1_1 || MBEDTLS_TLS_VERSION_1_2
 
 config MBEDTLS_SSL_ALPN
 	bool "Support for setting the supported Application Layer Protocols"
-	depends on MBEDTLS_TLS_VERSION_1_0 || MBEDTLS_TLS_VERSION_1_1 || MBEDTLS_TLS_VERSION_1_2
 
-endmenu
+endif
+
+endmenu # TLS
 
 menu "Ciphersuite configuration"
 

--- a/modules/mbedtls/configs/config-tls-generic.h
+++ b/modules/mbedtls/configs/config-tls-generic.h
@@ -51,22 +51,13 @@
 /* mbedTLS feature support */
 
 /* Supported TLS versions */
-#if defined(CONFIG_MBEDTLS_TLS_VERSION_1_0)
-#define MBEDTLS_SSL_PROTO_TLS1
-#endif
 
-#if defined(CONFIG_MBEDTLS_TLS_VERSION_1_1)
-#define MBEDTLS_SSL_PROTO_TLS1_1
-#endif
 
 #if defined(CONFIG_MBEDTLS_TLS_VERSION_1_2)
 #define MBEDTLS_SSL_PROTO_TLS1_2
 #endif
 
-
-#if defined(CONFIG_MBEDTLS_TLS_VERSION_1_0) || \
-    defined(CONFIG_MBEDTLS_TLS_VERSION_1_1) || \
-    defined(CONFIG_MBEDTLS_TLS_VERSION_1_2)
+#if defined(CONFIG_MBEDTLS_TLS_VERSION_1_2)
 
 /* Modules required for TLS */
 #define MBEDTLS_SSL_TLS_C


### PR DESCRIPTION
Support for those has been removed from Mbed TLS a while ago: https://github.com/Mbed-TLS/mbedtls/issues/4286