### PR TITLE
style: Flow rewrite to avoid skip of init or unreachable code warnings

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1414,15 +1414,14 @@ void shell_uninit(const struct shell *sh, shell_uninit_cb_t cb)
 		/* signal kill message */
 		(void)k_poll_signal_raise(signal, 0);
 
-		return;
-	}
-
-	int err = instance_uninit(sh);
-
-	if (cb) {
-		cb(sh, err);
 	} else {
-		__ASSERT_NO_MSG(0);
+		int err = instance_uninit(sh);
+
+		if (cb) {
+			cb(sh, err);
+		} else {
+			__ASSERT_NO_MSG(0);
+		}
 	}
 }
 


### PR DESCRIPTION
Rewrote code with gotos or if(true) that caused warnings of 
unreachable code or bypassing of variable initialization.

Example of IAR warnings:
                goto bail;
                ^
"~\zephyrproject\zephyr\drivers\timer\nrf_rtc_timer.c",615  Warning[Pe546]: 
   transfer of control bypasses initialization of:
            variable "now" (declared at line 626)