### PR TITLE
drivers: i3c: add support for setaasa initialization

### DIFF
--- a/drivers/i3c/i3c_shell.c
+++ b/drivers/i3c/i3c_shell.c
@@ -550,7 +550,8 @@ static int cmd_i3c_ccc_setaasa(const struct shell *shell_ctx, size_t argc, char 
 		SYS_SLIST_FOR_EACH_NODE(&data->attached_dev.devices.i3c, node) {
 			struct i3c_device_desc *desc =
 				CONTAINER_OF(node, struct i3c_device_desc, node);
-			if ((desc->dynamic_addr == 0) && (desc->static_addr != 0)) {
+			if ((desc->supports_setaasa) && (desc->dynamic_addr == 0) &&
+			    (desc->static_addr != 0)) {
 				desc->dynamic_addr = desc->static_addr;
 			}
 		}

--- a/dts/bindings/i3c/i3c-device.yaml
+++ b/dts/bindings/i3c/i3c-device.yaml
@@ -61,3 +61,9 @@ properties:
     type: int
     description: |
       Dynamic address to be assigned to the device.
+
+  supports-setaasa:
+    type: boolean
+    description: |
+      Indicates if the device supports the CCC SETAASA. If true, it will
+      be used as an optimization for bus initialization.

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -950,6 +950,14 @@ struct i3c_device_desc {
 	const uint8_t init_dynamic_addr;
 
 	/**
+	 * Device support for SETAASA
+	 *
+	 * This will be used as an optimization for bus initializtion if the
+	 * device supports SETAASA.
+	 */
+	const bool supports_setaasa;
+
+	/**
 	 * Dynamic Address for this target device used for communication.
 	 *
 	 * This is to be set by the controller driver in one of

--- a/include/zephyr/drivers/i3c/devicetree.h
+++ b/include/zephyr/drivers/i3c/devicetree.h
@@ -71,6 +71,7 @@ extern "C" {
 		       | DT_PROP_BY_IDX(node_id, reg, 2),		\
 		.init_dynamic_addr =					\
 			DT_PROP_OR(node_id, assigned_address, 0),	\
+		.supports_setaasa = DT_PROP(node_id, supports_setaasa), \
 	},
 
 /**


### PR DESCRIPTION
Adds a new DTS prop for i3c devices as support for the CCC SETAASA requires prior knowledge of the target if it supports it according to i3c spec v1.1.1 section 5.19.3.23.

This will be used as an optimization for bus initialization.