### PR TITLE
same70b: Add support for SMC for SAME70-series

### DIFF
--- a/drivers/memc/memc_sam_smc.c
+++ b/drivers/memc/memc_sam_smc.c
@@ -75,10 +75,14 @@ static int memc_smc_init(const struct device *dev)
 	SMC_CYCLE_NWE_CYCLE(DT_PROP_BY_IDX(node_id, atmel_smc_cycle_timing, 0))		\
 	| SMC_CYCLE_NRD_CYCLE(DT_PROP_BY_IDX(node_id, atmel_smc_cycle_timing, 1))
 
+#define BUS_WIDTH(node_id) COND_CODE_1(DT_ENUM_IDX(node_id, atmel_smc_bus_width), \
+			   (SMC_MODE_DBW_16_BIT), (0))
+
 #define BANK_CONFIG(node_id)								\
 	{										\
 		.cs = DT_REG_ADDR(node_id),						\
-		.mode = COND_CODE_1(DT_ENUM_IDX(node_id, atmel_smc_write_mode),		\
+		.mode = BUS_WIDTH(node_id)                                              \
+			| COND_CODE_1(DT_ENUM_IDX(node_id, atmel_smc_write_mode),	\
 				    (SMC_MODE_WRITE_MODE), (0))				\
 			| COND_CODE_1(DT_ENUM_IDX(node_id, atmel_smc_read_mode),	\
 				      (SMC_MODE_READ_MODE), (0)),			\

--- a/dts/arm/atmel/samx7x.dtsi
+++ b/dts/arm/atmel/samx7x.dtsi
@@ -472,6 +472,15 @@
 			clocks = <&pmc PMC_TYPE_PERIPHERAL 46>;
 			status = "disabled";
 		};
+
+		smc: smc@40080000 {
+			compatible = "atmel,sam-smc";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40080000 0x4000>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 9>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/dts/bindings/memory-controllers/atmel,sam-smc.yaml
+++ b/dts/bindings/memory-controllers/atmel,sam-smc.yaml
@@ -148,3 +148,17 @@ child-binding:
         is encoded in 9 bits where the two highest bits are multiplied
         with an offset of 256.
         Effective value for each element: 256 x cycle[8:7] + cycle[6:0]
+
+    atmel,smc-bus-width:
+      type: int
+      default: 8
+      description: |
+        Bus Width configuration for the Static Memory Controller that
+        is wired to the external device.
+        SMC on SAMx7 supports 8/16-bit bus width, on SAM4
+        only 8-bit data buses are supported.
+
+        The default value is 8-bit data buses.
+      enum:
+        - 8
+        - 16

--- a/west.yml
+++ b/west.yml
@@ -157,7 +157,7 @@ manifest:
       groups:
         - hal
     - name: hal_atmel
-      revision: dde7a36d00bd5dafd1ffcd8d243dfbceeb20e856
+      revision: pull/41/head
       path: modules/hal/atmel
       groups:
         - hal


### PR DESCRIPTION
The Static Memory Controller driver (which is already implemented for SAM4S in the existing memc) is not enabled for SAME70, nor does it support the 16-bit memory width of that SMC. This PR (with the accompanying one in [hal_atmel](https://github.com/zephyrproject-rtos/hal_atmel/pull/41)) adds this support.

Tested on a custom board, and tests for SAM4S build locally (tests/drivers/memc/ram).

- Add smc definition in same70.dtsi.
- Add atmel,smc-bus-width to atmel,sam-smc dts bindings. Update driver to select bus width from DT.