### PR TITLE
Rework how `nordic,clock-enable` works

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-pinctrl.dtsi
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-pinctrl.dtsi
@@ -26,12 +26,8 @@
 
 	/omit-if-no-ref/ uart135_default: uart135_default {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 1, 11)>;
-			nordic,clock-enable;
-		};
-
-		group2 {
-			psels = <NRF_PSEL(UART_RTS, 1, 9)>;
+			psels = <NRF_PSEL(UART_TX, 1, 11)>,
+				<NRF_PSEL(UART_RTS, 1, 9)>;
 		};
 
 		group3 {
@@ -53,12 +49,8 @@
 
 	/omit-if-no-ref/ uart136_default: uart136_default {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 2, 6)>;
-			nordic,clock-enable;
-		};
-
-		group2 {
-			psels = <NRF_PSEL(UART_RTS, 2, 7)>;
+			psels = <NRF_PSEL(UART_TX, 2, 6)>,
+				<NRF_PSEL(UART_RTS, 2, 7)>;
 		};
 
 		group3 {

--- a/drivers/pinctrl/pinctrl_nrf.c
+++ b/drivers/pinctrl/pinctrl_nrf.c
@@ -365,7 +365,7 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 			nrf_gpio_cfg(pin, dir, input, NRF_GET_PULL(pins[i]),
 				     drive, NRF_GPIO_PIN_NOSENSE);
 #if NRF_GPIO_HAS_CLOCKPIN
-			nrf_gpio_pin_clock_set(pin, NRF_GET_CLOCK_ENABLE(pins[i]));
+			nrf_gpio_pin_clock_set(pin, NRF_GET_CLOCKPIN_ENABLE(pins[i]));
 #endif
 		}
 	}

--- a/dts/bindings/i2c/nordic,nrf-twi-common.yaml
+++ b/dts/bindings/i2c/nordic,nrf-twi-common.yaml
@@ -4,7 +4,7 @@
 
 # Common fields for Nordic nRF family TWI peripherals
 
-include: [i2c-controller.yaml, pinctrl-device.yaml]
+include: [i2c-controller.yaml, pinctrl-device.yaml, nordic-clockpin.yaml]
 
 properties:
   reg:

--- a/dts/bindings/pinctrl/nordic,nrf-pinctrl.yaml
+++ b/dts/bindings/pinctrl/nordic,nrf-pinctrl.yaml
@@ -119,9 +119,3 @@ child-binding:
         description: |
           Invert pin polarity (set the active state to low).
           Only valid for PWM channel output pins.
-
-      nordic,clock-enable:
-        type: boolean
-        description: |
-          Enable clock for the pin. Only valid or required for certain
-          peripherals, refer to the reference manual.

--- a/dts/bindings/pinctrl/nordic-clockpin.yaml
+++ b/dts/bindings/pinctrl/nordic-clockpin.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+properties:
+  nordic,clockpin-enable:
+    type: array
+    description: |
+      List of signals that require CLOCKPIN setting enablement.

--- a/dts/bindings/serial/nordic,nrf-uart-common.yaml
+++ b/dts/bindings/serial/nordic,nrf-uart-common.yaml
@@ -1,4 +1,4 @@
-include: [uart-controller.yaml, pinctrl-device.yaml]
+include: [uart-controller.yaml, pinctrl-device.yaml, nordic-clockpin.yaml]
 
 properties:
   reg:

--- a/dts/bindings/spi/nordic,nrf-spi-common.yaml
+++ b/dts/bindings/spi/nordic,nrf-spi-common.yaml
@@ -3,7 +3,7 @@
 
 # Common fields for Nordic nRF family SPI peripherals
 
-include: [spi-controller.yaml, pinctrl-device.yaml]
+include: [spi-controller.yaml, pinctrl-device.yaml, nordic-clockpin.yaml]
 
 properties:
   reg:

--- a/dts/common/nordic/nrf54h20.dtsi
+++ b/dts/common/nordic/nrf54h20.dtsi
@@ -561,6 +561,8 @@
 				#size-cells = <0>;
 				rx-delay-supported;
 				rx-delay = <1>;
+				nordic,clockpin-enable = <NRF_FUN_SPIM_SCK>,
+							 <NRF_FUN_SPIS_SCK>;
 			};
 
 			uart120: uart@8e6000 {
@@ -582,6 +584,8 @@
 				#size-cells = <0>;
 				rx-delay-supported;
 				rx-delay = <1>;
+				nordic,clockpin-enable = <NRF_FUN_SPIM_SCK>,
+							 <NRF_FUN_SPIS_SCK>;
 			};
 
 			cpuppr_vpr: vpr@908000 {
@@ -833,6 +837,8 @@
 				easydma-maxcnt-bits = <15>;
 				#address-cells = <1>;
 				#size-cells = <0>;
+				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
+							 <NRF_FUN_TWIM_SCL>;
 			};
 
 			spi130: spi@9a5000 {
@@ -846,6 +852,10 @@
 				#size-cells = <0>;
 				rx-delay-supported;
 				rx-delay = <1>;
+				nordic,clockpin-enable = <NRF_FUN_SPIM_MOSI>,
+							 <NRF_FUN_SPIM_SCK>,
+							 <NRF_FUN_SPIS_MISO>,
+							 <NRF_FUN_SPIS_SCK>;
 			};
 
 			uart130: uart@9a5000 {
@@ -853,6 +863,7 @@
 				reg = <0x9a5000 0x1000>;
 				status = "disabled";
 				interrupts = <421 NRF_DEFAULT_IRQ_PRIORITY>;
+				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
 			};
 
 			i2c131: i2c@9a6000 {
@@ -863,6 +874,8 @@
 				easydma-maxcnt-bits = <15>;
 				#address-cells = <1>;
 				#size-cells = <0>;
+				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
+							 <NRF_FUN_TWIM_SCL>;
 			};
 
 			spi131: spi@9a6000 {
@@ -876,6 +889,10 @@
 				#size-cells = <0>;
 				rx-delay-supported;
 				rx-delay = <1>;
+				nordic,clockpin-enable = <NRF_FUN_SPIM_MOSI>,
+							 <NRF_FUN_SPIM_SCK>,
+							 <NRF_FUN_SPIS_MISO>,
+							 <NRF_FUN_SPIS_SCK>;
 			};
 
 			uart131: uart@9a6000 {
@@ -883,6 +900,7 @@
 				reg = <0x9a6000 0x1000>;
 				status = "disabled";
 				interrupts = <422 NRF_DEFAULT_IRQ_PRIORITY>;
+				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
 			};
 
 			dppic134: dppic@9b1000 {
@@ -927,6 +945,8 @@
 				easydma-maxcnt-bits = <15>;
 				#address-cells = <1>;
 				#size-cells = <0>;
+				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
+							 <NRF_FUN_TWIM_SCL>;
 			};
 
 			spi132: spi@9b5000 {
@@ -940,6 +960,10 @@
 				#size-cells = <0>;
 				rx-delay-supported;
 				rx-delay = <1>;
+				nordic,clockpin-enable = <NRF_FUN_SPIM_MOSI>,
+							 <NRF_FUN_SPIM_SCK>,
+							 <NRF_FUN_SPIS_MISO>,
+							 <NRF_FUN_SPIS_SCK>;
 			};
 
 			uart132: uart@9b5000 {
@@ -947,6 +971,7 @@
 				reg = <0x9b5000 0x1000>;
 				status = "disabled";
 				interrupts = <437 NRF_DEFAULT_IRQ_PRIORITY>;
+				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
 			};
 
 			i2c133: i2c@9b6000 {
@@ -957,6 +982,8 @@
 				easydma-maxcnt-bits = <15>;
 				#address-cells = <1>;
 				#size-cells = <0>;
+				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
+							 <NRF_FUN_TWIM_SCL>;
 			};
 
 			spi133: spi@9b6000 {
@@ -970,6 +997,10 @@
 				#size-cells = <0>;
 				rx-delay-supported;
 				rx-delay = <1>;
+				nordic,clockpin-enable = <NRF_FUN_SPIM_MOSI>,
+							 <NRF_FUN_SPIM_SCK>,
+							 <NRF_FUN_SPIS_MISO>,
+							 <NRF_FUN_SPIS_SCK>;
 			};
 
 			uart133: uart@9b6000 {
@@ -977,6 +1008,7 @@
 				reg = <0x9b6000 0x1000>;
 				status = "disabled";
 				interrupts = <438 NRF_DEFAULT_IRQ_PRIORITY>;
+				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
 			};
 
 			dppic135: dppic@9c1000 {
@@ -1021,6 +1053,8 @@
 				easydma-maxcnt-bits = <15>;
 				#address-cells = <1>;
 				#size-cells = <0>;
+				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
+							 <NRF_FUN_TWIM_SCL>;
 			};
 
 			spi134: spi@9c5000 {
@@ -1034,6 +1068,10 @@
 				#size-cells = <0>;
 				rx-delay-supported;
 				rx-delay = <1>;
+				nordic,clockpin-enable = <NRF_FUN_SPIM_MOSI>,
+							 <NRF_FUN_SPIM_SCK>,
+							 <NRF_FUN_SPIS_MISO>,
+							 <NRF_FUN_SPIS_SCK>;
 			};
 
 			uart134: uart@9c5000 {
@@ -1041,6 +1079,7 @@
 				reg = <0x9c5000 0x1000>;
 				status = "disabled";
 				interrupts = <453 NRF_DEFAULT_IRQ_PRIORITY>;
+				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
 			};
 
 			i2c135: i2c@9c6000 {
@@ -1051,6 +1090,8 @@
 				easydma-maxcnt-bits = <15>;
 				#address-cells = <1>;
 				#size-cells = <0>;
+				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
+							 <NRF_FUN_TWIM_SCL>;
 			};
 
 			spi135: spi@9c6000 {
@@ -1064,6 +1105,10 @@
 				#size-cells = <0>;
 				rx-delay-supported;
 				rx-delay = <1>;
+				nordic,clockpin-enable = <NRF_FUN_SPIM_MOSI>,
+							 <NRF_FUN_SPIM_SCK>,
+							 <NRF_FUN_SPIS_MISO>,
+							 <NRF_FUN_SPIS_SCK>;
 			};
 
 			uart135: uart@9c6000 {
@@ -1071,6 +1116,7 @@
 				reg = <0x9c6000 0x1000>;
 				status = "disabled";
 				interrupts = <454 NRF_DEFAULT_IRQ_PRIORITY>;
+				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
 			};
 
 			dppic136: dppic@9d1000 {
@@ -1115,6 +1161,8 @@
 				easydma-maxcnt-bits = <15>;
 				#address-cells = <1>;
 				#size-cells = <0>;
+				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
+							 <NRF_FUN_TWIM_SCL>;
 			};
 
 			spi136: spi@9d5000 {
@@ -1128,6 +1176,10 @@
 				#size-cells = <0>;
 				rx-delay-supported;
 				rx-delay = <1>;
+				nordic,clockpin-enable = <NRF_FUN_SPIM_MOSI>,
+							 <NRF_FUN_SPIM_SCK>,
+							 <NRF_FUN_SPIS_MISO>,
+							 <NRF_FUN_SPIS_SCK>;
 			};
 
 			uart136: uart@9d5000 {
@@ -1135,6 +1187,7 @@
 				reg = <0x9d5000 0x1000>;
 				status = "disabled";
 				interrupts = <469 NRF_DEFAULT_IRQ_PRIORITY>;
+				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
 			};
 
 			i2c137: i2c@9d6000 {
@@ -1145,6 +1198,8 @@
 				easydma-maxcnt-bits = <15>;
 				#address-cells = <1>;
 				#size-cells = <0>;
+				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
+							 <NRF_FUN_TWIM_SCL>;
 			};
 
 			spi137: spi@9d6000 {
@@ -1158,6 +1213,10 @@
 				#size-cells = <0>;
 				rx-delay-supported;
 				rx-delay = <1>;
+				nordic,clockpin-enable = <NRF_FUN_SPIM_MOSI>,
+							 <NRF_FUN_SPIM_SCK>,
+							 <NRF_FUN_SPIS_MISO>,
+							 <NRF_FUN_SPIS_SCK>;
 			};
 
 			uart137: uart@9d6000 {
@@ -1165,6 +1224,7 @@
 				reg = <0x9d6000 0x1000>;
 				status = "disabled";
 				interrupts = <470 NRF_DEFAULT_IRQ_PRIORITY>;
+				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
 			};
 		};
 	};

--- a/include/zephyr/dt-bindings/pinctrl/nrf-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/nrf-pinctrl.h
@@ -10,7 +10,8 @@
  * The whole nRF pin configuration information is encoded in a 32-bit bitfield
  * organized as follows:
  *
- * - 31..17: Pin function.
+ * - 31..18: Pin function.
+ * - 17:     Clockpin enable.
  * - 16:     Pin inversion mode.
  * - 15:     Pin low power mode.
  * - 14..11: Pin output drive configuration.
@@ -27,10 +28,10 @@
 #define NRF_FUN_POS 18U
 /** Mask for the function field. */
 #define NRF_FUN_MSK 0x3FFFU
-/** Position of the clock enable field. */
-#define NRF_CLOCK_ENABLE_POS 17U
-/** Mask for the clock enable field. */
-#define NRF_CLOCK_ENABLE_MSK 0x1U
+/** Position of the clockpin enable field. */
+#define NRF_CLOCKPIN_ENABLE_POS 17U
+/** Mask for the clockpin enable field. */
+#define NRF_CLOCKPIN_ENABLE_MSK 0x1U
 /** Position of the invert field. */
 #define NRF_INVERT_POS 16U
 /** Mask for the invert field. */

--- a/soc/nordic/common/pinctrl_soc.h
+++ b/soc/nordic/common/pinctrl_soc.h
@@ -26,20 +26,51 @@ extern "C" {
 typedef uint32_t pinctrl_soc_pin_t;
 
 /**
+ * @brief Utility macro to check if a function requires clockpin enable.
+ *
+ * @param node_id Node identifier.
+ * @param prop Property name.
+ * @param idx Property entry index.
+ * @param p_node_id Parent node identifier.
+ */
+#define Z_CHECK_CLOCKPIN_ENABLE(node_id, prop, idx, fun) \
+	DT_PROP_BY_IDX(node_id, prop, idx) == fun ? BIT(NRF_CLOCKPIN_ENABLE_POS) :
+
+/**
+ * @brief Utility macro compute the clockpin enable bit.
+ *
+ * @note DT_FOREACH_PROP_ELEM_SEP_VARGS() is used instead of
+ * DT_FOREACH_PROP_ELEM_VARGS() because the latter is already resolved in the
+ * same run.
+ *
+ * @param node_id Node identifier.
+ * @param prop Property name.
+ * @param idx Property entry index.
+ * @param p_node_id Parent node identifier.
+ */
+#define Z_GET_CLOCKPIN_ENABLE(node_id, prop, idx, p_node_id)		            \
+	COND_CODE_1(DT_NODE_HAS_PROP(p_node_id, nordic_clockpin_enable),            \
+		    ((DT_FOREACH_PROP_ELEM_SEP_VARGS(			            \
+			p_node_id, nordic_clockpin_enable, Z_CHECK_CLOCKPIN_ENABLE, \
+			(), NRF_GET_FUN(DT_PROP_BY_IDX(node_id, prop, idx)))        \
+		      0)), (0))
+
+/**
  * @brief Utility macro to initialize each pin.
  *
  * @param node_id Node identifier.
  * @param prop Property name.
  * @param idx Property entry index.
+ * @param p_node_id Parent node identifier.
  */
-#define Z_PINCTRL_STATE_PIN_INIT(node_id, prop, idx)			       \
+#define Z_PINCTRL_STATE_PIN_INIT(node_id, prop, idx, p_node_id)		       \
 	(DT_PROP_BY_IDX(node_id, prop, idx) |				       \
 	 ((NRF_PULL_DOWN * DT_PROP(node_id, bias_pull_down)) << NRF_PULL_POS) |\
 	 ((NRF_PULL_UP * DT_PROP(node_id, bias_pull_up)) << NRF_PULL_POS) |    \
 	 (DT_PROP(node_id, nordic_drive_mode) << NRF_DRIVE_POS) |	       \
 	 ((NRF_LP_ENABLE * DT_PROP(node_id, low_power_enable)) << NRF_LP_POS) |\
 	 (DT_PROP(node_id, nordic_invert) << NRF_INVERT_POS) |		       \
-	 (DT_PROP(node_id, nordic_clock_enable) << NRF_CLOCK_ENABLE_POS)       \
+	 Z_GET_CLOCKPIN_ENABLE(node_id, prop, idx, p_node_id)		       \
 	),
 
 /**
@@ -50,8 +81,8 @@ typedef uint32_t pinctrl_soc_pin_t;
  */
 #define Z_PINCTRL_STATE_PINS_INIT(node_id, prop)			       \
 	{DT_FOREACH_CHILD_VARGS(DT_PHANDLE(node_id, prop),		       \
-				DT_FOREACH_PROP_ELEM, psels,		       \
-				Z_PINCTRL_STATE_PIN_INIT)}
+				DT_FOREACH_PROP_ELEM_VARGS, psels,	       \
+				Z_PINCTRL_STATE_PIN_INIT, node_id)}
 
 /**
  * @brief Utility macro to obtain pin function.
@@ -61,11 +92,12 @@ typedef uint32_t pinctrl_soc_pin_t;
 #define NRF_GET_FUN(pincfg) (((pincfg) >> NRF_FUN_POS) & NRF_FUN_MSK)
 
 /**
- * @brief Utility macro to obtain pin clock enable flag.
+ * @brief Utility macro to obtain pin clockpin enable flag.
  *
  * @param pincfg Pin configuration bit field.
  */
-#define NRF_GET_CLOCK_ENABLE(pincfg) (((pincfg) >> NRF_CLOCK_ENABLE_POS) & NRF_CLOCK_ENABLE_MSK)
+#define NRF_GET_CLOCKPIN_ENABLE(pincfg) \
+	(((pincfg) >> NRF_CLOCKPIN_ENABLE_POS) & NRF_CLOCKPIN_ENABLE_MSK)
 
 /**
  * @brief Utility macro to obtain pin inversion flag.

--- a/tests/boards/nrf/dmm/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/boards/nrf/dmm/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -10,7 +10,6 @@
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 2, 8)>,
 				<NRF_PSEL(SPIM_SCK, 1, 2)>;
-			nordic,clock-enable;
 		};
 	};
 

--- a/tests/boards/nrf/i2c/i2c_slave/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/boards/nrf/i2c/i2c_slave/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -9,7 +9,6 @@
 		group1 {
 			psels = <NRF_PSEL(TWIM_SDA, 2, 8)>,
 				<NRF_PSEL(TWIM_SCL, 1, 2)>;
-			nordic,clock-enable;
 		};
 	};
 
@@ -28,7 +27,6 @@
 			psels = <NRF_PSEL(TWIM_SDA, 2, 9)>,
 				<NRF_PSEL(TWIM_SCL, 1, 3)>;
 			bias-pull-up;
-			nordic,clock-enable;
 		};
 	};
 

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_common.dtsi
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_common.dtsi
@@ -8,12 +8,8 @@
 	spi130_default_alt: spi130_default_alt {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 0, 0)>,
-				<NRF_PSEL(SPIM_MOSI, 0, 8)>;
-			nordic,clock-enable;
-		};
-
-		group2 {
-			psels = <NRF_PSEL(SPIM_MISO, 0, 6)>;
+				<NRF_PSEL(SPIM_MOSI, 0, 8)>,
+				<NRF_PSEL(SPIM_MISO, 0, 6)>;
 		};
 	};
 
@@ -29,12 +25,8 @@
 	spis131_default_alt: spis131_default_alt {
 		group1 {
 			psels = <NRF_PSEL(SPIS_SCK, 0, 1)>,
-				<NRF_PSEL(SPIS_MISO, 0, 7)>;
-			nordic,clock-enable;
-		};
-
-		group2 {
-			psels = <NRF_PSEL(SPIS_MOSI, 0, 9)>,
+				<NRF_PSEL(SPIS_MISO, 0, 7)>,
+				<NRF_PSEL(SPIS_MOSI, 0, 9)>,
 				<NRF_PSEL(SPIS_CSN, 0, 11)>;
 		};
 	};

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay
@@ -25,12 +25,8 @@
 	spis131_default_alt: spis131_default_alt {
 		group1 {
 			psels = <NRF_PSEL(SPIS_SCK, 1, 0)>,
-				<NRF_PSEL(SPIS_MISO, 1, 9)>;
-			nordic,clock-enable;
-		};
-
-		group2 {
-			psels = <NRF_PSEL(SPIS_MOSI, 1, 5)>,
+				<NRF_PSEL(SPIS_MISO, 1, 9)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 5)>,
 				<NRF_PSEL(SPIS_CSN, 0, 11)>;
 		};
 	};

--- a/tests/drivers/spi/spi_error_cases/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/spi/spi_error_cases/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -8,12 +8,8 @@
 	spi130_default_alt: spi130_default_alt {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 0, 0)>,
-				<NRF_PSEL(SPIM_MOSI, 0, 8)>;
-			nordic,clock-enable;
-		};
-
-		group2 {
-			psels = <NRF_PSEL(SPIM_MISO, 0, 6)>;
+				<NRF_PSEL(SPIM_MOSI, 0, 8)>,
+				<NRF_PSEL(SPIM_MISO, 0, 6)>;
 		};
 	};
 
@@ -29,12 +25,8 @@
 	spis131_default_alt: spis131_default_alt {
 		group1 {
 			psels = <NRF_PSEL(SPIS_SCK, 0, 1)>,
-				<NRF_PSEL(SPIS_MISO, 0, 7)>;
-			nordic,clock-enable;
-		};
-
-		group2 {
-			psels = <NRF_PSEL(SPIS_MOSI, 0, 9)>,
+				<NRF_PSEL(SPIS_MISO, 0, 7)>,
+				<NRF_PSEL(SPIS_MOSI, 0, 9)>,
 				<NRF_PSEL(SPIS_CSN, 0, 11)>;
 		};
 	};

--- a/tests/drivers/spi/spi_error_cases/boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay
+++ b/tests/drivers/spi/spi_error_cases/boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay
@@ -25,12 +25,8 @@
 	spis131_default_alt: spis131_default_alt {
 		group1 {
 			psels = <NRF_PSEL(SPIS_SCK, 1, 0)>,
-				<NRF_PSEL(SPIS_MISO, 1, 9)>;
-			nordic,clock-enable;
-		};
-
-		group2 {
-			psels = <NRF_PSEL(SPIS_MOSI, 1, 5)>,
+				<NRF_PSEL(SPIS_MISO, 1, 9)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 5)>,
 				<NRF_PSEL(SPIS_CSN, 0, 11)>;
 		};
 	};

--- a/tests/drivers/spi/spi_error_cases/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
+++ b/tests/drivers/spi/spi_error_cases/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
@@ -8,12 +8,8 @@
 	spi130_default_alt: spi130_default_alt {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 0, 0)>,
-				<NRF_PSEL(SPIM_MOSI, 0, 8)>;
-			nordic,clock-enable;
-		};
-
-		group2 {
-			psels = <NRF_PSEL(SPIM_MISO, 0, 6)>;
+				<NRF_PSEL(SPIM_MOSI, 0, 8)>,
+				<NRF_PSEL(SPIM_MISO, 0, 6)>;
 		};
 	};
 
@@ -29,12 +25,8 @@
 	spis131_default_alt: spis131_default_alt {
 		group1 {
 			psels = <NRF_PSEL(SPIS_SCK, 0, 1)>,
-				<NRF_PSEL(SPIS_MISO, 0, 7)>;
-			nordic,clock-enable;
-		};
-
-		group2 {
-			psels = <NRF_PSEL(SPIS_MOSI, 0, 9)>,
+				<NRF_PSEL(SPIS_MISO, 0, 7)>,
+				<NRF_PSEL(SPIS_MOSI, 0, 9)>,
 				<NRF_PSEL(SPIS_CSN, 0, 11)>;
 		};
 	};

--- a/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -8,12 +8,8 @@
 	spi130_default: spi130_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 0, 0)>,
-				<NRF_PSEL(SPIM_MOSI, 0, 7)>;
-			nordic,clock-enable;
-		};
-
-		group2 {
-			psels = <NRF_PSEL(SPIM_MISO, 0, 6)>;
+				<NRF_PSEL(SPIM_MOSI, 0, 7)>,
+				<NRF_PSEL(SPIM_MISO, 0, 6)>;
 		};
 	};
 


### PR DESCRIPTION
Rework how `nordic,clock-enable` works. New approach allows users to skip this setting, as it is something known at compile time.

Thanks to @nordic-krch for macrobatics suggestions.

Fixes #76830