### PR TITLE
bluetooth: mesh: Fix proxy client compilation

### DIFF
--- a/subsys/bluetooth/mesh/subnet.h
+++ b/subsys/bluetooth/mesh/subnet.h
@@ -74,7 +74,7 @@ struct bt_mesh_subnet {
 		struct bt_mesh_key net;         /* NetKey */
 		struct bt_mesh_net_cred msg;
 		uint8_t net_id[8];              /* Network ID */
-	#if defined(CONFIG_BT_MESH_GATT_PROXY)
+	#if defined(CONFIG_BT_MESH_GATT)
 		struct bt_mesh_key identity;    /* IdentityKey */
 	#endif
 		struct bt_mesh_key beacon;      /* BeaconKey */


### PR DESCRIPTION
When building proxy client without proxy server, it fails to find the `identity` field in the `struct bt_mesh_subnet_keys` because the latter only compiles when Proxy server is enabled. It should be possible to compile Proxy Client without Proxy server.

This commit compiles the field if any of GATT features is enabled.

Fixes #75914