### PR TITLE
board: imx93_evk: fix document introduced by hwmv2

### DIFF
--- a/boards/nxp/imx93_evk/doc/index.rst
+++ b/boards/nxp/imx93_evk/doc/index.rst
@@ -161,19 +161,19 @@ for example, with the :zephyr:code-sample:`synchronization` sample:
 .. zephyr-app-commands::
    :zephyr-app: samples/synchronization
    :host-os: unix
-   :board: mimx93_evk/mimx9352/a55
-   :goals: run
+   :board: imx93_evk/mimx9352/a55
+   :goals: build
 
 This will build an image with the synchronization sample app, boot it and
 display the following console output:
 
 .. code-block:: console
 
-    *** Booting Zephyr OS build zephyr-v3.2.0-8-g1613870534a0  ***
-    thread_a: Hello World from cpu 0 on mimx93_evk_a55!
-    thread_b: Hello World from cpu 0 on mimx93_evk_a55!
-    thread_a: Hello World from cpu 0 on mimx93_evk_a55!
-    thread_b: Hello World from cpu 0 on mimx93_evk_a55!
+    *** Booting Zephyr OS build Booting Zephyr OS build v3.7.0-2055-g630f27a5a867  ***
+    thread_a: Hello World from cpu 0 on imx93_evk!
+    thread_b: Hello World from cpu 0 on imx93_evk!
+    thread_a: Hello World from cpu 0 on imx93_evk!
+    thread_b: Hello World from cpu 0 on imx93_evk!
 
 Programming and Debugging (M33)
 *******************************


### PR DESCRIPTION
Fixed board name according to hwmv2 update, and also updated the demo log.