### PR TITLE
samples: subsys: modbus: fix Modbus TCP reply

### DIFF
--- a/samples/subsys/modbus/tcp_server/src/main.c
+++ b/samples/subsys/modbus/tcp_server/src/main.c
@@ -213,14 +213,14 @@ static int init_modbus_server(void)
 
 static int modbus_tcp_reply(int client, struct modbus_adu *adu)
 {
-	uint8_t header[MODBUS_MBAP_AND_FC_LENGTH];
+	uint8_t message[MODBUS_MBAP_AND_FC_LENGTH + adu->length];
 
-	modbus_raw_put_header(adu, header);
-	if (send(client, header, sizeof(header), 0) < 0) {
-		return -errno;
-	}
+	modbus_raw_put_header(adu, message);
 
-	if (send(client, adu->data, adu->length, 0) < 0) {
+	memcpy(&message[MODBUS_MBAP_AND_FC_LENGTH], adu->data,
+	       MIN(MODBUS_MBAP_AND_FC_LENGTH + adu->length, CONFIG_MODBUS_BUFFER_SIZE));
+
+	if (send(client, message, sizeof(message), 0) < 0) {
 		return -errno;
 	}
 


### PR DESCRIPTION
In the Modbus TCP server sample code, the tcp reply splits the header and data packet.
This is likely a non-standard behavior. Some modbus client systems expect the modbus tcp reply message in one packet.
It may otherwise keep sending repeated request messages.
The sample code was sending the MBAP header and the data separately.
The fix is to copy both MBAP header and data into one message and send.
Tested with hardware running zephyr and an HMI with Modbus TCP client and checking the network logs.
