### PR TITLE
tests: drivers: build_all: watchdog: Add i2c-devices build test

### DIFF
--- a/tests/drivers/build_all/watchdog/i2c_devices.overlay
+++ b/tests/drivers/build_all/watchdog/i2c_devices.overlay
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024 TOKITA Hiroshi
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	test {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		test_gpio: gpio@deadbeef {
+			compatible = "vnd,gpio";
+			gpio-controller;
+			reg = <0xdeadbeef 0x1000>;
+			#gpio-cells = <0x2>;
+			status = "okay";
+		};
+
+		test_i2c: i2c@11112222 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			compatible = "vnd,i2c";
+			reg = <0x11112222 0x1000>;
+			status = "okay";
+			clock-frequency = <100000>;
+
+			npm6001_ek_pmic: pmic@0 {
+				compatible = "nordic,npm6001";
+				reg = <0x0>;
+
+				npm6001_ek_wdt: watchdog {
+					compatible = "nordic,npm6001-wdt";
+				};
+			};
+		};
+	};
+};

--- a/tests/drivers/build_all/watchdog/spi_devices.overlay
+++ b/tests/drivers/build_all/watchdog/spi_devices.overlay
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024 TOKITA Hiroshi
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	test {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		test_gpio: gpio@deadbeef {
+			compatible = "vnd,gpio";
+			gpio-controller;
+			reg = <0xdeadbeef 0x1000>;
+			#gpio-cells = <0x2>;
+			status = "okay";
+		};
+
+		test_spi: spi@33334444 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			compatible = "vnd,spi";
+			reg = <0x33334444 0x1000>;
+			status = "okay";
+			clock-frequency = <2000000>;
+
+			/* one entry for every devices at spi.dtsi */
+			cs-gpios = <&test_gpio 0 0>,
+				   <&test_gpio 0 0>,
+				   <&test_gpio 0 0>,
+				   <&test_gpio 0 0>,
+				   <&test_gpio 0 0>;
+
+			test_spi_fs26: fs26@0 {
+				compatible = "nxp,fs26-wdog";
+				reg = <0>;
+				spi-max-frequency = <5000000>;
+				type = "challenger";
+				int-gpios = <&test_gpio 2 0>;
+				status = "okay";
+			};
+		};
+	};
+};

--- a/tests/drivers/build_all/watchdog/testcase.yaml
+++ b/tests/drivers/build_all/watchdog/testcase.yaml
@@ -8,3 +8,17 @@ tests:
     # will cover drivers without in-tree boards
     platform_allow: qemu_cortex_m3
     extra_args: "CONFIG_WATCHDOG=y"
+  drivers.watchdog.build.i2c:
+    extra_args: DTC_OVERLAY_FILE="i2c_devices.overlay"
+    extra_configs:
+      - CONFIG_I2C=y
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+  drivers.watchdog.build.spi:
+    extra_args: DTC_OVERLAY_FILE="spi_devices.overlay"
+    extra_configs:
+      - CONFIG_SPI=y
+    platform_allow:
+      - native_sim
+      - native_sim/native/64


### PR DESCRIPTION
Add build tests for following devices.

- nordic,npm6001-wdt
- nxp,fs26-wdog