### PR TITLE
scripts: dts: properly escape string properties

### DIFF
--- a/dts/bindings/test/vnd,string-array.yaml
+++ b/dts/bindings/test/vnd,string-array.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) 2024 Zephyr Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test string array property container
+
+compatible: "vnd,string-array"
+
+properties:
+  val:
+    type: string-array
+    required: true

--- a/dts/bindings/test/vnd,string.yaml
+++ b/dts/bindings/test/vnd,string.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) 2024 Zephyr Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test string property container
+
+compatible: "vnd,string"
+
+properties:
+  val:
+    type: string
+    required: true

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -583,7 +583,7 @@ def write_vanilla_props(node: edtlib.Node) -> None:
 
         if prop.spec.type == 'string':
             # DT_N_<node-id>_P_<prop-id>_IDX_<i>_STRING_UNQUOTED
-            macro2val[macro + "_STRING_UNQUOTED"] = prop.val
+            macro2val[macro + "_STRING_UNQUOTED"] = escape_unquoted(prop.val)
             # DT_N_<node-id>_P_<prop-id>_IDX_<i>_STRING_TOKEN
             macro2val[macro + "_STRING_TOKEN"] = prop.val_as_token
             # DT_N_<node-id>_P_<prop-id>_IDX_<i>_STRING_UPPER_TOKEN
@@ -626,7 +626,7 @@ def write_vanilla_props(node: edtlib.Node) -> None:
                     macro2val[macro + f"_IDX_{i}"] = quote_str(subval)
                     subval_as_token = edtlib.str_as_token(subval)
                     # DT_N_<node-id>_P_<prop-id>_IDX_<i>_STRING_UNQUOTED
-                    macro2val[macro + f"_IDX_{i}_STRING_UNQUOTED"] = subval
+                    macro2val[macro + f"_IDX_{i}_STRING_UNQUOTED"] = escape_unquoted(subval)
                     # DT_N_<node-id>_P_<prop-id>_IDX_<i>_STRING_TOKEN
                     macro2val[macro + f"_IDX_{i}_STRING_TOKEN"] = subval_as_token
                     # DT_N_<node-id>_P_<prop-id>_IDX_<i>_STRING_UPPER_TOKEN
@@ -1020,11 +1020,20 @@ def out_comment(s: str, blank_before=True) -> None:
         print("/* " + s + " */", file=header_file)
 
 
-def escape(s: str) -> str:
-    # Backslash-escapes any double quotes and backslashes in 's'
+ESCAPE_TABLE = str.maketrans(
+    {
+        "\n": "\\n",
+        "\r": "\\r",
+        "\\": "\\\\",
+        '"': '\\"',
+    }
+)
 
-    # \ must be escaped before " to avoid double escaping
-    return s.replace("\\", "\\\\").replace('"', '\\"')
+
+def escape(s: str) -> str:
+    # Backslash-escapes any double quotes, backslashes, and new lines in 's'
+
+    return s.translate(ESCAPE_TABLE)
 
 
 def quote_str(s: str) -> str:
@@ -1032,6 +1041,15 @@ def quote_str(s: str) -> str:
     # backslashes within it
 
     return f'"{escape(s)}"'
+
+
+def escape_unquoted(s: str) -> str:
+    # C macros cannot contain line breaks, so replace them with spaces.
+    # Whitespace is used to separate preprocessor tokens, but it does not matter
+    # which whitespace characters are used, so a line break and a space are
+    # equivalent with regards to unquoted strings being used as C code.
+
+    return s.replace("\r", " ").replace("\n", " ")
 
 
 def err(s: str) -> NoReturn:

--- a/scripts/dts/gen_dts_cmake.py
+++ b/scripts/dts/gen_dts_cmake.py
@@ -48,6 +48,22 @@ from collections import defaultdict
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'python-devicetree',
                                 'src'))
 
+ESCAPE_TABLE = str.maketrans(
+    {
+        "\n": "\\n",
+        "\r": "\\r",
+        '\"': '\\"',
+        "\\": "\\\\",
+    }
+)
+
+
+def escape(value):
+    if isinstance(value, str):
+        return value.translate(ESCAPE_TABLE)
+
+    return value
+
 
 def parse_args():
     # Returns parsed command-line arguments
@@ -117,7 +133,7 @@ def main():
                 # Encode node's property 'item' as a CMake target property
                 # with a name like 'DT_PROP|<path>|<property>'.
                 cmake_prop = f'DT_PROP|{node.path}|{item}'
-                cmake_props.append(f'"{cmake_prop}" "{cmake_value}"')
+                cmake_props.append(f'"{cmake_prop}" "{escape(cmake_value)}"')
 
                 if item == 'compatible':
                     # compatibles is always an array

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -687,6 +687,20 @@
 			val = "XA XPLUS XB";
 		};
 
+		test_str_unquoted_esc_t: string-unquoted-escape-t {
+			compatible = "vnd,string-unquoted";
+			val = "XA\nXPLUS\nXB";
+		};
+
+		/*
+		 * Tests expect all vnd,string-unquoted instances to evaluate to doubles,
+		 * so use vnd,string instead.
+		 */
+		test_str_unquoted_esc_s: string-unquoted-escape-s {
+			compatible = "vnd,string";
+			val = "XSTR1 \" plus \" XSTR2";
+		};
+
 		test_stra_unquoted_f0: string-array-unquoted-f0 {
 			compatible = "vnd,string-array-unquoted";
 			val = "1.0e2", "2.0e2", "3.0e2", "4.0e2";
@@ -700,6 +714,43 @@
 		test_stra_unquoted_t: string-array-unquoted-t {
 			compatible = "vnd,string-array-unquoted";
 			val = "XA XPLUS XB", "XC XPLUS XD", "XA XMINUS XB", "XC XMINUS XD";
+		};
+
+		/*
+		 * Tests expect all vnd,string-array-unquoted instances to evaluate to doubles,
+		 * so use vnd,string-array instead.
+		 */
+		test_stra_unquoted_esc: string-array-unquoted-escape {
+			compatible = "vnd,string-array";
+			val = "XA\nXPLUS\nXB", "XSTR1 \" plus \" XSTR2";
+		};
+
+		test_str_escape_0: string-escape-0 {
+			compatible = "vnd,string";
+			val = "\a\b\f\n\r\t\v";
+		};
+
+		test_str_escape_1: string-escape-1 {
+			compatible = "vnd,string";
+			val = "\'single\' \"double\"";
+		};
+
+		test_str_escape_2: string-escape-2 {
+			compatible = "vnd,string";
+			val = "first\nsecond";
+		};
+
+		test_str_escape_3: string-escape-3 {
+			compatible = "vnd,string";
+			val = "\x01\x7F";
+		};
+
+		test_stra_escape: string-array-escape {
+			compatible = "vnd,string-array";
+			val = "\a\b\f\n\r\t\v",
+			      "\'single\' \"double\"",
+			      "first\nsecond",
+			      "\x01\x7F";
 		};
 
 		test-mtd@ffeeddcc {

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -3179,6 +3179,8 @@ ZTEST(devicetree_api, test_string_unquoted)
 #define XA 12.0
 #define XB 34.0
 #define XPLUS +
+#define XSTR1 "one"
+#define XSTR2 "two"
 	const double f0_expected = 0.1234;
 	const double f1_expected = 0.9e-3;
 	const double delta = 0.1e-4;
@@ -3190,6 +3192,10 @@ ZTEST(devicetree_api, test_string_unquoted)
 		       f1_expected, delta, "");
 	zassert_within(DT_STRING_UNQUOTED(DT_NODELABEL(test_str_unquoted_t), val),
 		       XA XPLUS XB, delta, "");
+	zassert_within(DT_STRING_UNQUOTED(DT_NODELABEL(test_str_unquoted_esc_t), val), XA XPLUS XB,
+		       delta, "");
+	zassert_str_equal(DT_STRING_UNQUOTED(DT_NODELABEL(test_str_unquoted_esc_s), val),
+			  "one plus two");
 	/* Test DT_STRING_UNQUOTED_OR */
 	zassert_within(DT_STRING_UNQUOTED_OR(DT_NODELABEL(test_str_unquoted_f0), val, (0.0)),
 		       f0_expected, delta, "");
@@ -3197,12 +3203,20 @@ ZTEST(devicetree_api, test_string_unquoted)
 		       f1_expected, delta, "");
 	zassert_within(DT_STRING_UNQUOTED_OR(DT_NODELABEL(test_str_unquoted_t), val, (0.0)),
 		       XA XPLUS XB, delta, "");
+	zassert_within(DT_STRING_UNQUOTED_OR(DT_NODELABEL(test_str_unquoted_esc_t), val, (0.0)),
+		       XA XPLUS XB, delta, "");
+	zassert_str_equal(DT_STRING_UNQUOTED_OR(DT_NODELABEL(test_str_unquoted_esc_s), val, "nak"),
+			  "one plus two");
 	zassert_within(DT_STRING_UNQUOTED_OR(DT_NODELABEL(test_str_unquoted_f0), nak, (0.0)),
 		       0.0, delta, "");
 	zassert_within(DT_STRING_UNQUOTED_OR(DT_NODELABEL(test_str_unquoted_f1), nak, (0.0)),
 		       0.0, delta, "");
 	zassert_within(DT_STRING_UNQUOTED_OR(DT_NODELABEL(test_str_unquoted_t), nak, (0.0)),
 		       0.0, delta, "");
+	zassert_within(DT_STRING_UNQUOTED_OR(DT_NODELABEL(test_str_unquoted_esc_t), nak, (0.0)),
+		       0.0, delta, "");
+	zassert_str_equal(DT_STRING_UNQUOTED_OR(DT_NODELABEL(test_str_unquoted_esc_s), nak, "nak"),
+			  "nak");
 	/* Test DT_INST_STRING_UNQUOTED */
 #define STRING_UNQUOTED_VAR(node_id) _CONCAT(var_, node_id)
 #define STRING_UNQUOTED_TEST_INST_EXPANSION(inst) \
@@ -3214,6 +3228,8 @@ ZTEST(devicetree_api, test_string_unquoted)
 	zassert_within(STRING_UNQUOTED_VAR(DT_NODELABEL(test_str_unquoted_f1)),
 		       f1_expected, delta, "");
 	zassert_within(STRING_UNQUOTED_VAR(DT_NODELABEL(test_str_unquoted_t)), XA XPLUS XB,
+		       delta, "");
+	zassert_within(STRING_UNQUOTED_VAR(DT_NODELABEL(test_str_unquoted_esc_t)), XA XPLUS XB,
 		       delta, "");
 
 	/* Test DT_INST_STRING_UNQUOTED_OR */
@@ -3231,15 +3247,21 @@ ZTEST(devicetree_api, test_string_unquoted)
 		       f1_expected, delta, "");
 	zassert_within(STRING_UNQUOTED_OR_VAR(DT_NODELABEL(test_str_unquoted_t))[0],
 		       XA XPLUS XB, delta, "");
+	zassert_within(STRING_UNQUOTED_OR_VAR(DT_NODELABEL(test_str_unquoted_esc_t))[0],
+		       XA XPLUS XB, delta, "");
 	zassert_within(STRING_UNQUOTED_OR_VAR(DT_NODELABEL(test_str_unquoted_f0))[1],
 		       1.0e10, delta, "");
 	zassert_within(STRING_UNQUOTED_OR_VAR(DT_NODELABEL(test_str_unquoted_f1))[1],
 		       1.0e10, delta, "");
 	zassert_within(STRING_UNQUOTED_OR_VAR(DT_NODELABEL(test_str_unquoted_t))[1],
 		       1.0e10, delta, "");
+	zassert_within(STRING_UNQUOTED_OR_VAR(DT_NODELABEL(test_str_unquoted_esc_t))[1], 1.0e10,
+		       delta, "");
 #undef XA
 #undef XB
 #undef XPLUS
+#undef XSTR1
+#undef XSTR2
 }
 
 #undef DT_DRV_COMPAT
@@ -3252,6 +3274,8 @@ ZTEST(devicetree_api, test_string_idx_unquoted)
 #define XD 78.0
 #define XPLUS +
 #define XMINUS -
+#define XSTR1  "one"
+#define XSTR2  "two"
 	const double delta = 0.1e-4;
 
 	/* DT_STRING_UNQUOTED_BY_IDX */
@@ -3281,6 +3305,11 @@ ZTEST(devicetree_api, test_string_idx_unquoted)
 		       XA XMINUS XB,  delta, "");
 	zassert_within(DT_STRING_UNQUOTED_BY_IDX(DT_NODELABEL(test_stra_unquoted_t), val, 3),
 		       XC XMINUS XD, delta, "");
+
+	zassert_within(DT_STRING_UNQUOTED_BY_IDX(DT_NODELABEL(test_stra_unquoted_esc), val, 0),
+		       XA XPLUS XB, delta, "");
+	zassert_str_equal(DT_STRING_UNQUOTED_BY_IDX(DT_NODELABEL(test_stra_unquoted_esc), val, 1),
+			  "one plus two");
 
 #define STRING_UNQUOTED_BY_IDX_VAR(node_id) _CONCAT(var_, node_id)
 #define STRING_UNQUOTED_BY_IDX_TEST_INST_EXPANSION(inst)       \
@@ -3324,6 +3353,26 @@ ZTEST(devicetree_api, test_string_idx_unquoted)
 #undef XD
 #undef XPLUS
 #undef XMINUS
+#undef XSTR1
+#undef XSTR2
+}
+
+#undef DT_DRV_COMPAT
+ZTEST(devicetree_api, test_string_escape)
+{
+	zassert_str_equal(DT_PROP(DT_NODELABEL(test_str_escape_0), val), "\a\b\f\n\r\t\v");
+	zassert_str_equal(DT_PROP(DT_NODELABEL(test_str_escape_1), val), "\'single\' \"double\"");
+	zassert_str_equal(DT_PROP(DT_NODELABEL(test_str_escape_2), val), "first\nsecond");
+	zassert_str_equal(DT_PROP(DT_NODELABEL(test_str_escape_3), val), "\x01\x7F");
+}
+
+ZTEST(devicetree_api, test_string_array_escape)
+{
+	zassert_str_equal(DT_PROP_BY_IDX(DT_NODELABEL(test_stra_escape), val, 0), "\a\b\f\n\r\t\v");
+	zassert_str_equal(DT_PROP_BY_IDX(DT_NODELABEL(test_stra_escape), val, 1),
+			  "\'single\' \"double\"");
+	zassert_str_equal(DT_PROP_BY_IDX(DT_NODELABEL(test_stra_escape), val, 2), "first\nsecond");
+	zassert_str_equal(DT_PROP_BY_IDX(DT_NODELABEL(test_stra_escape), val, 3), "\x01\x7F");
 }
 
 #undef DT_DRV_COMPAT


### PR DESCRIPTION
Fixed escaping of double quotes, backslashes, and new line characters so they can be used in string properties.

Previously, double quotes and backslashes were escaped in gen_defines.py but not in gen_dts_cmake.py, and new lines were not escaped in either, so using any of these characters would break the build. These characters aren't typically used in devicetree (I found this while working on a feature for [ZMK](https://zmk.dev/), whose keymaps system is probably an atypical use of devicetree), but I don't see why they _shouldn't_ be supported.

This may conflict with #78159, but the conflicts look minimal.