### PR TITLE
kscan: mark the kscan driver class as deprecated

### DIFF
--- a/doc/hardware/peripherals/kscan.rst
+++ b/doc/hardware/peripherals/kscan.rst
@@ -4,8 +4,12 @@
 Keyboard Scan
 #############
 
+.. note:: Kscan APIs are deprecated, any driver and applications should be
+   ported over to use :ref:`input` instead.
+
 Overview
 ********
+
 The kscan driver (keyboard scan matrix) is used for detecting a key press in a
 connected matrix keyboard or any device with buttons such as joysticks.
 Typically, matrix keyboards are implemented using a two-dimensional

--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -47,6 +47,8 @@ Deprecated in this release
 * Deprecated the :c:func:`net_buf_put` and :c:func:`net_buf_get` API functions in favor of
   :c:func:`k_fifo_put` and :c:func:`k_fifo_get`.
 
+* The :ref:`kscan_api` subsystem has been marked as deprecated.
+
 Architectures
 *************
 

--- a/drivers/kscan/Kconfig
+++ b/drivers/kscan/Kconfig
@@ -4,7 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig KSCAN
-	bool "Keyboard scan drivers"
+	bool "Keyboard scan drivers [DEPRECATED]"
+	select DEPRECATED
 	help
 	  Include Keyboard scan drivers in system config.
 

--- a/include/zephyr/drivers/kscan.h
+++ b/include/zephyr/drivers/kscan.h
@@ -30,11 +30,13 @@ extern "C" {
  * @defgroup kscan_interface Keyboard Scan Driver APIs
  * @since 2.1
  * @version 1.0.0
+ * @deprecated
  * @ingroup io_interfaces
  * @{
  */
 
 /**
+ * @deprecated
  * @brief Keyboard scan callback called when user press/release
  * a key on a matrix keyboard.
  *
@@ -48,6 +50,7 @@ typedef void (*kscan_callback_t)(const struct device *dev, uint32_t row,
 				 bool pressed);
 
 /**
+ * @deprecated
  * @cond INTERNAL_HIDDEN
  *
  * Keyboard scan driver API definition and system call entry points.
@@ -69,6 +72,7 @@ __subsystem struct kscan_driver_api {
  */
 
 /**
+ * @deprecated
  * @brief Configure a Keyboard scan instance.
  *
  * @param dev Pointer to the device structure for the driver instance.
@@ -90,6 +94,7 @@ static inline int z_impl_kscan_config(const struct device *dev,
 	return api->config(dev, callback);
 }
 /**
+ * @deprecated
  * @brief Enables callback.
  * @param dev Pointer to the device structure for the driver instance.
  *
@@ -111,6 +116,7 @@ static inline int z_impl_kscan_enable_callback(const struct device *dev)
 }
 
 /**
+ * @deprecated
  * @brief Disables callback.
  * @param dev Pointer to the device structure for the driver instance.
  *


### PR DESCRIPTION
All kscan drivers have been moved over to input, Mark the kscan driver class as deprecated so it can be removed in the 4.2 release.