### PR TITLE
arm64: thread stack address randomization (ASLR)

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -55,6 +55,7 @@ config ARM64
 	select ARCH_HAS_DIRECTED_IPIS
 	select ARCH_HAS_DEMAND_PAGING
 	select ARCH_HAS_DEMAND_MAPPING
+	select ARCH_SUPPORTS_ASLR
 	help
 	  ARM64 (AArch64) architecture
 
@@ -727,6 +728,11 @@ config ARCH_HAS_THREAD_PRIV_STACK_SPACE_GET
 	bool
 	help
 	  Select when the architecture implements arch_thread_priv_stack_space_get().
+
+config ARCH_SUPPORTS_ASLR
+	bool
+	help
+	  Select when the architecture supports the experimental aslr
 
 #
 # Other architecture related options

--- a/include/zephyr/kernel/thread.h
+++ b/include/zephyr/kernel/thread.h
@@ -172,6 +172,33 @@ struct _thread_stack_info {
 	 */
 	size_t delta;
 
+	/* Enabling this option will allow for the physical stack to be
+	 * randomly mapped to a virtual address. Currently only works on
+	 * ARM64
+	 *
+	 *                     phys        the kernel        virt
+	 *                  address space   randomly     address space
+	 *                +---------------+ chooses a  +---------------+
+	 *                |               | va         |               |
+	 *                |               |        ->  +---------------+ -> va_addr
+	 *                |               |       /    |               |
+	 *                |               |      /     +---------------+ -> start
+	 *                |               |     /      |               |
+	 *                |               |    /       +---------------+ -> stack limit
+	 *   stack_obj -> +---------------+ <-/        |               |
+	 *                |               |            |               |
+	 *       start -> +---------------+            |               |
+	 *                |               |            |               |
+	 *       stack -> +---------------+            |               |
+	 *       limit    |               |            |               |
+	 *                +---------------+            +---------------+
+	 */
+
+#ifdef CONFIG_ASLR
+	/* Base address of the memory mapped thread stack */
+	k_thread_stack_t *va_addr;
+#endif
+
 #if defined(CONFIG_THREAD_STACK_MEM_MAPPED)
 	struct {
 		/** Base address of the memory mapped thread stack */
@@ -324,8 +351,9 @@ struct k_thread {
 	/**
 	 * Base address of thread stack.
 	 *
-	 * If memory mapped stack (CONFIG_THREAD_STACK_MEM_MAPPED)
-	 * is enabled, this is the physical address of the stack.
+	 * If memory mapped stack (CONFIG_THREAD_STACK_MEM_MAPPED ||
+	 * CONFIG_ASLR) is enabled, this is the physical
+	 * address of the stack.
 	 */
 	k_thread_stack_t *stack_obj;
 

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -202,6 +202,27 @@ config THREAD_STACK_MEM_MAPPED
 	  mapped with guard pages on both ends to catch undesired
 	  accesses.
 
+config ASLR
+	bool "Thread stack address randomization [EXPERIMENTAL]"
+	depends on MMU && ARCH_SUPPORTS_ASLR
+	select EXPERIMENTAL
+	help
+	  Enables the ability to map do a non 1:1 mapping for the user thread
+	  stack. The kernel will randomly choose an address that "should" not
+	  be used for.
+
+if ASLR
+
+config ASLR_LOWER_BOUND_VA_ADDRESS
+	hex "Lower Bound for the VA address when choosing it randomly"
+	default 0x50000000
+	depends on MMU && ARCH_SUPPORTS_ASLR
+	help
+	  This value should never be lower than the .text section as to not
+	  overwrite it in a user thread table when mapping PA to VA
+
+endif
+
 config THREAD_ABORT_HOOK
 	bool
 	help


### PR DESCRIPTION
Introduces ASLR for threads stacks (enables the kernel to choose a user thread's stack address randomly).

The benefit of this approach is to have an optional extra layer of security against memory vulnerabilities.

Currently only works on ARM64; additional architecture-specific code is required to support this feature.
### Implementations details:
When this feature is enabled, the stack virtual address is not the same as the physical address.
The address selected by the kernel is between a lower bound set through KConfig and the current max virtual
address. The choice of a lower bound is there to avoid overlapping with any devices or code outside of the application code.

### Questions:
Settings the virtual stack address range through Kconfig is fragile and prone to accidental overlaps. I did it solely to have a fully functional proof-of-concept.
Would you think of any better to do so? Somehow allocate virtual memory (but how to do it statically)? Declare some kind of device in the dts (would need per-board work, but at least we avoid overlaps)? ...? Please advise. 🙂

PS: this is my first PR here. Happy to take any kind of feedback!