### PR TITLE
samples: bluetooth: use zephyr:code-sample directive

### DIFF
--- a/boards/96boards/carbon/doc/stm32f401xe.rst
+++ b/boards/96boards/carbon/doc/stm32f401xe.rst
@@ -347,7 +347,7 @@ in general, see :ref:`build_an_application`.
       :board: 96b_carbon/stm32f401xe
       :goals: build flash
 
-#. Refer to the instructions in :ref:`peripheral_hr` for how
+#. Refer to the instructions in :zephyr:code-sample:`ble_peripheral_hr` for how
    to verify functionality.
 
 Congratulations! Your 96Boards Carbon now has Bluetooth

--- a/boards/ezurio/bl5340_dvk/doc/index.rst
+++ b/boards/ezurio/bl5340_dvk/doc/index.rst
@@ -409,9 +409,9 @@ Testing Bluetooth on the BL5340 DVK
 Many of the Bluetooth examples will work on the BL5340 DVK.
 Try them out:
 
-* :ref:`ble_peripheral`
-* :ref:`bluetooth-eddystone-sample`
-* :ref:`bluetooth-ibeacon-sample`
+* :zephyr:code-sample:`ble_peripheral`
+* :zephyr:code-sample:`bluetooth_eddystone`
+* :zephyr:code-sample:`bluetooth_ibeacon`
 
 References
 **********

--- a/boards/ezurio/bl652_dvk/doc/bl652_dvk.rst
+++ b/boards/ezurio/bl652_dvk/doc/bl652_dvk.rst
@@ -245,9 +245,9 @@ Testing Bluetooth on the BL652 DVK
 Many of the Bluetooth examples will work on the BL652 DVK.
 Try them out:
 
-* :ref:`ble_peripheral`
-* :ref:`bluetooth-eddystone-sample`
-* :ref:`bluetooth-ibeacon-sample`
+* :zephyr:code-sample:`ble_peripheral`
+* :zephyr:code-sample:`bluetooth_eddystone`
+* :zephyr:code-sample:`bluetooth_ibeacon`
 
 Testing the LEDs and buttons in the BL652 DVK
 *********************************************

--- a/boards/ezurio/bl653_dvk/doc/bl653_dvk.rst
+++ b/boards/ezurio/bl653_dvk/doc/bl653_dvk.rst
@@ -151,9 +151,9 @@ Testing Bluetooth on the BL653 DVK
 Many of the Bluetooth examples will work on the BL653 DVK.
 Try them out:
 
-* :ref:`ble_peripheral`
-* :ref:`bluetooth-eddystone-sample`
-* :ref:`bluetooth-ibeacon-sample`
+* :zephyr:code-sample:`ble_peripheral`
+* :zephyr:code-sample:`bluetooth_eddystone`
+* :zephyr:code-sample:`bluetooth_ibeacon`
 
 
 Testing the LEDs and buttons on the BL653 DVK

--- a/boards/ezurio/bl654_dvk/doc/bl654_dvk.rst
+++ b/boards/ezurio/bl654_dvk/doc/bl654_dvk.rst
@@ -162,9 +162,9 @@ Testing Bluetooth on the BL654 DVK
 Many of the Bluetooth examples will work on the BL654 DVK.
 Try them out:
 
-* :ref:`ble_peripheral`
-* :ref:`bluetooth-eddystone-sample`
-* :ref:`bluetooth-ibeacon-sample`
+* :zephyr:code-sample:`ble_peripheral`
+* :zephyr:code-sample:`bluetooth_eddystone`
+* :zephyr:code-sample:`bluetooth_ibeacon`
 
 
 Testing the LEDs and buttons on the BL654 DVK

--- a/boards/ezurio/bl654_sensor_board/doc/bl654_sensor_board.rst
+++ b/boards/ezurio/bl654_sensor_board/doc/bl654_sensor_board.rst
@@ -222,9 +222,9 @@ Testing Bluetooth on the BL654 Sensor Board
 Many of the Bluetooth examples will work on the BL654 Sensor Board.
 Try them out:
 
-* :ref:`ble_peripheral`
-* :ref:`bluetooth-eddystone-sample`
-* :ref:`bluetooth-ibeacon-sample`
+* :zephyr:code-sample:`ble_peripheral`
+* :zephyr:code-sample:`bluetooth_eddystone`
+* :zephyr:code-sample:`bluetooth_ibeacon`
 
 
 Testing the LED and button on the BL654 Sensor Board

--- a/boards/ezurio/bl654_usb/doc/bl654_usb.rst
+++ b/boards/ezurio/bl654_usb/doc/bl654_usb.rst
@@ -160,9 +160,9 @@ Testing Bluetooth on the BL654 USB
 Many of the Bluetooth examples will work on the BL654 USB.
 Try them out:
 
-* :ref:`ble_peripheral`
-* :ref:`bluetooth-eddystone-sample`
-* :ref:`bluetooth-ibeacon-sample`
+* :zephyr:code-sample:`ble_peripheral`
+* :zephyr:code-sample:`bluetooth_eddystone`
+* :zephyr:code-sample:`bluetooth_ibeacon`
 
 
 Testing the LED on the BL654 USB

--- a/boards/ezurio/bt510/doc/bt510.rst
+++ b/boards/ezurio/bt510/doc/bt510.rst
@@ -228,9 +228,9 @@ Testing Bluetooth on the BT510
 Many of the Bluetooth examples will work on the BT510.
 Try them out:
 
-* :ref:`ble_peripheral`
-* :ref:`bluetooth-eddystone-sample`
-* :ref:`bluetooth-ibeacon-sample`
+* :zephyr:code-sample:`ble_peripheral`
+* :zephyr:code-sample:`bluetooth_eddystone`
+* :zephyr:code-sample:`bluetooth_ibeacon`
 
 
 Testing the LEDs and buttons on the BT510

--- a/boards/ezurio/bt610/doc/bt610.rst
+++ b/boards/ezurio/bt610/doc/bt610.rst
@@ -582,9 +582,9 @@ Testing Bluetooth on the BT610
 Many of the Bluetooth examples will work on the BT610.
 Try them out:
 
-* :ref:`ble_peripheral`
-* :ref:`bluetooth-eddystone-sample`
-* :ref:`bluetooth-ibeacon-sample`
+* :zephyr:code-sample:`ble_peripheral`
+* :zephyr:code-sample:`bluetooth_eddystone`
+* :zephyr:code-sample:`bluetooth_ibeacon`
 
 
 Testing the LEDs and buttons on the BT610

--- a/boards/ezurio/mg100/doc/index.rst
+++ b/boards/ezurio/mg100/doc/index.rst
@@ -213,9 +213,9 @@ Testing Bluetooth on the MG100
 Many of the Bluetooth examples will work on the MG100.
 Try them out:
 
-* :ref:`ble_peripheral`
-* :ref:`bluetooth-eddystone-sample`
-* :ref:`bluetooth-ibeacon-sample`
+* :zephyr:code-sample:`ble_peripheral`
+* :zephyr:code-sample:`bluetooth_eddystone`
+* :zephyr:code-sample:`bluetooth_ibeacon`
 
 Testing the LEDs and buttons in the MG100
 ====================================================

--- a/boards/ezurio/pinnacle_100_dvk/doc/index.rst
+++ b/boards/ezurio/pinnacle_100_dvk/doc/index.rst
@@ -187,9 +187,9 @@ Testing Bluetooth on the Pinnacle 100 DVK
 Many of the Bluetooth examples will work on the Pinnacle 100 DVK.
 Try them out:
 
-* :ref:`ble_peripheral`
-* :ref:`bluetooth-eddystone-sample`
-* :ref:`bluetooth-ibeacon-sample`
+* :zephyr:code-sample:`ble_peripheral`
+* :zephyr:code-sample:`bluetooth_eddystone`
+* :zephyr:code-sample:`bluetooth_ibeacon`
 
 Testing the LEDs and buttons in the Pinnacle 100 DVK
 ====================================================

--- a/boards/silabs/dev_kits/sltb010a/doc/index.rst
+++ b/boards/silabs/dev_kits/sltb010a/doc/index.rst
@@ -177,7 +177,7 @@ blobs from the SiLabs HAL repository.
    west blobs fetch hal_silabs
 
 Then build the Zephyr kernel and a Bluetooth sample with the following
-command. The :ref:`bluetooth-observer-sample` sample application is used in
+command. The :zephyr:code-sample:`bluetooth_observer` sample application is used in
 this example.
 
 BRD4184A:

--- a/boards/silabs/dev_kits/xg24_dk2601b/doc/index.rst
+++ b/boards/silabs/dev_kits/xg24_dk2601b/doc/index.rst
@@ -160,7 +160,7 @@ blobs from the SiLabs HAL repository.
    west blobs fetch hal_silabs
 
 Then build the Zephyr kernel and a Bluetooth sample with the following
-command. The :ref:`bluetooth-observer-sample` sample application is used in
+command. The :zephyr:code-sample:`bluetooth_observer` sample application is used in
 this example.
 
 .. zephyr-app-commands::

--- a/boards/sparkfun/thing_plus_matter_mgm240p/doc/index.rst
+++ b/boards/sparkfun/thing_plus_matter_mgm240p/doc/index.rst
@@ -141,7 +141,7 @@ blobs from the SiLabs HAL repository.
    west blobs fetch silabs
 
 Then build the Zephyr kernel and a Bluetooth sample with the following
-command. The :ref:`bluetooth-observer-sample` sample application is used in
+command. The :zephyr:code-sample:`bluetooth_observer` sample application is used in
 this example.
 
 .. zephyr-app-commands::

--- a/boards/st/stm32wb5mmg/doc/stm32wb5mmg.rst
+++ b/boards/st/stm32wb5mmg/doc/stm32wb5mmg.rst
@@ -245,7 +245,7 @@ Flashing `hci_uart` application to STM32WB5MMG
 Connect the B-U585I-IOT02A to your host computer using the USB port. Put
 the SW4 (MCU SWD) in OFF mode and SW5 (SWD BLE) in ON mode. Then build
 and flash an application. Here is an example for the
-:ref:`hci_uart <bluetooth-hci-uart-sample>` application.
+:zephyr:code-sample:`bluetooth_hci_uart` application.
 
 Run a serial host program to connect with your B-U585I-IOT02A board:
 
@@ -287,7 +287,7 @@ Debugging
 =========
 
 You can debug an application in the usual way.  Here is an example for the
-:ref:`hci_uart <bluetooth-hci-uart-sample>` application.
+:zephyr:code-sample:`bluetooth_hci_uart` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/bluetooth/observer

--- a/boards/vngiotlab/nrf51_vbluno51/doc/index.rst
+++ b/boards/vngiotlab/nrf51_vbluno51/doc/index.rst
@@ -138,8 +138,8 @@ Testing the VBLUno51 with Zephyr: buttons, LEDs, UART, BLE
  * :ref:`hello_world`
  * :zephyr:code-sample:`blinky`
  * :zephyr:code-sample:`button`
- * :ref:`bluetooth-beacon-sample`
- * :ref:`peripheral_hr`
+ * :zephyr:code-sample:`bluetooth_beacon`
+ * :zephyr:code-sample:`ble_peripheral_hr`
 
 References
 **********

--- a/boards/vngiotlab/nrf52_vbluno52/doc/index.rst
+++ b/boards/vngiotlab/nrf52_vbluno52/doc/index.rst
@@ -103,5 +103,5 @@ components on the VBLUno52 board:
 * :ref:`hello_world`
 * :zephyr:code-sample:`blinky`
 * :zephyr:code-sample:`button`
-* :ref:`bluetooth-beacon-sample`
-* :ref:`peripheral_hr`
+* :zephyr:code-sample:`bluetooth_beacon`
+* :zephyr:code-sample:`ble_peripheral_hr`

--- a/doc/build/dts/api/api.rst
+++ b/doc/build/dts/api/api.rst
@@ -382,7 +382,7 @@ device.
      - Purpose
    * - zephyr,bt-c2h-uart
      - Selects the UART used for host communication in the
-       :ref:`bluetooth-hci-uart-sample`
+       :zephyr:code-sample:`bluetooth_hci_uart`
    * - zephyr,bt-mon-uart
      - Sets UART device used for the Bluetooth monitor logging
    * - zephyr,bt-hci

--- a/doc/connectivity/bluetooth/bluetooth-arch.rst
+++ b/doc/connectivity/bluetooth/bluetooth-arch.rst
@@ -97,9 +97,9 @@ BLE-enabled builds that can be produced from the Zephyr project codebase:
   the Link Layer and a special application. This application is different
   depending on the physical transport chosen for HCI:
 
-  * :ref:`hci_uart <bluetooth-hci-uart-sample>`
-  * :ref:`hci_usb <bluetooth-hci-usb-sample>`
-  * :ref:`hci_spi <bluetooth-hci-spi-sample>`
+  * :zephyr:code-sample:`bluetooth_hci_uart`
+  * :zephyr:code-sample:`bluetooth_hci_usb`
+  * :zephyr:code-sample:`bluetooth_hci_spi`
 
   This application acts as a bridge between the UART, SPI or USB peripherals and
   the Controller subsystem, listening for HCI commands, sending application data
@@ -160,8 +160,8 @@ must be built with different configurations, yielding two separate images that
 must be programmed into each of the chips respectively. The Host build image
 contains the application, the BLE Host and the selected HCI driver (UART or
 SPI), while the Controller build runs either the
-:ref:`hci_uart <bluetooth-hci-uart-sample>`, or the
-:ref:`hci_spi <bluetooth-hci-spi-sample>` app to provide an interface to
+:zephyr:code-sample:`bluetooth_hci_uart`, or the
+:zephyr:code-sample:`bluetooth_hci_spi` app to provide an interface to
 the BLE Controller.
 
 This configuration is not limited to using a Zephyr OS Host, as the right side

--- a/doc/connectivity/bluetooth/bluetooth-dev.rst
+++ b/doc/connectivity/bluetooth/bluetooth-dev.rst
@@ -153,7 +153,7 @@ devices in either of :ref:`these boards's documentation <nrf52bsim_build_and_run
 
 With the :ref:`nrf52_bsim <nrf52_bsim>`, typically you do :ref:`Combined builds
 <bluetooth-build-types>`, but it is also possible to build the controller with one of the
-:ref:`HCI UART <bluetooth-hci-uart-sample>` samples in one simulated device, and the host with
+:zephyr:code-sample:`bluetooth_hci_uart` samples in one simulated device, and the host with
 the H4 driver instead of the integrated controller in another simulated device.
 
 With the :ref:`nrf5340bsim <nrf5340bsim>`, you can build with either, both controller and host

--- a/doc/connectivity/bluetooth/bluetooth-shell.rst
+++ b/doc/connectivity/bluetooth/bluetooth-shell.rst
@@ -394,7 +394,7 @@ The server can now notify the client with the command :code:`gatt notify`.
 Another option available through the GATT command is initiating the MTU exchange. To do it, use the
 :code:`gatt exchange-mtu` command. To update the shell maximum MTU, you need to update Kconfig
 symbols in the configuration file of the shell. For more details, see
-:ref:`bluetooth_mtu_update_sample`.
+:zephyr:code-sample:`bluetooth_mtu_update`.
 
 L2CAP
 *****

--- a/doc/connectivity/bluetooth/bluetooth-tools.rst
+++ b/doc/connectivity/bluetooth/bluetooth-tools.rst
@@ -166,9 +166,9 @@ Using a Zephyr-based BLE Controller
 Depending on which hardware you have available, you can choose between two
 transports when building a single-mode, Zephyr-based BLE Controller:
 
-* UART: Use the :ref:`hci_uart <bluetooth-hci-uart-sample>` sample and follow
+* UART: Use the :zephyr:code-sample:`bluetooth_hci_uart` sample and follow
   the instructions in :ref:`bluetooth-hci-uart-qemu-posix`.
-* USB: Use the :ref:`hci_usb <bluetooth-hci-usb-sample>` sample and then
+* USB: Use the :zephyr:code-sample:`bluetooth_hci_usb` sample and then
   treat it as a Host System Bluetooth Controller (see previous section)
 
 .. _bluetooth-hci-tracing:
@@ -301,7 +301,8 @@ After following these steps the Zephyr application will be available to the Andr
 over the virtual Bluetooth controller that was bridged with Bumble. You can verify that the
 Zephyr application can communicate over Bluetooth by opening the Bluetooth settings in your
 AVD and scanning for your Zephyr application device. To test this you can build the Bluetooth
-peripheral samples such as :ref:`Peripheral HR <peripheral_hr>` or :ref:`Peripheral DIS <peripheral_dis>`
+peripheral samples such as :zephyr:code-sample:`ble_peripheral_hr` or
+:zephyr:code-sample:`ble_peripheral_dis`.
 
 .. _bluetooth_ctlr_bluez:
 

--- a/doc/connectivity/usb/device/usb_device.rst
+++ b/doc/connectivity/usb/device/usb_device.rst
@@ -64,7 +64,7 @@ the next interface, preventing other composite functions from working.
 Because of this problem, HCI USB should not be used in a composite configuration.
 This problem is fixed in the implementation for new USB support.
 
-See :ref:`bluetooth-hci-usb-sample` sample for reference.
+See :zephyr:code-sample:`bluetooth_hci_usb` sample for reference.
 
 .. _usb_device_cdc_acm:
 
@@ -168,7 +168,7 @@ List of few Zephyr specific chosen properties which can be used to select
 CDC ACM UART as backend for a subsystem or application:
 
 * ``zephyr,bt-c2h-uart`` used in Bluetooth,
-  for example see :ref:`bluetooth-hci-uart-sample`
+  for example see :zephyr:code-sample:`bluetooth_hci_uart`
 * ``zephyr,ot-uart`` used in OpenThread,
   for example see :zephyr:code-sample:`coprocessor`
 * ``zephyr,shell-uart`` used by shell for serial backend,
@@ -595,9 +595,9 @@ The following Product IDs are currently used:
 +----------------------------------------------------+--------+
 | :zephyr:code-sample:`webusb`                       | 0x000A |
 +----------------------------------------------------+--------+
-| :ref:`bluetooth-hci-usb-sample`                    | 0x000B |
+| :zephyr:code-sample:`bluetooth_hci_usb`            | 0x000B |
 +----------------------------------------------------+--------+
-| :ref:`bluetooth-hci-usb-h4-sample`                 | 0x000C |
+| :zephyr:code-sample:`bluetooth_hci_usb_h4`         | 0x000C |
 +----------------------------------------------------+--------+
 | Reserved (previously: wpan-usb)                    | 0x000D |
 +----------------------------------------------------+--------+

--- a/doc/connectivity/usb/device_next/usb_device.rst
+++ b/doc/connectivity/usb/device_next/usb_device.rst
@@ -64,7 +64,7 @@ To build a sample that supports both the old and new USB device stack, set the
 configuration ``-DCONF_FILE=usbd_next_prj.conf`` either directly or via
 ``west``.
 
-* :ref:`bluetooth-hci-usb-sample`
+* :zephyr:code-sample:`bluetooth_hci_usb`
 
 * :zephyr:code-sample:`usb-cdc-acm`
 

--- a/samples/bluetooth/bap_broadcast_assistant/README.rst
+++ b/samples/bluetooth/bap_broadcast_assistant/README.rst
@@ -1,8 +1,8 @@
 .. zephyr:code-sample:: bluetooth_bap_broadcast_assistant
-   :name: Bluetooth: Broadcast Audio Assistant
+   :name: Broadcast Audio Assistant
    :relevant-api: bt_bap
 
-   Use LE Audio Broadcast Assistant functionality
+   Use LE Audio Broadcast Assistant functionality.
 
 Overview
 ********

--- a/samples/bluetooth/bap_broadcast_sink/README.rst
+++ b/samples/bluetooth/bap_broadcast_sink/README.rst
@@ -1,8 +1,8 @@
 .. zephyr:code-sample:: bluetooth_bap_broadcast_sink
-   :name: Bluetooth: Broadcast Audio Sink
+   :name: Broadcast Audio Sink
    :relevant-api: bluetooth
 
-   Bluetooth: Broadcast Audio Sink
+   Use LE Audio Broadcast Sink functionality.
 
 Overview
 ********
@@ -53,7 +53,7 @@ If you prefer to only build the application core image, you can do so by doing i
    :goals: build
 
 In that case you can pair this application core image with the
-:ref:`hci_ipc sample <bluetooth-hci-ipc-sample>`
+:zephyr:code-sample:`bluetooth_hci_ipc` sample
 :zephyr_file:`samples/bluetooth/hci_ipc/nrf5340_cpunet_iso-bt_ll_sw_split.conf` configuration.
 
 Building for a simulated nrf5340bsim

--- a/samples/bluetooth/bap_broadcast_source/README.rst
+++ b/samples/bluetooth/bap_broadcast_source/README.rst
@@ -1,8 +1,8 @@
 .. zephyr:code-sample:: bluetooth_bap_broadcast_source
-   :name: Bluetooth: Broadcast Audio Source
+   :name: Broadcast Audio Source
    :relevant-api: bluetooth
 
-   Bluetooth: Broadcast Audio Source
+   Use LE Audio Broadcast Source functionality.
 
 Overview
 ********
@@ -52,7 +52,7 @@ If you prefer to only build the application core image, you can do so by doing i
    :goals: build
 
 In that case you can pair this application core image with the
-:ref:`hci_ipc sample <bluetooth-hci-ipc-sample>`
+:zephyr:code-sample:`bluetooth_hci_ipc` sample
 :zephyr_file:`samples/bluetooth/hci_ipc/nrf5340_cpunet_iso-bt_ll_sw_split.conf` configuration.
 
 Building for a simulated nrf5340bsim

--- a/samples/bluetooth/bap_unicast_client/README.rst
+++ b/samples/bluetooth/bap_unicast_client/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth_bap_unicast_client:
+.. zephyr:code-sample:: bluetooth_bap_unicast_client
+   :name: Unicast Audio Client
+   :relevant-api: bt_bap bt_audio
 
-Bluetooth: Unicast Audio Client
-###############################
+   Use LE Audio Unicast Client functionality.
 
 Overview
 ********
@@ -56,7 +57,7 @@ If you prefer to only build the application core image, you can do so by doing i
    :goals: build
 
 In that case you can pair this application core image with the
-:ref:`hci_ipc sample <bluetooth-hci-ipc-sample>`
+:zephyr:code-sample:`bluetooth_hci_ipc` sample
 :zephyr_file:`samples/bluetooth/hci_ipc/nrf5340_cpunet_iso-bt_ll_sw_split.conf` configuration.
 
 Building for a simulated nrf52_bsim

--- a/samples/bluetooth/bap_unicast_server/README.rst
+++ b/samples/bluetooth/bap_unicast_server/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth_bap_unicast_server:
+.. zephyr:code-sample:: bluetooth_bap_unicast_server
+   :name: Unicast Audio Server
+   :relevant-api: bt_bap bt_audio
 
-Bluetooth: Unicast Audio Server
-###############################
+   Use LE Audio Unicast Server functionality.
 
 Overview
 ********
@@ -56,7 +57,7 @@ If you prefer to only build the application core image, you can do so by doing i
    :goals: build
 
 In that case you can pair this application core image with the
-:ref:`hci_ipc sample <bluetooth-hci-ipc-sample>`
+:zephyr:code-sample:`bluetooth_hci_ipc` sample
 :zephyr_file:`samples/bluetooth/hci_ipc/nrf5340_cpunet_iso-bt_ll_sw_split.conf` configuration.
 
 Building for a simulated nrf52_bsim

--- a/samples/bluetooth/beacon/README.rst
+++ b/samples/bluetooth/beacon/README.rst
@@ -1,15 +1,14 @@
-.. _bluetooth-beacon-sample:
+.. zephyr:code-sample:: bluetooth_beacon
+   :name: Beacon
+   :relevant-api: bluetooth
 
-Bluetooth: Beacon
-#################
+   Advertise an Eddystone URL using GAP Broadcaster role.
 
 Overview
 ********
 
-A simple application demonstrating the BLE Broadcaster role functionality by
+A simple application demonstrating the GAP Broadcaster role functionality by
 advertising an Eddystone URL (the Zephyr website).
-
-
 
 Requirements
 ************

--- a/samples/bluetooth/beacon/README.rst
+++ b/samples/bluetooth/beacon/README.rst
@@ -14,7 +14,7 @@ Requirements
 ************
 
 * BlueZ running on the host, or
-* A board with BLE support
+* A board with Bluetooth LE support
 
 Building and Running
 ********************

--- a/samples/bluetooth/bluetooth.rst
+++ b/samples/bluetooth/bluetooth.rst
@@ -20,7 +20,7 @@ documentation and are prefixed with :literal:`hci_` in their folder names.
    ``-DBOARD=nrf5340dk/nrf5340/cpuapp`` or
    ``-DBOARD=nrf5340dk/nrf5340/cpuapp/ns``) you must also build
    and program the corresponding sample for the nRF5340 network core
-   :ref:`bluetooth-hci-ipc-sample` which implements the Bluetooth
+   :zephyr:code-sample:`bluetooth_hci_ipc` which implements the Bluetooth
    Low Energy controller.
 
 .. note::

--- a/samples/bluetooth/broadcaster/README.rst
+++ b/samples/bluetooth/broadcaster/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth-broadcaster-sample:
+.. zephyr:code-sample:: bluetooth_broadcaster
+   :name: Broadcaster
+   :relevant-api: bluetooth
 
-Bluetooth: Broadcaster
-###########################
+   Periodically send out advertising packets with a manufacturer data element.
 
 Overview
 ********

--- a/samples/bluetooth/broadcaster/README.rst
+++ b/samples/bluetooth/broadcaster/README.rst
@@ -17,7 +17,7 @@ Requirements
 ************
 
 * BlueZ running on the host, or
-* A board with BLE support
+* A board with Bluetooth LE support
 
 Building and Running
 ********************

--- a/samples/bluetooth/broadcaster_multiple/README.rst
+++ b/samples/bluetooth/broadcaster_multiple/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth-broadcaster-multiple-sample:
+.. zephyr:code-sample:: bluetooth_broadcaster_multiple
+   :name: Multiple Broadcaster
+   :relevant-api: bluetooth
 
-Bluetooth: Multiple Broadcaster
-###############################
+   Advertise multiple advertising sets.
 
 Overview
 ********

--- a/samples/bluetooth/bthome_sensor_template/README.rst
+++ b/samples/bluetooth/bthome_sensor_template/README.rst
@@ -12,7 +12,7 @@ This code sample provides a template for implementing a `BTHome <https://bthome.
 Requirements
 ************
 
-* A board with BLE support
+* A board with Bluetooth LE support
 * A BTHome compatible listener, for example `Home Assistant <https://www.home-assistant.io/>`_ with the BTHome integration running.
 
 Building and Running

--- a/samples/bluetooth/bthome_sensor_template/README.rst
+++ b/samples/bluetooth/bthome_sensor_template/README.rst
@@ -1,9 +1,13 @@
-.. _bluetooth-bthome-sensor-template-sample:
+.. zephyr:code-sample:: bluetooth_bthome_sensor_template
+   :name: BTHome sensor template
+   :relevant-api: bluetooth
 
-Bluetooth: BTHome sensor template
-#################################
+   Implement a BTHome sensor.
 
-Template for a `BTHome <https://bthome.io/>`_ sensor.
+Overview
+********
+
+This code sample provides a template for implementing a `BTHome <https://bthome.io/>`_ sensor.
 
 Requirements
 ************

--- a/samples/bluetooth/cap_acceptor/README.rst
+++ b/samples/bluetooth/cap_acceptor/README.rst
@@ -1,8 +1,8 @@
 .. zephyr:code-sample:: bluetooth_cap_acceptor
-   :name: Bluetooth: Common Audio Profile Acceptor
+   :name: Common Audio Profile Acceptor
    :relevant-api: bt_cap bt_bap bluetooth
 
-   CAP Acceptor sample that advertises audio availability to CAP Initiators.
+   Advertise audio availability to CAP Initiators using the CAP Acceptor role.
 
 Overview
 ********
@@ -47,7 +47,7 @@ If you prefer to only build the application core image, you can do so by doing i
    :goals: build
 
 In that case you can pair this application core image with the
-:ref:`hci_ipc sample <bluetooth-hci-ipc-sample>`
+:zephyr:code-sample:`bluetooth_hci_ipc` sample
 :zephyr_file:`samples/bluetooth/hci_ipc/nrf5340_cpunet_iso-bt_ll_sw_split.conf` configuration.
 
 Building for a simulated nrf5340bsim

--- a/samples/bluetooth/cap_initiator/README.rst
+++ b/samples/bluetooth/cap_initiator/README.rst
@@ -1,9 +1,8 @@
 .. zephyr:code-sample:: bluetooth_cap_initiator
-   :name: Bluetooth: Common Audio Profile Initiator
+   :name: Common Audio Profile Initiator
    :relevant-api: bt_cap bt_bap bluetooth
 
-   CAP Initiator sample that connects to CAP Acceptors and setup unicast audio streaming,
-   or broadcast audio streams.
+   Connect to CAP Acceptors and setup unicast audio streaming or broadcast audio streams.
 
 Overview
 ********
@@ -49,7 +48,7 @@ If you prefer to only build the application core image, you can do so by doing i
    :goals: build
 
 In that case you can pair this application core image with the
-:ref:`hci_ipc sample <bluetooth-hci-ipc-sample>`
+:zephyr:code-sample:`bluetooth_hci_ipc` sample
 :zephyr_file:`samples/bluetooth/hci_ipc/nrf5340_cpunet_iso-bt_ll_sw_split.conf` configuration.
 
 Building for a simulated nrf5340bsim

--- a/samples/bluetooth/central/README.rst
+++ b/samples/bluetooth/central/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth_central:
+.. zephyr:code-sample:: ble_central
+   :name: Central
+   :relevant-api: bluetooth
 
-Bluetooth: Central
-##################
+   Implement basic BLE Central role functionality (scanning and connecting).
 
 Overview
 ********
@@ -9,8 +10,6 @@ Overview
 Application demonstrating very basic BLE Central role functionality by scanning
 for other BLE devices and establishing a connection to the first one with a
 strong enough signal.
-
-
 
 Requirements
 ************

--- a/samples/bluetooth/central/README.rst
+++ b/samples/bluetooth/central/README.rst
@@ -2,20 +2,20 @@
    :name: Central
    :relevant-api: bluetooth
 
-   Implement basic BLE Central role functionality (scanning and connecting).
+   Implement basic Bluetooth LE Central role functionality (scanning and connecting).
 
 Overview
 ********
 
-Application demonstrating very basic BLE Central role functionality by scanning
-for other BLE devices and establishing a connection to the first one with a
+Application demonstrating very basic Bluetooth LE Central role functionality by scanning
+for other Bluetooth LE devices and establishing a connection to the first one with a
 strong enough signal.
 
 Requirements
 ************
 
 * BlueZ running on the host, or
-* A board with BLE support
+* A board with Bluetooth LE support
 
 Building and Running
 ********************

--- a/samples/bluetooth/central_gatt_write/README.rst
+++ b/samples/bluetooth/central_gatt_write/README.rst
@@ -2,7 +2,7 @@
    :name: Central / GATT Write
    :relevant-api: bluetooth
 
-   Scan for a BLE device, connect to it and write a value to a characteristic.
+   Scan for a Bluetooth LE device, connect to it and write a value to a characteristic.
 
 Overview
 ********
@@ -14,7 +14,7 @@ Requirements
 ************
 
 * BlueZ running on the host, or
-* A board with BLE support
+* A board with Bluetooth LE support
 
 Building and Running
 ********************

--- a/samples/bluetooth/central_gatt_write/README.rst
+++ b/samples/bluetooth/central_gatt_write/README.rst
@@ -1,12 +1,13 @@
-.. _bluetooth_central_gatt_write:
+.. zephyr:code-sample:: ble_central_gatt_write
+   :name: Central / GATT Write
+   :relevant-api: bluetooth
 
-Bluetooth: Central / GATT Write
-###############################
+   Scan for a BLE device, connect to it and write a value to a characteristic.
 
 Overview
 ********
 
-Similar to the :ref:`Central <bluetooth_central>` sample, except that this
+Similar to the :zephyr:code-sample:`ble_central` sample, except that this
 application use GATT Write Without Response.
 
 Requirements

--- a/samples/bluetooth/central_hr/README.rst
+++ b/samples/bluetooth/central_hr/README.rst
@@ -1,12 +1,13 @@
-.. _bluetooth_central_hr:
+.. zephyr:code-sample:: ble_central_hr
+   :name: Heart-rate Monitor (Central)
+   :relevant-api: bluetooth
 
-Bluetooth: Central / Heart-rate Monitor
-#######################################
+   Connect to a BLE heart-rate monitor and read heart-rate measurements.
 
 Overview
 ********
 
-Similar to the :ref:`Central <bluetooth_central>` sample, except that this
+Similar to the :zephyr:code-sample:`ble_central` sample, except that this
 application specifically looks for heart-rate monitors and reports the
 heart-rate readings once connected.
 

--- a/samples/bluetooth/central_hr/README.rst
+++ b/samples/bluetooth/central_hr/README.rst
@@ -2,7 +2,7 @@
    :name: Heart-rate Monitor (Central)
    :relevant-api: bluetooth
 
-   Connect to a BLE heart-rate monitor and read heart-rate measurements.
+   Connect to a Bluetooth LE heart-rate monitor and read heart-rate measurements.
 
 Overview
 ********
@@ -15,7 +15,7 @@ Requirements
 ************
 
 * BlueZ running on the host, or
-* A board with BLE support
+* A board with Bluetooth LE support
 
 Building and Running
 ********************

--- a/samples/bluetooth/central_ht/README.rst
+++ b/samples/bluetooth/central_ht/README.rst
@@ -2,7 +2,7 @@
    :name: Health Thermometer (Central)
    :relevant-api: bluetooth
 
-   Connect to a BLE health thermometer sensor and read temperature measurements.
+   Connect to a Bluetooth LE health thermometer sensor and read temperature measurements.
 
 Overview
 ********
@@ -15,7 +15,7 @@ Requirements
 ************
 
 * BlueZ running on the host, or
-* A board with BLE support
+* A board with Bluetooth LE support
 
 Building and Running
 ********************

--- a/samples/bluetooth/central_ht/README.rst
+++ b/samples/bluetooth/central_ht/README.rst
@@ -1,12 +1,13 @@
-.. _bluetooth_central_ht:
+.. zephyr:code-sample:: ble_central_ht
+   :name: Health Thermometer (Central)
+   :relevant-api: bluetooth
 
-Bluetooth: Central / Health Thermometer sensor
-##############################################
+   Connect to a BLE health thermometer sensor and read temperature measurements.
 
 Overview
 ********
 
-Similar to the :ref:`Central <bluetooth_central>` sample, except that this
+Similar to the :zephyr:code-sample:`ble_central` sample, except that this
 application specifically looks for health thermometer sensor and reports the
 die temperature readings once connected.
 

--- a/samples/bluetooth/central_multilink/README.rst
+++ b/samples/bluetooth/central_multilink/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth_central_multilink:
+.. zephyr:code-sample:: ble_central_multilink
+   :name: Central Multilink
+   :relevant-api: bluetooth
 
-Bluetooth: Central
-##################
+   Scan, connect and establish connection to up to 62 peripherals.
 
 Overview
 ********

--- a/samples/bluetooth/central_multilink/README.rst
+++ b/samples/bluetooth/central_multilink/README.rst
@@ -7,7 +7,7 @@
 Overview
 ********
 
-Application demonstrating BLE Central role functionality by scanning for other
+Application demonstrating Bluetooth LE Central role functionality by scanning for other
 BLE devices and establishing connection to up to 62 peripherals with a strong
 enough signal.
 
@@ -15,7 +15,7 @@ Requirements
 ************
 
 * BlueZ running on the host, or
-* A board with BLE support
+* A board with Bluetooth LE support
 
 Building and Running
 ********************

--- a/samples/bluetooth/central_otc/README.rst
+++ b/samples/bluetooth/central_otc/README.rst
@@ -1,12 +1,13 @@
-.. _central_otc:
+.. zephyr:code-sample:: ble_central_otc
+   :name: Central OTC
+   :relevant-api: bluetooth
 
-Bluetooth: Central OTC
-######################
+   Connect to a BLE peripheral that supports the Object Transfer Service (OTS)
 
 Overview
 ********
 
-Similar to the :ref:`Central <bluetooth_central>` sample, except that this
+Similar to the :zephyr:code-sample:`ble_central` sample, except that this
 application specifically looks for the OTS (Object Transfer) GATT Service.
 And this sample is to select object sequentially, to read metadata, to write data,
 to read data, and to calculate checksum of selected objects.

--- a/samples/bluetooth/central_otc/README.rst
+++ b/samples/bluetooth/central_otc/README.rst
@@ -2,7 +2,7 @@
    :name: Central OTC
    :relevant-api: bluetooth
 
-   Connect to a BLE peripheral that supports the Object Transfer Service (OTS)
+   Connect to a Bluetooth LE peripheral that supports the Object Transfer Service (OTS)
 
 Overview
 ********
@@ -15,7 +15,7 @@ to read data, and to calculate checksum of selected objects.
 Requirements
 ************
 
-* A board with BLE support and 4 buttons.
+* A board with Bluetooth LE support and 4 buttons.
 
 Building and Running
 ********************

--- a/samples/bluetooth/central_past/README.rst
+++ b/samples/bluetooth/central_past/README.rst
@@ -7,13 +7,13 @@
 Overview
 ********
 
-A simple application demonstrating the BLE Periodic Advertising Sync Transfer
+A simple application demonstrating the Bluetooth LE Periodic Advertising Sync Transfer
 functionality as the sender.
 
 Requirements
 ************
 
-* A board with BLE 5.1 support
+* A board with Bluetooth LE 5.1 support
 
 Building and Running
 ********************

--- a/samples/bluetooth/central_past/README.rst
+++ b/samples/bluetooth/central_past/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth-central-past-sample:
+.. zephyr:code-sample:: ble_central_past
+   :name: Central Periodic Advertising Sync Transfer (PAST)
+   :relevant-api: bt_gap bluetooth
 
-Bluetooth: Central Periodic Advertising Sync Transfer (PAST)
-############################################################
+   Use the Periodic Advertising Sync Transfer (PAST) feature as the sender.
 
 Overview
 ********

--- a/samples/bluetooth/direct_adv/README.rst
+++ b/samples/bluetooth/direct_adv/README.rst
@@ -1,7 +1,8 @@
-.. _ble_direct_adv:
+.. zephyr:code-sample:: ble_direct_adv
+   :name: Direct Advertising
+   :relevant-api: bluetooth
 
-Bluetooth: Direct Advertising
-#############################
+   Advertise directly to a bonded central device.
 
 Overview
 ********

--- a/samples/bluetooth/direct_adv/README.rst
+++ b/samples/bluetooth/direct_adv/README.rst
@@ -7,21 +7,21 @@
 Overview
 ********
 
-Application demonstrating the BLE Direct Advertising capability. If no device is bonded
+Application demonstrating the Bluetooth LE Direct Advertising capability. If no device is bonded
 to the peripheral, casual advertising will be performed. Once bonded, on every subsequent
 boot direct advertising to the bonded central will be performed. Additionally this sample
-provides two BLE characteristics. To perform write, devices need to be bonded, while read
+provides two Bluetooth LE characteristics. To perform write, devices need to be bonded, while read
 can be done just after connection (no bonding required).
 
 Please note that direct advertising towards iOS based devices is not allowed.
-For more information about designing BLE devices for Apple products refer to
+For more information about designing Bluetooth LE devices for Apple products refer to
 "Accessory Design Guidelines for Apple Devices".
 
 Requirements
 ************
 
-* A board with BLE support
-* Second BLE device acting as a central with enabled privacy. For example another Zephyr board
+* A board with Bluetooth LE support
+* Second Bluetooth LE device acting as a central with enabled privacy. For example another Zephyr board
   or any modern smartphone
 
 Building and Running

--- a/samples/bluetooth/direction_finding_central/README.rst
+++ b/samples/bluetooth/direction_finding_central/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth_direction_finding_central:
+.. zephyr:code-sample:: bluetooth_direction_finding_central
+   :name: Direction Finding Central
+   :relevant-api: bluetooth
 
-Bluetooth: Direction Finding Central
-####################################
+   Connect to a BLE Direction Finding peripheral and request Constant Tone Extension.
 
 Overview
 ********
@@ -37,7 +38,7 @@ changing ``nrf52833dk/nrf52833`` as needed for your board:
    :compact:
 
 To run the application on nRF5340DK, a Bluetooth controller application must
-also run on the network core. The :ref:`bluetooth-hci-ipc-sample` sample
+also run on the network core. The :zephyr:code-sample:`bluetooth_hci_ipc` sample
 application may be used. To build this sample with direction finding support
 enabled:
 
@@ -69,7 +70,7 @@ this overlay. See :ref:`set-devicetree-overlays` for information on setting up
 and using overlays.
 
 Note that antenna matrix configuration for the nRF5340 SoC is part of the
-network core application. When :ref:`bluetooth-hci-ipc-sample` is used as the
+network core application. When :zephyr:code-sample:`bluetooth_hci_ipc` is used as the
 network core application, the antenna matrix configuration should be stored in
 the file
 :file:`samples/bluetooth/hci_ipc/boards/nrf5340dk_nrf5340_cpunet.overlay`

--- a/samples/bluetooth/direction_finding_central/README.rst
+++ b/samples/bluetooth/direction_finding_central/README.rst
@@ -2,12 +2,12 @@
    :name: Direction Finding Central
    :relevant-api: bluetooth
 
-   Connect to a BLE Direction Finding peripheral and request Constant Tone Extension.
+   Connect to a Bluetooth LE Direction Finding peripheral and request Constant Tone Extension.
 
 Overview
 ********
 
-A simple application demonstrating the BLE Direction Finding CTE reception in
+A simple application demonstrating the Bluetooth LE Direction Finding CTE reception in
 connected mode by requesting transmission of a packet containing Constant
 Tone Extension by connected peer device.
 

--- a/samples/bluetooth/direction_finding_connectionless_rx/README.rst
+++ b/samples/bluetooth/direction_finding_connectionless_rx/README.rst
@@ -2,12 +2,12 @@
    :name: Direction Finding Periodic Advertising Locator
    :relevant-api: bt_gap bluetooth
 
-   Implement BLE Direction Finding CTE Locator functionality.
+   Implement Bluetooth LE Direction Finding CTE Locator functionality.
 
 Overview
 ********
 
-A simple application demonstrating the BLE Direction Finding CTE Locator
+A simple application demonstrating the Bluetooth LE Direction Finding CTE Locator
 functionality by receiving and sampling sending Constant Tone Extension with
 periodic advertising PDUs.
 

--- a/samples/bluetooth/direction_finding_connectionless_rx/README.rst
+++ b/samples/bluetooth/direction_finding_connectionless_rx/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth_direction_finding_connectionless_rx:
+.. zephyr:code-sample:: ble_direction_finding_connectionless_rx
+   :name: Direction Finding Periodic Advertising Locator
+   :relevant-api: bt_gap bluetooth
 
-Bluetooth: Direction Finding Periodic Advertising Locator
-#########################################################
+   Implement BLE Direction Finding CTE Locator functionality.
 
 Overview
 ********
@@ -37,7 +38,7 @@ changing ``nrf52833dk/nrf52833`` as needed for your board:
    :compact:
 
 To run the application on nRF5340DK, a Bluetooth controller application must
-also run on the network core. The :ref:`bluetooth-hci-ipc-sample` sample
+also run on the network core. The :zephyr:code-sample:`bluetooth_hci_ipc` sample
 application may be used. To build this sample with direction finding support
 enabled:
 
@@ -72,7 +73,7 @@ this overlay. See :ref:`set-devicetree-overlays` for information on setting up
 and using overlays.
 
 Note that antenna matrix configuration for the nRF5340 SoC is part of the
-network core application. When :ref:`bluetooth-hci-ipc-sample` is used as the
+network core application. When :zephyr:code-sample:`bluetooth_hci_ipc` is used as the
 network core application, the antenna matrix configuration should be stored in
 the file
 :file:`samples/bluetooth/hci_ipc/boards/nrf5340dk_nrf5340_cpunet.overlay`

--- a/samples/bluetooth/direction_finding_connectionless_tx/README.rst
+++ b/samples/bluetooth/direction_finding_connectionless_tx/README.rst
@@ -2,12 +2,12 @@
    :name: Direction Finding Periodic Advertising Beacon
    :relevant-api: bt_gap bluetooth
 
-   Implement BLE Direction Finding CTE Broadcaster functionality.
+   Implement Bluetooth LE Direction Finding CTE Broadcaster functionality.
 
 Overview
 ********
 
-A simple application demonstrating the BLE Direction Finding CTE Broadcaster
+A simple application demonstrating the Bluetooth LE Direction Finding CTE Broadcaster
 functionality by sending Constant Tone Extension with periodic advertising PDUs.
 
 Requirements

--- a/samples/bluetooth/direction_finding_connectionless_tx/README.rst
+++ b/samples/bluetooth/direction_finding_connectionless_tx/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth_direction_finding_connectionless_tx:
+.. zephyr:code-sample:: ble_direction_finding_connectionless_tx
+   :name: Direction Finding Periodic Advertising Beacon
+   :relevant-api: bt_gap bluetooth
 
-Bluetooth: Direction Finding Periodic Advertising Beacon
-########################################################
+   Implement BLE Direction Finding CTE Broadcaster functionality.
 
 Overview
 ********
@@ -73,7 +74,7 @@ this overlay. See :ref:`set-devicetree-overlays` for information on setting up
 and using overlays.
 
 Note that antenna matrix configuration for the nRF5340 SoC is part of the
-network core application. When :ref:`bluetooth-hci-ipc-sample` is used as
+network core application. When :zephyr:code-sample:`bluetooth_hci_ipc` is used as
 network core application, the antenna matrix configuration should be stored in
 the file
 :file:`samples/bluetooth/hci_ipc/boards/nrf5340dk_nrf5340_cpunet.overlay`

--- a/samples/bluetooth/direction_finding_peripheral/README.rst
+++ b/samples/bluetooth/direction_finding_peripheral/README.rst
@@ -2,12 +2,12 @@
    :name: Direction Finding Peripheral
    :relevant-api: bluetooth
 
-   Implement BLE Direction Finding peripheral transmitting CTE in connected mode.
+   Implement Bluetooth LE Direction Finding peripheral transmitting CTE in connected mode.
 
 Overview
 ********
 
-A simple application demonstrating the BLE Direction Finding CTE transmission in
+A simple application demonstrating the Bluetooth LE Direction Finding CTE transmission in
 connected mode by response to a request received from connected peer device.
 
 Requirements

--- a/samples/bluetooth/direction_finding_peripheral/README.rst
+++ b/samples/bluetooth/direction_finding_peripheral/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth_direction_finding_peripheral:
+.. zephyr:code-sample:: bluetooth_direction_finding_peripheral
+   :name: Direction Finding Peripheral
+   :relevant-api: bluetooth
 
-Bluetooth: Direction Finding Peripheral
-#######################################
+   Implement BLE Direction Finding peripheral transmitting CTE in connected mode.
 
 Overview
 ********
@@ -36,7 +37,7 @@ changing ``nrf52833dk/nrf52833`` as needed for your board:
    :compact:
 
 To run the application on nRF5340DK, a Bluetooth controller application must
-also run on the network core. The :ref:`bluetooth-hci-ipc-sample` sample
+also run on the network core. The :zephyr:code-sample:`bluetooth_hci_ipc` sample
 application may be used. To build this sample with direction finding support
 enabled:
 
@@ -68,7 +69,7 @@ this overlay. See :ref:`set-devicetree-overlays` for information on setting up
 and using overlays.
 
 Note that antenna matrix configuration for the nRF5340 SoC is part of the
-network core application. When :ref:`bluetooth-hci-ipc-sample` is used as the
+network core application. When :zephyr:code-sample:`bluetooth_hci_ipc` is used as the
 network core application, the antenna matrix configuration should be stored in
 the file
 :file:`samples/bluetooth/hci_ipc/boards/nrf5340dk_nrf5340_cpunet.overlay`

--- a/samples/bluetooth/eddystone/README.rst
+++ b/samples/bluetooth/eddystone/README.rst
@@ -2,7 +2,7 @@
    :name: Eddystone
    :relevant-api: bluetooth
 
-   Export an Eddystone Configuration Service as a BLE GATT service.
+   Export an Eddystone Configuration Service as a Bluetooth LE GATT service.
 
 Overview
 ********
@@ -19,7 +19,7 @@ Requirements
 ************
 
 * BlueZ running on the host, or
-* A board with BLE support
+* A board with Bluetooth LE support
 
 Building and Running
 ********************

--- a/samples/bluetooth/eddystone/README.rst
+++ b/samples/bluetooth/eddystone/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth-eddystone-sample:
+.. zephyr:code-sample:: bluetooth_eddystone
+   :name: Eddystone
+   :relevant-api: bluetooth
 
-Bluetooth: Eddystone
-####################
+   Export an Eddystone Configuration Service as a BLE GATT service.
 
 Overview
 ********

--- a/samples/bluetooth/encrypted_advertising/README.rst
+++ b/samples/bluetooth/encrypted_advertising/README.rst
@@ -2,7 +2,7 @@
    :name: Encrypted Advertising
    :relevant-api: bluetooth
 
-   Use the BLE encrypted advertising feature.
+   Use the Bluetooth LE encrypted advertising feature.
 
 Overview
 ********

--- a/samples/bluetooth/encrypted_advertising/README.rst
+++ b/samples/bluetooth/encrypted_advertising/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth_encrypted_advertising_sample:
+.. zephyr:code-sample:: bluetooth_encrypted_advertising
+   :name: Encrypted Advertising
+   :relevant-api: bluetooth
 
-Bluetooth: Encrypted Advertising
-################################
+   Use the BLE encrypted advertising feature.
 
 Overview
 ********

--- a/samples/bluetooth/extended_adv/README.rst
+++ b/samples/bluetooth/extended_adv/README.rst
@@ -2,7 +2,7 @@
    :name: Extended Advertising
    :relevant-api: bluetooth
 
-   Use the BLE extended advertising feature.
+   Use the Bluetooth LE extended advertising feature.
 
 Overview
 ********

--- a/samples/bluetooth/extended_adv/README.rst
+++ b/samples/bluetooth/extended_adv/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth_extended_advertising_sample:
+.. zephyr:code-sample:: bluetooth_extended_advertising
+   :name: Extended Advertising
+   :relevant-api: bluetooth
 
-Bluetooth: Extended Advertising
-################################
+   Use the BLE extended advertising feature.
 
 Overview
 ********

--- a/samples/bluetooth/handsfree/README.rst
+++ b/samples/bluetooth/handsfree/README.rst
@@ -1,7 +1,8 @@
-.. _bt_handsfree:
+.. zephyr:code-sample:: bluetooth_handsfree
+   :name: Hands-free
+   :relevant-api: bt_hfp bluetooth
 
-Bluetooth: Handsfree
-####################
+   Use the Hands-Free Profile (HFP) APIs.
 
 Overview
 ********

--- a/samples/bluetooth/handsfree_ag/README.rst
+++ b/samples/bluetooth/handsfree_ag/README.rst
@@ -1,7 +1,8 @@
-.. _bt_handsfree_ag:
+.. zephyr:code-sample:: bluetooth_handsfree_ag
+   :name: Hands-free Audio Gateway (AG)
+   :relevant-api: bt_hfp bluetooth
 
-Bluetooth: Handsfree Audio Gateway
-##################################
+   Use the Hands-Free Profile Audio Gateway (AG) APIs.
 
 Overview
 ********

--- a/samples/bluetooth/hap_ha/README.rst
+++ b/samples/bluetooth/hap_ha/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth_hap_ha:
+.. zephyr:code-sample:: bluetooth_hap_ha
+   :name: Hearing Access Profile (HAP) Hearing Aid (HA)
+   :relevant-api: bt_has
 
-Bluetooth: HAP Hearing Aid (HA)
-###############################
+   Advertise and await connection from a Hearing Aid Unicast Client or Remote Controller.
 
 Overview
 ********

--- a/samples/bluetooth/hci_ipc/README.rst
+++ b/samples/bluetooth/hci_ipc/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth-hci-ipc-sample:
+.. zephyr:code-sample:: bluetooth_hci_ipc
+   :name: HCI IPC
+   :relevant-api: hci_raw bluetooth
 
-Bluetooth: HCI IPC
-##################
+   Expose a Bluetooth controller to another device or CPU using the IPC subsystem.
 
 Overview
 ********

--- a/samples/bluetooth/hci_pwr_ctrl/README.rst
+++ b/samples/bluetooth/hci_pwr_ctrl/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth-hci-pwr-ctrl-sample:
+.. zephyr:code-sample:: bluetooth_hci_pwr_ctrl
+   :name: HCI Power Control
+   :relevant-api: bt_hrs bluetooth
 
-Bluetooth: HCI Power Control
-############################
+   Dynamically control the Tx power of a BLE Controller using HCI vendor-specific commands.
 
 Overview
 ********

--- a/samples/bluetooth/hci_pwr_ctrl/README.rst
+++ b/samples/bluetooth/hci_pwr_ctrl/README.rst
@@ -2,13 +2,13 @@
    :name: HCI Power Control
    :relevant-api: bt_hrs bluetooth
 
-   Dynamically control the Tx power of a BLE Controller using HCI vendor-specific commands.
+   Dynamically control the Tx power of a Bluetooth LE Controller using HCI vendor-specific commands.
 
 Overview
 ********
 
 This sample application demonstrates the dynamic Tx power control over the LL
-of the BLE controller via Zephyr HCI VS commands. The application implements a
+of the Bluetooth LE controller via Zephyr HCI VS commands. The application implements a
 peripheral advertising with varying Tx power. The initial advertiser TX power
 for the first 5s of the application is the Kconfig set default TX power. Then,
 the TX power variation of the advertiser is a repeatedly descending staircase
@@ -25,7 +25,7 @@ Requirements
 ************
 
 * BlueZ running on the host, or
-* A board with BLE support
+* A board with Bluetooth LE support
 * A central device & monitor (e.g. nRF Connect) to check the RSSI values
   obtained from the peripheral.
 

--- a/samples/bluetooth/hci_spi/README.rst
+++ b/samples/bluetooth/hci_spi/README.rst
@@ -1,12 +1,13 @@
-.. _bluetooth-hci-spi-sample:
+.. zephyr:code-sample:: bluetooth_hci_spi
+   :name: HCI SPI
+   :relevant-api: hci_raw bluetooth spi_interface
 
-Bluetooth: HCI SPI
-##################
+   Expose a Bluetooth controller to another device or CPU over SPI.
 
 Overview
 ********
 
-Expose Zephyr Bluetooth Controller support over SPI to another device/CPU using
+Expose Bluetooth Controller support over SPI to another device/CPU using
 the Zephyr SPI HCI transport protocol (similar to BlueNRG).
 
 Requirements

--- a/samples/bluetooth/hci_uart/README.rst
+++ b/samples/bluetooth/hci_uart/README.rst
@@ -1,12 +1,13 @@
-.. _bluetooth-hci-uart-sample:
+.. zephyr:code-sample:: bluetooth_hci_uart
+   :name: HCI UART
+   :relevant-api: hci_raw bluetooth uart_interface
 
-Bluetooth: HCI UART
-####################
+   Expose a Bluetooth controller to another device or CPU over UART.
 
 Overview
 *********
 
-Expose the Zephyr Bluetooth controller support over UART to another device/CPU
+Expose Bluetooth controller support over UART to another device/CPU
 using the H:4 HCI transport protocol (requires HW flow control from the UART).
 
 Requirements
@@ -142,7 +143,8 @@ You can use following targets:
 * ``nrf5340dk/nrf5340/cpunet@df``
 * ``nrf52833dk/nrf52833@df``
 
-Check the :ref:`bluetooth_direction_finding_connectionless_rx` and the :ref:`bluetooth_direction_finding_connectionless_tx` for more details.
+Check the :zephyr:code-sample:`ble_direction_finding_connectionless_rx` and the
+:zephyr:code-sample:`ble_direction_finding_connectionless_tx` for more details.
 
 Using a USB CDC ACM UART
 ========================

--- a/samples/bluetooth/hci_uart/README.rst
+++ b/samples/bluetooth/hci_uart/README.rst
@@ -13,7 +13,7 @@ using the H:4 HCI transport protocol (requires HW flow control from the UART).
 Requirements
 ************
 
-* A board with BLE support
+* A board with Bluetooth LE support
 
 Default UART settings
 *********************
@@ -35,8 +35,8 @@ Using the controller with emulators and BlueZ
 
 The instructions below show how to use a Nordic nRF5x device as a Zephyr BLE
 controller and expose it to Linux's BlueZ. This can be very useful for testing
-the Zephyr Link Layer with the BlueZ Host. The Zephyr BLE controller can also
-provide a modern BLE 5.0 controller to a Linux-based machine for native
+the Zephyr Link Layer with the BlueZ Host. The Zephyr Bluetooth LE controller can also
+provide a modern Bluetooth LE 5.0 controller to a Linux-based machine for native
 BLE support or QEMU-based development.
 
 First, make sure you have a recent BlueZ version installed by following the
@@ -130,7 +130,7 @@ Then attach RTT as described here: :ref:`Using Segger J-Link <Using Segger J-Lin
 Support for the Direction Finding
 =================================
 
-The sample can be built with the support for the BLE Direction Finding.
+The sample can be built with the support for the Bluetooth LE Direction Finding.
 To enable this feature build this sample for specific board variants that provide
 required hardware configuration for the Radio.
 

--- a/samples/bluetooth/hci_uart_3wire/README.rst
+++ b/samples/bluetooth/hci_uart_3wire/README.rst
@@ -1,12 +1,13 @@
-.. _bluetooth-hci-uart-3wire-sample:
+.. zephyr:code-sample:: bluetooth_hci_uart_3wire
+   :name: HCI 3-wire (H:5)
+   :relevant-api: hci_raw bluetooth uart_interface
 
-Bluetooth: HCI UART 3WIRE
-#########################
+   Expose a Bluetooth controller to another device or CPU over H5:HCI transport.
 
 Overview
 *********
 
-Expose the Zephyr Bluetooth controller support over UART to another device/CPU
+Expose Bluetooth controller support over UART to another device/CPU
 using the H:5 HCI transport protocol.
 
 Requirements
@@ -142,7 +143,8 @@ You can use following targets:
 * ``nrf5340dk/nrf5340/cpunet@df``
 * ``nrf52833dk/nrf52833@df``
 
-Check the :ref:`bluetooth_direction_finding_connectionless_rx` and the :ref:`bluetooth_direction_finding_connectionless_tx` for more details.
+Check the :zephyr:code-sample:`ble_direction_finding_connectionless_rx` and the
+:zephyr:code-sample:`ble_direction_finding_connectionless_tx` for more details.
 
 Using a USB CDC ACM UART
 ========================

--- a/samples/bluetooth/hci_uart_3wire/README.rst
+++ b/samples/bluetooth/hci_uart_3wire/README.rst
@@ -13,7 +13,7 @@ using the H:5 HCI transport protocol.
 Requirements
 ************
 
-* A board with BLE support
+* A board with Bluetooth LE support
 
 Default UART settings
 *********************
@@ -35,8 +35,8 @@ Using the controller with emulators and BlueZ
 
 The instructions below show how to use a Nordic nRF5x device as a Zephyr BLE
 controller and expose it to Linux's BlueZ. This can be very useful for testing
-the Zephyr Link Layer with the BlueZ Host. The Zephyr BLE controller can also
-provide a modern BLE 5.0 controller to a Linux-based machine for native
+the Zephyr Link Layer with the BlueZ Host. The Zephyr Bluetooth LE controller can also
+provide a modern Bluetooth LE 5.0 controller to a Linux-based machine for native
 BLE support or QEMU-based development.
 
 First, make sure you have a recent BlueZ version installed by following the
@@ -130,7 +130,7 @@ Then attach RTT as described here: :ref:`Using Segger J-Link <Using Segger J-Lin
 Support for the Direction Finding
 =================================
 
-The sample can be built with the support for the BLE Direction Finding.
+The sample can be built with the support for the Bluetooth LE Direction Finding.
 To enable this feature build this sample for specific board variants that provide
 required hardware configuration for the Radio.
 

--- a/samples/bluetooth/hci_uart_async/README.rst
+++ b/samples/bluetooth/hci_uart_async/README.rst
@@ -16,7 +16,7 @@ of the HCI UART sample may be different.
 Requirements
 ************
 
-* A board with BLE support
+* A board with Bluetooth LE support
 
 Default UART settings
 *********************

--- a/samples/bluetooth/hci_uart_async/README.rst
+++ b/samples/bluetooth/hci_uart_async/README.rst
@@ -1,9 +1,13 @@
-.. _bluetooth-hci-uart-async-sample:
+.. zephyr:code-sample:: bluetooth_hci_uart_async
+   :name: HCI UART async
+   :relevant-api: hci_raw bluetooth uart_interface
 
-Bluetooth: HCI UART based on ASYNC UART
-#######################################
+   Expose a Bluetooth controller to another device or CPU over asynchronous UART.
 
-Expose a Zephyr Bluetooth Controller over a standard Bluetooth HCI UART interface.
+Overview
+*********
+
+Expose Bluetooth Controller support over a standard Bluetooth HCI UART interface.
 
 This sample performs the same basic function as the HCI UART sample, but it uses the UART_ASYNC_API
 instead of UART_INTERRUPT_DRIVEN API. Not all boards implement both UART APIs, so the board support

--- a/samples/bluetooth/hci_usb/README.rst
+++ b/samples/bluetooth/hci_usb/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth-hci-usb-sample:
+.. zephyr:code-sample:: bluetooth_hci_usb
+   :name: HCI USB
+   :relevant-api: hci_raw bluetooth _usb_device_core_api usbd_api
 
-Bluetooth: HCI USB
-##################
+   Turn a Zephyr board into a USB Bluetooth dongle (compatible with all operating systems).
 
 Overview
 ********

--- a/samples/bluetooth/hci_usb/README.rst
+++ b/samples/bluetooth/hci_usb/README.rst
@@ -8,7 +8,7 @@ Overview
 ********
 
 Make a USB Bluetooth dongle out of Zephyr. Requires USB device support from the
-board it runs on (e.g. :ref:`nrf52840dk_nrf52840` supports both BLE and USB).
+board it runs on (e.g. :ref:`nrf52840dk_nrf52840` supports both Bluetooth LE and USB).
 
 Requirements
 ************

--- a/samples/bluetooth/hci_usb_h4/README.rst
+++ b/samples/bluetooth/hci_usb_h4/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth-hci-usb-h4-sample:
+.. zephyr:code-sample:: bluetooth_hci_usb_h4
+   :name: HCI H4 over USB
+   :relevant-api: hci_raw bluetooth _usb_device_core_api usbd_api
 
-Bluetooth: HCI H4 over USB
-##########################
+   Turn a Zephyr board into a USB H4 Bluetooth dongle (Linux/BlueZ only).
 
 Overview
 ********

--- a/samples/bluetooth/hci_usb_h4/README.rst
+++ b/samples/bluetooth/hci_usb_h4/README.rst
@@ -8,7 +8,7 @@ Overview
 ********
 
 Make a USB H4 Bluetooth dongle out of Zephyr. Requires USB device support from
-the board it runs on (e.g. :ref:`nrf52840dk_nrf52840` supports both BLE and
+the board it runs on (e.g. :ref:`nrf52840dk_nrf52840` supports both Bluetooth LE and
 USB).
 
 Requirements

--- a/samples/bluetooth/hci_vs_scan_req/README.rst
+++ b/samples/bluetooth/hci_vs_scan_req/README.rst
@@ -18,7 +18,7 @@ connection can also be added, depending on configuration choices.
 Requirements
 ************
 
-* A board with BLE support
+* A board with Bluetooth LE support
 * A central device & monitor (e.g. nRF Connect) to check the advertiments and
   send scan requests.
 

--- a/samples/bluetooth/hci_vs_scan_req/README.rst
+++ b/samples/bluetooth/hci_vs_scan_req/README.rst
@@ -1,13 +1,14 @@
-.. _bluetooth-hci-vs-scan-req-sample:
+.. zephyr:code-sample:: bluetooth_hci_vs_scan_req
+   :name: HCI Vendor-Specific Scan Request
+   :relevant-api: bluetooth
 
-Bluetooth: HCI VS Scan Request
-##############################
+   Use vendor-specific HCI commands to enable Scan Request events when using legacy advertising.
 
 Overview
 ********
 
 This simple application is a usage example to manage HCI VS commands to obtain
-scan equest events even using legacy advertisements, while may result in lower
+scan request events even using legacy advertisements, while may result in lower
 RAM usage than using extended advertising.
 This is quite important in applications in which the broadcaster role is added
 to the central role, where the RAM saving can be bigger.

--- a/samples/bluetooth/ibeacon/README.rst
+++ b/samples/bluetooth/ibeacon/README.rst
@@ -1,12 +1,13 @@
-.. _bluetooth-ibeacon-sample:
+.. zephyr:code-sample:: bluetooth_ibeacon
+   :name: iBeacon
+   :relevant-api: bluetooth
 
-Bluetooth: iBeacon
-##################
+   Advertise an Apple iBeacon using GAP Broadcaster role.
 
 Overview
 ********
 
-This simple application demonstrates the BLE Broadcaster role
+This simple application demonstrates the GAP Broadcaster role
 functionality by advertising an Apple iBeacon. The calibrated RSSI @ 1
 meter distance can be set using an IBEACON_RSSI build variable
 (e.g. IBEACON_RSSI=0xb8 for -72 dBm RSSI @ 1 meter), or by manually

--- a/samples/bluetooth/iso_broadcast/README.rst
+++ b/samples/bluetooth/iso_broadcast/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth-isochronous-broadcaster-sample:
+.. zephyr:code-sample:: bluetooth_isochronous_broadcaster
+   :name: Isochronous Broadcaster
+   :relevant-api: bt_iso bluetooth
 
-Bluetooth: Isochronous Broadcaster
-##################################
+   Use the Bluetooth Low Energy Isochronous Broadcaster functionality.
 
 Overview
 ********

--- a/samples/bluetooth/iso_broadcast_benchmark/README.rst
+++ b/samples/bluetooth/iso_broadcast_benchmark/README.rst
@@ -1,7 +1,8 @@
-.. _iso_broadcast_benchmark:
+.. zephyr:code-sample:: bluetooth_isochronous_broadcaster_benchmark
+   :name: Isochronous Broadcaster Benchmark
+   :relevant-api: bt_iso bluetooth
 
-Bluetooth: Throughput
-#####################
+   Measure packet loss and sync loss of an ISO broadcaster against one or more receivers.
 
 The ISO Broadcast Benchmark sample measures and report packet loss and sync loss
 of an ISO broadcaster against one or more ISO broadcast receivers.

--- a/samples/bluetooth/iso_central/README.rst
+++ b/samples/bluetooth/iso_central/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth_iso_central:
+.. zephyr:code-sample:: ble_central_iso
+   :name: ISO (Central)
+   :relevant-api: bt_iso bluetooth
 
-Bluetooth: ISO Central
-######################
+   Transfer isochronous data to a peer device using an isochronous channel as a central.
 
 Overview
 ********
@@ -9,7 +10,7 @@ Overview
 This sample demonstrates how to use an isochronous channel as a central.
 The sample scans for a peripheral, establishes a connection, and sets up a connected isochronous channel to it.
 Once the isochronous channel is connected, isochronous data is transferred to the peer device every 10 milliseconds.
-It is recommended to run this sample together with the :ref:`Bluetooth: ISO Peripheral <iso_peripheral>` sample.
+It is recommended to run this sample together with the :zephyr:code-sample:`ble_peripheral_iso` sample.
 
 To run the sample with an encrypted isochronous channel, enable :kconfig:option:`CONFIG_BT_SMP`.
 

--- a/samples/bluetooth/iso_connected_benchmark/README.rst
+++ b/samples/bluetooth/iso_connected_benchmark/README.rst
@@ -1,11 +1,11 @@
-.. _iso_connected_benchmark:
+.. zephyr:code-sample:: bluetooth_isochronous_connected_benchmark
+   :name: Isochronous Connected Channels Benchmark
+   :relevant-api: bt_iso bluetooth
 
-Bluetooth: Throughput
-#####################
+   Measure packet loss and sync loss in connected ISO channels.
 
 The ISO Connected Channels Benchmark sample measures and reports packet loss
 and sync loss in connected ISO channels.
-
 
 Overview
 ********

--- a/samples/bluetooth/iso_peripheral/README.rst
+++ b/samples/bluetooth/iso_peripheral/README.rst
@@ -1,7 +1,8 @@
-.. _iso_peripheral:
+.. zephyr:code-sample:: ble_peripheral_iso
+   :name: ISO (Peripheral)
+   :relevant-api: bt_bas bluetooth
 
-Bluetooth: ISO Peripheral
-#########################
+   Implement a BLE Peripheral that uses isochronous channels.
 
 Overview
 ********
@@ -9,7 +10,7 @@ Overview
 This sample demonstrates how to use isochronous channels as a peripheral.
 The sample starts advertising, waits for a central to connect to it and set up an isochronous channel.
 Once the isochronous channel is set up, received isochronous data is printed out.
-It is recommended to run this sample together with the :ref:`Bluetooth: Central ISO <bluetooth_iso_central>` sample.
+It is recommended to run this sample together with the :zephyr:code-sample:`ble_central_iso` sample.
 
 Requirements
 ************

--- a/samples/bluetooth/iso_peripheral/README.rst
+++ b/samples/bluetooth/iso_peripheral/README.rst
@@ -2,7 +2,7 @@
    :name: ISO (Peripheral)
    :relevant-api: bt_bas bluetooth
 
-   Implement a BLE Peripheral that uses isochronous channels.
+   Implement a Bluetooth LE Peripheral that uses isochronous channels.
 
 Overview
 ********

--- a/samples/bluetooth/iso_receive/README.rst
+++ b/samples/bluetooth/iso_receive/README.rst
@@ -2,7 +2,7 @@
    :name: Synchronized Receiver
    :relevant-api: bt_iso bluetooth
 
-   Use BLE Synchronized Receiver functionality.
+   Use Bluetooth LE Synchronized Receiver functionality.
 
 Overview
 ********

--- a/samples/bluetooth/iso_receive/README.rst
+++ b/samples/bluetooth/iso_receive/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth-iso-receive-sample:
+.. zephyr:code-sample:: bluetooth_isochronous_receiver
+   :name: Synchronized Receiver
+   :relevant-api: bt_iso bluetooth
 
-Bluetooth: Synchronized Receiver
-###############################################
+   Use BLE Synchronized Receiver functionality.
 
 Overview
 ********

--- a/samples/bluetooth/mesh/README.rst
+++ b/samples/bluetooth/mesh/README.rst
@@ -1,7 +1,8 @@
-.. _ble_mesh:
+.. zephyr:code-sample:: ble_mesh
+   :name: Mesh
+   :relevant-api: bt_mesh bluetooth
 
-Bluetooth: Mesh
-###############
+   Use basic BLE Mesh functionality.
 
 Overview
 ********
@@ -45,7 +46,7 @@ Refer to your :ref:`board's documentation <boards>` for alternative
 flash instructions if your board doesn't support the ``flash`` target.
 
 To run the application on an :ref:`nrf5340dk_nrf5340`, a Bluetooth controller application
-must also run on the network core. The :ref:`bluetooth-hci-ipc-sample` sample
+must also run on the network core. The :zephyr:code-sample:`bluetooth_hci_ipc` sample
 application may be used. Build this sample with configuration
 :zephyr_file:`samples/bluetooth/hci_ipc/nrf5340_cpunet_bt_mesh-bt_ll_sw_split.conf`
 to enable mesh support.

--- a/samples/bluetooth/mesh/README.rst
+++ b/samples/bluetooth/mesh/README.rst
@@ -2,7 +2,7 @@
    :name: Mesh
    :relevant-api: bt_mesh bluetooth
 
-   Use basic BLE Mesh functionality.
+   Use basic Bluetooth LE Mesh functionality.
 
 Overview
 ********

--- a/samples/bluetooth/mesh_demo/README.rst
+++ b/samples/bluetooth/mesh_demo/README.rst
@@ -1,7 +1,8 @@
-.. _ble_mesh_demo:
+.. zephyr:code-sample:: ble_mesh_demo
+   :name: Mesh Demo
+   :relevant-api: bt_mesh bluetooth
 
-Bluetooth: Mesh Demo
-####################
+   Implement a Bluetooth Mesh demo application.
 
 Overview
 ********
@@ -56,7 +57,7 @@ Refer to your :ref:`board's documentation <boards>` for alternative
 flash instructions if your board doesn't support the ``flash`` target.
 
 To run the application on an :ref:`nrf5340dk_nrf5340`, a Bluetooth controller application
-must also run on the network core. The :ref:`bluetooth-hci-ipc-sample` sample
+must also run on the network core. The :zephyr:code-sample:`bluetooth_hci_ipc` sample
 application may be used. Build this sample with configuration
 :zephyr_file:`samples/bluetooth/hci_ipc/nrf5340_cpunet_bt_mesh-bt_ll_sw_split.conf`
 to enable mesh support.

--- a/samples/bluetooth/mesh_provisioner/README.rst
+++ b/samples/bluetooth/mesh_provisioner/README.rst
@@ -1,7 +1,8 @@
-.. _ble_mesh_provisioner:
+.. zephyr:code-sample:: ble_mesh_provisioner
+   :name: Mesh Provisioner
+   :relevant-api: bt_mesh bluetooth
 
-Bluetooth: Mesh Provisioner
-###########################
+   Provision a node and configure it using the Bluetooth Mesh APIs.
 
 Overview
 ********
@@ -54,7 +55,7 @@ Refer to your :ref:`board's documentation <boards>` for alternative
 flash instructions if your board doesn't support the ``flash`` target.
 
 To run the application on an :ref:`nrf5340dk_nrf5340`, a Bluetooth controller application
-must also run on the network core. The :ref:`bluetooth-hci-ipc-sample` sample
+must also run on the network core. The :zephyr:code-sample:`bluetooth_hci_ipc` sample
 application may be used. Build this sample with configuration
 :zephyr_file:`samples/bluetooth/hci_ipc/nrf5340_cpunet_bt_mesh-bt_ll_sw_split.conf`
 to enable mesh support.

--- a/samples/bluetooth/mtu_update/README.rst
+++ b/samples/bluetooth/mtu_update/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth_mtu_update_sample:
+.. zephyr:code-sample:: bluetooth_mtu_update
+   :name: MTU Update
+   :relevant-api: bt_gatt bluetooth
 
-Bluetooth: MTU Update
-#####################
+   Configure and exchange MTU between two devices.
 
 Q&A:
 ****

--- a/samples/bluetooth/observer/README.rst
+++ b/samples/bluetooth/observer/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth-observer-sample:
+.. zephyr:code-sample:: bluetooth_observer
+   :name: Observer
+   :relevant-api: bt_gap bluetooth
 
-Bluetooth: Observer
-###################
+   Scan for Bluetooth devices nearby and print their information.
 
 Overview
 ********

--- a/samples/bluetooth/pbp_public_broadcast_sink/README.rst
+++ b/samples/bluetooth/pbp_public_broadcast_sink/README.rst
@@ -1,5 +1,5 @@
 .. zephyr:code-sample:: bluetooth_public_broadcast_sink
-   :name: Bluetooth: Public Broadcast Sink
+   :name: Public Broadcast Sink
    :relevant-api: bluetooth
 
    Bluetooth: Public Broadcast Sink
@@ -50,7 +50,7 @@ If you prefer to only build the application core image, you can do so by doing i
    :goals: build
 
 In that case you can pair this application core image with the
-:ref:`hci_ipc sample <bluetooth-hci-ipc-sample>`
+:zephyr:code-sample:`bluetooth_hci_ipc` sample
 :zephyr_file:`samples/bluetooth/hci_ipc/nrf5340_cpunet_iso-bt_ll_sw_split.conf` configuration.
 
 Building for a simulated nrf5340bsim

--- a/samples/bluetooth/pbp_public_broadcast_source/README.rst
+++ b/samples/bluetooth/pbp_public_broadcast_source/README.rst
@@ -1,5 +1,5 @@
 .. zephyr:code-sample:: bluetooth_public_broadcast_source
-   :name: Bluetooth: Public Broadcast Source
+   :name: Public Broadcast Source
    :relevant-api: bluetooth
 
    Bluetooth: Public Broadcast Source
@@ -50,7 +50,7 @@ If you prefer to only build the application core image, you can do so by doing i
    :goals: build
 
 In that case you can pair this application core image with the
-:ref:`hci_ipc sample <bluetooth-hci-ipc-sample>`
+:zephyr:code-sample:`bluetooth_hci_ipc` sample
 :zephyr_file:`samples/bluetooth/hci_ipc/nrf5340_cpunet_iso-bt_ll_sw_split.conf` configuration.
 
 Building for a simulated nrf5340bsim

--- a/samples/bluetooth/periodic_adv/README.rst
+++ b/samples/bluetooth/periodic_adv/README.rst
@@ -2,17 +2,17 @@
    :name: Periodic Advertising
    :relevant-api: bt_gap bluetooth
 
-   Use BLE Periodic Advertising functionality.
+   Use Bluetooth LE Periodic Advertising functionality.
 
 Overview
 ********
 
-A simple application demonstrating the BLE Periodic Advertising functionality.
+A simple application demonstrating the Bluetooth LE Periodic Advertising functionality.
 
 Requirements
 ************
 
-* A board with BLE support
+* A board with Bluetooth LE support
 
 Building and Running
 ********************

--- a/samples/bluetooth/periodic_adv/README.rst
+++ b/samples/bluetooth/periodic_adv/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth-periodic-advertising-sample:
+.. zephyr:code-sample:: ble_periodic_adv
+   :name: Periodic Advertising
+   :relevant-api: bt_gap bluetooth
 
-Bluetooth: Periodic Advertising
-###############################
+   Use BLE Periodic Advertising functionality.
 
 Overview
 ********

--- a/samples/bluetooth/periodic_adv_conn/README.rst
+++ b/samples/bluetooth/periodic_adv_conn/README.rst
@@ -18,7 +18,7 @@ wait for disconnect before connecting to another synced device.
 Requirements
 ************
 
-* A board with BLE support
+* A board with Bluetooth LE support
 * A controller that supports the Periodic Advertising with Responses (PAwR) - Advertiser feature
 
 Building and Running

--- a/samples/bluetooth/periodic_adv_conn/README.rst
+++ b/samples/bluetooth/periodic_adv_conn/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth-periodic-advertising-conn-sample:
+.. zephyr:code-sample:: ble_periodic_adv_conn
+   :name: Periodic Advertising Connection Procedure (Initiator)
+   :relevant-api: bt_gap bluetooth
 
-Bluetooth: Periodic Advertising Connection Procedure - Initiator
-################################################################
+   Initiate a connection to a device using the Periodic Advertising Connection Procedure.
 
 Overview
 ********

--- a/samples/bluetooth/periodic_adv_rsp/README.rst
+++ b/samples/bluetooth/periodic_adv_rsp/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth-periodic-advertising-rsp-sample:
+.. zephyr:code-sample:: ble_periodic_adv_rsp
+   :name: Periodic Advertising with Responses (PAwR) Advertiser
+   :relevant-api: bt_gap bluetooth
 
-Bluetooth: Periodic Advertising with Responses (PAwR) Advertiser
-################################################################
+   Use BLE Periodic Advertising with Responses (PAwR) Advertiser functionality.
 
 Overview
 ********

--- a/samples/bluetooth/periodic_adv_rsp/README.rst
+++ b/samples/bluetooth/periodic_adv_rsp/README.rst
@@ -2,12 +2,12 @@
    :name: Periodic Advertising with Responses (PAwR) Advertiser
    :relevant-api: bt_gap bluetooth
 
-   Use BLE Periodic Advertising with Responses (PAwR) Advertiser functionality.
+   Use Bluetooth LE Periodic Advertising with Responses (PAwR) Advertiser functionality.
 
 Overview
 ********
 
-A simple application demonstrating the BLE Periodic Advertising with
+A simple application demonstrating the Bluetooth LE Periodic Advertising with
 Responses Advertiser functionality.
 
 This sample will scan for the corresponding sync sample and send the required
@@ -24,7 +24,7 @@ the assigned subevent and response slot.
 Requirements
 ************
 
-* A board with BLE support
+* A board with Bluetooth LE support
 * A controller that supports the Periodic Advertising with Responses (PAwR) - Advertiser feature
 
 Building and Running

--- a/samples/bluetooth/periodic_sync/README.rst
+++ b/samples/bluetooth/periodic_sync/README.rst
@@ -2,18 +2,18 @@
    :name: Periodic Advertising Synchronization
    :relevant-api: bt_gap bluetooth
 
-   Use BLE Periodic Advertising Synchronization functionality.
+   Use Bluetooth LE Periodic Advertising Synchronization functionality.
 
 Overview
 ********
 
-A simple application demonstrating the BLE Periodic Advertising Synchronization
+A simple application demonstrating the Bluetooth LE Periodic Advertising Synchronization
 functionality.
 
 Requirements
 ************
 
-* A board with BLE support
+* A board with Bluetooth LE support
 
 Building and Running
 ********************

--- a/samples/bluetooth/periodic_sync/README.rst
+++ b/samples/bluetooth/periodic_sync/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth-periodic-advertising-sync-sample:
+.. zephyr:code-sample:: ble_periodic_adv_sync
+   :name: Periodic Advertising Synchronization
+   :relevant-api: bt_gap bluetooth
 
-Bluetooth: Periodic Advertising Synchronization
-###############################################
+   Use BLE Periodic Advertising Synchronization functionality.
 
 Overview
 ********

--- a/samples/bluetooth/periodic_sync_conn/README.rst
+++ b/samples/bluetooth/periodic_sync_conn/README.rst
@@ -17,7 +17,7 @@ for a new connection to be established.
 Requirements
 ************
 
-* A board with BLE support
+* A board with Bluetooth LE support
 * A controller that supports the Periodic Advertising with Responses (PAwR) - Scanner feature
 
 Building and Running

--- a/samples/bluetooth/periodic_sync_conn/README.rst
+++ b/samples/bluetooth/periodic_sync_conn/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth-periodic-advertising-sync-conn-sample:
+.. zephyr:code-sample:: ble_periodic_adv_sync_conn
+   :name: Periodic Advertising Connection Procedure (Responder)
+   :relevant-api: bt_gap bluetooth
 
-Bluetooth: Periodic Advertising Connection Procedure - Responder
-#####################################################################
+   Respond to periodic advertising and establish a connection.
 
 Overview
 ********

--- a/samples/bluetooth/periodic_sync_rsp/README.rst
+++ b/samples/bluetooth/periodic_sync_rsp/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth-periodic-advertising-sync-rsp-sample:
+.. zephyr:code-sample:: ble_periodic_adv_sync_rsp
+   :name: Periodic Advertising with Responses (PAwR) Synchronization
+   :relevant-api: bt_gap bluetooth
 
-Bluetooth: Periodic Advertising with Responses (PAwR) Synchronization
-#####################################################################
+   Implement BLE Periodic Advertising with Responses Synchronization.
 
 Overview
 ********

--- a/samples/bluetooth/periodic_sync_rsp/README.rst
+++ b/samples/bluetooth/periodic_sync_rsp/README.rst
@@ -2,12 +2,12 @@
    :name: Periodic Advertising with Responses (PAwR) Synchronization
    :relevant-api: bt_gap bluetooth
 
-   Implement BLE Periodic Advertising with Responses Synchronization.
+   Implement Bluetooth LE Periodic Advertising with Responses Synchronization.
 
 Overview
 ********
 
-A simple application demonstrating the BLE Periodic Advertising with
+A simple application demonstrating the Bluetooth LE Periodic Advertising with
 Responses Synchronization functionality.
 
 This sample will echo the data received in subevent indications back to the
@@ -25,7 +25,7 @@ advertiser concurrently.
 Requirements
 ************
 
-* A board with BLE support
+* A board with Bluetooth LE support
 * A controller that supports the Periodic Advertising with Responses (PAwR) - Scanner feature
 
 Building and Running

--- a/samples/bluetooth/peripheral/README.rst
+++ b/samples/bluetooth/peripheral/README.rst
@@ -2,12 +2,12 @@
    :name: Peripheral
    :relevant-api: bt_gatt bluetooth
 
-   Implement basic BLE Peripheral role functionality (advertising and exposing GATT services).
+   Implement basic Bluetooth LE Peripheral role functionality (advertising and exposing GATT services).
 
 Overview
 ********
 
-Application demonstrating the BLE Peripheral role. It has several well-known and
+Application demonstrating the Bluetooth LE Peripheral role. It has several well-known and
 vendor-specific GATT services that it exposes.
 
 
@@ -15,7 +15,7 @@ Requirements
 ************
 
 * BlueZ running on the host, or
-* A board with BLE support
+* A board with Bluetooth LE support
 
 Building and Running
 ********************

--- a/samples/bluetooth/peripheral/README.rst
+++ b/samples/bluetooth/peripheral/README.rst
@@ -1,7 +1,8 @@
-.. _ble_peripheral:
+.. zephyr:code-sample:: ble_peripheral
+   :name: Peripheral
+   :relevant-api: bt_gatt bluetooth
 
-Bluetooth: Peripheral
-#####################
+   Implement basic BLE Peripheral role functionality (advertising and exposing GATT services).
 
 Overview
 ********

--- a/samples/bluetooth/peripheral_accept_list/README.rst
+++ b/samples/bluetooth/peripheral_accept_list/README.rst
@@ -7,7 +7,7 @@
 Overview
 ********
 
-This application demonstrates the BLE advertising accept filter list feature.
+This application demonstrates the Bluetooth LE advertising accept filter list feature.
 If no device is bonded to the peripheral, casual advertising will be performed.
 Once a device is bonded, on subsequent boots, connection requests will only be
 accepted if the central device is on the accept list. Additionally, scan response
@@ -15,15 +15,15 @@ data will only be sent to devices that are on the accept list. As a result, some
 BLE central devices (such as Android smartphones) might not display the device
 in the scan results if the central device is not on the accept list.
 
-This sample also provides two BLE characteristics. To perform a write, devices need
+This sample also provides two Bluetooth LE characteristics. To perform a write, devices need
 to be bonded, while a read can be done immediately after a connection
 (no bonding required).
 
 Requirements
 ************
 
-* A board with BLE support
-* Second BLE device acting as a central. For example another Zephyr board or smartphone
+* A board with Bluetooth LE support
+* Second Bluetooth LE device acting as a central. For example another Zephyr board or smartphone
 
 Building and Running
 ********************

--- a/samples/bluetooth/peripheral_accept_list/README.rst
+++ b/samples/bluetooth/peripheral_accept_list/README.rst
@@ -1,7 +1,8 @@
-.. _ble_peripheral_accept_list:
+.. zephyr:code-sample:: ble_peripheral_accept_list
+   :name: Peripheral Accept List
+   :relevant-api: bt_conn bt_gatt bluetooth
 
-Bluetooth: Peripheral Accept List
-#################################
+   Advertise and accept connections only from devices on an accept list.
 
 Overview
 ********

--- a/samples/bluetooth/peripheral_csc/README.rst
+++ b/samples/bluetooth/peripheral_csc/README.rst
@@ -1,12 +1,13 @@
-.. _peripheral_csc:
+.. zephyr:code-sample:: ble_peripheral_csc
+   :name: Cycling Speed and Cadence (CSC) Peripheral
+   :relevant-api: bt_gatt bluetooth
 
-Bluetooth: Peripheral CSC
-#########################
+   Expose a Cycling Speed and Cadence (CSC) GATT Service.
 
 Overview
 ********
 
-Similar to the :ref:`Peripheral <ble_peripheral>` sample, except that this
+Similar to the :zephyr:code-sample:`ble_peripheral` sample, except that this
 application specifically exposes the CSC (Cycling Speed and Cadence) GATT
 Service.
 

--- a/samples/bluetooth/peripheral_csc/README.rst
+++ b/samples/bluetooth/peripheral_csc/README.rst
@@ -16,7 +16,7 @@ Requirements
 ************
 
 * BlueZ running on the host, or
-* A board with BLE support
+* A board with Bluetooth LE support
 
 Building and Running
 ********************

--- a/samples/bluetooth/peripheral_dis/README.rst
+++ b/samples/bluetooth/peripheral_dis/README.rst
@@ -15,7 +15,7 @@ Requirements
 ************
 
 * BlueZ running on the host, or
-* A board with BLE support
+* A board with Bluetooth LE support
 
 Building and Running
 ********************

--- a/samples/bluetooth/peripheral_dis/README.rst
+++ b/samples/bluetooth/peripheral_dis/README.rst
@@ -1,12 +1,13 @@
-.. _peripheral_dis:
+.. zephyr:code-sample:: ble_peripheral_dis
+   :name: DIS Peripheral
+   :relevant-api: bt_gatt bluetooth
 
-Bluetooth: Peripheral DIS
-#########################
+   Expose device information using the Device Information Service (DIS).
 
 Overview
 ********
 
-Similar to the :ref:`Peripheral <ble_peripheral>` sample, except that this
+Similar to the :zephyr:code-sample:`ble_peripheral` sample, except that this
 application specifically exposes the DIS (Device Information) GATT Service.
 
 

--- a/samples/bluetooth/peripheral_esp/README.rst
+++ b/samples/bluetooth/peripheral_esp/README.rst
@@ -15,7 +15,7 @@ Requirements
 ************
 
 * BlueZ running on the host, or
-* A board with BLE support
+* A board with Bluetooth LE support
 
 Building and Running
 ********************

--- a/samples/bluetooth/peripheral_esp/README.rst
+++ b/samples/bluetooth/peripheral_esp/README.rst
@@ -1,11 +1,12 @@
-.. _peripheral_esp:
+.. zephyr:code-sample:: ble_peripheral_esp
+   :name: ESP Peripheral
+   :relevant-api: bt_gatt bt_bas bluetooth
 
-Bluetooth: Peripheral ESP
-#########################
+   Expose environmental information using the Environmental Sensing Profile (ESP).
 
 Overview
 ********
-Similar to the :ref:`Peripheral <ble_peripheral>` sample, except that this
+Similar to the :zephyr:code-sample:`ble_peripheral` sample, except that this
 application specifically exposes the ESP (Environmental Sensing Profile) GATT
 Service.
 

--- a/samples/bluetooth/peripheral_gatt_write/README.rst
+++ b/samples/bluetooth/peripheral_gatt_write/README.rst
@@ -15,7 +15,7 @@ Requirements
 ************
 
 * BlueZ running on the host, or
-* A board with BLE support
+* A board with Bluetooth LE support
 
 Building and Running
 ********************

--- a/samples/bluetooth/peripheral_gatt_write/README.rst
+++ b/samples/bluetooth/peripheral_gatt_write/README.rst
@@ -1,12 +1,13 @@
-.. _peripheral_gatt_write:
+.. zephyr:code-sample:: ble_peripheral_gatt_write
+   :name: Peripheral GATT Write
+   :relevant-api: bt_gatt bluetooth
 
-Bluetooth: Peripheral GATT Write
-################################
+   Write a value to a characteristic using GATT Write Without Response.
 
 Overview
 ********
 
-Similar to the :ref:`Peripheral <ble_peripheral>` sample, except that this
+Similar to the :zephyr:code-sample:`ble_peripheral` sample, except that this
 application uses GATT Write Without Response.
 
 

--- a/samples/bluetooth/peripheral_hids/README.rst
+++ b/samples/bluetooth/peripheral_hids/README.rst
@@ -21,7 +21,7 @@ Requirements
 ************
 
 * BlueZ running on the host, or
-* A board with BLE support
+* A board with Bluetooth LE support
 
 Building and Running
 ********************

--- a/samples/bluetooth/peripheral_hids/README.rst
+++ b/samples/bluetooth/peripheral_hids/README.rst
@@ -1,12 +1,13 @@
-.. _peripheral_hids:
+.. zephyr:code-sample:: ble_peripheral_hids
+   :name: HID Peripheral
+   :relevant-api: bt_gatt bluetooth
 
-Bluetooth: Peripheral HIDs
-##########################
+   Implement a Bluetooth HID peripheral (generic mouse)
 
 Overview
 ********
 
-Similar to the :ref:`Peripheral <ble_peripheral>` sample, except that this
+Similar to the :zephyr:code-sample:`ble_peripheral` sample, except that this
 application specifically exposes the HID GATT Service. The report map used is
 for a generic mouse.
 

--- a/samples/bluetooth/peripheral_hr/README.rst
+++ b/samples/bluetooth/peripheral_hr/README.rst
@@ -1,12 +1,13 @@
-.. _peripheral_hr:
+.. zephyr:code-sample:: ble_peripheral_hr
+   :name: Heart-rate Monitor (Peripheral)
+   :relevant-api: bt_hrs bt_bas bluetooth
 
-Bluetooth: Peripheral HR
-########################
+   Expose a Heart Rate (HR) GATT Service generating dummy heart-rate values.
 
 Overview
 ********
 
-Similar to the :ref:`Peripheral <ble_peripheral>` sample, except that this
+Similar to the :zephyr:code-sample:`ble_peripheral` sample, except that this
 application specifically exposes the HR (Heart Rate) GATT Service. Once a device
 connects it will generate dummy heart-rate values.
 

--- a/samples/bluetooth/peripheral_hr/README.rst
+++ b/samples/bluetooth/peripheral_hr/README.rst
@@ -16,7 +16,7 @@ Requirements
 ************
 
 * BlueZ running on the host, or
-* A board with BLE support
+* A board with Bluetooth LE support
 
 Building and Running
 ********************

--- a/samples/bluetooth/peripheral_ht/README.rst
+++ b/samples/bluetooth/peripheral_ht/README.rst
@@ -19,7 +19,7 @@ Requirements
 ************
 
 * BlueZ running on the host, or
-* A board with BLE support
+* A board with Bluetooth LE support
 
 Building and Running
 ********************

--- a/samples/bluetooth/peripheral_ht/README.rst
+++ b/samples/bluetooth/peripheral_ht/README.rst
@@ -1,12 +1,13 @@
-.. _peripheral_ht:
+.. zephyr:code-sample:: ble_peripheral_ht
+   :name: Health Thermometer (Peripheral)
+   :relevant-api: bt_bas bluetooth
 
-Bluetooth: Peripheral HT
-########################
+   Expose a Health Thermometer (HT) GATT Service generating dummy temperature values.
 
 Overview
 ********
 
-Similar to the :ref:`Peripheral <ble_peripheral>` sample, except that this
+Similar to the :zephyr:code-sample:`ble_peripheral` sample, except that this
 application specifically exposes the HT (Health Thermometer) GATT Service.
 
 On Nordic nRF devices, this sample uses the built-in TEMP peripheral to return

--- a/samples/bluetooth/peripheral_identity/README.rst
+++ b/samples/bluetooth/peripheral_identity/README.rst
@@ -1,7 +1,8 @@
-.. _peripheral_identity:
+.. zephyr:code-sample:: ble_peripheral_identity
+   :name: Peripheral Identity
+   :relevant-api: bluetooth
 
-Bluetooth: Peripheral Identity
-##############################
+   Use multiple identities to allow connections from multiple central devices.
 
 Overview
 ********

--- a/samples/bluetooth/peripheral_identity/README.rst
+++ b/samples/bluetooth/peripheral_identity/README.rst
@@ -14,7 +14,7 @@ Requirements
 ************
 
 * BlueZ running on the host, or
-* A board with BLE support
+* A board with Bluetooth LE support
 
 Building and Running
 ********************

--- a/samples/bluetooth/peripheral_nus/README.rst
+++ b/samples/bluetooth/peripheral_nus/README.rst
@@ -1,7 +1,8 @@
-.. _peripheral_nus:
+.. zephyr:code-sample:: ble_peripheral_nus
+   :name: Peripheral NUS
+   :relevant-api: bluetooth
 
-Bluetooth: Peripheral NUS
-#########################
+   Implement a simple echo server using the Nordic UART Service (NUS).
 
 Overview
 ********

--- a/samples/bluetooth/peripheral_nus/README.rst
+++ b/samples/bluetooth/peripheral_nus/README.rst
@@ -16,7 +16,7 @@ Requirements
 ************
 
 * BlueZ running on the host, or
-* A board with BLE support
+* A board with Bluetooth LE support
 
 Building and Running
 ********************

--- a/samples/bluetooth/peripheral_ots/README.rst
+++ b/samples/bluetooth/peripheral_ots/README.rst
@@ -15,7 +15,7 @@ Requirements
 ************
 
 * BlueZ running on the host, or
-* A board with BLE support
+* A board with Bluetooth LE support
 
 Building and Running
 ********************

--- a/samples/bluetooth/peripheral_ots/README.rst
+++ b/samples/bluetooth/peripheral_ots/README.rst
@@ -1,12 +1,13 @@
-.. _peripheral_ots:
+.. zephyr:code-sample:: ble_peripheral_ots
+   :name: Peripheral Object Transfer Service (OTS)
+   :relevant-api: bt_ots bluetooth
 
-Bluetooth: Peripheral OTS
-#########################
+   Expose an Object Transfer Service (OTS) GATT Service.
 
 Overview
 ********
 
-Similar to the :ref:`Peripheral <ble_peripheral>` sample, except that this
+Similar to the :zephyr:code-sample:`ble_peripheral` sample, except that this
 application specifically exposes the OTS (Object Transfer) GATT Service.
 
 

--- a/samples/bluetooth/peripheral_past/README.rst
+++ b/samples/bluetooth/peripheral_past/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth-peripheral-past-sample:
+.. zephyr:code-sample:: ble_peripheral_past
+   :name: Periodic Advertising Synchronization Transfer Peripheral
+   :relevant-api: bt_gap bluetooth
 
-Bluetooth: Periodic Advertising Synchronization Transfer
-########################################################
+   Use the Periodic Advertising Sync Transfer (PAST) feature as the receiver.
 
 Overview
 ********

--- a/samples/bluetooth/peripheral_past/README.rst
+++ b/samples/bluetooth/peripheral_past/README.rst
@@ -7,13 +7,13 @@
 Overview
 ********
 
-A simple application demonstrating the BLE Periodic Advertising Synchronization
+A simple application demonstrating the Bluetooth LE Periodic Advertising Synchronization
 Transfer (PAST) functionality as the receiver.
 
 Requirements
 ************
 
-* A board with BLE 5.1 support
+* A board with Bluetooth LE 5.1 support
 
 Building and Running
 ********************

--- a/samples/bluetooth/peripheral_sc_only/README.rst
+++ b/samples/bluetooth/peripheral_sc_only/README.rst
@@ -2,7 +2,7 @@
    :name: Peripheral SC-only
    :relevant-api: bt_conn bluetooth
 
-   Enable "Secure Connections Only" mode for a BLE peripheral.
+   Enable "Secure Connections Only" mode for a Bluetooth LE peripheral.
 
 Overview
 ********
@@ -16,7 +16,7 @@ Requirements
 ************
 
 * BlueZ running on the host, or
-* A board with BLE support
+* A board with Bluetooth LE support
 
 Building and Running
 ********************

--- a/samples/bluetooth/peripheral_sc_only/README.rst
+++ b/samples/bluetooth/peripheral_sc_only/README.rst
@@ -1,12 +1,13 @@
-.. _peripheral_sc_only:
+.. zephyr:code-sample:: ble_peripheral_sc_only
+   :name: Peripheral SC-only
+   :relevant-api: bt_conn bluetooth
 
-Bluetooth: Peripheral SC-only
-#############################
+   Enable "Secure Connections Only" mode for a BLE peripheral.
 
 Overview
 ********
 
-Similar to the :ref:`Peripheral <ble_peripheral>` sample, except that this
+Similar to the :zephyr:code-sample:`ble_peripheral` sample, except that this
 application enables the Secure Connections Only mode, i.e. will only
 accept connections that are secured using security level 4 (FIPS).
 

--- a/samples/bluetooth/scan_adv/README.rst
+++ b/samples/bluetooth/scan_adv/README.rst
@@ -2,12 +2,12 @@
    :name: Scan & Advertise
    :relevant-api: bt_gap bluetooth
 
-   Combine BLE Broadcaster & Observer roles to advertise and scan for devices simultaneously.
+   Combine Bluetooth LE Broadcaster & Observer roles to advertise and scan for devices simultaneously.
 
 Overview
 ********
 
-A simple application demonstrating combined BLE Broadcaster & Observer
+A simple application demonstrating combined Bluetooth LE Broadcaster & Observer
 role functionality. The application will periodically send out
 advertising packets with a manufacturer data element. The content of the
 data is a single byte indicating how many advertising packets the device
@@ -17,7 +17,7 @@ Requirements
 ************
 
 * BlueZ running on the host, or
-* A board with BLE support
+* A board with Bluetooth LE support
 
 Building and Running
 ********************

--- a/samples/bluetooth/scan_adv/README.rst
+++ b/samples/bluetooth/scan_adv/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth-scan-adv-sample:
+.. zephyr:code-sample:: ble_scan_adv
+   :name: Scan & Advertise
+   :relevant-api: bt_gap bluetooth
 
-Bluetooth: Scan & Advertise
-###########################
+   Combine BLE Broadcaster & Observer roles to advertise and scan for devices simultaneously.
 
 Overview
 ********

--- a/samples/bluetooth/st_ble_sensor/README.rst
+++ b/samples/bluetooth/st_ble_sensor/README.rst
@@ -1,5 +1,5 @@
 .. zephyr:code-sample:: bluetooth_st_ble_sensor
-   :name: ST BLE Sensor Demo
+   :name: ST Bluetooth LE Sensor Demo
    :relevant-api: bt_gatt bluetooth
 
    Export vendor-specific GATT services over BLE.
@@ -7,16 +7,16 @@
 Overview
 ********
 
-This application demonstrates BLE peripheral by exposing vendor-specific
+This application demonstrates Bluetooth LE peripheral by exposing vendor-specific
 GATT services. Currently only button notification and LED service are
-implemented. Other BLE sensor services can easily be added.
+implemented. Other Bluetooth LE sensor services can easily be added.
 See `BlueST protocol`_ document for details of how to add a new service.
 
 Requirements
 ************
 
-* `ST BLE Sensor Android app`_
-* A board with BLE support
+* `ST Bluetooth LE Sensor Android app`_
+* A board with Bluetooth LE support
 
 Building and Running
 ********************
@@ -24,14 +24,14 @@ Building and Running
 This sample can be found under :zephyr_file:`samples/bluetooth/st_ble_sensor` in the
 Zephyr tree.
 
-Open ST BLE Sensor app and click on "CONNECT TO A DEVICE" button to scan BLE devices.
+Open ST Bluetooth LE Sensor app and click on "CONNECT TO A DEVICE" button to scan Bluetooth LE devices.
 To connect click on the device shown in the Device List.
 After connected, tap LED image on Android to test LED service.
 Push SW0 button on embedded device to test button service.
 
 See :ref:`bluetooth samples section <bluetooth-samples>` for details.
 
-.. _ST BLE Sensor Android app:
+.. _ST Bluetooth LE Sensor Android app:
     https://play.google.com/store/apps/details?id=com.st.bluems
 
 .. _BlueST protocol:

--- a/samples/bluetooth/st_ble_sensor/README.rst
+++ b/samples/bluetooth/st_ble_sensor/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth-st_ble_sensor:
+.. zephyr:code-sample:: bluetooth_st_ble_sensor
+   :name: ST BLE Sensor Demo
+   :relevant-api: bt_gatt bluetooth
 
-Bluetooth: ST BLE Sensor Demo
-#############################
+   Export vendor-specific GATT services over BLE.
 
 Overview
 ********

--- a/samples/bluetooth/tmap_bmr/README.rst
+++ b/samples/bluetooth/tmap_bmr/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth_tmap_bmr:
+.. zephyr:code-sample:: ble_peripheral_tmap_bmr
+   :name: TMAP Broadcast Media Receiver (BMR)
+   :relevant-api: bt_audio bt_bap bluetooth
 
-Bluetooth: TMAP BMR
-###################
+   Implement the LE Audio TMAP Broadcast Media Receiver (BMR) role.
 
 Overview
 ********

--- a/samples/bluetooth/tmap_bms/README.rst
+++ b/samples/bluetooth/tmap_bms/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth_tmap_bms:
+.. zephyr:code-sample:: ble_peripheral_tmap_bms
+   :name: TMAP Broadcast Media Sender (BMS)
+   :relevant-api: bt_audio bt_bap bluetooth
 
-Bluetooth: TMAP BMS
-###################
+   Implement the LE Audio TMAP Broadcast Media Sender (BMS) role.
 
 Overview
 ********

--- a/samples/bluetooth/tmap_central/README.rst
+++ b/samples/bluetooth/tmap_central/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth_tmap_central:
+.. zephyr:code-sample:: ble_peripheral_tmap_central
+   :name: TMAP (Central)
+   :relevant-api: bt_audio bt_bap bluetooth
 
-Bluetooth: TMAP Central
-#######################
+   Implement the LE Audio TMAP central functionality (CG and UMS roles).
 
 Overview
 ********

--- a/samples/bluetooth/tmap_peripheral/README.rst
+++ b/samples/bluetooth/tmap_peripheral/README.rst
@@ -1,7 +1,8 @@
-.. _bluetooth_tmap_peripheral:
+.. zephyr:code-sample:: ble_peripheral_tmap_peripheral
+   :name: TMAP (Peripheral)
+   :relevant-api: bt_audio bt_bap bluetooth
 
-Bluetooth: TMAP Peripheral
-##########################
+   Implement the LE Audio TMAP central functionality (CT and UMR roles).
 
 Overview
 ********


### PR DESCRIPTION
Describe the Bluetooth samples using `code-sample` directive in preparation for upcoming changes to the Zephyr documentation that will be leveraging the provided description and metadata.

This is a work in progress but I am almost done. Perhaps the main "disruptive" change this is introducing is dropping "Bluetooth: " prefix in front of all the samples' names, but hopefully people agree it is redundant :)

The "descriptions" are not prominently featured just yet but will be in an upcoming update to how samples are listed. It will look something like the below, which hopefully illustrates the added value of these short descriptions :)

<img width="749" alt="image" src="https://github.com/user-attachments/assets/c91a301b-94aa-4c84-9366-2340c6d7a914">

---

**Could people added as early reviewers confirm that this is going in the right direction for them and that I didn't miss something obvious or a constraint specific to Bluetooth samples?**

Note that the upcoming change to the docs will allow to add code sample *categories*, so it might make sense to add new groups for TMAP, HCI, etc. at some point