### PR TITLE
boards: nxp: frdm_ke17z512: update dts to update bus_clk divider

### DIFF
--- a/boards/nxp/frdm_ke17z512/frdm_ke17z512.dts
+++ b/boards/nxp/frdm_ke17z512/frdm_ke17z512.dts
@@ -100,6 +100,12 @@
 	status = "okay";
 };
 
+&scg {
+	bus_clk {
+		clock-div = <2>;
+	};
+};
+
 &gpioe {
 	status = "okay";
 };


### PR DESCRIPTION
Update the bus_clk divider value from 4 to 2 for frdm_ke17z512 platform. The bus and flash clocks are raised to 24Mhz to ensure that `tests.kernel.timer.timer_jitter_drift` sample passes.

Fix: https://github.com/zephyrproject-rtos/zephyr/issues/76862.