### PR TITLE
scripts: handle auto defined ZEPHYR_<name>_MODULE settings in compliance

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -380,11 +380,6 @@ class KconfigCheck(ComplianceTest):
         This is needed to complete Kconfig sanity tests.
 
         """
-        if self.no_modules:
-            with open(modules_file, 'w') as fp_module_file:
-                fp_module_file.write("# Empty\n")
-            return
-
         # Invoke the script directly using the Python executable since this is
         # not a module nor a pip-installed Python utility
         zephyr_module_path = os.path.join(ZEPHYR_BASE, "scripts",
@@ -411,6 +406,18 @@ class KconfigCheck(ComplianceTest):
                     modules_dir + '/' + module + '/Kconfig'
                 ))
             fp_module_file.write(content)
+
+        if self.no_modules:
+            module_define_content = ""
+            module_definition = re.compile('config ZEPHYR_.*_MODULE.*').search
+            with open(modules_file, 'r+') as fp_module_file:
+                for line in fp_module_file:
+                    if module_definition(line):
+                        module_define_content += line
+                        module_define_content += "\tbool\n"
+                fp_module_file.seek(0)
+                fp_module_file.write(module_define_content)
+                fp_module_file.truncate()
 
     def get_module_setting_root(self, root, settings_file):
         """


### PR DESCRIPTION
Update check_compliance to handle auto defined `ZEPHYR_<name>_MODULE` Kconfig symbols.

check_compliance runs three levels of Kconfig check. A basic and a full, both which uses the generated Kconfig.modules created according to Zephyr modules present.

A Kconfig check where no Zephyr modules are sourced. This check ensures that Zephyr Kconfig tree doesn't refer to Kconfig symbols defined in Zephyr module's local Kconfig trees.

However, there are a few auto generated symbols which are allowed, such as: `ZEPHYR_<name>_MODULE` and `ZEPHYR_<name>_MODULE_BLOBS`.

Therefore, when testing no blobs, filter the generated Kconfig.modules file, so that no sourcing of extra Kconfig files are performed but lines defining `ZEPHYR_<name>_MODULE` and `ZEPHYR_<name>_MODULE_BLOBS` are preserved.