### PR TITLE
Bluetooth: L2CAP: Some cleanups

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -934,12 +934,7 @@ struct bt_conn *get_conn_ready(void)
 		__maybe_unused sys_snode_t *s = sys_slist_get(&bt_dev.le.conn_ready);
 
 		__ASSERT_NO_MSG(s == node);
-
 		(void)atomic_set(&conn->_conn_ready_lock, 0);
-		/* Note: we can't assert `old` is non-NULL here, as the
-		 * connection might have been marked ready by an l2cap channel
-		 * that cancelled its request to send.
-		 */
 
 		/* Append connection to list if it still has data */
 		if (conn->has_data(conn)) {

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -903,11 +903,15 @@ struct net_buf *l2cap_data_pull(struct bt_conn *conn,
 	 */
 	struct net_buf *pdu = k_fifo_peek_head(&lechan->tx_queue);
 
+	/* We don't have anything to send for the current channel. We could
+	 * however have something to send on another channel that is attached to
+	 * the same ACL connection. Re-trigger the TX processor: it will call us
+	 * again and this time we will select another channel to pull data from.
+	 */
 	if (!pdu) {
 		bt_tx_irq_raise();
 		return NULL;
 	}
-	/* __ASSERT(pdu, "signaled ready but no PDUs in the TX queue"); */
 
 	if (bt_buf_has_view(pdu)) {
 		LOG_ERR("already have view on %p", pdu);


### PR DESCRIPTION
```
commit 7981a9a905899188d8c41f401f6303d0d5b2cda0 (HEAD -> l2cap-🧹, jori/l2cap-🧹)
Author: Jonathan Rico <jonathan.rico@nordicsemi.no>
Date:   Fri Aug 16 08:44:19 2024 +0200

    Bluetooth: L2CAP: remove commented-out assert
    
    This assert cannot be turned on, as `pdu` will be NULL sometimes. This
    is okay, it just means that the current channel doesn't have anything to
    send and that we should probably try another one.
    
    Signed-off-by: Jonathan Rico <jonathan.rico@nordicsemi.no>

commit 94a46c48ec69a3347f114d5f455b848c00499e26
Author: Jonathan Rico <jonathan.rico@nordicsemi.no>
Date:   Fri Aug 16 07:50:48 2024 +0200

    Bluetooth: Host: remove outdated comment
    
    This comment refers to an old piece of code that never got in main.
    
    Signed-off-by: Jonathan Rico <jonathan.rico@nordicsemi.no>

```