### PR TITLE
rtio: Disable xtensa dc233c

### DIFF
--- a/tests/subsys/rtio/rtio_api/testcase.yaml
+++ b/tests/subsys/rtio/rtio_api/testcase.yaml
@@ -1,6 +1,7 @@
 common:
   # renode causes timeouts unfortunately
-  platform_exclude: m2gl025_miv m5stack_core2 hifive1
+  # xtensa dc233 (with mmu) has a TLB exception for unclear reasons
+  platform_exclude: m2gl025_miv m5stack_core2 hifive1 qemu_xtensa_dc233c
   platform_key:
     - arch
     - simulation


### PR DESCRIPTION
This particular qemu platform seems to run into a strange TLB exception with unclear cause. Disable the test suite on xtensa qemu for the time being.