### PR TITLE
tests: kernel.common.stack_sentinel: re-enable some platforms

### DIFF
--- a/tests/kernel/fatal/exception/testcase.yaml
+++ b/tests/kernel/fatal/exception/testcase.yaml
@@ -45,8 +45,6 @@ tests:
     extra_args: CONF_FILE=sentinel.conf
     platform_exclude:
       - qemu_cortex_a9 # FIXME: See issue #39948
-      - hifive1        # FIXME: See issue #66070
-      - m2gl025_miv    # FIXME: See issue #66070
     tags: kernel
     integration_platforms:
       - qemu_x86


### PR DESCRIPTION
This PR re-enables the following platforms for the `kernel.common.stack_sentinel` test:
* `hifive1`
* `m2gl025_miv`

These platforms working correctly after Renode was upgraded to 1.15.2 in the CI.