### PR TITLE
Drivers: Sensors: Bosch bmp390 merge into bmp388

### DIFF
--- a/drivers/sensor/bosch/bmp388/Kconfig
+++ b/drivers/sensor/bosch/bmp388/Kconfig
@@ -4,9 +4,11 @@
 menuconfig BMP388
 	bool "Bosch BMP388 pressure sensor"
 	default y
-	depends on DT_HAS_BOSCH_BMP388_ENABLED
-	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BMP388),i2c)
-	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BMP388),spi)
+	depends on DT_HAS_BOSCH_BMP388_ENABLED || DT_HAS_BOSCH_BMP390_ENABLED
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BMP388),i2c) || \
+			$(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BMP390),i2c)
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BMP388),spi) || \
+			$(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BMP390),spi)
 	help
 	  Enable driver for the Bosch BMP388 pressure sensor
 

--- a/drivers/sensor/bosch/bmp388/bmp388.h
+++ b/drivers/sensor/bosch/bmp388/bmp388.h
@@ -8,8 +8,8 @@
  * https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmp388-ds001.pdf
  */
 
-#ifndef __BMP388_H
-#define __BMP388_H
+#ifndef ZEPHYR_BMP388_H
+#define ZEPHYR_BMP388_H
 
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
@@ -19,16 +19,29 @@
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/sys/util.h>
 
-#define DT_DRV_COMPAT bosch_bmp388
-
+#define DT_DRV_COMPAT  bosch_bmp388
 #define BMP388_BUS_SPI DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
 #define BMP388_BUS_I2C DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
+#undef DT_DRV_COMPAT
+
+#define DT_DRV_COMPAT  bosch_bmp390
+#define BMP390_BUS_SPI DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
+#define BMP390_BUS_I2C DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
+#undef DT_DRV_COMPAT
+
+#if defined(BMP388_BUS_SPI) || defined(BMP390_BUS_SPI)
+#define BMP3XX_USE_SPI_BUS
+#endif
+
+#if defined(BMP388_BUS_I2C) || defined(BMP390_BUS_I2C)
+#define BMP3XX_USE_I2C_BUS
+#endif
 
 union bmp388_bus {
-#if BMP388_BUS_SPI
+#ifdef BMP3XX_USE_SPI_BUS
 	struct spi_dt_spec spi;
 #endif
-#if BMP388_BUS_I2C
+#ifdef BMP3XX_USE_I2C_BUS
 	struct i2c_dt_spec i2c;
 #endif
 };
@@ -45,13 +58,13 @@ struct bmp388_bus_io {
 	bmp388_reg_write_fn write;
 };
 
-#if BMP388_BUS_SPI
+#ifdef BMP3XX_USE_SPI_BUS
 #define BMP388_SPI_OPERATION (SPI_WORD_SET(8) | SPI_TRANSFER_MSB |	\
 			      SPI_MODE_CPOL | SPI_MODE_CPHA)
 extern const struct bmp388_bus_io bmp388_bus_io_spi;
 #endif
 
-#if BMP388_BUS_I2C
+#ifdef BMP3XX_USE_I2C_BUS
 extern const struct bmp388_bus_io bmp388_bus_io_i2c;
 #endif
 
@@ -176,6 +189,7 @@ struct bmp388_data {
 	uint8_t odr;
 	uint8_t osr_pressure;
 	uint8_t osr_temp;
+	uint8_t chip_id;
 	struct bmp388_cal_data cal;
 
 #if defined(CONFIG_BMP388_TRIGGER)
@@ -212,4 +226,4 @@ int bmp388_reg_field_update(const struct device *dev,
 			    uint8_t mask,
 			    uint8_t val);
 
-#endif /* __BMP388_H */
+#endif /* ZEPHYR_BMP388_H */

--- a/drivers/sensor/bosch/bmp388/bmp388_i2c.c
+++ b/drivers/sensor/bosch/bmp388/bmp388_i2c.c
@@ -12,7 +12,7 @@
 
 #include "bmp388.h"
 
-#if BMP388_BUS_I2C
+#ifdef BMP3XX_USE_I2C_BUS
 static int bmp388_bus_check_i2c(const union bmp388_bus *bus)
 {
 	return i2c_is_ready_dt(&bus->i2c) ? 0 : -ENODEV;
@@ -35,4 +35,4 @@ const struct bmp388_bus_io bmp388_bus_io_i2c = {
 	.read = bmp388_reg_read_i2c,
 	.write = bmp388_reg_write_i2c,
 };
-#endif /* BMP388_BUS_I2C */
+#endif /* BMP3XX_USE_I2C_BUS */

--- a/dts/bindings/sensor/bosch,bmp390-i2c.yaml
+++ b/dts/bindings/sensor/bosch,bmp390-i2c.yaml
@@ -1,0 +1,9 @@
+# Copyright (c) 2024 Chris Ruehl
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    Bosch BMP390 pressure sensor accessed through I2C bus
+
+compatible: "bosch,bmp390"
+
+include: [i2c-device.yaml, "bosch,bmp390.yaml"]

--- a/dts/bindings/sensor/bosch,bmp390-spi.yaml
+++ b/dts/bindings/sensor/bosch,bmp390-spi.yaml
@@ -1,0 +1,9 @@
+# Copyright (c) 2024 Chris Ruehl
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    Bosch BMP390 pressure sensor accessed through SPI bus
+
+compatible: "bosch,bmp390"
+
+include: [spi-device.yaml, "bosch,bmp390.yaml"]

--- a/dts/bindings/sensor/bosch,bmp390.yaml
+++ b/dts/bindings/sensor/bosch,bmp390.yaml
@@ -1,0 +1,107 @@
+# Copyright (c) 2024 Chris Ruehl
+# Code based on the bosch,bmp388.yaml
+# SPDX-License-Identifier: Apache-2.0
+
+# Common fields for BMP390
+
+include: sensor-device.yaml
+
+properties:
+  int-gpios:
+    type: phandle-array
+
+  odr:
+    type: string
+    description: |
+      Default output data rate in Hz. Only the following values are allowed:
+        200   - 200     - 5ms  (default; chip reset value)
+        100   - 100     - 10ms
+        50    - 50      - 20ms
+        25    - 25      - 40ms
+        12.5  - 25/2    - 80ms
+        6.25  - 25/4    - 160ms
+        3.125 - 25/8    - 320ms
+        1.563 - 25/16   - 640ms
+        .781  - 25/32   - 1.28s
+        .391  - 25/64   - 2.56s
+        .195  - 25/128  - 5.12s
+        .098  - 25/256  - 10.24s
+        .049  - 25/512  - 20.48s
+        .024  - 25/1024 - 40.96s
+        .012  - 25/2048 - 81.92s
+        .006  - 25/4096 - 163.84s
+        .003  - 25/8192 - 327.68s
+    default: "200"
+    enum:
+      - "200"
+      - "100"
+      - "50"
+      - "25"
+      - "12.5"
+      - "6.25"
+      - "3.125"
+      - "1.563"
+      - ".781"
+      - ".391"
+      - ".195"
+      - ".098"
+      - ".049"
+      - ".024"
+      - ".012"
+      - ".006"
+      - ".003"
+
+  osr-press:
+    type: int
+    description: |
+      Default pressure oversampling rate. Only the following values are
+      allowed:
+        1 sample, 16-bit, 2.64 Pa
+        2 samples, 17-bit, 1.32 Pa
+        4 samples, 18-bit, 0.66 Pa (default; chip reset value)
+        8 samples, 19-bit, 0.33 Pa
+        16 samples, 20-bit, 0.17 Pa
+        32 Samples, 21-bit, 0.085 Pa
+    default: 4
+    enum:
+      - 1
+      - 2
+      - 4
+      - 8
+      - 16
+      - 32
+
+  osr-temp:
+    type: int
+    description: |
+      Default temperature oversampling rate. Only the following values are
+      allowed:
+        1 sample, 16-bit, .0050 C (default; chip reset value)
+        2 samples, 17-bit, .0025 C
+        4 samples, 18-bit, .0012 C
+        8 samples, 19-bit, .0006 C
+        16 samples, 20-bit, .0003 C
+        32 Samples, 21-bit, .00015 C
+    default: 1
+    enum:
+      - 1
+      - 2
+      - 4
+      - 8
+      - 16
+      - 32
+
+  iir-filter:
+    type: int
+    description: |
+      Default IIR filter coefficient. The default 0 is the chip reset value.
+    default: 0
+    enum:
+      - 0
+      - 1
+      - 3
+      - 7
+      - 15
+      - 31
+      - 63
+      - 127

--- a/tests/drivers/build_all/sensor/app.overlay
+++ b/tests/drivers/build_all/sensor/app.overlay
@@ -145,7 +145,8 @@
 				   <&test_gpio 0 0>,
 				   <&test_gpio 0 0>,
 				   <&test_gpio 0 0>,
-				   <&test_gpio 0 0>;	/* 0x2e */
+				   <&test_gpio 0 0>,
+				   <&test_gpio 0 0>;	/* 0x2f */
 
 			#include "spi.dtsi"
 		};

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -1088,6 +1088,17 @@ test_i2c_tmp1075: tmp1075@98 {
 	interrupt-mode;
 };
 
+test_i2c_bmp390: bmp390@99 {
+	compatible = "bosch,bmp390";
+	reg = <0x99>;
+	int-gpios = <&test_gpio 0 0>;
+	osr-press = <0x01>;
+	odr = "12.5";
+	osr-press = <8>;
+	osr-temp = <1>;
+	iir-filter = <3>;
+};
+
 apds_9306: apds9306@92 {
 	compatible = "avago,apds9306";
 	reg = <0x92>;

--- a/tests/drivers/build_all/sensor/spi.dtsi
+++ b/tests/drivers/build_all/sensor/spi.dtsi
@@ -379,3 +379,15 @@ test_spi_tle9104: tle9104@2e {
 		#sensor-cells = <0>;
 	};
 };
+
+test_spi_bmp390: bmp390@2f {
+	compatible = "bosch,bmp390";
+	reg = <0x2f>;
+	spi-max-frequency = <0>;
+	int-gpios = <&test_gpio 0 0>;
+	osr-press = <0x01>;
+	odr = "12.5";
+	osr-press = <8>;
+	osr-temp = <1>;
+	iir-filter = <3>;
+};


### PR DESCRIPTION
Add support for Bosch bmp390 sensor, the drop in replacement for the bmp388 with same register but different chip-id. This patch make use of "bosch_bmp390" or "bosch_bmp388" and set the specific chip-id in a data->chip-id variable, which then used to check against the register value.

Additional, manual shift operation had been replaced with ENDIAN safe macros, and calibration values with target variable of int16_t add a cast for it.