### PR TITLE
Bluetooth: Enable BLE support for Arduino Portenta H7

### DIFF
--- a/boards/arduino/portenta_h7/Kconfig.defconfig
+++ b/boards/arduino/portenta_h7/Kconfig.defconfig
@@ -41,3 +41,15 @@ endif # LOG
 endif # USB_DEVICE_STACK
 
 endif # BOARD_ARDUINO_PORTENTA_H7
+
+if BT
+
+choice AIROC_PART
+	default CYW4343W
+endchoice
+
+choice CYW4343W_MODULE
+	default CYW4343W_MURATA_1DX
+endchoice
+
+endif # BT

--- a/boards/arduino/portenta_h7/arduino_portenta_h7_stm32h747xx_m7.dts
+++ b/boards/arduino/portenta_h7/arduino_portenta_h7_stm32h747xx_m7.dts
@@ -21,6 +21,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,bt-hci = &bt_hci_uart;
 	};
 
 	oscen: oscen {
@@ -134,6 +135,27 @@
 		slot1_partition: partition@A0000 {
 			label = "image-1";
 			reg = <0x000A0000 0x00060000>;
+		};
+	};
+};
+
+&uart7 {
+	pinctrl-0 = <&uart7_tx_pa15 &uart7_rx_pf6
+		     &uart7_cts_pf9 &uart7_rts_pf8>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	hw-flow-control;
+	status = "okay";
+
+	bt_hci_uart: bt_hci_uart {
+		compatible = "zephyr,bt-hci-uart";
+		status = "okay";
+
+		murata-1dx {
+			compatible = "infineon,cyw43xxx-bt-hci";
+			bt-reg-on-gpios = <&gpioj 12 GPIO_ACTIVE_HIGH>;
+			bt-host-wake-gpios = <&gpioj 13 GPIO_ACTIVE_HIGH>;
+			bt-dev-wake-gpios = <&gpioj 14 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };

--- a/boards/arduino/portenta_h7/doc/index.rst
+++ b/boards/arduino/portenta_h7/doc/index.rst
@@ -65,6 +65,8 @@ The current Zephyr arduino_portenta_h7 board configuration supports the followin
 +-----------+------------+-------------------------------------+
 | ETHERNET  | on-board   | eth                                 |
 +-----------+------------+-------------------------------------+
+| RADIO     | Murata 1DX | WiFi and Bluetooth module           |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on Zephyr porting.
 
@@ -73,6 +75,22 @@ boards with hardware revision 4.10 or greater. By default the internal source
 is used; to enable the use of the external oscillator, manually specify the
 hardware revision at build time (see :ref:`application_board_version` for
 information on how to build for specific revisions of the board).
+
+Applications that intend to use BLE must specify hardware revision at build time.
+
+Currently only BLE is supported on this board, WiFi is not supported.
+
+Fetch Binary Blobs
+******************
+
+The board Bluetooth/WiFi module requires fetching some binary blob files, to do
+that run the command:
+
+.. code-block:: console
+
+   west blobs fetch hal_infineon
+
+.. note:: Only Bluetooth functionality is currently supported.
 
 Resources sharing
 =================


### PR DESCRIPTION
Enable BLE support based on how BLE is integrated for Arduino Giga.

Tested with bluetooth/peripheral sample on the actual board.