### PR TITLE
manifest: update hal_nordic revision to align LPCOMP driver to Zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -188,7 +188,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: af7b21c4f875bea26689307daa8e52e9a8e8323c
+      revision: pull/205/head
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
New hal_nordic revision contains aligned LPCOMP driver adding new functions matching regular COMP driver.