### PR TITLE
bluetooth: host: adv: Release buf if failed to set addr

### DIFF
--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -1139,6 +1139,7 @@ static int le_ext_adv_param_set(struct bt_le_ext_adv *adv,
 	err = bt_id_set_adv_own_addr(adv, param->options, dir_adv,
 				     &cp->own_addr_type);
 	if (err) {
+		net_buf_unref(buf);
 		return err;
 	}
 


### PR DESCRIPTION
The `bt_id_set_adv_own_addr` function itself tries to allocate a buffer for the command and it failes due to lack of buffers, it returns error. However, the `le_ext_adv_param_set` function doesn't handle the error properly and keeps its own allocated buffer.

This commit releases the allocated buffer.
Partially fixes mesh in #77241.