### PR TITLE
lib: libc: Add minimal libc config for enabling printf functions

### DIFF
--- a/lib/libc/minimal/CMakeLists.txt
+++ b/lib/libc/minimal/CMakeLists.txt
@@ -24,8 +24,6 @@ zephyr_library_sources(
   source/string/string.c
   source/string/strspn.c
   source/stdout/stdout_console.c
-  source/stdout/sprintf.c
-  source/stdout/fprintf.c
   source/math/sqrtf.c
   source/math/sqrt.c
   ${STRERROR_TABLE_H}
@@ -36,6 +34,13 @@ if(CONFIG_MINIMAL_LIBC_TIME)
 endif()
 
 zephyr_library_sources_ifdef(CONFIG_MINIMAL_LIBC_RAND source/stdlib/rand.c)
+
+if (CONFIG_MINIMAL_LIBC_PRINTF)
+  zephyr_library_sources(
+    source/stdout/sprintf.c
+    source/stdout/fprintf.c
+  )
+endif()
 
 add_custom_command(
   OUTPUT ${STRERROR_TABLE_H}

--- a/lib/libc/minimal/Kconfig
+++ b/lib/libc/minimal/Kconfig
@@ -63,4 +63,10 @@ config MINIMAL_LIBC_STRING_ERROR_TABLE
 	  symbols are still present, but the functions produce an empty
 	  string.
 
+config MINIMAL_LIBC_PRINTF
+	bool "Printf functions"
+	default y
+	help
+	  Enable sprintf() and fprintf() for the minimal libc.
+
 endif # MINIMAL_LIBC


### PR DESCRIPTION
This commit adds a config to minimal libc that allows enabling or disabling the printf functions defined by the minimal libc library. This change is useful for projects that wish to use minimal libc, but define their own implementation of the printf functions.