### PR TITLE
tests: Bluetooth: BAP: Add -RealEncryption=1 to enc broadcast test

### DIFF
--- a/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_encrypted.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_encrypted.sh
@@ -16,11 +16,13 @@ printf "\n\n======== Broadcaster encrypted test =========\n\n"
 SIMULATION_ID="broadcaster_encrypted"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=broadcast_source_encrypted -rs=23 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=broadcast_source_encrypted \
+  -RealEncryption=1 -rs=23 -D=2
 
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=broadcast_sink_encrypted -rs=27 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=broadcast_sink_encrypted \
+  -RealEncryption=1 -rs=27 -D=2
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \


### PR DESCRIPTION
The shell script did not provide -RealEncryption=1 which then never really did proper encryption, which is the point of the test.