### PR TITLE
samples/llext/modules: fix basic build, improve documentation

### DIFF
--- a/samples/subsys/llext/modules/Kconfig
+++ b/samples/subsys/llext/modules/Kconfig
@@ -7,7 +7,7 @@ source "Kconfig.zephyr"
 
 config HELLO_WORLD_MODE
 	tristate "Include the hello_world function"
-	default m
+	default y
 	help
 	  This enables building the hello_world function, implemented in
 	  hello_world_ext.c, either as an llext module or as a built-in part of
@@ -16,3 +16,7 @@ config HELLO_WORLD_MODE
 	  If you select 'm', the hello_world function will be built as an llext
 	  "module". If you select 'y', the hello_world function will be directly
 	  linked in the Zephyr image.
+
+	  Note that additional architecture-specific configuration may be
+	  required if you select 'm'. Please review this sample's documentation
+	  and sample.yaml for more information.

--- a/samples/subsys/llext/modules/README.rst
+++ b/samples/subsys/llext/modules/README.rst
@@ -36,14 +36,13 @@ executed in QEMU emulation on the :ref:`qemu_xtensa <qemu_xtensa>` or
 Building and running
 ********************
 
-- The following commands build and run the sample so that the files are linked
-  together in the same binary:
+- By default, the sample will compile the function along with the rest of
+  Zephyr in the same binary. This can be verified via the following commands:
 
   .. zephyr-app-commands::
      :zephyr-app: samples/subsys/llext/modules
      :board: qemu_xtensa
      :goals: build run
-     :west-args: -T sample.llext.modules.builtin_build
      :compact:
 
 - The following commands build and run the sample so that the extension code is
@@ -56,8 +55,9 @@ Building and running
      :west-args: -T sample.llext.modules.module_build
      :compact:
 
-  Take a look at :zephyr_file:`samples/subsys/llext/modules/sample.yaml` for the
-  additional architecture-specific configurations required in this case.
+  .. important::
+     Take a look at :zephyr_file:`samples/subsys/llext/modules/sample.yaml` for
+     the additional architecture-specific configurations required in this case.
 
 To build for a different board, replace ``qemu_xtensa`` in the commands above
 with the desired board name.

--- a/samples/subsys/llext/modules/prj.conf
+++ b/samples/subsys/llext/modules/prj.conf
@@ -1,6 +1,10 @@
 CONFIG_LOG=y
 CONFIG_LOG_MODE_IMMEDIATE=y
 
+# CONFIG_MODULES must be enabled to allow setting any options to "m" in the
+# Kconfig files. For compatibility with Kconfiglib, the name must be kept
+# as-is even if Zephyr has a completely different concept for "modules".
+
 CONFIG_MODULES=y
 
 # LLEXT is only required when loading the extension at runtime. Since in this
@@ -11,9 +15,21 @@ CONFIG_MODULES=y
 CONFIG_LLEXT=y
 CONFIG_LLEXT_LOG_LEVEL_DBG=y
 CONFIG_LLEXT_HEAP_SIZE=64
-CONFIG_LLEXT_TYPE_ELF_RELOCATABLE=y
+CONFIG_LLEXT_TYPE_ELF_RELOCATABLE=y # supported by all targets
 
 # This test consumes large amounts of stack when loading the LLEXT.
 # Increase the available size to avoid overflowing (see issue #74536).
 
 CONFIG_MAIN_STACK_SIZE=2048
+
+# NOTE
+#
+# This project file explicitly does NOT include the configuration for
+# CONFIG_HELLO_WORLD_MODE, so a clean compile will include the function as
+# built-in by default.
+#
+# To build it as an llext, please follow the instructions in the documentation
+# of this sample; there are architecture-specific settings that must be set in
+# addition to CONFIG_HELLO_WORLD_MODE=m. For example, most ARM targets need to
+# either enable CONFIG_USERSPACE (if they support it) or disable MPU/MMU
+# features for LLEXT to work correctly.

--- a/samples/subsys/llext/modules/sample.yaml
+++ b/samples/subsys/llext/modules/sample.yaml
@@ -1,28 +1,14 @@
 common:
   tags: llext
-  arch_allow:
-    - arm
-    - xtensa
-  platform_exclude:
-    # platforms with active issues
-    - apollo4p_evb            # See #73443
-    - apollo4p_blue_kxr_evb   # See #73443
-    - numaker_pfm_m487        # See #63167
-    - s32z2xxdc2/s32z270/rtu0 # See commit 18a0660
-    - s32z2xxdc2/s32z270/rtu1 # See commit 18a0660
-    # platforms that are always skipped by the runtime filter
-    - qemu_arc/qemu_arc_em
-    - qemu_arc/qemu_arc_hs
-    - qemu_arc/qemu_arc_hs/xip
-    - qemu_arc/qemu_arc_hs5x
-    - qemu_arc/qemu_arc_hs6x
-    - qemu_cortex_m0
-    - qemu_xtensa/dc233c/mmu
-  integration_platforms:
+  platform_allow:
     - qemu_cortex_a9          # ARM Cortex-A9 (ARMv7-A ISA)
     - qemu_cortex_r5          # ARM Cortex-R5 (ARMv7-R ISA)
     - mps2/an385              # ARM Cortex-M3 (ARMv7-M ISA)
     - mps2/an521/cpu0         # ARM Cortex-M33 (ARMv8-M ISA)
+    - qemu_xtensa
+  integration_platforms:
+    - qemu_xtensa
+    - mps2/an385
   harness: console
 
 sample:
@@ -31,7 +17,6 @@ sample:
 
 tests:
   sample.llext.modules.module_build:
-    filter: not CONFIG_MPU and not CONFIG_MMU and not CONFIG_SOC_SERIES_S32ZE
     extra_configs:
       - CONFIG_HELLO_WORLD_MODE=m
       # Disabling MPU is the most compatible option. If the target supports

--- a/samples/subsys/llext/modules/sample.yaml
+++ b/samples/subsys/llext/modules/sample.yaml
@@ -33,16 +33,17 @@ tests:
   sample.llext.modules.module_build:
     filter: not CONFIG_MPU and not CONFIG_MMU and not CONFIG_SOC_SERIES_S32ZE
     extra_configs:
+      - CONFIG_HELLO_WORLD_MODE=m
+      # Disabling MPU is the most compatible option. If the target supports
+      # CONFIG_USERSPACE, that should be preferred as it has many additional
+      # security benefits.
       - arch:arm:CONFIG_ARM_MPU=n
       - arch:arm:CONFIG_ARM_AARCH32_MMU=n
-      - CONFIG_HELLO_WORLD_MODE=m
     harness_config:
       type: one_line
       regex:
         - "Hello, world, from an llext!"
   sample.llext.modules.builtin_build:
-    extra_configs:
-      - CONFIG_HELLO_WORLD_MODE=y
     harness_config:
       type: one_line
       regex:


### PR DESCRIPTION
The LLEXT "modules" sample was designed to show how to compile the same code in two different ways - directly as part of one binary, or as a separate extension. As described in the [related doc](https://docs.zephyrproject.org/latest/samples/subsys/llext/modules/README.html#building-and-running), this can achieved with proper `west build -T ...` commands defined in the sample's `sample.yaml`.

However, #77515 has highlighted the fact that when the sample is compiled as a project (without `-T`), it almost certainly results in a non-working binary. This is due to the fact that the build mode defaults to "as a module", but the other options that are required for LLEXT to work are only defined in the `sample.yaml`.

This PR sets the default build to "built-in" (which is obviously always supported).
References to how to set the sample to work "as a module" have been added:
* in the Kconfig help for the option setting the build mode;
* in the `prj.conf` project file;
* in the `sample.yaml` sample configuration file.

The `sample.yaml` has also been simplified following advice in [this comment](https://github.com/zephyrproject-rtos/zephyr/pull/77614#issuecomment-2312133323).