### PR TITLE
samples: llext: disable memory protection

### DIFF
--- a/samples/subsys/llext/modules/prj.conf
+++ b/samples/subsys/llext/modules/prj.conf
@@ -17,3 +17,6 @@ CONFIG_LLEXT_TYPE_ELF_RELOCATABLE=y
 # Increase the available size to avoid overflowing (see issue #74536).
 
 CONFIG_MAIN_STACK_SIZE=2048
+
+# Memory protection should be disable for this sample to work
+CONFIG_ARM_MPU=n


### PR DESCRIPTION
Hi,

As stated in the llext shell sample documentation and configured in samples test suites,  memory protection should be disabled for llext samples to work in most cases.

If disabling each MPU support (xtensa, riscv, arm, arc) in these samples config files is too specific, maybe someone has an idea of a better solution ? 

Thanks

Refs: #77515 #72957