### PR TITLE
[Drivers][RGPIO and IGPIO] improve handling of non-contiguous gpio pin layouts

### DIFF
--- a/drivers/gpio/gpio_mcux_igpio.c
+++ b/drivers/gpio/gpio_mcux_igpio.c
@@ -18,19 +18,13 @@
 
 #include <zephyr/drivers/gpio/gpio_utils.h>
 
-struct gpio_pin_gaps {
-	uint8_t start;
-	uint8_t len;
-};
 
 struct mcux_igpio_config {
 	/* gpio_driver_config needs to be first */
 	struct gpio_driver_config common;
 	GPIO_Type *base;
 	const struct pinctrl_soc_pinmux *pin_muxes;
-	const struct gpio_pin_gaps *pin_gaps;
 	uint8_t mux_count;
-	uint8_t gap_count;
 };
 
 struct mcux_igpio_data {
@@ -49,15 +43,15 @@ static int mcux_igpio_configure(const struct device *dev,
 	struct pinctrl_soc_pin pin_cfg;
 	int cfg_idx = pin, i;
 
+	/* Make sure pin is supported */
+	if ((config->common.port_pin_mask & BIT(pin)) == 0) {
+		return -ENOTSUP;
+	}
+
 	/* Some SOCs have non-contiguous gpio pin layouts, account for this */
-	for (i = 0; i < config->gap_count; i++) {
-		if (pin >= config->pin_gaps[i].start) {
-			if (pin < (config->pin_gaps[i].start +
-				config->pin_gaps[i].len)) {
-				/* Pin is not connected to a mux */
-				return -ENOTSUP;
-			}
-			cfg_idx -= config->pin_gaps[i].len;
+	for (i = 0; i < pin; i++) {
+		if ((config->common.port_pin_mask & BIT(i)) == 0) {
+			cfg_idx--;
 		}
 	}
 
@@ -274,6 +268,11 @@ static int mcux_igpio_pin_interrupt_configure(const struct device *dev,
 	uint8_t icr;
 	int shift;
 
+	/* Make sure pin is supported */
+	if ((config->common.port_pin_mask & BIT(pin)) == 0) {
+		return -ENOTSUP;
+	}
+
 	if (mode == GPIO_INT_MODE_DISABLED) {
 		key = irq_lock();
 
@@ -356,14 +355,10 @@ static const struct gpio_driver_api mcux_igpio_driver_api = {
 #define MCUX_IGPIO_PIN_DECLARE(n)						\
 	const struct pinctrl_soc_pinmux mcux_igpio_pinmux_##n[] = {		\
 		DT_FOREACH_PROP_ELEM(DT_DRV_INST(n), pinmux, PINMUX_INIT)	\
-	};									\
-	const uint8_t mcux_igpio_pin_gaps_##n[] =				\
-		DT_INST_PROP_OR(n, gpio_reserved_ranges, {});
+	};
 #define MCUX_IGPIO_PIN_INIT(n)							\
 	.pin_muxes = mcux_igpio_pinmux_##n,					\
-	.pin_gaps = (const struct gpio_pin_gaps *)mcux_igpio_pin_gaps_##n,	\
-	.mux_count = DT_PROP_LEN(DT_DRV_INST(n), pinmux),			\
-	.gap_count = (ARRAY_SIZE(mcux_igpio_pin_gaps_##n) / 2)
+	.mux_count = DT_PROP_LEN(DT_DRV_INST(n), pinmux)
 
 #define MCUX_IGPIO_IRQ_INIT(n, i)					\
 	do {								\
@@ -381,7 +376,8 @@ static const struct gpio_driver_api mcux_igpio_driver_api = {
 									\
 	static const struct mcux_igpio_config mcux_igpio_##n##_config = {\
 		.common = {						\
-			.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(n),\
+			.port_pin_mask = GPIO_DT_INST_PORT_PIN_MASK_NGPIOS_EXC(\
+				n, DT_INST_PROP(n, ngpios)),\
 		},							\
 		.base = (GPIO_Type *)DT_INST_REG_ADDR(n),		\
 		MCUX_IGPIO_PIN_INIT(n)					\


### PR DESCRIPTION
Improve handling of "pin-gaps" using "GPIO_DT_RESERVED_RANGES_NGPIOS"
series macro.