### PR TITLE
scripts: twister: Don't use match/case statements

### DIFF
--- a/scripts/pylib/twister/twisterlib/statuses.py
+++ b/scripts/pylib/twister/twisterlib/statuses.py
@@ -23,18 +23,17 @@ class TwisterStatus(str, Enum):
 
     @staticmethod
     def get_color(status: TwisterStatus) -> str:
-        match(status):
-            case TwisterStatus.PASS:
-                color = Fore.GREEN
-            case TwisterStatus.SKIP | TwisterStatus.FILTER | TwisterStatus.BLOCK:
-                color = Fore.YELLOW
-            case TwisterStatus.FAIL | TwisterStatus.ERROR:
-                color = Fore.RED
-            case TwisterStatus.STARTED | TwisterStatus.NONE:
-                color = Fore.MAGENTA
-            case _:
-                color = Fore.RESET
-        return color
+        status2color = {
+            TwisterStatus.PASS: Fore.GREEN,
+            TwisterStatus.SKIP: Fore.YELLOW,
+            TwisterStatus.FILTER: Fore.YELLOW,
+            TwisterStatus.BLOCK: Fore.YELLOW,
+            TwisterStatus.FAIL: Fore.RED,
+            TwisterStatus.ERROR: Fore.RED,
+            TwisterStatus.STARTED: Fore.MAGENTA,
+            TwisterStatus.NONE: Fore.MAGENTA
+        }
+        return status2color[status] if status in status2color else Fore.RESET
 
     # All statuses below this comment can be used for TestCase
     BLOCK = 'blocked'


### PR DESCRIPTION
Don't use match/case syntax to allow twister run with python3 versions < 3.10.

To avoid confusing SyntaxError after recent #78345 with older python3 despite Zephyr [requires min 3.10](https://docs.zephyrproject.org/latest/develop/getting_started/index.html#install-dependencies).
```
$ ./scripts/twister --help
Traceback (most recent call last):
  File "./scripts/twister", line 207, in <module>
    from twisterlib.twister_main import main
  File "zephyr/scripts/pylib/twister/twisterlib/twister_main.py", line 16, in <module>
    from twisterlib.statuses import TwisterStatus
  File "zephyr/scripts/pylib/twister/twisterlib/statuses.py", line 26
    match(status):
                 ^
SyntaxError: invalid syntax
```