### PR TITLE
shell: shell_help: fix terminal offset of subcommands' help text

### DIFF
--- a/subsys/shell/modules/devmem_service.c
+++ b/subsys/shell/modules/devmem_service.c
@@ -315,10 +315,6 @@ static int cmd_devmem(const struct shell *sh, size_t argc, char **argv)
 	uint32_t value = 0;
 	uint8_t width;
 
-	if (argc < 2 || argc > 4) {
-		return -EINVAL;
-	}
-
 	phys_addr = strtoul(argv[1], NULL, 16);
 
 #if defined(CONFIG_MMU) || defined(CONFIG_PCIE)
@@ -365,11 +361,11 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_devmem,
 					     cmd_load, 2, 1),
 			       SHELL_SUBCMD_SET_END);
 
-SHELL_CMD_REGISTER(devmem, &sub_devmem,
+SHELL_CMD_ARG_REGISTER(devmem, &sub_devmem,
 		   "Read/write physical memory\n"
 		   "Usage:\n"
 		   "Read memory at address with optional width:\n"
-		   "devmem address [width]\n"
+		   "devmem <address> [<width>]\n"
 		   "Write memory at address with mandatory width and value:\n"
-		   "devmem address <width> <value>",
-		   cmd_devmem);
+		   "devmem <address> <width> <value>",
+		   cmd_devmem, 2, 2);

--- a/subsys/shell/shell_help.c
+++ b/subsys/shell/shell_help.c
@@ -110,7 +110,8 @@ static void help_item_print(const struct shell *sh, const char *item_name,
 			    uint16_t item_name_width, const char *item_help)
 {
 	static const uint8_t tabulator[] = "  ";
-	const uint16_t offset = 2 * strlen(tabulator) + item_name_width + 1;
+	static const char sub_cmd_sep[] = ": "; /* subcommands separator */
+	const uint16_t offset = 2 * strlen(tabulator) + item_name_width + strlen(sub_cmd_sep);
 
 	if ((item_name == NULL) || (item_name[0] == '\0')) {
 		return;


### PR DESCRIPTION
**before:**

```
uart:~$ devmem -h
devmem - Read/write physical memory
         Usage:
         Read memory at address with optional width:
         devmem address [width]
         Write memory at address with mandatory width and value:
         devmem address <width> <value>
Subcommands:
  dump  : Usage:
         devmem dump -a <address> -s <size> [-w <width>]
        ~~~
         ^ not aligned

  load  : Usage:
         devmem load [options] [address]
        ~~~
         ^ not aligned
Options:
-e      little-endian parse
```

**after:**

```
uart:~$ devmem -h
devmem - Read/write physical memory
         Usage:
         Read memory at address with optional width:
         devmem <address> [<width>]
         Write memory at address with mandatory width and value:
         devmem <address> <width> <value>
Subcommands:
  dump  : Usage:
          devmem dump -a <address> -s <size> [-w <width>]

  load  : Usage:
          devmem load [options] [address]
Options:
-e      little-endian parse
```