### PR TITLE
drivers: mipi_dbi: nxp_lcdic: calculate reset delay correctly

### DIFF
--- a/drivers/mipi_dbi/mipi_dbi_nxp_lcdic.c
+++ b/drivers/mipi_dbi/mipi_dbi_nxp_lcdic.c
@@ -563,8 +563,8 @@ static int mipi_dbi_lcdic_reset(const struct device *dev, k_timeout_t delay)
 	const struct mipi_dbi_lcdic_config *config = dev->config;
 	LCDIC_Type *base = config->base;
 	uint32_t lcdic_freq;
+	uint32_t delay_ms = k_ticks_to_ms_ceil32(delay.ticks);
 	uint8_t rst_width, pulse_cnt;
-	uint32_t delay_ms = k_ticks_to_ms_ceil32(delay);
 
 	/* Calculate delay based off timer0 ratio. Formula given
 	 * by RM is as follows:


### PR DESCRIPTION
Reset delay was not being calculated correctly in lcdic driver, the ticks field needs to be accessed directly within the timeout structure to calculate the correct delay time

Fixes #77590