### PR TITLE
drivers: adc: adc_mcux_adc16: Allow ADC_REF_VDD_1 reference option

### DIFF
--- a/drivers/adc/adc_mcux_adc16.c
+++ b/drivers/adc/adc_mcux_adc16.c
@@ -124,11 +124,6 @@ static int mcux_adc16_channel_setup(const struct device *dev,
 		return -EINVAL;
 	}
 
-	if (channel_cfg->reference != ADC_REF_INTERNAL) {
-		LOG_ERR("Invalid channel reference");
-		return -EINVAL;
-	}
-
 #ifdef CONFIG_ADC_MCUX_ADC16_HW_TRIGGER
 	adc_hw_trigger_enable(dev);
 #endif


### PR DESCRIPTION
Only ADC_REF_INTERNAL ADC reference option is allowed in adc_mcux_adc16 driver. Some NXP SoCs have also VDDA option. Enable ADC_REF_VDD_1 option in driver.
The option is selectable in Devicetree using zephyr,reference ADC channel property, the voltage is configurable using zephyr,vref-mv property. It is used by ADC API function adc_raw_to_millivolts_dt for milivolts calculation.