### PR TITLE
samples: modules: use zephyr:code-sample directive

### DIFF
--- a/samples/modules/canopennode/README.rst
+++ b/samples/modules/canopennode/README.rst
@@ -1,7 +1,7 @@
-.. _canopennode-sample:
+.. zephyr:code-sample:: canopennode
+   :name: CANopenNode
 
-CANopenNode
-###########
+   Use the CANopenNode CANopen protocol stack in Zephyr.
 
 Overview
 ********

--- a/samples/modules/chre/README.rst
+++ b/samples/modules/chre/README.rst
@@ -1,5 +1,10 @@
-Android's Context Hub Runtime Environment (CHRE)
-################################################
+.. zephyr:code-sample:: chre
+   :name: Android's Context Hub Runtime Environment (CHRE)
+
+   Run nanoapps on Zephyr using the Context Hub Runtime Environment (CHRE).
+
+Overview
+========
 
 Android's context hub enables the use of nanoapps. A single nanoapp has 3 entry points seen in
 `chre_api/chre/nanoapp.h`_:

--- a/samples/modules/cmsis_dsp/cmsis_dsp.rst
+++ b/samples/modules/cmsis_dsp/cmsis_dsp.rst
@@ -1,0 +1,12 @@
+CMSIS-DSP
+#########
+
+These samples demonstrate how to use the CMSIS-DSP module to perform signal processing operations
+in Zephyr.
+
+.. toctree::
+   :titlesonly:
+   :glob:
+   :maxdepth: 1
+
+   */*

--- a/samples/modules/compression/lz4/README.rst
+++ b/samples/modules/compression/lz4/README.rst
@@ -1,7 +1,7 @@
-.. _lz4:
+.. zephyr:code-sample:: lz4
+   :name: LZ4
 
-LZ4
-###
+   Compress and decompress data using the LZ4 module.
 
 Overview
 ********

--- a/samples/modules/index.rst
+++ b/samples/modules/index.rst
@@ -5,7 +5,7 @@ External Module Samples
 
 .. toctree::
    :titlesonly:
-   :maxdepth: 1
+   :maxdepth: 2
    :glob:
 
-   **/*
+   */*

--- a/samples/modules/lvgl/lvgl.rst
+++ b/samples/modules/lvgl/lvgl.rst
@@ -1,0 +1,13 @@
+.. _lvgl_samples:
+
+LVGL
+####
+
+These samples demonstrate how to build graphical user interfaces using LVGL in Zephyr.
+
+.. toctree::
+   :titlesonly:
+   :glob:
+   :maxdepth: 1
+
+   **/*

--- a/samples/modules/nanopb/README.rst
+++ b/samples/modules/nanopb/README.rst
@@ -1,7 +1,7 @@
-.. _nanopb_sample:
+.. zephyr:code-sample:: nanopb
+   :name: Nanopb
 
-Nanopb sample
-#############
+   Serialize and deserialize structured data using the nanopb module.
 
 Overview
 ********

--- a/samples/modules/tflite-micro/hello_world/README.rst
+++ b/samples/modules/tflite-micro/hello_world/README.rst
@@ -1,7 +1,7 @@
-.. _tensorflow_hello_world:
+.. zephyr:code-sample:: tflite-hello-world
+   :name: Hello World
 
-TensorFlow Lite Micro Hello World sample
-########################################
+   Replicate a sine wave using TensorFlow Lite for Microcontrollers.
 
 Overview
 ********

--- a/samples/modules/tflite-micro/magic_wand/README.rst
+++ b/samples/modules/tflite-micro/magic_wand/README.rst
@@ -1,7 +1,8 @@
-.. _tensorflow_magic_wand:
+.. zephyr:code-sample:: tflite-magicwand
+   :name: Magic Wand
 
-TensorFlow Lite Micro Magic Wand sample
-#######################################
+   Recognize gestures from an accelerometer using TensorFlow Lite for Microcontrollers and a 20KB
+   neural network.
 
 Overview
 ********

--- a/samples/modules/tflite-micro/tflite-micro.rst
+++ b/samples/modules/tflite-micro/tflite-micro.rst
@@ -1,0 +1,13 @@
+.. _tflitemicro_samples:
+
+TensorFlow Lite for Microcontrollers
+####################################
+
+These samples demonstrate how to use TensorFlow Lite for Microcontrollers in Zephyr.
+
+.. toctree::
+   :titlesonly:
+   :glob:
+   :maxdepth: 1
+
+   **/*

--- a/samples/modules/tflite-micro/tflm_ethosu/README.rst
+++ b/samples/modules/tflite-micro/tflm_ethosu/README.rst
@@ -1,7 +1,10 @@
-.. _tflm_ethosu:
+.. zephyr:code-sample:: tflite-ethosu
+   :name: TensorFlow Lite for Microcontrollers on Arm Ethos-U
 
-Arm(R) Ethos(TM)-U Tensorflow Lite for Microcontrollers test application
-########################################################################
+   Run an inference using an optimized TFLite model on Arm Ethos-U NPU.
+
+Overview
+********
 
 A sample application that demonstrates how to run an inference using the TFLM
 framework and the Arm Ethos-U NPU.

--- a/samples/modules/thrift/hello/README.rst
+++ b/samples/modules/thrift/hello/README.rst
@@ -1,7 +1,10 @@
-.. _thrift-hello-sample:
+.. zephyr:code-sample:: thrift-hello
+   :name: Apache Thrift Hello World
 
-Thrift sample
-#############
+   Implement a simple Apache Thrift client-server application.
+
+Overview
+********
 
 .. figure:: thrift-layers.png
    :align: center

--- a/samples/modules/thrift/thrift.rst
+++ b/samples/modules/thrift/thrift.rst
@@ -1,0 +1,11 @@
+Apache Thrift
+=============
+
+These samples demonstrate how to use Apache Thrift in Zephyr.
+
+.. toctree::
+   :titlesonly:
+   :glob:
+   :maxdepth: 1
+
+   */*


### PR DESCRIPTION
Describe the external module samples using `zephyr:code-sample` directive in preparation for upcoming changes to the Zephyr documentation that will be leveraging the provided description and metadata.

Also fixed a couple invalid or missing table of contents to have proper document hierarchy.