### PR TITLE
Add rt1180 acmp support

### DIFF
--- a/boards/nxp/mimxrt1180_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1180_evk/doc/index.rst
@@ -107,6 +107,8 @@ configuration supports the following hardware features:
 +-----------+------------+-------------------------------------+
 | I2C       | on-chip    | i2c                                 |
 +-----------+------------+-------------------------------------+
+| ACMP      | on-chip    | analog comparator                   |
++-----------+------------+-------------------------------------+
 
 The default configuration can be found in the defconfig file:
 :zephyr_file:`boards/nxp/mimxrt1180_evk/mimxrt1180_evk_mimxrt1189_cm33_defconfig`

--- a/drivers/sensor/nxp/mcux_acmp/mcux_acmp.c
+++ b/drivers/sensor/nxp/mcux_acmp/mcux_acmp.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Vestas Wind Systems A/S
- * Copyright 2022 NXP
+ * Copyright 2022, 2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -107,6 +107,7 @@ static int mcux_acmp_attr_set(const struct device *dev,
 		}
 		break;
 #endif /* MCUX_ACMP_HAS_OFFSET */
+#if MCUX_ACMP_HAS_HYSTCTR
 	case SENSOR_ATTR_MCUX_ACMP_HYSTERESIS_LEVEL:
 		if (val1 >= kACMP_HysteresisLevel0 &&
 		    val1 <= kACMP_HysteresisLevel3) {
@@ -118,6 +119,7 @@ static int mcux_acmp_attr_set(const struct device *dev,
 			return -EINVAL;
 		}
 		break;
+#endif /* MCUX_ACMP_HAS_HYSTCTR */
 	case SENSOR_ATTR_MCUX_ACMP_DAC_VOLTAGE_REFERENCE:
 		if (val1 >= kACMP_VrefSourceVin1 &&
 		    val1 <= kACMP_VrefSourceVin2) {
@@ -271,9 +273,11 @@ static int mcux_acmp_attr_get(const struct device *dev,
 		val->val1 = data->config.offsetMode;
 		break;
 #endif /* MCUX_ACMP_HAS_OFFSET */
+#if MCUX_ACMP_HAS_HYSTCTR
 	case SENSOR_ATTR_MCUX_ACMP_HYSTERESIS_LEVEL:
 		val->val1 = data->config.hysteresisMode;
 		break;
+#endif /* MCUX_ACMP_HAS_HYSTCTR */
 	case SENSOR_ATTR_MCUX_ACMP_DAC_VOLTAGE_REFERENCE:
 		val->val1 = data->dac.referenceVoltageSource;
 		break;

--- a/dts/arm/nxp/nxp_rt118x.dtsi
+++ b/dts/arm/nxp/nxp_rt118x.dtsi
@@ -293,6 +293,38 @@
 		gptfreq = <240000000>;
 		clocks = <&ccm IMX_CCM_GPT2_CLK 0x41 0>;
 	};
+
+	acmp1: cmp@2dc0000 {
+		compatible = "nxp,kinetis-acmp";
+		reg = <0x2dc0000 0x4000>;
+		interrupts = <200 0>;
+		status = "disabled";
+		#io-channel-cells = <2>;
+	};
+
+	acmp2: cmp@2dd0000 {
+		compatible = "nxp,kinetis-acmp";
+		reg = <0x2dd0000 0x4000>;
+		interrupts = <201 0>;
+		status = "disabled";
+		#io-channel-cells = <2>;
+	};
+
+	acmp3: cmp@2de0000 {
+		compatible = "nxp,kinetis-acmp";
+		reg = <0x2de0000 0x4000>;
+		interrupts = <202 0>;
+		status = "disabled";
+		#io-channel-cells = <2>;
+	};
+
+	acmp4: cmp@2df0000 {
+		compatible = "nxp,kinetis-acmp";
+		reg = <0x2df0000 0x4000>;
+		interrupts = <203 0>;
+		status = "disabled";
+		#io-channel-cells = <2>;
+	};
 };
 
 &flexspi1 {

--- a/include/zephyr/drivers/sensor/mcux_acmp.h
+++ b/include/zephyr/drivers/sensor/mcux_acmp.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Vestas Wind Systems A/S
- * Copyright 2022 NXP
+ * Copyright 2022, 2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -41,6 +41,12 @@ extern "C" {
 #define MCUX_ACMP_HAS_DISCRETE_MODE 1
 #else
 #define MCUX_ACMP_HAS_DISCRETE_MODE 0
+#endif
+
+#if defined(FSL_FEATURE_ACMP_HAS_C0_HYSTCTR_BIT) && (FSL_FEATURE_ACMP_HAS_C0_HYSTCTR_BIT == 1U)
+#define MCUX_ACMP_HAS_HYSTCTR 1
+#else
+#define MCUX_ACMP_HAS_HYSTCTR 0
 #endif
 
 enum sensor_channel_mcux_acmp {

--- a/samples/sensor/mcux_acmp/README.rst
+++ b/samples/sensor/mcux_acmp/README.rst
@@ -8,14 +8,15 @@ Overview
 
 This sample show how to use the NXP MCUX Analog Comparator (ACMP) driver. The
 sample supports the :ref:`twr_ke18f`, :ref:`mimxrt1170_evk`, :ref:`frdm_ke17z`
-and :ref:`frdm_ke17z512`.
+, :ref:`frdm_ke17z512` and :ref:`mimxrt1180_evk`.
 
 The input voltage for the negative input of the analog comparator is
 provided by the ACMP Digital-to-Analog Converter (DAC). The input voltage for
 the positive input can be adjusted by turning the on-board potentiometer for
 :ref:`twr_ke18f` board, for :ref:`mimxrt1170_evk` the voltage signal is
 captured on J25-13, the :ref:`frdm_ke17z` and :ref:`frdm_ke17z512` boards are
-captured in J2-3, need change the external voltage signal to check the output.
+captured in J2-3, the :ref:`mimxrt1180_evk` board are captured in J45-13, need
+change the external voltage signal to check the output.
 
 The output value of the analog comparator is reported on the console.
 
@@ -63,5 +64,22 @@ ACMP input voltage by changing the voltage input to J2-3.
 .. zephyr-app-commands::
    :zephyr-app: samples/sensor/mcux_acmp
    :board: frdm_ke17z512
+   :goals: flash
+   :compact:
+
+Building and Running for MIMXRT1180-EVK
+=======================================
+Build the application for the MIMXRT1180-EVK board, and adjust the
+ACMP input voltage by changing the voltage input to J45-13.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/sensor/mcux_acmp
+   :board: mimxrt1180_evk/mimxrt1189/cm33
+   :goals: flash
+   :compact:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/sensor/mcux_acmp
+   :board: mimxrt1180_evk/mimxrt1189/cm7
    :goals: flash
    :compact:

--- a/samples/sensor/mcux_acmp/boards/mimxrt1180_evk_mimxrt1189_cm33.overlay
+++ b/samples/sensor/mcux_acmp/boards/mimxrt1180_evk_mimxrt1189_cm33.overlay
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	acmp1_default: acmp1_default {
+		group0 {
+			pinmux = <&iomuxc_gpio_ad_01_acmp1_in2>;
+			drive-strength = "high";
+			bias-pull-up;
+			slew-rate = "fast";
+		};
+	};
+};
+
+&acmp1 {
+	status = "okay";
+	pinctrl-0 = <&acmp1_default>;
+	pinctrl-names = "default";
+};

--- a/samples/sensor/mcux_acmp/boards/mimxrt1180_evk_mimxrt1189_cm7.overlay
+++ b/samples/sensor/mcux_acmp/boards/mimxrt1180_evk_mimxrt1189_cm7.overlay
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	acmp1_default: acmp1_default {
+		group0 {
+			pinmux = <&iomuxc_gpio_ad_01_acmp1_in2>;
+			drive-strength = "high";
+			bias-pull-up;
+			slew-rate = "fast";
+		};
+	};
+};
+
+&acmp1 {
+	status = "okay";
+	pinctrl-0 = <&acmp1_default>;
+	pinctrl-names = "default";
+};

--- a/samples/sensor/mcux_acmp/sample.yaml
+++ b/samples/sensor/mcux_acmp/sample.yaml
@@ -8,6 +8,8 @@ common:
     - mimxrt1170_evk/mimxrt1176/cm4
     - frdm_ke17z
     - frdm_ke17z512
+    - mimxrt1180_evk/mimxrt1189/cm33
+    - mimxrt1180_evk/mimxrt1189/cm7
   integration_platforms:
     - twr_ke18f
   tags:

--- a/samples/sensor/mcux_acmp/src/main.c
+++ b/samples/sensor/mcux_acmp/src/main.c
@@ -16,7 +16,7 @@
 #define ACMP_POSITIVE 5
 #define ACMP_NEGATIVE 5
 #define ACMP_DAC_VREF 0
-#elif defined(CONFIG_BOARD_MIMXRT1170_EVK)
+#elif (defined(CONFIG_BOARD_MIMXRT1170_EVK) || defined(CONFIG_BOARD_MIMXRT1180_EVK))
 #define ACMP_NODE  DT_NODELABEL(acmp1)
 #define ACMP_POSITIVE 2
 #define ACMP_NEGATIVE 7
@@ -58,8 +58,10 @@ static const struct acmp_attr attrs[] = {
 	  .val = ACMP_DAC_VREF },
 	/* DAC value */
 	{ .attr = SENSOR_ATTR_MCUX_ACMP_DAC_VALUE, .val = ACMP_DAC_VALUE },
+#if MCUX_ACMP_HAS_HYSTCTR
 	/* Hysteresis level */
 	{ .attr = SENSOR_ATTR_MCUX_ACMP_HYSTERESIS_LEVEL, .val = 3 },
+#endif
 #if MCUX_ACMP_HAS_DISCRETE_MODE
 	/* Discrete mode */
 	{ .attr = SENSOR_ATTR_MCUX_ACMP_POSITIVE_DISCRETE_MODE, .val = 1 },

--- a/soc/nxp/imxrt/imxrt118x/soc.c
+++ b/soc/nxp/imxrt/imxrt118x/soc.c
@@ -269,6 +269,20 @@ static ALWAYS_INLINE void clock_init(void)
 
 #endif /* CONFIG_COUNTER_MCUX_GPT */
 
+#ifdef CONFIG_MCUX_ACMP
+
+#if (DT_NODE_HAS_STATUS(DT_NODELABEL(acmp1), okay)  \
+	|| DT_NODE_HAS_STATUS(DT_NODELABEL(acmp2), okay) \
+	|| DT_NODE_HAS_STATUS(DT_NODELABEL(acmp3), okay) \
+	|| DT_NODE_HAS_STATUS(DT_NODELABEL(acmp4), okay))
+	/* Configure ACMP using MuxSysPll3Out */
+	rootCfg.mux = kCLOCK_ACMP_ClockRoot_MuxSysPll3Out;
+	rootCfg.div = 2;
+	CLOCK_SetRootClock(kCLOCK_Root_Acmp, &rootCfg);
+#endif
+
+#endif /* CONFIG_MCUX_ACMP */
+
 	/* Keep core clock ungated during WFI */
 	CCM->LPCG[1].LPM0 = 0x33333333;
 	CCM->LPCG[1].LPM1 = 0x33333333;


### PR DESCRIPTION
samples/sensor/mcux_acmp have been supported.
`mimxrt1180_evk` board are captured in J45-13, need change the external voltage signal to check the output.