### PR TITLE
drivers: stepper: Fix missing _driver_api suffix

### DIFF
--- a/drivers/stepper/gpio_stepper_controller.c
+++ b/drivers/stepper/gpio_stepper_controller.c
@@ -322,7 +322,7 @@ static int gpio_stepper_motor_controller_init(const struct device *dev)
 			.control_pins = gpio_stepper_motor_control_pins_##child};
 
 #define GPIO_STEPPER_API_DEFINE(child)                                                             \
-	static const struct stepper_api gpio_stepper_api_##child = {                               \
+	static const struct stepper_driver_api gpio_stepper_api_##child = {                        \
 		.enable = gpio_stepper_enable,                                                     \
 		.move = gpio_stepper_move,                                                         \
 		.is_moving = gpio_stepper_is_moving,                                               \

--- a/include/zephyr/drivers/stepper.h
+++ b/include/zephyr/drivers/stepper.h
@@ -168,7 +168,7 @@ typedef int (*stepper_enable_constant_velocity_mode_t)(const struct device *dev,
 /**
  * @brief Stepper Motor Controller API
  */
-__subsystem struct stepper_api {
+__subsystem struct stepper_driver_api {
 	stepper_enable_t enable;
 	stepper_move_t move;
 	stepper_set_max_velocity_t set_max_velocity;
@@ -198,7 +198,7 @@ __syscall int stepper_enable(const struct device *dev, const bool enable);
 
 static inline int z_impl_stepper_enable(const struct device *dev, const bool enable)
 {
-	const struct stepper_api *api = (const struct stepper_api *)dev->api;
+	const struct stepper_driver_api *api = (const struct stepper_driver_api *)dev->api;
 
 	return api->enable(dev, enable);
 }
@@ -222,7 +222,7 @@ __syscall int stepper_move(const struct device *dev, int32_t micro_steps,
 static inline int z_impl_stepper_move(const struct device *dev, const int32_t micro_steps,
 				      struct k_poll_signal *async)
 {
-	const struct stepper_api *api = (const struct stepper_api *)dev->api;
+	const struct stepper_driver_api *api = (const struct stepper_driver_api *)dev->api;
 
 	return api->move(dev, micro_steps, async);
 }
@@ -248,7 +248,7 @@ __syscall int stepper_set_max_velocity(const struct device *dev, uint32_t micro_
 static inline int z_impl_stepper_set_max_velocity(const struct device *dev,
 						  const uint32_t micro_steps_per_second)
 {
-	const struct stepper_api *api = (const struct stepper_api *)dev->api;
+	const struct stepper_driver_api *api = (const struct stepper_driver_api *)dev->api;
 
 	return api->set_max_velocity(dev, micro_steps_per_second);
 }
@@ -270,7 +270,7 @@ __syscall int stepper_set_micro_step_res(const struct device *dev,
 static inline int z_impl_stepper_set_micro_step_res(const struct device *dev,
 						    enum micro_step_resolution resolution)
 {
-	const struct stepper_api *api = (const struct stepper_api *)dev->api;
+	const struct stepper_driver_api *api = (const struct stepper_driver_api *)dev->api;
 
 	if (api->set_micro_step_res == NULL) {
 		return -ENOSYS;
@@ -294,7 +294,7 @@ __syscall int stepper_get_micro_step_res(const struct device *dev,
 static inline int z_impl_stepper_get_micro_step_res(const struct device *dev,
 						    enum micro_step_resolution *resolution)
 {
-	const struct stepper_api *api = (const struct stepper_api *)dev->api;
+	const struct stepper_driver_api *api = (const struct stepper_driver_api *)dev->api;
 
 	if (api->get_micro_step_res == NULL) {
 		return -ENOSYS;
@@ -316,7 +316,7 @@ __syscall int stepper_set_actual_position(const struct device *dev, int32_t valu
 
 static inline int z_impl_stepper_set_actual_position(const struct device *dev, const int32_t value)
 {
-	const struct stepper_api *api = (const struct stepper_api *)dev->api;
+	const struct stepper_driver_api *api = (const struct stepper_driver_api *)dev->api;
 
 	if (api->set_actual_position == NULL) {
 		return -ENOSYS;
@@ -338,7 +338,7 @@ __syscall int stepper_get_actual_position(const struct device *dev, int32_t *val
 
 static inline int z_impl_stepper_get_actual_position(const struct device *dev, int32_t *value)
 {
-	const struct stepper_api *api = (const struct stepper_api *)dev->api;
+	const struct stepper_driver_api *api = (const struct stepper_driver_api *)dev->api;
 
 	if (api->get_actual_position == NULL) {
 		return -ENOSYS;
@@ -366,7 +366,7 @@ __syscall int stepper_set_target_position(const struct device *dev, int32_t valu
 static inline int z_impl_stepper_set_target_position(const struct device *dev, const int32_t value,
 						     struct k_poll_signal *async)
 {
-	const struct stepper_api *api = (const struct stepper_api *)dev->api;
+	const struct stepper_driver_api *api = (const struct stepper_driver_api *)dev->api;
 
 	if (api->set_target_position == NULL) {
 		return -ENOSYS;
@@ -388,7 +388,7 @@ __syscall int stepper_is_moving(const struct device *dev, bool *is_moving);
 
 static inline int z_impl_stepper_is_moving(const struct device *dev, bool *is_moving)
 {
-	const struct stepper_api *api = (const struct stepper_api *)dev->api;
+	const struct stepper_driver_api *api = (const struct stepper_driver_api *)dev->api;
 
 	if (api->is_moving == NULL) {
 		return -ENOSYS;
@@ -421,7 +421,7 @@ __syscall int stepper_enable_constant_velocity_mode(const struct device *dev,
 static inline int z_impl_stepper_enable_constant_velocity_mode(
 	const struct device *dev, const enum stepper_direction direction, const uint32_t value)
 {
-	const struct stepper_api *api = (const struct stepper_api *)dev->api;
+	const struct stepper_driver_api *api = (const struct stepper_driver_api *)dev->api;
 
 	if (api->enable_constant_velocity_mode == NULL) {
 		return -ENOSYS;


### PR DESCRIPTION
The gen_kobject_list.py script expects the __subystem declaration to end with _driver_api. Adjust the stepper api and existing driver implementation accordingly.

Found via:
```
west build -b nrf5340dk_nrf5340_cpuapp tests/drivers/build_all/stepper
```

Traceback:
```
FAILED: zephyr/kobject_prebuilt_hash.gperf /home/faxe/projects/zephyr_workspace/zephyr/build/zephyr/kobject_prebuilt_hash.gperf
cd /home/faxe/projects/zephyr_workspace/zephyr/build/zephyr && /home/faxe/projects/zephyr_workspace/.venv/bin/python3 /home/faxe/projects/zephyr_workspace/zephyr/scripts/build/gen_kobject_list.py --kernel /home/faxe/projects/zephyr_workspace/zephyr/build/zephyr/zephyr_pre0.elf --gperf-output kobject_prebuilt_hash.gperf --include-subsystem-list /home/faxe/projects/zephyr_workspace/zephyr/build/zephyr/misc/generated/struct_tags.json
Traceback (most recent call last):
  File "/home/faxe/projects/zephyr_workspace/zephyr/scripts/build/gen_kobject_list.py", line 1070, in <module>
    main()
  File "/home/faxe/projects/zephyr_workspace/zephyr/scripts/build/gen_kobject_list.py", line 1037, in main
    objs = find_kobjects(elf, syms)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/faxe/projects/zephyr_workspace/zephyr/scripts/build/gen_kobject_list.py", line 704, in find_kobjects
    ko.type_name = subsystem_to_enum(apiobj.type_obj.name)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/faxe/projects/zephyr_workspace/zephyr/scripts/build/gen_kobject_list.py", line 142, in subsystem_to_enum
    raise Exception("__subsystem is missing _driver_api suffix: (%s)" % subsys)
Exception: __subsystem is missing _driver_api suffix: (stepper_api)
ninja: build stopped: subcommand failed.
FATAL ERROR: command exited with status 1: /usr/bin/cmake --build /home/faxe/projects/zephyr_workspace/zephyr/build
```