### PR TITLE
cpp: Fix compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,7 @@ zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:$<TARGET_PROPERTY:compiler-cpp,
 # Extra warnings options for twister run
 if (CONFIG_COMPILER_WARNINGS_AS_ERRORS)
   zephyr_compile_options($<$<COMPILE_LANGUAGE:C>:$<TARGET_PROPERTY:compiler,warnings_as_errors>>)
+  zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:$<TARGET_PROPERTY:compiler,warnings_as_errors>>)
   zephyr_compile_options($<$<COMPILE_LANGUAGE:ASM>:$<TARGET_PROPERTY:asm,warnings_as_errors>>)
   zephyr_link_libraries($<TARGET_PROPERTY:linker,warnings_as_errors>)
 endif()

--- a/include/zephyr/drivers/mspi.h
+++ b/include/zephyr/drivers/mspi.h
@@ -204,7 +204,9 @@ enum mspi_timing_param {
  * @brief Stub for struct timing_cfg
  */
 struct mspi_timing_cfg {
-
+#ifdef __cplusplus
+	uint8_t reserved;
+#endif
 };
 
 /**

--- a/tests/drivers/i2c/i2c_emul/src/emulated_target.cpp
+++ b/tests/drivers/i2c/i2c_emul/src/emulated_target.cpp
@@ -17,15 +17,15 @@ DEFINE_FFF_GLOBALS;
 			       uint8_t);                                                           \
 	DEFINE_FAKE_VALUE_FUNC(int, target_stop_##n, struct i2c_target_config *);                  \
 	DEFINE_FAKE_VALUE_FUNC(int, target_buf_read_requested_##n, struct i2c_target_config *,     \
-				uint8_t **, uint32_t *)                                            \
+			       uint8_t **, uint32_t *)                                             \
 	DEFINE_FAKE_VOID_FUNC(target_buf_write_received_##n, struct i2c_target_config *,           \
-			       uint8_t *, uint32_t)
+			      uint8_t *, uint32_t)
 
 DT_FOREACH_PROP_ELEM(CONTROLLER_LABEL, forwards, DEFINE_FAKE_TARGET_FUNCTION);
 
 /* clang-format off */
 #define DEFINE_EMULATED_CALLBACK(node_id, prop, n)                                                 \
-	[n] = {                                                                                    \
+	{                                                                                    \
 		.write_requested = target_write_requested_##n,                                     \
 		.read_requested = target_read_requested_##n,                                       \
 		.write_received = target_write_received_##n,                                       \
@@ -42,7 +42,7 @@ struct i2c_target_callbacks emulated_callbacks[FORWARD_COUNT] = {
 	DT_FOREACH_PROP_ELEM(CONTROLLER_LABEL, forwards, DEFINE_EMULATED_CALLBACK)};
 
 #define DEFINE_EMULATED_TARGET_CONFIG(node_id, prop, n)                                            \
-	[n] = {                                                                                    \
+	{                                                                                          \
 		.flags = 0,                                                                        \
 		.address = DT_PHA_BY_IDX(node_id, prop, n, addr),                                  \
 		.callbacks = &emulated_callbacks[n],                                               \

--- a/tests/drivers/i2c/i2c_emul/src/test_forwarding_pio.cpp
+++ b/tests/drivers/i2c/i2c_emul/src/test_forwarding_pio.cpp
@@ -23,7 +23,7 @@ ZTEST(i2c_emul_forwarding, test_write_is_forwarded)
 {
 	// Try writing some values
 	for (uint8_t data = 0; data < 10; ++data) {
-		const int expected_call_count = 1 + data;
+		const unsigned int expected_call_count = 1 + data;
 
 		zassert_ok(i2c_write(controller, &data, sizeof(data),
 				     emulated_target_config[0].address));

--- a/tests/lib/cbprintf_package/src/main.c
+++ b/tests/lib/cbprintf_package/src/main.c
@@ -923,7 +923,8 @@ ZTEST(cbprintf_package, test_cbprintf_package_convert_static)
 	uint32_t copy_flags = CBPRINTF_PACKAGE_CONVERT_RW_STR;
 
 	clen = cbprintf_package_convert(spackage, slen, NULL, 0, copy_flags, NULL, 0);
-	zassert_true(clen == slen + sizeof(test_str1) + 1/*null*/ - 2 /* arg+ro idx gone*/);
+	zassert_true(clen >= 0);
+	zassert_true((size_t)clen == slen + sizeof(test_str1) + 1/*null*/ - 2 /* arg+ro idx gone*/);
 
 	clen = cbprintf_package_convert(spackage, slen, convert_cb, &ctx, copy_flags, NULL, 0);
 	zassert_true(clen > 0);


### PR DESCRIPTION
Fix the compiler warnings and enable warnings_as_errors