### PR TITLE
Bluetooth: VCP: Use atomic

### DIFF
--- a/subsys/bluetooth/audio/vcp_internal.h
+++ b/subsys/bluetooth/audio/vcp_internal.h
@@ -46,17 +46,17 @@ struct vcs_control_vol {
 
 struct bt_vcp_vol_ctlr {
 	struct vcs_state state;
-	uint8_t flags;
+	uint8_t vol_flags;
 
 	uint16_t start_handle;
 	uint16_t end_handle;
 	uint16_t state_handle;
 	uint16_t control_handle;
-	uint16_t flag_handle;
+	uint16_t vol_flag_handle;
 	struct bt_gatt_subscribe_params state_sub_params;
 	struct bt_gatt_discover_params state_sub_disc_params;
-	struct bt_gatt_subscribe_params flag_sub_params;
-	struct bt_gatt_discover_params flag_sub_disc_params;
+	struct bt_gatt_subscribe_params vol_flag_sub_params;
+	struct bt_gatt_discover_params vol_flag_sub_disc_params;
 	bool cp_retried;
 
 	bool busy;

--- a/subsys/bluetooth/audio/vcp_internal.h
+++ b/subsys/bluetooth/audio/vcp_internal.h
@@ -18,6 +18,7 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/bluetooth/uuid.h>
+#include <zephyr/sys/atomic.h>
 
 /* VCS opcodes */
 #define BT_VCP_OPCODE_REL_VOL_DOWN                      0x00
@@ -44,6 +45,13 @@ struct vcs_control_vol {
 	uint8_t volume;
 } __packed;
 
+enum bt_vcp_vol_ctlr_flag {
+	BT_VCP_VOL_CTLR_FLAG_BUSY,
+	BT_VCP_VOL_CTLR_FLAG_CP_RETRIED,
+
+	BT_VCP_VOL_CTLR_FLAG_NUM_FLAGS, /* keep as last */
+};
+
 struct bt_vcp_vol_ctlr {
 	struct vcs_state state;
 	uint8_t vol_flags;
@@ -57,9 +65,7 @@ struct bt_vcp_vol_ctlr {
 	struct bt_gatt_discover_params state_sub_disc_params;
 	struct bt_gatt_subscribe_params vol_flag_sub_params;
 	struct bt_gatt_discover_params vol_flag_sub_disc_params;
-	bool cp_retried;
 
-	bool busy;
 	struct vcs_control_vol cp_val;
 	struct bt_gatt_write_params write_params;
 	struct bt_gatt_read_params read_params;
@@ -75,6 +81,8 @@ struct bt_vcp_vol_ctlr {
 	uint8_t aics_inst_cnt;
 	struct bt_aics *aics[CONFIG_BT_VCP_VOL_CTLR_MAX_AICS_INST];
 #endif /* CONFIG_BT_VCP_VOL_CTLR_AICS */
+
+	ATOMIC_DEFINE(flags, BT_VCP_VOL_CTLR_FLAG_NUM_FLAGS);
 };
 
 #endif /* ZEPHYR_INCLUDE_BLUETOOTH_AUDIO_VCP_INTERNAL_*/

--- a/tests/bluetooth/tester/src/audio/btp_vcp.c
+++ b/tests/bluetooth/tester/src/audio/btp_vcp.c
@@ -685,7 +685,7 @@ static void vcp_vol_ctlr_discover_cb(struct bt_vcp_vol_ctlr *vol_ctlr, int err, 
 	}
 
 	chrc_handles.vcp_handles.ctrl_pt = vol_ctlr->control_handle;
-	chrc_handles.vcp_handles.flags = vol_ctlr->flag_handle;
+	chrc_handles.vcp_handles.flags = vol_ctlr->vol_flag_handle;
 	chrc_handles.vcp_handles.state = vol_ctlr->state_handle;
 	btp_send_vcp_found_ev(conn, err, &chrc_handles);
 }


### PR DESCRIPTION
Modifies the VCP volume controller to use atomic instead of `bool` for guarding resources. 