### PR TITLE
drivers: udc: mcux: ehci: enable the cache maintenance

### DIFF
--- a/modules/hal_nxp/usb/usb_device_config.h
+++ b/modules/hal_nxp/usb/usb_device_config.h
@@ -101,6 +101,12 @@ BUILD_ASSERT(NUM_INSTS <= 1, "Only one USB device supported");
 #if ((defined(USB_DEVICE_CONFIG_EHCI)) && (USB_DEVICE_CONFIG_EHCI > 0U))
 /*! @brief How many the DTD are supported. */
 #define USB_DEVICE_CONFIG_EHCI_MAX_DTD (16U)
+
+#ifndef CONFIG_UDC_BUF_FORCE_NOCACHE
+#ifdef CONFIG_NOCACHE_MEMORY
+#define USB_DEVICE_CONFIG_BUFFER_PROPERTY_CACHEABLE (1U)
+#endif
+#endif
 #endif
 
 #endif


### PR DESCRIPTION
MCUX ehci controller driver support cache maintenance if USB_DEVICE_CONFIG_BUFFER_PROPERTY_CACHEABLE is enabled. Enable USB_DEVICE_CONFIG_BUFFER_PROPERTY_CACHEABLE if CONFIG_UDC_BUF_FORCE_NOCACHE is false and CONFIG_NOCACHE_MEMORY is true.