### PR TITLE
drivers: wifi: nrfwifi: determine shared iovdd and bucken from dt

### DIFF
--- a/drivers/wifi/nrfwifi/Kconfig.nrfwifi
+++ b/drivers/wifi/nrfwifi/Kconfig.nrfwifi
@@ -664,13 +664,6 @@ config NET_MGMT_EVENT_QUEUE_SIZE
 	default 16
 endif # NRF_WIFI_RPU_RECOVERY
 
-config NRF_WIFI_COMBINED_BUCKEN_IOVDD_GPIO
-	bool
-	help
-	  Enable this option to use a single GPIO to control both buck enable and IOVDD enable,
-	  there will be a internal hardware switch to add delay between the two operations. This
-	  is typically 4ms delay for nRF70.
-
 config NRF_WIFI_FEAT_WMM
 	bool "WMM/QoS support"
 	default y

--- a/drivers/wifi/nrfwifi/src/qspi/src/rpu_hw_if.c
+++ b/drivers/wifi/nrfwifi/src/qspi/src/rpu_hw_if.c
@@ -242,7 +242,8 @@ static int rpu_pwron(void)
 	/* Settling time for iovdd nRF7002 DK/EK - switch (TCK106AG): ~600us */
 	k_msleep(1);
 
-	if (IS_ENABLED(CONFIG_NRF_WIFI_COMBINED_BUCKEN_IOVDD_GPIO)) {
+	if ((bucken_spec.port == iovdd_ctrl_spec.port) &&
+	    (bucken_spec.pin == iovdd_ctrl_spec.pin)) {
 		/* When a single GPIO is used, we need a total wait time after bucken assertion
 		 * to be 6ms (1ms + 1ms + 4ms).
 		 */


### PR DESCRIPTION
Currently a user, or a shield definition, must select a Kconfig to signal that the iovdd_ctrl and bucken GPIOs are connected to the same pin. We can instead check this in the driver by simply checking if the `iovdd_ctrl_spec` and `bucken_spec` are the same pin.

We could also optimize the driver by adding some build time ifdefs based on the pin properties, but let's keep it simple for now :)