### PR TITLE
net: shell: include stdio.h to fix build warning

### DIFF
--- a/subsys/net/lib/shell/cm.c
+++ b/subsys/net/lib/shell/cm.c
@@ -9,6 +9,7 @@ LOG_MODULE_DECLARE(net_shell);
 
 #include <zephyr/net/net_if.h>
 #include <strings.h>
+#include <stdio.h>
 #include <ctype.h>
 
 #include "net_shell_private.h"


### PR DESCRIPTION
This commit fixes a build warning about implicit
declaration of snprintf