### PR TITLE
dtlib: fix _raw_unit_addr() function

### DIFF
--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -2267,7 +2267,6 @@ class EDT:
                 _err(
                         f"'{binding_path}' appears in binding directories "
                         f"but isn't valid YAML: {e}")
-                continue
 
             # Convert the raw data to a Binding object, erroring out
             # if necessary.
@@ -2952,7 +2951,7 @@ def _map_interrupt(
         return own_address_cells(node) + _interrupt_cells(node)
 
     parent, raw_spec = _map(
-        "interrupt", child, parent, _raw_unit_addr(child) + child_spec,
+        "interrupt", child, parent, _raw_unit_addr(child, parent) + child_spec,
         spec_len_fn, require_controller=True)
 
     # Strip the parent unit address part, if any
@@ -3116,21 +3115,39 @@ def _pass_thru(
     return res[-len(parent_spec):]
 
 
-def _raw_unit_addr(node: dtlib_Node) -> bytes:
+def _raw_unit_addr(node: dtlib_Node, parent: dtlib_Node) -> bytes:
     # _map_interrupt() helper. Returns the unit address (derived from 'reg' and
     # #address-cells) as a raw 'bytes'
+
+    iparent: Optional[dtlib_Node] = parent
+    addr_len: Optional[int] = None
+
+    while iparent is not None:
+        addr_len = _address_cells_self(iparent)
+        if addr_len is None:
+            # check the parent(s) of interrupt-controller(s) too
+            iparent = iparent.parent
+        else:
+            break
+
+    if addr_len is None:
+        addr_len =  2  # Default value per DT spec.
+
+    if addr_len == 0:
+        return b''
 
     if 'reg' not in node.props:
         _err(f"{node!r} lacks 'reg' property "
              "(needed for 'interrupt-map' unit address lookup)")
 
-    addr_len = 4*_address_cells(node)
-
-    if len(node.props['reg'].value) < addr_len:
-        _err(f"{node!r} has too short 'reg' property "
+    addr_len *= 4
+    prop_len = len(node.props['reg'].value)
+    if  prop_len < addr_len or prop_len % 4 != 0:
+        _err(f"{node!r} has too short or incorrectly defined 'reg' property "
              "(while doing 'interrupt-map' unit address lookup)")
 
-    return node.props['reg'].value[:addr_len]
+    # address is a big endian value
+    return node.props['reg'].value[-addr_len:]
 
 
 def _and(b1: bytes, b2: bytes) -> bytes:
@@ -3210,6 +3227,12 @@ def _phandle_val_list(
 
     return res
 
+def _address_cells_self(node: Optional[dtlib_Node]) -> Optional[int]:
+    # Returns the #address-cells setting for 'node', giving the number of <u32>
+    # cells used to encode the address in the 'reg' property
+    if node is not None and "#address-cells" in node.props:
+        return node.props["#address-cells"].to_num()
+    return None
 
 def _address_cells(node: dtlib_Node) -> int:
     # Returns the #address-cells setting for 'node', giving the number of <u32>
@@ -3217,9 +3240,10 @@ def _address_cells(node: dtlib_Node) -> int:
     if TYPE_CHECKING:
         assert node.parent
 
-    if "#address-cells" in node.parent.props:
-        return node.parent.props["#address-cells"].to_num()
-    return 2  # Default value per DT spec.
+    ret = _address_cells_self(node.parent)
+    if ret is None:
+        return 2  # Default value per DT spec.
+    return int(ret)
 
 
 def _size_cells(node: dtlib_Node) -> int:

--- a/scripts/dts/python-devicetree/tests/test.dts
+++ b/scripts/dts/python-devicetree/tests/test.dts
@@ -80,6 +80,22 @@
 				0 1  0 1  &{/interrupt-map-test/controller-1}  0 0    0 4
 				0 1  0 2  &{/interrupt-map-test/controller-2}  0 0 0  0 0 5>;
 		};
+		nexus-0 {
+			#address-cells = <0>;
+			#interrupt-cells = <2>;
+			interrupt-map = <
+				0 0  &{/interrupt-map-test/controller-0}  0      0
+				0 1  &{/interrupt-map-test/controller-1}  0 0    0 1
+				1 2  &{/interrupt-map-test/controller-2}  0 0 0  0 0 2>;
+		};
+		nexus-1 {
+			#address-cells = <1>;
+			#interrupt-cells = <1>;
+			interrupt-map = <
+				4 0  &{/interrupt-map-test/controller-0}  0      3
+				4 1  &{/interrupt-map-test/controller-1}  0 0    0 4
+				4 2  &{/interrupt-map-test/controller-2}  0 0 0  0 0 5>;
+		};
 		node@0 {
 			reg = <0 0>;
 			interrupts = <0 0 0 1 0 2>;
@@ -91,6 +107,30 @@
 			    &{/interrupt-map-test/nexus} 0 0
 			    &{/interrupt-map-test/nexus} 0 1
 			    &{/interrupt-map-test/nexus} 0 2>;
+		};
+		node@2 {
+			reg = <0 2>;
+			interrupts = <0 0 0 1 1 2>;
+			interrupt-parent = <&{/interrupt-map-test/nexus-0}>;
+		};
+		node@3 { /* Test the precedence of interrupts/interrupts-extended too */
+			reg = <0 3>;
+			interrupts = <1 2 0 0 0 1>;
+			interrupt-parent = <&{/interrupt-map-test/nexus-0}>;
+			interrupts-extended = <
+			    &{/interrupt-map-test/nexus-0} 0 0
+			    &{/interrupt-map-test/nexus-0} 0 1
+			    &{/interrupt-map-test/nexus-0} 1 2>;
+		};
+		node@4 {
+			reg = <0 4>;
+			interrupts = <0 1 2>;
+			interrupt-parent = <&{/interrupt-map-test/nexus-1}>;
+		};
+		node@100000004 {
+			reg = <1 4>;
+			interrupts = <0 1 2>;
+			interrupt-parent = <&{/interrupt-map-test/nexus-1}>;
 		};
 	};
 	interrupt-map-bitops-test {

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -97,6 +97,34 @@ def test_interrupts():
         edtlib.ControllerAndData(node=node, controller=controller_2, data={'one': 0, 'two': 0, 'three': 5}, name=None, basename=None)
     ]
 
+    node = edt.get_node("/interrupt-map-test/node@2")
+    assert node.interrupts == [
+        edtlib.ControllerAndData(node=node, controller=controller_0, data={'one': 0}, name=None, basename=None),
+        edtlib.ControllerAndData(node=node, controller=controller_1, data={'one': 0, 'two': 1}, name=None, basename=None),
+        edtlib.ControllerAndData(node=node, controller=controller_2, data={'one': 0, 'two': 0, 'three': 2}, name=None, basename=None)
+    ]
+
+    node = edt.get_node("/interrupt-map-test/node@3")
+    assert node.interrupts == [
+        edtlib.ControllerAndData(node=node, controller=controller_0, data={'one': 0}, name=None, basename=None),
+        edtlib.ControllerAndData(node=node, controller=controller_1, data={'one': 0, 'two': 1}, name=None, basename=None),
+        edtlib.ControllerAndData(node=node, controller=controller_2, data={'one': 0, 'two': 0, 'three': 2}, name=None, basename=None)
+    ]
+
+    node = edt.get_node("/interrupt-map-test/node@4")
+    assert node.interrupts == [
+        edtlib.ControllerAndData(node=node, controller=controller_0, data={'one': 3}, name=None, basename=None),
+        edtlib.ControllerAndData(node=node, controller=controller_1, data={'one': 0, 'two': 4}, name=None, basename=None),
+        edtlib.ControllerAndData(node=node, controller=controller_2, data={'one': 0, 'two': 0, 'three': 5}, name=None, basename=None)
+    ]
+
+    node = edt.get_node("/interrupt-map-test/node@100000004")
+    assert node.interrupts == [
+        edtlib.ControllerAndData(node=node, controller=controller_0, data={'one': 3}, name=None, basename=None),
+        edtlib.ControllerAndData(node=node, controller=controller_1, data={'one': 0, 'two': 4}, name=None, basename=None),
+        edtlib.ControllerAndData(node=node, controller=controller_2, data={'one': 0, 'two': 0, 'three': 5}, name=None, basename=None)
+    ]
+
     node = edt.get_node("/interrupt-map-bitops-test/node@70000000E")
     assert node.interrupts == [
         edtlib.ControllerAndData(node=node, controller=edt.get_node('/interrupt-map-bitops-test/controller'), data={'one': 3, 'two': 2}, name=None, basename=None)


### PR DESCRIPTION
The '_raw_unit_addr()' function was incorrectly written a long time ago. It tries to look up and use the '#address-cells' of the node containing the 'interrupts' property itself, instead of using the '#address-cells' of the interrupt controller's node (or its parent).
 
 As a result, the mapping is successful only if the '#address-cells' value is the same in both the node and the interrupt controller, all other cases lead to random errors being generated by the 'gen_defines.py' script.
 
 Fixes https://github.com/zephyrproject-rtos/zephyr/issues/77890, https://github.com/zephyrproject-rtos/zephyr/issues/78020