### PR TITLE
west.yml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -285,7 +285,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 52e2afc2f809c424b0f337f56059d1dfcc7e6d98
+      revision: e890df7ab975da181a9f3fb3abc470bf935625ab
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  e890df7ab975da181a9f3fb3abc470bf935625ab

Brings following Zephyr relevant fixes:
  - e890df7a boot: zephyr: Add ESP32C2/ESP8684 support
  - 5d5f0492 bootutil: Fix AES and SHA-256 contexts not with mbedTLS
  - ca06b9fe boot: zephyr: Add fallback to USB DFU
  - 43a49a3b bootutil: Add better mode selection checks
  - 956311d2 boot: Make boot_enc_valid take slot instead of image index
  - 242db1a9 boot: zephyr: boards: Add nrf54l15dk configuration
  - 651775b5 boot: zephyr: board: Fix nrf54l15pdk Kconfig fragment
  - a3762626 boot: zephyr: MCXN947 currently only does not support swap mode

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.