### PR TITLE
samples: sockets: echo_server: test on native_sim/native/64

### DIFF
--- a/samples/net/sockets/echo_server/sample.yaml
+++ b/samples/net/sockets/echo_server/sample.yaml
@@ -139,5 +139,6 @@ tests:
   sample.net.sockets.echo_server.nsos:
     platform_allow:
       - native_sim
+      - native_sim/native/64
     extra_args:
       - OVERLAY_CONFIG="overlay-nsos.conf"


### PR DESCRIPTION
Add 64-bit platform to allowed, so it is tested by twister.