### PR TITLE
arch: riscv: fatal: always print `mcause` & `mtval`, make `cause_str()` reusable

### DIFF
--- a/arch/riscv/core/fatal.c
+++ b/arch/riscv/core/fatal.c
@@ -52,7 +52,7 @@ uintptr_t z_riscv_get_sp_before_exc(const struct arch_esf *esf)
 	return sp;
 }
 
-static char *cause_str(unsigned long cause)
+const char *z_riscv_mcause_str(unsigned long cause)
 {
 	switch (cause) {
 	case 0:
@@ -103,7 +103,7 @@ FUNC_NORETURN void z_riscv_fatal_error_csf(unsigned int reason, const struct arc
 
 	mcause &= CONFIG_RISCV_MCAUSE_EXCEPTION_MASK;
 	LOG_ERR("");
-	LOG_ERR(" mcause: %ld, %s", mcause, cause_str(mcause));
+	LOG_ERR(" mcause: %ld, %s", mcause, z_riscv_mcause_str(mcause));
 
 #ifndef CONFIG_SOC_OPENISA_RV32M1
 	unsigned long mtval;

--- a/arch/riscv/core/fatal.c
+++ b/arch/riscv/core/fatal.c
@@ -52,6 +52,42 @@ uintptr_t z_riscv_get_sp_before_exc(const struct arch_esf *esf)
 	return sp;
 }
 
+static char *cause_str(unsigned long cause)
+{
+	switch (cause) {
+	case 0:
+		return "Instruction address misaligned";
+	case 1:
+		return "Instruction Access fault";
+	case 2:
+		return "Illegal instruction";
+	case 3:
+		return "Breakpoint";
+	case 4:
+		return "Load address misaligned";
+	case 5:
+		return "Load access fault";
+	case 6:
+		return "Store/AMO address misaligned";
+	case 7:
+		return "Store/AMO access fault";
+	case 8:
+		return "Environment call from U-mode";
+	case 9:
+		return "Environment call from S-mode";
+	case 11:
+		return "Environment call from M-mode";
+	case 12:
+		return "Instruction page fault";
+	case 13:
+		return "Load page fault";
+	case 15:
+		return "Store/AMO page fault";
+	default:
+		return "unknown";
+	}
+}
+
 FUNC_NORETURN void z_riscv_fatal_error(unsigned int reason,
 				       const struct arch_esf *esf)
 {
@@ -61,6 +97,21 @@ FUNC_NORETURN void z_riscv_fatal_error(unsigned int reason,
 FUNC_NORETURN void z_riscv_fatal_error_csf(unsigned int reason, const struct arch_esf *esf,
 					   const _callee_saved_t *csf)
 {
+	unsigned long mcause;
+
+	__asm__ volatile("csrr %0, mcause" : "=r" (mcause));
+
+	mcause &= CONFIG_RISCV_MCAUSE_EXCEPTION_MASK;
+	LOG_ERR("");
+	LOG_ERR(" mcause: %ld, %s", mcause, cause_str(mcause));
+
+#ifndef CONFIG_SOC_OPENISA_RV32M1
+	unsigned long mtval;
+
+	__asm__ volatile("csrr %0, mtval" : "=r" (mtval));
+	LOG_ERR("  mtval: %lx", mtval);
+#endif /* CONFIG_SOC_OPENISA_RV32M1 */
+
 #ifdef CONFIG_EXCEPTION_DEBUG
 	if (esf != NULL) {
 		LOG_ERR("     a0: " PR_REG "    t0: " PR_REG, esf->a0, esf->t0);
@@ -106,42 +157,6 @@ FUNC_NORETURN void z_riscv_fatal_error_csf(unsigned int reason, const struct arc
 
 	z_fatal_error(reason, esf);
 	CODE_UNREACHABLE;
-}
-
-static char *cause_str(unsigned long cause)
-{
-	switch (cause) {
-	case 0:
-		return "Instruction address misaligned";
-	case 1:
-		return "Instruction Access fault";
-	case 2:
-		return "Illegal instruction";
-	case 3:
-		return "Breakpoint";
-	case 4:
-		return "Load address misaligned";
-	case 5:
-		return "Load access fault";
-	case 6:
-		return "Store/AMO address misaligned";
-	case 7:
-		return "Store/AMO access fault";
-	case 8:
-		return "Environment call from U-mode";
-	case 9:
-		return "Environment call from S-mode";
-	case 11:
-		return "Environment call from M-mode";
-	case 12:
-		return "Instruction page fault";
-	case 13:
-		return "Load page fault";
-	case 15:
-		return "Store/AMO page fault";
-	default:
-		return "unknown";
-	}
 }
 
 static bool bad_stack_pointer(struct arch_esf *esf)
@@ -206,22 +221,6 @@ void _Fault(struct arch_esf *esf)
 		}
 	}
 #endif /* CONFIG_USERSPACE */
-
-	unsigned long mcause;
-
-	__asm__ volatile("csrr %0, mcause" : "=r" (mcause));
-
-#ifndef CONFIG_SOC_OPENISA_RV32M1
-	unsigned long mtval;
-	__asm__ volatile("csrr %0, mtval" : "=r" (mtval));
-#endif
-
-	mcause &= CONFIG_RISCV_MCAUSE_EXCEPTION_MASK;
-	LOG_ERR("");
-	LOG_ERR(" mcause: %ld, %s", mcause, cause_str(mcause));
-#ifndef CONFIG_SOC_OPENISA_RV32M1
-	LOG_ERR("  mtval: %lx", mtval);
-#endif
 
 	unsigned int reason = K_ERR_CPU_EXCEPTION;
 

--- a/arch/riscv/core/fatal.c
+++ b/arch/riscv/core/fatal.c
@@ -54,38 +54,27 @@ uintptr_t z_riscv_get_sp_before_exc(const struct arch_esf *esf)
 
 const char *z_riscv_mcause_str(unsigned long cause)
 {
-	switch (cause) {
-	case 0:
-		return "Instruction address misaligned";
-	case 1:
-		return "Instruction Access fault";
-	case 2:
-		return "Illegal instruction";
-	case 3:
-		return "Breakpoint";
-	case 4:
-		return "Load address misaligned";
-	case 5:
-		return "Load access fault";
-	case 6:
-		return "Store/AMO address misaligned";
-	case 7:
-		return "Store/AMO access fault";
-	case 8:
-		return "Environment call from U-mode";
-	case 9:
-		return "Environment call from S-mode";
-	case 11:
-		return "Environment call from M-mode";
-	case 12:
-		return "Instruction page fault";
-	case 13:
-		return "Load page fault";
-	case 15:
-		return "Store/AMO page fault";
-	default:
-		return "unknown";
-	}
+	static const char *const mcause_str[17] = {
+		[0] = "Instruction address misaligned",
+		[1] = "Instruction Access fault",
+		[2] = "Illegal instruction",
+		[3] = "Breakpoint",
+		[4] = "Load address misaligned",
+		[5] = "Load access fault",
+		[6] = "Store/AMO address misaligned",
+		[7] = "Store/AMO access fault",
+		[8] = "Environment call from U-mode",
+		[9] = "Environment call from S-mode",
+		[10] = "unknown",
+		[11] = "Environment call from M-mode",
+		[12] = "Instruction page fault",
+		[13] = "Load page fault",
+		[14] = "unknown",
+		[15] = "Store/AMO page fault",
+		[16] = "unknown",
+	};
+
+	return mcause_str[MIN(cause, ARRAY_SIZE(mcause_str) - 1)];
 }
 
 FUNC_NORETURN void z_riscv_fatal_error(unsigned int reason,


### PR DESCRIPTION
Relocate the logging of mcause & mtval from `_Fault` to
`z_riscv_fatal_error_csf` so that they are always printed
upon exception.

Rename `z_riscv_cause_str` to `cause_str` and make it non-static,
so that it can be used in user-implemented `k_sys_fatal_error_handler`.

Also, this function should return a constant string, so add `const`
to it.