### PR TITLE
shell: rename `shell_xxx_impl` wrapper functions to `shell_fprintf_xxx`

### DIFF
--- a/include/zephyr/shell/shell.h
+++ b/include/zephyr/shell/shell.h
@@ -1093,8 +1093,8 @@ void shell_hexdump(const struct shell *sh, const uint8_t *data, size_t len);
  * @param[in] ... List of parameters to print.
  */
 #define shell_info(_sh, _ft, ...) \
-	shell_info_impl(_sh, _ft "\n", ##__VA_ARGS__)
-void __printf_like(2, 3) shell_info_impl(const struct shell *sh, const char *fmt, ...);
+	shell_fprintf_info(_sh, _ft "\n", ##__VA_ARGS__)
+void __printf_like(2, 3) shell_fprintf_info(const struct shell *sh, const char *fmt, ...);
 
 /**
  * @brief Print normal message to the shell.
@@ -1106,8 +1106,8 @@ void __printf_like(2, 3) shell_info_impl(const struct shell *sh, const char *fmt
  * @param[in] ... List of parameters to print.
  */
 #define shell_print(_sh, _ft, ...) \
-	shell_print_impl(_sh, _ft "\n", ##__VA_ARGS__)
-void __printf_like(2, 3) shell_print_impl(const struct shell *sh, const char *fmt, ...);
+	shell_fprintf_normal(_sh, _ft "\n", ##__VA_ARGS__)
+void __printf_like(2, 3) shell_fprintf_normal(const struct shell *sh, const char *fmt, ...);
 
 /**
  * @brief Print warning message to the shell.
@@ -1119,8 +1119,8 @@ void __printf_like(2, 3) shell_print_impl(const struct shell *sh, const char *fm
  * @param[in] ... List of parameters to print.
  */
 #define shell_warn(_sh, _ft, ...) \
-	shell_warn_impl(_sh, _ft "\n", ##__VA_ARGS__)
-void __printf_like(2, 3) shell_warn_impl(const struct shell *sh, const char *fmt, ...);
+	shell_fprintf_warn(_sh, _ft "\n", ##__VA_ARGS__)
+void __printf_like(2, 3) shell_fprintf_warn(const struct shell *sh, const char *fmt, ...);
 
 /**
  * @brief Print error message to the shell.
@@ -1132,8 +1132,8 @@ void __printf_like(2, 3) shell_warn_impl(const struct shell *sh, const char *fmt
  * @param[in] ... List of parameters to print.
  */
 #define shell_error(_sh, _ft, ...) \
-	shell_error_impl(_sh, _ft "\n", ##__VA_ARGS__)
-void __printf_like(2, 3) shell_error_impl(const struct shell *sh, const char *fmt, ...);
+	shell_fprintf_error(_sh, _ft "\n", ##__VA_ARGS__)
+void __printf_like(2, 3) shell_fprintf_error(const struct shell *sh, const char *fmt, ...);
 
 /**
  * @brief Process function, which should be executed when data is ready in the

--- a/subsys/net/lib/shell/net_shell_private.h
+++ b/subsys/net/lib/shell/net_shell_private.h
@@ -11,7 +11,7 @@
 #define PR(fmt, ...)                                                            \
 	do {                                                                    \
 		if (sh) {                                                       \
-			shell_print_impl(sh, fmt, ##__VA_ARGS__);               \
+			shell_fprintf_normal(sh, fmt, ##__VA_ARGS__);           \
 		} else {                                                        \
 			printk(fmt, ##__VA_ARGS__);                             \
 		}                                                               \
@@ -20,7 +20,7 @@
 #define PR_SHELL(sh, fmt, ...)                                                  \
 	do {                                                                    \
 		if (sh) {                                                       \
-			shell_print_impl(sh, fmt, ##__VA_ARGS__);               \
+			shell_fprintf_normal(sh, fmt, ##__VA_ARGS__);           \
 		} else {                                                        \
 			printk(fmt, ##__VA_ARGS__);                             \
 		}                                                               \
@@ -29,7 +29,7 @@
 #define PR_ERROR(fmt, ...)                                                      \
 	do {                                                                    \
 		if (sh) {                                                       \
-			shell_error_impl(sh, fmt, ##__VA_ARGS__);               \
+			shell_fprintf_error(sh, fmt, ##__VA_ARGS__);            \
 		} else {                                                        \
 			printk(fmt, ##__VA_ARGS__);                             \
 		}                                                               \
@@ -38,7 +38,7 @@
 #define PR_INFO(fmt, ...)                                                       \
 	do {                                                                    \
 		if (sh) {                                                       \
-			shell_info_impl(sh, fmt, ##__VA_ARGS__);                \
+			shell_fprintf_info(sh, fmt, ##__VA_ARGS__);             \
 		} else {                                                        \
 			printk(fmt, ##__VA_ARGS__);                             \
 		}                                                               \
@@ -47,7 +47,7 @@
 #define PR_WARNING(fmt, ...)                                                    \
 	do {                                                                    \
 		if (sh) {                                                       \
-			shell_warn_impl(sh, fmt, ##__VA_ARGS__);                \
+			shell_fprintf_warn(sh, fmt, ##__VA_ARGS__);             \
 		} else {                                                        \
 			printk(fmt, ##__VA_ARGS__);                             \
 		}                                                               \

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1548,10 +1548,10 @@ void shell_vfprintf(const struct shell *sh, enum shell_vt100_color color,
 
 /* These functions mustn't be used from shell context to avoid deadlock:
  * - shell_fprintf_impl
- * - shell_info_impl
- * - shell_print_impl
- * - shell_warn_impl
- * - shell_error_impl
+ * - shell_fprintf_info
+ * - shell_fprintf_normal
+ * - shell_fprintf_warn
+ * - shell_fprintf_error
  * However, they can be used in shell command handlers.
  */
 void shell_fprintf_impl(const struct shell *sh, enum shell_vt100_color color,
@@ -1564,7 +1564,7 @@ void shell_fprintf_impl(const struct shell *sh, enum shell_vt100_color color,
 	va_end(args);
 }
 
-void shell_info_impl(const struct shell *sh, const char *fmt, ...)
+void shell_fprintf_info(const struct shell *sh, const char *fmt, ...)
 {
 	va_list args;
 
@@ -1573,7 +1573,7 @@ void shell_info_impl(const struct shell *sh, const char *fmt, ...)
 	va_end(args);
 }
 
-void shell_print_impl(const struct shell *sh, const char *fmt, ...)
+void shell_fprintf_normal(const struct shell *sh, const char *fmt, ...)
 {
 	va_list args;
 
@@ -1582,7 +1582,7 @@ void shell_print_impl(const struct shell *sh, const char *fmt, ...)
 	va_end(args);
 }
 
-void shell_warn_impl(const struct shell *sh, const char *fmt, ...)
+void shell_fprintf_warn(const struct shell *sh, const char *fmt, ...)
 {
 	va_list args;
 
@@ -1591,7 +1591,7 @@ void shell_warn_impl(const struct shell *sh, const char *fmt, ...)
 	va_end(args);
 }
 
-void shell_error_impl(const struct shell *sh, const char *fmt, ...)
+void shell_fprintf_error(const struct shell *sh, const char *fmt, ...)
 {
 	va_list args;
 
@@ -1607,35 +1607,35 @@ void shell_hexdump_line(const struct shell *sh, unsigned int offset,
 
 	int i;
 
-	shell_print_impl(sh, "%08X: ", offset);
+	shell_fprintf_normal(sh, "%08X: ", offset);
 
 	for (i = 0; i < SHELL_HEXDUMP_BYTES_IN_LINE; i++) {
 		if (i > 0 && !(i % 8)) {
-			shell_print_impl(sh, " ");
+			shell_fprintf_normal(sh, " ");
 		}
 
 		if (i < len) {
-			shell_print_impl(sh, "%02x ",
-					 data[i] & 0xFF);
+			shell_fprintf_normal(sh, "%02x ",
+					     data[i] & 0xFF);
 		} else {
-			shell_print_impl(sh, "   ");
+			shell_fprintf_normal(sh, "   ");
 		}
 	}
 
-	shell_print_impl(sh, "|");
+	shell_fprintf_normal(sh, "|");
 
 	for (i = 0; i < SHELL_HEXDUMP_BYTES_IN_LINE; i++) {
 		if (i > 0 && !(i % 8)) {
-			shell_print_impl(sh, " ");
+			shell_fprintf_normal(sh, " ");
 		}
 
 		if (i < len) {
 			char c = data[i];
 
-			shell_print_impl(sh, "%c",
-					 isprint((int)c) != 0 ? c : '.');
+			shell_fprintf_normal(sh, "%c",
+					     isprint((int)c) != 0 ? c : '.');
 		} else {
-			shell_print_impl(sh, " ");
+			shell_fprintf_normal(sh, " ");
 		}
 	}
 


### PR DESCRIPTION
Since the `_impl` naming convention is intended for internal use only, renaming these functions to the `shell_fprintf_xxx` variant is more suitable for calls outside the module:
- `shell_info_impl` to `shell_fprintf_info`
- `shell_print_impl` to `shell_fprintf_normal`
- `shell_warn_impl` to `shell_fprintf_warn`
- `shell_error_impl` to `shell_fprintf_error`

---
This change is related to PR https://github.com/zephyrproject-rtos/zephyr/pull/77165.
