### PR TITLE
shell: kernel: do a cold reboot by standard

### DIFF
--- a/subsys/shell/modules/kernel_service.c
+++ b/subsys/shell/modules/kernel_service.c
@@ -673,7 +673,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_kernel_reboot,
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_kernel,
 	SHELL_CMD(cycles, NULL, "Kernel cycles.", cmd_kernel_cycles),
 #if defined(CONFIG_REBOOT)
-	SHELL_CMD(reboot, &sub_kernel_reboot, "Reboot.", NULL),
+	SHELL_CMD(reboot, &sub_kernel_reboot, "Reboot.", cmd_kernel_reboot_cold),
 #endif
 	SHELL_CMD(thread, &sub_kernel_thread, "Kernel threads.", NULL),
 #if defined(CONFIG_SYS_HEAP_RUNTIME_STATS) && (K_HEAP_MEM_POOL_SIZE > 0)


### PR DESCRIPTION
do a cold reboot by default if no option is provided for `kernel reboot`, instead of requiring to
type `kernel reboot cold`.

`kernel reboot cold` and `kernel reboot warm` will still be available.