### PR TITLE
mgmt: mcumgr: os_mgmt: fix millisecond return

### DIFF
--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -292,6 +292,8 @@ Libraries / Subsystems
 
     * Added support for :ref:`mcumgr_smp_group_10`, which allows for listing information on
       supported groups.
+    * Fixed formatting of milliseconds in :c:enum:`OS_MGMT_ID_DATETIME_STR` by adding
+      leading zeros.
 
 * Logging
 

--- a/subsys/mgmt/mcumgr/grp/os_mgmt/src/os_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/src/os_mgmt.c
@@ -836,7 +836,7 @@ static int os_mgmt_datetime_read(struct smp_streamer *ctxt)
 
 	sprintf(date_string, "%4d-%02d-%02dT%02d:%02d:%02d"
 #ifdef CONFIG_MCUMGR_GRP_OS_DATETIME_MS
-		".%d"
+		".%03d"
 #endif
 		, (uint16_t)(current_time.tm_year + RTC_DATETIME_YEAR_OFFSET),
 		(uint8_t)(current_time.tm_mon + RTC_DATETIME_MONTH_OFFSET),


### PR DESCRIPTION
Ensure that leading zeros are present in the milliseconds field, otherwise a milliseconds count of 35 will appear as `x.35`, i.e. 350 milliseconds. With this fix, it will appear as `x.035`.