### PR TITLE
tests: kernel: add missing test call argument

### DIFF
--- a/subsys/testsuite/ztest/include/zephyr/ztest_test.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest_test.h
@@ -584,9 +584,10 @@ void ztest_simple_1cpu_after(void *data);
  * @param shuffle Shuffle tests
  * @param suite_iter Test suite repetitions.
  * @param case_iter Test case repetitions.
+ * @param param Test parameter
  */
-#define ztest_run_test_suite(suite, shuffle, suite_iter, case_iter) \
-	z_ztest_run_test_suite(STRINGIFY(suite), shuffle, suite_iter, case_iter)
+#define ztest_run_test_suite(suite, shuffle, suite_iter, case_iter, param) \
+	z_ztest_run_test_suite(STRINGIFY(suite), shuffle, suite_iter, case_iter, param)
 
 /**
  * @brief Structure for architecture specific APIs

--- a/tests/kernel/timer/timer_behavior/src/main.c
+++ b/tests/kernel/timer/timer_behavior/src/main.c
@@ -8,8 +8,8 @@
 
 void test_main(void)
 {
-	ztest_run_test_suite(timer_jitter_drift, false, 1, 1);
+	ztest_run_test_suite(timer_jitter_drift, false, 1, 1, NULL);
 #ifndef CONFIG_TIMER_EXTERNAL_TEST
-	ztest_run_test_suite(timer_tick_train, false, 1, 1);
+	ztest_run_test_suite(timer_tick_train, false, 1, 1, NULL);
 #endif
 }


### PR DESCRIPTION
Add missing param argument.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
