### PR TITLE
manifest: update tf-m to fix nRF pinctrl issues

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -327,7 +327,7 @@ manifest:
       groups:
         - crypto
     - name: trusted-firmware-m
-      revision: 069455be098383bf96eab73e3ff8e0c66c60fa5a
+      revision: pull/110/head
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
nRF code in TF-M relies on the same Zephyr pinctrl field layout. It was not updated during the v3.7 release cycle.

See also https://github.com/zephyrproject-rtos/zephyr/pull/77224

Fixes #77185 (only v3.7-branch)