### PR TITLE
twister: Fix failing tests on CI with Python 3.12

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -5,17 +5,19 @@
 # Copyright 2022 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-import os
-import pkg_resources
-import sys
-from pathlib import Path
+import argparse
 import json
 import logging
-import subprocess
-import shutil
+import os
 import re
-import argparse
+import shutil
+import subprocess
+import sys
 from datetime import datetime, timezone
+from importlib import metadata
+from pathlib import Path
+from typing import Generator
+
 from twisterlib.coverage import supported_coverage_formats
 
 logger = logging.getLogger('twister')
@@ -40,12 +42,21 @@ import zephyr_module
 # Note "normalization" is different from canonicalization, see os.path.
 canonical_zephyr_base = os.path.realpath(ZEPHYR_BASE)
 
-installed_packages = [pkg.project_name for pkg in pkg_resources.working_set]  # pylint: disable=not-an-iterable
+
+def _get_installed_packages() -> Generator[str, None, None]:
+    """Return list of installed python packages."""
+    for dist in metadata.distributions():
+        yield dist.metadata['Name']
+
+
+installed_packages: list[str] = list(_get_installed_packages())
 PYTEST_PLUGIN_INSTALLED = 'pytest-twister-harness' in installed_packages
+
 
 def norm_path(astring):
     newstring = os.path.normpath(astring).replace(os.sep, '/')
     return newstring
+
 
 def add_parse_arguments(parser = None):
     if parser is None:

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -668,6 +668,7 @@ class Gtest(Harness):
 
 
 class Test(Harness):
+    __test__ = False  # for pytest to skip this class when collects tests
     RUN_PASSED = "PROJECT EXECUTION SUCCESSFUL"
     RUN_FAILED = "PROJECT EXECUTION FAILED"
     test_suite_start_pattern = r"Running TESTSUITE (?P<suite_name>.*)"

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -77,7 +77,9 @@ class TestLevel:
     levels = []
     scenarios = []
 
+
 class TestPlan:
+    __test__ = False  # for pytest to skip this class when collects tests
     config_re = re.compile('(CONFIG_[A-Za-z0-9_]+)[=]\"?([^\"]*)\"?$')
     dt_re = re.compile('([A-Za-z0-9_]+)[=]\"?([^\"]*)\"?$')
 


### PR DESCRIPTION
This change is removing some deprecation warnings
which for some reason causing failing tests with
Python 3.12 on CI #76877.

Also, it fixes warnings from pytest like:
PytestCollectionWarning: cannot collect test class 'TestPlan' because it has a __init__ constructor
(from: scripts/tests/twister/test_testplan.py)

Fixes: #76877