### PR TITLE
boards: esp32-based: update documentation

### DIFF
--- a/boards/espressif/esp32_devkitc_wroom/doc/index.rst
+++ b/boards/espressif/esp32_devkitc_wroom/doc/index.rst
@@ -1,17 +1,17 @@
 .. _esp32_devkitc_wroom:
 
-ESP32-DEVKITC-WROOM
+ESP32-DevKitC-WROOM
 ###################
 
 Overview
 ********
 
-ESP32-DEVKITC-WROOM is a series of low cost, low power system on a chip microcontrollers
-with integrated Wi-Fi & dual-mode Bluetooth.  The ESP32 series employs a
+ESP32 is a series of low cost, low power system on a chip microcontrollers
+with integrated Wi-Fi & dual-mode Bluetooth. The ESP32 series employs a
 Tensilica Xtensa LX6 microprocessor in both dual-core and single-core
-variations.  ESP32-WROOM is created and developed by Espressif Systems, a
+variations. ESP32 is created and developed by Espressif Systems, a
 Shanghai-based Chinese company, and is manufactured by TSMC using their 40nm
-process. [1]_
+process. For more information, check `ESP32-DevKitC-WROOM`_.
 
 The features include the following:
 
@@ -43,20 +43,23 @@ The features include the following:
 
 .. figure:: img/esp32_devkitc_wroom.jpg
     :align: center
-    :alt: ESP32-DEVKITC-WROOM
+    :alt: ESP32-DevKitC-WROOM
 
     ESP32-DevKitC-WROOM-32D DK
+
+For more information, check the datasheet at `ESP32 Datasheet`_ or the technical reference
+manual at `ESP32 Technical Reference Manual`_.
 
 Asymmetric Multiprocessing (AMP)
 ********************************
 
-ESP32-DEVKITC-WROOM allows 2 different applications to be executed in ESP32 SoC. Due to its dual-core architecture, each core can be enabled to execute customized tasks in stand-alone mode
+ESP32-DevKitC-WROOM allows 2 different applications to be executed in ESP32 SoC. Due to its dual-core architecture, each core can be enabled to execute customized tasks in stand-alone mode
 and/or exchanging data over OpenAMP framework. See :ref:`ipc_samples` folder as code reference.
 
 Supported Features
 ==================
 
-Current Zephyr's ESP32-WROOM board supports the following features:
+Current Zephyr's ESP32-DevKitC-WROOM board supports the following features:
 
 +------------+------------+-------------------------------------+
 | Interface  | Controller | Driver/Component                    |
@@ -235,10 +238,9 @@ message in the monitor:
 Debugging
 *********
 
-ESP32-DEVKITC-WROOM support on OpenOCD is available upstream as of version 0.12.0.
-Download and install OpenOCD from `OpenOCD`_.
+ESP32 support on OpenOCD is available at `OpenOCD ESP32`_.
 
-On the ESP-WROOM-32 DevKitC board, the JTAG pins are not run to a
+On the ESP32-DevKitC-WROOM board, the JTAG pins are not run to a
 standard connector (e.g. ARM 20-pin) and need to be manually connected
 to the external programmer (e.g. a Flyswatter2):
 
@@ -260,8 +262,7 @@ to the external programmer (e.g. a Flyswatter2):
 | IO15       | TDO       |
 +------------+-----------+
 
-Further documentation can be obtained from the SoC vendor in `JTAG debugging
-for ESP32`_.
+Further documentation can be obtained from the SoC vendor in `JTAG debugging for ESP32`_.
 
 Here is an example for building the :ref:`hello_world` application.
 
@@ -288,12 +289,11 @@ GDB stub is enabled on ESP32.
   This does not work as the code is on flash which cannot be randomly
   accessed for modification.
 
-.. _`JTAG debugging for ESP32`: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/jtag-debugging/index.html
-.. _`OpenOCD`: https://github.com/openocd-org/openocd
-
 References
 **********
 
-.. [1] https://en.wikipedia.org/wiki/ESP32
-.. _ESP32 Technical Reference Manual: https://espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf
-.. _Hardware Reference: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/index.html
+.. _`ESP32-DevKitC-WROOM`: https://docs.espressif.com/projects/esp-idf/en/stable/esp32/hw-reference/esp32/get-started-devkitc.html#
+.. _`ESP32 Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf
+.. _`ESP32 Technical Reference Manual`: https://espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf
+.. _`JTAG debugging for ESP32`: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/jtag-debugging/index.html
+.. _`OpenOCD ESP32`: https://github.com/espressif/openocd-esp32/releases

--- a/boards/espressif/esp32_devkitc_wrover/doc/index.rst
+++ b/boards/espressif/esp32_devkitc_wrover/doc/index.rst
@@ -1,17 +1,17 @@
 .. _esp32_devkitc_wrover:
 
-ESP32-DEVKITC-WROVER
+ESP32-DevKitC-WROVER
 ####################
 
 Overview
 ********
 
 ESP32 is a series of low cost, low power system on a chip microcontrollers
-with integrated Wi-Fi & dual-mode Bluetooth.  The ESP32 series employs a
+with integrated Wi-Fi & dual-mode Bluetooth. The ESP32 series employs a
 Tensilica Xtensa LX6 microprocessor in both dual-core and single-core
-variations.  ESP32 is created and developed by Espressif Systems, a
+variations. ESP32 is created and developed by Espressif Systems, a
 Shanghai-based Chinese company, and is manufactured by TSMC using their 40nm
-process. [1]_
+process. For more information, check `ESP32-DevKitC-WROVER`_.
 
 The features include the following:
 
@@ -43,20 +43,23 @@ The features include the following:
 
 .. figure:: img/esp32_devkitc_wrover.jpg
     :align: center
-    :alt: ESP32-DEVKITC-WROVER
+    :alt: ESP32-DevKitC-WROVER
 
     ESP32-DevKitC-WROVER-IE
+
+For more information, check the datasheet at `ESP32 Datasheet`_ or the technical reference
+manual at `ESP32 Technical Reference Manual`_.
 
 Asymmetric Multiprocessing (AMP)
 ********************************
 
-ESP32-DEVKITC-WROVER allows 2 different applications to be executed in ESP32 SoC. Due to its dual-core architecture, each core can be enabled to execute customized tasks in stand-alone mode
+ESP32-DevKitC-WROVER allows 2 different applications to be executed in ESP32 SoC. Due to its dual-core architecture, each core can be enabled to execute customized tasks in stand-alone mode
 and/or exchanging data over OpenAMP framework. See :ref:`ipc_samples` folder as code reference.
 
 Supported Features
 ==================
 
-Current Zephyr's ESP32-devkitc board supports the following features:
+Current Zephyr's ESP32-DevKitC-WROVER board supports the following features:
 
 +------------+------------+-------------------------------------+
 | Interface  | Controller | Driver/Component                    |
@@ -235,10 +238,9 @@ message in the monitor:
 Debugging
 *********
 
-ESP32 support on OpenOCD is available upstream as of version 0.12.0.
-Download and install OpenOCD from `OpenOCD`_.
+ESP32 support on OpenOCD is available at `OpenOCD ESP32`_.
 
-On the ESP-WROOM-32 DevKitC board, the JTAG pins are not run to a
+On the ESP32-DevKitC-WROVER board, the JTAG pins are not run to a
 standard connector (e.g. ARM 20-pin) and need to be manually connected
 to the external programmer (e.g. a Flyswatter2):
 
@@ -260,8 +262,7 @@ to the external programmer (e.g. a Flyswatter2):
 | IO15       | TDO       |
 +------------+-----------+
 
-Further documentation can be obtained from the SoC vendor in `JTAG debugging
-for ESP32`_.
+Further documentation can be obtained from the SoC vendor in `JTAG debugging for ESP32`_.
 
 Here is an example for building the :ref:`hello_world` application.
 
@@ -288,12 +289,11 @@ GDB stub is enabled on ESP32.
   This does not work as the code is on flash which cannot be randomly
   accessed for modification.
 
-.. _`JTAG debugging for ESP32`: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/jtag-debugging/index.html
-.. _`OpenOCD`: https://github.com/openocd-org/openocd
-
 References
 **********
 
-.. [1] https://en.wikipedia.org/wiki/ESP32
-.. _ESP32 Technical Reference Manual: https://espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf
-.. _Hardware Reference: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/index.html
+.. _`ESP32-DevKitC-WROVER`: https://docs.espressif.com/projects/esp-idf/en/stable/esp32/hw-reference/esp32/get-started-devkitc.html#
+.. _`ESP32 Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf
+.. _`ESP32 Technical Reference Manual`: https://espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf
+.. _`JTAG debugging for ESP32`: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/jtag-debugging/index.html
+.. _`OpenOCD ESP32`: https://github.com/espressif/openocd-esp32/releases

--- a/boards/espressif/esp32_ethernet_kit/doc/index.rst
+++ b/boards/espressif/esp32_ethernet_kit/doc/index.rst
@@ -1,7 +1,10 @@
 .. _esp32_ethernet_kit:
 
-ESP32-ETHERNET-KIT
+ESP32-Ethernet-Kit
 ##################
+
+Overview
+********
 
 The ESP32-Ethernet-Kit is an Ethernet-to-Wi-Fi development board that enables
 Ethernet devices to be interconnected over Wi-Fi. At the same time, to provide
@@ -17,16 +20,13 @@ over Ethernet (PoE).
 
     ESP32-Ethernet-Kit V1.2 Overview
 
-Overview
-********
+ESP32-Ethernet-Kit is an ESP32-WROVER-E based development.
+For more information, check the datasheet at `ESP32-WROVER-E Datasheet`_.
 
-ESP32-Ethernet-Kit is an ESP32-based development board produced by
-`Espressif <https://espressif.com>`_.
-
-It consists of two development boards, the Ethernet board A and the PoE
-board B. The `Ethernet board (A)`_ contains Bluetooth/Wi-Fi dual-mode
+It consists of two development boards, the Ethernet Board A and the PoE
+board B. The `Ethernet Board (A)`_ contains Bluetooth/Wi-Fi dual-mode
 ESP32-WROVER-E module and IP101GRI, a Single Port 10/100 Fast Ethernet
-Transceiver (PHY). The `PoE board (B)`_ provides power over Ethernet
+Transceiver (PHY). The `PoE Board (B)`_ provides power over Ethernet
 functionality. The A board can work independently, without the board B
 installed.
 
@@ -39,7 +39,7 @@ installed.
 
     ESP32-Ethernet-Kit V1.2
 
-For the application loading and monitoring, the Ethernet board (A) also
+For the application loading and monitoring, the Ethernet Board (A) also
 features FTDI FT2232H chip - an advanced multi-interface USB bridge.
 This chip enables to use JTAG for direct debugging of ESP32 through the
 USB interface without a separate JTAG debugger.
@@ -76,7 +76,7 @@ Ethernet Board (A)
     :alt: ESP32-Ethernet-Kit V1.2
     :figclass: align-center
 
-    ESP32-Ethernet-Kit - Ethernet board (A) layout
+    ESP32-Ethernet-Kit - Ethernet Board (A) layout
 
 The table below provides description starting from the picture's top right
 corner and going clockwise.
@@ -104,8 +104,7 @@ corner and going clockwise.
       ESP32. FT2232H also features USB-to-JTAG interface which is available
       on channel A of the chip, while USB-to-serial is on channel B.
       The FT2232H chip enhances user-friendliness in terms of application
-      development and debugging. See
-      `ESP32-Ethernet-Kit V1.2 Ethernet board (A) Schematic <https://dl.espressif.com/dl/schematics/SCH_ESP32-Ethernet-Kit_A_V1.2_20200528.pdf>`_.
+      development and debugging. See `ESP32-Ethernet-Kit V1.2 Ethernet Board (A) Schematic`_
   * - USB Port
     - USB interface. Power supply for the board as well as the communication
       interface between a computer and the board.
@@ -121,7 +120,7 @@ corner and going clockwise.
   * - DC/DC Converter
     - Provided DC 5 V to 3.3 V conversion, output current up to 2 A.
   * - Board B Connectors
-    - A pair male and female header pins for mounting the `PoE board (B)`_
+    - A pair male and female header pins for mounting the `PoE Board (B)`_
   * - IP101GRI (PHY)
     - The physical layer (PHY) connection to the Ethernet cable is
       implemented using the
@@ -155,27 +154,27 @@ PoE Board (B)
 ^^^^^^^^^^^^^
 
 This board coverts power delivered over the Ethernet cable (PoE) to provide a
-power supply for the Ethernet board (A). The main components of the PoE board
+power supply for the Ethernet Board (A). The main components of the PoE Board
 (B) are shown on the block diagram under `Functionality Overview`_.
 
-The PoE board (B) has the following features:
+The PoE Board (B) has the following features:
 
 * Support for IEEE 802.3at
 * Power output: 5 V, 1.4 A
 
 To take advantage of the PoE functionality the **RJ45 Port** of the Ethernet
 board (A) should be connected with an Ethernet cable to a switch that supports
-PoE. When the Ethernet board (A) detects 5 V power output from the PoE board
+PoE. When the Ethernet Board (A) detects 5 V power output from the PoE Board
 (B), the USB power will be automatically cut off.
 
 .. figure:: img/esp32-ethernet-kit-b-v1.0-layout.jpg
     :align: center
-    :alt: ESP32-Ethernet-Kit - PoE board (B)
+    :alt: ESP32-Ethernet-Kit - PoE Board (B)
     :figclass: align-center
 
-    ESP32-Ethernet-Kit - PoE board (B) layout
+    ESP32-Ethernet-Kit - PoE Board (B) layout
 
-.. list-table:: Table  PoE board (B)
+.. list-table:: Table  PoE Board (B)
   :widths: 40 150
   :header-rows: 1
 
@@ -183,11 +182,11 @@ PoE. When the Ethernet board (A) detects 5 V power output from the PoE board
     - Description
   * - Board A Connector
     - Four female (left) and four male (right) header pins for connecting the
-      PoE board (B) to `Ethernet board (A)`_. The pins on the left accept
+      PoE Board (B) to `Ethernet Board (A)`_. The pins on the left accept
       power coming from a PoE switch. The pins on the right deliver 5 V power
-      supply to the Ethernet board (A).
+      supply to the Ethernet Board (A).
   * - External Power Terminals
-    - Optional power supply (26.6 ~ 54 V) to the PoE board (B).
+    - Optional power supply (26.6 ~ 54 V) to the PoE Board (B).
 
 .. _get-started-esp32-ethernet-kit-v1.2-setup-options:
 
@@ -225,9 +224,7 @@ or generated from internal ESP32 APLL (not recommended).
 .. note::
 
     For additional information on the RMII clock selection, please refer to
-    `ESP32-Ethernet-Kit V1.2 Ethernet board (A) Schematic <https://dl.espressif.com/dl/schematics/SCH_ESP32-Ethernet-Kit_A_V1.2_20200528.pdf>`_,
-    sheet 2, location D2.
-
+    `ESP32-Ethernet-Kit V1.2 Ethernet Board (A) Schematic`_, sheet 2, location D2.
 
 RMII Clock Sourced Externally by PHY
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -267,7 +264,7 @@ for transmission line delay, and then supplied to the PHY.
 
 To implement this option, users need to remove or add some RC components on
 the board. For details please refer to
-`ESP32-Ethernet-Kit V1.2 Ethernet board (A) Schematic <https://dl.espressif.com/dl/schematics/SCH_ESP32-Ethernet-Kit_A_V1.2_20200528.pdf>`_,
+`ESP32-Ethernet-Kit V1.2 Ethernet Board (A) Schematic`_,
 sheet 2, location D2. Please note that if the APLL is already used for other
 purposes (e.g. I2S peripheral), then you have no choice but use an external
 RMII clock.
@@ -411,7 +408,7 @@ GPIO Allocation Summary
        module that can be disabled/enabled externally. Similarly like when
        using RESET_N, the oscillator module should be disabled by default and
        turned on by ESP32 after power-up. For a reference design please see
-       `ESP32-Ethernet-Kit V1.2 Ethernet board (A) Schematic <https://dl.espressif.com/dl/schematics/SCH_ESP32-Ethernet-Kit_A_V1.2_20200528.pdf>`_.
+       `ESP32-Ethernet-Kit V1.2 Ethernet Board (A) Schematic`_.
 
     2. The ESP32 pins GPIO16 and GPIO17 are not broken out to the
        ESP32-WROVER-E module and therefore not available for use. If you need
@@ -560,7 +557,7 @@ Debugging
 
 As with much custom hardware, the ESP32 modules require patches to
 OpenOCD that are not upstreamed yet. Espressif maintains their own fork of
-the project. The custom OpenOCD can be obtained at `OpenOCD ESP32`_
+the project. The custom OpenOCD can be obtained at `OpenOCD ESP32`_.
 
 The Zephyr SDK uses a bundled version of OpenOCD by default. You can overwrite that behavior by adding the
 ``-DOPENOCD=<path/to/bin/openocd> -DOPENOCD_DEFAULT_PATH=<path/to/openocd/share/openocd/scripts>``
@@ -615,13 +612,9 @@ Board Init
 RESET_N (GPIO5) is automatically set high to enable the Ethernet PHY
 during board initialization (board_init.c)
 
-Related Documents
-*****************
+References
+**********
 
-* `ESP32-Ethernet-Kit V1.2 Ethernet Board (A) Schematic <https://dl.espressif.com/dl/schematics/SCH_ESP32-Ethernet-Kit_A_V1.2_20200528.pdf>`_ (PDF)
-* `ESP32-Ethernet-Kit PoE Board (B) Schematic <https://dl.espressif.com/dl/schematics/SCH_ESP32-ETHERNET-KIT_B_V1.0_20190517.pdf>`_ (PDF)
-* `ESP32-Ethernet-Kit V1.2 Ethernet Board (A) PCB Layout <https://dl.espressif.com/dl/schematics/PCB_ESP32-Ethernet-Kit_A_V1_2_20190829.pdf>`_ (PDF)
-* `ESP32-Ethernet-Kit PoE Board (B) PCB Layout <https://dl.espressif.com/dl/schematics/PCB_ESP32-Ethernet-Kit_B_V1_0_20190306.pdf>`_ (PDF)
-* `ESP32 Datasheet <https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf>`_ (PDF)
-* `ESP32-WROVER-E Datasheet <https://www.espressif.com/sites/default/files/documentation/esp32-wrover-e_esp32-wrover-ie_datasheet_en.pdf>`_ (PDF)
-* `OpenOCD ESP32 <https://github.com/espressif/openocd-esp32/releases>`_
+.. _`ESP32-Ethernet-Kit V1.2 Ethernet Board (A) Schematic`: https://dl.espressif.com/dl/schematics/SCH_ESP32-Ethernet-Kit_A_V1.2_20200528.pdf
+.. _`ESP32-WROVER-E Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32-wrover-e_esp32-wrover-ie_datasheet_en.pdf
+.. _`OpenOCD ESP32`: https://github.com/espressif/openocd-esp32/releases

--- a/boards/espressif/esp32c3_devkitc/doc/index.rst
+++ b/boards/espressif/esp32c3_devkitc/doc/index.rst
@@ -1,9 +1,16 @@
 .. _esp32c3_devkitc:
 
-ESP32-C3
-########
+ESP32-C3-DevKitC
+################
 
 Overview
+********
+
+ESP32-C3-DevKitC-02 is an entry-level development board based on ESP32-C3-WROOM-02,
+a general-purpose module with 4 MB SPI flash. This board integrates complete Wi-Fi and Bluetooth® Low Energy functions.
+For more information, check `ESP32-C3-DevKitC`_.
+
+Hardware
 ********
 
 ESP32-C3 is a single-core Wi-Fi and Bluetooth 5 (LE) microcontroller SoC,
@@ -11,7 +18,7 @@ based on the open-source RISC-V architecture. It strikes the right balance of po
 I/O capabilities and security, thus offering the optimal cost-effective
 solution for connected devices.
 The availability of Wi-Fi and Bluetooth 5 (LE) connectivity not only makes the device configuration easy,
-but it also facilitates a variety of use-cases based on dual connectivity. [1]_
+but it also facilitates a variety of use-cases based on dual connectivity.
 
 The features include the following:
 
@@ -32,10 +39,13 @@ The features include the following:
 
 - Cryptographic hardware acceleration (RNG, ECC, RSA, SHA-2, AES)
 
+For more information, check the datasheet at `ESP32-C3 Datasheet`_ or the technical reference
+manual at `ESP32-C3 Technical Reference Manual`_.
+
 Supported Features
 ==================
 
-Current Zephyr's ESP32-C3-Devkitc board supports the following features:
+Current Zephyr's ESP32-C3-DevKitC board supports the following features:
 
 +------------+------------+-------------------------------------+
 | Interface  | Controller | Driver/Component                    |
@@ -212,7 +222,7 @@ Debugging
 
 As with much custom hardware, the ESP32-C3 modules require patches to
 OpenOCD that are not upstreamed yet. Espressif maintains their own fork of
-the project. The custom OpenOCD can be obtained at `OpenOCD ESP32`_
+the project. The custom OpenOCD can be obtained at `OpenOCD ESP32`_.
 
 The Zephyr SDK uses a bundled version of OpenOCD by default. You can overwrite that behavior by adding the
 ``-DOPENOCD=<path/to/bin/openocd> -DOPENOCD_DEFAULT_PATH=<path/to/openocd/share/openocd/scripts>``
@@ -233,12 +243,10 @@ You can debug an application in the usual way. Here is an example for the :ref:`
    :board: esp32c3_devkitc
    :goals: debug
 
-.. _`OpenOCD ESP32`: https://github.com/espressif/openocd-esp32/releases
-
 References
 **********
 
-.. [1] https://www.espressif.com/en/products/socs/esp32-c3
-.. _ESP32C3 Devkitc User Guide: https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32c3/esp32-c3-devkitc-02
-.. _ESP32C3 Technical Reference Manual: https://espressif.com/sites/default/files/documentation/esp32-c3_technical_reference_manual_en.pdf
-.. _ESP32C3 Datasheet: https://www.espressif.com/sites/default/files/documentation/esp32-c3_datasheet_en.pdf
+.. _`ESP32-C3-DevKitC`: https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32c3/esp32-c3-devkitc-02/index.html
+.. _`ESP32-C3 Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32-c3_datasheet_en.pdf
+.. _`ESP32-C3 Technical Reference Manual`: https://espressif.com/sites/default/files/documentation/esp32-c3_technical_reference_manual_en.pdf
+.. _`OpenOCD ESP32`: https://github.com/espressif/openocd-esp32/releases

--- a/boards/espressif/esp32c3_devkitm/doc/index.rst
+++ b/boards/espressif/esp32c3_devkitm/doc/index.rst
@@ -1,9 +1,16 @@
 .. _esp32c3_devkitm:
 
-ESP32-C3
-########
+ESP32-C3-DevKitM
+################
 
 Overview
+********
+
+ESP32-C3-DevKitM is an entry-level development board based on ESP32-C3-MINI-1,
+a module named for its small size. This board integrates complete Wi-Fi and Bluetooth® Low Energy functions.
+For more information, check `ESP32-C3-DevKitM`_.
+
+Hardware
 ********
 
 ESP32-C3 is a single-core Wi-Fi and Bluetooth 5 (LE) microcontroller SoC,
@@ -11,7 +18,7 @@ based on the open-source RISC-V architecture. It strikes the right balance of po
 I/O capabilities and security, thus offering the optimal cost-effective
 solution for connected devices.
 The availability of Wi-Fi and Bluetooth 5 (LE) connectivity not only makes the device configuration easy,
-but it also facilitates a variety of use-cases based on dual connectivity. [1]_
+but it also facilitates a variety of use-cases based on dual connectivity.
 
 The features include the following:
 
@@ -31,6 +38,9 @@ The features include the following:
   - LED PWM with up to 6 channels
 
 - Cryptographic hardware acceleration (RNG, ECC, RSA, SHA-2, AES)
+
+For more information, check the datasheet at `ESP32-C3 Datasheet`_ or the technical reference
+manual at `ESP32-C3 Technical Reference Manual`_.
 
 Supported Features
 ==================
@@ -212,7 +222,7 @@ Debugging
 
 As with much custom hardware, the ESP32-C3 modules require patches to
 OpenOCD that are not upstreamed yet. Espressif maintains their own fork of
-the project. The custom OpenOCD can be obtained at `OpenOCD ESP32`_
+the project. The custom OpenOCD can be obtained at `OpenOCD ESP32`_.
 
 The Zephyr SDK uses a bundled version of OpenOCD by default. You can overwrite that behavior by adding the
 ``-DOPENOCD=<path/to/bin/openocd> -DOPENOCD_DEFAULT_PATH=<path/to/openocd/share/openocd/scripts>``
@@ -233,12 +243,10 @@ You can debug an application in the usual way. Here is an example for the :ref:`
    :board: esp32c3_devkitm
    :goals: debug
 
-.. _`OpenOCD ESP32`: https://github.com/espressif/openocd-esp32/releases
-
 References
 **********
 
-.. [1] https://www.espressif.com/en/products/socs/esp32-c3
-.. _ESP32C3 Devkitm User Guide: https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/hw-reference/esp32c3/user-guide-devkitm-1.html
-.. _ESP32C3 Technical Reference Manual: https://espressif.com/sites/default/files/documentation/esp32-c3_technical_reference_manual_en.pdf
-.. _ESP32C3 Datasheet: https://www.espressif.com/sites/default/files/documentation/esp32-c3_datasheet_en.pdf
+.. _`ESP32-C3-DevKitM`: https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/hw-reference/esp32c3/user-guide-devkitm-1.html
+.. _`ESP32-C3 Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32-c3_datasheet_en.pdf
+.. _`ESP32-C3 Technical Reference Manual`: https://espressif.com/sites/default/files/documentation/esp32-c3_technical_reference_manual_en.pdf
+.. _`OpenOCD ESP32`: https://github.com/espressif/openocd-esp32/releases

--- a/boards/espressif/esp32c3_rust/doc/index.rst
+++ b/boards/espressif/esp32c3_rust/doc/index.rst
@@ -1,12 +1,19 @@
 .. _esp32c3_rust:
 
-ESP32-C3-DevKit-RUST-1
-######################
+ESP32-C3-DevKit-RUST
+####################
 
 Overview
 ********
 
-This board is based on the ESP32-C3 [1]_ and includes sensors, LEDs, buttons, a battery charger, and USB type-C connector.
+ESP32-C3-DevKit-RUST is based on the ESP32-C3, a single-core Wi-Fi and Bluetooth 5 (LE) microcontroller SoC,
+based on the open-source RISC-V architecture. This special board also includes the ESP32-C3-MINI-1 module,
+a 6DoF IMU, a temperature and humidity sensor, a Li-Ion battery charger, and a Type-C USB. The board is designed
+to be easily used in training sessions, demonstrating its capabilities with all the board peripherals.
+For more information, check `ESP32-C3-DevKit-RUST`_.
+
+Hardware
+********
 
 SoC Features:
 
@@ -32,10 +39,13 @@ SoC Features:
 - 2 x 12-bit SAR ADCs, up to 6 channels
 - 1 x temperature sensor
 
+For more information, check the datasheet at `ESP32-C3 Datasheet`_ or the technical reference
+manual at `ESP32-C3 Technical Reference Manual`_.
+
 Supported Features
 ==================
 
-Current Zephyr's ESP32-C3-DevKit-RUST-1 board supports the following features:
+Current Zephyr's ESP32-C3-DevKit-RUST board supports the following features:
 
 +------------+------------+-------------------------------------+
 | Interface  | Controller | Driver/Component                    |
@@ -257,7 +267,7 @@ Debugging
 
 As with much custom hardware, the ESP32-C3 modules require patches to
 OpenOCD that are not upstreamed yet. Espressif maintains their own fork of
-the project. The custom OpenOCD can be obtained at `OpenOCD ESP32`_
+the project. The custom OpenOCD can be obtained at `OpenOCD ESP32`_.
 
 The Zephyr SDK uses a bundled version of OpenOCD by default. You can overwrite that behavior by adding the
 ``-DOPENOCD=<path/to/bin/openocd> -DOPENOCD_DEFAULT_PATH=<path/to/openocd/share/openocd/scripts>``
@@ -278,12 +288,10 @@ You can debug an application in the usual way. Here is an example for the :ref:`
    :board: esp32c3_rust
    :goals: debug
 
-.. _`OpenOCD ESP32`: https://github.com/espressif/openocd-esp32/releases
-
 References
 **********
 
-.. [1] https://www.espressif.com/en/products/socs/esp32-c3
-.. _ESP32-C3-DevKit-RUST-1: https://github.com/esp-rs/esp-rust-board/tree/v1.2
-.. _ESP32C3 Technical Reference Manual: https://espressif.com/sites/default/files/documentation/esp32-c3_technical_reference_manual_en.pdf
-.. _ESP32C3 Datasheet: https://www.espressif.com/sites/default/files/documentation/esp32-c3_datasheet_en.pdf
+.. _`ESP32-C3-DevKit-RUST`: https://github.com/esp-rs/esp-rust-board/tree/v1.2
+.. _`ESP32-C3 Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32-c3_datasheet_en.pdf
+.. _`ESP32-C3 Technical Reference Manual`: https://espressif.com/sites/default/files/documentation/esp32-c3_technical_reference_manual_en.pdf
+.. _`OpenOCD ESP32`: https://github.com/espressif/openocd-esp32/releases

--- a/boards/espressif/esp32c6_devkitc/doc/index.rst
+++ b/boards/espressif/esp32c6_devkitc/doc/index.rst
@@ -1,9 +1,16 @@
 .. _esp32c6_devkitc:
 
-ESP32-C6-DevKitC-1
-##################
+ESP32-C6-DevKitC
+################
 
 Overview
+********
+
+ESP32-C6-DevKitC is an entry-level development board based on ESP32-C6-WROOM-1(U),
+a general-purpose module with a 8 MB SPI flash. This board integrates complete Wi-Fi,
+Bluetooth LE, Zigbee, and Thread functions. For more information, check `ESP32-C6-DevKitC`_.
+
+Hardware
 ********
 
 ESP32-C6 is Espressif's first Wi-Fi 6 SoC integrating 2.4 GHz Wi-Fi 6, Bluetooth 5.3 (LE) and the
@@ -11,14 +18,14 @@ ESP32-C6 is Espressif's first Wi-Fi 6 SoC integrating 2.4 GHz Wi-Fi 6, Bluetooth
 features and multiple memory resources for IoT products.
 It consists of a high-performance (HP) 32-bit RISC-V processor, which can be clocked up to 160 MHz,
 and a low-power (LP) 32-bit RISC-V processor, which can be clocked up to 20 MHz.
-It has a 320KB ROM, a 512KB SRAM, and works with external flash. [1]_
+It has a 320KB ROM, a 512KB SRAM, and works with external flash.
 
-ESP32-C6-DevKitC-1 is an entry-level development board based on ESP32-C6-WROOM-1(U),
+ESP32-C6-DevKitC is an entry-level development board based on ESP32-C6-WROOM-1(U),
 a general-purpose module with a 8 MB SPI flash.
 
 Most of the I/O pins are broken out to the pin headers on both sides for easy interfacing.
-Developers can either connect peripherals with jumper wires or mount ESP32-C6-DevKitC-1 on
-a breadboard. [2]_
+Developers can either connect peripherals with jumper wires or mount ESP32-C6-DevKitC on
+a breadboard.
 
 ESP32-C6 includes the following features:
 
@@ -74,7 +81,8 @@ Security:
 - Cryptographic hardware acceleration: (AES-128/256, ECC, HMAC, RSA, SHA, Digital signature, Hash)
 - Random number generator (RNG)
 
-For more information, check the datasheet at `ESP32C6 Datasheet`_
+For more information, check the datasheet at `ESP32-C6 Datasheet`_ or the technical reference
+manual at `ESP32-C6 Technical Reference Manual`_.
 
 Supported Features
 ==================
@@ -248,7 +256,7 @@ Debugging
 
 As with much custom hardware, the ESP32-C6 modules require patches to
 OpenOCD that are not upstreamed yet. Espressif maintains their own fork of
-the project. The custom OpenOCD can be obtained at `OpenOCD ESP32`_
+the project. The custom OpenOCD can be obtained at `OpenOCD ESP32`_.
 
 The Zephyr SDK uses a bundled version of OpenOCD by default. You can overwrite that behavior by adding the
 ``-DOPENOCD=<path/to/bin/openocd> -DOPENOCD_DEFAULT_PATH=<path/to/openocd/share/openocd/scripts>``
@@ -269,13 +277,11 @@ You can debug an application in the usual way. Here is an example for the :ref:`
    :board: esp32c6_devkitc
    :goals: debug
 
-.. _`OpenOCD ESP32`: https://github.com/espressif/openocd-esp32/releases
 
 References
 **********
 
-.. [1] https://www.espressif.com/en/products/socs/esp32-c6
-.. [2] https://docs.espressif.com/projects/espressif-esp-dev-kits/en/latest/esp32c6/esp32-c6-devkitc-1/user_guide.html
-.. _ESP32C6 Devkitm User Guide: https://docs.espressif.com/projects/espressif-esp-dev-kits/en/latest/esp32c6/esp32-c6-devkitc-1/user_guide.html
-.. _ESP32C6 Technical Reference Manual: https://espressif.com/sites/default/files/documentation/esp32-c6_technical_reference_manual_en.pdf
-.. _ESP32C6 Datasheet: https://www.espressif.com/sites/default/files/documentation/esp32-c6_datasheet_en.pdf
+.. _`ESP32-C6-DevKitC`: https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32c6/esp32-c6-devkitc-1/user_guide.html
+.. _`ESP32-C6 Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32-c6_datasheet_en.pdf
+.. _`ESP32-C6 Technical Reference Manual`: https://espressif.com/sites/default/files/documentation/esp32-c6_technical_reference_manual_en.pdf
+.. _`OpenOCD ESP32`: https://github.com/espressif/openocd-esp32/releases

--- a/boards/espressif/esp32s2_devkitc/doc/index.rst
+++ b/boards/espressif/esp32s2_devkitc/doc/index.rst
@@ -1,13 +1,21 @@
 .. _esp32s2_devkitc:
 
-ESP32-S2
-########
+ESP32-S2-DevKitC
+################
 
 Overview
 ********
 
+ESP32-S2-DevKitC is an entry-level development board. This board integrates complete Wi-Fi functions.
+Most of the I/O pins are broken out to the pin headers on both sides for easy interfacing.
+Developers can either connect peripherals with jumper wires or mount ESP32-S2-DevKitC on a breadboard.
+For more information, check `ESP32-S2-DevKitC`_.
+
+Hardware
+********
+
 ESP32-S2 is a highly integrated, low-power, single-core Wi-Fi Microcontroller SoC, designed to be secure and
-cost-effective, with a high performance and a rich set of IO capabilities. [1]_
+cost-effective, with a high performance and a rich set of IO capabilities.
 
 The features include the following:
 
@@ -29,6 +37,9 @@ The features include the following:
   - ADC
   - DAC
   - LED PWM with up to 8 channels
+
+For more information, check the datasheet at `ESP32-S2 Datasheet`_ or the technical reference
+manual at `ESP32-S2 Technical Reference Manual`_.
 
 Supported Features
 ==================
@@ -206,8 +217,7 @@ message in the monitor:
 Debugging
 *********
 
-ESP32-S2 support on OpenOCD is available upstream as of version 0.12.0.
-Download and install OpenOCD from `OpenOCD`_.
+ESP32-S2 support on OpenOCD is available at `OpenOCD ESP32`_.
 
 The following table shows the pin mapping between ESP32-S2 board and JTAG interface.
 
@@ -239,14 +249,11 @@ You can debug an application in the usual way. Here is an example for the :ref:`
    :board: esp32s2_devkitc
    :goals: debug
 
-.. _`OpenOCD`: https://github.com/openocd-org/openocd
-.. _`JTAG debugging for ESP32-S2`: https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-guides/jtag-debugging/index.html
-
-
 References
 **********
 
-.. [1] https://www.espressif.com/en/products/socs/esp32-s2
-.. _ESP32-S2 DevKitC User Guide: https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-s2-devkitc-1.html
-.. _ESP32S2 Technical Reference Manual: https://espressif.com/sites/default/files/documentation/esp32-s2_technical_reference_manual_en.pdf
-.. _ESP32S2 Datasheet: https://www.espressif.com/sites/default/files/documentation/esp32-s2_datasheet_en.pdf
+.. _`ESP32-S3-DevKitC`: https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-saola-1-v1.2.html
+.. _`ESP32-S2 Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32-s2_datasheet_en.pdf
+.. _`ESP32-S2 Technical Reference Manual`: https://espressif.com/sites/default/files/documentation/esp32-s2_technical_reference_manual_en.pdf
+.. _`JTAG debugging for ESP32-S2`: https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-guides/jtag-debugging/index.html
+.. _`OpenOCD ESP32`: https://github.com/espressif/openocd-esp32/releases

--- a/boards/espressif/esp32s2_saola/doc/index.rst
+++ b/boards/espressif/esp32s2_saola/doc/index.rst
@@ -1,13 +1,21 @@
 .. _esp32s2_saola:
 
-ESP32-S2
-########
+ESP32-S2-Saola
+##############
 
 Overview
 ********
 
+ESP32-S2-Saola is a small-sized ESP32-S2 based development board produced by Espressif.
+Most of the I/O pins are broken out to the pin headers on both sides for easy interfacing.
+Developers can either connect peripherals with jumper wires or mount ESP32-S2-Saola on a breadboard.
+For more information, check `ESP32-S3-DevKitC`_.
+
+Hardware
+********
+
 ESP32-S2 is a highly integrated, low-power, single-core Wi-Fi Microcontroller SoC, designed to be secure and
-cost-effective, with a high performance and a rich set of IO capabilities. [1]_
+cost-effective, with a high performance and a rich set of IO capabilities.
 
 The features include the following:
 
@@ -30,10 +38,13 @@ The features include the following:
   - DAC
   - LED PWM with up to 8 channels
 
+For more information, check the datasheet at `ESP32-S2 Datasheet`_ or the technical reference
+manual at `ESP32-S2 Technical Reference Manual`_.
+
 Supported Features
 ==================
 
-Current Zephyr's ESP32-S2-saola board supports the following features:
+Current Zephyr's ESP32-S2-Saola board supports the following features:
 
 +------------+------------+-------------------------------------+
 | Interface  | Controller | Driver/Component                    |
@@ -206,8 +217,7 @@ message in the monitor:
 Debugging
 *********
 
-ESP32-S2 support on OpenOCD is available upstream as of version 0.12.0.
-Download and install OpenOCD from `OpenOCD`_.
+ESP32-S2 support on OpenOCD is available at `OpenOCD ESP32`_.
 
 The following table shows the pin mapping between ESP32-S2 board and JTAG interface.
 
@@ -239,14 +249,11 @@ You can debug an application in the usual way. Here is an example for the :ref:`
    :board: esp32s2_saola
    :goals: debug
 
-.. _`OpenOCD`: https://github.com/openocd-org/openocd
-.. _`JTAG debugging for ESP32-S2`: https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-guides/jtag-debugging/index.html
-
-
 References
 **********
 
-.. [1] https://www.espressif.com/en/products/socs/esp32-s2
-.. _ESP32-S2 Saola User Guide: https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-saola-1-v1.2.html
-.. _ESP32S2 Technical Reference Manual: https://espressif.com/sites/default/files/documentation/esp32-s2_technical_reference_manual_en.pdf
-.. _ESP32S2 Datasheet: https://www.espressif.com/sites/default/files/documentation/esp32-s2_datasheet_en.pdf
+.. _`ESP32-S3-DevKitC`: https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-saola-1-v1.2.html
+.. _`ESP32-S2 Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32-s2_datasheet_en.pdf
+.. _`ESP32-S2 Technical Reference Manual`: https://espressif.com/sites/default/files/documentation/esp32-s2_technical_reference_manual_en.pdf
+.. _`JTAG debugging for ESP32-S2`: https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-guides/jtag-debugging/index.html
+.. _`OpenOCD ESP32`: https://github.com/espressif/openocd-esp32/releases

--- a/boards/espressif/esp32s3_devkitc/doc/index.rst
+++ b/boards/espressif/esp32s3_devkitc/doc/index.rst
@@ -1,14 +1,14 @@
 .. _esp32s3_devkitc:
 
-ESP32S3-DevKitC
-###############
+ESP32-S3-DevKitC
+################
 
 Overview
 ********
 
 The ESP32-S3-DevKitC is an entry-level development board equipped with either ESP32-S3-WROOM-1
 or ESP32-S3-WROOM-1U, a module named for its small size. This board integrates complete Wi-Fi
-and Bluetooth Low Energy functions. For more information, check `ESP32-S3 DevKitC`_
+and Bluetooth Low Energy functions. For more information, check `ESP32-S3-DevKitC`_.
 
 Hardware
 ********
@@ -18,7 +18,7 @@ and Bluetooth® Low Energy (Bluetooth LE). It consists of high-performance dual-
 (Xtensa® 32-bit LX7), a low power coprocessor, a Wi-Fi baseband, a Bluetooth LE baseband,
 RF module, and numerous peripherals.
 
-ESP32-S3 DevKitC includes the following features:
+ESP32-S3-DevKitC includes the following features:
 
 - Dual core 32-bit Xtensa Microprocessor (Tensilica LX7), running up to 240MHz
 - Additional vector instructions support for AI acceleration
@@ -78,7 +78,8 @@ ESP32S3-DevKitC allows 2 different applications to be executed in ESP32-S3 SoC. 
 architecture, each core can be enabled to execute customized tasks in stand-alone mode
 and/or exchanging data over OpenAMP framework. See :ref:`ipc_samples` folder as code reference.
 
-For more information, check the datasheet at `ESP32-S3 Datasheet`_.
+For more information, check the datasheet at `ESP32-S3 Datasheet`_ or the technical reference
+manual at `ESP32-S3 Technical Reference Manual`_.
 
 Supported Features
 ==================
@@ -255,13 +256,11 @@ message in the monitor:
 Debugging
 *********
 
-ESP32-S3 support on OpenOCD is available upstream as of version 0.12.0.
-Download and install OpenOCD from `OpenOCD`_.
+ESP32-S3 support on OpenOCD is available at `OpenOCD ESP32`_.
 
 ESP32-S3 has a built-in JTAG circuitry and can be debugged without any additional chip. Only an USB cable connected to the D+/D- pins is necessary.
 
-Further documentation can be obtained from the SoC vendor in `JTAG debugging
-for ESP32-S3`_.
+Further documentation can be obtained from the SoC vendor in `JTAG debugging for ESP32-S3`_.
 
 Here is an example for building the :ref:`hello_world` application.
 
@@ -277,13 +276,11 @@ You can debug an application in the usual way. Here is an example for the :ref:`
    :board: esp32s3_devkitc/esp32s3/procpu
    :goals: debug
 
-.. _`JTAG debugging for ESP32-S3`: https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/api-guides/jtag-debugging/
-.. _`OpenOCD`: https://github.com/openocd-org/openocd
-.. _`ESP32-S3 DevKitC`: https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/user-guide-devkitc-1.html
-
 References
 **********
 
-.. _ESP32-S3 DevKitC User Guide: https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/user-guide-devkitc-1.html
-.. _ESP32-S3 Datasheet: https://www.espressif.com/sites/default/files/documentation/esp32-s3-wroom-1_wroom-1u_datasheet_en.pdf
-.. _ESP32 Technical Reference Manual: https://www.espressif.com/sites/default/files/documentation/esp32-s3_technical_reference_manual_en.pdf
+.. _`ESP32-S3-DevKitC`: https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/user-guide-devkitc-1.html
+.. _`ESP32-S3 Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32-s3-wroom-1_wroom-1u_datasheet_en.pdf
+.. _`ESP32-S3 Technical Reference Manual`: https://www.espressif.com/sites/default/files/documentation/esp32-s3_technical_reference_manual_en.pdf
+.. _`JTAG debugging for ESP32-S3`: https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/api-guides/jtag-debugging/
+.. _`OpenOCD ESP32`: https://github.com/espressif/openocd-esp32/releases

--- a/boards/espressif/esp32s3_devkitm/doc/index.rst
+++ b/boards/espressif/esp32s3_devkitm/doc/index.rst
@@ -1,14 +1,14 @@
 .. _esp32s3_devkitm:
 
-ESP32S3-DevKitM
-###############
+ESP32-S3-DevKitM
+################
 
 Overview
 ********
 
 The ESP32-S3-DevKitM is an entry-level development board equipped with either ESP32-S3-MINI-1
 or ESP32-S3-MINI-1U, a module named for its small size. This board integrates complete Wi-Fi
-and Bluetooth Low Energy functions. For more information, check `ESP32-S3 DevKitM`_
+and Bluetooth Low Energy functions. For more information, check `ESP32-S3-DevKitM User Guide`_.
 
 Hardware
 ********
@@ -18,7 +18,7 @@ and Bluetooth® Low Energy (Bluetooth LE). It consists of high-performance dual-
 (Xtensa® 32-bit LX7), a low power coprocessor, a Wi-Fi baseband, a Bluetooth LE baseband,
 RF module, and numerous peripherals.
 
-ESP32-S3 DevKitM includes the following features:
+ESP32-S3-DevKitM includes the following features:
 
 - Dual core 32-bit Xtensa Microprocessor (Tensilica LX7), running up to 240MHz
 - Additional vector instructions support for AI acceleration
@@ -78,7 +78,8 @@ ESP32S3-DevKitM allows 2 different applications to be executed in ESP32-S3 SoC. 
 architecture, each core can be enabled to execute customized tasks in stand-alone mode
 and/or exchanging data over OpenAMP framework. See :ref:`ipc_samples` folder as code reference.
 
-For more information, check the datasheet at `ESP32-S3 Datasheet`_.
+For more information, check the datasheet at `ESP32-S3 Datasheet`_ or the technical reference
+manual at `ESP32-S3 Technical Reference Manual`_.
 
 Supported Features
 ==================
@@ -255,13 +256,11 @@ message in the monitor:
 Debugging
 *********
 
-ESP32-S3 support on OpenOCD is available upstream as of version 0.12.0.
-Download and install OpenOCD from `OpenOCD`_.
+ESP32-S3 support on OpenOCD is available at `OpenOCD ESP32`_.
 
 ESP32-S3 has a built-in JTAG circuitry and can be debugged without any additional chip. Only an USB cable connected to the D+/D- pins is necessary.
 
-Further documentation can be obtained from the SoC vendor in `JTAG debugging
-for ESP32-S3`_.
+Further documentation can be obtained from the SoC vendor in `JTAG debugging for ESP32-S3`_.
 
 Here is an example for building the :ref:`hello_world` application.
 
@@ -277,13 +276,11 @@ You can debug an application in the usual way. Here is an example for the :ref:`
    :board: esp32s3_devkitm/esp32s3/procpu
    :goals: debug
 
-.. _`JTAG debugging for ESP32-S3`: https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/api-guides/jtag-debugging/
-.. _`OpenOCD`: https://github.com/openocd-org/openocd
-.. _`ESP32-S3 DevKitM`: https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/user-guide-devkitm-1.html
-
 References
 **********
 
-.. _ESP32-S3 DevKitM User Guide: https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/user-guide-devkitm-1.html
-.. _ESP32-S3 Datasheet: https://www.espressif.com/sites/default/files/documentation/esp32-s3-mini-1_mini-1u_datasheet_en.pdf
-.. _ESP32 Technical Reference Manual: https://www.espressif.com/sites/default/files/documentation/esp32-s3_technical_reference_manual_en.pdf
+.. _`ESP32-S3-DevKitM User Guide`: https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/user-guide-devkitm-1.html
+.. _`ESP32-S3 Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32-s3-mini-1_mini-1u_datasheet_en.pdf
+.. _`ESP32-S3 Technical Reference Manual`: https://www.espressif.com/sites/default/files/documentation/esp32-s3_technical_reference_manual_en.pdf
+.. _`OpenOCD ESP32`: https://github.com/espressif/openocd-esp32/releases
+.. _`JTAG debugging for ESP32-S3`: https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/api-guides/jtag-debugging/

--- a/boards/espressif/esp8684_devkitm/doc/index.rst
+++ b/boards/espressif/esp8684_devkitm/doc/index.rst
@@ -1,9 +1,16 @@
 .. _esp8684_devkitm:
 
-ESP32-C2
-########
+ESP8684-DevKitM
+###############
 
 Overview
+********
+
+The ESP8684-DevKitM is an entry-level development board based on ESP8684-MINI-1, a general-purpose
+module with 1 MB/2 MB/4 MB SPI flash. This board integrates complete Wi-Fi and Bluetooth LE functions.
+For more information, check `ESP8684-DevKitM User Guide`_
+
+Hardware
 ********
 
 ESP32-C2 (ESP8684 core) is a low-cost, Wi-Fi 4 & Bluetooth 5 (LE) chip. Its unique design
@@ -12,9 +19,9 @@ makes the chip smaller and yet more powerful than ESP8266. ESP32-C2 is built aro
 ESP32-C2 has been designed to target simple, high-volume, and low-data-rate IoT applications,
 such as smart plugs and smart light bulbs. ESP32-C2 offers easy and robust wireless connectivity,
 which makes it the go-to solution for developing simple, user-friendly and reliable
-smart-home devices [1]_.
+smart-home devices. For more information, check `ESP8684 Datasheet`_.
 
-Features include the following (`ESP8684 Datasheet`_):
+Features include the following:
 
 - 32-bit core RISC-V microcontroller with a maximum clock speed of 120 MHz
 - 2 MB or 4 MB in chip (ESP8684) or in package (ESP32-C2) flash
@@ -42,7 +49,7 @@ For detailed information check `ESP8684 Technical Reference Manual`_.
 Supported Features
 ==================
 
-Current Zephyr's ESP8684-Devkitm board supports the following features:
+Current Zephyr's ESP8684-DevKitM board supports the following features:
 
 +------------+------------+-------------------------------------+
 | Interface  | Controller | Driver/Component                    |
@@ -64,7 +71,7 @@ Current Zephyr's ESP8684-Devkitm board supports the following features:
 | LEDC       | on-chip    | pwm                                 |
 +------------+------------+-------------------------------------+
 
-For a getting started user guide, please check `ESP8684 Devkitm User Guide`_.
+For a getting started user guide, please check `ESP8684-DevKitM User Guide`_.
 
 System requirements
 *******************
@@ -207,7 +214,7 @@ Debugging
 
 As with much custom hardware, the ESP8684 modules require patches to
 OpenOCD that are not upstreamed yet. Espressif maintains their own fork of
-the project. The custom OpenOCD can be obtained at `OpenOCD ESP32`_
+the project. The custom OpenOCD can be obtained at `OpenOCD ESP32`_.
 
 The Zephyr SDK uses a bundled version of OpenOCD by default. You can overwrite that behavior by adding the
 ``-DOPENOCD=<path/to/bin/openocd> -DOPENOCD_DEFAULT_PATH=<path/to/openocd/share/openocd/scripts>``
@@ -228,12 +235,10 @@ You can debug an application in the usual way. Here is an example for the :ref:`
    :board: esp8684_devkitm
    :goals: debug
 
-.. _`OpenOCD ESP32`: https://github.com/espressif/openocd-esp32/releases
-
 References
 **********
 
-.. [1] https://www.espressif.com/en/products/socs/esp8684
-.. _ESP8684 Devkitm User Guide: https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp8684/esp8684-devkitm-1/user_guide.html
-.. _ESP8684 Technical Reference Manual: https://www.espressif.com/sites/default/files/documentation/esp8684_technical_reference_manual_en.pdf
-.. _ESP8684 Datasheet: https://www.espressif.com/sites/default/files/documentation/esp8684_datasheet_en.pdf
+.. _`ESP8684-DevKitM User Guide`: https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp8684/esp8684-devkitm-1/user_guide.html
+.. _`ESP8684 Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp8684_datasheet_en.pdf
+.. _`ESP8684 Technical Reference Manual`: https://www.espressif.com/sites/default/files/documentation/esp8684_technical_reference_manual_en.pdf
+.. _`OpenOCD ESP32`: https://github.com/espressif/openocd-esp32/releases

--- a/boards/espressif/esp_wrover_kit/doc/index.rst
+++ b/boards/espressif/esp_wrover_kit/doc/index.rst
@@ -26,6 +26,8 @@ Most of the ESP32 I/O pins are broken out to the board's pin headers for easy ac
    ESP32's GPIO16 and GPIO17 are used as chip select and clock signals for PSRAM. By default, the two
    GPIOs are not broken out to the board's pin headers in order to ensure reliable performance.
 
+For more information, check `ESP32-WROVER-E Datasheet`_ and `ESP32 Datasheet`_.
+
 Functionality Overview
 **********************
 
@@ -56,7 +58,7 @@ of the ESP-WROVER-KIT board.
      ESP-WROVER-KIT board layout - back
 
 The table below provides description in the following manner:
-- Starting from the first picture’s top right corner and going clockwise
+- Starting from the first picture's top right corner and going clockwise
 - Then moving on to the second picture
 
 +------------------+-------------------------------------------------------------------------+
@@ -253,7 +255,7 @@ Legend:
   - LED - RGB LED
   - MicroSD - MicroSD Card / J4
   - LCD - LCD / U5
-  - PSRAM - ESP32-WROVER-E’s PSRAM
+  - PSRAM - ESP32-WROVER-E's PSRAM
 
 32.768 kHz Oscillator
 *********************
@@ -293,10 +295,10 @@ SPI Flash / JP2
 +---+--------------+
 
 .. important::
-   The module’s flash bus is connected to the jumper block JP2 through zero-ohm resistors R140 ~
+   The module's flash bus is connected to the jumper block JP2 through zero-ohm resistors R140 ~
    R145. If the flash memory needs to operate at the frequency of 80 MHz, for reasons such as
    improving the integrity of bus signals, you can desolder these resistors to disconnect the
-   module’s flash bus from the pin header JP2.
+   module's flash bus from the pin header JP2.
 
 JTAG / JP2
 **********
@@ -621,8 +623,7 @@ message in the monitor:
 Debugging
 *********
 
-ESP32 support on OpenOCD is available upstream as of version 0.12.0.
-Download and install OpenOCD from `OpenOCD`_.
+ESP32 support on OpenOCD is available at `OpenOCD ESP32`_.
 
 On the ESP-WROVER-KIT board, the JTAG pins are connected internally to
 a USB serial port on the same device as the console.  These boards
@@ -648,14 +649,10 @@ You can debug an application in the usual way. Here is an example for the :ref:`
    :board: esp_wrover_kit/esp32/procpu
    :goals: debug
 
-.. _`OpenOCD`: https://github.com/openocd-org/openocd
+References
+**********
+
+.. _`ESP32 Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf (PDF)
+.. _`ESP32-WROVER-E Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32-wrover-e_esp32-wrover-ie_datasheet_en.pdf (PDF)
+.. _`OpenOCD ESP32`: https://github.com/espressif/openocd-esp32/releases
 .. _`ESP-WROVER-32 V3 Getting Started Guide`: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/get-started-wrover-kit.html
-
-Related Documents
-*****************
-
-.. _ESP-WROVER-KIT V4.1 schematics: https://dl.espressif.com/dl/schematics/ESP-WROVER-KIT_V4_1.pdf (PDF)
-.. _ESP-WROVER-KIT V4.1 layout: https://dl.espressif.com/dl/schematics/ESP-WROVER-KIT_V4.1.dxf (DXF)
-.. _ESP32 Datasheet: https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf (PDF)
-.. _ESP32-WROVER-E Datasheet: https://www.espressif.com/sites/default/files/documentation/esp32-wrover-e_esp32-wrover-ie_datasheet_en.pdf (PDF)
-.. _ESP32 Hardware Reference: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/index.html

--- a/boards/hardkernel/odroid_go/doc/index.rst
+++ b/boards/hardkernel/odroid_go/doc/index.rst
@@ -98,12 +98,15 @@ below to retrieve those files.
 Building & Flashing
 *******************
 
-ESP-IDF bootloader
-==================
+Simple boot
+===========
 
-The board is using the ESP-IDF bootloader as the default 2nd stage bootloader.
-It is build as a subproject at each application build. No further attention
-is expected from the user.
+The board could be loaded using the single binary image, without 2nd stage bootloader.
+It is the default option when building the application without additional configuration.
+
+.. note::
+
+   Simple boot does not provide any security features nor OTA updates.
 
 MCUboot bootloader
 ==================
@@ -216,7 +219,7 @@ Debugging
 
 As with much custom hardware, the ESP32 modules require patches to
 OpenOCD that are not upstreamed yet. Espressif maintains their own fork of
-the project. The custom OpenOCD can be obtained at `OpenOCD ESP32`_
+the project. The custom OpenOCD can be obtained at `OpenOCD ESP32`_.
 
 The Zephyr SDK uses a bundled version of OpenOCD by default. You can overwrite that behavior by adding the
 ``-DOPENOCD=<path/to/bin/openocd> -DOPENOCD_DEFAULT_PATH=<path/to/openocd/share/openocd/scripts>``

--- a/boards/heltec/heltec_wifi_lora32_v2/doc/index.rst
+++ b/boards/heltec/heltec_wifi_lora32_v2/doc/index.rst
@@ -163,7 +163,7 @@ Debugging
 
 As with much custom hardware, the ESP32 modules require patches to
 OpenOCD that are not upstreamed yet. Espressif maintains their own fork of
-the project. The custom OpenOCD can be obtained at `OpenOCD ESP32`_
+the project. The custom OpenOCD can be obtained at `OpenOCD ESP32`_.
 
 The Zephyr SDK uses a bundled version of OpenOCD by default. You can overwrite that behavior by adding the
 ``-DOPENOCD=<path/to/bin/openocd> -DOPENOCD_DEFAULT_PATH=<path/to/openocd/share/openocd/scripts>``

--- a/boards/heltec/heltec_wireless_stick_lite_v3/doc/index.rst
+++ b/boards/heltec/heltec_wireless_stick_lite_v3/doc/index.rst
@@ -277,7 +277,7 @@ Debugging
 
 As with much custom hardware, the ESP32S3 modules require patches to
 OpenOCD that are not upstreamed yet. Espressif maintains their own fork of
-the project. The custom OpenOCD can be obtained at `OpenOCD ESP32`_
+the project. The custom OpenOCD can be obtained at `OpenOCD ESP32`_.
 
 The Zephyr SDK uses a bundled version of OpenOCD by default. You can overwrite that behavior by adding the
 ``-DOPENOCD=<path/to/bin/openocd> -DOPENOCD_DEFAULT_PATH=<path/to/openocd/share/openocd/scripts>``

--- a/boards/luatos/esp32c3_luatos_core/doc/index.rst
+++ b/boards/luatos/esp32c3_luatos_core/doc/index.rst
@@ -230,7 +230,7 @@ Debugging
 
 As with much custom hardware, the ESP32-C3 modules require patches to
 OpenOCD that are not upstreamed yet. Espressif maintains their own fork of
-the project. The custom OpenOCD can be obtained at `OpenOCD ESP32`_
+the project. The custom OpenOCD can be obtained at `OpenOCD ESP32`_.
 
 The Zephyr SDK uses a bundled version of OpenOCD by default. You can overwrite that behavior by adding the
 ``-DOPENOCD=<path/to/bin/openocd> -DOPENOCD_DEFAULT_PATH=<path/to/openocd/share/openocd/scripts>``

--- a/boards/luatos/esp32s3_luatos_core/doc/index.rst
+++ b/boards/luatos/esp32s3_luatos_core/doc/index.rst
@@ -6,9 +6,9 @@ ESP32S3-Luatos-Core
 Overview
 ********
 
-The ESP32S3-LUATOS-CORE development board is a compact board based on Espressif ESP32-S3.
+The ESP32S3-Luatos-Core development board is a compact board based on Espressif ESP32-S3.
 The board comes equipped with a 2.4GHz antenna and supports both Wi-Fi and Bluetooth functionalities.
-For more information, check `ESP32S3-LUATOS-CORE`_ (chinese)
+For more information, check `ESP32S3-Luatos-Core`_ (chinese)
 
 .. image:: img/esp32s3_luatos_core.jpg
      :align: center
@@ -22,7 +22,7 @@ and Bluetooth® Low Energy (Bluetooth LE). It consists of high-performance dual-
 (Xtensa® 32-bit LX7), a low power coprocessor, a Wi-Fi baseband, a Bluetooth LE baseband,
 RF module, and numerous peripherals.
 
-ESP32S3-LUATOS-CORE includes the following features:
+ESP32S3-Luatos-Core includes the following features:
 
 - Dual core 32-bit Xtensa Microprocessor (Tensilica LX7), running up to 240MHz
 - Additional vector instructions support for AI acceleration
@@ -75,7 +75,8 @@ Security:
 - 4-Kbit OTP, up to 1792 bits for users
 - Cryptographic hardware acceleration: (AES-128/256, Hash, RSA, RNG, HMAC, Digital signature)
 
-For more information, check the datasheet at `ESP32-S3 Datasheet`_.
+For more information, check the datasheet at `ESP32-S3 Datasheet`_ or the technical reference
+manual at `ESP32-S3 Technical Reference Manual`_.
 
 .. image:: img/esp32s3_luatos_core_pinout.jpg
      :align: center
@@ -84,7 +85,7 @@ For more information, check the datasheet at `ESP32-S3 Datasheet`_.
 Supported Features
 ==================
 
-Current Zephyr's ESP32S3-LUATOS-Core board supports the following features:
+Current Zephyr's ESP32S3-Luatos-Core board supports the following features:
 
 +------------+------------+-------------------------------------+
 | Interface  | Controller | Driver/Component                    |
@@ -261,13 +262,11 @@ message in the monitor:
 Debugging
 *********
 
-ESP32-S3 support on OpenOCD is available upstream as of version 0.12.0.
-Download and install OpenOCD from `OpenOCD`_.
+ESP32-S3 support on OpenOCD is available at `OpenOCD ESP32`_.
 
 ESP32-S3 has a built-in JTAG circuitry and can be debugged without any additional chip. Only an USB cable connected to the D+/D- pins is necessary.
 
-Further documentation can be obtained from the SoC vendor in `JTAG debugging
-for ESP32-S3`_.
+Further documentation can be obtained from the SoC vendor in `JTAG debugging for ESP32-S3`_.
 
 Here is an example for building the :ref:`hello_world` application.
 
@@ -283,13 +282,12 @@ You can debug an application in the usual way. Here is an example for the :ref:`
    :board: esp32s3_luatos_core/esp32s3/procpu
    :goals: debug
 
-.. _`JTAG debugging for ESP32-S3`: https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/api-guides/jtag-debugging/
-.. _`OpenOCD`: https://github.com/openocd-org/openocd
-.. _`ESP32S3-LUATOS-CORE`: https://wiki.luatos.com/chips/esp32s3/board.html
 
 References
 **********
 
-.. _ESP32S3-LUATOS-CORE User Guide: https://wiki.luatos.com/chips/esp32s3/board.html
-.. _ESP32-S3 Datasheet: https://www.espressif.com/sites/default/files/documentation/esp32-s3-mini-1_mini-1u_datasheet_en.pdf
-.. _ESP32 Technical Reference Manual: https://www.espressif.com/sites/default/files/documentation/esp32-s3_technical_reference_manual_en.pdf
+.. _`ESP32S3-Luatos-Core`: https://wiki.luatos.com/chips/esp32s3/board.html
+.. _`ESP32-S3 Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32-s3-mini-1_mini-1u_datasheet_en.pdf
+.. _`ESP32-S3 Technical Reference Manual`: https://www.espressif.com/sites/default/files/documentation/esp32-s3_technical_reference_manual_en.pdf
+.. _`JTAG debugging for ESP32-S3`: https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/api-guides/jtag-debugging/
+.. _`OpenOCD ESP32`: https://github.com/espressif/openocd-esp32/releases

--- a/boards/m5stack/m5stickc_plus/doc/index.rst
+++ b/boards/m5stack/m5stickc_plus/doc/index.rst
@@ -87,12 +87,15 @@ below to retrieve those files.
 Building & Flashing
 *******************
 
-ESP-IDF bootloader
-==================
+Simple boot
+===========
 
-The board is using the ESP-IDF bootloader as the default 2nd stage bootloader.
-It is build as a subproject at each application build. No further attention
-is expected from the user.
+The board could be loaded using the single binary image, without 2nd stage bootloader.
+It is the default option when building the application without additional configuration.
+
+.. note::
+
+   Simple boot does not provide any security features nor OTA updates.
 
 MCUboot bootloader
 ==================

--- a/boards/m5stack/stamp_c3/doc/index.rst
+++ b/boards/m5stack/stamp_c3/doc/index.rst
@@ -56,12 +56,15 @@ below to retrieve those files.
 Building & Flashing
 *******************
 
-ESP-IDF bootloader
-==================
+Simple boot
+===========
 
-The board is using the ESP-IDF bootloader as the default 2nd stage bootloader.
-It is build as a subproject at each application build. No further attention
-is expected from the user.
+The board could be loaded using the single binary image, without 2nd stage bootloader.
+It is the default option when building the application without additional configuration.
+
+.. note::
+
+   Simple boot does not provide any security features nor OTA updates.
 
 MCUboot bootloader
 ==================
@@ -174,7 +177,7 @@ Debugging
 
 As with much custom hardware, the ESP32 modules require patches to
 OpenOCD that are not upstreamed yet. Espressif maintains their own fork of
-the project. The custom OpenOCD can be obtained at `OpenOCD ESP32`_
+the project. The custom OpenOCD can be obtained at `OpenOCD ESP32`_.
 
 The Zephyr SDK uses a bundled version of OpenOCD by default. You can overwrite that behavior by adding the
 ``-DOPENOCD=<path/to/bin/openocd> -DOPENOCD_DEFAULT_PATH=<path/to/openocd/share/openocd/scripts>``

--- a/boards/olimex/olimex_esp32_evb/doc/index.rst
+++ b/boards/olimex/olimex_esp32_evb/doc/index.rst
@@ -232,7 +232,7 @@ Debugging
 
 As with much custom hardware, the ESP32 modules require patches to
 OpenOCD that are not upstreamed yet. Espressif maintains their own fork of
-the project. The custom OpenOCD can be obtained at `OpenOCD ESP32`_
+the project. The custom OpenOCD can be obtained at `OpenOCD ESP32`_.
 
 The Zephyr SDK uses a bundled version of OpenOCD by default. You can overwrite that behavior by adding the
 ``-DOPENOCD=<path/to/bin/openocd> -DOPENOCD_DEFAULT_PATH=<path/to/openocd/share/openocd/scripts>``

--- a/boards/seeed/xiao_esp32c3/doc/index.rst
+++ b/boards/seeed/xiao_esp32c3/doc/index.rst
@@ -192,7 +192,7 @@ Debugging
 
 As with much custom hardware, the ESP32 modules require patches to
 OpenOCD that are not upstreamed yet. Espressif maintains their own fork of
-the project. The custom OpenOCD can be obtained at `OpenOCD ESP32`_
+the project. The custom OpenOCD can be obtained at `OpenOCD ESP32`_.
 
 The Zephyr SDK uses a bundled version of OpenOCD by default. You can overwrite that behavior by adding the
 ``-DOPENOCD=<path/to/bin/openocd> -DOPENOCD_DEFAULT_PATH=<path/to/openocd/share/openocd/scripts>``

--- a/boards/seeed/xiao_esp32s3/doc/index.rst
+++ b/boards/seeed/xiao_esp32s3/doc/index.rst
@@ -214,13 +214,11 @@ message in the monitor:
 Debugging
 *********
 
-ESP32-S3 support on OpenOCD is available upstream as of version 0.12.0.
-Download and install OpenOCD from `OpenOCD`_.
+ESP32-S3 support on OpenOCD is available at `OpenOCD ESP32`_.
 
 ESP32-S3 has a built-in JTAG circuitry and can be debugged without any additional chip. Only an USB cable connected to the D+/D- pins is necessary.
 
-Further documentation can be obtained from the SoC vendor in `JTAG debugging
-for ESP32-S3`_.
+Further documentation can be obtained from the SoC vendor in `JTAG debugging for ESP32-S3`_.
 
 Here is an example for building the :ref:`hello_world` application.
 
@@ -235,12 +233,10 @@ You can debug an application in the usual way. Here is an example for the :ref:`
    :zephyr-app: samples/hello_world
    :board: xiao_esp32s3/esp32/procpu
    :goals: debug
-.. _`JTAG debugging for ESP32-S3`: https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/api-guides/jtag-debugging/
-.. _`OpenOCD`: https://github.com/openocd-org/openocd
 
 References
 **********
 
-.. target-notes::
-
 .. _`Seeed Studio XIAO ESP32S3`: https://wiki.seeedstudio.com/xiao_esp32s3_getting_started/
+.. _`JTAG debugging for ESP32-S3`: https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/api-guides/jtag-debugging/
+.. _`OpenOCD ESP32`: https://github.com/espressif/openocd-esp32/releases

--- a/boards/vcc-gnd/yd_esp32/doc/index.rst
+++ b/boards/vcc-gnd/yd_esp32/doc/index.rst
@@ -6,7 +6,7 @@ YD-ESP32
 Overview
 ********
 
-The YD-ESP32 development board is one of VCC-GND® Studio’s official boards.
+The YD-ESP32 development board is one of VCC-GND® Studio's official boards.
 This board is based on the ESP32-WROOM-32E module, with the ESP32 as the core.
 
 .. figure:: img/yd_esp32.png
@@ -23,7 +23,7 @@ with integrated Wi-Fi & dual-mode Bluetooth.  The ESP32 series employs a
 Tensilica Xtensa LX6 microprocessor in both dual-core and single-core
 variations.  ESP32 is created and developed by Espressif Systems, a
 Shanghai-based Chinese company, and is manufactured by TSMC using their 40nm
-process. [1]_
+process.
 
 The features include the following:
 
@@ -52,6 +52,9 @@ The features include the following:
 
 - Cryptographic hardware acceleration (RNG, ECC, RSA, SHA-2, AES)
 - 5uA deep sleep current
+
+For more information, check the datasheet at `ESP32 Datasheet`_ or the technical reference
+manual at `ESP32 Technical Reference Manual`_.
 
 Supported Features
 ==================
@@ -249,8 +252,7 @@ Here is an example of how to test it using the :zephyr:code-sample:`led-strip` a
 Debugging
 *********
 
-ESP32 support on OpenOCD is available upstream as of version 0.12.0.
-Download and install OpenOCD from `OpenOCD`_.
+ESP32 support on OpenOCD is available at `OpenOCD ESP32`_.
 
 On the YD-ESP32 board, the JTAG pins are not run to a
 standard connector (e.g. ARM 20-pin) and need to be manually connected
@@ -274,8 +276,7 @@ to the external programmer (e.g. a Flyswatter2):
 | IO15       | TDO       |
 +------------+-----------+
 
-Further documentation can be obtained from the SoC vendor in `JTAG debugging
-for ESP32`_.
+Further documentation can be obtained from the SoC vendor in `JTAG debugging for ESP32`_.
 
 Here is an example for building the :ref:`hello_world` application.
 
@@ -302,12 +303,11 @@ GDB stub is enabled on ESP32.
   This does not work as the code is on flash which cannot be randomly
   accessed for modification.
 
-.. _`JTAG debugging for ESP32`: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/jtag-debugging/index.html
-.. _`OpenOCD`: https://github.com/openocd-org/openocd
-
 References
 **********
 
-.. [1] https://en.wikipedia.org/wiki/ESP32
-.. _ESP32 Technical Reference Manual: https://espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf
-.. _Hardware Reference: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/index.html
+.. _`ESP32-DevKitC-WROVER`: https://docs.espressif.com/projects/esp-idf/en/stable/esp32/hw-reference/esp32/get-started-devkitc.html#
+.. _`ESP32 Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf
+.. _`ESP32 Technical Reference Manual`: https://espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf
+.. _`JTAG debugging for ESP32`: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/jtag-debugging/index.html
+.. _`OpenOCD ESP32`: https://github.com/espressif/openocd-esp32/releases

--- a/boards/waveshare/esp32s3_touch_lcd_1_28/doc/index.rst
+++ b/boards/waveshare/esp32s3_touch_lcd_1_28/doc/index.rst
@@ -54,7 +54,8 @@ ESP32-S3 allows 2 different applications to be executed in ESP32-S3 SoC. Due to 
 architecture, each core can be enabled to execute customized tasks in stand-alone mode
 and/or exchanging data over OpenAMP framework. See :ref:`ipc_samples` folder as code reference.
 
-For more information, check the datasheet at `ESP32-S3 Datasheet`_.
+For more information, check the datasheet at `ESP32-S3 Datasheet`_ or the technical reference
+manual at `ESP32-S3 Technical Reference Manual`_.
 
 Supported Features
 ==================
@@ -108,16 +109,19 @@ below to retrieve those files.
 Building & Flashing
 *******************
 
-ESP-IDF bootloader
-==================
+Simple boot
+===========
 
-The board is using the ESP-IDF bootloader as the default 2nd stage bootloader.
-It is build as a subproject at each application build. No further attention
-is expected from the user.
+The board could be loaded using the single binary image, without 2nd stage bootloader.
+It is the default option when building the application without additional configuration.
+
+.. note::
+
+   Simple boot does not provide any security features nor OTA updates.
 
 References
 **********
 
 .. _ESP32-S3-Touch-LCD-1.28 Waveshare Wiki: https://www.waveshare.com/wiki/ESP32-S3-Touch-LCD-1.28
 .. _ESP32-S3 Datasheet: https://www.espressif.com/sites/default/files/documentation/esp32-s3-mini-1_mini-1u_datasheet_en.pdf
-.. _ESP32 Technical Reference Manual: https://www.espressif.com/sites/default/files/documentation/esp32-s3_technical_reference_manual_en.pdf
+.. _ESP32-S3 Technical Reference Manual: https://www.espressif.com/sites/default/files/documentation/esp32-s3_technical_reference_manual_en.pdf


### PR DESCRIPTION
This PR updates all Espressif board names to meet its
original value. It also update reference links, re-organize
entries and removes unused content.

This also fixes bootloader information regarding a few boards.
IDF Bootloader was removed and these boards kept that info.
This updated it accordingly with the Simpleboot Bootloader.

Fixes #78150