### PR TITLE
openamp: resource table: fixes resource table to work with ram_console section

### DIFF
--- a/lib/open-amp/resource_table.c
+++ b/lib/open-amp/resource_table.c
@@ -29,7 +29,7 @@
 #include <zephyr/kernel.h>
 #include <resource_table.h>
 
-extern char ram_console[];
+extern char ram_console_buf[];
 
 #define __resource Z_GENERIC_SECTION(.resource_table)
 
@@ -68,7 +68,7 @@ static struct fw_resource_table __resource resource_table = {
 #if defined(CONFIG_RAM_CONSOLE)
 	.cm_trace = {
 		RSC_TRACE,
-		(uint32_t)ram_console, CONFIG_RAM_CONSOLE_BUFFER_SIZE, 0,
+		(uint32_t)ram_console_buf, CONFIG_RAM_CONSOLE_BUFFER_SIZE, 0,
 		"Zephyr_log",
 	},
 #endif


### PR DESCRIPTION
in commit 1cd37f21f3a the global ram console buffer was replaced with a pointer. This didn't work with the OpenAMP resource table anymore (#75656). This commit removes also the unnecessary console buffer, if a ram console device tree node is configured.
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/75656