### PR TITLE
manifest: Update mcuboot and tf-m

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -285,7 +285,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: fb2cf0ec3da3687b93f28e556ab682bdd4b85223
+      revision: 52e2afc2f809c424b0f337f56059d1dfcc7e6d98
       path: bootloader/mcuboot
       groups:
         - bootloader
@@ -327,7 +327,7 @@ manifest:
       groups:
         - crypto
     - name: trusted-firmware-m
-      revision: 069455be098383bf96eab73e3ff8e0c66c60fa5a
+      revision: pull/113/head
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
This change brings mcuboot and tf-m to the latest revisions in their upstream respos.  This is necessary to do together as there has been an API change in the mcuboot interface.