### PR TITLE
twister: scripts: Split lines before processing 

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -443,12 +443,13 @@ class DeviceHandler(Handler):
             # Just because ser_fileno has data doesn't mean an entire line
             # is available yet.
             if serial_line:
-                sl = serial_line.decode('utf-8', 'ignore').lstrip()
-                logger.debug("DEVICE: {0}".format(sl.rstrip()))
-
-                log_out_fp.write(strip_ansi_sequences(sl).encode('utf-8'))
-                log_out_fp.flush()
-                harness.handle(sl.rstrip())
+                # can be more lines in serial_line so split them before handling
+                for sl in serial_line.decode('utf-8', 'ignore').splitlines():
+                    log_out_fp.write(strip_ansi_sequences(sl).encode('utf-8'))
+                    log_out_fp.flush()
+                    if sl := sl.strip():
+                        logger.debug("DEVICE: {0}".format(sl))
+                        harness.handle(sl)
 
             if harness.status != TwisterStatus.NONE:
                 if not harness.capture_coverage:

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -729,6 +729,24 @@ def test_devicehandler_monitor_serial(
     )
 
 
+def test_devicehandler_monitor_serial_splitlines(mocked_instance):
+    halt_event = mock.Mock(is_set=mock.Mock(return_value=False))
+    ser = mock.Mock(
+        isOpen=mock.Mock(side_effect=[True, True, False]),
+        in_waiting=mock.Mock(return_value=False),
+        readline=mock.Mock(return_value='\nline1\nline2\n'.encode('utf-8'))
+    )
+    harness = mock.Mock(status=TwisterStatus.PASS)
+
+    handler = DeviceHandler(mocked_instance, 'build')
+    handler.options = mock.Mock(enable_coverage=False)
+
+    with mock.patch('builtins.open', mock.mock_open(read_data='')):
+        handler.monitor_serial(ser, halt_event, harness)
+
+    assert harness.handle.call_count == 2
+
+
 TESTDATA_10 = [
     (
         'dummy_platform',


### PR DESCRIPTION
Readline method sometimes receives more lines in buffer.
Split them to avoid misinterpreting data in harness module.

Why:
In test: https://github.com/nrfconnect/sdk-zephyr/blob/main/tests/boot/mcuboot_recovery_retention/testcase.yaml#L16
we sometimes received two lines in one buffer from `readline` method:
`DEVICE: b'mcuboot_status: 2\r\xffWaiting...\r\n'`
all data are correct, but Twister processed it as a one line and missed `Waiting...` string, that is also checked by harness console.


