### PR TITLE
drivers: dac: esp32: clock initialization fix

### DIFF
--- a/drivers/dac/dac_esp32.c
+++ b/drivers/dac/dac_esp32.c
@@ -63,8 +63,7 @@ static int dac_esp32_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	if (clock_control_on(cfg->clock_dev,
-		(clock_control_subsys_t) &cfg->clock_subsys) != 0) {
+	if (clock_control_on(cfg->clock_dev, (clock_control_subsys_t)cfg->clock_subsys) != 0) {
 		LOG_ERR("DAC clock setup failed (%d)", -EIO);
 		return -EIO;
 	}


### PR DESCRIPTION
Fixed ESP32 DAC clock initialization

Fixes: #70295