### PR TITLE
boards: infineon: cyw920829m2: Fix unit and first address mismatch

### DIFF
--- a/boards/infineon/cyw920829m2evk_02/cyw920829m2evk_02.dts
+++ b/boards/infineon/cyw920829m2evk_02/cyw920829m2evk_02.dts
@@ -120,7 +120,7 @@ uart2: &scb2 {
 				#address-cells = <1>;
 				#size-cells = <1>;
 
-				storage_partition: storage_partition@70000 {
+				storage_partition: storage_partition@60000 {
 					compatible = "soc-nv-flash";
 					reg = <0x60000 DT_SIZE_K(64)>;
 				};


### PR DESCRIPTION
This fixes the following warning:

> unit address and first address in 'reg' (0x60000) don't match for
> /qspi_flash@40890000/flash@60000000/partitions/storage_partition@70000