### PR TITLE
driver: ssp: Refactor SSP driver to use SSP_IP_VER for version checks

### DIFF
--- a/drivers/dai/intel/ssp/ssp.c
+++ b/drivers/dai/intel/ssp/ssp.c
@@ -792,7 +792,7 @@ static void dai_ssp_pm_runtime_en_ssp_power(struct dai_intel_ssp *dp, uint32_t s
 	int ret;
 
 	LOG_INF("SSP%d", ssp_index);
-#if CONFIG_SOC_INTEL_ACE15_MTPM || CONFIG_SOC_SERIES_INTEL_ADSP_CAVS
+#if SSP_IP_VER < SSP_IP_VER_2_0
 	sys_write32(sys_read32(dai_ip_base(dp) + I2SLCTL_OFFSET) | I2SLCTL_SPA(ssp_index),
 		    dai_ip_base(dp) + I2SLCTL_OFFSET);
 
@@ -800,7 +800,7 @@ static void dai_ssp_pm_runtime_en_ssp_power(struct dai_intel_ssp *dp, uint32_t s
 	ret = dai_ssp_poll_for_register_delay(dai_ip_base(dp) + I2SLCTL_OFFSET,
 					      I2SLCTL_CPA(ssp_index), I2SLCTL_CPA(ssp_index),
 					      DAI_INTEL_SSP_MAX_SEND_TIME_PER_SAMPLE);
-#elif CONFIG_SOC_INTEL_ACE20_LNL || CONFIG_SOC_INTEL_ACE30
+#elif SSP_IP_VER > SSP_IP_VER_1_5
 	sys_write32(sys_read32(dai_hdamlssp_base(dp) + I2SLCTL_OFFSET) |
 			       I2SLCTL_SPA(ssp_index),
 			       dai_hdamlssp_base(dp) + I2SLCTL_OFFSET);
@@ -826,7 +826,7 @@ static void dai_ssp_pm_runtime_dis_ssp_power(struct dai_intel_ssp *dp, uint32_t 
 	int ret;
 
 	LOG_INF("SSP%d", ssp_index);
-#if CONFIG_SOC_INTEL_ACE15_MTPM || CONFIG_SOC_SERIES_INTEL_ADSP_CAVS
+#if SSP_IP_VER < SSP_IP_VER_2_0
 	sys_write32(sys_read32(dai_ip_base(dp) + I2SLCTL_OFFSET) & (~I2SLCTL_SPA(ssp_index)),
 		    dai_ip_base(dp) + I2SLCTL_OFFSET);
 
@@ -835,7 +835,7 @@ static void dai_ssp_pm_runtime_dis_ssp_power(struct dai_intel_ssp *dp, uint32_t 
 					      I2SLCTL_CPA(ssp_index), 0,
 					      DAI_INTEL_SSP_MAX_SEND_TIME_PER_SAMPLE);
 
-#elif CONFIG_SOC_INTEL_ACE20_LNL || CONFIG_SOC_INTEL_ACE30
+#elif SSP_IP_VER > SSP_IP_VER_1_5
 	sys_write32(sys_read32(dai_hdamlssp_base(dp) + I2SLCTL_OFFSET) & (~I2SLCTL_SPA(ssp_index)),
 			dai_hdamlssp_base(dp) + I2SLCTL_OFFSET);
 
@@ -873,7 +873,7 @@ static void dai_ssp_program_channel_map(struct dai_intel_ssp *dp,
 		/* Program HDA input stream parameters */
 		sys_write16((pcmsycm & 0xffff), reg_add);
 	}
-#elif defined(CONFIG_SOC_INTEL_ACE30)
+#elif SSP_IP_VER > SSP_IP_VER_2_0
 	const struct dai_intel_ipc4_ssp_configuration_blob_ver_3_0 *blob30 = spec_config;
 	const struct dai_intel_ipc4_ssp_configuration_blob *blob = spec_config;
 	uint64_t time_slot_map = 0;
@@ -930,7 +930,7 @@ static void dai_ssp_empty_tx_fifo(struct dai_intel_ssp *dp)
 	 * SSSR_TNF is cleared when TX FIFO is empty or full,
 	 * so wait for set TNF then for TFL zero - order matter.
 	 */
-#ifdef CONFIG_SOC_INTEL_ACE30
+#if SSP_IP_VER > SSP_IP_VER_2_0
 	ret = dai_ssp_poll_for_register_delay(dai_base(dp) + SSMODyCS(dp->tdm_slot_group),
 							SSMODyCS_TNF, SSMODyCS_TNF,
 							DAI_INTEL_SSP_MAX_SEND_TIME_PER_SAMPLE);
@@ -959,7 +959,7 @@ static void dai_ssp_empty_tx_fifo(struct dai_intel_ssp *dp)
 	}
 }
 
-#ifdef CONFIG_SOC_INTEL_ACE30
+#if SSP_IP_VER > SSP_IP_VER_2_0
 static void ssp_empty_rx_fifo_on_start(struct dai_intel_ssp *dp)
 {
 	uint32_t retry = DAI_INTEL_SSP_RX_FLUSH_RETRY_MAX;
@@ -1162,7 +1162,6 @@ static int dai_ssp_bclk_prepare_enable(struct dai_intel_ssp *dp)
 	struct dai_intel_ssp_plat_data *ssp_plat_data = dai_get_plat_data(dp);
 	uint32_t sscr0;
 	uint32_t mdiv;
-	bool need_ecs = false;
 	int ret = 0;
 
 	if (ssp_plat_data->clk_active & SSP_CLK_BCLK_ACTIVE) {
@@ -1172,6 +1171,7 @@ static int dai_ssp_bclk_prepare_enable(struct dai_intel_ssp *dp)
 	sscr0 = sys_read32(dai_base(dp) + SSCR0);
 
 #if CONFIG_INTEL_MN
+	bool need_ecs = false;
 	/* BCLK config */
 	ret = dai_ssp_mn_set_bclk(dp, dp->dai_index, ssp_plat_data->params.bclk_rate,
 				  &mdiv, &need_ecs);
@@ -1191,10 +1191,12 @@ static int dai_ssp_bclk_prepare_enable(struct dai_intel_ssp *dp)
 	mdiv = ft[DAI_INTEL_SSP_DEFAULT_IDX].freq / ssp_plat_data->params.bclk_rate;
 #endif
 
-#ifndef CONFIG_SOC_INTEL_ACE30
+#if SSP_IP_VER < CONFIG_SOC_INTEL_ACE30
+#if CONFIG_INTEL_MN
 	if (need_ecs) {
 		sscr0 |= SSCR0_ECS;
 	}
+#endif
 #endif
 
 	/* clock divisor is SCR + 1 */
@@ -1724,7 +1726,8 @@ static int dai_ssp_set_config_tplg(struct dai_intel_ssp *dp, const struct dai_co
 	sys_write32(sspsp2, dai_base(dp) + SSPSP2);
 	sys_write32(ssioc, dai_base(dp) + SSIOC);
 	sys_write32(ssto, dai_base(dp) + SSTO);
-#ifdef CONFIG_SOC_INTEL_ACE30
+
+#if SSP_IP_VER > SSP_IP_VER_2_0
 	for (uint32_t idx = 0; idx < I2SIPCMC; ++idx) {
 		sys_write64(sstsa, dai_base(dp) + SSMODyTSA(idx));
 	}
@@ -1777,7 +1780,8 @@ clk:
 			ssp_plat_data->clk_active |= SSP_CLK_BCLK_ES_REQ;
 
 			if (enable_sse) {
-#ifdef CONFIG_SOC_INTEL_ACE30
+
+#if SSP_IP_VER > SSP_IP_VER_2_0
 				dai_ssp_update_bits(dp, SSMIDyCS(dp->tdm_slot_group),
 						    SSMIDyCS_RSRE, SSMIDyCS_RSRE);
 				dai_ssp_update_bits(dp, SSMODyCS(dp->tdm_slot_group),
@@ -1806,7 +1810,8 @@ clk:
 			LOG_INF("hw_free stage: releasing BCLK clocks for SSP%d...",
 					dp->dai_index);
 			if (ssp_plat_data->clk_active & SSP_CLK_BCLK_ACTIVE) {
-#ifdef CONFIG_SOC_INTEL_ACE30
+
+#if SSP_IP_VER > SSP_IP_VER_2_0
 				for (uint32_t idx = 0; idx < I2SOPCMC; ++idx) {
 					dai_ssp_update_bits(dp, SSMODyCS(idx), SSMODyCS_TSRE, 0);
 				}
@@ -1865,7 +1870,7 @@ static int dai_ssp_check_aux_data(struct ssp_intel_aux_tlv *aux_tlv, int aux_len
 		size = sizeof(struct ssp_intel_ext_ctl);
 		break;
 	case SSP_LINK_CLK_SOURCE:
-#ifdef CONFIG_SOC_SERIES_INTEL_ADSP_ACE
+#if SSP_IP_VER >= SSP_IP_VER_1_5
 		size = sizeof(struct ssp_intel_link_ctl);
 		break;
 #else
@@ -1931,7 +1936,7 @@ static int dai_ssp_parse_tlv(struct dai_intel_ssp *dp, const uint8_t *aux_ptr, s
 	struct ssp_intel_node_ctl *node;
 	struct ssp_intel_sync_ctl *sync;
 	struct ssp_intel_ext_ctl *ext;
-#ifdef CONFIG_SOC_SERIES_INTEL_ADSP_ACE
+#if SSP_IP_VER >= SSP_IP_VER_1_5
 	struct ssp_intel_link_ctl *link;
 #endif
 
@@ -1978,14 +1983,14 @@ static int dai_ssp_parse_tlv(struct dai_intel_ssp *dp, const uint8_t *aux_ptr, s
 			LOG_INF("ext ext_data %u", ext->ext_data);
 			break;
 		case SSP_LINK_CLK_SOURCE:
-#ifdef CONFIG_SOC_SERIES_INTEL_ADSP_ACE
+#if SSP_IP_VER >= SSP_IP_VER_1_5
 			link = (struct ssp_intel_link_ctl *)&aux_tlv->val;
-#if CONFIG_SOC_INTEL_ACE15_MTPM
+#if SSP_IP_VER < SSP_IP_VER_2_0
 			sys_write32((sys_read32(dai_ip_base(dp) + I2SLCTL_OFFSET) &
 				    ~I2CLCTL_MLCS(0x7)) |
 				    I2CLCTL_MLCS(link->clock_source), dai_ip_base(dp) +
 				    I2SLCTL_OFFSET);
-#elif CONFIG_SOC_INTEL_ACE20_LNL || CONFIG_SOC_INTEL_ACE30
+#elif SSP_IP_VER > SSP_IP_VER_1_5
 			sys_write32((sys_read32(dai_i2svss_base(dp) + I2SLCTL_OFFSET) &
 				    ~I2CLCTL_MLCS(0x7)) |
 				    I2CLCTL_MLCS(link->clock_source),
@@ -2065,7 +2070,7 @@ static int dai_ssp_set_clock_control_ver_1(struct dai_intel_ssp *dp,
 	return 0;
 }
 
-#ifdef CONFIG_SOC_INTEL_ACE30
+#if SSP_IP_VER > SSP_IP_VER_2_0
 static void dai_ssp_set_reg_config(struct dai_intel_ssp *dp, const struct dai_config *cfg,
 				   const void *spec_config)
 {
@@ -2184,7 +2189,7 @@ static int dai_ssp_set_config_blob(struct dai_intel_ssp *dp, const struct dai_co
 	struct dai_intel_ssp_plat_data *ssp_plat_data = dai_get_plat_data(dp);
 	int err;
 
-#ifdef CONFIG_SOC_INTEL_ACE30
+#if SSP_IP_VER > SSP_IP_VER_2_0
 	dp->tdm_slot_group = cfg->tdm_slot_group;
 #endif
 
@@ -2322,7 +2327,7 @@ static void dai_ssp_start(struct dai_intel_ssp *dp, int direction)
 
 
 	/* enable DMA */
-#if CONFIG_SOC_INTEL_ACE30
+#if SSP_IP_VER > SSP_IP_VER_2_0
 	if (direction == DAI_DIR_PLAYBACK) {
 		dai_ssp_update_bits(dp, SSMODyCS(dp->tdm_slot_group),
 				    SSMODyCS_TSRE, SSMODyCS_TSRE);
@@ -2392,7 +2397,8 @@ static void dai_ssp_stop(struct dai_intel_ssp *dp, int direction)
 	if (direction == DAI_DIR_CAPTURE &&
 	    dp->state[DAI_DIR_CAPTURE] != DAI_STATE_PRE_RUNNING) {
 		LOG_INF("SSP%d RX", dp->dai_index);
-#if CONFIG_SOC_INTEL_ACE30
+
+#if SSP_IP_VER > SSP_IP_VER_2_0
 		dai_ssp_update_bits(dp, SSMIDyCS(dp->tdm_slot_group), SSMIDyCS_RXEN, 0);
 		dai_ssp_update_bits(dp, SSMIDyCS(dp->tdm_slot_group), SSMIDyCS_RSRE, 0);
 #else
@@ -2407,7 +2413,8 @@ static void dai_ssp_stop(struct dai_intel_ssp *dp, int direction)
 	if (direction == DAI_DIR_PLAYBACK &&
 	    dp->state[DAI_DIR_PLAYBACK] != DAI_STATE_PRE_RUNNING) {
 		LOG_INF("SSP%d TX", dp->dai_index);
-#if CONFIG_SOC_INTEL_ACE30
+
+#if SSP_IP_VER > SSP_IP_VER_2_0
 		dai_ssp_update_bits(dp, SSMODyCS(dp->tdm_slot_group), SSMODyCS_TSRE, 0);
 		dai_ssp_empty_tx_fifo(dp);
 		dai_ssp_update_bits(dp, SSMODyCS(dp->tdm_slot_group), SSMODyCS_TXEN, 0);

--- a/drivers/dai/intel/ssp/ssp.h
+++ b/drivers/dai/intel/ssp/ssp.h
@@ -7,6 +7,24 @@
 #ifndef __INTEL_DAI_DRIVER_SSP_H__
 #define __INTEL_DAI_DRIVER_SSP_H__
 
+#define SSP_IP_VER_1_0 0x10000 /* cAVS */
+#define SSP_IP_VER_1_5 0x10500 /* ACE15 */
+#define SSP_IP_VER_2_0 0x20000 /* ACE20 */
+#define SSP_IP_VER_3_0 0x30000 /* ACE30 */
+
+/* SSP IP version defined by CONFIG_SOC*/
+#if defined(CONFIG_SOC_SERIES_INTEL_ADSP_CAVS)
+#define SSP_IP_VER SSP_IP_VER_1_0
+#elif defined(CONFIG_SOC_INTEL_ACE15_MTPM)
+#define SSP_IP_VER SSP_IP_VER_1_5
+#elif defined(CONFIG_SOC_INTEL_ACE20_LNL)
+#define SSP_IP_VER SSP_IP_VER_2_0
+#elif defined(CONFIG_SOC_INTEL_ACE30)
+#define SSP_IP_VER SSP_IP_VER_3_0
+#else
+#error "Unknown SSP IP"
+#endif
+
 #include <stdint.h>
 #include <zephyr/drivers/dai.h>
 #include "dai-params-intel-ipc3.h"
@@ -116,7 +134,7 @@ struct dai_intel_ssp_plat_data {
 	uint32_t base;
 	uint32_t ip_base;
 	uint32_t shim_base;
-#if defined(CONFIG_SOC_INTEL_ACE20_LNL) || defined(CONFIG_SOC_INTEL_ACE30)
+#if SSP_IP_VER > SSP_IP_VER_1_5
 	uint32_t hdamlssp_base;
 	uint32_t i2svss_base;
 #endif


### PR DESCRIPTION
This commit updates the SSP driver to use the newly defined SSP_IP_VER macros for IP version checks instead of relying on CONFIG_SOC_* macros. The change ensures better readability and maintainability by centralizing the IP version definitions and comparisons.