### PR TITLE
Add support Flash QSPI on S32Z270

### DIFF
--- a/boards/nxp/mr_canhubk3/mr_canhubk3.dts
+++ b/boards/nxp/mr_canhubk3/mr_canhubk3.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NXP
+ * Copyright 2023-2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -344,6 +344,8 @@
 		readoc = "1-4-4";
 		writeoc = "1-4-4";
 		has-32k-erase;
+		max-program-buffer-size = <256>;
+		write-block-size = <1>;
 		status = "okay";
 
 		partitions {

--- a/boards/nxp/s32z2xxdc2/doc/index.rst
+++ b/boards/nxp/s32z2xxdc2/doc/index.rst
@@ -62,6 +62,8 @@ The boards support the following hardware features:
 +-----------+------------+-------------------------------------+
 | eMIOS     | on-chip    | pwm                                 |
 +-----------+------------+-------------------------------------+
+| QSPI      | on-chip    | flash                               |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not currently supported by the port.
 
@@ -171,6 +173,12 @@ EDMA
 
 The EDMA modules feature four EDMA3 instances: Instance 0 with 32 channels,
 and instances 1, 4, and 5, each with 16 channels.
+
+External Flash
+==============
+
+The on-board S26HS512T 512M-bit HyperFlash memory is connected to the QSPI controller
+port A1. This board configuration selects it as the default flash controller.
 
 Programming and Debugging
 *************************

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270.dtsi
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include "s32z2xxdc2_s32z270_pinctrl.dtsi"
+#include <zephyr/dt-bindings/qspi/nxp-s32-qspi.h>
 
 &swt0 {
 	status = "okay";
@@ -57,4 +58,70 @@
 
 &sar_adc1 {
 	vref-mv = <1800>;
+};
+
+&qspi0 {
+	pinctrl-0 = <&qspi0_default>;
+	pinctrl-names = "default";
+	data-rate = "DDR";
+	column-space = <3>;
+	word-addressable;
+	hold-time-2x;
+	a-dll-freq-enable;
+	a-dll-ref-counter = <2>;
+	a-dll-resolution = <2>;
+	a-dll-coarse-delay = <2>;
+	a-dll-fine-delay = <2>;
+	a-dll-mode = "AUTO UPDATE";
+	a-rx-clock-source = "EXTERNAL DQS";
+	ahb-buffers-masters = <0 1 2 3>;
+	ahb-buffers-sizes = <256 256 256 256>;
+	ahb-buffers-all-masters;
+	status = "okay";
+
+	sfp_mdad {
+		compatible = "nxp,s32-qspi-sfp-mdad";
+
+		mdad_0: mdad_0 {
+			domain-id = <0>;
+			secure-attribute = <NXP_S32_QSPI_SECURE>;
+		};
+	};
+
+	sfp_frad {
+		compatible = "nxp,s32-qspi-sfp-frad";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		frad_0: frad@0 {
+			reg = <0x0 DT_SIZE_M(512)>;
+			master-domain-acp-policy = <NXP_S32_QSPI_SECURE>;
+		};
+	};
+
+	s26hs512t: s26hs512t@0 {
+		compatible = "nxp,s32-qspi-hyperflash";
+		reg = <0>;
+		jedec-id = [00 34 00 7b 00 1a 00 0f 00 90];
+		device-id-word-addr = <0x800>;
+		size = <DT_SIZE_M(512)>;
+		write-block-size = <2>;
+		read-latency-cycles = <16>;
+		max-program-buffer-size = <256>;
+		vcc-mv = <1800>;
+		drive-strength-ohm = <27>;
+		ppw-sectors-addr-mapping = "LOW";
+		status = "okay";
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			storage_partition: partition@0 {
+				label = "storage";
+				reg = <0x0 0x10000>;
+			};
+		};
+	};
 };

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_pinctrl.dtsi
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_pinctrl.dtsi
@@ -127,4 +127,25 @@
 			drive-open-drain;
 		};
 	};
+
+	qspi0_default: qspi0_default {
+		group1 {
+			pinmux = <PI4_QSPI_0_DATA_A_O0>, <PH14_QSPI_0_DATA_A_O1>,
+				 <PI8_QSPI_0_DATA_A_O2>, <PI1_QSPI_0_DATA_A_O3>,
+				 <PI5_QSPI_0_DATA_A_O4>, <PH15_QSPI_0_DATA_A_O5>,
+				 <PI7_QSPI_0_DATA_A_O6>, <PI0_QSPI_0_DATA_A_O7>,
+				 <PI6_QSPI_0_DQS_A_O>;
+			output-enable;
+			input-enable;
+		};
+		group2 {
+			pinmux = <PH13_QSPI_0_CS_A0>, <PI9_QSPI_0_CS_A1>,
+				 <PI2_QSPI_0_CK_A_B>, <PI3_QSPI_0_CK_A>;
+			output-enable;
+		};
+		group3 {
+			pinmux = <PH12_QSPI_0_INTA_B>;
+			input-enable;
+		};
+	};
 };

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu0.dts
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu0.dts
@@ -16,6 +16,7 @@
 		zephyr,sram = &dram0;
 		zephyr,flash = &cram0;
 		zephyr,canbus = &canxl0;
+		zephyr,flash-controller = &s26hs512t;
 	};
 
 	aliases {

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu1.dts
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu1.dts
@@ -16,6 +16,7 @@
 		zephyr,sram = &dram1;
 		zephyr,flash = &cram1;
 		zephyr,canbus = &flexcan0;
+		zephyr,flash-controller = &s26hs512t;
 	};
 
 	aliases {

--- a/drivers/flash/CMakeLists.txt
+++ b/drivers/flash/CMakeLists.txt
@@ -149,6 +149,7 @@ zephyr_library_include_directories_ifdef(
 )
 
 zephyr_library_sources_ifdef(CONFIG_FLASH_NXP_S32_QSPI_NOR flash_nxp_s32_qspi_nor.c)
+zephyr_library_sources_ifdef(CONFIG_FLASH_NXP_S32_QSPI_NOR flash_nxp_s32_qspi.c)
 zephyr_library_include_directories_ifdef(
   CONFIG_FLASH_NXP_S32_QSPI_NOR
   ${ZEPHYR_BASE}/drivers/memc

--- a/drivers/flash/CMakeLists.txt
+++ b/drivers/flash/CMakeLists.txt
@@ -149,11 +149,11 @@ zephyr_library_include_directories_ifdef(
 )
 
 zephyr_library_sources_ifdef(CONFIG_FLASH_NXP_S32_QSPI_NOR flash_nxp_s32_qspi_nor.c)
-zephyr_library_sources_ifdef(CONFIG_FLASH_NXP_S32_QSPI_NOR flash_nxp_s32_qspi.c)
-zephyr_library_include_directories_ifdef(
-  CONFIG_FLASH_NXP_S32_QSPI_NOR
-  ${ZEPHYR_BASE}/drivers/memc
-)
+zephyr_library_sources_ifdef(CONFIG_FLASH_NXP_S32_QSPI_HYPERFLASH flash_nxp_s32_qspi_hyperflash.c)
+if(CONFIG_FLASH_NXP_S32_QSPI_NOR OR CONFIG_FLASH_NXP_S32_QSPI_HYPERFLASH)
+  zephyr_library_sources(flash_nxp_s32_qspi.c)
+  zephyr_library_include_directories(${ZEPHYR_BASE}/drivers/memc)
+endif()
 
 if(CONFIG_RA_FLASH_HP)
   zephyr_library_sources(flash_hp_ra.c)

--- a/drivers/flash/Kconfig.nxp_s32
+++ b/drivers/flash/Kconfig.nxp_s32
@@ -16,7 +16,7 @@ config FLASH_NXP_S32_QSPI_NOR
 
 if FLASH_NXP_S32_QSPI_NOR
 
-config FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME
+config FLASH_NXP_S32_QSPI_SFDP_RUNTIME
 	bool "Read flash parameters at runtime"
 	help
 	  Read flash device characteristics from the device at runtime.

--- a/drivers/flash/Kconfig.nxp_s32
+++ b/drivers/flash/Kconfig.nxp_s32
@@ -1,4 +1,4 @@
-# Copyright 2023 NXP
+# Copyright 2023-2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 config FLASH_NXP_S32_QSPI_NOR
@@ -14,10 +14,23 @@ config FLASH_NXP_S32_QSPI_NOR
 	  Enable the Flash driver for a NOR Serial Flash Memory device connected
 	  to an NXP S32 QSPI bus.
 
-if FLASH_NXP_S32_QSPI_NOR
+config FLASH_NXP_S32_QSPI_HYPERFLASH
+	bool "NXP S32 QSPI HYPERFLASH driver"
+	default y
+	depends on DT_HAS_NXP_S32_QSPI_HYPERFLASH_ENABLED
+	select MEMC
+	select FLASH_HAS_PAGE_LAYOUT
+	select FLASH_HAS_DRIVER_ENABLED
+	select FLASH_HAS_EXPLICIT_ERASE
+	help
+	  Enable the Flash driver for a HyperFlash Memory device connected
+	  to an NXP S32 QSPI bus.
+
+if FLASH_NXP_S32_QSPI_NOR || FLASH_NXP_S32_QSPI_HYPERFLASH
 
 config FLASH_NXP_S32_QSPI_SFDP_RUNTIME
 	bool "Read flash parameters at runtime"
+	depends on FLASH_NXP_S32_QSPI_NOR
 	help
 	  Read flash device characteristics from the device at runtime.
 	  This option should provide functionality for all supported
@@ -52,4 +65,4 @@ config FLASH_NXP_S32_QSPI_LAYOUT_PAGE_SIZE
 	  flash memory. Other options may include the 32K-byte erase size (32768),
 	  the block size (65536), or any non-zero multiple of the sector size.
 
-endif # FLASH_NXP_S32_QSPI_NOR
+endif # FLASH_NXP_S32_QSPI_NOR || FLASH_NXP_S32_QSPI_HYPERFLASH

--- a/drivers/flash/flash_nxp_s32_qspi.c
+++ b/drivers/flash/flash_nxp_s32_qspi.c
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2023-2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/flash.h>
+#include <zephyr/logging/log.h>
+
+#include <Qspi_Ip.h>
+
+#include "flash_nxp_s32_qspi.h"
+
+LOG_MODULE_REGISTER(flash_nxp_s32_qspi, CONFIG_FLASH_LOG_LEVEL);
+
+static ALWAYS_INLINE bool area_is_subregion(const struct device *dev, off_t offset, size_t size)
+{
+	Qspi_Ip_MemoryConfigType *memory_cfg = get_memory_config(dev);
+
+	return ((offset >= 0) && (offset < memory_cfg->memSize) &&
+		((memory_cfg->memSize - offset) >= size));
+}
+
+uint8_t nxp_s32_qspi_register_device(void)
+{
+	static uint8_t instance_cnt;
+
+	return instance_cnt++;
+}
+
+/* Must be called with lock */
+int nxp_s32_qspi_wait_until_ready(const struct device *dev)
+{
+	struct nxp_s32_qspi_data *data = dev->data;
+	Qspi_Ip_StatusType status;
+	uint32_t timeout = 0xFFFFFF;
+	int ret = 0;
+
+	do {
+		status = Qspi_Ip_GetMemoryStatus(data->instance);
+		timeout--;
+	} while ((status == STATUS_QSPI_IP_BUSY) && (timeout > 0));
+
+	if (status != STATUS_QSPI_IP_SUCCESS) {
+		LOG_ERR("Failed to read memory status (%d)", status);
+		ret = -EIO;
+	} else if (timeout == 0) {
+		LOG_ERR("Timeout, memory is busy");
+		ret = -ETIMEDOUT;
+	}
+
+	return ret;
+}
+
+int nxp_s32_qspi_read(const struct device *dev, off_t offset, void *dest, size_t size)
+{
+	struct nxp_s32_qspi_data *data = dev->data;
+	Qspi_Ip_StatusType status;
+	int ret = 0;
+
+	if (!dest) {
+		return -EINVAL;
+	}
+
+	if (!area_is_subregion(dev, offset, size)) {
+		return -EINVAL;
+	}
+
+	if (size) {
+		nxp_s32_qspi_lock(dev);
+
+		status = Qspi_Ip_Read(data->instance, (uint32_t)offset, (uint8_t *)dest,
+				      (uint32_t)size);
+		if (status != STATUS_QSPI_IP_SUCCESS) {
+			LOG_ERR("Failed to read %zu bytes at 0x%lx (%d)", size, offset, status);
+			ret = -EIO;
+		}
+
+		nxp_s32_qspi_unlock(dev);
+	}
+
+	return ret;
+}
+
+int nxp_s32_qspi_write(const struct device *dev, off_t offset, const void *src, size_t size)
+{
+	const struct nxp_s32_qspi_config *config = dev->config;
+	struct nxp_s32_qspi_data *data = dev->data;
+	Qspi_Ip_MemoryConfigType *memory_cfg = get_memory_config(dev);
+	Qspi_Ip_StatusType status;
+	size_t max_write = (size_t)MIN(QSPI_IP_MAX_WRITE_SIZE, memory_cfg->pageSize);
+	size_t len;
+	int ret = 0;
+
+	if (!src || !size) {
+		return -EINVAL;
+	}
+
+	if (!area_is_subregion(dev, offset, size) ||
+	    (offset % config->flash_parameters.write_block_size) ||
+	    (size % config->flash_parameters.write_block_size)) {
+		return -EINVAL;
+	}
+
+	nxp_s32_qspi_lock(dev);
+
+	while (size) {
+		len = MIN(max_write - (offset % max_write), size);
+		status = Qspi_Ip_Program(data->instance, (uint32_t)offset, (const uint8_t *)src,
+					 (uint32_t)len);
+		if (status != STATUS_QSPI_IP_SUCCESS) {
+			LOG_ERR("Failed to write %zu bytes at 0x%lx (%d)", len, offset, status);
+			ret = -EIO;
+			break;
+		}
+
+		ret = nxp_s32_qspi_wait_until_ready(dev);
+		if (ret != 0) {
+			break;
+		}
+
+		if (IS_ENABLED(CONFIG_FLASH_NXP_S32_QSPI_VERIFY_WRITE)) {
+			status = Qspi_Ip_ProgramVerify(data->instance, (uint32_t)offset,
+						       (const uint8_t *)src, (uint32_t)len);
+			if (status != STATUS_QSPI_IP_SUCCESS) {
+				LOG_ERR("Write verification failed at 0x%lx (%d)", offset, status);
+				ret = -EIO;
+				break;
+			}
+		}
+
+		size -= len;
+		src = (const uint8_t *)src + len;
+		offset += len;
+	}
+
+	nxp_s32_qspi_unlock(dev);
+
+	return ret;
+}
+
+static int nxp_s32_qspi_erase_block(const struct device *dev, off_t offset, size_t size,
+				    size_t *erase_size)
+{
+	struct nxp_s32_qspi_data *data = dev->data;
+	Qspi_Ip_MemoryConfigType *memory_cfg = get_memory_config(dev);
+	Qspi_Ip_EraseVarConfigType *etp = NULL;
+	Qspi_Ip_EraseVarConfigType *etp_tmp;
+	Qspi_Ip_StatusType status;
+	int ret = 0;
+
+	/*
+	 * Find the erase type with bigger size that can erase all or part of the
+	 * requested memory size
+	 */
+	for (uint8_t i = 0; i < QSPI_IP_ERASE_TYPES; i++) {
+		etp_tmp = (Qspi_Ip_EraseVarConfigType *)&(memory_cfg->eraseSettings.eraseTypes[i]);
+		if ((etp_tmp->eraseLut != QSPI_IP_LUT_INVALID) &&
+		    QSPI_IS_ALIGNED(offset, etp_tmp->size) && (BIT(etp_tmp->size) <= size) &&
+		    ((etp == NULL) || (etp_tmp->size > etp->size))) {
+
+			etp = etp_tmp;
+		}
+	}
+	if (etp != NULL) {
+		*erase_size = BIT(etp->size);
+		status = Qspi_Ip_EraseBlock(data->instance, (uint32_t)offset, *erase_size);
+		if (status != STATUS_QSPI_IP_SUCCESS) {
+			LOG_ERR("Failed to erase %zu bytes at 0x%lx (%d)", *erase_size,
+				(long)offset, status);
+			ret = -EIO;
+		}
+	} else {
+		LOG_ERR("Can't find erase size to erase %zu bytes", size);
+		ret = -EINVAL;
+	}
+
+	return ret;
+}
+
+int nxp_s32_qspi_erase(const struct device *dev, off_t offset, size_t size)
+{
+	struct nxp_s32_qspi_data *data = dev->data;
+	Qspi_Ip_MemoryConfigType *memory_cfg = get_memory_config(dev);
+	Qspi_Ip_StatusType status;
+	size_t erase_size;
+	int ret = 0;
+
+	if (!area_is_subregion(dev, offset, size) || !size) {
+		return -EINVAL;
+	}
+
+	nxp_s32_qspi_lock(dev);
+
+	if (size == memory_cfg->memSize) {
+		status = Qspi_Ip_EraseChip(data->instance);
+		if (status != STATUS_QSPI_IP_SUCCESS) {
+			LOG_ERR("Failed to erase chip (%d)", status);
+			ret = -EIO;
+		}
+	} else {
+		while (size > 0) {
+			erase_size = 0;
+
+			ret = nxp_s32_qspi_erase_block(dev, offset, size, &erase_size);
+			if (ret != 0) {
+				break;
+			}
+
+			ret = nxp_s32_qspi_wait_until_ready(dev);
+			if (ret != 0) {
+				break;
+			}
+
+			if (IS_ENABLED(CONFIG_FLASH_NXP_S32_QSPI_VERIFY_ERASE)) {
+				status = Qspi_Ip_EraseVerify(data->instance, (uint32_t)offset,
+							     erase_size);
+				if (status != STATUS_QSPI_IP_SUCCESS) {
+					LOG_ERR("Erase verification failed at 0x%lx (%d)", offset,
+						status);
+					ret = -EIO;
+					break;
+				}
+			}
+
+			offset += erase_size;
+			size -= erase_size;
+		}
+	}
+
+	nxp_s32_qspi_unlock(dev);
+
+	return ret;
+}
+
+const struct flash_parameters *nxp_s32_qspi_get_parameters(const struct device *dev)
+{
+	const struct nxp_s32_qspi_config *config = dev->config;
+
+	return &config->flash_parameters;
+}
+
+#if defined(CONFIG_FLASH_PAGE_LAYOUT)
+void nxp_s32_qspi_pages_layout(const struct device *dev, const struct flash_pages_layout **layout,
+			       size_t *layout_size)
+{
+	const struct nxp_s32_qspi_config *config = dev->config;
+
+	*layout = &config->layout;
+	*layout_size = 1;
+}
+#endif /* CONFIG_FLASH_PAGE_LAYOUT */
+
+#if defined(CONFIG_FLASH_JESD216_API) || !defined(CONFIG_FLASH_NXP_S32_QSPI_SFDP_RUNTIME)
+int nxp_s32_qspi_read_id(const struct device *dev, uint8_t *id)
+{
+	struct nxp_s32_qspi_data *data = dev->data;
+	Qspi_Ip_StatusType status;
+	int ret = 0;
+
+	nxp_s32_qspi_lock(dev);
+
+	status = Qspi_Ip_ReadId(data->instance, id);
+	if (status != STATUS_QSPI_IP_SUCCESS) {
+		LOG_ERR("Failed to read device ID (%d)", status);
+		ret = -EIO;
+	}
+
+	nxp_s32_qspi_unlock(dev);
+
+	return ret;
+}
+#endif /* CONFIG_FLASH_JESD216_API || !CONFIG_FLASH_NXP_S32_QSPI_SFDP_RUNTIME */

--- a/drivers/flash/flash_nxp_s32_qspi.h
+++ b/drivers/flash/flash_nxp_s32_qspi.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2023-2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_FLASH_NXP_S32_QSPI_H_
+#define ZEPHYR_DRIVERS_FLASH_NXP_S32_QSPI_H_
+
+#include "jesd216.h"
+
+#define QSPI_ERASE_VALUE 0xff
+
+#define QSPI_IS_ALIGNED(addr, bits) (((addr) & BIT_MASK(bits)) == 0)
+
+#if defined(CONFIG_FLASH_NXP_S32_QSPI_SFDP_RUNTIME)
+/* Size of LUT */
+#define QSPI_SFDP_LUT_SIZE     130U
+/* Size of init operations */
+#define QSPI_SFDP_INIT_OP_SIZE 8U
+#if defined(CONFIG_FLASH_JESD216_API)
+/* Size of all LUT sequences for JESD216 operations */
+#define QSPI_JESD216_SEQ_SIZE 8U
+#endif /* CONFIG_FLASH_JESD216_API */
+#endif /* CONFIG_FLASH_NXP_S32_QSPI_SFDP_RUNTIME */
+
+struct nxp_s32_qspi_config {
+	const struct device *controller;
+	struct flash_parameters flash_parameters;
+#if defined(CONFIG_FLASH_PAGE_LAYOUT)
+	struct flash_pages_layout layout;
+#endif
+#if !defined(CONFIG_FLASH_NXP_S32_QSPI_SFDP_RUNTIME)
+	const Qspi_Ip_MemoryConfigType memory_cfg;
+	enum jesd216_dw15_qer_type qer_type;
+	bool quad_mode;
+#endif
+};
+
+struct nxp_s32_qspi_data {
+	uint8_t instance;
+	Qspi_Ip_MemoryConnectionType memory_conn_cfg;
+	uint8_t read_sfdp_lut_idx;
+#if defined(CONFIG_FLASH_NXP_S32_QSPI_SFDP_RUNTIME)
+	Qspi_Ip_MemoryConfigType memory_cfg;
+	Qspi_Ip_InstrOpType lut_ops[QSPI_SFDP_LUT_SIZE];
+	Qspi_Ip_InitOperationType init_ops[QSPI_SFDP_INIT_OP_SIZE];
+#endif
+#if defined(CONFIG_MULTITHREADING)
+	struct k_sem sem;
+#endif
+};
+
+static ALWAYS_INLINE Qspi_Ip_MemoryConfigType *get_memory_config(const struct device *dev)
+{
+#if defined(CONFIG_FLASH_NXP_S32_QSPI_SFDP_RUNTIME)
+	return &((struct nxp_s32_qspi_data *)dev->data)->memory_cfg;
+#else
+	return ((Qspi_Ip_MemoryConfigType *)&((const struct nxp_s32_qspi_config *)dev->config)
+			->memory_cfg);
+#endif
+}
+
+static inline void nxp_s32_qspi_lock(const struct device *dev)
+{
+#ifdef CONFIG_MULTITHREADING
+	struct nxp_s32_qspi_data *data = dev->data;
+
+	k_sem_take(&data->sem, K_FOREVER);
+#else
+	ARG_UNUSED(dev);
+#endif
+}
+
+static inline void nxp_s32_qspi_unlock(const struct device *dev)
+{
+#ifdef CONFIG_MULTITHREADING
+	struct nxp_s32_qspi_data *data = dev->data;
+
+	k_sem_give(&data->sem);
+#else
+	ARG_UNUSED(dev);
+#endif
+}
+
+/*
+ * This function retrieves the device instance used by the HAL
+ * to access the internal driver state.
+ */
+uint8_t nxp_s32_qspi_register_device(void);
+
+int nxp_s32_qspi_wait_until_ready(const struct device *dev);
+
+int nxp_s32_qspi_read(const struct device *dev, off_t offset, void *dest, size_t size);
+
+int nxp_s32_qspi_write(const struct device *dev, off_t offset, const void *src, size_t size);
+
+int nxp_s32_qspi_erase(const struct device *dev, off_t offset, size_t size);
+
+const struct flash_parameters *nxp_s32_qspi_get_parameters(const struct device *dev);
+
+#if defined(CONFIG_FLASH_PAGE_LAYOUT)
+void nxp_s32_qspi_pages_layout(const struct device *dev, const struct flash_pages_layout **layout,
+			       size_t *layout_size);
+#endif /* CONFIG_FLASH_PAGE_LAYOUT */
+
+#if defined(CONFIG_FLASH_JESD216_API) || !defined(CONFIG_FLASH_NXP_S32_QSPI_SFDP_RUNTIME)
+int nxp_s32_qspi_read_id(const struct device *dev, uint8_t *id);
+#endif /* CONFIG_FLASH_JESD216_API || !CONFIG_FLASH_NXP_S32_QSPI_SFDP_RUNTIME */
+
+#endif /* ZEPHYR_DRIVERS_FLASH_NXP_S32_QSPI_H_ */

--- a/drivers/flash/flash_nxp_s32_qspi_hyperflash.c
+++ b/drivers/flash/flash_nxp_s32_qspi_hyperflash.c
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT nxp_s32_qspi_hyperflash
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/flash.h>
+#include <zephyr/logging/log.h>
+
+#include <Qspi_Ip.h>
+
+#include "memc_nxp_s32_qspi.h"
+#include "flash_nxp_s32_qspi.h"
+
+LOG_MODULE_REGISTER(nxp_s32_qspi_hyperflash, CONFIG_FLASH_LOG_LEVEL);
+
+/* Use the fixed command sets from Qspi_Ip_Hyperflash.c */
+extern Qspi_Ip_InstrOpType QSPI_IP_HF_LUT_NAME[QSPI_IP_HF_LUT_SIZE];
+
+static int nxp_s32_qspi_init(const struct device *dev)
+{
+	struct nxp_s32_qspi_data *data = dev->data;
+	const struct nxp_s32_qspi_config *config = dev->config;
+	Qspi_Ip_MemoryConfigType *memory_cfg = get_memory_config(dev);
+	uint8_t dev_id[memory_cfg->readIdSettings.readIdSize];
+	Qspi_Ip_StatusType status;
+	int ret = 0;
+
+	/* Used by the HAL to retrieve the internal driver state */
+	data->instance = nxp_s32_qspi_register_device();
+	__ASSERT_NO_MSG(data->instance < QSPI_IP_MEM_INSTANCE_COUNT);
+	data->memory_conn_cfg.qspiInstance = memc_nxp_s32_qspi_get_instance(config->controller);
+
+#if defined(CONFIG_MULTITHREADING)
+	k_sem_init(&data->sem, 1, 1);
+#endif
+
+	if (!device_is_ready(config->controller)) {
+		LOG_ERR("Memory control device not ready");
+		return -ENODEV;
+	}
+
+	status = Qspi_Ip_Init(data->instance, (const Qspi_Ip_MemoryConfigType *)memory_cfg,
+			      (const Qspi_Ip_MemoryConnectionType *)&data->memory_conn_cfg);
+	if (status != STATUS_QSPI_IP_SUCCESS) {
+		LOG_ERR("Fail to init memory device %d (%d)", data->instance, status);
+		return -EIO;
+	}
+
+	/* Verify connectivity by reading the device ID */
+	ret = nxp_s32_qspi_read_id(dev, dev_id);
+	if (ret != 0) {
+		LOG_ERR("Device ID read failed (%d)", ret);
+		return -ENODEV;
+	}
+
+	if (memcmp(dev_id, memory_cfg->readIdSettings.readIdExpected, sizeof(dev_id))) {
+		LOG_ERR("Device id does not match config");
+		return -EINVAL;
+	}
+
+	return ret;
+}
+
+static DEVICE_API(flash, nxp_s32_qspi_api) = {
+	.erase = nxp_s32_qspi_erase,
+	.write = nxp_s32_qspi_write,
+	.read = nxp_s32_qspi_read,
+	.get_parameters = nxp_s32_qspi_get_parameters,
+#if defined(CONFIG_FLASH_PAGE_LAYOUT)
+	.page_layout = nxp_s32_qspi_pages_layout,
+#endif /* CONFIG_FLASH_PAGE_LAYOUT */
+};
+
+#define QSPI_PAGE_LAYOUT(n)							\
+	.layout = {								\
+		.pages_count = (DT_INST_PROP(n, size) / 8)			\
+			/ CONFIG_FLASH_NXP_S32_QSPI_LAYOUT_PAGE_SIZE,		\
+		.pages_size = CONFIG_FLASH_NXP_S32_QSPI_LAYOUT_PAGE_SIZE,	\
+	}
+
+#define QSPI_READ_ID_CFG(n)							\
+	{									\
+		.readIdLut = QSPI_IP_HF_LUT_READ,				\
+		.readIdSize = DT_INST_PROP_LEN(n, jedec_id),			\
+		.readIdExpected = DT_INST_PROP(n, jedec_id),			\
+	}
+
+#define QSPI_MEMORY_CONN_CFG(n)							\
+	{									\
+		.connectionType = (Qspi_Ip_ConnectionType)DT_INST_REG_ADDR(n),	\
+		.memAlignment = DT_INST_PROP(n, write_block_size)		\
+	}
+
+#define QSPI_ERASE_CFG(n)							\
+	{									\
+		.eraseTypes = {							\
+			{							\
+				.eraseLut = QSPI_IP_HF_LUT_SE,			\
+				.size = 12, /* 4 KB */				\
+			},							\
+			{							\
+				.eraseLut = QSPI_IP_HF_LUT_SE,			\
+				.size = 18, /* 256 KB */			\
+			},							\
+			{							\
+				.eraseLut = QSPI_IP_LUT_INVALID,		\
+				.size = 0,					\
+			},							\
+			{							\
+				.eraseLut = QSPI_IP_LUT_INVALID,		\
+				.size = 0,					\
+			},							\
+		},								\
+		.chipEraseLut = QSPI_IP_HF_LUT_CE,				\
+	}
+
+#define QSPI_RESET_CFG(n)							\
+	{									\
+		.resetCmdLut = QSPI_IP_HF_LUT_RST,				\
+		.resetCmdCount = QSPI_IP_HF_RST_CNT,				\
+	}
+
+#define QSPI_STATUS_REG_CFG(n)							\
+	{									\
+		.statusRegInitReadLut = QSPI_IP_HF_LUT_RDSR,			\
+		.statusRegReadLut = QSPI_IP_HF_LUT_RDSR,			\
+		.statusRegWriteLut = QSPI_IP_LUT_INVALID,			\
+		.writeEnableSRLut = QSPI_IP_LUT_INVALID,			\
+		.writeEnableLut = QSPI_IP_LUT_INVALID,				\
+		.regSize = 1U,							\
+		.busyOffset = 0U,						\
+		.busyValue = 1U,						\
+		.writeEnableOffset = 1U,					\
+	}
+
+#define QSPI_INIT_CFG(n)							\
+	{									\
+		.opCount = 0U,							\
+		.operations = NULL,						\
+	}
+
+#define QSPI_LUT_CFG(n)								\
+	{									\
+		.opCount = QSPI_IP_HF_LUT_SIZE,					\
+		.lutOps = (Qspi_Ip_InstrOpType *)QSPI_IP_HF_LUT_NAME,		\
+	}
+
+#define QSPI_SUSPEND_CFG(n)							\
+	{									\
+		.eraseSuspendLut = QSPI_IP_HF_LUT_ES,				\
+		.eraseResumeLut = QSPI_IP_HF_LUT_ER,				\
+		.programSuspendLut = QSPI_IP_HF_LUT_PS,				\
+		.programResumeLut = QSPI_IP_HF_LUT_PR,				\
+	}
+
+#define QSPI_MEMORY_CFG(n)							\
+	{									\
+		.memType = QSPI_IP_HYPER_FLASH,					\
+		.hfConfig = &hyperflash_config_##n,				\
+		.memSize = DT_INST_PROP(n, size) / 8,				\
+		.pageSize = DT_INST_PROP(n, max_program_buffer_size),		\
+		.writeLut = QSPI_IP_HF_LUT_WRITE,				\
+		.readLut = QSPI_IP_HF_LUT_READ,					\
+		.read0xxLut = QSPI_IP_LUT_INVALID,				\
+		.read0xxLutAHB = QSPI_IP_LUT_INVALID,				\
+		.eraseSettings = QSPI_ERASE_CFG(n),				\
+		.statusConfig = QSPI_STATUS_REG_CFG(n),				\
+		.resetSettings = QSPI_RESET_CFG(n),				\
+		.initResetSettings = QSPI_RESET_CFG(n),				\
+		.initConfiguration = QSPI_INIT_CFG(n),				\
+		.lutSequences = QSPI_LUT_CFG(n),				\
+		.readIdSettings = QSPI_READ_ID_CFG(n),				\
+		.suspendSettings = QSPI_SUSPEND_CFG(n),				\
+		.initCallout = NULL,						\
+		.resetCallout = NULL,						\
+		.errorCheckCallout = NULL,					\
+		.eccCheckCallout = NULL,					\
+		.ctrlAutoCfgPtr = NULL,						\
+	}
+
+#define FLASH_NXP_S32_QSPI_DRV_STRENGTH(n)							\
+	COND_CODE_1(DT_INST_ENUM_IDX(n, vcc_mv),						\
+		(DT_INST_PROP(n, drive_strength_ohm) == 12 ? QSPI_IP_HF_DRV_STRENGTH_007 :	\
+		(DT_INST_PROP(n, drive_strength_ohm) == 14 ? QSPI_IP_HF_DRV_STRENGTH_006 :	\
+		(DT_INST_PROP(n, drive_strength_ohm) == 16 ? QSPI_IP_HF_DRV_STRENGTH_005 :	\
+		(DT_INST_PROP(n, drive_strength_ohm) == 20 ? QSPI_IP_HF_DRV_STRENGTH_000 :	\
+		(DT_INST_PROP(n, drive_strength_ohm) == 27 ? QSPI_IP_HF_DRV_STRENGTH_003 :	\
+		(DT_INST_PROP(n, drive_strength_ohm) == 40 ? QSPI_IP_HF_DRV_STRENGTH_002 :	\
+		(DT_INST_PROP(n, drive_strength_ohm) == 71 ? QSPI_IP_HF_DRV_STRENGTH_001 :	\
+		QSPI_IP_HF_DRV_STRENGTH_000))))))),						\
+		(DT_INST_PROP(n, drive_strength_ohm) == 20 ? QSPI_IP_HF_DRV_STRENGTH_007 :	\
+		(DT_INST_PROP(n, drive_strength_ohm) == 24 ? QSPI_IP_HF_DRV_STRENGTH_006 :	\
+		(DT_INST_PROP(n, drive_strength_ohm) == 27 ? QSPI_IP_HF_DRV_STRENGTH_000 :	\
+		(DT_INST_PROP(n, drive_strength_ohm) == 34 ? QSPI_IP_HF_DRV_STRENGTH_004 :	\
+		(DT_INST_PROP(n, drive_strength_ohm) == 45 ? QSPI_IP_HF_DRV_STRENGTH_003 :	\
+		(DT_INST_PROP(n, drive_strength_ohm) == 68 ? QSPI_IP_HF_DRV_STRENGTH_002 :	\
+		(DT_INST_PROP(n, drive_strength_ohm) == 117 ? QSPI_IP_HF_DRV_STRENGTH_001 :	\
+		QSPI_IP_HF_DRV_STRENGTH_000))))))))
+
+#define FLASH_NXP_S32_QSPI_SECTOR_MAP(n)							\
+	COND_CODE_1(DT_INST_PROP(n, support_only_uniform_sectors),				\
+		(DT_INST_ENUM_IDX(n, ppw_sectors_addr_mapping) ?				\
+			QSPI_IP_HF_UNIFORM_SECTORS_READ_PASSWORD_HIGH :				\
+			QSPI_IP_HF_UNIFORM_SECTORS_READ_PASSWORD_LOW),				\
+		(DT_INST_ENUM_IDX(n, ppw_sectors_addr_mapping) ?				\
+			QSPI_IP_HF_PARAM_AND_PASSWORD_MAP_HIGH :				\
+			QSPI_IP_HF_PARAM_AND_PASSWORD_MAP_LOW))
+
+#define FLASH_NXP_S32_QSPI_INIT_DEVICE(n)					\
+	static Qspi_Ip_HyperFlashConfigType hyperflash_config_##n =		\
+	{									\
+		.outputDriverStrength = FLASH_NXP_S32_QSPI_DRV_STRENGTH(n),	\
+		.RWDSLowOnDualError = DT_INST_PROP(n, rwds_low_dual_error),	\
+		.secureRegionUnlocked = !DT_INST_PROP(n, secure_region_locked),	\
+		.readLatency = DT_INST_ENUM_IDX(n, read_latency_cycles),	\
+		.paramSectorMap = FLASH_NXP_S32_QSPI_SECTOR_MAP(n),		\
+		.deviceIdWordAddress = DT_INST_PROP(n, device_id_word_addr),	\
+	};									\
+	static const struct nxp_s32_qspi_config nxp_s32_qspi_config_##n = {	\
+		.controller = DEVICE_DT_GET(DT_INST_BUS(n)),			\
+		.flash_parameters = {						\
+			.write_block_size = DT_INST_PROP(n, write_block_size),	\
+			.erase_value = QSPI_ERASE_VALUE,			\
+		},								\
+		IF_ENABLED(CONFIG_FLASH_PAGE_LAYOUT,				\
+			(QSPI_PAGE_LAYOUT(n),))					\
+		.memory_cfg = QSPI_MEMORY_CFG(n),				\
+	};									\
+										\
+	static struct nxp_s32_qspi_data nxp_s32_qspi_data_##n = {		\
+		.memory_conn_cfg = QSPI_MEMORY_CONN_CFG(n),			\
+	};									\
+										\
+	DEVICE_DT_INST_DEFINE(n,						\
+			      nxp_s32_qspi_init,				\
+			      NULL,						\
+			      &nxp_s32_qspi_data_##n,				\
+			      &nxp_s32_qspi_config_##n,				\
+			      POST_KERNEL,					\
+			      CONFIG_FLASH_INIT_PRIORITY,			\
+			      &nxp_s32_qspi_api);
+
+DT_INST_FOREACH_STATUS_OKAY(FLASH_NXP_S32_QSPI_INIT_DEVICE)

--- a/drivers/flash/flash_nxp_s32_qspi_nor.c
+++ b/drivers/flash/flash_nxp_s32_qspi_nor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NXP
+ * Copyright 2023-2024 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -19,6 +19,7 @@ LOG_MODULE_REGISTER(nxp_s32_qspi_nor, CONFIG_FLASH_LOG_LEVEL);
 #include "jesd216.h"
 
 #include "memc_nxp_s32_qspi.h"
+#include "flash_nxp_s32_qspi.h"
 
 #define QSPI_INST_NODE_HAS_PROP_EQ_AND_OR(n, prop, val)				\
 	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, prop),				\
@@ -55,51 +56,8 @@ LOG_MODULE_REGISTER(nxp_s32_qspi_nor, CONFIG_FLASH_LOG_LEVEL);
 		(_CONCAT(QSPI_SEQ_READ_, DT_INST_STRING_UPPER_TOKEN(n, readoc))),\
 		(QSPI_SEQ_READ_1_1_1))
 
-#define QSPI_ERASE_VALUE 0xff
-#define QSPI_WRITE_BLOCK_SIZE 1U
-
-#define QSPI_IS_ALIGNED(addr, bits) (((addr) & BIT_MASK(bits)) == 0)
-
 #define QSPI_LUT_ENTRY_SIZE (FEATURE_QSPI_LUT_SEQUENCE_SIZE * 2)
 #define QSPI_LUT_IDX(n)	(n * QSPI_LUT_ENTRY_SIZE)
-
-#if defined(CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME)
-/* Size of LUT */
-#define QSPI_SFDP_LUT_SIZE 130U
-/* Size of init operations */
-#define QSPI_SFDP_INIT_OP_SIZE 8U
-#if defined(CONFIG_FLASH_JESD216_API)
-/* Size of all LUT sequences for JESD216 operations */
-#define QSPI_JESD216_SEQ_SIZE 8U
-#endif /* CONFIG_FLASH_JESD216_API */
-#endif /* CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME */
-
-struct nxp_s32_qspi_config {
-	const struct device *controller;
-	struct flash_parameters flash_parameters;
-#if defined(CONFIG_FLASH_PAGE_LAYOUT)
-	struct flash_pages_layout layout;
-#endif
-#if !defined(CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME)
-	const Qspi_Ip_MemoryConfigType memory_cfg;
-	enum jesd216_dw15_qer_type qer_type;
-	bool quad_mode;
-#endif
-};
-
-struct nxp_s32_qspi_data {
-	uint8_t instance;
-	Qspi_Ip_MemoryConnectionType memory_conn_cfg;
-	uint8_t read_sfdp_lut_idx;
-#if defined(CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME)
-	Qspi_Ip_MemoryConfigType memory_cfg;
-	Qspi_Ip_InstrOpType lut_ops[QSPI_SFDP_LUT_SIZE];
-	Qspi_Ip_InitOperationType init_ops[QSPI_SFDP_INIT_OP_SIZE];
-#endif
-#if defined(CONFIG_MULTITHREADING)
-	struct k_sem sem;
-#endif
-};
 
 enum {
 	QSPI_SEQ_RDSR,
@@ -145,7 +103,7 @@ enum {
 #endif
 };
 
-#if !defined(CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME)
+#if !defined(CONFIG_FLASH_NXP_S32_QSPI_SFDP_RUNTIME)
 static const Qspi_Ip_InstrOpType nxp_s32_qspi_lut[][QSPI_LUT_ENTRY_SIZE] = {
 	[QSPI_SEQ_RDSR] = {
 		QSPI_LUT_OP(QSPI_IP_LUT_INSTR_CMD, QSPI_IP_LUT_PADS_1, SPI_NOR_CMD_RDSR),
@@ -309,73 +267,9 @@ static const Qspi_Ip_InstrOpType nxp_s32_qspi_lut[][QSPI_LUT_ENTRY_SIZE] = {
 	},
 #endif
 };
-#endif /* !defined(CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME) */
+#endif /* !defined(CONFIG_FLASH_NXP_S32_QSPI_SFDP_RUNTIME) */
 
-static ALWAYS_INLINE Qspi_Ip_MemoryConfigType *get_memory_config(const struct device *dev)
-{
-#if defined(CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME)
-	return &((struct nxp_s32_qspi_data *)dev->data)->memory_cfg;
-#else
-	return ((Qspi_Ip_MemoryConfigType *)
-		&((const struct nxp_s32_qspi_config *)dev->config)->memory_cfg);
-#endif
-}
-
-static ALWAYS_INLINE bool area_is_subregion(const struct device *dev, off_t offset, size_t size)
-{
-	Qspi_Ip_MemoryConfigType *memory_cfg = get_memory_config(dev);
-
-	return ((offset >= 0) && (offset < memory_cfg->memSize)
-		&& ((size + offset) <= memory_cfg->memSize));
-}
-
-static inline void nxp_s32_qspi_lock(const struct device *dev)
-{
-#ifdef CONFIG_MULTITHREADING
-	struct nxp_s32_qspi_data *data = dev->data;
-
-	k_sem_take(&data->sem, K_FOREVER);
-#else
-	ARG_UNUSED(dev);
-#endif
-}
-
-static inline void nxp_s32_qspi_unlock(const struct device *dev)
-{
-#ifdef CONFIG_MULTITHREADING
-	struct nxp_s32_qspi_data *data = dev->data;
-
-	k_sem_give(&data->sem);
-#else
-	ARG_UNUSED(dev);
-#endif
-}
-
-/* Must be called with lock */
-static int nxp_s32_qspi_wait_until_ready(const struct device *dev)
-{
-	struct nxp_s32_qspi_data *data = dev->data;
-	Qspi_Ip_StatusType status;
-	uint32_t timeout = 0xFFFFFF;
-	int ret = 0;
-
-	do {
-		status = Qspi_Ip_GetMemoryStatus(data->instance);
-		timeout--;
-	} while ((status == STATUS_QSPI_IP_BUSY) && (timeout > 0));
-
-	if (status != STATUS_QSPI_IP_SUCCESS) {
-		LOG_ERR("Failed to read memory status (%d)", status);
-		ret = -EIO;
-	} else if (timeout <= 0) {
-		LOG_ERR("Timeout, memory is busy");
-		ret = -ETIMEDOUT;
-	}
-
-	return ret;
-}
-
-#if !defined(CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME)
+#if !defined(CONFIG_FLASH_NXP_S32_QSPI_SFDP_RUNTIME)
 static int nxp_s32_qspi_read_status_register(const struct device *dev,
 					     uint8_t reg_num,
 					     uint8_t *val)
@@ -565,210 +459,7 @@ static int nxp_s32_qspi_set_quad_mode(const struct device *dev, bool enabled)
 
 	return ret;
 }
-#endif /* !defined(CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME) */
-
-static int nxp_s32_qspi_read(const struct device *dev, off_t offset, void *dest, size_t size)
-{
-	struct nxp_s32_qspi_data *data = dev->data;
-	Qspi_Ip_StatusType status;
-	int ret = 0;
-
-	if (!dest) {
-		return -EINVAL;
-	}
-
-	if (!area_is_subregion(dev, offset, size)) {
-		return -ENODEV;
-	}
-
-	if (size) {
-		nxp_s32_qspi_lock(dev);
-
-		status = Qspi_Ip_Read(data->instance, (uint32_t)offset, (uint8_t *)dest,
-				      (uint32_t)size);
-		if (status != STATUS_QSPI_IP_SUCCESS) {
-			LOG_ERR("Failed to read %zu bytes at 0x%lx (%d)",
-				size, offset, status);
-			ret = -EIO;
-		}
-
-		nxp_s32_qspi_unlock(dev);
-	}
-
-	return ret;
-}
-
-static int nxp_s32_qspi_write(const struct device *dev, off_t offset, const void *src, size_t size)
-{
-	struct nxp_s32_qspi_data *data = dev->data;
-	Qspi_Ip_MemoryConfigType *memory_cfg = get_memory_config(dev);
-	Qspi_Ip_StatusType status;
-	size_t max_write = (size_t)MIN(QSPI_IP_MAX_WRITE_SIZE, memory_cfg->pageSize);
-	size_t len;
-	int ret = 0;
-
-	if (!src) {
-		return -EINVAL;
-	}
-
-	if (!area_is_subregion(dev, offset, size)) {
-		return -ENODEV;
-	}
-
-	nxp_s32_qspi_lock(dev);
-
-	while (size) {
-		len = MIN(max_write - (offset % max_write), size);
-		status = Qspi_Ip_Program(data->instance, (uint32_t)offset,
-					(const uint8_t *)src, (uint32_t)len);
-		if (status != STATUS_QSPI_IP_SUCCESS) {
-			LOG_ERR("Failed to write %zu bytes at 0x%lx (%d)",
-				len, offset, status);
-			ret = -EIO;
-			break;
-		}
-
-		ret = nxp_s32_qspi_wait_until_ready(dev);
-		if (ret != 0) {
-			break;
-		}
-
-		if (IS_ENABLED(CONFIG_FLASH_NXP_S32_QSPI_VERIFY_WRITE)) {
-			status = Qspi_Ip_ProgramVerify(data->instance, (uint32_t)offset,
-						       (const uint8_t *)src, (uint32_t)len);
-			if (status != STATUS_QSPI_IP_SUCCESS) {
-				LOG_ERR("Write verification failed at 0x%lx (%d)",
-					offset, status);
-				ret = -EIO;
-				break;
-			}
-		}
-
-		size -= len;
-		src = (const uint8_t *)src + len;
-		offset += len;
-	}
-
-	nxp_s32_qspi_unlock(dev);
-
-	return ret;
-}
-
-static int nxp_s32_qspi_erase_block(const struct device *dev, off_t offset,
-				    size_t size, size_t *erase_size)
-{
-	struct nxp_s32_qspi_data *data = dev->data;
-	Qspi_Ip_MemoryConfigType *memory_cfg = get_memory_config(dev);
-	Qspi_Ip_EraseVarConfigType *etp = NULL;
-	Qspi_Ip_EraseVarConfigType *etp_tmp;
-	Qspi_Ip_StatusType status;
-	int ret = 0;
-
-	/*
-	 * Find the erase type with bigger size that can erase all or part of the
-	 * requested memory size
-	 */
-	for (uint8_t i = 0; i < QSPI_IP_ERASE_TYPES; i++) {
-		etp_tmp = (Qspi_Ip_EraseVarConfigType *)&(memory_cfg->eraseSettings.eraseTypes[i]);
-		if ((etp_tmp->eraseLut != QSPI_IP_LUT_INVALID)
-			&& QSPI_IS_ALIGNED(offset, etp_tmp->size)
-			&& (BIT(etp_tmp->size) <= size)
-			&& ((etp == NULL) || (etp_tmp->size > etp->size))) {
-
-			etp = etp_tmp;
-		}
-	}
-	if (etp != NULL) {
-		*erase_size = BIT(etp->size);
-		status = Qspi_Ip_EraseBlock(data->instance, (uint32_t)offset, *erase_size);
-		if (status != STATUS_QSPI_IP_SUCCESS) {
-			LOG_ERR("Failed to erase %zu bytes at 0x%lx (%d)",
-				*erase_size, (long)offset, status);
-			ret = -EIO;
-		}
-	} else {
-		LOG_ERR("Can't find erase size to erase %zu bytes", size);
-		ret = -EINVAL;
-	}
-
-	return ret;
-}
-
-static int nxp_s32_qspi_erase(const struct device *dev, off_t offset, size_t size)
-{
-	struct nxp_s32_qspi_data *data = dev->data;
-	Qspi_Ip_MemoryConfigType *memory_cfg = get_memory_config(dev);
-	Qspi_Ip_StatusType status;
-	size_t erase_size;
-	int ret = 0;
-
-	if (!area_is_subregion(dev, offset, size)) {
-		return -ENODEV;
-	}
-
-	nxp_s32_qspi_lock(dev);
-
-	if (size == memory_cfg->memSize) {
-		status = Qspi_Ip_EraseChip(data->instance);
-		if (status != STATUS_QSPI_IP_SUCCESS) {
-			LOG_ERR("Failed to erase chip (%d)", status);
-			ret = -EIO;
-		}
-	} else {
-		while (size > 0) {
-			erase_size = 0;
-
-			ret = nxp_s32_qspi_erase_block(dev, offset, size, &erase_size);
-			if (ret != 0) {
-				break;
-			}
-
-			ret = nxp_s32_qspi_wait_until_ready(dev);
-			if (ret != 0) {
-				break;
-			}
-
-			if (IS_ENABLED(CONFIG_FLASH_NXP_S32_QSPI_VERIFY_ERASE)) {
-				status = Qspi_Ip_EraseVerify(data->instance, (uint32_t)offset,
-							erase_size);
-				if (status != STATUS_QSPI_IP_SUCCESS) {
-					LOG_ERR("Erase verification failed at 0x%lx (%d)",
-						offset, status);
-					ret = -EIO;
-					break;
-				}
-			}
-
-			offset += erase_size;
-			size -= erase_size;
-		}
-	}
-
-	nxp_s32_qspi_unlock(dev);
-
-	return ret;
-}
-
-#if defined(CONFIG_FLASH_JESD216_API) || !defined(CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME)
-static int nxp_s32_qspi_read_id(const struct device *dev, uint8_t *id)
-{
-	struct nxp_s32_qspi_data *data = dev->data;
-	Qspi_Ip_StatusType status;
-	int ret = 0;
-
-	nxp_s32_qspi_lock(dev);
-
-	status = Qspi_Ip_ReadId(data->instance, id);
-	if (status != STATUS_QSPI_IP_SUCCESS) {
-		LOG_ERR("Failed to read device ID (%d)", status);
-		ret = -EIO;
-	}
-
-	nxp_s32_qspi_unlock(dev);
-
-	return ret;
-}
-#endif /* CONFIG_FLASH_JESD216_API || !CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME */
+#endif /* !defined(CONFIG_FLASH_NXP_S32_QSPI_SFDP_RUNTIME) */
 
 #if defined(CONFIG_FLASH_JESD216_API)
 static int nxp_s32_qspi_sfdp_read(const struct device *dev, off_t offset, void *buf, size_t len)
@@ -792,7 +483,7 @@ static int nxp_s32_qspi_sfdp_read(const struct device *dev, off_t offset, void *
 }
 #endif /* CONFIG_FLASH_JESD216_API */
 
-#if defined(CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME)
+#if defined(CONFIG_FLASH_NXP_S32_QSPI_SFDP_RUNTIME)
 static int nxp_s32_qspi_sfdp_config(const struct device *dev)
 {
 	struct nxp_s32_qspi_data *data = dev->data;
@@ -852,36 +543,16 @@ static int nxp_s32_qspi_sfdp_config(const struct device *dev)
 }
 #endif
 
-static const struct flash_parameters *nxp_s32_qspi_get_parameters(const struct device *dev)
-{
-	const struct nxp_s32_qspi_config *config = dev->config;
-
-	return &config->flash_parameters;
-}
-
-#if defined(CONFIG_FLASH_PAGE_LAYOUT)
-static void nxp_s32_qspi_pages_layout(const struct device *dev,
-				const struct flash_pages_layout **layout,
-				size_t *layout_size)
-{
-	const struct nxp_s32_qspi_config *config = dev->config;
-
-	*layout = &config->layout;
-	*layout_size = 1;
-}
-#endif /* CONFIG_FLASH_PAGE_LAYOUT */
-
 static int nxp_s32_qspi_init(const struct device *dev)
 {
 	struct nxp_s32_qspi_data *data = dev->data;
 	const struct nxp_s32_qspi_config *config = dev->config;
 	Qspi_Ip_MemoryConfigType *memory_cfg = get_memory_config(dev);
 	Qspi_Ip_StatusType status;
-	static uint8_t instance_cnt;
 	int ret = 0;
 
 	/* Used by the HAL to retrieve the internal driver state */
-	data->instance = instance_cnt++;
+	data->instance = nxp_s32_qspi_register_device();
 	__ASSERT_NO_MSG(data->instance < QSPI_IP_MEM_INSTANCE_COUNT);
 	data->memory_conn_cfg.qspiInstance = memc_nxp_s32_qspi_get_instance(config->controller);
 
@@ -889,7 +560,7 @@ static int nxp_s32_qspi_init(const struct device *dev)
 	k_sem_init(&data->sem, 1, 1);
 #endif
 
-#if defined(CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME)
+#if defined(CONFIG_FLASH_NXP_S32_QSPI_SFDP_RUNTIME)
 	nxp_s32_qspi_sfdp_config(dev);
 #endif
 
@@ -903,7 +574,7 @@ static int nxp_s32_qspi_init(const struct device *dev)
 	}
 
 
-#if !defined(CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME)
+#if !defined(CONFIG_FLASH_NXP_S32_QSPI_SFDP_RUNTIME)
 	uint8_t jedec_id[JESD216_READ_ID_LEN];
 
 	/* Verify connectivity by reading the device ID */
@@ -930,7 +601,7 @@ static int nxp_s32_qspi_init(const struct device *dev)
 	if (ret < 0) {
 		return ret;
 	}
-#endif /* !CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME */
+#endif /* !CONFIG_FLASH_NXP_S32_QSPI_SFDP_RUNTIME */
 
 	return ret;
 }
@@ -966,7 +637,7 @@ static DEVICE_API(flash, nxp_s32_qspi_api) = {
 #define QSPI_MEMORY_CONN_CFG(n)							\
 	{									\
 		.connectionType = (Qspi_Ip_ConnectionType)DT_INST_REG_ADDR(n),	\
-		.memAlignment = DT_INST_PROP_OR(n, memory_alignment, 1)		\
+		.memAlignment = DT_INST_PROP(n, write_block_size)		\
 	}
 
 #define QSPI_ERASE_CFG(n)							\
@@ -1037,7 +708,7 @@ static DEVICE_API(flash, nxp_s32_qspi_api) = {
 		.memType = QSPI_IP_SERIAL_FLASH,				\
 		.hfConfig = NULL,						\
 		.memSize = DT_INST_PROP(n, size) / 8,				\
-		.pageSize = CONFIG_FLASH_NXP_S32_QSPI_LAYOUT_PAGE_SIZE,		\
+		.pageSize = DT_INST_PROP(n, max_program_buffer_size),		\
 		.writeLut = QSPI_LUT_IDX(QSPI_WRITE_SEQ(n)),			\
 		.readLut = QSPI_LUT_IDX(QSPI_READ_SEQ(n)),			\
 		.read0xxLut = QSPI_IP_LUT_INVALID,				\
@@ -1048,7 +719,7 @@ static DEVICE_API(flash, nxp_s32_qspi_api) = {
 		.initResetSettings = QSPI_RESET_CFG(n),				\
 		.initConfiguration = QSPI_INIT_CFG(n),				\
 		.lutSequences = QSPI_LUT_CFG(n),				\
-		COND_CODE_1(CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME, (), (	\
+		COND_CODE_1(CONFIG_FLASH_NXP_S32_QSPI_SFDP_RUNTIME, (), (	\
 			.readIdSettings = QSPI_READ_ID_CFG(n),)			\
 		)								\
 		.suspendSettings = {						\
@@ -1065,7 +736,7 @@ static DEVICE_API(flash, nxp_s32_qspi_api) = {
 	}
 
 #define FLASH_NXP_S32_QSPI_INIT_DEVICE(n)					\
-	COND_CODE_1(CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME, (), (		\
+	COND_CODE_1(CONFIG_FLASH_NXP_S32_QSPI_SFDP_RUNTIME, (), (		\
 		BUILD_ASSERT(DT_INST_NODE_HAS_PROP(n, jedec_id),		\
 			"jedec-id is required for non-runtime SFDP");		\
 		BUILD_ASSERT(DT_INST_PROP_LEN(n, jedec_id) == JESD216_READ_ID_LEN,\
@@ -1075,12 +746,12 @@ static DEVICE_API(flash, nxp_s32_qspi_api) = {
 	static const struct nxp_s32_qspi_config nxp_s32_qspi_config_##n = {	\
 		.controller = DEVICE_DT_GET(DT_INST_BUS(n)),			\
 		.flash_parameters = {						\
-			.write_block_size = QSPI_WRITE_BLOCK_SIZE,		\
+			.write_block_size = DT_INST_PROP(n, write_block_size),	\
 			.erase_value = QSPI_ERASE_VALUE,			\
 		},								\
 		IF_ENABLED(CONFIG_FLASH_PAGE_LAYOUT,				\
 			(QSPI_PAGE_LAYOUT(n),))					\
-		COND_CODE_1(CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME, (), (	\
+		COND_CODE_1(CONFIG_FLASH_NXP_S32_QSPI_SFDP_RUNTIME, (), (	\
 			.memory_cfg = QSPI_MEMORY_CFG(n),			\
 			.qer_type = QSPI_QER_TYPE(n),				\
 			.quad_mode = QSPI_HAS_QUAD_MODE(n)			\
@@ -1089,7 +760,7 @@ static DEVICE_API(flash, nxp_s32_qspi_api) = {
 										\
 	static struct nxp_s32_qspi_data nxp_s32_qspi_data_##n = {		\
 		.memory_conn_cfg = QSPI_MEMORY_CONN_CFG(n),			\
-		COND_CODE_1(CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME, (), (	\
+		COND_CODE_1(CONFIG_FLASH_NXP_S32_QSPI_SFDP_RUNTIME, (), (	\
 			.read_sfdp_lut_idx = QSPI_LUT_IDX(QSPI_SEQ_READ_SFDP),	\
 		))								\
 	};									\

--- a/drivers/memc/memc_nxp_s32_qspi.c
+++ b/drivers/memc/memc_nxp_s32_qspi.c
@@ -11,6 +11,7 @@ LOG_MODULE_REGISTER(nxp_s32_qspi_memc, CONFIG_MEMC_LOG_LEVEL);
 
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/dt-bindings/qspi/nxp-s32-qspi.h>
 
 #include <soc.h>
 #include "memc_nxp_s32_qspi.h"
@@ -154,6 +155,81 @@ uint8_t memc_nxp_s32_qspi_get_instance(const struct device *dev)
 	QSPI_PORT_SIZE(n, side_upper)							\
 	.readMode##side_upper = QSPI_READ_MODE(n, side, side_upper),
 
+#if FEATURE_QSPI_HAS_SFP
+
+#if QSPI_IP_SFP_ENABLE_MDAD
+#define SFP_MDAD_NODE(n) DT_INST_CHILD(n, sfp_mdad)
+
+#define QSPI_SECURE_ATTRIBUTE(node_id)								\
+	(DT_PROP(node_id, secure_attribute) == NXP_S32_QSPI_NON_SECURE ? QSPI_IP_SFP_UNSECURE :	\
+	(DT_PROP(node_id, secure_attribute) == NXP_S32_QSPI_SECURE ? QSPI_IP_SFP_SECURE :	\
+	(DT_PROP(node_id, secure_attribute) == (NXP_S32_QSPI_NON_SECURE | NXP_S32_QSPI_SECURE) ?\
+									QSPI_IP_SFP_BOTH :	\
+	QSPI_IP_SFP_RESERVED)))
+
+#define _QSPI_SFP_MDAD_CFG(node_id, n)							\
+	{										\
+		.SecureAttribute = QSPI_SECURE_ATTRIBUTE(node_id),			\
+		.MaskType = DT_ENUM_IDX(node_id, mask_type),				\
+		.Valid = true,								\
+		.Mask = DT_PROP(node_id, mask),						\
+		.DomainId = DT_PROP(node_id, domain_id),				\
+	},
+
+#define QSPI_SFP_MDAD_CFG(n)								\
+	.Tg = {										\
+		DT_FOREACH_CHILD_STATUS_OKAY_VARGS(SFP_MDAD_NODE(n), _QSPI_SFP_MDAD_CFG, n)\
+	},
+#endif /* QSPI_IP_SFP_ENABLE_MDAD */
+
+#if QSPI_IP_SFP_ENABLE_FRAD
+#define SFP_FRAD_NODE(n) DT_INST_CHILD(n, sfp_frad)
+
+#define QSPI_ACP_POLICY(node_id)							\
+	(DT_PROP(node_id, master_domain_acp_policy) == NXP_S32_QSPI_SECURE ?		\
+								QSPI_IP_SFP_ACP_SECURE :\
+	(DT_PROP(node_id, master_domain_acp_policy) == (NXP_S32_QSPI_NON_SECURE |	\
+				NXP_S32_QSPI_PRIVILEGE) ? QSPI_IP_SFP_ACP_PRIVILEGED :	\
+	(DT_PROP(node_id, master_domain_acp_policy) == (NXP_S32_QSPI_SECURE |		\
+				NXP_S32_QSPI_PRIVILEGE) ? QSPI_IP_SFP_ACP_SECURE_PRIVILEGED :\
+	(DT_PROP(node_id, master_domain_acp_policy) == (NXP_S32_QSPI_NON_SECURE |	\
+		NXP_S32_QSPI_SECURE | NXP_S32_QSPI_PRIVILEGE) ? QSPI_IP_SFP_ACP_ALL :	\
+	QSPI_IP_SFP_ACP_NONE))))
+
+#define QSPI_EXCLUSIVE_ACCESS_LOCK(node_id)						\
+	(DT_ENUM_IDX(node_id, exclusive_access_lock) == 0 ? QSPI_IP_SFP_EAL_DISABLED :	\
+	(DT_ENUM_IDX(node_id, exclusive_access_lock) == 1 ? QSPI_IP_SFP_EAL_OWNER :	\
+	QSPI_IP_SFP_EAL_NONE))
+
+#define _QSPI_SFP_FRAD_CFG(node_id, n)							\
+	{										\
+		.StartAddress = DT_REG_ADDR(node_id),					\
+		.EndAddress = DT_REG_ADDR(node_id) + DT_REG_SIZE(node_id) - 1,		\
+		.Valid = true,								\
+		.Md0Acp = QSPI_ACP_POLICY(node_id),					\
+		.Md1Acp = QSPI_ACP_POLICY(node_id),					\
+		.ExclusiveAccessLock = QSPI_EXCLUSIVE_ACCESS_LOCK(node_id),		\
+		.ExclusiveAccessOwner = DT_PROP(node_id, exclusive_access_owner),	\
+	},
+
+#define QSPI_SFP_FRAD_CFG(n)								\
+	.Frad = {									\
+		DT_FOREACH_CHILD_STATUS_OKAY_VARGS(SFP_FRAD_NODE(n), _QSPI_SFP_FRAD_CFG, n)\
+	},
+#endif /* QSPI_IP_SFP_ENABLE_FRAD */
+
+#define QSPI_SFP_MASTER_TIMEOUT_CYCLES 0xffff
+
+#define QSPI_SFP_CFG(n)									\
+	IF_ENABLED(QSPI_IP_SFP_ENABLE_GLOBAL,						\
+		(.SfpCfg = {								\
+			.MasterTimeout = QSPI_SFP_MASTER_TIMEOUT_CYCLES,		\
+			IF_ENABLED(QSPI_IP_SFP_ENABLE_MDAD, (QSPI_SFP_MDAD_CFG(n)))	\
+			IF_ENABLED(QSPI_IP_SFP_ENABLE_FRAD, (QSPI_SFP_FRAD_CFG(n)))	\
+		},))
+
+#endif /* FEATURE_QSPI_HAS_SFP */
+
 #define MEMC_NXP_S32_QSPI_CONTROLLER_CONFIG(n)						\
 	BUILD_ASSERT(DT_INST_PROP_LEN(n, ahb_buffers_masters) == QSPI_IP_AHB_BUFFERS,	\
 		"ahb-buffers-masters must be of size QSPI_IP_AHB_BUFFERS");		\
@@ -174,6 +250,7 @@ uint8_t memc_nxp_s32_qspi_get_instance(const struct device *dev)
 		QSPI_DATA_CFG(n)							\
 		QSPI_ADDR_CFG(n)							\
 		QSPI_BYTES_SWAP_ADDR(n)							\
+		IF_ENABLED(FEATURE_QSPI_HAS_SFP, (QSPI_SFP_CFG(n)))			\
 	}
 
 #define MEMC_NXP_S32_QSPI_INIT_DEVICE(n)						\

--- a/drivers/memc/memc_nxp_s32_qspi.c
+++ b/drivers/memc/memc_nxp_s32_qspi.c
@@ -138,7 +138,7 @@ uint8_t memc_nxp_s32_qspi_get_instance(const struct device *dev)
 	))
 
 #define QSPI_PORT_SIZE_FN(node_id, side_upper, port)					\
-	COND_CODE_1(IS_EQ(DT_REG_ADDR(node_id), QSPI_PCSF##side_upper##port),		\
+	COND_CODE_1(IS_EQ(DT_REG_ADDR_RAW(node_id), QSPI_PCSF##side_upper##port),	\
 		(COND_CODE_1(DT_NODE_HAS_STATUS_OKAY(node_id),				\
 			(.memSize##side_upper##port = DT_PROP(node_id, size) / 8,),	\
 			(.memSize##side_upper##port = 0,))),				\

--- a/dts/arm/nxp/nxp_s32z27x_r52.dtsi
+++ b/dts/arm/nxp/nxp_s32z27x_r52.dtsi
@@ -1431,5 +1431,21 @@
 				status = "disabled";
 			};
 		};
+
+		qspi0: qspi@42320000 {
+			compatible = "nxp,s32-qspi";
+			reg = <0x42320000 0x4000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
+
+		qspi1: qspi@42340000 {
+			compatible = "nxp,s32-qspi";
+			reg = <0x42340000 0x4000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/bindings/mtd/nxp,s32-qspi-device.yaml
+++ b/dts/bindings/mtd/nxp,s32-qspi-device.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 NXP
+# Copyright 2023-2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
@@ -14,9 +14,15 @@ properties:
   reg:
     required: true
 
-  memory-alignment:
+  max-program-buffer-size:
     type: int
+    required: true
     description: |
-      Memory alignment in bytes, used to calculate padding when performing
-      unaligned accesses.
-      If not provided, 1 byte alignment will be selected.
+      The maximum of programming page buffer size of the flash memory device,
+      as specified in the flash memory device datasheet.
+
+  write-block-size:
+    type: int
+    required: true
+    description: |
+      The number of bytes used in write operations.

--- a/dts/bindings/mtd/nxp,s32-qspi-hyperflash.yaml
+++ b/dts/bindings/mtd/nxp,s32-qspi-hyperflash.yaml
@@ -1,0 +1,99 @@
+# Copyright 2024 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  QSPI hyperflash connected to the NXP S32 QSPI bus.
+
+compatible: "nxp,s32-qspi-hyperflash"
+
+include: "nxp,s32-qspi-device.yaml"
+
+properties:
+  device-id-word-addr:
+    required: true
+    type: int
+    description: |
+      The word address of the device ID in ASO (Application-Specific Object).
+      This address specifies the exact location within the memory where the device ID is stored.
+
+  rwds-low-dual-error:
+    type: boolean
+    description: |
+      Enable Read-Write Data Strobe (RWDS) dual error detect.
+
+  secure-region-locked:
+    type: boolean
+    description: |
+      The secure region is locked and cannot be accessed or modified.
+      This is particularly useful in scenarios where sensitive data needs protection from
+      unauthorized access, such as in financial applications or secure communication systems.
+      If it is disable, having access to all memory regions is beneficial during development
+      or debugging phases.
+
+  vcc-mv:
+    type: int
+    required: true
+    enum:
+      - 1800
+      - 3000
+    description: |
+      The memory operating voltage supply in mV.
+
+  drive-strength-ohm:
+    type: int
+    required: true
+    enum:
+      - 12
+      - 14
+      - 16
+      - 20
+      - 24
+      - 27
+      - 34
+      - 40
+      - 45
+      - 68
+      - 71
+      - 117
+    description: |
+      Specifies the output drive strength in ohm, which based on the operating device VCC.
+      The supported typical impedance settings:
+        For 1.8V: 117 Ohm, 68 Ohm, 45 Ohm, 34 Ohm, 27 Ohm, 24 Ohm, 20 Ohm
+        For 3V: 71 Ohm, 40 Ohm, 27 Ohm, 20 Ohm, 16 Ohm, 14 Ohm, 12 Ohm
+      See the xVCR[14:12] field in VCR configuration register in the memory device datasheet.
+
+  read-latency-cycles:
+    type: int
+    required: true
+    enum:
+      - 5
+      - 6
+      - 7
+      - 8
+      - 9
+      - 10
+      - 11
+      - 12
+      - 13
+      - 14
+      - 15
+      - 16
+    description: |
+      Specifies the read latency in cycles, which is determined based on the operating frequency
+      as specified in the memory device datasheet.
+
+  support-only-uniform-sectors:
+    type: boolean
+    description: |
+      The memory device supports only uniform (256KB) sectors.
+
+  ppw-sectors-addr-mapping:
+    type: string
+    required: true
+    enum:
+      - LOW
+      - HIGH
+    description: |
+      The mapping of the parameter and read password sectors:
+        - LOW: Parameter and read password sectors mapped into lowest addresses
+        - HIGH: Parameter and read password sectors mapped into highest addresses

--- a/dts/bindings/qspi/nxp,s32-qspi-sfp-frad.yaml
+++ b/dts/bindings/qspi/nxp,s32-qspi-sfp-frad.yaml
@@ -1,0 +1,53 @@
+# Copyright 2024 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: NXP S32 Quad Serial Peripheral Interface (QSPI) Secure Flash Protection SFP FRAD.
+
+  The SFP FRAD performs second-level checks on input flash write and erase transactions,
+  based on the address range of each transaction.
+
+compatible: "nxp,s32-qspi-sfp-frad"
+
+child-binding:
+
+  properties:
+    reg:
+      type: array
+      required: true
+
+    master-domain-acp-policy:
+      type: int
+      required: true
+      description: |
+        Selects the master domain access control policy, defined in dt-bindings/qspi/nxp-s32-qspi.h:
+        - NXP_S32_QSPI_NON_SECURE: Selects the non-secure access control policy.
+        - NXP_S32_QSPI_SECURE: Selects the secure access control policy.
+        - NXP_S32_QSPI_PRIVILEGE: Selects the privilege access control policy.
+        Allowed combinations:
+        - NXP_S32_QSPI_SECURE
+        - NXP_S32_QSPI_SECURE | NXP_S32_QSPI_PRIVILEGE
+        - NXP_S32_QSPI_NON_SECURE | NXP_S32_QSPI_PRIVILEGE
+        - NXP_S32_QSPI_NON_SECURE | NXP_S32_QSPI_SECURE | NXP_S32_QSPI_PRIVILEGE
+
+    exclusive-access-lock:
+      type: string
+      enum:
+        - DISABLED
+        - OWNER
+        - NONE
+      default: DISABLED
+      description: |
+        Selects the exclusive access lock:
+        - DISABLED: The exclusive access lock disabled, granting write permissions for all masters
+        - ENABLED: The exclusive access lock enabled, granting write permissions only to the
+          exclusive access owner master and disabling write permissions for other masters.
+        - NONE: This configuration should not be used
+        The default corresponds to the reset value of the register field.
+
+    exclusive-access-owner:
+      type: int
+      default: 0
+      description: |
+        The domain master ID that owns the exclusive access lock.
+        Valid range: 0 - 63. The default corresponds to the reset
+        value of the register field.

--- a/dts/bindings/qspi/nxp,s32-qspi-sfp-mdad.yaml
+++ b/dts/bindings/qspi/nxp,s32-qspi-sfp-mdad.yaml
@@ -1,0 +1,51 @@
+# Copyright 2024 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: NXP S32 Quad Serial Peripheral Interface (QSPI) Secure Flash Protection SFP MDAD.
+
+  The SFP MDAD performs first-level checks on input transactions, based on the secure attribute
+  and MGID associated with each transaction.
+
+compatible: "nxp,s32-qspi-sfp-mdad"
+
+child-binding:
+
+  properties:
+    secure-attribute:
+      type: int
+      required: true
+      description: |
+        Selects the secure attribute, defined in dt-bindings/qspi/nxp-s32-qspi.h:
+        - NXP_S32_QSPI_NON_SECURE: Allow the bus attribute for this master to non-secure
+        - NXP_S32_QSPI_SECURE: Allow the bus attribute for this master to secure
+        Allowed combinations:
+        - NXP_S32_QSPI_NON_SECURE
+        - NXP_S32_QSPI_SECURE
+        - NXP_S32_QSPI_NON_SECURE | NXP_S32_QSPI_SECURE
+
+    mask-type:
+      type: string
+      enum:
+        - AND
+        - OR
+      default: AND
+      description: |
+        Selects the mask type:
+        - AND: AND-ed mask
+        - OR: OR-ed mask
+        The default corresponds to the reset value of the register field.
+
+    mask:
+      type: int
+      default: 0
+      description: |
+        Defines the mask value for the ID-Match comparison.
+        Valid range: 0 - 63. The default corresponds to the
+        reset value of the register field.
+
+    domain-id:
+      type: int
+      required: true
+      description: |
+        Domain ID Reference value of the Domain-ID (MID) for MID-comparison.
+        Valid range: 0 - 63.

--- a/include/zephyr/dt-bindings/qspi/nxp-s32-qspi.h
+++ b/include/zephyr/dt-bindings/qspi/nxp-s32-qspi.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_NXP_S32_QSPI_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_NXP_S32_QSPI_H_
+
+#include <zephyr/dt-bindings/dt-util.h>
+
+/* The QSPI secure attribute and secure policy references */
+#define NXP_S32_QSPI_NON_SECURE	BIT(0)
+#define NXP_S32_QSPI_SECURE	BIT(1)
+#define NXP_S32_QSPI_PRIVILEGE	BIT(2)
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_NXP_S32_QSPI_H_ */

--- a/samples/subsys/fs/littlefs/sample.yaml
+++ b/samples/subsys/fs/littlefs/sample.yaml
@@ -26,6 +26,10 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - frdm_ke17z
       - frdm_ke17z512
+      - s32z2xxdc2/s32z270/rtu0
+      - s32z2xxdc2/s32z270/rtu1
+      - s32z2xxdc2@D/s32z270/rtu0
+      - s32z2xxdc2@D/s32z270/rtu1
     integration_platforms:
       - nrf52840dk/nrf52840
   sample.filesystem.littlefs.blk:

--- a/samples/subsys/settings/boards/s32z2xxdc2_s32z270_rtu0.conf
+++ b/samples/subsys/settings/boards/s32z2xxdc2_s32z270_rtu0.conf
@@ -1,0 +1,5 @@
+# Copyright 2024 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_NVS=y
+CONFIG_SETTINGS_NVS=y

--- a/samples/subsys/settings/boards/s32z2xxdc2_s32z270_rtu1.conf
+++ b/samples/subsys/settings/boards/s32z2xxdc2_s32z270_rtu1.conf
@@ -1,0 +1,5 @@
+# Copyright 2024 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_NVS=y
+CONFIG_SETTINGS_NVS=y

--- a/samples/subsys/settings/sample.yaml
+++ b/samples/subsys/settings/sample.yaml
@@ -14,6 +14,10 @@ tests:
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
+      - s32z2xxdc2/s32z270/rtu0
+      - s32z2xxdc2/s32z270/rtu1
+      - s32z2xxdc2@D/s32z270/rtu0
+      - s32z2xxdc2@D/s32z270/rtu1
     integration_platforms:
       - native_sim
     harness: console

--- a/samples/subsys/shell/fs/sample.yaml
+++ b/samples/subsys/shell/fs/sample.yaml
@@ -13,6 +13,10 @@ tests:
       - mimxrt1060_evk/mimxrt1062/qspi
       - mr_canhubk3
       - native_sim
+      - s32z2xxdc2/s32z270/rtu0
+      - s32z2xxdc2/s32z270/rtu1
+      - s32z2xxdc2@D/s32z270/rtu0
+      - s32z2xxdc2@D/s32z270/rtu1
     integration_platforms:
       - reel_board
   sample.filesystem.shell.fuse:

--- a/tests/drivers/flash/common/testcase.yaml
+++ b/tests/drivers/flash/common/testcase.yaml
@@ -65,7 +65,7 @@ tests:
   drivers.flash.common.mr_canhubk3_sfdp_runtime:
     platform_allow: mr_canhubk3
     extra_configs:
-      - CONFIG_FLASH_NXP_S32_QSPI_NOR_SFDP_RUNTIME=y
+      - CONFIG_FLASH_NXP_S32_QSPI_SFDP_RUNTIME=y
   drivers.flash.common.spi_nor:
     platform_allow: nrf52840dk/nrf52840
     extra_configs:

--- a/tests/subsys/fs/littlefs/boards/s32z2xxdc2_s32z270_rtu0.overlay
+++ b/tests/subsys/fs/littlefs/boards/s32z2xxdc2_s32z270_rtu0.overlay
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &storage_partition;
+
+&s26hs512t {
+	partitions {
+		small_partition: partition@0 {
+			label = "small";
+			reg = <0x00000000 0x00010000>;
+		};
+		medium_partition: partition@10000 {
+			label = "medium";
+			reg = <0x00010000 0x000F0000>;
+		};
+		large_partition: partition@100000 {
+			label = "large";
+			reg = <0x00100000 0x00300000>;
+		};
+	};
+};

--- a/tests/subsys/fs/littlefs/boards/s32z2xxdc2_s32z270_rtu1.overlay
+++ b/tests/subsys/fs/littlefs/boards/s32z2xxdc2_s32z270_rtu1.overlay
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &storage_partition;
+
+&s26hs512t {
+	partitions {
+		small_partition: partition@0 {
+			label = "small";
+			reg = <0x00000000 0x00010000>;
+		};
+		medium_partition: partition@10000 {
+			label = "medium";
+			reg = <0x00010000 0x000F0000>;
+		};
+		large_partition: partition@100000 {
+			label = "large";
+			reg = <0x00100000 0x00300000>;
+		};
+	};
+};

--- a/tests/subsys/fs/littlefs/testcase.yaml
+++ b/tests/subsys/fs/littlefs/testcase.yaml
@@ -15,7 +15,12 @@ common:
 tests:
   filesystem.littlefs.default:
     timeout: 60
-    platform_allow: nrf54l15dk/nrf54l15/cpuapp
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - s32z2xxdc2/s32z270/rtu0
+      - s32z2xxdc2/s32z270/rtu1
+      - s32z2xxdc2@D/s32z270/rtu0
+      - s32z2xxdc2@D/s32z270/rtu1
   filesystem.littlefs.custom:
     timeout: 180
     extra_configs:

--- a/tests/subsys/logging/log_backend_fs/boards/s32z2xxdc2_s32z270_rtu0.overlay
+++ b/tests/subsys/logging/log_backend_fs/boards/s32z2xxdc2_s32z270_rtu0.overlay
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &storage_partition;
+
+/ {
+	fstab {
+		compatible = "zephyr,fstab";
+		lfs1: lfs1 {
+			compatible = "zephyr,fstab,littlefs";
+			mount-point = "/lfs1";
+			partition = <&lfs1_part>;
+			read-size = <16>;
+			prog-size = <16>;
+			cache-size = <64>;
+			lookahead-size = <32>;
+			block-cycles = <512>;
+		};
+	};
+};
+
+&s26hs512t {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		lfs1_part: partition@0 {
+			label = "storage";
+			reg = <0x00000000 0x00010000>;
+		};
+	};
+};

--- a/tests/subsys/logging/log_backend_fs/boards/s32z2xxdc2_s32z270_rtu1.overlay
+++ b/tests/subsys/logging/log_backend_fs/boards/s32z2xxdc2_s32z270_rtu1.overlay
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &storage_partition;
+
+/ {
+	fstab {
+		compatible = "zephyr,fstab";
+		lfs1: lfs1 {
+			compatible = "zephyr,fstab,littlefs";
+			mount-point = "/lfs1";
+			partition = <&lfs1_part>;
+			read-size = <16>;
+			prog-size = <16>;
+			cache-size = <64>;
+			lookahead-size = <32>;
+			block-cycles = <512>;
+		};
+	};
+};
+
+&s26hs512t {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		lfs1_part: partition@0 {
+			label = "storage";
+			reg = <0x00000000 0x00010000>;
+		};
+	};
+};

--- a/tests/subsys/logging/log_backend_fs/testcase.yaml
+++ b/tests/subsys/logging/log_backend_fs/testcase.yaml
@@ -12,6 +12,10 @@ common:
     - native_sim/native/64
     - nrf52840dk/nrf52840
     - mr_canhubk3
+    - s32z2xxdc2/s32z270/rtu0
+    - s32z2xxdc2/s32z270/rtu1
+    - s32z2xxdc2@D/s32z270/rtu0
+    - s32z2xxdc2@D/s32z270/rtu1
   integration_platforms:
     - native_sim
 tests:

--- a/tests/subsys/settings/fcb/testcase.yaml
+++ b/tests/subsys/settings/fcb/testcase.yaml
@@ -6,6 +6,10 @@ tests:
       - native_sim
       - native_sim/native/64
       - mr_canhubk3
+      - s32z2xxdc2/s32z270/rtu0
+      - s32z2xxdc2/s32z270/rtu1
+      - s32z2xxdc2@D/s32z270/rtu0
+      - s32z2xxdc2@D/s32z270/rtu1
     integration_platforms:
       - nrf52840dk/nrf52840
       - native_sim

--- a/tests/subsys/settings/file/boards/s32z2xxdc2_s32z270_rtu0.overlay
+++ b/tests/subsys/settings/file/boards/s32z2xxdc2_s32z270_rtu0.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &storage_partition;
+
+&s26hs512t {
+	partitions {
+		settings_file_partition: partition@0 {
+			label = "settings_file_partition";
+			reg = <0x00000000 0x00010000>;
+		};
+	};
+};

--- a/tests/subsys/settings/file/boards/s32z2xxdc2_s32z270_rtu1.overlay
+++ b/tests/subsys/settings/file/boards/s32z2xxdc2_s32z270_rtu1.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &storage_partition;
+
+&s26hs512t {
+	partitions {
+		settings_file_partition: partition@0 {
+			label = "settings_file_partition";
+			reg = <0x00000000 0x00010000>;
+		};
+	};
+};

--- a/tests/subsys/settings/file/testcase.yaml
+++ b/tests/subsys/settings/file/testcase.yaml
@@ -8,6 +8,10 @@ tests:
       - native_sim
       - native_sim/native/64
       - mr_canhubk3
+      - s32z2xxdc2/s32z270/rtu0
+      - s32z2xxdc2/s32z270/rtu1
+      - s32z2xxdc2@D/s32z270/rtu0
+      - s32z2xxdc2@D/s32z270/rtu1
     integration_platforms:
       - nrf52840dk/nrf52840
     tags:

--- a/tests/subsys/settings/functional/fcb/testcase.yaml
+++ b/tests/subsys/settings/functional/fcb/testcase.yaml
@@ -6,6 +6,10 @@ tests:
       - native_sim
       - native_sim/native/64
       - mr_canhubk3
+      - s32z2xxdc2/s32z270/rtu0
+      - s32z2xxdc2/s32z270/rtu1
+      - s32z2xxdc2@D/s32z270/rtu0
+      - s32z2xxdc2@D/s32z270/rtu1
     integration_platforms:
       - nrf52840dk/nrf52840
     tags:
@@ -17,6 +21,10 @@ tests:
       - native_sim
       - native_sim/native/64
       - mr_canhubk3
+      - s32z2xxdc2/s32z270/rtu0
+      - s32z2xxdc2/s32z270/rtu1
+      - s32z2xxdc2@D/s32z270/rtu0
+      - s32z2xxdc2@D/s32z270/rtu1
     integration_platforms:
       - native_sim
     tags:

--- a/tests/subsys/settings/functional/file/testcase.yaml
+++ b/tests/subsys/settings/functional/file/testcase.yaml
@@ -6,6 +6,10 @@ tests:
       - native_sim
       - native_sim/native/64
       - mr_canhubk3
+      - s32z2xxdc2/s32z270/rtu0
+      - s32z2xxdc2/s32z270/rtu1
+      - s32z2xxdc2@D/s32z270/rtu0
+      - s32z2xxdc2@D/s32z270/rtu1
     integration_platforms:
       - native_sim
     tags:

--- a/tests/subsys/settings/functional/nvs/testcase.yaml
+++ b/tests/subsys/settings/functional/nvs/testcase.yaml
@@ -4,6 +4,10 @@ tests:
       - qemu_x86
       - native_sim
       - native_sim/native/64
+      - s32z2xxdc2/s32z270/rtu0
+      - s32z2xxdc2/s32z270/rtu1
+      - s32z2xxdc2@D/s32z270/rtu0
+      - s32z2xxdc2@D/s32z270/rtu1
     tags:
       - settings
       - nvs
@@ -12,6 +16,10 @@ tests:
     platform_allow:
       - native_sim
       - native_sim/native/64
+      - s32z2xxdc2/s32z270/rtu0
+      - s32z2xxdc2/s32z270/rtu1
+      - s32z2xxdc2@D/s32z270/rtu0
+      - s32z2xxdc2@D/s32z270/rtu1
     tags:
       - settings
       - nvs
@@ -20,6 +28,10 @@ tests:
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
+      - s32z2xxdc2/s32z270/rtu0
+      - s32z2xxdc2/s32z270/rtu1
+      - s32z2xxdc2@D/s32z270/rtu0
+      - s32z2xxdc2@D/s32z270/rtu1
     integration_platforms:
       - nrf52840dk/nrf52840
     tags:

--- a/tests/subsys/storage/flash_map/boards/s32z2xxdc2_s32z270_rtu0.overlay
+++ b/tests/subsys/storage/flash_map/boards/s32z2xxdc2_s32z270_rtu0.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "../app.overlay"
+
+&s26hs512t {
+	partitions {
+		slot1_partition: partition@100000 {
+			reg = <0x100000 0x100000>;
+		};
+	};
+};

--- a/tests/subsys/storage/flash_map/boards/s32z2xxdc2_s32z270_rtu1.overlay
+++ b/tests/subsys/storage/flash_map/boards/s32z2xxdc2_s32z270_rtu1.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "../app.overlay"
+
+&s26hs512t {
+	partitions {
+		slot1_partition: partition@100000 {
+			reg = <0x100000 0x100000>;
+		};
+	};
+};

--- a/tests/subsys/storage/flash_map/testcase.yaml
+++ b/tests/subsys/storage/flash_map/testcase.yaml
@@ -7,6 +7,10 @@ tests:
       - native_sim
       - native_sim/native/64
       - mr_canhubk3
+      - s32z2xxdc2/s32z270/rtu0
+      - s32z2xxdc2/s32z270/rtu1
+      - s32z2xxdc2@D/s32z270/rtu0
+      - s32z2xxdc2@D/s32z270/rtu1
     tags: flash_map
     integration_platforms:
       - native_sim
@@ -30,6 +34,10 @@ tests:
       - native_sim
       - native_sim/native/64
       - mr_canhubk3
+      - s32z2xxdc2/s32z270/rtu0
+      - s32z2xxdc2/s32z270/rtu1
+      - s32z2xxdc2@D/s32z270/rtu0
+      - s32z2xxdc2@D/s32z270/rtu1
     tags: flash_map
     integration_platforms:
       - native_sim
@@ -40,6 +48,10 @@ tests:
       - native_sim
       - native_sim/native/64
       - mr_canhubk3
+      - s32z2xxdc2/s32z270/rtu0
+      - s32z2xxdc2/s32z270/rtu1
+      - s32z2xxdc2@D/s32z270/rtu0
+      - s32z2xxdc2@D/s32z270/rtu1
     tags: flash_map
     integration_platforms:
       - native_sim

--- a/west.yml
+++ b/west.yml
@@ -203,7 +203,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: a7dc61f89063c1008f24ee21575c68d0165de91b
+      revision: 5576d444d203e8973f7e8f5be18263b3d8a7bb1f
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Introduce support HyperFlash  memory devices on a NXP S32 QSPI bus. This driver uses a fixed LUT configuration that defined in HAL RTD HyperFlash driver and  allows to read, write, and erase HyperFlash devices.
Add support QSPI secure flash protection (SFP) for memory control NXP S32 QSPI.
Enable support Flash QSPI on S32Z2XX, the on-board S26HS512T 512M-bit HyperFlash memory is connected to the QSPI controller port A1. This board configuration selects it as the default flash controller.

The test result:

 ```
west twister  --disable-warnings-as-errors --device-testing --device-serial=/dev/ttyUSB0 -v --runtime-artifact-cleanup --west-runner trace32 --west-flash="--config=./config.t32" -p s32z2xxdc2/s32z270/rtu1  -T samples/subsys/fs/littlefs -T samples/subsys/settings -T samples/subsys/shell/fs -T tests/drivers/flash -T tests/subsys/fs -T tests/subsys/settings -T tests/subsys/storage/flash_map -T tests/subsys/logging/log_backend_fs
INFO    - Using Ninja..
INFO    - Zephyr version: 8c53d91026a8
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testsuite list...

Device testing on:

| Platform                | ID   | Serial device   |
|-------------------------|------|-----------------|
| s32z2xxdc2/s32z270/rtu1 |      | /dev/ttyUSB0 |

INFO    - JOBS: 6
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - 58/77 s32z2xxdc2/s32z270/rtu1   tests/subsys/storage/flash_map/storage.flash_map   PASSED (device 80.480s)
INFO    - 59/77 s32z2xxdc2/s32z270/rtu1   tests/subsys/logging/log_backend_fs/logging.backend.fs.automounted PASSED (device 38.796s)
INFO    - 60/77 s32z2xxdc2/s32z270/rtu1   tests/subsys/settings/functional/file/settings.file PASSED (device 28.017s)
INFO    - 61/77 s32z2xxdc2/s32z270/rtu1   tests/subsys/logging/log_backend_fs/logging.backend.fs.manualmounted PASSED (device 40.086s)
INFO    - 62/77 s32z2xxdc2/s32z270/rtu1   tests/subsys/settings/functional/nvs/settings.functional.nvs.chosen PASSED (device 27.685s)
INFO    - 63/77 s32z2xxdc2/s32z270/rtu1   tests/subsys/settings/functional/fcb/settings.functional.fcb.chosen PASSED (device 27.686s)
INFO    - 64/77 s32z2xxdc2/s32z270/rtu1   tests/subsys/settings/functional/fcb/settings.functional.fcb PASSED (device 27.692s)
INFO    - 65/77 s32z2xxdc2/s32z270/rtu1   tests/subsys/settings/functional/nvs/settings.functional.nvs.dk PASSED (device 27.624s)
INFO    - 66/77 s32z2xxdc2/s32z270/rtu1   tests/subsys/settings/functional/nvs/settings.functional.nvs PASSED (device 27.641s)
INFO    - 67/77 s32z2xxdc2/s32z270/rtu1   tests/subsys/fs/fat_fs_api/filesystem.fat.api.sdmmc SKIPPED (runtime filter)
INFO    - 68/77 s32z2xxdc2/s32z270/rtu1   tests/subsys/fs/fat_fs_api/filesystem.fat.api.mmc  SKIPPED (runtime filter)
INFO    - 69/77 s32z2xxdc2/s32z270/rtu1   tests/subsys/storage/flash_map/storage.flash_map.mbedtls PASSED (device 80.335s)
INFO    - 70/77 s32z2xxdc2/s32z270/rtu1   tests/subsys/storage/flash_map/storage.flash_map.psa PASSED (device 80.570s)
INFO    - 72/77 s32z2xxdc2/s32z270/rtu1   tests/subsys/settings/file/settings.file.raw       PASSED (device 30.420s)
INFO    - 73/77 s32z2xxdc2/s32z270/rtu1   samples/subsys/settings/sample.subsys.settings     PASSED (device 27.357s)
INFO    - 74/77 s32z2xxdc2/s32z270/rtu1   tests/subsys/fs/fs_api/filesystem.api              PASSED (device 26.865s)
INFO    - 75/77 s32z2xxdc2/s32z270/rtu1   tests/subsys/settings/fcb/settings.fcb.raw         PASSED (device 47.201s)
INFO    - 76/77 s32z2xxdc2/s32z270/rtu1   tests/drivers/flash/common/drivers.flash.common.default PASSED (device 26.663s)
INFO    - 77/77 s32z2xxdc2/s32z270/rtu1   tests/subsys/fs/littlefs/filesystem.littlefs.default PASSED (device 39.218s)

INFO    - 77 test scenarios (77 test instances) selected, 59 configurations skipped (57 by static filter, 2 at runtime).
INFO    - 18 of 77 test configurations passed (100.00%), 0 failed, 0 errored, 59 skipped with 0 warnings in 808.67 seconds
INFO    - In total 134 test cases were executed, 355 skipped on 1 out of total 4 platforms (25.00%)
INFO    - 18 test configurations executed on platforms, 0 test configurations were only built.
```