### PR TITLE
i2c: Fix build failure with i2c_mcux_rtio driver

### DIFF
--- a/drivers/i2c/i2c_mcux_lpi2c_rtio.c
+++ b/drivers/i2c/i2c_mcux_lpi2c_rtio.c
@@ -192,13 +192,15 @@ static bool mcux_lpi2c_start(const struct device *dev)
 	switch (sqe->op) {
 	case RTIO_OP_RX:
 		return mcux_lpi2c_msg_start(dev, I2C_MSG_READ | sqe->iodev_flags,
-				      sqe->rx.buf, sqe->rx.buf_len, dt_spec->addr);
+					    sqe->rx.buf, sqe->rx.buf_len, dt_spec->addr);
 	case RTIO_OP_TINY_TX:
 		return mcux_lpi2c_msg_start(dev, I2C_MSG_WRITE | sqe->iodev_flags,
-				      sqe->tiny_tx.buf, sqe->tiny_tx.buf_len, dt_spec->addr);
+					    (uint8_t *)sqe->tiny_tx.buf, sqe->tiny_tx.buf_len,
+					    dt_spec->addr);
 	case RTIO_OP_TX:
 		return mcux_lpi2c_msg_start(dev, I2C_MSG_WRITE | sqe->iodev_flags,
-				      sqe->tx.buf, sqe->tx.buf_len, dt_spec->addr);
+					    (uint8_t *)sqe->tx.buf, sqe->tx.buf_len,
+					    dt_spec->addr);
 	case RTIO_OP_I2C_CONFIGURE:
 		res = mcux_lpi2c_do_configure(dev, sqe->i2c_config);
 		return i2c_rtio_complete(data->ctx, res);


### PR DESCRIPTION
Build was failing due to const variable being passed as function param accepting non-const variable discarding const qualifier. Explicitly cast to fix the build issue.

Fixes #77245 