### PR TITLE
gpio: add wakeup source support

### DIFF
--- a/drivers/gpio/Kconfig
+++ b/drivers/gpio/Kconfig
@@ -94,6 +94,12 @@ config GPIO_ENABLE_DISABLE_INTERRUPT
 	  on/off the interrupt signal without changing other registers, such as
 	  pending register, etc. The driver must implement it to work.
 
+config GPIO_GET_WAKEUP_SOURCE
+	bool "Support for reading GPIO wakeup source"
+	select EXPERIMENTAL
+	help
+	  Enable support for reading GPIO wakeup source.
+
 # zephyr-keep-sorted-start
 source "drivers/gpio/Kconfig.ad559x"
 source "drivers/gpio/Kconfig.adp5585"

--- a/drivers/gpio/gpio_gecko.c
+++ b/drivers/gpio/gpio_gecko.c
@@ -358,6 +358,19 @@ static void gpio_gecko_common_isr(const struct device *dev)
 	}
 }
 
+#ifdef CONFIG_GPIO_GET_WAKEUP_SOURCE
+static int gpio_gecko_get_wakeup_source(const struct device *dev, uint32_t *wakeup_source)
+{
+	if (!wakeup_source) {
+		return -EFAULT;
+	}
+
+	*wakeup_source = GPIO_EM4GetPinWakeupCause();
+
+	return 0;
+}
+#endif /* CONFIG_GPIO_GET_WAKEUP_SOURCE */
+
 static const struct gpio_driver_api gpio_gecko_driver_api = {
 	.pin_configure = gpio_gecko_configure,
 #ifdef CONFIG_GPIO_GET_CONFIG
@@ -370,6 +383,9 @@ static const struct gpio_driver_api gpio_gecko_driver_api = {
 	.port_toggle_bits = gpio_gecko_port_toggle_bits,
 	.pin_interrupt_configure = gpio_gecko_pin_interrupt_configure,
 	.manage_callback = gpio_gecko_manage_callback,
+#ifdef CONFIG_GPIO_GET_WAKEUP_SOURCE
+	.get_wakeup_source = gpio_gecko_get_wakeup_source,
+#endif /* CONFIG_GPIO_GET_WAKEUP_SOURCE */
 };
 
 static const struct gpio_driver_api gpio_gecko_common_driver_api = {

--- a/include/zephyr/drivers/gpio.h
+++ b/include/zephyr/drivers/gpio.h
@@ -818,6 +818,9 @@ __subsystem struct gpio_driver_api {
 	int (*port_get_direction)(const struct device *port, gpio_port_pins_t map,
 				  gpio_port_pins_t *inputs, gpio_port_pins_t *outputs);
 #endif /* CONFIG_GPIO_GET_DIRECTION */
+#ifdef CONFIG_GPIO_GET_WAKEUP_SOURCE
+	int (*get_wakeup_source)(const struct device *dev, uint32_t *wakeup_source);
+#endif /* CONFIG_GPIO_GET_WAKEUP_SOURCE */
 };
 
 /**
@@ -1068,6 +1071,33 @@ static inline int z_impl_gpio_port_get_direction(const struct device *port, gpio
 	return api->port_get_direction(port, map, inputs, outputs);
 }
 #endif /* CONFIG_GPIO_GET_DIRECTION */
+
+/**
+ * @brief Get wakeup source.
+ *
+ * Retrieve the wakeup source if occurred via GPIO.
+ *
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param wakeup_source Pointer to a variable where wakeup source will be stored.
+ *
+ * @retval 0 If successful.
+ * @retval -ENOSYS if the underlying driver does not support this call.
+ */
+__syscall int gpio_get_wakeup_source(const struct device *dev, uint32_t *wakeup_source);
+
+#ifdef CONFIG_GPIO_GET_WAKEUP_SOURCE
+static inline int z_impl_gpio_get_wakeup_source(const struct device *dev, uint32_t *wakeup_source)
+{
+	const struct gpio_driver_api *api = (const struct gpio_driver_api *)dev->api;
+
+	if (api->get_wakeup_source == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->get_wakeup_source(dev, wakeup_source);
+}
+#endif /* CONFIG_GPIO_GET_WAKEUP_SOURCE */
 
 /**
  * @brief Check if @p pin is configured for input


### PR DESCRIPTION
- Update GPIO API with wakeup source read function
- Update GPIO Kconfig to add experimental support
- Add a sample with silabs gecko implementation

Fixes #74272