### PR TITLE
tests: drivers: stepper: stepper_api: Fix UAF of poll signal

### DIFF
--- a/tests/drivers/stepper/stepper_api/src/main.c
+++ b/tests/drivers/stepper/stepper_api/src/main.c
@@ -9,6 +9,8 @@
 
 struct stepper_fixture {
 	const struct device *dev;
+	struct k_poll_signal signal;
+	struct k_poll_event event;
 };
 
 static void *stepper_setup(void)
@@ -16,6 +18,10 @@ static void *stepper_setup(void)
 	static struct stepper_fixture fixture = {
 		.dev = DEVICE_DT_GET(DT_NODELABEL(motor_1)),
 	};
+
+	k_poll_signal_init(&fixture.signal);
+	k_poll_event_init(&fixture.event, K_POLL_TYPE_SIGNAL, K_POLL_MODE_NOTIFY_ONLY,
+			  &fixture.signal);
 
 	zassert_not_null(fixture.dev);
 	return &fixture;
@@ -25,6 +31,7 @@ static void stepper_before(void *f)
 {
 	struct stepper_fixture *fixture = f;
 	(void)stepper_set_actual_position(fixture->dev, 0);
+	k_poll_signal_reset(&fixture->signal);
 }
 
 ZTEST_SUITE(stepper, NULL, stepper_setup, stepper_before, NULL, NULL);
@@ -48,19 +55,14 @@ ZTEST_F(stepper, test_actual_position)
 ZTEST_F(stepper, test_target_position)
 {
 	int32_t pos = 100u;
-	struct k_poll_signal signal;
 
-	k_poll_signal_init(&signal);
-	struct k_poll_event event;
-
-	k_poll_event_init(&event, K_POLL_TYPE_SIGNAL, K_POLL_MODE_NOTIFY_ONLY, &signal);
 	(void)stepper_set_max_velocity(fixture->dev, 100u);
-	(void)stepper_set_target_position(fixture->dev, pos, &signal);
-	(void)k_poll(&event, 1, K_SECONDS(2));
+	(void)stepper_set_target_position(fixture->dev, pos, &fixture->signal);
+	(void)k_poll(&fixture->event, 1, K_SECONDS(5));
 	unsigned int signaled;
 	int result;
 
-	k_poll_signal_check(&signal, &signaled, &result);
+	k_poll_signal_check(&fixture->signal, &signaled, &result);
 	zassert_equal(signaled, 1, "Signal not set");
 	zassert_equal(result, STEPPER_SIGNAL_STEPS_COMPLETED, "Signal not set");
 	(void)stepper_get_actual_position(fixture->dev, &pos);


### PR DESCRIPTION
The test_target_position test used a stack allocated `poll_signal` which is kept as a refrence inside the gpio driver. Since the time for polling the signal was chosen pretty narrow, the function exited with the driver still trying to signal the stack allocated value upon movement completion. Fix by adding the structs to the test fixture and increase the timeout.

Resolves #78466.