### PR TITLE
Posix: fs: add O_TRUNC flag for open()

### DIFF
--- a/include/zephyr/posix/fcntl.h
+++ b/include/zephyr/posix/fcntl.h
@@ -8,9 +8,13 @@
 #define ZEPHYR_POSIX_FCNTL_H_
 
 #ifdef CONFIG_PICOLIBC
-#define O_CREAT 0x0040
+#define O_CREAT	 0x0040
+#define O_TRUNC	 0x0200
+#define O_APPEND 0x0400
 #else
-#define O_CREAT 0x0200
+#define O_CREAT	 0x0200
+#define O_TRUNC	 0x0400
+#define O_APPEND 0x0008
 #endif
 
 #define O_ACCMODE (O_RDONLY | O_WRONLY | O_RDWR)
@@ -19,7 +23,6 @@
 #define O_WRONLY 01
 #define O_RDWR	 02
 
-#define O_APPEND   0x0400
 #define O_EXCL	   0x0800
 #define O_NONBLOCK 0x4000
 

--- a/lib/posix/options/fs.c
+++ b/lib/posix/options/fs.c
@@ -64,6 +64,7 @@ static int posix_mode_to_zephyr(int mf)
 	int mode = (mf & O_CREAT) ? FS_O_CREATE : 0;
 
 	mode |= (mf & O_APPEND) ? FS_O_APPEND : 0;
+	mode |= (mf & O_TRUNC) ? FS_O_TRUNC : 0;
 
 	switch (mf & O_ACCMODE) {
 	case O_RDONLY:

--- a/tests/posix/fs/src/test_fs_file.c
+++ b/tests/posix/fs/src/test_fs_file.c
@@ -341,3 +341,20 @@ ZTEST(posix_fs_file_test, test_fs_fd_leak)
 		}
 	}
 }
+
+ZTEST(posix_fs_file_test, test_file_open_truncate)
+{
+	struct stat buf = {0};
+
+	zassert_ok(test_file_open());
+	zassert_ok(test_file_write());
+	zassert_ok(test_file_close());
+	file = open(TEST_FILE, O_RDWR | O_TRUNC);
+	zassert_not_equal(file, -1,
+			  "File open failed for truncate mode");
+
+	zassert_ok(test_file_close());
+	zassert_ok(stat(TEST_FILE, &buf));
+	zassert_equal(buf.st_size, 0, "Error: file is not truncated");
+	zassert_ok(test_file_delete());
+}


### PR DESCRIPTION
Add flag argument for posix open() api, which needs to convert to zephyr respective file system flag.
Introduction of O_TRUNC flag for open() has conflict with the libc(picolibc), flags introduction commit
will be based on https://github.com/zephyrproject-rtos/zephyr/commit/f646390c3218e8cdc71e9e9b0f371d2f40d3a5a7.