### PR TITLE
boards: shields: add NXP vendor name to shields

### DIFF
--- a/boards/shields/g1120b0mipi/doc/index.rst
+++ b/boards/shields/g1120b0mipi/doc/index.rst
@@ -1,7 +1,7 @@
 .. _g1120b0mipi:
 
-G1120B0MIPI MIPI Display
-##########################
+NXP G1120B0MIPI MIPI Display
+############################
 
 Overview
 ********

--- a/boards/shields/rk043fn02h_ct/doc/index.rst
+++ b/boards/shields/rk043fn02h_ct/doc/index.rst
@@ -1,7 +1,7 @@
 .. _rk043fn02h_ct:
 
-RK043FN02H-CT Parallel Display
-##############################
+NXP RK043FN02H-CT Parallel Display
+##################################
 
 Overview
 ********

--- a/boards/shields/rk043fn66hs_ctg/doc/index.rst
+++ b/boards/shields/rk043fn66hs_ctg/doc/index.rst
@@ -1,7 +1,7 @@
 .. _rk043fn66hs_ctg:
 
-RK043FN66HS-CTG Parallel Display
-################################
+NXP RK043FN66HS-CTG Parallel Display
+####################################
 
 Overview
 ********

--- a/boards/shields/rk055hdmipi4m/doc/index.rst
+++ b/boards/shields/rk055hdmipi4m/doc/index.rst
@@ -1,7 +1,7 @@
 .. _rk055hdmipi4m:
 
-RK055HDMIPI4M MIPI Display
-##########################
+NXP RK055HDMIPI4M MIPI Display
+##############################
 
 Overview
 ********

--- a/boards/shields/rk055hdmipi4ma0/doc/index.rst
+++ b/boards/shields/rk055hdmipi4ma0/doc/index.rst
@@ -1,7 +1,7 @@
 .. _rk055hdmipi4ma0:
 
-RK055HDMIPI4MA0 MIPI Display
-############################
+NXP RK055HDMIPI4MA0 MIPI Display
+################################
 
 Overview
 ********


### PR DESCRIPTION
Update shield doc pages to list NXP vendor name in list of shields.