### PR TITLE
Bluetooth: MICP: Replace busy bool with atomic

### DIFF
--- a/subsys/bluetooth/audio/micp_internal.h
+++ b/subsys/bluetooth/audio/micp_internal.h
@@ -18,6 +18,13 @@
 #include <zephyr/autoconf.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/gatt.h>
+#include <zephyr/sys/atomic.h>
+
+enum bt_micp_mic_ctlr_flag {
+	BT_MICP_MIC_CTLR_FLAG_BUSY,
+
+	BT_MICP_MIC_CTLR_FLAG_NUM_FLAGS, /* keep as last */
+};
 
 struct bt_micp_mic_ctlr {
 	uint16_t start_handle;
@@ -26,7 +33,6 @@ struct bt_micp_mic_ctlr {
 	struct bt_gatt_subscribe_params mute_sub_params;
 	struct bt_gatt_discover_params mute_sub_disc_params;
 
-	bool busy;
 	uint8_t mute_val_buf[1]; /* Mute value is a single octet */
 	struct bt_gatt_write_params write_params;
 	struct bt_gatt_read_params read_params;
@@ -37,6 +43,8 @@ struct bt_micp_mic_ctlr {
 	uint8_t aics_inst_cnt;
 	struct bt_aics *aics[CONFIG_BT_MICP_MIC_CTLR_MAX_AICS_INST];
 #endif /* CONFIG_BT_MICP_MIC_CTLR_AICS */
+
+	ATOMIC_DEFINE(flags, BT_MICP_MIC_CTLR_FLAG_NUM_FLAGS);
 };
 
 #endif /* ZEPHYR_INCLUDE_BLUETOOTH_AUDIO_MICP_INTERNAL_ */

--- a/subsys/bluetooth/audio/micp_mic_ctlr.c
+++ b/subsys/bluetooth/audio/micp_mic_ctlr.c
@@ -80,6 +80,8 @@ static void micp_mic_ctlr_discover_complete(struct bt_micp_mic_ctlr *mic_ctlr, i
 {
 	struct bt_micp_mic_ctlr_cb *listener, *next;
 
+	atomic_clear_bit(mic_ctlr->flags, BT_MICP_MIC_CTLR_FLAG_BUSY);
+
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&micp_mic_ctlr_cbs, listener, next, _node) {
 		if (listener->discover) {
 			uint8_t aics_cnt = 0U;
@@ -128,7 +130,7 @@ static uint8_t micp_mic_ctlr_read_mute_cb(struct bt_conn *conn, uint8_t err,
 	uint8_t cb_err = err;
 	uint8_t mute_val = 0;
 
-	mic_ctlr->busy = false;
+	atomic_clear_bit(mic_ctlr->flags, BT_MICP_MIC_CTLR_FLAG_BUSY);
 
 	if (err > 0) {
 		LOG_DBG("err: 0x%02X", err);
@@ -155,7 +157,7 @@ static void micp_mic_ctlr_write_mics_mute_cb(struct bt_conn *conn, uint8_t err,
 
 	LOG_DBG("Write %s (0x%02X)", err ? "failed" : "successful", err);
 
-	mic_ctlr->busy = false;
+	atomic_clear_bit(mic_ctlr->flags, BT_MICP_MIC_CTLR_FLAG_BUSY);
 
 	micp_mic_ctlr_mute_written(mic_ctlr, err, mute_val);
 }
@@ -540,6 +542,11 @@ int bt_micp_mic_ctlr_discover(struct bt_conn *conn, struct bt_micp_mic_ctlr **mi
 	}
 
 	mic_ctlr = mic_ctlr_get_by_conn(conn);
+	if (atomic_test_and_set_bit(mic_ctlr->flags, BT_MICP_MIC_CTLR_FLAG_BUSY)) {
+		LOG_DBG("Instance is busy");
+
+		return -EBUSY;
+	}
 
 	(void)memset(&mic_ctlr->discover_params, 0,
 		     sizeof(mic_ctlr->discover_params));
@@ -589,6 +596,8 @@ int bt_micp_mic_ctlr_discover(struct bt_conn *conn, struct bt_micp_mic_ctlr **mi
 	err = bt_gatt_discover(conn, &mic_ctlr->discover_params);
 	if (err == 0) {
 		*mic_ctlr_out = mic_ctlr;
+	} else {
+		atomic_clear_bit(mic_ctlr->flags, BT_MICP_MIC_CTLR_FLAG_BUSY);
 	}
 
 	return err;
@@ -682,7 +691,9 @@ int bt_micp_mic_ctlr_mute_get(struct bt_micp_mic_ctlr *mic_ctlr)
 	if (mic_ctlr->mute_handle == 0) {
 		LOG_DBG("Handle not set");
 		return -EINVAL;
-	} else if (mic_ctlr->busy) {
+	} else if (atomic_test_and_set_bit(mic_ctlr->flags, BT_MICP_MIC_CTLR_FLAG_BUSY)) {
+		LOG_DBG("Instance is busy");
+
 		return -EBUSY;
 	}
 
@@ -692,14 +703,14 @@ int bt_micp_mic_ctlr_mute_get(struct bt_micp_mic_ctlr *mic_ctlr)
 	mic_ctlr->read_params.single.offset = 0U;
 
 	err = bt_gatt_read(mic_ctlr->conn, &mic_ctlr->read_params);
-	if (err == 0) {
-		mic_ctlr->busy = true;
+	if (err != 0) {
+		atomic_clear_bit(mic_ctlr->flags, BT_MICP_MIC_CTLR_FLAG_BUSY);
 	}
 
 	return err;
 }
 
-int bt_micp_mic_ctlr_write_mute(struct bt_micp_mic_ctlr *mic_ctlr, bool mute)
+static int bt_micp_mic_ctlr_write_mute(struct bt_micp_mic_ctlr *mic_ctlr, bool mute)
 {
 	int err;
 
@@ -711,7 +722,9 @@ int bt_micp_mic_ctlr_write_mute(struct bt_micp_mic_ctlr *mic_ctlr, bool mute)
 	if (mic_ctlr->mute_handle == 0) {
 		LOG_DBG("Handle not set");
 		return -EINVAL;
-	} else if (mic_ctlr->busy) {
+	} else if (atomic_test_and_set_bit(mic_ctlr->flags, BT_MICP_MIC_CTLR_FLAG_BUSY)) {
+		LOG_DBG("Instance is busy");
+
 		return -EBUSY;
 	}
 
@@ -723,8 +736,8 @@ int bt_micp_mic_ctlr_write_mute(struct bt_micp_mic_ctlr *mic_ctlr, bool mute)
 	mic_ctlr->write_params.func = micp_mic_ctlr_write_mics_mute_cb;
 
 	err = bt_gatt_write(mic_ctlr->conn, &mic_ctlr->write_params);
-	if (err == 0) {
-		mic_ctlr->busy = true;
+	if (err != 0) {
+		atomic_clear_bit(mic_ctlr->flags, BT_MICP_MIC_CTLR_FLAG_BUSY);
 	}
 
 	return err;


### PR DESCRIPTION
Replace the busy boolean flag with an atomic value. This prevents any race conditions with the MICP client implementation.

This also adds a missing check for the discovery procedure.