### PR TITLE
ztest: undefine _POSIX_C_SOURCE before defining it

### DIFF
--- a/subsys/testsuite/ztest/CMakeLists.txt
+++ b/subsys/testsuite/ztest/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 zephyr_library()
 
 # For strtok_r() and strdup()
-zephyr_library_compile_options(-D_POSIX_C_SOURCE=200809L)
+zephyr_library_compile_options(-U_POSIX_C_SOURCE -D_POSIX_C_SOURCE=200809L)
 
 zephyr_library_sources(
   src/ztest.c


### PR DESCRIPTION
Undefine _POSIX_C_SOURCE before defining it to avoid double definition

The previous version, changed in this PR https://github.com/zephyrproject-rtos/zephyr/pull/70363, did the undef.
Make sure to do the same for all files in the current dir.