### PR TITLE
nxp: Fix address mismatches

### DIFF
--- a/boards/nxp/frdm_kw41z/frdm_kw41z.dts
+++ b/boards/nxp/frdm_kw41z/frdm_kw41z.dts
@@ -184,7 +184,7 @@
 			label = "image-0";
 			reg = <0x00000000 0x00070000>;
 		};
-		storage_partition: partition@700000 {
+		storage_partition: partition@70000 {
 			label = "storage";
 			reg = <0x00070000 0x00010000>;
 		};

--- a/boards/nxp/frdm_mcxn236/frdm_mcxn236.dtsi
+++ b/boards/nxp/frdm_mcxn236/frdm_mcxn236.dtsi
@@ -107,7 +107,7 @@
 			label = "image-0";
 			reg = <0x00010000 DT_SIZE_K(480)>;
 		};
-		slot1_partition: partition@80000 {
+		slot1_partition: partition@88000 {
 			label = "image-1";
 			reg = <0x0088000 DT_SIZE_K(472)>;
 		};

--- a/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_a53.dts
+++ b/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_a53.dts
@@ -54,7 +54,7 @@
 	pinctrl-0 = <&pinmux_mdio>;
 	pinctrl-names = "default";
 	status = "okay";
-	phy: phy@0 {
+	phy: phy@1 {
 		compatible = "realtek,rtl8211f";
 		reg = <1>;
 		status = "okay";

--- a/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_a53_smp.dts
+++ b/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_a53_smp.dts
@@ -56,7 +56,7 @@
 	pinctrl-0 = <&pinmux_mdio>;
 	pinctrl-names = "default";
 	status = "okay";
-	phy: phy@0 {
+	phy: phy@1 {
 		compatible = "realtek,rtl8211f";
 		reg = <1>;
 		status = "okay";

--- a/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.dts
+++ b/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.dts
@@ -89,7 +89,7 @@
 	pinctrl-0 = <&pinmux_mdio>;
 	pinctrl-names = "default";
 	status = "okay";
-	phy: phy@0 {
+	phy: phy@2 {
 		compatible = "realtek,rtl8211f";
 		reg = <2>;
 		status = "okay";

--- a/boards/nxp/usb_kw24d512/usb_kw24d512.dts
+++ b/boards/nxp/usb_kw24d512/usb_kw24d512.dts
@@ -106,7 +106,7 @@ zephyr_udc0: &usbd {
 			label = "image-0";
 			reg = <0x00000000 0x00070000>;
 		};
-		storage_partition: partition@700000 {
+		storage_partition: partition@70000 {
 			label = "storage";
 			reg = <0x00070000 0x00010000>;
 		};

--- a/dts/arm/nxp/nxp_lpc55S0x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S0x_common.dtsi
@@ -95,7 +95,7 @@
 			status = "disabled";
 		};
 
-		uuid: flash@9fc70 {
+		uuid: flash@3fc70 {
 			compatible = "nxp,lpc-uid";
 			reg = <0x3fc70 0x10>;
 		};

--- a/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
@@ -319,7 +319,7 @@
 		status = "okay";
 	};
 
-	usbhs: usbhs@144000 {
+	usbhs: usbhs@94000 {
 		compatible = "nxp,lpcip3511";
 		reg = <0x94000 0x1000>;
 		interrupts = <47 1>;

--- a/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
@@ -102,7 +102,7 @@
 			status = "disabled";
 		};
 
-		uuid: flash@9fc70 {
+		uuid: flash@3fc70 {
 			compatible = "nxp,lpc-uid";
 			reg = <0x3fc70 0x10>;
 		};

--- a/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
@@ -313,7 +313,7 @@
 		clocks = <&syscon MCUX_LPADC1_CLK>;
 	};
 
-	usbhs: usbhs@144000 {
+	usbhs: usbhs@94000 {
 		compatible = "nxp,lpcip3511";
 		reg = <0x94000 0x1000>;
 		interrupts = <47 1>;


### PR DESCRIPTION
This fixes the following kind of warnings:

> devicetree error: unit address and first address in 'reg' (0x70000)
> don't match for
> /soc/flash-controller@40020000/flash@0/partitions/partition@700000