### PR TITLE
boards: st: nucleo_g0b1re: update pyocd target

### DIFF
--- a/boards/st/nucleo_g0b1re/board.cmake
+++ b/boards/st/nucleo_g0b1re/board.cmake
@@ -3,9 +3,7 @@
 # keep first
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 
-# keil.stm32g0xx_dfp.1.3.0.pack introduced stm32g0b series, but the target does
-# not work with pyocd currently.
-board_runner_args(pyocd "--target=stm32g071rbtx")
+board_runner_args(pyocd "--target=stm32g0b1retx")
 board_runner_args(pyocd "--flash-opt=-O reset_type=hw")
 board_runner_args(pyocd "--flash-opt=-O connect_mode=under-reset")
 board_runner_args(jlink "--device=STM32G0B1RE" "--speed=4000")

--- a/boards/st/nucleo_g0b1re/doc/index.rst
+++ b/boards/st/nucleo_g0b1re/doc/index.rst
@@ -168,10 +168,8 @@ the ``--runner`` (or ``-r``) option:
    $ west flash --runner jlink
    $ west flash --runner pyocd
 
-Pyocd support is currently limited: As the stm32g0b1 target causes issues,
-the stm32g071 target is used. For STM32G0 support pyOCD needs additional target
-information, which can be installed by adding "pack" support with the
-following pyOCD commands:
+For STM32G0 support pyocd needs additional target information,
+which can be installed by adding "pack" support with the following pyocd command:
 
 .. code-block:: console
 


### PR DESCRIPTION
Update the pyocd runner configuration of the nucleo_g0b1re to use the correct target.

Pyocd had issues only just after the release of the G0B1/C1 line. This issue has already been fixed a few releases ago.