### PR TITLE
soc: nordic: nrf52: fix used define for enabling DCDC converter

### DIFF
--- a/soc/nordic/nrf52/soc.c
+++ b/soc/nordic/nrf52/soc.c
@@ -32,8 +32,8 @@ static int nordicsemi_nrf52_init(void)
 	NRF_NVMC->ICACHECNF = NVMC_ICACHECNF_CACHEEN_Msk;
 #endif
 
-#if defined(CONFIG_SOC_DCDC_NRF52X) || \
-	(DT_PROP(DT_INST(0, nordic_nrf5x_regulator), regulator_initial_mode) == NRF_REG_MODE_DCDC)
+#if defined(CONFIG_SOC_DCDC_NRF52X) || (DT_PROP(DT_INST(0, nordic_nrf5x_regulator),                \
+						regulator_initial_mode) == NRF5X_REG_MODE_DCDC)
 	nrf_power_dcdcen_set(NRF_POWER, true);
 #endif
 #if NRF_POWER_HAS_DCDCEN_VDDH && (defined(CONFIG_SOC_DCDC_NRF52X_HV) || \


### PR DESCRIPTION
Use the correct define for checking if the DCDC converter shall be enabled.

This resolves the opposite behavior where boards that enable the DCDC converter uses the LDO and boards where LDO is used they enable the DCDC.

Fixes: e189fb07205 ("soc: nordic: nrf52: add support for DT-based regulators config")