### PR TITLE
drivers: sensor: ti: ina230: Add support for INA236

### DIFF
--- a/drivers/sensor/ti/ina23x/Kconfig
+++ b/drivers/sensor/ti/ina23x/Kconfig
@@ -5,7 +5,7 @@
 config INA23X
 	bool "INA23X Current and Power Monitor"
 	default y
-	depends on DT_HAS_TI_INA230_ENABLED || DT_HAS_TI_INA237_ENABLED
+	depends on DT_HAS_TI_INA230_ENABLED || DT_HAS_TI_INA236_ENABLED || DT_HAS_TI_INA237_ENABLED
 	select I2C
 	help
 	  Enable driver for INA23X Current and Power Monitor.
@@ -15,9 +15,9 @@ if INA23X
 config INA230
 	bool "INA230"
 	default y
-	depends on DT_HAS_TI_INA230_ENABLED
+	depends on DT_HAS_TI_INA230_ENABLED || DT_HAS_TI_INA236_ENABLED
 	help
-	  Enable driver for INA230/INA231.
+	  Enable driver for INA230/INA231/INA236.
 
 config INA237
 	bool "INA237"

--- a/drivers/sensor/ti/ina23x/ina230.h
+++ b/drivers/sensor/ti/ina23x/ina230.h
@@ -23,14 +23,16 @@
 #include <zephyr/kernel.h>
 #endif
 
-#define INA230_REG_CONFIG     0x00
-#define INA230_REG_SHUNT_VOLT 0x01
-#define INA230_REG_BUS_VOLT   0x02
-#define INA230_REG_POWER      0x03
-#define INA230_REG_CURRENT    0x04
-#define INA230_REG_CALIB      0x05
-#define INA230_REG_MASK       0x06
-#define INA230_REG_ALERT      0x07
+#define INA230_REG_CONFIG          0x00
+#define INA230_REG_SHUNT_VOLT      0x01
+#define INA230_REG_BUS_VOLT        0x02
+#define INA230_REG_POWER           0x03
+#define INA230_REG_CURRENT         0x04
+#define INA230_REG_CALIB           0x05
+#define INA230_REG_MASK            0x06
+#define INA230_REG_ALERT           0x07
+#define INA236_REG_MANUFACTURER_ID 0x3E
+#define INA236_REG_DEVICE_ID       0x3F
 
 struct ina230_data {
 	const struct device *dev;
@@ -43,7 +45,7 @@ struct ina230_data {
 	struct k_work work;
 	sensor_trigger_handler_t handler_alert;
 	const struct sensor_trigger *trig_alert;
-#endif  /* CONFIG_INA230_TRIGGER */
+#endif /* CONFIG_INA230_TRIGGER */
 };
 
 struct ina230_config {
@@ -51,17 +53,18 @@ struct ina230_config {
 	uint16_t config;
 	uint32_t current_lsb;
 	uint16_t cal;
+	uint8_t power_scale;
+	uint32_t uv_lsb;
 #ifdef CONFIG_INA230_TRIGGER
 	bool trig_enabled;
 	uint16_t mask;
 	const struct gpio_dt_spec alert_gpio;
 	uint16_t alert_limit;
-#endif  /* CONFIG_INA230_TRIGGER */
+#endif /* CONFIG_INA230_TRIGGER */
 };
 
 int ina230_trigger_mode_init(const struct device *dev);
-int ina230_trigger_set(const struct device *dev,
-		       const struct sensor_trigger *trig,
+int ina230_trigger_set(const struct device *dev, const struct sensor_trigger *trig,
 		       sensor_trigger_handler_t handler);
 
 #endif /* ZEPHYR_DRIVERS_SENSOR_INA23X_INA230_H_ */

--- a/dts/bindings/sensor/ti,ina230.yaml
+++ b/dts/bindings/sensor/ti,ina230.yaml
@@ -6,7 +6,7 @@
 #
 
 description: |
-    TI INA230 and INA231 Bidirectional Current and Power Monitor.
+    TI INA230, INA231 and INA236 Bidirectional Current and Power Monitor.
     The <zephyr/dt-bindings/sensor/ina230.h> file should be included in the
     DeviceTree and it provides macro that can be used for initializing the
     configuration register.

--- a/dts/bindings/sensor/ti,ina236.yaml
+++ b/dts/bindings/sensor/ti,ina236.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright 2024 Tomas Jurena
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+description: |
+    TI INA236 Bidirectional Current and Power Monitor.
+    The <zephyr/dt-bindings/sensor/ina230.h> file should be included in the
+    DeviceTree and it provides macro that can be used for initializing the
+    configuration register.
+
+compatible: "ti,ina236"
+
+include: ti,ina230.yaml
+
+properties:
+  high-precision:
+    type: boolean
+    description: |
+      Enable high precision mode (4x the resolution).

--- a/tests/drivers/sensor/ina230/boards/native_sim.overlay
+++ b/tests/drivers/sensor/ina230/boards/native_sim.overlay
@@ -15,4 +15,12 @@
 		current-lsb-microamps = <1000>;
 		status = "okay";
 	};
+
+	ina236_default_test: ina236@41 {
+		compatible = "ti,ina236";
+		reg = <0x41>;
+		rshunt-micro-ohms = <2000>;
+		current-lsb-microamps = <1000>;
+		status = "okay";
+	};
 };

--- a/tests/drivers/sensor/ina230/src/ina230_emul.h
+++ b/tests/drivers/sensor/ina230/src/ina230_emul.h
@@ -9,6 +9,7 @@
 #define INA230_EMUL_H_
 
 #define INA230_REGISTER_COUNT 8
+#define INA236_REGISTER_COUNT 2
 
 int ina230_mock_set_register(void *data_ptr, int reg, uint32_t value);
 int ina230_mock_get_register(void *data_ptr, int reg, uint32_t *value_ptr);


### PR DESCRIPTION
This commit adds support for INA236 into the existing INA230 driver. These two chips are similar enough to share most of the code. The device can be defined the same way as INA230 and we only have the extra option to select the high-precision mode.

```
ina236: ina236@40 {
		status = "okay";
		compatible = "ti,ina236", "ti,ina230";
		reg = <0x40>;
		adc-mode = "Bus and shunt voltage continuous";
		vbus-conversion-time-us = <1100>;
		vshunt-conversion-time-us = <1100>;
		avg-count = <1>;
		current-lsb-microamps = <1000>;
		rshunt-micro-ohms = <15000>;
		alert-gpios = <&gpiod 0 GPIO_ACTIVE_LOW>;
		high-precision;
	};
```