### PR TITLE
Bluetooth: drivers: userchan: Fix gcc 13 overflow warning

### DIFF
--- a/drivers/bluetooth/hci/userchan.c
+++ b/drivers/bluetooth/hci/userchan.c
@@ -181,7 +181,7 @@ static void rx_thread(void *p1, void *p2, void *p3)
 
 	LOG_DBG("started");
 
-	uint16_t frame_size = 0;
+	ssize_t frame_size = 0;
 
 	while (1) {
 		static uint8_t frame[512];


### PR DESCRIPTION
gcc 13 produces a build warning (see below), as it seems to believe the number of read bytes may overflow the frame_size type.
Let's increase the frame_size bitwidth to avoid this. (Any 32bit type, signed or unsigned, avoids this warning)

The build warning:
```
In file included from /usr/include/features.h:502,
                 from /usr/include/i386-linux-gnu/bits/libc-header-start.h:33,
                 from /usr/include/stdint.h:26,
                 from /usr/lib/gcc/x86_64-linux-gnu/13/include/stdint.h:9,
                 from zephyr/include/zephyr/types.h:11,
                 from zephyr/include/zephyr/kernel_includes.h:21,
                 from zephyr/include/zephyr/kernel.h:17,
                 from zephyr/drivers/bluetooth/hci/userchan.c:9:
In function ‘read’,
    inlined from ‘rx_thread’ at drivers/bluetooth/hci/userchan.c:201:9:
/usr/include/i386-linux-gnu/bits/unistd.h:28:10: warning: ‘__read_alias’ specified size
between 4294902273 and 4294967295 exceeds maximum object size 2147483647
[-Wstringop-overflow=]
   28 |   return __glibc_fortify (read, __nbytes, sizeof (char),
      |          ^~~~~~~~~~~~~~~
drivers/bluetooth/hci/userchan.c: In function ‘rx_thread’:
drivers/bluetooth/hci/userchan.c:187:32: note: destination object allocated here
  187 |                 static uint8_t frame[512];
      |                                ^~~~~
/usr/include/i386-linux-gnu/bits/unistd-decl.h:29:16: note: in a call to function
‘__read_alias’ declared with attribute ‘access (write_only, 2, 3)’
   29 | extern ssize_t __REDIRECT_FORTIFY (__read_alias, (int __fd, void *__buf,
      |                ^~~~~~~~~~~~~~~~~~
```

Fixes #76912