### PR TITLE
native_posix: deprecate with planned removal for 4.2

### DIFF
--- a/boards/native/native_posix/Kconfig.defconfig
+++ b/boards/native/native_posix/Kconfig.defconfig
@@ -3,6 +3,9 @@
 
 if BOARD_NATIVE_POSIX
 
+config BOARD_DEPRECATED_RELEASE
+	default "v4.2.0"
+
 config BUILD_OUTPUT_BIN
 	default n
 

--- a/boards/native/native_posix/doc/index.rst
+++ b/boards/native/native_posix/doc/index.rst
@@ -11,6 +11,15 @@ Native POSIX execution (native_posix)
 Overview
 ********
 
+.. warning::
+   ``native_posix`` is deprecated in favour of :ref:`native_sim<native_sim>`, and will be removed
+   in the 4.2 release.
+
+.. note::
+   For native_posix users, if needed, :ref:`native_sim<native_sim>` includes a compatibility mode
+   :kconfig:option:`CONFIG_NATIVE_SIM_NATIVE_POSIX_COMPAT`,
+   which will set its configuration to mimic a native_posix-like configuration.
+
 ``native_posix`` is the predecessor of :ref:`native_sim<native_sim>`.
 Just like with :ref:`native_sim<native_sim>` you can build your Zephyr application
 with the Zephyr kernel, creating a normal Linux executable with your host tooling,
@@ -18,15 +27,6 @@ and can debug and instrument it like any other Linux program.
 
 But unlike with :ref:`native_sim<native_sim>` you are limited to only using the host C library.
 :ref:`native_sim<native_sim>` supports all ``native_posix`` use cases.
-
-.. note::
-
-   | If you are a new user, you are encouraged to use :ref:`native_sim<native_sim>` directly.
-   | If you have been using native_posix you are recommended to start using
-     :ref:`native_sim<native_sim>` instead.
-   | If needed, :ref:`native_sim<native_sim>` includes a compatibility mode
-     :kconfig:option:`CONFIG_NATIVE_SIM_NATIVE_POSIX_COMPAT`,
-     which will set its configuration to mimic a native_posix's like configuration.
 
 This board does not intend to simulate any particular HW, but it provides
 a few peripherals such as an Ethernet driver, display, UART, etc., to enable

--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -24,6 +24,9 @@ Kernel
 Boards
 ******
 
+* :ref:`native_posix<native_posix>` has been deprecated in favour of
+  :ref:`native_sim<native_sim>` (:github:`76898`).
+
 Modules
 *******
 

--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -66,6 +66,9 @@ Boards & SoC Support
 
 * Made these board changes:
 
+  * :ref:`native_posix<native_posix>` has been deprecated in favour of
+    :ref:`native_sim<native_sim>`.
+
 * Added support for the following shields:
 
 Build system and Infrastructure


### PR DESCRIPTION
native_posix has been replaced with native_sim.
Users have been encouraged to switch since 3.6.

We deprecate it now, and plan to remove it in 4.2.

Related to #76895