### PR TITLE
modules: tfm: default version numbers from `VERSION`

### DIFF
--- a/modules/trusted-firmware-m/Kconfig.tfm
+++ b/modules/trusted-firmware-m/Kconfig.tfm
@@ -188,6 +188,7 @@ config TFM_BL2_NOT_SUPPORTED
 
 config TFM_IMAGE_VERSION_S
 	string "Version of the Secure Image"
+	default "$(APP_VERSION_TWEAK_STRING)" if "$(VERSION_MAJOR)" != "" && TFM_MCUBOOT_IMAGE_NUMBER = 1
 	default "0.0.0+0"
 	help
 	  MCUBoot may be configured to prevent rollback prevention based on image
@@ -198,6 +199,7 @@ config TFM_IMAGE_VERSION_S
 
 config TFM_IMAGE_VERSION_NS
 	string "Version of the Non-Secure Image"
+	default "$(APP_VERSION_TWEAK_STRING)" if "$(VERSION_MAJOR)" != "" && TFM_MCUBOOT_IMAGE_NUMBER = 2
 	default "0.0.0+0"
 	help
 	  MCUBoot may be configured to prevent rollback prevention based on image


### PR DESCRIPTION
Populate the TFM application version numbers from the application `VERSION` file if it exists.

This is the same logic used in the mcuboot module:
https://github.com/zephyrproject-rtos/zephyr/blob/874e4e2e199c138d73f3acfca9d9f7d90f79666b/modules/Kconfig.mcuboot#L104-L107