### PR TITLE
drivers: i3c: add i3c ccc entas

### DIFF
--- a/drivers/i3c/i3c_ccc.c
+++ b/drivers/i3c/i3c_ccc.c
@@ -239,6 +239,40 @@ int i3c_ccc_do_events_set(struct i3c_device_desc *target,
 	return i3c_do_ccc(target->bus, &ccc_payload);
 }
 
+int i3c_ccc_do_entas(const struct i3c_device_desc *target, uint8_t as)
+{
+	struct i3c_ccc_payload ccc_payload;
+	struct i3c_ccc_target_payload ccc_tgt_payload;
+
+	__ASSERT_NO_MSG(target != NULL);
+	__ASSERT_NO_MSG(target->bus != NULL);
+	__ASSERT_NO_MSG(as <= 3);
+
+	memset(&ccc_payload, 0, sizeof(ccc_payload));
+
+	ccc_tgt_payload.addr = target->dynamic_addr;
+	ccc_tgt_payload.rnw = 0;
+
+	ccc_payload.ccc.id = I3C_CCC_ENTAS(as, false);
+	ccc_payload.targets.payloads = &ccc_tgt_payload;
+	ccc_payload.targets.num_targets = 1;
+
+	return i3c_do_ccc(target->bus, &ccc_payload);
+}
+
+int i3c_ccc_do_entas_all(const struct device *controller, uint8_t as)
+{
+	struct i3c_ccc_payload ccc_payload;
+
+	__ASSERT_NO_MSG(controller != NULL);
+	__ASSERT_NO_MSG(as <= 3);
+
+	memset(&ccc_payload, 0, sizeof(ccc_payload));
+	ccc_payload.ccc.id = I3C_CCC_ENTAS(as, true);
+
+	return i3c_do_ccc(controller, &ccc_payload);
+}
+
 int i3c_ccc_do_setmwl_all(const struct device *controller,
 			  const struct i3c_ccc_mwl *mwl)
 {

--- a/drivers/i3c/i3c_shell.c
+++ b/drivers/i3c/i3c_shell.c
@@ -1062,6 +1062,226 @@ static int cmd_i3c_ccc_disec(const struct shell *shell_ctx, size_t argc, char **
 	return ret;
 }
 
+/* i3c ccc entas0_bc <device> */
+static int cmd_i3c_ccc_entas0_bc(const struct shell *shell_ctx, size_t argc, char **argv)
+{
+	const struct device *dev;
+	struct i3c_driver_data *data;
+	int ret;
+
+	dev = device_get_binding(argv[ARGV_DEV]);
+	if (!dev) {
+		shell_error(shell_ctx, "I3C: Device driver %s not found.", argv[ARGV_DEV]);
+		return -ENODEV;
+	}
+	data = (struct i3c_driver_data *)dev->data;
+
+	ret = i3c_ccc_do_entas0_all(dev);
+	if (ret < 0) {
+		shell_error(shell_ctx, "I3C: unable to send CCC ENTAS0 BC.");
+		return ret;
+	}
+
+	return ret;
+}
+
+/* i3c ccc entas1_bc <device> */
+static int cmd_i3c_ccc_entas1_bc(const struct shell *shell_ctx, size_t argc, char **argv)
+{
+	const struct device *dev;
+	struct i3c_driver_data *data;
+	int ret;
+
+	dev = device_get_binding(argv[ARGV_DEV]);
+	if (!dev) {
+		shell_error(shell_ctx, "I3C: Device driver %s not found.", argv[ARGV_DEV]);
+		return -ENODEV;
+	}
+	data = (struct i3c_driver_data *)dev->data;
+
+	ret = i3c_ccc_do_entas1_all(dev);
+	if (ret < 0) {
+		shell_error(shell_ctx, "I3C: unable to send CCC ENTAS1 BC.");
+		return ret;
+	}
+
+	return ret;
+}
+
+/* i3c ccc entas2_bc <device> */
+static int cmd_i3c_ccc_entas2_bc(const struct shell *shell_ctx, size_t argc, char **argv)
+{
+	const struct device *dev;
+	struct i3c_driver_data *data;
+	int ret;
+
+	dev = device_get_binding(argv[ARGV_DEV]);
+	if (!dev) {
+		shell_error(shell_ctx, "I3C: Device driver %s not found.", argv[ARGV_DEV]);
+		return -ENODEV;
+	}
+	data = (struct i3c_driver_data *)dev->data;
+
+	ret = i3c_ccc_do_entas2_all(dev);
+	if (ret < 0) {
+		shell_error(shell_ctx, "I3C: unable to send CCC ENTAS2 BC.");
+		return ret;
+	}
+
+	return ret;
+}
+
+/* i3c ccc entas3_bc <device> */
+static int cmd_i3c_ccc_entas3_bc(const struct shell *shell_ctx, size_t argc, char **argv)
+{
+	const struct device *dev;
+	struct i3c_driver_data *data;
+	int ret;
+
+	dev = device_get_binding(argv[ARGV_DEV]);
+	if (!dev) {
+		shell_error(shell_ctx, "I3C: Device driver %s not found.", argv[ARGV_DEV]);
+		return -ENODEV;
+	}
+	data = (struct i3c_driver_data *)dev->data;
+
+	ret = i3c_ccc_do_entas3_all(dev);
+	if (ret < 0) {
+		shell_error(shell_ctx, "I3C: unable to send CCC ENTAS3 BC.");
+		return ret;
+	}
+
+	return ret;
+}
+
+/* i3c ccc entas0 <device> <target> */
+static int cmd_i3c_ccc_entas0(const struct shell *shell_ctx, size_t argc, char **argv)
+{
+	const struct device *dev, *tdev;
+	struct i3c_device_desc *desc;
+	int ret;
+
+	dev = device_get_binding(argv[ARGV_DEV]);
+	if (!dev) {
+		shell_error(shell_ctx, "I3C: Device driver %s not found.", argv[ARGV_DEV]);
+		return -ENODEV;
+	}
+	tdev = device_get_binding(argv[ARGV_TDEV]);
+	if (!tdev) {
+		shell_error(shell_ctx, "I3C: Device driver %s not found.", argv[ARGV_TDEV]);
+		return -ENODEV;
+	}
+	desc = get_i3c_attached_desc_from_dev_name(dev, tdev->name);
+	if (!desc) {
+		shell_error(shell_ctx, "I3C: Device %s not attached to bus.", tdev->name);
+		return -ENODEV;
+	}
+
+	ret = i3c_ccc_do_entas0(desc);
+	if (ret < 0) {
+		shell_error(shell_ctx, "I3C: unable to send CCC ENTAS0.");
+		return ret;
+	}
+
+	return ret;
+}
+
+/* i3c ccc entas1 <device> <target> */
+static int cmd_i3c_ccc_entas1(const struct shell *shell_ctx, size_t argc, char **argv)
+{
+	const struct device *dev, *tdev;
+	struct i3c_device_desc *desc;
+	int ret;
+
+	dev = device_get_binding(argv[ARGV_DEV]);
+	if (!dev) {
+		shell_error(shell_ctx, "I3C: Device driver %s not found.", argv[ARGV_DEV]);
+		return -ENODEV;
+	}
+	tdev = device_get_binding(argv[ARGV_TDEV]);
+	if (!tdev) {
+		shell_error(shell_ctx, "I3C: Device driver %s not found.", argv[ARGV_TDEV]);
+		return -ENODEV;
+	}
+	desc = get_i3c_attached_desc_from_dev_name(dev, tdev->name);
+	if (!desc) {
+		shell_error(shell_ctx, "I3C: Device %s not attached to bus.", tdev->name);
+		return -ENODEV;
+	}
+
+	ret = i3c_ccc_do_entas1(desc);
+	if (ret < 0) {
+		shell_error(shell_ctx, "I3C: unable to send CCC ENTAS1.");
+		return ret;
+	}
+
+	return ret;
+}
+
+/* i3c ccc entas2 <device> <target> */
+static int cmd_i3c_ccc_entas2(const struct shell *shell_ctx, size_t argc, char **argv)
+{
+	const struct device *dev, *tdev;
+	struct i3c_device_desc *desc;
+	int ret;
+
+	dev = device_get_binding(argv[ARGV_DEV]);
+	if (!dev) {
+		shell_error(shell_ctx, "I3C: Device driver %s not found.", argv[ARGV_DEV]);
+		return -ENODEV;
+	}
+	tdev = device_get_binding(argv[ARGV_TDEV]);
+	if (!tdev) {
+		shell_error(shell_ctx, "I3C: Device driver %s not found.", argv[ARGV_TDEV]);
+		return -ENODEV;
+	}
+	desc = get_i3c_attached_desc_from_dev_name(dev, tdev->name);
+	if (!desc) {
+		shell_error(shell_ctx, "I3C: Device %s not attached to bus.", tdev->name);
+		return -ENODEV;
+	}
+
+	ret = i3c_ccc_do_entas2(desc);
+	if (ret < 0) {
+		shell_error(shell_ctx, "I3C: unable to send CCC ENTAS2.");
+		return ret;
+	}
+
+	return ret;
+}
+
+/* i3c ccc entas3 <device> <target> */
+static int cmd_i3c_ccc_entas3(const struct shell *shell_ctx, size_t argc, char **argv)
+{
+	const struct device *dev, *tdev;
+	struct i3c_device_desc *desc;
+	int ret;
+
+	dev = device_get_binding(argv[ARGV_DEV]);
+	if (!dev) {
+		shell_error(shell_ctx, "I3C: Device driver %s not found.", argv[ARGV_DEV]);
+		return -ENODEV;
+	}
+	tdev = device_get_binding(argv[ARGV_TDEV]);
+	if (!tdev) {
+		shell_error(shell_ctx, "I3C: Device driver %s not found.", argv[ARGV_TDEV]);
+		return -ENODEV;
+	}
+	desc = get_i3c_attached_desc_from_dev_name(dev, tdev->name);
+	if (!desc) {
+		shell_error(shell_ctx, "I3C: Device %s not attached to bus.", tdev->name);
+		return -ENODEV;
+	}
+
+	ret = i3c_ccc_do_entas3(desc);
+	if (ret < 0) {
+		shell_error(shell_ctx, "I3C: unable to send CCC ENTAS3.");
+		return ret;
+	}
+
+	return ret;
+}
+
 /* i3c ccc getstatus <device> <target> [<defining byte>] */
 static int cmd_i3c_ccc_getstatus(const struct shell *shell_ctx, size_t argc, char **argv)
 {
@@ -1560,6 +1780,38 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      "Send CCC DISEC\n"
 		      "Usage: ccc disec <device> <target> <defining byte>",
 		      cmd_i3c_ccc_disec, 4, 0),
+	SHELL_CMD_ARG(entas0_bc, &dsub_i3c_device_name,
+		      "Send CCC ENTAS0 BC\n"
+		      "Usage: ccc entas0 <device>",
+		      cmd_i3c_ccc_entas0_bc, 2, 0),
+	SHELL_CMD_ARG(entas1_bc, &dsub_i3c_device_name,
+		      "Send CCC ENTAS1 BC\n"
+		      "Usage: ccc entas1 <device>",
+		      cmd_i3c_ccc_entas1_bc, 2, 0),
+	SHELL_CMD_ARG(entas2_bc, &dsub_i3c_device_name,
+		      "Send CCC ENTAS2 BC\n"
+		      "Usage: ccc entas2 <device>",
+		      cmd_i3c_ccc_entas2_bc, 2, 0),
+	SHELL_CMD_ARG(entas3_bc, &dsub_i3c_device_name,
+		      "Send CCC ENTAS3 BC\n"
+		      "Usage: ccc entas3 <device>",
+		      cmd_i3c_ccc_entas3_bc, 2, 0),
+	SHELL_CMD_ARG(entas0, &dsub_i3c_device_attached_name,
+		      "Send CCC ENTAS0\n"
+		      "Usage: ccc entas0 <device> <target>",
+		      cmd_i3c_ccc_entas0, 3, 0),
+	SHELL_CMD_ARG(entas1, &dsub_i3c_device_attached_name,
+		      "Send CCC ENTAS1\n"
+		      "Usage: ccc entas1 <device> <target>",
+		      cmd_i3c_ccc_entas1, 3, 0),
+	SHELL_CMD_ARG(entas2, &dsub_i3c_device_attached_name,
+		      "Send CCC ENTAS2\n"
+		      "Usage: ccc entas2 <device> <target>",
+		      cmd_i3c_ccc_entas2, 3, 0),
+	SHELL_CMD_ARG(entas3, &dsub_i3c_device_attached_name,
+		      "Send CCC ENTAS3\n"
+		      "Usage: ccc entas3 <device> <target>",
+		      cmd_i3c_ccc_entas3, 3, 0),
 	SHELL_CMD_ARG(getstatus, &dsub_i3c_device_attached_name,
 		      "Send CCC GETSTATUS\n"
 		      "Usage: ccc getstatus <device> <target> [<defining byte>]",

--- a/include/zephyr/drivers/i3c/ccc.h
+++ b/include/zephyr/drivers/i3c/ccc.h
@@ -1357,6 +1357,147 @@ int i3c_ccc_do_events_set(struct i3c_device_desc *target,
 			  bool enable, struct i3c_ccc_events *events);
 
 /**
+ * @brief Direct ENTAS to set the Activity State.
+ *
+ * Helper function to broadcast Activity State Command on a single
+ * target.
+ *
+ * @param[in] target Pointer to the target device descriptor.
+ * @param[in] as Activity State level
+ *
+ * @return @see i3c_do_ccc
+ */
+int i3c_ccc_do_entas(const struct i3c_device_desc *target, uint8_t as);
+
+/**
+ * @brief Direct ENTAS0
+ *
+ * Helper function to do ENTAS0 setting the minimum bus activity level to 1us
+ * on a single target.
+ *
+ * @param[in] target Pointer to the target device descriptor.
+ *
+ * @return @see i3c_do_ccc
+ */
+static inline int i3c_ccc_do_entas0(const struct i3c_device_desc *target)
+{
+	return i3c_ccc_do_entas(target, 0);
+}
+
+/**
+ * @brief Direct ENTAS1
+ *
+ * Helper function to do ENTAS1 setting the minimum bus activity level to 100us
+ * on a single target.
+ *
+ * @param[in] target Pointer to the target device descriptor.
+ *
+ * @return @see i3c_do_ccc
+ */
+static inline int i3c_ccc_do_entas1(const struct i3c_device_desc *target)
+{
+	return i3c_ccc_do_entas(target, 1);
+}
+
+/**
+ * @brief Direct ENTAS2
+ *
+ * Helper function to do ENTAS2 setting the minimum bus activity level to 2ms
+ * on a single target.
+ *
+ * @param[in] target Pointer to the target device descriptor.
+ *
+ * @return @see i3c_do_ccc
+ */
+static inline int i3c_ccc_do_entas2(const struct i3c_device_desc *target)
+{
+	return i3c_ccc_do_entas(target, 2);
+}
+
+/**
+ * @brief Direct ENTAS3
+ *
+ * Helper function to do ENTAS3 setting the minimum bus activity level to 50ms
+ * on a single target.
+ *
+ * @param[in] target Pointer to the target device descriptor.
+ *
+ * @return @see i3c_do_ccc
+ */
+static inline int i3c_ccc_do_entas3(const struct i3c_device_desc *target)
+{
+	return i3c_ccc_do_entas(target, 3);
+}
+
+/**
+ * @brief Broadcast ENTAS to set the Activity State.
+ *
+ * Helper function to broadcast Activity State Command.
+ *
+ * @param[in] controller Pointer to the controller device driver instance.
+ * @param[in] as Activity State level
+ *
+ * @return @see i3c_do_ccc
+ */
+int i3c_ccc_do_entas_all(const struct device *controller, uint8_t as);
+
+/**
+ * @brief Broadcast ENTAS0
+ *
+ * Helper function to do ENTAS0 setting the minimum bus activity level to 1us
+ *
+ * @param[in] controller Pointer to the controller device driver instance.
+ *
+ * @return @see i3c_do_ccc
+ */
+static inline int i3c_ccc_do_entas0_all(const struct device *controller)
+{
+	return i3c_ccc_do_entas_all(controller, 0);
+}
+
+/**
+ * @brief Broadcast ENTAS1
+ *
+ * Helper function to do ENTAS1 setting the minimum bus activity level to 100us
+ *
+ * @param[in] controller Pointer to the controller device driver instance.
+ *
+ * @return @see i3c_do_ccc
+ */
+static inline int i3c_ccc_do_entas1_all(const struct device *controller)
+{
+	return i3c_ccc_do_entas_all(controller, 1);
+}
+
+/**
+ * @brief Broadcast ENTAS2
+ *
+ * Helper function to do ENTAS2 setting the minimum bus activity level to 2ms
+ *
+ * @param[in] controller Pointer to the controller device driver instance.
+ *
+ * @return @see i3c_do_ccc
+ */
+static inline int i3c_ccc_do_entas2_all(const struct device *controller)
+{
+	return i3c_ccc_do_entas_all(controller, 2);
+}
+
+/**
+ * @brief Broadcast ENTAS3
+ *
+ * Helper function to do ENTAS3 setting the minimum bus activity level to 50ms
+ *
+ * @param[in] controller Pointer to the controller device driver instance.
+ *
+ * @return @see i3c_do_ccc
+ */
+static inline int i3c_ccc_do_entas3_all(const struct device *controller)
+{
+	return i3c_ccc_do_entas_all(controller, 3);
+}
+
+/**
  * @brief Broadcast SETMWL to Set Maximum Write Length.
  *
  * Helper function to do SETMWL (Set Maximum Write Length) to


### PR DESCRIPTION
Add helper function for the i3c ccc entas0, entas1, entas2, and entas3.

Also include shell commands for these.