### PR TITLE
ci: run docs and bsim tests GH actions also on files *deletion*

### DIFF
--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -132,10 +132,10 @@ jobs:
 
       - name: Update BabbleSim to manifest revision
         if: >
-          steps.check-bluetooth-files.outputs.any_changed == 'true'
-          || steps.check-networking-files.outputs.any_changed == 'true'
-          || steps.check-uart-files.outputs.any_changed == 'true'
-          || steps.check-common-files.outputs.any_changed == 'true'
+          steps.check-bluetooth-files.outputs.any_modified == 'true'
+          || steps.check-networking-files.outputs.any_modified == 'true'
+          || steps.check-uart-files.outputs.any_modified == 'true'
+          || steps.check-common-files.outputs.any_modified == 'true'
         run: |
           export BSIM_VERSION=$( west list bsim -f {revision} )
           echo "Manifest points to bsim sha $BSIM_VERSION"
@@ -146,17 +146,17 @@ jobs:
           make everything -s -j 8
 
       - name: Run Bluetooth Tests with BSIM
-        if: steps.check-bluetooth-files.outputs.any_changed == 'true' || steps.check-common-files.outputs.any_changed == 'true'
+        if: steps.check-bluetooth-files.outputs.any_modified == 'true' || steps.check-common-files.outputs.any_modified == 'true'
         run: |
           tests/bsim/ci.bt.sh
 
       - name: Run Networking Tests with BSIM
-        if: steps.check-networking-files.outputs.any_changed == 'true' || steps.check-common-files.outputs.any_changed == 'true'
+        if: steps.check-networking-files.outputs.any_modified == 'true' || steps.check-common-files.outputs.any_modified == 'true'
         run: |
           tests/bsim/ci.net.sh
 
       - name: Run UART Tests with BSIM
-        if: steps.check-uart-files.outputs.any_changed == 'true' || steps.check-common-files.outputs.any_changed == 'true'
+        if: steps.check-uart-files.outputs.any_modified == 'true' || steps.check-common-files.outputs.any_modified == 'true'
         run: |
           tests/bsim/ci.uart.sh
 

--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -85,7 +85,7 @@ jobs:
           echo "ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/zephyr-sdk-$( cat SDK_VERSION )" >> $GITHUB_ENV
 
       - name: Check common triggering files
-        uses: tj-actions/changed-files@v44
+        uses: tj-actions/changed-files@v45
         id: check-common-files
         with:
           files: |
@@ -100,7 +100,7 @@ jobs:
             tests/bsim/*
 
       - name: Check if Bluethooth files changed
-        uses: tj-actions/changed-files@v44
+        uses: tj-actions/changed-files@v45
         id: check-bluetooth-files
         with:
           files: |
@@ -109,7 +109,7 @@ jobs:
             subsys/bluetooth/
 
       - name: Check if Networking files changed
-        uses: tj-actions/changed-files@v44
+        uses: tj-actions/changed-files@v45
         id: check-networking-files
         with:
           files: |
@@ -122,7 +122,7 @@ jobs:
             include/zephyr/net/ieee802154*
 
       - name: Check if UART files changed
-        uses: tj-actions/changed-files@v44
+        uses: tj-actions/changed-files@v45
         id: check-uart-files
         with:
           files: |

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -29,7 +29,7 @@ jobs:
     if: >
       github.repository_owner == 'zephyrproject-rtos'
     outputs:
-      file_check: ${{ steps.check-doc-files.outputs.any_changed }}
+      file_check: ${{ steps.check-doc-files.outputs.any_modified }}
     steps:
     - name: checkout
       uses: actions/checkout@v4

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -37,7 +37,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
     - name: Check if Documentation related files changed
-      uses: tj-actions/changed-files@v44
+      uses: tj-actions/changed-files@v45
       id: check-doc-files
       with:
         files: |


### PR DESCRIPTION
Use correct output for the changed-files action so that docs and bsim tests jobs also run when *deleted* files are detected, not just added/copied/modified/renamed.
See https://github.com/tj-actions/changed-files?tab=readme-ov-file#output_any_changed vs. https://github.com/tj-actions/changed-files?tab=readme-ov-file#output_any_modified

Spotted this when https://github.com/zephyrproject-rtos/zephyr/pull/77522 did not trigger a doc build when it should have

Also bump to latest version of the action (BTW @stephanosio @ceolin @nashif, can/should we switch to using pinned GH Actions SHAs in all our workflows? happy to send a PR)