### PR TITLE
boards: frdm_mcxc242: Add i2c support

### DIFF
--- a/boards/nxp/frdm_mcxc242/doc/index.rst
+++ b/boards/nxp/frdm_mcxc242/doc/index.rst
@@ -64,6 +64,8 @@ The ``frdm_mcxc242`` board target supports the following hardware features:
 +-----------+------------+-------------------------------------+
 | FLASH     | on-chip    | soc flash                           |
 +-----------+------------+-------------------------------------+
+| I2C       | on-chip    | i2c                                 |
++-----------+------------+-------------------------------------+
 
 
 Targets available

--- a/boards/nxp/frdm_mcxc242/frdm_mcxc242-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxc242/frdm_mcxc242-pinctrl.dtsi
@@ -16,4 +16,13 @@
 			slew-rate = "slow";
 		};
 	};
+	pinmux_i2c1: pinmux_i2c1 {
+		group0 {
+			pinmux = <I2C1_SCL_PTD7>,
+				<I2C1_SDA_PTD6>;
+			drive-strength = "low";
+			drive-open-drain;
+			slew-rate = "fast";
+		};
+	};
 };

--- a/boards/nxp/frdm_mcxc242/frdm_mcxc242.dts
+++ b/boards/nxp/frdm_mcxc242/frdm_mcxc242.dts
@@ -20,6 +20,7 @@
 		led2 = &red_led;
 		sw0 = &user_button_2;
 		sw1 = &user_button_3;
+		accel0 = &fxls8974;
 	};
 
 	chosen {
@@ -95,4 +96,18 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&pinmux_lpuart0>;
 	pinctrl-names = "default";
+};
+
+i2c1: &i2c1 {
+	status = "okay";
+	pinctrl-0 = <&pinmux_i2c1>;
+	pinctrl-names = "default";
+
+	fxls8974: fxls8974@18 {
+		status = "okay";
+		compatible = "nxp,fxls8974";
+		reg = <0x18>;
+		int1-gpios = <&gpioc 2 GPIO_ACTIVE_LOW>;
+		int2-gpios = <&gpioc 3 GPIO_ACTIVE_LOW>;
+	};
 };

--- a/boards/nxp/frdm_mcxc242/frdm_mcxc242.yaml
+++ b/boards/nxp/frdm_mcxc242/frdm_mcxc242.yaml
@@ -16,6 +16,7 @@ toolchain:
   - xtools
 supported:
   - gpio
+  - i2c
 testing:
   ignore_tags:
     - net


### PR DESCRIPTION
frmd_mcxc242 supports i2c, but it is not enabled.
Enable i2c and configure it to read accelerometer sensor on the board. Update board documentation. Test it using sample.sensor.accel_polling.