### PR TITLE
coding guidelines: comply with MISRA C:2012 Rule 15.6

### DIFF
--- a/arch/arm/core/cortex_a_r/fault.c
+++ b/arch/arm/core/cortex_a_r/fault.c
@@ -147,8 +147,9 @@ bool z_arm_fault_undef_instruction_fp(void)
 	 * the FP was already enabled then this was an actual undefined
 	 * instruction.
 	 */
-	if (__get_FPEXC() & FPEXC_EN)
+	if (__get_FPEXC() & FPEXC_EN) {
 		return true;
+	}
 
 	__set_FPEXC(FPEXC_EN);
 
@@ -162,8 +163,9 @@ bool z_arm_fault_undef_instruction_fp(void)
 		struct __fpu_sf *spill_esf =
 			(struct __fpu_sf *)_current_cpu->fp_ctx;
 
-		if (spill_esf == NULL)
+		if (spill_esf == NULL) {
 			return false;
+		}
 
 		_current_cpu->fp_ctx = NULL;
 

--- a/arch/arm64/core/fatal.c
+++ b/arch/arm64/core/fatal.c
@@ -287,8 +287,9 @@ static bool z_arm64_stack_corruption_check(struct arch_esf *esf, uint64_t esr, u
 static bool is_recoverable(struct arch_esf *esf, uint64_t esr, uint64_t far,
 			   uint64_t elr)
 {
-	if (!esf)
+	if (!esf) {
 		return false;
+	}
 
 #ifdef CONFIG_USERSPACE
 	for (int i = 0; i < ARRAY_SIZE(exceptions); i++) {
@@ -345,8 +346,9 @@ void z_arm64_fatal_error(unsigned int reason, struct arch_esf *esf)
 
 			dump_esr(esr, &dump_far);
 
-			if (dump_far)
+			if (dump_far) {
 				LOG_ERR("FAR_ELn: 0x%016llx", far);
+			}
 
 			LOG_ERR("TPIDRRO: 0x%016llx", read_tpidrro_el0());
 #endif /* CONFIG_EXCEPTION_DEBUG */

--- a/arch/arm64/core/mmu.c
+++ b/arch/arm64/core/mmu.c
@@ -686,17 +686,20 @@ static uint64_t get_region_desc(uint32_t attrs)
 	case MT_NORMAL_NC:
 	case MT_NORMAL:
 		/* Make Normal RW memory as execute never */
-		if ((attrs & MT_RW) || (attrs & MT_P_EXECUTE_NEVER))
+		if ((attrs & MT_RW) || (attrs & MT_P_EXECUTE_NEVER)) {
 			desc |= PTE_BLOCK_DESC_PXN;
+		}
 
 		if (((attrs & MT_RW) && (attrs & MT_RW_AP_ELx)) ||
-		     (attrs & MT_U_EXECUTE_NEVER))
+		     (attrs & MT_U_EXECUTE_NEVER)) {
 			desc |= PTE_BLOCK_DESC_UXN;
+		}
 
-		if (mem_type == MT_NORMAL)
+		if (mem_type == MT_NORMAL) {
 			desc |= PTE_BLOCK_DESC_INNER_SHARE;
-		else
+		} else {
 			desc |= PTE_BLOCK_DESC_OUTER_SHARE;
+		}
 	}
 
 	/* non-Global bit */
@@ -844,8 +847,9 @@ static void setup_page_tables(struct arm_mmu_ptables *ptables)
 	uintptr_t max_va = 0, max_pa = 0;
 
 	MMU_DEBUG("xlat tables:\n");
-	for (index = 0U; index < CONFIG_MAX_XLAT_TABLES; index++)
+	for (index = 0U; index < CONFIG_MAX_XLAT_TABLES; index++) {
 		MMU_DEBUG("%d: %p\n", index, xlat_tables + index * Ln_XLAT_NUM_ENTRIES);
+	}
 
 	for (index = 0U; index < mmu_config.num_regions; index++) {
 		region = &mmu_config.mmu_regions[index];
@@ -1329,8 +1333,9 @@ void z_arm64_thread_mem_domains_init(struct k_thread *incoming)
 {
 	struct arm_mmu_ptables *ptables;
 
-	if ((incoming->base.user_options & K_USER) == 0)
+	if ((incoming->base.user_options & K_USER) == 0) {
 		return;
+	}
 
 	ptables = incoming->arch.ptables;
 

--- a/boards/sparkfun/thing_plus_matter_mgm240p/board.c
+++ b/boards/sparkfun/thing_plus_matter_mgm240p/board.c
@@ -35,8 +35,9 @@ static int sparkfun_thing_plus_mgm240p_init(void)
 		return -ENODEV;
 	}
 	ret = gpio_pin_configure_dt(&wake_up_gpio_dev, GPIO_OUTPUT_ACTIVE);
-	if (ret < 0)
+	if (ret < 0) {
 		return ret;
+	}
 
 	return 0;
 }

--- a/drivers/clock_control/clock_control_litex.c
+++ b/drivers/clock_control/clock_control_litex.c
@@ -386,10 +386,11 @@ static void litex_clk_check_DO(char *reg_name, uint8_t clk_reg_addr,
 	int ret;
 
 	ret = litex_clk_get_DO(clk_reg_addr, res);
-	if (ret != 0)
+	if (ret != 0) {
 		LOG_ERR("%s: read error: %d", reg_name, ret);
-	else
+	} else {
 		LOG_DBG("%s:  0x%x", reg_name, *res);
+	}
 }
 
 static void litex_clk_print_general_regs(void)

--- a/drivers/clock_control/clock_control_mcux_ccm.c
+++ b/drivers/clock_control/clock_control_mcux_ccm.c
@@ -307,10 +307,11 @@ static int mcux_ccm_get_subsys_rate(const struct device *dev,
 	{
 		uint32_t mux = CLOCK_GetRootMux(kCLOCK_RootGpt1);
 
-		if (mux == 0)
+		if (mux == 0) {
 			*rate = OSC24M_CLK_FREQ;
-		else
+		} else {
 			*rate = 0;
+		}
 	} break;
 #endif
 #endif

--- a/drivers/clock_control/clock_control_npcx.c
+++ b/drivers/clock_control/clock_control_npcx.c
@@ -130,8 +130,9 @@ void npcx_clock_control_turn_on_system_sleep(bool is_deep, bool is_instant)
 	if (is_deep) {
 		pm_flags |= BIT(NPCX_PMCSR_DHF);
 		/* Add 'Instant Wake-up' flag if sleep time is within 200 ms */
-		if (is_instant)
+		if (is_instant) {
 			pm_flags |= BIT(NPCX_PMCSR_DI_INSTW);
+		}
 	}
 
 	inst_pmc->PMCSR = pm_flags;

--- a/drivers/counter/counter_mcux_tpm.c
+++ b/drivers/counter/counter_mcux_tpm.c
@@ -86,18 +86,21 @@ static int mcux_tpm_set_alarm(const struct device *dev, uint8_t chan_id,
 		return -EINVAL;
 	}
 
-	if (ticks > (top_value))
+	if (ticks > (top_value)) {
 		return -EINVAL;
-
-	if ((alarm_cfg->flags & COUNTER_ALARM_CFG_ABSOLUTE) == 0) {
-		if (top_value - current >= ticks)
-			ticks += current;
-		else
-			ticks -= top_value - current;
 	}
 
-	if (data->alarm_callback)
+	if ((alarm_cfg->flags & COUNTER_ALARM_CFG_ABSOLUTE) == 0) {
+		if (top_value - current >= ticks) {
+			ticks += current;
+		} else {
+			ticks -= top_value - current;
+		}
+	}
+
+	if (data->alarm_callback) {
 		return -EBUSY;
+	}
 
 	data->alarm_callback = alarm_cfg->callback;
 	data->alarm_user_data = alarm_cfg->user_data;
@@ -163,8 +166,9 @@ static int mcux_tpm_set_top_value(const struct device *dev,
 	TPM_Type *base = get_base(dev);
 	struct mcux_tpm_data *data = dev->data;
 
-	if (data->alarm_callback)
+	if (data->alarm_callback) {
 		return -EBUSY;
+	}
 
 	/* Check if timer already enabled. */
 #if defined(FSL_FEATURE_TPM_HAS_SC_CLKS) && FSL_FEATURE_TPM_HAS_SC_CLKS
@@ -173,8 +177,9 @@ static int mcux_tpm_set_top_value(const struct device *dev,
 	if (base->SC & TPM_SC_CMOD_MASK) {
 #endif
 		/* Timer already enabled, check flags before resetting */
-		if (cfg->flags & COUNTER_TOP_CFG_DONT_RESET)
+		if (cfg->flags & COUNTER_TOP_CFG_DONT_RESET) {
 			return -ENOTSUP;
+		}
 
 		TPM_StopTimer(base);
 		base->CNT = 0;

--- a/drivers/dai/intel/dmic/dmic.c
+++ b/drivers/dai/intel/dmic/dmic.c
@@ -519,12 +519,14 @@ static void dai_dmic_gain_ramp(struct dai_intel_dmic *dmic)
 
 	/* Write gain to registers */
 	for (i = 0; i < CONFIG_DAI_DMIC_HW_CONTROLLERS; i++) {
-		if (!dmic->enable[i])
+		if (!dmic->enable[i]) {
 			continue;
+		}
 
-		if (dmic->startcount == DMIC_UNMUTE_CIC)
+		if (dmic->startcount == DMIC_UNMUTE_CIC) {
 			dai_dmic_update_bits(dmic, dmic_base[i] + CIC_CONTROL,
 					     CIC_CONTROL_MIC_MUTE, 0);
+		}
 
 		if (dmic->startcount == DMIC_UNMUTE_FIR) {
 			dai_dmic_update_bits(dmic, dmic_base[i] + FIR_CHANNEL_REGS_SIZE *
@@ -563,8 +565,9 @@ static void dai_dmic_start(struct dai_intel_dmic *dmic)
 	key = k_spin_lock(&dmic->lock);
 
 #ifdef CONFIG_SOC_SERIES_INTEL_ADSP_ACE
-	for (i = 0; i < CONFIG_DAI_DMIC_HW_CONTROLLERS; i++)
+	for (i = 0; i < CONFIG_DAI_DMIC_HW_CONTROLLERS; i++) {
 		dai_dmic_update_bits(dmic, dmic_base[i] + CIC_CONTROL, CIC_CONTROL_SOFT_RESET, 0);
+	}
 #endif
 
 	dmic->startcount = 0;

--- a/drivers/dai/intel/dmic/dmic.h
+++ b/drivers/dai/intel/dmic/dmic.h
@@ -185,12 +185,13 @@ struct dai_intel_dmic {
 
 static inline int32_t sat_int32(int64_t x)
 {
-	if (x > INT32_MAX)
+	if (x > INT32_MAX) {
 		return INT32_MAX;
-	else if (x < INT32_MIN)
+	} else if (x < INT32_MIN) {
 		return INT32_MIN;
-	else
+	} else {
 		return (int32_t)x;
+	}
 }
 /* Fractional multiplication with shift and saturation */
 static inline int32_t q_multsr_sat_32x32(int32_t x, int32_t y,

--- a/drivers/dai/intel/dmic/dmic_nhlt.c
+++ b/drivers/dai/intel/dmic/dmic_nhlt.c
@@ -182,17 +182,19 @@ static int dai_ipm_source_to_enable(struct dai_intel_dmic *dmic,
 {
 	int mic_swap;
 
-	if (source_pdm >= CONFIG_DAI_DMIC_HW_CONTROLLERS)
+	if (source_pdm >= CONFIG_DAI_DMIC_HW_CONTROLLERS) {
 		return -EINVAL;
+	}
 
 	if (*count < pdm_count) {
 		(*count)++;
 		mic_swap = FIELD_GET(MIC_CONTROL_CLK_EDGE, dai_dmic_read(
 						dmic, dmic_base[source_pdm] + MIC_CONTROL));
-		if (stereo)
+		if (stereo) {
 			dmic->enable[source_pdm] = 0x3; /* PDMi MIC A and B */
-		else
+		} else {
 			dmic->enable[source_pdm] = mic_swap ? 0x2 : 0x1; /* PDMi MIC B or MIC A */
+		}
 	}
 
 	return 0;
@@ -234,8 +236,9 @@ static int dai_nhlt_dmic_dai_params_get(struct dai_intel_dmic *dmic, const int c
 	stereo_pdm = FIELD_GET(OUTCONTROL_IPM_SOURCE_MODE, outcontrol_val);
 
 	dmic->dai_config_params.channels = (stereo_pdm + 1) * num_pdm;
-	for (n = 0; n < CONFIG_DAI_DMIC_HW_CONTROLLERS; n++)
+	for (n = 0; n < CONFIG_DAI_DMIC_HW_CONTROLLERS; n++) {
 		dmic->enable[n] = 0;
+	}
 
 	n = 0;
 	source_pdm = FIELD_GET(OUTCONTROL_IPM_SOURCE_1, outcontrol_val);

--- a/drivers/dai/intel/ssp/ssp.c
+++ b/drivers/dai/intel/ssp/ssp.c
@@ -502,11 +502,12 @@ static int dai_ssp_find_bclk_source(struct dai_intel_ssp *dp, uint32_t bclk, uin
 	}
 
 	/* searching the smallest possible bclk source */
-	for (i = 0; i <= DAI_INTEL_SSP_MAX_FREQ_INDEX; i++)
+	for (i = 0; i <= DAI_INTEL_SSP_MAX_FREQ_INDEX; i++) {
 		if (ft[i].freq % bclk == 0) {
 			*scr_div = ft[i].freq / bclk;
 			return i;
 		}
+	}
 
 	/* check if we can get target BCLK with M/N */
 	for (i = 0; i <= DAI_INTEL_SSP_MAX_FREQ_INDEX; i++) {
@@ -958,8 +959,9 @@ static void ssp_empty_rx_fifo_on_start(struct dai_intel_ssp *dp)
 	if (sssr & SSSR_ROR) {
 		/* The RX FIFO is in overflow condition, empty it */
 		for (uint32_t idx = 0; idx < I2SIPCMC; ++idx) {
-			for (i = 0; i < DAI_INTEL_SSP_FIFO_DEPTH; i++)
+			for (i = 0; i < DAI_INTEL_SSP_FIFO_DEPTH; i++) {
 				sys_read32(dai_base(dp) + SSMIDyD(idx));
+			}
 		}
 
 		/* Clear the overflow status */
@@ -974,8 +976,9 @@ static void ssp_empty_rx_fifo_on_start(struct dai_intel_ssp *dp)
 				SSMIDyCS(idx)));
 
 			/* Empty the RX FIFO (the DMA is not running at this point) */
-			for (i = 0; i < entries + 1; i++)
+			for (i = 0; i < entries + 1; i++) {
 				sys_read32(dai_base(dp) + SSMIDyD(idx));
+			}
 
 			sssr = sys_read32(dai_base(dp) + SSSR);
 		}
@@ -1017,8 +1020,9 @@ static void ssp_empty_rx_fifo_on_stop(struct dai_intel_ssp *dp)
 			 * directly, otherwise let the next loop iteration to
 			 * check the status
 			 */
-			for (i = 0; i < entries[1] + 1; i++)
+			for (i = 0; i < entries[1] + 1; i++) {
 				sys_read32(dai_base(dp) + SSMIDyD(dp->tdm_slot_group));
+			}
 		}
 		sssr = sys_read32(dai_base(dp) + SSSR);
 	}
@@ -1037,8 +1041,9 @@ static void ssp_empty_rx_fifo_on_start(struct dai_intel_ssp *dp)
 
 	if (sssr & SSSR_ROR) {
 		/* The RX FIFO is in overflow condition, empty it */
-		for (i = 0; i < DAI_INTEL_SSP_FIFO_DEPTH; i++)
+		for (i = 0; i < DAI_INTEL_SSP_FIFO_DEPTH; i++) {
 			sys_read32(dai_base(dp) + SSDR);
+		}
 
 		/* Clear the overflow status */
 		dai_ssp_update_bits(dp, SSSR, SSSR_ROR, SSSR_ROR);
@@ -1050,8 +1055,9 @@ static void ssp_empty_rx_fifo_on_start(struct dai_intel_ssp *dp)
 		uint32_t entries = SSCR3_RFL_VAL(sys_read32(dai_base(dp) + SSCR3));
 
 		/* Empty the RX FIFO (the DMA is not running at this point) */
-		for (i = 0; i < entries + 1; i++)
+		for (i = 0; i < entries + 1; i++) {
 			sys_read32(dai_base(dp) + SSDR);
+		}
 
 		sssr = sys_read32(dai_base(dp) + SSSR);
 	}
@@ -1088,8 +1094,9 @@ static void ssp_empty_rx_fifo_on_stop(struct dai_intel_ssp *dp)
 			 * directly, otherwise let the next loop iteration to
 			 * check the status
 			 */
-			for (i = 0; i < entries[1] + 1; i++)
+			for (i = 0; i < entries[1] + 1; i++) {
 				sys_read32(dai_base(dp) + SSDR);
+			}
 		}
 
 		sssr = sys_read32(dai_base(dp) + SSSR);

--- a/drivers/dma/dma_intel_adsp_gpdma.c
+++ b/drivers/dma/dma_intel_adsp_gpdma.c
@@ -72,15 +72,17 @@ static void intel_adsp_gpdma_dump_registers(const struct device *dev, uint32_t c
 		channel, cap, ctl, ipptr, llpc, llpl, llpu);
 
 	/* Channel Register Dump */
-	for (i = 0; i <= DW_DMA_CHANNEL_REGISTER_OFFSET_END; i += 0x8)
+	for (i = 0; i <= DW_DMA_CHANNEL_REGISTER_OFFSET_END; i += 0x8) {
 		LOG_INF(" channel register offset: %#x value: %#x\n", chan_reg_offs[i],
 			dw_read(dw_cfg->base, DW_CHAN_OFFSET(channel) + chan_reg_offs[i]));
+	}
 
 	/* IP Register Dump */
 	for (i = DW_DMA_CHANNEL_REGISTER_OFFSET_START; i <= DW_DMA_CHANNEL_REGISTER_OFFSET_END;
-	     i += 0x8)
+	     i += 0x8) {
 		LOG_INF(" ip register offset: %#x value: %#x\n", ip_reg_offs[i],
 			dw_read(dw_cfg->base, ip_reg_offs[i]));
+	}
 }
 #endif
 

--- a/drivers/dma/dma_iproc_pax_v1.c
+++ b/drivers/dma/dma_iproc_pax_v1.c
@@ -536,8 +536,9 @@ static int peek_ring_cmpl(const struct device *dev,
 	do {
 		wr_offs = sys_read32(RM_RING_REG(pd, idx,
 						 RING_CMPL_WRITE_PTR));
-		if (PAX_DMA_GET_CMPL_COUNT(wr_offs, rd_offs) >= pl_len)
+		if (PAX_DMA_GET_CMPL_COUNT(wr_offs, rd_offs) >= pl_len) {
 			break;
+		}
 		k_busy_wait(1);
 	} while (--timeout);
 

--- a/drivers/dma/dma_iproc_pax_v2.c
+++ b/drivers/dma/dma_iproc_pax_v2.c
@@ -623,8 +623,9 @@ static int peek_ring_cmpl(const struct device *dev,
 	do {
 		wr_offs = sys_read32(RM_RING_REG(pd, idx,
 						 RING_CMPL_WRITE_PTR));
-		if (PAX_DMA_GET_CMPL_COUNT(wr_offs, rd_offs) >= pl_len)
+		if (PAX_DMA_GET_CMPL_COUNT(wr_offs, rd_offs) >= pl_len) {
 			break;
+		}
 		k_busy_wait(1);
 	} while (--timeout);
 

--- a/drivers/ethernet/phy/phy_mii.c
+++ b/drivers/ethernet/phy/phy_mii.c
@@ -349,15 +349,17 @@ static int phy_mii_cfg_link(const struct device *dev,
 	}
 
 	if (data->gigabit_supported) {
-		if (adv_speeds & LINK_FULL_1000BASE_T)
+		if (adv_speeds & LINK_FULL_1000BASE_T) {
 			c1kt_reg |= MII_ADVERTISE_1000_FULL;
-		else
+		} else {
 			c1kt_reg &= ~MII_ADVERTISE_1000_FULL;
+		}
 
-		if (adv_speeds & LINK_HALF_1000BASE_T)
+		if (adv_speeds & LINK_HALF_1000BASE_T) {
 			c1kt_reg |= MII_ADVERTISE_1000_HALF;
-		else
+		} else {
 			c1kt_reg &= ~MII_ADVERTISE_1000_HALF;
+		}
 
 		if (reg_write(dev, MII_1KTCR, c1kt_reg) < 0) {
 			return -EIO;

--- a/drivers/firmware/scmi/mailbox.c
+++ b/drivers/firmware/scmi/mailbox.c
@@ -16,8 +16,9 @@ static void scmi_mbox_cb(const struct device *mbox,
 {
 	struct scmi_channel *scmi_chan = user_data;
 
-	if (scmi_chan->cb)
+	if (scmi_chan->cb) {
 		scmi_chan->cb(scmi_chan);
+	}
 }
 
 static int scmi_mbox_send_message(const struct device *transport,

--- a/drivers/flash/flash_cadence_qspi_nor_ll.c
+++ b/drivers/flash/flash_cadence_qspi_nor_ll.c
@@ -307,8 +307,9 @@ int cad_qspi_n25q_wait_for_program_and_erase(struct cad_qspi_params *cad_params,
 			LOG_ERR("Error getting device status\n");
 			return -1;
 		}
-		if (!CAD_QSPI_STIG_SR_BUSY(status))
+		if (!CAD_QSPI_STIG_SR_BUSY(status)) {
 			break;
+		}
 		count++;
 	}
 
@@ -328,12 +329,14 @@ int cad_qspi_n25q_wait_for_program_and_erase(struct cad_qspi_params *cad_params,
 		}
 
 		if ((program_only && CAD_QSPI_STIG_FLAGSR_PROGRAMREADY(flag_sr)) ||
-		    (!program_only && CAD_QSPI_STIG_FLAGSR_ERASEREADY(flag_sr)))
+		    (!program_only && CAD_QSPI_STIG_FLAGSR_ERASEREADY(flag_sr))) {
 			break;
+		}
 	}
 
-	if (count >= CAD_QSPI_COMMAND_TIMEOUT)
+	if (count >= CAD_QSPI_COMMAND_TIMEOUT) {
 		LOG_ERR("Timed out waiting for program and erase\n");
+	}
 
 	if ((program_only && CAD_QSPI_STIG_FLAGSR_PROGRAMERROR(flag_sr)) ||
 	    (!program_only && CAD_QSPI_STIG_FLAGSR_ERASEERROR(flag_sr))) {
@@ -546,10 +549,11 @@ void cad_qspi_calibration(struct cad_qspi_params *cad_params, uint32_t dev_clk,
 		}
 
 		if (rdid == sample_rdid) {
-			if (first_pass == -1)
+			if (first_pass == -1) {
 				first_pass = data_cap_delay;
-			else
+			} else {
 				last_pass = data_cap_delay;
+			}
 		}
 
 		data_cap_delay++;
@@ -725,8 +729,9 @@ int cad_qspi_indirect_page_bound_write(struct cad_qspi_params *cad_params, uint3
 		space = MIN(write_capacity - write_fill_level,
 			    (len - write_count) / sizeof(uint32_t));
 		write_data = (uint32_t *)(buffer + write_count);
-		for (i = 0; i < space; ++i)
+		for (i = 0; i < space; ++i) {
 			sys_write32(*write_data++, cad_params->data_base);
+		}
 
 		write_count += space * sizeof(uint32_t);
 	}
@@ -756,8 +761,9 @@ int cad_qspi_read_bank(struct cad_qspi_params *cad_params, uint8_t *buffer, uint
 			level = CAD_QSPI_SRAMFILL_INDRDPART(
 				sys_read32(cad_params->reg_base + CAD_QSPI_SRAMFILL));
 			read_data = (uint32_t *)(buffer + read_count);
-			for (i = 0; i < level; ++i)
+			for (i = 0; i < level; ++i) {
 				*read_data++ = sys_read32(cad_params->data_base);
+			}
 
 			read_count += level * sizeof(uint32_t);
 			count++;

--- a/drivers/flash/flash_rpi_pico.c
+++ b/drivers/flash/flash_rpi_pico.c
@@ -68,8 +68,9 @@ static void __no_inline_not_in_flash_func(flash_init_boot2_copyout)(void)
 	if (boot2_copyout_valid) {
 		return;
 	}
-	for (int i = 0; i < BOOT2_SIZE_WORDS; ++i)
+	for (int i = 0; i < BOOT2_SIZE_WORDS; ++i) {
 		boot2_copyout[i] = ((uint32_t *)FLASH_BASE)[i];
+	}
 	__compiler_memory_barrier();
 	boot2_copyout_valid = true;
 }
@@ -119,8 +120,9 @@ void __no_inline_not_in_flash_func(flash_put_get)(const uint8_t *tx, uint8_t *rx
 			if (rx_skip) {
 				--rx_skip;
 			} else {
-				if (rx)
+				if (rx) {
 					*rx++ = rxbyte;
+				}
 				--rx_count;
 			}
 		}

--- a/drivers/flash/flash_stm32l4x.c
+++ b/drivers/flash/flash_stm32l4x.c
@@ -192,8 +192,9 @@ static int erase_page(const struct device *dev, unsigned int page)
 #ifdef FLASH_CR_BKER
 	regs->CR &= ~FLASH_CR_BKER_Msk;
 	/* Select bank, only for DUALBANK devices */
-	if (page >= pages_per_bank)
+	if (page >= pages_per_bank) {
 		regs->CR |= FLASH_CR_BKER;
+	}
 #endif
 	regs->CR &= ~FLASH_CR_PNB_Msk;
 	regs->CR |= ((page % pages_per_bank) << 3);

--- a/drivers/fuel_gauge/sbs_gauge/emul_sbs_gauge.c
+++ b/drivers/fuel_gauge/sbs_gauge/emul_sbs_gauge.c
@@ -291,8 +291,9 @@ static int emul_sbs_fuel_gauge_set_battery_charging(const struct emul *target, u
 {
 	struct sbs_gauge_emul_data *data = target->data;
 
-	if (uV == 0 || uA == 0)
+	if (uV == 0 || uA == 0) {
 		return -EINVAL;
+	}
 
 	data->batt_state.uA = uA;
 	data->batt_state.uV = uV;

--- a/drivers/gpio/gpio_ite_it8xxx2.c
+++ b/drivers/gpio/gpio_ite_it8xxx2.c
@@ -433,12 +433,13 @@ static int gpio_ite_configure(const struct device *dev,
 	}
 
 	/* Set input or output. */
-	if (flags & GPIO_OUTPUT)
+	if (flags & GPIO_OUTPUT) {
 		*reg_gpcr = (*reg_gpcr | GPCR_PORT_PIN_MODE_OUTPUT) &
 				~GPCR_PORT_PIN_MODE_INPUT;
-	else
+	} else {
 		*reg_gpcr = (*reg_gpcr | GPCR_PORT_PIN_MODE_INPUT) &
 				~GPCR_PORT_PIN_MODE_OUTPUT;
+	}
 
 	/* Handle pullup / pulldown */
 	if (flags & GPIO_PULL_UP) {
@@ -475,8 +476,9 @@ static int gpio_ite_get_config(const struct device *dev,
 		"Invalid GPIO group index");
 
 	/* push-pull or open-drain */
-	if (*reg_gpotr & mask)
+	if (*reg_gpotr & mask) {
 		flags |= GPIO_OPEN_DRAIN;
+	}
 
 	/* 1.8V or 3.3V */
 	reg_1p8v = &IT8XXX2_GPIO_GCRX(

--- a/drivers/gpio/gpio_rt1718s_port.c
+++ b/drivers/gpio/gpio_rt1718s_port.c
@@ -331,10 +331,11 @@ void rt1718s_gpio_alert_handler(const struct device *dev)
 
 	k_sem_give(&data_port->lock);
 
-	if (reg_int8 & RT1718S_GPIO_INT_MASK)
+	if (reg_int8 & RT1718S_GPIO_INT_MASK) {
 		/* Call the GPIO callbacks for rising *or* falling edge */
 		gpio_fire_callbacks(&data_port->cb_list_gpio, config->gpio_port_dev,
 				    (reg_int8 & 0x7) | ((reg_int8 >> 4) & 0x7));
+	}
 }
 
 static const struct gpio_driver_api gpio_rt1718s_driver = {

--- a/drivers/hwspinlock/sqn_hwspinlock.c
+++ b/drivers/hwspinlock/sqn_hwspinlock.c
@@ -45,8 +45,9 @@ static int sqn_hwspinlock_trylock(const struct device *dev, uint32_t id)
 	const struct sqn_hwspinlock_config *config = dev->config;
 	uint8_t cpuid;
 
-	if (id > config->num_locks)
+	if (id > config->num_locks) {
 		return -EINVAL;
+	}
 
 	/*
 	 * If the register value is equal to cpuid, this means that the current

--- a/drivers/power_domain/power_domain_intel_adsp.c
+++ b/drivers/power_domain/power_domain_intel_adsp.c
@@ -43,8 +43,9 @@ static int pd_intel_adsp_set_power_enable(struct pg_bits *bits, bool power_enabl
 			volatile uint32_t *key_read_ptr = &adsp_pending_buffer;
 			uint32_t key_value = *key_read_ptr;
 
-			if (key_value != INTEL_ADSP_ACE15_MAGIC_KEY)
+			if (key_value != INTEL_ADSP_ACE15_MAGIC_KEY) {
 				return -EINVAL;
+			}
 		}
 #endif
 		sys_write16(sys_read16((mem_addr_t)ACE_PWRCTL) & ~(SPA_bit_mask),

--- a/drivers/ps2/ps2_npcx_controller.c
+++ b/drivers/ps2/ps2_npcx_controller.c
@@ -361,8 +361,9 @@ static int ps2_npcx_ctrl_init(const struct device *dev)
 	 */
 	inst->PSIEN = BIT(NPCX_PSIEN_SOTIE) | BIT(NPCX_PSIEN_EOTIE) |
 		      BIT(NPCX_PSIEN_PS2_WUE);
-	if (config->clk_cfg.bus == NPCX_CLOCK_BUS_FREERUN)
+	if (config->clk_cfg.bus == NPCX_CLOCK_BUS_FREERUN) {
 		inst->PSIEN |= BIT(NPCX_PSIEN_PS2_CLK_SEL);
+	}
 	/* Enable weak internal pull-up */
 	inst->PSCON |= BIT(NPCX_PSCON_WPUED);
 	/* Enable shift mechanism */

--- a/drivers/pwm/pwm_mchp_xec.c
+++ b/drivers/pwm/pwm_mchp_xec.c
@@ -327,8 +327,9 @@ static int pwm_xec_set_cycles(const struct device *dev, uint32_t channel,
 		return -EIO;
 	}
 
-	if (flags & PWM_POLARITY_INVERTED)
+	if (flags & PWM_POLARITY_INVERTED) {
 		regs->CONFIG |= MCHP_PWM_CFG_ON_POL_LO;
+	}
 
 	on = pulse_cycles;
 	off = period_cycles - pulse_cycles;

--- a/drivers/pwm/pwm_npcx.c
+++ b/drivers/pwm/pwm_npcx.c
@@ -70,10 +70,11 @@ static void pwm_npcx_configure(const struct device *dev, int clk_bus)
 			NPCX_PWM_CLOCK_APB2_LFCLK);
 
 	/* Select clock source to LFCLK by flag, otherwise APB clock source */
-	if (clk_bus == NPCX_CLOCK_BUS_LFCLK)
+	if (clk_bus == NPCX_CLOCK_BUS_LFCLK) {
 		inst->PWMCTL |= BIT(NPCX_PWMCTL_CKSEL);
-	else
+	} else {
 		inst->PWMCTL &= ~BIT(NPCX_PWMCTL_CKSEL);
+	}
 }
 
 /* PWM api functions */

--- a/drivers/rtc/rtc_ambiq.c
+++ b/drivers/rtc/rtc_ambiq.c
@@ -68,10 +68,11 @@ static void rtc_time_to_ambiq_time_set(const struct rtc_time *tm, am_hal_rtc_tim
 static void ambiq_time_to_rtc_time_set(const am_hal_rtc_time_t *atm, struct rtc_time *tm)
 {
 	tm->tm_year = atm->ui32Year;
-	if (atm->ui32CenturyBit == 0)
+	if (atm->ui32CenturyBit == 0) {
 		tm->tm_year += 100;
-	else
+	} else {
 		tm->tm_year += 200;
+	}
 	tm->tm_wday = atm->ui32Weekday;
 	tm->tm_mon = atm->ui32Month - 1;
 	tm->tm_mday = atm->ui32DayOfMonth;

--- a/drivers/sensor/adi/adxl367/adxl367.c
+++ b/drivers/sensor/adi/adxl367/adxl367.c
@@ -352,8 +352,9 @@ int adxl367_self_test(const struct device *dev)
 	x_axis_2 = ((int16_t)read_val[0] << 6) + (read_val[1] >> 2);
 
 	/* extend sign to 16 bits */
-	if ((x_axis_2 & BIT(13)) != 0)
+	if ((x_axis_2 & BIT(13)) != 0) {
 		x_axis_2 |= GENMASK(15, 14);
+	}
 
 	ret = adxl367_set_op_mode(dev, ADXL367_STANDBY);
 	if (ret != 0) {

--- a/drivers/sensor/adi/adxl367/adxl367_i2c.c
+++ b/drivers/sensor/adi/adxl367/adxl367_i2c.c
@@ -28,8 +28,9 @@ static int adxl367_bus_access(const struct device *dev, uint8_t reg,
 					 ADXL367_TO_REG(reg),
 					 (uint8_t *) data, length);
 	} else {
-		if (length != 1)
+		if (length != 1) {
 			return -EINVAL;
+		}
 
 		return i2c_reg_write_byte_dt(&config->i2c,
 					     ADXL367_TO_REG(reg),

--- a/drivers/sensor/bosch/bme280/bme280.c
+++ b/drivers/sensor/bosch/bme280/bme280.c
@@ -148,8 +148,9 @@ int bme280_sample_fetch_helper(const struct device *dev,
 	enum pm_device_state state;
 	(void)pm_device_state_get(dev, &state);
 	/* Do not allow sample fetching from suspended state */
-	if (state == PM_DEVICE_STATE_SUSPENDED)
+	if (state == PM_DEVICE_STATE_SUSPENDED) {
 		return -EIO;
+	}
 #endif
 
 #ifdef CONFIG_BME280_MODE_FORCED

--- a/drivers/sensor/silabs/si7210/si7210.c
+++ b/drivers/sensor/silabs/si7210/si7210.c
@@ -332,8 +332,9 @@ static int si7210_sample_fetch(const struct device *dev, enum sensor_channel cha
 	enum pm_device_state state;
 	(void)pm_device_state_get(dev, &state);
 	/* Do not allow sample fetching from suspended state */
-	if (state == PM_DEVICE_STATE_SUSPENDED)
+	if (state == PM_DEVICE_STATE_SUSPENDED) {
 		return -EIO;
+	}
 #endif
 
 	/* Prevent going into suspend in the middle of the conversion */

--- a/drivers/sensor/st/iis2iclx/iis2iclx_trigger.c
+++ b/drivers/sensor/st/iis2iclx/iis2iclx_trigger.c
@@ -36,8 +36,9 @@ static int iis2iclx_enable_t_int(const struct device *dev, int enable)
 	}
 
 	/* set interrupt (TEMP DRDY interrupt is only on INT2) */
-	if (cfg->int_pin == 1)
+	if (cfg->int_pin == 1) {
 		return -EIO;
+	}
 
 	iis2iclx_read_reg((stmdev_ctx_t *)&cfg->ctx, IIS2ICLX_INT2_CTRL,
 			  (uint8_t *)&int2_route.int2_ctrl, 1);

--- a/drivers/sensor/st/ism330dhcx/ism330dhcx_trigger.c
+++ b/drivers/sensor/st/ism330dhcx/ism330dhcx_trigger.c
@@ -37,8 +37,9 @@ static int ism330dhcx_enable_t_int(const struct device *dev, int enable)
 	}
 
 	/* set interrupt (TEMP DRDY interrupt is only on INT2) */
-	if (cfg->int_pin == 1)
+	if (cfg->int_pin == 1) {
 		return -EIO;
+	}
 
 	ism330dhcx_read_reg(ism330dhcx->ctx, ISM330DHCX_INT2_CTRL,
 			    (uint8_t *)&int2_route.int2_ctrl, 1);

--- a/drivers/sensor/st/lsm6dso/lsm6dso_trigger.c
+++ b/drivers/sensor/st/lsm6dso/lsm6dso_trigger.c
@@ -37,8 +37,9 @@ static int lsm6dso_enable_t_int(const struct device *dev, int enable)
 	}
 
 	/* set interrupt (TEMP DRDY interrupt is only on INT2) */
-	if (cfg->int_pin == 1)
+	if (cfg->int_pin == 1) {
 		return -EIO;
+	}
 
 	lsm6dso_read_reg(ctx, LSM6DSO_INT2_CTRL, (uint8_t *)&int2_ctrl, 1);
 	int2_ctrl.int2_drdy_temp = enable;

--- a/drivers/sensor/vishay/vcnl4040/vcnl4040.c
+++ b/drivers/sensor/vishay/vcnl4040/vcnl4040.c
@@ -189,14 +189,16 @@ static int vcnl4040_pm_action(const struct device *dev,
 	uint16_t ps_conf;
 
 	ret = vcnl4040_read(dev, VCNL4040_REG_PS_CONF, &ps_conf);
-	if (ret < 0)
+	if (ret < 0) {
 		return ret;
+	}
 #ifdef CONFIG_VCNL4040_ENABLE_ALS
 	uint16_t als_conf;
 
 	ret = vcnl4040_read(dev, VCNL4040_REG_ALS_CONF, &als_conf);
-	if (ret < 0)
+	if (ret < 0) {
 		return ret;
+	}
 #endif
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
@@ -205,16 +207,18 @@ static int vcnl4040_pm_action(const struct device *dev,
 
 		ret = vcnl4040_write(dev, VCNL4040_REG_PS_CONF,
 					ps_conf);
-		if (ret < 0)
+		if (ret < 0) {
 			return ret;
+		}
 #ifdef CONFIG_VCNL4040_ENABLE_ALS
 		/* Clear als shutdown */
 		als_conf &= ~VCNL4040_ALS_SD_MASK;
 
 		ret = vcnl4040_write(dev, VCNL4040_REG_ALS_CONF,
 					als_conf);
-		if (ret < 0)
+		if (ret < 0) {
 			return ret;
+		}
 #endif
 		break;
 	case PM_DEVICE_ACTION_SUSPEND:
@@ -223,16 +227,18 @@ static int vcnl4040_pm_action(const struct device *dev,
 
 		ret = vcnl4040_write(dev, VCNL4040_REG_PS_CONF,
 					ps_conf);
-		if (ret < 0)
+		if (ret < 0) {
 			return ret;
+		}
 #ifdef CONFIG_VCNL4040_ENABLE_ALS
 		/* Clear als shutdown bit 0 */
 		als_conf |= VCNL4040_ALS_SD_MASK;
 
 		ret = vcnl4040_write(dev, VCNL4040_REG_ALS_CONF,
 					als_conf);
-		if (ret < 0)
+		if (ret < 0) {
 			return ret;
+		}
 #endif
 		break;
 	default:

--- a/drivers/serial/uart_pl011.c
+++ b/drivers/serial/uart_pl011.c
@@ -378,8 +378,9 @@ static int pl011_irq_tx_ready(const struct device *dev)
 {
 	struct pl011_data *data = dev->data;
 
-	if (!data->sbsa && !(get_uart(dev)->cr & PL011_CR_TXE))
+	if (!data->sbsa && !(get_uart(dev)->cr & PL011_CR_TXE)) {
 		return false;
+	}
 
 	return ((get_uart(dev)->imsc & PL011_IMSC_TXIM) &&
 		/* Check for TX interrupt status is set or TX FIFO is empty. */
@@ -400,8 +401,9 @@ static int pl011_irq_rx_ready(const struct device *dev)
 {
 	struct pl011_data *data = dev->data;
 
-	if (!data->sbsa && !(get_uart(dev)->cr & PL011_CR_RXE))
+	if (!data->sbsa && !(get_uart(dev)->cr & PL011_CR_RXE)) {
 		return false;
+	}
 
 	return ((get_uart(dev)->imsc & PL011_IMSC_RXIM) &&
 		(!(get_uart(dev)->fr & PL011_FR_RXFE)));

--- a/drivers/serial/uart_sifive.c
+++ b/drivers/serial/uart_sifive.c
@@ -132,8 +132,9 @@ static int uart_sifive_fifo_fill(const struct device *dev,
 	volatile struct uart_sifive_regs_t *uart = DEV_UART(dev);
 	int i;
 
-	for (i = 0; i < size && !(uart->tx & TXDATA_FULL); i++)
+	for (i = 0; i < size && !(uart->tx & TXDATA_FULL); i++) {
 		uart->tx = (int)tx_data[i];
+	}
 
 	return i;
 }
@@ -158,8 +159,9 @@ static int uart_sifive_fifo_read(const struct device *dev,
 	for (i = 0; i < size; i++) {
 		val = uart->rx;
 
-		if (val & RXDATA_EMPTY)
+		if (val & RXDATA_EMPTY) {
 			break;
+		}
 
 		rx_data[i] = (uint8_t)(val & RXDATA_MASK);
 	}
@@ -311,8 +313,9 @@ static void uart_sifive_irq_handler(const struct device *dev)
 {
 	struct uart_sifive_data *data = dev->data;
 
-	if (data->callback)
+	if (data->callback) {
 		data->callback(dev, data->cb_data);
+	}
 }
 
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */

--- a/drivers/spi/spi_pl022.c
+++ b/drivers/spi/spi_pl022.c
@@ -694,11 +694,13 @@ static void spi_pl022_start_async_xfer(const struct device *dev)
 	struct spi_pl022_data *data = dev->data;
 
 	/* Ensure writable */
-	while (!SSP_TX_FIFO_EMPTY(cfg->reg))
+	while (!SSP_TX_FIFO_EMPTY(cfg->reg)) {
 		;
+	}
 	/* Drain RX FIFO */
-	while (SSP_RX_FIFO_NOT_EMPTY(cfg->reg))
+	while (SSP_RX_FIFO_NOT_EMPTY(cfg->reg)) {
 		SSP_READ_REG(SSP_DR(cfg->reg));
+	}
 
 	data->tx_count = 0;
 	data->rx_count = 0;
@@ -745,8 +747,9 @@ static void spi_pl022_xfer(const struct device *dev)
 		;
 	}
 	/* Drain RX FIFO */
-	while (SSP_RX_FIFO_NOT_EMPTY(cfg->reg))
+	while (SSP_RX_FIFO_NOT_EMPTY(cfg->reg)) {
 		SSP_READ_REG(SSP_DR(cfg->reg));
+	}
 
 	while (data->rx_count < chunk_len || data->tx_count < chunk_len) {
 		/* Fill up fifo with available TX data */

--- a/drivers/tee/optee/optee.c
+++ b/drivers/tee/optee/optee.c
@@ -473,8 +473,9 @@ static int optee_notif_wait(const struct device *dev, uint32_t key)
 	k_spinlock_key_t sp_key;
 	int prev_val;
 
-	if (key > CONFIG_OPTEE_MAX_NOTIF)
+	if (key > CONFIG_OPTEE_MAX_NOTIF) {
 		return -EINVAL;
+	}
 
 	entry = k_malloc(sizeof(*entry));
 	if (!entry) {

--- a/drivers/timer/ite_it8xxx2_timer.c
+++ b/drivers/timer/ite_it8xxx2_timer.c
@@ -381,10 +381,11 @@ static int timer_init(enum ext_timer_idx ext_timer,
 
 	/* Disable external timer x */
 	IT8XXX2_EXT_CTRLX(ext_timer) &= ~IT8XXX2_EXT_ETXEN;
-	if (start == EXT_START_TIMER)
+	if (start == EXT_START_TIMER) {
 		/* Enable and re-start external timer x */
 		IT8XXX2_EXT_CTRLX(ext_timer) |= (IT8XXX2_EXT_ETXEN |
 						 IT8XXX2_EXT_ETXRST);
+	}
 
 	if (with_int == EXT_WITH_TIMER_INT) {
 		irq_enable(irq_num);

--- a/drivers/timer/npcx_itim_timer.c
+++ b/drivers/timer/npcx_itim_timer.c
@@ -223,8 +223,9 @@ static inline uint32_t npcx_itim_get_evt_cyc32(void)
 	 * Wait for two consecutive equal values are read since the source clock
 	 * of event timer is 32KHz.
 	 */
-	while ((cnt2 = evt_tmr->ITCNT32) != cnt1)
+	while ((cnt2 = evt_tmr->ITCNT32) != cnt1) {
 		cnt1 = cnt2;
+	}
 
 	/* Return current value of 32-bit counter of event timer  */
 	return cnt2;

--- a/drivers/watchdog/wdt_dw.h
+++ b/drivers/watchdog/wdt_dw.h
@@ -326,10 +326,11 @@ static inline void dw_wdt_response_mode_set(const uint32_t base, const bool mode
 {
 	uint32_t control = sys_read32(base + WDT_CR);
 
-	if (mode)
+	if (mode) {
 		control |= WDT_CR_RMOD;
-	else
+	} else {
 		control &= ~WDT_CR_RMOD;
+	}
 
 	sys_write32(control, base + WDT_CR);
 }

--- a/drivers/wifi/nrfwifi/src/qspi/src/qspi_if.c
+++ b/drivers/wifi/nrfwifi/src/qspi/src/qspi_if.c
@@ -175,10 +175,11 @@ static inline int qspi_get_mode(bool cpol, bool cpha)
 {
 	register int ret = -EINVAL;
 
-	if ((!cpol) && (!cpha))
+	if ((!cpol) && (!cpha)) {
 		ret = 0;
-	else if (cpol && cpha)
+	} else if (cpol && cpha) {
 		ret = 1;
+	}
 
 	__ASSERT(ret != -EINVAL, "Invalid QSPI mode");
 
@@ -427,15 +428,17 @@ static inline void qspi_complete(struct qspi_nor_data *dev_data)
 
 static inline void _qspi_complete(struct qspi_nor_data *dev_data)
 {
-	if (!qspi_cfg->easydma)
+	if (!qspi_cfg->easydma) {
 		return;
+	}
 
 	qspi_complete(dev_data);
 }
 static inline void _qspi_wait_for_completion(const struct device *dev, nrfx_err_t res)
 {
-	if (!qspi_cfg->easydma)
+	if (!qspi_cfg->easydma) {
 		return;
+	}
 
 	qspi_wait_for_completion(dev, res);
 }
@@ -451,8 +454,9 @@ static void qspi_handler(nrfx_qspi_evt_t event, void *p_context)
 {
 	struct qspi_nor_data *dev_data = p_context;
 
-	if (event == NRFX_QSPI_EVENT_DONE)
+	if (event == NRFX_QSPI_EVENT_DONE) {
 		_qspi_complete(dev_data);
+	}
 }
 
 static bool qspi_initialized;
@@ -509,10 +513,11 @@ static void qspi_device_uninit(const struct device *dev)
 
 	if (last) {
 		while (nrfx_qspi_mem_busy_check() != NRFX_SUCCESS) {
-			if (IS_ENABLED(CONFIG_MULTITHREADING))
+			if (IS_ENABLED(CONFIG_MULTITHREADING)) {
 				k_msleep(50);
-			else
+			} else {
 				k_busy_wait(50000);
+			}
 		}
 
 		nrfx_qspi_uninit();
@@ -536,8 +541,9 @@ static void qspi_device_uninit(const struct device *dev)
 static int qspi_send_cmd(const struct device *dev, const struct qspi_cmd *cmd, bool wren)
 {
 	/* Check input parameters */
-	if (!cmd)
+	if (!cmd) {
 		return -EINVAL;
+	}
 
 	const void *tx_buf = NULL;
 	size_t tx_len = 0;
@@ -556,13 +562,15 @@ static int qspi_send_cmd(const struct device *dev, const struct qspi_cmd *cmd, b
 	}
 
 	if ((rx_len != 0) && (tx_len != 0)) {
-		if (rx_len != tx_len)
+		if (rx_len != tx_len) {
 			return -EINVAL;
+		}
 
 		xfer_len += tx_len;
-	} else
+	} else {
 		/* At least one of these is zero. */
 		xfer_len += tx_len + rx_len;
+	}
 
 	if (xfer_len > NRF_QSPI_CINSTR_LEN_9B) {
 		LOG_WRN("cinstr %02x transfer too long: %zu", cmd->op_code, xfer_len);
@@ -673,8 +681,9 @@ static inline void qspi_fill_init_struct(nrfx_qspi_config_t *initstruct)
 /* Configures QSPI memory for the transfer */
 static int qspi_nrfx_configure(const struct device *dev)
 {
-	if (!dev)
+	if (!dev) {
 		return -ENXIO;
+	}
 
 	struct qspi_nor_data *dev_data = dev->data;
 
@@ -741,12 +750,14 @@ static int qspi_nrfx_configure(const struct device *dev)
 			 * commands sent while it's happening can be
 			 * corrupted.  Wait.
 			 */
-			if (ret == 0)
+			if (ret == 0) {
 				ret = qspi_wait_while_writing(dev);
+			}
 		}
 
-		if (ret < 0)
+		if (ret < 0) {
 			LOG_ERR("QE %s failed: %d", qe_value ? "set" : "clear", ret);
+		}
 	}
 
 	return ret;
@@ -760,13 +771,15 @@ static inline nrfx_err_t read_non_aligned(const struct device *dev, int addr, vo
 
 	int flash_prefix = (WORD_SIZE - (addr % WORD_SIZE)) % WORD_SIZE;
 
-	if (flash_prefix > size)
+	if (flash_prefix > size) {
 		flash_prefix = size;
+	}
 
 	int dest_prefix = (WORD_SIZE - (int)dptr % WORD_SIZE) % WORD_SIZE;
 
-	if (dest_prefix > size)
+	if (dest_prefix > size) {
 		dest_prefix = size;
+	}
 
 	int flash_suffix = (size - flash_prefix) % WORD_SIZE;
 	int flash_middle = size - flash_prefix - flash_suffix;
@@ -785,12 +798,14 @@ static inline nrfx_err_t read_non_aligned(const struct device *dev, int addr, vo
 
 		_qspi_wait_for_completion(dev, res);
 
-		if (res != NRFX_SUCCESS)
+		if (res != NRFX_SUCCESS) {
 			return res;
+		}
 
 		/* perform shift in RAM */
-		if (flash_prefix != dest_prefix)
+		if (flash_prefix != dest_prefix) {
 			memmove(dptr + flash_prefix, dptr + dest_prefix, flash_middle);
+		}
 	}
 
 	/* read prefix */
@@ -799,8 +814,9 @@ static inline nrfx_err_t read_non_aligned(const struct device *dev, int addr, vo
 
 		_qspi_wait_for_completion(dev, res);
 
-		if (res != NRFX_SUCCESS)
+		if (res != NRFX_SUCCESS) {
 			return res;
+		}
 
 		memcpy(dptr, buf + WORD_SIZE - flash_prefix, flash_prefix);
 	}
@@ -811,8 +827,9 @@ static inline nrfx_err_t read_non_aligned(const struct device *dev, int addr, vo
 
 		_qspi_wait_for_completion(dev, res);
 
-		if (res != NRFX_SUCCESS)
+		if (res != NRFX_SUCCESS) {
 			return res;
+		}
 
 		memcpy(dptr + flash_prefix + flash_middle, buf, flash_suffix);
 	}
@@ -822,17 +839,20 @@ static inline nrfx_err_t read_non_aligned(const struct device *dev, int addr, vo
 
 static int qspi_nor_read(const struct device *dev, int addr, void *dest, size_t size)
 {
-	if (!dest)
+	if (!dest) {
 		return -EINVAL;
+	}
 
 	/* read size must be non-zero */
-	if (!size)
+	if (!size) {
 		return 0;
+	}
 
 	int rc = qspi_device_init(dev);
 
-	if (rc != 0)
+	if (rc != 0) {
 		goto out;
+	}
 
 	qspi_lock(dev);
 
@@ -871,31 +891,35 @@ static inline nrfx_err_t write_sub_word(const struct device *dev, int addr, cons
 
 static int qspi_nor_write(const struct device *dev, int addr, const void *src, size_t size)
 {
-	if (!src)
+	if (!src) {
 		return -EINVAL;
+	}
 
 	/* write size must be non-zero, less than 4, or a multiple of 4 */
-	if ((size == 0) || ((size > 4) && ((size % 4U) != 0)))
+	if ((size == 0) || ((size > 4) && ((size % 4U) != 0))) {
 		return -EINVAL;
+	}
 
 	/* address must be 4-byte aligned */
-	if ((addr % 4U) != 0)
+	if ((addr % 4U) != 0) {
 		return -EINVAL;
+	}
 
 	nrfx_err_t res = NRFX_SUCCESS;
 
 	int rc = qspi_device_init(dev);
 
-	if (rc != 0)
+	if (rc != 0) {
 		goto out;
+	}
 
 	qspi_trans_lock(dev);
 
 	qspi_lock(dev);
 
-	if (size < 4U)
+	if (size < 4U) {
 		res = write_sub_word(dev, addr, src, size);
-	else {
+	} else {
 		res = _nrfx_qspi_write(src, size, addr);
 		_qspi_wait_for_completion(dev, res);
 	}
@@ -921,8 +945,9 @@ static int qspi_nor_configure(const struct device *dev)
 {
 	int ret = qspi_nrfx_configure(dev);
 
-	if (ret != 0)
+	if (ret != 0) {
 		return ret;
+	}
 
 	qspi_device_uninit(dev);
 
@@ -967,13 +992,15 @@ static int qspi_cmd_encryption(const struct device *dev, nrf_qspi_encryption_t *
 
 	int ret = qspi_device_init(dev);
 
-	if (ret == 0)
+	if (ret == 0) {
 		ret = qspi_send_cmd(dev, &cmd, false);
+	}
 
 	qspi_device_uninit(dev);
 
-	if (ret < 0)
+	if (ret < 0) {
 		LOG_DBG("cmd_encryption failed %d", ret);
+	}
 
 	return ret;
 }
@@ -1001,8 +1028,9 @@ int qspi_RDSR2(const struct device *dev, uint8_t *rdsr2)
 
 	LOG_DBG("RDSR2 = 0x%x", sr);
 
-	if (ret == 0)
+	if (ret == 0) {
 		*rdsr2 = sr;
+	}
 
 	return ret;
 }
@@ -1046,8 +1074,9 @@ int qspi_RDSR1(const struct device *dev, uint8_t *rdsr1)
 
 	LOG_DBG("RDSR1 = 0x%x", sr);
 
-	if (ret == 0)
+	if (ret == 0) {
 		*rdsr1 = sr;
+	}
 
 	return ret;
 }
@@ -1093,13 +1122,15 @@ int qspi_WRSR2(const struct device *dev, uint8_t data)
 	};
 	int ret = qspi_device_init(dev);
 
-	if (ret == 0)
+	if (ret == 0) {
 		ret = qspi_send_cmd(dev, &cmd, false);
+	}
 
 	qspi_device_uninit(dev);
 
-	if (ret < 0)
+	if (ret < 0) {
 		LOG_ERR("cmd_wakeup RPU failed %d", ret);
+	}
 
 	return ret;
 }
@@ -1149,13 +1180,15 @@ void qspi_update_nonce(unsigned int addr, int len, int hlread)
 
 	NRF_QSPI_Type *p_reg = NRF_QSPI;
 
-	if (!qspi_cfg->encryption)
+	if (!qspi_cfg->encryption) {
 		return;
+	}
 
-	if (nonce_last_addr == 0 || hlread)
+	if (nonce_last_addr == 0 || hlread) {
 		p_reg->DMA_ENC.NONCE2 = ++nonce_cnt;
-	else if ((nonce_last_addr + 4) != addr)
+	} else if ((nonce_last_addr + 4) != addr) {
 		p_reg->DMA_ENC.NONCE2 = ++nonce_cnt;
+	}
 
 	nonce_last_addr = addr + len - 4;
 
@@ -1292,8 +1325,9 @@ int qspi_enable_encryption(uint8_t *key)
 #if defined(CONFIG_SOC_SERIES_NRF53X)
 	int err = 0;
 
-	if (qspi_cfg->encryption)
+	if (qspi_cfg->encryption) {
 		return -EALREADY;
+	}
 
 	int ret = qspi_device_init(&qspi_perip);
 

--- a/drivers/wifi/nrfwifi/src/qspi/src/rpu_hw_if.c
+++ b/drivers/wifi/nrfwifi/src/qspi/src/rpu_hw_if.c
@@ -282,10 +282,11 @@ int rpu_read(unsigned int addr, void *data, int len)
 		return -1;
 	}
 
-	if (hl_flag)
+	if (hl_flag) {
 		return qdev->hl_read(addr, data, len);
-	else
+	} else {
 		return qdev->read(addr, data, len);
+	}
 }
 
 int rpu_write(unsigned int addr, const void *data, int len)

--- a/drivers/wifi/nrfwifi/src/qspi/src/spi_if.c
+++ b/drivers/wifi/nrfwifi/src/qspi/src/spi_if.c
@@ -103,8 +103,9 @@ int spim_read_reg(uint32_t reg_addr, uint8_t *reg_value)
 
 	LOG_DBG("err: %d -> %x %x %x %x %x %x", err, sr[0], sr[1], sr[2], sr[3], sr[4], sr[5]);
 
-	if (err == 0)
+	if (err == 0) {
 		*reg_value = sr[1];
+	}
 
 	return err;
 }

--- a/drivers/wifi/nrfwifi/src/shim.c
+++ b/drivers/wifi/nrfwifi/src/shim.c
@@ -213,8 +213,9 @@ static void *zep_shim_nbuf_alloc(unsigned int size)
 
 	nbuff = (struct nwb *)k_calloc(sizeof(struct nwb), sizeof(char));
 
-	if (!nbuff)
+	if (!nbuff) {
 		return NULL;
+	}
 
 	nbuff->priv = k_calloc(size, sizeof(char));
 
@@ -811,8 +812,9 @@ static void *zep_shim_timer_alloc(void)
 
 	timer = k_malloc(sizeof(*timer));
 
-	if (!timer)
+	if (!timer) {
 		LOG_ERR("%s: Unable to allocate memory for work", __func__);
+	}
 
 	return timer;
 }

--- a/drivers/wifi/nrfwifi/src/wifi_mgmt_scan.c
+++ b/drivers/wifi/nrfwifi/src/wifi_mgmt_scan.c
@@ -262,12 +262,15 @@ out:
 
 static inline enum wifi_mfp_options drv_to_wifi_mgmt_mfp(unsigned char mfp_flag)
 {
-	if (!mfp_flag)
+	if (!mfp_flag) {
 		return WIFI_MFP_DISABLE;
-	if (mfp_flag & NRF_WIFI_MFP_REQUIRED)
+	}
+	if (mfp_flag & NRF_WIFI_MFP_REQUIRED) {
 		return WIFI_MFP_REQUIRED;
-	if (mfp_flag & NRF_WIFI_MFP_CAPABLE)
+	}
+	if (mfp_flag & NRF_WIFI_MFP_CAPABLE) {
 		return WIFI_MFP_OPTIONAL;
+	}
 
 	return WIFI_MFP_UNKNOWN;
 }

--- a/drivers/wifi/nrfwifi/src/wifi_util.c
+++ b/drivers/wifi/nrfwifi/src/wifi_util.c
@@ -993,8 +993,9 @@ SHELL_CMD_REGISTER(wifi_util,
 static int nrf_wifi_util_init(void)
 {
 
-	if (nrf_wifi_util_conf_init(&ctx->conf_params) < 0)
+	if (nrf_wifi_util_conf_init(&ctx->conf_params) < 0) {
 		return -1;
+	}
 
 	return 0;
 }

--- a/drivers/wifi/nrfwifi/src/work.c
+++ b/drivers/wifi/nrfwifi/src/work.c
@@ -41,8 +41,9 @@ int get_free_work_item_index(void)
 	int i;
 
 	for (i = 0; i < CONFIG_NRF70_WORKQ_MAX_ITEMS; i++) {
-		if (zep_work_item[i].in_use)
+		if (zep_work_item[i].in_use) {
 			continue;
+		}
 		return i;
 	}
 
@@ -130,17 +131,20 @@ void work_init(struct zep_work_item *item, void (*callback)(unsigned long),
 
 void work_schedule(struct zep_work_item *item)
 {
-	if (item->type == ZEP_WORK_TYPE_IRQ)
+	if (item->type == ZEP_WORK_TYPE_IRQ) {
 		k_work_submit_to_queue(&zep_wifi_intr_q, &item->work);
-	else if (item->type == ZEP_WORK_TYPE_BH)
+	} else if (item->type == ZEP_WORK_TYPE_BH) {
 		k_work_submit_to_queue(&zep_wifi_bh_q, &item->work);
+	}
 #ifdef CONFIG_NRF70_TX_DONE_WQ_ENABLED
-	else if (item->type == ZEP_WORK_TYPE_TX_DONE)
+	else if (item->type == ZEP_WORK_TYPE_TX_DONE) {
 		k_work_submit_to_queue(&zep_wifi_tx_done_q, &item->work);
+	}
 #endif /* CONFIG_NRF70_TX_DONE_WQ_ENABLED */
 #ifdef CONFIG_NRF70_RX_WQ_ENABLED
-	else if (item->type == ZEP_WORK_TYPE_RX)
+	else if (item->type == ZEP_WORK_TYPE_RX) {
 		k_work_submit_to_queue(&zep_wifi_rx_q, &item->work);
+	}
 #endif /* CONFIG_NRF70_RX_WQ_ENABLED */
 }
 

--- a/drivers/wifi/nrfwifi/src/wpa_supp_if.c
+++ b/drivers/wifi/nrfwifi/src/wpa_supp_if.c
@@ -514,8 +514,9 @@ int nrf_wifi_wpa_supp_scan2(void *if_priv, struct wpa_driver_scan_params *params
 	}
 
 	if (params->freqs) {
-		for (indx = 0; params->freqs[indx]; indx++)
+		for (indx = 0; params->freqs[indx]; indx++) {
 			num_freqs++;
+		}
 	}
 
 	scan_info = k_calloc(sizeof(*scan_info) + (num_freqs * sizeof(unsigned int)),
@@ -577,8 +578,9 @@ int nrf_wifi_wpa_supp_scan2(void *if_priv, struct wpa_driver_scan_params *params
 
 	ret = 0;
 out:
-	if (scan_info)
+	if (scan_info) {
 		k_free(scan_info);
+	}
 	k_mutex_unlock(&vif_ctx_zep->vif_lock);
 	return ret;
 }
@@ -1362,7 +1364,7 @@ void nrf_wifi_wpa_supp_event_proc_unprot_mgmt(void *if_priv,
 
 	if (cmd_evnt == NRF_WIFI_UMAC_EVENT_UNPROT_DEAUTHENTICATE) {
 		event.unprot_deauth.reason_code = le_to_host16(mgmt->u.deauth.reason_code);
-		if (vif_ctx_zep->supp_drv_if_ctx && vif_ctx_zep->supp_callbk_fns.unprot_deauth)	{
+		if (vif_ctx_zep->supp_drv_if_ctx && vif_ctx_zep->supp_callbk_fns.unprot_deauth) {
 			vif_ctx_zep->supp_callbk_fns.unprot_deauth(vif_ctx_zep->supp_drv_if_ctx,
 									  &event);
 		}
@@ -1415,20 +1417,25 @@ int nrf_wifi_nl80211_send_mlme(void *if_priv, const u8 *data,
 		goto out;
 	}
 
-	if (offchanok)
+	if (offchanok) {
 		mgmt_tx_info->nrf_wifi_flags |= NRF_WIFI_CMD_FRAME_OFFCHANNEL_TX_OK;
+	}
 
-	if (noack)
+	if (noack) {
 		mgmt_tx_info->nrf_wifi_flags |= NRF_WIFI_CMD_FRAME_DONT_WAIT_FOR_ACK;
+	}
 
-	if (no_cck)
+	if (no_cck) {
 		mgmt_tx_info->nrf_wifi_flags |= NRF_WIFI_CMD_FRAME_TX_NO_CCK_RATE;
+	}
 
-	if (freq)
+	if (freq) {
 		mgmt_tx_info->frequency = freq;
+	}
 
-	if (wait_time)
+	if (wait_time) {
 		mgmt_tx_info->dur = wait_time;
+	}
 
 	if (data_len) {
 		memcpy(mgmt_tx_info->frame.frame, data, data_len);
@@ -1479,8 +1486,9 @@ int nrf_wifi_nl80211_send_mlme(void *if_priv, const u8 *data,
 	}
 
 out:
-	if (mgmt_tx_info)
+	if (mgmt_tx_info) {
 		k_free(mgmt_tx_info);
+	}
 	k_mutex_unlock(&mgmt_tx_lock);
 	k_mutex_unlock(&vif_ctx_zep->vif_lock);
 	return status;

--- a/kernel/thread_monitor.c
+++ b/kernel/thread_monitor.c
@@ -105,8 +105,9 @@ void k_thread_foreach_filter_by_cpu(unsigned int cpu, k_thread_user_cb_t user_cb
 	SYS_PORT_TRACING_FUNC_ENTER(k_thread, foreach);
 
 	for (thread = _kernel.threads; thread; thread = thread->next_thread) {
-		if (thread->base.cpu == cpu)
+		if (thread->base.cpu == cpu) {
 			user_cb(thread, user_data);
+		}
 	}
 
 	SYS_PORT_TRACING_FUNC_EXIT(k_thread, foreach);

--- a/lib/libc/common/source/stdlib/malloc.c
+++ b/lib/libc/common/source/stdlib/malloc.c
@@ -210,14 +210,16 @@ static int malloc_prepare(void)
 
 	/* Align size to power of two */
 	heap_size = 1;
-	while (heap_size * 2 <= HEAP_SIZE)
+	while (heap_size * 2 <= HEAP_SIZE) {
 		heap_size *= 2;
+	}
 
 	/* Search for an aligned heap that fits within the available space */
 	while (heap_size >= HEAP_ALIGN) {
 		heap_base = UINT_TO_POINTER(ROUND_UP(HEAP_BASE, heap_size));
-		if (POINTER_TO_UINT(heap_base) + heap_size <= HEAP_BASE + HEAP_SIZE)
+		if (POINTER_TO_UINT(heap_base) + heap_size <= HEAP_BASE + HEAP_SIZE) {
 			break;
+		}
 		heap_size >>= 1;
 	}
 #else

--- a/lib/os/p4wq.c
+++ b/lib/os/p4wq.c
@@ -176,8 +176,9 @@ static int static_init(void)
 			if (pp->flags & K_P4WQ_USER_CPU_MASK) {
 				int ret = k_thread_cpu_mask_clear(&pp->threads[i]);
 
-				if (ret < 0)
+				if (ret < 0) {
 					LOG_ERR("Couldn't clear CPU mask: %d", ret);
+				}
 			}
 #endif
 		}
@@ -196,8 +197,9 @@ void k_p4wq_enable_static_thread(struct k_p4wq *queue, struct k_thread *thread,
 		while ((i = find_lsb_set(cpu_mask))) {
 			int ret = k_thread_cpu_mask_enable(thread, i - 1);
 
-			if (ret < 0)
+			if (ret < 0) {
 				LOG_ERR("Couldn't set CPU mask for %u: %d", i, ret);
+			}
 			cpu_mask &= ~BIT(i - 1);
 		}
 	}

--- a/lib/posix/options/getopt/getopt_long.c
+++ b/lib/posix/options/getopt/getopt_long.c
@@ -364,10 +364,11 @@ getopt_internal(struct getopt_state *state, int nargc, char * const *nargv,
 		flags &= ~FLAG_PERMUTE;
 	}
 #else
-	if (*options == '+')
+	if (*options == '+') {
 		flags &= ~FLAG_PERMUTE;
-	else if (*options == '-')
+	} else if (*options == '-') {
 		flags |= FLAG_ALLARGS;
+	}
 #endif
 	if (*options == '+' || *options == '-') {
 		options++;

--- a/samples/arch/smp/pktqueue/src/main.c
+++ b/samples/arch/smp/pktqueue/src/main.c
@@ -133,13 +133,14 @@ void queue_thread(void *arg1, void *arg2, void *arg3)
 	current_queue++;
 	k_mutex_unlock(&fetch_queue_mtx);
 
-	for (int i = 0; i < THREADS_NUM; i++)
+	for (int i = 0; i < THREADS_NUM; i++) {
 		k_thread_create(&tthread[i+THREADS_NUM*queue_num],
 			tstack[i+THREADS_NUM*queue_num], STACK_SIZE,
 			test_thread,
 			(void *)&sender[queue_num],
 			(void *)&receiver[queue_num], (void *)&queue_num,
 			K_PRIO_PREEMPT(10), 0, K_NO_WAIT);
+	}
 
 	/* Wait until sender queue is not empty */
 	while (sender[queue_num].count != 0) {
@@ -173,11 +174,12 @@ int main(void)
 	/* Capture initial time stamp */
 	start_time = k_cycle_get_32();
 
-	for (int i = 0; i < QUEUE_NUM; i++)
+	for (int i = 0; i < QUEUE_NUM; i++) {
 		k_thread_create(&qthread[i], qstack[i], STACK_SIZE,
 				queue_thread,
 				(void *)&sender[i], (void *)&receiver[i],
 				(void *)&i, K_PRIO_PREEMPT(11), 0, K_NO_WAIT);
+	}
 
 	/* Wait until all queues are not processed */
 	while (queues_remain > 0) {

--- a/samples/sensor/lsm6dso/src/main.c
+++ b/samples/sensor/lsm6dso/src/main.c
@@ -79,8 +79,9 @@ static void test_trigger_mode(const struct device *dev)
 {
 	struct sensor_trigger trig;
 
-	if (set_sampling_freq(dev) != 0)
+	if (set_sampling_freq(dev) != 0) {
 		return;
+	}
 
 	trig.type = SENSOR_TRIG_DATA_READY;
 	trig.chan = SENSOR_CHAN_ACCEL_XYZ;

--- a/soc/intel/intel_adsp/ace/comm_widget.h
+++ b/soc/intel/intel_adsp/ace/comm_widget.h
@@ -809,10 +809,11 @@ static inline void cw_upstream_enable_sent_intr(bool enable)
 {
 	uint32_t cmd = sys_read32(CW_BASE + USCMD);
 
-	if (enable)
+	if (enable) {
 		cmd |= USCMD_IE;
-	else
+	} else {
 		cmd &= ~USCMD_IE;
+	}
 
 	sys_write32(cmd, CW_BASE + USCMD);
 }

--- a/soc/intel/intel_adsp/cavs/multiprocessing.c
+++ b/soc/intel/intel_adsp/cavs/multiprocessing.c
@@ -82,10 +82,11 @@ void soc_start_core(int cpu_num)
 	 * initialization, the next pm state is set to ACTIVE. This way we can determine
 	 * whether the core is being turned on again or for the first time.
 	 */
-	if (pm_state_next_get(cpu_num)->state == PM_STATE_ACTIVE)
+	if (pm_state_next_get(cpu_num)->state == PM_STATE_ACTIVE) {
 		lpsram[1] = z_soc_mp_asm_entry;
-	else
+	} else {
 		lpsram[1] = dsp_restore_vector;
+	}
 #else
 	lpsram[1] = z_soc_mp_asm_entry;
 #endif

--- a/soc/intel/intel_adsp/cavs/power.c
+++ b/soc/intel/intel_adsp/cavs/power.c
@@ -159,8 +159,9 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 
 #ifdef CONFIG_ADSP_POWER_DOWN_HPSRAM
 			/* turn off all HPSRAM banks - get a full bitmap */
-			for (int i = 0; i < HPSRAM_SEGMENTS; i++)
+			for (int i = 0; i < HPSRAM_SEGMENTS; i++) {
 				hpsram_mask[i] = HPSRAM_MEMMASK(i);
+			}
 #endif /* CONFIG_ADSP_POWER_DOWN_HPSRAM */
 			/* do power down - this function won't return */
 			power_down_cavs(true, uncache_to_cache(&hpsram_mask[0]));

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -2461,8 +2461,9 @@ static int att_change_security(struct bt_conn *conn, uint8_t err)
 
 	switch (err) {
 	case BT_ATT_ERR_INSUFFICIENT_ENCRYPTION:
-		if (conn->sec_level >= BT_SECURITY_L2)
+		if (conn->sec_level >= BT_SECURITY_L2) {
 			return -EALREADY;
+		}
 		sec = BT_SECURITY_L2;
 		break;
 	case BT_ATT_ERR_AUTHENTICATION:

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -828,8 +828,9 @@ static uint8_t gen_hash_m(const struct bt_gatt_attr *attr, uint16_t handle,
 	ssize_t len;
 	uint16_t value;
 
-	if (attr->uuid->type != BT_UUID_TYPE_16)
+	if (attr->uuid->type != BT_UUID_TYPE_16) {
 		return BT_GATT_ITER_CONTINUE;
+	}
 
 	u16 = (struct bt_uuid_16 *)attr->uuid;
 
@@ -3780,8 +3781,9 @@ static void gatt_discover_next(struct bt_conn *conn, uint16_t last_handle,
 			       struct bt_gatt_discover_params *params)
 {
 	/* Skip if last_handle is not set */
-	if (!last_handle)
+	if (!last_handle) {
 		goto discover;
+	}
 
 	/* Continue from the last found handle */
 	params->start_handle = last_handle;

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -5232,11 +5232,13 @@ static int smp_f6_test(void)
 	int err;
 
 	err = bt_crypto_f6(w, n1, n2, r, io_cap, &a1, &a2, res);
-	if (err)
+	if (err) {
 		return err;
+	}
 
-	if (memcmp(res, exp, 16))
+	if (memcmp(res, exp, 16)) {
 		return -EINVAL;
+	}
 
 	return 0;
 }

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -298,8 +298,9 @@ static bool data_cb(struct bt_data *data, void *user_data)
 
 static void print_data_hex(const uint8_t *data, uint8_t len, enum shell_vt100_color color)
 {
-	if (len == 0)
+	if (len == 0) {
 		return;
+	}
 
 	shell_fprintf(ctx_shell, color, "0x");
 	/* Reverse the byte order when printing as advertising data is LE

--- a/subsys/debug/thread_analyzer.c
+++ b/subsys/debug/thread_analyzer.c
@@ -252,8 +252,9 @@ static int thread_analyzer_init(void)
 		}
 		snprintf(name, sizeof(name), "core %u thread analyzer", i);
 		ret = k_thread_name_set(tid, name);
-		if (ret < 0)
+		if (ret < 0) {
 			LOG_INF("k_thread_name_set failed: %d for %u", ret, i);
+		}
 
 		k_thread_start(tid);
 		LOG_DBG("Thread %p for core %u started", tid, i);

--- a/subsys/llext/llext_link.c
+++ b/subsys/llext/llext_link.c
@@ -44,10 +44,12 @@ static size_t llext_file_offset(struct llext_loader *ldr, size_t offset)
 {
 	unsigned int i;
 
-	for (i = 0; i < LLEXT_MEM_COUNT; i++)
+	for (i = 0; i < LLEXT_MEM_COUNT; i++) {
 		if (ldr->sects[i].sh_addr <= offset &&
-		    ldr->sects[i].sh_addr + ldr->sects[i].sh_size > offset)
+		    ldr->sects[i].sh_addr + ldr->sects[i].sh_size > offset) {
 			return offset - ldr->sects[i].sh_addr + ldr->sects[i].sh_offset;
+		}
+	}
 
 	return offset;
 }

--- a/subsys/profiling/perf/backends/perf_riscv.c
+++ b/subsys/profiling/perf/backends/perf_riscv.c
@@ -26,8 +26,9 @@ static inline bool in_text_region(uintptr_t addr)
  */
 size_t arch_perf_current_stack_trace(uintptr_t *buf, size_t size)
 {
-	if (size < 2U)
+	if (size < 2U) {
 		return 0;
+	}
 
 	size_t idx = 0;
 
@@ -79,8 +80,9 @@ size_t arch_perf_current_stack_trace(uintptr_t *buf, size_t size)
 		fp = new_fp;
 	}
 	while (valid_stack((uintptr_t)fp, _current)) {
-		if (idx >= size)
+		if (idx >= size) {
 			return 0;
+		}
 
 		if (!in_text_region((uintptr_t)fp[-1])) {
 			break;

--- a/subsys/profiling/perf/backends/perf_x86.c
+++ b/subsys/profiling/perf/backends/perf_x86.c
@@ -36,8 +36,9 @@ struct isf {
  */
 size_t arch_perf_current_stack_trace(uintptr_t *buf, size_t size)
 {
-	if (size < 1U)
+	if (size < 1U) {
 		return 0;
+	}
 
 	size_t idx = 0;
 
@@ -67,8 +68,9 @@ size_t arch_perf_current_stack_trace(uintptr_t *buf, size_t size)
 
 	buf[idx++] = (uintptr_t)isf->eip;
 	while (valid_stack((uintptr_t)fp, _current)) {
-		if (idx >= size)
+		if (idx >= size) {
 			return 0;
+		}
 
 		if (!in_text_region((uintptr_t)fp[1])) {
 			break;

--- a/subsys/profiling/perf/backends/perf_x86_64.c
+++ b/subsys/profiling/perf/backends/perf_x86_64.c
@@ -27,8 +27,9 @@ static inline bool in_text_region(uintptr_t addr)
  */
 size_t arch_perf_current_stack_trace(uintptr_t *buf, size_t size)
 {
-	if (size < 1U)
+	if (size < 1U) {
 		return 0;
+	}
 
 	size_t idx = 0;
 
@@ -53,8 +54,9 @@ size_t arch_perf_current_stack_trace(uintptr_t *buf, size_t size)
 	 *  ....
 	 */
 	while (valid_stack((uintptr_t)fp, _current)) {
-		if (idx >= size)
+		if (idx >= size) {
 			return 0;
+		}
 
 		if (!in_text_region((uintptr_t)fp[1])) {
 			break;

--- a/tests/arch/common/timing/src/main.c
+++ b/tests/arch/common/timing/src/main.c
@@ -112,8 +112,9 @@ ZTEST(arch_timing, test_arch_timing_smp)
 		k_thread_start(&threads[i]);
 	}
 
-	for (i = 0; i < num_threads; i++)
+	for (i = 0; i < num_threads; i++) {
 		k_thread_join(&threads[i], K_FOREVER);
+	}
 }
 #else
 ZTEST(arch_timing, test_arch_timing_smp)

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_a_1.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_a_1.c
@@ -152,10 +152,12 @@ static ssize_t write_value_v2(struct bt_conn *conn,
 {
 	char *value = attr->user_data;
 
-	if (offset >= sizeof(value_v2_value))
+	if (offset >= sizeof(value_v2_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v2_value))
+	}
+	if (offset + len > sizeof(value_v2_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -182,10 +184,12 @@ static ssize_t write_value_v2_1(struct bt_conn *conn,
 {
 	char *value = attr->user_data;
 
-	if (offset >= sizeof(value_v2_1_value))
+	if (offset >= sizeof(value_v2_1_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v2_1_value))
+	}
+	if (offset + len > sizeof(value_v2_1_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -211,10 +215,12 @@ static ssize_t write_value_v3(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(value_v3_value))
+	if (offset >= sizeof(value_v3_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v3_value))
+	}
+	if (offset + len > sizeof(value_v3_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_a_2.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_a_2.c
@@ -111,10 +111,12 @@ static ssize_t write_value_v2(struct bt_conn *conn,
 {
 	char *value = attr->user_data;
 
-	if (offset >= sizeof(value_v2_value))
+	if (offset >= sizeof(value_v2_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v2_value))
+	}
+	if (offset + len > sizeof(value_v2_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -140,10 +142,12 @@ static ssize_t write_value_v3(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(value_v3_value))
+	if (offset >= sizeof(value_v3_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v3_value))
+	}
+	if (offset + len > sizeof(value_v3_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_a_3.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_a_3.c
@@ -111,10 +111,12 @@ static ssize_t write_value_v2(struct bt_conn *conn,
 {
 	char *value = attr->user_data;
 
-	if (offset >= sizeof(value_v2_value))
+	if (offset >= sizeof(value_v2_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v2_value))
+	}
+	if (offset + len > sizeof(value_v2_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -140,10 +142,12 @@ static ssize_t write_value_v3(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(value_v3_value))
+	if (offset >= sizeof(value_v3_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v3_value))
+	}
+	if (offset + len > sizeof(value_v3_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_1_1.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_1_1.c
@@ -95,10 +95,12 @@ static ssize_t write_value_v4(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(value_v4_value))
+	if (offset >= sizeof(value_v4_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v4_value))
+	}
+	if (offset + len > sizeof(value_v4_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -147,10 +149,12 @@ static ssize_t write_value_v4_1(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(value_v4_1_value))
+	if (offset >= sizeof(value_v4_1_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v4_1_value))
+	}
+	if (offset + len > sizeof(value_v4_1_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -204,10 +208,12 @@ static ssize_t write_server_cha_con(struct bt_conn *conn,
 	uint16_t *value = attr->user_data;
 	uint16_t server_cha_con_conv = sys_cpu_to_le16(*value);
 
-	if (offset >= sizeof(server_cha_con_value))
+	if (offset >= sizeof(server_cha_con_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(server_cha_con_value))
+	}
+	if (offset + len > sizeof(server_cha_con_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy((uint8_t *)&server_cha_con_conv + offset, buf, len);
 

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_1_2.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_1_2.c
@@ -69,10 +69,12 @@ static ssize_t write_value_v4(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(value_v4_value))
+	if (offset >= sizeof(value_v4_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v4_value))
+	}
+	if (offset + len > sizeof(value_v4_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_1_3.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_1_3.c
@@ -69,10 +69,12 @@ static ssize_t write_value_v4(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(value_v4_value))
+	if (offset >= sizeof(value_v4_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v4_value))
+	}
+	if (offset + len > sizeof(value_v4_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_2_1.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_2_1.c
@@ -87,12 +87,15 @@ static ssize_t write_value_v5(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(value_v5_value))
+	if (offset >= sizeof(value_v5_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v5_value))
+	}
+	if (offset + len > sizeof(value_v5_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
-	if (!bAuthorized)
+	}
+	if (!bAuthorized) {
 		return BT_GATT_ERR(BT_ATT_ERR_AUTHORIZATION);
+	}
 
 	memcpy(value + offset, buf, len);
 

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_2_2.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_2_2.c
@@ -86,10 +86,12 @@ static ssize_t write_value_v5(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(value_v5_value))
+	if (offset >= sizeof(value_v5_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v5_value))
+	}
+	if (offset + len > sizeof(value_v5_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_2_3.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_2_3.c
@@ -86,10 +86,12 @@ static ssize_t write_value_v5(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(value_v5_value))
+	if (offset >= sizeof(value_v5_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v5_value))
+	}
+	if (offset + len > sizeof(value_v5_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_3_1.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_3_1.c
@@ -70,10 +70,12 @@ static ssize_t write_value_v6(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(value_v6_value))
+	if (offset >= sizeof(value_v6_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v6_value))
+	}
+	if (offset + len > sizeof(value_v6_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_3_2.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_3_2.c
@@ -72,10 +72,12 @@ static ssize_t write_value_v6(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(value_v6_value))
+	if (offset >= sizeof(value_v6_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v6_value))
+	}
+	if (offset + len > sizeof(value_v6_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_4_1.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_4_1.c
@@ -47,10 +47,12 @@ static ssize_t write_value_v7(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(value_v7_value))
+	if (offset >= sizeof(value_v7_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v7_value))
+	}
+	if (offset + len > sizeof(value_v7_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_4_2.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_4_2.c
@@ -47,10 +47,12 @@ static ssize_t write_value_v7(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(value_v7_value))
+	if (offset >= sizeof(value_v7_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v7_value))
+	}
+	if (offset + len > sizeof(value_v7_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_4_3.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_4_3.c
@@ -47,10 +47,12 @@ static ssize_t write_value_v7(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(value_v7_value))
+	if (offset >= sizeof(value_v7_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v7_value))
+	}
+	if (offset + len > sizeof(value_v7_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_5_1.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_b_5_1.c
@@ -88,10 +88,12 @@ static ssize_t write_value_v8(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(value_v8_value))
+	if (offset >= sizeof(value_v8_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v8_value))
+	}
+	if (offset + len > sizeof(value_v8_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -139,10 +141,12 @@ static ssize_t write_des_v8d1(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(des_v8d1_value))
+	if (offset >= sizeof(des_v8d1_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(des_v8d1_value))
+	}
+	if (offset + len > sizeof(des_v8d1_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -167,8 +171,9 @@ static ssize_t read_des_v8d2(struct bt_conn *conn,
 {
 	const uint8_t *value = attr->user_data;
 
-	if (!bAuthorized)
+	if (!bAuthorized) {
 		return BT_GATT_ERR(BT_ATT_ERR_AUTHORIZATION);
+	}
 
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, value,
 				 sizeof(des_v8d2_value));
@@ -193,12 +198,15 @@ static ssize_t write_des_v8d2(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(des_v8d2_value))
+	if (offset >= sizeof(des_v8d2_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(des_v8d2_value))
+	}
+	if (offset + len > sizeof(des_v8d2_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
-	if (!bAuthorized)
+	}
+	if (!bAuthorized) {
 		return BT_GATT_ERR(BT_ATT_ERR_AUTHORIZATION);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -246,10 +254,12 @@ static ssize_t write_des_v8d3(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(des_v8d3_value))
+	if (offset >= sizeof(des_v8d3_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(des_v8d3_value))
+	}
+	if (offset + len > sizeof(des_v8d3_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_c_1_1.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_c_1_1.c
@@ -93,10 +93,12 @@ static ssize_t write_value_v9__128_bit_uuid(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(value_v9__128_bit_uuid_value))
+	if (offset >= sizeof(value_v9__128_bit_uuid_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v9__128_bit_uuid_value))
+	}
+	if (offset + len > sizeof(value_v9__128_bit_uuid_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -147,10 +149,12 @@ static ssize_t write_des_v9d2__128_bit_uuid(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(des_v9d2__128_bit_uuid_value))
+	if (offset >= sizeof(des_v9d2__128_bit_uuid_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(des_v9d2__128_bit_uuid_value))
+	}
+	if (offset + len > sizeof(des_v9d2__128_bit_uuid_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -178,10 +182,12 @@ static ssize_t write_des_v9d3__128_bit_uuid(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(des_v9d3__128_bit_uuid_value))
+	if (offset >= sizeof(des_v9d3__128_bit_uuid_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(des_v9d3__128_bit_uuid_value))
+	}
+	if (offset + len > sizeof(des_v9d3__128_bit_uuid_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_c_1_2.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_c_1_2.c
@@ -93,10 +93,12 @@ static ssize_t write_value_v9__128_bit_uuid(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(value_v9__128_bit_uuid_value))
+	if (offset >= sizeof(value_v9__128_bit_uuid_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v9__128_bit_uuid_value))
+	}
+	if (offset + len > sizeof(value_v9__128_bit_uuid_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -147,10 +149,12 @@ static ssize_t write_des_v9d2__128_bit_uuid(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(des_v9d2__128_bit_uuid_value))
+	if (offset >= sizeof(des_v9d2__128_bit_uuid_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(des_v9d2__128_bit_uuid_value))
+	}
+	if (offset + len > sizeof(des_v9d2__128_bit_uuid_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -178,10 +182,12 @@ static ssize_t write_des_v9d3__128_bit_uuid(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(des_v9d3__128_bit_uuid_value))
+	if (offset >= sizeof(des_v9d3__128_bit_uuid_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(des_v9d3__128_bit_uuid_value))
+	}
+	if (offset + len > sizeof(des_v9d3__128_bit_uuid_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_c_1_3.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_c_1_3.c
@@ -91,10 +91,12 @@ static ssize_t write_value_v9__128_bit_uuid(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(value_v9__128_bit_uuid_value))
+	if (offset >= sizeof(value_v9__128_bit_uuid_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v9__128_bit_uuid_value))
+	}
+	if (offset + len > sizeof(value_v9__128_bit_uuid_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -145,10 +147,12 @@ static ssize_t write_des_v9d2__128_bit_uuid(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(des_v9d2__128_bit_uuid_value))
+	if (offset >= sizeof(des_v9d2__128_bit_uuid_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(des_v9d2__128_bit_uuid_value))
+	}
+	if (offset + len > sizeof(des_v9d2__128_bit_uuid_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -176,10 +180,12 @@ static ssize_t write_des_v9d3__128_bit_uuid(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(des_v9d3__128_bit_uuid_value))
+	if (offset >= sizeof(des_v9d3__128_bit_uuid_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(des_v9d3__128_bit_uuid_value))
+	}
+	if (offset + len > sizeof(des_v9d3__128_bit_uuid_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_c_2_1.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_c_2_1.c
@@ -214,10 +214,12 @@ static ssize_t write_value_v2(struct bt_conn *conn,
 {
 	char *value = attr->user_data;
 
-	if (offset >= sizeof(value_v2_value))
+	if (offset >= sizeof(value_v2_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v2_value))
+	}
+	if (offset + len > sizeof(value_v2_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -266,10 +268,12 @@ static ssize_t write_long_des_v2d1(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(long_des_v2d1_value))
+	if (offset >= sizeof(long_des_v2d1_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(long_des_v2d1_value))
+	}
+	if (offset + len > sizeof(long_des_v2d1_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -296,10 +300,12 @@ static ssize_t write_value_v2_1(struct bt_conn *conn,
 {
 	char *value = attr->user_data;
 
-	if (offset >= sizeof(value_v2_1_value))
+	if (offset >= sizeof(value_v2_1_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v2_1_value))
+	}
+	if (offset + len > sizeof(value_v2_1_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -348,10 +354,12 @@ static ssize_t write_long_des_v2d2(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(long_des_v2d2_value))
+	if (offset >= sizeof(long_des_v2d2_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(long_des_v2d2_value))
+	}
+	if (offset + len > sizeof(long_des_v2d2_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -378,10 +386,12 @@ static ssize_t write_value_v2_2(struct bt_conn *conn,
 {
 	char *value = attr->user_data;
 
-	if (offset >= sizeof(value_v2_2_value))
+	if (offset >= sizeof(value_v2_2_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v2_2_value))
+	}
+	if (offset + len > sizeof(value_v2_2_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -430,10 +440,12 @@ static ssize_t write_long_des_v2d3(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(long_des_v2d3_value))
+	if (offset >= sizeof(long_des_v2d3_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(long_des_v2d3_value))
+	}
+	if (offset + len > sizeof(long_des_v2d3_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -482,10 +494,12 @@ static ssize_t write_value_v2_3(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(value_v2_3_value))
+	if (offset >= sizeof(value_v2_3_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v2_3_value))
+	}
+	if (offset + len > sizeof(value_v2_3_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -534,10 +548,12 @@ static ssize_t write_long_des_v2d1_1(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(long_des_v2d1_1_value))
+	if (offset >= sizeof(long_des_v2d1_1_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(long_des_v2d1_1_value))
+	}
+	if (offset + len > sizeof(long_des_v2d1_1_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -586,10 +602,12 @@ static ssize_t write_value_v2_4(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(value_v2_4_value))
+	if (offset >= sizeof(value_v2_4_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v2_4_value))
+	}
+	if (offset + len > sizeof(value_v2_4_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -638,10 +656,12 @@ static ssize_t write_long_des_v2d2_1(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(long_des_v2d2_1_value))
+	if (offset >= sizeof(long_des_v2d2_1_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(long_des_v2d2_1_value))
+	}
+	if (offset + len > sizeof(long_des_v2d2_1_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -690,10 +710,12 @@ static ssize_t write_value_v2_5(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(value_v2_5_value))
+	if (offset >= sizeof(value_v2_5_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v2_5_value))
+	}
+	if (offset + len > sizeof(value_v2_5_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -742,10 +764,12 @@ static ssize_t write_long_des_v2d3_1(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(long_des_v2d3_1_value))
+	if (offset >= sizeof(long_des_v2d3_1_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(long_des_v2d3_1_value))
+	}
+	if (offset + len > sizeof(long_des_v2d3_1_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -772,10 +796,12 @@ static ssize_t write_value_v2_6(struct bt_conn *conn,
 {
 	char *value = attr->user_data;
 
-	if (offset >= sizeof(value_v2_6_value))
+	if (offset >= sizeof(value_v2_6_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v2_6_value))
+	}
+	if (offset + len > sizeof(value_v2_6_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -824,10 +850,12 @@ static ssize_t write_long_des_v2d1_2(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(long_des_v2d1_2_value))
+	if (offset >= sizeof(long_des_v2d1_2_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(long_des_v2d1_2_value))
+	}
+	if (offset + len > sizeof(long_des_v2d1_2_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -852,8 +880,9 @@ static ssize_t read_str_auth_value(struct bt_conn *conn,
 {
 	const char *value = attr->user_data;
 
-	if (!bAuthorized)
+	if (!bAuthorized) {
 		return BT_GATT_ERR(BT_ATT_ERR_AUTHORIZATION);
+	}
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, value,
 				 strlen(value));
 }
@@ -878,12 +907,15 @@ static ssize_t write_value_v2_7(struct bt_conn *conn,
 {
 	char *value = attr->user_data;
 
-	if (offset >= sizeof(value_v2_7_value))
+	if (offset >= sizeof(value_v2_7_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v2_7_value))
+	}
+	if (offset + len > sizeof(value_v2_7_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
-	if (!bAuthorized)
+	}
+	if (!bAuthorized) {
 		return BT_GATT_ERR(BT_ATT_ERR_AUTHORIZATION);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -908,8 +940,9 @@ static ssize_t read_long_des_v2d2_2(struct bt_conn *conn,
 {
 	const uint8_t *value = attr->user_data;
 
-	if (!bAuthorized)
+	if (!bAuthorized) {
 		return BT_GATT_ERR(BT_ATT_ERR_AUTHORIZATION);
+	}
 
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, value,
 				 sizeof(long_des_v2d2_2_value));
@@ -935,12 +968,15 @@ static ssize_t write_long_des_v2d2_2(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(long_des_v2d2_2_value))
+	if (offset >= sizeof(long_des_v2d2_2_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(long_des_v2d2_2_value))
+	}
+	if (offset + len > sizeof(long_des_v2d2_2_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
-	if (!bAuthorized)
+	}
+	if (!bAuthorized) {
 		return BT_GATT_ERR(BT_ATT_ERR_AUTHORIZATION);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -967,10 +1003,12 @@ static ssize_t write_value_v2_8(struct bt_conn *conn,
 {
 	char *value = attr->user_data;
 
-	if (offset >= sizeof(value_v2_8_value))
+	if (offset >= sizeof(value_v2_8_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v2_8_value))
+	}
+	if (offset + len > sizeof(value_v2_8_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -1019,10 +1057,12 @@ static ssize_t write_long_des_v2d3_2(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(long_des_v2d3_2_value))
+	if (offset >= sizeof(long_des_v2d3_2_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(long_des_v2d3_2_value))
+	}
+	if (offset + len > sizeof(long_des_v2d3_2_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_c_2_2.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_c_2_2.c
@@ -128,10 +128,12 @@ static ssize_t write_value_v2(struct bt_conn *conn,
 {
 	char *value = attr->user_data;
 
-	if (offset >= sizeof(value_v2_value))
+	if (offset >= sizeof(value_v2_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v2_value))
+	}
+	if (offset + len > sizeof(value_v2_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -158,10 +160,12 @@ static ssize_t write_value_v2_1(struct bt_conn *conn,
 {
 	char *value = attr->user_data;
 
-	if (offset >= sizeof(value_v2_1_value))
+	if (offset >= sizeof(value_v2_1_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v2_1_value))
+	}
+	if (offset + len > sizeof(value_v2_1_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -188,10 +192,12 @@ static ssize_t write_value_v2_2(struct bt_conn *conn,
 {
 	char *value = attr->user_data;
 
-	if (offset >= sizeof(value_v2_2_value))
+	if (offset >= sizeof(value_v2_2_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v2_2_value))
+	}
+	if (offset + len > sizeof(value_v2_2_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -218,10 +224,12 @@ static ssize_t write_value_v2_3(struct bt_conn *conn,
 {
 	char *value = attr->user_data;
 
-	if (offset >= sizeof(value_v2_3_value))
+	if (offset >= sizeof(value_v2_3_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v2_3_value))
+	}
+	if (offset + len > sizeof(value_v2_3_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -248,10 +256,12 @@ static ssize_t write_value_v2_4(struct bt_conn *conn,
 {
 	char *value = attr->user_data;
 
-	if (offset >= sizeof(value_v2_4_value))
+	if (offset >= sizeof(value_v2_4_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v2_4_value))
+	}
+	if (offset + len > sizeof(value_v2_4_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -278,10 +288,12 @@ static ssize_t write_value_v2_5(struct bt_conn *conn,
 {
 	char *value = attr->user_data;
 
-	if (offset >= sizeof(value_v2_5_value))
+	if (offset >= sizeof(value_v2_5_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v2_5_value))
+	}
+	if (offset + len > sizeof(value_v2_5_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_c_2_3.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_c_2_3.c
@@ -128,10 +128,12 @@ static ssize_t write_value_v2(struct bt_conn *conn,
 {
 	char *value = attr->user_data;
 
-	if (offset >= sizeof(value_v2_value))
+	if (offset >= sizeof(value_v2_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v2_value))
+	}
+	if (offset + len > sizeof(value_v2_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -158,10 +160,12 @@ static ssize_t write_value_v2_1(struct bt_conn *conn,
 {
 	char *value = attr->user_data;
 
-	if (offset >= sizeof(value_v2_1_value))
+	if (offset >= sizeof(value_v2_1_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v2_1_value))
+	}
+	if (offset + len > sizeof(value_v2_1_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -188,10 +192,12 @@ static ssize_t write_value_v2_2(struct bt_conn *conn,
 {
 	char *value = attr->user_data;
 
-	if (offset >= sizeof(value_v2_2_value))
+	if (offset >= sizeof(value_v2_2_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v2_2_value))
+	}
+	if (offset + len > sizeof(value_v2_2_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -218,10 +224,12 @@ static ssize_t write_value_v2_3(struct bt_conn *conn,
 {
 	char *value = attr->user_data;
 
-	if (offset >= sizeof(value_v2_3_value))
+	if (offset >= sizeof(value_v2_3_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v2_3_value))
+	}
+	if (offset + len > sizeof(value_v2_3_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -248,10 +256,12 @@ static ssize_t write_value_v2_4(struct bt_conn *conn,
 {
 	char *value = attr->user_data;
 
-	if (offset >= sizeof(value_v2_4_value))
+	if (offset >= sizeof(value_v2_4_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v2_4_value))
+	}
+	if (offset + len > sizeof(value_v2_4_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -278,10 +288,12 @@ static ssize_t write_value_v2_5(struct bt_conn *conn,
 {
 	char *value = attr->user_data;
 
-	if (offset >= sizeof(value_v2_5_value))
+	if (offset >= sizeof(value_v2_5_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v2_5_value))
+	}
+	if (offset + len > sizeof(value_v2_5_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_d_1.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_d_1.c
@@ -79,8 +79,9 @@ static ssize_t read_value_v11__128_bit_uuid(struct bt_conn *conn,
 {
 	const uint8_t *value = attr->user_data;
 
-	if (!bAuthorized)
+	if (!bAuthorized) {
 		return BT_GATT_ERR(BT_ATT_ERR_AUTHORIZATION);
+	}
 
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, value,
 				 sizeof(value_v11__128_bit_uuid_value));

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_f_1.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/gatt/service_f_1.c
@@ -149,10 +149,12 @@ static ssize_t write_value_v15(struct bt_conn *conn,
 {
 	uint8_t *value = attr->user_data;
 
-	if (offset >= sizeof(value_v15_value))
+	if (offset >= sizeof(value_v15_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v15_value))
+	}
+	if (offset + len > sizeof(value_v15_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy(value + offset, buf, len);
 
@@ -202,10 +204,12 @@ static ssize_t write_value_v6(struct bt_conn *conn,
 	uint16_t *value = attr->user_data;
 	uint16_t value_v6_conv = sys_cpu_to_le16(*value);
 
-	if (offset >= sizeof(value_v6_value))
+	if (offset >= sizeof(value_v6_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v6_value))
+	}
+	if (offset + len > sizeof(value_v6_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy((uint8_t *)&value_v6_conv + offset, buf, len);
 
@@ -257,10 +261,12 @@ static ssize_t write_value_v7(struct bt_conn *conn,
 	uint32_t *value = attr->user_data;
 	uint32_t value_v7_conv = sys_cpu_to_le32(*value);
 
-	if (offset >= sizeof(value_v7_value))
+	if (offset >= sizeof(value_v7_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	if (offset + len > sizeof(value_v7_value))
+	}
+	if (offset + len > sizeof(value_v7_value)) {
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
 
 	memcpy((uint8_t *)&value_v7_conv + offset, buf, len);
 

--- a/tests/bsim/bluetooth/ll/edtt/hci_test_app/src/main.c
+++ b/tests/bsim/bluetooth/ll/edtt/hci_test_app/src/main.c
@@ -819,10 +819,11 @@ int main(void)
 
 			edtt_read((uint8_t *)&multiple, sizeof(multiple),
 				  EDTTT_BLOCK);
-			if (multiple)
+			if (multiple) {
 				get_events(--size);
-			else
+			} else {
 				get_event(--size);
+			}
 		}
 		break;
 		case CMD_LE_FLUSH_DATA_REQ:

--- a/tests/posix/fs/src/test_fs_file.c
+++ b/tests/posix/fs/src/test_fs_file.c
@@ -165,8 +165,9 @@ static int test_file_fdatasync(void)
 {
 	int res = 0;
 
-	if (file < 0)
+	if (file < 0) {
 		return res;
+	}
 
 	res = fdatasync(file);
 	if (res < 0) {


### PR DESCRIPTION
Thank you for merging PR #77144.

---
I just realized that `clang-tidy`, which was used in a previous PR, did not analyze pieces of code that were turned off.
This led to this PR, which uses `clang-format` with the `--dry-run` option to identify the target files before correcting the format in the following directories:
- arch
- boards
- drivers
- kernel
- lib
- samples
- soc
- subsys
- tests