### PR TITLE
drivers: sensor: tmp116: support set sample frequency

### DIFF
--- a/drivers/sensor/ti/tmp116/tmp116.h
+++ b/drivers/sensor/ti/tmp116/tmp116.h
@@ -7,6 +7,8 @@
 #ifndef ZEPHYR_DRIVERS_SENSOR_TMP116_TMP116_H_
 #define ZEPHYR_DRIVERS_SENSOR_TMP116_TMP116_H_
 
+#include <zephyr/sys/util_macro.h>
+
 #define TMP116_REG_TEMP		0x0
 #define TMP116_REG_CFGR		0x1
 #define TMP116_REG_HIGH_LIM		0x2
@@ -26,6 +28,7 @@
 #define TMP117_DEVICE_ID		0x0117
 
 #define TMP116_CFGR_AVG			(BIT(5) | BIT(6))
+#define TMP116_CFGR_CONV		(BIT(7) | BIT(8) | BIT(9))
 #define TMP116_CFGR_MODE		(BIT(10) | BIT(11))
 #define TMP116_CFGR_DATA_READY  BIT(13)
 #define TMP116_EEPROM_UL_UNLOCK BIT(15)
@@ -46,6 +49,7 @@ struct tmp116_data {
 
 struct tmp116_dev_config {
 	struct i2c_dt_spec bus;
+	uint16_t odr;
 };
 
 #endif /*  ZEPHYR_DRIVERS_SENSOR_TMP116_TMP116_H_ */

--- a/dts/bindings/sensor/ti,tmp116.yaml
+++ b/dts/bindings/sensor/ti,tmp116.yaml
@@ -8,3 +8,20 @@ compatible: "ti,tmp116"
 bus: tmp116
 
 include: [sensor-device.yaml, i2c-device.yaml]
+
+properties:
+  odr:
+    type: int
+    default: 0x200
+    description: |
+      Specify the default temperature output data rate in milliseconds (ms).
+      Default is power-up configuration.
+    enum:
+      - 0     # TMP116_DT_ODR_15_5_MS
+      - 0x80  # TMP116_DT_ODR_125_MS
+      - 0x100 # TMP116_DT_ODR_250_MS
+      - 0x180 # TMP116_DT_ODR_500_MS
+      - 0x200 # TMP116_DT_ODR_1000_MS
+      - 0x280 # TMP116_DT_ODR_4000_MS
+      - 0x300 # TMP116_DT_ODR_8000_MS
+      - 0x380 # TMP116_DT_ODR_16000_MS

--- a/include/zephyr/dt-bindings/sensor/tmp116.h
+++ b/include/zephyr/dt-bindings/sensor/tmp116.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024 Vitrolife A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_TI_TMP116_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_TI_TMP116_H_
+
+/**
+ * @defgroup TMP116 Texas Instruments (TI) TMP116 DT Options
+ * @ingroup sensor_interface
+ * @{
+ */
+
+/**
+ * @defgroup TMP116_ODR Temperature output data rate
+ * @{
+ */
+#define TMP116_DT_ODR_15_5_MS  0
+#define TMP116_DT_ODR_125_MS   0x80
+#define TMP116_DT_ODR_250_MS   0x100
+#define TMP116_DT_ODR_500_MS   0x180
+#define TMP116_DT_ODR_1000_MS  0x200
+#define TMP116_DT_ODR_4000_MS  0x280
+#define TMP116_DT_ODR_8000_MS  0x300
+#define TMP116_DT_ODR_16000_MS 0x380
+/** @} */
+
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_TI_TMP116_H_ */

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -24,6 +24,7 @@
 #include <zephyr/dt-bindings/sensor/stts22h.h>
 #include <zephyr/dt-bindings/sensor/ina226.h>
 #include <zephyr/dt-bindings/sensor/apds9253.h>
+#include <zephyr/dt-bindings/sensor/tmp116.h>
 
 /****************************************
  * PLEASE KEEP REG ADDRESSES SEQUENTIAL *
@@ -478,6 +479,7 @@ test_i2c_tmp112: tmp112@46 {
 test_i2c_tmp116: tmp116@47 {
 	compatible = "ti,tmp116";
 	reg = <0x47>;
+	odr = <TMP116_DT_ODR_125_MS>;
 };
 
 test_i2c_bq274xx: bq27xx@48 {


### PR DESCRIPTION
Support setting sample frequency via `attr_set` and dts.
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/74614.