### PR TITLE
Ignore failure to set random address when restarting the scanner and using host-based privacy

### DIFF
--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -1786,7 +1786,12 @@ int bt_id_set_scan_own_addr(bool active_scan, uint8_t *own_addr_type)
 
 	if (IS_ENABLED(CONFIG_BT_PRIVACY)) {
 		err = bt_id_set_private_addr(BT_ID_DEFAULT);
-		if (err) {
+		if (err == -EACCES && (atomic_test_bit(bt_dev.flags, BT_DEV_SCANNING) ||
+				       atomic_test_bit(bt_dev.flags, BT_DEV_INITIATING))) {
+			LOG_WRN("Set random addr failure ignored in scan/init state");
+
+			return 0;
+		} else if (err) {
 			return err;
 		}
 


### PR DESCRIPTION
Ignores "command disallowed" if the host privacy implementation tries
to change the device's random address while scanning or initiating.
This is not allowed by spec. It's caused by scan_update() in scan.c.