### PR TITLE
cmake: Treat pristine build warnings as errors

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -3328,7 +3328,7 @@ function(zephyr_check_cache variable)
     # without cleaning first
     if(cli_argument)
       if(NOT ((CACHED_${variable} STREQUAL cli_argument) OR (${variable}_DEPRECATED STREQUAL cli_argument)))
-        message(WARNING "The build directory must be cleaned pristinely when "
+        message(FATAL_ERROR "The build directory must be cleaned pristinely when "
                         "changing ${variable_text},\n"
                         "Current value=\"${CACHED_${variable}}\", "
                         "Ignored value=\"${cli_argument}\"")


### PR DESCRIPTION
~~A pristine build is needed when snippets are changed. Currently, this only triggers a warning which can easily be missed and the new target snippets won't be applied.
Make the warning an error.~~

A pristine build is needed when snippets/boards/shields are changed. Currently, this is treated as a warning which can be easily missed and the new settings won't be applied. Treat the warning as an error.


