### PR TITLE
drivers: espi: npcx: support DnX VW signal

### DIFF
--- a/boards/nuvoton/npcx4m8f_evb/npcx4m8f_evb.dts
+++ b/boards/nuvoton/npcx4m8f_evb/npcx4m8f_evb.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 
 #include <nuvoton/npcx4m8f.dtsi>
+#include <nuvoton/npcx/npcx-espi-vws-ex-map.dtsi>
 #include "npcx4m8f_evb-pinctrl.dtsi"
 
 / {

--- a/dts/arm/nuvoton/npcx/npcx-espi-vws-ex-map.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx-espi-vws-ex-map.dtsi
@@ -24,6 +24,10 @@
  *  [S] System-/[P] Platform-Specific Virtual Wires
  */
 
+&espi0 {
+	vw-index-extend-set = < ESPI_NPCX_VW_EX_VAL(1, 6, 0x4A) >;
+};
+
 / {
 	npcx-espi-vws-map {
 		/* eSPI Virtual Vire (VW) input configuration */

--- a/dts/arm/nuvoton/npcx/npcx-espi-vws-ex-map.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx-espi-vws-ex-map.dtsi
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Common eSPI Virtual Wire (VW) mapping configurations in npcx family */
+
+#include <nuvoton/npcx/npcx-espi-vws-map.dtsi>
+
+/*
+ *                Nuvoton NPCX eSPI Virtual Wires Mapping Table
+ * |--------------------------------------------------------------------------|
+ * | VW idx | SLV reg | Wire Bit 3   | Wire Bit 2   | Wire Bit 1| Wire Bit 0  |
+ * |--------------------------------------------------------------------------|
+ * |                 Input (Master-to-Slave) Virtual Wires                    |
+ * |--------------------------------------------------------------------------|
+ * | 4Ah[P] | VWEVMS6 | Reserved     | Reserved     | DnX_WARN  | Reserved    |
+ * |--------------------------------------------------------------------------|
+ * |                Output (Slave-to-Master) Virtual Wires                    |
+ * |--------------------------------------------------------------------------|
+ * | 40h[P] | VWEVSM3 | Reserved     | Reserved     | DNX_ACK   | SUS_ACK#    |
+ * |--------------------------------------------------------------------------|
+ *  [S] System-/[P] Platform-Specific Virtual Wires
+ */
+
+/ {
+	npcx-espi-vws-map {
+		/* eSPI Virtual Vire (VW) input configuration */
+		/* index 4Ah (In) */
+		vw-dnx-warn {
+			vw-reg = <NPCX_VWEVMS6 0x02>;
+			vw-wui = <&wui_vw_dnx_warn>;
+		};
+
+		/* eSPI Virtual Vire (VW) output configuration */
+		/* index 40h (Out) */
+		vw-dnx-ack {
+			vw-reg = <NPCX_VWEVSM3 0x02>;
+		};
+	};
+};

--- a/dts/arm/nuvoton/npcx/npcx-miwus-wui-map.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx-miwus-wui-map.dtsi
@@ -439,7 +439,7 @@
 			miwus = <&miwu2 2 0>; /* SLP_LAN_L */
 		};
 		wui_vw_slp_wlan: wui2-3-1 {
-			miwus = <&miwu2 2 1>; /* SLP_WLAN_L) */
+			miwus = <&miwu2 2 1>; /* SLP_WLAN_L */
 		};
 		wui_vw_fl_ack: wui2-3-4 {
 			miwus = <&miwu2 2 4>; /* FL_ACK */
@@ -460,6 +460,9 @@
 		};
 		wui_vw_pch_to_ec_gen_5: wui2-4-1 {
 			miwus = <&miwu2 3 1>; /* PCH_TO_EC_GENERIC_5 */
+		};
+		wui_vw_dnx_warn: wui2-4-1-alter {
+			miwus = <&miwu2 3 1>; /* DnX_WARN */
 		};
 		wui_vw_pch_to_ec_gen_6: wui2-4-2 {
 			miwus = <&miwu2 3 2>; /* PCH_TO_EC_GENERIC_6 */

--- a/dts/bindings/espi/nuvoton,npcx-espi.yaml
+++ b/dts/bindings/espi/nuvoton,npcx-espi.yaml
@@ -40,3 +40,17 @@ properties:
     type: int
     required: true
     description: The maximum transmit channel payload size.
+
+  vw-index-extend-set:
+    type: array
+    description: |
+      Array of encoded virtual wire information
+      Update the vw index in group setting. Here is the format.
+      < ESPI_NPCX_VW_EX_VAL(direction, group_number, index) >
+      direction: 1 for ESPI_CONTROLLER_TO_TARGET and 0 for ESPI_TARGET_TO_CONTROLLER.
+      group_number: The number of VWEVMS or VWEVSM.
+      index: The index to be replaced.
+
+      For example, update the index of VWEVMS6 into 0x4A and the index of VWEVSM8 into 0x53
+        vw-index-extend-set = < ESPI_NPCX_VW_EX_VAL(1, 6, 0x4A)
+                                ESPI_NPCX_VW_EX_VAL(0, 8, 0x53) >

--- a/include/zephyr/dt-bindings/espi/npcx_espi.h
+++ b/include/zephyr/dt-bindings/espi/npcx_espi.h
@@ -6,6 +6,20 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ESPI_NPCX_ESPI_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_ESPI_NPCX_ESPI_H_
 
+/*
+ * Encode virtual wire information into a 16-bit unsigned.
+ * index  = bits[7:0], Replacement index number
+ * group = bits[11:8], Group number for VWEVMS or VWEVSM
+ * dir = bits[13:12], Direction for controller to target or target to controller
+ */
+#define ESPI_NPCX_VW_EX_VAL(dir, group, index)                                                     \
+	(((dir & 0x1) << 12) + ((group & 0xf) << 8) + (index & 0xff))
+
+/* extract specific information from encoded ESPI_NPCX_VW_EX_VAL */
+#define ESPI_NPCX_VW_EX_INDEX(e)     ((e) & 0xff)
+#define ESPI_NPCX_VW_EX_GROUP_NUM(e) (((e) >> 8) & 0xf)
+#define ESPI_NPCX_VW_EX_DIR(e)       (((e) >> 12) & 0x1)
+
 /* eSPI VW Master to Slave Register Index */
 #define NPCX_VWEVMS0 0
 #define NPCX_VWEVMS1 1
@@ -17,6 +31,9 @@
 #define NPCX_VWEVMS7 7
 #define NPCX_VWEVMS8 8
 #define NPCX_VWEVMS9 9
+#define NPCX_VWEVMS10 10
+#define NPCX_VWEVMS11 11
+#define NPCX_VWEVMS_MAX 12
 
 /* eSPI VW Slave to Master Register Index */
 #define NPCX_VWEVSM0 0
@@ -29,8 +46,7 @@
 #define NPCX_VWEVSM7 7
 #define NPCX_VWEVSM8 8
 #define NPCX_VWEVSM9 9
-#define NPCX_VWEVSM10 10
-#define NPCX_VWEVSM11 11
+#define NPCX_VWEVSM_MAX 10
 
 /* eSPI VW GPIO Slave to Master Register Index */
 #define NPCX_VWGPSM0 0

--- a/soc/nuvoton/npcx/common/reg/reg_def.h
+++ b/soc/nuvoton/npcx/common/reg/reg_def.h
@@ -750,10 +750,14 @@ struct espi_reg {
 #define NPCX_VWSWIRQ_EDGE_IRQ            28
 #define NPCX_VWEVMS_WIRE                 FIELD(0, 4)
 #define NPCX_VWEVMS_VALID                FIELD(4, 4)
+#define NPCX_VWEVMS_INDEX                FIELD(8, 7)
+#define NPCX_VWEVMS_INDEX_EN             15
 #define NPCX_VWEVMS_IE                   18
 #define NPCX_VWEVMS_WE                   20
 #define NPCX_VWEVSM_WIRE                 FIELD(0, 4)
 #define NPCX_VWEVSM_VALID                FIELD(4, 4)
+#define NPCX_VWEVSM_INDEX                FIELD(8, 7)
+#define NPCX_VWEVSM_INDEX_EN             15
 #define NPCX_VWEVSM_BIT_VALID(n)         (4+n)
 #define NPCX_VWEVSM_HW_WIRE              FIELD(24, 4)
 #define NPCX_VWGPSM_INDEX_EN             15


### PR DESCRIPTION
This commit adds the support for DnX_ACK and DnX_WARN virtual wire signals in the handler. Besides, add the function that can expand VW index settings according to the property setting.