### PR TITLE
net: fix handle unaligned memory access in net_context_bind()

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -865,7 +865,7 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 
 			ptr = &maddr->address.in_addr;
 
-		} else if (addr4->sin_addr.s_addr == INADDR_ANY) {
+		} else if (UNALIGNED_GET(&addr4->sin_addr.s_addr) == INADDR_ANY) {
 			if (iface == NULL) {
 				iface = net_if_ipv4_select_src_iface(
 					&net_sin(&context->remote)->sin_addr);


### PR DESCRIPTION
This commit addresses an issue in net_context_bind() where unaligned memory access was not properly handled when checking for INADDR_ANY. The problem primarily affected MCUs like ARMv6 that don't support unaligned memory access.

- Use UNALIGNED_GET() to safely access the sin_addr.s_addr field
- Ensures correct behavior on architectures with alignment restrictions

This fix improves compatibility and prevents potential crashes or unexpected behavior on affected platforms.

Fixes #77188