### PR TITLE
DX: make the first devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+FROM ghcr.io/zephyrproject-rtos/ci:v0.26.13
+
+# Install gdbserver for enabling GUI debugging in VSCode
+RUN apt-get -y update && \
+	apt-get -y upgrade && \
+	apt-get install --no-install-recommends -y \
+	gdbserver
+
+# See .github/workflows/compliance.yml *cries in requirements.txt*
+RUN pip3 install python-magic lxml junitparser gitlint pylint pykwalify yamllint clang-format unidiff
+
+RUN usermod -s /usr/bin/bash user
+
+USER user
+
+CMD /usr/bin/bash

--- a/.devcontainer/bsim-local/devcontainer.json
+++ b/.devcontainer/bsim-local/devcontainer.json
@@ -1,0 +1,38 @@
+{
+    "name": "Bluetooth w/ babblesim (passthrough workspace)",
+    "build": {"dockerfile": "../Dockerfile"},
+
+    "containerEnv": {
+        "HISTCONTROL": "ignoredups:erasedups",
+        "ZEPHYR_BASE": "/workspaces/zephyr",
+        "ZEPHYR_TOOLCHAIN_VARIANT": "zephyr",
+        "BSIM_OUT_PATH": "/opt/bsim/",
+        "BSIM_COMPONENTS_PATH": "/opt/bsim/components",
+        "EDTT_PATH": "../tools/edtt"
+    },
+
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-vscode.cpptools",
+                "xaver.clang-format",
+                "EditorConfig.EditorConfig"
+            ],
+            "settings": {
+                "extensions.showRecommendationsOnlyOnDemand": true,
+                "files.watcherExclude": {
+                    "${localWorkspaceFolder}/bsim_out/*/**": true
+                }
+            }
+        }
+    },
+
+    "initializeCommand": "mkdir -p ${localWorkspaceFolder}/.cache && touch ${localWorkspaceFolder}/.cache/.bash_history",
+    "onCreateCommand": "git config --global --add safe.directory '*'",
+    "updateContentCommand": "${ZEPHYR_BASE}/.devcontainer/scripts/setup-env.sh && ${ZEPHYR_BASE}/.devcontainer/scripts/setup-bsim.sh",
+
+    "mounts": [
+        "source=${localWorkspaceFolder}/.cache/.bash_history,target=/home/user/.bash_history,type=bind,consistency=cached",
+        "source=${localWorkspaceFolder}/../,target=/workspaces,type=bind,consistency=cached"
+    ]
+}

--- a/.devcontainer/bsim/devcontainer.json
+++ b/.devcontainer/bsim/devcontainer.json
@@ -1,0 +1,36 @@
+{
+    "name": "Bluetooth w/ babblesim",
+    "build": {"dockerfile": "../Dockerfile"},
+
+    "containerEnv": {
+        "HISTCONTROL": "ignoredups:erasedups",
+        "ZEPHYR_BASE": "/workspaces/zephyr",
+        "ZEPHYR_TOOLCHAIN_VARIANT": "zephyr",
+        "BSIM_OUT_PATH": "/opt/bsim/",
+        "BSIM_COMPONENTS_PATH": "/opt/bsim/components",
+        "EDTT_PATH": "../tools/edtt"
+    },
+
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-vscode.cpptools",
+                "xaver.clang-format",
+                "EditorConfig.EditorConfig"
+            ],
+            "settings": {
+                "files.watcherExclude": {
+                    "${localWorkspaceFolder}/bsim_out/*/**": true
+                }
+            }
+        }
+    },
+
+    "initializeCommand": "mkdir -p ${localWorkspaceFolder}/.cache && touch ${localWorkspaceFolder}/.cache/.bash_history",
+    "onCreateCommand": "git config --global --add safe.directory '*'",
+    "updateContentCommand": "${ZEPHYR_BASE}/.devcontainer/scripts/setup-env.sh && ${ZEPHYR_BASE}/.devcontainer/scripts/setup-bsim.sh",
+
+    "mounts": [
+        "source=${localWorkspaceFolder}/.cache/.bash_history,target=/home/user/.bash_history,type=bind,consistency=cached"
+    ]
+}

--- a/.devcontainer/bsim/west-bsim.yml
+++ b/.devcontainer/bsim/west-bsim.yml
@@ -1,0 +1,26 @@
+# A minimal manifest file to develop the Bluetooth stack using the bsim framework
+#
+# TODO: nRF53 / multi-cpu support
+
+manifest:
+  defaults:
+    remote: upstream
+
+  remotes:
+    - name: upstream
+      url-base: https://github.com/zephyrproject-rtos
+    - name: babblesim
+      url-base: https://github.com/BabbleSim
+
+  group-filter: [-optional]
+
+  self:
+    path: zephyr
+    import:
+      file: west.yml
+      name-allowlist:
+        - bsim
+        - cmsis
+        - hal_nordic
+        - nrf_hw_models
+        - tinycrypt

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+    "name": "Zephyr basic",
+    "build": {"dockerfile": "Dockerfile"},
+
+    "containerEnv": {
+        "HISTCONTROL": "ignoredups:erasedups",
+        "ZEPHYR_BASE": "/workspaces/zephyr",
+        "ZEPHYR_TOOLCHAIN_VARIANT": "zephyr"
+    },
+
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-vscode.cpptools",
+                "xaver.clang-format",
+                "EditorConfig.EditorConfig"
+            ]
+        }
+    },
+
+    "onCreateCommand": "git config --global --add safe.directory '*'",
+    "updateContentCommand": "${ZEPHYR_BASE}/.devcontainer/scripts/setup-env.sh",
+}

--- a/.devcontainer/scripts/setup-bsim.sh
+++ b/.devcontainer/scripts/setup-bsim.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+
+echo "Updating and rebuilding BSIM"
+
+export BSIM_VERSION=$( west list bsim -f {revision} )
+echo "Manifest points to bsim sha $BSIM_VERSION"
+
+cd /opt/bsim_west/bsim
+
+git fetch -n origin ${BSIM_VERSION}
+git -c advice.detachedHead=false checkout ${BSIM_VERSION}
+
+west update
+make everything -s -j 8
+
+echo "Updated and re-built BSIM"

--- a/.devcontainer/scripts/setup-env.sh
+++ b/.devcontainer/scripts/setup-env.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+
+echo "Setting up environment"
+
+export ZEPHYR_SDK_INSTALL_DIR="/opt/toolchains/zephyr-sdk-$( cat SDK_VERSION )"
+
+# Skip if a workspace already exists
+config_path="/workspaces/.west/config"
+if [ -f "$config_path" ]; then
+    echo "West .config exists, skipping init and update."
+    exit 0
+fi
+
+# Can that have bad consequences if host UID != 1000?
+sudo chown user:user /workspaces
+
+# When checking out a single PR or branch, vscode will perform a shallow clone.
+# Fetch the whole remote in order to be able to run check_compliance.py against
+# origin/main (or any other branch in origin).
+cd /workspaces/zephyr
+git fetch origin
+cd -
+
+# Set up west workspace.
+# If we are building a bsim devcontainer, we don't need the whole set, just a
+# minimal configuration.
+if [[ -z "${BSIM_OUT_PATH+x}" ]]; then
+    west init -l --mf west.yml
+else
+    west init -l --mf .devcontainer/bsim/west-bsim.yml
+fi
+west config --global update.narrow true
+west update
+
+# Reset every project except the main zephyr repo.
+#
+# I can't "just" use $(pwd) or shell expansion as it will be expanded _before_
+# the command is executed in every west project.
+west forall -c 'pwd | xargs basename | xargs test "zephyr" != && git reset --hard HEAD' || true
+
+echo "West initialized successfully"

--- a/doc/develop/devcontainer.rst
+++ b/doc/develop/devcontainer.rst
@@ -1,0 +1,89 @@
+.. _devcontainer:
+
+Developing with DevContainers
+#############################
+
+What is a devcontainer
+**********************
+
+To put it simply, a devcontainer is a disposable, self-contained development
+environment, closely coupled to an editor or IDE.
+
+It enables developers to not waste time installing and maintaining an up-to-date
+toolchain for a given project.
+
+The initial implementation comes from the visual studio code editor, but is now
+an open specification and has support from other editors, e.g. `Jetbrains`_,
+`command-line interface`_.
+
+Why use devcontainers
+*********************
+
+Here are a few use-cases:
+
+- Work on a computer with no admin rights
+- Work on a computer that cannot install the tools (e.g. using babblesim on Windows)
+- Author a small patch: faster feedback for ``check_compliance.py``
+- Try a `pull request`_ without modifying your local west workspace
+
+How do I use devcontainers
+**************************
+
+This document describes two ways of using devcontainers. One is to use a
+cloud-based instance on github codespaces, the other is using a local
+installation of the VSCode editor.
+
+Github codespaces
+=================
+
+.. warning::
+   The current CI image is too big for the Github codespace builder. Until that
+   is fixed, the devcontainer can unfortunately only be used locally.
+
+The `cloud option`_. It is a paid service, but they have `free minutes`_. At the
+time of writing, those were 60 hours of uptime per month, using the smallest
+machine option (2core, 8GB ram).
+
+1. Log in to github
+#. Using a recent web browser, go to `github codespaces`_
+#. Click on the "Create codespace" button
+#. Select the ``zephyrproject-rtos/zephyr`` repository
+#. Select which codespace you want to instantiate
+#. Click on "Create codespace"
+#. Walk to starbucks, buy a coffee (it takes a while to load)
+#. You are dropped into a vscode instance with the Zephyr toolchain. Depending
+   on the chosen codespace, you may have a subset of the default west projects
+   and some other tools installed (e.g. The Babblesim codespace has a minimal
+   west checkout and the babblesim tools installed and updated).
+
+Local VSCode
+============
+
+The local option. Completely free. Expect ~10GB of disk usage.
+
+See the `official installation guide`_ for more details.
+
+1. Install docker, add yourself to the ``docker`` group
+#. Install and open `vscode`_
+#. Install the `devcontainers extension`_
+#. Clone the `zephyr repo`_
+#. In VSCode, run the "Dev Containers: `open folder`_ in container" command and
+   select the path where the zephyr project is cloned.
+#. Select the right devcontainer from the list. E.g. "Bluetooth w/ Babblesim".
+#. Brace for bandwidth (and disk) usage..
+#. You are dropped into a vscode instance with the Zephyr toolchain. Depending
+   on the chosen codespace, you may have a subset of the default west projects
+   and some other tools installed (e.g. The Babblesim codespace has a minimal
+   west checkout and the babblesim tools installed and updated).
+
+.. _`Jetbrains`: https://plugins.jetbrains.com/plugin/21962-dev-containers
+.. _`command-line interface`: https://code.visualstudio.com/docs/devcontainers/devcontainer-cli
+.. _`github codespaces`: https://github.com/codespaces
+.. _`pull request`: https://code.visualstudio.com/docs/devcontainers/containers#_quick-start-open-a-git-repository-or-github-pr-in-an-isolated-container-volume
+.. _`free minutes`: https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces#monthly-included-storage-and-core-hours-for-personal-accounts
+.. _`cloud option`: https://docs.github.com/en/codespaces/overview
+.. _`devcontainers extension`: https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers
+.. _`vscode`: https://code.visualstudio.com/
+.. _`zephyr repo`: https://github.com/zephyrproject-rtos/zephyr
+.. _`official installation guide`: https://code.visualstudio.com/docs/devcontainers/containers#_installation
+.. _`open folder`: https://code.visualstudio.com/docs/devcontainers/containers#_quick-start-open-an-existing-folder-in-a-container

--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -11,6 +11,8 @@ Follow this guide to:
 - Get the source code
 - Build, flash, and run a sample application
 
+Alternatively, use the experimental :ref:`Devcontainer support <devcontainer>`.
+
 .. _host_setup:
 
 Select and Update OS

--- a/doc/develop/index.rst
+++ b/doc/develop/index.rst
@@ -7,6 +7,7 @@ Developing with Zephyr
    :maxdepth: 1
 
    getting_started/index.rst
+   devcontainer.rst
    beyond-GSG.rst
    env_vars.rst
    application/index.rst


### PR DESCRIPTION
This PR adds 3 devcontainer [1] environments.
1. "Zephyr basic": run twister, check_compliance.py
2. "Bluetooth w/ babblesim" contribute to the Bluetooth subsystem.

The containers are based on the Zephyr CI image.

These environments are directly usable on Github codespaces [3], and enable contributors to develop features, bug fixes and tests armed with only a browser (and some $$$).

They are also usable locally, with Visual Studio Code. Tested on linux with native docker, but should also work on Windows with WSL.

For this first version there are a few rough edges, notably:

- CI image is bloated with unnecessary toolchains
- Image has repo cache. Maybe faster if we just clone from scratch
- The ubuntu system in the image is "minimized". That means a bunch of QoL features are disabled, like shell completion.

[1] What are devcontainers:
https://code.visualstudio.com/docs/devcontainers/create-dev-container

[2] Devcontainer specification:
https://containers.dev/implementors/json_reference/ https://containers.dev/implementors/spec/

[3] Codespaces (hosted devcontainer platform)
https://github.com/codespaces