### PR TITLE
CODEOWNERS/MAINTAINERS: Clean up for ARC & Synopsys

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -367,7 +367,6 @@
 /drivers/timer/*rcar_cmt*                 @aaillet
 /drivers/timer/*esp32_sys*                @uLipe
 /drivers/timer/*sam0_rtc*                 @bendiscz
-/drivers/timer/*arcv2*                    @ruuddw
 /drivers/timer/*xtensa*                   @dcpleung
 /drivers/timer/*rv32m1_lptmr*             @mbolivar
 /drivers/timer/*nrf_rtc*                  @anangl

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -395,7 +395,6 @@
 /drivers/wifi/eswifi/                     @loicpoulain @nandojve
 /drivers/wifi/winc1500/                   @kludentwo
 /drivers/virtualization/		  @tbursztyka
-/dts/arc/                                 @abrodkin @ruuddw @iriszzw @evgeniy-paltsev
 /dts/arm/acsip/                           @NorthernDean
 /dts/arm/aspeed/                          @aspeeddylan
 /dts/arm/atmel/                           @galak @nandojve

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -136,6 +136,7 @@ ARC arch:
     - arch/arc/
     - include/zephyr/arch/arc/
     - drivers/timer/*arcv2*
+    - drivers/interrupt_controller/*arcv2*
     - tests/arch/arc/
     - dts/arc/
     - dts/bindings/arc/

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -135,6 +135,7 @@ ARC arch:
   files:
     - arch/arc/
     - include/zephyr/arch/arc/
+    - drivers/timer/*arcv2*
     - tests/arch/arc/
     - dts/arc/
     - dts/bindings/arc/

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -136,7 +136,7 @@ ARC arch:
     - arch/arc/
     - include/zephyr/arch/arc/
     - tests/arch/arc/
-    - dts/arc/synopsys/
+    - dts/arc/
     - dts/bindings/arc/
     - doc/hardware/arch/arc-support-status.rst
   labels:

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -129,9 +129,9 @@ ARC arch:
   status: maintained
   maintainers:
     - ruuddw
+    - evgeniy-paltsev
   collaborators:
     - abrodkin
-    - evgeniy-paltsev
   files:
     - arch/arc/
     - include/zephyr/arch/arc/
@@ -3345,9 +3345,9 @@ Synopsys Platforms:
   status: maintained
   maintainers:
     - ruuddw
+    - evgeniy-paltsev
   collaborators:
     - abrodkin
-    - evgeniy-paltsev
   files:
     - soc/snps/
     - boards/snps/


### PR DESCRIPTION
 - migrate rest of the ARC entries from CODEOWNERS to MAINTAINERS (rationale: #38725)
   - migrate dts/arc/ from CODEOWNERS
   - migrate arc timer driver from CODEOWNERS
 - add missing ARC interrupt controller
 - add evgeniy-paltsev as a co-maintainer for ARC/Synopsys