### PR TITLE
MAINTAINERS: Add missing exclude of mesh for Bluetooth Host

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -387,7 +387,7 @@ Bluetooth Host:
     - subsys/bluetooth/host/classic/
     - include/zephyr/bluetooth/audio/
     - include/zephyr/bluetooth/classic/
-    - include/zephyr/bluetooth/audio/
+    - include/zephyr/bluetooth/mesh/
     - include/zephyr/bluetooth/iso.h
     - include/zephyr/bluetooth/controller.h
     - include/zephyr/bluetooth/mesh.h


### PR DESCRIPTION
include/zephyr/bluetooth/mesh/ was missing from the exclusion files for Bluetooth Host, and include/zephyr/bluetooth/audio/ was there twice.