### PR TITLE
Parameter type within reset function corrected

### DIFF
--- a/drivers/mipi_dbi/mipi_dbi_stm32_fmc.c
+++ b/drivers/mipi_dbi/mipi_dbi_stm32_fmc.c
@@ -122,7 +122,7 @@ static int mipi_dbi_stm32_fmc_write_display(const struct device *dev,
 	return 0;
 }
 
-static int mipi_dbi_stm32_fmc_reset(const struct device *dev, uint32_t delay)
+static int mipi_dbi_stm32_fmc_reset(const struct device *dev, k_timeout_t delay)
 {
 	const struct mipi_dbi_stm32_fmc_config *config = dev->config;
 	int ret;
@@ -136,7 +136,7 @@ static int mipi_dbi_stm32_fmc_reset(const struct device *dev, uint32_t delay)
 		return ret;
 	}
 
-	k_msleep(delay);
+	k_sleep(delay);
 
 	return gpio_pin_set_dt(&config->reset, 0);
 }


### PR DESCRIPTION
The reset function uses `uint32_t` as its 2nd parameter, which leads to the following compiler warning.

```
zephyr/drivers/mipi_dbi/mipi_dbi_stm32_fmc.c:176:18: warning: initialization of 'int (*)(const struct device *, k_timeout_t)' from incompatible pointer type 'int (*)(const struct device *, uint32_t)' {aka 'int (*)(const struct device *, unsigned int)'} [-Wincompatible-pointer-types]
  176 |         .reset = mipi_dbi_stm32_fmc_reset,
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~
```

When you look at similar drivers, you note they use `k_timeout_t`.

https://github.com/zephyrproject-rtos/zephyr/blob/main/drivers/mipi_dbi/mipi_dbi_smartbond.c#L126
https://github.com/zephyrproject-rtos/zephyr/blob/main/drivers/mipi_dbi/mipi_dbi_nxp_lcdic.c#L561

So the whole fix is to correct the type.