### PR TITLE
drivers: adc: stm32: don't fail init if pinctrl is not provided

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -1434,9 +1434,14 @@ static int adc_stm32_init(const struct device *dev)
 
 	adc_stm32_set_clock(dev);
 
-	/* Configure dt provided device signals when available */
+	/* Configure ADC inputs as specified in Device Tree, if any */
 	err = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
-	if (err < 0) {
+	if ((err < 0) && (err != -ENOENT)) {
+		/*
+		 * If the ADC is used only with internal channels, then no pinctrl is
+		 * provided in Device Tree, and pinctrl_apply_state returns -ENOENT,
+		 * but this should not be treated as an error.
+		 */
 		LOG_ERR("ADC pinctrl setup failed (%d)", err);
 		return err;
 	}


### PR DESCRIPTION
Commit 47187a9ec9693b754f09e346023d7514c76af567 made the `pinctrl` property of STM32 ADCs optional, to allow usage of internal channels without wasting GPIO pins. However, the driver was not adapted to support this new usecase.

(The real bug comes from commit 93956b207386d1833d162c3ee9b71c6bd8a81da3, that transitioned from a custom `stm32_dt_pinctrl_configure` function to the standard `pinctrl_apply_state`, without accounting for the fact that the former returns 0 when pinctrl is empty, but the latter returns -ENOENT)

Modify the driver to work even if no `pinctrl` is present on the ADC node.

Fixes #78310 