### PR TITLE
boards: nordic: nrf54l15pdk: Default to nrfutil runner

### DIFF
--- a/boards/nordic/nrf54l15pdk/board.cmake
+++ b/boards/nordic/nrf54l15pdk/board.cmake
@@ -7,6 +7,6 @@ elseif (CONFIG_SOC_NRF54L15_ENGA_CPUFLPR)
   board_runner_args(jlink "--speed=4000")
 endif()
 
-include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/nrfutil.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
nrfutil is becoming the default tool for flashing Nordic devices. Default to it for the nRF54L15.