### PR TITLE
scripts: ci: compliance: ClangFormat only check .c/.h files

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -274,6 +274,9 @@ class ClangFormatCheck(ComplianceTest):
 
     def run(self):
         for file in get_files():
+            if Path(file).suffix not in ['.c', '.h']:
+                continue
+
             diff = subprocess.Popen(('git', 'diff', '-U0', '--no-color', COMMIT_RANGE, '--', file),
                                     stdout=subprocess.PIPE,
                                     cwd=GIT_TOP)


### PR DESCRIPTION
The clang format compliance check should only be applied to .c and .h files.