### PR TITLE
drivers: dma: intel-adsp-gpdma: Account for LLPL wrapping

### DIFF
--- a/drivers/dma/dma_intel_adsp_gpdma.c
+++ b/drivers/dma/dma_intel_adsp_gpdma.c
@@ -129,9 +129,15 @@ static inline void intel_adsp_gpdma_llp_read(const struct device *dev,
 {
 #ifdef CONFIG_DMA_INTEL_ADSP_GPDMA_HAS_LLP
 	const struct intel_adsp_gpdma_cfg *const dev_cfg = dev->config;
+	uint32_t tmp;
 
-	*llp_l = dw_read(dev_cfg->shim, GPDMA_CHLLPL(channel));
+	tmp = dw_read(dev_cfg->shim, GPDMA_CHLLPL(channel));
 	*llp_u = dw_read(dev_cfg->shim, GPDMA_CHLLPU(channel));
+	*llp_l = dw_read(dev_cfg->shim, GPDMA_CHLLPL(channel));
+	if (tmp > *llp_l) {
+		/* re-read the LLPU value, as LLPL just wrapped */
+		*llp_u = dw_read(dev_cfg->shim, GPDMA_CHLLPU(channel));
+	}
 #endif
 }
 


### PR DESCRIPTION
In case the LLP wraps we need to re-read the LLPU to make sure we return the correct value.

Suggested-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>