### PR TITLE
STM32 die temperature sensor driver rework

### DIFF
--- a/drivers/sensor/st/stm32_temp/stm32_temp.c
+++ b/drivers/sensor/st/stm32_temp/stm32_temp.c
@@ -315,10 +315,7 @@ static const struct stm32_temp_config stm32_temp_dev_config = {
 	.ts_cal1_addr = (const void *)DT_INST_PROP(0, ts_cal1_addr),
 	.ts_cal1_temp = DT_INST_PROP(0, ts_cal1_temp),
 #if defined(HAS_SINGLE_CALIBRATION)
-	/* DT property is premultiplied by 1000 to cope with Device Tree
-	 * properties being integer-only. Rescale here during compile.
-	 */
-	.average_slope = ((float)DT_INST_PROP(0, avgslope) / 1000.0f),
+	.average_slope = ((float)DT_INST_STRING_UNQUOTED(0, avgslope)),
 #else /* HAS_DUAL_CALIBRATION */
 	.ts_cal2_addr = (const void *)DT_INST_PROP(0, ts_cal2_addr),
 	.ts_cal2_temp = DT_INST_PROP(0, ts_cal2_temp),
@@ -326,10 +323,7 @@ static const struct stm32_temp_config stm32_temp_dev_config = {
 	.calib_data_shift = (DT_INST_PROP(0, ts_cal_resolution) - CAL_RES),
 	.calib_vrefanalog = DT_INST_PROP(0, ts_cal_vrefanalog),
 #else
-	/* DT property is premultiplied by 10 to cope with Device Tree
-	 * properties being integer-only. Rescale here during compile.
-	 */
-	.average_slope = ((float)DT_INST_PROP(0, avgslope) / 10.0f),
+	.average_slope = ((float)DT_INST_STRING_UNQUOTED(0, avgslope)),
 	.v25 = DT_INST_PROP(0, v25),
 #endif
 	.is_ntc = DT_INST_PROP_OR(0, ntc, false)

--- a/dts/arm/st/c0/stm32c0.dtsi
+++ b/dts/arm/st/c0/stm32c0.dtsi
@@ -334,7 +334,7 @@
 		ts-cal1-addr = <0x1FFF7568>;
 		ts-cal1-temp = <30>;
 		ts-cal-vrefanalog = <3000>;
-		avgslope = <2530>;
+		avgslope = "2.53";
 		io-channels = <&adc1 9>;
 		status = "disabled";
 	};

--- a/dts/arm/st/f0/stm32f030.dtsi
+++ b/dts/arm/st/f0/stm32f030.dtsi
@@ -16,7 +16,7 @@
 		ts-cal1-addr = <0x1FFFF7B8>;
 		ts-cal1-temp = <30>;
 		ts-cal-vrefanalog = <3300>;
-		avgslope = <4300>;
+		avgslope = "4.3";
 		io-channels = <&adc1 16>;
 		ntc;
 		status = "disabled";

--- a/dts/arm/st/f0/stm32f030.dtsi
+++ b/dts/arm/st/f0/stm32f030.dtsi
@@ -15,9 +15,10 @@
 		compatible = "st,stm32c0-temp-cal";
 		ts-cal1-addr = <0x1FFFF7B8>;
 		ts-cal1-temp = <30>;
-		ntc;
 		ts-cal-vrefanalog = <3300>;
+		avgslope = <4300>;
 		io-channels = <&adc1 16>;
+		ntc;
 		status = "disabled";
 	};
 };

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -358,7 +358,7 @@
 		compatible = "st,stm32-temp";
 		io-channels = <&adc1 16>;
 		status = "disabled";
-		avgslope = <43>;
+		avgslope = "4.3";
 		v25 = <1430>;
 		ntc;
 	};

--- a/dts/arm/st/f1/stm32f100Xb.dtsi
+++ b/dts/arm/st/f1/stm32f100Xb.dtsi
@@ -52,4 +52,8 @@
 			#io-channel-cells = <1>;
 		};
 	};
+
+	die_temp: dietemp {
+		v25 = <1410>;
+	};
 };

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -708,7 +708,6 @@
 		io-channels = <&adc1 16>;
 		status = "disabled";
 		v25 = <760>;
-		ntc;
 		avgslope = <25>;
 	};
 

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -707,8 +707,8 @@
 		compatible = "st,stm32-temp";
 		io-channels = <&adc1 16>;
 		status = "disabled";
+		avgslope = "2.5";
 		v25 = <760>;
-		avgslope = <25>;
 	};
 
 	otgfs_phy: otgfs_phy {

--- a/dts/bindings/sensor/st,stm32-temp-cal-common.yaml
+++ b/dts/bindings/sensor/st,stm32-temp-cal-common.yaml
@@ -9,29 +9,30 @@ properties:
   ts-cal1-addr:
     type: int
     required: true
-    description: address of parameter TS_CAL1
+    description: Address of TS_CAL1 calibration parameter
 
   ts-cal1-temp:
     type: int
     required: true
-    description: |
-      temperature at which temperature sensor has been
-      calibrated in production for data into ts-cal1-addr
+    description: Temperature at which TS_CAL1 has been measured (TS_CAL2_TEMP)
 
   ts-cal-vrefanalog:
     type: int
     required: true
     description: |
       Analog voltage reference (Vref+) voltage with which
-      temperature sensor has been calibrated in production
+      temperature sensor calibration parameters have been
+      measured
 
   ts-cal-resolution:
     type: int
     description: |
-      Temperature calibration resolution with which the ts-cal1-temp and
-      ts-cal2-temp are measured.
-      For most stm32 series a native 12-bit ADC is embedded in the device,
-      except for H7 on 16-bit and U5 on 14-bit
+      ADC resolution used for measuring calibration data
+
+      This is usually equal to the ADC's native resolution.
+
+      Most series have a 12-bit ADC, but 14-bit and 16-bit
+      also exists on e.g., STM32U5 and STM32H7 (16) series.
     default: 12
     enum:
     - 12

--- a/dts/bindings/sensor/st,stm32-temp-cal.yaml
+++ b/dts/bindings/sensor/st,stm32-temp-cal.yaml
@@ -2,8 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    STM32 family TEMP node for production calibrated sensors like L5/U5
-    with two calibration temperatures.
+    STM32 family TEMP node for production calibrated sensors with two calibration temperatures.
 
 compatible: "st,stm32-temp-cal"
 
@@ -16,11 +15,9 @@ properties:
   ts-cal2-addr:
     type: int
     required: true
-    description: address of parameter TS_CAL2
+    description: Address of TS_CAL2 calibration parameter
 
   ts-cal2-temp:
     type: int
     required: true
-    description: |
-      temperature at which temperature sensor has been
-      calibrated in production for data into ts-cal2-addr
+    description: Temperature at which TS_CAL2 has been measured (TS_CAL2_TEMP)

--- a/dts/bindings/sensor/st,stm32-temp-cal.yaml
+++ b/dts/bindings/sensor/st,stm32-temp-cal.yaml
@@ -9,6 +9,7 @@ compatible: "st,stm32-temp-cal"
 include:
   - name: st,stm32-temp-cal-common.yaml
     property-blocklist:
+      - avgslope
       - ntc
 
 properties:

--- a/dts/bindings/sensor/st,stm32-temp-cal.yaml
+++ b/dts/bindings/sensor/st,stm32-temp-cal.yaml
@@ -7,7 +7,10 @@ description: |
 
 compatible: "st,stm32-temp-cal"
 
-include: "st,stm32-temp-cal-common.yaml"
+include:
+  - name: st,stm32-temp-cal-common.yaml
+    property-blocklist:
+      - ntc
 
 properties:
   ts-cal2-addr:

--- a/dts/bindings/sensor/st,stm32-temp-common.yaml
+++ b/dts/bindings/sensor/st,stm32-temp-common.yaml
@@ -7,3 +7,14 @@ properties:
   io-channels:
     required: true
     description: ADC channel for temperature sensor
+
+  ntc:
+    type: boolean
+    description: |
+      Negative Temperature Coefficient
+
+      Set when the sensor's value is inversely proportional to temperature
+      (i.e., the sensor's value decreases as the temperature increases).
+
+      This is visible in the formula used for temperature calculation, which has the
+      form "Calibration_Value - ADC_Value" rather than "ADC_Value - Calibration_Value".

--- a/dts/bindings/sensor/st,stm32-temp-common.yaml
+++ b/dts/bindings/sensor/st,stm32-temp-common.yaml
@@ -8,6 +8,13 @@ properties:
     required: true
     description: ADC channel for temperature sensor
 
+  avgslope:
+    type: string
+    required: true
+    description: |
+      Average slope of T-V chart (in mV/°C), found in MCU datasheet
+      chapters "Electrical characteristics" or "Operating conditions"
+
   ntc:
     type: boolean
     description: |

--- a/dts/bindings/sensor/st,stm32-temp.yaml
+++ b/dts/bindings/sensor/st,stm32-temp.yaml
@@ -19,7 +19,7 @@ properties:
 
   v25:
     type: int
-    default: 760
+    required: true
     description: |
       Voltage of temperature sensor at 25C in mV according to
       datasheet "Electrical characteristics/Operating conditions"

--- a/dts/bindings/sensor/st,stm32-temp.yaml
+++ b/dts/bindings/sensor/st,stm32-temp.yaml
@@ -12,16 +12,12 @@ properties:
     type: int
     required: true
     description: |
-      Average slope of T-V chart (in mV/C x10) according to
-      datasheet "Electrical characteristics/Operating conditions"
-      STM32F1 Table 5.3.19 (min 4 mV/C, max 4.6, default 4.3)
-      STM32F4 Table 6.3.21 default 2.5
+      Average slope of T-V chart (in mV/°C, x10), found in MCU datasheet
+      chapters "Electrical characteristics" or "Operating conditions"
 
   v25:
     type: int
     required: true
     description: |
-      Voltage of temperature sensor at 25C in mV according to
-      datasheet "Electrical characteristics/Operating conditions"
-      STM32F1 Table 5.3.19 (min 1340, max 1520, default 1430)
-      STM32F4 Table 6.3.21 default 760
+      Voltage of temperature sensor at 25°C (in mV), found in MCU datasheet
+      chapters "Electrical characteristics" or "Operating conditions"

--- a/dts/bindings/sensor/st,stm32-temp.yaml
+++ b/dts/bindings/sensor/st,stm32-temp.yaml
@@ -10,7 +10,7 @@ include: [base.yaml, "st,stm32-temp-common.yaml"]
 properties:
   avgslope:
     type: int
-    default: 25
+    required: true
     description: |
       Average slope of T-V chart (in mV/C x10) according to
       datasheet "Electrical characteristics/Operating conditions"

--- a/dts/bindings/sensor/st,stm32-temp.yaml
+++ b/dts/bindings/sensor/st,stm32-temp.yaml
@@ -25,7 +25,3 @@ properties:
       datasheet "Electrical characteristics/Operating conditions"
       STM32F1 Table 5.3.19 (min 1340, max 1520, default 1430)
       STM32F4 Table 6.3.21 default 760
-
-  ntc:
-    type: boolean
-    description: Negative Temperature Coefficient. True if STM32F1

--- a/dts/bindings/sensor/st,stm32-temp.yaml
+++ b/dts/bindings/sensor/st,stm32-temp.yaml
@@ -8,13 +8,6 @@ compatible: "st,stm32-temp"
 include: [base.yaml, "st,stm32-temp-common.yaml"]
 
 properties:
-  avgslope:
-    type: int
-    required: true
-    description: |
-      Average slope of T-V chart (in mV/°C, x10), found in MCU datasheet
-      chapters "Electrical characteristics" or "Operating conditions"
-
   v25:
     type: int
     required: true

--- a/dts/bindings/sensor/st,stm32c0-temp-cal.yaml
+++ b/dts/bindings/sensor/st,stm32c0-temp-cal.yaml
@@ -7,11 +7,3 @@ description: |
 compatible: "st,stm32c0-temp-cal"
 
 include: "st,stm32-temp-cal-common.yaml"
-
-properties:
-  avgslope:
-    type: int
-    required: true
-    description: |
-      Average slope of T-V chart (in µV/°C), found in MCU datasheet
-      chapters "Electrical characteristics" or "Operating conditions"

--- a/dts/bindings/sensor/st,stm32c0-temp-cal.yaml
+++ b/dts/bindings/sensor/st,stm32c0-temp-cal.yaml
@@ -2,8 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    STM32 family TEMP node for production calibrated sensors like C0
-    with a single calibration temperature.
+    STM32 family TEMP node for production calibrated sensors with a single calibration temperature.
 
 compatible: "st,stm32c0-temp-cal"
 
@@ -14,6 +13,5 @@ properties:
     type: int
     required: true
     description: |
-      Average slope of T-V chart (in uV/C) according to
-      datasheet "Electrical characteristics/Operating conditions"
-      STM32C0 Table 5.3.16 (min 2400 uV/C, max 2650, typ: 2530)
+      Average slope of T-V chart (in µV/°C), found in MCU datasheet
+      chapters "Electrical characteristics" or "Operating conditions"

--- a/dts/bindings/sensor/st,stm32c0-temp-cal.yaml
+++ b/dts/bindings/sensor/st,stm32c0-temp-cal.yaml
@@ -12,7 +12,7 @@ include: "st,stm32-temp-cal-common.yaml"
 properties:
   avgslope:
     type: int
-    default: 2530
+    required: true
     description: |
       Average slope of T-V chart (in uV/C) according to
       datasheet "Electrical characteristics/Operating conditions"

--- a/dts/bindings/sensor/st,stm32c0-temp-cal.yaml
+++ b/dts/bindings/sensor/st,stm32c0-temp-cal.yaml
@@ -17,7 +17,3 @@ properties:
       Average slope of T-V chart (in uV/C) according to
       datasheet "Electrical characteristics/Operating conditions"
       STM32C0 Table 5.3.16 (min 2400 uV/C, max 2650, typ: 2530)
-
-  ntc:
-    type: boolean
-    description: Negative Temperature Coefficient. True if STM32F0x0


### PR DESCRIPTION
This PR is a rework of the STM32 die temperature sensor driver.

The main reason for this PR is the upcoming introduction of STM32WB0 series, which has a few differences from other series (calibration data is 32-bit, formula is different, sensor is always enabled) - with this reworked driver, the main differences are factored out, so the series can be easily integrated.

While at it, the driver and bindings have been heavily documented, and modified to follow the Reference Manuals more closely.

This PR also fixes errors in certain SoCs' DTSI (STM32030/STM32070 and STM32100 lines, STM32F2 series) and a few MISRA Rule 20.9 violations (using `#if xxx` on potentially undefined macros, instead of `#if defined(xxx)`).