### PR TITLE
drivers: adc: ra: rename "channels-num" to the more common "channel-count"

### DIFF
--- a/drivers/adc/adc_renesas_ra.c
+++ b/drivers/adc/adc_renesas_ra.c
@@ -348,7 +348,7 @@ const adc_extended_cfg_t g_adc_cfg_extend = {
 		.ref_internal = DT_INST_PROP(idx, vref_mv),                                        \
 		IF_ENABLED(CONFIG_ADC_ASYNC, (.read_async = adc_ra_read_async))};                  \
 	static const struct adc_ra_config adc_ra_config_##idx = {                                  \
-		.num_channels = DT_INST_PROP(idx, channels_num),                                   \
+		.num_channels = DT_INST_PROP(idx, channel_count),                                  \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(idx),                                       \
 		IRQ_CONFIGURE_DEFINE(idx),                                                         \
 	};                                                                                         \

--- a/dts/arm/renesas/ra/ra8/ra8x1.dtsi
+++ b/dts/arm/renesas/ra/ra8/ra8x1.dtsi
@@ -284,7 +284,7 @@
 			reg = <0x40332000 0x100>;
 			#io-channel-cells = <1>;
 			vref-mv = <3300>;
-			channels-num = <12>;
+			channel-count = <12>;
 			status = "disabled";
 		};
 
@@ -295,7 +295,7 @@
 			reg = <0x40332200 0x100>;
 			#io-channel-cells = <1>;
 			vref-mv = <3300>;
-			channels-num = <13>;
+			channel-count = <13>;
 			status = "disabled";
 		};
 

--- a/dts/bindings/adc/renesas,ra-adc.yaml
+++ b/dts/bindings/adc/renesas,ra-adc.yaml
@@ -16,10 +16,10 @@ properties:
     required: true
     description: ADC reference voltage (Unit:mV)
 
-  channels-num:
+  channel-count:
     type: int
     required: true
-    description: ADC channels number
+    description: The number of ADC channels
 
   "#io-channel-cells":
     const: 1


### PR DESCRIPTION
The "channels-num" should not be used in the device tree, other system's parts are using "channel-count" instead for the same purpose.

Also property's description has been сorrected.