### PR TITLE
drivers: video: stm32_dcmi: add set and get ctrl

### DIFF
--- a/drivers/video/video_stm32_dcmi.c
+++ b/drivers/video/video_stm32_dcmi.c
@@ -356,6 +356,28 @@ static int video_stm32_dcmi_get_caps(const struct device *dev,
 	return ret;
 }
 
+static inline int video_stm32_dcmi_set_ctrl(const struct device *dev, unsigned int cid, void *value)
+{
+	const struct video_stm32_dcmi_config *config = dev->config;
+	int ret;
+
+	/* Forward to source dev if any */
+	ret = video_set_ctrl(config->sensor_dev, cid, value);
+
+	return ret;
+}
+
+static inline int video_stm32_dcmi_get_ctrl(const struct device *dev, unsigned int cid, void *value)
+{
+	const struct video_stm32_dcmi_config *config = dev->config;
+	int ret;
+
+	/* Forward to source dev if any */
+	ret = video_get_ctrl(config->sensor_dev, cid, value);
+
+	return ret;
+}
+
 static const struct video_driver_api video_stm32_dcmi_driver_api = {
 	.set_format = video_stm32_dcmi_set_fmt,
 	.get_format = video_stm32_dcmi_get_fmt,
@@ -364,6 +386,8 @@ static const struct video_driver_api video_stm32_dcmi_driver_api = {
 	.enqueue = video_stm32_dcmi_enqueue,
 	.dequeue = video_stm32_dcmi_dequeue,
 	.get_caps = video_stm32_dcmi_get_caps,
+	.set_ctrl = video_stm32_dcmi_set_ctrl,
+	.get_ctrl = video_stm32_dcmi_get_ctrl,
 };
 
 static void video_stm32_dcmi_irq_config_func(const struct device *dev)


### PR DESCRIPTION
Add set_ctrl and get_ctrl functions. These were tested with https://github.com/zephyrproject-rtos/zephyr/pull/71463