### PR TITLE
Bluetooth: CAP: Revert order of CAP stream callbacks

### DIFF
--- a/subsys/bluetooth/audio/cap_stream.c
+++ b/subsys/bluetooth/audio/cap_stream.c
@@ -56,13 +56,13 @@ static void cap_stream_configured_cb(struct bt_bap_stream *bap_stream,
 
 	LOG_DBG("%p", cap_stream);
 
+	if (ops != NULL && ops->configured != NULL) {
+		ops->configured(bap_stream, pref);
+	}
+
 	if (IS_ENABLED(CONFIG_BT_CAP_INITIATOR) && IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) &&
 	    stream_is_central(bap_stream)) {
 		bt_cap_initiator_codec_configured(cap_stream);
-	}
-
-	if (ops != NULL && ops->configured != NULL) {
-		ops->configured(bap_stream, pref);
 	}
 }
 
@@ -75,13 +75,13 @@ static void cap_stream_qos_set_cb(struct bt_bap_stream *bap_stream)
 
 	LOG_DBG("%p", cap_stream);
 
+	if (ops != NULL && ops->qos_set != NULL) {
+		ops->qos_set(bap_stream);
+	}
+
 	if (IS_ENABLED(CONFIG_BT_CAP_INITIATOR) && IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) &&
 	    stream_is_central(bap_stream)) {
 		bt_cap_initiator_qos_configured(cap_stream);
-	}
-
-	if (ops != NULL && ops->qos_set != NULL) {
-		ops->qos_set(bap_stream);
 	}
 }
 
@@ -94,13 +94,13 @@ static void cap_stream_enabled_cb(struct bt_bap_stream *bap_stream)
 
 	LOG_DBG("%p", cap_stream);
 
+	if (ops != NULL && ops->enabled != NULL) {
+		ops->enabled(bap_stream);
+	}
+
 	if (IS_ENABLED(CONFIG_BT_CAP_INITIATOR) && IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) &&
 	    stream_is_central(bap_stream)) {
 		bt_cap_initiator_enabled(cap_stream);
-	}
-
-	if (ops != NULL && ops->enabled != NULL) {
-		ops->enabled(bap_stream);
 	}
 }
 
@@ -113,13 +113,13 @@ static void cap_stream_metadata_updated_cb(struct bt_bap_stream *bap_stream)
 
 	LOG_DBG("%p", cap_stream);
 
+	if (ops != NULL && ops->metadata_updated != NULL) {
+		ops->metadata_updated(bap_stream);
+	}
+
 	if (IS_ENABLED(CONFIG_BT_CAP_INITIATOR) && IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) &&
 	    stream_is_central(bap_stream)) {
 		bt_cap_initiator_metadata_updated(cap_stream);
-	}
-
-	if (ops != NULL && ops->metadata_updated != NULL) {
-		ops->metadata_updated(bap_stream);
 	}
 }
 
@@ -146,15 +146,15 @@ static void cap_stream_released_cb(struct bt_bap_stream *bap_stream)
 
 	LOG_DBG("%p", cap_stream);
 
+	if (ops != NULL && ops->released != NULL) {
+		ops->released(bap_stream);
+	}
+
 	/* Here we cannot use stream_is_central as bap_stream->conn is NULL, so fall back to
 	 * a more generic, less accurate check
 	 */
 	if (IS_ENABLED(CONFIG_BT_CAP_INITIATOR) && IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT)) {
 		bt_cap_initiator_released(cap_stream);
-	}
-
-	if (ops != NULL && ops->released != NULL) {
-		ops->released(bap_stream);
 	}
 }
 
@@ -169,13 +169,13 @@ static void cap_stream_started_cb(struct bt_bap_stream *bap_stream)
 
 	LOG_DBG("%p", cap_stream);
 
+	if (ops != NULL && ops->started != NULL) {
+		ops->started(bap_stream);
+	}
+
 	if (IS_ENABLED(CONFIG_BT_CAP_INITIATOR) && IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) &&
 	    stream_is_central(bap_stream)) {
 		bt_cap_initiator_started(cap_stream);
-	}
-
-	if (ops != NULL && ops->started != NULL) {
-		ops->started(bap_stream);
 	}
 }
 
@@ -228,13 +228,13 @@ static void cap_stream_connected_cb(struct bt_bap_stream *bap_stream)
 		CONTAINER_OF(bap_stream, struct bt_cap_stream, bap_stream);
 	struct bt_bap_stream_ops *ops = cap_stream->ops;
 
+	if (ops != NULL && ops->connected != NULL) {
+		ops->connected(bap_stream);
+	}
+
 	if (IS_ENABLED(CONFIG_BT_CAP_INITIATOR) && IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) &&
 	    stream_is_central(bap_stream)) {
 		bt_cap_initiator_connected(cap_stream);
-	}
-
-	if (ops != NULL && ops->connected != NULL) {
-		ops->connected(bap_stream);
 	}
 }
 


### PR DESCRIPTION
Modify the CAP stream callbacks so that the application callbacks are called before the CAP initiator.

This allows the application to abort/cancel a procedure before we send out any future request.