### PR TITLE
[Backport v3.7-branch] manifest: mbedtls: update to 3.6.1

### DIFF
--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -2,6 +2,30 @@
 
 .. _zephyr_3.7:
 
+.. _zephyr_3.7.1:
+
+Zephyr 3.7.1
+############
+
+This is an LTS maintenance release with fixes.
+
+Issues fixed
+************
+
+These GitHub issues were addressed since the previous 3.7.0 tagged release:
+
+
+Mbed TLS
+********
+
+Mbed TLS was updated to version 3.6.1. The release notes can be found at:
+https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.1
+
+Mbed TLS 3.6 is an LTS release that will be supported
+with bug and security fixes until at least March 2027.
+
+.. _zephyr_3.7.0:
+
 Zephyr 3.7.0
 ############
 

--- a/west.yml
+++ b/west.yml
@@ -282,7 +282,7 @@ manifest:
       revision: 2b498e6f36d6b82ae1da12c8b7742e318624ecf5
       path: modules/lib/gui/lvgl
     - name: mbedtls
-      revision: 2f24831ee13d399ce019c4632b0bcd440a713f7c
+      revision: fb36f3fe20f9f62e67b1a20c0cfe0a6788ec2bf6
       path: modules/crypto/mbedtls
       groups:
         - crypto


### PR DESCRIPTION
Backport b9b166c7f8dfcf610042fad55df770d310a97f5e from https://github.com/zephyrproject-rtos/zephyr/pull/77874.

Fixes #78037.