### PR TITLE
boards: adi: Add max32690fthr

### DIFF
--- a/boards/adi/max32690fthr/Kconfig.max32690fthr
+++ b/boards/adi/max32690fthr/Kconfig.max32690fthr
@@ -1,0 +1,7 @@
+# MAX32690 board configuration
+
+# Copyright (c) 2023-2024 Analog Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_MAX32690FTHR
+	select SOC_MAX32690_M4 if BOARD_MAX32690FTHR_MAX32690_M4

--- a/boards/adi/max32690fthr/board.cmake
+++ b/boards/adi/max32690fthr/board.cmake
@@ -1,0 +1,9 @@
+# Copyright (c) 2023-2024 Analog Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+board_runner_args(openocd --cmd-pre-init "source [find interface/cmsis-dap.cfg]")
+board_runner_args(openocd --cmd-pre-init "source [find target/max32690.cfg]")
+board_runner_args(jlink "--device=MAX32690" "--reset-after-load")
+
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/adi/max32690fthr/board.yml
+++ b/boards/adi/max32690fthr/board.yml
@@ -1,0 +1,8 @@
+# Copyright (c) 2023-2024 Analog Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+board:
+  name: max32690fthr
+  vendor: adi
+  socs:
+    - name: max32690

--- a/boards/adi/max32690fthr/doc/index.rst
+++ b/boards/adi/max32690fthr/doc/index.rst
@@ -1,0 +1,134 @@
+.. _max32690_fthr:
+
+MAX32690FTHR
+############
+
+Overview
+********
+
+The MAX32690FTHR is a rapid development platform to help engineers quickly
+implement ultra low-power wireless solutions using MAX32690 Arm© Cortex®-M4F
+and Bluetooth® 5.2 Low Energy (LE). The board also includes the MAX77654 PMIC
+for battery and power management. The form factor is a small 0.9in x 2.6in
+dual-row header footprint that is compatible with Adafruit Feather Wing
+peripheral expansion boards.
+
+Hardware
+********
+
+- MAX32690 MCU:
+
+    - Ultra-Efficient Microcontroller for Battery-Powered Applications
+
+      - 120MHz Arm Cortex-M4 Processor with FPU
+      - 7.3728MHz and 60MHz Low-Power Oscillators
+      - External Crystal Support (32MHz required for BLE)
+      - 32.768kHz RTC Clock (Requires External Crystal)
+      - 8kHz Always-On Ultra-Low Power Oscillator
+      - 3MB Internal Flash, 1MB Internal SRAM (832kB ECC ON)
+      - 85 μW/MHz ACTIVE mode at 1.1V
+      - 1.8V and 3.3V I/O with No Level Translators
+      - External Flash & SRAM Expansion Interfaces
+
+    - Bluetooth 5.2 LE Radio
+
+      - Dedicated, Ultra-Low-Power, 32-Bit RISC-V Coprocessor to Offload
+        Timing-Critical Bluetooth Processing
+      - Fully Open-Source Bluetooth 5.2 Stack Available
+      - Supports AoA, AoD, LE Audio, and Mesh
+      - High-Throughput (2Mbps) Mode
+      - Long-Range (125kbps and 500kbps) Modes
+      - Rx Sensitivity: -97.5dBm; Tx Power: +4.5dBm
+      - Single-Ended Antenna Connection (50Ω)
+
+    - Multiple Peripherals for System Control
+
+      - 16-Channel DMA
+      - Up To Five Quad SPI Master (60MHz)/Slave (48MHz)
+      - Up To Four 1Mbaud UARTs with Flow Control
+      - Up To Two 1MHz I2C Master/Slave
+      - I2S Master/Slave
+      - Eight External Channel, 12-bit 1MSPS SAR ADC w/ on-die temperature sensor
+      - USB 2.0 Hi-Speed Device
+      - 16 Pulse Train Engines
+      - Up To Six 32-Bit Timers with 8mA High Drive
+      - Up To Two CAN 2.0 Controllers
+      - Up To Four Micro-Power Comparators
+      - 1-Wire Master
+
+    - Security and Integrity​
+
+      - ChipDNA Physically Un-clonable Function (PUF)
+      - Modular Arithmetic Accelerator (MAA), True Random Number Generator (TRNG)
+      - Secure Nonvolatile Key Storage, SHA-256, AES-128/192/256
+      - Secure Boot ROM
+
+Supported Features
+==================
+
+Below interfaces are supported by Zephyr on MAX32690FTHR.
+
++-----------+------------+-------------------------------------+
+| Interface | Controller | Driver/Component                    |
++===========+============+=====================================+
+| NVIC      | on-chip    | nested vector interrupt controller  |
++-----------+------------+-------------------------------------+
+| SYSTICK   | on-chip    | systick                             |
++-----------+------------+-------------------------------------+
+| CLOCK     | on-chip    | clock and reset control             |
++-----------+------------+-------------------------------------+
+| GPIO      | on-chip    | gpio                                |
++-----------+------------+-------------------------------------+
+| UART      | on-chip    | serial                              |
++-----------+------------+-------------------------------------+
+| I2C       | on-chip    | i2c                                 |
++-----------+------------+-------------------------------------+
+| SPI       | on-chip    | spi                                 |
++--------------------------------------------------------------+
+
+Programming and Debugging
+*************************
+
+Flashing
+========
+
+The MAX32690 MCU can be flashed by connecting an external debug probe to the
+SWD port. SWD debug can be accessed through the Cortex 10-pin connector, J4.
+Logic levels are fixed to VDDIO (1.8V).
+
+Once the debug probe is connected to your host computer, then you can run the
+``west flash`` command to write a firmware image into flash. Here is an example
+for the :ref:`hello_world` application.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: max32690fthr/max32690/m4
+   :goals: flash
+
+.. note::
+
+   This board uses OpenOCD as the default debug interface. You can also use a
+   Segger J-Link with Segger's native tooling by overriding the runner,
+   appending ``--runner jlink`` to your ``west`` command(s). The J-Link should
+   be connected to the standard 2*5 pin debug connector (J4) using an
+   appropriate adapter board and cable.
+
+Debugging
+=========
+
+Once the debug probe is connected to your host computer, then you can run the
+``west debug`` command to write a firmware image into flash and start a debug
+session. Here is an example for the :ref:`hello_world` application.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: max32690fthr/max32690/m4
+   :goals: debug
+
+References
+**********
+
+- `MAX32690 product page`_
+
+.. _MAX32690 product page:
+   https://www.analog.com/en/products/max32690.html

--- a/boards/adi/max32690fthr/max32690fthr_max32690_m4.dts
+++ b/boards/adi/max32690fthr/max32690fthr_max32690_m4.dts
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2023-2024 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+#include <adi/max32/max32690.dtsi>
+#include <adi/max32/max32690-pinctrl.dtsi>
+#include <zephyr/dt-bindings/gpio/adi-max32-gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+
+/ {
+	model = "Analog Devices MAX32690FTHR";
+	compatible = "adi,max32690fthr";
+
+	chosen {
+		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
+		zephyr,sram = &sram0;
+		zephyr,flash = &flash0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		red_led: led_0 {
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+			label = "LED0";
+		};
+		green_led: led_1 {
+			gpios = <&gpio2 24 GPIO_ACTIVE_LOW>;
+			label = "LED1";
+		};
+		blue_led: led_2 {
+			gpios = <&gpio2 25 GPIO_ACTIVE_LOW>;
+			label = "LED2";
+		};
+	};
+
+	buttons {
+		compatible = "gpio-keys";
+		pb1: pb1 {
+			gpios = <&gpio1 14 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "SW3";
+			zephyr,code = <INPUT_KEY_0>;
+		};
+		pb2: pb2 {
+			gpios = <&gpio1 15 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "SW4";
+			zephyr,code = <INPUT_KEY_1>;
+		};
+	};
+
+	aliases {
+		led0 = &red_led;
+		led1 = &green_led;
+		led2 = &blue_led;
+		sw0 = &pb1;
+		sw1 = &pb2;
+	 };
+
+	feather_header: feather_connector {
+		compatible = "adafruit-feather-header";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpio3 0 0>,	/* A0 */
+			   <1 0 &gpio3 1 0>,	/* A1 */
+			   <2 0 &gpio3 4 0>,	/* A2 */
+			   <3 0 &gpio0 9 0>,	/* A3 */
+			   <4 0 &gpio0 10 0>,	/* A4 */
+			   <5 0 &gpio0 7 0>,	/* A5 */
+			   <6 0 &gpio2 29 0>,	/* SCK */
+			   <7 0 &gpio2 28 0>,	/* MOSI */
+			   <8 0 &gpio2 27 0>,	/* MISO */
+			   <9 0 &gpio1 9 0>,	/* RXD */
+			   <10 0 &gpio1 10 0>,	/* TXD */
+			   /* 11 (D2) not connected */
+			   <12 0 &gpio2 7 0>,	/* SDA */
+			   <13 0 &gpio2 8 0>,	/* SCL */
+			   <14 0 &gpio1 7 0>,	/* D5 */
+			   <15 0 &gpio1 8 0>,	/* D6 */
+			   <16 0 &gpio2 26 0>,	/* D9 */
+			   <17 0 &gpio0 23 0>,	/* D10 */
+			   <18 0 &gpio1 12 0>,	/* D11 */
+			   <19 0 &gpio1 11 0>,	/* D12 */
+			   <20 0 &gpio0 8 0>;	/* D13 */
+	};
+};
+
+&clk_ibro {
+	status = "okay";
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&uart0 {
+	clock-source = <ADI_MAX32_PRPH_CLK_SRC_IBRO>;
+	pinctrl-0 = <&uart0a_tx_p2_12 &uart0a_rx_p2_11>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	data-bits = <8>;
+	parity = "none";
+	status = "okay";
+};
+
+feather_serial: &uart2 {
+	clock-source = <ADI_MAX32_PRPH_CLK_SRC_IBRO>;
+	pinctrl-0 = <&uart2a_tx_p1_10 &uart2a_rx_p1_9>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	data-bits = <8>;
+	parity = "none";
+	status = "okay";
+};
+
+feather_i2c: &i2c0 {
+	status = "okay";
+	pinctrl-0 = <&i2c0a_scl_p2_8 &i2c0a_sda_p2_7>;
+	pinctrl-names = "default";
+};
+
+feather_spi: &spi0 {
+	status = "okay";
+	pinctrl-0 = <&spi0b_mosi_p2_28 &spi0b_miso_p2_27 &spi0b_sck_p2_29>;
+	pinctrl-names = "default";
+};

--- a/boards/adi/max32690fthr/max32690fthr_max32690_m4.yaml
+++ b/boards/adi/max32690fthr/max32690fthr_max32690_m4.yaml
@@ -1,0 +1,19 @@
+identifier: max32690fthr/max32690/m4
+name: max32690fthr m4
+vendor: adi
+type: mcu
+arch: arm
+toolchain:
+  - zephyr
+  - gnuarmemb
+  - xtools
+supported:
+  - gpio
+  - serial
+  - i2c
+  - spi
+  - feather_serial
+  - feather_i2c
+  - feather_spi
+ram: 1024
+flash: 3072

--- a/boards/adi/max32690fthr/max32690fthr_max32690_m4_defconfig
+++ b/boards/adi/max32690fthr/max32690fthr_max32690_m4_defconfig
@@ -1,0 +1,13 @@
+# Copyright (c) 2023-2024 Analog Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Enable GPIO
+CONFIG_GPIO=y
+
+# Console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+
+# Enable UART
+CONFIG_SERIAL=y
+CONFIG_UART_INTERRUPT_DRIVEN=y


### PR DESCRIPTION
Adds a new board definition for the ADI MAX32690FTHR board. This board uses the same SoC as the MAX32690EVKIT board, but with a smaller feather form factor.

Tested on hardware with the following samples:
- samples/hello_world
- samples/basic/blinky
- samples/basic/threads
- samples/subsys/shell/shell_module
- samples/subsys/input/input_dump