### PR TITLE
net: ipv6: Setting Router Solication Packet timeout

### DIFF
--- a/subsys/net/ip/Kconfig.ipv6
+++ b/subsys/net/ip/Kconfig.ipv6
@@ -156,6 +156,15 @@ config NET_IPV6_DAD
 	  The value depends on your network needs. DAD should normally
 	  be active.
 
+config NET_IPV6_RS_TIMEOUT
+	int "Timeout of Router Solicitation messaging"
+	depends on NET_IPV6_ND
+	range 1 30
+	default 1
+	help
+	  The timeout in seconds between attempts to send a Router
+	  Solicitation message at startup.
+
 config NET_IPV6_RA_RDNSS
 	bool "Support RA RDNSS option"
 	depends on NET_IPV6_ND

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -1425,7 +1425,7 @@ static inline void net_if_ipv6_start_dad(struct net_if *iface,
 #endif /* CONFIG_NET_IPV6_DAD */
 
 #if defined(CONFIG_NET_IPV6_ND)
-#define RS_TIMEOUT (1U * MSEC_PER_SEC)
+#define RS_TIMEOUT (CONFIG_NET_IPV6_RS_TIMEOUT * MSEC_PER_SEC)
 #define RS_COUNT 3
 
 static void rs_timeout(struct k_work *work)


### PR DESCRIPTION
Running IPv6 on STM32H743 using eth_stm32_hal I had to extend the timeout between the attempts to send Router Solicitation packets from 1 second to 2 seconds. Else it looked liked the packet never got sent (checked using tcpdump).

This solution is maybe a bit complicated (but generic) solution. The simple solution would be to just change the 1 to a 2.

If you want me to do the simple version of the PR I can fix that as well.

There is an issue in https://github.com/zephyrproject-rtos/zephyr/issues/78697 that matches this and should explain more on this PR.

Fixes #78697