### PR TITLE
soc: intel_adsp: ace: Configurable SRAM retention mode and cleanup

### DIFF
--- a/soc/intel/intel_adsp/ace/Kconfig
+++ b/soc/intel/intel_adsp/ace/Kconfig
@@ -23,3 +23,11 @@ config SOC_INTEL_COMM_WIDGET
 	help
 	  Select this to enable Intel Communication Widget driver.
 	  DSP Communication Widget is a device for generic sideband message transmit/receive.
+
+config SRAM_RETENTION_MODE
+	bool "SRAM retention mode during initialization"
+	default y
+	help
+	  When this option is enabled, the SRAM retention mode will be
+	  activated during the firmware boot-up process. If disabled,
+	  the retention mode will not be activated.

--- a/soc/intel/intel_adsp/ace/sram.c
+++ b/soc/intel/intel_adsp/ace/sram.c
@@ -13,8 +13,6 @@
 #include <cpu_init.h>
 #include "manifest.h"
 
-#define DELAY_COUNT			256
-
 __imr void hp_sram_init(uint32_t memory_size)
 {
 	ARG_UNUSED(memory_size);
@@ -24,7 +22,7 @@ __imr void hp_sram_init(uint32_t memory_size)
 
 	for (idx = 0; idx < hpsram_ebb_quantity; ++idx) {
 		HPSRAM_REGS(idx)->HSxPGCTL = 0;
-		HPSRAM_REGS(idx)->HSxRMCTL = 1;
+		HPSRAM_REGS(idx)->HSxRMCTL = IS_ENABLED(CONFIG_SRAM_RETENTION_MODE);
 	}
 	for (idx = 0; idx < hpsram_ebb_quantity; ++idx) {
 		while (HPSRAM_REGS(idx)->HSxPGISTS != 0) {
@@ -41,7 +39,7 @@ __imr void lp_sram_init(void)
 
 	for (idx = 0; idx < lpsram_ebb_quantity; ++idx) {
 		LPSRAM_REGS(idx)->USxPGCTL = 0;
-		LPSRAM_REGS(idx)->USxRMCTL = 1;
+		LPSRAM_REGS(idx)->USxRMCTL = IS_ENABLED(CONFIG_SRAM_RETENTION_MODE);
 	}
 	for (idx = 0; idx < lpsram_ebb_quantity; ++idx) {
 		while (LPSRAM_REGS(idx)->USxPGISTS != 0) {


### PR DESCRIPTION
This commit introduces a new Kconfig option `CONFIG_SRAM_RETENTION_MODE` that allows the configuration of SRAM retention mode during the initialization phase of the firmware boot-up process. By default, the retention mode is enabled to maintain the existing behavior. However, this option provides the flexibility to disable the retention mode if needed, without modifying the Zephyr codebase.

The SRAM initialization functions `hp_sram_init` and `lp_sram_init` in `sram.c` have been updated to conditionally set the retention mode based on the value of this Kconfig option.

Additionally, an unused macro `DELAY_COUNT` has been removed from `sram.c` to clean up the code.