### PR TITLE
Intel: ADSP: move HPSRAM mask into assembly

### DIFF
--- a/soc/intel/intel_adsp/ace/asm_memory_management.h
+++ b/soc/intel/intel_adsp/ace/asm_memory_management.h
@@ -9,8 +9,6 @@
 #ifndef __ZEPHYR_ACE_LIB_ASM_MEMORY_MANAGEMENT_H__
 #define __ZEPHYR_ACE_LIB_ASM_MEMORY_MANAGEMENT_H__
 
-#ifdef _ASMLANGUAGE
-
 /* These definitions should be placed elsewhere, but I can't find a good place for them. */
 #define LSPGCTL				0x71D80
 #define LSPGCTL_HIGH			((LSPGCTL >> 4) & 0xff00)
@@ -18,6 +16,8 @@
 #define MAX_MEMORY_SEGMENTS		1
 #define EBB_SEGMENT_SIZE		32
 #define PLATFORM_HPSRAM_EBB_COUNT	22
+
+#ifdef _ASMLANGUAGE
 
 .macro m_ace_hpsram_power_change segment_index, mask, ax, ay, az, au, aw
 	.if \segment_index == 0

--- a/soc/intel/intel_adsp/ace/power.c
+++ b/soc/intel/intel_adsp/ace/power.c
@@ -72,8 +72,7 @@ __imr void power_init(void)
  * (each bit corresponds to one ebb)
  * @param response_to_ipc       flag if ipc response should be send during power down
  */
-extern void power_down(bool disable_lpsram, uint32_t __sparse_cache * hpsram_pg_mask,
-		       bool response_to_ipc);
+void power_down(bool disable_lpsram, bool hpsram_mask, bool response_to_ipc);
 
 #ifdef CONFIG_ADSP_IMR_CONTEXT_SAVE
 /**
@@ -275,6 +274,9 @@ __imr void pm_state_imr_restore(void)
 }
 #endif /* CONFIG_ADSP_IMR_CONTEXT_SAVE */
 
+#include "asm_memory_management.h"
+extern uint32_t hpsram_mask[MAX_MEMORY_SEGMENTS];
+
 void pm_state_set(enum pm_state state, uint8_t substate_id)
 {
 	ARG_UNUSED(substate_id);
@@ -340,21 +342,17 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 			sys_cache_data_flush_range((void *)imr_layout, sizeof(*imr_layout));
 #endif /* CONFIG_ADSP_IMR_CONTEXT_SAVE */
 #ifdef CONFIG_ADSP_POWER_DOWN_HPSRAM
-			const int dcache_words = XCHAL_DCACHE_LINESIZE / sizeof(uint32_t);
-			uint32_t hpsram_mask[dcache_words] __aligned(XCHAL_DCACHE_LINESIZE);
-
-			hpsram_mask[0] = 0;
 			/* turn off all HPSRAM banks - get a full bitmap */
 			uint32_t ebb_banks = ace_hpsram_get_bank_count();
 			hpsram_mask[0] = (1 << ebb_banks) - 1;
-#define HPSRAM_MASK_ADDR sys_cache_cached_ptr_get(&hpsram_mask)
+#define HPSRAM_MASK true
 #else
-#define HPSRAM_MASK_ADDR NULL
+#define HPSRAM_MASK false
 #endif /* CONFIG_ADSP_POWER_DOWN_HPSRAM */
 			ret = pm_device_runtime_put(INTEL_ADSP_HST_DOMAIN_DEV);
 			__ASSERT_NO_MSG(ret == 0);
 			/* do power down - this function won't return */
-			power_down(true, HPSRAM_MASK_ADDR, true);
+			power_down(true, HPSRAM_MASK, true);
 		} else {
 			power_gate_entry(cpu);
 		}

--- a/soc/intel/intel_adsp/ace/power_down.S
+++ b/soc/intel/intel_adsp/ace/power_down.S
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- #include "asm_memory_management.h"
+#include "asm_memory_management.h"
 
 	.section .text, "ax"
 	.align 64
@@ -10,9 +10,14 @@ power_down_literals:
 	.literal_position
 ipc_flag:
 	.word 0x80000000 // IPC_DIPCTDR_BUSY
+hpsram_mask:
+	.rept MAX_MEMORY_SEGMENTS
+		.word 0
+	.endr
 sram_dis_loop_cnt:
 	.word 4096
 
+	.global hpsram_mask
 	.global power_down
 	.type power_down, @function
 
@@ -48,7 +53,6 @@ power_down:
 	 * effectively executes:
 	 * xthal_dcache_region_lock(&literals, 128);
 	 * xthal_icache_region_lock(&powerdown, 256);
-	 * xthal_dcache_region_lock(&pu32_hpsram_mask, 64);
 	 */
 	movi pfl_reg, power_down_literals
 	dpfl pfl_reg, 0
@@ -66,12 +70,7 @@ power_down:
 	movi u32_ipc_response_mask, 0x20000000
 
 	beqz pu32_hpsram_mask, _PD_DISABLE_LPSRAM
-	/*
-	 * This assumes a single HPSRAM segment although the code below is
-	 * generic and uses MAX_MEMORY_SEGMENTS for their number
-	 */
-	mov  pfl_reg, pu32_hpsram_mask
-	dpfl pfl_reg, 0
+	movi pu32_hpsram_mask, hpsram_mask
 
 _PD_DISABLE_LPSRAM:
 /**


### PR DESCRIPTION
Assembly in power_down() in power_down.S already defines data and code to be locked in cache when powering down SRAM. Instead of adding another such location in power.c, move the hpsram_mask[] array into power_down.S.  This fixes hard to debug failures when shutting down the ADSP.

Yes, https://github.com/thesofproject/sof/issues/9268 raises its ugly head again: https://sof-ci.01.org/sofpr/PR9430/build7664/devicetest/index.html We are no wiser about real reasons, but this is yet another attempt at a more robust fix