### PR TITLE
doc: release: 4.0: Add note about .elf flash support

### DIFF
--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -107,6 +107,8 @@ Boards & SoC Support
 Build system and Infrastructure
 *******************************
 
+* Added support for .elf files to the west flash command for jlink, pyocd and linkserver runners.
+
 Documentation
 *************
 


### PR DESCRIPTION
Added note about enabled support for the flashing of .elf files for jlink, pyocd and linkserver runners. 
By commits:
- e767ac07033151a897f38cd6d4be888068126354
- c1fe3150e987d4d403bcc81bc2f2701c8973e798
- 3f5fc42fbae6dc5dc67994bab2ab7ef699d853f3