### PR TITLE
drivers: udc_dwc2: Implement USBHS hibernation quirks

### DIFF
--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -1019,6 +1019,8 @@ static void dwc2_enter_hibernation(const struct device *dev)
 	/* Switch off power to the controller */
 	sys_set_bits(gpwrdn_reg, USB_DWC2_GPWRDN_PWRDNSWTCH);
 
+	(void)dwc2_quirk_post_hibernation_entry(dev);
+
 	/* Mark that the core is hibernated */
 	priv->hibernated = 1;
 	LOG_DBG("Hibernated");
@@ -1031,6 +1033,8 @@ static void dwc2_exit_hibernation(const struct device *dev, bool rwup)
 	struct udc_dwc2_data *const priv = udc_get_private(dev);
 	mem_addr_t gpwrdn_reg = (mem_addr_t)&base->gpwrdn;
 	mem_addr_t pcgcctl_reg = (mem_addr_t)&base->pcgcctl;
+
+	(void)dwc2_quirk_pre_hibernation_exit(dev);
 
 	/* Switch on power to the controller */
 	sys_clear_bits(gpwrdn_reg, USB_DWC2_GPWRDN_PWRDNSWTCH);

--- a/drivers/usb/udc/udc_dwc2.h
+++ b/drivers/usb/udc/udc_dwc2.h
@@ -30,6 +30,10 @@ struct dwc2_vendor_quirks {
 	int (*caps)(const struct device *dev);
 	/* Called while waiting for bits that require PHY to be clocked */
 	int (*is_phy_clk_off)(const struct device *dev);
+	/* Called after hibernation entry sequence */
+	int (*post_hibernation_entry)(const struct device *dev);
+	/* Called before hibernation exit sequence */
+	int (*pre_hibernation_exit)(const struct device *dev);
 };
 
 /* Driver configuration per instance */
@@ -72,5 +76,7 @@ DWC2_QUIRK_FUNC_DEFINE(shutdown)
 DWC2_QUIRK_FUNC_DEFINE(irq_clear)
 DWC2_QUIRK_FUNC_DEFINE(caps)
 DWC2_QUIRK_FUNC_DEFINE(is_phy_clk_off)
+DWC2_QUIRK_FUNC_DEFINE(post_hibernation_entry)
+DWC2_QUIRK_FUNC_DEFINE(pre_hibernation_exit)
 
 #endif /* ZEPHYR_DRIVERS_USB_UDC_DWC2_H */


### PR DESCRIPTION
Use the quirk to keep only the necessary clocks running when the core is hibernated. The quirk is necessary to bring the USB suspend current below the USB 2.0 suspend current limit.