### PR TITLE
websocket: remove consts in websocket_request structure

### DIFF
--- a/include/zephyr/net/http/client.h
+++ b/include/zephyr/net/http/client.h
@@ -245,7 +245,7 @@ struct http_request {
 	 * calling application wants to know the parsing status or the HTTP
 	 * fields. This is optional and normally not needed.
 	 */
-	const struct http_parser_settings *http_cb;
+	struct http_parser_settings *http_cb;
 
 	/** User supplied buffer where received data is stored */
 	uint8_t *recv_buf;
@@ -254,10 +254,10 @@ struct http_request {
 	size_t recv_buf_len;
 
 	/** The URL for this request, for example: /index.html */
-	const char *url;
+	char *url;
 
 	/** The HTTP protocol, for example "HTTP/1.1" */
-	const char *protocol;
+	char *protocol;
 
 	/** The HTTP header fields (application specific)
 	 * The Content-Type may be specified here or in the next field.
@@ -265,16 +265,16 @@ struct http_request {
 	 * some header fields may remain constant through the application's
 	 * life cycle. This is a NULL terminated list of header fields.
 	 */
-	const char **header_fields;
+	char **header_fields;
 
 	/** The value of the Content-Type header field, may be NULL */
-	const char *content_type_value;
+	char *content_type_value;
 
 	/** Hostname to be used in the request */
-	const char *host;
+	char *host;
 
 	/** Port number to be used in the request */
-	const char *port;
+	char *port;
 
 	/** User supplied callback function to call when payload
 	 * needs to be sent. This can be NULL in which case the payload field
@@ -285,7 +285,7 @@ struct http_request {
 	http_payload_cb_t payload_cb;
 
 	/** Payload, may be NULL */
-	const char *payload;
+	char *payload;
 
 	/** Payload length is used to calculate Content-Length. Set to 0
 	 * for chunked transfers.
@@ -309,7 +309,7 @@ struct http_request {
 	 * header_fields variable and any optional application specific
 	 * headers will be placed into this field.
 	 */
-	const char **optional_headers;
+	char **optional_headers;
 };
 
 /**

--- a/include/zephyr/net/websocket.h
+++ b/include/zephyr/net/websocket.h
@@ -69,10 +69,10 @@ typedef int (*websocket_connect_cb_t)(int ws_sock, struct http_request *req,
  */
 struct websocket_request {
 	/** Host of the Websocket server when doing HTTP handshakes. */
-	const char *host;
+	char *host;
 
 	/** URL of the Websocket. */
-	const char *url;
+	char *url;
 
 	/** User supplied callback function to call when optional headers need
 	 * to be sent. This can be NULL, in which case the optional_headers
@@ -86,7 +86,7 @@ struct websocket_request {
 	 * should be added to the HTTP request. May be NULL.
 	 * If the optional_headers_cb is specified, then this field is ignored.
 	 */
-	const char **optional_headers;
+	char **optional_headers;
 
 	/** User supplied callback function to call when a connection is
 	 * established.
@@ -99,7 +99,7 @@ struct websocket_request {
 	 * is useful if the caller wants to know something about
 	 * the fields that the server is sending.
 	 */
-	const struct http_parser_settings *http_cb;
+	struct http_parser_settings *http_cb;
 
 	/** User supplied buffer where HTTP connection data is stored */
 	uint8_t *tmp_buf;

--- a/subsys/net/lib/websocket/websocket.c
+++ b/subsys/net/lib/websocket/websocket.c
@@ -312,7 +312,7 @@ int websocket_connect(int sock, struct websocket_request *wreq,
 	req.url = wreq->url;
 	req.host = wreq->host;
 	req.protocol = "HTTP/1.1";
-	req.header_fields = (const char **)headers;
+	req.header_fields = headers;
 	req.optional_headers_cb = wreq->optional_headers_cb;
 	req.optional_headers = wreq->optional_headers;
 	req.response = response_cb;


### PR DESCRIPTION
Remove const definitions in the websocket_request structure so that user application is not constrained by the definition of the fields.

@jukkar this is following discussion on Discord. Do you think this should be backported to v3.7 branch ? This should be better according to me.