### PR TITLE
sensor: current_amp: request calibration

### DIFF
--- a/drivers/sensor/current_amp/current_amp.c
+++ b/drivers/sensor/current_amp/current_amp.c
@@ -149,6 +149,7 @@ static int current_init(const struct device *dev)
 
 	data->sequence.buffer = &data->raw;
 	data->sequence.buffer_size = sizeof(data->raw);
+	data->sequence.calibrate = true;
 
 	return 0;
 }


### PR DESCRIPTION
Request calibration on ADC samples to improve the accuracy of the ADC outputs and therefore the final measured current.