### PR TITLE
devicetree: use stable identifiers for LLEXT-exported DT object names

### DIFF
--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -243,6 +243,16 @@
 #define DT_HAS_ALIAS(alias_name) DT_NODE_EXISTS(DT_ALIAS(alias_name))
 
 /**
+ * @brief Get the hash associated with a DT node
+ *
+ * Get the hash for the specified node_id. The hash is calculated on the
+ * full devicetree path of the node.
+ * @param node_id node identifier
+ * @return hash value as a preprocessor token
+ */
+#define DT_NODE_HASH(node_id) DT_CAT(node_id, _HASH)
+
+/**
  * @brief Get a node identifier for an instance of a compatible
  *
  * All nodes with a particular compatible property value are assigned

--- a/include/zephyr/llext/symbol.h
+++ b/include/zephyr/llext/symbol.h
@@ -90,17 +90,29 @@ struct llext_symtable {
 /** @cond ignore */
 #ifdef LL_EXTENSION_BUILD
 /* Extension build: add exported symbols to llext table */
-#define Z_LL_EXTENSION_SYMBOL(x)						\
+#define Z_LL_EXTENSION_SYMBOL_NAMED(sym_ident, sym_name)			\
 	static const struct llext_const_symbol					\
 			Z_GENERIC_SECTION(".exported_sym") __used		\
-			__llext_sym_ ## x = {					\
-		.name = STRINGIFY(x), .addr = (const void *)&x,			\
+			__llext_sym_ ## sym_name = {				\
+		.name = STRINGIFY(sym_name), .addr = (const void *)&sym_ident,	\
 	}
 #else
 /* No-op when not building an extension */
-#define Z_LL_EXTENSION_SYMBOL(x)
+#define Z_LL_EXTENSION_SYMBOL_NAMED(sym_ident, sym_name)
 #endif
 /** @endcond */
+
+/**
+ * @brief Exports a symbol from an extension to the base image with a custom name
+ *
+ * Version of @ref LL_EXTENSION_SYMBOL that allows the user to specify a custom
+ * name for the exported symbol.
+ *
+ * @param sym_ident Extension symbol to export to the base image
+ * @param sym_name Name associated with the symbol
+ */
+#define LL_EXTENSION_SYMBOL_NAMED(sym_ident, sym_name)				\
+	Z_LL_EXTENSION_SYMBOL_NAMED(sym_ident, sym_name)
 
 /**
  * @brief Exports a symbol from an extension to the base image
@@ -113,33 +125,49 @@ struct llext_symtable {
  *
  * @param x Extension symbol to export to the base image
  */
-#define LL_EXTENSION_SYMBOL(x) Z_LL_EXTENSION_SYMBOL(x)
+#define LL_EXTENSION_SYMBOL(x) Z_LL_EXTENSION_SYMBOL_NAMED(x, x)
 
 /** @cond ignore */
 #if defined(LL_EXTENSION_BUILD)
 /* Extension build: EXPORT_SYMBOL maps to LL_EXTENSION_SYMBOL */
-#define Z_EXPORT_SYMBOL(x) Z_LL_EXTENSION_SYMBOL(x)
+#define Z_EXPORT_SYMBOL_NAMED(sym_ident, sym_name)				\
+	Z_LL_EXTENSION_SYMBOL_NAMED(sym_ident, sym_name)
 #elif defined(CONFIG_LLEXT_EXPORT_BUILTINS_BY_SLID)
 /* SLID-enabled LLEXT application: export symbols, names in separate section */
-#define Z_EXPORT_SYMBOL(x)							\
+#define Z_EXPORT_SYMBOL_NAMED(sym_ident, sym_name)				\
 	static const char Z_GENERIC_SECTION("llext_exports_strtab") __used	\
-		__llext_sym_name_ ## x[] = STRINGIFY(x);				\
-	static const STRUCT_SECTION_ITERABLE(llext_const_symbol,                \
-					     __llext_sym_ ## x) = {	        \
-		.name = __llext_sym_name_ ## x, .addr = (const void *)&x,		\
+		__llext_sym_name_ ## sym_name[] = STRINGIFY(sym_name);		\
+	static const STRUCT_SECTION_ITERABLE(llext_const_symbol,		\
+					     __llext_sym_ ## sym_name) = {	\
+		.name = __llext_sym_name_ ## sym_name,				\
+		.addr = (const void *)&sym_ident,				\
 	}
 #elif defined(CONFIG_LLEXT)
 /* LLEXT application: export symbols */
-#define Z_EXPORT_SYMBOL(x)							\
-	static const STRUCT_SECTION_ITERABLE(llext_const_symbol,                \
-					     __llext_sym_ ## x) = {	        \
-		.name = STRINGIFY(x), .addr = (const void *)&x,			\
+#define Z_EXPORT_SYMBOL_NAMED(sym_ident, sym_name)				\
+	static const STRUCT_SECTION_ITERABLE(llext_const_symbol,		\
+					     __llext_sym_ ## sym_name) = {	\
+		.name = STRINGIFY(sym_name), .addr = (const void *)&sym_ident,	\
 	}
 #else
 /* No extension support in this build */
-#define Z_EXPORT_SYMBOL(x)
+#define Z_EXPORT_SYMBOL_NAMED(sym_ident, sym_name)
 #endif
 /** @endcond */
+
+/**
+ * @brief Export a constant symbol from the current build with a custom name
+ *
+ * Version of @ref EXPORT_SYMBOL that allows the user to specify a custom name
+ * for the exported symbol.
+ *
+ * When @c CONFIG_LLEXT is not enabled, this macro is a no-op.
+ *
+ * @param sym_ident Symbol to export
+ * @param sym_name Name associated with the symbol
+ */
+#define EXPORT_SYMBOL_NAMED(sym_ident, sym_name)				\
+	Z_EXPORT_SYMBOL_NAMED(sym_ident, sym_name)
 
 /**
  * @brief Export a constant symbol from the current build
@@ -152,7 +180,7 @@ struct llext_symtable {
  *
  * @param x Symbol to export
  */
-#define EXPORT_SYMBOL(x) Z_EXPORT_SYMBOL(x)
+#define EXPORT_SYMBOL(x) EXPORT_SYMBOL_NAMED(x, x)
 
 /**
  * @}

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -720,6 +720,9 @@ def write_dep_info(node: edtlib.Node) -> None:
         else:
             return "/* nothing */"
 
+    out_comment("Node's hash:")
+    out_dt_define(f"{node.z_path_id}_HASH", node.hash)
+
     out_comment("Node's dependency ordinal:")
     out_dt_define(f"{node.z_path_id}_ORD", node.dep_ordinal)
     out_dt_define(f"{node.z_path_id}_ORD_STR_SORTABLE", f"{node.dep_ordinal:0>5}")

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -72,6 +72,8 @@ from copy import deepcopy
 from dataclasses import dataclass
 from typing import (Any, Callable, Iterable, NoReturn,
                     Optional, TYPE_CHECKING, Union)
+import base64
+import hashlib
 import logging
 import os
 import re
@@ -89,6 +91,12 @@ from devicetree.dtlib import Node as dtlib_Node
 from devicetree.dtlib import Property as dtlib_Property
 from devicetree.grutils import Graph
 from devicetree._private import _slice_helper
+
+def _compute_hash(path: str) -> str:
+    # Calculates the hash associated with the node's full path.
+    hasher = hashlib.sha256()
+    hasher.update(path.encode())
+    return base64.b64encode(hasher.digest(), altchars=b'__').decode().rstrip('=')
 
 #
 # Public classes
@@ -912,6 +920,11 @@ class Node:
       The ordinal is defined for all Nodes, and is unique among nodes in its
       EDT 'nodes' list.
 
+    hash:
+      A hashed value of the devicetree path of the node. This is defined for
+      all Nodes, and is checked for uniqueness among nodes in its EDT 'nodes'
+      list.
+
     required_by:
       A list with the nodes that directly depend on the node
 
@@ -1027,6 +1040,7 @@ class Node:
         self.interrupts: list[ControllerAndData] = []
         self.pinctrls: list[PinCtrl] = []
         self.bus_node = self._bus_node(support_fixed_partitions_on_any_bus)
+        self.hash: str = _compute_hash(dt_node.path)
 
         self._init_binding()
         self._init_regs()
@@ -2270,10 +2284,18 @@ class EDT:
         # Creates a list of edtlib.Node objects from the dtlib.Node objects, in
         # self.nodes
 
+        hash2node: dict[str, Node] = {}
+
         for dt_node in self._dt.node_iter():
             # Warning: We depend on parent Nodes being created before their
             # children. This is guaranteed by node_iter().
             node = Node(dt_node, self, self._fixed_partitions_no_bus)
+
+            if node.hash in hash2node:
+                _err(f"hash collision between '{node.path}' and "
+                     f"'{hash2node[node.hash].path}'")
+            hash2node[node.hash] = node
+
             self.nodes.append(node)
             self._node2enode[dt_node] = node
 

--- a/subsys/llext/Kconfig
+++ b/subsys/llext/Kconfig
@@ -86,6 +86,14 @@ config LLEXT_EXPORT_DEVICES
 	  When enabled, all Zephyr devices defined in the device tree are
 	  made available to llexts via the standard DT_ / DEVICE_* macros.
 
+config LLEXT_EXPORT_DEV_IDS_BY_HASH
+	bool "Use hash of device path in device name"
+	depends on LLEXT_EXPORT_DEVICES
+	help
+	  When enabled, exported device names are generated from a hash of the
+	  node path instead of an ordinal number. Identifiers generated this
+	  way are stable across rebuilds.
+
 config LLEXT_EXPORT_BUILTINS_BY_SLID
 	bool "Export built-in symbols to llexts via SLIDs"
 	help

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -338,6 +338,16 @@ ZTEST(devicetree_api, test_has_alias)
 	zassert_equal(DT_NODE_HAS_STATUS(DT_ALIAS(test_undef), okay), 0, "");
 }
 
+ZTEST(devicetree_api, test_node_hashes)
+{
+	zassert_str_equal(TO_STRING(DT_NODE_HASH(DT_ROOT)),
+			  "il7asoJjJEMhngUeSt4tHVu8Zxx4EFG_FDeJfL3_oPE");
+	zassert_str_equal(TO_STRING(DT_NODE_HASH(TEST_DEADBEEF)),
+			  "kPPqtBX5DX_QDQMO0_cOls2ebJMevAWHhAPY1JCKTyU");
+	zassert_str_equal(TO_STRING(DT_NODE_HASH(TEST_ABCD1234)),
+			  "Bk4fvF6o3Mgslz_xiIZaJcuwo6_IeelozwOaxtUsSos");
+}
+
 ZTEST(devicetree_api, test_inst_checks)
 {
 	zassert_equal(DT_NODE_EXISTS(DT_INST(0, vnd_gpio_device)), 1, "");

--- a/tests/subsys/llext/testcase.yaml
+++ b/tests/subsys/llext/testcase.yaml
@@ -123,3 +123,21 @@ tests:
       - CONFIG_LLEXT_STORAGE_WRITABLE=y
       - CONFIG_LLEXT_TYPE_ELF_RELOCATABLE=y
       - CONFIG_LLEXT_EXPORT_BUILTINS_BY_SLID=y
+
+  # Test the export device IDs by hash feature on a single architecture in
+  # both normal and SLID mode.
+  llext.devices_by_hash:
+    arch_allow: arm
+    filter: not CONFIG_MPU and not CONFIG_MMU
+    extra_conf_files: ['no_mem_protection.conf']
+    extra_configs:
+      - CONFIG_LLEXT_STORAGE_WRITABLE=n
+      - CONFIG_LLEXT_EXPORT_DEV_IDS_BY_HASH=y
+  llext.devices_by_hash_slid_linking:
+    arch_allow: arm
+    filter: not CONFIG_MPU and not CONFIG_MMU
+    extra_conf_files: ['no_mem_protection.conf']
+    extra_configs:
+      - CONFIG_LLEXT_STORAGE_WRITABLE=n
+      - CONFIG_LLEXT_EXPORT_DEV_IDS_BY_HASH=y
+      - CONFIG_LLEXT_EXPORT_BUILTINS_BY_SLID=y


### PR DESCRIPTION
This is the candidate implementation for RFC #83800.