### PR TITLE
tests: latency_measure: fix stacks for the busy threads

### DIFF
--- a/tests/benchmarks/latency_measure/boards/qemu_riscv64_qemu_virt_riscv64_smp.conf
+++ b/tests/benchmarks/latency_measure/boards/qemu_riscv64_qemu_virt_riscv64_smp.conf
@@ -1,0 +1,4 @@
+CONFIG_MP_MAX_NUM_CPUS=8
+
+# To support the amount of thread objects in userspace
+CONFIG_MAX_THREAD_BYTES=3

--- a/tests/benchmarks/latency_measure/src/main.c
+++ b/tests/benchmarks/latency_measure/src/main.c
@@ -36,7 +36,7 @@ struct k_thread  busy_thread[CONFIG_MP_MAX_NUM_CPUS - 1];
 
 #define BUSY_THREAD_STACK_SIZE  (1024 + CONFIG_TEST_EXTRA_STACK_SIZE)
 
-K_THREAD_STACK_DEFINE(busy_thread_stack, BUSY_THREAD_STACK_SIZE);
+K_THREAD_STACK_ARRAY_DEFINE(busy_thread_stack, CONFIG_MP_MAX_NUM_CPUS - 1, BUSY_THREAD_STACK_SIZE);
 #endif
 
 struct k_thread  start_thread;
@@ -88,7 +88,7 @@ static void test_thread(void *arg1, void *arg2, void *arg3)
 	/* Spawn busy threads that will execute on the other cores */
 
 	for (uint32_t i = 0; i < CONFIG_MP_MAX_NUM_CPUS - 1; i++) {
-		k_thread_create(&busy_thread[i], &busy_thread_stack[i],
+		k_thread_create(&busy_thread[i], busy_thread_stack[i],
 				BUSY_THREAD_STACK_SIZE, busy_thread_entry,
 				NULL, NULL, NULL,
 				K_HIGHEST_THREAD_PRIO, 0, K_NO_WAIT);

--- a/tests/benchmarks/latency_measure/testcase.yaml
+++ b/tests/benchmarks/latency_measure/testcase.yaml
@@ -13,6 +13,7 @@ tests:
     integration_platforms:
       - qemu_x86
       - qemu_arc/qemu_arc_em
+      - qemu_riscv64/qemu_virt_riscv64/smp
     harness_config:
       type: one_line
       record:


### PR DESCRIPTION
The current `K_THREAD_STACK_DEFINE` only create a single stack shared by all the busy threads. This is causing the application to crash when there are more than 2 cores in the system.

We should use `K_THREAD_STACK_ARRAY_DEFINE` to create an array of stacks instead.

Tested with:
```
west build -b qemu_riscv64_smp -p auto -t run zephyr/tests/benchmarks/latency_measure -- -DCONFIG_MP_MAX_NUM_CPUS=8 -DCONFIG_SYMTAB=y
```