### PR TITLE
hostap: fix SAP UDP RX low throughput in 5GHz

### DIFF
--- a/modules/hostap/src/supp_main.c
+++ b/modules/hostap/src/supp_main.c
@@ -874,6 +874,7 @@ struct hostapd_config *hostapd_config_read2(const char *fname)
 	conf->ht_op_mode_fixed  = 1;
 	conf->ieee80211ac       = 1;
 	conf->vht_oper_chwidth  = CHANWIDTH_USE_HT;
+	conf->vht_capab |= VHT_CAP_MAX_A_MPDU_LENGTH_EXPONENT_MAX;
 	conf->ieee80211ax       = 1;
 	conf->he_oper_chwidth   = CHANWIDTH_USE_HT;
 	conf->he_phy_capab.he_su_beamformer = 0;


### PR DESCRIPTION
The default Max A-MPDU length is 8191 shown in the VHT Cap Info from SAP's beacon/Assoc response, and this length is read from hapd->iface->conf->vht_capab. It will lead to the AMPDU only contains 5 packets and the throughput is only 60Mbps for 1x1 HE case in 5GHz. Change the default vht_capab to VHT_CAP_MAX_A_MPDU_LENGTH_EXPONENT_MAX (1048575), and the throughput can be increased to 83Mbps.