### PR TITLE
STM32U0: provide support for ADC peripherals

### DIFF
--- a/boards/st/nucleo_u031r8/doc/index.rst
+++ b/boards/st/nucleo_u031r8/doc/index.rst
@@ -140,12 +140,15 @@ The Zephyr _nucleo_u031r8_ board configuration supports the following hardware f
 +-----------+------------+-------------------------------------+
 | NVIC      | on-chip    | nested vector interrupt controller  |
 +-----------+------------+-------------------------------------+
+| ADC       | on-chip    | adc                                 |
++-----------+------------+-------------------------------------+
 | DAC       | on-chip    | DAC Controller                      |
 +-----------+------------+-------------------------------------+
 | I2C       | on-chip    | i2c                                 |
 +-----------+------------+-------------------------------------+
 | PWM       | on-chip    | pwm                                 |
 +-----------+------------+-------------------------------------+
+
 
 Other hardware features are not yet supported on this Zephyr port.
 

--- a/boards/st/nucleo_u031r8/nucleo_u031r8.dts
+++ b/boards/st/nucleo_u031r8/nucleo_u031r8.dts
@@ -102,6 +102,15 @@
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
+&adc1 {
+	pinctrl-0 = <&adc1_in0_pc0 &adc1_in1_pc1>;
+	pinctrl-names = "default";
+	st,adc-clock-source = <SYNC>;
+	st,adc-prescaler = <4>;
+	status = "okay";
+	vref-mv = <3300>;
+};
+
 &timers1 {
 	st,prescaler = <10000>;
 	status = "okay";

--- a/boards/st/nucleo_u031r8/nucleo_u031r8.yaml
+++ b/boards/st/nucleo_u031r8/nucleo_u031r8.yaml
@@ -6,6 +6,7 @@ toolchain:
   - zephyr
 supported:
   - arduino_gpio
+  - adc
   - dac
   - gpio
   - i2c

--- a/boards/st/nucleo_u083rc/doc/index.rst
+++ b/boards/st/nucleo_u083rc/doc/index.rst
@@ -146,6 +146,8 @@ The Zephyr nucleo_u083rc board configuration supports the following hardware fea
 | UART      | on-chip    | serial port-polling;                |
 |           |            | serial port-interrupt               |
 +-----------+------------+-------------------------------------+
+| ADC       | on-chip    | adc                                 |
++-----------+------------+-------------------------------------+
 | DAC       | on-chip    | DAC Controller                      |
 +-----------+------------+-------------------------------------+
 | I2C       | on-chip    | i2c                                 |

--- a/boards/st/nucleo_u083rc/nucleo_u083rc.dts
+++ b/boards/st/nucleo_u083rc/nucleo_u083rc.dts
@@ -102,6 +102,17 @@
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
+&adc1 {
+	pinctrl-0 = <&adc1_in0_pc0 &adc1_in1_pc1>;
+	pinctrl-names = "default";
+	st,adc-clock-source = <ASYNC>;
+	clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00100000>,
+		 <&rcc STM32_SRC_HSI ADC_SEL(2)>;
+	st,adc-prescaler = <4>;
+	status = "okay";
+	vref-mv = <3300>;
+};
+
 &timers1 {
 	st,prescaler = <10000>;
 	status = "okay";

--- a/boards/st/nucleo_u083rc/nucleo_u083rc.yaml
+++ b/boards/st/nucleo_u083rc/nucleo_u083rc.yaml
@@ -7,6 +7,7 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - adc
   - arduino_gpio
   - dac
   - gpio

--- a/boards/st/stm32u083c_dk/doc/index.rst
+++ b/boards/st/stm32u083c_dk/doc/index.rst
@@ -159,6 +159,8 @@ The Zephyr stm32u083c_dk board configuration supports the following hardware fea
 | UART      | on-chip    | serial port-polling;                |
 |           |            | serial port-interrupt               |
 +-----------+------------+-------------------------------------+
+| ADC       | on-chip    | adc                                 |
++-----------+------------+-------------------------------------+
 | DAC       | on-chip    | DAC Controller                      |
 +-----------+------------+-------------------------------------+
 | I2C       | on-chip    | i2c                                 |

--- a/boards/st/stm32u083c_dk/stm32u083c_dk.dts
+++ b/boards/st/stm32u083c_dk/stm32u083c_dk.dts
@@ -72,6 +72,17 @@
 	apb1-prescaler = <1>;
 };
 
+&adc1 {
+	pinctrl-0 = <&adc1_in0_pc0 &adc1_in1_pc1>;
+	pinctrl-names = "default";
+	st,adc-clock-source = <ASYNC>;
+	clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00100000>,
+		 <&rcc STM32_SRC_HSI ADC_SEL(2)>;
+	st,adc-prescaler = <4>;
+	status = "okay";
+	vref-mv = <3300>;
+};
+
 &dac1 {
 	status = "okay";
 	pinctrl-0 = <&dac1_out1_pa4>;

--- a/boards/st/stm32u083c_dk/stm32u083c_dk.yaml
+++ b/boards/st/stm32u083c_dk/stm32u083c_dk.yaml
@@ -7,6 +7,7 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - adc
   - arduino_gpio
   - dac
   - gpio

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -454,6 +454,7 @@ static void adc_stm32_disable(ADC_TypeDef *adc)
 	!DT_HAS_COMPAT_STATUS_OKAY(st_stm32f4_adc) && \
 	!defined(CONFIG_SOC_SERIES_STM32G0X) && \
 	!defined(CONFIG_SOC_SERIES_STM32L0X) && \
+	!defined(CONFIG_SOC_SERIES_STM32U0X) && \
 	!defined(CONFIG_SOC_SERIES_STM32WBAX) && \
 	!defined(CONFIG_SOC_SERIES_STM32WLX)
 	if (LL_ADC_INJ_IsConversionOngoing(adc)) {
@@ -532,8 +533,10 @@ static void adc_stm32_calibration_start(const struct device *dev)
 	DT_HAS_COMPAT_STATUS_OKAY(st_stm32f1_adc) || \
 	defined(CONFIG_SOC_SERIES_STM32G0X) || \
 	defined(CONFIG_SOC_SERIES_STM32L0X) || \
+	defined(CONFIG_SOC_SERIES_STM32U0X) || \
 	defined(CONFIG_SOC_SERIES_STM32WLX) || \
 	defined(CONFIG_SOC_SERIES_STM32WBAX)
+
 	LL_ADC_StartCalibration(adc);
 #elif defined(CONFIG_SOC_SERIES_STM32U5X)
 	if (adc != ADC4) {
@@ -580,6 +583,7 @@ static int adc_stm32_calibrate(const struct device *dev)
 	defined(CONFIG_SOC_SERIES_STM32G0X) || \
 	defined(CONFIG_SOC_SERIES_STM32H7RSX) || \
 	defined(CONFIG_SOC_SERIES_STM32L0X) || \
+	defined(CONFIG_SOC_SERIES_STM32U0X) || \
 	defined(CONFIG_SOC_SERIES_STM32WBAX) || \
 	defined(CONFIG_SOC_SERIES_STM32WLX)
 	/* Make sure DMA is disabled before starting calibration */
@@ -1384,6 +1388,7 @@ static int adc_stm32_set_clock(const struct device *dev)
 #elif defined(CONFIG_SOC_SERIES_STM32C0X) || \
 	defined(CONFIG_SOC_SERIES_STM32G0X) || \
 	defined(CONFIG_SOC_SERIES_STM32L0X) || \
+	defined(CONFIG_SOC_SERIES_STM32U0X) || \
 	(defined(CONFIG_SOC_SERIES_STM32WBX) && defined(ADC_SUPPORT_2_5_MSPS)) || \
 	defined(CONFIG_SOC_SERIES_STM32WLX)
 	if ((config->clk_prescaler == LL_ADC_CLOCK_SYNC_PCLK_DIV1) ||

--- a/dts/arm/st/u0/stm32u0.dtsi
+++ b/dts/arm/st/u0/stm32u0.dtsi
@@ -8,6 +8,8 @@
 #include <arm/armv6-m.dtsi>
 #include <zephyr/dt-bindings/clock/stm32u0_clock.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/adc/stm32l4_adc.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
@@ -209,6 +211,22 @@
 			resets = <&rctl STM32_RESET(APB1L, 18U)>;
 			interrupts = <29 0>;
 			status = "disabled";
+		};
+
+		adc1: adc@40012400 {
+			compatible = "st,stm32-adc";
+			reg = <0x40012400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00100000>;
+			interrupts = <12 0>;
+			status = "disabled";
+			#io-channel-cells = <1>;
+			resolutions = <STM32_ADC_RES(12, 0x00)
+				       STM32_ADC_RES(10, 0x01)
+				       STM32_ADC_RES(8, 0x02)
+				       STM32_ADC_RES(6, 0x03)>;
+			sampling-times = <2 4 8 13 20 40 80 161>;
+			num-sampling-time-common-channels = <2>;
+			st,adc-sequencer = <NOT_FULLY_CONFIGURABLE>;
 		};
 
 		dac1: dac@40007400 {

--- a/tests/drivers/adc/adc_api/boards/nucleo_u083rc.overlay
+++ b/tests/drivers/adc/adc_api/boards/nucleo_u083rc.overlay
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2024 STMicroelectronics
+ */
+
+/ {
+	zephyr,user {
+		/* adjust channel number according to pinmux in board.dts */
+		io-channels = <&adc1 0>, <&adc1 1>;
+	};
+};
+
+&adc1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};

--- a/tests/drivers/adc/adc_api/boards/stm32u083c_dk.overlay
+++ b/tests/drivers/adc/adc_api/boards/stm32u083c_dk.overlay
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2024 STMicroelectronics
+ */
+
+/ {
+	zephyr,user {
+		/* adjust channel number according to pinmux in board.dts */
+		io-channels = <&adc1 0>, <&adc1 1>;
+	};
+};
+
+&adc1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
+};

--- a/tests/drivers/adc/adc_api/testcase.yaml
+++ b/tests/drivers/adc/adc_api/testcase.yaml
@@ -7,6 +7,8 @@ tests:
   drivers.adc:
     depends_on: adc
     min_flash: 40
+    platform_exclude:
+      - nucleo_u031r8
   drivers.adc.b_u585i_iot02a_adc4:
     extra_args:
       - DTC_OVERLAY_FILE="boards/b_u585i_iot02a_adc4.overlay"
@@ -33,12 +35,14 @@ tests:
       - nucleo_l073rz
       - nucleo_l152re
       - nucleo_l476rg
+      - nucleo_u083rc
       - nucleo_u575zi_q
       - nucleo_wb55rg
       - nucleo_wba52cg
       - nucleo_wl55jc
       - stm32f3_disco
       - stm32h573i_dk
+      - stm32u083c_dk
   drivers.adc.dma_nxp_kinetis:
     extra_args:
       - OVERLAY_CONFIG="overlay-dma-kinetis.conf"


### PR DESCRIPTION
This PR adds ADC peripherals on the stm32U0 boards.