### PR TITLE
drivers/i2c: it8xxx2: Add a property for max time allowed I2C transfer

### DIFF
--- a/drivers/i2c/i2c_ite_enhance.c
+++ b/drivers/i2c/i2c_ite_enhance.c
@@ -73,6 +73,7 @@ struct i2c_enhance_config {
 	uint8_t prescale_scl_low;
 	uint8_t data_hold_time;
 	uint32_t clock_gate_offset;
+	int transfer_timeout_ms;
 	bool target_enable;
 	bool target_pio_mode;
 	bool push_pull_recovery;
@@ -626,8 +627,7 @@ static int i2c_enhance_pio_transfer(const struct device *dev,
 			irq_enable(config->i2c_irq_base);
 		}
 		/* Wait for the transfer to complete */
-		/* TODO: the timeout should be adjustable */
-		res = k_sem_take(&data->device_sync_sem, K_MSEC(100));
+		res = k_sem_take(&data->device_sync_sem, K_MSEC(config->transfer_timeout_ms));
 		/*
 		 * The irq will be enabled at the condition of start or
 		 * repeat start of I2C. If timeout occurs without being
@@ -838,7 +838,7 @@ static int i2c_enhance_cq_transfer(const struct device *dev,
 		irq_enable(config->i2c_irq_base);
 	}
 	/* Wait for the transfer to complete */
-	res = k_sem_take(&data->device_sync_sem, K_MSEC(100));
+	res = k_sem_take(&data->device_sync_sem, K_MSEC(config->transfer_timeout_ms));
 
 	irq_disable(config->i2c_irq_base);
 
@@ -1492,6 +1492,7 @@ BUILD_ASSERT(IS_ENABLED(CONFIG_I2C_TARGET_BUFFER_MODE),
 		.prescale_scl_low = DT_INST_PROP_OR(inst, prescale_scl_low, 0), \
 		.data_hold_time = DT_INST_PROP_OR(inst, data_hold_time, 0),     \
 		.clock_gate_offset = DT_INST_PROP(inst, clock_gate_offset),     \
+		.transfer_timeout_ms = DT_INST_PROP(inst, transfer_timeout_ms), \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),                   \
 		.target_enable = DT_INST_PROP(inst, target_enable),             \
 		.target_pio_mode = DT_INST_PROP(inst, target_pio_mode),         \

--- a/drivers/i2c/i2c_ite_it8xxx2.c
+++ b/drivers/i2c/i2c_ite_it8xxx2.c
@@ -52,6 +52,7 @@ struct i2c_it8xxx2_config {
 	/* I2C alternate configuration */
 	const struct pinctrl_dev_config *pcfg;
 	uint32_t clock_gate_offset;
+	int transfer_timeout_ms;
 	bool fifo_enable;
 	bool push_pull_recovery;
 };
@@ -1008,8 +1009,7 @@ static int i2c_it8xxx2_transfer(const struct device *dev, struct i2c_msg *msgs,
 			}
 		}
 		/* Wait for the transfer to complete */
-		/* TODO: the timeout should be adjustable */
-		res = k_sem_take(&data->device_sync_sem, K_MSEC(100));
+		res = k_sem_take(&data->device_sync_sem, K_MSEC(config->transfer_timeout_ms));
 		/*
 		 * The irq will be enabled at the condition of start or
 		 * repeat start of I2C. If timeout occurs without being
@@ -1303,6 +1303,7 @@ DT_INST_FOREACH_STATUS_OKAY(I2C_IT8XXX2_CHECK_SUPPORTED_CLOCK)
 		.scl_gpios = GPIO_DT_SPEC_INST_GET(inst, scl_gpios),            \
 		.sda_gpios = GPIO_DT_SPEC_INST_GET(inst, sda_gpios),            \
 		.clock_gate_offset = DT_INST_PROP(inst, clock_gate_offset),     \
+		.transfer_timeout_ms = DT_INST_PROP(inst, transfer_timeout_ms), \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),                   \
 		.fifo_enable = DT_INST_PROP(inst, fifo_enable),                 \
 		.push_pull_recovery = DT_INST_PROP(inst, push_pull_recovery),   \

--- a/dts/bindings/i2c/ite,common-i2c.yaml
+++ b/dts/bindings/i2c/ite,common-i2c.yaml
@@ -97,6 +97,12 @@ properties:
       The clock gate offsets combine the register offset from
       ECPM_BASE and the mask within that register into one value.
 
+  transfer-timeout-ms:
+    type: int
+    default: 100
+    description: |
+      Maximum time allowed for an I2C transfer.
+
   pinctrl-0:
     required: true
 


### PR DESCRIPTION

Add a property of the maximum time allowed for an I2C transfer.