### PR TITLE
west: fix for Python prior to 3.10

### DIFF
--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -777,7 +777,7 @@ class ZephyrBinaryRunner(abc.ABC):
             raise MissingProgram(program)
         return ret
 
-    def get_rtt_address(self) -> int | None:
+    def get_rtt_address(self) -> Optional[int]:
         '''Helper method for extracting a the RTT control block address.
 
         If args.rtt_address was supplied, returns that.


### PR DESCRIPTION
"type | None" syntax is only available with Python from version 3.10, fix building with earlier 3.x Python versions.

This fixes currently broken SOF CI builds with Zephyr "main"