### PR TITLE
subsys: net: lib: add wifi_credentials library

### DIFF
--- a/include/zephyr/net/wifi_credentials.h
+++ b/include/zephyr/net/wifi_credentials.h
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef WIFI_CREDENTIALS_H__
+#define WIFI_CREDENTIALS_H__
+
+#include <zephyr/types.h>
+#include <zephyr/net/wifi.h>
+#include <zephyr/kernel.h>
+
+/**
+ * @defgroup wifi_credentials Wi-Fi credentials library
+ * @ingroup networking
+ * @since 4.0
+ * @version 0.1.0
+ * @{
+ * @brief Library that provides a way to store and load Wi-Fi credentials.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* this entry contains a BSSID */
+#define WIFI_CREDENTIALS_FLAG_BSSID        BIT(0)
+/* this entry is to be preferred over others */
+#define WIFI_CREDENTIALS_FLAG_FAVORITE     BIT(1)
+/* this entry can use the 2.4 GHz band */
+#define WIFI_CREDENTIALS_FLAG_2_4GHz       BIT(2)
+/* this entry can use the 5 GHz band */
+#define WIFI_CREDENTIALS_FLAG_5GHz         BIT(3)
+/* this entry requires management frame protection */
+#define WIFI_CREDENTIALS_FLAG_MFP_REQUIRED BIT(4)
+/* this entry disables management frame protection */
+#define WIFI_CREDENTIALS_FLAG_MFP_DISABLED BIT(5)
+
+#define WIFI_CREDENTIALS_MAX_PASSWORD_LEN                                                          \
+	MAX(WIFI_PSK_MAX_LEN, CONFIG_WIFI_CREDENTIALS_SAE_PASSWORD_LENGTH)
+
+/**
+ * @brief Wi-Fi credentials entry header
+ * @note Every settings entry starts with this header.
+ *       Depending on the `type` field, the header can be casted to a larger type.
+ *       In addition to SSID (usually a string) and BSSID (a MAC address),
+ *       a `flags` field can be used to control some detail settings.
+ *
+ */
+struct wifi_credentials_header {
+	enum wifi_security_type type;     /**< Wi-Fi security type */
+	char ssid[WIFI_SSID_MAX_LEN];     /**< SSID (Service Set Identifier) */
+	size_t ssid_len;                  /**< Length of the SSID */
+	uint32_t flags;                   /**< Flags for controlling detail settings */
+	uint32_t timeout;                 /**< Timeout for connecting to the network */
+	uint8_t bssid[WIFI_MAC_ADDR_LEN]; /**< BSSID (Basic Service Set Identifier) */
+	uint8_t channel;                  /**< Channel on which the network operates */
+};
+
+/**
+ * @brief Wi-Fi Personal credentials entry
+ * @note Contains only the header and a password.
+ *       For PSK security, passwords can be up to `WIFI_PSK_MAX_LEN` bytes long
+ *       including NULL termination. For SAE security it can range up to
+ *       `CONFIG_WIFI_CREDENTIALS_SAE_PASSWORD_LENGTH`.
+ *
+ */
+struct wifi_credentials_personal {
+	struct wifi_credentials_header header;            /**< Header */
+	char password[WIFI_CREDENTIALS_MAX_PASSWORD_LEN]; /**< Password/PSK */
+	size_t password_len;                              /**< Length of the password */
+};
+
+/**
+ * @brief Wi-Fi Enterprise credentials entry
+ * @note This functionality is not yet implemented.
+ */
+struct wifi_credentials_enterprise {
+	struct wifi_credentials_header header; /**< Header */
+	size_t identity_len;                   /**< Length of the identity */
+	size_t anonymous_identity_len;         /**< Length of the anonymous identity */
+	size_t password_len;                   /**< Length of the password */
+	size_t ca_cert_len;                    /**< Length of the CA certificate */
+	size_t client_cert_len;                /**< Length of the client certificate */
+	size_t private_key_len;                /**< Length of the private key */
+	size_t private_key_pw_len;             /**< Length of the private key password */
+};
+
+/**
+ * @brief Get credentials for given SSID.
+ *
+ * @param[in] ssid			SSID to look for
+ * @param[in] ssid_len			length of SSID
+ * @param[out] type			Wi-Fi security type
+ * @param[out] bssid_buf		buffer to store BSSID if it was fixed
+ * @param[in] bssid_buf_len		length of bssid_buf
+ * @param[out] password_buf		buffer to store password
+ * @param[in] password_buf_len		length of password_buf
+ * @param[out] password_len		length of password
+ * @param[out] flags			flags
+ * @param[out] channel			channel
+ * @param[out] timeout			timeout
+ *
+ * @return 0		Success.
+ * @return -ENOENT	No network with this SSID was found.
+ * @return -EINVAL	A required buffer was NULL or invalid SSID length.
+ * @return -EPROTO	The network with this SSID is not a personal network.
+ */
+int wifi_credentials_get_by_ssid_personal(const char *ssid, size_t ssid_len,
+					  enum wifi_security_type *type, uint8_t *bssid_buf,
+					  size_t bssid_buf_len, char *password_buf,
+					  size_t password_buf_len, size_t *password_len,
+					  uint32_t *flags, uint8_t *channel, uint32_t *timeout);
+
+/**
+ * @brief Set credentials for given SSID.
+ *
+ * @param[in] ssid		SSID to look for
+ * @param[in] ssid_len		length of SSID
+ * @param[in] type		Wi-Fi security type
+ * @param[in] bssid		BSSID (may be NULL)
+ * @param[in] bssid_len		length of BSSID buffer (either 0 or WIFI_MAC_ADDR_LEN)
+ * @param[in] password		password
+ * @param[in] password_len		length of password
+ * @param[in] flags			flags
+ * @param[in] channel			Channel
+ * @param[in] timeout			Timeout
+ *
+ * @return 0			Success. Credentials are stored in persistent storage.
+ * @return -EINVAL		A required buffer was NULL or security type is not supported.
+ * @return -ENOTSUP		Security type is not supported.
+ * @return -ENOBUFS		All slots are already taken.
+ */
+int wifi_credentials_set_personal(const char *ssid, size_t ssid_len, enum wifi_security_type type,
+				  const uint8_t *bssid, size_t bssid_len, const char *password,
+				  size_t password_len, uint32_t flags, uint8_t channel,
+				  uint32_t timeout);
+
+/**
+ * @brief Get credentials for given SSID by struct.
+ *
+ * @param[in] ssid		SSID to look for
+ * @param[in] ssid_len		length of SSID
+ * @param[out] buf		credentials Pointer to struct where credentials are stored
+ *
+ * @return 0			Success.
+ * @return -ENOENT		No network with this SSID was found.
+ * @return -EINVAL		A required buffer was NULL or too small.
+ * @return -EPROTO		The network with this SSID is not a personal network.
+ */
+int wifi_credentials_get_by_ssid_personal_struct(const char *ssid, size_t ssid_len,
+						 struct wifi_credentials_personal *buf);
+
+/**
+ * @brief Set credentials for given SSID by struct.
+ *
+ * @param[in] creds		credentials Pointer to struct from which credentials are loaded
+ *
+ * @return 0			Success.
+ * @return -ENOENT		No network with this SSID was found.
+ * @return -EINVAL		A required buffer was NULL or incorrect size.
+ * @return -ENOBUFS		All slots are already taken.
+ */
+int wifi_credentials_set_personal_struct(const struct wifi_credentials_personal *creds);
+
+/**
+ * @brief Delete credentials for given SSID.
+ *
+ * @param[in] ssid		SSID to look for
+ * @param[in] ssid_len		length of SSID
+ *
+ * @return			-ENOENT if No network with this SSID was found.
+ * @return			0 on success, otherwise a negative error code
+ */
+int wifi_credentials_delete_by_ssid(const char *ssid, size_t ssid_len);
+
+/**
+ * @brief Check if credentials storage is empty.
+ *
+ * @return			true if credential storage is empty, otherwise false
+ */
+bool wifi_credentials_is_empty(void);
+
+/**
+ * @brief Deletes all stored Wi-Fi credentials.
+ *
+ * This function deletes all Wi-Fi credentials that have been stored in the system.
+ * It is typically used when you want to clear all saved networks.
+ *
+ * @return			0 on successful, otherwise a negative error code
+ */
+int wifi_credentials_delete_all(void);
+
+/**
+ * @brief Callback type for wifi_credentials_for_each_ssid.
+ * @param[in] cb_arg      arguments for the callback function. Appropriate cb_arg is
+ *                        transferred by wifi_credentials_for_each_ssid.
+ * @param[in] ssid        SSID
+ * @param[in] ssid_len    length of SSID
+ */
+typedef void (*wifi_credentials_ssid_cb)(void *cb_arg, const char *ssid, size_t ssid_len);
+
+/**
+ * @brief Call callback for each registered SSID.
+ *
+ * @param cb		callback
+ * @param cb_arg	argument for callback function
+ */
+void wifi_credentials_for_each_ssid(wifi_credentials_ssid_cb cb, void *cb_arg);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+#endif /* WIFI_CREDENTIALS_H__ */

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017 Intel Corporation.
  * Copyright 2024 NXP
+ * Copyright (c) 2024 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -108,9 +109,13 @@ enum net_request_wifi_cmd {
 	NET_REQUEST_WIFI_CMD_RTS_THRESHOLD_CONFIG,
 	/** WPS config */
 	NET_REQUEST_WIFI_CMD_WPS_CONFIG,
+#ifdef CONFIG_WIFI_CREDENTIALS_CONNECT_STORED
+	/** Connect to APs stored using wifi_credentials library. */
+	NET_REQUEST_WIFI_CMD_CONNECT_STORED,
+#endif
 	/** @cond INTERNAL_HIDDEN */
 	NET_REQUEST_WIFI_CMD_MAX
-/** @endcond */
+	/** @endcond */
 };
 
 /** Request a Wi-Fi scan */
@@ -257,6 +262,11 @@ NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_RTS_THRESHOLD_CONFIG);
 #define NET_REQUEST_WIFI_WPS_CONFIG (_NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_WPS_CONFIG)
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_WPS_CONFIG);
+#ifdef CONFIG_WIFI_CREDENTIALS_CONNECT_STORED
+#define NET_REQUEST_WIFI_CONNECT_STORED (_NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_CONNECT_STORED)
+
+NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_CONNECT_STORED);
+#endif
 
 /** @brief Wi-Fi management events */
 enum net_event_wifi_cmd {

--- a/samples/net/wifi/sample.yaml
+++ b/samples/net/wifi/sample.yaml
@@ -42,7 +42,13 @@ tests:
     integration_platforms:
       - frdm_k64f
   sample.net.wifi.nrf70dk:
-    extra_args: CONFIG_NRF_WIFI_BUILD_ONLY_MODE=y
+    extra_args:
+      - CONFIG_NRF_WIFI_BUILD_ONLY_MODE=y
+      - CONFIG_WIFI_CREDENTIALS=y
+      - CONFIG_FLASH=y
+      - CONFIG_FLASH_MAP=y
+      - CONFIG_NVS=y
+      - CONFIG_SETTINGS=y
     platform_allow:
       - nrf7002dk/nrf5340/cpuapp
       - nrf7002dk/nrf5340/cpuapp/nrf7001

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -5,12 +5,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#undef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L /* For strnlen() */
+
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_wifi_mgmt, CONFIG_NET_L2_WIFI_MGMT_LOG_LEVEL);
 
 #include <errno.h>
 #include <string.h>
-
+#include <stdio.h>
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/wifi_mgmt.h>
@@ -1009,3 +1012,238 @@ void wifi_mgmt_raise_ap_sta_disconnected_event(struct net_if *iface,
 					iface, sta_info,
 					sizeof(struct wifi_ap_sta_info));
 }
+
+#ifdef CONFIG_WIFI_CREDENTIALS_CONNECT_STORED
+
+#include <zephyr/net/wifi_credentials.h>
+
+#if defined(CONFIG_WIFI_CREDENTIALS_STATIC)
+BUILD_ASSERT(sizeof(CONFIG_WIFI_CREDENTIALS_STATIC_SSID) != 1,
+	     "CONFIG_WIFI_CREDENTIALS_STATIC_SSID required");
+#endif /* defined(CONFIG_WIFI_CREDENTIALS_STATIC) */
+
+static int __stored_creds_to_params(struct wifi_credentials_personal *creds,
+				    struct wifi_connect_req_params *params)
+{
+	char *ssid = NULL;
+	char *psk = NULL;
+	int ret;
+
+	/* SSID */
+	ssid = (char *)k_malloc(creds->header.ssid_len + 1);
+	if (!ssid) {
+		LOG_ERR("Failed to allocate memory for SSID\n");
+		ret = -ENOMEM;
+		goto err_out;
+	}
+
+	memset(ssid, 0, creds->header.ssid_len + 1);
+	ret = snprintf(ssid, creds->header.ssid_len + 1, "%s", creds->header.ssid);
+	if (ret > creds->header.ssid_len) {
+		LOG_ERR("SSID string truncated\n");
+		ret = -EINVAL;
+		goto err_out;
+	}
+
+	params->ssid = ssid;
+	params->ssid_length = creds->header.ssid_len;
+
+	/* PSK (optional) */
+	if (creds->password_len > 0) {
+		psk = (char *)k_malloc(creds->password_len + 1);
+		if (!psk) {
+			LOG_ERR("Failed to allocate memory for PSK\n");
+			ret = -ENOMEM;
+			goto err_out;
+		}
+
+		memset(psk, 0, creds->password_len + 1);
+		ret = snprintf(psk, creds->password_len + 1, "%s", creds->password);
+		if (ret > creds->password_len) {
+			LOG_ERR("PSK string truncated\n");
+			ret = -EINVAL;
+			goto err_out;
+		}
+
+		params->psk = psk;
+		params->psk_length = creds->password_len;
+	}
+
+	/* Defaults */
+	params->security = creds->header.type;
+
+	/* If channel is set to 0 we default to ANY. 0 is not a valid Wi-Fi channel. */
+	params->channel = (creds->header.channel != 0) ? creds->header.channel : WIFI_CHANNEL_ANY;
+	params->timeout = (creds->header.timeout != 0)
+				  ? creds->header.timeout
+				  : CONFIG_WIFI_CREDENTIALS_CONNECT_STORED_CONNECTION_TIMEOUT;
+
+	/* Security type (optional) */
+	if (creds->header.type > WIFI_SECURITY_TYPE_MAX) {
+		params->security = WIFI_SECURITY_TYPE_NONE;
+	}
+
+	if (creds->header.flags & WIFI_CREDENTIALS_FLAG_2_4GHz) {
+		params->band = WIFI_FREQ_BAND_2_4_GHZ;
+	} else if (creds->header.flags & WIFI_CREDENTIALS_FLAG_5GHz) {
+		params->band = WIFI_FREQ_BAND_5_GHZ;
+	} else {
+		params->band = WIFI_FREQ_BAND_UNKNOWN;
+	}
+
+	/* MFP setting (default: optional) */
+	if (creds->header.flags & WIFI_CREDENTIALS_FLAG_MFP_DISABLED) {
+		params->mfp = WIFI_MFP_DISABLE;
+	} else if (creds->header.flags & WIFI_CREDENTIALS_FLAG_MFP_REQUIRED) {
+		params->mfp = WIFI_MFP_REQUIRED;
+	} else {
+		params->mfp = WIFI_MFP_OPTIONAL;
+	}
+
+	return 0;
+err_out:
+	if (ssid) {
+		k_free(ssid);
+		ssid = NULL;
+	}
+
+	if (psk) {
+		k_free(psk);
+		psk = NULL;
+	}
+
+	return ret;
+}
+
+static inline const char *wpa_supp_security_txt(enum wifi_security_type security)
+{
+	switch (security) {
+	case WIFI_SECURITY_TYPE_NONE:
+		return "NONE";
+	case WIFI_SECURITY_TYPE_PSK:
+		return "WPA-PSK";
+	case WIFI_SECURITY_TYPE_PSK_SHA256:
+		return "WPA-PSK-SHA256";
+	case WIFI_SECURITY_TYPE_SAE:
+		return "SAE";
+	case WIFI_SECURITY_TYPE_UNKNOWN:
+	default:
+		return "UNKNOWN";
+	}
+}
+
+static int add_network_from_credentials_struct_personal(struct wifi_credentials_personal *creds,
+							struct net_if *iface)
+{
+	int ret = 0;
+	struct wifi_connect_req_params cnx_params = {0};
+
+	if (__stored_creds_to_params(creds, &cnx_params)) {
+		ret = -ENOEXEC;
+		goto out;
+	}
+
+	if (net_mgmt(NET_REQUEST_WIFI_CONNECT, iface, &cnx_params,
+		     sizeof(struct wifi_connect_req_params))) {
+		LOG_ERR("Connection request failed\n");
+
+		return -ENOEXEC;
+	}
+
+	LOG_INF("Connection requested");
+
+out:
+	if (cnx_params.psk) {
+		k_free((void *)cnx_params.psk);
+	}
+
+	if (cnx_params.ssid) {
+		k_free((void *)cnx_params.ssid);
+	}
+
+	return ret;
+}
+
+static void add_stored_network(void *cb_arg, const char *ssid, size_t ssid_len)
+{
+	int ret = 0;
+	struct wifi_credentials_personal creds;
+
+	/* load stored data */
+	ret = wifi_credentials_get_by_ssid_personal_struct(ssid, ssid_len, &creds);
+
+	if (ret) {
+		LOG_ERR("Loading WiFi credentials failed for SSID [%.*s], len: %d, err: %d",
+			ssid_len, ssid, ssid_len, ret);
+		return;
+	}
+
+	add_network_from_credentials_struct_personal(&creds, (struct net_if *)cb_arg);
+}
+
+static int add_static_network_config(struct net_if *iface)
+{
+#if defined(CONFIG_WIFI_CREDENTIALS_STATIC)
+
+	struct wifi_credentials_personal creds = {
+		.header = {
+			.ssid_len = strlen(CONFIG_WIFI_CREDENTIALS_STATIC_SSID),
+		},
+		.password_len = strlen(CONFIG_WIFI_CREDENTIALS_STATIC_PASSWORD),
+	};
+
+	int ret = wifi_credentials_get_by_ssid_personal_struct(
+		CONFIG_WIFI_CREDENTIALS_STATIC_SSID, strlen(CONFIG_WIFI_CREDENTIALS_STATIC_SSID),
+		&creds);
+
+	if (!ret) {
+		LOG_WRN("Statically configured WiFi network was overridden by storage.");
+		return 0;
+	}
+
+#if defined(CONFIG_WIFI_CREDENTIALS_STATIC_TYPE_OPEN)
+	creds.header.type = WIFI_SECURITY_TYPE_NONE;
+#elif defined(CONFIG_WIFI_CREDENTIALS_STATIC_TYPE_PSK)
+	creds.header.type = WIFI_SECURITY_TYPE_PSK;
+#elif defined(CONFIG_WIFI_CREDENTIALS_STATIC_TYPE_PSK_SHA256)
+	creds.header.type = WIFI_SECURITY_TYPE_PSK_SHA256;
+#elif defined(CONFIG_WIFI_CREDENTIALS_STATIC_TYPE_SAE)
+	creds.header.type = WIFI_SECURITY_TYPE_SAE;
+#elif defined(CONFIG_WIFI_CREDENTIALS_STATIC_TYPE_WPA_PSK)
+	creds.header.type = WIFI_SECURITY_TYPE_WPA_PSK;
+#else
+#error "invalid CONFIG_WIFI_CREDENTIALS_STATIC_TYPE"
+#endif
+
+	memcpy(creds.header.ssid, CONFIG_WIFI_CREDENTIALS_STATIC_SSID,
+	       strlen(CONFIG_WIFI_CREDENTIALS_STATIC_SSID));
+	memcpy(creds.password, CONFIG_WIFI_CREDENTIALS_STATIC_PASSWORD,
+	       strlen(CONFIG_WIFI_CREDENTIALS_STATIC_PASSWORD));
+
+	LOG_DBG("Adding statically configured WiFi network [%s] to internal list.",
+		creds.header.ssid);
+
+	return add_network_from_credentials_struct_personal(&creds, iface);
+#else
+	return 0;
+#endif /* defined(CONFIG_WIFI_CREDENTIALS_STATIC) */
+}
+
+static int connect_stored_command(uint32_t mgmt_request, struct net_if *iface, void *data,
+				  size_t len)
+{
+	int ret = 0;
+
+	ret = add_static_network_config(iface);
+	if (ret) {
+		return ret;
+	}
+
+	wifi_credentials_for_each_ssid(add_stored_network, iface);
+
+	return ret;
+};
+
+NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_CONNECT_STORED, connect_stored_command);
+
+#endif /* CONFIG_WIFI_CREDENTIALS_CONNECT_STORED */

--- a/subsys/net/lib/CMakeLists.txt
+++ b/subsys/net/lib/CMakeLists.txt
@@ -18,6 +18,7 @@ add_subdirectory_ifdef(CONFIG_NET_SHELL              shell)
 add_subdirectory_ifdef(CONFIG_NET_TRICKLE            trickle)
 add_subdirectory_ifdef(CONFIG_NET_DHCPV6             dhcpv6)
 add_subdirectory_ifdef(CONFIG_PROMETHEUS             prometheus)
+add_subdirectory_ifdef(CONFIG_WIFI_CREDENTIALS       wifi_credentials)
 
 if (CONFIG_NET_DHCPV4 OR CONFIG_NET_DHCPV4_SERVER)
   add_subdirectory(dhcpv4)

--- a/subsys/net/lib/Kconfig
+++ b/subsys/net/lib/Kconfig
@@ -51,4 +51,6 @@ source "subsys/net/lib/zperf/Kconfig"
 
 source "subsys/net/lib/prometheus/Kconfig"
 
+source "subsys/net/lib/wifi_credentials/Kconfig"
+
 endmenu

--- a/subsys/net/lib/wifi_credentials/CMakeLists.txt
+++ b/subsys/net/lib/wifi_credentials/CMakeLists.txt
@@ -1,0 +1,36 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+zephyr_library_named(wifi_credentials)
+zephyr_library_sources(wifi_credentials.c)
+
+if (CONFIG_WIFI_CREDENTIALS_BACKEND_PSA)
+zephyr_library_include_directories(
+	$<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/api_ns/interface/include
+)
+endif()
+
+zephyr_library_sources_ifdef(
+	CONFIG_WIFI_CREDENTIALS_BACKEND_SETTINGS
+	wifi_credentials_backend_settings.c)
+
+zephyr_library_sources_ifdef(
+	CONFIG_WIFI_CREDENTIALS_BACKEND_PSA
+	wifi_credentials_backend_psa.c)
+
+zephyr_library_sources_ifdef(
+	CONFIG_WIFI_CREDENTIALS_BACKEND_NONE
+	wifi_credentials_backend_none.c)
+
+zephyr_library_sources_ifdef(
+	CONFIG_WIFI_CREDENTIALS_SHELL
+	wifi_credentials_shell.c)
+
+if(WIFI_CREDENTIALS_STATIC_SSID)
+	message(WARNING
+		"Static Wi-Fi configuration is used, please remove before deployment!"
+	)
+endif()

--- a/subsys/net/lib/wifi_credentials/Kconfig
+++ b/subsys/net/lib/wifi_credentials/Kconfig
@@ -1,0 +1,109 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+menuconfig WIFI_CREDENTIALS
+	bool "WIFI credentials management"
+	select EXPERIMENTAL
+	help
+	  Enable WiFi credentials management subsystem.
+
+if WIFI_CREDENTIALS
+
+module = WIFI_CREDENTIALS
+module-str = wifi_credentials
+source "subsys/logging/Kconfig.template.log_config"
+
+choice WIFI_CREDENTIALS_BACKEND
+	prompt "WiFi credentials backend"
+	default WIFI_CREDENTIALS_BACKEND_PSA if BUILD_WITH_TFM
+	default WIFI_CREDENTIALS_BACKEND_SETTINGS
+	default WIFI_CREDENTIALS_BACKEND_NONE if WIFI_CREDENTIALS_STATIC
+	help
+	  Selects whether to use PSA Protected Storage or the Zephyr settings subsystem
+	  for credentials storage.
+
+config WIFI_CREDENTIALS_BACKEND_SETTINGS
+	bool "Zephyr Settings"
+	depends on SETTINGS
+	depends on !SETTINGS_NONE
+
+config WIFI_CREDENTIALS_BACKEND_PSA
+	bool "PSA Protected Storage"
+	depends on BUILD_WITH_TFM
+
+config WIFI_CREDENTIALS_BACKEND_NONE
+	bool "No credentials storage"
+	depends on WIFI_CREDENTIALS_STATIC
+
+endchoice
+
+config WIFI_CREDENTIALS_MAX_ENTRIES
+	int "Number of supported WiFi credentials"
+	default 2
+	help
+	  This detemines how many different WiFi networks can be configured at a time.
+
+config WIFI_CREDENTIALS_SAE_PASSWORD_LENGTH
+	int "Max. length of SAE password"
+	default 128
+	help
+	  There is no official limit on SAE password length,
+	  but for example Linux 6.0 has a hardcoded limit of 128 bytes.
+
+config WIFI_CREDENTIALS_SHELL
+	bool "Shell commands to manage Wi-Fi credentials"
+	default y
+	depends on SHELL
+	depends on !WIFI_CREDENTIALS_BACKEND_NONE
+
+endif # WIFI_CREDENTIALS
+
+if WIFI_CREDENTIALS_BACKEND_PSA
+
+config WIFI_CREDENTIALS_BACKEND_PSA_OFFSET
+	int "PSA_KEY_ID range offset"
+	default 0
+	help
+	  The PSA specification mandates to set key identifiers for keys
+	  with persistent lifetime. The users of the PSA API are responsible (WIFI credentials
+	  management is user of PSA API) to provide correct and unique identifiers.
+
+endif # WIFI_CREDENTIALS_BACKEND_PSA
+
+config WIFI_CREDENTIALS_STATIC
+	bool "Static Wi-Fi network configuration"
+
+if WIFI_CREDENTIALS_STATIC
+
+config WIFI_CREDENTIALS_STATIC_SSID
+	string "SSID of statically configured WiFi network"
+
+config WIFI_CREDENTIALS_STATIC_PASSWORD
+	string "Password of statically configured Wi-Fi network"
+	default ""
+
+choice WIFI_CREDENTIALS_STATIC_TYPE
+	prompt "Static Wi-Fi network security type"
+	default WIFI_CREDENTIALS_STATIC_TYPE_PSK
+
+config WIFI_CREDENTIALS_STATIC_TYPE_OPEN
+	bool "OPEN"
+
+config WIFI_CREDENTIALS_STATIC_TYPE_PSK
+	bool "WPA2-PSK"
+
+config WIFI_CREDENTIALS_STATIC_TYPE_PSK_SHA256
+	bool "WPA2-PSK-SHA256"
+
+config WIFI_CREDENTIALS_STATIC_TYPE_SAE
+	bool "SAE"
+
+config WIFI_CREDENTIALS_STATIC_TYPE_WPA_PSK
+	bool "WPA-PSK"
+
+endchoice
+
+endif

--- a/subsys/net/lib/wifi_credentials/Kconfig
+++ b/subsys/net/lib/wifi_credentials/Kconfig
@@ -59,6 +59,20 @@ config WIFI_CREDENTIALS_SHELL
 	depends on SHELL
 	depends on !WIFI_CREDENTIALS_BACKEND_NONE
 
+config WIFI_CREDENTIALS_CONNECT_STORED
+	bool "Add command to connect to stored networks directly."
+	default y
+
+if WIFI_CREDENTIALS_CONNECT_STORED
+
+config WIFI_CREDENTIALS_CONNECT_STORED_CONNECTION_TIMEOUT
+	int "Connection timeout"
+	default 30
+	help
+	   Wait period before falling back to the next entry in the list of stored SSIDs.
+
+endif # WIFI_CREDENTIALS_CONNECT_STORED
+
 endif # WIFI_CREDENTIALS
 
 if WIFI_CREDENTIALS_BACKEND_PSA

--- a/subsys/net/lib/wifi_credentials/wifi_credentials.c
+++ b/subsys/net/lib/wifi_credentials/wifi_credentials.c
@@ -1,0 +1,409 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/logging/log.h>
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
+#include <zephyr/net/wifi_credentials.h>
+#include <sys/types.h>
+
+#include "wifi_credentials_internal.h"
+
+LOG_MODULE_REGISTER(wifi_credentials, CONFIG_WIFI_CREDENTIALS_LOG_LEVEL);
+
+static K_MUTEX_DEFINE(wifi_credentials_mutex);
+
+/* SSID cache: maps SSIDs to their storage indices */
+static char ssid_cache[CONFIG_WIFI_CREDENTIALS_MAX_ENTRIES][WIFI_SSID_MAX_LEN];
+static size_t ssid_cache_lengths[CONFIG_WIFI_CREDENTIALS_MAX_ENTRIES];
+
+/**
+ * @brief Finds index of given SSID if it exists.
+ *
+ * @param ssid		SSID to look for (buffer of WIFI_SSID_MAX_LEN length)
+ * @return		index if entry is found, -1 otherwise
+ */
+static inline ssize_t lookup_idx(const uint8_t *ssid, size_t ssid_len)
+{
+	for (size_t i = 0; i < CONFIG_WIFI_CREDENTIALS_MAX_ENTRIES; ++i) {
+		if (ssid_len != ssid_cache_lengths[i]) {
+			continue;
+		}
+
+		if (strncmp(ssid, ssid_cache[i], ssid_len) == 0) {
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+/**
+ * @brief Determine whether an index is currently used for storing network credentials.
+ *
+ * @param idx credential index
+ * @return true if index is used, false otherwise
+ */
+static inline bool is_entry_used(size_t idx)
+{
+	return ssid_cache_lengths[idx] != 0;
+}
+
+/**
+ * @brief Finds unused index to store new entry at.
+ *
+ * @return		index if empty slot is found, -1 otherwise
+ */
+static inline ssize_t lookup_unused_idx(void)
+{
+	for (size_t i = 0; i < CONFIG_WIFI_CREDENTIALS_MAX_ENTRIES; ++i) {
+		if (!is_entry_used(i)) {
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+static int init(void)
+{
+
+	int ret;
+
+	k_mutex_lock(&wifi_credentials_mutex, K_FOREVER);
+
+	ret = wifi_credentials_backend_init();
+	if (ret) {
+		LOG_ERR("Initializing WiFi credentials storage backend failed, err: %d", ret);
+	}
+
+	k_mutex_unlock(&wifi_credentials_mutex);
+
+	return 0;
+}
+
+void wifi_credentials_cache_ssid(size_t idx, const struct wifi_credentials_header *buf)
+{
+	memcpy(ssid_cache[idx], buf->ssid, buf->ssid_len);
+	ssid_cache_lengths[idx] = buf->ssid_len;
+}
+
+/**
+ * @brief Clear entry in SSID cache.
+ *
+ * @param idx credential index
+ */
+void wifi_credentials_uncache_ssid(size_t idx)
+{
+	ssid_cache_lengths[idx] = 0;
+}
+
+int wifi_credentials_get_by_ssid_personal_struct(const char *ssid, size_t ssid_len,
+						 struct wifi_credentials_personal *buf)
+{
+	int ret;
+
+	if (ssid == NULL || ssid_len > WIFI_SSID_MAX_LEN || ssid_len == 0) {
+		LOG_ERR("Cannot retrieve WiFi credentials, SSID has invalid format");
+		return -EINVAL;
+	}
+
+	if (buf == NULL) {
+		LOG_ERR("Cannot retrieve WiFi credentials, "
+			"destination struct pointer cannot be NULL");
+		return -EINVAL;
+	}
+
+	k_mutex_lock(&wifi_credentials_mutex, K_FOREVER);
+
+	ssize_t idx = lookup_idx(ssid, ssid_len);
+
+	if (idx == -1) {
+		LOG_DBG("Cannot retrieve WiFi credentials, no entry found for the provided SSID");
+		ret = -ENOENT;
+		goto exit;
+	}
+
+	ret = wifi_credentials_load_entry(idx, buf, sizeof(struct wifi_credentials_personal));
+
+	if (ret) {
+		LOG_ERR("Failed to load WiFi credentials at index %d, err: %d", idx, ret);
+		goto exit;
+	}
+
+	if (buf->header.type != WIFI_SECURITY_TYPE_NONE &&
+	    buf->header.type != WIFI_SECURITY_TYPE_PSK &&
+	    buf->header.type != WIFI_SECURITY_TYPE_PSK_SHA256 &&
+	    buf->header.type != WIFI_SECURITY_TYPE_SAE &&
+	    buf->header.type != WIFI_SECURITY_TYPE_WPA_PSK) {
+		LOG_ERR("Requested WiFi credentials entry is corrupted");
+		ret = -EPROTO;
+		goto exit;
+	}
+
+exit:
+	k_mutex_unlock(&wifi_credentials_mutex);
+
+	return ret;
+}
+
+int wifi_credentials_set_personal_struct(const struct wifi_credentials_personal *creds)
+{
+	int ret;
+
+	if (creds->header.ssid_len > WIFI_SSID_MAX_LEN || creds->header.ssid_len == 0) {
+		LOG_ERR("Cannot set WiFi credentials, SSID has invalid format");
+		return -EINVAL;
+	}
+
+	if (creds == NULL) {
+		LOG_ERR("Cannot set WiFi credentials, provided struct pointer cannot be NULL");
+		return -EINVAL;
+	}
+
+	k_mutex_lock(&wifi_credentials_mutex, K_FOREVER);
+
+	ssize_t idx = lookup_idx(creds->header.ssid, creds->header.ssid_len);
+
+	if (idx == -1) {
+		idx = lookup_unused_idx();
+		if (idx == -1) {
+			LOG_ERR("Cannot store WiFi credentials, no space left");
+			ret = -ENOBUFS;
+			goto exit;
+		}
+	}
+
+	ret = wifi_credentials_store_entry(idx, creds, sizeof(struct wifi_credentials_personal));
+
+	if (ret) {
+		LOG_ERR("Failed to store WiFi credentials at index %d, err: %d", idx, ret);
+		goto exit;
+	}
+
+	wifi_credentials_cache_ssid(idx, &creds->header);
+
+exit:
+	k_mutex_unlock(&wifi_credentials_mutex);
+
+	return ret;
+}
+
+int wifi_credentials_set_personal(const char *ssid, size_t ssid_len, enum wifi_security_type type,
+				  const uint8_t *bssid, size_t bssid_len, const char *password,
+				  size_t password_len, uint32_t flags, uint8_t channel,
+				  uint32_t timeout)
+{
+	int ret = 0;
+	uint8_t buf[ENTRY_MAX_LEN] = {0};
+
+	if (ssid == NULL || ssid_len > WIFI_SSID_MAX_LEN || ssid_len == 0) {
+		LOG_ERR("Cannot set WiFi credentials, SSID has invalid format");
+		return -EINVAL;
+	}
+
+	if (flags & WIFI_CREDENTIALS_FLAG_BSSID &&
+	    (bssid_len != WIFI_MAC_ADDR_LEN || bssid == NULL)) {
+		LOG_ERR("Cannot set WiFi credentials, "
+			"provided flags indicated BSSID, but no BSSID provided");
+		return -EINVAL;
+	}
+
+	if ((type != WIFI_SECURITY_TYPE_NONE && (password_len == 0 || password == NULL)) ||
+	    (password_len > WIFI_CREDENTIALS_MAX_PASSWORD_LEN)) {
+		LOG_ERR("Cannot set WiFi credentials, password not provided or invalid");
+		return -EINVAL;
+	}
+
+	/* pack entry */
+	struct wifi_credentials_header *header = (struct wifi_credentials_header *)buf;
+
+	header->type = type;
+	memcpy(header->ssid, ssid, ssid_len);
+	header->ssid_len = ssid_len;
+	header->flags = flags;
+	header->channel = channel;
+	header->timeout = timeout;
+
+	if (flags & WIFI_CREDENTIALS_FLAG_BSSID) {
+		memcpy(header->bssid, bssid, WIFI_MAC_ADDR_LEN);
+	}
+
+	switch (type) {
+	case WIFI_SECURITY_TYPE_NONE:
+		break;
+	case WIFI_SECURITY_TYPE_PSK:
+	case WIFI_SECURITY_TYPE_PSK_SHA256:
+	case WIFI_SECURITY_TYPE_WPA_PSK:
+	case WIFI_SECURITY_TYPE_SAE: {
+		struct wifi_credentials_personal *header_personal =
+			(struct wifi_credentials_personal *)buf;
+
+		memcpy(header_personal->password, password, password_len);
+		header_personal->password_len = password_len;
+		break;
+	}
+	default:
+		LOG_ERR("Cannot set WiFi credentials, "
+			"provided security type %d is unsupported",
+			type);
+		return -ENOTSUP;
+	}
+
+	/* store entry */
+	ret = wifi_credentials_set_personal_struct((struct wifi_credentials_personal *)buf);
+
+	return ret;
+}
+
+int wifi_credentials_get_by_ssid_personal(const char *ssid, size_t ssid_len,
+					  enum wifi_security_type *type, uint8_t *bssid_buf,
+					  size_t bssid_buf_len, char *password_buf,
+					  size_t password_buf_len, size_t *password_len,
+					  uint32_t *flags, uint8_t *channel, uint32_t *timeout)
+{
+	int ret = 0;
+	uint8_t buf[ENTRY_MAX_LEN] = {0};
+
+	if (ssid == NULL || ssid_len > WIFI_SSID_MAX_LEN || ssid_len == 0) {
+		LOG_ERR("Cannot retrieve WiFi credentials, SSID has invalid format");
+		return -EINVAL;
+	}
+
+	if (bssid_buf_len != WIFI_MAC_ADDR_LEN || bssid_buf == NULL) {
+		LOG_ERR("BSSID buffer needs to be provided");
+		return -EINVAL;
+	}
+
+	if (password_buf == NULL || password_buf_len > WIFI_CREDENTIALS_MAX_PASSWORD_LEN ||
+	    password_buf_len == 0) {
+		LOG_ERR("WiFi password buffer needs to be provided");
+		return -EINVAL;
+	}
+
+	/* load entry */
+	ret = wifi_credentials_get_by_ssid_personal_struct(ssid, ssid_len,
+							   (struct wifi_credentials_personal *)buf);
+	if (ret) {
+		return ret;
+	}
+
+	/* unpack entry*/
+	struct wifi_credentials_header *header = (struct wifi_credentials_header *)buf;
+
+	*type = header->type;
+	*flags = header->flags;
+	*channel = header->channel;
+	*timeout = header->timeout;
+
+	if (header->flags & WIFI_CREDENTIALS_FLAG_BSSID) {
+		memcpy(bssid_buf, header->bssid, WIFI_MAC_ADDR_LEN);
+	}
+
+	switch (header->type) {
+	case WIFI_SECURITY_TYPE_NONE:
+		break;
+	case WIFI_SECURITY_TYPE_PSK:
+	case WIFI_SECURITY_TYPE_PSK_SHA256:
+	case WIFI_SECURITY_TYPE_WPA_PSK:
+	case WIFI_SECURITY_TYPE_SAE: {
+		struct wifi_credentials_personal *header_personal =
+			(struct wifi_credentials_personal *)buf;
+
+		memcpy(password_buf, header_personal->password, header_personal->password_len);
+		*password_len = header_personal->password_len;
+		break;
+	}
+	default:
+		LOG_ERR("Cannot get WiFi credentials, "
+			"the requested credentials have invalid WIFI_SECURITY_TYPE");
+		ret = -EPROTO;
+	}
+	return ret;
+}
+
+int wifi_credentials_delete_by_ssid(const char *ssid, size_t ssid_len)
+{
+	int ret = 0;
+
+	if (ssid == NULL || ssid_len > WIFI_SSID_MAX_LEN || ssid_len == 0) {
+		LOG_ERR("Cannot delete WiFi credentials, SSID has invalid format");
+		return -EINVAL;
+	}
+
+	k_mutex_lock(&wifi_credentials_mutex, K_FOREVER);
+	ssize_t idx = lookup_idx(ssid, ssid_len);
+
+	if (idx == -1) {
+		LOG_DBG("WiFi credentials entry was not found");
+		goto exit;
+	}
+
+	ret = wifi_credentials_delete_entry(idx);
+
+	if (ret) {
+		LOG_ERR("Failed to delete WiFi credentials index %d, err: %d", idx, ret);
+		goto exit;
+	}
+
+	wifi_credentials_uncache_ssid(idx);
+
+exit:
+	k_mutex_unlock(&wifi_credentials_mutex);
+	return ret;
+}
+
+void wifi_credentials_for_each_ssid(wifi_credentials_ssid_cb cb, void *cb_arg)
+{
+	k_mutex_lock(&wifi_credentials_mutex, K_FOREVER);
+
+	for (size_t i = 0; i < CONFIG_WIFI_CREDENTIALS_MAX_ENTRIES; ++i) {
+		if (is_entry_used(i)) {
+			cb(cb_arg, ssid_cache[i], ssid_cache_lengths[i]);
+		}
+	}
+
+	k_mutex_unlock(&wifi_credentials_mutex);
+}
+
+bool wifi_credentials_is_empty(void)
+{
+	k_mutex_lock(&wifi_credentials_mutex, K_FOREVER);
+
+	for (size_t i = 0; i < CONFIG_WIFI_CREDENTIALS_MAX_ENTRIES; ++i) {
+		if (is_entry_used(i)) {
+			k_mutex_unlock(&wifi_credentials_mutex);
+			return false;
+		}
+	}
+
+	k_mutex_unlock(&wifi_credentials_mutex);
+	return true;
+}
+
+int wifi_credentials_delete_all(void)
+{
+	int ret = 0;
+
+	k_mutex_lock(&wifi_credentials_mutex, K_FOREVER);
+	for (size_t i = 0; i < CONFIG_WIFI_CREDENTIALS_MAX_ENTRIES; ++i) {
+		if (is_entry_used(i)) {
+			ret = wifi_credentials_delete_entry(i);
+			if (ret) {
+				LOG_ERR("Failed to delete WiFi credentials index %d, err: %d", i,
+					ret);
+				break;
+			}
+
+			wifi_credentials_uncache_ssid(i);
+		}
+	}
+
+	k_mutex_unlock(&wifi_credentials_mutex);
+	return ret;
+}
+
+SYS_INIT(init, POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY);

--- a/subsys/net/lib/wifi_credentials/wifi_credentials_backend_none.c
+++ b/subsys/net/lib/wifi_credentials/wifi_credentials_backend_none.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+
+#include "wifi_credentials_internal.h"
+
+int wifi_credentials_store_entry(size_t idx, const void *buf, size_t buf_len)
+{
+	ARG_UNUSED(idx);
+	ARG_UNUSED(buf);
+	ARG_UNUSED(buf_len);
+
+	return 0;
+}
+
+int wifi_credentials_delete_entry(size_t idx)
+{
+	ARG_UNUSED(idx);
+
+	return 0;
+}
+
+int wifi_credentials_load_entry(size_t idx, void *buf, size_t buf_len)
+{
+	ARG_UNUSED(idx);
+	ARG_UNUSED(buf);
+	ARG_UNUSED(buf_len);
+
+	return 0;
+}
+
+int wifi_credentials_backend_init(void)
+{
+	return 0;
+}

--- a/subsys/net/lib/wifi_credentials/wifi_credentials_backend_psa.c
+++ b/subsys/net/lib/wifi_credentials/wifi_credentials_backend_psa.c
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include "psa/crypto.h"
+
+#include "wifi_credentials_internal.h"
+
+LOG_MODULE_REGISTER(wifi_credentials_backend, CONFIG_WIFI_CREDENTIALS_LOG_LEVEL);
+
+#define WIFI_CREDENTIALS_BACKEND_PSA_KEY_ID_USER_MIN                                               \
+	(PSA_KEY_ID_USER_MIN + CONFIG_WIFI_CREDENTIALS_BACKEND_PSA_OFFSET)
+
+BUILD_ASSERT((WIFI_CREDENTIALS_BACKEND_PSA_KEY_ID_USER_MIN + CONFIG_WIFI_CREDENTIALS_MAX_ENTRIES) <=
+		     PSA_KEY_ID_USER_MAX,
+	     "WIFI credentials management PSA key id range exceeds PSA_KEY_ID_USER_MAX.");
+
+int wifi_credentials_backend_init(void)
+{
+	psa_status_t ret;
+	uint8_t buf[ENTRY_MAX_LEN];
+
+	for (size_t i = 0; i < CONFIG_WIFI_CREDENTIALS_MAX_ENTRIES; ++i) {
+		size_t length_read = 0;
+		size_t key_id = i + WIFI_CREDENTIALS_BACKEND_PSA_KEY_ID_USER_MIN;
+
+		ret = psa_export_key(key_id, buf, ARRAY_SIZE(buf), &length_read);
+		if (ret == PSA_SUCCESS && length_read == ENTRY_MAX_LEN) {
+			wifi_credentials_cache_ssid(i, (struct wifi_credentials_header *)buf);
+		} else if (ret != PSA_ERROR_INVALID_HANDLE) {
+			LOG_ERR("psa_export_key failed, err: %d", ret);
+			return -EFAULT;
+		}
+	}
+
+	return 0;
+}
+
+int wifi_credentials_store_entry(size_t idx, const void *buf, size_t buf_len)
+{
+	psa_status_t ret;
+	psa_key_attributes_t key_attributes = {0};
+	psa_key_id_t key_id;
+
+	psa_set_key_id(&key_attributes, idx + WIFI_CREDENTIALS_BACKEND_PSA_KEY_ID_USER_MIN);
+	psa_set_key_usage_flags(&key_attributes, PSA_KEY_USAGE_EXPORT);
+	psa_set_key_lifetime(&key_attributes, PSA_KEY_LIFETIME_PERSISTENT);
+	psa_set_key_algorithm(&key_attributes, PSA_ALG_NONE);
+	psa_set_key_type(&key_attributes, PSA_KEY_TYPE_RAW_DATA);
+	psa_set_key_bits(&key_attributes, buf_len * 8);
+
+	ret = psa_import_key(&key_attributes, buf, buf_len, &key_id);
+	if (ret == PSA_ERROR_ALREADY_EXISTS) {
+		LOG_ERR("psa_import_key failed, duplicate key: %d", ret);
+		return -EEXIST;
+	} else if (ret != PSA_SUCCESS) {
+		LOG_ERR("psa_import_key failed, err: %d", ret);
+		return -EFAULT;
+	}
+
+	return 0;
+}
+
+int wifi_credentials_delete_entry(size_t idx)
+{
+	psa_status_t ret = psa_destroy_key(idx + WIFI_CREDENTIALS_BACKEND_PSA_KEY_ID_USER_MIN);
+
+	if (ret != PSA_SUCCESS) {
+		LOG_ERR("psa_destroy_key failed, err: %d", ret);
+		return -EFAULT;
+	}
+
+	return 0;
+}
+
+int wifi_credentials_load_entry(size_t idx, void *buf, size_t buf_len)
+{
+	size_t length_read = 0;
+	size_t key_id = idx + WIFI_CREDENTIALS_BACKEND_PSA_KEY_ID_USER_MIN;
+	psa_status_t ret;
+
+	ret = psa_export_key(key_id, buf, buf_len, &length_read);
+	if (ret != PSA_SUCCESS) {
+		LOG_ERR("psa_export_key failed, err: %d", ret);
+		return -EFAULT;
+	}
+
+	if (buf_len != length_read) {
+		return -EIO;
+	}
+
+	return 0;
+}

--- a/subsys/net/lib/wifi_credentials/wifi_credentials_backend_settings.c
+++ b/subsys/net/lib/wifi_credentials/wifi_credentials_backend_settings.c
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <stdlib.h>
+#include <zephyr/settings/settings.h>
+
+#include "wifi_credentials_internal.h"
+
+LOG_MODULE_REGISTER(wifi_credentials_backend, CONFIG_WIFI_CREDENTIALS_LOG_LEVEL);
+
+BUILD_ASSERT(ENTRY_MAX_LEN <= SETTINGS_MAX_VAL_LEN);
+
+#define WIFI_CREDENTIALS_SBE_BASE_KEY "wifi_cred"
+#define WIFI_CREDENTIALS_SBE_KEY_SIZE                                                              \
+	sizeof(WIFI_CREDENTIALS_SBE_BASE_KEY "/" STRINGIFY(CONFIG_WIFI_CREDENTIALS_MAX_ENTRIES))
+#define WIFI_CREDENTIALS_SBE_KEY_FMT WIFI_CREDENTIALS_SBE_BASE_KEY "/%d"
+
+/* Type of the callback argument used in the function below. */
+struct zephyr_settings_backend_load_cb_arg {
+	uint8_t *buf;
+	size_t buf_len;
+	size_t idx;
+	bool found;
+};
+
+/* This callback function is used to retrieve credentials on demand. */
+static int zephyr_settings_backend_load_val_cb(const char *key, size_t len,
+					       settings_read_cb read_cb, void *cb_arg, void *param)
+{
+	struct zephyr_settings_backend_load_cb_arg *arg = param;
+	int idx = atoi(key);
+
+	if (arg->idx != idx) {
+		LOG_DBG("Skipping index [%s]", key);
+		return 0;
+	}
+
+	if (len != arg->buf_len) {
+		LOG_ERR("Settings error: invalid settings length");
+		return -EINVAL;
+	}
+
+	size_t length_read = read_cb(cb_arg, arg->buf, arg->buf_len);
+
+	/* value validation */
+	if (length_read < len) {
+		LOG_ERR("Settings error: entry incomplete");
+		return -ENODATA;
+	}
+
+	arg->found = true;
+
+	return 0;
+}
+
+/* This callback function is used to initialize the SSID cache. */
+static int zephyr_settings_backend_load_key_cb(const char *key, size_t len,
+					       settings_read_cb read_cb, void *cb_arg, void *param)
+{
+	ARG_UNUSED(param);
+
+	/* key validation */
+	if (!key) {
+		LOG_ERR("Settings error: no key");
+		return -EINVAL;
+	}
+
+	int idx = atoi(key);
+
+	if ((idx == 0 && strcmp(key, "0") != 0) || idx >= CONFIG_WIFI_CREDENTIALS_MAX_ENTRIES) {
+		LOG_ERR("Settings error: index too large");
+		return -EINVAL;
+	}
+
+	if (len < sizeof(struct wifi_credentials_header)) {
+		LOG_ERR("Settings error: invalid settings length");
+		return -EINVAL;
+	}
+
+	uint8_t buf[ENTRY_MAX_LEN];
+	size_t length_read = read_cb(cb_arg, buf, ARRAY_SIZE(buf));
+
+	/* value validation */
+	if (length_read < len) {
+		LOG_ERR("Settings error: entry incomplete");
+		return -ENODATA;
+	}
+
+	wifi_credentials_cache_ssid(idx, (struct wifi_credentials_header *)buf);
+	return 0;
+}
+
+int wifi_credentials_backend_init(void)
+{
+	int ret = settings_subsys_init();
+
+	if (ret) {
+		LOG_ERR("Initializing settings subsystem failed: %d", ret);
+		return ret;
+	}
+
+	ret = settings_load_subtree_direct(WIFI_CREDENTIALS_SBE_BASE_KEY,
+					   zephyr_settings_backend_load_key_cb, NULL);
+
+	return ret;
+}
+
+int wifi_credentials_store_entry(size_t idx, const void *buf, size_t buf_len)
+{
+	char settings_name_buf[WIFI_CREDENTIALS_SBE_KEY_SIZE] = {0};
+
+	int ret = snprintk(settings_name_buf, ARRAY_SIZE(settings_name_buf),
+			   WIFI_CREDENTIALS_SBE_KEY_FMT, idx);
+
+	if (ret < 0 || ret == ARRAY_SIZE(settings_name_buf)) {
+		LOG_ERR("WiFi credentials settings key could not be generated, idx: %d", idx);
+		return -EFAULT;
+	}
+
+	return settings_save_one(settings_name_buf, buf, buf_len);
+}
+
+int wifi_credentials_delete_entry(size_t idx)
+{
+	char settings_name_buf[WIFI_CREDENTIALS_SBE_KEY_SIZE] = {0};
+
+	int ret = snprintk(settings_name_buf, ARRAY_SIZE(settings_name_buf),
+			   WIFI_CREDENTIALS_SBE_KEY_FMT, idx);
+
+	if (ret < 0 || ret == ARRAY_SIZE(settings_name_buf)) {
+		LOG_ERR("WiFi credentials settings key could not be generated, idx: %d", idx);
+		return -EFAULT;
+	}
+
+	return settings_delete(settings_name_buf);
+}
+
+int wifi_credentials_load_entry(size_t idx, void *buf, size_t buf_len)
+{
+	struct zephyr_settings_backend_load_cb_arg arg = {
+		.buf = buf,
+		.buf_len = buf_len,
+		.idx = idx,
+		.found = false,
+	};
+	int ret;
+
+	/* Browse through the settings entries with custom callback to load the whole entry. */
+	ret = settings_load_subtree_direct(WIFI_CREDENTIALS_SBE_BASE_KEY,
+					   zephyr_settings_backend_load_val_cb, &arg);
+
+	if (ret) {
+		return ret;
+	}
+
+	if (!arg.found) {
+		return -ENOENT;
+	}
+
+	return 0;
+}

--- a/subsys/net/lib/wifi_credentials/wifi_credentials_internal.h
+++ b/subsys/net/lib/wifi_credentials/wifi_credentials_internal.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/net/wifi_credentials.h>
+
+#define ENTRY_MAX_LEN sizeof(struct wifi_credentials_personal)
+
+/**
+ * @brief Write entry to SSID cache.
+ *
+ * @param idx credential index
+ * @param buf encoded settings entry
+ * @param buf_len length of buf
+ */
+void wifi_credentials_cache_ssid(size_t idx, const struct wifi_credentials_header *buf);
+
+/**
+ * @brief Clear entry in SSID cache.
+ *
+ * @param idx credential index
+ */
+void wifi_credentials_uncache_ssid(size_t idx);
+
+/**
+ * @brief Stores settings entry in flash.
+ *
+ * @param idx credential index
+ * @param buf encoded settings entry
+ * @param buf_len length of buf
+ * @return 0 on success, otherwise a negative error code
+ */
+int wifi_credentials_store_entry(size_t idx, const void *buf, size_t buf_len);
+
+/**
+ * @brief Deletes settings entry from flash.
+ *
+ * @param idx credential index
+ * @return 0 on success, otherwise a negative error code
+ */
+int wifi_credentials_delete_entry(size_t idx);
+
+/**
+ * @brief Loads settings entry from flash.
+ *
+ * @param idx credential index
+ * @param buf encoded settings entry
+ * @param buf_len length of buf
+ * @return 0 on success, otherwise a negative error code
+ */
+int wifi_credentials_load_entry(size_t idx, void *buf, size_t buf_len);
+
+/**
+ * @brief Initialize backend.
+ * @note Is called by the library on system startup.
+ *
+ */
+int wifi_credentials_backend_init(void);

--- a/subsys/net/lib/wifi_credentials/wifi_credentials_shell.c
+++ b/subsys/net/lib/wifi_credentials/wifi_credentials_shell.c
@@ -66,8 +66,7 @@ static void print_network_info(void *cb_arg, const char *ssid, size_t ssid_len)
 	}
 
 	if (creds.header.channel) {
-		shell_fprintf(sh, SHELL_VT100_COLOR_DEFAULT, ", channel: %d",
-			      creds.header.channel);
+		shell_fprintf(sh, SHELL_VT100_COLOR_DEFAULT, ", channel: %d", creds.header.channel);
 	}
 
 	if (creds.header.flags & WIFI_CREDENTIALS_FLAG_FAVORITE) {
@@ -83,8 +82,7 @@ static void print_network_info(void *cb_arg, const char *ssid, size_t ssid_len)
 	}
 
 	if (creds.header.timeout) {
-		shell_fprintf(sh, SHELL_VT100_COLOR_DEFAULT, ", timeout: %d",
-			      creds.header.timeout);
+		shell_fprintf(sh, SHELL_VT100_COLOR_DEFAULT, ", timeout: %d", creds.header.timeout);
 	}
 
 	shell_fprintf(sh, SHELL_VT100_COLOR_DEFAULT, "\n");
@@ -258,14 +256,14 @@ static int cmd_add_network(const struct shell *sh, size_t argc, char *argv[])
 	return wifi_credentials_set_personal_struct(&creds);
 help:
 	shell_print(sh, "Usage: wifi_cred add \"network name\""
-			   " {OPEN, WPA2-PSK, WPA2-PSK-SHA256, WPA3-SAE, WPA-PSK}"
-			   " [psk/password]"
-			   " [bssid]"
-			   " [{2.4GHz, 5GHz}]"
-			   " [channel]"
-			   " [favorite]"
-			   " [mfp_disabled|mfp_required]"
-			   " [timeout]");
+			" {OPEN, WPA2-PSK, WPA2-PSK-SHA256, WPA3-SAE, WPA-PSK}"
+			" [psk/password]"
+			" [bssid]"
+			" [{2.4GHz, 5GHz}]"
+			" [channel]"
+			" [favorite]"
+			" [mfp_disabled|mfp_required]"
+			" [timeout]");
 	return -EINVAL;
 }
 
@@ -281,8 +279,7 @@ static int cmd_delete_network(const struct shell *sh, size_t argc, char *argv[])
 		return -EINVAL;
 	}
 
-	shell_print(sh, "\tDeleting network ssid: \"%s\", ssid_len: %d", argv[1],
-		    strlen(argv[1]));
+	shell_print(sh, "\tDeleting network ssid: \"%s\", ssid_len: %d", argv[1], strlen(argv[1]));
 	return wifi_credentials_delete_by_ssid(argv[1], strlen(argv[1]));
 }
 
@@ -291,6 +288,24 @@ static int cmd_list_networks(const struct shell *sh, size_t argc, char *argv[])
 	wifi_credentials_for_each_ssid(print_network_info, (void *)sh);
 	return 0;
 }
+
+#if CONFIG_WIFI_CREDENTIALS_CONNECT_STORED
+
+static int cmd_auto_connect(const struct shell *sh, size_t argc, char *argv[])
+{
+	struct net_if *iface = net_if_get_first_by_type(&NET_L2_GET_NAME(ETHERNET));
+	int rc = net_mgmt(NET_REQUEST_WIFI_CONNECT_STORED, iface, NULL, 0);
+
+	if (rc) {
+		shell_error(sh,
+			    "An error occurred when trying to auto-connect to a network. err: %d",
+			    rc);
+	}
+
+	return 0;
+}
+
+#endif /* CONFIG_WIFI_CREDENTIALS_CONNECT_STORED */
 
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_wifi_cred,
 	SHELL_CMD_ARG(add, NULL,
@@ -304,6 +319,14 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_wifi_cred,
 		      "List stored networks.\n",
 		      cmd_list_networks,
 		      0, 0),
+
+#if CONFIG_WIFI_CREDENTIALS_CONNECT_STORED
+	SHELL_CMD_ARG(auto_connect, NULL,
+		      "Connect to any stored network.\n",
+		      cmd_auto_connect,
+		      0, 0),
+#endif /* CONFIG_WIFI_CREDENTIALS_CONNECT_STORED */
+
 	SHELL_SUBCMD_SET_END
 );
 

--- a/subsys/net/lib/wifi_credentials/wifi_credentials_shell.c
+++ b/subsys/net/lib/wifi_credentials/wifi_credentials_shell.c
@@ -1,0 +1,313 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#undef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L /* For strnlen() */
+
+#include <zephyr/kernel.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <zephyr/shell/shell.h>
+#include <zephyr/init.h>
+
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/wifi_mgmt.h>
+#include <zephyr/net/net_event.h>
+#include <zephyr/net/net_l2.h>
+#include <zephyr/net/ethernet.h>
+
+#include <zephyr/net/wifi_credentials.h>
+
+#define MACSTR "%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx"
+
+static void print_network_info(void *cb_arg, const char *ssid, size_t ssid_len)
+{
+	int ret = 0;
+	struct wifi_credentials_personal creds = {0};
+	const struct shell *sh = (const struct shell *)cb_arg;
+
+	ret = wifi_credentials_get_by_ssid_personal_struct(ssid, ssid_len, &creds);
+	if (ret) {
+		shell_error(sh,
+			    "An error occurred when trying to load credentials for network \"%.*s\""
+			    ". err: %d",
+			    ssid_len, ssid, ret);
+		return;
+	}
+
+	shell_fprintf(sh, SHELL_VT100_COLOR_DEFAULT,
+		      "  network ssid: \"%.*s\", ssid_len: %d, type: %s", ssid_len, ssid, ssid_len,
+		      wifi_security_txt(creds.header.type));
+
+	if (creds.header.type == WIFI_SECURITY_TYPE_PSK ||
+	    creds.header.type == WIFI_SECURITY_TYPE_PSK_SHA256 ||
+	    creds.header.type == WIFI_SECURITY_TYPE_SAE ||
+	    creds.header.type == WIFI_SECURITY_TYPE_WPA_PSK) {
+		shell_fprintf(sh, SHELL_VT100_COLOR_DEFAULT,
+			      ", password: \"%.*s\", password_len: %d", creds.password_len,
+			      creds.password, creds.password_len);
+	}
+
+	if (creds.header.flags & WIFI_CREDENTIALS_FLAG_BSSID) {
+		shell_fprintf(sh, SHELL_VT100_COLOR_DEFAULT, ", bssid: " MACSTR,
+			      creds.header.bssid[0], creds.header.bssid[1], creds.header.bssid[2],
+			      creds.header.bssid[3], creds.header.bssid[4], creds.header.bssid[5]);
+	}
+
+	if (creds.header.flags & WIFI_CREDENTIALS_FLAG_2_4GHz) {
+		shell_fprintf(sh, SHELL_VT100_COLOR_DEFAULT, ", band: 2.4GHz");
+	}
+
+	if (creds.header.flags & WIFI_CREDENTIALS_FLAG_5GHz) {
+		shell_fprintf(sh, SHELL_VT100_COLOR_DEFAULT, ", band: 5GHz");
+	}
+
+	if (creds.header.channel) {
+		shell_fprintf(sh, SHELL_VT100_COLOR_DEFAULT, ", channel: %d",
+			      creds.header.channel);
+	}
+
+	if (creds.header.flags & WIFI_CREDENTIALS_FLAG_FAVORITE) {
+		shell_fprintf(sh, SHELL_VT100_COLOR_DEFAULT, ", favorite");
+	}
+
+	if (creds.header.flags & WIFI_CREDENTIALS_FLAG_MFP_REQUIRED) {
+		shell_fprintf(sh, SHELL_VT100_COLOR_DEFAULT, ", MFP_REQUIRED");
+	} else if (creds.header.flags & WIFI_CREDENTIALS_FLAG_MFP_DISABLED) {
+		shell_fprintf(sh, SHELL_VT100_COLOR_DEFAULT, ", MFP_DISABLED");
+	} else {
+		shell_fprintf(sh, SHELL_VT100_COLOR_DEFAULT, ", MFP_OPTIONAL");
+	}
+
+	if (creds.header.timeout) {
+		shell_fprintf(sh, SHELL_VT100_COLOR_DEFAULT, ", timeout: %d",
+			      creds.header.timeout);
+	}
+
+	shell_fprintf(sh, SHELL_VT100_COLOR_DEFAULT, "\n");
+}
+
+static enum wifi_security_type parse_sec_type(const char *s)
+{
+	if (strcmp("OPEN", s) == 0) {
+		return WIFI_SECURITY_TYPE_NONE;
+	}
+
+	if (strcmp("WPA2-PSK", s) == 0) {
+		return WIFI_SECURITY_TYPE_PSK;
+	}
+
+	if (strcmp("WPA2-PSK-SHA256", s) == 0) {
+		return WIFI_SECURITY_TYPE_PSK_SHA256;
+	}
+
+	if (strcmp("WPA3-SAE", s) == 0) {
+		return WIFI_SECURITY_TYPE_SAE;
+	}
+
+	if (strcmp("WPA-PSK", s) == 0) {
+		return WIFI_SECURITY_TYPE_WPA_PSK;
+	}
+
+	return WIFI_SECURITY_TYPE_UNKNOWN;
+}
+
+static enum wifi_frequency_bands parse_band(const char *s)
+{
+	if (strcmp("2.4GHz", s) == 0) {
+		return WIFI_FREQ_BAND_2_4_GHZ;
+	}
+
+	if (strcmp("5GHz", s) == 0) {
+		return WIFI_FREQ_BAND_5_GHZ;
+	}
+
+	if (strcmp("6GHz", s) == 0) {
+		return WIFI_FREQ_BAND_6_GHZ;
+	}
+
+	return WIFI_FREQ_BAND_UNKNOWN;
+}
+
+static int cmd_add_network(const struct shell *sh, size_t argc, char *argv[])
+{
+	int ret;
+
+	if (argc < 3) {
+		goto help;
+	}
+
+	if (strnlen(argv[1], WIFI_SSID_MAX_LEN + 1) > WIFI_SSID_MAX_LEN) {
+		shell_error(sh, "SSID too long");
+		goto help;
+	}
+
+	struct wifi_credentials_personal creds = {
+		.header.ssid_len = strlen(argv[1]),
+		.header.type = parse_sec_type(argv[2]),
+	};
+
+	memcpy(creds.header.ssid, argv[1], creds.header.ssid_len);
+
+	if (creds.header.type == WIFI_SECURITY_TYPE_UNKNOWN) {
+		shell_error(sh, "Cannot parse security type");
+		goto help;
+	}
+
+	size_t arg_idx = 3;
+
+	if (creds.header.type == WIFI_SECURITY_TYPE_PSK ||
+	    creds.header.type == WIFI_SECURITY_TYPE_PSK_SHA256 ||
+	    creds.header.type == WIFI_SECURITY_TYPE_SAE ||
+	    creds.header.type == WIFI_SECURITY_TYPE_WPA_PSK) {
+		/* parse passphrase */
+		if (argc < 4) {
+			shell_error(sh, "Missing password");
+			goto help;
+		}
+		creds.password_len = strlen(argv[3]);
+		if (creds.password_len < WIFI_PSK_MIN_LEN) {
+			shell_error(sh, "Passphrase should be minimum %d characters",
+				    WIFI_PSK_MIN_LEN);
+			goto help;
+		}
+		if ((creds.password_len > CONFIG_WIFI_CREDENTIALS_SAE_PASSWORD_LENGTH &&
+		     creds.header.type == WIFI_SECURITY_TYPE_SAE) ||
+		    (creds.password_len > WIFI_PSK_MAX_LEN &&
+		     creds.header.type != WIFI_SECURITY_TYPE_SAE)) {
+			shell_error(sh, "Password is too long for this security type");
+			goto help;
+		}
+		memcpy(creds.password, argv[3], creds.password_len);
+		++arg_idx;
+	}
+
+	if (arg_idx < argc) {
+		/* look for bssid */
+		ret = sscanf(argv[arg_idx], MACSTR, &creds.header.bssid[0], &creds.header.bssid[1],
+			     &creds.header.bssid[2], &creds.header.bssid[3], &creds.header.bssid[4],
+			     &creds.header.bssid[5]);
+		if (ret == 6) {
+			creds.header.flags |= WIFI_CREDENTIALS_FLAG_BSSID;
+			++arg_idx;
+		}
+	}
+
+	if (arg_idx < argc) {
+		/* look for band */
+		enum wifi_frequency_bands band = parse_band(argv[arg_idx]);
+
+		if (band == WIFI_FREQ_BAND_2_4_GHZ) {
+			creds.header.flags |= WIFI_CREDENTIALS_FLAG_2_4GHz;
+			++arg_idx;
+		}
+		if (band == WIFI_FREQ_BAND_5_GHZ) {
+			creds.header.flags |= WIFI_CREDENTIALS_FLAG_5GHz;
+			++arg_idx;
+		}
+	}
+
+	if (arg_idx < argc) {
+		/* look for channel */
+		char *end;
+
+		creds.header.channel = strtol(argv[arg_idx], &end, 10);
+		if (*end == '\0') {
+			++arg_idx;
+		}
+	}
+
+	if (arg_idx < argc) {
+		/* look for favorite flag */
+		if (strncmp("favorite", argv[arg_idx], strlen("favorite")) == 0) {
+			creds.header.flags |= WIFI_CREDENTIALS_FLAG_FAVORITE;
+			++arg_idx;
+		}
+	}
+
+	if (arg_idx < argc) {
+		/* look for mfp_disabled flag */
+		if (strncmp("mfp_disabled", argv[arg_idx], strlen("mfp_disabled")) == 0) {
+			creds.header.flags |= WIFI_CREDENTIALS_FLAG_MFP_DISABLED;
+			++arg_idx;
+		} else if (strncmp("mfp_required", argv[arg_idx], strlen("mfp_required")) == 0) {
+			creds.header.flags |= WIFI_CREDENTIALS_FLAG_MFP_REQUIRED;
+			++arg_idx;
+		}
+	}
+
+	if (arg_idx < argc) {
+		/* look for timeout */
+		char *end;
+
+		creds.header.timeout = strtol(argv[arg_idx], &end, 10);
+		if (*end == '\0') {
+			++arg_idx;
+		}
+	}
+
+	if (arg_idx != argc) {
+		for (size_t i = arg_idx; i < argc; ++i) {
+			shell_warn(sh, "Unparsed arg: [%s]", argv[i]);
+		}
+	}
+
+	return wifi_credentials_set_personal_struct(&creds);
+help:
+	shell_print(sh, "Usage: wifi_cred add \"network name\""
+			   " {OPEN, WPA2-PSK, WPA2-PSK-SHA256, WPA3-SAE, WPA-PSK}"
+			   " [psk/password]"
+			   " [bssid]"
+			   " [{2.4GHz, 5GHz}]"
+			   " [channel]"
+			   " [favorite]"
+			   " [mfp_disabled|mfp_required]"
+			   " [timeout]");
+	return -EINVAL;
+}
+
+static int cmd_delete_network(const struct shell *sh, size_t argc, char *argv[])
+{
+	if (argc != 2) {
+		shell_print(sh, "Usage: wifi_cred delete \"network name\"");
+		return -EINVAL;
+	}
+
+	if (strnlen(argv[1], WIFI_SSID_MAX_LEN + 1) > WIFI_SSID_MAX_LEN) {
+		shell_error(sh, "SSID too long");
+		return -EINVAL;
+	}
+
+	shell_print(sh, "\tDeleting network ssid: \"%s\", ssid_len: %d", argv[1],
+		    strlen(argv[1]));
+	return wifi_credentials_delete_by_ssid(argv[1], strlen(argv[1]));
+}
+
+static int cmd_list_networks(const struct shell *sh, size_t argc, char *argv[])
+{
+	wifi_credentials_for_each_ssid(print_network_info, (void *)sh);
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_wifi_cred,
+	SHELL_CMD_ARG(add, NULL,
+		      "Add network to storage.\n",
+		      cmd_add_network, 0, 0),
+	SHELL_CMD_ARG(delete, NULL,
+		      "Delete network from storage.\n",
+		      cmd_delete_network,
+		      0, 0),
+	SHELL_CMD_ARG(list, NULL,
+		      "List stored networks.\n",
+		      cmd_list_networks,
+		      0, 0),
+	SHELL_SUBCMD_SET_END
+);
+
+SHELL_SUBCMD_ADD((wifi), cred, &sub_wifi_cred,
+		 "Wifi credentials management.\n",
+		 NULL,
+		 0, 0);

--- a/tests/net/lib/wifi_credentials/CMakeLists.txt
+++ b/tests/net/lib/wifi_credentials/CMakeLists.txt
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(wifi_credentials_test)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})
+
+target_sources(app
+  PRIVATE
+  ${ZEPHYR_BASE}/subsys/net/lib/wifi_credentials/wifi_credentials.c
+)
+
+zephyr_include_directories(${ZEPHYR_BASE}/subsys/testsuite/include)
+zephyr_include_directories(${ZEPHYR_BASE}/subsys/net/lib/wifi_credentials/)
+
+target_compile_options(app
+  PRIVATE
+  -DCONFIG_WIFI_CREDENTIALS_MAX_ENTRIES=2
+  -DCONFIG_WIFI_CREDENTIALS_SAE_PASSWORD_LENGTH=128
+  -DCONFIG_WIFI_CREDENTIALS_LOG_LEVEL=4
+)

--- a/tests/net/lib/wifi_credentials/prj.conf
+++ b/tests/net/lib/wifi_credentials/prj.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_ZTEST=y
+CONFIG_LOG=y

--- a/tests/net/lib/wifi_credentials/src/main.c
+++ b/tests/net/lib/wifi_credentials/src/main.c
@@ -1,0 +1,354 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+
+#include <zephyr/fff.h>
+
+#include <zephyr/net/wifi_credentials.h>
+
+#include "wifi_credentials_internal.h"
+
+DEFINE_FFF_GLOBALS;
+
+FAKE_VALUE_FUNC(int, wifi_credentials_store_entry, size_t, const void *, size_t)
+FAKE_VALUE_FUNC(int, wifi_credentials_load_entry, size_t, void *, size_t)
+FAKE_VALUE_FUNC(int, wifi_credentials_delete_entry, size_t)
+FAKE_VALUE_FUNC(int, wifi_credentials_backend_init)
+
+uint8_t fake_settings_buf[CONFIG_WIFI_CREDENTIALS_MAX_ENTRIES][ENTRY_MAX_LEN];
+
+int custom_wifi_credentials_store_entry(size_t idx, const void *buf, size_t buf_len)
+{
+	zassert_true(idx < CONFIG_WIFI_CREDENTIALS_MAX_ENTRIES, "Index out of bounds");
+	memcpy(fake_settings_buf[idx], buf, MIN(ENTRY_MAX_LEN, buf_len));
+	return 0;
+}
+
+int custom_wifi_credentials_load_entry(size_t idx, void *buf, size_t buf_len)
+{
+	zassert_true(idx < CONFIG_WIFI_CREDENTIALS_MAX_ENTRIES, "Index out of bounds");
+	memcpy(buf, fake_settings_buf[idx], MIN(ENTRY_MAX_LEN, buf_len));
+	return 0;
+}
+
+#define SSID1     "test1"
+#define PSK1      "super secret"
+#define SECURITY1 WIFI_SECURITY_TYPE_PSK
+#define BSSID1    "abcdef"
+#define FLAGS1    WIFI_CREDENTIALS_FLAG_BSSID
+#define CHANNEL1  1
+
+#define SSID2     "test2"
+#define SECURITY2 WIFI_SECURITY_TYPE_NONE
+#define FLAGS2    0
+#define CHANNEL2  2
+
+#define SSID3     "test3"
+#define PSK3      "extremely secret"
+#define SECURITY3 WIFI_SECURITY_TYPE_SAE
+#define FLAGS3    0
+#define CHANNEL3  3
+
+#define SSID4     "\0what's\0null\0termination\0anyway"
+#define PSK4      PSK1
+#define SECURITY4 SECURITY1
+#define BSSID4    BSSID1
+#define FLAGS4    FLAGS1
+#define CHANNEL4  4
+
+static void wifi_credentials_setup(void *unused)
+{
+	RESET_FAKE(wifi_credentials_store_entry);
+	RESET_FAKE(wifi_credentials_load_entry);
+	RESET_FAKE(wifi_credentials_delete_entry);
+	wifi_credentials_store_entry_fake.custom_fake = custom_wifi_credentials_store_entry;
+	wifi_credentials_load_entry_fake.custom_fake = custom_wifi_credentials_load_entry;
+}
+
+static void wifi_credentials_teardown(void *unused)
+{
+	wifi_credentials_delete_by_ssid(SSID1, ARRAY_SIZE(SSID1));
+	wifi_credentials_delete_by_ssid(SSID2, ARRAY_SIZE(SSID2));
+	wifi_credentials_delete_by_ssid(SSID3, ARRAY_SIZE(SSID3));
+	wifi_credentials_delete_by_ssid(SSID4, ARRAY_SIZE(SSID4));
+	wifi_credentials_delete_by_ssid("", 0);
+}
+
+/* Verify that attempting to retrieve a non-existent credentials entry raises -ENOENT. */
+ZTEST(wifi_credentials, test_get_non_existing)
+{
+	int err;
+	enum wifi_security_type security = -1;
+	uint8_t bssid_buf[WIFI_MAC_ADDR_LEN] = "";
+	char psk_buf[WIFI_CREDENTIALS_MAX_PASSWORD_LEN] = "";
+	size_t psk_len = 0;
+	uint32_t flags = 0;
+	uint8_t channel = 0;
+	uint32_t timeout = 0;
+
+	err = wifi_credentials_get_by_ssid_personal(
+		SSID1, sizeof(SSID1), &security, bssid_buf, ARRAY_SIZE(bssid_buf), psk_buf,
+		ARRAY_SIZE(psk_buf), &psk_len, &flags, &channel, &timeout);
+	zassert_equal(err, -ENOENT, "Expected -ENOENT, got %d", err);
+}
+
+/* Verify that we can successfully set/get a network without a specified BSSID. */
+ZTEST(wifi_credentials, test_single_no_bssid)
+{
+	int err;
+
+	/* set network credentials without BSSID */
+	err = wifi_credentials_set_personal(SSID1, sizeof(SSID1), SECURITY1, NULL, 0, PSK1,
+					    sizeof(PSK1), 0, 0, 0);
+	zassert_equal(err, EXIT_SUCCESS, "Expected EXIT_SUCCESS, got %d", err);
+
+	enum wifi_security_type security = -1;
+	uint8_t bssid_buf[WIFI_MAC_ADDR_LEN] = "";
+	char psk_buf[WIFI_CREDENTIALS_MAX_PASSWORD_LEN] = "";
+	size_t psk_len = 0;
+	uint32_t flags = 0;
+	uint8_t channel = 0;
+	uint32_t timeout = 0;
+
+	/* retrieve network credentials without BSSID */
+	err = wifi_credentials_get_by_ssid_personal(
+		SSID1, sizeof(SSID1), &security, bssid_buf, ARRAY_SIZE(bssid_buf), psk_buf,
+		ARRAY_SIZE(psk_buf), &psk_len, &flags, &channel, &timeout);
+	zassert_equal(err, EXIT_SUCCESS, "Expected EXIT_SUCCESS, got %d", err);
+	zassert_equal(strncmp(PSK1, psk_buf, ARRAY_SIZE(psk_buf)), 0, "PSK mismatch");
+	zassert_equal(flags, 0, "Flags mismatch");
+	zassert_equal(channel, 0, "Channel mismatch");
+	zassert_equal(security, SECURITY1, "Security type mismatch");
+
+	err = wifi_credentials_delete_by_ssid(SSID1, sizeof(SSID1));
+	zassert_equal(err, EXIT_SUCCESS, "Expected EXIT_SUCCESS, got %d", err);
+}
+
+/* Verify that we can successfully set/get a network with a fixed BSSID. */
+ZTEST(wifi_credentials, test_single_with_bssid)
+{
+	int err;
+
+	/* set network credentials with BSSID */
+	err = wifi_credentials_set_personal(SSID1, sizeof(SSID1), SECURITY1, BSSID1, 6, PSK1,
+					    sizeof(PSK1), FLAGS1, CHANNEL1, 0);
+	zassert_equal(err, EXIT_SUCCESS, "Expected EXIT_SUCCESS, got %d", err);
+
+	enum wifi_security_type security = -1;
+	uint8_t bssid_buf[WIFI_MAC_ADDR_LEN] = "";
+	char psk_buf[WIFI_CREDENTIALS_MAX_PASSWORD_LEN] = "";
+	size_t psk_len = 0;
+	uint32_t flags = 0;
+	uint8_t channel = 0;
+	uint32_t timeout = 0;
+
+	/* retrieve network credentials with BSSID */
+	err = wifi_credentials_get_by_ssid_personal(
+		SSID1, sizeof(SSID1), &security, bssid_buf, ARRAY_SIZE(bssid_buf), psk_buf,
+		ARRAY_SIZE(psk_buf), &psk_len, &flags, &channel, &timeout);
+	zassert_equal(err, EXIT_SUCCESS, "Expected EXIT_SUCCESS, got %d", err);
+	zassert_equal(strncmp(PSK1, psk_buf, ARRAY_SIZE(psk_buf)), 0, "PSK mismatch");
+	zassert_equal(psk_len, sizeof(PSK1), "PSK length mismatch");
+	zassert_equal(strncmp(BSSID1, bssid_buf, ARRAY_SIZE(bssid_buf)), 0, "BSSID mismatch");
+	zassert_equal(flags, WIFI_CREDENTIALS_FLAG_BSSID, "Flags mismatch");
+	zassert_equal(channel, CHANNEL1, "Channel mismatch");
+	zassert_equal(security, SECURITY1, "Security type mismatch");
+
+	err = wifi_credentials_delete_by_ssid(SSID1, sizeof(SSID1));
+	zassert_equal(err, EXIT_SUCCESS, "Expected EXIT_SUCCESS, got %d", err);
+}
+
+/* Verify that we can successfully set/get an open network. */
+ZTEST(wifi_credentials, test_single_without_psk)
+{
+	int err;
+
+	/* set network credentials without PSK/BSSID */
+	err = wifi_credentials_set_personal(SSID2, sizeof(SSID2), SECURITY2, NULL, 6, NULL, 0,
+					    FLAGS2, CHANNEL2, 0);
+	zassert_equal(err, EXIT_SUCCESS, "Expected EXIT_SUCCESS, got %d", err);
+
+	enum wifi_security_type security = -1;
+	uint8_t bssid_buf[WIFI_MAC_ADDR_LEN] = "";
+	char psk_buf[WIFI_CREDENTIALS_MAX_PASSWORD_LEN] = "";
+	size_t psk_len = 0;
+	uint32_t flags = 0;
+	uint8_t channel = 0;
+	uint32_t timeout = 0;
+
+	/* retrieve network credentials without PSK/BSSID */
+	err = wifi_credentials_get_by_ssid_personal(
+		SSID2, sizeof(SSID2), &security, bssid_buf, ARRAY_SIZE(bssid_buf), psk_buf,
+		ARRAY_SIZE(psk_buf), &psk_len, &flags, &channel, &timeout);
+	zassert_equal(err, EXIT_SUCCESS, "Expected EXIT_SUCCESS, got %d", err);
+	zassert_equal(psk_len, 0, "PSK length mismatch");
+	zassert_equal(flags, 0, "Flags mismatch");
+	zassert_equal(channel, CHANNEL2, "Channel mismatch");
+
+	err = wifi_credentials_delete_by_ssid(SSID2, sizeof(SSID2));
+	zassert_equal(err, EXIT_SUCCESS, "Expected EXIT_SUCCESS, got %d", err);
+}
+
+/* Verify that we can set/get a network that is only identified by a BSSID. */
+ZTEST(wifi_credentials, test_single_without_ssid)
+{
+	int err;
+
+	err = wifi_credentials_set_personal("", 0, SECURITY1, BSSID1, 6, PSK1, sizeof(PSK1), FLAGS1,
+					    CHANNEL1, 0);
+	zassert_equal(err, -EINVAL, "Expected -EINVAL, got %d", err);
+
+	enum wifi_security_type security = -1;
+	uint8_t bssid_buf[WIFI_MAC_ADDR_LEN] = "";
+	char psk_buf[WIFI_CREDENTIALS_MAX_PASSWORD_LEN] = "";
+	size_t psk_len = 0;
+	uint32_t flags = 0;
+	uint8_t channel = 0;
+	uint32_t timeout = 0;
+
+	err = wifi_credentials_get_by_ssid_personal(
+		"", 0, &security, bssid_buf, ARRAY_SIZE(bssid_buf), psk_buf, ARRAY_SIZE(psk_buf),
+		&psk_len, &flags, &channel, &timeout);
+	zassert_equal(err, -EINVAL, "Expected -EINVAL, got %d", err);
+
+	err = wifi_credentials_delete_by_ssid("", 0);
+	zassert_equal(err, -EINVAL, "Expected -EINVAL, got %d", err);
+}
+
+/* Verify that we can handle SSIDs that contain NULL characters. */
+ZTEST(wifi_credentials, test_single_garbled_ssid)
+{
+	int err;
+
+	err = wifi_credentials_set_personal(SSID4, sizeof(SSID4), SECURITY4, BSSID4, 6, PSK4,
+					    sizeof(PSK4), FLAGS4, CHANNEL4, 0);
+	zassert_equal(err, EXIT_SUCCESS, "Expected EXIT_SUCCESS, got %d", err);
+
+	enum wifi_security_type security = -1;
+	uint8_t bssid_buf[WIFI_MAC_ADDR_LEN] = "";
+	char psk_buf[WIFI_CREDENTIALS_MAX_PASSWORD_LEN] = "";
+	size_t psk_len = 0;
+	uint32_t flags = 0;
+	uint8_t channel = 0;
+	uint32_t timeout = 0;
+
+	err = wifi_credentials_get_by_ssid_personal(
+		SSID4, sizeof(SSID4), &security, bssid_buf, ARRAY_SIZE(bssid_buf), psk_buf,
+		ARRAY_SIZE(psk_buf), &psk_len, &flags, &channel, &timeout);
+	zassert_equal(err, EXIT_SUCCESS, "Expected EXIT_SUCCESS, got %d", err);
+	zassert_equal(strncmp(PSK4, psk_buf, ARRAY_SIZE(psk_buf)), 0, "PSK mismatch");
+	zassert_equal(psk_len, sizeof(PSK4), "PSK length mismatch");
+	zassert_equal(strncmp(BSSID4, bssid_buf, ARRAY_SIZE(bssid_buf)), 0, "BSSID mismatch");
+	zassert_equal(security, SECURITY4, "Security type mismatch");
+	zassert_equal(flags, FLAGS4, "Flags mismatch");
+	zassert_equal(channel, CHANNEL4, "Channel mismatch");
+
+	err = wifi_credentials_delete_by_ssid(SSID4, sizeof(SSID4));
+	zassert_equal(err, EXIT_SUCCESS, "Expected EXIT_SUCCESS, got %d", err);
+}
+
+/* Helper function for test_set_storage_limit, making sure that the SSID cache is correct. */
+void verify_ssid_cache_cb(void *cb_arg, const char *ssid, size_t ssid_len)
+{
+	static int call_count;
+	static const char *const ssids[] = {SSID3, SSID2};
+
+	zassert_equal(strncmp(ssids[call_count++], ssid, ssid_len), 0, "SSID cache mismatch");
+	zassert_is_null(cb_arg, "Callback argument is not NULL");
+}
+
+/* Verify that wifi_credentials behaves correctly when the storage limit is reached. */
+ZTEST(wifi_credentials, test_storage_limit)
+{
+	int err;
+
+	/* Set two networks */
+	err = wifi_credentials_set_personal(SSID1, sizeof(SSID1), SECURITY1, BSSID1, 6, PSK1,
+					    sizeof(PSK1), FLAGS1, CHANNEL1, 0);
+	zassert_equal(err, EXIT_SUCCESS, "Expected EXIT_SUCCESS, got %d", err);
+
+	err = wifi_credentials_set_personal(SSID2, sizeof(SSID2), SECURITY2, NULL, 6, NULL, 0,
+					    FLAGS2, CHANNEL2, 0);
+	zassert_equal(err, EXIT_SUCCESS, "Expected EXIT_SUCCESS, got %d", err);
+
+	enum wifi_security_type security = -1;
+	uint8_t bssid_buf[WIFI_MAC_ADDR_LEN] = "";
+	char psk_buf[WIFI_CREDENTIALS_MAX_PASSWORD_LEN] = "";
+	size_t psk_len = 0;
+	uint32_t flags = 0;
+	uint8_t channel = 0;
+	uint32_t timeout = 0;
+
+	/* Get two networks */
+	err = wifi_credentials_get_by_ssid_personal(
+		SSID1, sizeof(SSID1), &security, bssid_buf, ARRAY_SIZE(bssid_buf), psk_buf,
+		ARRAY_SIZE(psk_buf), &psk_len, &flags, &channel, &timeout);
+	zassert_equal(err, EXIT_SUCCESS, "Expected EXIT_SUCCESS, got %d", err);
+	zassert_equal(strncmp(PSK1, psk_buf, ARRAY_SIZE(psk_buf)), 0, "PSK mismatch");
+	zassert_equal(psk_len, sizeof(PSK1), "PSK length mismatch");
+	zassert_equal(strncmp(BSSID1, bssid_buf, ARRAY_SIZE(bssid_buf)), 0, "BSSID mismatch");
+	zassert_equal(security, SECURITY1, "Security type mismatch");
+	zassert_equal(flags, FLAGS1, "Flags mismatch");
+	zassert_equal(channel, CHANNEL1, "Channel mismatch");
+
+	err = wifi_credentials_get_by_ssid_personal(
+		SSID2, sizeof(SSID2), &security, bssid_buf, ARRAY_SIZE(bssid_buf), psk_buf,
+		ARRAY_SIZE(psk_buf), &psk_len, &flags, &channel, &timeout);
+	zassert_equal(err, EXIT_SUCCESS, "Expected EXIT_SUCCESS, got %d", err);
+	zassert_equal(security, SECURITY2, "Security type mismatch");
+	zassert_equal(flags, FLAGS2, "Flags mismatch");
+	zassert_equal(channel, CHANNEL2, "Channel mismatch");
+
+	/* Set third network */
+	err = wifi_credentials_set_personal(SSID3, sizeof(SSID3), SECURITY3, NULL, 6, PSK3,
+					    sizeof(PSK3), FLAGS3, CHANNEL3, 0);
+	zassert_equal(err, -ENOBUFS, "Expected -ENOBUFS, got %d", err);
+
+	/* Not enough space? Delete the first one. */
+	wifi_credentials_delete_by_ssid(SSID1, ARRAY_SIZE(SSID1));
+	err = wifi_credentials_set_personal(SSID3, sizeof(SSID3), SECURITY3, NULL, 6, PSK3,
+					    sizeof(PSK3), FLAGS3, CHANNEL3, 0);
+	zassert_equal(err, EXIT_SUCCESS, "Expected EXIT_SUCCESS, got %d", err);
+
+	err = wifi_credentials_get_by_ssid_personal(
+		SSID3, sizeof(SSID3), &security, bssid_buf, ARRAY_SIZE(bssid_buf), psk_buf,
+		ARRAY_SIZE(psk_buf), &psk_len, &flags, &channel, &timeout);
+	zassert_equal(err, EXIT_SUCCESS, "Expected EXIT_SUCCESS, got %d", err);
+	zassert_equal(security, SECURITY3, "Security type mismatch");
+	zassert_equal(psk_len, sizeof(PSK3), "PSK length mismatch");
+	zassert_equal(strncmp(PSK3, psk_buf, ARRAY_SIZE(psk_buf)), 0, "PSK mismatch");
+	zassert_equal(flags, FLAGS3, "Flags mismatch");
+	zassert_equal(channel, CHANNEL3, "Channel mismatch");
+
+	wifi_credentials_for_each_ssid(verify_ssid_cache_cb, NULL);
+}
+
+/* Verify that all entries are deleted. */
+ZTEST(wifi_credentials, test_delete_all_entries)
+{
+	/* Set two networks */
+	int err = wifi_credentials_set_personal(SSID1, sizeof(SSID1), SECURITY1, BSSID1, 6, PSK1,
+						sizeof(PSK1), FLAGS1, CHANNEL1, 0);
+	zassert_equal(err, EXIT_SUCCESS, "Expected EXIT_SUCCESS, got %d", err);
+
+	err = wifi_credentials_set_personal(SSID2, sizeof(SSID2), SECURITY2, NULL, 6, NULL, 0,
+					    FLAGS2, CHANNEL2, 0);
+	zassert_equal(err, EXIT_SUCCESS, "Expected EXIT_SUCCESS, got %d", err);
+
+	/* Delete all networks */
+	err = wifi_credentials_delete_all();
+	zassert_equal(err, EXIT_SUCCESS, "Expected EXIT_SUCCESS, got %d", err);
+
+	/* Verify that the storage is empty */
+	zassert_true(wifi_credentials_is_empty(), "Storage is not empty");
+}
+
+ZTEST_SUITE(wifi_credentials, NULL, NULL, wifi_credentials_setup, wifi_credentials_teardown, NULL);

--- a/tests/net/lib/wifi_credentials/testcase.yaml
+++ b/tests/net/lib/wifi_credentials/testcase.yaml
@@ -1,0 +1,6 @@
+tests:
+  net.wifi_credentials:
+    tags:
+      - net
+    integration_platforms:
+      - native_sim

--- a/tests/net/lib/wifi_credentials_backend_psa/CMakeLists.txt
+++ b/tests/net/lib/wifi_credentials_backend_psa/CMakeLists.txt
@@ -1,0 +1,36 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(wifi_credentials_test)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})
+
+target_sources(app
+  PRIVATE
+  ${ZEPHYR_BASE}/subsys/net/lib/wifi_credentials/wifi_credentials_backend_psa.c
+)
+
+zephyr_include_directories(${ZEPHYR_BASE}/subsys/testsuite/include)
+zephyr_include_directories(${ZEPHYR_BASE}/subsys/net/lib/wifi_credentials/)
+zephyr_include_directories(${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}/interface/include/)
+zephyr_include_directories(${ZEPHYR_BASE}/../modules/crypto/mbedtls/include/)
+
+target_compile_options(app
+  PRIVATE
+  -DCONFIG_WIFI_CREDENTIALS_MAX_ENTRIES=2
+  -DCONFIG_WIFI_CREDENTIALS_SAE_PASSWORD_LENGTH=128
+  -DCONFIG_WIFI_CREDENTIALS_LOG_LEVEL=4
+  -DCONFIG_WIFI_CREDENTIALS_BACKEND_PSA_OFFSET=5
+)
+
+set_property(
+	SOURCE ${ZEPHYR_BASE}/subsys/net/lib/wifi_credentials/wifi_credentials_backend_psa.c
+	PROPERTY COMPILE_FLAGS "-include ${CMAKE_CURRENT_SOURCE_DIR}/src/normalized_crypto.h"
+)

--- a/tests/net/lib/wifi_credentials_backend_psa/prj.conf
+++ b/tests/net/lib/wifi_credentials_backend_psa/prj.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_ZTEST=y
+CONFIG_LOG=y

--- a/tests/net/lib/wifi_credentials_backend_psa/src/main.c
+++ b/tests/net/lib/wifi_credentials_backend_psa/src/main.c
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
+
+#include <zephyr/fff.h>
+
+#include <zephyr/net/wifi_credentials.h>
+
+#include "wifi_credentials_internal.h"
+#include "psa/crypto_types.h"
+#include "psa/crypto_values.h"
+
+#define SSID1     "test1"
+#define PSK1      "super secret"
+#define SECURITY1 WIFI_SECURITY_TYPE_PSK
+#define BSSID1    "abcdef"
+#define FLAGS1    WIFI_CREDENTIALS_FLAG_BSSID
+
+#define SSID2     "test2"
+#define PSK2      NULL
+#define SECURITY2 WIFI_SECURITY_TYPE_NONE
+#define BSSID2    NULL
+#define FLAGS2    0
+
+#define WIFI_CREDENTIALS_BACKEND_PSA_KEY_ID_USER_MIN                                               \
+	(PSA_KEY_ID_USER_MIN + CONFIG_WIFI_CREDENTIALS_BACKEND_PSA_OFFSET)
+
+DEFINE_FFF_GLOBALS;
+
+K_MUTEX_DEFINE(wifi_credentials_mutex);
+
+FAKE_VOID_FUNC(wifi_credentials_cache_ssid, size_t, const struct wifi_credentials_header *);
+FAKE_VALUE_FUNC(psa_status_t, psa_export_key, mbedtls_svc_key_id_t, uint8_t *, size_t, size_t *);
+FAKE_VALUE_FUNC(psa_status_t, psa_import_key, psa_key_attributes_t *, uint8_t *, size_t,
+		mbedtls_svc_key_id_t *);
+FAKE_VALUE_FUNC(psa_status_t, psa_destroy_key, mbedtls_svc_key_id_t);
+FAKE_VOID_FUNC(psa_set_key_id, psa_key_attributes_t *, uint32_t);
+FAKE_VOID_FUNC(psa_set_key_usage_flags, psa_key_attributes_t *, psa_key_usage_t);
+FAKE_VOID_FUNC(psa_set_key_lifetime, psa_key_attributes_t *, psa_key_lifetime_t);
+FAKE_VOID_FUNC(psa_set_key_algorithm, psa_key_attributes_t *, psa_algorithm_t);
+FAKE_VOID_FUNC(psa_set_key_type, psa_key_attributes_t *, psa_key_type_t);
+FAKE_VOID_FUNC(psa_set_key_bits, psa_key_attributes_t *, size_t);
+
+static const struct wifi_credentials_personal example1 = {
+	.header = {
+		.ssid = SSID1,
+		.ssid_len = strlen(SSID1),
+		.type = SECURITY1,
+		.bssid = BSSID1,
+		.flags = FLAGS1,
+	},
+	.password = PSK1,
+	.password_len = strlen(PSK1),
+};
+
+static const struct wifi_credentials_personal example2 = {
+	.header = {
+		.ssid = SSID2,
+		.ssid_len = strlen(SSID2),
+		.type = SECURITY2,
+		.flags = FLAGS2,
+	},
+};
+
+static size_t idx;
+
+psa_status_t custom_psa_export_key(mbedtls_svc_key_id_t key, uint8_t *data, size_t data_size,
+				   size_t *data_length)
+{
+	/* confirm that we read the requested amount of data */
+	*data_length = data_size;
+	return PSA_SUCCESS;
+}
+
+static void custom_psa_set_key_id(psa_key_attributes_t *attributes, mbedtls_svc_key_id_t key)
+{
+	zassert_equal(idx + WIFI_CREDENTIALS_BACKEND_PSA_KEY_ID_USER_MIN, key, "Key ID mismatch");
+}
+
+void custom_psa_set_key_bits(psa_key_attributes_t *attributes, size_t bits)
+{
+	zassert_equal(sizeof(struct wifi_credentials_personal) * 8, bits, "Key bits mismatch");
+}
+
+void custom_psa_set_key_type(psa_key_attributes_t *attributes, psa_key_type_t type)
+{
+	zassert_equal(PSA_KEY_TYPE_RAW_DATA, type, "Key type mismatch");
+}
+
+void custom_psa_set_key_algorithm(psa_key_attributes_t *attributes, psa_algorithm_t alg)
+{
+	zassert_equal(PSA_ALG_NONE, alg, "Key algorithm mismatch");
+}
+
+void custom_psa_set_key_lifetime(psa_key_attributes_t *attributes, psa_key_lifetime_t lifetime)
+{
+	zassert_equal(PSA_KEY_LIFETIME_PERSISTENT, lifetime, "Key lifetime mismatch");
+}
+
+void custom_psa_set_key_usage_flags(psa_key_attributes_t *attributes, psa_key_usage_t usage_flags)
+{
+	zassert_equal(PSA_KEY_USAGE_EXPORT, usage_flags, "Key usage flags mismatch");
+}
+
+static void wifi_credentials_backend_psa_setup(void *_unused)
+{
+	RESET_FAKE(wifi_credentials_cache_ssid);
+	RESET_FAKE(psa_export_key);
+	RESET_FAKE(psa_import_key);
+	RESET_FAKE(psa_destroy_key);
+	psa_export_key_fake.custom_fake = custom_psa_export_key;
+	psa_set_key_id_fake.custom_fake = custom_psa_set_key_id;
+	psa_set_key_usage_flags_fake.custom_fake = custom_psa_set_key_usage_flags;
+	psa_set_key_lifetime_fake.custom_fake = custom_psa_set_key_lifetime;
+	psa_set_key_algorithm_fake.custom_fake = custom_psa_set_key_algorithm;
+	psa_set_key_type_fake.custom_fake = custom_psa_set_key_type;
+	psa_set_key_bits_fake.custom_fake = custom_psa_set_key_bits;
+	idx = 0;
+}
+
+ZTEST(wifi_credentials_backend_psa, test_init)
+{
+	int ret;
+
+	ret = wifi_credentials_backend_init();
+
+	zassert_equal(0, ret, "Initialization failed");
+	zassert_equal(psa_export_key_fake.call_count, CONFIG_WIFI_CREDENTIALS_MAX_ENTRIES,
+		      "Export key call count mismatch");
+	zassert_equal(wifi_credentials_cache_ssid_fake.call_count,
+		      CONFIG_WIFI_CREDENTIALS_MAX_ENTRIES, "Cache SSID call count mismatch");
+}
+
+ZTEST(wifi_credentials_backend_psa, test_add)
+{
+	int ret = wifi_credentials_store_entry(idx, &example1,
+					       sizeof(struct wifi_credentials_personal));
+
+	zassert_equal(0, ret, "Store entry failed");
+	zassert_equal_ptr(psa_import_key_fake.arg1_val, &example1, "Import key arg1 mismatch");
+	zassert_equal(psa_import_key_fake.arg2_val, sizeof(struct wifi_credentials_personal),
+		      "Import key arg2 mismatch");
+
+	idx++;
+
+	ret = wifi_credentials_store_entry(idx, &example2,
+					   sizeof(struct wifi_credentials_personal));
+
+	zassert_equal(0, ret, "Store entry failed");
+	zassert_equal_ptr(psa_import_key_fake.arg1_val, &example2, "Import key arg1 mismatch");
+	zassert_equal(psa_import_key_fake.arg2_val, sizeof(struct wifi_credentials_personal),
+		      "Import key arg2 mismatch");
+
+	zassert_equal(psa_import_key_fake.call_count, 2, "Import key call count mismatch");
+	zassert_equal(psa_set_key_id_fake.call_count, 2, "Set key ID call count mismatch");
+	zassert_equal(psa_set_key_usage_flags_fake.call_count, 2,
+		      "Set key usage flags call count mismatch");
+	zassert_equal(psa_set_key_lifetime_fake.call_count, 2,
+		      "Set key lifetime call count mismatch");
+	zassert_equal(psa_set_key_algorithm_fake.call_count, 2,
+		      "Set key algorithm call count mismatch");
+	zassert_equal(psa_set_key_type_fake.call_count, 2, "Set key type call count mismatch");
+	zassert_equal(psa_set_key_bits_fake.call_count, 2, "Set key bits call count mismatch");
+}
+
+ZTEST(wifi_credentials_backend_psa, test_get)
+{
+	int ret;
+	psa_key_id_t key_id = idx + WIFI_CREDENTIALS_BACKEND_PSA_KEY_ID_USER_MIN;
+	uint8_t buf[ENTRY_MAX_LEN];
+
+	ret = wifi_credentials_load_entry(idx, buf, ARRAY_SIZE(buf));
+
+	zassert_equal(0, ret, "Load entry failed");
+	zassert_equal(psa_export_key_fake.arg0_val, key_id, "Export key arg0 mismatch");
+	zassert_equal_ptr(psa_export_key_fake.arg1_val, buf, "Export key arg1 mismatch");
+	zassert_equal(psa_export_key_fake.arg2_val, ARRAY_SIZE(buf), "Export key arg2 mismatch");
+
+	idx++;
+	key_id = idx + WIFI_CREDENTIALS_BACKEND_PSA_KEY_ID_USER_MIN;
+
+	ret = wifi_credentials_load_entry(idx, buf, ARRAY_SIZE(buf));
+
+	zassert_equal(0, ret, "Load entry failed");
+	zassert_equal(psa_export_key_fake.arg0_val, key_id, "Export key arg0 mismatch");
+	zassert_equal_ptr(psa_export_key_fake.arg1_val, buf, "Export key arg1 mismatch");
+	zassert_equal(psa_export_key_fake.arg2_val, ARRAY_SIZE(buf), "Export key arg2 mismatch");
+
+	zassert_equal(psa_export_key_fake.call_count, 2, "Export key call count mismatch");
+}
+
+ZTEST(wifi_credentials_backend_psa, test_delete)
+{
+	int ret;
+
+	ret = wifi_credentials_delete_entry(idx);
+
+	zassert_equal(0, ret, "Delete entry failed");
+	zassert_equal(psa_destroy_key_fake.arg0_val, WIFI_CREDENTIALS_BACKEND_PSA_KEY_ID_USER_MIN,
+		      "Destroy key arg0 mismatch");
+
+	idx++;
+
+	ret = wifi_credentials_delete_entry(1);
+
+	zassert_equal(0, ret, "Delete entry failed");
+	zassert_equal(psa_destroy_key_fake.arg0_val,
+		      idx + WIFI_CREDENTIALS_BACKEND_PSA_KEY_ID_USER_MIN,
+		      "Destroy key arg0 mismatch");
+
+	zassert_equal(psa_destroy_key_fake.call_count, 2, "Destroy key call count mismatch");
+}
+
+ZTEST_SUITE(wifi_credentials_backend_psa, NULL, NULL, wifi_credentials_backend_psa_setup, NULL,
+	    NULL);

--- a/tests/net/lib/wifi_credentials_backend_psa/src/normalized_crypto.h
+++ b/tests/net/lib/wifi_credentials_backend_psa/src/normalized_crypto.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef PSA_CRYPTO_H
+#define PSA_CRYPTO_H
+
+#include "zephyr/types.h"
+#include "psa/crypto_types.h"
+#include "psa/crypto_values.h"
+
+struct psa_client_key_attributes_s {
+	uint16_t type;
+	uint16_t bits;
+	uint32_t lifetime;
+	psa_key_id_t id;
+	uint32_t usage;
+	uint32_t alg;
+};
+
+struct psa_key_attributes_s {
+	struct psa_client_key_attributes_s client;
+};
+
+typedef struct psa_key_attributes_s psa_key_attributes_t;
+
+psa_status_t psa_import_key(const psa_key_attributes_t *attributes, const uint8_t *data,
+			    size_t data_length, mbedtls_svc_key_id_t *key);
+
+psa_status_t psa_export_key(mbedtls_svc_key_id_t key, uint8_t *data, size_t data_size,
+			    size_t *data_length);
+
+psa_status_t psa_destroy_key(mbedtls_svc_key_id_t key);
+void psa_set_key_id(psa_key_attributes_t *attributes, mbedtls_svc_key_id_t key);
+void psa_set_key_bits(psa_key_attributes_t *attributes, size_t bits);
+void psa_set_key_type(psa_key_attributes_t *attributes, psa_key_type_t type);
+void psa_set_key_algorithm(psa_key_attributes_t *attributes, psa_algorithm_t alg);
+void psa_set_key_lifetime(psa_key_attributes_t *attributes, psa_key_lifetime_t lifetime);
+psa_status_t psa_destroy_key(mbedtls_svc_key_id_t key);
+void psa_set_key_usage_flags(psa_key_attributes_t *attributes, psa_key_usage_t usage_flags);
+
+#endif

--- a/tests/net/lib/wifi_credentials_backend_psa/testcase.yaml
+++ b/tests/net/lib/wifi_credentials_backend_psa/testcase.yaml
@@ -1,0 +1,6 @@
+tests:
+  net.wifi_credentials_backend_psa:
+    tags:
+      - net
+    integration_platforms:
+      - native_sim

--- a/tests/net/lib/wifi_credentials_backend_settings/CMakeLists.txt
+++ b/tests/net/lib/wifi_credentials_backend_settings/CMakeLists.txt
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(wifi_credentials_test)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})
+
+target_sources(app
+  PRIVATE
+  ${ZEPHYR_BASE}/subsys/net/lib/wifi_credentials/wifi_credentials_backend_settings.c
+)
+
+zephyr_include_directories(${ZEPHYR_BASE}/subsys/testsuite/include)
+zephyr_include_directories(${ZEPHYR_BASE}/subsys/net/lib/wifi_credentials/)
+
+target_compile_options(app
+  PRIVATE
+  -DCONFIG_WIFI_CREDENTIALS_MAX_ENTRIES=2
+  -DCONFIG_WIFI_CREDENTIALS_SAE_PASSWORD_LENGTH=128
+  -DCONFIG_WIFI_CREDENTIALS_LOG_LEVEL=4
+)

--- a/tests/net/lib/wifi_credentials_backend_settings/prj.conf
+++ b/tests/net/lib/wifi_credentials_backend_settings/prj.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_ZTEST=y
+CONFIG_LOG=y

--- a/tests/net/lib/wifi_credentials_backend_settings/src/main.c
+++ b/tests/net/lib/wifi_credentials_backend_settings/src/main.c
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <zephyr/kernel.h>
+#include <zephyr/settings/settings.h>
+
+#include <zephyr/fff.h>
+
+#include <zephyr/net/wifi_credentials.h>
+
+#include "wifi_credentials_internal.h"
+
+#define MAX_KEY_LEN 16
+
+#define SSID1     "test1"
+#define PSK1      "super secret"
+#define SECURITY1 WIFI_SECURITY_TYPE_PSK
+#define BSSID1    "abcdef"
+#define FLAGS1    WIFI_CREDENTIALS_FLAG_BSSID
+
+#define SSID2     "test2"
+#define PSK2      NULL
+#define SECURITY2 WIFI_SECURITY_TYPE_NONE
+#define BSSID2    NULL
+#define FLAGS2    0
+
+DEFINE_FFF_GLOBALS;
+
+K_MUTEX_DEFINE(wifi_credentials_mutex);
+
+FAKE_VALUE_FUNC(int, settings_subsys_init);
+FAKE_VALUE_FUNC(int, settings_save_one, const char *, const void *, size_t);
+FAKE_VALUE_FUNC(int, settings_delete, const char *);
+FAKE_VALUE_FUNC(int, settings_load_subtree_direct, const char *, settings_load_direct_cb, void *);
+FAKE_VOID_FUNC(wifi_credentials_cache_ssid, size_t, const struct wifi_credentials_header *);
+
+static uint8_t fake_settings_buf[CONFIG_WIFI_CREDENTIALS_MAX_ENTRIES][ENTRY_MAX_LEN];
+static char fake_settings_buf_keys[CONFIG_WIFI_CREDENTIALS_MAX_ENTRIES][MAX_KEY_LEN];
+static size_t fake_settings_buf_lens[CONFIG_WIFI_CREDENTIALS_MAX_ENTRIES];
+
+typedef int (*settings_set_cb)(const char *key, size_t len, settings_read_cb read_cb, void *cb_arg);
+
+static const struct wifi_credentials_personal example1 = {
+	.header = {
+		.ssid = SSID1,
+		.ssid_len = strlen(SSID1),
+		.type = SECURITY1,
+		.bssid = BSSID1,
+		.flags = FLAGS1,
+	},
+	.password = PSK1,
+	.password_len = strlen(PSK1),
+};
+
+static const struct wifi_credentials_personal example2 = {
+	.header = {
+		.ssid = SSID2,
+		.ssid_len = strlen(SSID2),
+		.type = SECURITY2,
+		.flags = FLAGS2,
+	},
+};
+
+/**
+ * @brief load content of given settings index to given buffer
+ *
+ * @param cb_arg size_t *idx
+ * @param data destination
+ * @param len length
+ * @return ssize_t MIN(length, length_available)
+ */
+ssize_t custom_settings_read_cb(void *cb_arg, void *data, size_t len)
+{
+	size_t *idx = cb_arg;
+
+	zassert_true(len <= ENTRY_MAX_LEN, "Length exceeds ENTRY_MAX_LEN");
+	memcpy(data, fake_settings_buf[*idx], len);
+	return len;
+}
+
+static int custom_settings_save_one(const char *name, const void *value, size_t val_len)
+{
+	zassert_true(strlen(name) < MAX_KEY_LEN, "Name length exceeds MAX_KEY_LEN");
+	zassert_true(val_len <= ENTRY_MAX_LEN, "Value length exceeds ENTRY_MAX_LEN");
+
+	for (size_t i = 0; i < CONFIG_WIFI_CREDENTIALS_MAX_ENTRIES; ++i) {
+		if (strlen(fake_settings_buf_keys[i]) == 0 ||
+		    strcmp(name, fake_settings_buf_keys[i]) == 0) {
+			strcpy(fake_settings_buf_keys[i], name);
+			memcpy(fake_settings_buf[i], value, val_len);
+			fake_settings_buf_lens[i] = val_len;
+			return 0;
+		}
+	}
+	return -ENOBUFS;
+}
+
+static int custom_settings_delete(const char *name)
+{
+	zassert_true(strlen(name) < MAX_KEY_LEN, "Name length exceeds MAX_KEY_LEN");
+	for (size_t i = 0; i < CONFIG_WIFI_CREDENTIALS_MAX_ENTRIES; ++i) {
+		if (strcmp(name, fake_settings_buf_keys[i]) == 0) {
+			memset(fake_settings_buf_keys[i], 0, MAX_KEY_LEN);
+			memset(fake_settings_buf[i], 0, ENTRY_MAX_LEN);
+			fake_settings_buf_lens[i] = 0;
+			return 0;
+		}
+	}
+	return -ENOENT;
+}
+
+static int custom_settings_load_subtree_direct(const char *subtree, settings_load_direct_cb cb,
+					       void *param)
+{
+	size_t subtree_len = strlen(subtree);
+
+	zassert_true(subtree_len < MAX_KEY_LEN, "Subtree length exceeds MAX_KEY_LEN");
+
+	for (size_t i = 0; i < CONFIG_WIFI_CREDENTIALS_MAX_ENTRIES; ++i) {
+		if (strncmp(subtree, fake_settings_buf_keys[i], subtree_len) == 0) {
+			const char *key = fake_settings_buf_keys[i] + subtree_len + 1;
+
+			cb(key, fake_settings_buf_lens[i], custom_settings_read_cb, &i, param);
+		}
+	}
+	return 0;
+}
+
+static void custom_wifi_credentials_cache_ssid(size_t idx,
+					       const struct wifi_credentials_header *buf)
+{
+	char name[16] = "";
+
+	snprintk(name, ARRAY_SIZE(name), "wifi_cred/%d", idx);
+	for (size_t i = 0; i < CONFIG_WIFI_CREDENTIALS_MAX_ENTRIES; ++i) {
+		if (strcmp(name, fake_settings_buf_keys[i]) == 0) {
+			zassert_equal(memcmp(buf, &fake_settings_buf[i],
+					     sizeof(struct wifi_credentials_header)),
+				      0, "Buffer mismatch");
+			return;
+		}
+	}
+	zassert_true(false, "SSID not found in cache");
+}
+
+static void wifi_credentials_backend_settings_setup(void *_unused)
+{
+	RESET_FAKE(settings_save_one);
+	RESET_FAKE(settings_delete);
+	RESET_FAKE(settings_load_subtree_direct);
+	RESET_FAKE(wifi_credentials_cache_ssid);
+	settings_save_one_fake.custom_fake = custom_settings_save_one;
+	settings_delete_fake.custom_fake = custom_settings_delete;
+	settings_load_subtree_direct_fake.custom_fake = custom_settings_load_subtree_direct;
+	wifi_credentials_cache_ssid_fake.custom_fake = custom_wifi_credentials_cache_ssid;
+	memset(fake_settings_buf_lens, 0, ARRAY_SIZE(fake_settings_buf_lens) * sizeof(size_t));
+	memset(fake_settings_buf_keys, 0, CONFIG_WIFI_CREDENTIALS_MAX_ENTRIES * MAX_KEY_LEN);
+	memset(fake_settings_buf, 0, CONFIG_WIFI_CREDENTIALS_MAX_ENTRIES * ENTRY_MAX_LEN);
+}
+
+ZTEST(wifi_credentials_backend_settings, test_init)
+{
+	int ret;
+
+	ret = wifi_credentials_store_entry(0, &example1, sizeof(struct wifi_credentials_personal));
+	zassert_equal(ret, 0, "Failed to store entry 0");
+	ret = wifi_credentials_store_entry(1, &example2, sizeof(struct wifi_credentials_personal));
+	zassert_equal(ret, 0, "Failed to store entry 1");
+
+	ret = wifi_credentials_backend_init();
+
+	zassert_equal(ret, 0, "Backend init failed");
+	zassert_equal(settings_subsys_init_fake.call_count, 1,
+		      "settings_subsys_init call count mismatch");
+	zassert_equal(wifi_credentials_cache_ssid_fake.call_count, 2,
+		      "wifi_credentials_cache_ssid call count mismatch");
+	zassert_equal(wifi_credentials_cache_ssid_fake.arg0_history[0], 0,
+		      "First cache SSID index mismatch");
+	zassert_equal(wifi_credentials_cache_ssid_fake.arg0_history[1], 1,
+		      "Second cache SSID index mismatch");
+}
+
+ZTEST(wifi_credentials_backend_settings, test_add)
+{
+	int ret = wifi_credentials_store_entry(0, "abc", 3);
+
+	zassert_equal(ret, 0, "Failed to add entry");
+	zassert_equal(settings_save_one_fake.call_count, 1,
+		      "settings_save_one call count mismatch");
+	zassert_equal(strcmp(fake_settings_buf_keys[0], "wifi_cred/0"), 0, "Key mismatch");
+	zassert_equal(strcmp(fake_settings_buf[0], "abc"), 0, "Value mismatch");
+	zassert_equal(fake_settings_buf_lens[0], 3, "Length mismatch");
+}
+
+ZTEST(wifi_credentials_backend_settings, test_get)
+{
+	int ret;
+
+	ret = wifi_credentials_store_entry(0, &example1, sizeof(struct wifi_credentials_personal));
+	zassert_equal(ret, 0, "Failed to store entry 0");
+	ret = wifi_credentials_store_entry(1, &example2, sizeof(struct wifi_credentials_personal));
+	zassert_equal(ret, 0, "Failed to store entry 1");
+
+	char buf[ENTRY_MAX_LEN] = {0};
+
+	ret = wifi_credentials_load_entry(0, buf, ARRAY_SIZE(buf));
+	zassert_equal(ret, 0, "Failed to load entry 0");
+	zassert_equal(memcmp(&example1, buf, ARRAY_SIZE(buf)), 0, "Entry 0 data mismatch");
+	ret = wifi_credentials_load_entry(1, buf, ARRAY_SIZE(buf));
+	zassert_equal(ret, 0, "Failed to load entry 1");
+	zassert_equal(memcmp(&example2, buf, ARRAY_SIZE(buf)), 0, "Entry 1 data mismatch");
+}
+
+ZTEST(wifi_credentials_backend_settings, test_delete)
+{
+	int ret;
+
+	ret = wifi_credentials_store_entry(0, "abc", 3);
+	zassert_equal(ret, 0, "Failed to store entry");
+
+	ret = wifi_credentials_delete_entry(0);
+	zassert_equal(ret, 0, "Failed to delete entry");
+	zassert_equal(settings_delete_fake.call_count, 1, "settings_delete call count mismatch");
+}
+
+ZTEST_SUITE(wifi_credentials_backend_settings, NULL, NULL, wifi_credentials_backend_settings_setup,
+	    NULL, NULL);

--- a/tests/net/lib/wifi_credentials_backend_settings/testcase.yaml
+++ b/tests/net/lib/wifi_credentials_backend_settings/testcase.yaml
@@ -1,0 +1,6 @@
+tests:
+  net.wifi_credentials_backend_settings:
+    tags:
+      - net
+    integration_platforms:
+      - native_sim


### PR DESCRIPTION
Upstream NCS's library for storing Wi-Fi credentials.
This library allows storage of Wi-Fi credentials using different backends.
Either the Zephyr settings subsystem or the PSA secure backend can be used.
For testing purposes, credentials can be defined statically.