### PR TITLE
arch: arm: cortex_a_r: Fix linker script

### DIFF
--- a/include/zephyr/arch/arm/cortex_a_r/scripts/linker.ld
+++ b/include/zephyr/arch/arm/cortex_a_r/scripts/linker.ld
@@ -257,7 +257,10 @@ SECTIONS
 
     GROUP_START(RAMABLE_REGION)
 
+#ifdef CONFIG_XIP
     . = RAM_ADDR;
+#endif
+
     /* Align the start of image RAM with the
      * minimum granularity required by MPU.
      */

--- a/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
@@ -257,7 +257,10 @@ SECTIONS
 
     GROUP_START(RAMABLE_REGION)
 
+#ifdef CONFIG_XIP
 	. = RAM_ADDR;
+#endif
+
 	/* Align the start of image RAM with the
 	 * minimum granularity required by MPU.
 	 */


### PR DESCRIPTION
This commit fixes overlapping MMU regions. If ROM_ADDR equals RAM_ADDR, the current output location counter will not be resetted, so the _image_ram range doesn't include the __text_region range.