### PR TITLE
I2C enablement on NXP i.MX95 EVK for M7

### DIFF
--- a/boards/nxp/imx95_evk/doc/index.rst
+++ b/boards/nxp/imx95_evk/doc/index.rst
@@ -91,6 +91,8 @@ The Zephyr ``imx95_evk/mimx9596/m7`` board target supports the following hardwar
 +-----------+------------+-------------------------------------+
 | UART      | on-chip    | serial port                         |
 +-----------+------------+-------------------------------------+
+| I2C       | on-chip    | i2c                                 |
++-----------+------------+-------------------------------------+
 
 The Zephyr ``imx95_evk/mimx9596/a55`` and ``imx95_evk/mimx9596/a55/smp`` board targets support
 the following hardware features:

--- a/boards/nxp/imx95_evk/imx95_evk-pinctrl.dtsi
+++ b/boards/nxp/imx95_evk/imx95_evk-pinctrl.dtsi
@@ -6,6 +6,27 @@
 #include <nxp/nxp_imx/mimx9596avzxn-pinctrl.dtsi>
 
 &pinctrl {
+	lpi2c5_default: lpi2c5_default {
+		group0 {
+			pinmux = <&iomuxc_gpio_io23_lpi2c_scl_lpi2c5_scl>,
+				<&iomuxc_gpio_io22_lpi2c_sda_lpi2c5_sda>;
+			drive-open-drain;
+			slew-rate = "slightly_fast";
+			drive-strength = "x4";
+			input-enable;
+		};
+	};
+
+	lpi2c7_default: lpi2c7_default {
+		group0 {
+			pinmux = <&iomuxc_gpio_io09_lpi2c_scl_lpi2c7_scl>,
+				<&iomuxc_gpio_io08_lpi2c_sda_lpi2c7_sda>;
+			drive-open-drain;
+			slew-rate = "slightly_fast";
+			drive-strength = "x4";
+			input-enable;
+		};
+	};
 
 	lpuart1_default: lpuart1_default {
 		group0 {

--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.dts
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.dts
@@ -23,6 +23,18 @@
 	};
 };
 
+&lpi2c5 {
+	pinctrl-0 = <&lpi2c5_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&lpi2c7 {
+	pinctrl-0 = <&lpi2c7_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
 &lpuart3 {
 	status = "okay";
 	current-speed = <115200>;

--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.yaml
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.yaml
@@ -16,4 +16,5 @@ toolchain:
   - xtools
 supported:
   - uart
+  - i2c
 vendor: nxp

--- a/dts/arm/nxp/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/nxp_imx95_m7.dtsi
@@ -6,6 +6,7 @@
 
 #include <arm/armv7-m.dtsi>
 #include <zephyr/dt-bindings/clock/imx95_clock.h>
+#include <dt-bindings/i2c/i2c.h>
 #include <mem.h>
 
 / {
@@ -76,6 +77,28 @@
 			reg = <0x20000000 DT_SIZE_K(256)>;
 		};
 
+		lpi2c3: i2c@42530000 {
+			compatible = "nxp,imx-lpi2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x42530000 0x4000>;
+			interrupts = <58 0>;
+			clocks = <&scmi_clk IMX95_CLK_LPI2C3>;
+			status = "disabled";
+		};
+
+		lpi2c4: i2c@42540000 {
+			compatible = "nxp,imx-lpi2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x42540000 0x4000>;
+			interrupts = <59 0>;
+			clocks = <&scmi_clk IMX95_CLK_LPI2C4>;
+			status = "disabled";
+		};
+
 		lpuart3: serial@42570000 {
 			compatible = "nxp,imx-lpuart", "nxp,kinetis-lpuart";
 			reg = <0x42570000 DT_SIZE_K(64)>;
@@ -121,6 +144,72 @@
 			reg = <0x426a0000 DT_SIZE_K(64)>;
 			interrupts = <69 3>;
 			clocks = <&scmi_clk IMX95_CLK_LPUART8>;
+			status = "disabled";
+		};
+
+		lpi2c5: i2c@426b0000 {
+			compatible = "nxp,imx-lpi2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x426b0000 0x4000>;
+			interrupts = <181 0>;
+			clocks = <&scmi_clk IMX95_CLK_LPI2C5>;
+			status = "disabled";
+		};
+
+		lpi2c6: i2c@426c0000 {
+			compatible = "nxp,imx-lpi2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x426c0000 0x4000>;
+			interrupts = <182 0>;
+			clocks = <&scmi_clk IMX95_CLK_LPI2C6>;
+			status = "disabled";
+		};
+
+		lpi2c7: i2c@426d0000 {
+			compatible = "nxp,imx-lpi2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x426d0000 0x4000>;
+			interrupts = <183 0>;
+			clocks = <&scmi_clk IMX95_CLK_LPI2C7>;
+			status = "disabled";
+		};
+
+		lpi2c8: i2c@426e0000 {
+			compatible = "nxp,imx-lpi2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x426e0000 0x4000>;
+			interrupts = <184 0>;
+			clocks = <&scmi_clk IMX95_CLK_LPI2C8>;
+			status = "disabled";
+		};
+
+		lpi2c1: i2c@44340000 {
+			compatible = "nxp,imx-lpi2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x44340000 0x4000>;
+			interrupts = <13 0>;
+			clocks = <&scmi_clk IMX95_CLK_LPI2C1>;
+			status = "disabled";
+		};
+
+		lpi2c2: i2c@44350000 {
+			compatible = "nxp,imx-lpi2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x44350000 0x4000>;
+			interrupts = <14 0>;
+			clocks = <&scmi_clk IMX95_CLK_LPI2C2>;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
This pull request is to add I2C devices support for i.MX95 M7 in dts. Also enabled two I2C interfaces for EVK board to use.
The functions had been verified through i2c command.
Thanks a lot.