### PR TITLE
doc: add missing documentation in PR76408

### DIFF
--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -40,6 +40,9 @@ Mbed TLS
 
 * The Kconfig options ``CONFIG_MBEDTLS_TLS_VERSION_1_0`` and ``CONFIG_MBEDTLS_TLS_VERSION_1_1``
   have been removed because Mbed TLS doesn't support TLS 1.0 and 1.1 anymore since v3.0. (:github:`76833`)
+* The following Kconfig symbols were renamed (:github:`76408`):
+  * ``CONFIG_MBEDTLS_ENTROPY_ENABLED`` is now :kconfig:option:``CONFIG_MBEDTLS_ENTROPY_C``,
+  * ``CONFIG_MBEDTLS_ZEPHYR_ENTROPY`` is now :kconfig:option:``CONFIG_MBEDTLS_ENTROPY_POLL_ZEPHYR``.
 
 Trusted Firmware-M
 ==================

--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -315,6 +315,11 @@ Libraries / Subsystems
 
   * Mbed TLS was updated to version 3.6.1. The release notes can be found at:
     https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.1
+  * The Kconfig symbol :kconfig:option:`CONFIG_MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG_ALLOW_NON_CSPRNG`
+    was added to allow ``psa_get_random()`` to make use of non-cryptographically
+    secure random sources when :kconfig:option:`CONFIG_MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG`
+    is also enabled. This is only meant to be used for test purposes, not in production.
+    (:github:`76408`)
 
 * CMSIS-NN
 


### PR DESCRIPTION
PR #76408 introduced some kconfig changes (some symbols were renamed while a new one was added), but none of these were documented. This PR covers this gap amending both migration guide and release notes.