### PR TITLE
Bluetooth: doc: update kconfig docstring

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -280,8 +280,8 @@ config BT_CONN_TX_USER_DATA_SIZE
 	default 32 if 64BIT
 	default 16
 	help
-	  Necessary user_data size for allowing packet fragmentation when
-	  sending over HCI. See `struct tx_meta` in conn.c.
+	  Necessary user_data size for stack usage. Mostly used for passing
+	  callbacks around. See `struct closure` in conn_internal.h.
 
 config BT_CONN_FRAG_COUNT
 	int


### PR DESCRIPTION
CONFIG_BT_CONN_TX_USER_DATA_SIZE is now used for callbacks in the host. We don't want to limit ourselves to that, so change the wording to be more generic.
In the future, the plan is to not use user_data at all, removing the need for the kconfig altogether.

Also rename the structure that was referenced in the docstring.