### PR TITLE
manifest: Update EDTT to latest version

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -127,7 +127,7 @@ manifest:
       revision: ea987c1ca661be723de83bd159aed815d6cbd430
       path: modules/lib/cmsis-nn
     - name: edtt
-      revision: 8d7b543d4d2f2be0f78481e4e1d8d73a88024803
+      revision: b9ca3c7030518f07b7937dacf970d37a47865a76
       path: tools/edtt
       groups:
         - tools


### PR DESCRIPTION
Update the EDTT module to:
b9ca3c7030518f07b7937dacf970d37a47865a76

Including the following:
* b9ca3c7 Fix for for python >= 3.11
* fe9b1d1 Corrected ISO interval for LL/CIS/PER/BV-05-C

Fixes #77669