### PR TITLE
drivers: usb_dc_rpi_pico: Fixed connected handling

### DIFF
--- a/drivers/usb/device/usb_dc_rpi_pico.c
+++ b/drivers/usb/device/usb_dc_rpi_pico.c
@@ -330,8 +330,8 @@ static void udc_rpi_isr(const void *arg)
 		msg.ep = 0U;
 		msg.ep_event = false;
 		msg.type = usb_hw->sie_status & USB_SIE_STATUS_CONNECTED_BITS ?
-			USB_DC_DISCONNECTED :
-			USB_DC_CONNECTED;
+			USB_DC_CONNECTED :
+			USB_DC_DISCONNECTED;
 
 		k_msgq_put(&usb_dc_msgq, &msg, K_NO_WAIT);
 	}


### PR DESCRIPTION
The sie_status register was cleared before evaluating it. Furthermore a connected state was reported as a disconnected state. This led to wrong reports of the connected state to all systems relying on it.