### PR TITLE
Bluetooth: mesh: Temporarily allow K_FOREVER on system workqueue

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -6,6 +6,7 @@
 menuconfig BT_MESH
 	bool "Bluetooth Mesh support"
 	depends on BT_OBSERVER && BT_BROADCASTER
+	select NET_BUF_NO_TIMEOUT_OVERRIDE
 	help
 	  This option enables Bluetooth Mesh support. The specific
 	  features that are available may depend on other features

--- a/subsys/net/Kconfig
+++ b/subsys/net/Kconfig
@@ -61,6 +61,14 @@ config NET_BUF_ALIGNMENT
 	  Default value of 0 means the alignment will be the size of a void pointer,
 	  any other value will force the alignment of a net buffer in bytes.
 
+config NET_BUF_NO_TIMEOUT_OVERRIDE
+	bool
+	help
+	  This option disables overriding the timeout to K_NO_WAIT when
+	  allocating a buffer on the system worqueue.
+
+	  Might introduce deadlocks, use at your own risk.
+
 endif # NET_BUF
 
 config NETWORKING

--- a/subsys/net/buf.c
+++ b/subsys/net/buf.c
@@ -271,7 +271,8 @@ struct net_buf *net_buf_alloc_len(struct net_buf_pool *pool, size_t size,
 
 	k_spin_unlock(&pool->lock, key);
 
-	if (!K_TIMEOUT_EQ(timeout, K_NO_WAIT) &&
+	if (!IS_ENABLED(CONFIG_NET_BUF_NO_TIMEOUT_OVERRIDE) &&
+	    !K_TIMEOUT_EQ(timeout, K_NO_WAIT) &&
 	    k_current_get() == k_work_queue_thread_get(&k_sys_work_q)) {
 		LOG_DBG("Timeout discarded. No blocking in syswq");
 		timeout = K_NO_WAIT;


### PR DESCRIPTION
This is intended as a hotfix of sorts, in order to give some time to the Bluetooth Host and Mesh stack maintainers to figure out a sustainable solution.

This commit should be reverted when that better solution is found.

Hotfixes https://github.com/zephyrproject-rtos/zephyr/issues/77241
DO NOT close the issue when the PR is merged. We should still design a better long-term solution to this problem.