### PR TITLE
 doc: zephyr_domain: Cross reference relevant API in code samples

### DIFF
--- a/samples/net/ptp/README.rst
+++ b/samples/net/ptp/README.rst
@@ -1,6 +1,6 @@
 .. zephyr:code-sample:: ptp
    :name: PTP
-   :relevant-api: ptp ptp_time ptp_clock
+   :relevant-api: ptp
 
    Enable PTP support and monitor messages and events via logging.
 

--- a/samples/net/sockets/coap_client/README.rst
+++ b/samples/net/sockets/coap_client/README.rst
@@ -1,6 +1,6 @@
 .. zephyr:code-sample:: coap-client
    :name: CoAP client
-   :relevant-api: coap udp
+   :relevant-api: coap
 
    Use the CoAP library to implement a client that fetches a resource.
 

--- a/samples/net/sockets/coap_download/README.rst
+++ b/samples/net/sockets/coap_download/README.rst
@@ -1,6 +1,6 @@
 .. zephyr:code-sample:: coap-download
    :name: CoAP download
-   :relevant-api: coap_client_interface
+   :relevant-api: coap
 
    Use the CoAP client API to download data via a GET request
 

--- a/samples/net/sockets/coap_server/README.rst
+++ b/samples/net/sockets/coap_server/README.rst
@@ -1,6 +1,6 @@
 .. zephyr:code-sample:: coap-server
    :name: CoAP service
-   :relevant-api: coap coap_service udp
+   :relevant-api: coap coap_service
 
    Use the CoAP server subsystem to register CoAP resources.
 

--- a/samples/subsys/llext/edk/README.rst
+++ b/samples/subsys/llext/edk/README.rst
@@ -1,6 +1,6 @@
 .. zephyr:code-sample:: llext-edk
    :name: Linkable loadable extensions EDK
-   :relevant-api: llext
+   :relevant-api: llext_apis
 
     Enable linkable loadable extension development outside the Zephyr tree using
     LLEXT EDK (Extension Development Kit).

--- a/samples/subsys/llext/modules/README.rst
+++ b/samples/subsys/llext/modules/README.rst
@@ -1,6 +1,6 @@
 .. zephyr:code-sample:: llext-modules
    :name: Linkable loadable extensions "module" sample
-   :relevant-api: llext
+   :relevant-api: llext_apis
 
     Call a function in a loadable extension module,
     either built-in or loaded at runtime.

--- a/samples/subsys/llext/shell_loader/README.rst
+++ b/samples/subsys/llext/shell_loader/README.rst
@@ -1,6 +1,6 @@
 .. zephyr:code-sample:: llext-shell-loader
    :name: Linkable loadable extensions shell module
-   :relevant-api: llext
+   :relevant-api: llext_apis
 
    Manage loadable extensions using shell commands.
 


### PR DESCRIPTION
Auto-add references to doxygen at the bottom of code samples' README
Fixes #77149.

Example of the new output: https://builds.zephyrproject.io/zephyr/pr/77159/docs/samples/synchronization/README.html