### PR TITLE
drivers: video: Add SMH option for video buffer

### DIFF
--- a/drivers/video/Kconfig
+++ b/drivers/video/Kconfig
@@ -35,6 +35,21 @@ config VIDEO_BUFFER_POOL_ALIGN
 	int "Alignment of the video pool’s buffer"
 	default 64
 
+config VIDEO_BUFFER_USE_SHARED_MULTI_HEAP
+	bool "Use shared multi heap for video buffer"
+	default n
+
+config VIDEO_BUFFER_SMH_ATTRIBUTE
+	int "Shared multi heap attribute for video buffer"
+	depends on VIDEO_BUFFER_USE_SHARED_MULTI_HEAP
+	default 0
+	range 0 2
+	help
+	  Shared multi heap attribute for video buffer:
+	  0: SMH_REG_ATTR_CACHEABLE
+	  1: SMH_REG_ATTR_NON_CACHEABLE
+	  2: SMH_REG_ATTR_EXTERNAL
+
 source "drivers/video/Kconfig.esp32_dvp"
 
 source "drivers/video/Kconfig.mcux_csi"

--- a/drivers/video/video_common.c
+++ b/drivers/video/video_common.c
@@ -7,9 +7,18 @@
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/video.h>
 
-K_HEAP_DEFINE(video_buffer_pool,
-	      CONFIG_VIDEO_BUFFER_POOL_SZ_MAX *
-	      CONFIG_VIDEO_BUFFER_POOL_NUM_MAX);
+#if defined(CONFIG_VIDEO_BUFFER_USE_SHARED_MULTI_HEAP)
+#include <zephyr/multi_heap/shared_multi_heap.h>
+
+#define VIDEO_COMMON_HEAP_ALLOC(align, size, timeout)                                              \
+	shared_multi_heap_aligned_alloc(CONFIG_VIDEO_BUFFER_SMH_ATTRIBUTE, align, size)
+#define VIDEO_COMMON_FREE(block) shared_multi_heap_free(block)
+#else
+K_HEAP_DEFINE(video_buffer_pool, CONFIG_VIDEO_BUFFER_POOL_SZ_MAX*CONFIG_VIDEO_BUFFER_POOL_NUM_MAX);
+#define VIDEO_COMMON_HEAP_ALLOC(align, size, timeout)                                              \
+	k_heap_aligned_alloc(&video_buffer_pool, align, size, timeout);
+#define VIDEO_COMMON_FREE(block) k_heap_free(&video_buffer_pool, block)
+#endif
 
 static struct video_buffer video_buf[CONFIG_VIDEO_BUFFER_POOL_NUM_MAX];
 
@@ -39,7 +48,7 @@ struct video_buffer *video_buffer_aligned_alloc(size_t size, size_t align)
 	}
 
 	/* Alloc buffer memory */
-	block->data = k_heap_aligned_alloc(&video_buffer_pool, align, size, K_FOREVER);
+	block->data = VIDEO_COMMON_HEAP_ALLOC(align, size, K_FOREVER);
 	if (block->data == NULL) {
 		return NULL;
 	}
@@ -71,6 +80,6 @@ void video_buffer_release(struct video_buffer *vbuf)
 
 	vbuf->buffer = NULL;
 	if (block) {
-		k_heap_free(&video_buffer_pool, block->data);
+		VIDEO_COMMON_FREE(block->data);
 	}
 }


### PR DESCRIPTION
This commit enables the user to choose whether to
allocate the video buffer from the video heap pool
or use a memory region with specific extra capabilities,
such as being cacheable/non-cacheable or using external
memory.
