### PR TITLE
scripts: twister: Enhance TestCase/Instance information and presentation

### DIFF
--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -584,39 +584,43 @@ class Reporting:
             pass_rate = 0
 
         logger.info(
-            "{}{} of {}{} test configurations passed ({:.2%}), {} built (not run), {}{}{} failed, {}{}{} errored, {} skipped with {}{}{} warnings in {:.2f} seconds".format(
-                Fore.RED if failed else Fore.GREEN,
-                results.passed,
-                results.total,
-                Fore.RESET,
-                pass_rate,
-                results.notrun,
-                Fore.RED if results.failed else Fore.RESET,
-                results.failed,
-                Fore.RESET,
-                Fore.RED if results.error else Fore.RESET,
-                results.error,
-                Fore.RESET,
-                results.skipped_configs,
-                Fore.YELLOW if self.plan.warnings else Fore.RESET,
-                self.plan.warnings,
-                Fore.RESET,
-                duration))
+            f"{TwisterStatus.get_color(TwisterStatus.FAIL) if failed else TwisterStatus.get_color(TwisterStatus.PASS)}{results.passed}"
+            f" of {results.total - results.skipped_configs}{Fore.RESET}"
+            f" executed test configurations passed ({pass_rate:.2%}),"
+            f" {f'{TwisterStatus.get_color(TwisterStatus.NOTRUN)}{results.notrun}{Fore.RESET}' if results.notrun else f'{results.notrun}'} built (not run),"
+            f" {f'{TwisterStatus.get_color(TwisterStatus.FAIL)}{results.failed}{Fore.RESET}' if results.failed else f'{results.failed}'} failed,"
+            f" {f'{TwisterStatus.get_color(TwisterStatus.ERROR)}{results.error}{Fore.RESET}' if results.error else f'{results.error}'} errored,"
+            f" with {f'{Fore.YELLOW}{self.plan.warnings}{Fore.RESET}' if self.plan.warnings else 'no'} warnings"
+            f" in {duration:.2f} seconds."
+        )
 
         total_platforms = len(self.platforms)
         # if we are only building, do not report about tests being executed.
         if self.platforms and not self.env.options.build_only:
-            logger.info("In total {} test cases were executed, {} skipped on {} out of total {} platforms ({:02.2f}%)".format(
-                results.cases - results.skipped_cases - results.notrun,
-                results.skipped_cases,
-                len(self.filtered_platforms),
-                total_platforms,
-                (100 * len(self.filtered_platforms) / len(self.platforms))
-            ))
+            executed_cases = results.cases - results.filtered_cases - results.skipped_cases - results.notrun_cases
+            pass_rate = 100 * (float(results.passed_cases) / float(executed_cases)) \
+                if executed_cases != 0 else 0
+            platform_rate = (100 * len(self.filtered_platforms) / len(self.platforms))
+            logger.info(
+                f'{results.passed_cases} of {executed_cases} executed test cases passed ({pass_rate:02.2f}%)'
+                f'{", " + str(results.blocked_cases) + " blocked" if results.blocked_cases else ""}'
+                f'{", " + str(results.failed_cases) + " failed" if results.failed_cases else ""}'
+                f'{", " + str(results.error_cases) + " errored" if results.error_cases else ""}'
+                f'{", " + str(results.none_cases) + " without a status" if results.none_cases else ""}'
+                f' on {len(self.filtered_platforms)} out of total {total_platforms} platforms ({platform_rate:02.2f}%).'
+            )
+            if results.skipped_cases or results.filtered_cases or results.notrun_cases:
+                logger.info(
+                    f'{results.skipped_cases + results.filtered_cases} selected test cases not executed:' \
+                    f'{" " + str(results.skipped_cases) + " skipped" if results.skipped_cases else ""}' \
+                    f'{(", " if results.skipped_cases else " ") + str(results.filtered_cases) + " filtered" if results.filtered_cases else ""}' \
+                    f'{(", " if results.skipped_cases or results.filtered_cases else " ") + str(results.notrun_cases) + " not run (built only)" if results.notrun_cases else ""}' \
+                    f'.'
+                )
 
         built_only = results.total - run - results.skipped_configs
         logger.info(f"{Fore.GREEN}{run}{Fore.RESET} test configurations executed on platforms, \
-{Fore.RED}{built_only}{Fore.RESET} test configurations were only built.")
+{TwisterStatus.get_color(TwisterStatus.NOTRUN)}{built_only}{Fore.RESET} test configurations were only built.")
 
     def save_reports(self, name, suffix, report_dir, no_update, platform_reports):
         if not self.instances:

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+from math import log10
 import multiprocessing
 import os
 import pickle
@@ -62,12 +63,16 @@ class ExecutionCounter(object):
     def __init__(self, total=0):
         '''
         Most of the stats are at test instance level
-        Except that "_cases" and "_skipped_cases" are for cases of ALL test instances
+        Except that case statistics are for cases of ALL test instances
 
-        total complete = done + skipped_filter
         total = yaml test scenarios * applicable platforms
-        complete perctenage = (done + skipped_filter) / total
+        done := instances that reached report_out stage of the pipeline
+        done = skipped_configs + passed + failed + error
+        completed = done - skipped_filter
+        skipped_configs = skipped_runtime + skipped_filter
+
         pass rate = passed / (total - skipped_configs)
+        case pass rate = passed_cases / (cases - filtered_cases - skipped_cases)
         '''
         # instances that go through the pipeline
         # updated by report_out()
@@ -92,12 +97,9 @@ class ExecutionCounter(object):
         # updated by report_out()
         self._skipped_runtime = Value('i', 0)
 
-        # staic filtered at yaml parsing time
+        # static filtered at yaml parsing time
         # updated by update_counting_before_pipeline()
         self._skipped_filter = Value('i', 0)
-
-        # updated by update_counting_before_pipeline() and report_out()
-        self._skipped_cases = Value('i', 0)
 
         # updated by report_out() in pipeline
         self._error = Value('i', 0)
@@ -106,25 +108,83 @@ class ExecutionCounter(object):
         # initialized to number of test instances
         self._total = Value('i', total)
 
+        #######################################
+        # TestCase counters for all instances #
+        #######################################
         # updated in report_out
         self._cases = Value('i', 0)
+
+        # updated by update_counting_before_pipeline() and report_out()
+        self._skipped_cases = Value('i', 0)
+        self._filtered_cases = Value('i', 0)
+
+        # updated by report_out() in pipeline
+        self._passed_cases = Value('i', 0)
+        self._notrun_cases = Value('i', 0)
+        self._failed_cases = Value('i', 0)
+        self._error_cases = Value('i', 0)
+        self._blocked_cases = Value('i', 0)
+
+        # Incorrect statuses
+        self._none_cases = Value('i', 0)
+        self._started_cases = Value('i', 0)
+
+
         self.lock = Lock()
 
+    @staticmethod
+    def _find_number_length(n):
+        if n > 0:
+            length = int(log10(n))+1
+        elif n == 0:
+            length = 1
+        else:
+            length = int(log10(-n))+2
+        return length
+
     def summary(self):
-        print("--------------------------------")
-        print(f"Total test suites: {self.total}") # actually test instances
-        print(f"Total test cases: {self.cases}")
-        print(f"Executed test cases: {self.cases - self.skipped_cases}")
-        print(f"Skipped test cases: {self.skipped_cases}")
-        print(f"Completed test suites: {self.done}")
-        print(f"Passing test suites: {self.passed}")
-        print(f"Built only test suites: {self.notrun}")
-        print(f"Failing test suites: {self.failed}")
-        print(f"Skipped test suites: {self.skipped_configs}")
-        print(f"Skipped test suites (runtime): {self.skipped_runtime}")
-        print(f"Skipped test suites (filter): {self.skipped_filter}")
-        print(f"Errors: {self.error}")
-        print("--------------------------------")
+        executed_cases = self.cases - self.skipped_cases - self.filtered_cases
+        completed_configs = self.done - self.skipped_filter
+
+        # Find alignment length for aesthetic printing
+        suites_n_length = self._find_number_length(self.total if self.total > self.done else self.done)
+        processed_suites_n_length = self._find_number_length(self.done)
+        completed_suites_n_length = self._find_number_length(completed_configs)
+        skipped_suites_n_length = self._find_number_length(self.skipped_configs)
+        total_cases_n_length = self._find_number_length(self.cases)
+        executed_cases_n_length = self._find_number_length(executed_cases)
+
+        print("--------------------------------------------------")
+        print(f"{'Total test suites: ':<23}{self.total:>{suites_n_length}}") # actually test instances
+        print(f"{'Processed test suites: ':<23}{self.done:>{suites_n_length}}")
+        print(f"├─ {'Filtered test suites (static): ':<37}{self.skipped_filter:>{processed_suites_n_length}}")
+        print(f"└─ {'Completed test suites: ':<37}{completed_configs:>{processed_suites_n_length}}")
+        print(f"   ├─ {'Filtered test suites (at runtime): ':<37}{self.skipped_runtime:>{completed_suites_n_length}}")
+        print(f"   ├─ {'Passed test suites: ':<37}{self.passed:>{completed_suites_n_length}}")
+        print(f"   ├─ {'Built only test suites: ':<37}{self.notrun:>{completed_suites_n_length}}")
+        print(f"   ├─ {'Failed test suites: ':<37}{self.failed:>{completed_suites_n_length}}")
+        print(f"   └─ {'Errors in test suites: ':<37}{self.error:>{completed_suites_n_length}}")
+        print(f"")
+        print(f"{'Filtered test suites: ':<21}{self.skipped_configs}")
+        print(f"├─ {'Filtered test suites (static): ':<37}{self.skipped_filter:>{skipped_suites_n_length}}")
+        print(f"└─ {'Filtered test suites (at runtime): ':<37}{self.skipped_runtime:>{skipped_suites_n_length}}")
+        print("----------------------      ----------------------")
+        print(f"{'Total test cases: ':<18}{self.cases}")
+        print(f"├─ {'Filtered test cases: ':<21}{self.filtered_cases:>{total_cases_n_length}}")
+        print(f"├─ {'Skipped test cases: ':<21}{self.skipped_cases:>{total_cases_n_length}}")
+        print(f"└─ {'Executed test cases: ':<21}{executed_cases:>{total_cases_n_length}}")
+        print(f"   ├─ {'Passed test cases: ':<25}{self.passed_cases:>{executed_cases_n_length}}")
+        print(f"   ├─ {'Built only test cases: ':<25}{self.notrun_cases:>{executed_cases_n_length}}")
+        print(f"   ├─ {'Blocked test cases: ':<25}{self.blocked_cases:>{executed_cases_n_length}}")
+        print(f"   ├─ {'Failed test cases: ':<25}{self.failed_cases:>{executed_cases_n_length}}")
+        print(f"   {'├' if self.none_cases or self.started_cases else '└'}─ {'Errors in test cases: ':<25}{self.error_cases:>{executed_cases_n_length}}")
+        if self.none_cases or self.started_cases:
+            print(f"   ├──── The following test case statuses should not appear in a proper execution ───")
+        if self.none_cases:
+            print(f"   {'├' if self.started_cases else '└'}─ {'Statusless test cases: ':<25}{self.none_cases:>{executed_cases_n_length}}")
+        if self.started_cases:
+            print(f"   └─ {'Test cases only started: ':<25}{self.started_cases:>{executed_cases_n_length}}")
+        print("--------------------------------------------------")
 
     @property
     def cases(self):
@@ -136,6 +196,10 @@ class ExecutionCounter(object):
         with self._cases.get_lock():
             self._cases.value = value
 
+    def cases_increment(self, value=1):
+        with self._cases.get_lock():
+            self._cases.value += value
+
     @property
     def skipped_cases(self):
         with self._skipped_cases.get_lock():
@@ -145,6 +209,122 @@ class ExecutionCounter(object):
     def skipped_cases(self, value):
         with self._skipped_cases.get_lock():
             self._skipped_cases.value = value
+
+    def skipped_cases_increment(self, value=1):
+        with self._skipped_cases.get_lock():
+            self._skipped_cases.value += value
+
+    @property
+    def filtered_cases(self):
+        with self._filtered_cases.get_lock():
+            return self._filtered_cases.value
+
+    @filtered_cases.setter
+    def filtered_cases(self, value):
+        with self._filtered_cases.get_lock():
+            self._filtered_cases.value = value
+
+    def filtered_cases_increment(self, value=1):
+        with self._filtered_cases.get_lock():
+            self._filtered_cases.value += value
+
+    @property
+    def passed_cases(self):
+        with self._passed_cases.get_lock():
+            return self._passed_cases.value
+
+    @passed_cases.setter
+    def passed_cases(self, value):
+        with self._passed_cases.get_lock():
+            self._passed_cases.value = value
+
+    def passed_cases_increment(self, value=1):
+        with self._passed_cases.get_lock():
+            self._passed_cases.value += value
+
+    @property
+    def notrun_cases(self):
+        with self._notrun_cases.get_lock():
+            return self._notrun_cases.value
+
+    @notrun_cases.setter
+    def notrun_cases(self, value):
+        with self._notrun.get_lock():
+            self._notrun.value = value
+
+    def notrun_cases_increment(self, value=1):
+        with self._notrun_cases.get_lock():
+            self._notrun_cases.value += value
+
+    @property
+    def failed_cases(self):
+        with self._failed_cases.get_lock():
+            return self._failed_cases.value
+
+    @failed_cases.setter
+    def failed_cases(self, value):
+        with self._failed_cases.get_lock():
+            self._failed_cases.value = value
+
+    def failed_cases_increment(self, value=1):
+        with self._failed_cases.get_lock():
+            self._failed_cases.value += value
+
+    @property
+    def error_cases(self):
+        with self._error_cases.get_lock():
+            return self._error_cases.value
+
+    @error_cases.setter
+    def error_cases(self, value):
+        with self._error_cases.get_lock():
+            self._error_cases.value = value
+
+    def error_cases_increment(self, value=1):
+        with self._error_cases.get_lock():
+            self._error_cases.value += value
+
+    @property
+    def blocked_cases(self):
+        with self._blocked_cases.get_lock():
+            return self._blocked_cases.value
+
+    @blocked_cases.setter
+    def blocked_cases(self, value):
+        with self._blocked_cases.get_lock():
+            self._blocked_cases.value = value
+
+    def blocked_cases_increment(self, value=1):
+        with self._blocked_cases.get_lock():
+            self._blocked_cases.value += value
+
+    @property
+    def none_cases(self):
+        with self._none_cases.get_lock():
+            return self._none_cases.value
+
+    @none_cases.setter
+    def none_cases(self, value):
+        with self._none_cases.get_lock():
+            self._none_cases.value = value
+
+    def none_cases_increment(self, value=1):
+        with self._none_cases.get_lock():
+            self._none_cases.value += value
+
+    @property
+    def started_cases(self):
+        with self._started_cases.get_lock():
+            return self._started_cases.value
+
+    @started_cases.setter
+    def started_cases(self, value):
+        with self._started_cases.get_lock():
+            self._started_cases.value = value
+
+    def started_cases_increment(self, value=1):
+        with self._started_cases.get_lock():
+            self._started_cases.value += value
 
     @property
     def error(self):
@@ -156,6 +336,10 @@ class ExecutionCounter(object):
         with self._error.get_lock():
             self._error.value = value
 
+    def error_increment(self, value=1):
+        with self._error.get_lock():
+            self._error.value += value
+
     @property
     def iteration(self):
         with self._iteration.get_lock():
@@ -165,6 +349,10 @@ class ExecutionCounter(object):
     def iteration(self, value):
         with self._iteration.get_lock():
             self._iteration.value = value
+
+    def iteration_increment(self, value=1):
+        with self._iteration.get_lock():
+            self._iteration.value += value
 
     @property
     def done(self):
@@ -176,6 +364,10 @@ class ExecutionCounter(object):
         with self._done.get_lock():
             self._done.value = value
 
+    def done_increment(self, value=1):
+        with self._done.get_lock():
+            self._done.value += value
+
     @property
     def passed(self):
         with self._passed.get_lock():
@@ -185,6 +377,10 @@ class ExecutionCounter(object):
     def passed(self, value):
         with self._passed.get_lock():
             self._passed.value = value
+
+    def passed_increment(self, value=1):
+        with self._passed.get_lock():
+            self._passed.value += value
 
     @property
     def notrun(self):
@@ -196,6 +392,10 @@ class ExecutionCounter(object):
         with self._notrun.get_lock():
             self._notrun.value = value
 
+    def notrun_increment(self, value=1):
+        with self._notrun.get_lock():
+            self._notrun.value += value
+
     @property
     def skipped_configs(self):
         with self._skipped_configs.get_lock():
@@ -205,6 +405,10 @@ class ExecutionCounter(object):
     def skipped_configs(self, value):
         with self._skipped_configs.get_lock():
             self._skipped_configs.value = value
+
+    def skipped_configs_increment(self, value=1):
+        with self._skipped_configs.get_lock():
+            self._skipped_configs.value += value
 
     @property
     def skipped_filter(self):
@@ -216,6 +420,10 @@ class ExecutionCounter(object):
         with self._skipped_filter.get_lock():
             self._skipped_filter.value = value
 
+    def skipped_filter_increment(self, value=1):
+        with self._skipped_filter.get_lock():
+            self._skipped_filter.value += value
+
     @property
     def skipped_runtime(self):
         with self._skipped_runtime.get_lock():
@@ -225,6 +433,10 @@ class ExecutionCounter(object):
     def skipped_runtime(self, value):
         with self._skipped_runtime.get_lock():
             self._skipped_runtime.value = value
+
+    def skipped_runtime_increment(self, value=1):
+        with self._skipped_runtime.get_lock():
+            self._skipped_runtime.value += value
 
     @property
     def failed(self):
@@ -236,10 +448,23 @@ class ExecutionCounter(object):
         with self._failed.get_lock():
             self._failed.value = value
 
+    def failed_increment(self, value=1):
+        with self._failed.get_lock():
+            self._failed.value += value
+
     @property
     def total(self):
         with self._total.get_lock():
             return self._total.value
+
+    @total.setter
+    def total(self, value):
+        with self._total.get_lock():
+            self._total.value = value
+
+    def total_increment(self, value=1):
+        with self._total.get_lock():
+            self._total.value += value
 
 class CMake:
     config_re = re.compile('(CONFIG_[A-Za-z0-9_]+)[=]\"?([^\"]*)\"?$')
@@ -652,7 +877,7 @@ class ProjectBuilder(FilterBuilder):
                         logger.debug("filtering %s" % self.instance.name)
                         self.instance.status = TwisterStatus.FILTER
                         self.instance.reason = "runtime filter"
-                        results.skipped_runtime += 1
+                        results.skipped_runtime_increment()
                         self.instance.add_missing_case_status(TwisterStatus.SKIP)
                         next_op = 'report'
                     else:
@@ -683,7 +908,7 @@ class ProjectBuilder(FilterBuilder):
                         logger.debug("filtering %s" % self.instance.name)
                         self.instance.status = TwisterStatus.FILTER
                         self.instance.reason = "runtime filter"
-                        results.skipped_runtime += 1
+                        results.skipped_runtime_increment()
                         self.instance.add_missing_case_status(TwisterStatus.SKIP)
                         next_op = 'report'
                     else:
@@ -710,7 +935,7 @@ class ProjectBuilder(FilterBuilder):
                     # Count skipped cases during build, for example
                     # due to ram/rom overflow.
                     if  self.instance.status == TwisterStatus.SKIP:
-                        results.skipped_runtime += 1
+                        results.skipped_runtime_increment()
                         self.instance.add_missing_case_status(TwisterStatus.SKIP, self.instance.reason)
 
                     if ret.get('returncode', 1) > 0:
@@ -1068,52 +1293,84 @@ class ProjectBuilder(FilterBuilder):
             with open(file_path, "wt") as file:
                 file.write(data)
 
+    @staticmethod
+    def _add_instance_testcases_to_status_counts(instance, results, decrement=False):
+        increment_value = -1 if decrement else 1
+        for tc in instance.testcases:
+            match tc.status:
+                case TwisterStatus.PASS:
+                    results.passed_cases_increment(increment_value)
+                case TwisterStatus.NOTRUN:
+                    results.notrun_cases_increment(increment_value)
+                case TwisterStatus.BLOCK:
+                    results.blocked_cases_increment(increment_value)
+                case TwisterStatus.SKIP:
+                    results.skipped_cases_increment(increment_value)
+                case TwisterStatus.FILTER:
+                    results.filtered_cases_increment(increment_value)
+                case TwisterStatus.ERROR:
+                    results.error_cases_increment(increment_value)
+                case TwisterStatus.FAIL:
+                    results.failed_cases_increment(increment_value)
+                # Statuses that should not appear.
+                # Crashing Twister at this point would be counterproductive,
+                # but having those statuses in this part of processing is an error.
+                case TwisterStatus.NONE:
+                    results.none_cases_increment(increment_value)
+                    logger.error(f'A None status detected in instance {instance.name},'
+                                 f' test case {tc.name}.')
+                case TwisterStatus.STARTED:
+                    results.started_cases_increment(increment_value)
+                    logger.error(f'A started status detected in instance {instance.name},'
+                                 f' test case {tc.name}.')
+                case _:
+                    logger.error(f'An unknown status "{tc.status}" detected in instance {instance.name},'
+                                 f' test case {tc.name}.')
+
+
     def report_out(self, results):
-        total_to_do = results.total
+        total_to_do = results.total - results.skipped_filter
         total_tests_width = len(str(total_to_do))
-        results.done += 1
+        results.done_increment()
         instance = self.instance
         if results.iteration == 1:
-            results.cases += len(instance.testcases)
+            results.cases_increment(len(instance.testcases))
+
+        self._add_instance_testcases_to_status_counts(instance, results)
+
+        status = f'{TwisterStatus.get_color(instance.status)}{str.upper(instance.status)}{Fore.RESET}'
 
         if instance.status in [TwisterStatus.ERROR, TwisterStatus.FAIL]:
             if instance.status == TwisterStatus.ERROR:
-                results.error += 1
-                txt = " ERROR "
+                results.error_increment()
             else:
-                results.failed += 1
-                txt = " FAILED "
+                results.failed_increment()
             if self.options.verbose:
-                status = Fore.RED + txt + Fore.RESET + instance.reason
+                status += " " + instance.reason
             else:
                 logger.error(
-                    "{:<25} {:<50} {}{}{}: {}".format(
+                    "{:<25} {:<50} {}: {}".format(
                         instance.platform.name,
                         instance.testsuite.name,
-                        Fore.RED,
-                        txt,
-                        Fore.RESET,
+                        status,
                         instance.reason))
             if not self.options.verbose:
                 self.log_info_file(self.options.inline_logs)
-        elif instance.status in [TwisterStatus.SKIP, TwisterStatus.FILTER]:
-            status = Fore.YELLOW + "SKIPPED" + Fore.RESET
-            results.skipped_configs += 1
-            # test cases skipped at the test instance level
-            results.skipped_cases += len(instance.testsuite.testcases)
+        elif instance.status == TwisterStatus.SKIP:
+            results.skipped_configs_increment()
+        elif instance.status == TwisterStatus.FILTER:
+            results.skipped_configs_increment()
         elif instance.status == TwisterStatus.PASS:
-            status = Fore.GREEN + "PASSED" + Fore.RESET
-            results.passed += 1
+            results.passed_increment()
             for case in instance.testcases:
                 # test cases skipped at the test case level
                 if case.status == TwisterStatus.SKIP:
-                    results.skipped_cases += 1
+                    results.skipped_cases_increment()
         elif instance.status == TwisterStatus.NOTRUN:
-            status = Fore.CYAN + "NOT RUN" + Fore.RESET
-            results.notrun += 1
+            results.notrun_increment()
             for case in instance.testcases:
                 if case.status == TwisterStatus.SKIP:
-                    results.skipped_cases += 1
+                    results.skipped_cases_increment()
         else:
             logger.debug(f"Unknown status = {instance.status}")
             status = Fore.YELLOW + "UNKNOWN" + Fore.RESET
@@ -1139,7 +1396,7 @@ class ProjectBuilder(FilterBuilder):
                      and self.instance.handler.seed is not None ):
                     more_info += "/seed: " + str(self.options.seed)
             logger.info("{:>{}}/{} {:<25} {:<50} {} ({})".format(
-                results.done, total_tests_width, total_to_do , instance.platform.name,
+                results.done - results.skipped_filter, total_tests_width, total_to_do , instance.platform.name,
                 instance.testsuite.name, status, more_info))
 
             if self.options.verbose > 1:
@@ -1154,22 +1411,24 @@ class ProjectBuilder(FilterBuilder):
         else:
             completed_perc = 0
             if total_to_do > 0:
-                completed_perc = int((float(results.done) / total_to_do) * 100)
+                completed_perc = int((float(results.done - results.skipped_filter) / total_to_do) * 100)
 
-            sys.stdout.write("INFO    - Total complete: %s%4d/%4d%s  %2d%%  built (not run): %4d, skipped: %s%4d%s, failed: %s%4d%s, error: %s%4d%s\r" % (
-                Fore.GREEN,
-                results.done,
+            sys.stdout.write("INFO    - Total complete: %s%4d/%4d%s  %2d%%  built (not run): %s%4d%s, filtered: %s%4d%s, failed: %s%4d%s, error: %s%4d%s\r" % (
+                TwisterStatus.get_color(TwisterStatus.PASS),
+                results.done - results.skipped_filter,
                 total_to_do,
                 Fore.RESET,
                 completed_perc,
+                TwisterStatus.get_color(TwisterStatus.NOTRUN),
                 results.notrun,
-                Fore.YELLOW if results.skipped_configs > 0 else Fore.RESET,
+                Fore.RESET,
+                TwisterStatus.get_color(TwisterStatus.SKIP) if results.skipped_configs > 0 else Fore.RESET,
                 results.skipped_configs,
                 Fore.RESET,
-                Fore.RED if results.failed > 0 else Fore.RESET,
+                TwisterStatus.get_color(TwisterStatus.FAIL) if results.failed > 0 else Fore.RESET,
                 results.failed,
                 Fore.RESET,
-                Fore.RED if results.error > 0 else Fore.RESET,
+                TwisterStatus.get_color(TwisterStatus.ERROR) if results.error > 0 else Fore.RESET,
                 results.error,
                 Fore.RESET
                 )
@@ -1376,15 +1635,16 @@ class TwisterRunner:
         self.update_counting_before_pipeline()
 
         while True:
-            self.results.iteration += 1
+            self.results.iteration_increment()
 
             if self.results.iteration > 1:
                 logger.info("%d Iteration:" % (self.results.iteration))
                 time.sleep(self.options.retry_interval)  # waiting for the system to settle down
-                self.results.done = self.results.total - self.results.failed - self.results.error
+                self.results.done = self.results.total - self.results.failed
                 self.results.failed = 0
                 if self.options.retry_build_errors:
                     self.results.error = 0
+                    self.results.done -= self.results.error
             else:
                 self.results.done = self.results.skipped_filter
 
@@ -1421,16 +1681,16 @@ class TwisterRunner:
         '''
         for instance in self.instances.values():
             if instance.status == TwisterStatus.FILTER and not instance.reason == 'runtime filter':
-                self.results.skipped_filter += 1
-                self.results.skipped_configs += 1
-                self.results.skipped_cases += len(instance.testsuite.testcases)
-                self.results.cases += len(instance.testsuite.testcases)
+                self.results.skipped_filter_increment()
+                self.results.skipped_configs_increment()
+                self.results.filtered_cases_increment(len(instance.testsuite.testcases))
+                self.results.cases_increment(len(instance.testsuite.testcases))
             elif instance.status == TwisterStatus.ERROR:
-                self.results.error += 1
+                self.results.error_increment()
 
     def show_brief(self):
         logger.info("%d test scenarios (%d test instances) selected, "
-                    "%d configurations skipped (%d by static filter, %d at runtime)." %
+                    "%d configurations filtered (%d by static filter, %d at runtime)." %
                     (len(self.suites), len(self.instances),
                     self.results.skipped_configs,
                     self.results.skipped_filter,
@@ -1450,6 +1710,9 @@ class TwisterRunner:
                 if instance.status != TwisterStatus.NONE:
                     instance.retries += 1
                 instance.status = TwisterStatus.NONE
+                # Previous states should be removed from the stats
+                if self.results.iteration > 1:
+                    ProjectBuilder._add_instance_testcases_to_status_counts(instance, self.results, decrement=True)
 
                 # Check if cmake package_helper script can be run in advance.
                 instance.filter_stages = []

--- a/scripts/tests/twister_blackbox/test_device.py
+++ b/scripts/tests/twister_blackbox/test_device.py
@@ -13,6 +13,7 @@ import pytest
 import sys
 import re
 
+# pylint: disable=no-name-in-module
 from conftest import ZEPHYR_BASE, TEST_DATA, testsuite_filename_mock
 from twisterlib.testplan import TestPlan
 
@@ -71,5 +72,5 @@ class TestDevice:
 
         assert str(sys_exit.value) == '1'
 
-        expected_line = r'seed_native_sim.dummy  FAILED Failed \(native (\d+\.\d+)s/seed: {}\)'.format(seed[0])
+        expected_line = r'seed_native_sim.dummy FAILED Failed \(native (\d+\.\d+)s/seed: {}\)'.format(seed[0])
         assert re.search(expected_line, err)

--- a/scripts/tests/twister_blackbox/test_error.py
+++ b/scripts/tests/twister_blackbox/test_error.py
@@ -13,6 +13,7 @@ import pytest
 import sys
 import re
 
+# pylint: disable=no-name-in-module
 from conftest import ZEPHYR_BASE, TEST_DATA, testsuite_filename_mock
 from twisterlib.testplan import TestPlan
 from twisterlib.error import TwisterRuntimeError
@@ -45,7 +46,7 @@ class TestError:
         ),
         (
             '--overflow-as-errors',
-            r'always_overflow.dummy  ERROR Build failure \(build\)'
+            r'always_overflow.dummy ERROR Build failure \(build\)'
         )
     ]
 

--- a/scripts/tests/twister_blackbox/test_platform.py
+++ b/scripts/tests/twister_blackbox/test_platform.py
@@ -28,6 +28,7 @@ class TestPlatform:
             {
                 'selected_test_scenarios': 3,
                 'selected_test_instances': 9,
+                'executed_test_instances': 6,
                 'skipped_configurations': 3,
                 'skipped_by_static_filter': 3,
                 'skipped_at_runtime': 0,
@@ -48,6 +49,7 @@ class TestPlatform:
             {
                 'selected_test_scenarios': 1,
                 'selected_test_instances': 3,
+                'executed_test_instances': 0,
                 'skipped_configurations': 3,
                 'skipped_by_static_filter': 3,
                 'skipped_at_runtime': 0,
@@ -190,8 +192,9 @@ class TestPlatform:
                 os.path.join(TEST_DATA, 'tests', 'dummy', 'agnostic'),
                 ['qemu_x86', 'qemu_x86_64'],
                 {
-                    'passed_configurations': 2,
                     'selected_test_instances': 6,
+                    'passed_configurations': 2,
+                    'executed_test_instances': 3,
                     'executed_on_platform': 2,
                     'only_built': 1,
                 }
@@ -217,7 +220,7 @@ class TestPlatform:
         sys.stderr.write(err)
 
         pass_regex = r'^INFO    - (?P<passed_configurations>[0-9]+) of' \
-                     r' (?P<test_instances>[0-9]+) test configurations passed'
+                     r' (?P<test_instances>[0-9]+) executed test configurations passed'
 
         built_regex = r'^INFO    - (?P<executed_on_platform>[0-9]+)' \
                       r' test configurations executed on platforms, (?P<only_built>[0-9]+)' \
@@ -229,7 +232,7 @@ class TestPlatform:
         assert int(pass_search.group('passed_configurations')) == \
                expected['passed_configurations']
         assert int(pass_search.group('test_instances')) == \
-               expected['selected_test_instances']
+               expected['executed_test_instances']
 
         built_search = re.search(built_regex, err, re.MULTILINE)
 
@@ -262,22 +265,31 @@ class TestPlatform:
 
         select_regex = r'^INFO    - (?P<test_scenarios>[0-9]+) test scenarios' \
                        r' \((?P<test_instances>[0-9]+) test instances\) selected,' \
-                       r' (?P<skipped_configurations>[0-9]+) configurations skipped' \
+                       r' (?P<skipped_configurations>[0-9]+) configurations filtered' \
                        r' \((?P<skipped_by_static_filter>[0-9]+) by static filter,' \
                        r' (?P<skipped_at_runtime>[0-9]+) at runtime\)\.$'
 
         pass_regex = r'^INFO    - (?P<passed_configurations>[0-9]+) of' \
-                     r' (?P<test_instances>[0-9]+) test configurations passed' \
+                     r' (?P<executed_test_instances>[0-9]+) executed test configurations passed' \
                      r' \([0-9]+\.[0-9]+%\), (?P<built_configurations>[0-9]+) built \(not run\),' \
                      r' (?P<failed_configurations>[0-9]+) failed,' \
                      r' (?P<errored_configurations>[0-9]+) errored,' \
-                     r' (?P<skipped_configurations>[0-9]+) skipped with' \
-                     r' [0-9]+ warnings in [0-9]+\.[0-9]+ seconds$'
+                     r' with (?:[0-9]+|no) warnings in [0-9]+\.[0-9]+ seconds.$'
 
-        case_regex = r'^INFO    - In total (?P<executed_test_cases>[0-9]+)' \
-                     r' test cases were executed, (?P<skipped_test_cases>[0-9]+) skipped' \
-                     r' on (?P<platform_count>[0-9]+) out of total [0-9]+ platforms' \
-                     r' \([0-9]+\.[0-9]+%\)$'
+        case_regex = r'^INFO    - (?P<passed_cases>[0-9]+) of' \
+                     r' (?P<executed_test_cases>[0-9]+) executed test cases passed' \
+                     r' \([0-9]+\.[0-9]+%\)' \
+                     r'(?:, (?P<blocked_cases>[0-9]+) blocked)?' \
+                     r'(?:, (?P<failed_cases>[0-9]+) failed)?' \
+                     r'(?:, (?P<errored_cases>[0-9]+) errored)?' \
+                     r'(?:, (?P<none_cases>[0-9]+) without a status)?' \
+                     r' on (?P<platform_count>[0-9]+) out of total' \
+                     r' (?P<total_platform_count>[0-9]+) platforms \([0-9]+\.[0-9]+%\)'
+
+        skip_regex = r'(?P<skipped_test_cases>[0-9]+) selected test cases not executed:' \
+                     r'(?: (?P<skipped_cases>[0-9]+) skipped)?' \
+                     r'(?:, (?P<filtered_cases>[0-9]+) filtered)?' \
+                     r'.'
 
         built_regex = r'^INFO    - (?P<executed_on_platform>[0-9]+)' \
                       r' test configurations executed on platforms, (?P<only_built>[0-9]+)' \
@@ -306,26 +318,31 @@ class TestPlatform:
         assert pass_search
         assert int(pass_search.group('passed_configurations')) == \
                expected['passed_configurations']
-        assert int(pass_search.group('test_instances')) == \
-               expected['selected_test_instances']
         assert int(pass_search.group('built_configurations')) == \
                expected['built_configurations']
-        assert int(pass_search.group('failed_configurations')) == \
-               expected['failed_configurations']
-        assert int(pass_search.group('errored_configurations')) == \
-               expected['errored_configurations']
-        assert int(pass_search.group('skipped_configurations')) == \
-               expected['skipped_configurations']
+        assert int(pass_search.group('executed_test_instances')) == \
+               expected['executed_test_instances']
+        if expected['failed_configurations']:
+            assert int(pass_search.group('failed_configurations')) == \
+                   expected['failed_configurations']
+        if expected['errored_configurations']:
+            assert int(pass_search.group('errored_configurations')) == \
+                   expected['errored_configurations']
 
         case_search = re.search(case_regex, err, re.MULTILINE)
 
         assert case_search
         assert int(case_search.group('executed_test_cases')) == \
                expected['executed_test_cases']
-        assert int(case_search.group('skipped_test_cases')) == \
-               expected['skipped_test_cases']
         assert int(case_search.group('platform_count')) == \
                expected['platform_count']
+
+        if expected['skipped_test_cases']:
+            skip_search = re.search(skip_regex, err, re.MULTILINE)
+
+            assert skip_search
+            assert int(skip_search.group('skipped_test_cases')) == \
+                   expected['skipped_test_cases']
 
         built_search = re.search(built_regex, err, re.MULTILINE)
 


### PR DESCRIPTION
### Description

`ExecutionCounter` has been expanded and now hold i.a. more information on the statuses of `TestCase`s. This information is now incorporated in relevant summaries - runner.py and reports.py. Layout of those was changed to present that and previous information in a clear and concise way.

`TestInstance` execution counter now is more intuitive. Instances filtered out before running are no longer included there. Retries now properly reset the counter.

`TestCases` with `NONE` and other incorrect final statuses are logged as errors, but do not exit Twister with a nonzero exit code. This is because `NONE` statuses, although incorrect, are currently common.

Note that this PR **does not** concern itself with the logic of status assignments and will not be fixing some peculiarities of current status regime.

### Demonstration

To illustrate the difference, I have run the `tests/ztest` tests with an additional `tests/ztest/temp` directory, containing the following testsuites, allowing for a wider status spread:
* `testing.ztest.temp.error` - a test that always errors out
* `testing.ztest.temp.fail` - a test that always fails
* `testing.ztest.temp.filter` - a test skipped by a filter statically
* `testing.ztest.temp.runtime_filter` - a test skipped by a filter at runtime
* `testing.ztest.temp.pass` - a simple test that should pass
* `testing.ztest.temp.build_only_skip` - a test that is build_only

#### `runner.py` summary

Old style:
```
--------------------------------
Total test suites: 32
Total test cases: 148
Executed test cases: 118
Skipped test cases: 30
Completed test suites: 31
Passing test suites: 12
Failing test suites: 1
Skipped test suites: 18
Skipped test suites (runtime): 1
Skipped test suites (filter): 17
Errors: 1
--------------------------------
```
New style:
```
--------------------------------------------------
Total test suites:     32
Processed test suites: 32
├─ Filtered test suites (static):       17
└─ Completed test suites:               15
   ├─ Filtered test suites (at runtime):    1
   ├─ Passed test suites:                  12
   ├─ Failed test suites:                   1
   └─ Errors in test suites:                1

Filtered test suites: 18
├─ Filtered test suites (static):        17
└─ Filtered test suites (at runtime):     1
----------------------      ----------------------
Total test cases: 148
├─ Filtered test cases:  28
├─ Skipped test cases:    2
└─ Executed test cases: 118
   ├─ Passed test cases:       110
   ├─ Blocked test cases:        1
   ├─ Failed test cases:         1
   ├─ Errors in test cases:      0
   ├──── The following test case statuses should not appear in a proper execution ───
   └─ Statusless test cases:     6
--------------------------------------------------
```

#### Full run log

Old style:
```
<user>:<ZEPHYR_BASE>$ twister -T tests/ztest/ -v -p qemu_x86_64 --retry-failed 1
Renaming output directory to <ZEPHYR_BASE>/twister-out.10
INFO    - Using Ninja..
INFO    - Zephyr version: v3.7.0-1575-g45705a84ab8e
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testsuite list...
INFO    - Writing JSON report <ZEPHYR_BASE>/twister-out/testplan.json
INFO    - JOBS: 12
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - 18/32 qemu_x86_64               tests/ztest/temp/subgroup_runtime_filter/testing.ztest.temp.runtime_filter SKIPPED (runtime filter)
INFO    - 19/32 qemu_x86_64               tests/ztest/temp/subgroup_error/testing.ztest.temp.error  ERROR Build failure (qemu)
ERROR   - see: <ZEPHYR_BASE>/twister-out/qemu_x86_64/tests/ztest/temp/subgroup_error/testing.ztest.temp.error/build.log
INFO    - 20/32 qemu_x86_64               tests/ztest/temp/subgroup_skip/testing.ztest.temp.build_only_skip PASSED (build)
INFO    - 21/32 qemu_x86_64               tests/ztest/base/testing.ztest.base.verbose_2      PASSED (qemu 1.451s)
INFO    - 22/32 qemu_x86_64               tests/ztest/error_hook/testing.ztest.error_hook.no_userspace PASSED (qemu 1.448s)
INFO    - 23/32 qemu_x86_64               tests/ztest/base/testing.ztest.base.verbose_1      PASSED (qemu 1.359s)
INFO    - 24/32 qemu_x86_64               tests/ztest/zexpect/testing.ztest.expect_cpp       PASSED (qemu 1.246s)
INFO    - 25/32 qemu_x86_64               tests/ztest/zexpect/testing.ztest.expect           PASSED (qemu 1.337s)
INFO    - 26/32 qemu_x86_64               tests/ztest/temp/subgroup_fail/testing.ztest.temp.fail  FAILED Testsuite failed (qemu 1.188s)
ERROR   - see:<ZEPHYR_BASE>/twister-out/qemu_x86_64/tests/ztest/temp/subgroup_fail/testing.ztest.temp.fail/handler.log
INFO    - 27/32 qemu_x86_64               tests/ztest/temp/subgroup_pass/testing.ztest.temp.pass PASSED (qemu 1.233s)
INFO    - 28/32 qemu_x86_64               tests/ztest/ztress/testing.ztest.ztress            PASSED (qemu 6.970s)
INFO    - 29/32 qemu_x86_64               tests/ztest/base/testing.ztest.base.verbose_0      PASSED (qemu 1.350s)
INFO    - 30/32 qemu_x86_64               tests/ztest/summary/testing.ztest.summary.shared_unit_test PASSED (qemu 1.220s)
INFO    - 31/32 qemu_x86_64               tests/ztest/error_hook/testing.ztest.error_hook    PASSED (qemu 1.213s)
INFO    - 32/32 qemu_x86_64               tests/ztest/base/testing.ztest.base.verbose_0_userspace PASSED (qemu 1.215s)

INFO    - 2 Iteration:
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - 31/32 qemu_x86_64               tests/ztest/temp/subgroup_fail/testing.ztest.temp.fail  FAILED Testsuite failed (qemu 1.135s)
ERROR   - see:<ZEPHYR_BASE>/twister-out/qemu_x86_64/tests/ztest/temp/subgroup_fail/testing.ztest.temp.fail/handler.log

INFO    - 35 test scenarios (32 test instances) selected, 18 configurations skipped (17 by static filter, 1 at runtime).
INFO    - 12 of 32 test configurations passed (85.71%), 1 failed, 1 errored, 18 skipped with 0 warnings in 163.02 seconds
INFO    - In total 118 test cases were executed, 30 skipped on 1 out of total 2 platforms (50.00%)
INFO    - 12 test configurations executed on platforms, 2 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing JSON report <ZEPHYR_BASE>/twister-out/twister.json
INFO    - Writing xunit report <ZEPHYR_BASE>/twister-out/twister.xml...
INFO    - Writing xunit report <ZEPHYR_BASE>/twister-out/twister_report.xml...
INFO    - -+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
INFO    - The following issues were found (showing the top 10 items):
INFO    - 1) tests/ztest/temp/subgroup_fail/testing.ztest.temp.fail on qemu_x86_64 failed (Testsuite failed)
INFO    - 2) tests/ztest/temp/subgroup_error/testing.ztest.temp.error on qemu_x86_64 error (Build failure)
INFO    - 
INFO    - To rerun the tests, call twister using the following commandline:
INFO    - west twister -p <PLATFORM> -s <TEST ID>, for example:
INFO    - 
INFO    - west twister -p qemu_x86_64 -s tests/ztest/temp/subgroup_error/testing.ztest.temp.error
INFO    - or with west:
INFO    - west build -p -b qemu_x86_64 tests/ztest/temp/subgroup_error -T testing.ztest.temp.error
INFO    - -+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
INFO    - Run completed
```

New style:
```
<user>:<ZEPHYR_BASE>$ twister -T tests/ztest/ -v -p qemu_x86_64 --retry-failed 1
Renaming output directory to <ZEPHYR_BASE>/twister-out.9
INFO    - Using Ninja..
INFO    - Zephyr version: v3.7.0-1378-g18cf1f3194af
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testsuite list...
INFO    - Writing JSON report <ZEPHYR_BASE>/twister-out/testplan.json
INFO    - JOBS: 12
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    -  1/15 qemu_x86_64               tests/ztest/temp/subgroup_runtime_filter/testing.ztest.temp.runtime_filter FILTERED (runtime filter)
INFO    -  2/15 qemu_x86_64               tests/ztest/temp/subgroup_error/testing.ztest.temp.error  ERROR Build failure (qemu)
ERROR   - see: <ZEPHYR_BASE>/twister-out/qemu_x86_64/tests/ztest/temp/subgroup_error/testing.ztest.temp.error/build.log
INFO    -  3/15 qemu_x86_64               tests/ztest/base/testing.ztest.base.verbose_2      PASSED (qemu 1.457s)
INFO    -  4/15 qemu_x86_64               tests/ztest/temp/subgroup_pass/testing.ztest.temp.pass PASSED (qemu 1.346s)
INFO    -  5/15 qemu_x86_64               tests/ztest/zexpect/testing.ztest.expect           PASSED (qemu 1.512s)
INFO    -  6/15 qemu_x86_64               tests/ztest/zexpect/testing.ztest.expect_cpp       PASSED (qemu 1.338s)
INFO    -  7/15 qemu_x86_64               tests/ztest/temp/subgroup_fail/testing.ztest.temp.fail  FAILED Testsuite failed (qemu 1.138s)
ERROR   - see: <ZEPHYR_BASE>/twister-out/qemu_x86_64/tests/ztest/temp/subgroup_fail/testing.ztest.temp.fail/handler.log
ERROR   - A None status detected in instance qemu_x86_64/tests/ztest/temp/subgroup_skip/testing.ztest.temp.build_only_skip, test case testing.ztest.temp.build_only_skip.skip.
INFO    -  8/15 qemu_x86_64               tests/ztest/temp/subgroup_skip/testing.ztest.temp.build_only_skip PASSED (build)
INFO    -  9/15 qemu_x86_64               tests/ztest/base/testing.ztest.base.verbose_1      PASSED (qemu 1.274s)
ERROR   - A None status detected in instance qemu_x86_64/tests/ztest/error_hook/testing.ztest.error_hook.no_userspace, test case testing.ztest.error_hook.no_userspace.to_skip1.
ERROR   - A None status detected in instance qemu_x86_64/tests/ztest/error_hook/testing.ztest.error_hook.no_userspace, test case testing.ztest.error_hook.no_userspace.to_skip0.
INFO    - 10/15 qemu_x86_64               tests/ztest/error_hook/testing.ztest.error_hook.no_userspace PASSED (qemu 1.199s)
INFO    - 11/15 qemu_x86_64               tests/ztest/ztress/testing.ztest.ztress            PASSED (qemu 7.027s)
INFO    - 12/15 qemu_x86_64               tests/ztest/base/testing.ztest.base.verbose_0      PASSED (qemu 1.255s)
ERROR   - A None status detected in instance qemu_x86_64/tests/ztest/summary/testing.ztest.summary.shared_unit_test, test case testing.ztest.summary.shared_unit_test.foo.
INFO    - 13/15 qemu_x86_64               tests/ztest/summary/testing.ztest.summary.shared_unit_test PASSED (qemu 1.141s)
ERROR   - A None status detected in instance qemu_x86_64/tests/ztest/error_hook/testing.ztest.error_hook, test case testing.ztest.error_hook.to_skip1.
ERROR   - A None status detected in instance qemu_x86_64/tests/ztest/error_hook/testing.ztest.error_hook, test case testing.ztest.error_hook.to_skip0.
INFO    - 14/15 qemu_x86_64               tests/ztest/error_hook/testing.ztest.error_hook    PASSED (qemu 1.199s)
INFO    - 15/15 qemu_x86_64               tests/ztest/base/testing.ztest.base.verbose_0_userspace PASSED (qemu 1.208s)

INFO    - 2 Iteration:
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - 15/15 qemu_x86_64               tests/ztest/temp/subgroup_fail/testing.ztest.temp.fail  FAILED Testsuite failed (qemu 1.165s)
ERROR   - see: <ZEPHYR_BASE>/twister-out/qemu_x86_64/tests/ztest/temp/subgroup_fail/testing.ztest.temp.fail/handler.log

INFO    - 35 test scenarios (32 test instances) selected, 18 configurations skipped (17 by static filter, 1 at runtime).
INFO    - 12 of 14 executed test configurations passed (85.71%), 1 failed, 1 errored, with no warnings in 144.19 seconds.
INFO    - 110 of 118 executed test cases passed (93.22%), 1 blocked, 1 failed, 6 without a status on 1 out of total 2 platforms (50.00%).
INFO    - 30 selected test cases not executed: 2 skipped, 28 filtered.
INFO    - 12 test configurations executed on platforms, 2 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing JSON report <ZEPHYR_BASE>/twister-out/twister.json
INFO    - Writing xunit report <ZEPHYR_BASE>/twister-out/twister.xml...
INFO    - Writing xunit report <ZEPHYR_BASE>/twister-out/twister_report.xml...
INFO    - -+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
INFO    - The following issues were found (showing the top 10 items):
INFO    - 1) tests/ztest/temp/subgroup_fail/testing.ztest.temp.fail on qemu_x86_64 failed (Testsuite failed)
INFO    - 2) tests/ztest/temp/subgroup_error/testing.ztest.temp.error on qemu_x86_64 error (Build failure)
INFO    - 
INFO    - To rerun the tests, call twister using the following commandline:
INFO    - west twister -p <PLATFORM> -s <TEST ID>, for example:
INFO    - 
INFO    - west twister -p qemu_x86_64 -s tests/ztest/temp/subgroup_error/testing.ztest.temp.error
INFO    - or with west:
INFO    - west build -p -b qemu_x86_64 tests/ztest/temp/subgroup_error -T testing.ztest.temp.error
INFO    - -+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
INFO    - Run completed
```