### PR TITLE
soc: intel_adsp: ace: set xtensa ccount hz kconfig per platform

### DIFF
--- a/soc/intel/intel_adsp/ace/Kconfig.defconfig.ace15_mtpm
+++ b/soc/intel/intel_adsp/ace/Kconfig.defconfig.ace15_mtpm
@@ -6,4 +6,11 @@ if SOC_INTEL_ACE15_MTPM
 config MP_MAX_NUM_CPUS
 	default 3
 
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default 393216000 if XTENSA_TIMER
+	default 38400000 if INTEL_ADSP_TIMER
+
+config XTENSA_CCOUNT_HZ
+	default 393216000
+
 endif

--- a/soc/intel/intel_adsp/ace/Kconfig.defconfig.ace20_lnl
+++ b/soc/intel/intel_adsp/ace/Kconfig.defconfig.ace20_lnl
@@ -6,4 +6,11 @@ if SOC_INTEL_ACE20_LNL
 config MP_MAX_NUM_CPUS
 	default 5
 
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default 393216000 if XTENSA_TIMER
+	default 38400000 if INTEL_ADSP_TIMER
+
+config XTENSA_CCOUNT_HZ
+	default 393216000
+
 endif

--- a/soc/intel/intel_adsp/ace/Kconfig.defconfig.ace30_ptl
+++ b/soc/intel/intel_adsp/ace/Kconfig.defconfig.ace30_ptl
@@ -7,6 +7,13 @@ if SOC_INTEL_ACE30_PTL
 config MP_MAX_NUM_CPUS
 	default 5
 
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default 442368000 if XTENSA_TIMER
+	default 38400000 if INTEL_ADSP_TIMER
+
+config XTENSA_CCOUNT_HZ
+	default 442368000
+
 config CPU_HAS_MMU
 	def_bool y
 

--- a/soc/intel/intel_adsp/ace/Kconfig.defconfig.series
+++ b/soc/intel/intel_adsp/ace/Kconfig.defconfig.series
@@ -40,15 +40,8 @@ config XTENSA_TIMER
 config XTENSA_TIMER_ID
 	default 0
 
-config SYS_CLOCK_HW_CYCLES_PER_SEC
-	default 393216000 if XTENSA_TIMER
-	default 38400000 if INTEL_ADSP_TIMER
-
 config SYS_CLOCK_TICKS_PER_SEC
 	default 12000
-
-config XTENSA_CCOUNT_HZ
-	default 393216000
 
 config INTEL_ADSP_TIMER
 	default y


### PR DESCRIPTION
XTENSA_CCOUNT_HZ is no longer common to ACE soc series
This will fix Hz value for ACE30 platform