### PR TITLE
samples: stm32: use zephyr:code-sample directive

### DIFF
--- a/samples/boards/stm32/backup_sram/README.rst
+++ b/samples/boards/stm32/backup_sram/README.rst
@@ -1,7 +1,7 @@
-.. _stm32_backup_sram:
+.. zephyr:code-sample:: stm32_backup_sram
+   :name: Backup SRAM
 
-STM32 Backup SRAM
-#################
+   Use Backup SRAM to store a variable that persists across power cycles.
 
 Overview
 ********

--- a/samples/boards/stm32/bluetooth/interactive_gui/README.rst
+++ b/samples/boards/stm32/bluetooth/interactive_gui/README.rst
@@ -3,7 +3,7 @@
    :name: Bluetooth: ST Interactive GUI
    :relevant-api: bluenrg_hci_driver bluetooth
 
-Expose ST BlueNRG Bluetooth network coprocessor over UART
+   Expose ST BlueNRG Bluetooth network coprocessor over UART.
 
 Overview
 *********

--- a/samples/boards/stm32/ccm/README.rst
+++ b/samples/boards/stm32/ccm/README.rst
@@ -1,7 +1,7 @@
-.. _samples_boards_stm32_ccm:
+.. zephyr:code-sample:: stm32_ccm
+   :name: Core Coupled Memory (CCM)
 
-STM32 CCM example
-#################
+   Place and use variables in the Core Coupled Memory (CCM).
 
 Overview
 ********

--- a/samples/boards/stm32/h7_dual_core/README.rst
+++ b/samples/boards/stm32/h7_dual_core/README.rst
@@ -1,7 +1,8 @@
-.. _stm32_h7_dual_core:
+.. zephyr:code-sample:: stm32_h7_dual_core
+   :name: Hardware Semaphore (HSEM) Inter-Processor Communication on STM32 H7
+   :relevant-api: ipm_interface
 
-STM32 HSEM IPM driver sample
-############################
+   Use the Hardware Semaphore (HSEM) to trigger LED blinking from one core to another.
 
 Overview
 ********

--- a/samples/boards/stm32/i2c_timing/README.rst
+++ b/samples/boards/stm32/i2c_timing/README.rst
@@ -1,6 +1,8 @@
 .. zephyr:code-sample:: stm32_i2c_v2_timings
-   :name: STM32 I2C V2 timings
+   :name: I2C V2 timings
    :relevant-api: i2c_interface
+
+   Retrieve I2C V2 timings at runtime.
 
 Overview
 ********

--- a/samples/boards/stm32/mco/README.rst
+++ b/samples/boards/stm32/mco/README.rst
@@ -1,7 +1,8 @@
-.. _samples_boards_stm32_mco:
+.. zephyr:code-sample:: stm32_mco
+   :name: Master Clock Output (MCO)
+   :relevant-api: pinctrl_interface
 
-STM32 MCO example
-#################
+   Output an internal clock for external use by the application.
 
 Overview
 ********

--- a/samples/boards/stm32/power_mgmt/adc/README.rst
+++ b/samples/boards/stm32/power_mgmt/adc/README.rst
@@ -1,7 +1,8 @@
-.. _stm32-pm-adc-sample:
+.. zephyr:code-sample:: stm32_pm_adc
+   :name: ADC power management
+   :relevant-api: adc_interface
 
-STM32 PM ADC
-############
+   Use ADC in a low-power context on STM32.
 
 Overview
 ********

--- a/samples/boards/stm32/power_mgmt/blinky/README.rst
+++ b/samples/boards/stm32/power_mgmt/blinky/README.rst
@@ -1,7 +1,7 @@
-.. _stm32-pm-blinky-sample:
+.. zephyr:code-sample:: stm32_pm_blinky
+   :name: Blinky with power management
 
-STM32 PM Blinky
-###############
+   Blink an LED using the GPIO API in a low-power context on STM32
 
 Overview
 ********

--- a/samples/boards/stm32/power_mgmt/serial_wakeup/README.rst
+++ b/samples/boards/stm32/power_mgmt/serial_wakeup/README.rst
@@ -1,7 +1,7 @@
-.. _stm32-pm-serial-wakeup-sample:
+.. zephyr:code-sample:: stm32_pm_serial_wakeup
+   :name: Serial wakeup
 
-STM32 PM Serial wakeup
-######################
+   Wake up on serial activity on STM32.
 
 Overview
 ********

--- a/samples/boards/stm32/power_mgmt/standby_shutdown/README.rst
+++ b/samples/boards/stm32/power_mgmt/standby_shutdown/README.rst
@@ -1,7 +1,7 @@
-.. _stm32-pm-standby_shutdown-sample:
+.. zephyr:code-sample:: stm32_pm_shutdown
+   :name: Standby/Shutdown mode
 
-STM32 PM Standby shutdown
-#########################
+   Enter and exit Standby/Shutdown mode on STM32.
 
 Overview
 ********

--- a/samples/boards/stm32/power_mgmt/stm32wb_ble/README.rst
+++ b/samples/boards/stm32/power_mgmt/stm32wb_ble/README.rst
@@ -1,7 +1,8 @@
-.. _boards-stm32-power_mgmt-stm32wb_ble-sample:
+.. zephyr:code-sample:: stm32_pm_stm32wb_ble
+   :name: Bluetooth Low Energy Power Management on STM32WB
+   :relevant-api: sys_poweroff bt_gap bluetooth
 
-STM32: PM BLE Power Management (STM32WB)
-########################################
+   Perform Bluetooth LE operations with Zephyr power management enabled on STM32WB.
 
 Overview
 ********

--- a/samples/boards/stm32/power_mgmt/stop3/README.rst
+++ b/samples/boards/stm32/power_mgmt/stop3/README.rst
@@ -1,7 +1,7 @@
-.. _stm32-pm-stop3:
+.. zephyr:code-sample:: stm32_pm_stop3
+   :name: STOP3 mode
 
-STM32 PM STOP3 mode
-###################
+   Use STOP3 low power mode on STM32U5.
 
 Overview
 ********

--- a/samples/boards/stm32/power_mgmt/suspend_to_ram/README.rst
+++ b/samples/boards/stm32/power_mgmt/suspend_to_ram/README.rst
@@ -1,7 +1,8 @@
-.. _stm32-pm-suspend-to-ram-sample:
+.. zephyr:code-sample:: stm32_pm_suspend_to_ram
+   :name: Suspend to RAM
+   :relevant-api: subsys_pm
 
-STM32 PM Suspend to RAM
-#######################
+   Use suspend to RAM low power mode on STM32.
 
 Overview
 ********

--- a/samples/boards/stm32/power_mgmt/wkup_pins/README.rst
+++ b/samples/boards/stm32/power_mgmt/wkup_pins/README.rst
@@ -1,7 +1,8 @@
-.. _gpio-as-a-wkup-pin-src-sample:
+.. zephyr:code-sample:: stm32_pm_gpio_wkup_src
+   :name: GPIO as a wake-up pin source
+   :relevant-api: adc_interface
 
-GPIO As A Wake-up Pin Source
-############################
+   Use a GPIO as a wake-up pin source.
 
 Overview
 ********

--- a/samples/boards/stm32/uart/single_wire/README.rst
+++ b/samples/boards/stm32/uart/single_wire/README.rst
@@ -1,5 +1,5 @@
 .. zephyr:code-sample:: uart-stm32-single-wire
-   :name: STM32 single-wire UART
+   :name: Single-wire UART
    :relevant-api: uart_interface
 
    Use single-wire/half-duplex UART functionality of STM32 devices.


### PR DESCRIPTION
Adds missing code-sample directive to all the STM32 samples in preparation for upcoming changes to the Zephyr documentation that will be leveraging the provided description and metadata.