### PR TITLE
arch: x86_64: re-enable -mno-red-zone

### DIFF
--- a/arch/x86/intel64.cmake
+++ b/arch/x86/intel64.cmake
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_cc_option(-m64)
+zephyr_cc_option(-mno-red-zone)
 
 set_property(GLOBAL PROPERTY PROPERTY_OUTPUT_ARCH "i386:x86-64")
 set_property(GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT "elf64-x86-64")


### PR DESCRIPTION
Red zone was causing issues in places where inline assembly was pushing data to stack, like arch_irq_lock, and possibly in other places. Initially -mno-red-zone was enabled on x86_64, but was later, maybe accidentially, disabled in https://github.com/zephyrproject-rtos/zephyr/commit/b7eb04b3007767be9febe677924918d2422a4406.

For example the following code built with `CONFIG_NO_OPTIMIZATIONS=y` results in invalid `should_return_42()` where push inside `arch_irq_lock()` overwrites `local_var` placed by gcc in the red zone.
```
#include <stdio.h>
#include <inttypes.h>
#include <zephyr/arch/cpu.h>

int64_t should_return_42()
{
	int64_t local_var = 42;
	(void)arch_irq_lock();
	return local_var;
}

int64_t returns_42()
{
	int64_t local_var = 42;
	return local_var;
}

int main(void)
{
	printf("should_return_42() = %" PRId64 "\n", should_return_42());
	printf("returns_42() = %" PRId64 "\n", returns_42());

	return 0;
}
```
Output without `-mno-red-zone`:
```
should_return_42() = 582
returns_42() = 42
```
Output with `-mno-red-zone`:
```
should_return_42() = 42
returns_42() = 42
```
It was tested on target `qemu_x86_64` with sdk 16.8