### PR TITLE
boards: nrf54l15bsim: DTS cleanup

### DIFF
--- a/boards/native/nrf_bsim/nrf54l15bsim_nrf54l15_cpuapp.dts
+++ b/boards/native/nrf_bsim/nrf54l15bsim_nrf54l15_cpuapp.dts
@@ -60,9 +60,6 @@
 			/delete-node/ gpio@10a000;
 			/delete-node/ gpiote@10c000;
 		};
-		/delete-node/ spu@50003000;
-		/delete-node/ gpiote@5000d000;
-		/delete-node/ crypto@50844000;
 	};
 
 	rng: rng {


### PR DESCRIPTION
Remove 3 delete-node directives which do not apply to this SOC.
They made it in originally thru a copy paste mistake from the nrf5340bsim dts file.