### PR TITLE
tests: drivers: uart: uart_error: Add missing pull up to the overlay file

### DIFF
--- a/tests/drivers/uart/uart_errors/boards/nrf54h20dk_nrf54h20_common.dtsi
+++ b/tests/drivers/uart/uart_errors/boards/nrf54h20dk_nrf54h20_common.dtsi
@@ -3,8 +3,11 @@
 &pinctrl {
 	uart135_default_alt: uart135_default_alt {
 		group1 {
-			psels = <NRF_PSEL(UART_RX, 0, 6)>,
-				<NRF_PSEL(UART_RTS, 0, 8)>;
+			psels = <NRF_PSEL(UART_RX, 0, 6)>;
+			bias-pull-up;
+		};
+		group2 {
+			psels = <NRF_PSEL(UART_RTS, 0, 8)>;
 		};
 	};
 


### PR DESCRIPTION
Add missing pull-up.