### PR TITLE
Icbmsg align to no multithreading

### DIFF
--- a/samples/subsys/ipc/ipc_service/icmsg/boards/nrf54l15pdk_nrf54l15_cpuapp_icbmsg.overlay
+++ b/samples/subsys/ipc/ipc_service/icmsg/boards/nrf54l15pdk_nrf54l15_cpuapp_icbmsg.overlay
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	soc {
+		reserved-memory {
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			sram_rx: memory@20018000 {
+				reg = <0x20018000 0x0800>;
+			};
+
+			sram_tx: memory@20020000 {
+				reg = <0x20020000 0x0800>;
+			};
+		};
+	};
+
+	ipc {
+		ipc0: ipc0 {
+			compatible = "zephyr,ipc-icbmsg";
+			tx-region = <&sram_tx>;
+			rx-region = <&sram_rx>;
+			tx-blocks = <16>;
+			rx-blocks = <18>;
+			mboxes = <&cpuapp_vevif_rx 15>, <&cpuapp_vevif_tx 16>;
+			mbox-names = "rx", "tx";
+			status = "okay";
+		};
+	};
+};
+
+&cpuapp_vevif_rx {
+	status = "okay";
+};
+
+&cpuapp_vevif_tx {
+	status = "okay";
+};

--- a/samples/subsys/ipc/ipc_service/icmsg/remote/boards/nrf54l15pdk_nrf54l15_cpuflpr_icbmsg.overlay
+++ b/samples/subsys/ipc/ipc_service/icmsg/remote/boards/nrf54l15pdk_nrf54l15_cpuflpr_icbmsg.overlay
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	soc {
+		reserved-memory {
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			sram_tx: memory@20018000 {
+				reg = <0x20018000 0x0800>;
+			};
+
+			sram_rx: memory@20020000 {
+				reg = <0x20020000 0x0800>;
+			};
+		};
+	};
+
+	ipc {
+		ipc0: ipc0 {
+			compatible = "zephyr,ipc-icbmsg";
+			tx-region = <&sram_tx>;
+			rx-region = <&sram_rx>;
+			tx-blocks = <18>;
+			rx-blocks = <16>;
+			mboxes = <&cpuflpr_vevif_rx 16>, <&cpuflpr_vevif_tx 15>;
+			mbox-names = "rx", "tx";
+			status = "okay";
+		};
+	};
+};
+
+&cpuflpr_vevif_rx {
+	status = "okay";
+};
+
+&cpuflpr_vevif_tx {
+	status = "okay";
+};
+
+&uart30 {
+	/delete-property/ hw-flow-control;
+};

--- a/samples/subsys/ipc/ipc_service/icmsg/sample.yaml
+++ b/samples/subsys/ipc/ipc_service/icmsg/sample.yaml
@@ -84,3 +84,81 @@ tests:
         - "host: Sent"
         - "host: Received"
         - "host: IPC-service HOST demo ended"
+
+  sample.ipc.icbmsg.nrf54l15:
+    platform_allow: nrf54l15pdk/nrf54l15/cpuapp
+    integration_platforms:
+      - nrf54l15pdk/nrf54l15/cpuapp
+    tags: ipc
+    extra_args:
+      icmsg_SNIPPET=nordic-flpr
+      icmsg_CONFIG_IPC_SERVICE_BACKEND_ICBMSG_NUM_EP=1
+      icmsg_DTC_OVERLAY_FILE="boards/nrf54l15pdk_nrf54l15_cpuapp_icbmsg.overlay"
+      remote_CONFIG_IPC_SERVICE_BACKEND_ICBMSG_NUM_EP=1
+      remote_DTC_OVERLAY_FILE="boards/nrf54l15pdk_nrf54l15_cpuflpr_icbmsg.overlay"
+    sysbuild: true
+    harness: console
+    harness_config:
+      type: multi_line
+      ordered: false
+      regex:
+        - "host: IPC-service HOST demo started"
+        - "host: Ep bounded"
+        - "host: Perform sends for"
+        - "host: Sent"
+        - "host: Received"
+        - "host: IPC-service HOST demo ended"
+
+  sample.ipc.icbmsg.nrf54l15_no_multithreading:
+    platform_allow: nrf54l15pdk/nrf54l15/cpuapp
+    integration_platforms:
+      - nrf54l15pdk/nrf54l15/cpuapp
+    tags: ipc
+    extra_args:
+      icmsg_SNIPPET=nordic-flpr
+      icmsg_CONFIG_IPC_SERVICE_BACKEND_ICBMSG_NUM_EP=1
+      icmsg_DTC_OVERLAY_FILE="boards/nrf54l15pdk_nrf54l15_cpuapp_icbmsg.overlay"
+      icmsg_CONFIG_MULTITHREADING=n
+      icmsg_CONFIG_LOG_MODE_MINIMAL=y
+      remote_CONFIG_IPC_SERVICE_BACKEND_ICBMSG_NUM_EP=1
+      remote_DTC_OVERLAY_FILE="boards/nrf54l15pdk_nrf54l15_cpuflpr_icbmsg.overlay"
+      remote_CONFIG_MULTITHREADING=n
+      remote_CONFIG_LOG_MODE_MINIMAL=y
+    sysbuild: true
+    harness: console
+    harness_config:
+      type: multi_line
+      ordered: false
+      regex:
+        - "host: IPC-service HOST demo started"
+        - "host: Ep bounded"
+        - "host: Perform sends for"
+        - "host: Sent"
+        - "host: Received"
+        - "host: IPC-service HOST demo ended"
+
+  sample.ipc.icbmsg.nrf54l15_remote_no_multithreading:
+    platform_allow: nrf54l15pdk/nrf54l15/cpuapp
+    integration_platforms:
+      - nrf54l15pdk/nrf54l15/cpuapp
+    tags: ipc
+    extra_args:
+      icmsg_SNIPPET=nordic-flpr
+      icmsg_CONFIG_IPC_SERVICE_BACKEND_ICBMSG_NUM_EP=1
+      icmsg_DTC_OVERLAY_FILE="boards/nrf54l15pdk_nrf54l15_cpuapp_icbmsg.overlay"
+      remote_CONFIG_IPC_SERVICE_BACKEND_ICBMSG_NUM_EP=1
+      remote_DTC_OVERLAY_FILE="boards/nrf54l15pdk_nrf54l15_cpuflpr_icbmsg.overlay"
+      remote_CONFIG_MULTITHREADING=n
+      remote_CONFIG_LOG_MODE_MINIMAL=y
+    sysbuild: true
+    harness: console
+    harness_config:
+      type: multi_line
+      ordered: false
+      regex:
+        - "host: IPC-service HOST demo started"
+        - "host: Ep bounded"
+        - "host: Perform sends for"
+        - "host: Sent"
+        - "host: Received"
+        - "host: IPC-service HOST demo ended"


### PR DESCRIPTION
Changed icbmsg, so that it could be used in no-multithreading applications. Also, added testcases to icmsg sample to test it with one endpoint and no-multithreading.