### PR TITLE
drivers: intc: plic: fix IRQ on all CPUs

### DIFF
--- a/arch/riscv/core/smp.c
+++ b/arch/riscv/core/smp.c
@@ -74,7 +74,11 @@ void arch_secondary_cpu_init(int hartid)
 #endif
 #ifdef CONFIG_SMP
 	irq_enable(RISCV_IRQ_MSOFT);
-#endif
+#if CONFIG_RISCV_HAS_PLIC
+	/* Enable on secondary cores so that they can respond to PLIC */
+	irq_enable(RISCV_IRQ_MEXT);
+#endif /* CONFIG_RISCV_HAS_PLIC */
+#endif /* CONFIG_SMP */
 	riscv_cpu_init[cpu_num].fn(riscv_cpu_init[cpu_num].arg);
 }
 


### PR DESCRIPTION
Enable IRQs on all CPUs, updated the shell command to print the number of IRQ hits on each CPU.


```
west build -b qemu_riscv64_smp -p auto -t run zephyr/samples/hello_world/ -- \
  -DCONFIG_SHELL=y \
  -DCONFIG_SYMTAB=y \
  -DCONFIG_PLIC_SHELL=y \
  -DCONFIG_MP_MAX_NUM_CPUS=4
```

```
*** Booting Zephyr OS build v3.7.0-1079-g17f11332a926 ***
Hello World! qemu_riscv64/qemu_virt_riscv64/smp


uart:~$ plic stats get interrupt-controller@c000000 
   IRQ       CPU 0       CPU 1       CPU 2       CPU 3       Total      ISR(ARG)
     0           1           1           0           1           3      z_irq_spurious(0)
    10           1           3         152           0         167      uart_ns16550_isr(0x80009cf8)

uart:~$ plic stats get interrupt-controller@c000000
   IRQ       CPU 0       CPU 1       CPU 2       CPU 3       Total      ISR(ARG)
     0           1           1           0           1           3      z_irq_spurious(0)
    10           1           3         291           0         306      uart_ns16550_isr(0x80009cf8)

uart:~$ plic stats get interrupt-controller@c000000
   IRQ       CPU 0       CPU 1       CPU 2       CPU 3       Total      ISR(ARG)
     0           1           1           0           1           3      z_irq_spurious(0)
    10           1           3         430           0         445      uart_ns16550_isr(0x80009cf8)
```