### PR TITLE
.clang-format: Enable align escape lines right

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -12,6 +12,7 @@
 ---
 BasedOnStyle: LLVM
 AlignConsecutiveMacros: AcrossComments
+AlignEscapedNewlines: LeftWithLastLine
 AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortEnumsOnASingleLine: false


### PR DESCRIPTION
Enable the clang format option to align escaped newlines to a rightmost column.