### PR TITLE
drivers: sdhc: esp32: remove unused code

### DIFF
--- a/drivers/sdhc/sdhc_esp32.c
+++ b/drivers/sdhc/sdhc_esp32.c
@@ -1081,10 +1081,9 @@ static int sdhc_esp32_request(const struct device *dev, struct sdhc_command *cmd
 			      struct sdhc_data *data)
 {
 	const struct sdhc_esp32_config *cfg = dev->config;
-	const sdmmc_dev_t *sdio_hw = cfg->sdio_hw;
 	int retries = (int)(cmd->retries + 1); /* first try plus retries */
-	uint32_t timeout_cfg;
-	int ret_esp;
+	uint32_t timeout_cfg = 0;
+	int ret_esp = 0;
 	int ret = 0;
 
 	/* convert command structures Zephyr vs ESP */

--- a/west.yml
+++ b/west.yml
@@ -157,7 +157,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: a79e607333bbd115a16e801ba49840a80c852253
+      revision: aa6a967d1ab4077691aa046229a782102960218a
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
Removed unused entry in SDHC driver and initialize variables accordingly. It updates hal_espressif to also remove one unused definition presented in there which is not caught by CI.