### PR TITLE
Add support dspi for s32z270dc2 board

### DIFF
--- a/boards/nxp/s32z2xxdc2/doc/index.rst
+++ b/boards/nxp/s32z2xxdc2/doc/index.rst
@@ -61,6 +61,8 @@ The boards support the following hardware features:
 +-----------+------------+-------------------------------------+
 | EDMA      | on-chip    | dma                                 |
 +-----------+------------+-------------------------------------+
+| DSPI      | on-chip    | spi                                 |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not currently supported by the port.
 

--- a/dts/arm/nxp/nxp_s32z27x_r52.dtsi
+++ b/dts/arm/nxp/nxp_s32z27x_r52.dtsi
@@ -560,6 +560,16 @@
 			status = "disabled";
 		};
 
+		dspi0: spi@40340000 {
+			compatible = "nxp,kinetis-dspi";
+			reg = <0x40340000 0x10000>;
+			interrupts = <GIC_SPI 204 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&clock NXP_S32_MSCDSPI_CLK>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
+
 		mru0: mbox@76070000 {
 			compatible = "nxp,s32-mru";
 			reg = <0x76070000 0x10000>;

--- a/dts/bindings/pinctrl/nxp,s32ze-pinctrl.yaml
+++ b/dts/bindings/pinctrl/nxp,s32ze-pinctrl.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 NXP
+# Copyright 2022, 2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
@@ -57,13 +57,13 @@ description: |
     - internal pull not enabled
     - open drain disabled
     - slew rate 4 (see description in property below).
+    - termination resistor disabled (affect LVDS pads only).
+    - current reference control disabled (affect LVDS pads only).
+    - Rx current boost disabled  (affect LVDS pads only).
 
-  Additionally, Safe Mode is always disabled (reset value) and configuration that
-  only applies to LVDS pads, which are not supported, default to reset values:
-    - termination resistor disabled
-    - receiver single ended
-    - current reference control disabled
-    - Rx current boost disabled.
+  Additionally:
+  - Safe Mode is always kept as reset value (disabled).
+  - Receiver Select is always kept as reset value (enables the differential vref based receiver).
 
 compatible: "nxp,s32ze-pinctrl"
 
@@ -116,3 +116,26 @@ child-binding:
             5: FMAX_33 = 50 MHz
             6: FMAX_33 = 50 MHz
             7: FMAX_33 = 1 MHz
+
+      nxp,current-reference-control:
+        type: boolean
+        description: |
+          This configuration applies the current reference control to
+          the associated pin. It is only applicable to LVDS pads and
+          has no effect on other types of pads
+
+      nxp,termination-resistor:
+        type: boolean
+        description: |
+          This configuration applies the termination resistor to
+          the associated pin. It is only applicable to LVDS pads and
+          has no effect on other types of pads
+
+      nxp,rx-current-boost:
+        type: boolean
+        description: |
+          RX LVDS Current Boost
+          Boosts RX IO current. It is only applicable to LVDS pads and
+          has no effect on other types of pads
+          0: Current reference is 200 μA; supports data rate up to 320 Mbaud
+          1: Current reference is 1 mA; supports data rate up to 420 Mbaud

--- a/soc/nxp/s32/s32ze/pinctrl_soc.h
+++ b/soc/nxp/s32/s32ze/pinctrl_soc.h
@@ -53,7 +53,10 @@
 		       SIUL2_MSCR_PUS(DT_PROP(group, bias_pull_up)) |                              \
 		       SIUL2_MSCR_SRE(DT_PROP(group, slew_rate)) |                                 \
 		       SIUL2_MSCR_ODE(DT_PROP(group, drive_open_drain) &&                          \
-				      DT_PROP(group, output_enable))                               \
+				      DT_PROP(group, output_enable)) |                             \
+		       SIUL2_MSCR_TRC(DT_PROP(group, nxp_termination_resistor)) |                  \
+		       SIUL2_MSCR_CREF(DT_PROP(group, nxp_current_reference_control)) |            \
+		       SIUL2_MSCR_RXCB(DT_PROP(group, nxp_rx_current_boost))                       \
 	},                                                                                         \
 	.imcr = {                                                                                  \
 		.inst = NXP_S32_PINMUX_GET_IMCR_SIUL2_IDX(value),                                  \

--- a/tests/drivers/spi/spi_loopback/boards/s32z2xxdc2_s32z270_dspi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/s32z2xxdc2_s32z270_dspi.overlay
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	dspi0_default: dspi0_default {
+		group1 {
+			pinmux = <LVDS_DSPI_10_SOUT>, <LVDS_DSPI_10_SCK>;
+			output-enable;
+			nxp,current-reference-control;
+			nxp,termination-resistor;
+		};
+		group2 {
+			pinmux = <LVDS_DSPI_10_SIN>;
+			input-enable;
+			nxp,current-reference-control;
+			nxp,termination-resistor;
+		};
+	};
+};
+
+&dspi0 {
+	pinctrl-0 = <&dspi0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <500000>;
+	};
+
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <16000000>;
+	};
+};

--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -204,3 +204,9 @@ tests:
   drivers.spi.max32_dma.loopback:
     extra_args: EXTRA_CONF_FILE="overlay-max32-spi-dma.conf"
     filter: CONFIG_SOC_FAMILY_MAX32
+  drivers.spi.s32z_dspi.loopback:
+    extra_args:
+      - DTC_OVERLAY_FILE=boards/s32z2xxdc2_s32z270_dspi.overlay
+    platform_allow:
+      - s32z2xxdc2/s32z270/rtu0
+      - s32z2xxdc2/s32z270/rtu1

--- a/west.yml
+++ b/west.yml
@@ -198,7 +198,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 4597b16cfedf5553cb155151e65eb994d5d0ef25
+      revision: 683c007c3b834012358b4adf96a532d18ce05646
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
This PR to support dspi by re-using mcux driver on s32z27xx devices
Tested on tests\drivers\spi\spi_loopback\drivers.spi.s32z_dspi.loopback
TESTSUITE spi_loopback succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [spi_loopback]: pass = 1, fail = 0, skip = 0, total = 1 duration = 0.366 seconds
 - PASS - [spi_loopback.test_spi_loopback] duration = 0.366 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL