### PR TITLE
boards: nordic: nrf54l15dk: enable HWFC

### DIFF
--- a/boards/nordic/nrf54l15dk/nrf54l15_cpuapp_common.dtsi
+++ b/boards/nordic/nrf54l15dk/nrf54l15_cpuapp_common.dtsi
@@ -87,6 +87,7 @@
 
 &uart20 {
 	status = "okay";
+	hw-flow-control;
 };
 
 &gpio0 {

--- a/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l15_cpuflpr.dts
+++ b/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l15_cpuflpr.dts
@@ -48,6 +48,7 @@
 
 &uart30 {
 	status = "okay";
+	hw-flow-control;
 };
 
 &gpio0 {


### PR DESCRIPTION
For both UARTs connected to debugger chip.