### PR TITLE
arch: riscv: smp: refactor IPI functions and guard with `CONFIG_RISCV_SMP_IPI_CLINT`

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -37,6 +37,13 @@ config RISCV_ALWAYS_SWITCH_THROUGH_ECALL
 	  and most people should say n here to minimize context switching
 	  overhead.
 
+config RISCV_SMP_IPI_CLINT
+	bool
+	default y if DT_HAS_SIFIVE_CLINT0_ENABLED
+	depends on SMP
+	help
+	  Internal config to indicate that SMP IPI is routed through CLINT
+
 menu "RISCV Processor Options"
 
 config INCLUDE_RESET_VECTOR

--- a/arch/riscv/core/smp.c
+++ b/arch/riscv/core/smp.c
@@ -12,6 +12,7 @@
 #include <zephyr/sys/atomic.h>
 #include <zephyr/arch/riscv/irq.h>
 #include <zephyr/drivers/pm_cpu_ops.h>
+#include <zephyr/devicetree.h>
 
 volatile struct {
 	arch_cpustart_t fn;
@@ -80,12 +81,37 @@ void arch_secondary_cpu_init(int hartid)
 
 #ifdef CONFIG_SMP
 
-#define MSIP_BASE 0x2000000UL
-#define MSIP(hartid) ((volatile uint32_t *)MSIP_BASE)[hartid]
-
 static atomic_val_t cpu_pending_ipi[CONFIG_MP_MAX_NUM_CPUS];
 #define IPI_SCHED	0
 #define IPI_FPU_FLUSH	1
+
+#ifdef CONFIG_RISCV_SMP_IPI_CLINT
+#define MSIP_BASE 0x2000000UL
+#define MSIP(hartid) ((volatile uint32_t *)MSIP_BASE)[hartid]
+
+static ALWAYS_INLINE void z_riscv_ipi_send(unsigned int cpu)
+{
+	MSIP(_kernel.cpus[cpu].arch.hartid) = 1;
+}
+
+static ALWAYS_INLINE void z_riscv_ipi_clear(unsigned int cpu)
+{
+	MSIP(_kernel.cpus[cpu].arch.hartid) = 0;
+}
+
+void z_riscv_sched_ipi_handler(const void *unused);
+int arch_smp_init(void)
+{
+	IRQ_CONNECT(RISCV_IRQ_MSOFT, 0, z_riscv_sched_ipi_handler, NULL, 0);
+	irq_enable(RISCV_IRQ_MSOFT);
+
+	return 0;
+}
+#else
+/* The following functions are implemented somewhere else */
+void z_riscv_ipi_send(unsigned int cpu);
+void z_riscv_ipi_clear(unsigned int cpu);
+#endif /* CONFIG_RISCV_SMP_IPI_CLINT */
 
 void arch_sched_directed_ipi(uint32_t cpu_bitmap)
 {
@@ -97,7 +123,7 @@ void arch_sched_directed_ipi(uint32_t cpu_bitmap)
 		if ((i != id) && _kernel.cpus[i].arch.online &&
 		    ((cpu_bitmap & BIT(i)) != 0)) {
 			atomic_set_bit(&cpu_pending_ipi[i], IPI_SCHED);
-			MSIP(_kernel.cpus[i].arch.hartid) = 1;
+			z_riscv_ipi_send(i);
 		}
 	}
 
@@ -113,15 +139,15 @@ void arch_sched_broadcast_ipi(void)
 void arch_flush_fpu_ipi(unsigned int cpu)
 {
 	atomic_set_bit(&cpu_pending_ipi[cpu], IPI_FPU_FLUSH);
-	MSIP(_kernel.cpus[cpu].arch.hartid) = 1;
+	z_riscv_ipi_send(cpu);
 }
 #endif
 
-static void sched_ipi_handler(const void *unused)
+void z_riscv_sched_ipi_handler(const void *unused)
 {
 	ARG_UNUSED(unused);
 
-	MSIP(csr_read(mhartid)) = 0;
+	z_riscv_ipi_clear(_current_cpu->id);
 
 	atomic_val_t pending_ipi = atomic_clear(&cpu_pending_ipi[_current_cpu->id]);
 
@@ -164,12 +190,4 @@ void arch_spin_relax(void)
 }
 #endif
 
-int arch_smp_init(void)
-{
-
-	IRQ_CONNECT(RISCV_IRQ_MSOFT, 0, sched_ipi_handler, NULL, 0);
-	irq_enable(RISCV_IRQ_MSOFT);
-
-	return 0;
-}
 #endif /* CONFIG_SMP */


### PR DESCRIPTION
Currently, the RISC-V SMP IPI implementation is CLINT-based. However, IPI in RISC-V is not necessarily always done through a CLINT, in SoC with PLIC connected to the MSIP (i.e. Andes AE350's PLIC_SW), IPI has to be routed through the PLIC.

This patch refactor the IPI delivery into functions and guard it with `CONFIG_RISCV_SMP_IPI_CLINT`, so that for SoC that do not have a `sifive,clint0` device, and has a different IPI mechanism, they can implement their own `z_riscv_ipi_send()` & `z_riscv_ipi_clear()`.

> [!NOTE]
> This is an alternative for #65824

- [ ] probably should add an entry to the release note