### PR TITLE
boards: arduino: nano_33_iot: Fix unit and first address mismatch

### DIFF
--- a/boards/arduino/nano_33_iot/arduino_nano_33_iot.dts
+++ b/boards/arduino/nano_33_iot/arduino_nano_33_iot.dts
@@ -114,7 +114,7 @@
 		reg = <0x6a>;
 	};
 
-	atecc608a@15 {
+	atecc608a@6a {
 		compatible = "atmel,atecc608";
 		reg = <0x6a>;
 	};


### PR DESCRIPTION
This fixes the following warning:

> unit address and first address in 'reg' (0x6a) don't match for
> /soc/sercom@42001800/atecc608a@15