### PR TITLE
docs: don't show doc version admonition on main

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -5,12 +5,6 @@
       The <a href="/latest/{{ pagename }}.html">latest development version</a>
       of this page may be more current than this released {{ version }} version.
     </div>
-  {% else %}
-    <div class="wy-alert wy-alert-danger" data-nosnippet>
-     This is the documentation for the latest (main) development branch of
-     Zephyr. If you are looking for the documentation of previous releases, use
-     the drop-down list at the bottom of the left panel and select the desired version.
-    </div>
   {% endif %}
   {{ super() }}
 {% endblock %}


### PR DESCRIPTION
https://builds.zephyrproject.io/zephyr/pr/78032/docs/introduction/index.html
vs. https://docs.zephyrproject.org/latest/introduction/index.html

It is hard to justify keeping the version admonition/disclaimer eating up so much real estate on all documentation pages. It was useful when search engines tended to index old versions of the documentation and reminding people where they "landed" was a good idea. Now, it is just taking up space and we can safely assume that people explicitly interested in older releases will find their way to the right place, as our version selector is in a very similar spot to how other projects do it.

Note that the admonition will still be included on "released" versions of the docs, since the "there might be a more current version of this page" admonition is actually useful to have.

So:

<img width="833" alt="image" src="https://github.com/user-attachments/assets/6c324369-8595-4de4-b33c-1d31fcfb42d0">

is going away for "https://docs.zephyrproject.org/latest/"

<img width="836" alt="image" src="https://github.com/user-attachments/assets/8cdb2890-9b22-4fd7-9fdc-05a7bca46d75">

stays on "https://docs.zephyrproject.org/vX.Y.Z/" going forward