### PR TITLE
scripts: Minimum clang-format version

### DIFF
--- a/scripts/requirements-compliance.txt
+++ b/scripts/requirements-compliance.txt
@@ -1,7 +1,7 @@
 # COMPLIANCE: required by the compliance scripts
 
 # used by ci/check_compliance
-clang-format
+clang-format>=15.0.0
 python-magic
 python-magic-bin; sys_platform == "win32"
 lxml


### PR DESCRIPTION
Set the minimum supported clang-format version to v15.

Small follow-up after #77286