### PR TITLE
Bluetooth: L2CAP: document memset requirement

### DIFF
--- a/include/zephyr/bluetooth/l2cap.h
+++ b/include/zephyr/bluetooth/l2cap.h
@@ -462,6 +462,9 @@ struct bt_l2cap_server {
 	 *  This callback is called whenever a new incoming connection requires
 	 *  authorization.
 	 *
+	 *  @warning It is the responsibility of this callback to zero out the
+	 *  parent of the chan object.
+	 *
 	 *  @param conn The connection that is requesting authorization
 	 *  @param server Pointer to the server structure this callback relates to
 	 *  @param chan Pointer to received the allocated channel
@@ -516,6 +519,9 @@ int bt_l2cap_br_server_register(struct bt_l2cap_server *server);
  *  each channel connected() callback will be called. If the connection is
  *  rejected disconnected() callback is called instead.
  *
+ *  @warning It is the responsibility of the caller to zero out the
+ *  parents of the chan objects.
+ *
  *  @param conn Connection object.
  *  @param chans Array of channel objects.
  *  @param psm Channel PSM to connect to.
@@ -550,6 +556,9 @@ int bt_l2cap_ecred_chan_reconfigure(struct bt_l2cap_chan **chans, uint16_t mtu);
  *  LE and/or type of bt_l2cap_br_chan for BR/EDR. Then pass to this API
  *  the location (address) of bt_l2cap_chan type object which is a member
  *  of both transport dedicated objects.
+ *
+ *  @warning It is the responsibility of the caller to zero out the
+ *  parent of the chan object.
  *
  *  @param conn Connection object.
  *  @param chan Channel object.


### PR DESCRIPTION
The `struct bt_l2cap_le_chan` and `struct bt_l2cap_br_chan` objects should be memset before passing them to the stack.

This was not stated anywhere, but all the in-tree users are doing it, so it must be API.

`#docfix`
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/76737