### PR TITLE
twister: runner: j-link: use dev-id instead of SelectEmuBySN

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
@@ -86,7 +86,7 @@ class HardwareAdapter(DeviceAdapter):
                 extra_args.append("--cmd-pre-init")
                 extra_args.append(f'adapter serial {board_id}')
             elif runner == 'jlink':
-                base_args.append(f'--tool-opt=-SelectEmuBySN {board_id}')
+                base_args.append(f'--dev-id {board_id}')
             elif runner == 'stm32cubeprogrammer':
                 base_args.append(f'--tool-opt=sn={board_id}')
             elif runner == 'linkserver':

--- a/scripts/pylib/pytest-twister-harness/tests/device/hardware_adapter_test.py
+++ b/scripts/pylib/pytest-twister-harness/tests/device/hardware_adapter_test.py
@@ -99,7 +99,7 @@ def test_if_get_command_returns_proper_string_6(patched_which, device: HardwareA
     assert isinstance(device.command, list)
     assert device.command == [
         'west', 'flash', '--skip-rebuild', '--build-dir', 'build', '--runner', 'jlink',
-        '--tool-opt=-SelectEmuBySN p_id'
+        '--dev-id p_id'
     ]
 
 

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -538,7 +538,8 @@ class DeviceHandler(Handler):
                         command_extra_args.append("--cmd-pre-init")
                         command_extra_args.append("adapter serial %s" % board_id)
                     elif runner == "jlink":
-                        command.append("--tool-opt=-SelectEmuBySN  %s" % board_id)
+                        command.append("--dev-id")
+                        command.append(board_id)
                     elif runner == "linkserver":
                         # for linkserver
                         # --probe=#<number> select by probe index

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -1028,7 +1028,7 @@ TESTDATA_13 = [
         'jlink',
         'product',
         ['west', 'flash', '--skip-rebuild', '-d', '$build_dir',
-         '--runner', 'jlink', '--tool-opt=-SelectEmuBySN  12345',  # 2x space
+         '--runner', 'jlink', '--dev-id', 12345,
          'param1', 'param2']
     ),
     (


### PR DESCRIPTION
The serial number for debugger selection over USB
can be selected with the dev-id. This change
reflects also more the workflow of west flash
with J-Link.
The usage of SelectEmuBySN breaks the support for
J-Link over IP with twister.