### PR TITLE
net: lib: http_server: Clear http1_headers_sent flag on new request

### DIFF
--- a/subsys/net/lib/http/http_server_http1.c
+++ b/subsys/net/lib/http/http_server_http1.c
@@ -588,6 +588,7 @@ int enter_http1_request(struct http_client_ctx *client)
 	client->parser_settings.on_body = on_body;
 	client->parser_settings.on_message_complete = on_message_complete;
 	client->parser_state = HTTP1_INIT_HEADER_STATE;
+	client->http1_headers_sent = false;
 
 	memset(client->header_buffer, 0, sizeof(client->header_buffer));
 	memset(client->url_buffer, 0, sizeof(client->url_buffer));


### PR DESCRIPTION
http1_headers_sent flag has to be cleared when entering HTTP_SERVER_REQUEST_STATE and not only on the client init. Otherwise, serving multiple HTTP1 POST requests over the same connection does not work as intended (headers were not sent for the second and further requests).

Fixes #76776