### PR TITLE
zscilib: Add Zephyr PR for Pull Request 62

### DIFF
--- a/submanifests/optional.yaml
+++ b/submanifests/optional.yaml
@@ -60,7 +60,7 @@ manifest:
         - optional
     - name: zscilib
       path: modules/lib/zscilib
-      revision: ee1b287d9dd07208d2cc52284240ac25bb66eae3
+      revision: pull/62/head
       remote: upstream
       groups:
         - optional


### PR DESCRIPTION
This diff adds a Zephyr PR for the zscilib PR 62 fixes for quaternions and Madgwick filter

Signed-off-by: Ismail Degani <deganii@gmail.com>