### PR TITLE
doc: rpi_pico fix I2C1 default peripheral mapping

### DIFF
--- a/boards/raspberrypi/rpi_pico/doc/index.rst
+++ b/boards/raspberrypi/rpi_pico/doc/index.rst
@@ -121,8 +121,8 @@ Default Zephyr Peripheral Mapping:
 - UART0_RX : P1
 - I2C0_SDA : P4
 - I2C0_SCL : P5
-- I2C1_SDA : P14
-- I2C1_SCL : P15
+- I2C1_SDA : P6
+- I2C1_SCL : P7
 - SPI0_RX : P16
 - SPI0_CSN : P17
 - SPI0_SCK : P18


### PR DESCRIPTION
This commit updates the board documentation to match the I2C1 default peripheral mapping in rpi_pico-pinctrl.dtsi.