### PR TITLE
LE Audio: add conn parameter for bt_vcp_vol_rend_cb

### DIFF
--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -147,6 +147,12 @@ Bluetooth Mesh
 Bluetooth Audio
 ===============
 
+* The Volume Renderer callback functions :code:`bt_vcp_vol_rend_cb.state` and
+  :code:`bt_vcp_vol_rend_cb.flags` for VCP now contain an additional parameter for
+  the connection.
+  This needs to be added to all instances of VCP Volume Renderer callback functions defined.
+  (:github:`76992`)
+
 Bluetooth Classic
 =================
 

--- a/include/zephyr/bluetooth/audio/vcp.h
+++ b/include/zephyr/bluetooth/audio/vcp.h
@@ -163,12 +163,14 @@ struct bt_vcp_vol_rend_cb {
 	 * bt_vcp_vol_rend_get_state(), or if the state is changed by either
 	 * the Volume Renderer or a remote Volume Controller.
 	 *
+	 * @param conn    Pointer to the connection to a remote device if
+	 *                the change was caused by it, otherwise NULL.
 	 * @param err     Error value. 0 on success, GATT error on positive value
 	 *                or errno on negative value.
 	 * @param volume  The volume of the Volume Control Service server.
 	 * @param mute    The mute setting of the Volume Control Service server.
 	 */
-	void (*state)(int err, uint8_t volume, uint8_t mute);
+	void (*state)(struct bt_conn *conn, int err, uint8_t volume, uint8_t mute);
 
 	/**
 	 * @brief Callback function for Volume Control Service flags.
@@ -177,11 +179,13 @@ struct bt_vcp_vol_rend_cb {
 	 * Called when the value is remotely read as the client.
 	 * Called if the value is changed by either the server or client.
 	 *
+	 * @param conn    Pointer to the connection to a remote device if
+	 *                the change was caused by it, otherwise NULL.
 	 * @param err     Error value. 0 on success, GATT error on positive value
 	 *                or errno on negative value.
 	 * @param flags   The flags of the Volume Control Service server.
 	 */
-	void (*flags)(int err, uint8_t flags);
+	void (*flags)(struct bt_conn *conn, int err, uint8_t flags);
 };
 
 /**

--- a/samples/bluetooth/hap_ha/src/vcp_vol_renderer.c
+++ b/samples/bluetooth/hap_ha/src/vcp_vol_renderer.c
@@ -18,7 +18,7 @@
 
 static struct bt_vcp_included vcp_included;
 
-static void vcs_state_cb(int err, uint8_t volume, uint8_t mute)
+static void vcs_state_cb(struct bt_conn *conn, int err, uint8_t volume, uint8_t mute)
 {
 	if (err) {
 		printk("VCS state get failed (%d)\n", err);
@@ -27,7 +27,7 @@ static void vcs_state_cb(int err, uint8_t volume, uint8_t mute)
 	}
 }
 
-static void vcs_flags_cb(int err, uint8_t flags)
+static void vcs_flags_cb(struct bt_conn *conn, int err, uint8_t flags)
 {
 	if (err) {
 		printk("VCS flags get failed (%d)\n", err);

--- a/samples/bluetooth/tmap_bmr/src/vcp_vol_renderer.c
+++ b/samples/bluetooth/tmap_bmr/src/vcp_vol_renderer.c
@@ -19,7 +19,7 @@
 
 static struct bt_vcp_included vcp_included;
 
-static void vcs_state_cb(int err, uint8_t volume, uint8_t mute)
+static void vcs_state_cb(struct bt_conn *conn, int err, uint8_t volume, uint8_t mute)
 {
 	if (err) {
 		printk("VCS state get failed (%d)\n", err);
@@ -28,7 +28,7 @@ static void vcs_state_cb(int err, uint8_t volume, uint8_t mute)
 	}
 }
 
-static void vcs_flags_cb(int err, uint8_t flags)
+static void vcs_flags_cb(struct bt_conn *conn, int err, uint8_t flags)
 {
 	if (err) {
 		printk("VCS flags get failed (%d)\n", err);

--- a/samples/bluetooth/tmap_peripheral/src/vcp_vol_renderer.c
+++ b/samples/bluetooth/tmap_peripheral/src/vcp_vol_renderer.c
@@ -19,7 +19,7 @@
 
 static struct bt_vcp_included vcp_included;
 
-static void vcs_state_cb(int err, uint8_t volume, uint8_t mute)
+static void vcs_state_cb(struct bt_conn *conn, int err, uint8_t volume, uint8_t mute)
 {
 	if (err) {
 		printk("VCS state get failed (%d)\n", err);
@@ -28,7 +28,7 @@ static void vcs_state_cb(int err, uint8_t volume, uint8_t mute)
 	}
 }
 
-static void vcs_flags_cb(int err, uint8_t flags)
+static void vcs_flags_cb(struct bt_conn *conn, int err, uint8_t flags)
 {
 	if (err) {
 		printk("VCS flags get failed (%d)\n", err);

--- a/subsys/bluetooth/audio/shell/vcp_vol_rend.c
+++ b/subsys/bluetooth/audio/shell/vcp_vol_rend.c
@@ -28,7 +28,7 @@
 
 static struct bt_vcp_included vcp_included;
 
-static void vcp_vol_rend_state_cb(int err, uint8_t volume, uint8_t mute)
+static void vcp_vol_rend_state_cb(struct bt_conn *conn, int err, uint8_t volume, uint8_t mute)
 {
 	if (err) {
 		shell_error(ctx_shell, "VCP state get failed (%d)", err);
@@ -37,7 +37,7 @@ static void vcp_vol_rend_state_cb(int err, uint8_t volume, uint8_t mute)
 	}
 }
 
-static void vcp_vol_rend_flags_cb(int err, uint8_t flags)
+static void vcp_vol_rend_flags_cb(struct bt_conn *conn, int err, uint8_t flags)
 {
 	if (err) {
 		shell_error(ctx_shell, "VCP flags get failed (%d)", err);

--- a/subsys/bluetooth/audio/vcp_vol_rend.c
+++ b/subsys/bluetooth/audio/vcp_vol_rend.c
@@ -269,8 +269,7 @@ static ssize_t write_vcs_control(struct bt_conn *conn,
 		value_changed(&vol_rend, NOTIFY_STATE);
 
 		if (vol_rend.cb && vol_rend.cb->state) {
-			vol_rend.cb->state(0, vol_rend.state.volume,
-					       vol_rend.state.mute);
+			vol_rend.cb->state(conn, 0, vol_rend.state.volume, vol_rend.state.mute);
 		}
 	}
 
@@ -282,7 +281,7 @@ static ssize_t write_vcs_control(struct bt_conn *conn,
 		}
 
 		if (vol_rend.cb && vol_rend.cb->flags) {
-			vol_rend.cb->flags(0, vol_rend.flags);
+			vol_rend.cb->flags(conn, 0, vol_rend.flags);
 		}
 	}
 	return len;
@@ -524,8 +523,7 @@ int bt_vcp_vol_rend_set_step(uint8_t volume_step)
 int bt_vcp_vol_rend_get_state(void)
 {
 	if (vol_rend.cb && vol_rend.cb->state) {
-		vol_rend.cb->state(0, vol_rend.state.volume,
-				   vol_rend.state.mute);
+		vol_rend.cb->state(NULL, 0, vol_rend.state.volume, vol_rend.state.mute);
 	}
 
 	return 0;
@@ -534,7 +532,7 @@ int bt_vcp_vol_rend_get_state(void)
 int bt_vcp_vol_rend_get_flags(void)
 {
 	if (vol_rend.cb && vol_rend.cb->flags) {
-		vol_rend.cb->flags(0, vol_rend.flags);
+		vol_rend.cb->flags(NULL, 0, vol_rend.flags);
 	}
 
 	return 0;

--- a/tests/bluetooth/tester/src/audio/btp_vcp.c
+++ b/tests/bluetooth/tester/src/audio/btp_vcp.c
@@ -144,12 +144,12 @@ static uint8_t unmute(const void *cmd, uint16_t cmd_len,
 	return BTP_STATUS_SUCCESS;
 }
 
-static void vcs_state_cb(int err, uint8_t volume, uint8_t mute)
+static void vcs_state_cb(struct bt_conn *conn, int err, uint8_t volume, uint8_t mute)
 {
 	LOG_DBG("VCP state cb err (%d)", err);
 }
 
-static void vcs_flags_cb(int err, uint8_t flags)
+static void vcs_flags_cb(struct bt_conn *conn, int err, uint8_t flags)
 {
 	LOG_DBG("VCP flags cb err (%d)", err);
 }

--- a/tests/bsim/bluetooth/audio/src/vcp_vol_rend_test.c
+++ b/tests/bsim/bluetooth/audio/src/vcp_vol_rend_test.c
@@ -54,7 +54,7 @@ static volatile bool g_aics_active = 1;
 static char g_aics_desc[AICS_DESC_SIZE];
 static volatile bool g_cb;
 
-static void vcs_state_cb(int err, uint8_t volume, uint8_t mute)
+static void vcs_state_cb(struct bt_conn *conn, int err, uint8_t volume, uint8_t mute)
 {
 	if (err != 0) {
 		FAIL("VCP state cb err (%d)", err);
@@ -66,7 +66,7 @@ static void vcs_state_cb(int err, uint8_t volume, uint8_t mute)
 	g_cb = true;
 }
 
-static void vcs_flags_cb(int err, uint8_t flags)
+static void vcs_flags_cb(struct bt_conn *conn, int err, uint8_t flags)
 {
 	if (err != 0) {
 		FAIL("VCP flags cb err (%d)", err);


### PR DESCRIPTION
Add conn parameter to status/flags callbacks of bt_vcp_vol_rend_cb to differentiate between remote and local changes.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/76988