### PR TITLE
boards/st/stm32f429i_disc1: add pyocd support

### DIFF
--- a/boards/st/stm32f429i_disc1/board.cmake
+++ b/boards/st/stm32f429i_disc1/board.cmake
@@ -2,7 +2,11 @@
 
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 board_runner_args(jlink "--device=STM32F429ZI" "--speed=4000")
+board_runner_args(pyocd "--target=stm32f429xi")
+board_runner_args(pyocd "--flash-opt=-O reset_type=hw")
+board_runner_args(pyocd "--flash-opt=-O connect_mode=under-reset")
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)


### PR DESCRIPTION
This PR enables pyOCD support for the STM32F429I Discovery board. Without this change, the following error would appear:

```
Error: Failed to read memory at 0xe0042008
Error: read_memory: read at 0xe0042004 with width=32 and count=1 failed
Error executing event examine-end on target STM32F429ZITx.cpu:
/home/roagen/zephyr-sdk-0.16.8/sysroots/x86_64-pokysdk-linux/usr/share/openocd/scripts/mem_helper.tcl:5: Error: read_memory: failed to read memory
in procedure 'ocd_process_reset' 
in procedure 'ocd_process_reset_inner' called at file "embedded:startup.tcl", line 876
in procedure 'mmw' called at file "/home/roagen/zephyr-sdk-0.16.8/sysroots/x86_64-pokysdk-linux/usr/share/openocd/scripts/target/stm32f4x.cfg", line 87
in procedure 'mrw' called at file "/home/roagen/zephyr-sdk-0.16.8/sysroots/x86_64-pokysdk-linux/usr/share/openocd/scripts/mem_helper.tcl", line 30
at file "/home/roagen/zephyr-sdk-0.16.8/sysroots/x86_64-pokysdk-linux/usr/share/openocd/scripts/mem_helper.tcl", line 5
Info : [STM32F429ZITx.cpu] AP write error, reset will not halt
Error: [STM32F429ZITx.cpu] DP initialisation failed
```