### PR TITLE
bluetooth: controller: Use CONFIG_BT_LLL_VENDOR_* instead of CONFIG_SOC_COMPATIBLE_*

### DIFF
--- a/subsys/bluetooth/controller/CMakeLists.txt
+++ b/subsys/bluetooth/controller/CMakeLists.txt
@@ -182,13 +182,13 @@ zephyr_library_include_directories_ifdef(
   )
 
 zephyr_library_include_directories_ifdef(
-  CONFIG_SOC_COMPATIBLE_NRF
+  CONFIG_BT_LLL_VENDOR_NORDIC
   ll_sw/nordic
   ll_sw/nordic/hci
   )
 
 zephyr_library_include_directories_ifdef(
-  CONFIG_SOC_OPENISA_RV32M1
+  CONFIG_BT_LLL_VENDOR_OPENISA
   ll_sw/openisa
   ll_sw/openisa/hci
   )
@@ -199,12 +199,12 @@ add_subdirectory_ifdef(
   )
 
 add_subdirectory_ifdef(
-  CONFIG_SOC_COMPATIBLE_NRF
+  CONFIG_BT_LLL_VENDOR_NORDIC
   ll_sw/nordic
   )
 
 add_subdirectory_ifdef(
-  CONFIG_SOC_OPENISA_RV32M1
+  CONFIG_BT_LLL_VENDOR_OPENISA
   ll_sw/openisa
   )
 


### PR DESCRIPTION
CONFIG_SOC_COMPATIBLE_* is not configurable, but CONFIG_BT_LLL_VENDOR_* is.

This allows an alternate LLL to be built on nordic and OpenISA chips. For example, for a non-HCI chip that requires an on-board LLL.

This change should not have any implication on current configurations, as CONFIG_BT_LLL_VENDOR_* and CONFIG_SOC_COMPATIBLE_* are equivalent unless explicitly disabled.