### PR TITLE
Bug: Fix issue in KConfig of Renesas modules

### DIFF
--- a/drivers/flash/Kconfig.renesas_ra
+++ b/drivers/flash/Kconfig.renesas_ra
@@ -25,4 +25,9 @@ config FLASH_RA_WRITE_PROTECT
 	  Enables flash extended operation to enable/disable flash write
 	  protection from external devices
 
+config DUAL_BANK_MODE
+	bool "Dual bank mode"
+	help
+	  Enable dual bank mode
+
 endif # RA_FLASH_HP

--- a/modules/Kconfig.renesas_fsp
+++ b/modules/Kconfig.renesas_fsp
@@ -8,6 +8,8 @@ config HAS_RENESAS_RA_FSP
 	help
 	  Enable Renesas RA FSP support
 
+if HAS_RENESAS_RA_FSP
+
 config USE_RA_FSP_SCI_B_UART
 	bool
 	help
@@ -58,3 +60,5 @@ config USE_RA_FSP_FLASH_HP
 	bool
 	help
 	  Enable RA FSP FLASH HP driver
+
+endif # HAS_RENESAS_RA_FSP

--- a/soc/renesas/ra/ra8d1/Kconfig.soc
+++ b/soc/renesas/ra/ra8d1/Kconfig.soc
@@ -6,7 +6,7 @@ config SOC_SERIES_RA8D1
 	bool
 	select SOC_FAMILY_RENESAS_RA
 	help
-		Renesas RA8D1 series
+	  Renesas RA8D1 series
 
 config SOC_SERIES
 	default "ra8d1" if SOC_SERIES_RA8D1
@@ -15,13 +15,7 @@ config SOC_R7FA8D1BHECBD
 	bool
 	select SOC_SERIES_RA8D1
 	help
-		R7FA8D1BHECBD
+	  R7FA8D1BHECBD
 
 config SOC
 	default "r7fa8d1bhecbd" if SOC_R7FA8D1BHECBD
-
-config DUAL_BANK_MODE
-	bool "Dual bank mode"
-	default n
-	help
-	  Enable dual bank mode

--- a/soc/renesas/ra/ra8m1/Kconfig.soc
+++ b/soc/renesas/ra/ra8m1/Kconfig.soc
@@ -19,9 +19,3 @@ config SOC_SERIES
 
 config SOC
 	default "r7fa8m1ahecbd" if SOC_R7FA8M1AHECBD
-
-config DUAL_BANK_MODE
-	bool "Dual bank mode"
-	default n
-	help
-	  Enable dual bank mode

--- a/soc/renesas/ra/ra8t1/Kconfig.soc
+++ b/soc/renesas/ra/ra8t1/Kconfig.soc
@@ -6,7 +6,7 @@ config SOC_SERIES_RA8T1
 	bool
 	select SOC_FAMILY_RENESAS_RA
 	help
-		Renesas RA8T1 series
+	  Renesas RA8T1 series
 
 config SOC_SERIES
 	default "ra8t1" if SOC_SERIES_RA8T1
@@ -15,13 +15,7 @@ config SOC_R7FA8T1AHECBD
 	bool
 	select SOC_SERIES_RA8T1
 	help
-		R7FA8T1AHECBD
+	  R7FA8T1AHECBD
 
 config SOC
 	default "r7fa8t1ahecbd" if SOC_R7FA8T1AHECBD
-
-config DUAL_BANK_MODE
-	bool "Dual bank mode"
-	default n
-	help
-	  Enable dual bank mode


### PR DESCRIPTION
Fix KConfig issue for Renesas related modules:
+ Add condition for KConfig Renesas FSP hal module
+ Move the DUAL_BANK_MODE from SOC to flash driver KCONFIG

Relate issue: https://github.com/zephyrproject-rtos/zephyr/issues/78205
Bug PR: https://github.com/zephyrproject-rtos/zephyr/pull/76304