### PR TITLE
tests/kernel/context: correct the way to get IRQ number of APIC TSC timer

### DIFF
--- a/tests/kernel/context/src/main.c
+++ b/tests/kernel/context/src/main.c
@@ -47,7 +47,7 @@
  * is not defined in platform, generate an error
  */
 
-#if defined(CONFIG_APIC_TSC_DEADLINE_TIMER)
+#if defined(CONFIG_APIC_TSC_DEADLINE_TIMER) || defined(CONFIG_APIC_TIMER_TSC)
 #define TICK_IRQ z_loapic_irq_base() /* first LVT interrupt */
 #elif defined(CONFIG_CPU_CORTEX_M)
 /*


### PR DESCRIPTION
This case fails to build on boards having APIC TSC timer enabled.
This change is needed after moving APIC TSC timer support from apic_timer.c to apic_tsc.c (https://github.com/zephyrproject-rtos/zephyr/pull/73185)