### PR TITLE
Driver: led: lp5562: Added en_gpio DTS property and Implemented PM Support

### DIFF
--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -162,6 +162,8 @@ Drivers and Sensors
 
 * LED
 
+  * lp5562: added ``enable-gpios`` property to describe the EN/VCC GPIO of the lp5562.
+
   * lp5569: added ``charge-pump-mode`` property to configure the charge pump of the lp5569.
 
   * lp5569: added ``enable-gpios`` property to describe the EN/PWM GPIO of the lp5569.

--- a/dts/bindings/led/ti,lp5562.yaml
+++ b/dts/bindings/led/ti,lp5562.yaml
@@ -25,3 +25,10 @@ properties:
     default: 175
     description: Output current of white channel in 0.1 mA (0-25.5 mA)
                  Default value is the power-on default. Valid range = 0 - 255
+
+  enable-gpios:
+    type: phandle-array
+    description: |
+      GPIO to enable LP5562 (both Charge-pump and Digital Communications interface).
+      If not provided, user must ensure enable pin is already asserted externally (e.g:
+      pull-up resistor).


### PR DESCRIPTION
### Description
This PR attempts to add LP5562 EN Pin handling if connected to MCU's GPIO. 

### Changes
- Added optional en_gpios DT property to lp5562.yaml
- Added lp5562_enable/disable API to handle EN pin toggle and EN bit set in right order with appropriate delays
- Added PM_DEVICE support using lp5562_enable/disable APIs.