### PR TITLE
drivers: clock_control: esp32c6: Fix for USB/JTAG port

### DIFF
--- a/drivers/clock_control/clock_control_esp32.c
+++ b/drivers/clock_control/clock_control_esp32.c
@@ -125,7 +125,9 @@ static void esp32_clock_perip_init(void)
 		REG_CLR_BIT(PCR_PVT_MONITOR_FUNC_CLK_CONF_REG, PCR_PVT_MONITOR_FUNC_CLK_EN);
 		WRITE_PERI_REG(PCR_CTRL_CLK_OUT_EN_REG, 0);
 
+#if CONFIG_SERIAL_ESP32_USB
 		usb_serial_jtag_ll_enable_bus_clock(false);
+#endif
 	}
 
 	if ((rst_reason == RESET_REASON_CHIP_POWER_ON) ||


### PR DESCRIPTION
After PR #76515, USB/JTAG port will not work for devices with USB serial not enabled.
Reason is that JTAG clock needs to be disabled at system init, but only when USB serial is enabled.
Otherwise, clock for USB/JTAG peripheral is never enabled and port would not work.