### PR TITLE
boards: ct: ctcc: Fix unit and first address mismatch

### DIFF
--- a/boards/ct/ctcc/ctcc_nrf52840.dts
+++ b/boards/ct/ctcc/ctcc_nrf52840.dts
@@ -58,7 +58,7 @@
 			label = "image-0";
 			reg = <0x00012000 0x00076000>;
 		};
-		slot1_partition: partition@87000 {
+		slot1_partition: partition@88000 {
 			label = "image-1";
 			reg = <0x00088000 0x00074000>;
 		};


### PR DESCRIPTION
This fixes the following warning:

> unit address and first address in 'reg' (0x88000) don't match for
> /soc/flash-controller@4001e000/flash@0/partitions/partition@87000