### PR TITLE
modules: hostap: Convert WPA cli to selectable option

### DIFF
--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -222,6 +222,12 @@ config WIFI_NM_WPA_SUPPLICANT_DPP
 	select MBEDTLS_X509_CSR_WRITE_C
 	select MBEDTLS_X509_CSR_PARSE_C
 
+
+config WPA_CLI
+	bool "WPA CLI support"
+	help
+	  Enable WPA CLI support for wpa_supplicant.
+
 # Create hidden config options that are used in hostap. This way we do not need
 # to mark them as allowed for CI checks, and also someone else cannot use the
 # same name options.
@@ -392,9 +398,6 @@ config SUITEB192
 config WEP
 	bool
 	default y if WIFI_NM_WPA_SUPPLICANT_WEP
-
-config WPA_CLI
-	bool
 
 config WPA_CRYPTO
 	bool

--- a/west.yml
+++ b/west.yml
@@ -259,7 +259,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: a941086775a865d170743a5d4790f1fa213ec6a4
+      revision: 77a4cad575c91f1b234c8d15630f87999881cde2
     - name: libmetal
       revision: a6851ba6dba8c9e87d00c42f171a822f7a29639b
       path: modules/hal/libmetal


### PR DESCRIPTION
This should be configurable by applications in case a full CLI interface to the WPA supplicant is needed.