### PR TITLE
Bluetooth: BAP: Broadcast sync fail receive state bis sync value fixed

### DIFF
--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -91,7 +91,9 @@ enum bt_bap_bass_att_err {
  * Value indicating that the Broadcast Assistant has no preference to which BIS
  * the Scan Delegator syncs to
  */
-#define BT_BAP_BIS_SYNC_NO_PREF                0xFFFFFFFF
+#define BT_BAP_BIS_SYNC_NO_PREF 0xFFFFFFFF
+/** BIS sync value indicating that the BIG sync has failed for any reason */
+#define BT_BAP_BIS_SYNC_FAILED  0xFFFFFFFF
 
 /** Endpoint states */
 enum bt_bap_ep_state {
@@ -305,7 +307,11 @@ struct bt_bap_scan_delegator_recv_state {
 	/** Number of subgroups */
 	uint8_t num_subgroups;
 
-	/** Subgroup specific information */
+	/** Subgroup specific information
+	 *
+	 * If the @ref bt_bap_bass_subgroup.bis_sync value is @ref BT_BAP_BIS_SYNC_FAILED then it
+	 * indicates that the BIG sync failed.
+	 */
 	struct bt_bap_bass_subgroup subgroups[CONFIG_BT_BAP_BASS_MAX_SUBGROUPS];
 };
 
@@ -2351,7 +2357,11 @@ struct bt_bap_broadcast_assistant_add_src_param {
 	/** Number of subgroups */
 	uint8_t num_subgroups;
 
-	/** Pointer to array of subgroups */
+	/** Pointer to array of subgroups
+	 *
+	 * The @ref bt_bap_bass_subgroup.bis_sync value can be set to BT_BAP_BIS_SYNC_NO_PREF to
+	 * let the broadcast sink decide which BIS to synchronize to.
+	 */
 	struct bt_bap_bass_subgroup *subgroups;
 };
 

--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -170,12 +170,13 @@ static void update_recv_state_big_cleared(const struct bt_bap_broadcast_sink *si
 		mod_src_param.encrypt_state = recv_state->encrypt_state;
 	}
 
-	/* BIS syncs will be automatically cleared since the mod_src_param
-	 * struct is 0-initialized
-	 *
-	 * Since the metadata_len is also 0, then the metadata won't be
-	 * modified by the operation either.
-	 */
+	if (reason != BT_HCI_ERR_LOCALHOST_TERM_CONN) {
+		for (uint8_t i = 0U; i < recv_state->num_subgroups; i++) {
+			mod_src_param.subgroups[i].bis_sync = BT_BAP_BIS_SYNC_FAILED;
+		}
+	}
+
+	/* Since the metadata_len is 0 then the metadata won't be modified by the operation either*/
 
 	/* Copy existing unchanged data */
 	mod_src_param.num_subgroups = recv_state->num_subgroups;

--- a/subsys/bluetooth/audio/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/bap_scan_delegator.c
@@ -1419,9 +1419,8 @@ static bool valid_bt_bap_scan_delegator_mod_src_param(
 	for (uint8_t i = 0U; i < param->num_subgroups; i++) {
 		const struct bt_bap_bass_subgroup *subgroup = &param->subgroups[i];
 
-		if (subgroup->bis_sync == BT_BAP_BIS_SYNC_NO_PREF ||
-		    !bis_syncs_unique_or_no_pref(subgroup->bis_sync,
-						 aggregated_bis_syncs)) {
+		if (subgroup->bis_sync != BT_BAP_BIS_SYNC_FAILED &&
+		    !bis_syncs_unique_or_no_pref(subgroup->bis_sync, aggregated_bis_syncs)) {
 			LOG_DBG("Invalid BIS sync: %u", subgroup->bis_sync);
 
 			return false;
@@ -1483,7 +1482,8 @@ int bt_bap_scan_delegator_mod_src(const struct bt_bap_scan_delegator_mod_src_par
 		const uint32_t bis_sync = param->subgroups[i].bis_sync;
 		const uint32_t bis_sync_requested = internal_state->requested_bis_sync[i];
 
-		if (!bits_subset_of(bis_sync, bis_sync_requested)) {
+		if (bis_sync != BT_BAP_BIS_SYNC_FAILED &&
+		    !bits_subset_of(bis_sync, bis_sync_requested)) {
 			LOG_DBG("Subgroup[%d] invalid bis_sync value %x for %x",
 				i, bis_sync, bis_sync_requested);
 

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_assistant_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_assistant_test.c
@@ -147,6 +147,16 @@ static void bap_broadcast_assistant_recv_state_cb(
 			FAIL("Bad code is not what we sent");
 			return;
 		}
+
+		for (uint8_t i = 0; i < state->num_subgroups; i++) {
+			const struct bt_bap_bass_subgroup *subgroup = &state->subgroups[i];
+
+			if (subgroup->bis_sync != BT_BAP_BIS_SYNC_FAILED) {
+				FAIL("Invalid BIS sync value 0x%08X for failed sync",
+				     subgroup->bis_sync);
+				return;
+			}
+		}
 	}
 
 	for (uint8_t i = 0; i < state->num_subgroups; i++) {


### PR DESCRIPTION
In the case that a broadcast sync fails for any reason, we need to
set the BIS_Sync value for all subgroups to 0xFFFFFFFF
(BT_BAP_BIS_SYNC_FAILED) as per the BAP spec.
   
This commit adds a new define for this and modifies
both the scan delegator and broadcast sink to support this.
    
The change is validated by a modification to the broadcast
assistant test that verifies that the value is set in the
case of an invalid broadcast code (which indicates a
failed BIG sync).

fixes https://github.com/zephyrproject-rtos/zephyr/issues/77414