### PR TITLE
scripts: twister: Add TestCase status and reason printing

### DIFF
--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -1111,6 +1111,13 @@ class ProjectBuilder(FilterBuilder):
                 results.done, total_tests_width, total_to_do , instance.platform.name,
                 instance.testsuite.name, status, more_info))
 
+            if self.options.verbose > 1:
+                for tc in self.instance.testcases:
+                    color = TwisterStatus.get_color(tc.status)
+                    logger.info(f'    {" ":<{total_tests_width+25+4}} {tc.name:<75} '
+                                f'{color}{str.upper(tc.status.value):<12}{Fore.RESET}'
+                                f'{" " + tc.reason if tc.reason else ""}')
+
             if instance.status in [TwisterStatus.ERROR, TwisterStatus.FAIL]:
                 self.log_info_file(self.options.inline_logs)
         else:

--- a/scripts/pylib/twister/twisterlib/statuses.py
+++ b/scripts/pylib/twister/twisterlib/statuses.py
@@ -5,7 +5,9 @@
 """
 Status classes to be used instead of str statuses.
 """
+from __future__ import annotations
 
+from colorama import Fore
 from enum import Enum
 
 
@@ -18,6 +20,21 @@ class TwisterStatus(str, Enum):
         super()._missing_(value)
         if value is None:
             return TwisterStatus.NONE
+
+    @staticmethod
+    def get_color(status: TwisterStatus) -> str:
+        match(status):
+            case TwisterStatus.PASS:
+                color = Fore.GREEN
+            case TwisterStatus.SKIP | TwisterStatus.FILTER | TwisterStatus.BLOCK:
+                color = Fore.YELLOW
+            case TwisterStatus.FAIL | TwisterStatus.ERROR:
+                color = Fore.RED
+            case TwisterStatus.STARTED | TwisterStatus.NONE:
+                color = Fore.MAGENTA
+            case _:
+                color = Fore.RESET
+        return color
 
     # All statuses below this comment can be used for TestCase
     BLOCK = 'blocked'

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -2008,9 +2008,13 @@ def test_projectbuilder_report_out(
     instance_mock.status = status
     instance_mock.reason = 'dummy reason'
     instance_mock.testsuite.name = 'dummy.testsuite.name'
-    instance_mock.testsuite.testcases = [mock.Mock() for _ in range(25)]
-    instance_mock.testcases = [mock.Mock() for _ in range(24)] + \
-                              [mock.Mock(status=TwisterStatus.SKIP)]
+    skip_mock_tc = mock.Mock(status=TwisterStatus.SKIP, reason='?')
+    skip_mock_tc.name = '?'
+    unknown_mock_tc = mock.Mock(status=mock.Mock(value='?'), reason='?')
+    unknown_mock_tc.name = '?'
+    instance_mock.testsuite.testcases = [unknown_mock_tc for _ in range(25)]
+    instance_mock.testcases = [unknown_mock_tc for _ in range(24)] + \
+                              [skip_mock_tc]
     env_mock = mock.Mock()
 
     pb = ProjectBuilder(instance_mock, env_mock, mocked_jobserver)


### PR DESCRIPTION
When at verbosity 1, we print out the status of TestInstances. However, we omit the TestCases in that print-out. This makes it harder to notice changes at TestCase level, which require perusing the logs.

This PR adds TestCase status and reason printing at verbosity level 2. Reason printing is suppressed if the reason in `None` or empty.

Visual example:
<img width="381" alt="image" src="https://github.com/user-attachments/assets/0b8b73e7-9a52-4ea2-a996-f5598435c9ee">