### PR TITLE
kernel: remove `CONFIG_MP_NUM_CPUS`

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -818,7 +818,7 @@ config CPU_CACHE_INCOHERENT
 	help
 	  This hidden configuration should be selected when the CPU has
 	  incoherent cache. This applies to intra-CPU multiprocessing
-	  incoherence and makes only sense when MP_NUM_CPUS > 1.
+	  incoherence and makes only sense when MP_MAX_NUM_CPUS > 1.
 
 config CPU_HAS_ICACHE
 	bool
@@ -1024,7 +1024,7 @@ config CACHE_DOUBLEMAP
 	  point to the same cached/uncached memory at different locations.
 
 	  This applies to intra-CPU multiprocessing incoherence and makes only
-	  sense when MP_NUM_CPUS > 1.
+	  sense when MP_MAX_NUM_CPUS > 1.
 
 config CACHE_MANAGEMENT
 	bool "Cache management features"

--- a/arch/x86/core/intel64/irq_offload.c
+++ b/arch/x86/core/intel64/irq_offload.c
@@ -18,8 +18,8 @@
 extern void (*x86_irq_funcs[NR_IRQ_VECTORS])(const void *arg);
 extern const void *x86_irq_args[NR_IRQ_VECTORS];
 
-static void (*irq_offload_funcs[CONFIG_MP_NUM_CPUS])(const void *arg);
-static const void *irq_offload_args[CONFIG_MP_NUM_CPUS];
+static void (*irq_offload_funcs[CONFIG_MP_MAX_NUM_CPUS])(const void *arg);
+static const void *irq_offload_args[CONFIG_MP_MAX_NUM_CPUS];
 
 static void dispatcher(const void *arg)
 {

--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -21,6 +21,9 @@ Build System
 Kernel
 ******
 
+* Removed the deprecated :kconfig:option:`CONFIG_MP_NUM_CPUS`, application should be updated to use
+  :kconfig:option:`CONFIG_MP_MAX_NUM_CPUS` instead.
+
 Boards
 ******
 

--- a/kernel/Kconfig.smp
+++ b/kernel/Kconfig.smp
@@ -38,13 +38,6 @@ config SMP_BOOT_DELAY
 	  (architecture/SoC/board/application) to boot secondary CPUs at
 	  a later time.
 
-config MP_NUM_CPUS
-	int "Number of CPUs/cores [DEPRECATED]"
-	default MP_MAX_NUM_CPUS
-	range 1 12
-	help
-	  This is deprecated, please use MP_MAX_NUM_CPUS instead.
-
 config MP_MAX_NUM_CPUS
 	int "Maximum number of CPUs/cores"
 	default 1

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -41,9 +41,6 @@
 #include <zephyr/internal/syscall_handler.h>
 LOG_MODULE_REGISTER(os, CONFIG_KERNEL_LOG_LEVEL);
 
-BUILD_ASSERT(CONFIG_MP_NUM_CPUS == CONFIG_MP_MAX_NUM_CPUS,
-	     "CONFIG_MP_NUM_CPUS and CONFIG_MP_MAX_NUM_CPUS need to be set the same");
-
 /* the only struct z_kernel instance */
 __pinned_bss
 struct z_kernel _kernel;


### PR DESCRIPTION
`CONFIG_MP_NUM_CPUS` has been deprecated for more than 2 releases (since v3.5), it's time to remove it.

Updated all usage of `CONFIG_MP_NUM_CPUS` to `CONFIG_MP_MAX_NUM_CPUS`