### PR TITLE
style: subsys: adjust `return` usage in `void functions`

### DIFF
--- a/arch/xtensa/include/kernel_arch_func.h
+++ b/arch/xtensa/include/kernel_arch_func.h
@@ -32,7 +32,7 @@ void xtensa_switch(void *switch_to, void **switched_from);
 
 static ALWAYS_INLINE void arch_switch(void *switch_to, void **switched_from)
 {
-	return xtensa_switch(switch_to, switched_from);
+	xtensa_switch(switch_to, switched_from);
 }
 
 #ifdef CONFIG_KERNEL_COHERENCE

--- a/include/zephyr/arch/riscv/sys_io.h
+++ b/include/zephyr/arch/riscv/sys_io.h
@@ -41,7 +41,7 @@ static ALWAYS_INLINE uint8_t sys_read8(mem_addr_t addr)
 
 static ALWAYS_INLINE void sys_write8(uint8_t data, mem_addr_t addr)
 {
-	return z_soc_sys_write8(data, addr);
+	z_soc_sys_write8(data, addr);
 }
 
 static ALWAYS_INLINE uint16_t sys_read16(mem_addr_t addr)
@@ -51,7 +51,7 @@ static ALWAYS_INLINE uint16_t sys_read16(mem_addr_t addr)
 
 static ALWAYS_INLINE void sys_write16(uint16_t data, mem_addr_t addr)
 {
-	return z_soc_sys_write16(data, addr);
+	z_soc_sys_write16(data, addr);
 }
 
 static ALWAYS_INLINE uint32_t sys_read32(mem_addr_t addr)
@@ -61,7 +61,7 @@ static ALWAYS_INLINE uint32_t sys_read32(mem_addr_t addr)
 
 static ALWAYS_INLINE void sys_write32(uint32_t data, mem_addr_t addr)
 {
-	return z_soc_sys_write32(data, addr);
+	z_soc_sys_write32(data, addr);
 }
 
 static ALWAYS_INLINE uint64_t sys_read64(mem_addr_t addr)
@@ -71,7 +71,7 @@ static ALWAYS_INLINE uint64_t sys_read64(mem_addr_t addr)
 
 static ALWAYS_INLINE void sys_write64(uint64_t data, mem_addr_t addr)
 {
-	return z_soc_sys_write64(data, addr);
+	z_soc_sys_write64(data, addr);
 }
 
 #endif /* CONFIG_RISCV_SOC_HAS_CUSTOM_SYS_IO */

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -355,7 +355,7 @@ void z_impl_k_thread_start(k_tid_t thread)
 static inline void z_vrfy_k_thread_start(k_tid_t thread)
 {
 	K_OOPS(K_SYSCALL_OBJ(thread, K_OBJ_THREAD));
-	return z_impl_k_thread_start(thread);
+	z_impl_k_thread_start(thread);
 }
 #include <zephyr/syscalls/k_thread_start_mrsh.c>
 #endif /* CONFIG_USERSPACE */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -1382,7 +1382,7 @@ static void isr_done(void *param)
 
 			err = isr_close_adv_mesh();
 			if (err) {
-				return 0;
+				return;
 			}
 		}
 #endif /* CONFIG_BT_HCI_MESH_EXT */

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
@@ -716,7 +716,7 @@ static void isr_done(void *param)
 
 			err = isr_close_adv_mesh();
 			if (err) {
-				return 0;
+				return;
 			}
 		}
 #endif /* CONFIG_BT_HCI_MESH_EXT */

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -2344,7 +2344,7 @@ static inline void dle_max_time_get(struct ll_conn *conn, uint16_t *max_rx_time,
 void ull_dle_max_time_get(struct ll_conn *conn, uint16_t *max_rx_time,
 				    uint16_t *max_tx_time)
 {
-	return dle_max_time_get(conn, max_rx_time, max_tx_time);
+	dle_max_time_get(conn, max_rx_time, max_tx_time);
 }
 
 /*

--- a/subsys/logging/log_msg.c
+++ b/subsys/logging/log_msg.c
@@ -337,7 +337,7 @@ static inline void z_vrfy_z_log_msg_static_create(const void *source,
 			      const struct log_msg_desc desc,
 			      uint8_t *package, const void *data)
 {
-	return z_impl_z_log_msg_static_create(source, desc, package, data);
+	z_impl_z_log_msg_static_create(source, desc, package, data);
 }
 #include <zephyr/syscalls/z_log_msg_static_create_mrsh.c>
 #endif

--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_shi_npcx.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_shi_npcx.c
@@ -417,7 +417,8 @@ static void shi_npcx_handle_host_package(const struct device *dev)
 
 	/* Read remaining bytes from input buffer */
 	if (!shi_npcx_read_inbuf_wait(dev, remain_bytes)) {
-		return shi_npcx_bad_received_data(dev);
+		shi_npcx_bad_received_data(dev);
+		return;
 	}
 
 	/* Move to processing state */
@@ -464,7 +465,8 @@ static void shi_npcx_parse_header(const struct device *dev)
 
 	/* Wait for version, command, length bytes */
 	if (!shi_npcx_read_inbuf_wait(dev, 3)) {
-		return shi_npcx_bad_received_data(dev);
+		shi_npcx_bad_received_data(dev);
+		return;
 	}
 
 	if (data->in_msg[0] == EC_HOST_REQUEST_VERSION) {
@@ -480,13 +482,15 @@ static void shi_npcx_parse_header(const struct device *dev)
 
 		/* Wait for the rest of the command header */
 		if (!shi_npcx_read_inbuf_wait(dev, sizeof(*r) - 3)) {
-			return shi_npcx_bad_received_data(dev);
+			shi_npcx_bad_received_data(dev);
+			return;
 		}
 
 		/* Check how big the packet should be */
 		pkt_size = shi_npcx_host_request_expected_size(r);
 		if (pkt_size == 0 || pkt_size > sizeof(data->in_msg)) {
-			return shi_npcx_bad_received_data(dev);
+			shi_npcx_bad_received_data(dev);
+			return;
 		}
 
 		/* Computing total bytes need to receive */
@@ -495,7 +499,8 @@ static void shi_npcx_parse_header(const struct device *dev)
 		shi_npcx_handle_host_package(dev);
 	} else {
 		/* Invalid version number */
-		return shi_npcx_bad_received_data(dev);
+		shi_npcx_bad_received_data(dev);
+		return;
 	}
 }
 
@@ -632,7 +637,8 @@ static void shi_npcx_handle_input_buf_half_full(const struct device *dev)
 	if (data->state == SHI_STATE_RECEIVING) {
 		/* Read data from input to msg buffer */
 		shi_npcx_read_half_inbuf(dev);
-		return shi_npcx_handle_host_package(dev);
+		shi_npcx_handle_host_package(dev);
+		return;
 	} else if (data->state == SHI_STATE_SENDING) {
 		/* Write data from msg buffer to output buffer */
 		if (data->tx_buf == inst->OBUF + SHI_OBUF_FULL_SIZE) {
@@ -658,7 +664,8 @@ static void shi_npcx_handle_input_buf_full(const struct device *dev)
 		shi_npcx_read_half_inbuf(dev);
 		/* Read to bottom address again */
 		data->rx_buf = inst->IBUF;
-		return shi_npcx_handle_host_package(dev);
+		shi_npcx_handle_host_package(dev);
+		return;
 	} else if (data->state == SHI_STATE_SENDING) {
 		/* Write data from msg buffer to output buffer */
 		if (data->tx_buf == inst->OBUF + SHI_OBUF_HALF_SIZE) {
@@ -729,7 +736,8 @@ static void shi_npcx_isr(const struct device *dev)
 		 * Mark not ready to abort next transaction
 		 */
 		LOG_DBG("CSH-");
-		return shi_npcx_handle_cs_deassert(dev);
+		shi_npcx_handle_cs_deassert(dev);
+		return;
 	}
 #endif
 
@@ -752,7 +760,8 @@ static void shi_npcx_isr(const struct device *dev)
 	 * Transaction is processing.
 	 */
 	if (IS_BIT_SET(stat, NPCX_EVSTAT_IBHF)) {
-		return shi_npcx_handle_input_buf_half_full(dev);
+		shi_npcx_handle_input_buf_half_full(dev);
+		return;
 	}
 
 	/*
@@ -760,7 +769,8 @@ static void shi_npcx_isr(const struct device *dev)
 	 * Transaction is processing.
 	 */
 	if (IS_BIT_SET(stat, NPCX_EVSTAT_IBF)) {
-		return shi_npcx_handle_input_buf_full(dev);
+		shi_npcx_handle_input_buf_full(dev);
+		return;
 	}
 }
 

--- a/subsys/net/lib/dhcpv4/dhcpv4.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4.c
@@ -1813,7 +1813,7 @@ int net_dhcpv4_remove_option_vendor_callback(struct net_dhcpv4_option_callback *
 
 void net_dhcpv4_start(struct net_if *iface)
 {
-	return dhcpv4_start_internal(iface, true);
+	dhcpv4_start_internal(iface, true);
 }
 
 void net_dhcpv4_stop(struct net_if *iface)

--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -2812,7 +2812,7 @@ void lwm2m_udp_receive(struct lwm2m_ctx *client_ctx, uint8_t *buf, uint16_t buf_
 		if (has_block2 && IS_ENABLED(CONFIG_LWM2M_COAP_BLOCK_TRANSFER)) {
 			msg = find_ongoing_block2_tx();
 			if (msg) {
-				return handle_ongoing_block2_tx(msg, &response);
+				handle_ongoing_block2_tx(msg, &response);
 			}
 			return;
 		}

--- a/subsys/net/lib/sockets/getaddrinfo.c
+++ b/subsys/net/lib/sockets/getaddrinfo.c
@@ -472,7 +472,8 @@ int zsock_getaddrinfo(const char *host, const char *service,
 void zsock_freeaddrinfo(struct zsock_addrinfo *ai)
 {
 	if (IS_ENABLED(CONFIG_NET_SOCKETS_OFFLOAD)) {
-		return socket_offload_freeaddrinfo(ai);
+		socket_offload_freeaddrinfo(ai);
+		return;
 	}
 
 	free(ai);

--- a/subsys/net/lib/sockets/socket_offload.c
+++ b/subsys/net/lib/sockets/socket_offload.c
@@ -37,5 +37,5 @@ void socket_offload_freeaddrinfo(struct zsock_addrinfo *res)
 	__ASSERT_NO_MSG(dns_offload);
 	__ASSERT_NO_MSG(dns_offload->freeaddrinfo);
 
-	return dns_offload->freeaddrinfo(res);
+	dns_offload->freeaddrinfo(res);
 }

--- a/subsys/shell/backends/shell_telnet.c
+++ b/subsys/shell/backends/shell_telnet.c
@@ -480,7 +480,8 @@ static void telnet_server_cb(struct k_work *work)
 		NET_ERR("Telnet socket %d error (%d)", evt->event.fd, sock_error);
 
 		if (evt->event.fd == sh_telnet->fds[SOCK_ID_CLIENT].fd) {
-			return telnet_end_client_connection();
+			telnet_end_client_connection();
+			return;
 		}
 
 		goto error;
@@ -491,11 +492,14 @@ static void telnet_server_cb(struct k_work *work)
 	}
 
 	if (evt->event.fd == sh_telnet->fds[SOCK_ID_IPV4_LISTEN].fd) {
-		return telnet_accept(&sh_telnet->fds[SOCK_ID_IPV4_LISTEN]);
+		telnet_accept(&sh_telnet->fds[SOCK_ID_IPV4_LISTEN]);
+		return;
 	} else if (evt->event.fd == sh_telnet->fds[SOCK_ID_IPV6_LISTEN].fd) {
-		return telnet_accept(&sh_telnet->fds[SOCK_ID_IPV6_LISTEN]);
+		telnet_accept(&sh_telnet->fds[SOCK_ID_IPV6_LISTEN]);
+		return;
 	} else if (evt->event.fd == sh_telnet->fds[SOCK_ID_CLIENT].fd) {
-		return telnet_recv(&sh_telnet->fds[SOCK_ID_CLIENT]);
+		telnet_recv(&sh_telnet->fds[SOCK_ID_CLIENT]);
+		return;
 	}
 
 	NET_ERR("Unexpected FD received for telnet, restarting service.");

--- a/tests/application_development/code_relocation/src/main.c
+++ b/tests/application_development/code_relocation/src/main.c
@@ -53,8 +53,6 @@ void  z_early_memcpy(void *dst, const void *src, size_t n)
 		*(d_byte++) = *(s_byte++);
 		n--;
 	}
-
-	return (void)dst;
 }
 
 __boot_func
@@ -69,7 +67,6 @@ void z_early_memset(void *dst, int c, size_t n)
 		*(d_byte++) = c_byte;
 		n--;
 	}
-	return (void)dst;
 }
 
 void *relocate_code_setup(void)

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -1007,7 +1007,7 @@ void z_impl_check_syscall_context(void)
 
 static inline void z_vrfy_check_syscall_context(void)
 {
-	return z_impl_check_syscall_context();
+	z_impl_check_syscall_context();
 }
 #include <zephyr/syscalls/check_syscall_context_mrsh.c>
 

--- a/tests/subsys/logging/log_benchmark/src/test_helpers.c
+++ b/tests/subsys/logging/log_benchmark/src/test_helpers.c
@@ -29,7 +29,7 @@ void z_impl_test_helpers_log_setup(void)
 #ifdef CONFIG_USERSPACE
 static inline void z_vrfy_test_helpers_log_setup(void)
 {
-	return z_impl_test_helpers_log_setup();
+	z_impl_test_helpers_log_setup();
 }
 #include <zephyr/syscalls/test_helpers_log_setup_mrsh.c>
 #endif


### PR DESCRIPTION
For code clarity, this PR addresses the use of `return` statements in functions with a `void` return type in the following areas:
- subsys
- kernel
- arch
- tests

---
The `drivers` directory was already addressed in PR #78460.
