### PR TITLE
Miscellaneous HD44780 auxdisplay driver enhancements

### DIFF
--- a/drivers/auxdisplay/auxdisplay_hd44780.c
+++ b/drivers/auxdisplay/auxdisplay_hd44780.c
@@ -77,41 +77,33 @@ struct auxdisplay_hd44780_config {
 static void auxdisplay_hd44780_set_entry_mode(const struct device *dev);
 static void auxdisplay_hd44780_set_display_mode(const struct device *dev, bool enabled);
 
-static void auxdisplay_hd44780_command(const struct device *dev, bool rs, uint8_t cmd,
-				       uint8_t mode)
+static void hd44780_pulse_enable_line(const struct device *dev)
 {
-	const struct auxdisplay_hd44780_config *config = dev->config;
-	int8_t i = 7;
-
-	if (mode == AUXDISPLAY_HD44780_MODE_8_BIT) {
-		while (i >= 0) {
-			gpio_pin_set_dt(&config->db_gpios[i], ((cmd & BIT(i)) ? 1 : 0));
-			--i;
-		}
-	} else {
-		while (i >= 4) {
-			gpio_pin_set_dt(&config->db_gpios[i], ((cmd & BIT(i)) ? 1 : 0));
-			--i;
-		}
-	}
-
-	gpio_pin_set_dt(&config->rs_gpio, rs);
+	const struct auxdisplay_hd44780_config *const config = dev->config;
 
 	gpio_pin_set_dt(&config->e_gpio, 1);
 	k_sleep(K_USEC(config->enable_line_rise_delay));
 	gpio_pin_set_dt(&config->e_gpio, 0);
 	k_sleep(K_USEC(config->enable_line_fall_delay));
+}
 
-	if (mode == AUXDISPLAY_HD44780_MODE_4_BIT) {
-		while (i >= 0) {
-			gpio_pin_set_dt(&config->db_gpios[(i + 4)], ((cmd & BIT(i)) ? 1 : 0));
+static void auxdisplay_hd44780_command(const struct device *dev, bool rs, uint8_t cmd,
+				       uint8_t mode)
+{
+	const struct auxdisplay_hd44780_config *config = dev->config;
+	int8_t i = 7;
+	const int8_t lsb_line = (mode == AUXDISPLAY_HD44780_MODE_8_BIT) ? 0 : 4;
+	int8_t ncommands = (mode == AUXDISPLAY_HD44780_MODE_4_BIT) ? 2 : 1;
+
+	gpio_pin_set_dt(&config->rs_gpio, rs);
+
+	while (ncommands--) {
+		for (int8_t line = 7; line >= lsb_line; --line) {
+			gpio_pin_set_dt(&config->db_gpios[line], ((cmd & BIT(i)) ? 1 : 0));
 			--i;
 		}
 
-		gpio_pin_set_dt(&config->e_gpio, 1);
-		k_sleep(K_USEC(config->enable_line_rise_delay));
-		gpio_pin_set_dt(&config->e_gpio, 0);
-		k_sleep(K_USEC(config->enable_line_fall_delay));
+		hd44780_pulse_enable_line(dev);
 	}
 }
 

--- a/drivers/auxdisplay/auxdisplay_hd44780.c
+++ b/drivers/auxdisplay/auxdisplay_hd44780.c
@@ -82,9 +82,9 @@ static void hd44780_pulse_enable_line(const struct device *dev)
 	const struct auxdisplay_hd44780_config *const config = dev->config;
 
 	gpio_pin_set_dt(&config->e_gpio, 1);
-	k_sleep(K_USEC(config->enable_line_rise_delay));
+	k_sleep(K_NSEC(config->enable_line_rise_delay));
 	gpio_pin_set_dt(&config->e_gpio, 0);
-	k_sleep(K_USEC(config->enable_line_fall_delay));
+	k_sleep(K_NSEC(config->enable_line_fall_delay));
 }
 
 static void auxdisplay_hd44780_command(const struct device *dev, bool rs, uint8_t cmd,
@@ -567,8 +567,8 @@ static const struct auxdisplay_driver_api auxdisplay_hd44780_auxdisplay_api = {
 		.line_addresses[2] = DT_INST_PROP_BY_IDX(inst, line_addresses, 2),		\
 		.line_addresses[3] = DT_INST_PROP_BY_IDX(inst, line_addresses, 3),		\
 		.backlight_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, backlight_gpios, {0}),		\
-		.enable_line_rise_delay = DT_INST_PROP(inst, enable_line_rise_delay_us),	\
-		.enable_line_fall_delay = DT_INST_PROP(inst, enable_line_fall_delay_us),	\
+		.enable_line_rise_delay = DT_INST_PROP(inst, enable_line_rise_delay_ns),	\
+		.enable_line_fall_delay = DT_INST_PROP(inst, enable_line_fall_delay_ns),	\
 		.clear_delay = DT_INST_PROP(inst, clear_command_delay_us),			\
 		.boot_delay = DT_INST_PROP(inst, boot_delay_ms),				\
 	};											\

--- a/drivers/auxdisplay/auxdisplay_hd44780.c
+++ b/drivers/auxdisplay/auxdisplay_hd44780.c
@@ -70,6 +70,7 @@ struct auxdisplay_hd44780_config {
 	uint8_t line_addresses[4];
 	uint16_t enable_line_rise_delay;
 	uint16_t enable_line_fall_delay;
+	uint16_t rs_line_delay;
 	uint16_t clear_delay;
 	uint16_t boot_delay;
 };
@@ -96,6 +97,7 @@ static void auxdisplay_hd44780_command(const struct device *dev, bool rs, uint8_
 	int8_t ncommands = (mode == AUXDISPLAY_HD44780_MODE_4_BIT) ? 2 : 1;
 
 	gpio_pin_set_dt(&config->rs_gpio, rs);
+	k_sleep(K_NSEC(config->rs_line_delay));
 
 	while (ncommands--) {
 		for (int8_t line = 7; line >= lsb_line; --line) {
@@ -569,6 +571,7 @@ static const struct auxdisplay_driver_api auxdisplay_hd44780_auxdisplay_api = {
 		.backlight_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, backlight_gpios, {0}),		\
 		.enable_line_rise_delay = DT_INST_PROP(inst, enable_line_rise_delay_ns),	\
 		.enable_line_fall_delay = DT_INST_PROP(inst, enable_line_fall_delay_ns),	\
+		.rs_line_delay = DT_INST_PROP(inst, rs_line_delay_ns),				\
 		.clear_delay = DT_INST_PROP(inst, clear_command_delay_us),			\
 		.boot_delay = DT_INST_PROP(inst, boot_delay_ms),				\
 	};											\

--- a/drivers/auxdisplay/auxdisplay_hd44780.c
+++ b/drivers/auxdisplay/auxdisplay_hd44780.c
@@ -97,10 +97,6 @@ static void auxdisplay_hd44780_command(const struct device *dev, bool rs, uint8_
 
 	gpio_pin_set_dt(&config->rs_gpio, rs);
 
-	if (config->rw_gpio.port) {
-		gpio_pin_set_dt(&config->rw_gpio, 0);
-	}
-
 	gpio_pin_set_dt(&config->e_gpio, 1);
 	k_sleep(K_USEC(config->enable_line_rise_delay));
 	gpio_pin_set_dt(&config->e_gpio, 0);
@@ -148,6 +144,8 @@ static int auxdisplay_hd44780_init(const struct device *dev)
 			LOG_ERR("Configuration of RW GPIO failed: %d", rc);
 			return rc;
 		}
+
+		gpio_pin_set_dt(&config->rw_gpio, 0);
 	}
 
 	rc = gpio_pin_configure_dt(&config->e_gpio, GPIO_OUTPUT);

--- a/dts/bindings/auxdisplay/hit,hd44780.yaml
+++ b/dts/bindings/auxdisplay/hit,hd44780.yaml
@@ -70,6 +70,13 @@ properties:
       Delay time (in ns) to wait after enable line falls before sending
       another command. Default is as per Hitachi HD44780 specification.
 
+  rs-line-delay-ns:
+    type: int
+    default: 60
+    description: |
+      Delay time (in ns) to wait after rs/rw line state has been set up before
+      sending another command. Default is as per Hitachi HD44780 specification.
+
   clear-command-delay-us:
     type: int
     default: 5000

--- a/dts/bindings/auxdisplay/hit,hd44780.yaml
+++ b/dts/bindings/auxdisplay/hit,hd44780.yaml
@@ -56,18 +56,18 @@ properties:
       Array of addresses for each row, will use defaults if not provided.
       Default is as per Hitachi HD44780 specification.
 
-  enable-line-rise-delay-us:
+  enable-line-rise-delay-ns:
     type: int
-    default: 800
+    default: 450
     description: |
-      Delay time (in us) to wait after enable line rises before setting low.
+      Delay time (in ns) to wait after enable line rises before setting low.
       Default is as per Hitachi HD44780 specification.
 
-  enable-line-fall-delay-us:
+  enable-line-fall-delay-ns:
     type: int
-    default: 100
+    default: 550
     description: |
-      Delay time (in us) to wait after enable line falls before sending
+      Delay time (in ns) to wait after enable line falls before sending
       another command. Default is as per Hitachi HD44780 specification.
 
   clear-command-delay-us:


### PR DESCRIPTION
This PR contains some hd44780 driver fixes and enhancements. Highlights:
1) riddance of excessive delays while waiting for some hd44780 command to finish (the driver now conforms to the hd44780 manual),
2) implementation of busy-flag polling mechanism (available only if RW pin is specified in DT), therefore allowing for faster completion of hd44780 commands as seen from MCU perspective.