### PR TITLE
cmake: Require Python >= 3.10

### DIFF
--- a/cmake/modules/python.cmake
+++ b/cmake/modules/python.cmake
@@ -11,7 +11,7 @@ if (WIN32)
   set(ENV{PYTHONIOENCODING} "utf-8")
 endif()
 
-set(PYTHON_MINIMUM_REQUIRED 3.8)
+set(PYTHON_MINIMUM_REQUIRED 3.10)
 
 find_package(Deprecated COMPONENTS PYTHON_PREFER)
 


### PR DESCRIPTION
The minimum Python version was bumped for Zephyr LTSv3, but only in the documentation and CI. The build system would still accept Python 3.8, yet some scripts in tree have already broken support with that version. Incompatibility errors should be prevented early.