### PR TITLE
tests: Fix the platform exclude board name

### DIFF
--- a/tests/subsys/rtio/rtio_api/testcase.yaml
+++ b/tests/subsys/rtio/rtio_api/testcase.yaml
@@ -1,7 +1,7 @@
 common:
   # renode causes timeouts unfortunately
   # xtensa dc233 (with mmu) has a TLB exception for unclear reasons
-  platform_exclude: m2gl025_miv m5stack_core2 hifive1 qemu_xtensa_dc233c
+  platform_exclude: m2gl025_miv m5stack_core2 hifive1 qemu_xtensa/dc233c/mmu
   platform_key:
     - arch
     - simulation


### PR DESCRIPTION
qemu_xtensa_dc233c didn't pan out like I expected, needed to be qemu_xtensa/dc233c/mmu to be excluded.

Related to #78004 