### PR TITLE
logging: fix failure report period

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -572,18 +572,21 @@ bool z_impl_log_process(void)
 		bool dropped_pend = z_log_dropped_pending();
 		bool unordered_pend = z_log_unordered_pending();
 
-		if ((dropped_pend || unordered_pend) &&
-		   (k_uptime_get() - last_failure_report) > CONFIG_LOG_FAILURE_REPORT_PERIOD) {
-			if (dropped_pend) {
-				dropped_notify();
-			}
+		if (dropped_pend || unordered_pend) {
+			uint64_t now = (uint64_t)k_uptime_get();
 
-			if (unordered_pend) {
-				unordered_notify();
+			if (now > last_failure_report + CONFIG_LOG_FAILURE_REPORT_PERIOD) {
+				if (dropped_pend) {
+					dropped_notify();
+				}
+
+				if (unordered_pend) {
+					unordered_notify();
+				}
+
+				last_failure_report = now;
 			}
 		}
-
-		last_failure_report += CONFIG_LOG_FAILURE_REPORT_PERIOD;
 	}
 
 	return z_log_msg_pending();


### PR DESCRIPTION
I noticed that CONFIG_LOG_FAILURE_REPORT_PERIOD Kconfig is not handled correctly in some scenarios.

That is, the "N messages dropped" reports may be generated more frequently than the default of 1000ms, which may waste the precious bandwidth in the case of slower logging backends and effectively cause even more drops.

For example, if some logs are processed very fast, the last_failure_report variable might be advanced faster than the current time, causing the "k_uptime_get() - last_failure_report" subtraction to underflow and always trigger the report.