### PR TITLE
boards: dts: esp_rust: enable bluetooth peripheral

### DIFF
--- a/boards/espressif/esp32c3_rust/esp32c3_rust.dts
+++ b/boards/espressif/esp32c3_rust/esp32c3_rust.dts
@@ -124,6 +124,10 @@
 	status = "disabled";
 };
 
+&esp32_bt_hci {
+	status = "okay";
+};
+
 &flash0 {
 	status = "okay";
 	partitions {


### PR DESCRIPTION
Adds BLE DTS entry to enable Bluetooth LE in esp_rust board.