### PR TITLE
scripts: twister: Fix warnings & update some style (dependency injection/type hints).

### DIFF
--- a/scripts/pylib/twister/twisterlib/config_parser.py
+++ b/scripts/pylib/twister/twisterlib/config_parser.py
@@ -36,7 +36,7 @@ def extract_fields_from_arg_list(target_fields: set, arg_list: Union[str, list])
             # Move to other_fields
             other_fields.append(field)
 
-    return extracted_fields, " ".join(other_fields)
+    return extracted_fields, other_fields
 
 class TwisterConfigParser:
     """Class to read testsuite yaml files with semantic checking

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -3,6 +3,8 @@
 #
 # Copyright (c) 2018 Intel Corporation
 # Copyright 2022 NXP
+# Copyright (c) 2024 Arm Limited (or its affiliates). All rights reserved.
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
@@ -931,7 +933,7 @@ def strip_ansi_sequences(s: str) -> str:
 
 class TwisterEnv:
 
-    def __init__(self, options=None, default_options=None) -> None:
+    def __init__(self, options, default_options=None) -> None:
         self.version = "Unknown"
         self.toolchain = None
         self.commit_date = "Unknown"
@@ -939,7 +941,7 @@ class TwisterEnv:
         self.options = options
         self.default_options = default_options
 
-        if options and options.ninja:
+        if options.ninja:
             self.generator_cmd = "ninja"
             self.generator = "Ninja"
         else:
@@ -947,17 +949,13 @@ class TwisterEnv:
             self.generator = "Unix Makefiles"
         logger.info(f"Using {self.generator}..")
 
-        self.test_roots = options.testsuite_root if options else None
+        self.test_roots = options.testsuite_root
 
-        if options:
-            if not isinstance(options.board_root, list):
-                self.board_roots = [self.options.board_root]
-            else:
-                self.board_roots = self.options.board_root
-            self.outdir = os.path.abspath(options.outdir)
+        if not isinstance(options.board_root, list):
+            self.board_roots = [options.board_root]
         else:
-            self.board_roots = None
-            self.outdir = None
+            self.board_roots = options.board_root
+        self.outdir = os.path.abspath(options.outdir)
 
         self.snippet_roots = [Path(ZEPHYR_BASE)]
         modules = zephyr_module.parse_modules(ZEPHYR_BASE)
@@ -984,14 +982,14 @@ class TwisterEnv:
 
         self.hwm = None
 
-        self.test_config = options.test_config if options else None
+        self.test_config = options.test_config
 
-        self.alt_config_root = options.alt_config_root if options else None
+        self.alt_config_root = options.alt_config_root
 
     def non_default_options(self) -> dict:
         """Returns current command line options which are set to non-default values."""
         diff = {}
-        if not self.options or not self.default_options:
+        if not self.default_options:
             return diff
         dict_options = vars(self.options)
         dict_default = vars(self.default_options)

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -562,7 +562,8 @@ class Pytest(Harness):
     def _parse_report_file(self, report):
         tree = ET.parse(report)
         root = tree.getroot()
-        if elem_ts := root.find('testsuite'):
+
+        if (elem_ts := root.find('testsuite')) is not None:
             if elem_ts.get('failures') != '0':
                 self.status = TwisterStatus.FAIL
                 self.instance.reason = f"{elem_ts.get('failures')}/{elem_ts.get('tests')} pytest scenario(s) failed"

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -2,6 +2,8 @@
 #
 # Copyright (c) 2018-2022 Intel Corporation
 # Copyright 2022 NXP
+# Copyright (c) 2024 Arm Limited (or its affiliates). All rights reserved.
+#
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 from enum import Enum
@@ -13,6 +15,7 @@ import shutil
 import glob
 import csv
 
+from twisterlib.environment import TwisterEnv
 from twisterlib.testsuite import TestCase, TestSuite
 from twisterlib.platform import Platform
 from twisterlib.error import BuildError, StatusAttributeError
@@ -201,41 +204,40 @@ class TestInstance:
 
         return can_run
 
-    def setup_handler(self, env):
+    def setup_handler(self, env: TwisterEnv):
+        # only setup once.
         if self.handler:
             return
 
         options = env.options
-        handler = Handler(self, "")
+        common_args = (options, env.generator_cmd, not options.disable_suite_name_check)
         if options.device_testing:
-            handler = DeviceHandler(self, "device")
+            handler = DeviceHandler(self, "device", *common_args)
             handler.call_make_run = False
             handler.ready = True
         elif self.platform.simulation != "na":
             if self.platform.simulation == "qemu":
                 if os.name != "nt":
-                    handler = QEMUHandler(self, "qemu")
+                    handler = QEMUHandler(self, "qemu", *common_args)
                 else:
-                    handler = QEMUWinHandler(self, "qemu")
+                    handler = QEMUWinHandler(self, "qemu", *common_args)
                 handler.args.append(f"QEMU_PIPE={handler.get_fifo()}")
                 handler.ready = True
             else:
-                handler = SimulationHandler(self, self.platform.simulation)
+                handler = SimulationHandler(self, self.platform.simulation, *common_args)
 
             if self.platform.simulation_exec and shutil.which(self.platform.simulation_exec):
                 handler.ready = True
         elif self.testsuite.type == "unit":
-            handler = BinaryHandler(self, "unit")
+            handler = BinaryHandler(self, "unit", *common_args)
             handler.binary = os.path.join(self.build_dir, "testbinary")
             if options.enable_coverage:
                 handler.args.append("COVERAGE=1")
             handler.call_make_run = False
             handler.ready = True
+        else:
+            handler = Handler(self, "", *common_args)
 
-        if handler:
-            handler.options = options
-            handler.generator_cmd = env.generator_cmd
-            handler.suite_name_check = not options.disable_suite_name_check
         self.handler = handler
 
     # Global testsuite parameters

--- a/scripts/pylib/twister/twisterlib/twister_main.py
+++ b/scripts/pylib/twister/twisterlib/twister_main.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2022 Google
 # SPDX-License-Identifier: Apache-2.0
 
+import argparse
 import colorama
 import logging
 import os
@@ -63,7 +64,7 @@ def init_color(colorama_strip):
     colorama.init(strip=colorama_strip)
 
 
-def main(options, default_options):
+def main(options: argparse.Namespace, default_options: argparse.Namespace):
     start_time = time.time()
 
     # Configure color output

--- a/scripts/tests/twister/test_data/test_data_with_deprecation_warnings.yaml
+++ b/scripts/tests/twister/test_data/test_data_with_deprecation_warnings.yaml
@@ -1,6 +1,7 @@
 common:
   extra_args: >
-    UNRELATED1=abc
+    CONF_FILE=conf1;conf2 DTC_OVERLAY_FILE=overlay1;overlay2
+    OVERLAY_CONFIG=oc1.conf UNRELATED1=abc
   extra_conf_files:
     - "conf3"
     - "conf4"
@@ -12,7 +13,8 @@ common:
 tests:
   test_config.main:
     extra_args: >
-      UNRELATED2=xyz
+      CONF_FILE=conf5;conf6 DTC_OVERLAY_FILE=overlay5;overlay6
+      OVERLAY_CONFIG=oc3.conf UNRELATED2=xyz
     extra_conf_files:
       - "conf7"
       - "conf8"

--- a/scripts/tests/twister/test_data/testsuites/tests/test_a/test_data.yaml
+++ b/scripts/tests/twister/test_data/testsuites/tests/test_a/test_data.yaml
@@ -3,5 +3,4 @@ tests:
     tags: test_a
     build_only: true
   test_a.check_2:
-    extra_args: CONF_FILE="test.conf"
     tags: test_a

--- a/scripts/tests/twister/test_data/testsuites/tests/test_b/test_data.yaml
+++ b/scripts/tests/twister/test_data/testsuites/tests/test_b/test_data.yaml
@@ -4,5 +4,4 @@ tests:
     tags: test_b
   test_b.check_2:
     min_ram: 32
-    extra_args: CONF_FILE="test.conf"
     tags: test_b

--- a/scripts/tests/twister/test_data/testsuites/tests/test_c/test_data.yaml
+++ b/scripts/tests/twister/test_data/testsuites/tests/test_c/test_data.yaml
@@ -2,5 +2,4 @@ tests:
   test_c.check_1:
     tags: test_c
   test_c.check_2:
-    extra_args: CONF_FILE="test.conf"
     tags: test_c

--- a/scripts/tests/twister/test_environment.py
+++ b/scripts/tests/twister/test_environment.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # Copyright (c) 2023 Intel Corporation
+# Copyright (c) 2024 Arm Limited (or its affiliates). All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 """
@@ -258,16 +259,6 @@ def test_parse_arguments(zephyr_base, additional_args):
 
 TESTDATA_3 = [
     (
-        None,
-        mock.Mock(
-            generator_cmd='make',
-            generator='Unix Makefiles',
-            test_roots=None,
-            board_roots=None,
-            outdir=None,
-        )
-    ),
-    (
         mock.Mock(
             ninja=True,
             board_root=['dummy1', 'dummy2'],
@@ -316,7 +307,6 @@ TESTDATA_3 = [
     'options, expected_env',
     TESTDATA_3,
     ids=[
-        'no options',
         'ninja',
         'make'
     ]

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # Copyright (c) 2023 Intel Corporation
+# Copyright (c) 2024 Arm Limited (or its affiliates). All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 """
@@ -126,7 +127,7 @@ def test_handler_final_handle_actions(mocked_instance):
     instance = mocked_instance
     instance.testcases = [mock.Mock()]
 
-    handler = Handler(mocked_instance)
+    handler = Handler(mocked_instance, 'build', mock.Mock())
     handler.suite_name_check = True
 
     harness = twisterlib.harness.Test()
@@ -178,7 +179,7 @@ def test_handler_verify_ztest_suite_name(
     handler_time = mock.Mock()
 
     with mock.patch.object(Handler, '_missing_suite_name') as _missing_mocked:
-        handler = Handler(instance)
+        handler = Handler(instance, 'build', mock.Mock())
         handler._verify_ztest_suite_name(
             harness_status,
             detected_suite_names,
@@ -195,7 +196,7 @@ def test_handler_missing_suite_name(mocked_instance):
     instance = mocked_instance
     instance.testcases = [mock.Mock()]
 
-    handler = Handler(mocked_instance)
+    handler = Handler(mocked_instance, 'build', mock.Mock())
     handler.suite_name_check = True
 
     expected_suite_names = ['dummy_testsuite_name']
@@ -219,7 +220,7 @@ def test_handler_terminate(mocked_instance):
 
     instance = mocked_instance
 
-    handler = Handler(instance)
+    handler = Handler(instance, 'build', mock.Mock())
 
     mock_process = mock.Mock()
     mock_child1 = mock.Mock(pid=1)
@@ -265,7 +266,7 @@ def test_binaryhandler_try_kill_process_by_pid(mocked_instance):
 
     instance = mocked_instance
 
-    handler = BinaryHandler(instance, 'build')
+    handler = BinaryHandler(instance, 'build', mock.Mock())
     handler.pid_fn = os.path.join('dummy', 'path', 'to', 'pid.pid')
 
     with mock.patch(
@@ -385,9 +386,8 @@ def test_binaryhandler_output_handler(
             if timeout_wait:
                 raise TimeoutExpired('dummy cmd', 'dummyamount')
 
-    handler = BinaryHandler(mocked_instance, 'build')
+    handler = BinaryHandler(mocked_instance, 'build', mock.Mock(timeout_multiplier=1))
     handler.terminate = mock.Mock()
-    handler.options = mock.Mock(timeout_multiplier=1)
 
     proc = MockProc(1, proc_stdout)
 
@@ -438,13 +438,12 @@ def test_binaryhandler_create_command(
     extra_args,
     expected
 ):
-    handler = BinaryHandler(mocked_instance, 'build')
-    handler.generator_cmd = 'generator'
+    options = SimpleNamespace()
+    options.enable_valgrind = enable_valgrind
+    options.coverage_basedir = "coverage_basedir"
+    handler = BinaryHandler(mocked_instance, 'build', options, 'generator', False)
     handler.binary = 'bin'
     handler.call_make_run = call_make_run
-    handler.options = SimpleNamespace()
-    handler.options.enable_valgrind = enable_valgrind
-    handler.options.coverage_basedir = "coverage_basedir"
     handler.seed = seed
     handler.extra_test_args = extra_args
     handler.build_dir = 'build_dir'
@@ -476,12 +475,11 @@ def test_binaryhandler_create_env(
     enable_lsan,
     enable_ubsan
 ):
-    handler = BinaryHandler(mocked_instance, 'build')
-    handler.options = mock.Mock(
+    handler = BinaryHandler(mocked_instance, 'build', mock.Mock(
         enable_asan=enable_asan,
         enable_lsan=enable_lsan,
         enable_ubsan=enable_ubsan
-    )
+    ))
 
     env = {
         'example_env_var': True,
@@ -531,11 +529,12 @@ def test_binaryhandler_update_instance_info(
     expected_reason,
     do_add_missing
 ):
-    handler = BinaryHandler(mocked_instance, 'build')
+    handler = BinaryHandler(mocked_instance, 'build', mock.Mock(
+        enable_valgrind=enable_valgrind
+    ))
     handler_time = 59
     handler.terminated = terminated
     handler.returncode = returncode
-    handler.options = mock.Mock(enable_valgrind=enable_valgrind)
     missing_mock = mock.Mock()
     handler.instance.add_missing_case_status = missing_mock
 
@@ -579,7 +578,7 @@ def test_binaryhandler_handle(
     def mock_thread(target, *args, **kwargs):
         return thread_mock_obj
 
-    handler = BinaryHandler(mocked_instance, 'build')
+    handler = BinaryHandler(mocked_instance, 'build', mock.Mock(coverage=coverage))
     handler.sourcedir = 'source_dir'
     handler.build_dir = 'build_dir'
     handler.name= 'Dummy Name'
@@ -589,7 +588,6 @@ def test_binaryhandler_handle(
     handler._final_handle_actions = mock.Mock()
     handler.terminate = mock.Mock()
     handler.try_kill_process_by_pid = mock.Mock()
-    handler.options = mock.Mock(coverage=coverage)
 
     robot_mock = mock.Mock()
     harness = mock.Mock(is_robot_test=is_robot_test, run_robot_test=robot_mock)
@@ -637,7 +635,7 @@ def test_simulationhandler_init(
     is_binary,
     expected_ready
 ):
-    handler = SimulationHandler(mocked_instance, type_str)
+    handler = SimulationHandler(mocked_instance, type_str, mock.Mock())
 
     assert handler.call_make_run == expected_call_make_run
     assert handler.ready == expected_ready
@@ -713,8 +711,7 @@ def test_devicehandler_monitor_serial(
     harness = mock.Mock(capture_coverage=False)
     type(harness).status=mock.PropertyMock(side_effect=status_iter)
 
-    handler = DeviceHandler(mocked_instance, 'build')
-    handler.options = mock.Mock(enable_coverage=not end_by_status)
+    handler = DeviceHandler(mocked_instance, 'build', mock.Mock(enable_coverage=not end_by_status))
 
     with mock.patch('builtins.open', mock.mock_open(read_data='')):
         handler.monitor_serial(ser, halt_event, harness)
@@ -738,8 +735,7 @@ def test_devicehandler_monitor_serial_splitlines(mocked_instance):
     )
     harness = mock.Mock(status=TwisterStatus.PASS)
 
-    handler = DeviceHandler(mocked_instance, 'build')
-    handler.options = mock.Mock(enable_coverage=False)
+    handler = DeviceHandler(mocked_instance, 'build', mock.Mock(enable_coverage=False))
 
     with mock.patch('builtins.open', mock.mock_open(read_data='')):
         handler.monitor_serial(ser, halt_event, harness)
@@ -914,7 +910,7 @@ def test_devicehandler_device_is_available(
     mocked_instance.platform.name = platform_name
     mocked_instance.testsuite.harness_config = {'fixture': fixture}
 
-    handler = DeviceHandler(mocked_instance, 'build')
+    handler = DeviceHandler(mocked_instance, 'build', mock.Mock())
     handler.duts = duts
 
     if isinstance(expected, int):
@@ -946,7 +942,7 @@ def test_devicehandler_make_dut_available(mocked_instance):
         )
     ]
 
-    handler = DeviceHandler(mocked_instance, 'build')
+    handler = DeviceHandler(mocked_instance, 'build', mock.Mock())
     handler.duts = duts
 
     handler.make_dut_available(duts[1])
@@ -1038,7 +1034,7 @@ def test_devicehandler_get_hardware(
             return None
         return expected_hardware
 
-    handler = DeviceHandler(mocked_instance, 'build')
+    handler = DeviceHandler(mocked_instance, 'build', mock.Mock())
     handler.no = num_of_failures
 
     with mock.patch.object(
@@ -1169,7 +1165,7 @@ def test_devicehandler_create_command(
     hardware_product_name,
     expected
 ):
-    handler = DeviceHandler(mocked_instance, 'build')
+    handler = DeviceHandler(mocked_instance, 'build', mock.Mock())
     handler.options = mock.Mock(west_flash=self_west_flash)
     handler.generator_cmd = 'generator_cmd'
 
@@ -1210,7 +1206,7 @@ def test_devicehandler_update_instance_info(
         expected_reason,
         do_add_missing
         ):
-    handler = DeviceHandler(mocked_instance, 'build')
+    handler = DeviceHandler(mocked_instance, 'build', mock.Mock())
     handler_time = 59
     missing_mock = mock.Mock()
     handler.instance.add_missing_case_status = missing_mock
@@ -1269,10 +1265,9 @@ def test_devicehandler_create_serial_connection(
             raise expected_exception('')
         return expected_result
 
-    handler = DeviceHandler(mocked_instance, 'build')
+    handler = DeviceHandler(mocked_instance, 'build', mock.Mock(timeout_multiplier=1))
     missing_mock = mock.Mock()
     handler.instance.add_missing_case_status = missing_mock
-    handler.options = mock.Mock(timeout_multiplier=1)
     twisterlib.handlers.terminate_process = mock.Mock()
 
     dut = DUT()
@@ -1329,7 +1324,7 @@ def test_devicehandler_get_serial_device(
             raise popen_exception(command, 'Dummy error')
         return mock.Mock()
 
-    handler = DeviceHandler(mocked_instance, 'build')
+    handler = DeviceHandler(mocked_instance, 'build', mock.Mock())
     hardware_serial = 'dummy hardware serial'
 
     popen_mock = mock.Mock(side_effect=mock_popen)
@@ -1442,7 +1437,7 @@ def test_devicehandler_handle(
         flash_with_test=True
     )
 
-    handler = DeviceHandler(mocked_instance, 'build')
+    handler = DeviceHandler(mocked_instance, 'build', mock.Mock())
     handler.get_hardware = mock.Mock(return_value=hardware)
     handler.options = mock.Mock(
         timeout_multiplier=1,
@@ -1518,7 +1513,7 @@ def test_qemuhandler_init(
 ):
     mocked_instance.testsuite.ignore_qemu_crash = ignore_qemu_crash
 
-    handler = QEMUHandler(mocked_instance, 'build')
+    handler = QEMUHandler(mocked_instance, 'build', mock.Mock())
 
     assert handler.ignore_qemu_crash == expected_ignore_crash
     assert handler.ignore_unexpected_eof == expected_ignore_unexpected_eof
@@ -1573,7 +1568,7 @@ def test_qemuhandler_get_default_domain_build_dir(
     domains_mock = mock.Mock(get_default_domain=get_default_domain_mock)
     from_file_mock = mock.Mock(return_value=domains_mock)
 
-    handler = QEMUHandler(mocked_instance, 'build')
+    handler = QEMUHandler(mocked_instance, 'build', mock.Mock())
     handler.instance.sysbuild = self_sysbuild
     handler.build_dir = self_build_dir
 
@@ -1613,7 +1608,7 @@ def test_qemuhandler_set_qemu_filenames(
     unlink_mock = mock.Mock()
     exists_mock = mock.Mock(return_value=exists_pid_fn)
 
-    handler = QEMUHandler(mocked_instance, 'build')
+    handler = QEMUHandler(mocked_instance, 'build', mock.Mock())
     handler.log = self_log
     handler.pid_fn = self_pid_fn
 
@@ -1636,8 +1631,7 @@ def test_qemuhandler_set_qemu_filenames(
 def test_qemuhandler_create_command(mocked_instance):
     sysbuild_build_dir = os.path.join('sysbuild', 'dummy_dir')
 
-    handler = QEMUHandler(mocked_instance, 'build')
-    handler.generator_cmd = 'dummy_cmd'
+    handler = QEMUHandler(mocked_instance, 'build', mock.Mock(), 'dummy_cmd', False)
 
     result = handler._create_command(sysbuild_build_dir)
 
@@ -1719,7 +1713,7 @@ def test_qemuhandler_update_instance_info(
     mocked_instance.add_missing_case_status = mock.Mock()
     mocked_instance.reason = self_instance_reason
 
-    handler = QEMUHandler(mocked_instance, 'build')
+    handler = QEMUHandler(mocked_instance, 'build', mock.Mock())
     handler.returncode = self_returncode
     handler.ignore_qemu_crash = self_ignore_qemu_crash
 
@@ -1855,7 +1849,7 @@ def test_qemuhandler_thread_update_instance_info(
     expected_status,
     expected_reason
 ):
-    handler = QEMUHandler(mocked_instance, 'build')
+    handler = QEMUHandler(mocked_instance, 'build', mock.Mock())
     handler_time = 59
 
     QEMUHandler._thread_update_instance_info(handler, handler_time, _status, _reason)
@@ -1980,11 +1974,10 @@ def test_qemuhandler_thread(
             raise ProcessLookupError()
 
     type(mocked_instance.testsuite).timeout = mock.PropertyMock(return_value=timeout)
-    handler = QEMUHandler(mocked_instance, 'build')
+    handler = QEMUHandler(mocked_instance, 'build', mock.Mock(timeout_multiplier=1))
     handler.ignore_unexpected_eof = False
     handler.pid_fn = 'pid_fn'
     handler.fifo_fn = 'fifo_fn'
-    handler.options = mock.Mock(timeout_multiplier=1)
 
     def mocked_open(filename, *args, **kwargs):
         if filename == handler.pid_fn:
@@ -2089,7 +2082,7 @@ def test_qemuhandler_handle(
     )
     mock_process.wait = mock.Mock(side_effect=mock_wait)
 
-    handler = QEMUHandler(mocked_instance, 'build')
+    handler = QEMUHandler(mocked_instance, 'build', mock.Mock(timeout_multiplier=1))
 
     def mock_path_exists(name, *args, **kwargs):
         return exists_pid_fn
@@ -2142,7 +2135,7 @@ def test_qemuhandler_handle(
 
 
 def test_qemuhandler_get_fifo(mocked_instance):
-    handler = QEMUHandler(mocked_instance, 'build')
+    handler = QEMUHandler(mocked_instance, 'build', mock.Mock(timeout_multiplier=1))
     handler.fifo_fn = 'fifo_fn'
 
     result = handler.get_fifo()

--- a/scripts/tests/twister/test_twister.py
+++ b/scripts/tests/twister/test_twister.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # Copyright (c) 2020 Intel Corporation
+# Copyright (c) 2024 Arm Limited (or its affiliates). All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 """
@@ -8,6 +9,7 @@ This test file contains foundational testcases for Twister tool
 
 import os
 import sys
+import mock
 import pytest
 
 from pathlib import Path
@@ -51,17 +53,24 @@ def test_incorrect_schema(filename, schema, test_data):
 
 def test_testsuite_config_files():
     """ Test to validate conf and overlay files are extracted properly """
-    filename = Path(ZEPHYR_BASE) / "scripts/tests/twister/test_data/testsuites/tests/test_config/test_data.yaml"
+    filename = Path(ZEPHYR_BASE) / "scripts/tests/twister/test_data/test_data_with_deprecation_warnings.yaml"
     schema = scl.yaml_load(Path(ZEPHYR_BASE) / "scripts/schemas/twister/testsuite-schema.yaml")
     data = TwisterConfigParser(filename, schema)
     data.load()
 
-    # Load and validate the specific scenario from testcases.yaml
-    scenario = data.get_scenario("test_config.main")
-    assert scenario
+    with mock.patch('warnings.warn') as warn_mock:
+        # Load and validate the specific scenario from testcases.yaml
+        scenario = data.get_scenario("test_config.main")
+        assert scenario
 
-    # CONF_FILE, DTC_OVERLAY_FILE, OVERLAY_CONFIG fields should be stripped out
-    # of extra_args. Other fields should remain untouched.
+        # CONF_FILE, DTC_OVERLAY_FILE, OVERLAY_CONFIG fields should be stripped out
+        # of extra_args. Other fields should remain untouched.
+        warn_mock.assert_called_once_with("Do not specify CONF_FILE, OVERLAY_CONFIG, or "
+                                          "DTC_OVERLAY_FILE in extra_args. This feature is "
+                                          "deprecated and will soon result in an error. Use "
+                                          "extra_conf_files, extra_overlay_confs or "
+                                          "extra_dtc_overlay_files YAML fields instead", DeprecationWarning)
+
     assert scenario["extra_args"] == ["UNRELATED1=abc", "UNRELATED2=xyz"]
 
     # Check that all conf files have been assembled in the correct order


### PR DESCRIPTION
These change allow `ZEPHYR_BASE=$(pwd) PYTHON_PATH=./scripts/tests pytest ./scripts/tests/twister` to run locally from zephyr's directory to pass and do so without warning.

Please refer to each commit messages for a short explanation of the related change.

I cannot get `ZEPHYR_BASE=$(pwd) PYTHON_PATH=./scripts/tests pytest ./scripts/tests/twister_blackbox` to run locally but I lack the time to investigate what am I doing wrong.
But it passes in CI :)