### PR TITLE
boards: nxp: fix mcuboot slots per automatic max sectors

### DIFF
--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_hyperflash.overlay
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_hyperflash.overlay
@@ -50,20 +50,20 @@
 				label = "mcuboot";
 				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			/* The MCUBoot swap-move algorithm uses the last 14 sectors
+			/* The MCUBoot swap-move algorithm uses the last 11 sectors
 			 * of the primary slot0 for swap status and move.
 			 */
 			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00020000 (DT_SIZE_M(3) + DT_SIZE_K(56))>;
+				reg = <0x00020000 (DT_SIZE_M(3) + DT_SIZE_K(44))>;
 			};
-			slot1_partition: partition@32E000 {
+			slot1_partition: partition@32B000 {
 				label = "image-1";
-				reg = <0x0032E000 DT_SIZE_M(3)>;
+				reg = <0x0032B000 DT_SIZE_M(3)>;
 			};
-			storage_partition: partition@62E000 {
+			storage_partition: partition@62B000 {
 				label = "storage";
-				reg = <0x0062E000 (DT_SIZE_M(58) - DT_SIZE_K(184))>;
+				reg = <0x0062B000 (DT_SIZE_M(58) - DT_SIZE_K(172))>;
 			};
 		};
 	};

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_hyperflash.overlay
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_hyperflash.overlay
@@ -48,20 +48,20 @@
 				label = "mcuboot";
 				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			/* The MCUBoot swap-move algorithm uses the last 14 sectors
+			/* The MCUBoot swap-move algorithm uses the last 11 sectors
 			 * of the primary slot0 for swap status and move.
 			 */
 			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00020000 (DT_SIZE_M(3) + DT_SIZE_K(56))>;
+				reg = <0x00020000 (DT_SIZE_M(3) + DT_SIZE_K(44))>;
 			};
-			slot1_partition: partition@32E000 {
+			slot1_partition: partition@32B000 {
 				label = "image-1";
-				reg = <0x0032E000 DT_SIZE_M(3)>;
+				reg = <0x0032B000 DT_SIZE_M(3)>;
 			};
-			storage_partition: partition@62E000 {
+			storage_partition: partition@62B000 {
 				label = "storage";
-				reg = <0x0062E000 (DT_SIZE_M(58) - DT_SIZE_K(184))>;
+				reg = <0x0062B000 (DT_SIZE_M(58) - DT_SIZE_K(172))>;
 			};
 		};
 	};

--- a/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6.dts
+++ b/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6.dts
@@ -211,20 +211,20 @@
 				label = "mcuboot";
 				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			/* The MCUBoot swap-move algorithm uses the last 14 sectors
+			/* The MCUBoot swap-move algorithm uses the last 11 sectors
 			 * of the primary slot0 for swap status and move.
 			 */
 			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00020000 (DT_SIZE_M(3) + DT_SIZE_K(56))>;
+				reg = <0x00020000 (DT_SIZE_M(3) + DT_SIZE_K(44))>;
 			};
-			slot1_partition: partition@32E000 {
+			slot1_partition: partition@32B000 {
 				label = "image-1";
-				reg = <0x0032E000 DT_SIZE_M(3)>;
+				reg = <0x0032B000 DT_SIZE_M(3)>;
 			};
-			storage_partition: partition@62E000 {
+			storage_partition: partition@62B000 {
 				label = "storage";
-				reg = <0x0062E000 (DT_SIZE_M(58) - DT_SIZE_K(184))>;
+				reg = <0x0062B000 (DT_SIZE_M(58) - DT_SIZE_K(172))>;
 			};
 		};
 	};

--- a/boards/nxp/rddrone_fmuk66/rddrone_fmuk66.dts
+++ b/boards/nxp/rddrone_fmuk66/rddrone_fmuk66.dts
@@ -240,20 +240,20 @@ zephyr_udc0: &usbotg {
 			reg = <0x00000000 DT_SIZE_K(64)>;
 			read-only;
 		};
-		/* The MCUBoot swap-move algorithm uses the last 2 sectors
+		/* The MCUBoot swap-move algorithm uses the last 3 sectors
 		 * of the primary slot0 for swap status and move.
 		 */
 		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x00010000 (DT_SIZE_K(928) + DT_SIZE_K(8))>;
+			reg = <0x00010000 (DT_SIZE_K(928) + DT_SIZE_K(12))>;
 		};
-		slot1_partition: partition@FA000 {
+		slot1_partition: partition@FB000 {
 			label = "image-1";
-			reg = <0x000FA000 DT_SIZE_K(928)>;
+			reg = <0x000FB000 DT_SIZE_K(928)>;
 		};
-		storage_partition: partition@1E2000 {
+		storage_partition: partition@1E3000 {
 			label = "storage";
-			reg = <0x001E2000 DT_SIZE_K(120)>;
+			reg = <0x001E3000 DT_SIZE_K(116)>;
 		};
 	};
 };


### PR DESCRIPTION
Fixed mcuboot slots, needed after MCUBoot added the default auto calculation max sectors (CONFIG_BOOT_MAX_IMG_SECTORS_AUTO).
Fixed a possible firmware update error.