### PR TITLE
st,stm32-qspi-nor driver resets flash chip by default and returns JEDEC ID

### DIFF
--- a/boards/st/stm32h745i_disco/stm32h745i_disco_stm32h745xx_m7.dts
+++ b/boards/st/stm32h745i_disco/stm32h745i_disco_stm32h745xx_m7.dts
@@ -184,6 +184,7 @@
 		reg = <0x90000000 DT_SIZE_M(64)>; /* 512 Mbits */
 		qspi-max-frequency = <72000000>;
 		spi-bus-width = <4>;
+		reset-cmd;
 		status = "okay";
 
 		partitions {

--- a/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m7.dts
+++ b/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m7.dts
@@ -255,6 +255,7 @@ zephyr_udc0: &usbotg_hs {
 		reg = <0x90000000 DT_SIZE_M(64)>; /* 512 Mbits */
 		qspi-max-frequency = <72000000>;
 		spi-bus-width = <4>;
+		reset-cmd;
 		status = "okay";
 
 		partitions {

--- a/boards/st/stm32h750b_dk/stm32h750b_dk.dts
+++ b/boards/st/stm32h750b_dk/stm32h750b_dk.dts
@@ -168,6 +168,7 @@
 		reg = <0x90000000 DT_SIZE_M(64)>; /* 512 Mbits */
 		qspi-max-frequency = <72000000>;
 		spi-bus-width = <4>;
+		reset-cmd;
 		status = "okay";
 
 		partitions {

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -35,7 +35,7 @@
 #define STM32_QSPI_BASE_ADDRESS DT_INST_REG_ADDR(0)
 
 #define STM32_QSPI_RESET_GPIO DT_INST_NODE_HAS_PROP(0, reset_gpios)
-#define STM32_QSPI_RESET_CMD DT_PROP(DT_NODELABEL(quadspi), set_cmd)
+#define STM32_QSPI_RESET_CMD  DT_INST_PROP(0, reset_cmd)
 
 #include <stm32_ll_dma.h>
 
@@ -336,8 +336,10 @@ static int qspi_read_jedec_id(const struct device *dev, uint8_t *id)
 		return -EIO;
 	}
 
+	LOG_DBG("Read JESD216-ID");
+
 	dev_data->cmd_status = 0;
-	id = &data[0];
+	memcpy(id, data, JESD216_READ_ID_LEN);
 
 	return 0;
 }
@@ -1270,6 +1272,9 @@ static int flash_stm32_qspi_send_reset(const struct device *dev)
 		LOG_ERR("%d: Failed to send RESET_MEM", ret);
 		return ret;
 	}
+
+	LOG_DBG("Send Reset command");
+
 	return 0;
 }
 #endif


### PR DESCRIPTION
Using the reset-cmd property of the "st,stm32-qspi-nor"  to send the reset cmd correctly on quad-flash init :
 SPI_NOR_CMD_RESET_EN followed by SPI_NOR_CMD_RESET_MEM 
Reports the jedecID correctly.


Fixes https://github.com/zephyrproject-rtos/zephyr/issues/76896


Reading the jedec-ID of the Micro quad-flash of  stm32h750b_dk disco kit gives: `jedec-id = [20 10 44];  `