### PR TITLE
serial: bluetooth: Print warning once when ring buffer is full

### DIFF
--- a/drivers/serial/uart_bt.c
+++ b/drivers/serial/uart_bt.c
@@ -160,7 +160,7 @@ static void uart_bt_poll_out(const struct device *dev, unsigned char c)
 	/** Right now we're discarding data if ring-buf is full. */
 	while (!ring_buf_put(ringbuf, &c, 1)) {
 		if (k_is_in_isr() || !atomic_get(&dev_data->bt.enabled)) {
-			LOG_INF("Ring buffer full, discard %c", c);
+			LOG_WRN_ONCE("Ring buffer full, discard %c", c);
 			break;
 		}
 


### PR DESCRIPTION
When compiling with the default `CONFIG_UART_LOG_LEVEL`, which seems to be `INF`, I get endless `Ring buffer full, discard` prints on the console, which also seem to have jammed the BLE connection with my target due to the repeated BLE sends:
![image](https://github.com/user-attachments/assets/bff51ab9-cc48-4b0b-8ba5-a95917c210dd)

This change avoids cluttering the logging subsystem.