### PR TITLE
net: Make sure net_buf data size is large enough for IPv6

### DIFF
--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -41,6 +41,17 @@ LOG_MODULE_REGISTER(net_pkt, CONFIG_NET_PKT_LOG_LEVEL);
 #include "net_private.h"
 #include "tcp_internal.h"
 
+/* Make sure net_buf data size is large enough that IPv6
+ * and possible extensions fit to the network buffer.
+ * The check is done using an arbitrarily chosen value 96 by monitoring
+ * wireshark traffic to see what the typical header lengts are.
+ * It is still recommended to use the default value 128 but allow smaller
+ * value if really needed.
+ */
+#if defined(CONFIG_NET_BUF_FIXED_DATA_SIZE) && defined(CONFIG_NET_NATIVE_IPV6)
+BUILD_ASSERT(CONFIG_NET_BUF_DATA_SIZE >= 96);
+#endif /* CONFIG_NET_BUF_FIXED_DATA_SIZE */
+
 /* Find max header size of IP protocol (IPv4 or IPv6) */
 #if defined(CONFIG_NET_IPV6) || defined(CONFIG_NET_RAW_MODE) || \
     defined(CONFIG_NET_SOCKETS_PACKET) || defined(CONFIG_NET_SOCKETS_OFFLOAD)


### PR DESCRIPTION
If IPv6 is enabled, the fixed size net_buf data needs to be large enough so that the full IPv6 header with extensions can fit to one net_buf packet.