### PR TITLE
samples: drivers: Enable SPI MEMORY driver samples for nrfl54l15

### DIFF
--- a/samples/drivers/jesd216/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
+++ b/samples/drivers/jesd216/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&mx25r64 {
+	status = "okay";
+};

--- a/samples/drivers/spi_flash/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
+++ b/samples/drivers/spi_flash/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&mx25r64 {
+	status = "okay";
+};


### PR DESCRIPTION
Cover more SPI flash memeory driver api methods
Extend testing for nrf54l15