### PR TITLE
tests: drivers: build_all: ieee802154: Add native_sim configuration

### DIFF
--- a/drivers/ieee802154/Kconfig.mcr20a
+++ b/drivers/ieee802154/Kconfig.mcr20a
@@ -7,6 +7,7 @@ menuconfig IEEE802154_MCR20A
 	bool "NXP MCR20A Driver support"
 	default y
 	depends on DT_HAS_NXP_MCR20A_ENABLED
+	depends on HAS_MCUX
 	select SPI
 
 if IEEE802154_MCR20A

--- a/tests/drivers/build_all/ieee802154/boards/native_sim.overlay
+++ b/tests/drivers/build_all/ieee802154/boards/native_sim.overlay
@@ -1,0 +1,6 @@
+/*
+ * Copyright (c) 2024 TOKITA Hiroshi
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "native_posix.overlay"

--- a/tests/drivers/build_all/ieee802154/boards/native_sim_native_64.overlay
+++ b/tests/drivers/build_all/ieee802154/boards/native_sim_native_64.overlay
@@ -1,0 +1,6 @@
+/*
+ * Copyright (c) 2024 TOKITA Hiroshi
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "native_posix.overlay"

--- a/tests/drivers/build_all/ieee802154/testcase.yaml
+++ b/tests/drivers/build_all/ieee802154/testcase.yaml
@@ -8,6 +8,7 @@ tests:
     platform_allow:
       - native_posix
       - native_sim
+      - native_sim/native/64
   drivers.ieee802154.build.cc13xx_cc26xx:
     platform_allow: cc1352r_sensortag
   drivers.ieee802154.build.kw41z:


### PR DESCRIPTION
The native_sim has already been added to the test cases of
`drivers.ieee802154.build.external` is not being appropriately
processed because there is no corresponding overlay.

Create an overlay as an alias of native_posix.overlay.

Also, add the native_sim/native/64 platforms in the same way.

- - -

The mcr20a driver referencing `MCR20Overwrites.h` which is under
`hal/nxp/mcux`.

So, put `depends HAS_MCUX` for clarify the dependency.