### PR TITLE
doc: languages: rust: Fix a few typos and markups

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3180,6 +3180,7 @@ Rust:
     - cmake/modules/rust.cmake
     - lib/rust/
     - samples/rust/
+    - doc/develop/languages/rust/
   labels:
     - "area: Rust"
 

--- a/doc/develop/languages/rust/index.rst
+++ b/doc/develop/languages/rust/index.rst
@@ -4,7 +4,7 @@ Rust Language Support
 #####################
 
 Rust is a systems programming language focused on safety, speed, and concurrency. Designed to
-prevent common programming errors such as null pointer dereferencing and buffer overflows, Rust
+prevent common programming errors, such as null pointer dereferencing and buffer overflows, Rust
 emphasizes memory safety without sacrificing performance. Its powerful type system and ownership
 model ensure thread-safe programming, making it an ideal choice for developing reliable and
 efficient low-level code.  Rust's expressive syntax and modern features make it a robust alternative
@@ -14,14 +14,14 @@ applications.
 Enabling Rust Support
 *********************
 
-Currently, Zephyr supports applications written in Rust and C.  The enable Rust support, you must
+Currently, Zephyr supports applications written in Rust and C.  To enable Rust support, you must
 select the :kconfig:option:`CONFIG_RUST` in the application configuration file.
 
-The rust toolchain is separate from the rest of the Zephyr SDK.   It is recommended to use the
-`rustup`_ tool to install the rust toolchain.  In addition to the base compiler, you will need to
-install core libraries for the target(s) you wish to compile on.  It is easiest to determine what
+The Rust toolchain is separate from the rest of the Zephyr SDK.   It is recommended to use the
+`rustup`_ tool to install the Rust toolchain.  In addition to the base compiler, you will need to
+install core libraries for the target(s) you wish to compile for.  It is easiest to determine what
 needs to be installed by trying a build.  The diagnostics from the rust compilation will indicate
-the rust command needed to install the appropriate target support:
+the Rust command needed to install the appropriate target support:
 
 .. _rustup: https://rustup.rs/
 
@@ -60,14 +60,14 @@ The application should contain a :file:`CMakeLists.txt`, similar to the followin
 Cargo files
 -----------
 
-Rust applications are built with Cargo.  The Zephyr build system will configure and invoke cargo in
-your application directory, with options set so that it can find the Zephyr support libraries, and
-that the output will be contained within the Zephyr build directory.
+Rust applications are built with Cargo.  The Zephyr build system will configure and invoke ``cargo``
+in your application directory, with options set so that it can find the Zephyr support libraries,
+and the output will be contained within the Zephyr build directory.
 
 The :file:`Cargo.toml` will need to have a ``[lib]`` section that sets ``crate-type =
 ["staticlib"]``, and will need to include ``zephyr = "0.1.0"`` as a dependency.  You can use
 crates.io and the Crate ecosystem to include any other dependencies you need.  Just make sure that
-you use crates that support building with no-std.
+you use crates that support building with ``no-std``.
 
 Application
 -----------
@@ -85,12 +85,13 @@ file would be:
    extern "C" fn rust_main() {
    }
 
-The ``no_std`` declaration is needed to prevent the code from referencing the ``std`` library.  The
-extern reference will cause the zephyr crate to be brought in, even if nothing from it is used.
-Practically, any meaningful Rust application on Zephyr will use something from this crate, and this
-line is not necessary.  Lastly, the main declaration exports the main symbol so that it can be
-called by C code.  The build ``rust_cargo_application()`` cmake function will include a small C file
-that will call into this from the C main function.
+The ``#![no_std]`` declaration is needed to prevent the code from referencing the ``std`` library.
+The ``extern crate zephyr;`` line will cause the zephyr crate to be brought in, even if nothing from
+it is used.  Practically, any meaningful Rust application on Zephyr will use something from this
+crate, so including it is usually necessary.  Lastly, the ```extern "C" fn rust_main()`` declaration
+exports the ``rust_main`` symbol so that it can be called by C code.  In the :file:`CMakeLists.txt`,
+the ``rust_cargo_application()`` function will include a small C file that calls into this
+``rust_main()`` function from the C main function.
 
 Zephyr Functionality
 ********************
@@ -102,8 +103,8 @@ Bool Kconfig settings
 
 Boolean Kconfig settings can be used from within Rust code.  Due to design constraints by the Rust
 language, settings that affect compilation must be determined before the build is made.  In order to
-use this in your application, you will need to use the ``zephyr-build`` crate, provided, to make
-these symbols available.
+use this in your application, you will need to use the provided ``zephyr-build`` crate to make these
+symbols available.
 
 To your ``Cargo.toml`` file, add the following:
 


### PR DESCRIPTION
This commit fixes a few typos, capitalization, and markups in the rust document.