### PR TITLE
modules: tfm: split security counter from version

### DIFF
--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -44,6 +44,11 @@ Mbed TLS
 Trusted Firmware-M
 ==================
 
+* The security counter used for the hardware rollback protection now comes explicitly from
+  :kconfig:option:`CONFIG_TFM_IMAGE_SECURITY_COUNTER`, instead of being automatically determined from
+  the image version. This has been changed as the implicit counter calculation is incompatible with
+  versions larger than ``0.0.1024`` (:github:`78128`).
+
 LVGL
 ====
 

--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -437,7 +437,7 @@ if (CONFIG_BUILD_WITH_TFM)
       ${pad_args}
       ${HEX_ADDR_ARGS_${SUFFIX}}
       ${ADD_${SUFFIX}_IMAGE_MIN_VER}
-      -s auto
+      -s ${CONFIG_TFM_IMAGE_SECURITY_COUNTER}
       --measured-boot-record
       -H ${CONFIG_ROM_START_OFFSET}
       ${INPUT_FILE}

--- a/modules/trusted-firmware-m/Kconfig.tfm
+++ b/modules/trusted-firmware-m/Kconfig.tfm
@@ -190,19 +190,14 @@ config TFM_IMAGE_VERSION_S
 	string "Version of the Secure Image"
 	default "0.0.0+0"
 	help
-	  MCUBoot may be configured to prevent rollback prevention based on image
-	  versions of both the secure firmware and non-secure firmware. This sets
-	  the secure firmware's version for rollback prevention. This version is
-	  also used for merged secure + non-secure builds
-	  (TFM_MCUBOOT_IMAGE_NUMBER == 1).
+	  Version of the secure image. This version is also used for merged
+	  secure + non-secure builds (TFM_MCUBOOT_IMAGE_NUMBER == 1).
 
 config TFM_IMAGE_VERSION_NS
 	string "Version of the Non-Secure Image"
 	default "0.0.0+0"
 	help
-	  MCUBoot may be configured to prevent rollback prevention based on image
-	  versions of both the secure firmware and non-secure firmware. This sets
-	  the non-secure firmware's version for rollback prevention.
+	  Version of the non-secure image.
 
 config TFM_BL2
 	bool "Add MCUboot to TFM"
@@ -239,6 +234,16 @@ config TFM_CONNECTION_BASED_SERVICE_API
 	  will result in compilation error.
 
 if TFM_BL2
+
+config TFM_IMAGE_SECURITY_COUNTER
+	int "Security counter value used for hardware rollback protection"
+	range 1 1024
+	default 1
+	help
+	  By default, TFM enables hardware rollback protection, which requires a security counter
+	  to be embedded in the image trailer. As per "Hardware-based downgrade prevention" in
+	  mcuboot/docs/design.md, this does not need to be incremented on every firmware update,
+	  but hardware rollback protection will only apply when this value is incremented.
 
 config TFM_MCUBOOT_SIGNATURE_TYPE
 	string "The signature type used to sign the secure and non-secure firmware images."


### PR DESCRIPTION
By default, TFM enables hardware rollback protection, which requires a security counter to be embedded in the image trailer. The default behaviour of constructing this counter from the image version breaks the TFM `boot_nv_security_counter_update` implementation once the version number is greater than `0.0.1024`. As such, explicitly specify the desired security counter value. As per the MCUboot docs, this does not need to be incremented on every firmware update.

Fixes #78128 