### PR TITLE
soc: nordic: nrf54l: integrate normal voltage mode fixes

### DIFF
--- a/soc/nordic/nrf54l/Kconfig
+++ b/soc/nordic/nrf54l/Kconfig
@@ -79,9 +79,6 @@ config SOC_NRF_FORCE_CONSTLAT
 	  of base resources on while in sleep. The advantage of having a constant
 	  and predictable latency will be at the cost of having increased power consumption.
 
-config SOC_NRF54L_NORMAL_VOLTAGE_MODE
-	bool "NRF54L Normal Voltage Mode."
-
 if NRF_GRTC_TIMER
 
 config ELV_GRTC_LFXO_ALLOWED

--- a/soc/nordic/nrf54l/soc.c
+++ b/soc/nordic/nrf54l/soc.c
@@ -156,10 +156,6 @@ static int nordicsemi_nrf54l_init(void)
 	nrf_regulators_vreg_enable_set(NRF_REGULATORS, NRF_REGULATORS_VREG_MAIN, true);
 #endif
 
-	if (IS_ENABLED(CONFIG_SOC_NRF54L_NORMAL_VOLTAGE_MODE)) {
-		nrf_regulators_vreg_enable_set(NRF_REGULATORS, NRF_REGULATORS_VREG_MEDIUM, false);
-	}
-
 #if defined(CONFIG_ELV_GRTC_LFXO_ALLOWED)
 	nrf_regulators_elv_mode_allow_set(NRF_REGULATORS, NRF_REGULATORS_ELV_ELVGRTCLFXO_MASK);
 #endif /* CONFIG_ELV_GRTC_LFXO_ALLOWED */


### PR DESCRIPTION
MDK 8.67.0 deprecates normal voltage mode for nRF54L, so it should no longer be used by the end users.