### PR TITLE
tests: Bluetooth: BAP: Add retry with correct broadcast code

### DIFF
--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
@@ -1054,6 +1054,18 @@ static void test_sink_encrypted_incorrect_code(void)
 	/* Wait for MIC failure */
 	WAIT_FOR_FLAG(flag_big_sync_mic_failure);
 
+	test_broadcast_sync(BROADCAST_CODE);
+
+	/* Wait for all to be started */
+	printk("Waiting for streams to be started\n");
+	for (size_t i = 0U; i < ARRAY_SIZE(streams); i++) {
+		k_sem_take(&sem_started, K_FOREVER);
+	}
+
+	printk("Waiting for data\n");
+	WAIT_FOR_FLAG(flag_audio_received);
+	printk("Data received\n");
+
 	backchannel_sync_send_all(); /* let other devices know we have received data */
 	backchannel_sync_send_all(); /* let the broadcast source know it can stop */
 


### PR DESCRIPTION
Expand test_sink_encrypted_incorrect_code to retry the sync with the correct broadcast code after failing the initial sync with the incorrect broadcast code.