### PR TITLE
Stm32H5: Add backup sram on additional SOCs

### DIFF
--- a/boards/st/nucleo_h503rb/doc/index.rst
+++ b/boards/st/nucleo_h503rb/doc/index.rst
@@ -135,6 +135,8 @@ The Zephyr nucleo_h503rb board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | RNG       | on-chip    | True Random number generator        |
 +-----------+------------+-------------------------------------+
+| BKP SRAM  | on-chip    | Backup SRAM                         |
++-----------+------------+-------------------------------------+
 | UART      | on-chip    | serial port-polling;                |
 |           |            | serial port-interrupt               |
 +-----------+------------+-------------------------------------+
@@ -177,6 +179,13 @@ Serial Port
 
 Nucleo H533RE board has up to 3 U(S)ARTs. The Zephyr console output is assigned
 to USART3. Default settings are 115200 8N1.
+
+Backup SRAM
+-----------
+
+In order to test backup SRAM, you may want to disconnect VBAT from VDD_MCU.
+You can do it by removing ``SB38`` jumper on the back side of the board.
+VBAT can be provided via the left ST Morpho connector's pin 33.
 
 Programming and Debugging
 *************************

--- a/boards/st/nucleo_h503rb/nucleo_h503rb.yaml
+++ b/boards/st/nucleo_h503rb/nucleo_h503rb.yaml
@@ -9,6 +9,7 @@ flash: 128
 supported:
   - arduino_gpio
   - arduino_serial
+  - backup_sram
   - gpio
   - uart
   - i2c

--- a/boards/st/nucleo_h533re/doc/index.rst
+++ b/boards/st/nucleo_h533re/doc/index.rst
@@ -165,6 +165,8 @@ The Zephyr nucleo_h533re board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | RTC       | on-chip    | Real Time Clock                     |
 +-----------+------------+-------------------------------------+
+| BKP SRAM  | on-chip    | Backup SRAM                         |
++-----------+------------+-------------------------------------+
 | UART      | on-chip    | serial port-polling;                |
 |           |            | serial port-interrupt               |
 +-----------+------------+-------------------------------------+
@@ -227,6 +229,13 @@ Serial Port
 
 Nucleo H533RE board has up to 4 USARTs, 2 UARTs, and one LPUART. The Zephyr console output is assigned
 to USART2. Default settings are 115200 8N1.
+
+Backup SRAM
+-----------
+
+In order to test backup SRAM, you may want to disconnect VBAT from VDD_MCU.
+You can do it by removing ``SB38`` jumper on the back side of the board.
+VBAT can be provided via the left ST Morpho connector's pin 33.
 
 Programming and Debugging
 *************************

--- a/boards/st/nucleo_h533re/nucleo_h533re.yaml
+++ b/boards/st/nucleo_h533re/nucleo_h533re.yaml
@@ -17,4 +17,5 @@ supported:
   - adc
   - usb_device
   - usb
+  - backup_sram
 vendor: st

--- a/boards/st/nucleo_h563zi/doc/index.rst
+++ b/boards/st/nucleo_h563zi/doc/index.rst
@@ -150,6 +150,8 @@ The Zephyr nucleo_h563zi board configuration supports the following hardware fea
 +===========+============+=====================================+
 | ADC       | on-chip    | ADC Controller                      |
 +-----------+------------+-------------------------------------+
+| BKP SRAM  | on-chip    | Backup SRAM                         |
++-----------+------------+-------------------------------------+
 | CAN/CANFD | on-chip    | CAN                                 |
 +-----------+------------+-------------------------------------+
 | CLOCK     | on-chip    | reset and clock control             |
@@ -239,6 +241,13 @@ Serial Port
 
 Nucleo H563ZI board has up to 12 U(S)ARTs. The Zephyr console output is assigned
 to USART3. Default settings are 115200 8N1.
+
+Backup SRAM
+-----------
+
+In order to test backup SRAM, you may want to disconnect VBAT from VDD_MCU.
+You can do it by removing ``SB55`` jumper on the back side of the board.
+VBAT can be provided via the left ST Morpho connector's pin 33.
 
 Programming and Debugging
 *************************

--- a/boards/st/nucleo_h563zi/nucleo_h563zi.yaml
+++ b/boards/st/nucleo_h563zi/nucleo_h563zi.yaml
@@ -11,6 +11,7 @@ supported:
   - gpio
   - arduino_serial
   - arduino_spi
+  - backup_sram
   - can
   - gpio
   - uart

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -117,6 +117,14 @@
 			};
 		};
 
+		backup_sram: memory@40036400 {
+			compatible = "zephyr,memory-region", "st,stm32-backup-sram";
+			reg = <0x40036400 DT_SIZE_K(2)>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x10000000>;
+			zephyr,memory-region = "BACKUP_SRAM";
+			status = "disabled";
+		};
+
 		power-states {
 			stop: state0 {
 				compatible = "zephyr,power-state";

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -57,11 +57,7 @@
 		};
 
 		backup_sram: memory@40036400 {
-			compatible = "zephyr,memory-region", "st,stm32-backup-sram";
 			reg = <0x40036400 DT_SIZE_K(4)>;
-			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x10000000>;
-			zephyr,memory-region = "BACKUP_SRAM";
-			status = "disabled";
 		};
 
 		lptim3: timers@44004800 {


### PR DESCRIPTION
The backup SRAM is available on all STM32H5 SOCs, therefore this PR adds the definition for all SOCs.
Additionally:
- Update Documentation for related nucleo boards
- Update the related sample to store a magic value next to the counter.
   The magic should be good enough for such a sample and doesn't add any dependencies, but please let me know if you'd prefer to use a crc instead of the magic value.