### PR TITLE
 Minor Grammar Correction in I2C Documentation

### DIFF
--- a/doc/hardware/peripherals/i2c.rst
+++ b/doc/hardware/peripherals/i2c.rst
@@ -26,10 +26,9 @@ support the target mode.  Zephyr has API for both roles.
 I2C Controller API
 ==================
 
-Zephyr's I2C controller API is used when an I2C peripheral controls the bus,
-in particularly the start and stop conditions and the clock.  This is
-the most common mode, used to interact with I2C devices like sensors and
-serial memory.
+Zephyr's I2C controller API is used when an I2C peripheral controls the bus, 
+particularly the start and stop conditions and the clock. This is the most 
+common mode, used to interact with I2C devices like sensors and serial memory.
 
 This API is supported in all in-tree I2C peripheral drivers and is
 considered stable.


### PR DESCRIPTION
This pull request addresses a minor grammar issue in the I2C documentation. The phrase “in particularly” has been corrected to “particularly” to improve readability and accuracy. This change affects the doc/hardware/peripherals/i2c.rst file, with 3 additions and 4 deletions. The update ensures that the documentation is clear and professional.