### PR TITLE
twister: Add Nuvoton to manufacturer table.

### DIFF
--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -144,7 +144,8 @@ class HardwareMap:
         'Microchip Technology Inc.',
         'FTDI',
         'Digilent',
-        'Microsoft'
+        'Microsoft',
+        'Nuvoton'
     ]
 
     runner_mapping = {


### PR DESCRIPTION
Using the twister command `twister --generate-hardware-map ./map.yaml` we've got the following warning.
```
INFO    - Using Ninja..
INFO    - Zephyr version: v3.6.0-3713-ge1e78a5f08a9
INFO    - Using 'zephyr' toolchain.
INFO    - Scanning connected hardware...
WARNING - Unsupported device (Nuvoton): <port> - NPCX4mnx_Evaluation_Board - NPCX4mnx_Evaluation_Board
WARNING - Unsupported device (Nuvoton): <port> - NPCX4mnx_Evaluation_Board - NPCX4mnx_Evaluation_Board
WARNING - Unsupported device (Nuvoton): <port> - NPCX4mnx_Evaluation_Board - NPCX4mnx_Evaluation_Board
WARNING - Unsupported device (Nuvoton): <port> - NPCX4mnx_Evaluation_Board - NPCX4mnx_Evaluation_Board
INFO    - Detected devices:

| Platform   | ID   | Serial device   |
|------------|------|-----------------|
```
To fix that, we need to expand the manufacturer table in the hardwaremap.py file to include `Nuvoton`.
After that, we are able to generate hardware map properly.
```
INFO    - Using Ninja..
INFO    - Zephyr version: v3.6.0-3713-ge1e78a5f08a9
INFO    - Using 'zephyr' toolchain.
INFO    - Scanning connected hardware...
INFO    - Registered devices:

| Platform   | ID             | Serial device   |
|------------|----------------|-----------------|
| unknown    | <id> | <port>    |
| unknown    | <id> | <port>    |
| unknown    | <id> | <port>    |
| unknown    | <id> | <port>    |

```