### PR TITLE
Bluetooth: GATT: Fix issue with 0/NULL for bt_gatt_attr_read

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -1833,11 +1833,20 @@ ssize_t bt_gatt_attr_read(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
 	}
 
-	len = MIN(buf_len, value_len - offset);
+	if (value_len != 0U && value == NULL) {
+		LOG_WRN("value_len of %u provided for NULL value", value_len);
+
+		return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
+	}
+
+	if (value_len == 0U) {
+		len = 0U;
+	} else {
+		len = MIN(buf_len, value_len - offset);
+		memcpy(buf, (uint8_t *)value + offset, len);
+	}
 
 	LOG_DBG("handle 0x%04x offset %u length %u", attr->handle, offset, len);
-
-	memcpy(buf, (uint8_t *)value + offset, len);
 
 	return len;
 }


### PR DESCRIPTION
The bt_gatt_attr_read function did not properly handle cases where value is NULL and/or value_len is 0, or bad mixes of the two.

The important part is here is that we do not perform the pointer arithmetic on NULL and/or call memcpy with a NULL src with a non-0 length.