### PR TITLE
sensors: voltage_divider: Reconfigure ADC for the channel to be used

### DIFF
--- a/drivers/sensor/voltage_divider/voltage.c
+++ b/drivers/sensor/voltage_divider/voltage.c
@@ -40,6 +40,14 @@ static int fetch(const struct device *dev, enum sensor_channel chan)
 	/* Wait until sampling is valid */
 	k_sleep(data->earliest_sample);
 
+	/* configure the active channel to be converted */
+	ret = adc_channel_setup_dt(&config->voltage.port);
+	if (ret != 0) {
+		LOG_ERR("adc_setup failed: %d", ret);
+		return ret;
+	}
+
+	/* start conversion */
 	ret = adc_read(config->voltage.port.dev, &data->sequence);
 	if (ret != 0) {
 		LOG_ERR("adc_read: %d", ret);


### PR DESCRIPTION
Some ADCs (e.g. SAM0) can only convert one channel at a time and therefore need to be reconfigured for every voltage divider prior to startin the conversion.

In the current implementation only one channel (whichever was initialized last) will be converted.

Fixes: #76732