### PR TITLE
samples: sockets: echo_server: fix IPPROTO_IPV6 on UDP sockets

### DIFF
--- a/samples/net/sockets/echo_server/src/udp.c
+++ b/samples/net/sockets/echo_server/src/udp.c
@@ -81,7 +81,7 @@ static int start_udp_proto(struct data *data, struct sockaddr *bind_addr,
 	if (bind_addr->sa_family == AF_INET6) {
 		/* Prefer IPv6 temporary addresses */
 		optval = IPV6_PREFER_SRC_PUBLIC;
-		(void)setsockopt(data->tcp.sock, IPPROTO_IPV6,
+		(void)setsockopt(data->udp.sock, IPPROTO_IPV6,
 				 IPV6_ADDR_PREFERENCES,
 				 &optval, sizeof(optval));
 
@@ -90,7 +90,7 @@ static int start_udp_proto(struct data *data, struct sockaddr *bind_addr,
 		 * IPv4 using another socket
 		 */
 		optval = 1;
-		(void)setsockopt(data->tcp.sock, IPPROTO_IPV6, IPV6_V6ONLY,
+		(void)setsockopt(data->udp.sock, IPPROTO_IPV6, IPV6_V6ONLY,
 				 &optval, sizeof(optval));
 	}
 


### PR DESCRIPTION
IPPROTO_IPV6 option was set on TCP socket (besides doing it already in
tcp.c) instead of UDP. Fix that.