### PR TITLE
fs: fuse: ensure S_IFxxx macros are available

### DIFF
--- a/subsys/fs/fuse_fs_access.c
+++ b/subsys/fs/fuse_fs_access.c
@@ -6,6 +6,9 @@
 
 #define FUSE_USE_VERSION 26
 
+#undef _XOPEN_SOURCE
+#define _XOPEN_SOURCE 700
+
 #include <fuse.h>
 #include <libgen.h>
 #include <linux/limits.h>
@@ -15,6 +18,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mount.h>
+#include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/types.h>
 


### PR DESCRIPTION
set _XOPEN_SOURCE appropriately to avoid compilation errors due to missing S_IFxxx macros on some systems.