### PR TITLE
ci: doc: build the documentation using GitHub-hosted runners

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -62,20 +62,13 @@ jobs:
     if: >
       github.repository_owner == 'zephyrproject-rtos' &&
         ( needs.doc-file-check.outputs.file_check == 'true' || github.event_name != 'pull_request' )
-    runs-on:
-      group: zephyr-runner-v2-linux-x64-4xlarge
+    runs-on: ubuntu-22.04
     timeout-minutes: 90
     concurrency:
       group: doc-build-html-${{ github.ref }}
       cancel-in-progress: true
 
     steps:
-    - name: Print cloud service information
-      run: |
-        echo "ZEPHYR_RUNNER_CLOUD_PROVIDER = ${ZEPHYR_RUNNER_CLOUD_PROVIDER}"
-        echo "ZEPHYR_RUNNER_CLOUD_NODE = ${ZEPHYR_RUNNER_CLOUD_NODE}"
-        echo "ZEPHYR_RUNNER_CLOUD_POD = ${ZEPHYR_RUNNER_CLOUD_POD}"
-
     - name: install-pkgs
       run: |
         sudo apt-get update
@@ -192,8 +185,7 @@ jobs:
     if: |
       github.event_name != 'pull_request' &&
       github.repository_owner == 'zephyrproject-rtos'
-    runs-on:
-      group: zephyr-runner-v2-linux-x64-4xlarge
+    runs-on: ubuntu-22.04
     container: texlive/texlive:latest
     timeout-minutes: 120
     concurrency:
@@ -204,12 +196,6 @@ jobs:
     - name: Apply container owner mismatch workaround
       run: |
         git config --global --add safe.directory ${GITHUB_WORKSPACE}
-
-    - name: Print cloud service information
-      run: |
-        echo "ZEPHYR_RUNNER_CLOUD_PROVIDER = ${ZEPHYR_RUNNER_CLOUD_PROVIDER}"
-        echo "ZEPHYR_RUNNER_CLOUD_NODE = ${ZEPHYR_RUNNER_CLOUD_NODE}"
-        echo "ZEPHYR_RUNNER_CLOUD_POD = ${ZEPHYR_RUNNER_CLOUD_POD}"
 
     - name: checkout
       uses: actions/checkout@v4


### PR DESCRIPTION
There is no reason to use our custom runners for docs build as it's equally fast on GH default runners and allows doc CI to be expedited more quickly even when our build farm is busy.

While PDF build is currently broken, I have confirmed that it will work fine on the GH-hosted runner too when we have a fix such as https://github.com/zephyrproject-rtos/zephyr/pull/78165 (or equivalent) in place.
https://github.com/kartben/zephyr/actions/runs/10848952742