### PR TITLE
boards: shields: Add Pmod ACL sensor module

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3327,6 +3327,7 @@ ADI Platforms:
     - microbuilder
   files:
     - boards/adi/
+    - boards/shields/pmod_acl/
     - drivers/*/*max*
     - drivers/*/*max*/
     - drivers/dac/dac_ltc*

--- a/boards/adi/apard32690/apard32690_max32690_m4.dts
+++ b/boards/adi/apard32690/apard32690_max32690_m4.dts
@@ -110,6 +110,28 @@ arduino_spi: &spi1 {
 	pinctrl-names = "default";
 };
 
+&spi4a_miso_p1_2 {
+	power-source = <MAX32_VSEL_VDDIOH>;
+};
+
+&spi4a_mosi_p1_1 {
+	power-source = <MAX32_VSEL_VDDIOH>;
+};
+
+&spi4a_sck_p1_3 {
+	power-source = <MAX32_VSEL_VDDIOH>;
+};
+
+&spi4a_ss0_p1_0 {
+	power-source = <MAX32_VSEL_VDDIOH>;
+};
+
+pmod_spi: &spi4 {
+	pinctrl-0 = <&spi4a_miso_p1_2 &spi4a_mosi_p1_1 &spi4a_sck_p1_3
+		     &spi4a_ss0_p1_0>;
+	pinctrl-names = "default";
+};
+
 &spi3a_miso_p0_20 {
 	power-source = <MAX32_VSEL_VDDIOH>;
 };

--- a/boards/adi/apard32690/apard32690_max32690_m4.yaml
+++ b/boards/adi/apard32690/apard32690_max32690_m4.yaml
@@ -10,6 +10,7 @@ toolchain:
 supported:
   - arduino_serial
   - arduino_spi
+  - pmod_spi
   - gpio
   - serial
   - spi

--- a/boards/shields/pmod_acl/Kconfig.shield
+++ b/boards/shields/pmod_acl/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright (c) 2024 Analog Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+config SHIELD_PMOD_ACL
+	def_bool $(shields_list_contains,pmod_acl)

--- a/boards/shields/pmod_acl/boards/apard32690_max32690_m4.overlay
+++ b/boards/shields/pmod_acl/boards/apard32690_max32690_m4.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2024 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		accel0 = &adxl345_pmod_acl;
+	};
+};

--- a/boards/shields/pmod_acl/doc/index.rst
+++ b/boards/shields/pmod_acl/doc/index.rst
@@ -1,0 +1,52 @@
+.. pmod_acl:
+
+Digilent Pmod ACL
+#################
+
+Overview
+********
+
+The Digilent Pmod ACL is a 3-axis digital accelerometer module powered by the
+Analog Devices ADXL345.
+
+Programming
+***********
+
+Set ``--shield pmod_acl`` when you invoke ``west build``. For example:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/sensor/sensor_shell
+   :board: apard32690/max32690/m4
+   :shield: pmod_acl
+   :goals: build
+
+Requirements
+************
+
+This shield can only be used with a board which provides a configuration
+for Pmod connectors and defines node aliases for SPI and GPIO interfaces
+(see :ref:`shields` for more details).
+
+References
+**********
+
+- `Pmod ACL product page`_
+- `Pmod ACL reference manual`_
+- `Pmod ACL schematic`_
+- `ADXL345 product page`_
+- `ADXL345 data sheet`_
+
+.. _Pmod ACL product page:
+   https://digilent.com/shop/pmod-acl-3-axis-accelerometer/
+
+.. _Pmod ACL reference manual:
+   https://digilent.com/reference/pmod/pmodacl/reference-manual
+
+.. _Pmod ACL schematic:
+   https://digilent.com/reference/_media/reference/pmod/pmodacl/pmodacl_sch.pdf
+
+.. _ADXL345 product page:
+   https://www.analog.com/en/products/adxl345.html
+
+.. _ADXL345 data sheet:
+   https://www.analog.com/media/en/technical-documentation/data-sheets/adxl345.pdf

--- a/boards/shields/pmod_acl/pmod_acl.overlay
+++ b/boards/shields/pmod_acl/pmod_acl.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2024 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pmod_spi {
+	status = "okay";
+
+	adxl345_pmod_acl: adxl345@0 {
+		compatible = "adi,adxl345";
+		reg = <0x0>;
+		spi-max-frequency = <DT_FREQ_M(1)>;
+		status = "okay";
+	};
+};


### PR DESCRIPTION
Adds a new shield definition for the Digilent Pmod ACL module. This
module provides support for an ADI ADXL345 3-axis accelerometer over a
Pmod SPI connector.

Signed-off-by: Maureen Helm <maureen.helm@analog.com>