### PR TITLE
drivers: video: fix a typo in get_ctrl API function type

### DIFF
--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -265,7 +265,7 @@ __subsystem struct video_driver_api {
 	video_api_dequeue_t dequeue;
 	video_api_flush_t flush;
 	video_api_set_ctrl_t set_ctrl;
-	video_api_set_ctrl_t get_ctrl;
+	video_api_get_ctrl_t get_ctrl;
 	video_api_set_signal_t set_signal;
 };
 


### PR DESCRIPTION
Thankfully, the typo does not have any effect in practice.