### PR TITLE
Flash map custom source

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -129,7 +129,7 @@ endif # HAS_FLASH_LOAD_OFFSET
 
 config ROM_START_OFFSET
 	hex
-	prompt "ROM start offset" if !BOOTLOADER_MCUBOOT
+	prompt "ROM start offset"
 	default 0x200 if BOOTLOADER_MCUBOOT
 	default 0
 	help

--- a/modules/Kconfig.mcuboot
+++ b/modules/Kconfig.mcuboot
@@ -258,6 +258,12 @@ endif
 
 endmenu # On board MCUboot operation mode
 
+config MCUBOOT_IMGTOOL_LOAD_ADDRESS
+	hex "If image is loaded to RAM, specify the load address"
+	default 0x00
+	help
+	  If the image is loaded to RAM, specify the load address.
+
 endif # BOOTLOADER_MCUBOOT
 
 menuconfig MCUBOOT_BOOTUTIL_LIB

--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -250,6 +250,7 @@ class ImgtoolSigner(Signer):
         # The vector table offset and application version are set in Kconfig:
         appver = self.get_cfg(command, build_conf, 'CONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION')
         vtoff = self.get_cfg(command, build_conf, 'CONFIG_ROM_START_OFFSET')
+        load_addr = self.get_cfg(command, build_conf, 'CONFIG_MCUBOOT_IMGTOOL_LOAD_ADDRESS')
         # Flash device write alignment and the partition's slot size
         # come from devicetree:
         flash = self.edt_flash_node(b, args.quiet)
@@ -288,6 +289,9 @@ class ImgtoolSigner(Signer):
                                '--align', str(align),
                                '--header-size', str(vtoff),
                                '--slot-size', str(size)]
+        if load_addr > 0:
+            sign_base += ['--load-addr', str(load_addr)]
+
         sign_base.extend(args.tool_args)
 
         if not args.quiet:

--- a/subsys/storage/flash_map/Kconfig
+++ b/subsys/storage/flash_map/Kconfig
@@ -9,7 +9,6 @@
 
 menuconfig FLASH_MAP
 	bool "Flash map abstraction module"
-	depends on FLASH_HAS_DRIVER_ENABLED
 	help
 	  Enable support of flash map abstraction.
 
@@ -27,6 +26,14 @@ config FLASH_MAP_CUSTOM
 	help
 	  This option enables custom flash map description.
 	  User must provide such a description in place of default on
+	  if had enabled this option.
+
+config FLASH_MAP_CUSTOM_BACKEND
+	bool "Custom flash map backend"
+	default y if !FLASH_HAS_DRIVER_ENABLED
+	help
+	  This option enables custom flash map backend.
+	  User must provide such a backend in place of default one
 	  if had enabled this option.
 
 config FLASH_AREA_CHECK_INTEGRITY


### PR DESCRIPTION
Flash map API is built on top of Flash API, which makes sense. However, some other storage devices could benefit from exposing a flash map API - specially in the context of mcuboot, which uses flash map API extensively.

This PR adds the possibility, under a new Kconfig FLASH_MAP_CUSTOM_BACKEND, to implement the flash map API directly. One just needs to implement `flash_area_open_custom` method, which is called when `flash_area_open` is called on a qualifying id. This method should be used to dispatch the flash_area creation to the right implementation. Such implementation then needs to fill the new `api` field from `struct flash_area`. Then, the flash map API will simply call the implementation methods from the struct.

A "qualifying id" is any id OR'ed with FLASH_MAP_CUSTOM_BACKEND_MASK. This is used to identify when a flash_area has a custom backend implementation, otherwise, default implementation will be used.

Also in this PR are patches that allow one to change ROM start offset for mcuboot and where an image should be loaded by mcuboot, when RAM load is used.

For an example of how this can be used, please refer to https://github.com/mcu-tools/mcuboot/pull/2031