### PR TITLE
drivers: dac_stm32: add support for internally connected channels

### DIFF
--- a/drivers/dac/dac_ad559x.c
+++ b/drivers/dac/dac_ad559x.c
@@ -43,6 +43,11 @@ static int dac_ad559x_channel_setup(const struct device *dev,
 		return -EINVAL;
 	}
 
+	if (channel_cfg->internal) {
+		LOG_ERR("Internal channels not supported");
+		return -ENOTSUP;
+	}
+
 	data->dac_conf |= BIT(channel_cfg->channel_id);
 
 	return mfd_ad559x_write_reg(config->mfd_dev, AD559X_REG_LDAC_EN, data->dac_conf);

--- a/drivers/dac/dac_ad569x.c
+++ b/drivers/dac/dac_ad569x.c
@@ -77,6 +77,11 @@ static int ad569x_channel_setup(const struct device *dev, const struct dac_chann
 		return -EINVAL;
 	}
 
+	if (channel_cfg->internal) {
+		LOG_ERR("Internal channels not supported");
+		return -ENOTSUP;
+	}
+
 	return 0;
 }
 

--- a/drivers/dac/dac_ad56xx.c
+++ b/drivers/dac/dac_ad56xx.c
@@ -94,6 +94,11 @@ static int ad56xx_channel_setup(const struct device *dev, const struct dac_chann
 		return -EINVAL;
 	}
 
+	if (channel_cfg->internal) {
+		LOG_ERR("Internal channels not supported");
+		return -ENOTSUP;
+	}
+
 	return 0;
 }
 

--- a/drivers/dac/dac_dacx0501.c
+++ b/drivers/dac/dac_dacx0501.c
@@ -106,6 +106,11 @@ static int dacx0501_channel_setup(const struct device *dev,
 		return -ENOTSUP;
 	}
 
+	if (channel_cfg->internal) {
+		LOG_ERR("Internal channels not supported");
+		return -ENOTSUP;
+	}
+
 	return 0;
 }
 

--- a/drivers/dac/dac_dacx0508.c
+++ b/drivers/dac/dac_dacx0508.c
@@ -163,6 +163,11 @@ static int dacx0508_channel_setup(const struct device *dev,
 		return -ENOTSUP;
 	}
 
+	if (channel_cfg->internal) {
+		LOG_ERR("Internal channels not supported");
+		return -ENOTSUP;
+	}
+
 	data->configured |= BIT(channel_cfg->channel_id);
 
 	return 0;

--- a/drivers/dac/dac_dacx3608.c
+++ b/drivers/dac/dac_dacx3608.c
@@ -102,6 +102,11 @@ static int dacx3608_channel_setup(const struct device *dev,
 		return -ENOTSUP;
 	}
 
+	if (channel_cfg->internal) {
+		LOG_ERR("Internal channels not supported");
+		return -ENOTSUP;
+	}
+
 	if (data->configured & BIT(channel_cfg->channel_id)) {
 		LOG_DBG("Channel %d already configured", channel_cfg->channel_id);
 		return 0;

--- a/drivers/dac/dac_esp32.c
+++ b/drivers/dac/dac_esp32.c
@@ -44,6 +44,11 @@ static int dac_esp32_channel_setup(const struct device *dev,
 		return -EINVAL;
 	}
 
+	if (channel_cfg->internal) {
+		LOG_ERR("Internal channels not supported");
+		return -ENOTSUP;
+	}
+
 	dac_output_enable(channel_cfg->channel_id);
 
 	return 0;

--- a/drivers/dac/dac_gd32.c
+++ b/drivers/dac/dac_gd32.c
@@ -115,6 +115,11 @@ static int dac_gd32_channel_setup(const struct device *dev,
 		return -ENOTSUP;
 	}
 
+	if (channel_cfg->internal) {
+		LOG_ERR("Internal channels not supported");
+		return -ENOTSUP;
+	}
+
 	data->resolutions[dacx] = channel_cfg->resolution;
 
 	dac_gd32_disable(dacx);

--- a/drivers/dac/dac_ltc166x.c
+++ b/drivers/dac/dac_ltc166x.c
@@ -66,6 +66,11 @@ static int ltc166x_channel_setup(const struct device *dev,
 		return -ENOTSUP;
 	}
 
+	if (channel_cfg->internal) {
+		LOG_ERR("Internal channels not supported");
+		return -ENOTSUP;
+	}
+
 	return 0;
 }
 

--- a/drivers/dac/dac_mcp4725.c
+++ b/drivers/dac/dac_mcp4725.c
@@ -76,6 +76,10 @@ static int mcp4725_channel_setup(const struct device *dev,
 		return -ENOTSUP;
 	}
 
+	if (channel_cfg->internal) {
+		return -ENOTSUP;
+	}
+
 	return 0;
 }
 

--- a/drivers/dac/dac_mcp4728.c
+++ b/drivers/dac/dac_mcp4728.c
@@ -45,6 +45,10 @@ static int mcp4728_channel_setup(const struct device *dev,
 		return -ENOTSUP;
 	}
 
+	if (channel_cfg->internal) {
+		return -ENOTSUP;
+	}
+
 	return 0;
 }
 

--- a/drivers/dac/dac_mcux_dac.c
+++ b/drivers/dac/dac_mcux_dac.c
@@ -41,6 +41,11 @@ static int mcux_dac_channel_setup(const struct device *dev,
 		return -ENOTSUP;
 	}
 
+	if (channel_cfg->internal) {
+		LOG_ERR("Internal channels not supported");
+		return -ENOTSUP;
+	}
+
 	DAC_GetDefaultConfig(&dac_config);
 	dac_config.enableLowPowerMode = config->low_power;
 	dac_config.referenceVoltageSource = config->reference;

--- a/drivers/dac/dac_mcux_dac32.c
+++ b/drivers/dac/dac_mcux_dac32.c
@@ -44,6 +44,11 @@ static int mcux_dac32_channel_setup(const struct device *dev,
 		return -ENOTSUP;
 	}
 
+	if (channel_cfg->internal) {
+		LOG_ERR("Internal channels not supported");
+		return -ENOTSUP;
+	}
+
 	DAC32_GetDefaultConfig(&dac32_config);
 	dac32_config.enableLowPowerMode = config->low_power;
 	dac32_config.referenceVoltageSource = config->reference;

--- a/drivers/dac/dac_mcux_lpdac.c
+++ b/drivers/dac/dac_mcux_lpdac.c
@@ -41,6 +41,11 @@ static int mcux_lpdac_channel_setup(const struct device *dev,
 		return -ENOTSUP;
 	}
 
+	if (channel_cfg->internal) {
+		LOG_ERR("Internal channels not supported");
+		return -ENOTSUP;
+	}
+
 	DAC_GetDefaultConfig(&dac_config);
 	dac_config.referenceVoltageSource = config->ref_voltage;
 #if defined(FSL_FEATURE_LPDAC_HAS_GCR_BUF_SPD_CTRL) && FSL_FEATURE_LPDAC_HAS_GCR_BUF_SPD_CTRL

--- a/drivers/dac/dac_sam.c
+++ b/drivers/dac/dac_sam.c
@@ -85,6 +85,10 @@ static int dac_sam_channel_setup(const struct device *dev,
 		return -ENOTSUP;
 	}
 
+	if (channel_cfg->internal) {
+		return -ENOTSUP;
+	}
+
 	/* Enable Channel */
 	dac->DACC_CHER = DACC_CHER_CH0 << channel_cfg->channel_id;
 

--- a/drivers/dac/dac_sam0.c
+++ b/drivers/dac/dac_sam0.c
@@ -63,6 +63,10 @@ static int dac_sam0_channel_setup(const struct device *dev,
 		return -ENOTSUP;
 	}
 
+	if (channel_cfg->internal) {
+		return -ENOSYS;
+	}
+
 	return 0;
 }
 

--- a/drivers/dac/dac_stm32.c
+++ b/drivers/dac/dac_stm32.c
@@ -159,7 +159,7 @@ static int dac_stm32_init(const struct device *dev)
 
 	/* Configure dt provided device signals when available */
 	err = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
-	if (err < 0) {
+	if ((err < 0) && (err != -ENOENT)) {
 		LOG_ERR("DAC pinctrl setup failed (%d)", err);
 		return err;
 	}

--- a/drivers/dac/dac_stm32.c
+++ b/drivers/dac/dac_stm32.c
@@ -89,7 +89,7 @@ static int dac_stm32_channel_setup(const struct device *dev,
 {
 	struct dac_stm32_data *data = dev->data;
 	const struct dac_stm32_cfg *cfg = dev->config;
-	uint32_t output_buffer;
+	uint32_t cfg_setting, channel;
 
 	if ((channel_cfg->channel_id - STM32_FIRST_CHANNEL >=
 			data->channel_count) ||
@@ -106,18 +106,33 @@ static int dac_stm32_channel_setup(const struct device *dev,
 		return -ENOTSUP;
 	}
 
+	channel = table_channels[channel_cfg->channel_id - STM32_FIRST_CHANNEL];
+
 	if (channel_cfg->buffered) {
-		output_buffer = LL_DAC_OUTPUT_BUFFER_ENABLE;
+		cfg_setting = LL_DAC_OUTPUT_BUFFER_ENABLE;
 	} else {
-		output_buffer = LL_DAC_OUTPUT_BUFFER_DISABLE;
+		cfg_setting = LL_DAC_OUTPUT_BUFFER_DISABLE;
 	}
 
-	LL_DAC_SetOutputBuffer(cfg->base,
-		table_channels[channel_cfg->channel_id - STM32_FIRST_CHANNEL],
-		output_buffer);
+	LL_DAC_SetOutputBuffer(cfg->base, channel, cfg_setting);
 
-	LL_DAC_Enable(cfg->base,
-		table_channels[channel_cfg->channel_id - STM32_FIRST_CHANNEL]);
+#if defined(LL_DAC_OUTPUT_CONNECT_INTERNAL)
+	/* If the DAC supports internal connections set it based on configuration */
+	if (channel_cfg->internal) {
+		cfg_setting = LL_DAC_OUTPUT_CONNECT_INTERNAL;
+	} else {
+		cfg_setting = LL_DAC_OUTPUT_CONNECT_GPIO;
+	}
+
+	LL_DAC_SetOutputConnection(cfg->base, channel, cfg_setting);
+#else
+	if (channel_cfg->internal) {
+		LOG_ERR("Internal connections not supported");
+		return -ENOTSUP;
+	}
+#endif /* LL_DAC_OUTPUT_CONNECT_INTERNAL */
+
+	LL_DAC_Enable(cfg->base, channel);
 
 	LOG_DBG("Channel setup succeeded!");
 

--- a/dts/bindings/dac/st,stm32-dac.yaml
+++ b/dts/bindings/dac/st,stm32-dac.yaml
@@ -17,11 +17,5 @@ properties:
   "#io-channel-cells":
     const: 1
 
-  pinctrl-0:
-    required: true
-
-  pinctrl-names:
-    required: true
-
 io-channel-cells:
   - output

--- a/include/zephyr/drivers/dac.h
+++ b/include/zephyr/drivers/dac.h
@@ -39,7 +39,12 @@ struct dac_channel_cfg {
 	 * This is relevant for instance if the output is directly connected to the load,
 	 * without an amplifierin between. The actual details on this are hardware dependent.
 	 */
-	bool buffered;
+	bool buffered: 1;
+	/** Enable internal output path for this channel. This is relevant for channels that
+	 * support directly connecting to on-chip peripherals via internal paths. The actual
+	 * details on this are hardware dependent.
+	 */
+	bool internal: 1;
 };
 
 /**


### PR DESCRIPTION
Adds support for configuring the STM32 DAC modes for internal connections. This is only enabled for SOCs that support it. As
part of this change, we make pinctrl configuration in the device tree optional.