### PR TITLE
drivers: gpio: support interrupt trigger on both edges

### DIFF
--- a/drivers/gpio/gpio_ifx_cat1.c
+++ b/drivers/gpio/gpio_ifx_cat1.c
@@ -239,11 +239,8 @@ static int gpio_cat1_pin_interrupt_configure(const struct device *dev, gpio_pin_
 		break;
 
 	case GPIO_INT_TRIG_BOTH:
-		/* Trigger detection on pin rising or falling edge (GPIO_INT_TRIG_BOTH)
-		 * is not supported. Refer to SWINTEGRATION-696
-		 */
-		/* event = CYHAL_GPIO_IRQ_BOTH; */
-		return -ENOTSUP;
+		event = CYHAL_GPIO_IRQ_BOTH;
+		break;
 
 	default:
 		return -ENOTSUP;


### PR DESCRIPTION
Interrupt trigger for both raising and falling edge was not supported due to an underlying bug which is fixed now. Hence enabling support for GPIO_INT_TRIG_BOTH