### PR TITLE
tests: Bluetooth: Audio: Add -RealEncryption=1 to all bsim tests

### DIFF
--- a/tests/bsim/bluetooth/audio/test_scripts/bap_bass_client_sync.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_bass_client_sync.sh
@@ -15,14 +15,15 @@ printf "\n\n======== Running BASS Client Sync =========\n\n"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=bap_scan_delegator_client_sync \
-  -rs=24 -D=3
+  -RealEncryption=1 -rs=24 -D=3
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 \
-  -testid=bap_broadcast_assistant_client_sync -rs=46 -D=3
+  -testid=bap_broadcast_assistant_client_sync -RealEncryption=1 -rs=46 -D=3
 
   Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=2 -testid=bass_broadcaster -rs=69 -D=3
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=2 -testid=bass_broadcaster \
+  -RealEncryption=1 -rs=69 -D=3
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -D=3 \

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_bass_server_sync_client_rem.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_bass_server_sync_client_rem.sh
@@ -14,14 +14,15 @@ printf "\n\n======== Running BASS Server Sync Client Remove =========\n\n"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 \
-  -testid=bap_scan_delegator_server_sync_client_rem -rs=24 -D=3
+  -testid=bap_scan_delegator_server_sync_client_rem -RealEncryption=1 -rs=24 -D=3
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 \
-  -testid=bap_broadcast_assistant_server_sync_client_rem -rs=46 -D=3
+  -testid=bap_broadcast_assistant_server_sync_client_rem -RealEncryption=1 -rs=46 -D=3
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=2 -testid=bass_broadcaster -rs=69 -D=3
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=2 -testid=bass_broadcaster \
+  -RealEncryption=1 -rs=69 -D=3
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -D=3 \

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_bass_server_sync_server_rem.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_bass_server_sync_server_rem.sh
@@ -13,14 +13,15 @@ printf "\n\n======== Running BASS Server Sync Server Remove =========\n\n"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 \
-  -testid=bap_scan_delegator_server_sync_server_rem -rs=24 -D=3
+  -testid=bap_scan_delegator_server_sync_server_rem -RealEncryption=1 -rs=24 -D=3
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 \
-  -testid=bap_broadcast_assistant_server_sync_server_rem -rs=46 -D=3
+  -testid=bap_broadcast_assistant_server_sync_server_rem -RealEncryption=1 -rs=46 -D=3
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=2 -testid=bass_broadcaster -rs=69 -D=3
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=2 -testid=bass_broadcaster \
+  -RealEncryption=1 -rs=69 -D=3
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -D=3 \

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio.sh
@@ -16,11 +16,13 @@ printf "\n\n======== Broadcaster test =========\n\n"
 SIMULATION_ID="broadcaster"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=broadcast_source -rs=23 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=broadcast_source \
+  -RealEncryption=1 -rs=23 -D=2
 
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=broadcast_sink -rs=27 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=broadcast_sink \
+  -RealEncryption=1 -rs=27 -D=2
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
@@ -33,12 +35,13 @@ printf "\n\n======== Broadcaster sink disconnect test =========\n\n"
 SIMULATION_ID="broadcaster_sink_disconnect"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=broadcast_source -rs=23 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=broadcast_source \
+  -RealEncryption=1 -rs=23 -D=2
 
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 \
-  -testid=broadcast_sink_disconnect -rs=27 -D=2
+  -testid=broadcast_sink_disconnect -RealEncryption=1 -rs=27 -D=2
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_assistant.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_assistant.sh
@@ -16,15 +16,15 @@ printf "\n\n======== Running BAP Broadcast Audio Assistant =========\n\n"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 \
-  -testid=broadcast_sink_with_assistant -rs=24 -D=3
+  -testid=broadcast_sink_with_assistant -RealEncryption=1 -rs=24 -D=3
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 \
-  -testid=bap_broadcast_assistant_client_sync -rs=46 -D=3
+  -testid=bap_broadcast_assistant_client_sync -RealEncryption=1 -rs=46 -D=3
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=2 \
-  -testid=broadcast_source -rs=69 -D=3
+  -testid=broadcast_source -RealEncryption=1 -rs=69 -D=3
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -D=3 -sim_length=60e6 $@

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_unicast_audio.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_unicast_audio.sh
@@ -14,10 +14,12 @@ cd ${BSIM_OUT_PATH}/bin
 printf "\n\n======== Unicast Audio test =========\n\n"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=unicast_client -rs=23 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=unicast_client \
+  -RealEncryption=1 -rs=23 -D=2
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=unicast_server -rs=28 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=unicast_server \
+  -RealEncryption=1 -rs=28 -D=2
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_unicast_audio_acl_disconnect.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_unicast_audio_acl_disconnect.sh
@@ -14,10 +14,12 @@ cd ${BSIM_OUT_PATH}/bin
 printf "\n\n======== Unicast Audio ACL Disconnect test =========\n\n"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=unicast_client_acl_disconnect -rs=23 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=unicast_client_acl_disconnect \
+  -RealEncryption=1 -rs=23 -D=2
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=unicast_server_acl_disconnect -rs=28 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=unicast_server_acl_disconnect \
+  -RealEncryption=1 -rs=28 -D=2
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_unicast_client_async_group.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_unicast_client_async_group.sh
@@ -14,7 +14,8 @@ cd ${BSIM_OUT_PATH}/bin
 printf "\n\n======== BAP Unicast Client Aync Group parameters test =========\n\n"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=unicast_client_async_group -rs=23 -D=1
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=unicast_client_async_group \
+  -RealEncryption=1 -rs=23 -D=1
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast.sh
@@ -14,10 +14,12 @@ cd ${BSIM_OUT_PATH}/bin
 printf "\n\n======== Running CAP broadcast test =========\n\n"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=cap_initiator_broadcast -rs=46 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=cap_initiator_broadcast \
+  -RealEncryption=1 -rs=46 -D=2
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=cap_acceptor_broadcast -rs=23 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=cap_acceptor_broadcast \
+  -RealEncryption=1 -rs=23 -D=2
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast_reception.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_broadcast_reception.sh
@@ -17,15 +17,15 @@ printf "\n\n======== Running CAP commander broadcast reception start and stop te
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=cap_commander_broadcast_reception \
-  -rs=46 -D=${NR_OF_DEVICES}
+  -RealEncryption=1 -rs=46 -D=${NR_OF_DEVICES}
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=broadcast_source \
-  -rs=23 -D=${NR_OF_DEVICES}
+  -RealEncryption=1 -rs=23 -D=${NR_OF_DEVICES}
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=2 -testid=cap_acceptor_broadcast_reception \
-  -rs=69 -D=${NR_OF_DEVICES}
+  -RealEncryption=1 -rs=69 -D=${NR_OF_DEVICES}
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_capture_and_render.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_capture_and_render.sh
@@ -15,15 +15,15 @@ printf "\n\n======== Running CAP commander capture and rendering test =========\
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=cap_commander_capture_and_render \
-  -rs=46 -D=3
+  -RealEncryption=1 -rs=46 -D=3
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=cap_acceptor_capture_and_render \
-  -rs=23 -D=3
+  -RealEncryption=1 -rs=23 -D=3
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=2 -testid=cap_acceptor_capture_and_render \
-  -rs=69 -D=3
+  -RealEncryption=1 -rs=69 -D=3
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast.sh
@@ -14,10 +14,12 @@ cd ${BSIM_OUT_PATH}/bin
 printf "\n\n======== Running CAP unicast test =========\n\n"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=cap_initiator_unicast -rs=46 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=cap_initiator_unicast \
+  -RealEncryption=1 -rs=46 -D=2
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=cap_acceptor_unicast -rs=23 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=cap_acceptor_unicast \
+  -RealEncryption=1 -rs=23 -D=2
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_inval.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_inval.sh
@@ -14,10 +14,12 @@ cd ${BSIM_OUT_PATH}/bin
 printf "\n\n======== Running CAP unicast test =========\n\n"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=cap_initiator_unicast_inval -rs=46 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=cap_initiator_unicast_inval \
+  -RealEncryption=1 -rs=46 -D=2
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=cap_acceptor_unicast -rs=23 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=cap_acceptor_unicast \
+  -RealEncryption=1 -rs=23 -D=2
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_timeout.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_timeout.sh
@@ -14,10 +14,12 @@ cd ${BSIM_OUT_PATH}/bin
 printf "\n\n======== Running CAP unicast timeout test =========\n\n"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=cap_initiator_unicast_timeout -rs=46 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=cap_initiator_unicast_timeout \
+  -RealEncryption=1 -rs=46 -D=2
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=cap_acceptor_unicast_timeout -rs=23 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=cap_acceptor_unicast_timeout \
+  -RealEncryption=1 -rs=23 -D=2
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \

--- a/tests/bsim/bluetooth/audio/test_scripts/has.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/has.sh
@@ -14,10 +14,12 @@ cd ${BSIM_OUT_PATH}/bin
 printf "\n\n======== Running HAS main (API) test =========\n\n"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=has -rs=24 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=has \
+  -RealEncryption=1 -rs=24 -D=2
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=has_client -rs=46 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=has_client \
+  -RealEncryption=1 -rs=46 -D=2
 
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
   -D=2 -sim_length=60e6 $@

--- a/tests/bsim/bluetooth/audio/test_scripts/has_offline.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/has_offline.sh
@@ -14,10 +14,12 @@ cd ${BSIM_OUT_PATH}/bin
 printf "\n\n Running Preset Changed Offline Behavior test \n\n"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=has_offline_behavior -rs=24 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=has_offline_behavior \
+  -RealEncryption=1 -rs=24 -D=2
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=has_client_offline_behavior -rs=46 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=has_client_offline_behavior \
+  -RealEncryption=1 -rs=46 -D=2
 
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
   -D=2 -sim_length=60e6 $@

--- a/tests/bsim/bluetooth/audio/test_scripts/ias.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/ias.sh
@@ -14,10 +14,12 @@ cd ${BSIM_OUT_PATH}/bin
 printf "\n\n======== Running IAS main (API) test =========\n\n"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=ias -rs=23 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=ias \
+  -RealEncryption=1 -rs=23 -D=2
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=ias_client -rs=6 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=ias_client \
+  -RealEncryption=1 -rs=6 -D=2
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \

--- a/tests/bsim/bluetooth/audio/test_scripts/mcs_mcc.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/mcs_mcc.sh
@@ -15,10 +15,12 @@ cd ${BSIM_OUT_PATH}/bin
 printf "\n\n======== Running MCS  and MCC test =========\n\n"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=mcc -rs=46 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=mcc \
+  -RealEncryption=1 -rs=46 -D=2
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=mcs -rs=23 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=mcs \
+  -RealEncryption=1 -rs=23 -D=2
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \

--- a/tests/bsim/bluetooth/audio/test_scripts/media_controller.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/media_controller.sh
@@ -14,7 +14,8 @@ cd ${BSIM_OUT_PATH}/bin
 printf "\n\n======== Running media controller local_player test =========\n\n"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=media_controller_local_player -rs=23 -D=1
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=media_controller_local_player \
+  -RealEncryption=1 -rs=23 -D=1
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
@@ -25,10 +26,12 @@ wait_for_background_jobs
 printf "\n\n======== Running media controller remote_player test =========\n\n"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=media_controller_remote_player -rs=46 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=media_controller_remote_player \
+  -RealEncryption=1 -rs=46 -D=2
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=media_controller_server -rs=23 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=media_controller_server \
+  -RealEncryption=1 -rs=23 -D=2
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \

--- a/tests/bsim/bluetooth/audio/test_scripts/micp.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/micp.sh
@@ -14,7 +14,8 @@ cd ${BSIM_OUT_PATH}/bin
 printf "\n\n==== Running MICP Microphone Device Only (API) test ====n\n"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=micp_mic_dev_only -rs=23 -D=1
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=micp_mic_dev_only -RealEncryption=1 \
+  -rs=23 -D=1
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
@@ -25,10 +26,12 @@ wait_for_background_jobs
 printf "\n\n==== Running MICP Microphone Device and MICP Microphone Controller test ====n\n"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=micp_mic_dev -rs=23 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=micp_mic_dev -RealEncryption=1 \
+  -rs=23 -D=2
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=micp_mic_ctlr -rs=46 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=micp_mic_ctlr \
+  -RealEncryption=1 -rs=46 -D=2
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \

--- a/tests/bsim/bluetooth/audio/test_scripts/pacs_notify.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/pacs_notify.sh
@@ -15,10 +15,12 @@ cd ${BSIM_OUT_PATH}/bin
 printf "\n\n======== Running PACS Notify test =========\n\n"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=pacs_notify_server -rs=24 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=pacs_notify_server \
+  -RealEncryption=1 -rs=24 -D=2
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=pacs_notify_client -rs=46 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=pacs_notify_client \
+  -RealEncryption=1 -rs=46 -D=2
 
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
   -D=2 -sim_length=60e6 $@

--- a/tests/bsim/bluetooth/audio/test_scripts/pbp.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/pbp.sh
@@ -16,10 +16,12 @@ printf "\n\n======== Public Broadcaster test =========\n\n"
 SIMULATION_ID="pbp_broadcaster"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=public_broadcast_source -rs=27 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=public_broadcast_source \
+  -RealEncryption=1 -rs=27 -D=2
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=public_broadcast_sink -rs=27 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=public_broadcast_sink \
+  -RealEncryption=1 -rs=27 -D=2
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \

--- a/tests/bsim/bluetooth/audio/test_scripts/tbs.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/tbs.sh
@@ -15,7 +15,8 @@ cd ${BSIM_OUT_PATH}/bin
 printf "\n\n==== Running TBS Server Only (API) test ====n\n"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=tbs_test_server_only -rs=23 -D=1
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=tbs_test_server_only \
+  -RealEncryption=1 -rs=23 -D=1
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
@@ -26,10 +27,12 @@ wait_for_background_jobs
 printf "\n\n==== Running TBS server & client tests ====n\n"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=tbs -rs=23 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=tbs \
+  -RealEncryption=1 -rs=23 -D=2
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=tbs_client -rs=6 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=tbs_client \
+  -RealEncryption=1 -rs=6 -D=2
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \

--- a/tests/bsim/bluetooth/audio/test_scripts/tmap.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/tmap.sh
@@ -14,10 +14,12 @@ cd ${BSIM_OUT_PATH}/bin
 printf "\n\n======== Running TMAP client & server test =========\n\n"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=tmap_client -rs=24 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=tmap_client \
+  -RealEncryption=1 -rs=24 -D=2
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=tmap_server -rs=23 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=tmap_server \
+  -RealEncryption=1 -rs=23 -D=2
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \

--- a/tests/bsim/bluetooth/audio/test_scripts/vcp.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/vcp.sh
@@ -14,7 +14,8 @@ cd ${BSIM_OUT_PATH}/bin
 printf "\n\n======== Running VCP Volume Renderer standalone (API) test =========\n\n"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=vcp_vol_rend_standalone -rs=23 -D=1
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=vcp_vol_rend_standalone \
+  -RealEncryption=1 -rs=23 -D=1
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
@@ -25,10 +26,12 @@ wait_for_background_jobs
 printf "\n\n======== Running VCP Volume Renderer and VCP Volume Controller test =========\n\n"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=vcp_vol_rend -rs=23 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=vcp_vol_rend \
+  -RealEncryption=1 -rs=23 -D=2
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
-  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=vcp_vol_ctlr -rs=46 -D=2
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=vcp_vol_ctlr \
+  -RealEncryption=1 -rs=46 -D=2
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \


### PR DESCRIPTION
Several BSIM tests did not enable -RealEncryption=1. Since everything in LE Audio effectively requires encryption, we should enable it, as we have seen a few tests passing before that shouldn't, because they didn't set -RealEncryption=1.