### PR TITLE
boards: witte: linum: fix documentation Linum documentation

### DIFF
--- a/boards/witte/linum/doc/index.rst
+++ b/boards/witte/linum/doc/index.rst
@@ -94,7 +94,7 @@ features:
 Other hardware features are not yet supported on this Zephyr port.
 
 The default configuration can be found in the defconfig file:
-:zephyr_file:`boards/witte_technology/linum/linum_defconfig`
+:zephyr_file:`boards/witte/linum/linum_defconfig`
 
 
 Default Zephyr Peripheral Mapping:

--- a/boards/witte/linum/doc/index.rst
+++ b/boards/witte/linum/doc/index.rst
@@ -49,6 +49,8 @@ Expansion connector 2 features.
   - 6 PWM Channels
   - 10 ADCs
 
+More information about the board, can be found at the `Witte Linum website`_.
+
 Supported Features
 ==================
 


### PR DESCRIPTION
This PR fixes two things:

* Fix the defconfig link broken in the documentation;
* Mention the Witte website in the documentation to the render the link in the HTML output.