### PR TITLE
cmake: Fix finding python in virtualenv

### DIFF
--- a/cmake/modules/python.cmake
+++ b/cmake/modules/python.cmake
@@ -25,7 +25,7 @@ if(NOT Python3_EXECUTABLE)
   # cause just using find_program directly could result in a python2.7 as python,
   # and not finding a valid python3.
   foreach(candidate "python" "python3")
-    find_program(Python3_EXECUTABLE ${candidate} PATHS ENV VIRTUAL_ENV NO_CMAKE_PATH)
+    find_program(Python3_EXECUTABLE ${candidate} PATHS ENV VIRTUAL_ENV NO_CMAKE_PATH NO_CMAKE_ENVIRONMENT_PATH)
     if(Python3_EXECUTABLE)
         execute_process (COMMAND "${Python3_EXECUTABLE}" -c
                                  "import sys; sys.stdout.write('.'.join([str(x) for x in sys.version_info[:2]]))"


### PR DESCRIPTION
When running cmake directly (without west, as twister does) on nix the CMake environment paths are set and thus it does not find the virtualenv'ed python. Fix this by ignoring the cmake environment variables nix sets.