### PR TITLE
boards: arm: v2m_musca_s1: Fix unit and first address mismatch

### DIFF
--- a/boards/arm/v2m_musca_s1/v2m_musca_s1_musca_s1_ns.dts
+++ b/boards/arm/v2m_musca_s1/v2m_musca_s1_musca_s1_ns.dts
@@ -41,7 +41,7 @@
 		};
 	};
 
-	mram0: mram@a080400 {
+	mram0: mram@a080000 {
 		/* Internal code eMRAM */
 		reg = <0x0a080000 0x80000>;
 	};


### PR DESCRIPTION
This fixes the following warnings:

> unit address and first address in 'reg' (0xa080000) don't match for
> /mram@a080400