### PR TITLE
intel_adsp: Fix build issues

### DIFF
--- a/soc/intel/intel_adsp/Kconfig.defconfig
+++ b/soc/intel/intel_adsp/Kconfig.defconfig
@@ -48,4 +48,7 @@ choice CACHE_TYPE
 	default ARCH_CACHE
 endchoice
 
+config DCACHE_LINE_SIZE
+	default 64
+
 endif # SOC_FAMILY_INTEL_ADSP

--- a/soc/intel/intel_adsp/ace/power.c
+++ b/soc/intel/intel_adsp/ace/power.c
@@ -43,7 +43,7 @@ __imr void power_init(void)
 #if CONFIG_SOC_INTEL_ACE15_MTPM
 	*((__sparse_force uint32_t *)sys_cache_cached_ptr_get(&adsp_pending_buffer)) =
 		INTEL_ADSP_ACE15_MAGIC_KEY;
-	cache_data_flush_range((__sparse_force void *)
+	sys_cache_data_flush_range((__sparse_force void *)
 			sys_cache_cached_ptr_get(&adsp_pending_buffer),
 			sizeof(adsp_pending_buffer));
 #endif /* CONFIG_SOC_INTEL_ACE15_MTPM */


### PR DESCRIPTION
- `DCACHE_LINE_SIZE` was not defined
- Undefined reference for `cache_data_flush_range`