### PR TITLE
devicetree: Reduce LoRa SPI frequency to allow reliable communciation

### DIFF
--- a/boards/heltec/heltec_wireless_stick_lite_v3/heltec_wireless_stick_lite_v3_procpu.dts
+++ b/boards/heltec/heltec_wireless_stick_lite_v3/heltec_wireless_stick_lite_v3_procpu.dts
@@ -128,7 +128,7 @@
 		dio2-tx-enable;
 		dio3-tcxo-voltage = <SX126X_DIO3_TCXO_1V8>;
 		tcxo-power-startup-delay-ms = <5>;
-		spi-max-frequency = <16000000>;
+		spi-max-frequency = <4000000>;
 	};
 };
 


### PR DESCRIPTION
The heltec_wireless_stick_lite_v3 board does not properly handle receive operations when the SPI used to communicate with onboard SX1262 has the clock frequency set too high. This causes radio recv operation to almost always hang forever without any error, as the SX1262 module returns 0xFF00 value as the interrupt status which does not make any sense, thus causing the LoRaWAN library to trigger RXTX timeout handler which in the current SX1262 driver implementation is not privded. The issue occurs almost always, sometimes allowing to receive few (3-5) tranmissions correctly, then fail. The root of the problem is not known for sure, but it is highly likely a board's limitation, though not confirmed by the manufacturer. The current SPI frequency was chosen arbitrarily based on the conducted experiments where the 30 000 messages have been received continiously without any problems (with 5s interval for each message).

Fixes #73177

![Screenshot from 2024-08-23 08-37-07](https://github.com/user-attachments/assets/48356314-699b-4b48-96c0-6b923fb6d902)

