### PR TITLE
fix build error of including wrong common.h

### DIFF
--- a/drivers/wifi/nxp/CMakeLists.txt
+++ b/drivers/wifi/nxp/CMakeLists.txt
@@ -6,5 +6,5 @@ if (CONFIG_WIFI_NXP)
 zephyr_library_sources(nxp_wifi_drv.c)
 
 zephyr_library_sources_ifdef(CONFIG_NXP_WIFI_SHELL nxp_wifi_shell.c)
-
+zephyr_library_link_libraries_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT hostap)
 endif()

--- a/modules/hostap/CMakeLists.txt
+++ b/modules/hostap/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 if(CONFIG_WIFI_NM_WPA_SUPPLICANT)
 
-zephyr_library()
+zephyr_interface_library_named(hostap)
 
 set(HOSTAP_BASE ${ZEPHYR_HOSTAP_MODULE_DIR})
 set(WIFI_NM_WPA_SUPPLICANT_BASE ${HOSTAP_BASE}/wpa_supplicant)
@@ -21,7 +21,6 @@ zephyr_include_directories(
 	${HOSTAP_BASE}/
 	${WIFI_NM_WPA_SUPPLICANT_BASE}/
 	${HOSTAP_SRC_BASE}/
-	${HOSTAP_SRC_BASE}/utils/
 	${HOSTAP_SRC_BASE}/common/
 	${HOSTAP_SRC_BASE}/eap_common
 	${HOSTAP_SRC_BASE}/eap_server
@@ -30,6 +29,10 @@ zephyr_include_directories(
 	${HOSTAP_SRC_BASE}/ap/
 	${HOSTAP_SRC_BASE}/drivers/
 	${HOSTAP_SRC_BASE}/rsn_supp
+)
+
+target_include_directories(hostap INTERFACE
+	${HOSTAP_SRC_BASE}/utils/
 )
 
 zephyr_library_compile_definitions(


### PR DESCRIPTION
When build with the psa_crypto_driver, it will try to include common.h
of mbedtls, but actually include the common.h from hostap, and causes
build error of undefined symbol. Use zephyr_interface_library_named
to define hostap, and other modules needs to link the library of hostap
when wants to use the header file in /utils path, such as the common.h.