### PR TITLE
soc: esp32: kconfig: add unsupported revision config

### DIFF
--- a/soc/espressif/common/Kconfig
+++ b/soc/espressif/common/Kconfig
@@ -7,6 +7,14 @@ config FLASH_SIZE
 config FLASH_BASE_ADDRESS
 	hex
 
+config ESP32_USE_UNSUPPORTED_REVISION
+	bool "Use unsupported ESP32 revision (Rev 0/1)"
+	help
+	  ESP32 SoC has multiple revisions, some of which are not supported by the current
+	  implementation, as such as REV0 and REV1. In case those revisions are required,
+	  set this option to enable support for them. Note that this is not recommended and
+	  may lead to unexpected behavior.
+
 rsource "Kconfig.spiram"
 rsource "Kconfig.esptool"
 rsource "Kconfig.flash"

--- a/soc/espressif/common/Kconfig.spiram
+++ b/soc/espressif/common/Kconfig.spiram
@@ -6,6 +6,7 @@ if SOC_SERIES_ESP32 || SOC_SERIES_ESP32S2 || SOC_SERIES_ESP32S3
 config ESP_SPIRAM
 	bool "Support for external, SPI-connected RAM"
 	default n if MCUBOOT
+	default n if ESP32_USE_UNSUPPORTED_REVISION && SOC_SERIES_ESP32
 	help
 	  This enables support for an external SPI RAM chip, connected in
 	  parallel with the main SPI flash chip.

--- a/west.yml
+++ b/west.yml
@@ -157,7 +157,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: e05b24f5caee741e0f3b43123bf2082e8cc908e7
+      revision: 2e3fea844bc09ff09e05ea4807e736352a0dde8c
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
ESP32 SoC has multiple revisions, some of which are not supported by the current implementation, as such as REV0 and REV1. This PR adds an option to indicate user that this is not recommended and not supported.