### PR TITLE
manifest: update to have new hal_nordic revision

### DIFF
--- a/modules/hal_nordic/nrfx/CMakeLists.txt
+++ b/modules/hal_nordic/nrfx/CMakeLists.txt
@@ -36,13 +36,13 @@ zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF5340_CPUAPP      NRF5340_XXAA_APP
 zephyr_compile_definitions_ifdef(CONFIG_SOC_COMPATIBLE_NRF5340_CPUAPP NRF5340_XXAA_APPLICATION)
 zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF5340_CPUNET      NRF5340_XXAA_NETWORK)
 zephyr_compile_definitions_ifdef(CONFIG_SOC_COMPATIBLE_NRF5340_CPUNET NRF5340_XXAA_NETWORK)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54H20_CPUAPP     NRF54H20_XXAA
+zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54H20_CPUAPP     NRF54H20_ENGB_XXAA
                                                                 NRF_APPLICATION)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54H20_CPURAD     NRF54H20_XXAA
+zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54H20_CPURAD     NRF54H20_ENGB_XXAA
                                                                 NRF_RADIOCORE)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54H20_CPUPPR     NRF54H20_XXAA
+zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54H20_CPUPPR     NRF54H20_ENGB_XXAA
                                                                 NRF_PPR)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54H20_CPUFLPR    NRF54H20_XXAA
+zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54H20_CPUFLPR    NRF54H20_ENGB_XXAA
                                                                 NRF_FLPR)
 zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54L15_ENGA       NRF54L15_ENGA_XXAA)
 zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54L15_ENGA_CPUAPP NRF_APPLICATION)

--- a/modules/hal_nordic/nrfx/nrfx_config.h
+++ b/modules/hal_nordic/nrfx/nrfx_config.h
@@ -1042,6 +1042,14 @@
     #include <nrfx_config_nrf5340_application.h>
 #elif defined(NRF5340_XXAA_NETWORK)
     #include <nrfx_config_nrf5340_network.h>
+#elif defined(NRF54H20_ENGB_XXAA) && defined(NRF_APPLICATION)
+    #include <nrfx_config_nrf54h20_application.h>
+#elif defined(NRF54H20_ENGB_XXAA) && defined(NRF_RADIOCORE)
+    #include <nrfx_config_nrf54h20_radiocore.h>
+#elif defined(NRF54H20_ENGB_XXAA) && defined(NRF_PPR)
+    #include <nrfx_config_nrf54h20_ppr.h>
+#elif defined(NRF54H20_ENGB_XXAA) && defined(NRF_FLPR)
+    #include <nrfx_config_nrf54h20_flpr.h>
 #elif defined(NRF54H20_XXAA) && defined(NRF_APPLICATION)
     #include <nrfx_config_nrf54h20_application.h>
 #elif defined(NRF54H20_XXAA) && defined(NRF_RADIOCORE)

--- a/west.yml
+++ b/west.yml
@@ -188,7 +188,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: af7b21c4f875bea26689307daa8e52e9a8e8323c
+      revision: pull/212/head
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
To be replaced once nrfx 3.7.0 release is available.