### PR TITLE
west.yaml: pickup the updates in hal_nxp for FlexCAN on S32Z27

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -198,7 +198,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 30bdef6d5a304abfa95cc19af4d3ba699aac456e
+      revision: f91541b8a4c39395a4ab9445fee69eeeaa050d6c
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
This PR is picking up the updates in hal_nxp for FlexCAN support on S32Z27 which is missing from https://github.com/zephyrproject-rtos/zephyr/pull/77138