### PR TITLE
boards: stm32: Fix Arduino I2C on Nucleo-WL55JC

### DIFF
--- a/boards/st/nucleo_wl55jc/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_wl55jc/arduino_r3_connector.dtsi
@@ -36,5 +36,5 @@
 };
 
 arduino_serial: &usart1 {};
-arduino_i2c: &i2c2 {};
+arduino_i2c: &i2c3 {};
 arduino_spi: &spi1 {};

--- a/boards/st/nucleo_wl55jc/doc/nucleo_wl55jc.rst
+++ b/boards/st/nucleo_wl55jc/doc/nucleo_wl55jc.rst
@@ -231,8 +231,8 @@ Default Zephyr Peripheral Mapping:
 .. rst-class:: rst-columns
 
 - LPUART_1 TX/RX : PA3/PA2 (ST-Link Virtual Port Com)
-- I2C_2_SCL : PA12 (Arduino I2C)
-- I2C_2_SDA : PA11 (Arduino I2C)
+- I2C_3_SCL : PB13 (Arduino I2C)
+- I2C_3_SDA : PB14 (Arduino I2C)
 - SPI_1_NSS : PA4 (arduino_spi)
 - SPI_1_SCK : PA5 (arduino_spi)
 - SPI_1_MISO : PA6 (arduino_spi)

--- a/boards/st/nucleo_wl55jc/nucleo_wl55jc.dts
+++ b/boards/st/nucleo_wl55jc/nucleo_wl55jc.dts
@@ -115,8 +115,8 @@ stm32_lp_tick_source: &lptim1 {
 	status = "okay";
 };
 
-&i2c2 {
-	pinctrl-0 = <&i2c2_scl_pa12 &i2c2_sda_pa11>;
+&i2c3 {
+	pinctrl-0 = <&i2c3_scl_pb13 &i2c3_sda_pb14>;
 	pinctrl-names = "default";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;


### PR DESCRIPTION
Fixed wrong I2C bus being enabled (i2c2 instead of i2c3) and corresponding arduino nexus mappings so that I2C works correctly on Arduino shields attached to Nucleo-WL55JC.


<img width="555" alt="image" src="https://github.com/user-attachments/assets/39c58211-b7fb-4a37-bb71-d212a3036fd4">
