### PR TITLE
west: hal_rpi_pico: Update Pico-SDK to 2.0.0

### DIFF
--- a/drivers/flash/flash_rpi_pico.c
+++ b/drivers/flash/flash_rpi_pico.c
@@ -171,9 +171,9 @@ void __no_inline_not_in_flash_func(flash_write_partial)(uint32_t flash_offs, con
 {
 	rom_connect_internal_flash_fn connect_internal_flash = (rom_connect_internal_flash_fn)
 					rom_func_lookup_inline(ROM_FUNC_CONNECT_INTERNAL_FLASH);
-	rom_flash_exit_xip_fn flash_exit_xip = (rom_flash_exit_xip_fn)
+	rom_flash_exit_xip_fn exit_xip = (rom_flash_exit_xip_fn)
 						rom_func_lookup_inline(ROM_FUNC_FLASH_EXIT_XIP);
-	rom_flash_flush_cache_fn flash_flush_cache = (rom_flash_flush_cache_fn)
+	rom_flash_flush_cache_fn flush_cache = (rom_flash_flush_cache_fn)
 						rom_func_lookup_inline(ROM_FUNC_FLASH_FLUSH_CACHE);
 
 	flash_init_boot2_copyout();
@@ -181,9 +181,9 @@ void __no_inline_not_in_flash_func(flash_write_partial)(uint32_t flash_offs, con
 	__compiler_memory_barrier();
 
 	connect_internal_flash();
-	flash_exit_xip();
+	exit_xip();
 	flash_write_partial_internal(flash_offs, data, count);
-	flash_flush_cache();
+	flush_cache();
 	flash_enable_xip_via_boot2();
 }
 

--- a/drivers/gpio/gpio_rpi_pico.c
+++ b/drivers/gpio/gpio_rpi_pico.c
@@ -192,7 +192,7 @@ static const struct gpio_driver_api gpio_rpi_driver_api = {
 static void gpio_rpi_isr(const struct device *dev)
 {
 	struct gpio_rpi_data *data = dev->data;
-	io_irq_ctrl_hw_t *irq_ctrl_base;
+	io_bank0_irq_ctrl_hw_t *irq_ctrl_base;
 	const io_rw_32 *status_reg;
 	uint32_t events;
 	uint32_t pin;

--- a/modules/hal_rpi_pico/CMakeLists.txt
+++ b/modules/hal_rpi_pico/CMakeLists.txt
@@ -8,7 +8,7 @@ if(CONFIG_HAS_RPI_PICO)
   set(rp2_common_dir ${ZEPHYR_HAL_RPI_PICO_MODULE_DIR}/src/rp2_common)
   set(rp2040_dir ${ZEPHYR_HAL_RPI_PICO_MODULE_DIR}/src/rp2040)
   set(common_dir ${ZEPHYR_HAL_RPI_PICO_MODULE_DIR}/src/common)
-  set(boot_stage_dir ${rp2_common_dir}/boot_stage2)
+  set(boot_stage_dir ${rp2040_dir}/boot_stage2)
 
   # The Second Stage Bootloader is only linked to the app that resides
   # at 0x100. Therefore, only if the app's offset is 0x100, the second
@@ -46,6 +46,8 @@ if(CONFIG_HAS_RPI_PICO)
       zephyr_library_sources(${rp2_bootloader_asm})
   endif()
 
+  zephyr_compile_definitions(PICO_RP2040)
+
   # Pico sources and headers necessary for every build.
   # These contain definitions and implementation used mostly for
   # initializing the SoC, and therefore are always required.
@@ -55,11 +57,12 @@ if(CONFIG_HAS_RPI_PICO)
     ${rp2_common_dir}/hardware_pll/pll.c
     ${rp2_common_dir}/hardware_xosc/xosc.c
     ${rp2_common_dir}/hardware_watchdog/watchdog.c
-    ${rp2_common_dir}/pico_platform/platform.c
     ${rp2_common_dir}/pico_bootrom/bootrom.c
+    ${rp2040_dir}/pico_platform/platform.c
   )
 
   zephyr_include_directories(
+    ${common_dir}/pico_base_headers/include
     ${rp2_common_dir}/hardware_base/include
     ${rp2_common_dir}/hardware_clocks/include
     ${rp2_common_dir}/hardware_watchdog/include
@@ -69,11 +72,18 @@ if(CONFIG_HAS_RPI_PICO)
     ${rp2_common_dir}/hardware_sync/include
     ${rp2_common_dir}/hardware_timer/include
     ${rp2_common_dir}/hardware_resets/include
+    ${rp2_common_dir}/hardware_boot_lock/include
+    ${rp2_common_dir}/hardware_ticks/include
+    ${rp2_common_dir}/hardware_sync_spin_lock/include
     ${rp2_common_dir}/pico_bootrom/include
+    ${rp2_common_dir}/pico_platform_compiler/include
+    ${rp2_common_dir}/pico_platform_sections/include
+    ${rp2_common_dir}/pico_platform_panic/include
+    ${common_dir}/boot_picoboot_headers/include
+    ${common_dir}/boot_picobin_headers/include
     ${rp2040_dir}/hardware_regs/include
     ${rp2040_dir}/hardware_structs/include
-    ${common_dir}/pico_base/include
-    ${rp2_common_dir}/pico_platform/include
+    ${rp2040_dir}/pico_platform/include
     ${CMAKE_CURRENT_LIST_DIR}
   )
 
@@ -108,15 +118,15 @@ if(CONFIG_HAS_RPI_PICO)
   zephyr_include_directories_ifdef(CONFIG_PICOSDK_USE_TIMER
           ${rp2_common_dir}/hardware_timer/include)
 
-  zephyr_library_sources_ifdef(CONFIG_PICOSDK_USE_CLAIM
-          ${rp2_common_dir}/hardware_claim/claim.c)
-  zephyr_include_directories_ifdef(CONFIG_PICOSDK_USE_CLAIM
-          ${rp2_common_dir}/hardware_claim/include)
-
   zephyr_library_sources_ifdef(CONFIG_PICOSDK_USE_RTC
           ${rp2_common_dir}/hardware_rtc/rtc.c)
   zephyr_include_directories_ifdef(CONFIG_PICOSDK_USE_RTC
           ${rp2_common_dir}/hardware_rtc/include)
+
+  zephyr_library_sources_ifdef(CONFIG_PICOSDK_USE_PIO
+          ${rp2_common_dir}/hardware_pio/pio.c)
+  zephyr_include_directories_ifdef(CONFIG_PICOSDK_USE_PIO
+          ${rp2_common_dir}/hardware_pio/include)
 
   # Some flash driver functions must be executed from the RAM.
   # Originally pico-sdk places them in the RW data section, so this
@@ -130,14 +140,9 @@ if(CONFIG_HAS_RPI_PICO)
     COMPILE_FLAGS $<TARGET_PROPERTY:compiler,warning_no_pointer_arithmetic>
   )
 
-  zephyr_library_sources_ifdef(CONFIG_PICOSDK_USE_PIO
-          ${rp2_common_dir}/hardware_pio/pio.c)
-  zephyr_include_directories_ifdef(CONFIG_PICOSDK_USE_PIO
-          ${rp2_common_dir}/hardware_pio/include)
-
   zephyr_library_sources_ifdef(CONFIG_PICOSDK_USE_CLAIM
-          ${rp2_common_dir}/hardware_claim/claim.c)
+          ${common_dir}/hardware_claim/claim.c)
   zephyr_include_directories_ifdef(CONFIG_PICOSDK_USE_CLAIM
-          ${rp2_common_dir}/hardware_claim/include)
+          ${common_dir}/hardware_claim/include)
 
 endif()

--- a/modules/hal_rpi_pico/bootloader/CMakeLists.txt
+++ b/modules/hal_rpi_pico/bootloader/CMakeLists.txt
@@ -11,7 +11,7 @@ enable_language(ASM)
 set(rp2_common_dir ${ZEPHYR_HAL_RPI_PICO_MODULE_DIR}/src/rp2_common)
 set(rp2040_dir ${ZEPHYR_HAL_RPI_PICO_MODULE_DIR}/src/rp2040)
 set(common_dir ${ZEPHYR_HAL_RPI_PICO_MODULE_DIR}/src/common)
-set(boot_stage_dir ${rp2_common_dir}/boot_stage2)
+set(boot_stage_dir ${rp2040_dir}/boot_stage2)
 
 add_executable(boot_stage2)
 
@@ -34,9 +34,12 @@ target_sources(boot_stage2 PRIVATE ${boot_stage_dir}/${flash_type_file})
 target_include_directories(boot_stage2 PUBLIC
   ..
   ${boot_stage_dir}/asminclude
-  ${rp2_common_dir}/pico_platform/include
+  ${rp2040_dir}/pico_platform/include
   ${rp2040_dir}/hardware_regs/include
-  ${common_dir}/pico_base/include
+  ${common_dir}/pico_base_headers/include
+  ${rp2_common_dir}/pico_platform_compiler/include
+  ${rp2_common_dir}/pico_platform_sections/include
+  ${rp2_common_dir}/pico_platform_panic/include
   ${ZEPHYR_BASE}/include
   )
 

--- a/west.yml
+++ b/west.yml
@@ -219,7 +219,7 @@ manifest:
         - hal
     - name: hal_rpi_pico
       path: modules/hal/rpi_pico
-      revision: fba7162cc7bee06d0149622bbcaac4e41062d368
+      revision: 79ee0f9e058a6327fc943d2f2a19cf3ade107cec
       groups:
         - hal
     - name: hal_silabs


### PR DESCRIPTION
Update Pico-SDK to 2.0.0 release.

- The directory structure has changed in 2.0.0, so we update it accordingly.
- Following the GPIO interface changes in pico-sdk 2.0.0.
- Some symbol names have been conflicted with introducing pico-sdk 2.0.0. Rename these.
