### PR TITLE
Revert "ci: set_assignee: pick next area when submitter = assignee"

### DIFF
--- a/scripts/set_assignees.py
+++ b/scripts/set_assignees.py
@@ -123,28 +123,18 @@ def process_pr(gh, maintainer_file, number):
     log(f"candidate maintainers: {_all_maintainers}")
 
     assignees = []
-    tmp_assignees = []
 
     # we start with areas with most files changed and pick the maintainer from the first one.
     # if the first area is an implementation, i.e. driver or platform, we
-    # continue searching for any other areas involved
+    # continue searching for any other areas
     for area, count in area_counter.items():
         if count == 0:
             continue
         if len(area.maintainers) > 0:
-            tmp_assignees = area.maintainers
-            if pr.user.login in area.maintainers:
-                # submitter = assignee, try to pick next area and
-                # assign someone else other than the submitter
-                continue
-            else:
-                assignees = area.maintainers
+            assignees = area.maintainers
 
             if 'Platform' not in area.name:
                 break
-
-    if tmp_assignees and not assignees:
-        assignees = tmp_assignees
 
     if assignees:
         prop = (found_maintainers[assignees[0]] / num_files) * 100


### PR DESCRIPTION
This reverts commit 913426e585e9dc72b9bc3eb04f44be192ccbfd6a, to be causing PRs from being misassigned in a confusing way, causing extra work to the misassigned assignee to reassign manually, for example:

- https://github.com/zephyrproject-rtos/zephyr/pull/77938
- https://github.com/zephyrproject-rtos/zephyr/pull/77803
- https://github.com/zephyrproject-rtos/zephyr/pull/77876