### PR TITLE
FIX fs: nvs: nvs fix static analysis error caused by mismatched variable assignment

### DIFF
--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -88,7 +88,7 @@ static void nvs_lookup_cache_invalidate(struct nvs_fs *fs, uint32_t sector)
 /* nvs_al_size returns size aligned to fs->write_block_size */
 static inline size_t nvs_al_size(struct nvs_fs *fs, size_t len)
 {
-	uint8_t write_block_size = fs->flash_parameters->write_block_size;
+	size_t write_block_size = fs->flash_parameters->write_block_size;
 
 	if (write_block_size <= 1U) {
 		return len;


### PR DESCRIPTION
A variable of type size_t is assigned to a variable of type uint8_t in nvs_al_size function. This can trigger static analysis. The problem is fixed by using size_t instead of uint8_t. 