### PR TITLE
logging: swo: make CoreSight setup optional

### DIFF
--- a/subsys/logging/backends/Kconfig.swo
+++ b/subsys/logging/backends/Kconfig.swo
@@ -11,6 +11,12 @@ config LOG_BACKEND_SWO
 
 if LOG_BACKEND_SWO
 
+config LOG_BACKEND_SWO_CONFIGURE_ITM
+	bool "Initialize ITM"
+	default y
+
+if LOG_BACKEND_SWO_CONFIGURE_ITM
+
 config LOG_BACKEND_SWO_REF_FREQ_HZ
 	int "SWO reference clock frequency"
 	default $(dt_node_int_prop_int,$(dt_nodelabel_path,itm),swo-ref-frequency) if $(dt_nodelabel_enabled,itm)
@@ -52,6 +58,8 @@ config LOG_BACKEND_SWO_PROTOCOL_MANCHESTER
 	  recovered automatically on the receiving side.
 
 endchoice
+
+endif # LOG_BACKEND_SWO_CONFIGURE_ITM
 
 backend = SWO
 backend-str = swo

--- a/subsys/logging/backends/log_backend_swo.c
+++ b/subsys/logging/backends/log_backend_swo.c
@@ -92,29 +92,31 @@ static int format_set(const struct log_backend *const backend, uint32_t log_type
 
 static void log_backend_swo_init(struct log_backend const *const backend)
 {
-	/* Enable DWT and ITM units */
-	CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
-	/* Enable access to ITM registers */
-	ITM->LAR  = 0xC5ACCE55;
-	/* Disable stimulus ports ITM_STIM0-ITM_STIM31 */
-	ITM->TER  = 0x0;
-	/* Disable ITM */
-	ITM->TCR  = 0x0;
-	/* Select TPIU encoding protocol */
-	TPI->SPPR = IS_ENABLED(CONFIG_LOG_BACKEND_SWO_PROTOCOL_NRZ) ? 2 : 1;
-	/* Set SWO baud rate prescaler value: SWO_clk = ref_clock/(ACPR + 1) */
-	TPI->ACPR = SWO_FREQ_DIV - 1;
-	/* Enable unprivileged access to ITM stimulus ports */
-	ITM->TPR  = 0x0;
-	/* Configure Debug Watchpoint and Trace */
-	DWT->CTRL &= (DWT_CTRL_POSTPRESET_Msk | DWT_CTRL_POSTINIT_Msk | DWT_CTRL_CYCCNTENA_Msk);
-	DWT->CTRL |= (DWT_CTRL_POSTPRESET_Msk | DWT_CTRL_POSTINIT_Msk);
-	/* Configure Formatter and Flush Control Register */
-	TPI->FFCR = 0x00000100;
-	/* Enable ITM, set TraceBusID=1, no local timestamp generation */
-	ITM->TCR  = 0x0001000D;
-	/* Enable stimulus port used by the logger */
-	ITM->TER  = 1 << ITM_PORT_LOGGER;
+	if (IS_ENABLED(CONFIG_LOG_BACKEND_SWO_CONFIGURE_ITM)) {
+		/* Enable DWT and ITM units */
+		CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+		/* Enable access to ITM registers */
+		ITM->LAR  = 0xC5ACCE55;
+		/* Disable stimulus ports ITM_STIM0-ITM_STIM31 */
+		ITM->TER  = 0x0;
+		/* Disable ITM */
+		ITM->TCR  = 0x0;
+		/* Select TPIU encoding protocol */
+		TPI->SPPR = IS_ENABLED(CONFIG_LOG_BACKEND_SWO_PROTOCOL_NRZ) ? 2 : 1;
+		/* Set SWO baud rate prescaler value: SWO_clk = ref_clock/(ACPR + 1) */
+		TPI->ACPR = SWO_FREQ_DIV - 1;
+		/* Enable unprivileged access to ITM stimulus ports */
+		ITM->TPR  = 0x0;
+		/* Configure Debug Watchpoint and Trace */
+		DWT->CTRL &= (DWT_CTRL_POSTPRESET_Msk | DWT_CTRL_POSTINIT_Msk | DWT_CTRL_CYCCNTENA_Msk);
+		DWT->CTRL |= (DWT_CTRL_POSTPRESET_Msk | DWT_CTRL_POSTINIT_Msk);
+		/* Configure Formatter and Flush Control Register */
+		TPI->FFCR = 0x00000100;
+		/* Enable ITM, set TraceBusID=1, no local timestamp generation */
+		ITM->TCR  = 0x0001000D;
+		/* Enable stimulus port used by the logger */
+		ITM->TER  = 1 << ITM_PORT_LOGGER;
+	}
 
 	/* Initialize pin control settings, if any are defined */
 #if DT_NODE_HAS_PROP(DT_NODELABEL(itm), pinctrl_0)


### PR DESCRIPTION
The SWO log backend currently always initializes the ITM, TPIU, etc so that log output becomes available to the user. While this is convenient, it interferes with the common practice of the debug probe setting up/dynamically controlling these components, both for ITM purposes (such as enabling/disabling stimulus ports) and other tracing features (like for example PC sampling, which gets disabled by the current init code).

To avoid this conflict, make the entire initialization optional. Calling ITM_SendChar indiscriminately is safe since it becomes a NOP when nobody has initialized these components and thus ITMENA is not set or the relevant stimulus port is not enabled.