### PR TITLE
add simics as a simulation platform

### DIFF
--- a/boards/common/simics.board.cmake
+++ b/boards/common/simics.board.cmake
@@ -1,0 +1,5 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+board_finalize_emu_args(simics)

--- a/boards/intel/ish/board.cmake
+++ b/boards/intel/ish/board.cmake
@@ -1,4 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
+set(SUPPORTED_EMU_PLATFORMS simics)
+
+if(CONFIG_BOARD_INTEL_ISH_5_8_0)
+  board_emu_args(simics "project=$ENV{SIMICS_PROJECT}")
+  board_emu_args(simics "zephyr_elf=${APPLICATION_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME}")
+  board_emu_args(simics "zephyr_start_address=${CONFIG_SRAM_BASE_ADDRESS}")
+  include(${ZEPHYR_BASE}/boards/common/simics.board.cmake)
+endif()
+
 board_set_flasher_ifnset(misc-flasher)
 board_finalize_runner_args(misc-flasher)

--- a/boards/intel/ish/intel_ish_5_8_0.yaml
+++ b/boards/intel/ish/intel_ish_5_8_0.yaml
@@ -5,6 +5,8 @@ arch: x86
 toolchain:
   - zephyr
 ram: 640
+simulation: simics
+simulation_exec: simics
 supported:
   - serial
 testing:

--- a/cmake/emu/simics.cmake
+++ b/cmake/emu/simics.cmake
@@ -1,0 +1,30 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+find_program(
+  SIMICS
+  NAMES simics
+  )
+
+zephyr_get(SIMICS_SCRIPT_PATH SYSBUILD GLOBAL)
+if(SIMICS_SCRIPT_PATH)
+  set(SIMICS_SCRIPT ${SIMICS_SCRIPT_PATH})
+else()
+  set(SIMICS_SCRIPT ${BOARD_DIR}/support/${BOARD}.simics)
+endif()
+
+get_property(SIMICS_ARGS GLOBAL PROPERTY "BOARD_EMU_ARGS_simics")
+
+add_custom_target(run_simics
+  COMMAND
+  ${SIMICS}
+  -no-gui
+  -no-win
+  ${SIMICS_SCRIPT}
+  ${SIMICS_ARGS}
+  -e run
+  WORKING_DIRECTORY ${APPLICATION_BINARY_DIR}
+  DEPENDS ${logical_target_for_zephyr_elf}
+  USES_TERMINAL
+  )

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -44,7 +44,7 @@ except ImportError as capture_error:
 logger = logging.getLogger('twister')
 logger.setLevel(logging.DEBUG)
 
-SUPPORTED_SIMS = ["mdb-nsim", "nsim", "renode", "qemu", "tsim", "armfvp", "xt-sim", "native", "custom"]
+SUPPORTED_SIMS = ["mdb-nsim", "nsim", "renode", "qemu", "tsim", "armfvp", "xt-sim", "native", "custom", "simics"]
 SUPPORTED_SIMS_IN_PYTEST = ['native', 'qemu']
 
 

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -269,7 +269,7 @@ class TestInstance:
         if self.testsuite.harness == 'pytest':
             target_ready = bool(filter == 'runnable' or self.platform.simulation in SUPPORTED_SIMS_IN_PYTEST)
 
-        SUPPORTED_SIMS_WITH_EXEC = ['nsim', 'mdb-nsim', 'renode', 'tsim', 'native']
+        SUPPORTED_SIMS_WITH_EXEC = ['nsim', 'mdb-nsim', 'renode', 'tsim', 'native', 'simics']
         if filter != 'runnable' and \
                 self.platform.simulation in SUPPORTED_SIMS_WITH_EXEC and \
                 self.platform.simulation_exec:


### PR DESCRIPTION
- cmake: Add board emulator extension functions
- cmake: add simics emu support
- twister: add simics as supported simulator
- intel_ish: add support for running with simics
