### PR TITLE
samples: drivers: flash_shell: Increase the min_ram size

### DIFF
--- a/samples/drivers/flash_shell/sample.yaml
+++ b/samples/drivers/flash_shell/sample.yaml
@@ -14,6 +14,6 @@ tests:
       - arduino_portenta_h7/stm32h747xx/m4
       - arduino_giga_r1/stm32h747xx/m4
     harness: keyboard
-    min_ram: 12
+    min_ram: 48
     integration_platforms:
       - qemu_x86


### PR DESCRIPTION
Modify the value of min_ram to be able to run the
test flash_shell on the board with 32 ram size.