### PR TITLE
tests: drivers: spi loopback testing on stm32h7s78_dk

### DIFF
--- a/tests/drivers/spi/spi_loopback/boards/stm32h7s78_dk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/stm32h7s78_dk.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2024 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&spi4 {
+	/* spi4 MOSI on D11 spi4 MISO on D12 */
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <500000>;
+	};
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+	};
+};

--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -128,6 +128,7 @@ tests:
       - nucleo_wl55jc
       - stm32f3_disco
       - stm32h573i_dk
+      - stm32h7s78_dk
   drivers.spi.gd32_spi_interrupt.loopback:
     extra_args: OVERLAY_CONFIG="overlay-gd32-spi-interrupt.conf"
     platform_allow:


### PR DESCRIPTION
Add the overlay file to configure the stm32h7s78_dk disco kit for running the tests/drivers/spi/spi_loopback Connect D11 and D12 of CN15 arduino connector
to PASS the test on spi4