### PR TITLE
net: lib: http_server: prevent falsely matching HTTP headers

### DIFF
--- a/subsys/net/lib/http/http_server_http1.c
+++ b/subsys/net/lib/http/http_server_http1.c
@@ -454,12 +454,9 @@ static int on_header_field(struct http_parser *parser, const char *at,
 			/* This means that the header field is fully parsed,
 			 * and we can use it directly.
 			 */
-			if (strncasecmp(ctx->header_buffer, "Upgrade",
-					sizeof("Upgrade") - 1) == 0) {
+			if (strcasecmp(ctx->header_buffer, "Upgrade") == 0) {
 				ctx->has_upgrade_header = true;
-			} else if (strncasecmp(ctx->header_buffer,
-					       "Sec-WebSocket-Key",
-					       sizeof("Sec-WebSocket-Key") - 1) == 0) {
+			} else if (strcasecmp(ctx->header_buffer, "Sec-WebSocket-Key") == 0) {
 				ctx->websocket_sec_key_next = true;
 			}
 
@@ -491,12 +488,9 @@ static int on_header_value(struct http_parser *parser,
 
 		if (parser->state == s_header_almost_done) {
 			if (ctx->has_upgrade_header) {
-				if (strncasecmp(ctx->header_buffer, "h2c",
-						sizeof("h2c") - 1) == 0) {
+				if (strcasecmp(ctx->header_buffer, "h2c") == 0) {
 					ctx->http2_upgrade = true;
-				} else if (strncasecmp(ctx->header_buffer,
-						       "websocket",
-						       sizeof("websocket") - 1) == 0) {
+				} else if (strcasecmp(ctx->header_buffer, "websocket") == 0) {
 					ctx->websocket_upgrade = true;
 				}
 


### PR DESCRIPTION
Using `strncasecmp` to match HTTP headers can give unexpected results when the strings to be compared match up until the end of one string, but the other string contains additional characters. This can result in falsely matching a HTTP header value, for example:
```
strncasecmp("Upgrade-Something", "Upgrade", sizeof("Upgrade") - 1) == 0
```
In this case we know that both strings are NULL terminated since one is a string literal and we have just length-checked and explicitly NULL terminated the other. So we can just use strcasecmp without a max length.

Alternatively including the NULL termination in the length to be compared (ie. just `sizeof("Upgrade")` instead of `sizeof("Upgrade") - 1` also works if using `strncasecmp` is preferred.