### PR TITLE
logging: frontend: stmesp_demux: Improve robustness

### DIFF
--- a/subsys/logging/frontends/Kconfig
+++ b/subsys/logging/frontends/Kconfig
@@ -95,6 +95,12 @@ config LOG_FRONTEND_STMESP_DEMUX_BUFFER_SIZE
 config LOG_FRONTEND_STMESP_DEMUX_MAX_UTILIZATION
 	bool "Track maximum utilization"
 
+config LOG_FRONTEND_STMESP_DEMUX_GC_TIMEOUT
+	int "Message timeout (in milliseconds)"
+	default 100
+	help
+	  If log message is not completed within that time frame it is discarded.
+
 endif # LOG_FRONTEND_STMESP_DEMUX
 
 config LOG_FRONTEND_STMESP_FLUSH_PORT_ID


### PR DESCRIPTION
Demultiplexer was not ready to handle case when log message was incomplete which was followed by other log messages. Such scenario could occur if there was a fault that happen during logging of a message. In that case incomplete message was followed by valid messages (fault report) and this fault report was not handled because processing was blocked waiting for completion of a message which preceeded fault report.

Since it is expected that some messages may be incomplete a garbage collection mechanism is added. When start of a message is received timestamp is logged and list of incomplete messages is checked for 'old' messages which persist in incomplete state for long. When message timeouts it is closed and marked as invalid. It unblocks processing of following messages.