### PR TITLE
Bluetooth: `byteorder.h`: Add big-endian macros

### DIFF
--- a/include/zephyr/bluetooth/byteorder.h
+++ b/include/zephyr/bluetooth/byteorder.h
@@ -107,6 +107,78 @@ extern "C" {
 	BT_BYTES_LIST_LE32(_v),        \
 	BT_BYTES_LIST_LE32((_v) >> 32) \
 
+/** @brief Encode 16-bit value into array values in big-endian format.
+ *
+ *  Helper macro to encode 16-bit values into comma separated values.
+ *
+ *  @note @p _v is evaluated 2 times.
+ *
+ *  @param _v 16-bit integer in host endianness.
+ *
+ *  @return The comma separated values for the 16-bit value.
+ */
+#define BT_BYTES_LIST_BE16(_v) (((_v) >> 8) & 0xFFU), (((_v) >> 0) & 0xFFU)
+
+/** @brief Encode 24-bit value into array values in big-endian format.
+ *
+ *  Helper macro to encode 24-bit values into comma separated values.
+ *
+ *  @note @p _v is evaluated 3 times.
+ *
+ *  @param _v 24-bit integer in host endianness.
+ *
+ *  @return The comma separated values for the 24-bit value.
+ */
+#define BT_BYTES_LIST_BE24(_v) (((_v) >> 16) & 0xFFU), BT_BYTES_LIST_BE16(_v)
+
+/** @brief Encode 32-bit value into array values in big-endian format.
+ *
+ *  Helper macro to encode 32-bit values into comma separated values.
+ *
+ *  @note @p _v is evaluated 4 times.
+ *
+ *  @param _v 32-bit integer in host endianness.
+ *
+ *  @return The comma separated values for the 32-bit value.
+ */
+#define BT_BYTES_LIST_BE32(_v) (((_v) >> 24) & 0xFFU), BT_BYTES_LIST_BE24(_v)
+
+/** @brief Encode 40-bit value into array values in big-endian format.
+ *
+ *  Helper macro to encode 40-bit values into comma separated values.
+ *
+ *  @note @p _v is evaluated 5 times.
+ *
+ *  @param _v 40-bit integer in host endianness.
+ *
+ *  @return The comma separated values for the 40-bit value.
+ */
+#define BT_BYTES_LIST_BE40(_v) BT_BYTES_LIST_BE16((_v) >> 24), BT_BYTES_LIST_BE24(_v)
+
+/** @brief Encode 48-bit value into array values in big-endian format.
+ *
+ *  Helper macro to encode 48-bit values into comma separated values.
+ *
+ *  @note @p _v is evaluated 6 times.
+ *
+ *  @param _v 48-bit integer in host endianness.
+ *
+ *  @return The comma separated values for the 48-bit value.
+ */
+#define BT_BYTES_LIST_BE48(_v) BT_BYTES_LIST_BE16((_v) >> 32), BT_BYTES_LIST_BE32(_v)
+
+/** @brief Encode 64-bit value into array values in big-endian format.
+ *
+ *  Helper macro to encode 64-bit values into comma separated values.
+ *
+ *  @note @p _v is evaluated 8 times.
+ *
+ *  @param _v 64-bit integer in host endianness.
+ *
+ *  @return The comma separated values for the 64-bit value.
+ */
+#define BT_BYTES_LIST_BE64(_v) BT_BYTES_LIST_BE32((_v) >> 32), BT_BYTES_LIST_BE32(_v)
+
 /**
  * @}
  */


### PR DESCRIPTION
This patch contains big-endian version of the macros present in that file. The new code is formatted by clang-format, which is why the formatting is different.