### PR TITLE
doc: fix links to wiki

### DIFF
--- a/doc/contribute/contributor_expectations.rst
+++ b/doc/contribute/contributor_expectations.rst
@@ -254,7 +254,7 @@ the steps below:
 
 .. _dev-review: https://github.com/zephyrproject-rtos/zephyr/labels/dev-review
 
-.. _Zephyr Dev Meeting: https://github.com/zephyrproject-rtos/zephyr/wiki/Zephyr-Committee-and-Working-Group-Meetings#zephyr-dev-meeting
+.. _Zephyr Dev Meeting: https://github.com/zephyrproject-rtos/zephyr/wiki/Zephyr-Committee-and-Working-Groups#zephyr-dev-meeting
 
 .. _Architecture Project: https://github.com/zephyrproject-rtos/zephyr/projects/18
 

--- a/doc/contribute/proposals_and_rfcs.rst
+++ b/doc/contribute/proposals_and_rfcs.rst
@@ -52,4 +52,4 @@ to either label it appropriately or include it in the corresponding GitHub
 project in order for it to be examined during the next meeting.
 
 .. _`RFC template`: https://github.com/zephyrproject-rtos/zephyr/blob/main/.github/ISSUE_TEMPLATE/003_rfc-proposal.md
-.. _`Zephyr meetings`: https://github.com/zephyrproject-rtos/zephyr/wiki/Zephyr-Committee-and-Working-Group-Meetings
+.. _`Zephyr meetings`: https://github.com/zephyrproject-rtos/zephyr/wiki/Zephyr-Committee-and-Working-Groups

--- a/doc/project/dev_env_and_tools.rst
+++ b/doc/project/dev_env_and_tools.rst
@@ -377,13 +377,13 @@ Labels applicable to both pull requests and issues
      - The issue is to be discussed in the following `dev-review`_ if time
        permits.
 
-       .. _`dev-review`: https://github.com/zephyrproject-rtos/zephyr/wiki/Zephyr-Committee-and-Working-Group-Meetings#zephyr-dev-meeting
+       .. _`dev-review`: https://github.com/zephyrproject-rtos/zephyr/wiki/Zephyr-Committee-and-Working-Groups#zephyr-dev-meeting
 
    * - :guilabel:`TSC`
      - TSC stands for Technical Steering Committee. The issue is to be discussed in the
        following `TSC meeting`_ if time permits.
 
-       .. _`TSC meeting`: https://github.com/zephyrproject-rtos/zephyr/wiki/Zephyr-Committee-and-Working-Group-Meetings#technical-steering-committee-tsc
+       .. _`TSC meeting`: https://github.com/zephyrproject-rtos/zephyr/wiki/Technical-Steering-Committee-(TSC)
 
    * - :guilabel:`Breaking API Change`
      - The issue or PR describes a breaking change to a stable API. See additional information


### PR DESCRIPTION
This fixes the broken links to the zephyr wiki in the docs.