### PR TITLE
drivers: spi: stm32: log debug actual frequency

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -624,6 +624,8 @@ static int spi_stm32_configure(const struct device *dev,
 		uint32_t clk = clock >> br;
 
 		if (clk <= config->frequency) {
+			LOG_DBG("%s frequency set to %uHz (requested %uHz)", dev->name, clk,
+				config->frequency);
 			break;
 		}
 	}


### PR DESCRIPTION
Add a LOG_DBG entry which prints the actual frequency and the spi-max-frequency.
This might be helpful when a device, e.g. LED strip drivers, requires an exact frequency.