### PR TITLE
tests: drivers: clock control of stm32wba serie

### DIFF
--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32wba_core/boards/clear_clocks.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32wba_core/boards/clear_clocks.overlay
@@ -11,11 +11,7 @@
 
 &clk_hse {
 	status = "disabled";
-	/delete-property/ hse-div;
-};
-
-&clk_hsi {
-	status = "disabled";
+	/delete-property/ hse-div2;
 };
 
 &clk_lse {

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32wba_core/testcase.yaml
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32wba_core/testcase.yaml
@@ -1,10 +1,10 @@
 common:
   timeout: 5
-  platform_allow: nucleo_wba52cg
+  platform_allow: nucleo_wba52cg nucleo_wba55cg
 tests:
-  drivers.clock.stm32_clock_configuration.wba.sysclksrc_hsi_32:
+  drivers.clock.stm32_clock_configuration.wba.sysclksrc_hsi_16:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/hsi_16.overlay"
-  drivers.clock.stm32_clock_configuration.wba.sysclksrc_hsi_32_ahb5_div:
+  drivers.clock.stm32_clock_configuration.wba.sysclksrc_hsi_16_ahb5_div:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/hsi_16_ahb5_div.overlay"
   drivers.clock.stm32_clock_configuration.wba.sysclksrc_hse_16:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/hse_16.overlay"


### PR DESCRIPTION
Add the nucleo_wba55 target for running the test clock configuration. 
HSI must not be disabled else no more clock present

