### PR TITLE
samples: modules: nanopb: display buffer content of correct size

### DIFF
--- a/samples/modules/nanopb/src/main.c
+++ b/samples/modules/nanopb/src/main.c
@@ -30,7 +30,7 @@ bool encode_message(uint8_t *buffer, size_t buffer_size, size_t *message_length)
 
 	/* Fill in the lucky number */
 	message.lucky_number = 13;
-	for (int i = 0; i < 8; ++i) {
+	for (int i = 0; i < CONFIG_SAMPLE_BUFFER_SIZE; ++i) {
 		message.buffer[i] = (uint8_t)(i * 2);
 	}
 #ifdef CONFIG_SAMPLE_UNLUCKY_NUMBER
@@ -66,7 +66,7 @@ bool decode_message(uint8_t *buffer, size_t message_length)
 		/* Print the data contained in the message. */
 		printk("Your lucky number was %d!\n", (int)message.lucky_number);
 		printk("Buffer contains: ");
-		for (int i = 0; i < 8; ++i) {
+		for (int i = 0; i < CONFIG_SAMPLE_BUFFER_SIZE; ++i) {
 			printk("%s%d", ((i == 0) ? "" : ", "), (int) message.buffer[i]);
 		}
 		printk("\n");


### PR DESCRIPTION
With commit ad242b9db85c86cb6d5de52111eea462926467c5, the buffer size was made configurable. Hence, the corresponding definition CONFIG_SAMPLE_BUFFER_SIZE has to be used when filling and displaying the buffer.