### PR TITLE
dts: arm: st: stm32h5: fix spi 1-3 clocks

### DIFF
--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -451,7 +451,8 @@
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
 			interrupts = <55 5>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00001000>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00001000>,
+				 <&rcc STM32_SRC_PLL1_Q SPI1_SEL(0)>;
 			status = "disabled";
 		};
 
@@ -461,7 +462,8 @@
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
 			interrupts = <56 5>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00004000>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00004000>,
+				 <&rcc STM32_SRC_PLL1_Q SPI2_SEL(0)>;
 			status = "disabled";
 		};
 
@@ -471,7 +473,8 @@
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
 			interrupts = <57 5>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00008000>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00008000>,
+				 <&rcc STM32_SRC_PLL1_Q SPI3_SEL(0)>;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
The STM32 SPI driver, `spi_ll_stm32.c`, reads the clock frequency via `clock_control_get_rate()`. The first `clocks` index is used as subsystem argument if there is no second index, but this is not the source clock for SPI 1, 2, and 3.
This causes the prescaler value calculation to be incorrect, resulting in a frequency potentially above the `spi-max-frequency` value.

Add clock source for SPI instances 1, 2 and 3, that matches the default clock configuration register reset value, which resolves the issue.