### PR TITLE
Allow NULL host parameter when defining HTTP service

### DIFF
--- a/include/zephyr/net/http/service.h
+++ b/include/zephyr/net/http/service.h
@@ -101,8 +101,9 @@ struct http_service_desc {
 /**
  * @brief Define an HTTP service without static resources.
  *
- * @note The @p _host parameter must be non-`NULL`. It is used to specify an IP address either in
- * IPv4 or IPv6 format a fully-qualified hostname or a virtual host.
+ * @note The @p _host parameter is used to specify an IP address either in
+ * IPv4 or IPv6 format a fully-qualified hostname or a virtual host. If left NULL, the listening
+ * port will listen on all addresses.
  *
  * @note The @p _port parameter must be non-`NULL`. It points to a location that specifies the port
  * number to use for the service. If the specified port number is zero, then an ephemeral port
@@ -122,8 +123,9 @@ struct http_service_desc {
 /**
  * @brief Define an HTTPS service without static resources.
  *
- * @note The @p _host parameter must be non-`NULL`. It is used to specify an IP address either in
- * IPv4 or IPv6 format a fully-qualified hostname or a virtual host.
+ * @note The @p _host parameter is used to specify an IP address either in
+ * IPv4 or IPv6 format a fully-qualified hostname or a virtual host. If left NULL, the listening
+ * port will listen on all addresses.
  *
  * @note The @p _port parameter must be non-`NULL`. It points to a location that specifies the port
  * number to use for the service. If the specified port number is zero, then an ephemeral port
@@ -149,8 +151,9 @@ struct http_service_desc {
 /**
  * @brief Define an HTTP service with static resources.
  *
- * @note The @p _host parameter must be non-`NULL`. It is used to specify an IP address either in
- * IPv4 or IPv6 format a fully-qualified hostname or a virtual host.
+ * @note The @p _host parameter is used to specify an IP address either in
+ * IPv4 or IPv6 format a fully-qualified hostname or a virtual host. If left NULL, the listening
+ * port will listen on all addresses.
  *
  * @note The @p _port parameter must be non-`NULL`. It points to a location that specifies the port
  * number to use for the service. If the specified port number is zero, then an ephemeral port
@@ -174,8 +177,9 @@ struct http_service_desc {
 /**
  * @brief Define an HTTPS service with static resources.
  *
- * @note The @p _host parameter must be non-`NULL`. It is used to specify an IP address either in
- * IPv4 or IPv6 format a fully-qualified hostname or a virtual host.
+ * @note The @p _host parameter is used to specify an IP address either in
+ * IPv4 or IPv6 format a fully-qualified hostname or a virtual host. If left NULL, the listening
+ * port will listen on all addresses.
  *
  * @note The @p _port parameter must be non-`NULL`. It points to a location that specifies the port
  * number to use for the service. If the specified port number is zero, then an ephemeral port

--- a/samples/net/sockets/http_server/src/main.c
+++ b/samples/net/sockets/http_server/src/main.c
@@ -265,7 +265,7 @@ struct http_resource_detail_websocket ws_netstats_resource_detail = {
 
 #if defined(CONFIG_NET_SAMPLE_HTTP_SERVICE)
 static uint16_t test_http_service_port = CONFIG_NET_SAMPLE_HTTP_SERVER_SERVICE_PORT;
-HTTP_SERVICE_DEFINE(test_http_service, CONFIG_NET_CONFIG_MY_IPV4_ADDR, &test_http_service_port, 1,
+HTTP_SERVICE_DEFINE(test_http_service, NULL, &test_http_service_port, 1,
 		    10, NULL);
 
 HTTP_RESOURCE_DEFINE(index_html_gz_resource, test_http_service, "/",
@@ -298,7 +298,7 @@ static const sec_tag_t sec_tag_list_verify_none[] = {
 	};
 
 static uint16_t test_https_service_port = CONFIG_NET_SAMPLE_HTTPS_SERVER_SERVICE_PORT;
-HTTPS_SERVICE_DEFINE(test_https_service, CONFIG_NET_CONFIG_MY_IPV4_ADDR,
+HTTPS_SERVICE_DEFINE(test_https_service, NULL,
 		     &test_https_service_port, 1, 10, NULL,
 		     sec_tag_list_verify_none, sizeof(sec_tag_list_verify_none));
 

--- a/subsys/net/lib/http/http_server_core.c
+++ b/subsys/net/lib/http/http_server_core.c
@@ -108,14 +108,14 @@ int http_server_init(struct http_server_ctx *ctx)
 		memset(&addr_storage, 0, sizeof(struct sockaddr_storage));
 
 		/* Set up the server address struct according to address family */
-		if (IS_ENABLED(CONFIG_NET_IPV6) &&
+		if (IS_ENABLED(CONFIG_NET_IPV6) && svc->host != NULL &&
 		    zsock_inet_pton(AF_INET6, svc->host, &addr.addr6->sin6_addr) == 1) {
 			af = AF_INET6;
 			len = sizeof(*addr.addr6);
 
 			addr.addr6->sin6_family = AF_INET6;
 			addr.addr6->sin6_port = htons(*svc->port);
-		} else if (IS_ENABLED(CONFIG_NET_IPV4) &&
+		} else if (IS_ENABLED(CONFIG_NET_IPV4) && svc->host != NULL &&
 			   zsock_inet_pton(AF_INET, svc->host, &addr.addr4->sin_addr) == 1) {
 			af = AF_INET;
 			len = sizeof(*addr.addr4);
@@ -209,7 +209,8 @@ int http_server_init(struct http_server_ctx *ctx)
 			continue;
 		}
 
-		LOG_DBG("Initialized HTTP Service %s:%u", svc->host, *svc->port);
+		LOG_DBG("Initialized HTTP Service %s:%u",
+			svc->host ? svc->host : "<any>", *svc->port);
 
 		ctx->fds[count].fd = fd;
 		ctx->fds[count].events = ZSOCK_POLLIN;

--- a/subsys/net/lib/http/http_server_core.c
+++ b/subsys/net/lib/http/http_server_core.c
@@ -157,6 +157,16 @@ int http_server_init(struct http_server_ctx *ctx)
 			continue;
 		}
 
+		/* If IPv4-to-IPv6 mapping is enabled, then turn off V6ONLY option
+		 * so that IPv6 socket can serve IPv4 connections.
+		 */
+		if (IS_ENABLED(CONFIG_NET_IPV4_MAPPING_TO_IPV6)) {
+			int optval = 0;
+
+			(void)setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY,
+					 &optval, sizeof(optval));
+		}
+
 #if defined(CONFIG_NET_SOCKETS_SOCKOPT_TLS)
 		if (svc->sec_tag_list != NULL) {
 			if (zsock_setsockopt(fd, SOL_TLS, TLS_SEC_TAG_LIST,


### PR DESCRIPTION
Allow NULL host parameter when creating HTTP service. This means that the listening socket is created without specifying binding address.
