### PR TITLE
drivers: pwm: Fix NXP TPM without combine channel feature

### DIFF
--- a/drivers/pwm/pwm_mcux_tpm.c
+++ b/drivers/pwm/pwm_mcux_tpm.c
@@ -162,7 +162,9 @@ static int mcux_tpm_init(const struct device *dev)
 		channel->chnlNumber = i;
 		channel->level = kTPM_NoPwmSignal;
 		channel->dutyCyclePercent = 0;
+#if defined(FSL_FEATURE_TPM_HAS_COMBINE) && FSL_FEATURE_TPM_HAS_COMBINE
 		channel->firstEdgeDelayPercent = 0;
+#endif
 		channel++;
 	}
 


### PR DESCRIPTION
TMP variant without combine channel feature is used in some NXP SoCs. Build error occurs for such socs because of accessing unavailable struct member in hal. Fix it by adding #if directive to check the feature presence.