### PR TITLE
drivers: video: ov2640: fix vertical flip

### DIFF
--- a/drivers/video/ov2640.c
+++ b/drivers/video/ov2640.c
@@ -108,6 +108,7 @@ LOG_MODULE_REGISTER(ov2640);
 #define REG04_DEFAULT       0x28
 #define REG04_HFLIP_IMG     0x80
 #define REG04_VFLIP_IMG     0x40
+#define REG04_VREF_EN       0x10
 #define REG04_HREF_EN       0x08
 #define REG04_SET(x)        (REG04_DEFAULT | x)
 
@@ -791,9 +792,9 @@ static int ov2640_set_vertical_flip(const struct device *dev, int enable)
 	reg = ov2640_read_reg(&cfg->i2c, REG04);
 
 	if (enable) {
-		reg |= REG04_VFLIP_IMG;
+		reg |= REG04_VFLIP_IMG | REG04_VREF_EN;
 	} else {
-		reg &= ~REG04_VFLIP_IMG;
+		reg &= ~(REG04_VFLIP_IMG | REG04_VREF_EN);
 	}
 
 	ret |= ov2640_write_reg(&cfg->i2c, REG04, reg);


### PR DESCRIPTION
When the ov2640_set_vertical_flip function rotates the image, but the colors are not displayed correctly.

Tested with https://github.com/zephyrproject-rtos/zephyr/pull/71463

**Before:**

![photo_5028818555545694602_y](https://github.com/user-attachments/assets/bc539e58-62b5-45e3-9bfa-317ea7716793)

**After:**

![photo_5028818555545694601_y](https://github.com/user-attachments/assets/8f20c923-5354-47fa-9b0e-8295072f347b)

