### PR TITLE
manifest: Update hostap to fix build error of FILE

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -259,7 +259,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: 77a4cad575c91f1b234c8d15630f87999881cde2
+      revision: 2bc64a991a363aec779c92696b8dfe9f0b69ff63
     - name: libmetal
       revision: a6851ba6dba8c9e87d00c42f171a822f7a29639b
       path: modules/hal/libmetal


### PR DESCRIPTION
When build the Matter over Wi-Fi with NEWLIB enabled, there is build error shows 'error: unknown type name 'FILE' ', adding this change can fix this build error, and don't affect the case that NEWLIB disabled.