### PR TITLE
Support flexcan for s32z27

### DIFF
--- a/boards/nxp/s32z2xxdc2/doc/index.rst
+++ b/boards/nxp/s32z2xxdc2/doc/index.rst
@@ -53,6 +53,8 @@ The boards support the following hardware features:
 +-----------+------------+-------------------------------------+
 | CANEXCEL  | on-chip    | can                                 |
 +-----------+------------+-------------------------------------+
+| FLEXCAN   | on-chip    | can                                 |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not currently supported by the port.
 
@@ -129,15 +131,24 @@ single Virtual SI (VSI). The rest of the VSI's shall be assigned to different
 cores of the system. Refer to :ref:`nxp_s32_netc-samples` to learn how to
 configure the Ethernet network controller.
 
-Controller Area Network (CAN)
-=============================
+Controller Area Network
+=======================
 
-Currently, the CANXL transceiver is not populated in this board. So CAN transceiver
-connection is required for running external traffic. We can use any CAN transceiver,
-which supports CAN 2.0 and CAN FD protocol.
+CANEXCEL
+--------
 
-CAN driver supports classic (CAN 2.0) and CAN FD mode. Remote transmission request is
-not supported as this feature is not available on NXP S32 CANXL HAL.
+CANEXCEL supports CAN Classic (CAN 2.0) and CAN FD modes. Remote transmission
+request is not supported.
+
+Note that this board does not currently come with CAN transceivers installed for
+the CANEXCEL ports. To facilitate external traffic, you will need to add a CAN
+transceiver. Any transceiver pin-compatible with CAN 2.0 and CAN FD protocols
+can be used.
+
+FlexCAN
+-------
+
+FlexCAN supports CAN Classic (CAN 2.0) and CAN FD modes.
 
 Programming and Debugging
 *************************

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270.dtsi
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270.dtsi
@@ -40,3 +40,13 @@
 	pinctrl-0 = <&canxl1_default>;
 	pinctrl-names = "default";
 };
+
+&flexcan0 {
+	pinctrl-0 = <&flexcan0_default>;
+	pinctrl-names = "default";
+};
+
+&flexcan1 {
+	pinctrl-0 = <&flexcan1_default>;
+	pinctrl-names = "default";
+};

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270.dtsi
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270.dtsi
@@ -31,13 +31,12 @@
 	status = "okay";
 };
 
-&can0 {
-	pinctrl-0 = <&can0_default>;
+&canxl0 {
+	pinctrl-0 = <&canxl0_default>;
 	pinctrl-names = "default";
-	status = "okay";
 };
 
-&can1 {
-	pinctrl-0 = <&can1_default>;
+&canxl1 {
+	pinctrl-0 = <&canxl1_default>;
 	pinctrl-names = "default";
 };

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_pinctrl.dtsi
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_pinctrl.dtsi
@@ -85,4 +85,26 @@
 			output-enable;
 		};
 	};
+
+	flexcan0_default: flexcan0_default {
+		group1 {
+			pinmux = <PA5_CAN_0_RX>;
+			input-enable;
+		};
+		group2 {
+			pinmux = <PA4_CAN_0_TX>;
+			output-enable;
+		};
+	};
+
+	flexcan1_default: flexcan1_default {
+		group1 {
+			pinmux = <PB7_CAN_1_RX>;
+			input-enable;
+		};
+		group2 {
+			pinmux = <PB6_CAN_1_TX>;
+			output-enable;
+		};
+	};
 };

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_pinctrl.dtsi
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_pinctrl.dtsi
@@ -64,7 +64,7 @@
 		};
 	};
 
-	can0_default: can0_default {
+	canxl0_default: canxl0_default {
 		group1 {
 			pinmux = <PN2_CANXL_0_RX>;
 			input-enable;
@@ -75,7 +75,7 @@
 		};
 	};
 
-	can1_default: can1_default {
+	canxl1_default: canxl1_default {
 		group1 {
 			pinmux = <PM11_CANXL_1_RX>;
 			input-enable;

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu0.dts
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu0.dts
@@ -14,7 +14,7 @@
 
 	chosen {
 		zephyr,sram = &sram0;
-		zephyr,canbus = &can0;
+		zephyr,canbus = &canxl0;
 	};
 
 	aliases {
@@ -30,4 +30,8 @@
 &enetc_psi0 {
 	mboxes = <&mru0 0>;
 	mbox-names = "rx";
+};
+
+&canxl0 {
+	status = "okay";
 };

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu1.dts
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu1.dts
@@ -16,7 +16,7 @@
 		zephyr,sram = &sram1;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
-		zephyr,canbus = &can0;
+		zephyr,canbus = &canxl0;
 	};
 
 	aliases {

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu1.dts
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu1.dts
@@ -16,7 +16,7 @@
 		zephyr,sram = &sram1;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
-		zephyr,canbus = &canxl0;
+		zephyr,canbus = &flexcan0;
 	};
 
 	aliases {
@@ -32,4 +32,8 @@
 &enetc_psi0 {
 	mboxes = <&mru4 0>;
 	mbox-names = "rx";
+};
+
+&flexcan0 {
+	status = "okay";
 };

--- a/drivers/can/Kconfig.mcux
+++ b/drivers/can/Kconfig.mcux
@@ -31,10 +31,11 @@ config CAN_MCUX_FLEXCAN_WAIT_TIMEOUT
 config CAN_MAX_MB
 	int "Maximum number of message buffers for concurrent active instances"
 	default 16
-	depends on SOC_SERIES_S32K3 || SOC_SERIES_S32K1
+	depends on SOC_SERIES_S32K3 || SOC_SERIES_S32K1 || SOC_SERIES_S32ZE
 	range 1 96 if SOC_SERIES_S32K3
 	range 1 32 if SOC_SERIES_S32K1 && !SOC_S32K142W && !SOC_S32K144W
 	range 1 64 if SOC_S32K142W || SOC_S32K144W
+	range 1 128 if SOC_SERIES_S32ZE
 	help
 	  Defines maximum number of message buffers for concurrent active instances.
 
@@ -47,6 +48,7 @@ config CAN_MAX_FILTER
 	range 1 96 if SOC_SERIES_S32K3
 	range 1 32 if SOC_SERIES_S32K1 && !SOC_S32K142W && !SOC_S32K144W
 	range 1 64 if SOC_S32K142W || SOC_S32K144W
+	range 1 128 if SOC_SERIES_S32ZE
 	help
 	  Defines maximum number of concurrent active RX filters
 

--- a/dts/arm/nxp/nxp_s32z27x_r52.dtsi
+++ b/dts/arm/nxp/nxp_s32z27x_r52.dtsi
@@ -686,7 +686,7 @@
 			};
 		};
 
-		can0: can@4741b000 {
+		canxl0: can@4741b000 {
 			compatible = "nxp,s32-canxl";
 			reg = <0x4741b000 0x1000>,
 				<0x47423000 0x1000>,
@@ -700,7 +700,7 @@
 			clocks = <&clock NXP_S32_P5_CANXL_PE_CLK>;
 		};
 
-		can1: can@4751b000 {
+		canxl1: can@4751b000 {
 			compatible = "nxp,s32-canxl";
 			reg = <0x4751b000 0x1000>,
 				<0x47523000 0x1000>,

--- a/dts/arm/nxp/nxp_s32z27x_r52.dtsi
+++ b/dts/arm/nxp/nxp_s32z27x_r52.dtsi
@@ -713,5 +713,366 @@
 			interrupt-names = "rx_tx_mru", "error";
 			clocks = <&clock NXP_S32_P5_CANXL_PE_CLK>;
 		};
+
+		flexcan0: can@449a0000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			reg = <0x449a0000 0x4000>;
+			clk-source = <0>;
+			interrupts = <GIC_SPI 581 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 583 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 584 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 585 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 586 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
+						"ored_64_95_mb", "ored_96_127_mb";
+			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			status = "disabled";
+		};
+
+		flexcan1: can@449b0000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			reg = <0x449b0000 0x4000>;
+			clk-source = <0>;
+			interrupts = <GIC_SPI 587 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 589 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 590 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 591 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 592 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
+						"ored_64_95_mb", "ored_96_127_mb";
+			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			status = "disabled";
+		};
+
+		flexcan2: can@449c0000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			clk-source = <0>;
+			reg = <0x449c0000 0x4000>;
+			interrupts = <GIC_SPI 593 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 595 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 596 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 597 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 598 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
+						"ored_64_95_mb", "ored_96_127_mb";
+			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			status = "disabled";
+		};
+
+		flexcan3: can@449d0000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			clk-source = <0>;
+			reg = <0x449d0000 0x4000>;
+			interrupts = <GIC_SPI 599 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 601 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 602 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 603 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 604 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
+						"ored_64_95_mb", "ored_96_127_mb";
+			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			status = "disabled";
+		};
+
+		flexcan4: can@449e0000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			clk-source = <0>;
+			reg = <0x449e0000 0x4000>;
+			interrupts = <GIC_SPI 605 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 607 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 608 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 609 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 610 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
+						"ored_64_95_mb", "ored_96_127_mb";
+			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			status = "disabled";
+		};
+
+		flexcan5: can@449f0000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			clk-source = <0>;
+			reg = <0x449f0000 0x4000>;
+			interrupts = <GIC_SPI 611 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 613 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 614 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 615 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 616 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
+						"ored_64_95_mb", "ored_96_127_mb";
+			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			status = "disabled";
+		};
+
+		flexcan6: can@44ba0000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			clk-source = <0>;
+			reg = <0x44ba0000 0x4000>;
+			interrupts = <GIC_SPI 617 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 619 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 620 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 621 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 622 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
+						"ored_64_95_mb", "ored_96_127_mb";
+			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			status = "disabled";
+		};
+
+		flexcan7: can@44bb0000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			clk-source = <0>;
+			reg = <0x44bb0000 0x4000>;
+			interrupts = <GIC_SPI 623 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 625 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 626 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 627 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 628 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
+						"ored_64_95_mb", "ored_96_127_mb";
+			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			status = "disabled";
+		};
+
+		flexcan8: can@44bc0000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			clk-source = <0>;
+			reg = <0x44bc0000 0x4000>;
+			interrupts = <GIC_SPI 629 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 631 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 632 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 633 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 634 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
+						"ored_64_95_mb", "ored_96_127_mb";
+			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			status = "disabled";
+		};
+
+		flexcan9: can@44bd0000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			clk-source = <0>;
+			reg = <0x44bd0000 0x4000>;
+			interrupts = <GIC_SPI 635 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 637 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 638 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 639 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 640 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
+						"ored_64_95_mb", "ored_96_127_mb";
+			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			status = "disabled";
+		};
+
+		flexcan10: can@44be0000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			clk-source = <0>;
+			reg = <0x44be0000 0x4000>;
+			interrupts = <GIC_SPI 641 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 643 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 644 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 645 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 646 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
+						"ored_64_95_mb", "ored_96_127_mb";
+			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			status = "disabled";
+		};
+
+		flexcan11: can@44bf0000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			clk-source = <0>;
+			reg = <0x44bf0000 0x4000>;
+			interrupts = <GIC_SPI 647 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 649 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 650 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 651 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 652 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
+						"ored_64_95_mb", "ored_96_127_mb";
+			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			status = "disabled";
+		};
+
+		flexcan12: can@44da0000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			clk-source = <0>;
+			reg = <0x44da0000 0x4000>;
+			interrupts = <GIC_SPI 653 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 655 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 656 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 657 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 658 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
+						"ored_64_95_mb", "ored_96_127_mb";
+			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			status = "disabled";
+		};
+
+		flexcan13: can@44db0000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			clk-source = <0>;
+			reg = <0x44db0000 0x4000>;
+			interrupts = <GIC_SPI 659 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 661 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 662 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 663 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 664 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
+						"ored_64_95_mb", "ored_96_127_mb";
+			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			status = "disabled";
+		};
+
+		flexcan14: can@44dc0000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			clk-source = <0>;
+			reg = <0x44dc0000 0x4000>;
+			interrupts = <GIC_SPI 665 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 667 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 668 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 669 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 670 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
+						"ored_64_95_mb", "ored_96_127_mb";
+			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			status = "disabled";
+		};
+
+		flexcan15: can@44dd0000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			clk-source = <0>;
+			reg = <0x44dd0000 0x4000>;
+			interrupts = <GIC_SPI 671 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 673 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 674 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 675 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 676 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
+						"ored_64_95_mb", "ored_96_127_mb";
+			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			status = "disabled";
+		};
+
+		flexcan16: can@44de0000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			clk-source = <0>;
+			reg = <0x44de0000 0x4000>;
+			interrupts = <GIC_SPI 677 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 679 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 680 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 681 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 682 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
+						"ored_64_95_mb", "ored_96_127_mb";
+			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			status = "disabled";
+		};
+
+		flexcan17: can@44df0000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			clk-source = <0>;
+			reg = <0x44df0000 0x4000>;
+			interrupts = <GIC_SPI 683 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 685 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 686 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 687 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 688 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
+						"ored_64_95_mb", "ored_96_127_mb";
+			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			status = "disabled";
+		};
+
+		flexcan18: can@44fa0000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			clk-source = <0>;
+			reg = <0x44fa0000 0x4000>;
+			interrupts = <GIC_SPI 689 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 691 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 692 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 693 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 694 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
+						"ored_64_95_mb", "ored_96_127_mb";
+			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			status = "disabled";
+		};
+
+		flexcan19: can@44fb0000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			clk-source = <0>;
+			reg = <0x44fb0000 0x4000>;
+			interrupts = <GIC_SPI 695 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 697 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 698 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 699 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 700 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
+						"ored_64_95_mb", "ored_96_127_mb";
+			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			status = "disabled";
+		};
+
+		flexcan20: can@44fc0000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			clk-source = <0>;
+			reg = <0x44fc0000 0x4000>;
+			interrupts = <GIC_SPI 701 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 703 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 704 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 705 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 706 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
+						"ored_64_95_mb", "ored_96_127_mb";
+			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			status = "disabled";
+		};
+
+		flexcan21: can@44fd0000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			clk-source = <0>;
+			reg = <0x44fd0000 0x4000>;
+			interrupts = <GIC_SPI 707 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 709 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 710 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 711 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 712 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
+						"ored_64_95_mb", "ored_96_127_mb";
+			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			status = "disabled";
+		};
+
+		flexcan22: can@44fe0000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			clk-source = <0>;
+			reg = <0x44fe0000 0x4000>;
+			interrupts = <GIC_SPI 713 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 715 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 716 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 717 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 718 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
+						"ored_64_95_mb", "ored_96_127_mb";
+			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			status = "disabled";
+		};
+
+		flexcan23: can@44ff0000 {
+			compatible = "nxp,flexcan-fd", "nxp,flexcan";
+			clk-source = <0>;
+			reg = <0x44ff0000 0x4000>;
+			interrupts = <GIC_SPI 719 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 721 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 722 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 723 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 724 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "ored", "ored_0_31_mb", "ored_32_63_mb",
+						"ored_64_95_mb", "ored_96_127_mb";
+			clocks = <&clock NXP_S32_P3_CAN_PE_CLK>;
+			status = "disabled";
+		};
+
 	};
 };

--- a/soc/nxp/s32/s32ze/Kconfig
+++ b/soc/nxp/s32/s32ze/Kconfig
@@ -16,6 +16,7 @@ config SOC_SERIES_S32ZE
 	select HAS_NXP_S32_HAL
 	select HAS_MCUX
 	select HAS_MCUX_PIT
+	select HAS_MCUX_FLEXCAN
 
 if SOC_SERIES_S32ZE
 

--- a/west.yml
+++ b/west.yml
@@ -198,7 +198,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: e8ccf3e4ad0d6ba80b468747682bde43ec97b435
+      revision: e400b5dba27d9abe1403fc799d48b58fa1b1daee
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
This PR supports FlexCan on S32ZE over MCUx driver

Flexcan0 is enable by default on boards s32z2xxdc2_s32z270_rtu1

~This depends on https://github.com/zephyrproject-rtos/zephyr/pull/76879~

Tested with tests\drivers\can
```
INFO    - 4/7 s32z2xxdc2/s32z270/rtu1   tests/drivers/can/shell/drivers.can.shell          PASSED (device 29.370s)
INFO    - 5/7 s32z2xxdc2/s32z270/rtu1   tests/drivers/can/api/drivers.can.api.rtr          PASSED (device 29.825s)
INFO    - 6/7 s32z2xxdc2/s32z270/rtu1   tests/drivers/can/timing/drivers.can.timing        PASSED (device 27.858s)
INFO    - 7/7 s32z2xxdc2/s32z270/rtu1   tests/drivers/can/api/drivers.can.api              PASSED (device 30.770s)
```

Tested with samples\net\sockets\can
```
INFO    - 1/2 s32z2xxdc2/s32z270/rtu1   samples/net/sockets/can/sample.net.sockets.can.two_sockets PASSED (device 31.218s)
INFO    - 2/2 s32z2xxdc2/s32z270/rtu1   samples/net/sockets/can/sample.net.sockets.can.one_socket PASSED (device 27.708s)
```