### PR TITLE
boards: espressif: Add uart1 to esp_wrover_kit

### DIFF
--- a/boards/espressif/esp_wrover_kit/esp_wrover_kit-pinctrl.dtsi
+++ b/boards/espressif/esp_wrover_kit/esp_wrover_kit-pinctrl.dtsi
@@ -21,6 +21,17 @@
 		};
 	};
 
+	uart1_default: uart1_default {
+		group1 {
+			pinmux = <UART1_TX_GPIO32>;
+			output-high;
+		};
+		group2 {
+			pinmux = <UART1_RX_GPIO33>;
+			bias-pull-up;
+		};
+	};
+
 	spim2_default: spim2_default {
 		group1 {
 			pinmux = <SPIM2_MISO_GPIO12>,

--- a/boards/espressif/esp_wrover_kit/esp_wrover_kit_procpu.dts
+++ b/boards/espressif/esp_wrover_kit/esp_wrover_kit_procpu.dts
@@ -103,6 +103,13 @@
 	pinctrl-names = "default";
 };
 
+&uart1 {
+	status = "disabled";
+	current-speed = <115200>;
+	pinctrl-0 = <&uart1_default>;
+	pinctrl-names = "default";
+};
+
 &gpio0 {
 	status = "okay";
 


### PR DESCRIPTION
Extend board capabilities by adding the uart1 node and setting its default `pinctrl`.
This is needed so that `esp-serial-flasher` module can be used in Zephyr.