### PR TITLE
boards: st: nucleo_wb0: Remove arduino_gpio compatibility declaration

### DIFF
--- a/boards/st/nucleo_wb05kz/nucleo_wb05kz.yaml
+++ b/boards/st/nucleo_wb05kz/nucleo_wb05kz.yaml
@@ -10,5 +10,4 @@ ram: 24
 flash: 192
 supported:
   - gpio
-  - arduino_gpio
 vendor: st

--- a/boards/st/nucleo_wb09ke/nucleo_wb09ke.yaml
+++ b/boards/st/nucleo_wb09ke/nucleo_wb09ke.yaml
@@ -10,5 +10,4 @@ ram: 64
 flash: 512
 supported:
   - gpio
-  - arduino_gpio
 vendor: st


### PR DESCRIPTION
gpio_basic_api test configuration drivers.gpio.2pin_arduino expects arduino pins D2 and D3 to be available but they aren't declared in arduino connectors for this board as not available by default.

Remove arduino_gpio compatibility declaration for now to solve CI failures.

This will have to be reviewed when we'll define CI test strategy for this series. Probably using `2pin_arduino_customized`
test configuration.