### PR TITLE
kernel: mmu: support for on-demand mappings

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -764,6 +764,13 @@ config ARCH_HAS_DEMAND_PAGING
 	  This hidden configuration should be selected by the architecture if
 	  demand paging is supported.
 
+config ARCH_HAS_DEMAND_MAPPING
+	bool
+	help
+	  This hidden configuration should be selected by the architecture if
+	  demand paging is supported and arch_mem_map() supports
+	  K_MEM_MAP_UNPAGED.
+
 config ARCH_HAS_RESERVED_PAGE_FRAMES
 	bool
 	help

--- a/include/zephyr/kernel/mm.h
+++ b/include/zephyr/kernel/mm.h
@@ -114,6 +114,25 @@ extern "C" {
  */
 #define K_MEM_MAP_LOCK		BIT(17)
 
+/**
+ * Region will be unpaged i.e. not mapped into memory
+ *
+ * This is meant to be used by kernel code and not by application code.
+ *
+ * Corresponding memory address range will be set so no actual memory will
+ * be allocated initially. Allocation will happen through demand paging when
+ * addresses in that range are accessed. This is incompatible with
+ * K_MEM_MAP_LOCK.
+ *
+ * When this flag is specified, the phys argument to arch_mem_map()
+ * is interpreted as a backing store location value not a physical address.
+ * This is very similar to arch_mem_page_out() in that regard.
+ * Two special location values are defined: ARCH_UNPAGED_ANON_ZERO and
+ * ARCH_UNPAGED_ANON_UNINIT. Those are to be used with anonymous memory
+ * mappings for zeroed and uninitialized pages respectively.
+ */
+#define K_MEM_MAP_UNPAGED	BIT(18)
+
 /** @} */
 
 /**
@@ -172,6 +191,54 @@ static inline void *k_mem_map(size_t size, uint32_t flags)
 {
 	return k_mem_map_phys_guard((uintptr_t)NULL, size, flags, true);
 }
+
+#ifdef CONFIG_DEMAND_MAPPING
+/**
+ * Create an unpaged mapping
+ *
+ * This maps backing-store "location" tokens into Zephyr's address space.
+ * Corresponding memory address range will be set so no actual memory will
+ * be allocated initially. Allocation will happen through demand paging when
+ * addresses in the mapped range are accessed.
+ *
+ * The kernel will choose a base virtual address and return it to the caller.
+ * The memory access permissions for all contexts will be set per the
+ * provided flags argument.
+ *
+ * If user thread access control needs to be managed in any way, do not enable
+ * K_MEM_PERM_USER flags here; instead manage the region's permissions
+ * with memory domain APIs after the mapping has been established. Setting
+ * K_MEM_PERM_USER here will allow all user threads to access this memory
+ * which is usually undesirable.
+ *
+ * This is incompatible with K_MEM_MAP_LOCK.
+ *
+ * The provided backing-store "location" token must be linearly incrementable
+ * by a page size across the entire mapping.
+ *
+ * Allocated pages will have write-back cache settings.
+ *
+ * The returned virtual memory pointer will be page-aligned. The size
+ * parameter, and any base address for re-mapping purposes must be page-
+ * aligned.
+ *
+ * Note that the allocation includes two guard pages immediately before
+ * and after the requested region. The total size of the allocation will be
+ * the requested size plus the size of these two guard pages.
+ *
+ * @param location Backing store initial location token
+ * @param size Size of the memory mapping. This must be page-aligned.
+ * @param flags K_MEM_PERM_*, K_MEM_MAP_* control flags.
+ * @return The mapping location, or NULL if insufficient virtual address
+ *         space to establish the mapping, or insufficient memory for paging
+ *         structures.
+ */
+static inline void *k_mem_map_unpaged(uintptr_t location, size_t size, uint32_t flags)
+{
+	flags |= K_MEM_MAP_UNPAGED;
+	return k_mem_map_phys_guard(location, size, flags, false);
+}
+#endif
 
 /**
  * Un-map mapped memory

--- a/kernel/Kconfig.vm
+++ b/kernel/Kconfig.vm
@@ -123,6 +123,15 @@ menuconfig DEMAND_PAGING
 	  backing store for evicted pages.
 
 if DEMAND_PAGING
+config DEMAND_MAPPING
+	bool "Allow on-demand memory mappings"
+	depends on ARCH_HAS_DEMAND_MAPPING
+	default y
+	help
+	  When this is enabled, RAM-based memory mappings don't actually
+	  allocate memory at mem_map time. They are made to be populated
+	  at access time using the demand paging mechanism instead.
+
 config DEMAND_PAGING_ALLOW_IRQ
 	bool "Allow interrupts during page-ins/outs"
 	help

--- a/subsys/demand_paging/backing_store/ram.c
+++ b/subsys/demand_paging/backing_store/ram.c
@@ -127,6 +127,12 @@ void k_mem_paging_backing_store_page_in(uintptr_t location)
 void k_mem_paging_backing_store_page_finalize(struct k_mem_page_frame *pf,
 					      uintptr_t location)
 {
+#ifdef CONFIG_DEMAND_MAPPING
+	/* ignore those */
+	if (location == ARCH_UNPAGED_ANON_ZERO || location == ARCH_UNPAGED_ANON_UNINIT) {
+		return;
+	}
+#endif
 	k_mem_paging_backing_store_location_free(location);
 }
 


### PR DESCRIPTION
This provides memory mappings with the ability to be initialized in their
paged-out state and be paged in on demand. This is especially nice for
anonymous memory mappings as they no longer have to allocate all memory
at mem_map time. This also allows for file mappings to be implemented by
simply providing backing store location tokens.

This can be seen in action in PR #74129 which contains the whole set of
still unmerged patches for ARM64.
