### PR TITLE
boards: nucleo_wba55cg: Enable mcuboot and mcumgr tests

### DIFF
--- a/boards/st/nucleo_wba55cg/nucleo_wba55cg.dts
+++ b/boards/st/nucleo_wba55cg/nucleo_wba55cg.dts
@@ -173,19 +173,15 @@ stm32_lp_tick_source: &lptim1 {
 		};
 		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x00010000 DT_SIZE_K(448)>;
+			reg = <0x00010000 DT_SIZE_K(456)>;
 		};
-		slot1_partition: partition@80000 {
+		slot1_partition: partition@82000 {
 			label = "image-1";
-			reg = <0x00080000 DT_SIZE_K(448)>;
+			reg = <0x00082000 DT_SIZE_K(448)>;
 		};
-		scratch_partition: partition@f0000 {
-			label = "image-scratch";
-			reg = <0x000f0000 DT_SIZE_K(16)>;
-		};
-		storage_partition: partition@f4000 {
+		storage_partition: partition@f2000 {
 			label = "storage";
-			reg = <0x000f4000 DT_SIZE_K(48)>;
+			reg = <0x000f2000 DT_SIZE_K(56)>;
 		};
 	};
 };

--- a/tests/boot/test_mcuboot/testcase.yaml
+++ b/tests/boot/test_mcuboot/testcase.yaml
@@ -35,6 +35,7 @@ tests:
       - mimxrt685_evk/mimxrt685s/cm33
       - nrf52840dk/nrf52840
       - rd_rw612_bga
+      - nucleo_wba55cg
     integration_platforms:
       - frdm_k64f
       - nrf52840dk/nrf52840

--- a/tests/boot/with_mcumgr/testcase.yaml
+++ b/tests/boot/with_mcumgr/testcase.yaml
@@ -5,6 +5,7 @@ common:
     - nrf5340dk/nrf5340/cpuapp
     - nrf54l15pdk/nrf54l15/cpuapp
     - nrf9160dk/nrf9160
+    - nucleo_wba55cg
   integration_platforms:
     - nrf52840dk/nrf52840
   timeout: 600


### PR DESCRIPTION
Make necessary modifications to run these tests on nucleo_wba55cg in CI