### PR TITLE
ili9341: mipi-dbi-mode setable through DT

### DIFF
--- a/drivers/display/display_ili9xxx.c
+++ b/drivers/display/display_ili9xxx.c
@@ -520,7 +520,8 @@ static const struct ili9xxx_quirks ili9488_quirks = {
 		.quirks = &ili##t##_quirks,                                    \
 		.mipi_dev = DEVICE_DT_GET(DT_PARENT(INST_DT_ILI9XXX(n, t))),   \
 		.dbi_config = {                                                \
-			.mode = MIPI_DBI_MODE_SPI_4WIRE,                       \
+			.mode = DT_PROP_OR(INST_DT_ILI9XXX(n, t), mipi_mode,   \
+					MIPI_DBI_MODE_SPI_4WIRE),              \
 			.config = MIPI_DBI_SPI_CONFIG_DT(                      \
 						INST_DT_ILI9XXX(n, t),         \
 						SPI_OP_MODE_MASTER |           \


### PR DESCRIPTION
Currently ili9xxx only supports SPI, but there is also a 8 and 16-bit interface with different modes, see [MIPI-DBI driver APIs](https://docs.zephyrproject.org/latest/doxygen/html/group__mipi__dbi__interface.html). STM calls it flexible memory controller, other vendors will have a similar interface.

My PR allows to set different modes that must be supported by the parent device. Regarding STM it's [mipi_dbi_stm32_fmc.c](https://github.com/zephyrproject-rtos/zephyr/blob/main/drivers/mipi_dbi/mipi_dbi_stm32_fmc.c#L46), that checks for `MIPI_DBI_MODE_8080_BUS_16_BIT`. My fix allows to set the mode accordingly and the configuration check passes.

To not break any existing DTs I made the mode setting optional.

```dts
	ili9341: lcd-panel@0 {
		compatible = "ilitek,ili9341";
		reg = <0>;
		pixel-format = <ILI9XXX_PIXEL_FORMAT_RGB565>;
		mipi-mode = <MIPI_DBI_MODE_8080_BUS_16_BIT>;
		mipi-max-frequency = <DT_FREQ_M(20)>;
// (..)
	};
```
