### PR TITLE
scripts: Add explicit utf8 encoding to twisterlib

### DIFF
--- a/scripts/pylib/twister/twisterlib/cmakecache.py
+++ b/scripts/pylib/twister/twisterlib/cmakecache.py
@@ -114,7 +114,7 @@ class CMakeCache:
 
     def load(self, cache_file):
         entries = []
-        with open(cache_file, 'r') as cache:
+        with open(cache_file, 'r', encoding='utf-8') as cache:
             for line_no, line in enumerate(cache):
                 entry = CMakeCacheEntry.from_line(line, line_no)
                 if entry:

--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -149,7 +149,7 @@ class CoverageTool:
                 logger.error("Gcov data capture incomplete: {}".format(filename))
                 coverage_completed = False
 
-        with open(os.path.join(outdir, "coverage.log"), "a") as coveragelog:
+        with open(os.path.join(outdir, "coverage.log"), "a", encoding="utf-8") as coveragelog:
             ret = self._generate(outdir, coveragelog)
             if ret == 0:
                 report_log = {

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -195,7 +195,7 @@ class BinaryHandler(Handler):
     def _output_handler(self, proc, harness):
         suffix = '\\r\\n'
 
-        with open(self.log, "wt") as log_out_fp:
+        with open(self.log, "wt", encoding="utf-8") as log_out_fp:
             timeout_extended = False
             timeout_time = time.time() + self.get_test_timeout()
             while True:
@@ -1128,7 +1128,7 @@ class QEMUWinHandler(Handler):
 
     @staticmethod
     def _open_log_file(logfile):
-        return open(logfile, "wt")
+        return open(logfile, "wt", encoding="utf-8")
 
     @staticmethod
     def _close_log_file(log_file):

--- a/scripts/pylib/twister/twisterlib/package.py
+++ b/scripts/pylib/twister/twisterlib/package.py
@@ -22,7 +22,7 @@ class Artifacts:
 
     def package(self):
         dirs = []
-        with open(os.path.join(self.options.outdir, "twister.json"), "r") as json_test_plan:
+        with open(os.path.join(self.options.outdir, "twister.json"), "r", encoding="utf-8") as json_test_plan:
             jtp = json.load(json_test_plan)
             for t in jtp['testsuites']:
                 if t['status'] != "filtered":

--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -101,7 +101,7 @@ class Reporting:
     def xunit_report_suites(self, json_file, filename):
 
         json_data = {}
-        with open(json_file, "r") as json_results:
+        with open(json_file, "r", encoding="utf-8") as json_results:
             json_data = json.load(json_results)
 
 
@@ -170,7 +170,7 @@ class Reporting:
             selected = self.selected_platforms
 
         json_data = {}
-        with open(json_file, "r") as json_results:
+        with open(json_file, "r", encoding="utf-8") as json_results:
             json_data = json.load(json_results)
 
 
@@ -407,7 +407,7 @@ class Reporting:
                     if do_all or k in self.env.options.footprint_report:
                         footprint_fname = os.path.join(instance.build_dir, v)
                         try:
-                            with open(footprint_fname, "rt") as footprint_json:
+                            with open(footprint_fname, "rt", encoding="utf-8") as footprint_json:
                                 logger.debug(f"Collect footprint.{k} for '{instance.name}'")
                                 suite['footprint'][k] = json.load(footprint_json)
                         except FileNotFoundError:
@@ -418,7 +418,7 @@ class Reporting:
             suites.append(suite)
 
         report["testsuites"] = suites
-        with open(filename, "wt") as json_file:
+        with open(filename, "wt", encoding="utf-8") as json_file:
             json.dump(report, json_file, indent=4, separators=(',',':'))
 
 
@@ -433,7 +433,7 @@ class Reporting:
 
         results = []
         saved_metrics = {}
-        with open(filename) as fp:
+        with open(filename, encoding="utf-8") as fp:
             jt = json.load(fp)
             for ts in jt.get("testsuites", []):
                 d = {}

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -395,7 +395,7 @@ def test_binaryhandler_output_handler(
          mock.patch('time.time', side_effect=faux_timer.time):
         handler._output_handler(proc, harness)
 
-        mock_file.assert_called_with(handler.log, 'wt')
+        mock_file.assert_called_with(handler.log, 'wt', encoding='utf-8')
 
     if expected_handler_calls:
         mock_file.return_value.write.assert_has_calls(expected_handler_calls)


### PR DESCRIPTION
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/76517 

Added UTF-8 encoding for reading and writing files in the twisterlib suite to create more universal encoding for all files coming in and out of twister.

This change resulted from the difference in how python handles files on windows vs unix. With this change it will now be explicit which file encoding to use for twister.

The files were parsed through to find which files should have the explicit encoding and not all open() functions were modified. Only what seemed necessary was modified.