### PR TITLE
uart: refactor internal bits from public API header file

### DIFF
--- a/include/zephyr/drivers/uart.h
+++ b/include/zephyr/drivers/uart.h
@@ -22,7 +22,6 @@
  * @{
  */
 
-#include <errno.h>
 #include <stddef.h>
 
 #include <zephyr/device.h>
@@ -140,13 +139,6 @@ struct uart_config {
  */
 typedef void (*uart_irq_callback_user_data_t)(const struct device *dev,
 					      void *user_data);
-
-/**
- * @brief For configuring IRQ on each individual UART device.
- *
- * @param dev UART device instance.
- */
-typedef void (*uart_irq_config_func_t)(const struct device *dev);
 
 /**
  * @}
@@ -329,135 +321,6 @@ typedef void (*uart_callback_t)(const struct device *dev,
  */
 
 /**
- * @cond INTERNAL_HIDDEN
- *
- * For internal driver use only, skip these in public documentation.
- */
-
-/** @brief Driver API structure. */
-__subsystem struct uart_driver_api {
-
-#ifdef CONFIG_UART_ASYNC_API
-
-	int (*callback_set)(const struct device *dev,
-			    uart_callback_t callback,
-			    void *user_data);
-
-	int (*tx)(const struct device *dev, const uint8_t *buf, size_t len,
-		  int32_t timeout);
-	int (*tx_abort)(const struct device *dev);
-
-	int (*rx_enable)(const struct device *dev, uint8_t *buf, size_t len,
-			 int32_t timeout);
-	int (*rx_buf_rsp)(const struct device *dev, uint8_t *buf, size_t len);
-	int (*rx_disable)(const struct device *dev);
-
-#ifdef CONFIG_UART_WIDE_DATA
-	int (*tx_u16)(const struct device *dev, const uint16_t *buf,
-		      size_t len, int32_t timeout);
-	int (*rx_enable_u16)(const struct device *dev, uint16_t *buf,
-			     size_t len, int32_t timeout);
-	int (*rx_buf_rsp_u16)(const struct device *dev, uint16_t *buf,
-			      size_t len);
-#endif
-
-#endif
-
-	/** Console I/O function */
-	int (*poll_in)(const struct device *dev, unsigned char *p_char);
-	void (*poll_out)(const struct device *dev, unsigned char out_char);
-
-#ifdef CONFIG_UART_WIDE_DATA
-	int (*poll_in_u16)(const struct device *dev, uint16_t *p_u16);
-	void (*poll_out_u16)(const struct device *dev, uint16_t out_u16);
-#endif
-
-	/** Console I/O function */
-	int (*err_check)(const struct device *dev);
-
-#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
-	/** UART configuration functions */
-	int (*configure)(const struct device *dev,
-			 const struct uart_config *cfg);
-	int (*config_get)(const struct device *dev, struct uart_config *cfg);
-#endif
-
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
-
-	/** Interrupt driven FIFO fill function */
-	int (*fifo_fill)(const struct device *dev, const uint8_t *tx_data,
-			 int len);
-
-#ifdef CONFIG_UART_WIDE_DATA
-	int (*fifo_fill_u16)(const struct device *dev, const uint16_t *tx_data,
-			     int len);
-#endif
-
-	/** Interrupt driven FIFO read function */
-	int (*fifo_read)(const struct device *dev, uint8_t *rx_data,
-			 const int size);
-
-#ifdef CONFIG_UART_WIDE_DATA
-	int (*fifo_read_u16)(const struct device *dev, uint16_t *rx_data,
-			     const int size);
-#endif
-
-	/** Interrupt driven transfer enabling function */
-	void (*irq_tx_enable)(const struct device *dev);
-
-	/** Interrupt driven transfer disabling function */
-	void (*irq_tx_disable)(const struct device *dev);
-
-	/** Interrupt driven transfer ready function */
-	int (*irq_tx_ready)(const struct device *dev);
-
-	/** Interrupt driven receiver enabling function */
-	void (*irq_rx_enable)(const struct device *dev);
-
-	/** Interrupt driven receiver disabling function */
-	void (*irq_rx_disable)(const struct device *dev);
-
-	/** Interrupt driven transfer complete function */
-	int (*irq_tx_complete)(const struct device *dev);
-
-	/** Interrupt driven receiver ready function */
-	int (*irq_rx_ready)(const struct device *dev);
-
-	/** Interrupt driven error enabling function */
-	void (*irq_err_enable)(const struct device *dev);
-
-	/** Interrupt driven error disabling function */
-	void (*irq_err_disable)(const struct device *dev);
-
-	/** Interrupt driven pending status function */
-	int (*irq_is_pending)(const struct device *dev);
-
-	/** Interrupt driven interrupt update function */
-	int (*irq_update)(const struct device *dev);
-
-	/** Set the irq callback function */
-	void (*irq_callback_set)(const struct device *dev,
-				 uart_irq_callback_user_data_t cb,
-				 void *user_data);
-
-#endif
-
-#ifdef CONFIG_UART_LINE_CTRL
-	int (*line_ctrl_set)(const struct device *dev, uint32_t ctrl,
-			     uint32_t val);
-	int (*line_ctrl_get)(const struct device *dev, uint32_t ctrl,
-			     uint32_t *val);
-#endif
-
-#ifdef CONFIG_UART_DRV_CMD
-	int (*drv_cmd)(const struct device *dev, uint32_t cmd, uint32_t p);
-#endif
-
-};
-
-/** @endcond */
-
-/**
  * @brief Check whether an error was detected.
  *
  * @param dev UART device instance.
@@ -467,18 +330,6 @@ __subsystem struct uart_driver_api {
  * @retval -ENOSYS If not implemented.
  */
 __syscall int uart_err_check(const struct device *dev);
-
-static inline int z_impl_uart_err_check(const struct device *dev)
-{
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	if (api->err_check == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->err_check(dev);
-}
 
 /**
  * @defgroup uart_polling Polling UART API
@@ -505,19 +356,6 @@ static inline int z_impl_uart_err_check(const struct device *dev)
  */
 __syscall int uart_poll_in(const struct device *dev, unsigned char *p_char);
 
-static inline int z_impl_uart_poll_in(const struct device *dev,
-				      unsigned char *p_char)
-{
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	if (api->poll_in == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->poll_in(dev, p_char);
-}
-
 /**
  * @brief Read a 16-bit datum from the device for input.
  *
@@ -539,25 +377,6 @@ static inline int z_impl_uart_poll_in(const struct device *dev,
  */
 __syscall int uart_poll_in_u16(const struct device *dev, uint16_t *p_u16);
 
-static inline int z_impl_uart_poll_in_u16(const struct device *dev,
-					  uint16_t *p_u16)
-{
-#ifdef CONFIG_UART_WIDE_DATA
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	if (api->poll_in_u16 == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->poll_in_u16(dev, p_u16);
-#else
-	ARG_UNUSED(dev);
-	ARG_UNUSED(p_u16);
-	return -ENOTSUP;
-#endif
-}
-
 /**
  * @brief Write a character to the device for output.
  *
@@ -575,15 +394,6 @@ static inline int z_impl_uart_poll_in_u16(const struct device *dev,
 __syscall void uart_poll_out(const struct device *dev,
 			     unsigned char out_char);
 
-static inline void z_impl_uart_poll_out(const struct device *dev,
-					unsigned char out_char)
-{
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	api->poll_out(dev, out_char);
-}
-
 /**
  * @brief Write a 16-bit datum to the device for output.
  *
@@ -599,20 +409,6 @@ static inline void z_impl_uart_poll_out(const struct device *dev,
  * @param out_u16 Wide data to send.
  */
 __syscall void uart_poll_out_u16(const struct device *dev, uint16_t out_u16);
-
-static inline void z_impl_uart_poll_out_u16(const struct device *dev,
-					    uint16_t out_u16)
-{
-#ifdef CONFIG_UART_WIDE_DATA
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	api->poll_out_u16(dev, out_u16);
-#else
-	ARG_UNUSED(dev);
-	ARG_UNUSED(out_u16);
-#endif
-}
 
 /**
  * @}
@@ -635,24 +431,6 @@ static inline void z_impl_uart_poll_out_u16(const struct device *dev,
 __syscall int uart_configure(const struct device *dev,
 			     const struct uart_config *cfg);
 
-static inline int z_impl_uart_configure(const struct device *dev,
-					const struct uart_config *cfg)
-{
-#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
-	const struct uart_driver_api *api =
-				(const struct uart_driver_api *)dev->api;
-
-	if (api->configure == NULL) {
-		return -ENOSYS;
-	}
-	return api->configure(dev, cfg);
-#else
-	ARG_UNUSED(dev);
-	ARG_UNUSED(cfg);
-	return -ENOTSUP;
-#endif
-}
-
 /**
  * @brief Get UART configuration.
  *
@@ -669,25 +447,6 @@ static inline int z_impl_uart_configure(const struct device *dev,
  */
 __syscall int uart_config_get(const struct device *dev,
 			      struct uart_config *cfg);
-
-static inline int z_impl_uart_config_get(const struct device *dev,
-					 struct uart_config *cfg)
-{
-#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
-	const struct uart_driver_api *api =
-				(const struct uart_driver_api *)dev->api;
-
-	if (api->config_get == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->config_get(dev, cfg);
-#else
-	ARG_UNUSED(dev);
-	ARG_UNUSED(cfg);
-	return -ENOTSUP;
-#endif
-}
 
 /**
  * @addtogroup uart_interrupt
@@ -714,26 +473,7 @@ static inline int z_impl_uart_config_get(const struct device *dev,
  * @retval -ENOSYS  if this function is not supported
  * @retval -ENOTSUP If API is not enabled.
  */
-static inline int uart_fifo_fill(const struct device *dev,
-				 const uint8_t *tx_data,
-				 int size)
-{
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	if (api->fifo_fill == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->fifo_fill(dev, tx_data, size);
-#else
-	ARG_UNUSED(dev);
-	ARG_UNUSED(tx_data);
-	ARG_UNUSED(size);
-	return -ENOTSUP;
-#endif
-}
+static inline int uart_fifo_fill(const struct device *dev, const uint8_t *tx_data, int size);
 
 /**
  * @brief Fill FIFO with wide data.
@@ -755,26 +495,7 @@ static inline int uart_fifo_fill(const struct device *dev,
  * @retval -ENOSYS If this function is not implemented
  * @retval -ENOTSUP If API is not enabled.
  */
-static inline int uart_fifo_fill_u16(const struct device *dev,
-				     const uint16_t *tx_data,
-				     int size)
-{
-#if defined(CONFIG_UART_INTERRUPT_DRIVEN) && defined(CONFIG_UART_WIDE_DATA)
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	if (api->fifo_fill_u16 == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->fifo_fill_u16(dev, tx_data, size);
-#else
-	ARG_UNUSED(dev);
-	ARG_UNUSED(tx_data);
-	ARG_UNUSED(size);
-	return -ENOTSUP;
-#endif
-}
+static inline int uart_fifo_fill_u16(const struct device *dev, const uint16_t *tx_data, int size);
 
 /**
  * @brief Read data from FIFO.
@@ -797,25 +518,7 @@ static inline int uart_fifo_fill_u16(const struct device *dev,
  * @retval -ENOSYS If this function is not implemented.
  * @retval -ENOTSUP If API is not enabled.
  */
-static inline int uart_fifo_read(const struct device *dev, uint8_t *rx_data,
-				 const int size)
-{
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	if (api->fifo_read == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->fifo_read(dev, rx_data, size);
-#else
-	ARG_UNUSED(dev);
-	ARG_UNUSED(rx_data);
-	ARG_UNUSED(size);
-	return -ENOTSUP;
-#endif
-}
+static inline int uart_fifo_read(const struct device *dev, uint8_t *rx_data, const int size);
 
 /**
  * @brief Read wide data from FIFO.
@@ -838,26 +541,7 @@ static inline int uart_fifo_read(const struct device *dev, uint8_t *rx_data,
  * @retval -ENOSYS If this function is not implemented.
  * @retval -ENOTSUP If API is not enabled.
  */
-static inline int uart_fifo_read_u16(const struct device *dev,
-				     uint16_t *rx_data,
-				     const int size)
-{
-#if defined(CONFIG_UART_INTERRUPT_DRIVEN) && defined(CONFIG_UART_WIDE_DATA)
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	if (api->fifo_read_u16 == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->fifo_read_u16(dev, rx_data, size);
-#else
-	ARG_UNUSED(dev);
-	ARG_UNUSED(rx_data);
-	ARG_UNUSED(size);
-	return -ENOTSUP;
-#endif
-}
+static inline int uart_fifo_read_u16(const struct device *dev, uint16_t *rx_data, const int size);
 
 /**
  * @brief Enable TX interrupt in IER.
@@ -866,40 +550,12 @@ static inline int uart_fifo_read_u16(const struct device *dev,
  */
 __syscall void uart_irq_tx_enable(const struct device *dev);
 
-static inline void z_impl_uart_irq_tx_enable(const struct device *dev)
-{
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	if (api->irq_tx_enable != NULL) {
-		api->irq_tx_enable(dev);
-	}
-#else
-	ARG_UNUSED(dev);
-#endif
-}
-
 /**
  * @brief Disable TX interrupt in IER.
  *
  * @param dev UART device instance.
  */
 __syscall void uart_irq_tx_disable(const struct device *dev);
-
-static inline void z_impl_uart_irq_tx_disable(const struct device *dev)
-{
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	if (api->irq_tx_disable != NULL) {
-		api->irq_tx_disable(dev);
-	}
-#else
-	ARG_UNUSED(dev);
-#endif
-}
 
 /**
  * @brief Check if UART TX buffer can accept a new char
@@ -919,22 +575,7 @@ static inline void z_impl_uart_irq_tx_disable(const struct device *dev)
  * @retval -ENOSYS If this function is not implemented.
  * @retval -ENOTSUP If API is not enabled.
  */
-static inline int uart_irq_tx_ready(const struct device *dev)
-{
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	if (api->irq_tx_ready == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->irq_tx_ready(dev);
-#else
-	ARG_UNUSED(dev);
-	return -ENOTSUP;
-#endif
-}
+static inline int uart_irq_tx_ready(const struct device *dev);
 
 /**
  * @brief Enable RX interrupt.
@@ -943,40 +584,12 @@ static inline int uart_irq_tx_ready(const struct device *dev)
  */
 __syscall void uart_irq_rx_enable(const struct device *dev);
 
-static inline void z_impl_uart_irq_rx_enable(const struct device *dev)
-{
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	if (api->irq_rx_enable != NULL) {
-		api->irq_rx_enable(dev);
-	}
-#else
-	ARG_UNUSED(dev);
-#endif
-}
-
 /**
  * @brief Disable RX interrupt.
  *
  * @param dev UART device instance.
  */
 __syscall void uart_irq_rx_disable(const struct device *dev);
-
-static inline void z_impl_uart_irq_rx_disable(const struct device *dev)
-{
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	if (api->irq_rx_disable != NULL) {
-		api->irq_rx_disable(dev);
-	}
-#else
-	ARG_UNUSED(dev);
-#endif
-}
 
 /**
  * @brief Check if UART TX block finished transmission
@@ -997,21 +610,7 @@ static inline void z_impl_uart_irq_rx_disable(const struct device *dev)
  * @retval -ENOSYS If this function is not implemented.
  * @retval -ENOTSUP If API is not enabled.
  */
-static inline int uart_irq_tx_complete(const struct device *dev)
-{
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	if (api->irq_tx_complete == NULL) {
-		return -ENOSYS;
-	}
-	return api->irq_tx_complete(dev);
-#else
-	ARG_UNUSED(dev);
-	return -ENOTSUP;
-#endif
-}
+static inline int uart_irq_tx_complete(const struct device *dev);
 
 /**
  * @brief Check if UART RX buffer has a received char
@@ -1033,21 +632,8 @@ static inline int uart_irq_tx_complete(const struct device *dev)
  * @retval -ENOSYS If this function is not implemented.
  * @retval -ENOTSUP If API is not enabled.
  */
-static inline int uart_irq_rx_ready(const struct device *dev)
-{
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
+static inline int uart_irq_rx_ready(const struct device *dev);
 
-	if (api->irq_rx_ready == NULL) {
-		return -ENOSYS;
-	}
-	return api->irq_rx_ready(dev);
-#else
-	ARG_UNUSED(dev);
-	return -ENOTSUP;
-#endif
-}
 /**
  * @brief Enable error interrupt.
  *
@@ -1055,40 +641,12 @@ static inline int uart_irq_rx_ready(const struct device *dev)
  */
 __syscall void uart_irq_err_enable(const struct device *dev);
 
-static inline void z_impl_uart_irq_err_enable(const struct device *dev)
-{
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	if (api->irq_err_enable) {
-		api->irq_err_enable(dev);
-	}
-#else
-	ARG_UNUSED(dev);
-#endif
-}
-
 /**
  * @brief Disable error interrupt.
  *
  * @param dev UART device instance.
  */
 __syscall void uart_irq_err_disable(const struct device *dev);
-
-static inline void z_impl_uart_irq_err_disable(const struct device *dev)
-{
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	if (api->irq_err_disable) {
-		api->irq_err_disable(dev);
-	}
-#else
-	ARG_UNUSED(dev);
-#endif
-}
 
 /**
  * @brief Check if any IRQs is pending.
@@ -1101,22 +659,6 @@ static inline void z_impl_uart_irq_err_disable(const struct device *dev)
  * @retval -ENOTSUP If API is not enabled.
  */
 __syscall int uart_irq_is_pending(const struct device *dev);
-
-static inline int z_impl_uart_irq_is_pending(const struct device *dev)
-{
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	if (api->irq_is_pending == NULL) {
-		return -ENOSYS;
-	}
-	return api->irq_is_pending(dev);
-#else
-	ARG_UNUSED(dev);
-	return -ENOTSUP;
-#endif
-}
 
 /**
  * @brief Start processing interrupts in ISR.
@@ -1145,22 +687,6 @@ static inline int z_impl_uart_irq_is_pending(const struct device *dev)
  */
 __syscall int uart_irq_update(const struct device *dev);
 
-static inline int z_impl_uart_irq_update(const struct device *dev)
-{
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	if (api->irq_update == NULL) {
-		return -ENOSYS;
-	}
-	return api->irq_update(dev);
-#else
-	ARG_UNUSED(dev);
-	return -ENOTSUP;
-#endif
-}
-
 /**
  * @brief Set the IRQ callback function pointer.
  *
@@ -1178,25 +704,7 @@ static inline int z_impl_uart_irq_update(const struct device *dev)
  */
 static inline int uart_irq_callback_user_data_set(const struct device *dev,
 						  uart_irq_callback_user_data_t cb,
-						  void *user_data)
-{
-#ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	if ((api != NULL) && (api->irq_callback_set != NULL)) {
-		api->irq_callback_set(dev, cb, user_data);
-		return 0;
-	} else {
-		return -ENOSYS;
-	}
-#else
-	ARG_UNUSED(dev);
-	ARG_UNUSED(cb);
-	ARG_UNUSED(user_data);
-	return -ENOTSUP;
-#endif
-}
+						  void *user_data);
 
 /**
  * @brief Set the IRQ callback function pointer (legacy).
@@ -1212,10 +720,7 @@ static inline int uart_irq_callback_user_data_set(const struct device *dev,
  * @retval -ENOTSUP If API is not enabled.
  */
 static inline int uart_irq_callback_set(const struct device *dev,
-					 uart_irq_callback_user_data_t cb)
-{
-	return uart_irq_callback_user_data_set(dev, cb, NULL);
-}
+					 uart_irq_callback_user_data_t cb);
 
 /**
  * @}
@@ -1243,24 +748,7 @@ static inline int uart_irq_callback_set(const struct device *dev,
  */
 static inline int uart_callback_set(const struct device *dev,
 				    uart_callback_t callback,
-				    void *user_data)
-{
-#ifdef CONFIG_UART_ASYNC_API
-	const struct uart_driver_api *api =
-			(const struct uart_driver_api *)dev->api;
-
-	if (api->callback_set == NULL) {
-		return -ENOSYS;
-	}
-
-	return api->callback_set(dev, callback, user_data);
-#else
-	ARG_UNUSED(dev);
-	ARG_UNUSED(callback);
-	ARG_UNUSED(user_data);
-	return -ENOTSUP;
-#endif
-}
+				    void *user_data);
 
 /**
  * @brief Send given number of bytes from buffer through UART.
@@ -1283,24 +771,6 @@ __syscall int uart_tx(const struct device *dev, const uint8_t *buf,
 		      size_t len,
 		      int32_t timeout);
 
-static inline int z_impl_uart_tx(const struct device *dev, const uint8_t *buf,
-				 size_t len, int32_t timeout)
-
-{
-#ifdef CONFIG_UART_ASYNC_API
-	const struct uart_driver_api *api =
-			(const struct uart_driver_api *)dev->api;
-
-	return api->tx(dev, buf, len, timeout);
-#else
-	ARG_UNUSED(dev);
-	ARG_UNUSED(buf);
-	ARG_UNUSED(len);
-	ARG_UNUSED(timeout);
-	return -ENOTSUP;
-#endif
-}
-
 /**
  * @brief Send given number of datum from buffer through UART.
  *
@@ -1321,25 +791,6 @@ static inline int z_impl_uart_tx(const struct device *dev, const uint8_t *buf,
 __syscall int uart_tx_u16(const struct device *dev, const uint16_t *buf,
 			  size_t len, int32_t timeout);
 
-static inline int z_impl_uart_tx_u16(const struct device *dev,
-				     const uint16_t *buf,
-				     size_t len, int32_t timeout)
-
-{
-#if defined(CONFIG_UART_ASYNC_API) && defined(CONFIG_UART_WIDE_DATA)
-	const struct uart_driver_api *api =
-			(const struct uart_driver_api *)dev->api;
-
-	return api->tx_u16(dev, buf, len, timeout);
-#else
-	ARG_UNUSED(dev);
-	ARG_UNUSED(buf);
-	ARG_UNUSED(len);
-	ARG_UNUSED(timeout);
-	return -ENOTSUP;
-#endif
-}
-
 /**
  * @brief Abort current TX transmission.
  *
@@ -1353,19 +804,6 @@ static inline int z_impl_uart_tx_u16(const struct device *dev,
  * @retval -errno Other negative errno value in case of failure.
  */
 __syscall int uart_tx_abort(const struct device *dev);
-
-static inline int z_impl_uart_tx_abort(const struct device *dev)
-{
-#ifdef CONFIG_UART_ASYNC_API
-	const struct uart_driver_api *api =
-			(const struct uart_driver_api *)dev->api;
-
-	return api->tx_abort(dev);
-#else
-	ARG_UNUSED(dev);
-	return -ENOTSUP;
-#endif
-}
 
 /**
  * @brief Start receiving data through UART.
@@ -1392,24 +830,6 @@ __syscall int uart_rx_enable(const struct device *dev, uint8_t *buf,
 			     size_t len,
 			     int32_t timeout);
 
-static inline int z_impl_uart_rx_enable(const struct device *dev,
-					uint8_t *buf,
-					size_t len, int32_t timeout)
-{
-#ifdef CONFIG_UART_ASYNC_API
-	const struct uart_driver_api *api =
-				(const struct uart_driver_api *)dev->api;
-
-	return api->rx_enable(dev, buf, len, timeout);
-#else
-	ARG_UNUSED(dev);
-	ARG_UNUSED(buf);
-	ARG_UNUSED(len);
-	ARG_UNUSED(timeout);
-	return -ENOTSUP;
-#endif
-}
-
 /**
  * @brief Start receiving wide data through UART.
  *
@@ -1434,24 +854,6 @@ static inline int z_impl_uart_rx_enable(const struct device *dev,
 __syscall int uart_rx_enable_u16(const struct device *dev, uint16_t *buf,
 				 size_t len, int32_t timeout);
 
-static inline int z_impl_uart_rx_enable_u16(const struct device *dev,
-					    uint16_t *buf, size_t len,
-					    int32_t timeout)
-{
-#if defined(CONFIG_UART_ASYNC_API) && defined(CONFIG_UART_WIDE_DATA)
-	const struct uart_driver_api *api =
-				(const struct uart_driver_api *)dev->api;
-
-	return api->rx_enable_u16(dev, buf, len, timeout);
-#else
-	ARG_UNUSED(dev);
-	ARG_UNUSED(buf);
-	ARG_UNUSED(len);
-	ARG_UNUSED(timeout);
-	return -ENOTSUP;
-#endif
-}
-
 /**
  * @brief Provide receive buffer in response to #UART_RX_BUF_REQUEST event.
  *
@@ -1473,20 +875,7 @@ static inline int z_impl_uart_rx_enable_u16(const struct device *dev,
  * @retval -errno Other negative errno value in case of failure.
  */
 static inline int uart_rx_buf_rsp(const struct device *dev, uint8_t *buf,
-				  size_t len)
-{
-#ifdef CONFIG_UART_ASYNC_API
-	const struct uart_driver_api *api =
-				(const struct uart_driver_api *)dev->api;
-
-	return api->rx_buf_rsp(dev, buf, len);
-#else
-	ARG_UNUSED(dev);
-	ARG_UNUSED(buf);
-	ARG_UNUSED(len);
-	return -ENOTSUP;
-#endif
-}
+				  size_t len);
 
 /**
  * @brief Provide wide data receive buffer in response to #UART_RX_BUF_REQUEST
@@ -1510,20 +899,7 @@ static inline int uart_rx_buf_rsp(const struct device *dev, uint8_t *buf,
  * @retval -errno Other negative errno value in case of failure.
  */
 static inline int uart_rx_buf_rsp_u16(const struct device *dev, uint16_t *buf,
-				      size_t len)
-{
-#if defined(CONFIG_UART_ASYNC_API) && defined(CONFIG_UART_WIDE_DATA)
-	const struct uart_driver_api *api =
-				(const struct uart_driver_api *)dev->api;
-
-	return api->rx_buf_rsp_u16(dev, buf, len);
-#else
-	ARG_UNUSED(dev);
-	ARG_UNUSED(buf);
-	ARG_UNUSED(len);
-	return -ENOTSUP;
-#endif
-}
+				      size_t len);
 
 /**
  * @brief Disable RX
@@ -1541,19 +917,6 @@ static inline int uart_rx_buf_rsp_u16(const struct device *dev, uint16_t *buf,
  * @retval -errno Other negative errno value in case of failure.
  */
 __syscall int uart_rx_disable(const struct device *dev);
-
-static inline int z_impl_uart_rx_disable(const struct device *dev)
-{
-#ifdef CONFIG_UART_ASYNC_API
-	const struct uart_driver_api *api =
-			(const struct uart_driver_api *)dev->api;
-
-	return api->rx_disable(dev);
-#else
-	ARG_UNUSED(dev);
-	return -ENOTSUP;
-#endif
-}
 
 /**
  * @}
@@ -1574,25 +937,6 @@ static inline int z_impl_uart_rx_disable(const struct device *dev)
 __syscall int uart_line_ctrl_set(const struct device *dev,
 				 uint32_t ctrl, uint32_t val);
 
-static inline int z_impl_uart_line_ctrl_set(const struct device *dev,
-					    uint32_t ctrl, uint32_t val)
-{
-#ifdef CONFIG_UART_LINE_CTRL
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	if (api->line_ctrl_set == NULL) {
-		return -ENOSYS;
-	}
-	return api->line_ctrl_set(dev, ctrl, val);
-#else
-	ARG_UNUSED(dev);
-	ARG_UNUSED(ctrl);
-	ARG_UNUSED(val);
-	return -ENOTSUP;
-#endif
-}
-
 /**
  * @brief Retrieve line control for UART.
  *
@@ -1607,25 +951,6 @@ static inline int z_impl_uart_line_ctrl_set(const struct device *dev,
  */
 __syscall int uart_line_ctrl_get(const struct device *dev, uint32_t ctrl,
 				 uint32_t *val);
-
-static inline int z_impl_uart_line_ctrl_get(const struct device *dev,
-					    uint32_t ctrl, uint32_t *val)
-{
-#ifdef CONFIG_UART_LINE_CTRL
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	if (api->line_ctrl_get == NULL) {
-		return -ENOSYS;
-	}
-	return api->line_ctrl_get(dev, ctrl, val);
-#else
-	ARG_UNUSED(dev);
-	ARG_UNUSED(ctrl);
-	ARG_UNUSED(val);
-	return -ENOTSUP;
-#endif
-}
 
 /**
  * @brief Send extra command to driver.
@@ -1644,25 +969,6 @@ static inline int z_impl_uart_line_ctrl_get(const struct device *dev,
  */
 __syscall int uart_drv_cmd(const struct device *dev, uint32_t cmd, uint32_t p);
 
-static inline int z_impl_uart_drv_cmd(const struct device *dev, uint32_t cmd,
-				      uint32_t p)
-{
-#ifdef CONFIG_UART_DRV_CMD
-	const struct uart_driver_api *api =
-		(const struct uart_driver_api *)dev->api;
-
-	if (api->drv_cmd == NULL) {
-		return -ENOSYS;
-	}
-	return api->drv_cmd(dev, cmd, p);
-#else
-	ARG_UNUSED(dev);
-	ARG_UNUSED(cmd);
-	ARG_UNUSED(p);
-	return -ENOTSUP;
-#endif
-}
-
 #ifdef __cplusplus
 }
 #endif
@@ -1671,6 +977,7 @@ static inline int z_impl_uart_drv_cmd(const struct device *dev, uint32_t cmd,
  * @}
  */
 
+#include <zephyr/drivers/uart/uart_internal.h>
 #include <zephyr/syscalls/uart.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_UART_H_ */

--- a/include/zephyr/drivers/uart/uart_internal.h
+++ b/include/zephyr/drivers/uart/uart_internal.h
@@ -1,0 +1,679 @@
+/*
+ * Copyright (c) 2018-2019 Nordic Semiconductor ASA
+ * Copyright (c) 2015 Wind River Systems, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Internal APIs for UART drivers
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_UART_UART_INTERNAL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_UART_UART_INTERNAL_H_
+
+#include <errno.h>
+#include <stddef.h>
+
+#include <zephyr/device.h>
+
+/**
+ * @cond INTERNAL_HIDDEN
+ *
+ * For internal driver use only, skip these in public documentation.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief For configuring IRQ on each individual UART device.
+ *
+ * @param dev UART device instance.
+ */
+typedef void (*uart_irq_config_func_t)(const struct device *dev);
+
+/** @brief Driver API structure. */
+__subsystem struct uart_driver_api {
+
+#ifdef CONFIG_UART_ASYNC_API
+
+	int (*callback_set)(const struct device *dev, uart_callback_t callback, void *user_data);
+
+	int (*tx)(const struct device *dev, const uint8_t *buf, size_t len, int32_t timeout);
+	int (*tx_abort)(const struct device *dev);
+
+	int (*rx_enable)(const struct device *dev, uint8_t *buf, size_t len, int32_t timeout);
+	int (*rx_buf_rsp)(const struct device *dev, uint8_t *buf, size_t len);
+	int (*rx_disable)(const struct device *dev);
+
+#ifdef CONFIG_UART_WIDE_DATA
+	int (*tx_u16)(const struct device *dev, const uint16_t *buf, size_t len, int32_t timeout);
+	int (*rx_enable_u16)(const struct device *dev, uint16_t *buf, size_t len, int32_t timeout);
+	int (*rx_buf_rsp_u16)(const struct device *dev, uint16_t *buf, size_t len);
+#endif
+
+#endif
+
+	/** Console I/O function */
+	int (*poll_in)(const struct device *dev, unsigned char *p_char);
+	void (*poll_out)(const struct device *dev, unsigned char out_char);
+
+#ifdef CONFIG_UART_WIDE_DATA
+	int (*poll_in_u16)(const struct device *dev, uint16_t *p_u16);
+	void (*poll_out_u16)(const struct device *dev, uint16_t out_u16);
+#endif
+
+	/** Console I/O function */
+	int (*err_check)(const struct device *dev);
+
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
+	/** UART configuration functions */
+	int (*configure)(const struct device *dev, const struct uart_config *cfg);
+	int (*config_get)(const struct device *dev, struct uart_config *cfg);
+#endif
+
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+
+	/** Interrupt driven FIFO fill function */
+	int (*fifo_fill)(const struct device *dev, const uint8_t *tx_data, int len);
+
+#ifdef CONFIG_UART_WIDE_DATA
+	int (*fifo_fill_u16)(const struct device *dev, const uint16_t *tx_data, int len);
+#endif
+
+	/** Interrupt driven FIFO read function */
+	int (*fifo_read)(const struct device *dev, uint8_t *rx_data, const int size);
+
+#ifdef CONFIG_UART_WIDE_DATA
+	int (*fifo_read_u16)(const struct device *dev, uint16_t *rx_data, const int size);
+#endif
+
+	/** Interrupt driven transfer enabling function */
+	void (*irq_tx_enable)(const struct device *dev);
+
+	/** Interrupt driven transfer disabling function */
+	void (*irq_tx_disable)(const struct device *dev);
+
+	/** Interrupt driven transfer ready function */
+	int (*irq_tx_ready)(const struct device *dev);
+
+	/** Interrupt driven receiver enabling function */
+	void (*irq_rx_enable)(const struct device *dev);
+
+	/** Interrupt driven receiver disabling function */
+	void (*irq_rx_disable)(const struct device *dev);
+
+	/** Interrupt driven transfer complete function */
+	int (*irq_tx_complete)(const struct device *dev);
+
+	/** Interrupt driven receiver ready function */
+	int (*irq_rx_ready)(const struct device *dev);
+
+	/** Interrupt driven error enabling function */
+	void (*irq_err_enable)(const struct device *dev);
+
+	/** Interrupt driven error disabling function */
+	void (*irq_err_disable)(const struct device *dev);
+
+	/** Interrupt driven pending status function */
+	int (*irq_is_pending)(const struct device *dev);
+
+	/** Interrupt driven interrupt update function */
+	int (*irq_update)(const struct device *dev);
+
+	/** Set the irq callback function */
+	void (*irq_callback_set)(const struct device *dev, uart_irq_callback_user_data_t cb,
+				 void *user_data);
+
+#endif
+
+#ifdef CONFIG_UART_LINE_CTRL
+	int (*line_ctrl_set)(const struct device *dev, uint32_t ctrl, uint32_t val);
+	int (*line_ctrl_get)(const struct device *dev, uint32_t ctrl, uint32_t *val);
+#endif
+
+#ifdef CONFIG_UART_DRV_CMD
+	int (*drv_cmd)(const struct device *dev, uint32_t cmd, uint32_t p);
+#endif
+};
+
+static inline int z_impl_uart_err_check(const struct device *dev)
+{
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
+
+	if (api->err_check == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->err_check(dev);
+}
+
+static inline int z_impl_uart_poll_in(const struct device *dev, unsigned char *p_char)
+{
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
+
+	if (api->poll_in == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->poll_in(dev, p_char);
+}
+
+static inline int z_impl_uart_poll_in_u16(const struct device *dev, uint16_t *p_u16)
+{
+#ifdef CONFIG_UART_WIDE_DATA
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
+
+	if (api->poll_in_u16 == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->poll_in_u16(dev, p_u16);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(p_u16);
+	return -ENOTSUP;
+#endif
+}
+
+static inline void z_impl_uart_poll_out(const struct device *dev, unsigned char out_char)
+{
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
+
+	api->poll_out(dev, out_char);
+}
+
+static inline void z_impl_uart_poll_out_u16(const struct device *dev, uint16_t out_u16)
+{
+#ifdef CONFIG_UART_WIDE_DATA
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
+
+	api->poll_out_u16(dev, out_u16);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(out_u16);
+#endif
+}
+
+static inline int z_impl_uart_configure(const struct device *dev, const struct uart_config *cfg)
+{
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
+
+	if (api->configure == NULL) {
+		return -ENOSYS;
+	}
+	return api->configure(dev, cfg);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(cfg);
+	return -ENOTSUP;
+#endif
+}
+
+static inline int z_impl_uart_config_get(const struct device *dev, struct uart_config *cfg)
+{
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
+
+	if (api->config_get == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->config_get(dev, cfg);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(cfg);
+	return -ENOTSUP;
+#endif
+}
+
+static inline int uart_fifo_fill(const struct device *dev, const uint8_t *tx_data, int size)
+{
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
+
+	if (api->fifo_fill == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->fifo_fill(dev, tx_data, size);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(tx_data);
+	ARG_UNUSED(size);
+	return -ENOTSUP;
+#endif
+}
+
+static inline int uart_fifo_fill_u16(const struct device *dev, const uint16_t *tx_data, int size)
+{
+#if defined(CONFIG_UART_INTERRUPT_DRIVEN) && defined(CONFIG_UART_WIDE_DATA)
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
+
+	if (api->fifo_fill_u16 == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->fifo_fill_u16(dev, tx_data, size);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(tx_data);
+	ARG_UNUSED(size);
+	return -ENOTSUP;
+#endif
+}
+
+static inline int uart_fifo_read(const struct device *dev, uint8_t *rx_data, const int size)
+{
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
+
+	if (api->fifo_read == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->fifo_read(dev, rx_data, size);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(rx_data);
+	ARG_UNUSED(size);
+	return -ENOTSUP;
+#endif
+}
+
+static inline int uart_fifo_read_u16(const struct device *dev, uint16_t *rx_data, const int size)
+{
+#if defined(CONFIG_UART_INTERRUPT_DRIVEN) && defined(CONFIG_UART_WIDE_DATA)
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
+
+	if (api->fifo_read_u16 == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->fifo_read_u16(dev, rx_data, size);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(rx_data);
+	ARG_UNUSED(size);
+	return -ENOTSUP;
+#endif
+}
+
+static inline void z_impl_uart_irq_tx_enable(const struct device *dev)
+{
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
+
+	if (api->irq_tx_enable != NULL) {
+		api->irq_tx_enable(dev);
+	}
+#else
+	ARG_UNUSED(dev);
+#endif
+}
+
+static inline void z_impl_uart_irq_tx_disable(const struct device *dev)
+{
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
+
+	if (api->irq_tx_disable != NULL) {
+		api->irq_tx_disable(dev);
+	}
+#else
+	ARG_UNUSED(dev);
+#endif
+}
+
+static inline int uart_irq_tx_ready(const struct device *dev)
+{
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
+
+	if (api->irq_tx_ready == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->irq_tx_ready(dev);
+#else
+	ARG_UNUSED(dev);
+	return -ENOTSUP;
+#endif
+}
+
+static inline void z_impl_uart_irq_rx_enable(const struct device *dev)
+{
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
+
+	if (api->irq_rx_enable != NULL) {
+		api->irq_rx_enable(dev);
+	}
+#else
+	ARG_UNUSED(dev);
+#endif
+}
+
+static inline void z_impl_uart_irq_rx_disable(const struct device *dev)
+{
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
+
+	if (api->irq_rx_disable != NULL) {
+		api->irq_rx_disable(dev);
+	}
+#else
+	ARG_UNUSED(dev);
+#endif
+}
+
+static inline int uart_irq_tx_complete(const struct device *dev)
+{
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
+
+	if (api->irq_tx_complete == NULL) {
+		return -ENOSYS;
+	}
+	return api->irq_tx_complete(dev);
+#else
+	ARG_UNUSED(dev);
+	return -ENOTSUP;
+#endif
+}
+
+static inline int uart_irq_rx_ready(const struct device *dev)
+{
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
+
+	if (api->irq_rx_ready == NULL) {
+		return -ENOSYS;
+	}
+	return api->irq_rx_ready(dev);
+#else
+	ARG_UNUSED(dev);
+	return -ENOTSUP;
+#endif
+}
+
+static inline void z_impl_uart_irq_err_enable(const struct device *dev)
+{
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
+
+	if (api->irq_err_enable) {
+		api->irq_err_enable(dev);
+	}
+#else
+	ARG_UNUSED(dev);
+#endif
+}
+
+static inline void z_impl_uart_irq_err_disable(const struct device *dev)
+{
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
+
+	if (api->irq_err_disable) {
+		api->irq_err_disable(dev);
+	}
+#else
+	ARG_UNUSED(dev);
+#endif
+}
+
+static inline int z_impl_uart_irq_is_pending(const struct device *dev)
+{
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
+
+	if (api->irq_is_pending == NULL) {
+		return -ENOSYS;
+	}
+	return api->irq_is_pending(dev);
+#else
+	ARG_UNUSED(dev);
+	return -ENOTSUP;
+#endif
+}
+
+static inline int z_impl_uart_irq_update(const struct device *dev)
+{
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
+
+	if (api->irq_update == NULL) {
+		return -ENOSYS;
+	}
+	return api->irq_update(dev);
+#else
+	ARG_UNUSED(dev);
+	return -ENOTSUP;
+#endif
+}
+
+static inline int uart_irq_callback_user_data_set(const struct device *dev,
+						  uart_irq_callback_user_data_t cb, void *user_data)
+{
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
+
+	if ((api != NULL) && (api->irq_callback_set != NULL)) {
+		api->irq_callback_set(dev, cb, user_data);
+		return 0;
+	} else {
+		return -ENOSYS;
+	}
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(cb);
+	ARG_UNUSED(user_data);
+	return -ENOTSUP;
+#endif
+}
+
+static inline int uart_irq_callback_set(const struct device *dev, uart_irq_callback_user_data_t cb)
+{
+	return uart_irq_callback_user_data_set(dev, cb, NULL);
+}
+
+static inline int uart_callback_set(const struct device *dev, uart_callback_t callback,
+				    void *user_data)
+{
+#ifdef CONFIG_UART_ASYNC_API
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
+
+	if (api->callback_set == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->callback_set(dev, callback, user_data);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(callback);
+	ARG_UNUSED(user_data);
+	return -ENOTSUP;
+#endif
+}
+
+static inline int z_impl_uart_tx(const struct device *dev, const uint8_t *buf, size_t len,
+				 int32_t timeout)
+
+{
+#ifdef CONFIG_UART_ASYNC_API
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
+
+	return api->tx(dev, buf, len, timeout);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(buf);
+	ARG_UNUSED(len);
+	ARG_UNUSED(timeout);
+	return -ENOTSUP;
+#endif
+}
+
+static inline int z_impl_uart_tx_u16(const struct device *dev, const uint16_t *buf, size_t len,
+				     int32_t timeout)
+
+{
+#if defined(CONFIG_UART_ASYNC_API) && defined(CONFIG_UART_WIDE_DATA)
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
+
+	return api->tx_u16(dev, buf, len, timeout);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(buf);
+	ARG_UNUSED(len);
+	ARG_UNUSED(timeout);
+	return -ENOTSUP;
+#endif
+}
+
+static inline int z_impl_uart_tx_abort(const struct device *dev)
+{
+#ifdef CONFIG_UART_ASYNC_API
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
+
+	return api->tx_abort(dev);
+#else
+	ARG_UNUSED(dev);
+	return -ENOTSUP;
+#endif
+}
+
+static inline int z_impl_uart_rx_enable(const struct device *dev, uint8_t *buf, size_t len,
+					int32_t timeout)
+{
+#ifdef CONFIG_UART_ASYNC_API
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
+
+	return api->rx_enable(dev, buf, len, timeout);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(buf);
+	ARG_UNUSED(len);
+	ARG_UNUSED(timeout);
+	return -ENOTSUP;
+#endif
+}
+
+static inline int z_impl_uart_rx_enable_u16(const struct device *dev, uint16_t *buf, size_t len,
+					    int32_t timeout)
+{
+#if defined(CONFIG_UART_ASYNC_API) && defined(CONFIG_UART_WIDE_DATA)
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
+
+	return api->rx_enable_u16(dev, buf, len, timeout);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(buf);
+	ARG_UNUSED(len);
+	ARG_UNUSED(timeout);
+	return -ENOTSUP;
+#endif
+}
+
+static inline int uart_rx_buf_rsp(const struct device *dev, uint8_t *buf, size_t len)
+{
+#ifdef CONFIG_UART_ASYNC_API
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
+
+	return api->rx_buf_rsp(dev, buf, len);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(buf);
+	ARG_UNUSED(len);
+	return -ENOTSUP;
+#endif
+}
+
+static inline int uart_rx_buf_rsp_u16(const struct device *dev, uint16_t *buf, size_t len)
+{
+#if defined(CONFIG_UART_ASYNC_API) && defined(CONFIG_UART_WIDE_DATA)
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
+
+	return api->rx_buf_rsp_u16(dev, buf, len);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(buf);
+	ARG_UNUSED(len);
+	return -ENOTSUP;
+#endif
+}
+
+static inline int z_impl_uart_rx_disable(const struct device *dev)
+{
+#ifdef CONFIG_UART_ASYNC_API
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
+
+	return api->rx_disable(dev);
+#else
+	ARG_UNUSED(dev);
+	return -ENOTSUP;
+#endif
+}
+
+static inline int z_impl_uart_line_ctrl_set(const struct device *dev, uint32_t ctrl, uint32_t val)
+{
+#ifdef CONFIG_UART_LINE_CTRL
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
+
+	if (api->line_ctrl_set == NULL) {
+		return -ENOSYS;
+	}
+	return api->line_ctrl_set(dev, ctrl, val);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(ctrl);
+	ARG_UNUSED(val);
+	return -ENOTSUP;
+#endif
+}
+
+static inline int z_impl_uart_line_ctrl_get(const struct device *dev, uint32_t ctrl, uint32_t *val)
+{
+#ifdef CONFIG_UART_LINE_CTRL
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
+
+	if (api->line_ctrl_get == NULL) {
+		return -ENOSYS;
+	}
+	return api->line_ctrl_get(dev, ctrl, val);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(ctrl);
+	ARG_UNUSED(val);
+	return -ENOTSUP;
+#endif
+}
+
+static inline int z_impl_uart_drv_cmd(const struct device *dev, uint32_t cmd, uint32_t p)
+{
+#ifdef CONFIG_UART_DRV_CMD
+	const struct uart_driver_api *api = (const struct uart_driver_api *)dev->api;
+
+	if (api->drv_cmd == NULL) {
+		return -ENOSYS;
+	}
+	return api->drv_cmd(dev, cmd, p);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(p);
+	return -ENOTSUP;
+#endif
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @endcond */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_UART_UART_INTERNAL_H_ */


### PR DESCRIPTION
This refactors internal bits out of the public API header file and into its own file. This includes:

* Driver API struct which is only used by driver implementations but not by users of API.
* Inline implementations of various APIs.
* Inline z_impl_*.

These are implementation details that do not need to live within the public API header file. This de-clutters the public header file.