### PR TITLE
manifest: Update nRF hw models to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -300,7 +300,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 3ede17158a9fe85c160e0384c0ad0306e24ee47e
+      revision: 6e70c2dc5d4c67c4da5913b2969c0774b27f0cd0
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: 76d2168bcdfcd23a9a7dce8c21f2083b90a1e60a


### PR DESCRIPTION
Update the HW models module to:
da5f426e7f3aff192a93e5874146260d4dcd943e

Including the following:
* 6e70c2d hal: hack: Support also AAR, CCM & ECB for 54L
* da5f426 Tests for AAR, CCM & ECB
* 03b8461 54: Added AAR, CCM & ECB models
* 2ebcc88 Add EVDMA model
* 71913e3 54: Enable AAR hal build
* 0f3a04b BLECrypt_if: Add new interfacing for latest libCrypto

----
Note this updated HW models will try to use the v1.4 libCrypto (which comes with [bsim v2.3](https://github.com/zephyrproject-rtos/zephyr/pull/77690)), but if they can't they will fallback to the previous API and just produce a harmless warning at startup. Lacking the updated libCrypto, one will only really note the difference with the 54L models, which would fail to do the CCM encryption in some 802.15.4 usecases. Nonetheless users are recommended to update.