### PR TITLE
Bluetooth: Mesh: Fix build warning with gcc 13

### DIFF
--- a/subsys/bluetooth/mesh/proxy_srv.c
+++ b/subsys/bluetooth/mesh/proxy_srv.c
@@ -783,7 +783,7 @@ static int gatt_proxy_advertise(void)
 {
 	int err;
 
-	int32_t max_adv_duration;
+	int32_t max_adv_duration = 0;
 	int cnt;
 	struct bt_mesh_subnet *sub;
 	struct proxy_adv_request request;


### PR DESCRIPTION
gcc 13 thinks  max_adv_duration may be used unitialized and warns accordingly (see below)
It seems the reason is the goto, which confuses it. In any case, pacifying this warning is trivial,
so let's just do so.

The warning:
```
In function ‘gatt_proxy_advertise’,
inlined from ‘bt_mesh_proxy_adv_start’ at
subsys/bluetooth/mesh/proxy_srv.c:1214:9:
subsys/bluetooth/mesh/proxy_srv.c:842:44: error: ‘max_adv_duration’ may
be used uninitialized [-Werror=maybe-uninitialized]
subsys/bluetooth/mesh/proxy_srv.c: In function ‘bt_mesh_proxy_adv_start’
zephyr/subsys/bluetooth/mesh/proxy_srv.c:786:17: note:
‘max_adv_duration’ was declared here
  786 |         int32_t max_adv_duration;
      |                 ^~~~~~~~~~~~~~~~
```