### PR TITLE
devicetree: add `DT_INST_NUM_IRQS()`

### DIFF
--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -4235,6 +4235,14 @@
 #define DT_INST_REG_SIZE(inst) DT_INST_REG_SIZE_BY_IDX(inst, 0)
 
 /**
+ * @brief Get a `DT_DRV_COMPAT`'s number of interrupts
+ *
+ * @param inst instance number
+ * @return number of interrupts
+ */
+#define DT_INST_NUM_IRQS(inst) DT_NUM_IRQS(DT_DRV_INST(inst))
+
+/**
  * @brief Get a `DT_DRV_COMPAT` interrupt level
  *
  * @param inst instance number

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -751,6 +751,9 @@ ZTEST(devicetree_api, test_irq)
 	/* DT_INST */
 	zassert_equal(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT), 1, "");
 
+	/* DT_INST_NUM_IRQS */
+	zassert_equal(DT_INST_NUM_IRQS(0), 3);
+
 	/* DT_INST_IRQ_HAS_IDX */
 	zassert_equal(DT_INST_IRQ_HAS_IDX(0, 0), 1, "");
 	zassert_equal(DT_INST_IRQ_HAS_IDX(0, 1), 1, "");


### PR DESCRIPTION
> [!NOTE]
> This PR is spinned-off from #77828 to declutter that PR, as the changes here are not specific to the irq-affinity implementation.

> [!IMPORTANT]
> This PR has to be backported to v3.7 if we want to backport #78140

Add `DT_INST_NUM_IRQS()` to get the number of interrupt lines of the current `DT_DRV_COMPAT`