### PR TITLE
Bluetooth: mesh: transport: logic fix for unseg msgs

### DIFF
--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -1666,7 +1666,16 @@ int bt_mesh_trans_recv(struct net_buf_simple *buf, struct bt_mesh_net_rx *rx)
 		err = trans_seg(buf, rx, &pdu_type, &seq_auth, &seg_count);
 	} else {
 		seg_count = 1;
-		err = trans_unseg(buf, rx, &seq_auth);
+
+		if(!rx->ctl){
+			if (!rx->local_match) {
+				/* if friend_match was set the frame is for LPN which we are
+				* friends. */
+				return rx->friend_match ? 0 : -ENXIO;
+			} else {
+				err = trans_unseg(buf, rx, &seq_auth);
+			}
+		}
 	}
 
 	/* Notify LPN state machine so a Friend Poll will be sent. */


### PR DESCRIPTION
Fixed transport layer logic causing excessive processing of unsegmented messages in bt_mesh_trans_recv() calls.

Remaining work:
- [ ] Run PTS tests for transport and heartbeat