### PR TITLE
firmware: scmi: transport.h: switch to including kernel.h

### DIFF
--- a/include/zephyr/drivers/firmware/scmi/transport.h
+++ b/include/zephyr/drivers/firmware/scmi/transport.h
@@ -13,7 +13,7 @@
 #define _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_TRANSPORT_H_
 
 #include <zephyr/device.h>
-#include <zephyr/sys/mutex.h>
+#include <zephyr/kernel.h>
 
 struct scmi_message;
 struct scmi_channel;


### PR DESCRIPTION
Toggling `CONFIG_USERSPACE` to `y` results in compilation errors caused by the fact that various k_* functions don't have their prototipes included in the SCMI sources (e.g: k_mutex_*, k_sem_*, k_is_pre_kernel()).

To fix this, switch to using the `kernel.h` header instead of `sys/mutex.h`. Previously, this worked because `sys/mutex.h` included `kernel.h` if `CONFIG_USERSPACE` was set to `n`.

Issue was discovered because of the failing twister tests from https://github.com/zephyrproject-rtos/zephyr/pull/74920.

To reproduce:

1) Pull in the patches from https://github.com/zephyrproject-rtos/zephyr/pull/74920
2) Run `west build -p -b imx95_evk//a55/smp samples/userspace/hello_world_user/` (any test/sample that sets `CONFIG_USERSPACE` to `y` should do the trick) (CPU or board variant are not relevant)
3) Compilation fails with error messages such as:

```
/__w/zephyr/zephyr/include/zephyr/drivers/firmware/scmi/transport.h:52:24: error: field 'lock' has incomplete type
   52 |         struct k_mutex lock;
      |                        ^~~~
/__w/zephyr/zephyr/include/zephyr/drivers/firmware/scmi/transport.h:58:22: error: field 'sem' has incomplete type
   58 |         struct k_sem sem;
      |                      ^~~
/__w/zephyr/zephyr/drivers/firmware/scmi/core.c: In function 'scmi_core_reply_cb':
/__w/zephyr/zephyr/drivers/firmware/scmi/core.c:47:14: error: implicit declaration of function 'k_is_pre_kernel' [-Werror=implicit-function-declaration]
   47 |         if (!k_is_pre_kernel()) {
      |        
``` 

(output taken from https://github.com/zephyrproject-rtos/zephyr/pull/74920, errors should be the same for all samples/tests)

https://github.com/zephyrproject-rtos/zephyr/pull/77343 shows the results of the twister tests with this patch applied to https://github.com/zephyrproject-rtos/zephyr/pull/74920