### PR TITLE
bluetooth: smp: remove experimental from BT_BONDABLE_PER_CONNECTION

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -645,8 +645,7 @@ config BT_BONDING_REQUIRED
 	  requests will be rejected.
 
 config BT_BONDABLE_PER_CONNECTION
-	bool "Set/clear the bonding flag per-connection [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "Set/clear the bonding flag per-connection"
 	help
 	  Enable support for the bt_conn_set_bondable API function that is
 	  used to set/clear the bonding flag on a per-connection basis.


### PR DESCRIPTION
Removed the experimental status from the BT_BONDABLE_PER_CONNECTION Kconfig option used in the Bluetooth Host SMP layer. This feature has been present in Zephyr for over a year without any issue reports or API modifications.

CC: @mkapala-nordic 