### PR TITLE
Bluetooth: Mesh: Fix uninitialized field when cancelling transfer blob

### DIFF
--- a/subsys/bluetooth/mesh/blob_srv.c
+++ b/subsys/bluetooth/mesh/blob_srv.c
@@ -219,6 +219,7 @@ static void cancel(struct bt_mesh_blob_srv *srv)
 	srv->state.xfer.mode = BT_MESH_BLOB_XFER_MODE_NONE;
 	srv->state.ttl = BT_MESH_TTL_DEFAULT;
 	srv->block.number = 0xffff;
+	memset(srv->block.missing, 0, sizeof(srv->block.missing));
 	srv->state.xfer.chunk_size = 0xffff;
 	k_work_cancel_delayable(&srv->rx_timeout);
 	k_work_cancel_delayable(&srv->pull.report);


### PR DESCRIPTION
Initialize the missing chunk field when canceling a BLOB Transfer. If you canceled a BLOB Transfer, the missing_chunk was not cleared in the next BLOB Transfer. This can make it look like there are still missing chunks, even though all chunks in the block have already been received, and it does cause bugs.