### PR TITLE
scripts: west_commands: remove family argument from nrfjprog and nrfutil

### DIFF
--- a/scripts/west_commands/runners/nrfjprog.py
+++ b/scripts/west_commands/runners/nrfjprog.py
@@ -59,9 +59,6 @@ class NrfJprogBinaryRunner(NrfBinaryRunner):
         self.logger.debug(f'Executing op: {op}')
         # Translate the op
 
-        families = {'NRF51_FAMILY': 'NRF51', 'NRF52_FAMILY': 'NRF52',
-                    'NRF53_FAMILY': 'NRF53', 'NRF54L_FAMILY': 'NRF54L',
-                    'NRF91_FAMILY': 'NRF91'}
         cores = {'NRFDL_DEVICE_CORE_APPLICATION': 'CP_APPLICATION',
                  'NRFDL_DEVICE_CORE_NETWORK': 'CP_NETWORK'}
 
@@ -112,8 +109,7 @@ class NrfJprogBinaryRunner(NrfBinaryRunner):
             raise RuntimeError(f'Invalid operation: {op_type}')
 
         try:
-            self.check_call(cmd + ['-f', families[self.family]] + core_opt +
-                            ['--snr', self.dev_id] + self.tool_opt)
+            self.check_call(cmd + core_opt + ['--snr', self.dev_id] + self.tool_opt)
         except subprocess.CalledProcessError as cpe:
             # Translate error codes
             if cpe.returncode == UnavailableOperationBecauseProtectionError:

--- a/scripts/west_commands/runners/nrfutil.py
+++ b/scripts/west_commands/runners/nrfutil.py
@@ -92,8 +92,7 @@ class NrfUtilBinaryRunner(NrfBinaryRunner):
 
     def _exec_batch(self):
         # prepare the dictionary and convert to JSON
-        batch = json.dumps({'family': f'{self.family}',
-                            'operations': [op for op in self._ops]},
+        batch = json.dumps({'operations': [op for op in self._ops]},
                             indent=4) + '\n'
 
         hex_dir = Path(self.hex_).parent


### PR DESCRIPTION
This patch removes the family option from the nrfjprog and nrfutil runners since it causes the tools to skip the family check and possibly brick devices.