### PR TITLE
soc: nordic: nrf54l15: add missing include

### DIFF
--- a/soc/nordic/nrf54l/soc.c
+++ b/soc/nordic/nrf54l/soc.c
@@ -17,6 +17,7 @@
 #include <zephyr/init.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/cache.h>
+#include <zephyr/dt-bindings/regulator/nrf5x.h>
 
 #if defined(NRF_APPLICATION)
 #include <cmsis_core.h>


### PR DESCRIPTION
Add nrf5x binding header, as NRF5X_REG_MODE_DCDC is used in a macro comparison. Missing header prevented evaluation to become true and so enable DC/DC module.