### PR TITLE
i2c: add locking, rework the stop enforcing code

### DIFF
--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -630,6 +630,10 @@ static int i2c_dw_transfer(const struct device *dev, struct i2c_msg *msgs, uint8
 		return 0;
 	}
 
+	if (!i2c_is_stop_op(&msgs[num_msgs - 1])) {
+		return -EINVAL;
+	}
+
 	ret = k_mutex_lock(&dw->bus_mutex, K_FOREVER);
 	if (ret != 0) {
 		return ret;

--- a/drivers/i2c/i2c_emul.c
+++ b/drivers/i2c/i2c_emul.c
@@ -24,6 +24,7 @@ LOG_MODULE_REGISTER(i2c_emul_ctlr);
 
 /** Working data for the device */
 struct i2c_emul_data {
+	struct i2c_common_data common;
 	/* List of struct i2c_emul associated with the device */
 	sys_slist_t emuls;
 	/* I2C host configuration */
@@ -249,11 +250,14 @@ static int i2c_emul_init(const struct device *dev)
 	sys_slist_init(&data->emuls);
 
 	rc = emul_init_for_bus(dev);
+	if (rc < 0) {
+		return rc;
+	}
 
 	/* Set config to an uninitialized state */
 	data->config = (I2C_MODE_CONTROLLER | i2c_map_dt_bitrate(data->bitrate));
 
-	return rc;
+	return i2c_common_init(dev);
 }
 
 int i2c_emul_register(const struct device *dev, struct i2c_emul *emul)

--- a/drivers/i2c/i2c_esp32.c
+++ b/drivers/i2c/i2c_esp32.c
@@ -618,8 +618,13 @@ static int IRAM_ATTR i2c_esp32_transfer(const struct device *dev, struct i2c_msg
 	uint32_t timeout = I2C_TRANSFER_TIMEOUT_MSEC * USEC_PER_MSEC;
 	int ret = 0;
 
+
 	if (!num_msgs) {
 		return 0;
+	}
+
+	if (!i2c_is_stop_op(&msgs[num_msgs - 1])) {
+		return -EINVAL;
 	}
 
 	while (i2c_ll_is_bus_busy(data->hal.dev)) {

--- a/drivers/i2c/i2c_gd32.c
+++ b/drivers/i2c/i2c_gd32.c
@@ -408,6 +408,10 @@ static int i2c_gd32_transfer(const struct device *dev,
 	uint8_t itr;
 	int err = 0;
 
+	if (!i2c_is_stop_op(&msgs[num_msgs - 1])) {
+		return -EINVAL;
+	}
+
 	current = msgs;
 
 	/* First message flags implicitly contain I2C_MSG_RESTART flag. */

--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -146,6 +146,10 @@ static int i2c_stm32_transfer(const struct device *dev, struct i2c_msg *msg,
 	struct i2c_msg *current, *next;
 	int ret = 0;
 
+	if (!i2c_is_stop_op(&msg[num_msgs - 1])) {
+		return -EINVAL;
+	}
+
 	/* Check for validity of all messages, to prevent having to abort
 	 * in the middle of a transfer
 	 */

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -24,6 +24,7 @@ LOG_MODULE_REGISTER(i2c_nrfx_twi, CONFIG_I2C_LOG_LEVEL);
 #endif
 
 struct i2c_nrfx_twi_data {
+	struct i2c_common_data common;
 	uint32_t dev_config;
 	struct k_sem transfer_sync;
 	struct k_sem completion_sync;
@@ -146,7 +147,11 @@ static const struct i2c_driver_api i2c_nrfx_twi_driver_api = {
 		if (err < 0) {						       \
 			return err;					       \
 		}							       \
-		return i2c_nrfx_twi_init(dev);				       \
+		err = i2c_nrfx_twi_init(dev);				       \
+		if (err < 0) {						       \
+			return err;					       \
+		}							       \
+		return i2c_common_init(dev);                                   \
 	}								       \
 	static struct i2c_nrfx_twi_data twi_##idx##_data = {		       \
 		.transfer_sync = Z_SEM_INITIALIZER(                            \

--- a/drivers/i2c/i2c_nrfx_twi_common.h
+++ b/drivers/i2c/i2c_nrfx_twi_common.h
@@ -26,6 +26,7 @@ extern "C" {
 					  I2C_BITRATE_STANDARD))
 
 struct i2c_nrfx_twi_common_data {
+	struct i2c_common_data common;
 	uint32_t dev_config;
 };
 

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -28,6 +28,7 @@ LOG_MODULE_REGISTER(i2c_nrfx_twim, CONFIG_I2C_LOG_LEVEL);
 #endif
 
 struct i2c_nrfx_twim_data {
+	struct i2c_common_data common;
 	struct k_sem transfer_sync;
 	struct k_sem completion_sync;
 	volatile nrfx_err_t res;
@@ -197,11 +198,17 @@ static void event_handler(nrfx_twim_evt_t const *p_event, void *p_context)
 static int i2c_nrfx_twim_init(const struct device *dev)
 {
 	struct i2c_nrfx_twim_data *data = dev->data;
+	int ret;
 
 	k_sem_init(&data->transfer_sync, 1, 1);
 	k_sem_init(&data->completion_sync, 0, 1);
 
-	return i2c_nrfx_twim_common_init(dev);
+	ret = i2c_nrfx_twim_common_init(dev);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return i2c_common_init(dev);
 }
 
 static const struct i2c_driver_api i2c_nrfx_twim_driver_api = {

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -883,8 +883,8 @@ static inline int z_impl_i2c_transfer(const struct device *dev,
 		return 0;
 	}
 
-	if (!IS_ENABLED(CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS)) {
-		msgs[num_msgs - 1].flags |= I2C_MSG_STOP;
+	if (!i2c_is_stop_op(&msgs[num_msgs - 1])) {
+		return -EINVAL;
 	}
 
 	i2c_bus_lock(dev, K_FOREVER);
@@ -953,8 +953,8 @@ static inline int i2c_transfer_cb(const struct device *dev,
 		return 0;
 	}
 
-	if (!IS_ENABLED(CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS)) {
-		msgs[num_msgs - 1].flags |= I2C_MSG_STOP;
+	if (!i2c_is_stop_op(&msgs[num_msgs - 1])) {
+		return -EINVAL;
 	}
 
 	i2c_bus_lock(dev, K_FOREVER);


### PR DESCRIPTION
This reworks few bits in the i2c subsystem:

- add a generic data structure for common data to be used across the drivers
- add a generic transfer lock function that is used to automatically syncronize transfers across the various i2c drivers
- add a set of lock/unlock and unlocked api so that an application can get exclusive control of the bus (something similar exists for spi as well)
- rework the last message stop bit code to error out rather than setting it automatically, but allow it on unlocked apis
- always error out on some drivers that do not support omitting the stop condition

NOTE: looking for feedback on the proposed implementation at this stage, this is continuing from the discussions in https://github.com/zephyrproject-rtos/zephyr/pull/76654 and https://github.com/zephyrproject-rtos/zephyr/issues/76660, I think the conversation went in the direction of "let's have a NO_STOP flag and hope for the best" to save from modifying all drivers but I'm willing to bite the bullet and add the common data, I think it'll be useful long term anyway, so this is the new proposal.

TODO (on this PR)
- [ ] Documentation, release notes, required changes etc
- [ ] Add the common data and init on all drivers
- [ ] Check out for in-tree drivers relying on not having the stop bit set automatically

Followups:
- This should allow removing a bunch of explicit transfer locks from most drivers
- It'd be nice to make the msgs struct const, this was pointed out in https://github.com/zephyrproject-rtos/zephyr/issues/76660 as well