### PR TITLE
net: config: add missing include

### DIFF
--- a/subsys/net/lib/config/init_clock_sntp.c
+++ b/subsys/net/lib/config/init_clock_sntp.c
@@ -8,6 +8,7 @@
 LOG_MODULE_DECLARE(net_config, CONFIG_NET_CONFIG_LOG_LEVEL);
 
 #include <errno.h>
+#include <zephyr/net/net_if.h>
 #include <zephyr/net/sntp.h>
 #include <zephyr/posix/time.h>
 


### PR DESCRIPTION
this adds a missing include of zephyr/net/net_if.h

it is needed for the `net_if_get_default` in line 18.