### PR TITLE
boards: npx: Fix address mismatches

### DIFF
--- a/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
+++ b/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
@@ -466,7 +466,7 @@ zephyr_udc0: &usbhs {
 
 	status = "okay";
 
-	audio_codec: wm8904@1a {
+	audio_codec: wm8904@1a0000000000000000 {
 		compatible = "wolfson,wm8904";
 		reg = <0x1a 0 0>;
 		clock-source = "MCLK";

--- a/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
+++ b/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
@@ -393,7 +393,7 @@ zephyr_udc0: &usbhs {
 
 	status = "okay";
 
-	audio_codec: wm8904@1a {
+	audio_codec: wm8904@1a0000000000000000 {
 		compatible = "wolfson,wm8904";
 		reg = <0x1a 0 0>;
 


### PR DESCRIPTION
This silences the following warning:

> unit address and first address in 'reg' (0x1a0000000000000000) don't
> match for /soc/peripheral@50000000/i3c@36000/wm8904@1a

<s>I am not sure however, whether this is just painting over a DT bug: It seems like the existing code with `reg = <0x1a 0 0>;` and `wm8904@1a` is already correct. Where does the huge number (0x1a0000000000000000) come from?

And ideas?</s>