### PR TITLE
usb: device: avoid starving other threads in CDC ACM UART fifo_fill

### DIFF
--- a/subsys/usb/device/class/cdc_acm.c
+++ b/subsys/usb/device/class/cdc_acm.c
@@ -666,7 +666,7 @@ static int cdc_acm_irq_rx_ready(const struct device *dev)
 {
 	struct cdc_acm_dev_data_t * const dev_data = dev->data;
 
-	if (dev_data->rx_ready) {
+	if (dev_data->rx_ready && dev_data->rx_irq_ena) {
 		return 1;
 	}
 
@@ -682,15 +682,11 @@ static int cdc_acm_irq_rx_ready(const struct device *dev)
  */
 static int cdc_acm_irq_is_pending(const struct device *dev)
 {
-	struct cdc_acm_dev_data_t * const dev_data = dev->data;
-
-	if (dev_data->tx_ready && dev_data->tx_irq_ena) {
+	if (cdc_acm_irq_rx_ready(dev) || cdc_acm_irq_tx_ready(dev)) {
 		return 1;
-	} else if (dev_data->rx_ready && dev_data->rx_irq_ena) {
-		return 1;
-	} else {
-		return 0;
 	}
+
+	return 0;
 }
 
 /**


### PR DESCRIPTION
The check for the device being configured or suspended in the fifo_fill
implementation can starve other threads, because the early return does
not change the state of the TX path, and fifo_fill is called again
from the callback loop. The ringbuffer that emulates the TX FIFO can be
filled and marked ready as long as the space is available.

Move the TX/RX ready flag updates into irq_update() where they belong.