### PR TITLE
xtensa: mmu: fix page table initialization

### DIFF
--- a/arch/xtensa/core/ptables.c
+++ b/arch/xtensa/core/ptables.c
@@ -267,6 +267,12 @@ static void map_memory(const uint32_t start, const uint32_t end,
 static void xtensa_init_page_tables(void)
 {
 	volatile uint8_t entry;
+	static bool already_inited;
+
+	if (already_inited) {
+		return;
+	}
+	already_inited = true;
 
 	init_page_table(xtensa_kernel_ptables, XTENSA_L1_PAGE_TABLE_ENTRIES);
 	atomic_set_bit(l1_page_table_track, 0);
@@ -305,15 +311,7 @@ __weak void arch_xtensa_mmu_post_init(bool is_core0)
 
 void xtensa_mmu_init(void)
 {
-	if (_current_cpu->id == 0) {
-		/* This is normally done via arch_kernel_init() inside z_cstart().
-		 * However, before that is called, we go through the sys_init of
-		 * INIT_LEVEL_EARLY, which is going to result in TLB misses.
-		 * So setup whatever necessary so the exception handler can work
-		 * properly.
-		 */
-		xtensa_init_page_tables();
-	}
+	xtensa_init_page_tables();
 
 	xtensa_init_paging(xtensa_kernel_ptables);
 


### PR DESCRIPTION
xtensa_mmu_init() is called really early in the boot process where the _kernel struct has not yet been initialized, and thus we cannot use it to determine if the current CPU is the boot CPU. In some cases, this may skip the call to initialize the page tables which leaves us with incorrect page table entries. Fix it by using a static variable to determine whether the page tables have been initialized so we only do it once per boot.

Fixes #76909