### PR TITLE
soc: nxp: rt1011: Fix RT1011 FCB offset

### DIFF
--- a/soc/nxp/imxrt/imxrt10xx/Kconfig.defconfig
+++ b/soc/nxp/imxrt/imxrt10xx/Kconfig.defconfig
@@ -24,5 +24,7 @@ config DCDC_VALUE
 config GPIO
 	default y
 
+config FLEXSPI_CONFIG_BLOCK_OFFSET
+	default 0x400 if SOC_MIMXRT1011
 
 endif # SOC_SERIES_IMXRT10XX


### PR DESCRIPTION
RT1011 expects it's flash configuration block at a different offset than the rest of the RT10xx series. Add default to fix the platform not booting.

Fixes #77646