### PR TITLE
drivers: serial: nrfx_uarte: Add support for ENDTX_STOPTX short

### DIFF
--- a/drivers/serial/Kconfig.nrfx_uart_instance
+++ b/drivers/serial/Kconfig.nrfx_uart_instance
@@ -20,7 +20,7 @@ config UART_$(nrfx_uart_num)_ASYNC
 
 config UART_$(nrfx_uart_num)_ENHANCED_POLL_OUT
 	bool "Efficient poll out on port $(nrfx_uart_num)"
-	depends on !SOC_SERIES_NRF54LX
+	depends on !$(dt_nodelabel_has_prop,uart$(nrfx_uart_num),short-endtx-stoptx)
 	default y
 	depends on HAS_HW_NRF_UARTE$(nrfx_uart_num)
 	depends on HAS_HW_NRF_PPI || HAS_HW_NRF_DPPIC

--- a/dts/bindings/serial/nordic,nrf-uarte.yaml
+++ b/dts/bindings/serial/nordic,nrf-uarte.yaml
@@ -3,3 +3,9 @@ description: Nordic nRF family UARTE (UART with EasyDMA)
 compatible: "nordic,nrf-uarte"
 
 include: ["nordic,nrf-uart-common.yaml", "memory-region.yaml"]
+
+properties:
+  endtx-stoptx-supported:
+    type: boolean
+    description: |
+      UARTE has ENDTX_STOPTX HW short.

--- a/dts/common/nordic/nrf54h20.dtsi
+++ b/dts/common/nordic/nrf54h20.dtsi
@@ -625,6 +625,7 @@
 				status = "disabled";
 				interrupts = <230 NRF_DEFAULT_IRQ_PRIORITY>;
 				clocks = <&hsfll120>;
+				endtx-stoptx-supported;
 			};
 
 			spi121: spi@8e7000 {
@@ -933,6 +934,7 @@
 				interrupts = <421 NRF_DEFAULT_IRQ_PRIORITY>;
 				clocks = <&fll16m>;
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
+				endtx-stoptx-supported;
 			};
 
 			i2c131: i2c@9a6000 {
@@ -973,6 +975,7 @@
 				interrupts = <422 NRF_DEFAULT_IRQ_PRIORITY>;
 				clocks = <&fll16m>;
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
+				endtx-stoptx-supported;
 			};
 
 			dppic134: dppic@9b1000 {
@@ -1050,6 +1053,7 @@
 				interrupts = <437 NRF_DEFAULT_IRQ_PRIORITY>;
 				clocks = <&fll16m>;
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
+				endtx-stoptx-supported;
 			};
 
 			i2c133: i2c@9b6000 {
@@ -1090,6 +1094,7 @@
 				interrupts = <438 NRF_DEFAULT_IRQ_PRIORITY>;
 				clocks = <&fll16m>;
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
+				endtx-stoptx-supported;
 			};
 
 			dppic135: dppic@9c1000 {
@@ -1167,6 +1172,7 @@
 				interrupts = <453 NRF_DEFAULT_IRQ_PRIORITY>;
 				clocks = <&fll16m>;
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
+				endtx-stoptx-supported;
 			};
 
 			i2c135: i2c@9c6000 {
@@ -1207,6 +1213,7 @@
 				interrupts = <454 NRF_DEFAULT_IRQ_PRIORITY>;
 				clocks = <&fll16m>;
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
+				endtx-stoptx-supported;
 			};
 
 			dppic136: dppic@9d1000 {
@@ -1284,6 +1291,7 @@
 				interrupts = <469 NRF_DEFAULT_IRQ_PRIORITY>;
 				clocks = <&fll16m>;
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
+				endtx-stoptx-supported;
 			};
 
 			i2c137: i2c@9d6000 {
@@ -1324,6 +1332,7 @@
 				interrupts = <470 NRF_DEFAULT_IRQ_PRIORITY>;
 				clocks = <&fll16m>;
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
+				endtx-stoptx-supported;
 			};
 		};
 	};

--- a/dts/common/nordic/nrf54l15.dtsi
+++ b/dts/common/nordic/nrf54l15.dtsi
@@ -136,6 +136,7 @@
 				reg = <0x4a000 0x1000>;
 				interrupts = <74 NRF_DEFAULT_IRQ_PRIORITY>;
 				status = "disabled";
+				endtx-stoptx-supported;
 			};
 
 			cpuflpr_vpr: vpr@4c000 {
@@ -266,6 +267,7 @@
 				reg = <0xc6000 0x1000>;
 				interrupts = <198 NRF_DEFAULT_IRQ_PRIORITY>;
 				status = "disabled";
+				endtx-stoptx-supported;
 			};
 
 			i2c21: i2c@c7000 {
@@ -303,6 +305,7 @@
 				reg = <0xc7000 0x1000>;
 				interrupts = <199 NRF_DEFAULT_IRQ_PRIORITY>;
 				status = "disabled";
+				endtx-stoptx-supported;
 			};
 
 			i2c22: i2c@c8000 {
@@ -340,6 +343,7 @@
 				reg = <0xc8000 0x1000>;
 				interrupts = <200 NRF_DEFAULT_IRQ_PRIORITY>;
 				status = "disabled";
+				endtx-stoptx-supported;
 			};
 
 			egu20: egu@c9000 {
@@ -548,6 +552,7 @@
 				reg = <0x104000 0x1000>;
 				interrupts = <260 NRF_DEFAULT_IRQ_PRIORITY>;
 				status = "disabled";
+				endtx-stoptx-supported;
 			};
 
 #ifdef USE_NON_SECURE_ADDRESS_MAP

--- a/dts/common/nordic/nrf54l20.dtsi
+++ b/dts/common/nordic/nrf54l20.dtsi
@@ -105,6 +105,7 @@
 				reg = <0x4d000 0x1000>;
 				interrupts = <77 NRF_DEFAULT_IRQ_PRIORITY>;
 				status = "disabled";
+				endtx-stoptx-supported;
 			};
 
 			gpio2: gpio@50400 {
@@ -217,6 +218,7 @@
 				reg = <0xc6000 0x1000>;
 				interrupts = <198 NRF_DEFAULT_IRQ_PRIORITY>;
 				status = "disabled";
+				endtx-stoptx-supported;
 			};
 
 			i2c21: i2c@c7000 {
@@ -254,6 +256,7 @@
 				reg = <0xc7000 0x1000>;
 				interrupts = <199 NRF_DEFAULT_IRQ_PRIORITY>;
 				status = "disabled";
+				endtx-stoptx-supported;
 			};
 
 			i2c22: i2c@c8000 {
@@ -291,6 +294,7 @@
 				reg = <0xc8000 0x1000>;
 				interrupts = <200 NRF_DEFAULT_IRQ_PRIORITY>;
 				status = "disabled";
+				endtx-stoptx-supported;
 			};
 
 			egu20: egu@c9000 {
@@ -490,6 +494,7 @@
 				reg = <0x104000 0x1000>;
 				interrupts = <260 NRF_DEFAULT_IRQ_PRIORITY>;
 				status = "disabled";
+				endtx-stoptx-supported;
 			};
 
 			wdt30: watchdog@108000 {

--- a/dts/common/nordic/nrf9280.dtsi
+++ b/dts/common/nordic/nrf9280.dtsi
@@ -515,6 +515,7 @@
 				reg = <0x8e6000 0x1000>;
 				status = "disabled";
 				interrupts = <230 NRF_DEFAULT_IRQ_PRIORITY>;
+				endtx-stoptx-supported;
 			};
 
 			spi121: spi@8e7000 {
@@ -844,6 +845,7 @@
 				status = "disabled";
 				interrupts = <421 NRF_DEFAULT_IRQ_PRIORITY>;
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
+				endtx-stoptx-supported;
 			};
 
 			i2c131: i2c@9a6000 {
@@ -881,6 +883,7 @@
 				status = "disabled";
 				interrupts = <422 NRF_DEFAULT_IRQ_PRIORITY>;
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
+				endtx-stoptx-supported;
 			};
 
 			dppic134: dppic@9b1000 {
@@ -952,6 +955,7 @@
 				status = "disabled";
 				interrupts = <437 NRF_DEFAULT_IRQ_PRIORITY>;
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
+				endtx-stoptx-supported;
 			};
 
 			i2c133: i2c@9b6000 {
@@ -989,6 +993,7 @@
 				status = "disabled";
 				interrupts = <438 NRF_DEFAULT_IRQ_PRIORITY>;
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
+				endtx-stoptx-supported;
 			};
 
 			dppic135: dppic@9c1000 {
@@ -1060,6 +1065,7 @@
 				status = "disabled";
 				interrupts = <453 NRF_DEFAULT_IRQ_PRIORITY>;
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
+				endtx-stoptx-supported;
 			};
 
 			i2c135: i2c@9c6000 {
@@ -1097,6 +1103,7 @@
 				status = "disabled";
 				interrupts = <454 NRF_DEFAULT_IRQ_PRIORITY>;
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
+				endtx-stoptx-supported;
 			};
 
 			dppic136: dppic@9d1000 {
@@ -1168,6 +1175,7 @@
 				status = "disabled";
 				interrupts = <469 NRF_DEFAULT_IRQ_PRIORITY>;
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
+				endtx-stoptx-supported;
 			};
 
 			i2c137: i2c@9d6000 {
@@ -1205,6 +1213,7 @@
 				status = "disabled";
 				interrupts = <470 NRF_DEFAULT_IRQ_PRIORITY>;
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
+				endtx-stoptx-supported;
 			};
 		};
 	};

--- a/samples/boards/nrf/nrfx/Kconfig
+++ b/samples/boards/nrf/nrfx/Kconfig
@@ -1,6 +1,8 @@
 # Copyright (c) 2021 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+source "Kconfig.zephyr"
+
 config NRFX_DPPI
 	default $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_DPPIC))
 
@@ -16,5 +18,3 @@ config NRFX_GPIOTE0
 config NRFX_GPIOTE1
 	default y if (SOC_SERIES_NRF53X && TRUSTED_EXECUTION_NONSECURE) || \
 		     (SOC_SERIES_NRF91X && TRUSTED_EXECUTION_NONSECURE)
-
-source "Kconfig.zephyr"


### PR DESCRIPTION
nrf54x has new feature: ENDTX_STOPTX short. Add devicetree property to UARTE. Use short is property is set.