### PR TITLE
boards: renesas: Fix unit and first address mismatch

### DIFF
--- a/boards/renesas/da14695_dk_usb/da14695_dk_usb.dts
+++ b/boards/renesas/da14695_dk_usb/da14695_dk_usb.dts
@@ -118,7 +118,7 @@
 			label = "image-0";
 			reg = <0x0000c000 0x00076000>;
 		};
-		slot1_partition: partition@80000 {
+		slot1_partition: partition@82000 {
 			label = "image-1";
 			reg = <0x00082000 0x00076000>;
 		};

--- a/boards/renesas/da1469x_dk_pro/da1469x_dk_pro.dts
+++ b/boards/renesas/da1469x_dk_pro/da1469x_dk_pro.dts
@@ -96,7 +96,7 @@
 			label = "image-0";
 			reg = <0x0000c000 0x00076000>;
 		};
-		slot1_partition: partition@80000 {
+		slot1_partition: partition@82000 {
 			label = "image-1";
 			reg = <0x00082000 0x00076000>;
 		};

--- a/dts/arm/renesas/rz/rzt2m.dtsi
+++ b/dts/arm/renesas/rz/rzt2m.dtsi
@@ -89,7 +89,7 @@
 			reg-io-width = <4>;
 		};
 
-		sckcr: sckcr@81280004 {
+		sckcr: sckcr@80280000 {
 			/* System Clock Control Register*/
 			compatible = "syscon";
 			reg = <0x80280000 0x20>;


### PR DESCRIPTION
This fixes the following warnings:

> unit address and first address in 'reg' (0x82000) don't match for
> /soc/flash-controller@38000000/flash@16000000/partitions/partition@80000

> unit address and first address in 'reg' (0x82000) don't match for
> /soc/flash-controller@38000000/flash@16000000/partitions/partition@80000