### PR TITLE
bluetooth: kconfig: Add channel sounding kconfigs

### DIFF
--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -94,6 +94,13 @@ config BT_OBSERVER
 	help
 	  Select this for LE Observer role support.
 
+config BT_CHANNEL_SOUNDING_TEST
+	bool "Channel Sounding Test support"
+	select EXPERIMENTAL
+	depends on !BT_CTLR || BT_CTLR_CHANNEL_SOUNDING_SUPPORT
+	help
+	  Enable support for Bluetooth 6.0 Channel Sounding Test feature.
+
 rsource "Kconfig.adv"
 
 config BT_CONN
@@ -188,6 +195,13 @@ config BT_SUBRATING
 	help
 	  Enable support for LE Connection Subrating feature that is defined in the
 	  Bluetooth Core specification, Version 5.4 | Vol 6, Part B, Section 4.6.35.
+
+config BT_CHANNEL_SOUNDING
+	bool "Channel Sounding support"
+	select EXPERIMENTAL
+	depends on !BT_CTLR || BT_CTLR_CHANNEL_SOUNDING_SUPPORT
+	help
+	  Enable support for Bluetooth 6.0 Channel Sounding feature.
 
 endif # BT_CONN
 

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -114,6 +114,9 @@ config BT_CTLR_LE_PATH_LOSS_MONITORING_SUPPORT
 config BT_CTLR_SUBRATING_SUPPORT
 	bool
 
+config BT_CTLR_CHANNEL_SOUNDING_SUPPORT
+	bool
+
 config BT_CTLR
 	bool "Bluetooth Controller"
 	help
@@ -1037,6 +1040,23 @@ config BT_CTLR_SUBRATING
 	help
 	  Enable support for Bluetooth v5.3 LE Connection Subrating
 	  in the Controller.
+
+config BT_CTLR_CHANNEL_SOUNDING_TEST
+	bool "Channel Sounding Test support"
+	depends on BT_CTLR_CHANNEL_SOUNDING_SUPPORT
+	default y if BT_CHANNEL_SOUNDING_TEST
+	help
+	  Enable support for Bluetooth 6.0 Channel Sounding Test in
+	  the Controller.
+
+config BT_CTLR_CHANNEL_SOUNDING
+	bool "Channel Sounding support"
+	depends on BT_CTLR_CHANNEL_SOUNDING_SUPPORT
+	select BT_CTLR_SET_HOST_FEATURE
+	default y if BT_CHANNEL_SOUNDING
+	help
+	  Enable support for Bluetooth 6.0 Channel Sounding in the
+	  Controller.
 
 rsource "Kconfig.df"
 rsource "Kconfig.ll_sw_split"


### PR DESCRIPTION
Add new controller and host kconfigs for Bluetooth 6.0 Channel Sounding and Channel Sounding Test.