### PR TITLE
soc: arm: infineon_xmc: Use cacheable flash address space

### DIFF
--- a/dts/arm/infineon/cat3/xmc/xmc4500_F100x1024.dtsi
+++ b/dts/arm/infineon/cat3/xmc/xmc4500_F100x1024.dtsi
@@ -26,7 +26,7 @@
 };
 
 &flash0 {
-	reg = <0xc000000 DT_SIZE_M(1)>;
+	reg = <0x8000000 DT_SIZE_M(1)>;
 	pages_layout: pages_layout {
 		pages_layout_16k: pages_layout_16k {
 			pages-count = <8>;

--- a/dts/arm/infineon/cat3/xmc/xmc4700_F144x2048.dtsi
+++ b/dts/arm/infineon/cat3/xmc/xmc4700_F144x2048.dtsi
@@ -20,7 +20,7 @@
 };
 
 &flash0 {
-	reg = <0xc000000 DT_SIZE_M(2)>;
+	reg = <0x8000000 DT_SIZE_M(2)>;
 	pages_layout: pages_layout {
 		pages_layout_16k: pages_layout_16k {
 			pages-count = <8>;

--- a/dts/arm/infineon/cat3/xmc/xmc4xxx.dtsi
+++ b/dts/arm/infineon/cat3/xmc/xmc4xxx.dtsi
@@ -26,7 +26,7 @@
 		reg = <0x58001000 0x1400>;
 		#address-cells = <1>;
 		#size-cells = <1>;
-		flash0: flash@c000000 {
+		flash0: flash@8000000 {
 			compatible = "infineon,xmc4xxx-nv-flash","soc-nv-flash";
 			write-block-size = <256>;
 		};


### PR DESCRIPTION
The infineon xmc4xxx series has two ways to access flash: one is the cacheable address space at 0x8000000 which may return pre-fetched/cached data to reduce flash access latency, the second is uncached space at 0xc000000 which is mainly used for write and erase operations.

Currently the LMA is set to the uncacheable address which is not efficient for executing in place (XIP). Instead use the cacheable address for the LMA.

The J-Link probe properly figures that it has to use uncached space for erasing and writing to flash.