### PR TITLE
tests: debug/thread_analyzer: Fix platform filter

### DIFF
--- a/tests/subsys/debug/thread_analyzer/testcase.yaml
+++ b/tests/subsys/debug/thread_analyzer/testcase.yaml
@@ -5,9 +5,9 @@ common:
   tags:
     - debug
     - thread_analyzer
-  platform_exclude:
-    # native_sim prints nothing from thread analyzer so skips it for now.
-    - native_sim
+  arch_exclude:
+    # The thread analyzer depends on !ARCH_POSIX
+    - posix
 tests:
   debug.thread_analyzer.printk:
     extra_configs:


### PR DESCRIPTION
Today the thread analyzer depends on !ARCH_POSIX,
so this filter needs to filter any board for this architecture not just native_sim.

Fixes #76908