### PR TITLE
Bluetooth: TBS: Add UTF8 requirement to Kconfigs

### DIFF
--- a/subsys/bluetooth/audio/Kconfig.tbs
+++ b/subsys/bluetooth/audio/Kconfig.tbs
@@ -13,6 +13,7 @@ config BT_TBS
 	bool "Telephone Bearer Service Support"
 	select BT_CCID
 	select BT_GATT_DYNAMIC_DB
+	depends on UTF8
 	help
 	  This option enables support for Telephone Bearer Service.
 
@@ -134,11 +135,13 @@ endif # BT_TBS
 
 config BT_TBS_CLIENT_GTBS
 	bool "Generic Telephone Bearer Service client support"
+	depends on UTF8
 	help
 	  This option enables support for the GTBS-oriented Call Control client.
 
 config BT_TBS_CLIENT_TBS
 	bool "Telephone Bearer Service client support"
+	depends on UTF8
 	help
 	  This option enables support for the TBS-oriented Call Control client.
 


### PR DESCRIPTION
The UTF8 implementions for both client and server
both use the utf8 API which require CONFIG_UTF8.