### PR TITLE
Enable multiple ICE40 on the same bus

### DIFF
--- a/drivers/spi/spi_esp32_spim.c
+++ b/drivers/spi/spi_esp32_spim.c
@@ -494,6 +494,13 @@ static int spi_esp32_release(const struct device *dev,
 	return 0;
 }
 
+static int spi_esp32_apply_default_pin_state(const struct device *dev)
+{
+	const struct spi_esp32_config *cfg = dev->config;
+
+	return pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
+}
+
 static const struct spi_driver_api spi_api = {
 	.transceive = spi_esp32_transceive,
 #ifdef CONFIG_SPI_ASYNC
@@ -502,7 +509,8 @@ static const struct spi_driver_api spi_api = {
 #ifdef CONFIG_SPI_RTIO
 	.iodev_submit = spi_rtio_iodev_default_submit,
 #endif
-	.release = spi_esp32_release
+	.release = spi_esp32_release,
+	.apply_default_pin_state = spi_esp32_apply_default_pin_state,
 };
 
 #ifdef CONFIG_SOC_SERIES_ESP32

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -73,6 +73,18 @@ LOG_MODULE_REGISTER(spi_ll_stm32);
 #endif
 #endif /* CONFIG_SOC_SERIES_STM32MP1X */
 
+static inline bool spi_stm32_is_subghzspi(const struct device *dev)
+{
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_subghz)
+	const struct spi_stm32_config *cfg = dev->config;
+
+	return cfg->use_subghzspi_nss;
+#else
+	ARG_UNUSED(dev);
+	return false;
+#endif /* st_stm32_spi_subghz */
+}
+
 static void spi_stm32_pm_policy_state_lock_get(const struct device *dev)
 {
 	if (IS_ENABLED(CONFIG_PM)) {
@@ -725,6 +737,17 @@ static int spi_stm32_release(const struct device *dev,
 	return 0;
 }
 
+static int spi_stm32_apply_default_pin_state(const struct device *dev)
+{
+	const struct spi_stm32_config *cfg = dev->config;
+
+	if (spi_stm32_is_subghzspi(dev)) {
+		return 0;
+	}
+
+	return pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
+}
+
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 static int32_t spi_stm32_count_bufset_frames(const struct spi_config *config,
 					     const struct spi_buf_set *bufs)
@@ -1162,19 +1185,8 @@ static const struct spi_driver_api api_funcs = {
 	.iodev_submit = spi_rtio_iodev_default_submit,
 #endif
 	.release = spi_stm32_release,
+	.apply_default_pin_state = spi_stm32_apply_default_pin_state,
 };
-
-static inline bool spi_stm32_is_subghzspi(const struct device *dev)
-{
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_subghz)
-	const struct spi_stm32_config *cfg = dev->config;
-
-	return cfg->use_subghzspi_nss;
-#else
-	ARG_UNUSED(dev);
-	return false;
-#endif /* st_stm32_spi_subghz */
-}
 
 static int spi_stm32_init(const struct device *dev)
 {

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -676,6 +676,12 @@ typedef void (*spi_api_iodev_submit)(const struct device *dev,
 typedef int (*spi_api_release)(const struct device *dev,
 			       const struct spi_config *config);
 
+/**
+ * @typedef spi_api_apply_default_pin_state
+ * @brief Callback API for applying the default pin state of a SPI device.
+ * See spi_apply_default_pin_state() for argument descriptions
+ */
+typedef int (*spi_api_apply_default_pin_state)(const struct device *dev);
 
 /**
  * @brief SPI driver API
@@ -690,6 +696,7 @@ __subsystem struct spi_driver_api {
 	spi_api_iodev_submit iodev_submit;
 #endif /* CONFIG_SPI_RTIO */
 	spi_api_release release;
+	spi_api_apply_default_pin_state apply_default_pin_state;
 };
 
 /**
@@ -1291,6 +1298,48 @@ static inline int z_impl_spi_release(const struct device *dev,
 static inline int spi_release_dt(const struct spi_dt_spec *spec)
 {
 	return spi_release(spec->bus, &spec->config);
+}
+
+
+/**
+ * @brief Apply the default pin state
+ *
+ * This applies the default pin state for the SPI. It might be used
+ * if other devices have reconfigured the pins to a different setup,
+ * for instance to do bitbanging on them.
+ *
+ * @param dev Pointer to the device structure for the driver instance
+ *
+ * @retval 0 If successful.
+ * @retval -errno Negative errno code on failure.
+ */
+__syscall int spi_apply_default_pin_state(const struct device *dev);
+
+static inline int z_impl_spi_apply_default_pin_state(const struct device *dev)
+{
+	const struct spi_driver_api *api = (const struct spi_driver_api *)dev->api;
+
+	if (api->apply_default_pin_state == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->apply_default_pin_state(dev);
+}
+
+/**
+ * @brief Apply the default pin state for the SPI device specified in @p spi_dt_spec.
+ *
+ * This is equivalent to:
+ *
+ *     spi_apply_default_pin_state(spec->bus)
+ *
+ * @param spec SPI specification from devicetree
+ *
+ * @return a value from spi_apply_default_pin_state().
+ */
+static inline int spi_apply_default_pin_state_dt(const struct spi_dt_spec *spec)
+{
+	return spi_apply_default_pin_state(spec->bus);
 }
 
 #ifdef __cplusplus

--- a/tests/drivers/build_all/fpga/prj.conf
+++ b/tests/drivers/build_all/fpga/prj.conf
@@ -5,11 +5,6 @@ CONFIG_SYS_CLOCK_TICKS_PER_SEC=1000
 CONFIG_GPIO=y
 CONFIG_SPI=y
 CONFIG_FPGA=y
-# Must disable pinctrl here because otherwise there is an error in
-# fpga_ice40.c here about the two nodes both declaring the same pinctrl data
-# of the common spi-bus parent. That effectively limits the number of
-# iCE40 FPGAs on a single bus to 1.
-CONFIG_PINCTRL=n
 CONFIG_ICE40_FPGA=y
 CONFIG_ALTERA_AGILEX_BRIDGE_FPGA=y
 CONFIG_ARM_SIP_SVC_DRIVER=y

--- a/tests/drivers/build_all/fpga/testcase.yaml
+++ b/tests/drivers/build_all/fpga/testcase.yaml
@@ -5,6 +5,7 @@ common:
   platform_allow:
     - native_posix
     - native_sim
+    - nucleo_f746zg
   build_only: true
 tests:
   drivers.fpga.build:


### PR DESCRIPTION
At the moment the build fails if multiple ICE40 are configured on the same SPI master with CONFIG_PINCTRL=y due to duplicate instantiation of the parent pinctrl-config.

This PR introduces a new SPI API which allows reapplying the default pin state, which in turn removes the necessity to have the parent pinctrl-config in the ICE40 driver.

So far I came up with only one alternative: Macrobatics in the ICE40 driver which loops over all SPI masters and creates one pinctrl-config instance for each SPI master with at least one ICE40 instance on it. This didn't seem to be a really good option to me.

Fixes #77983.