### PR TITLE
logging: Improve error message for LOG_FRONTEND on native_sim

### DIFF
--- a/boards/native/native_sim/CMakeLists.txt
+++ b/boards/native/native_sim/CMakeLists.txt
@@ -27,6 +27,10 @@ if(CONFIG_HAS_SDL)
   add_subdirectory(${ZEPHYR_BASE}/boards/native/common/sdl/ ${CMAKE_CURRENT_BINARY_DIR}/sdl)
 endif()
 
+if(CONFIG_LOG_FRONTEND)
+  message(FATAL_ERROR "LOG_FRONTEND is not supported on the native_sim board.")
+endif()
+
 add_subdirectory(${ZEPHYR_BASE}/boards/native/common/extra_args/
 	${CMAKE_CURRENT_BINARY_DIR}/extra_args
 )


### PR DESCRIPTION
### Problem
When LOG_FRONTEND was enabled for the native_sim board, it resulted in misleading undefined reference errors during linking (e.g., `undefined reference to 'log_frontend_init'`).

### Solution
Add CMake check to throw a clear error if LOG_FRONTEND is enabled on native_sim.