### PR TITLE
Update index.rst for macOS, Issue #76811

### DIFF
--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -132,7 +132,7 @@ The current minimum required version for the main dependencies are:
 
          .. code-block:: bash
 
-            brew install cmake ninja gperf python3 ccache qemu dtc libmagic wget openocd
+            brew install cmake ninja gperf python3 python-tk ccache qemu dtc libmagic wget openocd
 
       #. Add the Homebrew Python folder to the path, in order to be able to
          execute ``python`` and ``pip`` as well ``python3`` and ``pip3``.


### PR DESCRIPTION
Added python-tk to the brew install statement.
In order to use the zephyr gui tools python must also have the "tkinter" (python tk interface) tools available.

tkinter is NOT part of 'python3' through homebrew on macOS.