### PR TITLE
shell: kernel_service: heap: add required header

### DIFF
--- a/subsys/shell/modules/kernel_service/heap.c
+++ b/subsys/shell/modules/kernel_service/heap.c
@@ -6,6 +6,8 @@
  */
 
 #if K_HEAP_MEM_POOL_SIZE > 0
+#include "kernel_shell.h"
+
 #include <zephyr/sys/sys_heap.h>
 
 extern struct sys_heap _system_heap;


### PR DESCRIPTION
Add the "kernel_shell.h" header which is required but missing, causing build error.

Fixes #78668