### PR TITLE
boards: opta: enable ethernet and RNG

### DIFF
--- a/boards/arduino/opta/Kconfig.defconfig
+++ b/boards/arduino/opta/Kconfig.defconfig
@@ -4,6 +4,13 @@
 
 if BOARD_ARDUINO_OPTA
 
+if NETWORKING
+
+config NET_L2_ETHERNET
+	default y
+
+endif # NETWORKING
+
 if USB_DEVICE_STACK
 
 config USB_DEVICE_PRODUCT

--- a/boards/arduino/opta/arduino_opta_stm32h747xx_m7.dts
+++ b/boards/arduino/opta/arduino_opta_stm32h747xx_m7.dts
@@ -17,9 +17,27 @@
 
 	chosen {
 		zephyr,console = &cdc_acm_uart0;
+		zephyr,shell-uart = &cdc_acm_uart0;
+		zephyr,cdc-acm-uart0 = &cdc_acm_uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+	};
+
+	ethernet_phy_en: ethernet_phy_en {
+		compatible = "regulator-fixed";
+		regulator-name = "ethernet-phy-reset-release";
+		enable-gpios = <&gpioj 15 GPIO_ACTIVE_HIGH>;
+		regulator-boot-on;
+		status = "okay";
+	};
+
+	sdram2: sdram@d0000000 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		device_type = "memory";
+		reg = <0xd0000000 DT_SIZE_M(32)>;
+		zephyr,memory-region = "SDRAM2";
+		zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_RAM) )>;
 	};
 };
 
@@ -91,12 +109,14 @@ zephyr_udc0: &usbotg_fs {
 	status = "disabled";
 };
 
+&cdc_acm_uart0 {
+	status = "okay";
+};
+
 &mac {
 	pinctrl-0 = <
 		&eth_ref_clk_pa1
-		&eth_mdio_pa2
 		&eth_crs_dv_pa7
-		&eth_mdc_pc1
 		&eth_rxd0_pc4
 		&eth_rxd1_pc5
 		&eth_tx_en_pg11
@@ -104,4 +124,21 @@ zephyr_udc0: &usbotg_fs {
 		&eth_txd0_pg13
 	>;
 	pinctrl-names = "default";
+	status = "okay";
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
+	pinctrl-names = "default";
+
+	ethernet-phy@0 {
+		compatible = "ethernet-phy";
+		reg = <0x00>;
+		status = "okay";
+	};
+};
+
+&rng {
+	status = "okay";
 };

--- a/boards/arduino/opta/arduino_opta_stm32h747xx_m7.yaml
+++ b/boards/arduino/opta/arduino_opta_stm32h747xx_m7.yaml
@@ -10,6 +10,7 @@ ram: 512
 flash: 768
 supported:
   - gpio
+  - netif:eth
 testing:
   ignore_tags:
     - mpu

--- a/boards/arduino/opta/arduino_opta_stm32h747xx_m7_defconfig
+++ b/boards/arduino/opta/arduino_opta_stm32h747xx_m7_defconfig
@@ -31,3 +31,7 @@ CONFIG_UART_LINE_CTRL=y
 
 # Enable USB Stack (needed for the console to work)
 CONFIG_USB_DEVICE_STACK=y
+
+# Enable regulator (needed to enable eth)
+CONFIG_REGULATOR=y
+CONFIG_REGULATOR_FIXED=y

--- a/boards/arduino/opta/doc/index.rst
+++ b/boards/arduino/opta/doc/index.rst
@@ -65,6 +65,8 @@ supports the following hardware features:
 +-----------+------------+-------------------------------------+
 | USB       | on-board   | usb-fs                              |
 +-----------+------------+-------------------------------------+
+| ETHERNET  | on-board   | eth                                 |
++-----------+------------+-------------------------------------+
 
 The ``arduino_opta/stm32h747xx/m4`` board target
 supports the following hardware features:
@@ -110,6 +112,14 @@ Default Zephyr Peripheral Mapping
 - Red "reset" LED: PH11
 - Blue LED: PE5
 - User button: PE4
+- Input 1 : PA0
+- Input 2 : PC2
+- Input 3 : PF12
+- Input 4 : PB0
+- Input 5 : PF10
+- Input 6 : PF8
+- Input 7 : PF6
+- Input 8 : PF4
 - Relay 1: PI6
 - Relay 2: PI5
 - Relay 3: PI7
@@ -163,8 +173,8 @@ Zephyr flash configuration has been set to be compatible with the
 partitioned as follows:
 
   - 0x08000000-0x0803FFFF (256k) Arduino MCUboot-derived bootloader
-  - 0x08040000-0x0817FFFF (768k) M7 application
-  - 0x08040000-0x0817FFFF (512k) M4 application
+  - 0x08040000-0x080FFFFF (768k) M7 application
+  - 0x08180000-0x081FFFFF (512k) M4 application
 
 
 Flashing an application to ARDUINO OPTA M7


### PR DESCRIPTION
Features enabled by this commit:

* RNG
* Ethernet port (shell sample works without changes)

Also fixed flash addresses in docs and added the default mapping between inputs and GPIO pins.

EDIT: [doc page link](https://builds.zephyrproject.io/zephyr/pr/78090/docs/boards/arduino/opta/doc/index.html)