### PR TITLE
compliance: Revert "scripts: handle auto defined ZEPHYR_<name>_MODULE"

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -387,6 +387,11 @@ class KconfigCheck(ComplianceTest):
         This is needed to complete Kconfig sanity tests.
 
         """
+        if self.no_modules:
+            with open(modules_file, 'w') as fp_module_file:
+                fp_module_file.write("# Empty\n")
+            return
+
         # Invoke the script directly using the Python executable since this is
         # not a module nor a pip-installed Python utility
         zephyr_module_path = os.path.join(ZEPHYR_BASE, "scripts",
@@ -413,18 +418,6 @@ class KconfigCheck(ComplianceTest):
                     modules_dir + '/' + module + '/Kconfig'
                 ))
             fp_module_file.write(content)
-
-        if self.no_modules:
-            module_define_content = ""
-            module_definition = re.compile('config ZEPHYR_.*_MODULE.*').search
-            with open(modules_file, 'r+') as fp_module_file:
-                for line in fp_module_file:
-                    if module_definition(line):
-                        module_define_content += line
-                        module_define_content += "\tbool\n"
-                fp_module_file.seek(0)
-                fp_module_file.write(module_define_content)
-                fp_module_file.truncate()
 
     def get_module_setting_root(self, root, settings_file):
         """


### PR DESCRIPTION
With the requirement in https://github.com/zephyrproject-rtos/zephyr/pull/78316 for Zephyr modules to always define ZEPHYR_<name>_MODULE Kconfig setting then there is no longer a need for this commit. Simplify check_compliance by reverting ths commit.

This reverts commit 35e28e6315893f573ca0de8e5fd5a29e849435f9.