### PR TITLE
manifest: Update nRF hw models to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -300,7 +300,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 4b0b020e25dbf1a11ccccf7b7741d6ca991ba9e4
+      revision: d2a119a9c7600ce06033a794de042e0ad9a38702
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: 76d2168bcdfcd23a9a7dce8c21f2083b90a1e60a


### PR DESCRIPTION
Update the HW models module to:
d2a119a9c7600ce06033a794de042e0ad9a38702

Including the following:
- d2a119a 54 ECB/CCM tests: Add BLE spec examples and more printouts 
- 17692a6 54 CCM: Correct variable names
- 16629b5 RRAMC: Add backwards compatible command line aliases for flash_*
- 52cbc36 54 AAR, CCM, ECB: Fix reset values and ECB key endianess 
- d51acf4 RADIO: Implement TASK_SOFTRESET
- 8285509 54 ECB: Correct t_ECB
- 4f70fba 54: AAR/CCM: Route tasks to the appropriate module 
- 895eabb RADIO: Warn only once about TASK_SOFTRESET not being implemented