### PR TITLE
drivers: i3c: add additional option to setdasa

### DIFF
--- a/drivers/i3c/i3c_ccc.c
+++ b/drivers/i3c/i3c_ccc.c
@@ -114,12 +114,10 @@ int i3c_ccc_do_rstdaa_all(const struct device *controller)
 	return i3c_do_ccc(controller, &ccc_payload);
 }
 
-int i3c_ccc_do_setdasa(const struct i3c_device_desc *target)
+int i3c_ccc_do_setdasa(const struct i3c_device_desc *target, struct i3c_ccc_address da)
 {
-	struct i3c_driver_data *bus_data = (struct i3c_driver_data *)target->bus->data;
 	struct i3c_ccc_payload ccc_payload;
 	struct i3c_ccc_target_payload ccc_tgt_payload;
-	uint8_t dyn_addr;
 
 	__ASSERT_NO_MSG(target != NULL);
 	__ASSERT_NO_MSG(target->bus != NULL);
@@ -128,24 +126,9 @@ int i3c_ccc_do_setdasa(const struct i3c_device_desc *target)
 		return -EINVAL;
 	}
 
-	/*
-	 * Note that the 7-bit address needs to start at bit 1
-	 * (aka left-justified). So shift left by 1;
-	 */
-	dyn_addr = (target->init_dynamic_addr ?
-				target->init_dynamic_addr : target->static_addr) << 1;
-
-	/* check that initial dynamic address is free before setting it */
-	if ((target->init_dynamic_addr != 0) &&
-		(target->init_dynamic_addr != target->static_addr)) {
-		if (!i3c_addr_slots_is_free(&bus_data->attached_dev.addr_slots, dyn_addr >> 1)) {
-			return -EINVAL;
-		}
-	}
-
 	ccc_tgt_payload.addr = target->static_addr;
 	ccc_tgt_payload.rnw = 0;
-	ccc_tgt_payload.data = &dyn_addr;
+	ccc_tgt_payload.data = (uint8_t *)&da.addr;
 	ccc_tgt_payload.data_len = 1;
 
 	memset(&ccc_payload, 0, sizeof(ccc_payload));
@@ -158,10 +141,8 @@ int i3c_ccc_do_setdasa(const struct i3c_device_desc *target)
 
 int i3c_ccc_do_setnewda(const struct i3c_device_desc *target, struct i3c_ccc_address new_da)
 {
-	struct i3c_driver_data *bus_data = (struct i3c_driver_data *)target->bus->data;
 	struct i3c_ccc_payload ccc_payload;
 	struct i3c_ccc_target_payload ccc_tgt_payload;
-	uint8_t new_dyn_addr;
 
 	__ASSERT_NO_MSG(target != NULL);
 	__ASSERT_NO_MSG(target->bus != NULL);
@@ -170,22 +151,9 @@ int i3c_ccc_do_setnewda(const struct i3c_device_desc *target, struct i3c_ccc_add
 		return -EINVAL;
 	}
 
-	/*
-	 * Note that the 7-bit address needs to start at bit 1
-	 * (aka left-justified). So shift left by 1;
-	 */
-	new_dyn_addr = new_da.addr << 1;
-
-	/* check that initial dynamic address is free before setting it */
-	if (target->dynamic_addr != new_da.addr) {
-		if (!i3c_addr_slots_is_free(&bus_data->attached_dev.addr_slots, new_da.addr)) {
-			return -EINVAL;
-		}
-	}
-
 	ccc_tgt_payload.addr = target->dynamic_addr;
 	ccc_tgt_payload.rnw = 0;
-	ccc_tgt_payload.data = &new_dyn_addr;
+	ccc_tgt_payload.data = (uint8_t *)&new_da.addr;
 	ccc_tgt_payload.data_len = 1;
 
 	memset(&ccc_payload, 0, sizeof(ccc_payload));

--- a/drivers/i3c/i3c_common.c
+++ b/drivers/i3c/i3c_common.c
@@ -616,6 +616,8 @@ static int i3c_bus_setdasa(const struct device *dev,
 	/* Loop through the registered I3C devices */
 	for (i = 0; i < dev_list->num_i3c; i++) {
 		struct i3c_device_desc *desc = &dev_list->i3c[i];
+		struct i3c_driver_data *bus_data = (struct i3c_driver_data *)dev->data;
+		struct i3c_ccc_address dyn_addr;
 
 		/*
 		 * A device without static address => need to do
@@ -639,10 +641,31 @@ static int i3c_bus_setdasa(const struct device *dev,
 
 		LOG_DBG("SETDASA for 0x%x", desc->static_addr);
 
-		ret = i3c_ccc_do_setdasa(desc);
+		/*
+		 * check that initial dynamic address is free before setting it
+		 * if configured
+		 */
+		if ((desc->init_dynamic_addr != 0) &&
+			(desc->init_dynamic_addr != desc->static_addr)) {
+			if (!i3c_addr_slots_is_free(&bus_data->attached_dev.addr_slots,
+				desc->init_dynamic_addr)) {
+				if (i3c_detach_i3c_device(desc) != 0) {
+					LOG_ERR("Failed to detach %s", desc->dev->name);
+				}
+				continue;
+			}
+		}
+
+		/*
+		 * Note that the 7-bit address needs to start at bit 1
+		 * (aka left-justified). So shift left by 1;
+		 */
+		dyn_addr.addr = (desc->init_dynamic_addr ?
+					desc->init_dynamic_addr : desc->static_addr) << 1;
+
+		ret = i3c_ccc_do_setdasa(desc, dyn_addr);
 		if (ret == 0) {
-			desc->dynamic_addr = (desc->init_dynamic_addr ? desc->init_dynamic_addr
-								      : desc->static_addr);
+			desc->dynamic_addr = dyn_addr.addr >> 1;
 			if (desc->dynamic_addr != desc->static_addr) {
 				if (i3c_reattach_i3c_device(desc, desc->static_addr) != 0) {
 					LOG_ERR("Failed to reattach %s (%d)", desc->dev->name, ret);
@@ -655,7 +678,6 @@ static int i3c_bus_setdasa(const struct device *dev,
 			}
 			LOG_ERR("SETDASA error on address 0x%x (%d)",
 				desc->static_addr, ret);
-			continue;
 		}
 	}
 

--- a/include/zephyr/drivers/i3c/ccc.h
+++ b/include/zephyr/drivers/i3c/ccc.h
@@ -496,7 +496,7 @@ struct i3c_ccc_address {
 	 * - For GETACCCR, the correct address of Secondary
 	 *   Controller.
 	 *
-	 * @note For SETDATA, SETNEWDA and SETGRAP,
+	 * @note For SETDATA, SETNEWDA and SETGRPA,
 	 * the address is left-shift by 1, and bit[0] is always 0.
 	 *
 	 * @note Fpr SET GETACCCR, the address is left-shift by 1,
@@ -1351,10 +1351,12 @@ int i3c_ccc_do_rstdaa_all(const struct device *controller);
  *
  * @param[in] target Pointer to the target device descriptor where
  *                   the device is configured with a static address.
+ * @param[in] da Struct of the Dynamic address
  *
  * @return @see i3c_do_ccc
  */
-int i3c_ccc_do_setdasa(const struct i3c_device_desc *target);
+int i3c_ccc_do_setdasa(const struct i3c_device_desc *target,
+			  struct i3c_ccc_address da);
 
 /**
  * @brief Set New Dynamic Address for a target
@@ -1365,7 +1367,7 @@ int i3c_ccc_do_setdasa(const struct i3c_device_desc *target);
  *
  * @param[in] target Pointer to the target device descriptor where
  *                   the device is configured with a static address.
- * @param[in] new_da Pointer to the new_da struct.
+ * @param[in] new_da Struct of the Dynamic address
  *
  * @return @see i3c_do_ccc
  */


### PR DESCRIPTION
struct i3c_ccc_address is intended to match the output where the address is left shifted by 1 for SETDASA and SETNEWDA. Require the operations calling it to shift the data.

add an additional parameter for the setdasa function which will allow for the da to be configured rather than being hard coded.

This also moves a lot of the 'address verifiction' out of the `i3c_ccc.c` as IMO I do not believe it should be doing that checking at that layer, but it now does it at `i3c_common.c`