### PR TITLE
Add support for LPI2C on S32Z27x

### DIFF
--- a/boards/nxp/s32z2xxdc2/doc/index.rst
+++ b/boards/nxp/s32z2xxdc2/doc/index.rst
@@ -57,6 +57,8 @@ The boards support the following hardware features:
 +-----------+------------+-------------------------------------+
 | SAR_ADC   | on-chip    | adc                                 |
 +-----------+------------+-------------------------------------+
+| LPI2C     | on-chip    | i2c                                 |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not currently supported by the port.
 

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_pinctrl.dtsi
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_pinctrl.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 NXP
+ * Copyright 2022-2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -105,6 +105,26 @@
 		group2 {
 			pinmux = <PB6_CAN_1_TX>;
 			output-enable;
+		};
+	};
+
+	i2c1_default: i2c1_default {
+		group1 {
+			pinmux = <(PC15_I2C_1_SDA_I | PC15_I2C_1_SDA_O)>,
+				<(PD0_I2C_1_SCL_I | PD0_I2C_1_SCL_O)>;
+			input-enable;
+			output-enable;
+			drive-open-drain;
+		};
+	};
+
+	i2c2_default: i2c2_default {
+		group1 {
+			pinmux = <(PJ11_I2C_2_SDA_I | PJ11_I2C_2_SDA_O)>,
+				<(PJ10_I2C_2_SCL_I | PJ10_I2C_2_SCL_O)>;
+			input-enable;
+			output-enable;
+			drive-open-drain;
 		};
 	};
 };

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu0.yaml
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu0.yaml
@@ -17,4 +17,5 @@ supported:
   - spi
   - counter
   - adc
+  - i2c
 vendor: nxp

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu0_D.yaml
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu0_D.yaml
@@ -17,4 +17,5 @@ supported:
   - spi
   - counter
   - adc
+  - i2c
 vendor: nxp

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu1.yaml
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu1.yaml
@@ -17,4 +17,5 @@ supported:
   - spi
   - counter
   - adc
+  - i2c
 vendor: nxp

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu1_D.yaml
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu1_D.yaml
@@ -17,4 +17,5 @@ supported:
   - spi
   - counter
   - adc
+  - i2c
 vendor: nxp

--- a/dts/arm/nxp/nxp_s32z27x_r52.dtsi
+++ b/dts/arm/nxp/nxp_s32z27x_r52.dtsi
@@ -8,6 +8,7 @@
 #include <arm/armv8-r.dtsi>
 #include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
 #include <zephyr/dt-bindings/clock/nxp_s32z2_clock.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	cpus {
@@ -1094,5 +1095,26 @@
 			status = "disabled";
 		};
 
+		lpi2c1: i2c@409d0000 {
+			compatible = "nxp,imx-lpi2c";
+			reg = <0x409d0000 0x10000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			interrupts = <GIC_SPI 253 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_P1_REG_INTF_CLK>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			status = "disabled";
+		};
+
+		lpi2c2: i2c@421d0000 {
+			compatible = "nxp,imx-lpi2c";
+			reg = <0x421d0000 0x10000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			interrupts = <GIC_SPI 254 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_P4_REG_INTF_CLK>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			status = "disabled";
+		};
 	};
 };

--- a/soc/nxp/s32/s32ze/Kconfig
+++ b/soc/nxp/s32/s32ze/Kconfig
@@ -17,6 +17,7 @@ config SOC_SERIES_S32ZE
 	select HAS_MCUX
 	select HAS_MCUX_PIT
 	select HAS_MCUX_FLEXCAN
+	select HAS_MCUX_LPI2C
 
 if SOC_SERIES_S32ZE
 

--- a/west.yml
+++ b/west.yml
@@ -198,7 +198,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 338aec96ae7eace2db263a365ab3fae9bddc48aa
+      revision: 30bdef6d5a304abfa95cc19af4d3ba699aac456e
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Reuse existing MCUX-based shim driver for LPI2C and update to compatible with the hardware block in S32Z27x, enable test

Tested with tests/drivers/eeprom/api
s32z2xxdc2/s32z270/rtu0   tests/drivers/eeprom/api/drivers.eeprom.api        PASSED (device 18.815s)
s32z2xxdc2/s32z270/rtu1   tests/drivers/eeprom/api/drivers.eeprom.api        PASSED (device 27.749s)