### PR TITLE
manifest: update hostap module

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -259,7 +259,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: 77a4cad575c91f1b234c8d15630f87999881cde2
+      revision: c030bbdf80ecda585d44a21f0088a7777648bcf0
     - name: libmetal
       revision: a6851ba6dba8c9e87d00c42f171a822f7a29639b
       path: modules/hal/libmetal


### PR DESCRIPTION
Enable TLS_MBEDTLS_CERT_VERIFY_EXTMATCH, to support the domain_match check, which is needed for the WPA3 CERT 11.1 case.