### PR TITLE
llext: (cosmetic) fix a name in an error message

### DIFF
--- a/tests/subsys/llext/simple/src/test_llext_simple.c
+++ b/tests/subsys/llext/simple/src/test_llext_simple.c
@@ -351,7 +351,7 @@ ZTEST(llext, test_inter_ext)
 
 	int (*test_entry_fn)() = llext_find_sym(&ext_dependent->exp_tab, "test_entry");
 
-	zassert_not_null(test_entry_fn, "test_dependent should be an exported symbol");
+	zassert_not_null(test_entry_fn, "test_entry should be an exported symbol");
 	test_entry_fn();
 
 	llext_unload(&ext_dependent);


### PR DESCRIPTION
test_dependent() was changed to test_entry() but one location was missed - in a warning message string. Fix it too.