### PR TITLE
drivers: ethernet: eth_stm32_hal: Modify RX thread creation

### DIFF
--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -45,10 +45,15 @@ config ETH_STM32_HAL_RX_THREAD_STACK_SIZE
 	  RX thread stack size
 
 config ETH_STM32_HAL_RX_THREAD_PRIO
-	int "RX thread priority"
+	int "STM32 Ethernet RX Thread Priority"
 	default 2
 	help
-	  RX thread priority
+	  This option allows to configure the priority of the RX thread that
+	  handles incoming Ethernet packets.
+	  Switching between preemptive and cooperative scheduling can be done by
+	  NET_TC_THREAD_PREEMPTIVE.
+	  Preemptive scheduling can lead to more responsive handling of network traffic,
+	  especially under high load.
 
 config ETH_STM32_HAL_USE_DTCM_FOR_DMA_BUFFER
 	bool "Use DTCM for DMA buffers"

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -1331,7 +1331,9 @@ static void eth_iface_init(struct net_if *iface)
 		k_thread_create(&dev_data->rx_thread, dev_data->rx_thread_stack,
 				K_KERNEL_STACK_SIZEOF(dev_data->rx_thread_stack),
 				rx_thread, (void *) dev, NULL, NULL,
-				K_PRIO_COOP(CONFIG_ETH_STM32_HAL_RX_THREAD_PRIO),
+				IS_ENABLED(CONFIG_NET_TC_THREAD_PREEMPTIVE)
+					? K_PRIO_PREEMPT(CONFIG_ETH_STM32_HAL_RX_THREAD_PRIO)
+					: K_PRIO_COOP(CONFIG_ETH_STM32_HAL_RX_THREAD_PRIO),
 				0, K_NO_WAIT);
 
 		k_thread_name_set(&dev_data->rx_thread, "stm_eth");


### PR DESCRIPTION
This change will allow users to configure the Ethernet RX thread according to their specific real-time requirements. 
Adding preemptive threading helps to reduce jitter and the impact of Ethernet traffic on real-time performance.