### PR TITLE
tests: net: wifi: exclude RW612 based boards

### DIFF
--- a/tests/net/wifi/wifi_nm/testcase.yaml
+++ b/tests/net/wifi/wifi_nm/testcase.yaml
@@ -9,3 +9,5 @@ tests:
       - nrf7002dk/nrf5340/cpuapp/ns
       - nrf7002dk/nrf5340/cpuapp/nrf7001
       - nrf7002dk/nrf5340/cpuapp/nrf7001/ns
+      - frdm_rw612 # Requires binary blobs to build
+      - rd_rw612_bga # Requires binary blobs to build


### PR DESCRIPTION
Exclude RW612 based boards from the WiFi testsuite, as these boards require binary blobs be downloaded in order to build as expected