### PR TITLE
drivers: sensor: bme280: use int math in decode q31 conv

### DIFF
--- a/drivers/sensor/bosch/bme280/bme280.h
+++ b/drivers/sensor/bosch/bme280/bme280.h
@@ -32,10 +32,9 @@ union bme280_bus {
 };
 
 typedef int (*bme280_bus_check_fn)(const union bme280_bus *bus);
-typedef int (*bme280_reg_read_fn)(const union bme280_bus *bus,
-				  uint8_t start, uint8_t *buf, int size);
-typedef int (*bme280_reg_write_fn)(const union bme280_bus *bus,
-				   uint8_t reg, uint8_t val);
+typedef int (*bme280_reg_read_fn)(const union bme280_bus *bus, uint8_t start, uint8_t *buf,
+				  int size);
+typedef int (*bme280_reg_write_fn)(const union bme280_bus *bus, uint8_t reg, uint8_t val);
 
 struct bme280_bus_io {
 	bme280_bus_check_fn check;
@@ -44,8 +43,7 @@ struct bme280_bus_io {
 };
 
 #if BME280_BUS_SPI
-#define BME280_SPI_OPERATION (SPI_WORD_SET(8) | SPI_TRANSFER_MSB |	\
-			      SPI_MODE_CPOL | SPI_MODE_CPHA)
+#define BME280_SPI_OPERATION (SPI_WORD_SET(8) | SPI_TRANSFER_MSB | SPI_MODE_CPOL | SPI_MODE_CPHA)
 extern const struct bme280_bus_io bme280_bus_io_spi;
 #endif
 
@@ -53,28 +51,28 @@ extern const struct bme280_bus_io bme280_bus_io_spi;
 extern const struct bme280_bus_io bme280_bus_io_i2c;
 #endif
 
-#define BME280_REG_PRESS_MSB            0xF7
-#define BME280_REG_COMP_START           0x88
-#define BME280_REG_HUM_COMP_PART1       0xA1
-#define BME280_REG_HUM_COMP_PART2       0xE1
-#define BME280_REG_ID                   0xD0
-#define BME280_REG_CONFIG               0xF5
-#define BME280_REG_CTRL_MEAS            0xF4
-#define BME280_REG_CTRL_HUM             0xF2
-#define BME280_REG_STATUS               0xF3
-#define BME280_REG_RESET                0xE0
+#define BME280_REG_PRESS_MSB      0xF7
+#define BME280_REG_COMP_START     0x88
+#define BME280_REG_HUM_COMP_PART1 0xA1
+#define BME280_REG_HUM_COMP_PART2 0xE1
+#define BME280_REG_ID             0xD0
+#define BME280_REG_CONFIG         0xF5
+#define BME280_REG_CTRL_MEAS      0xF4
+#define BME280_REG_CTRL_HUM       0xF2
+#define BME280_REG_STATUS         0xF3
+#define BME280_REG_RESET          0xE0
 
-#define BMP280_CHIP_ID_SAMPLE_1         0x56
-#define BMP280_CHIP_ID_SAMPLE_2         0x57
-#define BMP280_CHIP_ID_MP               0x58
-#define BME280_CHIP_ID                  0x60
-#define BME280_MODE_SLEEP               0x00
-#define BME280_MODE_FORCED              0x01
-#define BME280_MODE_NORMAL              0x03
-#define BME280_SPI_3W_DISABLE           0x00
-#define BME280_CMD_SOFT_RESET           0xB6
-#define BME280_STATUS_MEASURING         0x08
-#define BME280_STATUS_IM_UPDATE         0x01
+#define BMP280_CHIP_ID_SAMPLE_1 0x56
+#define BMP280_CHIP_ID_SAMPLE_2 0x57
+#define BMP280_CHIP_ID_MP       0x58
+#define BME280_CHIP_ID          0x60
+#define BME280_MODE_SLEEP       0x00
+#define BME280_MODE_FORCED      0x01
+#define BME280_MODE_NORMAL      0x03
+#define BME280_SPI_3W_DISABLE   0x00
+#define BME280_CMD_SOFT_RESET   0xB6
+#define BME280_STATUS_MEASURING 0x08
+#define BME280_STATUS_IM_UPDATE 0x01
 
 #if defined CONFIG_BME280_MODE_NORMAL
 #define BME280_MODE BME280_MODE_NORMAL
@@ -83,93 +81,86 @@ extern const struct bme280_bus_io bme280_bus_io_i2c;
 #endif
 
 #if defined CONFIG_BME280_TEMP_OVER_1X
-#define BME280_TEMP_OVER                (1 << 5)
+#define BME280_TEMP_OVER (1 << 5)
 #elif defined CONFIG_BME280_TEMP_OVER_2X
-#define BME280_TEMP_OVER                (2 << 5)
+#define BME280_TEMP_OVER (2 << 5)
 #elif defined CONFIG_BME280_TEMP_OVER_4X
-#define BME280_TEMP_OVER                (3 << 5)
+#define BME280_TEMP_OVER (3 << 5)
 #elif defined CONFIG_BME280_TEMP_OVER_8X
-#define BME280_TEMP_OVER                (4 << 5)
+#define BME280_TEMP_OVER (4 << 5)
 #elif defined CONFIG_BME280_TEMP_OVER_16X
-#define BME280_TEMP_OVER                (5 << 5)
+#define BME280_TEMP_OVER (5 << 5)
 #endif
 
 #if defined CONFIG_BME280_PRESS_OVER_1X
-#define BME280_PRESS_OVER               (1 << 2)
+#define BME280_PRESS_OVER (1 << 2)
 #elif defined CONFIG_BME280_PRESS_OVER_2X
-#define BME280_PRESS_OVER               (2 << 2)
+#define BME280_PRESS_OVER (2 << 2)
 #elif defined CONFIG_BME280_PRESS_OVER_4X
-#define BME280_PRESS_OVER               (3 << 2)
+#define BME280_PRESS_OVER (3 << 2)
 #elif defined CONFIG_BME280_PRESS_OVER_8X
-#define BME280_PRESS_OVER               (4 << 2)
+#define BME280_PRESS_OVER (4 << 2)
 #elif defined CONFIG_BME280_PRESS_OVER_16X
-#define BME280_PRESS_OVER               (5 << 2)
+#define BME280_PRESS_OVER (5 << 2)
 #endif
 
 #if defined CONFIG_BME280_HUMIDITY_OVER_1X
-#define BME280_HUMIDITY_OVER            1
+#define BME280_HUMIDITY_OVER 1
 #elif defined CONFIG_BME280_HUMIDITY_OVER_2X
-#define BME280_HUMIDITY_OVER            2
+#define BME280_HUMIDITY_OVER 2
 #elif defined CONFIG_BME280_HUMIDITY_OVER_4X
-#define BME280_HUMIDITY_OVER            3
+#define BME280_HUMIDITY_OVER 3
 #elif defined CONFIG_BME280_HUMIDITY_OVER_8X
-#define BME280_HUMIDITY_OVER            4
+#define BME280_HUMIDITY_OVER 4
 #elif defined CONFIG_BME280_HUMIDITY_OVER_16X
-#define BME280_HUMIDITY_OVER            5
+#define BME280_HUMIDITY_OVER 5
 #endif
 
 #if defined CONFIG_BME280_STANDBY_05MS
-#define BME280_STANDBY                  0
+#define BME280_STANDBY 0
 #elif defined CONFIG_BME280_STANDBY_62MS
-#define BME280_STANDBY                  (1 << 5)
+#define BME280_STANDBY (1 << 5)
 #elif defined CONFIG_BME280_STANDBY_125MS
-#define BME280_STANDBY                  (2 << 5)
+#define BME280_STANDBY (2 << 5)
 #elif defined CONFIG_BME280_STANDBY_250MS
-#define BME280_STANDBY                  (3 << 5)
+#define BME280_STANDBY (3 << 5)
 #elif defined CONFIG_BME280_STANDBY_500MS
-#define BME280_STANDBY                  (4 << 5)
+#define BME280_STANDBY (4 << 5)
 #elif defined CONFIG_BME280_STANDBY_1000MS
-#define BME280_STANDBY                  (5 << 5)
+#define BME280_STANDBY (5 << 5)
 #elif defined CONFIG_BME280_STANDBY_2000MS
-#define BME280_STANDBY                  (6 << 5)
+#define BME280_STANDBY (6 << 5)
 #elif defined CONFIG_BME280_STANDBY_4000MS
-#define BME280_STANDBY                  (7 << 5)
+#define BME280_STANDBY (7 << 5)
 #endif
 
 #if defined CONFIG_BME280_FILTER_OFF
-#define BME280_FILTER                   0
+#define BME280_FILTER 0
 #elif defined CONFIG_BME280_FILTER_2
-#define BME280_FILTER                   (1 << 2)
+#define BME280_FILTER (1 << 2)
 #elif defined CONFIG_BME280_FILTER_4
-#define BME280_FILTER                   (2 << 2)
+#define BME280_FILTER (2 << 2)
 #elif defined CONFIG_BME280_FILTER_8
-#define BME280_FILTER                   (3 << 2)
+#define BME280_FILTER (3 << 2)
 #elif defined CONFIG_BME280_FILTER_16
-#define BME280_FILTER                   (4 << 2)
+#define BME280_FILTER (4 << 2)
 #endif
 
-#define BME280_CTRL_MEAS_VAL            (BME280_PRESS_OVER | \
-					 BME280_TEMP_OVER |  \
-					 BME280_MODE)
-#define BME280_CONFIG_VAL               (BME280_STANDBY | \
-					 BME280_FILTER |  \
-					 BME280_SPI_3W_DISABLE)
+#define BME280_CTRL_MEAS_VAL (BME280_PRESS_OVER | BME280_TEMP_OVER | BME280_MODE)
+#define BME280_CONFIG_VAL    (BME280_STANDBY | BME280_FILTER | BME280_SPI_3W_DISABLE)
 
-
-#define BME280_CTRL_MEAS_OFF_VAL	(BME280_PRESS_OVER | \
-					 BME280_TEMP_OVER |  \
-					 BME280_MODE_SLEEP)
+#define BME280_CTRL_MEAS_OFF_VAL (BME280_PRESS_OVER | BME280_TEMP_OVER | BME280_MODE_SLEEP)
 
 /* Convert to Q15.16 */
-#define BME280_TEMP_CONV         100
-#define BME280_TEMP_SHIFT        16
+#define BME280_TEMP_CONV      100
+#define BME280_TEMP_SHIFT     16
 /* Treat UQ24.8 as Q23.8
  * Need to divide by 1000 to convert to kPa
  */
-#define BME280_PRESS_CONV_KPA    1000
-#define BME280_PRESS_SHIFT       23
+#define BME280_PRESS_CONV_KPA 1000
+#define BME280_PRESS_SHIFT    23
 /* Treat UQ22.10 as Q21.10 */
-#define BME280_HUM_SHIFT         21
+#define BME280_HUM_SHIFT      21
 
 struct bme280_reading {
 	/* Compensated values. */
@@ -232,11 +223,9 @@ int bme280_get_decoder(const struct device *dev, const struct sensor_decoder_api
 
 void bme280_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe);
 
-int bme280_sample_fetch(const struct device *dev,
-			       enum sensor_channel chan);
+int bme280_sample_fetch(const struct device *dev, enum sensor_channel chan);
 
-int bme280_sample_fetch_helper(const struct device *dev,
-			       enum sensor_channel chan,
+int bme280_sample_fetch_helper(const struct device *dev, enum sensor_channel chan,
 			       struct bme280_reading *reading);
 
 #endif /* ZEPHYR_DRIVERS_SENSOR_BME280_BME280_H_ */

--- a/drivers/sensor/bosch/bme280/bme280.h
+++ b/drivers/sensor/bosch/bme280/bme280.h
@@ -160,6 +160,17 @@ extern const struct bme280_bus_io bme280_bus_io_i2c;
 					 BME280_TEMP_OVER |  \
 					 BME280_MODE_SLEEP)
 
+/* Convert to Q15.16 */
+#define BME280_TEMP_CONV         100
+#define BME280_TEMP_SHIFT        16
+/* Treat UQ24.8 as Q23.8
+ * Need to divide by 1000 to convert to kPa
+ */
+#define BME280_PRESS_CONV_KPA    1000
+#define BME280_PRESS_SHIFT       23
+/* Treat UQ22.10 as Q21.10 */
+#define BME280_HUM_SHIFT         21
+
 struct bme280_reading {
 	/* Compensated values. */
 	int32_t comp_temp;

--- a/drivers/sensor/bosch/bme280/bme280_decoder.c
+++ b/drivers/sensor/bosch/bme280/bme280_decoder.c
@@ -54,50 +54,8 @@ static int bme280_decoder_get_size_info(struct sensor_chan_spec chan_spec, size_
 	}
 }
 
-#define BME280_HUM_SHIFT (22)
-#define BME280_PRESS_SHIFT (24)
-#define BME280_TEMP_SHIFT (24)
-
-static void bme280_convert_double_to_q31(double reading, int32_t shift, q31_t *out)
-{
-	reading = reading * pow(2, 31 - shift);
-
-	int64_t reading_round = (reading < 0) ? (reading - 0.5) : (reading + 0.5);
-	int32_t reading_q31 = CLAMP(reading_round, INT32_MIN, INT32_MAX);
-
-	if (reading_q31 < 0) {
-		reading_q31 = abs(reading_q31);
-		reading_q31 = ~reading_q31;
-		reading_q31++;
-	}
-
-	*out = reading_q31;
-}
-
-/* Refer to bme280.c bme280_channel_get() */
-static void bme280_convert_signed_temp_raw_to_q31(int32_t reading, q31_t *out)
-{
-	double temp_double = reading / 100.0;
-
-	bme280_convert_double_to_q31(temp_double, BME280_TEMP_SHIFT, out);
-}
-
-static void bme280_convert_unsigned_pressure_raw_to_q31(uint32_t reading, q31_t *out)
-{
-	double press_double = (reading / 256.0) / 1000.0; /* Pa -> hPa */
-
-	bme280_convert_double_to_q31(press_double, BME280_PRESS_SHIFT, out);
-}
-
-static void bme280_convert_unsigned_humidity_raw_to_q31(uint32_t reading, q31_t *out)
-{
-	double hum_double = (reading / 1024.0);
-
-	bme280_convert_double_to_q31(hum_double, BME280_HUM_SHIFT, out);
-}
-
 static int bme280_decoder_decode(const uint8_t *buffer, struct sensor_chan_spec chan_spec,
-				    uint32_t *fit, uint16_t max_count, void *data_out)
+				 uint32_t *fit, uint16_t max_count, void *data_out)
 {
 	const struct bme280_encoded_data *edata = (const struct bme280_encoded_data *)buffer;
 
@@ -113,8 +71,12 @@ static int bme280_decoder_decode(const uint8_t *buffer, struct sensor_chan_spec 
 	switch (chan_spec.chan_type) {
 	case SENSOR_CHAN_AMBIENT_TEMP:
 		if (edata->has_temp) {
-			bme280_convert_signed_temp_raw_to_q31(edata->reading.comp_temp,
-				&out->readings[0].temperature);
+			int32_t readq = edata->reading.comp_temp * pow(2, 31 - BME280_TEMP_SHIFT);
+			int32_t convq = BME280_TEMP_CONV * pow(2, 31 - BME280_TEMP_SHIFT);
+
+			out->readings[0].temperature =
+				(int32_t)((((int64_t)readq) << (31 - BME280_TEMP_SHIFT)) /
+					  ((int64_t)convq));
 			out->shift = BME280_TEMP_SHIFT;
 		} else {
 			return -ENODATA;
@@ -122,8 +84,12 @@ static int bme280_decoder_decode(const uint8_t *buffer, struct sensor_chan_spec 
 		break;
 	case SENSOR_CHAN_PRESS:
 		if (edata->has_press) {
-			bme280_convert_unsigned_pressure_raw_to_q31(edata->reading.comp_press,
-				&out->readings[0].pressure);
+			int32_t readq = edata->reading.comp_press;
+			int32_t convq = BME280_PRESS_CONV_KPA * pow(2, 31 - BME280_PRESS_SHIFT);
+
+			out->readings[0].pressure =
+				(int32_t)((((int64_t)readq) << (31 - BME280_PRESS_SHIFT)) /
+					  ((int64_t)convq));
 			out->shift = BME280_PRESS_SHIFT;
 		} else {
 			return -ENODATA;
@@ -131,8 +97,7 @@ static int bme280_decoder_decode(const uint8_t *buffer, struct sensor_chan_spec 
 		break;
 	case SENSOR_CHAN_HUMIDITY:
 		if (edata->has_humidity) {
-			bme280_convert_unsigned_humidity_raw_to_q31(edata->reading.comp_humidity,
-				&out->readings[0].humidity);
+			out->readings[0].humidity = edata->reading.comp_humidity;
 			out->shift = BME280_HUM_SHIFT;
 		} else {
 			return -ENODATA;
@@ -146,7 +111,6 @@ static int bme280_decoder_decode(const uint8_t *buffer, struct sensor_chan_spec 
 
 	return 1;
 }
-
 
 SENSOR_DECODER_API_DT_DEFINE() = {
 	.get_frame_count = bme280_decoder_get_frame_count,

--- a/drivers/sensor/bosch/bme280/bme280_decoder.c
+++ b/drivers/sensor/bosch/bme280/bme280_decoder.c
@@ -6,9 +6,8 @@
 #include "bme280.h"
 #include <math.h>
 
-static int bme280_decoder_get_frame_count(const uint8_t *buffer,
-					     struct sensor_chan_spec chan_spec,
-					     uint16_t *frame_count)
+static int bme280_decoder_get_frame_count(const uint8_t *buffer, struct sensor_chan_spec chan_spec,
+					  uint16_t *frame_count)
 {
 	const struct bme280_encoded_data *edata = (const struct bme280_encoded_data *)buffer;
 	int32_t ret = -ENOTSUP;
@@ -40,7 +39,7 @@ static int bme280_decoder_get_frame_count(const uint8_t *buffer,
 }
 
 static int bme280_decoder_get_size_info(struct sensor_chan_spec chan_spec, size_t *base_size,
-					   size_t *frame_size)
+					size_t *frame_size)
 {
 	switch (chan_spec.chan_type) {
 	case SENSOR_CHAN_AMBIENT_TEMP:


### PR DESCRIPTION
Fix decoder to use integer math when converting readings to Q31. Clang format files.

Fixes #77295 