### PR TITLE
drivers: crypto: Add support for STM32L4 AES accelerator

### DIFF
--- a/boards/st/nucleo_l4a6zg/nucleo_l4a6zg.dts
+++ b/boards/st/nucleo_l4a6zg/nucleo_l4a6zg.dts
@@ -141,3 +141,7 @@
 &wwdg {
 	status = "okay";
 };
+
+&aes {
+	status = "okay";
+};

--- a/drivers/crypto/crypto_stm32_priv.h
+++ b/drivers/crypto/crypto_stm32_priv.h
@@ -8,6 +8,12 @@
 #ifndef ZEPHYR_DRIVERS_CRYPTO_CRYPTO_STM32_PRIV_H_
 #define ZEPHYR_DRIVERS_CRYPTO_CRYPTO_STM32_PRIV_H_
 
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32l4_aes)
+#define crypt_config_t CRYP_InitTypeDef
+#else
+#define crypt_config_t CRYP_ConfigTypeDef
+#endif
+
 /* Maximum supported key length is 256 bits */
 #define CRYPTO_STM32_AES_MAX_KEY_LEN (256 / 8)
 
@@ -23,7 +29,7 @@ struct crypto_stm32_data {
 };
 
 struct crypto_stm32_session {
-	CRYP_ConfigTypeDef config;
+	crypt_config_t config;
 	uint32_t key[CRYPTO_STM32_AES_MAX_KEY_LEN / sizeof(uint32_t)];
 	bool in_use;
 };

--- a/dts/arm/st/l4/stm32l422.dtsi
+++ b/dts/arm/st/l4/stm32l422.dtsi
@@ -11,7 +11,7 @@
 		compatible = "st,stm32l422", "st,stm32l4", "simple-bus";
 
 		aes: aes@50060000 {
-			compatible = "st,stm32-aes";
+			compatible = "st,stm32l4-aes", "st,stm32-aes";
 			reg = <0x50060000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00010000>;
 			resets = <&rctl STM32_RESET(AHB2, 16U)>;

--- a/dts/arm/st/l4/stm32l462.dtsi
+++ b/dts/arm/st/l4/stm32l462.dtsi
@@ -11,7 +11,7 @@
 		compatible = "st,stm32l462", "st,stm32l4", "simple-bus";
 
 		aes: aes@50060000 {
-			compatible = "st,stm32-aes";
+			compatible = "st,stm32l4-aes", "st,stm32-aes";
 			reg = <0x50060000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00010000>;
 			resets = <&rctl STM32_RESET(AHB2, 16U)>;

--- a/dts/arm/st/l4/stm32l486.dtsi
+++ b/dts/arm/st/l4/stm32l486.dtsi
@@ -9,5 +9,15 @@
 / {
 	soc {
 		compatible = "st,stm32l486", "st,stm32l4", "simple-bus";
+
+		aes: aes@50060000 {
+			compatible = "st,stm32l4-aes", "st,stm32-aes";
+			reg = <0x50060000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00010000>;
+			resets = <&rctl STM32_RESET(AHB2, 16U)>;
+			interrupts = <79 0>;
+			interrupt-names = "aes";
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/st/l4/stm32l496.dtsi
+++ b/dts/arm/st/l4/stm32l496.dtsi
@@ -60,16 +60,6 @@
 			status = "disabled";
 		};
 
-		aes: aes@50060000 {
-			compatible = "st,stm32-aes";
-			reg = <0x50060000 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00010000>;
-			resets = <&rctl STM32_RESET(AHB2, 16U)>;
-			interrupts = <79 0>;
-			interrupt-names = "aes";
-			status = "disabled";
-		};
-
 		usbotg_fs: otgfs@50000000 {
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00001000>,
 				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;

--- a/dts/arm/st/l4/stm32l4a6.dtsi
+++ b/dts/arm/st/l4/stm32l4a6.dtsi
@@ -9,5 +9,15 @@
 / {
 	soc {
 		compatible = "st,stm32l4a6", "st,stm32l4", "simple-bus";
+
+		aes: aes@50060000 {
+			compatible = "st,stm32l4-aes", "st,stm32-aes";
+			reg = <0x50060000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00010000>;
+			resets = <&rctl STM32_RESET(AHB2, 16U)>;
+			interrupts = <79 0>;
+			interrupt-names = "aes";
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/st/l4/stm32l4p5.dtsi
+++ b/dts/arm/st/l4/stm32l4p5.dtsi
@@ -294,16 +294,6 @@
 			status = "disabled";
 		};
 
-		aes: aes@50060000 {
-			compatible = "st,stm32-aes";
-			reg = <0x50060000 0x400>;
-			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00010000>;
-			resets = <&rctl STM32_RESET(AHB2, 16U)>;
-			interrupts = <79 0>;
-			interrupt-names = "aes";
-			status = "disabled";
-		};
-
 		usbotg_fs: otgfs@50000000 {
 			compatible = "st,stm32-otgfs";
 			reg = <0x50000000 0x40000>;

--- a/dts/arm/st/l4/stm32l4q5.dtsi
+++ b/dts/arm/st/l4/stm32l4q5.dtsi
@@ -9,5 +9,15 @@
 / {
 	soc {
 		compatible = "st,stm32l4q5", "st,stm32l4", "simple-bus";
+
+		aes: aes@50060000 {
+			compatible = "st,stm32l4-aes", "st,stm32-aes";
+			reg = <0x50060000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00010000>;
+			resets = <&rctl STM32_RESET(AHB2, 16U)>;
+			interrupts = <79 0>;
+			interrupt-names = "aes";
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/st/l4/stm32l4s5.dtsi
+++ b/dts/arm/st/l4/stm32l4s5.dtsi
@@ -9,5 +9,15 @@
 / {
 	soc {
 		compatible = "st,stm32l4s5", "st,stm32l4", "simple-bus";
+
+		aes: aes@50060000 {
+			compatible = "st,stm32l4-aes", "st,stm32-aes";
+			reg = <0x50060000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00010000>;
+			resets = <&rctl STM32_RESET(AHB2, 16U)>;
+			interrupts = <79 0>;
+			interrupt-names = "aes";
+			status = "disabled";
+		};
 	};
 };

--- a/dts/bindings/crypto/st,stm32l4-aes.yaml
+++ b/dts/bindings/crypto/st,stm32l4-aes.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2024, Lucas Dietrich
+# SPDX-License-Identifier: Apache-2.0
+
+description: STM32L4 AES Accelerator
+
+compatible: "st,stm32l4-aes"
+
+include: st,stm32-crypto-common.yaml


### PR DESCRIPTION
The STM32L4 series features an AES accelerator with differences in the HAL API compared to other STM32 devices. This patch adds support for the STM32L4 AES accelerator in the STM32 crypto driver.

Key changes:

- Introduce a new device type `st,stm32l4-aes` to represent the STM32L4 AES accelerator variant. Add the device tree binding file `st,stm32l4-aes.yaml` and update `stm32l462.dtsi` accordingly.
- Modify `crypto_stm32.c` to handle the differences in the HAL API:
  - Use specific HAL functions for encryption and decryption (e.g., `HAL_CRYP_AESECB_Encrypt`) when building for STM32L4 AES.
  - Adjust the initialization and configuration structures accordingly.
  - Replace `copy_reverse_words` with `copy_words_adjust_endianness` to handle endianness conversion only when necessary.

The driver has been successfully tested with the `crypto` sample on a custom board based on the STM32L462RE.

---

Related to issue #78482