### PR TITLE
hostap: only add STA interface when hostapd enabled

### DIFF
--- a/modules/hostap/src/supp_main.c
+++ b/modules/hostap/src/supp_main.c
@@ -487,6 +487,12 @@ static void iface_cb(struct net_if *iface, void *user_data)
 		return;
 	}
 
+#ifdef CONFIG_WIFI_NM_HOSTAPD_AP
+	if (wifi_nm_iface_is_sap(iface)) {
+		return;
+	}
+#endif
+
 	if (!net_if_is_admin_up(iface)) {
 		return;
 	}


### PR DESCRIPTION
For add_interface(), only add STA interface when hostapd enabled, and the Soft-AP interface will be added in zephyr_hostapd_init().