### PR TITLE
tests: drivers: build_all: sensor: Add emulator testcase

### DIFF
--- a/tests/drivers/build_all/sensor/testcase.yaml
+++ b/tests/drivers/build_all/sensor/testcase.yaml
@@ -24,6 +24,12 @@ tests:
     extra_args: OVERLAY_CONFIG=sensors_die_temp.conf
     extra_configs:
       - CONFIG_UART_INTERRUPT_DRIVEN=y
+  sensors.build.emul:
+    tags: sensors
+    extra_args: OVERLAY_CONFIG=sensors_die_temp.conf
+    extra_configs:
+      - CONFIG_UART_INTERRUPT_DRIVEN=y
+      - CONFIG_EMUL=y
   sensors.build.pm:
     extra_configs:
       - CONFIG_PM=y


### PR DESCRIPTION
Some sensor implementation provides an emulator.
Add a test case that enables the CONFIG_EMUL to test these.