### PR TITLE
llext: SOF hotfix: fix `sparse` check regression

### DIFF
--- a/subsys/llext/llext.c
+++ b/subsys/llext/llext.c
@@ -297,7 +297,7 @@ static int call_fn_table(struct llext *ext, bool is_init)
 
 	for (int i = 0; i < fn_count; i++) {
 		LOG_DBG("calling %s function %p()",
-			is_init ? "bringup" : "teardown", fn_table[i]);
+			is_init ? "bringup" : "teardown", (void *)fn_table[i]);
 		fn_table[i]();
 	}
 
@@ -326,7 +326,7 @@ void llext_bootstrap(struct llext *ext, llext_entry_fn_t entry_fn, void *user_da
 	}
 
 	/* Start extension main function */
-	LOG_DBG("calling entry function %p(%p)", entry_fn, user_data);
+	LOG_DBG("calling entry function %p(%p)", (void *)entry_fn, user_data);
 	entry_fn(user_data);
 
 	/* Call de-initialization functions */

--- a/subsys/llext/llext_handlers.c
+++ b/subsys/llext/llext_handlers.c
@@ -60,7 +60,8 @@ ssize_t z_impl_llext_get_fn_table(struct llext *ext, bool is_init, void *buf, si
 
 		for (int i = 0; i < table_size / sizeof(void *); i++) {
 			if (fn_ptrs[i] < text_start || fn_ptrs[i] >= text_end) {
-				LOG_ERR("init function %i (%p) outside text region",
+				LOG_ERR("%s function %i (%p) outside text region",
+					is_init ? "bringup" : "teardown",
 					i, fn_ptrs[i]);
 				return -EFAULT;
 			}


### PR DESCRIPTION
Some function pointers were being passed via `%p` to `LOG_DBG`, and this was causing the following kinds of [issues in SOF CI](https://github.com/thesofproject/sof/actions/runs/10791954297/job/29930534306?pr=9455) with the `sparse` checker:

    subsys/llext/llext.c: error: arithmetics on pointers to functions
    subsys/llext/llext.c: error: incompatible types for operation (+)

This patch fixes the issue by casting the function pointers to void*. Also fix a misleading error message in `llext_get_fn_table()`.