### PR TITLE
bluetooth: conn: add `conn` to recycled callback

### DIFF
--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -181,6 +181,11 @@ Bluetooth Classic
 Bluetooth Host
 ==============
 
+* The Bluetooth connection callback function :code:`bt_conn_cb.recycled` now contains an additional
+  parameter for the connection that was freed. This can be used by the callback to match against
+  connections created from an advertising set. This parameter needs to be added to all instances of
+  this callback.
+
 Bluetooth Crypto
 ================
 

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -1173,8 +1173,11 @@ struct bt_conn_cb {
 	 * @ref bt_conn_unref which is used by the BT stack. Making
 	 * Bluetooth API calls in this context is error-prone and strongly
 	 * discouraged.
+	 *
+	 * @param conn Connection object that was returned. Can ONLY be used
+	 *             for comparison purposes, not API calls.
 	 */
-	void (*recycled)(void);
+	void (*recycled)(const void *conn);
 
 	/** @brief LE connection parameter update request.
 	 *

--- a/samples/bluetooth/extended_adv/advertiser/src/main.c
+++ b/samples/bluetooth/extended_adv/advertiser/src/main.c
@@ -60,7 +60,7 @@ static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 	default_conn = NULL;
 }
 
-static void recycled_cb(void)
+static void recycled_cb(const void *conn)
 {
 	printk("Connection object available from previous conn. Disconnect is complete!\n");
 	raise_evt(BT_SAMPLE_EVT_DISCONNECTED);

--- a/samples/bluetooth/extended_adv/scanner/src/main.c
+++ b/samples/bluetooth/extended_adv/scanner/src/main.c
@@ -64,7 +64,7 @@ static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 	printk("Disconnected, reason 0x%02X %s\n", reason, bt_hci_err_to_str(reason));
 }
 
-static void recycled_cb(void)
+static void recycled_cb(const void *conn)
 {
 	printk("Connection object available from previous conn. Disconnect is complete!\n");
 	raise_evt(BT_SAMPLE_EVT_DISCONNECTED);

--- a/samples/subsys/mgmt/mcumgr/smp_svr/src/bluetooth.c
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/src/bluetooth.c
@@ -57,7 +57,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	LOG_INF("Disconnected, reason 0x%02x %s", reason, bt_hci_err_to_str(reason));
 }
 
-static void on_conn_recycled(void)
+static void on_conn_recycled(const void *conn)
 {
 	k_work_submit(&advertise_work);
 }

--- a/tests/bluetooth/common/testlib/src/conn_wait.c
+++ b/tests/bluetooth/common/testlib/src/conn_wait.c
@@ -30,7 +30,7 @@ static void on_change(struct bt_conn *conn, uint8_t err)
 	k_mutex_unlock(&conn_wait_mutex);
 }
 
-static void on_conn_recycled(void)
+static void on_conn_recycled(const void *conn)
 {
 	k_mutex_lock(&conn_wait_mutex, K_FOREVER);
 	k_condvar_broadcast(&conn_recycled);

--- a/tests/bsim/bluetooth/host/adv/extended/src/ext_adv_advertiser.c
+++ b/tests/bsim/bluetooth/host/adv/extended/src/ext_adv_advertiser.c
@@ -154,7 +154,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	UNSET_FLAG(flag_connected);
 }
 
-static void recycled(void)
+static void recycled(const void *conn)
 {
 	SET_FLAG(flag_conn_recycled);
 }

--- a/tests/bsim/bluetooth/host/adv/extended/src/ext_adv_scanner.c
+++ b/tests/bsim/bluetooth/host/adv/extended/src/ext_adv_scanner.c
@@ -69,7 +69,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	UNSET_FLAG(flag_connected);
 }
 
-static void recycled(void)
+static void recycled(const void *conn)
 {
 	SET_FLAG(flag_conn_recycled);
 }

--- a/tests/bsim/bluetooth/host/misc/acl_tx_frag/src/dut.c
+++ b/tests/bsim/bluetooth/host/misc/acl_tx_frag/src/dut.c
@@ -35,7 +35,7 @@ static DEFINE_FLAG(indicated);
 
 extern unsigned long runtime_log_level;
 
-static void recycled(void)
+static void recycled(const void *conn)
 {
 	LOG_DBG("");
 	SET_FLAG(conn_recycled);


### PR DESCRIPTION
Add the connection object that was recycled to the recycled callback. This can be used to match the connections created from advertising sets to the recycled callback invocation.

In turn, this allows software libraries to manage only a single advertising set, restarting the set when a connection created from that set terminates, emulating the behaviour of `!BT_LE_ADV_OPT_ONE_TIME` for extended advertising.