### PR TITLE
twister: setup soc/arch roots based on module settings

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -958,6 +958,22 @@ class TwisterEnv:
             if snippet_root:
                 self.snippet_roots.append(Path(module.project) / snippet_root)
 
+
+        self.soc_roots = [Path(ZEPHYR_BASE), Path(ZEPHYR_BASE) / 'subsys' / 'testsuite']
+        self.dts_roots = [Path(ZEPHYR_BASE)]
+        self.arch_roots = [Path(ZEPHYR_BASE)]
+
+        for module in modules:
+            soc_root = module.meta.get("build", {}).get("settings", {}).get("soc_root")
+            if soc_root:
+                self.soc_roots.append(os.path.join(module.project, soc_root))
+            dts_root = module.meta.get("build", {}).get("settings", {}).get("dts_root")
+            if soc_root:
+                self.dts_roots.append(os.path.join(module.project, dts_root))
+            arch_root = module.meta.get("build", {}).get("settings", {}).get("arch_root")
+            if arch_root:
+                self.arch_roots.append(os.path.join(module.project, arch_root))
+
         self.hwm = None
 
         self.test_config = options.test_config if options else None

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -404,9 +404,9 @@ class TestPlan:
         # Note, internally in twister a board root includes the `boards` folder
         # but in Zephyr build system, the board root is without the `boards` in folder path.
         board_roots = [Path(os.path.dirname(root)) for root in self.env.board_roots]
-        lb_args = Namespace(arch_roots=[Path(ZEPHYR_BASE)], soc_roots=[Path(ZEPHYR_BASE),
-                            Path(ZEPHYR_BASE) / 'subsys' / 'testsuite'],
+        lb_args = Namespace(arch_roots=self.env.arch_roots, soc_roots=self.env.soc_roots,
                             board_roots=board_roots, board=None, board_dir=None)
+
         v1_boards = list_boards.find_boards(lb_args)
         v2_dirs = list_boards.find_v2_board_dirs(lb_args)
         for b in v1_boards:

--- a/scripts/tests/twister/test_testplan.py
+++ b/scripts/tests/twister/test_testplan.py
@@ -1233,7 +1233,7 @@ toolchain:
     p3_yamlfile = tmp_p3_dir / 'p3_B.conf'
     p3_yamlfile.write_text('')
 
-    env = mock.Mock(board_roots=[tmp_board_root_dir])
+    env = mock.Mock(board_roots=[tmp_board_root_dir],soc_roots=[tmp_path], arch_roots=[tmp_path])
 
     testplan = TestPlan(env=env)
 


### PR DESCRIPTION
Get data for various roots from modules and do not hardcode location
when retrieving list of boards in testplan.

Fixes #71761

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
