### PR TITLE
Tests: bsim: Use correct compilation folder

### DIFF
--- a/tests/bsim/compile.source
+++ b/tests/bsim/compile.source
@@ -42,6 +42,10 @@ function _compile(){
   local map_file_name=${exe_name}.Tsymbols
 
   local this_dir=${WORK_DIR}/${app}/${exe_basename}
+  local app_absolute=$(realpath "${app_root}/${app}")
+  if [[ "${app_absolute}" != "${app_root}"* ]]; then
+    this_dir=${WORK_DIR}/${app_absolute}/${exe_basename}
+  fi
 
   local modules_arg="${ZEPHYR_MODULES:+-DZEPHYR_MODULES=${ZEPHYR_MODULES}}"
 


### PR DESCRIPTION
If a test was written outside 'app_root' the 'app' path may contain previous directory ('..') which would lead to the compilation file being written outside the 'WORK_DIR'.

Fix the issue by checking if the 'app' is inside 'app_root', if it's not, use the absolute path to the app for creating the 'this_dir' variable.