### PR TITLE
doc: generation: fix link to zephyr.tag

### DIFF
--- a/doc/contribute/documentation/generation.rst
+++ b/doc/contribute/documentation/generation.rst
@@ -290,7 +290,7 @@ Linking external Doxygen projects against Zephyr
 
 External projects that build upon Zephyr functionality and wish to refer to
 Zephyr documentation in Doxygen (through the use of @ref), can utilize the
-tag file exported at `zephyr.tag </doxygen/html/zephyr.tag>`_
+tag file exported at `zephyr.tag <../../doxygen/html/zephyr.tag>`_
 
 Once downloaded, the tag file can be used in a custom ``doxyfile.in`` as follows::
 


### PR DESCRIPTION
This link probably never worked. This commit fixes the relative URL to properly point to where Doxygen docs live.

Fixes #78016.