### PR TITLE
tests: twister: add quit-on-failure option

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -669,6 +669,12 @@ structure in the main Zephyr tree: boards/<vendor>/<board_name>/""")
              "to verify their current status.")
 
     parser.add_argument(
+        "--quit-on-failure",
+        action="store_true",
+        help="""quit twister once there is build / run failure
+        """)
+
+    parser.add_argument(
         "--report-name",
         help="""Create a report with a custom name.
         """)

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -1927,6 +1927,11 @@ class TwisterRunner:
                             pb = ProjectBuilder(instance, self.env, self.jobserver)
                             pb.duts = self.duts
                             pb.process(pipeline, done_queue, task, lock, results)
+                            if self.env.options.quit_on_failure and \
+                                pb.instance.status in [TwisterStatus.FAIL, TwisterStatus.ERROR]:
+                                with pipeline.mutex:
+                                    pipeline.queue.clear()
+                                break
 
                     return True
             else:
@@ -1940,6 +1945,11 @@ class TwisterRunner:
                         pb = ProjectBuilder(instance, self.env, self.jobserver)
                         pb.duts = self.duts
                         pb.process(pipeline, done_queue, task, lock, results)
+                        if self.env.options.quit_on_failure and \
+                            pb.instance.status in [TwisterStatus.FAIL, TwisterStatus.ERROR]:
+                            with pipeline.mutex:
+                                pipeline.queue.clear()
+                            break
                 return True
         except Exception as e:
             logger.error(f"General exception: {e}")

--- a/scripts/pylib/twister/twisterlib/twister_main.py
+++ b/scripts/pylib/twister/twisterlib/twister_main.py
@@ -238,13 +238,17 @@ def main(options: argparse.Namespace, default_options: argparse.Namespace):
         artifacts = Artifacts(env)
         artifacts.package()
 
-    logger.info("Run completed")
     if (
         runner.results.failed
         or runner.results.error
         or (tplan.warnings and options.warnings_as_errors)
         or (options.coverage and not coverage_completed)
     ):
+        if env.options.quit_on_failure:
+            logger.info("twister aborted because of a failure/error")
+        else:
+            logger.info("Run completed")
         return 1
 
+    logger.info("Run completed")
     return 0


### PR DESCRIPTION
in CI, we may need to quit if there is any failure to save time, so add this --quit-on-failure so that any failure will quit the test.