### PR TITLE
drivers: usb: udc_dwc2: Restrict TxFIFO to SPRAM size

### DIFF
--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -1760,6 +1760,11 @@ static int dwc2_set_dedicated_fifo(const struct device *dev,
 			return -ENOMEM;
 		}
 
+		/* Do not allocate TxFIFO outside the SPRAM */
+		if (txfaddr + txfdep > priv->dfifodepth) {
+			return -ENOMEM;
+		}
+
 		/* Set FIFO depth (32-bit words) and address */
 		dwc2_set_txf(dev, ep_idx - 1, txfdep, txfaddr);
 	} else {


### PR DESCRIPTION
Do not allocate TxFIFO in a way that could corrupt Endpoint Information Controller data (stored at DFIFO Depth address) or access locations outside the SPRAM.