### PR TITLE
modules: percepio: Fix python executable name

### DIFF
--- a/modules/percepio/CMakeLists.txt
+++ b/modules/percepio/CMakeLists.txt
@@ -104,7 +104,7 @@ if(CONFIG_PERCEPIO_TRACERECORDER)
     )
 
   set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
-      COMMAND python3 ${TRACERECORDER_DIR}/kernelports/Zephyr/scripts/tz_parse_syscalls.py ${CMAKE_BINARY_DIR} ${ZEPHYR_BASE}
+      COMMAND ${PYTHON_EXECUTABLE} ${TRACERECORDER_DIR}/kernelports/Zephyr/scripts/tz_parse_syscalls.py ${CMAKE_BINARY_DIR} ${ZEPHYR_BASE}
     )
 
 endif()


### PR DESCRIPTION
Fix python executable name in percepio module's CMakeLists.txt.

Signed-off-by: Erik Tamlin <erik.tamlin@percepio.com>