### PR TITLE
include: cbprintf: drop deprecated CBPRINTF_PACKAGE_COPY_* macros

### DIFF
--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -40,6 +40,7 @@ Removed APIs in this release
 
 * Macro ``K_THREAD_STACK_MEMBER``, deprecated since v3.5.0, has been removed.
   Use :c:macro:`K_KERNEL_STACK_MEMBER` instead.
+* ``CBPRINTF_PACKAGE_COPY_*`` macros, deprecated since Zephyr 3.5.0, have been removed.
 
 Deprecated in this release
 ==========================

--- a/include/zephyr/sys/cbprintf.h
+++ b/include/zephyr/sys/cbprintf.h
@@ -216,8 +216,6 @@ BUILD_ASSERT(Z_IS_POW2(CBPRINTF_PACKAGE_ALIGNMENT));
  * are also checked and if determined to be read-only they are also copied.
  */
 #define CBPRINTF_PACKAGE_CONVERT_RO_STR BIT(0)
-/** @deprecated Use @ref CBPRINTF_PACKAGE_CONVERT_RO_STR instead. */
-#define CBPRINTF_PACKAGE_COPY_RO_STR CBPRINTF_PACKAGE_CONVERT_RO_STR __DEPRECATED_MACRO
 
 /** @brief Append read-write strings from source package to destination package.
  *
@@ -230,8 +228,6 @@ BUILD_ASSERT(Z_IS_POW2(CBPRINTF_PACKAGE_ALIGNMENT));
  * package if @ref CBPRINTF_PACKAGE_CONVERT_KEEP_RO_STR is set.
  */
 #define CBPRINTF_PACKAGE_CONVERT_RW_STR BIT(1)
-/** @deprecated Use @ref CBPRINTF_PACKAGE_CONVERT_RW_STR instead. */
-#define CBPRINTF_PACKAGE_COPY_RW_STR CBPRINTF_PACKAGE_CONVERT_RW_STR __DEPRECATED_MACRO
 
 /** @brief Keep read-only location indexes in the package.
  *
@@ -239,8 +235,6 @@ BUILD_ASSERT(Z_IS_POW2(CBPRINTF_PACKAGE_ALIGNMENT));
  * not set they are discarded.
  */
 #define CBPRINTF_PACKAGE_CONVERT_KEEP_RO_STR BIT(2)
-/** @deprecated Use @ref CBPRINTF_PACKAGE_CONVERT_KEEP_RO_STR instead. */
-#define CBPRINTF_PACKAGE_COPY_KEEP_RO_STR CBPRINTF_PACKAGE_CONVERT_KEEP_RO_STR __DEPRECATED_MACRO
 
 /** @brief Check format string if %p argument was treated as %s in the package.
  *


### PR DESCRIPTION
Commit bb74b4f028c22bbc4a66f5f6ac7b3aebab62f2bb deprecated a few `CBPRINTF_PACKAGE_COPY_*` macros.
This drops them and calls out the change in the release notes.