### PR TITLE
MAINTAINERS: Adds entry haptics subsystem

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1446,6 +1446,22 @@ Release Notes:
   tests:
     - drivers.gnss
 
+"Drivers: Haptics":
+  status: maintained
+  maintainers:
+    - rriveramcrus
+  files:
+    - drivers/haptics/
+    - dts/bindings/haptics/
+    - include/zephyr/drivers/haptics.h
+    - doc/hardware/peripherals/haptics.rst
+    - tests/drivers/build_all/haptics/
+    - samples/drivers/haptics/
+  labels:
+    - "area: Haptics"
+  tests:
+    - drivers.haptics
+
 "Drivers: HW Info":
   status: maintained
   maintainers:


### PR DESCRIPTION
Adds an entry to the MAINTAINERS file claiming maintenance of the haptics subsystem.