### PR TITLE
Change instructions on how to track deprecated items for removal and add a few more links

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -949,6 +949,8 @@ config DEPRECATED
 	help
 	  Symbol that must be selected by a feature or module if it is
 	  considered to be deprecated.
+	  When adding this to an option, remember to follow the instructions in
+	  https://docs.zephyrproject.org/latest/develop/api/api_lifecycle.html#deprecated
 
 config WARN_DEPRECATED
 	bool

--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -37,6 +37,8 @@ config BOARD_DEPRECATED_RELEASE
 	  the Zephyr release that the board configuration will be removed.
 	  When set, any build for that board will generate a clearly visible
 	  deprecation warning.
+	  When adding this to a BOARD, remember to follow the instructions in
+	  https://docs.zephyrproject.org/latest/develop/api/api_lifecycle.html#deprecated
 
 config QEMU_TARGET
 	bool

--- a/boards/deprecated.cmake
+++ b/boards/deprecated.cmake
@@ -1,12 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# This file contains boards in Zephyr which has been replaced with a new board
+# This file contains boards in Zephyr which have been replaced with a new board
 # name.
 # This allows the system to automatically change the board while at the same
 # time prints a warning to the user, that the board name is deprecated.
 #
 # To add a board rename, add a line in following format:
 # set(<old_board_name>_DEPRECATED <new_board_name>)
+#
+# When adding board aliases here, remember to add a mention in the corresponding GitHub issue
+# tracking the removal of API/options
+# https://docs.zephyrproject.org/latest/develop/api/api_lifecycle.html#deprecated,
+# so these aliases are eventually removed
 
 set(96b_carbon_DEPRECATED
     96b_carbon/stm32f401xe

--- a/doc/develop/api/api_lifecycle.rst
+++ b/doc/develop/api/api_lifecycle.rst
@@ -236,9 +236,9 @@ The following are the requirements for deprecating an existing API:
   - Code using the deprecated API needs to be modified to remove usage of said
     API
   - The change needs to be atomic and bisectable
-  - Create a GitHub issue to track the removal of the deprecated API, and
-    add it to the roadmap targeting the appropriate release
-    (in the example above, 1.16).
+  - Add an entry in the corresponding release
+    `GitHub issue <https://github.com/zephyrproject-rtos/zephyr/labels/deprecation_tracker>`_
+    tracking removal of deprecated APIs.
 
 During the deprecation waiting period, the API will be in the ``deprecated``
 state. The Zephyr maintainers will track usage of deprecated APIs on

--- a/doc/develop/api/api_lifecycle.rst
+++ b/doc/develop/api/api_lifecycle.rst
@@ -219,8 +219,8 @@ The following are the requirements for deprecating an existing API:
 
 - Deprecation Time (stable APIs): 2 Releases
   The API needs to be marked as deprecated in at least two full releases.
-  For example, if an API was first deprecated in release 1.14,
-  it will be ready to be removed in 1.16 at the earliest.
+  For example, if an API was first deprecated in release 4.0,
+  it will be ready to be removed in 4.2 at the earliest.
   There may be special circumstances, determined by the Architecture working group,
   where an API is deprecated sooner.
 - What is required when deprecating:
@@ -239,6 +239,7 @@ The following are the requirements for deprecating an existing API:
   - Add an entry in the corresponding release
     `GitHub issue <https://github.com/zephyrproject-rtos/zephyr/labels/deprecation_tracker>`_
     tracking removal of deprecated APIs.
+    In this example in the one corresponding to the 4.2 release.
 
 During the deprecation waiting period, the API will be in the ``deprecated``
 state. The Zephyr maintainers will track usage of deprecated APIs on

--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -250,6 +250,9 @@ do {                                                                    \
 
 #ifndef __deprecated
 #define __deprecated	__attribute__((deprecated))
+/* When adding this, remember to follow the instructions in
+ * https://docs.zephyrproject.org/latest/develop/api/api_lifecycle.html#deprecated
+ */
 #endif
 
 #ifndef __attribute_const__
@@ -312,6 +315,9 @@ do {                                                                    \
 /* Generic message */
 #ifndef __DEPRECATED_MACRO
 #define __DEPRECATED_MACRO __WARN("Macro is deprecated")
+/* When adding this, remember to follow the instructions in
+ * https://docs.zephyrproject.org/latest/develop/api/api_lifecycle.html#deprecated
+ */
 #endif
 
 /* These macros allow having ARM asm functions callable from thumb */

--- a/soc/Kconfig
+++ b/soc/Kconfig
@@ -58,6 +58,8 @@ config SOC_DEPRECATED_RELEASE
 	  the Zephyr release that the SoC configuration will be removed.
 	  When set, any build for that SoC will generate a clearly visible
 	  deprecation warning.
+	  When adding this to a SOC, remember to follow the instructions in
+	  https://docs.zephyrproject.org/latest/develop/api/api_lifecycle.html#deprecated
 
 config SOC_HAS_TIMING_FUNCTIONS
 	bool


### PR DESCRIPTION
Following the discussion in discord: https://discord.com/channels/720317445772017664/733037890514321419/1272496160308723754

Let's change the docs, so we tell developers to add to one GitHub issue tracking all deprecated APIs meant to be removed, so the process is simpler and hopefully developers do it.

Let's also add a few references from the options they use so we remind developers to do so.
