### PR TITLE
twister: runner: j-link: Fix parameter passing

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
@@ -86,7 +86,8 @@ class HardwareAdapter(DeviceAdapter):
                 extra_args.append("--cmd-pre-init")
                 extra_args.append(f'adapter serial {board_id}')
             elif runner == 'jlink':
-                base_args.append(f'--dev-id {board_id}')
+                base_args.append('--dev-id')
+                base_args.append(board_id)
             elif runner == 'stm32cubeprogrammer':
                 base_args.append(f'--tool-opt=sn={board_id}')
             elif runner == 'linkserver':

--- a/scripts/pylib/pytest-twister-harness/tests/device/hardware_adapter_test.py
+++ b/scripts/pylib/pytest-twister-harness/tests/device/hardware_adapter_test.py
@@ -99,7 +99,7 @@ def test_if_get_command_returns_proper_string_6(patched_which, device: HardwareA
     assert isinstance(device.command, list)
     assert device.command == [
         'west', 'flash', '--skip-rebuild', '--build-dir', 'build', '--runner', 'jlink',
-        '--dev-id p_id'
+        '--dev-id', 'p_id'
     ]
 
 


### PR DESCRIPTION
To specify the serial number, JLink expects either one argument
('--dev-id=xxx') or two (e.g. '--dev-id' 'xxx'), but it can not deal
with a single one that is '--dev-id xxx'.

The problem has been introduced (or just made visible?) by commit
5ee42843205dcdfa1c9833282613731dee75c93c (twister: runner: j-link: use
dev-id instead of SelectEmuBySN) in PR #76931.

How to reproduce:

1. Create a HW configuration map, e.g.:

```
$ cat zephyr-hw-map-nrf52840dk-1.yml
- connected: true
  id: '683517317'
  platform: nrf52840dk/nrf52840
  product: nRF52840 DK 1
  runner: jlink
  serial: /dev/ttyACM-nrf-dk-1
```

2. Run test `logging.dictionary` with Twister:

```
$ west twister --platform nrf52840dk/nrf52840 --device-testing \
  --hardware-map zephyr-hw-map-nrf52840dk-1.yml -s logging.dictionary
```

3. The build will fail, and the `twister_harness.log` contains:

```
10:21:24.375:DEBUG:twister_harness.device.factory: Get device type "hardware"
10:21:24.375:DEBUG:twister_harness.device.hardware_adapter: Opening
  serial connection for /dev/ttyACM-nrf-dk-1
10:21:24.376:DEBUG:twister_harness.device.hardware_adapter: Flashing
  device 683517317
10:21:24.376:DEBUG:twister_harness.device.hardware_adapter: Flashing
  command: <snip>/bin/west flash --skip-rebuild --build-dir
  <snip>/twister-out/<snip>/tests/subsys/logging/dictionary/logging.dictionary
  --runner jlink '--dev-id 683517317'
10:21:24.590:ERROR:twister_harness.device.hardware_adapter: Could not
  flash device 683517317
10:21:24.592:DEBUG:twister_harness.device.hardware_adapter: Closed
  serial connection for /dev/ttyACM-nrf-dk-1
```
(note the '--dev-id 683517317' part)

4. Running the stated `west flash` command shows the following error
   message:

```
-- west flash: using runner jlink
FATAL ERROR: runner jlink received unknown arguments: ['--dev-id 683517317']
```