### PR TITLE
doc: samples: use :zephyr-app: for in-tree samples

### DIFF
--- a/boards/01space/esp32c3_042_oled/doc/index.rst
+++ b/boards/01space/esp32c3_042_oled/doc/index.rst
@@ -130,7 +130,7 @@ To build the sample application using sysbuild, use this command:
 
 .. zephyr-app-commands::
    :tool: west
-   :app: samples/hello_world
+   :zephyr-app: samples/hello_world
    :board: esp32c3_042_oled
    :goals: build
    :west-args: --sysbuild

--- a/boards/ct/ctcc/doc/index.rst
+++ b/boards/ct/ctcc/doc/index.rst
@@ -155,7 +155,7 @@ Zephyr repositories using :ref:`west` tool.
 #. Flash other Zephyr application to fill in slot0 e.g:
 
    .. zephyr-app-commands::
-      :app: samples/subsys/usb/dfu
+      :zephyr-app: samples/subsys/usb/dfu
       :board: ctcc/nrf52840
       :build-dir: dfu
       :goals: build

--- a/boards/espressif/esp32_devkitc_wroom/doc/index.rst
+++ b/boards/espressif/esp32_devkitc_wroom/doc/index.rst
@@ -156,7 +156,7 @@ To build the sample application using sysbuild use the command:
 
 .. zephyr-app-commands::
    :tool: west
-   :app: samples/hello_world
+   :zephyr-app: samples/hello_world
    :board: esp_wrover_kit
    :goals: build
    :west-args: --sysbuild

--- a/boards/espressif/esp32_devkitc_wrover/doc/index.rst
+++ b/boards/espressif/esp32_devkitc_wrover/doc/index.rst
@@ -156,7 +156,7 @@ To build the sample application using sysbuild use the command:
 
 .. zephyr-app-commands::
    :tool: west
-   :app: samples/hello_world
+   :zephyr-app: samples/hello_world
    :board: esp32_devkitc_wrover
    :goals: build
    :west-args: --sysbuild

--- a/boards/espressif/esp32_ethernet_kit/doc/index.rst
+++ b/boards/espressif/esp32_ethernet_kit/doc/index.rst
@@ -478,7 +478,7 @@ To build the sample application using sysbuild use the command:
 
 .. zephyr-app-commands::
    :tool: west
-   :app: samples/hello_world
+   :zephyr-app: samples/hello_world
    :board: esp32_ethernet_kit/esp32/procpu
    :goals: build
    :west-args: --sysbuild

--- a/boards/espressif/esp32c3_devkitc/doc/index.rst
+++ b/boards/espressif/esp32c3_devkitc/doc/index.rst
@@ -131,7 +131,7 @@ To build the sample application using sysbuild use the command:
 
 .. zephyr-app-commands::
    :tool: west
-   :app: samples/hello_world
+   :zephyr-app: samples/hello_world
    :board: esp32c3_devkitc
    :goals: build
    :west-args: --sysbuild

--- a/boards/espressif/esp32c3_devkitm/doc/index.rst
+++ b/boards/espressif/esp32c3_devkitm/doc/index.rst
@@ -131,7 +131,7 @@ To build the sample application using sysbuild use the command:
 
 .. zephyr-app-commands::
    :tool: west
-   :app: samples/hello_world
+   :zephyr-app: samples/hello_world
    :board: esp32c3_devkitm
    :goals: build
    :west-args: --sysbuild

--- a/boards/espressif/esp32c3_rust/doc/index.rst
+++ b/boards/espressif/esp32c3_rust/doc/index.rst
@@ -176,7 +176,7 @@ To build the sample application using sysbuild use the command:
 
 .. zephyr-app-commands::
    :tool: west
-   :app: samples/hello_world
+   :zephyr-app: samples/hello_world
    :board: esp32c3_rust
    :goals: build
    :west-args: --sysbuild

--- a/boards/espressif/esp32c6_devkitc/doc/index.rst
+++ b/boards/espressif/esp32c6_devkitc/doc/index.rst
@@ -167,7 +167,7 @@ To build the sample application using sysbuild use the command:
 
 .. zephyr-app-commands::
    :tool: west
-   :app: samples/hello_world
+   :zephyr-app: samples/hello_world
    :board: esp32c6_devkitc
    :goals: build
    :west-args: --sysbuild

--- a/boards/espressif/esp32s2_devkitc/doc/index.rst
+++ b/boards/espressif/esp32s2_devkitc/doc/index.rst
@@ -127,7 +127,7 @@ To build the sample application using sysbuild use the command:
 
 .. zephyr-app-commands::
    :tool: west
-   :app: samples/hello_world
+   :zephyr-app: samples/hello_world
    :board: esp32s2_devkitc
    :goals: build
    :west-args: --sysbuild

--- a/boards/espressif/esp32s2_saola/doc/index.rst
+++ b/boards/espressif/esp32s2_saola/doc/index.rst
@@ -127,7 +127,7 @@ To build the sample application using sysbuild use the command:
 
 .. zephyr-app-commands::
    :tool: west
-   :app: samples/hello_world
+   :zephyr-app: samples/hello_world
    :board: esp32s2_saola
    :goals: build
    :west-args: --sysbuild

--- a/boards/espressif/esp32s3_devkitc/doc/index.rst
+++ b/boards/espressif/esp32s3_devkitc/doc/index.rst
@@ -176,7 +176,7 @@ To build the sample application using sysbuild use the command:
 
 .. zephyr-app-commands::
    :tool: west
-   :app: samples/hello_world
+   :zephyr-app: samples/hello_world
    :board: esp32s3_devkitc/esp32s3/procpu
    :goals: build
    :west-args: --sysbuild

--- a/boards/espressif/esp32s3_devkitm/doc/index.rst
+++ b/boards/espressif/esp32s3_devkitm/doc/index.rst
@@ -176,7 +176,7 @@ To build the sample application using sysbuild use the command:
 
 .. zephyr-app-commands::
    :tool: west
-   :app: samples/hello_world
+   :zephyr-app: samples/hello_world
    :board: esp32s3_devkitm
    :goals: build
    :west-args: --sysbuild

--- a/boards/espressif/esp8684_devkitm/doc/index.rst
+++ b/boards/espressif/esp8684_devkitm/doc/index.rst
@@ -124,7 +124,7 @@ To build the sample application using sysbuild use the command:
 
 .. zephyr-app-commands::
    :tool: west
-   :app: samples/hello_world
+   :zephyr-app: samples/hello_world
    :board: esp8684_devkitm
    :goals: build
    :west-args: --sysbuild

--- a/boards/espressif/esp_wrover_kit/doc/index.rst
+++ b/boards/espressif/esp_wrover_kit/doc/index.rst
@@ -542,7 +542,7 @@ To build the sample application using sysbuild use the command:
 
 .. zephyr-app-commands::
    :tool: west
-   :app: samples/hello_world
+   :zephyr-app: samples/hello_world
    :board: esp_wrover_kit
    :goals: build
    :west-args: --sysbuild

--- a/boards/franzininho/esp32s2_franzininho/doc/index.rst
+++ b/boards/franzininho/esp32s2_franzininho/doc/index.rst
@@ -94,7 +94,7 @@ To build the sample application using sysbuild use the command:
 
 .. zephyr-app-commands::
    :tool: west
-   :app: samples/hello_world
+   :zephyr-app: samples/hello_world
    :board: esp32s2_franzininho
    :goals: build
    :west-args: --sysbuild

--- a/boards/hardkernel/odroid_go/doc/index.rst
+++ b/boards/hardkernel/odroid_go/doc/index.rst
@@ -135,7 +135,7 @@ To build the sample application using sysbuild use the command:
 
 .. zephyr-app-commands::
    :tool: west
-   :app: samples/hello_world
+   :zephyr-app: samples/hello_world
    :board: odroid_go
    :goals: build
    :west-args: --sysbuild

--- a/boards/heltec/heltec_wifi_lora32_v2/doc/index.rst
+++ b/boards/heltec/heltec_wifi_lora32_v2/doc/index.rst
@@ -82,7 +82,7 @@ To build the sample application using sysbuild use the command:
 
 .. zephyr-app-commands::
    :tool: west
-   :app: samples/hello_world
+   :zephyr-app: samples/hello_world
    :board: heltec_wifi_lora32_v2
    :goals: build
    :west-args: --sysbuild

--- a/boards/heltec/heltec_wireless_stick_lite_v3/doc/index.rst
+++ b/boards/heltec/heltec_wireless_stick_lite_v3/doc/index.rst
@@ -196,7 +196,7 @@ To build the sample application using sysbuild use the command:
 
 .. zephyr-app-commands::
    :tool: west
-   :app: samples/hello_world
+   :zephyr-app: samples/hello_world
    :board: heltec_wireless_stick_lite_v3
    :goals: build
    :west-args: --sysbuild

--- a/boards/lilygo/ttgo_lora32/doc/index.rst
+++ b/boards/lilygo/ttgo_lora32/doc/index.rst
@@ -125,7 +125,7 @@ To build the sample application using sysbuild use the command:
 
 .. zephyr-app-commands::
    :tool: west
-   :app: samples/hello_world
+   :zephyr-app: samples/hello_world
    :board: ttgo_lora32/esp32/procpu
    :goals: build
    :west-args: --sysbuild
@@ -214,7 +214,7 @@ To build the LoRa transmit sample application using sysbuild use the command:
 
 .. zephyr-app-commands::
    :tool: west
-   :app: samples/drivers/lora/send
+   :zephyr-app: samples/drivers/lora/send
    :board: ttgo_lora32/esp32/procpu
    :goals: build
    :west-args: --sysbuild
@@ -224,7 +224,7 @@ To build the LoRa receive sample application using sysbuild use the command:
 
 .. zephyr-app-commands::
    :tool: west
-   :app: samples/drivers/lora/receive
+   :zephyr-app: samples/drivers/lora/receive
    :board: ttgo_lora32/esp32/procpu
    :goals: build
    :west-args: --sysbuild

--- a/boards/lilygo/ttgo_t8c3/doc/index.rst
+++ b/boards/lilygo/ttgo_t8c3/doc/index.rst
@@ -123,7 +123,7 @@ To build the sample application using sysbuild use the command:
 
 .. zephyr-app-commands::
    :tool: west
-   :app: samples/hello_world
+   :zephyr-app: samples/hello_world
    :board: ttgo_t8c3
    :goals: build
    :west-args: --sysbuild
@@ -212,7 +212,7 @@ To build the blinky sample:
 
 .. zephyr-app-commands::
    :tool: west
-   :app: samples/basic/blinky
+   :zephyr-app: samples/basic/blinky
    :board: ttgo_t8c3
    :goals: build
 
@@ -220,7 +220,7 @@ To build the bluetooth beacon sample:
 
 .. zephyr-app-commands::
    :tool: west
-   :app: samples/bluetooth/beacon
+   :zephyr-app: samples/bluetooth/beacon
    :board: ttgo_t8c3
    :goals: build
 

--- a/boards/luatos/esp32c3_luatos_core/doc/index.rst
+++ b/boards/luatos/esp32c3_luatos_core/doc/index.rst
@@ -149,7 +149,7 @@ To build the sample application using sysbuild use the command:
 
 .. zephyr-app-commands::
    :tool: west
-   :app: samples/hello_world
+   :zephyr-app: samples/hello_world
    :board: esp32c3_luatos_core
    :goals: build
    :west-args: --sysbuild

--- a/boards/luatos/esp32s3_luatos_core/doc/index.rst
+++ b/boards/luatos/esp32s3_luatos_core/doc/index.rst
@@ -175,7 +175,7 @@ To build the sample application using sysbuild use the command:
 
 .. zephyr-app-commands::
    :tool: west
-   :app: samples/hello_world
+   :zephyr-app: samples/hello_world
    :board: esp32s3_luatos_core
    :goals: build
    :west-args: --sysbuild

--- a/boards/m5stack/m5stickc_plus/doc/index.rst
+++ b/boards/m5stack/m5stickc_plus/doc/index.rst
@@ -124,7 +124,7 @@ To build the sample application using sysbuild use the command:
 
 .. zephyr-app-commands::
    :tool: west
-   :app: samples/hello_world
+   :zephyr-app: samples/hello_world
    :board: m5stickc_plus
    :goals: build
    :west-args: --sysbuild

--- a/boards/m5stack/stamp_c3/doc/index.rst
+++ b/boards/m5stack/stamp_c3/doc/index.rst
@@ -93,7 +93,7 @@ To build the sample application using sysbuild use the command:
 
 .. zephyr-app-commands::
    :tool: west
-   :app: samples/hello_world
+   :zephyr-app: samples/hello_world
    :board: stamp_c3
    :goals: build
    :west-args: --sysbuild

--- a/boards/olimex/olimex_esp32_evb/doc/index.rst
+++ b/boards/olimex/olimex_esp32_evb/doc/index.rst
@@ -151,7 +151,7 @@ To build the sample application using sysbuild use the command:
 
 .. zephyr-app-commands::
    :tool: west
-   :app: samples/hello_world
+   :zephyr-app: samples/hello_world
    :board: olimex_esp32_evb
    :goals: build
    :west-args: --sysbuild

--- a/boards/others/icev_wireless/doc/index.rst
+++ b/boards/others/icev_wireless/doc/index.rst
@@ -138,7 +138,7 @@ To build the sample application using sysbuild use the command:
 
 .. zephyr-app-commands::
    :tool: west
-   :app: samples/hello_world
+   :zephyr-app: samples/hello_world
    :board: icev_wireless
    :goals: build
    :west-args: --sysbuild

--- a/boards/seeed/xiao_esp32c3/doc/index.rst
+++ b/boards/seeed/xiao_esp32c3/doc/index.rst
@@ -120,7 +120,7 @@ To build the sample application using sysbuild use the command:
 
 .. zephyr-app-commands::
    :tool: west
-   :app: samples/hello_world
+   :zephyr-app: samples/hello_world
    :board: xiao_esp32c3
    :goals: build
    :west-args: --sysbuild

--- a/boards/seeed/xiao_esp32s3/doc/index.rst
+++ b/boards/seeed/xiao_esp32s3/doc/index.rst
@@ -135,7 +135,7 @@ To build the sample application using sysbuild use the command:
 
 .. zephyr-app-commands::
    :tool: west
-   :app: samples/hello_world
+   :zephyr-app: samples/hello_world
    :board: xiao_esp32s3
    :goals: build
    :west-args: --sysbuild

--- a/boards/vcc-gnd/yd_esp32/doc/index.rst
+++ b/boards/vcc-gnd/yd_esp32/doc/index.rst
@@ -156,7 +156,7 @@ To build the sample application using sysbuild use the command:
 
 .. zephyr-app-commands::
    :tool: west
-   :app: samples/hello_world
+   :zephyr-app: samples/hello_world
    :board: yd_esp32
    :goals: build
    :west-args: --sysbuild

--- a/doc/build/sysbuild/index.rst
+++ b/doc/build/sysbuild/index.rst
@@ -95,7 +95,7 @@ As mentioned above, you can run sysbuild via ``west build`` or ``cmake``.
 
       .. zephyr-app-commands::
          :tool: west
-         :app: samples/hello_world
+         :zephyr-app: samples/hello_world
          :board: reel_board
          :goals: build
          :west-args: --sysbuild
@@ -166,7 +166,7 @@ applying to both images debug optimizations:
 
       .. zephyr-app-commands::
          :tool: west
-         :app: samples/hello_world
+         :zephyr-app: samples/hello_world
          :board: reel_board
          :goals: build
          :west-args: --sysbuild
@@ -316,7 +316,7 @@ enable MCUboot and build and flash the sample as follows:
 
       .. zephyr-app-commands::
          :tool: west
-         :app: samples/hello_world
+         :zephyr-app: samples/hello_world
          :board: reel_board
          :goals: build
          :west-args: --sysbuild
@@ -381,7 +381,7 @@ specify this file when building with sysbuild, as follows:
 
       .. zephyr-app-commands::
          :tool: west
-         :app: samples/hello_world
+         :zephyr-app: samples/hello_world
          :board: reel_board
          :goals: build
          :west-args: --sysbuild

--- a/doc/develop/application/index.rst
+++ b/doc/develop/application/index.rst
@@ -802,7 +802,7 @@ As an example, let's build the Hello World sample for the ``reel_board``:
 
 .. zephyr-app-commands::
    :tool: all
-   :app: samples/hello_world
+   :zephyr-app: samples/hello_world
    :board: reel_board
    :goals: build
 
@@ -820,7 +820,7 @@ Using CMake directly:
 
 .. zephyr-app-commands::
    :tool: cmake
-   :app: samples/hello_world
+   :zephyr-app: samples/hello_world
    :generator: make
    :host-os: unix
    :board: reel_board

--- a/doc/develop/beyond-GSG.rst
+++ b/doc/develop/beyond-GSG.rst
@@ -203,7 +203,7 @@ a list of supported boards.
 #. Build the blinky sample for the ``reel_board``:
 
    .. zephyr-app-commands::
-      :app: samples/basic/blinky
+      :zephyr-app: samples/basic/blinky
       :board: reel_board
       :goals: build
 

--- a/doc/develop/debug/index.rst
+++ b/doc/develop/debug/index.rst
@@ -225,7 +225,7 @@ Generate and Import an Eclipse Project
 
    .. zephyr-app-commands::
       :tool: all
-      :app: %ZEPHYR_BASE%\samples\synchronization
+      :zephyr-app: samples\synchronization
       :host-os: win
       :board: frdm_k64f
       :gen-args: -G"Eclipse CDT4 - Ninja"

--- a/doc/develop/optimizations/tools.rst
+++ b/doc/develop/optimizations/tools.rst
@@ -53,7 +53,7 @@ Use the ``ram_report`` target with your board, as in the following example.
 
 .. zephyr-app-commands::
     :tool: all
-    :app: samples/hello_world
+    :zephyr-app: samples/hello_world
     :board: reel_board
     :goals: ram_report
 
@@ -114,7 +114,7 @@ Use the ``rom_report`` target with your board, as in the following example.
 
 .. zephyr-app-commands::
     :tool: all
-    :app: samples/hello_world
+    :zephyr-app: samples/hello_world
     :board: reel_board
     :goals: rom_report
 
@@ -179,7 +179,7 @@ as in the following example.
 
 .. zephyr-app-commands::
     :tool: all
-    :app: samples/hello_world
+    :zephyr-app: samples/hello_world
     :board: reel_board
     :goals: puncover
 
@@ -189,7 +189,7 @@ To view worst-case stack usage analysis, build this with the
 
 .. zephyr-app-commands::
     :tool: all
-    :app: samples/hello_world
+    :zephyr-app: samples/hello_world
     :board: reel_board
     :goals: puncover
     :gen-args: -DCONFIG_STACK_USAGE=y
@@ -223,7 +223,7 @@ as in the following example.
 
 .. zephyr-app-commands::
     :tool: all
-    :app: samples/hello_world
+    :zephyr-app: samples/hello_world
     :board: reel_board
     :goals: pahole
 

--- a/doc/hardware/emulator/bus_emulators.rst
+++ b/doc/hardware/emulator/bus_emulators.rst
@@ -184,7 +184,7 @@ Here are some examples present in Zephyr:
 #. Bosch BMI160 sensor driver connected via both I2C and SPI to an emulator:
 
    .. zephyr-app-commands::
-      :app: tests/drivers/sensor/accel/
+      :zephyr-app: tests/drivers/sensor/accel/
       :board: native_sim
       :goals: build
 
@@ -192,7 +192,7 @@ Here are some examples present in Zephyr:
    connected via I2C an emulator:
 
    .. zephyr-app-commands::
-      :app: tests/drivers/eeprom/api
+      :zephyr-app: tests/drivers/eeprom/api
       :board: native_sim
       :goals: build
       :gen-args: -DDTC_OVERLAY_FILE=at2x_emul.overlay -DOVERLAY_CONFIG=at2x_emul.conf

--- a/doc/security/hardening-tool.rst
+++ b/doc/security/hardening-tool.rst
@@ -25,7 +25,7 @@ Usage
 
 .. zephyr-app-commands::
     :tool: all
-    :app: samples/hello_world
+    :zephyr-app: samples/hello_world
     :board: reel_board
     :goals: hardenconfig
 

--- a/doc/services/debugging/thread-analyzer.rst
+++ b/doc/services/debugging/thread-analyzer.rst
@@ -14,7 +14,7 @@ For example, to build the synchronization sample with Thread Analyser enabled,
 do the following:
 
    .. zephyr-app-commands::
-      :app: samples/synchronization/
+      :zephyr-app: samples/synchronization/
       :board: qemu_x86
       :goals: build
       :gen-args: -DCONFIG_QEMU_ICOUNT=n -DCONFIG_THREAD_ANALYZER=y \

--- a/doc/services/tfm/build.rst
+++ b/doc/services/tfm/build.rst
@@ -145,7 +145,7 @@ Use the ``tfm_ram_report`` to get the RAM report for TF-M secure firmware (tfm_s
 
 .. zephyr-app-commands::
     :tool: all
-    :app: samples/hello_world
+    :zephyr-app: samples/hello_world
     :board: mps2_an521_ns
     :goals: tfm_ram_report
 
@@ -153,7 +153,7 @@ Use the ``tfm_rom_report`` to get the ROM report for TF-M secure firmware (tfm_s
 
 .. zephyr-app-commands::
     :tool: all
-    :app: samples/hello_world
+    :zephyr-app: samples/hello_world
     :board: mps2_an521_ns
     :goals: tfm_rom_report
 
@@ -161,7 +161,7 @@ Use the ``bl2_ram_report`` to get the RAM report for TF-M MCUboot, if enabled.
 
 .. zephyr-app-commands::
     :tool: all
-    :app: samples/hello_world
+    :zephyr-app: samples/hello_world
     :board: mps2_an521_ns
     :goals: bl2_ram_report
 
@@ -169,6 +169,6 @@ Use the ``bl2_rom_report`` to get the ROM report for TF-M MCUboot, if enabled.
 
 .. zephyr-app-commands::
     :tool: all
-    :app: samples/hello_world
+    :zephyr-app: samples/hello_world
     :board: mps2_an521_ns
     :goals: bl2_rom_report

--- a/doc/services/tracing/index.rst
+++ b/doc/services/tracing/index.rst
@@ -464,7 +464,7 @@ port, build the sample as follows:
 
 .. zephyr-app-commands::
    :tool: all
-   :app: samples/subsys/tracing
+   :zephyr-app: samples/subsys/tracing
    :board: native_sim
    :gen-args: -DCONF_FILE=prj_native_ctf.conf
    :goals: build

--- a/samples/boards/stm32/ccm/README.rst
+++ b/samples/boards/stm32/ccm/README.rst
@@ -43,7 +43,7 @@ Building and Running
 ********************
 
 .. zephyr-app-commands::
-   :app: samples/boards/stm32/ccm
+   :zephyr-app: samples/boards/stm32/ccm
    :goals: build flash
 
 The first time the example is run after power on, the output will

--- a/samples/boards/stm32/mco/README.rst
+++ b/samples/boards/stm32/mco/README.rst
@@ -21,7 +21,7 @@ Building and Running
 ********************
 
 .. zephyr-app-commands::
-   :app: samples/boards/stm32/mco
+   :zephyr-app: samples/boards/stm32/mco
    :board: nucleo_u5a5zj_q
    :goals: build flash
 

--- a/samples/modules/canopennode/README.rst
+++ b/samples/modules/canopennode/README.rst
@@ -405,7 +405,7 @@ for the FRDM-K64F as follows:
 
    .. zephyr-app-commands::
       :tool: west
-      :app: samples/modules/canopennode
+      :zephyr-app: samples/modules/canopennode
       :board: frdm_k64f
       :goals: build
       :west-args: --sysbuild

--- a/samples/sensor/vcnl4040/README.rst
+++ b/samples/sensor/vcnl4040/README.rst
@@ -28,7 +28,7 @@ Building and Running
  sensor to be connected to the desired board.
 
  .. zephyr-app-commands::
-    :app: samples/sensor/vcnl4040/
+    :zephyr-app: samples/sensor/vcnl4040/
     :goals: build flash
 
 

--- a/samples/sensor/vl53l0x/README.rst
+++ b/samples/sensor/vl53l0x/README.rst
@@ -27,7 +27,7 @@ Building and Running
  sensor, which is present on the disco_l475_iot1 board.
 
  .. zephyr-app-commands::
-    :app: samples/sensor/vl53l0x/
+    :zephyr-app: samples/sensor/vl53l0x/
     :goals: build flash
 
 

--- a/samples/sysbuild/with_mcuboot/README.rst
+++ b/samples/sysbuild/with_mcuboot/README.rst
@@ -32,7 +32,7 @@ To build both the sample and MCUboot with ``west`` for the ``reel_board``, run:
 
 .. zephyr-app-commands::
    :tool: west
-   :app: samples/application_development/sysbuild/with_mcuboot
+   :zephyr-app: samples/application_development/sysbuild/with_mcuboot
    :board: reel_board
    :goals: build
    :west-args: --sysbuild


### PR DESCRIPTION
The `zephyr-app-commands` directive can output a helpful hint to the user when they are trying to build a sample that is in the Zephyr tree, telling them to ensure they are in the root folder of the Zephyr repo before running the command.

Update all doc pages that were using :app: instead of :zephyr-app: so that the hint is displayed.