### PR TITLE
intel_adsp: ace: Refactor HPSRAM power-down mechanism for Intel ADSP ACE platforms

### DIFF
--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -126,6 +126,11 @@
 			reg = <0x1fe80088 0x4>;
 		};
 
+		hsbcap: hsbcap@71d00 {
+			compatible = "intel,adsp-hsbcap";
+			reg = <0x71d00 0x4>;
+		};
+
 		lsbpm: lsbpm@71d80 {
 			compatible = "intel,adsp-lsbpm";
 			reg = <0x71d80 0x0008>;

--- a/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
@@ -145,6 +145,11 @@
 			reg = <0x1fe80088 0x4>;
 		};
 
+		hsbcap: hsbcap@71d00 {
+			compatible = "intel,adsp-hsbcap";
+			reg = <0x71d00 0x4>;
+		};
+
 		lsbpm: lsbpm@71d80 {
 			compatible = "intel,adsp-lsbpm";
 			reg = <0x71d80 0x0008>;

--- a/dts/xtensa/intel/intel_adsp_ace30_ptl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace30_ptl.dtsi
@@ -139,6 +139,11 @@
 			reg = <0x3fe80088 0x4>;
 		};
 
+		hsbcap: hsbcap@71d00 {
+			compatible = "intel,adsp-hsbcap";
+			reg = <0x71d00 0x4>;
+		};
+
 		lsbpm: lsbpm@71d80 {
 			compatible = "intel,adsp-lsbpm";
 			reg = <0x71d80 0x0008>;

--- a/soc/intel/intel_adsp/ace/asm_memory_management.h
+++ b/soc/intel/intel_adsp/ace/asm_memory_management.h
@@ -9,33 +9,34 @@
 #ifndef __ZEPHYR_ACE_LIB_ASM_MEMORY_MANAGEMENT_H__
 #define __ZEPHYR_ACE_LIB_ASM_MEMORY_MANAGEMENT_H__
 
-/* These definitions should be placed elsewhere, but I can't find a good place for them. */
-#define LSPGCTL				0x71D80
-#define LSPGCTL_HIGH			((LSPGCTL >> 4) & 0xff00)
-#define LSPGCTL_LOW			((LSPGCTL >> 4) & 0xff)
-
 #include <zephyr/devicetree.h>
 
 #ifdef _ASMLANGUAGE
 
 .macro m_ace_lpsram_power_down_entire ax, ay, az, au
-	movi \au, 8 /* LPSRAM_EBB_QUANTITY */
-	movi \az, LSPGCTL_LOW
-	addmi \az, \az, LSPGCTL_HIGH
-	slli \az, \az, 4
+	/* Retrieve the LPSRAM bank count from the ACE_L2MCAP register */
+	movi \az, DT_REG_ADDR(DT_NODELABEL(hsbcap))
+	l32i \az, \az, 0
+	/* Extract the 4-bit bank count field starting from bit 8 */
+	extui \au, \az, 8, 4
 
-	movi \ay, 1
+	movi \ay, 1       /* Power down command */
+
+	/* Get the address of the LPSRAM control register from the Devicetree */
+	movi \az, DT_REG_ADDR(DT_NODELABEL(lsbpm))
 2 :
+	/* Issue the power down command to the current LPSRAM bank */
 	s8i \ay, \az, 0
 	memw
-
 1 :
+	/* Poll the status register to confirm the power down command has taken effect */
 	l8ui \ax, \az, 4
 	bne \ax, \ay, 1b
 
-	addi \az, \az, 8
-	addi \au, \au, -1
-	bnez \au, 2b
+	/* Move to the next LPSRAM bank control register */
+	addi \az, \az, DT_REG_SIZE(DT_NODELABEL(lsbpm))
+	addi \au, \au, -1 /* Decrement bank count */
+	bnez \au, 2b      /* If banks are left, continue loop */
 .endm
 
 .macro m_ace_hpsram_power_down_entire ax, ay, az, au

--- a/soc/intel/intel_adsp/ace/include/adsp_memory.h
+++ b/soc/intel/intel_adsp/ace/include/adsp_memory.h
@@ -99,7 +99,7 @@
 /* L2 Local Memory Management */
 
 /* These registers are for the L2 memory control and status. */
-#define DFL2MM_REG 0x71d00
+#define DFL2MM_REG (DT_REG_ADDR(DT_NODELABEL(hsbcap)))
 
 struct ace_l2mm {
 	uint32_t l2mcap;

--- a/soc/intel/intel_adsp/ace/power_down.S
+++ b/soc/intel/intel_adsp/ace/power_down.S
@@ -36,20 +36,20 @@ sram_dis_loop_cnt:
  * @param A4 - send response to ipc
  */
 
-#define IPC_HOST_BASE				0x00073000
-#define b_enable_lpsram				a2
-#define pu32_hpsram_mask			a3
-#define b_ipc_response				a4
-#define temp_reg0					a6
-#define temp_reg1					a7
-#define temp_reg2					a8
-#define temp_reg3					a9
-#define temp_reg4					a10
-#define temp_reg5					a11
-#define temp_reg6					a12
-#define p_ipc_regs					a13
+#define IPC_HOST_BASE			0x00073000
+#define b_enable_lpsram			a2
+#define pu32_hpsram_mask		a3
+#define b_ipc_response			a4
+#define temp_reg0			a6
+#define temp_reg1			a7
+#define temp_reg2			a8
+#define temp_reg3			a9
+#define temp_reg4			a10
+#define temp_reg5			a11
+#define temp_reg6			a12
+#define p_ipc_regs			a13
 #define u32_ipc_response_mask		a14
-#define pfl_reg						a15
+#define pfl_reg				a15
 
 power_down:
 	entry sp, 32

--- a/soc/intel/intel_adsp/ace/power_down.S
+++ b/soc/intel/intel_adsp/ace/power_down.S
@@ -4,15 +4,6 @@
 
 #include "asm_memory_management.h"
 
-	.section .cached.hpsram_mask, "w"
-	.align 64
-hpsram_mask:
-	.rept MAX_MEMORY_SEGMENTS
-		.word 0
-	.endr
-
-	.global hpsram_mask
-
 	.section .text, "ax"
 	.align 64
 power_down_literals:
@@ -31,14 +22,13 @@ sram_dis_loop_cnt:
  * Depending on arguments, memories are switched off.
  *
  * @param A2 - argument for LPSRAM
- * @param A3 - pointer to array containing power gating mask.
- * Size of array is determined by MAX_MEMORY_SEGMENTS define.
+ * @param A3 - argument for HPSRAM
  * @param A4 - send response to ipc
  */
 
 #define IPC_HOST_BASE			0x00073000
-#define b_enable_lpsram			a2
-#define pu32_hpsram_mask		a3
+#define b_disable_lpsram		a2
+#define b_disable_hpsram		a3
 #define b_ipc_response			a4
 #define temp_reg0			a6
 #define temp_reg1			a7
@@ -95,44 +85,25 @@ power_down:
 	l32i pfl_reg, p_ipc_regs, 0
 #endif
 
-	beqz pu32_hpsram_mask, _PD_DISABLE_LPSRAM
-	movi pu32_hpsram_mask, hpsram_mask
-
 _PD_DISABLE_LPSRAM:
 /**
  * effectively executes:
- * if (b_enable_lpsram) {
+ * if (b_disable_lpsram) {
  *     ace_lpsram_power_down_entire();
  * }
  */
-	beqz b_enable_lpsram, _PD_DISABLE_HPSRAM
+	beqz b_disable_lpsram, _PD_DISABLE_HPSRAM
 	m_ace_lpsram_power_down_entire temp_reg0, temp_reg1, temp_reg2, temp_reg3
 
 _PD_DISABLE_HPSRAM:
-	/* if value pu32_hpsram_mask = 0 - do not disable hpsram. */
-	beqz pu32_hpsram_mask, _PD_SEND_IPC
-	/**
-	 * effectively executes:
-	 * for (size_t seg_index = (MAX_MEMORY_SEGMENTS - 1); seg_index >= 0;
-	 * --seg_index) {
-	 * ace_hpsram_power_change(seg_index, mask[seg_index]);
-	 * }
-	 * where mask is given in pu32_hpsram_mask register
-	 */
-
-	.set seg_index, MAX_MEMORY_SEGMENTS - 1
-	.rept MAX_MEMORY_SEGMENTS
-		l32i temp_reg0, pu32_hpsram_mask, 4 * seg_index
-		m_ace_hpsram_power_change\
-			/*segment_index=*/	seg_index,\
-			/*mask=*/	temp_reg0,\
-			temp_reg1,\
-			temp_reg2,\
-			temp_reg3,\
-			temp_reg4,\
-			temp_reg5
-		.set seg_index, seg_index - 1
-	.endr
+/**
+ * effectively executes:
+ * if (b_disable_hpsram) {
+ *     ace_hpsram_power_down_entire();
+ * }
+ */
+	beqz b_disable_hpsram, _PD_SEND_IPC
+	m_ace_hpsram_power_down_entire temp_reg0, temp_reg1, temp_reg2, temp_reg3
 
 _PD_SEND_IPC:
 	/**

--- a/soc/intel/intel_adsp/ace/power_down.S
+++ b/soc/intel/intel_adsp/ace/power_down.S
@@ -72,6 +72,28 @@ power_down:
 	/* load address of DIPCTDR register */
 	movi p_ipc_regs, IPC_HOST_BASE
 	movi u32_ipc_response_mask, 0x20000000
+#if CONFIG_XTENSA_MMU
+	/**
+	 * Preload the IPC register to ensure the TLB entry is present.
+	 * This addresses an issue on platforms with an MMU where a
+	 * LoadStoreTLBMissCause exception occurs when accessing hardware
+	 * registers during the power-down process. By preloading the IPC
+	 * register, we ensure that the necessary TLB entry is available,
+	 * preventing a double exception (LoadStoreTLBMissCause followed by
+	 * InstrPIFDataErrorCause) when accessing the IPC register after
+	 * HPSRAM is powered down.
+	 *
+	 * Two solutions were considered:
+	 * 1. Use TLB way9 to lock IPC MMIO registers (Zephyr PR80333)
+	 * 2. Manually force TLB entry to be fetched in power_down (this solution)
+	 *
+	 * The decision was made to proceed with this solution due to its
+	 * simplicity and directness, despite the potential performance benefits
+	 * of the TLB way9 approach. The TLB way9 approach would also reserve
+	 * way9, potentially limiting its use for other purposes in the future.
+	 */
+	l32i pfl_reg, p_ipc_regs, 0
+#endif
 
 	beqz pu32_hpsram_mask, _PD_DISABLE_LPSRAM
 	movi pu32_hpsram_mask, hpsram_mask


### PR DESCRIPTION
This pull request introduces a series of changes to the HPSRAM power-down mechanism for Intel ADSP ACE platforms, improving code maintainability and readability. The updates include the introduction of a new assembly macro, cleanup of obsolete code, and refactoring of the `power_down` function to align with the new approach.

**Key Changes:**
1. **Introduce L2 Memory Capabilities Register Node:** Adds the L2 Memory Capabilities (`hsbcap`) register node to the Devicetree specifications for ACE platforms, providing essential information for system configuration and resource management. 
2. **New Assembly Macro for HPSRAM Power-Down:** Implements a new macro `m_ace_hpsram_power_down_entire` using Zephyr Devicetree macros to dynamically retrieve HPSRAM bank count and control register address, simplifying the power-down process. 
3. **Refactor `power_down` Function:** Updates the `power_down` function to use the new `m_ace_hpsram_power_down_entire` macro, replacing the previous segment-based power gating mask approach with a single boolean flag.
4. **Cleanup of Obsolete Code:** Removes the no longer used `m_ace_hpsram_power_change` macro from `asm_memory_management.h`, streamlining the codebase.