### PR TITLE
boards: seeed: Configure QSPI CS pin as pull-up in sleep

### DIFF
--- a/boards/seeed/xiao_ble/xiao_ble-pinctrl.dtsi
+++ b/boards/seeed/xiao_ble/xiao_ble-pinctrl.dtsi
@@ -132,9 +132,13 @@
 				<NRF_PSEL(QSPI_IO0, 0, 20)>,
 				<NRF_PSEL(QSPI_IO1, 0, 24)>,
 				<NRF_PSEL(QSPI_IO2, 0, 22)>,
-				<NRF_PSEL(QSPI_IO3, 0, 23)>,
-				<NRF_PSEL(QSPI_CSN, 0, 25)>;
+				<NRF_PSEL(QSPI_IO3, 0, 23)>;
 			low-power-enable;
+		};
+		group2 {
+			psels = <NRF_PSEL(QSPI_CSN, 0, 25)>;
+			low-power-enable;
+			bias-pull-up;
 		};
 	};
 };


### PR DESCRIPTION
QSPI sleep now set QSPI CS pin to pull-up, decreasing current consumption.
The issue was found in https://devzone.nordicsemi.com/f/nordic-q-a/114224/external-flash-to-sleep/500350 