### PR TITLE
scripts: requirements-extra.txt: Add patool

### DIFF
--- a/scripts/requirements-extras.txt
+++ b/scripts/requirements-extras.txt
@@ -30,3 +30,6 @@ graphviz
 
 # used to generate CBOR encoders and decoders, e.g. lwm2m_senml_cbor.
 zcbor>=0.8.0
+
+# "west sdk" imports patoolib
+patool


### PR DESCRIPTION
The Patool library is used/required by the recently introduced "west sdk" command.

Without this change, "west sdk install" fails with the following error:

> ModuleNotFoundError: No module named 'patoolib'