### PR TITLE
STM32U0: provide support for TIMERS peripherals

### DIFF
--- a/boards/st/nucleo_u031r8/doc/index.rst
+++ b/boards/st/nucleo_u031r8/doc/index.rst
@@ -144,6 +144,8 @@ The Zephyr _nucleo_u031r8_ board configuration supports the following hardware f
 +-----------+------------+-------------------------------------+
 | I2C       | on-chip    | i2c                                 |
 +-----------+------------+-------------------------------------+
+| PWM       | on-chip    | pwm                                 |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.
 

--- a/boards/st/nucleo_u031r8/nucleo_u031r8.dts
+++ b/boards/st/nucleo_u031r8/nucleo_u031r8.dts
@@ -101,3 +101,25 @@
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
+
+&timers1 {
+	st,prescaler = <10000>;
+	status = "okay";
+
+	pwm1: pwm {
+		status = "okay";
+		pinctrl-0 = <&tim1_ch1_pa8>;
+		pinctrl-names = "default";
+	};
+};
+
+&timers2 {
+	st,prescaler = <10000>;
+	status = "okay";
+
+	pwm2: pwm {
+		pinctrl-0 = <&tim2_ch1_pa5>;
+		pinctrl-names = "default";
+		status = "okay";
+	};
+};

--- a/boards/st/nucleo_u031r8/nucleo_u031r8.yaml
+++ b/boards/st/nucleo_u031r8/nucleo_u031r8.yaml
@@ -9,6 +9,7 @@ supported:
   - dac
   - gpio
   - i2c
+  - pwm
   - usart
 ram: 12
 flash: 64

--- a/boards/st/nucleo_u083rc/doc/index.rst
+++ b/boards/st/nucleo_u083rc/doc/index.rst
@@ -150,6 +150,8 @@ The Zephyr nucleo_u083rc board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | I2C       | on-chip    | i2c                                 |
 +-----------+------------+-------------------------------------+
+| PWM       | on-chip    | pwm                                 |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.
 

--- a/boards/st/nucleo_u083rc/nucleo_u083rc.dts
+++ b/boards/st/nucleo_u083rc/nucleo_u083rc.dts
@@ -101,3 +101,25 @@
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
+
+&timers1 {
+	st,prescaler = <10000>;
+	status = "okay";
+
+	pwm1: pwm {
+		status = "okay";
+		pinctrl-0 = <&tim1_ch1_pa8>;
+		pinctrl-names = "default";
+	};
+};
+
+&timers2 {
+	st,prescaler = <10000>;
+	status = "okay";
+
+	pwm2: pwm {
+		pinctrl-0 = <&tim2_ch1_pa5>;
+		pinctrl-names = "default";
+		status = "okay";
+	};
+};

--- a/boards/st/nucleo_u083rc/nucleo_u083rc.yaml
+++ b/boards/st/nucleo_u083rc/nucleo_u083rc.yaml
@@ -11,6 +11,7 @@ supported:
   - dac
   - gpio
   - i2c
+  - pwm
   - usart
 ram: 40
 flash: 256

--- a/boards/st/stm32u083c_dk/doc/index.rst
+++ b/boards/st/stm32u083c_dk/doc/index.rst
@@ -163,6 +163,8 @@ The Zephyr stm32u083c_dk board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | I2C       | on-chip    | i2c                                 |
 +-----------+------------+-------------------------------------+
+| PWM       | on-chip    | pwm                                 |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.
 

--- a/boards/st/stm32u083c_dk/stm32u083c_dk.dts
+++ b/boards/st/stm32u083c_dk/stm32u083c_dk.dts
@@ -91,3 +91,25 @@
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
+
+&timers1 {
+	st,prescaler = <10000>;
+	status = "okay";
+
+	pwm1: pwm {
+		status = "okay";
+		pinctrl-0 = <&tim1_ch1_pa8>;
+		pinctrl-names = "default";
+	};
+};
+
+&timers2 {
+	st,prescaler = <10000>;
+	status = "okay";
+
+	pwm2: pwm {
+		pinctrl-0 = <&tim2_ch1_pa5>;
+		pinctrl-names = "default";
+		status = "okay";
+	};
+};

--- a/boards/st/stm32u083c_dk/stm32u083c_dk.yaml
+++ b/boards/st/stm32u083c_dk/stm32u083c_dk.yaml
@@ -11,6 +11,7 @@ supported:
   - dac
   - gpio
   - i2c
+  - pwm
   - usart
 ram: 40
 flash: 256

--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -246,7 +246,7 @@ static int get_tim_clk(const struct stm32_pclken *pclken, uint32_t *tim_clk)
 #endif
 	}
 #if !defined(CONFIG_SOC_SERIES_STM32C0X) && !defined(CONFIG_SOC_SERIES_STM32F0X) &&                \
-	!defined(CONFIG_SOC_SERIES_STM32G0X)
+	!defined(CONFIG_SOC_SERIES_STM32G0X) && !defined(CONFIG_SOC_SERIES_STM32U0X)
 	else {
 #if defined(CONFIG_SOC_SERIES_STM32MP1X)
 		apb_psc = (uint32_t)(READ_BIT(RCC->APB2DIVR, RCC_APB2DIVR_APB2DIV));

--- a/dts/arm/st/u0/stm32u0.dtsi
+++ b/dts/arm/st/u0/stm32u0.dtsi
@@ -8,6 +8,8 @@
 #include <arm/armv6-m.dtsi>
 #include <zephyr/dt-bindings/clock/stm32u0_clock.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/reset/stm32u0_reset.h>
 #include <freq.h>
@@ -253,6 +255,138 @@
 			status = "disabled";
 		};
 
+
+		timers1: timers@40012c00 {
+			compatible = "st,stm32-timers";
+			reg = <0x40012C00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000800>;
+			resets = <&rctl STM32_RESET(APB1H, 11U)>;
+			interrupts = <13 0>, <14 0>;
+			interrupt-names = "brk_up_trg_com", "cc";
+			st,prescaler = <0>;
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+		};
+
+		timers2: timers@40000000 {
+			compatible = "st,stm32-timers";
+			reg = <0x40000000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000001>;
+			resets = <&rctl STM32_RESET(APB1L, 0U)>;
+			interrupts = <15 0>;
+			interrupt-names = "global";
+			st,prescaler = <0>;
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+		};
+
+		timers3: timers@40000400 {
+			compatible = "st,stm32-timers";
+			reg = <0x40000400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000002>;
+			resets = <&rctl STM32_RESET(APB1L, 1U)>;
+			interrupts = <16 0>;
+			interrupt-names = "global";
+			st,prescaler = <0>;
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+		};
+
+		timers6: timers@40001000 {
+			compatible = "st,stm32-timers";
+			reg = <0x40001000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000010>;
+			resets = <&rctl STM32_RESET(APB1L, 4U)>;
+			interrupts = <17 0>;
+			interrupt-names = "combined";
+			st,prescaler = <0>;
+			status = "disabled";
+		};
+
+		timers7: timers@40001400 {
+			compatible = "st,stm32-timers";
+			reg = <0x40001400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000020>;
+			resets = <&rctl STM32_RESET(APB1L, 5U)>;
+			interrupts = <18 0>;
+			interrupt-names = "combined";
+			st,prescaler = <0>;
+			status = "disabled";
+		};
+
+		timers15: timers@40014000 {
+			compatible = "st,stm32-timers";
+			reg = <0x40014000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00010000>;
+			resets = <&rctl STM32_RESET(APB1H, 16U)>;
+			interrupts = <19 0>;
+			interrupt-names = "combined";
+			st,prescaler = <0>;
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+		};
+
+		timers16: timers@40014400 {
+			compatible = "st,stm32-timers";
+			reg = <0x40014400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00020000>;
+			resets = <&rctl STM32_RESET(APB1H, 17U)>;
+			interrupts = <20 0>;
+			interrupt-names = "global";
+			st,prescaler = <0>;
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+		};
 	};
 };
 

--- a/tests/drivers/counter/counter_basic_api/boards/nucleo_u083rc.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/nucleo_u083rc.overlay
@@ -1,0 +1,41 @@
+&timers2 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers3 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers6 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers7 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers15 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers16 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/stm32u083c_dk.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/stm32u083c_dk.overlay
@@ -1,0 +1,41 @@
+&timers2 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers3 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers6 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers7 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers15 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers16 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};


### PR DESCRIPTION
This PR adds Timers peripherals on the stm32U0 boards.

We will able to use counter and also generate PWM signals 