### PR TITLE
Bluetooth: Host: Fix incorrect build assert

### DIFF
--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -333,7 +333,7 @@ struct closure {
 } __packed;
 
 #if defined(CONFIG_BT_CONN_TX_USER_DATA_SIZE)
-BUILD_ASSERT(sizeof(struct closure) < CONFIG_BT_CONN_TX_USER_DATA_SIZE);
+BUILD_ASSERT(sizeof(struct closure) <= CONFIG_BT_CONN_TX_USER_DATA_SIZE);
 #endif
 
 static inline void make_closure(void *storage, void *cb, void *data)

--- a/tests/bluetooth/host/id/bt_id_set_adv_own_addr/prj.conf
+++ b/tests/bluetooth/host/id/bt_id_set_adv_own_addr/prj.conf
@@ -7,3 +7,7 @@ CONFIG_ASSERT=y
 CONFIG_ASSERT_LEVEL=2
 CONFIG_ASSERT_VERBOSE=y
 CONFIG_ASSERT_ON_ERRORS=y
+
+# Enabling optimizations will make the test fail.
+# Reason is (at the time of writing) unknown.
+CONFIG_NO_OPTIMIZATIONS=y


### PR DESCRIPTION
We want to make sure `struct closure` fits in the user data, so a user data size of `sizeof(struct closure)` is valid.