### PR TITLE
boards: st: nucleo_h723zg: enable fdcan1

### DIFF
--- a/boards/st/nucleo_h723zg/doc/index.rst
+++ b/boards/st/nucleo_h723zg/doc/index.rst
@@ -117,6 +117,8 @@ features:
 +-------------+------------+-------------------------------------+
 | RTC         | on-chip    | rtc                                 |
 +-------------+------------+-------------------------------------+
+| FDCAN1      | on-chip    | CAN-FD Controller                   |
++-------------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.
 
@@ -138,6 +140,7 @@ and a ST morpho connector. Board is configured as follows:
 - LD3 : PB14
 - I2C : PB8, PB9
 - SPI1 NSS/SCK/MISO/MOSI : PD14PA5/PA6/PB5 (Arduino SPI)
+- FDCAN1 RX/TX : PD0, PD1
 
 System Clock
 ------------
@@ -157,6 +160,13 @@ Backup SRAM
 
 In order to test backup SRAM you may want to disconnect VBAT from VDD. You can
 do it by removing ``SB52`` jumper on the back side of the board.
+
+FDCAN
+=====
+
+The Nucleo H723ZG board does not have any onboard CAN transceiver. In order to
+use the FDCAN bus on this board, an external CAN bus transceiver must be
+connected to pins PD0 (RX) and PD1 (TX).
 
 Programming and Debugging
 *************************

--- a/boards/st/nucleo_h723zg/nucleo_h723zg.dts
+++ b/boards/st/nucleo_h723zg/nucleo_h723zg.dts
@@ -24,6 +24,7 @@
 		zephyr,dtcm = &dtcm;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,canbus = &fdcan1;
 	};
 
 	leds: leds {
@@ -93,6 +94,16 @@
 	div-p = <1>;
 	div-q = <4>;
 	div-r = <2>;
+	clocks = <&clk_hse>;
+	status = "okay";
+};
+
+&pll2 {
+	div-m = <1>;
+	mul-n = <10>;
+	div-p = <1>;
+	div-q = <1>;
+	div-r = <1>;
 	clocks = <&clk_hse>;
 	status = "okay";
 };
@@ -188,5 +199,13 @@ zephyr_udc0: &usbotg_hs {
 };
 
 &rng {
+	status = "okay";
+};
+
+&fdcan1 {
+	pinctrl-0 = <&fdcan1_rx_pd0 &fdcan1_tx_pd1>;
+	pinctrl-names = "default";
+	clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000100>,
+		 <&rcc STM32_SRC_PLL2_Q FDCAN_SEL(2)>;
 	status = "okay";
 };

--- a/boards/st/nucleo_h723zg/nucleo_h723zg.yaml
+++ b/boards/st/nucleo_h723zg/nucleo_h723zg.yaml
@@ -22,4 +22,5 @@ supported:
   - backup_sram
   - usb_device
   - rtc
+  - can
 vendor: st


### PR DESCRIPTION
Enable FDCAN1 on the ST Nucleo H723ZG development board.