### PR TITLE
dts: bindings: clock: renesas_ra: Change `_` to `-` in property name

### DIFF
--- a/boards/renesas/ek_ra6m4/ek_ra6m4.dts
+++ b/boards/renesas/ek_ra6m4/ek_ra6m4.dts
@@ -75,7 +75,7 @@
 };
 
 &pclka {
-	clk_src = <RA_CLOCK_SOURCE_PLL>;
-	clk_div = <RA_SYS_CLOCK_DIV_2>;
+	clk-src = <RA_CLOCK_SOURCE_PLL>;
+	clk-div = <RA_SYS_CLOCK_DIV_2>;
 	status = "okay";
 };

--- a/boards/renesas/ek_ra8d1/ek_ra8d1.dts
+++ b/boards/renesas/ek_ra8d1/ek_ra8d1.dts
@@ -69,8 +69,8 @@
 };
 
 &sciclk {
-	clk_src = <RA_CLOCK_SOURCE_PLL1P>;
-	clk_div = <RA_SCI_CLOCK_DIV_4>;
+	clk-src = <RA_CLOCK_SOURCE_PLL1P>;
+	clk-div = <RA_SCI_CLOCK_DIV_4>;
 	status = "okay";
 };
 

--- a/boards/renesas/ek_ra8m1/ek_ra8m1.dts
+++ b/boards/renesas/ek_ra8m1/ek_ra8m1.dts
@@ -92,8 +92,8 @@
 };
 
 &sciclk {
-	clk_src = <RA_CLOCK_SOURCE_PLL1P>;
-	clk_div = <RA_SCI_CLOCK_DIV_4>;
+	clk-src = <RA_CLOCK_SOURCE_PLL1P>;
+	clk-div = <RA_SCI_CLOCK_DIV_4>;
 	status = "okay";
 };
 

--- a/boards/renesas/mck_ra8t1/mck_ra8t1.dts
+++ b/boards/renesas/mck_ra8t1/mck_ra8t1.dts
@@ -73,8 +73,8 @@
 };
 
 &sciclk {
-	clk_src = <RA_CLOCK_SOURCE_PLL1P>;
-	clk_div = <RA_SCI_CLOCK_DIV_4>;
+	clk-src = <RA_CLOCK_SOURCE_PLL1P>;
+	clk-div = <RA_SCI_CLOCK_DIV_4>;
 	status = "okay";
 };
 

--- a/dts/arm/renesas/ra/ra2/r7fa2a1xh.dtsi
+++ b/dts/arm/renesas/ra/ra2/r7fa2a1xh.dtsi
@@ -69,28 +69,28 @@
 
 			iclk: iclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_1>;
+				clk-div = <RA_SYS_CLOCK_DIV_1>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkb: pclkb {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkd: pclkd {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_1>;
+				clk-div = <RA_SYS_CLOCK_DIV_1>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			fclk: fclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_1>;
+				clk-div = <RA_SYS_CLOCK_DIV_1>;
 				#clock-cells = <2>;
 				status = "okay";
 			};

--- a/dts/arm/renesas/ra/ra4/r7fa4e2b93cfm.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4e2b93cfm.dtsi
@@ -101,42 +101,42 @@
 
 			iclk: iclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclka: pclka {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkb: pclkb {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkc: pclkc {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkd: pclkd {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			fclk: fclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				#clock-cells = <2>;
 				status = "okay";
 			};

--- a/dts/arm/renesas/ra/ra4/r7fa4m2ax.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4m2ax.dtsi
@@ -161,42 +161,42 @@
 
 			iclk: iclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclka: pclka {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkb: pclkb {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkc: pclkc {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkd: pclkd {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			fclk: fclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				#clock-cells = <2>;
 				status = "okay";
 			};

--- a/dts/arm/renesas/ra/ra4/r7fa4m3ax.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4m3ax.dtsi
@@ -169,42 +169,42 @@
 
 			iclk: iclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclka: pclka {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkb: pclkb {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkc: pclkc {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkd: pclkd {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			fclk: fclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				#clock-cells = <2>;
 				status = "okay";
 			};

--- a/dts/arm/renesas/ra/ra4/r7fa4w1ad2cng.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4w1ad2cng.dtsi
@@ -95,42 +95,42 @@
 
 			iclk: iclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_1>;
+				clk-div = <RA_SYS_CLOCK_DIV_1>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclka: pclka {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_1>;
+				clk-div = <RA_SYS_CLOCK_DIV_1>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkb: pclkb {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkc: pclkc {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_1>;
+				clk-div = <RA_SYS_CLOCK_DIV_1>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkd: pclkd {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_1>;
+				clk-div = <RA_SYS_CLOCK_DIV_1>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			fclk: fclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
@@ -143,7 +143,7 @@
 
 			uclk: uclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_USB_CLOCK_DIV_1>;
+				clk-div = <RA_USB_CLOCK_DIV_1>;
 				#clock-cells = <2>;
 				status = "okay";
 			};

--- a/dts/arm/renesas/ra/ra6/r7fa6e10x.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6e10x.dtsi
@@ -161,42 +161,42 @@
 
 			iclk: iclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_1>;
+				clk-div = <RA_SYS_CLOCK_DIV_1>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclka: pclka {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkb: pclkb {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkc: pclkc {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkd: pclkd {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			fclk: fclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				#clock-cells = <2>;
 				status = "okay";
 			};

--- a/dts/arm/renesas/ra/ra6/r7fa6e2bx.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6e2bx.dtsi
@@ -91,42 +91,42 @@
 
 			iclk: iclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_1>;
+				clk-div = <RA_SYS_CLOCK_DIV_1>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclka: pclka {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkb: pclkb {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkc: pclkc {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkd: pclkd {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			fclk: fclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				#clock-cells = <2>;
 				status = "okay";
 			};

--- a/dts/arm/renesas/ra/ra6/r7fa6m1ad3cfp.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m1ad3cfp.dtsi
@@ -85,45 +85,45 @@
 
 			iclk: iclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclka: pclka {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkb: pclkb {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkc: pclkc {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkd: pclkd {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			bclk: bclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				bclkout: bclkout {
 					compatible = "renesas,ra-cgc-busclk";
-					clk_out_div = <2>;
+					clk-out-div = <2>;
 					sdclk = <0>;
 					#clock-cells = <0>;
 				};
@@ -133,14 +133,14 @@
 
 			uclk: uclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_USB_CLOCK_DIV_5>;
+				clk-div = <RA_USB_CLOCK_DIV_5>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			fclk: fclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				#clock-cells = <2>;
 				status = "okay";
 			};

--- a/dts/arm/renesas/ra/ra6/r7fa6m2ax.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m2ax.dtsi
@@ -116,45 +116,45 @@
 
 			iclk: iclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclka: pclka {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkb: pclkb {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkc: pclkc {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkd: pclkd {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			bclk: bclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				bclkout: bclkout {
 					compatible = "renesas,ra-cgc-busclk";
-					clk_out_div = <2>;
+					clk-out-div = <2>;
 					sdclk = <1>;
 					#clock-cells = <0>;
 				};
@@ -164,14 +164,14 @@
 
 			uclk: uclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_USB_CLOCK_DIV_5>;
+				clk-div = <RA_USB_CLOCK_DIV_5>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			fclk: fclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				#clock-cells = <2>;
 				status = "okay";
 			};

--- a/dts/arm/renesas/ra/ra6/r7fa6m3ax.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m3ax.dtsi
@@ -156,45 +156,45 @@
 
 			iclk: iclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclka: pclka {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkb: pclkb {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkc: pclkc {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkd: pclkd {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			bclk: bclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				bclkout: bclkout {
 					compatible = "renesas,ra-cgc-busclk";
-					clk_out_div = <2>;
+					clk-out-div = <2>;
 					sdclk = <1>;
 					#clock-cells = <0>;
 				};
@@ -204,14 +204,14 @@
 
 			uclk: uclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_USB_CLOCK_DIV_5>;
+				clk-div = <RA_USB_CLOCK_DIV_5>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			fclk: fclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				#clock-cells = <2>;
 				status = "okay";
 			};

--- a/dts/arm/renesas/ra/ra6/r7fa6m4ax.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m4ax.dtsi
@@ -197,45 +197,45 @@
 
 			iclk: iclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_1>;
+				clk-div = <RA_SYS_CLOCK_DIV_1>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclka: pclka {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkb: pclkb {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkc: pclkc {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkd: pclkd {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			bclk: bclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				bclkout: bclkout {
 					compatible = "renesas,ra-cgc-busclk";
-					clk_out_div = <2>;
+					clk-out-div = <2>;
 					sdclk = <0>;
 					#clock-cells = <0>;
 				};
@@ -245,7 +245,7 @@
 
 			fclk: fclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				#clock-cells = <2>;
 				status = "okay";
 			};

--- a/dts/arm/renesas/ra/ra6/r7fa6m5xh.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m5xh.dtsi
@@ -257,45 +257,45 @@
 
 			iclk: iclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_1>;
+				clk-div = <RA_SYS_CLOCK_DIV_1>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclka: pclka {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkb: pclkb {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkc: pclkc {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkd: pclkd {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			bclk: bclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				bclkout: bclkout {
 					compatible = "renesas,ra-cgc-busclk";
-					clk_out_div = <2>;
+					clk-out-div = <2>;
 					sdclk = <0>;
 					#clock-cells = <0>;
 				};
@@ -305,7 +305,7 @@
 
 			fclk: fclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				#clock-cells = <2>;
 				status = "okay";
 			};

--- a/dts/arm/renesas/ra/ra8/r7fa8d1xh.dtsi
+++ b/dts/arm/renesas/ra/ra8/r7fa8d1xh.dtsi
@@ -90,59 +90,59 @@
 
 			cpuclk: cpuclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_1>;
+				clk-div = <RA_SYS_CLOCK_DIV_1>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			iclk: iclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclka: pclka {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkb: pclkb {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_8>;
+				clk-div = <RA_SYS_CLOCK_DIV_8>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkc: pclkc {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_8>;
+				clk-div = <RA_SYS_CLOCK_DIV_8>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkd: pclkd {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclke: pclke {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			bclk: bclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				bclkout: bclkout {
 					compatible = "renesas,ra-cgc-busclk";
-					clk_out_div = <2>;
+					clk-out-div = <2>;
 					sdclk = <1>;
 					#clock-cells = <0>;
 				};
@@ -152,7 +152,7 @@
 
 			fclk: fclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_8>;
+				clk-div = <RA_SYS_CLOCK_DIV_8>;
 				#clock-cells = <2>;
 				status = "okay";
 			};

--- a/dts/arm/renesas/ra/ra8/r7fa8m1xh.dtsi
+++ b/dts/arm/renesas/ra/ra8/r7fa8m1xh.dtsi
@@ -90,59 +90,59 @@
 
 			cpuclk: cpuclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_1>;
+				clk-div = <RA_SYS_CLOCK_DIV_1>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			iclk: iclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclka: pclka {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkb: pclkb {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_8>;
+				clk-div = <RA_SYS_CLOCK_DIV_8>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkc: pclkc {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_8>;
+				clk-div = <RA_SYS_CLOCK_DIV_8>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkd: pclkd {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclke: pclke {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			bclk: bclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				bclkout: bclkout {
 					compatible = "renesas,ra-cgc-busclk";
-					clk_out_div = <2>;
+					clk-out-div = <2>;
 					sdclk = <1>;
 					#clock-cells = <0>;
 				};
@@ -152,7 +152,7 @@
 
 			fclk: fclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_8>;
+				clk-div = <RA_SYS_CLOCK_DIV_8>;
 				#clock-cells = <2>;
 				status = "okay";
 			};

--- a/dts/arm/renesas/ra/ra8/r7fa8t1xh.dtsi
+++ b/dts/arm/renesas/ra/ra8/r7fa8t1xh.dtsi
@@ -90,59 +90,59 @@
 
 			cpuclk: cpuclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_1>;
+				clk-div = <RA_SYS_CLOCK_DIV_1>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			iclk: iclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclka: pclka {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkb: pclkb {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_8>;
+				clk-div = <RA_SYS_CLOCK_DIV_8>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkc: pclkc {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_8>;
+				clk-div = <RA_SYS_CLOCK_DIV_8>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclkd: pclkd {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			pclke: pclke {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_2>;
+				clk-div = <RA_SYS_CLOCK_DIV_2>;
 				#clock-cells = <2>;
 				status = "okay";
 			};
 
 			bclk: bclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_4>;
+				clk-div = <RA_SYS_CLOCK_DIV_4>;
 				bclkout: bclkout {
 					compatible = "renesas,ra-cgc-busclk";
-					clk_out_div = <2>;
+					clk-out-div = <2>;
 					sdclk = <1>;
 					#clock-cells = <0>;
 				};
@@ -152,7 +152,7 @@
 
 			fclk: fclk {
 				compatible = "renesas,ra-cgc-pclk";
-				clk_div = <RA_SYS_CLOCK_DIV_8>;
+				clk-div = <RA_SYS_CLOCK_DIV_8>;
 				#clock-cells = <2>;
 				status = "okay";
 			};

--- a/dts/bindings/clock/renesas,ra-cgc-busclk.yaml
+++ b/dts/bindings/clock/renesas,ra-cgc-busclk.yaml
@@ -8,7 +8,7 @@ compatible: "renesas,ra-cgc-busclk"
 include: [clock-controller.yaml, base.yaml]
 
 properties:
-  clk_out_div:
+  clk-out-div:
     type: int
     enum:
     - 0

--- a/dts/bindings/clock/renesas,ra-cgc-pclk.yaml
+++ b/dts/bindings/clock/renesas,ra-cgc-pclk.yaml
@@ -8,10 +8,10 @@ compatible: "renesas,ra-cgc-pclk"
 include: [clock-controller.yaml, base.yaml]
 
 properties:
-  clk_src:
+  clk-src:
     type: int
 
-  clk_div:
+  clk-div:
     type: int
     required: true
     description: Prescale divider to calculate the subclock frequency from the


### PR DESCRIPTION
`-` is preferred over `_` in devicetree property names. Since, change `clk_src`, `clk_div`, and `clk_out_div` to `clk-src`, `clk-div`, and `clk-out-div`.