### PR TITLE
Bluetooth: Host: Don't do tx_notify in conn_recv

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -439,9 +439,9 @@ static void bt_acl_recv(struct bt_conn *conn, struct net_buf *buf, uint8_t flags
 	bt_l2cap_recv(conn, buf, true);
 }
 
+#if defined(CONFIG_BT_CONN_TX)
 static void wait_for_tx_work(struct bt_conn *conn)
 {
-#if defined(CONFIG_BT_CONN_TX)
 	LOG_DBG("conn %p", conn);
 
 	if (IS_ENABLED(CONFIG_BT_RECV_WORKQ_SYS) ||
@@ -457,21 +457,11 @@ static void wait_for_tx_work(struct bt_conn *conn)
 		k_work_flush(&conn->tx_complete_work, &sync);
 	}
 	LOG_DBG("done");
-#else
-	ARG_UNUSED(conn);
-#endif	/* CONFIG_BT_CONN_TX */
 }
+#endif	/* CONFIG_BT_CONN_TX */
 
 void bt_conn_recv(struct bt_conn *conn, struct net_buf *buf, uint8_t flags)
 {
-	/* Make sure we notify any pending TX callbacks before processing
-	 * new data for this connection.
-	 *
-	 * Always do so from the same context for sanity. In this case that will
-	 * be the system workqueue.
-	 */
-	wait_for_tx_work(conn);
-
 	LOG_DBG("handle %u len %u flags %02x", conn->handle, buf->len, flags);
 
 	if (IS_ENABLED(CONFIG_BT_ISO_RX) && conn->type == BT_CONN_TYPE_ISO) {


### PR DESCRIPTION
Code untangling.

It not well documented why tx_notify was called in conn_recv. I speculate this is probably a hack that is not needed now.

I think it was likely because the ATT implementation processes requests and sends the response synchronously. It does not handle out-of-resources well. The tx_notify was probably there to make it more likely that the ATT response succeeds, but it was no guarantee. This is no longer relevant because ATT no longer uses tx_notify.

Upon digging a bit, I found that [the PR that introduced the comment above the call to tx_notify] (the comment that says what the code does instead why it does it \*grrr\*) closes an issue due to ATT flow control enforcing. This feature was proven unsound, and has been removed.

[the PR that introduced the comment above the call to tx_notify]: https://github.com/zephyrproject-rtos/zephyr/pull/21056/files#diff-00881f70fc7ec49b966fed79bd6a5a8ed5357599b241b5b029736bbc97683f83R1134-R1137

To conclude; This should probably not be here. It's purpose is not documented, and non-obvious code like this is a burden on maintainability.

If someone comes up with a reasonable explanation for why this was here, we should find a better way to solve the problem.