### PR TITLE
net: buf: Clear `user_data` on allocation

### DIFF
--- a/include/zephyr/net/buf.h
+++ b/include/zephyr/net/buf.h
@@ -1049,7 +1049,7 @@ struct net_buf {
 		/** @endcond */
 	};
 
-	/** System metadata for this buffer. */
+	/** System metadata for this buffer. Cleared on allocation. */
 	uint8_t user_data[] __net_buf_align;
 };
 

--- a/subsys/net/buf.c
+++ b/subsys/net/buf.c
@@ -338,6 +338,7 @@ success:
 	buf->flags = 0U;
 	buf->frags = NULL;
 	buf->size  = size;
+	memset(buf->user_data, 0, buf->user_data_size);
 	net_buf_reset(buf);
 
 #if defined(CONFIG_NET_BUF_POOL_USAGE)


### PR DESCRIPTION
For two reasons:
- prevent exposing the previous user's info to the new user
- make NULL checks on user_data work

Since we don't really have a field that specifies what part of the user_data array is valid, we have to rely on other checks.

Such a check, if user_data contains a callback, is comparing against NULL before calling said callback.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/77088