### PR TITLE
net: lib: http_server: Allow application to send arbitrary headers and status codes

### DIFF
--- a/doc/connectivity/networking/api/http_server.rst
+++ b/doc/connectivity/networking/api/http_server.rst
@@ -223,18 +223,16 @@ Dynamic resources
 =================
 
 For dynamic resource, a resource callback is registered to exchange data between
-the server and the application. The application defines a resource buffer used
-to pass the request payload data from the server, and to provide response payload
-to the server. The following example code shows how to register a dynamic resource
-with a simple resource handler, which echoes received data back to the client:
+the server and the application.
+
+The following example code shows how to register a dynamic resource with a simple
+resource handler, which echoes received data back to the client:
 
 .. code-block:: c
 
-    static uint8_t recv_buffer[1024];
-
-    static int dyn_handler(struct http_client_ctx *client,
-                           enum http_data_status status, uint8_t *buffer,
-                           size_t len, void *user_data)
+    static int dyn_handler(struct http_client_ctx *client, enum http_data_status status,
+			               uint8_t *buffer, size_t len, struct http_response_ctx *response_ctx,
+			               void *user_data)
     {
     #define MAX_TEMP_PRINT_LEN 32
         static char print_str[MAX_TEMP_PRINT_LEN];
@@ -260,10 +258,12 @@ with a simple resource handler, which echoes received data back to the client:
             processed = 0;
         }
 
-        /* This will echo data back to client as the buffer and recv_buffer
-         * point to same area.
-         */
-        return len;
+        /* Echo data back to client */
+        response_ctx->body = buffer;
+        response_ctx->body_len = len;
+        response_ctx->final_chunk = (status == HTTP_SERVER_DATA_FINAL);
+
+        return 0;
     }
 
     struct http_resource_detail_dynamic dyn_resource_detail = {
@@ -273,8 +273,6 @@ with a simple resource handler, which echoes received data back to the client:
                 BIT(HTTP_GET) | BIT(HTTP_POST),
         },
         .cb = dyn_handler,
-        .data_buffer = recv_buffer,
-        .data_buffer_len = sizeof(recv_buffer),
         .user_data = NULL,
     };
 
@@ -298,9 +296,25 @@ the application shall reset any progress recorded for the resource, and await
 a new request to come. The server guarantees that the resource can only be
 accessed by single client at a time.
 
-The resource callback returns the number of bytes to be replied in the response
-payload to the server (provided in the resource data buffer). In case there is
-no more data to be included in the response, the callback should return 0.
+The ``response_ctx`` field is used by the application to pass response data to
+the HTTP server:
+
+* The ``status`` field allows the application to send an HTTP response code. If
+  not populated, the response code will be 200 by default.
+
+* The ``headers`` and ``header_count`` fields can be used for the application to
+  send any arbitrary HTTP headers. If not populated, only Transfer-Encoding and
+  Content-Type are sent by default. The callback may override the Content-Type
+  if desired.
+
+* The ``body`` and ``body_len`` fields are used to send body data.
+
+* The ``final_chunk`` field is used to indicate that the application has no more
+  response data to send.
+
+Headers and/or response codes may only be sent in the first populated
+``response_ctx``, after which only further body data is allowed in subsequent
+callbacks.
 
 The server will call the resource callback until it provided all request data
 to the application, and the application reports there is no more data to include

--- a/include/zephyr/net/http/server.h
+++ b/include/zephyr/net/http/server.h
@@ -214,14 +214,6 @@ struct http_resource_detail_dynamic {
 	 */
 	http_resource_dynamic_cb_t cb;
 
-	/** Data buffer used to exchanged data between server and the,
-	 *  application.
-	 */
-	uint8_t *data_buffer;
-
-	/** Length of the data in the data buffer. */
-	size_t data_buffer_len;
-
 	/** A pointer to the client currently processing resource, used to
 	 *  prevent concurrent access to the resource from multiple clients.
 	 */

--- a/samples/net/sockets/http_server/src/main.c
+++ b/samples/net/sockets/http_server/src/main.c
@@ -45,10 +45,6 @@ static uint8_t main_js_gz[] = {
 #include "main.js.gz.inc"
 };
 
-static uint8_t uptime_buf[256];
-static uint8_t led_buf[256];
-static uint8_t echo_buf[1024];
-
 static struct http_resource_detail_static index_html_gz_resource_detail = {
 	.common = {
 			.type = HTTP_RESOURCE_TYPE_STATIC,
@@ -113,8 +109,6 @@ static struct http_resource_detail_dynamic echo_resource_detail = {
 			.bitmask_of_supported_http_methods = BIT(HTTP_GET) | BIT(HTTP_POST),
 		},
 	.cb = echo_handler,
-	.data_buffer = echo_buf,
-	.data_buffer_len = sizeof(echo_buf),
 	.user_data = NULL,
 };
 
@@ -151,8 +145,6 @@ static struct http_resource_detail_dynamic uptime_resource_detail = {
 			.bitmask_of_supported_http_methods = BIT(HTTP_GET),
 		},
 	.cb = uptime_handler,
-	.data_buffer = uptime_buf,
-	.data_buffer_len = sizeof(uptime_buf),
 	.user_data = NULL,
 };
 
@@ -219,8 +211,6 @@ static struct http_resource_detail_dynamic led_resource_detail = {
 			.bitmask_of_supported_http_methods = BIT(HTTP_POST),
 		},
 	.cb = led_handler,
-	.data_buffer = led_buf,
-	.data_buffer_len = sizeof(led_buf),
 	.user_data = NULL,
 };
 

--- a/subsys/net/lib/http/Kconfig
+++ b/subsys/net/lib/http/Kconfig
@@ -107,6 +107,17 @@ config HTTP_SERVER_MAX_HEADER_LEN
 	  internal header processing, and only needs to be increased if the
 	  application wishes to access headers of a greater length.
 
+config HTTP_SERVER_HTTP2_MAX_HEADER_FRAME_LEN
+	int "Maximum HTTP/2 response header frame length"
+	default 64
+	range 64 2048
+	help
+	  This setting determines the maximum length of an HTTP/2 header frame
+	  (applies to response headers only, not request headers). The default
+	  value is sufficient for the standard headers included with a response,
+	  and only needs to be increased if the application wishes to send
+	  additional response headers.
+
 config HTTP_SERVER_CAPTURE_HEADERS
 	bool "Allow capturing HTTP headers for application use"
 	help

--- a/subsys/net/lib/http/headers/server_internal.h
+++ b/subsys/net/lib/http/headers/server_internal.h
@@ -43,6 +43,8 @@ void http_server_get_content_type_from_extension(char *url, char *content_type,
 						 size_t content_type_size);
 int http_server_find_file(char *fname, size_t fname_size, size_t *file_size, bool *gzipped);
 void http_client_timer_restart(struct http_client_ctx *client);
+bool http_response_is_final(struct http_response_ctx *rsp, enum http_data_status status);
+bool http_response_is_provided(struct http_response_ctx *rsp);
 
 /* TODO Could be static, but currently used in tests. */
 int parse_http_frame_header(struct http_client_ctx *client, const uint8_t *buffer,


### PR DESCRIPTION
Allow application to send arbitrary headers and status code with dynamic resources. 

With a bit more work, this could resolve https://github.com/zephyrproject-rtos/zephyr/issues/76280 and https://github.com/zephyrproject-rtos/zephyr/issues/77689. 

There is some overlap with https://github.com/zephyrproject-rtos/zephyr/pull/77003, but I've kept them as separate PRs for now as this one changes the existing user API for the HTTP server, while accessing request headers only adds to the API without breaking existing users.

**Summary**

Instead of returning data from the application to the HTTP server using the dynamic resource callback parameters, a function `http_server_send_response` is introduced to allow status codes, headers and body data to be sent to the HTTP server. The function is intended to be used from inside the dynamic resource callback.

The "dynamic response state" is tracked for each client to ensure that:
- The server is in a valid state for a dynamic resource response to be sent
- Headers and status code can only be sent once for each request
- Multiple calls to `http_server_send_response` are allowed, as long as any calls after the first one only send body data

Any application-defined headers are combined with the default headers that would be sent by the server. In practice only the `Content-Type` can be overridden by the application, the `Transfer-Encoding` cannot be changed.

**Alternatives considered**

Instead of introducing a new function to be called from the callback, all data could be passed back to the HTTP server using the callback parameters. However there are quite a lot of different items to be passed in each direction:

Server --> Application:
- status of data
- data pointer
- data length
- user data
- 
Application --> server:
- HTTP status code
- Headers pointer
- Headers count/length
- Body pointer
- Body length
- Indication of whether response is finished yet

Personally I think it's more straightforward to introduce the new function rather than introduce more parameters to the callback and potentially make some parameters bi-directional. This is also similar to the existing CoAP server API (`coap_resource_send`).

This approach also has a few additional benefits:
- For simple GET handlers, the callback only needs to be called once. Data can be sent and the response can be completed by returning 0 in a single call, rather than the application having to keep track of whether a response is already sent via a static variable, and then return 0 in a subsequent callback.
- The size of data sent back to the server in a single callback is not limited by the size of the dynamic resource buffer. This opens up the possibility to use a dynamic callback to serve a static resource with dynamic response code and/or headers, and just provide a pointer/length of the constant data in a single call to the callback.
- It might actually be possible to entirely remove the dynamic resource buffer to save some memory, and just pass data from server --> application directly in the client context buffer with no copying.


This is currently only a proof of concept supporting dynamic GET and POST requests for HTTP1, to see if this approach is viable. Tests and HTTP2 will not work at the moment, I can update the tests and add HTTP2 support if there's some agreement that this approach to the issue is worth continuing with.