### PR TITLE
dts: stm32h7: Add missing ITCM memory to stm32h743.dtsi as it's available there.

### DIFF
--- a/dts/arm/st/h7/stm32h743.dtsi
+++ b/dts/arm/st/h7/stm32h743.dtsi
@@ -102,6 +102,12 @@
 		zephyr,memory-region = "DTCM";
 	};
 
+	itcm: memory@0 {
+		compatible = "zephyr,memory-region", "arm,itcm";
+		reg = <0x00000000 DT_SIZE_K(64)>;
+		zephyr,memory-region = "ITCM";
+	};
+
 	otghs_fs_phy: otghs_fs_phy {
 		compatible = "usb-nop-xceiv";
 		#phy-cells = <0>;


### PR DESCRIPTION
The ITCM is available on all STM32H75x/74x couple to the M7 core.