### PR TITLE
drivers: i3c: add controller handoff

### DIFF
--- a/drivers/i3c/CMakeLists.txt
+++ b/drivers/i3c/CMakeLists.txt
@@ -11,6 +11,14 @@ zephyr_library_sources(
   i3c_common.c
 )
 
+if(CONFIG_I3C_NUM_OF_DESC_MEM_SLABS GREATER 0)
+  zephyr_library_sources(i3c_mem_slab.c)
+endif()
+
+if(CONFIG_I3C_I2C_NUM_OF_DESC_MEM_SLABS GREATER 0)
+  zephyr_library_sources(i3c_i2c_mem_slab.c)
+endif()
+
 zephyr_library_sources_ifdef(
   CONFIG_USERSPACE
   i3c_handlers.c

--- a/drivers/i3c/Kconfig
+++ b/drivers/i3c/Kconfig
@@ -117,6 +117,22 @@ config I3C_INIT_RSTACT
 	  This determines whether the bus initialization routine
 	  sends a reset action command to I3C targets.
 
+config I3C_NUM_OF_DESC_MEM_SLABS
+	int "Number of I3C Device Descriptors Mem Slabs"
+	default 3
+	help
+	  This is the number of memory slabs allocated from when
+	  there is a device encounted through ENTDAA or DEFTGTS that
+	  is not within known I3C devices.
+
+config I3C_I2C_NUM_OF_DESC_MEM_SLABS
+	int "Number of I2C Device Descriptors Mem Slabs"
+	default 3
+	help
+	  This is the number of memory slabs allocated from when
+	  there is a device encounted through DEFTGTS that is not
+	  within known I2C devices.
+
 config I3C_RTIO
 	bool "I3C RTIO API"
 	select EXPERIMENTAL

--- a/drivers/i3c/i3c_ccc.c
+++ b/drivers/i3c/i3c_ccc.c
@@ -910,3 +910,28 @@ int i3c_ccc_do_setbuscon(const struct device *controller,
 
 	return i3c_do_ccc(controller, &ccc_payload);
 }
+
+int i3c_ccc_do_getacccr(const struct i3c_device_desc *target,
+			 struct i3c_ccc_address *handoff_address)
+{
+	struct i3c_ccc_payload ccc_payload;
+	struct i3c_ccc_target_payload ccc_tgt_payload;
+	int ret;
+
+	__ASSERT_NO_MSG(target != NULL);
+	__ASSERT_NO_MSG(handoff_address != NULL);
+
+	ccc_tgt_payload.addr = target->dynamic_addr;
+	ccc_tgt_payload.rnw = 1;
+	ccc_tgt_payload.data = &handoff_address->addr;
+	ccc_tgt_payload.data_len = 1;
+
+	memset(&ccc_payload, 0, sizeof(ccc_payload));
+	ccc_payload.ccc.id = I3C_CCC_GETACCCR;
+	ccc_payload.targets.payloads = &ccc_tgt_payload;
+	ccc_payload.targets.num_targets = 1;
+
+	ret = i3c_do_ccc(target->bus, &ccc_payload);
+
+	return ret;
+}

--- a/drivers/i3c/i3c_cdns.c
+++ b/drivers/i3c/i3c_cdns.c
@@ -14,6 +14,8 @@
 #include <zephyr/sys/sys_io.h>
 #include <zephyr/sys/util.h>
 
+#include <stdlib.h>
+
 #define DEV_ID            0x0
 #define DEV_ID_I3C_MASTER 0x5034
 
@@ -344,7 +346,8 @@
 #define SLV_ERR1          BIT(1)
 #define SLV_ERR0          BIT(0)
 
-#define SLV_STATUS2 0xA8
+#define SLV_STATUS2        0xA8
+#define SLV_STATUS2_MRL(s) (((s) & GENMASK(23, 8)) >> 8)
 
 #define SLV_STATUS3           0xAC
 #define SLV_STATUS3_BC_FSM(s) (((s) & GENMASK(26, 16)) >> 16)
@@ -572,7 +575,9 @@ struct cdns_i3c_config {
 
 /* Driver instance data */
 struct cdns_i3c_data {
+	/* common must be first! */
 	struct i3c_driver_data common;
+	const struct device *dev;
 	struct cdns_i3c_hw_config hw_cfg;
 #ifdef CONFIG_I3C_USE_IBI
 	struct cdns_i3c_ibi_buf ibi_buf;
@@ -581,7 +586,12 @@ struct cdns_i3c_data {
 	struct cdns_i3c_i2c_dev_data cdns_i3c_i2c_priv_data[I3C_MAX_DEVS];
 	struct cdns_i3c_xfer xfer;
 	struct i3c_target_config *target_config;
+	struct k_work deftgts_work;
+#ifdef CONFIG_I3C_USE_IBI
 	struct k_sem ibi_hj_complete;
+	struct k_sem ibi_cr_complete;
+#endif
+	struct k_sem ch_complete;
 	uint32_t free_rr_slots;
 	uint16_t fifo_bytes_read;
 	uint8_t max_devs;
@@ -999,7 +1009,8 @@ static uint32_t prepare_rr0_dev_address(uint16_t addr)
 /**
  * @brief Program Retaining Registers with device lists
  *
- * This will program the retaining register with the controller itself
+ * This will program the retaining register with the controller itself, this should
+ * only be called if it is a primary controller.
  *
  * @param dev Pointer to controller device driver instance.
  */
@@ -1015,7 +1026,8 @@ static void cdns_i3c_program_controller_retaining_reg(const struct device *dev)
 			i3c_addr_slots_next_free_find(&data->common.attached_dev.addr_slots, 0);
 		LOG_DBG("%s: 0x%02x DA selected for controller", dev->name, controller_da);
 	}
-	sys_write32(prepare_rr0_dev_address(controller_da), config->base + DEV_ID_RR0(0));
+	sys_write32(prepare_rr0_dev_address(controller_da) | DEV_ID_RR0_IS_I3C,
+		    config->base + DEV_ID_RR0(0));
 	/* Mark the address as I3C device */
 	i3c_addr_slots_mark_i3c(&data->common.attached_dev.addr_slots, controller_da);
 }
@@ -1043,7 +1055,8 @@ static int cdns_i3c_controller_ibi_enable(const struct device *dev, struct i3c_d
 	struct i3c_ccc_events i3c_events;
 	int ret = 0;
 
-	if (!i3c_device_is_ibi_capable(target)) {
+	/* Check if the device can issue IBI TIRs or CR */
+	if (!i3c_device_is_ibi_capable(target) && !i3c_device_is_controller_capable(target)) {
 		ret = -EINVAL;
 		return ret;
 	}
@@ -1053,7 +1066,8 @@ static int cdns_i3c_controller_ibi_enable(const struct device *dev, struct i3c_d
 	sir_cfg = SIR_MAP_DEV_ROLE(I3C_BCR_DEVICE_ROLE(target->bcr)) |
 		  SIR_MAP_DEV_DA(target->dynamic_addr) |
 		  SIR_MAP_DEV_PL(target->data_length.max_ibi);
-	if (target->ibi_cb != NULL) {
+	/* ACK if there is an ibi tir cb or if it is controller capable*/
+	if ((target->ibi_cb != NULL) || i3c_device_is_controller_capable(target)) {
 		sir_cfg |= SIR_MAP_DEV_ACK;
 	}
 	if (target->bcr & I3C_BCR_MAX_DATA_SPEED_LIMIT) {
@@ -1063,8 +1077,8 @@ static int cdns_i3c_controller_ibi_enable(const struct device *dev, struct i3c_d
 	LOG_DBG("%s: IBI enabling for 0x%02x (BCR 0x%02x)", dev->name, target->dynamic_addr,
 		target->bcr);
 
-	/* Tell target to enable IBI */
-	i3c_events.events = I3C_CCC_EVT_INTR;
+	/* Tell target to enable IBI TIRs and CRs */
+	i3c_events.events = I3C_CCC_EVT_INTR | I3C_CCC_EVT_CR;
 	ret = i3c_ccc_do_events_set(target, true, &i3c_events);
 	if (ret != 0) {
 		LOG_ERR("%s: Error sending IBI ENEC for 0x%02x (%d)", dev->name,
@@ -1143,6 +1157,31 @@ static int cdns_i3c_target_ibi_raise_hj(const struct device *dev)
 	return 0;
 }
 
+static int cdns_i3c_target_ibi_raise_cr(const struct device *dev)
+{
+	const struct cdns_i3c_config *config = dev->config;
+	struct cdns_i3c_data *data = dev->data;
+
+	/* Check if target does not have a DA assigned to it */
+	if (!(sys_read32(config->base + SLV_STATUS1) & SLV_STATUS1_HAS_DA)) {
+		LOG_ERR("%s: CR not available, DA not assigned", dev->name);
+		return -EACCES;
+	}
+	/* Check if CR requests DISEC CCC with DISMR field set has been received */
+	if (sys_read32(config->base + SLV_STATUS1) & SLV_STATUS1_MR_DIS) {
+		LOG_ERR("%s: CR requests are currently disabled by DISEC", dev->name);
+		return -EAGAIN;
+	}
+
+	sys_write32(CTRL_MST_INIT | sys_read32(config->base + CTRL), config->base + CTRL);
+	k_sem_reset(&data->ibi_cr_complete);
+	if (k_sem_take(&data->ibi_cr_complete, K_MSEC(500)) != 0) {
+		LOG_ERR("%s: timeout waiting for GETACCCR after CR", dev->name);
+		return -ETIMEDOUT;
+	}
+	return 0;
+}
+
 static int cdns_i3c_target_ibi_raise_intr(const struct device *dev, struct i3c_ibi *request)
 {
 	const struct cdns_i3c_config *config = dev->config;
@@ -1150,6 +1189,17 @@ static int cdns_i3c_target_ibi_raise_intr(const struct device *dev, struct i3c_i
 	uint32_t ibi_ctrl_val;
 
 	LOG_DBG("%s: issuing IBI TIR", dev->name);
+
+	/* Check if target does not have a DA assigned to it */
+	if (!(sys_read32(config->base + SLV_STATUS1) & SLV_STATUS1_HAS_DA)) {
+		LOG_ERR("%s: TIR not available, DA not assigned", dev->name);
+		return -EACCES;
+	}
+	/* Check if TIR requests DISEC CCC with DISMR field set has been received */
+	if (sys_read32(config->base + SLV_STATUS1) & SLV_STATUS1_IBI_DIS) {
+		LOG_ERR("%s: TIR requests are currently disabled by DISEC", dev->name);
+		return -EAGAIN;
+	}
 
 	/*
 	 * Ensure data will fit within FIFO
@@ -1175,10 +1225,14 @@ static int cdns_i3c_target_ibi_raise_intr(const struct device *dev, struct i3c_i
 
 static int cdns_i3c_target_ibi_raise(const struct device *dev, struct i3c_ibi *request)
 {
+	const struct cdns_i3c_config *config = dev->config;
 	struct cdns_i3c_data *data = dev->data;
 
-	if (request == NULL) {
-		return -EINVAL;
+	__ASSERT_NO_MSG(request != NULL);
+
+	/* make sure we are not currently the active controller */
+	if (sys_read32(config->base + MST_STATUS0) & MST_STATUS0_MASTER_MODE) {
+		return -EACCES;
 	}
 
 	switch (request->ibi_type) {
@@ -1190,8 +1244,7 @@ static int cdns_i3c_target_ibi_raise(const struct device *dev, struct i3c_ibi *r
 			return -ENOTSUP;
 		}
 	case I3C_IBI_CONTROLLER_ROLE_REQUEST:
-		/* TODO: Cadence I3C can support CR, but not implemented yet */
-		return -ENOTSUP;
+		return cdns_i3c_target_ibi_raise_cr(dev);
 	case I3C_IBI_HOTJOIN:
 		return cdns_i3c_target_ibi_raise_hj(dev);
 	default:
@@ -1495,6 +1548,12 @@ static int cdns_i3c_do_ccc(const struct device *dev, struct i3c_ccc_payload *pay
 	}
 
 	ret = data->xfer.ret;
+
+	/* TODO: decide if this is the right approach or add a new separate API for CH */
+	/* Wait for Controller Handoff to finish */
+	if (payload->ccc.id == I3C_CCC_GETACCCR) {
+		ret = k_sem_take(&data->ch_complete, K_MSEC(1000));
+	}
 error:
 	k_mutex_unlock(&data->bus_lock);
 
@@ -1580,20 +1639,46 @@ static int cdns_i3c_do_daa(const struct device *dev)
 				const struct i3c_device_id i3c_id = I3C_DEVICE_ID(pid);
 				struct i3c_device_desc *target = i3c_device_find(dev, &i3c_id);
 
-				if (target == NULL) {
+				if (!target) {
+					/* Target found that is not known, allocate a desc */
+					target = i3c_device_desc_alloc();
+					if (target) {
+						/*
+						 * able to allocate a descriptor
+						 * write all known values
+						 */
+						*(const struct device **)&target->bus = dev;
+						*(uint64_t *)&target->pid = pid;
+						target->dynamic_addr = dyn_addr;
+						target->bcr = bcr;
+						target->dcr = dcr;
+						/* attach it to the slist */
+						sys_slist_append(
+							&data->common.attached_dev.devices.i3c,
+							&target->node);
+
+						data->cdns_i3c_i2c_priv_data[rr_idx].id = rr_idx;
+						target->controller_priv =
+							&(data->cdns_i3c_i2c_priv_data[rr_idx]);
+					}
+
 					LOG_INF("%s: PID 0x%012llx is not in registered device "
 						"list, given DA 0x%02x",
 						dev->name, pid, dyn_addr);
-					i3c_addr_slots_mark_i3c(
-						&data->common.attached_dev.addr_slots, dyn_addr);
 				} else {
 					target->dynamic_addr = dyn_addr;
 					target->bcr = bcr;
 					target->dcr = dcr;
 
+					data->cdns_i3c_i2c_priv_data[rr_idx].id = rr_idx;
+					target->controller_priv =
+						&(data->cdns_i3c_i2c_priv_data[rr_idx]);
+
 					LOG_DBG("%s: PID 0x%012llx assigned dynamic address 0x%02x",
 						dev->name, pid, dyn_addr);
 				}
+				i3c_addr_slots_mark_i3c(&data->common.attached_dev.addr_slots,
+							dyn_addr);
 			}
 		}
 	} else {
@@ -2440,6 +2525,45 @@ static void cdns_i3c_handle_ibi(const struct device *dev, uint32_t ibir)
 	}
 }
 
+static void cdns_i3c_handle_cr(const struct device *dev, uint32_t ibir)
+{
+	const struct cdns_i3c_config *config = dev->config;
+
+	/* The slave ID returned here is the device ID in the SIR map NOT the device ID
+	 * in the RR map.
+	 */
+	uint8_t slave_id = IBIR_SLVID(ibir);
+
+	if (slave_id == IBIR_SLVID_INV) {
+		/* DA does not match any value among SIR map */
+		return;
+	}
+
+	uint32_t dev_id_rr0 = sys_read32(config->base + DEV_ID_RR0(slave_id + 1));
+	uint8_t dyn_addr = DEV_ID_RR0_GET_DEV_ADDR(dev_id_rr0);
+	struct i3c_device_desc *desc = i3c_dev_list_i3c_addr_find(dev, dyn_addr);
+
+	/*
+	 * Check for NAK or error conditions.
+	 *
+	 * Note: The logging is for debugging only so will be compiled out in most cases.
+	 * However, if the log level for this module is DEBUG and log mode is IMMEDIATE or MINIMAL,
+	 * this option is also set this may cause problems due to being inside an ISR.
+	 */
+	if (!(IBIR_ACKED & ibir)) {
+		LOG_DBG("%s: NAK for slave ID %u", dev->name, (unsigned int)slave_id);
+		return;
+	}
+	if (ibir & IBIR_ERROR) {
+		LOG_ERR("%s: Data overflow", dev->name);
+		return;
+	}
+
+	if (i3c_ibi_work_enqueue_controller_request(desc) != 0) {
+		LOG_ERR("%s: Error enqueue IBI IRQ work", dev->name);
+	}
+}
+
 static void cdns_i3c_handle_hj(const struct device *dev, uint32_t ibir)
 {
 	if (!(IBIR_ACKED & ibir)) {
@@ -2447,6 +2571,7 @@ static void cdns_i3c_handle_hj(const struct device *dev, uint32_t ibir)
 		return;
 	}
 
+	/* TODO: disable CTRL_HJ_DISEC and process auto-ENTDAA*/
 	if (i3c_ibi_work_enqueue_hotjoin(dev) != 0) {
 		LOG_ERR("%s: Error enqueue IBI HJ work", dev->name);
 	}
@@ -2468,7 +2593,7 @@ static void cnds_i3c_master_demux_ibis(const struct device *dev)
 			cdns_i3c_handle_hj(dev, ibir);
 			break;
 		case IBIR_TYPE_MR:
-			/* not implemented */
+			cdns_i3c_handle_cr(dev, ibir);
 			break;
 		default:
 			break;
@@ -2481,6 +2606,13 @@ static void cdns_i3c_target_ibi_hj_complete(const struct device *dev)
 	struct cdns_i3c_data *data = dev->data;
 
 	k_sem_give(&data->ibi_hj_complete);
+}
+
+static void cdns_i3c_target_ibi_cr_complete(const struct device *dev)
+{
+	struct cdns_i3c_data *data = dev->data;
+
+	k_sem_give(&data->ibi_cr_complete);
 }
 #endif
 
@@ -2542,235 +2674,238 @@ static void cdns_i3c_irq_handler(const struct device *dev)
 {
 	const struct cdns_i3c_config *config = dev->config;
 	struct cdns_i3c_data *data = dev->data;
+	uint32_t int_st = sys_read32(config->base + MST_ISR);
 
-	if (sys_read32(config->base + MST_STATUS0) & MST_STATUS0_MASTER_MODE) {
-		uint32_t int_st = sys_read32(config->base + MST_ISR);
-		sys_write32(int_st, config->base + MST_ICR);
+	sys_write32(int_st, config->base + MST_ICR);
 
-		/* Command queue empty */
-		if (int_st & MST_INT_HALTED) {
-			LOG_WRN("Core Halted, 2 read aborts");
-		}
+	/* Command queue empty */
+	if (int_st & MST_INT_HALTED) {
+		LOG_WRN("Core Halted, 2 read aborts");
+	}
 
-		/* Command queue empty */
-		if (int_st & MST_INT_CMDD_EMP) {
-			cdns_i3c_complete_transfer(dev);
-		}
+	/* Command queue empty */
+	if (int_st & MST_INT_CMDD_EMP) {
+		cdns_i3c_complete_transfer(dev);
+	}
 
-		/* In-band interrupt */
-		if (int_st & MST_INT_IBIR_THR) {
+	/* In-band interrupt */
+	if (int_st & MST_INT_IBIR_THR) {
 #ifdef CONFIG_I3C_USE_IBI
-			cnds_i3c_master_demux_ibis(dev);
+		cnds_i3c_master_demux_ibis(dev);
 #else
-			LOG_ERR("%s: IBI received - Kconfig for using IBIs is not enabled",
-				dev->name);
+		LOG_ERR("%s: IBI received - Kconfig for using IBIs is not enabled", dev->name);
 #endif
-		}
+	}
 
-		/* In-band interrupt data threshold */
-		if (int_st & MST_INT_IBID_THR) {
+	/* In-band interrupt data threshold */
+	if (int_st & MST_INT_IBID_THR) {
 #ifdef CONFIG_I3C_USE_IBI
-			/* pop data out of the IBI FIFO */
-			while (!cdns_i3c_ibi_fifo_empty(config)) {
-				uint32_t *ptr = (uint32_t *)&data->ibi_buf
-							.ibi_data[data->ibi_buf.ibi_data_cnt];
-				*ptr = sys_le32_to_cpu(sys_read32(config->base + IBI_DATA_FIFO));
-				data->ibi_buf.ibi_data_cnt += 4;
+		/* pop data out of the IBI FIFO */
+		while (!cdns_i3c_ibi_fifo_empty(config)) {
+			uint32_t *ptr =
+				(uint32_t *)&data->ibi_buf.ibi_data[data->ibi_buf.ibi_data_cnt];
+			*ptr = sys_le32_to_cpu(sys_read32(config->base + IBI_DATA_FIFO));
+			data->ibi_buf.ibi_data_cnt += 4;
+		}
+#else
+		LOG_ERR("%s: IBI received - Kconfig for using IBIs is not enabled", dev->name);
+#endif
+	}
+
+	/* In-band interrupt response overflow */
+	if (int_st & MST_INT_IBIR_OVF) {
+		LOG_ERR("%s: controller ibir overflow,", dev->name);
+	}
+
+	/* In-band interrupt data */
+	if (int_st & MST_INT_TX_OVF) {
+		LOG_ERR("%s: controller tx buffer overflow,", dev->name);
+	}
+
+	/* In-band interrupt data */
+	if (int_st & MST_INT_RX_UNF) {
+		LOG_ERR("%s: controller rx buffer underflow,", dev->name);
+	}
+
+	if (int_st & MST_INT_MR_DONE) {
+		LOG_DBG("%s: controller CR Handoff done,", dev->name);
+		k_sem_give(&data->ch_complete);
+	}
+
+	uint32_t int_sl = sys_read32(config->base + SLV_ISR);
+	const struct i3c_target_callbacks *target_cb =
+		data->target_config ? data->target_config->callbacks : NULL;
+	/* Clear interrupts */
+	sys_write32(int_sl, config->base + SLV_ICR);
+
+	/* SLV SDR rx fifo threshold */
+	if (int_sl & SLV_INT_SDR_RX_THR) {
+		/* while rx fifo is not empty */
+		while (!(sys_read32(config->base + SLV_STATUS1) & SLV_STATUS1_SDR_RX_EMPTY)) {
+			if (target_cb != NULL && target_cb->write_received_cb != NULL) {
+				cdns_i3c_target_read_rx_fifo(dev);
 			}
-#else
-			LOG_ERR("%s: IBI received - Kconfig for using IBIs is not enabled",
-				dev->name);
+		}
+	}
+
+	/* SLV SDR tx fifo threshold */
+	if (int_sl & SLV_INT_SDR_TX_THR) {
+		cdns_i3c_target_sdr_tx_thr_int_handler(dev, target_cb);
+	}
+
+	/* SLV SDR rx complete */
+	if (int_sl & SLV_INT_SDR_RD_COMP) {
+		/* a read needs to be done on slv_status 0 else a NACK will happen */
+		(void)sys_read32(config->base + SLV_STATUS0);
+		/* call stop function pointer */
+		if (target_cb != NULL && target_cb->stop_cb) {
+			target_cb->stop_cb(data->target_config);
+		}
+	}
+
+	/* SLV SDR tx complete */
+	if (int_sl & SLV_INT_SDR_WR_COMP) {
+		/* a read needs to be done on slv_status 0 else a NACK will happen */
+		(void)sys_read32(config->base + SLV_STATUS0);
+		/* clear bytes read parameter */
+		data->fifo_bytes_read = 0;
+		/* call stop function pointer */
+		if (target_cb != NULL && target_cb->stop_cb) {
+			target_cb->stop_cb(data->target_config);
+		}
+	}
+
+	/* DA has been updated */
+	if (int_sl & SLV_INT_DA_UPD) {
+		LOG_INF("%s: DA updated to 0x%02lx", dev->name,
+			SLV_STATUS1_DA(sys_read32(config->base + SLV_STATUS1)));
+#ifdef CONFIG_I3C_USE_IBI
+		cdns_i3c_target_ibi_hj_complete(dev);
 #endif
-		}
+	}
 
-		/* In-band interrupt response overflow */
-		if (int_st & MST_INT_IBIR_OVF) {
-			LOG_ERR("%s: controller ibir overflow,", dev->name);
-		}
+	/* HJ complete and DA has been assigned or HJ NACK'ed or DISEC disabled HJ */
+	if (int_sl & SLV_INT_HJ_DONE) {
 
-		/* In-band interrupt data */
-		if (int_st & MST_INT_TX_OVF) {
-			LOG_ERR("%s: controller tx buffer overflow,", dev->name);
-		}
+	}
 
-		/* In-band interrupt data */
-		if (int_st & MST_INT_RX_UNF) {
-			LOG_ERR("%s: controller rx buffer underflow,", dev->name);
+	/* Controllership has been been given to us */
+	if (int_sl & SLV_INT_MR_DONE) {
+#ifdef CONFIG_I3C_USE_IBI
+		cdns_i3c_target_ibi_cr_complete(dev);
+		i3c_ibi_work_enqueue_cb(dev, i3c_sec_handoffed);
+		if (target_cb != NULL && target_cb->controller_handoff_cb) {
+			target_cb->controller_handoff_cb(data->target_config);
 		}
-	} else {
-		uint32_t int_sl = sys_read32(config->base + SLV_ISR);
-		const struct i3c_target_callbacks *target_cb =
-			data->target_config ? data->target_config->callbacks : NULL;
-		/* Clear interrupts */
-		sys_write32(int_sl, config->base + SLV_ICR);
+#endif
+	}
 
-		/* SLV SDR rx fifo threshold */
-		if (int_sl & SLV_INT_SDR_RX_THR) {
-			/* while rx fifo is not empty */
-			while (!(sys_read32(config->base + SLV_STATUS1) &
-				 SLV_STATUS1_SDR_RX_EMPTY)) {
+	/* EISC or DISEC has been received */
+	if (int_sl & SLV_INT_EVENT_UP) {
+	}
+
+	/* sdr transfer aborted by controller */
+	if (int_sl & SLV_INT_M_RD_ABORT) {
+		/* TODO: consider flushing tx buffer? */
+	}
+
+	/* SLV SDR rx fifo underflow */
+	if (int_sl & SLV_INT_SDR_RX_UNF) {
+		LOG_ERR("%s: slave sdr rx buffer underflow", dev->name);
+	}
+
+	/* SLV SDR tx fifo overflow */
+	if (int_sl & SLV_INT_SDR_TX_OVF) {
+		LOG_ERR("%s: slave sdr tx buffer overflow,", dev->name);
+	}
+
+	if (int_sl & SLV_INT_DDR_RX_THR) {
+	}
+
+	/* SLV DDR WR COMPLETE */
+	if (int_sl & SLV_INT_DDR_WR_COMP) {
+		/* initial value of CRC5 for HDR-DDR is 0x1F */
+		uint8_t crc5 = 0x1F;
+
+		while (!(sys_read32(config->base + SLV_STATUS1) & SLV_STATUS1_DDR_RX_EMPTY)) {
+			uint32_t ddr_rx_data = sys_read32(config->base + SLV_DDR_RX_FIFO);
+			uint32_t preamble = (ddr_rx_data & DDR_PREAMBLE_MASK);
+
+			if (preamble == DDR_PREAMBLE_DATA_ABORT ||
+			    preamble == DDR_PREAMBLE_DATA_ABORT_ALT) {
+				uint16_t ddr_payload = DDR_DATA(ddr_rx_data);
+
+				if (cdns_i3c_ddr_parity(ddr_payload) !=
+				    (ddr_rx_data & (DDR_ODD_PARITY | DDR_EVEN_PARITY))) {
+					LOG_ERR("%s: Received incorrect DDR Parity", dev->name);
+				}
+				/* calculate a running a crc */
+				crc5 = i3c_cdns_crc5(crc5, ddr_payload);
+
 				if (target_cb != NULL && target_cb->write_received_cb != NULL) {
-					cdns_i3c_target_read_rx_fifo(dev);
+					/* DDR receives 2B for each payload */
+					target_cb->write_received_cb(
+						data->target_config,
+						(uint8_t)((ddr_payload >> 8) & 0xFF));
+					target_cb->write_received_cb(data->target_config,
+								     (uint8_t)(ddr_payload));
+				}
+
+			} else if ((preamble == DDR_PREAMBLE_CMD_CRC) &&
+				   ((ddr_rx_data & DDR_CRC_TOKEN_MASK) == DDR_CRC_TOKEN)) {
+				/* should come through here last */
+				if (crc5 != DDR_CRC(ddr_rx_data)) {
+					LOG_ERR("%s: Received incorrect DDR CRC5", dev->name);
+				}
+			} else if (preamble == DDR_PREAMBLE_CMD_CRC) {
+				/* should come through here first */
+				uint16_t ddr_header_payload = DDR_DATA(ddr_rx_data);
+
+				crc5 = i3c_cdns_crc5(crc5, ddr_header_payload);
+			}
+		}
+
+		if (target_cb != NULL && target_cb->stop_cb != NULL) {
+			target_cb->stop_cb(data->target_config);
+		}
+	}
+
+	/* SLV SDR rx complete */
+	if (int_sl & SLV_INT_DDR_RD_COMP) {
+		/* a read needs to be done on slv_status 0 else a NACK will happen */
+		(void)sys_read32(config->base + SLV_STATUS0);
+		/* call stop function pointer */
+		if (target_cb != NULL && target_cb->stop_cb) {
+			target_cb->stop_cb(data->target_config);
+		}
+	}
+
+	/* SLV DDR TX THR */
+	if (int_sl & SLV_INT_DDR_TX_THR) {
+		int status = 0;
+
+		if (target_cb != NULL && target_cb->read_processed_cb) {
+
+			while ((!(sys_read32(config->base + SLV_STATUS1) &
+				  SLV_STATUS1_DDR_TX_FULL)) &&
+			       (status == 0)) {
+				/* call function pointer for read */
+				uint8_t byte;
+				/* will return negative if no data left to transmit
+				 * and 0 if data available
+				 */
+				status = target_cb->read_processed_cb(data->target_config, &byte);
+				if (status == 0) {
+					cdns_i3c_write_ddr_tx_fifo(config, &byte, sizeof(byte));
 				}
 			}
 		}
+	}
 
-		/* SLV SDR tx fifo threshold */
-		if (int_sl & SLV_INT_SDR_TX_THR) {
-			cdns_i3c_target_sdr_tx_thr_int_handler(dev, target_cb);
-		}
-
-		/* SLV SDR rx complete */
-		if (int_sl & SLV_INT_SDR_RD_COMP) {
-			/* a read needs to be done on slv_status 0 else a NACK will happen */
-			(void)sys_read32(config->base + SLV_STATUS0);
-			/* call stop function pointer */
-			if (target_cb != NULL && target_cb->stop_cb) {
-				target_cb->stop_cb(data->target_config);
-			}
-		}
-
-		/* SLV SDR tx complete */
-		if (int_sl & SLV_INT_SDR_WR_COMP) {
-			/* a read needs to be done on slv_status 0 else a NACK will happen */
-			(void)sys_read32(config->base + SLV_STATUS0);
-			/* clear bytes read parameter */
-			data->fifo_bytes_read = 0;
-			/* call stop function pointer */
-			if (target_cb != NULL && target_cb->stop_cb) {
-				target_cb->stop_cb(data->target_config);
-			}
-		}
-
-		/* DA has been updated */
-		if (int_sl & SLV_INT_DA_UPD) {
-			LOG_INF("%s: DA updated to 0x%02lx", dev->name,
-				SLV_STATUS1_DA(sys_read32(config->base + SLV_STATUS1)));
-			/* HJ could send a DISEC which would trigger the SLV_INT_EVENT_UP bit,
-			 * but it's still expected to eventually send a DAA
-			 */
-#ifdef CONFIG_I3C_USE_IBI
-			cdns_i3c_target_ibi_hj_complete(dev);
-#endif
-		}
-
-		/* HJ complete and DA has been assigned */
-		if (int_sl & SLV_INT_HJ_DONE) {
-		}
-
-		/* Controllership has been been given */
-		if (int_sl & SLV_INT_MR_DONE) {
-			/* TODO: implement support for controllership handoff */
-		}
-
-		/* EISC or DISEC has been received */
-		if (int_sl & SLV_INT_EVENT_UP) {
-		}
-
-		/* sdr transfer aborted by controller */
-		if (int_sl & SLV_INT_M_RD_ABORT) {
-			/* TODO: consider flushing tx buffer? */
-		}
-
-		/* SLV SDR rx fifo underflow */
-		if (int_sl & SLV_INT_SDR_RX_UNF) {
-			LOG_ERR("%s: slave sdr rx buffer underflow", dev->name);
-		}
-
-		/* SLV SDR tx fifo overflow */
-		if (int_sl & SLV_INT_SDR_TX_OVF) {
-			LOG_ERR("%s: slave sdr tx buffer overflow,", dev->name);
-		}
-
-		if (int_sl & SLV_INT_DDR_RX_THR) {
-		}
-
-		/* SLV DDR WR COMPLETE */
-		if (int_sl & SLV_INT_DDR_WR_COMP) {
-			/* initial value of CRC5 for HDR-DDR is 0x1F */
-			uint8_t crc5 = 0x1F;
-
-			while (!(sys_read32(config->base + SLV_STATUS1) &
-				 SLV_STATUS1_DDR_RX_EMPTY)) {
-				uint32_t ddr_rx_data = sys_read32(config->base + SLV_DDR_RX_FIFO);
-				uint32_t preamble = (ddr_rx_data & DDR_PREAMBLE_MASK);
-
-				if (preamble == DDR_PREAMBLE_DATA_ABORT ||
-				    preamble == DDR_PREAMBLE_DATA_ABORT_ALT) {
-					uint16_t ddr_payload = DDR_DATA(ddr_rx_data);
-
-					if (cdns_i3c_ddr_parity(ddr_payload) !=
-					    (ddr_rx_data & (DDR_ODD_PARITY | DDR_EVEN_PARITY))) {
-						LOG_ERR("%s: Received incorrect DDR Parity",
-							dev->name);
-					}
-					/* calculate a running a crc */
-					crc5 = i3c_cdns_crc5(crc5, ddr_payload);
-
-					if (target_cb != NULL &&
-					    target_cb->write_received_cb != NULL) {
-						/* DDR receives 2B for each payload */
-						target_cb->write_received_cb(
-							data->target_config,
-							(uint8_t)((ddr_payload >> 8) & 0xFF));
-						target_cb->write_received_cb(
-							data->target_config,
-							(uint8_t)(ddr_payload));
-					}
-
-				} else if ((preamble == DDR_PREAMBLE_CMD_CRC) &&
-					   ((ddr_rx_data & DDR_CRC_TOKEN_MASK) == DDR_CRC_TOKEN)) {
-					/* should come through here last */
-					if (crc5 != DDR_CRC(ddr_rx_data)) {
-						LOG_ERR("%s: Received incorrect DDR CRC5",
-							dev->name);
-					}
-				} else if (preamble == DDR_PREAMBLE_CMD_CRC) {
-					/* should come through here first */
-					uint16_t ddr_header_payload = DDR_DATA(ddr_rx_data);
-
-					crc5 = i3c_cdns_crc5(crc5, ddr_header_payload);
-				}
-			}
-
-			if (target_cb != NULL && target_cb->stop_cb != NULL) {
-				target_cb->stop_cb(data->target_config);
-			}
-		}
-
-		/* SLV SDR rx complete */
-		if (int_sl & SLV_INT_DDR_RD_COMP) {
-			/* a read needs to be done on slv_status 0 else a NACK will happen */
-			(void)sys_read32(config->base + SLV_STATUS0);
-			/* call stop function pointer */
-			if (target_cb != NULL && target_cb->stop_cb) {
-				target_cb->stop_cb(data->target_config);
-			}
-		}
-
-		/*SLV DDR TX THR*/
-		if (int_sl & SLV_INT_DDR_TX_THR) {
-			int status = 0;
-
-			if (target_cb != NULL && target_cb->read_processed_cb) {
-
-				while ((!(sys_read32(config->base + SLV_STATUS1) &
-					  SLV_STATUS1_DDR_TX_FULL)) &&
-				       (status == 0)) {
-					/* call function pointer for read */
-					uint8_t byte;
-					/* will return negative if no data left to transmit
-					 * and 0 if data available
-					 */
-					status = target_cb->read_processed_cb(data->target_config,
-									      &byte);
-					if (status == 0) {
-						cdns_i3c_write_ddr_tx_fifo(config, &byte,
-									   sizeof(byte));
-					}
-				}
-			}
-		}
+	/* DEFTGTS */
+	if (int_sl & SLV_INT_DEFSLVS) {
+		/* Execute outside of the ISR context */
+		k_work_submit(&data->deftgts_work);
 	}
 }
 
@@ -2845,18 +2980,50 @@ static void cdns_i3c_read_hw_cfg(const struct device *dev)
  */
 static int cdns_i3c_config_get(const struct device *dev, enum i3c_config_type type, void *config)
 {
+	const struct cdns_i3c_config *dev_config = dev->config;
 	struct cdns_i3c_data *data = dev->data;
-	int ret = 0;
 
-	if (config == NULL) {
-		ret = -EINVAL;
-		goto out_configure;
+	__ASSERT_NO_MSG(config != NULL);
+
+	if (type == I3C_CONFIG_CONTROLLER) {
+		(void)memcpy(config, &data->common.ctrl_config, sizeof(data->common.ctrl_config));
+	} else if (type == I3C_CONFIG_TARGET) {
+		struct i3c_config_target *target_config = (struct i3c_config_target *)config;
+		/* Read RR_0 registers for itself */
+		uint32_t dev_id_rr0 = sys_read32(dev_config->base + DEV_ID_RR0(0));
+		uint32_t dev_id_rr1 = sys_read32(dev_config->base + DEV_ID_RR1(0));
+		uint32_t dev_id_rr2 = sys_read32(dev_config->base + DEV_ID_RR2(0));
+		uint32_t slv_status1 = sys_read32(dev_config->base + SLV_STATUS1);
+
+		/* if we are currently a target */
+		target_config->enable =
+			!!!(sys_read32(dev_config->base + MST_STATUS0) & MST_STATUS0_MASTER_MODE);
+		if (data->common.ctrl_config.is_secondary) {
+			target_config->dynamic_addr = SLV_STATUS1_DA(slv_status1);
+		} else {
+			target_config->dynamic_addr = (dev_id_rr0 & 0xFE) >> 1;
+		}
+		target_config->static_addr = 0;
+		target_config->pid = ((uint64_t)dev_id_rr1 << 16) + (dev_id_rr2 >> 16);
+		target_config->pid_random = !!(slv_status1 & SLV_STATUS1_VEN_TM);
+		target_config->bcr = dev_id_rr2 >> 8;
+		target_config->dcr = dev_id_rr2 & 0xFF;
+		/* Version 1p7 supports reading MRL/MWL */
+		if (REV_ID_REV(data->hw_cfg.rev_id) >= REV_ID_VERSION(1, 7)) {
+			target_config->max_read_len =
+				SLV_STATUS2_MRL(sys_read32(dev_config->base + SLV_STATUS2));
+			target_config->max_write_len =
+				SLV_STATUS3_MWL(sys_read32(dev_config->base + SLV_STATUS3));
+		} else {
+			target_config->max_read_len = 0;
+			target_config->max_write_len = 0;
+		}
+		target_config->supported_hdr = data->common.ctrl_config.supported_hdr;
+	} else {
+		return -EINVAL;
 	}
 
-	(void)memcpy(config, &data->common.ctrl_config, sizeof(data->common.ctrl_config));
-
-out_configure:
-	return ret;
+	return 0;
 }
 
 static int cdns_i3c_target_tx_ddr_write(const struct device *dev, uint8_t *buf, uint16_t len)
@@ -3115,6 +3282,31 @@ static int cdns_i3c_i2c_api_transfer(const struct device *dev, struct i2c_msg *m
 }
 
 /**
+ * ACK or NACK Controller Handoffs
+ *
+ * Reads the LVR of all I2C devices and returns the I3C bus
+ * Mode
+ *
+ * @param dev Pointer to device driver instance.
+ * @param accept True to accept controller handoffs, False to decline
+ *
+ * @return @see i3c_target_controller_handoff
+ */
+static int cdns_i3c_target_controller_handoff(const struct device *dev, bool accept)
+{
+	const struct cdns_i3c_config *config = dev->config;
+	uint32_t ctrl = sys_read32(config->base + CTRL);
+
+	if (accept) {
+		sys_write32(ctrl | CTRL_MST_ACK, config->base + CTRL);
+	} else {
+		sys_write32(ctrl & ~CTRL_MST_ACK, config->base + CTRL);
+	}
+
+	return 0;
+}
+
+/**
  * Determine I3C bus mode from the i2c devices on the bus
  *
  * Reads the LVR of all I2C devices and returns the I3C bus
@@ -3176,6 +3368,84 @@ static uint8_t cdns_i3c_sda_data_hold(const struct device *dev)
 	return (THD_DELAY_MAX - thd_delay);
 }
 
+static void i3c_cdns_deftgts_work_fn(struct k_work *work)
+{
+	const struct cdns_i3c_config *config;
+	struct cdns_i3c_data *data;
+	struct i3c_ccc_deftgts *deftgts;
+	const struct device *dev;
+	uint32_t devs;
+	uint8_t n = 0;
+
+	data = CONTAINER_OF(work, struct cdns_i3c_data, deftgts_work);
+	dev = data->dev;
+	config = dev->config;
+	data = dev->data;
+	deftgts = data->common.deftgts;
+
+	/* Allocate memory for deftgts if not already */
+	if (!deftgts) {
+		deftgts =
+			malloc(sizeof(uint8_t) + sizeof(struct i3c_ccc_deftgts_active_controller) +
+			       (data->max_devs * sizeof(struct i3c_ccc_deftgts_target)));
+		if (!deftgts) {
+			LOG_ERR("%s: Failed to allocate memory for DEFTGTS", dev->name);
+			return;
+		}
+	}
+
+	devs = sys_read32(config->base + DEVS_CTRL) & DEVS_CTRL_DEVS_ACTIVE_MASK;
+	data->free_rr_slots = GENMASK(data->max_devs, 1) & ~devs;
+
+	/*
+	 * count the number of ones in devs, The IP will 'skip' writing it self to the RR if
+	 * it was in DEFTGTS. Also, if the IP never had a DA, then the deftgts interrupt will
+	 * never fire. Subtract 1 as the active controller is not included in `count`.
+	 */
+	deftgts->count = POPCOUNT(devs) - 1;
+
+	for (uint8_t i = find_lsb_set(devs); i <= find_msb_set(devs); i++) {
+		uint8_t rr_idx = i - 1;
+
+		if (devs & BIT(rr_idx)) {
+			/* Read RRx registers */
+			uint32_t dev_id_rr0 = sys_read32(config->base + DEV_ID_RR0(rr_idx));
+			uint32_t dev_id_rr2 = sys_read32(config->base + DEV_ID_RR2(rr_idx));
+
+			uint8_t addr = (dev_id_rr0 & 0xFE) >> 1;
+			uint8_t bcr = dev_id_rr2 >> 8;
+			uint8_t dcr_lvr = dev_id_rr2 & 0xFF;
+			bool is_i3c = !!(dev_id_rr0 & DEV_ID_RR0_IS_I3C);
+
+
+			/* RR IDX 1 should always be expected to be the AC */
+			if (rr_idx == 1) {
+				deftgts->active_controller.addr = addr;
+				deftgts->active_controller.dcr = dcr_lvr;
+				deftgts->active_controller.bcr = bcr;
+				deftgts->active_controller.static_addr = 0;
+			} else if (is_i3c) {
+				deftgts->targets[n].addr = addr;
+				deftgts->targets[n].dcr = dcr_lvr;
+				deftgts->targets[n].bcr = bcr;
+				deftgts->targets[n].static_addr = 0;
+				n++;
+			} else {
+				deftgts->targets[n].addr = 0;
+				deftgts->targets[n].lvr = dcr_lvr;
+				deftgts->targets[n].bcr = 0;
+				deftgts->targets[n].static_addr = addr;
+				n++;
+			}
+		}
+	}
+	data->common.deftgts_refreshed = true;
+	LOG_HEXDUMP_DBG((uint8_t *)deftgts,
+			sizeof(uint8_t) + sizeof(struct i3c_ccc_deftgts_active_controller) +
+				(deftgts->count * sizeof(struct i3c_ccc_deftgts_target)),
+			"DEFTGTS Received");
+}
+
 /**
  * @brief Initialize the hardware.
  *
@@ -3186,6 +3456,8 @@ static int cdns_i3c_bus_init(const struct device *dev)
 	struct cdns_i3c_data *data = dev->data;
 	const struct cdns_i3c_config *config = dev->config;
 	struct i3c_config_controller *ctrl_config = &data->common.ctrl_config;
+
+	data->dev = dev;
 
 	cdns_i3c_read_hw_cfg(dev);
 
@@ -3211,7 +3483,12 @@ static int cdns_i3c_bus_init(const struct device *dev)
 	}
 	k_mutex_init(&data->bus_lock);
 	k_sem_init(&data->xfer.complete, 0, 1);
+	k_sem_init(&data->ch_complete, 0, 1);
+	k_work_init(&data->deftgts_work, i3c_cdns_deftgts_work_fn);
+#ifdef CONFIG_I3C_USE_IBI
 	k_sem_init(&data->ibi_hj_complete, 0, 1);
+	k_sem_init(&data->ibi_cr_complete, 0, 1);
+#endif
 
 	cdns_i3c_interrupts_disable(config);
 	cdns_i3c_interrupts_clear(config);
@@ -3251,9 +3528,8 @@ static int cdns_i3c_bus_init(const struct device *dev)
 	 *
 	 * Set the I3C Bus Mode based on the LVR of the I2C devices
 	 */
-	uint32_t ctrl = CTRL_HJ_DISEC | CTRL_MCS_EN | (CTRL_BUS_MODE_MASK & cdns_mode);
-	/* Disable Controllership requests as it is not supported yet by the driver */
-	ctrl &= ~CTRL_MST_ACK;
+	uint32_t ctrl =
+		CTRL_HJ_DISEC | CTRL_MCS_EN | CTRL_MST_ACK | (CTRL_BUS_MODE_MASK & cdns_mode);
 
 	/*
 	 * Cadence I3C release r104v1p0 and above support configuration of the sda data hold time
@@ -3295,13 +3571,14 @@ static int cdns_i3c_bus_init(const struct device *dev)
 	/* enable target interrupts */
 	sys_write32(SLV_INT_DA_UPD | SLV_INT_SDR_RD_COMP | SLV_INT_SDR_WR_COMP |
 			    SLV_INT_SDR_RX_THR | SLV_INT_SDR_TX_THR | SLV_INT_SDR_RX_UNF |
-			    SLV_INT_SDR_TX_OVF | SLV_INT_HJ_DONE | SLV_INT_DDR_WR_COMP |
-			    SLV_INT_DDR_RD_COMP | SLV_INT_DDR_RX_THR | SLV_INT_DDR_TX_THR,
+			    SLV_INT_SDR_TX_OVF | SLV_INT_HJ_DONE | SLV_INT_MR_DONE |
+			    SLV_INT_DEFSLVS | SLV_INT_DDR_WR_COMP | SLV_INT_DDR_RD_COMP |
+			    SLV_INT_DDR_RX_THR | SLV_INT_DDR_TX_THR,
 		    config->base + SLV_IER);
 
-	/* Enable IBI interrupts. */
-	sys_write32(MST_INT_IBIR_THR | MST_INT_RX_UNF | MST_INT_HALTED | MST_INT_TX_OVF |
-			    MST_INT_IBIR_OVF | MST_INT_IBID_THR,
+	/* Enable controller interrupts. */
+	sys_write32(MST_INT_IBIR_THR | MST_INT_RX_UNF | MST_INT_HALTED | MST_INT_MR_DONE |
+			    MST_INT_TX_OVF | MST_INT_IBIR_OVF | MST_INT_IBID_THR,
 		    config->base + MST_IER);
 
 	int ret = i3c_addr_slots_init(dev);
@@ -3310,11 +3587,10 @@ static int cdns_i3c_bus_init(const struct device *dev)
 		return ret;
 	}
 
-	/* Program retaining regs. */
-	cdns_i3c_program_controller_retaining_reg(dev);
-
 	/* only primary controllers are responsible for initializing the bus */
 	if (!ctrl_config->is_secondary) {
+		/* Program retaining regs. */
+		cdns_i3c_program_controller_retaining_reg(dev);
 		/* Sleep to wait for bus idle. */
 		k_busy_wait(201);
 		/* Perform bus initialization */
@@ -3354,6 +3630,7 @@ static DEVICE_API(i3c, api) = {
 	.target_tx_write = cdns_i3c_target_tx_write,
 	.target_register = cdns_i3c_target_register,
 	.target_unregister = cdns_i3c_target_unregister,
+	.target_controller_handoff = cdns_i3c_target_controller_handoff,
 
 #ifdef CONFIG_I3C_USE_IBI
 	.ibi_hj_response = cdns_i3c_ibi_hj_response,

--- a/drivers/i3c/i3c_common.c
+++ b/drivers/i3c/i3c_common.c
@@ -450,6 +450,124 @@ err:
 	return ret;
 }
 
+uint8_t i3c_odd_parity(uint8_t p)
+{
+	p ^= p >> 4;
+	p &= 0xf;
+	return (0x9669 >> p) & 1;
+}
+
+int i3c_device_controller_handoff(const struct i3c_device_desc *target, bool requested)
+{
+	int ret;
+	union i3c_ccc_getstatus status = {0};
+	struct i3c_ccc_events i3c_events;
+	struct i3c_ccc_address handoff_address;
+
+	/*
+	 * If the Active Controller intends to pass the Controller Role to a selected Secondary
+	 * Controller that did not send a Controller Role Request, then the Active Controller should
+	 * verify that the selected Secondary Controller is active and ready to respond to
+	 * additional commands
+	 */
+	if (!requested) {
+		ret = i3c_ccc_do_getstatus_fmt1(target, &status);
+		if (ret != 0) {
+			return ret;
+		}
+
+		if (I3C_CCC_GETSTATUS_ACTIVITY_MODE(status.fmt1.status) ==
+		    I3C_CCC_GETSTATUS_ACTIVITY_MODE_NCH) {
+			return -EBUSY;
+		}
+	}
+
+	/*
+	 * The Active Controller needs to disable Hot-Joins, Target Interrupt Requests, and other
+	 * Bus events that could interfere with the Handoff, then it sends the appropriate
+	 * Broadcast to disable those events before the Handoff. Once the Handoff is complete, the
+	 * new Active Controller should re-enable events that are disabled in this step.
+	 */
+	i3c_events.events = I3C_CCC_EVT_ALL;
+	ret = i3c_ccc_do_events_all_set(target->bus, false, &i3c_events);
+	if (ret != 0) {
+		return ret;
+	}
+
+	/** TODO: reconfigure MLANE if needed */
+
+	/*
+	 * If the Active Controller knows that the selected Secondary Controller must be put into a
+	 * different Activity State before Handoff, then the Active Controller shall send the
+	 * appropriate Broadcast or Direct CCCs to put the Bus (or selected Devices) into a
+	 * different Activity State
+	 */
+	if (target->crhdly1 & I3C_CCC_GETMXDS_CRDHLY1_SET_BUS_ACT_STATE) {
+		ret = i3c_ccc_do_entas(
+			target, I3C_CCC_GETMXDS_CRDHLY1_CTRL_HANDOFF_ACT_STATE(target->crhdly1));
+		if (ret != 0) {
+			return ret;
+		}
+	}
+
+	if ((target->getcaps.getcap3 & I3C_CCC_GETCAPS3_GETSTATUS_DEFINING_BYTE_SUPPORT) &&
+	    (target->crcaps.crcaps2 & I3C_CCC_GETCAPS_CRCAPS2_DEEP_SLEEP_CAPABLE)) {
+		ret = i3c_ccc_do_getstatus_fmt2(target, &status, GETSTATUS_FORMAT_2_PRECR);
+		if (ret != 0) {
+			return ret;
+		}
+
+		/*
+		 * If the Active Controller determines that the indicated Secondary Controller has
+		 * been in a “deep sleep” state and may need to be re-synchronized with the most
+		 * current list of I3C Targets and Group Addresses, then the Active Controller
+		 * should send CCC DEFTGTS and DEFGRPA
+		 */
+		if (status.fmt2.precr & I3C_CCC_GETSTATUS_PRECR_DEEP_SLEEP_DETECTED) {
+			ret = i3c_bus_deftgts(target->bus);
+			if (ret != 0) {
+				return ret;
+			}
+			/* TODO: broadcast DEFGRPA when group address support comes */
+
+			/* Check CRCAPS if the device needs additional time to process */
+			if (target->crcaps.crcaps2 &
+			    I3C_CCC_GETCAPS_CRCAPS2_DELAYED_CONTROLLER_HANDOFF) {
+				/*
+				 * Afterwards, the Active Controller should poll the Secondary
+				 * Controller to ensure that it has successfully processed this data
+				 * and indicates that it is ready to accept the Controller Role
+				 */
+				do {
+					ret = i3c_ccc_do_getstatus_fmt2(target, &status,
+									GETSTATUS_FORMAT_2_PRECR);
+					if (ret != 0) {
+						return ret;
+					}
+				} while (!(status.fmt2.precr &
+					   I3C_CCC_GETSTATUS_PRECR_HANDOFF_DELAY_NACK));
+			}
+		}
+	}
+
+	/*
+	 * After the Active Controller has prepared for Handoff, the Active Controller shall
+	 * then issue a GETACCCR CCC
+	 */
+	ret = i3c_ccc_do_getacccr(target, &handoff_address);
+	if (ret != 0) {
+		return ret;
+	}
+
+	/* Verify Odd Parity and Correct Dynamic Address Reply */
+	if ((i3c_odd_parity(handoff_address.addr >> 1) != (handoff_address.addr & BIT(0))) ||
+	    (handoff_address.addr >> 1 != target->dynamic_addr)) {
+		return -EIO;
+	}
+
+	return ret;
+}
+
 int i3c_device_basic_info_get(struct i3c_device_desc *target)
 {
 	int ret;

--- a/drivers/i3c/i3c_i2c_mem_slab.c
+++ b/drivers/i3c/i3c_i2c_mem_slab.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024 Meta Platforms
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <string.h>
+#include <stdlib.h>
+
+#include <zephyr/drivers/i3c.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(i3c, CONFIG_I3C_LOG_LEVEL);
+
+K_MEM_SLAB_DEFINE(i3c_i2c_device_desc_pool, sizeof(struct i3c_i2c_device_desc),
+	CONFIG_I3C_I2C_NUM_OF_DESC_MEM_SLABS, 4);
+
+struct i3c_i2c_device_desc *i3c_i2c_device_desc_alloc(void)
+{
+	struct i3c_i2c_device_desc *desc;
+
+	if (k_mem_slab_alloc(&i3c_i2c_device_desc_pool, (void **)&desc, K_NO_WAIT) == 0) {
+		memset(desc, 0, sizeof(struct i3c_i2c_device_desc));
+		LOG_INF("I2C Device Desc allocated - %d free",
+			k_mem_slab_num_free_get(&i3c_i2c_device_desc_pool));
+	} else {
+		LOG_WRN("No memory left for I2C descriptors");
+	}
+
+	return desc;
+}
+
+void i3c_i2c_device_desc_free(struct i3c_i2c_device_desc *desc)
+{
+	k_mem_slab_free(&i3c_i2c_device_desc_pool, (void *)desc);
+	LOG_DBG("I2C Device Desc freed");
+}
+
+bool i3c_i2c_device_desc_in_pool(struct i3c_i2c_device_desc *desc)
+{
+	const char *p =  (const char *)desc;
+	ptrdiff_t offset = p - i3c_i2c_device_desc_pool.buffer;
+
+	return (offset >= 0) &&
+	       (offset < (i3c_i2c_device_desc_pool.info.block_size *
+		   i3c_i2c_device_desc_pool.info.num_blocks)) &&
+	       ((offset % i3c_i2c_device_desc_pool.info.block_size) == 0);
+}

--- a/drivers/i3c/i3c_ibi_workq.c
+++ b/drivers/i3c/i3c_ibi_workq.c
@@ -86,6 +86,32 @@ out:
 	return ret;
 }
 
+int i3c_ibi_work_enqueue_controller_request(struct i3c_device_desc *target)
+{
+	sys_snode_t *node;
+	struct i3c_ibi_work *ibi_node;
+	int ret;
+
+	node = sys_slist_get(&i3c_ibi_work_nodes_free);
+	if (node == NULL) {
+		ret = -ENOMEM;
+		goto out;
+	}
+
+	ibi_node = (struct i3c_ibi_work *)node;
+
+	ibi_node->type = I3C_IBI_CONTROLLER_ROLE_REQUEST;
+	ibi_node->target = target;
+
+	ret = ibi_work_submit(ibi_node);
+	if (ret >= 0) {
+		ret = 0;
+	}
+
+out:
+	return ret;
+}
+
 int i3c_ibi_work_enqueue_hotjoin(const struct device *dev)
 {
 	sys_snode_t *node;
@@ -167,9 +193,13 @@ static void i3c_ibi_work_handler(struct k_work *work)
 			payload = NULL;
 		}
 
-		ret = ibi_node->target->ibi_cb(ibi_node->target, payload);
-		if ((ret != 0) && (ret != -EBUSY)) {
-			LOG_ERR("IBI work %p cb returns %d", ibi_node, ret);
+		if (ibi_node->target->ibi_cb) {
+			ret = ibi_node->target->ibi_cb(ibi_node->target, payload);
+			if ((ret != 0) && (ret != -EBUSY)) {
+				LOG_ERR("IBI work %p cb returns %d", ibi_node, ret);
+			}
+		} else {
+			LOG_ERR("No IBI callback for target %s", ibi_node->target->dev->name);
 		}
 		break;
 

--- a/drivers/i3c/i3c_ibi_workq.c
+++ b/drivers/i3c/i3c_ibi_workq.c
@@ -194,8 +194,11 @@ static void i3c_ibi_work_handler(struct k_work *work)
 		break;
 
 	case I3C_IBI_CONTROLLER_ROLE_REQUEST:
-		/* TODO: Add support for controller role request */
-		__fallthrough;
+		ret = i3c_device_controller_handoff(ibi_node->target, true);
+		if (ret != 0) {
+			LOG_ERR("i3c_device_controller_handoff returns %d", ret);
+		}
+		break;
 
 	default:
 		/* Unknown IBI type: do nothing */

--- a/drivers/i3c/i3c_mem_slab.c
+++ b/drivers/i3c/i3c_mem_slab.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024 Meta Platforms
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <string.h>
+#include <stdlib.h>
+
+#include <zephyr/drivers/i3c.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(i3c, CONFIG_I3C_LOG_LEVEL);
+
+/* Generate Names */
+#define UNKNOWN_NAME_STR(i, _)                                                                     \
+	{                                                                                          \
+		.name = "unknown-" STRINGIFY(i)                                                    \
+	}
+const struct device dummy_devs[] = {
+	LISTIFY(CONFIG_I3C_NUM_OF_DESC_MEM_SLABS, UNKNOWN_NAME_STR, (,)) };
+
+K_MEM_SLAB_DEFINE(i3c_device_desc_pool, sizeof(struct i3c_device_desc),
+		  CONFIG_I3C_NUM_OF_DESC_MEM_SLABS, 4);
+
+struct i3c_device_desc *i3c_device_desc_alloc(void)
+{
+	struct i3c_device_desc *desc;
+
+	if (k_mem_slab_alloc(&i3c_device_desc_pool, (void **)&desc, K_NO_WAIT) == 0) {
+		memset(desc, 0, sizeof(struct i3c_device_desc));
+		*(const struct device **)&desc->dev =
+			&dummy_devs[k_mem_slab_num_free_get(&i3c_device_desc_pool)];
+		LOG_DBG("I3C Device Desc allocated - %d free",
+			k_mem_slab_num_free_get(&i3c_device_desc_pool));
+	} else {
+		LOG_WRN("No memory left for I3C descriptors");
+	}
+
+	return desc;
+}
+
+void i3c_device_desc_free(struct i3c_device_desc *desc)
+{
+	k_mem_slab_free(&i3c_device_desc_pool, (void *)desc);
+	LOG_DBG("I3C Device Desc freed");
+}
+
+bool i3c_device_desc_in_pool(struct i3c_device_desc *desc)
+{
+	const char *p = (const char *)desc;
+	ptrdiff_t offset = p - i3c_device_desc_pool.buffer;
+
+	return (offset >= 0) &&
+	       (offset < (i3c_device_desc_pool.info.block_size *
+		   i3c_device_desc_pool.info.num_blocks)) &&
+	       ((offset % i3c_device_desc_pool.info.block_size) == 0);
+}

--- a/drivers/i3c/i3c_shell.c
+++ b/drivers/i3c/i3c_shell.c
@@ -1500,6 +1500,7 @@ static int cmd_i3c_ccc_getcaps(const struct shell *sh, size_t argc, char **argv)
 		} else if (defbyte == GETCAPS_FORMAT_2_CRCAPS) {
 			shell_print(sh, "CRCAPS: 0x%02x; 0x%02x", caps.fmt2.crcaps[0],
 				    caps.fmt2.crcaps[1]);
+			memcpy(&desc->crcaps, &caps, sizeof(desc->crcaps));
 		} else if (defbyte == GETCAPS_FORMAT_2_VTCAPS) {
 			shell_print(sh, "VTCAPS: 0x%02x; 0x%02x", caps.fmt2.vtcaps[0],
 				    caps.fmt2.vtcaps[1]);
@@ -1733,6 +1734,7 @@ static int cmd_i3c_ccc_getmxds(const struct shell *sh, size_t argc, char **argv)
 			desc->data_speed.max_read_turnaround = sys_get_le24(&mxds.fmt3.wrrdturn[2]);
 		} else if (defbyte == GETMXDS_FORMAT_3_CRHDLY) {
 			shell_print(sh, "CRHDLY1: 0x%02x", mxds.fmt3.crhdly1);
+			desc->crhdly1 = mxds.fmt3.crhdly1;
 		}
 	} else {
 		shell_print(sh, "GETMXDS: maxwr 0x%02x; maxrd 0x%02x; maxrdturn 0x%06x",

--- a/drivers/i3c/i3c_shell.c
+++ b/drivers/i3c/i3c_shell.c
@@ -209,7 +209,9 @@ static int cmd_i3c_info(const struct shell *sh, size_t argc, char **argv)
 						    "\tmrl: 0x%04x\n"
 						    "\tmwl: 0x%04x\n"
 						    "\tmax_ibi: 0x%02x\n"
-						    "\tgetcaps: 0x%02x; 0x%02x; 0x%02x; 0x%02x",
+						    "\tcrhdly1: 0x%02x\n"
+						    "\tgetcaps: 0x%02x; 0x%02x; 0x%02x; 0x%02x\n"
+						    "\tcrcaps: 0x%02x; 0x%02x",
 						    desc->dev->name, (uint64_t)desc->pid,
 						    desc->static_addr, desc->dynamic_addr,
 #if defined(CONFIG_I3C_USE_GROUP_ADDR)
@@ -219,9 +221,10 @@ static int cmd_i3c_info(const struct shell *sh, size_t argc, char **argv)
 						    desc->data_speed.maxwr,
 						    desc->data_speed.max_read_turnaround,
 						    desc->data_length.mrl, desc->data_length.mwl,
-						    desc->data_length.max_ibi,
+						    desc->data_length.max_ibi, desc->crhdly1,
 						    desc->getcaps.getcap1, desc->getcaps.getcap2,
-						    desc->getcaps.getcap3, desc->getcaps.getcap4);
+						    desc->getcaps.getcap3, desc->getcaps.getcap4,
+						    desc->crcaps.crcaps1, desc->crcaps.crcaps2);
 					found = true;
 					break;
 				}
@@ -255,7 +258,9 @@ static int cmd_i3c_info(const struct shell *sh, size_t argc, char **argv)
 					    "\tmrl: 0x%04x\n"
 					    "\tmwl: 0x%04x\n"
 					    "\tmax_ibi: 0x%02x\n"
-					    "\tgetcaps: 0x%02x; 0x%02x; 0x%02x; 0x%02x",
+					    "\tcrhdly1: 0x%02x\n"
+					    "\tgetcaps: 0x%02x; 0x%02x; 0x%02x; 0x%02x\n"
+					    "\tcrcaps: 0x%02x; 0x%02x",
 					    desc->dev->name, (uint64_t)desc->pid, desc->static_addr,
 					    desc->dynamic_addr,
 #if defined(CONFIG_I3C_USE_GROUP_ADDR)
@@ -265,9 +270,10 @@ static int cmd_i3c_info(const struct shell *sh, size_t argc, char **argv)
 					    desc->data_speed.maxwr,
 					    desc->data_speed.max_read_turnaround,
 					    desc->data_length.mrl, desc->data_length.mwl,
-					    desc->data_length.max_ibi, desc->getcaps.getcap1,
-					    desc->getcaps.getcap2, desc->getcaps.getcap3,
-					    desc->getcaps.getcap4);
+					    desc->data_length.max_ibi, desc->crhdly1,
+					    desc->getcaps.getcap1, desc->getcaps.getcap2,
+					    desc->getcaps.getcap3, desc->getcaps.getcap4,
+					    desc->crcaps.crcaps1, desc->crcaps.crcaps2);
 			}
 		} else {
 			shell_print(sh, "I3C: No devices found.");

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -2192,6 +2192,33 @@ bool i3c_bus_has_sec_controller(const struct device *dev);
  */
 int i3c_bus_deftgts(const struct device *dev);
 
+/**
+ * @brief Calculate odd parity
+ *
+ * Calculate the Odd Parity of a Target Address.
+ *
+ * @param p The 7b target dynamic address
+ *
+ * @return The odd parity bit
+ */
+uint8_t i3c_odd_parity(uint8_t p);
+
+/**
+ * @brief Perform Controller Handoff
+ *
+ * This performs the controller handoff according to 5.1.7.1 of
+ * I3C v1.1.1 Specification.
+ *
+ * @param target I3C target device descriptor.
+ * @param requested True if the target requested the Handoff, False if
+ * the active controller is passing it to a secondary controller
+ *
+ * @retval 0 if successful.
+ * @retval -EIO General Input/Output error.
+ * @retval -EBUSY Target cannot accept Controller Handoff
+ */
+int i3c_device_controller_handoff(const struct i3c_device_desc *target, bool requested);
+
 #if defined(CONFIG_I3C_RTIO) || defined(__DOXYGEN__)
 
 struct i3c_iodev_data {

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -810,6 +810,24 @@ __subsystem struct i3c_driver_api {
 	int (*target_tx_write)(const struct device *dev,
 				 uint8_t *buf, uint16_t len, uint8_t hdr_mode);
 
+	/**
+	 * ACK or NACK controller handoffs
+	 *
+	 * This will tell the target to ACK or NACK controller handoffs
+	 * from the CCC GETACCCR
+	 *
+	 * Target device only API.
+	 *
+	 * @see i3c_target_controller_handoff()
+	 *
+	 * @param dev Pointer to the controller device driver instance.
+	 * @param accept True to ACK controller handoffs, False to NACK.
+	 *
+	 * @return See i3c_target_controller_handoff()
+	 */
+	int (*target_controller_handoff)(const struct device *dev,
+				      bool accept);
+
 #ifdef CONFIG_I3C_RTIO
 	/**
 	 * RTIO
@@ -877,7 +895,8 @@ struct i3c_device_desc {
 	const struct device * const dev;
 
 	/** Device Provisioned ID */
-	const uint64_t pid:48;
+	/* TODO: bring back the bitfield */
+	const uint64_t pid;
 
 	/**
 	 * Static address for this target device.
@@ -1184,6 +1203,12 @@ struct i3c_driver_data {
 
 	/** Attached I3C/I2C devices and addresses */
 	struct i3c_dev_attached_list attached_dev;
+
+	/** Received DEFTGTS Pointer */
+	struct i3c_ccc_deftgts *deftgts;
+
+	/** DEFTGTS refreshed */
+	bool deftgts_refreshed;
 };
 
 /**
@@ -2218,6 +2243,125 @@ uint8_t i3c_odd_parity(uint8_t p);
  * @retval -EBUSY Target cannot accept Controller Handoff
  */
 int i3c_device_controller_handoff(const struct i3c_device_desc *target, bool requested);
+
+#ifdef CONFIG_I3C_USE_IBI
+/**
+ * @brief Call back for when Controllership is Handoffed to itself
+ *
+ * This reads the DEFTGTS it received earlier and processes it by reading
+ * the PIDs of all the devices with GETPID and then matching it with known
+ * PIDS. If it does not match, then it will attempt to grab a mem slab
+ * for i3c_device_desc. It will then obtain the standard I3C information
+ * from the device.
+ *
+ * @param work pointer to the work item.
+ */
+void i3c_sec_handoffed(struct k_work *work);
+#endif
+
+#if CONFIG_I3C_NUM_OF_DESC_MEM_SLABS > 0
+
+/**
+ * @brief Allocate memory for a i3c device descriptor
+ *
+ * This allocates memory from a mem slab for a i3c_device_desc
+ *
+ * @retval Pointer to allocated i3c_device_desc
+ * @retval NULL if no mem slabs available
+ */
+struct i3c_device_desc *i3c_device_desc_alloc(void);
+
+/**
+ * @brief Free memory from a i3c device descriptor
+ *
+ * This frees memory from a mem slab of a i3c_device_desc
+ *
+ * @param desc Pointer to allocated i3c_device_desc
+ */
+void i3c_device_desc_free(struct i3c_device_desc *desc);
+
+/**
+ * @brief Report if the i3c device descriptor was from a mem slab
+ *
+ * This reports if the i3c_device_desc was from a memory slab
+ *
+ * @param desc Pointer to a i3c_device_desc
+ *
+ * @return True if from a memory slab, False if not
+ */
+bool i3c_device_desc_in_pool(struct i3c_device_desc *desc);
+
+#else
+
+static inline struct i3c_device_desc *i3c_device_desc_alloc(void)
+{
+	return NULL;
+}
+
+static inline void i3c_device_desc_free(struct i3c_device_desc *desc)
+{
+	ARG_UNUSED(desc);
+}
+
+static inline bool i3c_device_desc_in_pool(struct i3c_device_desc *desc)
+{
+	ARG_UNUSED(desc);
+	return false;
+}
+
+#endif /* CONFIG_I3C_NUM_OF_DESC_MEM_SLABS > 0 */
+
+#if CONFIG_I3C_I2C_NUM_OF_DESC_MEM_SLABS > 0
+
+/**
+ * @brief Allocate memory for a i3c i2c device descriptor
+ *
+ * This allocates memory from a mem slab for a i3c_i2c_device_desc
+ *
+ * @return Pointer to allocated i3c_i2c_device_desc, NULL if none
+ *         available
+ */
+struct i3c_i2c_device_desc *i3c_i2c_device_desc_alloc(void);
+
+/**
+ * @brief Free memory from a i3c i2c device descriptor
+ *
+ * This frees memory from a mem slab of a i3c_i2c_device_desc
+ *
+ * @param desc Pointer to allocated i3c_i2c_device_desc
+ */
+void i3c_i2c_device_desc_free(struct i3c_i2c_device_desc *desc);
+
+/**
+ * @brief Report if the i3c i2c device descriptor was from a mem slab
+ *
+ * This reports if the i3c_i2c_device_desc was from a memory slab
+ *
+ * @param desc Pointer to a i3c_i2c_device_desc
+ *
+ * @return True if from a memory slab, False if not
+ */
+bool i3c_i2c_device_desc_in_pool(struct i3c_i2c_device_desc *desc);
+
+#else
+
+static inline struct i3c_i2c_device_desc *i3c_i2c_device_desc_alloc(void)
+{
+	return NULL;
+}
+
+static inline void i3c_i2c_device_desc_free(struct i3c_i2c_device_desc *desc)
+{
+	ARG_UNUSED(desc);
+}
+
+static inline bool i3c_i2c_device_desc_in_pool(struct i3c_i2c_device_desc *desc)
+{
+	ARG_UNUSED(desc);
+	return false;
+}
+
+#endif /* CONFIG_I3C_I2C_NUM_OF_DESC_MEM_SLABS > 0 */
 
 #if defined(CONFIG_I3C_RTIO) || defined(__DOXYGEN__)
 

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -975,6 +975,9 @@ struct i3c_device_desc {
 		uint8_t max_ibi;
 	} data_length;
 
+	/** Controller Handoff Delay Parameters */
+	uint8_t crhdly1;
+
 	/** Describes advanced (Target) capabilities and features */
 	struct {
 		union {
@@ -1026,6 +1029,28 @@ struct i3c_device_desc {
 		 */
 		uint8_t getcap4;
 	} getcaps;
+
+	/* Describes Controller Feature Capabilities */
+	struct {
+		/**
+		 * CRCAPS1
+		 * - Bit[0]: Hot-Join Support
+		 * - Bit[1]: Group Management Support
+		 * - Bit[2]: Multi-Lane Support
+		 * - Bit[7:3]: Reserved
+		 */
+		uint8_t crcaps1;
+
+		/**
+		 * CRCAPS2
+		 * - Bit[0]: In-Band Interrupt Support
+		 * - Bit[1]: Controller Pass-Back
+		 * - Bit[2]: Deep Sleep Capable
+		 * - Bit[3]: Delayed Controller Handoff
+		 * - Bit[7:4]: Reserved
+		 */
+		uint8_t crcaps2;
+	} crcaps;
 
 	/** @cond INTERNAL_HIDDEN */
 	/**

--- a/include/zephyr/drivers/i3c/ccc.h
+++ b/include/zephyr/drivers/i3c/ccc.h
@@ -515,7 +515,7 @@ struct i3c_ccc_address {
 	 * @note For SETDATA, SETNEWDA and SETGRPA,
 	 * the address is left-shift by 1, and bit[0] is always 0.
 	 *
-	 * @note Fpr SET GETACCCR, the address is left-shift by 1,
+	 * @note For SET GETACCCR, the address is left-shift by 1,
 	 * and bit[0] is the calculated odd parity bit.
 	 */
 	uint8_t addr;
@@ -638,6 +638,9 @@ union i3c_ccc_getstatus {
  */
 #define I3C_CCC_GETSTATUS_ACTIVITY_MODE(status)			\
 	FIELD_GET(I3C_CCC_GETSTATUS_ACTIVITY_MODE_MASK, (status))
+
+/** GETSTATUS Format 1 - Activity Mode Unable to participate in Controller Handoff */
+#define I3C_CCC_GETSTATUS_ACTIVITY_MODE_NCH			0x3
 
 /** GETSTATUS Format 1 - Number of Pending Interrupts bitmask. */
 #define I3C_CCC_GETSTATUS_NUM_INT_MASK				GENMASK(3U, 0U)
@@ -869,7 +872,7 @@ union i3c_ccc_getmxds {
  * @param crhdly1 GETMXDS value.
  */
 #define I3C_CCC_GETMXDS_CRDHLY1_CTRL_HANDOFF_ACT_STATE(crhdly1)	\
-	FIELD_GET(I3C_CCC_GETMXDS_CRDHLY1_CTRL_HANDOFF_ACT_STATE_MASK, (chrdly1))
+	FIELD_GET(I3C_CCC_GETMXDS_CRDHLY1_CTRL_HANDOFF_ACT_STATE_MASK, (crhdly1))
 
 /**
  * @brief Indicate which format of GETCAPS to use.

--- a/include/zephyr/drivers/i3c/ccc.h
+++ b/include/zephyr/drivers/i3c/ccc.h
@@ -2135,6 +2135,24 @@ int i3c_ccc_do_deftgts_all(const struct device *controller,
 int i3c_ccc_do_setbuscon(const struct device *controller,
 				uint8_t *context, uint16_t length);
 
+/**
+ * @brief Direct GETACCCR for Controller Handoff
+ *
+ * Helper function to allow for the Active Controller to pass the
+ * Controller Role to a Secondary Controller. The returned address
+ * should match it's dynamic address along with odd parity.
+ *
+ * Note it is up to the caller to verify the correct returned address
+ *
+ * @param[in] target Pointer to the target device descriptor.
+ * @param[out] handoff_address Pointer to the address returned by the secondary
+ * controller.
+ *
+ * @return @see i3c_do_ccc
+ */
+int i3c_ccc_do_getacccr(const struct i3c_device_desc *target,
+			   struct i3c_ccc_address *handoff_address);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/drivers/i3c/ibi.h
+++ b/include/zephyr/drivers/i3c/ibi.h
@@ -185,6 +185,21 @@ int i3c_ibi_work_enqueue_target_irq(struct i3c_device_desc *target,
 				    uint8_t *payload, size_t payload_len);
 
 /**
+ * @brief Queue a controllership request IBI for future processing.
+ *
+ * This queues up a controllership request IBI in the IBI workqueue
+ * for future processing.
+ *
+ * @param target Pointer to target device descriptor.
+ *
+ * @retval 0 If work item is successfully queued.
+ * @retval -ENOMEM If no more free internal node to
+ *                 store IBI work item.
+ * @retval Others @see k_work_submit_to_queue
+ */
+int i3c_ibi_work_enqueue_controller_request(struct i3c_device_desc *target);
+
+/**
  * @brief Queue a hot join IBI for future processing.
  *
  * This queues up a hot join IBI in the IBI workqueue

--- a/include/zephyr/drivers/i3c/target_device.h
+++ b/include/zephyr/drivers/i3c/target_device.h
@@ -261,12 +261,53 @@ struct i3c_target_callbacks {
 	 * @return Ignored.
 	 */
 	int (*stop_cb)(struct i3c_target_config *config);
+
+	/**
+	 * @brief Function called when an active controller handoffs controlership
+	 * to this target.
+	 *
+	 * This function is invoked by the active controller when it handoffs
+	 * controllership to this target. This can happen wither the target has
+	 * requested it or if the active controller chooses to handoff to the
+	 * controller capable target.
+	 *
+	 * @param config Configuration structure associated with the
+	 *               device to which the operation is addressed.
+	 *
+	 * @return Ignored.
+	 */
+	int (*controller_handoff_cb)(struct i3c_target_config *config);
 };
 
 __subsystem struct i3c_target_driver_api {
 	int (*driver_register)(const struct device *dev);
 	int (*driver_unregister)(const struct device *dev);
 };
+
+/**
+ * @brief Accept or Decline Controller Handoffs
+ *
+ * This sets the target to ACK or NACK handoffs from the active
+ * controller from the CCC GETACCCR.
+ *
+ * @param dev Pointer to the device structure for an I3C controller
+ *            driver configured in target mode.
+ * @param accept True to ACK controller handoffs, False to NACK
+ *
+ * @retval 0 Is successful
+ */
+static inline int i3c_target_controller_handoff(const struct device *dev,
+				      bool accept)
+{
+	const struct i3c_driver_api *api =
+		(const struct i3c_driver_api *)dev->api;
+
+	if (api->target_controller_handoff == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->target_controller_handoff(dev, accept);
+}
 
 /**
  * @brief Writes to the target's TX FIFO


### PR DESCRIPTION
This implements Controller Handoff according to Section 5.1.7.1 of I3C v1.1.1 Specification

## DEFTGTS reception 

Most (if not all) IPs contain an interrupt that signals the reception of the CCC DEFTGTS. The driver allocates memory, writes a copy of the received data to the common data area, and signals that the DEFTGTS data was refreshed.
DEFTGTS has no purpose until a Controller Handoff happens. From then, most (if not all) IPs contain an interrupt that signals when a controller handoff has happened (along with an ACK). From then, the I3C common layer has code that should (can?) be used to read through the DEFTGTS data it should have received earlier and correlate that data with known devices by reading the PID with the CCC GETPID of each I3C device from DEFTGTS.
If any PIDs are seen where it can't correlate that to a statically defined `i3c_device_desc`, then it shall allocate memory from the `i3c_device_desc` pool. Same for `i3c_i2c_device_desc`. `CONFIG_I3C_NUM_OF_DESC_MEM_SLABS` and `CONFIG_I3C_I2C_NUM_OF_DESC_MEM_SLABS` were added to define the number of statically allocated dynamic memory. It needs to retain this information because it is possible for it to change address or ack hotjoins and when that happens, it will then need to broadcast out another DEFTGTS to all the other secondary controllers as well as back to the primary controller. These kconfigs can also be set to `0` to reduce the footprint and have no extra memory allocated.

## Controller Handoff

Section 5.1.7.1 of I3C v1.1.1 Specification explains in detail what is to happen in a handoff.  This is implemented with the function `i3c_device_controller_handoff`

![image](https://github.com/user-attachments/assets/495324a5-2e84-41a9-a461-b2f0689a4e25)

## Controllership Request

A Target can request controllership by broadcasting out it's Dynamic Address on the bus as an In-Band Interrupt (IBI). This implements the workq request to eventually call `i3c_device_controller_handoff`

It is also possible for a secondary controller to just be given controllership without a request just through the CCC GETACCCR, but the secondary controller can refuse this by giving a NACK. The I3C target API `target_controller_handoff` was added to configure either ACK'ing or NACK'ing these handoffs. The callback `controller_handoff_cb` was added for when a handoff has happened and it is now the Active Controller.

## ~~Getting Device Info Optimization~~

~~ENTDAA and DEFTGTS both already receive the BCR and DCR of the I3C device, but then `i3c_device_basic_info_get` will then redundantly retrieve the BCR and DCR again. This adds an extra arg to skip the BCR and DCR.~~

_Split off into https://github.com/zephyrproject-rtos/zephyr/pull/82988_