### PR TITLE
scripts: RISCV instruction SEPC

### DIFF
--- a/scripts/spelling.txt
+++ b/scripts/spelling.txt
@@ -1400,7 +1400,6 @@ senarios||scenarios
 sentivite||sensitive
 separatly||separately
 sepcify||specify
-sepc||spec
 seperated||separated
 seperately||separately
 seperate||separate


### PR DESCRIPTION
In RISCV "sepc" is actually the name of an instruction. As this prevents building. We should remove the line.