### PR TITLE
doc: doxygen: fix include paths

### DIFF
--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -174,7 +174,10 @@ FULL_PATH_NAMES        = YES
 # will be relative from the directory where doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        = @ZEPHYR_BASE@/include
+STRIP_FROM_PATH        = @ZEPHYR_BASE@/include \
+                         @ZEPHYR_BASE@/kernel/include/ \
+                         @ZEPHYR_BASE@/lib/ \
+                         @ZEPHYR_BASE@/subsys/testsuite/ztest/include/
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which
@@ -923,13 +926,16 @@ WARN_LOGFILE           =
 
 INPUT                  = @ZEPHYR_BASE@/doc/_doxygen/mainpage.md \
                          @ZEPHYR_BASE@/doc/_doxygen/groups.dox \
-                         @ZEPHYR_BASE@/kernel/include/kernel_arch_interface.h \
-                         @ZEPHYR_BASE@/include/zephyr/arch/cache.h \
-                         @ZEPHYR_BASE@/include/zephyr/sys/atomic.h \
                          @ZEPHYR_BASE@/include/ \
+                         @ZEPHYR_BASE@/kernel/include/kernel_arch_interface.h \
                          @ZEPHYR_BASE@/lib/libc/minimal/include/ \
                          @ZEPHYR_BASE@/subsys/testsuite/include/ \
                          @ZEPHYR_BASE@/subsys/testsuite/ztest/include/
+
+# Note that when adding paths to INPUT you most likely want to add them
+# to STRIP_FROM_PATH as well, which will remove those parts from
+# the paths of the #include examples and the file list
+# in the generated documentation.
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
See commit details.

Examples of what this fixes from the current documentation:

- https://docs.zephyrproject.org/3.7.0/doxygen/html/group__arch-timing.html#gaffc9f3013d53e72c25243ce4f972549f
  `#include </home/runner/_work/zephyr/zephyr/kernel/include/kernel_arch_interface.h>`

- https://docs.zephyrproject.org/3.7.0/doxygen/html/group__fff__extensions.html#ga4a4e81f6291e0bfbe7f60e0a03c2e9b1
  `#include </home/runner/_work/zephyr/zephyr/subsys/testsuite/include/zephyr/fff_extensions.h>`