### PR TITLE
west.yml: hal_stm32: Update STM32L4xx to 1.18.1

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -233,7 +233,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 4c1adf8a2e2e9888f3b43374bf6521b0788aa82d
+      revision: pull/228/head
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Should resolve https://github.com/zephyrproject-rtos/zephyr/issues/73398.

Not totally sure how far back this should be backported, but for our needs we'd at least like it in v3.7