### PR TITLE
wifi: nrf: Add build only to twister

### DIFF
--- a/drivers/wifi/nrfwifi/CMakeLists.txt
+++ b/drivers/wifi/nrfwifi/CMakeLists.txt
@@ -58,10 +58,13 @@ zephyr_library_sources(
   src/work.c
   src/timer.c
   src/fmac_main.c
-  src/fw_load.c
   src/qspi/src/device.c
   src/qspi/src/rpu_hw_if.c
   src/qspi/src/ficr_prog.c
+)
+
+zephyr_library_sources_ifndef(CONFIG_NRF_WIFI_BUILD_ONLY_MODE
+  src/fw_load.c
 )
 
 zephyr_library_sources_ifndef(CONFIG_NRF70_RADIO_TEST
@@ -132,6 +135,14 @@ zephyr_compile_definitions_ifdef(CONFIG_NRF70_ON_QSPI
   -DNRF53_ERRATA_159_ENABLE_WORKAROUND=0
 )
 
+if (CONFIG_NRF_WIFI_BUILD_ONLY_MODE)
+message(WARNING "
+------------------------------------------------------------------------
+Building only the nRF70 driver, skipping firmware patch.
+This is only for building (CI) purposes and will not work on a real device.
+------------------------------------------------------------------------
+")
+else()
 # RPU FW patch binaries based on the selected configuration
 if(CONFIG_NRF70_SYSTEM_MODE)
   set(NRF70_PATCH ${FW_BINS_BASE}/default/nrf70.bin)
@@ -158,6 +169,9 @@ endif()
 zephyr_compile_definitions(
   -DCONFIG_NRF_WIFI_FW_BIN=${NRF70_PATCH}
 )
+endif()
+
+
 
 # Translate the configuration to the OS agnostic code
 zephyr_compile_definitions_ifdef(CONFIG_NRF_WIFI_LOW_POWER

--- a/drivers/wifi/nrfwifi/Kconfig.nrfwifi
+++ b/drivers/wifi/nrfwifi/Kconfig.nrfwifi
@@ -700,4 +700,11 @@ config NRF_WIFI_QOS_NULL_BASED_RETRIEVAL
 
 endchoice
 
+config NRF_WIFI_BUILD_ONLY_MODE
+	bool "Build only mode"
+	help
+	  Enable this option to build the driver without firmware loading, removes
+	  dependency on firmware binary and patches.
+	  This is useful to check the build and link errors.
+
 endif # WIFI_NRF70

--- a/drivers/wifi/nrfwifi/inc/fmac_main.h
+++ b/drivers/wifi/nrfwifi/inc/fmac_main.h
@@ -125,7 +125,16 @@ void set_tx_pwr_ceil_default(struct nrf_wifi_tx_pwr_ceil_params *pwr_ceil_params
 const char *nrf_wifi_get_drv_version(void);
 enum nrf_wifi_status nrf_wifi_fmac_dev_add_zep(struct nrf_wifi_drv_priv_zep *drv_priv_zep);
 enum nrf_wifi_status nrf_wifi_fmac_dev_rem_zep(struct nrf_wifi_drv_priv_zep *drv_priv_zep);
+#ifdef CONFIG_NRF_WIFI_BUILD_ONLY_MODE
+inline enum nrf_wifi_status nrf_wifi_fw_load(void *rpu_ctx)
+{
+	(void)rpu_ctx;
+
+	return NRF_WIFI_STATUS_SUCCESS;
+}
+#else
 enum nrf_wifi_status nrf_wifi_fw_load(void *rpu_ctx);
+#endif /* CONFIG_NRF_WIFI_BUILD_ONLY_MODE */
 struct nrf_wifi_vif_ctx_zep *nrf_wifi_get_vif_ctx(struct net_if *iface);
 void nrf_wifi_rpu_recovery_cb(void *vif_ctx,
 		void *event_data,

--- a/samples/net/wifi/sample.yaml
+++ b/samples/net/wifi/sample.yaml
@@ -41,3 +41,24 @@ tests:
       - nucleo_f767zi
     integration_platforms:
       - frdm_k64f
+  sample.net.wifi.nrf70dk:
+    extra_args: CONFIG_NRF_WIFI_BUILD_ONLY_MODE=y
+    platform_allow:
+      - nrf7002dk/nrf5340/cpuapp
+      - nrf7002dk/nrf5340/cpuapp/ns
+      - nrf7002dk/nrf5340/cpuapp/nrf7001
+      - nrf7002dk/nrf5340/cpuapp/nrf7001/ns
+    integration_platforms:
+      - nrf7002dk/nrf5340/cpuapp
+      - nrf7002dk/nrf5340/cpuapp/nrf7001
+  sample.net.wifi.nrf7002ek:
+    extra_args:
+      - CONFIG_NRF_WIFI_BUILD_ONLY_MODE=y
+      - SHIELD=nrf7002ek
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp/ns
+      - nucleo_h723zg
+    integration_platforms:
+      - nrf5340dk/nrf5340/cpuapp
+      - nucleo_h723zg

--- a/tests/net/wifi/wifi_nm/testcase.yaml
+++ b/tests/net/wifi/wifi_nm/testcase.yaml
@@ -3,11 +3,10 @@ common:
 tests:
   net.wifi:
     min_ram: 32
+    extra_args:
+      # Will be ignored for other platforms
+      - CONFIG_NRF_WIFI_BUILD_ONLY_MODE=y
     tags: wifi
     platform_exclude:
-      - nrf7002dk/nrf5340/cpuapp
-      - nrf7002dk/nrf5340/cpuapp/ns
-      - nrf7002dk/nrf5340/cpuapp/nrf7001
-      - nrf7002dk/nrf5340/cpuapp/nrf7001/ns
       - frdm_rw612 # Requires binary blobs to build
       - rd_rw612_bga # Requires binary blobs to build


### PR DESCRIPTION
This helps validate basic build check without the need to fetch FW blobs. Actual testing will still be done in the Nordic internal CI.