### PR TITLE
MAINTAINERS: Exclude BT ISO from BT Host

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -414,6 +414,8 @@ Bluetooth Host:
     - subsys/bluetooth/shell/ll.h
     - subsys/bluetooth/shell/ticker.c
     - subsys/bluetooth/Kconfig.iso
+    - subsys/bluetooth/host/iso.c
+    - subsys/bluetooth/host/iso_internal.h
     - tests/bluetooth/audio/
     - tests/bluetooth/controller/
     - tests/bluetooth/ctrl*/
@@ -526,6 +528,8 @@ Bluetooth ISO:
     - samples/bluetooth/iso_*/
     - subsys/bluetooth/shell/iso.c
     - subsys/bluetooth/Kconfig.iso
+    - subsys/bluetooth/host/iso.c
+    - subsys/bluetooth/host/iso_internal.h
   labels:
     - "area: Bluetooth ISO"
     - "area: Bluetooth"


### PR DESCRIPTION
Changes to ISO files should only get the BT ISO label and not the BT host label.