### PR TITLE
MAINTAINERS: add josuah as Video collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2088,6 +2088,7 @@ Release Notes:
   status: odd fixes
   collaborators:
     - loicpoulain
+    - josuah
   files:
     - drivers/video/
     - include/zephyr/drivers/video.h
@@ -2095,6 +2096,7 @@ Release Notes:
     - doc/hardware/peripherals/video.rst
     - tests/drivers/*/video/
     - dts/bindings/video/
+    - samples/drivers/video/
   labels:
     - "area: Video"
   tests:


### PR DESCRIPTION
My goals:

- Take guidance from @loicpoulain about decisions, and refer to the original [Video4Zephyr](https://static.linaro.org/connect/san19/presentations/san19-503.pdf) for inspiration.
- Keep learning from [reviews](https://github.com/zephyrproject-rtos/zephyr/pull/77770) and [feedback](https://github.com/zephyrproject-rtos/zephyr/pull/73013) by maintainers to apply it to the Video driver class (reviews / existing drivers).

Hope I understood the [role](https://docs.zephyrproject.org/latest/project/project_roles.html#collaborator) well.

Would that permit the bot to flag me for when someone (including me) tags an issue to `Area: Video`?