### PR TITLE
drivers: spi: esp32:  fix exception when in mode 3 & software-controlled CS

### DIFF
--- a/drivers/spi/spi_esp32_spim.c
+++ b/drivers/spi/spi_esp32_spim.c
@@ -425,12 +425,12 @@ static int transceive(const struct device *dev,
 
 	spi_context_lock(&data->ctx, asynchronous, cb, userdata, spi_cfg);
 
+	data->dfs = spi_esp32_get_frame_size(spi_cfg);
+
 	ret = spi_esp32_configure(dev, spi_cfg);
 	if (ret) {
 		goto done;
 	}
-
-	data->dfs = spi_esp32_get_frame_size(spi_cfg);
 
 	spi_context_buffers_setup(&data->ctx, tx_bufs, rx_bufs, data->dfs);
 


### PR DESCRIPTION
Fixes division by zero exception when SPI is configured to operate in mode3 whit CS controlled by software

Such exception occurred because data->dfs variable was listed as the denominator in a division inside the spi_esp32_transfer() function which is called from spi_esp32_configure() (before assigning a value to data->dfs) inside transceive() in the condition where mode 3 is chosen as the SPI operating mode and the chip-select is configured to be software-controlled.