### PR TITLE
logging: change failure report period timer logic

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -571,9 +571,10 @@ bool z_impl_log_process(void)
 	if (IS_ENABLED(CONFIG_LOG_MODE_DEFERRED)) {
 		bool dropped_pend = z_log_dropped_pending();
 		bool unordered_pend = z_log_unordered_pending();
+		uint64_t now_ms = (uint64_t)k_uptime_get();
 
 		if ((dropped_pend || unordered_pend) &&
-		   (k_uptime_get() - last_failure_report) > CONFIG_LOG_FAILURE_REPORT_PERIOD) {
+		   (now_ms - last_failure_report) > CONFIG_LOG_FAILURE_REPORT_PERIOD) {
 			if (dropped_pend) {
 				dropped_notify();
 			}
@@ -581,9 +582,9 @@ bool z_impl_log_process(void)
 			if (unordered_pend) {
 				unordered_notify();
 			}
+			last_failure_report = now_ms;
 		}
 
-		last_failure_report += CONFIG_LOG_FAILURE_REPORT_PERIOD;
 	}
 
 	return z_log_msg_pending();


### PR DESCRIPTION
The CONFIG_LOG_FAILURE_REPORT_PERIOD does not work for failure report.