### PR TITLE
net: lwm2m: fix buffer size check for U16 resource

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_registry.c
+++ b/subsys/net/lib/lwm2m/lwm2m_registry.c
@@ -515,6 +515,7 @@ static int lwm2m_check_buf_sizes(uint8_t data_type, uint16_t resource_length, ui
 		}
 		break;
 	case LWM2M_RES_TYPE_U32:
+	case LWM2M_RES_TYPE_U16:
 	case LWM2M_RES_TYPE_U8:
 	case LWM2M_RES_TYPE_S64:
 	case LWM2M_RES_TYPE_S32:


### PR DESCRIPTION
This PR addresses the issue where `lwm2m_check_buf_sizes` function was not 
properly checking resources of type `LWM2M_RES_TYPE_U16`. This could potentially 
lead to overflows when writing larger data types into U16 resources.

Changes made:
- Added a case for `LWM2M_RES_TYPE_U16` in the `lwm2m_check_buf_sizes` function
- This ensures that the function returns `-EINVAL` if the resource length doesn't 
  match the buffer length for U16 resources

Fixes #77016