### PR TITLE
boards: st: Fix false arduino_gpio support

### DIFF
--- a/boards/st/stm32h735g_disco/stm32h735g_disco.yaml
+++ b/boards/st/stm32h735g_disco/stm32h735g_disco.yaml
@@ -9,7 +9,6 @@ toolchain:
 ram: 368
 flash: 1024
 supported:
-  - arduino_gpio
   - gpio
   - netif:eth
   - memc

--- a/boards/st/stm32h750b_dk/stm32h750b_dk.dts
+++ b/boards/st/stm32h750b_dk/stm32h750b_dk.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 #include <st/h7/stm32h750Xb.dtsi>
 #include <st/h7/stm32h750xbhx-pinctrl.dtsi>
+#include "arduino_r3_connector.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {


### PR DESCRIPTION
On those boards, `arduino_gpio` is declared while the connector is not actually described, leading to issues in tests making use of gpio arduino connectors.
Fix this.