### PR TITLE
mikroe_ble_tiny_click: Use zephyr,bt-hci-3wire-uart compatible

### DIFF
--- a/boards/shields/mikroe_ble_tiny_click/doc/index.rst
+++ b/boards/shields/mikroe_ble_tiny_click/doc/index.rst
@@ -63,7 +63,7 @@ example:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/bluetooth/beacon
-   :board: ek-ra8m1
+   :board: ek_ra8m1
    :shield: mikroe_ble_tiny_click
    :goals: build
 

--- a/boards/shields/mikroe_ble_tiny_click/mikroe_ble_tiny_click.overlay
+++ b/boards/shields/mikroe_ble_tiny_click/mikroe_ble_tiny_click.overlay
@@ -14,6 +14,6 @@
 	status = "okay";
 
 	bt_hci_uart: bt_hci_uart {
-		compatible = "zephyr,bt-hci-uart";
+		compatible = "zephyr,bt-hci-3wire-uart";
 	};
 };


### PR DESCRIPTION
As UART hardware flow control is disabled we should use zephyr,bt-hci-3wire-uart compatible