### PR TITLE
scripts: ci: Fix clang-format notice at file beginning/end

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -303,11 +303,14 @@ class ClangFormatCheck(ComplianceTest):
                 for patch in patchset:
                     for hunk in patch:
                         # Strip the before and after context
-                        msg = "".join([str(l) for l in hunk[3:-3]])
+                        before = next(i for i,v in enumerate(hunk) if str(v).startswith('-'))
+                        after = next(i for i,v in enumerate(reversed(hunk)) if str(v).startswith('+'))
+                        msg = "".join([str(l) for l in hunk[before:-after or None]])
+
                         # show the hunk at the last line
                         self.fmtd_failure("notice",
                                           "You may want to run clang-format on this change",
-                                          file, line=hunk.source_start + hunk.source_length - 3,
+                                          file, line=hunk.source_start + hunk.source_length - after,
                                           desc=f'\r\n{msg}')
 
 


### PR DESCRIPTION
The clang-format check outputs a git diff with surrounding context. It naively removed the first and last 3 lines, but this does not work if there are less lines.