### PR TITLE
arm/gicv3: set routing affinity before enable IRQ

### DIFF
--- a/drivers/interrupt_controller/intc_gicv3.c
+++ b/drivers/interrupt_controller/intc_gicv3.c
@@ -171,8 +171,6 @@ void arm_gic_irq_enable(unsigned int intid)
 	uint32_t mask = BIT(intid & (GIC_NUM_INTR_PER_REG - 1));
 	uint32_t idx = intid / GIC_NUM_INTR_PER_REG;
 
-	sys_write32(mask, ISENABLER(GET_DIST_BASE(intid), idx));
-
 #if defined(CONFIG_ARMV8_A_NS) || defined(CONFIG_GIC_SINGLE_SECURITY_STATE)
 	/*
 	 * Affinity routing is enabled for Armv8-A Non-secure state (GICD_CTLR.ARE_NS
@@ -183,6 +181,8 @@ void arm_gic_irq_enable(unsigned int intid)
 		arm_gic_write_irouter(MPIDR_TO_CORE(GET_MPIDR()), intid);
 	}
 #endif
+
+	sys_write32(mask, ISENABLER(GET_DIST_BASE(intid), idx));
 }
 
 void arm_gic_irq_disable(unsigned int intid)


### PR DESCRIPTION
arm/gicv3: set routing affinity before enable IRQ

In corner case, the pending ISR will be triggered immediately after enable the IRQ, this PR will setting CPU affinity first to avoid routing the unexpected IRQ to other CPUs.

Signed-off-by: chao an <anchao@lixiang.com>