### PR TITLE
drivers: dai: esai: don't reset ESAI on init

### DIFF
--- a/drivers/dai/nxp/esai/esai.c
+++ b/drivers/dai/nxp/esai/esai.c
@@ -684,8 +684,6 @@ static int esai_init(const struct device *dev)
 
 	device_map(&data->regmap, cfg->regmap_phys, cfg->regmap_size, K_MEM_CACHE_NONE);
 
-	ESAI_Reset(UINT_TO_ESAI(data->regmap));
-
 	ret = esai_parse_pinmodes(cfg, data);
 	if (ret < 0) {
 		return ret;


### PR DESCRIPTION
The ESAI is already reset during the config_set() function so no need to also reset it during init().