### PR TITLE
ci: drop unused python exclusions

### DIFF
--- a/.github/workflows/devicetree_checks.yml
+++ b/.github/workflows/devicetree_checks.yml
@@ -28,11 +28,6 @@ jobs:
       matrix:
         python-version: ['3.10', '3.11', '3.12']
         os: [ubuntu-22.04, macos-14, windows-2022]
-        exclude:
-        - os: macos-14
-          python-version: 3.6
-        - os: windows-2022
-          python-version: 3.6
     steps:
     - name: checkout
       uses: actions/checkout@v4

--- a/.github/workflows/west_cmds.yml
+++ b/.github/workflows/west_cmds.yml
@@ -31,11 +31,6 @@ jobs:
       matrix:
         python-version: ['3.10', '3.11', '3.12']
         os: [ubuntu-22.04, macos-14, windows-2022]
-        exclude:
-        - os: macos-14
-          python-version: 3.6
-        - os: windows-2022
-          python-version: 3.6
     steps:
     - name: checkout
       uses: actions/checkout@v4


### PR DESCRIPTION
Drop some exclusions for python 3.6, this version is not tested in the first place anyway so these are redundant.