### PR TITLE
drivers: stm32: Make some config symbols menuconfig symbols

### DIFF
--- a/drivers/flash/Kconfig.stm32
+++ b/drivers/flash/Kconfig.stm32
@@ -16,7 +16,7 @@ config STM32_MEMMAP
 	  This option enables the XIP mode for the external NOR flash
 	  mounted on STM32 boards.
 
-config SOC_FLASH_STM32
+menuconfig SOC_FLASH_STM32
 	bool "STM32 flash driver"
 	depends on DT_HAS_ST_STM32_FLASH_CONTROLLER_ENABLED
 	select FLASH_HAS_DRIVER_ENABLED

--- a/drivers/pinctrl/Kconfig.stm32
+++ b/drivers/pinctrl/Kconfig.stm32
@@ -1,8 +1,8 @@
 # Copyright (c) 2021 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-config PINCTRL_STM32
-	bool
+menuconfig PINCTRL_STM32
+	bool "Pin controller driver for STM32 MCUs"
 	default y
 	depends on DT_HAS_ST_STM32_PINCTRL_ENABLED || DT_HAS_ST_STM32F1_PINCTRL_ENABLED
 	help

--- a/drivers/smbus/Kconfig
+++ b/drivers/smbus/Kconfig
@@ -77,7 +77,7 @@ config SMBUS_INTEL_PCH_SMBALERT
 
 endif # SMBUS_INTEL_PCH
 
-config SMBUS_STM32
+menuconfig SMBUS_STM32
 	bool "STM32 SMBus driver"
 	default y
 	depends on DT_HAS_ST_STM32_SMBUS_ENABLED

--- a/drivers/watchdog/Kconfig.stm32
+++ b/drivers/watchdog/Kconfig.stm32
@@ -5,7 +5,7 @@
 # Copyright (c) 2019 Centaur Analytics, Inc
 # SPDX-License-Identifier: Apache-2.0
 
-config IWDG_STM32
+menuconfig IWDG_STM32
 	bool "Independent Watchdog (IWDG) Driver for STM32 family of MCUs"
 	default y
 	depends on DT_HAS_ST_STM32_WATCHDOG_ENABLED


### PR DESCRIPTION
Move some STM32 drivers  related Kconfig symbols from `config` to `menuconfig` when driver options depends on these symbols.