### PR TITLE
doc: rework footer to be more compact

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -780,23 +780,6 @@ kbd, .kbd,
     background-color: var(--navbar-scrollbar-active-color);
 }
 
-/* Breathe tweaks */
-
-.rst-content .section > dl > dd {
-    margin-left: 0;
-}
-
-.rst-content p.breathe-sectiondef-title {
-    font-size: 115%;
-    color: var(--link-color);
-}
-
-.rst-content dl:not(.docutils) dl:not(.rst-other-versions) dt {
-    background: var(--admonition-note-background-color) !important;
-    border-top: none !important;
-    border-left: none !important;
-}
-
 /* Misc tweaks */
 
 .rst-columns {

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -171,6 +171,8 @@ a.icon-home:visited {
 
 .wy-nav-content {
     background-color: var(--content-background-color);
+    min-height: 100vh;
+    display: flex;
 }
 
 .wy-body-for-nav {
@@ -757,6 +759,9 @@ kbd, .kbd,
         overflow-y: initial;
         max-height: initial;
     }
+    .wy-nav-content {
+        min-height: calc(100dvh - 64px);
+    }
 }
 
 /* Scrollbar styling */
@@ -886,6 +891,19 @@ dark-mode-toggle::part(toggleLabel){
 .lastupdated {
     font-weight: 200;
     font-size: 0.9rem;
+}
+
+/* Make actual document take all vertical space available so that footer is always at the bottom */
+
+.rst-content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+}
+
+.document {
+    flex-grow: 1;
 }
 
 /* Custom search box, including search engine selection */

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -883,6 +883,11 @@ dark-mode-toggle::part(toggleLabel){
    color: white;
 }
 
+.lastupdated {
+    font-weight: 200;
+    font-size: 0.9rem;
+}
+
 /* Custom search box, including search engine selection */
 
 .search-container {

--- a/doc/_templates/footer.html
+++ b/doc/_templates/footer.html
@@ -6,25 +6,13 @@
   {%- endif %}
 
   {%- if last_updated %}
-  <span class="lastupdated">
-    Last generated on {{ last_updated }}.
-  </span>
+  <div class="lastupdated">
+    Last generated: {{ last_updated }}.
+    {%- set git_last_updated, sha1 = pagename | git_info | default((None, None), true) %}
+    {%- if git_last_updated %}
+    Last source update: {{ git_last_updated }}.
+    {%- endif %}
+  </div>
   {%- endif -%}
 </p>
-{%- set git_last_updated, sha1 = pagename | git_info | default((None, None), true) %}
-{%- if git_last_updated %}
-<div class="admonition tip" data-nosnippet>
-  <p class="admonition-title">
-    Help us keep our technical documentation accurate and up-to-date!
-  </p>
-  <p>
-    The human-authored contents on this page was last updated on {{ git_last_updated }}.
-  </p>
-  <p>
-    If you find any errors on this page, outdated information, or have any other suggestion for
-    improving its contents, please consider
-    <a href="{{ pagename | gh_link_get_open_issue_url(sha1) }}">opening an issue</a>.
-  </p>
-</div>
-{%- endif %}
 {% endblock %}


### PR DESCRIPTION
https://builds.zephyrproject.io/zephyr/pr/78043/docs/safety/index.html vs.
https://docs.zephyrproject.org/latest/safety/index.html

There is likely no need for the footer to be so prominently asking folks to report issues with a page based on the number of issues that have been reported in the past year or so.

This change makes the footer less crowded and saves some precious vertical space.

Also made a change so that footer is always at the actual bottom of the screen rather, which makes pages with little text (like the one linked at the beginning of this comment) look better.

Related: similar work to save some space towards the top of the page #78032