### PR TITLE
cmake: remove spurious parenthese just added to xt-ld/linker_flags

### DIFF
--- a/cmake/linker/xt-ld/linker_flags.cmake
+++ b/cmake/linker/xt-ld/linker_flags.cmake
@@ -29,7 +29,7 @@ check_set_linker_property(TARGET linker PROPERTY orphan_error
 set_property(TARGET linker PROPERTY partial_linking "-r")
 
 check_set_linker_property(TARGET linker PROPERTY no_relax ${LINKERFLAGPREFIX},--no-relax)
-)
+
 check_set_linker_property(TARGET linker PROPERTY sort_alignment
                           ${LINKERFLAGPREFIX},--sort-common=descending
                           ${LINKERFLAGPREFIX},--sort-section=alignment


### PR DESCRIPTION
Fixes commit 9a9e252d1677 ("cmake: linker: move toolchain_ld_<base|cpp>
to linker flag property")

Fixes failure:

```
CMake Error at zephyr/cmake/linker/xt-ld/linker_flags.cmake:32:
  Parse error.  Expected a command name, got right paren with text ")".

Call Stack (most recent call first):
  zephyr/cmake/target_toolchain_flags.cmake:42 (include)
  zephyr/cmake/modules/kernel.cmake:148 (include)
  zephyr/cmake/modules/zephyr_default.cmake:142 (include)
  zephyr/share/zephyr-package/cmake/ZephyrConfig.cmake:66 (include)
  zephyr/share/zephyr-package/cmake/ZephyrConfig.cmake:97 (include_boi
```