### PR TITLE
boards: renesas: update xtal clock frequency on Renesas RA boards

### DIFF
--- a/boards/renesas/ek_ra6m1/ek_ra6m1.dts
+++ b/boards/renesas/ek_ra6m1/ek_ra6m1.dts
@@ -49,7 +49,7 @@
 };
 
 &xtal {
-	clock-frequency = <DT_FREQ_M(20)>;
+	clock-frequency = <DT_FREQ_M(12)>;
 	mosel = <0>;
 	#clock-cells = <0>;
 	status = "okay";

--- a/boards/renesas/ek_ra6m2/doc/index.rst
+++ b/boards/renesas/ek_ra6m2/doc/index.rst
@@ -19,7 +19,7 @@ The key features of the EK-RA6M2 board are categorized in three groups as follow
 - Native pin access through 4 x 40-pin male headers
 - MCU and USB current measurement points for precision current consumption measurement
 - Multiple clock sources - RA6M2 MCU oscillator and sub-clock oscillator crystals,
-  providing precision 24.000 MHz and 32,768 Hz reference clock.
+  providing precision 12.000 MHz and 32,768 Hz reference clock.
   Additional low precision clocks are avaialbe internal to the RA6M2 MCU
 
 **System Control and Ecosystem Access**


### PR DESCRIPTION
This PR is to:
- Update the wrong value of xtal frequency on EK-RA6M1
- Update documentation of EK-RA6M2 regarding the clock description
It fixed PR #76080