### PR TITLE
doc: Coding guidelines: use fixed title for reference to Bluetooth APIs

### DIFF
--- a/doc/contribute/coding_guidelines/index.rst
+++ b/doc/contribute/coding_guidelines/index.rst
@@ -1208,7 +1208,7 @@ Related GitHub Issues and Pull Requests are tagged with the `Inclusive Language 
      - Selected Replacements
      - Status
 
-   * - :ref:`bluetooth_api`
+   * - :ref:`Bluetooth <bluetooth_api>`
      - See `Bluetooth Appropriate Language Mapping Tables`_
      -
 


### PR DESCRIPTION
Commit 698a0c3193cebb617cb8b37260d1f4e52520841f changed the `bluetooth_api` section title, which made the reference in the Coding guidelines turn into "API", which is confusing.

Use a fixed title for that reference to fix the issue.