### PR TITLE
boards: nxp: frdm_mcxn947: fix sysbuild mcuboot

### DIFF
--- a/boards/nxp/frdm_mcxn947/Kconfig.sysbuild
+++ b/boards/nxp/frdm_mcxn947/Kconfig.sysbuild
@@ -1,0 +1,6 @@
+# Copyright 2024 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+choice MCUBOOT_MODE
+	default MCUBOOT_MODE_OVERWRITE_ONLY
+endchoice


### PR DESCRIPTION
Adds the default MCUboot operating mode when building using sysbuild.
Fix mcuboot sysbuild for frdm_mcxn947.