### PR TITLE
boards: nordic: thingy53: add missing edge connector SPI to cpunet core

### DIFF
--- a/boards/nordic/thingy53/thingy53_nrf5340_cpunet.dts
+++ b/boards/nordic/thingy53/thingy53_nrf5340_cpunet.dts
@@ -141,6 +141,15 @@
 	};
 };
 
+edge_connector_spi: &spi4 {
+	compatible = "nordic,nrf-spim";
+	status = "okay";
+	cs-gpios = <&edge_connector 18 GPIO_ACTIVE_LOW>;
+	pinctrl-0 = <&spi4_default>;
+	pinctrl-1 = <&spi4_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
 &ieee802154 {
 	status = "okay";
 };


### PR DESCRIPTION
The nordic edge-connector spi node is missing from the dts of cpunet. This missing node causes undefined node issues when building for the cpunet core with the nrf7002eb shield enabled, since it depends on the spi node.