### PR TITLE
Ztest documentation

### DIFF
--- a/doc/develop/test/ztest.rst
+++ b/doc/develop/test/ztest.rst
@@ -231,7 +231,7 @@ To select just one of the test scenarios, run Twister with ``--scenario`` comman
 
 .. code-block:: console
 
-   ./scripts/twister --scenario tests/foo/bar/your.test.scenario.name
+   ./scripts/twister --scenario your.test.scenario.name
 
 In the command line above ``tests/foo/bar`` is the path to your test application and
 ``your.test.scenario.name`` references a test scenario defined in :file:`testcase.yaml`


### PR DESCRIPTION
Fix the command using twister with --scenario option. utilizing path as misleading

./scripts/twister --scenario tests/foo/bar/your.test.scenario.name

to 

./scripts/twister --scenario your.test.scenario.name