### PR TITLE
modules: hal_nordic: dvfs: refactor

### DIFF
--- a/modules/hal_nordic/nrfs/dvfs/Kconfig
+++ b/modules/hal_nordic/nrfs/dvfs/Kconfig
@@ -30,6 +30,8 @@ config NRFS_LOCAL_DOMAIN_DOWNSCALE_FINISH_DELAY_TIMEOUT_US
 	int "Additional delay to let secdom finish dowscale procedure in us"
 	range 1 10000000
 	default 1000
+	help
+	  This value depends on the secdom core performance and shouldn't be touched by the user.
 
 config NRFS_LOCAL_DOMAIN_DVFS_HANDLER_TASK_STACK_SIZE
 	int "Stack size used for DVFS handling task"

--- a/modules/hal_nordic/nrfs/dvfs/ld_dvfs_handler.c
+++ b/modules/hal_nordic/nrfs/dvfs/ld_dvfs_handler.c
@@ -178,10 +178,9 @@ static void dvfs_service_handler_set_initial_hsfll_config(void)
 
 static void dvfs_service_handler_scaling_finish_delay_timeout(struct k_timer *timer)
 {
-	if (timer) {
-		dvfs_service_handler_scaling_finish(
-			*(enum dvfs_frequency_setting *)timer->user_data);
-	}
+
+	dvfs_service_handler_scaling_finish(
+		*(enum dvfs_frequency_setting *)k_timer_user_data_get(timer));
 }
 
 K_TIMER_DEFINE(dvfs_service_scaling_finish_delay_timer,
@@ -237,7 +236,8 @@ static void nrfs_dvfs_evt_handler(nrfs_dvfs_evt_t const *p_evt, void *context)
 			static enum dvfs_frequency_setting freq;
 
 			freq = p_evt->freq;
-			dvfs_service_scaling_finish_delay_timer.user_data = (void *)&freq;
+			k_timer_user_data_set(&dvfs_service_scaling_finish_delay_timer,
+					      (void *)&freq);
 			k_timer_start(&dvfs_service_scaling_finish_delay_timer,
 				      SCALING_FINISH_DELAY_TIMEOUT_US, K_NO_WAIT);
 		} else {


### PR DESCRIPTION
This is follow up to commit:
modules: hal_nordic: dvfs: added callback when scaling done Used get and set timer user data functions.
Added missing help text in KConfig.

Changes requested in review.