### PR TITLE
doc: Various Sphinx lint fixes

### DIFF
--- a/boards/blues/swan_r5/doc/index.rst
+++ b/boards/blues/swan_r5/doc/index.rst
@@ -20,8 +20,8 @@ Due to its novel design, for high-volume deployment the low-cost Swan
 can also be soldered directly to a parent PCB integrating those sensors,
 utilizing the full range of Swan's I/O capabilities.
 
-The board has three independent power options-USB, Battery, or Line power-
-and provides a software-switchable 2 Amp regulator for powering external
+The board has three independent power options---USB, Battery, or Line
+power---and provides a software-switchable 2 Amp regulator for powering external
 sensors. When operating in its low-power operating mode, the entire Swan
 board commonly draws only about 8uA while retaining all of its memory,
 making it quite suitable for battery-powered devices.

--- a/boards/cdns/xt-sim/doc/index.rst
+++ b/boards/cdns/xt-sim/doc/index.rst
@@ -38,7 +38,7 @@ System requirements
 Prerequisites
 =============
 A Linux host system is required for Xtensa development work.
-We recommend using a __``Debian 9.x (Stretch)``__ or recent __``Ubuntu``__
+We recommend using a Debian 9.x (Stretch) or recent Ubuntu
 releases (with multilib support).
 
 Only Xtensa tools version ``RF-2016.4-linux`` or later are officially

--- a/doc/build/dts/api-usage.rst
+++ b/doc/build/dts/api-usage.rst
@@ -330,8 +330,8 @@ Here are pointers to some other available APIs.
 
 - :c:func:`DT_CHOSEN`, :c:func:`DT_HAS_CHOSEN`: for properties
   of the special ``/chosen`` node
-- :c:func:`DT_HAS_COMPAT_STATUS_OKAY`, :c:func:`DT_NODE_HAS_COMPAT`: global-
-  and node-specific tests related to the ``compatible`` property
+- :c:func:`DT_HAS_COMPAT_STATUS_OKAY`, :c:func:`DT_NODE_HAS_COMPAT`: global- and
+  node-specific tests related to the ``compatible`` property
 - :c:func:`DT_BUS`: get a node's bus controller, if there is one
 - :c:func:`DT_ENUM_IDX`: for properties whose values are among a fixed list of
   choices

--- a/doc/build/sysbuild/index.rst
+++ b/doc/build/sysbuild/index.rst
@@ -658,7 +658,7 @@ with ``application``.
 Sysbuild file suffix support
 ----------------------------
 
-File suffix support through the makevar:`FILE_SUFFIX` is supported in sysbuild
+File suffix support through the :makevar:`FILE_SUFFIX` is supported in sysbuild
 (see :ref:`application-file-suffixes` for details on this feature in applications). For sysbuild,
 a globally provided option will be passed down to all images. In addition, the image configuration
 file will have this value applied and used (instead of the build type) if the file exists.

--- a/doc/connectivity/networking/api/net_l2.rst
+++ b/doc/connectivity/networking/api/net_l2.rst
@@ -129,8 +129,8 @@ here as well. There are two specific differences however:
   packet will often have to be split into several fragments and IP6 packet headers
   and fragments need to be compressed using a protocol like 6LoWPAN before being
   passed on to the radio driver. Additionally the IEEE 802.15.4 standard defines
-  medium access (e.g. CSMA/CA), frame retransmission, encryption and other pre-
-  processing procedures (e.g. addition of information elements) that individual
+  medium access (e.g. CSMA/CA), frame retransmission, encryption and other pre-processing
+  procedures (e.g. addition of information elements) that individual
   radio drivers should not have to care about. This is why the
   :c:struct:`ieee802154_radio_api` requires a tx function pointer which differs
   from the :c:struct:`net_if_api` send function pointer. Zephyr's native

--- a/doc/develop/sca/index.rst
+++ b/doc/develop/sca/index.rst
@@ -17,8 +17,8 @@ to enable the static analysis tool ``sparse``.
 SCA Tool infrastructure
 ***********************
 
-Support for an SCA tool is implemented in a file:`sca.cmake` file.
-The file:`sca.cmake` must be placed under file:`<SCA_ROOT>/cmake/sca/<tool>/sca.cmake`.
+Support for an SCA tool is implemented in a :file:`sca.cmake` file.
+The :file:`sca.cmake` must be placed under :file:`{SCA_ROOT}/cmake/sca/{tool}/sca.cmake`.
 Zephyr itself is always added as an :makevar:`SCA_ROOT` but the build system offers the
 possibility to add additional folders to the :makevar:`SCA_ROOT` setting.
 

--- a/doc/develop/west/build-flash-debug.rst
+++ b/doc/develop/west/build-flash-debug.rst
@@ -771,7 +771,7 @@ Runner-Specific Overrides
 =========================
 
 To view all of the available options supported by the runners, as well
-as their usage information, use ``--context`` (or``-H``)::
+as their usage information, use ``--context`` (or ``-H``)::
 
   west simulate --runner=renode --context
 

--- a/doc/develop/west/west-apis.rst
+++ b/doc/develop/west/west-apis.rst
@@ -148,7 +148,7 @@ WestCommand
    .. method:: check_call(args, **kwargs)
 
       Runs ``subprocess.check_call(args, **kwargs)`` after
-      logging the call at Verbosity.DBG_MORE`` level.
+      logging the call at ``Verbosity.DBG_MORE`` level.
 
    .. versionchanged:: 1.2.0
       The *cwd* keyword argument was replaced with a catch-all ``**kwargs``.

--- a/doc/hardware/porting/arch.rst
+++ b/doc/hardware/porting/arch.rst
@@ -745,8 +745,8 @@ privilege elevation stack must be allocated elsewhere.
 :c:macro:`Z_POW2_CEIL()`. :c:macro:`K_THREAD_STACK_RESERVED` must be 0.
 
 For the privilege stacks, the :kconfig:option:`CONFIG_GEN_PRIV_STACKS` must be,
-enabled. For every thread stack found in the system, a corresponding fixed-
-size kernel stack used for handling system calls is generated. The address
+enabled. For every thread stack found in the system, a corresponding fixed-size
+kernel stack used for handling system calls is generated. The address
 of the privilege stacks can be looked up quickly at runtime based on the
 thread stack address using :c:func:`z_priv_stack_find()`. These stacks are
 laid out the same way as other kernel-only stacks.

--- a/doc/kernel/services/threads/index.rst
+++ b/doc/kernel/services/threads/index.rst
@@ -175,8 +175,8 @@ met:
 
 - There may need to be additional memory reserved for memory management
   structures
-- If guard-based stack overflow detection is enabled, a small write-
-  protected memory management region must immediately precede the stack buffer
+- If guard-based stack overflow detection is enabled, a small write-protected
+  memory management region must immediately precede the stack buffer
   to catch overflows.
 - If userspace is enabled, a separate fixed-size privilege elevation stack must
   be reserved to serve as a private kernel stack for handling system calls.

--- a/doc/kernel/usermode/overview.rst
+++ b/doc/kernel/usermode/overview.rst
@@ -84,11 +84,11 @@ For threads running in a non-privileged CPU state (hereafter referred to as
 - We prevent invoking system calls to functions excluded by the kernel
   configuration.
 
-- We prevent disabling of or tampering with kernel-defined and hardware-
-  enforced memory protections.
+- We prevent disabling of or tampering with kernel-defined and
+  hardware-enforced memory protections.
 
-- We prevent re-entry from user to supervisor mode except through the kernel-
-  defined system calls and interrupt handlers.
+- We prevent re-entry from user to supervisor mode except through the
+  kernel-defined system calls and interrupt handlers.
 
 - We prevent the introduction of new executable code by user mode threads,
   except to the extent to which this is supported by kernel system calls.

--- a/doc/security/standards/etsi-303645.rst
+++ b/doc/security/standards/etsi-303645.rst
@@ -327,7 +327,8 @@ Provisions Assessment
       - The device should verify the authenticity and integrity of software updates.
       - R C
       - Y
-      - Functionality provided by `MCUboot <https://github.com/zephyrproject-rtos/mcuboot>`. Also see :ref:`Device Firwmware Upgrade  <dfu>`
+      - Functionality provided by `MCUboot <https://github.com/zephyrproject-rtos/mcuboot>`_.
+        Also see :ref:`Device Firwmware Upgrade  <dfu>`.
 
         .. _ETSI_Provision_5_3_10:
     * - Provision 5.3-10
@@ -557,7 +558,8 @@ Provisions Assessment
       - The consumer IoT device should verify its software using secure boot mechanisms.
       - R
       - Y
-      - Functionality provided by `MCUboot <https://github.com/zephyrproject-rtos/mcuboot>`. Also see :ref:`Security Overview  <west-sign>`
+      - Functionality provided by `MCUboot <https://github.com/zephyrproject-rtos/mcuboot>`_.
+        Also see :ref:`Security Overview  <west-sign>`.
 
         .. _ETSI_Provision_5_7_2:
     * - Provision 5.7-2

--- a/doc/services/device_mgmt/mcumgr_callbacks.rst
+++ b/doc/services/device_mgmt/mcumgr_callbacks.rst
@@ -29,7 +29,7 @@ be selected by enabling the Kconfig's for the required callbacks (see
 :ref:`mcumgr_cb_events` for further details). A callback function with the
 :c:type:`mgmt_cb` type definition can then be declared and registered by
 calling :c:func:`mgmt_callback_register` for the desired event inside of a
-:c:struct`mgmt_callback` structure. Handlers are called in the order that they
+:c:struct:`mgmt_callback` structure. Handlers are called in the order that they
 were registered.
 
 With the system enabled, a basic handler can be set up and defined in

--- a/doc/services/rtio/index.rst
+++ b/doc/services/rtio/index.rst
@@ -224,7 +224,7 @@ I2C buses have a default implementation which allows apps to leverage the RTIO w
 vendors implement the submit function. With this queue, any I2C bus driver that does not implement
 the ``iodev_submit`` function will defer to a work item which will perform a blocking I2C
 transaction. To change the pool size, set a different value to
-:kconfig:option`CONFIG_RTIO_WORKQ_POOL_ITEMS`.
+:kconfig:option:`CONFIG_RTIO_WORKQ_POOL_ITEMS`.
 
 API Reference
 *************

--- a/samples/boards/arc_secure_services/README.rst
+++ b/samples/boards/arc_secure_services/README.rst
@@ -68,7 +68,7 @@ Currently, in normal application, MPU is not accessible, so no user space and
 mpu-based stack checking. Please copy the specific dts file and def_config
 file to the specific board dir to build normal application.
 
-Here,take :ref:'dining-philosophers-sample' as an example for normal
+Here,take :ref:`dining-philosophers-sample` as an example for normal
 application.
 
 .. zephyr-app-commands::

--- a/samples/boards/bbc_microbit/pong/README.rst
+++ b/samples/boards/bbc_microbit/pong/README.rst
@@ -16,8 +16,8 @@ to select the current choice. To start the game, the player with the
 ball launches the ball by pressing both buttons.
 
 When multi-player mode has been selected the game will try to look for
-and connect to a second micro:bit which has also been set into multi-
-player mode.
+and connect to a second micro:bit which has also been set into multi-player
+mode.
 
 If the board has a piezo buzzer connected to pin 0, this will be used to
 generate beeps whenever the ball hits a wall or the paddle.

--- a/tests/bsim/bluetooth/mesh/README.rst
+++ b/tests/bsim/bluetooth/mesh/README.rst
@@ -97,7 +97,7 @@ Test scripts should be organized by submodules under the test_scripts
 directory, and each test case needs a separate test script with a single test
 run.
 
-Each test harness is defined by a ``struct bst_test_instance` structure, that
+Each test harness is defined by a ``struct bst_test_instance`` structure, that
 is presented to the test runner through an ``install`` function called from the
 test application's main function. The harness contains a set of callback
 functions that allows starting the test behavior.


### PR DESCRIPTION
ReST and Sphinx are easy to get wrong. In preparation of introducing a Sphinx/RST linter, this commit fixes several (trivial) issues spotted by `sphinx-lint` which are the kind of issues that don't cause the documentation build to fail, and yet lead to an output (HTML or otherwise) that's not what the original author had intended (ex. missing hyperlink, ...).

Note that **I've refrained from fixing past release notes** because I don't like the idea of touching them unless *really* needed, but for the record here's the reported failures (surprisingly not that many!) with the default sphinx-lint checkers (minus `horizontal-tab`)

```
releases/release-notes-1.11.rst:382: role with no backticks: " :github:'XYZ' " (role-without-backticks)
releases/release-notes-1.5.rst:209: found an unbalanced inline literal markup. (unbalanced-inline-literals-delimiters)
releases/release-notes-3.7.rst:837: role missing opening tag colon ( c:struct:`). (missing-space-before-role)
releases/release-notes-3.7.rst:871: role missing opening tag colon ( c:macro:`). (missing-space-before-role)
releases/release-notes-3.7.rst:1050: missing space before role ( zephyr:code-sample:`). (missing-space-before-role)
releases/release-notes-3.7.rst:1406: role missing opening tag colon ( c:func:`). (missing-space-before-role)
releases/release-notes-3.5.rst:2183: role missing opening tag colon ( ref:`). (missing-space-before-role)
releases/release-notes-3.1.rst:985: Line ends with dangling hyphen (dangling-hyphen)
releases/release-notes-2.6.rst:56: role with no backticks: ' :c:func:bt_l2cap_chan_send ' (role-without-backticks)
```


I will be addressing bad use of "default roles" (i.e. the infamous case of people using single backticks for they expect things to render as inline literal, while it's not) in a separate PR as it's impacting many more files.