### PR TITLE
samples: tfm_integration: use zephyr:code-sample directive

### DIFF
--- a/samples/tfm_integration/psa_crypto/README.rst
+++ b/samples/tfm_integration/psa_crypto/README.rst
@@ -1,7 +1,7 @@
-.. _tfm_psa_crypto:
+.. zephyr:code-sample:: tfm_psa_crypto
+   :name: TF-M PSA crypto
 
-TF-M PSA crypto
-################
+   Use the PSA Crypto API for cryptography and device certificate signing requests.
 
 Overview
 ********

--- a/samples/tfm_integration/psa_protected_storage/README.rst
+++ b/samples/tfm_integration/psa_protected_storage/README.rst
@@ -1,7 +1,7 @@
-.. psa_protected_storage:
+.. zephyr:code-sample:: psa_protected_storage
+   :name: TF-M PSA Protected Storage
 
-PSA Protected Storage
-#####################
+   Use the Protected Storage (PS) API to store encrypted data.
 
 Overview
 ********
@@ -41,7 +41,7 @@ run as the overwrite protection will not be removed with a power reset.
 On QEMU
 ========
 
-Refer to :ref:`tfm_ipc` for detailed instructions.
+Refer to :zephyr:code-sample:`tfm_ipc` for detailed instructions.
 Following is an example based on ``west build``
 
    .. code-block:: bash

--- a/samples/tfm_integration/tfm_ipc/README.rst
+++ b/samples/tfm_integration/tfm_ipc/README.rst
@@ -1,7 +1,7 @@
-.. _tfm_ipc:
+.. zephyr:code-sample:: tfm_ipc
+   :name: TF-M IPC
 
-TF-M IPC
-########
+   Implement communication between the secure and non-secure images using IPC.
 
 Overview
 ********

--- a/samples/tfm_integration/tfm_psa_test/README.rst
+++ b/samples/tfm_integration/tfm_psa_test/README.rst
@@ -40,12 +40,12 @@ Note that not all test suites are valid on all boards.
 On Target
 =========
 
-Refer to :ref:`tfm_ipc` for detailed instructions.
+Refer to :zephyr:code-sample:`tfm_ipc` for detailed instructions.
 
 On QEMU:
 ========
 
-Refer to :ref:`tfm_ipc` for detailed instructions.
+Refer to :zephyr:code-sample:`tfm_ipc` for detailed instructions.
 Following is an example based on ``west build``
 
    .. code-block:: bash

--- a/samples/tfm_integration/tfm_regression_test/README.rst
+++ b/samples/tfm_integration/tfm_regression_test/README.rst
@@ -24,12 +24,12 @@ Tests for both the secure and non-secure domain are enabled by default, controll
 On Target
 =========
 
-Refer to :ref:`tfm_ipc` for detailed instructions.
+Refer to :zephyr:code-sample:`tfm_ipc` for detailed instructions.
 
 On QEMU:
 ========
 
-Refer to :ref:`tfm_ipc` for detailed instructions.
+Refer to :zephyr:code-sample:`tfm_ipc` for detailed instructions.
 Following is an example based on ``west build``
 
    .. code-block:: bash

--- a/samples/tfm_integration/tfm_secure_partition/README.rst
+++ b/samples/tfm_integration/tfm_secure_partition/README.rst
@@ -1,7 +1,7 @@
-.. _tfm_secure_partition:
+.. zephyr:code-sample:: tfm_secure_partition
+   :name: TF-M Secure Partition
 
-TF-M Secure Partition Sample
-############################
+   Create a secure partition that exposes secure services.
 
 Overview
 ********
@@ -38,12 +38,12 @@ This sample can be built with or without CONFIG_TFM_IPC, since it contains code 
 On Target
 =========
 
-Refer to :ref:`tfm_ipc` for detailed instructions.
+Refer to :zephyr:code-sample:`tfm_ipc` for detailed instructions.
 
 On QEMU
 =======
 
-Refer to :ref:`tfm_ipc` for detailed instructions.
+Refer to :zephyr:code-sample:`tfm_ipc` for detailed instructions.
 
 Sample Output
 =============


### PR DESCRIPTION
Adds missing code-sample directive to all the tfm_integration samples in preparation for upcoming changes to the Zephyr documentation that will be leveraging the provided description and metadata.

Note that I intentionally left out `tfm_regression_test` as it really looks like something that should be moved to `tests/`...