### PR TITLE
drivers: dma: dma_nxp_edma: add support for EDMAv5

### DIFF
--- a/drivers/dma/dma_nxp_edma.h
+++ b/drivers/dma/dma_nxp_edma.h
@@ -514,6 +514,13 @@ static inline int set_slast_dlast(struct dma_config *dma_cfg,
 	EDMA_ChannelRegWrite(data->hal_cfg, chan_id, EDMA_TCD_SLAST_SDA, slast);
 	EDMA_ChannelRegWrite(data->hal_cfg, chan_id, EDMA_TCD_DLAST_SGA, dlast);
 
+	if (data->hal_cfg->flags & EDMA_HAS_64BIT_TCD_FLAG) {
+		EDMA_ChannelRegWrite(data->hal_cfg, chan_id, EDMA_TCD_SLAST_SDA_HIGH,
+				     slast >= 0x0 ? 0x0 : 0xffffffff);
+		EDMA_ChannelRegWrite(data->hal_cfg, chan_id, EDMA_TCD_DLAST_SGA_HIGH,
+				     dlast >= 0x0 ? 0x0 : 0xffffffff);
+	}
+
 	return 0;
 }
 

--- a/drivers/dma/dma_nxp_edma.h
+++ b/drivers/dma/dma_nxp_edma.h
@@ -417,6 +417,8 @@ static inline int edma_chan_cyclic_produce(struct edma_channel *chan,
 static inline void edma_dump_channel_registers(struct edma_data *data,
 					       uint32_t chan_id)
 {
+	uint32_t mux_reg;
+
 	LOG_DBG("dumping channel data for channel %d", chan_id);
 
 	LOG_DBG("CH_CSR: 0x%x",
@@ -431,8 +433,13 @@ static inline void edma_dump_channel_registers(struct edma_data *data,
 		EDMA_ChannelRegRead(data->hal_cfg, chan_id, EDMA_TCD_CH_PRI));
 
 	if (EDMA_HAS_MUX(data->hal_cfg)) {
-		LOG_DBG("CH_MUX: 0x%x",
-			EDMA_ChannelRegRead(data->hal_cfg, chan_id, EDMA_TCD_CH_MUX));
+		if (data->hal_cfg->flags & EDMA_HAS_MP_MUX_FLAG) {
+			mux_reg = EDMA_MP_CH_MUX;
+		} else {
+			mux_reg = EDMA_TCD_CH_MUX;
+		}
+
+		LOG_DBG("CH_MUX: 0x%x", EDMA_ChannelRegRead(data->hal_cfg, chan_id, mux_reg));
 	}
 
 	LOG_DBG("TCD_SADDR: 0x%x",

--- a/west.yml
+++ b/west.yml
@@ -198,7 +198,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 77815705c465627b8436cbac51f0bf0594bbeba2
+      revision: 17aac63df44266c4ea0e111c731ca7664fe51e70
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
For now, this sums up to supporting some 64-bit TCD registers and the MUX register being in the MP range.