### PR TITLE
drivers: intc: plic: implement irq affinity configuration

### DIFF
--- a/arch/riscv/core/smp.c
+++ b/arch/riscv/core/smp.c
@@ -74,7 +74,11 @@ void arch_secondary_cpu_init(int hartid)
 #endif
 #ifdef CONFIG_SMP
 	irq_enable(RISCV_IRQ_MSOFT);
-#endif
+#ifdef CONFIG_PLIC_IRQ_AFFINITY
+	/* Enable on secondary cores so that they can respond to PLIC */
+	irq_enable(RISCV_IRQ_MEXT);
+#endif /* CONFIG_PLIC_IRQ_AFFINITY */
+#endif /* CONFIG_SMP */
 	riscv_cpu_init[cpu_num].fn(riscv_cpu_init[cpu_num].arg);
 }
 

--- a/drivers/interrupt_controller/Kconfig.plic
+++ b/drivers/interrupt_controller/Kconfig.plic
@@ -13,11 +13,43 @@ config PLIC
 
 if PLIC
 
+config PLIC_IRQ_AFFINITY
+	bool "Configure IRQ affinity"
+	depends on SMP
+	depends on MP_MAX_NUM_CPUS > 1
+	help
+	  Enable configuration of IRQ affinity.
+
+config PLIC_IRQ_AFFINITY_MASK
+	hex "Default IRQ affinity mask"
+	depends on PLIC_IRQ_AFFINITY
+	default 0x1
+	help
+	  Default mask for the driver when IRQ affinity is enabled.
+
 config PLIC_SHELL
 	bool "PLIC shell commands"
 	depends on SHELL
 	help
 	  Enable additional shell commands useful for debugging.
 	  Caution: This can use quite a bit of RAM (PLICs * IRQs * sizeof(uint16_t)).
+
+if PLIC_SHELL
+
+config PLIC_SHELL_IRQ_COUNT
+	bool "IRQ count shell commands"
+	default y
+	help
+	  Records the number of hits per interrupt line and provide shell commands to access them.
+	  Caution: This can use quite a bit of RAM (PLICs * IRQs * sizeof(PLIC_IRQ_COUNT_TYPE)).
+
+config PLIC_SHELL_IRQ_AFFINITY
+	bool "Shell commands to configure IRQ affinity"
+	default y
+	depends on PLIC_IRQ_AFFINITY
+	help
+	  Provide shell commands to configure IRQ affinity in runtime.
+
+endif # PLIC_SHELL
 
 endif # PLIC

--- a/drivers/interrupt_controller/intc_plic.c
+++ b/drivers/interrupt_controller/intc_plic.c
@@ -70,6 +70,18 @@
 #define INTC_PLIC_STATIC_INLINE static inline
 #endif /* CONFIG_TEST_INTC_PLIC */
 
+#ifdef CONFIG_PLIC_IRQ_AFFINITY
+#if CONFIG_MP_MAX_NUM_CPUS <= 8
+typedef uint8_t plic_cpumask_t;
+#elif CONFIG_MP_MAX_NUM_CPUS <= 16
+typedef uint16_t plic_cpumask_t;
+#elif CONFIG_MP_MAX_NUM_CPUS <= 32
+typedef uint32_t plic_cpumask_t;
+#else
+#error "Currently only supports up to 32 cores"
+#endif /* CONFIG_MP_MAX_NUM_CPUS */
+#endif /* CONFIG_PLIC_IRQ_AFFINITY */
+
 typedef void (*riscv_plic_irq_config_func_t)(void);
 struct plic_config {
 	mem_addr_t prio;
@@ -77,7 +89,11 @@ struct plic_config {
 	mem_addr_t reg;
 	mem_addr_t trig;
 	uint32_t max_prio;
-	uint32_t num_irqs;
+	/* Number of IRQs that the PLIC physically supports */
+	uint32_t riscv_ndev;
+	/* Number of IRQs supported in this driver */
+	uint32_t nr_irqs;
+	uint32_t irq;
 	riscv_plic_irq_config_func_t irq_config_func;
 	struct _isr_table_entry *isr_table;
 	const uint32_t *const hart_context;
@@ -89,11 +105,19 @@ struct plic_stats {
 };
 
 struct plic_data {
+
+#ifdef CONFIG_PLIC_SHELL_IRQ_COUNT
 	struct plic_stats stats;
+#endif /* CONFIG_PLIC_SHELL_IRQ_COUNT */
+
+#ifdef CONFIG_PLIC_IRQ_AFFINITY
+	plic_cpumask_t *irq_cpumask;
+#endif /* CONFIG_PLIC_IRQ_AFFINITY */
+
 };
 
-static uint32_t save_irq;
-static const struct device *save_dev;
+static uint32_t save_irq[CONFIG_MP_MAX_NUM_CPUS];
+static const struct device *save_dev[CONFIG_MP_MAX_NUM_CPUS];
 
 INTC_PLIC_STATIC_INLINE uint32_t local_irq_to_reg_index(uint32_t local_irq)
 {
@@ -109,7 +133,7 @@ static inline uint32_t get_plic_enabled_size(const struct device *dev)
 {
 	const struct plic_config *config = dev->config;
 
-	return local_irq_to_reg_index(config->num_irqs) + 1;
+	return local_irq_to_reg_index(config->nr_irqs) + 1;
 }
 
 static ALWAYS_INLINE uint32_t get_hart_context(const struct device *dev, uint32_t hartid)
@@ -117,6 +141,20 @@ static ALWAYS_INLINE uint32_t get_hart_context(const struct device *dev, uint32_
 	const struct plic_config *config = dev->config;
 
 	return config->hart_context[hartid];
+}
+
+static ALWAYS_INLINE uint32_t get_irq_cpumask(const struct device *dev, uint32_t local_irq)
+{
+#ifdef CONFIG_PLIC_IRQ_AFFINITY
+	const struct plic_data *data = dev->data;
+
+	return data->irq_cpumask[local_irq];
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(local_irq);
+
+	return 0x1;
+#endif /* CONFIG_PLIC_IRQ_AFFINITY */
 }
 
 static inline mem_addr_t get_context_en_addr(const struct device *dev, uint32_t cpu_num)
@@ -131,7 +169,7 @@ static inline mem_addr_t get_context_en_addr(const struct device *dev, uint32_t 
 #else
 	hartid = arch_proc_id();
 #endif
-	return  config->irq_en + get_hart_context(dev, hartid) * CONTEXT_ENABLE_SIZE;
+	return config->irq_en + get_hart_context(dev, hartid) * CONTEXT_ENABLE_SIZE;
 }
 
 static inline mem_addr_t get_claim_complete_addr(const struct device *dev)
@@ -142,10 +180,8 @@ static inline mem_addr_t get_claim_complete_addr(const struct device *dev)
 	 * We want to return the claim complete addr for the hart's context.
 	 */
 
-	return config->reg + get_hart_context(dev, arch_proc_id()) * CONTEXT_SIZE +
-	       CONTEXT_CLAIM;
+	return config->reg + get_hart_context(dev, arch_proc_id()) * CONTEXT_SIZE + CONTEXT_CLAIM;
 }
-
 
 static inline mem_addr_t get_threshold_priority_addr(const struct device *dev, uint32_t cpu_num)
 {
@@ -159,6 +195,13 @@ static inline mem_addr_t get_threshold_priority_addr(const struct device *dev, u
 #endif
 
 	return config->reg + (get_hart_context(dev, hartid) * CONTEXT_SIZE);
+}
+
+static ALWAYS_INLINE uint32_t local_irq_to_irq(const struct device *dev, uint32_t local_irq)
+{
+	const struct plic_config *config = dev->config;
+
+	return irq_to_level_2(local_irq) | config->irq;
 }
 
 /**
@@ -213,7 +256,8 @@ static void plic_irq_enable_set_state(uint32_t irq, bool enable)
 		uint32_t en_value;
 
 		en_value = sys_read32(en_addr);
-		WRITE_BIT(en_value, local_irq & PLIC_REG_MASK, enable);
+		WRITE_BIT(en_value, local_irq & PLIC_REG_MASK,
+			  enable ? (get_irq_cpumask(dev, local_irq) & BIT(cpu_num)) != 0 : false);
 		sys_write32(en_value, en_addr);
 	}
 }
@@ -267,15 +311,27 @@ void riscv_plic_irq_disable(uint32_t irq)
 int riscv_plic_irq_is_enabled(uint32_t irq)
 {
 	const struct device *dev = get_plic_dev_from_irq(irq);
-	const struct plic_config *config = dev->config;
 	const uint32_t local_irq = irq_from_level_2(irq);
-	mem_addr_t en_addr = config->irq_en + local_irq_to_reg_offset(local_irq);
+	uint32_t bit_position = local_irq & PLIC_REG_MASK;
 	uint32_t en_value;
+	int is_enabled = IS_ENABLED(CONFIG_PLIC_IRQ_AFFINITY) ? 0 : 1;
+	uint32_t key = irq_lock();
 
-	en_value = sys_read32(en_addr);
-	en_value &= BIT(local_irq & PLIC_REG_MASK);
+	for (uint32_t cpu_num = 0; cpu_num < arch_num_cpus(); cpu_num++) {
+		mem_addr_t en_addr =
+			get_context_en_addr(dev, cpu_num) + local_irq_to_reg_offset(local_irq);
 
-	return !!en_value;
+		en_value = sys_read32(en_addr);
+		if (IS_ENABLED(CONFIG_PLIC_IRQ_AFFINITY)) {
+			is_enabled |= !!(en_value & BIT(bit_position));
+		} else {
+			is_enabled &= !!(en_value & BIT(bit_position));
+		}
+	}
+
+	irq_unlock(key);
+
+	return is_enabled;
 }
 
 /**
@@ -314,13 +370,97 @@ void riscv_plic_set_priority(uint32_t irq, uint32_t priority)
  */
 unsigned int riscv_plic_get_irq(void)
 {
-	return save_irq;
+	return save_irq[arch_proc_id()];
 }
 
+/**
+ * @brief Get riscv PLIC causing an interrupt
+ *
+ * This routine returns the RISCV PLIC device causing an interrupt.
+ *
+ * @return PLIC device causing an interrupt.
+ */
 const struct device *riscv_plic_get_dev(void)
 {
-	return save_dev;
+	return save_dev[arch_proc_id()];
 }
+
+#ifdef CONFIG_PLIC_IRQ_AFFINITY
+/**
+ * @brief Set riscv PLIC-specific interrupt enable by cpu bitmask
+ *
+ * @param irq IRQ number for which to set smp irq affinity
+ * @param cpumask Bitmask to specific which cores can handle IRQ
+ */
+int riscv_plic_irq_set_affinity(uint32_t irq, uint32_t cpumask)
+{
+	const struct device *dev = get_plic_dev_from_irq(irq);
+	const struct plic_data *data = dev->data;
+	__maybe_unused const struct plic_config *config = dev->config;
+	const uint32_t local_irq = irq_from_level_2(irq);
+
+	if (local_irq >= config->nr_irqs) {
+		__ASSERT(false, "overflow: irq %d, local_irq %d", irq, local_irq);
+		return -EINVAL;
+	}
+
+	if ((cpumask & ~BIT_MASK(arch_num_cpus())) != 0) {
+		__ASSERT(false, "cpumask: 0x%X", cpumask);
+		return -EINVAL;
+	}
+
+	uint32_t key = irq_lock();
+
+	/* Updated irq_cpumask for next time setting plic enable register */
+	data->irq_cpumask[local_irq] = (plic_cpumask_t)cpumask;
+
+	/* If irq is enabled, apply the new irq affinity */
+	if (riscv_plic_irq_is_enabled(irq)) {
+		riscv_plic_irq_enable(irq);
+	}
+
+	irq_unlock(key);
+
+	return 0;
+}
+#endif /* CONFIG_PLIC_IRQ_AFFINITY */
+
+#ifdef CONFIG_PLIC_SHELL_IRQ_COUNT
+/**
+ * If there's more than one core, irq_count points to a 2D-array: irq_count[NUM_CPUs + 1][nr_irqs]
+ *
+ *    i.e. NUM_CPUs == 2:
+ *      CPU 0    [0 ... nr_irqs - 1]
+ *      CPU 1    [0 ... nr_irqs - 1]
+ *      TOTAL    [0 ... nr_irqs - 1]
+ */
+static ALWAYS_INLINE uint16_t *get_irq_hit_count_cpu(const struct device *dev, int cpu,
+						     uint32_t local_irq)
+{
+	const struct plic_config *config = dev->config;
+	const struct plic_data *data = dev->data;
+	uint32_t offset = local_irq;
+
+	if (CONFIG_MP_MAX_NUM_CPUS > 1) {
+		offset = cpu * config->nr_irqs + local_irq;
+	}
+
+	return &data->stats.irq_count[offset];
+}
+
+static ALWAYS_INLINE uint16_t *get_irq_hit_count_total(const struct device *dev, uint32_t local_irq)
+{
+	const struct plic_config *config = dev->config;
+	const struct plic_data *data = dev->data;
+	uint32_t offset = local_irq;
+
+	if (CONFIG_MP_MAX_NUM_CPUS > 1) {
+		offset = arch_num_cpus() * config->nr_irqs + local_irq;
+	}
+
+	return &data->stats.irq_count[offset];
+}
+#endif /* CONFIG_PLIC_SHELL_IRQ_COUNT */
 
 static void plic_irq_handler(const struct device *dev)
 {
@@ -328,19 +468,34 @@ static void plic_irq_handler(const struct device *dev)
 	mem_addr_t claim_complete_addr = get_claim_complete_addr(dev);
 	struct _isr_table_entry *ite;
 	uint32_t __maybe_unused trig_val;
-
+	uint32_t cpu_id = arch_proc_id();
 	/* Get the IRQ number generating the interrupt */
 	const uint32_t local_irq = sys_read32(claim_complete_addr);
 
-#ifdef CONFIG_PLIC_SHELL
-	const struct plic_data *data = dev->data;
-	struct plic_stats stat = data->stats;
+#ifdef CONFIG_PLIC_SHELL_IRQ_COUNT
+	uint16_t *cpu_count = get_irq_hit_count_cpu(dev, cpu_id, local_irq);
+	uint16_t *total_count = get_irq_hit_count_total(dev, local_irq);
 
 	/* Cap the count at __UINT16_MAX__ */
-	if (stat.irq_count[local_irq] != __UINT16_MAX__) {
-		stat.irq_count[local_irq]++;
+	if (*total_count < __UINT16_MAX__) {
+		(*cpu_count)++;
+		if (CONFIG_MP_MAX_NUM_CPUS > 1) {
+			(*total_count)++;
+		}
 	}
-#endif /* CONFIG_PLIC_SHELL */
+#endif /* CONFIG_PLIC_SHELL_IRQ_COUNT */
+
+	/*
+	 * Note: Because PLIC only supports multicast of interrupt, all enabled
+	 * targets will receive interrupt notification. Only the fastest target
+	 * will claim this interrupt, and other targets will claim ID 0 if
+	 * no other pending interrupt now.
+	 *
+	 * (by RISC-V Privileged Architecture v1.10)
+	 */
+	if (IS_ENABLED(CONFIG_SMP) && (local_irq == 0U)) {
+		return;
+	}
 
 	/*
 	 * Save IRQ in save_irq. To be used, if need be, by
@@ -348,14 +503,14 @@ static void plic_irq_handler(const struct device *dev)
 	 * as IRQ number held by the claim_complete register is
 	 * cleared upon read.
 	 */
-	save_irq = local_irq;
-	save_dev = dev;
+	save_irq[cpu_id] = local_irq;
+	save_dev[cpu_id] = dev;
 
 	/*
 	 * If the IRQ is out of range, call z_irq_spurious.
 	 * A call to z_irq_spurious will not return.
 	 */
-	if (local_irq == 0U || local_irq >= config->num_irqs) {
+	if ((local_irq == 0U) || (local_irq >= config->nr_irqs)) {
 		z_irq_spurious(NULL);
 	}
 
@@ -417,7 +572,7 @@ static int plic_init(const struct device *dev)
 	}
 
 	/* Set priority of each interrupt line to 0 initially */
-	for (uint32_t i = 0; i < config->num_irqs; i++) {
+	for (uint32_t i = 0; i < config->nr_irqs; i++) {
 		sys_write32(0U, prio_addr + (i * sizeof(uint32_t)));
 	}
 
@@ -442,7 +597,8 @@ static inline int parse_device(const struct shell *sh, size_t argc, char *argv[]
 	return 0;
 }
 
-static int cmd_get_stats(const struct shell *sh, size_t argc, char *argv[])
+#ifdef CONFIG_PLIC_SHELL_IRQ_COUNT
+static int cmd_stats_get(const struct shell *sh, size_t argc, char *argv[])
 {
 	const struct device *dev;
 	int ret = parse_device(sh, argc, argv, &dev);
@@ -453,35 +609,60 @@ static int cmd_get_stats(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	const struct plic_config *config = dev->config;
-	const struct plic_data *data = dev->data;
-	struct plic_stats stat = data->stats;
 
 	if (argc > 2) {
-		min_hit = (uint16_t)atoi(argv[2]);
+		min_hit = (uint16_t)shell_strtoul(argv[2], 10, &ret);
+		if (ret != 0) {
+			shell_error(sh, "Failed to parse %s: %d", argv[2], ret);
+			return ret;
+		}
 		shell_print(sh, "IRQ line with > %d hits:", min_hit);
 	}
 
-	shell_print(sh, "   IRQ        Hits\tISR(ARG)");
-	for (int i = 0; i < stat.irq_count_len; i++) {
-		if (stat.irq_count[i] > min_hit) {
-#ifdef CONFIG_SYMTAB
-			const char *name =
-				symtab_find_symbol_name((uintptr_t)config->isr_table[i].isr, NULL);
+	shell_fprintf(sh, SHELL_NORMAL, "   IRQ");
+	for (int cpu_id = 0; cpu_id < arch_num_cpus(); cpu_id++) {
+		shell_fprintf(sh, SHELL_NORMAL, "  CPU%2d", cpu_id);
+	}
+	if (CONFIG_MP_MAX_NUM_CPUS > 1) {
+		shell_fprintf(sh, SHELL_NORMAL, "  Total");
+	}
+	shell_fprintf(sh, SHELL_NORMAL, "\tISR(ARG)\n");
 
-			shell_print(sh, "  %4d  %10d\t%s(%p)", i, stat.irq_count[i], name,
-				    config->isr_table[i].arg);
-#else
-			shell_print(sh, "  %4d  %10d\t%p(%p)", i, stat.irq_count[i],
-				    (void *)config->isr_table[i].isr, config->isr_table[i].arg);
-#endif /* CONFIG_SYMTAB */
+	for (int i = 0; i < config->nr_irqs; i++) {
+		uint16_t *total_count = get_irq_hit_count_total(dev, i);
+
+		if (*total_count <= min_hit) {
+			/* Skips printing if total_hit is lesser than min_hit */
+			continue;
 		}
+
+		shell_fprintf(sh, SHELL_NORMAL, "  %4d", i); /* IRQ number */
+		/* Print the IRQ hit counts on each CPU */
+		for (int cpu_id = 0; cpu_id < arch_num_cpus(); cpu_id++) {
+			uint16_t *cpu_count = get_irq_hit_count_cpu(dev, cpu_id, i);
+
+			shell_fprintf(sh, SHELL_NORMAL, "  %5d", *cpu_count);
+		}
+		if (CONFIG_MP_MAX_NUM_CPUS > 1) {
+			/* If there's > 1 CPU, print the total hit count at the end */
+			shell_fprintf(sh, SHELL_NORMAL, "  %5d", *total_count);
+		}
+#ifdef CONFIG_SYMTAB
+		const char *name =
+			symtab_find_symbol_name((uintptr_t)config->isr_table[i].isr, NULL);
+
+		shell_fprintf(sh, SHELL_NORMAL, "\t%s(%p)\n", name, config->isr_table[i].arg);
+#else
+		shell_fprintf(sh, SHELL_NORMAL, "\t%p(%p)\n", (void *)config->isr_table[i].isr,
+			      config->isr_table[i].arg);
+#endif /* CONFIG_SYMTAB */
 	}
 	shell_print(sh, "");
 
 	return 0;
 }
 
-static int cmd_clear_stats(const struct shell *sh, size_t argc, char *argv[])
+static int cmd_stats_clear(const struct shell *sh, size_t argc, char *argv[])
 {
 	const struct device *dev;
 	int ret = parse_device(sh, argc, argv, &dev);
@@ -491,19 +672,111 @@ static int cmd_clear_stats(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	const struct plic_data *data = dev->data;
+	const struct plic_config *config = dev->config;
 	struct plic_stats stat = data->stats;
 
-	memset(stat.irq_count, 0, stat.irq_count_len * sizeof(uint16_t));
+	memset(stat.irq_count, 0,
+	       config->nr_irqs *
+		       COND_CODE_1(CONFIG_MP_MAX_NUM_CPUS, (1),
+				   (UTIL_INC(CONFIG_MP_MAX_NUM_CPUS))) *
+		       sizeof(uint16_t));
 
 	shell_print(sh, "Cleared stats of %s.\n", dev->name);
 
 	return 0;
 }
+#endif /* CONFIG_PLIC_SHELL_IRQ_COUNT */
+
+#ifdef CONFIG_PLIC_SHELL_IRQ_AFFINITY
+static int cmd_affinity_set(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+
+	uint32_t local_irq, irq, mask;
+	const struct device *dev;
+	int rc = parse_device(sh, argc, argv, &dev);
+	const struct plic_config *config = dev->config;
+
+	if (rc != 0) {
+		return rc;
+	}
+
+	local_irq = (uint32_t)shell_strtol(argv[2], 10, &rc);
+	if (rc != 0) {
+		shell_error(sh, "Failed to parse %s: %d", argv[2], rc);
+	}
+
+	if (local_irq >= config->nr_irqs) {
+		shell_error(sh, "local_irq (%d) > nr_irqs (%d)", local_irq, config->nr_irqs);
+		return -EINVAL;
+	}
+
+	mask = (uint32_t)shell_strtol(argv[3], 16, &rc);
+	if (rc != 0) {
+		shell_error(sh, "Failed to parse %s: %d", argv[3], rc);
+	}
+
+	if ((mask & ~BIT_MASK(arch_num_cpus())) != 0) {
+		shell_error(sh, "cpumask: 0x%X num_cpus: %d", mask, arch_num_cpus());
+		return -EINVAL;
+	}
+
+	if (local_irq != 0) {
+		irq = local_irq_to_irq(dev, local_irq);
+		riscv_plic_irq_set_affinity(irq, mask);
+		shell_print(sh, "IRQ %d affinity set to 0x%X", local_irq, mask);
+	} else {
+		for (local_irq = 1; local_irq <= config->nr_irqs; local_irq++) {
+			irq = local_irq_to_irq(dev, local_irq);
+			riscv_plic_irq_set_affinity(irq, mask);
+		}
+		shell_print(sh, "All IRQ affinity set to 0x%X", mask);
+	}
+
+	return 0;
+}
+
+static int cmd_affinity_get(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+
+	const struct device *dev;
+	int rc = parse_device(sh, argc, argv, &dev);
+	const struct plic_config *config = dev->config;
+
+	if (rc != 0) {
+		return rc;
+	}
+
+	shell_print(sh, " IRQ  MASK");
+	if (argc == 2) {
+		for (uint32_t local_irq = 0; local_irq < config->nr_irqs; local_irq++) {
+			shell_print(sh, "%4d  0x%X", local_irq, get_irq_cpumask(dev, local_irq));
+		}
+	} else {
+		uint32_t local_irq = (uint32_t)shell_strtol(argv[2], 10, &rc);
+
+		if (rc != 0) {
+			shell_error(sh, "Failed to parse %s: %d", argv[2], rc);
+		}
+
+		if (local_irq >= config->nr_irqs) {
+			shell_error(sh, "local_irq (%d) > nr_irqs (%d)", local_irq,
+				    config->nr_irqs);
+			return -EINVAL;
+		}
+
+		shell_print(sh, "%4d  0x%X", local_irq, get_irq_cpumask(dev, local_irq));
+	}
+
+	return 0;
+}
+#endif /* CONFIG_PLIC_SHELL_IRQ_AFFINITY */
 
 /* Device name autocompletion support */
 static void device_name_get(size_t idx, struct shell_static_entry *entry)
 {
-	const struct device *dev = shell_device_lookup(idx, NULL);
+	const struct device *dev = shell_device_lookup(idx, "interrupt-controller");
 
 	entry->syntax = (dev != NULL) ? dev->name : NULL;
 	entry->handler = NULL;
@@ -513,50 +786,81 @@ static void device_name_get(size_t idx, struct shell_static_entry *entry)
 
 SHELL_DYNAMIC_CMD_CREATE(dsub_device_name, device_name_get);
 
+#ifdef CONFIG_PLIC_SHELL_IRQ_COUNT
 SHELL_STATIC_SUBCMD_SET_CREATE(plic_stats_cmds,
 	SHELL_CMD_ARG(get, &dsub_device_name,
 		"Read PLIC's stats.\n"
 		"Usage: plic stats get <device> [minimum hits]",
-		cmd_get_stats, 2, 1),
+		cmd_stats_get, 2, 1),
 	SHELL_CMD_ARG(clear, &dsub_device_name,
 		"Reset PLIC's stats.\n"
 		"Usage: plic stats clear <device>",
-		cmd_clear_stats, 2, 0),
+		cmd_stats_clear, 2, 0),
 	SHELL_SUBCMD_SET_END
 );
+#endif /* CONFIG_PLIC_SHELL_IRQ_COUNT */
+
+#ifdef CONFIG_PLIC_SHELL_IRQ_AFFINITY
+SHELL_STATIC_SUBCMD_SET_CREATE(plic_affinity_cmds,
+	SHELL_CMD_ARG(set, &dsub_device_name,
+		      "Set IRQ affinity.\n"
+		      "Usage: plic affinity set <device> <local_irq> <cpumask>",
+		      cmd_affinity_set, 4, 0),
+	SHELL_CMD_ARG(get, &dsub_device_name,
+		      "Get IRQ affinity.\n"
+		      "Usage: plic affinity get <device> <local_irq>",
+		      cmd_affinity_get, 2, 1),
+	SHELL_SUBCMD_SET_END);
+#endif /* CONFIG_PLIC_SHELL_IRQ_AFFINITY */
 
 SHELL_STATIC_SUBCMD_SET_CREATE(plic_cmds,
-	SHELL_CMD_ARG(stats, &plic_stats_cmds, "PLIC stats", NULL, 3, 0),
+#ifdef CONFIG_PLIC_SHELL_IRQ_COUNT
+	SHELL_CMD(stats, &plic_stats_cmds, "IRQ stats", NULL),
+#endif /* CONFIG_PLIC_SHELL_IRQ_COUNT */
+#ifdef CONFIG_PLIC_SHELL_IRQ_AFFINITY
+	SHELL_CMD(affinity, &plic_affinity_cmds, "IRQ affinity", NULL),
+#endif /* CONFIG_PLIC_SHELL_IRQ_AFFINITY */
 	SHELL_SUBCMD_SET_END
 );
 
-static int cmd_plic(const struct shell *sh, size_t argc, char **argv)
-{
-	shell_error(sh, "%s:unknown parameter: %s", argv[0], argv[1]);
-	return -EINVAL;
-}
-
-SHELL_CMD_ARG_REGISTER(plic, &plic_cmds, "PLIC shell commands",
-		       cmd_plic, 2, 0);
+SHELL_CMD_REGISTER(plic, &plic_cmds, "PLIC shell commands", NULL);
+#endif /* CONFIG_PLIC_SHELL */
 
 #define PLIC_MIN_IRQ_NUM(n) MIN(DT_INST_PROP(n, riscv_ndev), CONFIG_MAX_IRQ_PER_AGGREGATOR)
+
+#ifdef CONFIG_PLIC_SHELL_IRQ_COUNT
 #define PLIC_INTC_IRQ_COUNT_BUF_DEFINE(n)                                                          \
-	static uint16_t local_irq_count_##n[PLIC_MIN_IRQ_NUM(n)];
+	static uint16_t local_irq_count_##n[COND_CODE_1(CONFIG_MP_MAX_NUM_CPUS, (1),               \
+							(UTIL_INC(CONFIG_MP_MAX_NUM_CPUS)))]       \
+					   [PLIC_MIN_IRQ_NUM(n)];
+#define PLIC_INTC_IRQ_COUNT_INIT(n)                                                                \
+	.stats = {                                                                                 \
+		.irq_count = &local_irq_count_##n[0][0],                                           \
+	},
+
+#else
+#define PLIC_INTC_IRQ_COUNT_BUF_DEFINE(n)
+#define PLIC_INTC_IRQ_COUNT_INIT(n)
+#endif /* CONFIG_PLIC_SHELL_IRQ_COUNT */
+
+#ifdef CONFIG_PLIC_IRQ_AFFINITY
+#define PLIC_IRQ_CPUMASK_BUF_DECLARE(n)                                                            \
+	static plic_cpumask_t irq_cpumask_##n[PLIC_MIN_IRQ_NUM(n)] = {                             \
+		[0 ...(PLIC_MIN_IRQ_NUM(n) - 1)] = CONFIG_PLIC_IRQ_AFFINITY_MASK,                  \
+	}
+#define PLIC_IRQ_CPUMASK_BUF_INIT(n) .irq_cpumask = &irq_cpumask_##n[0],
+#else
+#define PLIC_IRQ_CPUMASK_BUF_DECLARE(n)
+#define PLIC_IRQ_CPUMASK_BUF_INIT(n)
+#endif /* CONFIG_PLIC_IRQ_AFFINITY */
 
 #define PLIC_INTC_DATA_INIT(n)                                                                     \
 	PLIC_INTC_IRQ_COUNT_BUF_DEFINE(n);                                                         \
+	PLIC_IRQ_CPUMASK_BUF_DECLARE(n);                                                           \
 	static struct plic_data plic_data_##n = {                                                  \
-		.stats = {                                                                         \
-			.irq_count = local_irq_count_##n,                                          \
-			.irq_count_len = PLIC_MIN_IRQ_NUM(n),                                      \
-		},                                                                                 \
+		PLIC_INTC_IRQ_COUNT_INIT(n)                                                        \
+		PLIC_IRQ_CPUMASK_BUF_INIT(n)                                                       \
 	};
-
-#define PLIC_INTC_DATA(n) &plic_data_##n
-#else
-#define PLIC_INTC_DATA_INIT(...)
-#define PLIC_INTC_DATA(n) (NULL)
-#endif
 
 #define PLIC_INTC_IRQ_FUNC_DECLARE(n) static void plic_irq_config_func_##n(void)
 
@@ -582,7 +886,9 @@ SHELL_CMD_ARG_REGISTER(plic, &plic_cmds, "PLIC shell commands",
 		IF_ENABLED(PLIC_SUPPORTS_TRIG_TYPE,                                                \
 			   (.trig = PLIC_BASE_ADDR(n) + PLIC_REG_TRIG_TYPE_OFFSET,))               \
 		.max_prio = DT_INST_PROP(n, riscv_max_priority),                                   \
-		.num_irqs = DT_INST_PROP(n, riscv_ndev),                                           \
+		.riscv_ndev = DT_INST_PROP(n, riscv_ndev),                                         \
+		.nr_irqs = PLIC_MIN_IRQ_NUM(n),                                                    \
+		.irq = DT_INST_IRQN(n),                                                            \
 		.irq_config_func = plic_irq_config_func_##n,                                       \
 		.isr_table = &_sw_isr_table[INTC_INST_ISR_TBL_OFFSET(n)],                          \
 		.hart_context = plic_hart_contexts_##n,                                            \
@@ -597,7 +903,7 @@ SHELL_CMD_ARG_REGISTER(plic, &plic_cmds, "PLIC shell commands",
 	PLIC_INTC_CONFIG_INIT(n)                                                                   \
 	PLIC_INTC_DATA_INIT(n)                                                                     \
 	DEVICE_DT_INST_DEFINE(n, &plic_init, NULL,                                                 \
-			      PLIC_INTC_DATA(n), &plic_config_##n,                                 \
+			      &plic_data_##n, &plic_config_##n,                                    \
 			      PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY,                             \
 			      NULL);
 

--- a/include/zephyr/drivers/interrupt_controller/riscv_plic.h
+++ b/include/zephyr/drivers/interrupt_controller/riscv_plic.h
@@ -45,6 +45,16 @@ int riscv_plic_irq_is_enabled(uint32_t irq);
 void riscv_plic_set_priority(uint32_t irq, uint32_t prio);
 
 /**
+ * @brief Set IRQ affinity.
+ *
+ * @param irq IRQ line.
+ * @param cpumask CPU bit mask.
+ *
+ * @return 0 if success, negative errno value otherwise
+ */
+int riscv_plic_irq_set_affinity(uint32_t irq, uint32_t cpumask);
+
+/**
  * @brief Get active interrupt ID
  *
  * @return Returns the ID of an active interrupt

--- a/tests/drivers/build_all/interrupt_controller/intc_plic/testcase.yaml
+++ b/tests/drivers/build_all/interrupt_controller/intc_plic/testcase.yaml
@@ -3,7 +3,9 @@ common:
   filter: CONFIG_PLIC
   platform_allow:
     - qemu_riscv32
+    - qemu_riscv32/qemu_virt_riscv32/smp
     - qemu_riscv64
+    - qemu_riscv64/qemu_virt_riscv64/smp
   tags:
     - drivers
     - interrupt
@@ -27,3 +29,11 @@ tests:
       - CONFIG_NUM_2ND_LEVEL_AGGREGATORS=2
       - CONFIG_2ND_LVL_INTR_01_OFFSET=8
       - CONFIG_UART_INTERRUPT_DRIVEN=y
+  drivers.interrupt_controller.intc_plic.irq_affinity.build:
+    filter: CONFIG_SMP
+    tags:
+      - smp
+    extra_configs:
+      - CONFIG_MP_MAX_NUM_CPUS=4
+      - CONFIG_PLIC_IRQ_AFFINITY=y
+      - CONFIG_PLIC_IRQ_AFFINITY_MASK=0xf


### PR DESCRIPTION
> [!NOTE]
> This is spinned off from #77828 and contains RISCV PLIC changes only

- Implement irq-set-affinity in RISCV PLIC.
- Added new affinity shell command to get/set the irq(s) affinity in runtime, when `0` is sent as the `local_irq`, it means set/get all IRQs affinity.
- Some minor optimizations

Updated the build_all test to build this new configuration.

Test command:
```
west build -b qemu_riscv64_smp -p auto -t run zephyr/samples/hello_world -- \
  -DCONFIG_SHELL=y \
  -DCONFIG_PLIC_SHELL=y \
  -DCONFIG_PLIC_IRQ_AFFINITY=y \
  -DCONFIG_MP_MAX_NUM_CPUS=4
```