### PR TITLE
modules: stm32: Add ZEPHYR_HAL_*_MODULE

### DIFF
--- a/modules/Kconfig.stm32
+++ b/modules/Kconfig.stm32
@@ -3,6 +3,9 @@
 # Copyright (c) 2016 Linaro Limited.
 # SPDX-License-Identifier: Apache-2.0
 
+config ZEPHYR_HAL_STM32_MODULE
+	bool
+
 config HAS_STM32LIB
 	bool
 


### PR DESCRIPTION
According to the cargo cult, this symbol is missing on stm32 module.