### PR TITLE
mgmt: mcumgr: grp: os_mgmt: Allow bootloader info without MCUboot

### DIFF
--- a/subsys/mgmt/mcumgr/grp/os_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/Kconfig
@@ -194,8 +194,6 @@ config MCUMGR_GRP_OS_INFO_BUILD_DATE_TIME
 
 endif
 
-if BOOTLOADER_MCUBOOT
-
 config MCUMGR_GRP_OS_BOOTLOADER_INFO
 	bool "Bootloader information"
 	help
@@ -208,8 +206,6 @@ config MCUMGR_GRP_OS_BOOTLOADER_INFO_HOOK
 	help
 	  Supports adding custom responses to the bootloader info command by using registered
 	  callbacks. Data can be appended to the struct provided in the callback.
-
-endif # BOOTLOADER_MCUBOOT
 
 module = MCUMGR_GRP_OS
 module-str = mcumgr_grp_os

--- a/subsys/mgmt/mcumgr/grp/os_mgmt/src/os_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/src/os_mgmt.c
@@ -505,7 +505,7 @@ os_mgmt_bootloader_info(struct smp_streamer *ctxt)
 	} else
 #endif
 	{
-		return OS_MGMT_ERR_QUERY_YIELDS_NO_ANSWER;
+		ok = smp_add_cmd_err(zse, MGMT_GROUP_ID_OS, OS_MGMT_ERR_QUERY_YIELDS_NO_ANSWER);
 	}
 
 	return ok ? MGMT_ERR_EOK : MGMT_ERR_EMSGSIZE;

--- a/subsys/mgmt/mcumgr/grp/os_mgmt/src/os_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/src/os_mgmt.c
@@ -423,6 +423,7 @@ os_mgmt_mcumgr_params(struct smp_streamer *ctxt)
 
 #if defined(CONFIG_MCUMGR_GRP_OS_BOOTLOADER_INFO)
 
+#if defined(CONFIG_BOOTLOADER_MCUBOOT)
 #if defined(CONFIG_MCUBOOT_BOOTLOADER_MODE_SINGLE_APP)
 #define BOOTLOADER_MODE MCUBOOT_MODE_SINGLE_SLOT
 #elif defined(CONFIG_MCUBOOT_BOOTLOADER_MODE_SWAP_SCRATCH)
@@ -439,6 +440,7 @@ os_mgmt_mcumgr_params(struct smp_streamer *ctxt)
 #define BOOTLOADER_MODE MCUBOOT_MODE_FIRMWARE_LOADER
 #else
 #define BOOTLOADER_MODE -1
+#endif
 #endif
 
 static int
@@ -485,6 +487,7 @@ os_mgmt_bootloader_info(struct smp_streamer *ctxt)
 #endif
 
 	/* If no parameter is recognized then just introduce the bootloader. */
+#if defined(CONFIG_BOOTLOADER_MCUBOOT)
 	if (decoded == 0) {
 		ok = zcbor_tstr_put_lit(zse, "bootloader") &&
 		     zcbor_tstr_put_lit(zse, "MCUboot");
@@ -499,7 +502,9 @@ os_mgmt_bootloader_info(struct smp_streamer *ctxt)
 		ok = ok && zcbor_tstr_put_lit(zse, "no-downgrade") &&
 		     zcbor_bool_encode(zse, &(bool){true});
 #endif
-	} else {
+	} else
+#endif
+	{
 		return OS_MGMT_ERR_QUERY_YIELDS_NO_ANSWER;
 	}
 


### PR DESCRIPTION
Allows enabling the bootloader info functionality without MCUboot being enabled, so that other bootloaders can add hooks with their own responses