### PR TITLE
Bluetooth: controller: fixing issue re. assert on overlapping conn update

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
@@ -236,9 +236,12 @@ void llcp_rr_flush_procedures(struct ll_conn *conn)
 void llcp_rr_rx(struct ll_conn *conn, struct proc_ctx *ctx, memq_link_t *link,
 		struct node_rx_pdu *rx)
 {
-	/* Store RX node and link */
-	ctx->node_ref.rx = rx;
-	ctx->node_ref.link = link;
+	/* See comment in ull_llcp_local.c::llcp_lr_rx() */
+	if (!ctx->node_ref.rx) {
+		/* Store RX node and link */
+		ctx->node_ref.rx = rx;
+		ctx->node_ref.link = link;
+	}
 
 	switch (ctx->proc) {
 	case PROC_UNKNOWN:


### PR DESCRIPTION
If a connection update (from central) overlaps a peripheral initiated connection param request, then central rejects peripheral request and continues central procedure. This lead to an assert in peripheral.
On instant there would not be an rx_node for notification, as this would have been discarded by reception of the REJECT_IND

This fix ensures that once an rx_node has been 'accepted' for retention it will not be discarded/overwritten by future RX.
This can only happen for connection param request 'overtaken' by connection update.
The added test will trigger the assert without the fix in.