### PR TITLE
boards: silabs: Fix bluetooth and net related tags & enablement

### DIFF
--- a/boards/silabs/dev_kits/sltb010a/sltb010a_0.yaml
+++ b/boards/silabs/dev_kits/sltb010a/sltb010a_0.yaml
@@ -9,13 +9,10 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - bluetooth
   - counter
   - gpio
   - uart
   - i2c
   - spi
-testing:
-  ignore_tags:
-    - net
-    - bluetooth
 vendor: silabs

--- a/boards/silabs/dev_kits/sltb010a/sltb010a_2.yaml
+++ b/boards/silabs/dev_kits/sltb010a/sltb010a_2.yaml
@@ -9,13 +9,10 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - bluetooth
   - counter
   - gpio
   - uart
   - i2c
   - spi
-testing:
-  ignore_tags:
-    - net
-    - bluetooth
 vendor: silabs

--- a/boards/silabs/dev_kits/xg24_dk2601b/xg24_dk2601b.yaml
+++ b/boards/silabs/dev_kits/xg24_dk2601b/xg24_dk2601b.yaml
@@ -8,14 +8,13 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
+  - bluetooth
   - counter
   - gpio
   - uart
   - watchdog
 testing:
   ignore_tags:
-    - net
-    - bluetooth
     - pm
     - hwinfo
 vendor: silabs

--- a/boards/silabs/dev_kits/xg27_dk2602a/xg27_dk2602a.yaml
+++ b/boards/silabs/dev_kits/xg27_dk2602a/xg27_dk2602a.yaml
@@ -9,11 +9,8 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - bluetooth
   - counter
   - gpio
   - uart
-testing:
-  ignore_tags:
-    - net
-    - bluetooth
 vendor: silabs

--- a/boards/silabs/radio_boards/slwrb4104a/slwrb4104a.dts
+++ b/boards/silabs/radio_boards/slwrb4104a/slwrb4104a.dts
@@ -11,10 +11,6 @@
 / {
 	model = "Silicon Labs BRD4104A (Blue Gecko 13 Radio Board)";
 	compatible = "silabs,slwrb4104a", "silabs,efr32bg13p";
-
-	chosen {
-		zephyr,bt-hci = &bt_hci_silabs;
-	};
 };
 
 &cpu0 {
@@ -59,8 +55,4 @@
 		};
 
 	};
-};
-
-&bt_hci_silabs {
-	status = "okay";
 };

--- a/boards/silabs/radio_boards/slwrb4161a/slwrb4161a.dts
+++ b/boards/silabs/radio_boards/slwrb4161a/slwrb4161a.dts
@@ -11,10 +11,6 @@
 / {
 	model = "Silicon Labs BRD4161A (Mighty Gecko 12 Radio Board)";
 	compatible = "silabs,slwrb4161a", "silabs,efr32mg12p";
-
-	chosen {
-		zephyr,bt-hci = &bt_hci_silabs;
-	};
 };
 
 &cpu0 {
@@ -92,8 +88,4 @@
 		reg = <0x40>;
 		status = "okay";
 	};
-};
-
-&bt_hci_silabs {
-	status = "okay";
 };

--- a/boards/silabs/radio_boards/slwrb4170a/slwrb4170a.dts
+++ b/boards/silabs/radio_boards/slwrb4170a/slwrb4170a.dts
@@ -11,10 +11,6 @@
 / {
 	model = "Silicon Labs BRD4170A (Mighty Gecko 12 Radio Board)";
 	compatible = "silabs,slwrb4170a", "silabs,efr32mg12p";
-
-	chosen {
-		zephyr,bt-hci = &bt_hci_silabs;
-	};
 };
 
 &cpu0 {
@@ -59,8 +55,4 @@
 		};
 
 	};
-};
-
-&bt_hci_silabs {
-	status = "okay";
 };

--- a/boards/silabs/radio_boards/xg24_rb4187c/xg24_rb4187c.yaml
+++ b/boards/silabs/radio_boards/xg24_rb4187c/xg24_rb4187c.yaml
@@ -9,13 +9,12 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - bluetooth
   - gpio
   - uart
   - watchdog
 testing:
   ignore_tags:
-    - net
-    - bluetooth
     - pm
     - hwinfo
 vendor: silabs


### PR DESCRIPTION
```
commit bbf4ce27b5818df8279d4dd674418ed0288b439b (HEAD -> silabs_board_tags, jhedberg/silabs_board_tags)
Author: Johan Hedberg <johan.hedberg@silabs.com>
Date:   Mon Aug 26 14:29:32 2024 +0300

    boards: silabs: Don't explicitly ignore bluetooth and net tags

    These boards support bluetoth, so it should be listed under "supported".
    There's also no (known) good reason to explicitly skip "net" tags, so
    remove that from the ignore_tags list as well. We don't particularly know
    or care about relevant net tests for these boards, so "net" is left out for
    now from the "supported" list.

    Signed-off-by: Johan Hedberg <johan.hedberg@silabs.com>

commit 1caf6c29eaefa8efb77351abbd1e185c3854a8cf
Author: Johan Hedberg <johan.hedberg@silabs.com>
Date:   Mon Aug 26 14:23:31 2024 +0300

    boards: silabs: Disable Bluetooth for boards which lack binary blobs

    These boards don't currently have the necessary binary blobs available
    for Bluetooth, so keep their Bluetooth HCI DT node disabled.

    Signed-off-by: Johan Hedberg <johan.hedberg@silabs.com>
```