### PR TITLE
dts: stm32l4: Remove aes node

### DIFF
--- a/dts/arm/st/l4/stm32l422.dtsi
+++ b/dts/arm/st/l4/stm32l422.dtsi
@@ -9,15 +9,5 @@
 / {
 	soc {
 		compatible = "st,stm32l422", "st,stm32l4", "simple-bus";
-
-		aes: aes@50060000 {
-			compatible = "st,stm32-aes";
-			reg = <0x50060000 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00010000>;
-			resets = <&rctl STM32_RESET(AHB2, 16U)>;
-			interrupts = <79 0>;
-			interrupt-names = "aes";
-			status = "disabled";
-		};
 	};
 };

--- a/dts/arm/st/l4/stm32l462.dtsi
+++ b/dts/arm/st/l4/stm32l462.dtsi
@@ -9,15 +9,5 @@
 / {
 	soc {
 		compatible = "st,stm32l462", "st,stm32l4", "simple-bus";
-
-		aes: aes@50060000 {
-			compatible = "st,stm32-aes";
-			reg = <0x50060000 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00010000>;
-			resets = <&rctl STM32_RESET(AHB2, 16U)>;
-			interrupts = <79 0>;
-			interrupt-names = "aes";
-			status = "disabled";
-		};
 	};
 };

--- a/dts/arm/st/l4/stm32l496.dtsi
+++ b/dts/arm/st/l4/stm32l496.dtsi
@@ -60,16 +60,6 @@
 			status = "disabled";
 		};
 
-		aes: aes@50060000 {
-			compatible = "st,stm32-aes";
-			reg = <0x50060000 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00010000>;
-			resets = <&rctl STM32_RESET(AHB2, 16U)>;
-			interrupts = <79 0>;
-			interrupt-names = "aes";
-			status = "disabled";
-		};
-
 		usbotg_fs: otgfs@50000000 {
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00001000>,
 				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;

--- a/dts/arm/st/l4/stm32l4p5.dtsi
+++ b/dts/arm/st/l4/stm32l4p5.dtsi
@@ -294,16 +294,6 @@
 			status = "disabled";
 		};
 
-		aes: aes@50060000 {
-			compatible = "st,stm32-aes";
-			reg = <0x50060000 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00010000>;
-			resets = <&rctl STM32_RESET(AHB2, 16U)>;
-			interrupts = <79 0>;
-			interrupt-names = "aes";
-			status = "disabled";
-		};
-
 		usbotg_fs: otgfs@50000000 {
 			compatible = "st,stm32-otgfs";
 			reg = <0x50000000 0x40000>;


### PR DESCRIPTION
aes node was present in stm32l4 .dtsi files but existing stm32 crypto driver is not compatible with stm32l4.

Removing aes nodes for now, waiting for the driver to be adapted to this series.

Fixes #78482