### PR TITLE
twister: pytest: Change the order or pytest-args

### DIFF
--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -419,10 +419,10 @@ class Pytest(Harness):
             for fixture in handler.options.fixture:
                 command.append(f'--twister-fixture={fixture}')
 
+        command.extend(pytest_args_yaml)
+
         if handler.options.pytest_args:
             command.extend(handler.options.pytest_args)
-
-        command.extend(pytest_args_yaml)
 
         return command
 

--- a/scripts/tests/twister/pytest_integration/test_harness_pytest.py
+++ b/scripts/tests/twister/pytest_integration/test_harness_pytest.py
@@ -83,6 +83,7 @@ def test_pytest_command_extra_args_in_options(testinstance: TestInstance):
     assert pytest_args_from_cmd[0] in command
     assert pytest_args_from_cmd[1] in command
     assert pytest_args_from_yaml in command
+    assert command.index(pytest_args_from_yaml) < command.index(pytest_args_from_cmd[1])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Use pytest-args parameters provided in command line after parameters taken from yaml file. The last occurence is considered by argparse, so parameters from command line will be used.

Fixes: #77319