### PR TITLE
drivers: usb: udc: add numaker m2l31x usbd controller

### DIFF
--- a/boards/nuvoton/numaker_m2l31ki/numaker_m2l31ki-pinctrl.dtsi
+++ b/boards/nuvoton/numaker_m2l31ki/numaker_m2l31ki-pinctrl.dtsi
@@ -24,4 +24,14 @@
 				 <PC9MFP_GPIO>;
 		};
 	};
+
+	/* USBD multi-function pins for VBUS, D+, D-, and ID pins */
+	usbd_default: usbd_default {
+		group0 {
+			pinmux = <PA12MFP_USB_VBUS>,
+				 <PA13MFP_USB_D_N>,
+				 <PA14MFP_USB_D_P>,
+				 <PA15MFP_USB_OTG_ID>;
+		};
+	};
 };

--- a/boards/nuvoton/numaker_m2l31ki/numaker_m2l31ki.dts
+++ b/boards/nuvoton/numaker_m2l31ki/numaker_m2l31ki.dts
@@ -35,12 +35,6 @@
 	};
 };
 
-&scc {
-	/* For USB 1.1 Host/Device/OTG, configure to 192MHz, which can generate necessary 48MHz. */
-	/* For USB 2.0 Host/Device/OTG or no USB application, comment out to use default. */
-	core-clock = <DT_FREQ_M(192)>;
-};
-
 &gpioc {
 	status = "okay";
 };
@@ -77,6 +71,13 @@
 &uart0 {
 	current-speed = <115200>;
 	pinctrl-0 = <&uart0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+/* On enabled, usbd is required to be clocked in 48MHz. */
+zephyr_udc0: &usbd {
+	pinctrl-0 = <&usbd_default>;
 	pinctrl-names = "default";
 	status = "okay";
 };

--- a/boards/nuvoton/numaker_m2l31ki/numaker_m2l31ki.yaml
+++ b/boards/nuvoton/numaker_m2l31ki/numaker_m2l31ki.yaml
@@ -13,4 +13,5 @@ ram: 168
 flash: 512
 supported:
   - gpio
+  - usbd
 vendor: nuvoton

--- a/dts/arm/nuvoton/m2l31x.dtsi
+++ b/dts/arm/nuvoton/m2l31x.dtsi
@@ -45,6 +45,7 @@
 			reg = <0x40000200 0x100>;
 			#clock-cells = <0>;
 			lxt = "enable";
+			hirc48m = "enable";
 			clk-pclkdiv = <(NUMAKER_CLK_PCLKDIV_APB0DIV_DIV2 |
 					NUMAKER_CLK_PCLKDIV_APB1DIV_DIV2)>;
 			core-clock = <DT_FREQ_M(72)>;
@@ -386,6 +387,19 @@
 				  NUMAKER_CLK_CLKDIV5_CANFD1(1)>;
 			bosch,mram-cfg = <0x0 12 10 3 3 3 3 3>;
 			status = "disabled";
+		};
+
+		usbd: usbd@400c0000 {
+			compatible = "nuvoton,numaker-usbd";
+			reg = <0x400c0000 0x1000>;
+			interrupts = <53 0>;
+			resets = <&rst NUMAKER_USBD_RST>;
+			clocks = <&pcc NUMAKER_USBD_MODULE NUMAKER_CLK_CLKSEL0_USBSEL_HIRC48M
+				  NUMAKER_CLK_CLKDIV0_USB(1)>;
+			dma-buffer-size = <1024>;
+			status = "disabled";
+			num-bidir-endpoints = <19>;
+			disallow-iso-in-out-same-number;
 		};
 
 		wwdt: watchdog@40096000 {

--- a/soc/nuvoton/numaker/m2l31x/soc.c
+++ b/soc/nuvoton/numaker/m2l31x/soc.c
@@ -57,14 +57,14 @@ void z_arm_platform_init(void)
 	/* Wait for LIRC clock ready */
 	CLK_WaitClockReady(CLK_STATUS_LIRCSTB_Msk);
 
-#if DT_NODE_HAS_PROP(DT_NODELABEL(scc), hirc48)
-	/* Enable/disable 48 MHz high-speed internal RC oscillator (HIRC48) */
-	if (DT_ENUM_IDX(DT_NODELABEL(scc), hirc48) == NUMAKER_SCC_CLKSW_ENABLE) {
-		CLK_EnableXtalRC(CLK_PWRCTL_HIRC48EN_Msk);
-		/* Wait for HIRC48 clock ready */
-		CLK_WaitClockReady(CLK_STATUS_HIRC48STB_Msk);
-	} else if (DT_ENUM_IDX(DT_NODELABEL(scc), hirc48) == NUMAKER_SCC_CLKSW_DISABLE) {
-		CLK_DisableXtalRC(CLK_PWRCTL_HIRC48EN_Msk);
+#if DT_NODE_HAS_PROP(DT_NODELABEL(scc), hirc48m)
+	/* Enable/disable 48 MHz high-speed internal RC oscillator (HIRC48M) */
+	if (DT_ENUM_IDX(DT_NODELABEL(scc), hirc48m) == NUMAKER_SCC_CLKSW_ENABLE) {
+		CLK_EnableXtalRC(CLK_PWRCTL_HIRC48MEN_Msk);
+		/* Wait for HIRC48M clock ready */
+		CLK_WaitClockReady(CLK_STATUS_HIRC48MSTB_Msk);
+	} else if (DT_ENUM_IDX(DT_NODELABEL(scc), hirc48m) == NUMAKER_SCC_CLKSW_DISABLE) {
+		CLK_DisableXtalRC(CLK_PWRCTL_HIRC48MEN_Msk);
 	}
 #endif
 


### PR DESCRIPTION
This is to support Nuvoton NuMaker M2L31 series SoC usbd controller.

Verified samples include:

- zephyr/samples/subsys/usb/cdc_acm
- zephyr/samples/subsys/usb/console
- zephyr/samples/subsys/usb/mass
