### PR TITLE
mbedtls: add ability to use custom memory section for mbedtls heap

### DIFF
--- a/modules/mbedtls/Kconfig
+++ b/modules/mbedtls/Kconfig
@@ -186,11 +186,12 @@ config MBEDTLS_ENABLE_HEAP
 	  in mbedtls. If this is enabled, and MBEDTLS_INIT is enabled then the
 	  Zephyr will, during the device startup, initialize the heap automatically.
 
+if MBEDTLS_ENABLE_HEAP
+
 config MBEDTLS_HEAP_SIZE
 	int "Heap size for mbed TLS"
 	default 10240 if OPENTHREAD_COMMISSIONER || OPENTHREAD_JOINER
 	default 512
-	depends on MBEDTLS_ENABLE_HEAP
 	help
 	  The mbedtls routines will use this heap if enabled.
 	  See ext/lib/crypto/mbedtls/include/mbedtls/config.h and
@@ -201,6 +202,15 @@ config MBEDTLS_HEAP_SIZE
 	  servers on the Internet, 32KB + overheads (up to another 20KB) may
 	  be needed. For some dedicated and specific usage of mbedtls API, the
 	  1000 bytes might be ok.
+
+config MBEDTLS_HEAP_CUSTOM_SECTION
+	bool "Use a custom section for the Mbed TLS heap"
+	help
+	  Place Mbed TLS heap in custom section, with tag ".mbedtls_heap".
+	  This can be used by custom linker scripts to relocate the Mbed TLS
+	  heap to a custom location, such as another SRAM region or external memory.
+
+endif # MBEDTLS_ENABLE_HEAP
 
 config MBEDTLS_INIT
 	bool "Initialize mbed TLS at boot"

--- a/modules/mbedtls/zephyr_init.c
+++ b/modules/mbedtls/zephyr_init.c
@@ -29,12 +29,12 @@
 	defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C)
 #include <mbedtls/memory_buffer_alloc.h>
 
-#if !defined(CONFIG_MBEDTLS_HEAP_SIZE)
-#error "Please set heap size to be used. Set value to CONFIG_MBEDTLS_HEAP_SIZE \
-option."
-#endif
-
-static unsigned char _mbedtls_heap[CONFIG_MBEDTLS_HEAP_SIZE];
+#ifdef CONFIG_MBEDTLS_HEAP_CUSTOM_SECTION
+#define HEAP_MEM_ATTRIBUTES Z_GENERIC_SECTION(.mbedtls_heap)
+#else
+#define HEAP_MEM_ATTRIBUTES
+#endif /* CONFIG_MBEDTLS_HEAP_CUSTOM_SECTION */
+static unsigned char _mbedtls_heap[CONFIG_MBEDTLS_HEAP_SIZE] HEAP_MEM_ATTRIBUTES;
 
 static void init_heap(void)
 {


### PR DESCRIPTION
This commit introduces the option to place the mbed TLS heap in a custom memory section. The heap might be quite large depending on concurrent TLS connections, thus it might be needed to place this manually.

For instance, the STM32H743 has 1MB of RAM but only 512KB of consecutive memory, with for example additional 128kb of SRAM1 & SRAM2 each. LVGL implements this design to be able to place both the frame buffer, work buffer and heap at custom locations.