### PR TITLE
stm32wb0: fix build on SoCs without SMPS output current limit (WB06/WB07)

### DIFF
--- a/dts/bindings/power/st,stm32wb0-pwr.yaml
+++ b/dts/bindings/power/st,stm32wb0-pwr.yaml
@@ -28,7 +28,8 @@ properties:
       PRECHARGE: (also called BYPASS)
         - SMPS converter enabled - clock disabled
         - LDOs supply voltage: VDD (though SMPS)
-          - Supplied current limitation can be programmed
+          - Current supplied to LDOs can be limited
+            (feature only supported on STM32WB05 / STM32WB09)
 
       RUN: (also called ON)
         - SMPS converter enabled - clock enabled
@@ -97,8 +98,12 @@ properties:
     description: |
       SMPS output current limit (in mA)
 
-      The default value corresponds to the hardware reset
-      configuration of 20 mA output current limit.
+      The default value of 20 mA corresponds to the maximal
+      output current allowed for the SMPS, and is also equal
+      to the hardware reset configuration.
+
+      On STM32WB06 and STM32WB07, this property is ignored as
+      the output current limitation feature is not available.
 
       This property is only used if `smps-mode` is "PRECHARGE".
     enum:

--- a/soc/st/stm32/stm32wb0x/soc.c
+++ b/soc/st/stm32/stm32wb0x/soc.c
@@ -67,9 +67,11 @@ __used RAM_VR_TypeDef RAM_VR;
 					(LL_PWR_SMPS_LPOPEN),		\
 					(LL_PWR_NO_SMPS_LPOPEN))
 
+#if defined(PWR_CR5_SMPS_PRECH_CUR_SEL)
 	#define SMPS_CURRENT_LIMIT					\
 		_CONCAT(LL_PWR_SMPS_PRECH_LIMIT_CUR_,			\
 			DT_STRING_UNQUOTED(PWRC, smps_current_limit))
+#endif /* PWR_CR5_SMPS_PRECH_CUR_SEL */
 
 	#define SMPS_OUTPUT_VOLTAGE					\
 			_CONCAT(LL_PWR_SMPS_OUTPUT_VOLTAGE_,		\
@@ -112,11 +114,15 @@ static void configure_smps(void)
 	}
 
 	if (SMPS_MODE == STM32WB0_SMPS_MODE_PRECHARGE) {
+#if defined(PWR_CR5_SMPS_PRECH_CUR_SEL)
 		/**
-		 * SMPS should remain in PRECHARGE mode, but
-		 * we still have to configure the current limit.
+		 * SMPS should remain in PRECHARGE mode.
+		 * We still have to configure the output current
+		 * limit specified in Device Tree, though this
+		 * can only be done if this SoC supports it.
 		 */
 		LL_PWR_SetSMPSPrechargeLimitCurrent(SMPS_CURRENT_LIMIT);
+#endif /* PWR_CR5_SMPS_PRECH_CUR_SEL */
 	} else {
 		/**
 		 * SMPS mode requested is RUN mode. Configure the output


### PR DESCRIPTION
The STM32WB06 and STM32WB07 SoCs do not support SMPS output current limit.
This makes the `LL_PWR_SetSMPSPrechargeLimitCurrent` function and all the `LL_PWR_SMPS_PRECH_LIMIT_CUR_xxx` defines not visible when one of these SoCs is selected, resulting in a build failure in `soc.c`.
(This is not seen in CI because there are no WB06/WB07 boards defined in Zephyr yet)

Fix this by only handling SMPS current limit when the feature is available, and update the power controller binding to indicate this behavior.

Tested by building `samples/hello_world` for a dummy board target set to use STM32WB07 SoC.