### PR TITLE
net: openthread: Fix the handling of address state changes

### DIFF
--- a/subsys/net/l2/openthread/openthread_utils.c
+++ b/subsys/net/l2/openthread/openthread_utils.c
@@ -32,7 +32,7 @@ static bool is_mesh_local(struct openthread_context *context,
 	const otMeshLocalPrefix *ml_prefix =
 				otThreadGetMeshLocalPrefix(context->instance);
 
-	return (memcmp(address, ml_prefix->m8, sizeof(ml_prefix)) == 0);
+	return (memcmp(address, ml_prefix->m8, sizeof(ml_prefix->m8)) == 0);
 }
 
 int pkt_list_add(struct openthread_context *context, struct net_pkt *pkt)
@@ -156,9 +156,8 @@ void add_ipv6_addr_to_zephyr(struct openthread_context *context)
 					context, address->mAddress.mFields.m8);
 
 		/* Mark address as deprecated if it is not preferred. */
-		if (!address->mPreferred) {
-			if_addr->addr_state = NET_ADDR_DEPRECATED;
-		}
+		if_addr->addr_state =
+			address->mPreferred ? NET_ADDR_PREFERRED : NET_ADDR_DEPRECATED;
 	}
 }
 


### PR DESCRIPTION
The #76671 fixed the issue where a deprecated address might have been used as a source address, leading to routing issues until the address was completely removed. What was missed in the implementation was the case where the address changes its state back to "preferred" from "deprecated." In such case OpenThread emits `OT_CHANGED_IP6_ADDRESS_REMOVED` and `OT_CHANGED_IP6_ADDRESS_ADDED` events, but it does so simultaneously in one callback and without the hard removal that was previously assumed. This commit simply removes the if-statement, allowing the address state to be set at any time, whether during the initial addition of the address or during any update. Btw. I believe the current implementation of synchronization of the addresses coulb be simplified by utilizing a new API `otIp6SetAddressCallback` - i can look at this in the future. 

Testing was conducted manually by removing/adding the prefix and observing the `net ipv6` shell output.

Additionally, during static code analysis, I believe I found an issue with prefix comparison in the `is_mesh_prefix` function. It was assumed that the prefix was the size of a pointer, which in rare situations, where the mesh-local prefix and on-mesh prefix have the same first bytes, may lead to a situation where no communication can occur.