### PR TITLE
Bluetooth: Fix 2 kconfig dependencies

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -93,7 +93,7 @@ config BT_SILABS_HCI
 
 config BT_USERCHAN
 	bool "HCI User Channel based driver"
-	depends on BOARD_NATIVE_POSIX
+	depends on (BOARD_NATIVE_POSIX || BOARD_NATIVE_SIM)
 	default y
 	depends on DT_HAS_ZEPHYR_BT_HCI_USERCHAN_ENABLED
 	help

--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -208,7 +208,7 @@ config BT_HCI_VS_FATAL_ERROR
 config BT_HCI_VS_EXT_DETECT
 	bool "Use heuristics to guess HCI vendor extensions support in advance"
 	depends on BT_HCI_VS && !BT_CTLR
-	default y if BOARD_QEMU_X86 || BOARD_QEMU_CORTEX_M3 || BOARD_NATIVE_POSIX
+	default y if BOARD_QEMU_X86 || BOARD_QEMU_CORTEX_M3 || BOARD_NATIVE_POSIX || BOARD_NATIVE_SIM
 	help
 	  Use some heuristics to try to guess in advance whether the controller
 	  supports the HCI vendor extensions in advance, in order to prevent


### PR DESCRIPTION
    drivers/bluetooth/userchan: Fix dependency
    
    The driver can run in either native_posix or native_sim.
    Let's make sure to set the dependencies acordingly.

------

    subsys/bluetooth: Correct BT_HCI_VS_EXT_DETECT default
    
    native_sim should be treated as native_posix.
    Let's fix it.

Note: By now native_sim builds with "native_posix compatibility mode" enabled, which sets BOARD_NATIVE_POSIX to avoid breaking all this kind of dependencies. But that will stop soon. So let's fix the dependencies.