### PR TITLE
fix xtensa-sample-controller.ld to avoid .note.GNU-stack warnings

### DIFF
--- a/soc/cdns/xtensa_sample_controller/include/xtensa-sample-controller.ld
+++ b/soc/cdns/xtensa_sample_controller/include/xtensa-sample-controller.ld
@@ -647,4 +647,6 @@ SECTIONS
   {
     KEEP (*(.debug.xt.callgraph .debug.xt.callgraph.* .gnu.linkonce.xt.callgraph.*))
   }
+
+  /DISCARD/ : { *(.note.GNU-stack) }
 }


### PR DESCRIPTION
Prevent following warnings when building using `west build -b xt-sim samples/hello_world`
```
xt-ld: warning: orphan section `.note.GNU-stack' from `zephyr/CMakeFiles/zephyr_final.dir/isr_tables.c.obj' being placed in section `.note.GNU-stack'
xt-ld: warning: orphan section `.note.GNU-stack' from `zephyr/CMakeFiles/offsets.dir/./arch/xtensa/core/offsets/offsets.c.obj' being placed in section `.note.GNU-stack'
xt-ld: warning: orphan section `.note.GNU-stack' from `app/libapp.a(main.c.obj)' being placed in section `.note.GNU-stack'
xt-ld: warning: orphan section `.note.GNU-stack' from `zephyr/libzephyr.a(printk.c.obj)' being placed in section `.note.GNU-stack'
xt-ld: warning: orphan section `.note.GNU-stack' from `zephyr/libzephyr.a(thread_entry.c.obj)' being placed in section `.note.GNU-stack'
xt-ld: warning: orphan section `.note.GNU-stack' from `zephyr/libzephyr.a(cbprintf_complete.c.obj)' being placed in section `.note.GNU-stack'
xt-ld: warning: orphan section `.note.GNU-stack' from `zephyr/libzephyr.a(configs.c.obj)' being placed in section `.note.GNU-stack'
xt-ld: warning: orphan section `.note.GNU-stack' from `zephyr/libzephyr.a(tracing_none.c.obj)' being placed in section `.note.GNU-stack'
xt-ld: warning: orphan section `.note.GNU-stack' from `zephyr/arch/arch/xtensa/core/libarch__xtensa__core.a(cpu_idle.c.obj)' being placed in section `.note.GNU-stack'
xt-ld: warning: orphan section `.note.GNU-stack' from `zephyr/arch/arch/xtensa/core/libarch__xtensa__core.a(fatal.c.obj)' being placed in section `.note.GNU-stack'
xt-ld: warning: orphan section `.note.GNU-stack' from `zephyr/arch/arch/xtensa/core/libarch__xtensa__core.a(irq_manage.c.obj)' being placed in section `.note.GNU-stack'
xt-ld: warning: orphan section `.note.GNU-stack' from `zephyr/arch/arch/xtensa/core/libarch__xtensa__core.a(thread.c.obj)' being placed in section `.note.GNU-stack'
xt-ld: warning: orphan section `.note.GNU-stack' from `zephyr/arch/arch/xtensa/core/libarch__xtensa__core.a(vector_handlers.c.obj)' being placed in section `.note.GNU-stack'
xt-ld: warning: orphan section `.note.GNU-stack' from `zephyr/arch/arch/xtensa/core/libarch__xtensa__core.a(prep_c.c.obj)' being placed in section `.note.GNU-stack'
xt-ld: warning: orphan section `.note.GNU-stack' from `zephyr/lib/libc/minimal/liblib__libc__minimal.a(string.c.obj)' being placed in section `.note.GNU-stack'
xt-ld: warning: orphan section `.note.GNU-stack' from `zephyr/lib/libc/minimal/liblib__libc__minimal.a(stdout_console.c.obj)' being placed in section `.note.GNU-stack'
xt-ld: warning: orphan section `.note.GNU-stack' from `zephyr/lib/libc/minimal/liblib__libc__minimal.a(fprintf.c.obj)' being placed in section `.note.GNU-stack'
xt-ld: warning: orphan section `.note.GNU-stack' from `zephyr/lib/libc/common/liblib__libc__common.a(strnlen.c.obj)' being placed in section `.note.GNU-stack'
xt-ld: warning: orphan section `.note.GNU-stack' from `zephyr/drivers/console/libdrivers__console.a(xtensa_sim_console.c.obj)' being placed in section `.note.GNU-stack'
xt-ld: warning: orphan section `.note.GNU-stack' from `zephyr/drivers/timer/libdrivers__timer.a(xtensa_sys_timer.c.obj)' being placed in section `.note.GNU-stack'
xt-ld: warning: orphan section `.note.GNU-stack' from `zephyr/kernel/libkernel.a(fatal.c.obj)' being placed in section `.note.GNU-stack'
xt-ld: warning: orphan section `.note.GNU-stack' from `zephyr/kernel/libkernel.a(init.c.obj)' being placed in section `.note.GNU-stack'
xt-ld: warning: orphan section `.note.GNU-stack' from `zephyr/kernel/libkernel.a(init_static.c.obj)' being placed in section `.note.GNU-stack'
xt-ld: warning: orphan section `.note.GNU-stack' from `zephyr/kernel/libkernel.a(idle.c.obj)' being placed in section `.note.GNU-stack'
xt-ld: warning: orphan section `.note.GNU-stack' from `zephyr/kernel/libkernel.a(thread.c.obj)' being placed in section `.note.GNU-stack'
xt-ld: warning: orphan section `.note.GNU-stack' from `zephyr/kernel/libkernel.a(sched.c.obj)' being placed in section `.note.GNU-stack'
xt-ld: warning: orphan section `.note.GNU-stack' from `zephyr/kernel/libkernel.a(timeslicing.c.obj)' being placed in section `.note.GNU-stack'
xt-ld: warning: orphan section `.note.GNU-stack' from `zephyr/kernel/libkernel.a(timeout.c.obj)' being placed in section `.note.GNU-stack'
xt-ld: warning: orphan section `.note.GNU-stack' from `zephyr/kernel/libkernel.a(banner.c.obj)' being placed in section `.note.GNU-stack'
xt-ld: warning: orphan section `.note.GNU-stack' from `zephyr/kernel/libkernel.a(device.c.obj)' being placed in section `.note.GNU-stack'
xt-ld: warning: orphan section `.note.GNU-stack' from `/home/williamt/xtensa/XtDevTools/install/builds/RJ-2024.3-linux/sample_controller/xtensa-elf/lib/xcc//libgcc.a(_muldi3.o)' being placed in section `.note.GNU-stack'
xt-ld: warning: orphan section `.note.GNU-stack' from `/home/williamt/xtensa/XtDevTools/install/builds/RJ-2024.3-linux/sample_controller/xtensa-elf/lib/xcc//libgcc.a(_udivdi3.o)' being placed in section `.note.GNU-stack'
```