### PR TITLE
dts: NXP: RW612: Fix FLEXSPI_BASE at Kconfig.defconfig

### DIFF
--- a/soc/nxp/rw/Kconfig.defconfig
+++ b/soc/nxp/rw/Kconfig.defconfig
@@ -53,7 +53,7 @@ config FLASH_SIZE
 if NXP_RW_ROM_RAMLOADER
 
 FLASH_BASE := $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
-FLEXSPI_BASE := $(dt_node_reg_addr_hex,/soc/spi@134000,1)
+FLEXSPI_BASE := $(dt_nodelabel_reg_addr_hex,flexspi,1)
 config BUILD_OUTPUT_ADJUST_LMA
 	default "$(FLEXSPI_BASE) - $(FLASH_BASE)"
 


### PR DESCRIPTION
The values the FLEXSPI_BASE is doing reference are wrong resulting in a problem when the LMA value is calculated for the linker. This is causing a huge output binary files when allocating code from ram to flash.