### PR TITLE
doc: kernel: iterable_sections: fix documentation typo

### DIFF
--- a/doc/kernel/iterable_sections/index.rst
+++ b/doc/kernel/iterable_sections/index.rst
@@ -32,7 +32,7 @@ instantiated anywhere in the code base.
     DEFINE_DATA(d2, 3, 4);
     DEFINE_DATA(d3, 5, 6);
 
-Then the linker has to be setup to place the place the structure in a
+Then the linker has to be setup to place the structure in a
 contiguous segment using one of the linker macros such as
 :c:macro:`ITERABLE_SECTION_RAM` or :c:macro:`ITERABLE_SECTION_ROM`. Custom
 linker snippets are normally declared using one of the


### PR DESCRIPTION
The docs for the iterable sections has a minor typo when describing how to add the structs to the linker, repeating 'place the' twice.