### PR TITLE
samples: Bluetooth: Audio: Add/fix API includes and references

### DIFF
--- a/samples/bluetooth/bap_broadcast_assistant/README.rst
+++ b/samples/bluetooth/bap_broadcast_assistant/README.rst
@@ -1,21 +1,21 @@
 .. zephyr:code-sample:: bluetooth_bap_broadcast_assistant
-   :name: Broadcast Audio Assistant
-   :relevant-api: bt_bap
+   :name: Basic Audio Profile (BAP) Broadcast Audio Assistant
+   :relevant-api: bluetooth bt_audio bt_bap bt_conn
 
-   Use LE Audio Broadcast Assistant functionality.
+   Use BAP Broadcast Assistant functionality.
 
 Overview
 ********
 
-Application demonstrating the LE Audio broadcast assistant functionality.
+Application demonstrating the BAP Broadcast Assistant functionality.
 
 The sample will automatically try to connect to a device in the BAP Scan Delegator
 role (advertising support for the Broadcast Audio Scan Service (BASS)).
 It will then search for a broadcast source and (if found) add the broadcast ID to
 the BAP Scan Delegator.
 
-Practical use of this sample requires a sink (e.g. the Broadcast Audio Sink sample or
-a set of LE Audio Broadcast capable earbuds) and a source (e.g. the Broadcast Audio
+Practical use of this sample requires a sink (e.g. the BAP Broadcast Audio Sink sample or
+a set of BAP Broadcast capable earbuds) and a source (e.g. the BAP Broadcast Audio
 Source sample).
 
 This sample can be found under

--- a/samples/bluetooth/bap_broadcast_assistant/src/main.c
+++ b/samples/bluetooth/bap_broadcast_assistant/src/main.c
@@ -1,20 +1,33 @@
 /*
  * Copyright (c) 2024 Demant A/S
+ * Copyright (c) 2024 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/types.h>
-#include <stddef.h>
-#include <strings.h>
 #include <errno.h>
-#include <zephyr/kernel.h>
-#include <zephyr/sys/printk.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include <strings.h>
 
-#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/gap.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/bluetooth/iso.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/kernel.h>
+#include <zephyr/net_buf.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/types.h>
 
 #define NAME_LEN 30
 #define PA_SYNC_SKIP         5

--- a/samples/bluetooth/bap_broadcast_sink/README.rst
+++ b/samples/bluetooth/bap_broadcast_sink/README.rst
@@ -1,14 +1,14 @@
 .. zephyr:code-sample:: bluetooth_bap_broadcast_sink
-   :name: Broadcast Audio Sink
-   :relevant-api: bluetooth
+   :name: Basic Audio Profile (BAP) Broadcast Audio Sink
+   :relevant-api: bluetooth bt_audio bt_bap bt_conn bt_pacs
 
-   Use LE Audio Broadcast Sink functionality.
+   Use BAP Broadcast Sink functionality.
 
 Overview
 ********
 
-Application demonstrating the LE Audio broadcast sink functionality.
-Starts by scanning for LE Audio broadcast sources and then synchronizes to
+Application demonstrating the BAP Broadcast Sink functionality.
+Starts by scanning for BAP Broadcast Sources and then synchronizes to
 the first found and listens to it until the source is (potentially) stopped.
 
 This sample can be found under

--- a/samples/bluetooth/bap_broadcast_sink/src/main.c
+++ b/samples/bluetooth/bap_broadcast_sink/src/main.c
@@ -1,22 +1,43 @@
 /*
- * Copyright (c) 2022-2023 Nordic Semiconductor ASA
+ * Copyright (c) 2022-2024 Nordic Semiconductor ASA
  * Copyright (c) 2024 Demant A/S
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ctype.h>
+#include <errno.h>
+#include <stdint.h>
+#include <string.h>
 #include <strings.h>
 
+#include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/audio/lc3.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap.h>
 #include <zephyr/bluetooth/audio/pacs.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/gap.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/bluetooth/iso.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/kernel.h>
+#include <zephyr/net_buf.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
+#include <zephyr/sys_clock.h>
+#include <zephyr/toolchain.h>
+
 #if defined(CONFIG_LIBLC3)
 #include "lc3.h"
 #endif /* defined(CONFIG_LIBLC3) */
 #if defined(CONFIG_USB_DEVICE_AUDIO)
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/usb/usb_device.h>
 #include <zephyr/usb/class/usb_audio.h>
 #include <zephyr/sys/ring_buffer.h>

--- a/samples/bluetooth/bap_broadcast_source/README.rst
+++ b/samples/bluetooth/bap_broadcast_source/README.rst
@@ -1,18 +1,18 @@
 .. zephyr:code-sample:: bluetooth_bap_broadcast_source
-   :name: Broadcast Audio Source
-   :relevant-api: bluetooth
+   :name: Basic Audio Profile (BAP) Broadcast Audio Source
+   :relevant-api: bluetooth bt_audio bt_bap
 
-   Use LE Audio Broadcast Source functionality.
+   Use BAP Broadcast Source functionality.
 
 Overview
 ********
 
-Application demonstrating the LE Audio broadcast audio source functionality.
+Application demonstrating the BAP Broadcast Source functionality.
 Will start advertising extended advertising with audio flags, periodic advertising with the
-broadcast audio source endpoint (BASE) and finally the BIGinfo together with
+Broadcast Audio Source Endpoint (BASE) and finally the BIGinfo together with
 (mock) Audio (ISO) data.
 
-The broadcast source will reset every 30 seconds to show the full API.
+The BAP Broadcast Source will reset every 30 seconds to show the full API.
 
 This sample can be found under
 :zephyr_file:`samples/bluetooth/bap_broadcast_source` in the Zephyr tree.

--- a/samples/bluetooth/bap_broadcast_source/src/main.c
+++ b/samples/bluetooth/bap_broadcast_source/src/main.c
@@ -1,13 +1,31 @@
 /*
- * Copyright (c) 2022-2023 Nordic Semiconductor ASA
+ * Copyright (c) 2022-2024 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/bluetooth/bluetooth.h>
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <zephyr/autoconf.h>
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap.h>
 #include <zephyr/bluetooth/audio/bap_lc3_preset.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/byteorder.h>
+#include <zephyr/bluetooth/gap.h>
+#include <zephyr/bluetooth/iso.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/kernel.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys_clock.h>
+#include <zephyr/toolchain.h>
 
 BUILD_ASSERT(strlen(CONFIG_BROADCAST_CODE) <= BT_AUDIO_BROADCAST_CODE_SIZE,
 	     "Invalid broadcast code");

--- a/samples/bluetooth/bap_unicast_client/README.rst
+++ b/samples/bluetooth/bap_unicast_client/README.rst
@@ -1,14 +1,14 @@
 .. zephyr:code-sample:: bluetooth_bap_unicast_client
-   :name: Unicast Audio Client
-   :relevant-api: bt_bap bt_audio
+   :name: Basic Audio Profile (BAP) Unicast Audio Client
+   :relevant-api: bluetooth bt_audio bt_bap bt_conn
 
-   Use LE Audio Unicast Client functionality.
+   Use BAP Unicast Client functionality.
 
 Overview
 ********
 
-Application demonstrating the LE Audio unicast client functionality. Scans for and
-connects to a LE Audio unicast server and establishes an audio stream.
+Application demonstrating the BAP Unicast Client functionality. Scans for and
+connects to a BAP Unicast Server and establishes an audio stream.
 
 This sample can be found under
 :zephyr_file:`samples/bluetooth/bap_unicast_client` in the Zephyr tree.

--- a/samples/bluetooth/bap_unicast_client/src/main.c
+++ b/samples/bluetooth/bap_unicast_client/src/main.c
@@ -4,17 +4,32 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <stddef.h>
 #include <errno.h>
+#include <inttypes.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
 
+#include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/att.h>
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap.h>
 #include <zephyr/bluetooth/audio/bap_lc3_preset.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/gap.h>
+#include <zephyr/bluetooth/gatt.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/bluetooth/iso.h>
+#include <zephyr/bluetooth/uuid.h>
 #include <zephyr/kernel.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/__assert.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/printk.h>
+#include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/types.h>
 

--- a/samples/bluetooth/bap_unicast_client/src/stream_tx.h
+++ b/samples/bluetooth/bap_unicast_client/src/stream_tx.h
@@ -7,6 +7,8 @@
 #ifndef STREAM_TX_H
 #define STREAM_TX_H
 
+#include <stdint.h>
+
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/audio/bap.h>
 #include <zephyr/bluetooth/audio/cap.h>

--- a/samples/bluetooth/bap_unicast_server/README.rst
+++ b/samples/bluetooth/bap_unicast_server/README.rst
@@ -1,14 +1,14 @@
 .. zephyr:code-sample:: bluetooth_bap_unicast_server
-   :name: Unicast Audio Server
-   :relevant-api: bt_bap bt_audio
+   :name: Basic Audio Profile (BAP) Unicast Audio Server
+   :relevant-api: bluetooth bt_audio bt_bap bt_pacs
 
-   Use LE Audio Unicast Server functionality.
+   Use BAP Unicast Server functionality.
 
 Overview
 ********
 
-Application demonstrating the LE Audio unicast server functionality.
-Starts advertising and awaits connection from a LE Audio unicast client.
+Application demonstrating the BAP Unicast Server functionality.
+Starts advertising and awaits connection from a BAP Unicast Client.
 
 This sample can be found under
 :zephyr_file:`samples/bluetooth/bap_unicast_server` in the Zephyr tree.

--- a/samples/bluetooth/bap_unicast_server/src/main.c
+++ b/samples/bluetooth/bap_unicast_server/src/main.c
@@ -1,22 +1,36 @@
 /*
- * Copyright (c) 2021-2023 Nordic Semiconductor ASA
+ * Copyright (c) 2021-2024 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/types.h>
-#include <stddef.h>
 #include <errno.h>
-#include <zephyr/kernel.h>
-#include <zephyr/sys/printk.h>
+#include <stddef.h>
+#include <stdint.h>
 
+#include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/audio/audio.h>
+#include <zephyr/bluetooth/audio/bap.h>
+#include <zephyr/bluetooth/audio/lc3.h>
+#include <zephyr/bluetooth/audio/pacs.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/byteorder.h>
 #include <zephyr/bluetooth/conn.h>
-#include <zephyr/bluetooth/audio/audio.h>
-#include <zephyr/bluetooth/audio/bap.h>
-#include <zephyr/bluetooth/audio/pacs.h>
+#include <zephyr/bluetooth/gap.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/bluetooth/iso.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/kernel.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/__assert.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
+#include <zephyr/sys_clock.h>
+#include <zephyr/types.h>
 
 #define AVAILABLE_SINK_CONTEXT  (BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED | \
 				 BT_AUDIO_CONTEXT_TYPE_CONVERSATIONAL | \

--- a/samples/bluetooth/cap_acceptor/README.rst
+++ b/samples/bluetooth/cap_acceptor/README.rst
@@ -1,6 +1,6 @@
 .. zephyr:code-sample:: bluetooth_cap_acceptor
-   :name: Common Audio Profile Acceptor
-   :relevant-api: bt_cap bt_bap bluetooth
+   :name: Common Audio Profile (CAP) Acceptor
+   :relevant-api: bluetooth bt_audio bt_bap bt_cap bt_pacs
 
    Advertise audio availability to CAP Initiators using the CAP Acceptor role.
 

--- a/samples/bluetooth/cap_acceptor/src/cap_acceptor.h
+++ b/samples/bluetooth/cap_acceptor/src/cap_acceptor.h
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdint.h>
+
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/cap.h>
 #include <zephyr/bluetooth/conn.h>

--- a/samples/bluetooth/cap_acceptor/src/main.c
+++ b/samples/bluetooth/cap_acceptor/src/main.c
@@ -19,6 +19,7 @@
 #include <zephyr/bluetooth/byteorder.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/gap.h>
+#include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/kernel.h>

--- a/samples/bluetooth/cap_initiator/README.rst
+++ b/samples/bluetooth/cap_initiator/README.rst
@@ -1,6 +1,6 @@
 .. zephyr:code-sample:: bluetooth_cap_initiator
-   :name: Common Audio Profile Initiator
-   :relevant-api: bt_cap bt_bap bluetooth
+   :name: Common Audio Profile (CAP) Initiator
+   :relevant-api: bluetooth bt_bap bt_cap bt_conn
 
    Connect to CAP Acceptors and setup unicast audio streaming or broadcast audio streams.
 

--- a/samples/bluetooth/cap_initiator/src/cap_initiator_broadcast.c
+++ b/samples/bluetooth/cap_initiator/src/cap_initiator_broadcast.c
@@ -4,14 +4,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap_lc3_preset.h>
 #include <zephyr/bluetooth/audio/cap.h>
 #include <zephyr/bluetooth/audio/bap.h>
 #include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/gap.h>
+#include <zephyr/bluetooth/uuid.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/logging/log_core.h>
+#include <zephyr/net_buf.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/util.h>
 #include <zephyr/types.h>
 
 #include "cap_initiator.h"

--- a/samples/bluetooth/cap_initiator/src/cap_initiator_tx.c
+++ b/samples/bluetooth/cap_initiator/src/cap_initiator_tx.c
@@ -4,15 +4,24 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/types.h>
-#include <zephyr/kernel.h>
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <zephyr/autoconf.h>
 #include <zephyr/bluetooth/audio/cap.h>
 #include <zephyr/bluetooth/audio/bap.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/iso.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel/thread_stack.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/logging/log_core.h>
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
+#include <zephyr/types.h>
 
 #include "cap_initiator.h"
 

--- a/samples/bluetooth/cap_initiator/src/cap_initiator_unicast.c
+++ b/samples/bluetooth/cap_initiator/src/cap_initiator_unicast.c
@@ -20,6 +20,7 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/gap.h>
 #include <zephyr/bluetooth/gatt.h>
+#include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/bluetooth/iso.h>
 #include <zephyr/bluetooth/uuid.h>

--- a/samples/bluetooth/pbp_public_broadcast_sink/README.rst
+++ b/samples/bluetooth/pbp_public_broadcast_sink/README.rst
@@ -1,14 +1,14 @@
 .. zephyr:code-sample:: bluetooth_public_broadcast_sink
-   :name: Public Broadcast Sink
-   :relevant-api: bluetooth
+   :name: Public Broadcast Profile (PBP) Public Broadcast Sink
+   :relevant-api: bluetooth bt_audio bt_bap bt_pacs bt_pbp
 
-   Bluetooth: Public Broadcast Sink
+   Use PBP Public Broadcast Sink functionality.
 
 Overview
 ********
 
-Application demonstrating the LE Public Broadcast Profile sink functionality.
-Starts by scanning for LE Audio broadcast sources and then synchronizes to
+Application demonstrating the PBP Public Broadcast Sink functionality.
+Starts by scanning for PBP Public Broadcast Sources and then synchronizes to
 the first found source which defines a Public Broadcast Announcement including
 a High Quality Public Broadcast Audio Stream configuration.
 

--- a/samples/bluetooth/pbp_public_broadcast_sink/src/main.c
+++ b/samples/bluetooth/pbp_public_broadcast_sink/src/main.c
@@ -1,21 +1,31 @@
 /*
  * Copyright 2023 NXP
+ * Copyright (c) 2024 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/types.h>
 #include <stddef.h>
-#include <errno.h>
-#include <zephyr/kernel.h>
-#include <zephyr/sys/printk.h>
-#include <zephyr/sys/byteorder.h>
-#include <zephyr/bluetooth/bluetooth.h>
+#include <stdint.h>
+
+#include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap.h>
+#include <zephyr/bluetooth/audio/lc3.h>
 #include <zephyr/bluetooth/audio/pacs.h>
 #include <zephyr/bluetooth/audio/bap_lc3_preset.h>
 #include <zephyr/bluetooth/audio/pbp.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/gap.h>
+#include <zephyr/bluetooth/iso.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/kernel.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
+#include <zephyr/types.h>
 
 #define AVAILABLE_SINK_CONTEXT  (BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED | \
 				 BT_AUDIO_CONTEXT_TYPE_CONVERSATIONAL | \

--- a/samples/bluetooth/pbp_public_broadcast_source/README.rst
+++ b/samples/bluetooth/pbp_public_broadcast_source/README.rst
@@ -1,13 +1,13 @@
 .. zephyr:code-sample:: bluetooth_public_broadcast_source
-   :name: Public Broadcast Source
-   :relevant-api: bluetooth
+   :name: Public Broadcast Profile (PBP) Public Broadcast Source
+   :relevant-api: bluetooth bt_audio bt_bap bt_pbp
 
-   Bluetooth: Public Broadcast Source
+   Use PBP Public Broadcast Source functionality.
 
 Overview
 ********
 
-Application demonstrating the LE Public Broadcast Profile source functionality.
+Application demonstrating the PBP Public Broadcast Source functionality.
 Will start advertising extended advertising and includes a Broadcast Audio Announcement.
 The advertised broadcast audio stream quality will cycle between high and standard quality
 every 15 seconds.

--- a/samples/bluetooth/pbp_public_broadcast_source/src/main.c
+++ b/samples/bluetooth/pbp_public_broadcast_source/src/main.c
@@ -1,21 +1,32 @@
 /*
  * Copyright 2023 NXP
+ * Copyright (c) 2024 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/types.h>
 #include <stddef.h>
-#include <errno.h>
-#include <zephyr/kernel.h>
-#include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/printk.h>
+#include <stdint.h>
+
+#include <zephyr/autoconf.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap_lc3_preset.h>
 #include <zephyr/bluetooth/audio/cap.h>
 #include <zephyr/bluetooth/audio/bap.h>
 #include <zephyr/bluetooth/audio/pbp.h>
+#include <zephyr/bluetooth/byteorder.h>
+#include <zephyr/bluetooth/gap.h>
+#include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/bluetooth/iso.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/kernel.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
+#include <zephyr/types.h>
 
 #define BROADCAST_ENQUEUE_COUNT 2U
 

--- a/samples/bluetooth/tmap_bmr/README.rst
+++ b/samples/bluetooth/tmap_bmr/README.rst
@@ -1,13 +1,13 @@
 .. zephyr:code-sample:: ble_peripheral_tmap_bmr
-   :name: TMAP Broadcast Media Receiver (BMR)
-   :relevant-api: bt_audio bt_bap bluetooth
+   :name: Telephone and Media Audio Profile (TMAP) Broadcast Media Receiver (BMR)
+   :relevant-api: bluetooth bt_audio bt_bap bt_pacs bt_vcp bt_tmap
 
-   Implement the LE Audio TMAP Broadcast Media Receiver (BMR) role.
+   Implement the TMAP Broadcast Media Receiver (BMR) role.
 
 Overview
 ********
 
-Application demonstrating the LE Audio TMAP Broadcast Media Receiver functionality.
+Application demonstrating the TMAP Broadcast Media Receiver functionality.
 Implements the BMR role.
 
 Requirements

--- a/samples/bluetooth/tmap_bmr/src/bap_broadcast_sink.c
+++ b/samples/bluetooth/tmap_bmr/src/bap_broadcast_sink.c
@@ -1,17 +1,30 @@
 /*
- * Copyright (c) 2022-2023 Nordic Semiconductor ASA
+ * Copyright (c) 2022-2024 Nordic Semiconductor ASA
  * Copyright 2023 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <zephyr/sys/byteorder.h>
 
-#include <zephyr/bluetooth/bluetooth.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap.h>
+#include <zephyr/bluetooth/audio/lc3.h>
 #include <zephyr/bluetooth/audio/pacs.h>
 #include <zephyr/bluetooth/audio/bap_lc3_preset.h>
 #include <zephyr/bluetooth/audio/tmap.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/gap.h>
+#include <zephyr/bluetooth/iso.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/kernel.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
 
 #define SEM_TIMEOUT K_SECONDS(10)
 #define PA_SYNC_SKIP         5

--- a/samples/bluetooth/tmap_bmr/src/vcp_vol_renderer.c
+++ b/samples/bluetooth/tmap_bmr/src/vcp_vol_renderer.c
@@ -2,20 +2,20 @@
  *  @brief Bluetooth Volume Control Profile (VCP) Volume Renderer role.
  *
  *  Copyright (c) 2020 Bose Corporation
- *  Copyright (c) 2020-2022 Nordic Semiconductor ASA
+ *  Copyright (c) 2020-2024 Nordic Semiconductor ASA
  *  Copyright (c) 2022 Codecoup
  *  Copyright 2023 NXP
  *
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/kernel.h>
-#include <zephyr/sys/printk.h>
-#include <stdlib.h>
-#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
 
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/audio/vcp.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/printk.h>
 
 static struct bt_vcp_included vcp_included;
 

--- a/samples/bluetooth/tmap_bms/README.rst
+++ b/samples/bluetooth/tmap_bms/README.rst
@@ -1,15 +1,14 @@
 .. zephyr:code-sample:: ble_peripheral_tmap_bms
-   :name: TMAP Broadcast Media Sender (BMS)
-   :relevant-api: bt_audio bt_bap bluetooth
+   :name: Telephone and Media Audio Profile (TMAP) Broadcast Media Sender (BMS)
+   :relevant-api: bluetooth bt_audio bt_bap bt_cap bt_tmap
 
    Implement the LE Audio TMAP Broadcast Media Sender (BMS) role.
 
 Overview
 ********
 
-Application demonstrating the LE Audio TMAP Broadcast Media Sender functionality.
+Application demonstrating the TMAP Broadcast Media Sender functionality.
 Implements the BMS role.
-
 
 Requirements
 ************

--- a/samples/bluetooth/tmap_bms/src/cap_initiator.c
+++ b/samples/bluetooth/tmap_bms/src/cap_initiator.c
@@ -1,19 +1,28 @@
 /*
- * Copyright (c) 2022-2023 Nordic Semiconductor ASA
+ * Copyright (c) 2022-2024 Nordic Semiconductor ASA
  * Copyright 2023 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/types.h>
 #include <stddef.h>
-#include <zephyr/kernel.h>
+#include <stdint.h>
+
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap_lc3_preset.h>
 #include <zephyr/bluetooth/audio/cap.h>
 #include <zephyr/bluetooth/audio/bap.h>
 #include <zephyr/bluetooth/audio/tmap.h>
+#include <zephyr/bluetooth/byteorder.h>
+#include <zephyr/bluetooth/gap.h>
+#include <zephyr/bluetooth/iso.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/kernel.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/types.h>
 
 #define BROADCAST_ENQUEUE_COUNT 2U
 

--- a/samples/bluetooth/tmap_central/README.rst
+++ b/samples/bluetooth/tmap_central/README.rst
@@ -1,13 +1,13 @@
 .. zephyr:code-sample:: ble_peripheral_tmap_central
-   :name: TMAP (Central)
-   :relevant-api: bt_audio bt_bap bluetooth
+   :name: Telephone and Media Audio Profile (TMAP) Central
+   :relevant-api: bluetooth bt_audio bt_bap bt_cap  bt_conn bt_tbs bt_tmap bt_vcp
 
-   Implement the LE Audio TMAP central functionality (CG and UMS roles).
+   Implement the TMAP Call Gateway (CG) and Unicast Media Sender (UMS) roles.
 
 Overview
 ********
 
-Application demonstrating the LE Audio TMAP central functionality. Implements the CG and UMS roles.
+Application demonstrating the TMAP central functionality. Implements the CG and UMS roles.
 
 
 Requirements

--- a/samples/bluetooth/tmap_central/src/cap_initiator.c
+++ b/samples/bluetooth/tmap_central/src/cap_initiator.c
@@ -1,21 +1,31 @@
 /*
- * Copyright (c) 2022-2023 Nordic Semiconductor ASA
+ * Copyright (c) 2022-2024 Nordic Semiconductor ASA
  * Copyright 2023 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#if defined(CONFIG_BT_CAP_INITIATOR)
-
-#include <zephyr/types.h>
 #include <stddef.h>
-#include <zephyr/kernel.h>
-#include <zephyr/bluetooth/bluetooth.h>
-#include <zephyr/bluetooth/conn.h>
+#include <stdint.h>
+
+#include <zephyr/autoconf.h>
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap_lc3_preset.h>
 #include <zephyr/bluetooth/audio/cap.h>
 #include <zephyr/bluetooth/audio/bap.h>
+#include <zephyr/bluetooth/audio/csip.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/bluetooth/iso.h>
+#include <zephyr/kernel.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
+#include <zephyr/types.h>
+
+#if defined(CONFIG_BT_CAP_INITIATOR)
 
 static struct k_work_delayable audio_send_work;
 

--- a/samples/bluetooth/tmap_central/src/ccp_server.c
+++ b/samples/bluetooth/tmap_central/src/ccp_server.c
@@ -2,17 +2,19 @@
  *  @brief Bluetooth Call Control Profile (CCP) Server role.
  *
  *  Copyright 2023 NXP
+ *  Copyright (c) 2024 Nordic Semiconductor ASA
  *
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/kernel.h>
-#include <zephyr/sys/printk.h>
-#include <stdlib.h>
+#include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/audio/tbs.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/printk.h>
 
 #define URI_LIST_LEN	2
 

--- a/samples/bluetooth/tmap_central/src/main.c
+++ b/samples/bluetooth/tmap_central/src/main.c
@@ -1,16 +1,14 @@
 /*
  * Copyright 2023 NXP
+ * Copyright (c) 2024 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/types.h>
 #include <stddef.h>
-#include <errno.h>
-#include <zephyr/kernel.h>
-#include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/printk.h>
+#include <stdint.h>
 
+#include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/audio/audio.h>
@@ -18,7 +16,15 @@
 #include <zephyr/bluetooth/audio/bap_lc3_preset.h>
 #include <zephyr/bluetooth/audio/tmap.h>
 #include <zephyr/bluetooth/audio/cap.h>
+#include <zephyr/bluetooth/gap.h>
+#include <zephyr/bluetooth/gatt.h>
 #include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/kernel.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/types.h>
 
 #include "tmap_central.h"
 

--- a/samples/bluetooth/tmap_central/src/tmap_central.h
+++ b/samples/bluetooth/tmap_central/src/tmap_central.h
@@ -1,9 +1,13 @@
 /*
  * Copyright 2023 NXP
+ * Copyright (c) 2024 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdint.h>
+
+#include <zephyr/bluetooth/conn.h>
 #include <zephyr/types.h>
 
 /**

--- a/samples/bluetooth/tmap_central/src/vcp_vol_ctlr.c
+++ b/samples/bluetooth/tmap_central/src/vcp_vol_ctlr.c
@@ -1,13 +1,20 @@
 /*
  * Copyright 2023 NXP
+ * Copyright (c) 2024 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/bluetooth/bluetooth.h>
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/vcp.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/hci.h>
+#include <zephyr/sys/printk.h>
 
 static struct bt_vcp_vol_ctlr *vcp_vol_ctlr;
 

--- a/samples/bluetooth/tmap_peripheral/README.rst
+++ b/samples/bluetooth/tmap_peripheral/README.rst
@@ -1,13 +1,13 @@
 .. zephyr:code-sample:: ble_peripheral_tmap_peripheral
-   :name: TMAP (Peripheral)
-   :relevant-api: bt_audio bt_bap bluetooth
+   :name: Telephone and Media Audio Profile (TMAP) Peripheral
+   :relevant-api: bluetooth bt_audio bt_bap bt_csip bt_mcc bt_tbs bt_tmap bt_vcp
 
-   Implement the LE Audio TMAP central functionality (CT and UMR roles).
+   Implement the TMAP Call Terminal (CT) and Unicast Media Receiver (UMR) roles.
 
 Overview
 ********
 
-Application demonstrating the LE Audio TMAP peripheral functionality. Implements the CT and UMR roles.
+Application demonstrating the TMAP peripheral functionality. Implements the CT and UMR roles.
 
 
 Requirements

--- a/samples/bluetooth/tmap_peripheral/src/bap_unicast_sr.c
+++ b/samples/bluetooth/tmap_peripheral/src/bap_unicast_sr.c
@@ -8,17 +8,29 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/kernel.h>
-#include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/printk.h>
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
 
-#include <zephyr/bluetooth/bluetooth.h>
-#include <zephyr/bluetooth/conn.h>
+#include <zephyr/autoconf.h>
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap_lc3_preset.h>
 #include <zephyr/bluetooth/audio/bap.h>
+#include <zephyr/bluetooth/audio/lc3.h>
 #include <zephyr/bluetooth/audio/pacs.h>
 #include <zephyr/bluetooth/audio/tbs.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/gap.h>
+#include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/bluetooth/iso.h>
+#include <zephyr/kernel.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
 
 #include "tmap_peripheral.h"
 

--- a/samples/bluetooth/tmap_peripheral/src/ccp_call_ctrl.c
+++ b/samples/bluetooth/tmap_peripheral/src/ccp_call_ctrl.c
@@ -1,20 +1,22 @@
 /** @file
  *  @brief Bluetooth Call Control Profile (CCP) Call Controller role.
  *
- *  Copyright (c) 2020 Nordic Semiconductor ASA
+ *  Copyright (c) 2020-2024 Nordic Semiconductor ASA
  *  Copyright (c) 2022 Codecoup
  *  Copyright 2023 NXP
  *
  *  SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdint.h>
+#include <string.h>
+
+#include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/audio/tbs.h>
+#include <zephyr/bluetooth/conn.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
-#include <string.h>
-
-#include <zephyr/bluetooth/conn.h>
-#include <zephyr/bluetooth/audio/tbs.h>
 
 #define URI_SEPARATOR ":"
 #define CALLER_ID "friend"

--- a/samples/bluetooth/tmap_peripheral/src/csip_set_member.c
+++ b/samples/bluetooth/tmap_peripheral/src/csip_set_member.c
@@ -3,15 +3,21 @@
  *
  *  Copyright (c) 2022 Codecoup
  *  Copyright 2023 NXP
+ *  Copyright (c) 2024 Nordic Semiconductor ASA
  *
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/kernel.h>
-#include <zephyr/sys/printk.h>
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
 
+#include <zephyr/autoconf.h>
 #include <zephyr/bluetooth/audio/cap.h>
 #include <zephyr/bluetooth/audio/csip.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/printk.h>
 
 static struct bt_csip_set_member_svc_inst *svc_inst;
 

--- a/samples/bluetooth/tmap_peripheral/src/main.c
+++ b/samples/bluetooth/tmap_peripheral/src/main.c
@@ -1,20 +1,15 @@
 /*
  * Copyright 2023 NXP
+ * Copyright (c) 2024 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/types.h>
 #include <stddef.h>
-#include <errno.h>
-#include <zephyr/kernel.h>
-#include <zephyr/sys/printk.h>
-#include <zephyr/sys/byteorder.h>
+#include <stdint.h>
 
-#include <zephyr/bluetooth/bluetooth.h>
-#include <zephyr/bluetooth/byteorder.h>
-#include <zephyr/bluetooth/conn.h>
-#include <zephyr/bluetooth/hci.h>
+#include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/bap.h>
 #include <zephyr/bluetooth/audio/bap_lc3_preset.h>
@@ -22,6 +17,18 @@
 #include <zephyr/bluetooth/audio/tmap.h>
 #include <zephyr/bluetooth/audio/cap.h>
 #include <zephyr/bluetooth/audio/mcs.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/byteorder.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/gap.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
+#include <zephyr/types.h>
 
 #include "tmap_peripheral.h"
 

--- a/samples/bluetooth/tmap_peripheral/src/mcp_ctlr.c
+++ b/samples/bluetooth/tmap_peripheral/src/mcp_ctlr.c
@@ -2,16 +2,20 @@
  *  @brief Bluetooth Media Control Profile (MCP) Controller role.
  *
  *  Copyright 2023 NXP
+ *  Copyright (c) 2024 Nordic Semiconductor ASA
  *
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/kernel.h>
-#include <zephyr/sys/printk.h>
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
 
-#include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/audio/mcc.h>
 #include <zephyr/bluetooth/audio/media_proxy.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/printk.h>
 
 static struct bt_conn *default_conn;
 

--- a/samples/bluetooth/tmap_peripheral/src/tmap_peripheral.h
+++ b/samples/bluetooth/tmap_peripheral/src/tmap_peripheral.h
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/types.h>
+#include <stdint.h>
+
+#include <zephyr/bluetooth/conn.h>
 
 #if defined(CONFIG_BT_ASCS_ASE_SNK)
 #define AVAILABLE_SINK_CONTEXT                                                                     \

--- a/samples/bluetooth/tmap_peripheral/src/vcp_vol_renderer.c
+++ b/samples/bluetooth/tmap_peripheral/src/vcp_vol_renderer.c
@@ -2,20 +2,20 @@
  *  @brief Bluetooth Volume Control Profile (VCP) Volume Renderer role.
  *
  *  Copyright (c) 2020 Bose Corporation
- *  Copyright (c) 2020-2022 Nordic Semiconductor ASA
+ *  Copyright (c) 2020-2024 Nordic Semiconductor ASA
  *  Copyright (c) 2022 Codecoup
  *  Copyright 2023 NXP
  *
  *  SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdint.h>
+#include <string.h>
+
+#include <zephyr/bluetooth/audio/vcp.h>
+#include <zephyr/bluetooth/conn.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
-#include <stdlib.h>
-#include <stdio.h>
-
-#include <zephyr/bluetooth/conn.h>
-#include <zephyr/bluetooth/audio/vcp.h>
 
 static struct bt_vcp_included vcp_included;
 


### PR DESCRIPTION
Update the includes for Bluetooth Audio samples so they properly include what they use.
    
The includes are then used to determine which relevant APIs to refer to in the READMEs.
    
Finally improve the naming and description of the samples using the Profile names and role.