### PR TITLE
sca: codechecker: Twister default values

### DIFF
--- a/.codechecker.yml
+++ b/.codechecker.yml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (c) 2024, Basalte bv
+
+analyzer:
+  # Start by disabling all
+  - --disable-all
+
+  # Enable the sensitive profile
+  - --enable=sensitive
+
+  # Disable unused cases
+  - --disable=boost
+  - --disable=mpi
+
+  # Many identifiers in zephyr start with _
+  - --disable=clang-diagnostic-reserved-identifier
+  - --disable=clang-diagnostic-reserved-macro-identifier
+
+  # Cleanup
+  - --clean

--- a/cmake/gen_version_h.cmake
+++ b/cmake/gen_version_h.cmake
@@ -2,6 +2,11 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
+set(ZEPHYR_BASE $ENV{ZEPHYR_BASE} CACHE PATH "Zephyr base")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${ZEPHYR_BASE}/cmake/modules)
+
+include(git)
+
 if(VERSION_TYPE STREQUAL KERNEL)
   set(BUILD_VERSION_NAME BUILD_VERSION)
 else()
@@ -10,23 +15,7 @@ endif()
 
 if(NOT DEFINED ${BUILD_VERSION_NAME})
   cmake_path(GET VERSION_FILE PARENT_PATH work_dir)
-  find_package(Git QUIET)
-  if(GIT_FOUND)
-    execute_process(
-      COMMAND ${GIT_EXECUTABLE} describe --abbrev=12 --always
-      WORKING_DIRECTORY                ${work_dir}
-      OUTPUT_VARIABLE                  ${BUILD_VERSION_NAME}
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-      ERROR_STRIP_TRAILING_WHITESPACE
-      ERROR_VARIABLE                   stderr
-      RESULT_VARIABLE                  return_code
-    )
-    if(return_code)
-      message(STATUS "git describe failed: ${stderr}")
-    elseif(NOT "${stderr}" STREQUAL "")
-      message(STATUS "git describe warned: ${stderr}")
-    endif()
-  endif()
+  git_describe(${work_dir} ${BUILD_VERSION_NAME})
 endif()
 
 include(${ZEPHYR_BASE}/cmake/modules/version.cmake)

--- a/cmake/modules/git.cmake
+++ b/cmake/modules/git.cmake
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include_guard(GLOBAL)
+
+find_package(Git QUIET)
+
+# Usage:
+#   git_describe(<dir> <output>)
+#
+# Helper function to get a short GIT desciption associated with a directory.
+# OUTPUT is set to the output of `git describe --abbrev=12 --always` as run
+# from DIR.
+#
+function(git_describe DIR OUTPUT)
+  if(GIT_FOUND)
+    execute_process(
+      COMMAND ${GIT_EXECUTABLE} describe --abbrev=12 --always
+      WORKING_DIRECTORY                ${DIR}
+      OUTPUT_VARIABLE                  DESCRIPTION
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_STRIP_TRAILING_WHITESPACE
+      ERROR_VARIABLE                   stderr
+      RESULT_VARIABLE                  return_code
+    )
+    if(return_code)
+      message(STATUS "git describe failed: ${stderr}")
+    elseif(NOT "${stderr}" STREQUAL "")
+      message(STATUS "git describe warned: ${stderr}")
+    else()
+      # Save output
+      set(${OUTPUT} ${DESCRIPTION} PARENT_SCOPE)
+    endif()
+  endif()
+endfunction()

--- a/cmake/sca/codechecker/sca.cmake
+++ b/cmake/sca/codechecker/sca.cmake
@@ -5,6 +5,14 @@
 find_program(CODECHECKER_EXE NAMES CodeChecker codechecker REQUIRED)
 message(STATUS "Found SCA: CodeChecker (${CODECHECKER_EXE})")
 
+# Get CodeChecker specific variables
+zephyr_get(CODECHECKER_ANALYZE_OPTS)
+zephyr_get(CODECHECKER_EXPORT)
+zephyr_get(CODECHECKER_PARSE_EXIT_STATUS)
+zephyr_get(CODECHECKER_PARSE_OPTS)
+zephyr_get(CODECHECKER_STORE)
+zephyr_get(CODECHECKER_STORE_OPTS)
+
 # CodeChecker uses the compile_commands.json as input
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
@@ -47,8 +55,7 @@ if(NOT CODECHECKER_PARSE_EXIT_STATUS)
   set(CODECHECKER_PARSE_OPTS ${CODECHECKER_PARSE_OPTS} || ${CMAKE_COMMAND} -E true)
 endif()
 
-
-if(CODECHECKER_EXPORT)
+if(DEFINED CODECHECKER_EXPORT)
   string(REPLACE "," ";" export_list ${CODECHECKER_EXPORT})
 
   foreach(export_item IN LISTS export_list)
@@ -80,7 +87,7 @@ else()
   )
 endif()
 
-if(CODECHECKER_STORE OR CODECHECKER_STORE_OPTS)
+if(DEFINED CODECHECKER_STORE OR DEFINED CODECHECKER_STORE_OPTS)
   add_custom_command(
     TARGET codechecker POST_BUILD
     COMMAND ${CODECHECKER_EXE} store

--- a/cmake/sca/codechecker/sca.cmake
+++ b/cmake/sca/codechecker/sca.cmake
@@ -64,7 +64,6 @@ add_custom_target(codechecker ALL
     ${CMAKE_BINARY_DIR}/compile_commands.json
     || ${CMAKE_COMMAND} -E true # allow to continue processing results
   DEPENDS ${CMAKE_BINARY_DIR}/compile_commands.json ${output_dir}/codechecker.ready
-  BYPRODUCTS ${output_dir}/codechecker.plist
   VERBATIM
   USES_TERMINAL
   COMMAND_EXPAND_LISTS
@@ -89,8 +88,7 @@ if(DEFINED CODECHECKER_EXPORT)
   foreach(export_item IN LISTS export_list)
     message(STATUS "CodeChecker export: ${CMAKE_BINARY_DIR}/codechecker.${export_item}")
 
-    add_custom_command(
-      TARGET codechecker POST_BUILD
+    add_custom_target(codechecker-report-${export_item} ALL
       COMMAND ${CODECHECKER_EXE} parse
         ${output_dir}/codechecker.plist
         --export ${export_item}
@@ -103,11 +101,11 @@ if(DEFINED CODECHECKER_EXPORT)
       USES_TERMINAL
       COMMAND_EXPAND_LISTS
     )
+    add_dependencies(codechecker-report-${export_item} codechecker)
   endforeach()
 elseif(NOT CODECHECKER_PARSE_SKIP)
   # Output parse results
-  add_custom_command(
-    TARGET codechecker POST_BUILD
+    add_custom_target(codechecker-parse ALL
     COMMAND ${CODECHECKER_EXE} parse
       ${output_dir}/codechecker.plist
       ${CODECHECKER_CONFIG_FILE}
@@ -117,11 +115,11 @@ elseif(NOT CODECHECKER_PARSE_SKIP)
     USES_TERMINAL
     COMMAND_EXPAND_LISTS
   )
+  add_dependencies(codechecker-parse codechecker)
 endif()
 
 if(DEFINED CODECHECKER_STORE OR DEFINED CODECHECKER_STORE_OPTS)
-  add_custom_command(
-    TARGET codechecker POST_BUILD
+  add_custom_target(codechecker-store ALL
     COMMAND ${CODECHECKER_EXE} store
       ${CODECHECKER_CONFIG_FILE}
       ${CODECHECKER_STORE_TAG}
@@ -132,4 +130,5 @@ if(DEFINED CODECHECKER_STORE OR DEFINED CODECHECKER_STORE_OPTS)
     USES_TERMINAL
     COMMAND_EXPAND_LISTS
   )
+  add_dependencies(codechecker-store codechecker)
 endif()

--- a/cmake/sca/codechecker/sca.cmake
+++ b/cmake/sca/codechecker/sca.cmake
@@ -13,6 +13,7 @@ message(STATUS "Found SCA: CodeChecker (${CODECHECKER_EXE})")
 # Get CodeChecker specific variables
 zephyr_get(CODECHECKER_ANALYZE_JOBS)
 zephyr_get(CODECHECKER_ANALYZE_OPTS)
+zephyr_get(CODECHECKER_CLEANUP)
 zephyr_get(CODECHECKER_CONFIG_FILE)
 zephyr_get(CODECHECKER_EXPORT)
 zephyr_get(CODECHECKER_NAME)
@@ -95,6 +96,16 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E rm ${output_dir}/codechecker.ready
 )
 
+if(CODECHECKER_CLEANUP)
+  add_custom_target(codechecker-cleanup ALL
+    COMMAND ${CMAKE_COMMAND} -E rm -r ${output_dir}/codechecker.plist
+  )
+else()
+  add_custom_target(codechecker-cleanup)
+endif()
+
+add_dependencies(codechecker-cleanup codechecker)
+
 # If 'codechecker parse' returns an exit status of '2', it means more than 0
 # issues were detected. Suppress the exit status by default, but permit opting
 # in to the failure.
@@ -122,6 +133,7 @@ if(DEFINED CODECHECKER_EXPORT)
       COMMAND_EXPAND_LISTS
     )
     add_dependencies(codechecker-report-${export_item} codechecker)
+    add_dependencies(codechecker-cleanup codechecker-report-${export_item})
   endforeach()
 elseif(NOT CODECHECKER_PARSE_SKIP)
   # Output parse results
@@ -136,6 +148,7 @@ elseif(NOT CODECHECKER_PARSE_SKIP)
     COMMAND_EXPAND_LISTS
   )
   add_dependencies(codechecker-parse codechecker)
+  add_dependencies(codechecker-cleanup codechecker-parse)
 endif()
 
 if(DEFINED CODECHECKER_STORE OR DEFINED CODECHECKER_STORE_OPTS)
@@ -151,4 +164,5 @@ if(DEFINED CODECHECKER_STORE OR DEFINED CODECHECKER_STORE_OPTS)
     COMMAND_EXPAND_LISTS
   )
   add_dependencies(codechecker-store codechecker)
+  add_dependencies(codechecker-cleanup codechecker-store)
 endif()

--- a/doc/develop/sca/codechecker.rst
+++ b/doc/develop/sca/codechecker.rst
@@ -19,8 +19,8 @@ CodeChecker itself is a python package available on `pypi <https://pypi.org/proj
 
     pip install codechecker
 
-Running with CodeChecker
-************************
+Building with CodeChecker
+*************************
 
 To run CodeChecker, :ref:`west build <west-building>` should be
 called with a ``-DZEPHYR_SCA_VARIANT=codechecker`` parameter, e.g.
@@ -33,56 +33,63 @@ called with a ``-DZEPHYR_SCA_VARIANT=codechecker`` parameter, e.g.
 Configuring CodeChecker
 ***********************
 
-To configure CodeChecker or analyzers used, arguments can be passed using the
-``CODECHECKER_ANALYZE_OPTS`` parameter, e.g.
+CodeChecker uses different command steps, each with their respective configuration
+parameters. The following table lists all these options.
 
-.. code-block:: shell
+.. list-table::
+   :header-rows: 1
 
-    west build -b mimxrt1064_evk samples/basic/blinky -- -DZEPHYR_SCA_VARIANT=codechecker \
-    -DCODECHECKER_ANALYZE_OPTS="--config;$CODECHECKER_CONFIG_FILE;--timeout;60"
+   * - Parameter
+     - Description
+   * - ``CODECHECKER_ANALYZE_JOBS``
+     - The number of threads to use in analysis. (default: <CPU count>)
+   * - ``CODECHECKER_ANALYZE_OPTS``
+     - Arguments passed to the ``analyze`` command directly. (e.g. ``--timeout;360``)
+   * - ``CODECHECKER_CLEANUP``
+     - Perform a cleanup after parsing/storing. This will remove all ``plist`` files.
+   * - ``CODECHECKER_CONFIG_FILE``
+     - A JSON or YAML file with configuration options passed to all commands.
+   * - ``CODECHECKER_EXPORT``
+     - A comma separated list of report types. Allowed types are:
+       ``html,json,codeclimate,gerrit,baseline``.
+   * - ``CODECHECKER_NAME``
+     - The CodeChecker run metadata name. (default: ``zephyr``)
+   * - ``CODECHECKER_PARSE_EXIT_STATUS``
+     - By default, CodeChecker identified issues will not fail the build, set this option to fail
+       during analysis.
+   * - ``CODECHECKER_PARSE_OPTS``
+     - Arguments passed to the ``parse`` command directly. (e.g. ``--verbose;debug``)
+   * - ``CODECHECKER_PARSE_SKIP``
+     - Skip parsing the analysis, useful if you simply want to store the results.
+   * - ``CODECHECKER_STORE``
+     - Run the ``store`` command after analysis.
+   * - ``CODECHECKER_STORE_OPTS``
+     - Arguments passed to the ``store`` command directly. Implies ``CODECHECKER_STORE``.
+       (e.g. ``--url;localhost:8001/Default``)
+   * - ``CODECHECKER_STORE_TAG``
+     - Pass an identifier ``--tag`` to the ``store`` command.
+   * - ``CODECHECKER_TRIM_PATH_PREFIX``
+     - Trim the defined path from the analysis results, e.g. ``/home/user/zephyrproject``.
+       The value from ``west topdir`` is added by default.
+
+These parameters can be passed on the command line, or be set as environment variables.
 
 
-Storing CodeChecker results
-***************************
+Running twister with CodeChecker
+********************************
 
-If a CodeChecker server is active the results can be uploaded and stored for tracking purposes.
-Storing is done using the optional ``CODECHECKER_STORE=y`` or ``CODECHECKER_STORE_OPTS="arg;list"``
-parameters, e.g.
+When running CodeChecker as part of ``twister`` some default options are set as following:
 
-.. code-block:: shell
+.. list-table::
+   :header-rows: 1
 
-    west build -b mimxrt1064_evk samples/basic/blinky -- -DZEPHYR_SCA_VARIANT=codechecker \
-    -DCODECHECKER_STORE_OPTS="--name;build;--url;localhost:8001/Default"
+   * - Parameter
+     - Value
+   * - ``CODECHECKER_ANALYZE_JOBS``
+     - ``1``
+   * - ``CODECHECKER_NAME``
+     - ``<board target>:<testsuite name>``
+   * - ``CODECHECKER_STORE_TAG``
+     - The value from ``git describe`` in the application source directory.
 
-.. note::
-
-    If ``--name`` isn't passed to either ``CODECHECKER_ANALYZE_OPTS`` or ``CODECHECKER_STORE_OPTS``,
-    the default ``zephyr`` is used.
-
-
-Exporting CodeChecker reports
-*****************************
-
-Optional reports can be generated using the CodeChecker results, when passing a
-``-DCODECHECKER_EXPORT=<type>`` parameter. Allowed types are: ``html,json,codeclimate,gerrit,baseline``.
-Multiple types can be passed as comma-separated arguments.
-
-Optional parser configuration arguments can be passed using the
-``CODECHECKER_PARSE_OPTS`` parameter, e.g.
-
-.. code-block:: shell
-
-    west build -b mimxrt1064_evk samples/basic/blinky -- -DZEPHYR_SCA_VARIANT=codechecker \
-    -DCODECHECKER_EXPORT=html,json -DCODECHECKER_PARSE_OPTS="--trim-path-prefix;$PWD"
-
-Failing the build on CodeChecker issues
-***************************************
-
-By default, CodeChecker identified issues will not fail the build, only generate
-a report. To fail the build if any issues are found (for example, for use in
-CI), pass the ``CODECHECKER_PARSE_EXIT_STATUS=y`` parameter, e.g.
-
-.. code-block:: shell
-
-    west build -b mimxrt1064_evk samples/basic/blinky -- -DZEPHYR_SCA_VARIANT=codechecker \
-    -DCODECHECKER_PARSE_EXIT_STATUS=y
+To override these values, set an environment variable or pass them as extra arguments.

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -343,6 +343,7 @@ class CMake:
         cmake_args = [
             f'-B{self.build_dir}',
             f'-DTC_RUNID={self.instance.run_id}',
+            f'-DTC_NAME={self.instance.testsuite.name}',
             f'-D{warning_command}={warnings_as_errors}',
             f'-DEXTRA_GEN_DEFINES_ARGS={gen_defines_args}',
             f'-G{self.env.generator}'

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -369,7 +369,7 @@ TESTDATA_2_2 = [
      True, True, False,
      TwisterStatus.NONE, None,
      [os.path.join('dummy', 'cmake'),
-      '-B' + os.path.join('build', 'dir'), '-DTC_RUNID=1',
+      '-B' + os.path.join('build', 'dir'), '-DTC_RUNID=1', '-DTC_NAME=testcase',
       '-DSB_CONFIG_COMPILER_WARNINGS_AS_ERRORS=y',
       '-DEXTRA_GEN_DEFINES_ARGS=--edtlib-Werror', '-Gdummy_generator',
       '-S' + os.path.join('source', 'dir'),
@@ -383,7 +383,7 @@ TESTDATA_2_2 = [
      True, False, True,
      TwisterStatus.ERROR, 'Cmake build failure',
      [os.path.join('dummy', 'cmake'),
-      '-B' + os.path.join('build', 'dir'), '-DTC_RUNID=1',
+      '-B' + os.path.join('build', 'dir'), '-DTC_RUNID=1', '-DTC_NAME=testcase',
       '-DSB_CONFIG_COMPILER_WARNINGS_AS_ERRORS=n',
       '-DEXTRA_GEN_DEFINES_ARGS=', '-Gdummy_generator',
       '-Szephyr_base/share/sysbuild',
@@ -442,6 +442,7 @@ def test_cmake_run_cmake(
     instance_mock.status = TwisterStatus.NONE
     instance_mock.reason = None
     instance_mock.testsuite = mock.Mock()
+    instance_mock.testsuite.name = 'testcase'
     instance_mock.testsuite.required_snippets = ['dummy snippet 1', 'ds2']
     instance_mock.testcases = [mock.Mock(), mock.Mock()]
     instance_mock.testcases[0].status = TwisterStatus.NONE


### PR DESCRIPTION
This PR enables running Static Code Analysis tools as part of twister. The main focus is to have a [CodeChecker](https://codechecker.readthedocs.io/en/latest/) server running to track reported issues.

An example:
```shell
# Setup the environment
$ export CODECHECKER_CONFIG_FILE="$PWD/.codechecker.yml"
$ export CODECHECKER_STORE_OPTS="--url;localhost:8001/Zephyr"
$ export CODECHECKER_CLEANUP=y
$ export CODECHECKER_PARSE_SKIP=y
# Run some twisters
$ west twister -T samples/net/sockets -p native_sim --build-only -x=ZEPHYR_SCA_VARIANT=codechecker
$ west twister -T samples/hello_world -p mimxrt1064_evk -p qemu_x86 --build-only -x=ZEPHYR_SCA_VARIANT=codechecker
```

![image](https://github.com/user-attachments/assets/59a3d095-e7e2-4762-ab19-f894ff18d3a8)
![image](https://github.com/user-attachments/assets/5e91a59d-74a4-4d2c-beaf-b1a9e9d120c9)
![image](https://github.com/user-attachments/assets/3039cbfe-7a90-4c79-a0b2-869b7407c8da)

