### PR TITLE
scripts: twister: Process KeyboardInterrupt Hardening

### DIFF
--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -614,6 +614,9 @@ class ProjectBuilder(FilterBuilder):
 
 
     def process(self, pipeline, done, message, lock, results):
+        next_op = None
+        additionals = {}
+
         op = message.get('op')
 
         self.instance.setup_handler(self.env)
@@ -771,8 +774,6 @@ class ProjectBuilder(FilterBuilder):
                     done.put(self.instance)
                     self.report_out(results)
 
-                next_op = None
-                additionals = {}
                 if not self.options.coverage:
                     if self.options.prep_artifacts_for_testing:
                         next_op = 'cleanup'


### PR DESCRIPTION
If you interrupt `process()` operation, we want Twister to exit as gracefully as it can. This avoids the `UnboundLocalError` that could appear e.g. when interrupting the operation via SIGINT.

Currently, we can experience a situation like this:
```
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
^CERROR   - General exception: cannot access local variable 'next_op' where it is not associated with a value
ERROR   - General exception: cannot access local variable 'next_op' where it is not associated with a value
ERROR   - General exception: cannot access local variable 'next_op' where it is not associated with a value
ERROR   - General exception: cannot access local variable 'next_op' where it is not associated with a value
ERROR   - General exception: cannot access local variable 'next_op' where it is not associated with a value
ERROR   - General exception: cannot access local variable 'next_op' where it is not associated with a value
ERROR   - General exception: cannot access local variable 'next_op' where it is not associated with a value
ERROR   - General exception: cannot access local variable 'next_op' where it is not associated with a value
ERROR   - General exception: cannot access local variable 'next_op' where it is not associated with a value
ERROR   - General exception: cannot access local variable 'next_op' where it is not associated with a value
ERROR   - General exception: cannot access local variable 'next_op' where it is not associated with a value
ERROR   - General exception: cannot access local variable 'next_op' where it is not associated with a value
INFO    - Execution interrupted
```