### PR TITLE
soc: nrf: Update systemoff sequence for nRF54L15

### DIFF
--- a/soc/nordic/common/poweroff.c
+++ b/soc/nordic/common/poweroff.c
@@ -11,9 +11,15 @@
 #else
 #include <hal/nrf_regulators.h>
 #endif
+#if defined(CONFIG_SOC_SERIES_NRF54LX)
+#include <helpers/nrfx_reset_reason.h>
+#endif
 
 void z_sys_poweroff(void)
 {
+#if defined(CONFIG_SOC_SERIES_NRF54LX)
+	nrfx_reset_reason_clear(UINT32_MAX);
+#endif
 #if defined(CONFIG_SOC_SERIES_NRF51X) || defined(CONFIG_SOC_SERIES_NRF52X)
 	nrf_power_system_off(NRF_POWER);
 #else


### PR DESCRIPTION
Production version of the nRF54L15 SoC needs reset reason to be cleared before going into system off.