### PR TITLE
kconfig: Add option to fail build on warning

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -530,8 +530,13 @@ config LTO
 	help
 	  This option enables Link Time Optimization.
 
+config KCONFIG_WARNINGS_AS_ERRORS
+	bool "Treat Kconfig warnings as errors"
+	help
+	  Break build when Kconfig issues a warning
+
 config COMPILER_WARNINGS_AS_ERRORS
-	bool "Treat warnings as errors"
+	bool "Treat compiler/linker warnings as errors"
 	help
 	  Turn on "warning as error" toolchain flags
 

--- a/scripts/kconfig/kconfig.py
+++ b/scripts/kconfig/kconfig.py
@@ -175,7 +175,7 @@ def check_assigned_sym_values(kconf):
                 msg += "Check these unsatisfied dependencies: " + \
                     ", ".join(expr_strs) + ". "
 
-            warn(msg + SYM_INFO_HINT.format(sym))
+            warn(msg + SYM_INFO_HINT.format(sym), kconf)
 
 
 def missing_deps(sym):
@@ -223,7 +223,8 @@ def check_assigned_choice_values(kconf):
             warn(f"""\
 The choice symbol {choice.user_selection.name_and_loc} was selected (set =y),
 but {choice.selection.name_and_loc if choice.selection else "no symbol"} ended
-up as the choice selection. """ + SYM_INFO_HINT.format(choice.user_selection))
+up as the choice selection. """ + SYM_INFO_HINT.format(choice.user_selection),
+                 kconf)
 
 
 # Hint on where to find symbol information. Used like
@@ -244,7 +245,7 @@ def check_deprecated(kconf):
         selectors = [s for s in split_expr(dep_expr, OR) if expr_value(s) == 2]
         for selector in selectors:
             selector_name = split_expr(selector, AND)[0].name
-            warn(f'Deprecated symbol {selector_name} is enabled.')
+            warn(f'Deprecated symbol {selector_name} is enabled.', kconf)
 
 
 def check_experimental(kconf):
@@ -255,7 +256,7 @@ def check_experimental(kconf):
         selectors = [s for s in split_expr(dep_expr, OR) if expr_value(s) == 2]
         for selector in selectors:
             selector_name = split_expr(selector, AND)[0].name
-            warn(f'Experimental symbol {selector_name} is enabled.')
+            warn(f'Experimental symbol {selector_name} is enabled.', kconf)
 
 
 def promptless(sym):
@@ -312,7 +313,9 @@ def parse_args():
     return parser.parse_args()
 
 
-def warn(msg):
+def warn(msg, kconf):
+    if kconf.syms.get('KCONFIG_WARNINGS_AS_ERRORS', kconf.n).tri_value == 2:
+        err(msg)
     # Use a large fill() width to try to avoid linebreaks in the symbol
     # reference link, and add some extra newlines to set the message off from
     # surrounding text (this usually gets printed as part of spammy CMake


### PR DESCRIPTION
This allows to ensure that CONFIG_* options do not get ignored due to unmet dependencies.

This would implement the first step of #77530. In a later one, twister should gain a parameter to enable this option on its runs.