### PR TITLE
Bluetooth: Controller: Rework FAKE_ENTROPY_NATIVE_POSIX text

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -157,18 +157,18 @@ config BT_CTLR_ENTROPY
 	select ENTROPY_GENERATOR
 	default y
 	help
-	  Use random number generation provided by the Controller.
+	  Use random number generation selected by the Controller.
 
 	  Bluetooth Core Specification mandates a use of random number generator
 	  compliant with FIPS PUB 140-2.
 
-	  This option allows for Controller implementation that do not use true
-	  random number generation and hence making the implementation as
-	  experimental.
+	  Deselecting this option allows for Controllers to use other entropy
+	  generators which may not be true random number generators, and hence
+	  would make the implementation experimental.
 
-	  Controller implementations can provide custom bare-metal random number
-	  implementation without any support in Zephyr driver, i.e. there is no
-	  ENTROPY_HAS_DRIVER enabled.
+	  A Controller implementation could also provide custom bare-metal
+	  random number generator implementation without any support in Zephyr
+	  driver, i.e. there is no ENTROPY_HAS_DRIVER enabled.
 
 config BT_CTLR_CRYPTO
 	bool "Crypto functions in Controller"
@@ -178,11 +178,11 @@ config BT_CTLR_CRYPTO
 	  Use random number generation and AES encryption support functions
 	  provided by the controller.
 
-	  Support for HCI LE Rand and HCI LE Encrypt commands are mandatory
-	  by Bluetooth Core Specification.
+	  Support for HCI LE Rand and HCI LE Encrypt commands is mandatory by
+	  Bluetooth Core Specification.
 
 	  In an Application/Host and Controller split (using a HCI transport) or
-	  combined builds for single CPU SoCs, applications can use its own
+	  combined builds for single CPU SoCs, applications can use their own
 	  FIPS-197 compliant cryptographic implementations. In this case the
 	  Controller cryptographic implementations can be disabled to save flash
 	  and RAM usage.

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -59,6 +59,9 @@ static struct {
 
 /* Entropy device */
 #if defined(CONFIG_ENTROPY_HAS_DRIVER)
+/* FIXME: This could probably use a chosen entropy device instead on relying on
+ * the nodelabel being the same as for the old nrf rng.
+ */
 static const struct device *const dev_entropy = DEVICE_DT_GET(DT_NODELABEL(rng));
 #endif /* CONFIG_ENTROPY_HAS_DRIVER */
 


### PR DESCRIPTION
Rework comment text for FAKE_ENTROPY_NATIVE_POSIX used as entropy driver for the Controller on BOARD_NRF54L15BSIM.

Relates to commit 34b6b3d9eb33 ("Bluetooth: Controller: Support FAKE_ENTROPY_NATIVE_POSIX").