### PR TITLE
boards: remove test feature usb_cdc and usb

### DIFF
--- a/boards/adafruit/feather_nrf52840/adafruit_feather_nrf52840_nrf52840_sense.yaml
+++ b/boards/adafruit/feather_nrf52840/adafruit_feather_nrf52840_nrf52840_sense.yaml
@@ -9,7 +9,6 @@ toolchain:
 supported:
   - adc
   - usb_device
-  - usb_cdc
   - ble
   - watchdog
   - counter

--- a/boards/adafruit/feather_nrf52840/adafruit_feather_nrf52840_nrf52840_sense_uf2.yaml
+++ b/boards/adafruit/feather_nrf52840/adafruit_feather_nrf52840_nrf52840_sense_uf2.yaml
@@ -9,7 +9,6 @@ toolchain:
 supported:
   - adc
   - usb_device
-  - usb_cdc
   - ble
   - watchdog
   - counter

--- a/boards/adafruit/feather_stm32f405/adafruit_feather_stm32f405.yaml
+++ b/boards/adafruit/feather_stm32f405/adafruit_feather_stm32f405.yaml
@@ -11,7 +11,6 @@ flash: 1024
 supported:
   - i2c
   - spi
-  - usb
   - feather_serial
   - feather_i2c
   - feather_spi

--- a/boards/atmel/sam/sam4l_ek/sam4l_ek.yaml
+++ b/boards/atmel/sam/sam4l_ek/sam4l_ek.yaml
@@ -16,6 +16,5 @@ supported:
   - i2c
   - spi
   - uart
-  - usb
   - usb_device
 vendor: atmel

--- a/boards/atmel/sam/sam_e70_xplained/sam_e70_xplained_same70q21.yaml
+++ b/boards/atmel/sam/sam_e70_xplained/sam_e70_xplained_same70q21.yaml
@@ -20,7 +20,6 @@ supported:
   - pwm
   - netif:eth
   - spi
-  - usb
   - usb_device
   - watchdog
 vendor: atmel

--- a/boards/atmel/sam/sam_e70_xplained/sam_e70_xplained_same70q21b.yaml
+++ b/boards/atmel/sam/sam_e70_xplained/sam_e70_xplained_same70q21b.yaml
@@ -20,7 +20,6 @@ supported:
   - pwm
   - netif:eth
   - spi
-  - usb
   - usb_device
   - watchdog
 vendor: atmel

--- a/boards/atmel/sam/sam_v71_xult/sam_v71_xult_samv71q21.yaml
+++ b/boards/atmel/sam/sam_v71_xult/sam_v71_xult_samv71q21.yaml
@@ -23,7 +23,6 @@ supported:
   - pwm
   - netif:eth
   - spi
-  - usb
   - usb_device
   - watchdog
   - xpro_gpio

--- a/boards/atmel/sam/sam_v71_xult/sam_v71_xult_samv71q21b.yaml
+++ b/boards/atmel/sam/sam_v71_xult/sam_v71_xult_samv71q21b.yaml
@@ -23,7 +23,6 @@ supported:
   - pwm
   - netif:eth
   - spi
-  - usb
   - usb_device
   - watchdog
   - xpro_gpio

--- a/boards/ct/ctcc/ctcc_nrf52840.yaml
+++ b/boards/ct/ctcc/ctcc_nrf52840.yaml
@@ -9,7 +9,6 @@ toolchain:
 supported:
   - ble
   - gpio
-  - usb_cdc
   - usb_device
   - watchdog
 vendor: ct

--- a/boards/mikroe/mini_m4_for_stm32/mikroe_mini_m4_for_stm32.yaml
+++ b/boards/mikroe/mini_m4_for_stm32/mikroe_mini_m4_for_stm32.yaml
@@ -14,5 +14,4 @@ supported:
   - i2c
   - spi
   - pwm
-  - usb
 vendor: mikroe

--- a/boards/others/black_f407ve/black_f407ve.yaml
+++ b/boards/others/black_f407ve/black_f407ve.yaml
@@ -12,6 +12,5 @@ supported:
   - can
   - pwm
   - counter
-  - usb
   - spi
   - gpio

--- a/boards/others/black_f407zg_pro/black_f407zg_pro.yaml
+++ b/boards/others/black_f407zg_pro/black_f407zg_pro.yaml
@@ -12,6 +12,5 @@ supported:
   - can
   - pwm
   - counter
-  - usb
   - spi
   - gpio

--- a/boards/others/serpente/serpente.yaml
+++ b/boards/others/serpente/serpente.yaml
@@ -17,6 +17,5 @@ supported:
   - pwm
   - spi
   - uart
-  - usb
   - usb_device
   - watchdog

--- a/boards/others/stm32f401_mini/stm32f401_mini.yaml
+++ b/boards/others/stm32f401_mini/stm32f401_mini.yaml
@@ -9,7 +9,6 @@ toolchain:
 supported:
   - counter
   - spi
-  - usb
   - i2c
   - uart
   - pwm

--- a/boards/seeed/seeeduino_xiao/seeeduino_xiao.yaml
+++ b/boards/seeed/seeeduino_xiao/seeeduino_xiao.yaml
@@ -16,7 +16,6 @@ supported:
   - i2c
   - spi
   - uart
-  - usb
   - usb_device
   - watchdog
 vendor: seeed

--- a/boards/sparkfun/micromod/micromod_nrf52840.yaml
+++ b/boards/sparkfun/micromod/micromod_nrf52840.yaml
@@ -17,7 +17,6 @@ supported:
   - pwm
   - adc
   - usb_device
-  - usb_cdc
   - watchdog
   - micromod_gpio
   - micromod_uart

--- a/boards/st/b_g474e_dpow1/b_g474e_dpow1.yaml
+++ b/boards/st/b_g474e_dpow1/b_g474e_dpow1.yaml
@@ -13,6 +13,5 @@ supported:
   - gpio
   - watchdog
   - tcpc
-  - usb
   - usbd
 vendor: st

--- a/boards/st/nucleo_f446ze/nucleo_f446ze.yaml
+++ b/boards/st/nucleo_f446ze/nucleo_f446ze.yaml
@@ -17,7 +17,6 @@ supported:
   - i2c
   - can
   - backup_sram
-  - usb
   - quadspi
 ram: 128
 flash: 512

--- a/boards/st/nucleo_h533re/nucleo_h533re.yaml
+++ b/boards/st/nucleo_h533re/nucleo_h533re.yaml
@@ -16,6 +16,5 @@ supported:
   - rtc
   - adc
   - usb_device
-  - usb
   - backup_sram
 vendor: st

--- a/boards/st/nucleo_h563zi/nucleo_h563zi.yaml
+++ b/boards/st/nucleo_h563zi/nucleo_h563zi.yaml
@@ -23,7 +23,6 @@ supported:
   - counter
   - spi
   - usb_device
-  - usb
   - rtc
   - i2c
 vendor: st

--- a/boards/st/nucleo_l496zg/nucleo_l496zg.yaml
+++ b/boards/st/nucleo_l496zg/nucleo_l496zg.yaml
@@ -16,7 +16,6 @@ supported:
   - spi
   - pwm
   - counter
-  - usb
   - usb_device
   - usbd
   - watchdog

--- a/boards/st/stm32f4_disco/stm32f4_disco.yaml
+++ b/boards/st/stm32f4_disco/stm32f4_disco.yaml
@@ -12,5 +12,4 @@ supported:
   - can
   - pwm
   - counter
-  - usb
 vendor: st

--- a/boards/st/stm32h573i_dk/stm32h573i_dk.yaml
+++ b/boards/st/stm32h573i_dk/stm32h573i_dk.yaml
@@ -22,7 +22,6 @@ supported:
   - octospi
   - can
   - usb_device
-  - usb
   - i2c
   - rtc
   - usbd

--- a/boards/st/stm32l4r9i_disco/stm32l4r9i_disco.yaml
+++ b/boards/st/stm32l4r9i_disco/stm32l4r9i_disco.yaml
@@ -20,5 +20,4 @@ supported:
   - rtc
   - spi
   - uart
-  - usb
   - usb_device

--- a/boards/st/stm32l562e_dk/stm32l562e_dk.yaml
+++ b/boards/st/stm32l562e_dk/stm32l562e_dk.yaml
@@ -19,7 +19,6 @@ supported:
   - dma
   - usart
   - arduino_spi
-  - usb
   - usb_device
   - nvs
   - usbd

--- a/boards/st/stm32l562e_dk/stm32l562e_dk_stm32l562xx_ns.yaml
+++ b/boards/st/stm32l562e_dk/stm32l562e_dk_stm32l562xx_ns.yaml
@@ -13,7 +13,6 @@ supported:
   - dac
   - spi
   - arduino_spi
-  - usb
   - usb_device
 ram: 192
 flash: 512

--- a/boards/weact/blackpill_f401cc/blackpill_f401cc.yaml
+++ b/boards/weact/blackpill_f401cc/blackpill_f401cc.yaml
@@ -9,7 +9,6 @@ toolchain:
 supported:
   - counter
   - spi
-  - usb
   - i2c
   - uart
   - pwm

--- a/boards/weact/blackpill_f401ce/blackpill_f401ce.yaml
+++ b/boards/weact/blackpill_f401ce/blackpill_f401ce.yaml
@@ -9,7 +9,6 @@ toolchain:
 supported:
   - counter
   - spi
-  - usb
   - i2c
   - uart
   - pwm

--- a/boards/weact/blackpill_f411ce/blackpill_f411ce.yaml
+++ b/boards/weact/blackpill_f411ce/blackpill_f411ce.yaml
@@ -9,7 +9,6 @@ toolchain:
 supported:
   - counter
   - spi
-  - usb
   - i2c
   - uart
   - pwm

--- a/boards/weact/mini_stm32h743/mini_stm32h743.yaml
+++ b/boards/weact/mini_stm32h743/mini_stm32h743.yaml
@@ -14,6 +14,5 @@ supported:
   - spi
   - backup_sram
   - watchdog
-  - usb
   - qspi
 vendor: weact

--- a/boards/weact/stm32f405_core/weact_stm32f405_core.yaml
+++ b/boards/weact/stm32f405_core/weact_stm32f405_core.yaml
@@ -13,7 +13,6 @@ supported:
   - spi
   - i2c
   - uart
-  - usb
   - can
   - gpio
   - watchdog


### PR DESCRIPTION
These test features are not required and are not used in any USB samples or tests.

Follow-up on commit 0809b75b42e6 ("boards: remove test feature usb_cdc")

It would be very nice if the board support submitter would stop thinking that these entries are necessary if the board has a certain feature, and blindly copy/paste them, e.g. https://github.com/zephyrproject-rtos/zephyr/pull/78187/commits/c62b8fcf04775fff141f99d6369f812ae37cdfdf#diff-3d63c757beb6fd3200aaddb17cac48404d0610d43ae9991367a2df49cbe34a42 (https://github.com/zephyrproject-rtos/zephyr/pull/78187)