### PR TITLE
Adding FMC to H56x-series

### DIFF
--- a/dts/arm/st/h5/stm32h533.dtsi
+++ b/dts/arm/st/h5/stm32h533.dtsi
@@ -16,5 +16,12 @@
 			reg = <0x42021400 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00000080>;
 		};
+
+		fmc: memory-controller@47000400 {
+			compatible = "st,stm32-fmc";
+			reg = <0x47000400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB4 0x00010000>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -465,6 +465,13 @@
 			interrupts = <79 0>;
 			status = "disabled";
 		};
+
+		fmc: memory-controller@47000400 {
+			compatible = "st,stm32-fmc";
+			reg = <0x47000400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB4 0x00010000>;
+			status = "disabled";
+		};
 	};
 
 	smbus3: smbus3 {


### PR DESCRIPTION
As requested in

https://github.com/zephyrproject-rtos/zephyr/issues/77888

I'm adding the DT basics for the flexible memory controller.