### PR TITLE
net: l2: ethernet: check dev->api and get_capabilities for being NULL

### DIFF
--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -933,14 +933,14 @@ void net_eth_ipv6_mcast_to_mac_addr(const struct in6_addr *ipv6_addr,
 static inline
 enum ethernet_hw_caps net_eth_get_hw_capabilities(struct net_if *iface)
 {
-	const struct ethernet_api *eth =
-		(struct ethernet_api *)net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct ethernet_api *api = (struct ethernet_api *)dev->api;
 
-	if (!eth->get_capabilities) {
+	if (!api || !api->get_capabilities) {
 		return (enum ethernet_hw_caps)0;
 	}
 
-	return eth->get_capabilities(net_if_get_device(iface));
+	return api->get_capabilities(dev);
 }
 
 /**

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -166,10 +166,7 @@ static void ethernet_update_rx_stats(struct net_if *iface,
 
 static inline bool eth_is_vlan_tag_stripped(struct net_if *iface)
 {
-	const struct device *dev = net_if_get_device(iface);
-	const struct ethernet_api *api = dev->api;
-
-	return (api->get_capabilities(dev) & ETHERNET_HW_VLAN_TAG_STRIP);
+	return (net_eth_get_hw_capabilities(iface) & ETHERNET_HW_VLAN_TAG_STRIP);
 }
 
 /* Drop packet if it has broadcast destination MAC address but the IP
@@ -210,7 +207,7 @@ static void ethernet_mcast_monitor_cb(struct net_if *iface, const struct net_add
 	dev = net_if_get_device(iface);
 	api = dev->api;
 
-	if (!(api->get_capabilities(dev) & ETHERNET_HW_FILTERING) || api->set_config == NULL) {
+	if (!(net_eth_get_hw_capabilities(iface) & ETHERNET_HW_FILTERING) || api->set_config == NULL) {
 		return;
 	}
 
@@ -868,7 +865,7 @@ const struct device *net_eth_get_ptp_clock(struct net_if *iface)
 		return NULL;
 	}
 
-	if (!(api->get_capabilities(dev) & ETHERNET_PTP)) {
+	if (!(net_eth_get_hw_capabilities(iface) & ETHERNET_PTP)) {
 		return NULL;
 	}
 

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -196,18 +196,20 @@ static void ethernet_mcast_monitor_cb(struct net_if *iface, const struct net_add
 			.type = ETHERNET_FILTER_TYPE_DST_MAC_ADDRESS,
 		},
 	};
-	const struct device *dev;
-	const struct ethernet_api *api;
+
+	const struct device *dev = net_if_get_device(iface);
+	const struct ethernet_api *api = dev->api;
 
 	/* Make sure we're an ethernet device */
 	if (net_if_l2(iface) != &NET_L2_GET_NAME(ETHERNET)) {
 		return;
 	}
 
-	dev = net_if_get_device(iface);
-	api = dev->api;
+	if (!(net_eth_get_hw_capabilities(iface) & ETHERNET_HW_FILTERING)) {
+		return;
+	}
 
-	if (!(net_eth_get_hw_capabilities(iface) & ETHERNET_HW_FILTERING) || api->set_config == NULL) {
+	if (!api || !api->set_config) {
 		return;
 	}
 

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -618,6 +618,11 @@ static int ethernet_send(struct net_if *iface, struct net_pkt *pkt)
 		goto error;
 	}
 
+	if (!api->send) {
+		ret = -ENOTSUP;
+		goto error;
+	}
+
 	if (IS_ENABLED(CONFIG_NET_ETHERNET_BRIDGE) &&
 	    net_pkt_is_l2_bridged(pkt)) {
 		net_pkt_cursor_init(pkt);

--- a/subsys/net/l2/ethernet/ethernet_mgmt.c
+++ b/subsys/net/l2/ethernet/ethernet_mgmt.c
@@ -18,11 +18,11 @@ static inline bool is_hw_caps_supported(const struct device *dev,
 {
 	const struct ethernet_api *api = dev->api;
 
-	if (!api) {
+	if (!api || !api->get_capabilities) {
 		return false;
 	}
 
-	return !!(api->get_capabilities(dev) & caps);
+	return ((api->get_capabilities(dev) & caps) != 0);
 }
 
 static int ethernet_set_config(uint32_t mgmt_request,


### PR DESCRIPTION
Adds missing checks for get_capabilities method not being NULL. Fixes crash with netusb and possibly other drivers.
See #77838
