### PR TITLE
github: workflows: Add cargo support to twister workflow

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -188,6 +188,7 @@ jobs:
             git log  --pretty=oneline | head -n 10
           fi
           echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
           west init -l . || true
           west config manifest.group-filter -- +ci,+optional
@@ -201,6 +202,8 @@ jobs:
         run: |
           cmake --version
           gcc --version
+          cargo --version
+          rustup target list --installed
           ls -la
           echo "github.ref: ${{ github.ref }}"
           echo "github.base_ref: ${{ github.base_ref }}"


### PR DESCRIPTION
This PR adds support to testing Rust applications in CI. The referenced docker image already contains support for the rust toolchain, and the needed targets. This change merely adds this toolchain to the path so that subsequent cmake changes can run these tests.

This PR has to be separate from any changes that bring in Rust support, as the twister workflow in CI is run from 'main', not from the branch.