### PR TITLE
west.yml: hal_stm32: stm32f7: fix TX timestamp check

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -233,7 +233,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 1e6116bd2a36db976d955ee772d21f329e529873
+      revision: c4099c229323f305eef75ff6ba93ee9b89827581
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Fix the TX timestamp check for STM32F7 and update the README patch list.