### PR TITLE
tests: gen_isr_table: remove misnamed platform

### DIFF
--- a/tests/kernel/gen_isr_table/testcase.yaml
+++ b/tests/kernel/gen_isr_table/testcase.yaml
@@ -20,7 +20,7 @@ tests:
   arch.interrupt.gen_isr_table.arm_mainline: &arm-mainline
     platform_allow: qemu_cortex_m3
     platform_exclude:
-      - stmf103_mini
+      - stm32f103_mini
       - nucleo_f103rb
       - olimexino_stm32
       - stm32_min_dev@black


### PR DESCRIPTION
this platform does not exist, causing ci failures due to recent additional checks added

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
