### PR TITLE
runners: jlink: Make port selectable for J-Link IP

### DIFF
--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -28,7 +28,7 @@ DEFAULT_JLINK_GDB_PORT = 2331
 
 def is_ip(ip):
     try:
-        ipaddress.ip_address(ip)
+        ipaddress.ip_address(ip.split(':')[0])
     except ValueError:
         return False
     return True


### PR DESCRIPTION
If multiple J-Links with IP support are used,
they can be selected with different ports.
The actual implementation is just using the default port. 
Make the port selectable with `<ip>:<port>`.