### PR TITLE
doc: fix some typos and doxygen tag errors

### DIFF
--- a/include/zephyr/drivers/mbox.h
+++ b/include/zephyr/drivers/mbox.h
@@ -201,7 +201,7 @@ typedef int (*mbox_register_callback_t)(const struct device *dev,
  *
  * @param dev MBOX device instance
  * @param channel_id Channel ID
- * @param enables Set to 0 to disable and to nonzero to enable.
+ * @param enabled Set to 0 to disable and to nonzero to enable.
  *
  * @return See return values for mbox_set_enabled()
  * @see mbox_set_enabled()

--- a/include/zephyr/drivers/regulator.h
+++ b/include/zephyr/drivers/regulator.h
@@ -179,7 +179,7 @@ struct regulator_common_config {
 	uint8_t allowed_modes_cnt;
 	/** Regulator initial mode */
 	regulator_mode_t initial_mode;
-	/** Flags (@reg REGULATOR_FLAGS). */
+	/** Flags (@ref REGULATOR_FLAGS). */
 	uint8_t flags;
 };
 

--- a/include/zephyr/drivers/serial/uart_async_to_irq.h
+++ b/include/zephyr/drivers/serial/uart_async_to_irq.h
@@ -202,7 +202,7 @@ struct uart_async_to_irq_tx_data {
 	size_t len;
 };
 
-/** @briref Data associated with the asynchronous to the interrupt driven API adaptation layer. */
+/** @brief Data associated with the asynchronous to the interrupt driven API adaptation layer. */
 struct uart_async_to_irq_data {
 	/** User callback for interrupt driven API. */
 	uart_irq_callback_user_data_t callback;

--- a/include/zephyr/net/net_pkt.h
+++ b/include/zephyr/net/net_pkt.h
@@ -1586,6 +1586,7 @@ void net_pkt_frag_insert_debug(struct net_pkt *pkt, struct net_buf *frag,
 	*/
 /** @endcond */
 
+#if defined(NET_PKT_DEBUG_ENABLED)
 /**
  * @brief Print fragment list and the fragment sizes
  *
@@ -1593,12 +1594,12 @@ void net_pkt_frag_insert_debug(struct net_pkt *pkt, struct net_buf *frag,
  *
  * @param pkt Network pkt.
  */
-#if defined(NET_PKT_DEBUG_ENABLED)
 void net_pkt_print_frags(struct net_pkt *pkt);
 #else
 #define net_pkt_print_frags(pkt)
 #endif
 
+#if !defined(NET_PKT_DEBUG_ENABLED)
 /**
  * @brief Get a data buffer from a given pool.
  *
@@ -1613,11 +1614,11 @@ void net_pkt_print_frags(struct net_pkt *pkt);
  *
  * @return Network buffer if successful, NULL otherwise.
  */
-#if !defined(NET_PKT_DEBUG_ENABLED)
 struct net_buf *net_pkt_get_reserve_data(struct net_buf_pool *pool,
 					 size_t min_len, k_timeout_t timeout);
 #endif
 
+#if !defined(NET_PKT_DEBUG_ENABLED)
 /**
  * @brief Get RX DATA buffer from pool.
  * Normally you should use net_pkt_get_frag() instead.
@@ -1632,10 +1633,10 @@ struct net_buf *net_pkt_get_reserve_data(struct net_buf_pool *pool,
  *
  * @return Network buffer if successful, NULL otherwise.
  */
-#if !defined(NET_PKT_DEBUG_ENABLED)
 struct net_buf *net_pkt_get_reserve_rx_data(size_t min_len, k_timeout_t timeout);
 #endif
 
+#if !defined(NET_PKT_DEBUG_ENABLED)
 /**
  * @brief Get TX DATA buffer from pool.
  * Normally you should use net_pkt_get_frag() instead.
@@ -1650,10 +1651,10 @@ struct net_buf *net_pkt_get_reserve_rx_data(size_t min_len, k_timeout_t timeout)
  *
  * @return Network buffer if successful, NULL otherwise.
  */
-#if !defined(NET_PKT_DEBUG_ENABLED)
 struct net_buf *net_pkt_get_reserve_tx_data(size_t min_len, k_timeout_t timeout);
 #endif
 
+#if !defined(NET_PKT_DEBUG_ENABLED)
 /**
  * @brief Get a data fragment that might be from user specific
  * buffer pool or from global DATA pool.
@@ -1666,11 +1667,11 @@ struct net_buf *net_pkt_get_reserve_tx_data(size_t min_len, k_timeout_t timeout)
  *
  * @return Network buffer if successful, NULL otherwise.
  */
-#if !defined(NET_PKT_DEBUG_ENABLED)
 struct net_buf *net_pkt_get_frag(struct net_pkt *pkt, size_t min_len,
 				 k_timeout_t timeout);
 #endif
 
+#if !defined(NET_PKT_DEBUG_ENABLED)
 /**
  * @brief Place packet back into the available packets slab
  *
@@ -1680,10 +1681,10 @@ struct net_buf *net_pkt_get_frag(struct net_pkt *pkt, size_t min_len,
  * @param pkt Network packet to release.
  *
  */
-#if !defined(NET_PKT_DEBUG_ENABLED)
 void net_pkt_unref(struct net_pkt *pkt);
 #endif
 
+#if !defined(NET_PKT_DEBUG_ENABLED)
 /**
  * @brief Increase the packet ref count
  *
@@ -1693,10 +1694,10 @@ void net_pkt_unref(struct net_pkt *pkt);
  *
  * @return Network packet if successful, NULL otherwise.
  */
-#if !defined(NET_PKT_DEBUG_ENABLED)
 struct net_pkt *net_pkt_ref(struct net_pkt *pkt);
 #endif
 
+#if !defined(NET_PKT_DEBUG_ENABLED)
 /**
  * @brief Increase the packet fragment ref count
  *
@@ -1706,19 +1707,19 @@ struct net_pkt *net_pkt_ref(struct net_pkt *pkt);
  *
  * @return a pointer on the referenced Network fragment.
  */
-#if !defined(NET_PKT_DEBUG_ENABLED)
 struct net_buf *net_pkt_frag_ref(struct net_buf *frag);
 #endif
 
+#if !defined(NET_PKT_DEBUG_ENABLED)
 /**
  * @brief Decrease the packet fragment ref count
  *
  * @param frag Network fragment to unref.
  */
-#if !defined(NET_PKT_DEBUG_ENABLED)
 void net_pkt_frag_unref(struct net_buf *frag);
 #endif
 
+#if !defined(NET_PKT_DEBUG_ENABLED)
 /**
  * @brief Delete existing fragment from a packet
  *
@@ -1729,29 +1730,28 @@ void net_pkt_frag_unref(struct net_buf *frag);
  * @return Pointer to the following fragment, or NULL if it had no
  *         further fragments.
  */
-#if !defined(NET_PKT_DEBUG_ENABLED)
 struct net_buf *net_pkt_frag_del(struct net_pkt *pkt,
 				 struct net_buf *parent,
 				 struct net_buf *frag);
 #endif
 
+#if !defined(NET_PKT_DEBUG_ENABLED)
 /**
  * @brief Add a fragment to a packet at the end of its fragment list
  *
  * @param pkt pkt Network packet where to add the fragment
  * @param frag Fragment to add
  */
-#if !defined(NET_PKT_DEBUG_ENABLED)
 void net_pkt_frag_add(struct net_pkt *pkt, struct net_buf *frag);
 #endif
 
+#if !defined(NET_PKT_DEBUG_ENABLED)
 /**
  * @brief Insert a fragment to a packet at the beginning of its fragment list
  *
  * @param pkt pkt Network packet where to insert the fragment
  * @param frag Fragment to insert
  */
-#if !defined(NET_PKT_DEBUG_ENABLED)
 void net_pkt_frag_insert(struct net_pkt *pkt, struct net_buf *frag);
 #endif
 
@@ -1882,6 +1882,7 @@ struct net_pkt *net_pkt_rx_alloc_with_buffer_debug(struct net_if *iface,
 #endif /* NET_PKT_DEBUG_ENABLED */
 /** @endcond */
 
+#if !defined(NET_PKT_DEBUG_ENABLED)
 /**
  * @brief Allocate an initialized net_pkt
  *
@@ -1892,10 +1893,10 @@ struct net_pkt *net_pkt_rx_alloc_with_buffer_debug(struct net_if *iface,
  *
  * @return a pointer to a newly allocated net_pkt on success, NULL otherwise.
  */
-#if !defined(NET_PKT_DEBUG_ENABLED)
 struct net_pkt *net_pkt_alloc(k_timeout_t timeout);
 #endif
 
+#if !defined(NET_PKT_DEBUG_ENABLED)
 /**
  * @brief Allocate an initialized net_pkt from a specific slab
  *
@@ -1910,11 +1911,11 @@ struct net_pkt *net_pkt_alloc(k_timeout_t timeout);
  *
  * @return a pointer to a newly allocated net_pkt on success, NULL otherwise.
  */
-#if !defined(NET_PKT_DEBUG_ENABLED)
 struct net_pkt *net_pkt_alloc_from_slab(struct k_mem_slab *slab,
 					k_timeout_t timeout);
 #endif
 
+#if !defined(NET_PKT_DEBUG_ENABLED)
 /**
  * @brief Allocate an initialized net_pkt for RX
  *
@@ -1925,10 +1926,10 @@ struct net_pkt *net_pkt_alloc_from_slab(struct k_mem_slab *slab,
  *
  * @return a pointer to a newly allocated net_pkt on success, NULL otherwise.
  */
-#if !defined(NET_PKT_DEBUG_ENABLED)
 struct net_pkt *net_pkt_rx_alloc(k_timeout_t timeout);
 #endif
 
+#if !defined(NET_PKT_DEBUG_ENABLED)
 /**
  * @brief Allocate a network packet for a specific network interface.
  *
@@ -1937,7 +1938,6 @@ struct net_pkt *net_pkt_rx_alloc(k_timeout_t timeout);
  *
  * @return a pointer to a newly allocated net_pkt on success, NULL otherwise.
  */
-#if !defined(NET_PKT_DEBUG_ENABLED)
 struct net_pkt *net_pkt_alloc_on_iface(struct net_if *iface,
 				       k_timeout_t timeout);
 
@@ -1950,6 +1950,7 @@ struct net_pkt *net_pkt_rx_alloc_on_iface(struct net_if *iface,
 
 #endif
 
+#if !defined(NET_PKT_DEBUG_ENABLED)
 /**
  * @brief Allocate buffer for a net_pkt
  *
@@ -1965,13 +1966,13 @@ struct net_pkt *net_pkt_rx_alloc_on_iface(struct net_if *iface,
  *
  * @return 0 on success, negative errno code otherwise.
  */
-#if !defined(NET_PKT_DEBUG_ENABLED)
 int net_pkt_alloc_buffer(struct net_pkt *pkt,
 			 size_t size,
 			 enum net_ip_protocol proto,
 			 k_timeout_t timeout);
 #endif
 
+#if !defined(NET_PKT_DEBUG_ENABLED)
 /**
  * @brief Allocate buffer for a net_pkt, of specified size, w/o any additional
  *        preconditions
@@ -1985,11 +1986,11 @@ int net_pkt_alloc_buffer(struct net_pkt *pkt,
  *
  * @return 0 on success, negative errno code otherwise.
  */
-#if !defined(NET_PKT_DEBUG_ENABLED)
 int net_pkt_alloc_buffer_raw(struct net_pkt *pkt, size_t size,
 			     k_timeout_t timeout);
 #endif
 
+#if !defined(NET_PKT_DEBUG_ENABLED)
 /**
  * @brief Allocate a network packet and buffer at once
  *
@@ -2001,7 +2002,6 @@ int net_pkt_alloc_buffer_raw(struct net_pkt *pkt, size_t size,
  *
  * @return a pointer to a newly allocated net_pkt on success, NULL otherwise.
  */
-#if !defined(NET_PKT_DEBUG_ENABLED)
 struct net_pkt *net_pkt_alloc_with_buffer(struct net_if *iface,
 					  size_t size,
 					  sa_family_t family,

--- a/include/zephyr/sys/poweroff.h
+++ b/include/zephyr/sys/poweroff.h
@@ -29,8 +29,6 @@ extern "C" {
  */
 FUNC_NORETURN void z_sys_poweroff(void);
 
-/** @} */
-
 /** @endcond */
 
 /**


### PR DESCRIPTION
This fixes some typos and doxygen tag errors. These were discovered when `INTERNAL_HIDDEN` blocks were being processed instead of being ignored.

See individual commits for details.