### PR TITLE
bindings: counter: extend binding with channel specifier

### DIFF
--- a/boards/native/native_sim/native_sim.dts
+++ b/boards/native/native_sim/native_sim.dts
@@ -170,6 +170,7 @@
 	counter0: counter {
 		status = "okay";
 		compatible = "zephyr,native-posix-counter";
+		#counter-cells = <1>;
 	};
 
 	gpio0: gpio_emul {

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -266,6 +266,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -288,6 +289,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -310,6 +312,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -332,6 +335,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -276,6 +276,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -298,6 +299,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -320,6 +322,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -458,6 +458,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -480,6 +481,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -502,6 +504,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -518,6 +521,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -534,6 +538,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -573,6 +578,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -595,6 +601,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -617,6 +624,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -639,6 +647,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -661,6 +670,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -683,6 +693,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -282,6 +282,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -304,6 +305,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -320,6 +322,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -336,6 +339,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -358,6 +362,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -380,6 +385,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -402,6 +408,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -351,6 +351,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 
 			qdec {
@@ -379,6 +380,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 
 			qdec {
@@ -407,6 +409,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 
 			qdec {
@@ -435,6 +438,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 
 			qdec {
@@ -463,6 +467,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -485,6 +490,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -507,6 +513,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 

--- a/dts/arm/st/f4/stm32f405.dtsi
+++ b/dts/arm/st/f4/stm32f405.dtsi
@@ -83,6 +83,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -99,6 +100,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -144,6 +146,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -166,6 +169,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -188,6 +192,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 

--- a/dts/arm/st/f4/stm32f410.dtsi
+++ b/dts/arm/st/f4/stm32f410.dtsi
@@ -87,6 +87,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 

--- a/dts/arm/st/f4/stm32f412.dtsi
+++ b/dts/arm/st/f4/stm32f412.dtsi
@@ -96,6 +96,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -141,6 +142,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -163,6 +165,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -185,6 +188,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -442,6 +442,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -464,6 +465,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -486,6 +488,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -508,6 +511,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -524,6 +528,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -540,6 +545,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -579,6 +585,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -601,6 +608,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -623,6 +631,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -645,6 +654,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -667,6 +677,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -689,6 +700,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -268,6 +268,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -290,6 +291,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -312,6 +314,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -334,6 +337,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -356,6 +360,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 

--- a/dts/arm/st/g0/stm32g051.dtsi
+++ b/dts/arm/st/g0/stm32g051.dtsi
@@ -22,6 +22,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -38,6 +39,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -60,6 +62,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -435,6 +435,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 
 			pwm {
@@ -457,6 +458,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 
 			pwm {
@@ -479,6 +481,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 
 			pwm {
@@ -546,6 +549,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -568,6 +572,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -590,6 +595,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -347,6 +347,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -368,6 +369,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -389,6 +391,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -410,6 +413,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -289,6 +289,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -310,6 +311,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -331,6 +333,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -352,6 +355,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -373,6 +377,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -394,6 +399,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -415,6 +421,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -436,6 +443,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -569,6 +569,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -591,6 +592,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -613,6 +615,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -635,6 +638,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -651,6 +655,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -667,6 +672,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -706,6 +712,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -728,6 +735,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -750,6 +758,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -772,6 +781,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -794,6 +804,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -816,6 +827,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 

--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -154,6 +154,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -176,6 +177,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -530,6 +530,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -552,6 +553,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -574,6 +576,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -596,6 +599,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -612,6 +616,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -628,6 +633,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -644,6 +650,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -666,6 +673,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -688,6 +696,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -710,6 +719,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -269,6 +269,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -291,6 +292,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 

--- a/dts/arm/st/l0/stm32l071.dtsi
+++ b/dts/arm/st/l0/stm32l071.dtsi
@@ -73,6 +73,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -89,6 +90,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -105,6 +107,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -127,6 +130,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -271,6 +271,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -293,6 +294,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -315,6 +317,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -337,6 +340,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -359,6 +363,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -381,6 +386,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -313,6 +313,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -329,6 +330,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -351,6 +353,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -373,6 +376,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 

--- a/dts/arm/st/l4/stm32l431.dtsi
+++ b/dts/arm/st/l4/stm32l431.dtsi
@@ -99,6 +99,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 

--- a/dts/arm/st/l4/stm32l432.dtsi
+++ b/dts/arm/st/l4/stm32l432.dtsi
@@ -48,6 +48,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 

--- a/dts/arm/st/l4/stm32l451.dtsi
+++ b/dts/arm/st/l4/stm32l451.dtsi
@@ -124,6 +124,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 

--- a/dts/arm/st/l4/stm32l471.dtsi
+++ b/dts/arm/st/l4/stm32l471.dtsi
@@ -123,6 +123,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -145,6 +146,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -167,6 +169,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -183,6 +186,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -222,6 +226,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 

--- a/dts/arm/st/l4/stm32l4p5.dtsi
+++ b/dts/arm/st/l4/stm32l4p5.dtsi
@@ -177,6 +177,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -199,6 +200,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -221,6 +223,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -243,6 +246,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -282,6 +286,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -502,6 +502,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -524,6 +525,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -546,6 +548,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -568,6 +571,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -607,6 +611,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -629,6 +634,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -651,6 +657,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 

--- a/dts/arm/st/mp1/stm32mp157.dtsi
+++ b/dts/arm/st/mp1/stm32mp157.dtsi
@@ -355,6 +355,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -377,6 +378,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -554,6 +554,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -575,6 +576,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -644,6 +646,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -665,6 +668,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -686,6 +690,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -364,6 +364,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -386,6 +387,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -408,6 +410,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 

--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -315,6 +315,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 
 			pwm {
@@ -337,6 +338,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 
 			pwm {
@@ -359,6 +361,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 
 			pwm {
@@ -380,6 +383,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 
 			pwm {
@@ -401,6 +405,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 
 			pwm {

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -401,6 +401,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -423,6 +424,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 
@@ -445,6 +447,7 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+				#counter-cells = <1>;
 			};
 		};
 

--- a/dts/bindings/counter/counter.yaml
+++ b/dts/bindings/counter/counter.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2024, Basalte bv
+# SPDX-License-Identifier: Apache-2.0
+
+include: base.yaml
+
+properties:
+  "#counter-cells":
+    type: int
+    required: true
+    description: Number of items to expect in a counter specifier

--- a/dts/bindings/counter/st,stm32-counter.yaml
+++ b/dts/bindings/counter/st,stm32-counter.yaml
@@ -5,4 +5,11 @@ description: STM32 counters
 
 compatible: "st,stm32-counter"
 
-include: base.yaml
+include: counter.yaml
+
+properties:
+  "#counter-cells":
+    const: 1
+
+counter-cells:
+  - channel

--- a/dts/bindings/counter/zephyr,native-posix-counter.yaml
+++ b/dts/bindings/counter/zephyr,native-posix-counter.yaml
@@ -5,4 +5,11 @@ description: Native POSIX Counter
 
 compatible: "zephyr,native-posix-counter"
 
-include: base.yaml
+include: "counter.yaml"
+
+properties:
+  "#counter-cells":
+    const: 1
+
+counter-cells:
+  - channel


### PR DESCRIPTION
**Suggestion**: make it possible to define the channel in the device tree when using a hardware counter.

**Proposal**: add a _counter.yaml_ file that specifies a #counter-cells property. This can than be included and used to add the channel to the specifiers.

**Fixes**: drivers that make use of hardware timers can now get the channel from the device tree, making them more portable.

As this change affects a large portion of the tree, I only adapted thenative sim and st,stm32-counter compatible for now to keep this PR organized. 

**Usecase**: When writing bitbang drivers, hardware counters can be used to toggle the gpio's (instead of a blocking wait like the i2c_bitbang). The counter channel can then be specified in the device tree.

I'd love to hear your feedback on this change.