### PR TITLE
Using `ZBUS_CHAN_DEFINE` with enabled `CONFIG_CPP` cause compilation error

### DIFF
--- a/include/zephyr/zbus/zbus.h
+++ b/include/zephyr/zbus/zbus.h
@@ -342,12 +342,12 @@ struct zbus_channel_observation {
 		.observers_start_idx = -1,                                                \
 		.observers_end_idx = -1,                                                  \
 		.sem = Z_SEM_INITIALIZER(_CONCAT(_zbus_chan_data_, _name).sem, 1, 1),     \
+		IF_ENABLED(CONFIG_ZBUS_PRIORITY_BOOST, (                                  \
+			.highest_observer_priority = ZBUS_MIN_THREAD_PRIORITY,            \
+		))                                                                        \
 		IF_ENABLED(CONFIG_ZBUS_RUNTIME_OBSERVERS, (                               \
 			.observers = SYS_SLIST_STATIC_INIT(                               \
 				&_CONCAT(_zbus_chan_data_, _name).observers),             \
-		))                                                                        \
-		IF_ENABLED(CONFIG_ZBUS_PRIORITY_BOOST, (                                  \
-			.highest_observer_priority = ZBUS_MIN_THREAD_PRIORITY,            \
 		))                                                                        \
 	};                                                                                \
 	static K_MUTEX_DEFINE(_CONCAT(_zbus_mutex_, _name));                              \


### PR DESCRIPTION
There appear error: `zephyr/zbus/zbus.h:352:9: error: designator order for field 'zbus_channel_data::highest_observer_priority' does not match declaration order in `zbus_channel_data`.

Solution: change order in `ZBUS_CHAN_DEFINE` macro according to zbus_channel_data structure.