### PR TITLE
PCAL64XXA external reset

### DIFF
--- a/drivers/gpio/gpio_pcal64xxa.c
+++ b/drivers/gpio/gpio_pcal64xxa.c
@@ -1,12 +1,13 @@
 /*
  * Copyright (c) 2021 Nordic Semiconductor ASA
- * Copyright (c) 2023 SILA Embedded Solutions GmbH
+ * Copyright (c) 2024 SILA Embedded Solutions GmbH
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/gpio/gpio_pcal64xxa.h>
 #include <zephyr/drivers/gpio/gpio_utils.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/logging/log.h>
@@ -95,6 +96,8 @@ struct pcal64xxa_drv_data {
 
 typedef int (*pcal64xxa_pins_cfg_apply)(const struct i2c_dt_spec *i2c,
 					const struct pcal64xxa_pins_cfg *pins_cfg);
+typedef int (*pcal64xxa_pins_cfg_read)(const struct i2c_dt_spec *i2c,
+				       struct pcal64xxa_pins_cfg *pins_cfg);
 typedef int (*pcal64xxa_triggers_apply)(const struct i2c_dt_spec *i2c,
 					const struct pcal64xxa_triggers *triggers);
 typedef int (*pcal64xxa_reset_state_apply)(const struct i2c_dt_spec *i2c);
@@ -108,6 +111,7 @@ struct pcal64xxa_chip_api {
 	pcal64xxa_inputs_read inputs_read;
 	pcal64xxa_outputs_write outputs_write;
 	pcal64xxa_reset_state_apply reset_state_apply;
+	pcal64xxa_pins_cfg_read pins_cfg_read;
 };
 
 struct pcal64xxa_drv_cfg {
@@ -119,6 +123,7 @@ struct pcal64xxa_drv_cfg {
 	const struct gpio_dt_spec gpio_reset;
 	const struct gpio_dt_spec gpio_interrupt;
 	const struct pcal64xxa_chip_api *chip_api;
+	bool automatic_reset;
 };
 
 static int pcal64xxa_pin_configure(const struct device *dev, gpio_pin_t pin, gpio_flags_t flags)
@@ -473,6 +478,43 @@ static int pcal6408a_pins_cfg_apply(const struct i2c_dt_spec *i2c,
 	return 0;
 }
 
+static int pcal6408a_pins_cfg_read(const struct i2c_dt_spec *i2c,
+				   struct pcal64xxa_pins_cfg *pins_cfg)
+{
+	int rc;
+	uint8_t value;
+
+	rc = pcal64xxa_i2c_read(i2c, PCAL6408A_REG_PULL_UP_DOWN_SELECT, &value);
+	if (rc != 0) {
+		return -EIO;
+	}
+
+	pins_cfg->pull_ups_selected = value;
+
+	rc = pcal64xxa_i2c_read(i2c, PCAL6408A_REG_PULL_UP_DOWN_ENABLE, &value);
+	if (rc != 0) {
+		return -EIO;
+	}
+
+	pins_cfg->pulls_enabled = value;
+
+	rc = pcal64xxa_i2c_read(i2c, PCAL6408A_REG_OUTPUT_PORT, &value);
+	if (rc != 0) {
+		return -EIO;
+	}
+
+	pins_cfg->outputs_high = value;
+
+	rc = pcal64xxa_i2c_read(i2c, PCAL6408A_REG_CONFIGURATION, &value);
+	if (rc != 0) {
+		return -EIO;
+	}
+
+	pins_cfg->configured_as_inputs = value;
+
+	return 0;
+}
+
 static int pcal6408a_inputs_read(const struct i2c_dt_spec *i2c, pcal64xxa_data_t *int_sources,
 				 pcal64xxa_data_t *input_port)
 {
@@ -564,6 +606,7 @@ static const struct pcal64xxa_chip_api pcal6408a_chip_api = {
 	.inputs_read = pcal6408a_inputs_read,
 	.outputs_write = pcal6408a_outputs_write,
 	.reset_state_apply = pcal6408a_reset_state_apply,
+	.pins_cfg_read = pcal6408a_pins_cfg_read,
 };
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(nxp_pcal6408a) */
 
@@ -619,6 +662,64 @@ static int pcal6416a_pins_cfg_apply(const struct i2c_dt_spec *i2c,
 	if (rc != 0) {
 		return -EIO;
 	}
+
+	return 0;
+}
+
+static int pcal6416a_pins_cfg_read(const struct i2c_dt_spec *i2c,
+				   struct pcal64xxa_pins_cfg *pins_cfg)
+{
+	int rc;
+	uint8_t value_low;
+	uint8_t value_high;
+
+	rc = pcal64xxa_i2c_read(i2c, PCAL6416A_REG_PULL_UP_DOWN_SELECT_0, &value_low);
+	if (rc != 0) {
+		return -EIO;
+	}
+
+	rc = pcal64xxa_i2c_read(i2c, PCAL6416A_REG_PULL_UP_DOWN_SELECT_1, &value_high);
+	if (rc != 0) {
+		return -EIO;
+	}
+
+	pins_cfg->pull_ups_selected = value_high << 8 | value_low;
+
+	rc = pcal64xxa_i2c_read(i2c, PCAL6416A_REG_PULL_UP_DOWN_ENABLE_0, &value_low);
+	if (rc != 0) {
+		return -EIO;
+	}
+
+	rc = pcal64xxa_i2c_read(i2c, PCAL6416A_REG_PULL_UP_DOWN_ENABLE_1, &value_high);
+	if (rc != 0) {
+		return -EIO;
+	}
+
+	pins_cfg->pulls_enabled = value_high << 8 | value_low;
+
+	rc = pcal64xxa_i2c_read(i2c, PCAL6416A_REG_OUTPUT_PORT_0, &value_low);
+	if (rc != 0) {
+		return -EIO;
+	}
+
+	rc = pcal64xxa_i2c_read(i2c, PCAL6416A_REG_OUTPUT_PORT_1, &value_high);
+	if (rc != 0) {
+		return -EIO;
+	}
+
+	pins_cfg->outputs_high = value_high << 8 | value_low;
+
+	rc = pcal64xxa_i2c_read(i2c, PCAL6416A_REG_CONFIGURATION_0, &value_low);
+	if (rc != 0) {
+		return -EIO;
+	}
+
+	rc = pcal64xxa_i2c_read(i2c, PCAL6416A_REG_CONFIGURATION_1, &value_high);
+	if (rc != 0) {
+		return -EIO;
+	}
+
+	pins_cfg->configured_as_inputs = value_high << 8 | value_low;
 
 	return 0;
 }
@@ -749,6 +850,7 @@ static const struct pcal64xxa_chip_api pcal6416a_chip_api = {
 	.inputs_read = pcal6416a_inputs_read,
 	.outputs_write = pcal6416a_outputs_write,
 	.reset_state_apply = pcal6416a_reset_state_apply,
+	.pins_cfg_read = pcal6416a_pins_cfg_read,
 };
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(nxp_pcal6416a) */
 
@@ -763,6 +865,8 @@ static int pcal64xxa_apply_initial_state(const struct device *dev)
 		.pulls_enabled = 0,
 	};
 	int rc;
+
+	LOG_DBG("%s: apply initial state", dev->name);
 
 	/* If the RESET line is available, use it to reset the expander.
 	 * Otherwise, write reset values to registers that are not used by
@@ -813,14 +917,101 @@ static int pcal64xxa_apply_initial_state(const struct device *dev)
 	return 0;
 }
 
-int pcal64xxa_init(const struct device *dev)
+static int pcal64xxa_read_state_from_registers(const struct device *dev)
+{
+	const struct pcal64xxa_drv_cfg *drv_cfg = dev->config;
+	struct pcal64xxa_drv_data *drv_data = dev->data;
+	int rc;
+
+	LOG_DBG("%s: use retained state", dev->name);
+
+	/* Read current configuration of the pins. */
+	rc = drv_cfg->chip_api->pins_cfg_read(&drv_cfg->i2c, &drv_data->pins_cfg);
+	if (rc != 0) {
+		LOG_ERR("%s: failed to apply pin config", dev->name);
+		return rc;
+	}
+
+	return 0;
+}
+
+static int pcal64xxa_apply_initial_triggers(const struct device *dev)
 {
 	const struct pcal64xxa_drv_cfg *drv_cfg = dev->config;
 	struct pcal64xxa_drv_data *drv_data = dev->data;
 	const struct pcal64xxa_triggers initial_triggers = {
 		.masked = PCAL64XXA_INIT_HIGH,
 	};
+	int rc;
+
+	/* Set initial state of the interrupt related registers. */
+	rc = drv_cfg->chip_api->triggers_apply(&drv_cfg->i2c, &initial_triggers);
+	if (rc != 0) {
+		LOG_ERR("%s: failed to apply triggers", dev->name);
+		return rc;
+	}
+
+	drv_data->triggers = initial_triggers;
+
+	return 0;
+}
+
+static int pcal64xxa_read_initial_inputs(const struct device *dev)
+{
+	const struct pcal64xxa_drv_cfg *drv_cfg = dev->config;
+	struct pcal64xxa_drv_data *drv_data = dev->data;
 	pcal64xxa_data_t int_sources;
+	int rc;
+
+	/* Read initial state of the input port register. */
+	rc = drv_cfg->chip_api->inputs_read(&drv_cfg->i2c, &int_sources,
+					    &drv_data->input_port_last);
+	if (rc != 0) {
+		LOG_ERR("%s: failed to read inputs", dev->name);
+		return rc;
+	}
+
+	return 0;
+}
+
+static int pcal64xxa_reset_unlocked(const struct device *dev)
+{
+	int rc;
+
+	rc = pcal64xxa_apply_initial_state(dev);
+	if (rc != 0) {
+		return rc;
+	}
+
+	rc = pcal64xxa_apply_initial_triggers(dev);
+	if (rc != 0) {
+		return rc;
+	}
+
+	rc = pcal64xxa_read_initial_inputs(dev);
+	if (rc != 0) {
+		return rc;
+	}
+
+	return 0;
+}
+
+int pcal64xxa_reset(const struct device *dev)
+{
+	struct pcal64xxa_drv_data *drv_data = dev->data;
+	int rc;
+
+	k_sem_take(&drv_data->lock, K_FOREVER);
+	rc = pcal64xxa_reset_unlocked(dev);
+	k_sem_give(&drv_data->lock);
+
+	return rc;
+}
+
+int pcal64xxa_init(const struct device *dev)
+{
+	const struct pcal64xxa_drv_cfg *drv_cfg = dev->config;
+	struct pcal64xxa_drv_data *drv_data = dev->data;
 	int rc;
 
 	LOG_DBG("%s: initializing PCAL64XXA", dev->name);
@@ -838,29 +1029,6 @@ int pcal64xxa_init(const struct device *dev)
 	if (!i2c_is_ready_dt(&drv_cfg->i2c)) {
 		LOG_ERR("%s: %s is not ready", dev->name, drv_cfg->i2c.bus->name);
 		return -ENODEV;
-	}
-
-	LOG_DBG("%s: apply initial state", dev->name);
-	rc = pcal64xxa_apply_initial_state(dev);
-	if (rc != 0) {
-		return rc;
-	}
-
-	/* Set initial state of the interrupt related registers. */
-	rc = drv_cfg->chip_api->triggers_apply(&drv_cfg->i2c, &initial_triggers);
-	if (rc != 0) {
-		LOG_ERR("%s: failed to apply triggers", dev->name);
-		return rc;
-	}
-
-	drv_data->triggers = initial_triggers;
-
-	/* Read initial state of the input port register. */
-	rc = drv_cfg->chip_api->inputs_read(&drv_cfg->i2c, &int_sources,
-					    &drv_data->input_port_last);
-	if (rc != 0) {
-		LOG_ERR("%s: failed to read inputs", dev->name);
-		return rc;
 	}
 
 	/* If the INT line is available, configure the callback for it. */
@@ -892,6 +1060,28 @@ int pcal64xxa_init(const struct device *dev)
 		}
 	}
 
+	if (drv_cfg->automatic_reset) {
+		rc = pcal64xxa_apply_initial_state(dev);
+		if (rc != 0) {
+			return rc;
+		}
+	} else {
+		rc = pcal64xxa_read_state_from_registers(dev);
+		if (rc != 0) {
+			return rc;
+		}
+	}
+
+	rc = pcal64xxa_apply_initial_triggers(dev);
+	if (rc != 0) {
+		return rc;
+	}
+
+	rc = pcal64xxa_read_initial_inputs(dev);
+	if (rc != 0) {
+		return rc;
+	}
+
 	/* Device configured, unlock it so that it can be used. */
 	k_sem_give(&drv_data->lock);
 
@@ -905,6 +1095,8 @@ int pcal64xxa_init(const struct device *dev)
 #define PCAL64XXA_INIT_RESET_GPIO_FIELDS(idx)                                                      \
 	COND_CODE_1(DT_INST_NODE_HAS_PROP(idx, reset_gpios),                                       \
 		    (GPIO_DT_SPEC_GET_BY_IDX(DT_DRV_INST(idx), reset_gpios, 0)), ({0}))
+
+#define PCAL64XXA_AUTOMATIC_RESET(idx) !(DT_INST_PROP(idx, no_auto_reset))
 
 #define GPIO_PCAL6408A_INST(idx)                                                                   \
 	static const struct gpio_driver_api pcal6408a_drv_api##idx = {                             \
@@ -926,6 +1118,7 @@ int pcal64xxa_init(const struct device *dev)
 		.gpio_interrupt = PCAL64XXA_INIT_INT_GPIO_FIELDS(idx),                             \
 		.gpio_reset = PCAL64XXA_INIT_RESET_GPIO_FIELDS(idx),                               \
 		.chip_api = &pcal6408a_chip_api,                                                   \
+		.automatic_reset = PCAL64XXA_AUTOMATIC_RESET(idx),                                 \
 	};                                                                                         \
 	static struct pcal64xxa_drv_data pcal6408a_data##idx = {                                   \
 		.lock = Z_SEM_INITIALIZER(pcal6408a_data##idx.lock, 1, 1),                         \
@@ -959,6 +1152,7 @@ DT_INST_FOREACH_STATUS_OKAY(GPIO_PCAL6408A_INST)
 		.gpio_interrupt = PCAL64XXA_INIT_INT_GPIO_FIELDS(idx),                             \
 		.gpio_reset = PCAL64XXA_INIT_RESET_GPIO_FIELDS(idx),                               \
 		.chip_api = &pcal6416a_chip_api,                                                   \
+		.automatic_reset = PCAL64XXA_AUTOMATIC_RESET(idx),                                 \
 	};                                                                                         \
 	static struct pcal64xxa_drv_data pcal6416a_data##idx = {                                   \
 		.lock = Z_SEM_INITIALIZER(pcal6416a_data##idx.lock, 1, 1),                         \

--- a/dts/bindings/gpio/nxp,pcal64xxa-base.yaml
+++ b/dts/bindings/gpio/nxp,pcal64xxa-base.yaml
@@ -15,6 +15,15 @@ properties:
     description: |
       GPIO connected to the controller RESET pin. This pin is active-low.
 
+  no-auto-reset:
+    type: boolean
+    description: |
+      This flag disables the automatic reset, which allows the implementation
+      of for instance an external state retention of the port expander. If
+      this flag is set it must be ensured that for an actually uninitialized
+      port expander the manual reset is triggered via the exposed reset
+      function, specific to the PCAL64XXA.
+
   "#gpio-cells":
     const: 2
 

--- a/include/zephyr/drivers/gpio/gpio_pcal64xxa.h
+++ b/include/zephyr/drivers/gpio/gpio_pcal64xxa.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024 SILA Embedded Solutions GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_GPIO_GPIO_PCAL64XXA_H_
+#define ZEPHYR_INCLUDE_DRIVERS_GPIO_GPIO_PCAL64XXA_H_
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Manually reset a PCAL64XXA
+ *
+ * Resetting a PCAL64XXA manually is only necessary if the by default
+ * enabled automatic reset has been disabled.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ *
+ * @retval 0 If successful.
+ */
+int pcal64xxa_reset(const struct device *dev);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_GPIO_GPIO_PCAL64XXA_H_ */


### PR DESCRIPTION
Implement an external reset for the port expander PCAL64XXA, which allows the downstream implementation of a device state retention.

This is basically based upon the discussion in #72382.