### PR TITLE
stm32wba: Update of `west blobs fetch` command due to field `name` definition in hal_stm32 module.yml

### DIFF
--- a/boards/st/nucleo_wba55cg/doc/nucleo_wba55cg.rst
+++ b/boards/st/nucleo_wba55cg/doc/nucleo_wba55cg.rst
@@ -196,7 +196,7 @@ To fetch Binary Blobs:
 
 .. code-block:: console
 
-   west blobs fetch stm32
+   west blobs fetch hal_stm32
 
 Connections and IOs
 ===================

--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -27,6 +27,9 @@ Boards
 * :ref:`native_posix<native_posix>` has been deprecated in favour of
   :ref:`native_sim<native_sim>` (:github:`76898`).
 
+* STM32WBA: The command used for fetching blobs required to build ble applications is now
+  `west blobs fetch hal_stm32` instead of `west blobs fetch stm32`.
+
 Modules
 *******
 

--- a/west.yml
+++ b/west.yml
@@ -233,7 +233,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 484af4f994737bef9e6ccc3e267cc319b85da332
+      revision: 4c1adf8a2e2e9888f3b43374bf6521b0788aa82d
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
stm32wba: Update of west blobs fetch command due to field name definition in hal_stm32 module.yml