### PR TITLE
Bluetooth: TBS: Fix type of uri in bt_tbs_valid_uri

### DIFF
--- a/subsys/bluetooth/audio/tbs.c
+++ b/subsys/bluetooth/audio/tbs.c
@@ -1741,7 +1741,7 @@ int bt_tbs_originate(uint8_t bearer_index, char *remote_uri,
 
 	if (tbs == NULL || inst_is_gtbs(tbs)) {
 		return -EINVAL;
-	} else if (!bt_tbs_valid_uri(remote_uri, strlen(remote_uri))) {
+	} else if (!bt_tbs_valid_uri((uint8_t *)remote_uri, strlen(remote_uri))) {
 		LOG_DBG("Invalid URI %s", remote_uri);
 		return -EINVAL;
 	}
@@ -1937,10 +1937,10 @@ int bt_tbs_remote_incoming(uint8_t bearer_index, const char *to,
 
 	if (inst == NULL || inst_is_gtbs(inst)) {
 		return -EINVAL;
-	} else if (!bt_tbs_valid_uri(to, strlen(to))) {
+	} else if (!bt_tbs_valid_uri((uint8_t *)to, strlen(to))) {
 		LOG_DBG("Invalid \"to\" URI: %s", to);
 		return -EINVAL;
-	} else if (!bt_tbs_valid_uri(from, strlen(from))) {
+	} else if (!bt_tbs_valid_uri((uint8_t *)from, strlen(from))) {
 		LOG_DBG("Invalid \"from\" URI: %s", from);
 		return -EINVAL;
 	}

--- a/subsys/bluetooth/audio/tbs_internal.h
+++ b/subsys/bluetooth/audio/tbs_internal.h
@@ -177,7 +177,7 @@ static inline const char *bt_tbs_term_reason_str(uint8_t reason)
 }
 
 /**
- * @brief Checks if a string contains a colon (':') followed by a printable
+ * @brief Checks if @p uri contains a colon (':') followed by a printable
  * character. Minimal uri is "a:b".
  *
  * @param uri The uri "scheme:id"
@@ -185,21 +185,20 @@ static inline const char *bt_tbs_term_reason_str(uint8_t reason)
  * @return true If the above is true
  * @return false If the above is not true
  */
-static inline bool bt_tbs_valid_uri(const char *uri, size_t len)
+static inline bool bt_tbs_valid_uri(const uint8_t *uri, size_t uri_len)
 {
 	if (!uri) {
 		return false;
 	}
 
-	if (len > CONFIG_BT_TBS_MAX_URI_LENGTH ||
-	    len < BT_TBS_MIN_URI_LEN) {
+	if (uri_len > CONFIG_BT_TBS_MAX_URI_LENGTH || uri_len < BT_TBS_MIN_URI_LEN) {
 		return false;
 	} else if (uri[0] < FIRST_PRINTABLE_ASCII_CHAR) {
 		/* Invalid first char */
 		return false;
 	}
 
-	for (int i = 1; i < len; i++) {
+	for (size_t i = 1; i < uri_len; i++) {
 		if (uri[i] == ':' && uri[i + 1] >= FIRST_PRINTABLE_ASCII_CHAR) {
 			return true;
 		}


### PR DESCRIPTION
The function had marked the type as char *, but it was in fact not a string but rather a uint8_t array.

Marked the type properly and added a cast when using it with strings.