### PR TITLE
boards: frdm_rw612: support latest linkserver

### DIFF
--- a/boards/nxp/frdm_rw612/board.cmake
+++ b/boards/nxp/frdm_rw612/board.cmake
@@ -3,7 +3,7 @@
 
 board_runner_args(jlink "--device=RW612" "--reset-after-load")
 
-board_runner_args(linkserver  "--device=RW612:RDRW612")
+board_runner_args(linkserver  "--device=RW612:FRDM-RW612")
 
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/linkserver.board.cmake)


### PR DESCRIPTION
latest linkserver 1.6.123 use RW612:FRDM-RW612