### PR TITLE
soc: stm32 decrease ticks per sec if sysclock is not LPTIM

### DIFF
--- a/soc/st/stm32/Kconfig.defconfig
+++ b/soc/st/stm32/Kconfig.defconfig
@@ -25,9 +25,10 @@ config LOG_BACKEND_SWO_REF_FREQ_HZ
 	default "$(DT_STM32_RCC_CLOCK_FREQ)" if "$(dt_nodelabel_enabled,rcc)"
 	depends on LOG_BACKEND_SWO
 
-# Tick of 10000 is too high for a sysclock lower than 32MHz
+# If sysclock is not LPTIM, tick of 10000 is too high for a frequency lower than 32MHz
 config SYS_CLOCK_TICKS_PER_SEC
 	default 8000 if SYS_CLOCK_HW_CYCLES_PER_SEC <= 32000000
+	depends on !STM32_LPTIM_TIMER
 
 # set the tick per sec as a divider of the LPTIM clock source
 # with a minimum value of 4096 for SYS_CLOCK_TICKS_PER_SEC to keep


### PR DESCRIPTION
Reduce the ticks per sec when the sysclock is low **and not** LPTIM.

When building the samples/boards/stm32/power_mgmt/blinky/  for the nucleo_wb55rg where the CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC is 32000000.
The CONFIG_SYS_CLOCK_TICKS_PER_SEC is set to 8000, even if CONFIG_STM32_LPTIM_TIMER 1  and `st,prescaler = <32>;`

It should set CONFIG_SYS_CLOCK_TICKS_PER_SEC to  1024  for that prescaler of 32,  thanks to the ./soc/st/stm32/Kconfig.defconfig but it does not.
--> assert comes from the ./drivers/timer/stm32_lptim_timer.c (line 472) `"Set SYS_CLOCK_TICKS_PER_SEC to CONFIG_STM32_LPTIM_CLOCK/lptim_clock_presc"`

