### PR TITLE
doc: shorten descriptions of doc homepage grid items

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -866,7 +866,7 @@ dark-mode-toggle::part(toggleLabel){
     -webkit-box-align: center;
         -ms-flex-align: center;
             align-items: center;
-    border-radius: 0.5rem;
+    border-radius: 1rem;
     background: linear-gradient(135deg, #0070c5 0%, #5c13a5 100%);
     color: white;
 }
@@ -888,6 +888,10 @@ dark-mode-toggle::part(toggleLabel){
     font-size: 0.9rem;
     margin-top: 0.5rem;
     color: var(--body-color);
+    font-weight: 200;
+    margin-left: -0.9em;
+    margin-right: -0.9em;
+    line-height: 1.4rem;
 }
 
 .grid-icon {

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -38,59 +38,56 @@ licensing, as described in :ref:`Zephyr_Licensing`.
 	       <img alt="" src="_static/images/kite.png"/>
 	       <h2>Introduction</h2>
 	   </a>
-	   <p>Introducing the Zephyr Project: overview, architecture, features, and licensing</p>
+	   <p>Architecture, features &amp; licensing details</p>
        </li>
        <li class="grid-item">
 	   <a href="develop/getting_started/index.html">
                <span class="grid-icon fa fa-map-signs"></span>
 	       <h2>Getting Started Guide</h2>
 	   </a>
-	   <p>Follow this guide to set up a Zephyr development environment on your
-	       system, and then build and run a sample application.</p>
+	   <p>Set up Zephyr, build &amp; run a sample application</p>
        </li>
        <li class="grid-item">
 	   <a href="contribute/index.html">
                <span class="grid-icon fa fa-github"></span>
 	       <h2>Contribution Guidelines</h2>
 	   </a>
-	   <p>As an open-source project, we welcome and encourage the community
-           to submit patches directly to the project.</p>
+	   <p>How to submit patches and contribute to Zephyr</p>
        </li>
        <li class="grid-item">
 	   <a href="samples/index.html">
                <span class="grid-icon fa fa-cogs"></span>
 	       <h2>Samples and Demos</h2>
 	   </a>
-	   <p>A list of samples and demos that can run on a variety of boards supported
-	       by Zephyr</p>
+	   <p>Explore samples and demos for various boards</p>
        </li>
        <li class="grid-item">
 	   <a href="hardware/index.html">
                <span class="grid-icon fa fa-sign-in"></span>
 	       <h2>Hardware Support</h2>
 	   </a>
-	   <p>Information about supported architectures, supported hardware and porting guides</p>
+	   <p>Supported hardware and porting guides</p>
        </li>
        <li class="grid-item">
 	   <a href="security/index.html">
                <span class="grid-icon fa fa-lock"></span>
 	       <h2>Security</h2>
 	   </a>
-	   <p>Requirements, processes, and developer guidelines for ensuring security is addressed within the Zephyr project.</p>
+	   <p>Security processes and guidelines</p>
        </li>
        <li class="grid-item">
 	   <a href="boards/index.html">
                <span class="grid-icon fa fa-object-group"></span>
 	       <h2>Supported Boards</h2>
 	   </a>
-	   <p>List of supported boards and platforms.</p>
+	   <p>List of supported boards and platforms</p>
        </li>
        <li class="grid-item">
 	   <a href="services/index.html">
                <span class="grid-icon fa fa-puzzle-piece"></span>
 	       <h2>OS Services</h2>
 	   </a>
-	   <p>OS Services and guides how to use them with Zephyr</p>
+	   <p>OS Services and usage guides</p>
        </li>
    </ul>
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -91,9 +91,6 @@ licensing, as described in :ref:`Zephyr_Licensing`.
        </li>
    </ul>
 
-Sections
-********
-
 .. toctree::
    :maxdepth: 1
    :caption: Contents


### PR DESCRIPTION
https://builds.zephyrproject.io/zephyr/pr/77739/docs/index.html

The descriptions of the homepage grid items were too long and often repetitive (e.g. there's no need to repeat "Zephyr" in almost every descriptions). This commit shortens them to aim at having them fit on two lines, three at most.

Also updated the look&feel slightly.

BEFORE:

<img width="800" alt="image" src="https://github.com/user-attachments/assets/c6b584be-d9d6-408a-9467-ea3a24ba4f67">

AFTER:

<img width="798" alt="image" src="https://github.com/user-attachments/assets/fe714a33-54ba-4cef-b211-56ecaf2af1f6">