### PR TITLE
shell: modules: kernel: print cpu_mask when available

### DIFF
--- a/subsys/shell/modules/kernel_service.c
+++ b/subsys/shell/modules/kernel_service.c
@@ -127,6 +127,10 @@ static void shell_tdata_dump(const struct k_thread *cthread, void *user_data)
 		    k_thread_state_str(thread, state_str, sizeof(state_str)),
 		    thread->entry.pEntry);
 
+#ifdef CONFIG_SCHED_CPU_MASK
+	shell_print(sh, "\tcpu_mask: 0x%x", thread->base.cpu_mask);
+#endif /* CONFIG_SCHED_CPU_MASK */
+
 #ifdef CONFIG_THREAD_RUNTIME_STATS
 	ret = 0;
 


### PR DESCRIPTION
Dump the `cpu_mask` of threads when available.

```
$ kernel threads
Scheduler: 0 since last call
Threads:
...
 0x800123a0 sysworkq  
        options: 0x1, priority: -1 timeout: 0
        state: pending, entry: 0x80009396
    --> cpu_mask: 0x2
        Total execution cycles: 2570 (0 %)
        Current execution cycles: 2570
        Peak execution cycles: 2570
        Average execution cycles: 2570
        stack size 1024, unused 700, usage 324 / 1024 (31 %)
...
```