### PR TITLE
net: lwm2m: support for Block-Wise composite write operations

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -175,8 +175,7 @@ static int get_block_ctx(const struct lwm2m_obj_path *path, struct lwm2m_block_c
 	*ctx = NULL;
 
 	for (i = 0; i < NUM_BLOCK1_CONTEXT; i++) {
-		if (memcmp(path, &block1_contexts[i].path,
-			  sizeof(struct lwm2m_obj_path)) == 0) {
+		if (lwm2m_obj_path_equal(path, &block1_contexts[i].path)) {
 			*ctx = &block1_contexts[i];
 			/* refresh timestamp */
 			(*ctx)->timestamp = k_uptime_get();

--- a/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
@@ -959,9 +959,11 @@ int do_write_op_tlv(struct lwm2m_message *msg)
 	struct oma_tlv tlv;
 	int ret;
 
-	/* In case of block transfer go directly to the
-	 * message processing - consecutive blocks will not carry the TLV
-	 * header.
+	/* In case of block transfer, check if there are any fragments
+	 * left from the previous resource (instance). If this is the
+	 * case, proceed directly to processing the message -
+	 * consecutive blocks from the same resource do not carry the
+	 * TLV header.
 	 */
 	if (msg->in.block_ctx != NULL && msg->in.block_ctx->ctx.current > 0) {
 		msg->path.res_id = msg->in.block_ctx->path.res_id;
@@ -971,7 +973,6 @@ int do_write_op_tlv(struct lwm2m_message *msg)
 			return ret;
 		}
 
-		return 0;
 	}
 
 	while (true) {


### PR DESCRIPTION
Currently only blockwise operations work for single resources, but with a few changes a composite write with several blocks is also possible via the TLV content format. This makes it possible, for example, to transfer certificates during the bootstrap.