### PR TITLE
net: shell: increase number of arguments to net suspend command

### DIFF
--- a/subsys/net/lib/shell/suspend.c
+++ b/subsys/net/lib/shell/suspend.c
@@ -56,4 +56,4 @@ static int cmd_net_suspend(const struct shell *sh, size_t argc, char *argv[])
 
 SHELL_SUBCMD_ADD((net), suspend, NULL,
 		 "Suspend a network interface",
-		 cmd_net_suspend, 1, 0);
+		 cmd_net_suspend, 2, 0);


### PR DESCRIPTION
Increased variable to the mandatory amount of commands, since the comment of SHELL_SUBCMD_ADD states

"Number of mandatory arguments including command name"

but net suspend takes the interface number to suspend