### PR TITLE
tests: drivers: counter: basic_api: Fix for failures on nrf54h20/cpuppr

### DIFF
--- a/drivers/counter/counter_nrfx_timer.c
+++ b/drivers/counter/counter_nrfx_timer.c
@@ -89,6 +89,7 @@ static uint32_t read(const struct device *dev)
 
 	nrf_timer_task_trigger(timer,
 			       nrf_timer_capture_task_get(COUNTER_READ_CC));
+	nrf_barrier_w();
 
 	return nrf_timer_cc_get(timer, COUNTER_READ_CC);
 }
@@ -160,6 +161,7 @@ static int set_cc(const struct device *dev, uint8_t id, uint32_t val,
 	 */
 	now = read(dev);
 	prev_val = nrf_timer_cc_get(reg, chan);
+	nrf_barrier_r();
 	nrf_timer_cc_set(reg, chan, now);
 	nrf_timer_event_clear(reg, evt);
 

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -900,7 +900,7 @@ static void test_cancelled_alarm_does_not_expire_instance(const struct device *d
 {
 	int err;
 	uint32_t cnt;
-	uint32_t us = 1500;
+	uint32_t us = 1000;
 	uint32_t ticks = counter_us_to_ticks(dev, us);
 	uint32_t top = counter_get_top_value(dev);
 


### PR DESCRIPTION
Previous attempt (331442f05) was not correct and it only prolonged the test twice. It turned out that there was a bug in the driver. Reverting previous change and fixing the driver.

Fixes #75450.