### PR TITLE
cmake: modules: dts: Restore gen_defines.py warnings

### DIFF
--- a/cmake/modules/dts.cmake
+++ b/cmake/modules/dts.cmake
@@ -289,33 +289,13 @@ ${EXTRA_GEN_DEFINES_ARGS}
 execute_process(
   COMMAND ${CMD_GEN_DEFINES}
   WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-  RESULT_VARIABLE ret
-  ERROR_VARIABLE stderr
+  COMMAND_ERROR_IS_FATAL ANY
   )
-if(NOT "${ret}" STREQUAL "0")
-  if (stderr)
-    # gen_defines.py failed after printing message(s) to stderr.
-    # Append stream content to the FATAL_ERROR message on a new line.
-    set(stderr "\n${stderr}")
-  else()
-    # gen_defines.py did not print anything on stderr. To inform users
-    # of this condition, set ${stderr} to "<empty>" to have this printed
-    # in the error message. Note that we do NOT want a newline, such that
-    # the error message is printed as a single line, e.g.:
-    #
-    #  gen_defines.py failed with result code: 1 - stderr contents: <empty>
-    #
-    set(stderr "<empty>")
-  endif()
-  message(STATUS "In: ${PROJECT_BINARY_DIR}, command: ${CMD_GEN_DEFINES}")
-  message(FATAL_ERROR "gen_defines.py failed with result code: ${ret} - stderr contents: ${stderr}")
-else()
-  zephyr_file_copy(${ZEPHYR_DTS}.new ${ZEPHYR_DTS} ONLY_IF_DIFFERENT)
-  zephyr_file_copy(${DEVICETREE_GENERATED_H}.new ${DEVICETREE_GENERATED_H} ONLY_IF_DIFFERENT)
-  file(REMOVE ${ZEPHYR_DTS}.new ${DEVICETREE_GENERATED_H}.new)
-  message(STATUS "Generated zephyr.dts: ${ZEPHYR_DTS}")
-  message(STATUS "Generated devicetree_generated.h: ${DEVICETREE_GENERATED_H}")
-endif()
+zephyr_file_copy(${ZEPHYR_DTS}.new ${ZEPHYR_DTS} ONLY_IF_DIFFERENT)
+zephyr_file_copy(${DEVICETREE_GENERATED_H}.new ${DEVICETREE_GENERATED_H} ONLY_IF_DIFFERENT)
+file(REMOVE ${ZEPHYR_DTS}.new ${DEVICETREE_GENERATED_H}.new)
+message(STATUS "Generated zephyr.dts: ${ZEPHYR_DTS}")
+message(STATUS "Generated devicetree_generated.h: ${DEVICETREE_GENERATED_H}")
 
 #
 # Run GEN_DRIVER_KCONFIG_SCRIPT.


### PR DESCRIPTION
Ever since 059aae7c9168328279657433d77ae0f1d0214f1b (cmake: modules:
dts: make Device Tree error messages more visible, PR #76472), warnings
generated by gen_defines.py got only printed when the exit code signaled
an error.

Warning: this half-way undoes #76472