### PR TITLE
bugfix: soc: esp32: disable interrupts in flash operation

### DIFF
--- a/soc/espressif/esp32c3/soc.c
+++ b/soc/espressif/esp32c3/soc.c
@@ -21,6 +21,7 @@
 #include <soc/interrupt_reg.h>
 #include <esp_private/spi_flash_os.h>
 #include "esp_private/esp_mmu_map_private.h"
+#include <esp_flash_internal.h>
 
 #include <zephyr/drivers/interrupt_controller/intc_esp32c3.h>
 
@@ -66,27 +67,13 @@ void __attribute__((section(".iram1"))) __esp_platform_start(void)
 	REG_CLR_BIT(SYSTEM_WIFI_CLK_EN_REG, SYSTEM_WIFI_CLK_SDIOSLAVE_EN);
 	SET_PERI_REG_MASK(SYSTEM_WIFI_CLK_EN_REG, SYSTEM_WIFI_CLK_EN);
 
-#ifdef CONFIG_SOC_FLASH_ESP32
-	esp_mspi_pin_init();
-
-	/**
-	 * This function initialise the Flash chip to the user-defined settings.
-	 *
-	 * In bootloader, we only init Flash (and MSPI) to a preliminary
-	 * state, for being flexible to different chips.
-	 * In this stage, we re-configure the Flash (and MSPI) to required configuration
-	 */
-	spi_flash_init_chip_state();
-
-	esp_mmu_map_init();
-
-#endif /*CONFIG_SOC_FLASH_ESP32*/
-
 	esp_timer_early_init();
 
-#if CONFIG_SOC_FLASH_ESP32
-	spi_flash_guard_set(&g_flash_guard_default_ops);
-#endif
+	esp_mspi_pin_init();
+
+	esp_flash_app_init();
+
+	esp_mmu_map_init();
 
 #endif /* !CONFIG_MCUBOOT */
 

--- a/soc/espressif/esp32c6/soc.c
+++ b/soc/espressif/esp32c6/soc.c
@@ -19,6 +19,7 @@
 #include <soc/interrupt_reg.h>
 #include <esp_private/spi_flash_os.h>
 #include "esp_private/esp_mmu_map_private.h"
+#include <esp_flash_internal.h>
 
 #include <zephyr/drivers/interrupt_controller/intc_esp32c3.h>
 
@@ -58,9 +59,9 @@ void IRAM_ATTR __esp_platform_start(void)
 
 	esp_timer_early_init();
 
-#if CONFIG_SOC_FLASH_ESP32
-	spi_flash_guard_set(&g_flash_guard_default_ops);
-#endif
+	esp_mspi_pin_init();
+
+	esp_flash_app_init();
 
 	esp_mmu_map_init();
 

--- a/soc/espressif/esp32s2/soc.c
+++ b/soc/espressif/esp32s2/soc.c
@@ -98,10 +98,11 @@ void __attribute__((section(".iram1"))) __esp_platform_start(void)
 	esp_config_data_cache_mode();
 	esp_rom_Cache_Enable_DCache(0);
 
-#ifdef CONFIG_SOC_FLASH_ESP32
+	esp_timer_early_init();
+
 	esp_mspi_pin_init();
-	spi_flash_init_chip_state();
-#endif /* CONFIG_SOC_FLASH_ESP32 */
+
+	esp_flash_app_init();
 
 	esp_mmu_map_init();
 
@@ -129,16 +130,6 @@ void __attribute__((section(".iram1"))) __esp_platform_start(void)
 
 #endif /* CONFIG_ESP_SPIRAM */
 
-	esp_timer_early_init();
-
-	/* Scheduler is not started at this point. Hence, guard functions
-	 * must be initialized after esp_spiram_init_cache which internally
-	 * uses guard functions. Setting guard functions before SPIRAM
-	 * cache initialization will result in a crash.
-	 */
-#if CONFIG_SOC_FLASH_ESP32 || CONFIG_ESP_SPIRAM
-	spi_flash_guard_set(&g_flash_guard_default_ops);
-#endif
 #endif /* !CONFIG_MCUBOOT */
 
 	esp_intr_initialize();

--- a/soc/espressif/esp32s3/soc.c
+++ b/soc/espressif/esp32s3/soc.c
@@ -151,9 +151,11 @@ void IRAM_ATTR __esp_platform_start(void)
 
 	esp_mspi_pin_init();
 
-	spi_flash_init_chip_state();
+	esp_flash_app_init();
 
 	mspi_timing_flash_tuning();
+
+	esp_mmu_map_init();
 
 	esp_mmu_map_init();
 

--- a/west.yml
+++ b/west.yml
@@ -157,7 +157,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 87e7902d7184a8280b4d13bce79801a723f4ddd8
+      revision: 796b3f62af6dc10cb7c7953f73c81882d4011d8d
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
When interrupts are placed in flash, it needs to be disabled when flash operations are called. This is not happening in current v3.7.0 release, causing system to crash whenever flash operations and interrupts happens simultaneously.

Fixes #77952