### PR TITLE
MAINTAINERS: Update release notes owners for 4.0

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -995,8 +995,8 @@ Documentation Infrastructure:
 Release Notes:
   status: maintained
   maintainers:
-    - nashif
-    - aescolar
+    - dkalowsk
+    - mmahadevan108
   collaborators:
     - kartben
   files:


### PR DESCRIPTION
As mentioned in the TSC Meeting of 7 August 2024
* Mahesh Mahadevan (mmahadevan108)
* Dan Kalowsky (dkalowsk) 

will be the release managers for 4.0.

Let's update the MAINTAINERS files accordingly.