### PR TITLE
cmake: add toolchain_ld_<name> macros to FindDeprecated

### DIFF
--- a/cmake/modules/FindDeprecated.cmake
+++ b/cmake/modules/FindDeprecated.cmake
@@ -99,6 +99,54 @@ if("PYTHON_PREFER" IN_LIST Deprecated_FIND_COMPONENTS)
   endif()
 endif()
 
+if("toolchain_ld_base" IN_LIST Deprecated_FIND_COMPONENTS)
+  # This code was deprecated after Zephyr v4.0.0
+  list(REMOVE_ITEM Deprecated_FIND_COMPONENTS toolchain_ld_base)
+
+  if(COMMAND toolchain_ld_base)
+    message(DEPRECATION
+        "The macro/function 'toolchain_ld_base' is deprecated. "
+        "Please use '${LINKER}/linker_flags.cmake' and define the appropriate "
+        "linker flags as properties instead. "
+        "See '${ZEPHYR_BASE}/cmake/linker/linker_flags_template.cmake' for "
+        "known linker properties."
+    )
+    toolchain_ld_base()
+  endif()
+endif()
+
+if("toolchain_ld_baremetal" IN_LIST Deprecated_FIND_COMPONENTS)
+  # This code was deprecated after Zephyr v4.0.0
+  list(REMOVE_ITEM Deprecated_FIND_COMPONENTS toolchain_ld_baremetal)
+
+  if(COMMAND toolchain_ld_baremetal)
+    message(DEPRECATION
+        "The macro/function 'toolchain_ld_baremetal' is deprecated. "
+        "Please use '${LINKER}/linker_flags.cmake' and define the appropriate "
+        "linker flags as properties instead. "
+        "See '${ZEPHYR_BASE}/cmake/linker/linker_flags_template.cmake' for "
+        "known linker properties."
+    )
+    toolchain_ld_baremetal()
+  endif()
+endif()
+
+if("toolchain_ld_cpp" IN_LIST Deprecated_FIND_COMPONENTS)
+  # This code was deprecated after Zephyr v4.0.0
+  list(REMOVE_ITEM Deprecated_FIND_COMPONENTS toolchain_ld_cpp)
+
+  if(COMMAND toolchain_ld_cpp)
+    message(DEPRECATION
+        "The macro/function 'toolchain_ld_cpp' is deprecated. "
+        "Please use '${LINKER}/linker_flags.cmake' and define the appropriate "
+        "linker flags as properties instead. "
+        "See '${ZEPHYR_BASE}/cmake/linker/linker_flags_template.cmake' for "
+        "known linker properties."
+    )
+    toolchain_ld_cpp()
+  endif()
+endif()
+
 if(NOT "${Deprecated_FIND_COMPONENTS}" STREQUAL "")
   message(STATUS "The following deprecated component(s) could not be found: "
                  "${Deprecated_FIND_COMPONENTS}")


### PR DESCRIPTION
Follow-up: #77887

The macros:
- toolchain_ld_base
- toolchain_ld_baremetal
- toolchain_ld_cpp

was deprecated in 5db1f1ae8f17a5f351e73fcc4aa45d52b2919505 but no check was added to FindDeprecated.cmake, meaning toolchains still providing those macros was not getting a proper deprecation warning.