### PR TITLE
Bluetooth: Controller: Fix hang due to loop in node_rx list

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_scan_aux.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_scan_aux.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define AUX_OFFSET_IS_VALID(_offset_us, _win_size_us, _pdu_us) \
+		(((_offset_us) + (_win_size_us)) >= ((_pdu_us) + (EVENT_MAFS_US)))
+
 int lll_scan_aux_init(void);
 int lll_scan_aux_reset(void);
 void lll_scan_aux_prepare(void *param);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -136,7 +136,7 @@ uint8_t lll_scan_aux_setup(struct pdu_adv *pdu, uint8_t pdu_phy,
 
 	/* Get reference to extended header */
 	pri_com_hdr = (void *)&pdu->adv_ext_ind;
-	if (!pdu->len || !pri_com_hdr->ext_hdr_len) {
+	if (unlikely(!pdu->len || !pri_com_hdr->ext_hdr_len)) {
 		return 0U;
 	}
 
@@ -385,7 +385,7 @@ bool lll_scan_aux_addr_match_get(const struct lll_scan *lll,
 	const struct pdu_adv_ext_hdr *ext_hdr;
 
 	ext_hdr = &pdu->adv_ext_ind.ext_hdr;
-	if (!ext_hdr->adv_addr) {
+	if (unlikely(!ext_hdr->adv_addr)) {
 		return false;
 	}
 
@@ -786,7 +786,7 @@ static void isr_rx(struct lll_scan *lll, struct lll_scan_aux *lll_aux,
 	lll_isr_rx_status_reset();
 
 	/* No Rx */
-	if (!trx_done || !crc_ok) {
+	if (unlikely(!trx_done || !crc_ok)) {
 		/* TODO: Combine the early exit with above if-then-else block
 		 */
 		err = -EINVAL;
@@ -802,7 +802,7 @@ static void isr_rx(struct lll_scan *lll, struct lll_scan_aux *lll_aux,
 	}
 
 	pdu = (void *)node_rx->pdu;
-	if ((pdu->type != PDU_ADV_TYPE_EXT_IND) || !pdu->len) {
+	if (unlikely((pdu->type != PDU_ADV_TYPE_EXT_IND) || !pdu->len)) {
 		err = -EINVAL;
 
 		goto isr_rx_do_close;
@@ -1509,7 +1509,7 @@ static void isr_rx_connect_rsp(void *param)
 	}
 
 	/* No Rx or invalid PDU received */
-	if (!trx_done) {
+	if (unlikely(!trx_done)) {
 		struct node_rx_ftr *ftr;
 
 		/* Try again with connection initiation */
@@ -1525,6 +1525,7 @@ static void isr_rx_connect_rsp(void *param)
 
 		rx = ftr->extra;
 		rx->hdr.type = NODE_RX_TYPE_RELEASE;
+
 		goto isr_rx_connect_rsp_do_close;
 	}
 
@@ -1600,20 +1601,18 @@ static bool isr_rx_connect_rsp_check(struct lll_scan *lll,
 				     struct pdu_adv *pdu_tx,
 				     struct pdu_adv *pdu_rx, uint8_t rl_idx)
 {
-	if (pdu_rx->type != PDU_ADV_TYPE_AUX_CONNECT_RSP) {
+	if (unlikely(pdu_rx->type != PDU_ADV_TYPE_AUX_CONNECT_RSP)) {
 		return false;
 	}
 
-	if (pdu_rx->len != offsetof(struct pdu_adv_com_ext_adv,
-				    ext_hdr_adv_data) +
-			   offsetof(struct pdu_adv_ext_hdr, data) + ADVA_SIZE +
-			   TARGETA_SIZE) {
+	if (unlikely(pdu_rx->len != (offsetof(struct pdu_adv_com_ext_adv, ext_hdr_adv_data) +
+				     offsetof(struct pdu_adv_ext_hdr, data) + ADVA_SIZE +
+				     TARGETA_SIZE))) {
 		return false;
 	}
 
-	if (pdu_rx->adv_ext_ind.adv_mode ||
-	    !pdu_rx->adv_ext_ind.ext_hdr.adv_addr ||
-	    !pdu_rx->adv_ext_ind.ext_hdr.tgt_addr) {
+	if (unlikely(pdu_rx->adv_ext_ind.adv_mode || !pdu_rx->adv_ext_ind.ext_hdr.adv_addr ||
+		     !pdu_rx->adv_ext_ind.ext_hdr.tgt_addr)) {
 		return false;
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -186,7 +186,7 @@ uint8_t lll_scan_aux_setup(struct pdu_adv *pdu, uint8_t pdu_phy,
 
 	/* Skip reception if invalid aux offset */
 	pdu_us = PDU_AC_US(pdu->len, pdu_phy, pdu_phy_flags_rx);
-	if (unlikely((aux_offset_us + window_size_us) < (pdu_us + EVENT_MAFS_US))) {
+	if (unlikely(!AUX_OFFSET_IS_VALID(aux_offset_us, window_size_us, pdu_us))) {
 		return 0U;
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -124,8 +124,8 @@ uint8_t lll_scan_aux_setup(struct pdu_adv *pdu, uint8_t pdu_phy,
 	struct pdu_cte_info *cte_info;
 	struct node_rx_pdu *node_rx;
 	uint32_t window_widening_us;
-	uint32_t window_size_us;
 	struct node_rx_ftr *ftr;
+	uint16_t window_size_us;
 	uint32_t aux_offset_us;
 	uint32_t overhead_us;
 	uint8_t *pri_dptr;
@@ -186,7 +186,7 @@ uint8_t lll_scan_aux_setup(struct pdu_adv *pdu, uint8_t pdu_phy,
 
 	/* Skip reception if invalid aux offset */
 	pdu_us = PDU_AC_US(pdu->len, pdu_phy, pdu_phy_flags_rx);
-	if (aux_offset_us < pdu_us) {
+	if (unlikely((aux_offset_us + window_size_us) < (pdu_us + EVENT_MAFS_US))) {
 		return 0U;
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -1053,6 +1053,7 @@ void ll_rx_dequeue(void)
 	{
 		struct node_rx_pdu *rx_curr;
 		struct pdu_adv *adv;
+		uint8_t loop = PDU_RX_POOL_SIZE / PDU_RX_NODE_POOL_ELEMENT_SIZE;
 
 		adv = (struct pdu_adv *)rx->pdu;
 		if (adv->type != PDU_ADV_TYPE_EXT_IND) {
@@ -1062,6 +1063,9 @@ void ll_rx_dequeue(void)
 		rx_curr = rx->rx_ftr.extra;
 		while (rx_curr) {
 			memq_link_t *link_free;
+
+			LL_ASSERT(loop);
+			loop--;
 
 			link_free = rx_curr->hdr.link;
 			rx_curr = rx_curr->rx_ftr.extra;

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -116,6 +116,7 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_pdu *rx)
 	struct pdu_adv_adi *adi;
 	struct node_rx_ftr *ftr;
 	uint32_t ready_delay_us;
+	uint16_t window_size_us;
 	uint32_t aux_offset_us;
 	uint32_t ticker_status;
 	struct lll_scan *lll;
@@ -511,6 +512,22 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_pdu *rx)
 		goto ull_scan_aux_rx_flush;
 	}
 
+	/* Determine the window size */
+	if (aux_ptr->offs_units) {
+		window_size_us = OFFS_UNIT_300_US;
+	} else {
+		window_size_us = OFFS_UNIT_30_US;
+	}
+
+	/* Calculate received aux offset we need to have ULL schedule a reception */
+	aux_offset_us = (uint32_t)PDU_ADV_AUX_PTR_OFFSET_GET(aux_ptr) * window_size_us;
+
+	/* Skip reception if invalid aux offset */
+	pdu_us = PDU_AC_US(pdu->len, phy, ftr->phy_flags);
+	if (unlikely((aux_offset_us + window_size_us) < (pdu_us + EVENT_MAFS_US))) {
+		goto ull_scan_aux_rx_flush;
+	}
+
 	if (!aux) {
 		aux = aux_acquire();
 		if (!aux) {
@@ -697,21 +714,6 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_pdu *rx)
 		aux->rx_head = rx;
 	}
 
-	/* Determine the window size */
-	if (aux_ptr->offs_units) {
-		lll_aux->window_size_us = OFFS_UNIT_300_US;
-	} else {
-		lll_aux->window_size_us = OFFS_UNIT_30_US;
-	}
-
-	aux_offset_us = (uint32_t)PDU_ADV_AUX_PTR_OFFSET_GET(aux_ptr) * lll_aux->window_size_us;
-
-	/* Skip reception if invalid aux offset */
-	pdu_us = PDU_AC_US(pdu->len, phy, ftr->phy_flags);
-	if (aux_offset_us < pdu_us) {
-		goto ull_scan_aux_rx_flush;
-	}
-
 	/* CA field contains the clock accuracy of the advertiser;
 	 * 0 - 51 ppm to 500 ppm
 	 * 1 - 0 ppm to 50 ppm
@@ -722,6 +724,7 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_pdu *rx)
 		window_widening_us = SCA_DRIFT_500_PPM_US(aux_offset_us);
 	}
 
+	lll_aux->window_size_us = window_size_us;
 	lll_aux->window_size_us += ((EVENT_TICKER_RES_MARGIN_US + EVENT_JITTER_US +
 				     window_widening_us) << 1);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -524,7 +524,7 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_pdu *rx)
 
 	/* Skip reception if invalid aux offset */
 	pdu_us = PDU_AC_US(pdu->len, phy, ftr->phy_flags);
-	if (unlikely((aux_offset_us + window_size_us) < (pdu_us + EVENT_MAFS_US))) {
+	if (unlikely(!AUX_OFFSET_IS_VALID(aux_offset_us, window_size_us, pdu_us))) {
 		goto ull_scan_aux_rx_flush;
 	}
 


### PR DESCRIPTION
Fix Controller hang due to infinite looping caused by
duplicate node_rx enqueued in auxiliary context.

When LLL scheduling is not applied due to invalid aux offset
then ULL scheduling too would skip setting up the reception
after similarly checking the validity of aux offset required
to schedule the reception of auxiliary PDU. This check in
ULL was after the received node_rx being enqueued into the
auxiliary context causing a loop in the list of node_rx.

Dequeue of a list with a loop of node_rx caused an infinite
loop execution in the Controller.

Regression introduced in commit https://github.com/zephyrproject-rtos/zephyr/commit/3590bd648f8fe39b04d81ee6431037e05f026406 ("Bluetooth:
Controller: Fix missing invalid aux offset check").