### PR TITLE
arch: `_callee_saved_t` → `struct arch_csf` & pass `csf` to fatal handling APIs

### DIFF
--- a/arch/arc/core/fatal.c
+++ b/arch/arc/core/fatal.c
@@ -50,7 +50,7 @@ void z_arc_fatal_error(unsigned int reason, const struct arch_esf *esf)
 	}
 #endif /* CONFIG_EXCEPTION_DEBUG */
 
-	z_fatal_error(reason, esf);
+	z_fatal_error(reason, esf, NULL);
 }
 
 FUNC_NORETURN void arch_syscall_oops(void *ssf_ptr)

--- a/arch/arc/core/irq_manage.c
+++ b/arch/arc/core/irq_manage.c
@@ -242,7 +242,7 @@ void z_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
 void z_irq_spurious(const void *unused)
 {
 	ARG_UNUSED(unused);
-	z_fatal_error(K_ERR_SPURIOUS_IRQ, NULL);
+	z_fatal_error(K_ERR_SPURIOUS_IRQ, NULL, NULL);
 }
 
 #ifdef CONFIG_DYNAMIC_INTERRUPTS

--- a/arch/arc/core/offsets/offsets.c
+++ b/arch/arc/core/offsets/offsets.c
@@ -78,7 +78,7 @@ GEN_OFFSET_SYM(_isf_t, sec_stat);
 GEN_OFFSET_SYM(_isf_t, status32);
 GEN_ABSOLUTE_SYM(___isf_t_SIZEOF, sizeof(_isf_t));
 
-GEN_OFFSET_SYM(_callee_saved_t, sp);
+GEN_OFFSET_STRUCT(arch_csf, sp);
 
 GEN_OFFSET_SYM(_callee_saved_stack_t, r13);
 GEN_OFFSET_SYM(_callee_saved_stack_t, r14);

--- a/arch/arc/include/offsets_short_arch.h
+++ b/arch/arc/include/offsets_short_arch.h
@@ -36,7 +36,7 @@
 	(___thread_t_arch_OFFSET + ___thread_arch_t_priv_stack_start_OFFSET)
 
 #define _thread_offset_to_sp \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_sp_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_sp_OFFSET)
 
 /* end - threads */
 

--- a/arch/arm/core/cortex_a_r/exc.S
+++ b/arch/arm/core/cortex_a_r/exc.S
@@ -76,7 +76,7 @@ GTEXT(z_arm_data_abort)
 	str r0, [sp, #4]
 	str r0, [sp, #8]
 
-	sub r1, sp, #___callee_saved_t_SIZEOF
+	sub r1, sp, #__struct_arch_csf_SIZEOF
 	str r1, [sp]
 	cps #MODE_SYS
 	stm r1, {r4-r11, sp}
@@ -99,7 +99,7 @@ GTEXT(z_arm_data_abort)
 	/* Exit exception */
 #if defined(CONFIG_EXTRA_EXCEPTION_INFO)
 	add sp, #___extra_esf_info_t_SIZEOF
-	add sp, #___callee_saved_t_SIZEOF
+	add sp, #__struct_arch_csf_SIZEOF
 #endif
 .endm
 
@@ -163,7 +163,7 @@ SECTION_SUBSEC_FUNC(TEXT, __exc, z_arm_undef_instruction)
 	str r0, [sp, #4]
 	str r0, [sp, #8]
 
-	sub r1, sp, #___callee_saved_t_SIZEOF
+	sub r1, sp, #__struct_arch_csf_SIZEOF
 	str r1, [sp]
 	cps #MODE_SYS
 	stm r1, {r4-r11, sp}

--- a/arch/arm/core/cortex_m/fault.c
+++ b/arch/arm/core/cortex_m/fault.c
@@ -1089,8 +1089,7 @@ static inline struct arch_esf *get_esf(uint32_t msp, uint32_t psp, uint32_t exc_
  * @param callee_regs Callee-saved registers (R4-R11, PSP)
  *
  */
-void z_arm_fault(uint32_t msp, uint32_t psp, uint32_t exc_return,
-	_callee_saved_t *callee_regs)
+void z_arm_fault(uint32_t msp, uint32_t psp, uint32_t exc_return, struct arch_csf *callee_regs)
 {
 	uint32_t reason = K_ERR_CPU_EXCEPTION;
 	int fault = SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk;

--- a/arch/arm/core/cortex_m/fault_s.S
+++ b/arch/arm/core/cortex_m/fault_s.S
@@ -81,7 +81,7 @@ SECTION_SUBSEC_FUNC(TEXT,__fault,z_arm_exc_spurious)
 	mrs r1, PSP
 	push {r0, lr}
 #if defined(CONFIG_EXTRA_EXCEPTION_INFO)
-	/* Build _callee_saved_t. To match the struct
+	/* Build struct arch_csf. To match the struct
 	 * definition we push the psp & then r11-r4
 	 */
 	push { r1, r2 }
@@ -96,7 +96,7 @@ SECTION_SUBSEC_FUNC(TEXT,__fault,z_arm_exc_spurious)
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
 	push {r4-r11}
 #endif
-	mov  r3, sp /* pointer to _callee_saved_t */
+	mov  r3, sp /* pointer to struct arch_csf */
 #endif /* CONFIG_EXTRA_EXCEPTION_INFO */
 	mov r2, lr /* EXC_RETURN */
 	bl z_arm_fault

--- a/arch/arm/core/cortex_m/swap_helper.S
+++ b/arch/arm/core/cortex_m/swap_helper.S
@@ -306,13 +306,13 @@ _oops:
     push {r0, lr}
 #if defined(CONFIG_EXTRA_EXCEPTION_INFO)
 #if defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
-    /* Build _callee_saved_t. To match the struct
+    /* Build struct arch_csf. To match the struct
      * definition we push the psp & then r11-r4
      */
     mrs r1, PSP
     push {r1, r2}
     push {r4-r11}
-    mov  r1, sp /* pointer to _callee_saved_t */
+    mov  r1, sp /* pointer to struct arch_csf */
 #endif /* CONFIG_ARMV7_M_ARMV8_M_MAINLINE */
 #endif /* CONFIG_EXTRA_EXCEPTION_INFO */
     bl z_do_kernel_oops

--- a/arch/arm/core/fatal.c
+++ b/arch/arm/core/fatal.c
@@ -83,7 +83,7 @@ void z_arm_fatal_error(unsigned int reason, const struct arch_esf *esf)
 	}
 #endif
 
-	z_fatal_error(reason, esf);
+	z_fatal_error(reason, esf, NULL);
 }
 
 /**

--- a/arch/arm/core/fatal.c
+++ b/arch/arm/core/fatal.c
@@ -47,7 +47,7 @@ static void esf_dump(const struct arch_esf *esf)
 	LOG_ERR("fpscr:  0x%08x", esf->fpu.fpscr);
 #endif
 #if defined(CONFIG_EXTRA_EXCEPTION_INFO)
-	const struct _callee_saved *callee = esf->extra_info.callee;
+	const struct arch_csf *callee = esf->extra_info.callee;
 
 	if (callee != NULL) {
 		LOG_ERR("r4/v1:  0x%08x  r5/v2:  0x%08x  r6/v3:  0x%08x",

--- a/arch/arm/core/fatal.c
+++ b/arch/arm/core/fatal.c
@@ -102,7 +102,7 @@ void z_arm_fatal_error(unsigned int reason, const struct arch_esf *esf)
  * @param esf exception frame
  * @param callee_regs Callee-saved registers (R4-R11)
  */
-void z_do_kernel_oops(const struct arch_esf *esf, _callee_saved_t *callee_regs)
+void z_do_kernel_oops(const struct arch_esf *esf, struct arch_csf *callee_regs)
 {
 #if !(defined(CONFIG_EXTRA_EXCEPTION_INFO) && defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE))
 	ARG_UNUSED(callee_regs);

--- a/arch/arm/core/offsets/offsets_aarch32.c
+++ b/arch/arm/core/offsets/offsets_aarch32.c
@@ -68,7 +68,7 @@ GEN_ABSOLUTE_SYM(___esf_t_SIZEOF, sizeof(_esf_t));
 
 /* size of the entire preempt registers structure */
 
-GEN_ABSOLUTE_SYM(___callee_saved_t_SIZEOF, sizeof(struct arch_csf));
+GEN_ABSOLUTE_SYM(__struct_arch_csf_SIZEOF, sizeof(struct arch_csf));
 
 #if defined(CONFIG_EXTRA_EXCEPTION_INFO)
 GEN_ABSOLUTE_SYM(___extra_esf_info_t_SIZEOF, sizeof(struct __extra_esf_info));

--- a/arch/arm/core/offsets/offsets_aarch32.c
+++ b/arch/arm/core/offsets/offsets_aarch32.c
@@ -68,7 +68,7 @@ GEN_ABSOLUTE_SYM(___esf_t_SIZEOF, sizeof(_esf_t));
 
 /* size of the entire preempt registers structure */
 
-GEN_ABSOLUTE_SYM(___callee_saved_t_SIZEOF, sizeof(struct _callee_saved));
+GEN_ABSOLUTE_SYM(___callee_saved_t_SIZEOF, sizeof(struct arch_csf));
 
 #if defined(CONFIG_EXTRA_EXCEPTION_INFO)
 GEN_ABSOLUTE_SYM(___extra_esf_info_t_SIZEOF, sizeof(struct __extra_esf_info));

--- a/arch/arm64/core/fatal.c
+++ b/arch/arm64/core/fatal.c
@@ -403,7 +403,7 @@ void z_arm64_fatal_error(unsigned int reason, struct arch_esf *esf)
 #endif /* CONFIG_EXCEPTION_STACK_TRACE */
 #endif /* CONFIG_EXCEPTION_DEBUG */
 
-	z_fatal_error(reason, esf);
+	z_fatal_error(reason, esf, NULL);
 
 	CODE_UNREACHABLE;
 }

--- a/arch/arm64/core/offsets/offsets.c
+++ b/arch/arm64/core/offsets/offsets.c
@@ -32,13 +32,13 @@
 
 GEN_OFFSET_SYM(_thread_arch_t, exception_depth);
 
-GEN_NAMED_OFFSET_SYM(_callee_saved_t, x19, x19_x20);
-GEN_NAMED_OFFSET_SYM(_callee_saved_t, x21, x21_x22);
-GEN_NAMED_OFFSET_SYM(_callee_saved_t, x23, x23_x24);
-GEN_NAMED_OFFSET_SYM(_callee_saved_t, x25, x25_x26);
-GEN_NAMED_OFFSET_SYM(_callee_saved_t, x27, x27_x28);
-GEN_NAMED_OFFSET_SYM(_callee_saved_t, x29, x29_sp_el0);
-GEN_NAMED_OFFSET_SYM(_callee_saved_t, sp_elx, sp_elx_lr);
+GEN_NAMED_OFFSET_STRUCT(arch_csf, x19, x19_x20);
+GEN_NAMED_OFFSET_STRUCT(arch_csf, x21, x21_x22);
+GEN_NAMED_OFFSET_STRUCT(arch_csf, x23, x23_x24);
+GEN_NAMED_OFFSET_STRUCT(arch_csf, x25, x25_x26);
+GEN_NAMED_OFFSET_STRUCT(arch_csf, x27, x27_x28);
+GEN_NAMED_OFFSET_STRUCT(arch_csf, x29, x29_sp_el0);
+GEN_NAMED_OFFSET_STRUCT(arch_csf, sp_elx, sp_elx_lr);
 
 #ifdef CONFIG_FRAME_POINTER
 GEN_NAMED_OFFSET_SYM(_esf_t, fp, fp);

--- a/arch/arm64/include/offsets_short_arch.h
+++ b/arch/arm64/include/offsets_short_arch.h
@@ -13,19 +13,19 @@
 	(___thread_t_arch_OFFSET + ___thread_arch_t_exception_depth_OFFSET)
 
 #define _thread_offset_to_callee_saved_x19_x20 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_x19_x20_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_x19_x20_OFFSET)
 #define _thread_offset_to_callee_saved_x21_x22 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_x21_x22_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_x21_x22_OFFSET)
 #define _thread_offset_to_callee_saved_x23_x24 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_x23_x24_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_x23_x24_OFFSET)
 #define _thread_offset_to_callee_saved_x25_x26 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_x25_x26_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_x25_x26_OFFSET)
 #define _thread_offset_to_callee_saved_x27_x28 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_x27_x28_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_x27_x28_OFFSET)
 #define _thread_offset_to_callee_saved_x29_sp_el0 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_x29_sp_el0_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_x29_sp_el0_OFFSET)
 #define _thread_offset_to_callee_saved_sp_elx_lr \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_sp_elx_lr_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_sp_elx_lr_OFFSET)
 
 #ifdef CONFIG_ARM64_SAFE_EXCEPTION_STACK
 #define _cpu_offset_to_safe_exception_stack \

--- a/arch/mips/core/fatal.c
+++ b/arch/mips/core/fatal.c
@@ -34,7 +34,7 @@ FUNC_NORETURN void z_mips_fatal_error(unsigned int reason,
 		LOG_ERR("BadVA : %08lx\n", esf->badvaddr);
 	}
 #endif /* CONFIG_EXCEPTION_DEBUG */
-	z_fatal_error(reason, esf);
+	z_fatal_error(reason, esf, NULL);
 	CODE_UNREACHABLE;
 }
 

--- a/arch/mips/core/offsets/offsets.c
+++ b/arch/mips/core/offsets/offsets.c
@@ -12,16 +12,16 @@
 
 GEN_OFFSET_SYM(_thread_arch_t, swap_return_value);
 
-GEN_OFFSET_SYM(_callee_saved_t, sp);
-GEN_OFFSET_SYM(_callee_saved_t, s0);
-GEN_OFFSET_SYM(_callee_saved_t, s1);
-GEN_OFFSET_SYM(_callee_saved_t, s2);
-GEN_OFFSET_SYM(_callee_saved_t, s3);
-GEN_OFFSET_SYM(_callee_saved_t, s4);
-GEN_OFFSET_SYM(_callee_saved_t, s5);
-GEN_OFFSET_SYM(_callee_saved_t, s6);
-GEN_OFFSET_SYM(_callee_saved_t, s7);
-GEN_OFFSET_SYM(_callee_saved_t, s8);
+GEN_OFFSET_STRUCT(arch_csf, sp);
+GEN_OFFSET_STRUCT(arch_csf, s0);
+GEN_OFFSET_STRUCT(arch_csf, s1);
+GEN_OFFSET_STRUCT(arch_csf, s2);
+GEN_OFFSET_STRUCT(arch_csf, s3);
+GEN_OFFSET_STRUCT(arch_csf, s4);
+GEN_OFFSET_STRUCT(arch_csf, s5);
+GEN_OFFSET_STRUCT(arch_csf, s6);
+GEN_OFFSET_STRUCT(arch_csf, s7);
+GEN_OFFSET_STRUCT(arch_csf, s8);
 
 GEN_OFFSET_STRUCT(arch_esf, ra);
 GEN_OFFSET_STRUCT(arch_esf, gp);

--- a/arch/mips/include/offsets_short_arch.h
+++ b/arch/mips/include/offsets_short_arch.h
@@ -12,34 +12,34 @@
 #include <zephyr/offsets.h>
 
 #define _thread_offset_to_sp \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_sp_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_sp_OFFSET)
 
 #define _thread_offset_to_s0 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_s0_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_s0_OFFSET)
 
 #define _thread_offset_to_s1 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_s1_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_s1_OFFSET)
 
 #define _thread_offset_to_s2 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_s2_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_s2_OFFSET)
 
 #define _thread_offset_to_s3 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_s3_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_s3_OFFSET)
 
 #define _thread_offset_to_s4 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_s4_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_s4_OFFSET)
 
 #define _thread_offset_to_s5 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_s5_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_s5_OFFSET)
 
 #define _thread_offset_to_s6 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_s6_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_s6_OFFSET)
 
 #define _thread_offset_to_s7 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_s7_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_s7_OFFSET)
 
 #define _thread_offset_to_s8 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_s8_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_s8_OFFSET)
 
 #define _thread_offset_to_swap_return_value \
 	(___thread_t_arch_OFFSET + ___thread_arch_t_swap_return_value_OFFSET)

--- a/arch/nios2/core/fatal.c
+++ b/arch/nios2/core/fatal.c
@@ -36,7 +36,7 @@ FUNC_NORETURN void z_nios2_fatal_error(unsigned int reason,
 	}
 #endif /* CONFIG_EXCEPTION_DEBUG */
 
-	z_fatal_error(reason, esf);
+	z_fatal_error(reason, esf, NULL);
 	CODE_UNREACHABLE;
 }
 

--- a/arch/nios2/core/offsets/offsets.c
+++ b/arch/nios2/core/offsets/offsets.c
@@ -30,19 +30,19 @@
 #include <kernel_offsets.h>
 
 /* struct coop member offsets */
-GEN_OFFSET_SYM(_callee_saved_t, r16);
-GEN_OFFSET_SYM(_callee_saved_t, r17);
-GEN_OFFSET_SYM(_callee_saved_t, r18);
-GEN_OFFSET_SYM(_callee_saved_t, r19);
-GEN_OFFSET_SYM(_callee_saved_t, r20);
-GEN_OFFSET_SYM(_callee_saved_t, r21);
-GEN_OFFSET_SYM(_callee_saved_t, r22);
-GEN_OFFSET_SYM(_callee_saved_t, r23);
-GEN_OFFSET_SYM(_callee_saved_t, r28);
-GEN_OFFSET_SYM(_callee_saved_t, ra);
-GEN_OFFSET_SYM(_callee_saved_t, sp);
-GEN_OFFSET_SYM(_callee_saved_t, key);
-GEN_OFFSET_SYM(_callee_saved_t, retval);
+GEN_OFFSET_STRUCT(arch_csf, r16);
+GEN_OFFSET_STRUCT(arch_csf, r17);
+GEN_OFFSET_STRUCT(arch_csf, r18);
+GEN_OFFSET_STRUCT(arch_csf, r19);
+GEN_OFFSET_STRUCT(arch_csf, r20);
+GEN_OFFSET_STRUCT(arch_csf, r21);
+GEN_OFFSET_STRUCT(arch_csf, r22);
+GEN_OFFSET_STRUCT(arch_csf, r23);
+GEN_OFFSET_STRUCT(arch_csf, r28);
+GEN_OFFSET_STRUCT(arch_csf, ra);
+GEN_OFFSET_STRUCT(arch_csf, sp);
+GEN_OFFSET_STRUCT(arch_csf, key);
+GEN_OFFSET_STRUCT(arch_csf, retval);
 
 GEN_OFFSET_STRUCT(arch_esf, ra);
 GEN_OFFSET_STRUCT(arch_esf, r1);

--- a/arch/nios2/include/offsets_short_arch.h
+++ b/arch/nios2/include/offsets_short_arch.h
@@ -18,43 +18,43 @@
 /* threads */
 
 #define _thread_offset_to_r16 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_r16_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_r16_OFFSET)
 
 #define _thread_offset_to_r17 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_r17_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_r17_OFFSET)
 
 #define _thread_offset_to_r18 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_r18_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_r18_OFFSET)
 
 #define _thread_offset_to_r19 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_r19_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_r19_OFFSET)
 
 #define _thread_offset_to_r20 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_r20_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_r20_OFFSET)
 
 #define _thread_offset_to_r21 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_r21_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_r21_OFFSET)
 
 #define _thread_offset_to_r22 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_r22_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_r22_OFFSET)
 
 #define _thread_offset_to_r23 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_r23_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_r23_OFFSET)
 
 #define _thread_offset_to_r28 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_r28_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_r28_OFFSET)
 
 #define _thread_offset_to_ra \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_ra_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_ra_OFFSET)
 
 #define _thread_offset_to_sp \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_sp_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_sp_OFFSET)
 
 #define _thread_offset_to_key \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_key_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_key_OFFSET)
 
 #define _thread_offset_to_retval \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_retval_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_retval_OFFSET)
 
 /* end - threads */
 

--- a/arch/riscv/core/fatal.c
+++ b/arch/riscv/core/fatal.c
@@ -104,7 +104,7 @@ FUNC_NORETURN void z_riscv_fatal_error_csf(unsigned int reason, const struct arc
 	z_riscv_unwind_stack(esf, csf);
 #endif /* CONFIG_EXCEPTION_STACK_TRACE */
 
-	z_fatal_error(reason, esf);
+	z_fatal_error(reason, esf, csf);
 	CODE_UNREACHABLE;
 }
 

--- a/arch/riscv/core/fatal.c
+++ b/arch/riscv/core/fatal.c
@@ -29,7 +29,7 @@ static const struct z_exc_handle exceptions[] = {
 #endif
 
 /* Stack trace function */
-void z_riscv_unwind_stack(const struct arch_esf *esf, const _callee_saved_t *csf);
+void z_riscv_unwind_stack(const struct arch_esf *esf, const struct arch_csf *csf);
 
 uintptr_t z_riscv_get_sp_before_exc(const struct arch_esf *esf)
 {
@@ -59,7 +59,7 @@ FUNC_NORETURN void z_riscv_fatal_error(unsigned int reason,
 }
 
 FUNC_NORETURN void z_riscv_fatal_error_csf(unsigned int reason, const struct arch_esf *esf,
-					   const _callee_saved_t *csf)
+					   const struct arch_csf *csf)
 {
 #ifdef CONFIG_EXCEPTION_DEBUG
 	if (esf != NULL) {

--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -44,18 +44,18 @@
 #ifdef CONFIG_EXCEPTION_DEBUG
 /* Convenience macro for storing callee saved register [s0 - s11] states. */
 #define STORE_CALLEE_SAVED() \
-	RV_E(	sr s0, ___callee_saved_t_s0_OFFSET(sp)		);\
-	RV_E(	sr s1, ___callee_saved_t_s1_OFFSET(sp)		);\
-	RV_I(	sr s2, ___callee_saved_t_s2_OFFSET(sp)		);\
-	RV_I(	sr s3, ___callee_saved_t_s3_OFFSET(sp)		);\
-	RV_I(	sr s4, ___callee_saved_t_s4_OFFSET(sp)		);\
-	RV_I(	sr s5, ___callee_saved_t_s5_OFFSET(sp)		);\
-	RV_I(	sr s6, ___callee_saved_t_s6_OFFSET(sp)		);\
-	RV_I(	sr s7, ___callee_saved_t_s7_OFFSET(sp)		);\
-	RV_I(	sr s8, ___callee_saved_t_s8_OFFSET(sp)		);\
-	RV_I(	sr s9, ___callee_saved_t_s9_OFFSET(sp)		);\
-	RV_I(	sr s10, ___callee_saved_t_s10_OFFSET(sp)	);\
-	RV_I(	sr s11, ___callee_saved_t_s11_OFFSET(sp)	)
+	RV_E(	sr s0, __struct_arch_csf_s0_OFFSET(sp)		);\
+	RV_E(	sr s1, __struct_arch_csf_s1_OFFSET(sp)		);\
+	RV_I(	sr s2, __struct_arch_csf_s2_OFFSET(sp)		);\
+	RV_I(	sr s3, __struct_arch_csf_s3_OFFSET(sp)		);\
+	RV_I(	sr s4, __struct_arch_csf_s4_OFFSET(sp)		);\
+	RV_I(	sr s5, __struct_arch_csf_s5_OFFSET(sp)		);\
+	RV_I(	sr s6, __struct_arch_csf_s6_OFFSET(sp)		);\
+	RV_I(	sr s7, __struct_arch_csf_s7_OFFSET(sp)		);\
+	RV_I(	sr s8, __struct_arch_csf_s8_OFFSET(sp)		);\
+	RV_I(	sr s9, __struct_arch_csf_s9_OFFSET(sp)		);\
+	RV_I(	sr s10, __struct_arch_csf_s10_OFFSET(sp)	);\
+	RV_I(	sr s11, __struct_arch_csf_s11_OFFSET(sp)	)
 #endif /* CONFIG_EXCEPTION_DEBUG */
 
 	.macro get_current_cpu dst
@@ -444,7 +444,7 @@ do_fault:
 
 #ifdef CONFIG_EXCEPTION_DEBUG
 	/* Allocate space for caller-saved registers on current thread stack */
-	addi sp, sp, -__callee_saved_t_SIZEOF
+	addi sp, sp, -_struct_arch_csf_SIZEOF
 
 	/* Save callee-saved registers to be passed as 3rd arg */
 	STORE_CALLEE_SAVED()		;

--- a/arch/riscv/core/offsets/offsets.c
+++ b/arch/riscv/core/offsets/offsets.c
@@ -27,7 +27,7 @@
 
 #include <kernel_offsets.h>
 
-/* struct _callee_saved member offsets */
+/* struct arch_csf member offsets */
 GEN_OFFSET_SYM(_callee_saved_t, sp);
 GEN_OFFSET_SYM(_callee_saved_t, ra);
 GEN_OFFSET_SYM(_callee_saved_t, s0);

--- a/arch/riscv/core/offsets/offsets.c
+++ b/arch/riscv/core/offsets/offsets.c
@@ -28,21 +28,21 @@
 #include <kernel_offsets.h>
 
 /* struct arch_csf member offsets */
-GEN_OFFSET_SYM(_callee_saved_t, sp);
-GEN_OFFSET_SYM(_callee_saved_t, ra);
-GEN_OFFSET_SYM(_callee_saved_t, s0);
-GEN_OFFSET_SYM(_callee_saved_t, s1);
+GEN_OFFSET_STRUCT(arch_csf, sp);
+GEN_OFFSET_STRUCT(arch_csf, ra);
+GEN_OFFSET_STRUCT(arch_csf, s0);
+GEN_OFFSET_STRUCT(arch_csf, s1);
 #if !defined(CONFIG_RISCV_ISA_RV32E)
-GEN_OFFSET_SYM(_callee_saved_t, s2);
-GEN_OFFSET_SYM(_callee_saved_t, s3);
-GEN_OFFSET_SYM(_callee_saved_t, s4);
-GEN_OFFSET_SYM(_callee_saved_t, s5);
-GEN_OFFSET_SYM(_callee_saved_t, s6);
-GEN_OFFSET_SYM(_callee_saved_t, s7);
-GEN_OFFSET_SYM(_callee_saved_t, s8);
-GEN_OFFSET_SYM(_callee_saved_t, s9);
-GEN_OFFSET_SYM(_callee_saved_t, s10);
-GEN_OFFSET_SYM(_callee_saved_t, s11);
+GEN_OFFSET_STRUCT(arch_csf, s2);
+GEN_OFFSET_STRUCT(arch_csf, s3);
+GEN_OFFSET_STRUCT(arch_csf, s4);
+GEN_OFFSET_STRUCT(arch_csf, s5);
+GEN_OFFSET_STRUCT(arch_csf, s6);
+GEN_OFFSET_STRUCT(arch_csf, s7);
+GEN_OFFSET_STRUCT(arch_csf, s8);
+GEN_OFFSET_STRUCT(arch_csf, s9);
+GEN_OFFSET_STRUCT(arch_csf, s10);
+GEN_OFFSET_STRUCT(arch_csf, s11);
 #endif /* !CONFIG_RISCV_ISA_RV32E */
 
 #if defined(CONFIG_FPU_SHARING)
@@ -128,7 +128,7 @@ GEN_SOC_OFFSET_SYMS();
 GEN_ABSOLUTE_SYM(__struct_arch_esf_SIZEOF, sizeof(struct arch_esf));
 
 #ifdef CONFIG_EXCEPTION_DEBUG
-GEN_ABSOLUTE_SYM(__callee_saved_t_SIZEOF, ROUND_UP(sizeof(_callee_saved_t), ARCH_STACK_PTR_ALIGN));
+GEN_ABSOLUTE_SYM(_struct_arch_csf_SIZEOF, ROUND_UP(sizeof(struct arch_csf), ARCH_STACK_PTR_ALIGN));
 #endif /* CONFIG_EXCEPTION_DEBUG */
 
 #ifdef CONFIG_USERSPACE

--- a/arch/riscv/core/stacktrace.c
+++ b/arch/riscv/core/stacktrace.c
@@ -98,7 +98,7 @@ static inline bool in_text_region(uintptr_t addr)
 #ifdef CONFIG_FRAME_POINTER
 static void walk_stackframe(riscv_stacktrace_cb cb, void *cookie, const struct k_thread *thread,
 			    const struct arch_esf *esf, stack_verify_fn vrfy,
-			    const _callee_saved_t *csf)
+			    const struct arch_csf *csf)
 {
 	uintptr_t fp, last_fp = 0;
 	uintptr_t ra;
@@ -171,7 +171,7 @@ static void walk_stackframe(riscv_stacktrace_cb cb, void *cookie, const struct k
 register uintptr_t current_stack_pointer __asm__("sp");
 static void walk_stackframe(riscv_stacktrace_cb cb, void *cookie, const struct k_thread *thread,
 			    const struct arch_esf *esf, stack_verify_fn vrfy,
-			    const _callee_saved_t *csf)
+			    const struct arch_csf *csf)
 {
 	uintptr_t sp;
 	uintptr_t ra;
@@ -275,7 +275,7 @@ static bool print_trace_address(void *arg, unsigned long ra, unsigned long sfp)
 	return true;
 }
 
-void z_riscv_unwind_stack(const struct arch_esf *esf, const _callee_saved_t *csf)
+void z_riscv_unwind_stack(const struct arch_esf *esf, const struct arch_csf *csf)
 {
 	int i = 0;
 

--- a/arch/riscv/include/kernel_arch_func.h
+++ b/arch/riscv/include/kernel_arch_func.h
@@ -74,7 +74,7 @@ FUNC_NORETURN void z_riscv_fatal_error(unsigned int reason,
 				       const struct arch_esf *esf);
 
 FUNC_NORETURN void z_riscv_fatal_error_csf(unsigned int reason, const struct arch_esf *esf,
-					   const _callee_saved_t *csf);
+					   const struct arch_csf *csf);
 
 static inline bool arch_is_in_isr(void)
 {

--- a/arch/riscv/include/offsets_short_arch.h
+++ b/arch/riscv/include/offsets_short_arch.h
@@ -10,46 +10,46 @@
 #include <zephyr/offsets.h>
 
 #define _thread_offset_to_sp \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_sp_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_sp_OFFSET)
 
 #define _thread_offset_to_ra \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_ra_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_ra_OFFSET)
 
 #define _thread_offset_to_s0 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_s0_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_s0_OFFSET)
 
 #define _thread_offset_to_s1 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_s1_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_s1_OFFSET)
 
 #define _thread_offset_to_s2 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_s2_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_s2_OFFSET)
 
 #define _thread_offset_to_s3 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_s3_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_s3_OFFSET)
 
 #define _thread_offset_to_s4 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_s4_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_s4_OFFSET)
 
 #define _thread_offset_to_s5 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_s5_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_s5_OFFSET)
 
 #define _thread_offset_to_s6 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_s6_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_s6_OFFSET)
 
 #define _thread_offset_to_s7 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_s7_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_s7_OFFSET)
 
 #define _thread_offset_to_s8 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_s8_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_s8_OFFSET)
 
 #define _thread_offset_to_s9 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_s9_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_s9_OFFSET)
 
 #define _thread_offset_to_s10 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_s10_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_s10_OFFSET)
 
 #define _thread_offset_to_s11 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_s11_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_s11_OFFSET)
 
 #define _thread_offset_to_swap_return_value \
 	(___thread_t_arch_OFFSET + ___thread_arch_t_swap_return_value_OFFSET)

--- a/arch/sparc/core/fatal.c
+++ b/arch/sparc/core/fatal.c
@@ -217,6 +217,6 @@ FUNC_NORETURN void z_sparc_fatal_error(unsigned int reason,
 	}
 #endif /* CONFIG_EXCEPTION_DEBUG */
 
-	z_fatal_error(reason, esf);
+	z_fatal_error(reason, esf, NULL);
 	CODE_UNREACHABLE;
 }

--- a/arch/sparc/core/offsets/offsets.c
+++ b/arch/sparc/core/offsets/offsets.c
@@ -17,18 +17,18 @@
 #include <gen_offset.h>
 #include <kernel_offsets.h>
 
-GEN_OFFSET_SYM(_callee_saved_t, y);
-GEN_OFFSET_SYM(_callee_saved_t, psr);
+GEN_OFFSET_STRUCT(arch_csf, y);
+GEN_OFFSET_STRUCT(arch_csf, psr);
 
-GEN_OFFSET_SYM(_callee_saved_t, l0_and_l1);
-GEN_OFFSET_SYM(_callee_saved_t, l2);
-GEN_OFFSET_SYM(_callee_saved_t, l4);
-GEN_OFFSET_SYM(_callee_saved_t, l6);
-GEN_OFFSET_SYM(_callee_saved_t, i0);
-GEN_OFFSET_SYM(_callee_saved_t, i2);
-GEN_OFFSET_SYM(_callee_saved_t, i4);
-GEN_OFFSET_SYM(_callee_saved_t, i6);
-GEN_OFFSET_SYM(_callee_saved_t, o6);
+GEN_OFFSET_STRUCT(arch_csf, l0_and_l1);
+GEN_OFFSET_STRUCT(arch_csf, l2);
+GEN_OFFSET_STRUCT(arch_csf, l4);
+GEN_OFFSET_STRUCT(arch_csf, l6);
+GEN_OFFSET_STRUCT(arch_csf, i0);
+GEN_OFFSET_STRUCT(arch_csf, i2);
+GEN_OFFSET_STRUCT(arch_csf, i4);
+GEN_OFFSET_STRUCT(arch_csf, i6);
+GEN_OFFSET_STRUCT(arch_csf, o6);
 
 /* esf member offsets */
 GEN_OFFSET_STRUCT(arch_esf, out);

--- a/arch/sparc/include/offsets_short_arch.h
+++ b/arch/sparc/include/offsets_short_arch.h
@@ -10,36 +10,36 @@
 #include <zephyr/offsets.h>
 
 #define _thread_offset_to_y \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_y_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_y_OFFSET)
 
 #define _thread_offset_to_l0_and_l1 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_l0_and_l1_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_l0_and_l1_OFFSET)
 
 #define _thread_offset_to_l2 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_l2_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_l2_OFFSET)
 
 #define _thread_offset_to_l4 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_l4_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_l4_OFFSET)
 
 #define _thread_offset_to_l6 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_l6_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_l6_OFFSET)
 
 #define _thread_offset_to_i0 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_i0_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_i0_OFFSET)
 
 #define _thread_offset_to_i2 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_i2_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_i2_OFFSET)
 
 #define _thread_offset_to_i4 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_i4_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_i4_OFFSET)
 
 #define _thread_offset_to_i6 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_i6_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_i6_OFFSET)
 
 #define _thread_offset_to_o6 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_o6_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_o6_OFFSET)
 
 #define _thread_offset_to_psr \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_psr_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_psr_OFFSET)
 
 #endif /* ZEPHYR_ARCH_SPARC_INCLUDE_OFFSETS_SHORT_ARCH_H_ */

--- a/arch/x86/core/fatal.c
+++ b/arch/x86/core/fatal.c
@@ -416,7 +416,7 @@ FUNC_NORETURN void z_x86_fatal_error(unsigned int reason,
 		}
 #endif
 	}
-	z_fatal_error(reason, esf);
+	z_fatal_error(reason, esf, NULL);
 	CODE_UNREACHABLE;
 }
 

--- a/arch/x86/core/intel64/irq.c
+++ b/arch/x86/core/intel64/irq.c
@@ -35,7 +35,7 @@ static const struct device *const vtd = DEVICE_DT_GET_ONE(intel_vt_d);
 static void irq_spurious(const void *arg)
 {
 	LOG_ERR("Spurious interrupt, vector %d\n", (uint32_t)(uint64_t)arg);
-	z_fatal_error(K_ERR_SPURIOUS_IRQ, NULL);
+	z_fatal_error(K_ERR_SPURIOUS_IRQ, NULL, NULL);
 }
 
 void x86_64_irq_init(void)

--- a/arch/x86/core/offsets/ia32_offsets.c
+++ b/arch/x86/core/offsets/ia32_offsets.c
@@ -50,7 +50,7 @@ GEN_OFFSET_SYM(_thread_arch_t, preempFloatReg);
 GEN_ABSOLUTE_SYM(_K_THREAD_NO_FLOAT_SIZEOF,
 		 sizeof(struct k_thread) - sizeof(tPreempFloatReg));
 
-GEN_OFFSET_SYM(_callee_saved_t, esp);
+GEN_OFFSET_STRUCT(arch_csf, esp);
 
 /* struct arch_esf structure member offsets */
 GEN_OFFSET_STRUCT(arch_esf, eflags);

--- a/arch/x86/core/offsets/intel64_offsets.c
+++ b/arch/x86/core/offsets/intel64_offsets.c
@@ -6,15 +6,15 @@
 #ifndef _X86_OFFSETS_INC_
 #define _X86_OFFSETS_INC_
 
-GEN_OFFSET_SYM(_callee_saved_t, rsp);
-GEN_OFFSET_SYM(_callee_saved_t, rbp);
-GEN_OFFSET_SYM(_callee_saved_t, rbx);
-GEN_OFFSET_SYM(_callee_saved_t, r12);
-GEN_OFFSET_SYM(_callee_saved_t, r13);
-GEN_OFFSET_SYM(_callee_saved_t, r14);
-GEN_OFFSET_SYM(_callee_saved_t, r15);
-GEN_OFFSET_SYM(_callee_saved_t, rip);
-GEN_OFFSET_SYM(_callee_saved_t, rflags);
+GEN_OFFSET_STRUCT(arch_csf, rsp);
+GEN_OFFSET_STRUCT(arch_csf, rbp);
+GEN_OFFSET_STRUCT(arch_csf, rbx);
+GEN_OFFSET_STRUCT(arch_csf, r12);
+GEN_OFFSET_STRUCT(arch_csf, r13);
+GEN_OFFSET_STRUCT(arch_csf, r14);
+GEN_OFFSET_STRUCT(arch_csf, r15);
+GEN_OFFSET_STRUCT(arch_csf, rip);
+GEN_OFFSET_STRUCT(arch_csf, rflags);
 
 GEN_OFFSET_SYM(_thread_arch_t, rax);
 GEN_OFFSET_SYM(_thread_arch_t, rcx);

--- a/arch/x86/include/ia32/offsets_short_arch.h
+++ b/arch/x86/include/ia32/offsets_short_arch.h
@@ -22,7 +22,7 @@
 	(___thread_t_arch_OFFSET + ___thread_arch_t_excNestCount_OFFSET)
 
 #define _thread_offset_to_esp \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_esp_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_esp_OFFSET)
 
 #define _thread_offset_to_preempFloatReg \
 	(___thread_t_arch_OFFSET + ___thread_arch_t_preempFloatReg_OFFSET)

--- a/arch/x86/include/intel64/offsets_short_arch.h
+++ b/arch/x86/include/intel64/offsets_short_arch.h
@@ -9,31 +9,31 @@
 #include <zephyr/offsets.h>
 
 #define _thread_offset_to_rsp \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_rsp_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_rsp_OFFSET)
 
 #define _thread_offset_to_rbx \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_rbx_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_rbx_OFFSET)
 
 #define _thread_offset_to_rbp \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_rbp_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_rbp_OFFSET)
 
 #define _thread_offset_to_r12 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_r12_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_r12_OFFSET)
 
 #define _thread_offset_to_r13 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_r13_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_r13_OFFSET)
 
 #define _thread_offset_to_r14 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_r14_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_r14_OFFSET)
 
 #define _thread_offset_to_r15 \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_r15_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_r15_OFFSET)
 
 #define _thread_offset_to_rip \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_rip_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_rip_OFFSET)
 
 #define _thread_offset_to_rflags \
-	(___thread_t_callee_saved_OFFSET + ___callee_saved_t_rflags_OFFSET)
+	(___thread_t_callee_saved_OFFSET + __struct_arch_csf_rflags_OFFSET)
 
 #define _thread_offset_to_rax \
 	(___thread_t_arch_OFFSET + ___thread_arch_t_rax_OFFSET)

--- a/arch/xtensa/core/fatal.c
+++ b/arch/xtensa/core/fatal.c
@@ -106,7 +106,7 @@ void xtensa_fatal_error(unsigned int reason, const struct arch_esf *esf)
 	}
 #endif /* CONFIG_EXCEPTION_DEBUG */
 
-	z_fatal_error(reason, esf);
+	z_fatal_error(reason, esf, NULL);
 }
 
 #if defined(CONFIG_SIMULATOR_XTENSA) || defined(XT_SIMULATOR)

--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -251,6 +251,11 @@ Modem
 Shell
 =====
 
+Ztest
+=====
+
+* ``ztest_post_fatal_error_hook`` now accepts an additional ``struct arch_csf *pCsf``.
+
 * ``kernel threads`` and ``kernel stacks`` shell command have been renamed to
   ``kernel thread list`` & ``kernel thread stacks``
 

--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -26,6 +26,9 @@ Kernel
 
 * The named struct ``_callee_saved_t`` is now deprecated. Use ``struct arch_csf`` instead. (:github:`78029`)
 
+* The fatal handling APIs - ``k_sys_fatal_error_handler`` & ``z_fatal_error`` have been updated to accept
+  an additional ``struct arch_csf`` argument. (:github:`78029`)
+
 Boards
 ******
 

--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -21,6 +21,11 @@ Build System
 Kernel
 ******
 
+* All architectures are now required to define the new ``struct arch_csf``, which describes the
+  callee-saved-registers frame. This new struct replaces the named struct ``_callee_saved_t``. (:github:`78029`)
+
+* The named struct ``_callee_saved_t`` is now deprecated. Use ``struct arch_csf`` instead. (:github:`78029`)
+
 Boards
 ******
 

--- a/include/zephyr/arch/arc/thread.h
+++ b/include/zephyr/arch/arc/thread.h
@@ -37,7 +37,6 @@ extern "C" {
 struct arch_csf {
 	uintptr_t sp; /* r28 */
 };
-typedef struct arch_csf _callee_saved_t;
 
 struct _thread_arch {
 

--- a/include/zephyr/arch/arc/thread.h
+++ b/include/zephyr/arch/arc/thread.h
@@ -11,7 +11,7 @@
  * This file contains definitions for
  *
  *  struct _thread_arch
- *  struct _callee_saved
+ *  struct arch_csf
  *
  * necessary to instantiate instances of struct k_thread.
  */
@@ -34,10 +34,10 @@
 extern "C" {
 #endif
 
-struct _callee_saved {
+struct arch_csf {
 	uintptr_t sp; /* r28 */
 };
-typedef struct _callee_saved _callee_saved_t;
+typedef struct arch_csf _callee_saved_t;
 
 struct _thread_arch {
 

--- a/include/zephyr/arch/arch_interface.h
+++ b/include/zephyr/arch/arch_interface.h
@@ -39,6 +39,7 @@ extern "C" {
 #endif
 
 /* NOTE: We cannot pull in kernel.h here, need some forward declarations  */
+struct arch_csf;
 struct arch_esf;
 struct k_thread;
 struct k_mem_domain;
@@ -47,6 +48,7 @@ typedef struct z_thread_stack_element k_thread_stack_t;
 
 typedef void (*k_thread_entry_t)(void *p1, void *p2, void *p3);
 
+__deprecated typedef struct arch_csf _callee_saved_t;
 __deprecated typedef struct arch_esf z_arch_esf_t;
 
 /**

--- a/include/zephyr/arch/arm/cortex_a_r/exception.h
+++ b/include/zephyr/arch/arm/cortex_a_r/exception.h
@@ -48,7 +48,7 @@ struct __fpu_sf {
  */
 #if defined(CONFIG_EXTRA_EXCEPTION_INFO)
 struct __extra_esf_info {
-	_callee_saved_t *callee;
+	struct arch_csf *callee;
 	uint32_t msp;
 	uint32_t exc_return;
 };

--- a/include/zephyr/arch/arm/cortex_m/exception.h
+++ b/include/zephyr/arch/arm/cortex_m/exception.h
@@ -92,7 +92,7 @@ struct __fpu_sf {
  */
 #if defined(CONFIG_EXTRA_EXCEPTION_INFO)
 struct __extra_esf_info {
-	_callee_saved_t *callee;
+	struct arch_csf *callee;
 	uint32_t msp;
 	uint32_t exc_return;
 };

--- a/include/zephyr/arch/arm/thread.h
+++ b/include/zephyr/arch/arm/thread.h
@@ -11,7 +11,7 @@
  * This file contains definitions for
  *
  *  struct _thread_arch
- *  struct _callee_saved
+ *  struct arch_csf
   *
  * necessary to instantiate instances of struct k_thread.
  */
@@ -22,7 +22,7 @@
 #ifndef _ASMLANGUAGE
 #include <zephyr/types.h>
 
-struct _callee_saved {
+struct arch_csf {
 	uint32_t v1;  /* r4 */
 	uint32_t v2;  /* r5 */
 	uint32_t v3;  /* r6 */
@@ -37,7 +37,7 @@ struct _callee_saved {
 #endif
 };
 
-typedef struct _callee_saved _callee_saved_t;
+typedef struct arch_csf _callee_saved_t;
 
 #if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
 struct _preempt_float {

--- a/include/zephyr/arch/arm/thread.h
+++ b/include/zephyr/arch/arm/thread.h
@@ -37,8 +37,6 @@ struct arch_csf {
 #endif
 };
 
-typedef struct arch_csf _callee_saved_t;
-
 #if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
 struct _preempt_float {
 	float  s16;

--- a/include/zephyr/arch/arm64/thread.h
+++ b/include/zephyr/arch/arm64/thread.h
@@ -40,8 +40,6 @@ struct arch_csf {
 	uint64_t lr;
 };
 
-typedef struct arch_csf _callee_saved_t;
-
 struct z_arm64_fp_context {
 	__int128 q0,  q1,  q2,  q3,  q4,  q5,  q6,  q7;
 	__int128 q8,  q9,  q10, q11, q12, q13, q14, q15;

--- a/include/zephyr/arch/arm64/thread.h
+++ b/include/zephyr/arch/arm64/thread.h
@@ -11,7 +11,7 @@
  * This file contains definitions for
  *
  *  struct _thread_arch
- *  struct _callee_saved
+ *  struct arch_csf
  *
  * necessary to instantiate instances of struct k_thread.
  */
@@ -23,7 +23,7 @@
 #include <zephyr/types.h>
 #include <zephyr/arch/arm64/mm.h>
 
-struct _callee_saved {
+struct arch_csf {
 	uint64_t x19;
 	uint64_t x20;
 	uint64_t x21;
@@ -40,7 +40,7 @@ struct _callee_saved {
 	uint64_t lr;
 };
 
-typedef struct _callee_saved _callee_saved_t;
+typedef struct arch_csf _callee_saved_t;
 
 struct z_arm64_fp_context {
 	__int128 q0,  q1,  q2,  q3,  q4,  q5,  q6,  q7;

--- a/include/zephyr/arch/mips/thread.h
+++ b/include/zephyr/arch/mips/thread.h
@@ -41,7 +41,6 @@ struct arch_csf {
 	unsigned long s7;	/* saved register */
 	unsigned long s8;	/* saved register AKA fp */
 };
-typedef struct arch_csf _callee_saved_t;
 
 struct _thread_arch {
 	uint32_t swap_return_value; /* Return value of z_swap() */

--- a/include/zephyr/arch/mips/thread.h
+++ b/include/zephyr/arch/mips/thread.h
@@ -13,7 +13,7 @@
  * This file contains definitions for
  *
  *  struct _thread_arch
- *  struct _callee_saved
+ *  struct arch_csf
  *
  * necessary to instantiate instances of struct k_thread.
  */
@@ -28,7 +28,7 @@
  * The following structure defines the list of registers that need to be
  * saved/restored when a cooperative context switch occurs.
  */
-struct _callee_saved {
+struct arch_csf {
 	unsigned long sp;	/* Stack pointer */
 
 	unsigned long s0;	/* saved register */
@@ -41,7 +41,7 @@ struct _callee_saved {
 	unsigned long s7;	/* saved register */
 	unsigned long s8;	/* saved register AKA fp */
 };
-typedef struct _callee_saved _callee_saved_t;
+typedef struct arch_csf _callee_saved_t;
 
 struct _thread_arch {
 	uint32_t swap_return_value; /* Return value of z_swap() */

--- a/include/zephyr/arch/nios2/thread.h
+++ b/include/zephyr/arch/nios2/thread.h
@@ -51,8 +51,6 @@ struct arch_csf {
 	uint32_t retval;
 };
 
-typedef struct arch_csf _callee_saved_t;
-
 struct _thread_arch {
 	/* nothing for now */
 };

--- a/include/zephyr/arch/nios2/thread.h
+++ b/include/zephyr/arch/nios2/thread.h
@@ -11,7 +11,7 @@
  * This file contains definitions for
  *
  *  struct _thread_arch
- *  struct _callee_saved
+ *  struct arch_csf
  *
  * necessary to instantiate instances of struct k_thread.
  */
@@ -22,7 +22,7 @@
 #ifndef _ASMLANGUAGE
 #include <zephyr/types.h>
 
-struct _callee_saved {
+struct arch_csf {
 	/* General purpose callee-saved registers */
 	uint32_t r16;
 	uint32_t r17;
@@ -51,7 +51,7 @@ struct _callee_saved {
 	uint32_t retval;
 };
 
-typedef struct _callee_saved _callee_saved_t;
+typedef struct arch_csf _callee_saved_t;
 
 struct _thread_arch {
 	/* nothing for now */

--- a/include/zephyr/arch/posix/thread.h
+++ b/include/zephyr/arch/posix/thread.h
@@ -12,7 +12,7 @@
  * This file contains definitions for
  *
  *  struct _thread_arch
- *  struct _callee_saved
+ *  struct arch_csf
  *
  * necessary to instantiate instances of struct k_thread.
  */
@@ -27,7 +27,7 @@
 extern "C" {
 #endif
 
-struct _callee_saved {
+struct arch_csf {
 	/* IRQ status before irq_lock() and call to z_swap() */
 	uint32_t key;
 

--- a/include/zephyr/arch/riscv/thread.h
+++ b/include/zephyr/arch/riscv/thread.h
@@ -45,7 +45,6 @@ struct arch_csf {
 	unsigned long s11;	/* saved register */
 #endif
 };
-typedef struct arch_csf _callee_saved_t;
 
 #if !defined(RV_FP_TYPE)
 #ifdef CONFIG_CPU_HAS_FPU_DOUBLE_PRECISION

--- a/include/zephyr/arch/riscv/thread.h
+++ b/include/zephyr/arch/riscv/thread.h
@@ -11,7 +11,7 @@
  * This file contains definitions for
  *
  *  struct _thread_arch
- *  struct _callee_saved
+ *  struct arch_csf
  *
  * necessary to instantiate instances of struct k_thread.
  */
@@ -26,7 +26,7 @@
  * The following structure defines the list of registers that need to be
  * saved/restored when a context switch occurs.
  */
-struct _callee_saved {
+struct arch_csf {
 	unsigned long sp;	/* Stack pointer, (x2 register) */
 	unsigned long ra;	/* return address */
 
@@ -45,7 +45,7 @@ struct _callee_saved {
 	unsigned long s11;	/* saved register */
 #endif
 };
-typedef struct _callee_saved _callee_saved_t;
+typedef struct arch_csf _callee_saved_t;
 
 #if !defined(RV_FP_TYPE)
 #ifdef CONFIG_CPU_HAS_FPU_DOUBLE_PRECISION

--- a/include/zephyr/arch/sparc/thread.h
+++ b/include/zephyr/arch/sparc/thread.h
@@ -11,7 +11,7 @@
  * This file contains definitions for
  *
  *  struct _thread_arch
- *  struct _callee_saved
+ *  struct arch_csf
  *
  * necessary to instantiate instances of struct k_thread.
  */
@@ -26,7 +26,7 @@
  * The following structure defines the list of registers that need to be
  * saved/restored when a cooperative context switch occurs.
  */
-struct _callee_saved {
+struct arch_csf {
 	/* y register used by mul/div */
 	uint32_t y;
 
@@ -63,7 +63,7 @@ struct _callee_saved {
 	uint32_t o7;
 
 };
-typedef struct _callee_saved _callee_saved_t;
+typedef struct arch_csf _callee_saved_t;
 
 struct _thread_arch {
 	/* empty */

--- a/include/zephyr/arch/sparc/thread.h
+++ b/include/zephyr/arch/sparc/thread.h
@@ -63,7 +63,6 @@ struct arch_csf {
 	uint32_t o7;
 
 };
-typedef struct arch_csf _callee_saved_t;
 
 struct _thread_arch {
 	/* empty */

--- a/include/zephyr/arch/x86/ia32/thread.h
+++ b/include/zephyr/arch/x86/ia32/thread.h
@@ -76,8 +76,6 @@ struct arch_csf {
 
 };
 
-typedef struct arch_csf _callee_saved_t;
-
 /*
  * The macros CONFIG_{LAZY|EAGER}_FPU_SHARING shall be set to indicate that the
  * saving/restoring of the traditional x87 floating point (and MMX) registers

--- a/include/zephyr/arch/x86/ia32/thread.h
+++ b/include/zephyr/arch/x86/ia32/thread.h
@@ -11,7 +11,7 @@
  * This file contains definitions for
  *
  *  struct _thread_arch
- *  struct _callee_saved
+ *  struct arch_csf
  *
  * necessary to instantiate instances of struct k_thread.
  */
@@ -58,7 +58,7 @@
  * switch occurs.
  */
 
-struct _callee_saved {
+struct arch_csf {
 	unsigned long esp;
 
 	/*
@@ -76,7 +76,7 @@ struct _callee_saved {
 
 };
 
-typedef struct _callee_saved _callee_saved_t;
+typedef struct arch_csf _callee_saved_t;
 
 /*
  * The macros CONFIG_{LAZY|EAGER}_FPU_SHARING shall be set to indicate that the

--- a/include/zephyr/arch/x86/intel64/thread.h
+++ b/include/zephyr/arch/x86/intel64/thread.h
@@ -96,13 +96,13 @@ struct x86_tss64 {
 typedef struct x86_tss64 x86_tss64_t;
 
 /*
- * The _callee_saved registers are unconditionally saved/restored across
+ * The arch_csf registers are unconditionally saved/restored across
  * context switches; the _thread_arch registers are only preserved when
  * the thread is interrupted. _arch_thread.flags tells __resume when to
  * cheat and only restore the first set. For more details see locore.S.
  */
 
-struct _callee_saved {
+struct arch_csf {
 	uint64_t rsp;
 	uint64_t rbx;
 	uint64_t rbp;
@@ -114,7 +114,7 @@ struct _callee_saved {
 	uint64_t rflags;
 };
 
-typedef struct _callee_saved _callee_saved_t;
+typedef struct arch_csf _callee_saved_t;
 
 struct _thread_arch {
 	uint8_t flags;

--- a/include/zephyr/arch/x86/intel64/thread.h
+++ b/include/zephyr/arch/x86/intel64/thread.h
@@ -114,8 +114,6 @@ struct arch_csf {
 	uint64_t rflags;
 };
 
-typedef struct arch_csf _callee_saved_t;
-
 struct _thread_arch {
 	uint8_t flags;
 

--- a/include/zephyr/arch/xtensa/thread.h
+++ b/include/zephyr/arch/xtensa/thread.h
@@ -23,8 +23,6 @@ struct arch_csf {
 	char dummy;
 };
 
-typedef struct arch_csf _callee_saved_t;
-
 struct _thread_arch {
 	uint32_t last_cpu;
 #ifdef CONFIG_USERSPACE

--- a/include/zephyr/arch/xtensa/thread.h
+++ b/include/zephyr/arch/xtensa/thread.h
@@ -19,11 +19,11 @@
  * field exists for sizeof compatibility with C++.
  */
 
-struct _callee_saved {
+struct arch_csf {
 	char dummy;
 };
 
-typedef struct _callee_saved _callee_saved_t;
+typedef struct arch_csf _callee_saved_t;
 
 struct _thread_arch {
 	uint32_t last_cpu;

--- a/include/zephyr/fatal.h
+++ b/include/zephyr/fatal.h
@@ -64,8 +64,11 @@ FUNC_NORETURN void k_fatal_halt(unsigned int reason);
  * @param reason The reason for the fatal error
  * @param esf Exception context, with details and partial or full register
  *            state when the error occurred. May in some cases be NULL.
+ * @param csf Callee-saved-registers, with details and partial or full register
+ *            state when the error occurred. May in some cases be NULL.
  */
-void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *esf);
+void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *esf,
+			       const struct arch_csf *csf);
 
 /**
  * @brief Called by architecture code upon a fatal error.
@@ -80,8 +83,10 @@ void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *esf);
  * @param reason The reason for the fatal error
  * @param esf Exception context, with details and partial or full register
  *            state when the error occurred. May in some cases be NULL.
+ * @param csf Callee-saved-registers, with details and partial or full register
+ *            state when the error occurred. May in some cases be NULL.
  */
-void z_fatal_error(unsigned int reason, const struct arch_esf *esf);
+void z_fatal_error(unsigned int reason, const struct arch_esf *esf, const struct arch_csf *csf);
 
 /** @} */
 

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -6045,7 +6045,7 @@ static inline void k_cpu_atomic_idle(unsigned int key)
  */
 #define z_except_reason(reason) do { \
 		__EXCEPT_LOC();              \
-		z_fatal_error(reason, NULL); \
+		z_fatal_error(reason, NULL, NULL); \
 	} while (false)
 
 #endif /* _ARCH__EXCEPT */

--- a/include/zephyr/kernel/thread.h
+++ b/include/zephyr/kernel/thread.h
@@ -261,7 +261,7 @@ struct k_thread {
 	struct _thread_base base;
 
 	/** defined by the architecture, but all archs need these */
-	struct _callee_saved callee_saved;
+	struct arch_csf callee_saved;
 
 	/** static thread init data */
 	void *init_data;

--- a/kernel/fatal.c
+++ b/kernel/fatal.c
@@ -35,9 +35,10 @@ FUNC_NORETURN __weak void arch_system_halt(unsigned int reason)
 
 /* LCOV_EXCL_START */
 __weak void k_sys_fatal_error_handler(unsigned int reason,
-				      const struct arch_esf *esf)
+				      const struct arch_esf *esf, const struct arch_csf *csf)
 {
 	ARG_UNUSED(esf);
+	ARG_UNUSED(csf);
 
 	LOG_PANIC();
 	LOG_ERR("Halting system");
@@ -82,7 +83,7 @@ FUNC_NORETURN void k_fatal_halt(unsigned int reason)
 }
 /* LCOV_EXCL_STOP */
 
-void z_fatal_error(unsigned int reason, const struct arch_esf *esf)
+void z_fatal_error(unsigned int reason, const struct arch_esf *esf, const struct arch_csf *csf)
 {
 	/* We can't allow this code to be preempted, but don't need to
 	 * synchronize between CPUs, so an arch-layer lock is
@@ -116,7 +117,7 @@ void z_fatal_error(unsigned int reason, const struct arch_esf *esf)
 
 	coredump(reason, esf, thread);
 
-	k_sys_fatal_error_handler(reason, esf);
+	k_sys_fatal_error_handler(reason, esf, csf);
 
 	/* If the system fatal error handler returns, then kill the faulting
 	 * thread; a policy decision was made not to hang the system.

--- a/samples/bluetooth/hci_ipc/src/main.c
+++ b/samples/bluetooth/hci_ipc/src/main.c
@@ -320,8 +320,11 @@ void bt_ctlr_assert_handle(char *file, uint32_t line)
 #endif /* CONFIG_BT_CTLR_ASSERT_HANDLER */
 
 #if defined(CONFIG_BT_HCI_VS_FATAL_ERROR)
-void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *esf)
+void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *esf,
+			       const struct arch_csf *csf)
 {
+	ARG_UNUSED(csf);
+
 	/* Disable interrupts, this is unrecoverable */
 	(void)irq_lock();
 

--- a/samples/subsys/llext/edk/app/src/main.c
+++ b/samples/subsys/llext/edk/app/src/main.c
@@ -100,8 +100,11 @@ static void user_function(void *p1, void *p2, void *p3)
 	printk("[app]Thread %p done\n", k_current_get());
 }
 
-void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *esf)
+void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *esf,
+			       const struct arch_csf *csf)
 {
+	ARG_UNUSED(csf);
+
 	int i;
 
 	printk("[app]Fatal handler! Thread: %p\n", k_current_get());

--- a/submanifests/optional.yaml
+++ b/submanifests/optional.yaml
@@ -34,7 +34,7 @@ manifest:
       groups:
         - optional
     - name: sof
-      revision: 0e4c4efcaae858036027607e88406d59bd2a31d8
+      revision: pull/49/head
       path: modules/audio/sof
       remote: upstream
       groups:

--- a/subsys/testsuite/ztest/include/zephyr/ztest_error_hook.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest_error_hook.h
@@ -38,7 +38,7 @@ __syscall void ztest_set_fault_valid(bool valid);
  * By default, it will do nothing before leaving error handler.
  */
 void ztest_post_fatal_error_hook(unsigned int reason,
-		const struct arch_esf *pEsf);
+		const struct arch_esf *pEsf, const struct arch_csf *pCsf);
 
 #endif
 

--- a/subsys/testsuite/ztest/src/ztest_error_hook.c
+++ b/subsys/testsuite/ztest/src/ztest_error_hook.c
@@ -42,8 +42,11 @@ static inline void z_vrfy_ztest_set_fault_valid(bool valid)
 #endif
 
 __weak void ztest_post_fatal_error_hook(unsigned int reason,
-		const struct arch_esf *pEsf)
+		const struct arch_esf *pEsf, const struct arch_csf *pCsf)
 {
+	ARG_UNUSED(reason);
+	ARG_UNUSED(pEsf);
+	ARG_UNUSED(pCsf);
 }
 
 void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf,
@@ -61,7 +64,7 @@ void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf,
 		reset_stored_fault_status();
 
 		/* do some action after expected fatal error happened */
-		ztest_post_fatal_error_hook(reason, pEsf);
+		ztest_post_fatal_error_hook(reason, pEsf, pCsf);
 	} else {
 		printk("Fatal error was unexpected, aborting...\n");
 		k_fatal_halt(reason);

--- a/subsys/testsuite/ztest/src/ztest_error_hook.c
+++ b/subsys/testsuite/ztest/src/ztest_error_hook.c
@@ -46,7 +46,8 @@ __weak void ztest_post_fatal_error_hook(unsigned int reason,
 {
 }
 
-void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf)
+void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf,
+			       const struct arch_csf *pCsf)
 {
 	k_tid_t curr_tid = k_current_get();
 	bool valid_fault = (curr_tid == valid_fault_tid) || fault_in_isr;

--- a/subsys/testsuite/ztest/unittest/include/zephyr/arch/cpu.h
+++ b/subsys/testsuite/ztest/unittest/include/zephyr/arch/cpu.h
@@ -20,8 +20,6 @@ struct arch_csf {
 #endif
 };
 
-typedef struct arch_csf _callee_saved_t;
-
 struct _thread_arch {
 #ifdef CONFIG_CPP
 	/* C++ does not allow empty structs, add an extra 1 byte */

--- a/subsys/testsuite/ztest/unittest/include/zephyr/arch/cpu.h
+++ b/subsys/testsuite/ztest/unittest/include/zephyr/arch/cpu.h
@@ -13,14 +13,14 @@ extern "C" {
 #endif
 
 /* Architecture thread structure */
-struct _callee_saved {
+struct arch_csf {
 #ifdef CONFIG_CPP
 	/* C++ does not allow empty structs, add an extra 1 byte */
 	uint8_t c;
 #endif
 };
 
-typedef struct _callee_saved _callee_saved_t;
+typedef struct arch_csf _callee_saved_t;
 
 struct _thread_arch {
 #ifdef CONFIG_CPP

--- a/tests/arch/arm/arm_hardfault_validation/src/arm_hardfault.c
+++ b/tests/arch/arm/arm_hardfault_validation/src/arm_hardfault.c
@@ -13,8 +13,12 @@
 
 static volatile int expected_reason = -1;
 
-void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf)
+void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf,
+			       const struct arch_csf *pCsf)
 {
+	ARG_UNUSED(pEsf);
+	ARG_UNUSED(pCsf);
+
 	static bool triggered_synchronous_svc;
 
 	TC_PRINT("Caught system error -- reason %d\n", reason);

--- a/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
+++ b/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
@@ -51,7 +51,7 @@ static int check_esf_matches_expectations(const struct arch_esf *pEsf)
 		(callee_regs->v7 /* r10 */ == 10) &&
 		(callee_regs->v8 /* r11 */ == 11);
 	if (!callee_regs_match_expected) {
-		printk("_callee_saved_t member of ESF is incorrect\n");
+		printk("struct arch_csf member of ESF is incorrect\n");
 		return -1;
 	}
 

--- a/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
+++ b/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
@@ -40,7 +40,7 @@ static int check_esf_matches_expectations(const struct arch_esf *pEsf)
 	}
 
 #if defined(CONFIG_EXTRA_EXCEPTION_INFO)
-	const struct _callee_saved *callee_regs = pEsf->extra_info.callee;
+	const struct arch_csf *callee_regs = pEsf->extra_info.callee;
 	const bool callee_regs_match_expected =
 		(callee_regs->v1 /* r4 */ == 4) &&
 		(callee_regs->v2 /* r5 */ == 5) &&

--- a/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
+++ b/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
@@ -88,8 +88,11 @@ static int check_esf_matches_expectations(const struct arch_esf *pEsf)
 	return 0;
 }
 
-void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf)
+void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf,
+			       const struct arch_csf *pCsf)
 {
+	ARG_UNUSED(pCsf);
+
 	TC_PRINT("Caught system error -- reason %d\n", reason);
 
 	if (expected_reason == -1) {

--- a/tests/arch/arm/arm_no_multithreading/src/main.c
+++ b/tests/arch/arm/arm_no_multithreading/src/main.c
@@ -36,8 +36,12 @@ void arm_isr_handler(const void *args)
 	test_flag++;
 }
 
-void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf)
+void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf,
+			       const struct arch_csf *pCsf)
 {
+	ARG_UNUSED(pEsf);
+	ARG_UNUSED(pCsf);
+
 	printk("Caught system error -- reason %d\n", reason);
 
 	if (expected_reason == -1) {

--- a/tests/arch/arm/arm_thread_swap/src/arm_thread_arch.c
+++ b/tests/arch/arm/arm_thread_swap/src/arm_thread_arch.c
@@ -51,18 +51,18 @@ bool volatile switch_flag;
 
 struct k_thread *p_ztest_thread;
 
-_callee_saved_t ztest_thread_callee_saved_regs_container;
+struct arch_csf ztest_thread_callee_saved_regs_container;
 int ztest_swap_return_val;
 
 /* Arbitrary values for the callee-saved registers,
  * enforced in the beginning of the test.
  */
-const _callee_saved_t ztest_thread_callee_saved_regs_init = {
+const struct arch_csf ztest_thread_callee_saved_regs_init = {
 	.v1 = 0x12345678, .v2 = 0x23456789, .v3 = 0x3456789a, .v4 = 0x456789ab,
 	.v5 = 0x56789abc, .v6 = 0x6789abcd, .v7 = 0x789abcde, .v8 = 0x89abcdef
 };
 
-static void load_callee_saved_regs(const _callee_saved_t *regs)
+static void load_callee_saved_regs(const struct arch_csf *regs)
 {
 	/* Load the callee-saved registers with given values */
 #if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
@@ -95,8 +95,8 @@ static void load_callee_saved_regs(const _callee_saved_t *regs)
 	barrier_dsync_fence_full();
 }
 
-static void verify_callee_saved(const _callee_saved_t *src,
-		const _callee_saved_t *dst)
+static void verify_callee_saved(const struct arch_csf *src,
+		const struct arch_csf *dst)
 {
 	/* Verify callee-saved registers are as expected */
 	zassert_true((src->v1 == dst->v1)
@@ -259,14 +259,14 @@ static void alt_thread_entry(void *p1, void *p2, void *p3)
 	 * registers properly in its corresponding callee-saved container.
 	 */
 	verify_callee_saved(
-		(const _callee_saved_t *)&p_ztest_thread->callee_saved,
+		(const struct arch_csf *)&p_ztest_thread->callee_saved,
 		&ztest_thread_callee_saved_regs_container);
 
 	/* Zero the container of the callee-saved registers, to validate,
 	 * later, that it is populated properly.
 	 */
 	memset(&ztest_thread_callee_saved_regs_container,
-		0, sizeof(_callee_saved_t));
+		0, sizeof(struct arch_csf));
 
 #if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
 
@@ -558,7 +558,7 @@ ZTEST(arm_thread_swap, test_arm_thread_swap)
 	 * The container will, later, be populated by the swap
 	 * mechanism.
 	 */
-	memset(&_current->callee_saved, 0, sizeof(_callee_saved_t));
+	memset(&_current->callee_saved, 0, sizeof(struct arch_csf));
 
 	/* Verify context-switch has not occurred yet. */
 	test_flag = switch_flag;

--- a/tests/arch/x86/static_idt/src/main.c
+++ b/tests/arch/x86/static_idt/src/main.c
@@ -47,8 +47,12 @@ static volatile int int_handler_executed;
 /* Assume the spurious interrupt handler will execute and abort the task */
 static volatile int spur_handler_aborted_thread = 1;
 
-void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *esf)
+void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *esf,
+			       const struct arch_csf *csf)
 {
+	ARG_UNUSED(esf);
+	ARG_UNUSED(csf);
+
 	if (reason != K_ERR_SPURIOUS_IRQ) {
 		printk("wrong error reason\n");
 		k_fatal_halt(reason);

--- a/tests/bluetooth/audio/mocks/src/fatal.c
+++ b/tests/bluetooth/audio/mocks/src/fatal.c
@@ -7,7 +7,11 @@
 #include <zephyr/fatal.h>
 #include <zephyr/kernel.h>
 
-void z_fatal_error(unsigned int reason, const struct arch_esf *esf)
+void z_fatal_error(unsigned int reason, const struct arch_esf *esf, const struct arch_csf *csf)
 {
+	ARG_UNUSED(reason);
+	ARG_UNUSED(esf);
+	ARG_UNUSED(csf);
+
 	ztest_test_fail();
 }

--- a/tests/drivers/coredump/coredump_api/src/main.c
+++ b/tests/drivers/coredump/coredump_api/src/main.c
@@ -32,9 +32,11 @@ static struct coredump_mem_region_node dump_region0 = {
 	.size = sizeof(values_to_dump)
 };
 
-void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf)
+void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf,
+			       const struct arch_csf *pCsf)
 {
 	ARG_UNUSED(pEsf);
+	ARG_UNUSED(pCsf);
 
 	printk("%s as expected; reason = %u; halting ...\n", __func__, reason);
 

--- a/tests/kernel/fatal/exception/src/main.c
+++ b/tests/kernel/fatal/exception/src/main.c
@@ -50,8 +50,12 @@ volatile int rv;
 
 static ZTEST_DMEM volatile int expected_reason = -1;
 
-void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf)
+void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf,
+			       const struct arch_csf *pCsf)
 {
+	ARG_UNUSED(pEsf);
+	ARG_UNUSED(pCsf);
+
 	TC_PRINT("Caught system error -- reason %d\n", reason);
 
 	if (expected_reason == -1) {

--- a/tests/kernel/fatal/message_capture/src/main.c
+++ b/tests/kernel/fatal/message_capture/src/main.c
@@ -12,8 +12,12 @@ static volatile int expected_reason = -1;
 
 void z_thread_essential_clear(struct k_thread *thread);
 
-void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf)
+void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf,
+			       const struct arch_csf *pCsf)
 {
+	ARG_UNUSED(pEsf);
+	ARG_UNUSED(pCsf);
+
 	printk("Caught system error -- reason %d\n", reason);
 
 	if (expected_reason == -1) {

--- a/tests/kernel/fatal/no-multithreading/src/main.c
+++ b/tests/kernel/fatal/no-multithreading/src/main.c
@@ -13,8 +13,12 @@
 
 static ZTEST_DMEM volatile int expected_reason = -1;
 
-void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf)
+void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf,
+			       const struct arch_csf *pCsf)
 {
+	ARG_UNUSED(pEsf);
+	ARG_UNUSED(pCsf);
+
 	int rv = TC_PASS;
 
 	TC_PRINT("Caught system error -- reason %d\n", reason);

--- a/tests/kernel/mem_protect/demand_paging/src/main.c
+++ b/tests/kernel/mem_protect/demand_paging/src/main.c
@@ -63,9 +63,12 @@ char *arena;
 __pinned_bss
 static bool expect_fault;
 
-__pinned_func
-void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf)
+__pinned_func void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf,
+					     const struct arch_csf *pCsf)
 {
+	ARG_UNUSED(pEsf);
+	ARG_UNUSED(pCsf);
+
 	printk("Caught system error -- reason %d\n", reason);
 
 	if (expect_fault && reason == 0) {

--- a/tests/kernel/mem_protect/mem_map/src/main.c
+++ b/tests/kernel/mem_protect/mem_map/src/main.c
@@ -33,8 +33,12 @@ volatile bool expect_fault;
 __pinned_noinit
 static uint8_t __aligned(CONFIG_MMU_PAGE_SIZE) test_page[TEST_PAGE_SZ];
 
-void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf)
+void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf,
+			       const struct arch_csf *pCsf)
 {
+	ARG_UNUSED(pEsf);
+	ARG_UNUSED(pCsf);
+
 	printk("Caught system error -- reason %d\n", reason);
 
 	if (expect_fault && reason == 0) {

--- a/tests/kernel/mem_protect/mem_protect/src/common.c
+++ b/tests/kernel/mem_protect/mem_protect/src/common.c
@@ -8,8 +8,12 @@
 
 ZTEST_BMEM volatile bool valid_fault;
 
-void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf)
+void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf,
+			       const struct arch_csf *pCsf)
 {
+	ARG_UNUSED(pEsf);
+	ARG_UNUSED(pCsf);
+
 	printk("Caught system error -- reason %d %d\n", reason, valid_fault);
 	if (valid_fault) {
 		printk("fatal error expected as part of test case\n");

--- a/tests/kernel/mem_protect/protection/src/main.c
+++ b/tests/kernel/mem_protect/protection/src/main.c
@@ -28,8 +28,12 @@
 
 #define INFO(fmt, ...) printk(fmt, ##__VA_ARGS__)
 
-void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf)
+void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf,
+			       const struct arch_csf *pCsf)
 {
+	ARG_UNUSED(pEsf);
+	ARG_UNUSED(pCsf);
+
 	INFO("Caught system error -- reason %d\n", reason);
 	ztest_test_pass();
 }

--- a/tests/kernel/mem_protect/stackprot/src/main.c
+++ b/tests/kernel/mem_protect/stackprot/src/main.c
@@ -15,8 +15,12 @@
 ZTEST_BMEM static int count;
 ZTEST_BMEM static int ret = TC_PASS;
 
-void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *esf)
+void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *esf,
+			       const struct arch_csf *csf)
 {
+	ARG_UNUSED(esf);
+	ARG_UNUSED(csf);
+
 	if (reason != K_ERR_STACK_CHK_FAIL) {
 		printk("wrong error type\n");
 		TC_END_REPORT(TC_FAIL);

--- a/tests/kernel/mem_protect/sys_sem/src/main.c
+++ b/tests/kernel/mem_protect/sys_sem/src/main.c
@@ -568,8 +568,12 @@ ZTEST_USER(sys_sem_1cpu, test_sem_multiple_threads_wait)
  * @}
  */
 
-void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf)
+void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf,
+			       const struct arch_csf *pCsf)
 {
+	ARG_UNUSED(pEsf);
+	ARG_UNUSED(pCsf);
+
 	printk("Caught system error -- reason %d\n", reason);
 	printk("Unexpected fault during test\n");
 	TC_END_REPORT(TC_FAIL);

--- a/tests/kernel/mem_protect/syscalls/src/main.c
+++ b/tests/kernel/mem_protect/syscalls/src/main.c
@@ -36,8 +36,12 @@ char kernel_string[BUF_SIZE];
 char kernel_buf[BUF_SIZE];
 ZTEST_BMEM char user_string[BUF_SIZE];
 
-void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf)
+void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf,
+			       const struct arch_csf *pCsf)
 {
+	ARG_UNUSED(pEsf);
+	ARG_UNUSED(pCsf);
+
 	printk("Caught system error -- reason %d\n", reason);
 	printk("Unexpected fault during test\n");
 	TC_END_REPORT(TC_FAIL);

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -76,8 +76,12 @@ static void set_fault(unsigned int reason)
 	compiler_barrier();
 }
 
-void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf)
+void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf,
+			       const struct arch_csf *pCsf)
 {
+	ARG_UNUSED(pEsf);
+	ARG_UNUSED(pCsf);
+
 	INFO("Caught system error -- reason %d\n", reason);
 
 	if (expect_fault) {

--- a/tests/kernel/mutex/mutex_error_case/src/test_mutex_error.c
+++ b/tests/kernel/mutex/mutex_error_case/src/test_mutex_error.c
@@ -38,9 +38,12 @@ extern struct k_sem offload_sem;
 
 /* A call back function which is hooked in default assert handler. */
 void ztest_post_fatal_error_hook(unsigned int reason,
-		const struct arch_esf *pEsf)
+		const struct arch_esf *pEsf, const struct arch_csf *pCsf)
 
 {
+	ARG_UNUSED(pEsf);
+	ARG_UNUSED(pCsf);
+
 	/* check if expected error */
 	zassert_equal(reason, K_ERR_KERNEL_OOPS);
 }

--- a/tests/kernel/pipe/pipe/src/test_pipe.c
+++ b/tests/kernel/pipe/pipe/src/test_pipe.c
@@ -674,8 +674,12 @@ void pipe_put_get_timeout(void)
 
 /******************************************************************************/
 ZTEST_BMEM bool valid_fault;
-void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf)
+void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf,
+			       const struct arch_csf *pCsf)
 {
+	ARG_UNUSED(pEsf);
+	ARG_UNUSED(pCsf);
+
 	printk("Caught system error -- reason %d\n", reason);
 	if (valid_fault) {
 		valid_fault = false; /* reset back to normal */

--- a/tests/kernel/smp/src/main.c
+++ b/tests/kernel/smp/src/main.c
@@ -757,8 +757,12 @@ ZTEST(smp, test_smp_ipi)
 }
 #endif
 
-void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *esf)
+void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *esf,
+			       const struct arch_csf *csf)
 {
+	ARG_UNUSED(esf);
+	ARG_UNUSED(csf);
+
 	static int trigger;
 
 	if (reason != K_ERR_KERNEL_OOPS) {

--- a/tests/kernel/threads/dynamic_thread/src/main.c
+++ b/tests/kernel/threads/dynamic_thread/src/main.c
@@ -16,8 +16,12 @@ static K_SEM_DEFINE(end_sem, 0, 1);
 static ZTEST_BMEM struct k_thread *dyn_thread;
 static struct k_thread *dynamic_threads[CONFIG_MAX_THREAD_BYTES * 8];
 
-void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *esf)
+void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *esf,
+			       const struct arch_csf *csf)
 {
+	ARG_UNUSED(esf);
+	ARG_UNUSED(csf);
+
 	if (reason != K_ERR_KERNEL_OOPS) {
 		printk("wrong error reason\n");
 		TC_END_REPORT(TC_FAIL);

--- a/tests/kernel/threads/dynamic_thread_stack/src/main.c
+++ b/tests/kernel/threads/dynamic_thread_stack/src/main.c
@@ -179,8 +179,12 @@ static void set_fault(unsigned int reason)
 	compiler_barrier();
 }
 
-void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf)
+void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf,
+			       const struct arch_csf *pCsf)
 {
+	ARG_UNUSED(pEsf);
+	ARG_UNUSED(pCsf);
+
 	if (expect_fault) {
 		if (expected_reason == reason) {
 			printk("System error was expected\n");

--- a/tests/kernel/threads/thread_apis/src/test_essential_thread.c
+++ b/tests/kernel/threads/thread_apis/src/test_essential_thread.c
@@ -60,10 +60,11 @@ ZTEST(threads_lifecycle, test_essential_thread_operation)
 	k_thread_abort(tid);
 }
 
-void k_sys_fatal_error_handler(unsigned int reason,
-				      const struct arch_esf *esf)
+void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *esf,
+			       const struct arch_csf *csf)
 {
 	ARG_UNUSED(esf);
+	ARG_UNUSED(csf);
 	ARG_UNUSED(reason);
 
 	fatal_error_signaled = true;

--- a/tests/lib/mem_blocks/src/main.c
+++ b/tests/lib/mem_blocks/src/main.c
@@ -25,8 +25,12 @@ static sys_multi_mem_blocks_t alloc_group;
 
 static ZTEST_DMEM volatile int expected_reason = -1;
 
-void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf)
+void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf,
+			       const struct arch_csf *pCsf)
 {
+	ARG_UNUSED(pEsf);
+	ARG_UNUSED(pCsf);
+
 	printk("Caught system error -- reason %d\n", reason);
 
 	if (expected_reason == -1) {

--- a/tests/subsys/debug/coredump/src/main.c
+++ b/tests/subsys/debug/coredump/src/main.c
@@ -12,10 +12,11 @@
 #include <zephyr/debug/gcov.h>
 #endif
 
-
-void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf)
+void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf,
+			       const struct arch_csf *pCsf)
 {
 	ARG_UNUSED(pEsf);
+	ARG_UNUSED(pCsf);
 
 	printk("%s is expected; reason = %u; halting ...\n", __func__, reason);
 

--- a/tests/subsys/debug/coredump_backends/src/main.c
+++ b/tests/subsys/debug/coredump_backends/src/main.c
@@ -19,10 +19,12 @@
 static struct k_thread dump_thread;
 static K_THREAD_STACK_DEFINE(dump_stack, STACK_SIZE);
 
-void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf)
+void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf,
+			       const struct arch_csf *pCsf)
 {
 	ARG_UNUSED(reason);
 	ARG_UNUSED(pEsf);
+	ARG_UNUSED(pCsf);
 }
 
 void dump_entry(void *p1, void *p2, void *p3)

--- a/tests/ztest/error_hook/src/main.c
+++ b/tests/ztest/error_hook/src/main.c
@@ -154,8 +154,11 @@ static void release_offload_sem(void)
  * default one.
  */
 void ztest_post_fatal_error_hook(unsigned int reason,
-		const struct arch_esf *pEsf)
+		const struct arch_esf *pEsf, const struct arch_csf *pCsf)
 {
+	ARG_UNUSED(pEsf);
+	ARG_UNUSED(pCsf);
+
 	switch (case_type) {
 	case ZTEST_CATCH_FATAL_ACCESS:
 	case ZTEST_CATCH_FATAL_ILLEAGAL_INSTRUCTION:


### PR DESCRIPTION
- Deprecate `_callee_saved_t`
- Rename `struct _callee_saved` to `struct arch_csf`, and add it to the `arch_interface.h`

The goal is to pass arch-agnostic callee-saved-registers to `k_sys_fatal_error_handler` & `z_fatal_error`, so that the error handlers can do more.

This is somewhat similar to #73593