### PR TITLE
dts: xtensa: intel_adsp: Set soft-off state as disabled

### DIFF
--- a/dts/xtensa/intel/intel_adsp_cavs25.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs25.dtsi
@@ -50,8 +50,9 @@
 			d3: off {
 				compatible = "zephyr,power-state";
 				power-state-name = "soft-off";
-				min-residency-us = <2147483647>;
+				min-residency-us = <0>;
 				exit-latency-us = <0>;
+				status = "disabled";
 			};
 		};
 	};


### PR DESCRIPTION
The 'soft-off' state must be used when explicitly request by calling `pm_state_force`. Set this state as disabled in dts ensures that the pm policy manager will not use this state.