### PR TITLE
drivers: dma: stm32: only clear busy flag when transfer is complete

### DIFF
--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -110,9 +110,6 @@ static void dma_stm32_irq_handler(const struct device *dev, uint32_t id)
 #else
 	callback_arg = id + STM32_DMA_STREAM_OFFSET;
 #endif /* CONFIG_DMAMUX_STM32 */
-	if (!IS_ENABLED(CONFIG_DMAMUX_STM32)) {
-		stream->busy = false;
-	}
 
 	/* The dma stream id is in range from STM32_DMA_STREAM_OFFSET..<dma-requests> */
 	if (stm32_dma_is_ht_irq_active(dma, id)) {
@@ -122,12 +119,10 @@ static void dma_stm32_irq_handler(const struct device *dev, uint32_t id)
 		}
 		stream->dma_callback(dev, stream->user_data, callback_arg, DMA_STATUS_BLOCK);
 	} else if (stm32_dma_is_tc_irq_active(dma, id)) {
-#ifdef CONFIG_DMAMUX_STM32
 		/* Circular buffer never stops receiving as long as peripheral is enabled */
 		if (!stream->cyclic) {
 			stream->busy = false;
 		}
-#endif
 		/* Let HAL DMA handle flags on its own */
 		if (!stream->hal_override) {
 			dma_stm32_clear_tc(dma, id);
@@ -139,6 +134,7 @@ static void dma_stm32_irq_handler(const struct device *dev, uint32_t id)
 				     callback_arg, -EIO);
 	} else {
 		LOG_ERR("Transfer Error.");
+		stream->busy = false;
 		dma_stm32_dump_stream_irq(dev, id);
 		dma_stm32_clear_stream_irq(dev, id);
 		stream->dma_callback(dev, stream->user_data,

--- a/drivers/dma/dma_stm32_bdma.h
+++ b/drivers/dma/dma_stm32_bdma.h
@@ -28,6 +28,7 @@ struct bdma_stm32_channel {
 	uint32_t dst_size;
 	void *user_data; /* holds the client data */
 	dma_callback_t bdma_callback;
+	bool cyclic;
 };
 
 struct bdma_stm32_data {

--- a/drivers/dma/dma_stm32u5.c
+++ b/drivers/dma/dma_stm32u5.c
@@ -264,7 +264,6 @@ static void dma_stm32_irq_handler(const struct device *dev, uint32_t id)
 		return;
 	}
 	callback_arg = id + STM32_DMA_STREAM_OFFSET;
-	stream->busy = false;
 
 	/* The dma stream id is in range from STM32_DMA_STREAM_OFFSET..<dma-requests> */
 	if (stm32_dma_is_ht_irq_active(dma, id)) {
@@ -274,6 +273,8 @@ static void dma_stm32_irq_handler(const struct device *dev, uint32_t id)
 		}
 		stream->dma_callback(dev, stream->user_data, callback_arg, DMA_STATUS_BLOCK);
 	} else if (stm32_dma_is_tc_irq_active(dma, id)) {
+		/* Assuming not cyclic transfer */
+		stream->busy = false;
 		/* Let HAL DMA handle flags on its own */
 		if (!stream->hal_override) {
 			dma_stm32_clear_tc(dma, id);
@@ -281,6 +282,7 @@ static void dma_stm32_irq_handler(const struct device *dev, uint32_t id)
 		stream->dma_callback(dev, stream->user_data, callback_arg, DMA_STATUS_COMPLETE);
 	} else {
 		LOG_ERR("Transfer Error.");
+		stream->busy = false;
 		dma_stm32_dump_stream_irq(dev, id);
 		dma_stm32_clear_stream_irq(dev, id);
 		stream->dma_callback(dev, stream->user_data,
@@ -404,14 +406,13 @@ static int dma_stm32_configure(const struct device *dev,
 		return -EINVAL;
 	}
 
-	/*
-	 * STM32's circular mode will auto reset both source address
-	 * counter and destination address counter.
+	/* Continuous transfers are supported by hardware but not implemented
+	 * by this driver
 	 */
-	if (config->head_block->source_reload_en !=
+	if (config->head_block->source_reload_en ||
 		config->head_block->dest_reload_en) {
-		LOG_ERR("source_reload_en and dest_reload_en must "
-			"be the same.");
+		LOG_ERR("source_reload_en and dest_reload_en not "
+			"implemented.");
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
The STM32 DMA driver can provide interrupts for transfers not yet complete.

However, the current implementation will clear the busy flag for all interrupts when CONFIG_DMAMUX_STM32 is not enabled. The previous fix for when CONFIG_DMAMUX_STM32 is enabled should also apply when not enabled. Also if CONFIG_DMAMUX_STM32 is enabled busy flag will not be cleared when error interrupts occur.

With this change, the busy flag is only cleared when completion interrupts in non-cyclic mode or error interrupts occur. These are the cases where transfer will not continue.