### PR TITLE
boards: nxp: Add uart-mcumgr for nxp boards

### DIFF
--- a/boards/nxp/frdm_k22f/frdm_k22f.dts
+++ b/boards/nxp/frdm_k22f/frdm_k22f.dts
@@ -34,6 +34,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,uart-mcumgr = &uart1;
 		zephyr,console = &uart1;
 		zephyr,shell-uart = &uart1;
 		zephyr,uart-pipe = &uart1;

--- a/boards/nxp/frdm_k82f/frdm_k82f.dts
+++ b/boards/nxp/frdm_k82f/frdm_k82f.dts
@@ -39,6 +39,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,uart-mcumgr = &lpuart4;
 		zephyr,console = &lpuart4;
 		zephyr,shell-uart = &lpuart4;
 		zephyr,uart-pipe = &lpuart4;

--- a/boards/nxp/frdm_kw41z/frdm_kw41z.dts
+++ b/boards/nxp/frdm_kw41z/frdm_kw41z.dts
@@ -33,6 +33,7 @@
 		zephyr,shell-uart = &lpuart0;
 		zephyr,ieee802154 = &ieee802154;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,uart-mcumgr = &lpuart0;
 	};
 
 	leds {

--- a/boards/nxp/frdm_mcxn236/frdm_mcxn236.dts
+++ b/boards/nxp/frdm_mcxn236/frdm_mcxn236.dts
@@ -18,6 +18,7 @@
 		zephyr,flash = &flash;
 		zephyr,flash-controller = &fmu;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,uart-mcumgr = &flexcomm4_lpuart4;
 		zephyr,console = &flexcomm4_lpuart4;
 		zephyr,shell-uart = &flexcomm4_lpuart4;
 	};

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.dtsi
@@ -23,6 +23,7 @@
 		zephyr,flash = &flash;
 		zephyr,flash-controller = &fmu;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,uart-mcumgr = &flexcomm4_lpuart4;
 		zephyr,console = &flexcomm4_lpuart4;
 		zephyr,shell-uart = &flexcomm4_lpuart4;
 		zephyr,canbus = &flexcan0;

--- a/boards/nxp/hexiwear/hexiwear_mk64f12.dts
+++ b/boards/nxp/hexiwear/hexiwear_mk64f12.dts
@@ -26,6 +26,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,uart-mcumgr = &uart0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,bt-hci = &bt_hci_uart;

--- a/boards/nxp/lpcxpresso54114/lpcxpresso54114_lpc54114_m4.dts
+++ b/boards/nxp/lpcxpresso54114/lpcxpresso54114_lpc54114_m4.dts
@@ -26,6 +26,7 @@
 		zephyr,console = &flexcomm0;
 		zephyr,shell-uart = &flexcomm0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,uart-mcumgr = &flexcomm0;
 	};
 
 	gpio_keys {

--- a/boards/nxp/lpcxpresso55s06/lpcxpresso55s06_common.dtsi
+++ b/boards/nxp/lpcxpresso55s06/lpcxpresso55s06_common.dtsi
@@ -13,6 +13,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,uart-mcumgr = &flexcomm0;
 		zephyr,console = &flexcomm0;
 		zephyr,shell-uart = &flexcomm0;
 		zephyr,entropy = &rng;

--- a/boards/nxp/lpcxpresso55s16/lpcxpresso55s16_common.dtsi
+++ b/boards/nxp/lpcxpresso55s16/lpcxpresso55s16_common.dtsi
@@ -13,6 +13,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,uart-mcumgr = &flexcomm0;
 		zephyr,console = &flexcomm0;
 		zephyr,shell-uart = &flexcomm0;
 		zephyr,entropy = &rng;

--- a/boards/nxp/lpcxpresso55s28/lpcxpresso55s28.dts
+++ b/boards/nxp/lpcxpresso55s28/lpcxpresso55s28.dts
@@ -27,6 +27,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,uart-mcumgr = &flexcomm0;
 		zephyr,console = &flexcomm0;
 		zephyr,shell-uart = &flexcomm0;
 		zephyr,entropy = &rng;

--- a/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.dts
+++ b/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.dts
@@ -18,6 +18,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,uart-mcumgr = &flexcomm0;
 		zephyr,console = &flexcomm0;
 		zephyr,shell-uart = &flexcomm0;
 		zephyr,canbus = &can0;

--- a/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0.dts
+++ b/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0.dts
@@ -37,6 +37,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,uart-mcumgr = &flexcomm0;
 		zephyr,code-cpu1-partition = &slot0_ns_partition;
 		zephyr,sram-cpu1-partition = &sram3;
 		zephyr,console = &flexcomm0;

--- a/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0_ns.dts
+++ b/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0_ns.dts
@@ -30,6 +30,7 @@
 		zephyr,sram = &non_secure_ram;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_ns_partition;
+		zephyr,uart-mcumgr = &flexcomm0;
 		zephyr,console = &flexcomm0;
 		zephyr,shell-uart = &flexcomm0;
 		zephyr,entropy = &rng;

--- a/boards/nxp/mimxrt1010_evk/mimxrt1010_evk.dts
+++ b/boards/nxp/mimxrt1010_evk/mimxrt1010_evk.dts
@@ -29,6 +29,7 @@
 		zephyr,flash = &at25sf128a;
 		zephyr,flash-controller = &at25sf128a;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,uart-mcumgr = &lpuart1;
 	};
 
 	leds {

--- a/boards/nxp/mimxrt1015_evk/mimxrt1015_evk.dts
+++ b/boards/nxp/mimxrt1015_evk/mimxrt1015_evk.dts
@@ -28,6 +28,7 @@
 		zephyr,flash = &at25sf128a;
 		zephyr,flash-controller = &at25sf128a;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,uart-mcumgr = &lpuart1;
 	};
 
 	leds {

--- a/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -24,6 +24,7 @@
 		zephyr,flash-controller = &is25wp064;
 		zephyr,flash = &is25wp064;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,uart-mcumgr = &lpuart1;
 		zephyr,sram = &sdram0;
 		zephyr,itcm = &itcm;
 		zephyr,dtcm = &dtcm;

--- a/boards/nxp/mimxrt1024_evk/mimxrt1024_evk.dts
+++ b/boards/nxp/mimxrt1024_evk/mimxrt1024_evk.dts
@@ -27,6 +27,7 @@
 		zephyr,flash-controller = &w25q32jvwj0;
 		zephyr,flash = &w25q32jvwj0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,uart-mcumgr = &lpuart1;
 		zephyr,sram = &sdram0;
 		zephyr,itcm = &itcm;
 		zephyr,dtcm = &dtcm;

--- a/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.dts
+++ b/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.dts
@@ -30,6 +30,7 @@
 		zephyr,flash = &w25q64jvssiq;
 		zephyr,flash-controller = &w25q64jvssiq;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,uart-mcumgr = &lpuart1;
 		zephyr,bt-hci = &bt_hci_uart;
 	};
 

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -27,6 +27,7 @@
 		zephyr,sram = &sdram0;
 		zephyr,itcm = &itcm;
 		zephyr,dtcm = &dtcm;
+		zephyr,uart-mcumgr = &lpuart1;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 	};

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -26,6 +26,7 @@
 		zephyr,sram = &sdram0;
 		zephyr,itcm = &itcm;
 		zephyr,dtcm = &dtcm;
+		zephyr,uart-mcumgr = &lpuart1;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,canbus = &flexcan3;

--- a/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6.dts
+++ b/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6.dts
@@ -29,6 +29,7 @@
 		zephyr,flash-controller = &s26ks512s0;
 		zephyr,flash = &s26ks512s0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,uart-mcumgr = &lpuart7;
 		zephyr,sram = &ocram;
 		zephyr,itcm = &itcm;
 		zephyr,dtcm = &dtcm;

--- a/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -26,6 +26,7 @@
 		zephyr,flash-controller = &is25wp064;
 		zephyr,flash = &w25q32jvwj0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,uart-mcumgr = &lpuart1;
 		zephyr,sram = &sdram0;
 		zephyr,itcm = &itcm;
 		zephyr,dtcm = &dtcm;

--- a/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm7.dts
+++ b/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm7.dts
@@ -23,6 +23,7 @@
 		zephyr,flash-controller = &is25wp128;
 		zephyr,flash = &is25wp128;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,uart-mcumgr = &lpuart1;
 		zephyr,cpu1-region = &ocram;
 		zephyr,ipc = &mailbox_a;
 	};

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7.dts
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7.dts
@@ -28,6 +28,7 @@
 		zephyr,flash-controller = &is25wp128;
 		zephyr,flash = &is25wp128;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,uart-mcumgr = &lpuart1;
 		zephyr,cpu1-region = &ocram;
 		zephyr,ipc = &mailbox_a;
 	};

--- a/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
+++ b/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
@@ -35,6 +35,7 @@
 		zephyr,flash-controller = &mx25um51345g;
 		zephyr,flash = &mx25um51345g;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,uart-mcumgr = &flexcomm0;
 		zephyr,sram = &sram0;
 		zephyr,console = &flexcomm0;
 		zephyr,shell-uart = &flexcomm0;

--- a/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
+++ b/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
@@ -40,6 +40,7 @@
 		zephyr,flash-controller = &mx25um51345g;
 		zephyr,flash = &mx25um51345g;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,uart-mcumgr = &flexcomm0;
 		zephyr,sram = &sram0;
 		zephyr,console = &flexcomm0;
 		zephyr,shell-uart = &flexcomm0;

--- a/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
+++ b/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
@@ -25,6 +25,7 @@
 		zephyr,sram = &sram_data;
 		zephyr,flash = &mx25u51245g;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,uart-mcumgr = &flexcomm3;
 		zephyr,flash-controller = &mx25u51245g;
 		zephyr,console = &flexcomm3;
 		zephyr,shell-uart = &flexcomm3;

--- a/boards/nxp/rddrone_fmuk66/rddrone_fmuk66.dts
+++ b/boards/nxp/rddrone_fmuk66/rddrone_fmuk66.dts
@@ -37,6 +37,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,uart-mcumgr = &lpuart0;
 		zephyr,console = &lpuart0;
 		zephyr,shell-uart = &lpuart0;
 		zephyr,uart-pipe = &lpuart0;

--- a/boards/nxp/twr_ke18f/twr_ke18f.dts
+++ b/boards/nxp/twr_ke18f/twr_ke18f.dts
@@ -47,6 +47,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,uart-mcumgr = &lpuart0;
 		zephyr,console = &lpuart0;
 		zephyr,shell-uart = &lpuart0;
 		zephyr,uart-pipe = &lpuart0;

--- a/boards/nxp/twr_kv58f220m/twr_kv58f220m.dts
+++ b/boards/nxp/twr_kv58f220m/twr_kv58f220m.dts
@@ -31,6 +31,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,uart-mcumgr = &uart0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,uart-pipe = &uart0;

--- a/boards/nxp/vmu_rt1170/vmu_rt1170_mimxrt1176_cm7.dts
+++ b/boards/nxp/vmu_rt1170/vmu_rt1170_mimxrt1176_cm7.dts
@@ -35,6 +35,7 @@
 		zephyr,flash-controller = &mx25um51345g;
 		zephyr,flash = &mx25um51345g;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,uart-mcumgr = &lpuart1;
 	};
 
 	/* This is the Arming Button on the included GPS module for 10 pin JST-GH */


### PR DESCRIPTION
- Adds "chosen,uart-mcumgr" for nxp boards that support the secondary bootloader partitioning.
- Fixes the subsys\mgmt\mcumgr\smp_svr sample.