### PR TITLE
fs: Fix fs_unmount while mountpoint is busy.

### DIFF
--- a/include/zephyr/fs/fs.h
+++ b/include/zephyr/fs/fs.h
@@ -106,6 +106,10 @@ struct fs_mount_t {
 	const struct fs_file_system_t *fs;
 	/** Mount flags */
 	uint8_t flags;
+#ifdef CONFIG_FILE_SYSTEM_MOUNT_USE_COUNT
+	/** Use count */
+	size_t use_count;
+#endif
 };
 
 /**
@@ -571,6 +575,7 @@ int fs_mount(struct fs_mount_t *mp);
  * @retval 0 on success;
  * @retval -EINVAL if no system has been mounted at given mount point;
  * @retval -ENOTSUP when not supported by underlying file system driver;
+ * @retval -EBUSY when mount point is busy;
  * @retval <0 an other negative errno code on error.
  */
 int fs_unmount(struct fs_mount_t *mp);

--- a/subsys/fs/Kconfig
+++ b/subsys/fs/Kconfig
@@ -96,6 +96,12 @@ config FILE_SYSTEM_MKFS
 	help
 	  Enables function fs_mkfs that can be used to format a storage device.
 
+config FILE_SYSTEM_MOUNT_USE_COUNT
+	bool "Optional mount point use count"
+	help
+	  Enables a use counter that protects a mountpoint from being unmounted
+	  while active.
+
 config FUSE_FS_ACCESS
 	bool "FUSE based access to file system partitions"
 	depends on ARCH_POSIX

--- a/tests/subsys/fs/fs_api/src/test_multi_fs.c
+++ b/tests/subsys/fs/fs_api/src/test_multi_fs.c
@@ -10,18 +10,19 @@
 #define TEST_FS_NAND1 "/NAND:"
 #define TEST_FS_NAND2 "/MMCBLOCK:"
 
-static struct test_fs_data test_data;
+static struct test_fs_data test_data_fs1;
+static struct test_fs_data test_data_fs2;
 
 static struct fs_mount_t test_fs_mnt_1 = {
-		.type = TEST_FS_1,
-		.mnt_point = TEST_FS_NAND1,
-		.fs_data = &test_data,
+	.type = TEST_FS_1,
+	.mnt_point = TEST_FS_NAND1,
+	.fs_data = &test_data_fs1,
 };
 
 static struct fs_mount_t test_fs_mnt_2 = {
-		.type = TEST_FS_2,
-		.mnt_point = TEST_FS_NAND2,
-		.fs_data = &test_data,
+	.type = TEST_FS_2,
+	.mnt_point = TEST_FS_NAND2,
+	.fs_data = &test_data_fs2,
 };
 
 static int test_fs_init(void)


### PR DESCRIPTION
Fixes fs_unmount when IO is potentially ongoing in a different thread. By using an use counter on the mountpoint we can prevent any thread from unmounting while busy. The fs_unmount adds -EBUSY as return value to reflect this case.