### PR TITLE
soc: atmel: fix number of wait states

### DIFF
--- a/soc/atmel/sam0/common/soc_samc2x.c
+++ b/soc/atmel/sam0/common/soc_samc2x.c
@@ -17,8 +17,8 @@
 
 static void flash_waitstates_init(void)
 {
-	/* One wait state at 48 MHz. */
-	NVMCTRL->CTRLB.bit.RWS = NVMCTRL_CTRLB_RWS_HALF_Val;
+	/* Two wait state at 48 MHz. */
+	NVMCTRL->CTRLB.bit.RWS = NVMCTRL_CTRLB_RWS_DUAL_Val;
 }
 
 static void osc48m_init(void)


### PR DESCRIPTION
The datasheet specifies that 2 wait states are required at 48 MHz.

![image](https://github.com/user-attachments/assets/ff68e974-ae4c-4e9e-8533-2df2ce00fa07)

[SAM_C20_C21_Datasheet.pdf](https://github.com/user-attachments/files/16863465/SAM_C20_C21_Datasheet.pdf)
