### PR TITLE
net: openthread: Fix missing dependency for OT `diag` shell.

### DIFF
--- a/modules/hal_nordic/Kconfig
+++ b/modules/hal_nordic/Kconfig
@@ -204,6 +204,7 @@ config NRF_802154_SECURITY_KEY_STORAGE_SIZE
 
 config NRF_802154_CARRIER_FUNCTIONS
 	bool "nRF 802.15.4 carrier functions"
+	default y if OPENTHREAD_DIAG
 	help
 	  This option enables functions such as modulated carrier and continuous carrier.
 	  If this option is modified on a multicore SoC, its remote counterpart must be set to the exact same value.


### PR DESCRIPTION
Commit fixes missing dependency for `ot diag cw` command for nrf5xx by adding default vale to `NRF_802154_CARRIER_FUNCTIONS`.
