### PR TITLE
net: shell: cm: Fix snprintf warnings on NEWLIBC

### DIFF
--- a/subsys/net/lib/shell/cm.c
+++ b/subsys/net/lib/shell/cm.c
@@ -368,10 +368,10 @@ static void cm_get_iface_info(struct net_if *iface, char *buf, size_t len)
 		strcpy(name, CM_IF_NAME_NONE);
 	}
 
-	snprintf(buf, len, "%d (%p - %s - %s)", net_if_get_by_iface(iface), iface, name,
+	snprintk(buf, len, "%d (%p - %s - %s)", net_if_get_by_iface(iface), iface, name,
 						iface2str(iface, NULL));
 #else
-	snprintf(buf, len, "%d (%p - %s)", net_if_get_by_iface(iface), iface,
+	snprintk(buf, len, "%d (%p - %s)", net_if_get_by_iface(iface), iface,
 					   iface2str(iface, NULL));
 #endif
 }


### PR DESCRIPTION
Building with NEWLIBC triggers warnings about
snprintf since stdio is no longer automatically
included by printk.h

This PR switches to using snprintk to avoid these
warnings.

Fixes #77330