### PR TITLE
Add suppport for Entropy driver on EK-RA8D1 and MCK-RA8T1

### DIFF
--- a/boards/renesas/ek_ra8d1/doc/index.rst
+++ b/boards/renesas/ek_ra8d1/doc/index.rst
@@ -98,6 +98,8 @@ The below features are currently supported on Zephyr OS for EK-RA8D1 board:
 +--------------+------------+------------------+
 | CLOCK        | on-chip    | clock control    |
 +--------------+------------+------------------+
+| ENTROPY      | on-chip    | entropy          |
++--------------+------------+------------------+
 
 Other hardware features are currently not supported by the port.
 

--- a/boards/renesas/ek_ra8d1/ek_ra8d1.dts
+++ b/boards/renesas/ek_ra8d1/ek_ra8d1.dts
@@ -19,6 +19,7 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &uart9;
 		zephyr,shell-uart = &uart9;
+		zephyr,entropy = &trng;
 	};
 
 	leds {
@@ -98,4 +99,8 @@
 		current-speed = <115200>;
 		status = "okay";
 	};
+};
+
+&trng {
+	status = "okay";
 };

--- a/boards/renesas/mck_ra8t1/doc/index.rst
+++ b/boards/renesas/mck_ra8t1/doc/index.rst
@@ -96,6 +96,8 @@ The below features are currently supported on Zephyr OS for MCB-RA8T1 board:
 +--------------+------------+----------------------+
 | CLOCK        | on-chip    | clock control        |
 +--------------+------------+----------------------+
+| ENTROPY      | on-chip    | entropy              |
++--------------+------------+----------------------+
 
 Other hardware features are currently not supported by the port.
 

--- a/boards/renesas/mck_ra8t1/mck_ra8t1.dts
+++ b/boards/renesas/mck_ra8t1/mck_ra8t1.dts
@@ -19,6 +19,7 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &uart3;
 		zephyr,shell-uart = &uart3;
+		zephyr,entropy = &trng;
 	};
 
 	leds {
@@ -92,4 +93,8 @@
 		current-speed = <115200>;
 		status = "okay";
 	};
+};
+
+&trng {
+	status = "okay";
 };


### PR DESCRIPTION
Add support for Entropy driver on these boards:
- EK-RA8D1
- MCK-RA8T1