### PR TITLE
boards: nxp: Fix the MX25UM51245G flash DTS write block size

### DIFF
--- a/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
+++ b/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
@@ -397,7 +397,7 @@ zephyr_udc0: &usbhs {
 		status = "okay";
 		jedec-id = [c2 81 3a];
 		erase-block-size = <4096>;
-		write-block-size = <16>;
+		write-block-size = <2>; /* FLASH_MCUX_FLEXSPI_MX25UM51345G_OPI_DTR set */
 
 		partitions {
 			compatible = "fixed-partitions";
@@ -408,20 +408,20 @@ zephyr_udc0: &usbhs {
 				label = "mcuboot";
 				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			/* The MCUBoot swap-move algorithm uses the last 98 sectors
+			/* The MCUBoot swap-move algorithm uses the last 3 sectors
 			 * of the primary slot0 for swap status and move.
 			 */
 			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00020000 (DT_SIZE_M(3) + DT_SIZE_K(98 * 4))>;
+				reg = <0x00020000 (DT_SIZE_M(3) + DT_SIZE_K(3 * 4))>;
 			};
-			slot1_partition: partition@382000 {
+			slot1_partition: partition@323000 {
 				label = "image-1";
-				reg = <0x00382000 DT_SIZE_M(3)>;
+				reg = <0x00323000 DT_SIZE_M(3)>;
 			};
-			storage_partition: partition@682000 {
+			storage_partition: partition@623000 {
 				label = "storage";
-				reg = <0x00682000 (DT_SIZE_M(58) - DT_SIZE_K(520))>;
+				reg = <0x00623000 (DT_SIZE_M(58) - DT_SIZE_K(140))>;
 			};
 		};
 	};

--- a/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
+++ b/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
@@ -259,7 +259,7 @@ i2s1: &flexcomm3 {
 		status = "okay";
 		jedec-id = [c2 81 3a];
 		erase-block-size = <4096>;
-		write-block-size = <16>;
+		write-block-size = <1>; /* FLASH_MCUX_FLEXSPI_MX25UM51345G_OPI_STR set */
 
 		partitions {
 			compatible = "fixed-partitions";
@@ -270,20 +270,20 @@ i2s1: &flexcomm3 {
 				label = "mcuboot";
 				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			/* The MCUBoot swap-move algorithm uses the last 98 sectors
+			/* The MCUBoot swap-move algorithm uses the last 2 sectors
 			 * of the primary slot0 for swap status and move.
 			 */
 			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00020000 (DT_SIZE_M(3) + DT_SIZE_K(98 * 4))>;
+				reg = <0x00020000 (DT_SIZE_M(3) + DT_SIZE_K(2 * 4))>;
 			};
-			slot1_partition: partition@382000 {
+			slot1_partition: partition@323000 {
 				label = "image-1";
-				reg = <0x00382000 DT_SIZE_M(3)>;
+				reg = <0x00323000 DT_SIZE_M(3)>;
 			};
-			storage_partition: partition@682000 {
+			storage_partition: partition@623000 {
 				label = "storage";
-				reg = <0x00682000 (DT_SIZE_M(58) - DT_SIZE_K(520))>;
+				reg = <0x00623000 (DT_SIZE_M(58) - DT_SIZE_K(136))>;
 			};
 		};
 	};

--- a/boards/nxp/vmu_rt1170/vmu_rt1170.dtsi
+++ b/boards/nxp/vmu_rt1170/vmu_rt1170.dtsi
@@ -206,7 +206,7 @@
 		status = "okay";
 		jedec-id = [c2 81 3a];
 		erase-block-size = <4096>;
-		write-block-size = <16>;
+		write-block-size = <2>; /* FLASH_MCUX_FLEXSPI_MX25UM51345G_OPI_DTR set */
 
 		partitions {
 			compatible = "fixed-partitions";
@@ -216,12 +216,12 @@
 				label = "mcuboot";
 				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			/* The MCUBoot swap-move algorithm uses the last 14 sectors
+			/* The MCUBoot swap-move algorithm uses the last 3 sectors
 			 * of the primary slot0 for swap status and move.
 			 */
 			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00020000 (DT_SIZE_M(3) + DT_SIZE_K(56))>;
+				reg = <0x00020000 (DT_SIZE_M(3) + DT_SIZE_K(3 * 4))>;
 			};
 			slot1_partition: partition@32E000 {
 				label = "image-1";
@@ -229,7 +229,7 @@
 			};
 			storage_partition: partition@62E000 {
 				label = "storage";
-				reg = <0x0062E000 (DT_SIZE_M(58) - DT_SIZE_K(184))>;
+				reg = <0x0062E000 (DT_SIZE_M(58) - DT_SIZE_K(140))>;
 			};
 		};
 	};


### PR DESCRIPTION
- Fixed the MX25UM51245G flash DTS write block size from 16 to a value used by the flash_mcux_flexspi_mx25um51345g driver.
- Fixed flash partitions.