### PR TITLE
boards: nordic: thingy53: Fixes for FEM

### DIFF
--- a/boards/nordic/thingy53/thingy53_nrf5340_common.dtsi
+++ b/boards/nordic/thingy53/thingy53_nrf5340_common.dtsi
@@ -131,6 +131,18 @@
 		};
 	};
 
+	/* Disabled by default as SPI lines are shared with peripherals on application core */
+	spi_fwd: nrf-spi-forwarder {
+		compatible = "nordic,nrf-gpio-forwarder";
+		status = "disabled";
+		fem-spi-if {
+			gpios = <&gpio0 24 0>,
+				<&gpio0 29 0>,
+				<&gpio0 27 0>,
+				<&gpio0 28 0>;
+		};
+	};
+
 	aliases {
 		sw0 = &button0;
 		sw1 = &button1;

--- a/boards/nordic/thingy53/thingy53_nrf5340_cpunet-pinctrl.dtsi
+++ b/boards/nordic/thingy53/thingy53_nrf5340_cpunet-pinctrl.dtsi
@@ -23,4 +23,20 @@
 		};
 	};
 
+	spi0_default: spi0_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 29)>,
+				<NRF_PSEL(SPIM_MISO, 0, 27)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 28)>;
+		};
+	};
+
+	spi0_sleep: spi0_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 29)>,
+				<NRF_PSEL(SPIM_MISO, 0, 27)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 28)>;
+			low-power-enable;
+		};
+	};
 };

--- a/boards/nordic/thingy53/thingy53_nrf5340_cpunet.dts
+++ b/boards/nordic/thingy53/thingy53_nrf5340_cpunet.dts
@@ -63,6 +63,7 @@
 		mode-gpios  = <&gpio1 12 GPIO_ACTIVE_HIGH>;
 		pdn-gpios   = <&gpio1 10 GPIO_ACTIVE_HIGH>;
 		tx-en-gpios = <&gpio0 30 GPIO_ACTIVE_HIGH>;
+		spi-if = <&nrf_radio_fem_spi>;
 		supply-voltage-mv = <3000>;
 	};
 
@@ -109,6 +110,27 @@
 	pinctrl-0 = <&uart0_default>;
 	pinctrl-1 = <&uart0_sleep>;
 	pinctrl-names = "default", "sleep";
+};
+
+/* Disabled by default as shares same GPIO lines as SPI peripherals on application core */
+fem_spi: &spi0 {
+	status = "disabled";
+	cs-gpios = <&gpio0 24 GPIO_ACTIVE_LOW>;
+	pinctrl-0 = <&spi0_default>;
+	pinctrl-1 = <&spi0_sleep>;
+	pinctrl-names = "default", "sleep";
+
+	nrf_radio_fem_spi: nrf21540_fem_spi@0 {
+		compatible = "nordic,nrf21540-fem-spi";
+		status = "disabled";
+		reg = <0>;
+		spi-max-frequency = <8000000>;
+	};
+};
+
+&radio {
+	/* Uncomment to enable SPI interface for FEM */
+	/* fem = <&nrf_radio_fem>; */
 };
 
 &flash1 {

--- a/soc/nordic/nrf53/Kconfig
+++ b/soc/nordic/nrf53/Kconfig
@@ -180,8 +180,6 @@ config SOC_NRF53_CPUNET_ENABLE
 	depends on !BT
 	default y if NRF_802154_SER_HOST
 	select SOC_NRF53_CPUNET_MGMT
-	select SOC_NRF_GPIO_FORWARDER_FOR_NRF5340 if \
-		$(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_GPIO_FORWARDER))
 	help
 	  This option enables releasing the Network 'force off' signal, which
 	  as a consequence will power up the Network MCU during system boot.


### PR DESCRIPTION
    boards: nordic: thingy53: Add missing FEM entries
    
    Adds missing SPI definition and settings for usage of FEM on
    this platform


    soc: nordic: nrf53: Make GPIO pin forwarding selectable
    
    Allows selecting the forward GPIO pins to network core Kconfig
    option and enables it by default if the node exists in devicetree
