### PR TITLE
samples: use zephyr:code-sample directive where missing

### DIFF
--- a/doc/kernel/code-relocation.rst
+++ b/doc/kernel/code-relocation.rst
@@ -161,5 +161,4 @@ This test shows how the code relocation feature is used.
 This test will place .text, .data, .bss from 3 files to various parts in the SRAM
 using a custom linker file derived from ``include/zephyr/arch/arm/cortex_m/scripts/linker.ld``
 
-A sample showcasing the NOCOPY flag is provided at
-``$ZEPHYR_BASE/samples/application_development/code_relocation_nocopy/``
+A sample showcasing the NOCOPY flag is provided here: :zephyr:code-sample:`code_relocation_nocopy`.

--- a/samples/application_development/code_relocation_nocopy/README.rst
+++ b/samples/application_development/code_relocation_nocopy/README.rst
@@ -1,7 +1,7 @@
-.. _code_relocation_nocopy:
+.. zephyr:code-sample:: code_relocation_nocopy
+   :name: Code relocation nocopy
 
-Code relocation nocopy
-######################
+   Relocate code, data, or bss sections using a custom linker script.
 
 Overview
 ********

--- a/samples/application_development/external_lib/README.rst
+++ b/samples/application_development/external_lib/README.rst
@@ -1,7 +1,7 @@
-.. _external_library:
+.. zephyr:code-sample:: external_library
+   :name: External Library
 
-External Library
-#################
+   Include an external static library into the Zephyr build system.
 
 Overview
 ********

--- a/samples/cpp/cpp_synchronization/README.rst
+++ b/samples/cpp/cpp_synchronization/README.rst
@@ -1,7 +1,7 @@
-.. _cpp_synchronization:
+.. zephyr:code-sample:: cpp_synchronization
+   :name: C++ synchronization
 
-C++ Synchronization
-###################
+   Use Zephyr synchronization primitives from C++ code.
 
 Overview
 ********

--- a/samples/cpp/hello_world/README.rst
+++ b/samples/cpp/hello_world/README.rst
@@ -1,7 +1,7 @@
-.. _hello_cpp_world:
+.. zephyr:code-sample:: hello_cpp_world
+   :name: Hello C++ world
 
-Hello C++ World
-###############
+   Print "Hello World" to the console in C++.
 
 Overview
 ********

--- a/samples/posix/env/README.rst
+++ b/samples/posix/env/README.rst
@@ -1,7 +1,7 @@
-.. _posix-env-sample:
+.. zephyr:code-sample:: posix-env
+   :name: Environment Variables
 
-POSIX Environment Variables
-###########################
+   Manipulate environment variables from a Zephyr application.
 
 Overview
 ********

--- a/samples/posix/eventfd/README.rst
+++ b/samples/posix/eventfd/README.rst
@@ -1,7 +1,7 @@
-.. _posix-eventfd-sample:
+.. zephyr:code-sample:: posix-eventfd
+   :name: eventfd()
 
-POSIX eventfd()
-###############
+   Use ``eventfd()`` to create a file descriptor for event notification.
 
 Overview
 ********

--- a/samples/posix/gettimeofday/README.rst
+++ b/samples/posix/gettimeofday/README.rst
@@ -1,7 +1,7 @@
-.. _posix-gettimeofday-sample:
+.. zephyr:code-sample:: posix-gettimeofday
+   :name: gettimeofday() with clock initialization
 
-POSIX gettimeofday() with clock initialization over SNTP
-########################################################
+   Use ``gettimeofday()`` with clock initialization over SNTP.
 
 Overview
 ********

--- a/samples/posix/philosophers/README.rst
+++ b/samples/posix/philosophers/README.rst
@@ -1,7 +1,7 @@
-.. _posix-philosophers-sample:
+.. zephyr:code-sample:: posix-philosophers
+   :name: POSIX Philosophers
 
-POSIX Philosophers
-##################
+   Implement a solution to the Dining Philosophers problem using the POSIX API.
 
 Overview
 ********

--- a/samples/posix/uname/README.rst
+++ b/samples/posix/uname/README.rst
@@ -1,7 +1,7 @@
-.. _posix-uname-sample:
+.. zephyr:code-sample:: posix-uname
+   :name: uname()
 
-POSIX uname()
-#############
+   Use ``uname()`` to acquire system information and output it to the console.
 
 Overview
 ********


### PR DESCRIPTION
Describe the samples using code-sample directive in preparation for upcoming changes to the Zephyr documentation that will be leveraging the provided description and metadata more.

I will be submitting these changes in several reasonably small PRs but not to the point t
where there is one PR per area so as to keep CI usage reasonable.