### PR TITLE
subsys: mgmt: Fix handler search

### DIFF
--- a/subsys/mgmt/mcumgr/mgmt/src/mgmt.c
+++ b/subsys/mgmt/mcumgr/mgmt/src/mgmt.c
@@ -49,7 +49,7 @@ mgmt_find_handler(uint16_t group_id, uint16_t command_id)
 			CONTAINER_OF(snp, struct mgmt_group, node);
 		if (loop_group->mg_group_id == group_id) {
 			if (command_id >= loop_group->mg_handlers_count) {
-				break;
+				continue;
 			}
 
 			if (!loop_group->mg_handlers[command_id].mh_read &&

--- a/subsys/mgmt/mcumgr/smp/src/smp.c
+++ b/subsys/mgmt/mcumgr/smp/src/smp.c
@@ -158,7 +158,6 @@ static int smp_build_err_rsp(struct smp_streamer *streamer, const struct smp_hdr
  */
 static int smp_handle_single_payload(struct smp_streamer *cbuf, const struct smp_hdr *req_hdr)
 {
-	const struct mgmt_group *group;
 	const struct mgmt_handler *handler;
 	mgmt_handler_fn handler_fn;
 	int rc;
@@ -169,12 +168,7 @@ static int smp_handle_single_payload(struct smp_streamer *cbuf, const struct smp
 	uint16_t err_group;
 #endif
 
-	group = mgmt_find_group(req_hdr->nh_group);
-	if (group == NULL) {
-		return MGMT_ERR_ENOTSUP;
-	}
-
-	handler = mgmt_get_handler(group, req_hdr->nh_id);
+	handler = mgmt_find_handler(req_hdr->nh_group, req_hdr->nh_id);
 	if (handler == NULL) {
 		return MGMT_ERR_ENOTSUP;
 	}


### PR DESCRIPTION
Allow to implement the same SMP group by multiple modules and iterate over all groups, so it is possible to use RESET command, implemented by Zephyr module and prvide custom BOOTLOADER_INFO command implementation.