### PR TITLE
dts: arm: st: h7: fix flash on M4 board targets

### DIFF
--- a/dts/arm/st/h7/stm32h745Xi_m4.dtsi
+++ b/dts/arm/st/h7/stm32h745Xi_m4.dtsi
@@ -10,11 +10,6 @@
 /delete-node/ &flash0;
 
 / {
-	chosen {
-		/* Flash controller support is not yet supported on M4 core */
-		/delete-property/ zephyr,flash-controller;
-	};
-
 	cpus {
 		/delete-node/ cpu@0;
 	};
@@ -23,6 +18,7 @@
 		flash-controller@52002000 {
 			flash1: flash@8100000 {
 				reg = <0x08100000 DT_SIZE_K(1024)>;
+				bank2-flash-size = <1024>;
 			};
 		};
 

--- a/dts/arm/st/h7/stm32h747Xi_m4.dtsi
+++ b/dts/arm/st/h7/stm32h747Xi_m4.dtsi
@@ -10,11 +10,6 @@
 /delete-node/ &flash0;
 
 / {
-	chosen {
-		/* Flash controller support is not yet supported on M4 core */
-		/delete-property/ zephyr,flash-controller;
-	};
-
 	cpus {
 		/delete-node/ cpu@0;
 	};
@@ -23,6 +18,7 @@
 		flash-controller@52002000 {
 			flash1: flash@8100000 {
 				reg = <0x08100000 DT_SIZE_K(1024)>;
+				bank2-flash-size = <1024>;
 			};
 		};
 

--- a/dts/arm/st/h7/stm32h755Xi_m4.dtsi
+++ b/dts/arm/st/h7/stm32h755Xi_m4.dtsi
@@ -18,6 +18,7 @@
 		flash-controller@52002000 {
 			flash1: flash@8100000 {
 				reg = <0x08100000 DT_SIZE_K(1024)>;
+				bank2-flash-size = <1024>;
 			};
 		};
 

--- a/samples/drivers/flash_shell/boards/stm32h745i_disco_stm32h745xx_m4.overlay
+++ b/samples/drivers/flash_shell/boards/stm32h745i_disco_stm32h745xx_m4.overlay
@@ -1,9 +1,0 @@
-/ {
-	chosen {
-		zephyr,flash-controller = &flash;
-	};
-};
-
-&flash1 {
-	bank2-flash-size = <1024>;
-};

--- a/samples/drivers/flash_shell/boards/stm32h747i_disco_stm32h747xx_m4.overlay
+++ b/samples/drivers/flash_shell/boards/stm32h747i_disco_stm32h747xx_m4.overlay
@@ -1,3 +1,0 @@
-&flash1 {
-	bank2-flash-size = <1024>;
-};

--- a/samples/drivers/flash_shell/sample.yaml
+++ b/samples/drivers/flash_shell/sample.yaml
@@ -8,13 +8,8 @@ tests:
       - shell
     filter: CONFIG_FLASH_HAS_DRIVER_ENABLED
     platform_exclude:
-      - nucleo_h745zi_q/stm32h745xx/m4
       - stm32h7s78_dk
       - gd32f350r_eval
-      - arduino_portenta_h7/stm32h747xx/m4
-      - arduino_nicla_vision/stm32h747xx/m4
-      - arduino_giga_r1/stm32h747xx/m4
-      - nucleo_h755zi_q/stm32h755xx/m4
     harness: keyboard
     min_ram: 12
     integration_platforms:

--- a/tests/subsys/mgmt/mcumgr/fs_mgmt_hash_supported/testcase.yaml
+++ b/tests/subsys/mgmt/mcumgr/fs_mgmt_hash_supported/testcase.yaml
@@ -11,18 +11,11 @@ common:
   integration_platforms:
     - native_sim
   platform_exclude:
-    - arduino_giga_r1/stm32h747xx/m4
-    - arduino_nicla_vision/stm32h747xx/m4
-    - arduino_portenta_h7/stm32h747xx/m4
     - lpcxpresso51u68
-    - nucleo_h745zi_q/stm32h745xx/m4
-    - nucleo_h755zi_q/stm32h755xx/m4
-    - stm32h747i_disco/stm32h747xx/m4
     - lpcxpresso55s69/lpc55s69/cpu1
     - mpfs_icicle
     - mpfs_icicle/polarfire/smp
     - apollo4p_evb
-    - stm32h745i_disco/stm32h745xx/m4
     - cyw920829m2evk_02
 tests:
   mgmt.mcumgr.fs.mgmt.hash.supported.crc32:


### PR DESCRIPTION
The flash controller is nowadays supported on the M4 core.
Add the bank2-flash-size property to the board definitions as required by the STM32 H7 flash driver.
