### PR TITLE
adc: current_sense_amplifier: all multiplications before divisions

### DIFF
--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -199,6 +199,8 @@ Sensors
 * The existing driver for the Microchip MCP9808 temperature sensor transformed and renamed
   to support all JEDEC JC 42.4 compatible temperature sensors. It now uses the
   :dtcompatible:`jedec,jc-42.4-temp` compatible string instead to the ``microchip,mcp9808`` string.
+* The :dtcompatible:`current-sense-amplifier` properties ``sense-gain-mult`` and ``sense-gain-div``
+  are now limited to a maximum value of ``UINT16_MAX``.
 
 Serial
 ======

--- a/drivers/sensor/current_amp/current_amp.c
+++ b/drivers/sensor/current_amp/current_amp.c
@@ -11,6 +11,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/pm/device.h>
+#include <zephyr/sys/__assert.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(current_amp, CONFIG_SENSOR_LOG_LEVEL);
@@ -114,6 +115,8 @@ static int current_init(const struct device *dev)
 	const struct current_sense_amplifier_dt_spec *config = dev->config;
 	struct current_sense_amplifier_data *data = dev->data;
 	int ret;
+
+	__ASSERT(config->sense_milli_ohms != 0, "Milli-ohms must not be 0");
 
 	if (!adc_is_ready_dt(&config->port)) {
 		LOG_ERR("ADC is not ready");

--- a/dts/bindings/iio/afe/current-sense-amplifier.yaml
+++ b/dts/bindings/iio/afe/current-sense-amplifier.yaml
@@ -24,7 +24,11 @@ properties:
     type: int
     required: true
     description: |
-      Resistance of the shunt resistor in micro-ohms
+      Resistance of the shunt resistor in micro-ohms.
+
+      This value is specified in micro-ohms to maintain compatibility with the
+      Linux bindings, but internally it is rounded down to milli-ohms for
+      computational complexity reasons.
 
   sense-gain-mult:
     type: int

--- a/dts/bindings/iio/afe/current-sense-amplifier.yaml
+++ b/dts/bindings/iio/afe/current-sense-amplifier.yaml
@@ -34,13 +34,13 @@ properties:
     type: int
     default: 1
     description: |
-      Amplifier gain multiplier. The default is <1>.
+      Amplifier gain multiplier. The default is <1>. The maximum value is <65535>.
 
   sense-gain-div:
     type: int
     default: 1
     description: |
-      Amplifier gain divider. The default is <1>.
+      Amplifier gain divider. The default is <1>. The maximum value is <65535>.
 
   power-gpios:
     type: phandle-array

--- a/dts/bindings/iio/afe/current-sense-shunt.yaml
+++ b/dts/bindings/iio/afe/current-sense-shunt.yaml
@@ -25,3 +25,7 @@ properties:
     required: true
     description: |
       Resistance of the shunt resistor in micro-ohms
+
+      This value is specified in micro-ohms to maintain compatibility with the
+      Linux bindings, but internally it is rounded down to milli-ohms for
+      computational complexity reasons.

--- a/include/zephyr/drivers/adc/current_sense_amplifier.h
+++ b/include/zephyr/drivers/adc/current_sense_amplifier.h
@@ -12,7 +12,7 @@
 
 struct current_sense_amplifier_dt_spec {
 	const struct adc_dt_spec port;
-	uint32_t sense_micro_ohms;
+	uint32_t sense_milli_ohms;
 	uint32_t sense_gain_mult;
 	uint32_t sense_gain_div;
 	struct gpio_dt_spec power_gpio;
@@ -31,7 +31,7 @@ struct current_sense_amplifier_dt_spec {
 #define CURRENT_SENSE_AMPLIFIER_DT_SPEC_GET(node_id)                                               \
 	{                                                                                          \
 		.port = ADC_DT_SPEC_GET(node_id),                                                  \
-		.sense_micro_ohms = DT_PROP(node_id, sense_resistor_micro_ohms),                   \
+		.sense_milli_ohms = DT_PROP(node_id, sense_resistor_micro_ohms) / 1000,            \
 		.sense_gain_mult = DT_PROP(node_id, sense_gain_mult),                              \
 		.sense_gain_div = DT_PROP(node_id, sense_gain_div),                                \
 		.power_gpio = GPIO_DT_SPEC_GET_OR(node_id, power_gpios, {0}),                      \
@@ -51,8 +51,8 @@ current_sense_amplifier_scale_dt(const struct current_sense_amplifier_dt_spec *s
 	/* store in a temporary 64 bit variable to prevent overflow during calculation */
 	int64_t tmp = *v_to_i;
 
-	/* multiplies by 1,000,000 before dividing by sense resistance in micro-ohms. */
-	tmp = tmp * 1000000 / spec->sense_micro_ohms * spec->sense_gain_div / spec->sense_gain_mult;
+	/* multiplies by 1,000 before dividing by sense resistance in milli-ohms. */
+	tmp = tmp * 1000 / spec->sense_milli_ohms * spec->sense_gain_div / spec->sense_gain_mult;
 
 	*v_to_i = (int32_t)tmp;
 }

--- a/include/zephyr/drivers/adc/current_sense_shunt.h
+++ b/include/zephyr/drivers/adc/current_sense_shunt.h
@@ -11,7 +11,7 @@
 
 struct current_sense_shunt_dt_spec {
 	const struct adc_dt_spec port;
-	uint32_t shunt_micro_ohms;
+	uint32_t shunt_milli_ohms;
 };
 
 /**
@@ -27,7 +27,7 @@ struct current_sense_shunt_dt_spec {
 #define CURRENT_SENSE_SHUNT_DT_SPEC_GET(node_id)                                                   \
 	{                                                                                          \
 		.port = ADC_DT_SPEC_GET(node_id),                                                  \
-		.shunt_micro_ohms = DT_PROP(node_id, shunt_resistor_micro_ohms),                   \
+		.shunt_milli_ohms = DT_PROP(node_id, shunt_resistor_micro_ohms) / 1000,            \
 	}
 
 /**
@@ -43,8 +43,8 @@ static inline void current_sense_shunt_scale_dt(const struct current_sense_shunt
 	/* store in a temporary 64 bit variable to prevent overflow during calculation */
 	int64_t tmp = *v_to_i;
 
-	/* multiplies by 1,000,000 before dividing by shunt resistance in micro-ohms. */
-	tmp = tmp * 1000000 / spec->shunt_micro_ohms;
+	/* multiplies by 1,000 before dividing by shunt resistance in milli-ohms. */
+	tmp = tmp * 1000 / spec->shunt_milli_ohms;
 
 	*v_to_i = (int32_t)tmp;
 }

--- a/tests/drivers/build_all/sensor/adc.dtsi
+++ b/tests/drivers/build_all/sensor/adc.dtsi
@@ -31,7 +31,7 @@ test_current: current_amp {
 	compatible = "current-sense-amplifier";
 	io-channels = <&test_adc 2>;
 	io-channel-names = "CURRENT_AMP";
-	sense-resistor-micro-ohms = <10>;
+	sense-resistor-micro-ohms = <1000>;
 	sense-gain-mult = <1>;
 	sense-gain-div = <1>;
 };


### PR DESCRIPTION
### adc: current convertors: use milliohms internally

While the devicetree bindings specify the unit of resistance in
micro-ohms, this is an unnecessarily precise unit for the purpose of
these calculations, and a resolution that is not realistic to achieve.

Furthermore, storing the resistance at such a high resolution makes
overflows much more likely when the desired output unit is micro-amps,
not milli-amps.

Unlike resistors characterised down to the micro-ohm, devices wanting to
measure micro-amps are actually realistic.

### adc: current_sense_amplifier: reduce valid scaling range

Reduce the valid scaling range for the gain multipliers and dividers to
provide more headroom on int64_t overflows in the calculations. Take
advantage of this headroom to perform all multiplications before
divisions.

### Reasoning

The current implementation is unsuitable for sense resistors larger than a few ohms. For example, attempting to monitor battery charging current, a 0-1V signal across a 300 ohm resistor with a gain of 300 (https://www.ti.com/product/BQ25185), which should give an output of 0-1000mA, is instead quantized to 300mA steps because of the ordering of operations.

Fixing the ordering without causing potential overflows requires the range reductions in this PR.