### PR TITLE
arch: arm: do not enable PLATFORM_SPECIFIC_INIT if SOC_RESET_HOOK=y 

### DIFF
--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -167,7 +167,6 @@ config RUNTIME_NMI
 
 config PLATFORM_SPECIFIC_INIT
 	bool "Platform (SOC) specific startup hook [DEPRECATED]"
-	default y if SOC_RESET_HOOK
 	select DEPRECATED
 	help
 	  The platform specific initialization code (z_arm_platform_init) is


### PR DESCRIPTION
Otherwise, we can't escape from DEPRECATED being selected, and so getting build warnings. It doesn't make sense that the option replacing the deprecated one is used to automatically enable it.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/78386