### PR TITLE
modules: hal_nordic: dvfs: queue request when busy

### DIFF
--- a/modules/hal_nordic/nrfs/dvfs/ld_dvfs_handler.h
+++ b/modules/hal_nordic/nrfs/dvfs/ld_dvfs_handler.h
@@ -17,7 +17,6 @@ extern "C" {
  * @brief Function to request LD frequency change.
  *
  * @param frequency requested frequency setting from enum dvfs_frequency_setting.
- * @return EBUSY                  Frequency change request pending.
  * @return EAGAIN                 DVFS init in progress.
  * @return ENXIO                  Not supported frequency settings.
  * @return NRFS_SUCCESS           Request sent successfully.


### PR DESCRIPTION
Added one element queue to change frequency setting function, when previous dvfs sequence is still in
progress. Thanks to this EBUSY status will not be
longer reported and last frequency setting will be queued and applied as soon as pending change is done. This is needed by clock control.