### PR TITLE
Bluetooth: Host: Set scan option type to uint8_t

### DIFF
--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -2065,7 +2065,7 @@ struct bt_le_scan_param {
 	uint8_t  type;
 
 	/** Bit-field of scanning options. */
-	uint32_t options;
+	uint8_t options;
 
 	/** Scan interval (N * 0.625 ms).
 	 *


### PR DESCRIPTION
Changed the scan option type from uint32_t to
uint8_t.

There are 2 reasons for this:
1) This reduces the size of the struct bt_le_scan_param.
   Since we are now storing two copies of scan parameters
   statically in the host, this is not insignficant.
2) This fixes a "hole" in the struct. There are no longer
   3 empty octets between the `type` and the `options`, which
   caused valgrind warnings when using `memcpy` and `memcmp`
   of the struct.

Currently we only need 8 bits for the options available. If additional options are added later, the field need to be increased. For the above reasons some additional refactoring my be required to avoid significant size increases and the valgrind issue.