### PR TITLE
manifest: update tf-m to align nRF pinctrl

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -327,7 +327,7 @@ manifest:
       groups:
         - crypto
     - name: trusted-firmware-m
-      revision: 069455be098383bf96eab73e3ff8e0c66c60fa5a
+      revision: pull/111/head
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
nRF code in TF-M relies on the same Zephyr pinctrl field layout. Align after CLOCKPIN changes, which modified the layout.

Fixes #77185