### PR TITLE
drivers: hwinfo: litex: depend on devicetree

### DIFF
--- a/drivers/hwinfo/Kconfig
+++ b/drivers/hwinfo/Kconfig
@@ -188,6 +188,7 @@ config HWINFO_LITEX
 	bool "LiteX device ID"
 	default y
 	depends on SOC_LITEX_VEXRISCV
+	depends on DT_HAS_LITEX_DNA0_ENABLED
 	select HWINFO_HAS_DRIVER
 	help
 	  Enable LiteX hwinfo driver


### PR DESCRIPTION
make litex hwinfo dependent of enabled state of device.