### PR TITLE
drivers: video: gc2145:  fixes compatible prefix of gc2145

### DIFF
--- a/drivers/video/Kconfig.gc2145
+++ b/drivers/video/Kconfig.gc2145
@@ -4,7 +4,7 @@
 config VIDEO_GC2145
 	bool "GC2145 CMOS digital image sensor"
 	select I2C
-	depends on DT_HAS_GC_GC2145_ENABLED
+	depends on DT_HAS_GALAXYCORE_GC2145_ENABLED
 	default y
 	help
 	  Enable driver for GC2145 CMOS digital image sensor device.

--- a/drivers/video/gc2145.c
+++ b/drivers/video/gc2145.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT gc_gc2145
+#define DT_DRV_COMPAT galaxycore_gc2145
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 

--- a/dts/bindings/video/galaxycore,gc2145.yaml
+++ b/dts/bindings/video/galaxycore,gc2145.yaml
@@ -3,7 +3,7 @@
 
 description: Galaxy Core GC2145 CMOS video sensor
 
-compatible: "gc,gc2145"
+compatible: "galaxycore,gc2145"
 
 include: i2c-device.yaml
 


### PR DESCRIPTION
This change is required to fix dts error of unknown vendor when parsing the compatible string when instancing gc2145.

Although it builds applications correctly, this error makes the ci to fail if some board instance this sensor on its dts, this is caused because it was not using the already existing prefix galaxycore, it was merged using gc prefix instead.
