### PR TITLE
Bluetooth: controller: Fix ISO broadcaster pre-transmission groups > 1

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
@@ -627,9 +627,24 @@ static void isr_tx_common(void *param,
 	if (!pdu) {
 		uint8_t payload_index;
 
-		payload_index = (lll->bn_curr - 1U) +
-				(lll->ptc_curr * lll->pto);
-		payload_count = lll->payload_count + payload_index - lll->bn;
+		if (lll->ptc_curr) {
+			uint8_t ptx_idx = lll->ptc_curr - 1;
+			uint8_t ptx_payload_idx;
+			uint32_t ptx_group_mult;
+			uint8_t ptx_group_idx;
+
+			/* Calculate group index and multiplier for deriving
+			 * pre-transmission payload index.
+			 */
+			ptx_group_idx = ptx_idx / lll->bn;
+			ptx_payload_idx = ptx_idx - ptx_group_idx * lll->bn;
+			ptx_group_mult = (ptx_group_idx + 1) * lll->pto;
+			payload_index = ptx_payload_idx + ptx_group_mult * lll->bn;
+		} else {
+			payload_index  = lll->bn_curr - 1U;
+		}
+
+		payload_count = lll->payload_count - lll->bn + payload_index;
 
 #if !TEST_WITH_DUMMY_PDU
 		struct lll_adv_iso_stream *stream;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
@@ -669,6 +669,10 @@ static void isr_tx_common(void *param,
 				 (tx->payload_count < payload_count));
 		}
 		if (!link || (tx->payload_count != payload_count)) {
+			/* FIXME: Do not transmit on air an empty PDU if this is a Pre-Transmission
+			 *        subevent, instead use radio_tmr_start_us() to schedule next valid
+			 *        subevent.
+			 */
 			pdu = radio_pkt_empty_get();
 			pdu->ll_id = lll->framing ? PDU_BIS_LLID_FRAMED :
 						    PDU_BIS_LLID_START_CONTINUE;

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -212,7 +212,7 @@ static uint8_t big_create(uint8_t big_handle, uint8_t adv_handle, uint8_t num_bi
 				return BT_HCI_ERR_INVALID_PARAM;
 			}
 
-			if (!IN_RANGE(pto, 0x00, 0x0F)) {
+			if (pto > 0x0F) {
 				return BT_HCI_ERR_INVALID_PARAM;
 			}
 
@@ -1210,6 +1210,12 @@ static uint8_t ptc_calc(const struct lll_adv_iso *lll, uint32_t event_spacing,
 			 */
 			ptc = MIN(ptc, (lll->bn * BT_CTLR_ADV_ISO_PTO_GROUP_COUNT));
 		}
+
+		/* FIXME: Do not remember why ptc is 4 bits, it should be 5 bits as ptc is a
+		 *        running buffer offset related to nse. Fix ptc and ptc_curr definitions,
+		 *        until then lets have an assert check here.
+		 */
+		LL_ASSERT(ptc <= BIT_MASK(4));
 
 		return ptc;
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -201,12 +201,11 @@ static uint8_t big_create(uint8_t big_handle, uint8_t adv_handle, uint8_t num_bi
 				return BT_HCI_ERR_INVALID_PARAM;
 			}
 
-			/* FIXME: PTO is currently limited to BN */
-			if (!IN_RANGE(pto, 0x00, bn /*0x0F*/)) {
+			if (!IN_RANGE(pto, 0x00, 0x0F)) {
 				return BT_HCI_ERR_INVALID_PARAM;
 			}
 
-			if (bn * irc + pto < nse) {
+			if (pto && !(bn * irc < nse)) {
 				return BT_HCI_ERR_INVALID_PARAM;
 			}
 		} else {
@@ -1162,10 +1161,8 @@ static uint8_t ptc_calc(const struct lll_adv_iso *lll, uint32_t event_spacing,
 		       (lll->sub_interval * lll->bn * lll->num_bis)) *
 		      lll->bn;
 
-		/* FIXME: Here we restrict to a maximum of BN Pre-Transmission
-		 * subevents per BIS
-		 */
-		ptc = MIN(ptc, lll->bn);
+		/* Restrict PTC to number of available subevents */
+		ptc = MIN(ptc, lll->nse - lll->bn * lll->irc);
 
 		return ptc;
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
@@ -483,13 +483,20 @@ void ull_sync_iso_setup(struct ll_sync_iso_set *sync_iso,
 	lll->sub_interval = PDU_BIG_INFO_SUB_INTERVAL_GET(bi);
 	lll->max_pdu = bi->max_pdu;
 	lll->pto = PDU_BIG_INFO_PTO_GET(bi);
+	lll->bis_spacing = PDU_BIG_INFO_SPACING_GET(bi);
+	lll->irc = PDU_BIG_INFO_IRC_GET(bi);
 	if (lll->pto) {
-		lll->ptc = lll->bn;
+		uint8_t nse;
+
+		nse = lll->irc * lll->bn; /* 4 bits * 3 bits, total 7 bits */
+		if (nse >= lll->nse) {
+			return;
+		}
+
+		lll->ptc = lll->nse - nse;
 	} else {
 		lll->ptc = 0U;
 	}
-	lll->bis_spacing = PDU_BIG_INFO_SPACING_GET(bi);
-	lll->irc = PDU_BIG_INFO_IRC_GET(bi);
 	lll->sdu_interval = PDU_BIG_INFO_SDU_INTERVAL_GET(bi);
 
 	/* Pick the 39-bit payload count, 1 MSb is framing bit */

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
@@ -494,6 +494,13 @@ void ull_sync_iso_setup(struct ll_sync_iso_set *sync_iso,
 		}
 
 		lll->ptc = lll->nse - nse;
+
+		/* FIXME: Do not remember why ptc is 4 bits, it should be 5 bits as ptc is a
+		 *        running buffer offset related to nse.
+		 *        Fix ptc and ptc_curr definitions, until then we keep an assertion check
+		 *        here.
+		 */
+		LL_ASSERT(lll->ptc <= BIT_MASK(4));
 	} else {
 		lll->ptc = 0U;
 	}


### PR DESCRIPTION
For pre-transmission groups > 1, the broadcaster link layer would fetch incorrect payloads from the TX node queue.

Update payload index calculation to reference correct TX payload. Fix PTO FIXMEs and range checks.

bsim bap_broadcast_audio_source/sink tested with PTO=2 PTO Group Count = 2:
[bsim_bap_broadcast_source_sink_pto_2_ptogc_2.zip](https://github.com/user-attachments/files/18363537/bsim_bap_broadcast_source_sink_pto_2_ptogc_2.zip)
