### PR TITLE
Shell: Remove unnecessary new lines at startup

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1446,9 +1446,10 @@ int shell_start(const struct shell *sh)
 		z_shell_vt100_color_set(sh, SHELL_NORMAL);
 	}
 
-	if (z_shell_strlen(sh->default_prompt) > 0) {
-		z_shell_raw_fprintf(sh->fprintf_ctx, "\n\n");
-	}
+	/* print new line before printing the prompt to clear the line
+	 * vt100 are not used here for compatibility reasons
+	 */
+	z_cursor_next_line_move(sh);
 	state_set(sh, SHELL_STATE_ACTIVE);
 
 	k_mutex_unlock(&sh->ctx->wr_mtx);

--- a/subsys/shell/shell_ops.c
+++ b/subsys/shell/shell_ops.c
@@ -43,8 +43,13 @@ void z_shell_op_cursor_horiz_move(const struct shell *sh, int32_t delta)
  */
 static inline bool full_line_cmd(const struct shell *sh)
 {
-	return ((sh->ctx->cmd_buff_len + z_shell_strlen(sh->ctx->prompt))
-			% sh->ctx->vt100_ctx.cons.terminal_wid == 0U);
+	size_t line_length = sh->ctx->cmd_buff_len + z_shell_strlen(sh->ctx->prompt);
+
+	if (line_length == 0) {
+		return false;
+	}
+
+	return (line_length % sh->ctx->vt100_ctx.cons.terminal_wid == 0U);
 }
 
 /* Function returns true if cursor is at beginning of an empty line. */

--- a/tests/subsys/shell/shell_backend_uart/src/main.c
+++ b/tests/subsys/shell/shell_backend_uart/src/main.c
@@ -110,6 +110,7 @@ SHELL_DEFINE(shell_euart0, "", &shell_transport_euart0,
 
 static void *setup(void)
 {
+	uint8_t tx_content[SAMPLE_DATA_SIZE] = {0};
 	static struct shell_backend_uart_fixture fixture = {
 		.dev = DEVICE_DT_GET(DT_NODELABEL(euart0)),
 	};
@@ -119,6 +120,10 @@ static void *setup(void)
 
 	/* Let the shell backend initialize. */
 	k_usleep(10);
+
+	/* get the shell startup newline */
+	uart_emul_get_tx_data(fixture.dev, tx_content, SAMPLE_DATA_SIZE);
+	zassert_mem_equal(tx_content, "\r\n", strlen("\r\n"));
 
 	return &fixture;
 }


### PR DESCRIPTION
When the shell start, it will print two lines. The reason for that behavior is not documented. Remove that to make the code simpler and shorter one line at a time.