### PR TITLE
lib/libc/Kconfig: Fix libC depends with NATIVE_APPlICATION

### DIFF
--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -27,6 +27,7 @@ config FULL_LIBC_SUPPORTED
 
 config MINIMAL_LIBC_SUPPORTED
 	bool
+	depends on !NATIVE_APPLICATION
 	default y
 	help
 	  Selected when the target has support for the minimal C library
@@ -35,6 +36,7 @@ config NEWLIB_LIBC_SUPPORTED
 	bool
 	default y
 	depends on "$(TOOLCHAIN_HAS_NEWLIB)" = "y"
+	depends on !NATIVE_APPLICATION
 	select FULL_LIBC_SUPPORTED
 	help
 	  Selected when the target has support for the newlib C library
@@ -66,7 +68,6 @@ choice LIBC_IMPLEMENTATION
 
 config MINIMAL_LIBC
 	bool "Minimal C library"
-	depends on !NATIVE_APPLICATION
 	depends on !REQUIRES_FULL_LIBC
 	depends on MINIMAL_LIBC_SUPPORTED
 	imply COMPILER_FREESTANDING
@@ -85,7 +86,6 @@ config PICOLIBC
 	select LIBC_ERRNO if THREAD_LOCAL_STORAGE
 	select NEED_LIBC_MEM_PARTITION
 	imply COMMON_LIBC_MALLOC
-	depends on !NATIVE_APPLICATION
 	depends on PICOLIBC_SUPPORTED
 	help
 	  Build with picolibc library. The picolibc library is built as
@@ -95,7 +95,6 @@ config PICOLIBC
 config NEWLIB_LIBC
 	bool "Newlib C library"
 	select COMMON_LIBC_ABORT
-	depends on !NATIVE_APPLICATION
 	depends on NEWLIB_LIBC_SUPPORTED
 	select NEED_LIBC_MEM_PARTITION
 	imply POSIX_DEVICE_IO_ALIAS_CLOSE

--- a/tests/lib/c_lib/common/src/main.c
+++ b/tests/lib/c_lib/common/src/main.c
@@ -1166,6 +1166,9 @@ ZTEST(libc_common, test_time_ctime)
 	char buf[26] = {0};
 	time_t test1 = 1718260000;
 
+#ifdef CONFIG_NATIVE_LIBC
+	setenv("TZ", "UTC", 1);
+#endif
 	zassert_not_null(ctime_r(&test1, buf));
 	zassert_equal(strncmp("Thu Jun 13 06:26:40 2024\n", buf, sizeof(buf)), 0);
 


### PR DESCRIPTION
NATIVE_APPlICATION (old native_posix) does not support bulding with the any other C library than the host libC (EXTERNAL_LIBC).

MINIMAL_LIBC_SUPPORTED defaulted to y always, and instead the depends was set in the LIBC_IMPLEMENTATION choice.
This lead to the right library selected, but an incorrectly set MINIMAL_LIBC_SUPPORTED.
Many tests filter based on MINIMAL_LIBC_SUPPORTED, so they were not filtered out appropriately.

Let's place the depends in the right place to avoid this problem. Also remove a redundant depends on for PICOLIBC and NEWLIB_LIBC which already have the dependency in their respective _SUPPORTED option.

Fixes #78427
@keith-packard I needed to cherry-pick your fix for that same test from your other PR, as it would otherwise also trigger here.