### PR TITLE
sys: lists: Remove static keyword from local variable in Z_GENLIST_LEN

### DIFF
--- a/include/zephyr/sys/list_gen.h
+++ b/include/zephyr/sys/list_gen.h
@@ -260,10 +260,10 @@
 	}
 
 #define Z_GENLIST_LEN(__lname, __nname)                                                            \
-	static inline size_t sys_##__lname##_len(sys_##__lname##_t * list)                         \
+	static inline size_t sys_##__lname##_len(sys_##__lname##_t *list)                          \
 	{                                                                                          \
 		size_t len = 0;                                                                    \
-		static sys_##__nname##_t * node;                                                   \
+		sys_##__nname##_t *node;                                                           \
 		Z_GENLIST_FOR_EACH_NODE(__lname, list, node) {                                     \
 			len++;                                                                     \
 		}                                                                                  \


### PR DESCRIPTION
The `Z_GENLIST_LEN` macro had the `node` variable defined as `static`, which is unnecessary and could prevent the compiler from optimizing it as a register variable.

This commit removes the `static` keyword, allowing for better optimization and consistent behavior across different invocations of the macro.