### PR TITLE
net: wifi: replace (1 << xyz) with BIT(xyz)

### DIFF
--- a/subsys/net/l2/wifi/wifi_nm.c
+++ b/subsys/net/l2/wifi/wifi_nm.c
@@ -66,12 +66,12 @@ unsigned char wifi_nm_get_type_iface(struct net_if *iface)
 
 bool wifi_nm_iface_is_sta(struct net_if *iface)
 {
-	return wifi_nm_get_type_iface(iface) & (1 << WIFI_TYPE_STA);
+	return wifi_nm_get_type_iface(iface) & BIT(WIFI_TYPE_STA);
 }
 
 bool wifi_nm_iface_is_sap(struct net_if *iface)
 {
-	return wifi_nm_get_type_iface(iface) & (1 << WIFI_TYPE_SAP);
+	return wifi_nm_get_type_iface(iface) & BIT(WIFI_TYPE_SAP);
 }
 
 int wifi_nm_register_mgd_iface(struct wifi_nm_instance *nm, struct net_if *iface)
@@ -117,7 +117,7 @@ int wifi_nm_register_mgd_type_iface(struct wifi_nm_instance *nm,
 	for (int i = 0; i < CONFIG_WIFI_NM_MAX_MANAGED_INTERFACES; i++) {
 		if (!nm->mgd_ifaces[i].iface) {
 			nm->mgd_ifaces[i].iface = iface;
-			nm->mgd_ifaces[i].type = (1 << type);
+			nm->mgd_ifaces[i].type = BIT(type);
 			k_mutex_unlock(&wifi_nm_lock);
 			return 0;
 		}


### PR DESCRIPTION
Refactor `(1 << xyz)` to use the `BIT(xyz)` macro.
The change aims to enhance code readability.
