### PR TITLE
runners: pyocd: Add support for .elf files to the pyocd flash command

### DIFF
--- a/scripts/west_commands/runners/pyocd.py
+++ b/scripts/west_commands/runners/pyocd.py
@@ -148,18 +148,19 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
             self.debug_debugserver(command, **kwargs)
 
     def flash(self, **kwargs):
+        # Use hex, bin or elf file provided by the buildsystem.
+        # Preferring .hex over .bin and .elf
         if self.hex_name is not None and os.path.isfile(self.hex_name):
             fname = self.hex_name
+        # Preferring .bin over .elf
         elif self.bin_name is not None and os.path.isfile(self.bin_name):
-            self.logger.warning(
-                'hex file ({}) does not exist; falling back on .bin ({}). '.
-                format(self.hex_name, self.bin_name) +
-                'Consider enabling CONFIG_BUILD_OUTPUT_HEX.')
             fname = self.bin_name
+        elif self.elf_name is not None and os.path.isfile(self.elf_name):
+            fname = self.elf_name
         else:
             raise ValueError(
-                'Cannot flash; no hex ({}) or bin ({}) files found. '.format(
-                    self.hex_name, self.bin_name))
+                'Cannot flash; no hex ({}), bin ({}) or elf ({}) files found. '.format(
+                    self.hex_name, self.bin_name, self.elf_name))
 
         erase_method = 'chip' if self.erase else 'sector'
 


### PR DESCRIPTION
As the .bin & .hex build output is optional and it can be disabled by CONFIG_BUILD_OUTPUT_BIN/HEX, 
add support for the mandatory .elf build output to the pyocd runner flash command.