### PR TITLE
add missing C-linkage in headers

### DIFF
--- a/include/zephyr/drivers/gpio/gpio_intel.h
+++ b/include/zephyr/drivers/gpio/gpio_intel.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifndef ZEPHYR_INCLUDE_DRIVERS_GPIO_GPIO_INTEL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_GPIO_GPIO_INTEL_H_
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -21,3 +24,5 @@ struct gpio_acpi_res {
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_GPIO_GPIO_INTEL_H_ */

--- a/include/zephyr/drivers/gpio/gpio_intel.h
+++ b/include/zephyr/drivers/gpio/gpio_intel.h
@@ -4,6 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct gpio_acpi_res {
 	uint8_t num_pins;
 	uint32_t pad_base;
@@ -13,3 +17,7 @@ struct gpio_acpi_res {
 	uint16_t base_num;
 	uintptr_t reg_base;
 };
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/zephyr/drivers/gpio/gpio_mmio32.h
+++ b/include/zephyr/drivers/gpio/gpio_mmio32.h
@@ -11,6 +11,10 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/types.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern const struct gpio_driver_api gpio_mmio32_api;
 
 struct gpio_mmio32_config {
@@ -68,5 +72,8 @@ DEVICE_DT_DEFINE(node_id,								\
 
 #endif
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_GPIO_GPIO_MMIO32_H_ */

--- a/include/zephyr/drivers/gpio/gpio_nct38xx.h
+++ b/include/zephyr/drivers/gpio/gpio_nct38xx.h
@@ -7,11 +7,19 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_GPIO_GPIO_NCT38XX_H_
 #define ZEPHYR_INCLUDE_DRIVERS_GPIO_GPIO_NCT38XX_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief Dispatch all GPIO ports ISR in the NCT38XX device.
  *
  * @param dev NCT38XX device.
  */
 void nct38xx_gpio_alert_handler(const struct device *dev);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_GPIO_GPIO_NCT38XX_H_ */

--- a/include/zephyr/drivers/gpio/gpio_sx1509b.h
+++ b/include/zephyr/drivers/gpio/gpio_sx1509b.h
@@ -10,6 +10,10 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief Configure a pin for LED intensity.
  *
@@ -41,5 +45,9 @@ int sx1509b_led_intensity_pin_configure(const struct device *dev,
  */
 int sx1509b_led_intensity_pin_set(const struct device *dev, gpio_pin_t pin,
 				  uint8_t intensity_val);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_GPIO_GPIO_SX1509B_H_ */

--- a/include/zephyr/drivers/gpio/gpio_utils.h
+++ b/include/zephyr/drivers/gpio/gpio_utils.h
@@ -17,6 +17,10 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/slist.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define GPIO_PORT_PIN_MASK_FROM_NGPIOS(ngpios)			\
 	((gpio_port_pins_t)(((uint64_t)1 << (ngpios)) - 1U))
 
@@ -95,5 +99,9 @@ static inline void gpio_fire_callbacks(sys_slist_t *list,
 		}
 	}
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_GPIO_GPIO_UTILS_H_ */


### PR DESCRIPTION
Add missing extern "C" statements in headers for GPIO drivers. Fixes #77605.