### PR TITLE
i2c: nrf_twi: Add cast to const buffer pointers

### DIFF
--- a/drivers/i2c/i2c_nrfx_twi_rtio.c
+++ b/drivers/i2c/i2c_nrfx_twi_rtio.c
@@ -72,11 +72,12 @@ static bool i2c_nrfx_twi_rtio_start(const struct device *dev)
 						   sqe->rx.buf, sqe->rx.buf_len, dt_spec->addr);
 	case RTIO_OP_TINY_TX:
 		return i2c_nrfx_twi_rtio_msg_start(dev, I2C_MSG_WRITE | sqe->iodev_flags,
-						   sqe->tiny_tx.buf, sqe->tiny_tx.buf_len,
-						   dt_spec->addr);
+						   (uint8_t *)sqe->tiny_tx.buf,
+						   sqe->tiny_tx.buf_len, dt_spec->addr);
 	case RTIO_OP_TX:
 		return i2c_nrfx_twi_rtio_msg_start(dev, I2C_MSG_WRITE | sqe->iodev_flags,
-						   sqe->tx.buf, sqe->tx.buf_len, dt_spec->addr);
+						   (uint8_t *)sqe->tx.buf,
+						   sqe->tx.buf_len, dt_spec->addr);
 	case RTIO_OP_I2C_CONFIGURE:
 		(void)i2c_nrfx_twi_configure(dev, sqe->i2c_config);
 		return false;


### PR DESCRIPTION
A warning was issued in the build as the rtio tx and tiny_tx buffer pointers are now labeled const. The internal API expects mutable buffers so an explicit cast is needed here to avoid the warning.

Fixes #77853 