### PR TITLE
mgmt: mcumgr: grp: os_mgmt: Add optional bootloader info hook

### DIFF
--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -313,6 +313,9 @@ Libraries / Subsystems
       supported groups.
     * Fixed formatting of milliseconds in :c:enum:`OS_MGMT_ID_DATETIME_STR` by adding
       leading zeros.
+    * Added support for custom os mgmt bootloader info responses using notification hooks, this
+      can be enabled witbh :kconfig:option`CONFIG_MCUMGR_GRP_OS_BOOTLOADER_INFO_HOOK`, the data
+      structure is :c:struct:`os_mgmt_bootloader_info_data`.
 
 * Logging
 

--- a/include/zephyr/mgmt/mcumgr/grp/os_mgmt/os_mgmt_callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/grp/os_mgmt/os_mgmt_callbacks.h
@@ -29,6 +29,24 @@ struct os_mgmt_reset_data {
 };
 
 /**
+ * Structure provided in the #MGMT_EVT_OP_OS_MGMT_BOOTLOADER_INFO notification callback: This
+ * callback function is used to add new fields to the bootloader info response.
+ */
+struct os_mgmt_bootloader_info_data {
+	/**
+	 * The zcbor encoder which is currently being used to output group information, additional
+	 * fields to the group can be added using this.
+	 */
+	zcbor_state_t *zse;
+
+	/** Contains the number of decoded parameters. */
+	const size_t *decoded;
+
+	/** Contains the value of the query parameter. */
+	struct zcbor_string *query;
+};
+
+/**
  * @}
  */
 

--- a/include/zephyr/mgmt/mcumgr/mgmt/callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/mgmt/callbacks.h
@@ -206,10 +206,16 @@ enum os_mgmt_group_events {
 	MGMT_EVT_OP_OS_MGMT_INFO_APPEND		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_OS, 2),
 
 	/** Callback when a datetime get command has been received. */
-	MGMT_EVT_OP_OS_MGMT_DATETIME_GET        = MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_OS, 3),
+	MGMT_EVT_OP_OS_MGMT_DATETIME_GET	= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_OS, 3),
 
 	/** Callback when a datetime set command has been received, data is struct rtc_time(). */
-	MGMT_EVT_OP_OS_MGMT_DATETIME_SET        = MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_OS, 4),
+	MGMT_EVT_OP_OS_MGMT_DATETIME_SET	= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_OS, 4),
+
+	/**
+	 * Callback when a bootloader info command has been received, data is
+	 * os_mgmt_bootloader_info_data.
+	 */
+	MGMT_EVT_OP_OS_MGMT_BOOTLOADER_INFO	= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_OS, 5),
 
 	/** Used to enable all os_mgmt_group events. */
 	MGMT_EVT_OP_OS_MGMT_ALL			= MGMT_DEF_EVT_OP_ALL(MGMT_EVT_GRP_OS),

--- a/subsys/mgmt/mcumgr/grp/os_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/Kconfig
@@ -202,6 +202,13 @@ config MCUMGR_GRP_OS_BOOTLOADER_INFO
 	  Allows to query MCUmgr about bootloader used by device and various bootloader
 	  parameters.
 
+config MCUMGR_GRP_OS_BOOTLOADER_INFO_HOOK
+	bool "Bootloader info hooks"
+	depends on MCUMGR_MGMT_NOTIFICATION_HOOKS
+	help
+	  Supports adding custom responses to the bootloader info command by using registered
+	  callbacks. Data can be appended to the struct provided in the callback.
+
 endif # BOOTLOADER_MCUBOOT
 
 module = MCUMGR_GRP_OS


### PR DESCRIPTION
    Adds an optional hook that allows for appending additional
    responses to the bootloader info command
