### PR TITLE
drivers: serial: ra_sci: refactor `uart_ra_sci_callback_adapter` function

### DIFF
--- a/drivers/serial/uart_renesas_ra_sci.c
+++ b/drivers/serial/uart_renesas_ra_sci.c
@@ -864,6 +864,7 @@ static void uart_ra_sci_callback_adapter(struct st_uart_callback_arg *fsp_args)
 		break;
 	case UART_EVENT_RX_COMPLETE:
 		async_evt_rx_complete(dev);
+		break;
 	case UART_EVENT_ERR_PARITY:
 		async_evt_rx_err(dev, UART_ERROR_PARITY);
 		break;

--- a/drivers/serial/uart_renesas_ra_sci.c
+++ b/drivers/serial/uart_renesas_ra_sci.c
@@ -860,17 +860,22 @@ static void uart_ra_sci_callback_adapter(struct st_uart_callback_arg *fsp_args)
 
 	switch (fsp_args->event) {
 	case UART_EVENT_TX_COMPLETE:
-		return async_evt_tx_done(dev);
+		async_evt_tx_done(dev);
+		break;
 	case UART_EVENT_RX_COMPLETE:
 		async_evt_rx_complete(dev);
 	case UART_EVENT_ERR_PARITY:
-		return async_evt_rx_err(dev, UART_ERROR_PARITY);
+		async_evt_rx_err(dev, UART_ERROR_PARITY);
+		break;
 	case UART_EVENT_ERR_FRAMING:
-		return async_evt_rx_err(dev, UART_ERROR_FRAMING);
+		async_evt_rx_err(dev, UART_ERROR_FRAMING);
+		break;
 	case UART_EVENT_ERR_OVERFLOW:
-		return async_evt_rx_err(dev, UART_ERROR_OVERRUN);
+		async_evt_rx_err(dev, UART_ERROR_OVERRUN);
+		break;
 	case UART_EVENT_BREAK_DETECT:
-		return async_evt_rx_err(dev, UART_BREAK);
+		async_evt_rx_err(dev, UART_BREAK);
+		break;
 	case UART_EVENT_TX_DATA_EMPTY:
 	case UART_EVENT_RX_CHAR:
 		break;


### PR DESCRIPTION
Two steps in the commit addressing the following:
- Revise switch-case to use `break` instead of `return`.
- Add missing `break` for the `UART_EVENT_RX_COMPLETE` case.
