### PR TITLE
net: dns: Add per socket user data for the dispatcher

### DIFF
--- a/subsys/net/lib/dns/dispatcher.c
+++ b/subsys/net/lib/dns/dispatcher.c
@@ -27,6 +27,10 @@ static sys_slist_t sockets;
 NET_BUF_POOL_DEFINE(dns_msg_pool, DNS_RESOLVER_BUF_CTR,
 		    DNS_RESOLVER_MAX_BUF_SIZE, 0, NULL);
 
+static struct socket_dispatch_table {
+	struct dns_socket_dispatcher *ctx;
+} dispatch_table[CONFIG_NET_SOCKETS_POLL_MAX];
+
 static int dns_dispatch(struct dns_socket_dispatcher *dispatcher,
 			int sock, struct sockaddr *addr, size_t addrlen,
 			struct net_buf *dns_data, size_t buf_len)
@@ -96,13 +100,16 @@ done:
 
 static int recv_data(struct net_socket_service_event *pev)
 {
-	struct dns_socket_dispatcher *dispatcher = pev->user_data;
+	struct socket_dispatch_table *table = pev->user_data;
+	struct dns_socket_dispatcher *dispatcher;
 	socklen_t optlen = sizeof(int);
 	struct net_buf *dns_data = NULL;
 	struct sockaddr addr;
 	size_t addrlen;
 	int family, sock_error;
 	int ret = 0, len;
+
+	dispatcher = table[pev->event.fd].ctx;
 
 	k_mutex_lock(&dispatcher->lock, K_FOREVER);
 
@@ -227,6 +234,12 @@ int dns_dispatcher_register(struct dns_socket_dispatcher *ctx)
 
 		entry->pair = ctx;
 
+		for (int i = 0; i < ctx->fds_len; i++) {
+			if (dispatch_table[ctx->fds[i].fd].ctx == NULL) {
+				dispatch_table[ctx->fds[i].fd].ctx = ctx;
+			}
+		}
+
 		/* Basically we are now done. If there is incoming data to
 		 * the socket, the dispatcher will then pass it to the correct
 		 * recipient.
@@ -253,7 +266,13 @@ int dns_dispatcher_register(struct dns_socket_dispatcher *ctx)
 
 	ctx->pair = NULL;
 
-	ret = net_socket_service_register(ctx->svc, ctx->fds, ctx->fds_len, ctx);
+	for (int i = 0; i < ctx->fds_len; i++) {
+		if (dispatch_table[ctx->fds[i].fd].ctx == NULL) {
+			dispatch_table[ctx->fds[i].fd].ctx = ctx;
+		}
+	}
+
+	ret = net_socket_service_register(ctx->svc, ctx->fds, ctx->fds_len, &dispatch_table);
 	if (ret < 0) {
 		NET_DBG("Cannot register socket service (%d)", ret);
 		goto out;
@@ -272,6 +291,10 @@ int dns_dispatcher_unregister(struct dns_socket_dispatcher *ctx)
 	k_mutex_lock(&lock, K_FOREVER);
 
 	(void)sys_slist_find_and_remove(&sockets, &ctx->node);
+
+	for (int i = 0; i < ctx->fds_len; i++) {
+		dispatch_table[ctx->fds[i].fd].ctx = NULL;
+	}
 
 	k_mutex_unlock(&lock);
 

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -678,6 +678,13 @@ static int register_dispatcher(struct mdns_responder_context *ctx,
 	ctx->dispatcher.mdns_ctx = ctx;
 	ctx->dispatcher.pair = NULL;
 
+	/* Mark the fd so that "net sockets" can show it. This is needed if there
+	 * is already a socket bound to same port and the dispatcher will mux
+	 * the connections. Without this, the FD in "net sockets" services list will
+	 * show the socket descriptor value as -1.
+	 */
+	svc->pev[0].event.fd = ctx->sock;
+
 	if (IS_ENABLED(CONFIG_NET_IPV6) && local->sa_family == AF_INET6) {
 		memcpy(&ctx->dispatcher.local_addr, local,
 		       sizeof(struct sockaddr_in6));


### PR DESCRIPTION
The socket services API has a limitation where the user data is shared between file descriptors described in the same service.
    
This can cause problem in DNS dispatcher where each listened socket needs to have their own dispatcher struct set as user data so that we can map between dispatcher context and socket. Solve this by always have a dispatcher table as user data, and then have the actual mapping done via the dispatcher table when receiving data to the dispatcher socket.

Fixes #78146
