### PR TITLE
net: fix compiler warning -Wtype-limits

### DIFF
--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -860,7 +860,8 @@ static inline enum net_if_oper_state net_if_oper_state_set(
 	NET_ASSERT(iface);
 	NET_ASSERT(iface->if_dev);
 
-	if (oper_state >= NET_IF_OPER_UNKNOWN && oper_state <= NET_IF_OPER_UP) {
+	BUILD_ASSERT((enum net_if_oper_state)(-1) > 0 && NET_IF_OPER_UNKNOWN == 0);
+	if (oper_state <= NET_IF_OPER_UP) {
 		iface->if_dev->oper_state = oper_state;
 	}
 


### PR DESCRIPTION
Move the lower bounds check of the enum value to a BUILD_ASSERT and make sure the enum type is an unsigned integer.