### PR TITLE
net: context: Set IPv4 address properly for sendmsg()

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -2026,19 +2026,6 @@ static int context_sendto(struct net_context *context,
 		const struct sockaddr_in *addr4 = (const struct sockaddr_in *)dst_addr;
 		struct sockaddr_in mapped;
 
-		/* Get the destination address from the mapped IPv6 address */
-		if (IS_ENABLED(CONFIG_NET_IPV4_MAPPING_TO_IPV6) &&
-		    addr4->sin_family == AF_INET6 &&
-		    net_ipv6_addr_is_v4_mapped(&net_sin6(dst_addr)->sin6_addr)) {
-			struct sockaddr_in6 *addr6 = (struct sockaddr_in6 *)dst_addr;
-
-			mapped.sin_port = addr6->sin6_port;
-			mapped.sin_family = AF_INET;
-			net_ipaddr_copy(&mapped.sin_addr,
-					(struct in_addr *)(&addr6->sin6_addr.s6_addr32[3]));
-			addr4 = &mapped;
-		}
-
 		if (msghdr) {
 			addr4 = msghdr->msg_name;
 			addrlen = msghdr->msg_namelen;
@@ -2051,6 +2038,19 @@ static int context_sendto(struct net_context *context,
 			/* For sendmsg(), the dst_addr is NULL so set it here.
 			 */
 			dst_addr = (const struct sockaddr *)addr4;
+		}
+
+		/* Get the destination address from the mapped IPv6 address */
+		if (IS_ENABLED(CONFIG_NET_IPV4_MAPPING_TO_IPV6) &&
+		    addr4->sin_family == AF_INET6 &&
+		    net_ipv6_addr_is_v4_mapped(&net_sin6(dst_addr)->sin6_addr)) {
+			struct sockaddr_in6 *addr6 = (struct sockaddr_in6 *)dst_addr;
+
+			mapped.sin_port = addr6->sin6_port;
+			mapped.sin_family = AF_INET;
+			net_ipaddr_copy(&mapped.sin_addr,
+					(struct in_addr *)(&addr6->sin6_addr.s6_addr32[3]));
+			addr4 = &mapped;
 		}
 
 		if (addrlen < sizeof(struct sockaddr_in)) {


### PR DESCRIPTION
When using sendmsg() and if CONFIG_NET_IPV4_MAPPING_TO_IPV6 is enabled, then the addr4 variable was set too late which was causing null pointer access.