### PR TITLE
tests: thread_analyzer: limit platforms to run on

### DIFF
--- a/tests/subsys/debug/thread_analyzer/testcase.yaml
+++ b/tests/subsys/debug/thread_analyzer/testcase.yaml
@@ -2,12 +2,18 @@ common:
   integration_platforms:
     - mps2/an385
     - qemu_x86_64
+  platform_allow:
+    # Representative platforms to make sure this builds without issues
+    # and the analyzer actually runs and outputs something.
+    - mps2/an385
+    - qemu_cortex_a53
+    - qemu_x86
+    - qemu_x86_64
+    - qemu_riscv32
+    - qemu_riscv64
   tags:
     - debug
     - thread_analyzer
-  arch_exclude:
-    # The thread analyzer depends on !ARCH_POSIX
-    - posix
 tests:
   debug.thread_analyzer.printk:
     extra_configs:


### PR DESCRIPTION
This adds platform_allow to limit the scope of platforms to build and run. This avoids the need to constantly nudge the platform filter lists to exclude platforms which fail to build or run due to incompatible kconfigs.

Fixes #76945