### PR TITLE
multi_heap: introduce support for realloc()

### DIFF
--- a/doc/kernel/memory_management/heap.rst
+++ b/doc/kernel/memory_management/heap.rst
@@ -127,6 +127,13 @@ application-provided callback is responsible for doing the underlying
 allocation from one of the managed heaps, and may use the
 configuration parameter in any way it likes to make that decision.
 
+For modifying the size of an allocated buffer (whether shrinking
+or enlarging it), you can use the
+:c:func:`sys_multi_heap_realloc` and
+:c:func:`sys_multi_heap_aligned_realloc` APIs.  If the buffer cannot be
+enlarged on the heap where it currently resides,
+any of the eligible heaps specified by the configuration parameter may be used.
+
 When unused, a multi heap may be freed via
 :c:func:`sys_multi_heap_free`.  The application does not need to pass
 a configuration parameter.  Memory allocated from any of the managed

--- a/include/zephyr/sys/multi_heap.h
+++ b/include/zephyr/sys/multi_heap.h
@@ -168,6 +168,32 @@ const struct sys_multi_heap_rec *sys_multi_heap_get_heap(const struct sys_multi_
  */
 void sys_multi_heap_free(struct sys_multi_heap *mheap, void *block);
 
+/** @brief Expand the size of an existing allocation on the multi heap
+ *
+ * Returns a pointer to a new memory region with the same contents,
+ * but a different allocated size.  If the new allocation can be
+ * expanded in place, the pointer returned will be identical.
+ * Otherwise the data will be copies to a new block and the old one
+ * will be freed as per sys_heap_free().  If the specified size is
+ * smaller than the original, the block will be truncated in place and
+ * the remaining memory returned to the heap.  If the allocation of a
+ * new block fails, then NULL will be returned and the old block will
+ * not be freed or modified. If a new allocation is needed, the choice
+ * for the heap used will be bases on the cfg parameter (same as in sys_multi_heap_aligned_alloc).
+ *
+ * @param mheap Multi heap pointer
+ * @param cfg Opaque configuration parameter, as for sys_multi_heap_fn_t
+ * @param ptr Original pointer returned from a previous allocation
+ * @param align Alignment in bytes, must be a power of two
+ * @param bytes Number of bytes requested for the new block
+ * @return Pointer to memory the caller can now use, or NULL
+ */
+void *sys_multi_heap_aligned_realloc(struct sys_multi_heap *mheap, void *cfg,
+				     void *ptr, size_t align, size_t bytes);
+
+#define sys_multi_heap_realloc(mheap, cfg, ptr, bytes) \
+	sys_multi_heap_aligned_realloc(mheap, cfg, ptr, 0, bytes)
+
 /**
  * @}
  */


### PR DESCRIPTION
Add support for realloc (and realloc_aligned) into the multi heap lib, where the buffer sent in will either be reused (maybe shrinked), or enlarged by allocating on any of the matching heaps of the multi heap.

See issue:
#77174 