### PR TITLE
drivers : display: stm32:  Replace release/reset  HAL API by Zephyr reset API

### DIFF
--- a/drivers/display/display_stm32_ltdc.c
+++ b/drivers/display/display_stm32_ltdc.c
@@ -17,6 +17,7 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/reset.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/sys/barrier.h>
 #include <zephyr/cache.h>
@@ -73,6 +74,7 @@ struct display_stm32_ltdc_config {
 	struct gpio_dt_spec disp_on_gpio;
 	struct gpio_dt_spec bl_ctrl_gpio;
 	struct stm32_pclken pclken;
+	const struct reset_dt_spec reset;
 	const struct pinctrl_dev_config *pctrl;
 	void (*irq_config_func)(const struct device *dev);
 	const struct device *display_controller;
@@ -354,8 +356,7 @@ static int stm32_ltdc_init(const struct device *dev)
 #endif
 
 	/* reset LTDC peripheral */
-	__HAL_RCC_LTDC_FORCE_RESET();
-	__HAL_RCC_LTDC_RELEASE_RESET();
+	(void)reset_line_toggle_dt(&config->reset);
 
 	data->current_pixel_format = DISPLAY_INIT_PIXEL_FORMAT;
 	data->current_pixel_size = STM32_LTDC_INIT_PIXEL_SIZE;
@@ -421,8 +422,7 @@ static int stm32_ltdc_suspend(const struct device *dev)
 	}
 
 	/* Reset LTDC peripheral registers */
-	__HAL_RCC_LTDC_FORCE_RESET();
-	__HAL_RCC_LTDC_RELEASE_RESET();
+	(void)reset_line_toggle_dt(&config->reset);
 
 	/* Turn off LTDC peripheral clock */
 	err = clock_control_off(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
@@ -601,6 +601,7 @@ static const struct display_driver_api stm32_ltdc_display_api = {
 				(GPIO_DT_SPEC_INST_GET(inst, disp_on_gpios)), ({ 0 })),		\
 		.bl_ctrl_gpio = COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, bl_ctrl_gpios),		\
 				(GPIO_DT_SPEC_INST_GET(inst, bl_ctrl_gpios)), ({ 0 })),		\
+		.reset = RESET_DT_SPEC_INST_GET(0),						\
 		.pclken = {									\
 			.enr = DT_INST_CLOCKS_CELL(inst, bits),					\
 			.bus = DT_INST_CLOCKS_CELL(inst, bus)					\

--- a/dts/arm/st/f4/stm32f429.dtsi
+++ b/dts/arm/st/f4/stm32f429.dtsi
@@ -25,6 +25,7 @@
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "ltdc", "ltdc_er";
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x04000000>;
+			resets = <&rctl STM32_RESET(APB2, 26U)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/f7/stm32f746.dtsi
+++ b/dts/arm/st/f7/stm32f746.dtsi
@@ -17,6 +17,7 @@
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "ltdc", "ltdc_err";
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x04000000>;
+			resets = <&rctl STM32_RESET(APB2, 26U)>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/f7/stm32f767.dtsi
+++ b/dts/arm/st/f7/stm32f767.dtsi
@@ -18,6 +18,7 @@
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "ltdc", "ltdc_err";
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x04000000>;
+			resets = <&rctl STM32_RESET(APB2, 26U)>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -88,6 +88,7 @@
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "ltdc", "ltdc_er";
 			clocks = <&rcc STM32_CLOCK_BUS_APB3 0x00000008>;
+			resets = <&rctl STM32_RESET(APB3, 4U)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/h7/stm32h743.dtsi
+++ b/dts/arm/st/h7/stm32h743.dtsi
@@ -49,6 +49,7 @@
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "ltdc", "ltdc_er";
 			clocks = <&rcc STM32_CLOCK_BUS_APB3 0x00000008>;
+			resets = <&rctl STM32_RESET(APB3, 4U)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/h7/stm32h745.dtsi
+++ b/dts/arm/st/h7/stm32h745.dtsi
@@ -42,6 +42,7 @@
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "ltdc", "ltdc_er";
 			clocks = <&rcc STM32_CLOCK_BUS_APB3 0x00000008>;
+			resets = <&rctl STM32_RESET(APB3, 4U)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/h7/stm32h750.dtsi
+++ b/dts/arm/st/h7/stm32h750.dtsi
@@ -49,6 +49,7 @@
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "ltdc", "ltdc_er";
 			clocks = <&rcc STM32_CLOCK_BUS_APB3 0x00000008>;
+			resets = <&rctl STM32_RESET(APB3, 4U)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/h7/stm32h7a3.dtsi
+++ b/dts/arm/st/h7/stm32h7a3.dtsi
@@ -52,6 +52,7 @@
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "ltdc", "ltdc_er";
 			clocks = <&rcc STM32_CLOCK_BUS_APB3 0x00000008>;
+			resets = <&rctl STM32_RESET(APB3, 4U)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/l4/stm32l4r9.dtsi
+++ b/dts/arm/st/l4/stm32l4r9.dtsi
@@ -17,7 +17,8 @@
 			reg = <0x40016800 0x200>;
 			interrupts = <91 0>, <92 0>;
 			interrupt-names = "ltdc", "ltdc_er";
-			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x40000000>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x04000000>;
+			resets = <&rctl STM32_RESET(APB2, 26U)>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/mp1/stm32mp157.dtsi
+++ b/dts/arm/st/mp1/stm32mp157.dtsi
@@ -395,6 +395,7 @@
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "ltdc", "ltdc_er";
 			clocks = <&rcc STM32_CLOCK_BUS_APB4 0x00000001>;
+			resets = <&rctl STM32_RESET(APB4, 26U)>;
 			status = "disabled";
 		};
 	};

--- a/dts/bindings/display/st,stm32-ltdc.yaml
+++ b/dts/bindings/display/st,stm32-ltdc.yaml
@@ -6,7 +6,7 @@ description: STM32 LCD-TFT display controller
 
 compatible: "st,stm32-ltdc"
 
-include: [lcd-controller.yaml, pinctrl-device.yaml]
+include: [lcd-controller.yaml, pinctrl-device.yaml, reset-device.yaml]
 
 properties:
   disp-on-gpios:
@@ -28,6 +28,9 @@ properties:
       If not defined, internal RAM will be used.
 
   clocks:
+    required: true
+
+  resets:
     required: true
 
   interrupts:


### PR DESCRIPTION
Replace direct hal api for display block reset to zephyr reset api framework.

- Replace all HAL_RESET/RELEASE functions with zephyr reset_line_toggle_dt  API function 
- Update the "st,stm32-ltdc"  binding by adding a resets require property 
- Update in all dts files that contain "ltdc" nodes with the "resets" property. which will allow us to control the LTDCRST bit of the specific register