### PR TITLE
drivers: firmware: scmi: add more protocols and APIs

### DIFF
--- a/doc/hardware/arch/arm-scmi.rst
+++ b/doc/hardware/arch/arm-scmi.rst
@@ -135,9 +135,21 @@ Protocols
 
 Currently, Zephyr has support for the following standard protocols:
 
+	#. **Power domain management**
 	#. **Clock management**
 	#. **Pin Control**
 
+
+Power domain management
+***********************
+
+This protocol is intended for management of power states of power domains.
+This is done via a set of functions implementing various commands, for
+example, ``POWER_STATE_GET`` and ``POWER_STATE_SET``.
+
+.. note::
+	This driver is vendor-agnostic. As such, it may be used on any
+	system that uses SCMI for power domain management operations.
 
 Clock management protocol
 *************************

--- a/drivers/firmware/scmi/CMakeLists.txt
+++ b/drivers/firmware/scmi/CMakeLists.txt
@@ -10,3 +10,4 @@ zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_SHMEM shmem.c)
 # SCMI protocol helper files
 zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_CLK_HELPERS clk.c)
 zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_PINCTRL_HELPERS pinctrl.c)
+zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_POWER_DOMAIN_HELPERS power.c)

--- a/drivers/firmware/scmi/Kconfig
+++ b/drivers/firmware/scmi/Kconfig
@@ -28,6 +28,13 @@ config ARM_SCMI_PINCTRL_HELPERS
 	help
 	  Enable support for SCMI pinctrl protocol helper functions.
 
+config ARM_SCMI_POWER_DOMAIN_HELPERS
+	bool "Helper functions for SCMI power domain protocol"
+	default y
+	depends on DT_HAS_ARM_SCMI_POWER_ENABLED
+	help
+	  Enable support for SCMI power domain protocol helper functions.
+
 config ARM_SCMI_SHMEM
 	bool "SCMI shared memory (SHMEM) driver"
 	default y

--- a/drivers/firmware/scmi/power.c
+++ b/drivers/firmware/scmi/power.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/firmware/scmi/power.h>
+#include <string.h>
+
+DT_SCMI_PROTOCOL_DEFINE_NODEV(DT_INST(0, arm_scmi_power), NULL);
+
+struct scmi_power_state_get_reply {
+	int32_t status;
+	uint32_t power_state;
+};
+
+int scmi_power_state_get(uint32_t domain_id, uint32_t *power_state)
+{
+	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_POWER_DOMAIN);
+	struct scmi_power_state_get_reply reply_buffer;
+	struct scmi_message msg, reply;
+	int ret;
+
+	/* sanity checks */
+	if (!proto || !power_state) {
+		return -EINVAL;
+	}
+
+	if (proto->id != SCMI_PROTOCOL_POWER_DOMAIN) {
+		return -EINVAL;
+	}
+
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(SCMI_POWER_DOMAIN_MSG_POWER_STATE_GET, SCMI_COMMAND,
+					proto->id, 0x0);
+	msg.len = sizeof(domain_id);
+	msg.content = &domain_id;
+
+	reply.hdr = msg.hdr;
+	reply.len = sizeof(reply_buffer);
+	reply.content = &reply_buffer;
+
+	ret = scmi_send_message(proto, &msg, &reply);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (reply_buffer.status != SCMI_SUCCESS) {
+		return scmi_status_to_errno(reply_buffer.status);
+	}
+
+	*power_state = reply_buffer.power_state;
+
+	return 0;
+}
+
+int scmi_power_state_set(struct scmi_power_state_config *cfg)
+{
+	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_POWER_DOMAIN);
+	struct scmi_message msg, reply;
+	int status, ret;
+
+	/* sanity checks */
+	if (!proto || !cfg) {
+		return -EINVAL;
+	}
+
+	if (proto->id != SCMI_PROTOCOL_POWER_DOMAIN) {
+		return -EINVAL;
+	}
+
+	/* Currently ASYNC flag is not supported. */
+	if (cfg->flags & SCMI_POWER_STATE_SET_FLAGS_ASYNC) {
+		return -ENOTSUP;
+	}
+
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(SCMI_POWER_DOMAIN_MSG_POWER_STATE_SET, SCMI_COMMAND,
+					proto->id, 0x0);
+	msg.len = sizeof(*cfg);
+	msg.content = cfg;
+
+	reply.hdr = msg.hdr;
+	reply.len = sizeof(status);
+	reply.content = &status;
+
+	ret = scmi_send_message(proto, &msg, &reply);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (status != SCMI_SUCCESS) {
+		return scmi_status_to_errno(status);
+	}
+
+	return 0;
+}

--- a/dts/bindings/firmware/arm,scmi-power.yaml
+++ b/dts/bindings/firmware/arm,scmi-power.yaml
@@ -1,0 +1,21 @@
+# Copyright 2024 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: System Control and Management Interface (SCMI) power domain protocol
+
+compatible: "arm,scmi-power"
+
+include: [base.yaml]
+
+properties:
+  reg:
+    required: true
+    const: [0x11]
+
+  "#power-domain-cells":
+    type: int
+    required: true
+    const: 1
+
+power-domain-cells:
+  - name

--- a/include/zephyr/drivers/firmware/scmi/clk.h
+++ b/include/zephyr/drivers/firmware/scmi/clk.h
@@ -20,6 +20,11 @@
 
 #define SCMI_CLK_ATTRIBUTES_CLK_NUM(x) ((x) & GENMASK(15, 0))
 
+#define SCMI_CLK_RATE_SET_FLAGS_ASYNC                BIT(0)
+#define SCMI_CLK_RATE_SET_FLAGS_IGNORE_DELEAYED_RESP BIT(1)
+#define SCMI_CLK_RATE_SET_FLAGS_ROUNDS_UP_DOWN       BIT(2)
+#define SCMI_CLK_RATE_SET_FLAGS_ROUNDS_AUTO          BIT(3)
+
 /**
  * @struct scmi_clock_config
  *
@@ -30,6 +35,18 @@ struct scmi_clock_config {
 	uint32_t clk_id;
 	uint32_t attributes;
 	uint32_t extended_cfg_val;
+};
+
+/**
+ * @struct scmi_clock_rate_config
+ *
+ * @brief Describes the parameters for the CLOCK_RATE_SET
+ * command
+ */
+struct scmi_clock_rate_config {
+	uint32_t flags;
+	uint32_t clk_id;
+	uint32_t rate[2];
 };
 
 /**
@@ -92,5 +109,42 @@ int scmi_clock_config_set(struct scmi_protocol *proto,
  */
 int scmi_clock_rate_get(struct scmi_protocol *proto,
 			uint32_t clk_id, uint32_t *rate);
+
+/**
+ * @brief Send the CLOCK_RATE_SET command and get its reply
+ *
+ * @param proto pointer to SCMI clock protocol data
+ * @param cfg pointer to structure containing configuration
+ * to be set
+ *
+ * @retval 0 if successful
+ * @retval negative errno if failure
+ */
+int scmi_clock_rate_set(struct scmi_protocol *proto, struct scmi_clock_rate_config *cfg);
+
+/**
+ * @brief Query the parent of a clock
+ *
+ * @param proto pointer to SCMI clock protocol data
+ * @param clk_id ID of the clock for which the query is done
+ * @param parent_id pointer to be set via this command
+ *
+ * @retval 0 if successful
+ * @retval negative errno if failure
+ */
+int scmi_clock_parent_get(struct scmi_protocol *proto, uint32_t clk_id, uint32_t *parent_id);
+
+/**
+ * @brief Send the CLOCK_PARENT_SET command and get its reply
+ *
+ * @param proto pointer to SCMI clock protocol data
+ * @param clk_id ID of the clock for which the query is done
+ * @param parent_id to be set via this command
+ * to be set
+ *
+ * @retval 0 if successful
+ * @retval negative errno if failure
+ */
+int scmi_clock_parent_set(struct scmi_protocol *proto, uint32_t clk_id, uint32_t parent_id);
 
 #endif /* _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_CLK_H_ */

--- a/include/zephyr/drivers/firmware/scmi/power.h
+++ b/include/zephyr/drivers/firmware/scmi/power.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief SCMI power domain protocol helpers
+ */
+
+#ifndef _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_POWER_H_
+#define _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_POWER_H_
+
+#include <zephyr/drivers/firmware/scmi/protocol.h>
+
+#define SCMI_POWER_STATE_SET_FLAGS_ASYNC BIT(0)
+
+/**
+ * @struct scmi_power_state_config
+ *
+ * @brief Describes the parameters for the POWER_STATE_SET
+ * command
+ */
+struct scmi_power_state_config {
+	uint32_t flags;
+	uint32_t domain_id;
+	uint32_t power_state;
+};
+
+/**
+ * @brief Power domain protocol command message IDs
+ */
+enum scmi_power_domain_message {
+	SCMI_POWER_DOMAIN_MSG_PROTOCOL_VERSION = 0x0,
+	SCMI_POWER_DOMAIN_MSG_PROTOCOL_ATTRIBUTES = 0x1,
+	SCMI_POWER_DOMAIN_MSG_PROTOCOL_MESSAGE_ATTRIBUTES = 0x2,
+	SCMI_POWER_DOMAIN_MSG_POWER_DOMAIN_ATTRIBUTES = 0x3,
+	SCMI_POWER_DOMAIN_MSG_POWER_STATE_SET = 0x4,
+	SCMI_POWER_DOMAIN_MSG_POWER_STATE_GET = 0x5,
+	SCMI_POWER_DOMAIN_MSG_POWER_STATE_NOTIFY = 0x6,
+	SCMI_POWER_DOMAIN_MSG_POWER_STATE_CHANGE_REQEUSTED_NOTIFY = 0x7,
+	SCMI_POWER_DOMAIN_MSG_POWER_DOMAIN_NAME_GET = 0x8,
+	SCMI_POWER_DOMAIN_MSG_NEGOTIATE_PROTOCOL_VERSION = 0x10,
+};
+
+/**
+ * @brief Send the POWER_STATE_SET command and get its reply
+ *
+ * @param cfg pointer to structure containing configuration
+ * to be set
+ *
+ * @retval 0 if successful
+ * @retval negative errno if failure
+ */
+int scmi_power_state_set(struct scmi_power_state_config *cfg);
+/**
+ * @brief Query the power domain state
+ *
+ * @param domain_id ID of the power domain for which the query is done
+ * @param power_state pointer to be set via this command
+ *
+ * @retval 0 if successful
+ * @retval negative errno if failure
+ */
+int scmi_power_state_get(uint32_t domain_id, uint32_t *power_state);
+
+#endif /* _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_POWER_H_ */


### PR DESCRIPTION
This patch-set is to add more SCMI clock protocol APIs and power domain protocol driver.
These are essential for platform to configure clock and control power domain.
These had been verified on NXP i.MX95 platforms.

Thank you very much.