### PR TITLE
west.yml:hal_intel: Update with a fix on gpio driver

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -178,7 +178,7 @@ manifest:
       groups:
         - hal
     - name: hal_intel
-      revision: 0905a528623de56b1bedf817536321bcdbc0efae
+      revision: 8876a1815bc59e0464d285459b71e3d69872edfd
       path: modules/hal/intel
       groups:
         - hal


### PR DESCRIPTION
Make chagne to correctly identify both edge triggered gpio pins.