### PR TITLE
drivers: serial: ra8_sci_b: refactor `uart_ra_sci_b_callback_adapter` function

### DIFF
--- a/drivers/serial/uart_renesas_ra8_sci_b.c
+++ b/drivers/serial/uart_renesas_ra8_sci_b.c
@@ -803,7 +803,7 @@ static void uart_ra_sci_b_callback_adapter(struct st_uart_callback_arg *fsp_args
 	case UART_EVENT_TX_COMPLETE: {
 		data->tx_buffer_len = data->tx_buffer_cap;
 		async_update_tx_buffer(dev);
-		return;
+		break;
 	}
 	case UART_EVENT_RX_COMPLETE: {
 		data->rx_buffer_len =
@@ -811,16 +811,20 @@ static void uart_ra_sci_b_callback_adapter(struct st_uart_callback_arg *fsp_args
 		async_rx_ready(dev);
 		async_release_rx_buffer(dev);
 		async_replace_rx_buffer(dev);
-		return;
+		break;
 	}
 	case UART_EVENT_ERR_PARITY:
-		return async_rx_error(dev, UART_ERROR_PARITY);
+		async_rx_error(dev, UART_ERROR_PARITY);
+		break;
 	case UART_EVENT_ERR_FRAMING:
-		return async_rx_error(dev, UART_ERROR_FRAMING);
+		async_rx_error(dev, UART_ERROR_FRAMING);
+		break;
 	case UART_EVENT_ERR_OVERFLOW:
-		return async_rx_error(dev, UART_ERROR_OVERRUN);
+		async_rx_error(dev, UART_ERROR_OVERRUN);
+		break;
 	case UART_EVENT_BREAK_DETECT:
-		return async_rx_error(dev, UART_BREAK);
+		async_rx_error(dev, UART_BREAK);
+		break;
 	case UART_EVENT_TX_DATA_EMPTY:
 	case UART_EVENT_RX_CHAR:
 		break;

--- a/drivers/serial/uart_renesas_ra8_sci_b.c
+++ b/drivers/serial/uart_renesas_ra8_sci_b.c
@@ -458,7 +458,7 @@ static inline void async_rx_disabled(const struct device *dev)
 	struct uart_event event = {
 		.type = UART_RX_DISABLED,
 	};
-	return async_user_callback(dev, &event);
+	async_user_callback(dev, &event);
 }
 
 static inline void async_request_rx_buffer(const struct device *dev)
@@ -466,7 +466,7 @@ static inline void async_request_rx_buffer(const struct device *dev)
 	struct uart_event event = {
 		.type = UART_RX_BUF_REQUEST,
 	};
-	return async_user_callback(dev, &event);
+	async_user_callback(dev, &event);
 }
 
 static inline void async_rx_ready(const struct device *dev)


### PR DESCRIPTION
This PR addresses the following:
- Revise switch-case to use `break` instead of `return`.
- Remove unnecessary `return` statements in `void` functions.
