### PR TITLE
Bluetooth: Add decoders and definitions for HCI version 6.0

### DIFF
--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -825,6 +825,7 @@ struct bt_hci_rp_configure_data_path {
 #define BT_HCI_VERSION_5_2                      11
 #define BT_HCI_VERSION_5_3                      12
 #define BT_HCI_VERSION_5_4                      13
+#define BT_HCI_VERSION_6_0                      14
 
 #define BT_HCI_OP_READ_LOCAL_VERSION_INFO       BT_OP(BT_OGF_INFO, 0x0001) /* 0x1001 */
 struct bt_hci_rp_read_local_version_info {

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3792,7 +3792,7 @@ const char *bt_hci_get_ver_str(uint8_t core_version)
 {
 	const char * const str[] = {
 		"1.0b", "1.1", "1.2", "2.0", "2.1", "3.0", "4.0", "4.1", "4.2",
-		"5.0", "5.1", "5.2", "5.3", "5.4"
+		"5.0", "5.1", "5.2", "5.3", "5.4", "6.0"
 	};
 
 	if (core_version < ARRAY_SIZE(str)) {

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -891,20 +891,6 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 #endif
 
 #if defined(CONFIG_BT_REMOTE_INFO)
-static const char *ver_str(uint8_t ver)
-{
-	const char * const str[] = {
-		"1.0b", "1.1", "1.2", "2.0", "2.1", "3.0", "4.0", "4.1", "4.2",
-		"5.0", "5.1", "5.2", "5.3", "5.4"
-	};
-
-	if (ver < ARRAY_SIZE(str)) {
-		return str[ver];
-	}
-
-	return "unknown";
-}
-
 static void remote_info_available(struct bt_conn *conn,
 				  struct bt_conn_remote_info *remote_info)
 {
@@ -915,7 +901,7 @@ static void remote_info_available(struct bt_conn *conn,
 	if (IS_ENABLED(CONFIG_BT_REMOTE_VERSION)) {
 		shell_print(ctx_shell,
 			    "Remote LMP version %s (0x%02x) subversion 0x%04x "
-			    "manufacturer 0x%04x", ver_str(remote_info->version),
+			    "manufacturer 0x%04x", bt_hci_get_ver_str(remote_info->version),
 			    remote_info->version, remote_info->subversion,
 			    remote_info->manufacturer);
 	}


### PR DESCRIPTION
The new Core Specification version 6.0 has been adopted, so add the initial definitions for it.