### PR TITLE
Add support for NXP S32 SAR_ADC driver

### DIFF
--- a/boards/nxp/s32z2xxdc2/doc/index.rst
+++ b/boards/nxp/s32z2xxdc2/doc/index.rst
@@ -55,6 +55,8 @@ The boards support the following hardware features:
 +-----------+------------+-------------------------------------+
 | FLEXCAN   | on-chip    | can                                 |
 +-----------+------------+-------------------------------------+
+| SAR_ADC   | on-chip    | adc                                 |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not currently supported by the port.
 
@@ -149,6 +151,15 @@ FlexCAN
 -------
 
 FlexCAN supports CAN Classic (CAN 2.0) and CAN FD modes.
+
+ADC
+===
+
+ADC is provided through ADC SAR controller with 2 instances. Each ADC SAR instance has
+12-bit resolution. ADC channels are divided into 2 groups (precision and internal/standard).
+
+.. note::
+   All channels of an instance only run on 1 group channel at the same time.
 
 Programming and Debugging
 *************************

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270.dtsi
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270.dtsi
@@ -50,3 +50,11 @@
 	pinctrl-0 = <&flexcan1_default>;
 	pinctrl-names = "default";
 };
+
+&sar_adc0 {
+	vref-mv = <1800>;
+};
+
+&sar_adc1 {
+	vref-mv = <1800>;
+};

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu0.yaml
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu0.yaml
@@ -16,4 +16,5 @@ supported:
   - can
   - spi
   - counter
+  - adc
 vendor: nxp

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu0_D.yaml
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu0_D.yaml
@@ -16,4 +16,5 @@ supported:
   - can
   - spi
   - counter
+  - adc
 vendor: nxp

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu1.yaml
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu1.yaml
@@ -16,4 +16,5 @@ supported:
   - can
   - spi
   - counter
+  - adc
 vendor: nxp

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu1_D.yaml
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu1_D.yaml
@@ -16,4 +16,5 @@ supported:
   - can
   - spi
   - counter
+  - adc
 vendor: nxp

--- a/drivers/adc/adc_nxp_s32_adc_sar.c
+++ b/drivers/adc/adc_nxp_s32_adc_sar.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NXP
+ * Copyright 2023-2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -403,6 +403,18 @@ static void adc_nxp_s32_isr(const struct device *dev)
 #define ADC_NXP_S32_GET_INSTANCE(n)		\
 	LISTIFY(__DEBRACKET ADC_INSTANCE_COUNT, ADC_NXP_S32_INSTANCE_CHECK, (|), n)
 
+#if (FEATURE_ADC_HAS_HIGH_SPEED_ENABLE == 1U)
+#define ADC_NXP_S32_HIGH_SPEED_CFG(n) .HighSpeedConvEn = DT_INST_PROP(n, high_speed),
+#else
+#define ADC_NXP_S32_HIGH_SPEED_CFG(n)
+#endif
+
+#if (ADC_SAR_IP_SET_RESOLUTION == STD_ON)
+#define ADC_NXP_S32_RESOLUTION_CFG(n) .AdcResolution = ADC_SAR_IP_RESOLUTION_14,
+#else
+#define ADC_NXP_S32_RESOLUTION_CFG(n)
+#endif
+
 #define ADC_NXP_S32_INIT_DEVICE(n)						\
 	ADC_NXP_S32_DRIVER_API(n)						\
 	ADC_NXP_S32_CALLBACK_DEFINE(n)						\
@@ -412,8 +424,8 @@ static void adc_nxp_s32_isr(const struct device *dev)
 	static const Adc_Sar_Ip_ConfigType adc_nxp_s32_default_config##n =	\
 	{									\
 		.ConvMode = ADC_SAR_IP_CONV_MODE_ONESHOT,			\
-		.AdcResolution = ADC_SAR_IP_RESOLUTION_14,			\
-		.HighSpeedConvEn = DT_INST_PROP(n, high_speed),			\
+		ADC_NXP_S32_RESOLUTION_CFG(n)					\
+		ADC_NXP_S32_HIGH_SPEED_CFG(n)					\
 		.EndOfNormalChainNotification =					\
 				adc_nxp_s32_normal_endchain_callback##n,	\
 		.EndOfConvNotification =					\

--- a/dts/arm/nxp/nxp_s32z27x_r52.dtsi
+++ b/dts/arm/nxp/nxp_s32z27x_r52.dtsi
@@ -1074,5 +1074,25 @@
 			status = "disabled";
 		};
 
+		sar_adc0: adc@402c0000 {
+			compatible = "nxp,s32-adc-sar";
+			reg = <0x402C0000 0x1000>;
+			interrupts = <GIC_SPI 168 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 169 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 170 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			#io-channel-cells = <1>;
+			status = "disabled";
+		};
+
+		sar_adc1: adc@402e0000 {
+			compatible = "nxp,s32-adc-sar";
+			reg = <0x402e0000 0x1000>;
+			interrupts = <GIC_SPI 201 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 202 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 203 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			#io-channel-cells = <1>;
+			status = "disabled";
+		};
+
 	};
 };

--- a/samples/drivers/adc/adc_dt/boards/s32z2xxdc2_s32z270_rtu0.overlay
+++ b/samples/drivers/adc/adc_dt/boards/s32z2xxdc2_s32z270_rtu0.overlay
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/adc/adc.h>
+
+/ {
+	zephyr,user {
+		io-channels = <&sar_adc0 2>, <&sar_adc0 3>, <&sar_adc0 4>, <&sar_adc0 5>,
+				<&sar_adc1 3>, <&sar_adc1 4>, <&sar_adc1 5>, <&sar_adc1 6>;
+	};
+};
+
+&sar_adc0 {
+	group-channel = "precision";
+	callback-select = "normal-end-chain";
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	vref-mv = <1800>;
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@3 {
+		reg = <3>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@4 {
+		reg = <4>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@5 {
+		reg = <5>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+};
+
+&sar_adc1 {
+	group-channel = "standard";
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@3 {
+		reg = <3>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@4 {
+		reg = <4>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@5 {
+		reg = <5>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@6 {
+		reg = <6>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};

--- a/samples/drivers/adc/adc_dt/boards/s32z2xxdc2_s32z270_rtu1.overlay
+++ b/samples/drivers/adc/adc_dt/boards/s32z2xxdc2_s32z270_rtu1.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "s32z2xxdc2_s32z270_rtu0.overlay"

--- a/samples/drivers/adc/adc_sequence/boards/s32z2xxdc2_s32z270_rtu0.conf
+++ b/samples/drivers/adc/adc_sequence/boards/s32z2xxdc2_s32z270_rtu0.conf
@@ -1,0 +1,4 @@
+# Copyright 2024 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SEQUENCE_RESOLUTION=12

--- a/samples/drivers/adc/adc_sequence/boards/s32z2xxdc2_s32z270_rtu0.overlay
+++ b/samples/drivers/adc/adc_sequence/boards/s32z2xxdc2_s32z270_rtu0.overlay
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/adc/adc.h>
+
+/ {
+	aliases {
+		adc0 = &sar_adc0;
+	};
+	zephyr,user {
+		io-channels = <&sar_adc0 3>, <&sar_adc0 4>, <&sar_adc0 5>, <&sar_adc0 6>;
+	};
+};
+
+&sar_adc0 {
+	group-channel = "standard";
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@3 {
+		reg = <3>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@4 {
+		reg = <4>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@5 {
+		reg = <5>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@6 {
+		reg = <6>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};

--- a/samples/drivers/adc/adc_sequence/boards/s32z2xxdc2_s32z270_rtu1.conf
+++ b/samples/drivers/adc/adc_sequence/boards/s32z2xxdc2_s32z270_rtu1.conf
@@ -1,0 +1,4 @@
+# Copyright 2024 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SEQUENCE_RESOLUTION=12

--- a/samples/drivers/adc/adc_sequence/boards/s32z2xxdc2_s32z270_rtu1.overlay
+++ b/samples/drivers/adc/adc_sequence/boards/s32z2xxdc2_s32z270_rtu1.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "s32z2xxdc2_s32z270_rtu0.overlay"

--- a/tests/drivers/adc/adc_api/boards/s32z2xxdc2_s32z270_rtu0.overlay
+++ b/tests/drivers/adc/adc_api/boards/s32z2xxdc2_s32z270_rtu0.overlay
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/adc/adc.h>
+
+/ {
+	zephyr,user {
+		io-channels = <&sar_adc0 2>, <&sar_adc0 3>;
+	};
+};
+
+&sar_adc0 {
+	group-channel = "precision";
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@3 {
+		reg = <3>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};

--- a/tests/drivers/adc/adc_api/boards/s32z2xxdc2_s32z270_rtu1.overlay
+++ b/tests/drivers/adc/adc_api/boards/s32z2xxdc2_s32z270_rtu1.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "s32z2xxdc2_s32z270_rtu0.overlay"

--- a/west.yml
+++ b/west.yml
@@ -198,7 +198,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: e400b5dba27d9abe1403fc799d48b58fa1b1daee
+      revision: 00fd3f5a3b1b7fc3a715b1e96cb2d5036b5cc27e
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
This PR introduces NXP S32 SAR_ADC driver for SoC NXP S32Z27 and enables its usage for board s32z270dc2

Updates in hal_nxp: https://github.com/zephyrproject-rtos/hal_nxp/pull/426 

Tests:
samples\drivers\adc\adc_dt:
```
ADC reading[1628]:
- adc@402c0000, channel 2: 0 = 0 mV
- adc@402c0000, channel 3: 0 = 0 mV
- adc@402c0000, channel 4: 2152 = 945 mV
- adc@402c0000, channel 5: 838 = 368 mV
- adc@402e0000, channel 3: 977 = 429 mV
- adc@402e0000, channel 4: 4095 = 1799 mV
- adc@402e0000, channel 5: 3 = 1 mV
- adc@402e0000, channel 6: 4091 = 1797 mV
```

tests/drivers/adc/adc_api:
```
------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [adc_basic]: pass = 6, fail = 0, skip = 0, total = 6 duration = 0.536 seconds
 - PASS - [adc_basic.test_adc_asynchronous_call] duration = 0.006 seconds
 - PASS - [adc_basic.test_adc_invalid_request] duration = 0.013 seconds
 - PASS - [adc_basic.test_adc_repeated_samplings] duration = 0.094 seconds
 - PASS - [adc_basic.test_adc_sample_one_channel] duration = 0.006 seconds
 - PASS - [adc_basic.test_adc_sample_two_channels] duration = 0.006 seconds
 - PASS - [adc_basic.test_adc_sample_with_interval] duration = 0.411 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```