### PR TITLE
boards: nordic: nrf52805: Fix slot1_partition base address

### DIFF
--- a/boards/nordic/nrf52dk/nrf52dk_nrf52805.dts
+++ b/boards/nordic/nrf52dk/nrf52dk_nrf52805.dts
@@ -144,9 +144,9 @@
 			label = "image-0";
 			reg = <0x0000C000 0xe000>;
 		};
-		slot1_partition: partition@19000 {
+		slot1_partition: partition@1a000 {
 			label = "image-1";
-			reg = <0x00020000 0xe000>;
+			reg = <0x0001a000 0xe000>;
 		};
 		storage_partition: partition@28000 {
 			label = "storage";


### PR DESCRIPTION
This prevents an overlap with `storage_partition`

Additionally, it fixes the following warning:

> unit address and first address in 'reg' (0x20000) don't match for
> /soc/flash-controller@4001e000/flash@0/partitions/partition@19000