### PR TITLE
scripts: Plug TwisterStatus type gaps

### DIFF
--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -37,6 +37,8 @@ logging.getLogger("pykwalify.core").setLevel(50)
 sys.path.append(os.path.join(zephyr_base, 'scripts'))
 import list_boards
 
+from pylib.twister.twisterlib.statuses import TwisterStatus
+
 
 def _get_match_fn(globs, regexes):
     # Constructs a single regex that tests for matches against the globs in
@@ -469,12 +471,12 @@ if __name__ == "__main__":
     dup_free_set = set()
     logging.info(f'Total tests gathered: {len(f.all_tests)}')
     for ts in f.all_tests:
-        if ts.get('status') == 'filtered':
+        if TwisterStatus(ts.get('status')) == TwisterStatus.FILTER:
             continue
         n = ts.get("name")
         a = ts.get("arch")
         p = ts.get("platform")
-        if ts.get('status') == 'error':
+        if TwisterStatus(ts.get('status')) == TwisterStatus.ERROR:
             logging.info(f"Error found: {n} on {p} ({ts.get('reason')})")
             errors += 1
         if (n, a, p,) not in dup_free_set:

--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -65,7 +65,7 @@ class Reporting:
 
 
     @staticmethod
-    def xunit_testcase(eleTestsuite, name, classname, status, ts_status, reason, duration, runnable, stats, log, build_only_as_skip):
+    def xunit_testcase(eleTestsuite, name, classname, status: TwisterStatus, ts_status: TwisterStatus, reason, duration, runnable, stats, log, build_only_as_skip):
         fails, passes, errors, skips = stats
 
         if status in [TwisterStatus.SKIP, TwisterStatus.FILTER]:
@@ -127,7 +127,7 @@ class Reporting:
         suites_to_report = all_suites
             # do not create entry if everything is filtered out
         if not self.env.options.detailed_skipped_report:
-            suites_to_report = list(filter(lambda d: d.get('status') != TwisterStatus.FILTER, all_suites))
+            suites_to_report = list(filter(lambda d: TwisterStatus(d.get('status')) != TwisterStatus.FILTER, all_suites))
 
         for suite in suites_to_report:
             duration = 0
@@ -149,9 +149,9 @@ class Reporting:
             handler_time = suite.get('execution_time', 0)
             runnable = suite.get('runnable', 0)
             duration += float(handler_time)
-            ts_status = suite.get('status')
+            ts_status = TwisterStatus(suite.get('status'))
             for tc in suite.get("testcases", []):
-                status = tc.get('status')
+                status = TwisterStatus(tc.get('status'))
                 reason = tc.get('reason', suite.get('reason', 'Unknown'))
                 log = tc.get("log", suite.get("log"))
 
@@ -197,7 +197,7 @@ class Reporting:
             suites = list(filter(lambda d: d['platform'] == platform, all_suites))
             # do not create entry if everything is filtered out
             if not self.env.options.detailed_skipped_report:
-                non_filtered = list(filter(lambda d: d.get('status') != TwisterStatus.FILTER, suites))
+                non_filtered = list(filter(lambda d: TwisterStatus(d.get('status')) != TwisterStatus.FILTER, suites))
                 if not non_filtered:
                     continue
 
@@ -221,13 +221,13 @@ class Reporting:
                 runnable = ts.get('runnable', 0)
                 duration += float(handler_time)
 
-                ts_status = ts.get('status')
+                ts_status = TwisterStatus(ts.get('status'))
                 # Do not report filtered testcases
                 if ts_status == TwisterStatus.FILTER and not self.env.options.detailed_skipped_report:
                     continue
                 if full_report:
                     for tc in ts.get("testcases", []):
-                        status = tc.get('status')
+                        status = TwisterStatus(tc.get('status'))
                         reason = tc.get('reason', ts.get('reason', 'Unknown'))
                         log = tc.get("log", ts.get("log"))
 

--- a/scripts/pylib/twister/twisterlib/statuses.py
+++ b/scripts/pylib/twister/twisterlib/statuses.py
@@ -13,6 +13,12 @@ class TwisterStatus(str, Enum):
     def __str__(self):
         return str(self.value)
 
+    @classmethod
+    def _missing_(cls, value):
+        super()._missing_(value)
+        if value is None:
+            return TwisterStatus.NONE
+
     # All statuses below this comment can be used for TestCase
     BLOCK = 'blocked'
     STARTED = 'started'

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -624,8 +624,7 @@ class TestPlan:
                     instance.metrics['available_ram'] = ts.get('available_ram', 0)
                     instance.metrics['available_rom'] = ts.get('available_rom', 0)
 
-                    status = ts.get('status')
-                    status = TwisterStatus(status) if status else TwisterStatus.NONE
+                    status = TwisterStatus(ts.get('status'))
                     reason = ts.get("reason", "Unknown")
                     if status in [TwisterStatus.ERROR, TwisterStatus.FAIL]:
                         if self.options.report_summary is not None:
@@ -649,8 +648,7 @@ class TestPlan:
 
                     for tc in ts.get('testcases', []):
                         identifier = tc['identifier']
-                        tc_status = tc.get('status')
-                        tc_status = TwisterStatus(tc_status) if tc_status else TwisterStatus.NONE
+                        tc_status = TwisterStatus(tc.get('status'))
                         tc_reason = None
                         # we set reason only if status is valid, it might have been
                         # reset above...

--- a/scripts/tests/twister_blackbox/test_report.py
+++ b/scripts/tests/twister_blackbox/test_report.py
@@ -19,6 +19,7 @@ from lxml import etree
 
 # pylint: disable=no-name-in-module
 from conftest import TEST_DATA, ZEPHYR_BASE, testsuite_filename_mock, clear_log_in_test
+from twisterlib.statuses import TwisterStatus
 from twisterlib.testplan import TestPlan
 
 
@@ -414,7 +415,7 @@ class TestReport:
 
         testsuites = j.get('testsuites')
         assert testsuites, 'No testsuites found.'
-        statuses = [testsuite.get('status') for testsuite in testsuites]
+        statuses = [TwisterStatus(testsuite.get('status')) for testsuite in testsuites]
         filtered_status_count = statuses.count("filtered")
         assert filtered_status_count == expected_filtered_count, \
             f'Expected {expected_filtered_count} filtered statuses, got {filtered_status_count}.'


### PR DESCRIPTION
Some `dict.get()` calls did not use a `TwisterStatus` as a default value, thus using a `NoneType` where
`TwisterStatus` should appear.

Brought to my attention by @golowanow in [a separate issue](https://github.com/zephyrproject-rtos/zephyr/pull/78319#issuecomment-2345771671). Most visible when prematurely ending `TestSuite` execution while still attempting to create a report.