### PR TITLE
boards: imx93_evk: add overlay to connect user button to pcal6524

### DIFF
--- a/boards/nxp/imx93_evk/doc/index.rst
+++ b/boards/nxp/imx93_evk/doc/index.rst
@@ -140,6 +140,28 @@ over dts config. For instance, if ``CONFIG_CAN`` is enabled, MUX A is selected
 even if ``mux="B";`` is configured in dts, and an warning would be reported in
 the log.
 
+User Button GPIO Option
+--------------------------
+
+The user buttons RFU_BTN1 and RFU_BTN2 is connected to i.MX 93 GPIO by default,
+but can be changed to connect to onboard GPIO expander PCAL6524 with on-board DIP
+switches. To do this, switch SW1006 to 0000, then switch SW1005 to 0101. An devicetree
+overlay is included to support this.
+
+Run following command to test user buttons on PCAL6524:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/button
+   :host-os: unix
+   :board: imx93_evk/mimx9352/a55
+   :goals: build
+   :gen-args: -DEXTRA_DTC_OVERLAY_FILE=imx93_evk_mimx9352_exp_btn.overlay
+
+Run the app, press RFU_BTN1 and the red LED turns on accordingly.
+
+Note: The overlay only supports ``mimx9352/a55``, but can be extended to support
+``mimx9352/m33`` if I2C and PCAL6524 is enabled.
+
 Programming and Debugging (A55)
 *******************************
 

--- a/boards/nxp/imx93_evk/dts/imx93_evk_mimx9352_exp_btn.overlay
+++ b/boards/nxp/imx93_evk/dts/imx93_evk_mimx9352_exp_btn.overlay
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Apply this overlay to test RFU_BTN1 and RFU_BTN2 on PCAL6524.
+ *
+ * The user buttons RFU_BTN1 and RFU_BTN2 is connected to i.MX 93 GPIO by default,
+ * but can be changed to connect to onboard GPIO expander PCAL6524. To do this,
+ * switch SW1006 to 0000, then switch SW1005 to 0101.
+ */
+
+/* Remove default keys */
+/delete-node/ &btn_1;
+/delete-node/ &btn_2;
+
+/ {
+	keys {
+		compatible = "gpio-keys";
+
+		btn_1: btn_1{
+			label = "BTN1";
+			gpios = <&gpio_exp1 5 GPIO_ACTIVE_LOW>;
+		};
+
+		btn_2: btn_2{
+			label = "BTN2";
+			gpios = <&gpio_exp1 6 GPIO_ACTIVE_LOW>;
+		};
+	};
+};


### PR DESCRIPTION
Apply this overlay to test RFU_BTN1 and RFU_BTN2 on PCAL6524.

The user buttons RFU_BTN1 and RFU_BTN2 is connected to i.MX 93 GPIO by default, but can be changed to connect to onboard GPIO expander PCAL6524. To do this, switch SW1006 to 0000, then switch SW1005 to 0101.

Not sure how to intergrate it into zephyr build/test system. Please shed some light