### PR TITLE
Generalised clock configuration

### DIFF
--- a/include/zephyr/devicetree/clocks.h
+++ b/include/zephyr/devicetree/clocks.h
@@ -348,6 +348,140 @@ extern "C" {
 	DT_INST_CLOCKS_CELL_BY_IDX(inst, 0, cell)
 
 /**
+ * @brief Get name of a variable (symbol) containing clock configuration cells
+ * for a particular clock consumer and an indexed clock referenced by it.
+ * @param node_id Path to the clock consumer node
+ * @param idx Clock index (index to the phandle-array property)
+ * @return The variable name, unquoted
+ */
+#define DT_CLOCK_CONFIG_NAME_BY_IDX(node_id, idx) \
+	CONCAT(node_id, _CLOCK_IDX_, idx, _CONFIG)
+
+/**
+ * @brief Get name of a variable (symbol) containing clock configuration cells
+ * for a particular clock consumer and a named clock referenced by it.
+ * @param node_id Path to the clock consumer node
+ * @param name Lowercase-and-underscores clock name
+ * @return The variable name, unquoted
+ */
+#define DT_CLOCK_CONFIG_NAME_BY_NAME(node_id, name) \
+	CONCAT(node_id, _CLOCK_NAME_, name, _CONFIG)
+
+/**
+ * @brief Get name of a variable (symbol) containing clock configuration cells
+ * for a particular clock consumer and an indexed clock referenced by it.
+ * @param inst Driver instance number
+ * @param idx Clock index (index to the phandle-array property)
+ * @return The variable name, unquoted
+ */
+#define DT_INST_CLOCK_CONFIG_NAME_BY_IDX(inst, idx) \
+	DT_CLOCK_CONFIG_NAME_BY_IDX(DT_DRV_INST(inst), idx)
+
+/**
+ * @brief Get name of a variable (symbol) containing clock configuration cells
+ * for a particular clock consumer and an indexed clock referenced by it.
+ * @param inst Driver instance number
+ * @param name Lowercase-and-underscores clock name
+ * @return The variable name, unquoted
+ */
+#define DT_INST_CLOCK_CONFIG_NAME_BY_NAME(inst, name) \
+	DT_CLOCK_CONFIG_NAME_BY_NAME(DT_DRV_INST(inst), name)
+
+/**
+ * @brief Get name of a variable (symbol) containing clock configuration cells
+ * for the first referenced clock of a particular clock consumer.
+ *
+ * Equivalent to: DT_CLOCK_CONFIG_NAME_BY_IDX(node_id, 0)
+ *
+ * @param node_id Path to the clock consumer node
+ * @return The variable name, unquoted
+ */
+#define DT_CLOCK_CONFIG_NAME(node_id) \
+	DT_CLOCK_CONFIG_NAME_BY_IDX(node_id, 0)
+
+/**
+ * @brief Get name of a variable (symbol) containing clock configuration cells
+ * for the first referenced clock of a particular clock consumer.
+ *
+ * Equivalent to: DT_CLOCK_CONFIG_NAME_BY_IDX(DT_DRV_INST(inst), 0)
+ *
+ * @param node_id Path to the clock consumer node
+ * @return The variable name, unquoted
+ */
+#define DT_INST_CLOCK_CONFIG_NAME(node_id) \
+	DT_CLOCK_CONFIG_NAME(DT_DRV_INST(inst))
+
+/**
+ * @brief Get the count of cells of a particular clock referenced by a particular
+ * clock consumer node.
+ *
+ * @param node Path to the clock consumer node
+ * @param idx Clock index (index to the phandle-array property)
+ * @return The count of cells
+ */
+#define DT_CLOCK_NUM_CELLS_BY_IDX(node_id, idx) \
+	CONCAT(node_id, _CLOCK_IDX_, idx, _CELLS_COUNT)
+
+/**
+ * @brief Get the count of cells of a particular clock referenced by a
+ * particular clock consumer node.
+ *
+ * @param node Path to the clock consumer node
+ * @param name Lowercase-and-underscores clock name
+ * @return The count of cells
+ */
+#define DT_CLOCK_NUM_CELLS_BY_NAME(node_id, name) \
+	CONCAT(node_id, _CLOCK_NAME_, name, _CELLS_COUNT)
+
+/**
+ * @brief Get the count of cells of a particular clock referenced by a
+ * particular clock consumer node.
+ *
+ * @param inst Driver instance number
+ * @param idx Clock index (index to the phandle-array property)
+ * @return The count of cells
+ */
+#define DT_INST_CLOCK_NUM_CELLS_BY_IDX(inst, idx) \
+	DT_CLOCK_NUM_CELLS_BY_IDX(DT_DRV_INST(inst), idx)
+
+/**
+ * @brief Get the count of cells of a particular clock referenced by a
+ * particular clock consumer node.
+ *
+ * @param inst Driver instance number
+ * @param name Lowercase-and-underscores clock name
+ * @return The count of cells
+ */
+#define DT_INST_CLOCK_NUM_CELLS_BY_NAME(inst, name) \
+	DT_CLOCK_NUM_CELLS_BY_NAME(DT_DRV_INST(inst), name)
+
+/**
+ * @brief Get the count of cells of a the first clock referenced by a
+ * particular clock consumer node.
+ *
+ * Equivalent to: DT_CLOCK_NUM_CELLS_BY_IDX(node_id, 0)
+ *
+ * @param node_id Path to the clock consumer node
+ * @param name Lowercase-and-underscores clock name
+ * @return The count of cells
+ */
+#define DT_NUM_CLOCK_CELLS(node_id) \
+	DT_CLOCK_NUM_CELLS_BY_IDX(node_id, 0)
+
+/**
+ * @brief Get the count of cells of a the first clock referenced by a
+ * particular clock consumer node.
+ *
+ * Equivalent to: DT_NUM_CLOCK_CELLS(DT_DRV_INST(inst))
+ *
+ * @param inst Driver instance number
+ * @param name Lowercase-and-underscores clock name
+ * @return The count of cells
+ */
+#define DT_NUM_INST_CLOCK_CELLS(inst) \
+	DT_NUM_CLOCK_CELLS(DT_DRV_INST(inst))
+
+/**
  * @}
  */
 

--- a/include/zephyr/drivers/clock_control.h
+++ b/include/zephyr/drivers/clock_control.h
@@ -295,6 +295,72 @@ static inline int clock_control_configure(const struct device *dev,
 	return api->configure(dev, sys, data);
 }
 
+/**
+ * @brief Helper macro defining a clock configuration cell.
+ *
+ * @param cellidx Index of the cell being formatted
+ * @param clkidx Index of the clock reference being processed
+ * @param node_id Path to the node referencing the clock
+ * @return Formatted clock cell value
+ *
+ * @see #CLOCKS_DT_INST_DEFINE
+ */
+#define  _CLOCKS_DT_CONFIG_CELLS_LIST_CELL(cellidx, clkidx, node_id) \
+	DT_CLOCKS_CELL_BY_IDX( \
+		node_id, \
+		clkidx, \
+		CONCAT(node_id, _CLOCK_IDX_, clkidx, _CELL_, cellidx, _NAME) \
+	)
+
+/**
+ * @brief Helper macro defining a list of configuration cells of a
+ * particular clock.
+ *
+ * @param node_id Path to the node referencing the clock
+ * @param prop Dictated by FOREACH macros, expected to be clocks
+ * @param clkidx Index of the clock reference being processed
+ * @return Variable definition
+ *
+ * @see #CLOCKS_DT_INST_DEFINE
+ */
+#define _CLOCKS_DT_CONFIG_DEFINE(node_id, prop, clkidx) \
+	int DT_CLOCK_CONFIG_NAME_BY_IDX(node_id, clkidx)[] = { \
+		LISTIFY( \
+			DT_CLOCK_NUM_CELLS_BY_IDX(node_id, clkidx), \
+			_CLOCKS_DT_CONFIG_CELLS_LIST_CELL, \
+			(,), \
+			clkidx, \
+			node_id \
+		) \
+	}
+
+/**
+ * @brief Define all clock consumer's configuration variables.
+ *
+ * This macro generates the __clock_config_*__device_dts_ord_* variables,
+ * which are filled with configuration cells written in the clock consumer's DT
+ * node. Pointers to these variables are then passed as-is to clock controllers
+ * (providers) when invoking them using the clock_control API.
+ *
+ * Example usage:
+ *
+ * 		#define DRV_INIT(n) \
+ * 			CLOCKS_DT_INST_DEFINE(n);
+ * 			...
+ *
+ * 		DT_INST_FOREACH_STATUS_OKAY(DRV_INIT)
+ *
+ * @param inst Clock consumer instance number
+ */
+#define CLOCKS_DT_INST_DEFINE(inst) \
+	DT_INST_FOREACH_PROP_ELEM_SEP( \
+		inst, \
+		clocks, \
+		_CLOCKS_DT_CONFIG_DEFINE, \
+		(;)\
+	) \
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -358,6 +358,7 @@ def write_special_props(node):
     # Macros that are special to bindings inherited from Linux, which
     # we can't capture with the current bindings language.
     write_pinctrls(node)
+    write_clocks(node)
     write_fixed_partitions(node)
     write_gpio_hogs(node)
 
@@ -606,6 +607,26 @@ def write_pinctrls(node):
         for idx, ph in enumerate(pinctrl.conf_nodes):
             out_dt_define(f"{node.z_path_id}_PINCTRL_NAME_{name}_IDX_{idx}_PH",
                           f"DT_{ph.z_path_id}")
+
+def write_clocks(node):
+    # Write special macros for clock properties
+
+    out_comment("Clock properties:")
+
+    if "clocks" in node.props:
+        for clkidx, clock in enumerate(node.props["clocks"].val):
+            out_dt_define(f"{node.z_path_id}_CLOCK_IDX_{clkidx}_CONFIG", f"__clock_config_{clkidx}__device_dts_ord_{node.dep_ordinal}")
+            out_dt_define(f"{node.z_path_id}_CLOCK_IDX_{clkidx}_CELLS_COUNT", len(clock.data))
+
+            for cellidx, cellname in enumerate(clock.data):
+                out_dt_define(f"{node.z_path_id}_CLOCK_IDX_{clkidx}_CELL_{cellidx}_NAME", cellname)
+
+            if clock.name is not None:
+                out_dt_define(f"{node.z_path_id}_CLOCK_NAME_{clock.name}_CONFIG", f"__clock_config_{clkidx}__device_dts_ord_{node.dep_ordinal}")
+                out_dt_define(f"{node.z_path_id}_CLOCK_NAME_{clock.name}_CELLS_COUNT", len(clock.data))
+
+                for cellidx, cellname in enumerate(clock.data):
+                    out_dt_define(f"{node.z_path_id}_CLOCK_NAME_{clock.name}_CELL_{cellidx}_NAME", cellname)
 
 
 def write_fixed_partitions(node):


### PR DESCRIPTION
This PR tries to solve the issue #67347, which discusses the lack of a generalised clock configuration mechanism.

Currently, clock consumers are expected to explicitly get and pass individual cells of each clock reference (cells item in the `clocks` property) written in the device tree to the clock provider - implementing the `clock_control` API. Mostly, the configuration consists of a single cell, that describes a clock index / name / identifier / ..., but this doesn't have to be the case, for example for the virtual `fixed-clock` driver which doesn't expect any cells or perhaps more advanced clock controllers, which can require more than a single cell. As the clock cells are named and, AFAIK, no conventions on names are established, those names are different from driver to driver.

This PR works this issue by modifying the `gen_defines.py` script to generate extra metadata (most importantly cell counts) for each clock reference in the DT. A clock consumer is then expected to use the `CLOCKS_DT_INST_DEFINE` macro to dump all of the clock cells into `int[]` variables, pointer to which the consumer driver passes wherever the `clock_control_subsys_t` type is expected in the `clock_control` API. The clock driver then access whatever cell it needs and they're abstracted away from the clock consumer.

To account for this change, every clock provider and consumer must be rewritten - the `clock_control_subsys_t` type must be treated truly as a pointer, not as an integer value containing, in most cases, the clock identifier. This isn't currently the case, as can be seen at least in `clock_control_mcux_syscon.c`. The changes, as they exist initially, don't break anything, things start to break once the clock providers start dereferencing that pointer or once the clock consumers start passing the generated arrays.

Of course, I don't expect for this PR to be merged straight away, consider this more as a proposal with actual code in it.