### PR TITLE
llext: flush logging before unloading extensions

### DIFF
--- a/subsys/llext/llext.c
+++ b/subsys/llext/llext.c
@@ -180,12 +180,63 @@ out:
 	return ret;
 }
 
+#include <zephyr/logging/log_ctrl.h>
+
+static void llext_log_flush(void)
+{
+#ifdef CONFIG_LOG_MODE_DEFERRED
+	extern struct k_thread logging_thread;
+	int cur_prio = k_thread_priority_get(k_current_get());
+	int log_prio = k_thread_priority_get(&logging_thread);
+	int target_prio;
+	bool adjust_cur, adjust_log;
+
+	/*
+	 * Our goal is to raise the logger thread priority above current, but if
+	 * current has the highest possble priority, both need to be adjusted,
+	 * particularly if the logger thread has the lowest possible priority
+	 */
+	if (log_prio < cur_prio) {
+		adjust_cur = false;
+		adjust_log = false;
+		target_prio = 0;
+	} else if (cur_prio == K_HIGHEST_THREAD_PRIO) {
+		adjust_cur = true;
+		adjust_log = true;
+		target_prio = cur_prio;
+		k_thread_priority_set(k_current_get(), cur_prio + 1);
+	} else {
+		adjust_cur = false;
+		adjust_log = true;
+		target_prio = cur_prio - 1;
+	}
+
+	/* adjust logging thread priority if needed */
+	if (adjust_log) {
+		k_thread_priority_set(&logging_thread, target_prio);
+	}
+
+	log_thread_trigger();
+	k_yield();
+
+	if (adjust_log) {
+		k_thread_priority_set(&logging_thread, log_prio);
+	}
+	if (adjust_cur) {
+		k_thread_priority_set(&logging_thread, cur_prio);
+	}
+#endif
+}
+
 int llext_unload(struct llext **ext)
 {
 	__ASSERT(*ext, "Expected non-null extension");
 	struct llext *tmp = *ext;
 
 	k_mutex_lock(&llext_lock, K_FOREVER);
+
+	llext_log_flush();
+
 	__ASSERT(tmp->use_count, "A valid LLEXT cannot have a zero use-count!");
 
 	if (tmp->use_count-- != 1) {


### PR DESCRIPTION
When logging is deferred it can happen that the logger thread attempts to emit a log entry when the memory, containing log data has been unmapped. This can happen e.g. when an LLEXT object was running from dynamically mapped memory, used logging and was unloaded and unmapped before the logger thread had a chance to emit the entry. To avoid this problem, check that the memory, where the format string is residing, hasn't been unmapped. If that does happen, ignore the error and drop the log entry.

This is required to fix https://github.com/thesofproject/sof/issues/9371 . The fix isn't particularly elegant, it's mixing two hardly related APIs: logging and memory mapping. The key problem is that when logging is deferred, memory that it's trying to access might be gone by then. Ideas for a more generic solution are welcome, but - as usually - if properly fixing this requires significant API extensions or changes, maybe we can apply this or something similar as a temporary fix, while working out a generic solution.