### PR TITLE
twister: pytest: Capture and log error messages from subprocess

### DIFF
--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -16,6 +16,7 @@ import time
 import shutil
 import json
 
+from pytest import ExitCode
 from twisterlib.reports import ReportStatus
 from twisterlib.error import ConfigurationError
 from twisterlib.environment import ZEPHYR_BASE, PYTEST_PLUGIN_INSTALLED
@@ -354,6 +355,7 @@ class Pytest(Harness):
         self.report_file = os.path.join(self.running_dir, 'report.xml')
         self.pytest_log_file_path = os.path.join(self.running_dir, 'twister_harness.log')
         self.reserved_serial = None
+        self._output = []
 
     def pytest_run(self, timeout):
         try:
@@ -487,7 +489,7 @@ class Pytest(Harness):
             env=env
         ) as proc:
             try:
-                reader_t = threading.Thread(target=self._output_reader, args=(proc, self), daemon=True)
+                reader_t = threading.Thread(target=self._output_reader, args=(proc,), daemon=True)
                 reader_t.start()
                 reader_t.join(timeout)
                 if reader_t.is_alive():
@@ -500,6 +502,13 @@ class Pytest(Harness):
             except subprocess.TimeoutExpired:
                 self.status = TwisterStatus.FAIL
                 proc.kill()
+
+        if proc.returncode in (ExitCode.INTERRUPTED, ExitCode.USAGE_ERROR, ExitCode.INTERNAL_ERROR):
+            self.status = TwisterStatus.ERROR
+            self.instance.reason = f'Pytest error - return code {proc.returncode}'
+            with open(self.pytest_log_file_path, 'w') as log_file:
+                log_file.write(shlex.join(cmd) + '\n\n')
+                log_file.write('\n'.join(self._output))
 
     @staticmethod
     def _update_command_with_env_dependencies(cmd):
@@ -523,14 +532,15 @@ class Pytest(Harness):
 
         return cmd, env
 
-    @staticmethod
-    def _output_reader(proc, harness):
+    def _output_reader(self, proc):
+        self._output = []
         while proc.stdout.readable() and proc.poll() is None:
             line = proc.stdout.readline().decode().strip()
             if not line:
                 continue
+            self._output.append(line)
             logger.debug('PYTEST: %s', line)
-            harness.parse_record(line)
+            self.parse_record(line)
         proc.communicate()
 
     def _update_test_status(self):


### PR DESCRIPTION
Updated the Pytest-Harness methods to capture and log error messages from the subprocess, when pytest command fails.
Ensured that error messages are logged with `--inline-log` option and placed in twister log reports.

Without this change, when pytest fails without creating any report (e.g. when pytest fails to start: has problem with loading fixtures, importing packages, has provided not implemented arguments ..) then Twister does not log any error message from pytest, instead Twister uses `build.log` file.

To test changes, one can:
* call pytest with args that are not implemented
   ` ./scripts/twister -T samples/subsys/testsuite/pytest/shell -p native_sim --pytest-args=--can-context=zcan0 -c --inline-logs`
* add to project `conftest.py` file with import errors
* import from test file not installed package