### PR TITLE
ci: compliance: in case of too many errors, send as a single failure

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -220,6 +220,13 @@ class CheckPatch(ComplianceTest):
                     r'^\s*#(\d+):\s*FILE:\s*(.+):(\d+):'
 
             matches = re.findall(regex, output, re.MULTILINE)
+
+            # add a guard here for excessive number of errors, do not try and
+            # process each one of them and instead push this as one failure.
+            if len(matches) > 500:
+                self.failure(output)
+                return
+
             for m in matches:
                 self.fmtd_failure(m[1].lower(), m[2], m[5], m[6], col=None,
                         desc=m[3])


### PR DESCRIPTION
Do not try to format each single failure, this will take too long to
process and will run for hours and spam GH.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>



see https://github.com/zephyrproject-rtos/zephyr/actions/runs/10471585103/job/28999175620?pr=75809
