### PR TITLE
doc: esp32: Update board identifier

### DIFF
--- a/boards/espressif/esp32_ethernet_kit/doc/index.rst
+++ b/boards/espressif/esp32_ethernet_kit/doc/index.rst
@@ -479,7 +479,7 @@ To build the sample application using sysbuild use the command:
 .. zephyr-app-commands::
    :tool: west
    :app: samples/hello_world
-   :board: esp32_ethernet_kit
+   :board: esp32_ethernet_kit/esp32/procpu
    :goals: build
    :west-args: --sysbuild
    :compact:


### PR DESCRIPTION
Clears CMake warning:
```
Deprecated BOARD=esp32_ethernet_kit specified, board automatically changed
  to: esp32_ethernet_kit/esp32/procpu.
```