### PR TITLE
drivers: uart_xmc4xxx: Forward DMA overrun errors to user

### DIFF
--- a/drivers/dma/dma_xmc4xxx.c
+++ b/drivers/dma/dma_xmc4xxx.c
@@ -101,11 +101,8 @@ static void dma_xmc4xxx_isr(const struct device *dev)
 		struct dma_xmc4xxx_channel *dma_channel;
 
 		dma_channel = &dev_data->channels[i];
-		if (dma_channel->cb && dma_channel->dlr_line != DLR_LINE_UNSET &&
+		if (dma_channel->dlr_line != DLR_LINE_UNSET &&
 		    sr_overruns & BIT(dma_channel->dlr_line)) {
-
-			LOG_ERR("Overruns detected on channel %d", i);
-			dma_channel->cb(dev, dma_channel->user_data, i, -EIO);
 
 			/* From XMC4700/4800 reference documentation - Section 4.4.1 */
 			/* Once the overrun condition is entered the user can clear the */
@@ -114,6 +111,11 @@ static void dma_xmc4xxx_isr(const struct device *dev)
 			/* disabling and enabling the respective line. */
 			DLR->LNEN &= ~BIT(dma_channel->dlr_line);
 			DLR->LNEN |= BIT(dma_channel->dlr_line);
+
+			LOG_ERR("Overruns detected on channel %d", i);
+			if (dma_channel->cb != NULL) {
+				dma_channel->cb(dev, dma_channel->user_data, i, -EIO);
+			}
 		}
 	}
 }

--- a/drivers/serial/uart_xmc4xxx.c
+++ b/drivers/serial/uart_xmc4xxx.c
@@ -428,6 +428,28 @@ static inline void async_evt_rx_release_buffer(struct uart_xmc4xxx_data *data, i
 	}
 }
 
+static inline void async_evt_rx_stopped(struct uart_xmc4xxx_data *data,
+					enum uart_rx_stop_reason reason)
+{
+	struct uart_event event = {.type = UART_RX_STOPPED, .data.rx_stop.reason = reason};
+	struct uart_event_rx *rx = &event.data.rx_stop.data;
+	struct dma_status stat;
+
+	if (data->dma_rx.buffer_len == 0 || data->async_cb == NULL) {
+		return;
+	}
+
+	rx->buf = data->dma_rx.buffer;
+	if (dma_get_status(data->dma_rx.dma_dev, data->dma_rx.dma_channel, &stat) == 0) {
+		data->dma_rx.counter = data->dma_rx.buffer_len - stat.pending_length;
+	}
+
+	rx->len = data->dma_rx.counter - data->dma_rx.offset;
+	rx->offset = data->dma_rx.counter;
+
+	data->async_cb(data->dev, &event, data->async_user_data);
+}
+
 static inline void async_evt_rx_disabled(struct uart_xmc4xxx_data *data)
 {
 	struct uart_event event = {.type = UART_RX_DISABLED};
@@ -707,13 +729,19 @@ static void uart_xmc4xxx_dma_rx_cb(const struct device *dma_dev, void *user_data
 	unsigned int key;
 	int ret;
 
-	if (status != 0) {
-		return;
-	}
-
 	__ASSERT_NO_MSG(channel == data->dma_rx.dma_channel);
 	key = irq_lock();
 	k_work_cancel_delayable(&data->dma_rx.timeout_work);
+
+	if (status < 0) {
+		async_evt_rx_stopped(data, UART_ERROR_OVERRUN);
+		uart_xmc4xxx_irq_rx_disable(dev_uart);
+		dma_stop(data->dma_rx.dma_dev, data->dma_rx.dma_channel);
+		async_evt_rx_release_buffer(data, CURRENT_BUFFER);
+		async_evt_rx_release_buffer(data, NEXT_BUFFER);
+		async_evt_rx_disabled(data);
+		goto done;
+	}
 
 	if (data->dma_rx.buffer_len == 0) {
 		goto done;
@@ -725,8 +753,8 @@ static void uart_xmc4xxx_dma_rx_cb(const struct device *dma_dev, void *user_data
 	async_evt_rx_release_buffer(data, CURRENT_BUFFER);
 
 	if (!data->rx_next_buffer) {
-		dma_stop(data->dma_rx.dma_dev, data->dma_rx.dma_channel);
 		uart_xmc4xxx_irq_rx_disable(dev_uart);
+		dma_stop(data->dma_rx.dma_dev, data->dma_rx.dma_channel);
 		async_evt_rx_disabled(data);
 		goto done;
 	}
@@ -743,8 +771,8 @@ static void uart_xmc4xxx_dma_rx_cb(const struct device *dma_dev, void *user_data
 			 data->dma_rx.buffer_len);
 
 	if (ret < 0) {
-		dma_stop(data->dma_rx.dma_dev, data->dma_rx.dma_channel);
 		uart_xmc4xxx_irq_rx_disable(dev_uart);
+		dma_stop(data->dma_rx.dma_dev, data->dma_rx.dma_channel);
 		async_evt_rx_release_buffer(data, CURRENT_BUFFER);
 		async_evt_rx_disabled(data);
 		goto done;


### PR DESCRIPTION
Currently DMA overrun errors are ignored. Forward the error to the user using the UART_RX_STOPPED with UART_ERROR_OVERRUN reason.    
