### PR TITLE
Bluetooth: mesh: transport: logic fix for unseg msgs

### DIFF
--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -1666,6 +1666,14 @@ int bt_mesh_trans_recv(struct net_buf_simple *buf, struct bt_mesh_net_rx *rx)
 		err = trans_seg(buf, rx, &pdu_type, &seq_auth, &seg_count);
 	} else {
 		seg_count = 1;
+
+		/* Avoid further processing of unsegmented messages that are not a
+		 * local match nor a Friend match, with the exception of ctl messages.
+		 */
+		if (!rx->ctl && !rx->local_match && !rx->friend_match) {
+			return 0;
+		}
+
 		err = trans_unseg(buf, rx, &seq_auth);
 	}
 


### PR DESCRIPTION
Fixed transport layer logic causing excessive processing of unsegmented messages in bt_mesh_trans_recv() calls.

**To do:**
- [x] Pass PTS tests (only known, unrelated issues failing)