### PR TITLE
net: lwm2m: remove deprecated APIs and confs

### DIFF
--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -915,21 +915,6 @@ int lwm2m_set_u16(const struct lwm2m_obj_path *path, uint16_t value);
 int lwm2m_set_u32(const struct lwm2m_obj_path *path, uint32_t value);
 
 /**
- * @brief Set resource (instance) value (u64)
- *
- * @deprecated Unsigned 64bit value type does not exits.
- *             This is internally handled as a int64_t.
- *             Use lwm2m_set_s64() instead.
- *
- * @param[in] path LwM2M path as a struct
- * @param[in] value u64 value
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_set_u64(const struct lwm2m_obj_path *path, uint64_t value);
-
-/**
  * @brief Set resource (instance) value (s8)
  *
  * @param[in] path LwM2M path as a struct
@@ -1106,21 +1091,6 @@ int lwm2m_get_u16(const struct lwm2m_obj_path *path, uint16_t *value);
  * @return 0 for success or negative in case of error.
  */
 int lwm2m_get_u32(const struct lwm2m_obj_path *path, uint32_t *value);
-
-/**
- * @brief Get resource (instance) value (u64)
- *
- * @deprecated Unsigned 64bit value type does not exits.
- *             This is internally handled as a int64_t.
- *             Use lwm2m_get_s64() instead.
-
- * @param[in] path LwM2M path as a struct
- * @param[out] value u64 buffer to copy data into
- *
- * @return 0 for success or negative in case of error.
- */
-__deprecated
-int lwm2m_get_u64(const struct lwm2m_obj_path *path, uint64_t *value);
 
 /**
  * @brief Get resource (instance) value (s8)

--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -716,12 +716,4 @@ source "subsys/net/lib/lwm2m/Kconfig.ipso"
 
 source "subsys/net/lib/lwm2m/Kconfig.ucifi"
 
-menu "Deprecated flags"
-config LWM2M_RD_CLIENT_SUPPORT
-	bool "DEPRECATED: client bootstrap/registration state machine"
-	select DEPRECATED
-	help
-	  Deprecated flag. RD state machine is always part of engine. It cannot be disabled.
-endmenu # "Deprecated flags"
-
 endif # LWM2M

--- a/subsys/net/lib/lwm2m/lwm2m_registry.c
+++ b/subsys/net/lib/lwm2m/lwm2m_registry.c
@@ -754,11 +754,6 @@ int lwm2m_set_u32(const struct lwm2m_obj_path *path, uint32_t value)
 	return lwm2m_engine_set(path, &value, 4);
 }
 
-int lwm2m_set_u64(const struct lwm2m_obj_path *path, uint64_t value)
-{
-	return lwm2m_engine_set(path, &value, 8);
-}
-
 int lwm2m_set_s8(const struct lwm2m_obj_path *path, int8_t value)
 {
 	return lwm2m_engine_set(path, &value, 1);
@@ -1028,11 +1023,6 @@ int lwm2m_get_u16(const struct lwm2m_obj_path *path, uint16_t *value)
 int lwm2m_get_u32(const struct lwm2m_obj_path *path, uint32_t *value)
 {
 	return lwm2m_engine_get(path, value, 4);
-}
-
-int lwm2m_get_u64(const struct lwm2m_obj_path *path, uint64_t *value)
-{
-	return lwm2m_engine_get(path, value, 8);
 }
 
 int lwm2m_get_s8(const struct lwm2m_obj_path *path, int8_t *value)


### PR DESCRIPTION
Remove deprecated APIs and configs:
* CONFIG_LWM2M_RD_CLIENT_SUPPORT
* lwm2m_get_u64()
* lwm2m_set_u64()

Requested in https://github.com/zephyrproject-rtos/zephyr/issues/76943
