### PR TITLE
Switch to stmems module v2.6

### DIFF
--- a/drivers/sensor/st/iis328dq/iis328dq.c
+++ b/drivers/sensor/st/iis328dq/iis328dq.c
@@ -77,10 +77,7 @@ static int iis328dq_set_odr(const struct device *dev, uint16_t odr)
 	} else if (odr <= 1) {
 		odr_reg = IIS328DQ_ODR_1Hz;
 	} else if (odr <= 2) {
-		/* not sure what "5Hz2" is about, datasheet says PM=0b100 is 2Hz
-		 * https://github.com/STMicroelectronics/STMems_Standard_C_drivers/issues/162
-		 */
-		odr_reg = IIS328DQ_ODR_5Hz2;
+		odr_reg = IIS328DQ_ODR_2Hz;
 	} else if (odr <= 5) {
 		odr_reg = IIS328DQ_ODR_5Hz;
 	} else if (odr <= 10) {

--- a/drivers/sensor/st/lis2dux12/lis2dux12.c
+++ b/drivers/sensor/st/lis2dux12/lis2dux12.c
@@ -213,10 +213,9 @@ static int lis2dux12_sample_fetch_temp(const struct device *dev)
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
 
 	/* fetch raw data sample */
-	lis2dux12_md_t mode;
 	lis2dux12_outt_data_t temp_data = {0};
 
-	if (lis2dux12_outt_data_get(ctx, &mode, &temp_data) < 0) {
+	if (lis2dux12_outt_data_get(ctx, &temp_data) < 0) {
 		LOG_ERR("Failed to fetch raw temperature data sample");
 		return -EIO;
 	}

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -1024,53 +1024,53 @@ test_i2c_lis2dux12: lis2dux12@8a {
 	status = "okay";
 };
 
-test_i2c_iis328dq: iis328dq@8a {
+test_i2c_iis328dq: iis328dq@8b {
 	compatible = "st,iis328dq";
 	status = "okay";
-	reg = <0x8a>;
+	reg = <0x8b>;
 	int2-gpios = <&test_gpio 0 0>;
 	threshold-int-pad = <2>;
 };
 
-test_i2c_nct75: test_i2c_nct75@8b {
+test_i2c_nct75: test_i2c_nct75@8c {
 	compatible = "onnn,nct75";
-	reg = <0x8b>;
+	reg = <0x8c>;
 	status = "okay";
 };
 
-test_i2c_tmp114: tmp114@8c {
+test_i2c_tmp114: tmp114@8d {
 	compatible = "ti,tmp114";
-	reg = <0x8c>;
+	reg = <0x8d>;
 };
 
-test_i2c_ina226: ina226@8d {
+test_i2c_ina226: ina226@8e {
 	compatible = "ti,ina226";
-	reg = <0x8d>;
+	reg = <0x8e>;
 	current-lsb-microamps = <5000>;
 	rshunt-micro-ohms = <500>;
 };
 
-test_i2c_shtc1: shtc1@8e {
+test_i2c_shtc1: shtc1@8f {
 	compatible = "sensirion,shtc1", "sensirion,shtcx";
-	reg = <0x8e>;
+	reg = <0x8f>;
 	measure-mode = "low-power";
 	clock-stretching;
 };
 
-test_i2c_lm95234: lm95234@8f {
+test_i2c_lm95234: lm95234@90 {
 	compatible = "national,lm95234";
-	reg = <0x8f>;
+	reg = <0x90>;
 	status = "okay";
 };
 
-test_i2c_sht21@90 {
+test_i2c_sht21@91 {
 	compatible = "sensirion,sht21";
-	reg = <0x90>;
+	reg = <0x91>;
 };
 
-test_i2c_lsm9ds1: lsm9ds1@91 {
+test_i2c_lsm9ds1: lsm9ds1@92 {
 	compatible = "st,lsm9ds1";
-	reg = <0x8e>;
+	reg = <0x92>;
 };
 
 test_i2c_icm42670: icm42670@92 {

--- a/west.yml
+++ b/west.yml
@@ -228,7 +228,7 @@ manifest:
       groups:
         - hal
     - name: hal_st
-      revision: b77157f6bc4395e398d90ab02a7d2cbc01ab2ce7
+      revision: b2f548fe672f24122c7f92027b2c9eeea8a0483a
       path: modules/hal/st
       groups:
         - hal


### PR DESCRIPTION
modules/hal_st: Align sensor drivers to stmemsc HAL i/f v2.6
    
Align all sensor drivers that are using stmemsc (STdC) HAL i/f
to new APIs of stmemsc v2.6
    
Requires https://github.com/zephyrproject-rtos/hal_st/pull/21
