### PR TITLE
soc: esp32xx: update flash initialization

### DIFF
--- a/soc/espressif/esp32/soc.c
+++ b/soc/espressif/esp32/soc.c
@@ -13,6 +13,7 @@
 #include <xtensa/corebits.h>
 #include <esp_private/spi_flash_os.h>
 #include <esp_private/esp_mmu_map_private.h>
+#include <esp_flash_internal.h>
 #if CONFIG_ESP_SPIRAM
 #include "psram.h"
 #endif
@@ -141,25 +142,15 @@ void IRAM_ATTR __esp_platform_start(void)
 	esp_start_appcpu();
 #endif
 
-	esp_mmu_map_init();
-
-#ifdef CONFIG_SOC_FLASH_ESP32
 	esp_mspi_pin_init();
-	spi_flash_init_chip_state();
-#endif
+
+	esp_flash_app_init();
+
+	esp_mmu_map_init();
 
 #if CONFIG_ESP_SPIRAM
 	esp_init_psram();
 #endif /* CONFIG_ESP_SPIRAM */
-
-/* Scheduler is not started at this point. Hence, guard functions
- * must be initialized after esp_spiram_init_cache which internally
- * uses guard functions. Setting guard functions before SPIRAM
- * cache initialization will result in a crash.
- */
-#if CONFIG_SOC_FLASH_ESP32 || CONFIG_ESP_SPIRAM
-	spi_flash_guard_set(&g_flash_guard_default_ops);
-#endif
 
 #endif /* !CONFIG_MCUBOOT */
 

--- a/soc/espressif/esp32c2/soc.c
+++ b/soc/espressif/esp32c2/soc.c
@@ -21,6 +21,7 @@
 #include <soc/interrupt_reg.h>
 #include <esp_private/spi_flash_os.h>
 #include "esp_private/esp_mmu_map_private.h"
+#include <esp_flash_internal.h>
 
 #include <zephyr/drivers/interrupt_controller/intc_esp32c3.h>
 
@@ -66,27 +67,13 @@ void __attribute__((section(".iram1"))) __esp_platform_start(void)
 	REG_CLR_BIT(SYSTEM_WIFI_CLK_EN_REG, SYSTEM_WIFI_CLK_SDIOSLAVE_EN);
 	SET_PERI_REG_MASK(SYSTEM_WIFI_CLK_EN_REG, SYSTEM_WIFI_CLK_EN);
 
-#ifdef CONFIG_SOC_FLASH_ESP32
-	esp_mspi_pin_init();
-
-	/**
-	 * This function initialise the Flash chip to the user-defined settings.
-	 *
-	 * In bootloader, we only init Flash (and MSPI) to a preliminary
-	 * state, for being flexible to different chips.
-	 * In this stage, we re-configure the Flash (and MSPI) to required configuration
-	 */
-	spi_flash_init_chip_state();
-
-	esp_mmu_map_init();
-
-#endif /*CONFIG_SOC_FLASH_ESP32*/
-
 	esp_timer_early_init();
 
-#if CONFIG_SOC_FLASH_ESP32
-	spi_flash_guard_set(&g_flash_guard_default_ops);
-#endif
+	esp_mspi_pin_init();
+
+	esp_flash_app_init();
+
+	esp_mmu_map_init();
 
 #endif /* !CONFIG_MCUBOOT */
 

--- a/soc/espressif/esp32c3/soc.c
+++ b/soc/espressif/esp32c3/soc.c
@@ -21,6 +21,7 @@
 #include <soc/interrupt_reg.h>
 #include <esp_private/spi_flash_os.h>
 #include "esp_private/esp_mmu_map_private.h"
+#include <esp_flash_internal.h>
 
 #include <zephyr/drivers/interrupt_controller/intc_esp32c3.h>
 
@@ -66,27 +67,13 @@ void __attribute__((section(".iram1"))) __esp_platform_start(void)
 	REG_CLR_BIT(SYSTEM_WIFI_CLK_EN_REG, SYSTEM_WIFI_CLK_SDIOSLAVE_EN);
 	SET_PERI_REG_MASK(SYSTEM_WIFI_CLK_EN_REG, SYSTEM_WIFI_CLK_EN);
 
-#ifdef CONFIG_SOC_FLASH_ESP32
-	esp_mspi_pin_init();
-
-	/**
-	 * This function initialise the Flash chip to the user-defined settings.
-	 *
-	 * In bootloader, we only init Flash (and MSPI) to a preliminary
-	 * state, for being flexible to different chips.
-	 * In this stage, we re-configure the Flash (and MSPI) to required configuration
-	 */
-	spi_flash_init_chip_state();
-
-	esp_mmu_map_init();
-
-#endif /*CONFIG_SOC_FLASH_ESP32*/
-
 	esp_timer_early_init();
 
-#if CONFIG_SOC_FLASH_ESP32
-	spi_flash_guard_set(&g_flash_guard_default_ops);
-#endif
+	esp_mspi_pin_init();
+
+	esp_flash_app_init();
+
+	esp_mmu_map_init();
 
 #endif /* !CONFIG_MCUBOOT */
 

--- a/soc/espressif/esp32c6/soc.c
+++ b/soc/espressif/esp32c6/soc.c
@@ -19,6 +19,7 @@
 #include <soc/interrupt_reg.h>
 #include <esp_private/spi_flash_os.h>
 #include "esp_private/esp_mmu_map_private.h"
+#include <esp_flash_internal.h>
 
 #include <zephyr/drivers/interrupt_controller/intc_esp32c3.h>
 
@@ -58,9 +59,9 @@ void IRAM_ATTR __esp_platform_start(void)
 
 	esp_timer_early_init();
 
-#if CONFIG_SOC_FLASH_ESP32
-	spi_flash_guard_set(&g_flash_guard_default_ops);
-#endif
+	esp_mspi_pin_init();
+
+	esp_flash_app_init();
 
 	esp_mmu_map_init();
 

--- a/soc/espressif/esp32s2/soc.c
+++ b/soc/espressif/esp32s2/soc.c
@@ -96,10 +96,11 @@ void __attribute__((section(".iram1"))) __esp_platform_start(void)
 	esp_config_data_cache_mode();
 	esp_rom_Cache_Enable_DCache(0);
 
-#ifdef CONFIG_SOC_FLASH_ESP32
+	esp_timer_early_init();
+
 	esp_mspi_pin_init();
-	spi_flash_init_chip_state();
-#endif /* CONFIG_SOC_FLASH_ESP32 */
+
+	esp_flash_app_init();
 
 	esp_mmu_map_init();
 
@@ -107,16 +108,6 @@ void __attribute__((section(".iram1"))) __esp_platform_start(void)
 	esp_init_psram();
 #endif /* CONFIG_ESP_SPIRAM */
 
-	esp_timer_early_init();
-
-	/* Scheduler is not started at this point. Hence, guard functions
-	 * must be initialized after esp_spiram_init_cache which internally
-	 * uses guard functions. Setting guard functions before SPIRAM
-	 * cache initialization will result in a crash.
-	 */
-#if CONFIG_SOC_FLASH_ESP32 || CONFIG_ESP_SPIRAM
-	spi_flash_guard_set(&g_flash_guard_default_ops);
-#endif
 #endif /* !CONFIG_MCUBOOT */
 
 	esp_intr_initialize();

--- a/soc/espressif/esp32s3/soc.c
+++ b/soc/espressif/esp32s3/soc.c
@@ -145,18 +145,6 @@ void IRAM_ATTR __esp_platform_start(void)
 	 */
 	esp_config_data_cache_mode();
 
-	esp_mspi_pin_init();
-
-	spi_flash_init_chip_state();
-
-	mspi_timing_flash_tuning();
-
-	esp_mmu_map_init();
-
-#if CONFIG_ESP_SPIRAM
-	esp_init_psram();
-#endif /* CONFIG_ESP_SPIRAM */
-
 	/* Apply SoC patches */
 	esp_errata();
 
@@ -174,14 +162,23 @@ void IRAM_ATTR __esp_platform_start(void)
 
 	esp_timer_early_init();
 
+	esp_mspi_pin_init();
+
+	esp_flash_app_init();
+
+	mspi_timing_flash_tuning();
+
+	esp_mmu_map_init();
+
+#if CONFIG_ESP_SPIRAM
+	esp_init_psram();
+#endif /* CONFIG_ESP_SPIRAM */
+
 #if CONFIG_SOC_ENABLE_APPCPU
 	/* start the ESP32S3 APP CPU */
 	esp_start_appcpu();
 #endif
 
-#if CONFIG_SOC_FLASH_ESP32
-	spi_flash_guard_set(&g_flash_guard_default_ops);
-#endif
 #endif /* !CONFIG_MCUBOOT */
 
 	esp_intr_initialize();

--- a/west.yml
+++ b/west.yml
@@ -157,7 +157,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: a79e607333bbd115a16e801ba49840a80c852253
+      revision: aa6a967d1ab4077691aa046229a782102960218a
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
Rework how flash is initialized in esp32 SoC.
"esp_flash_app_init()" will make sure proper cache handling will be set in place.

Fix #77551