### PR TITLE
entropy: esp32c6: Add support

### DIFF
--- a/boards/espressif/esp32c6_devkitc/esp32c6_devkitc.dts
+++ b/boards/espressif/esp32c6_devkitc/esp32c6_devkitc.dts
@@ -44,6 +44,10 @@
 	pinctrl-names = "default";
 };
 
+&trng0 {
+	status = "okay";
+};
+
 &spi2 {
 	#address-cells = <1>;
 	#size-cells = <0>;

--- a/boards/espressif/esp32c6_devkitc/esp32c6_devkitc.yaml
+++ b/boards/espressif/esp32c6_devkitc/esp32c6_devkitc.yaml
@@ -11,6 +11,7 @@ supported:
   - uart
   - dma
   - spi
+  - entropy
 testing:
   ignore_tags:
     - net

--- a/drivers/entropy/entropy_esp32.c
+++ b/drivers/entropy/entropy_esp32.c
@@ -12,7 +12,13 @@
 #include <esp_system.h>
 #include <soc.h>
 #include <esp_cpu.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/drivers/entropy.h>
+#if defined(SOC_RNG_CLOCK_IS_INDEPENDENT)
+#include <zephyr/drivers/clock_control.h>
+#endif
+
+LOG_MODULE_REGISTER(entropy, CONFIG_ENTROPY_LOG_LEVEL);
 
 static inline uint32_t entropy_esp32_get_u32(void)
 {
@@ -58,8 +64,28 @@ static int entropy_esp32_get_entropy(const struct device *dev, uint8_t *buf,
 
 static int entropy_esp32_init(const struct device *dev)
 {
+	int ret = 0;
+
+#if defined(SOC_RNG_CLOCK_IS_INDEPENDENT)
+	const struct device *clock_dev =
+		DEVICE_DT_GET(DT_CLOCKS_CTLR(DT_NODELABEL(trng0)));
+	clock_control_subsys_t clock_subsys =
+		(clock_control_subsys_t)DT_CLOCKS_CELL(DT_NODELABEL(trng0), offset);
+
+	if (!device_is_ready(clock_dev)) {
+		return -ENODEV;
+	}
+
+	ret = clock_control_on(clock_dev, clock_subsys);
+
+	if (ret != 0) {
+		LOG_ERR("Error enabling TRNG clock");
+	}
+#else
 	/* clock initialization handled by clock manager */
-	return 0;
+#endif
+
+	return ret;
 }
 
 static const struct entropy_driver_api entropy_esp32_api_funcs = {

--- a/dts/riscv/espressif/esp32c6/esp32c6_common.dtsi
+++ b/dts/riscv/espressif/esp32c6/esp32c6_common.dtsi
@@ -15,6 +15,7 @@
 	#size-cells = <1>;
 
 	chosen {
+		zephyr,entropy = &trng0;
 		zephyr,flash-controller = &flash;
 	};
 
@@ -98,6 +99,13 @@
 			clocks = <&rtc ESP32_MODULE_MAX>;
 			interrupts = <LP_RTC_TIMER_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
+			status = "disabled";
+		};
+
+		trng0: trng@600b2808 {
+			compatible = "espressif,esp32-trng";
+			reg = <0x600B2808 0x4>;
+			clocks = <&rtc ESP32_RNG_MODULE>;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
Enable support of entropy (TRNG) driver for ESP32C6 devices