### PR TITLE
drivers: spi_bitbang: Add support for SPI_TRANSFER_LSB flag

### DIFF
--- a/drivers/spi/spi_bitbang.c
+++ b/drivers/spi/spi_bitbang.c
@@ -36,7 +36,7 @@ static int spi_bitbang_configure(const struct spi_bitbang_config *info,
 		return -ENOTSUP;
 	}
 
-	if (config->operation & (SPI_LINES_DUAL | SPI_LINES_QUAD)) {
+	if (config->operation & (SPI_LINES_DUAL | SPI_LINES_QUAD | SPI_LINES_OCTAL)) {
 		LOG_ERR("Unsupported configuration");
 		return -ENOTSUP;
 	}


### PR DESCRIPTION
The SPI bitbang driver now supports LSB-first transfers. Additionally, when `SPI_LINES_OCTAL` flag is set, the driver will yield an error.

Transfer without `SPI_TRANSFER_LSB`:
![obraz](https://github.com/user-attachments/assets/ab662efe-5e54-4f00-abb5-bd5d35c7fd47)

Transfer with `SPI_TRANSFER_LSB` (the result of this pull request):
![obraz](https://github.com/user-attachments/assets/43d2076f-a47f-4cad-8e80-d673af2e508d)


