### PR TITLE
Remove references from a few drivers to the native_posix target

### DIFF
--- a/drivers/can/can_native_linux.c
+++ b/drivers/can/can_native_linux.c
@@ -495,9 +495,9 @@ CAN_DEVICE_DT_INST_DEFINE(inst, can_native_linux_init, NULL,			\
 
 DT_INST_FOREACH_STATUS_OKAY(CAN_NATIVE_LINUX_INIT)
 
-static void add_native_posix_options(void)
+static void add_native_options(void)
 {
-	static struct args_struct_t can_native_posix_options[] = {
+	static struct args_struct_t can_native_options[] = {
 		{
 			.is_mandatory = false,
 			.option = "can-if",
@@ -509,7 +509,7 @@ static void add_native_posix_options(void)
 		ARG_TABLE_ENDMARKER,
 	};
 
-	native_add_command_line_opts(can_native_posix_options);
+	native_add_command_line_opts(can_native_options);
 }
 
-NATIVE_TASK(add_native_posix_options, PRE_BOOT_1, 10);
+NATIVE_TASK(add_native_options, PRE_BOOT_1, 10);

--- a/drivers/can/can_native_linux_adapt.h
+++ b/drivers/can/can_native_linux_adapt.h
@@ -8,8 +8,8 @@
  * @brief Private functions for native posix canbus driver.
  */
 
-#ifndef ZEPHYR_DRIVERS_CAN_NATIVE_POSIX_LINUX_SOCKETCAN_H_
-#define ZEPHYR_DRIVERS_CAN_NATIVE_POSIX_LINUX_SOCKETCAN_H_
+#ifndef ZEPHYR_DRIVERS_CAN_NATIVE_LINUX_ADAPT_H_
+#define ZEPHYR_DRIVERS_CAN_NATIVE_LINUX_ADAPT_H_
 
 int linux_socketcan_iface_open(const char *if_name);
 
@@ -21,4 +21,4 @@ int linux_socketcan_read_data(int fd, void *buf, size_t buf_len, bool *msg_confi
 
 int linux_socketcan_set_mode_fd(int fd, bool mode_fd);
 
-#endif /* ZEPHYR_DRIVERS_CAN_NATIVE_POSIX_LINUX_SOCKETCAN_H_ */
+#endif /* ZEPHYR_DRIVERS_CAN_NATIVE_LINUX_ADAPT_H_ */

--- a/drivers/display/display_sdl.c
+++ b/drivers/display/display_sdl.c
@@ -534,7 +534,7 @@ static const struct display_driver_api sdl_display_api = {
 
 DT_INST_FOREACH_STATUS_OKAY(DISPLAY_SDL_DEFINE)
 
-static void display_sdl_native_posix_options(void)
+static void display_sdl_options(void)
 {
 	static struct args_struct_t sdl_display_options[] = {
 		{ .option = "display_zoom_pct",
@@ -551,4 +551,4 @@ static void display_sdl_native_posix_options(void)
 	native_add_command_line_opts(sdl_display_options);
 }
 
-NATIVE_TASK(display_sdl_native_posix_options, PRE_BOOT_1, 1);
+NATIVE_TASK(display_sdl_options, PRE_BOOT_1, 1);

--- a/drivers/eeprom/eeprom_simulator.c
+++ b/drivers/eeprom/eeprom_simulator.c
@@ -275,7 +275,7 @@ DEVICE_DT_INST_DEFINE(0, &eeprom_sim_init, NULL,
 
 #ifdef CONFIG_ARCH_POSIX
 
-static void eeprom_native_posix_cleanup(void)
+static void eeprom_native_cleanup(void)
 {
 	if ((mock_eeprom != MAP_FAILED) && (mock_eeprom != NULL)) {
 		munmap(mock_eeprom, DT_INST_PROP(0, size));
@@ -286,7 +286,7 @@ static void eeprom_native_posix_cleanup(void)
 	}
 }
 
-static void eeprom_native_posix_options(void)
+static void eeprom_native_options(void)
 {
 	static struct args_struct_t eeprom_options[] = {
 		{ .manual = false,
@@ -304,8 +304,7 @@ static void eeprom_native_posix_options(void)
 	native_add_command_line_opts(eeprom_options);
 }
 
-
-NATIVE_TASK(eeprom_native_posix_options, PRE_BOOT_1, 1);
-NATIVE_TASK(eeprom_native_posix_cleanup, ON_EXIT, 1);
+NATIVE_TASK(eeprom_native_options, PRE_BOOT_1, 1);
+NATIVE_TASK(eeprom_native_cleanup, ON_EXIT, 1);
 
 #endif /* CONFIG_ARCH_POSIX */

--- a/drivers/flash/flash_simulator.c
+++ b/drivers/flash/flash_simulator.c
@@ -437,14 +437,14 @@ DEVICE_DT_INST_DEFINE(0, flash_init, NULL,
 
 #ifdef CONFIG_ARCH_POSIX
 
-static void flash_native_posix_cleanup(void)
+static void flash_native_cleanup(void)
 {
 	flash_mock_cleanup_native(flash_in_ram, flash_fd, mock_flash,
 				  FLASH_SIMULATOR_FLASH_SIZE, flash_file_path,
 				  flash_rm_at_exit);
 }
 
-static void flash_native_posix_options(void)
+static void flash_native_options(void)
 {
 	static struct args_struct_t flash_options[] = {
 		{ .option = "flash",
@@ -476,9 +476,8 @@ static void flash_native_posix_options(void)
 	native_add_command_line_opts(flash_options);
 }
 
-
-NATIVE_TASK(flash_native_posix_options, PRE_BOOT_1, 1);
-NATIVE_TASK(flash_native_posix_cleanup, ON_EXIT, 1);
+NATIVE_TASK(flash_native_options, PRE_BOOT_1, 1);
+NATIVE_TASK(flash_native_cleanup, ON_EXIT, 1);
 
 #endif /* CONFIG_ARCH_POSIX */
 


### PR DESCRIPTION
native_posix is being removed. So it is better to not have too many names in the tree that refer to it.
This drivers had native_posix in internal function names or macros which did not need having it.
Let's just replace that.