### PR TITLE
doc: i2c, i3c: remove unnecessary preposition 'in'

### DIFF
--- a/doc/hardware/peripherals/i2c.rst
+++ b/doc/hardware/peripherals/i2c.rst
@@ -27,7 +27,7 @@ I2C Controller API
 ==================
 
 Zephyr's I2C controller API is used when an I2C peripheral controls the bus,
-in particularly the start and stop conditions and the clock.  This is
+particularly the start and stop conditions and the clock.  This is
 the most common mode, used to interact with I2C devices like sensors and
 serial memory.
 

--- a/doc/hardware/peripherals/i3c.rst
+++ b/doc/hardware/peripherals/i3c.rst
@@ -21,7 +21,7 @@ I3C Controller API
 ******************
 
 Zephyr's I3C controller API is used when an I3C controller controls
-the bus, in particularly the start and stop conditions and the clock.
+the bus, particularly the start and stop conditions and the clock.
 This is the most common mode, used to interact with I3C target
 devices such as sensors.
 


### PR DESCRIPTION
This commit removes the preposition "in" from the phrase "in particularly"
in the I2C and I3C Controller API sections to improve readability.