### PR TITLE
drivers: eth: fix stm32_hal PHY address resolution

### DIFF
--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -59,7 +59,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #if defined(CONFIG_MDIO)
 
 #define DEVICE_PHY_BY_NAME(n) \
-	    DEVICE_DT_GET(DT_CHILD(DT_INST_CHILD(n, mdio), ethernet_phy_0))
+	    DEVICE_DT_GET(DT_CHILD(DT_INST_CHILD(n, mdio), __CONCAT(ethernet_phy_, PHY_ADDR)))
 
 static const struct device *eth_stm32_phy_dev = DEVICE_PHY_BY_NAME(0);
 


### PR DESCRIPTION
Hi all 👋

We recently faced an issue with a custom board where the PHY is hardware designed to be talked to on its address `1`.

Our mdio node of the device tree is therefore labeled `ethernet-phy@1`. And we defined in the board conf `CONFIG_ETH_STM32_HAL_PHY_ADDRESS=1`.

But still, compilation fails because the HAL expects the DTS node to be only `ethernet-phy@0`.

This hard coded `ethernet_phy_0` was set during the ethernet driver rework during PR #71012 