### PR TITLE
drivers: can: shell: use `shell_fprintf_normal` instead of `shell_fprintf`

### DIFF
--- a/drivers/can/can_shell.c
+++ b/drivers/can/can_shell.c
@@ -90,41 +90,41 @@ static void can_shell_print_frame(const struct shell *sh, const struct device *d
 
 #ifdef CONFIG_CAN_RX_TIMESTAMP
 	/* Timestamp */
-	shell_fprintf(sh, SHELL_NORMAL, "(%05d)  ", frame->timestamp);
+	shell_fprintf_normal(sh, "(%05d)  ", frame->timestamp);
 #endif /* CONFIG_CAN_RX_TIMESTAMP */
 
-	shell_fprintf(sh, SHELL_NORMAL, "%s  ", dev->name);
+	shell_fprintf_normal(sh, "%s  ", dev->name);
 
 #ifdef CONFIG_CAN_FD_MODE
 	/* Flags */
-	shell_fprintf(sh, SHELL_NORMAL, "%c%c  ",
-		      (frame->flags & CAN_FRAME_BRS) == 0 ? '-' : 'B',
-		      (frame->flags & CAN_FRAME_ESI) == 0 ? '-' : 'P');
+	shell_fprintf_normal(sh, "%c%c  ",
+			     (frame->flags & CAN_FRAME_BRS) == 0 ? '-' : 'B',
+			     (frame->flags & CAN_FRAME_ESI) == 0 ? '-' : 'P');
 #endif /* CONFIG_CAN_FD_MODE */
 
 	/* CAN ID */
-	shell_fprintf(sh, SHELL_NORMAL, "%*s%0*x  ",
-		(frame->flags & CAN_FRAME_IDE) != 0 ? 0 : 5, "",
-		(frame->flags & CAN_FRAME_IDE) != 0 ? 8 : 3,
-		(frame->flags & CAN_FRAME_IDE) != 0 ?
-		frame->id & CAN_EXT_ID_MASK : frame->id & CAN_STD_ID_MASK);
+	shell_fprintf_normal(sh, "%*s%0*x  ",
+			     (frame->flags & CAN_FRAME_IDE) != 0 ? 0 : 5, "",
+			     (frame->flags & CAN_FRAME_IDE) != 0 ? 8 : 3,
+			     (frame->flags & CAN_FRAME_IDE) != 0 ?
+			     frame->id & CAN_EXT_ID_MASK : frame->id & CAN_STD_ID_MASK);
 
 	/* DLC as number of bytes */
-	shell_fprintf(sh, SHELL_NORMAL, "%s[%0*d]  ",
-		(frame->flags & CAN_FRAME_FDF) != 0 ? "" : " ",
-		(frame->flags & CAN_FRAME_FDF) != 0 ? 2 : 1,
-		nbytes);
+	shell_fprintf_normal(sh, "%s[%0*d]  ",
+			     (frame->flags & CAN_FRAME_FDF) != 0 ? "" : " ",
+			     (frame->flags & CAN_FRAME_FDF) != 0 ? 2 : 1,
+			     nbytes);
 
 	/* Data payload */
 	if ((frame->flags & CAN_FRAME_RTR) != 0) {
-		shell_fprintf(sh, SHELL_NORMAL, "remote transmission request");
+		shell_fprintf_normal(sh, "remote transmission request");
 	} else {
 		for (i = 0; i < nbytes; i++) {
-			shell_fprintf(sh, SHELL_NORMAL, "%02x ", frame->data[i]);
+			shell_fprintf_normal(sh, "%02x ", frame->data[i]);
 		}
 	}
 
-	shell_fprintf(sh, SHELL_NORMAL, "\n");
+	shell_fprintf_normal(sh, "\n");
 
 #ifdef CONFIG_CAN_SHELL_SCRIPTING_FRIENDLY
 	shell_set_bypass(sh, NULL);
@@ -262,14 +262,14 @@ static void can_shell_print_extended_modes(const struct shell *sh, can_mode_t ca
 		/* Lookup symbolic mode name */
 		for (i = 0; i < ARRAY_SIZE(can_shell_mode_map); i++) {
 			if (BIT(bit) == can_shell_mode_map[i].mode) {
-				shell_fprintf(sh, SHELL_NORMAL, "%s ", can_shell_mode_map[i].name);
+				shell_fprintf_normal(sh, "%s ", can_shell_mode_map[i].name);
 				break;
 			}
 		}
 
 		if (i == ARRAY_SIZE(can_shell_mode_map)) {
 			/* Symbolic name not found, use raw mode */
-			shell_fprintf(sh, SHELL_NORMAL, "0x%08x ", (can_mode_t)BIT(bit));
+			shell_fprintf_normal(sh, "0x%08x ", (can_mode_t)BIT(bit));
 		}
 	}
 }
@@ -373,13 +373,13 @@ static int cmd_can_show(const struct shell *sh, size_t argc, char **argv)
 	shell_print(sh, "max std filters: %d", max_std_filters);
 	shell_print(sh, "max ext filters: %d", max_ext_filters);
 
-	shell_fprintf(sh, SHELL_NORMAL, "capabilities:    normal ");
+	shell_fprintf_normal(sh, "capabilities:    normal ");
 	can_shell_print_extended_modes(sh, cap);
-	shell_fprintf(sh, SHELL_NORMAL, "\n");
+	shell_fprintf_normal(sh, "\n");
 
-	shell_fprintf(sh, SHELL_NORMAL, "mode:            normal ");
+	shell_fprintf_normal(sh, "mode:            normal ");
 	can_shell_print_extended_modes(sh, can_get_mode(dev));
-	shell_fprintf(sh, SHELL_NORMAL, "\n");
+	shell_fprintf_normal(sh, "\n");
 
 	shell_print(sh, "state:           %s", can_shell_state_to_string(state));
 	shell_print(sh, "rx errors:       %d", err_cnt.rx_err_cnt);


### PR DESCRIPTION
Due to the introduction of `shell_xxx_impl` wrapper functions in PR #75340 and rename to `shell_fprintf_xxx` in PR #77192 we can minimize caller overhead by eliminating direct `color` parameter passing.
