### PR TITLE
usb: device_next: uac2: Handle speed properties

### DIFF
--- a/include/zephyr/usb/usb_ch9.h
+++ b/include/zephyr/usb/usb_ch9.h
@@ -364,6 +364,12 @@ struct usb_association_descriptor {
 	 ((tpl) > 1024) ? ((1 << 11) | ((tpl) / 2)) :	\
 	 (tpl))
 
+/** Round up total payload length to next valid value */
+#define USB_TPL_ROUND_UP(tpl)				\
+	(((tpl) > 2048) ? ROUND_UP(tpl, 3) :		\
+	 ((tpl) > 1024) ? ROUND_UP(tpl, 2) :		\
+	 (tpl))
+
 /** Determine whether total payload length value is valid according to USB 2.0 */
 #define USB_TPL_IS_VALID(tpl)				\
 	(((tpl) > 3072) ? false :			\

--- a/samples/subsys/usb/uac2_explicit_feedback/app.overlay
+++ b/samples/subsys/usb/uac2_explicit_feedback/app.overlay
@@ -10,6 +10,7 @@
 	uac2_headphones: usb_audio2 {
 		compatible = "zephyr,uac2";
 		status = "okay";
+		full-speed;
 		audio-function = <AUDIO_FUNCTION_OTHER>;
 
 		uac_aclk: aclk {

--- a/samples/subsys/usb/uac2_implicit_feedback/app.overlay
+++ b/samples/subsys/usb/uac2_implicit_feedback/app.overlay
@@ -10,6 +10,7 @@
 	uac2_headset: usb_audio2 {
 		compatible = "zephyr,uac2";
 		status = "okay";
+		full-speed;
 		audio-function = <AUDIO_FUNCTION_HEADSET>;
 
 		uac_aclk: aclk {

--- a/subsys/usb/device_next/class/usbd_uac2.c
+++ b/subsys/usb/device_next/class/usbd_uac2.c
@@ -759,12 +759,11 @@ struct usbd_class_api uac2_api = {
 	DT_INST_FOREACH_CHILD_STATUS_OKAY_VARGS(i, DEFINE_CLOCK_SOURCES, i)
 
 #define DEFINE_UAC2_CLASS_DATA(inst)						\
-	DT_INST_FOREACH_CHILD(inst, VALIDATE_NODE)				\
+	VALIDATE_INSTANCE(DT_DRV_INST(inst))					\
 	static struct uac2_ctx uac2_ctx_##inst;					\
 	UAC2_DESCRIPTOR_ARRAYS(DT_DRV_INST(inst))				\
-	static const struct usb_desc_header *uac2_descriptors_##inst[] = {	\
-		UAC2_DESCRIPTOR_PTRS(DT_DRV_INST(inst))				\
-	};									\
+	static const struct usb_desc_header *uac2_descriptors_##inst[] =	\
+		UAC2_FS_DESCRIPTOR_PTRS_ARRAY(DT_DRV_INST(inst));		\
 	USBD_DEFINE_CLASS(uac2_##inst, &uac2_api,				\
 			  (void *)DEVICE_DT_GET(DT_DRV_INST(inst)), NULL);	\
 	DEFINE_LOOKUP_TABLES(inst)						\

--- a/subsys/usb/device_next/class/usbd_uac2_macros.h
+++ b/subsys/usb/device_next/class/usbd_uac2_macros.h
@@ -378,10 +378,6 @@
 	IF_ENABLED(IS_EQ(AUDIO_STREAMING_FORMAT_TYPE(node), FORMAT_TYPE_IV), (	\
 		AUDIO_STREAMING_FORMAT_IV_TYPE_DESCRIPTOR(node)))
 
-#define AUDIO_STREAMING_INTERFACE_DESCRIPTORS(node)				\
-	AUDIO_STREAMING_GENERAL_DESCRIPTOR(node)				\
-	AUDIO_STREAMING_FORMAT_TYPE_DESCRIPTOR(node)
-
 #define AUDIO_STREAMING_INTERFACE_DESCRIPTORS_ARRAYS(node)			\
 	static uint8_t DESCRIPTOR_NAME(as_general_desc, node)[] = {		\
 		AUDIO_STREAMING_GENERAL_DESCRIPTOR(node)			\
@@ -390,6 +386,7 @@
 		AUDIO_STREAMING_FORMAT_TYPE_DESCRIPTOR(node)			\
 	};
 
+/* Full and High speed share common class-specific interface descriptors */
 #define AUDIO_STREAMING_INTERFACE_DESCRIPTORS_PTRS(node)			\
 	(struct usb_desc_header *) &DESCRIPTOR_NAME(as_general_desc, node),	\
 	(struct usb_desc_header *) &DESCRIPTOR_NAME(as_format_desc, node),
@@ -419,6 +416,12 @@
 	1 /* AudioControl interface */ +					\
 	DT_FOREACH_CHILD_SEP(node, IS_AUDIOSTREAMING_INTERFACE, (+))
 
+#define UAC2_ALLOWED_AT_FULL_SPEED(node)					\
+	DT_PROP(node, full_speed)
+
+#define UAC2_ALLOWED_AT_HIGH_SPEED(node)					\
+	DT_PROP(node, high_speed)
+
 /* 4.6 Interface Association Descriptor */
 #define UAC2_INTERFACE_ASSOCIATION_DESCRIPTOR(node)				\
 	0x08,						/* bLength */		\
@@ -431,12 +434,22 @@
 	0x00,						/* iFunction */
 
 #define UAC2_INTERFACE_ASSOCIATION_DESCRIPTOR_ARRAY(node)			\
-	static uint8_t DESCRIPTOR_NAME(iad, node)[] = {				\
-		UAC2_INTERFACE_ASSOCIATION_DESCRIPTOR(node)					\
-	};
+	IF_ENABLED(UAC2_ALLOWED_AT_FULL_SPEED(node), (				\
+		static uint8_t DESCRIPTOR_NAME(fs_iad, node)[] = {		\
+			UAC2_INTERFACE_ASSOCIATION_DESCRIPTOR(node)		\
+		};								\
+	))									\
+	IF_ENABLED(UAC2_ALLOWED_AT_HIGH_SPEED(node), (				\
+		static uint8_t DESCRIPTOR_NAME(hs_iad, node)[] = {		\
+			UAC2_INTERFACE_ASSOCIATION_DESCRIPTOR(node)		\
+		};								\
+	))
 
-#define UAC2_INTERFACE_ASSOCIATION_DESCRIPTOR_PTR(node)				\
-	(struct usb_desc_header *) &DESCRIPTOR_NAME(iad, node),
+#define UAC2_INTERFACE_ASSOCIATION_FS_DESCRIPTOR_PTR(node)			\
+	(struct usb_desc_header *) &DESCRIPTOR_NAME(fs_iad, node),
+
+#define UAC2_INTERFACE_ASSOCIATION_HS_DESCRIPTOR_PTR(node)			\
+	(struct usb_desc_header *) &DESCRIPTOR_NAME(hs_iad, node),
 
 /* 4.7.1 Standard AC Interface Descriptor */
 #define AC_INTERFACE_DESCRIPTOR(node)						\
@@ -451,12 +464,22 @@
 	0x00,						/* iInterface */
 
 #define AC_INTERFACE_DESCRIPTOR_ARRAY(node)					\
-	static uint8_t DESCRIPTOR_NAME(ac_interface, node)[] = {		\
-		AC_INTERFACE_DESCRIPTOR(node)					\
-	};
+	IF_ENABLED(UAC2_ALLOWED_AT_FULL_SPEED(node), (				\
+		static uint8_t DESCRIPTOR_NAME(fs_ac_interface, node)[] = {	\
+			AC_INTERFACE_DESCRIPTOR(node)				\
+		};								\
+	))									\
+	IF_ENABLED(UAC2_ALLOWED_AT_HIGH_SPEED(node), (				\
+		static uint8_t DESCRIPTOR_NAME(hs_ac_interface, node)[] = {	\
+			AC_INTERFACE_DESCRIPTOR(node)				\
+		};								\
+	))
 
-#define AC_INTERFACE_DESCRIPTOR_PTR(node)					\
-	(struct usb_desc_header *) &DESCRIPTOR_NAME(ac_interface, node),
+#define AC_INTERFACE_FS_DESCRIPTOR_PTR(node)					\
+	(struct usb_desc_header *) &DESCRIPTOR_NAME(fs_ac_interface, node),
+
+#define AC_INTERFACE_HS_DESCRIPTOR_PTR(node)					\
+	(struct usb_desc_header *) &DESCRIPTOR_NAME(hs_ac_interface, node),
 
 /* 4.8.2.1 Standard AC Interrupt Endpoint Descriptor */
 #define AC_ENDPOINT_DESCRIPTOR(node)						\
@@ -548,13 +571,29 @@
 	IP_VERSION_02_00,				/* bInterfaceProtocol */\
 	0x00,						/* iInterface */
 
-#define AS_INTERFACE_DESCRIPTOR_ARRAY(node, alternate, numendpoints)		\
-	static uint8_t DESCRIPTOR_NAME(as_if_alt##alternate, node)[] = {	\
+#define AS_INTERFACE_FS_DESCRIPTOR_ARRAY(node, alternate, numendpoints)		\
+	static uint8_t DESCRIPTOR_NAME(fs_as_if_alt##alternate, node)[] = {	\
 		AS_INTERFACE_DESCRIPTOR(node, alternate, numendpoints)		\
 	};
 
-#define AS_INTERFACE_DESCRIPTOR_PTR(node, alternate)				\
-	(struct usb_desc_header *) &DESCRIPTOR_NAME(as_if_alt##alternate, node),
+#define AS_INTERFACE_HS_DESCRIPTOR_ARRAY(node, alternate, numendpoints)		\
+	static uint8_t DESCRIPTOR_NAME(hs_as_if_alt##alternate, node)[] = {	\
+		AS_INTERFACE_DESCRIPTOR(node, alternate, numendpoints)		\
+	};
+
+#define AS_INTERFACE_DESCRIPTOR_ARRAY(node, alternate, numendpoints)		\
+	IF_ENABLED(UAC2_ALLOWED_AT_FULL_SPEED(DT_PARENT(node)), (		\
+		AS_INTERFACE_FS_DESCRIPTOR_ARRAY(node, alternate, numendpoints)	\
+	))									\
+	IF_ENABLED(UAC2_ALLOWED_AT_HIGH_SPEED(DT_PARENT(node)), (		\
+		AS_INTERFACE_HS_DESCRIPTOR_ARRAY(node, alternate, numendpoints)	\
+	))
+
+#define AS_INTERFACE_FS_DESCRIPTOR_PTR(node, altnum)				\
+	(struct usb_desc_header *) &DESCRIPTOR_NAME(fs_as_if_alt##altnum, node),
+
+#define AS_INTERFACE_HS_DESCRIPTOR_PTR(node, altnum)				\
+	(struct usb_desc_header *) &DESCRIPTOR_NAME(hs_as_if_alt##altnum, node),
 
 #define COUNT_AS_OUT_ENDPOINTS_BEFORE_IDX(node, idx)				\
 	+ AS_IS_USB_ISO_OUT(node) * (DT_NODE_CHILD_IDX(node) < idx)
@@ -591,8 +630,12 @@
 	DT_PROP(node, subslot_size)
 
 /* Asynchronous endpoints needs space for 1 extra sample */
-#define AS_SAMPLES_PER_PACKET(node)						\
+#define AS_SAMPLES_PER_FRAME(node)						\
 	((ROUND_UP(AS_CLK_MAX_FREQUENCY(node), 1000) / 1000) +			\
+	  UTIL_NOT(AS_IS_SOF_SYNCHRONIZED(node)))
+
+#define AS_SAMPLES_PER_MICROFRAME(node)						\
+	((ROUND_UP(AS_CLK_MAX_FREQUENCY(node), 8000) / 8000) +			\
 	  UTIL_NOT(AS_IS_SOF_SYNCHRONIZED(node)))
 
 #define AS_DATA_EP_SYNC_TYPE(node)						\
@@ -606,18 +649,43 @@
 	USB_EP_TYPE_ISO | AS_DATA_EP_SYNC_TYPE(node) |				\
 	AS_DATA_EP_USAGE_TYPE(node)
 
-#define AS_DATA_EP_MAX_PACKET_SIZE(node)					\
+#define AS_FS_DATA_EP_MAX_PACKET_SIZE(node)					\
 	AUDIO_STREAMING_NUM_SPATIAL_LOCATIONS(node) *				\
-	AS_BYTES_PER_SAMPLE(node) * AS_SAMPLES_PER_PACKET(node)
+	AS_BYTES_PER_SAMPLE(node) * AS_SAMPLES_PER_FRAME(node)
+
+#define AS_HS_DATA_EP_TPL(node)							\
+	USB_TPL_ROUND_UP(AUDIO_STREAMING_NUM_SPATIAL_LOCATIONS(node) *		\
+		AS_BYTES_PER_SAMPLE(node) * AS_SAMPLES_PER_MICROFRAME(node))
+
+#define AS_HS_DATA_EP_MAX_PACKET_SIZE(node)					\
+	USB_TPL_TO_MPS(AS_HS_DATA_EP_TPL(node))
 
 /* 4.10.1.1 Standard AS Isochronous Audio Data Endpoint Descriptor */
-#define STANDARD_AS_ISOCHRONOUS_DATA_ENDPOINT_DESCRIPTOR(node)			\
+#define STANDARD_AS_ISOCHRONOUS_DATA_ENDPOINT_FS_DESCRIPTOR(node)		\
 	0x07,						/* bLength */		\
 	USB_DESC_ENDPOINT,				/* bDescriptorType */	\
 	AS_DATA_EP_ADDR(node),				/* bEndpointAddress */	\
 	AS_DATA_EP_ATTR(node),				/* bmAttributes */	\
-	U16_LE(AS_DATA_EP_MAX_PACKET_SIZE(node)),	/* wMaxPacketSize */	\
+	U16_LE(AS_FS_DATA_EP_MAX_PACKET_SIZE(node)),	/* wMaxPacketSize */	\
 	0x01,						/* bInterval */
+
+#define AS_ISOCHRONOUS_DATA_ENDPOINT_FS_DESCRIPTORS_ARRAYS(node)		\
+	static uint8_t DESCRIPTOR_NAME(fs_std_data_ep, node)[] = {		\
+		STANDARD_AS_ISOCHRONOUS_DATA_ENDPOINT_FS_DESCRIPTOR(node)	\
+	};
+
+#define STANDARD_AS_ISOCHRONOUS_DATA_ENDPOINT_HS_DESCRIPTOR(node)		\
+	0x07,						/* bLength */		\
+	USB_DESC_ENDPOINT,				/* bDescriptorType */	\
+	AS_DATA_EP_ADDR(node),				/* bEndpointAddress */	\
+	AS_DATA_EP_ATTR(node),				/* bmAttributes */	\
+	U16_LE(AS_HS_DATA_EP_MAX_PACKET_SIZE(node)),	/* wMaxPacketSize */	\
+	0x01,						/* bInterval */
+
+#define AS_ISOCHRONOUS_DATA_ENDPOINT_HS_DESCRIPTORS_ARRAYS(node)		\
+	static uint8_t DESCRIPTOR_NAME(hs_std_data_ep, node)[] = {		\
+		STANDARD_AS_ISOCHRONOUS_DATA_ENDPOINT_HS_DESCRIPTOR(node)	\
+	};
 
 #define LOCK_DELAY_UNITS(node)							\
 	COND_CODE_1(DT_NODE_HAS_PROP(node, lock_delay_units),			\
@@ -634,48 +702,64 @@
 	LOCK_DELAY_UNITS(node),				/* bLockDelayUnits */	\
 	U16_LE(DT_PROP_OR(node, lock_delay, 0)),	/* wLockDelay */
 
-#define AS_ISOCHRONOUS_DATA_ENDPOINT_DESCRIPTORS(node)				\
-	STANDARD_AS_ISOCHRONOUS_DATA_ENDPOINT_DESCRIPTOR(node)			\
-	CLASS_SPECIFIC_AS_ISOCHRONOUS_DATA_ENDPOINT_DESCRIPTOR(node)
-
-#define AS_ISOCHRONOUS_DATA_ENDPOINT_DESCRIPTORS_ARRAYS(node)			\
-	static uint8_t DESCRIPTOR_NAME(std_data_ep, node)[] = {			\
-		STANDARD_AS_ISOCHRONOUS_DATA_ENDPOINT_DESCRIPTOR(node)		\
-	};									\
+/* Full and High speed share common class-specific descriptor */
+#define AS_ISOCHRONOUS_DATA_ENDPOINT_CS_DESCRIPTORS_ARRAYS(node)		\
 	static uint8_t DESCRIPTOR_NAME(cs_data_ep, node)[] = {			\
 		CLASS_SPECIFIC_AS_ISOCHRONOUS_DATA_ENDPOINT_DESCRIPTOR(node)	\
 	};
 
-#define AS_ISOCHRONOUS_DATA_ENDPOINT_DESCRIPTORS_PTRS(node)			\
-	(struct usb_desc_header *) &DESCRIPTOR_NAME(std_data_ep, node),		\
+#define AS_ISOCHRONOUS_DATA_ENDPOINT_FS_DESCRIPTORS_PTRS(node)			\
+	(struct usb_desc_header *) &DESCRIPTOR_NAME(fs_std_data_ep, node),	\
 	(struct usb_desc_header *) &DESCRIPTOR_NAME(cs_data_ep, node),
 
-#define AS_EXPLICIT_FEEDBACK_ENDPOINT_DESCRIPTOR(node)				\
+#define AS_ISOCHRONOUS_DATA_ENDPOINT_HS_DESCRIPTORS_PTRS(node)			\
+	(struct usb_desc_header *) &DESCRIPTOR_NAME(hs_std_data_ep, node),	\
+	(struct usb_desc_header *) &DESCRIPTOR_NAME(cs_data_ep, node),
+
+#define AS_EXPLICIT_FEEDBACK_ENDPOINT_FS_DESCRIPTOR(node)			\
 	0x07,						/* bLength */		\
 	USB_DESC_ENDPOINT,				/* bDescriptorType */	\
 	AS_NEXT_IN_EP_ADDR(node),			/* bEndpointAddress */	\
 	0x11,						/* bmAttributes */	\
-	U16_LE(0x03), /* FIXME: 4 on High-Speed*/	/* wMaxPacketSize */	\
+	U16_LE(0x03),					/* wMaxPacketSize */	\
 	0x01, /* TODO: adjust to P 5.12.4.2 Feedback */	/* bInterval */
 
-#define AS_EXPLICIT_FEEDBACK_ENDPOINT_DESCRIPTOR_ARRAY(node)			\
-	static uint8_t DESCRIPTOR_NAME(feedback_ep, node)[] = {			\
-		AS_EXPLICIT_FEEDBACK_ENDPOINT_DESCRIPTOR(node)			\
+#define AS_EXPLICIT_FEEDBACK_FS_DESCRIPTOR_ARRAY(node)				\
+	static uint8_t DESCRIPTOR_NAME(fs_feedback_ep, node)[] = {		\
+		AS_EXPLICIT_FEEDBACK_ENDPOINT_FS_DESCRIPTOR(node)		\
 	};
 
-#define AS_EXPLICIT_FEEDBACK_ENDPOINT_DESCRIPTOR_PTR(node)			\
-	(struct usb_desc_header *) &DESCRIPTOR_NAME(feedback_ep, node),
+#define AS_EXPLICIT_FEEDBACK_ENDPOINT_FS_DESCRIPTOR_PTR(node)			\
+	(struct usb_desc_header *) &DESCRIPTOR_NAME(fs_feedback_ep, node),
 
-#define AS_DESCRIPTORS(node)							\
-	AS_INTERFACE_DESCRIPTOR(node, 0, 0)					\
+#define AS_EXPLICIT_FEEDBACK_ENDPOINT_HS_DESCRIPTOR(node)			\
+	0x07,						/* bLength */		\
+	USB_DESC_ENDPOINT,				/* bDescriptorType */	\
+	AS_NEXT_IN_EP_ADDR(node),			/* bEndpointAddress */	\
+	0x11,						/* bmAttributes */	\
+	U16_LE(0x04),					/* wMaxPacketSize */	\
+	0x01, /* TODO: adjust to P 5.12.4.2 Feedback */	/* bInterval */
+
+#define AS_EXPLICIT_FEEDBACK_HS_DESCRIPTOR_ARRAY(node)				\
+	static uint8_t DESCRIPTOR_NAME(hs_feedback_ep, node)[] = {		\
+		AS_EXPLICIT_FEEDBACK_ENDPOINT_HS_DESCRIPTOR(node)		\
+	};
+
+#define AS_EXPLICIT_FEEDBACK_ENDPOINT_HS_DESCRIPTOR_PTR(node)			\
+	(struct usb_desc_header *) &DESCRIPTOR_NAME(hs_feedback_ep, node),
+
+#define AS_FS_DESCRIPTORS_ARRAYS(node)						\
 	IF_ENABLED(AS_HAS_ISOCHRONOUS_DATA_ENDPOINT(node), (			\
-		AS_INTERFACE_DESCRIPTOR(node, 1,				\
-			AS_INTERFACE_NUM_ENDPOINTS(node))))			\
-	AUDIO_STREAMING_INTERFACE_DESCRIPTORS(node)				\
-	IF_ENABLED(AS_HAS_ISOCHRONOUS_DATA_ENDPOINT(node), (			\
-		AS_ISOCHRONOUS_DATA_ENDPOINT_DESCRIPTORS(node)			\
+		AS_ISOCHRONOUS_DATA_ENDPOINT_FS_DESCRIPTORS_ARRAYS(node)	\
 		IF_ENABLED(AS_HAS_EXPLICIT_FEEDBACK_ENDPOINT(node), (		\
-			AS_EXPLICIT_FEEDBACK_ENDPOINT_DESCRIPTOR(node)))	\
+			AS_EXPLICIT_FEEDBACK_FS_DESCRIPTOR_ARRAY(node)))	\
+	))
+
+#define AS_HS_DESCRIPTORS_ARRAYS(node)						\
+	IF_ENABLED(AS_HAS_ISOCHRONOUS_DATA_ENDPOINT(node), (			\
+		AS_ISOCHRONOUS_DATA_ENDPOINT_HS_DESCRIPTORS_ARRAYS(node)	\
+		IF_ENABLED(AS_HAS_EXPLICIT_FEEDBACK_ENDPOINT(node), (		\
+			AS_EXPLICIT_FEEDBACK_HS_DESCRIPTOR_ARRAY(node)))	\
 	))
 
 #define AS_DESCRIPTORS_ARRAYS(node)						\
@@ -684,41 +768,46 @@
 		AS_INTERFACE_DESCRIPTOR_ARRAY(node, 1,				\
 			AS_INTERFACE_NUM_ENDPOINTS(node))))			\
 	AUDIO_STREAMING_INTERFACE_DESCRIPTORS_ARRAYS(node)			\
+	IF_ENABLED(UAC2_ALLOWED_AT_FULL_SPEED(DT_PARENT(node)), (		\
+		AS_FS_DESCRIPTORS_ARRAYS(node)))				\
+	IF_ENABLED(UAC2_ALLOWED_AT_HIGH_SPEED(DT_PARENT(node)), (		\
+		AS_HS_DESCRIPTORS_ARRAYS(node)))				\
 	IF_ENABLED(AS_HAS_ISOCHRONOUS_DATA_ENDPOINT(node), (			\
-		AS_ISOCHRONOUS_DATA_ENDPOINT_DESCRIPTORS_ARRAYS(node)		\
-		IF_ENABLED(AS_HAS_EXPLICIT_FEEDBACK_ENDPOINT(node), (		\
-			AS_EXPLICIT_FEEDBACK_ENDPOINT_DESCRIPTOR_ARRAY(node)))	\
-	))
+		AS_ISOCHRONOUS_DATA_ENDPOINT_CS_DESCRIPTORS_ARRAYS(node)))
 
-#define AS_DESCRIPTORS_PTRS(node)						\
-	AS_INTERFACE_DESCRIPTOR_PTR(node, 0)					\
+#define AS_FS_DESCRIPTORS_PTRS(node)						\
+	AS_INTERFACE_FS_DESCRIPTOR_PTR(node, 0)					\
 	IF_ENABLED(AS_HAS_ISOCHRONOUS_DATA_ENDPOINT(node), (			\
-		AS_INTERFACE_DESCRIPTOR_PTR(node, 1)))				\
+		AS_INTERFACE_FS_DESCRIPTOR_PTR(node, 1)))			\
 	AUDIO_STREAMING_INTERFACE_DESCRIPTORS_PTRS(node)			\
 	IF_ENABLED(AS_HAS_ISOCHRONOUS_DATA_ENDPOINT(node), (			\
-		AS_ISOCHRONOUS_DATA_ENDPOINT_DESCRIPTORS_PTRS(node)		\
+		AS_ISOCHRONOUS_DATA_ENDPOINT_FS_DESCRIPTORS_PTRS(node)		\
 		IF_ENABLED(AS_HAS_EXPLICIT_FEEDBACK_ENDPOINT(node), (		\
-			AS_EXPLICIT_FEEDBACK_ENDPOINT_DESCRIPTOR_PTR(node)))	\
+			AS_EXPLICIT_FEEDBACK_ENDPOINT_FS_DESCRIPTOR_PTR(node)))	\
 	))
 
-#define AS_DESCRIPTORS_IF_AUDIOSTREAMING(node)					\
-	IF_ENABLED(DT_NODE_HAS_COMPAT(node, zephyr_uac2_audio_streaming), (	\
-		AS_DESCRIPTORS(node)))
+#define AS_HS_DESCRIPTORS_PTRS(node)						\
+	AS_INTERFACE_HS_DESCRIPTOR_PTR(node, 0)					\
+	IF_ENABLED(AS_HAS_ISOCHRONOUS_DATA_ENDPOINT(node), (			\
+		AS_INTERFACE_HS_DESCRIPTOR_PTR(node, 1)))			\
+	AUDIO_STREAMING_INTERFACE_DESCRIPTORS_PTRS(node)			\
+	IF_ENABLED(AS_HAS_ISOCHRONOUS_DATA_ENDPOINT(node), (			\
+		AS_ISOCHRONOUS_DATA_ENDPOINT_HS_DESCRIPTORS_PTRS(node)		\
+		IF_ENABLED(AS_HAS_EXPLICIT_FEEDBACK_ENDPOINT(node), (		\
+			AS_EXPLICIT_FEEDBACK_ENDPOINT_HS_DESCRIPTOR_PTR(node)))	\
+	))
 
 #define AS_DESCRIPTORS_ARRAYS_IF_AUDIOSTREAMING(node)				\
 	IF_ENABLED(DT_NODE_HAS_COMPAT(node, zephyr_uac2_audio_streaming), (	\
 		AS_DESCRIPTORS_ARRAYS(node)))
 
-#define AS_DESCRIPTORS_PTRS_IF_AUDIOSTREAMING(node)				\
+#define AS_FS_DESCRIPTORS_PTRS_IF_AUDIOSTREAMING(node)				\
 	IF_ENABLED(DT_NODE_HAS_COMPAT(node, zephyr_uac2_audio_streaming), (	\
-		AS_DESCRIPTORS_PTRS(node)))
+		AS_FS_DESCRIPTORS_PTRS(node)))
 
-#define UAC2_AUDIO_CONTROL_DESCRIPTORS(node)					\
-	AC_INTERFACE_DESCRIPTOR(node)						\
-	AC_INTERFACE_HEADER_DESCRIPTOR(node)					\
-	ENTITY_HEADERS(node)							\
-	IF_ENABLED(DT_PROP(node, interrupt_endpoint), (				\
-		AC_ENDPOINT_DESCRIPTOR(node)))
+#define AS_HS_DESCRIPTORS_PTRS_IF_AUDIOSTREAMING(node)				\
+	IF_ENABLED(DT_NODE_HAS_COMPAT(node, zephyr_uac2_audio_streaming), (	\
+		AS_HS_DESCRIPTORS_PTRS(node)))
 
 #define UAC2_AUDIO_CONTROL_DESCRIPTOR_ARRAYS(node)				\
 	AC_INTERFACE_DESCRIPTOR_ARRAY(node)					\
@@ -727,102 +816,85 @@
 	IF_ENABLED(DT_PROP(node, interrupt_endpoint), (				\
 		AC_ENDPOINT_DESCRIPTOR_ARRAY(node)))
 
-#define UAC2_AUDIO_CONTROL_DESCRIPTOR_PTRS(node)				\
-	AC_INTERFACE_DESCRIPTOR_PTR(node)					\
+#define UAC2_AUDIO_CONTROL_COMMON_DESCRIPTOR_PTRS(node)				\
 	AC_INTERFACE_HEADER_DESCRIPTOR_PTR(node)				\
 	ENTITY_HEADERS_PTRS(node)						\
 	IF_ENABLED(DT_PROP(node, interrupt_endpoint), (				\
 		AC_ENDPOINT_DESCRIPTOR_PTR(node)))
+
+#define UAC2_AUDIO_CONTROL_FS_DESCRIPTOR_PTRS(node)				\
+	AC_INTERFACE_FS_DESCRIPTOR_PTR(node)					\
+	UAC2_AUDIO_CONTROL_COMMON_DESCRIPTOR_PTRS(node)
+
+#define UAC2_AUDIO_CONTROL_HS_DESCRIPTOR_PTRS(node)				\
+	AC_INTERFACE_HS_DESCRIPTOR_PTR(node)					\
+	UAC2_AUDIO_CONTROL_COMMON_DESCRIPTOR_PTRS(node)
 
 #define UAC2_DESCRIPTOR_ARRAYS(node)						\
 	UAC2_INTERFACE_ASSOCIATION_DESCRIPTOR_ARRAY(node)			\
 	UAC2_AUDIO_CONTROL_DESCRIPTOR_ARRAYS(node)				\
 	DT_FOREACH_CHILD(node, AS_DESCRIPTORS_ARRAYS_IF_AUDIOSTREAMING)
 
-#define UAC2_DESCRIPTOR_PTRS(node)						\
-	UAC2_INTERFACE_ASSOCIATION_DESCRIPTOR_PTR(node)				\
-	UAC2_AUDIO_CONTROL_DESCRIPTOR_PTRS(node)				\
-	DT_FOREACH_CHILD(node, AS_DESCRIPTORS_PTRS_IF_AUDIOSTREAMING)		\
+#define UAC2_FS_DESCRIPTOR_PTRS(node)						\
+	UAC2_INTERFACE_ASSOCIATION_FS_DESCRIPTOR_PTR(node)			\
+	UAC2_AUDIO_CONTROL_FS_DESCRIPTOR_PTRS(node)				\
+	DT_FOREACH_CHILD(node, AS_FS_DESCRIPTORS_PTRS_IF_AUDIOSTREAMING)	\
 	NULL
 
-#define UAC2_DESCRIPTORS(node)							\
-	UAC2_INTERFACE_ASSOCIATION_DESCRIPTOR(node)				\
-	UAC2_AUDIO_CONTROL_DESCRIPTORS(node)					\
-	DT_FOREACH_CHILD(node, AS_DESCRIPTORS_IF_AUDIOSTREAMING)
+#define UAC2_HS_DESCRIPTOR_PTRS(node)						\
+	UAC2_INTERFACE_ASSOCIATION_HS_DESCRIPTOR_PTR(node)			\
+	UAC2_AUDIO_CONTROL_HS_DESCRIPTOR_PTRS(node)				\
+	DT_FOREACH_CHILD(node, AS_HS_DESCRIPTORS_PTRS_IF_AUDIOSTREAMING)	\
+	NULL
 
+#define UAC2_FS_DESCRIPTOR_PTRS_ARRAY(node)					\
+	COND_CODE_1(UAC2_ALLOWED_AT_FULL_SPEED(node),				\
+		({UAC2_FS_DESCRIPTOR_PTRS(node)}), ({NULL}))
 
-/* Helper macros to determine endpoint offset within complete UAC2 blob */
-#define COUNT_AS_DESCRIPTORS_BYTES_UP_TO_IDX(node, idx)				\
-	(sizeof((uint8_t []){AS_DESCRIPTORS_IF_AUDIOSTREAMING(node)}) *		\
-	(DT_NODE_CHILD_IDX(node) <= idx))
-
-#define UAC2_DESCRIPTOR_AS_DESC_END_OFFSET(node)				\
-	(sizeof((uint8_t []){							\
-		UAC2_INTERFACE_ASSOCIATION_DESCRIPTOR(DT_PARENT(node))		\
-		UAC2_AUDIO_CONTROL_DESCRIPTORS(DT_PARENT(node))			\
-	})) + DT_FOREACH_CHILD_SEP_VARGS(DT_PARENT(node),			\
-		COUNT_AS_DESCRIPTORS_BYTES_UP_TO_IDX, (+),			\
-		DT_NODE_CHILD_IDX(node))
-
-#define AS_ISOCHRONOUS_DATA_ENDPOINT_DESCRIPTORS_SIZE(node)			\
-	(sizeof((uint8_t []) {AS_ISOCHRONOUS_DATA_ENDPOINT_DESCRIPTORS(node)}))
-
-#define AS_EXPLICIT_FEEDBACK_ENDPOINT_DESCRIPTOR_SIZE(node)			\
-	COND_CODE_1(AS_HAS_EXPLICIT_FEEDBACK_ENDPOINT(node),			\
-		(sizeof((uint8_t []) {						\
-			AS_EXPLICIT_FEEDBACK_ENDPOINT_DESCRIPTOR(node)		\
-		})), (0))
-
-/* Return offset inside UAC2_DESCRIPTORS(DT_PARENT(node)) poiting to data
- * endpoint address belonging to given AudioStreaming interface node.
- *
- * It is programmer error to call this macro with node other than AudioStreaming
- * or when AS_HAS_ISOCHRONOUS_DATA_ENDPOINT(node) is 0.
- */
-#define UAC2_DESCRIPTOR_AS_DATA_EP_OFFSET(node)					\
-	UAC2_DESCRIPTOR_AS_DESC_END_OFFSET(node)				\
-	- AS_EXPLICIT_FEEDBACK_ENDPOINT_DESCRIPTOR_SIZE(node)			\
-	- AS_ISOCHRONOUS_DATA_ENDPOINT_DESCRIPTORS_SIZE(node)			\
-	+ offsetof(struct usb_ep_descriptor, bEndpointAddress)
-
-/* Return offset inside UAC2_DESCRIPTORS(DT_PARENT(node)) poiting to feedback
- * endpoint address belonging to given AudioStreaming interface node.
- *
- * It is programmer error to call this macro with node other than AudioStreaming
- * or when AS_HAS_EXPLICIT_FEEDBACK_ENDPOINT(node) is 0.
- */
-#define UAC2_DESCRIPTOR_AS_FEEDBACK_EP_OFFSET(node)				\
-	UAC2_DESCRIPTOR_AS_DESC_END_OFFSET(node)				\
-	- AS_EXPLICIT_FEEDBACK_ENDPOINT_DESCRIPTOR_SIZE(node)			\
-	+ offsetof(struct usb_ep_descriptor, bEndpointAddress)
+#define UAC2_HS_DESCRIPTOR_PTRS_ARRAY(node)					\
+	COND_CODE_1(UAC2_ALLOWED_AT_HIGH_SPEED(node),				\
+		({UAC2_HS_DESCRIPTOR_PTRS(node)}), ({NULL}))
 
 /* Helper macros to determine endpoint descriptor offset within descriptor set */
 #define COUNT_PTRS(...) sizeof((struct usb_desc_header *[]){__VA_ARGS__})	\
 	/ sizeof(struct usb_desc_header *)
 
 #define COUNT_AS_DESCRIPTORS_UP_TO_IDX(node, idx)				\
-	(COUNT_PTRS(AS_DESCRIPTORS_PTRS_IF_AUDIOSTREAMING(node))) *		\
+	(COUNT_PTRS(COND_CODE_1(UAC2_ALLOWED_AT_FULL_SPEED(DT_PARENT(node)),	\
+		(AS_FS_DESCRIPTORS_PTRS_IF_AUDIOSTREAMING(node)),		\
+		(AS_HS_DESCRIPTORS_PTRS_IF_AUDIOSTREAMING(node))))) *		\
 	(DT_NODE_CHILD_IDX(node) <= idx)
 
 #define UAC2_DESCRIPTOR_AS_DESC_END_COUNT(node)					\
-	(COUNT_PTRS(								\
-		UAC2_INTERFACE_ASSOCIATION_DESCRIPTOR_PTR(DT_PARENT(node))	\
-		UAC2_AUDIO_CONTROL_DESCRIPTOR_PTRS(DT_PARENT(node))		\
-	)) + DT_FOREACH_CHILD_SEP_VARGS(DT_PARENT(node),			\
+	(COUNT_PTRS(COND_CODE_1(UAC2_ALLOWED_AT_FULL_SPEED(DT_PARENT(node)), (	\
+		UAC2_INTERFACE_ASSOCIATION_FS_DESCRIPTOR_PTR(DT_PARENT(node))	\
+		UAC2_AUDIO_CONTROL_FS_DESCRIPTOR_PTRS(DT_PARENT(node))		\
+	), (									\
+		UAC2_INTERFACE_ASSOCIATION_HS_DESCRIPTOR_PTR(DT_PARENT(node))	\
+		UAC2_AUDIO_CONTROL_HS_DESCRIPTOR_PTRS(DT_PARENT(node))		\
+	)))) + DT_FOREACH_CHILD_SEP_VARGS(DT_PARENT(node),			\
 		COUNT_AS_DESCRIPTORS_UP_TO_IDX, (+),				\
 		DT_NODE_CHILD_IDX(node))
 
 #define AS_ISOCHRONOUS_DATA_ENDPOINT_DESCRIPTORS_COUNT(node)			\
-	COUNT_PTRS(AS_ISOCHRONOUS_DATA_ENDPOINT_DESCRIPTORS_PTRS(node))
+	COUNT_PTRS(COND_CODE_1(UAC2_ALLOWED_AT_FULL_SPEED(DT_PARENT(node)), (	\
+		AS_ISOCHRONOUS_DATA_ENDPOINT_FS_DESCRIPTORS_PTRS(node)		\
+	), (									\
+		AS_ISOCHRONOUS_DATA_ENDPOINT_HS_DESCRIPTORS_PTRS(node)		\
+	)))
 
 #define AS_EXPLICIT_FEEDBACK_ENDPOINT_DESCRIPTOR_COUNT(node)			\
-	COND_CODE_1(AS_HAS_EXPLICIT_FEEDBACK_ENDPOINT(node),			\
-		(COUNT_PTRS(							\
-			AS_EXPLICIT_FEEDBACK_ENDPOINT_DESCRIPTOR_PTR(node)	\
-		)), (0))
+	COND_CODE_1(AS_HAS_EXPLICIT_FEEDBACK_ENDPOINT(node), (COUNT_PTRS(	\
+		COND_CODE_1(UAC2_ALLOWED_AT_FULL_SPEED(DT_PARENT(node)), (	\
+			AS_EXPLICIT_FEEDBACK_ENDPOINT_FS_DESCRIPTOR_PTR(node)	\
+		), (								\
+			AS_EXPLICIT_FEEDBACK_ENDPOINT_HS_DESCRIPTOR_PTR(node)	\
+		))								\
+	)), (0))
 
-/* Return index inside UAC2_DESCRIPTOR_PTRS(DT_PARENT(node)) poiting to data
- * endpoint descriptor belonging to given AudioStreaming interface node.
+/* Return index inside UAC2_FS_DESCRIPTOR_PTRS(DT_PARENT(node)) and/or
+ * UAC2_HS_DESCRIPTOR_PTRS(DT_PARENT(node)) pointing to data endpoint
+ * descriptor belonging to given AudioStreaming interface node.
  *
  * It is programmer error to call this macro with node other than AudioStreaming
  * or when AS_HAS_ISOCHRONOUS_DATA_ENDPOINT(node) is 0.
@@ -832,8 +904,9 @@
 	- AS_EXPLICIT_FEEDBACK_ENDPOINT_DESCRIPTOR_COUNT(node)			\
 	- AS_ISOCHRONOUS_DATA_ENDPOINT_DESCRIPTORS_COUNT(node)
 
-/* Return index inside UAC2_DESCRIPTOR_PTRS(DT_PARENT(node)) poiting to feedback
- * endpoint descriptor belonging to given AudioStreaming interface node.
+/* Return index inside UAC2_FS_DESCRIPTOR_PTRS(DT_PARENT(node)) and/or
+ * UAC2_HS_DESCRIPTOR_PTRS(DT_PARENT(node)) pointing to feedback endpoint
+ * descriptor belonging to given AudioStreaming interface node.
  *
  * It is programmer error to call this macro with node other than AudioStreaming
  * or when AS_HAS_EXPLICIT_FEEDBACK_ENDPOINT(node) is 0.
@@ -873,6 +946,16 @@
 		DT_NODE_HAS_COMPAT(DT_PROP(node, linked_terminal),		\
 		zephyr_uac2_output_terminal))
 
+#define VALIDATE_AS_BANDWIDTH(node)						\
+	IF_ENABLED(UAC2_ALLOWED_AT_FULL_SPEED(DT_PARENT(node)),	(		\
+		BUILD_ASSERT(AS_FS_DATA_EP_MAX_PACKET_SIZE(node) <= 1023,	\
+			"Full-Speed bandwidth exceeded");			\
+	))									\
+	IF_ENABLED(UAC2_ALLOWED_AT_HIGH_SPEED(DT_PARENT(node)), (		\
+		BUILD_ASSERT(USB_TPL_IS_VALID(AS_HS_DATA_EP_TPL(node)),		\
+			"High-Speed bandwidth exceeded");			\
+	))
+
 #define VALIDATE_NODE(node)							\
 	IF_ENABLED(DT_NODE_HAS_COMPAT(node, zephyr_uac2_clock_source), (	\
 		BUILD_ASSERT(DT_PROP_LEN(node, sampling_frequencies),		\
@@ -903,6 +986,13 @@
 		BUILD_ASSERT(!DT_PROP(node, implicit_feedback) ||		\
 			!AS_IS_SOF_SYNCHRONIZED(node),				\
 			"Implicit feedback on SOF synchronized clock");		\
+		IF_ENABLED(AS_HAS_ISOCHRONOUS_DATA_ENDPOINT(node), (		\
+			VALIDATE_AS_BANDWIDTH(node)))				\
 	))
+
+#define VALIDATE_INSTANCE(uac2)							\
+	BUILD_ASSERT(DT_PROP(uac2, full_speed) || DT_PROP(uac2, high_speed),	\
+		"Instance must be allowed to operate at least at one speed");	\
+	DT_FOREACH_CHILD(uac2, VALIDATE_NODE)
 
 #endif /* ZEPHYR_INCLUDE_USBD_UAC2_MACROS_H_ */

--- a/tests/subsys/usb/device_next/build_all.overlay
+++ b/tests/subsys/usb/device_next/build_all.overlay
@@ -12,6 +12,7 @@
 	uac2_headphones: usb_audio2 {
 		compatible = "zephyr,uac2";
 		status = "okay";
+		full-speed;
 		audio-function = <AUDIO_FUNCTION_OTHER>;
 
 		uac_aclk: aclk {

--- a/tests/subsys/usb/uac2/app.overlay
+++ b/tests/subsys/usb/uac2/app.overlay
@@ -11,6 +11,7 @@
 		compatible = "zephyr,uac2";
 		status = "okay";
 		full-speed;
+		high-speed;
 		audio-function = <AUDIO_FUNCTION_HEADSET>;
 
 		uac_aclk: aclk {

--- a/tests/subsys/usb/uac2/app.overlay
+++ b/tests/subsys/usb/uac2/app.overlay
@@ -74,3 +74,41 @@
 		};
 	};
 };
+
+/ {
+	hs_uac2_headphones: hs_usb_audio2 {
+		compatible = "zephyr,uac2";
+		status = "okay";
+		high-speed;
+		audio-function = <AUDIO_FUNCTION_OTHER>;
+
+		hs_uac_aclk: hs_aclk {
+			compatible = "zephyr,uac2-clock-source";
+			clock-type = "internal-programmable";
+			frequency-control = "host-programmable";
+			sampling-frequencies = <192000>;
+		};
+
+		hs_out_terminal: hs_out_terminal {
+			compatible = "zephyr,uac2-input-terminal";
+			clock-source = <&hs_uac_aclk>;
+			terminal-type = <USB_TERMINAL_STREAMING>;
+			front-left;
+			front-right;
+		};
+
+		hs_headphones_output: hs_headphones {
+			compatible = "zephyr,uac2-output-terminal";
+			data-source = <&hs_out_terminal>;
+			clock-source = <&hs_uac_aclk>;
+			terminal-type = <OUTPUT_TERMINAL_HEADPHONES>;
+		};
+
+		hs_as_iso_out: hs_out_interface {
+			compatible = "zephyr,uac2-audio-streaming";
+			linked-terminal = <&hs_out_terminal>;
+			subslot-size = <3>;
+			bit-resolution = <24>;
+		};
+	};
+};

--- a/tests/subsys/usb/uac2/app.overlay
+++ b/tests/subsys/usb/uac2/app.overlay
@@ -10,6 +10,7 @@
 	uac2_headset: usb_audio2 {
 		compatible = "zephyr,uac2";
 		status = "okay";
+		full-speed;
 		audio-function = <AUDIO_FUNCTION_HEADSET>;
 
 		uac_aclk: aclk {

--- a/tests/subsys/usb/uac2/src/uac2_desc.c
+++ b/tests/subsys/usb/uac2/src/uac2_desc.c
@@ -158,13 +158,12 @@ static const uint8_t reference_as_ep_descriptor[] = {
 	0x00, 0x00,		/* wLockDelay = 0 */
 };
 
-DT_FOREACH_CHILD(DT_NODELABEL(uac2_headset), VALIDATE_NODE)
+VALIDATE_INSTANCE(DT_NODELABEL(uac2_headset))
 
 UAC2_DESCRIPTOR_ARRAYS(DT_NODELABEL(uac2_headset))
 
-const static struct usb_desc_header *generated_uac2_descriptor_set[] = {
-	UAC2_DESCRIPTOR_PTRS(DT_NODELABEL(uac2_headset))
-};
+const static struct usb_desc_header *generated_uac2_descriptor_set[] =
+	UAC2_FS_DESCRIPTOR_PTRS_ARRAY(DT_NODELABEL(uac2_headset));
 
 ZTEST(uac2_desc, test_uac2_descriptors)
 {

--- a/tests/subsys/usb/uac2/src/uac2_desc.c
+++ b/tests/subsys/usb/uac2/src/uac2_desc.c
@@ -10,6 +10,7 @@
 #include <zephyr/usb/usbd.h>
 #include <usbd_uac2_macros.h>
 
+/* 48 kHz headset with implicit feedback, allowed on both Full and High-Speed */
 static const uint8_t reference_ac_interface_descriptor[] = {
 	/* 4.7.2 Class-Specific AC Interface Descriptor */
 	0x09,			/* bLength = 9 */
@@ -168,6 +169,98 @@ const static struct usb_desc_header *uac2_fs_descriptor_set[] =
 
 const static struct usb_desc_header *uac2_hs_descriptor_set[] =
 	UAC2_HS_DESCRIPTOR_PTRS_ARRAY(DT_NODELABEL(uac2_headset));
+
+VALIDATE_INSTANCE(DT_NODELABEL(uac2_headset))
+
+/* 192 kHz 24-bit stereo headphones allowed on High-Speed only */
+static const uint8_t reference_hs_ac_interface_descriptor[] = {
+	/* 4.7.2 Class-Specific AC Interface Descriptor */
+	0x09,			/* bLength = 9 */
+	0x24,			/* bDescriptorType = CS_INTERFACE */
+	0x01,			/* bDescriptorSubtype = HEADER */
+	0x00, 0x02,		/* bcdADC = 02.00 */
+	0xff,			/* bCategory = OTHER */
+	0x2e, 0x00,		/* wTotalLength = 0x2e = 46 */
+	0x00,			/* bmControls = Latency Control not present */
+};
+
+static const uint8_t reference_hs_ac_clock_source_descriptor[] = {
+	/* 4.7.2.1 Clock Source Descriptor */
+	0x08,			/* bLength = 8 */
+	0x24,			/* bDescriptorType = CS_INTERFACE */
+	0x0a,			/* bDescriptorSubtype = CLOCK_SOURCE */
+	0x01,			/* bClockID = 1 */
+	0x03,			/* bmAttributes = Internal programmable */
+	0x03,			/* bmControls = frequency host programmable */
+	0x00,			/* bAssocTerminal = 0 (not associated) */
+	0x00,			/* iClockSource = 0 (no string descriptor) */
+};
+
+static const uint8_t reference_hs_ac_input_terminal_descriptor[] = {
+	/* 4.7.2.4 Input Terminal Descriptor */
+	0x11,			/* bLength = 17 */
+	0x24,			/* bDescriptorType = CS_INTERFACE */
+	0x02,			/* bDescriptorSubtype = INPUT_TERMINAL */
+	0x02,			/* bTerminalID = 2 */
+	0x01, 0x01,		/* wTerminalType = 0x0101 (USB streaming) */
+	0x00,			/* bAssocTerminal = 0 (not associated) */
+	0x01,			/* bCSourceID = 1 (main clock) */
+	0x02,			/* bNrChannels = 2 */
+	0x03, 0x00, 0x00, 0x00,	/* bmChannelConfig = Front Left, Front Right */
+	0x00,			/* iChannelNames = 0 (all pre-defined) */
+	0x00, 0x00,		/* bmControls = none present */
+	0x00,			/* iTerminal = 0 (no string descriptor) */
+};
+
+static const uint8_t reference_hs_ac_output_terminal_descriptor[] = {
+	/* 4.7.2.5 Output Terminal Descriptor */
+	0x0c,			/* bLength = 12 */
+	0x24,			/* bDescriptorType = CS_INTERFACE */
+	0x03,			/* bDescriptorSubtype = OUTPUT_TERMINAL */
+	0x03,			/* bTerminalID = 3 */
+	0x02, 0x03,		/* wTerminalType = 0x0302 (Headphones) */
+	0x00,			/* bAssocTerminal = 0 (none) */
+	0x02,			/* bSourceID = 2 (streaming input) */
+	0x01,			/* bCSourceID = 1 (main clock) */
+	0x00, 0x00,		/* bmControls = none present */
+	0x00,			/* iTerminal = 0 (no string descriptor) */
+};
+
+static const uint8_t reference_hs_as_cs_general_descriptor[] = {
+	/* 4.9.2 Class-Specific AS Interface Descriptor */
+	0x10,			/* bLength = 16 */
+	0x24,			/* bDescriptorType = CS_INTERFACE */
+	0x01,			/* bDescriptorSubtype = AS_GENERAL */
+	0x02,			/* bTerminalLink = 2 (USB streaming input) */
+	0x00,			/* bmControls = non present */
+	0x01,			/* bFormatType = 1 */
+	0x01, 0x00, 0x00, 0x00,	/* bmFormats = PCM */
+	0x02,			/* bNrChannels = 2 */
+	0x03, 0x00, 0x00, 0x00,	/* bmChannelConfig = Front Left, Front Right */
+	0x00,			/* iChannelNames = 0 (all pre-defined) */
+};
+
+static const uint8_t reference_hs_as_cs_format_descriptor[] = {
+	/* Universal Serial Bus Device Class Definition for Audio Data Formats
+	 * Release 2.0, May 31, 2006. 2.3.1.6 Type I Format Type Descriptor
+	 */
+	0x06,			/* bLength = 6 */
+	0x24,			/* bDescriptorType = CS_INTERFACE */
+	0x02,			/* bDescriptorSubtype = FORMAT_TYPE */
+	0x01,			/* bFormatType = 1 */
+	0x03,			/* bSubslotSize = 3 */
+	0x18,			/* bBitResolution = 24 */
+};
+
+VALIDATE_INSTANCE(DT_NODELABEL(hs_uac2_headphones))
+
+UAC2_DESCRIPTOR_ARRAYS(DT_NODELABEL(hs_uac2_headphones))
+
+const static struct usb_desc_header *fs_headphones_descriptor_set[] =
+	UAC2_FS_DESCRIPTOR_PTRS_ARRAY(DT_NODELABEL(hs_uac2_headphones));
+
+const static struct usb_desc_header *hs_headphones_descriptor_set[] =
+	UAC2_HS_DESCRIPTOR_PTRS_ARRAY(DT_NODELABEL(hs_uac2_headphones));
 
 static void test_uac2_descriptors(const struct usb_desc_header **descriptors,
 				  enum usbd_speed speed)
@@ -390,6 +483,133 @@ ZTEST(uac2_desc, test_fs_hs_iface_and_ep_descriptors_not_shared)
 		fs_ptr++;
 		hs_ptr++;
 	}
+}
+
+ZTEST(uac2_desc, test_hs_only_headset)
+{
+	const struct usb_desc_header **ptr = hs_headphones_descriptor_set;
+
+	const struct usb_association_descriptor *iad;
+	const struct usb_if_descriptor *iface;
+	const struct usb_ep_descriptor *ep;
+
+	/* Allowed only at High-Speed so Full-Speed should be NULL */
+	zassert_equal(*fs_headphones_descriptor_set, NULL);
+
+	/* Headset has 3 interfaces: 1 AudioControl and 2 AudioStreaming */
+	iad = (const struct usb_association_descriptor *)*ptr;
+	zassert_not_null(iad);
+	zassert_equal(iad->bLength, sizeof(struct usb_association_descriptor));
+	zassert_equal(iad->bDescriptorType, USB_DESC_INTERFACE_ASSOC);
+	zassert_equal(iad->bFirstInterface, FIRST_INTERFACE_NUMBER);
+	zassert_equal(iad->bInterfaceCount, 2);
+	zassert_equal(iad->bFunctionClass, AUDIO_FUNCTION);
+	zassert_equal(iad->bFunctionSubClass, FUNCTION_SUBCLASS_UNDEFINED);
+	zassert_equal(iad->bFunctionProtocol, AF_VERSION_02_00);
+	zassert_equal(iad->iFunction, 0);
+	ptr++;
+
+	/* AudioControl interface goes first */
+	iface = (const struct usb_if_descriptor *)*ptr;
+	zassert_not_null(iface);
+	zassert_equal(iface->bLength, sizeof(struct usb_if_descriptor));
+	zassert_equal(iface->bDescriptorType, USB_DESC_INTERFACE);
+	zassert_equal(iface->bInterfaceNumber, FIRST_INTERFACE_NUMBER);
+	zassert_equal(iface->bAlternateSetting, 0);
+	zassert_equal(iface->bNumEndpoints, 0);
+	zassert_equal(iface->bInterfaceClass, AUDIO);
+	zassert_equal(iface->bInterfaceSubClass, AUDIOCONTROL);
+	zassert_equal(iface->bInterfaceProtocol, IP_VERSION_02_00);
+	zassert_equal(iface->iInterface, 0);
+	ptr++;
+
+	/* AudioControl class-specific descriptors */
+	zassert_mem_equal(reference_hs_ac_interface_descriptor, *ptr,
+		ARRAY_SIZE(reference_hs_ac_interface_descriptor));
+	ptr++;
+	zassert_mem_equal(reference_hs_ac_clock_source_descriptor, *ptr,
+		ARRAY_SIZE(reference_hs_ac_clock_source_descriptor));
+	ptr++;
+	zassert_mem_equal(reference_hs_ac_input_terminal_descriptor, *ptr,
+		ARRAY_SIZE(reference_hs_ac_input_terminal_descriptor));
+	ptr++;
+	zassert_mem_equal(reference_hs_ac_output_terminal_descriptor, *ptr,
+		ARRAY_SIZE(reference_hs_ac_output_terminal_descriptor));
+	ptr++;
+
+	/* AudioStreaming OUT interface Alt 0 without endpoints */
+	iface = (const struct usb_if_descriptor *)*ptr;
+	zassert_not_null(iface);
+	zassert_equal(iface->bLength, sizeof(struct usb_if_descriptor));
+	zassert_equal(iface->bDescriptorType, USB_DESC_INTERFACE);
+	zassert_equal(iface->bInterfaceNumber, FIRST_INTERFACE_NUMBER + 1);
+	zassert_equal(iface->bAlternateSetting, 0);
+	zassert_equal(iface->bNumEndpoints, 0);
+	zassert_equal(iface->bInterfaceClass, AUDIO);
+	zassert_equal(iface->bInterfaceSubClass, AUDIOSTREAMING);
+	zassert_equal(iface->bInterfaceProtocol, IP_VERSION_02_00);
+	zassert_equal(iface->iInterface, 0);
+	ptr++;
+
+	/* AudioStreaming OUT interface Alt 1 with endpoints */
+	iface = (const struct usb_if_descriptor *)*ptr;
+	zassert_not_null(iface);
+	zassert_equal(iface->bLength, sizeof(struct usb_if_descriptor));
+	zassert_equal(iface->bDescriptorType, USB_DESC_INTERFACE);
+	zassert_equal(iface->bInterfaceNumber, FIRST_INTERFACE_NUMBER + 1);
+	zassert_equal(iface->bAlternateSetting, 1);
+	zassert_equal(iface->bNumEndpoints, 2);
+	zassert_equal(iface->bInterfaceClass, AUDIO);
+	zassert_equal(iface->bInterfaceSubClass, AUDIOSTREAMING);
+	zassert_equal(iface->bInterfaceProtocol, IP_VERSION_02_00);
+	zassert_equal(iface->iInterface, 0);
+	ptr++;
+
+	/* AudioStreaming OUT class-specific descriptors */
+	zassert_mem_equal(reference_hs_as_cs_general_descriptor, *ptr,
+		ARRAY_SIZE(reference_hs_as_cs_general_descriptor));
+	ptr++;
+	zassert_mem_equal(reference_hs_as_cs_format_descriptor, *ptr,
+		ARRAY_SIZE(reference_hs_as_cs_format_descriptor));
+	ptr++;
+
+	/* Isochronous OUT endpoint descriptor */
+	ep = (const struct usb_ep_descriptor *)*ptr;
+	zassert_not_null(ep);
+	zassert_equal(ep->bLength, sizeof(struct usb_ep_descriptor));
+	zassert_equal(ep->bDescriptorType, USB_DESC_ENDPOINT);
+	zassert_equal(ep->bEndpointAddress, FIRST_OUT_EP_ADDR);
+	zassert_equal(ptr - hs_headphones_descriptor_set,
+		UAC2_DESCRIPTOR_AS_DATA_EP_INDEX(DT_NODELABEL(hs_as_iso_out)));
+	zassert_equal(ep->Attributes.transfer, USB_EP_TYPE_ISO);
+	zassert_equal(ep->Attributes.synch, 1 /* Asynchronous */);
+	zassert_equal(ep->Attributes.usage, 0 /* Data Endpoint */);
+	zassert_equal(sys_le16_to_cpu(ep->wMaxPacketSize), 150);
+	zassert_equal(ep->bInterval, 1);
+	ptr++;
+
+	/* AudioStreaming OUT endpoint descriptor */
+	zassert_mem_equal(reference_as_ep_descriptor, *ptr,
+		ARRAY_SIZE(reference_as_ep_descriptor));
+	ptr++;
+
+	/* Isochronous IN explicit feedback endpoint descriptor */
+	ep = (const struct usb_ep_descriptor *)*ptr;
+	zassert_not_null(ep);
+	zassert_equal(ep->bLength, sizeof(struct usb_ep_descriptor));
+	zassert_equal(ep->bDescriptorType, USB_DESC_ENDPOINT);
+	zassert_equal(ep->bEndpointAddress, FIRST_IN_EP_ADDR);
+	zassert_equal(ptr - hs_headphones_descriptor_set,
+		UAC2_DESCRIPTOR_AS_FEEDBACK_EP_INDEX(DT_NODELABEL(hs_as_iso_out)));
+	zassert_equal(ep->Attributes.transfer, USB_EP_TYPE_ISO);
+	zassert_equal(ep->Attributes.synch, 0 /* No Synchronization */);
+	zassert_equal(ep->Attributes.usage, 1 /* Explicit Feedback-Endpoint */);
+	zassert_equal(sys_le16_to_cpu(ep->wMaxPacketSize), 4);
+	zassert_equal(ep->bInterval, 1);
+	ptr++;
+
+	/* Confirm there is no trailing data */
+	zassert_equal(*ptr, NULL);
 }
 
 ZTEST_SUITE(uac2_desc, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Update macrobatics to handle full-speed and high-speed properties. PR scope limited to macros and tests. Actual High-Speed handling in class will come later.