### PR TITLE
drivers: intc: plic: fix IRQ on every hart regardless of mapping

### DIFF
--- a/tests/drivers/interrupt_controller/intc_plic/Kconfig
+++ b/tests/drivers/interrupt_controller/intc_plic/Kconfig
@@ -7,4 +7,7 @@ config TEST_INTC_PLIC
 	help
 	   Declare some intc_plic.c functions in the global scope for verification.
 
+config TEST_INTC_PLIC_ALT_MAPPING
+	bool "Test alternate hartid - context mapping"
+
 source "Kconfig"

--- a/tests/drivers/interrupt_controller/intc_plic/alt_mapping.overlay
+++ b/tests/drivers/interrupt_controller/intc_plic/alt_mapping.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024 Meta Platforms
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/{
+	soc {
+		plic: interrupt-controller@c000000 {
+			riscv,max-priority = <7>;
+			riscv,ndev = < 1024 >;
+			reg = <0x0c000000 0x04000000>;
+			interrupts-extended = <
+				&hlic0 0x0b
+				&hlic1 0x0b &hlic1 0x09
+				&hlic2 0x0b &hlic2 0x09
+				&hlic3 0x0b &hlic3 0x09
+				&hlic4 0x0b &hlic4 0x09
+				&hlic5 0x0b &hlic5 0x09
+				&hlic6 0x0b &hlic6 0x09
+				&hlic7 0x0b &hlic7 0x09
+			>;
+			interrupt-controller;
+			compatible = "sifive,plic-1.0.0";
+			#address-cells = < 0x00 >;
+			#interrupt-cells = < 0x02 >;
+		};
+	};
+};

--- a/tests/drivers/interrupt_controller/intc_plic/src/main.c
+++ b/tests/drivers/interrupt_controller/intc_plic/src/main.c
@@ -29,3 +29,30 @@ ZTEST(intc_plic, test_local_irq_to_reg_offset)
 	zassert_equal(4, local_irq_to_reg_offset(0x3f));
 	zassert_equal(8, local_irq_to_reg_offset(0x40));
 }
+
+ZTEST(intc_plic, test_hart_context_mapping)
+{
+	extern const uint32_t plic_hart_contexts_0[];
+
+	if (!IS_ENABLED(CONFIG_TEST_INTC_PLIC_ALT_MAPPING)) {
+		/* Based on the default qemu_riscv64 devicetree */
+		zassert_equal(plic_hart_contexts_0[0], 0);
+		zassert_equal(plic_hart_contexts_0[1], 2);
+		zassert_equal(plic_hart_contexts_0[2], 4);
+		zassert_equal(plic_hart_contexts_0[3], 6);
+		zassert_equal(plic_hart_contexts_0[4], 8);
+		zassert_equal(plic_hart_contexts_0[5], 10);
+		zassert_equal(plic_hart_contexts_0[6], 12);
+		zassert_equal(plic_hart_contexts_0[7], 14);
+	} else {
+		/* Based on the definition in the `alt_mapping.overlay` */
+		zassert_equal(plic_hart_contexts_0[0], 0);
+		zassert_equal(plic_hart_contexts_0[1], 1);
+		zassert_equal(plic_hart_contexts_0[2], 3);
+		zassert_equal(plic_hart_contexts_0[3], 5);
+		zassert_equal(plic_hart_contexts_0[4], 7);
+		zassert_equal(plic_hart_contexts_0[5], 9);
+		zassert_equal(plic_hart_contexts_0[6], 11);
+		zassert_equal(plic_hart_contexts_0[7], 13);
+	}
+}

--- a/tests/drivers/interrupt_controller/intc_plic/testcase.yaml
+++ b/tests/drivers/interrupt_controller/intc_plic/testcase.yaml
@@ -1,7 +1,14 @@
+common:
+  platform_allow: qemu_riscv64
+  tags:
+    - drivers
+    - interrupt
+    - plic
+
 tests:
-  drivers.interrupt_controller.intc_plic:
-    tags:
-      - drivers
-      - interrupt
-      - plic
-    platform_allow: qemu_riscv64
+  drivers.interrupt_controller.intc_plic: {}
+  drivers.interrupt_controller.intc_plic.alt_mapping:
+    extra_args:
+      DTC_OVERLAY_FILE="./alt_mapping.overlay"
+    extra_configs:
+      - CONFIG_TEST_INTC_PLIC_ALT_MAPPING=y


### PR DESCRIPTION
Allow IRQs to work on every hart regardless of the mapping of the contexts.

> [!NOTE]
> This PR is spinned-off from #77828 to declutter that PR. It is also easier to backport this PR to v3.7

> [!IMPORTANT]
> depends on #78137

> [!IMPORTANT]
> Following this PR, PLIC will be able to properly notify all enabled cores in SMP when there's an interrupt.

Fixes #78138