### PR TITLE
drivers: serial: pl011: Fix ignored const qualifiers

### DIFF
--- a/drivers/serial/uart_pl011_registers.h
+++ b/drivers/serial/uart_pl011_registers.h
@@ -37,9 +37,9 @@ struct pl011_regs {
 };
 
 static inline
-volatile struct pl011_regs *const get_uart(const struct device *dev)
+volatile struct pl011_regs *get_uart(const struct device *dev)
 {
-	return (volatile struct pl011_regs *const)DEVICE_MMIO_GET(dev);
+	return (volatile struct pl011_regs *)DEVICE_MMIO_GET(dev);
 }
 
 #define PL011_BIT_MASK(x, y) (((2 << x) - 1) << y)


### PR DESCRIPTION
When trying to build Zephyr with -Wignored-qualifiers this leads to a compiler warning like:

zephyr/drivers/serial/uart_pl011_registers.h:40:1: error: type qualifiers ignored on function return type [-Werror=ignored-qualifiers]

Since the return value is copied by the caller, making it const has no effect and the compiler warns that this is being ignored. This enables applications to build with additional compiler warnings turned on.