### PR TITLE
drivers: bluetooth: hci: Remove prompt on non user selectable symbols

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -32,12 +32,12 @@ config BT_H5
 # Removed: Here only to give the user a warning about its removal
 # Remove after 3.7.0 is released
 config BT_RPMSG
-	bool "[REMOVED] HCI using RPMsg"
+	bool
 	help
 	  Use BT_HCI_IPC instead
 
 config BT_HCI_IPC
-	bool "HCI using the IPC subsystem"
+	bool
 	default y
 	depends on DT_HAS_ZEPHYR_BT_HCI_IPC_ENABLED
 	select BT_HAS_HCI_VS
@@ -58,7 +58,7 @@ config BT_SPI
 	  devices are.
 
 config BT_STM32_IPM
-	bool "IPM HCI"
+	bool
 	default y
 	depends on DT_HAS_ST_STM32WB_RF_ENABLED
 	select USE_STM32_HAL_CORTEX
@@ -68,7 +68,7 @@ config BT_STM32_IPM
 	  TODO
 
 config BT_STM32WBA
-	bool "STM32WBA HCI driver"
+	bool
 	default y
 	depends on DT_HAS_ST_HCI_STM32WBA_ENABLED
 	select HAS_STM32LIB
@@ -77,7 +77,7 @@ config BT_STM32WBA
 	  ST STM32WBA HCI Bluetooth interface
 
 config BT_SILABS_HCI
-	bool "Silicon Labs Bluetooth interface"
+	bool
 	default y
 	depends on DT_HAS_SILABS_BT_HCI_ENABLED
 	depends on !PM || SOC_GECKO_PM_BACKEND_PMGR
@@ -92,7 +92,7 @@ config BT_SILABS_HCI
 	  controller.
 
 config BT_USERCHAN
-	bool "HCI User Channel based driver"
+	bool
 	depends on (BOARD_NATIVE_POSIX || BOARD_NATIVE_SIM)
 	default y
 	depends on DT_HAS_ZEPHYR_BT_HCI_USERCHAN_ENABLED
@@ -104,14 +104,14 @@ config BT_USERCHAN
 	  be able to use it.
 
 config BT_ESP32
-	bool "ESP32 HCI driver"
+	bool
 	default y
 	depends on DT_HAS_ESPRESSIF_ESP32_BT_HCI_ENABLED
 	help
 	  Espressif HCI bluetooth interface
 
 config BT_PSOC6_BLESS
-	bool "PSOC6 BLESS driver"
+	bool
 	default y
 	depends on DT_HAS_INFINEON_CAT1_BLESS_HCI_ENABLED
 	select BT_HCI_SETUP
@@ -120,7 +120,7 @@ config BT_PSOC6_BLESS
 	  Single CPU mode.
 
 config BT_DA1469X
-	bool "DA1469x HCI driver"
+	bool
 	default y
 	depends on DT_HAS_RENESAS_BT_HCI_DA1469X_ENABLED
 	help
@@ -128,7 +128,7 @@ config BT_DA1469X
 	  on DA1469x MCU.
 
 config BT_NXP
-	bool "NXP HCI driver"
+	bool
 	default y
 	depends on DT_HAS_NXP_HCI_BLE_ENABLED
 	select BT_HCI_SETUP
@@ -137,14 +137,14 @@ config BT_NXP
 	  NXP HCI bluetooth interface
 
 config BT_CYW208XX
-	bool "CYW208XX BLE driver"
+	bool
 	default y
 	depends on DT_HAS_INFINEON_CYW208XX_HCI_ENABLED
 	help
 	  Infineon CYW208XX HCI bluetooth interface
 
 config BT_AMBIQ_HCI
-	bool "AMBIQ BT HCI driver"
+	bool
 	default y
 	depends on DT_HAS_AMBIQ_BT_HCI_SPI_ENABLED
 	select SPI


### PR DESCRIPTION
Most of BT_FOO symbols that are designed to select the hci driver implementation which will drive the comunication with controller are selected based on device tree compatible and should not be made available as an configurable option to the user.
To do this, remove the prompt on these symbols.