### PR TITLE
Hotfix for #78099 - Segfault on nrf5340 bsim simulations during IPC init

### DIFF
--- a/boards/ezurio/bl5340_dvk/bl5340_dvk_nrf5340_cpuapp_partition_conf.dtsi
+++ b/boards/ezurio/bl5340_dvk/bl5340_dvk_nrf5340_cpuapp_partition_conf.dtsi
@@ -57,5 +57,5 @@
 	reg = <0x20040000 0x30000>;
 };
 
-/* Include default shared RAM configuration file */
-#include <common/nordic/nrf5340_shared_sram_partition.dtsi>
+/* Include shared RAM configuration file */
+#include "bl5340_dvk_nrf5340_shared_sram_planning_conf.dtsi"

--- a/boards/ezurio/bl5340_dvk/bl5340_dvk_nrf5340_cpunet_common.dtsi
+++ b/boards/ezurio/bl5340_dvk/bl5340_dvk_nrf5340_cpunet_common.dtsi
@@ -63,5 +63,5 @@
 	};
 };
 
-/* Include default shared RAM configuration file */
-#include <common/nordic/nrf5340_shared_sram_partition.dtsi>
+/* Include shared RAM configuration file */
+#include "bl5340_dvk_nrf5340_shared_sram_planning_conf.dtsi"

--- a/boards/ezurio/bl5340_dvk/bl5340_dvk_nrf5340_shared_sram_planning_conf.dtsi
+++ b/boards/ezurio/bl5340_dvk/bl5340_dvk_nrf5340_shared_sram_planning_conf.dtsi
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ * Copyright (c) 2021 Laird Connectivity
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Default shared SRAM planning when building for BL5340 DVK.
+ * This file is included by both nRF5340 CPUAPP (Application MCU)
+ * and nRF5340 CPUNET (Network MCU).
+ * - 64 kB SRAM allocated as Shared memory (sram0_shared)
+ * - Region defined after the image SRAM of Application MCU
+ */
+
+/ {
+	chosen {
+		/* shared memory reserved for the inter-processor communication */
+		zephyr,ipc_shm = &sram0_shared;
+	};
+
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		sram0_shared: memory@20070000 {
+			/* SRAM allocated to shared memory */
+			reg = <0x20070000 0x10000>;
+		};
+	};
+};

--- a/dts/arm/nordic/nrf5340_cpuapp_ipc.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp_ipc.dtsi
@@ -5,14 +5,12 @@
  */
 
 ipc0: ipc0 {
-	compatible = "zephyr,ipc-icbmsg";
-	status = "okay";
+	compatible = "zephyr,ipc-openamp-static-vrings";
+	memory-region = <&sram0_shared>;
 	mboxes = <&mbox 0>, <&mbox 1>;
 	mbox-names = "tx", "rx";
-	tx-region = <&cpuapp_cpunet_ipc_shm>;
-	rx-region = <&cpunet_cpuapp_ipc_shm>;
-	tx-blocks = <32>;
-	rx-blocks = <32>;
+	role = "host";
+	status = "okay";
 
 	bt_hci_ipc0: bt_hci_ipc0 {
 		compatible = "zephyr,bt-hci-ipc";

--- a/dts/arm/nordic/nrf5340_cpunet.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet.dtsi
@@ -347,14 +347,12 @@
 	/* Default IPC description */
 	ipc {
 		ipc0: ipc0 {
-			compatible = "zephyr,ipc-icbmsg";
-			status = "okay";
+			compatible = "zephyr,ipc-openamp-static-vrings";
+			memory-region = <&sram0_shared>;
 			mboxes = <&mbox 0>, <&mbox 1>;
 			mbox-names = "rx", "tx";
-			tx-region = <&cpunet_cpuapp_ipc_shm>;
-			rx-region = <&cpuapp_cpunet_ipc_shm>;
-			tx-blocks = <32>;
-			rx-blocks = <32>;
+			role = "remote";
+			status = "okay";
 		};
 	};
 };

--- a/dts/common/nordic/nrf5340_shared_sram_partition.dtsi
+++ b/dts/common/nordic/nrf5340_shared_sram_partition.dtsi
@@ -14,9 +14,7 @@
  * the memory range allocated to the non-secure image (sram0_ns).
  *
  * By default the last 64 kB of application core SRAM is allocated as shared
- * memory (sram0_shared) which is divided in:
- * - 32 kB CPUAPP to CPUNET communication (cpuapp_cpunet_ipc_shm)
- * - 32 kB CPUNET to CPUAPP communication (cpunet_cpuapp_ipc_shm)
+ * memory (sram0_shared).
  */
 
 / {
@@ -30,18 +28,8 @@
 		ranges;
 
 		sram0_shared: memory@20070000 {
-			#address-cells = <1>;
-			#size-cells = <1>;
 			/* Last 64 kB of sram0 */
 			reg = <0x20070000 0x10000>;
-
-			cpuapp_cpunet_ipc_shm: memory@20070000 {
-				reg = <0x20070000 DT_SIZE_K(32)>;
-			};
-
-			cpunet_cpuapp_ipc_shm: memory@20078000 {
-				reg = <0x20078000 DT_SIZE_K(32)>;
-			};
 		};
 	};
 };


### PR DESCRIPTION
This reverts commit 518de763a6f096ed5e217d9dd0688a11a099407a.

This commit switched nrf5340 devices to use the icbmsg IPC backend.
Unfortunately this backend is not currently supported in the nrf5340bsim target (it is not properly configured) which results in a segfault during its initialization. As this issue is currently blocking CI for all BT development in Zephyr, let's revert this provisionally while we add support for it.

See for more info.
- https://github.com/zephyrproject-rtos/zephyr/issues/78099

Reverted PR:
- https://github.com/zephyrproject-rtos/zephyr/pull/76729
