### PR TITLE
cmake: use the warnings_as_errors flag for cpp files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,7 @@ zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:$<TARGET_PROPERTY:compiler-cpp,
 # Extra warnings options for twister run
 if (CONFIG_COMPILER_WARNINGS_AS_ERRORS)
   zephyr_compile_options($<$<COMPILE_LANGUAGE:C>:$<TARGET_PROPERTY:compiler,warnings_as_errors>>)
+  zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:$<TARGET_PROPERTY:compiler,warnings_as_errors>>)
   zephyr_compile_options($<$<COMPILE_LANGUAGE:ASM>:$<TARGET_PROPERTY:asm,warnings_as_errors>>)
   zephyr_link_libraries($<TARGET_PROPERTY:linker,warnings_as_errors>)
 endif()

--- a/include/zephyr/drivers/mspi.h
+++ b/include/zephyr/drivers/mspi.h
@@ -204,7 +204,10 @@ enum mspi_timing_param {
  * @brief Stub for struct timing_cfg
  */
 struct mspi_timing_cfg {
-
+#ifdef __cplusplus
+	/* For C++ compatibility. */
+	uint8_t dummy;
+#endif
 };
 
 /**

--- a/include/zephyr/sys/device_mmio.h
+++ b/include/zephyr/sys/device_mmio.h
@@ -63,13 +63,13 @@ struct z_device_mmio_rom {
 
 #define Z_DEVICE_MMIO_ROM_INITIALIZER(node_id) \
 	{ \
-		.phys_addr = DT_REG_ADDR(node_id), \
+		.phys_addr = UINT32_C(DT_REG_ADDR(node_id)), \
 		.size = DT_REG_SIZE(node_id) \
 	}
 
 #define Z_DEVICE_MMIO_NAMED_ROM_INITIALIZER(name, node_id) \
 	{ \
-		.phys_addr = DT_REG_ADDR_BY_NAME(node_id, name), \
+		.phys_addr = UINT32_C(DT_REG_ADDR_BY_NAME(node_id, name)), \
 		.size = DT_REG_SIZE_BY_NAME(node_id, name) \
 	}
 

--- a/tests/drivers/i2c/i2c_emul/src/emulated_target.cpp
+++ b/tests/drivers/i2c/i2c_emul/src/emulated_target.cpp
@@ -25,7 +25,7 @@ DT_FOREACH_PROP_ELEM(CONTROLLER_LABEL, forwards, DEFINE_FAKE_TARGET_FUNCTION);
 
 /* clang-format off */
 #define DEFINE_EMULATED_CALLBACK(node_id, prop, n)                                                 \
-	[n] = {                                                                                    \
+	{                                                                                          \
 		.write_requested = target_write_requested_##n,                                     \
 		.read_requested = target_read_requested_##n,                                       \
 		.write_received = target_write_received_##n,                                       \
@@ -42,7 +42,7 @@ struct i2c_target_callbacks emulated_callbacks[FORWARD_COUNT] = {
 	DT_FOREACH_PROP_ELEM(CONTROLLER_LABEL, forwards, DEFINE_EMULATED_CALLBACK)};
 
 #define DEFINE_EMULATED_TARGET_CONFIG(node_id, prop, n)                                            \
-	[n] = {                                                                                    \
+	{                                                                                          \
 		.flags = 0,                                                                        \
 		.address = DT_PHA_BY_IDX(node_id, prop, n, addr),                                  \
 		.callbacks = &emulated_callbacks[n],                                               \

--- a/tests/drivers/i2c/i2c_emul/src/test_forwarding_pio.cpp
+++ b/tests/drivers/i2c/i2c_emul/src/test_forwarding_pio.cpp
@@ -23,7 +23,7 @@ ZTEST(i2c_emul_forwarding, test_write_is_forwarded)
 {
 	// Try writing some values
 	for (uint8_t data = 0; data < 10; ++data) {
-		const int expected_call_count = 1 + data;
+		const unsigned int expected_call_count = 1 + data;
 
 		zassert_ok(i2c_write(controller, &data, sizeof(data),
 				     emulated_target_config[0].address));

--- a/tests/lib/cbprintf_package/src/main.c
+++ b/tests/lib/cbprintf_package/src/main.c
@@ -923,7 +923,8 @@ ZTEST(cbprintf_package, test_cbprintf_package_convert_static)
 	uint32_t copy_flags = CBPRINTF_PACKAGE_CONVERT_RW_STR;
 
 	clen = cbprintf_package_convert(spackage, slen, NULL, 0, copy_flags, NULL, 0);
-	zassert_true(clen == slen + sizeof(test_str1) + 1/*null*/ - 2 /* arg+ro idx gone*/);
+	zassert_true(clen >= 0);
+	zassert_true((size_t)clen == slen + sizeof(test_str1) + 1/*null*/ - 2 /* arg+ro idx gone*/);
 
 	clen = cbprintf_package_convert(spackage, slen, convert_cb, &ctx, copy_flags, NULL, 0);
 	zassert_true(clen > 0);

--- a/tests/lib/cpp/cxx/src/main.cpp
+++ b/tests/lib/cpp/cxx/src/main.cpp
@@ -145,10 +145,11 @@ ZTEST_SUITE(cxx_tests, NULL, NULL, NULL, NULL, NULL);
  *
  * DEVICE_DEFINE(dev_id, name, * init_fn, pm, data, config, level, prio, api)
  */
-DEVICE_DT_DEFINE(DT_NODELABEL(test_dev0_boot), NULL, NULL, NULL, NULL, POST_KERNEL, 33, NULL);
-
 DEVICE_DT_DEFINE(DT_NODELABEL(test_dev1_dfr), NULL, NULL, NULL, NULL, POST_KERNEL, 33, NULL);
 
 static int fake_pm_action(const struct device *dev,
 		enum pm_device_action pm_action) { return -1; }
 PM_DEVICE_DT_DEFINE(DT_NODELABEL(test_dev0_boot), fake_pm_action);
+
+DEVICE_DT_DEFINE(DT_NODELABEL(test_dev0_boot), NULL,
+		 PM_DEVICE_DT_GET(DT_NODELABEL(test_dev0_boot)), NULL, NULL, POST_KERNEL, 34, NULL);


### PR DESCRIPTION
C++ file compilation is actually missing the warning-as-error handling, causing warnings in build files to be unnoticed in CI. Add a flag to handle them as well.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/78348

Pushed on https://github.com/zephyrproject-rtos/zephyr-testing/tree/vfabio-testing-branch as well