### PR TITLE
MAINTAINERS: Add BT role specific conf files to right groups

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -416,6 +416,8 @@ Bluetooth Host:
     - tests/bluetooth/controller/
     - tests/bluetooth/mesh*/
     - tests/bluetooth/qualification/
+    - tests/bluetooth/shell/audio.conf
+    - tests/bluetooth/shell/mesh.conf
     - tests/bluetooth/tester/
     - tests/bsim/bluetooth/audio/
     - tests/bsim/bluetooth/audio_samples/
@@ -446,6 +448,7 @@ Bluetooth Mesh:
     - samples/bluetooth/mesh*/
     - subsys/bluetooth/mesh/
     - tests/bluetooth/mesh*/
+    - tests/bluetooth/shell/mesh.conf
     - tests/bsim/bluetooth/mesh/
   labels:
     - "area: Bluetooth Mesh"


### PR DESCRIPTION
The mesh.conf belongs to the Mesh group and the audio.conf belongs to the Audio group.