### PR TITLE
cleanup STM32H750 dtsi file:  remove unnecessary inclusion 

### DIFF
--- a/dts/arm/st/h7/stm32h750.dtsi
+++ b/dts/arm/st/h7/stm32h750.dtsi
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <st/h7/stm32h7.dtsi>
 #include <st/h7/stm32h743.dtsi>
 #include <zephyr/dt-bindings/display/panel.h>
 


### PR DESCRIPTION
Since stm32h7.dtsi is already include in st/h7/stm32h743.dtsi we don't need to include here again.