### PR TITLE
doc: requirements: Update to Sphinx RTD Theme 3.0

### DIFF
--- a/doc/_extensions/zephyr/gh_utils.py
+++ b/doc/_extensions/zephyr/gh_utils.py
@@ -112,7 +112,7 @@ def gh_link_get_url(app: Sphinx, pagename: str, mode: str = "blob") -> Optional[
             mode,
             app.config.gh_link_version,
             page_prefix,
-            app.env.doc2path(pagename, False),
+            str(app.env.doc2path(pagename, False)),
         ]
     )
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,7 +1,7 @@
 # DOC: used to generate docs
 
 sphinx
-sphinx_rtd_theme~=2.0
+sphinx_rtd_theme~=3.0
 sphinx-tabs
 sphinxcontrib-svg2pdfconverter
 pygments>=2.9


### PR DESCRIPTION
https://builds.zephyrproject.io/zephyr/pr/77296/docs/

Update to latest Sphinx RTD Theme version.
Main benefit is to now be able to leverage Sphinx 8.0 since previous version of the theme was depending on 'sphinx < 8.0'.