### PR TITLE
boards: silabs: slstk3401a: Fix unit and first address mismatch

### DIFF
--- a/boards/silabs/starter_kits/slstk3401a/slstk3401a-common.dtsi
+++ b/boards/silabs/starter_kits/slstk3401a/slstk3401a-common.dtsi
@@ -127,7 +127,7 @@
 		#size-cells = <1>;
 
 		/* Set 6Kb of storage at the end of the 256Kb of flash */
-		storage_partition: partition@fe800 {
+		storage_partition: partition@3e800 {
 			label = "storage";
 			reg = <0x0003e800 0x00001800>;
 		};


### PR DESCRIPTION
This fixes the following warning:

> unit address and first address in 'reg' (0x3e800) don't match for
> /soc/flash-controller@400e0000/flash@0/partitions/partition@fe800