### PR TITLE
backport the security patch of CVE-2024-1638

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -3103,7 +3103,8 @@ uint8_t bt_gatt_check_perm(struct bt_conn *conn, const struct bt_gatt_attr *attr
 	 * the error code “Insufficient Encryption”.
 	 */
 
-	if (mask & (BT_GATT_PERM_ENCRYPT_MASK | BT_GATT_PERM_AUTHEN_MASK)) {
+	if (mask & (BT_GATT_PERM_ENCRYPT_MASK | BT_GATT_PERM_AUTHEN_MASK |
+			BT_GATT_PERM_LESC_MASK)) {
 #if defined(CONFIG_BT_SMP)
 		if (!conn->encrypt) {
 			if (bt_conn_ltk_present(conn)) {


### PR DESCRIPTION
Here is a vulnerability which is fixed in the https://github.com/zephyrproject-rtos/zephyr/tree/main and https://github.com/zephyrproject-rtos/zephyr/tree/v3.7-branch branch https://github.com/zephyrproject-rtos/zephyr/commit/d9ff7eb0eda36b4b70e5c5badfd6661c1ddfe626, but is not fixed in the branch of v3.5-branch, maybe it should be backported?