### PR TITLE
doc: fix issue with keydown/keyup being ignored

### DIFF
--- a/doc/_templates/searchbox.html
+++ b/doc/_templates/searchbox.html
@@ -57,6 +57,7 @@
       .getElementById("search-se-settings-icon")
       .setAttribute("aria-expanded", visible ? "true" : "false");
   };
+  setSearchEngineSettingsMenuVisibility(false);
 
   window.toggleSearchEngineSettingsMenu = function () {
     isVisible = searchMenu.style.display === "block";


### PR DESCRIPTION
Ensure initial search menu visibility is properly set so that key events don't get trapped preventing arrow key navigation on the document.

Fixes #77396