### PR TITLE
doc: samples: Improve code sample list styling

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -965,3 +965,21 @@ dark-mode-toggle::part(toggleLabel){
     font-size: 0.875em;
     font-weight: bold;
 }
+
+.code-sample-list li {
+    margin-bottom: 0.25em;
+}
+.code-sample-name {
+    font-weight: bold;
+    padding-right: 0.5em;
+}
+
+.code-sample-description {
+    font-weight: 300;
+}
+
+.code-sample-description::before {
+    content: '\F0A9'; /* arrow-circle-right */
+    font-family: 'FontAwesome';
+    padding-right: 0.5em;
+}


### PR DESCRIPTION
Make lists of code samples more compact (a lot of vertical real estate was being wasted) and more visually appealing.

<img width="739" alt="image" src="https://github.com/user-attachments/assets/8ceef074-2f5d-4238-b4df-404f35c487bf">

After:
https://builds.zephyrproject.io/zephyr/pr/77918/docs/connectivity/networking/api/coap.html#api-reference

Before:
https://docs.zephyrproject.org/latest/connectivity/networking/api/coap.html#api-reference