### PR TITLE
dts: bindings: clock: rpi_pico: add XOSC definition

### DIFF
--- a/dts/arm/rpi_pico/rp2040.dtsi
+++ b/dts/arm/rpi_pico/rp2040.dtsi
@@ -157,8 +157,9 @@
 		};
 
 		xosc: xosc {
-			compatible = "raspberrypi,pico-clock";
+			compatible = "raspberrypi,pico-xosc";
 			clock-frequency = <12000000>;
+			startup-delay-multiplier = <64>;
 			#clock-cells = <0>;
 		};
 

--- a/dts/bindings/clock/raspberrypi,pico-xosc.yaml
+++ b/dts/bindings/clock/raspberrypi,pico-xosc.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2024 Xudong Zheng
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  The representation of Raspberry Pi Pico external oscillator
+
+compatible: "raspberrypi,pico-xosc"
+
+include: raspberrypi,pico-clock.yaml
+
+properties:
+  startup-delay-multiplier:
+    type: int
+    description: Startup delay multiplier

--- a/modules/hal_rpi_pico/pico/config_autogen.h
+++ b/modules/hal_rpi_pico/pico/config_autogen.h
@@ -32,6 +32,11 @@
 /* Disable binary info */
 #define PICO_NO_BINARY_INFO 1
 
+#ifdef CONFIG_DT_HAS_RASPBERRYPI_PICO_XOSC_ENABLED
+#include <zephyr/devicetree.h>
+#define PICO_XOSC_STARTUP_DELAY_MULTIPLIER DT_PROP(DT_NODELABEL(xosc), startup_delay_multiplier)
+#endif
+
 /* Zephyr compatible way of forcing inline */
 #ifndef __always_inline
 #define __always_inline ALWAYS_INLINE


### PR DESCRIPTION
On some boards, XOSC can take longer to stabilize.