### PR TITLE
Make MMU and LLEXT compatible

### DIFF
--- a/include/zephyr/kernel/mm.h
+++ b/include/zephyr/kernel/mm.h
@@ -259,6 +259,23 @@ static inline void k_mem_unmap(void *addr, size_t size)
 }
 
 /**
+ * Modify memory mapping attribute flags
+ *
+ * This updates caching, access and control flags for the provided
+ * page-aligned memory region.
+ *
+ * Calling this function on a region which was not mapped to begin with is
+ * undefined behavior. However system memory implicitly mapped at boot time
+ * is supported.
+ *
+ * @param addr Page-aligned memory region base virtual address
+ * @param size Page-aligned memory region size
+ * @param flags K_MEM_PERM_*, K_MEM_MAP_* control flags.
+ * @return 0 for success, negative error code otherwise.
+ */
+int k_mem_update_flags(void *addr, size_t size, uint32_t flags);
+
+/**
  * Given an arbitrary region, provide a aligned region that covers it
  *
  * The returned region will have both its base address and size aligned

--- a/subsys/llext/llext_load.c
+++ b/subsys/llext/llext_load.c
@@ -632,6 +632,8 @@ int do_llext_load(struct llext_loader *ldr, struct llext *ext,
 		goto out;
 	}
 
+	llext_adjust_mmu_permissions(ext);
+
 out:
 	/*
 	 * Free resources only used during loading. Note that this exploits

--- a/subsys/llext/llext_mem.c
+++ b/subsys/llext/llext_mem.c
@@ -159,9 +159,51 @@ int llext_copy_regions(struct llext_loader *ldr, struct llext *ext)
 	return 0;
 }
 
+void llext_adjust_mmu_permissions(struct llext *ext)
+{
+#ifdef CONFIG_MMU
+	void *addr;
+	size_t size;
+	uint32_t flags;
+
+	for (enum llext_mem mem_idx = 0; mem_idx < LLEXT_MEM_PARTITIONS; mem_idx++) {
+		addr = ext->mem[mem_idx];
+		size = ROUND_UP(ext->mem_size[mem_idx], LLEXT_PAGE_SIZE);
+		if (size == 0) {
+			continue;
+		}
+		switch (mem_idx) {
+		case LLEXT_MEM_TEXT:
+			sys_cache_instr_invd_range(addr, size);
+			flags = K_MEM_PERM_EXEC;
+			break;
+		case LLEXT_MEM_DATA:
+		case LLEXT_MEM_BSS:
+			/* memory is already K_MEM_PERM_RW by default */
+			continue;
+		case LLEXT_MEM_RODATA:
+			flags = 0;
+			break;
+		default:
+			continue;
+		}
+		sys_cache_data_flush_range(addr, size);
+		k_mem_update_flags(addr, size, flags);
+	}
+#endif
+}
+
 void llext_free_regions(struct llext *ext)
 {
 	for (int i = 0; i < LLEXT_MEM_COUNT; i++) {
+#ifdef CONFIG_MMU
+		if (ext->mem_size[i] != 0) {
+			/* restore default RAM permissions */
+			k_mem_update_flags(ext->mem[i],
+					   ROUND_UP(ext->mem_size[i], LLEXT_PAGE_SIZE),
+					   K_MEM_PERM_RW);
+		}
+#endif
 		if (ext->mem_on_heap[i]) {
 			LOG_DBG("freeing memory region %d", i);
 			llext_free(ext->mem[i]);

--- a/subsys/llext/llext_priv.h
+++ b/subsys/llext/llext_priv.h
@@ -22,6 +22,7 @@ struct llext_elf_sect_map {
 int llext_copy_strings(struct llext_loader *ldr, struct llext *ext);
 int llext_copy_regions(struct llext_loader *ldr, struct llext *ext);
 void llext_free_regions(struct llext *ext);
+void llext_adjust_mmu_permissions(struct llext *ext);
 
 static inline void *llext_alloc(size_t bytes)
 {


### PR DESCRIPTION
For LLEXT to work on MMU systems, we must be able to change memory
attributes for those pages used by LLEXT segments, like making them
executable.
