### PR TITLE
drivers: sensors: fix compile error due to conflicting types.

### DIFF
--- a/drivers/sensor/sensor_handlers.c
+++ b/drivers/sensor/sensor_handlers.c
@@ -70,7 +70,7 @@ static inline int z_vrfy_sensor_get_decoder(const struct device *dev,
 
 static inline int z_vrfy_sensor_reconfigure_read_iodev(struct rtio_iodev *iodev,
 						       const struct device *sensor,
-						       const enum sensor_channel *channels,
+						       const struct sensor_chan_spec *channels,
 						       size_t num_channels)
 {
 	K_OOPS(K_SYSCALL_OBJ(iodev, K_OBJ_RTIO_IODEV));


### PR DESCRIPTION
Since b249535 (sensors: Add channel specifier) the signature of sensor_reconfigure_read_iodev() changed, but sensor_handlers.c apparently hasn't been updated.

Fix compile time error by updating sensor_reconfigure_read_iodev() signature in sensor_handlers.c