### PR TITLE
logging: add formatted timestamp for realtime 

### DIFF
--- a/subsys/logging/Kconfig.formatting
+++ b/subsys/logging/Kconfig.formatting
@@ -192,6 +192,11 @@ config LOG_OUTPUT_FORMAT_DATE_TIMESTAMP
 	help
 	  When enabled timestamp is formatted to YYYY-MM-DD hh:mm:ss.ms,us.
 
+config LOG_OUTPUT_FORMAT_ISO8601_TIMESTAMP
+	bool "Format timestamp in ISO 8601 format"
+	help
+	  When enabled timestamp is formatted to YYYY-MM-DDThh:mm:ss,ffffffZ.
+
 config LOG_OUTPUT_FORMAT_LINUX_TIMESTAMP
 	bool "Format timestamp in Linux format"
 	help

--- a/subsys/logging/Kconfig.formatting
+++ b/subsys/logging/Kconfig.formatting
@@ -175,7 +175,22 @@ config LOG_BACKEND_FORMAT_TIMESTAMP
 	depends on LOG_BACKEND_SUPPORTS_FORMAT_TIMESTAMP
 	default y
 	help
-	  When enabled timestamp is formatted to hh:mm:ss:ms,us.
+	  When enabled timestamp is formatted.
+
+choice LOG_BACKEND_FORMAT_TIMESTAMP_MODE
+	prompt "Timestamp format mode"
+	default LOG_OUTPUT_FORMAT_DATE_TIMESTAMP if LOG_TIMESTAMP_USE_REALTIME
+	default LOG_OUTPUT_FORMAT_TIME_TIMESTAMP
+
+config LOG_OUTPUT_FORMAT_TIME_TIMESTAMP
+	bool "Format timestamp in time format"
+	help
+	  When enabled timestamp is formatted to hh:mm:ss.ms,us.
+
+config LOG_OUTPUT_FORMAT_DATE_TIMESTAMP
+	bool "Format timestamp in date format"
+	help
+	  When enabled timestamp is formatted to YYYY-MM-DD hh:mm:ss.ms,us.
 
 config LOG_OUTPUT_FORMAT_LINUX_TIMESTAMP
 	bool "Format timestamp in Linux format"
@@ -190,5 +205,7 @@ config LOG_OUTPUT_FORMAT_CUSTOM_TIMESTAMP
 	help
 	  Enable support for custom formatter for the timestamp.
 	  It will be applied to all backends except the syslog net backend.
+
+endchoice
 
 endmenu

--- a/subsys/logging/Kconfig.formatting
+++ b/subsys/logging/Kconfig.formatting
@@ -189,6 +189,6 @@ config LOG_OUTPUT_FORMAT_CUSTOM_TIMESTAMP
 	bool "Custom timestamp format support"
 	help
 	  Enable support for custom formatter for the timestamp.
-	  It will be applied to all backends.
+	  It will be applied to all backends except the syslog net backend.
 
 endmenu

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -255,13 +255,12 @@ static int timestamp_print(const struct log_output *output,
 		if (IS_ENABLED(CONFIG_LOG_BACKEND_NET) && flags & LOG_OUTPUT_FLAG_FORMAT_SYSLOG) {
 #if defined(CONFIG_REQUIRES_FULL_LIBC)
 			char time_str[sizeof("1970-01-01T00:00:00")];
-			struct tm *tm;
-			time_t time;
+			struct tm tm_timestamp = {0};
+			time_t time_seconds = total_seconds;
 
-			time = total_seconds;
-			tm = gmtime(&time);
+			gmtime_r(&time_seconds, &tm_timestamp);
 
-			strftime(time_str, sizeof(time_str), "%FT%T", tm);
+			strftime(time_str, sizeof(time_str), "%FT%T", &tm_timestamp);
 
 			length = print_formatted(output, "%s.%06uZ ",
 						 time_str, ms * 1000U + us);
@@ -289,12 +288,12 @@ static int timestamp_print(const struct log_output *output,
 			} else if (IS_ENABLED(CONFIG_LOG_OUTPUT_FORMAT_DATE_TIMESTAMP)) {
 #if defined(CONFIG_REQUIRES_FULL_LIBC)
 				char time_str[sizeof("1970-01-01 00:00:00")];
-				struct tm *tm_timestamp;
+				struct tm tm_timestamp = {0};
 				time_t time_seconds = total_seconds;
 
-				tm_timestamp = gmtime(&time_seconds);
+				gmtime_r(&time_seconds, &tm_timestamp);
 
-				strftime(time_str, sizeof(time_str), "%F %T", tm_timestamp);
+				strftime(time_str, sizeof(time_str), "%F %T", &tm_timestamp);
 
 				length = print_formatted(output, "[%s.%03u,%03u] ", time_str, ms,
 							 us);
@@ -311,12 +310,12 @@ static int timestamp_print(const struct log_output *output,
 			} else if (IS_ENABLED(CONFIG_LOG_OUTPUT_FORMAT_ISO8601_TIMESTAMP)) {
 #if defined(CONFIG_REQUIRES_FULL_LIBC)
 				char time_str[sizeof("1970-01-01T00:00:00")];
-				struct tm *tm_timestamp;
+				struct tm tm_timestamp = {0};
 				time_t time_seconds = total_seconds;
 
-				tm_timestamp = gmtime(&time_seconds);
+				gmtime_r(&time_seconds, &tm_timestamp);
 
-				strftime(time_str, sizeof(time_str), "%FT%T", tm_timestamp);
+				strftime(time_str, sizeof(time_str), "%FT%T", &tm_timestamp);
 
 				length = print_formatted(output, "[%s,%06uZ] ", time_str,
 							 ms * 1000U + us);

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -286,6 +286,28 @@ static int timestamp_print(const struct log_output *output,
 							"[%5lu.%06d] ",
 #endif
 							total_seconds, ms * 1000U + us);
+			} else if (IS_ENABLED(CONFIG_LOG_OUTPUT_FORMAT_DATE_TIMESTAMP)) {
+#if defined(CONFIG_REQUIRES_FULL_LIBC)
+				char time_str[sizeof("1970-01-01 00:00:00")];
+				struct tm *tm_timestamp;
+				time_t time_seconds = total_seconds;
+
+				tm_timestamp = gmtime(&time_seconds);
+
+				strftime(time_str, sizeof(time_str), "%F %T", tm_timestamp);
+
+				length = print_formatted(output, "[%s.%03u,%03u] ", time_str, ms,
+							 us);
+#else
+				struct YMD_date date;
+
+				get_YMD_from_seconds(total_seconds, &date);
+				hours = hours % 24;
+				length = print_formatted(
+					output, "[%04u-%02u-%02u %02u:%02u:%02u.%03u,%03u] ",
+					date.year, date.month, date.day, hours, mins, seconds, ms,
+					us);
+#endif
 			} else {
 				length = print_formatted(output,
 							"[%02u:%02u:%02u.%03u,%03u] ",

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -252,10 +252,7 @@ static int timestamp_print(const struct log_output *output,
 		ms = (remainder * 1000U) / freq;
 		us = (1000 * (remainder * 1000U - (ms * freq))) / freq;
 
-		if (IS_ENABLED(CONFIG_LOG_OUTPUT_FORMAT_CUSTOM_TIMESTAMP)) {
-			length = log_custom_timestamp_print(output, timestamp, print_formatted);
-		} else if (IS_ENABLED(CONFIG_LOG_BACKEND_NET) &&
-			   flags & LOG_OUTPUT_FLAG_FORMAT_SYSLOG) {
+		if (IS_ENABLED(CONFIG_LOG_BACKEND_NET) && flags & LOG_OUTPUT_FLAG_FORMAT_SYSLOG) {
 #if defined(CONFIG_REQUIRES_FULL_LIBC)
 			char time_str[sizeof("1970-01-01T00:00:00")];
 			struct tm *tm;
@@ -278,6 +275,8 @@ static int timestamp_print(const struct log_output *output,
 					date.year, date.month, date.day,
 					hours, mins, seconds, ms * 1000U + us);
 #endif
+		} else if (IS_ENABLED(CONFIG_LOG_OUTPUT_FORMAT_CUSTOM_TIMESTAMP)) {
+			length = log_custom_timestamp_print(output, timestamp, print_formatted);
 		} else {
 			if (IS_ENABLED(CONFIG_LOG_OUTPUT_FORMAT_LINUX_TIMESTAMP)) {
 				length = print_formatted(output,

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -308,6 +308,28 @@ static int timestamp_print(const struct log_output *output,
 					date.year, date.month, date.day, hours, mins, seconds, ms,
 					us);
 #endif
+			} else if (IS_ENABLED(CONFIG_LOG_OUTPUT_FORMAT_ISO8601_TIMESTAMP)) {
+#if defined(CONFIG_REQUIRES_FULL_LIBC)
+				char time_str[sizeof("1970-01-01T00:00:00")];
+				struct tm *tm_timestamp;
+				time_t time_seconds = total_seconds;
+
+				tm_timestamp = gmtime(&time_seconds);
+
+				strftime(time_str, sizeof(time_str), "%FT%T", tm_timestamp);
+
+				length = print_formatted(output, "[%s,%06uZ] ", time_str,
+							 ms * 1000U + us);
+#else
+				struct YMD_date date;
+
+				get_YMD_from_seconds(total_seconds, &date);
+				hours = hours % 24;
+				length = print_formatted(output,
+							 "[%04u-%02u-%02uT%02u:%02u:%02u,%06uZ] ",
+							 date.year, date.month, date.day, hours,
+							 mins, seconds, ms * 1000U + us);
+#endif
 			} else {
 				length = print_formatted(output,
 							"[%02u:%02u:%02u.%03u,%03u] ",

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#undef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
 #include <zephyr/logging/log_output.h>
 #include <zephyr/logging/log_ctrl.h>
 #include <zephyr/logging/log_output_custom.h>

--- a/tests/subsys/logging/log_output/src/log_output_test.c
+++ b/tests/subsys/logging/log_output/src/log_output_test.c
@@ -129,9 +129,15 @@ ZTEST(test_log_output, test_ts_flag)
 
 ZTEST(test_log_output, test_format_ts)
 {
+#ifdef CONFIG_LOG_OUTPUT_FORMAT_DATE_TIMESTAMP
+#define TIMESTAMP_STR "[1970-01-01 00:00:01.000,000] "
+#elif defined(CONFIG_LOG_OUTPUT_FORMAT_ISO8601_TIMESTAMP)
+#define TIMESTAMP_STR "[1970-01-01T00:00:01,000000Z] "
+#else
+#define TIMESTAMP_STR "[00:00:01.000,000] "
+#endif
 	char package[256];
-	static const char *exp_str =
-		"[00:00:01.000,000] " DNAME "/" SNAME ": " TEST_STR "\r\n";
+	static const char *exp_str = TIMESTAMP_STR DNAME "/" SNAME ": " TEST_STR "\r\n";
 	uint32_t flags = LOG_OUTPUT_FLAG_TIMESTAMP | LOG_OUTPUT_FLAG_FORMAT_TIMESTAMP;
 	int err;
 

--- a/tests/subsys/logging/log_output/testcase.yaml
+++ b/tests/subsys/logging/log_output/testcase.yaml
@@ -15,6 +15,38 @@ tests:
       - logging
     extra_configs:
       - CONFIG_LOG_TIMESTAMP_64BIT=y
+  logging.output.ts64.date:
+    tags:
+      - log_output
+      - logging
+    extra_configs:
+      - CONFIG_LOG_TIMESTAMP_64BIT=y
+      - CONFIG_LOG_OUTPUT_FORMAT_DATE_TIMESTAMP=y
+  logging.output.ts64.date.fulllibc:
+    tags:
+      - log_output
+      - logging
+    extra_configs:
+      - CONFIG_LOG_TIMESTAMP_64BIT=y
+      - CONFIG_LOG_OUTPUT_FORMAT_DATE_TIMESTAMP=y
+      - CONFIG_REQUIRES_FULL_LIBC=y
+    filter: CONFIG_FULL_LIBC_SUPPORTED
+  logging.output.ts64.iso8601:
+    tags:
+      - log_output
+      - logging
+    extra_configs:
+      - CONFIG_LOG_TIMESTAMP_64BIT=y
+      - CONFIG_LOG_OUTPUT_FORMAT_ISO8601_TIMESTAMP=y
+  logging.output.ts64.iso8601.fulllibc:
+    tags:
+      - log_output
+      - logging
+    extra_configs:
+      - CONFIG_LOG_TIMESTAMP_64BIT=y
+      - CONFIG_LOG_OUTPUT_FORMAT_ISO8601_TIMESTAMP=y
+      - CONFIG_REQUIRES_FULL_LIBC=y
+    filter: CONFIG_FULL_LIBC_SUPPORTED
   logging.output.thread_id:
     tags:
       - log_output


### PR DESCRIPTION
this adds a formatted timestamp that includes the date, which is useful, when realtime is used for the timestamp.