### PR TITLE
samples: sensors: improve filtering

### DIFF
--- a/boards/96boards/wistrio/96b_wistrio.yaml
+++ b/boards/96boards/wistrio/96b_wistrio.yaml
@@ -12,3 +12,4 @@ supported:
   - i2c
   - eeprom
   - lora
+  - lis2dh

--- a/boards/actinius/icarus/actinius_icarus_nrf9160_2_0_0.yaml
+++ b/boards/actinius/icarus/actinius_icarus_nrf9160_2_0_0.yaml
@@ -20,4 +20,5 @@ supported:
   - feather_spi
   - arduino_i2c
   - arduino_spi
+  - lis2dh
 vendor: actinius

--- a/boards/bbc/microbit/bbc_microbit.yaml
+++ b/boards/bbc/microbit/bbc_microbit.yaml
@@ -15,3 +15,4 @@ supported:
   - i2c
   - gpio
   - pwm
+  - lis2dh

--- a/boards/croxel/croxel_cx1825/croxel_cx1825_nrf52840.yaml
+++ b/boards/croxel/croxel_cx1825/croxel_cx1825_nrf52840.yaml
@@ -14,4 +14,5 @@ supported:
   - gpio
   - i2c
   - watchdog
+  - hts221
 vendor: croxel

--- a/boards/ezurio/bt510/bt510.yaml
+++ b/boards/ezurio/bt510/bt510.yaml
@@ -7,6 +7,7 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - gpio
   - adc
   - ble
   - pwm

--- a/boards/innblue/innblue21/innblue21_nrf9160.yaml
+++ b/boards/innblue/innblue21/innblue21_nrf9160.yaml
@@ -12,3 +12,4 @@ supported:
   - i2c
   - pwm
   - watchdog
+  - hts221

--- a/boards/nordic/thingy52/thingy52_nrf52832.yaml
+++ b/boards/nordic/thingy52/thingy52_nrf52832.yaml
@@ -12,4 +12,5 @@ supported:
   - gpio
   - i2c
   - hts221
+  - lis2dh
 vendor: nordic

--- a/boards/ruuvi/ruuvitag/ruuvi_ruuvitag.yaml
+++ b/boards/ruuvi/ruuvitag/ruuvi_ruuvitag.yaml
@@ -16,4 +16,5 @@ supported:
   - counter
   - nvs
   - watchdog
+  - bme280
 vendor: ruuvi

--- a/boards/st/sensortile_box/sensortile_box.yaml
+++ b/boards/st/sensortile_box/sensortile_box.yaml
@@ -15,6 +15,7 @@ supported:
   - usb device
   - nvs
   - counter
+  - lps22hh
 ram: 640
 flash: 2048
 vendor: st

--- a/boards/st/stm32f411e_disco/stm32f411e_disco_stm32f411xe_B.yaml
+++ b/boards/st/stm32f411e_disco/stm32f411e_disco_stm32f411xe_B.yaml
@@ -8,4 +8,5 @@ toolchain:
   - xtools
 supported:
   - counter
+  - lis2dh
 vendor: st

--- a/boards/st/stm32f411e_disco/stm32f411e_disco_stm32f411xe_D.yaml
+++ b/boards/st/stm32f411e_disco/stm32f411e_disco_stm32f411xe_D.yaml
@@ -8,4 +8,5 @@ toolchain:
   - xtools
 supported:
   - counter
+  - lis2dh
 vendor: st

--- a/boards/st/stm32l562e_dk/stm32l562e_dk.yaml
+++ b/boards/st/stm32l562e_dk/stm32l562e_dk.yaml
@@ -22,6 +22,7 @@ supported:
   - usb_device
   - nvs
   - usbd
+  - lsm6dso
 ram: 192
 flash: 512
 vendor: st

--- a/samples/sensor/accel_polling/sample.yaml
+++ b/samples/sensor/accel_polling/sample.yaml
@@ -3,29 +3,17 @@ sample:
 tests:
   sample.sensor.accel_polling:
     harness: console
-    tags: sensors
     filter: dt_alias_exists("accel0")
+    tags:
+      - sensors
+      - accelerometer
     harness_config:
       type: one_line
       regex:
         - "^\\s*[0-9A-Za-z_,+-.]*@[0-9A-Fa-f]* \\[m\/s\\^2\\]:    \
            \\(\\s*-?[0-9\\.]*,\\s*-?[0-9\\.]*,\\s*-?[0-9\\.]*\\)$"
     integration_platforms:
-      - cc1352r_sensortag               # adxl362
-      - blueclover_plt_demo_v2/nrf52832 # bmi270
-      - frdm_kl25z                      # mma8451q
-      - lpcxpresso55s28                 # mma8652fc
-      - bbc_microbit                    # mmc8653fc
-      - frdm_k64f                       # fxos8700
-      - mimxrt1040_evk                  # fxls8974
-      - sparkfun_thing_plus/nrf9160     # lis2dh
-      - thingy52/nrf52832               # lis2dh12
-      - stm32f411e_disco                # lsm303agr_accel
       - stm32f3_disco                   # lsm303dlhc_accel
-      - bl5340_dvk/nrf5340/cpuapp       # lis3dh
-      - b_l4s5i_iot01a                  # lsm6dsl
-      - sensortile_box                  # lis2dw12, lsm6dso, iisdhhc
-      - thingy53/nrf5340/cpuapp         # adxl362, bmi270
   sample.sensor.accel_polling.adxl362-stream:
     harness: console
     tags: sensors

--- a/samples/sensor/adc_cmp_npcx/sample.yaml
+++ b/samples/sensor/adc_cmp_npcx/sample.yaml
@@ -2,7 +2,8 @@ sample:
   description: Demonstration of nuvoton NPCX ADC comparator driver
   name: NPCX ADC comparator sample
 common:
-  platform_allow: npcx9m6f_evb
+  platform_allow:
+    - npcx9m6f_evb
   integration_platforms:
     - npcx9m6f_evb
   tags:

--- a/samples/sensor/adt7420/sample.yaml
+++ b/samples/sensor/adt7420/sample.yaml
@@ -4,5 +4,6 @@ tests:
   sample.sensor.adt7420:
     harness: sensor
     tags: sensors
-    platform_allow: frdm_k64f
+    platform_allow:
+      - frdm_k64f
     depends_on: i2c

--- a/samples/sensor/amg88xx/sample.yaml
+++ b/samples/sensor/amg88xx/sample.yaml
@@ -7,7 +7,11 @@ tests:
   sample.sensor.amg88xx.amg88xx_grid_eye_eval_shield:
     build_only: true
     depends_on: arduino_i2c arduino_gpio
-    platform_allow: pan1780_evb pan1770_evb pan1781_evb pan1782_evb
+    platform_allow:
+      - pan1780_evb
+      - pan1770_evb
+      - pan1781_evb
+      - pan1782_evb
     integration_platforms:
       - pan1780_evb
     extra_args: SHIELD=amg88xx_grid_eye_eval_shield

--- a/samples/sensor/ams_iAQcore/sample.yaml
+++ b/samples/sensor/ams_iAQcore/sample.yaml
@@ -4,7 +4,10 @@ sample:
 tests:
   sample.sensor.iaqcore:
     harness: sensor
-    tags: samples
+    tags:
+      - iAQcore
+    platform_allow:
+      - nucleo_f446re
     depends_on:
       - i2c
       - arduino_i2c

--- a/samples/sensor/apds9960/sample.yaml
+++ b/samples/sensor/apds9960/sample.yaml
@@ -3,7 +3,8 @@ sample:
 tests:
   sample.sensor.apds9960:
     harness: console
-    platform_allow: reel_board
+    platform_allow:
+      - reel_board
     integration_platforms:
       - reel_board
     tags: sensors
@@ -19,7 +20,8 @@ tests:
       fixture: fixture_i2c_apds9960
   sample.sensor.apds9960.trigger:
     harness: console
-    platform_allow: reel_board
+    platform_allow:
+      - reel_board
     integration_platforms:
       - reel_board
     tags: sensors

--- a/samples/sensor/bme280/sample.yaml
+++ b/samples/sensor/bme280/sample.yaml
@@ -17,19 +17,18 @@ tests:
   sample.sensor.bme280.spi:
     harness: console
     tags: sensors
-    depends_on:
-      - spi
-      - bme280
-    extra_args: "DTC_OVERLAY_FILE=arduino_spi.overlay"
     harness_config:
       type: one_line
       regex:
         - "temp: (.*); press: (.*); humidity: (.*)"
       fixture: fixture_spi_bme280
+    platform_allow:
+      - ruuvi_ruuvitag
   sample.sensor.bme280.rpi_pico.pio:
     harness: console
     tags: sensors
-    platform_allow: rpi_pico
+    platform_allow:
+      - rpi_pico
     integration_platforms:
       - rpi_pico
     extra_args: "DTC_OVERLAY_FILE=rpi_pico_spi_pio.overlay"

--- a/samples/sensor/bmg160/sample.yaml
+++ b/samples/sensor/bmg160/sample.yaml
@@ -7,4 +7,7 @@ tests:
     depends_on:
       - i2c
       - gpio
-    filter: dt_compat_enabled("bosch,bmg160")
+    platform_allow:
+      - frdm_k64f
+    integration_platforms:
+      - frdm_k64f

--- a/samples/sensor/bmi270/sample.yaml
+++ b/samples/sensor/bmi270/sample.yaml
@@ -7,3 +7,5 @@ tests:
       - samples
       - sensor
     depends_on: arduino_i2c
+    platform_allow:
+      - nrf52840dk/nrf52840

--- a/samples/sensor/bq274xx/sample.yaml
+++ b/samples/sensor/bq274xx/sample.yaml
@@ -4,14 +4,16 @@ sample:
 tests:
   sample.sensor.bq274xx:
     harness: sensor
-    platform_allow: innblue22/nrf9160
+    platform_allow:
+      - innblue22/nrf9160
     integration_platforms:
       - innblue22/nrf9160
     tags: sensors
     depends_on: i2c
   sample.sensor.bq274xx_without_int_gpios:
     harness: sensor
-    platform_allow: innblue22/nrf9160
+    platform_allow:
+      - innblue22/nrf9160
     integration_platforms:
       - innblue22/nrf9160
     tags: sensors

--- a/samples/sensor/co2_polling/sample.yaml
+++ b/samples/sensor/co2_polling/sample.yaml
@@ -4,5 +4,7 @@ tests:
   sample.sensor.co2:
     harness: sensor
     tags: sensors
-    filter: dt_alias_exists("co2")
-    depends_on: serial uart_interrupt_driven
+    platform_allow:
+      - nucleo_h563zi
+    integration_platforms:
+      - nucleo_h563zi

--- a/samples/sensor/dht_polling/sample.yaml
+++ b/samples/sensor/dht_polling/sample.yaml
@@ -10,7 +10,8 @@ sample:
 tests:
   sample.sensor.dht_polling:
     tags: sensors
-    filter: dt_alias_exists("dht0")
+    platform_allow:
+      - nucleo_f401re
     integration_platforms:
       - nucleo_f401re
     harness: console

--- a/samples/sensor/die_temp_polling/sample.yaml
+++ b/samples/sensor/die_temp_polling/sample.yaml
@@ -5,9 +5,10 @@ tests:
   sample.sensor.die_temperature_polling:
     tags:
       - sensors
-    filter: dt_alias_exists("die-temp0")
-    integration_platforms:
+    platform_allow:
       - stm32f3_disco
+      - nucleo_h7a3zi_q
+    integration_platforms:
       - nucleo_h7a3zi_q
     harness: console
     harness_config:

--- a/samples/sensor/ds18b20/sample.yaml
+++ b/samples/sensor/ds18b20/sample.yaml
@@ -17,8 +17,10 @@ tests:
         - "Temp: (.*)"
       fixture: fixture_w1_serial_ds18b20
   sample.sensor.ds18b20.w1_arduino_serial:
-    platform_allow: nucleo_g071rb
-    depends_on: arduino_serial
+    platform_allow:
+      - nucleo_g071rb
+    depends_on:
+      - arduino_serial
     integration_platforms:
       - nucleo_g071rb
     extra_args: "DTC_OVERLAY_FILE=arduino_serial.overlay"

--- a/samples/sensor/fdc2x1x/sample.yaml
+++ b/samples/sensor/fdc2x1x/sample.yaml
@@ -5,6 +5,7 @@ tests:
   sample.sensor.fdc2x1x:
     harness: sensor
     tags: sensors
-    platform_allow: nrf9160dk/nrf9160
+    platform_allow:
+      - nrf9160dk/nrf9160
     integration_platforms:
       - nrf9160dk/nrf9160

--- a/samples/sensor/fxas21002/sample.yaml
+++ b/samples/sensor/fxas21002/sample.yaml
@@ -4,6 +4,7 @@ tests:
   sample.sensor.fxas21002:
     harness: sensor
     tags: sensors
-    platform_allow: hexiwear/mk64f12
+    platform_allow:
+      - hexiwear/mk64f12
     integration_platforms:
       - hexiwear/mk64f12

--- a/samples/sensor/grove_light/sample.yaml
+++ b/samples/sensor/grove_light/sample.yaml
@@ -9,7 +9,8 @@ tests:
       - sensor
       - grove
       - light
-    platform_allow: nrf52dk/nrf52832
+    platform_allow:
+      - nrf52dk/nrf52832
     integration_platforms:
       - nrf52dk/nrf52832
     harness: grove

--- a/samples/sensor/grove_temperature/sample.yaml
+++ b/samples/sensor/grove_temperature/sample.yaml
@@ -10,7 +10,8 @@ tests:
       - sensor
       - grove
       - temperature
-    platform_allow: nrf52dk/nrf52832
+    platform_allow:
+      - nrf52dk/nrf52832
     integration_platforms:
       - nrf52dk/nrf52832
     harness: grove

--- a/samples/sensor/grow_r502a/sample.yaml
+++ b/samples/sensor/grow_r502a/sample.yaml
@@ -11,4 +11,5 @@ tests:
     harness: sensor
     build_only: true
     depends_on: serial
-    filter: dt_compat_enabled("hzgrow,r502a")
+    platform_allow:
+      - esp32_devkitc_wroom/esp32/procpu

--- a/samples/sensor/hts221/sample.yaml
+++ b/samples/sensor/hts221/sample.yaml
@@ -4,7 +4,6 @@ common:
   harness: console
   integration_platforms:
     - disco_l475_iot1
-  filter: dt_compat_enabled("st,hts221")
   tags: sensors
   depends_on:
     - i2c

--- a/samples/sensor/i3g4250d/sample.yaml
+++ b/samples/sensor/i3g4250d/sample.yaml
@@ -8,5 +8,6 @@ sample:
   name: I3G4250D Sensor Sample
 tests:
   sample.sensor.i3g4250d:
-    platform_allow: stm32f3_disco@E
+    platform_allow:
+      - stm32f3_disco@E
     tags: sensors

--- a/samples/sensor/icm42605/sample.yaml
+++ b/samples/sensor/icm42605/sample.yaml
@@ -9,7 +9,8 @@ sample:
 tests:
   sample.sensor.icm42605:
     build_only: true
-    platform_allow: nrf52dk/nrf52832
+    platform_allow:
+      - nrf52dk/nrf52832
     integration_platforms:
       - nrf52dk/nrf52832
     tags: sensors

--- a/samples/sensor/ina219/sample.yaml
+++ b/samples/sensor/ina219/sample.yaml
@@ -10,5 +10,6 @@ sample:
 tests:
   sample.drivers.ina219:
     build_only: true
-    platform_allow: blackpill_f411ce
+    platform_allow:
+      - blackpill_f411ce
     tags: sensors

--- a/samples/sensor/isl29035/sample.yaml
+++ b/samples/sensor/isl29035/sample.yaml
@@ -4,7 +4,8 @@ tests:
   sample.sensor.isl29035:
     tags: sensors
     depends_on: i2c
-    platform_allow: nrf52dk/nrf52832
+    platform_allow:
+      - nrf52dk/nrf52832
     integration_platforms:
       - nrf52dk/nrf52832
     harness: console

--- a/samples/sensor/jc42/sample.yaml
+++ b/samples/sensor/jc42/sample.yaml
@@ -6,6 +6,5 @@ tests:
     tags: sensors
     depends_on: i2c
     filter: dt_compat_enabled("jedec,jc-42.4-temp")
-    platform_allow: nucleo_l053r8
-    integration_platforms:
+    platform_allow:
       - nucleo_l053r8

--- a/samples/sensor/lis2dh/sample.yaml
+++ b/samples/sensor/lis2dh/sample.yaml
@@ -9,3 +9,5 @@ tests:
     depends_on:
       - i2c
       - lis2dh
+    integration_platforms:
+      - thingy52/nrf52832

--- a/samples/sensor/lps22hb/sample.yaml
+++ b/samples/sensor/lps22hb/sample.yaml
@@ -14,3 +14,5 @@ tests:
         - "Temperature: (.*)"
         - "Relative Humidity: (.*)"
       fixture: fixture_i2c_lps22hb
+    integration_platforms:
+      - disco_l475_iot1

--- a/samples/sensor/lps22hh/sample.yaml
+++ b/samples/sensor/lps22hh/sample.yaml
@@ -4,8 +4,11 @@ tests:
   sample.sensor.lps22hh:
     harness: console
     tags: sensors
-    depends_on: i2c
-    filter: dt_compat_enabled("st,lps22hh")
+    depends_on:
+      - i2c
+      - lps22hh
+    integration_platforms:
+      - sensortile_box
     harness_config:
       type: multi_line
       ordered: true

--- a/samples/sensor/lps22hh_i3c/sample.yaml
+++ b/samples/sensor/lps22hh_i3c/sample.yaml
@@ -4,8 +4,10 @@ tests:
   sample.sensor.lps22hh.i3c:
     harness: console
     tags: sensors
-    depends_on: i3c
-    filter: dt_compat_enabled("st,lps22hh")
+    depends_on:
+      - i3c
+    platform_allow:
+      - mimxrt685_evk/mimxrt685s/cm33
     build_only: true
     harness_config:
       type: multi_line

--- a/samples/sensor/lsm303dlhc/sample.yaml
+++ b/samples/sensor/lsm303dlhc/sample.yaml
@@ -9,3 +9,5 @@ tests:
     depends_on:
       - i2c
       - lsm303dlhc
+    integration_platforms:
+      - stm32f3_disco

--- a/samples/sensor/lsm6dso/sample.yaml
+++ b/samples/sensor/lsm6dso/sample.yaml
@@ -6,7 +6,8 @@ tests:
     tags:
       - sensors
     timeout: 15
-    filter: dt_compat_enabled("st,lsm6dso")
+    depends_on:
+      - lsm6dso
     integration_platforms:
       - stm32l562e_dk
     harness_config:

--- a/samples/sensor/lsm6dso_i2c_on_i3c/sample.yaml
+++ b/samples/sensor/lsm6dso_i2c_on_i3c/sample.yaml
@@ -4,8 +4,10 @@ tests:
   sample.sensor.lsm6dso.i2c_on_i3c_bus:
     harness: console
     tags: sensors
-    depends_on: i3c
-    filter: dt_compat_enabled("st,lsm6dso")
+    depends_on:
+      - i3c
+    platform_allow:
+      - mimxrt685_evk/mimxrt685s/cm33
     timeout: 15
     build_only: true
     harness_config:

--- a/samples/sensor/magn_polling/sample.yaml
+++ b/samples/sensor/magn_polling/sample.yaml
@@ -4,10 +4,11 @@ tests:
   sample.sensor.magn_polling:
     harness: sensor
     tags: sensors
-    filter: dt_alias_exists("magn0")
-    integration_platforms:
+    platform_allow:
       - frdm_k64f               # fxos8700
       - thingy53/nrf5340/cpuapp # bmm150
       - sensortile_box          # lis2mdl
       - stm32f411e_disco        # lsm303agr_magn
       - stm32f3_disco           # lsm303dlhc_magn
+    integration_platforms:
+      - frdm_k64f

--- a/samples/sensor/max17262/sample.yaml
+++ b/samples/sensor/max17262/sample.yaml
@@ -7,7 +7,8 @@ tests:
     depends_on: arduino_i2c
     harness: console
     tags: sensors
-    platform_allow: nrf52840dk/nrf52840
+    platform_allow:
+      - nrf52840dk/nrf52840
     harness_config:
       type: one_line
       regex:

--- a/samples/sensor/max30101/sample.yaml
+++ b/samples/sensor/max30101/sample.yaml
@@ -5,7 +5,6 @@ tests:
   sample.sensor.max30101:
     harness: sensor
     tags: sensors
-    platform_allow: hexiwear/mk64f12
-    depends_on: i2c
-    integration_platforms:
+    platform_allow:
       - hexiwear/mk64f12
+    depends_on: i2c

--- a/samples/sensor/max44009/sample.yaml
+++ b/samples/sensor/max44009/sample.yaml
@@ -7,7 +7,10 @@ tests:
   sample.sensor.max44009:
     tags: sensors
     harness: console
-    depends_on: i2c
+    depends_on:
+      - i2c
+    platform_allow:
+      - frdm_k64f
     harness_config:
       type: multi_line
       ordered: true
@@ -15,4 +18,3 @@ tests:
         - "MAX44009 light sensor application"
         - "sensor: lum reading: (.*)"
       fixture: fixture_i2c_max44009
-    filter: dt_compat_enabled("maxim,max44009")

--- a/samples/sensor/max6675/sample.yaml
+++ b/samples/sensor/max6675/sample.yaml
@@ -4,11 +4,13 @@ tests:
   sample.sensor.max6675:
     tags: sensors
     harness: console
-    depends_on: spi
+    depends_on:
+      - spi
+    platform_allow:
+      - nucleo_f030r8
     harness_config:
       type: multi_line
       ordered: true
       regex:
         - "Temperature: ([0-9\\.]+) C"
       fixture: fixture_spi_max6675
-    filter: dt_compat_enabled("maxim,max6675")

--- a/samples/sensor/mhz19b/sample.yaml
+++ b/samples/sensor/mhz19b/sample.yaml
@@ -10,5 +10,7 @@ tests:
     build_only: true
     harness: sensor
     tags: sensors
-    depends_on: serial
-    filter: dt_compat_enabled("winsen,mhz19b")
+    depends_on:
+      - serial
+    platform_allow:
+      - nucleo_g0b1re

--- a/samples/sensor/mpr/sample.yaml
+++ b/samples/sensor/mpr/sample.yaml
@@ -4,6 +4,5 @@ tests:
   sample.sensor.mpr:
     harness: sensor
     tags: sensors
-    platform_allow: arduino_due
-    integration_platforms:
+    platform_allow:
       - arduino_due

--- a/samples/sensor/mpu6050/sample.yaml
+++ b/samples/sensor/mpu6050/sample.yaml
@@ -9,7 +9,6 @@ sample:
 tests:
   sample.sensor.mpu6050:
     build_only: true
-    platform_allow: nrf52dk/nrf52832
-    tags: sensors
-    integration_platforms:
+    platform_allow:
       - nrf52dk/nrf52832
+    tags: sensors

--- a/samples/sensor/ms5837/sample.yaml
+++ b/samples/sensor/ms5837/sample.yaml
@@ -4,7 +4,8 @@ sample:
 tests:
   sample.sensor.ms5837:
     build_only: true
-    platform_allow: nrf52840dk/nrf52840
+    platform_allow:
+      - nrf52840dk/nrf52840
     integration_platforms:
       - nrf52840dk/nrf52840
     tags: sensors

--- a/samples/sensor/proximity_polling/sample.yaml
+++ b/samples/sensor/proximity_polling/sample.yaml
@@ -6,6 +6,5 @@ tests:
     tags:
       - sensors
       - proximity
-    filter: dt_alias_exists("prox-sensor0")
-    integration_platforms:
+    platform_allow:
       - nrf52840dk/nrf52840

--- a/samples/sensor/qdec/sample.yaml
+++ b/samples/sensor/qdec/sample.yaml
@@ -8,7 +8,12 @@ common:
 
 tests:
   sample.sensor.qdec_sensor:
-    filter: dt_alias_exists("qdec0")
+    platform_allow:
+      - mimxrt1050_evk@qspi
+      - mimxrt1050_evk
+      - esp32s3_luatos_core/esp32s3/procpu
+    integration_platforms:
+      - mimxrt1050_evk
     harness_config:
       type: multi_line
       ordered: true
@@ -28,7 +33,8 @@ tests:
         - "Position = (.*) degrees"
 
   sample.sensor.st_qdec_sensor:
-    platform_allow: nucleo_f401re
+    platform_allow:
+      - nucleo_f401re
     harness_config:
       fixture: fixture_mech_encoder
       type: multi_line

--- a/samples/sensor/sensor_shell/sample.yaml
+++ b/samples/sensor/sensor_shell/sample.yaml
@@ -7,21 +7,18 @@ common:
 
 tests:
   sample.sensor.shell:
-    integration_platforms:
+    platform_allow:
       - frdm_k64f
-    # TODO Remove once #63414 is resolved
-    platform_exclude: gd32l233r_eval
-    filter: ( CONFIG_UART_CONSOLE and CONFIG_SERIAL_SUPPORT_INTERRUPT )
+      - robokit1
     harness: keyboard
     min_ram: 20
     min_flash: 33
   sample.sensor.shell.pytest:
-    filter: CONFIG_SERIAL and dt_chosen_enabled("zephyr,shell-uart")
     min_ram: 40
     harness: pytest
     timeout: 180
     extra_configs:
       - arch:posix:CONFIG_NATIVE_UART_0_ON_STDINOUT=y
       - CONFIG_SAMPLES_SENSOR_SHELL_FAKE_SENSOR=y
-    integration_platforms:
+    platform_allow:
       - native_sim

--- a/samples/sensor/sgp40_sht4x/sample.yaml
+++ b/samples/sensor/sgp40_sht4x/sample.yaml
@@ -9,5 +9,6 @@ sample:
 tests:
   sample.sensor.sgp40_sht4x:
     build_only: true
-    platform_allow: blackpill_f411ce
+    platform_allow:
+      - blackpill_f411ce
     tags: sensors

--- a/samples/sensor/sm351lt/sample.yaml
+++ b/samples/sensor/sm351lt/sample.yaml
@@ -9,3 +9,5 @@ tests:
     depends_on:
       - gpio
       - sm351lt
+    integration_platforms:
+      - bt510

--- a/samples/sensor/soc_voltage/sample.yaml
+++ b/samples/sensor/soc_voltage/sample.yaml
@@ -6,7 +6,8 @@ tests:
     depends_on: adc
     tags: sensors
     timeout: 10
-    filter: dt_alias_exists("volt-sensor0")
+    platform_allow:
+      - nucleo_g071rb
     harness: console
     harness_config:
       type: one_line

--- a/samples/sensor/sx9500/sample.yaml
+++ b/samples/sensor/sx9500/sample.yaml
@@ -7,4 +7,5 @@ tests:
     depends_on:
       - i2c
       - gpio
-    filter: dt_compat_enabled("semtech,sx9500")
+    platform_allow:
+      - frdm_k64f

--- a/samples/sensor/th02/sample.yaml
+++ b/samples/sensor/th02/sample.yaml
@@ -5,4 +5,5 @@ tests:
     harness: sensor
     tags: sensors
     depends_on: i2c
-    filter: dt_compat_enabled("hoperf,th02") and dt_compat_enabled("seeed,grove-lcd-rgb")
+    platform_allow:
+      - frdm_k64f

--- a/samples/sensor/thermometer/sample.yaml
+++ b/samples/sensor/thermometer/sample.yaml
@@ -4,10 +4,11 @@ tests:
   sample.sensor.thermometer:
     tags: sensors
     harness: sensor
-    filter: dt_alias_exists("ambient-temp0")
-    integration_platforms:
+    platform_allow:
       - nrf52840dk/nrf52840   # mcp9700a
       - frdm_k22f             # tcn75a
       - robokit1              # ntc_thermistor
       - adi_eval_adin1110ebz  # adt7420
       - frdm_mcxn947/mcxn947/cpu0 # p3t1755
+    integration_platforms:
+      - frdm_k22f

--- a/samples/sensor/tmp112/sample.yaml
+++ b/samples/sensor/tmp112/sample.yaml
@@ -5,7 +5,8 @@ tests:
     harness: console
     tags: sensors
     depends_on: i2c
-    filter: dt_compat_enabled("ti,tmp112")
+    platform_allow:
+      - frdm_k64f
     harness_config:
       type: one_line
       regex:

--- a/samples/sensor/tmp116/sample.yaml
+++ b/samples/sensor/tmp116/sample.yaml
@@ -3,8 +3,7 @@ sample:
 tests:
   sample.sensor.tmp116:
     harness: console
-    platform_allow: nucleo_f401re
-    integration_platforms:
+    platform_allow:
       - nucleo_f401re
     tags: sensors
     depends_on: i2c

--- a/samples/sensor/vcnl4040/sample.yaml
+++ b/samples/sensor/vcnl4040/sample.yaml
@@ -3,8 +3,6 @@ sample:
 tests:
   sample.sensor.vcnl4040:
     harness: sensor
-    platform_allow: adafruit_feather_stm32f405
-    integration_platforms:
+    platform_allow:
       - adafruit_feather_stm32f405
     tags: sensors
-    filter: dt_compat_enabled("vishay,vcnl4040")

--- a/samples/sensor/veaa_x_3/sample.yaml
+++ b/samples/sensor/veaa_x_3/sample.yaml
@@ -4,5 +4,8 @@ tests:
   sample.sensor.veaa_x_3:
     harness: sensor
     tags: sensors
-    filter: dt_compat_enabled("festo,veaa-x-3")
-    depends_on: adc dac
+    depends_on:
+      - adc
+      - dac
+    platform_allow:
+      - nucleo_h563zi

--- a/samples/sensor/vl53l0x/sample.yaml
+++ b/samples/sensor/vl53l0x/sample.yaml
@@ -7,3 +7,5 @@ tests:
       - i2c
       - vl53l0x
     tags: sensors
+    integration_platforms:
+      - b_l4s5i_iot01a


### PR DESCRIPTION
Improve filtering by avoiding wildcard filters and dts lookups, instead,
target the platforms in the README or those with overlays.

Improve integration_platforms and reduce the number of platforms we
enable in integration mode.

Various other cosmetics fixes.

This will help speed up CI and avoud useless builds trying to find a
matching system when we know exactly what platforms already support
this sensor for example.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
