### PR TITLE
Enable SWO support on the Microchip SAM D5x/E5x family

### DIFF
--- a/dts/arm/atmel/samd5x.dtsi
+++ b/dts/arm/atmel/samd5x.dtsi
@@ -30,6 +30,13 @@
 				compatible = "arm,armv7m-mpu";
 				reg = <0xe000ed90 0x40>;
 			};
+
+			itm: itm@e0000000 {
+				compatible = "arm,armv7m-itm";
+				reg = <0xe0000000 0x1000>;
+
+				// reference frequency depends on GCLK_CM4_TRACE channel
+			};
 		};
 	};
 

--- a/soc/atmel/sam0/samd51/Kconfig
+++ b/soc/atmel/sam0/samd51/Kconfig
@@ -10,4 +10,5 @@ config SOC_SERIES_SAMD51
 	select CPU_CORTEX_M_HAS_DWT
 	select CPU_HAS_ARM_MPU
 	select CPU_HAS_FPU
+	select HAS_SWO
 	select PLATFORM_SPECIFIC_INIT

--- a/soc/atmel/sam0/same51/Kconfig
+++ b/soc/atmel/sam0/same51/Kconfig
@@ -10,4 +10,5 @@ config SOC_SERIES_SAME51
 	select CPU_CORTEX_M_HAS_DWT
 	select CPU_HAS_ARM_MPU
 	select CPU_HAS_FPU
+	select HAS_SWO
 	select PLATFORM_SPECIFIC_INIT

--- a/soc/atmel/sam0/same53/Kconfig
+++ b/soc/atmel/sam0/same53/Kconfig
@@ -10,4 +10,5 @@ config SOC_SERIES_SAME53
 	select CPU_CORTEX_M_HAS_DWT
 	select CPU_HAS_ARM_MPU
 	select CPU_HAS_FPU
+	select HAS_SWO
 	select PLATFORM_SPECIFIC_INIT

--- a/soc/atmel/sam0/same54/Kconfig
+++ b/soc/atmel/sam0/same54/Kconfig
@@ -10,4 +10,5 @@ config SOC_SERIES_SAME54
 	select CPU_CORTEX_M_HAS_DWT
 	select CPU_HAS_ARM_MPU
 	select CPU_HAS_FPU
+	select HAS_SWO
 	select PLATFORM_SPECIFIC_INIT


### PR DESCRIPTION
The Atmel/Microchip SAM D5x/E5x chips support the standard suite of tracing functionality that comes with a Cortex-M4 processor. However, the relevant declarations have been missing from DTS/Kconfig, preventing the use of SWO for logging, for example.

This PR adds the necessary bits and pieces.

I'm ambivalent as to how to deal with the necessary clock tree setup here - one option would be to simply always set up the CM4_TRACE clock to match the CPU core clock in `soc_samd5x.c` to align this with other SoCs work, but this seems wasteful (maybe we should only do it when `itm` has `status = "okay"`?).