### PR TITLE
scripts: Remove wrong bz package

### DIFF
--- a/scripts/requirements-run-test.txt
+++ b/scripts/requirements-run-test.txt
@@ -15,8 +15,5 @@ cbor>=1.0.0
 # use for twister
 psutil
 
-# Artifacts package creation
-bz
-
 # used for CAN <=> host testing
 python-can>=4.3.0


### PR DESCRIPTION
Package in the requirements-run-test.txt file, `bz`, is not package enabling bz2 support.
It is a security concern and must be removed.

Fixes #78622 