### PR TITLE
   test: Bluetooth: CAP: refactor CAP commander test

### DIFF
--- a/include/zephyr/bluetooth/audio/cap.h
+++ b/include/zephyr/bluetooth/audio/cap.h
@@ -817,6 +817,17 @@ struct bt_cap_commander_cb {
 	 *			by bt_cap_commander_cancel().
 	 */
 	void (*broadcast_reception_start)(struct bt_conn *conn, int err);
+	/**
+	 * @brief Callback for bt_cap_commander_broadcast_reception_stop().
+	 *
+	 * @param conn		Pointer to the connection where the error
+	 *			occurred. NULL if @p err is 0 or if cancelled by
+	 *			bt_cap_commander_cancel()
+	 * @param err		0 on success, BT_GATT_ERR() with a
+	 *			specific ATT (BT_ATT_ERR_*) error code or -ECANCELED if cancelled
+	 *			by bt_cap_commander_cancel().
+	 */
+	void (*broadcast_reception_stop)(struct bt_conn *conn, int err);
 #endif /* CONFIG_BT_BAP_BROADCAST_ASSISTANT */
 };
 
@@ -945,14 +956,26 @@ int bt_cap_commander_broadcast_reception_start(
 	const struct bt_cap_commander_broadcast_reception_start_param *param);
 
 /** Parameters for stopping broadcast reception  */
+
+struct bt_cap_commander_broadcast_reception_stop_member_param {
+	/** Coordinated or ad-hoc set member. */
+	union bt_cap_set_member member;
+
+	/** Source ID of the receive state. */
+	uint8_t src_id;
+
+	/** Number of subgroups */
+	size_t num_subgroups;
+};
+
 struct bt_cap_commander_broadcast_reception_stop_param {
 	/** The type of the set. */
 	enum bt_cap_set_type type;
 
-	/** Coordinated or ad-hoc set member. */
-	union bt_cap_set_member *members;
+	/** The set of devices for this procedure */
+	struct bt_cap_commander_broadcast_reception_stop_member_param *param;
 
-	/** The number of members in @p members */
+	/** The number of parameters in @p param */
 	size_t count;
 };
 

--- a/subsys/bluetooth/audio/cap_commander.c
+++ b/subsys/bluetooth/audio/cap_commander.c
@@ -99,7 +99,7 @@ int bt_cap_commander_discover(struct bt_conn *conn)
 
 #if defined(CONFIG_BT_BAP_BROADCAST_ASSISTANT)
 static struct bt_bap_broadcast_assistant_cb broadcast_assistant_cb;
-static bool ba_cb_registered;
+static bool broadcast_assistant_cb_registered;
 
 static void
 copy_broadcast_reception_start_param(struct bt_bap_broadcast_assistant_add_src_param *add_src_param,
@@ -114,7 +114,7 @@ copy_broadcast_reception_start_param(struct bt_bap_broadcast_assistant_add_src_p
 	add_src_param->subgroups = start_param->subgroups;
 }
 
-static void cap_commander_ba_add_src_cb(struct bt_conn *conn, int err)
+static void cap_commander_broadcast_assistant_add_src_cb(struct bt_conn *conn, int err)
 {
 	struct bt_cap_common_proc *active_proc = bt_cap_common_get_active_proc();
 	struct bt_bap_broadcast_assistant_add_src_param add_src_param = {0};
@@ -169,7 +169,7 @@ static void cap_commander_ba_add_src_cb(struct bt_conn *conn, int err)
 	}
 }
 
-static int cap_commander_register_ba_cb(void)
+static int cap_commander_register_broadcast_assistant_cb(void)
 {
 	int err;
 
@@ -180,7 +180,7 @@ static int cap_commander_register_ba_cb(void)
 		return -ENOEXEC;
 	}
 
-	ba_cb_registered = true;
+	broadcast_assistant_cb_registered = true;
 
 	return 0;
 }
@@ -196,7 +196,7 @@ static bool valid_broadcast_reception_start_param(
 	}
 
 	CHECKIF(param->count == 0) {
-		LOG_DBG("Invalid param->count: %u", param->count);
+		LOG_DBG("Invalid param->count: %zu", param->count);
 		return false;
 	}
 
@@ -344,8 +344,9 @@ int bt_cap_commander_broadcast_reception_start(
 
 	bt_cap_common_start_proc(BT_CAP_COMMON_PROC_TYPE_BROADCAST_RECEPTION_START, param->count);
 
-	broadcast_assistant_cb.add_src = cap_commander_ba_add_src_cb;
-	if (!ba_cb_registered && cap_commander_register_ba_cb() != 0) {
+	broadcast_assistant_cb.add_src = cap_commander_broadcast_assistant_add_src_cb;
+	if (!broadcast_assistant_cb_registered &&
+	    cap_commander_register_broadcast_assistant_cb() != 0) {
 		LOG_DBG("Failed to register broadcast assistant callbacks");
 
 		return -ENOEXEC;
@@ -399,13 +400,279 @@ int bt_cap_commander_broadcast_reception_start(
 
 	return 0;
 }
-#endif /* CONFIG_BT_BAP_BROADCAST_ASSISTANT */
+
+static void
+copy_broadcast_reception_stop_param(struct bt_bap_broadcast_assistant_mod_src_param *mod_src_param,
+				    struct cap_broadcast_reception_stop *stop_param)
+{
+	mod_src_param->src_id = stop_param->src_id;
+	mod_src_param->pa_sync = false;
+	mod_src_param->pa_interval = BT_BAP_PA_INTERVAL_UNKNOWN;
+	mod_src_param->num_subgroups = stop_param->num_subgroups;
+
+	mod_src_param->subgroups = stop_param->subgroups;
+}
+
+static void cap_commander_broadcast_assistant_recv_state_cb(
+	struct bt_conn *conn, int err, const struct bt_bap_scan_delegator_recv_state *state)
+{
+	struct bt_cap_common_proc *active_proc = bt_cap_common_get_active_proc();
+
+	if (state == NULL) {
+		/* Empty receive state, so there is no BIS information available which
+		 * can trigger a remove source operation
+		 */
+		return;
+	}
+
+	if (bt_cap_common_conn_in_active_proc(conn) &&
+	    active_proc->proc_type == BT_CAP_COMMON_PROC_TYPE_BROADCAST_RECEPTION_STOP) {
+		bool bis_sync_zero = true;
+
+		LOG_DBG("BASS recv state: conn %p, src_id %u", (void *)conn, state->src_id);
+
+		for (uint8_t i = 0; i < state->num_subgroups; i++) {
+			const struct bt_bap_bass_subgroup *subgroup = &state->subgroups[i];
+
+			if (subgroup->bis_sync != 0) {
+				bis_sync_zero = false;
+				break;
+			}
+		}
+
+		if (bis_sync_zero) {
+			LOG_DBG("Removing source for conn %p", (void *)conn);
+			err = bt_bap_broadcast_assistant_rem_src(conn, state->src_id);
+			if (err != 0) {
+				LOG_DBG("Failed to rem_src for conn %p: %d", (void *)conn, err);
+				bt_cap_common_abort_proc(conn, err);
+				cap_commander_proc_complete();
+			}
+		}
+	}
+}
+
+static void cap_commander_broadcast_assistant_rem_src_cb(struct bt_conn *conn, int err)
+{
+	struct bt_cap_common_proc *active_proc = bt_cap_common_get_active_proc();
+	struct bt_bap_broadcast_assistant_mod_src_param mod_src_param = {0};
+
+	if (!bt_cap_common_conn_in_active_proc(conn)) {
+		/* State change happened outside of a procedure; ignore */
+		return;
+	}
+
+	if (err != 0) {
+		LOG_DBG("Failed removing source: %d", err);
+		LOG_DBG("Aborting the proc %d %d", active_proc->proc_done_cnt,
+			active_proc->proc_initiated_cnt);
+
+		bt_cap_common_abort_proc(conn, err);
+	} else {
+		active_proc->proc_done_cnt++;
+
+		LOG_DBG("Conn %p broadcast source removed (%zu/%zu streams done)", (void *)conn,
+			active_proc->proc_done_cnt, active_proc->proc_cnt);
+	}
+
+	if (bt_cap_common_proc_is_aborted()) {
+		if (bt_cap_common_proc_all_handled()) {
+			cap_commander_proc_complete();
+		}
+
+		return;
+	}
+
+	if (!bt_cap_common_proc_is_done()) {
+		struct bt_cap_commander_proc_param *proc_param;
+
+		proc_param = &active_proc->proc_param.commander[active_proc->proc_done_cnt];
+		conn = proc_param->conn;
+		copy_broadcast_reception_stop_param(&mod_src_param,
+						    &proc_param->broadcast_reception_stop);
+		active_proc->proc_initiated_cnt++;
+		err = bt_bap_broadcast_assistant_mod_src(conn, &mod_src_param);
+		if (err != 0) {
+			LOG_DBG("Failed to mod_src for conn %p: %d", (void *)conn, err);
+			bt_cap_common_abort_proc(conn, err);
+			cap_commander_proc_complete();
+		}
+	} else {
+		cap_commander_proc_complete();
+	}
+}
+
+static void cap_commander_broadcast_assistant_mod_src_cb(struct bt_conn *conn, int err)
+{
+	struct bt_cap_common_proc *active_proc = bt_cap_common_get_active_proc();
+
+	if (!bt_cap_common_conn_in_active_proc(conn)) {
+		/* State change happened outside of a procedure; ignore */
+		return;
+	}
+
+	if (err != 0) {
+		LOG_DBG("Failed modifying source: %d", err);
+		LOG_DBG("Aborting the proc %d %d", active_proc->proc_done_cnt,
+			active_proc->proc_initiated_cnt);
+
+		bt_cap_common_abort_proc(conn, err);
+	} else {
+		LOG_DBG("Conn %p broadcast source modifified (%zu/%zu streams done)", (void *)conn,
+			active_proc->proc_done_cnt, active_proc->proc_cnt);
+	}
+
+	if (bt_cap_common_proc_is_aborted()) {
+		if (bt_cap_common_proc_all_handled()) {
+			cap_commander_proc_complete();
+		}
+	}
+}
+
+static bool valid_broadcast_reception_stop_param(
+	const struct bt_cap_commander_broadcast_reception_stop_param *param)
+{
+	CHECKIF(param == NULL) {
+		LOG_DBG("param is NULL");
+		return false;
+	}
+
+	CHECKIF(param->count == 0) {
+		LOG_DBG("Invalid param->count: %zu", param->count);
+		return false;
+	}
+
+	CHECKIF(param->count > CONFIG_BT_MAX_CONN) {
+		LOG_DBG("param->count (%zu) is larger than CONFIG_BT_MAX_CONN (%d)", param->count,
+			CONFIG_BT_MAX_CONN);
+		return false;
+	}
+
+	CHECKIF(param->param == NULL) {
+		LOG_DBG("param->param is NULL");
+		return false;
+	}
+
+	for (size_t i = 0; i < param->count; i++) {
+		const struct bt_cap_commander_broadcast_reception_stop_member_param *stop_param =
+			&param->param[i];
+		const union bt_cap_set_member *member = &param->param[i].member;
+		const struct bt_conn *member_conn =
+			bt_cap_common_get_member_conn(param->type, member);
+
+		if (member == NULL) {
+			LOG_DBG("param->param[%zu].member is NULL", i);
+			return false;
+		}
+
+		if (member_conn == NULL) {
+			LOG_DBG("Invalid param->param[%zu].member", i);
+			return false;
+		}
+
+		CHECKIF(stop_param->num_subgroups == 0) {
+			LOG_DBG("param->param[%zu]->num_subgroups is 0", i);
+			return false;
+		}
+
+		CHECKIF(stop_param->num_subgroups > CONFIG_BT_BAP_BASS_MAX_SUBGROUPS) {
+			LOG_DBG("Too many subgroups %u/%u", stop_param->num_subgroups,
+				CONFIG_BT_BAP_BASS_MAX_SUBGROUPS);
+			return false;
+		}
+
+		for (size_t j = 0U; j < i; j++) {
+			const union bt_cap_set_member *other = &param->param[j].member;
+			uint8_t other_src_id = param->param[j].src_id;
+
+			if (other == member && stop_param->src_id == other_src_id) {
+				LOG_DBG("param->members[%zu], src_id %d (%p) is duplicated by "
+					"param->members[%zu], src_id %d (%p)",
+					j, other_src_id, other, i, stop_param->src_id, member);
+				return false;
+			}
+		}
+	}
+
+	return true;
+}
 
 int bt_cap_commander_broadcast_reception_stop(
 	const struct bt_cap_commander_broadcast_reception_stop_param *param)
 {
-	return -ENOSYS;
+	struct bt_bap_broadcast_assistant_mod_src_param mod_src_param = {0};
+	struct bt_cap_commander_proc_param *proc_param;
+	struct bt_cap_common_proc *active_proc;
+	struct bt_conn *conn;
+	int err;
+
+	if (bt_cap_common_proc_is_active()) {
+		LOG_DBG("A CAP procedure is already in progress");
+
+		return -EBUSY;
+	}
+
+	if (!valid_broadcast_reception_stop_param(param)) {
+		return -EINVAL;
+	}
+
+	bt_cap_common_start_proc(BT_CAP_COMMON_PROC_TYPE_BROADCAST_RECEPTION_STOP, param->count);
+
+	broadcast_assistant_cb.mod_src = cap_commander_broadcast_assistant_mod_src_cb;
+	broadcast_assistant_cb.rem_src = cap_commander_broadcast_assistant_rem_src_cb;
+	broadcast_assistant_cb.recv_state = cap_commander_broadcast_assistant_recv_state_cb;
+	if (!broadcast_assistant_cb_registered &&
+	    cap_commander_register_broadcast_assistant_cb() != 0) {
+		LOG_DBG("Failed to register broadcast assistant callbacks");
+
+		return -ENOEXEC;
+	}
+
+	active_proc = bt_cap_common_get_active_proc();
+
+	for (size_t i = 0U; i < param->count; i++) {
+		const struct bt_cap_commander_broadcast_reception_stop_member_param *member_param =
+			&param->param[i];
+		struct bt_cap_commander_proc_param *stored_param;
+		struct bt_conn *member_conn =
+			bt_cap_common_get_member_conn(param->type, &member_param->member);
+
+		if (member_conn == NULL) {
+			LOG_DBG("Invalid param->member[%zu]", i);
+
+			return -EINVAL;
+		}
+		/* Store the necessary parameters as we cannot assume that the supplied
+		 * parameters are kept valid
+		 */
+		stored_param = &active_proc->proc_param.commander[i];
+		stored_param->conn = member_conn;
+		stored_param->broadcast_reception_stop.src_id = member_param->src_id;
+		stored_param->broadcast_reception_stop.num_subgroups = member_param->num_subgroups;
+		for (size_t j = 0U; j < CONFIG_BT_BAP_BASS_MAX_SUBGROUPS; j++) {
+			stored_param->broadcast_reception_stop.subgroups[j].bis_sync = 0;
+			stored_param->broadcast_reception_stop.subgroups[j].metadata_len = 0;
+		}
+	}
+
+	proc_param = &active_proc->proc_param.commander[0];
+
+	conn = proc_param->conn;
+	copy_broadcast_reception_stop_param(&mod_src_param, &proc_param->broadcast_reception_stop);
+
+	active_proc->proc_initiated_cnt++;
+
+	err = bt_bap_broadcast_assistant_mod_src(conn, &mod_src_param);
+	if (err != 0) {
+		LOG_DBG("Failed to stop broadcast reception for conn %p: %d", (void *)conn, err);
+
+		return -ENOEXEC;
+	}
+
+	return 0;
 }
+
+#endif /* CONFIG_BT_BAP_BROADCAST_ASSISTANT */
 
 static void cap_commander_proc_complete(void)
 {
@@ -461,6 +728,11 @@ static void cap_commander_proc_complete(void)
 	case BT_CAP_COMMON_PROC_TYPE_BROADCAST_RECEPTION_START:
 		if (cap_cb->broadcast_reception_start != NULL) {
 			cap_cb->broadcast_reception_start(failed_conn, err);
+		}
+		break;
+	case BT_CAP_COMMON_PROC_TYPE_BROADCAST_RECEPTION_STOP:
+		if (cap_cb->broadcast_reception_stop != NULL) {
+			cap_cb->broadcast_reception_stop(failed_conn, err);
 		}
 		break;
 #endif /* CONFIG_BT_BAP_BROADCAST_ASSISTANT */

--- a/subsys/bluetooth/audio/cap_common.c
+++ b/subsys/bluetooth/audio/cap_common.c
@@ -153,6 +153,7 @@ static bool active_proc_is_commander(void)
 	case BT_CAP_COMMON_PROC_TYPE_MICROPHONE_GAIN_CHANGE:
 	case BT_CAP_COMMON_PROC_TYPE_MICROPHONE_MUTE_CHANGE:
 	case BT_CAP_COMMON_PROC_TYPE_BROADCAST_RECEPTION_START:
+	case BT_CAP_COMMON_PROC_TYPE_BROADCAST_RECEPTION_STOP:
 		return true;
 	default:
 		return false;
@@ -180,7 +181,7 @@ bool bt_cap_common_conn_in_active_proc(const struct bt_conn *conn)
 				return true;
 			}
 		}
-#endif /* CONFIG_BT_CAP_INITIATOR_UNICAST */
+#endif /* CONFIG_BT_CAP_COMMANDER */
 	}
 
 	return false;

--- a/subsys/bluetooth/audio/cap_internal.h
+++ b/subsys/bluetooth/audio/cap_internal.h
@@ -46,6 +46,7 @@ enum bt_cap_common_proc_type {
 	BT_CAP_COMMON_PROC_TYPE_UPDATE,
 	BT_CAP_COMMON_PROC_TYPE_STOP,
 	BT_CAP_COMMON_PROC_TYPE_BROADCAST_RECEPTION_START,
+	BT_CAP_COMMON_PROC_TYPE_BROADCAST_RECEPTION_STOP,
 	BT_CAP_COMMON_PROC_TYPE_VOLUME_CHANGE,
 	BT_CAP_COMMON_PROC_TYPE_VOLUME_OFFSET_CHANGE,
 	BT_CAP_COMMON_PROC_TYPE_VOLUME_MUTE_CHANGE,
@@ -92,6 +93,12 @@ struct cap_broadcast_reception_start {
 	uint8_t num_subgroups;
 	struct bt_bap_bass_subgroup subgroups[CONFIG_BT_BAP_BASS_MAX_SUBGROUPS];
 };
+
+struct cap_broadcast_reception_stop {
+	uint8_t src_id;
+	uint8_t num_subgroups;
+	struct bt_bap_bass_subgroup subgroups[CONFIG_BT_BAP_BASS_MAX_SUBGROUPS];
+};
 #endif /* CONFIG_BT_BAP_BROADCAST_ASSISTANT */
 
 struct bt_cap_commander_proc_param {
@@ -113,6 +120,7 @@ struct bt_cap_commander_proc_param {
 #endif /* CONFIG_BT_VCP_VOL_CTLR_VOCS */
 #if defined(CONFIG_BT_BAP_BROADCAST_ASSISTANT)
 		struct cap_broadcast_reception_start broadcast_reception_start;
+		struct cap_broadcast_reception_stop broadcast_reception_stop;
 #endif /* CONFIG_BT_BAP_BROADCAST_ASSISTANT */
 #if defined(CONFIG_BT_MICP_MIC_CTLR)
 		struct {

--- a/tests/bluetooth/audio/cap_commander/include/cap_commander.h
+++ b/tests/bluetooth/audio/cap_commander/include/cap_commander.h
@@ -24,5 +24,6 @@ DECLARE_FAKE_VOID_FUNC(mock_cap_commander_volume_offset_changed_cb, struct bt_co
 DECLARE_FAKE_VOID_FUNC(mock_cap_commander_microphone_mute_changed_cb, struct bt_conn *, int);
 DECLARE_FAKE_VOID_FUNC(mock_cap_commander_microphone_gain_changed_cb, struct bt_conn *, int);
 DECLARE_FAKE_VOID_FUNC(mock_cap_commander_broadcast_reception_start_cb, struct bt_conn *, int);
+DECLARE_FAKE_VOID_FUNC(mock_cap_commander_broadcast_reception_stop_cb, struct bt_conn *, int);
 
 #endif /* MOCKS_CAP_COMMANDER_H_ */

--- a/tests/bluetooth/audio/cap_commander/src/test_broadcast_reception.c
+++ b/tests/bluetooth/audio/cap_commander/src/test_broadcast_reception.c
@@ -1,4 +1,4 @@
-/* test_broadcast_reception.c - unit test for broadcast reception */
+/* test_broadcast_reception.c - unit test for broadcast reception start and stop */
 
 /*
  * Copyright (c) 2024 Nordic Semiconductor ASA
@@ -157,6 +157,36 @@ static void test_stop_param_init(void *f)
 	}
 }
 
+static void
+test_broadcast_reception_start(struct bt_cap_commander_broadcast_reception_start_param *start_param)
+{
+	int err;
+
+	err = bt_cap_commander_broadcast_reception_start(start_param);
+	zassert_equal(0, err, "Unexpected return value %d", err);
+
+	zexpect_call_count("bt_cap_commander_cb.broadcast_reception_start", 1,
+			   mock_cap_commander_broadcast_reception_start_cb_fake.call_count);
+	zassert_equal_ptr(NULL,
+			  mock_cap_commander_broadcast_reception_start_cb_fake.arg0_history[0]);
+	zassert_equal(0, mock_cap_commander_broadcast_reception_start_cb_fake.arg1_history[0]);
+}
+
+static void
+test_broadcast_reception_stop(struct bt_cap_commander_broadcast_reception_stop_param *stop_param)
+{
+	int err;
+
+	err = bt_cap_commander_broadcast_reception_stop(stop_param);
+	zassert_equal(0, err, "Unexpected return value %d", err);
+
+	zexpect_call_count("bt_cap_commander_cb.broadcast_reception_stop", 1,
+			   mock_cap_commander_broadcast_reception_stop_cb_fake.call_count);
+	zassert_equal_ptr(NULL,
+			  mock_cap_commander_broadcast_reception_stop_cb_fake.arg0_history[0]);
+	zassert_equal(0, mock_cap_commander_broadcast_reception_stop_cb_fake.arg1_history[0]);
+}
+
 ZTEST_SUITE(cap_commander_test_broadcast_reception, NULL,
 	    cap_commander_test_broadcast_reception_setup,
 	    cap_commander_test_broadcast_reception_before,
@@ -170,11 +200,7 @@ ZTEST_F(cap_commander_test_broadcast_reception, test_commander_reception_start)
 	err = bt_cap_commander_register_cb(&mock_cap_commander_cb);
 	zassert_equal(0, err, "Unexpected return value %d", err);
 
-	err = bt_cap_commander_broadcast_reception_start(&fixture->start_param);
-	zassert_equal(0, err, "Unexpected return value %d", err);
-
-	zexpect_call_count("bt_cap_commander_cb.broadcast_reception_start", 1,
-			   mock_cap_commander_broadcast_reception_start_cb_fake.call_count);
+	test_broadcast_reception_start(&fixture->start_param);
 }
 
 ZTEST_F(cap_commander_test_broadcast_reception, test_commander_reception_start_one_subgroup)
@@ -189,11 +215,7 @@ ZTEST_F(cap_commander_test_broadcast_reception, test_commander_reception_start_o
 		fixture->start_param.param[i].num_subgroups = 1;
 	}
 
-	err = bt_cap_commander_broadcast_reception_start(&fixture->start_param);
-	zassert_equal(0, err, "Unexpected return value %d", err);
-
-	zexpect_call_count("bt_cap_commander_cb.broadcast_reception_start", 1,
-			   mock_cap_commander_broadcast_reception_start_cb_fake.call_count);
+	test_broadcast_reception_start(&fixture->start_param);
 }
 
 ZTEST_F(cap_commander_test_broadcast_reception, test_commander_reception_start_double)
@@ -203,9 +225,12 @@ ZTEST_F(cap_commander_test_broadcast_reception, test_commander_reception_start_d
 	err = bt_cap_commander_register_cb(&mock_cap_commander_cb);
 	zassert_equal(0, err, "Unexpected return value %d", err);
 
-	err = bt_cap_commander_broadcast_reception_start(&fixture->start_param);
-	zassert_equal(0, err, "Unexpected return value %d", err);
+	test_broadcast_reception_start(&fixture->start_param);
 
+	/*
+	 * We can not use test_broadcast_reception_start because of the check on how often the
+	 * callback function is called
+	 */
 	err = bt_cap_commander_broadcast_reception_start(&fixture->start_param);
 	zassert_equal(0, err, "Unexpected return value %d", err);
 
@@ -419,27 +444,13 @@ ZTEST_F(cap_commander_test_broadcast_reception, test_commander_reception_stop_de
 	err = bt_cap_commander_register_cb(&mock_cap_commander_cb);
 	zassert_equal(0, err, "Unexpected return value %d", err);
 
-	err = bt_cap_commander_broadcast_reception_start(&fixture->start_param);
-	zassert_equal(0, err, "Unexpected return value %d", err);
-
-	zexpect_call_count("bt_cap_commander_cb.broadcast_reception_start", 1,
-			   mock_cap_commander_broadcast_reception_start_cb_fake.call_count);
-	zassert_equal_ptr(NULL,
-			  mock_cap_commander_broadcast_reception_start_cb_fake.arg0_history[0]);
-	zassert_equal(0, mock_cap_commander_broadcast_reception_start_cb_fake.arg1_history[0]);
+	test_broadcast_reception_start(&fixture->start_param);
 
 	for (size_t i = 0U; i < CONFIG_BT_MAX_CONN; i++) {
 		fixture->stop_param.param[i].src_id = src_id[i];
 	}
 
-	err = bt_cap_commander_broadcast_reception_stop(&fixture->stop_param);
-	zassert_equal(0, err, "Unexpected return value %d", err);
-
-	zexpect_call_count("bt_cap_commander_cb.broadcast_reception_stop", 1,
-			   mock_cap_commander_broadcast_reception_stop_cb_fake.call_count);
-	zassert_equal_ptr(NULL,
-			  mock_cap_commander_broadcast_reception_stop_cb_fake.arg0_history[0]);
-	zassert_equal(0, mock_cap_commander_broadcast_reception_stop_cb_fake.arg1_history[0]);
+	test_broadcast_reception_stop(&fixture->stop_param);
 }
 
 ZTEST_F(cap_commander_test_broadcast_reception, test_commander_reception_stop_one_subgroup)
@@ -449,14 +460,7 @@ ZTEST_F(cap_commander_test_broadcast_reception, test_commander_reception_stop_on
 	err = bt_cap_commander_register_cb(&mock_cap_commander_cb);
 	zassert_equal(0, err, "Unexpected return value %d", err);
 
-	err = bt_cap_commander_broadcast_reception_start(&fixture->start_param);
-	zassert_equal(0, err, "Unexpected return value %d", err);
-
-	zexpect_call_count("bt_cap_commander_cb.broadcast_reception_start", 1,
-			   mock_cap_commander_broadcast_reception_start_cb_fake.call_count);
-	zassert_equal_ptr(NULL,
-			  mock_cap_commander_broadcast_reception_start_cb_fake.arg0_history[0]);
-	zassert_equal(0, mock_cap_commander_broadcast_reception_start_cb_fake.arg1_history[0]);
+	test_broadcast_reception_start(&fixture->start_param);
 
 	/* We test with one subgroup, instead of CONFIG_BT_BAP_BASS_MAX_SUBGROUPS subgroups */
 	for (size_t i = 0U; i < CONFIG_BT_MAX_CONN; i++) {
@@ -464,14 +468,7 @@ ZTEST_F(cap_commander_test_broadcast_reception, test_commander_reception_stop_on
 		fixture->stop_param.param[i].src_id = src_id[i];
 	}
 
-	err = bt_cap_commander_broadcast_reception_stop(&fixture->stop_param);
-	zassert_equal(0, err, "Unexpected return value %d", err);
-
-	zexpect_call_count("bt_cap_commander_cb.broadcast_reception_stop", 1,
-			   mock_cap_commander_broadcast_reception_stop_cb_fake.call_count);
-	zassert_equal_ptr(NULL,
-			  mock_cap_commander_broadcast_reception_stop_cb_fake.arg0_history[0]);
-	zassert_equal(0, mock_cap_commander_broadcast_reception_stop_cb_fake.arg1_history[0]);
+	test_broadcast_reception_stop(&fixture->stop_param);
 }
 
 ZTEST_F(cap_commander_test_broadcast_reception, test_commander_reception_stop_double)
@@ -481,14 +478,7 @@ ZTEST_F(cap_commander_test_broadcast_reception, test_commander_reception_stop_do
 	err = bt_cap_commander_register_cb(&mock_cap_commander_cb);
 	zassert_equal(0, err, "Unexpected return value %d", err);
 
-	err = bt_cap_commander_broadcast_reception_start(&fixture->start_param);
-	zassert_equal(0, err, "Unexpected return value %d", err);
-
-	zexpect_call_count("bt_cap_commander_cb.broadcast_reception_start", 1,
-			   mock_cap_commander_broadcast_reception_start_cb_fake.call_count);
-	zassert_equal_ptr(NULL,
-			  mock_cap_commander_broadcast_reception_start_cb_fake.arg0_history[0]);
-	zassert_equal(0, mock_cap_commander_broadcast_reception_start_cb_fake.arg1_history[0]);
+	test_broadcast_reception_start(&fixture->start_param);
 
 	for (size_t i = 0U; i < CONFIG_BT_MAX_CONN; i++) {
 		printk("Source ID %d: %d %d\n", i, fixture->stop_param.param[i].src_id, src_id[i]);
@@ -496,18 +486,14 @@ ZTEST_F(cap_commander_test_broadcast_reception, test_commander_reception_stop_do
 		fixture->stop_param.param[i].src_id = src_id[i];
 	}
 
-	err = bt_cap_commander_broadcast_reception_stop(&fixture->stop_param);
-	zassert_equal(0, err, "Unexpected return value %d", err);
+	test_broadcast_reception_stop(&fixture->stop_param);
 
-	err = bt_cap_commander_broadcast_reception_stop(&fixture->stop_param);
-	zassert_equal(0, err, "Unexpected return value %d", err);
-
-	zexpect_call_count("bt_cap_commander_cb.broadcast_reception_stop", 1,
-			   mock_cap_commander_broadcast_reception_stop_cb_fake.call_count);
+	test_broadcast_reception_stop(&fixture->stop_param);
 
 	/*
 	 * Since the 2nd reception_stop procedure never completed initiating a new CAP procedure
 	 * should result in an error -EBUSY
+	 * we try with broadcast_reception_start, but could use any CAP procedure for this test
 	 */
 	err = bt_cap_commander_broadcast_reception_start(&fixture->start_param);
 	zassert_equal(-EBUSY, err, "Unexpected return value %d", err);

--- a/tests/bluetooth/audio/cap_commander/uut/bap_broadcast_assistant.c
+++ b/tests/bluetooth/audio/cap_commander/uut/bap_broadcast_assistant.c
@@ -28,3 +28,40 @@ int bt_bap_broadcast_assistant_add_src(struct bt_conn *conn,
 
 	return 0;
 }
+
+int bt_bap_broadcast_assistant_mod_src(struct bt_conn *conn,
+				       const struct bt_bap_broadcast_assistant_mod_src_param *param)
+{
+	struct bt_bap_scan_delegator_recv_state state;
+
+	zassert_not_null(conn, "conn is NULL");
+	zassert_not_null(param, "param is NULL");
+
+	state.pa_sync_state = param->pa_sync ? BT_BAP_PA_STATE_SYNCED : BT_BAP_PA_STATE_NOT_SYNCED;
+	state.src_id = param->src_id;
+	state.num_subgroups = param->num_subgroups;
+	for (size_t i = 0; i < param->num_subgroups; i++) {
+		state.subgroups[i].bis_sync = param->subgroups[i].bis_sync;
+	}
+
+	if (broadcast_assistant_cbs->mod_src != NULL) {
+		broadcast_assistant_cbs->mod_src(conn, 0);
+	}
+	if (broadcast_assistant_cbs->recv_state != NULL) {
+		broadcast_assistant_cbs->recv_state(conn, 0, &state);
+	}
+
+	return 0;
+}
+
+int bt_bap_broadcast_assistant_rem_src(struct bt_conn *conn, uint8_t src_id)
+{
+	zassert_not_null(conn, "conn is NULL");
+	zassert_not_equal(src_id, 0, "src_id is 0");
+
+	if (broadcast_assistant_cbs->rem_src != NULL) {
+		broadcast_assistant_cbs->rem_src(conn, 0);
+	}
+
+	return 0;
+}

--- a/tests/bluetooth/audio/cap_commander/uut/bap_broadcast_assistant.c
+++ b/tests/bluetooth/audio/cap_commander/uut/bap_broadcast_assistant.c
@@ -6,11 +6,66 @@
 
 #include "zephyr/bluetooth/audio/bap.h"
 
-static struct bt_bap_broadcast_assistant_cb *broadcast_assistant_cbs;
+static sys_slist_t broadcast_assistant_cbs = SYS_SLIST_STATIC_INIT(&broadcast_assistant_cbs);
+
+struct bap_broadcast_assistant_recv_state_info {
+	uint8_t src_id;
+	/** Cached PAST available */
+	bool past_avail;
+	uint8_t adv_sid;
+	uint32_t broadcast_id;
+	bt_addr_le_t addr;
+};
+
+struct bap_broadcast_assistant_instance {
+	struct bt_conn *conn;
+	struct bap_broadcast_assistant_recv_state_info
+		recv_states[CONFIG_BT_BAP_BROADCAST_ASSISTANT_RECV_STATE_COUNT];
+	bool inst_active;
+};
+
+static struct bap_broadcast_assistant_instance broadcast_assistants[CONFIG_BT_MAX_CONN];
+static uint8_t max_src_id = 0;
+
+static struct bap_broadcast_assistant_instance *inst_by_conn(struct bt_conn *conn)
+{
+	struct bap_broadcast_assistant_instance *inst;
+
+	zassert_not_null(conn, "conn is NULL");
+
+	inst = &broadcast_assistants[bt_conn_index(conn)];
+
+	return inst;
+}
 
 int bt_bap_broadcast_assistant_register_cb(struct bt_bap_broadcast_assistant_cb *cb)
 {
-	broadcast_assistant_cbs = cb;
+	struct bt_bap_broadcast_assistant_cb *tmp;
+
+	if (cb == NULL) {
+		return -EINVAL;
+	}
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&broadcast_assistant_cbs, tmp, _node) {
+		if (tmp == cb) {
+			return -EALREADY;
+		}
+	}
+
+	sys_slist_append(&broadcast_assistant_cbs, &cb->_node);
+
+	return 0;
+}
+
+int bt_bap_broadcast_assistant_unregister_cb(struct bt_bap_broadcast_assistant_cb *cb)
+{
+	if (cb == NULL) {
+		return -EINVAL;
+	}
+
+	if (!sys_slist_find_and_remove(&broadcast_assistant_cbs, &cb->_node)) {
+		return -EALREADY;
+	}
 
 	return 0;
 }
@@ -18,12 +73,39 @@ int bt_bap_broadcast_assistant_register_cb(struct bt_bap_broadcast_assistant_cb 
 int bt_bap_broadcast_assistant_add_src(struct bt_conn *conn,
 				       const struct bt_bap_broadcast_assistant_add_src_param *param)
 {
+	struct bap_broadcast_assistant_instance *inst;
+	struct bt_bap_scan_delegator_recv_state state;
+	struct bt_bap_broadcast_assistant_cb *listener, *next;
+
 	/* Note that proper parameter checking is done in the caller */
 	zassert_not_null(conn, "conn is NULL");
 	zassert_not_null(param, "param is NULL");
 
-	if (broadcast_assistant_cbs->add_src != NULL) {
-		broadcast_assistant_cbs->add_src(conn, 0);
+	inst = inst_by_conn(conn);
+	zassert_not_null(inst, "inst is NULL");
+
+	max_src_id++;
+	inst->recv_states[0].src_id = max_src_id;
+	inst->recv_states[0].past_avail = false;
+	inst->recv_states[0].adv_sid = param->adv_sid;
+	inst->recv_states[0].broadcast_id = param->broadcast_id;
+	inst->inst_active = true;
+	state.pa_sync_state = param->pa_sync;
+	state.src_id = max_src_id;
+	state.num_subgroups = param->num_subgroups;
+	for (size_t i = 0; i < param->num_subgroups; i++) {
+		state.subgroups[i].bis_sync = param->subgroups[i].bis_sync;
+	}
+
+	bt_addr_le_copy(&inst->recv_states[0].addr, &param->addr);
+
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&broadcast_assistant_cbs, listener, next, _node) {
+		if (listener->add_src != NULL) {
+			listener->add_src(conn, 0);
+		}
+		if (listener->recv_state != NULL) {
+			listener->recv_state(conn, 0, &state);
+		}
 	}
 
 	return 0;
@@ -32,35 +114,52 @@ int bt_bap_broadcast_assistant_add_src(struct bt_conn *conn,
 int bt_bap_broadcast_assistant_mod_src(struct bt_conn *conn,
 				       const struct bt_bap_broadcast_assistant_mod_src_param *param)
 {
+	struct bap_broadcast_assistant_instance *inst;
 	struct bt_bap_scan_delegator_recv_state state;
+	struct bt_bap_broadcast_assistant_cb *listener, *next;
 
 	zassert_not_null(conn, "conn is NULL");
 	zassert_not_null(param, "param is NULL");
 
-	state.pa_sync_state = param->pa_sync ? BT_BAP_PA_STATE_SYNCED : BT_BAP_PA_STATE_NOT_SYNCED;
-	state.src_id = param->src_id;
-	state.num_subgroups = param->num_subgroups;
-	for (size_t i = 0; i < param->num_subgroups; i++) {
-		state.subgroups[i].bis_sync = param->subgroups[i].bis_sync;
-	}
+	inst = inst_by_conn(conn);
+	zassert_not_null(inst, "inst is NULL");
 
-	if (broadcast_assistant_cbs->mod_src != NULL) {
-		broadcast_assistant_cbs->mod_src(conn, 0);
+	if (inst->inst_active) {
+		state.pa_sync_state =
+			param->pa_sync ? BT_BAP_PA_STATE_SYNCED : BT_BAP_PA_STATE_NOT_SYNCED;
+		state.src_id = param->src_id;
+		state.num_subgroups = param->num_subgroups;
+		for (size_t i = 0; i < param->num_subgroups; i++) {
+			state.subgroups[i].bis_sync = param->subgroups[i].bis_sync;
+		}
+		SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&broadcast_assistant_cbs, listener, next, _node) {
+			if (listener->mod_src != NULL) {
+				listener->mod_src(conn, 0);
+			}
+			if (listener->recv_state != NULL) {
+				listener->recv_state(conn, 0, &state);
+			}
+		}
 	}
-	if (broadcast_assistant_cbs->recv_state != NULL) {
-		broadcast_assistant_cbs->recv_state(conn, 0, &state);
-	}
-
 	return 0;
 }
 
 int bt_bap_broadcast_assistant_rem_src(struct bt_conn *conn, uint8_t src_id)
 {
-	zassert_not_null(conn, "conn is NULL");
-	zassert_not_equal(src_id, 0, "src_id is 0");
+	struct bap_broadcast_assistant_instance *inst;
+	struct bt_bap_broadcast_assistant_cb *listener, *next;
 
-	if (broadcast_assistant_cbs->rem_src != NULL) {
-		broadcast_assistant_cbs->rem_src(conn, 0);
+	zassert_not_null(conn, "conn is NULL");
+
+	inst = inst_by_conn(conn);
+	zassert_true(inst->inst_active, "Instant is not active");
+	zassert_equal(src_id, inst->recv_states[0].src_id, "Invalid src_id");
+
+	inst->inst_active = false;
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&broadcast_assistant_cbs, listener, next, _node) {
+		if (listener->rem_src != NULL) {
+			listener->rem_src(conn, 0);
+		}
 	}
 
 	return 0;

--- a/tests/bluetooth/audio/cap_commander/uut/cap_commander.c
+++ b/tests/bluetooth/audio/cap_commander/uut/cap_commander.c
@@ -16,7 +16,8 @@
 	FAKE(mock_cap_commander_volume_offset_changed_cb)                                          \
 	FAKE(mock_cap_commander_microphone_mute_changed_cb)                                        \
 	FAKE(mock_cap_commander_microphone_gain_changed_cb)                                        \
-	FAKE(mock_cap_commander_broadcast_reception_start_cb)
+	FAKE(mock_cap_commander_broadcast_reception_start_cb)                                      \
+	FAKE(mock_cap_commander_broadcast_reception_stop_cb)
 
 DEFINE_FAKE_VOID_FUNC(mock_cap_commander_discovery_complete_cb, struct bt_conn *, int,
 		      const struct bt_csip_set_coordinator_set_member *,
@@ -28,6 +29,7 @@ DEFINE_FAKE_VOID_FUNC(mock_cap_commander_volume_offset_changed_cb, struct bt_con
 DEFINE_FAKE_VOID_FUNC(mock_cap_commander_microphone_mute_changed_cb, struct bt_conn *, int);
 DEFINE_FAKE_VOID_FUNC(mock_cap_commander_microphone_gain_changed_cb, struct bt_conn *, int);
 DEFINE_FAKE_VOID_FUNC(mock_cap_commander_broadcast_reception_start_cb, struct bt_conn *, int);
+DEFINE_FAKE_VOID_FUNC(mock_cap_commander_broadcast_reception_stop_cb, struct bt_conn *, int);
 
 const struct bt_cap_commander_cb mock_cap_commander_cb = {
 	.discovery_complete = mock_cap_commander_discovery_complete_cb,
@@ -46,6 +48,7 @@ const struct bt_cap_commander_cb mock_cap_commander_cb = {
 #endif /* CONFIG_BT_MICP_MIC_CTLR */
 #if defined(CONFIG_BT_BAP_BROADCAST_ASSISTANT)
 	.broadcast_reception_start = mock_cap_commander_broadcast_reception_start_cb,
+	.broadcast_reception_stop = mock_cap_commander_broadcast_reception_stop_cb,
 #endif /* CONFIG_BT_BAP_BROADCAST_ASSISTANT */
 };
 

--- a/tests/bsim/bluetooth/audio/src/cap_commander_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_commander_test.c
@@ -1000,7 +1000,7 @@ static void test_broadcast_reception_stop(size_t acceptor_count)
 
 	/* reception stop is not implemented yet, for now the following command will fail*/
 	reception_stop_param.type = BT_CAP_SET_TYPE_AD_HOC;
-	reception_stop_param.members = NULL;
+	reception_stop_param.param = NULL;
 	reception_stop_param.count = 0U;
 	err = bt_cap_commander_broadcast_reception_stop(&reception_stop_param);
 	if (err != 0) {


### PR DESCRIPTION
   test: Bluetooth: refactor CAP commander test
    
    Refactor the tests for CAP commander procedures
    broadcast reception start and stop
    
    This ensures that proper parameter checking is done in all tests
    
    Signed-off-by: Andries Kruithof <andries.kruithof@nordicsemi.no>
