### PR TITLE
tests: drivers: wdt_basic_api: Correct rpi_pico configuration

### DIFF
--- a/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
+++ b/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
@@ -107,7 +107,7 @@
 #define WDT_TEST_MAX_WINDOW 200U
 #endif
 #if DT_HAS_COMPAT_STATUS_OKAY(raspberrypi_pico_watchdog)
-#define WDT_TEST_MAX_WINDOW 20000U
+#define WDT_TEST_MAX_WINDOW 8000U
 #define TIMEOUTS 0
 #endif
 #if DT_HAS_COMPAT_STATUS_OKAY(intel_tco_wdt)


### PR DESCRIPTION
The max window time of RaspberryPi Pico WDT is 8,388,607 us(0x7FFFFF), But 20,000ms have been set.

Correcting the value to 8,000ms to pass the test.

This was a problem that was discovered because the fix in ccedcd1ac04c8e6436b764a6f411e4590ee35e5 now properly handles the error.