### PR TITLE
doc: update references to video capture sample

### DIFF
--- a/boards/shields/dvp_fpc24_mt9m114/doc/index.rst
+++ b/boards/shields/dvp_fpc24_mt9m114/doc/index.rst
@@ -78,7 +78,7 @@ Programming
 Set ``--shield dvp_fpc24_mt9m114`` when you invoke ``west build``. For example:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/subsys/video/capture
+   :zephyr-app: samples/drivers/video/capture
    :board: mimxrt1064_evk
    :shield: dvp_fpc24_mt9m114
    :goals: build

--- a/boards/shields/nxp_btb44_ov5640/doc/index.rst
+++ b/boards/shields/nxp_btb44_ov5640/doc/index.rst
@@ -120,7 +120,7 @@ Programming
 Set ``--shield nxp_btb44_ov5640`` when you invoke ``west build``. For example:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/subsys/video/capture
+   :zephyr-app: samples/drivers/video/capture
    :board: mimxrt1170_evk/mimxrt1176/cm7
    :shield: nxp_btb44_ov5640
    :goals: build

--- a/samples/drivers/video/capture/README.rst
+++ b/samples/drivers/video/capture/README.rst
@@ -50,7 +50,7 @@ For :ref:`mimxrt1064_evk`, build this sample application with the following comm
 For :ref:`mimxrt1170_evk`, build this sample application with the following commands:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/subsys/video/capture
+   :zephyr-app: samples/drivers/video/capture
    :board: mimxrt1170_evk/mimxrt1176/cm7
    :shield: nxp_btb44_ov5640,rk055hdmipi4ma0
    :goals: build


### PR DESCRIPTION
Video samples have moved from samples/subsys/video to samples/drivers/video.
Until https://github.com/zephyrproject-rtos/zephyr/pull/78414 the samples/subsys/video still existed so the old reference still kinda worked

This wasn't caught due to CI probably still having the old "empty" folder when rebasing the PR "removing" that folder on top of main, as the Sphinx extension only checks on folder existence to check if a path to a "zephyr app" is valid. It does fail on a clean clone though.