### PR TITLE
drivers: serial: ns16550: fix typo and reduce compile switch

### DIFF
--- a/drivers/serial/Kconfig.it8xxx2
+++ b/drivers/serial/Kconfig.it8xxx2
@@ -4,7 +4,7 @@
 config UART_ITE_IT8XXX2
 	bool "ITE IT8XXX2 UART driver"
 	default y
-	select UART_NS16550_ITE_HIGH_SPEED_BUADRATE
+	select UART_NS16550_ITE_HIGH_SPEED_BAUDRATE
 	depends on DT_HAS_ITE_IT8XXX2_UART_ENABLED
 	help
 	  IT8XXX2 uses shared ns16550.c driver which does not

--- a/drivers/serial/Kconfig.ns16550
+++ b/drivers/serial/Kconfig.ns16550
@@ -74,7 +74,7 @@ config UART_NS16550_TI_K3
 	  Texas Instruments K3 SoCs by enabling a vendor specific extended register
 	  set.
 
-config UART_NS16550_ITE_HIGH_SPEED_BUADRATE
+config UART_NS16550_ITE_HIGH_SPEED_BAUDRATE
 	bool "IT8XXX2 specific baud rate configuration"
 	help
 	  Enable IT8XXX2 specific baud rate configuration.

--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -267,7 +267,7 @@ BUILD_ASSERT(IS_ENABLED(CONFIG_PCIE), "NS16550(s) in DT need CONFIG_PCIE");
 
 #define IIRC(dev) (((struct uart_ns16550_dev_data *)(dev)->data)->iir_cache)
 
-#ifdef CONFIG_UART_NS16550_ITE_HIGH_SPEED_BUADRATE
+#ifdef CONFIG_UART_NS16550_ITE_HIGH_SPEED_BAUDRATE
 /* Register definitions (ITE_IT8XXX2) */
 #define REG_ECSPMR 0x08 /* EC Serial port mode reg */
 
@@ -482,7 +482,7 @@ static inline uintptr_t get_port(const struct device *dev)
 	return port;
 }
 
-static uint32_t get_uart_burdrate_divisor(const struct device *dev,
+static uint32_t get_uart_baudrate_divisor(const struct device *dev,
 					  uint32_t baud_rate,
 					  uint32_t pclk)
 {
@@ -494,8 +494,8 @@ static uint32_t get_uart_burdrate_divisor(const struct device *dev,
 	return ((pclk + (baud_rate << 3)) / baud_rate) >> 4;
 }
 
-#ifdef CONFIG_UART_NS16550_ITE_HIGH_SPEED_BUADRATE
-static uint32_t get_ite_uart_burdrate_divisor(const struct device *dev,
+#ifdef CONFIG_UART_NS16550_ITE_HIGH_SPEED_BAUDRATE
+static uint32_t get_ite_uart_baudrate_divisor(const struct device *dev,
 					      uint32_t baud_rate,
 					      uint32_t pclk)
 {
@@ -517,7 +517,7 @@ static uint32_t get_ite_uart_burdrate_divisor(const struct device *dev,
 		 */
 		ns16550_outbyte(dev_cfg, ECSPMR(dev), ECSPMR_ECHS);
 	} else {
-		divisor = get_uart_burdrate_divisor(dev, baud_rate, pclk);
+		divisor = get_uart_baudrate_divisor(dev, baud_rate, pclk);
 		/* Set ECSPMR register as default */
 		ns16550_outbyte(dev_cfg, ECSPMR(dev), 0);
 	}
@@ -534,10 +534,10 @@ static void set_baud_rate(const struct device *dev, uint32_t baud_rate, uint32_t
 	uint8_t lcr_cache;
 
 	if ((baud_rate != 0U) && (pclk != 0U)) {
-#ifdef CONFIG_UART_NS16550_ITE_HIGH_SPEED_BUADRATE
-		divisor = get_ite_uart_burdrate_divisor(dev, baud_rate, pclk);
+#ifdef CONFIG_UART_NS16550_ITE_HIGH_SPEED_BAUDRATE
+		divisor = get_ite_uart_baudrate_divisor(dev, baud_rate, pclk);
 #else
-		divisor = get_uart_burdrate_divisor(dev, baud_rate, pclk);
+		divisor = get_uart_baudrate_divisor(dev, baud_rate, pclk);
 #endif
 		/* set the DLAB to access the baud rate divisor registers */
 		lcr_cache = ns16550_inbyte(dev_cfg, LCR(dev));

--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -427,8 +427,7 @@ static uint8_t ns16550_inbyte(const struct uart_ns16550_device_config *cfg,
 	return 0;
 }
 
-#if (defined(CONFIG_UART_NS16550_INTEL_LPSS_DMA) & (defined(CONFIG_UART_ASYNC_API)))\
-	| UART_NS16550_PCP_ENABLED
+__maybe_unused
 static void ns16550_outword(const struct uart_ns16550_device_config *cfg,
 			    uintptr_t port, uint32_t val)
 {
@@ -444,6 +443,7 @@ static void ns16550_outword(const struct uart_ns16550_device_config *cfg,
 	}
 }
 
+__maybe_unused
 static uint32_t ns16550_inword(const struct uart_ns16550_device_config *cfg,
 			      uintptr_t port)
 {
@@ -455,7 +455,6 @@ static uint32_t ns16550_inword(const struct uart_ns16550_device_config *cfg,
 	/* MMIO mapped */
 	return sys_read32(port);
 }
-#endif
 
 static inline uint8_t reg_interval(const struct device *dev)
 {


### PR DESCRIPTION
The following two commits incorporate with this PR.
- Fix typo for `BAUDRATE`, `baudrate`
- Apply `__maybe_unused` in the `ns16550_outword` and `ns16550_inword` functions