### PR TITLE
[DNM][RFC] irq: introduce new `irq_set_affinity()` API

### DIFF
--- a/arch/arc/core/irq_manage.c
+++ b/arch/arc/core/irq_manage.c
@@ -184,6 +184,12 @@ int arch_irq_is_enabled(unsigned int irq)
 		return z_arc_v2_irq_unit_int_enabled(irq);
 	}
 }
+
+void arch_irq_set_affinity(unsigned int irq, unsigned int mask)
+{
+	ARG_UNUSED(irq);
+	ARG_UNUSED(mask);
+}
 #else
 void arch_irq_enable(unsigned int irq)
 {
@@ -198,6 +204,12 @@ void arch_irq_disable(unsigned int irq)
 int arch_irq_is_enabled(unsigned int irq)
 {
 	return z_arc_v2_irq_unit_int_enabled(irq);
+}
+
+void arch_irq_set_affinity(unsigned int irq, unsigned int mask)
+{
+	ARG_UNUSED(irq);
+	ARG_UNUSED(mask);
 }
 #endif /* CONFIG_ARC_CONNECT */
 

--- a/arch/arm/core/cortex_a_r/irq_manage.c
+++ b/arch/arm/core/cortex_a_r/irq_manage.c
@@ -55,6 +55,12 @@ int arch_irq_is_enabled(unsigned int irq)
 	return arm_gic_irq_is_enabled(irq);
 }
 
+void arch_irq_set_affinity(unsigned int irq, unsigned int mask)
+{
+	ARG_UNUSED(irq);
+	ARG_UNUSED(mask);
+}
+
 /**
  * @internal
  *

--- a/arch/arm/core/cortex_m/irq_manage.c
+++ b/arch/arm/core/cortex_m/irq_manage.c
@@ -49,6 +49,12 @@ int arch_irq_is_enabled(unsigned int irq)
 	return NVIC->ISER[REG_FROM_IRQ(irq)] & BIT(BIT_FROM_IRQ(irq));
 }
 
+void arch_irq_set_affinity(unsigned int irq, unsigned int mask)
+{
+	ARG_UNUSED(irq);
+	ARG_UNUSED(mask);
+}
+
 /**
  * @internal
  *

--- a/arch/arm64/core/irq_manage.c
+++ b/arch/arm64/core/irq_manage.c
@@ -47,6 +47,12 @@ int arch_irq_is_enabled(unsigned int irq)
 	return arm_gic_irq_is_enabled(irq);
 }
 
+void arch_irq_set_affinity(unsigned int irq, unsigned int mask)
+{
+	ARG_UNUSED(irq);
+	ARG_UNUSED(mask);
+}
+
 void z_arm64_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
 {
 	arm_gic_irq_set_priority(irq, prio, flags);

--- a/arch/mips/core/irq_manage.c
+++ b/arch/mips/core/irq_manage.c
@@ -60,6 +60,12 @@ int arch_irq_is_enabled(unsigned int irq)
 	return read_c0_status() & (ST0_IP0 << irq);
 }
 
+void arch_irq_set_affinity(unsigned int irq, unsigned int mask)
+{
+	ARG_UNUSED(irq);
+	ARG_UNUSED(mask);
+}
+
 void z_mips_enter_irq(uint32_t ipending)
 {
 	_current_cpu->nested++;

--- a/arch/nios2/core/irq_manage.c
+++ b/arch/nios2/core/irq_manage.c
@@ -69,6 +69,12 @@ int arch_irq_is_enabled(unsigned int irq)
 	return ienable & BIT(irq);
 }
 
+void arch_irq_set_affinity(unsigned int irq, unsigned int mask)
+{
+	ARG_UNUSED(irq);
+	ARG_UNUSED(mask);
+}
+
 /**
  * @brief Interrupt demux function
  *

--- a/arch/posix/core/irq.c
+++ b/arch/posix/core/irq.c
@@ -31,6 +31,12 @@ int arch_irq_is_enabled(unsigned int irq)
 	return posix_irq_is_enabled(irq);
 }
 
+void arch_irq_set_affinity(unsigned int irq, unsigned int mask)
+{
+	ARG_UNUSED(irq);
+	ARG_UNUSED(mask);
+}
+
 #ifdef CONFIG_DYNAMIC_INTERRUPTS
 /**
  * Configure a dynamic interrupt.

--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -165,6 +165,12 @@ config RISCV_HAS_PLIC
 	help
 	  Does the SOC provide support for a Platform Level Interrupt Controller (PLIC).
 
+config RISCV_PLIC_HAS_IRQ_AFFINITY
+	bool
+	depends on RISCV_HAS_PLIC
+	help
+	  Does the PLIC driver support IRQ affinity.
+
 config RISCV_HAS_CLIC
 	bool
 	depends on RISCV_PRIVILEGED

--- a/arch/riscv/core/smp.c
+++ b/arch/riscv/core/smp.c
@@ -74,7 +74,11 @@ void arch_secondary_cpu_init(int hartid)
 #endif
 #ifdef CONFIG_SMP
 	irq_enable(RISCV_IRQ_MSOFT);
-#endif
+#ifdef CONFIG_RISCV_PLIC_HAS_IRQ_AFFINITY
+	/* Enable on secondary cores so that they can respond to PLIC */
+	irq_enable(RISCV_IRQ_MEXT);
+#endif /* CONFIG_RISCV_PLIC_HAS_IRQ_AFFINITY */
+#endif /* CONFIG_SMP */
 	riscv_cpu_init[cpu_num].fn(riscv_cpu_init[cpu_num].arg);
 }
 

--- a/drivers/interrupt_controller/Kconfig.plic
+++ b/drivers/interrupt_controller/Kconfig.plic
@@ -13,11 +13,45 @@ config PLIC
 
 if PLIC
 
+config PLIC_IRQ_AFFINITY
+	bool "PLIC IRQ affinity"
+	default y
+	depends on SMP
+	depends on MP_MAX_NUM_CPUS > 1
+	select RISCV_PLIC_HAS_IRQ_AFFINITY
+	help
+	  Enable IRQ affinity.
+
+config PLIC_IRQ_AFFINITY_MASK
+	hex "IRQ affinity mask"
+	depends on PLIC_IRQ_AFFINITY
+	default 0x1
+	help
+	  IRQ affinity mask.
+
 config PLIC_SHELL
 	bool "PLIC shell commands"
 	depends on SHELL
 	help
 	  Enable additional shell commands useful for debugging.
 	  Caution: This can use quite a bit of RAM (PLICs * IRQs * sizeof(uint16_t)).
+
+if PLIC_SHELL
+
+config PLIC_SHELL_IRQ_COUNT
+	bool "IRQ count shell commands"
+	default y
+	help
+	  Records the number of hits per interrupt line and provide shell commands to access them.
+	  Caution: This can use quite a bit of RAM (PLICs * IRQs * sizeof(PLIC_IRQ_COUNT_TYPE)).
+
+config PLIC_SHELL_IRQ_AFFINITY
+	bool "Shell commands to configure IRQ affinity"
+	default y
+	depends on PLIC_IRQ_AFFINITY
+	help
+	  Provide shell commands to configure IRQ affinity in runtime.
+
+endif # PLIC_SHELL
 
 endif # PLIC

--- a/drivers/interrupt_controller/intc_plic.c
+++ b/drivers/interrupt_controller/intc_plic.c
@@ -214,15 +214,11 @@ static void plic_irq_enable_set_state(uint32_t irq, bool enable)
 	for (uint32_t cpu_num = 0; cpu_num < arch_num_cpus(); cpu_num++) {
 		mem_addr_t en_addr =
 			get_context_en_addr(dev, cpu_num) + local_irq_to_reg_offset(local_irq);
-
 		uint32_t en_value;
-		uint32_t key;
 
-		key = irq_lock();
 		en_value = sys_read32(en_addr);
 		WRITE_BIT(en_value, local_irq & PLIC_REG_MASK, enable);
 		sys_write32(en_value, en_addr);
-		irq_unlock(key);
 	}
 }
 
@@ -238,7 +234,11 @@ static void plic_irq_enable_set_state(uint32_t irq, bool enable)
  */
 void riscv_plic_irq_enable(uint32_t irq)
 {
+	uint32_t key = irq_lock();
+
 	plic_irq_enable_set_state(irq, true);
+
+	irq_unlock(key);
 }
 
 /**
@@ -253,7 +253,11 @@ void riscv_plic_irq_enable(uint32_t irq)
  */
 void riscv_plic_irq_disable(uint32_t irq)
 {
+	uint32_t key = irq_lock();
+
 	plic_irq_enable_set_state(irq, false);
+
+	irq_unlock(key);
 }
 
 /**

--- a/drivers/interrupt_controller/intc_plic.c
+++ b/drivers/interrupt_controller/intc_plic.c
@@ -68,6 +68,18 @@
 #define INTC_PLIC_STATIC static inline
 #endif
 
+#ifdef CONFIG_PLIC_IRQ_AFFINITY
+#if CONFIG_MP_MAX_NUM_CPUS <= 8
+typedef uint8_t plic_cpumask_t;
+#elif CONFIG_MP_MAX_NUM_CPUS <= 16
+typedef uint16_t plic_cpumask_t;
+#elif CONFIG_MP_MAX_NUM_CPUS <= 32
+typedef uint32_t plic_cpumask_t;
+#else
+#error "Currently only supports up to 32 cores"
+#endif /* CONFIG_MP_MAX_NUM_CPUS */
+#endif /* CONFIG_PLIC_IRQ_AFFINITY */
+
 typedef void (*riscv_plic_irq_config_func_t)(void);
 struct plic_config {
 	mem_addr_t prio;
@@ -75,9 +87,14 @@ struct plic_config {
 	mem_addr_t reg;
 	mem_addr_t trig;
 	uint32_t max_prio;
-	uint32_t num_irqs;
+	/* Number of IRQs that the PLIC physically supports */
+	uint32_t riscv_ndev;
+	/* Number of IRQs supported in this driver */
+	uint32_t nr_irqs;
+	uint32_t irq;
 	riscv_plic_irq_config_func_t irq_config_func;
 	struct _isr_table_entry *isr_table;
+	const int *const hart_context;
 };
 
 struct plic_stats {
@@ -87,10 +104,13 @@ struct plic_stats {
 
 struct plic_data {
 	struct plic_stats stats;
+#ifdef CONFIG_PLIC_IRQ_AFFINITY
+	plic_cpumask_t *irq_cpumask;
+#endif /* CONFIG_PLIC_IRQ_AFFINITY */
 };
 
-static uint32_t save_irq;
-static const struct device *save_dev;
+static uint32_t save_irq[CONFIG_MP_MAX_NUM_CPUS];
+static const struct device *save_dev[CONFIG_MP_MAX_NUM_CPUS];
 
 INTC_PLIC_STATIC uint32_t local_irq_to_reg_index(uint32_t local_irq)
 {
@@ -106,48 +126,55 @@ static inline uint32_t get_plic_enabled_size(const struct device *dev)
 {
 	const struct plic_config *config = dev->config;
 
-	return local_irq_to_reg_index(config->num_irqs) + 1;
+	return local_irq_to_reg_index(config->nr_irqs) + 1;
 }
 
-static inline uint32_t get_first_context(uint32_t hartid)
+static ALWAYS_INLINE uint32_t get_hart_context(const struct device *dev, uint32_t hartid)
 {
-	return hartid == 0 ? 0 : (hartid * 2) - 1;
+#ifdef CONFIG_PLIC_IRQ_AFFINITY
+	const struct plic_config *config = dev->config;
+
+	return config->hart_context[hartid];
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(hartid);
+
+	return 0;
+#endif /* CONFIG_PLIC_IRQ_AFFINITY */
+}
+
+static ALWAYS_INLINE uint32_t get_irq_cpumask(const struct device *dev, uint32_t local_irq)
+{
+#ifdef CONFIG_PLIC_IRQ_AFFINITY
+	const struct plic_data *data = dev->data;
+
+	return data->irq_cpumask[local_irq];
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(local_irq);
+
+	return 0x1;
+#endif /* CONFIG_PLIC_IRQ_AFFINITY */
 }
 
 static inline mem_addr_t get_context_en_addr(const struct device *dev, uint32_t cpu_num)
 {
 	const struct plic_config *config = dev->config;
 	uint32_t hartid;
-	/*
-	 * We want to return the irq_en address for the context of given hart.
-	 * If hartid is 0, we return the devices irq_en property, job done. If it is
-	 * greater than zero, we assume that there are two context's associated with
-	 * each hart: M mode enable, followed by S mode enable. We return the M mode
-	 * enable address.
-	 */
+
 #if CONFIG_SMP
 	hartid = _kernel.cpus[cpu_num].arch.hartid;
 #else
 	hartid = arch_proc_id();
 #endif
-	return  config->irq_en + get_first_context(hartid) * CONTEXT_ENABLE_SIZE;
+	return config->irq_en + get_hart_context(dev, hartid) * CONTEXT_ENABLE_SIZE;
 }
 
 static inline mem_addr_t get_claim_complete_addr(const struct device *dev)
 {
 	const struct plic_config *config = dev->config;
 
-	/*
-	 * We want to return the claim complete addr for the hart's context.
-	 * We are making a few assumptions here:
-	 * 1. for hart 0, return the first context claim complete.
-	 * 2. for any other hart, we assume they have two privileged mode contexts
-	 * which are contiguous, where the m mode context is first.
-	 * We return the m mode context.
-	 */
-
-	return config->reg + get_first_context(arch_proc_id()) * CONTEXT_SIZE +
-	       CONTEXT_CLAIM;
+	return config->reg + get_hart_context(dev, arch_proc_id()) * CONTEXT_SIZE + CONTEXT_CLAIM;
 }
 
 
@@ -162,7 +189,14 @@ static inline mem_addr_t get_threshold_priority_addr(const struct device *dev, u
 	hartid = arch_proc_id();
 #endif
 
-	return config->reg + (get_first_context(hartid) * CONTEXT_SIZE);
+	return config->reg + (get_hart_context(dev, hartid) * CONTEXT_SIZE);
+}
+
+static ALWAYS_INLINE uint32_t local_irq_to_irq(const struct device *dev, uint32_t local_irq)
+{
+	const struct plic_config *config = dev->config;
+
+	return irq_to_level_2(local_irq) | config->irq;
 }
 
 /**
@@ -217,7 +251,8 @@ static void plic_irq_enable_set_state(uint32_t irq, bool enable)
 		uint32_t en_value;
 
 		en_value = sys_read32(en_addr);
-		WRITE_BIT(en_value, local_irq & PLIC_REG_MASK, enable);
+		WRITE_BIT(en_value, local_irq & PLIC_REG_MASK,
+			  enable ? (get_irq_cpumask(dev, local_irq) & BIT(cpu_num)) != 0 : false);
 		sys_write32(en_value, en_addr);
 	}
 }
@@ -271,15 +306,27 @@ void riscv_plic_irq_disable(uint32_t irq)
 int riscv_plic_irq_is_enabled(uint32_t irq)
 {
 	const struct device *dev = get_plic_dev_from_irq(irq);
-	const struct plic_config *config = dev->config;
 	const uint32_t local_irq = irq_from_level_2(irq);
-	mem_addr_t en_addr = config->irq_en + local_irq_to_reg_offset(local_irq);
+	uint32_t bit_position = local_irq & PLIC_REG_MASK;
 	uint32_t en_value;
+	int is_enabled = IS_ENABLED(CONFIG_PLIC_IRQ_AFFINITY) ? 0 : 1;
+	uint32_t key = irq_lock();
 
-	en_value = sys_read32(en_addr);
-	en_value &= BIT(local_irq & PLIC_REG_MASK);
+	for (uint32_t cpu_num = 0; cpu_num < arch_num_cpus(); cpu_num++) {
+		mem_addr_t en_addr =
+			get_context_en_addr(dev, cpu_num) + local_irq_to_reg_offset(local_irq);
 
-	return !!en_value;
+		en_value = sys_read32(en_addr);
+		if (IS_ENABLED(CONFIG_PLIC_IRQ_AFFINITY)) {
+			is_enabled |= !!(en_value & BIT(bit_position));
+		} else {
+			is_enabled &= !!(en_value & BIT(bit_position));
+		}
+	}
+
+	irq_unlock(key);
+
+	return is_enabled;
 }
 
 /**
@@ -318,12 +365,54 @@ void riscv_plic_set_priority(uint32_t irq, uint32_t priority)
  */
 unsigned int riscv_plic_get_irq(void)
 {
-	return save_irq;
+	return save_irq[arch_proc_id()];
 }
 
+/**
+ * @brief Get riscv PLIC causing an interrupt
+ *
+ * This routine returns the RISCV PLIC device causing an interrupt.
+ *
+ * @return PLIC device causing an interrupt.
+ */
 const struct device *riscv_plic_get_dev(void)
 {
-	return save_dev;
+	return save_dev[arch_proc_id()];
+}
+
+/**
+ *
+ * @brief Set riscv PLIC-specific interrupt enable by cpu bitmask
+ *
+ * @param irq IRQ number for which to set smp irq affinity
+ * @param mask Bitmask to specific which cores can handle IRQ
+ */
+void riscv_plic_irq_set_affinity(uint32_t irq, uint32_t mask)
+{
+#ifdef CONFIG_PLIC_IRQ_AFFINITY
+	const struct device *dev = get_plic_dev_from_irq(irq);
+	const struct plic_data *data = dev->data;
+	__maybe_unused const struct plic_config *config = dev->config;
+	const uint32_t local_irq = irq_from_level_2(irq);
+
+	__ASSERT(local_irq < config->nr_irqs, "overflow: irq %d, local_irq %d", irq, local_irq);
+	__ASSERT((mask & ~BIT_MASK(arch_num_cpus())) == 0, "cpumask: 0x%X", mask);
+
+	uint32_t key = irq_lock();
+
+	/* Updated irq_cpumask for next time setting plic enable register */
+	data->irq_cpumask[local_irq] = (plic_cpumask_t)mask;
+
+	/* If irq is enabled, apply the new irq affinity */
+	if (riscv_plic_irq_is_enabled(irq)) {
+		riscv_plic_irq_enable(irq);
+	}
+
+	irq_unlock(key);
+#else
+	ARG_UNUSED(irq);
+	ARG_UNUSED(mask);
+#endif /* CONFIG_PLIC_IRQ_AFFINITY */
 }
 
 static void plic_irq_handler(const struct device *dev)
@@ -332,19 +421,40 @@ static void plic_irq_handler(const struct device *dev)
 	mem_addr_t claim_complete_addr = get_claim_complete_addr(dev);
 	struct _isr_table_entry *ite;
 	uint32_t __maybe_unused trig_val;
-
+	uint32_t cpu_id = arch_proc_id();
 	/* Get the IRQ number generating the interrupt */
 	const uint32_t local_irq = sys_read32(claim_complete_addr);
 
-#ifdef CONFIG_PLIC_SHELL
+#ifdef CONFIG_PLIC_SHELL_IRQ_COUNT
 	const struct plic_data *data = dev->data;
 	struct plic_stats stat = data->stats;
+	uint32_t irq_index = cpu_id * config->nr_irqs + local_irq;
+#if CONFIG_MP_NUM_CPUS > 1
+	uint32_t irq_total = arch_num_cpus() * config->nr_irqs + local_irq;
+#else
+	uint32_t irq_total = irq_index;
+#endif /* CONFIG_MP_NUM_CPUS > 1 */
 
 	/* Cap the count at __UINT16_MAX__ */
-	if (stat.irq_count[local_irq] != __UINT16_MAX__) {
-		stat.irq_count[local_irq]++;
+	if (stat.irq_count[irq_total] < __UINT16_MAX__) {
+		stat.irq_count[irq_index]++;
+		if (CONFIG_MP_NUM_CPUS > 1) {
+			stat.irq_count[irq_total]++;
+		}
 	}
-#endif /* CONFIG_PLIC_SHELL */
+#endif /* CONFIG_PLIC_SHELL_IRQ_COUNT */
+
+	/*
+	 * Note: Because PLIC only supports multicast of interrupt, all enabled
+	 * targets will receive interrupt notification. Only the fastest target
+	 * will claim this interrupt, and other targets will claim ID 0 if
+	 * no other pending interrupt now.
+	 *
+	 * (by RISC-V Privileged Architecture v1.10)
+	 */
+	if (IS_ENABLED(CONFIG_SMP) && (local_irq == 0U)) {
+		return;
+	}
 
 	/*
 	 * Save IRQ in save_irq. To be used, if need be, by
@@ -352,14 +462,14 @@ static void plic_irq_handler(const struct device *dev)
 	 * as IRQ number held by the claim_complete register is
 	 * cleared upon read.
 	 */
-	save_irq = local_irq;
-	save_dev = dev;
+	save_irq[cpu_id] = local_irq;
+	save_dev[cpu_id] = dev;
 
 	/*
 	 * If the IRQ is out of range, call z_irq_spurious.
 	 * A call to z_irq_spurious will not return.
 	 */
-	if (local_irq == 0U || local_irq >= config->num_irqs) {
+	if ((local_irq == 0U) || (local_irq >= config->nr_irqs)) {
 		z_irq_spurious(NULL);
 	}
 
@@ -421,7 +531,7 @@ static int plic_init(const struct device *dev)
 	}
 
 	/* Set priority of each interrupt line to 0 initially */
-	for (uint32_t i = 0; i < config->num_irqs; i++) {
+	for (uint32_t i = 0; i < config->nr_irqs; i++) {
 		sys_write32(0U, prio_addr + (i * sizeof(uint32_t)));
 	}
 
@@ -446,7 +556,8 @@ static inline int parse_device(const struct shell *sh, size_t argc, char *argv[]
 	return 0;
 }
 
-static int cmd_get_stats(const struct shell *sh, size_t argc, char *argv[])
+#ifdef CONFIG_PLIC_SHELL_IRQ_COUNT
+static int cmd_stats_get(const struct shell *sh, size_t argc, char *argv[])
 {
 	const struct device *dev;
 	int ret = parse_device(sh, argc, argv, &dev);
@@ -461,31 +572,57 @@ static int cmd_get_stats(const struct shell *sh, size_t argc, char *argv[])
 	struct plic_stats stat = data->stats;
 
 	if (argc > 2) {
-		min_hit = (uint16_t)atoi(argv[2]);
+		min_hit = (uint16_t)shell_strtoul(argv[2], 10, &ret);
+		if (ret != 0) {
+			shell_error(sh, "Failed to parse %s: %d", argv[2], ret);
+			return ret;
+		}
 		shell_print(sh, "IRQ line with > %d hits:", min_hit);
 	}
 
-	shell_print(sh, "   IRQ        Hits\tISR(ARG)");
-	for (int i = 0; i < stat.irq_count_len; i++) {
-		if (stat.irq_count[i] > min_hit) {
-#ifdef CONFIG_SYMTAB
-			const char *name =
-				symtab_find_symbol_name((uintptr_t)config->isr_table[i].isr, NULL);
+	shell_fprintf(sh, SHELL_NORMAL, "   IRQ");
+	for (int cpu_id = 0; cpu_id < arch_num_cpus(); cpu_id++) {
+		shell_fprintf(sh, SHELL_NORMAL, "  CPU%2d", cpu_id);
+	}
+	if (CONFIG_MP_NUM_CPUS > 1) {
+		shell_fprintf(sh, SHELL_NORMAL, "  Total");
+	}
+	shell_fprintf(sh, SHELL_NORMAL, "\tISR(ARG)\n");
 
-			shell_print(sh, "  %4d  %10d\t%s(%p)", i, stat.irq_count[i], name,
-				    config->isr_table[i].arg);
-#else
-			shell_print(sh, "  %4d  %10d\t%p(%p)", i, stat.irq_count[i],
-				    (void *)config->isr_table[i].isr, config->isr_table[i].arg);
-#endif /* CONFIG_SYMTAB */
+	for (int i = 0; i < config->nr_irqs; i++) {
+		int offset = (CONFIG_MP_NUM_CPUS > 1) ? arch_num_cpus() * config->nr_irqs : 0;
+		uint16_t total_hits = stat.irq_count[offset + i];
+
+		if (total_hits <= min_hit) {
+			continue;
 		}
+
+		shell_fprintf(sh, SHELL_NORMAL, "  %4d", i); /* IRQ number */
+		for (int cpu_id = 0; cpu_id < arch_num_cpus(); cpu_id++) {
+			uint32_t irq_index = cpu_id * config->nr_irqs + i;
+
+			shell_fprintf(sh, SHELL_NORMAL, "  %5d", stat.irq_count[irq_index]);
+		}
+		if (CONFIG_MP_NUM_CPUS > 1) {
+			shell_fprintf(sh, SHELL_NORMAL, "  %5d",
+				      stat.irq_count[arch_num_cpus() * config->nr_irqs + i]);
+		}
+#ifdef CONFIG_SYMTAB
+		const char *name =
+			symtab_find_symbol_name((uintptr_t)config->isr_table[i].isr, NULL);
+
+		shell_fprintf(sh, SHELL_NORMAL, "\t%s(%p)\n", name, config->isr_table[i].arg);
+#else
+		shell_fprintf(sh, SHELL_NORMAL, "\t%p(%p)\n", (void *)config->isr_table[i].isr,
+			      config->isr_table[i].arg);
+#endif /* CONFIG_SYMTAB */
 	}
 	shell_print(sh, "");
 
 	return 0;
 }
 
-static int cmd_clear_stats(const struct shell *sh, size_t argc, char *argv[])
+static int cmd_stats_clear(const struct shell *sh, size_t argc, char *argv[])
 {
 	const struct device *dev;
 	int ret = parse_device(sh, argc, argv, &dev);
@@ -495,19 +632,112 @@ static int cmd_clear_stats(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	const struct plic_data *data = dev->data;
+	const struct plic_config *config = dev->config;
 	struct plic_stats stat = data->stats;
 
-	memset(stat.irq_count, 0, stat.irq_count_len * sizeof(uint16_t));
+	memset(stat.irq_count, 0,
+	       config->nr_irqs *
+		       COND_CODE_1(CONFIG_MP_MAX_NUM_CPUS, (1),
+				   (UTIL_INC(CONFIG_MP_MAX_NUM_CPUS))) *
+		       sizeof(uint16_t));
 
 	shell_print(sh, "Cleared stats of %s.\n", dev->name);
 
 	return 0;
 }
+#endif /* CONFIG_PLIC_SHELL_IRQ_COUNT */
+
+#ifdef CONFIG_PLIC_SHELL_IRQ_AFFINITY
+static int cmd_affinity_set(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+
+	uint32_t local_irq, irq, mask;
+	const struct device *dev;
+	int rc = parse_device(sh, argc, argv, &dev);
+	const struct plic_config *config = dev->config;
+
+	if (rc != 0) {
+		return rc;
+	}
+
+	local_irq = (uint32_t)shell_strtol(argv[2], 10, &rc);
+	if (rc != 0) {
+		shell_error(sh, "Failed to parse %s: %d", argv[2], rc);
+	}
+
+	if (local_irq >= config->nr_irqs) {
+		shell_error(sh, "local_irq (%d) > nr_irqs (%d)", local_irq, config->nr_irqs);
+		return -EINVAL;
+	}
+
+	mask = (uint32_t)shell_strtol(argv[3], 16, &rc);
+	if (rc != 0) {
+		shell_error(sh, "Failed to parse %s: %d", argv[3], rc);
+	}
+
+	if ((mask & ~BIT_MASK(arch_num_cpus())) != 0) {
+		shell_error(sh, "cpumask: 0x%X num_cpus: %d", mask, arch_num_cpus());
+		return -EINVAL;
+	}
+
+	if (local_irq != 0) {
+		irq = local_irq_to_irq(dev, local_irq);
+		riscv_plic_irq_set_affinity(irq, mask);
+		shell_print(sh, "IRQ %d affinity set to 0x%X", local_irq, mask);
+	} else {
+		for (local_irq = 1; local_irq <= config->nr_irqs; local_irq++) {
+			irq = local_irq_to_irq(dev, local_irq);
+			shell_info(sh, "%d %d", irq, local_irq);
+			riscv_plic_irq_set_affinity(irq, mask);
+		}
+		shell_print(sh, "All IRQ affinity set to 0x%X", mask);
+	}
+
+	return 0;
+}
+
+static int cmd_affinity_get(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+
+	const struct device *dev;
+	int rc = parse_device(sh, argc, argv, &dev);
+	const struct plic_config *config = dev->config;
+
+	if (rc != 0) {
+		return rc;
+	}
+
+	shell_print(sh, " IRQ  MASK");
+	if (argc == 2) {
+		for (uint32_t local_irq = 0; local_irq < config->nr_irqs; local_irq++) {
+			shell_print(sh, "%4d  0x%X", local_irq, get_irq_cpumask(dev, local_irq));
+		}
+	} else {
+		uint32_t local_irq = (uint32_t)shell_strtol(argv[2], 10, &rc);
+
+		if (rc != 0) {
+			shell_error(sh, "Failed to parse %s: %d", argv[2], rc);
+		}
+
+		if (local_irq >= config->nr_irqs) {
+			shell_error(sh, "local_irq (%d) > nr_irqs (%d)", local_irq,
+				    config->nr_irqs);
+			return -EINVAL;
+		}
+
+		shell_print(sh, "%4d  0x%X", local_irq, get_irq_cpumask(dev, local_irq));
+	}
+
+	return 0;
+}
+#endif /* CONFIG_PLIC_SHELL_IRQ_AFFINITY */
 
 /* Device name autocompletion support */
 static void device_name_get(size_t idx, struct shell_static_entry *entry)
 {
-	const struct device *dev = shell_device_lookup(idx, NULL);
+	const struct device *dev = shell_device_lookup(idx, "interrupt-controller");
 
 	entry->syntax = (dev != NULL) ? dev->name : NULL;
 	entry->handler = NULL;
@@ -517,50 +747,81 @@ static void device_name_get(size_t idx, struct shell_static_entry *entry)
 
 SHELL_DYNAMIC_CMD_CREATE(dsub_device_name, device_name_get);
 
+#ifdef CONFIG_PLIC_SHELL_IRQ_COUNT
 SHELL_STATIC_SUBCMD_SET_CREATE(plic_stats_cmds,
 	SHELL_CMD_ARG(get, &dsub_device_name,
 		"Read PLIC's stats.\n"
 		"Usage: plic stats get <device> [minimum hits]",
-		cmd_get_stats, 2, 1),
+		cmd_stats_get, 2, 1),
 	SHELL_CMD_ARG(clear, &dsub_device_name,
 		"Reset PLIC's stats.\n"
 		"Usage: plic stats clear <device>",
-		cmd_clear_stats, 2, 0),
+		cmd_stats_clear, 2, 0),
 	SHELL_SUBCMD_SET_END
 );
+#endif /* CONFIG_PLIC_SHELL_IRQ_COUNT */
+
+#ifdef CONFIG_PLIC_SHELL_IRQ_AFFINITY
+SHELL_STATIC_SUBCMD_SET_CREATE(plic_affinity_cmds,
+	SHELL_CMD_ARG(set, &dsub_device_name,
+		      "Set IRQ affinity.\n"
+		      "Usage: plic affinity set <device> <local_irq> <cpumask>",
+		      cmd_affinity_set, 4, 0),
+	SHELL_CMD_ARG(get, &dsub_device_name,
+		      "Get IRQ affinity.\n"
+		      "Usage: plic affinity get <device> <local_irq>",
+		      cmd_affinity_get, 2, 1),
+	SHELL_SUBCMD_SET_END);
+#endif /* CONFIG_PLIC_SHELL_IRQ_AFFINITY */
 
 SHELL_STATIC_SUBCMD_SET_CREATE(plic_cmds,
-	SHELL_CMD_ARG(stats, &plic_stats_cmds, "PLIC stats", NULL, 3, 0),
+#ifdef CONFIG_PLIC_SHELL_IRQ_COUNT
+	SHELL_CMD(stats, &plic_stats_cmds, "IRQ stats", NULL),
+#endif /* CONFIG_PLIC_SHELL_IRQ_COUNT */
+#ifdef CONFIG_PLIC_SHELL_IRQ_AFFINITY
+	SHELL_CMD(affinity, &plic_affinity_cmds, "IRQ affinity", NULL),
+#endif /* CONFIG_PLIC_SHELL_IRQ_AFFINITY */
 	SHELL_SUBCMD_SET_END
 );
 
-static int cmd_plic(const struct shell *sh, size_t argc, char **argv)
-{
-	shell_error(sh, "%s:unknown parameter: %s", argv[0], argv[1]);
-	return -EINVAL;
-}
-
-SHELL_CMD_ARG_REGISTER(plic, &plic_cmds, "PLIC shell commands",
-		       cmd_plic, 2, 0);
+SHELL_CMD_REGISTER(plic, &plic_cmds, "PLIC shell commands", NULL);
+#endif /* CONFIG_PLIC_SHELL */
 
 #define PLIC_MIN_IRQ_NUM(n) MIN(DT_INST_PROP(n, riscv_ndev), CONFIG_MAX_IRQ_PER_AGGREGATOR)
+
+#ifdef CONFIG_PLIC_SHELL
 #define PLIC_INTC_IRQ_COUNT_BUF_DEFINE(n)                                                          \
-	static uint16_t local_irq_count_##n[PLIC_MIN_IRQ_NUM(n)];
+	static uint16_t local_irq_count_##n[COND_CODE_1(CONFIG_MP_MAX_NUM_CPUS, (1),               \
+							(UTIL_INC(CONFIG_MP_MAX_NUM_CPUS)))]       \
+					   [PLIC_MIN_IRQ_NUM(n)];
+#define PLIC_INTC_IRQ_COUNT_INIT(n)                                                                \
+	.stats = {                                                                                 \
+		.irq_count = &local_irq_count_##n[0][0],                                           \
+	},
+
+#else
+#define PLIC_INTC_IRQ_COUNT_BUF_DEFINE(n)
+#define PLIC_INTC_IRQ_COUNT_INIT(n)
+#endif /* CONFIG_PLIC_SHELL */
+
+#ifdef CONFIG_PLIC_IRQ_AFFINITY
+#define PLIC_IRQ_CPUMASK_BUF_DECLARE(n)                                                            \
+	static plic_cpumask_t irq_cpumask_##n[PLIC_MIN_IRQ_NUM(n)] = {                             \
+		[0 ...(PLIC_MIN_IRQ_NUM(n) - 1)] = CONFIG_PLIC_IRQ_AFFINITY_MASK,                  \
+	}
+#define PLIC_IRQ_CPUMASK_BUF_INIT(n) .irq_cpumask = &irq_cpumask_##n[0],
+#else
+#define PLIC_IRQ_CPUMASK_BUF_DECLARE(n)
+#define PLIC_IRQ_CPUMASK_BUF_INIT(n)
+#endif /* CONFIG_PLIC_IRQ_AFFINITY */
 
 #define PLIC_INTC_DATA_INIT(n)                                                                     \
 	PLIC_INTC_IRQ_COUNT_BUF_DEFINE(n);                                                         \
+	PLIC_IRQ_CPUMASK_BUF_DECLARE(n);                                                           \
 	static struct plic_data plic_data_##n = {                                                  \
-		.stats = {                                                                         \
-			.irq_count = local_irq_count_##n,                                          \
-			.irq_count_len = PLIC_MIN_IRQ_NUM(n),                                      \
-		},                                                                                 \
+		PLIC_INTC_IRQ_COUNT_INIT(n)                                                        \
+		PLIC_IRQ_CPUMASK_BUF_INIT(n)                                                       \
 	};
-
-#define PLIC_INTC_DATA(n) &plic_data_##n
-#else
-#define PLIC_INTC_DATA_INIT(...)
-#define PLIC_INTC_DATA(n) (NULL)
-#endif
 
 #define PLIC_INTC_IRQ_FUNC_DECLARE(n) static void plic_irq_config_func_##n(void)
 
@@ -571,8 +832,14 @@ SHELL_CMD_ARG_REGISTER(plic, &plic_cmds, "PLIC shell commands",
 		irq_enable(DT_INST_IRQN(n));                                                       \
 	}
 
+#define HART_CONTEXTS(i, n) IF_ENABLED(IS_EQ(DT_INST_IRQN_BY_IDX(n, i), DT_INST_IRQN(n)), (i,))
+#define PLIC_HART_CONTEXT_DECLARE(n)                                                               \
+	static const int hart_contexts_##n[DT_CHILD_NUM(DT_PATH(cpus))] = {                        \
+		LISTIFY(DT_INST_NUM_IRQS(n), HART_CONTEXTS, (), n)}
+
 #define PLIC_INTC_CONFIG_INIT(n)                                                                   \
 	PLIC_INTC_IRQ_FUNC_DECLARE(n);                                                             \
+	PLIC_HART_CONTEXT_DECLARE(n);                                                              \
 	static const struct plic_config plic_config_##n = {                                        \
 		.prio = PLIC_BASE_ADDR(n),                                                         \
 		.irq_en = PLIC_BASE_ADDR(n) + CONTEXT_ENABLE_BASE,                                 \
@@ -580,9 +847,12 @@ SHELL_CMD_ARG_REGISTER(plic, &plic_cmds, "PLIC shell commands",
 		IF_ENABLED(PLIC_SUPPORTS_TRIG_TYPE,                                                \
 			   (.trig = PLIC_BASE_ADDR(n) + PLIC_REG_TRIG_TYPE_OFFSET,))               \
 		.max_prio = DT_INST_PROP(n, riscv_max_priority),                                   \
-		.num_irqs = DT_INST_PROP(n, riscv_ndev),                                           \
+		.riscv_ndev = DT_INST_PROP(n, riscv_ndev),                                         \
+		.nr_irqs = PLIC_MIN_IRQ_NUM(n),                                                    \
+		.irq = DT_INST_IRQN(n),                                                            \
 		.irq_config_func = plic_irq_config_func_##n,                                       \
 		.isr_table = &_sw_isr_table[INTC_INST_ISR_TBL_OFFSET(n)],                          \
+		.hart_context = hart_contexts_##n,                                                 \
 	};                                                                                         \
 	PLIC_INTC_IRQ_FUNC_DEFINE(n)
 
@@ -594,7 +864,7 @@ SHELL_CMD_ARG_REGISTER(plic, &plic_cmds, "PLIC shell commands",
 	PLIC_INTC_CONFIG_INIT(n)                                                                   \
 	PLIC_INTC_DATA_INIT(n)                                                                     \
 	DEVICE_DT_INST_DEFINE(n, &plic_init, NULL,                                                 \
-			      PLIC_INTC_DATA(n), &plic_config_##n,                                 \
+			      &plic_data_##n, &plic_config_##n,                                    \
 			      PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY,                             \
 			      NULL);
 

--- a/drivers/interrupt_controller/intc_swerv_pic.c
+++ b/drivers/interrupt_controller/intc_swerv_pic.c
@@ -238,5 +238,11 @@ int arch_irq_is_enabled(unsigned int irq)
 	return !!(mie & (1 << irq));
 }
 
+void arch_irq_set_affinity(unsigned int irq, unsigned int mask)
+{
+	ARG_UNUSED(irq);
+	ARG_UNUSED(mask);
+}
+
 DEVICE_DT_INST_DEFINE(0, swerv_pic_init, NULL,  NULL,  NULL,
 		      PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY, NULL);

--- a/drivers/interrupt_controller/intc_vexriscv_litex.c
+++ b/drivers/interrupt_controller/intc_vexriscv_litex.c
@@ -83,6 +83,12 @@ int arch_irq_is_enabled(unsigned int irq)
 	return vexriscv_litex_irq_getmask() & (1 << irq);
 }
 
+void arch_irq_set_affinity(unsigned int irq, unsigned int mask)
+{
+	ARG_UNUSED(irq);
+	ARG_UNUSED(mask);
+}
+
 static int vexriscv_litex_irq_init(const struct device *dev)
 {
 	__asm__ volatile ("csrrs x0, mie, %0"

--- a/include/zephyr/arch/arc/v2/irq.h
+++ b/include/zephyr/arch/arc/v2/irq.h
@@ -32,6 +32,7 @@ extern void z_arc_firq_stack_set(void);
 extern void arch_irq_enable(unsigned int irq);
 extern void arch_irq_disable(unsigned int irq);
 extern int arch_irq_is_enabled(unsigned int irq);
+extern void arch_irq_set_affinity(unsigned int irq, unsigned int mask);
 #ifdef CONFIG_TRACING_ISR
 extern void sys_trace_isr_enter(void);
 extern void sys_trace_isr_exit(void);

--- a/include/zephyr/arch/arch_interface.h
+++ b/include/zephyr/arch/arch_interface.h
@@ -313,6 +313,13 @@ void arch_irq_enable(unsigned int irq);
 int arch_irq_is_enabled(unsigned int irq);
 
 /**
+ *  Set the affinity of the specified interrupt line
+ *
+ * @see irq_set_affinity()
+ */
+void arch_irq_set_affinity(unsigned int irq, unsigned int mask);
+
+/**
  * Arch-specific hook to install a dynamic interrupt.
  *
  * @param irq IRQ line number

--- a/include/zephyr/arch/arm/irq.h
+++ b/include/zephyr/arch/arm/irq.h
@@ -39,6 +39,7 @@ GTEXT(z_soc_irq_eoi)
 extern void arch_irq_enable(unsigned int irq);
 extern void arch_irq_disable(unsigned int irq);
 extern int arch_irq_is_enabled(unsigned int irq);
+extern void arch_irq_set_affinity(unsigned int irq, unsigned int mask);
 
 /* internal routine documented in C file, needed by IRQ_CONNECT() macro */
 extern void z_arm_irq_priority_set(unsigned int irq, unsigned int prio,
@@ -55,6 +56,7 @@ void z_soc_irq_init(void);
 void z_soc_irq_enable(unsigned int irq);
 void z_soc_irq_disable(unsigned int irq);
 int z_soc_irq_is_enabled(unsigned int irq);
+int z_soc_irq_set_affinity(unsigned int irq, unsigned int mask);
 
 void z_soc_irq_priority_set(
 	unsigned int irq, unsigned int prio, unsigned int flags);
@@ -65,6 +67,7 @@ void z_soc_irq_eoi(unsigned int irq);
 #define arch_irq_enable(irq)		z_soc_irq_enable(irq)
 #define arch_irq_disable(irq)		z_soc_irq_disable(irq)
 #define arch_irq_is_enabled(irq)	z_soc_irq_is_enabled(irq)
+#define arch_irq_set_affinity(irq, mask) z_soc_irq_set_affinity(irq, mask)
 
 #define z_arm_irq_priority_set(irq, prio, flags)	\
 	z_soc_irq_priority_set(irq, prio, flags)

--- a/include/zephyr/arch/arm64/irq.h
+++ b/include/zephyr/arch/arm64/irq.h
@@ -38,6 +38,7 @@ GTEXT(z_soc_irq_eoi)
 extern void arch_irq_enable(unsigned int irq);
 extern void arch_irq_disable(unsigned int irq);
 extern int arch_irq_is_enabled(unsigned int irq);
+extern void arch_irq_set_affinity(unsigned int irq, unsigned int mask);
 
 /* internal routine documented in C file, needed by IRQ_CONNECT() macro */
 extern void z_arm64_irq_priority_set(unsigned int irq, unsigned int prio,
@@ -54,6 +55,7 @@ void z_soc_irq_init(void);
 void z_soc_irq_enable(unsigned int irq);
 void z_soc_irq_disable(unsigned int irq);
 int z_soc_irq_is_enabled(unsigned int irq);
+void z_soc_irq_set_affinity(unsigned int irq, unsigned int mask);
 
 void z_soc_irq_priority_set(
 	unsigned int irq, unsigned int prio, unsigned int flags);
@@ -64,6 +66,7 @@ void z_soc_irq_eoi(unsigned int irq);
 #define arch_irq_enable(irq)		z_soc_irq_enable(irq)
 #define arch_irq_disable(irq)		z_soc_irq_disable(irq)
 #define arch_irq_is_enabled(irq)	z_soc_irq_is_enabled(irq)
+#define arch_irq_set_affinity(irq, mask) z_soc_irq_set_affinity(irq, mask)
 
 #define z_arm64_irq_priority_set(irq, prio, flags)	\
 	z_soc_irq_priority_set(irq, prio, flags)

--- a/include/zephyr/arch/mips/arch.h
+++ b/include/zephyr/arch/mips/arch.h
@@ -39,6 +39,7 @@ extern "C" {
 void arch_irq_enable(unsigned int irq);
 void arch_irq_disable(unsigned int irq);
 int arch_irq_is_enabled(unsigned int irq);
+void arch_irq_set_affinity(unsigned int irq, unsigned int mask);
 void z_irq_spurious(const void *unused);
 
 /**

--- a/include/zephyr/arch/riscv/irq.h
+++ b/include/zephyr/arch/riscv/irq.h
@@ -53,6 +53,7 @@ extern "C" {
 extern void arch_irq_enable(unsigned int irq);
 extern void arch_irq_disable(unsigned int irq);
 extern int arch_irq_is_enabled(unsigned int irq);
+extern void arch_irq_set_affinity(unsigned int irq, unsigned int mask);
 
 #if defined(CONFIG_RISCV_HAS_PLIC) || defined(CONFIG_RISCV_HAS_CLIC)
 extern void z_riscv_irq_priority_set(unsigned int irq,

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -4235,6 +4235,14 @@
 #define DT_INST_REG_SIZE(inst) DT_INST_REG_SIZE_BY_IDX(inst, 0)
 
 /**
+ * @brief Get a `DT_DRV_COMPAT`'s number of interrupts
+ *
+ * @param inst instance number
+ * @return number of interrupts
+ */
+#define DT_INST_NUM_IRQS(inst) DT_NUM_IRQS(DT_DRV_INST(inst))
+
+/**
  * @brief Get a `DT_DRV_COMPAT` interrupt level
  *
  * @param inst instance number

--- a/include/zephyr/drivers/interrupt_controller/riscv_plic.h
+++ b/include/zephyr/drivers/interrupt_controller/riscv_plic.h
@@ -45,6 +45,14 @@ int riscv_plic_irq_is_enabled(uint32_t irq);
 void riscv_plic_set_priority(uint32_t irq, uint32_t prio);
 
 /**
+ * @brief Set IRQ affinity.
+ *
+ * @param irq IRQ line.
+ * @param mask CPU bit mask.
+ */
+void riscv_plic_irq_set_affinity(uint32_t irq, uint32_t mask);
+
+/**
  * @brief Get active interrupt ID
  *
  * @return Returns the ID of an active interrupt

--- a/include/zephyr/irq.h
+++ b/include/zephyr/irq.h
@@ -310,6 +310,16 @@ void z_smp_global_unlock(unsigned int key);
 #define irq_is_enabled(irq) arch_irq_is_enabled(irq)
 
 /**
+ * @brief Set IRQ affinity.
+ *
+ * This routine configure a set of CPU cores that can service the @a irq.
+ *
+ * @param irq IRQ line.
+ * @param mask CPU bit mask.
+ */
+#define irq_set_affinity(irq, mask) arch_irq_set_affinity(irq, mask)
+
+/**
  * @}
  */
 

--- a/soc/common/riscv-privileged/soc_common_irq.c
+++ b/soc/common/riscv-privileged/soc_common_irq.c
@@ -113,8 +113,13 @@ int arch_irq_is_enabled(unsigned int irq)
 
 void arch_irq_set_affinity(unsigned int irq, unsigned int mask)
 {
-	ARG_UNUSED(irq);
-	ARG_UNUSED(mask);
+#if defined(CONFIG_RISCV_PLIC_HAS_IRQ_AFFINITY)
+	unsigned int level = irq_get_level(irq);
+
+	if (level == 2) {
+		riscv_plic_irq_set_affinity(irq, mask);
+	}
+#endif
 }
 
 #if defined(CONFIG_RISCV_HAS_PLIC)

--- a/soc/common/riscv-privileged/soc_common_irq.c
+++ b/soc/common/riscv-privileged/soc_common_irq.c
@@ -32,6 +32,12 @@ int arch_irq_is_enabled(unsigned int irq)
 	return riscv_clic_irq_is_enabled(irq);
 }
 
+void arch_irq_set_affinity(unsigned int irq, unsigned int mask)
+{
+	ARG_UNUSED(irq);
+	ARG_UNUSED(mask);
+}
+
 void z_riscv_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
 {
 	riscv_clic_irq_priority_set(irq, prio, flags);
@@ -103,6 +109,12 @@ int arch_irq_is_enabled(unsigned int irq)
 	mie = csr_read(mie);
 
 	return !!(mie & (1 << irq));
+}
+
+void arch_irq_set_affinity(unsigned int irq, unsigned int mask)
+{
+	ARG_UNUSED(irq);
+	ARG_UNUSED(mask);
 }
 
 #if defined(CONFIG_RISCV_HAS_PLIC)

--- a/soc/espressif/esp32c2/soc_irq.c
+++ b/soc/espressif/esp32c2/soc_irq.c
@@ -49,6 +49,12 @@ int arch_irq_is_enabled(unsigned int irq)
 	return res;
 }
 
+void arch_irq_set_affinity(unsigned int irq, unsigned int mask)
+{
+	ARG_UNUSED(irq);
+	ARG_UNUSED(mask);
+}
+
 uint32_t soc_intr_get_next_source(void)
 {
 	uint32_t status;

--- a/soc/espressif/esp32c3/soc_irq.c
+++ b/soc/espressif/esp32c3/soc_irq.c
@@ -49,6 +49,12 @@ int arch_irq_is_enabled(unsigned int irq)
 	return res;
 }
 
+void arch_irq_set_affinity(unsigned int irq, unsigned int mask)
+{
+	ARG_UNUSED(irq);
+	ARG_UNUSED(mask);
+}
+
 uint32_t soc_intr_get_next_source(void)
 {
 	uint32_t status;

--- a/soc/espressif/esp32c6/soc_irq.c
+++ b/soc/espressif/esp32c6/soc_irq.c
@@ -50,6 +50,12 @@ int arch_irq_is_enabled(unsigned int irq)
 	return res;
 }
 
+void arch_irq_set_affinity(unsigned int irq, unsigned int mask)
+{
+	ARG_UNUSED(irq);
+	ARG_UNUSED(mask);
+}
+
 uint32_t soc_intr_get_next_source(void)
 {
 	uint32_t status;

--- a/soc/ite/ec/common/soc_common_irq.c
+++ b/soc/ite/ec/common/soc_common_irq.c
@@ -40,3 +40,9 @@ int arch_irq_is_enabled(unsigned int irq)
 		return 0;
 	}
 }
+
+void arch_irq_set_affinity(unsigned int irq, unsigned int mask)
+{
+	ARG_UNUSED(irq);
+	ARG_UNUSED(mask);
+}

--- a/soc/openisa/rv32m1/soc.c
+++ b/soc/openisa/rv32m1/soc.c
@@ -133,6 +133,12 @@ int arch_irq_is_enabled(unsigned int irq)
 	}
 }
 
+void arch_irq_set_affinity(unsigned int irq, unsigned int mask)
+{
+	ARG_UNUSED(irq);
+	ARG_UNUSED(mask);
+}
+
 /*
  * SoC-level interrupt initialization. Clear any pending interrupts or
  * events, and find the INTMUX device if necessary.

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -751,6 +751,9 @@ ZTEST(devicetree_api, test_irq)
 	/* DT_INST */
 	zassert_equal(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT), 1, "");
 
+	/* DT_INST_NUM_IRQS */
+	zassert_equal(DT_INST_NUM_IRQS(0), 3);
+
 	/* DT_INST_IRQ_HAS_IDX */
 	zassert_equal(DT_INST_IRQ_HAS_IDX(0, 0), 1, "");
 	zassert_equal(DT_INST_IRQ_HAS_IDX(0, 1), 1, "");


### PR DESCRIPTION
> [!NOTE]
> Alternate implementation that doesn't require stubbing every architectures - #77828

`irq_set_affinity(irq, mask)` allows the runtime affinity configuration of an interrupt line, which can be helpful in tuning the performance in a SMP setup (i.e. `irqbalance`).

This commit currently only creates an empty implementation for all of the architectures.

~~I will upstream an implementation for RISCV PLIC in this PR if this API is acceptable,~~ (added an implementation for RISCV PLIC) looking for comments

___

# Testing on `qemu_riscv64_smp`


```
west build -b qemu_riscv64_smp -p always -t run zephyr/samples/hello_world -- \
  -DCONFIG_SHELL=y \
  -DCONFIG_MP_MAX_NUM_CPUS=4 \
  -DCONFIG_PLIC_SHELL=y
```

```
[125/126] To exit from QEMU enter: 'CTRL+a, x'[QEMU] CPU: riscv64
*** Booting Zephyr OS build v3.7.0-1894-g2555dd2bb4f6 ***
Hello World! qemu_riscv64/qemu_virt_riscv64/smp

uart:~$ plic stats get interrupt-controller@c000000 
   IRQ       CPU 0       CPU 1       CPU 2       CPU 3       Total      ISR(ARG)
    10         105           0           0           0         123      0x800058fa(0x8000a130)

uart:~$ plic stats get interrupt-controller@c000000
   IRQ       CPU 0       CPU 1       CPU 2       CPU 3       Total      ISR(ARG)
    10         211           0           0           0         229      0x800058fa(0x8000a130)

uart:~$ plic affinity set interrupt-controller@c000000 10 0x2
IRQ 10 affinity set to 0x2
uart:~$ plic stats get interrupt-controller@c000000
   IRQ       CPU 0       CPU 1       CPU 2       CPU 3       Total      ISR(ARG)
    10         367         110           0           0         490      0x800058fa(0x8000a130)

uart:~$ plic stats get interrupt-controller@c000000
   IRQ       CPU 0       CPU 1       CPU 2       CPU 3       Total      ISR(ARG)
    10         367         208           0           0         589      0x800058fa(0x8000a130)

uart:~$ plic stats get interrupt-controller@c000000
   IRQ       CPU 0       CPU 1       CPU 2       CPU 3       Total      ISR(ARG)
    10         367         315           0           0         695      0x800058fa(0x8000a130)

uart:~$ plic affinity set interrupt-controller@c000000 10 0x4
IRQ 10 affinity set to 0x4
uart:~$ plic stats get interrupt-controller@c000000
   IRQ       CPU 0       CPU 1       CPU 2       CPU 3       Total      ISR(ARG)
    10         367         404         100           0         880      0x800058fa(0x8000a130)

uart:~$ plic stats get interrupt-controller@c000000
   IRQ       CPU 0       CPU 1       CPU 2       CPU 3       Total      ISR(ARG)
    10         367         404         206           0         986      0x800058fa(0x8000a130)

uart:~$ plic stats get interrupt-controller@c000000
   IRQ       CPU 0       CPU 1       CPU 2       CPU 3       Total      ISR(ARG)
    10         367         404         305           0        1085      0x800058fa(0x8000a130)

uart:~$ plic affinity set interrupt-controller@c000000 10 0x8
IRQ 10 affinity set to 0x8
uart:~$ plic stats get interrupt-controller@c000000
   IRQ       CPU 0       CPU 1       CPU 2       CPU 3       Total      ISR(ARG)
    10         367         404         398         114        1287      0x800058fa(0x8000a130)

uart:~$ plic stats get interrupt-controller@c000000
   IRQ       CPU 0       CPU 1       CPU 2       CPU 3       Total      ISR(ARG)
    10         367         404         398         216        1390      0x800058fa(0x8000a130)

uart:~$ plic affinity set interrupt-controller@c000000 10 0xf
IRQ 10 affinity set to 0xF
uart:~$ plic stats get interrupt-controller@c000000
   IRQ       CPU 0       CPU 1       CPU 2       CPU 3       Total      ISR(ARG)
     0          12          16          14          20          71      0x800045f4(0)
    10         391         432         421         345        1598      0x800058fa(0x8000a130)

uart:~$ plic stats get interrupt-controller@c000000
   IRQ       CPU 0       CPU 1       CPU 2       CPU 3       Total      ISR(ARG)
     0          38          38          40          40         162      0x800045f4(0)
    10         417         457         452         371        1706      0x800058fa(0x8000a130)

uart:~$ plic stats get interrupt-controller@c000000
   IRQ       CPU 0       CPU 1       CPU 2       CPU 3       Total      ISR(ARG)
     0          62          60          65          58         252      0x800045f4(0)
    10         438         484         486         398        1815      0x800058fa(0x8000a130)

uart:~$ 
```