### PR TITLE
Additional PHY API parameter

### DIFF
--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -222,7 +222,7 @@ static HAL_StatusTypeDef read_eth_phy_register(ETH_HandleTypeDef *heth,
 						uint32_t *RegVal)
 {
 #if defined(CONFIG_MDIO)
-	return phy_read(eth_stm32_phy_dev, PHYReg, RegVal);
+	return phy_read(eth_stm32_phy_dev, PHYAddr, PHYReg, RegVal);
 #elif defined(CONFIG_ETH_STM32_HAL_API_V2)
 	return HAL_ETH_ReadPHYRegister(heth, PHYAddr, PHYReg, RegVal);
 #else

--- a/include/zephyr/net/phy.h
+++ b/include/zephyr/net/phy.h
@@ -112,12 +112,12 @@ __subsystem struct ethphy_driver_api {
 			   void *user_data);
 
 	/** Read PHY register */
-	int (*read)(const struct device *dev, uint16_t reg_addr,
-		    uint32_t *data);
+	int (*read)(const struct device *dev, uint16_t phy_addr,
+			uint16_t reg_addr, uint32_t *data);
 
 	/** Write PHY register */
-	int (*write)(const struct device *dev, uint16_t reg_addr,
-		     uint32_t data);
+	int (*write)(const struct device *dev, uint16_t phy_addr,
+			uint16_t reg_addr, uint32_t data);
 };
 /**
  * @endcond
@@ -196,19 +196,20 @@ static inline int phy_link_callback_set(const struct device *dev,
  * This routine provides a generic interface to read from a PHY register.
  *
  * @param[in]  dev       PHY device structure
+ * @param[in]  phy_addr  PHY address
  * @param[in]  reg_addr  Register address
  * @param      value     Pointer to receive read value
  *
  * @retval 0 If successful.
  * @retval -EIO If communication with PHY failed.
  */
-static inline int phy_read(const struct device *dev, uint16_t reg_addr,
-			   uint32_t *value)
+static inline int phy_read(const struct device *dev, uint16_t phy_addr,
+			   uint16_t reg_addr, uint32_t *value)
 {
 	const struct ethphy_driver_api *api =
 		(const struct ethphy_driver_api *)dev->api;
 
-	return api->read(dev, reg_addr, value);
+	return api->read(dev, phy_addr, reg_addr, value);
 }
 
 /**
@@ -217,19 +218,20 @@ static inline int phy_read(const struct device *dev, uint16_t reg_addr,
  * This routine provides a generic interface to write to a PHY register.
  *
  * @param[in]  dev       PHY device structure
+ * @param[in]  phy_addr  PHY address
  * @param[in]  reg_addr  Register address
  * @param[in]  value     Value to write
  *
  * @retval 0 If successful.
  * @retval -EIO If communication with PHY failed.
  */
-static inline int phy_write(const struct device *dev, uint16_t reg_addr,
-			    uint32_t value)
+static inline int phy_write(const struct device *dev, uint16_t phy_addr,
+			   uint16_t reg_addr, uint32_t value)
 {
 	const struct ethphy_driver_api *api =
 		(const struct ethphy_driver_api *)dev->api;
 
-	return api->write(dev, reg_addr, value);
+	return api->write(dev, phy_addr, reg_addr, value);
 }
 
 


### PR DESCRIPTION
Last time, during developing the driver for Davicom DM8806 PHY driver I noticed, that Dacom  West has different approach to this topic. Each PHY register Absolute Address is glued from two parts - 5bit PHY Address and 5-bit Register Address. And the PHY Addresses may have a scope from 0x2h up to 19h. To read for example Port 5 MAC Control, we need to glue 0x18 (PHY Address) and 0x15 (Register Address) to get 0x315h - according to Clause 22:
[Clause 22](https://www.totalphase.com/support/articles/200349206-mdio-background/?srsltid=AfmBOoogyJ2YGDR_J46mkttfMEINpnup9TP_Mi3cs4dfpzCy2eVmG4ph)
The solution is to add one parameter to the PHY API which will be passed to the PHY drivers which need it. One of the driver which needs this parameter is Davicom DM8806 - separate Pull Request [77812](https://github.com/zephyrproject-rtos/zephyr/pull/77812 is ongoing