### PR TITLE
native_simulator: Separate native sim interface code and data during linking

### DIFF
--- a/boards/native/nrf_bsim/ipc_backend.c
+++ b/boards/native/nrf_bsim/ipc_backend.c
@@ -21,7 +21,7 @@
 #define DT_DRV_COMPAT zephyr_ipc_openamp_static_vrings
 
 #define DEFINE_BACKEND_BUFFER(i) \
-	NATIVE_SIMULATOR_IF \
+	NATIVE_SIMULATOR_IF_DATA \
 	char IPC##i##_shm_buffer[DT_REG_SIZE(DT_INST_PHANDLE(i, memory_region))];
 
 DT_INST_FOREACH_STATUS_OKAY(DEFINE_BACKEND_BUFFER)

--- a/include/zephyr/arch/posix/linker.ld
+++ b/include/zephyr/arch/posix/linker.ld
@@ -86,10 +86,7 @@ SECTION_DATA_PROLOGUE(_NOINIT_SECTION_NAME,,)
 
 } INSERT AFTER .data;
 
-SECTIONS
-{
 #include <zephyr/arch/posix/native_sim_interface.ld>
-} INSERT AFTER .text;
 
 /*
  * Note that the INSERT command actually changes the meaning of the -T command

--- a/include/zephyr/arch/posix/native_sim_interface.ld
+++ b/include/zephyr/arch/posix/native_sim_interface.ld
@@ -4,8 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-SECTION_PROLOGUE (.native_sim_if,,)
+#include <zephyr/linker/sections.h>
+
+SECTIONS
 {
-	KEEP(*(.native_sim_if));
-	KEEP(*(.native_sim_if.*));
-}
+	SECTION_PROLOGUE (.native_sim_if.data,,)
+	{
+		KEEP(*(.native_sim_if.data));
+	}
+} INSERT AFTER .data;
+
+SECTIONS
+{
+	SECTION_PROLOGUE (.native_sim_if,,)
+	{
+		KEEP(*(.native_sim_if));
+		KEEP(*(.native_sim_if.*));
+	}
+} INSERT AFTER .text;

--- a/samples/boards/nrf/nrf53_sync_rtc/src/main.c
+++ b/samples/boards/nrf/nrf53_sync_rtc/src/main.c
@@ -17,7 +17,7 @@ LOG_MODULE_REGISTER(main);
 /* For simulation, we can define shared memory variables linkable from
  * other MCUs just by using NATIVE_SIMULATOR_IF
  */
-NATIVE_SIMULATOR_IF uint32_t shared_cell_buffer;
+NATIVE_SIMULATOR_IF_DATA uint32_t shared_cell_buffer;
 static uint32_t shared_cell = (uintptr_t)&shared_cell_buffer;
 #else
 static uint32_t shared_cell = 0x20070000;

--- a/scripts/native_simulator/common/src/include/nsi_cpu_if.h
+++ b/scripts/native_simulator/common/src/include/nsi_cpu_if.h
@@ -14,12 +14,16 @@ extern "C" {
 #include "nsi_cpu_if_internal.h"
 
 /*
- * Any symbol annotated by this macro will be visible outside of the
+ * Any symbol annotated by these macros will be visible outside of the
  * embedded SW library, both by the native simulator runner,
  * and other possible embedded CPU's SW.
  */
-#define NATIVE_SIMULATOR_IF __attribute__((visibility("default"))) \
-	__attribute__((__section__(".native_sim_if")))
+#define NATIVE_SIMULATOR_IF_SECT(sect) __attribute__((visibility("default"))) \
+	__attribute__((__section__(sect)))
+#define NATIVE_SIMULATOR_IF NATIVE_SIMULATOR_IF_SECT(".native_sim_if")
+#define NATIVE_SIMULATOR_IF_DATA NATIVE_SIMULATOR_IF_SECT(".native_sim_if.data")
+#define NATIVE_SIMULATOR_IF_TEXT NATIVE_SIMULATOR_IF_SECT(".native_sim_if.text")
+
 /*
  * Implementation note:
  * The interface between the embedded SW and the native simulator is allocated in its


### PR DESCRIPTION
ld is getting more picky about ending up with RW data and text (eXe) in the same segment (new versions warn about it)
For the native simulator, we have macros to define symbols which we want exposed out of the embedded SW image.
So far we placed these in the same section which we kept during the embedded SW image linking to avoid them being garbage collected. As we just bundled them all in one section, this could end up in the same segment.

Let's provide users with two sections where to place these symbols, and place one after .data and the other after .text, to make the linker life easier.

Related to #74332