### PR TITLE
west.yml: Update hal_stm32 with a fix on the stm32h7 drivers

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -233,7 +233,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 1e6116bd2a36db976d955ee772d21f329e529873
+      revision: c4099c229323f305eef75ff6ba93ee9b89827581
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
stm32h7xx_hal driver partial update to v1.11.3

Fixes [76834](https://github.com/zephyrproject-rtos/zephyr/issues/76834)