### PR TITLE
ipc: icmsg: configure PBUF RX rx_buffer using kconfig

### DIFF
--- a/subsys/ipc/ipc_service/lib/Kconfig.icmsg
+++ b/subsys/ipc/ipc_service/lib/Kconfig.icmsg
@@ -80,3 +80,11 @@ config PBUF
 	  with read/write semantics on top of a memory region shared by the
 	  reader and writer. It optionally embeds cache and memory barrier
 	  management to ensure correct data access.
+
+if PBUF
+
+config PBUF_RX_READ_BUF_SIZE
+	int "Size of PBUF read buffer in bytes"
+	default 128
+
+endif # PBUF


### PR DESCRIPTION
The size of the rx_buffer used by icmsg.c mbox_callback_process() is not MISRA compliant, being "dynamically" allocated on the stack.

This commit adds a kconfig to configure the size of the buffer along with additional logging to detect and report misconfigured rx_buffer size.