### PR TITLE
charger: bq25180: set a default constant-charge-voltage-max-microvolt

### DIFF
--- a/dts/bindings/charger/ti,bq25180.yaml
+++ b/dts/bindings/charger/ti,bq25180.yaml
@@ -30,7 +30,11 @@ properties:
       driver initialization.
 
   constant-charge-voltage-max-microvolt:
-    required: true
+    type: int
+    default: 4200000
+    description: |
+      The maximum voltage that the battery will be charged at, defaults to
+      4.2V, matching the device default reset configuration.
 
   precharge-voltage-threshold-microvolt:
     type: int


### PR DESCRIPTION
Set a default value for constant-charge-voltage-max-microvolt, matching the device hardware default, this ensure compatibility with existing applications that did not specify the recently introduced property.