### PR TITLE
boards: nrf54l15bsim: Set native_posix entropy ready

### DIFF
--- a/boards/native/nrf_bsim/nrf54l15bsim_nrf54l15_cpuapp.dts
+++ b/boards/native/nrf_bsim/nrf54l15bsim_nrf54l15_cpuapp.dts
@@ -103,3 +103,8 @@
 &clock {
 	status = "okay";
 };
+
+&rng {
+	status = "okay";
+	compatible = "zephyr,native-posix-rng";
+};


### PR DESCRIPTION
By now this target relies on the native_posix entropy driver. Let's set it as "okay" so it will be used by default as is when a sample needs an entropy driver.