### PR TITLE
drivers: wifi: eswifi: Ignore F_GETFL and F_SETFL ioctl calls. Add ZSOCK_POLLOUT revent in offloaded poll. Use peer_addr as addr in recvfrom.

### DIFF
--- a/drivers/wifi/eswifi/eswifi_socket_offload.c
+++ b/drivers/wifi/eswifi/eswifi_socket_offload.c
@@ -533,7 +533,7 @@ static int eswifi_socket_poll(struct zsock_pollfd *fds, int nfds, int msecs)
 	ret = k_sem_take(&socket->read_sem, timeout);
 	if (ret) {
 		errno = ETIMEDOUT;
-		return -1;
+		return 0;
 	}
 
 done:

--- a/drivers/wifi/eswifi/eswifi_socket_offload.c
+++ b/drivers/wifi/eswifi/eswifi_socket_offload.c
@@ -391,8 +391,9 @@ static ssize_t eswifi_socket_recvfrom(void *obj, void *buf, size_t len,
 				      socklen_t *fromlen)
 {
 	if (fromlen != NULL) {
-		errno = EOPNOTSUPP;
-		return -1;
+		int sock = OBJ_TO_SD(obj);
+		struct eswifi_off_socket *socket = &eswifi->socket[sock];
+		*from = socket->peer_addr;
 	}
 
 	return eswifi_socket_recv(obj, buf, len, flags);

--- a/drivers/wifi/eswifi/eswifi_socket_offload.c
+++ b/drivers/wifi/eswifi/eswifi_socket_offload.c
@@ -610,6 +610,12 @@ int eswifi_socket_create(int family, int type, int proto)
 static int eswifi_socket_ioctl(void *obj, unsigned int request, va_list args)
 {
 	switch (request) {
+	case F_GETFL:
+		LOG_WRN("F_GETFL not supported, returning flags as 0");
+		return 0;
+	case F_SETFL:
+		LOG_WRN("F_SETFL not supported, ignoring flags");
+		return 0;
 	case ZFD_IOCTL_POLL_PREPARE:
 		return -EXDEV;
 

--- a/drivers/wifi/eswifi/eswifi_socket_offload.c
+++ b/drivers/wifi/eswifi/eswifi_socket_offload.c
@@ -14,6 +14,7 @@ LOG_MODULE_DECLARE(LOG_MODULE_NAME);
 #include <stdlib.h>
 #include <errno.h>
 
+#include <zephyr/posix/fcntl.h>
 #include <zephyr/net/socket_offload.h>
 #include <zephyr/net/tls_credentials.h>
 
@@ -513,6 +514,10 @@ static int eswifi_socket_poll(struct zsock_pollfd *fds, int nfds, int msecs)
 	if (socket->state != ESWIFI_SOCKET_STATE_CONNECTED) {
 		errno = EINVAL;
 		return -1;
+	}
+
+	if ((fds[0].events & ZSOCK_POLLOUT)) {
+		fds[0].revents = ZSOCK_POLLOUT;
 	}
 
 	if (!k_fifo_is_empty(&socket->fifo)) {


### PR DESCRIPTION
Hello everyone.

Working on a `b_l4s5i_iot01a` board which is using a ESWIFI chip with offloaded sockets. I am struggling to make it work in order to connect to an LWM2M server and get the full functionality. 

For now the following problems have been / need to be addressed:

- [x] Add support or ignore F_GETFL and F_SETFL ioctl calls from lwm2m_engine
- [x] Add support for sending in offloaded poll.
- [x] Add support for recvfrom with addr.
- [x] ~~Review send invalid bytes  (see information below).~~
- [x] ~~Review recv invalid bytes (see information below).~~

With the first 3 commits I can properly connect to a LWM2M server (i.e. leshan or thingsboard). 
However,  I still face two issues:

1. When the LWM2M server performs a read request, it seems to be completed successfully but the server is reporting unexpected 0xFF bytes in CoAP.
```
[CoapServer(main)#9] INFO  org.eclipse.californium.ban - [LWM2M Server-coap://0.0.0.0:5685] Found payload marker (0xFF) but message contains no payload;
``` 

2. ~~When pushing an image from the LWM2M server to the device, bytes received are incorrect. As an example, the first bytes of the binary file are `3db8 f396 0000 0000 0002 0000 58a7 0200` and we receive `3db8 f396 0000 0000 0002 0000 5ca7 0200` in the LWM2M function.~~

LWM2M code seems fine as it is working well when running in a Ethernet board, so I guess that problems come from ESWIFI. Any help for debugging this is highly appreciated.
