### PR TITLE
drivers: sensor: Fix adxl345 sample fetch return value

### DIFF
--- a/drivers/sensor/adi/adxl345/adxl345.c
+++ b/drivers/sensor/adi/adxl345/adxl345.c
@@ -165,7 +165,7 @@ static int adxl345_sample_fetch(const struct device *dev,
 		data->bufz[s] = sample.z;
 	}
 
-	return samples_count;
+	return 0;
 }
 
 static int adxl345_channel_get(const struct device *dev,


### PR DESCRIPTION
Fixes the adxl345 accelerometer driver to return zero on sample fetch success, as specified by the sensor driver API. Prior to this change, the driver incorrectly returned a positive non-zero value on sample fetch success, which in turn caused a bus fault getting data with the sensor shell.