### PR TITLE
edtlib: Remove unreachable code

### DIFF
--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -2267,7 +2267,6 @@ class EDT:
                 _err(
                         f"'{binding_path}' appears in binding directories "
                         f"but isn't valid YAML: {e}")
-                continue
 
             # Convert the raw data to a Binding object, erroring out
             # if necessary.


### PR DESCRIPTION
This fixes the following error reported by
./scripts/ci/check_compliance.py:

> 1 checks failed
> ERROR   : Test Pylint failed:
> W0101:Unreachable code (unreachable)
> File:scripts/dts/python-devicetree/src/devicetree/edtlib.py
> Line:2271
> Column:16
>
> Complete results in compliance.xml