### PR TITLE
serial: bluetooth: Maximize notification payload size based on ATT MTU

### DIFF
--- a/drivers/serial/uart_bt.c
+++ b/drivers/serial/uart_bt.c
@@ -18,6 +18,8 @@ LOG_MODULE_REGISTER(uart_nus, CONFIG_UART_LOG_LEVEL);
 K_THREAD_STACK_DEFINE(nus_work_queue_stack, CONFIG_UART_BT_WORKQUEUE_STACK_SIZE);
 static struct k_work_q nus_work_queue;
 
+#define UART_BT_MTU_INVALID 0xFFFF
+
 struct uart_bt_data {
 	struct {
 		struct bt_nus_inst *inst;
@@ -78,6 +80,38 @@ static void bt_received(struct bt_conn *conn, const void *data, uint16_t len, vo
 	k_work_submit_to_queue(&nus_work_queue, &dev_data->uart.cb_work);
 }
 
+static void foreach_conn_handler_get_att_mtu(struct bt_conn *conn, void *data)
+{
+	uint16_t *min_att_mtu = (uint16_t *)data;
+	uint16_t conn_att_mtu = 0;
+	struct bt_conn_info conn_info;
+	int err;
+
+	err = bt_conn_get_info(conn, &conn_info);
+	if (!err && conn_info.state == BT_CONN_STATE_CONNECTED) {
+		conn_att_mtu = bt_gatt_get_uatt_mtu(conn);
+
+		if (conn_att_mtu > 0) {
+			*min_att_mtu = MIN(*min_att_mtu, conn_att_mtu);
+		}
+	}
+}
+
+static inline uint16_t get_max_chunk_size(void)
+{
+	uint16_t min_att_mtu = UART_BT_MTU_INVALID;
+
+	bt_conn_foreach(BT_CONN_TYPE_LE, foreach_conn_handler_get_att_mtu, &min_att_mtu);
+
+	if (min_att_mtu == UART_BT_MTU_INVALID) {
+		/** Default ATT MTU */
+		min_att_mtu = 23;
+	}
+
+	/** ATT NTF Payload overhead: opcode (1 octet) + attribute (2 octets) */
+	return (min_att_mtu - 1 - 2);
+}
+
 static void cb_work_handler(struct k_work *work)
 {
 	struct uart_bt_data *dev_data = CONTAINER_OF(work, struct uart_bt_data, uart.cb_work);
@@ -99,13 +133,13 @@ static void tx_work_handler(struct k_work *work)
 
 	__ASSERT_NO_MSG(dev_data);
 
+	uint16_t chunk_size = get_max_chunk_size();
 	do {
-		/** Using Minimum MTU at this point to guarantee all connected
-		 * peers will receive the data, without keeping track of MTU
-		 * size per-connection. This has the trade-off of limiting
-		 * throughput but allows multi-connection support.
+		/** The chunk size is based on the smallest MTU among all
+		 * peers, and the same chunk is sent to everyone. This avoids
+		 * managing separate read pointers: one per connection.
 		 */
-		len = ring_buf_get_claim(dev_data->uart.tx_ringbuf, &data, 20);
+		len = ring_buf_get_claim(dev_data->uart.tx_ringbuf, &data, chunk_size);
 		if (len > 0) {
 			err = bt_nus_inst_send(NULL, dev_data->bt.inst, data, len);
 			if (err) {


### PR DESCRIPTION
### Description
This PR adds the UART BT driver the ability to maximize the payload notification size by keeping track of run-time ATT MTU of all connected peers; thus making it possible to optimize the data-throughput sent over Bluetooth.

Note that this assumes the Bluetooth connection is properly configured (with the corresponding connection parameters) to optimize performance. This is application-specific and shall be examined on each scenario for optimal performance.

Fixes: #72018

### Testing
#### Test - Verify MTU-size bigger than 23
- Build and run Sample code using NUS:
``` console
west build -b nrf52840dk/nrf52840 -S nus-console samples/subsys/logging/logger/ -- -DCONFIG_LOG_BACKEND_UART_BUFFER_SIZE=512
```
- Connect using NUS Client app and observe packets flowing. This is an example of using a Linux client with btmon:
``` console
> ACL Data RX: Handle 3585 flags 0x02 dlen 98                                                                               #112430 [hci0] 2004.815437
      ATT: Handle Value Notification (0x1b) len 93
        Handle: 0x0012
          Data: 6520371b5b306d0d0a64656d6f5f746167205b30303a30303a30362e3234312c3633385d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d65737361676520381b5b306d0d0a
> ACL Data RX: Handle 3585 flags 0x02 dlen 251                                                                              #112431 [hci0] 2004.817377
> ACL Data RX: Handle 3585 flags 0x01 dlen 251                                                                              #112432 [hci0] 2004.820377
      ATT: Handle Value Notification (0x1b) len 497
        Handle: 0x0012
          Data: 64656d6f5f746167205b30303a30303a30362e3234312c3633385d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d65737361676520391b5b306d0d0a64656d6f5f746167205b30303a30303a30362e3234312c3633385d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d6573736167652031301b5b306d0d0a64656d6f5f746167205b30303a30303a30362e3234312c3636385d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d657373616765
> ACL Data RX: Handle 3585 flags 0x02 dlen 28                                                                               #112433 [hci0] 2004.820378
      ATT: Handle Value Notification (0x1b) len 23
        Handle: 0x0012
          Data: 0d0a64656d6f5f746167205b30303a30303a30362e
> ACL Data RX: Handle 3585 flags 0x02 dlen 154                                                                              #112434 [hci0] 2004.822403
      ATT: Handle Value Notification (0x1b) len 149
        Handle: 0x0012
          Data: 3234312c3639395d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d6573736167652031351b5b306d0d0a64656d6f5f746167205b30303a30303a30362e3234312c3639395d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d6573736167652031361b5b306d0d0a
> ACL Data RX: Handle 3585 flags 0x02 dlen 173                                                                              #112435 [hci0] 2004.825376
      ATT: Handle Value Notification (0x1b) len 168
        Handle: 0x0012
          Data: 64656d6f5f746167205b30303a30303a30362e3234312c3732395d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d6573736167652031371b5b306d0d0a64656d6f5f746167205b30303a30303a30362e3234312c3732395d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d6573736167652031381b5b306d0d0a
> ACL Data RX: Handle 3585 flags 0x02 dlen 251                                                                              #112436 [hci0] 2004.825432
> ACL Data RX: Handle 3585 flags 0x01 dlen 5                                                                                #112437 [hci0] 2004.825432
      ATT: Handle Value Notification (0x1b) len 251
        Handle: 0x0012
          Data: 64656d6f5f746167205b30303a30303a30362e3234312c3732395d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d6573736167652031391b5b306d0d0a64656d6f5f746167205b30303a30303a30362e3234312c3736305d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d6573736167652032301b5b306d0d0a64656d6f5f746167205b30303a30303a30362e3234312c3736305d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d6573736167652032311b5b306d0d0a
> ACL Data RX: Handle 3585 flags 0x02 dlen 90                                                                               #112438 [hci0] 2004.827418
      ATT: Handle Value Notification (0x1b) len 85
        Handle: 0x0012
          Data: 64656d6f5f746167205b30303a30303a30362e3234312c3736305d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d6573736167652032321b5b306d0d0a
> ACL Data RX: Handle 3585 flags 0x02 dlen 90                                                                               #112439 [hci0] 2004.829408
      ATT: Handle Value Notification (0x1b) len 85
        Handle: 0x0012
          Data: 64656d6f5f746167205b30303a30303a30362e3234312c3739305d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d6573736167652032331b5b306d0d0a
> ACL Data RX: Handle 3585 flags 0x02 dlen 163                                                                              #112440 [hci0] 2005.842377
      ATT: Handle Value Notification (0x1b) len 158
        Handle: 0x0012
          Data: 64656d6f5f746167205b30303a30303a30372e3236342c3337335d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d65737361676520301b5b306d0d0a64656d6f5f746167205b30303a30303a30372e3236342c3430345d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d657373616765
> ACL Data RX: Handle 3585 flags 0x02 dlen 97                                                                               #112441 [hci0] 2005.842378
      ATT: Handle Value Notification (0x1b) len 92
        Handle: 0x0012
          Data: 20311b5b306d0d0a64656d6f5f746167205b30303a30303a30372e3236342c3430345d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d65737361676520321b5b306d0d0a
> ACL Data RX: Handle 3585 flags 0x02 dlen 57                                                                               #112442 [hci0] 2005.844410
      ATT: Handle Value Notification (0x1b) len 52
        Handle: 0x0012
          Data: 64656d6f5f746167205b30303a30303a30372e3236342c3430345d201b5b306d3c696e663e206d61696e3a20706572666f72
> ACL Data RX: Handle 3585 flags 0x02 dlen 110                                                                              #112443 [hci0] 2005.844411
      ATT: Handle Value Notification (0x1b) len 105
        Handle: 0x0012
          Data: 6d616e63652074657374202d206c6f67206d65737361676520331b5b306d0d0a64656d6f5f746167205b30303a30303a30372e3236342c3433345d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d657373
> ACL Data RX: Handle 3585 flags 0x02 dlen 100                                                                              #112444 [hci0] 2005.846376
      ATT: Handle Value Notification (0x1b) len 95
        Handle: 0x0012
          Data: 61676520341b5b306d0d0a64656d6f5f746167205b30303a30303a30372e3236342c3433345d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d65737361676520351b5b306d0d0a
> ACL Data RX: Handle 3585 flags 0x02 dlen 162                                                                              #112445 [hci0] 2005.848376
      ATT: Handle Value Notification (0x1b) len 157
        Handle: 0x0012
          Data: 64656d6f5f746167205b30303a30303a30372e3236342c3433345d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d65737361676520361b5b306d0d0a64656d6f5f746167205b30303a30303a30372e3236342c3436355d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d6573736167
> ACL Data RX: Handle 3585 flags 0x02 dlen 98                                                                               #112446 [hci0] 2005.848377
      ATT: Handle Value Notification (0x1b) len 93
        Handle: 0x0012
          Data: 6520371b5b306d0d0a64656d6f5f746167205b30303a30303a30372e3236342c3436355d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d65737361676520381b5b306d0d0a
> ACL Data RX: Handle 3585 flags 0x02 dlen 251                                                                              #112447 [hci0] 2005.852377
> ACL Data RX: Handle 3585 flags 0x01 dlen 251                                                                              #112448 [hci0] 2005.855376
      ATT: Handle Value Notification (0x1b) len 497
        Handle: 0x0012
          Data: 64656d6f5f746167205b30303a30303a30372e3236342c3436355d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d65737361676520391b5b306d0d0a64656d6f5f746167205b30303a30303a30372e3236342c3436355d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d6573736167652031301b5b306d0d0a64656d6f5f746167205b30303a30303a30372e3236342c3439355d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d657373616765
> ACL Data RX: Handle 3585 flags 0x02 dlen 94                                                                               #112449 [hci0] 2005.855377
      ATT: Handle Value Notification (0x1b) len 89
        Handle: 0x0012
          Data: 0d0a64656d6f5f746167205b30303a30303a30372e3236342c3532365d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d6573736167652031351b5b306d0d0a6465
> ACL Data RX: Handle 3585 flags 0x02 dlen 251                                                                              #112450 [hci0] 2005.858377
> ACL Data RX: Handle 3585 flags 0x01 dlen 237                                                                              #112451 [hci0] 2005.861376
      ATT: Handle Value Notification (0x1b) len 483
        Handle: 0x0012
          Data: 6d6f5f746167205b30303a30303a30372e3236342c3532365d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d6573736167652031361b5b306d0d0a64656d6f5f746167205b30303a30303a30372e3236342c3535365d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d6573736167652031371b5b306d0d0a64656d6f5f746167205b30303a30303a30372e3236342c3535365d201b5b306d3c696e663e206d61696e3a20706572666f726d616e6365207465737420
> ACL Data RX: Handle 3585 flags 0x02 dlen 105                                                                              #112452 [hci0] 2005.861377
      ATT: Handle Value Notification (0x1b) len 100
        Handle: 0x0012
          Data: 6573736167652032311b5b306d0d0a64656d6f5f746167205b30303a30303a30372e3236342c3538375d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d6573736167652032321b5b306d0d0a
> ACL Data RX: Handle 3585 flags 0x02 dlen 251                                                                              #112453 [hci0] 2005.864383
> ACL Data RX: Handle 3585 flags 0x01 dlen 5                                                                                #112454 [hci0] 2005.864384
      ATT: Handle Value Notification (0x1b) len 251
        Handle: 0x0012
          Data: 64656d6f5f746167205b30303a30303a30372e3236342c3631375d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d6573736167652032331b5b306d0d0a64656d6f5f746167205b30303a30303a30372e3236342c3631375d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d6573736167652032341b5b306d0d0a64656d6f5f746167205b30303a30303a30372e3236342c3631375d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d6573736167652032351b5b306d0d0a
> ACL Data RX: Handle 3585 flags 0x02 dlen 90                                                                               #112455 [hci0] 2005.866418
      ATT: Handle Value Notification (0x1b) len 85
        Handle: 0x0012
          Data: 64656d6f5f746167205b30303a30303a30372e3236342c3634385d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d6573736167652032361b5b306d0d0a
> ACL Data RX: Handle 3585 flags 0x02 dlen 120                                                                              #112456 [hci0] 2005.866419
      ATT: Handle Value Notification (0x1b) len 115
        Handle: 0x0012
          Data: 64656d6f5f746167205b30303a30303a30372e3236342c3634385d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d6573736167652032371b5b306d0d0a64656d6f5f746167205b30303a30303a30372e3236342c3634385d201b5b
> ACL Data RX: Handle 3585 flags 0x02 dlen 251                                                                              #112457 [hci0] 2005.870401
> ACL Data RX: Handle 3585 flags 0x01 dlen 184                                                                              #112458 [hci0] 2005.872376
      ATT: Handle Value Notification (0x1b) len 430
        Handle: 0x0012
          Data: 306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d6573736167652032381b5b306d0d0a64656d6f5f746167205b30303a30303a30372e3236342c3637385d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d6573736167652032391b5b306d0d0a64656d6f5f746167205b30303a30303a30372e3236342c3637385d201b5b306d3c696e66
> ACL Data RX: Handle 3585 flags 0x02 dlen 251                                                                              #112459 [hci0] 2005.875375
> ACL Data RX: Handle 3585 flags 0x01 dlen 211                                                                              #112460 [hci0] 2005.875377
      ATT: Handle Value Notification (0x1b) len 457
        Handle: 0x0012
          Data: 20706572666f726d616e63652074657374202d206c6f67206d6573736167652033331b5b306d0d0a64656d6f5f746167205b30303a30303a30372e3236342c3730395d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d6573736167652033341b5b306d0d0a64656d6f5f746167205b30303a30303a30372e3236342c3730395d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d6573736167652033
> ACL Data RX: Handle 3585 flags 0x02 dlen 90                                                                               #112461 [hci0] 2005.877405
      ATT: Handle Value Notification (0x1b) len 85
        Handle: 0x0012
          Data: 64656d6f5f746167205b30303a30303a30372e3236342c3737305d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d6573736167652033391b5b306d0d0a
> ACL Data RX: Handle 3585 flags 0x02 dlen 65                                                                               #112462 [hci0] 2005.877407
      ATT: Handle Value Notification (0x1b) len 60
        Handle: 0x0012
          Data: 64656d6f5f746167205b30303a30303a30372e3236342c3737305d201b5b306d3c696e663e206d61696e3a20706572666f726d616e6365207465
> ACL Data RX: Handle 3585 flags 0x02 dlen 251                                                                              #112463 [hci0] 2005.881404
> ACL Data RX: Handle 3585 flags 0x01 dlen 30                                                                               #112464 [hci0] 2005.881406
      ATT: Handle Value Notification (0x1b) len 276
        Handle: 0x0012
          Data: 7374202d206c6f67206d6573736167652034
> ACL Data RX: Handle 3585 flags 0x02 dlen 251                                                                              #112465 [hci0] 2005.884401
> ACL Data RX: Handle 3585 flags 0x01 dlen 88                                                                               #112466 [hci0] 2005.886380
      ATT: Handle Value Notification (0x1b) len 334
        Handle: 0x0012
          Data: 64656d6f5f746167205b30303a30303a30372e3236342c3830315d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d6573736167652034
> ACL Data RX: Handle 3585 flags 0x02 dlen 90                                                                               #112467 [hci0] 2005.886403
      ATT: Handle Value Notification (0x1b) len 85
        Handle: 0x0012
          Data: 64656d6f5f746167205b30303a30303a30372e3236342c3836325d201b5b306d3c696e663e206d61696e3a20706572666f726d616e63652074657374202d206c6f67206d6573736167652034381b5b306d0d0a
> ACL Data RX: Handle 3585 flags 0x02 dlen 63                                                                               #112468 [hci0] 2006.876376
      ATT: Handle Value Notification (0x1b) len 58
        Handle: 0x0012
          Data: 457374696d61746564206c6f6767696e67206361706162696c69746965733a20313030333532206d657373616765732f7365636f6e640d0a
> ACL Data RX: Handle 3585 flags 0x02 dlen 117                                                                              #112469 [hci0] 2007.911377
      ATT: Handle Value Notification (0x1b) len 112
        Handle: 0x0012
          Data: 4c6f67732066726f6d2065787465726e616c206c6f6767696e672073797374656d2073686f77636173652e0d0a64656d6f5f746167205b30303a30303a30392e3332322c3636325d201b5b313b33316d3c6572723e20637269746963616c206c6576656c206c6f671b5b306d0d0a
> ACL Data RX: Handle 3585 flags 0x02 dlen 163                                                                              #112470 [hci0] 2007.913414
      ATT: Handle Value Notification (0x1b) len 158
        Handle: 0x0012
          Data: 64656d6f5f746167205b30303a30303a30392e3332322c3639325d201b5b313b33316d3c6572723e206572726f72206c6576656c206c6f672c203120617267756d656e74733a20311b5b306d0d0a64656d6f5f746167205b30303a30303a30392e3332322c3732335d201b5b313b33336d3c77726e3e207761726e696e67206c6576656c206c6f672c203220617267756d656e74733a203120321b5b
> ACL Data RX: Handle 3585 flags 0x02 dlen 20                                                                               #112471 [hci0] 2007.913415
      ATT: Handle Value Notification (0x1b) len 15
        Handle: 0x0012
          Data: 306d0d0a64656d6f5f74616720
> ACL Data RX: Handle 3585 flags 0x02 dlen 96                                                                               #112472 [hci0] 2007.915377
      ATT: Handle Value Notification (0x1b) len 91
        Handle: 0x0012
          Data: 5b30303a30303a30392e3332322c3735335d201b5b306d3c696e663e206e6f74696365206c6576656c206c6f672c203320617267756d656e74733a203130302c20737472696e672c20307830303030303235351b5b306d0d0a
> ACL Data RX: Handle 3585 flags 0x02 dlen 158                                                                              #112473 [hci0] 2007.917414
      ATT: Handle Value Notification (0x1b) len 153
        Handle: 0x0012
          Data: 64656d6f5f746167205b30303a30303a30392e3332322c3831345d201b5b306d3c696e663e20696e666f206c6576656c206c6f672c203420617267756d656e7473203a20312032203320341b5b306d0d0a64656d6f5f746167205b30303a30303a30392e3332322c3834355d201b5b306d3c6462673e206465627567206c6576656c206c6f672c203520617267756d656e74733a203120
> ACL Data RX: Handle 3585 flags 0x02 dlen 20
```