### PR TITLE
Add flexio pwm and flexio spi support for frdm_ke17z and frdm_ke17z512

### DIFF
--- a/boards/nxp/frdm_ke17z/frdm_ke17z-pinctrl.dtsi
+++ b/boards/nxp/frdm_ke17z/frdm_ke17z-pinctrl.dtsi
@@ -28,6 +28,15 @@
 		};
 	};
 
+	flexio_pwm_default: flexio_pwm_default {
+		group0 {
+			pinmux = <FXIO_D3_PTD5>,
+				<FXIO_D5_PTD3>;
+			drive-strength = "low";
+			slew-rate = "slow";
+		};
+	};
+
 	lpspi0_default: lpspi0_default {
 		group0 {
 			pinmux = <LPSPI0_SCK_PTB2>,

--- a/boards/nxp/frdm_ke17z512/frdm_ke17z512-pinctrl.dtsi
+++ b/boards/nxp/frdm_ke17z512/frdm_ke17z512-pinctrl.dtsi
@@ -59,4 +59,13 @@
 			slew-rate = "slow";
 		};
 	};
+
+	flexio_pwm_default: flexio_pwm_default {
+		group0 {
+			pinmux = <FXIO_D3_PTD5>,
+				<FXIO_D5_PTD3>;
+			drive-strength = "low";
+			slew-rate = "slow";
+		};
+	};
 };

--- a/drivers/spi/spi_mcux_flexio.c
+++ b/drivers/spi/spi_mcux_flexio.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2024, STRIM, ALC
+ * Copyright 2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -100,6 +101,11 @@ static int spi_mcux_flexio_isr(void *user_data)
 	const struct spi_mcux_flexio_config *config = dev->config;
 	struct spi_mcux_flexio_data *data = dev->data;
 
+#if defined(CONFIG_SOC_SERIES_KE1XZ)
+	/* Wait until data transfer complete. */
+	WAIT_FOR((0U == (FLEXIO_SPI_GetStatusFlags(config->flexio_spi)
+		& (uint32_t)kFLEXIO_SPI_TxBufferEmptyFlag)), 100, NULL);
+#endif
 	FLEXIO_SPI_MasterTransferHandleIRQ(config->flexio_spi, &data->handle);
 
 	return 0;

--- a/dts/arm/nxp/nxp_ke1xz.dtsi
+++ b/dts/arm/nxp/nxp_ke1xz.dtsi
@@ -339,6 +339,14 @@
 			#dma-cells = <2>;
 			irq-shared-offset = <4>;
 		};
+
+		flexio: flexio@4005a000 {
+			compatible = "nxp,flexio";
+			reg = <0x4005a000 0x1000>;
+			status = "disabled";
+			interrupts = <23 0>;
+			clocks = <&pcc 0x168 KINETIS_PCC_SRC_FIRC_ASYNC>;
+		};
 	};
 };
 

--- a/soc/nxp/kinetis/ke1xz/soc.c
+++ b/soc/nxp/kinetis/ke1xz/soc.c
@@ -126,6 +126,10 @@ static ALWAYS_INLINE void clk_init(void)
 	CLOCK_SetIpSrc(kCLOCK_Lpi2c1,
 		       DT_CLOCKS_CELL(DT_NODELABEL(lpi2c1), ip_source));
 #endif
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(flexio), okay)
+	CLOCK_SetIpSrc(kCLOCK_Flexio0,
+		       DT_CLOCKS_CELL(DT_NODELABEL(flexio), ip_source));
+#endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(lpspi0), okay)
 	CLOCK_SetIpSrc(kCLOCK_Lpspi0,
 		       DT_CLOCKS_CELL(DT_NODELABEL(lpspi0), ip_source));

--- a/tests/drivers/pwm/pwm_api/boards/frdm_ke1xz_flexio_pwm.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/frdm_ke1xz_flexio_pwm.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-0 = &flexio0_pwm;
+	};
+};
+
+
+&flexio {
+	status = "okay";
+	flexio0_pwm: flexio0_pwm {
+		compatible = "nxp,flexio-pwm";
+		#pwm-cells = <3>;
+		status = "okay";
+		pinctrl-0 = <&flexio_pwm_default>;
+		pinctrl-names = "default";
+
+		pwm_0 {
+			pin-id = <3>;
+			prescaler = <1>;
+		};
+	};
+};

--- a/tests/drivers/pwm/pwm_api/testcase.yaml
+++ b/tests/drivers/pwm/pwm_api/testcase.yaml
@@ -8,3 +8,16 @@ tests:
       or dt_alias_exists("pwm-3") or dt_compat_enabled("st,stm32-pwm")
       or dt_compat_enabled("intel,blinky-pwm") or dt_compat_enabled("nordic,nrf-pwm")
     depends_on: pwm
+  drivers.pwm.ke1xz_pwm_flexio:
+    tags:
+      - drivers
+      - pwm
+      - userspace
+    extra_args: DTC_OVERLAY_FILE="boards/frdm_ke1xz_flexio_pwm.overlay"
+    platform_allow:
+      - frdm_ke17z
+      - frdm_ke17z512
+    filter: (dt_alias_exists("pwm-0") or dt_alias_exists("pwm-1") or dt_alias_exists("pwm-2")
+      or dt_alias_exists("pwm-3")) and CONFIG_DT_HAS_NXP_FLEXIO_ENABLED and
+      CONFIG_DT_HAS_NXP_FLEXIO_PWM_ENABLED
+    depends_on: pwm

--- a/tests/drivers/spi/spi_loopback/boards/frdm_ke1xz_flexio_spi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_ke1xz_flexio_spi.overlay
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* To test this sample, connect
+ * SDO(J2-3)  -->  SDI(J2-4)
+ */
+
+&pinctrl {
+	pinmux_flexio_spi0: pinmux_flexio_spi0 {
+		group0 {
+			pinmux = <FXIO_D6_PTA8>, /* cs */
+				<FXIO_D4_PTB8>, /* sck */
+				<FXIO_D7_PTC3>, /* sdo */
+				<FXIO_D1_PTB11>; /* sdi */
+			drive-strength = "low";
+			slew-rate = "slow";
+		};
+	};
+};
+
+&flexio {
+	status = "okay";
+
+	flexio_spi0: flexio_spi0 {
+		compatible = "nxp,flexio-spi";
+		status = "okay";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		cs-gpios = <&gpioa 8 GPIO_ACTIVE_LOW>;
+		sdo-pin = <7>;
+		sdi-pin = <1>;
+		sck-pin = <4>;
+		pinctrl-0 = <&pinmux_flexio_spi0>;
+		pinctrl-names = "default";
+		slow@0 {
+			status = "okay";
+			compatible = "test-spi-loopback-slow";
+			reg = <0>;
+			spi-max-frequency = <500000>;
+		};
+		fast@0 {
+			compatible = "test-spi-loopback-fast";
+			reg = <0>;
+			spi-max-frequency = <4000000>;
+		};
+	};
+};
+
+&gpioa {
+	status = "okay";
+};

--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -182,3 +182,10 @@ tests:
     extra_args: DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
+  drivers.spi.ke1xz_flexio_spi.loopback:
+    extra_args: DTC_OVERLAY_FILE="boards/frdm_ke1xz_flexio_spi.overlay"
+    filter: CONFIG_DT_HAS_NXP_FLEXIO_ENABLED and
+            CONFIG_DT_HAS_NXP_FLEXIO_SPI_ENABLED
+    platform_allow:
+      - frdm_ke17z
+      - frdm_ke17z512


### PR DESCRIPTION
Flexio_pwm: tested `tests/drivers/pwm/pwm_api` `drivers.pwm.ke1xz_pwm_flexio`.
Flexio_spi: tested `tests/drivers/spi/spi_loopback` `drivers.spi.ke1xz_flexio_spi.loopback`.
