### PR TITLE
ci: bsim tests: Also trigger on common nordic DT changes

### DIFF
--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -8,6 +8,8 @@ on:
       - "west.yml"
       - "subsys/bluetooth/**"
       - "tests/bsim/**"
+      - "boards/nordic/nrf5*/*dt*"
+      - "dts/*/nordic/**"
       - "tests/bluetooth/common/testlib/**"
       - "samples/bluetooth/**"
       - "boards/posix/**"
@@ -98,6 +100,8 @@ jobs:
             include/zephyr/arch/posix/
             scripts/native_simulator/
             tests/bsim/*
+            boards/nordic/nrf5*/*dt*
+            dts/*/nordic/
 
       - name: Check if Bluethooth files changed
         uses: tj-actions/changed-files@v45


### PR DESCRIPTION
The bsim boards, just like the real ones, use the common nordic DT definitions, but this were not triggering CI. Some issues got in main due to this. Let's be sure to trigger this workflow also when the releavnt DT files are changed.