### PR TITLE
tests: drivers: build_all: rtc: Add i2c-devices build tests

### DIFF
--- a/tests/drivers/build_all/rtc/i2c_devices.overlay
+++ b/tests/drivers/build_all/rtc/i2c_devices.overlay
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2024 TOKITA Hiroshi
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	test {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		test_gpio: gpio@deadbeef {
+			compatible = "vnd,gpio";
+			gpio-controller;
+			reg = <0xdeadbeef 0x1000>;
+			#gpio-cells = <0x2>;
+			status = "okay";
+		};
+
+		test_i2c: i2c@11112222 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			compatible = "vnd,i2c";
+			reg = <0x11112222 0x1000>;
+			status = "okay";
+			clock-frequency = <100000>;
+
+			test_am1805: am1805@0 {
+				compatible = "ambiq,am1805";
+				status = "okay";
+				reg = <0x0>;
+				am1805-gpios = <&test_gpio 0 0>;
+			};
+
+			test_pcf8523: pcf8523@1 {
+				compatible = "nxp,pcf8523";
+				status = "okay";
+				reg = <0x1>;
+				alarms-count = <1>;
+				battery-switch-over = "standard";
+				int1-gpios = <&test_gpio 0 0>;
+			};
+
+			test_pcf8563: pcf8563@2 {
+				compatible = "nxp,pcf8563";
+				status = "okay";
+				reg = <0x2>;
+			};
+
+			test_rv3028: rv3028@3 {
+				compatible = "microcrystal,rv3028";
+				status = "okay";
+				reg = <0x3>;
+				clkout-frequency = <1>;
+				backup-switch-mode = "disabled";
+				trickle-resistor-ohms = <3000>;
+				int-gpios = <&test_gpio 0 0>;
+			};
+
+			test_rv8263: rv8263@4 {
+				compatible = "microcrystal,rv-8263-c8";
+				status = "okay";
+				reg = <0x4>;
+				int-gpios = <&test_gpio 0 0>;
+				clkout = <4096>;
+			};
+
+			test_ds1307: ds1307@5 {
+				compatible = "maxim,ds1307";
+				status = "okay";
+				reg = <0x5>;
+			};
+		};
+	};
+};

--- a/tests/drivers/build_all/rtc/testcase.yaml
+++ b/tests/drivers/build_all/rtc/testcase.yaml
@@ -11,3 +11,12 @@ tests:
       - arduino_gpio
     extra_args: SHIELD=adafruit_data_logger
     platform_allow: frdm_k64f
+  drivers.rtc.build.i2c:
+    extra_args: DTC_OVERLAY_FILE="i2c_devices.overlay"
+    extra_configs:
+      - CONFIG_I2C=y
+    platform_allow:
+      - native_posix
+      - native_posix/native/64
+      - native_sim
+      - native_sim/native/64


### PR DESCRIPTION
Add build tests for following devices.

- ambiq,am1805
- nxp,pcf8523
- nxp,pcf8563
- microcrystal,rv3028
- microcrystal,rv-8263-c8
- maxim,ds1307