### PR TITLE
rtio: add helper function `rtio_sqe_prep_callback_no_cqe`

### DIFF
--- a/include/zephyr/rtio/rtio.h
+++ b/include/zephyr/rtio/rtio.h
@@ -606,6 +606,25 @@ static inline void rtio_sqe_prep_callback(struct rtio_sqe *sqe,
 }
 
 /**
+ * @brief Prepare a callback op submission that does not create a CQE
+ *
+ * Similar to @ref rtio_sqe_prep_callback, but the @ref RTIO_SQE_NO_RESPONSE
+ * flag is set on the SQE to prevent the generation of a CQE upon completion.
+ *
+ * This can be useful when the callback is the last operation in a sequence
+ * whose job is to clean up all the previous CQE's. Without @ref RTIO_SQE_NO_RESPONSE
+ * the completion itself will result in a CQE that cannot be consumed in the callback.
+ */
+static inline void rtio_sqe_prep_callback_no_cqe(struct rtio_sqe *sqe,
+						 rtio_callback_t callback,
+						 void *arg0,
+						 void *userdata)
+{
+	rtio_sqe_prep_callback(sqe, callback, arg0, userdata);
+	sqe->flags |= RTIO_SQE_NO_RESPONSE;
+}
+
+/**
  * @brief Prepare a transceive op submission
  */
 static inline void rtio_sqe_prep_transceive(struct rtio_sqe *sqe,

--- a/tests/subsys/rtio/rtio_api/src/test_rtio_api.c
+++ b/tests/subsys/rtio/rtio_api/src/test_rtio_api.c
@@ -25,8 +25,8 @@
 #define MEM_BLK_SIZE 16
 #define MEM_BLK_ALIGN 4
 
-#define SQE_POOL_SIZE 4
-#define CQE_POOL_SIZE 4
+#define SQE_POOL_SIZE 5
+#define CQE_POOL_SIZE 5
 
 /*
  * Purposefully double the block count and half the block size. This leaves the same size mempool,
@@ -654,6 +654,7 @@ ZTEST(rtio_api, test_rtio_throughput)
 
 RTIO_DEFINE(r_callback_chaining, SQE_POOL_SIZE, CQE_POOL_SIZE);
 RTIO_IODEV_TEST_DEFINE(iodev_test_callback_chaining0);
+static bool cb_no_cqe_run;
 
 /**
  * Callback for testing with
@@ -661,6 +662,12 @@ RTIO_IODEV_TEST_DEFINE(iodev_test_callback_chaining0);
 void rtio_callback_chaining_cb(struct rtio *r, const struct rtio_sqe *sqe, void *arg0)
 {
 	TC_PRINT("chaining callback with userdata %p\n", arg0);
+}
+
+void rtio_callback_chaining_cb_no_cqe(struct rtio *r, const struct rtio_sqe *sqe, void *arg0)
+{
+	TC_PRINT("Chaining callback with userdata %p (No CQE)\n", arg0);
+	cb_no_cqe_run = true;
 }
 
 /**
@@ -698,6 +705,11 @@ void test_rtio_callback_chaining_(struct rtio *r)
 
 	sqe = rtio_sqe_acquire(r);
 	zassert_not_null(sqe, "Expected a valid sqe");
+	rtio_sqe_prep_callback_no_cqe(sqe, &rtio_callback_chaining_cb_no_cqe, sqe, NULL);
+	sqe->flags |= RTIO_SQE_CHAINED;
+
+	sqe = rtio_sqe_acquire(r);
+	zassert_not_null(sqe, "Expected a valid sqe");
 	rtio_sqe_prep_callback(sqe, &rtio_callback_chaining_cb, sqe, &userdata[3]);
 
 	TC_PRINT("submitting\n");
@@ -706,6 +718,7 @@ void test_rtio_callback_chaining_(struct rtio *r)
 		 cq_count, atomic_get(&r->cq_count));
 	zassert_ok(res, "Should return ok from rtio_execute");
 	zassert_equal(atomic_get(&r->cq_count) - cq_count, 4, "Should have 4 pending completions");
+	zassert_true(cb_no_cqe_run, "Callback without CQE should have run");
 
 	for (int i = 0; i < 4; i++) {
 		TC_PRINT("consume %d\n", i);


### PR DESCRIPTION
Add a helper function that constructs a callback operation that doesn't generate a completion queue event.

Fixes #76351