### PR TITLE
dts: nxp_rt1010: mark edma channel has separate interrupt entry

### DIFF
--- a/dts/arm/nxp/nxp_rt1010.dtsi
+++ b/dts/arm/nxp/nxp_rt1010.dtsi
@@ -57,6 +57,8 @@
 };
 
 &edma0 {
+	/* Each channel has separate interrupt entry */
+	irq-shared-offset = <0>;
 	dma-channels = <16>;
 };
 


### PR DESCRIPTION
In SoC imxrt1010, edma channel has separate interrupt entry, not like the rest of in-tree imxrt SoC series.
~I don't have board to test so temporarily mark this PR as draft, waiting feedback from reporter~
This fixes: #77129

