### PR TITLE
Set PINCTRL for MAX32 MCUs

### DIFF
--- a/drivers/i2c/Kconfig.max32
+++ b/drivers/i2c/Kconfig.max32
@@ -5,6 +5,7 @@ menuconfig I2C_MAX32
 	bool "Analog Devices MAX32 I2C driver"
 	default y
 	depends on DT_HAS_ADI_MAX32_I2C_ENABLED
+	select PINCTRL
 	help
 	  i2c driver for max32 family.
 

--- a/drivers/spi/Kconfig.max32
+++ b/drivers/spi/Kconfig.max32
@@ -5,6 +5,7 @@ config SPI_MAX32
 	bool "MAX32 MCU SPI controller driver"
 	default y
 	depends on DT_HAS_ADI_MAX32_SPI_ENABLED
+	select PINCTRL
 	help
 	  Enable SPI support on the MAX32 family of processors.
 


### PR DESCRIPTION
PINCTRL need be selected for SPI and I2C too, to able to use pinmux functions.