### PR TITLE
arch: arm64: add fake sys_arch_reboot

### DIFF
--- a/arch/arm64/core/CMakeLists.txt
+++ b/arch/arm64/core/CMakeLists.txt
@@ -9,6 +9,7 @@ zephyr_library_sources(
   irq_init.c
   irq_manage.c
   prep_c.c
+  reboot.c
   reset.S
   reset.c
   switch.S

--- a/arch/arm64/core/reboot.c
+++ b/arch/arm64/core/reboot.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2013-2014 Wind River Systems, Inc.
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief ARM Cortex-A and Cortex-R System Control Block interface
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/sys/util.h>
+
+/**
+ *
+ * @brief Reset the system
+ *
+ * This routine resets the processor.
+ *
+ */
+
+void __weak sys_arch_reboot(int type)
+{
+	ARG_UNUSED(type);
+}


### PR DESCRIPTION
When enabling FlexCAN on i.mx93 (#76195), Sample samples/modules/canopennode is failing to build (and will fail on all other arm64 platforms if they enables CAN, due to sys_arch_reboot is missing. This commit adds a weak sys_arch_reboot to fix it.