### PR TITLE
dts: subsys: npcx: update the required change of npcx9mfb

### DIFF
--- a/dts/arm/nuvoton/npcx9m7fb.dtsi
+++ b/dts/arm/nuvoton/npcx9m7fb.dtsi
@@ -40,3 +40,11 @@
 		pinctrl-names = "default";
 	};
 };
+
+/*
+ * Raising the interrupt priority of the MIWU group, which owns SHI CS, to the same as
+ * SHI's priority.
+ */
+&group_f1 {
+	irq-prio = <1>;
+};

--- a/dts/arm/nuvoton/npcx9m7fb.dtsi
+++ b/dts/arm/nuvoton/npcx9m7fb.dtsi
@@ -9,16 +9,16 @@
 
 / {
 	flash0: flash@10070000 {
-		reg = <0x10070000 DT_SIZE_K(320)>;
+		reg = <0x10070000 DT_SIZE_K(256)>;
 	};
 
 	flash1: flash@64000000 {
-		reg = <0x64000000 DT_SIZE_K(1024)>;
+		reg = <0x64000000 DT_SIZE_K(512)>;
 	};
 
 	sram0: memory@200c0000 {
 		compatible = "mmio-sram";
-		reg = <0x200C0000 DT_SIZE_K(64)>;
+		reg = <0x200B0000 DT_SIZE_K(128)>;
 	};
 
 	soc-id {
@@ -29,7 +29,7 @@
 &qspi_fiu0 {
 	int_flash: w25q80@0 {
 		compatible ="nuvoton,npcx-fiu-nor";
-		size = <DT_SIZE_M(1 * 8)>;
+		size = <DT_SIZE_K(512 * 8)>;
 		reg = <0>;
 		status = "okay";
 

--- a/subsys/mgmt/ec_host_cmd/backends/Kconfig
+++ b/subsys/mgmt/ec_host_cmd/backends/Kconfig
@@ -75,6 +75,13 @@ config EC_HOST_CMD_BACKEND_SHI_NPCX_ENHANCED_BUF_MODE
 	  single-byte output buffer can be selected/switched to generate a
 	  response to simultaneous Read/Write transactions.
 
+config EC_HOST_CMD_BACKEND_SHI_NPCX_CS_DETECT_WORKAROUND
+	bool
+	default y if SOC_NPCX9M7FB
+	help
+	  Workaround the issue "CSnFE and CSnRE bits of EVSTATS2 Register (SHI)"
+	  in the npcx9m7fb SoC errata.
+
 config EC_HOST_CMD_BACKEND_SHI_MAX_REQUEST
 	int "Max data size for the version 3 request packet"
 	default 544 if EC_HOST_CMD_BACKEND_SHI_NPCX


### PR DESCRIPTION
This PR is for the required change of npcx9mfb for the Chromebook EC project.
It includes the following:
1. Update the internal flash size of npcx9m7fb
2. Add the workaround for the issue on the SHI hardware peripheral to detect CS rising/failing 