### PR TITLE
drivers: wifi/airoc: Remove dependency on Infineon SOC family selection

### DIFF
--- a/drivers/wifi/infineon/airoc_wifi.c
+++ b/drivers/wifi/infineon/airoc_wifi.c
@@ -761,7 +761,7 @@ static const struct wifi_mgmt_ops airoc_wifi_mgmt = {
 	.disconnect = airoc_mgmt_disconnect,
 	.ap_enable = airoc_mgmt_ap_enable,
 	.ap_disable = airoc_mgmt_ap_disable,
-#if defined(CONFIG_NET_STATISTICS_ETHERNET)
+#if defined(CONFIG_NET_STATISTICS_WIFI)
 	.get_stats = airoc_mgmt_wifi_stats,
 #endif
 };

--- a/modules/hal_infineon/Kconfig
+++ b/modules/hal_infineon/Kconfig
@@ -77,13 +77,14 @@ config USE_INFINEON_FLASH
 	help
 	  Enable Flash HAL module driver for Infineon devices
 
-config USE_INFINEON_ABSTRACTION_RTOS
-	bool "Abstraction RTOS component (Zephyr support)"
-	help
-	  Enable Abstraction RTOS component with Zephyr support
 config USE_INFINEON_SMIF
 	bool
 	help
 	  Enable SMIF HAL driver for Infineon devices
 
 endif # SOC_FAMILY_INFINEON_CAT1 || SOC_FAMILY_PSOC6_LEGACY
+
+config USE_INFINEON_ABSTRACTION_RTOS
+	bool "Abstraction RTOS component (Zephyr support)"
+	help
+	  Enable Abstraction RTOS component with Zephyr support


### PR DESCRIPTION
Issue:
Kconfig WIFI_AIROC should not depend on infineon SOC family selection for the connection. See https://github.com/zephyrproject-rtos/zephyr/issues/77012 for details.

Fix:
- update modules/hal_infineon/Kconfig to be able enable USE_INFINEON_ABSTRACTION_RTOS for non Infineon SOC family.

- fix CONFIG_NET_STATISTICS_ETHERNET to CONFIG_NET_STATISTICS_WIFI in airoc_wifi.c

Signed-off-by: Nazar Palamar <nazar.palamar@infineon.com>