### PR TITLE
Remove a few references to native_posix in docs and comments

### DIFF
--- a/boards/native/doc/Port_vs_QEMU_vs.svg
+++ b/boards/native/doc/Port_vs_QEMU_vs.svg
@@ -365,19 +365,19 @@
 			<text x="6.39" y="301.76" class="st17" v:langID="6153"><v:paragraph v:horizAlign="1"/><v:tabList/>QEMU</text>		</g>
 		<g id="shape88-174" v:mID="88" v:groupContext="shape" transform="translate(646.299,-127.559)">
 			<title>Sheet.88</title>
-			<desc>native_ posix</desc>
+			<desc>native _sim</desc>
 			<v:textBlock v:margins="rect(4,4,4,4)" v:tabSpace="42.5197"/>
 			<v:textRect cx="32.3082" cy="291.969" width="64.62" height="28.3465"/>
 			<rect x="0" y="277.795" width="64.6164" height="28.3465" class="st3"/>
-			<text x="16.19" y="288.97" class="st9" v:langID="6153"><v:paragraph v:horizAlign="1"/><v:tabList/>native_<v:lf/><tspan
-						x="20.64" dy="1.2em" class="st6">posix</tspan></text>		</g>
+			<text x="16.19" y="288.97" class="st9" v:langID="6153"><v:paragraph v:horizAlign="1"/><v:tabList/>native<v:lf/><tspan
+						x="20.64" dy="1.2em" class="st6">_sim</tspan></text>		</g>
 		<g id="shape89-178" v:mID="89" v:groupContext="shape" transform="translate(302.18,-259.795)">
 			<title>Sheet.89</title>
-			<desc>native_posix</desc>
+			<desc>native_sim</desc>
 			<v:textBlock v:margins="rect(4,4,4,4)" v:tabSpace="42.5197"/>
 			<v:textRect cx="32.3082" cy="291.969" width="64.62" height="28.3465"/>
 			<rect x="0" y="277.795" width="64.6164" height="28.3465" class="st3"/>
-			<text x="4.51" y="294.97" class="st9" v:langID="6153"><v:paragraph v:horizAlign="1"/><v:tabList/>native_posix</text>		</g>
+			<text x="4.51" y="294.97" class="st9" v:langID="6153"><v:paragraph v:horizAlign="1"/><v:tabList/>native_sim</text>		</g>
 		<g id="shape90-181" v:mID="90" v:groupContext="shape" transform="translate(287.819,-267.874)">
 			<title>Sheet.90</title>
 			<v:textBlock v:margins="rect(4,4,4,4)" v:tabSpace="42.5197"/>

--- a/boards/native/doc/arch_soc.rst
+++ b/boards/native/doc/arch_soc.rst
@@ -33,9 +33,9 @@ target hardware in the early phases of development.
 Types of POSIX arch based boards
 ================================
 
-Today there are two types of POSIX boards: The native boards, :ref:`native_posix<native_posix>`
-and :ref:`native_sim<native_sim>`, and the :ref:`bsim boards<bsim boards>`.
-While they share the main objectives and principles, the first are intended as
+Today there are two types of POSIX boards:
+:ref:`native_sim<native_sim>`, and the :ref:`bsim boards<bsim boards>`.
+While they share the main objectives and principles, the first is intended as
 a HW agnostic test platform which in some cases utilizes the host OS
 peripherals, while the second intend to simulate a particular HW platform,
 with focus on their radio (e.g. BT LE) and utilize the `BabbleSim`_ physical layer

--- a/boards/native/doc/layering.svg
+++ b/boards/native/doc/layering.svg
@@ -129,11 +129,11 @@
 						x="42.81" dy="1.2em" class="st4">layering</tspan></text>		</g>
 		<g id="shape14-47" v:mID="14" v:groupContext="shape" transform="translate(244.319,-226.677)">
 			<title>Sheet.14</title>
-			<desc>native_posix/sim &#38; _bsim boards Zephyr layering</desc>
+			<desc>native_sim &#38; _bsim boards Zephyr layering</desc>
 			<v:textBlock v:margins="rect(4,4,4,4)" v:tabSpace="42.5197"/>
 			<v:textRect cx="92.126" cy="250.866" width="184.26" height="28.3465"/>
 			<rect x="0" y="236.693" width="184.252" height="28.3465" class="st7"/>
-			<text x="42.05" y="238.27" class="st8" v:langID="6153"><v:paragraph v:horizAlign="1"/><v:tabList/>native_posix/sim <v:newlineChar/><tspan
+			<text x="60.05" y="238.27" class="st8" v:langID="6153"><v:paragraph v:horizAlign="1"/><v:tabList/>native_sim <v:newlineChar/><tspan
 						x="43.49" dy="1.2em" class="st4">&#38; _bsim boards <v:lf/></tspan><tspan x="43.88" dy="1.2em" class="st4">Zephyr layering</tspan></text>		</g>
 	</g>
 </svg>

--- a/boards/native/nrf_bsim/common/cmdline.h
+++ b/boards/native/nrf_bsim/common/cmdline.h
@@ -5,20 +5,20 @@
  */
 
 /**
- * This header exists solely to allow drivers meant for the native_posix board
- * to be used directly in the nrf52_bsim board.
+ * This header exists solely to allow drivers meant for the native_sim board
+ * to be used directly in the nrf5*_bsim boards.
  * Note that such reuse should be done with great care.
  *
- * The command line arguments parsing logic from native_posix was born as a copy
+ * The command line arguments parsing logic from native_sim was born as a copy
  * of the one from the BabbleSim's libUtil library
  * They are therefore mostly equal except for types and functions names.
  *
- * This header converts these so the native_posix call to dynamically register
- * command line arguments is passed to the nrf52_bsim one
+ * This header converts these so the native_sim call to dynamically register
+ * command line arguments is passed to the nrf*_bsim one
  */
 
-#ifndef BOARDS_POSIX_NRF52_BSIM_CMDLINE_H
-#define BOARDS_POSIX_NRF52_BSIM_CMDLINE_H
+#ifndef BOARDS_POSIX_NRF_BSIM_CMDLINE_H
+#define BOARDS_POSIX_NRF_BSIM_CMDLINE_H
 
 #include "../../native_posix/cmdline_common.h"
 
@@ -36,4 +36,4 @@ static inline void native_add_command_line_opts(struct args_struct_t *args)
 }
 #endif
 
-#endif /* BOARDS_POSIX_NRF52_BSIM_CMDLINE_H */
+#endif /* BOARDS_POSIX_NRF_BSIM_CMDLINE_H */

--- a/include/zephyr/shell/shell.h
+++ b/include/zephyr/shell/shell.h
@@ -191,7 +191,7 @@ typedef int (*shell_dict_cmd_handler)(const struct shell *sh, size_t argc,
 				      char **argv, void *data);
 
 /* When entries are added to the memory section a padding is applied for
- * native_posix_64 and x86_64 targets. Adding padding to allow handle data
+ * the posix architecture with 64bits builds and x86_64 targets. Adding padding to allow handle data
  * in the memory section as array.
  */
 #if (defined(CONFIG_ARCH_POSIX) && defined(CONFIG_64BIT)) || defined(CONFIG_X86_64)

--- a/subsys/testsuite/arch/unit_testing/Kconfig
+++ b/subsys/testsuite/arch/unit_testing/Kconfig
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Current the use of X86 is for consistency with old testsuite/ztest which
-# defined CONFIG_X86 manually. To consider, is NATIVE_POSIX a better choice?
+# defined CONFIG_X86 manually. To consider, is ARCH_POSIX a better choice?
 config X86
 	bool
 	default y


### PR DESCRIPTION
native_posix has been deprecated and will be removed in 2 releases.
Let's remove a few references to it from the docs & figures.

Let's also correct 2 comments which should have reffered to the arch instead of native_posix, and the description in one nrfbsim header.