### PR TITLE
boards: nxp: imx95_evk: enable cache management for ddr board

### DIFF
--- a/soc/nxp/imx/imx9/imx95/Kconfig
+++ b/soc/nxp/imx/imx9/imx95/Kconfig
@@ -10,6 +10,7 @@ config SOC_MIMX9596_M7
 	select CPU_HAS_DCACHE
 	select CPU_HAS_ARM_MPU
 	select ARM_MPU
+	select SOC_LATE_INIT_HOOK
 	select HAS_MCUX
 
 config SOC_MIMX9596_A55

--- a/soc/nxp/imx/imx9/imx95/Kconfig.defconfig.mimx95.m7
+++ b/soc/nxp/imx/imx9/imx95/Kconfig.defconfig.mimx95.m7
@@ -19,4 +19,7 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 	int
 	default 800000000
 
+config CACHE_MANAGEMENT
+	default y
+
 endif # SOC_MIMX9596_M7

--- a/soc/nxp/imx/imx9/imx95/m7/CMakeLists.txt
+++ b/soc/nxp/imx/imx9/imx95/m7/CMakeLists.txt
@@ -2,4 +2,7 @@
 
 zephyr_include_directories(.)
 
+zephyr_library()
+zephyr_library_sources(soc.c)
+
 set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")

--- a/soc/nxp/imx/imx9/imx95/m7/soc.c
+++ b/soc/nxp/imx/imx9/imx95/m7/soc.c
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/cache.h>
+
+void soc_late_init_hook(void)
+{
+#ifdef CONFIG_CACHE_MANAGEMENT
+	sys_cache_data_enable();
+	sys_cache_instr_enable();
+#endif /* CONFIG_CACHE_MANAGEMENT */
+}


### PR DESCRIPTION
Enable cache management on the i.MX95 DDR board variant.