### PR TITLE
wifi: Add overrun_count, current_phy_rate implementation

### DIFF
--- a/drivers/wifi/nrfwifi/src/net_if.c
+++ b/drivers/wifi/nrfwifi/src/net_if.c
@@ -1141,6 +1141,7 @@ int nrf_wifi_stats_get(const struct device *dev, struct net_stats_wifi *zstats)
 	zstats->multicast.tx = stats.fw.umac.interface_data_stats.tx_multicast_pkt_count;
 	zstats->unicast.rx   = stats.fw.umac.interface_data_stats.rx_unicast_pkt_count;
 	zstats->unicast.tx   = stats.fw.umac.interface_data_stats.tx_unicast_pkt_count;
+	zstats->overrun_count = stats.host.total_tx_drop_pkts + stats.host.total_rx_drop_pkts;
 
 #ifdef CONFIG_NRF70_RAW_DATA_TX
 	def_dev_ctx = wifi_dev_priv(rpu_ctx_zep->rpu_ctx);

--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -904,6 +904,15 @@ int supplicant_status(const struct device *dev, struct wifi_iface_status *status
 		}
 
 		os_free(conn_info);
+
+		ret = wpa_drv_signal_poll(wpa_s, si);
+		if (!ret) {
+			status->current_phy_rate = si->current_txrate;
+		} else {
+			wpa_printf(MSG_WARNING, "%s: Failed to get signal info\n", __func__);
+			status->current_phy_rate = 0;
+			ret = 0;
+		}
 	} else {
 		ret = 0;
 	}


### PR DESCRIPTION
Add currnet PHY rate which will be TX data rate in bits per second. Also add overrun count which will be represent the number of packets dropped either at received and sent due to lack of buffer memory.