### PR TITLE
scripts: coccinelle: add errno as a reserved name

### DIFF
--- a/scripts/coccinelle/symbols.txt
+++ b/scripts/coccinelle/symbols.txt
@@ -31,6 +31,7 @@ difftime64
 div
 erf
 erfc
+errno
 exit
 exp
 fabs


### PR DESCRIPTION
errno is defined by the ISO C standard to be a modifiable lvalue of type int, and **must not be explicitly declared**

Tested as working as expected here: https://github.com/zephyrproject-rtos/zephyr/actions/runs/10467750404/job/28987164179?pr=77268