### PR TITLE
usb: device: class: netusb: Add dummy get_capabilities API

### DIFF
--- a/subsys/usb/device/class/netusb/netusb.c
+++ b/subsys/usb/device/class/netusb/netusb.c
@@ -137,10 +137,15 @@ static void netusb_init(struct net_if *iface)
 	LOG_INF("netusb initialized");
 }
 
+static enum ethernet_hw_caps netusb_get_capabilities(const struct device *dev)
+{
+	return 0;
+}
+
 static const struct ethernet_api netusb_api_funcs = {
 	.iface_api.init = netusb_init,
 
-	.get_capabilities = NULL,
+	.get_capabilities = netusb_get_capabilities,
 	.send = netusb_send,
 };
 


### PR DESCRIPTION
The L2 Ethernet layer uses get_capabilities API, without checking if it is NULL or not. I presume that this is intended and every ethernet driver shall implement this api. netusb implementation misses this API, which causes a nasty crash on RTOS startup when it is used.

Fixes crashes in sybsys/net/l2/ethernet/ethernet.c.