### PR TITLE
arch: riscv: init IRQ stacks with 0xAA

### DIFF
--- a/arch/riscv/core/reset.S
+++ b/arch/riscv/core/reset.S
@@ -62,7 +62,8 @@ boot_first_core:
 #ifdef CONFIG_INIT_STACKS
 	/* Pre-populate all bytes in z_interrupt_stacks with 0xAA */
 	la t0, z_interrupt_stacks
-	li t1, __z_interrupt_stack_SIZEOF
+	/* Total size of all cores' IRQ stack */
+	li t1, __z_interrupt_all_stacks_SIZEOF
 	add t1, t1, t0
 
 	/* Populate z_interrupt_stacks with 0xaaaaaaaa */
@@ -71,7 +72,7 @@ aa_loop:
 	sw t2, 0x00(t0)
 	addi t0, t0, 4
 	blt t0, t1, aa_loop
-#endif
+#endif /* CONFIG_INIT_STACKS */
 
 	/*
 	 * Initially, setup stack pointer to

--- a/kernel/include/kernel_offsets.h
+++ b/kernel/include/kernel_offsets.h
@@ -71,6 +71,7 @@ GEN_OFFSET_SYM(_thread_t, tls);
 #endif /* CONFIG_THREAD_LOCAL_STORAGE */
 
 GEN_ABSOLUTE_SYM(__z_interrupt_stack_SIZEOF, sizeof(z_interrupt_stacks[0]));
+GEN_ABSOLUTE_SYM(__z_interrupt_all_stacks_SIZEOF, sizeof(z_interrupt_stacks));
 
 /* member offsets in the device structure. Used in image post-processing */
 #ifdef CONFIG_DEVICE_DEPS


### PR DESCRIPTION
memset IRQ stacks memory to 0xAA on init, so that `z_stack_space_get` can calculate the remaining space properly.

this PR:

```
*** Booting Zephyr OS build v3.7.0-2381-g734cc05d9170 ***
Hello World! qemu_riscv64/qemu_virt_riscv64/smp

uart:~$ kernel thread stacks 
0x80011938 idle 01                          (real size 1024):   unused  676     usage  348 / 1024 (33 %)
0x800110f0 shell_uart                       (real size 3072):   unused 1284     usage 1788 / 3072 (58 %)
0x80011e58 sysworkq                         (real size 1024):   unused  700     usage  324 / 1024 (31 %)
0x800117c8 idle 00                          (real size 1024):   unused  612     usage  412 / 1024 (40 %)
0x80012c10 IRQ 00                           (real size 2048):   unused 1556     usage  492 / 2048 (24 %)
0x80013410 IRQ 01                           (real size 2048):   unused 1876     usage  172 / 2048 ( 8 %)
```

current:

```
*** Booting Zephyr OS build zephyr-v3.5.0-80-gd47129f0f7d5 ***
Hello World! qemu_riscv64_smp


uart:~$ kernel stacks 
0x80010870 idle 01                          (real size 1024):   unused  612     usage  412 / 1024 (40 %)
0x80010c00 sysworkq                         (real size 1024):   unused  668     usage  356 / 1024 (34 %)
0x800100f0 shell_uart                       (real size 3072):   unused 1268     usage 1804 / 3072 (58 %)
0x80010710 idle 00                          (real size 1024):   unused  612     usage  412 / 1024 (40 %)
0x800119b0 IRQ 00                           (real size 2048):   unused 1236     usage  812 / 2048 (39 %)
0x800121b0 IRQ 01                           (real size 2048):   unused    0     usage 2048 / 2048 (100 %)
```

Fixes #78244