### PR TITLE
NXP drivers: spi: spi_mcux_lpspi: enable CONFIG_SPI_ASYNC mode with DMA

### DIFF
--- a/drivers/dma/dma_mcux_edma.c
+++ b/drivers/dma/dma_mcux_edma.c
@@ -532,6 +532,17 @@ static int dma_mcux_edma_reload(const struct device *dev, uint32_t channel,
 		ret = -EFAULT;
 	}
 
+	if (data->edma_handle.tcdPool == NULL) {
+		/* Not using scatter/gather mode:
+		 * The fsl_edma driver uses the eDMA DREQ bit to automatically
+		 * disable the hardware DMA request at the end of the major loop.
+		 * After submitting a new transer, re-enable the hardware
+		 * request
+		 */
+		EDMA_EnableChannelRequest(DEV_EDMA_HANDLE(dev, channel)->base,
+			channel);
+	}
+
 cleanup:
 	irq_unlock(key);
 	return ret;

--- a/drivers/spi/Kconfig.mcux_lpspi
+++ b/drivers/spi/Kconfig.mcux_lpspi
@@ -9,6 +9,7 @@ config SPI_MCUX_LPSPI
 	depends on DT_HAS_NXP_IMX_LPSPI_ENABLED
 	depends on CLOCK_CONTROL
 	select PINCTRL
+	select SPI_MCUX_LPSPI_DMA if SPI_ASYNC
 	help
 	  Enable support for mcux spi driver.
 

--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -322,26 +322,64 @@ static void spi_mcux_dma_callback(const struct device *dev, void *arg,
 		}
 	}
 #if CONFIG_SPI_ASYNC
+	int ret;
+
 	if (data->ctx.asynchronous &&
 	((data->status_flags & SPI_MCUX_LPSPI_DMA_DONE_FLAG)  ==
 	SPI_MCUX_LPSPI_DMA_DONE_FLAG)) {
-		/* Load dma blocks of equal length */
-		size_t dma_size = MIN(data->ctx.tx_len, data->ctx.rx_len);
-
-		if (dma_size == 0) {
-			dma_size = MAX(data->ctx.tx_len, data->ctx.rx_len);
-		}
+		/* dma_size of completed transfers were the same for TX and RX */
+		size_t dma_size = data->ctx.tx_len;
 
 		spi_context_update_tx(&data->ctx, 1, dma_size);
 		spi_context_update_rx(&data->ctx, 1, dma_size);
 
 		if (data->ctx.tx_len == 0 && data->ctx.rx_len == 0) {
 			spi_context_complete(&data->ctx, spi_dev, 0);
+			return;
 		}
+
+		/* Restart DMA for next buffer */
+		/* Load dma blocks of equal length */
+		dma_size = MIN(data->ctx.tx_len, data->ctx.rx_len);
+
+		if (dma_size == 0) {
+			dma_size = MAX(data->ctx.tx_len, data->ctx.rx_len);
+		}
+
+		/* Clear status flags */
+		data->status_flags = 0U;
+
+		/* Restart the RX DMA */
+		ret = dma_reload(dev,
+				 data->dma_rx.channel,
+				 data->dma_rx.dma_blk_cfg.source_address,
+				 (uint32_t) data->ctx.rx_buf,
+				 dma_size);
+		if (ret != 0) {
+			LOG_ERR("RX dma_reload() failed with error %x.", ret);
+			data->status_flags |= SPI_MCUX_LPSPI_DMA_ERROR_FLAG;
+		}
+
+		/* Restart the TX DMA */
+		ret = dma_reload(dev,
+				 data->dma_tx.channel,
+				 (uint32_t) data->ctx.tx_buf,
+				 data->dma_tx.dma_blk_cfg.dest_address,
+				 dma_size);
+		if (ret != 0) {
+			LOG_ERR("TX dma_reload() failed with error %x.", ret);
+			data->status_flags |= SPI_MCUX_LPSPI_DMA_ERROR_FLAG;
+		}
+
 		return;
 	}
-#endif
+
+	if (!data->ctx.asynchronous) {
+		spi_context_complete(&data->ctx, spi_dev, 0);
+	}
+#else
 	spi_context_complete(&data->ctx, spi_dev, 0);
+#endif /* CONFIG_SPI_ASYNC */
 }
 
 static int spi_mcux_dma_tx_load(const struct device *dev, const uint8_t *buf, size_t len)

--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -370,8 +370,6 @@ static int spi_mcux_dma_tx_load(const struct device *dev, const uint8_t *buf, si
 		blk_cfg->source_address = (uint32_t)buf;
 		stream->dma_cfg.channel_direction = MEMORY_TO_PERIPHERAL;
 	}
-	/* Enable scatter/gather */
-	blk_cfg->source_gather_en = 1;
 	/* Dest is LPSPI tx fifo */
 	blk_cfg->dest_address = LPSPI_GetTxRegisterAddress(base);
 	blk_cfg->block_size = len;
@@ -414,8 +412,6 @@ static int spi_mcux_dma_rx_load(const struct device *dev, uint8_t *buf,
 		stream->dma_cfg.channel_direction = PERIPHERAL_TO_MEMORY;
 	}
 	blk_cfg->block_size = len;
-	/* Enable scatter/gather */
-	blk_cfg->dest_scatter_en = 1;
 	/* Source is LPSPI rx fifo */
 	blk_cfg->source_address = LPSPI_GetRxRegisterAddress(base);
 	stream->dma_cfg.source_burst_length = 1;

--- a/tests/drivers/spi/spi_loopback/boards/frdm_ke17z512.conf
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_ke17z512.conf
@@ -4,4 +4,3 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 CONFIG_SPI_MCUX_LPSPI_DMA=y
-CONFIG_SPI_ASYNC=n

--- a/tests/drivers/spi/spi_loopback/boards/frdm_mcxn236.conf
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_mcxn236.conf
@@ -4,4 +4,3 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 CONFIG_SPI_MCUX_LPSPI_DMA=n
-CONFIG_SPI_ASYNC=n

--- a/tests/drivers/spi/spi_loopback/boards/frdm_mcxn947_mcxn947_cpu0.conf
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_mcxn947_mcxn947_cpu0.conf
@@ -4,4 +4,3 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 CONFIG_SPI_MCUX_LPSPI_DMA=y
-CONFIG_SPI_ASYNC=n

--- a/tests/drivers/spi/spi_loopback/boards/frdm_mcxn947_mcxn947_cpu0_qspi.conf
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_mcxn947_mcxn947_cpu0_qspi.conf
@@ -4,4 +4,3 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 CONFIG_SPI_MCUX_LPSPI_DMA=y
-CONFIG_SPI_ASYNC=n

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1010_evk.conf
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1010_evk.conf
@@ -4,4 +4,3 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 CONFIG_SPI_MCUX_LPSPI_DMA=y
-CONFIG_SPI_ASYNC=n

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1015_evk.conf
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1015_evk.conf
@@ -4,4 +4,3 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 CONFIG_SPI_MCUX_LPSPI_DMA=y
-CONFIG_SPI_ASYNC=n

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1020_evk.conf
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1020_evk.conf
@@ -4,4 +4,3 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 CONFIG_SPI_MCUX_LPSPI_DMA=y
-CONFIG_SPI_ASYNC=n

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1024_evk.conf
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1024_evk.conf
@@ -4,4 +4,3 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 CONFIG_SPI_MCUX_LPSPI_DMA=y
-CONFIG_SPI_ASYNC=n

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1040_evk.conf
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1040_evk.conf
@@ -4,4 +4,3 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 CONFIG_SPI_MCUX_LPSPI_DMA=y
-CONFIG_SPI_ASYNC=n

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1050_evk.conf
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1050_evk.conf
@@ -4,4 +4,3 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 CONFIG_SPI_MCUX_LPSPI_DMA=y
-CONFIG_SPI_ASYNC=n

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1060_evk.conf
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1060_evk.conf
@@ -4,4 +4,3 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 CONFIG_SPI_MCUX_LPSPI_DMA=y
-CONFIG_SPI_ASYNC=n

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1064_evk.conf
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1064_evk.conf
@@ -4,4 +4,3 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 CONFIG_SPI_MCUX_LPSPI_DMA=y
-CONFIG_SPI_ASYNC=n

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1170_evk_mimxrt1176_cm7_A.conf
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1170_evk_mimxrt1176_cm7_A.conf
@@ -4,4 +4,3 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 CONFIG_SPI_MCUX_LPSPI_DMA=y
-CONFIG_SPI_ASYNC=n

--- a/tests/drivers/spi/spi_loopback/src/spi.c
+++ b/tests/drivers/spi/spi_loopback/src/spi.c
@@ -59,6 +59,9 @@ static struct spi_dt_spec spi_slow = SPI_DT_SPEC_GET(SPI_SLOW_DEV, SPI_OP(FRAME_
 #define BUF_SIZE 18
 #define BUF2_SIZE 36
 #define BUF3_SIZE 8192
+#define TX_BUF_SIZE 8
+BUILD_ASSERT(TX_BUF_SIZE < BUF_SIZE,
+	"Transmit buffer is expected to be smaller than the receive buffer");
 
 #if CONFIG_NOCACHE_MEMORY
 #define __NOCACHE	__attribute__((__section__(".nocache")))
@@ -449,10 +452,7 @@ static int spi_rx_every_4(struct spi_dt_spec *spec)
 
 static int spi_rx_bigger_than_tx(struct spi_dt_spec *spec)
 {
-	const uint32_t tx_buf_size = 8;
-
-	BUILD_ASSERT(tx_buf_size < BUF_SIZE,
-		"Transmit buffer is expected to be smaller than the receive buffer");
+	const uint32_t tx_buf_size = TX_BUF_SIZE;
 
 	const struct spi_buf tx_bufs[] = {
 		{


### PR DESCRIPTION
Updates LPSPI driver to support async mode with DMA.  Enables `spi_loopback` testing async mode on all the NXP boards with the LPSPI peripherals.  Resolves #74907.

spi_loopback test with `CONFIG_SPI_ASYNC` passes on the following boards.  The test failed on 1 board which needs more investigation, a separate issue created for that board at https://github.com/zephyrproject-rtos/zephyr/issues/78238.
- Mimxrt1010_evk
- Mimxrt1020_evk
- Mimxrt1024_evk
- Mimxrt1040_evk
- Mimxrt1170_evk_cm7
- Frdm_ke17z512
- frdm_mcxn947//cpu0
- frdm_mcxn236