### PR TITLE
cpp: Fix warnings

### DIFF
--- a/include/zephyr/drivers/emul.h
+++ b/include/zephyr/drivers/emul.h
@@ -114,7 +114,7 @@ struct emul {
  * the bus its on. Intended for use in other internal macros when declaring {bus}_emul
  * structs in peripheral emulators.
  */
-#define Z_EMUL_REG_BUS_IDENTIFIER(_dev_node_id) (_CONCAT(_CONCAT(__emulreg_, _dev_node_id), _bus))
+#define Z_EMUL_REG_BUS_IDENTIFIER(_dev_node_id) _CONCAT(_CONCAT(__emulreg_, _dev_node_id), _bus)
 
 /* Conditionally places text based on what bus _dev_node_id is on. */
 #define Z_EMUL_BUS(_dev_node_id, _i2c, _espi, _spi, _mspi, _uart, _none)                           \

--- a/tests/drivers/i2c/i2c_emul/src/test_fowarding_common.cpp
+++ b/tests/drivers/i2c/i2c_emul/src/test_fowarding_common.cpp
@@ -55,7 +55,7 @@ ZTEST_SUITE(i2c_emul_forwarding, NULL, i2c_emul_forwarding_setup, i2c_emul_forwa
 
 ZTEST(i2c_emul_forwarding, test_invalid_address_for_target)
 {
-	uint8_t data;
+	uint8_t data = 0;
 	int rc = i2c_write(targets[0], &data, 1, emulated_target_config[0].address + 1);
 	zassert_equal(-EINVAL, rc, "Expected %d (-EINVAL), but got %d", -EINVAL, rc);
 	zexpect_equal(0, target_read_requested_0_fake.call_count);
@@ -69,7 +69,7 @@ ZTEST(i2c_emul_forwarding, test_invalid_address_for_target)
 
 ZTEST(i2c_emul_forwarding, test_error_in_stop)
 {
-	uint8_t data;
+	uint8_t data = 0;
 
 	target_stop_0_fake.return_val = -EINTR;
 	zassert_equal(-EINTR, i2c_write(controller, &data, 1, emulated_target_config[0].address));


### PR DESCRIPTION
Fix warnings caught by running west build. Another fix will have to go in to see why twister was missing these.

#78348