### PR TITLE
Misc updates for the nrf54l15bsim board

### DIFF
--- a/boards/native/nrf_bsim/doc/nrf54l15bsim.rst
+++ b/boards/native/nrf_bsim/doc/nrf54l15bsim.rst
@@ -21,7 +21,7 @@ run applications natively on the development system. This has the benefit of
 providing native code execution performance and easy debugging using
 native tools, but inherits :ref:`its limitations <posix_arch_limitations>`.
 
-Just like for the nrf54l15pdk target,
+Just like for the nrf54l15dk target,
 the nrf54l15bsim/nrf54l15/cpuapp build target provides support for the application core,
 on the simulated nRF54L15 SOC.
 
@@ -51,7 +51,7 @@ This boards include models of some of the nRF54L15 SOC peripherals:
 * TIMER
 * UICR (User Information Configuration Registers)
 
-and will use the same drivers as the nrf54l15pdk targets for these.
+and will use the same drivers as the nrf54l15dk targets for these.
 For more information on what is modeled to which level of detail,
 check the `HW models implementation status`_.
 

--- a/boards/native/nrf_bsim/doc/nrf54l15bsim.rst
+++ b/boards/native/nrf_bsim/doc/nrf54l15bsim.rst
@@ -31,14 +31,15 @@ on the simulated nRF54L15 SOC.
 
 .. warning::
 
-   This target is experimental, and even though it includes models of the RADIO, it does not yet
-   include models of the AAR, CCM or ECB peripherals, so the BLE and 802.15.4 stacks can only be
-   run without encryption or privacy features so far.
+   This target is experimental.
 
 This boards include models of some of the nRF54L15 SOC peripherals:
 
+* AAR (Accelerated Address Resolver)
+* CCM (AES CCM mode encryption)
 * CLOCK (Clock control)
 * DPPI (Distributed Programmable Peripheral Interconnect)
+* ECB (AES electronic codebook mode encryption)
 * EGU (Event Generator Unit)
 * FICR (Factory Information Configuration Registers)
 * GRTC (Global Real-time Counter)

--- a/boards/native/nrf_bsim/nrf54l15bsim_nrf54l15_cpuapp.dts
+++ b/boards/native/nrf_bsim/nrf54l15bsim_nrf54l15_cpuapp.dts
@@ -69,6 +69,10 @@
 		status = "okay";
 		compatible = "zephyr,native-posix-rng";
 	};
+
+	psa_rng: psa-rng {
+		status = "disabled";
+	};
 };
 
 &grtc {

--- a/west.yml
+++ b/west.yml
@@ -300,7 +300,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 6e70c2dc5d4c67c4da5913b2969c0774b27f0cd0
+      revision: 4b0b020e25dbf1a11ccccf7b7741d6ca991ba9e4
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: 76d2168bcdfcd23a9a7dce8c21f2083b90a1e60a


### PR DESCRIPTION
A set of minor fixes/improvements for the nrf54l15bsim

    manifest: Update nRF hw models to latest
    
    Update the HW models module to:
    4b0b020e25dbf1a11ccccf7b7741d6ca991ba9e4
    
    Including the following:
    * 4b0b020 54L CLOCK: Generate XOSTARTED event
    * 79287fb hal: RADIO: support also triggering TASK_SOFTRESET from HAL
    
    Signed-off-by: Alberto Escolar Piedras <alberto.escolar.piedras@nordicsemi.no>

-------

    boards: nrf54l15bsim: Compare it to the DK instead of the PDK
    
    The nrf54l15dk is now avaliable in the tree.
    Let's compare the simulated board to this one instead.
    
    Signed-off-by: Alberto Escolar Piedras <alberto.escolar.piedras@nordicsemi.no>

------

    boards: nrf54l15_bsim: Update docs including AAR,CCM, ECB
    
    These peripherals are now included. Let's mention them
    and remove the warning about them being missing.
    
    Signed-off-by: Alberto Escolar Piedras <alberto.escolar.piedras@nordicsemi.no>

-----

    boards: nrf54l15_bsim: Actively set psa-rng to disabled
    
    This target does not yet support the PSA random generator.
    Lets explicitly set it to disabled, to even if the
    SOC definition sets it to "okay" it is not built in
    by default.
