### PR TITLE
logging: fix log buffer pending while it is definitely full

### DIFF
--- a/lib/os/mpsc_pbuf.c
+++ b/lib/os/mpsc_pbuf.c
@@ -611,8 +611,10 @@ void mpsc_pbuf_free(struct mpsc_pbuf_buffer *buffer,
 bool mpsc_pbuf_is_pending(struct mpsc_pbuf_buffer *buffer)
 {
 	uint32_t a;
+	k_spinlock_key_t key = k_spin_lock(&buffer->lock);
 
 	(void)available(buffer, &a);
+	k_spin_unlock(&buffer->lock, key);
 
 	return a ? true : false;
 }


### PR DESCRIPTION
The buffer flags MPSC_PBUF_FULL is a shared resource to determine whether the buffer is available. When processing drop messages, the flag will be cleared first and then set, add spin lock protection.