### PR TITLE
Drivers: Sensor: Add Bosch Bmp180 sensor v3

### DIFF
--- a/drivers/sensor/bosch/CMakeLists.txt
+++ b/drivers/sensor/bosch/CMakeLists.txt
@@ -13,6 +13,7 @@ add_subdirectory_ifdef(CONFIG_BMI160 bmi160)
 add_subdirectory_ifdef(CONFIG_BMI270 bmi270)
 add_subdirectory_ifdef(CONFIG_BMI323 bmi323)
 add_subdirectory_ifdef(CONFIG_BMM150 bmm150)
+add_subdirectory_ifdef(CONFIG_BMP180 bmp180)
 add_subdirectory_ifdef(CONFIG_BMP388 bmp388)
 add_subdirectory_ifdef(CONFIG_BMP581 bmp581)
 # zephyr-keep-sorted-stop

--- a/drivers/sensor/bosch/Kconfig
+++ b/drivers/sensor/bosch/Kconfig
@@ -13,6 +13,7 @@ source "drivers/sensor/bosch/bmi160/Kconfig"
 source "drivers/sensor/bosch/bmi270/Kconfig"
 source "drivers/sensor/bosch/bmi323/Kconfig"
 source "drivers/sensor/bosch/bmm150/Kconfig"
+source "drivers/sensor/bosch/bmp180/Kconfig"
 source "drivers/sensor/bosch/bmp388/Kconfig"
 source "drivers/sensor/bosch/bmp581/Kconfig"
 # zephyr-keep-sorted-stop

--- a/drivers/sensor/bosch/bmp180/CMakeLists.txt
+++ b/drivers/sensor/bosch/bmp180/CMakeLists.txt
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2024 Chris Ruehl
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+zephyr_library()
+zephyr_library_sources(bmp180.c bmp180_i2c.c)

--- a/drivers/sensor/bosch/bmp180/Kconfig
+++ b/drivers/sensor/bosch/bmp180/Kconfig
@@ -1,0 +1,18 @@
+# Copyright (c) 2024 Chris Ruehl
+# SPDX-License-Identifier: Apache-2.0
+
+menuconfig BMP180
+	bool "Bosch BMP180 pressure sensor"
+	default y
+	depends on DT_HAS_BOSCH_BMP180_ENABLED
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BMP180),i2c)
+	help
+	  Enable driver for the Bosch BMP180 pressure sensor
+
+if BMP180
+
+config BMP180_OSR_RUNTIME
+	bool "Change OSR at runtime."
+	default y
+
+endif # BMP180

--- a/drivers/sensor/bosch/bmp180/bmp180.c
+++ b/drivers/sensor/bosch/bmp180/bmp180.c
@@ -1,0 +1,485 @@
+/* Bosch BMP180 pressure sensor
+ *
+ * Copyright (c) 2024 , Chris Ruehl
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Datasheet:
+ * https://www.mouser.hk/datasheet/2/783/BST-BMP180-DS000-1509579.pdf
+ */
+
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/pm/device.h>
+#include <math.h>
+
+#include "bmp180.h"
+
+LOG_MODULE_REGISTER(BMP180, CONFIG_SENSOR_LOG_LEVEL);
+
+static inline int bmp180_bus_check(const struct device *dev)
+{
+	const struct bmp180_config *cfg = dev->config;
+
+	return cfg->bus_io->check(&cfg->bus);
+}
+
+static inline int bmp180_reg_read(const struct device *dev,
+				  uint8_t start, uint8_t *buf, int size)
+{
+	const struct bmp180_config *cfg = dev->config;
+
+	return cfg->bus_io->read(&cfg->bus, start, buf, size);
+}
+
+static inline int bmp180_reg_write(const struct device *dev, uint8_t reg,
+				   uint8_t val)
+{
+	const struct bmp180_config *cfg = dev->config;
+
+	return cfg->bus_io->write(&cfg->bus, reg, val);
+}
+
+int bmp180_reg_field_update(const struct device *dev,
+			    uint8_t reg,
+			    uint8_t mask,
+			    uint8_t val)
+{
+	int rc = 0;
+	uint8_t old_value, new_value;
+	const struct bmp180_config *cfg = dev->config;
+
+	rc = cfg->bus_io->read(&cfg->bus, reg, &old_value, 1);
+	if (rc != 0) {
+		return rc;
+	}
+
+	new_value = (old_value & ~mask) | (val & mask);
+	if (new_value == old_value) {
+		return 0;
+	}
+
+	return cfg->bus_io->write(&cfg->bus, reg, new_value);
+}
+
+#ifdef CONFIG_BMP180_OSR_RUNTIME
+static int bmp180_attr_set_oversampling(const struct device *dev,
+					enum sensor_channel chan,
+					uint16_t val)
+{
+	struct bmp180_data *data = dev->data;
+
+	/* Value must be a positive value 0-3 */
+	if ((chan==SENSOR_CHAN_PRESS) && (val<=3)) {
+	     data->osr_pressure = val;
+	}
+	else {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_BMP180_OSR_RUNTIME */
+
+static int bmp180_attr_set(const struct device *dev,
+			   enum sensor_channel chan,
+			   enum sensor_attribute attr,
+			   const struct sensor_value *val)
+{
+	int ret;
+
+#ifdef CONFIG_PM_DEVICE
+	enum pm_device_state state;
+
+	(void)pm_device_state_get(dev, &state);
+	if (state != PM_DEVICE_STATE_ACTIVE) {
+		return -EBUSY;
+	}
+#endif /* CONFIG_PM_DEVICE */
+
+	switch (attr) {
+#ifdef CONFIG_BMP180_OSR_RUNTIME
+	case SENSOR_ATTR_OVERSAMPLING:
+		ret = bmp180_attr_set_oversampling(dev, chan, val->val1);
+		break;
+#endif /* CONFIG_BMP180_OSR_RUNTIME */
+
+	default:
+		ret = -EINVAL;
+	}
+
+	return ret;
+}
+
+
+static int read_raw_temperature(const struct device *dev)
+{
+	int ret;
+	bool wait = true;
+	uint8_t ctrlreg, msb, lsb;
+	struct bmp180_data *data = dev->data;
+
+	/* send temperature measurement command */
+	ret = bmp180_reg_write(dev, BMP180_REG_MEAS_CTRL, BMP180_CMD_GET_TEMPERATURE);
+	if (ret) {
+		return ret;
+	}
+
+	/* for the first while read get_temp_delay+1ms which is the convention time
+	   descripted in the data-sheet in case the register not yet ready wait again */
+	k_sleep(K_MSEC(BMP180_CMD_GET_TEMP_DELAY));
+
+	while(wait) {
+		k_sleep(K_MSEC(1));
+		ret = bmp180_reg_read(dev, BMP180_REG_MEAS_CTRL, &ctrlreg, 1);
+		if (ret) {
+			return ret;
+		}
+
+		/* bit 5 is 1 until data registers are ready */
+		if ((ctrlreg & BMP180_STATUS_CMD_RDY)==0) {
+			wait = false;
+		}
+	}
+
+	ret = bmp180_reg_read(dev, BMP180_REG_MSB, &msb, 1);
+	if (ret) {
+		return ret;
+	}
+
+	ret = bmp180_reg_read(dev, BMP180_REG_LSB, &lsb, 1);
+	if (ret) {
+		return ret;
+	}
+
+	data->sample.raw_temp = ((int32_t)msb<<8) | (int32_t)lsb;
+	data->sample.comp_temp = 0;
+
+	return 0;
+}
+
+static int read_raw_pressure(const struct device *dev)
+{
+	int ret;
+	bool wait = true;
+	uint8_t ctrlreg, msb, lsb, xlsb;
+	uint32_t delay;
+	int32_t pressure;
+	struct bmp180_data *data = dev->data;
+
+	switch (data->osr_pressure) {
+		case BMP180_ULTRALOWPOWER:
+			ctrlreg = BMP180_CMD_GET_OSS0_PRESS;
+			delay = BMP180_CMD_GET_OSS0_DELAY;
+			break;
+
+		case BMP180_STANDARD:
+			ctrlreg = BMP180_CMD_GET_OSS1_PRESS;
+			delay = BMP180_CMD_GET_OSS1_DELAY;
+			break;
+
+		case BMP180_HIGHRES:
+			ctrlreg = BMP180_CMD_GET_OSS2_PRESS;
+			delay = BMP180_CMD_GET_OSS2_DELAY;
+			break;
+
+		case BMP180_ULTRAHIGH:
+			ctrlreg = BMP180_CMD_GET_OSS3_PRESS;
+			delay = BMP180_CMD_GET_OSS3_DELAY;
+			break;
+		default:
+			return -EINVAL;
+	}
+
+	ret = bmp180_reg_write(dev, BMP180_REG_MEAS_CTRL, ctrlreg);
+	if (ret) {
+		return ret;
+	}
+
+	k_sleep(K_MSEC(delay));
+
+	while(wait) {
+		k_sleep(K_MSEC(1));
+		ret = bmp180_reg_read(dev, BMP180_REG_MEAS_CTRL, &ctrlreg, 1);
+		if (ret) {
+			return ret;
+		}
+
+		if ((ctrlreg & BMP180_STATUS_CMD_RDY)==0) {
+			wait = false;
+		}
+	}
+
+	ret = bmp180_reg_read(dev, BMP180_REG_MSB, &msb, 1);
+	if (ret) {
+		return ret;
+	}
+
+	ret = bmp180_reg_read(dev, BMP180_REG_LSB, &lsb, 1);
+	if (ret) {
+		return ret;
+	}
+
+	ret = bmp180_reg_read(dev, BMP180_REG_XLSB, &xlsb, 1);
+	if (ret) {
+		return ret;
+	}
+
+	pressure = ((int32_t)msb<<16) | ((int32_t)lsb<<8) | (int32_t)xlsb;
+	pressure >>= (8 - data->osr_pressure);
+	data->sample.raw_press = pressure;
+
+	return 0;
+}
+
+static int bmp180_sample_fetch(const struct device *dev,
+			       enum sensor_channel chan)
+{
+	int ret = 0;
+
+	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL);
+
+#ifdef CONFIG_PM_DEVICE
+	enum pm_device_state state;
+
+	(void)pm_device_state_get(dev, &state);
+	if (state != PM_DEVICE_STATE_ACTIVE) {
+		return -EBUSY;
+	}
+#endif /* CONFIG_PM_DEVICE */
+
+	pm_device_busy_set(dev);
+
+	ret = read_raw_temperature(dev);
+	if (ret < 0) {
+		goto error;
+	}
+
+	ret = read_raw_pressure(dev);
+
+error:
+	pm_device_busy_clear(dev);
+	return ret;
+}
+
+static void bmp180_compensate_temp(struct bmp180_data *data)
+{
+	int32_t partial_data1;
+	int32_t partial_data2;
+	struct bmp180_cal_data *cal = &data->cal;
+
+	partial_data1 = (data->sample.raw_temp - cal->ac6) * cal->ac5 / 0x8000;
+	partial_data2 = cal->mc * 0x800 / (partial_data1 + cal->md);
+
+	/* Store for pressure calculation */
+	data->sample.comp_temp = (partial_data1 + partial_data2);
+}
+
+static int bmp180_temp_channel_get(const struct device *dev,
+				   struct sensor_value *val)
+{
+	struct bmp180_data *data = dev->data;
+
+	if (data->sample.comp_temp == 0) {
+		bmp180_compensate_temp(data);
+	}
+
+	float ftmp = ((data->sample.comp_temp+8)>>4) / 10.0;
+	int64_t tmp = (int64_t) floorf(ftmp * 1000000);
+
+	val->val1 = tmp / 1000000;
+	val->val2 = tmp % 1000000;
+
+	return 0;
+}
+
+static uint32_t bmp180_compensate_press(struct bmp180_data *data)
+{
+	uint64_t partial_B7;
+	uint64_t partial_B4;
+	int32_t partial_X1;
+	int32_t partial_X2;
+	int32_t partial_X3;
+	int32_t partial_B3;
+	int32_t partial_B6;
+	uint32_t comp_press;
+	int32_t raw_pressure = data->sample.raw_press;
+	struct bmp180_cal_data *cal = &data->cal;
+
+	partial_B6 = data->sample.comp_temp - 4000;
+	partial_X1 = (cal->b2 * partial_B6 * partial_B6) / 0x800000;
+	partial_X2 = (cal->ac2 * partial_B6) / 0x800;
+	partial_X3 = partial_X1 + partial_X2;
+	partial_B3 = (((cal->ac1 * 4 + partial_X3)<<data->osr_pressure)+2) / 4;
+
+	partial_X1 = (cal->ac3 * partial_B6) / 0x2000;
+	partial_X2 = (cal->b1 * partial_B6 * partial_B6) / 0x10000000;
+	partial_X3 = (partial_X1 + partial_X2 + 2) / 4;
+	partial_B4 = (cal->ac4 * (partial_X3 + 32768)) / 0x8000;
+	partial_B7 = (raw_pressure - partial_B3) * (50000>>data->osr_pressure);
+
+	comp_press = (uint32_t)(partial_B7 / partial_B4 * 2);
+
+	partial_X1 = (comp_press>>8)*(comp_press>>8);
+	partial_X1 = (partial_X1 * 3038) / 0x10000;
+	partial_X2 = ((int32_t)(-7357 * comp_press))/ 0x10000;
+	comp_press += (partial_X1 + partial_X2 + 3791) / 16;
+
+	/* returned value is Pa */
+	return comp_press;
+}
+
+static int bmp180_press_channel_get(const struct device *dev,
+				    struct sensor_value *val)
+{
+	struct bmp180_data *data = dev->data;
+
+	if (data->sample.comp_temp == 0) {
+		bmp180_compensate_temp(data);
+	}
+
+	uint32_t tmp = bmp180_compensate_press(data);
+
+	/* tmp is in hundredths of Pa. Convert to kPa as specified in sensor
+	 * interface.
+	 */
+	val->val1 = tmp / 100000;
+	val->val2 = (tmp % 100000) * 10;
+
+	return 0;
+}
+
+static int bmp180_channel_get(const struct device *dev,
+			      enum sensor_channel chan,
+			      struct sensor_value *val)
+{
+	switch (chan) {
+	case SENSOR_CHAN_PRESS:
+		bmp180_press_channel_get(dev, val);
+		break;
+
+	case SENSOR_CHAN_DIE_TEMP:
+	case SENSOR_CHAN_AMBIENT_TEMP:
+		bmp180_temp_channel_get(dev, val);
+		break;
+
+	default:
+		LOG_DBG("Channel not supported.");
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+
+static int bmp180_get_calibration_data(const struct device *dev)
+{
+	struct bmp180_data *data = dev->data;
+	struct bmp180_cal_data *cal = &data->cal;
+
+	if (bmp180_reg_read(dev, BMP180_REG_CALIB0, (uint8_t *)cal, sizeof(struct bmp180_cal_data)) < 0) {
+		return -EIO;
+	}
+
+	cal->ac1 = BSWAP_s16(cal->ac1);
+	cal->ac2 = BSWAP_s16(cal->ac2);
+	cal->ac3 = BSWAP_s16(cal->ac3);
+	cal->ac4 = BSWAP_u16(cal->ac4);
+	cal->ac5 = BSWAP_u16(cal->ac5);
+	cal->ac6 = BSWAP_u16(cal->ac6);
+	cal->b1 = BSWAP_s16(cal->b1);
+	cal->b2 = BSWAP_s16(cal->b2);
+	cal->mb = BSWAP_s16(cal->mb);
+	cal->mc = BSWAP_s16(cal->mc);
+	cal->md = BSWAP_s16(cal->md);
+
+	LOG_DBG("ac1 = %d", cal->ac1);
+	LOG_DBG("ac2 = %d", cal->ac2);
+	LOG_DBG("ac3 = %d", cal->ac3);
+	LOG_DBG("ac4 = %d", cal->ac4);
+	LOG_DBG("ac5 = %d", cal->ac5);
+	LOG_DBG("ac6 = %d", cal->ac6);
+	LOG_DBG("b1 = %d", cal->b1);
+	LOG_DBG("b2 = %d", cal->b2);
+	LOG_DBG("mb = %d", cal->mb);
+	LOG_DBG("mc = %d", cal->mc);
+	LOG_DBG("md = %d", cal->md);
+
+	return 0;
+}
+
+#ifdef CONFIG_PM_DEVICE
+static int bmp180_pm_action(const struct device *dev,
+			    enum pm_device_action action)
+{
+    /* no power saving feature in bmp180 */
+	return 0;
+}
+#endif /* CONFIG_PM_DEVICE */
+
+static const struct sensor_driver_api bmp180_api = {
+	.attr_set = bmp180_attr_set,
+	.sample_fetch = bmp180_sample_fetch,
+	.channel_get = bmp180_channel_get,
+};
+
+static int bmp180_init(const struct device *dev)
+{
+	uint8_t val = 0U;
+
+	if (bmp180_bus_check(dev) < 0) {
+		LOG_DBG("bus check failed");
+		return -ENODEV;
+	}
+
+	/* reboot the chip */
+	if (bmp180_reg_write(dev, BMP180_REG_CMD, BMP180_CMD_SOFT_RESET) < 0) {
+		LOG_ERR("Cannot reboot chip.");
+		return -EIO;
+	}
+
+	k_sleep(K_MSEC(2));
+
+	if (bmp180_reg_read(dev, BMP180_REG_CHIPID, &val, 1) < 0) {
+		LOG_ERR("Failed to read chip id.");
+		return -EIO;
+	}
+
+	if (val != BMP180_CHIP_ID) {
+		LOG_ERR("Unsupported chip detected (0x%x)!", val);
+		return -ENODEV;
+	}
+
+	/* Read calibration data */
+	if (bmp180_get_calibration_data(dev) < 0) {
+		LOG_ERR("Failed to read calibration data.");
+		return -EIO;
+	}
+
+	return 0;
+}
+
+/* Initializes a struct bmp180_config for an instance on an I2C bus. */
+#define BMP180_CONFIG_I2C(inst)			       \
+	.bus.i2c = I2C_DT_SPEC_INST_GET(inst),	       \
+	.bus_io = &bmp180_bus_io_i2c,
+
+#define BMP180_INST(inst)						   \
+	static struct bmp180_data bmp180_data_##inst = {		   \
+		.osr_pressure = DT_INST_ENUM_IDX(inst, osr_press),	   \
+	};								   \
+	static const struct bmp180_config bmp180_config_##inst = {	   \
+		BMP180_CONFIG_I2C(inst)					   \
+	};								   \
+	PM_DEVICE_DT_INST_DEFINE(inst, bmp180_pm_action);		   \
+	SENSOR_DEVICE_DT_INST_DEFINE(					   \
+		inst,							   \
+		bmp180_init,						   \
+		PM_DEVICE_DT_INST_GET(inst),				   \
+		&bmp180_data_##inst,					   \
+		&bmp180_config_##inst,					   \
+		POST_KERNEL,						   \
+		CONFIG_SENSOR_INIT_PRIORITY,				   \
+		&bmp180_api);
+
+DT_INST_FOREACH_STATUS_OKAY(BMP180_INST)

--- a/drivers/sensor/bosch/bmp180/bmp180.h
+++ b/drivers/sensor/bosch/bmp180/bmp180.h
@@ -1,0 +1,124 @@
+/* Bosch BMP180 pressure sensor
+ *
+ * Copyright (c) 2024 Chris Ruehl
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Datasheet:
+ * https://www.mouser.hk/datasheet/2/783/BST-BMP180-DS000-1509579.pdf
+ */
+#ifndef BMP180_H
+#define BMP180_H
+
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/sys/util.h>
+
+#define DT_DRV_COMPAT bosch_bmp180
+
+#define BMP180_BUS_I2C DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
+
+union bmp180_bus {
+	struct i2c_dt_spec i2c;
+};
+
+typedef int (*bmp180_bus_check_fn)(const union bmp180_bus *bus);
+typedef int (*bmp180_reg_read_fn)(const union bmp180_bus *bus,
+				  uint8_t start, uint8_t *buf, int size);
+typedef int (*bmp180_reg_write_fn)(const union bmp180_bus *bus,
+				   uint8_t reg, uint8_t val);
+
+struct bmp180_bus_io {
+	bmp180_bus_check_fn check;
+	bmp180_reg_read_fn read;
+	bmp180_reg_write_fn write;
+};
+
+extern const struct bmp180_bus_io bmp180_bus_io_i2c;
+
+/* Registers */
+#define BMP180_REG_CHIPID       0xD0
+#define BMP180_REG_CMD          0xE0
+#define BMP180_REG_MEAS_CTRL    0xF4
+#define BMP180_REG_MSB          0xF6
+#define BMP180_REG_LSB          0xF7
+#define BMP180_REG_XLSB         0xF8
+#define BMP180_REG_CALIB0       0xAA
+#define BMP180_REG_CALIB21      0xBF
+
+/* BMP180_REG_CHIPID */
+#define BMP180_CHIP_ID 0x55
+
+/* BMP180_REG_STATUS */
+#define BMP180_STATUS_CMD_RDY    BIT(5)
+
+/* BMP180_REG_CMD */
+#define BMP180_CMD_SOFT_RESET 0xB6
+#define BMP180_CMD_GET_TEMPERATURE 0x2E
+#define BMP180_CMD_GET_OSS0_PRESS  0x34
+#define BMP180_CMD_GET_OSS1_PRESS  0x74 // 0x34 | OSR<<6
+#define BMP180_CMD_GET_OSS2_PRESS  0xB4 // ..
+#define BMP180_CMD_GET_OSS3_PRESS  0xF4 // ..
+
+/* command result waiting time in ms */
+#define BMP180_CMD_GET_TEMP_DELAY  3
+#define BMP180_CMD_GET_OSS0_DELAY  3
+#define BMP180_CMD_GET_OSS1_DELAY  6
+#define BMP180_CMD_GET_OSS2_DELAY  12
+#define BMP180_CMD_GET_OSS3_DELAY  24
+
+#define BMP180_ULTRALOWPOWER 0x00  // oversampling 1x
+#define BMP180_STANDARD      0x01  // oversampling 2x
+#define BMP180_HIGHRES       0x02  // oversampling 4x
+#define BMP180_ULTRAHIGH     0x03  // oversampling 8x
+
+/*
+ byte swap added for signed (int16_t)
+ and named _u16 and _s16 to make clear what its used for
+ macro from include/zephyr/sys/byteorder.h
+*/
+#define BSWAP_u16(x) sys_cpu_to_be16(x)
+#define BSWAP_s16(x) ((int16_t) sys_cpu_to_be16(x))
+
+/* Calibration Registers structure */
+struct bmp180_cal_data {
+	int16_t ac1;
+	int16_t ac2;
+	int16_t ac3;
+	uint16_t ac4;
+	uint16_t ac5;
+	uint16_t ac6;
+	int16_t b1;
+	int16_t b2;
+	int16_t mb;
+	int16_t mc;
+	int16_t md;
+} __packed;
+
+struct bmp180_sample {
+	int32_t raw_press;
+	int32_t raw_temp;
+	int32_t comp_temp;
+};
+
+struct bmp180_config {
+	union bmp180_bus bus;
+	const struct bmp180_bus_io *bus_io;
+};
+
+struct bmp180_data {
+	uint8_t osr_pressure;
+	struct bmp180_cal_data cal;
+	struct bmp180_sample sample;
+};
+
+int bmp180_reg_field_update(const struct device *dev,
+			    uint8_t reg,
+			    uint8_t mask,
+			    uint8_t val);
+
+#endif /* BMP180_H */

--- a/drivers/sensor/bosch/bmp180/bmp180_i2c.c
+++ b/drivers/sensor/bosch/bmp180/bmp180_i2c.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024 Chris Ruehl
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Bus-specific functionality for BMP180s accessed via I2C.
+ */
+
+#include "bmp180.h"
+
+#if BMP180_BUS_I2C
+static int bmp180_bus_check_i2c(const union bmp180_bus *bus)
+{
+	return i2c_is_ready_dt(&bus->i2c) ? 0 : -ENODEV;
+}
+
+static int bmp180_reg_read_i2c(const union bmp180_bus *bus,
+			       uint8_t start, uint8_t *buf, int size)
+{
+	return i2c_burst_read_dt(&bus->i2c, start, buf, size);
+}
+
+static int bmp180_reg_write_i2c(const union bmp180_bus *bus,
+				uint8_t reg, uint8_t val)
+{
+	return i2c_reg_write_byte_dt(&bus->i2c, reg, val);
+}
+
+const struct bmp180_bus_io bmp180_bus_io_i2c = {
+	.check = bmp180_bus_check_i2c,
+	.read = bmp180_reg_read_i2c,
+	.write = bmp180_reg_write_i2c,
+};
+#endif /* BMP180_BUS_I2C */

--- a/dts/bindings/sensor/bosch,bmp180-i2c.yaml
+++ b/dts/bindings/sensor/bosch,bmp180-i2c.yaml
@@ -1,0 +1,9 @@
+# Copyright (c) 2024 Chris Ruehl
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    Bosch BMP180 pressure sensor accessed through I2C bus
+
+compatible: "bosch,bmp180"
+
+include: [i2c-device.yaml, "bosch,bmp180.yaml"]

--- a/dts/bindings/sensor/bosch,bmp180.yaml
+++ b/dts/bindings/sensor/bosch,bmp180.yaml
@@ -1,0 +1,27 @@
+# Copyright (c) 2024 Chris Ruehl
+# SPDX-License-Identifier: Apache-2.0
+
+# Common fields for BMP180
+
+include: sensor-device.yaml
+
+properties:
+  int-gpios:
+    type: phandle-array
+
+  osr-press:
+    type: int
+    required: true
+    description: |
+      Default pressure oversampling rate. Only the following values are
+      allowed:
+        0 ultra low power, 1 sample
+        1 standard,        2 sample
+        2 high,            4 sample
+        3 ultra high,      8 sample
+    enum:
+      - 0
+      - 1
+      - 2
+      - 3
+

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -1070,7 +1070,7 @@ test_i2c_sht21@90 {
 
 test_i2c_lsm9ds1: lsm9ds1@91 {
 	compatible = "st,lsm9ds1";
-	reg = <0x8e>;
+	reg = <0x91>;
 };
 
 test_i2c_icm42670: icm42670@92 {
@@ -1089,4 +1089,10 @@ test_i2c_fxls8974: fxls8974@93 {
 	reset-gpios = <&test_gpio 0 0>;
 	int1-gpios = <&test_gpio 0 0>;
 	int2-gpios = <&test_gpio 0 0>;
+};
+
+test_i2c_bmp180: bmp180@94 {
+	compatible = "bosch,bmp180";
+	reg = <0x94>;
+	osr-press = <0x01>;
 };


### PR DESCRIPTION
Too many rework and conflict issues with v2.  Better start over with version 3 of my pull request.
I continue working on this driver, because the maintainer of the concurrent version has to stop for legal reason.

This pull request has fixed up all comments and change requests from v2.

Bosch bmp180 pressure sensor added to the driver/sensor/bosch/bmp180.
it support the Zephyr Sensor API for channel TEMP/DIE and PRESSURE.

Please review.
Thanks