### PR TITLE
Bluetooth: Host: Prepare for H4 encapsulation

### DIFF
--- a/include/zephyr/bluetooth/buf.h
+++ b/include/zephyr/bluetooth/buf.h
@@ -161,6 +161,40 @@ static inline enum bt_buf_type bt_buf_get_type(struct net_buf *buf)
 		->type;
 }
 
+static inline enum bt_buf_type bt_buf_h4_type_to_out_type(uint8_t h4_type)
+{
+	switch (h4_type) {
+	case BT_HCI_H4_CMD:
+		return BT_BUF_CMD;
+	case BT_HCI_H4_ACL:
+		return BT_BUF_ACL_OUT;
+	case BT_HCI_H4_ISO:
+		return BT_BUF_ISO_OUT;
+	default:
+		__ASSERT_NO_MSG(false);
+		return 0xff;
+	}
+}
+
+static inline uint8_t bt_buf_type_to_h4_type(enum bt_buf_type buf_type)
+{
+	switch (buf_type) {
+	case BT_BUF_CMD:
+		return BT_HCI_H4_CMD;
+	case BT_BUF_ACL_IN:
+	case BT_BUF_ACL_OUT:
+		return BT_HCI_H4_ACL;
+	case BT_BUF_EVT:
+		return BT_HCI_H4_EVT;
+	case BT_BUF_ISO_IN:
+	case BT_BUF_ISO_OUT:
+		return BT_HCI_H4_ISO;
+	default:
+		__ASSERT_NO_MSG(false);
+		return BT_HCI_H4_NONE;
+	}
+}
+
 /**
  * @}
  */

--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -22,16 +22,19 @@
 extern "C" {
 #endif
 
-/* Bluetooth spec v5.4 Vol 4, Part A Table 2.1: HCI packet indicators
+/**
+ * Bluetooth spec v5.4 Vol 4, Part A Table 2.1: HCI packet indicators
  * The following definitions are intended for use with the UART Transport Layer and
  * may be reused with other transport layers if desired.
  */
-#define BT_HCI_H4_NONE                  0x00    /* None of the known packet types */
-#define BT_HCI_H4_CMD                   0x01    /* HCI Command packet */
-#define BT_HCI_H4_ACL                   0x02    /* HCI ACL Data packet */
-#define BT_HCI_H4_SCO                   0x03    /* HCI Synchronous Data packet */
-#define BT_HCI_H4_EVT                   0x04    /* HCI Event packet */
-#define BT_HCI_H4_ISO                   0x05    /* HCI ISO Data packet */
+enum bt_hci_h4 {
+	BT_HCI_H4_NONE = 0x00, /**< None of the known packet types */
+	BT_HCI_H4_CMD = 0x01,  /**< HCI Command packet */
+	BT_HCI_H4_ACL = 0x02,  /**< HCI ACL Data packet */
+	BT_HCI_H4_SCO = 0x03,  /**< HCI Synchronous Data packet */
+	BT_HCI_H4_EVT = 0x04,  /**< HCI Event packet */
+	BT_HCI_H4_ISO = 0x05,  /**< HCI ISO Data packet */
+};
 
 /* Special own address types for LL privacy (used in adv & scan parameters) */
 #define BT_HCI_OWN_ADDR_RPA_OR_PUBLIC   0x02

--- a/include/zephyr/drivers/bluetooth.h
+++ b/include/zephyr/drivers/bluetooth.h
@@ -19,6 +19,7 @@
  * @{
  */
 
+#include <errno.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <zephyr/net/buf.h>
@@ -26,6 +27,7 @@
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/hci_vs.h>
 #include <zephyr/device.h>
+#include <zephyr/sys/check.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -140,6 +142,8 @@ static inline int bt_hci_close(const struct device *dev)
  * Send an HCI packet to the controller. The packet type of the buffer
  * must be set using bt_buf_set_type().
  *
+ * Only the BT_BUF_H4 packet type is accepted.
+ *
  * @note This function must only be called from a cooperative thread.
  *
  * @param dev HCI device
@@ -150,6 +154,13 @@ static inline int bt_hci_close(const struct device *dev)
 static inline int bt_hci_send(const struct device *dev, struct net_buf *buf)
 {
 	const struct bt_hci_driver_api *api = (const struct bt_hci_driver_api *)dev->api;
+
+	CHECKIF(bt_buf_get_type(buf) != BT_BUF_H4) {
+		return -EPROTO;
+	}
+
+	/* Translate from H4 encapsulation to BT_BUF_TYPE. */
+	bt_buf_set_type(buf, bt_buf_h4_type_to_out_type(net_buf_pull_u8(buf)));
 
 	return api->send(dev, buf);
 }

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -526,7 +526,8 @@ static int send_acl(struct bt_conn *conn, struct net_buf *buf, uint8_t flags)
 	hdr->handle = sys_cpu_to_le16(bt_acl_handle_pack(conn->handle, flags));
 	hdr->len = sys_cpu_to_le16(buf->len - sizeof(*hdr));
 
-	bt_buf_set_type(buf, BT_BUF_ACL_OUT);
+	bt_buf_set_type(buf, BT_BUF_H4);
+	net_buf_push_u8(buf, BT_HCI_H4_ACL);
 
 	return bt_send(buf);
 }
@@ -584,7 +585,8 @@ static int send_iso(struct bt_conn *conn, struct net_buf *buf, uint8_t flags)
 	hdr->handle = sys_cpu_to_le16(bt_iso_handle_pack(conn->handle, flags, ts));
 	hdr->len = sys_cpu_to_le16(buf->len - sizeof(*hdr));
 
-	bt_buf_set_type(buf, BT_BUF_ISO_OUT);
+	bt_buf_set_type(buf, BT_BUF_H4);
+	net_buf_push_u8(buf, BT_HCI_H4_ISO);
 
 	return bt_send(buf);
 }

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -8,6 +8,7 @@
  */
 
 #include <zephyr/kernel.h>
+#include <stdint.h>
 #include <string.h>
 #include <stdio.h>
 #include <errno.h>
@@ -24,6 +25,7 @@
 #include <zephyr/settings/settings.h>
 
 #include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/buf.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/l2cap.h>
 #include <zephyr/bluetooth/hci.h>
@@ -346,6 +348,9 @@ int bt_hci_cmd_send(uint16_t opcode, struct net_buf *buf)
 	 */
 	if (opcode == BT_HCI_OP_HOST_NUM_COMPLETED_PACKETS) {
 		int err;
+
+		bt_buf_set_type(buf, BT_BUF_H4);
+		net_buf_push_u8(buf, BT_HCI_H4_CMD);
 
 		err = bt_send(buf);
 		if (err) {
@@ -3070,6 +3075,9 @@ static void hci_core_send_cmd(void)
 
 	LOG_DBG("Sending command 0x%04x (buf %p) to driver", cmd(buf)->opcode, buf);
 
+	bt_buf_set_type(buf, BT_BUF_H4);
+	net_buf_push_u8(buf, BT_HCI_H4_CMD);
+
 	err = bt_send(buf);
 	if (err) {
 		LOG_ERR("Unable to send to driver (err %d)", err);
@@ -4055,9 +4063,17 @@ static int hci_init(void)
 
 int bt_send(struct net_buf *buf)
 {
+	uint8_t h4_type;
+
 	LOG_DBG("buf %p len %u type %u", buf, buf->len, bt_buf_get_type(buf));
 
-	bt_monitor_send(bt_monitor_opcode(buf), buf->data, buf->len);
+	__ASSERT_NO_MSG(bt_buf_get_type(buf) == BT_BUF_H4);
+	__ASSERT_NO_MSG(buf->len >= sizeof(h4_type));
+	h4_type = buf->data[0];
+
+	bt_monitor_send(bt_monitor_opcode_tx(h4_type), &buf->data[sizeof(h4_type)],
+			buf->len - sizeof(h4_type));
+	(void)h4_type;
 
 	if (IS_ENABLED(CONFIG_BT_TINYCRYPT_ECC)) {
 		return bt_hci_ecc_send(buf);
@@ -4066,6 +4082,7 @@ int bt_send(struct net_buf *buf)
 #if DT_HAS_CHOSEN(zephyr_bt_hci)
 	return bt_hci_send(bt_dev.hci, buf);
 #else
+	bt_buf_set_type(buf, bt_buf_out_type_from_h4_type(net_buf_pull_u8(buf)));
 	return bt_dev.drv->send(buf);
 #endif
 }
@@ -4094,8 +4111,14 @@ void hci_event_prio(struct net_buf *buf)
 	struct net_buf_simple_state state;
 	struct bt_hci_evt_hdr *hdr;
 	uint8_t evt_flags;
+	uint8_t h4_type;
 
 	net_buf_simple_save(&buf->b, &state);
+
+	__ASSERT_NO_MSG(bt_buf_get_type(buf) == BT_BUF_H4);
+	h4_type = net_buf_pull_u8(buf);
+	__ASSERT_NO_MSG(h4_type == BT_HCI_H4_EVT);
+	(void)h4_type;
 
 	if (buf->len < sizeof(*hdr)) {
 		LOG_ERR("Invalid HCI event size (%u)", buf->len);
@@ -4132,19 +4155,34 @@ static void rx_queue_put(struct net_buf *buf)
 
 static int bt_recv_unsafe(struct net_buf *buf)
 {
-	bt_monitor_send(bt_monitor_opcode(buf), buf->data, buf->len);
+	uint8_t h4_type;
+
+	if (bt_buf_get_type(buf) != BT_BUF_H4) {
+		net_buf_push_u8(buf, bt_buf_type_to_h4_type(bt_buf_get_type(buf)));
+		bt_buf_set_type(buf, BT_BUF_H4);
+	}
+
+	CHECKIF(buf->len < sizeof(h4_type)) {
+		net_buf_unref(buf);
+		return -EINVAL;
+	}
+
+	h4_type = buf->data[0];
+
+	bt_monitor_send(bt_monitor_opcode_rx(h4_type), &buf->data[sizeof(h4_type)],
+			buf->len - sizeof(h4_type));
 
 	LOG_DBG("buf %p len %u", buf, buf->len);
 
-	switch (bt_buf_get_type(buf)) {
+	switch (h4_type) {
 #if defined(CONFIG_BT_CONN)
-	case BT_BUF_ACL_IN:
+	case BT_HCI_H4_ACL:
 		rx_queue_put(buf);
 		return 0;
 #endif /* BT_CONN */
-	case BT_BUF_EVT:
+	case BT_HCI_H4_EVT:
 	{
-		struct bt_hci_evt_hdr *hdr = (void *)buf->data;
+		struct bt_hci_evt_hdr *hdr = (void *)&buf->data[sizeof(h4_type)];
 		uint8_t evt_flags = bt_hci_evt_get_flags(hdr->evt);
 
 		if (evt_flags & BT_HCI_EVT_FLAG_RECV_PRIO) {
@@ -4158,12 +4196,12 @@ static int bt_recv_unsafe(struct net_buf *buf)
 		return 0;
 	}
 #if defined(CONFIG_BT_ISO)
-	case BT_BUF_ISO_IN:
+	case BT_HCI_H4_ISO:
 		rx_queue_put(buf);
 		return 0;
 #endif /* CONFIG_BT_ISO */
 	default:
-		LOG_ERR("Invalid buf type %u", bt_buf_get_type(buf));
+		LOG_ERR("Invalid buf h4 type %u", h4_type);
 		net_buf_unref(buf);
 		return -EINVAL;
 	}
@@ -4269,6 +4307,7 @@ static void init_work(struct k_work *work)
 static void rx_work_handler(struct k_work *work)
 {
 	int err;
+	uint8_t h4_type;
 
 	struct net_buf *buf;
 
@@ -4280,22 +4319,25 @@ static void rx_work_handler(struct k_work *work)
 
 	LOG_DBG("buf %p type %u len %u", buf, bt_buf_get_type(buf), buf->len);
 
-	switch (bt_buf_get_type(buf)) {
+	__ASSERT_NO_MSG(bt_buf_get_type(buf) == BT_BUF_H4);
+	h4_type = net_buf_pull_u8(buf);
+
+	switch (h4_type) {
 #if defined(CONFIG_BT_CONN)
-	case BT_BUF_ACL_IN:
+	case BT_HCI_H4_ACL:
 		hci_acl(buf);
 		break;
 #endif /* CONFIG_BT_CONN */
 #if defined(CONFIG_BT_ISO)
-	case BT_BUF_ISO_IN:
+	case BT_HCI_H4_ISO:
 		hci_iso(buf);
 		break;
 #endif /* CONFIG_BT_ISO */
-	case BT_BUF_EVT:
+	case BT_HCI_H4_EVT:
 		hci_event(buf);
 		break;
 	default:
-		LOG_ERR("Unknown buf type %u", bt_buf_get_type(buf));
+		LOG_ERR("Unknown h4 type %u", h4_type);
 		net_buf_unref(buf);
 		break;
 	}

--- a/subsys/bluetooth/host/monitor.h
+++ b/subsys/bluetooth/host/monitor.h
@@ -75,21 +75,29 @@ struct bt_monitor_user_logging {
 	uint8_t  ident_len;
 } __packed;
 
-static inline uint8_t bt_monitor_opcode(struct net_buf *buf)
+static inline uint8_t bt_monitor_opcode_rx(enum bt_hci_h4 h4_type)
 {
-	switch (bt_buf_get_type(buf)) {
-	case BT_BUF_CMD:
-		return BT_MONITOR_COMMAND_PKT;
-	case BT_BUF_EVT:
+	switch (h4_type) {
+	case BT_HCI_H4_EVT:
 		return BT_MONITOR_EVENT_PKT;
-	case BT_BUF_ACL_OUT:
-		return BT_MONITOR_ACL_TX_PKT;
-	case BT_BUF_ACL_IN:
+	case BT_HCI_H4_ACL:
 		return BT_MONITOR_ACL_RX_PKT;
-	case BT_BUF_ISO_OUT:
-		return BT_MONITOR_ISO_TX_PKT;
-	case BT_BUF_ISO_IN:
+	case BT_HCI_H4_ISO:
 		return BT_MONITOR_ISO_RX_PKT;
+	default:
+		return BT_MONITOR_NOP;
+	}
+}
+
+static inline uint8_t bt_monitor_opcode_tx(enum bt_hci_h4 h4_type)
+{
+	switch (h4_type) {
+	case BT_HCI_H4_CMD:
+		return BT_MONITOR_COMMAND_PKT;
+	case BT_HCI_H4_ACL:
+		return BT_MONITOR_ACL_TX_PKT;
+	case BT_HCI_H4_ISO:
+		return BT_MONITOR_ISO_TX_PKT;
 	default:
 		return BT_MONITOR_NOP;
 	}

--- a/tests/bsim/bluetooth/host/iso/frag_2/src/broadcaster.c
+++ b/tests/bsim/bluetooth/host/iso/frag_2/src/broadcaster.c
@@ -12,6 +12,7 @@
 
 #include "babblekit/flags.h"
 #include "babblekit/testcase.h"
+#include "bs_types.h"
 
 LOG_MODULE_REGISTER(broadcaster, LOG_LEVEL_INF);
 
@@ -260,9 +261,13 @@ int __real_bt_send(struct net_buf *buf);
 
 int __wrap_bt_send(struct net_buf *buf)
 {
-	struct bt_hci_iso_hdr *hci_hdr = (void *)buf->data;
+	uint8_t h4_type = buf->data[0];
 
-	if (bt_buf_get_type(buf) == BT_BUF_ISO_OUT) {
+	__ASSERT_NO_MSG(bt_buf_get_type(buf) == BT_BUF_H4);
+
+	if (h4_type == BT_HCI_H4_ISO) {
+		struct bt_hci_iso_hdr *hci_hdr = (void *)&buf->data[sizeof(h4_type)];
+
 		uint16_t handle = sys_le16_to_cpu(hci_hdr->handle);
 		uint8_t flags = bt_iso_flags(handle);
 		uint8_t pb_flag = bt_iso_flags_pb(flags);


### PR DESCRIPTION
This patch converts bt_send to take an H4 packet and bt_recv to optionally take an H4 packet. This is a step towards eliminating the use of net_buf user-data to communicate the packet type between layers.