### PR TITLE
dts: arm: renesas: ra4: Defining MSTP regs in devicetree

### DIFF
--- a/dts/arm/renesas/ra/ra4/r7fa4e2b93cfm.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4e2b93cfm.dtsi
@@ -43,6 +43,9 @@
 	};
 
 	clocks: clocks {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
 		xtal: clock-xtal {
 			compatible = "renesas,ra-cgc-external-clock";
 			clock-frequency = <DT_FREQ_M(20)>;
@@ -86,8 +89,12 @@
 			status = "disabled";
 		};
 
-		pclkblock: pclkblock {
+		pclkblock: pclkblock@40084000 {
 			compatible = "renesas,ra-cgc-pclk-block";
+			reg = <0x40084000 4>, <0x40084004 4>, <0x40084008 4>,
+			      <0x4008400c 4>, <0x40084010 4>;
+			reg-names = "MSTPA", "MSTPB","MSTPC",
+				    "MSTPD", "MSTPE";
 			#clock-cells = <0>;
 			sysclock-src = <RA_CLOCK_SOURCE_PLL>;
 			status = "okay";

--- a/dts/arm/renesas/ra/ra4/r7fa4m2ax.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4m2ax.dtsi
@@ -91,7 +91,10 @@
 		};
 	};
 
-    clocks: clocks {
+	clocks: clocks {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
 		xtal: clock-xtal {
 			compatible = "renesas,ra-cgc-external-clock";
 			clock-frequency = <DT_FREQ_M(24)>;
@@ -146,8 +149,12 @@
 			status = "disabled";
 		};
 
-		pclkblock: pclkblock {
+		pclkblock: pclkblock@40084000 {
 			compatible = "renesas,ra-cgc-pclk-block";
+			reg = <0x40084000 4>, <0x40084004 4>, <0x40084008 4>,
+			      <0x4008400c 4>, <0x40084010 4>;
+			reg-names = "MSTPA", "MSTPB","MSTPC",
+				    "MSTPD", "MSTPE";
 			#clock-cells = <0>;
 			sysclock-src = <RA_CLOCK_SOURCE_PLL>;
 			status = "okay";

--- a/dts/arm/renesas/ra/ra4/r7fa4m3ax.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4m3ax.dtsi
@@ -101,7 +101,10 @@
 		};
 	};
 
-    clocks: clocks {
+	clocks: clocks {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
 		xtal: clock-xtal {
 			compatible = "renesas,ra-cgc-external-clock";
 			clock-frequency = <DT_FREQ_M(24)>;
@@ -154,8 +157,12 @@
 			status = "disabled";
 		};
 
-		pclkblock: pclkblock {
+		pclkblock: pclkblock@40084000 {
 			compatible = "renesas,ra-cgc-pclk-block";
+			reg = <0x40084000 4>, <0x40084004 4>, <0x40084008 4>,
+			      <0x4008400c 4>, <0x40084010 4>;
+			reg-names = "MSTPA", "MSTPB","MSTPC",
+				    "MSTPD", "MSTPE";
 			#clock-cells = <0>;
 			sysclock-src = <RA_CLOCK_SOURCE_PLL>;
 			status = "okay";

--- a/dts/arm/renesas/ra/ra4/r7fa4w1ad2cng.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4w1ad2cng.dtsi
@@ -37,6 +37,9 @@
 	};
 
 	clocks: clocks {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
 		xtal: clock-xtal {
 			compatible = "renesas,ra-cgc-external-clock";
 			clock-frequency = <DT_FREQ_M(8)>;
@@ -80,8 +83,12 @@
 			status = "disabled";
 		};
 
-		pclkblock: pclkblock {
+		pclkblock: pclkblock@4001e01c {
 			compatible = "renesas,ra-cgc-pclk-block";
+			reg = <0x4001e01c 4>, <0x40047000 4>, <0x40047004 4>,
+			      <0x40047008 4>;
+			reg-names = "MSTPA", "MSTPB","MSTPC",
+				    "MSTPD";
 			#clock-cells = <0>;
 			sysclock-src = <RA_CLOCK_SOURCE_HOCO>;
 			status = "okay";


### PR DESCRIPTION
Add a definition for RA4, which was not included in #76820.