### PR TITLE
tests: kernel.common.stack_sentinel: exclude `m2gl025_miv`

### DIFF
--- a/tests/kernel/fatal/exception/testcase.yaml
+++ b/tests/kernel/fatal/exception/testcase.yaml
@@ -46,6 +46,7 @@ tests:
     platform_exclude:
       - qemu_cortex_a9 # FIXME: See issue #39948
       - hifive1        # FIXME: See issue #66070
+      - m2gl025_miv    # FIXME: See issue #66070
     tags: kernel
     integration_platforms:
       - qemu_x86


### PR DESCRIPTION
This PR excludes the `m2gl025_miv` platform from running the `kernel.common.stack_sentinel` test. It experiences the same issue as `hifive1`, which was described in issue #66070.

Both of these platforms can be removed from the `platform_exclude` list once `ci:v0.26.14` is used in Twister workflows.