### PR TITLE
style: drivers: adjust `return` usage in `void functions`

### DIFF
--- a/drivers/can/can_sja1000.c
+++ b/drivers/can/can_sja1000.c
@@ -23,7 +23,7 @@ static inline void can_sja1000_write_reg(const struct device *dev, uint8_t reg, 
 {
 	const struct can_sja1000_config *config = dev->config;
 
-	return config->write_reg(dev, reg, val);
+	config->write_reg(dev, reg, val);
 }
 
 static inline uint8_t can_sja1000_read_reg(const struct device *dev, uint8_t reg)

--- a/drivers/fpga/fpga_mpfs.c
+++ b/drivers/fpga/fpga_mpfs.c
@@ -58,7 +58,7 @@ static inline uint32_t scb_read(mm_reg_t add, mm_reg_t offset)
 
 static inline void scb_write(mm_reg_t add, mm_reg_t offset, uint32_t val)
 {
-	return sys_write32(val, add + offset);
+	sys_write32(val, add + offset);
 }
 
 /*This function add the index of new image into the spi directory at offset 0x004.

--- a/drivers/i2c/i2c_npcx_controller.c
+++ b/drivers/i2c/i2c_npcx_controller.c
@@ -593,7 +593,7 @@ static void i2c_ctrl_handle_write_int_event(const struct device *dev)
 		}
 	}
 
-	return i2c_ctrl_notify(dev, 0);
+	i2c_ctrl_notify(dev, 0);
 }
 
 static void i2c_ctrl_handle_read_int_event(const struct device *dev)
@@ -667,7 +667,7 @@ static void i2c_ctrl_handle_read_int_event(const struct device *dev)
 		data->oper_state = NPCX_I2C_READ_SUSPEND;
 	}
 
-	return i2c_ctrl_notify(dev, 0);
+	i2c_ctrl_notify(dev, 0);
 }
 
 static int i2c_ctrl_proc_write_msg(const struct device *dev,
@@ -871,7 +871,8 @@ static void i2c_ctrl_isr(const struct device *dev)
 
 #ifdef CONFIG_I2C_TARGET
 	if (atomic_test_bit(&data->flags, NPCX_I2C_FLAG_TARGET)) {
-		return i2c_ctrl_target_isr(dev, status);
+		i2c_ctrl_target_isr(dev, status);
+		return;
 	}
 #endif
 
@@ -906,16 +907,18 @@ static void i2c_ctrl_isr(const struct device *dev)
 		data->oper_state = NPCX_I2C_WAIT_STOP;
 
 		/* No such device or address */
-		return i2c_ctrl_notify(dev, -ENXIO);
+		i2c_ctrl_notify(dev, -ENXIO);
+		return;
 	}
 
 	/* START, tx FIFO empty or rx FIFO full has occurred */
 	if (IS_BIT_SET(status, NPCX_SMBST_SDAST)) {
 		if (data->is_write) {
-			return i2c_ctrl_handle_write_int_event(dev);
+			i2c_ctrl_handle_write_int_event(dev);
 		} else {
-			return i2c_ctrl_handle_read_int_event(dev);
+			i2c_ctrl_handle_read_int_event(dev);
 		}
+		return;
 	}
 
 	/* Clear unexpected status bits */

--- a/drivers/i3c/i3c_npcx.c
+++ b/drivers/i3c/i3c_npcx.c
@@ -1776,7 +1776,8 @@ static void npcx_i3c_isr(const struct device *dev)
 
 		/* MDMA write */
 		if (get_oper_state(dev) == NPCX_I3C_WR) {
-			return i3c_ctrl_notify(dev);
+			i3c_ctrl_notify(dev);
+			return;
 		}
 	}
 
@@ -1785,7 +1786,8 @@ static void npcx_i3c_isr(const struct device *dev)
 
 		/* MDMA read */
 		if (get_oper_state(dev) == NPCX_I3C_RD) {
-			return i3c_ctrl_notify(dev);
+			i3c_ctrl_notify(dev);
+			return;
 		}
 
 	}

--- a/drivers/serial/uart_cc13xx_cc26xx.c
+++ b/drivers/serial/uart_cc13xx_cc26xx.c
@@ -339,18 +339,14 @@ static void uart_cc13xx_cc26xx_irq_err_enable(const struct device *dev)
 {
 	const struct uart_cc13xx_cc26xx_config *config = dev->config;
 
-	return UARTIntEnable(config->reg,
-			     UART_INT_OE | UART_INT_BE | UART_INT_PE |
-				     UART_INT_FE);
+	UARTIntEnable(config->reg, UART_INT_OE | UART_INT_BE | UART_INT_PE | UART_INT_FE);
 }
 
 static void uart_cc13xx_cc26xx_irq_err_disable(const struct device *dev)
 {
 	const struct uart_cc13xx_cc26xx_config *config = dev->config;
 
-	return UARTIntDisable(config->reg,
-			      UART_INT_OE | UART_INT_BE | UART_INT_PE |
-				      UART_INT_FE);
+	UARTIntDisable(config->reg, UART_INT_OE | UART_INT_BE | UART_INT_PE | UART_INT_FE);
 }
 
 static int uart_cc13xx_cc26xx_irq_is_pending(const struct device *dev)

--- a/drivers/spi/spi_pw.c
+++ b/drivers/spi/spi_pw.c
@@ -31,7 +31,7 @@ static void spi_pw_reg_write(const struct device *dev,
 			     uint32_t offset,
 			     uint32_t val)
 {
-	return sys_write32(val, DEVICE_MMIO_GET(dev) + offset);
+	sys_write32(val, DEVICE_MMIO_GET(dev) + offset);
 }
 
 static void spi_pw_ssp_reset(const struct device *dev)

--- a/drivers/usb/udc/udc_nrf.c
+++ b/drivers/usb/udc/udc_nrf.c
@@ -177,7 +177,8 @@ static void udc_event_xfer_in(const struct device *dev,
 
 		udc_ep_set_busy(dev, ep, false);
 		if (ep == USB_CONTROL_EP_IN) {
-			return udc_event_xfer_ctrl_in(dev, buf);
+			udc_event_xfer_ctrl_in(dev, buf);
+			return;
 		}
 
 		udc_submit_ep_event(dev, buf, 0);

--- a/drivers/wifi/nrfwifi/src/shim.c
+++ b/drivers/wifi/nrfwifi/src/shim.c
@@ -585,7 +585,7 @@ static void *zep_shim_work_alloc(int type)
 
 static void zep_shim_work_free(void *item)
 {
-	return work_free(item);
+	work_free(item);
 }
 
 static void zep_shim_work_init(void *item, void (*callback)(unsigned long data),

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -1425,7 +1425,7 @@ static inline void z_impl_can_remove_rx_filter(const struct device *dev, int fil
 {
 	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
 
-	return api->remove_rx_filter(dev, filter_id);
+	api->remove_rx_filter(dev, filter_id);
 }
 
 /**

--- a/include/zephyr/drivers/interrupt_controller/intel_vtd.h
+++ b/include/zephyr/drivers/interrupt_controller/intel_vtd.h
@@ -215,7 +215,7 @@ static inline void vtd_set_irte_msi(const struct device *dev,
 	const struct vtd_driver_api *api =
 		(const struct vtd_driver_api *)dev->api;
 
-	return api->set_irte_msi(dev, irte_idx, msi);
+	api->set_irte_msi(dev, irte_idx, msi);
 }
 
 static inline bool vtd_irte_is_msi(const struct device *dev,

--- a/include/zephyr/drivers/sip_svc/sip_svc_driver.h
+++ b/include/zephyr/drivers/sip_svc/sip_svc_driver.h
@@ -224,7 +224,7 @@ static inline void z_impl_sip_svc_plat_update_trans_id(const struct device *dev,
 		 "sip_svc_plat_update_trans_id func shouldn't be NULL");
 	__ASSERT(request, "request shouldn't be NULL");
 
-	return api->sip_svc_plat_update_trans_id(dev, request, trans_id);
+	api->sip_svc_plat_update_trans_id(dev, request, trans_id);
 }
 
 /**

--- a/include/zephyr/drivers/usb_c/usbc_tcpc.h
+++ b/include/zephyr/drivers/usb_c/usbc_tcpc.h
@@ -356,7 +356,7 @@ static inline void tcpc_set_vconn_cb(const struct device *dev,
 	__ASSERT(api->set_vconn_cb != NULL,
 		 "Callback pointer should not be NULL");
 
-	return api->set_vconn_cb(dev, vconn_cb);
+	api->set_vconn_cb(dev, vconn_cb);
 }
 
 /**
@@ -378,7 +378,7 @@ static inline void tcpc_set_vconn_discharge_cb(const struct device *dev,
 	__ASSERT(api->set_vconn_discharge_cb != NULL,
 		 "Callback pointer should not be NULL");
 
-	return api->set_vconn_discharge_cb(dev, cb);
+	api->set_vconn_discharge_cb(dev, cb);
 }
 
 /**


### PR DESCRIPTION
For code clarity, this commit adjusts the use of `return` statements in functions with a void return type as follows:
- Transform `return foo();` into separate statements:
  `foo();`
  `return;`
- Remove unnecessary `return` statements when they don't affect control flow.