### PR TITLE
imxrt11xx enable FlexIO

### DIFF
--- a/drivers/clock_control/clock_control_mcux_ccm_rev2.c
+++ b/drivers/clock_control/clock_control_mcux_ccm_rev2.c
@@ -172,6 +172,15 @@ static int mcux_ccm_get_subsys_rate(const struct device *dev,
 		break;
 #endif
 
+#ifdef CONFIG_MCUX_FLEXIO
+	case IMX_CCM_FLEXIO1_CLK:
+		clock_root = kCLOCK_Root_Flexio1;
+		break;
+	case IMX_CCM_FLEXIO2_CLK:
+		clock_root = kCLOCK_Root_Flexio2;
+		break;
+#endif
+
 #ifdef CONFIG_PWM_MCUX_QTMR
 	case IMX_CCM_QTMR1_CLK:
 	case IMX_CCM_QTMR2_CLK:

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -750,6 +750,22 @@
 			};
 		};
 
+		flexio1: flexio@400ac000 {
+			compatible = "nxp,flexio";
+			reg = <0x400ac000 0x4000>;
+			interrupts = <110 0>;
+			clocks = <&ccm IMX_CCM_FLEXIO1_CLK 0 0>;
+			status = "disabled";
+		};
+
+		flexio2: flexio@400b0000 {
+			compatible = "nxp,flexio";
+			reg = <0x400b0000 0x4000>;
+			interrupts = <111 0>;
+			clocks = <&ccm IMX_CCM_FLEXIO2_CLK 0 0>;
+			status = "disabled";
+		};
+
 		enet: ethernet@40424000 {
 			compatible = "nxp,enet";
 			reg = <0x40424000 0x628>;

--- a/include/zephyr/dt-bindings/clock/imx_ccm_rev2.h
+++ b/include/zephyr/dt-bindings/clock/imx_ccm_rev2.h
@@ -122,6 +122,11 @@
 #define IMX_CCM_TPM5_CLK               0x1604UL
 #define IMX_CCM_TPM6_CLK               0x1605UL
 
+/* FLEXIO */
+#define IMX_CCM_FLEXIO_CLK             0x1700UL
+#define IMX_CCM_FLEXIO1_CLK            0x1700UL
+#define IMX_CCM_FLEXIO2_CLK            0x1701UL
+
 /* QTMR */
 #define IMX_CCM_QTMR_CLK               0x6000UL
 #define IMX_CCM_QTMR1_CLK              0x6000UL


### PR DESCRIPTION
Adds clock definition and dts definitions for FlexIO on IMXRT11XX chips.

Tested on vmu_rt1170.