### PR TITLE
boards: rd_rw612_bga: Rename LED to "virtual"

### DIFF
--- a/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
+++ b/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
@@ -14,7 +14,6 @@
 
 	aliases {
 		usart-0 = &flexcomm3;
-		led0 = &green_led;
 		sw0 = &sw_4;
 		i2c-0 = &flexcomm2;
 		watchdog0 = &wwdt;
@@ -29,14 +28,6 @@
 		zephyr,flash-controller = &mx25u51245g;
 		zephyr,console = &flexcomm3;
 		zephyr,shell-uart = &flexcomm3;
-	};
-
-	leds {
-		compatible = "gpio-leds";
-		green_led: led_1 {
-			gpios = <&hsgpio1 20 0>;
-			label = "User LED_GREEN";
-		};
 	};
 
 	gpio_keys {


### PR DESCRIPTION
There is not a real LED on this board, it's just a pin header, rename the led node to prevent confusion from green_led to virtual_led.