### PR TITLE
usb: fix wrong capacity report for USB mass storage device

### DIFF
--- a/subsys/usb/device/class/msc.c
+++ b/subsys/usb/device/class/msc.c
@@ -442,7 +442,7 @@ static bool readFormatCapacity(void)
 
 static bool readCapacity(void)
 {
-	uint8_t capacity[8];
+	static uint8_t capacity[8];
 
 	sys_put_be32(block_count - 1, &capacity[0]);
 	sys_put_be32(BLOCK_SIZE, &capacity[4]);


### PR DESCRIPTION
cherry-picked 32481b64185205222a58acdc6e7272ef2c06869d from https://github.com/zephyrproject-rtos/zephyr/pull/77173
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/77175.