### PR TITLE
ci: rerun issue check on PR edit

### DIFF
--- a/.github/workflows/backport_issue_check.yml
+++ b/.github/workflows/backport_issue_check.yml
@@ -2,12 +2,20 @@ name: Backport Issue Check
 
 on:
   pull_request_target:
+    types:
+      - edited
+      - opened
+      - reopened
+      - synchronize
     branches:
       - v*-branch
 
 jobs:
   backport:
     name: Backport Issue Check
+    concurrency:
+      group: backport-issue-check-${{ github.ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-22.04
     if: github.repository == 'zephyrproject-rtos/zephyr'
 

--- a/scripts/ci/twister_ignore.txt
+++ b/scripts/ci/twister_ignore.txt
@@ -23,6 +23,7 @@
 .github/workflows/stale-workflow-queue-cleanup.yml
 .github/workflows/greet_first_time_contributor.yml
 .github/workflows/issues-report-config.json
+.github/workflows/backport_issue_check.yml
 CODEOWNERS
 MAINTAINERS.yml
 LICENSE


### PR DESCRIPTION
Re-run issue check when a PR is updated, i.e. when someone adds
'Fixes...` to the PR body.

This is mostly for release branches and has no effect on main branch.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
