### PR TITLE
arch: riscv: revert `ARCH_STACK_PTR_ALIGN` change in #76791 to fix #76996

### DIFF
--- a/arch/riscv/core/stacktrace.c
+++ b/arch/riscv/core/stacktrace.c
@@ -227,10 +227,7 @@ void arch_stack_walk(stack_trace_callback_fn callback_fn, void *cookie,
 static bool in_fatal_stack_bound(uintptr_t addr, const struct k_thread *const thread,
 				 const struct arch_esf *esf)
 {
-	const uintptr_t align =
-		COND_CODE_1(CONFIG_FRAME_POINTER, (ARCH_STACK_PTR_ALIGN), (sizeof(uintptr_t)));
-
-	if (!IS_ALIGNED(addr, align)) {
+	if (!IS_ALIGNED(addr, sizeof(uintptr_t))) {
 		return false;
 	}
 

--- a/include/zephyr/arch/riscv/arch.h
+++ b/include/zephyr/arch/riscv/arch.h
@@ -30,13 +30,8 @@
 #include <zephyr/arch/riscv/csr.h>
 #include <zephyr/arch/riscv/exception.h>
 
-#ifdef CONFIG_RISCV_ISA_RV32E
-/* Stack alignment for RV32E is 4 bytes */
-#define ARCH_STACK_PTR_ALIGN  4
-#else
 /* stacks, for RISCV architecture stack should be 16byte-aligned */
 #define ARCH_STACK_PTR_ALIGN  16
-#endif
 
 #define Z_RISCV_STACK_PMP_ALIGN \
 	MAX(CONFIG_PMP_GRANULARITY, ARCH_STACK_PTR_ALIGN)


### PR DESCRIPTION
Partially undo #76045 (but keep the required part to fix the traces output) and partially revert #76791 (but keep the test)

Fixes #76996