### PR TITLE
edtlib: Apply Werror to address mismatches

### DIFF
--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -2025,8 +2025,8 @@ class EDT:
 
         werror (default: False):
           If True, some edtlib specific warnings become errors. This currently
-          errors out if 'dts' has any deprecated properties set, or an unknown
-          vendor prefix is used.
+          errors out if 'dts' has any deprecated properties set, warn_reg_unit_address_mismatch
+          triggers a warning or an unknown vendor prefix is used.
         """
         # All instance attributes should be initialized here.
         # This makes it easy to keep track of them, which makes
@@ -2053,6 +2053,7 @@ class EDT:
         self._infer_binding_for_paths: set[str] = set(infer_binding_for_paths or [])
         self._vendor_prefixes: dict[str, str] = vendor_prefixes or {}
         self._werror: bool = bool(werror)
+        self._warn_handler: Any = _err if werror else _LOG.warning
 
         # Other internal state
         self._compat2binding: dict[tuple[str, Optional[str]], Binding] = {}
@@ -2359,9 +2360,9 @@ class EDT:
                 # Address mismatch is ok for PCI devices
                 if (node.regs and node.regs[0].addr != node.unit_addr and
                         not node.is_pci_device):
-                    _LOG.warning("unit address and first address in 'reg' "
-                                 f"(0x{node.regs[0].addr:x}) don't match for "
-                                 f"{node.path}")
+                    self._warn_handler("unit address and first address in 'reg' "
+                                       f"(0x{node.regs[0].addr:x}) don't match for "
+                                       f"{node.path}")
 
     def _init_luts(self) -> None:
         # Initialize node lookup tables (LUTs).
@@ -2395,11 +2396,7 @@ class EDT:
                     # As an exception, the root node can have whatever
                     # compatibles it wants. Other nodes get checked.
                     elif node.path != '/':
-                        if self._werror:
-                            handler_fn: Any = _err
-                        else:
-                            handler_fn = _LOG.warning
-                        handler_fn(
+                        self._warn_handler(
                             f"node '{node.path}' compatible '{compat}' "
                             f"has unknown vendor prefix '{vendor}'")
 


### PR DESCRIPTION
# Problem
When running gen_defines.py with --edtlib-Werror, this change causes address mismatches to be treated as errors.

For now, this change will fail in CI due to preexisting, so far not discovered/cleaned up issues.

This PR can (should) be merged only once the following command does not yield any issue anymore:

```console
twister --cmake-only
```

# Results
`v4.1.0-2236-g11ef4a293c4` (`twister --cmake-only --runtime-artifact-cleanup all`):

```
- 0 of 19631 executed test configurations passed (0.00%), 19587 built (not run), 0 failed, 44 errored, with no warnings in 8409.00 seconds.
```

```bash
$ rg -l "devicetree error: unit address and first address in" ~/tmp/build/twister-out-expose-address-mismatch/*/* | awk --field-separator=/ '{print $7}' | sort | uniq --count | sort --numeric-sort
      1 ek_ra6m3_r7fa6m3ah3cfc
      1 frdm_kl25z_mkl25z4
      1 frdm_mcxc444_mcxc444
      1 lpcxpresso11u68_lpc11u68
      1 qemu_riscv32_qemu_virt_riscv32
      1 qemu_x86_64_atom
      1 qemu_x86_atom
      2 nrf54l15dk_nrf54l15_cpuflpr
      2 ophelia4ev_nrf54l15_cpuflpr
      8 nrf54l20pdk_nrf54l20_cpuapp
      9 mimxrt595_evk_mimxrt595s_cm33
     11 native_sim_native
```

<details>

```bash
$ time twister --cmake-only --runtime-artifact-cleanup all --outdir ~/tmp/build/twister-out-expose-address-mismatch
Renaming output directory to ~/tmp/build/twister-out-expose-address-mismatch.1
INFO    - Using Ninja..
INFO    - Zephyr version: v4.1.0-2236-g11ef4a293c44
INFO    - Using 'zephyr' toolchain.
INFO    - Selecting default platforms per testsuite scenario
INFO    - Building initial testsuite list...
INFO    - Writing JSON report ~/tmp/build/twister-out-expose-address-mismatch/testplan.json
INFO    - JOBS: 24
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/samples/synchronization for ek_ra6m3/r7fa6m3ah3cfc
ERROR   - ek_ra6m3/r7fa6m3ah3cfc    samples/synchronization/sample.kernel.synchronization ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/ek_ra6m3_r7fa6m3ah3cfc/zephyr/samples/synchronization/sample.kernel.synchronization/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/samples/synchronization for mimxrt595_evk/mimxrt595s/cm33
ERROR   - mimxrt595_evk/mimxrt595s/cm33 samples/synchronization/sample.kernel.synchronization ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/mimxrt595_evk_mimxrt595s_cm33/zephyr/samples/synchronization/sample.kernel.synchronization/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/samples/synchronization for lpcxpresso11u68/lpc11u68
ERROR   - lpcxpresso11u68/lpc11u68  samples/synchronization/sample.kernel.synchronization ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/lpcxpresso11u68_lpc11u68/zephyr/samples/synchronization/sample.kernel.synchronization/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/samples/synchronization for frdm_mcxc444/mcxc444
ERROR   - frdm_mcxc444/mcxc444      samples/synchronization/sample.kernel.synchronization ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/frdm_mcxc444_mcxc444/zephyr/samples/synchronization/sample.kernel.synchronization/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/samples/kernel/bootargs for qemu_x86_64/atom
ERROR   - qemu_x86_64/atom          samples/kernel/bootargs/sample.kernel.bootargs.efi ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/qemu_x86_64_atom/zephyr/samples/kernel/bootargs/sample.kernel.bootargs.efi/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/samples/drivers/memc for mimxrt595_evk/mimxrt595s/cm33
ERROR   - mimxrt595_evk/mimxrt595s/cm33 samples/drivers/memc/sample.drivers.memc           ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/mimxrt595_evk_mimxrt595s_cm33/zephyr/samples/drivers/memc/sample.drivers.memc/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/samples/drivers/i2s/i2s_codec for mimxrt595_evk/mimxrt595s/cm33
ERROR   - mimxrt595_evk/mimxrt595s/cm33 samples/drivers/i2s/i2s_codec/sample.drivers.i2s.codec ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/mimxrt595_evk_mimxrt595s_cm33/zephyr/samples/drivers/i2s/i2s_codec/sample.drivers.i2s.codec/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/samples/drivers/display for mimxrt595_evk/mimxrt595s/cm33
ERROR   - mimxrt595_evk/mimxrt595s/cm33 samples/drivers/display/sample.display.g1120b0mipi ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/mimxrt595_evk_mimxrt595s_cm33/zephyr/samples/drivers/display/sample.display.g1120b0mipi/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/samples/boards/nxp/mimxrt595_evk/system_off for mimxrt595_evk/mimxrt595s/cm33
ERROR   - mimxrt595_evk/mimxrt595s/cm33 samples/boards/nxp/mimxrt595_evk/system_off/sample.boards.mimxrt595_evk.system_off ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/mimxrt595_evk_mimxrt595s_cm33/zephyr/samples/boards/nxp/mimxrt595_evk/system_off/sample.boards.mimxrt595_evk.system_off/build.log
~/tmp/build/twister-out-expose-address-mismatch/ek_ra6m3_r7fa6m3ah3cfc/zephyr/samples/synchronization/sample.kernel.synchronization/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/subsys/sd/mmc for mimxrt595_evk/mimxrt595s/cm33
ERROR   - mimxrt595_evk/mimxrt595s/cm33 tests/subsys/sd/mmc/sd.mmc                         ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/mimxrt595_evk_mimxrt595s_cm33/zephyr/tests/subsys/sd/mmc/sd.mmc/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/misc/kconfigoptions for native_sim/native
ERROR   - native_sim/native         tests/misc/kconfigoptions/kconfig.kconfigoptions   ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/native_sim_native/host/tests/misc/kconfigoptions/kconfig.kconfigoptions/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/lib/devicetree/api for qemu_x86_64/atom
ERROR   - qemu_x86_64/atom          tests/lib/devicetree/api/libraries.devicetree.api  ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/qemu_x86_64_atom/zephyr/tests/lib/devicetree/api/libraries.devicetree.api/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/lib/devicetree/api for qemu_x86/atom
ERROR   - qemu_x86/atom             tests/lib/devicetree/api/libraries.devicetree.api  ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/qemu_x86_atom/zephyr/tests/lib/devicetree/api/libraries.devicetree.api/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/lib/devicetree/api for qemu_riscv32/qemu_virt_riscv32
ERROR   - qemu_riscv32/qemu_virt_riscv32 tests/lib/devicetree/api/libraries.devicetree.api  ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/qemu_riscv32_qemu_virt_riscv32/zephyr/tests/lib/devicetree/api/libraries.devicetree.api/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/lib/devicetree/api for native_sim/native
ERROR   - native_sim/native         tests/lib/devicetree/api/libraries.devicetree.api  ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/native_sim_native/host/tests/lib/devicetree/api/libraries.devicetree.api/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/uart/uart_errors for nrf54l20pdk/nrf54l20/cpuapp
ERROR   - nrf54l20pdk/nrf54l20/cpuapp tests/drivers/uart/uart_errors/drivers.uart.uart_errors.async ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/nrf54l20pdk_nrf54l20_cpuapp/zephyr/tests/drivers/uart/uart_errors/drivers.uart.uart_errors.async/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/uart/uart_errors for nrf54l20pdk/nrf54l20/cpuapp
ERROR   - nrf54l20pdk/nrf54l20/cpuapp tests/drivers/uart/uart_errors/drivers.uart.uart_errors.int_driven ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/nrf54l20pdk_nrf54l20_cpuapp/zephyr/tests/drivers/uart/uart_errors/drivers.uart.uart_errors.int_driven/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/uart/uart_elementary for nrf54l15dk/nrf54l15/cpuflpr
ERROR   - nrf54l15dk/nrf54l15/cpuflpr tests/drivers/uart/uart_elementary/drivers.uart.uart_elementary_dual_setup_mismatch_nrf54l_cpuflpr ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/nrf54l15dk_nrf54l15_cpuflpr/zephyr/tests/drivers/uart/uart_elementary/drivers.uart.uart_elementary_dual_setup_mismatch_nrf54l_cpuflpr/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/uart/uart_elementary for ophelia4ev/nrf54l15/cpuflpr
ERROR   - ophelia4ev/nrf54l15/cpuflpr tests/drivers/uart/uart_elementary/drivers.uart.uart_elementary_dual_setup_mismatch_nrf54l_cpuflpr ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/ophelia4ev_nrf54l15_cpuflpr/zephyr/tests/drivers/uart/uart_elementary/drivers.uart.uart_elementary_dual_setup_mismatch_nrf54l_cpuflpr/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/uart/uart_elementary for ophelia4ev/nrf54l15/cpuflpr
ERROR   - ophelia4ev/nrf54l15/cpuflpr tests/drivers/uart/uart_elementary/drivers.uart.uart_elementary_dual_nrf54l_cpuflpr ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/ophelia4ev_nrf54l15_cpuflpr/zephyr/tests/drivers/uart/uart_elementary/drivers.uart.uart_elementary_dual_nrf54l_cpuflpr/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/uart/uart_elementary for nrf54l15dk/nrf54l15/cpuflpr
ERROR   - nrf54l15dk/nrf54l15/cpuflpr tests/drivers/uart/uart_elementary/drivers.uart.uart_elementary_dual_nrf54l_cpuflpr ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/nrf54l15dk_nrf54l15_cpuflpr/zephyr/tests/drivers/uart/uart_elementary/drivers.uart.uart_elementary_dual_nrf54l_cpuflpr/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/uart/uart_elementary for nrf54l20pdk/nrf54l20/cpuapp
ERROR   - nrf54l20pdk/nrf54l20/cpuapp tests/drivers/uart/uart_elementary/drivers.uart.uart_elementary_dual_setup_mismatch_nrf54l ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/nrf54l20pdk_nrf54l20_cpuapp/zephyr/tests/drivers/uart/uart_elementary/drivers.uart.uart_elementary_dual_setup_mismatch_nrf54l/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/uart/uart_elementary for nrf54l20pdk/nrf54l20/cpuapp
ERROR   - nrf54l20pdk/nrf54l20/cpuapp tests/drivers/uart/uart_elementary/drivers.uart.uart_elementary_dual_nrf54l ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/nrf54l20pdk_nrf54l20_cpuapp/zephyr/tests/drivers/uart/uart_elementary/drivers.uart.uart_elementary_dual_nrf54l/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/spi/spi_loopback for nrf54l20pdk/nrf54l20/cpuapp
ERROR   - nrf54l20pdk/nrf54l20/cpuapp tests/drivers/spi/spi_loopback/drivers.spi.nrf54l_32mhz ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/nrf54l20pdk_nrf54l20_cpuapp/zephyr/tests/drivers/spi/spi_loopback/drivers.spi.nrf54l_32mhz/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/spi/spi_loopback for nrf54l20pdk/nrf54l20/cpuapp
ERROR   - nrf54l20pdk/nrf54l20/cpuapp tests/drivers/spi/spi_loopback/drivers.spi.nrf54l_16mhz ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/nrf54l20pdk_nrf54l20_cpuapp/zephyr/tests/drivers/spi/spi_loopback/drivers.spi.nrf54l_16mhz/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/spi/spi_loopback for nrf54l20pdk/nrf54l20/cpuapp
ERROR   - nrf54l20pdk/nrf54l20/cpuapp tests/drivers/spi/spi_loopback/drivers.spi.nrf54l_8mhz ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/nrf54l20pdk_nrf54l20_cpuapp/zephyr/tests/drivers/spi/spi_loopback/drivers.spi.nrf54l_8mhz/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/spi/spi_controller_peripheral for nrf54l20pdk/nrf54l20/cpuapp
ERROR   - nrf54l20pdk/nrf54l20/cpuapp tests/drivers/spi/spi_controller_peripheral/drivers.spi.pm_runtime ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/nrf54l20pdk_nrf54l20_cpuapp/zephyr/tests/drivers/spi/spi_controller_peripheral/drivers.spi.pm_runtime/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/gpio/gpio_basic_api for mimxrt595_evk/mimxrt595s/cm33
ERROR   - mimxrt595_evk/mimxrt595s/cm33 tests/drivers/gpio/gpio_basic_api/drivers.gpio.2pin_arduino_customized ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/mimxrt595_evk_mimxrt595s_cm33/zephyr/tests/drivers/gpio/gpio_basic_api/drivers.gpio.2pin_arduino_customized/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/disk/disk_performance for mimxrt595_evk/mimxrt595s/cm33
ERROR   - mimxrt595_evk/mimxrt595s/cm33 tests/drivers/disk/disk_performance/drivers.disk.disk_performance.sdhc ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/mimxrt595_evk_mimxrt595s_cm33/zephyr/tests/drivers/disk/disk_performance/drivers.disk.disk_performance.sdhc/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/build_all/sensor for native_sim/native
ERROR   - native_sim/native         tests/drivers/build_all/sensor/drivers.sensor.generic_test ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/native_sim_native/host/tests/drivers/build_all/sensor/drivers.sensor.generic_test/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/build_all/sensor for native_sim/native
ERROR   - native_sim/native         tests/drivers/build_all/sensor/drivers.sensor.pm.build ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/native_sim_native/host/tests/drivers/build_all/sensor/drivers.sensor.pm.build/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/build_all/sensor for native_sim/native
ERROR   - native_sim/native         tests/drivers/build_all/sensor/drivers.sensor.build ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/native_sim_native/host/tests/drivers/build_all/sensor/drivers.sensor.build/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/build_all/sensor for native_sim/native
ERROR   - native_sim/native         tests/drivers/build_all/sensor/drivers.sensor.no_default.build ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/native_sim_native/host/tests/drivers/build_all/sensor/drivers.sensor.no_default.build/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/build_all/sensor for native_sim/native
ERROR   - native_sim/native         tests/drivers/build_all/sensor/drivers.sensor.trigger.none.build ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/native_sim_native/host/tests/drivers/build_all/sensor/drivers.sensor.trigger.none.build/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/build_all/sensor for native_sim/native
ERROR   - native_sim/native         tests/drivers/build_all/sensor/drivers.sensor.trigger.own.build ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/native_sim_native/host/tests/drivers/build_all/sensor/drivers.sensor.trigger.own.build/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/build_all/sensor for native_sim/native
ERROR   - native_sim/native         tests/drivers/build_all/sensor/drivers.sensor.trigger.global.build ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/native_sim_native/host/tests/drivers/build_all/sensor/drivers.sensor.trigger.global.build/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/build_all/sensor for native_sim/native
ERROR   - native_sim/native         tests/drivers/build_all/sensor/drivers.sensor.sensorhub.build ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/native_sim_native/host/tests/drivers/build_all/sensor/drivers.sensor.sensorhub.build/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/build_all/auxdisplay for native_sim/native
ERROR   - native_sim/native         tests/drivers/build_all/auxdisplay/drivers.auxdisplay.build.i2c ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/native_sim_native/host/tests/drivers/build_all/auxdisplay/drivers.auxdisplay.build.i2c/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/audio/dmic_api for mimxrt595_evk/mimxrt595s/cm33
ERROR   - mimxrt595_evk/mimxrt595s/cm33 tests/drivers/audio/dmic_api/drivers.audio.dmic_api ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/mimxrt595_evk_mimxrt595s_cm33/zephyr/tests/drivers/audio/dmic_api/drivers.audio.dmic_api/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/adc/adc_accuracy_test for frdm_kl25z/mkl25z4
ERROR   - frdm_kl25z/mkl25z4        tests/drivers/adc/adc_accuracy_test/drivers.adc.accuracy.ref_volt ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/frdm_kl25z_mkl25z4/zephyr/tests/drivers/adc/adc_accuracy_test/drivers.adc.accuracy.ref_volt/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/boot/uefi for qemu_x86_64/atom
ERROR   - qemu_x86_64/atom          tests/boot/uefi/boot.uefi                          ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/qemu_x86_64_atom/zephyr/tests/boot/uefi/boot.uefi/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/boards/espressif/wifi for esp32c3_devkitm/esp32c3
ERROR   - esp32c3_devkitm/esp32c3   tests/boards/espressif/wifi/esp.wifi.sec.wpa3      ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/esp32c3_devkitm_esp32c3/zephyr/tests/boards/espressif/wifi/esp.wifi.sec.wpa3/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/boards/espressif/wifi for esp32c3_devkitm/esp32c3
ERROR   - esp32c3_devkitm/esp32c3   tests/boards/espressif/wifi/esp.wifi.sec.wpa2      ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/esp32c3_devkitm_esp32c3/zephyr/tests/boards/espressif/wifi/esp.wifi.sec.wpa2/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/boards/espressif/wifi for esp32c3_devkitm/esp32c3
ERROR   - esp32c3_devkitm/esp32c3   tests/boards/espressif/wifi/esp.wifi.sec.none      ERROR: CMake build failure
ERROR   - see: ~/tmp/build/twister-out-expose-address-mismatch/esp32c3_devkitm_esp32c3/zephyr/tests/boards/espressif/wifi/esp.wifi.sec.none/build.log
INFO    - Total complete: 23787/23787  100%  built (not run): 19587, filtered: 70098, failed:    0, error:   44
INFO    - 3609 test scenarios (89729 configurations) selected, 70098 configurations filtered (65942 by static filter, 4156 at runtime).
INFO    - 0 of 19631 executed test configurations passed (0.00%), 19587 built (not run), 0 failed, 44 errored, with no warnings in 8409.00 seconds.
INFO    - 0 of 434 executed test cases passed (0.00%), 434 errored on 13 out of total 1005 platforms (1.29%).
INFO    - 140407 selected test cases not executed: 140407 not run (built only).
INFO    - 0 test configurations executed on platforms, 19631 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing JSON report ~/tmp/build/twister-out-expose-address-mismatch/twister.json
INFO    - Writing xunit report ~/tmp/build/twister-out-expose-address-mismatch/twister.xml...
INFO    - Writing xunit report ~/tmp/build/twister-out-expose-address-mismatch/twister_report.xml...
INFO    - -+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
INFO    - The following issues were found (showing the top 10 items):
INFO    - 1) tests/boards/espressif/wifi/esp.wifi.sec.none on esp32c3_devkitm/esp32c3 error (CMake build failure - CMake Error at ~/code/3rd-party/zephyrproject/zephyr/cmake/modules/extensions.cmake:1867 (message):   Blob for path)
INFO    - 2) tests/boards/espressif/wifi/esp.wifi.sec.wpa2 on esp32c3_devkitm/esp32c3 error (CMake build failure - CMake Error at ~/code/3rd-party/zephyrproject/zephyr/cmake/modules/extensions.cmake:1867 (message):   Blob for path)
INFO    - 3) tests/boards/espressif/wifi/esp.wifi.sec.wpa3 on esp32c3_devkitm/esp32c3 error (CMake build failure - CMake Error at ~/code/3rd-party/zephyrproject/zephyr/cmake/modules/extensions.cmake:1867 (message):   Blob for path)
INFO    - 4) tests/boot/uefi/boot.uefi on qemu_x86_64/atom error (CMake build failure - CMake Error at ~/code/3rd-party/zephyrproject/zephyr/cmake/emu/qemu.cmake:35 (find_program):   Could not find UEFI using the following names: uefi-run)
INFO    - 5) tests/drivers/adc/adc_accuracy_test/drivers.adc.accuracy.ref_volt on frdm_kl25z/mkl25z4 error (CMake build failure - devicetree error)
INFO    - 6) tests/drivers/audio/dmic_api/drivers.audio.dmic_api on mimxrt595_evk/mimxrt595s/cm33 error (CMake build failure - devicetree error)
INFO    - 7) tests/drivers/build_all/auxdisplay/drivers.auxdisplay.build.i2c on native_sim/native error (CMake build failure - devicetree error)
INFO    - 8) tests/drivers/build_all/sensor/drivers.sensor.sensorhub.build on native_sim/native error (CMake build failure - devicetree error)
INFO    - 9) tests/drivers/build_all/sensor/drivers.sensor.trigger.own.build on native_sim/native error (CMake build failure - devicetree error)
INFO    - 10) tests/drivers/build_all/sensor/drivers.sensor.trigger.global.build on native_sim/native error (CMake build failure - devicetree error)
INFO    -
INFO    - To rerun the tests, call twister using the following commandline:
INFO    - west twister -p <PLATFORM> -s <TEST ID>, for example:
INFO    -
INFO    - west twister -p native_sim/native -s tests/drivers/build_all/sensor/drivers.sensor.trigger.global.build
INFO    - or with west:
INFO    - west build -p -b native_sim/native zephyr/tests/drivers/build_all/sensor -T drivers.sensor.trigger.global.build
INFO    - -+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
INFO    - Run completed

real    140m18.586s
user    2696m5.468s
sys     493m25.756s
```

</details>

`v4.0.0-769-gb06bf51459e` (`twister --cmake-only --runtime-artifact-cleanup all`):
```
- 0 of 18784 executed test configurations passed (0.00%), 18714 built (not run), 0 failed, 70 errored, with no warnings in 12808.68 seconds.
```

```bash
$ rg "CMake build failure: " twister-out-expose-address-mismatch/results.txt  | awk '{print $8}' | sort | uniq -c | sort -n
      1 frdm_kl25z/mkl25z4
      1 frdm_mcxc444/mcxc444
      1 lpcxpresso11u68/lpc11u68
      1 qemu_riscv32/qemu_virt_riscv32
      1 qemu_x86/atom
      3 nrf54l15dk/nrf54l15/cpuflpr
      3 qemu_x86_64/atom
      9 mimxrt595_evk/mimxrt595s/cm33
     11 native_sim/native
     11 nrf54l15dk/nrf54l15/cpuapp
```
<details>

```bash
$ twister --cmake-only --outdir ~/tmp/twister-out-expose-address-mismatch --runtime-artifact-cleanup all
INFO    - Using Ninja..
INFO    - Zephyr version: v4.0.0-770-gc45fdbf95215
INFO    - Using 'zephyr' toolchain.
INFO    - Selecting default platforms per test case
INFO    - Building initial testsuite list...
INFO    - Writing JSON report ~/twister-out-expose-address-mismatch/testplan.json
INFO    - JOBS: 22
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/samples/synchronization for frdm_mcxc444/mcxc444
ERROR   - frdm_mcxc444/mcxc444      samples/synchronization/sample.kernel.synchronization ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/frdm_mcxc444_mcxc444/samples/synchronization/sample.kernel.synchronization/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/samples/synchronization for mimxrt595_evk/mimxrt595s/cm33
ERROR   - mimxrt595_evk/mimxrt595s/cm33 samples/synchronization/sample.kernel.synchronization ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/mimxrt595_evk_mimxrt595s_cm33/samples/synchronization/sample.kernel.synchronization/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/samples/synchronization for lpcxpresso11u68/lpc11u68
ERROR   - lpcxpresso11u68/lpc11u68  samples/synchronization/sample.kernel.synchronization ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/lpcxpresso11u68_lpc11u68/samples/synchronization/sample.kernel.synchronization/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/samples/kernel/bootargs for qemu_x86_64/atom
ERROR   - qemu_x86_64/atom          samples/kernel/bootargs/sample.kernel.bootargs.efi ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/qemu_x86_64_atom/samples/kernel/bootargs/sample.kernel.bootargs.efi/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/samples/drivers/memc for mimxrt595_evk/mimxrt595s/cm33
ERROR   - mimxrt595_evk/mimxrt595s/cm33 samples/drivers/memc/sample.drivers.memc           ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/mimxrt595_evk_mimxrt595s_cm33/samples/drivers/memc/sample.drivers.memc/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/samples/drivers/i2s/i2s_codec for mimxrt595_evk/mimxrt595s/cm33
ERROR   - mimxrt595_evk/mimxrt595s/cm33 samples/drivers/i2s/i2s_codec/sample.drivers.i2s.codec ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/mimxrt595_evk_mimxrt595s_cm33/samples/drivers/i2s/i2s_codec/sample.drivers.i2s.codec/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/samples/drivers/display for mimxrt595_evk/mimxrt595s/cm33
ERROR   - mimxrt595_evk/mimxrt595s/cm33 samples/drivers/display/sample.display.g1120b0mipi ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/mimxrt595_evk_mimxrt595s_cm33/samples/drivers/display/sample.display.g1120b0mipi/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/samples/drivers/audio/dmic for nrf54l15dk/nrf54l15/cpuapp
ERROR   - nrf54l15dk/nrf54l15/cpuapp samples/drivers/audio/dmic/sample.drivers.audio.dmic ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/nrf54l15dk_nrf54l15_cpuapp/samples/drivers/audio/dmic/sample.drivers.audio.dmic/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/samples/boards/nxp/mimxrt595_evk/system_off for mimxrt595_evk/mimxrt595s/cm33
ERROR   - mimxrt595_evk/mimxrt595s/cm33 samples/boards/nxp/mimxrt595_evk/system_off/sample.boards.mimxrt595_evk.system_off ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/mimxrt595_evk_mimxrt595s_cm33/samples/boards/nxp/mimxrt595_evk/system_off/sample.boards.mimxrt595_evk.system_off/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/subsys/secure_storage/psa/its for nrf54l15dk/nrf54l15/cpuapp
ERROR   - nrf54l15dk/nrf54l15/cpuapp tests/subsys/secure_storage/psa/its/secure_storage.psa.its.secure_storage.custom.both ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/nrf54l15dk_nrf54l15_cpuapp/tests/subsys/secure_storage/psa/its/secure_storage.psa.its.secure_storage.custom.both/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/subsys/secure_storage/psa/its for nrf54l15dk/nrf54l15/cpuapp
ERROR   - nrf54l15dk/nrf54l15/cpuapp tests/subsys/secure_storage/psa/its/secure_storage.psa.its.secure_storage.custom.store ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/nrf54l15dk_nrf54l15_cpuapp/tests/subsys/secure_storage/psa/its/secure_storage.psa.its.secure_storage.custom.store/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/subsys/secure_storage/psa/its for nrf54l15dk/nrf54l15/cpuapp
ERROR   - nrf54l15dk/nrf54l15/cpuapp tests/subsys/secure_storage/psa/its/secure_storage.psa.its.secure_storage.custom.transform ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/nrf54l15dk_nrf54l15_cpuapp/tests/subsys/secure_storage/psa/its/secure_storage.psa.its.secure_storage.custom.transform/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/subsys/secure_storage/psa/its for nrf54l15dk/nrf54l15/cpuapp
ERROR   - nrf54l15dk/nrf54l15/cpuapp tests/subsys/secure_storage/psa/its/secure_storage.psa.its.secure_storage ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/nrf54l15dk_nrf54l15_cpuapp/tests/subsys/secure_storage/psa/its/secure_storage.psa.its.secure_storage/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/subsys/secure_storage/psa/crypto for nrf54l15dk/nrf54l15/cpuapp
ERROR   - nrf54l15dk/nrf54l15/cpuapp tests/subsys/secure_storage/psa/crypto/secure_storage.psa.crypto.secure_storage ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/nrf54l15dk_nrf54l15_cpuapp/tests/subsys/secure_storage/psa/crypto/secure_storage.psa.crypto.secure_storage/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/subsys/sd/mmc for mimxrt595_evk/mimxrt595s/cm33
ERROR   - mimxrt595_evk/mimxrt595s/cm33 tests/subsys/sd/mmc/sd.mmc                         ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/mimxrt595_evk_mimxrt595s_cm33/tests/subsys/sd/mmc/sd.mmc/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/misc/kconfigoptions for native_sim/native
ERROR   - native_sim/native         tests/misc/kconfigoptions/kconfig.kconfigoptions   ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/native_sim_native/tests/misc/kconfigoptions/kconfig.kconfigoptions/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/lib/devicetree/api for qemu_x86_64/atom
ERROR   - qemu_x86_64/atom          tests/lib/devicetree/api/libraries.devicetree.api  ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/qemu_x86_64_atom/tests/lib/devicetree/api/libraries.devicetree.api/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/lib/devicetree/api for qemu_x86/atom
ERROR   - qemu_x86/atom             tests/lib/devicetree/api/libraries.devicetree.api  ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/qemu_x86_atom/tests/lib/devicetree/api/libraries.devicetree.api/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/lib/devicetree/api for native_sim/native
ERROR   - native_sim/native         tests/lib/devicetree/api/libraries.devicetree.api  ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/native_sim_native/tests/lib/devicetree/api/libraries.devicetree.api/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/lib/devicetree/api for qemu_riscv32/qemu_virt_riscv32
ERROR   - qemu_riscv32/qemu_virt_riscv32 tests/lib/devicetree/api/libraries.devicetree.api  ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/qemu_riscv32_qemu_virt_riscv32/tests/lib/devicetree/api/libraries.devicetree.api/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/uart/uart_errors for nrf54l15dk/nrf54l15/cpuapp
ERROR   - nrf54l15dk/nrf54l15/cpuapp tests/drivers/uart/uart_errors/drivers.uart.uart_errors.async ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/nrf54l15dk_nrf54l15_cpuapp/tests/drivers/uart/uart_errors/drivers.uart.uart_errors.async/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/uart/uart_errors for nrf54l15dk/nrf54l15/cpuapp
ERROR   - nrf54l15dk/nrf54l15/cpuapp tests/drivers/uart/uart_errors/drivers.uart.uart_errors.int_driven ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/nrf54l15dk_nrf54l15_cpuapp/tests/drivers/uart/uart_errors/drivers.uart.uart_errors.int_driven/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/uart/uart_elementary for nrf54l15dk/nrf54l15/cpuflpr
ERROR   - nrf54l15dk/nrf54l15/cpuflpr tests/drivers/uart/uart_elementary/drivers.uart.uart_elementary_dual_setup_mismatch_nrf54l_cpuflpr ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/nrf54l15dk_nrf54l15_cpuflpr/tests/drivers/uart/uart_elementary/drivers.uart.uart_elementary_dual_setup_mismatch_nrf54l_cpuflpr/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/uart/uart_elementary for nrf54l15dk/nrf54l15/cpuflpr
ERROR   - nrf54l15dk/nrf54l15/cpuflpr tests/drivers/uart/uart_elementary/drivers.uart.uart_elementary_dual_nrf54l_cpuflpr ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/nrf54l15dk_nrf54l15_cpuflpr/tests/drivers/uart/uart_elementary/drivers.uart.uart_elementary_dual_nrf54l_cpuflpr/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/uart/uart_elementary for nrf54l15dk/nrf54l15/cpuapp
ERROR   - nrf54l15dk/nrf54l15/cpuapp tests/drivers/uart/uart_elementary/drivers.uart.uart_elementary_dual_setup_mismatch_nrf54l ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/nrf54l15dk_nrf54l15_cpuapp/tests/drivers/uart/uart_elementary/drivers.uart.uart_elementary_dual_setup_mismatch_nrf54l/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/uart/uart_elementary for nrf54l15dk/nrf54l15/cpuapp
ERROR   - nrf54l15dk/nrf54l15/cpuapp tests/drivers/uart/uart_elementary/drivers.uart.uart_elementary_dual_nrf54l ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/nrf54l15dk_nrf54l15_cpuapp/tests/drivers/uart/uart_elementary/drivers.uart.uart_elementary_dual_nrf54l/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/uart/uart_elementary for nrf54l15dk/nrf54l15/cpuflpr
ERROR   - nrf54l15dk/nrf54l15/cpuflpr tests/drivers/uart/uart_elementary/drivers.uart.uart_elementary ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/nrf54l15dk_nrf54l15_cpuflpr/tests/drivers/uart/uart_elementary/drivers.uart.uart_elementary/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/uart/uart_elementary for nrf54l15dk/nrf54l15/cpuapp
ERROR   - nrf54l15dk/nrf54l15/cpuapp tests/drivers/uart/uart_elementary/drivers.uart.uart_elementary ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/nrf54l15dk_nrf54l15_cpuapp/tests/drivers/uart/uart_elementary/drivers.uart.uart_elementary/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/gpio/gpio_basic_api for mimxrt595_evk/mimxrt595s/cm33
ERROR   - mimxrt595_evk/mimxrt595s/cm33 tests/drivers/gpio/gpio_basic_api/drivers.gpio.2pin_arduino_customized ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/mimxrt595_evk_mimxrt595s_cm33/tests/drivers/gpio/gpio_basic_api/drivers.gpio.2pin_arduino_customized/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/disk/disk_performance for mimxrt595_evk/mimxrt595s/cm33
ERROR   - mimxrt595_evk/mimxrt595s/cm33 tests/drivers/disk/disk_performance/drivers.disk.disk_performance.sdhc ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/mimxrt595_evk_mimxrt595s_cm33/tests/drivers/disk/disk_performance/drivers.disk.disk_performance.sdhc/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/build_all/auxdisplay for native_sim/native
ERROR   - native_sim/native         tests/drivers/build_all/auxdisplay/drivers.auxdisplay.build.i2c ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/native_sim_native/tests/drivers/build_all/auxdisplay/drivers.auxdisplay.build.i2c/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/build_all/sensor for native_sim/native
ERROR   - native_sim/native         tests/drivers/build_all/sensor/sensors.generic_test ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/native_sim_native/tests/drivers/build_all/sensor/sensors.generic_test/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/build_all/sensor for native_sim/native
ERROR   - native_sim/native         tests/drivers/build_all/sensor/sensors.build       ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/native_sim_native/tests/drivers/build_all/sensor/sensors.build/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/build_all/sensor for native_sim/native
ERROR   - native_sim/native         tests/drivers/build_all/sensor/sensors.build.pm    ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/native_sim_native/tests/drivers/build_all/sensor/sensors.build.pm/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/build_all/sensor for native_sim/native
ERROR   - native_sim/native         tests/drivers/build_all/sensor/sensors.build.no_default ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/native_sim_native/tests/drivers/build_all/sensor/sensors.build.no_default/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/build_all/sensor for native_sim/native
ERROR   - native_sim/native         tests/drivers/build_all/sensor/sensors.build.trigger.none ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/native_sim_native/tests/drivers/build_all/sensor/sensors.build.trigger.none/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/build_all/sensor for native_sim/native
ERROR   - native_sim/native         tests/drivers/build_all/sensor/sensors.build.trigger.global ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/native_sim_native/tests/drivers/build_all/sensor/sensors.build.trigger.global/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/build_all/sensor for native_sim/native
ERROR   - native_sim/native         tests/drivers/build_all/sensor/sensors.build.trigger.own ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/native_sim_native/tests/drivers/build_all/sensor/sensors.build.trigger.own/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/build_all/sensor for native_sim/native
ERROR   - native_sim/native         tests/drivers/build_all/sensor/sensors.build.sensorhub ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/native_sim_native/tests/drivers/build_all/sensor/sensors.build.sensorhub/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/audio/dmic_api for mimxrt595_evk/mimxrt595s/cm33
ERROR   - mimxrt595_evk/mimxrt595s/cm33 tests/drivers/audio/dmic_api/drivers.audio.dmic_api ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/mimxrt595_evk_mimxrt595s_cm33/tests/drivers/audio/dmic_api/drivers.audio.dmic_api/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/drivers/adc/adc_accuracy_test for frdm_kl25z/mkl25z4
ERROR   - frdm_kl25z/mkl25z4        tests/drivers/adc/adc_accuracy_test/drivers.adc.accuracy.ref_volt ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/frdm_kl25z_mkl25z4/tests/drivers/adc/adc_accuracy_test/drivers.adc.accuracy.ref_volt/build.log
ERROR   - CMake build failure: ~/code/3rd-party/zephyrproject/zephyr/tests/boot/uefi for qemu_x86_64/atom
ERROR   - qemu_x86_64/atom          tests/boot/uefi/boot.uefi                          ERROR: CMake build failure
ERROR   - see: ~/twister-out-expose-address-mismatch/qemu_x86_64_atom/tests/boot/uefi/boot.uefi/build.log
INFO    - Total complete: 22116/22144  99%  built (not run): 18714, filtered: 60230, failed:    0, error:   70
INFO    - 3251 test scenarios (79014 configurations) selected, 60230 configurations filtered (56870 by static filter, 3360 at runtime).
INFO    - 0 of 18784 executed test configurations passed (0.00%), 18714 built (not run), 0 failed, 70 errored, with no warnings in 12808.68 seconds.
INFO    - 0 of 375 executed test cases passed (0.00%), 375 errored on 13 out of total 865 platforms (1.50%).
INFO    - 134940 selected test cases not executed: 134940 not run (built only).
INFO    - 0 test configurations executed on platforms, 18784 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing JSON report ~/twister-out-expose-address-mismatch/twister.json
INFO    - Writing xunit report ~/twister-out-expose-address-mismatch/twister.xml...
INFO    - Writing xunit report ~/twister-out-expose-address-mismatch/twister_report.xml...
INFO    - -+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
INFO    - The following issues were found (showing the top 10 items):
INFO    - 1) tests/boot/uefi/boot.uefi on qemu_x86_64/atom error (CMake build failure)
INFO    - 2) tests/bsim/bluetooth/ll/bis/bluetooth.ll.bis on nrf52_bsim/native error (Environment (BSIM_OUT_PATH) not satisfied but is one of the integration platforms)
INFO    - 3) tests/bsim/bluetooth/ll/bis/bluetooth.ll.bis on nrf5340bsim/nrf5340/cpuapp error (Environment (BSIM_OUT_PATH) not satisfied but is one of the integration platforms)
INFO    - 4) tests/bsim/bluetooth/ll/bis/bluetooth.ll.bis on nrf5340bsim/nrf5340/cpunet error (Environment (BSIM_OUT_PATH) not satisfied but is one of the integration platforms)
INFO    - 5) tests/bsim/bluetooth/ll/bis/bluetooth.ll.bis_ticker_expire_info on nrf52_bsim/native error (Environment (BSIM_OUT_PATH) not satisfied but is one of the integration platforms)
INFO    - 6) tests/bsim/bluetooth/ll/bis/bluetooth.ll.bis_ticker_expire_info on nrf5340bsim/nrf5340/cpunet error (Environment (BSIM_OUT_PATH) not satisfied but is one of the integration platforms)
INFO    - 7) tests/bsim/bluetooth/ll/bis/bluetooth.ll.bis_vs_dp on nrf52_bsim/native error (Environment (BSIM_OUT_PATH) not satisfied but is one of the integration platforms)
INFO    - 8) tests/bsim/bluetooth/ll/bis/bluetooth.ll.bis_vs_dp on nrf5340bsim/nrf5340/cpunet error (Environment (BSIM_OUT_PATH) not satisfied but is one of the integration platforms)
INFO    - 9) tests/bsim/bluetooth/ll/bis/bluetooth.ll.bis_past on nrf52_bsim/native error (Environment (BSIM_OUT_PATH) not satisfied but is one of the integration platforms)
INFO    - 10) tests/bsim/bluetooth/ll/bis/bluetooth.ll.bis_past on nrf5340bsim/nrf5340/cpunet error (Environment (BSIM_OUT_PATH) not satisfied but is one of the integration platforms)
INFO    - 
INFO    - To rerun the tests, call twister using the following commandline:
INFO    - west twister -p <PLATFORM> -s <TEST ID>, for example:
INFO    - 
INFO    - west twister -p nrf5340bsim/nrf5340/cpunet -s tests/bsim/bluetooth/ll/bis/bluetooth.ll.bis_past
INFO    - or with west:
INFO    - west build -p -b nrf5340bsim/nrf5340/cpunet tests/bsim/bluetooth/ll/bis -T bluetooth.ll.bis_past
INFO    - -+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
INFO    - Run completed
```
</details>

`v3.7.0-5004-ga2f2dc9ad11`:
```
- 19453 of 74544 test configurations passed (98.88%), 0 built (not run), 0 failed, 220 errored, 54871 skipped with 0 warnings in 8176.27 seconds
```

The following issues have been identified as blockers for this PR:
- [x] #72273
- [x] #78251

If anyone knows another way to resolve/work around those issues, please let me know.

Already resolved blockers:
- [x] #78437
- [x] #78438
- [x] #78439
- [x] #78440
- [x] #78441
- [x] #78442
- [x] #78443
- [x] #78444
- [x] #78445
- [x] #78446
- [x] #78447
- [x] #78451
- [x] #78452