### PR TITLE
drivers: adc: SAM0: Enable automatic result devision when oversampling

### DIFF
--- a/drivers/adc/adc_sam0.c
+++ b/drivers/adc/adc_sam0.c
@@ -180,7 +180,6 @@ static int adc_sam0_channel_setup(const struct device *dev,
 #endif
 	}
 
-
 	uint32_t inputctrl = 0;
 
 	switch (channel_cfg->gain) {
@@ -258,7 +257,6 @@ static int adc_sam0_channel_setup(const struct device *dev,
 		break;
 	}
 
-
 	return 0;
 }
 
@@ -328,6 +326,12 @@ static int start_read(const struct device *dev,
 	}
 
 	adc->AVGCTRL.reg = ADC_AVGCTRL_SAMPLENUM(sequence->oversampling);
+	if (sequence->oversampling < 4) {
+		adc->AVGCTRL.reg |= ADC_AVGCTRL_ADJRES(sequence->oversampling);
+	} else {
+		adc->AVGCTRL.reg |= ADC_AVGCTRL_ADJRES(4);
+	}
+
 	/* AVGCTRL is not synchronized */
 
 #ifdef CONFIG_SOC_SERIES_SAMD20


### PR DESCRIPTION
The SAM0 ADC has an internal register to divide the accumulated results of oversampling the ADC by the amount of samples collected. This value has to be set by the driver and was missing.

Fixes  #74607