### PR TITLE
kernel: arch: lib: tests: Replace __thread with _Thread_local

### DIFF
--- a/arch/riscv/core/thread.c
+++ b/arch/riscv/core/thread.c
@@ -15,7 +15,7 @@
 /*
  * Per-thread (TLS) variable indicating whether execution is in user mode.
  */
-__thread uint8_t is_user_mode;
+_Thread_local uint8_t is_user_mode;
 #endif
 
 void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,

--- a/arch/xtensa/core/thread.c
+++ b/arch/xtensa/core/thread.c
@@ -22,7 +22,7 @@ LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 /*
  * Per-thread (TLS) variable indicating whether execution is in user mode.
  */
-__thread uint32_t is_user_mode;
+_Thread_local uint32_t is_user_mode;
 #endif
 
 #endif /* CONFIG_USERSPACE */

--- a/doc/kernel/services/other/thread_local_storage.rst
+++ b/doc/kernel/services/other/thread_local_storage.rst
@@ -29,25 +29,25 @@ making a system call.
 Declaring and Using Thread Local Variables
 ******************************************
 
-The keyword ``__thread`` can be used to declare thread local variables.
+The C11 keyword ``_Thread_local`` can be used to declare thread local variables.
 
 For example, to declare a thread local variable in header files:
 
 .. code-block:: c
 
-   extern __thread int i;
+   extern _Thread_local int i;
 
 And to declare the actual variable in source files:
 
 .. code-block:: c
 
-   __thread int i;
+   _Thread_local int i;
 
 Keyword ``static`` can also be used to limit the variable within a source file:
 
 .. code-block:: c
 
-   static __thread int j;
+   static _Thread_local int j;
 
 Using the thread local variable is the same as using other variable, for example:
 

--- a/include/zephyr/arch/riscv/syscall.h
+++ b/include/zephyr/arch/riscv/syscall.h
@@ -158,7 +158,7 @@ static inline bool arch_is_user_context(void)
 	}
 
 	/* Defined in arch/riscv/core/thread.c */
-	extern __thread uint8_t is_user_mode;
+	extern _Thread_local uint8_t is_user_mode;
 
 	return is_user_mode != 0;
 }

--- a/include/zephyr/arch/xtensa/syscall.h
+++ b/include/zephyr/arch/xtensa/syscall.h
@@ -211,7 +211,7 @@ static inline bool arch_is_user_context(void)
 		: "=a" (thread)
 	);
 #ifdef CONFIG_THREAD_LOCAL_STORAGE
-	extern __thread uint32_t is_user_mode;
+	extern _Thread_local uint32_t is_user_mode;
 
 	if (!thread) {
 		return false;

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -665,7 +665,7 @@ static inline k_tid_t k_current_get(void)
 #ifdef CONFIG_CURRENT_THREAD_USE_TLS
 
 	/* Thread-local cache of current thread ID, set in z_thread_entry() */
-	extern __thread k_tid_t z_tls_current;
+	extern _Thread_local k_tid_t z_tls_current;
 
 	return z_tls_current;
 #else

--- a/include/zephyr/sys/errno_private.h
+++ b/include/zephyr/sys/errno_private.h
@@ -26,7 +26,7 @@ static inline int *z_errno(void)
 }
 
 #elif defined(CONFIG_ERRNO_IN_TLS)
-extern __thread int z_errno_var;
+extern _Thread_local int z_errno_var;
 
 static inline int *z_errno(void)
 {

--- a/kernel/compiler_stack_protect.c
+++ b/kernel/compiler_stack_protect.c
@@ -47,7 +47,7 @@ void _StackCheckHandler(void)
  * The canary value gets initialized in z_cstart().
  */
 #ifdef CONFIG_STACK_CANARIES_TLS
-__thread volatile uintptr_t __stack_chk_guard;
+_Thread_local volatile uintptr_t __stack_chk_guard;
 #elif CONFIG_USERSPACE
 K_APP_DMEM(z_libc_partition) volatile uintptr_t __stack_chk_guard;
 #else

--- a/kernel/errno.c
+++ b/kernel/errno.c
@@ -27,7 +27,7 @@ const int _k_neg_eagain = -EAGAIN;
 #if defined(CONFIG_LIBC_ERRNO)
 /* nothing needed here */
 #elif defined(CONFIG_ERRNO_IN_TLS)
-__thread int z_errno_var;
+_Thread_local int z_errno_var;
 #else
 
 #ifdef CONFIG_USERSPACE

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -294,7 +294,7 @@ void z_bss_zero_pinned(void)
 
 #ifdef CONFIG_STACK_CANARIES
 #ifdef CONFIG_STACK_CANARIES_TLS
-extern __thread volatile uintptr_t __stack_chk_guard;
+extern _Thread_local volatile uintptr_t __stack_chk_guard;
 #else
 extern volatile uintptr_t __stack_chk_guard;
 #endif /* CONFIG_STACK_CANARIES_TLS */

--- a/kernel/xip.c
+++ b/kernel/xip.c
@@ -12,7 +12,7 @@
 
 #ifdef CONFIG_STACK_CANARIES
 #ifdef CONFIG_STACK_CANARIES_TLS
-extern __thread volatile uintptr_t __stack_chk_guard;
+extern _Thread_local volatile uintptr_t __stack_chk_guard;
 #else
 extern volatile uintptr_t __stack_chk_guard;
 #endif /* CONFIG_STACK_CANARIES_TLS */

--- a/lib/os/thread_entry.c
+++ b/lib/os/thread_entry.c
@@ -15,11 +15,11 @@
 #ifdef CONFIG_CURRENT_THREAD_USE_TLS
 #include <zephyr/random/random.h>
 
-__thread k_tid_t z_tls_current;
+_Thread_local k_tid_t z_tls_current;
 #endif
 
 #ifdef CONFIG_STACK_CANARIES_TLS
-extern __thread volatile uintptr_t __stack_chk_guard;
+extern _Thread_local volatile uintptr_t __stack_chk_guard;
 #endif /* CONFIG_STACK_CANARIES_TLS */
 
 /*

--- a/tests/kernel/mem_protect/stackprot/src/main.c
+++ b/tests/kernel/mem_protect/stackprot/src/main.c
@@ -143,7 +143,7 @@ ZTEST(stackprot, test_create_alt_thread)
 }
 
 #ifdef CONFIG_STACK_CANARIES_TLS
-extern __thread volatile uintptr_t __stack_chk_guard;
+extern _Thread_local volatile uintptr_t __stack_chk_guard;
 #else
 extern volatile uintptr_t __stack_chk_guard;
 #endif

--- a/tests/kernel/threads/tls/src/main.c
+++ b/tests/kernel/threads/tls/src/main.c
@@ -51,14 +51,14 @@ K_APP_BMEM(part_common) static k_tid_t tls_tid[NUM_THREADS];
 K_APP_BMEM(part_common) static enum test_result tls_result[NUM_THREADS];
 
 /* Thread data with initialized values */
-static uint8_t  __thread thread_data8  = STATIC_DATA8;
-static uint32_t __thread thread_data32 = STATIC_DATA32;
-static uint64_t __thread thread_data64 = STATIC_DATA64;
+static uint8_t  _Thread_local thread_data8  = STATIC_DATA8;
+static uint32_t _Thread_local thread_data32 = STATIC_DATA32;
+static uint64_t _Thread_local thread_data64 = STATIC_DATA64;
 
 /* Zeroed thread data */
-static uint8_t  __thread thread_bss8;
-static uint32_t __thread thread_bss32;
-static uint64_t __thread thread_bss64;
+static uint8_t  _Thread_local thread_bss8;
+static uint32_t _Thread_local thread_bss32;
+static uint64_t _Thread_local thread_bss64;
 
 static void tls_thread_entry(void *p1, void *p2, void *p3)
 {


### PR DESCRIPTION
Start using the C11 _Thread_local keyword instead of GNU's __thread keyword for declaring thread local variables.

To the best of my knowledge these keywords behave the same in GCC and using _Thread_local increases compatibility with other toolchains (for instance IAR).

Signed-off-by: Daniel Flodin <daniel.flodin@iar.com>