### PR TITLE
twister: Fix TypeError at get_installed_packages

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -16,7 +16,7 @@ import sys
 from datetime import datetime, timezone
 from importlib import metadata
 from pathlib import Path
-from typing import Generator
+from typing import Generator, List
 
 from twisterlib.coverage import supported_coverage_formats
 
@@ -49,7 +49,7 @@ def _get_installed_packages() -> Generator[str, None, None]:
         yield dist.metadata['Name']
 
 
-installed_packages: list[str] = list(_get_installed_packages())
+installed_packages: List[str] = list(_get_installed_packages())
 PYTEST_PLUGIN_INSTALLED = 'pytest-twister-harness' in installed_packages
 
 


### PR DESCRIPTION
Fix confusing `TypeError: 'type' object is not subscriptable` at _get_installed_packages() if twister runs on [python version < 3.9](https://docs.python.org/3.9/whatsnew/3.9.html#type-hinting-generics-in-standard-collections) after #76880 
The problem shouldn't appear if Zephyr [install dependencies](https://github.com/zephyrproject-rtos/zephyr/blob/858a68705294a27c41392bdae88a1f95a7e8fdea/doc/develop/getting_started/index.rst?plain=1#L63-L64) to have python >=3.10  are satisfied.

```
$ python --version                                            
Python 3.8.10                                                                                                       

$ ./scripts/twister --help                                    
Traceback (most recent call last):                                                                                  
  File "./scripts/twister", line 206, in <module>                                                                   
    from twisterlib.environment import add_parse_arguments, parse_arguments                                         
  File "./zephyr/scripts/pylib/twister/twisterlib/environment.py", line 52, in <module>  
    installed_packages: list[str] = list(_get_installed_packages())                                                                                                                        
TypeError: 'type' object is not subscriptable
```
