### PR TITLE
drivers: intc: shared_irq: change init and isr function to static

### DIFF
--- a/drivers/interrupt_controller/intc_shared_irq.c
+++ b/drivers/interrupt_controller/intc_shared_irq.c
@@ -117,7 +117,7 @@ static inline int disable(const struct device *dev,
 	return -EIO;
 }
 
-void shared_irq_isr(const struct device *dev)
+static void shared_irq_isr(const struct device *dev)
 {
 	struct shared_irq_runtime *clients = dev->data;
 	const struct shared_irq_config *config = dev->config;
@@ -137,9 +137,10 @@ static const struct shared_irq_driver_api api_funcs = {
 };
 
 
-int shared_irq_initialize(const struct device *dev)
+static int shared_irq_initialize(const struct device *dev)
 {
 	const struct shared_irq_config *config = dev->config;
+
 	config->config();
 	return 0;
 }


### PR DESCRIPTION
Device init & ISR functions should be made static.