### PR TITLE
X86 compatibles

### DIFF
--- a/boards/acrn/acrn/acrn.dts
+++ b/boards/acrn/acrn/acrn.dts
@@ -46,3 +46,7 @@
 	status = "okay";
 	current-speed = <115200>;
 };
+
+&cpu {
+	compatible = "intel,x86_64";
+};

--- a/boards/intel/adl/intel_adl.dts
+++ b/boards/intel/adl/intel_adl.dts
@@ -22,3 +22,7 @@
 		sdhc0 = &emmc;
 	};
 };
+
+&cpu {
+	compatible = "intel,x86_64";
+};

--- a/boards/qemu/x86/qemu_x86.dts
+++ b/boards/qemu/x86/qemu_x86.dts
@@ -166,3 +166,7 @@
 		};
 	};
 };
+
+&cpu {
+	compatible = "intel,x86";
+};

--- a/boards/qemu/x86/qemu_x86_64.dts
+++ b/boards/qemu/x86/qemu_x86_64.dts
@@ -9,7 +9,7 @@
 	cpus {
 		cpu@1 {
 			device_type = "cpu";
-			compatible = "intel,x86";
+			compatible = "intel,x86_64";
 			d-cache-line-size = <64>;
 			reg = <1>;
 		};
@@ -28,4 +28,8 @@
 
 		status = "okay";
 	};
+};
+
+&cpu {
+	compatible = "intel,x86_64";
 };

--- a/boards/qemu/x86/qemu_x86_64_atom_nokpti.dts
+++ b/boards/qemu/x86/qemu_x86_64_atom_nokpti.dts
@@ -9,9 +9,13 @@
 	cpus {
 		cpu@1 {
 			device_type = "cpu";
-			compatible = "intel,x86";
+			compatible = "intel,x86_64";
 			d-cache-line-size = <64>;
 			reg = <1>;
 		};
 	};
+};
+
+&cpu {
+	compatible = "intel,x86_64";
 };

--- a/boards/up-bridge-the-gap/up_squared/up_squared.dts
+++ b/boards/up-bridge-the-gap/up_squared/up_squared.dts
@@ -36,14 +36,14 @@
 
 		cpu@0 {
 			device_type = "cpu";
-			compatible = "intel,apollo-lake";
+			compatible = "intel,apollo-lake", "intel,x86_64";
 			d-cache-line-size = <64>;
 			reg = <0>;
 		};
 
 		cpu@1 {
 			device_type = "cpu";
-			compatible = "intel,apollo-lake";
+			compatible = "intel,apollo-lake", "intel,x86_64";
 			d-cache-line-size = <64>;
 			reg = <1>;
 		};

--- a/dts/x86/intel/alder_lake.dtsi
+++ b/dts/x86/intel/alder_lake.dtsi
@@ -16,9 +16,9 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		cpu@0 {
+		cpu: cpu@0 {
 			device_type = "cpu";
-			compatible = "intel,alder-lake";
+			compatible = "intel,alder-lake", "intel,x86_64";
 			d-cache-line-size = <64>;
 			reg = <0>;
 		};

--- a/dts/x86/intel/apollo_lake.dtsi
+++ b/dts/x86/intel/apollo_lake.dtsi
@@ -16,7 +16,7 @@
 
 		cpu@0 {
 			device_type = "cpu";
-			compatible = "intel,apollo-lake";
+			compatible = "intel,apollo-lake", "intel,x86_64";
 			d-cache-line-size = <64>;
 			reg = <0>;
 		};

--- a/dts/x86/intel/atom.dtsi
+++ b/dts/x86/intel/atom.dtsi
@@ -12,9 +12,8 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		cpu@0 {
+		cpu: cpu@0 {
 			device_type = "cpu";
-			compatible = "intel,x86";
 			d-cache-line-size = <64>;
 			reg = <0>;
 		};

--- a/dts/x86/intel/elkhart_lake.dtsi
+++ b/dts/x86/intel/elkhart_lake.dtsi
@@ -16,7 +16,7 @@
 
 		cpu@0 {
 			device_type = "cpu";
-			compatible = "intel,elkhart-lake";
+			compatible = "intel,elkhart-lake", "intel,x86_64";
 			d-cache-line-size = <64>;
 			reg = <0>;
 		};

--- a/dts/x86/intel/intel_ish5.dtsi
+++ b/dts/x86/intel/intel_ish5.dtsi
@@ -39,7 +39,7 @@
 
 		cpu0: cpu0@0 {
 			device_type = "cpu";
-			compatible = "intel,ish";
+			compatible = "intel,ish", "intel,x86";
 			reg = <0>;
 			cpu-power-states = <&d0i0 &d0i2 &d0i3>;
 		};

--- a/dts/x86/intel/lakemont.dtsi
+++ b/dts/x86/intel/lakemont.dtsi
@@ -14,7 +14,7 @@
 
 		cpu@0 {
 			device_type = "cpu";
-			compatible = "intel,lakemont";
+			compatible = "intel,lakemont", "intel,x86";
 			d-cache-line-size = <64>;
 			reg = <0>;
 		};

--- a/dts/x86/intel/raptor_lake_p.dtsi
+++ b/dts/x86/intel/raptor_lake_p.dtsi
@@ -15,7 +15,7 @@
 		#size-cells = <0>;
 
 		cpu@0 {
-			compatible = "intel,raptor-lake";
+			compatible = "intel,raptor-lake", "intel,x86_64";
 			device_type = "cpu";
 			d-cache-line-size = <64>;
 			reg = <0>;

--- a/dts/x86/intel/raptor_lake_s.dtsi
+++ b/dts/x86/intel/raptor_lake_s.dtsi
@@ -16,7 +16,7 @@
 
 		cpu@0 {
 			device_type = "cpu";
-			compatible = "intel,raptor-lake";
+			compatible = "intel,raptor-lake", "intel,x86_64";
 			d-cache-line-size = <64>;
 			reg = <0>;
 		};


### PR DESCRIPTION
This merge request unifies x86 and x86-64 targets by adding an explicit `compatible` note to all platforms.

These entries are not added on the same level in every case due to the organization of existing x86[-64] platforms which I didn't want to change. 

This change should effectively just add data to existing platforms but not change their behavior. 