### PR TITLE
tests: net: wifi: exclude RW612 ethernet variant

### DIFF
--- a/tests/net/wifi/wifi_nm/testcase.yaml
+++ b/tests/net/wifi/wifi_nm/testcase.yaml
@@ -8,5 +8,4 @@ tests:
       - CONFIG_NRF_WIFI_BUILD_ONLY_MODE=y
     tags: wifi
     platform_exclude:
-      - frdm_rw612 # Requires binary blobs to build
-      - rd_rw612_bga # Requires binary blobs to build
+      - rd_rw612_bga/rw612/ethernet # Requires binary blobs to build


### PR DESCRIPTION
Ethernet board variant was missed in commit 138e9591f85 (tests: net: wifi: exclude RW612 based boards) that originally excluded the RW612 from this test (due to a binary blob requirement)

Add the variant to the exclude list