### PR TITLE
runners: jlink: add support for J-Link tunnels

### DIFF
--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -36,6 +36,9 @@ def is_ip(ip):
         return False
     return True
 
+def is_tunnel(tunnel):
+    return tunnel.startswith("tunnel:")
+
 class ToggleAction(argparse.Action):
 
     def __call__(self, parser, args, ignored, option):
@@ -247,7 +250,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
 
         server_cmd = ([self.gdbserver] +
                       ['-select',
-                                           ('ip' if is_ip(self.dev_id) else 'usb') +
+                                           ('ip' if (is_ip(self.dev_id) or is_tunnel(self.dev_id)) else 'usb') +
                                            (f'={self.dev_id}' if self.dev_id else ''),
                        '-port', str(self.gdb_port),
                        '-if', self.iface,
@@ -404,7 +407,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                 loader_details = "?" + self.loader
 
             cmd = ([self.commander] +
-                   (['-IP', f'{self.dev_id}'] if is_ip(self.dev_id) else (['-USB', f'{self.dev_id}'] if self.dev_id else [])) +
+                   (['-IP', f'{self.dev_id}'] if (is_ip(self.dev_id) or is_tunnel(self.dev_id)) else (['-USB', f'{self.dev_id}'] if self.dev_id else [])) +
                    (['-nogui', '1'] if self.supports_nogui else []) +
                    ['-if', self.iface,
                     '-speed', self.speed,


### PR DESCRIPTION
This adds support for J-Link tunnels, which run on top of an IP network and therefore uses the -IP option. J-Link tunnels are identified by a tunnel: prefix instead of a bare IP address. This change checks for the presence of such a prefix, and choses the -IP transport option if the tunnel prefix is found.

This has been tested with J-Link Remote Server v7.98g and the SEGGER tunnel option.