### PR TITLE
pm: s2ram : support for custom bootstack on wakeup

### DIFF
--- a/arch/arm/core/cortex_m/pm_s2ram.S
+++ b/arch/arm/core/cortex_m/pm_s2ram.S
@@ -99,8 +99,20 @@ SECTION_FUNC(TEXT, arch_pm_s2ram_suspend)
 	bx	lr
 
 
+#if defined(CONFIG_PM_S2RAM_CUSTOM_BOOTSTACK)
+GTEXT(soc_pm_s2ram_custom_bootstack)
+#endif
+
 GTEXT(arch_pm_s2ram_resume)
 SECTION_FUNC(TEXT, arch_pm_s2ram_resume)
+
+#if defined(CONFIG_PM_S2RAM_CUSTOM_BOOTSTACK)
+	/* Setup stack for soc specific initialisation after wake up,
+	 * so the main stack does not get corrupted in the process.
+	 */
+	bl soc_pm_s2ram_custom_bootstack
+#endif /* CONFIG_PM_S2RAM_CUSTOM_BOOTSTACK */
+
 	/*
 	 * Check if reset occurred after suspending to RAM.
 	 */

--- a/arch/arm/core/cortex_m/reset.S
+++ b/arch/arm/core/cortex_m/reset.S
@@ -89,6 +89,7 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
 
 #endif /* CONFIG_INIT_ARCH_HW_AT_BOOT */
 
+/* Needs to be done before any stack operation is executed */
 #if defined(CONFIG_PM_S2RAM)
     bl arch_pm_s2ram_resume
 #endif /* CONFIG_PM_S2RAM */

--- a/subsys/pm/Kconfig
+++ b/subsys/pm/Kconfig
@@ -46,6 +46,13 @@ config PM_S2RAM_CUSTOM_MARKING
 	  By default a magic word in RAM is used to mark entering suspend-to-RAM. Enabling
 	  this option allows custom implementation of functions which handle the marking.
 
+config PM_S2RAM_CUSTOM_BOOTSTACK
+	bool "Use custom boot-stack after wakeup"
+	depends on PM_S2RAM
+	help
+	  By default the main-stack is used to boot after reset. In some SoCs a specific
+	  boot-stack needs to be used to ensure the main-stack is not corrupted upon wakeup.
+
 config PM_NEED_ALL_DEVICES_IDLE
 	bool "System Low Power Mode Needs All Devices Idle"
 	depends on PM_DEVICE && !SMP


### PR DESCRIPTION
By default the main-stack is used to boot after reset. In some SoCs a specific boot-stack needs to be used to ensure the main-stack is not corrupted upon wakeup.

fixes #77202 