### PR TITLE
tests: drivers.gpio.1pin: re-enable hifive1

### DIFF
--- a/tests/drivers/gpio/gpio_api_1pin/testcase.yaml
+++ b/tests/drivers/gpio/gpio_api_1pin/testcase.yaml
@@ -10,5 +10,4 @@ tests:
       - mps2/an385
       - mps2/an521/cpu0
       - neorv32
-      - hifive1  # see #69350
     filter: dt_enabled_alias_with_parent_compat("led0", "gpio-leds")


### PR DESCRIPTION
This PR removes the `hifive1` board from the `platform_exclude` list for the `drivers.gpio.1pin` pin.

The root cause for why this platform was disabled was fixed in the recent Renode version upgrade in the CI image.

Fixes #69350.