### PR TITLE
Series of linker infrastructure cleanups and alignments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -385,6 +385,28 @@ toolchain_ld_force_undefined_symbols(
 if(NOT CONFIG_NATIVE_BUILD)
   # @Intent: Set linker specific flags for bare metal target
   toolchain_ld_baremetal()
+
+  zephyr_link_libraries(PROPERTY baremetal)
+
+  # Note that some architectures will skip this flag if set to error, even
+  # though the compiler flag check passes (e.g. ARC and Xtensa). So warning
+  # should be the default for now.
+  #
+  # Skip this for native application as Zephyr only provides
+  # additions to the host toolchain linker script. The relocation
+  # sections (.rel*) requires us to override those provided
+  # by host toolchain. As we can't account for all possible
+  # combination of compiler and linker on all machines used
+  # for development, it is better to turn this off.
+  #
+  # CONFIG_LINKER_ORPHAN_SECTION_PLACE is to place the orphan sections
+  # without any warnings or errors, which is the default behavior.
+  # So there is no need to explicitly set a linker flag.
+  if(CONFIG_LINKER_ORPHAN_SECTION_WARN)
+    zephyr_link_libraries(PROPERTY orphan_warning)
+  elseif(CONFIG_LINKER_ORPHAN_SECTION_ERROR)
+    zephyr_link_libraries(PROPERTY orphan_error)
+  endif()
 endif()
 
 if(CONFIG_CPP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,6 +363,20 @@ zephyr_compile_options(
 # @Intent: Set fundamental linker specific flags
 toolchain_ld_base()
 
+if(DEFINED TOOLCHAIN_LD_FLAGS)
+  zephyr_ld_options(${TOOLCHAIN_LD_FLAGS})
+endif()
+
+zephyr_link_libraries(PROPERTY base)
+
+zephyr_link_libraries_ifndef(CONFIG_LINKER_USE_RELAX PROPERTY no_relax)
+
+zephyr_link_libraries_ifdef(CONFIG_LINKER_USE_RELAX PROPERTY relax)
+
+# Sort the common symbols and each input section by alignment
+# in descending order to minimize padding between these symbols.
+zephyr_link_libraries_ifdef(CONFIG_LINKER_SORT_BY_ALIGNMENT PROPERTY sort_alignment)
+
 toolchain_ld_force_undefined_symbols(
   _OffsetAbsSyms
   _ConfigAbsSyms
@@ -373,9 +387,13 @@ if(NOT CONFIG_NATIVE_BUILD)
   toolchain_ld_baremetal()
 endif()
 
-if(CONFIG_CPP AND NOT CONFIG_MINIMAL_LIBCPP AND NOT CONFIG_NATIVE_LIBRARY)
-  # @Intent: Set linker specific flags for C++
-  toolchain_ld_cpp()
+if(CONFIG_CPP)
+  if(NOT CONFIG_MINIMAL_LIBCPP AND NOT CONFIG_NATIVE_LIBRARY)
+    # @Intent: Set linker specific flags for C++
+    toolchain_ld_cpp()
+  endif()
+
+  zephyr_link_libraries(PROPERTY cpp_base)
 endif()
 
 # @Intent: Add the basic toolchain warning flags

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,8 +360,7 @@ zephyr_compile_options(
   $<$<COMPILE_LANGUAGE:ASM>:-D_ASMLANGUAGE>
 )
 
-# @Intent: Set fundamental linker specific flags
-toolchain_ld_base()
+find_package(Deprecated COMPONENTS toolchain_ld_base)
 
 if(DEFINED TOOLCHAIN_LD_FLAGS)
   zephyr_ld_options(${TOOLCHAIN_LD_FLAGS})
@@ -383,8 +382,7 @@ toolchain_ld_force_undefined_symbols(
 )
 
 if(NOT CONFIG_NATIVE_BUILD)
-  # @Intent: Set linker specific flags for bare metal target
-  toolchain_ld_baremetal()
+  find_package(Deprecated COMPONENTS toolchain_ld_baremetal)
 
   zephyr_link_libraries(PROPERTY baremetal)
 
@@ -411,8 +409,7 @@ endif()
 
 if(CONFIG_CPP)
   if(NOT CONFIG_MINIMAL_LIBCPP AND NOT CONFIG_NATIVE_LIBRARY)
-    # @Intent: Set linker specific flags for C++
-    toolchain_ld_cpp()
+    find_package(Deprecated COMPONENTS toolchain_ld_cpp)
   endif()
 
   zephyr_link_libraries(PROPERTY cpp_base)

--- a/cmake/compiler/clang/target.cmake
+++ b/cmake/compiler/clang/target.cmake
@@ -83,11 +83,3 @@ if(NOT "${ARCH}" STREQUAL "posix")
   string(REPLACE ";" " " CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
 
 endif()
-
-# Load toolchain_cc-family macros
-
-macro(toolchain_cc_nostdinc)
-  if(NOT "${ARCH}" STREQUAL "posix")
-    zephyr_compile_options( -nostdinc)
-  endif()
-endmacro()

--- a/cmake/compiler/icx/target.cmake
+++ b/cmake/compiler/icx/target.cmake
@@ -63,11 +63,6 @@ endif()
 set(CMAKE_REQUIRED_FLAGS -nostartfiles -nostdlib ${isystem_include_flags})
 string(REPLACE ";" " " CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
 
-# Load toolchain_cc-family macros
-macro(toolchain_cc_nostdinc)
-    zephyr_compile_options( -nostdinc)
-endmacro()
-
 if(CONFIG_CPP)
   list(APPEND TOOLCHAIN_C_FLAGS "-no-intel-lib=libirc")
 endif()

--- a/cmake/linker/arcmwdt/linker_flags.cmake
+++ b/cmake/linker/arcmwdt/linker_flags.cmake
@@ -1,4 +1,10 @@
+# Copyright (c) 2024 Nordic Semiconductor
+#
 # SPDX-License-Identifier: Apache-2.0
+
+set_property(TARGET linker PROPERTY cpp_base -Hcplus)
 
 # Extra warnings options for twister run
 set_property(TARGET linker PROPERTY warnings_as_errors -Wl,--fatal-warnings)
+
+check_set_linker_property(TARGET linker PROPERTY sort_alignment -Wl,--sort-section=alignment)

--- a/cmake/linker/arcmwdt/linker_flags.cmake
+++ b/cmake/linker/arcmwdt/linker_flags.cmake
@@ -4,6 +4,38 @@
 
 set_property(TARGET linker PROPERTY cpp_base -Hcplus)
 
+check_set_linker_property(TARGET linker PROPERTY baremetal
+                          -Hlld
+                          -Hnosdata
+                          -Xtimer0 # to suppress the warning message
+                          -Hnoxcheck_obj
+                          -Hnocplus
+                          -Hhostlib=
+                          -Hheap=0
+                          -Hnoivt
+                          -Hnocrt
+)
+
+# There are two options:
+# - We have full MWDT libc support and we link MWDT libc - this is default
+#   behavior and we don't need to do something for that.
+# - We use minimal libc provided by Zephyr itself. In that case we must not
+#   link MWDT libc, but we still need to link libmw
+if(CONFIG_MINIMAL_LIBC)
+  check_set_linker_property(TARGET linker APPEND PROPERTY baremetal
+                            -Hnolib
+                            -Hldopt=-lmw
+  )
+endif()
+
+check_set_linker_property(TARGET linker PROPERTY orphan_warning
+                          ${LINKERFLAGPREFIX},--orphan-handling=warn
+)
+
+check_set_linker_property(TARGET linker PROPERTY orphan_error
+                          ${LINKERFLAGPREFIX},--orphan-handling=error
+)
+
 # Extra warnings options for twister run
 set_property(TARGET linker PROPERTY warnings_as_errors -Wl,--fatal-warnings)
 

--- a/cmake/linker/arcmwdt/target.cmake
+++ b/cmake/linker/arcmwdt/target.cmake
@@ -30,7 +30,6 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
   endif()
 
   zephyr_get_include_directories_for_lang(C current_includes)
-  get_property(current_defines GLOBAL PROPERTY PROPERTY_LINKER_SCRIPT_DEFINES)
 
 # the command to generate linker file from template
   add_custom_command(
@@ -48,9 +47,9 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
     -MD -MF ${linker_script_gen}.dep -MT ${linker_script_gen}
     -D_LINKER
     -D_ASMLANGUAGE
+    -D__MWDT_LINKER_CMD__
     -imacros ${AUTOCONF_H}
     ${current_includes}
-    ${current_defines}
     ${template_script_defines}
     ${LINKER_SCRIPT}
     -E
@@ -160,10 +159,6 @@ endmacro()
 
 # base linker options
 macro(toolchain_ld_base)
-  if(NOT PROPERTY_LINKER_SCRIPT_DEFINES)
-    set_property(GLOBAL PROPERTY PROPERTY_LINKER_SCRIPT_DEFINES -D__MWDT_LINKER_CMD__)
-  endif()
-
   # Sort the common symbols and each input section by alignment
   # in descending order to minimize padding between these symbols.
   zephyr_ld_option_ifdef(

--- a/cmake/linker/arcmwdt/target.cmake
+++ b/cmake/linker/arcmwdt/target.cmake
@@ -110,51 +110,6 @@ endfunction(toolchain_ld_link_elf)
 
 # linker options of temporary linkage for code generation
 macro(toolchain_ld_baremetal)
-  zephyr_ld_options(
-    -Hlld
-    -Hnosdata
-    -Xtimer0 # to suppress the warning message
-    -Hnoxcheck_obj
-    -Hnocplus
-    -Hhostlib=
-    -Hheap=0
-    -Hnoivt
-    -Hnocrt
-  )
-
-  # There are two options:
-  # - We have full MWDT libc support and we link MWDT libc - this is default
-  #   behavior and we don't need to do something for that.
-  # - We use minimal libc provided by Zephyr itself. In that case we must not
-  #   link MWDT libc, but we still need to link libmw
-  if(CONFIG_MINIMAL_LIBC)
-    zephyr_ld_options(
-      -Hnolib
-      -Hldopt=-lmw
-    )
-  endif()
-
-  # Funny thing is if this is set to =error, some architectures will
-  # skip this flag even though the compiler flag check passes
-  # (e.g. ARC and Xtensa). So warning should be the default for now.
-  #
-  # Skip this for native application as Zephyr only provides
-  # additions to the host toolchain linker script. The relocation
-  # sections (.rel*) requires us to override those provided
-  # by host toolchain. As we can't account for all possible
-  # combination of compiler and linker on all machines used
-  # for development, it is better to turn this off.
-  #
-  # CONFIG_LINKER_ORPHAN_SECTION_PLACE is to place the orphan sections
-  # without any warnings or errors, which is the default behavior.
-  # So there is no need to explicitly set a linker flag.
-  if(CONFIG_LINKER_ORPHAN_SECTION_WARN)
-    message(WARNING "MWDT toolchain does not support
-           CONFIG_LINKER_ORPHAN_SECTION_WARN")
-  elseif(CONFIG_LINKER_ORPHAN_SECTION_ERROR)
-    zephyr_ld_options(
-      ${LINKERFLAGPREFIX}--orphan-handling=error)
-  endif()
 endmacro()
 
 # base linker options

--- a/cmake/linker/arcmwdt/target.cmake
+++ b/cmake/linker/arcmwdt/target.cmake
@@ -159,12 +159,6 @@ endmacro()
 
 # base linker options
 macro(toolchain_ld_base)
-  # Sort the common symbols and each input section by alignment
-  # in descending order to minimize padding between these symbols.
-  zephyr_ld_option_ifdef(
-    CONFIG_LINKER_SORT_BY_ALIGNMENT
-    ${LINKERFLAGPREFIX}--sort-section=alignment
-  )
 endmacro()
 
 # generate linker script snippets from configure files
@@ -188,9 +182,6 @@ endmacro()
 
 # link C++ libraries
 macro(toolchain_ld_cpp)
-  zephyr_link_libraries(
-    -Hcplus
-  )
 endmacro()
 
 # use linker for relocation

--- a/cmake/linker/armlink/target.cmake
+++ b/cmake/linker/armlink/target.cmake
@@ -6,17 +6,11 @@ find_program(CMAKE_LINKER ${CROSS_COMPILE}armlink PATHS ${TOOLCHAIN_HOME} NO_DEF
 
 add_custom_target(armlink)
 
-macro(toolchain_ld_base)
-endmacro()
-
 function(toolchain_ld_force_undefined_symbols)
   foreach(symbol ${ARGN})
     zephyr_link_libraries(--undefined=${symbol})
   endforeach()
 endfunction()
-
-macro(toolchain_ld_baremetal)
-endmacro()
 
 macro(configure_linker_script linker_script_gen linker_pass_define)
   set(STEERING_FILE)
@@ -114,6 +108,5 @@ function(toolchain_ld_link_elf)
   )
 endfunction(toolchain_ld_link_elf)
 
-include(${ZEPHYR_BASE}/cmake/linker/ld/target_cpp.cmake)
 include(${ZEPHYR_BASE}/cmake/linker/ld/target_relocation.cmake)
 include(${ZEPHYR_BASE}/cmake/linker/ld/target_configure.cmake)

--- a/cmake/linker/ld/clang/linker_flags.cmake
+++ b/cmake/linker/ld/clang/linker_flags.cmake
@@ -6,4 +6,10 @@ elseif(CONFIG_COVERAGE_NATIVE_SOURCE)
 endif()
 
 # Extra warnings options for twister run
-set_property(TARGET linker PROPERTY ld_extra_warning_options -Wl,--fatal-warnings)
+set_property(TARGET linker PROPERTY ld_extra_warning_options ${LINKERFLAGPREFIX},--fatal-warnings)
+
+# GNU ld and LLVM lld complains when used with llvm/clang:
+#   error: section: init_array is not contiguous with other relro sections
+#
+# So do not create RELRO program header.
+set_property(TARGET linker APPEND PROPERTY cpp_base ${LINKERFLAGPREFIX},-z,norelro)

--- a/cmake/linker/ld/linker_flags.cmake
+++ b/cmake/linker/ld/linker_flags.cmake
@@ -1,3 +1,16 @@
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: Apache-2.0
+
+check_set_linker_property(TARGET linker PROPERTY base
+                          ${LINKERFLAGPREFIX},--gc-sections
+                          ${LINKERFLAGPREFIX},--build-id=none
+)
+
+if(NOT CONFIG_MINIMAL_LIBCPP AND NOT CONFIG_NATIVE_LIBRARY AND NOT CONFIG_EXTERNAL_MODULE_LIBCPP)
+  set_property(TARGET linker PROPERTY cpp_base -lstdc++)
+endif()
+
 check_set_linker_property(TARGET linker PROPERTY memusage "${LINKERFLAGPREFIX},--print-memory-usage")
 
 # -no-pie is not supported until binutils 2.37.
@@ -13,6 +26,13 @@ endif()
 set_property(TARGET linker PROPERTY partial_linking "-r")
 
 set_property(TARGET linker PROPERTY lto_arguments -flto -fno-ipa-sra -ffunction-sections -fdata-sections)
+
+check_set_linker_property(TARGET linker PROPERTY no_relax ${LINKERFLAGPREFIX},--no-relax)
+
+check_set_linker_property(TARGET linker PROPERTY sort_alignment
+                          ${LINKERFLAGPREFIX},--sort-common=descending
+                          ${LINKERFLAGPREFIX},--sort-section=alignment
+)
 
 # Some linker flags might not be purely ld specific, but a combination of
 # linker and compiler, such as:

--- a/cmake/linker/ld/linker_flags.cmake
+++ b/cmake/linker/ld/linker_flags.cmake
@@ -11,6 +11,21 @@ if(NOT CONFIG_MINIMAL_LIBCPP AND NOT CONFIG_NATIVE_LIBRARY AND NOT CONFIG_EXTERN
   set_property(TARGET linker PROPERTY cpp_base -lstdc++)
 endif()
 
+check_set_linker_property(TARGET linker PROPERTY baremetal
+                          -nostdlib
+                          -static
+                          ${LINKERFLAGPREFIX},-X
+                          ${LINKERFLAGPREFIX},-N
+)
+
+check_set_linker_property(TARGET linker PROPERTY orphan_warning
+                          ${LINKERFLAGPREFIX},--orphan-handling=warn
+)
+
+check_set_linker_property(TARGET linker PROPERTY orphan_error
+                          ${LINKERFLAGPREFIX},--orphan-handling=error
+)
+
 check_set_linker_property(TARGET linker PROPERTY memusage "${LINKERFLAGPREFIX},--print-memory-usage")
 
 # -no-pie is not supported until binutils 2.37.

--- a/cmake/linker/ld/target.cmake
+++ b/cmake/linker/ld/target.cmake
@@ -56,7 +56,6 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
     endif()
 
     zephyr_get_include_directories_for_lang(C current_includes)
-    get_property(current_defines GLOBAL PROPERTY PROPERTY_LINKER_SCRIPT_DEFINES)
     if(DEFINED SOC_LINKER_SCRIPT)
       cmake_path(GET SOC_LINKER_SCRIPT PARENT_PATH soc_linker_script_includes)
       set(soc_linker_script_includes -I${soc_linker_script_includes})
@@ -76,10 +75,10 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
       -MD -MF ${linker_script_gen}.dep -MT ${linker_script_gen}
       -D_LINKER
       -D_ASMLANGUAGE
+      -D__GCC_LINKER_CMD__
       -imacros ${AUTOCONF_H}
       ${current_includes}
       ${soc_linker_script_includes}
-      ${current_defines}
       ${template_script_defines}
       -E ${LINKER_SCRIPT}
       -P # Prevent generation of debug `#line' directives.

--- a/cmake/linker/ld/target.cmake
+++ b/cmake/linker/ld/target.cmake
@@ -146,8 +146,5 @@ function(toolchain_ld_link_elf)
 endfunction(toolchain_ld_link_elf)
 
 # Load toolchain_ld-family macros
-include(${ZEPHYR_BASE}/cmake/linker/${LINKER}/target_base.cmake)
-include(${ZEPHYR_BASE}/cmake/linker/${LINKER}/target_baremetal.cmake)
-include(${ZEPHYR_BASE}/cmake/linker/${LINKER}/target_cpp.cmake)
 include(${ZEPHYR_BASE}/cmake/linker/${LINKER}/target_relocation.cmake)
 include(${ZEPHYR_BASE}/cmake/linker/${LINKER}/target_configure.cmake)

--- a/cmake/linker/ld/target_baremetal.cmake
+++ b/cmake/linker/ld/target_baremetal.cmake
@@ -3,37 +3,4 @@
 # See root CMakeLists.txt for description and expectations of these macros
 
 macro(toolchain_ld_baremetal)
-
-  # LINKERFLAGPREFIX comes from linker/ld/target.cmake
-  zephyr_ld_options(
-    -nostdlib
-    -static
-    ${LINKERFLAGPREFIX},-X
-    ${LINKERFLAGPREFIX},-N
-  )
-
-  # Funny thing is if this is set to =error, some architectures will
-  # skip this flag even though the compiler flag check passes
-  # (e.g. ARC and Xtensa). So warning should be the default for now.
-  #
-  # Skip this for native application as Zephyr only provides
-  # additions to the host toolchain linker script. The relocation
-  # sections (.rel*) requires us to override those provided
-  # by host toolchain. As we can't account for all possible
-  # combination of compiler and linker on all machines used
-  # for development, it is better to turn this off.
-  #
-  # CONFIG_LINKER_ORPHAN_SECTION_PLACE is to place the orphan sections
-  # without any warnings or errors, which is the default behavior.
-  # So there is no need to explicitly set a linker flag.
-  if(CONFIG_LINKER_ORPHAN_SECTION_WARN)
-    zephyr_ld_options(
-      ${LINKERFLAGPREFIX},--orphan-handling=warn
-    )
-  elseif(CONFIG_LINKER_ORPHAN_SECTION_ERROR)
-    zephyr_ld_options(
-      ${LINKERFLAGPREFIX},--orphan-handling=error
-    )
-  endif()
-
 endmacro()

--- a/cmake/linker/ld/target_baremetal.cmake
+++ b/cmake/linker/ld/target_baremetal.cmake
@@ -1,6 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# See root CMakeLists.txt for description and expectations of these macros
-
-macro(toolchain_ld_baremetal)
-endmacro()

--- a/cmake/linker/ld/target_base.cmake
+++ b/cmake/linker/ld/target_base.cmake
@@ -3,39 +3,4 @@
 # See root CMakeLists.txt for description and expectations of these macros
 
 macro(toolchain_ld_base)
-  # TOOLCHAIN_LD_FLAGS comes from compiler/gcc/target.cmake
-  # LINKERFLAGPREFIX comes from linker/ld/target.cmake
-  zephyr_ld_options(
-    ${TOOLCHAIN_LD_FLAGS}
-  )
-
-  zephyr_ld_options(
-    ${LINKERFLAGPREFIX},--gc-sections
-    ${LINKERFLAGPREFIX},--build-id=none
-  )
-
-  # Sort the common symbols and each input section by alignment
-  # in descending order to minimize padding between these symbols.
-  zephyr_ld_option_ifdef(
-    CONFIG_LINKER_SORT_BY_ALIGNMENT
-    ${LINKERFLAGPREFIX},--sort-common=descending
-    ${LINKERFLAGPREFIX},--sort-section=alignment
-  )
-
-  if (NOT CONFIG_LINKER_USE_RELAX)
-    zephyr_ld_options(
-      ${LINKERFLAGPREFIX},--no-relax
-    )
-  endif()
-
-  if(CONFIG_CPP AND (CMAKE_C_COMPILER_ID STREQUAL "Clang"))
-    # GNU ld complains when used with llvm/clang:
-    #   error: section: init_array is not contiguous with other relro sections
-    #
-    # So do not create RELRO program header.
-    zephyr_link_libraries(
-      -Wl,-z,norelro
-    )
-  endif()
-
 endmacro()

--- a/cmake/linker/ld/target_base.cmake
+++ b/cmake/linker/ld/target_base.cmake
@@ -28,18 +28,6 @@ macro(toolchain_ld_base)
     )
   endif()
 
-  if (CONFIG_LLVM_USE_LD)
-    if(CONFIG_LIBGCC_RTLIB)
-      set(runtime_lib "libgcc")
-    elseif(CONFIG_COMPILER_RT_RTLIB)
-      set(runtime_lib "compiler_rt")
-    endif()
-
-    zephyr_link_libraries(
-      --config ${ZEPHYR_BASE}/cmake/toolchain/llvm/clang_${runtime_lib}.cfg
-    )
-  endif()
-
   if(CONFIG_CPP AND (CMAKE_C_COMPILER_ID STREQUAL "Clang"))
     # GNU ld complains when used with llvm/clang:
     #   error: section: init_array is not contiguous with other relro sections

--- a/cmake/linker/ld/target_base.cmake
+++ b/cmake/linker/ld/target_base.cmake
@@ -1,6 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# See root CMakeLists.txt for description and expectations of these macros
-
-macro(toolchain_ld_base)
-endmacro()

--- a/cmake/linker/ld/target_base.cmake
+++ b/cmake/linker/ld/target_base.cmake
@@ -3,11 +3,6 @@
 # See root CMakeLists.txt for description and expectations of these macros
 
 macro(toolchain_ld_base)
-
-  if(NOT PROPERTY_LINKER_SCRIPT_DEFINES)
-    set_property(GLOBAL PROPERTY PROPERTY_LINKER_SCRIPT_DEFINES -D__GCC_LINKER_CMD__)
-  endif()
-
   # TOOLCHAIN_LD_FLAGS comes from compiler/gcc/target.cmake
   # LINKERFLAGPREFIX comes from linker/ld/target.cmake
   zephyr_ld_options(

--- a/cmake/linker/ld/target_cpp.cmake
+++ b/cmake/linker/ld/target_cpp.cmake
@@ -1,6 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# See root CMakeLists.txt for description and expectations of these macros
-
-macro(toolchain_ld_cpp)
-endmacro()

--- a/cmake/linker/ld/target_cpp.cmake
+++ b/cmake/linker/ld/target_cpp.cmake
@@ -3,11 +3,4 @@
 # See root CMakeLists.txt for description and expectations of these macros
 
 macro(toolchain_ld_cpp)
-
-  if(NOT CONFIG_EXTERNAL_MODULE_LIBCPP)
-    zephyr_link_libraries(
-      -lstdc++
-    )
-  endif()
-
 endmacro()

--- a/cmake/linker/linker_flags_template.cmake
+++ b/cmake/linker/linker_flags_template.cmake
@@ -11,6 +11,13 @@ set_property(TARGET linker PROPERTY base)
 # using C++.
 set_property(TARGET linker PROPERTY cpp_base)
 
+# Base properties when building Zephyr for an embedded target (baremetal).
+set_property(TARGET linker PROPERTY baremetal)
+
+# Property for controlling linker reporting / handling when placing orphaned sections.
+set_property(TARGET linker PROPERTY orphan_warning)
+set_property(TARGET linker PROPERTY orphan_error)
+
 # coverage is a property holding the linker flag required for coverage support on the toolchain.
 # For example, on ld/gcc this would be: -lgcov
 # Set the property for the corresponding flags of the given toolchain.

--- a/cmake/linker/linker_flags_template.cmake
+++ b/cmake/linker/linker_flags_template.cmake
@@ -1,3 +1,16 @@
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Base properties.
+# Basic linker properties which should always be applied for a Zephyr build.
+set_property(TARGET linker PROPERTY base)
+
+# Base properties when C++ support is enabled.
+# Basic linker properties which should always be applied for a Zephyr build
+# using C++.
+set_property(TARGET linker PROPERTY cpp_base)
+
 # coverage is a property holding the linker flag required for coverage support on the toolchain.
 # For example, on ld/gcc this would be: -lgcov
 # Set the property for the corresponding flags of the given toolchain.
@@ -20,3 +33,12 @@ set_property(TARGET linker PROPERTY no_position_independent)
 # Linker flag for doing partial linking
 # such as, "-r" or "--relocatable" for LD and LLD.
 set_property(TARGET linker PROPERTY partial_linking)
+
+# Linker flag for section sorting by alignment
+set_property(TARGET linker PROPERTY sort_alignment)
+
+# Linker flag for disabling relaxation of address optimization for jump calls.
+set_property(TARGET linker PROPERTY no_relax)
+
+# Linker flag for enabling relaxation of address optimization for jump calls.
+set_property(TARGET linker PROPERTY relax)

--- a/cmake/linker/lld/linker_flags.cmake
+++ b/cmake/linker/lld/linker_flags.cmake
@@ -1,11 +1,20 @@
 # Copyright (c) 2022 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
-# Since lld is a drop in replacement for ld, we can just use ld's flags
-include(${ZEPHYR_BASE}/cmake/linker/ld/${COMPILER}/linker_flags.cmake OPTIONAL)
+# Since lld is a drop in replacement for ld, we can just use ld's flags as a base
+# and adjust for lld specifics afterwards.
+include(${ZEPHYR_BASE}/cmake/linker/ld/linker_flags.cmake OPTIONAL)
 
-check_set_linker_property(TARGET linker PROPERTY memusage "${LINKERFLAGPREFIX},--print-memory-usage")
+if(NOT CONFIG_MINIMAL_LIBCPP AND NOT CONFIG_NATIVE_LIBRARY AND NOT CONFIG_EXTERNAL_MODULE_LIBCPP)
+  set_property(TARGET linker PROPERTY cpp_base -lc++ ${LINKERFLAGPREFIX},-z,norelro)
+endif()
 
 set_property(TARGET linker PROPERTY no_position_independent "${LINKERFLAGPREFIX},--no-pie")
 
-set_property(TARGET linker PROPERTY partial_linking "-r")
+set_property(TARGET linker PROPERTY lto_arguments)
+
+check_set_linker_property(TARGET linker PROPERTY sort_alignment ${LINKERFLAGPREFIX},--sort-section=alignment)
+
+if(CONFIG_RISCV_GP)
+  check_set_linker_property(TARGET linker PROPERTY relax ${LINKERFLAGPREFIX},--relax-gp)
+endif()

--- a/cmake/linker/lld/linker_flags.cmake
+++ b/cmake/linker/lld/linker_flags.cmake
@@ -9,6 +9,11 @@ if(NOT CONFIG_MINIMAL_LIBCPP AND NOT CONFIG_NATIVE_LIBRARY AND NOT CONFIG_EXTERN
   set_property(TARGET linker PROPERTY cpp_base -lc++ ${LINKERFLAGPREFIX},-z,norelro)
 endif()
 
+# Force LLVM to use built-in lld linker
+if(NOT CONFIG_LLVM_USE_LD)
+  check_set_linker_property(TARGET linker APPEND PROPERTY baremetal -fuse-ld=lld)
+endif()
+
 set_property(TARGET linker PROPERTY no_position_independent "${LINKERFLAGPREFIX},--no-pie")
 
 set_property(TARGET linker PROPERTY lto_arguments)

--- a/cmake/linker/lld/target.cmake
+++ b/cmake/linker/lld/target.cmake
@@ -30,7 +30,6 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
   endif()
 
   zephyr_get_include_directories_for_lang(C current_includes)
-  get_property(current_defines GLOBAL PROPERTY PROPERTY_LINKER_SCRIPT_DEFINES)
 
   add_custom_command(
     OUTPUT ${linker_script_gen}
@@ -45,9 +44,9 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
     -MD -MF ${linker_script_gen}.dep -MT ${linker_script_gen}
     -D_LINKER
     -D_ASMLANGUAGE
+    -D__LLD_LINKER_CMD__
     -imacros ${AUTOCONF_H}
     ${current_includes}
-    ${current_defines}
     ${template_script_defines}
     -E ${LINKER_SCRIPT}
     -P # Prevent generation of debug `#line' directives.

--- a/cmake/linker/lld/target.cmake
+++ b/cmake/linker/lld/target.cmake
@@ -107,8 +107,5 @@ endfunction(toolchain_ld_link_elf)
 
 
 # Load toolchain_ld-family macros
-include(${ZEPHYR_BASE}/cmake/linker/${LINKER}/target_base.cmake)
-include(${ZEPHYR_BASE}/cmake/linker/${LINKER}/target_baremetal.cmake)
-include(${ZEPHYR_BASE}/cmake/linker/${LINKER}/target_cpp.cmake)
 include(${ZEPHYR_BASE}/cmake/linker/ld/target_relocation.cmake)
 include(${ZEPHYR_BASE}/cmake/linker/ld/target_configure.cmake)

--- a/cmake/linker/lld/target_baremetal.cmake
+++ b/cmake/linker/lld/target_baremetal.cmake
@@ -1,6 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# See root CMakeLists.txt for description and expectations of these macros
-
-macro(toolchain_ld_baremetal)
-endmacro()

--- a/cmake/linker/lld/target_baremetal.cmake
+++ b/cmake/linker/lld/target_baremetal.cmake
@@ -3,44 +3,4 @@
 # See root CMakeLists.txt for description and expectations of these macros
 
 macro(toolchain_ld_baremetal)
-
-  # LINKERFLAGPREFIX comes from linker/lld/target.cmake
-  zephyr_ld_options(
-    -nostdlib
-    -static
-    ${LINKERFLAGPREFIX},-X
-    ${LINKERFLAGPREFIX},-N
-  )
-
-  # Force LLVM to use built-in lld linker
-  if(NOT CONFIG_LLVM_USE_LD)
-    zephyr_ld_options(
-      -fuse-ld=lld
-  )
-  endif()
-
-  # Funny thing is if this is set to =error, some architectures will
-  # skip this flag even though the compiler flag check passes
-  # (e.g. ARC and Xtensa). So warning should be the default for now.
-  #
-  # Skip this for native application as Zephyr only provides
-  # additions to the host toolchain linker script. The relocation
-  # sections (.rel*) requires us to override those provided
-  # by host toolchain. As we can't account for all possible
-  # combination of compiler and linker on all machines used
-  # for development, it is better to turn this off.
-  #
-  # CONFIG_LINKER_ORPHAN_SECTION_PLACE is to place the orphan sections
-  # without any warnings or errors, which is the default behavior.
-  # So there is no need to explicitly set a linker flag.
-  if(CONFIG_LINKER_ORPHAN_SECTION_WARN)
-    zephyr_ld_options(
-      ${LINKERFLAGPREFIX},--orphan-handling=warn
-    )
-  elseif(CONFIG_LINKER_ORPHAN_SECTION_ERROR)
-    zephyr_ld_options(
-      ${LINKERFLAGPREFIX},--orphan-handling=error
-    )
-  endif()
-
 endmacro()

--- a/cmake/linker/lld/target_base.cmake
+++ b/cmake/linker/lld/target_base.cmake
@@ -3,11 +3,6 @@
 # See root CMakeLists.txt for description and expectations of these macros
 
 macro(toolchain_ld_base)
-
-  if(NOT PROPERTY_LINKER_SCRIPT_DEFINES)
-    set_property(GLOBAL PROPERTY PROPERTY_LINKER_SCRIPT_DEFINES -D__LLD_LINKER_CMD__)
-  endif()
-
   # TOOLCHAIN_LD_FLAGS comes from compiler/clang/target.cmake
   # LINKERFLAGPREFIX comes from linker/lld/target.cmake
   zephyr_ld_options(

--- a/cmake/linker/lld/target_base.cmake
+++ b/cmake/linker/lld/target_base.cmake
@@ -43,14 +43,4 @@ macro(toolchain_ld_base)
       -Wl,-z,norelro
     )
   endif()
-
-  if(CONFIG_LIBGCC_RTLIB)
-    set(runtime_lib "libgcc")
-  elseif(CONFIG_COMPILER_RT_RTLIB)
-    set(runtime_lib "compiler_rt")
-  endif()
-
-  zephyr_link_libraries(
-    --config ${ZEPHYR_BASE}/cmake/toolchain/llvm/clang_${runtime_lib}.cfg
-  )
 endmacro()

--- a/cmake/linker/lld/target_base.cmake
+++ b/cmake/linker/lld/target_base.cmake
@@ -1,6 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# See root CMakeLists.txt for description and expectations of these macros
-
-macro(toolchain_ld_base)
-endmacro()

--- a/cmake/linker/lld/target_base.cmake
+++ b/cmake/linker/lld/target_base.cmake
@@ -3,44 +3,4 @@
 # See root CMakeLists.txt for description and expectations of these macros
 
 macro(toolchain_ld_base)
-  # TOOLCHAIN_LD_FLAGS comes from compiler/clang/target.cmake
-  # LINKERFLAGPREFIX comes from linker/lld/target.cmake
-  zephyr_ld_options(
-    ${TOOLCHAIN_LD_FLAGS}
-  )
-
-  zephyr_ld_options(
-    ${LINKERFLAGPREFIX},--gc-sections
-    ${LINKERFLAGPREFIX},--build-id=none
-  )
-
-  # Sort each input section by alignment.
-  zephyr_ld_option_ifdef(
-    CONFIG_LINKER_SORT_BY_ALIGNMENT
-    ${LINKERFLAGPREFIX},--sort-section=alignment
-  )
-
-  if (NOT CONFIG_LINKER_USE_RELAX)
-    zephyr_ld_options(
-      ${LINKERFLAGPREFIX},--no-relax
-    )
-  endif()
-
-  # Global pointer relaxation is off by default in lld. Explicitly enable it if
-  # linker relaxations and gp usage are both allowed.
-  if (CONFIG_LINKER_USE_RELAX AND CONFIG_RISCV_GP)
-    zephyr_ld_options(
-      ${LINKERFLAGPREFIX},--relax-gp
-    )
-  endif()
-
-  if(CONFIG_CPP)
-    # LLVM lld complains:
-    #   error: section: init_array is not contiguous with other relro sections
-    #
-    # So do not create RELRO program header.
-    zephyr_link_libraries(
-      -Wl,-z,norelro
-    )
-  endif()
 endmacro()

--- a/cmake/linker/lld/target_cpp.cmake
+++ b/cmake/linker/lld/target_cpp.cmake
@@ -1,6 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# See root CMakeLists.txt for description and expectations of these macros
-
-macro(toolchain_ld_cpp)
-endmacro()

--- a/cmake/linker/lld/target_cpp.cmake
+++ b/cmake/linker/lld/target_cpp.cmake
@@ -3,9 +3,4 @@
 # See root CMakeLists.txt for description and expectations of these macros
 
 macro(toolchain_ld_cpp)
-
-  zephyr_link_libraries(
-    -lc++
-  )
-
 endmacro()

--- a/cmake/linker/xt-ld/linker_flags.cmake
+++ b/cmake/linker/xt-ld/linker_flags.cmake
@@ -11,6 +11,21 @@ if(NOT CONFIG_MINIMAL_LIBCPP AND NOT CONFIG_NATIVE_LIBRARY AND NOT CONFIG_EXTERN
   set_property(TARGET linker PROPERTY cpp_base -lstdc++)
 endif()
 
+check_set_linker_property(TARGET linker PROPERTY baremetal
+    -nostdlib
+    -static
+    ${LINKERFLAGPREFIX},-X
+    ${LINKERFLAGPREFIX},-N
+)
+
+check_set_linker_property(TARGET linker PROPERTY orphan_warning
+			  ${LINKERFLAGPREFIX},--orphan-handling=warn
+)
+
+check_set_linker_property(TARGET linker PROPERTY orphan_error
+			  ${LINKERFLAGPREFIX},--orphan-handling=error
+)
+
 set_property(TARGET linker PROPERTY partial_linking "-r")
 
 check_set_linker_property(TARGET linker PROPERTY no_relax ${LINKERFLAGPREFIX},--no-relax)

--- a/cmake/linker/xt-ld/linker_flags.cmake
+++ b/cmake/linker/xt-ld/linker_flags.cmake
@@ -1,3 +1,21 @@
+# Copyright (c) 2024 Nordic Semiconductor
+#
 # SPDX-License-Identifier: Apache-2.0
 
+check_set_linker_property(TARGET linker PROPERTY base
+                          ${LINKERFLAGPREFIX},--gc-sections
+                          ${LINKERFLAGPREFIX},--build-id=none
+)
+
+if(NOT CONFIG_MINIMAL_LIBCPP AND NOT CONFIG_NATIVE_LIBRARY AND NOT CONFIG_EXTERNAL_MODULE_LIBCPP)
+  set_property(TARGET linker PROPERTY cpp_base -lstdc++)
+endif()
+
 set_property(TARGET linker PROPERTY partial_linking "-r")
+
+check_set_linker_property(TARGET linker PROPERTY no_relax ${LINKERFLAGPREFIX},--no-relax)
+)
+check_set_linker_property(TARGET linker PROPERTY sort_alignment
+                          ${LINKERFLAGPREFIX},--sort-common=descending
+                          ${LINKERFLAGPREFIX},--sort-section=alignment
+)

--- a/cmake/linker/xt-ld/target.cmake
+++ b/cmake/linker/xt-ld/target.cmake
@@ -139,8 +139,5 @@ endfunction(toolchain_ld_link_elf)
 
 # xt-ld is Xtensa's own version of binutils' ld.
 # So we can reuse most of the ld configurations.
-include(${ZEPHYR_BASE}/cmake/linker/${LINKER}/target_base.cmake)
-include(${ZEPHYR_BASE}/cmake/linker/ld/target_baremetal.cmake)
-include(${ZEPHYR_BASE}/cmake/linker/ld/target_cpp.cmake)
 include(${ZEPHYR_BASE}/cmake/linker/ld/target_relocation.cmake)
 include(${ZEPHYR_BASE}/cmake/linker/ld/target_configure.cmake)

--- a/cmake/linker/xt-ld/target.cmake
+++ b/cmake/linker/xt-ld/target.cmake
@@ -59,7 +59,6 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
     endif()
 
     zephyr_get_include_directories_for_lang(C current_includes)
-    get_property(current_defines GLOBAL PROPERTY PROPERTY_LINKER_SCRIPT_DEFINES)
 
     add_custom_command(
       OUTPUT ${linker_script_gen}
@@ -75,9 +74,9 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
       -MD -MF ${linker_script_gen}.dep -MT ${linker_script_gen}
       -D_LINKER
       -D_ASMLANGUAGE
+      -D__GCC_LINKER_CMD__
       -imacros ${AUTOCONF_H}
       ${current_includes}
-      ${current_defines}
       ${template_script_defines}
       -E ${LINKER_SCRIPT}
       -P # Prevent generation of debug `#line' directives.

--- a/cmake/linker/xt-ld/target_base.cmake
+++ b/cmake/linker/xt-ld/target_base.cmake
@@ -3,29 +3,4 @@
 # See root CMakeLists.txt for description and expectations of these macros
 
 macro(toolchain_ld_base)
-  # TOOLCHAIN_LD_FLAGS comes from compiler/gcc/target.cmake
-  # LINKERFLAGPREFIX comes from linker/xt-ld/target.cmake
-  zephyr_ld_options(
-    ${TOOLCHAIN_LD_FLAGS}
-  )
-
-  zephyr_ld_options(
-    ${LINKERFLAGPREFIX},--gc-sections
-    ${LINKERFLAGPREFIX},--build-id=none
-  )
-
-  # Sort the common symbols and each input section by alignment
-  # in descending order to minimize padding between these symbols.
-  zephyr_ld_option_ifdef(
-    CONFIG_LINKER_SORT_BY_ALIGNMENT
-    ${LINKERFLAGPREFIX},--sort-common=descending
-    ${LINKERFLAGPREFIX},--sort-section=alignment
-  )
-
-  if (NOT CONFIG_LINKER_USE_RELAX)
-    zephyr_ld_options(
-      ${LINKERFLAGPREFIX},--no-relax
-    )
-  endif()
-
 endmacro()

--- a/cmake/linker/xt-ld/target_base.cmake
+++ b/cmake/linker/xt-ld/target_base.cmake
@@ -1,6 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# See root CMakeLists.txt for description and expectations of these macros
-
-macro(toolchain_ld_base)
-endmacro()

--- a/cmake/linker/xt-ld/target_base.cmake
+++ b/cmake/linker/xt-ld/target_base.cmake
@@ -3,11 +3,6 @@
 # See root CMakeLists.txt for description and expectations of these macros
 
 macro(toolchain_ld_base)
-
-  if(NOT PROPERTY_LINKER_SCRIPT_DEFINES)
-    set_property(GLOBAL PROPERTY PROPERTY_LINKER_SCRIPT_DEFINES -D__GCC_LINKER_CMD__)
-  endif()
-
   # TOOLCHAIN_LD_FLAGS comes from compiler/gcc/target.cmake
   # LINKERFLAGPREFIX comes from linker/xt-ld/target.cmake
   zephyr_ld_options(

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -113,7 +113,14 @@ endfunction()
 
 # https://cmake.org/cmake/help/latest/command/target_link_libraries.html
 function(zephyr_link_libraries)
-  target_link_libraries(zephyr_interface INTERFACE ${ARGV})
+  if(ARGV0 STREQUAL "PROPERTY")
+    if(ARGC GREATER 2)
+      message(FATAL_ERROR "zephyr_link_libraries(PROPERTY <prop>) only allows a single property.")
+    endif()
+    target_link_libraries(zephyr_interface INTERFACE $<TARGET_PROPERTY:linker,${ARGV1}>)
+  else()
+    target_link_libraries(zephyr_interface INTERFACE ${ARGV})
+  endif()
 endfunction()
 
 function(zephyr_libc_link_libraries)

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -2393,18 +2393,20 @@ function(check_set_linker_property)
 
   list(GET LINKER_PROPERTY_PROPERTY 0 property)
   list(REMOVE_AT LINKER_PROPERTY_PROPERTY 0)
-  set(option ${LINKER_PROPERTY_PROPERTY})
 
-  string(MAKE_C_IDENTIFIER check${option} check)
+  foreach(option ${LINKER_PROPERTY_PROPERTY})
+    string(MAKE_C_IDENTIFIER check${option} check)
 
-  set(SAVED_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
-  set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} ${option}")
-  zephyr_check_compiler_flag(C "" ${check})
-  set(CMAKE_REQUIRED_FLAGS ${SAVED_CMAKE_REQUIRED_FLAGS})
+    set(SAVED_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
+    set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} ${option}")
+    zephyr_check_compiler_flag(C "" ${check})
+    set(CMAKE_REQUIRED_FLAGS ${SAVED_CMAKE_REQUIRED_FLAGS})
 
-  if(${${check}})
-    set_property(TARGET ${LINKER_PROPERTY_TARGET} ${APPEND} PROPERTY ${property} ${option})
-  endif()
+    if(${${check}})
+      set_property(TARGET ${LINKER_PROPERTY_TARGET} ${APPEND} PROPERTY ${property} ${option})
+      set(APPEND "APPEND")
+    endif()
+  endforeach()
 endfunction()
 
 # 'set_compiler_property' is a function that sets the property for the C and

--- a/lib/libc/newlib/CMakeLists.txt
+++ b/lib/libc/newlib/CMakeLists.txt
@@ -13,18 +13,11 @@ set_source_files_properties(libc-hooks.c PROPERTIES COMPILE_OPTIONS $<TARGET_PRO
 # explicitly include the newlib header that provides those macros.
 zephyr_include_directories(include)
 
-# LIBC_*_DIR may or may not have been set by the toolchain. E.g. when
+# LIBC_LIBRARY_DIR may or may not have been set by the toolchain. E.g. when
 # using ZEPHYR_TOOLCHAIN_VARIANT=cross-compile it will be either up to the
 # toolchain to know where it's libc implementation is, or if it is
-# unable to, it will be up to the user to specify LIBC_*_DIR vars to
-# point to a newlib implementation.  Note that this does not change the
-# directory order if LIBC_INCLUDE_DIR is already a system header
-# directory.
-
-if(LIBC_INCLUDE_DIR)
-  zephyr_include_directories(${LIBC_INCLUDE_DIR})
-endif()
-
+# unable to, it will be up to the user to specify LIBC_LIBRARY_DIR vars to
+# point to a newlib implementation.
 if(LIBC_LIBRARY_DIR)
   set(LIBC_LIBRARY_DIR_FLAG -L${LIBC_LIBRARY_DIR})
 endif()


### PR DESCRIPTION
This PR contains a series of cleanup commit and commits which aligns linker flag handling with the compiler infrastructure introduced in PR #24851 .

This work cleanup and alignment is done to prepare for upcoming work related to improved linker handling, especially related to runtime library linking.

This will be needed for improved LLVM integration with Zephyr.

No functional change expected.