### PR TITLE
usb: device_next: msc: Allow user to sort LUNs

### DIFF
--- a/include/zephyr/usb/class/usbd_msc.h
+++ b/include/zephyr/usb/class/usbd_msc.h
@@ -37,17 +37,18 @@ struct usbd_msc_lun {
  * Up to `CONFIG_USBD_MSC_LUNS_PER_INSTANCE` disks can be registered on single
  * USB MSC instance. Currently only one USB MSC instance is supported.
  *
+ * @param id Identifier by which the linker sorts registered LUNs
  * @param disk_name Disk name as used in @ref disk_access_interface
  * @param t10_vendor T10 Vendor Indetification
  * @param t10_product T10 Product Identification
  * @param t10_revision T10 Product Revision Level
  */
-#define USBD_DEFINE_MSC_LUN(disk_name, t10_vendor, t10_product, t10_revision)	\
-	STRUCT_SECTION_ITERABLE(usbd_msc_lun, usbd_msc_lun_##disk_name) = {	\
-		.disk = STRINGIFY(disk_name),					\
-		.vendor = t10_vendor,						\
-		.product = t10_product,						\
-		.revision = t10_revision,					\
+#define USBD_DEFINE_MSC_LUN(id, disk_name, t10_vendor, t10_product, t10_revision)	\
+	static const STRUCT_SECTION_ITERABLE(usbd_msc_lun, usbd_msc_lun_##id) = {	\
+		.disk = disk_name,							\
+		.vendor = t10_vendor,							\
+		.product = t10_product,							\
+		.revision = t10_revision,						\
 	}
 
 /**

--- a/samples/subsys/usb/mass/src/main.c
+++ b/samples/subsys/usb/mass/src/main.c
@@ -45,15 +45,15 @@ static struct fs_mount_t fs_mnt;
 static struct usbd_context *sample_usbd;
 
 #if CONFIG_DISK_DRIVER_RAM
-USBD_DEFINE_MSC_LUN(RAM, "Zephyr", "RAMDisk", "0.00");
+USBD_DEFINE_MSC_LUN(ram, "RAM", "Zephyr", "RAMDisk", "0.00");
 #endif
 
 #if CONFIG_DISK_DRIVER_FLASH
-USBD_DEFINE_MSC_LUN(NAND, "Zephyr", "FlashDisk", "0.00");
+USBD_DEFINE_MSC_LUN(nand, "NAND", "Zephyr", "FlashDisk", "0.00");
 #endif
 
 #if CONFIG_DISK_DRIVER_SDMMC
-USBD_DEFINE_MSC_LUN(SD, "Zephyr", "SD", "0.00");
+USBD_DEFINE_MSC_LUN(sd, "SD", "Zephyr", "SD", "0.00");
 #endif
 
 static int enable_usb_device_next(void)


### PR DESCRIPTION
Modify USBD_DEFINE_MSC_LUN() to take in separate id by which the LUNs are sorted. Previously the disk name itself was implicitly used as a sorting key. This is a breaking change to Experimental API.

Another advantage of splitting the sorting id from disk name is the ability to use KConfig symbols as disk name. Currently the MMC disk driver uses KConfig symbol CONFIG_MMC_VOLUME_NAME.

Mark LUN definitions as static const because the LUNs are ending up in ITERABLE_SECTION_ROM().

---

The issue of not being able to use CONFIG_MMC_VOLUME_NAME as disk name was initially discovered in #76409 