### PR TITLE
charger: bq25180: Add more options

### DIFF
--- a/drivers/charger/charger_bq25180.c
+++ b/drivers/charger/charger_bq25180.c
@@ -32,6 +32,7 @@ LOG_MODULE_REGISTER(bq25180, CONFIG_CHARGER_LOG_LEVEL);
 #define BQ25180_STAT0_CHG_STAT_CONSTANT_VOLTAGE 0x02
 #define BQ25180_STAT0_CHG_STAT_DONE 0x03
 #define BQ25180_STAT0_VIN_PGOOD_STAT BIT(0)
+#define BQ25180_VBAT_MSK                        GENMASK(6, 0)
 #define BQ25180_ICHG_CHG_DIS BIT(7)
 #define BQ25180_ICHG_MSK GENMASK(6, 0)
 #define BQ25180_WATCHDOG_SEL_1_MSK GENMASK(1, 0)
@@ -45,10 +46,15 @@ LOG_MODULE_REGISTER(bq25180, CONFIG_CHARGER_LOG_LEVEL);
 /* Charging current limits */
 #define BQ25180_CURRENT_MIN_MA 5
 #define BQ25180_CURRENT_MAX_MA 1000
+#define BQ25180_VOLTAGE_MIN_MV 3500
+#define BQ25180_VOLTAGE_MAX_MV 4650
+
+#define BQ25180_FACTOR_VBAT_TO_MV 10
 
 struct bq25180_config {
 	struct i2c_dt_spec i2c;
 	uint32_t initial_current_microamp;
+	uint32_t max_voltage_microvolt;
 };
 
 /*
@@ -85,6 +91,28 @@ static uint32_t bq25180_ichg_to_ma(uint8_t ichg)
 	}
 
 	return (ichg - 31) * 10 + 40;
+}
+
+static int bq25180_mv_to_vbatreg(const struct bq25180_config *cfg, uint32_t voltage_mv,
+				 uint8_t *vbat)
+{
+	if (!IN_RANGE(voltage_mv, BQ25180_VOLTAGE_MIN_MV, cfg->max_voltage_microvolt)) {
+		LOG_WRN("charging voltage out of range: %dmV, "
+			"clamping to the nearest limit",
+			voltage_mv);
+	}
+	voltage_mv = CLAMP(voltage_mv, BQ25180_VOLTAGE_MIN_MV, cfg->max_voltage_microvolt);
+
+	*vbat = (voltage_mv - BQ25180_VOLTAGE_MIN_MV) / BQ25180_FACTOR_VBAT_TO_MV;
+
+	return 0;
+}
+
+static uint32_t bq25180_vbatreg_to_mv(uint8_t vbat)
+{
+	vbat &= BQ25180_VBAT_MSK;
+
+	return (vbat * BQ25180_FACTOR_VBAT_TO_MV) + BQ25180_VOLTAGE_MIN_MV;
 }
 
 static int bq25183_charge_enable(const struct device *dev, const bool enable)
@@ -136,6 +164,41 @@ static int bq25180_get_charge_current(const struct device *dev,
 	}
 
 	*const_charge_current_ua = bq25180_ichg_to_ma(val) * 1000;
+
+	return 0;
+}
+
+static int bq25180_set_charge_voltage(const struct device *dev, uint32_t const_charge_voltage_uv)
+{
+	const struct bq25180_config *cfg = dev->config;
+	uint8_t val;
+	int ret;
+
+	ret = bq25180_mv_to_vbatreg(cfg, const_charge_voltage_uv / 1000, &val);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = i2c_reg_update_byte_dt(&cfg->i2c, BQ25180_VBAT_CTRL, BQ25180_VBAT_MSK, val);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return 0;
+}
+
+static int bq25180_get_charge_voltage(const struct device *dev, uint32_t *const_charge_voltage_uv)
+{
+	const struct bq25180_config *cfg = dev->config;
+	uint8_t val;
+	int ret;
+
+	ret = i2c_reg_read_byte_dt(&cfg->i2c, BQ25180_VBAT_CTRL, &val);
+	if (ret < 0) {
+		return ret;
+	}
+
+	*const_charge_voltage_uv = bq25180_vbatreg_to_mv(val) * 1000;
 
 	return 0;
 }
@@ -215,6 +278,8 @@ static int bq25180_get_prop(const struct device *dev, charger_prop_t prop,
 		return bq25180_get_status(dev, &val->status);
 	case CHARGER_PROP_CONSTANT_CHARGE_CURRENT_UA:
 		return bq25180_get_charge_current(dev, &val->const_charge_current_ua);
+	case CHARGER_PROP_CONSTANT_CHARGE_VOLTAGE_UV:
+		return bq25180_get_charge_voltage(dev, &val->const_charge_voltage_uv);
 	default:
 		return -ENOTSUP;
 	}
@@ -226,6 +291,8 @@ static int bq25180_set_prop(const struct device *dev, charger_prop_t prop,
 	switch (prop) {
 	case CHARGER_PROP_CONSTANT_CHARGE_CURRENT_UA:
 		return bq25180_set_charge_current(dev, val->const_charge_current_ua);
+	case CHARGER_PROP_CONSTANT_CHARGE_VOLTAGE_UV:
+		return bq25180_set_charge_voltage(dev, val->const_charge_voltage_uv);
 	default:
 		return -ENOTSUP;
 	}
@@ -262,6 +329,12 @@ static int bq25180_init(const struct device *dev)
 		return ret;
 	}
 
+	ret = bq25180_set_charge_voltage(dev, cfg->max_voltage_microvolt);
+	if (ret < 0) {
+		LOG_ERR("Could not set the target voltage. (rc: %d)", ret);
+		return ret;
+	}
+
 	if (cfg->initial_current_microamp > 0) {
 		ret = bq25180_set_charge_current(dev, cfg->initial_current_microamp);
 		if (ret < 0) {
@@ -272,16 +345,16 @@ static int bq25180_init(const struct device *dev)
 	return 0;
 }
 
-#define CHARGER_BQ25180_INIT(inst)								\
-	static const struct bq25180_config bq25180_config_##inst = {				\
-		.i2c = I2C_DT_SPEC_INST_GET(inst),						\
-		.initial_current_microamp = DT_INST_PROP(					\
-				inst, constant_charge_current_max_microamp),			\
-	};											\
-												\
-	DEVICE_DT_INST_DEFINE(inst, bq25180_init, NULL, NULL,					\
-			      &bq25180_config_##inst, POST_KERNEL,				\
-			      CONFIG_CHARGER_INIT_PRIORITY,					\
-			      &bq25180_api);
+#define CHARGER_BQ25180_INIT(inst)                                                                 \
+	static const struct bq25180_config bq25180_config_##inst = {                               \
+		.i2c = I2C_DT_SPEC_INST_GET(inst),                                                 \
+		.initial_current_microamp =                                                        \
+			DT_INST_PROP(inst, constant_charge_current_max_microamp),                  \
+		.max_voltage_microvolt =                                                           \
+			DT_INST_PROP(inst, constant_charge_voltage_max_microvolt),                 \
+	};                                                                                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(inst, bq25180_init, NULL, NULL, &bq25180_config_##inst, POST_KERNEL, \
+			      CONFIG_CHARGER_INIT_PRIORITY, &bq25180_api);
 
 DT_INST_FOREACH_STATUS_OKAY(CHARGER_BQ25180_INIT)

--- a/dts/bindings/charger/ti,bq25180.yaml
+++ b/dts/bindings/charger/ti,bq25180.yaml
@@ -28,3 +28,6 @@ properties:
       The value specified will be rounded down to the closest implemented
       value. If set to 0 (default) skip setting the charge current value at
       driver initialization.
+
+  constant-charge-voltage-max-microvolt:
+    required: true

--- a/dts/bindings/charger/ti,bq25180.yaml
+++ b/dts/bindings/charger/ti,bq25180.yaml
@@ -31,3 +31,10 @@ properties:
 
   constant-charge-voltage-max-microvolt:
     required: true
+
+  precharge-voltage-threshold-microvolt:
+    type: int
+    default: 3000000
+    description: |
+      Threshold at which voltage to switch to constant current charge.
+      Must be either 3.0V or 2.8V

--- a/tests/drivers/build_all/charger/i2c.dtsi
+++ b/tests/drivers/build_all/charger/i2c.dtsi
@@ -37,4 +37,5 @@ bq25180@2 {
 	compatible = "ti,bq25180";
 	reg = <0x2>;
 	constant-charge-current-max-microamp = <500000>;
+	constant-charge-voltage-max-microvolt = <4200000>;
 };


### PR DESCRIPTION
Extended the charge controller driver with some more of the supported options.

* Set-options for battery target voltage
* Control for recharge threshold
* Voltage threshold for pre-charge to normal charge

Especially setting the target voltage to something different then 4.2V