### PR TITLE
boards: xtensa/sample_controller: no HAL for xcc or xt-clang

### DIFF
--- a/soc/cdns/xtensa_sample_controller/Kconfig
+++ b/soc/cdns/xtensa_sample_controller/Kconfig
@@ -3,5 +3,5 @@
 
 config SOC_XTENSA_SAMPLE_CONTROLLER
 	select XTENSA
-	select XTENSA_HAL
+	select XTENSA_HAL if ("$(ZEPHYR_TOOLCHAIN_VARIANT)" != "xcc" && "$(ZEPHYR_TOOLCHAIN_VARIANT)" != "xt-clang")
 	select ARCH_SUPPORTS_COREDUMP


### PR DESCRIPTION
Xtensa toolchains also contain a profile for sample_controller. So if compiling for it, skip the Xtensa HAL module in Zephyr tree so the toolchain can use the one included in the toolchain.