### PR TITLE
drivers: xmc4xxx_uart: Delay service request/transmit interrupt until byte is sent out

### DIFF
--- a/drivers/serial/uart_xmc4xxx.c
+++ b/drivers/serial/uart_xmc4xxx.c
@@ -116,7 +116,7 @@ static void disable_tx_events(const struct uart_xmc4xxx_config *config)
 		XMC_USIC_CH_TXFIFO_DisableEvent(config->uart,
 					       XMC_USIC_CH_TXFIFO_EVENT_CONF_STANDARD);
 	} else {
-		XMC_USIC_CH_DisableEvent(config->uart, XMC_USIC_CH_EVENT_TRANSMIT_BUFFER);
+		XMC_USIC_CH_DisableEvent(config->uart, XMC_USIC_CH_EVENT_TRANSMIT_SHIFT);
 	}
 }
 #endif
@@ -131,7 +131,7 @@ static void enable_tx_events(const struct uart_xmc4xxx_config *config)
 		XMC_USIC_CH_TXFIFO_EnableEvent(config->uart,
 					       XMC_USIC_CH_TXFIFO_EVENT_CONF_STANDARD);
 	} else {
-		XMC_USIC_CH_EnableEvent(config->uart, XMC_USIC_CH_EVENT_TRANSMIT_BUFFER);
+		XMC_USIC_CH_EnableEvent(config->uart, XMC_USIC_CH_EVENT_TRANSMIT_SHIFT);
 	}
 }
 
@@ -189,7 +189,7 @@ static void uart_xmc4xxx_configure_service_requests(const struct device *dev)
 			data->service_request_tx);
 	} else {
 		XMC_USIC_CH_SetInterruptNodePointer(
-			config->uart, XMC_USIC_CH_INTERRUPT_NODE_POINTER_TRANSMIT_BUFFER,
+			config->uart, XMC_USIC_CH_INTERRUPT_NODE_POINTER_TRANSMIT_SHIFT,
 			data->service_request_tx);
 	}
 
@@ -338,7 +338,7 @@ static void uart_xmc4xxx_irq_tx_disable(const struct device *dev)
 		XMC_USIC_CH_TXFIFO_DisableEvent(config->uart,
 						XMC_USIC_CH_TXFIFO_EVENT_CONF_STANDARD);
 	} else {
-		XMC_USIC_CH_DisableEvent(config->uart, XMC_USIC_CH_EVENT_TRANSMIT_BUFFER);
+		XMC_USIC_CH_DisableEvent(config->uart, XMC_USIC_CH_EVENT_TRANSMIT_SHIFT);
 	}
 }
 


### PR DESCRIPTION
Generate the Tx service request after the symbol is shifted out of the UART. This is useful when the UART is connected to an RS485 transducer which has a separate transmit enable gpio/line. Hence it's important to know when the transmission actually finishes so that the drive enable line can be disabled.