### PR TITLE
net: lwm2m: Bootstrap discovery fixes

### DIFF
--- a/samples/net/lwm2m_client/src/lwm2m-client.c
+++ b/samples/net/lwm2m_client/src/lwm2m-client.c
@@ -127,9 +127,6 @@ static int lwm2m_setup(void)
 #if defined(CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP)
 	/* Mark 1st instance of security object as a bootstrap server */
 	lwm2m_set_u8(&LWM2M_OBJ(0, 0, 1), 1);
-
-	/* Create 2nd instance of security object needed for bootstrap */
-	lwm2m_create_object_inst(&LWM2M_OBJ(0, 1));
 #else
 	/* Match Security object instance with a Server object instance with
 	 * Short Server ID.

--- a/subsys/net/lib/lwm2m/lwm2m_rw_link_format.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_link_format.c
@@ -15,7 +15,11 @@ LOG_MODULE_REGISTER(net_lwm2m_link_format, CONFIG_LWM2M_LOG_LEVEL);
 
 #define CORELINK_BUF_SIZE 24
 
-#define ENABLER_VERSION "lwm2m=\"" LWM2M_PROTOCOL_VERSION_STRING "\""
+#if defined(CONFIG_LWM2M_VERSION_1_1)
+#define ENABLER_VERSION "</>;lwm2m=" LWM2M_PROTOCOL_VERSION_STRING
+#else
+#define ENABLER_VERSION "</>;lwm2m=\"" LWM2M_PROTOCOL_VERSION_STRING "\""
+#endif
 
 /*
  * TODO: to implement a way for clients to specify alternate path

--- a/tests/net/lib/lwm2m/content_link_format/src/main.c
+++ b/tests/net/lib/lwm2m/content_link_format/src/main.c
@@ -140,7 +140,7 @@ ZTEST(net_content_link_format, test_put_begin_discovery)
 ZTEST(net_content_link_format, test_put_begin_bs_discovery)
 {
 	int ret;
-	const char *expected_payload = "lwm2m=\"1.0\"";
+	const char *expected_payload = "</>;lwm2m=\"1.0\"";
 
 	test_formatter_data.mode = LINK_FORMAT_MODE_BOOTSTRAP_DISCOVERY;
 


### PR DESCRIPTION
Fix bootstrap discovery response formatting issues, which prevented successful bootstrap with Leshan.
Verified with Leshan, both LwM2M 1.0 and LwM2M 1.1 versions, with and w/o security enabled.

Fixes #77061