### PR TITLE
DRV2605 DT Property Cleanup

### DIFF
--- a/drivers/haptics/drv2605.c
+++ b/drivers/haptics/drv2605.c
@@ -124,6 +124,10 @@ LOG_MODULE_REGISTER(DRV2605, CONFIG_HAPTICS_LOG_LEVEL);
 
 #define DRV2605_POWER_UP_DELAY_US 250
 
+#define DRV2605_VOLTAGE_SCALE_FACTOR_MV 5600
+
+#define DRV2605_CALCULATE_VOLTAGE(_volt) ((_volt * 255) / DRV2605_VOLTAGE_SCALE_FACTOR_MV)
+
 struct drv2605_config {
 	struct i2c_dt_spec i2c;
 	struct gpio_dt_spec en_gpio;
@@ -452,6 +456,11 @@ static int drv2605_hw_config(const struct device *dev)
 		return ret;
 	}
 
+	ret = i2c_reg_write_byte_dt(&config->i2c, DRV2605_REG_RATED_VOLTAGE, config->rated_voltage);
+	if (ret < 0) {
+		return ret;
+	}
+
 	return 0;
 }
 
@@ -600,6 +609,7 @@ static const struct haptics_driver_api drv2605_driver_api = {
 		.feedback_brake_factor = DT_INST_ENUM_IDX(inst, feedback_brake_factor),            \
 		.loop_gain = DT_INST_ENUM_IDX(inst, loop_gain),                                    \
 		.actuator_mode = DT_INST_ENUM_IDX(inst, actuator_mode),                            \
+		.rated_voltage = DRV2605_CALCULATE_VOLTAGE(DT_INST_PROP(inst, vib_rated_mv)),      \
 	};                                                                                         \
                                                                                                    \
 	static struct drv2605_data drv2605_data_##inst = {                                         \

--- a/drivers/haptics/drv2605.c
+++ b/drivers/haptics/drv2605.c
@@ -461,6 +461,12 @@ static int drv2605_hw_config(const struct device *dev)
 		return ret;
 	}
 
+	ret = i2c_reg_write_byte_dt(&config->i2c, DRV2605_REG_OVERDRIVE_CLAMP_VOLTAGE,
+				    config->overdrive_clamp_voltage);
+	if (ret < 0) {
+		return ret;
+	}
+
 	return 0;
 }
 
@@ -610,6 +616,8 @@ static const struct haptics_driver_api drv2605_driver_api = {
 		.loop_gain = DT_INST_ENUM_IDX(inst, loop_gain),                                    \
 		.actuator_mode = DT_INST_ENUM_IDX(inst, actuator_mode),                            \
 		.rated_voltage = DRV2605_CALCULATE_VOLTAGE(DT_INST_PROP(inst, vib_rated_mv)),      \
+		.overdrive_clamp_voltage =                                                         \
+			DRV2605_CALCULATE_VOLTAGE(DT_INST_PROP(inst, vib_overdrive_mv)),           \
 	};                                                                                         \
                                                                                                    \
 	static struct drv2605_data drv2605_data_##inst = {                                         \

--- a/drivers/haptics/drv2605.c
+++ b/drivers/haptics/drv2605.c
@@ -597,9 +597,9 @@ static const struct haptics_driver_api drv2605_driver_api = {
 		.i2c = I2C_DT_SPEC_INST_GET(inst),                                                 \
 		.en_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, en_gpios, {}),                           \
 		.in_trig_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, in_trig_gpios, {}),                 \
-		.feedback_brake_factor = DT_INST_ENUM_IDX_OR(inst, feedback_brake_factor, 3),      \
-		.loop_gain = DT_INST_ENUM_IDX_OR(inst, loop_gain, 2),                              \
-		.actuator_mode = DT_INST_ENUM_IDX_OR(inst, actuator_mode, 0),                      \
+		.feedback_brake_factor = DT_INST_ENUM_IDX(inst, feedback_brake_factor),            \
+		.loop_gain = DT_INST_ENUM_IDX(inst, loop_gain),                                    \
+		.actuator_mode = DT_INST_ENUM_IDX(inst, actuator_mode),                            \
 	};                                                                                         \
                                                                                                    \
 	static struct drv2605_data drv2605_data_##inst = {                                         \

--- a/drivers/haptics/drv2605.c
+++ b/drivers/haptics/drv2605.c
@@ -90,6 +90,9 @@ LOG_MODULE_REGISTER(DRV2605, CONFIG_HAPTICS_LOG_LEVEL);
 #define DRV2605_LOOP_GAIN            GENMASK(3, 2)
 #define DRV2605_BEMF_GAIN            GENMASK(1, 0)
 
+#define DRV2605_ACTUATOR_MODE_ERM 0
+#define DRV2605_ACTUATOR_MODE_LRA 1
+
 #define DRV2605_REG_CONTROL1  0x1b
 #define DRV2605_STARTUP_BOOST BIT(7)
 #define DRV2605_AC_COUPLE     BIT(5)
@@ -465,6 +468,14 @@ static int drv2605_hw_config(const struct device *dev)
 				    config->overdrive_clamp_voltage);
 	if (ret < 0) {
 		return ret;
+	}
+
+	if (config->actuator_mode == DRV2605_ACTUATOR_MODE_LRA) {
+		ret = i2c_reg_update_byte_dt(&config->i2c, DRV2605_REG_CONTROL3,
+					     DRV2605_LRA_OPEN_LOOP, DRV2605_LRA_OPEN_LOOP);
+		if (ret < 0) {
+			return ret;
+		}
 	}
 
 	return 0;

--- a/drivers/haptics/drv2605.c
+++ b/drivers/haptics/drv2605.c
@@ -124,12 +124,6 @@ LOG_MODULE_REGISTER(DRV2605, CONFIG_HAPTICS_LOG_LEVEL);
 
 #define DRV2605_POWER_UP_DELAY_US 250
 
-enum drv2605_pm_state {
-	DRV2605_PM_STATE_SHUTDOWN,
-	DRV2605_PM_STATE_STANDBY,
-	DRV2605_PM_STATE_ACTIVE,
-};
-
 struct drv2605_config {
 	struct i2c_dt_spec i2c;
 	struct gpio_dt_spec en_gpio;

--- a/drivers/haptics/drv2605.c
+++ b/drivers/haptics/drv2605.c
@@ -601,11 +601,11 @@ static const struct haptics_driver_api drv2605_driver_api = {
                                                                                                    \
 	static const struct drv2605_config drv2605_config_##inst = {                               \
 		.i2c = I2C_DT_SPEC_INST_GET(inst),                                                 \
-		.en_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, ti_en_gpios, {}),                        \
-		.in_trig_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, ti_in_trig_gpios, {}),              \
-		.feedback_brake_factor = DT_INST_ENUM_IDX_OR(inst, ti_feedback_brake_factor, 3),   \
-		.loop_gain = DT_INST_ENUM_IDX_OR(inst, ti_loop_gain, 2),                           \
-		.actuator_mode = DT_INST_ENUM_IDX_OR(inst, ti_actuator_mode, 0),                   \
+		.en_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, en_gpios, {}),                           \
+		.in_trig_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, in_trig_gpios, {}),                 \
+		.feedback_brake_factor = DT_INST_ENUM_IDX_OR(inst, feedback_brake_factor, 3),      \
+		.loop_gain = DT_INST_ENUM_IDX_OR(inst, loop_gain, 2),                              \
+		.actuator_mode = DT_INST_ENUM_IDX_OR(inst, actuator_mode, 0),                      \
 	};                                                                                         \
                                                                                                    \
 	static struct drv2605_data drv2605_data_##inst = {                                         \

--- a/dts/bindings/haptics/ti,drv2605.yaml
+++ b/dts/bindings/haptics/ti,drv2605.yaml
@@ -49,6 +49,12 @@ properties:
     description: |
       Sets the reference voltage for full-scale output during closed-loop
       operation. The default value is inherited from ti,drv260x.yaml in Linux.
+  vib-overdrive-mv:
+    type: int
+    default: 3200
+    description: |
+      Sets a clamp so that the automatic overdrive is bounded. The default
+      value is inherited from ti,drv260x.yaml in Linux.
   en-gpios:
     type: phandle-array
     description: GPIO to enable and disable the device.

--- a/dts/bindings/haptics/ti,drv2605.yaml
+++ b/dts/bindings/haptics/ti,drv2605.yaml
@@ -27,6 +27,11 @@ properties:
       - "8X"
       - "16X"
       - "DISABLED"
+    default: "3X"
+    description: |
+      Selects the feedback gain ratio between braking gain and driving gain.
+      According to the datasheet, a value of 2 ("3X") is valid for most
+      actuators.
   loop-gain:
     type: string
     enum:
@@ -34,6 +39,10 @@ properties:
       - "MEDIUM"
       - "HIGH"
       - "VERY_HIGH"
+    default: "HIGH"
+    description: |
+      Selects a loop gain for the feedback control. According to the datasheet,
+      a value of 2 ("HIGH") is valid for most actuators.
   en-gpios:
     type: phandle-array
     description: GPIO to enable and disable the device.

--- a/dts/bindings/haptics/ti,drv2605.yaml
+++ b/dts/bindings/haptics/ti,drv2605.yaml
@@ -11,6 +11,7 @@ include: i2c-device.yaml
 
 properties:
   actuator-mode:
+    required: true
     type: string
     enum:
       - "ERM"

--- a/dts/bindings/haptics/ti,drv2605.yaml
+++ b/dts/bindings/haptics/ti,drv2605.yaml
@@ -43,6 +43,12 @@ properties:
     description: |
       Selects a loop gain for the feedback control. According to the datasheet,
       a value of 2 ("HIGH") is valid for most actuators.
+  vib-rated-mv:
+    type: int
+    default: 3200
+    description: |
+      Sets the reference voltage for full-scale output during closed-loop
+      operation. The default value is inherited from ti,drv260x.yaml in Linux.
   en-gpios:
     type: phandle-array
     description: GPIO to enable and disable the device.

--- a/dts/bindings/haptics/ti,drv2605.yaml
+++ b/dts/bindings/haptics/ti,drv2605.yaml
@@ -33,3 +33,9 @@ properties:
       - "MEDIUM"
       - "HIGH"
       - "VERY_HIGH"
+  en-gpios:
+    type: phandle-array
+    description: GPIO to enable and disable the device.
+  in-trig-gpios:
+    type: phandle-array
+    description: GPIO to trigger ROM waveforms or drive an input signal.

--- a/tests/drivers/build_all/haptics/i2c.dtsi
+++ b/tests/drivers/build_all/haptics/i2c.dtsi
@@ -11,4 +11,6 @@ drv2605@0 {
 	compatible = "ti,drv2605";
 	reg = <0x0>;
 	status = "okay";
+
+	actuator-mode = "LRA";
 };


### PR DESCRIPTION
https://github.com/zephyrproject-rtos/zephyr/pull/76343#discussion_r1713519188
Address the issues raised by this comment:
- Drop manufacturer prefix from properties in the driver
- Document the GPIOs in the devicetree bindings