### PR TITLE
drivers: ad559x: implement double range option 

### DIFF
--- a/drivers/adc/adc_ad559x.c
+++ b/drivers/adc/adc_ad559x.c
@@ -29,6 +29,7 @@ LOG_MODULE_REGISTER(adc_ad559x, CONFIG_ADC_LOG_LEVEL);
 
 struct adc_ad559x_config {
 	const struct device *mfd_dev;
+	bool double_input_range;
 };
 
 struct adc_ad559x_data {
@@ -240,9 +241,26 @@ static int adc_ad559x_init(const struct device *dev)
 	struct adc_ad559x_data *data = dev->data;
 	k_tid_t tid;
 	int ret;
+	uint16_t reg_val;
 
 	if (!device_is_ready(config->mfd_dev)) {
 		return -ENODEV;
+	}
+
+	ret = mfd_ad559x_read_reg(config->mfd_dev, AD559X_REG_GEN_CTRL, 0, &reg_val);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (config->double_input_range) {
+		reg_val |= AD559X_ADC_RANGE;
+	} else {
+		reg_val &= ~AD559X_ADC_RANGE;
+	}
+
+	ret = mfd_ad559x_write_reg(config->mfd_dev, AD559X_REG_GEN_CTRL, reg_val);
+	if (ret < 0) {
+		return ret;
 	}
 
 	ret = mfd_ad559x_write_reg(config->mfd_dev, AD559X_REG_PD_REF_CTRL, AD559X_EN_REF);
@@ -272,24 +290,31 @@ static int adc_ad559x_init(const struct device *dev)
 	return 0;
 }
 
-static const struct adc_driver_api adc_ad559x_api = {
-	.channel_setup = adc_ad559x_channel_setup,
-	.read = adc_ad559x_read,
 #ifdef CONFIG_ADC_ASYNC
-	.read_async = adc_ad559x_read_async,
+#define ADC_AD559X_ASYNC() .read_async = adc_ad559x_read_async,
+#else
+#define ADC_AD559X_ASYNC()
 #endif
-	.ref_internal = AD559X_ADC_VREF_MV,
-};
+
+#define ADC_AD559X_DRIVER_API(inst)                                                                \
+	static const struct adc_driver_api adc_ad559x_api##inst = {                                \
+		.channel_setup = adc_ad559x_channel_setup,                                         \
+		.read = adc_ad559x_read,                                                           \
+		.ref_internal = AD559X_ADC_VREF_MV * (1 + DT_INST_PROP(inst, double_input_range)), \
+		ADC_AD559X_ASYNC()}
 
 #define ADC_AD559X_DEFINE(inst)                                                                    \
+	ADC_AD559X_DRIVER_API(inst);                                                               \
+                                                                                                   \
 	static const struct adc_ad559x_config adc_ad559x_config##inst = {                          \
 		.mfd_dev = DEVICE_DT_GET(DT_INST_PARENT(inst)),                                    \
+		.double_input_range = DT_INST_PROP(inst, double_input_range),                      \
 	};                                                                                         \
                                                                                                    \
 	static struct adc_ad559x_data adc_ad559x_data##inst;                                       \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(inst, adc_ad559x_init, NULL, &adc_ad559x_data##inst,                 \
 			      &adc_ad559x_config##inst, POST_KERNEL, CONFIG_MFD_INIT_PRIORITY,     \
-			      &adc_ad559x_api);
+			      &adc_ad559x_api##inst);
 
 DT_INST_FOREACH_STATUS_OKAY(ADC_AD559X_DEFINE)

--- a/drivers/dac/dac_ad559x.c
+++ b/drivers/dac/dac_ad559x.c
@@ -21,6 +21,7 @@ LOG_MODULE_REGISTER(dac_ad559x, CONFIG_DAC_LOG_LEVEL);
 
 struct dac_ad559x_config {
 	const struct device *mfd_dev;
+	bool double_output_range;
 };
 
 struct dac_ad559x_data {
@@ -83,9 +84,26 @@ static int dac_ad559x_init(const struct device *dev)
 {
 	const struct dac_ad559x_config *config = dev->config;
 	int ret;
+	uint16_t reg_val;
 
 	if (!device_is_ready(config->mfd_dev)) {
 		return -ENODEV;
+	}
+
+	ret = mfd_ad559x_read_reg(config->mfd_dev, AD559X_REG_GEN_CTRL, 0, &reg_val);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (config->double_output_range) {
+		reg_val |= AD559X_DAC_RANGE;
+	} else {
+		reg_val &= ~AD559X_DAC_RANGE;
+	}
+
+	ret = mfd_ad559x_write_reg(config->mfd_dev, AD559X_REG_GEN_CTRL, reg_val);
+	if (ret < 0) {
+		return ret;
 	}
 
 	ret = mfd_ad559x_write_reg(config->mfd_dev, AD559X_REG_PD_REF_CTRL, AD559X_EN_REF);
@@ -99,6 +117,7 @@ static int dac_ad559x_init(const struct device *dev)
 #define DAC_AD559X_DEFINE(inst)                                                                    \
 	static const struct dac_ad559x_config dac_ad559x_config##inst = {                          \
 		.mfd_dev = DEVICE_DT_GET(DT_INST_PARENT(inst)),                                    \
+		.double_output_range = DT_INST_PROP(inst, double_output_range),                    \
 	};                                                                                         \
                                                                                                    \
 	struct dac_ad559x_data dac_ad559x_data##inst;                                              \

--- a/drivers/mfd/mfd_ad559x_i2c.c
+++ b/drivers/mfd/mfd_ad559x_i2c.c
@@ -12,6 +12,8 @@
 
 #include "mfd_ad559x.h"
 
+#define AD559X_REG_RD_POINTER 0x70
+
 static int mfd_ad559x_i2c_read_raw(const struct device *dev, uint8_t *val, size_t len)
 {
 	const struct mfd_ad559x_config *config = dev->config;
@@ -35,7 +37,9 @@ static int mfd_ad559x_i2c_read_reg(const struct device *dev, uint8_t reg, uint8_
 
 	ARG_UNUSED(reg_data);
 
-	__ASSERT((reg & 0xf0) == 0, "reg bits [7:4] should be 0: 0x%x", reg);
+	if (reg >= AD559X_REG_SEQ_ADC || reg <= AD559X_REG_IO_TS_CONFIG) {
+		reg |= AD559X_REG_RD_POINTER;
+	}
 
 	ret = i2c_write_read_dt(&config->i2c, &reg, sizeof(reg), buf, sizeof(buf));
 	if (ret < 0) {

--- a/dts/bindings/adc/adi,ad559x-adc.yaml
+++ b/dts/bindings/adc/adi,ad559x-adc.yaml
@@ -11,5 +11,12 @@ properties:
   "#io-channel-cells":
     const: 1
 
+  double-input-range:
+    type: boolean
+    description: |
+      Default ADC input range is 0V to Vref.
+      This option increases the range from 0V to 2 x Vref. Note that this
+      requires VDD >= 2 x Vref.
+
 io-channel-cells:
   - input

--- a/dts/bindings/dac/adi,ad559x-dac.yaml
+++ b/dts/bindings/dac/adi,ad559x-dac.yaml
@@ -11,5 +11,12 @@ properties:
   "#io-channel-cells":
     const: 1
 
+  double-output-range:
+    type: boolean
+    description: |
+      Default DAC output range is 0V to Vref.
+      This option increases the range from 0V to 2 x Vref. Note that this
+      requires VDD >= 2 x Vref.
+
 io-channel-cells:
   - output

--- a/include/zephyr/drivers/mfd/ad559x.h
+++ b/include/zephyr/drivers/mfd/ad559x.h
@@ -25,6 +25,7 @@ extern "C" {
 #define AD559X_REG_IO_TS_CONFIG   0x0DU
 
 #define AD559X_DAC_RANGE BIT(4)
+#define AD559X_ADC_RANGE BIT(5)
 #define AD559X_EN_REF    BIT(9)
 
 #define AD559X_PIN_MAX 8U

--- a/include/zephyr/drivers/mfd/ad559x.h
+++ b/include/zephyr/drivers/mfd/ad559x.h
@@ -13,6 +13,7 @@ extern "C" {
 #include <zephyr/device.h>
 
 #define AD559X_REG_SEQ_ADC        0x02U
+#define AD559X_REG_GEN_CTRL       0x03U
 #define AD559X_REG_ADC_CONFIG     0x04U
 #define AD559X_REG_LDAC_EN        0x05U
 #define AD559X_REG_GPIO_PULLDOWN  0x06U
@@ -23,7 +24,8 @@ extern "C" {
 #define AD559X_REG_PD_REF_CTRL    0x0BU
 #define AD559X_REG_IO_TS_CONFIG   0x0DU
 
-#define AD559X_EN_REF BIT(9)
+#define AD559X_DAC_RANGE BIT(4)
+#define AD559X_EN_REF    BIT(9)
 
 #define AD559X_PIN_MAX 8U
 

--- a/include/zephyr/drivers/mfd/ad559x.h
+++ b/include/zephyr/drivers/mfd/ad559x.h
@@ -21,6 +21,7 @@ extern "C" {
 #define AD559X_REG_GPIO_SET       0x09U
 #define AD559X_REG_GPIO_INPUT_EN  0x0AU
 #define AD559X_REG_PD_REF_CTRL    0x0BU
+#define AD559X_REG_IO_TS_CONFIG   0x0DU
 
 #define AD559X_EN_REF BIT(9)
 


### PR DESCRIPTION
Add support for double range (2 x Vref) for both ADC and DAC.