### PR TITLE
USB Device next cdc acm can get in a deadlock when the host doesn't pull the endpoint data

### DIFF
--- a/subsys/usb/device_next/class/usbd_cdc_acm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_acm.c
@@ -49,6 +49,7 @@ UDC_BUF_POOL_DEFINE(cdc_acm_ep_pool,
 #define CDC_ACM_IRQ_RX_ENABLED		2
 #define CDC_ACM_IRQ_TX_ENABLED		3
 #define CDC_ACM_RX_FIFO_BUSY		4
+#define CDC_ACM_TX_FIFO_BUSY		5
 
 static struct k_work_q cdc_acm_work_q;
 static K_KERNEL_STACK_DEFINE(cdc_acm_stack,
@@ -228,6 +229,10 @@ static int usbd_cdc_acm_request(struct usbd_class_data *const c_data,
 			atomic_clear_bit(&data->state, CDC_ACM_RX_FIFO_BUSY);
 		}
 
+		if (bi->ep == cdc_acm_get_bulk_in(c_data)) {
+			atomic_clear_bit(&data->state, CDC_ACM_TX_FIFO_BUSY);
+		}
+
 		goto ep_request_error;
 	}
 
@@ -250,6 +255,14 @@ static int usbd_cdc_acm_request(struct usbd_class_data *const c_data,
 		if (data->cb) {
 			cdc_acm_work_submit(&data->irq_cb_work);
 		}
+
+		atomic_clear_bit(&data->state, CDC_ACM_TX_FIFO_BUSY);
+
+		if (!ring_buf_is_empty(data->tx_fifo.rb)) {
+			/* Queue pending TX data on IN endpoint */
+			cdc_acm_work_schedule(&data->tx_fifo_work, K_NO_WAIT);
+		}
+
 	}
 
 	if (bi->ep == cdc_acm_get_int_in(c_data)) {
@@ -548,8 +561,14 @@ static void cdc_acm_tx_fifo_handler(struct k_work *work)
 		return;
 	}
 
+	if (atomic_test_and_set_bit(&data->state, CDC_ACM_TX_FIFO_BUSY)) {
+		LOG_DBG("TX transfer already in progress");
+		return;
+	}
+
 	buf = cdc_acm_buf_alloc(cdc_acm_get_bulk_in(c_data));
 	if (buf == NULL) {
+		atomic_clear_bit(&data->state, CDC_ACM_TX_FIFO_BUSY);
 		cdc_acm_work_schedule(&data->tx_fifo_work, K_MSEC(1));
 		return;
 	}
@@ -561,6 +580,7 @@ static void cdc_acm_tx_fifo_handler(struct k_work *work)
 	if (ret) {
 		LOG_ERR("Failed to enqueue");
 		net_buf_unref(buf);
+		atomic_clear_bit(&data->state, CDC_ACM_TX_FIFO_BUSY);
 	}
 }
 
@@ -828,7 +848,9 @@ static void cdc_acm_irq_cb_handler(struct k_work *work)
 
 	if (data->tx_fifo.altered) {
 		LOG_DBG("tx fifo altered, submit work");
-		cdc_acm_work_schedule(&data->tx_fifo_work, K_NO_WAIT);
+		if (!atomic_test_bit(&data->state, CDC_ACM_TX_FIFO_BUSY)) {
+			cdc_acm_work_schedule(&data->tx_fifo_work, K_NO_WAIT);
+		}
 	}
 
 	if (atomic_test_bit(&data->state, CDC_ACM_IRQ_RX_ENABLED) &&


### PR DESCRIPTION
Fixes #78104 

Current situation before the fix:
- The cdc_acm code starts claiming buffers to hand over to the lower layer driver for TX. 
- The lower layer drivers puts the data into the endpoint for the application / host
- lower layer gives a request callback when the endpoint is read
- cdc_acm layer frees the buffer. 

When the endpoint is not read, due to no terminal application running, the last two steps doesn't occur and the cdc_acm simply occupies all available buffers, followed by rescheduling the same work task for tx_fifo directly, creating an endless loop. 

By checking if a TX task is ongoing, the new work task scheduled as soon as the callback is given. 

There is no timeout used in this case, as I couldn't find an interface to configure a timeout. 
