### PR TITLE
boards: st: nucleo_l496zg: add zephyr_udc0 and hsi48 dt nodes

### DIFF
--- a/boards/st/nucleo_l496zg/doc/index.rst
+++ b/boards/st/nucleo_l496zg/doc/index.rst
@@ -127,6 +127,8 @@ The Zephyr nucleo_l496zg board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | RTC       | on-chip    | rtc                                 |
 +-----------+------------+-------------------------------------+
+| OTG FS    | on-chip    | USB OTG Full-speed                  |
++-----------+------------+-------------------------------------+
 | WATCHDOG  | on-chip    | System Window Watchdog              |
 +-----------+------------+-------------------------------------+
 

--- a/boards/st/nucleo_l496zg/nucleo_l496zg.dts
+++ b/boards/st/nucleo_l496zg/nucleo_l496zg.dts
@@ -72,6 +72,10 @@
 	status = "okay";
 };
 
+&clk_hsi48 {
+	status = "okay";
+};
+
 &pll {
 	div-m = <1>;
 	mul-n = <20>;
@@ -108,6 +112,12 @@
 	pinctrl-0 = <&lpuart1_tx_pg7 &lpuart1_rx_pg8>;
 	pinctrl-names = "default";
 	current-speed = <115200>;
+	status = "okay";
+};
+
+zephyr_udc0: &usbotg_fs {
+	pinctrl-0 = <&usb_otg_fs_dm_pa11 &usb_otg_fs_dp_pa12>;
+	pinctrl-names = "default";
 	status = "okay";
 };
 

--- a/boards/st/nucleo_l496zg/nucleo_l496zg.yaml
+++ b/boards/st/nucleo_l496zg/nucleo_l496zg.yaml
@@ -16,6 +16,9 @@ supported:
   - spi
   - pwm
   - counter
+  - usb
+  - usb_device
+  - usbd
   - watchdog
 testing:
   ignore_tags:


### PR DESCRIPTION
Add Zephyr UDC (USB Device Class) and clk_hsi48 (hi-speed internal 48 MHz) devicetree nodes so that the nucleo_l496zg board works with other USB DC samples and tests.

Update the board yaml description to indicate usb and usb device roles are supported.