### PR TITLE
boards: seagate: legend: Fix unit and first address mismatch

### DIFF
--- a/boards/seagate/legend/legend.dts
+++ b/boards/seagate/legend/legend.dts
@@ -137,7 +137,7 @@
 				label = "product-info";
 				reg = <0x00000000 DT_SIZE_K(4)>;
 			};
-			led_das: partition@10000 {
+			led_das: partition@1000 {
 				label = "led-das";
 				reg = <0x00001000 DT_SIZE_K(60)>;
 			};


### PR DESCRIPTION
This fixes the following warning:

> unit address and first address in 'reg' (0x1000) don't match for
> /soc/spi@40003800/spi_nor@0/partitions/partition@10000