### PR TITLE
dts: nios2: intel: Fix unit and first address mismatch

### DIFF
--- a/dts/nios2/intel/nios2f.dtsi
+++ b/dts/nios2/intel/nios2f.dtsi
@@ -59,7 +59,7 @@
 			interrupts = <4 10>;
 		};
 
-		dma: dma@100200 {
+		dma: dma@1002c0 {
 			compatible = "altr,msgdma";
 			reg = <0x1002c0 0x30>;
 			interrupts = <3 3>;


### PR DESCRIPTION
This fixes the following warning:

> unit address and first address in 'reg' (0x1002c0) don't match for
> /soc/dma@100200