### PR TITLE
driver: lora: sx12xx: add method for channel activity detection

### DIFF
--- a/drivers/lora/sx126x.c
+++ b/drivers/lora/sx126x.c
@@ -469,6 +469,8 @@ static const struct lora_driver_api sx126x_lora_api = {
 	.send_async = sx12xx_lora_send_async,
 	.recv = sx12xx_lora_recv,
 	.recv_async = sx12xx_lora_recv_async,
+	.cad = sx12xx_lora_cad,
+	.cad_async = sx12xx_lora_cad_async,
 	.test_cw = sx12xx_lora_test_cw,
 };
 

--- a/drivers/lora/sx12xx_common.h
+++ b/drivers/lora/sx12xx_common.h
@@ -31,6 +31,10 @@ int sx12xx_lora_recv(const struct device *dev, uint8_t *data, uint8_t size,
 
 int sx12xx_lora_recv_async(const struct device *dev, lora_recv_cb cb);
 
+int sx12xx_lora_cad(const struct device *dev, k_timeout_t timeout);
+
+int sx12xx_lora_cad_async(const struct device *dev, lora_cad_cb cb);
+
 int sx12xx_lora_config(const struct device *dev,
 		       struct lora_modem_config *config);
 


### PR DESCRIPTION
add ```lora_cad``` and ```lora_cad_async``` function to support channel activity detection (CAD) for Radio sx126x or llcc68, it has been verified on the SX1262 radio frequency chip that it can correctly detect that the channel is busy.

Signed-off-by: Chiho Sin [chihosin@icloud.com](mailto:chihosin@icloud.com)