### PR TITLE
Bluetooth: Controller: Initialize BIG info RFU field

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -541,6 +541,7 @@ static uint8_t big_create(uint8_t big_handle, uint8_t adv_handle, uint8_t num_bi
 	PDU_BIG_INFO_IRC_SET(big_info, lll_adv_iso->irc);
 
 	big_info->max_pdu = lll_adv_iso->max_pdu;
+	big_info->rfu = 0U;
 
 	(void)memcpy(&big_info->seed_access_addr, lll_adv_iso->seed_access_addr,
 		     sizeof(big_info->seed_access_addr));


### PR DESCRIPTION
The BIG info new Framing Mode field was not initialiazed, so random garbage was being sent to the air in this field. For the controller this field is still RFU.
The spec specifies RFU fields must be initialiazed to 0. So let's do so to avoid sending invalid data,
and avoid having random data in the air which can cause random differences in testcases.

Fixes #77679