### PR TITLE
ec_host_cmd: Fix generating multiple Port80 notifications

### DIFF
--- a/drivers/espi/espi_mchp_xec_host_v2.c
+++ b/drivers/espi/espi_mchp_xec_host_v2.c
@@ -855,6 +855,7 @@ static void p80bd0_isr(const struct device *dev)
 			espi_send_callbacks(&data->callbacks, dev, evt);
 			evt.evt_details = 0;
 		}
+		dattr = p80regs->EC_DA;
 	}
 
 	/* clear GIRQ status */


### PR DESCRIPTION
Port80 notifications are continously generated as long as NOT_EMPTY bit inside of Data Attributes register is set. This register was only read once prior entering loop and its value was not checked on each iteration.

This patch will include reading Data Attributes register on each iteration, this way we can exit loop when no more data is available.