### PR TITLE
hotfix: drivers: i2s: update esp32s3/c3 I2S dtsi

### DIFF
--- a/dts/riscv/espressif/esp32c3/esp32c3_common.dtsi
+++ b/dts/riscv/espressif/esp32c3/esp32c3_common.dtsi
@@ -175,7 +175,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x6002d000 0x1000>;
-			interrupts = <I2S1_INTR_SOURCE>;
+			interrupts = <I2S1_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_I2S1_MODULE>;
 			dmas = <&dma 2>, <&dma 3>;

--- a/dts/xtensa/espressif/esp32s3/esp32s3_common.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_common.dtsi
@@ -285,7 +285,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x6000f000 0x1000>;
-			interrupts = <I2S0_INTR_SOURCE>;
+			interrupts = <I2S0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_I2S0_MODULE>;
 			dmas = <&dma 2>, <&dma 3>;
@@ -299,7 +299,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x6002d000 0x1000>;
-			interrupts = <I2S1_INTR_SOURCE>;
+			interrupts = <I2S1_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_I2S1_MODULE>;
 			dmas = <&dma 4>, <&dma 5>;


### PR DESCRIPTION
I2S driver was merged after interrupt .dtsi was changed, causing CI to fail. This updates it accordingly.