### PR TITLE
drivers: rtc: RV8263 OS flag is never cleared

### DIFF
--- a/drivers/rtc/rtc_rv8263.c
+++ b/drivers/rtc/rtc_rv8263.c
@@ -281,7 +281,7 @@ static int rv8263c8_time_get(const struct device *dev, struct rtc_time *timeptr)
 static int rv8263c8_init(const struct device *dev)
 {
 	int err;
-	int temp;
+	uint8_t temp;
 	struct rv8263c8_data *data = dev->data;
 	const struct rv8263c8_config *config = dev->config;
 


### PR DESCRIPTION
Clear the OS flag when reading the time
and when the flag is set. Also clear the
flag once during the initialization.