### PR TITLE
soc: esp32s3: bump esp32s3 bootloader iram and dram sizes.

### DIFF
--- a/soc/espressif/esp32s3/memory.h
+++ b/soc/espressif/esp32s3/memory.h
@@ -45,9 +45,9 @@
 
 /* For safety margin between bootloader data section and startup stacks */
 #define BOOTLOADER_STACK_OVERHEAD      0x0
-#define BOOTLOADER_DRAM_SEG_LEN        0x8000
+#define BOOTLOADER_DRAM_SEG_LEN        0x9000
 #define BOOTLOADER_IRAM_LOADER_SEG_LEN 0x1a00
-#define BOOTLOADER_IRAM_SEG_LEN        0xa800
+#define BOOTLOADER_IRAM_SEG_LEN        0xc000
 
 /* Start of the lower region is determined by region size and the end of the higher region */
 #define BOOTLOADER_IRAM_LOADER_SEG_START (BOOTLOADER_USER_DRAM_END - BOOTLOADER_STACK_OVERHEAD + \


### PR DESCRIPTION
Currently the RAM allocated for MCUBoot is not enough for crypto signatures.
This commit bumps the #defines accordingly to fix compile errors with ecdsa_p256 and rsa. 

closes https://github.com/zephyrproject-rtos/zephyr/issues/76566