### PR TITLE
drivers: usb: udc_dwc2: Notify upper layer on failed TX

### DIFF
--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -585,9 +585,18 @@ static void dwc2_handle_xfer_next(const struct device *dev,
 	if (USB_EP_DIR_IS_OUT(cfg->addr)) {
 		dwc2_prep_rx(dev, buf, cfg);
 	} else {
-		if (dwc2_tx_fifo_write(dev, cfg, buf)) {
-			LOG_ERR("Failed to start write to TX FIFO, ep 0x%02x",
-				cfg->addr);
+		int err = dwc2_tx_fifo_write(dev, cfg, buf);
+
+		if (err) {
+			LOG_ERR("Failed to start write to TX FIFO, ep 0x%02x (err: %d)",
+				cfg->addr, err);
+
+			buf = udc_buf_get(dev, cfg->addr);
+			if (udc_submit_ep_event(dev, buf, -ECONNREFUSED)) {
+				LOG_ERR("Failed to submit endpoint event");
+			};
+
+			return;
 		}
 	}
 


### PR DESCRIPTION
Change ensures that `dwc2_handle_xfer_next` would notify upper layer if `dwc2_tx_fifo_write` fails. This is necessary to ensure that upper layer is aware of the failed TX for the submitted transfer. It also ensures that the submitted transfer is removed from the TX queue.