### PR TITLE
dts: nordic: nrf-uarte: Add frame-timeout-supported property

### DIFF
--- a/dts/bindings/serial/nordic,nrf-uarte.yaml
+++ b/dts/bindings/serial/nordic,nrf-uarte.yaml
@@ -9,3 +9,8 @@ properties:
     type: boolean
     description: |
       UARTE has ENDTX_STOPTX HW short.
+
+  frame-timeout-supported:
+    type: boolean
+    description: |
+      UARTE has RX frame timeout HW feature.

--- a/dts/common/nordic/nrf54h20.dtsi
+++ b/dts/common/nordic/nrf54h20.dtsi
@@ -626,6 +626,7 @@
 				interrupts = <230 NRF_DEFAULT_IRQ_PRIORITY>;
 				clocks = <&hsfll120>;
 				endtx-stoptx-supported;
+				frame-timeout-supported;
 			};
 
 			spi121: spi@8e7000 {
@@ -935,6 +936,7 @@
 				clocks = <&fll16m>;
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
 				endtx-stoptx-supported;
+				frame-timeout-supported;
 			};
 
 			i2c131: i2c@9a6000 {
@@ -976,6 +978,7 @@
 				clocks = <&fll16m>;
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
 				endtx-stoptx-supported;
+				frame-timeout-supported;
 			};
 
 			dppic134: dppic@9b1000 {
@@ -1054,6 +1057,7 @@
 				clocks = <&fll16m>;
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
 				endtx-stoptx-supported;
+				frame-timeout-supported;
 			};
 
 			i2c133: i2c@9b6000 {
@@ -1095,6 +1099,7 @@
 				clocks = <&fll16m>;
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
 				endtx-stoptx-supported;
+				frame-timeout-supported;
 			};
 
 			dppic135: dppic@9c1000 {
@@ -1173,6 +1178,7 @@
 				clocks = <&fll16m>;
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
 				endtx-stoptx-supported;
+				frame-timeout-supported;
 			};
 
 			i2c135: i2c@9c6000 {
@@ -1214,6 +1220,7 @@
 				clocks = <&fll16m>;
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
 				endtx-stoptx-supported;
+				frame-timeout-supported;
 			};
 
 			dppic136: dppic@9d1000 {
@@ -1292,6 +1299,7 @@
 				clocks = <&fll16m>;
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
 				endtx-stoptx-supported;
+				frame-timeout-supported;
 			};
 
 			i2c137: i2c@9d6000 {
@@ -1333,6 +1341,7 @@
 				clocks = <&fll16m>;
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
 				endtx-stoptx-supported;
+				frame-timeout-supported;
 			};
 		};
 	};

--- a/dts/common/nordic/nrf54l15.dtsi
+++ b/dts/common/nordic/nrf54l15.dtsi
@@ -137,6 +137,7 @@
 				interrupts = <74 NRF_DEFAULT_IRQ_PRIORITY>;
 				status = "disabled";
 				endtx-stoptx-supported;
+				frame-timeout-supported;
 			};
 
 			cpuflpr_vpr: vpr@4c000 {
@@ -268,6 +269,7 @@
 				interrupts = <198 NRF_DEFAULT_IRQ_PRIORITY>;
 				status = "disabled";
 				endtx-stoptx-supported;
+				frame-timeout-supported;
 			};
 
 			i2c21: i2c@c7000 {
@@ -306,6 +308,7 @@
 				interrupts = <199 NRF_DEFAULT_IRQ_PRIORITY>;
 				status = "disabled";
 				endtx-stoptx-supported;
+				frame-timeout-supported;
 			};
 
 			i2c22: i2c@c8000 {
@@ -344,6 +347,7 @@
 				interrupts = <200 NRF_DEFAULT_IRQ_PRIORITY>;
 				status = "disabled";
 				endtx-stoptx-supported;
+				frame-timeout-supported;
 			};
 
 			egu20: egu@c9000 {
@@ -553,6 +557,7 @@
 				interrupts = <260 NRF_DEFAULT_IRQ_PRIORITY>;
 				status = "disabled";
 				endtx-stoptx-supported;
+				frame-timeout-supported;
 			};
 
 #ifdef USE_NON_SECURE_ADDRESS_MAP

--- a/dts/common/nordic/nrf54l20.dtsi
+++ b/dts/common/nordic/nrf54l20.dtsi
@@ -106,6 +106,7 @@
 				interrupts = <77 NRF_DEFAULT_IRQ_PRIORITY>;
 				status = "disabled";
 				endtx-stoptx-supported;
+				frame-timeout-supported;
 			};
 
 			gpio2: gpio@50400 {
@@ -219,6 +220,7 @@
 				interrupts = <198 NRF_DEFAULT_IRQ_PRIORITY>;
 				status = "disabled";
 				endtx-stoptx-supported;
+				frame-timeout-supported;
 			};
 
 			i2c21: i2c@c7000 {
@@ -257,6 +259,7 @@
 				interrupts = <199 NRF_DEFAULT_IRQ_PRIORITY>;
 				status = "disabled";
 				endtx-stoptx-supported;
+				frame-timeout-supported;
 			};
 
 			i2c22: i2c@c8000 {
@@ -295,6 +298,7 @@
 				interrupts = <200 NRF_DEFAULT_IRQ_PRIORITY>;
 				status = "disabled";
 				endtx-stoptx-supported;
+				frame-timeout-supported;
 			};
 
 			egu20: egu@c9000 {
@@ -495,6 +499,7 @@
 				interrupts = <260 NRF_DEFAULT_IRQ_PRIORITY>;
 				status = "disabled";
 				endtx-stoptx-supported;
+				frame-timeout-supported;
 			};
 
 			wdt30: watchdog@108000 {

--- a/dts/common/nordic/nrf9280.dtsi
+++ b/dts/common/nordic/nrf9280.dtsi
@@ -516,6 +516,7 @@
 				status = "disabled";
 				interrupts = <230 NRF_DEFAULT_IRQ_PRIORITY>;
 				endtx-stoptx-supported;
+				frame-timeout-supported;
 			};
 
 			spi121: spi@8e7000 {
@@ -846,6 +847,7 @@
 				interrupts = <421 NRF_DEFAULT_IRQ_PRIORITY>;
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
 				endtx-stoptx-supported;
+				frame-timeout-supported;
 			};
 
 			i2c131: i2c@9a6000 {
@@ -884,6 +886,7 @@
 				interrupts = <422 NRF_DEFAULT_IRQ_PRIORITY>;
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
 				endtx-stoptx-supported;
+				frame-timeout-supported;
 			};
 
 			dppic134: dppic@9b1000 {
@@ -956,6 +959,7 @@
 				interrupts = <437 NRF_DEFAULT_IRQ_PRIORITY>;
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
 				endtx-stoptx-supported;
+				frame-timeout-supported;
 			};
 
 			i2c133: i2c@9b6000 {
@@ -994,6 +998,7 @@
 				interrupts = <438 NRF_DEFAULT_IRQ_PRIORITY>;
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
 				endtx-stoptx-supported;
+				frame-timeout-supported;
 			};
 
 			dppic135: dppic@9c1000 {
@@ -1066,6 +1071,7 @@
 				interrupts = <453 NRF_DEFAULT_IRQ_PRIORITY>;
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
 				endtx-stoptx-supported;
+				frame-timeout-supported;
 			};
 
 			i2c135: i2c@9c6000 {
@@ -1104,6 +1110,7 @@
 				interrupts = <454 NRF_DEFAULT_IRQ_PRIORITY>;
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
 				endtx-stoptx-supported;
+				frame-timeout-supported;
 			};
 
 			dppic136: dppic@9d1000 {
@@ -1176,6 +1183,7 @@
 				interrupts = <469 NRF_DEFAULT_IRQ_PRIORITY>;
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
 				endtx-stoptx-supported;
+				frame-timeout-supported;
 			};
 
 			i2c137: i2c@9d6000 {
@@ -1214,6 +1222,7 @@
 				interrupts = <470 NRF_DEFAULT_IRQ_PRIORITY>;
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
 				endtx-stoptx-supported;
+				frame-timeout-supported;
 			};
 		};
 	};


### PR DESCRIPTION
Add property which indicates that UARTE support frame timeout feature. Property is added to nrf54h20, nrf9280, nrf54l20 and nrf54l15.