### PR TITLE
doc: PM: Fix dereference in 'services/pm/device_runtime'

### DIFF
--- a/doc/services/pm/device_runtime.rst
+++ b/doc/services/pm/device_runtime.rst
@@ -124,7 +124,7 @@ by the PM subsystem to suspend or resume devices.
 .. code-block:: c
 
     static int mydev_pm_action(const struct device *dev,
-                               enum pm_device_action *action)
+                               enum pm_device_action action)
     {
         switch (action) {
         case PM_DEVICE_ACTION_SUSPEND:


### PR DESCRIPTION
See https://github.com/zephyrproject-rtos/zephyr/issues/76741

Fixes the dereference of the PM action in the doc.