### PR TITLE
samples: arch: use zephyr:code-sample directive

### DIFF
--- a/samples/arch/index.rst
+++ b/samples/arch/index.rst
@@ -4,7 +4,7 @@ Architecture Dependent Samples
 ##############################
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
    :glob:
 
-   **/*
+   */*

--- a/samples/arch/mpu/mpu_test/README.rst
+++ b/samples/arch/mpu/mpu_test/README.rst
@@ -1,7 +1,7 @@
-.. _mpu_test:
+.. zephyr:code-sample:: mpu
+   :name: Memory Protection Unit (MPU)
 
-Memory Protection Unit (MPU) Sample
-###################################
+   Use memory protection to prevent common security issues.
 
 Overview
 ********

--- a/samples/arch/smp/pi/README.rst
+++ b/samples/arch/smp/pi/README.rst
@@ -1,7 +1,7 @@
-.. _smp_pi:
+.. zephyr:code-sample:: smp_pi
+   :name: SMP Pi
 
-SMP Pi
-###########
+   Calculate the first 240 digits of Pi on multiple execution units.
 
 Overview
 ********

--- a/samples/arch/smp/pktqueue/README.rst
+++ b/samples/arch/smp/pktqueue/README.rst
@@ -1,7 +1,7 @@
-.. _smp_pktqueue:
+.. zephyr:code-sample:: smp_pktqueue
+   :name: SMP pktqueue
 
-SMP pktqueue
-############
+   Use SMP to process multiple packet headers in parallel.
 
 Overview
 ********


### PR DESCRIPTION
Adds missing code-sample directive to all the arch samples in
preparation for upcoming changes to the Zephyr documentation that will
be leveraging the provided description and metadata.