### PR TITLE
manifest: Update hostap to fix build error

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -259,7 +259,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: 7761b17eea9a2442af6ea9df830904fa4ba7bbca
+      revision: f3b848c4e576a519f7c5609caf800fa69d86fe69
     - name: libmetal
       revision: a6851ba6dba8c9e87d00c42f171a822f7a29639b
       path: modules/hal/libmetal


### PR DESCRIPTION
Fix build error when CONFIG_WIFI_NM_HOSTAPD_AP is enabled, should use the new API net_if_get_wifi_sap().