### PR TITLE
hotfix: boards: doc: reference tfm_ipc sample using zephyr:code-sample: role

### DIFF
--- a/boards/st/b_u585i_iot02a/doc/index.rst
+++ b/boards/st/b_u585i_iot02a/doc/index.rst
@@ -220,7 +220,7 @@ The BOARD options are summarized below:
 +-------------------------------+-------------------------------------------+
 
 Here are the instructions to build Zephyr with a non-secure configuration,
-using :ref:`tfm_ipc` sample:
+using :zephyr:code-sample:`tfm_ipc` sample:
 
    .. code-block:: bash
 

--- a/boards/st/nucleo_l552ze_q/doc/nucleol552ze_q.rst
+++ b/boards/st/nucleo_l552ze_q/doc/nucleol552ze_q.rst
@@ -197,7 +197,7 @@ The BOARD options are summarized below:
 +--------------------------------+-------------------------------------------+
 
 Here are the instructions to build Zephyr with a non-secure configuration,
-using :ref:`tfm_ipc` sample:
+using :zephyr:code-sample:`tfm_ipc` sample:
 
    .. code-block:: console
 

--- a/boards/st/stm32l562e_dk/doc/index.rst
+++ b/boards/st/stm32l562e_dk/doc/index.rst
@@ -223,7 +223,7 @@ The BOARD options are summarized below:
 +------------------------------+-------------------------------------------+
 
 Here are the instructions to build Zephyr with a non-secure configuration,
-using :ref:`tfm_ipc` sample:
+using :zephyr:code-sample:`tfm_ipc` sample:
 
    .. code-block:: bash
 


### PR DESCRIPTION
https://github.com/zephyrproject-rtos/zephyr/pull/78301 just got in, but although two short days elapsed between the time I made the PR on top of main and today, a few boards were introduced with "old" references, which breaks doc build.