### PR TITLE
samples: usb/mass: fix board name for adafruit_feather_nrf52840_sense

### DIFF
--- a/samples/subsys/usb/mass/sample.yaml
+++ b/samples/subsys/usb/mass/sample.yaml
@@ -73,7 +73,7 @@ tests:
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
-      - adafruit_feather_nrf52840_sense
+      - adafruit_feather_nrf52840/nrf52840/sense
     integration_platforms:
       - nrf52840dk/nrf52840
     extra_configs:
@@ -98,7 +98,7 @@ tests:
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
-      - adafruit_feather_nrf52840_sense
+      - adafruit_feather_nrf52840/nrf52840/sense
     integration_platforms:
       - nrf52840dk/nrf52840
     extra_args: CONF_FILE="usbd_next_prj.conf"
@@ -169,7 +169,7 @@ tests:
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
-      - adafruit_feather_nrf52840_sense
+      - adafruit_feather_nrf52840/nrf52840/sense
     integration_platforms:
       - nrf52840dk/nrf52840
     extra_configs:


### PR DESCRIPTION
The Adafruit feather boards have been converted to variants, use the correct board name.