### PR TITLE
Configure ECSPI for phyBOARD Polis

### DIFF
--- a/boards/phytec/mimx8mm_phyboard_polis/mimx8mm_phyboard_polis-pinctrl.dtsi
+++ b/boards/phytec/mimx8mm_phyboard_polis/mimx8mm_phyboard_polis-pinctrl.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 PHYTEC Messtechnik GmbH
+ * Copyright (c) 2022-2024 PHYTEC Messtechnik GmbH
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -44,6 +44,45 @@
 				<&iomuxc_sai2_txfs_uart_cts_b_uart1_cts_b>;
 			slew-rate = "fast";
 			drive-strength = "x6";
+		};
+	};
+
+	ecspi1_default: ecspi1_default {
+		group1 {
+			pinmux = <&iomuxc_ecspi1_miso_ecspi_miso_ecspi1_miso>,
+					 <&iomuxc_ecspi1_mosi_ecspi_mosi_ecspi1_mosi>,
+					 <&iomuxc_ecspi1_sclk_ecspi_sclk_ecspi1_sclk>;
+			slew-rate = "fast";
+			drive-strength = "x6";
+		};
+		group2 {
+			pinmux = <&iomuxc_ecspi1_ss0_gpio_io_gpio5_io09>;
+			slew-rate = "fast";
+			drive-strength = "x6";
+			bias-pull-up;
+		};
+		group3 {
+			pinmux = <&iomuxc_sd2_wp_gpio_io_gpio2_io20>;
+			slew-rate = "fast";
+			drive-strength = "x6";
+			bias-pull-up;
+		};
+	};
+
+	ecspi2_default: ecspi2_default {
+		group1 {
+			pinmux = <&iomuxc_ecspi2_miso_ecspi_miso_ecspi2_miso>,
+					 <&iomuxc_ecspi2_mosi_ecspi_mosi_ecspi2_mosi>,
+					 <&iomuxc_ecspi2_sclk_ecspi_sclk_ecspi2_sclk>;
+			slew-rate = "fast";
+			drive-strength = "x6";
+			bias-pull-up;
+		};
+		group2 {
+			pinmux = <&iomuxc_ecspi2_ss0_gpio_io_gpio5_io13>;
+			slew-rate = "fast";
+			drive-strength = "x6";
+			bias-pull-up;
 		};
 	};
 };

--- a/boards/phytec/mimx8mm_phyboard_polis/mimx8mm_phyboard_polis_mimx8mm6_m4.dts
+++ b/boards/phytec/mimx8mm_phyboard_polis/mimx8mm_phyboard_polis_mimx8mm6_m4.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 PHYTEC Messtechnik GmbH
+ * Copyright (c) 2022-2024 PHYTEC Messtechnik GmbH
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -26,6 +26,7 @@
 		zephyr,sram = &tcmu_sys;
 		zephyr,console = &uart4;
 		zephyr,shell-uart = &uart4;
+		zephyr,canbus = &mcp2518;
 	};
 
 	leds {
@@ -44,6 +45,37 @@
 		};
 	};
 
+};
+
+&ecspi1 {
+	status = "disabled";
+	pinctrl-0 = <&ecspi1_default>;
+	pinctrl-names = "default";
+	/* first cs is for on board MCP2518, the second for SPI on expansion header */
+	cs-gpios = <&gpio5 9 GPIO_ACTIVE_LOW>,
+				<&gpio2 20 GPIO_ACTIVE_LOW>;
+
+	/* CAN FD */
+	mcp2518: mcp2518@0 {
+		compatible = "microchip,mcp251xfd";
+		reg = <0>;
+		spi-max-frequency = <20000000>;
+		int-gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
+		supply-gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
+		osc-freq = <40000000>;
+		status = "disabled";
+	};
+};
+
+/*
+ * TPM Module TI SLB9670
+ * Currently there is no driver for the used module
+ */
+&ecspi2 {
+	status = "disabled";
+	pinctrl-0 = <&ecspi2_default>;
+	pinctrl-names = "default";
+	cs-gpios = <&gpio5 13 GPIO_ACTIVE_LOW>;
 };
 
 /* RS232 / RS485 pinheader on the board */

--- a/boards/phytec/mimx8mm_phyboard_polis/mimx8mm_phyboard_polis_mimx8mm6_m4.yaml
+++ b/boards/phytec/mimx8mm_phyboard_polis/mimx8mm_phyboard_polis_mimx8mm6_m4.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 PHYTEC Messtechnik GmbH
+# Copyright (c) 2020-2024 PHYTEC Messtechnik GmbH
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -18,4 +18,9 @@ testing:
   ignore_tags:
     - net
     - bluetooth
+supported:
+  - uart
+  - spi
+  - gpio
+  - can
 vendor: nxp

--- a/dts/arm/nxp/nxp_imx8m_m4.dtsi
+++ b/dts/arm/nxp/nxp_imx8m_m4.dtsi
@@ -136,6 +136,36 @@
 			#clock-cells = <3>;
 		};
 
+		ecspi1: spi@30820000 {
+			compatible = "nxp,imx-ecspi";
+			reg = <0x30820000 DT_SIZE_K(64)>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			interrupts = <31 3>;
+			clocks = <&ccm IMX_CCM_ECSPI1_CLK 0 0>;
+			status = "disabled";
+		};
+
+		ecspi2: spi@30830000 {
+			compatible = "nxp,imx-ecspi";
+			reg = <0x30830000 DT_SIZE_K(64)>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			interrupts = <32 3>;
+			clocks = <&ccm IMX_CCM_ECSPI2_CLK 0 0>;
+			status = "disabled";
+		};
+
+		ecspi3: spi@30840000 {
+			compatible = "nxp,imx-ecspi";
+			reg = <0x30840000 DT_SIZE_K(64)>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			interrupts = <33 3>;
+			clocks = <&ccm IMX_CCM_ECSPI3_CLK 0 0>;
+			status = "disabled";
+		};
+
 		uart1: uart@30860000 {
 			compatible = "nxp,imx-iuart";
 			reg = <0x30860000 0x10000>;

--- a/soc/nxp/imx/imx8m/m4_mini/soc.c
+++ b/soc/nxp/imx/imx8m/m4_mini/soc.c
@@ -130,6 +130,29 @@ static void SOC_ClockInit(void)
 #endif
 #endif
 
+#if defined(CONFIG_SPI_MCUX_ECSPI)
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(ecspi1), okay)
+	/* Set ECSPI1 source to SYSTEM PLL1 800MHZ */
+	CLOCK_SetRootMux(kCLOCK_RootEcspi1, kCLOCK_EcspiRootmuxSysPll1);
+	/* Set root clock to 800MHZ / 10 = 80MHZ */
+	CLOCK_SetRootDivider(kCLOCK_RootEcspi1, 2U, 5U);
+#endif
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(ecspi2), okay)
+	/* Set ECSPI2 source to SYSTEM PLL1 800MHZ */
+	CLOCK_SetRootMux(kCLOCK_RootEcspi2, kCLOCK_EcspiRootmuxSysPll1);
+	/* Set root clock to 800MHZ / 10 = 80MHZ */
+	CLOCK_SetRootDivider(kCLOCK_RootEcspi2, 2U, 5U);
+#endif
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(ecspi3), okay)
+	/* Set ECSPI3 source to SYSTEM PLL1 800MHZ */
+	CLOCK_SetRootMux(kCLOCK_RootEcspi3, kCLOCK_EcspiRootmuxSysPll1);
+	/* Set root clock to 800MHZ / 10 = 80MHZ */
+	CLOCK_SetRootDivider(kCLOCK_RootEcspi3, 2U, 5U);
+#endif
+#endif
+
 	/* Enable RDC clock */
 	CLOCK_EnableClock(kCLOCK_Rdc);
 

--- a/tests/drivers/spi/spi_loopback/boards/mimx8mm_phyboard_polis_mimx8mm6_m4.conf
+++ b/tests/drivers/spi/spi_loopback/boards/mimx8mm_phyboard_polis_mimx8mm6_m4.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (C) 2024 PHYTEC Messtechnik GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_SPI_LOOPBACK_MODE_LOOP=y

--- a/tests/drivers/spi/spi_loopback/boards/mimx8mm_phyboard_polis_mimx8mm6_m4.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimx8mm_phyboard_polis_mimx8mm6_m4.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 PHYTEC Messtechnik GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&ecspi1 {
+	status = "okay";
+
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <500000>;
+	};
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <16000000>;
+	};
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&gpio5 {
+	status = "okay";
+};


### PR DESCRIPTION
This PR adds ECSPI Support for the imx8m SoCs and enables it for the phyBOARD Polis.
The implementation was tested using the SPI loopback test. 

The documentation for the phyBOARD Polis was updated accordingly.