### PR TITLE
logging: When strings are stripped keep source name pointers

### DIFF
--- a/include/zephyr/logging/log.h
+++ b/include/zephyr/logging/log.h
@@ -328,8 +328,7 @@ void z_log_vprintk(const char *fmt, va_list ap);
 		log_source_const_data,								\
 		Z_LOG_ITEM_CONST_DATA(_name)) =							\
 	{											\
-		.name = IS_ENABLED(CONFIG_LOG_FMT_SECTION_STRIP) ? NULL :			\
-			COND_CODE_1(CONFIG_LOG_FMT_SECTION,					\
+		.name = COND_CODE_1(CONFIG_LOG_FMT_SECTION,					\
 				(UTIL_CAT(_name, _str)), (STRINGIFY(_name))),			\
 		.level = (_level)								\
 	}

--- a/subsys/logging/log_mgmt.c
+++ b/subsys/logging/log_mgmt.c
@@ -243,6 +243,9 @@ static const char *link_source_name_get(uint8_t domain_id, uint32_t source_id)
 const char *log_source_name_get(uint32_t domain_id, uint32_t source_id)
 {
 	if (z_log_is_local_domain(domain_id)) {
+		if (IS_ENABLED(CONFIG_LOG_FMT_SECTION_STRIP)) {
+			return "unknown";
+		}
 		if (source_id < log_src_cnt_get(domain_id)) {
 			return TYPE_SECTION_START(log_const)[source_id].name;
 		} else {
@@ -362,6 +365,10 @@ void z_log_runtime_filters_init(void)
 
 int log_source_id_get(const char *name)
 {
+	if (IS_ENABLED(CONFIG_LOG_FMT_SECTION_STRIP)) {
+		return -1;
+	}
+
 	for (int i = 0; i < log_src_cnt_get(Z_LOG_LOCAL_DOMAIN_ID); i++) {
 		const char *sname = log_source_name_get(Z_LOG_LOCAL_DOMAIN_ID, i);
 


### PR DESCRIPTION
90ab94f61dd added a change that source name pointers were not stored in the const data structure associated with a logging source. That was done because those string pointers were invalid (on purpose pointing to non-existing memory) and reading those strings could lead to a fault. However, those pointers are used by scripts which are building the dictionary database and after this change script was no longer able to retrieve source names from elf file and database was incomplete.

This patch brings back storing of source name string pointers but in API for reading those source names guards are added to not return invalid addresses.