### PR TITLE
drivers: display: stm32_ltdc: fix return value

### DIFF
--- a/drivers/display/display_stm32_ltdc.c
+++ b/drivers/display/display_stm32_ltdc.c
@@ -254,8 +254,10 @@ static int stm32_ltdc_display_blanking_off(const struct device *dev)
 	const struct display_stm32_ltdc_config *config = dev->config;
 	const struct device *display_dev = config->display_controller;
 
+	/* Panel controller's phandle is not passed to LTDC in devicetree */
 	if (display_dev == NULL) {
-		return 0;
+		LOG_ERR("There is no panel controller to forward blanking_off call to");
+		return -ENOSYS;
 	}
 
 	if (!device_is_ready(display_dev)) {
@@ -271,8 +273,10 @@ static int stm32_ltdc_display_blanking_on(const struct device *dev)
 	const struct display_stm32_ltdc_config *config = dev->config;
 	const struct device *display_dev = config->display_controller;
 
+	/* Panel controller's phandle is not passed to LTDC in devicetree */
 	if (display_dev == NULL) {
-		return 0;
+		LOG_ERR("There is no panel controller to forward blanking_on call to");
+		return -ENOSYS;
 	}
 
 	if (!device_is_ready(config->display_controller)) {


### PR DESCRIPTION
Blanking On/Off calls should not return 0 when there is no panel controller to forward them to, instead they should return ENOSYS to signal to the application that they were not actually executed.

"device_is_ready" does check for null, but also for "dev->state->initialized == false", so we need to isolate the "dev == NULL" case.

Fixes #75265