### PR TITLE
Backport 3.6: zephyr: Add zero-len check for utf8_trunc

### DIFF
--- a/lib/utils/utf8.c
+++ b/lib/utils/utf8.c
@@ -16,7 +16,14 @@
 
 char *utf8_trunc(char *utf8_str)
 {
-	char *last_byte_p = utf8_str + strlen(utf8_str) - 1;
+	const size_t len = strlen(utf8_str);
+
+	if (len == 0U) {
+		/* no-op */
+		return utf8_str;
+	}
+
+	char *last_byte_p = utf8_str + len - 1U;
 	uint8_t bytes_truncated;
 	char seq_start_byte;
 


### PR DESCRIPTION
Backports https://github.com/zephyrproject-rtos/zephyr/pull/74949

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/77956
Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/77957