### PR TITLE
soc: dts: esp32c2: esp8684: Fix XTAL property

### DIFF
--- a/dts/riscv/espressif/esp32c2/esp32c2_common.dtsi
+++ b/dts/riscv/espressif/esp32c2/esp32c2_common.dtsi
@@ -36,7 +36,6 @@
 			reg = <0>;
 			clock-source = <ESP32_CPU_CLK_SRC_PLL>;
 			clock-frequency = <DT_FREQ_M(120)>;
-			xtal-freq = <DT_FREQ_M(26)>;
 		};
 	};
 
@@ -153,7 +152,6 @@
 			interrupts = <UART1_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_UART1_MODULE>;
-			current-speed = <115200>;
 		};
 
 		ledc0: ledc@60019000 {

--- a/dts/riscv/espressif/esp32c2/esp8684_mini_h2.dtsi
+++ b/dts/riscv/espressif/esp32c2/esp8684_mini_h2.dtsi
@@ -6,6 +6,10 @@
 
 #include "esp32c2_common.dtsi"
 
+&cpu0 {
+	xtal-freq = <DT_FREQ_M(26)>;
+};
+
 /* 2MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(2)>;

--- a/dts/riscv/espressif/esp32c2/esp8684_mini_h4.dtsi
+++ b/dts/riscv/espressif/esp32c2/esp8684_mini_h4.dtsi
@@ -6,6 +6,10 @@
 
 #include "esp32c2_common.dtsi"
 
+&cpu0 {
+	xtal-freq = <DT_FREQ_M(26)>;
+};
+
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;

--- a/dts/riscv/espressif/esp32c2/esp8684_wroom_h2.dtsi
+++ b/dts/riscv/espressif/esp32c2/esp8684_wroom_h2.dtsi
@@ -6,6 +6,10 @@
 
 #include "esp32c2_common.dtsi"
 
+&cpu0 {
+	xtal-freq = <DT_FREQ_M(26)>;
+};
+
 /* 2MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(2)>;

--- a/dts/riscv/espressif/esp32c2/esp8684_wroom_h4.dtsi
+++ b/dts/riscv/espressif/esp32c2/esp8684_wroom_h4.dtsi
@@ -6,6 +6,10 @@
 
 #include "esp32c2_common.dtsi"
 
+&cpu0 {
+	xtal-freq = <DT_FREQ_M(26)>;
+};
+
 /* 4MB flash */
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;


### PR DESCRIPTION
XTAL frequency is a property of the SoC and has two versions (26 Mhz and 40 Mhz), so it was moved from the common .dts to the SoC's .dts.