### PR TITLE
samples: Bluetooth: hci_uart/hci_ipc: CI coverage for nRF53+nRF21 FEM

### DIFF
--- a/samples/bluetooth/hci_ipc/boards/nrf5340_audio_dk_nrf5340_cpunet_nrf21540_ek.overlay
+++ b/samples/bluetooth/hci_ipc/boards/nrf5340_audio_dk_nrf5340_cpunet_nrf21540_ek.overlay
@@ -1,0 +1,28 @@
+/ {
+	nrf_radio_fem: nrf21540_fem {
+		compatible        = "nordic,nrf21540-fem";
+		tx-en-gpios       = <&arduino_header 11 GPIO_ACTIVE_HIGH>; /* D5 */
+		rx-en-gpios       = <&arduino_header 9  GPIO_ACTIVE_HIGH>; /* D3 */
+		pdn-gpios         = <&arduino_header 15 GPIO_ACTIVE_HIGH>; /* D9 */
+		ant-sel-gpios     = <&arduino_header 10 GPIO_ACTIVE_HIGH>; /* D4 */
+		mode-gpios        = <&arduino_header 8  GPIO_ACTIVE_HIGH>; /* D2 */
+		spi-if            = <&nrf_radio_fem_spi>;
+		supply-voltage-mv = <3000>;
+	};
+};
+
+&spi0 {
+	/* status   = "okay"; */
+	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
+
+	nrf_radio_fem_spi: nrf21540_fem_spi@0 {
+		compatible        = "nordic,nrf21540-fem-spi";
+		/* status            = "okay"; */
+		reg               = <0>;
+		spi-max-frequency = <8000000>;
+	};
+};
+
+&radio {
+	fem = <&nrf_radio_fem>;
+};

--- a/samples/bluetooth/hci_ipc/boards/nrf5340_audio_dk_nrf5340_cpunet_nrf21540_ek.overlay
+++ b/samples/bluetooth/hci_ipc/boards/nrf5340_audio_dk_nrf5340_cpunet_nrf21540_ek.overlay
@@ -6,20 +6,7 @@
 		pdn-gpios         = <&arduino_header 15 GPIO_ACTIVE_HIGH>; /* D9 */
 		ant-sel-gpios     = <&arduino_header 10 GPIO_ACTIVE_HIGH>; /* D4 */
 		mode-gpios        = <&arduino_header 8  GPIO_ACTIVE_HIGH>; /* D2 */
-		spi-if            = <&nrf_radio_fem_spi>;
 		supply-voltage-mv = <3000>;
-	};
-};
-
-&spi0 {
-	/* status   = "okay"; */
-	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
-
-	nrf_radio_fem_spi: nrf21540_fem_spi@0 {
-		compatible        = "nordic,nrf21540-fem-spi";
-		/* status            = "okay"; */
-		reg               = <0>;
-		spi-max-frequency = <8000000>;
 	};
 };
 

--- a/samples/bluetooth/hci_ipc/sample.yaml
+++ b/samples/bluetooth/hci_ipc/sample.yaml
@@ -82,6 +82,16 @@ tests:
       - nrf5340bsim/nrf5340/cpunet
     integration_platforms:
       - nrf5340dk/nrf5340/cpunet
+  sample.bluetooth.hci_ipc.iso.fem.bt_ll_sw_split:
+    harness: bluetooth
+    tags: bluetooth
+    extra_args:
+      - CONF_FILE="nrf5340_cpunet_iso-bt_ll_sw_split.conf"
+      - DTC_OVERLAY_FILE="./boards/nrf5340_audio_dk_nrf5340_cpunet_nrf21540_ek.overlay"
+    platform_allow:
+      - nrf5340_audio_dk/nrf5340/cpunet
+    integration_platforms:
+      - nrf5340_audio_dk/nrf5340/cpunet
   sample.bluetooth.hci_ipc.df.bt_ll_sw_split:
     harness: bluetooth
     tags: bluetooth

--- a/samples/bluetooth/hci_ipc/sample.yaml
+++ b/samples/bluetooth/hci_ipc/sample.yaml
@@ -22,7 +22,6 @@ tests:
       - nrf5340bsim/nrf5340/cpunet
     integration_platforms:
       - nrf5340dk/nrf5340/cpunet
-      - nrf5340_audio_dk/nrf5340/cpunet
   sample.bluetooth.hci_ipc.iso_receive.bt_ll_sw_split:
     harness: bluetooth
     tags: bluetooth
@@ -79,6 +78,7 @@ tests:
     extra_args: CONF_FILE="nrf5340_cpunet_iso-bt_ll_sw_split.conf"
     platform_allow:
       - nrf5340dk/nrf5340/cpunet
+      - nrf5340_audio_dk/nrf5340/cpunet
       - nrf5340bsim/nrf5340/cpunet
     integration_platforms:
       - nrf5340dk/nrf5340/cpunet

--- a/samples/bluetooth/hci_uart/boards/nrf5340_audio_dk_nrf5340_cpuapp_nrf21540_ek.overlay
+++ b/samples/bluetooth/hci_uart/boards/nrf5340_audio_dk_nrf5340_cpuapp_nrf21540_ek.overlay
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/ {
+	gpio_fwd: nrf-gpio-forwarder {
+		compatible = "nordic,nrf-gpio-forwarder";
+		status = "okay";
+
+		nrf21540-gpio-if {
+			gpios = <&arduino_header 11 0>, /* tx-en-gpios */
+				<&arduino_header 9  0>, /* rx-en-gpios */
+				<&arduino_header 15 0>,	/* pdn-gpios */
+				<&arduino_header 10 0>, /* ant-sel-gpios */
+				<&arduino_header 8  0>; /* mode-gpios */
+		};
+
+		nrf21540-spi-if {
+			gpios = <&arduino_header 16 0>, /* cs-gpios */
+				<&gpio0          8  0>, /* SPIM_SCK */
+				<&gpio0          10 0>, /* SPIM_MISO */
+				<&gpio0          9  0>; /* SPIM_MOSI */
+		};
+	};
+};
+
+&uart0 {
+	compatible = "nordic,nrf-uarte";
+	current-speed = <1000000>;
+	status = "okay";
+	hw-flow-control;
+};

--- a/samples/bluetooth/hci_uart/sample.yaml
+++ b/samples/bluetooth/hci_uart/sample.yaml
@@ -9,6 +9,7 @@ tests:
       - nrf52840dk/nrf52840
       - nrf21540dk/nrf52840
     integration_platforms:
+      - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
       - nrf21540dk/nrf52840
     tags:

--- a/samples/bluetooth/hci_uart/sample.yaml
+++ b/samples/bluetooth/hci_uart/sample.yaml
@@ -47,6 +47,16 @@ tests:
     tags:
       - uart
       - bluetooth
+  sample.bluetooth.hci_uart.nrf5340_audio_dk_cpuapp.fem:
+    harness: bluetooth
+    platform_allow:
+      - nrf5340_audio_dk/nrf5340/cpuapp
+    integration_platforms:
+      - nrf5340_audio_dk/nrf5340/cpuapp
+    extra_args: DTC_OVERLAY_FILE=./boards/nrf5340_audio_dk_nrf5340_cpuapp_nrf21540_ek.overlay
+    tags:
+      - uart
+      - bluetooth
   sample.bluetooth.hci_uart.nrf52833.all:
     harness: bluetooth
     platform_allow: nrf52833dk/nrf52833

--- a/samples/bluetooth/hci_uart/sample.yaml
+++ b/samples/bluetooth/hci_uart/sample.yaml
@@ -6,6 +6,9 @@ tests:
     harness: bluetooth
     platform_allow:
       - nrf52dk/nrf52832
+      - nrf21540dk/nrf52840
+    integration_platforms:
+      - nrf21540dk/nrf52840
     tags:
       - uart
       - bluetooth

--- a/samples/bluetooth/hci_uart/sample.yaml
+++ b/samples/bluetooth/hci_uart/sample.yaml
@@ -18,6 +18,8 @@ tests:
   sample.bluetooth.hci_uart.nrf52833.df:
     harness: bluetooth
     platform_allow: nrf52833dk/nrf52833
+    integration_platforms:
+      - nrf52833dk/nrf52833
     extra_args: DTC_OVERLAY_FILE=./boards/nrf52833dk_nrf52833_df.overlay
     extra_configs:
       - CONFIG_BT_CTLR_DF=y
@@ -36,6 +38,8 @@ tests:
   sample.bluetooth.hci_uart.nrf52833.df.iq_report:
     harness: bluetooth
     platform_allow: nrf52833dk/nrf52833
+    integration_platforms:
+      - nrf52833dk/nrf52833
     extra_args: DTC_OVERLAY_FILE=./boards/nrf52833dk_nrf52833_df.overlay
     extra_configs:
       - CONFIG_BT_CTLR_DF=y

--- a/samples/bluetooth/hci_uart/sample.yaml
+++ b/samples/bluetooth/hci_uart/sample.yaml
@@ -47,6 +47,15 @@ tests:
     tags:
       - uart
       - bluetooth
+  sample.bluetooth.hci_uart.nrf5340dk_cpuapp:
+    harness: bluetooth
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp
+    integration_platforms:
+      - nrf5340dk/nrf5340/cpuapp
+    tags:
+      - uart
+      - bluetooth
   sample.bluetooth.hci_uart.nrf5340_audio_dk_cpuapp.fem:
     harness: bluetooth
     platform_allow:

--- a/samples/bluetooth/hci_uart/sample.yaml
+++ b/samples/bluetooth/hci_uart/sample.yaml
@@ -6,8 +6,10 @@ tests:
     harness: bluetooth
     platform_allow:
       - nrf52dk/nrf52832
+      - nrf52840dk/nrf52840
       - nrf21540dk/nrf52840
     integration_platforms:
+      - nrf52840dk/nrf52840
       - nrf21540dk/nrf52840
     tags:
       - uart

--- a/soc/nordic/nrf53/Kconfig
+++ b/soc/nordic/nrf53/Kconfig
@@ -163,10 +163,11 @@ config NRF_SPU_RAM_REGION_SIZE
 	  RAM region size for the NRF_SPU peripheral
 
 config SOC_NRF_GPIO_FORWARDER_FOR_NRF5340
-	bool
+	bool "Forward GPIO pins to network core"
 	depends on NRF_SOC_SECURE_SUPPORTED
+	default y if $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_GPIO_FORWARDER))
 	help
-	  hidden option for including the nRF GPIO pin forwarding
+	  Will forward configured pins with the forwarder compatible to the network core for usage.
 
 config SOC_NRF53_CPUNET_MGMT
 	bool

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -79,9 +79,6 @@ BUILD_ASSERT(NRF_DT_GPIOTE_INST(FEM_NODE, HAL_RADIO_GPIO_PA_PROP) ==
 static const nrfx_gpiote_t gpiote_pdn = NRFX_GPIOTE_INSTANCE(
 	NRF_DT_GPIOTE_INST(FEM_NODE, pdn_gpios));
 static uint8_t gpiote_ch_pdn;
-static const nrfx_gpiote_t gpiote_csn = NRFX_GPIOTE_INSTANCE(
-	NRF_DT_GPIOTE_INST(DT_BUS(FEM_SPI_DEV_NODE), cs_gpios));
-static uint8_t gpiote_ch_csn;
 #endif
 
 /* These headers require the above gpiote-related variables to be declared. */
@@ -133,20 +130,6 @@ BUILD_ASSERT(!BAD_FLAGS(NRF_GPIO_LNA_FLAGS),
 #define NRF_GPIO_PDN_OFFSET DT_PROP(FEM_NODE, pdn_settle_time_us)
 NRF_DT_CHECK_GPIO_CTLR_IS_SOC(FEM_NODE, pdn_gpios, "pdn-gpios");
 #endif	/* DT_NODE_HAS_PROP(FEM_NODE, pdn_gpios) */
-
-/* CSN is special because it comes from the spi-if property. */
-#if defined(HAL_RADIO_FEM_NRF21540_HAS_CSN)
-#define NRF_GPIO_CSN_CTLR  DT_SPI_DEV_CS_GPIOS_CTLR(FEM_SPI_DEV_NODE)
-#define NRF_GPIO_CSN       ((NRF_GPIO_Type *)DT_REG_ADDR(NRF_GPIO_CSN_CTLR))
-#define NRF_GPIO_CSN_PIN   DT_SPI_DEV_CS_GPIOS_PIN(FEM_SPI_DEV_NODE)
-#define NRF_GPIO_CSN_FLAGS DT_SPI_DEV_CS_GPIOS_FLAGS(FEM_SPI_DEV_NODE)
-#define NRF_GPIO_CSN_PSEL  (NRF_GPIO_CSN_PIN + \
-			    (DT_PROP(NRF_GPIO_CSN_CTLR, port) << 5))
-BUILD_ASSERT(DT_NODE_HAS_COMPAT(NRF_GPIO_CSN_CTLR, nordic_nrf_gpio),
-	     "fem node " DT_NODE_PATH(FEM_NODE) " has a spi-if property, "
-	     " but the chip select pin is not on the SoC. Check cs-gpios in "
-	     DT_NODE_PATH(DT_BUS(FEM_SPI_DEV_NODE)));
-#endif	/* HAL_RADIO_FEM_NRF21540_HAS_CSN */
 
 #endif	/* HAL_RADIO_FEM_IS_NRF21540 */
 
@@ -207,15 +190,6 @@ void radio_setup(void)
 		NRF_GPIO_PDN->OUTCLR = BIT(NRF_GPIO_PDN_PIN);
 	}
 #endif /* NRF_GPIO_PDN_PIN */
-
-#if defined(NRF_GPIO_CSN_PIN)
-	NRF_GPIO_CSN->DIRSET = BIT(NRF_GPIO_CSN_PIN);
-	if (ACTIVE_LOW(NRF_GPIO_CSN_FLAGS)) {
-		NRF_GPIO_CSN->OUTSET = BIT(NRF_GPIO_CSN_PIN);
-	} else {
-		NRF_GPIO_CSN->OUTCLR = BIT(NRF_GPIO_CSN_PIN);
-	}
-#endif /* NRF_GPIO_CSN_PIN */
 
 	hal_radio_ram_prio_setup();
 }
@@ -1841,12 +1815,6 @@ int radio_gpio_pa_lna_init(void)
 	}
 #endif
 
-#if defined(NRF_GPIO_CSN_PIN)
-	if (nrfx_gpiote_channel_alloc(&gpiote_csn, &gpiote_ch_csn) != NRFX_SUCCESS) {
-		return -ENOMEM;
-	}
-#endif
-
 	return 0;
 }
 
@@ -1858,10 +1826,6 @@ void radio_gpio_pa_lna_deinit(void)
 
 #if defined(NRF_GPIO_PDN_PIN)
 	(void)nrfx_gpiote_channel_free(&gpiote_pdn, gpiote_ch_pdn);
-#endif
-
-#if defined(NRF_GPIO_CSN_PIN)
-	(void)nrfx_gpiote_channel_free(&gpiote_csn, gpiote_ch_csn);
 #endif
 }
 
@@ -1881,7 +1845,6 @@ void radio_gpio_pa_setup(void)
 #if defined(HAL_RADIO_FEM_IS_NRF21540)
 	hal_pa_ppi_setup();
 	radio_gpio_pdn_setup();
-	radio_gpio_csn_setup();
 #endif
 }
 #endif /* HAL_RADIO_GPIO_HAVE_PA_PIN */
@@ -1902,7 +1865,6 @@ void radio_gpio_lna_setup(void)
 #if defined(HAL_RADIO_FEM_IS_NRF21540)
 	hal_lna_ppi_setup();
 	radio_gpio_pdn_setup();
-	radio_gpio_csn_setup();
 #endif
 }
 
@@ -1920,22 +1882,6 @@ void radio_gpio_pdn_setup(void)
 		(OUTINIT_INACTIVE(NRF_GPIO_PDN_FLAGS) <<
 		 GPIOTE_CONFIG_OUTINIT_Pos);
 #endif /* NRF_GPIO_PDN_PIN */
-}
-
-void radio_gpio_csn_setup(void)
-{
-	/* Note: the spi-if property is optional. */
-#if defined(NRF_GPIO_CSN_PIN)
-	gpiote_csn.p_reg->CONFIG[gpiote_ch_csn] =
-		(GPIOTE_CONFIG_MODE_Task <<
-		 GPIOTE_CONFIG_MODE_Pos) |
-		(NRF_GPIO_CSN_PSEL <<
-		 GPIOTE_CONFIG_PSEL_Pos) |
-		(GPIOTE_CONFIG_POLARITY_Toggle <<
-		 GPIOTE_CONFIG_POLARITY_Pos) |
-		(OUTINIT_INACTIVE(NRF_GPIO_CSN_FLAGS) <<
-		 GPIOTE_CONFIG_OUTINIT_Pos);
-#endif /* NRF_GPIO_CSN_PIN */
 }
 
 void radio_gpio_lna_on(void)
@@ -1981,7 +1927,6 @@ void radio_gpio_pa_lna_disable(void)
 					   BIT(HAL_DISABLE_FEM_PPI));
 	gpiote_palna.p_reg->CONFIG[gpiote_ch_palna] = 0;
 	gpiote_pdn.p_reg->CONFIG[gpiote_ch_pdn] = 0;
-	gpiote_csn.p_reg->CONFIG[gpiote_ch_csn] = 0;
 #else
 	hal_radio_nrf_ppi_channels_disable(BIT(HAL_ENABLE_PALNA_PPI) |
 					   BIT(HAL_DISABLE_PALNA_PPI));

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.h
@@ -163,7 +163,6 @@ void radio_gpio_pa_lna_deinit(void);
 void radio_gpio_pa_setup(void);
 void radio_gpio_lna_setup(void);
 void radio_gpio_pdn_setup(void);
-void radio_gpio_csn_setup(void);
 void radio_gpio_lna_on(void);
 void radio_gpio_lna_off(void);
 void radio_gpio_pa_lna_enable(uint32_t trx_us);

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi_gpiote.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi_gpiote.h
@@ -66,10 +66,6 @@ static inline void hal_fem_ppi_setup(void)
 	hal_gpiote_tasks_setup(gpiote_pdn.p_reg, gpiote_ch_pdn,
 			       IS_ENABLED(HAL_RADIO_GPIO_NRF21540_PDN_POL_INV),
 			       HAL_ENABLE_FEM_PPI, HAL_DISABLE_FEM_PPI);
-
-	hal_gpiote_tasks_setup(gpiote_csn.p_reg, gpiote_ch_csn,
-			       IS_ENABLED(HAL_RADIO_GPIO_NRF21540_CSN_POL_INV),
-			       HAL_ENABLE_FEM_PPI, HAL_DISABLE_FEM_PPI);
 }
 
 #endif /* HAL_RADIO_FEM_IS_NRF21540 */

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_fem_nrf21540.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_fem_nrf21540.h
@@ -59,19 +59,3 @@
 #define HAL_RADIO_GPIO_NRF21540_PDN_POL_INV 1
 #endif	/* DT_GPIO_FLAGS(FEM_NODE, pdn_gpios) & GPIO_ACTIVE_LOW */
 #endif	/* FEM_HAS_PROP(pdn_gpios) */
-
-#if FEM_HAS_PROP(spi_if)
-/* This is the "SPI device" node, i.e. the one with compatible
- * nordic,nrf21540-fem-spi.
- */
-#define FEM_SPI_DEV_NODE DT_PHANDLE(FEM_NODE, spi_if)
-/* If the SPI device node has a chip select gpio... */
-#if DT_SPI_DEV_HAS_CS_GPIOS(FEM_SPI_DEV_NODE)
-/* set a macro indicating that, and... */
-#define HAL_RADIO_FEM_NRF21540_HAS_CSN 1
-/* use it to get the CSN polarity. */
-#if DT_SPI_DEV_CS_GPIOS_FLAGS(FEM_SPI_DEV_NODE) & GPIO_ACTIVE_LOW
-#define HAL_RADIO_GPIO_NRF21540_CSN_POL_INV 1
-#endif	/* DT_SPI_DEV_CS_GPIOS_FLAGS(FEM_SPI_DEV_NODE) & GPIO_ACTIVE_LOW */
-#endif	/* DT_SPI_DEV_HAS_CS_GPIOS(FEM_SPI_DEV_NODE) */
-#endif	/* FEM_HAS_PROP(spi_if) */

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi_gpiote.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi_gpiote.h
@@ -36,18 +36,16 @@ static inline void hal_lna_ppi_setup(void)
 
 static inline void hal_fem_ppi_setup(void)
 {
-	nrf_ppi_channel_and_fork_endpoint_setup(
+	nrf_ppi_channel_endpoint_setup(
 		NRF_PPI,
 		HAL_ENABLE_FEM_PPI,
 		(uint32_t)&(EVENT_TIMER->EVENTS_COMPARE[3]),
-		(uint32_t)&(gpiote_pdn.p_reg->TASKS_OUT[gpiote_ch_pdn]),
-		(uint32_t)&(gpiote_csn.p_reg->TASKS_OUT[gpiote_ch_csn]));
-	nrf_ppi_channel_and_fork_endpoint_setup(
+		(uint32_t)&(gpiote_pdn.p_reg->TASKS_OUT[gpiote_ch_pdn]));
+	nrf_ppi_channel_endpoint_setup(
 		NRF_PPI,
 		HAL_DISABLE_FEM_PPI,
 		(uint32_t)&(NRF_RADIO->EVENTS_DISABLED),
-		(uint32_t)&(gpiote_pdn.p_reg->TASKS_OUT[gpiote_ch_pdn]),
-		(uint32_t)&(gpiote_csn.p_reg->TASKS_OUT[gpiote_ch_csn]));
+		(uint32_t)&(gpiote_pdn.p_reg->TASKS_OUT[gpiote_ch_pdn]));
 }
 
 #endif /* HAL_RADIO_FEM_IS_NRF21540 */


### PR DESCRIPTION
Add CI coverage for nRF5340 plus nRF21540 FEM usage in hci_uart plus hci_ipc samples.

These builds will help catch future regressions, like this support issue where a downstream release had build errors: https://devzone.nordicsemi.com/f/nordic-q-a/114551/building-zypher-ble-controller-fails-on-sdk-2-6-1

List of covered boards by this PR:
![image](https://github.com/user-attachments/assets/2fdb29c2-2f82-49f5-9b49-250e55fc9d4f)
