### PR TITLE
ipc: Remove remaining use of metal_device

### DIFF
--- a/include/zephyr/ipc/ipc_static_vrings.h
+++ b/include/zephyr/ipc/ipc_static_vrings.h
@@ -9,7 +9,6 @@
 
 #include <zephyr/ipc/ipc_service.h>
 #include <openamp/open_amp.h>
-#include <metal/device.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -55,9 +54,6 @@ struct ipc_static_vrings {
 	/** SHM physmap. */
 	metal_phys_addr_t shm_physmap[1];
 
-	/** SHM device. */
-	struct metal_device shm_device;
-
 	/** SHM and addresses. */
 	uintptr_t status_reg_addr;
 
@@ -77,7 +73,7 @@ struct ipc_static_vrings {
 	size_t shm_size;
 
 	/** SHM IO region. */
-	struct metal_io_region *shm_io;
+	struct metal_io_region shm_io;
 
 	/** VRINGs */
 	struct virtio_vring_info rvrings[VRING_COUNT];

--- a/samples/subsys/ipc/openamp/remote/src/main.c
+++ b/samples/subsys/ipc/openamp/remote/src/main.c
@@ -15,7 +15,6 @@
 #include <string.h>
 
 #include <openamp/open_amp.h>
-#include <metal/device.h>
 
 #include "common.h"
 
@@ -27,25 +26,6 @@ static const struct device *const ipm_handle =
 	DEVICE_DT_GET(DT_CHOSEN(zephyr_ipc));
 
 static metal_phys_addr_t shm_physmap[] = { SHM_START_ADDR };
-static struct metal_device shm_device = {
-	.name = SHM_DEVICE_NAME,
-	.bus = NULL,
-	.num_regions = 1,
-	{
-		{
-			.virt       = (void *) SHM_START_ADDR,
-			.physmap    = shm_physmap,
-			.size       = SHM_SIZE,
-			.page_shift = 0xffffffff,
-			.page_mask  = 0xffffffff,
-			.mem_flags  = 0,
-			.ops        = { NULL },
-		},
-	},
-	.node = { NULL },
-	.irq_num = 0,
-	.irq_info = NULL
-};
 
 static volatile unsigned int received_data;
 
@@ -59,7 +39,8 @@ static struct virtio_vring_info rvrings[2] = {
 };
 static struct virtio_device vdev;
 static struct rpmsg_virtio_device rvdev;
-static struct metal_io_region *io;
+static struct metal_io_region shm_io_data;
+static struct metal_io_region *io = &shm_io_data;
 static struct virtqueue *vqueue[2];
 
 static unsigned char ipc_virtio_get_status(struct virtio_device *dev)
@@ -147,7 +128,6 @@ void app_task(void *arg1, void *arg2, void *arg3)
 
 	int status = 0;
 	unsigned int message = 0U;
-	struct metal_device *device;
 	struct rpmsg_device *rdev;
 	struct metal_init_params metal_params = METAL_INIT_DEFAULTS;
 
@@ -159,23 +139,8 @@ void app_task(void *arg1, void *arg2, void *arg3)
 		return;
 	}
 
-	status = metal_register_generic_device(&shm_device);
-	if (status != 0) {
-		printk("Couldn't register shared memory device: %d\n", status);
-		return;
-	}
-
-	status = metal_device_open("generic", SHM_DEVICE_NAME, &device);
-	if (status != 0) {
-		printk("metal_device_open failed: %d\n", status);
-		return;
-	}
-
-	io = metal_device_io_region(device, 0);
-	if (io == NULL) {
-		printk("metal_device_io_region failed to get region\n");
-		return;
-	}
+	/* declare shared memory region */
+	metal_io_init(io, (void *)SHM_START_ADDR, shm_physmap, SHM_SIZE, -1, 0, NULL);
 
 	/* setup IPM */
 	if (!device_is_ready(ipm_handle)) {

--- a/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
+++ b/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
@@ -577,7 +577,6 @@ static int open(const struct device *instance)
 
 	data->vr.notify_cb = virtio_notify_cb;
 	data->vr.priv = (void *) conf;
-	data->vr.shm_device.name = instance->name;
 
 	err = ipc_static_vrings_init(&data->vr, conf->role);
 	if (err != 0) {
@@ -595,9 +594,9 @@ static int open(const struct device *instance)
 	rpmsg_inst->cb = ept_cb;
 
 	err = ipc_rpmsg_init(rpmsg_inst, data->role, conf->buffer_size,
-			     data->vr.shm_io, &data->vr.vdev,
-			     (void *) data->vr.shm_device.regions->virt,
-			     data->vr.shm_device.regions->size, ns_bind_cb);
+			     &data->vr.shm_io, &data->vr.vdev,
+			     (void *)data->vr.shm_addr,
+			     data->vr.shm_size, ns_bind_cb);
 	if (err != 0) {
 		goto error;
 	}

--- a/subsys/ipc/ipc_service/lib/ipc_static_vrings.c
+++ b/subsys/ipc/ipc_service/lib/ipc_static_vrings.c
@@ -7,8 +7,6 @@
 #include <zephyr/ipc/ipc_static_vrings.h>
 #include <zephyr/cache.h>
 
-#define SHM_DEVICE_DEFAULT_NAME		"sram0.shm"
-
 #define RPMSG_VQ_0		(0) /* TX virtqueue queue index */
 #define RPMSG_VQ_1		(1) /* RX virtqueue queue index */
 
@@ -75,26 +73,10 @@ const static struct virtio_dispatch dispatch = {
 static int libmetal_setup(struct ipc_static_vrings *vr)
 {
 	struct metal_init_params metal_params = METAL_INIT_DEFAULTS;
-	struct metal_device *device;
 	int err;
 
 	err = metal_init(&metal_params);
 	if (err != 0) {
-		return err;
-	}
-
-	err = metal_register_generic_device(&vr->shm_device);
-	if (err != 0) {
-		return err;
-	}
-
-	err = metal_device_open("generic", vr->shm_device.name, &device);
-	if (err != 0) {
-		return err;
-	}
-
-	vr->shm_io = metal_device_io_region(device, 0);
-	if (vr->shm_io == NULL) {
 		return err;
 	}
 
@@ -103,10 +85,6 @@ static int libmetal_setup(struct ipc_static_vrings *vr)
 
 static int libmetal_teardown(struct ipc_static_vrings *vr)
 {
-	vr->shm_io = 0;
-
-	metal_device_close(&vr->shm_device);
-
 	metal_finish();
 
 	return 0;
@@ -124,13 +102,13 @@ static int vq_setup(struct ipc_static_vrings *vr, unsigned int role)
 		return -ENOMEM;
 	}
 
-	vr->rvrings[RPMSG_VQ_0].io = vr->shm_io;
+	vr->rvrings[RPMSG_VQ_0].io = &vr->shm_io;
 	vr->rvrings[RPMSG_VQ_0].info.vaddr = (void *) vr->tx_addr;
 	vr->rvrings[RPMSG_VQ_0].info.num_descs = vr->vring_size;
 	vr->rvrings[RPMSG_VQ_0].info.align = MEM_ALIGNMENT;
 	vr->rvrings[RPMSG_VQ_0].vq = vr->vq[RPMSG_VQ_0];
 
-	vr->rvrings[RPMSG_VQ_1].io = vr->shm_io;
+	vr->rvrings[RPMSG_VQ_1].io = &vr->shm_io;
 	vr->rvrings[RPMSG_VQ_1].info.vaddr = (void *) vr->rx_addr;
 	vr->rvrings[RPMSG_VQ_1].info.num_descs = vr->vring_size;
 	vr->rvrings[RPMSG_VQ_1].info.align = MEM_ALIGNMENT;
@@ -166,13 +144,9 @@ int ipc_static_vrings_init(struct ipc_static_vrings *vr, unsigned int role)
 		return -EINVAL;
 	}
 
-	if (!vr->shm_device.name) {
-		vr->shm_device.name = SHM_DEVICE_DEFAULT_NAME;
-	}
-	vr->shm_device.num_regions = 1;
 	vr->shm_physmap[0] = vr->shm_addr;
 
-	metal_io_init(vr->shm_device.regions, (void *) vr->shm_addr,
+	metal_io_init(&vr->shm_io, (void *)vr->shm_addr,
 		      vr->shm_physmap, vr->shm_size, -1, 0, NULL);
 
 	err = libmetal_setup(vr);
@@ -197,7 +171,7 @@ int ipc_static_vrings_deinit(struct ipc_static_vrings *vr, unsigned int role)
 		return err;
 	}
 
-	metal_io_finish(vr->shm_device.regions);
+	metal_io_finish(&vr->shm_io);
 
 	return 0;
 }

--- a/subsys/ipc/rpmsg_service/rpmsg_backend.c
+++ b/subsys/ipc/rpmsg_service/rpmsg_backend.c
@@ -13,7 +13,6 @@
 #include <zephyr/logging/log.h>
 
 #include <openamp/open_amp.h>
-#include <metal/device.h>
 
 #define LOG_MODULE_NAME rpmsg_backend
 LOG_MODULE_REGISTER(LOG_MODULE_NAME, CONFIG_RPMSG_SERVICE_LOG_LEVEL);
@@ -61,25 +60,7 @@ static const struct device *const ipm_handle =
 #endif
 
 static metal_phys_addr_t shm_physmap[] = { SHM_START_ADDR };
-static struct metal_device shm_device = {
-	.name = SHM_DEVICE_NAME,
-	.bus = NULL,
-	.num_regions = 1,
-	{
-		{
-			.virt       = (void *) SHM_START_ADDR,
-			.physmap    = shm_physmap,
-			.size       = SHM_SIZE,
-			.page_shift = 0xffffffff,
-			.page_mask  = 0xffffffff,
-			.mem_flags  = 0,
-			.ops        = { NULL },
-		},
-	},
-	.node = { NULL },
-	.irq_num = 0,
-	.irq_info = NULL
-};
+static struct metal_io_region shm_io;
 
 static struct virtio_vring_info rvrings[2] = {
 	[0] = {
@@ -184,7 +165,6 @@ int rpmsg_backend_init(struct metal_io_region **io, struct virtio_device *vdev)
 {
 	int32_t                  err;
 	struct metal_init_params metal_params = METAL_INIT_DEFAULTS;
-	struct metal_device     *device;
 
 	/* Start IPM workqueue */
 	k_work_queue_start(&ipm_work_q, ipm_stack_area,
@@ -202,23 +182,9 @@ int rpmsg_backend_init(struct metal_io_region **io, struct virtio_device *vdev)
 		return err;
 	}
 
-	err = metal_register_generic_device(&shm_device);
-	if (err) {
-		LOG_ERR("Couldn't register shared memory device: %d", err);
-		return err;
-	}
-
-	err = metal_device_open("generic", SHM_DEVICE_NAME, &device);
-	if (err) {
-		LOG_ERR("metal_device_open failed: %d", err);
-		return err;
-	}
-
-	*io = metal_device_io_region(device, 0);
-	if (!*io) {
-		LOG_ERR("metal_device_io_region failed to get region");
-		return err;
-	}
+	/* declare shared memory region */
+	metal_io_init(&shm_io, (void *)SHM_START_ADDR, shm_physmap, SHM_SIZE, -1, 0, NULL);
+	*io = &shm_io;
 
 	/* IPM setup */
 #if defined(CONFIG_RPMSG_SERVICE_DUAL_IPM_SUPPORT)


### PR DESCRIPTION
The libmetal "device" abstraction can be used to represent devices in a system. This can be useful for baremetal code, but Zephyr has a proper device model. All current uses of `struct metal_device` in Zephyr are indirect ways to get at `struct metal_io_region`. This abstraction adds nothing and forces complexity due to issues with `struct metal_device` (such as it having a variable size based on compile time definitions).

Convert the last couple users of `struct metal_device` to use `struct metal_io_region` directly.
