### PR TITLE
doc: clean ENABLED_SECTION option for doxygen

### DIFF
--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -769,7 +769,7 @@ GENERATE_DEPRECATEDLIST= YES
 # sections, marked by \if <section_label> ... \endif and \cond <section_label>
 # ... \endcond blocks.
 
-ENABLED_SECTIONS       = YES
+ENABLED_SECTIONS       =
 
 # The MAX_INITIALIZER_LINES tag determines the maximum number of lines that the
 # initial value of a variable or macro / define can have for it to appear in the


### PR DESCRIPTION
The ENABLED_SECTION option is not a YES/NO option but should contain a list of section label to be processed. For example, adding INTERNAL_HIDDEN will make doxygen to look through all the blocks with "@cond INTERNAL_HIDDEN" and "@endcond". So just remove the "YES" and leave it an empty list.