### PR TITLE
drivers: dma: intel-adsp-hda: Report total_copied bytes on ACE2/3

### DIFF
--- a/drivers/dma/dma_intel_adsp_hda.c
+++ b/drivers/dma/dma_intel_adsp_hda.c
@@ -219,6 +219,8 @@ int intel_adsp_hda_dma_status(const struct device *dev, uint32_t channel,
 	struct dma_status *stat)
 {
 	const struct intel_adsp_hda_dma_cfg *const cfg = dev->config;
+	uint32_t llp_l = 0;
+	uint32_t llp_u = 0;
 	bool xrun_det;
 
 	__ASSERT(channel < cfg->dma_channels, "Channel does not exist");
@@ -232,6 +234,22 @@ int intel_adsp_hda_dma_status(const struct device *dev, uint32_t channel,
 	stat->read_position = *DGBRP(cfg->base, cfg->regblock_size, channel);
 	stat->pending_length = used;
 	stat->free = unused;
+
+#if CONFIG_SOC_INTEL_ACE20_LNL || CONFIG_SOC_INTEL_ACE30_PTL
+	/* Linear Link Position via HDA-DMA is only supported on ACE2 or newer */
+	if (cfg->direction == MEMORY_TO_PERIPHERAL || cfg->direction == PERIPHERAL_TO_MEMORY) {
+		uint32_t tmp;
+
+		tmp = *DGLLLPL(cfg->base, cfg->regblock_size, channel);
+		llp_u = *DGLLLPU(cfg->base, cfg->regblock_size, channel);
+		llp_l = *DGLLLPL(cfg->base, cfg->regblock_size, channel);
+		if (tmp > llp_l) {
+			/* re-read the LLPU value, as LLPL just wrapped */
+			llp_u = *DGLLLPU(cfg->base, cfg->regblock_size, channel);
+		}
+	}
+#endif
+	stat->total_copied = ((uint64_t)llp_u << 32) | llp_l;
 
 	switch (cfg->direction) {
 	case MEMORY_TO_PERIPHERAL:

--- a/soc/intel/intel_adsp/common/include/intel_adsp_hda.h
+++ b/soc/intel/intel_adsp/common/include/intel_adsp_hda.h
@@ -89,6 +89,13 @@
 #define DGLPIBI(base, regblock_size, stream) \
 	((volatile uint32_t *)(HDA_ADDR(base, regblock_size, stream) + 0x28))
 
+/* Gateway Linear Link Position registers (ACE2 and onwards */
+#define DGLLLPL(base, regblock_size, stream) \
+	((volatile uint32_t *)(HDA_ADDR(base, regblock_size, stream) + 0x20))
+
+#define DGLLLPU(base, regblock_size, stream) \
+	((volatile uint32_t *)(HDA_ADDR(base, regblock_size, stream) + 0x24))
+
 /**
  * @brief Dump all the useful registers of an HDA stream to printk
  *


### PR DESCRIPTION
With ACE2/3 the HDA DMA includes registers to read the Linear Link
Position.
Previous platforms (CAVS, ACE1) was able to report the LLP for GPDMA. Since
ACE2 all links are handled with HD-DMA, hence the new register has been
added for the firmware to report the LLP to the host.

Set the total_copied to 0 for older ACE1/CAVS platforms and in case of
host DMA on ACE2/3 since the informatiojn is not available.