### PR TITLE
disk: sdmmc: power off card in `DISK_IOCTL_CTRL_DEINIT`

### DIFF
--- a/drivers/disk/sdmmc_subsys.c
+++ b/drivers/disk/sdmmc_subsys.c
@@ -93,12 +93,9 @@ static int disk_sdmmc_access_ioctl(struct disk_info *disk, uint8_t cmd, void *bu
 	case DISK_IOCTL_CTRL_INIT:
 		return disk_sdmmc_access_init(disk);
 	case DISK_IOCTL_CTRL_DEINIT:
-		sdmmc_ioctl(&data->card, DISK_IOCTL_CTRL_SYNC, NULL);
-		/* sd_init() will toggle power to SDMMC, so we can just mark
-		 * disk as uninitialized
-		 */
+		/* Card will be uninitialized after DEINIT */
 		data->status = SD_UNINIT;
-		return 0;
+		return sdmmc_ioctl(&data->card, DISK_IOCTL_CTRL_DEINIT, NULL);
 	default:
 		return sdmmc_ioctl(&data->card, cmd, buf);
 	}

--- a/drivers/sdhc/sdhc_spi.c
+++ b/drivers/sdhc/sdhc_spi.c
@@ -720,10 +720,12 @@ static int sdhc_spi_set_io(const struct device *dev, struct sdhc_io *ios)
 				if (gpio_pin_set_dt(&cfg->pwr_gpio, 1)) {
 					return -EIO;
 				}
+				LOG_INF("Powered up");
 			} else {
 				if (gpio_pin_set_dt(&cfg->pwr_gpio, 0)) {
 					return -EIO;
 				}
+				LOG_INF("Powered down");
 			}
 		}
 		data->power_mode = ios->power_mode;

--- a/subsys/sd/sd_ops.c
+++ b/subsys/sd/sd_ops.c
@@ -795,6 +795,16 @@ int card_ioctl(struct sd_card *card, uint8_t cmd, void *buf)
 		 */
 		ret = sdmmc_wait_ready(card);
 		break;
+	case DISK_IOCTL_CTRL_DEINIT:
+		/* Ensure card is not busy with data write */
+		ret = sdmmc_wait_ready(card);
+		if (ret < 0) {
+			LOG_WRN("Card busy when powering off");
+		}
+		/* Power down the card */
+		card->bus_io.power_mode = SDHC_POWER_OFF;
+		ret = sdhc_set_io(card->sdhc, &card->bus_io);
+		break;
 	default:
 		ret = -ENOTSUP;
 	}


### PR DESCRIPTION
Power off the SD card in `DISK_IOCTL_CTRL_DEINIT`, instead of only
waiting for the card to be idle then doing nothing. This is a safer
state for `DISK_IOCTL_CTRL_DEINIT`, which is documented as preparing the
disk to be removed from the system. It also has the advantage of
lowering power consumption while de-initialized.

Add a basic log message when power is applied or removed from the SDHC card.
