### PR TITLE
subsys: modbus: fix Modbus TCP server FC03 and FC04 response byte count

### DIFF
--- a/subsys/modbus/modbus_server.c
+++ b/subsys/modbus/modbus_server.c
@@ -345,6 +345,9 @@ static bool mbs_fc03_hreg_read(struct modbus_context *ctx)
 			return true;
 		}
 
+		/* compute the register quantity in terms of 16-bit registers */
+		reg_qty = reg_qty / 2;
+
 		if (reg_qty == 0 || reg_qty > (regs_limit / 2)) {
 			LOG_ERR("Number of registers limit exceeded");
 			mbs_exception_rsp(ctx, MODBUS_EXC_ILLEGAL_DATA_VAL);
@@ -454,6 +457,9 @@ static bool mbs_fc04_inreg_read(struct modbus_context *ctx)
 			mbs_exception_rsp(ctx, MODBUS_EXC_ILLEGAL_FC);
 			return true;
 		}
+
+		/* compute the register quantity in terms of 16-bit registers */
+		reg_qty = reg_qty / 2;
 
 		if (reg_qty == 0 || reg_qty > (regs_limit / 2)) {
 			LOG_ERR("Number of registers limit exceeded");


### PR DESCRIPTION
The Modbus TCP server is returning incorrect, larger number of bytes when requested for reading floating point input and holding registers.
Most Modbus TCP client software would not be able to process the unexpected length of return data.

In the Modbus TCP, the request header for FC03 and FC04 includes the requested quantity of 16-bit registers.
If two 16-bit integer variables are requested the register quantity field would be two.
If one 32-bit floating point variable is requested (i.e. starting address greater than equal to 5000) the register quantity field would also be two.
The code was not interpreting the 32-bit floating point variable request correctly by not treating the register count as 16-bit registers.

The fix is to divide the requested register quantity by two when floating point registers are requested.
Tested with hardware running zephyr and an HMI with Modbus TCP client and checking the network logs.

Fixes #68788 