### PR TITLE
ci: build samples/cpp/hello_world as part of the multiplatform test

### DIFF
--- a/.github/workflows/hello_world_multiplatform.yaml
+++ b/.github/workflows/hello_world_multiplatform.yaml
@@ -69,7 +69,7 @@ jobs:
           elif [ "${{ runner.os }}" = "Windows" ]; then
             EXTRA_TWISTER_FLAGS="-P native_sim --short-build-path -O/tmp/twister-out"
           fi
-          ./scripts/twister --force-color --inline-logs -T samples/hello_world -v $EXTRA_TWISTER_FLAGS
+          ./scripts/twister --force-color --inline-logs -T samples/hello_world -T samples/cpp/hello_world -v $EXTRA_TWISTER_FLAGS
 
       - name: Upload artifacts
         if: failure()
@@ -78,3 +78,4 @@ jobs:
           if-no-files-found: ignore
           path:
             zephyr/twister-out/*/samples/hello_world/sample.basic.helloworld/build.log
+            zephyr/twister-out/*/samples/cpp/hello_world/sample.cpp.helloworld/build.log


### PR DESCRIPTION
Build the C++ version of the Hello, World sample as part of the multiplatform (build) test in CI.

This was inspired by https://github.com/zephyrproject-rtos/zephyr/issues/78263