### PR TITLE
boards: others: add esp32c3_supermini board support

### DIFF
--- a/boards/others/esp32c3_supermini/Kconfig.defconfig
+++ b/boards/others/esp32c3_supermini/Kconfig.defconfig
@@ -1,0 +1,9 @@
+# Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+config HEAP_MEM_POOL_ADD_SIZE_BOARD
+	int
+	default 65535 if WIFI && BT
+	default 51200 if WIFI
+	default 40960 if BT
+	default 4096

--- a/boards/others/esp32c3_supermini/Kconfig.esp32c3_supermini
+++ b/boards/others/esp32c3_supermini/Kconfig.esp32c3_supermini
@@ -1,0 +1,5 @@
+# Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_ESP32C3_SUPERMINI
+	select SOC_ESP32C3_FX4

--- a/boards/others/esp32c3_supermini/Kconfig.sysbuild
+++ b/boards/others/esp32c3_supermini/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+# Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+choice BOOTLOADER
+	default BOOTLOADER_MCUBOOT
+endchoice
+
+choice BOOT_SIGNATURE_TYPE
+	default BOOT_SIGNATURE_TYPE_NONE
+endchoice

--- a/boards/others/esp32c3_supermini/board.cmake
+++ b/boards/others/esp32c3_supermini/board.cmake
@@ -1,0 +1,10 @@
+# Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+if(NOT "${OPENOCD}" MATCHES "^${ESPRESSIF_TOOLCHAIN_PATH}/.*")
+  set(OPENOCD OPENOCD-NOTFOUND)
+endif()
+find_program(OPENOCD openocd PATHS ${ESPRESSIF_TOOLCHAIN_PATH}/openocd-esp32/bin NO_DEFAULT_PATH)
+
+include(${ZEPHYR_BASE}/boards/common/esp32.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/others/esp32c3_supermini/board.yml
+++ b/boards/others/esp32c3_supermini/board.yml
@@ -1,0 +1,8 @@
+# Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+board:
+  name: esp32c3_supermini
+  vendor: espressif
+  socs:
+  - name: esp32c3

--- a/boards/others/esp32c3_supermini/doc/index.rst
+++ b/boards/others/esp32c3_supermini/doc/index.rst
@@ -43,7 +43,7 @@ manual at `ESP32-C3 Technical Reference Manual`_.
 Supported Features
 ==================
 
-Current Zephyr's ESP32-C3-SUPERMINI board supports the following features:
+Currently Zephyr's ``esp32c3_supermini`` board supports the following features:
 
 +------------+------------+-------------------------------------+
 | Interface  | Controller | Driver/Component                    |

--- a/boards/others/esp32c3_supermini/doc/index.rst
+++ b/boards/others/esp32c3_supermini/doc/index.rst
@@ -280,3 +280,4 @@ References
 .. _`ESP32-C3 Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32-c3_datasheet_en.pdf
 .. _`ESP32-C3 Technical Reference Manual`: https://espressif.com/sites/default/files/documentation/esp32-c3_technical_reference_manual_en.pdf
 .. _`OpenOCD ESP32`: https://github.com/espressif/openocd-esp32/releases
+

--- a/boards/others/esp32c3_supermini/doc/index.rst
+++ b/boards/others/esp32c3_supermini/doc/index.rst
@@ -1,0 +1,282 @@
+.. _esp32c3_supermini:
+
+ESP32-C3-SUPERMINI
+####################
+
+Overview
+********
+
+ESP32-C3-SUPERMINI is based on the ESP32-C3, a single-core Wi-Fi and Bluetooth 5 (LE) microcontroller SoC,
+based on the open-source RISC-V architecture. This board also includes a Type-C USB Serial/JTAG port.
+For more information, check `ESP32-C3-SUPERMINI`_
+
+Hardware
+********
+
+SoC Features:
+
+- IEEE 802.11 b/g/n-compliant
+- Bluetooth 5, Bluetooth mesh
+- 32-bit RISC-V single-core processor, up to 160MHz
+- 384 KB ROM
+- 400 KB SRAM (16 KB for cache)
+- 8 KB SRAM in RTC
+- 22 x programmable GPIOs
+- 3 x SPI
+- 2 x UART
+- 1 x I2C
+- 1 x I2S
+- 2 x 54-bit general-purpose timers
+- 3 x watchdog timers
+- 1 x 52-bit system timer
+- Remote Control Peripheral (RMT)
+- LED PWM controller (LEDC)
+- Full-speed USB Serial/JTAG controller
+- General DMA controller (GDMA)
+- 1 x TWAI®
+- 2 x 12-bit SAR ADCs, up to 6 channels
+- 1 x soc core temperature sensor
+
+For more information on the ESP32-C3 SOC, check the datasheet at `ESP32-C3 Datasheet`_ or the technical reference
+manual at `ESP32-C3 Technical Reference Manual`_.
+
+Supported Features
+==================
+
+Current Zephyr's ESP32-C3-SUPERMINI board supports the following features:
+
++------------+------------+-------------------------------------+
+| Interface  | Controller | Driver/Component                    |
++============+============+=====================================+
+| UART       | on-chip    | serial port                         |
++------------+------------+-------------------------------------+
+| GPIO       | on-chip    | gpio                                |
++------------+------------+-------------------------------------+
+| PINMUX     | on-chip    | pinmux                              |
++------------+------------+-------------------------------------+
+| USB-JTAG   | on-chip    | hardware interface                  |
++------------+------------+-------------------------------------+
+| SPI Master | on-chip    | spi                                 |
++------------+------------+-------------------------------------+
+| Timers     | on-chip    | counter                             |
++------------+------------+-------------------------------------+
+| Watchdog   | on-chip    | watchdog                            |
++------------+------------+-------------------------------------+
+| TRNG       | on-chip    | entropy                             |
++------------+------------+-------------------------------------+
+| LEDC       | on-chip    | pwm                                 |
++------------+------------+-------------------------------------+
+| SPI DMA    | on-chip    | spi                                 |
++------------+------------+-------------------------------------+
+| TWAI       | on-chip    | can                                 |
++------------+------------+-------------------------------------+
+| USB-CDC    | on-chip    | serial                              |
++------------+------------+-------------------------------------+
+| ADC        | on-chip    | adc                                 |
++------------+------------+-------------------------------------+
+| Wi-Fi      | on-chip    |                                     |
++------------+------------+-------------------------------------+
+| Bluetooth  | on-chip    |                                     |
++------------+------------+-------------------------------------+
+
+I2C Peripherals
+===============
+
+I2C Bus Connection
+==================
+
++---------+--------+
+| Signal  | GPIO   |
++=========+========+
+| SDA     | GPIO10 |
++---------+--------+
+| SCL     | GPIO8  |
++---------+--------+
+
+I/Os
+====
+
+The following devices are connected through GPIO:
+
++--------------+--------+
+| I/O Devices  | GPIO   |
++==============+========+
+| LED          | GPIO8  |
++--------------+--------+
+| Button/Boot  | GPIO9  |
++--------------+--------+
+
+Power
+=====
+
+* USB type-C (*no PD compatibility*).
+
+System requirements
+*******************
+
+Prerequisites
+=============
+
+Espressif HAL requires WiFi and Bluetooth binary blobs in order work. Run the command
+below to retrieve those files.
+
+.. code-block:: console
+
+   west blobs fetch hal_espressif
+
+.. note::
+
+   It is recommended running the command above after :file:`west update`.
+
+Building & Flashing
+*******************
+
+Simple boot
+===========
+
+The board could be loaded using the single binary image, without 2nd stage bootloader.
+It is the default option when building the application without additional configuration.
+
+.. note::
+
+   Simple boot does not provide any security features nor OTA updates.
+
+MCUboot bootloader
+==================
+
+User may choose to use MCUboot bootloader instead. In that case the bootloader
+must be built (and flashed) at least once.
+
+There are two options to be used when building an application:
+
+1. Sysbuild
+2. Manual build
+
+.. note::
+
+   User can select the MCUboot bootloader by adding the following line
+   to the board default configuration file.
+
+   .. code:: cfg
+
+      CONFIG_BOOTLOADER_MCUBOOT=y
+
+Sysbuild
+========
+
+The sysbuild makes possible to build and flash all necessary images needed to
+bootstrap the board with the ESP32 SoC.
+
+To build the sample application using sysbuild use the command:
+
+.. zephyr-app-commands::
+   :tool: west
+   :zephyr-app: samples/hello_world
+   :board: esp32c3_supermini
+   :goals: build
+   :west-args: --sysbuild
+   :compact:
+
+By default, the ESP32 sysbuild creates bootloader (MCUboot) and application
+images. But it can be configured to create other kind of images.
+
+Build directory structure created by sysbuild is different from traditional
+Zephyr build. Output is structured by the domain subdirectories:
+
+.. code-block::
+
+  build/
+  ├── hello_world
+  │   └── zephyr
+  │       ├── zephyr.elf
+  │       └── zephyr.bin
+  ├── mcuboot
+  │    └── zephyr
+  │       ├── zephyr.elf
+  │       └── zephyr.bin
+  └── domains.yaml
+
+.. note::
+
+   With ``--sysbuild`` option the bootloader will be re-build and re-flash
+   every time the pristine build is used.
+
+For more information about the system build please read the :ref:`sysbuild` documentation.
+
+Manual build
+============
+
+During the development cycle, it is intended to build & flash as quickly possible.
+For that reason, images can be built one at a time using traditional build.
+
+The instructions following are relevant for both manual build and sysbuild.
+The only difference is the structure of the build directory.
+
+.. note::
+
+   Remember that bootloader (MCUboot) needs to be flash at least once.
+
+Build and flash applications as usual (see :ref:`build_an_application` and
+:ref:`application_run` for more details).
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: esp32c3_supermini
+   :goals: build
+
+The usual ``flash`` target will work with the ``esp32c3_supermini`` board
+configuration. Here is an example for the :zephyr:code-sample:`hello_world`
+application.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: esp32c3_supermini
+   :goals: flash
+
+Open the serial monitor using the following command:
+
+.. code-block:: shell
+
+   west espressif monitor
+
+After the board has automatically reset and booted, you should see the following
+message in the monitor:
+
+.. code-block:: console
+
+   ***** Booting Zephyr OS vx.x.x-xxx-gxxxxxxxxxxxx *****
+   Hello World! esp32c3_supermini
+
+Debugging
+*********
+
+As with much custom hardware, the ESP32-C3 modules require patches to
+OpenOCD that are not upstreamed yet. Espressif maintains their own fork of
+the project. The custom OpenOCD can be obtained at `OpenOCD ESP32`_.
+
+The Zephyr SDK uses a bundled version of OpenOCD by default. You can overwrite that behavior by adding the
+``-DOPENOCD=<path/to/bin/openocd> -DOPENOCD_DEFAULT_PATH=<path/to/openocd/share/openocd/scripts>``
+parameter when building.
+
+Here is an example for building the :zephyr:code-sample:`hello_world` application.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: esp32c3_supermini
+   :goals: build flash
+   :gen-args: -DOPENOCD=<path/to/bin/openocd> -DOPENOCD_DEFAULT_PATH=<path/to/openocd/share/openocd/scripts>
+
+You can debug an application in the usual way. Here is an example for the :zephyr:code-sample:`hello_world` application.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: esp32c3_supermini
+   :goals: debug
+
+References
+**********
+
+.. _`ESP32-C3-SUPERMINI`: https://www.nologo.tech/product/esp32/esp32c3SuperMini/esp32C3SuperMini.html
+.. _`ESP32-C3 Datasheet`: https://www.espressif.com/sites/default/files/documentation/esp32-c3_datasheet_en.pdf
+.. _`ESP32-C3 Technical Reference Manual`: https://espressif.com/sites/default/files/documentation/esp32-c3_technical_reference_manual_en.pdf
+.. _`OpenOCD ESP32`: https://github.com/espressif/openocd-esp32/releases

--- a/boards/others/esp32c3_supermini/esp32c3_rust.yaml
+++ b/boards/others/esp32c3_supermini/esp32c3_rust.yaml
@@ -1,0 +1,25 @@
+# Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+identifier: esp32c3_supermini
+name: ESP32-C3-SUPERMINI
+type: mcu
+arch: riscv
+toolchain:
+  - zephyr
+supported:
+  - adc
+  - gpio
+  - i2c
+  - watchdog
+  - uart
+  - dma
+  - pwm
+  - spi
+  - counter
+  - entropy
+testing:
+  ignore_tags:
+    - net
+    - bluetooth
+vendor: espressif

--- a/boards/others/esp32c3_supermini/esp32c3_supermini-pinctrl.dtsi
+++ b/boards/others/esp32c3_supermini/esp32c3_supermini-pinctrl.dtsi
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
+#include <dt-bindings/pinctrl/esp32c3-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/esp32c3-gpio-sigmap.h>
+
+&pinctrl {
+
+	uart0_default: uart0_default {
+		group1 {
+			pinmux = <UART0_TX_GPIO21>;
+			output-high;
+		};
+		group2 {
+			pinmux = <UART0_RX_GPIO20>;
+			bias-pull-up;
+		};
+	};
+
+	spim2_default: spim2_default {
+		group1 {
+			pinmux = <SPIM2_MISO_GPIO5>,
+				 <SPIM2_SCLK_GPIO4>,
+				 <SPIM2_CSEL_GPIO7>;
+		};
+		group2 {
+			pinmux = <SPIM2_MOSI_GPIO6>;
+			output-low;
+		};
+	};
+
+	i2c0_default: i2c0_default {
+		group1 {
+			pinmux = <I2C0_SDA_GPIO8>,
+				 <I2C0_SCL_GPIO9>;
+			bias-pull-up;
+			drive-open-drain;
+			output-high;
+		};
+	};
+};

--- a/boards/others/esp32c3_supermini/esp32c3_supermini.dts
+++ b/boards/others/esp32c3_supermini/esp32c3_supermini.dts
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+#include <espressif/esp32c3/esp32c3_mini_n4.dtsi>
+#include "esp32c3_supermini-pinctrl.dtsi"
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/led/led.h>
+#include <espressif/partitions_0x0_default.dtsi>
+
+/ {
+	model = "ESP32C3-SUPERMINI";
+	compatible = "espressif,esp32c3_supermini";
+
+	chosen {
+		zephyr,sram = &sram0;
+		zephyr,console = &usb_serial;
+		zephyr,shell-uart = &usb_serial;
+		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
+	};
+
+	aliases {
+		led0 = &blue_led_0;
+		sw0 = &user_button1;
+		i2c-0 = &i2c0;
+		watchdog0 = &wdt0;
+		/* led-strip = &led_strip; */
+	};
+
+	gpio_keys {
+		compatible = "gpio-keys";
+		user_button1: button_1 {
+			label = "User SW1";
+			gpios = <&gpio0 9 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			zephyr,code = <INPUT_KEY_0>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		blue_led_0: led_0 {
+			gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
+			label = "User LD0";
+		};
+	};
+
+};
+
+&spi2 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+	pinctrl-0 = <&spim2_default>;
+	pinctrl-names = "default";
+
+};
+
+&usb_serial {
+	status = "okay";
+};
+
+
+&i2c0 {
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	pinctrl-0 = <&i2c0_default>;
+	pinctrl-names = "default";
+};
+
+&trng0 {
+	status = "okay";
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&wdt0 {
+	status = "okay";
+};
+
+&uart0 {
+	status = "disabled";
+};
+
+&esp32_bt_hci {
+	status = "okay";
+};

--- a/boards/others/esp32c3_supermini/esp32c3_supermini_defconfig
+++ b/boards/others/esp32c3_supermini/esp32c3_supermini_defconfig
@@ -1,0 +1,12 @@
+# Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_MAIN_STACK_SIZE=2048
+
+CONFIG_CONSOLE=y
+CONFIG_SERIAL=y
+CONFIG_UART_CONSOLE=y
+CONFIG_GPIO=y
+CONFIG_I2C=y
+#CONFIG_LED_STRIP=y
+#CONFIG_SENSOR=y

--- a/boards/others/esp32c3_supermini/support/openocd.cfg
+++ b/boards/others/esp32c3_supermini/support/openocd.cfg
@@ -1,0 +1,11 @@
+set ESP_RTOS none
+
+# ESP32C3 has built-in JTAG interface over USB port in pins GPIO18/GPIO19 (D-/D+).
+# Uncomment the line below to enable USB debugging.
+source [find interface/esp_usb_jtag.cfg]
+
+# Otherwise, use external JTAG programmer as ESP-Prog
+source [find interface/ftdi/esp32_devkitj_v1.cfg]
+
+source [find target/esp32c3.cfg]
+adapter speed 5000


### PR DESCRIPTION
Having been unable to determine the original board
designer\vendor with any confidence, adding the
board under vendor "others".

Tested samples:
  * hello_world
  * basic/blinky
  
Signed-off-by: Arrel Neumiller <rlneumiller@gmail.com>