### PR TITLE
[Backport v3.7-branch] drivers: sdhc: imx_usdhc: assume card is present if no detection method

### DIFF
--- a/dts/bindings/sdhc/nxp,imx-usdhc.yaml
+++ b/dts/bindings/sdhc/nxp,imx-usdhc.yaml
@@ -66,3 +66,10 @@ properties:
       Enable the host to detect an SD card via the DAT3 line of the SD card
       connection. Requires the board to define a function to pull DAT3 low or
       high using pullup/pulldown resistors.
+
+  detect-cd:
+    type: boolean
+    description: |
+      Use the host's internal card detect signal (USDHC_CD) to detect the SD
+      card. This signal is available as an alternative to card detect via GPIO,
+      and should be connected to the SD slot's detect pin if used.


### PR DESCRIPTION
Backport https://github.com/zephyrproject-rtos/zephyr/commit/17f71e19f01e36cbde14b78d90449b73300a66f9 from https://github.com/zephyrproject-rtos/zephyr/pull/77301.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/42227