### PR TITLE
usb: cdc_acm: disable logging if used for shell with logging

### DIFF
--- a/subsys/usb/device/class/cdc_acm.c
+++ b/subsys/usb/device/class/cdc_acm.c
@@ -56,14 +56,16 @@
 /* definitions */
 
 #include <zephyr/logging/log.h>
-#if DT_NODE_HAS_COMPAT(DT_CHOSEN(zephyr_console), zephyr_cdc_acm_uart) \
-	&& defined(CONFIG_LOG_BACKEND_UART) \
-	&& defined(CONFIG_USB_CDC_ACM_LOG_LEVEL) \
-	&& CONFIG_USB_CDC_ACM_LOG_LEVEL != LOG_LEVEL_NONE
 /* Prevent endless recursive logging loop and warn user about it */
+#if defined(CONFIG_USB_CDC_ACM_LOG_LEVEL) && CONFIG_USB_CDC_ACM_LOG_LEVEL != LOG_LEVEL_NONE
+#define CHOSEN_CONSOLE DT_NODE_HAS_COMPAT(DT_CHOSEN(zephyr_console), zephyr_cdc_acm_uart)
+#define CHOSEN_SHELL   DT_NODE_HAS_COMPAT(DT_CHOSEN(zephyr_shell_uart), zephyr_cdc_acm_uart)
+#if (CHOSEN_CONSOLE && defined(CONFIG_LOG_BACKEND_UART)) || \
+	(CHOSEN_SHELL && defined(CONFIG_SHELL_LOG_BACKEND))
 #warning "USB_CDC_ACM_LOG_LEVEL forced to LOG_LEVEL_NONE"
 #undef CONFIG_USB_CDC_ACM_LOG_LEVEL
 #define CONFIG_USB_CDC_ACM_LOG_LEVEL LOG_LEVEL_NONE
+#endif
 #endif
 LOG_MODULE_REGISTER(usb_cdc_acm, CONFIG_USB_CDC_ACM_LOG_LEVEL);
 

--- a/subsys/usb/device_next/class/usbd_cdc_acm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_acm.c
@@ -21,14 +21,16 @@
 #include "usbd_msg.h"
 
 #include <zephyr/logging/log.h>
-#if DT_NODE_HAS_COMPAT(DT_CHOSEN(zephyr_console), zephyr_cdc_acm_uart) \
-	&& defined(CONFIG_LOG_BACKEND_UART) \
-	&& defined(CONFIG_USBD_CDC_ACM_LOG_LEVEL) \
-	&& CONFIG_USBD_CDC_ACM_LOG_LEVEL != LOG_LEVEL_NONE
 /* Prevent endless recursive logging loop and warn user about it */
-#warning "USB_CDC_ACM_LOG_LEVEL forced to LOG_LEVEL_NONE"
+#if defined(CONFIG_USBD_CDC_ACM_LOG_LEVEL) && CONFIG_USBD_CDC_ACM_LOG_LEVEL != LOG_LEVEL_NONE
+#define CHOSEN_CONSOLE DT_NODE_HAS_COMPAT(DT_CHOSEN(zephyr_console), zephyr_cdc_acm_uart)
+#define CHOSEN_SHELL   DT_NODE_HAS_COMPAT(DT_CHOSEN(zephyr_shell_uart), zephyr_cdc_acm_uart)
+#if (CHOSEN_CONSOLE && defined(CONFIG_LOG_BACKEND_UART)) || \
+	(CHOSEN_SHELL && defined(CONFIG_SHELL_LOG_BACKEND))
+#warning "USBD_CDC_ACM_LOG_LEVEL forced to LOG_LEVEL_NONE"
 #undef CONFIG_USBD_CDC_ACM_LOG_LEVEL
 #define CONFIG_USBD_CDC_ACM_LOG_LEVEL LOG_LEVEL_NONE
+#endif
 #endif
 LOG_MODULE_REGISTER(usbd_cdc_acm, CONFIG_USBD_CDC_ACM_LOG_LEVEL);
 


### PR DESCRIPTION
This prevents recursive logging loop when USB CDC ACM is used for shell with logging.

Change affects both USB stacks.