### PR TITLE
ci: do not run twister on some script changes

### DIFF
--- a/scripts/ci/twister_ignore.txt
+++ b/scripts/ci/twister_ignore.txt
@@ -39,6 +39,9 @@ doc/*
 # twister.
 scripts/ci/test_plan.py
 scripts/ci/twister_ignore.txt
+scripts/ci/check_compliance.py
+scripts/ci/errno.py
+scripts/ci/upload_test_results_es.py
 scripts/ci/what_changed.py
 scripts/ci/version_mgr.py
 scripts/ci/stats/*


### PR DESCRIPTION
Do not run twister on some script changes that do not require a twister
run.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
