### PR TITLE
tests: drivers: build_all: adc: Add spi-devices build test

### DIFF
--- a/drivers/adc/Kconfig.ads1112
+++ b/drivers/adc/Kconfig.ads1112
@@ -6,6 +6,7 @@
 config ADC_ADS1112
 	bool "Texas Instruments ADS1112 ADC driver"
 	depends on DT_HAS_TI_ADS1112_ENABLED
+	default y
 	select I2C
 	select ADC_CONFIGURABLE_INPUTS
 	help

--- a/drivers/adc/adc_ads1112.c
+++ b/drivers/adc/adc_ads1112.c
@@ -176,7 +176,6 @@ static int ads1112_read_sample(const struct device *dev, uint16_t *buff)
 {
 	int res;
 	uint8_t sample[2] = {0};
-	const struct ads1112_config *config = dev->config;
 
 	res = ads1112_read_reg(dev, ADS1112_REG_OUTPUT, sample);
 	buff[0] = sys_get_be16(sample);
@@ -263,8 +262,6 @@ static int ads1112_validate_buffer_size(const struct adc_sequence *sequence)
 
 static int ads1112_validate_sequence(const struct device *dev, const struct adc_sequence *sequence)
 {
-	const struct ads1112_data *data = dev->data;
-
 	if (sequence->channels != BIT(0)) {
 		LOG_ERR("Invalid Channel 0x%x", sequence->channels);
 		return -EINVAL;
@@ -360,7 +357,6 @@ static int ads1112_read(const struct device *dev, const struct adc_sequence *seq
 static int ads1112_init(const struct device *dev)
 {
 	int rc = 0;
-	uint8_t status;
 	const struct ads1112_config *config = dev->config;
 	struct ads1112_data *data = dev->data;
 

--- a/tests/drivers/build_all/adc/boards/native_sim.overlay
+++ b/tests/drivers/build_all/adc/boards/native_sim.overlay
@@ -111,6 +111,12 @@
 					#io-channel-cells = <1>;
 				};
 			};
+
+			test_i2c_tla2021: tla2021@a {
+				compatible = "ti,tla2021";
+				reg = <0xa>;
+				#io-channel-cells = <1>;
+			};
 		};
 
 		test_spi: spi@33334444 {


### PR DESCRIPTION
Add build tests for following devices.

- ti,tla2021


- - -
And ADS1112 was not enabled correctly, so I fixed it.