### PR TITLE
github: workflows: Update other docker image reference

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -129,7 +129,7 @@ jobs:
     needs: twister-build-prep
     if: needs.twister-build-prep.outputs.size != 0
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.26.13.20240601
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.26.14.20240823
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false


### PR DESCRIPTION
The twister workflow contains two references to the docker image to use. The earlier change only updated one of these.  Update the other to match.  This should allow rust code to be built in the whole twister workflow.