### PR TITLE
cmake: Do not fill gaps of hex/s19 files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1644,7 +1644,6 @@ if(CONFIG_BUILD_OUTPUT_HEX OR BOARD_FLASH_RUNNER STREQUAL openocd)
       post_build_commands
       COMMAND $<TARGET_PROPERTY:bintools,elfconvert_command>
               $<TARGET_PROPERTY:bintools,elfconvert_flag>
-              ${GAP_FILL}
               $<TARGET_PROPERTY:bintools,elfconvert_flag_outtarget>ihex
               ${remove_sections_argument_list}
               $<TARGET_PROPERTY:bintools,elfconvert_flag_infile>${KERNEL_ELF_NAME}
@@ -1753,7 +1752,6 @@ if(CONFIG_BUILD_OUTPUT_S19)
       post_build_commands
       COMMAND $<TARGET_PROPERTY:bintools,elfconvert_command>
               $<TARGET_PROPERTY:bintools,elfconvert_flag>
-              ${GAP_FILL}
               $<TARGET_PROPERTY:bintools,elfconvert_flag_outtarget>srec
               $<TARGET_PROPERTY:bintools,elfconvert_flag_srec_len>1
               $<TARGET_PROPERTY:bintools,elfconvert_flag_infile>${KERNEL_ELF_NAME}

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -694,7 +694,7 @@ config CLEANUP_INTERMEDIATE_FILES
 	  (Software Bill of Material generation), and maybe others.
 
 config BUILD_NO_GAP_FILL
-	bool "Don't fill gaps in generated hex/bin/s19 files."
+	bool "Don't fill gaps in generated bin files by the 0xFF pattern."
 
 config BUILD_OUTPUT_HEX
 	bool "Build a binary in HEX format"


### PR DESCRIPTION
- Do not fill gaps in generated hex/s19 files, to be equivalent to contents of elf files.
- Fixes possible generation of large hex/s19 files.