### PR TITLE
mgmt: mcumgr: Add SMP SVC and CHR UUIDs to header 

### DIFF
--- a/include/zephyr/mgmt/mcumgr/transport/smp_bt.h
+++ b/include/zephyr/mgmt/mcumgr/transport/smp_bt.h
@@ -11,12 +11,31 @@
 #ifndef ZEPHYR_INCLUDE_MGMT_SMP_BT_H_
 #define ZEPHYR_INCLUDE_MGMT_SMP_BT_H_
 
+#include <zephyr/bluetooth/uuid.h>
 #include <zephyr/types.h>
 struct bt_conn;
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/** SMP service UUID value. */
+#define SMP_BT_SVC_UUID_VAL \
+	BT_UUID_128_ENCODE(0x8d53dc1d, 0x1db7, 0x4cd3, 0x868b, 0x8a527460aa84)
+
+/** SMP service UUID. */
+#define SMP_BT_SVC_UUID \
+	BT_UUID_DECLARE_128(SMP_BT_SVC_UUID_VAL)
+
+/** SMP characteristic UUID value. */
+#define SMP_BT_CHR_UUID_VAL \
+	BT_UUID_128_ENCODE(0xda2e7828, 0xfbce, 0x4e01, 0xae9e, 0x261174997c48)
+
+/** SMP characteristic UUID
+ *  Used for both requests and responses.
+ */
+#define SMP_BT_CHR_UUID \
+	BT_UUID_DECLARE_128(SMP_BT_CHR_UUID_VAL)
 
 /**
  * @brief	Registers the SMP Bluetooth service. Should only be called if the Bluetooth

--- a/samples/subsys/mgmt/mcumgr/smp_svr/src/bluetooth.c
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/src/bluetooth.c
@@ -19,9 +19,7 @@ static struct k_work advertise_work;
 
 static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
-	BT_DATA_BYTES(BT_DATA_UUID128_ALL,
-		      0x84, 0xaa, 0x60, 0x74, 0x52, 0x8a, 0x8b, 0x86,
-		      0xd3, 0x4c, 0xb7, 0x1d, 0x1d, 0xdc, 0x53, 0x8d),
+	BT_DATA_BYTES(BT_DATA_UUID128_ALL, SMP_BT_SVC_UUID_VAL),
 };
 
 static const struct bt_data sd[] = {

--- a/subsys/mgmt/mcumgr/transport/src/smp_bt.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_bt.c
@@ -88,18 +88,6 @@ static uint8_t next_id;
 static struct smp_transport smp_bt_transport;
 static struct conn_param_data conn_data[CONFIG_BT_MAX_CONN];
 
-/* SMP service.
- * {8D53DC1D-1DB7-4CD3-868B-8A527460AA84}
- */
-static const struct bt_uuid_128 smp_bt_svc_uuid = BT_UUID_INIT_128(
-	BT_UUID_128_ENCODE(0x8d53dc1d, 0x1db7, 0x4cd3, 0x868b, 0x8a527460aa84));
-
-/* SMP characteristic; used for both requests and responses.
- * {DA2E7828-FBCE-4E01-AE9E-261174997C48}
- */
-static const struct bt_uuid_128 smp_bt_chr_uuid = BT_UUID_INIT_128(
-	BT_UUID_128_ENCODE(0xda2e7828, 0xfbce, 0x4e01, 0xae9e, 0x261174997c48));
-
 static void connected(struct bt_conn *conn, uint8_t err);
 static void disconnected(struct bt_conn *conn, uint8_t reason);
 
@@ -354,8 +342,8 @@ static void smp_bt_ccc_changed(const struct bt_gatt_attr *attr, uint16_t value)
 }
 
 #define SMP_BT_ATTRS									\
-	BT_GATT_PRIMARY_SERVICE(&smp_bt_svc_uuid),					\
-	BT_GATT_CHARACTERISTIC(&smp_bt_chr_uuid.uuid,					\
+	BT_GATT_PRIMARY_SERVICE(SMP_BT_SVC_UUID),					\
+	BT_GATT_CHARACTERISTIC(SMP_BT_CHR_UUID,						\
 			       BT_GATT_CHRC_WRITE_WITHOUT_RESP |			\
 			       BT_GATT_CHRC_NOTIFY,					\
 			       COND_CODE_1(CONFIG_MCUMGR_TRANSPORT_BT_AUTHEN,		\


### PR DESCRIPTION
Added the SMP service and characteristic UUIDs to the smp_bt module header and used those definitions.
Used the SMP_BT_SVC_UUID_VAL define exposed in the smp_bt header in the smp_svr sample instead of hardcoding its value.

CC: @kapi-no