### PR TITLE
driver: ssp: Refactor SSP driver to use SSP_IP_VER for version checks

### DIFF
--- a/drivers/dai/intel/ssp/dai-params-intel-ipc4.h
+++ b/drivers/dai/intel/ssp/dai-params-intel-ipc4.h
@@ -231,7 +231,7 @@ struct dai_intel_ipc4_ssp_config {
 	uint32_t ssc1;
 	uint32_t sscto;
 	uint32_t sspsp;
-#ifndef CONFIG_SOC_INTEL_ACE30_PTL
+#if SSP_IP_VER < SSP_IP_VER_3_0
 	uint32_t sstsa;
 	uint32_t ssrsa;
 #endif
@@ -239,7 +239,7 @@ struct dai_intel_ipc4_ssp_config {
 	uint32_t sspsp2;
 	uint32_t ssc3;
 	uint32_t ssioc;
-#ifdef CONFIG_SOC_INTEL_ACE30_PTL
+#if SSP_IP_VER > SSP_IP_VER_2_0
 	uint64_t ssmidytsa[I2SIPCMC];
 	uint64_t ssmodytsa[I2SOPCMC];
 #endif

--- a/drivers/dai/intel/ssp/ssp.c
+++ b/drivers/dai/intel/ssp/ssp.c
@@ -791,7 +791,7 @@ static void dai_ssp_pm_runtime_en_ssp_power(struct dai_intel_ssp *dp, uint32_t s
 	int ret;
 
 	LOG_INF("SSP%d", ssp_index);
-#if CONFIG_SOC_INTEL_ACE15_MTPM || CONFIG_SOC_SERIES_INTEL_ADSP_CAVS
+#if SSP_IP_VER < SSP_IP_VER_2_0
 	sys_write32(sys_read32(dai_ip_base(dp) + I2SLCTL_OFFSET) | I2SLCTL_SPA(ssp_index),
 		    dai_ip_base(dp) + I2SLCTL_OFFSET);
 
@@ -799,7 +799,7 @@ static void dai_ssp_pm_runtime_en_ssp_power(struct dai_intel_ssp *dp, uint32_t s
 	ret = dai_ssp_poll_for_register_delay(dai_ip_base(dp) + I2SLCTL_OFFSET,
 					      I2SLCTL_CPA(ssp_index), I2SLCTL_CPA(ssp_index),
 					      DAI_INTEL_SSP_MAX_SEND_TIME_PER_SAMPLE);
-#elif CONFIG_SOC_INTEL_ACE20_LNL || CONFIG_SOC_INTEL_ACE30_PTL
+#elif SSP_IP_VER > SSP_IP_VER_1_5
 	sys_write32(sys_read32(dai_hdamlssp_base(dp) + I2SLCTL_OFFSET) |
 			       I2SLCTL_SPA(ssp_index),
 			       dai_hdamlssp_base(dp) + I2SLCTL_OFFSET);
@@ -825,7 +825,7 @@ static void dai_ssp_pm_runtime_dis_ssp_power(struct dai_intel_ssp *dp, uint32_t 
 	int ret;
 
 	LOG_INF("SSP%d", ssp_index);
-#if CONFIG_SOC_INTEL_ACE15_MTPM || CONFIG_SOC_SERIES_INTEL_ADSP_CAVS
+#if SSP_IP_VER < SSP_IP_VER_2_0
 	sys_write32(sys_read32(dai_ip_base(dp) + I2SLCTL_OFFSET) & (~I2SLCTL_SPA(ssp_index)),
 		    dai_ip_base(dp) + I2SLCTL_OFFSET);
 
@@ -834,7 +834,7 @@ static void dai_ssp_pm_runtime_dis_ssp_power(struct dai_intel_ssp *dp, uint32_t 
 					      I2SLCTL_CPA(ssp_index), 0,
 					      DAI_INTEL_SSP_MAX_SEND_TIME_PER_SAMPLE);
 
-#elif CONFIG_SOC_INTEL_ACE20_LNL || CONFIG_SOC_INTEL_ACE30_PTL
+#elif SSP_IP_VER > SSP_IP_VER_1_5
 	sys_write32(sys_read32(dai_hdamlssp_base(dp) + I2SLCTL_OFFSET) & (~I2SLCTL_SPA(ssp_index)),
 			dai_hdamlssp_base(dp) + I2SLCTL_OFFSET);
 
@@ -872,7 +872,7 @@ static void dai_ssp_program_channel_map(struct dai_intel_ssp *dp,
 		/* Program HDA input stream parameters */
 		sys_write16((pcmsycm & 0xffff), reg_add);
 	}
-#elif defined(CONFIG_SOC_INTEL_ACE30_PTL)
+#elif SSP_IP_VER > SSP_IP_VER_2_0
 	const struct dai_intel_ipc4_ssp_configuration_blob *blob = spec_config;
 	uint64_t time_slot_map = 0;
 	uint16_t pcmsycm = cfg->link_config;
@@ -918,7 +918,7 @@ static void dai_ssp_empty_tx_fifo(struct dai_intel_ssp *dp)
 	 * SSSR_TNF is cleared when TX FIFO is empty or full,
 	 * so wait for set TNF then for TFL zero - order matter.
 	 */
-#ifdef CONFIG_SOC_INTEL_ACE30_PTL
+#if SSP_IP_VER > SSP_IP_VER_2_0
 	ret = dai_ssp_poll_for_register_delay(dai_base(dp) + SSMODyCS(dp->tdm_slot_group),
 							SSMODyCS_TNF, SSMODyCS_TNF,
 							DAI_INTEL_SSP_MAX_SEND_TIME_PER_SAMPLE);
@@ -947,7 +947,7 @@ static void dai_ssp_empty_tx_fifo(struct dai_intel_ssp *dp)
 	}
 }
 
-#ifdef CONFIG_SOC_INTEL_ACE30_PTL
+#if SSP_IP_VER > SSP_IP_VER_2_0
 static void ssp_empty_rx_fifo_on_start(struct dai_intel_ssp *dp)
 {
 	uint32_t retry = DAI_INTEL_SSP_RX_FLUSH_RETRY_MAX;
@@ -1173,7 +1173,7 @@ static int dai_ssp_bclk_prepare_enable(struct dai_intel_ssp *dp)
 	mdiv = ft[DAI_INTEL_SSP_DEFAULT_IDX].freq / ssp_plat_data->params.bclk_rate;
 #endif
 
-#ifndef CONFIG_SOC_INTEL_ACE30_PTL
+#if SSP_IP_VER < SSP_IP_VER_3_0
 	if (need_ecs) {
 		sscr0 |= SSCR0_ECS;
 	}
@@ -1706,7 +1706,7 @@ static int dai_ssp_set_config_tplg(struct dai_intel_ssp *dp, const struct dai_co
 	sys_write32(sspsp2, dai_base(dp) + SSPSP2);
 	sys_write32(ssioc, dai_base(dp) + SSIOC);
 	sys_write32(ssto, dai_base(dp) + SSTO);
-#ifdef CONFIG_SOC_INTEL_ACE30_PTL
+#if SSP_IP_VER > SSP_IP_VER_2_0
 	for (uint32_t idx = 0; idx < I2SIPCMC; ++idx) {
 		sys_write64(sstsa, dai_base(dp) + SSMODyTSA(idx));
 	}
@@ -1759,7 +1759,7 @@ clk:
 			ssp_plat_data->clk_active |= SSP_CLK_BCLK_ES_REQ;
 
 			if (enable_sse) {
-#ifdef CONFIG_SOC_INTEL_ACE30_PTL
+#if SSP_IP_VER > SSP_IP_VER_2_0
 				dai_ssp_update_bits(dp, SSMIDyCS(dp->tdm_slot_group),
 						    SSMIDyCS_RSRE, SSMIDyCS_RSRE);
 				dai_ssp_update_bits(dp, SSMODyCS(dp->tdm_slot_group),
@@ -1788,7 +1788,7 @@ clk:
 			LOG_INF("hw_free stage: releasing BCLK clocks for SSP%d...",
 					dp->dai_index);
 			if (ssp_plat_data->clk_active & SSP_CLK_BCLK_ACTIVE) {
-#ifdef CONFIG_SOC_INTEL_ACE30_PTL
+#if SSP_IP_VER > SSP_IP_VER_2_0
 				for (uint32_t idx = 0; idx < I2SOPCMC; ++idx) {
 					dai_ssp_update_bits(dp, SSMODyCS(idx), SSMODyCS_TSRE, 0);
 				}
@@ -1962,12 +1962,12 @@ static int dai_ssp_parse_tlv(struct dai_intel_ssp *dp, const uint8_t *aux_ptr, s
 		case SSP_LINK_CLK_SOURCE:
 #ifdef CONFIG_SOC_SERIES_INTEL_ADSP_ACE
 			link = (struct ssp_intel_link_ctl *)&aux_tlv->val;
-#if CONFIG_SOC_INTEL_ACE15_MTPM
+#if SSP_IP_VER < CONFIG_SOC_INTEL_ACE20_LNL
 			sys_write32((sys_read32(dai_ip_base(dp) + I2SLCTL_OFFSET) &
 				    ~I2CLCTL_MLCS(0x7)) |
 				    I2CLCTL_MLCS(link->clock_source), dai_ip_base(dp) +
 				    I2SLCTL_OFFSET);
-#elif CONFIG_SOC_INTEL_ACE20_LNL || CONFIG_SOC_INTEL_ACE30_PTL
+#elif SSP_IP_VER > SSP_IP_VER_1_5
 			sys_write32((sys_read32(dai_i2svss_base(dp) + I2SLCTL_OFFSET) &
 				    ~I2CLCTL_MLCS(0x7)) |
 				    I2CLCTL_MLCS(link->clock_source),
@@ -2043,7 +2043,7 @@ static void dai_ssp_set_reg_config(struct dai_intel_ssp *dp, const struct dai_co
 	uint32_t ssrsa = 0;
 	uint32_t ssc0 = regs->ssc0;
 
-#ifdef CONFIG_SOC_INTEL_ACE30_PTL
+#if SSP_IP_VER > SSP_IP_VER_2_0
 	sscr1 = regs->ssc1 & ~(SSCR1_RSVD21);
 #else
 	sscr1 = regs->ssc1 & ~(SSCR1_RSRE | SSCR1_TSRE);
@@ -2052,7 +2052,7 @@ static void dai_ssp_set_reg_config(struct dai_intel_ssp *dp, const struct dai_co
 #endif
 
 	LOG_INF("SSP%d configuration:", dp->dai_index);
-#ifndef CONFIG_SOC_INTEL_ACE30_PTL
+#if SSP_IP_VER < SSP_IP_VER_3_0
 	if (regs->sstsa & SSTSA_TXEN || regs->ssrsa & SSRSA_RXEN ||
 	    regs->ssc1 & (SSCR1_RSRE | SSCR1_TSRE)) {
 		LOG_INF(" Ignoring %s%s%s%sfrom blob",
@@ -2068,14 +2068,14 @@ static void dai_ssp_set_reg_config(struct dai_intel_ssp *dp, const struct dai_co
 	sys_write32(sscr1, dai_base(dp) + SSCR1);
 	sys_write32(regs->ssc2 | SSCR2_SFRMEN, dai_base(dp) + SSCR2); /* hardware specific flow */
 	sys_write32(regs->ssc2, dai_base(dp) + SSCR2);
-#ifndef CONFIG_SOC_INTEL_ACE30_PTL
+#if SSP_IP_VER < SSP_IP_VER_3_0
 	sys_write32(regs->ssc3, dai_base(dp) + SSCR3);
 #endif
 	sys_write32(regs->sspsp, dai_base(dp) + SSPSP);
 	sys_write32(regs->sspsp2, dai_base(dp) + SSPSP2);
 	sys_write32(regs->ssioc, dai_base(dp) + SSIOC);
 	sys_write32(regs->sscto, dai_base(dp) + SSTO);
-#ifdef CONFIG_SOC_INTEL_ACE30_PTL
+#if SSP_IP_VER > SSP_IP_VER_2_0
 	for (uint32_t idx = 0; idx < I2SIPCMC; ++idx) {
 		sys_write64(regs->ssmidytsa[idx], dai_base(dp) + SSMIDyTSA(idx));
 	}
@@ -2099,7 +2099,7 @@ static void dai_ssp_set_reg_config(struct dai_intel_ssp *dp, const struct dai_co
 	if (ssc0 & SSCR0_EDSS) {
 		ssp_plat_data->params.sample_valid_bits += 16;
 	}
-#ifdef CONFIG_SOC_INTEL_ACE30_PTL
+#if SSP_IP_VER > SSP_IP_VER_2_0
 	ssp_plat_data->params.tx_slots = regs->ssmodytsa[dp->tdm_slot_group];
 	ssp_plat_data->params.rx_slots = regs->ssmidytsa[dp->tdm_slot_group];
 #else
@@ -2120,7 +2120,7 @@ static int dai_ssp_set_config_blob(struct dai_intel_ssp *dp, const struct dai_co
 	struct dai_intel_ssp_plat_data *ssp_plat_data = dai_get_plat_data(dp);
 	int err;
 
-#ifdef CONFIG_SOC_INTEL_ACE30_PTL
+#if SSP_IP_VER > SSP_IP_VER_2_0
 	dp->tdm_slot_group = cfg->tdm_slot_group;
 #endif
 
@@ -2248,7 +2248,7 @@ static void dai_ssp_start(struct dai_intel_ssp *dp, int direction)
 
 
 	/* enable DMA */
-#if CONFIG_SOC_INTEL_ACE30_PTL
+#if SSP_IP_VER > SSP_IP_VER_2_0
 	if (direction == DAI_DIR_PLAYBACK) {
 		dai_ssp_update_bits(dp, SSMODyCS(dp->tdm_slot_group),
 				    SSMODyCS_TSRE, SSMODyCS_TSRE);
@@ -2318,7 +2318,7 @@ static void dai_ssp_stop(struct dai_intel_ssp *dp, int direction)
 	if (direction == DAI_DIR_CAPTURE &&
 	    dp->state[DAI_DIR_CAPTURE] != DAI_STATE_PRE_RUNNING) {
 		LOG_INF("SSP%d RX", dp->dai_index);
-#if CONFIG_SOC_INTEL_ACE30_PTL
+#if SSP_IP_VER > SSP_IP_VER_2_0
 		dai_ssp_update_bits(dp, SSMIDyCS(dp->tdm_slot_group), SSMIDyCS_RXEN, 0);
 		dai_ssp_update_bits(dp, SSMIDyCS(dp->tdm_slot_group), SSMIDyCS_RSRE, 0);
 #else
@@ -2333,7 +2333,7 @@ static void dai_ssp_stop(struct dai_intel_ssp *dp, int direction)
 	if (direction == DAI_DIR_PLAYBACK &&
 	    dp->state[DAI_DIR_PLAYBACK] != DAI_STATE_PRE_RUNNING) {
 		LOG_INF("SSP%d TX", dp->dai_index);
-#if CONFIG_SOC_INTEL_ACE30_PTL
+#if SSP_IP_VER > SSP_IP_VER_2_0
 		dai_ssp_update_bits(dp, SSMODyCS(dp->tdm_slot_group), SSMODyCS_TSRE, 0);
 		dai_ssp_empty_tx_fifo(dp);
 		dai_ssp_update_bits(dp, SSMODyCS(dp->tdm_slot_group), SSMODyCS_TXEN, 0);

--- a/drivers/dai/intel/ssp/ssp.h
+++ b/drivers/dai/intel/ssp/ssp.h
@@ -7,6 +7,22 @@
 #ifndef __INTEL_DAI_DRIVER_SSP_H__
 #define __INTEL_DAI_DRIVER_SSP_H__
 
+#define SSP_IP_VER_1_0 0x10000 /* cAVS */
+#define SSP_IP_VER_1_5 0x10500 /* MTL */
+#define SSP_IP_VER_2_0 0x20000 /* LNL */
+#define SSP_IP_VER_3_0 0x30000 /* PTL */
+
+/* SSP IP version defined by CONFIG_SOC*/
+#if defined(CONFIG_SOC_SERIES_INTEL_ADSP_CAVS)
+#define SSP_IP_VER SSP_IP_VER_1_0
+#elif defined(CONFIG_SOC_INTEL_ACE15_MTPM)
+#define SSP_IP_VER SSP_IP_VER_1_5
+#elif defined(CONFIG_SOC_INTEL_ACE20_LNL)
+#define SSP_IP_VER SSP_IP_VER_2_0
+#elif defined(CONFIG_SOC_INTEL_ACE30_PTL)
+#define SSP_IP_VER SSP_IP_VER_3_0
+#endif
+
 #include <stdint.h>
 #include <zephyr/drivers/dai.h>
 #include "dai-params-intel-ipc3.h"
@@ -116,7 +132,7 @@ struct dai_intel_ssp_plat_data {
 	uint32_t base;
 	uint32_t ip_base;
 	uint32_t shim_base;
-#if defined(CONFIG_SOC_INTEL_ACE20_LNL) || defined(CONFIG_SOC_INTEL_ACE30_PTL)
+#if SSP_IP_VER > SSP_IP_VER_1_5
 	uint32_t hdamlssp_base;
 	uint32_t i2svss_base;
 #endif


### PR DESCRIPTION
This commit updates the SSP driver to use the newly defined SSP_IP_VER macros for IP version checks instead of relying on CONFIG_SOC_* macros. The change ensures better readability and maintainability by centralizing the IP version definitions and comparisons.