### PR TITLE
dts: bindings: fix typo in icm42688

### DIFF
--- a/dts/bindings/sensor/invensense,icm42688.yaml
+++ b/dts/bindings/sensor/invensense,icm42688.yaml
@@ -74,10 +74,10 @@ properties:
       Specify the accelerometer range in g.
       Default is power-up configuration.
     enum:
-      - 0 # ICM42688_DT_ACCEL_FS_16G
-      - 1 # ICM42688_DT_ACCEL_FS_8G
-      - 2 # ICM42688_DT_ACCEL_FS_4G
-      - 3 # ICM42688_DT_ACCEL_FS_2G
+      - 0 # ICM42688_DT_ACCEL_FS_16
+      - 1 # ICM42688_DT_ACCEL_FS_8
+      - 2 # ICM42688_DT_ACCEL_FS_4
+      - 3 # ICM42688_DT_ACCEL_FS_2
 
   gyro-pwr-mode:
     type: int


### PR DESCRIPTION
accelerometer range is not suffixed with 'G' in the header and also in the usages, but bindings use with suffix 'G'. remove the suffix 'G' to have same reference.

Signed-off-by: Parthiban Nallathambi <parthiban@linumiz.com>