### PR TITLE
boards: nrf54h20dk: Fix settings partition

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-memory_map.dtsi
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-memory_map.dtsi
@@ -249,11 +249,11 @@
 		#size-cells = <1>;
 
 		dfu_partition: partition@100000 {
-			reg = < 0x100000 DT_SIZE_K(892) >;
+			reg = < 0x100000 DT_SIZE_K(908) >;
 		};
 
-		storage_partition: partition@1df000 {
-			reg = < 0x1df000 DT_SIZE_K(24) >;
+		storage_partition: partition@1e3000 {
+			reg = < 0x1e3000 DT_SIZE_K(24) >;
 		};
 	};
 };


### PR DESCRIPTION
Align settings and DFU partition definition with the values, specified by the design documentation.