### PR TITLE
boards: arm: sensortile_box_pro: add bluenrg-lp chip description

### DIFF
--- a/boards/st/sensortile_box_pro/doc/index.rst
+++ b/boards/st/sensortile_box_pro/doc/index.rst
@@ -41,6 +41,9 @@ sensors on board)
 Hardware
 ********
 
+The following is a summary of the main board features. More info can be find on `UM3133`_
+and the `schematic`_.
+
 The STM32U585xx devices are an ultra-low-power microcontrollers family (STM32U5
 Series) based on the high-performance Arm|reg| Cortex|reg|-M33 32-bit RISC core.
 They operate at a frequency of up to 160 MHz.
@@ -212,6 +215,14 @@ The final application may use it to declare SensorTile.box PRO device as belongi
 certain standard or vendor class, e.g. a CDC, a mass storage or a composite device with both
 functions.
 
+BlueNRG-LP chip
+===============
+
+The board is equipped with an STMicroelectronics `BlueNRG-LP`_ chip. Before running Zephyr Bluetooth samples
+on SensorTile.box PRO, it is required to upgrade the BlueNRG chip with a Zephyr BLE stack compatible firmware.
+The upgrade may be easily performed using the application provided in `SensorTile.box PRO BLE firmware upgrade package`_.
+For more information about BLE binaries for SensorTile.box family, see `stsw-mkbox-bleco`_.
+
 Console
 =======
 
@@ -333,6 +344,12 @@ References
 .. _SensorTile.box PRO website:
    https://www.st.com/en/evaluation-tools/steval-mkboxpro.html
 
+.. _UM3133:
+   https://www.st.com/resource/en/user_manual/um3133-getting-started-with-sensortilebox-pro-multisensors-and-wireless-connectivity-development-kit-for-any-intelligent-iot-node-stmicroelectronics.pdf
+
+.. _schematic:
+   https://www.st.com/resource/en/schematic_pack/steval-mkboxpro-schematic.pdf
+
 .. _STM32U585 on www.st.com:
    https://www.st.com/en/microcontrollers-microprocessors/stm32u575-585.html
 
@@ -356,6 +373,15 @@ References
 
 .. _mp23db01hp datasheet:
    https://www.st.com/en/mems-and-sensors/mp23db01hp.html
+
+.. _BlueNRG-LP:
+   https://www.st.com/en/wireless-connectivity/bluenrg-lp.html
+
+.. _SensorTile.box PRO BLE firmware upgrade package:
+   https://github.com/STMicroelectronics/stsw-mkbox-bleco/blob/master/ble_fw_upg_app/README.rst
+
+.. _stsw-mkbox-bleco:
+   https://www.st.com/en/embedded-software/stsw-mkbox-bleco.html
 
 .. _AN2606:
    http://www.st.com/content/ccc/resource/technical/document/application_note/b9/9b/16/3a/12/1e/40/0c/CD00167594.pdf/files/CD00167594.pdf/jcr:content/translations/en.CD00167594.pdf


### PR DESCRIPTION
Extend sensortile_box_pro document adding BlueNRG-LP chip description.

This PR replaces #74255