### PR TITLE
arch/arm64/mmu: allow partial unmap of block mappings again

### DIFF
--- a/arch/arm64/core/mmu.c
+++ b/arch/arm64/core/mmu.c
@@ -373,6 +373,11 @@ static void del_mapping(uint64_t *table, uintptr_t virt, size_t size,
 			continue;
 		}
 
+		if (step != level_size && is_block_desc(*pte)) {
+			/* need to split this block mapping */
+			expand_to_table(pte, level);
+		}
+
 		if (is_table_desc(*pte, level)) {
 			subtable = pte_desc_table(*pte);
 			del_mapping(subtable, virt, step, level + 1);
@@ -380,12 +385,6 @@ static void del_mapping(uint64_t *table, uintptr_t virt, size_t size,
 				continue;
 			}
 			dec_table_ref(subtable);
-		} else {
-			/*
-			 * We assume that block mappings will be unmapped
-			 * as a whole and not partially.
-			 */
-			__ASSERT(step == level_size, "");
 		}
 
 		/* free this entry */


### PR DESCRIPTION
Before commit baa70d8d361c ("arch/arm64/mmu: fix page table reference
counting part 2")  it was possible to perform a partial unmap of a block
mapping. Restore that ability and provide a test case to validate it.
