### PR TITLE
clang-format: add more whitespace sensitive macros

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -101,5 +101,10 @@ SpaceBeforeParens: ControlStatementsExceptControlMacros
 SortIncludes: Never
 UseTab: ForContinuationAndIndentation
 WhitespaceSensitiveMacros:
+  - COND_CODE_0
+  - COND_CODE_1
+  - IF_DISABLED
+  - IF_ENABLED
+  - LISTIFY
   - STRINGIFY
   - Z_STRINGIFY


### PR DESCRIPTION
An issue with some macros is that a space is added to conditional expansions. Prevent some of these macros to get formatted.

Ref #78214