### PR TITLE
modules: lvgl: provide alignment definition

### DIFF
--- a/modules/lvgl/include/lv_conf.h
+++ b/modules/lvgl/include/lv_conf.h
@@ -8,6 +8,8 @@
 #ifndef ZEPHYR_MODULES_LVGL_LV_CONF_H_
 #define ZEPHYR_MODULES_LVGL_LV_CONF_H_
 
+#include <zephyr/toolchain.h>
+
 /* Memory manager settings */
 
 #define LV_MEMCPY_MEMSET_STD 1
@@ -41,6 +43,9 @@
 #define LV_SPRINTF_INCLUDE "stdio.h"
 #define lv_snprintf        snprintf
 #define lv_vsnprintf       vsnprintf
+
+/* Provide definition to align LVGL buffers */
+#define LV_ATTRIBUTE_MEM_ALIGN __aligned(CONFIG_LV_ATTRIBUTE_MEM_ALIGN_SIZE)
 
 /*
  * Needed because of a workaround for a GCC bug,


### PR DESCRIPTION
For some systems, the display peripheral or GPU requires that buffers be aligned on a boundary for optimal performance. We already align display buffers using CONFIG_LV_ATTRIBUTE_MEM_ALIGN_SIZE, but some applications will rely on the definition of LV_ATTRIBUTE_MEM_ALIGN. Provide this definition so those buffers will be aligned as well.