### PR TITLE
doc: optimization: link to sysbuild commands

### DIFF
--- a/doc/develop/optimizations/tools.rst
+++ b/doc/develop/optimizations/tools.rst
@@ -50,6 +50,7 @@ per symbol and the percentage it uses. The data is grouped based on the file
 system location of the object in the tree and the file containing the symbol.
 
 Use the ``ram_report`` target with your board, as in the following example.
+If you are using :ref:`sysbuild`, see :ref:`sysbuild_dedicated_image_build_targets` instead.
 
 .. zephyr-app-commands::
     :tool: all
@@ -111,6 +112,7 @@ per symbol and the percentage it uses. The data is grouped based on the file
 system location of the object in the tree and the file containing the symbol.
 
 Use the ``rom_report`` target with your board, as in the following example.
+If you are using :ref:`sysbuild`, see :ref:`sysbuild_dedicated_image_build_targets` instead.
 
 .. zephyr-app-commands::
     :tool: all
@@ -176,6 +178,7 @@ target, install the puncover Python module::
 
 After you installed the Python module, use ``puncover`` target with your board,
 as in the following example.
+If you are using :ref:`sysbuild`, see :ref:`sysbuild_dedicated_image_build_targets` instead.
 
 .. zephyr-app-commands::
     :tool: all
@@ -220,6 +223,7 @@ Alternatively, you can get it from fedora::
 
 After you installed the package, use ``pahole`` target with your board,
 as in the following example.
+If you are using :ref:`sysbuild`, see :ref:`sysbuild_dedicated_image_build_targets` instead.
 
 .. zephyr-app-commands::
     :tool: all


### PR DESCRIPTION
Added links pointing to the Dedicated image build targets from Optimization tools page for ram_report, rom_report, footprint, puncover, and pahole.
Reported by @markaj-nordic.