### PR TITLE
samples: subsys: use zephyr:code-sample directive

### DIFF
--- a/doc/services/debugging/debugmon.rst
+++ b/doc/services/debugging/debugmon.rst
@@ -64,4 +64,4 @@ Using other custom ISR
 ======================
 In order to provide a custom debug monitor interrupt, override ``z_arm_debug_monitor``
 symbol. Additionally, manual configuration of some registers is required
-(see :ref:`debug monitor sample<debugmon-sample>`).
+(see :zephyr:code-sample:`debugmon` sample).

--- a/doc/services/ipc/ipc_service/backends/ipc_service_icbmsg.rst
+++ b/doc/services/ipc/ipc_service/backends/ipc_service_icbmsg.rst
@@ -80,4 +80,4 @@ Swap the MBOX channels, memory regions (``tx-region`` and ``rx-region``), and bl
 Samples
 =======
 
-* :ref:`ipc_multi_endpoint_sample`
+* :zephyr:code-sample:`ipc_multi_endpoint`

--- a/samples/subsys/dap/README.rst
+++ b/samples/subsys/dap/README.rst
@@ -1,7 +1,7 @@
-.. _dap-sample:
+.. zephyr:code-sample:: cmsis-dap
+   :name: CMSIS-DAP
 
-DAP Sample Application
-######################
+   Implement a custom CMSIS-DAP controller using SWDP interface driver.
 
 Overview
 ********

--- a/samples/subsys/debug/debugmon/README.rst
+++ b/samples/subsys/debug/debugmon/README.rst
@@ -1,7 +1,7 @@
-.. _debugmon-sample:
+.. zephyr:code-sample:: debugmon
+   :name: Debug Monitor
 
-Debug monitor
-#############
+   Configure the Debug Monitor feature on a Cortex-M processor.
 
 Overview
 ********

--- a/samples/subsys/debug/fuzz/README.rst
+++ b/samples/subsys/debug/fuzz/README.rst
@@ -1,11 +1,13 @@
-Fuzzing Example
-###############
+.. zephyr:code-sample:: fuzzing
+   :name: Fuzzing
+
+   Integrate fuzz testing with Zephyr apps.
 
 Overview
 ********
 
 This is a simple example of fuzz test integration with Zephyr apps
-that displays LLVM libfuzzer's most important feature: it's ability to
+that displays LLVM libfuzzer's most important feature: its ability to
 detect and explore deep and complicated call trees by exploiting
 coverage information gleaned from instrumented binaries.
 

--- a/samples/subsys/ipc/ipc_service/multi_endpoint/README.rst
+++ b/samples/subsys/ipc/ipc_service/multi_endpoint/README.rst
@@ -1,7 +1,8 @@
-.. _ipc_multi_endpoint_sample:
+.. zephyr:code-sample:: ipc_multi_endpoint
+   :name: IPC service: Multi-endpoint
+   :relevant-api: ipc
 
-IPC Service - Multi-endpoint Sample Application
-###############################################
+   Use the IPC Service with multiple endpoints.
 
 This application demonstrates how to use IPC Service with multiple endpoints.
 By default, it uses the ``icmsg_me`` backend.

--- a/samples/subsys/sip_svc/README.rst
+++ b/samples/subsys/sip_svc/README.rst
@@ -1,7 +1,7 @@
-.. _sip_svc_sample:
+.. zephyr:code-sample:: sip_svc
+   :name: Arm SiP Services on Intel Agilex SoC FPGA
 
-SiP SVC sample
-##############
+   Use the SiP SVC subsystem to interact with the Secure Device Manager on Intel Agilex SoC FPGA.
 
 Overview
 ********


### PR DESCRIPTION
Adds missing code-sample directive to the remaining samples in `samples/subsys` that didn't use it yet in preparation for upcoming changes to the Zephyr documentation that will be leveraging the provided description and metadata.