### PR TITLE
samples: bluetooth: remove outdated platform_exclude

### DIFF
--- a/samples/bluetooth/hci_usb/sample.yaml
+++ b/samples/bluetooth/hci_usb/sample.yaml
@@ -9,8 +9,6 @@ tests:
     tags:
       - usb
       - bluetooth
-    # FIXME: exclude due to build error
-    platform_exclude: 96b_carbon stm32l562e_dk
   sample.bluetooth.hci_usb.device_next:
     harness: bluetooth
     depends_on:


### PR DESCRIPTION
Remove some outdated platform_exclude entries.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
