### PR TITLE
tests: include drivers/watchdog/wdt_basic_api on it8xxx2_evb

### DIFF
--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -16,9 +16,6 @@ tests:
       - s32z2xxdc2/s32z270/rtu1
       - s32z2xxdc2@D/s32z270/rtu0
       - s32z2xxdc2@D/s32z270/rtu1
-      # excluded it8xxx2_evb because test can't be automate,
-      # and needs external reset, git issue #75389
-      - it8xxx2_evb
   drivers.watchdog.stm32wwdg:
     filter: dt_compat_enabled("st,stm32-window-watchdog") or dt_compat_enabled("st,stm32-watchdog")
     extra_args: DTC_OVERLAY_FILE="boards/stm32_wwdg.overlay"


### PR DESCRIPTION
Due to issues with running the watchdog test in a fully automated manner on the IT8XXX2_EVB, it was previously removed. However, a fix has now been merged, and it should be operational on this board once again.