### PR TITLE
unittest: Enable debug info by default

### DIFF
--- a/cmake/modules/unittest.cmake
+++ b/cmake/modules/unittest.cmake
@@ -121,6 +121,8 @@ target_link_libraries(testbinary PRIVATE
   ${EXTRA_LDFLAGS_AS_LIST}
   )
 
+target_compile_options(test_interface INTERFACE $<TARGET_PROPERTY:compiler,debug>)
+
 if(CONFIG_COVERAGE)
   target_compile_options(test_interface INTERFACE $<TARGET_PROPERTY:compiler,coverage>)
 


### PR DESCRIPTION
By enabling debugging information it becomes way much simpler to find the root cause of a failing unit test as we can simply run it with a debugger.

I'm not sure if it was intentional to leave this out in the initial PR (https://github.com/zephyrproject-rtos/zephyr/pull/48732).
I'm also not sure if and how people debugged unit tests before this change.