### PR TITLE
samples: sensor: use zephyr:code-sample directive

### DIFF
--- a/boards/nordic/thingy52/doc/index.rst
+++ b/boards/nordic/thingy52/doc/index.rst
@@ -376,7 +376,7 @@ The green lightwell LED can be tested with the :zephyr:code-sample:`blinky` exam
 
 
 
-Also the temperature and humidity sensor can be tested with the :ref:`hts221`
+Also the temperature and humidity sensor can be tested with the :zephyr:code-sample:`hts221`
 sample.
 
 .. zephyr-app-commands::

--- a/boards/shields/frdm_stbc_agm01/doc/index.rst
+++ b/boards/shields/frdm_stbc_agm01/doc/index.rst
@@ -43,8 +43,8 @@ Pin Assignment of the FRDM-STBC-AGM01 Shield
 For more information about the FXOS8700, FXAS21002, and FRDM-STBC-AGM01
 board:
 
-- :ref:`fxos8700`
-- :ref:`fxas21002`
+- :zephyr:code-sample:`fxos8700`
+- :zephyr:code-sample:`fxas21002`
 - `FRDM-STBC-AGM01 Website`_
 - `FRDM-STBC-AGM01 Quick Reference Card`_
 - `FRDM-STBC-AGM01 Schematics`_

--- a/boards/shields/x_nucleo_53l0a1/doc/index.rst
+++ b/boards/shields/x_nucleo_53l0a1/doc/index.rst
@@ -58,7 +58,7 @@ External links
 Samples
 *******
 
-The sample :ref:`vl53l0x` demonstrates how to use the ranging sensor VL53L0X
+The sample :zephyr:code-sample:`vl53l0x` demonstrates how to use the ranging sensor VL53L0X
 using the center sensor only.
 
 The sample :zephyr:code-sample:`x-nucleo-53l0a1` sample demonstrates how to use the three

--- a/samples/sensor/accel_polling/README.rst
+++ b/samples/sensor/accel_polling/README.rst
@@ -1,7 +1,8 @@
-.. _accel_polling:
+.. zephyr:code-sample:: accel_polling
+   :name: Generic 3-Axis accelerometer polling
+   :relevant-api: sensor_interface
 
-Generic 3-Axis accelerometer polling sample
-###########################################
+   Get 3-Axis accelerometer data from a sensor (polling mode).
 
 Overview
 ********

--- a/samples/sensor/adc_cmp_npcx/README.rst
+++ b/samples/sensor/adc_cmp_npcx/README.rst
@@ -1,7 +1,8 @@
-.. _adc_cmp_npcx:
+.. zephyr:code-sample:: adc_cmp_npcx
+   :name: NPCX ADC Comparator
+   :relevant-api: sensor_interface
 
-NPCX ADC Comparator
-###################
+   Detect upper/lower voltage limits using NPCX ADC Comparator driver.
 
 Overview
 ********

--- a/samples/sensor/adt7420/README.rst
+++ b/samples/sensor/adt7420/README.rst
@@ -1,7 +1,8 @@
-.. _adt7420:
+.. zephyr:code-sample:: adt7420
+   :name: ADT7420 high-accuracy digital I2C temperature sensor
+   :relevant-api: sensor_interface
 
-ADT7420: High accuracy digital I2C temperature sensor
-#####################################################
+   Get temperature data from an ADT7420 sensor using polling and window mode.
 
 Description
 ***********

--- a/samples/sensor/amg88xx/README.rst
+++ b/samples/sensor/amg88xx/README.rst
@@ -1,7 +1,8 @@
-.. _amg88xx:
+.. zephyr:code-sample:: amg88xx
+   :name: AMG88XX infrared array sensor
+   :relevant-api: sensor_interface
 
-AMG88XX Infrared Array Sensor
-#############################
+   Get temperature data from an AMG88XX 8x8 thermal camera sensor.
 
 Overview
 ********

--- a/samples/sensor/ams_iAQcore/README.rst
+++ b/samples/sensor/ams_iAQcore/README.rst
@@ -1,7 +1,8 @@
-.. _ams_iaqcore:
+.. zephyr:code-sample:: ams_iaqcore
+   :name: ams iAQcore indoor air quality sensor
+   :relevant-api: sensor_interface
 
-ams iAQcore Indoor air quality sensor
-#####################################
+   Get CO2 equivalent and VOC data from an ams iAQcore sensor.
 
 Overview
 ********

--- a/samples/sensor/apds9960/README.rst
+++ b/samples/sensor/apds9960/README.rst
@@ -1,7 +1,8 @@
-.. _apds9960:
+.. zephyr:code-sample:: apds9960
+   :name: APDS9960 RGB, ambient light, and gesture sensor
+   :relevant-api: sensor_interface
 
-APDS9960 RGB, Ambient Light, Gesture Sensor
-###########################################
+   Get ambient light, RGB, and proximity/gesture data from an APDS9960 sensor.
 
 Overview
 ********

--- a/samples/sensor/bme280/README.rst
+++ b/samples/sensor/bme280/README.rst
@@ -1,7 +1,8 @@
-.. _bme280:
+.. zephyr:code-sample:: bme280
+   :name: BME280 humidity and pressure sensor
+   :relevant-api: sensor_interface
 
-BME280 Humidity and Pressure Sensor
-###################################
+   Get temperature, pressure, and humidity data from a BME280 sensor.
 
 Overview
 ********

--- a/samples/sensor/bmi270/README.rst
+++ b/samples/sensor/bmi270/README.rst
@@ -1,7 +1,8 @@
-.. _bmi270:
+.. zephyr:code-sample:: bmi270
+   :name: BMI270 6-axis IMU sensor
+   :relevant-api: sensor_interface
 
-BMI270: 6 axis inertial measurement unit
-########################################
+   Configure and read accelerometer and gyroscope data from a BMI270 sensor.
 
 Description
 ***********

--- a/samples/sensor/bq274xx/README.rst
+++ b/samples/sensor/bq274xx/README.rst
@@ -1,7 +1,8 @@
-.. _bq274xx-sample:
+.. zephyr:code-sample:: bq274xx
+   :name: BQ274XX fuel gauge sensor
+   :relevant-api: sensor_interface
 
-BQ274XX Sensor Sample
-#####################
+   Get various fuel gauge parameters from a BQ274XX sensor.
 
 Overview
 ********

--- a/samples/sensor/ccs811/README.rst
+++ b/samples/sensor/ccs811/README.rst
@@ -1,7 +1,8 @@
-.. _ccs811:
+.. zephyr:code-sample:: ccs811
+   :name: CCS811 indoor air quality sensor
+   :relevant-api: sensor_interface
 
-CCS811 Indoor Air Quality Sensor
-################################
+   Get CO2 equivalent and VOC data from a CCS811 sensor.
 
 Overview
 ********

--- a/samples/sensor/co2_polling/README.rst
+++ b/samples/sensor/co2_polling/README.rst
@@ -1,7 +1,8 @@
-.. co2:
+.. zephyr:code-sample:: co2
+   :name: Generic CO2 polling sample
+   :relevant-api: sensor_interface
 
-Generic CO2 polling sample
-##########################
+   Get CO2 data from a sensor (polling mode).
 
 Overview
 ********

--- a/samples/sensor/dht_polling/README.rst
+++ b/samples/sensor/dht_polling/README.rst
@@ -1,7 +1,8 @@
-.. _dht_polling:
+.. zephyr:code-sample:: dht_polling
+   :name: Generic digital humidity temperature sensor polling
+   :relevant-api: sensor_interface
 
-Generic Digital Humidity Temperature sensor polling sample
-##########################################################
+   Get temperature and humidity data from a DHT sensor (polling mode).
 
 Overview
 ********

--- a/samples/sensor/die_temp_polling/README.rst
+++ b/samples/sensor/die_temp_polling/README.rst
@@ -1,7 +1,8 @@
-.. _die_temp_polling:
+.. zephyr:code-sample:: die_temp_polling
+   :name: CPU die temperature polling
+   :relevant-api: sensor_interface
 
-CPU Die Temperature polling
-###########################
+   Get CPU die temperature data from a sensor using polling.
 
 Overview
 ********

--- a/samples/sensor/ds18b20/README.rst
+++ b/samples/sensor/ds18b20/README.rst
@@ -1,7 +1,8 @@
-.. _ds18b20_sample:
+.. zephyr:code-sample:: ds18b20
+   :name: DS18B20 1-Wire Temperature Sensor
+   :relevant-api: sensor_interface w1_sensor
 
-DS18B20 1-Wire Temperature Sensor
-#################################
+   Get ambient temperature data from a DS18B20 sensor (polling mode).
 
 Overview
 ********

--- a/samples/sensor/fdc2x1x/README.rst
+++ b/samples/sensor/fdc2x1x/README.rst
@@ -1,7 +1,8 @@
-.. _fdc2x1x:
+.. zephyr:code-sample:: fdc2x1x
+   :name: FDC2X1X Capacitance-to-Digital Converter
+   :relevant-api: sensor_interface
 
-FDC2X1X: Capacitance-to-Digital Converter
-#########################################
+   Get capacitance and frequency data from a FDC2X1X sensor (polling & trigger).
 
 Overview
 ********

--- a/samples/sensor/fxas21002/README.rst
+++ b/samples/sensor/fxas21002/README.rst
@@ -1,7 +1,8 @@
-.. _fxas21002:
+.. zephyr:code-sample:: fxas21002
+   :name: FXAS21002 Gyroscope Sensor
+   :relevant-api: sensor_interface
 
-FXAS21002 Gyroscope Sensor
-##########################
+   Get gyroscope data synchronously from an FXAS21002 sensor.
 
 Overview
 ********

--- a/samples/sensor/fxos8700/README.rst
+++ b/samples/sensor/fxos8700/README.rst
@@ -1,7 +1,8 @@
-.. _fxos8700:
+.. zephyr:code-sample:: fxos8700
+   :name: FXOS8700 Accelerometer/Magnetometer Sensor
+   :relevant-api: sensor_interface
 
-FXOS8700 Accelerometer/Magnetometer Sensor
-##########################################
+   Get accelerometer and magnetometer data from an FXOS8700 sensor (polling & trigger mode).
 
 Overview
 ********

--- a/samples/sensor/grove_light/README.rst
+++ b/samples/sensor/grove_light/README.rst
@@ -1,7 +1,8 @@
-.. _grove_light:
+.. zephyr:code-sample:: grove_light
+   :name: Grove Light Sensor
+   :relevant-api: sensor_interface
 
-Grove Light Sensor
-##################
+   Get illuminance data from a Grove Light Sensor.
 
 Overview
 ********

--- a/samples/sensor/grove_temperature/README.rst
+++ b/samples/sensor/grove_temperature/README.rst
@@ -1,7 +1,8 @@
-.. _grove_temperature:
+.. zephyr:code-sample:: grove_temperature
+   :name: Grove Temperature Sensor
+   :relevant-api: sensor_interface
 
-Grove Temperature Sensor
-########################
+   Get temperature data from a Grove temperature sensor and display it on an LCD display.
 
 Overview
 ********

--- a/samples/sensor/grow_r502a/README.rst
+++ b/samples/sensor/grow_r502a/README.rst
@@ -1,7 +1,8 @@
-.. _grow_r502a:
+.. zephyr:code-sample:: grow_r502a
+   :name: GROW R502-A Fingerprint Sensor
+   :relevant-api: sensor_interface
 
-GROW_R502A Fingerprint Sensor
-#############################
+   Store and match fingerprints using the GROW R502-A fingerprint sensor.
 
 Overview
 ********

--- a/samples/sensor/hts221/README.rst
+++ b/samples/sensor/hts221/README.rst
@@ -1,7 +1,8 @@
-.. _hts221:
+.. zephyr:code-sample:: hts221
+   :name: HTS221 Temperature and Humidity Monitor
+   :relevant-api: sensor_interface
 
-HTS221: Temperature and Humidity Monitor
-########################################
+   Get temperature and humidity data from an HTS221 sensor (polling & trigger mode).
 
 Overview
 ********

--- a/samples/sensor/i3g4250d/README.rst
+++ b/samples/sensor/i3g4250d/README.rst
@@ -1,7 +1,8 @@
-.. _i3g4250d:
+.. zephyr:code-sample:: i3g4250d
+   :name: I3G4250D 3-axis gyroscope sensor
+   :relevant-api: sensor_interface
 
-I3G4250D: 3-axis digital output gyroscope
-#########################################
+   Get gyroscope data from an I3G4250D sensor.
 
 Description
 ***********

--- a/samples/sensor/icm42605/README.rst
+++ b/samples/sensor/icm42605/README.rst
@@ -1,7 +1,9 @@
-.. _icm42605:
+.. zephyr:code-sample:: icm42605
+   :name: MPU6050 Invensense Motion Tracking Device
+   :relevant-api: sensor_interface
 
-MPU6050: Invensense Motion Tracking Device
-##########################################
+   Get temperature, acceleration, and angular velocity from an ICM42605 sensor (polling & trigger
+   mode).
 
 Description
 ***********

--- a/samples/sensor/ina219/README.rst
+++ b/samples/sensor/ina219/README.rst
@@ -1,7 +1,8 @@
-.. _ina219:
+.. zephyr:code-sample:: ina219
+   :name: INA219 Bidirectional Power/Current Monitor
+   :relevant-api: sensor_interface
 
-INA219 Bidirectional Power/Current Monitor
-##########################################
+   Get shunt voltage, bus voltage, power and current from an INA219 sensor.
 
 Overview
 ********

--- a/samples/sensor/isl29035/README.rst
+++ b/samples/sensor/isl29035/README.rst
@@ -1,7 +1,8 @@
-.. _isl29035:
+.. zephyr:code-sample:: isl29035
+   :name: ISL29035 Digital Light Sensor
+   :relevant-api: sensor_interface
 
-ISL29035: Digital Light Sensor
-##############################
+   Get light intensity data from an ISL29035 sensor (polling & trigger mode).
 
 Overview
 ********

--- a/samples/sensor/jc42/README.rst
+++ b/samples/sensor/jc42/README.rst
@@ -1,7 +1,9 @@
-.. _jc42-sample:
+.. zephyr:code-sample:: jc42
+   :name: JEDEC JC 42.4 compliant Temperature Sensor
+   :relevant-api: sensor_interface
 
-JEDEC JC 42.4 compliant Temperature Sensor
-##########################################
+   Get ambient temperature from a JEDEC JC 42.4 compliant temperature sensor (polling & trigger
+   mode).
 
 Overview
 ********

--- a/samples/sensor/lis2dh/README.rst
+++ b/samples/sensor/lis2dh/README.rst
@@ -1,7 +1,8 @@
-.. _lis2dh:
+.. zephyr:code-sample:: lis2dh
+   :name: LIS2DH Motion Sensor
+   :relevant-api: sensor_interface
 
-LIS2DH: Motion Sensor Monitor
-#############################
+   Get accelerometer data from an LIS2DH sensor (polling & trigger mode).
 
 Overview
 ********

--- a/samples/sensor/lps22hb/README.rst
+++ b/samples/sensor/lps22hb/README.rst
@@ -1,7 +1,8 @@
-.. _lps22hb:
+.. zephyr:code-sample:: lps22hb
+   :name: LPS22HB Temperature and Pressure Sensor
+   :relevant-api: sensor_interface
 
-LPS22HB: Temperature and Pressure Monitor
-#########################################
+   Get pressure and temperature data from an LPS22HB sensor (polling mode).
 
 Overview
 ********

--- a/samples/sensor/lps22hh/README.rst
+++ b/samples/sensor/lps22hh/README.rst
@@ -1,7 +1,8 @@
-.. _lps22hh:
+.. zephyr:code-sample:: lps22hh
+   :name: LPSS22HH Temperature and Pressure Sensor
+   :relevant-api: sensor_interface
 
-LPS22HH: Temperature and Pressure Monitor
-#########################################
+   Get pressure and temperature data from an LPS22HH sensor (polling & trigger mode).
 
 Overview
 ********

--- a/samples/sensor/lps22hh_i3c/README.rst
+++ b/samples/sensor/lps22hh_i3c/README.rst
@@ -1,7 +1,9 @@
-.. _lps22hh_i3c:
+.. zephyr:code-sample:: lps22hh_i3c
+   :name: LPSS22HH Temperature and Pressure Sensor (I3C)
+   :relevant-api: sensor_interface
 
-LPS22HH: Temperature and Pressure Monitor (I3C)
-###############################################
+   Get pressure and temperature data from an LPS22HH sensor over I3C (polling &
+   trigger mode).
 
 Overview
 ********

--- a/samples/sensor/lsm303dlhc/README.rst
+++ b/samples/sensor/lsm303dlhc/README.rst
@@ -1,7 +1,9 @@
-.. _lsm303dlhc:
+.. zephyr:code-sample:: lsmd303dlhc
+   :name: LSM303DLHC Magnetometer and Accelerometer sensor
+   :relevant-api: sensor_interface
 
-LSM303DLHC: Magnetometer and Accelerometer data Monitor
-#######################################################
+   Get magnetometer and accelerometer data from an LSM303DLHC sensor (polling
+   mode).
 
 Overview
 ********

--- a/samples/sensor/lsm6dsl/README.rst
+++ b/samples/sensor/lsm6dsl/README.rst
@@ -1,10 +1,13 @@
-.. _lsm6dsl:
+.. zephyr:code-sample:: lsmd6dsl
+   :name: LSM6DSL IMU sensor
+   :relevant-api: sensor_interface
 
-LSM6DSL: IMU sensor Monitor
-###########################
+   Get accelerometer and gyroscope data from an LSM6DSL sensor (polling & trigger
+   mode).
 
 Overview
 ********
+
 This sample sets the LSM6DSL accelerometer and gyroscope to 104Hz
 and enable a trigger on data ready. It displays on the console the
 values for accelerometer and gyroscope, plus optionally the values of

--- a/samples/sensor/lsm6dso/README.rst
+++ b/samples/sensor/lsm6dso/README.rst
@@ -1,7 +1,9 @@
-.. _lsm6dso:
+.. zephyr:code-sample:: lsmd6dso
+   :name: LSM6DSO IMU sensor
+   :relevant-api: sensor_interface
 
-LSM6DSO: IMU Sensor Monitor
-###########################
+   Get accelerometer and gyroscope data from an LSM6DSO sensor (polling & trigger
+   mode).
 
 Overview
 ********

--- a/samples/sensor/lsm6dso_i2c_on_i3c/README.rst
+++ b/samples/sensor/lsm6dso_i2c_on_i3c/README.rst
@@ -1,7 +1,9 @@
-.. _lsm6dso_i2c_on_i3c:
+.. zephyr:code-sample:: lsmd6dso_i2c_on_i3c
+   :name: LSM6DSO IMU sensor (I2C on I3C bus)
+   :relevant-api: sensor_interface
 
-LSM6DSO: IMU Sensor Monitor (I2C on I3C bus)
-############################################
+   Get accelerometer and gyroscope data from an LSM6DSO sensor using I2C on I3C
+   bus (polling & trigger mode).
 
 Overview
 ********

--- a/samples/sensor/magn_polling/README.rst
+++ b/samples/sensor/magn_polling/README.rst
@@ -1,7 +1,8 @@
-.. _magn-polling-sample:
+.. zephyr:code-sample:: magn_polling
+   :name: Magnetometer Sensor
+   :relevant-api: sensor_interface
 
-BMC150 Magnetometer Sample
-##########################
+   Get magnetometer data from a magnetometer sensor (polling mode).
 
 Overview
 ********

--- a/samples/sensor/max17262/README.rst
+++ b/samples/sensor/max17262/README.rst
@@ -1,7 +1,8 @@
-.. _max17262:
+.. zephyr:code-sample:: max17262
+   :name: MAX17262 Fuel Gauge Sensor
+   :relevant-api: sensor_interface
 
-MAX17262 Fuel Gauge Sensor
-###################################
+   Get voltage, current and temperature data from a MAX17262 sensor (polling mode).
 
 Overview
 ********

--- a/samples/sensor/max30101/README.rst
+++ b/samples/sensor/max30101/README.rst
@@ -1,7 +1,8 @@
-.. _max30101:
+.. zephyr:code-sample:: max30101
+   :name: MAX30101 Heart Rate Sensor
+   :relevant-api: sensor_interface
 
-MAX30101 Heart Rate Sensor
-##########################
+   Get heart rate data from a MAX30101 sensor (polling mode).
 
 Overview
 ********

--- a/samples/sensor/max6675/README.rst
+++ b/samples/sensor/max6675/README.rst
@@ -1,5 +1,9 @@
-MAX6675 K-thermocouple to digital converter
-###########################################
+.. zephyr:code-sample:: max6675
+   :name: MAX6675 K-thermocouple to digital converter
+   :relevant-api: sensor_interface
+
+   Get temperature from a MAX6675 K-thermocouple to digital converter (polling
+   mode).
 
 Overview
 ********

--- a/samples/sensor/mcux_acmp/README.rst
+++ b/samples/sensor/mcux_acmp/README.rst
@@ -1,7 +1,8 @@
-.. _mcux_acmp:
+.. zephyr:code-sample:: mcux_acmp
+   :name: NXP MCUX Analog Comparator (ACMP)
+   :relevant-api: sensor_interface
 
-NXP MCUX Analog Comparator (ACMP)
-#################################
+   Get analog comparator data from an NXP MCUX Analog Comparator (ACMP).
 
 Overview
 ********

--- a/samples/sensor/mcux_lpcmp/README.rst
+++ b/samples/sensor/mcux_lpcmp/README.rst
@@ -1,12 +1,13 @@
-.. _mcux_lpcmp:
+.. zephyr:code-sample:: mcux_lpcmp
+   :name: NXP MCUX Low-power Analog Comparator (LPCMP)
+   :relevant-api: sensor_interface
 
-NXP MCUX Low-power Analog Comparator (LPCMP)
-############################################
+   Get analog comparator data from an NXP MCUX Low-power Analog Comparator (LPCMP).
 
 Overview
 ********
 
-This sample show how to use the NXP MCUX Analog Comparator (LPCMP) driver.
+This sample show how to use the NXP MCUX Low-power Analog Comparator (LPCMP) driver.
 
 In this application, the negative input port of the LPCMP is set to 7 which
 means the input voltage comes from the LPCMP internal DAC, the reference

--- a/samples/sensor/mpr/README.rst
+++ b/samples/sensor/mpr/README.rst
@@ -1,7 +1,8 @@
-.. _mpr-sample:
+.. zephyr:code-sample:: mpr
+   :name: MPR Pressure Sensor
+   :relevant-api: sensor_interface
 
-MPR Pressure Sensor
-###################
+   Get atmospheric pressure data from an MPR pressure sensor.
 
 Overview
 ********

--- a/samples/sensor/mpu6050/README.rst
+++ b/samples/sensor/mpu6050/README.rst
@@ -1,7 +1,9 @@
-.. _mpu6050:
+.. zephyr:code-sample:: mpu6050
+   :name: MPU6050 motion tracking device
+   :relevant-api: sensor_interface
 
-MPU6050: Invensense Motion Tracking Device
-##########################################
+   Get temperature, acceleration, and angular velocity from an MPU6050 sensor (polling & trigger
+   mode).
 
 Description
 ***********

--- a/samples/sensor/ms5837/README.rst
+++ b/samples/sensor/ms5837/README.rst
@@ -1,7 +1,8 @@
-.. _ms5837-sample:
+.. zephyr:code-sample:: ms5837
+   :name: MS5837 Digital Pressure Sensor
+   :relevant-api: sensor_interface
 
-MS5837 Sensor Sample
-####################
+   Get pressure and temperature data from an MS5837 sensor (polling mode).
 
 Overview
 ********

--- a/samples/sensor/proximity_polling/README.rst
+++ b/samples/sensor/proximity_polling/README.rst
@@ -1,7 +1,8 @@
-.. _tmd2620:
+.. zephyr:code-sample:: proximity_polling
+   :name: Proximity sensor
+   :relevant-api: sensor_interface
 
-Generic Proximity Sensor Sample
-###############################
+   Get proximity data from up to 10 proximity sensors (polling mode).
 
 Overview
 ********

--- a/samples/sensor/qdec/README.rst
+++ b/samples/sensor/qdec/README.rst
@@ -1,7 +1,8 @@
-.. _qdec_sensor:
+.. zephyr:code-sample:: qdec
+   :name: Quadrature Decoder Sensor
+   :relevant-api: sensor_interface
 
-Quadrature Decoder Sensor
-#########################
+   Get rotation data from a quadrature decoder sensor.
 
 Overview
 ********

--- a/samples/sensor/sensor_shell/README.rst
+++ b/samples/sensor/sensor_shell/README.rst
@@ -1,7 +1,8 @@
-.. _sensor_shell_sample:
+.. zephyr:code-sample:: sensor_shell
+   :name: Sensor shell
+   :relevant-api: sensor_interface
 
-Sensor Shell Module Sample
-##########################
+   Interact with sensors using the shell module.
 
 Overview
 ********

--- a/samples/sensor/sgp40_sht4x/README.rst
+++ b/samples/sensor/sgp40_sht4x/README.rst
@@ -1,7 +1,8 @@
-.. _sgp40_sht4x:
+.. zephyr:code-sample:: sgp40_sht4x
+   :name: SGP40 and SHT4X digital humidity and multipixel gas sensor
+   :relevant-api: sensor_interface
 
-SGP40 and SHT4X: High accuracy digital I2C humidity sensor and multipixel gas sensor
-####################################################################################
+   Get temperature, humidity and gas sensor data from SGP40 and SHT4X sensors (polling mode).
 
 Description
 ***********

--- a/samples/sensor/sht3xd/README.rst
+++ b/samples/sensor/sht3xd/README.rst
@@ -1,7 +1,8 @@
-.. _sht3xd:
+.. zephyr:code-sample:: sht3xd
+   :name: SHT3XD humidity sensor
+   :relevant-api: sensor_interface
 
-SHT3XD: High accuracy digital I2C humidity sensor
-#################################################
+   Get temperature and humidity from a SHT3XD sensor (polling & trigger mode).
 
 Description
 ***********

--- a/samples/sensor/sm351lt/README.rst
+++ b/samples/sensor/sm351lt/README.rst
@@ -1,7 +1,8 @@
-.. _sm351lt:
+.. zephyr:code-sample:: sm351lt
+   :name: SM351LT Magnetoresistive Sensor
+   :relevant-api: sensor_interface
 
-SM351LT: Magnetoresistive Sensor Example
-########################################
+   Detect a magnet's presence using the SM351LT magnetoresistive sensor (polling & trigger mode).
 
 Overview
 ********

--- a/samples/sensor/soc_voltage/README.rst
+++ b/samples/sensor/soc_voltage/README.rst
@@ -1,7 +1,8 @@
-.. _soc_voltage:
+.. zephyr:code-sample:: soc_voltage
+   :name: SoC Voltage Sensor
+   :relevant-api: sensor_interface
 
-SoC voltage sensor measurement
-##############################
+   Get voltage data from an SoC's voltage sensor(s).
 
 Overview
 ********

--- a/samples/sensor/th02/README.rst
+++ b/samples/sensor/th02/README.rst
@@ -1,7 +1,8 @@
-.. _th02-sample:
+.. zephyr:code-sample:: th02
+   :name: TH02 Temperature and Humidity Sensor
+   :relevant-api: sensor_interface
 
-TH02: Temperature and Humidity Monitor
-######################################
+   Get temperature and humidity data from a TH02 sensor (polling mode).
 
 Overview
 ********

--- a/samples/sensor/thermometer/README.rst
+++ b/samples/sensor/thermometer/README.rst
@@ -1,7 +1,9 @@
-.. _thermometer-sample:
+.. zephyr:code-sample:: thermometer
+   :name: Thermometer
+   :relevant-api: sensor_interface
 
-Thermometer sample
-##################
+   Get ambient temperature data from a temperature sensor and get alerts when temperature drifts
+   above a threshold. (polling & trigger mode).
 
 Overview
 ********

--- a/samples/sensor/tmp108/README.rst
+++ b/samples/sensor/tmp108/README.rst
@@ -1,7 +1,8 @@
-.. _tmp108_sample:
+.. zephyr:code-sample:: tmp108
+   :name: TMP108 Temperature Sensor
+   :relevant-api: sensor_interface
 
-TMP108 sample
-#############
+   Get temperature data from a TMP108 sensor (polling & trigger mode).
 
 Description
 ***********

--- a/samples/sensor/tmp112/README.rst
+++ b/samples/sensor/tmp112/README.rst
@@ -1,7 +1,8 @@
-.. _tmp112_sample:
+.. zephyr:code-sample:: tmp112
+   :name: TMP112 Temperature Sensor
+   :relevant-api: sensor_interface
 
-TMP112 sample
-#############
+   Get temperature data from a TMP112 sensor (polling & trigger mode).
 
 Overview
 ********

--- a/samples/sensor/vcnl4040/README.rst
+++ b/samples/sensor/vcnl4040/README.rst
@@ -1,10 +1,12 @@
-.. _vcnl4040_sample:
+.. zephyr:code-sample:: vcml4040
+   :name: VCNL4040 Proximity and Ambient Light Sensor
+   :relevant-api: sensor_interface
 
-VCNL4040: proximity and ambient light sensor
-############################################
+   Get proximity and ambient light data from a VCNL4040 sensor (polling & trigger mode).
 
 Overview
 ********
+
  This sample periodically measures proximity and light for
  5 sec in the interval of 300msec in polling mode. Then threshold trigger mode
  is enabled with the high threshold value of 127 and data is fetched based

--- a/samples/sensor/veaa_x_3/README.rst
+++ b/samples/sensor/veaa_x_3/README.rst
@@ -1,7 +1,8 @@
-.. veaa_x_3:
+.. zephyr:code-sample:: veea_x_3
+   :name: VEAA-X-3 proportional pressure control valve
+   :relevant-api: sensor_interface
 
-VEAA-X-3 sample
-##########################
+   Control a VEAA-X-3 proportional pressure control valve.
 
 Overview
 ********

--- a/samples/sensor/vl53l0x/README.rst
+++ b/samples/sensor/vl53l0x/README.rst
@@ -1,14 +1,15 @@
-.. _vl53l0x:
+.. zephyr:code-sample:: vl53l0x
+   :name: VL53L0X Time Of Flight sensor
+   :relevant-api: sensor_interface
 
-VL53L0X: Time Of Flight sensor
-##############################
+   Get distance data from a VL53L0X sensor (polling mode).
 
 Overview
 ********
+
 This sample periodically measures distance between vl53l0x sensor
 and target. The result is displayed on the console.
 It also shows how we can use the vl53l0x as a proximity sensor.
-
 
 Requirements
 ************


### PR DESCRIPTION
Describe the samples using `.. zephyr:code-sample::` directive in preparation for upcoming changes to the Zephyr documentation that will be leveraging the provided description and metadata more.