### PR TITLE
west.yml: hal_stm32: revert ble_fw blobs

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -233,7 +233,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: c4099c229323f305eef75ff6ba93ee9b89827581
+      revision: 1ff820533c1b1c17f1a4d7d28ab99a94a234883b
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Since the mkbox board ble f/w upgrade method based on binary blobs that was proposed in #74255 has been turned down, all the work done in hal_stm32 module to host blobs is now reverted.

The application will be pushed as part of https://github.com/STMicroelectronics/stsw-mkbox-bleco.git package