### PR TITLE
drivers: i3c: Move clocking code out of NXP I3C driver

### DIFF
--- a/drivers/i3c/i3c_mcux.c
+++ b/drivers/i3c/i3c_mcux.c
@@ -98,27 +98,8 @@ struct mcux_i3c_data {
 	/** Condvar for waiting for bus to be in IDLE state */
 	struct k_condvar condvar;
 
-	struct {
-		/**
-		 * Clock divider for use when generating clock for
-		 * I3C Push-pull mode.
-		 */
-		uint8_t clk_div_pp;
-
-		/**
-		 * Clock divider for use when generating clock for
-		 * I3C open drain mode.
-		 */
-		uint8_t clk_div_od;
-
-		/**
-		 * Clock divider for the slow time control clock.
-		 */
-		uint8_t clk_div_tc;
-
-		/** I3C open drain clock frequency in Hz. */
-		uint32_t i3c_od_scl_hz;
-	} clocks;
+	/** I3C open drain clock frequency in Hz. */
+	uint32_t i3c_od_scl_hz;
 
 #ifdef CONFIG_I3C_USE_IBI
 	struct {
@@ -1912,8 +1893,8 @@ static int mcux_i3c_configure(const struct device *dev,
 	master_config.baudRate_Hz.i3cPushPullBaud = ctrl_cfg->scl.i3c;
 	master_config.enableOpenDrainHigh = dev_cfg->disable_open_drain_high_pp ? false : true;
 
-	if (dev_data->clocks.i3c_od_scl_hz) {
-		master_config.baudRate_Hz.i3cOpenDrainBaud = dev_data->clocks.i3c_od_scl_hz;
+	if (dev_data->i3c_od_scl_hz) {
+		master_config.baudRate_Hz.i3cOpenDrainBaud = dev_data->i3c_od_scl_hz;
 	}
 
 	/* Initialize hardware */
@@ -1978,10 +1959,6 @@ static int mcux_i3c_init(const struct device *dev)
 	if (ret != 0) {
 		goto err_out;
 	}
-
-	CLOCK_SetClkDiv(kCLOCK_DivI3cClk, data->clocks.clk_div_pp);
-	CLOCK_SetClkDiv(kCLOCK_DivI3cSlowClk, data->clocks.clk_div_od);
-	CLOCK_SetClkDiv(kCLOCK_DivI3cTcClk, data->clocks.clk_div_tc);
 
 	ret = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
 	if (ret != 0) {
@@ -2159,12 +2136,9 @@ static const struct i3c_driver_api mcux_i3c_driver_api = {
 			DT_INST_PROP(id, disable_open_drain_high_pp),		\
 	};									\
 	static struct mcux_i3c_data mcux_i3c_data_##id = {			\
-		.clocks.i3c_od_scl_hz = DT_INST_PROP_OR(id, i3c_od_scl_hz, 0),	\
+		.i3c_od_scl_hz = DT_INST_PROP_OR(id, i3c_od_scl_hz, 0),		\
 		.common.ctrl_config.scl.i3c = DT_INST_PROP_OR(id, i3c_scl_hz, 0),	\
 		.common.ctrl_config.scl.i2c = DT_INST_PROP_OR(id, i2c_scl_hz, 0),	\
-		.clocks.clk_div_pp = DT_INST_PROP(id, clk_divider),		\
-		.clocks.clk_div_od = DT_INST_PROP(id, clk_divider_slow),	\
-		.clocks.clk_div_tc = DT_INST_PROP(id, clk_divider_tc),		\
 	};									\
 	DEVICE_DT_INST_DEFINE(id,						\
 			      mcux_i3c_init,					\

--- a/soc/nxp/imxrt/imxrt5xx/cm33/soc.c
+++ b/soc/nxp/imxrt/imxrt5xx/cm33/soc.c
@@ -303,9 +303,16 @@ void __weak rt5xx_clock_init(void)
 	CLOCK_AttachClk(kFRO_DIV4_to_FLEXCOMM4);
 #endif
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(i3c0), nxp_mcux_i3c, okay)
-	/* Attach main clock to I3C, divider will be set in i3c_mcux.c */
+	/* Attach main clock to I3C */
 	CLOCK_AttachClk(kMAIN_CLK_to_I3C_CLK);
 	CLOCK_AttachClk(kLPOSC_to_I3C_TC_CLK);
+
+	CLOCK_SetClkDiv(kCLOCK_DivI3cClk,
+			DT_PROP(DT_NODELABEL(i3c0), clk_divider));
+	CLOCK_SetClkDiv(kCLOCK_DivI3cSlowClk,
+			DT_PROP(DT_NODELABEL(i3c0), clk_divider_slow));
+	CLOCK_SetClkDiv(kCLOCK_DivI3cTcClk,
+			DT_PROP(DT_NODELABEL(i3c0), clk_divider_tc));
 #endif
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(hs_spi1), nxp_lpc_spi, okay)
 	CLOCK_AttachClk(kFRO_DIV4_to_FLEXCOMM16);

--- a/soc/nxp/imxrt/imxrt6xx/cm33/soc.c
+++ b/soc/nxp/imxrt/imxrt6xx/cm33/soc.c
@@ -307,6 +307,13 @@ static ALWAYS_INLINE void clock_init(void)
 #if (DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(i3c0), nxp_mcux_i3c, okay))
 	CLOCK_AttachClk(kFFRO_to_I3C_CLK);
 	CLOCK_AttachClk(kLPOSC_to_I3C_TC_CLK);
+
+	CLOCK_SetClkDiv(kCLOCK_DivI3cClk,
+			DT_PROP(DT_NODELABEL(i3c0), clk_divider));
+	CLOCK_SetClkDiv(kCLOCK_DivI3cSlowClk,
+			DT_PROP(DT_NODELABEL(i3c0), clk_divider_slow));
+	CLOCK_SetClkDiv(kCLOCK_DivI3cTcClk,
+			DT_PROP(DT_NODELABEL(i3c0), clk_divider_tc));
 #endif
 
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(lpadc0), nxp_lpc_lpadc, okay)


### PR DESCRIPTION
The clocking code present inside the NXP I3C is SoC specific. This has been moved to the SoC folder which makes this driver more flexible to clock architecture variations between SoC's and SDK driver clock API variations.