### PR TITLE
modules: hostap: Add wifi statistics reset support

### DIFF
--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -1057,6 +1057,18 @@ int supplicant_get_stats(const struct device *dev, struct net_stats_wifi *stats)
 
 	return wifi_mgmt_api->get_stats(dev, stats);
 }
+
+int supplicant_reset_stats(const struct device *dev)
+{
+	const struct wifi_mgmt_ops *const wifi_mgmt_api = get_wifi_mgmt_api(dev);
+
+	if (!wifi_mgmt_api || !wifi_mgmt_api->reset_stats) {
+		wpa_printf(MSG_WARNING, "Reset stats not supported");
+		return -ENOTSUP;
+	}
+
+	return wifi_mgmt_api->reset_stats(dev);
+}
 #endif /* CONFIG_NET_STATISTICS_WIFI */
 
 int supplicant_pmksa_flush(const struct device *dev)

--- a/modules/hostap/src/supp_api.h
+++ b/modules/hostap/src/supp_api.h
@@ -82,6 +82,14 @@ int supplicant_scan(const struct device *dev, struct wifi_scan_params *params,
  * @return 0 for OK; -1 for ERROR
  */
 int supplicant_get_stats(const struct device *dev, struct net_stats_wifi *stats);
+/**
+ * @brief Reset Wi-Fi statistics
+ *
+ * @param dev Wi-Fi interface name to use
+ *
+ * @return 0 for OK; -1 for ERROR
+ */
+int supplicant_reset_stats(const struct device *dev);
 #endif /* CONFIG_NET_STATISTICS_WIFI || __DOXYGEN__ */
 
 /** Flush PMKSA cache entries

--- a/modules/hostap/src/supp_main.c
+++ b/modules/hostap/src/supp_main.c
@@ -60,6 +60,7 @@ static const struct wifi_mgmt_ops mgmt_ops = {
 	.iface_status = supplicant_status,
 #ifdef CONFIG_NET_STATISTICS_WIFI
 	.get_stats = supplicant_get_stats,
+	.reset_stats = supplicant_reset_stats,
 #endif
 	.set_power_save = supplicant_set_power_save,
 	.set_twt = supplicant_set_twt,


### PR DESCRIPTION
This change will add  an API to reset the wifi statistics when reset command is called.