### PR TITLE
MAX32: Add gpio wakeup option

### DIFF
--- a/drivers/gpio/gpio_max32.c
+++ b/drivers/gpio/gpio_max32.c
@@ -11,6 +11,7 @@
 #include <zephyr/drivers/clock_control/adi_max32_clock_control.h>
 #include <zephyr/dt-bindings/gpio/adi-max32-gpio.h>
 #include <gpio.h>
+#include <wrap_max32_lp.h>
 
 #define DT_DRV_COMPAT adi_max32_gpio
 
@@ -137,6 +138,12 @@ static int api_pin_configure(const struct device *dev, gpio_pin_t pin, gpio_flag
 		} else if (flags & GPIO_OUTPUT_INIT_HIGH) {
 			MXC_GPIO_OutSet(cfg->regs, BIT(pin));
 		}
+	}
+
+	/* Enable wakeup source if flag exist */
+	if (flags & MAX32_GPIO_WAKEUP_EN) {
+		MXC_LP_EnableGPIOWakeup(&gpio_cfg);
+		MXC_GPIO_SetWakeEn(gpio_cfg.port, gpio_cfg.mask);
 	}
 
 	return 0;

--- a/include/zephyr/dt-bindings/gpio/adi-max32-gpio.h
+++ b/include/zephyr/dt-bindings/gpio/adi-max32-gpio.h
@@ -38,6 +38,10 @@
  * - Bit 11: Weak pull down selection, Weak Pulldown to VDDIOH (1MOhm)
  *          0: Disable
  *          1: Enable
+ *
+ * - Bit 12: Enable the I/O as a wakeup from low-power modes (SLEEP, DEEPSLEEP, BACKUP).
+ *          0: Disable
+ *          1: Enable
  * @{
  */
 
@@ -61,6 +65,10 @@
 /** GPIO bias weak pull down selection, to VDDIOH (1MOhm) */
 #define MAX32_GPIO_WEAK_PULL_DOWN_POS (11U)
 #define MAX32_GPIO_WEAK_PULL_DOWN     (1U << MAX32_GPIO_WEAK_PULL_DOWN_POS)
+
+/** GPIO wakeup enable */
+#define MAX32_GPIO_WAKEUP_EN_POS (12U)
+#define MAX32_GPIO_WAKEUP_EN     (1U << MAX32_GPIO_WAKEUP_EN_POS)
 
 /** @} */
 


### PR DESCRIPTION
GPIO pins can be used to wakeup device from sleep/deepsleep modes This commit add this feature in gpio driver.

Usage:

```
...
buttons {
    compatible = gpio-keys;
    pb1: pb1 {
         gpios = <&gpio0 18 MAX32_GPIO_WAKEUP_EN>;
    };
};
...
```


Can be tested with samples/basic/button with CONFIG_PM=y

![image](https://github.com/user-attachments/assets/39d2a035-ba56-4b36-b64c-87be68e5fb9c)
