### PR TITLE
drivers: counter: stm32 counter timer exclude stm32 devices without APB2

### DIFF
--- a/drivers/counter/counter_ll_stm32_timer.c
+++ b/drivers/counter/counter_ll_stm32_timer.c
@@ -395,18 +395,18 @@ static int counter_stm32_get_tim_clk(const struct stm32_pclken *pclken, uint32_t
 		apb_psc = (uint32_t)(READ_BIT(RCC->APB1DIVR, RCC_APB1DIVR_APB1DIV));
 #else
 		apb_psc = STM32_APB1_PRESCALER;
-#endif
+#endif /* CONFIG_SOC_SERIES_STM32MP1X */
 	}
-#if !defined(CONFIG_SOC_SERIES_STM32F0X) && !defined(CONFIG_SOC_SERIES_STM32G0X)
+#if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32f0_rcc)
 	else {
 #if defined(CONFIG_SOC_SERIES_STM32MP1X)
 		apb_psc = (uint32_t)(READ_BIT(RCC->APB2DIVR, RCC_APB2DIVR_APB2DIV));
 #else
 		apb_psc = STM32_APB2_PRESCALER;
-#endif
+#endif /* CONFIG_SOC_SERIES_STM32MP1X */
 	}
-#endif
-#endif
+#endif /* ! st_stm32f0_rcc */
+#endif /* CONFIG_SOC_SERIES_STM32H7X */
 
 #if defined(RCC_DCKCFGR_TIMPRE) || defined(RCC_DCKCFGR1_TIMPRE) || \
 	defined(RCC_CFGR_TIMPRE)


### PR DESCRIPTION
The STM32 devices like stm32F0/G0/C0 which have a f0-rcc compatible does not have APB2 prescaler : do not try to set it.

Avoid building error of  tests/drivers/counter/counter_basic_api/  on nucleo_c031c6
```
counter_stm32_get_tim_clk':
./build/zephyr/include/generated/zephyr/devicetree_generated.h:888:36: error: 'DT_N_S_soc_S_rcc_40021000_P_apb2_prescaler' undeclared (first use in this function); did you mean 'DT_N_S_soc_S_rcc_40021000_P_apb1_prescaler'?
  888 | #define DT_N_NODELABEL_rcc         DT_N_S_soc_S_rcc_40021000
...
```

