### PR TITLE
scripts: compliance: add sphinx-lint linter

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -38,7 +38,7 @@ jobs:
       run: |
         pip3 install setuptools
         pip3 install wheel
-        pip3 install python-magic lxml junitparser gitlint pylint pykwalify yamllint clang-format unidiff
+        pip3 install python-magic lxml junitparser gitlint pylint pykwalify yamllint clang-format unidiff sphinx-lint
         pip3 install west
 
     - name: west setup

--- a/.gitignore
+++ b/.gitignore
@@ -91,4 +91,5 @@ MaintainersFormat.txt
 ModulesMaintainers.txt
 Nits.txt
 Pylint.txt
+SphinxLint.txt
 YAMLLint.txt

--- a/scripts/requirements-compliance.txt
+++ b/scripts/requirements-compliance.txt
@@ -9,3 +9,4 @@ junitparser>=2
 pylint>=3
 unidiff
 yamllint
+sphinx-lint


### PR DESCRIPTION
ReStructuredText can sometimes be tricky to get right, especially for folks that might be more familiar with Markdown.

This adds a Sphinx/RST linter to the compliance check script to help catch common issues that can easily go unnoticed and cause rendering issues. The issues are reported as **errors** based on my experience fixing linting issues across the tree where I could not find a single instance of the tool reporting a false positive.

Example of issues it catches: https://github.com/kartben/zephyr/pull/30/files

Depends on #78266 as this fixes remaining lint issues in the tree.