### PR TITLE
samples: bluetooth: direction_finding_connectionless_rx: Fix sync timeout

### DIFF
--- a/samples/bluetooth/direction_finding_connectionless_rx/src/main.c
+++ b/samples/bluetooth/direction_finding_connectionless_rx/src/main.c
@@ -263,7 +263,7 @@ static void create_sync(void)
 	sync_create_param.options = BT_LE_PER_ADV_SYNC_OPT_SYNC_ONLY_CONST_TONE_EXT;
 	sync_create_param.sid = per_sid;
 	sync_create_param.skip = 0;
-	sync_create_param.timeout = sync_create_timeout_ms * 10 / 10; /* 10 attempts */
+	sync_create_param.timeout = sync_create_timeout_ms / 10;
 	err = bt_le_per_adv_sync_create(&sync_create_param, &adv_sync);
 	if (err != 0) {
 		printk("failed (err %d)\n", err);


### PR DESCRIPTION
The sync timeout is in 10 ms units. The sync_create_timeout_ms variable already takes into account that we want to have a timeout of at least 7 events.