### PR TITLE
drivers: video: Add VIDEO_BUF_STARTED to poll signals

### DIFF
--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -140,6 +140,7 @@ enum video_endpoint_id {
  * Identify video event.
  */
 enum video_signal_result {
+	VIDEO_BUF_STARTED,
 	VIDEO_BUF_DONE,
 	VIDEO_BUF_ABORTED,
 	VIDEO_BUF_ERROR,


### PR DESCRIPTION
Adding `VIDEO_BUF_STARTED` result to `enum video_signal_result`. 

`VIDEO_BUF_STARTED`: Gets triggered at the start of buffer processing (e.g. start of capturing data)

Full disclosure:
I'm developing a sensor driver for a TOF image sensor and I need to change some settings on the driver after every frame.
The Idea would be to produce the `VIDEO_BUF_STARTED` in the video driver using the vsync or SOF interrupt and pulling for it in the sensor driver using a `meta-IRQ thread`.
