### PR TITLE
serial: mchp_xec: Fix `uart_xec_irq_tx_complete` function

### DIFF
--- a/drivers/serial/uart_mchp_xec.c
+++ b/drivers/serial/uart_mchp_xec.c
@@ -747,10 +747,15 @@ static int uart_xec_irq_tx_complete(const struct device *dev)
 	const struct uart_xec_device_config * const dev_cfg = dev->config;
 	struct uart_xec_dev_data *dev_data = dev->data;
 	struct uart_regs *regs = dev_cfg->regs;
+	int ret;
 	k_spinlock_key_t key = k_spin_lock(&dev_data->lock);
 
-	int ret = ((regs->LSR & (LSR_TEMT | LSR_THRE))
-				== (LSR_TEMT | LSR_THRE)) ? 1 : 0;
+	if ((regs->IER & IER_TBE) ||
+	    ((regs->LSR & (LSR_TEMT | LSR_THRE)) != (LSR_TEMT | LSR_THRE))) {
+		ret = 0;
+	} else {
+		ret = 1;
+	}
 
 	k_spin_unlock(&dev_data->lock, key);
 


### PR DESCRIPTION
This function is only checking for byte current byte being transmitted. This patch ensures that function returns `1` until TX is disabled and no byte is being transmitted.