### PR TITLE
libc: common: Ignore GCC analyzer-malloc-leak warning

### DIFF
--- a/lib/libc/common/source/stdlib/malloc.c
+++ b/lib/libc/common/source/stdlib/malloc.c
@@ -137,6 +137,12 @@ malloc_unlock(void)
 #define malloc_unlock()
 #endif
 
+/* Define outside malloc() to make checkpatch EMBEDDED_FUNCTION_NAME happy. */
+#if defined(__GNUC__)
+#define GCC_DIAGNOSTIC_IGNORED_ANALYZER_LEAK \
+	_Pragma("GCC diagnostic ignored \"-Wanalyzer-malloc-leak\"")
+#endif
+
 void *malloc(size_t size)
 {
 	malloc_lock();
@@ -150,7 +156,17 @@ void *malloc(size_t size)
 
 	malloc_unlock();
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+	GCC_DIAGNOSTIC_IGNORED_ANALYZER_LEAK
+#undef GCC_DIAGNOSTIC_IGNORED_ANALYZER_LEAK
+#endif
+
 	return ret;
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 }
 
 void *aligned_alloc(size_t alignment, size_t size)
@@ -250,7 +266,16 @@ void *realloc(void *ptr, size_t requested_size)
 
 	malloc_unlock();
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wanalyzer-malloc-leak"
+#endif
+
 	return ret;
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 }
 
 void free(void *ptr)


### PR DESCRIPTION
Ignore GCC static analyzer warning (analyzer-malloc-leak) on malloc() and realloc() return values as false positive.

` west build -p -b qemu_x86 tests/kernel/timer/timer_api -DZEPHYR_SCA_VARIANT=gcc`

```
[110/142] Building C object zephyr/lib/libc/common/CMakeFiles/lib__libc__common.dir/source/stdlib/malloc.c.obj
/foo/zephyr/lib/libc/common/source/stdlib/malloc.c: In function 'malloc':
/foo/zephyr/lib/libc/common/source/stdlib/malloc.c:153:16: warning: leak of 'ret' [CWE-401] [-Wanalyzer-malloc-leak] 
...
[113/143] Building C object zephyr/lib/libc/common/CMakeFiles/lib__libc__common.dir/source/stdlib/malloc.c.obj
/foo/zephyr/lib/libc/common/source/stdlib/malloc.c: In function 'realloc':
/foo/zephyr/lib/libc/common/source/stdlib/malloc.c:253:16: warning: leak of 'realloc(ptr,  __real__ .MUL_OVERFLOW (nmemb_4(D), size_12(D)))' [CWE-401] [-Wanalyzer-malloc-leak]
```

This warning, for example, is 102 of 108 build errors for qemu_x86 on ./tests/kernel/* (v3.7.0-1999-g7cf124b4a964) with GCC static analyzer
```
./scripts/twister -b -p qemu_x86 -x=ZEPHYR_SCA_VARIANT=gcc -T ./tests/kernel
...
INFO    - Total complete:  192/ 192  100%  skipped:   72, failed:    0, error:  108                                          
INFO    - 192 test scenarios (192 test instances) selected, 72 configurations skipped (58 by static filter, 14 at runtime).  
INFO    - 12 of 192 test configurations passed (10.00%), 0 failed, 108 errored, 72 skipped with 0 warnings in 533.02 seconds 
...	
grep -Ee "malloc\.c:153:16: error:.*CWE-401" ./twister-out/**/build.log | wc -l
102
```
