### PR TITLE
arch: arm: cortex_m: pm_s2ram: save system_off before s2ram marking

### DIFF
--- a/arch/arm/core/cortex_m/pm_s2ram.S
+++ b/arch/arm/core/cortex_m/pm_s2ram.S
@@ -27,6 +27,11 @@ SECTION_FUNC(TEXT, arch_pm_s2ram_suspend)
 	 * r0: address of the system_off function
 	 */
 	push	{r4-r12, lr}
+
+	/* Move system_off to protected register. */
+	mov 	r4, r0
+
+	/* Store CPU context */
 	ldr	r1, =_cpu_context
 
 	mrs	r2, msp
@@ -71,7 +76,7 @@ SECTION_FUNC(TEXT, arch_pm_s2ram_suspend)
 	 * Call the system_off function passed as parameter. This should never
 	 * return.
 	 */
-	blx	r0
+	blx	r4
 
 	/*
 	 * The system_off function returns here only when the powering off was
@@ -81,9 +86,10 @@ SECTION_FUNC(TEXT, arch_pm_s2ram_suspend)
 	/*
 	 * Reset the marking of suspend to RAM, return is ignored.
 	 */
-	push	{r0}
 	bl pm_s2ram_mark_check_and_clear
-	pop	{r0}
+
+	/* Move system_off back to r0 as return value */
+	mov	r0, r4
 
 	pop	{r4-r12, lr}
 	bx	lr
@@ -93,11 +99,14 @@ GTEXT(arch_pm_s2ram_resume)
 SECTION_FUNC(TEXT, arch_pm_s2ram_resume)
 	/*
 	 * Check if reset occurred after suspending to RAM.
+	 * Store LR to ensure we can continue boot when we are not suspended
+	 * to RAM. In addition to LR, R0 is pushed too, to ensure "SP mod 8 = 0",
+	 * as stated by ARM rule 6.2.1.2 for AAPCS32.
 	 */
-	push    {lr}
+	push    {r0, lr}
 	bl      pm_s2ram_mark_check_and_clear
 	cmp	r0, #0x1
-	pop     {lr}
+	pop     {r0, lr}
 	beq	resume
 	bx	lr
 


### PR DESCRIPTION
The r0 register holds the system_off function pointer. As r0 is a scratch register, it needs to be pushed and popped to the stack before branching to a (custom) marker function.