### PR TITLE
video: esp32_dvp: change default log level to the recent CONFIG_VIDEO_LOG_LEVEL option

### DIFF
--- a/drivers/video/video_esp32_dvp.c
+++ b/drivers/video/video_esp32_dvp.c
@@ -20,7 +20,7 @@
 #include <hal/cam_ll.h>
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(video_esp32_lcd_cam, LOG_LEVEL_INF);
+LOG_MODULE_REGISTER(video_esp32_lcd_cam, CONFIG_VIDEO_LOG_LEVEL);
 
 #define VIDEO_ESP32_DMA_BUFFER_MAX_SIZE 4095
 


### PR DESCRIPTION
With the recent addition of the CONFIG_VIDEO_LOG_LEVEL, change the esp32 video driver to use that to keep the consistency of the other drivers, 