### PR TITLE
device_dt_metadata: handle dt_meta being NULL

### DIFF
--- a/drivers/gpio/gpio_shell.c
+++ b/drivers/gpio/gpio_shell.c
@@ -442,7 +442,7 @@ static int cmd_gpio_devices(const struct shell *sh, size_t argc, char **argv)
 #ifdef CONFIG_DEVICE_DT_METADATA
 		const struct device_dt_nodelabels *nl = device_get_dt_nodelabels(dev);
 
-		if (nl->num_nodelabels > 0) {
+		if (nl != NULL && nl->num_nodelabels > 0) {
 			for (size_t j = 0; j < nl->num_nodelabels; j++) {
 				const char *nodelabel = nl->nodelabels[j];
 

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -923,11 +923,14 @@ __syscall const struct device *device_get_by_dt_nodelabel(const char *nodelabel)
 /**
  * @brief Get the devicetree node labels associated with a device
  * @param dev device whose metadata to look up
- * @return information about the devicetree node labels
+ * @return information about the devicetree node labels or NULL if not available
  */
 static inline const struct device_dt_nodelabels *
 device_get_dt_nodelabels(const struct device *dev)
 {
+	if (dev->dt_meta == NULL) {
+		return NULL;
+	}
 	return dev->dt_meta->nl;
 }
 

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -98,7 +98,7 @@ const struct device *z_impl_device_get_by_dt_nodelabel(const char *nodelabel)
 	STRUCT_SECTION_FOREACH(device, dev) {
 		const struct device_dt_nodelabels *nl = device_get_dt_nodelabels(dev);
 
-		if (!z_impl_device_is_ready(dev)) {
+		if (!z_impl_device_is_ready(dev) || nl == NULL) {
 			continue;
 		}
 

--- a/subsys/shell/modules/device_service.c
+++ b/subsys/shell/modules/device_service.c
@@ -102,7 +102,7 @@ static int cmd_device_list(const struct shell *sh,
 #ifdef CONFIG_DEVICE_DT_METADATA
 		const struct device_dt_nodelabels *nl = device_get_dt_nodelabels(dev);
 
-		if (nl->num_nodelabels > 0) {
+		if (nl != NULL && nl->num_nodelabels > 0) {
 			shell_fprintf(sh, SHELL_NORMAL, "  DT node labels:");
 			for (size_t j = 0; j < nl->num_nodelabels; j++) {
 				const char *nodelabel = nl->nodelabels[j];


### PR DESCRIPTION
In #71912, a link between devices and their devicetree names has been created. 

Using  DEVICE_DEFINE(), a device without a corresponding DT node can be defined (for example CRYPTO_MTLS, which is enabled by CONFIG_CRYPTO_MBEDTLS_SHIM). Z_DEVICE_INIT() does not initialize dt_meta for such devices, leaving the field NULL (at least on the arm architecture I tested on). device_get_dt_nodelabels() and functions calling it have to handle dev->dt_meta == NULL to prevent fatal errors.