### PR TITLE
tests/bsim/bluetooth/host: Enable RealEncryption

### DIFF
--- a/tests/bsim/bluetooth/host/adv/encrypted/ead_sample/test_scripts/ead_sample.sh
+++ b/tests/bsim/bluetooth/host/adv/encrypted/ead_sample/test_scripts/ead_sample.sh
@@ -10,10 +10,10 @@ verbosity_level=2
 cd ${BSIM_OUT_PATH}/bin
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_host_adv_encrypted_ead_sample_prj_conf \
-  -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central
+  -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central -RealEncryption=1
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_host_adv_encrypted_ead_sample_prj_conf \
-  -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral
+  -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral -RealEncryption=1
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=60e6 $@

--- a/tests/bsim/bluetooth/host/att/eatt/tests_scripts/autoconnect.sh
+++ b/tests/bsim/bluetooth/host/att/eatt/tests_scripts/autoconnect.sh
@@ -11,10 +11,10 @@ EXECUTE_TIMEOUT=120
 cd ${BSIM_OUT_PATH}/bin
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_host_att_eatt_prj_autoconnect_conf \
-  -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central_autoconnect
+  -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central_autoconnect -RealEncryption=1
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_host_att_eatt_prj_autoconnect_conf \
-  -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral_autoconnect
+  -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral_autoconnect -RealEncryption=1
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=200e6 $@

--- a/tests/bsim/bluetooth/host/att/eatt/tests_scripts/collision.sh
+++ b/tests/bsim/bluetooth/host/att/eatt/tests_scripts/collision.sh
@@ -11,10 +11,10 @@ EXECUTE_TIMEOUT=120
 cd ${BSIM_OUT_PATH}/bin
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_host_att_eatt_prj_collision_conf \
-  -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central
+  -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central -RealEncryption=1
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_host_att_eatt_prj_collision_conf \
-  -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral
+  -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral -RealEncryption=1
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=200e6 $@

--- a/tests/bsim/bluetooth/host/att/eatt/tests_scripts/lowres.sh
+++ b/tests/bsim/bluetooth/host/att/eatt/tests_scripts/lowres.sh
@@ -10,10 +10,10 @@ verbosity_level=2
 cd ${BSIM_OUT_PATH}/bin
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_host_att_eatt_prj_autoconnect_conf \
-  -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central_lowres
+  -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central_lowres -RealEncryption=1
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_host_att_eatt_prj_lowres_conf \
-  -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral_lowres
+  -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral_lowres -RealEncryption=1
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=200e6 $@

--- a/tests/bsim/bluetooth/host/att/eatt/tests_scripts/multiple_conn.sh
+++ b/tests/bsim/bluetooth/host/att/eatt/tests_scripts/multiple_conn.sh
@@ -11,10 +11,10 @@ EXECUTE_TIMEOUT=120
 cd ${BSIM_OUT_PATH}/bin
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_host_att_eatt_prj_multiple_conn_conf \
-  -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central
+  -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central -RealEncryption=1
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_host_att_eatt_prj_multiple_conn_conf \
-  -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral
+  -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral -RealEncryption=1
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=200e6 $@

--- a/tests/bsim/bluetooth/host/att/eatt/tests_scripts/reconfigure.sh
+++ b/tests/bsim/bluetooth/host/att/eatt/tests_scripts/reconfigure.sh
@@ -11,10 +11,10 @@ EXECUTE_TIMEOUT=120
 cd ${BSIM_OUT_PATH}/bin
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_host_att_eatt_prj_autoconnect_conf \
-  -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central_reconfigure
+  -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central_reconfigure -RealEncryption=1
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_host_att_eatt_prj_autoconnect_conf \
-  -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral_reconfigure
+  -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral_reconfigure -RealEncryption=1
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=60e6 $@

--- a/tests/bsim/bluetooth/host/att/eatt_notif/test_scripts/eatt_notif.sh
+++ b/tests/bsim/bluetooth/host/att/eatt_notif/test_scripts/eatt_notif.sh
@@ -13,10 +13,10 @@ EXECUTE_TIMEOUT=120
 cd ${BSIM_OUT_PATH}/bin
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_host_att_eatt_notif_prj_conf \
-  -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=client
+  -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=client -RealEncryption=1
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_host_att_eatt_notif_prj_conf \
-  -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=server
+  -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=server -RealEncryption=1
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=60e6 $@

--- a/tests/bsim/bluetooth/host/gatt/caching/test_scripts/_run_test.sh
+++ b/tests/bsim/bluetooth/host/gatt/caching/test_scripts/_run_test.sh
@@ -11,10 +11,10 @@ BIN_SUFFIX=${bin_suffix:-}
 cd ${BSIM_OUT_PATH}/bin
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_host_gatt_caching_prj_conf${BIN_SUFFIX} \
-    -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=${client_id}
+    -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=${client_id} -RealEncryption=1
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_host_gatt_caching_prj_conf${BIN_SUFFIX} \
-    -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=${server_id}
+    -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=${server_id} -RealEncryption=1
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
     -D=2 -sim_length=60e6 $@

--- a/tests/bsim/bluetooth/host/gatt/ccc_store/test_scripts/ccc_store.sh
+++ b/tests/bsim/bluetooth/host/gatt/ccc_store/test_scripts/ccc_store.sh
@@ -13,13 +13,13 @@ cd ${BSIM_OUT_PATH}/bin
 if [ "${1}" != 'debug0' ]; then
   Execute "./${test_exe}" \
     -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central \
-    -flash="${simulation_id}_client.log.bin" -flash_rm -argstest 10
+    -flash="${simulation_id}_client.log.bin" -flash_rm -RealEncryption=1 -argstest 10
 fi
 
 if [ "${1}" != 'debug1' ]; then
   Execute "./${test_exe}" \
     -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral \
-    -flash="${simulation_id}_server.log.bin" -flash_rm -argstest 10
+    -flash="${simulation_id}_server.log.bin" -flash_rm -RealEncryption=1 -argstest 10
 fi
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
@@ -28,13 +28,13 @@ Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
 if [ "${1}" == 'debug0' ]; then
   gdb --args "./${test_exe}" \
     -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central \
-    -flash="${simulation_id}_client.log.bin" -flash_rm -argstest 10
+    -flash="${simulation_id}_client.log.bin" -flash_rm -RealEncryption=1 -argstest 10
 fi
 
 if [ "${1}" == 'debug1' ]; then
   gdb --args "./${test_exe}" \
     -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral \
-    -flash="${simulation_id}_server.log.bin" -flash_rm -argstest 10
+    -flash="${simulation_id}_server.log.bin" -flash_rm -RealEncryption=1 -argstest 10
 fi
 
 wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/gatt/ccc_store/test_scripts/ccc_store_2.sh
+++ b/tests/bsim/bluetooth/host/gatt/ccc_store/test_scripts/ccc_store_2.sh
@@ -13,13 +13,13 @@ cd ${BSIM_OUT_PATH}/bin
 if [ "${1}" != 'debug0' ]; then
   Execute "./${test_exe}" \
     -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central \
-    -flash="${simulation_id}_client.log.bin" -flash_rm -argstest 10
+    -flash="${simulation_id}_client.log.bin" -flash_rm -RealEncryption=1 -argstest 10
 fi
 
 if [ "${1}" != 'debug1' ]; then
   Execute "./${test_exe}" \
     -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral \
-    -flash="${simulation_id}_server.log.bin" -flash_rm -argstest 10
+    -flash="${simulation_id}_server.log.bin" -flash_rm -RealEncryption=1 -argstest 10
 fi
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
@@ -28,13 +28,13 @@ Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
 if [ "${1}" == 'debug0' ]; then
   gdb --args "./${test_exe}" \
     -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central \
-    -flash="${simulation_id}_client.log.bin" -flash_rm -argstest 10
+    -flash="${simulation_id}_client.log.bin" -flash_rm -RealEncryption=1 -argstest 10
 fi
 
 if [ "${1}" == 'debug1' ]; then
   gdb --args "./${test_exe}" \
     -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral \
-    -flash="${simulation_id}_server.log.bin" -flash_rm -argstest 10
+    -flash="${simulation_id}_server.log.bin" -flash_rm -RealEncryption=1 -argstest 10
 fi
 
 wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/gatt/general/test_scripts/gatt.sh
+++ b/tests/bsim/bluetooth/host/gatt/general/test_scripts/gatt.sh
@@ -15,10 +15,10 @@ EXECUTE_TIMEOUT=120
 cd ${BSIM_OUT_PATH}/bin
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_host_gatt_general_prj_conf \
-  -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=gatt_client
+  -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=gatt_client -RealEncryption=1
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_host_gatt_general_prj_conf \
-  -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=gatt_server
+  -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=gatt_server -RealEncryption=1
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=60e6 $@

--- a/tests/bsim/bluetooth/host/gatt/notify/test_scripts/_run_test.sh
+++ b/tests/bsim/bluetooth/host/gatt/notify/test_scripts/_run_test.sh
@@ -10,10 +10,10 @@ verbosity_level=2
 cd ${BSIM_OUT_PATH}/bin
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_host_gatt_notify_prj_conf \
-    -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=${client_id}
+    -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=${client_id} -RealEncryption=1
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_host_gatt_notify_prj_conf \
-    -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=${server_id}
+    -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=${server_id} -RealEncryption=1
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
     -D=2 -sim_length=60e6 $@

--- a/tests/bsim/bluetooth/host/gatt/notify_multiple/test_scripts/notify.sh
+++ b/tests/bsim/bluetooth/host/gatt/notify_multiple/test_scripts/notify.sh
@@ -12,10 +12,10 @@ EXECUTE_TIMEOUT=120
 cd ${BSIM_OUT_PATH}/bin
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_host_gatt_notify_multiple_prj_conf \
-  -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=gatt_client
+  -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=gatt_client -RealEncryption=1
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_host_gatt_notify_multiple_prj_conf \
-  -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=gatt_server
+  -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=gatt_server -RealEncryption=1
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=60e6 $@

--- a/tests/bsim/bluetooth/host/gatt/sc_indicate/test_scripts/sc_indicate.sh
+++ b/tests/bsim/bluetooth/host/gatt/sc_indicate/test_scripts/sc_indicate.sh
@@ -12,10 +12,10 @@ verbosity_level=2
 cd ${BSIM_OUT_PATH}/bin
 
 Execute "./${test_exe}" \
-  -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central
+  -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central -RealEncryption=1
 
 Execute "./${test_exe}" \
-  -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral
+  -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral -RealEncryption=1
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=60e6

--- a/tests/bsim/bluetooth/host/security/ccc_update/test_scripts/ccc_update.sh
+++ b/tests/bsim/bluetooth/host/security/ccc_update/test_scripts/ccc_update.sh
@@ -14,19 +14,19 @@ cd ${BSIM_OUT_PATH}/bin
 if [ "${1}" != 'debug0' ]; then
   Execute "./${test_exe}" \
     -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central \
-    -flash="${simulation_id}_client.log.bin" -flash_rm
+    -flash="${simulation_id}_client.log.bin" -flash_rm -RealEncryption=1
 fi
 
 if [ "${1}" != 'debug1' ]; then
   Execute "./${test_exe}" \
     -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=bad_central \
-    -flash="${simulation_id}_bad_client.log.bin" -flash_rm
+    -flash="${simulation_id}_bad_client.log.bin" -flash_rm -RealEncryption=1
 fi
 
 if [ "${1}" != 'debug2' ]; then
   Execute "./${test_exe}" \
     -v=${verbosity_level} -s=${simulation_id} -d=2 -testid=peripheral \
-    -flash="${simulation_id}_server.log.bin" -flash_rm
+    -flash="${simulation_id}_server.log.bin" -flash_rm -RealEncryption=1
 fi
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
@@ -35,19 +35,19 @@ Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
 if [ "${1}" == 'debug0' ]; then
   gdb --args "./${test_exe}" \
     -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central \
-    -flash="${simulation_id}_client.log.bin" -flash_rm
+    -flash="${simulation_id}_client.log.bin" -flash_rm -RealEncryption=1
 fi
 
 if [ "${1}" == 'debug1' ]; then
   gdb --args "./${test_exe}" \
     -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=bad_central \
-    -flash="${simulation_id}_bad_client.log.bin" -flash_rm
+    -flash="${simulation_id}_bad_client.log.bin" -flash_rm -RealEncryption=1
 fi
 
 if [ "${1}" == 'debug2' ]; then
   gdb --args "./${test_exe}" \
     -v=${verbosity_level} -s=${simulation_id} -d=2 -testid=peripheral \
-    -flash="${simulation_id}_server.log.bin" -flash_rm
+    -flash="${simulation_id}_server.log.bin" -flash_rm -RealEncryption=1
 fi
 
 wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/security/ccc_update/test_scripts/ccc_update_2.sh
+++ b/tests/bsim/bluetooth/host/security/ccc_update/test_scripts/ccc_update_2.sh
@@ -14,19 +14,19 @@ cd ${BSIM_OUT_PATH}/bin
 if [ "${1}" != 'debug0' ]; then
   Execute "./${test_exe}" \
     -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central \
-    -flash="${simulation_id}_client.log.bin" -flash_rm
+    -flash="${simulation_id}_client.log.bin" -flash_rm -RealEncryption=1
 fi
 
 if [ "${1}" != 'debug1' ]; then
   Execute "./${test_exe}" \
     -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=bad_central \
-    -flash="${simulation_id}_bad_client.log.bin" -flash_rm
+    -flash="${simulation_id}_bad_client.log.bin" -flash_rm -RealEncryption=1
 fi
 
 if [ "${1}" != 'debug2' ]; then
   Execute "./${test_exe}" \
     -v=${verbosity_level} -s=${simulation_id} -d=2 -testid=peripheral \
-    -flash="${simulation_id}_server.log.bin" -flash_rm
+    -flash="${simulation_id}_server.log.bin" -flash_rm -RealEncryption=1
 fi
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
@@ -35,19 +35,19 @@ Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
 if [ "${1}" == 'debug0' ]; then
   gdb --args "./${test_exe}" \
     -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central \
-    -flash="${simulation_id}_client.log.bin" -flash_rm
+    -flash="${simulation_id}_client.log.bin" -flash_rm -RealEncryption=1
 fi
 
 if [ "${1}" == 'debug1' ]; then
   gdb --args "./${test_exe}" \
     -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=bad_central \
-    -flash="${simulation_id}_bad_client.log.bin" -flash_rm
+    -flash="${simulation_id}_bad_client.log.bin" -flash_rm -RealEncryption=1
 fi
 
 if [ "${1}" == 'debug2' ]; then
   gdb --args "./${test_exe}" \
     -v=${verbosity_level} -s=${simulation_id} -d=2 -testid=peripheral \
-    -flash="${simulation_id}_server.log.bin" -flash_rm
+    -flash="${simulation_id}_server.log.bin" -flash_rm -RealEncryption=1
 fi
 
 wait_for_background_jobs

--- a/tests/bsim/bluetooth/host/security/security_changed_callback/test_scripts/security_changed_callback.sh
+++ b/tests/bsim/bluetooth/host/security/security_changed_callback/test_scripts/security_changed_callback.sh
@@ -12,10 +12,11 @@ verbosity_level=2
 cd ${BSIM_OUT_PATH}/bin
 
 Execute "./${test_exe}" \
-  -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central
+  -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central -RealEncryption=1
 
 Execute "./${test_exe}" \
-  -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral_disconnect_in_sec_cb
+  -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral_disconnect_in_sec_cb \
+  -RealEncryption=1
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=60e6
@@ -23,10 +24,11 @@ Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
 wait_for_background_jobs
 
 Execute "./${test_exe}" \
-  -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central
+  -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central  -RealEncryption=1
 
 Execute "./${test_exe}" \
-  -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral_unpair_in_sec_cb
+  -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral_unpair_in_sec_cb \
+  -RealEncryption=1
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=60e6


### PR DESCRIPTION
Let's run host tests with security/privacy with the HW models actually running the encryption, so in case of misaligned keys tests fail.

Related to #77701