### PR TITLE
STM32 :  add soc for stm32u073 series

### DIFF
--- a/dts/arm/st/u0/stm32u073.dtsi
+++ b/dts/arm/st/u0/stm32u073.dtsi
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2024 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <st/u0/stm32u031.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32u073", "st,stm32u0", "simple-bus";
+	};
+
+	sram1: memory@20000000 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		zephyr,memory-region = "SRAM1";
+	};
+
+	sram2: memory@20008000 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		zephyr,memory-region = "SRAM2";
+	};
+};

--- a/dts/arm/st/u0/stm32u073X8.dtsi
+++ b/dts/arm/st/u0/stm32u073X8.dtsi
@@ -1,0 +1,26 @@
+
+/*
+ * Copyright (c) 2024 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <mem.h>
+#include <st/u0/stm32u073.dtsi>
+
+/ {
+	sram1: memory@20000000 {
+		reg = <0x20000000 DT_SIZE_K(32)>;
+	};
+
+	sram2: memory@20008000 {
+		reg = <0x20008000 DT_SIZE_K(8)>;
+	};
+
+	soc {
+		flash-controller@40022000 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_K(64)>;
+			};
+		};
+	};
+};

--- a/dts/arm/st/u0/stm32u073Xb.dtsi
+++ b/dts/arm/st/u0/stm32u073Xb.dtsi
@@ -1,0 +1,26 @@
+
+/*
+ * Copyright (c) 2024 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <mem.h>
+#include <st/u0/stm32u073.dtsi>
+
+/ {
+	sram1: memory@20000000 {
+		reg = <0x20000000 DT_SIZE_K(32)>;
+	};
+
+	sram2: memory@20008000 {
+		reg = <0x20008000 DT_SIZE_K(8)>;
+	};
+
+	soc {
+		flash-controller@40022000 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_K(128)>;
+			};
+		};
+	};
+};

--- a/dts/arm/st/u0/stm32u073Xc.dtsi
+++ b/dts/arm/st/u0/stm32u073Xc.dtsi
@@ -1,0 +1,26 @@
+
+/*
+ * Copyright (c) 2024 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <mem.h>
+#include <st/u0/stm32u073.dtsi>
+
+/ {
+	sram1: memory@20000000 {
+		reg = <0x20000000 DT_SIZE_K(32)>;
+	};
+
+	sram2: memory@20008000 {
+		reg = <0x20008000 DT_SIZE_K(8)>;
+	};
+
+	soc {
+		flash-controller@40022000 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_K(256)>;
+			};
+		};
+	};
+};

--- a/dts/arm/st/u0/stm32u083.dtsi
+++ b/dts/arm/st/u0/stm32u083.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <st/u0/stm32u031.dtsi>
+#include <st/u0/stm32u073.dtsi>
 
 / {
 	soc {

--- a/soc/st/stm32/soc.yml
+++ b/soc/st/stm32/soc.yml
@@ -184,6 +184,7 @@ family:
   - name: stm32u0x
     socs:
     - name: stm32u031xx
+    - name: stm32u073xx
     - name: stm32u083xx
   - name: stm32u5x
     socs:

--- a/soc/st/stm32/stm32u0x/Kconfig.defconfig.stm32u073xx
+++ b/soc/st/stm32/stm32u0x/Kconfig.defconfig.stm32u073xx
@@ -1,0 +1,11 @@
+# STMicroelectronics STM32U073XX MCU
+
+# Copyright (c) 2024 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_STM32U073XX
+
+config NUM_IRQS
+	default 32
+
+endif # SOC_STM32U073XX

--- a/soc/st/stm32/stm32u0x/Kconfig.soc
+++ b/soc/st/stm32/stm32u0x/Kconfig.soc
@@ -14,10 +14,15 @@ config SOC_STM32U031XX
 	bool
 	select SOC_SERIES_STM32U0X
 
+config SOC_STM32U073XX
+	bool
+	select SOC_SERIES_STM32U0X
+
 config SOC_STM32U083XX
 	bool
 	select SOC_SERIES_STM32U0X
 
 config SOC
 	default "stm32u031xx" if SOC_STM32U031XX
+	default "stm32u073xx" if SOC_STM32U073XX
 	default "stm32u083xx" if SOC_STM32U083XX


### PR DESCRIPTION
select soc for stm32 nucleo_u073xx boards  and irq default configuration