### PR TITLE
Fix   warning (simple_bus_reg): /soc/clocks: missing or empty  on STM32 nucleo boards 

### DIFF
--- a/dts/arm/st/f0/stm32f042.dtsi
+++ b/dts/arm/st/f0/stm32f042.dtsi
@@ -7,17 +7,19 @@
 #include <st/f0/stm32f031.dtsi>
 
 / {
+
+	clocks {
+		clk_hsi48: clk-hsi48 {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <DT_FREQ_M(48)>;
+			status = "disabled";
+		};
+	};
+
 	soc {
 		compatible = "st,stm32f042", "st,stm32f0", "simple-bus";
 
-		clocks {
-			clk_hsi48: clk-hsi48 {
-				#clock-cells = <0>;
-				compatible = "fixed-clock";
-				clock-frequency = <DT_FREQ_M(48)>;
-				status = "disabled";
-			};
-		};
 
 		usart2: serial@40004400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";

--- a/dts/arm/st/g0/stm32g0b1.dtsi
+++ b/dts/arm/st/g0/stm32g0b1.dtsi
@@ -8,17 +8,19 @@
 #include <st/g0/stm32g071.dtsi>
 
 / {
+
+	clocks {
+		clk_hsi48: clk-hsi48 {
+			#clock-cells = <0>;
+			compatible = "st,stm32-hsi48-clock";
+			clock-frequency = <DT_FREQ_M(48)>;
+			status = "disabled";
+		};
+	};
+
 	soc {
 		compatible = "st,stm32g0b1", "st,stm32g0", "simple-bus";
 
-		clocks {
-			clk_hsi48: clk-hsi48 {
-				#clock-cells = <0>;
-				compatible = "st,stm32-hsi48-clock";
-				clock-frequency = <DT_FREQ_M(48)>;
-				status = "disabled";
-			};
-		};
 
 		pinctrl: pin-controller@50000000 {
 			gpioe: gpio@50001000 {

--- a/dts/arm/st/l0/stm32l053.dtsi
+++ b/dts/arm/st/l0/stm32l053.dtsi
@@ -7,17 +7,18 @@
 #include <st/l0/stm32l051.dtsi>
 
 / {
+
+	clocks {
+		clk_hsi48: clk-hsi48 {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <DT_FREQ_M(48)>;
+			status = "disabled";
+		};
+	};
+
 	soc {
 		compatible = "st,stm32l053", "st,stm32l0", "simple-bus";
-
-		clocks {
-			clk_hsi48: clk-hsi48 {
-				#clock-cells = <0>;
-				compatible = "fixed-clock";
-				clock-frequency = <DT_FREQ_M(48)>;
-				status = "disabled";
-			};
-		};
 
 		usb: usb@40005c00 {
 			compatible = "st,stm32-usb";

--- a/dts/arm/st/l0/stm32l072.dtsi
+++ b/dts/arm/st/l0/stm32l072.dtsi
@@ -11,17 +11,17 @@
 		zephyr,entropy = &rng;
 	};
 
+	clocks {
+		clk_hsi48: clk-hsi48 {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <DT_FREQ_M(48)>;
+			status = "disabled";
+		};
+	};
+
 	soc {
 		compatible = "st,stm32l072", "st,stm32l0", "simple-bus";
-
-		clocks {
-			clk_hsi48: clk-hsi48 {
-				#clock-cells = <0>;
-				compatible = "fixed-clock";
-				clock-frequency = <DT_FREQ_M(48)>;
-				status = "disabled";
-			};
-		};
 
 		usb: usb@40005c00 {
 			compatible = "st,stm32-usb";

--- a/dts/arm/st/l4/stm32l412.dtsi
+++ b/dts/arm/st/l4/stm32l412.dtsi
@@ -7,17 +7,19 @@
 #include <st/l4/stm32l4.dtsi>
 
 / {
+
+	clocks {
+		clk_hsi48: clk-hsi48 {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <DT_FREQ_M(48)>;
+			status = "disabled";
+		};
+	};
+
 	soc {
 		compatible = "st,stm32l412", "st,stm32l4", "simple-bus";
 
-		clocks {
-			clk_hsi48: clk-hsi48 {
-				#clock-cells = <0>;
-				compatible = "fixed-clock";
-				clock-frequency = <DT_FREQ_M(48)>;
-				status = "disabled";
-			};
-		};
 
 		rng: rng@50060800 {
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00040000>,

--- a/dts/arm/st/l4/stm32l431.dtsi
+++ b/dts/arm/st/l4/stm32l431.dtsi
@@ -7,17 +7,18 @@
 #include <st/l4/stm32l4.dtsi>
 
 / {
+
+	clocks {
+		clk_hsi48: clk-hsi48 {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <DT_FREQ_M(48)>;
+			status = "disabled";
+		};
+	};
+
 	soc {
 		compatible = "st,stm32l431", "st,stm32l4", "simple-bus";
-
-		clocks {
-			clk_hsi48: clk-hsi48 {
-				#clock-cells = <0>;
-				compatible = "fixed-clock";
-				clock-frequency = <DT_FREQ_M(48)>;
-				status = "disabled";
-			};
-		};
 
 		pinctrl: pin-controller@48000000 {
 

--- a/dts/arm/st/l4/stm32l432.dtsi
+++ b/dts/arm/st/l4/stm32l432.dtsi
@@ -7,17 +7,18 @@
 #include <st/l4/stm32l4.dtsi>
 
 / {
+
+	clocks {
+		clk_hsi48: clk-hsi48 {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <DT_FREQ_M(48)>;
+			status = "disabled";
+		};
+	};
+
 	soc {
 		compatible = "st,stm32l432", "st,stm32l4", "simple-bus";
-
-		clocks {
-			clk_hsi48: clk-hsi48 {
-				#clock-cells = <0>;
-				compatible = "fixed-clock";
-				clock-frequency = <DT_FREQ_M(48)>;
-				status = "disabled";
-			};
-		};
 
 		rng: rng@50060800 {
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00040000>,

--- a/dts/arm/st/l4/stm32l451.dtsi
+++ b/dts/arm/st/l4/stm32l451.dtsi
@@ -7,17 +7,18 @@
 #include <st/l4/stm32l4.dtsi>
 
 / {
+
+	clocks {
+		clk_hsi48: clk-hsi48 {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <DT_FREQ_M(48)>;
+			status = "disabled";
+		};
+	};
+
 	soc {
 		compatible = "st,stm32l451", "st,stm32l4", "simple-bus";
-
-		clocks {
-			clk_hsi48: clk-hsi48 {
-				#clock-cells = <0>;
-				compatible = "fixed-clock";
-				clock-frequency = <DT_FREQ_M(48)>;
-				status = "disabled";
-			};
-		};
 
 		pinctrl: pin-controller@48000000 {
 			gpiod: gpio@48000c00 {

--- a/dts/arm/st/l4/stm32l496.dtsi
+++ b/dts/arm/st/l4/stm32l496.dtsi
@@ -7,17 +7,18 @@
 #include <st/l4/stm32l475.dtsi>
 
 / {
+
+	clocks {
+		clk_hsi48: clk-hsi48 {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <DT_FREQ_M(48)>;
+			status = "disabled";
+		};
+	};
+
 	soc {
 		compatible = "st,stm32l496", "st,stm32l4", "simple-bus";
-
-		clocks {
-			clk_hsi48: clk-hsi48 {
-				#clock-cells = <0>;
-				compatible = "fixed-clock";
-				clock-frequency = <DT_FREQ_M(48)>;
-				status = "disabled";
-			};
-		};
 
 		rng: rng@50060800 {
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00040000>,

--- a/dts/arm/st/l4/stm32l4p5.dtsi
+++ b/dts/arm/st/l4/stm32l4p5.dtsi
@@ -15,17 +15,18 @@
 		reg = <0x20000000 DT_SIZE_K(320)>;
 	};
 
+	clocks {
+		clk_hsi48: clk-hsi48 {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <DT_FREQ_M(48)>;
+			status = "disabled";
+		};
+	};
+
 	soc {
 		compatible = "st,stm32l4p5", "st,stm32l4", "simple-bus";
 
-		clocks {
-			clk_hsi48: clk-hsi48 {
-				#clock-cells = <0>;
-				compatible = "fixed-clock";
-				clock-frequency = <DT_FREQ_M(48)>;
-				status = "disabled";
-			};
-		};
 
 		flash-controller@40022000 {
 			flash0: flash@8000000 {


### PR DESCRIPTION
- Remove clocks node inside soc node

  Since the clock node is not a child node of the soc node, but from the root node.
  This removes the warning log at compilation.
  
  
  Fixes #77266 