### PR TITLE
 drivers: i3c: i3c_cdns: Fix null pointer issue in i3c cadence driver

### DIFF
--- a/drivers/i3c/i3c_cdns.c
+++ b/drivers/i3c/i3c_cdns.c
@@ -2450,7 +2450,8 @@ static void cdns_i3c_irq_handler(const struct device *dev)
 	} else {
 		uint32_t int_sl = sys_read32(config->base + SLV_ISR);
 		struct cdns_i3c_data *data = dev->data;
-		const struct i3c_target_callbacks *target_cb = data->target_config->callbacks;
+		const struct i3c_target_callbacks *target_cb =
+			data->target_config ? data->target_config->callbacks : NULL;
 		/* Clear interrupts */
 		sys_write32(int_sl, config->base + SLV_ICR);
 


### PR DESCRIPTION
Fixing a bug where during the bus_init routine, when a slave is initialized, the target hardware can get an interrupt, and this can occur before the target_config structure is assigned; the generic IRQ handler attempts to use this structure to grab callback function pointers, but with no target config it attempts to access the structure member from a null pointer.

Fix simply adds a ternary operation to assign callback pointer if target_config is not null.
