### PR TITLE
Bluetooth: Mesh: Use dfd_phase_set() in dfu_suspended()

### DIFF
--- a/subsys/bluetooth/mesh/dfd_srv.c
+++ b/subsys/bluetooth/mesh/dfd_srv.c
@@ -801,7 +801,7 @@ static void dfu_suspended(struct bt_mesh_dfu_cli *cli)
 	struct bt_mesh_dfd_srv *srv =
 		CONTAINER_OF(cli, struct bt_mesh_dfd_srv, dfu);
 
-	srv->phase = BT_MESH_DFD_PHASE_TRANSFER_SUSPENDED;
+	dfd_phase_set(srv, BT_MESH_DFD_PHASE_TRANSFER_SUSPENDED);
 }
 
 static void dfu_ended(struct bt_mesh_dfu_cli *cli,


### PR DESCRIPTION
Currently, dfu_suspended() sets the phase BT_MESH_DFD_PHASE_TRANSFER_SUSPENDED directly in the structure, bypassing the dfd_phase_set() function. This prevents the phase change callback in the bt_mesh_dfd_srv_cb structure from receiving the BT_MESH_DFD_PHASE_TRANSFER_SUSPENDED event.