### PR TITLE
ci: twister: disable testing on 3.12 until issue is resolved

### DIFF
--- a/.github/workflows/twister_tests.yml
+++ b/.github/workflows/twister_tests.yml
@@ -32,7 +32,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        # python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11']
         os: [ubuntu-22.04]
     steps:
     - name: checkout


### PR DESCRIPTION
when running tests on python 3.12, we have some unreproducible fails
that currently block every PR concerning twister. The issues seem to be
CI centric and can't be reproduced locally with python 3.12.

Disabling for now while we look for the real issue in the environment.

See #76877

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
