### PR TITLE
drivers: sdhc: imx_usdhc: assume card is present if no detection method

### DIFF
--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -88,6 +88,14 @@ Interrupt Controller
 LED Strip
 =========
 
+SDHC
+====
+
+* The NXP USDHC driver now assumes a card is present if no card detect method
+  is configured, instead of using the peripheral's internal card detect signal
+  to check for card presence. To use the internal card detect signal, the
+  devicetree property ``detect-cd`` should be added to the USDHC node in use.
+
 Sensors
 =======
 

--- a/dts/bindings/sdhc/nxp,imx-usdhc.yaml
+++ b/dts/bindings/sdhc/nxp,imx-usdhc.yaml
@@ -66,3 +66,10 @@ properties:
       Enable the host to detect an SD card via the DAT3 line of the SD card
       connection. Requires the board to define a function to pull DAT3 low or
       high using pullup/pulldown resistors.
+
+  detect-cd:
+    type: boolean
+    description: |
+      Use the host's internal card detect signal (USDHC_CD) to detect the SD
+      card. This signal is available as an alternative to card detect via GPIO,
+      and should be connected to the SD slot's detect pin if used.


### PR DESCRIPTION
The imx USDHC driver previously queried the peripheral's internal card
detect signal to check card presence if no card detect method was
configured. However, some boards do not route the card detect signal and
do not work correctly with the DAT3 detection method supported by this
peripheral. As a fallback, assume the card is present in the slot but
log a warning to the user.

Fixes #42227
