### PR TITLE
net: shell: Move bridge shell under net shell

### DIFF
--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -168,6 +168,10 @@ Networking
   :c:func:`coap_get_block2_option` now accepts an additional ``bool *has_more``
   parameter, to store the value of the more flag. (:github:`76052`)
 
+* The Ethernet bridge shell is moved under network shell. This is done so that
+  all the network shell activities can be found under ``net`` shell command.
+  After this change the bridge shell is used by ``net bridge`` command.
+
 Other Subsystems
 ****************
 

--- a/subsys/net/l2/ethernet/Kconfig
+++ b/subsys/net/l2/ethernet/Kconfig
@@ -115,7 +115,7 @@ endif # NET_ETHERNET_BRIDGE
 config NET_ETHERNET_BRIDGE_SHELL
 	bool "Ethernet Bridging management shell"
 	depends on NET_ETHERNET_BRIDGE
-	select SHELL
+	select NET_SHELL
 	help
 	  Enables shell utility to manage bridge configuration interactively.
 

--- a/subsys/net/l2/ethernet/bridge_shell.c
+++ b/subsys/net/l2/ethernet/bridge_shell.c
@@ -221,7 +221,9 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bridge_commands,
 	SHELL_SUBCMD_SET_END
 );
 
-SHELL_CMD_REGISTER(bridge, &bridge_commands, "Ethernet Bridge commands", NULL);
+SHELL_SUBCMD_ADD((net), bridge, &bridge_commands,
+		 "Ethernet bridge commands.",
+		 cmd_bridge_show, 1, 1);
 
 #if defined(CONFIG_NET_ETHERNET_BRIDGE_DEFAULT)
 static ETH_BRIDGE_INIT(shell_default_bridge);


### PR DESCRIPTION
All the network related shell activities should be under network shell so moving it to "net bridge ..." command. Add this information to migration guide.