### PR TITLE
intel_adsp: debug_window: Add slot type for debug-stream transport

### DIFF
--- a/soc/intel/intel_adsp/common/include/adsp_debug_window.h
+++ b/soc/intel/intel_adsp/common/include/adsp_debug_window.h
@@ -53,6 +53,7 @@
 #define ADSP_DW_SLOT_TELEMETRY		0x4c455400
 #define ADSP_DW_SLOT_TRACE		0x54524143
 #define ADSP_DW_SLOT_SHELL		0x73686c6c
+#define ADSP_DW_SLOT_DEBUG_STREAM	0x53523134
 #define ADSP_DW_SLOT_BROKEN		0x44414544
 
  /* for debug and critical types */


### PR DESCRIPTION
Add slot type for debug-stream transport over a debug window slot. For details see src/debug/debug_stream/debug_stream_slot.h under SOF sources [1].

[1] https://github.com/thesofproject/sof