### PR TITLE
arch: common: Add user can specify the nocache location

### DIFF
--- a/arch/common/nocache.ld
+++ b/arch/common/nocache.ld
@@ -7,6 +7,12 @@
 
 /* Copied from linker.ld */
 
+#if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_nocache_ram), okay)
+#define NOCACHE_REGION LINKER_DT_NODE_REGION_NAME_TOKEN(DT_CHOSEN(zephyr_nocache_ram))
+#else
+#define NOCACHE_REGION RAMABLE_REGION
+#endif
+
 /* Non-cached region of RAM */
 SECTION_DATA_PROLOGUE(_NOCACHE_SECTION_NAME,(NOLOAD),)
 {
@@ -27,5 +33,5 @@ SECTION_DATA_PROLOGUE(_NOCACHE_SECTION_NAME,(NOLOAD),)
 	MPU_ALIGN(_nocache_ram_size);
 #endif
 	_nocache_ram_end = .;
-} GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
+} GROUP_DATA_LINK_IN(NOCACHE_REGION, NOCACHE_REGION)
 _nocache_ram_size = _nocache_ram_end - _nocache_ram_start;


### PR DESCRIPTION
nocache memory is usually used by DMA to transfer data between
peripherals and memory. Some chips may separate memory block
for nocache,which does not necessarily have to be in RAMABLE-REGION.
By specifying the zephyr,nocache options,users can specify the region
where Nocache is located.If the user does not specify it, it defaults
to RAMABLE-REGION.