### PR TITLE
MAINTAINERS: add intc_gic drivers to the ARM platform area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -202,6 +202,7 @@ ARM Platforms:
     - soc/arm/fvp_aemv8*/
     - dts/arm/armv*.dtsi
     - dts/bindings/arm/arm*.yaml
+    - drivers/interrupt_controller/intc_gic*
   labels:
     - "platform: ARM"
 


### PR DESCRIPTION
Add drivers/interrupt_controller/intc_gic* to the ARM area so they get assigned to the ARM maintainers directly.