### PR TITLE
drivers: counter: shell: support timer device name autocompletion

### DIFF
--- a/drivers/counter/counter_timer_shell.c
+++ b/drivers/counter/counter_timer_shell.c
@@ -22,14 +22,14 @@
 
 static struct k_sem timer_sem;
 
-void timer_top_handler(const struct device *counter_dev, void *user_data)
+static void timer_top_handler(const struct device *counter_dev, void *user_data)
 {
 	ARG_UNUSED(counter_dev);
 
 	k_sem_give(&timer_sem);
 }
 
-void timer_alarm_handler(const struct device *counter_dev, uint8_t chan_id,
+static void timer_alarm_handler(const struct device *counter_dev, uint8_t chan_id,
 				uint32_t ticks, void *user_data)
 {
 	ARG_UNUSED(counter_dev);

--- a/drivers/counter/counter_timer_shell.c
+++ b/drivers/counter/counter_timer_shell.c
@@ -37,16 +37,27 @@ static void timer_alarm_handler(const struct device *counter_dev, uint8_t chan_i
 	k_sem_give(&timer_sem);
 }
 
-static int cmd_timer_free_running(const struct shell *shctx, size_t argc, char **argv)
+static inline int parse_device(const struct shell *shctx, size_t argc, char *argv[],
+			       const struct device **timer_dev)
 {
 	ARG_UNUSED(argc);
-	int err = 0;
-	const struct device *timer_dev;
 
-	timer_dev = device_get_binding(argv[ARGV_DEV]);
-	if (!timer_dev) {
+	*timer_dev = device_get_binding(argv[ARGV_DEV]);
+	if (*timer_dev == NULL) {
 		shell_error(shctx, "Timer: Device %s not found", argv[ARGV_DEV]);
 		return -ENODEV;
+	}
+
+	return 0;
+}
+
+static int cmd_timer_free_running(const struct shell *shctx, size_t argc, char **argv)
+{
+	const struct device *timer_dev;
+	int err = parse_device(shctx, argc, argv, &timer_dev);
+
+	if (err != 0) {
+		return err;
 	}
 
 	/* start timer in free running mode */
@@ -63,14 +74,12 @@ static int cmd_timer_free_running(const struct shell *shctx, size_t argc, char *
 
 static int cmd_timer_stop(const struct shell *shctx, size_t argc, char **argv)
 {
-	ARG_UNUSED(argc);
 	uint32_t ticks1 = 0, ticks2 = 0;
 	const struct device *timer_dev;
+	int err = parse_device(shctx, argc, argv, &timer_dev);
 
-	timer_dev = device_get_binding(argv[ARGV_DEV]);
-	if (!timer_dev) {
-		shell_error(shctx, "Timer: Device %s not found", argv[ARGV_DEV]);
-		return -ENODEV;
+	if (err != 0) {
+		return err;
 	}
 
 	counter_stop(timer_dev);
@@ -90,19 +99,16 @@ static int cmd_timer_stop(const struct shell *shctx, size_t argc, char **argv)
 
 static int cmd_timer_oneshot(const struct shell *shctx, size_t argc, char **argv)
 {
-	ARG_UNUSED(argc);
-	int err = 0;
 	unsigned long delay = 0;
 	unsigned long channel = 0;
 	const struct device *timer_dev;
+	int err = parse_device(shctx, argc, argv, &timer_dev);
 	struct counter_alarm_cfg alarm_cfg;
 
 	k_sem_init(&timer_sem, 0, 1);
 
-	timer_dev = device_get_binding(argv[ARGV_DEV]);
-	if (!timer_dev) {
-		shell_error(shctx, "Timer: Device %s not found", argv[ARGV_DEV]);
-		return -ENODEV;
+	if (err != 0) {
+		return err;
 	}
 
 	delay = shell_strtoul(argv[ARGV_ONESHOT_TIME], 10, &err);
@@ -146,17 +152,15 @@ static int cmd_timer_periodic(const struct shell *shctx, size_t argc, char **arg
 {
 	ARG_UNUSED(argc);
 	uint32_t count = 0;
-	int err = 0;
 	unsigned long delay = 0;
 	const struct device *timer_dev;
+	int err = parse_device(shctx, argc, argv, &timer_dev);
 	struct counter_top_cfg top_cfg;
 
 	k_sem_init(&timer_sem, 0, 1);
 
-	timer_dev = device_get_binding(argv[ARGV_DEV]);
-	if (!timer_dev) {
-		shell_error(shctx, "Timer: Device %s not found", argv[ARGV_DEV]);
-		return -ENODEV;
+	if (err != 0) {
+		return err;
 	}
 
 	delay = shell_strtoul(argv[ARGV_PERIODIC_TIME], 10, &err);
@@ -193,17 +197,30 @@ static int cmd_timer_periodic(const struct shell *shctx, size_t argc, char **arg
 	return 0;
 }
 
+/* Device name autocompletion support */
+static void device_name_get(size_t idx, struct shell_static_entry *entry)
+{
+	const struct device *dev = shell_device_lookup(idx, "timer");
+
+	entry->syntax = (dev != NULL) ? dev->name : NULL;
+	entry->handler = NULL;
+	entry->help = NULL;
+	entry->subcmd = NULL;
+}
+
+SHELL_DYNAMIC_CMD_CREATE(dsub_device_name, device_name_get);
+
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_timer,
-			SHELL_CMD_ARG(periodic, NULL,
+			SHELL_CMD_ARG(periodic, &dsub_device_name,
 			"timer periodic <timer_instance_node_id> <time_in_us>",
 			cmd_timer_periodic, 3, 0),
-			SHELL_CMD_ARG(oneshot, NULL,
+			SHELL_CMD_ARG(oneshot, &dsub_device_name,
 			"timer oneshot <timer_instance_node_id> <channel_id> <time_in_us>",
 			cmd_timer_oneshot, 4, 0),
-			SHELL_CMD_ARG(freerun, NULL,
+			SHELL_CMD_ARG(freerun, &dsub_device_name,
 			"timer freerun <timer_instance_node_id>",
 			cmd_timer_free_running, 2, 0),
-			SHELL_CMD_ARG(stop, NULL,
+			SHELL_CMD_ARG(stop, &dsub_device_name,
 			"timer stop <timer_instance_node_id>",
 			cmd_timer_stop, 2, 0),
 			SHELL_SUBCMD_SET_END /* array terminated. */


### PR DESCRIPTION
Add support for timer device name autocompletion.