### PR TITLE
input/touch: add common size/inverted/swap properties

### DIFF
--- a/doc/services/input/index.rst
+++ b/doc/services/input/index.rst
@@ -109,3 +109,8 @@ Analog Axis API Reference
 *************************
 
 .. doxygengroup:: input_analog_axis
+
+Touchscreen API Reference
+*************************
+
+.. doxygengroup:: touch_events

--- a/drivers/input/CMakeLists.txt
+++ b/drivers/input/CMakeLists.txt
@@ -26,6 +26,7 @@ zephyr_library_sources_ifdef(CONFIG_INPUT_PINNACLE input_pinnacle.c)
 zephyr_library_sources_ifdef(CONFIG_INPUT_PMW3610 input_pmw3610.c)
 zephyr_library_sources_ifdef(CONFIG_INPUT_SBUS input_sbus.c)
 zephyr_library_sources_ifdef(CONFIG_INPUT_STMPE811 input_stmpe811.c)
+zephyr_library_sources_ifdef(CONFIG_INPUT_TOUCH input_touch.c)
 zephyr_library_sources_ifdef(CONFIG_INPUT_XEC_KBD input_xec_kbd.c)
 zephyr_library_sources_ifdef(CONFIG_INPUT_XPT2046 input_xpt2046.c)
 # zephyr-keep-sorted-stop

--- a/drivers/input/Kconfig
+++ b/drivers/input/Kconfig
@@ -29,6 +29,7 @@ source "drivers/input/Kconfig.pmw3610"
 source "drivers/input/Kconfig.sbus"
 source "drivers/input/Kconfig.sdl"
 source "drivers/input/Kconfig.stmpe811"
+source "drivers/input/Kconfig.touch"
 source "drivers/input/Kconfig.xec"
 source "drivers/input/Kconfig.xpt2046"
 # zephyr-keep-sorted-stop

--- a/drivers/input/Kconfig.ft5336
+++ b/drivers/input/Kconfig.ft5336
@@ -7,6 +7,7 @@ menuconfig INPUT_FT5336
 	default y
 	depends on DT_HAS_FOCALTECH_FT5336_ENABLED
 	select I2C
+	select INPUT_TOUCH
 	help
 	  Enable driver for multiple Focaltech capacitive touch panel
 	  controllers. This driver should support FT5x06, FT5606, FT5x16,

--- a/drivers/input/Kconfig.stmpe811
+++ b/drivers/input/Kconfig.stmpe811
@@ -6,5 +6,6 @@ config INPUT_STMPE811
 	default y
 	depends on DT_HAS_ST_STMPE811_ENABLED
 	select I2C
+	select INPUT_TOUCH
 	help
 	  Enable driver for STMPE811 touch panel.

--- a/drivers/input/Kconfig.touch
+++ b/drivers/input/Kconfig.touch
@@ -1,0 +1,7 @@
+# Copyright (c) 2024 Antmicro Ltd <www.antmicro.com>
+# SPDX-License-Identifier: Apache-2.0
+
+config INPUT_TOUCH
+	bool
+	help
+	  Enable library used for touchscreen drivers.

--- a/drivers/input/input_touch.c
+++ b/drivers/input/input_touch.c
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2024 Antmicro <www.antmicro.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/input/input_touch.h>
+
+void input_touchscreen_report_pos(const struct device *dev,
+		uint32_t x, uint32_t y,
+		k_timeout_t timeout)
+{
+	const struct input_touchscreen_common_config *cfg = dev->config;
+	const uint32_t reported_x_code = cfg->swapped_x_y ? INPUT_ABS_Y : INPUT_ABS_X;
+	const uint32_t reported_y_code = cfg->swapped_x_y ? INPUT_ABS_X : INPUT_ABS_Y;
+	const uint32_t reported_x = cfg->inverted_x ? cfg->screen_width - x : x;
+	const uint32_t reported_y = cfg->inverted_y ? cfg->screen_height - y : y;
+
+	input_report_abs(dev, reported_x_code, reported_x, false, timeout);
+	input_report_abs(dev, reported_y_code, reported_y, false, timeout);
+}

--- a/dts/bindings/input/focaltech,ft5336.yaml
+++ b/dts/bindings/input/focaltech,ft5336.yaml
@@ -5,7 +5,7 @@ description: FT3267/FT5XX6/FT6XX6 capacitive touch panels
 
 compatible: "focaltech,ft5336"
 
-include: i2c-device.yaml
+include: [i2c-device.yaml, touchscreen-common.yaml]
 
 properties:
   int-gpios:

--- a/dts/bindings/input/st,stmpe811.yaml
+++ b/dts/bindings/input/st,stmpe811.yaml
@@ -5,7 +5,7 @@ description: STMPE811 I2C touchscreen controller
 
 compatible: "st,stmpe811"
 
-include: i2c-device.yaml
+include: [i2c-device.yaml, touchscreen-common.yaml]
 
 properties:
   int-gpios:
@@ -13,20 +13,6 @@ properties:
     description: |
       Interrupt GPIO. Used by the controller to signal touch data is
       available. Active low.
-
-  screen-width:
-    type: int
-    default: 0
-    description: |
-      Screen width for scaling the reported coordinates.
-      Default: raw touchscreen resolution.
-
-  screen-height:
-    type: int
-    default: 0
-    description: |
-      Screen height for scaling the reported coordinates.
-      Default: raw touchscreen resolution.
 
   raw-x-min:
     type: int

--- a/dts/bindings/input/touchscreen-common.yaml
+++ b/dts/bindings/input/touchscreen-common.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) 2024 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: Apache-2.0
+
+# Common fields for touch controllers
+
+include: base.yaml
+
+properties:
+  screen-width:
+    type: int
+    default: 0
+    description: |
+      Horizontal resolution of touchscreen (maximum x coordinate reported + 1). The default
+      corresponds to a valid value for non-inverted axis, required for a display with an inverted x
+      axis.
+
+  screen-height:
+    type: int
+    default: 0
+    description: |
+      Vertical resolution of touchscreen (maximum y coordinate reported + 1). The default
+      corresponds to a valid value for non-inverted axis, required for a display with an inverted y
+      axis.
+
+  inverted-x:
+    type: boolean
+    description: X axis is inverted.
+
+  inverted-y:
+    type: boolean
+    description: Y axis is inverted.
+
+  swapped-x-y:
+    type: boolean
+    description: X and Y axis are swapped. Swapping is done after inverting the axis.

--- a/include/zephyr/input/input_touch.h
+++ b/include/zephyr/input/input_touch.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2024 Antmicro <www.antmicro.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_INPUT_TOUCH_H_
+#define ZEPHYR_INCLUDE_INPUT_TOUCH_H_
+
+/**
+ * @brief Touch Events API
+ * @defgroup touch_events Touchscreen Event Report API
+ * @since 3.7
+ * @version 0.1.0
+ * @ingroup io_interfaces
+ * @{
+ */
+
+#include <zephyr/input/input.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Common touchscreen config.
+ *
+ * This structure **must** be placed first in the driver's config structure.
+ *
+ * @param screen_width Horizontal resolution of touchscreen
+ * @param screen_height Vertical resolution of touchscreen
+ * @param inverted_x  X axis is inverted
+ * @param inverted_y Y axis is inverted
+ * @param swapped_x_y X and Y axes are swapped
+ *
+ * see touchscreem-common.yaml for more details
+ */
+struct input_touchscreen_common_config {
+	uint32_t screen_width;
+	uint32_t screen_height;
+	bool inverted_x;
+	bool inverted_y;
+	bool swapped_x_y;
+};
+
+/**
+ * @brief Initialize common touchscreen config from devicetree
+ *
+ * @param node_id The devicetree node identifier.
+ */
+#define INPUT_TOUCH_DT_COMMON_CONFIG_INIT(node_id)			\
+	{								\
+		.screen_width = DT_PROP(node_id, screen_width),		\
+		.screen_height = DT_PROP(node_id, screen_height),	\
+		.inverted_x = DT_PROP(node_id, inverted_x),		\
+		.inverted_y = DT_PROP(node_id, inverted_y),		\
+		.swapped_x_y = DT_PROP(node_id, swapped_x_y)		\
+	}
+
+/**
+ * @brief Initialize common touchscreen config from devicetree instance.
+ *
+ * @param inst Instance.
+ */
+#define INPUT_TOUCH_DT_INST_COMMON_CONFIG_INIT(inst) \
+	INPUT_TOUCH_DT_COMMON_CONFIG_INIT(DT_DRV_INST(inst))
+
+/**
+ * @brief Validate the offset of the common config structure.
+ *
+ * @param config Name of the config structure.
+ */
+#define INPUT_TOUCH_STRUCT_CHECK(config) \
+	BUILD_ASSERT(offsetof(config, common) == 0, \
+		     "struct input_touchscreen_common_config must be placed first");
+
+/**
+ * @brief Common utility for reporting touchscreen position events.
+ *
+ * @param dev Touchscreen controller
+ * @param x X coordinate as reported by the controller
+ * @param y Y coordinate as reported by the controller
+ * @param timeout Timeout for reporting the event
+ */
+void input_touchscreen_report_pos(const struct device *dev,
+		uint32_t x, uint32_t y,
+		k_timeout_t timeout);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_INPUT_TOUCH_H_ */


### PR DESCRIPTION
This PR adds common properties for touchscreen drivers: sizes, inverted and swapped axes. It also adds a way of reporting touchscreen events so that aforementioned props are taken into account.

This PR also adds the usage of the new event reporting method for ft5336 and stmpe811 drivers.