### PR TITLE
logging: log_backend_ble: add level prefix and improve flag settings

### DIFF
--- a/subsys/logging/backends/log_backend_ble.c
+++ b/subsys/logging/backends/log_backend_ble.c
@@ -144,7 +144,15 @@ LOG_OUTPUT_DEFINE(log_output_ble, line_out, output_buf, sizeof(output_buf));
 static void process(const struct log_backend *const backend, union log_msg_generic *msg)
 {
 	ARG_UNUSED(backend);
-	uint32_t flags = LOG_OUTPUT_FLAG_FORMAT_SYSLOG | LOG_OUTPUT_FLAG_TIMESTAMP;
+	uint32_t flags = LOG_OUTPUT_FLAG_FORMAT_SYSLOG | LOG_OUTPUT_FLAG_TIMESTAMP | LOG_OUTPUT_FLAG_LEVEL;
+
+	if (IS_ENABLED(CONFIG_LOG_BACKEND_FORMAT_TIMESTAMP)) {
+		flags |= LOG_OUTPUT_FLAG_FORMAT_TIMESTAMP;
+	}
+
+	if (IS_ENABLED(CONFIG_LOG_THREAD_ID_PREFIX)) {
+		flags |= LOG_OUTPUT_FLAG_THREAD;
+	}
 
 	if (panic_mode) {
 		return;


### PR DESCRIPTION
Two changes:
1. Enable the logging level prefix as default. I think this adds a lot of value and allows for easy filtering of messages on the receiving device
2. For those flags that have an equivalent Kconfig option, match its value

@vChavezB I am tagging you because you worked on this module.
