### PR TITLE
drivers: sensors: explorir_m: fix uart flush early termination

### DIFF
--- a/drivers/sensor/explorir_m/explorir_m.c
+++ b/drivers/sensor/explorir_m/explorir_m.c
@@ -83,10 +83,11 @@ static void explorir_m_uart_flush_until_end(const struct device *uart_dev)
 	uint32_t uptime;
 
 	uptime = k_uptime_get_32();
-	do {
-		uart_poll_in(uart_dev, &tmp);
-	} while (tmp != EXPLORIR_M_END_CHAR &&
-		 k_uptime_get_32() - uptime < EXPLORIR_M_MAX_RESPONSE_DELAY);
+	while (k_uptime_get_32() - uptime < EXPLORIR_M_MAX_RESPONSE_DELAY) {
+		if (uart_poll_in(uart_dev, &tmp) == 0 && tmp == EXPLORIR_M_END_CHAR) {
+			break;
+		}
+	}
 }
 
 static void explorir_m_buffer_reset(struct explorir_m_data *data)


### PR DESCRIPTION
`explorir_m_uart_flush_until_end` terminates immediately if the read variable is initially equal to `EXPLORIR_M_MAX_RESPONSE_DELAY` and `uart_poll_in` does not read anything.

Fix this by only checking the read variable if `uart_poll_in` reads a char.