### PR TITLE
tests: build_all: sensor: Fix i2c duplicate address

### DIFF
--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -1064,7 +1064,7 @@ test_i2c_lm95234: lm95234@90 {
 	status = "okay";
 };
 
-test_i2c_sht21@91 {
+test_i2c_sht21: sht21@91 {
 	compatible = "sensirion,sht21";
 	reg = <0x91>;
 };
@@ -1074,9 +1074,9 @@ test_i2c_lsm9ds1: lsm9ds1@92 {
 	reg = <0x92>;
 };
 
-test_i2c_icm42670: icm42670@92 {
+test_i2c_icm42670: icm42670@93 {
 	compatible = "invensense,icm42670";
-	reg = <0x92>;
+	reg = <0x93>;
 	int-gpios = <&test_gpio 0 0>;
 	accel-hz = <800>;
 	accel-fs = <16>;
@@ -1084,23 +1084,23 @@ test_i2c_icm42670: icm42670@92 {
 	gyro-fs = <2000>;
 };
 
-test_i2c_fxls8974: fxls8974@93 {
+test_i2c_fxls8974: fxls8974@94 {
 	compatible = "nxp,fxls8974";
-	reg = <0x93>;
+	reg = <0x94>;
 	reset-gpios = <&test_gpio 0 0>;
 	int1-gpios = <&test_gpio 0 0>;
 	int2-gpios = <&test_gpio 0 0>;
 };
 
-test_i2c_bmp180: bmp180@94 {
+test_i2c_bmp180: bmp180@95 {
 	compatible = "bosch,bmp180";
-	reg = <0x94>;
+	reg = <0x95>;
 	osr-press = <0x01>;
 };
 
-test_i2c_apds9253: apds9253@91 {
+test_i2c_apds9253: apds9253@96 {
 	compatible = "avago,apds9253";
-	reg = <0x91>;
+	reg = <0x96>;
 	int-gpios = <&test_gpio 0 0>;
 	gain = <APDS9253_GAIN_RANGE_1>;
 	rate = <APDS9253_MEASUREMENT_RATE_50MS>;


### PR DESCRIPTION
The address after @91 is messed up, so I fixed it.