### PR TITLE
scripts: twister: Make TwisterStatus autocasting more intuitive

### DIFF
--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -73,9 +73,9 @@ class Harness:
     def status(self, value : TwisterStatus) -> None:
         # Check for illegal assignments by value
         try:
-            key = value.name if isinstance(value, Enum) else value
-            self._status = TwisterStatus[key]
-        except KeyError:
+            key = value.value if isinstance(value, Enum) else value
+            self._status = TwisterStatus(key)
+        except ValueError:
             raise StatusAttributeError(self.__class__, value)
 
     def configure(self, instance):

--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -36,7 +36,7 @@ class Reporting:
             'deny_suite': ['footprint']
         },
         'footprint.json': {
-            'deny_status': ['FILTER'],
+            'deny_status': ['filtered'],
             'deny_suite': ['testcases', 'execution_time', 'recording', 'retries', 'runnable']
         }
     }
@@ -288,12 +288,12 @@ class Reporting:
             if instance.status == TwisterStatus.FILTER and not self.env.options.report_filtered:
                 continue
             if (filters and 'allow_status' in filters and \
-                instance.status not in [TwisterStatus[s] for s in filters['allow_status']]):
+                instance.status not in [TwisterStatus(s) for s in filters['allow_status']]):
                 logger.debug(f"Skip test suite '{instance.testsuite.name}' status '{instance.status}' "
                              f"not allowed for {filename}")
                 continue
             if (filters and 'deny_status' in filters and \
-                instance.status in [TwisterStatus[s] for s in filters['deny_status']]):
+                instance.status in [TwisterStatus(s) for s in filters['deny_status']]):
                 logger.debug(f"Skip test suite '{instance.testsuite.name}' status '{instance.status}' "
                              f"denied for {filename}")
                 continue

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -105,9 +105,9 @@ class TestInstance:
     def status(self, value : TwisterStatus) -> None:
         # Check for illegal assignments by value
         try:
-            key = value.name if isinstance(value, Enum) else value
-            self._status = TwisterStatus[key]
-        except KeyError:
+            key = value.value if isinstance(value, Enum) else value
+            self._status = TwisterStatus(key)
+        except ValueError:
             raise StatusAttributeError(self.__class__, value)
 
     def add_filter(self, reason, filter_type):

--- a/scripts/pylib/twister/twisterlib/testsuite.py
+++ b/scripts/pylib/twister/twisterlib/testsuite.py
@@ -374,9 +374,9 @@ class TestCase(DisablePyTestCollectionMixin):
     def status(self, value : TwisterStatus) -> None:
         # Check for illegal assignments by value
         try:
-            key = value.name if isinstance(value, Enum) else value
-            self._status = TwisterStatus[key]
-        except KeyError:
+            key = value.value if isinstance(value, Enum) else value
+            self._status = TwisterStatus(key)
+        except ValueError:
             raise StatusAttributeError(self.__class__, value)
 
     def __lt__(self, other):
@@ -440,9 +440,9 @@ class TestSuite(DisablePyTestCollectionMixin):
     def status(self, value : TwisterStatus) -> None:
         # Check for illegal assignments by value
         try:
-            key = value.name if isinstance(value, Enum) else value
-            self._status = TwisterStatus[key]
-        except KeyError:
+            key = value.value if isinstance(value, Enum) else value
+            self._status = TwisterStatus(key)
+        except ValueError:
             raise StatusAttributeError(self.__class__, value)
 
     def load(self, data):

--- a/scripts/tests/twister/test_errors.py
+++ b/scripts/tests/twister/test_errors.py
@@ -28,8 +28,8 @@ def test_configurationerror():
 def test_status_value_error():
     harness = Test()
 
-    expected_err = 'Test assigned status None,' \
+    expected_err = 'Test assigned status NONE,' \
                    ' which could not be cast to a TwisterStatus.'
 
     with pytest.raises(StatusAttributeError, match=expected_err):
-        harness.status = None
+        harness.status = 'NONE'

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -131,7 +131,7 @@ def test_handler_final_handle_actions(mocked_instance):
     handler.suite_name_check = True
 
     harness = twisterlib.harness.Test()
-    harness.status = 'NONE'
+    harness.status = None
     harness.detected_suite_names = mock.Mock()
     harness.matched_run_id = False
     harness.run_id_exists = True


### PR DESCRIPTION
Rather than writing the Enum key names, like `'FILTER'`, users probably would be more at-home using the same terms as they can find in their Twister reports, e.g. `'filtered'`. `None` will also be accepted and converted to `TwisterStatus.NONE`.