### PR TITLE
doc: dts: Link Linux binding guidelines.

### DIFF
--- a/doc/build/dts/bindings-upstream.rst
+++ b/doc/build/dts/bindings-upstream.rst
@@ -41,6 +41,12 @@ In particular, this rule applies if:
 General rules
 *************
 
+Wherever possible, when writing Devicetree bindings for Zephyr, try to follow
+the same `design guidelines laid out by Linux`_.
+
+.. _design guidelines laid out by Linux:
+   https://docs.kernel.org/devicetree/bindings/writing-bindings.html
+
 File names
 ==========
 


### PR DESCRIPTION
The Linux binding DO's and DONT's about designing DT bindings pretty much all apply to Zephyr as well, and a lot of these issues come up in reviews in Zephyr, which is the reason that Linux has this page in the first place, to list common binding review topics.