### PR TITLE
Bug fix on vendor-prefixes list compliance validation

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -264,8 +264,12 @@ class BoardYmlCheck(ComplianceTest):
                 line = line.strip()
                 if not line or line.startswith("#"):
                     continue
-                vendor, _ = line.split("\t", 2)
-                vendor_prefixes.append(vendor)
+                try:
+                    vendor, _ = line.split("\t", 2)
+                    vendor_prefixes.append(vendor)
+                except ValueError:
+                    self.error(f"Invalid line in vendor-prefixes.txt:\"{line}\".")
+                    self.error("Did you forget the tab character?")
 
         path = Path(ZEPHYR_BASE)
         for file in path.glob("**/board.yml"):


### PR DESCRIPTION
**When** inserting new vendor in vendor-prefixes.txt file
**I expect** in the case of the tab character is missing
The compliance will show a friendly error message in the console.
Currently the compliance script crashes.

This PR implements a fix displaying a friendly message to the user.

I am also adding a new vendor to the list.