### PR TITLE
RFC: drivers: uart: async: Keep receiver opened when flow control enabled

### DIFF
--- a/include/zephyr/drivers/uart.h
+++ b/include/zephyr/drivers/uart.h
@@ -179,11 +179,12 @@ typedef void (*uart_irq_config_func_t)(const struct device *dev);
  *    no longer used by the driver. It will immediately follow #UART_RX_RDY event.
  *    Depending on the implementation buffer may be released when it is completely
  *    or partially filled.
- * 5. If there was second buffer provided, it will become current buffer and
+ * 5. If there was a second buffer provided, it will become current buffer and
  *    we start again at point 2.
- *    If no second buffer was specified receiving is stopped and
- *    #UART_RX_DISABLED event is generated. After that whole process can be
- *    repeated.
+ *    If no second buffer was specified and flow control is not enabled receiving
+ *    is stopped and #UART_RX_DISABLED event is generated. Receiver is in the
+ *    initial state. In case of flow control receiver is kept enabled and
+ *    reception is suspended until next buffer is provided.
  *
  * Any time during reception #UART_RX_STOPPED event can occur. if there is any
  * data received, #UART_RX_RDY event will be generated. It will be followed by


### PR DESCRIPTION
When flow control is enabled then when next RX buffer is not provided on time it is expected that receiver will be suspended and transmission is prevented using control lines. In that case receiving RX_DISABLED is misleading thus it should not be generated. In case of flow control receiver can only be explicitly disabled using uart_rx_disable.

On the other hand, when flow control is not used then receiver is enabled as long as it has reception buffer provided and is closed automatically if there is no buffer.