### PR TITLE
samples: net: http_client: Fix busy-looping in case of errors

### DIFF
--- a/samples/net/sockets/http_client/src/main.c
+++ b/samples/net/sockets/http_client/src/main.c
@@ -141,6 +141,8 @@ static int connect_socket(sa_family_t family, const char *server, int port,
 		LOG_ERR("Cannot connect to %s remote (%d)",
 			family == AF_INET ? "IPv4" : "IPv6",
 			-errno);
+		close(*sock);
+		*sock = -1;
 		ret = -errno;
 	}
 
@@ -360,20 +362,23 @@ int main(void)
 {
 	int iterations = CONFIG_NET_SAMPLE_SEND_ITERATIONS;
 	int i = 0;
-	int ret;
+	int ret = 0;
 
 	while (iterations == 0 || i < iterations) {
 		ret = run_queries();
 		if (ret < 0) {
-			exit(1);
+			ret = 1;
+			break;
 		}
 
 		if (iterations > 0) {
 			i++;
 			if (i >= iterations) {
+				ret = 0;
 				break;
 			}
 		} else {
+			ret = 0;
 			break;
 		}
 	}
@@ -382,6 +387,6 @@ int main(void)
 		k_sleep(K_FOREVER);
 	}
 
-	exit(0);
-	return 0;
+	exit(ret);
+	return ret;
 }


### PR DESCRIPTION
The http_client sample ignored connect() errors and attempted to run HTTP query even if the connection failed.

Additionally, in case the query failed, the sample called `exit(1)` directly, causing busy-looping in the sample. This prevented the logger output from being printed.

Both of those issues made the sample behavior very confusing when it encountered connection problems. The sample did not print any output at all (due to busy looping) or printed several connect failures (due to ignoring connect() results). This commit fixes those problems.