### PR TITLE
soc: npcx: scfg: select host interface type in global

### DIFF
--- a/drivers/espi/espi_npcx.c
+++ b/drivers/espi/espi_npcx.c
@@ -1329,11 +1329,6 @@ static int espi_npcx_init(const struct device *dev)
 	const struct device *const clk_dev = DEVICE_DT_GET(NPCX_CLK_CTRL_NODE);
 	int i, ret;
 
-	/* If booter doesn't set the host interface type */
-	if (!NPCX_BOOTER_IS_HIF_TYPE_SET()) {
-		npcx_host_interface_sel(NPCX_HIF_TYPE_ESPI_SHI);
-	}
-
 	if (!device_is_ready(clk_dev)) {
 		LOG_ERR("clock control device not ready");
 		return -ENODEV;

--- a/soc/nuvoton/npcx/common/scfg.c
+++ b/soc/nuvoton/npcx/common/scfg.c
@@ -145,6 +145,11 @@ void npcx_dbg_freeze_enable(bool enable)
 /* Pin-control driver registration */
 static int npcx_scfg_init(void)
 {
+	/* If booter doesn't set the host interface type */
+	if (!NPCX_BOOTER_IS_HIF_TYPE_SET()) {
+		npcx_host_interface_sel(NPCX_HIF_TYPE_ESPI_SHI);
+	}
+
 	/* Change all pads whose default functionality isn't IO to GPIO */
 	for (int i = 0; i < ARRAY_SIZE(def_alts); i++) {
 		npcx_pinctrl_alt_sel(&def_alts[i], 0);

--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_shi_npcx.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_shi_npcx.c
@@ -875,11 +875,6 @@ static int shi_npcx_init_registers(const struct device *dev)
 		return ret;
 	}
 
-	/* If booter doesn't set the host interface type */
-	if (!NPCX_BOOTER_IS_HIF_TYPE_SET()) {
-		npcx_host_interface_sel(NPCX_HIF_TYPE_ESPI_SHI);
-	}
-
 	/*
 	 * SHICFG1 (SHI Configuration 1) setting
 	 * [7] - IWRAP	= 1: Wrap input buffer to the first address


### PR DESCRIPTION
The Host Interface Type in the DEVCNT register sets the HIF type (either eSPI or LPC).
Currently, it is configured in the host-interface-related drivers like eSPI or SHI. 
However, some I/O pads sourced from VHIF in the other modules such as GPIO and I3C also rely on this field.
It might be problematic when using those I/Os without enabling eSPI or SHI drivers. 
This commit moves the setting from the specific drivers to the global system initialization function scfg_init().