### PR TITLE
tests: net: cm: Increase event wait time

### DIFF
--- a/tests/net/conn_mgr_monitor/src/main.c
+++ b/tests/net/conn_mgr_monitor/src/main.c
@@ -24,7 +24,7 @@
 #include <zephyr/logging/log.h>
 
 /* Time to wait for NET_MGMT events to finish firing */
-#define EVENT_WAIT_TIME K_MSEC(1)
+#define EVENT_WAIT_TIME K_MSEC(10)
 
 
 /* Time to wait for IPv6 DAD-gated events to finish.


### PR DESCRIPTION
This was seen in CI
```
START - test_cycle_ready_CC

  Assertion failed at ...tests/net/conn_mgr_monitor/src/main.c:262:
    cycle_ready_ifaces: (stats.conn_count_gen not equal to 1)
    NET_EVENT_L4_CONNECTED should be fired when connectivity is gained.
FAIL - test_cycle_ready_CC in 0.015 seconds
```
As the event wait timeout is very short (1ms) by default, increase it to 10ms so that we will not miss the event.