### PR TITLE
shell: modules: streamline codebase

### DIFF
--- a/subsys/shell/modules/date_service.c
+++ b/subsys/shell/modules/date_service.c
@@ -42,7 +42,6 @@ static int get_y_m_d(const struct shell *sh, struct tm *t, char *date_str)
 	int day;
 	char *endptr;
 
-	endptr = NULL;
 	year = strtol(date_str, &endptr, 10);
 	if ((endptr == date_str) || (*endptr != '-')) {
 		return -EINVAL;
@@ -50,7 +49,6 @@ static int get_y_m_d(const struct shell *sh, struct tm *t, char *date_str)
 
 	date_str = endptr + 1;
 
-	endptr = NULL;
 	month = strtol(date_str, &endptr, 10);
 	if ((endptr == date_str) || (*endptr != '-')) {
 		return -EINVAL;
@@ -63,7 +61,6 @@ static int get_y_m_d(const struct shell *sh, struct tm *t, char *date_str)
 
 	date_str = endptr + 1;
 
-	endptr = NULL;
 	day = strtol(date_str, &endptr, 10);
 	if ((endptr == date_str) || (*endptr != '\0')) {
 		return -EINVAL;
@@ -94,7 +91,6 @@ static int get_h_m_s(const struct shell *sh, struct tm *t, char *time_str)
 	if (*time_str == ':') {
 		time_str++;
 	} else {
-		endptr = NULL;
 		t->tm_hour = strtol(time_str, &endptr, 10);
 		if (endptr == time_str) {
 			return -EINVAL;
@@ -113,7 +109,6 @@ static int get_h_m_s(const struct shell *sh, struct tm *t, char *time_str)
 	if (*time_str == ':') {
 		time_str++;
 	} else {
-		endptr = NULL;
 		t->tm_min = strtol(time_str, &endptr, 10);
 		if (endptr == time_str) {
 			return -EINVAL;
@@ -129,7 +124,6 @@ static int get_h_m_s(const struct shell *sh, struct tm *t, char *time_str)
 		}
 	}
 
-	endptr = NULL;
 	t->tm_sec = strtol(time_str, &endptr, 10);
 	if ((endptr == time_str) || (*endptr != '\0')) {
 		return -EINVAL;

--- a/subsys/shell/modules/devmem_service.c
+++ b/subsys/shell/modules/devmem_service.c
@@ -100,6 +100,7 @@ static int memory_dump(const struct shell *sh, mem_addr_t phys_addr, size_t size
 static int cmd_dump(const struct shell *sh, size_t argc, char **argv)
 {
 	int rv;
+	int err = 0;
 	size_t size = -1;
 	size_t width = 32;
 	mem_addr_t addr = -1;
@@ -111,22 +112,22 @@ static int cmd_dump(const struct shell *sh, size_t argc, char **argv)
 	while ((rv = getopt(argc, argv, "a:s:w:")) != -1) {
 		switch (rv) {
 		case 'a':
-			addr = (mem_addr_t)strtoul(optarg, NULL, 16);
-			if (addr == 0 && errno == EINVAL) {
+			addr = (mem_addr_t)shell_strtoul(optarg, 16, &err);
+			if (err != 0) {
 				shell_error(sh, "invalid addr '%s'", optarg);
 				return -EINVAL;
 			}
 			break;
 		case 's':
-			size = (size_t)strtoul(optarg, NULL, 0);
-			if (size == 0 && errno == EINVAL) {
+			size = (size_t)shell_strtoul(optarg, 0, &err);
+			if (err != 0) {
 				shell_error(sh, "invalid size '%s'", optarg);
 				return -EINVAL;
 			}
 			break;
 		case 'w':
-			width = (size_t)strtoul(optarg, NULL, 0);
-			if (width == 0 && errno == EINVAL) {
+			width = (size_t)shell_strtoul(optarg, 0, &err);
+			if (err != 0) {
 				shell_error(sh, "invalid width '%s'", optarg);
 				return -EINVAL;
 			}

--- a/subsys/shell/modules/kernel_service/thread/list.c
+++ b/subsys/shell/modules/kernel_service/thread/list.c
@@ -73,14 +73,14 @@ static void shell_tdata_dump(const struct k_thread *cthread, void *user_data)
 	tname = k_thread_name_get(thread);
 
 	shell_print(sh, "%s%p %-10s",
-		      (thread == k_current_get()) ? "*" : " ",
-		      thread,
-		      tname ? tname : "NA");
+		    (thread == k_current_get()) ? "*" : " ",
+		    thread,
+		    tname ? tname : "NA");
 	/* Cannot use lld as it's less portable. */
 	shell_print(sh, "\toptions: 0x%x, priority: %d timeout: %" PRId64,
-		      thread->base.user_options,
-		      thread->base.prio,
-		      (int64_t)thread->base.timeout.dticks);
+		    thread->base.user_options,
+		    thread->base.prio,
+		    (int64_t)thread->base.timeout.dticks);
 	shell_print(sh, "\tstate: %s, entry: %p",
 		    k_thread_state_str(thread, state_str, sizeof(state_str)),
 		    thread->entry.pEntry);

--- a/subsys/shell/modules/kernel_service/thread/stacks.c
+++ b/subsys/shell/modules/kernel_service/thread/stacks.c
@@ -41,10 +41,10 @@ static void shell_stack_dump(const struct k_thread *thread, void *user_data)
 	/* Calculate the real size reserved for the stack */
 	pcnt = ((size - unused) * 100U) / size;
 
-	shell_print(
-		(const struct shell *)user_data, "%p %-" STRINGIFY(THREAD_MAX_NAM_LEN) "s "
-		"(real size %4zu):\tunused %4zu\tusage %4zu / %4zu (%2u %%)",
-		thread, tname ? tname : "NA", size, unused, size - unused, size, pcnt);
+	shell_print(sh,
+		    "%p %-" STRINGIFY(THREAD_MAX_NAM_LEN) "s "
+		    "(real size %4zu):\tunused %4zu\tusage %4zu / %4zu (%2u %%)",
+		    thread, tname ? tname : "NA", size, unused, size - unused, size, pcnt);
 }
 
 K_KERNEL_STACK_ARRAY_DECLARE(z_interrupt_stacks, CONFIG_MP_MAX_NUM_CPUS,

--- a/subsys/shell/shell_utils.c
+++ b/subsys/shell/shell_utils.c
@@ -539,7 +539,7 @@ const struct device *shell_device_lookup(size_t idx,
 long shell_strtol(const char *str, int base, int *err)
 {
 	long val;
-	char *endptr = NULL;
+	char *endptr;
 
 	errno = 0;
 	val = strtol(str, &endptr, base);
@@ -557,7 +557,7 @@ long shell_strtol(const char *str, int base, int *err)
 unsigned long shell_strtoul(const char *str, int base, int *err)
 {
 	unsigned long val;
-	char *endptr = NULL;
+	char *endptr;
 
 	if (*str == '-') {
 		*err = -EINVAL;
@@ -580,7 +580,7 @@ unsigned long shell_strtoul(const char *str, int base, int *err)
 unsigned long long shell_strtoull(const char *str, int base, int *err)
 {
 	unsigned long long val;
-	char *endptr = NULL;
+	char *endptr;
 
 	if (*str == '-') {
 		*err = -EINVAL;


### PR DESCRIPTION
This PR includes 4 commits focused on streamlining the codebase in `subsys/shell/modules`:

---
- **shell: utils:** omit `NULL` initialization of `endptr`
- **shell: modules: date:** omit `NULL` initialization of `endptr`
- **shell: modules: devmem:** utilizing `shell_strtoul` in `cmd_dump`
- **shell: modules: kernel:** various code cleanups.
