### PR TITLE
boards: google: twinkie_v2: Fix unit and first address mismatch

### DIFF
--- a/boards/google/twinkie_v2/google_twinkie_v2.dts
+++ b/boards/google/twinkie_v2/google_twinkie_v2.dts
@@ -123,7 +123,7 @@
 		zephyr,resolution = <12>;
 	};
 
-	channel@15 {
+	channel@f {
 		reg = <15>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
@@ -132,7 +132,7 @@
 		zephyr,resolution = <12>;
 	};
 
-	channel@17 {
+	channel@11 {
 		reg = <17>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
@@ -141,7 +141,7 @@
 		zephyr,resolution = <12>;
 	};
 
-	channel@18 {
+	channel@12 {
 		reg = <18>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";


### PR DESCRIPTION
This fixes the following kind of warnings:

> unit address and first address in 'reg' (0xf) don't match for
> /soc/adc@40012400/channel@15