### PR TITLE
Update QEMU RISCV IRQ config, fix interrupt bits check

### DIFF
--- a/arch/common/multilevel_irq.c
+++ b/arch/common/multilevel_irq.c
@@ -11,9 +11,12 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/util.h>
 
-BUILD_ASSERT((CONFIG_NUM_2ND_LEVEL_AGGREGATORS * CONFIG_MAX_IRQ_PER_AGGREGATOR) <=
-		     BIT(CONFIG_2ND_LEVEL_INTERRUPT_BITS),
+BUILD_ASSERT(CONFIG_MAX_IRQ_PER_AGGREGATOR < BIT(CONFIG_2ND_LEVEL_INTERRUPT_BITS),
 	     "L2 bits not enough to cover the number of L2 IRQs");
+#ifdef CONFIG_3RD_LEVEL_INTERRUPTS
+BUILD_ASSERT(CONFIG_MAX_IRQ_PER_AGGREGATOR < BIT(CONFIG_3RD_LEVEL_INTERRUPT_BITS),
+	     "L3 bits not enough to cover the number of L3 IRQs");
+#endif /* CONFIG_3RD_LEVEL_INTERRUPTS */
 
 /**
  * @brief Get the aggregator that's responsible for the given irq
@@ -85,7 +88,8 @@ unsigned int z_get_sw_isr_table_idx(unsigned int irq)
 
 	table_idx -= CONFIG_GEN_IRQ_START_VECTOR;
 
-	__ASSERT_NO_MSG(table_idx < IRQ_TABLE_SIZE);
+	__ASSERT(table_idx < IRQ_TABLE_SIZE, "table_idx(%d) < IRQ_TABLE_SIZE(%d)", table_idx,
+		 IRQ_TABLE_SIZE);
 
 	return table_idx;
 }

--- a/soc/qemu/virt_riscv/Kconfig.defconfig
+++ b/soc/qemu/virt_riscv/Kconfig.defconfig
@@ -19,11 +19,14 @@ config 2ND_LVL_ISR_TBL_OFFSET
 config 2ND_LVL_INTR_00_OFFSET
 	default 11
 
+config 2ND_LEVEL_INTERRUPT_BITS
+	default 11
+
 config MAX_IRQ_PER_AGGREGATOR
-	default 52
+	default 1024
 
 config NUM_IRQS
-	default 1035
+	default 1036
 
 config PMP_SLOTS
 	default 16

--- a/tests/drivers/build_all/interrupt_controller/intc_plic/testcase.yaml
+++ b/tests/drivers/build_all/interrupt_controller/intc_plic/testcase.yaml
@@ -21,6 +21,7 @@ tests:
       DTC_OVERLAY_FILE="./app.multi_instance.overlay"
     extra_configs:
       - CONFIG_NUM_IRQS=116
+      - CONFIG_MAX_IRQ_PER_AGGREGATOR=52
       - CONFIG_MULTI_LEVEL_INTERRUPTS=y
       - CONFIG_DYNAMIC_INTERRUPTS=y
       - CONFIG_NUM_2ND_LEVEL_AGGREGATORS=2

--- a/tests/kernel/gen_isr_table/testcase.yaml
+++ b/tests/kernel/gen_isr_table/testcase.yaml
@@ -85,12 +85,14 @@ tests:
     platform_allow: qemu_riscv32
     filter: CONFIG_RISCV_PRIVILEGED
     extra_configs:
+      - CONFIG_MAX_IRQ_PER_AGGREGATOR=52
       - CONFIG_1ST_LEVEL_INTERRUPT_BITS=7
       - CONFIG_2ND_LEVEL_INTERRUPT_BITS=9
   arch.interrupt.gen_isr_table.bit_shift_3rd_level:
     platform_allow: qemu_riscv32
     filter: CONFIG_RISCV_PRIVILEGED
     extra_configs:
+      - CONFIG_MAX_IRQ_PER_AGGREGATOR=52
       - CONFIG_MULTI_LEVEL_INTERRUPTS=y
       - CONFIG_2ND_LEVEL_INTERRUPTS=y
       - CONFIG_3RD_LEVEL_INTERRUPTS=y


### PR DESCRIPTION
- Update QEMU RISCV IRQ config
- Fix aggregator interrupt bit check