### PR TITLE
sysbuild: fix extra kconfig targets when using sysbuild

### DIFF
--- a/share/sysbuild/cmake/modules/sysbuild_kconfig.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_kconfig.cmake
@@ -11,6 +11,11 @@ set(EXTRA_KCONFIG_TARGET_COMMAND_FOR_sysbuild_guiconfig
 )
 
 set(KCONFIG_TARGETS sysbuild_menuconfig sysbuild_guiconfig)
+foreach(extra_target ${EXTRA_KCONFIG_TARGETS})
+  set(EXTRA_KCONFIG_TARGET_COMMAND_FOR_sysbuild_${extra_target}
+      "${EXTRA_KCONFIG_TARGET_COMMAND_FOR_${extra_target}}"
+  )
+endforeach()
 list(TRANSFORM EXTRA_KCONFIG_TARGETS PREPEND "sysbuild_")
 
 zephyr_get(APPLICATION_CONFIG_DIR)


### PR DESCRIPTION
Zephyr provides a feature to hook in custom menuconfig implementations by setting EXTRA_KCONFIG_TARGETS and then defining the corresponding command to invoke as EXTRA_KCONFIG_TARGET_COMMAND_FOR_<target>.

This feature is broken with sysbuild because sysbuild will try to create multiple custom targets with identical names.

This commit fix the sysbuild handling of extra kconfig targets.