### PR TITLE
fs: littlefs: get block_cycles value from dts

### DIFF
--- a/dts/bindings/fs/zephyr,fstab,littlefs.yaml
+++ b/dts/bindings/fs/zephyr,fstab,littlefs.yaml
@@ -75,4 +75,4 @@ properties:
       is moved to another block.  Set to a non-positive value to disable
       leveling.
 
-      This corresponds to CONFIG_FS_LITTLEFS_LOOKAHEAD_SIZE.
+      This corresponds to CONFIG_FS_LITTLEFS_BLOCK_CYCLES.

--- a/subsys/fs/littlefs_fs.c
+++ b/subsys/fs/littlefs_fs.c
@@ -1061,6 +1061,7 @@ static struct fs_littlefs fs_data_##inst = { \
 		.prog_size = DT_INST_PROP(inst, prog_size), \
 		.cache_size = DT_INST_PROP(inst, cache_size), \
 		.lookahead_size = DT_INST_PROP(inst, lookahead_size), \
+		.block_cycles = DT_INST_PROP(inst, block_cycles), \
 		.read_buffer = read_buffer_##inst, \
 		.prog_buffer = prog_buffer_##inst, \
 		.lookahead_buffer = lookahead_buffer_##inst, \


### PR DESCRIPTION
Property "block-cycles" is required for node "zephyr,fstab,littlefs", but source code did not get the value from dts file, now add it.

Additionally correct the wrong description of property "block-cycles" in binding file.