### PR TITLE
drivers: bluetooth: hci: STM32WBA should select TAIN_BLOBS

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -73,6 +73,7 @@ config BT_STM32WBA
 	depends on DT_HAS_ST_HCI_STM32WBA_ENABLED
 	select HAS_STM32LIB
 	select BT_HCI_SET_PUBLIC_ADDR
+	select TAINT_BLOBS
 	help
 	  ST STM32WBA HCI Bluetooth interface
 


### PR DESCRIPTION
Since use of BLE on STM32WBA requires linking zephyr image with a binary blob that provides the BLE controller implementation, it should select TAIN_BLOBS symbols which signals a blob is used in the resulting zephyr firmware.