### PR TITLE
bluetooth: smp: remove experimental from BT_GATT_AUTHORIZATION_CUSTOM

### DIFF
--- a/subsys/bluetooth/host/Kconfig.gatt
+++ b/subsys/bluetooth/host/Kconfig.gatt
@@ -285,8 +285,7 @@ config DEVICE_NAME_GATT_WRITABLE_AUTHEN
 endif #BT_DEVICE_NAME_GATT_WRITABLE
 
 config BT_GATT_AUTHORIZATION_CUSTOM
-	bool "Custom authorization of GATT operations [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "Custom authorization of GATT operations"
 	help
 	  This option allows the user to define application-specific
 	  authorization logic for GATT operations that can be registered


### PR DESCRIPTION
Removed the experimental status from the BT_GATT_AUTHORIZATION_CUSTOM Kconfig option used in the Bluetooth Host GATT layer. This feature has been present in Zephyr for almost a year without any issue reports or API modifications.