### PR TITLE
drivers: pwm: pwm_stm32: Add error log for 16-bit timer buffer overflow

### DIFF
--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -330,6 +330,7 @@ static int pwm_stm32_set_cycles(const struct device *dev, uint32_t channel,
 	 */
 	if (!IS_TIM_32B_COUNTER_INSTANCE(cfg->timer) &&
 	    (period_cycles > UINT16_MAX + 1)) {
+		LOG_ERR("Cannot set PWM output, value exceeds 16-bit timer limit.");
 		return -ENOTSUP;
 	}
 


### PR DESCRIPTION
If the value in the period_cycles variable exceeds UINT16_MAX, a 16-bit timer will return an error code 134. An error message was added to indicate that the value does not fit into the 16-bit timer register. An error message advising developers to reduce the value to 16-bit simplifies the process, allowing them to understand immediately that reducing the value will resolve the issue.