### PR TITLE
net: http_server: Enable v4-to-v6 mapping by default

### DIFF
--- a/subsys/net/lib/http/Kconfig
+++ b/subsys/net/lib/http/Kconfig
@@ -34,6 +34,7 @@ config HTTP_SERVER
 	select HTTP_PARSER
 	select HTTP_PARSER_URL
 	select EXPERIMENTAL
+	imply NET_IPV4_MAPPING_TO_IPV6 if NET_IPV4 && NET_IPV6
 	help
 	  HTTP1 and HTTP2 server support.
 


### PR DESCRIPTION
Fixing the regression caused by 3949873886a7 ("Allow service to be created with NULL host"). If the host parameter is null when creating the HTTP service, the IPv6 socket is created by default. This can cause issues if both IPv4 and IPv6 are enabled, like in HTTP server sample, and the HTTP client connection is done by IPv4.
To fix this, we need to enable IPv4-to-IPv6 mapping in order to allow IPv6 socket to serve a IPv4 connection. Allow also user to override this if needed.

Fixes #78112