### PR TITLE
manifest: mbedtls: update to 3.6.1

### DIFF
--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -299,6 +299,9 @@ Libraries / Subsystems
 
 * Crypto
 
+  * Mbed TLS was updated to version 3.6.1. The release notes can be found at:
+    https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.1
+
 * CMSIS-NN
 
 * FPGA

--- a/west.yml
+++ b/west.yml
@@ -280,7 +280,7 @@ manifest:
       revision: 2b498e6f36d6b82ae1da12c8b7742e318624ecf5
       path: modules/lib/gui/lvgl
     - name: mbedtls
-      revision: 2f24831ee13d399ce019c4632b0bcd440a713f7c
+      revision: fb36f3fe20f9f62e67b1a20c0cfe0a6788ec2bf6
       path: modules/crypto/mbedtls
       groups:
         - crypto


### PR DESCRIPTION
Brings in Mbed TLS 3.6.1.