### PR TITLE
scripts: twister: NOTRUN status (test was built only, not run)

### DIFF
--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -96,7 +96,9 @@ class Reporting:
             if log:
                 el.text = log
         elif status == TwisterStatus.PASS:
-            if not runnable and build_only_as_skip:
+            passes += 1
+        elif status == TwisterStatus.NOTRUN:
+            if build_only_as_skip:
                 ET.SubElement(eleTestcase, ReportStatus.SKIP, type="build", message="built only")
                 skips += 1
             else:
@@ -527,7 +529,7 @@ class Reporting:
         example_instance = None
         detailed_test_id = self.env.options.detailed_test_id
         for instance in self.instances.values():
-            if instance.status not in [TwisterStatus.PASS, TwisterStatus.FILTER, TwisterStatus.SKIP]:
+            if instance.status not in [TwisterStatus.PASS, TwisterStatus.FILTER, TwisterStatus.SKIP, TwisterStatus.NOTRUN]:
                 cnt += 1
                 if cnt == 1:
                     logger.info("-+" * 40)
@@ -582,12 +584,13 @@ class Reporting:
             pass_rate = 0
 
         logger.info(
-            "{}{} of {}{} test configurations passed ({:.2%}), {}{}{} failed, {}{}{} errored, {} skipped with {}{}{} warnings in {:.2f} seconds".format(
+            "{}{} of {}{} test configurations passed ({:.2%}), {} built (not run), {}{}{} failed, {}{}{} errored, {} skipped with {}{}{} warnings in {:.2f} seconds".format(
                 Fore.RED if failed else Fore.GREEN,
                 results.passed,
                 results.total,
                 Fore.RESET,
                 pass_rate,
+                results.notrun,
                 Fore.RED if results.failed else Fore.RESET,
                 results.failed,
                 Fore.RESET,
@@ -604,7 +607,7 @@ class Reporting:
         # if we are only building, do not report about tests being executed.
         if self.platforms and not self.env.options.build_only:
             logger.info("In total {} test cases were executed, {} skipped on {} out of total {} platforms ({:02.2f}%)".format(
-                results.cases - results.skipped_cases,
+                results.cases - results.skipped_cases - results.notrun,
                 results.skipped_cases,
                 len(self.filtered_platforms),
                 total_platforms,

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -79,6 +79,10 @@ class ExecutionCounter(object):
         # updated by report_out()
         self._passed = Value('i', 0)
 
+        # instances that are built but not runnable
+        # updated by report_out()
+        self._notrun = Value('i', 0)
+
         # static filter + runtime filter + build skipped
         # updated by update_counting_before_pipeline() and report_out()
         self._skipped_configs = Value('i', 0)
@@ -113,6 +117,7 @@ class ExecutionCounter(object):
         print(f"Skipped test cases: {self.skipped_cases}")
         print(f"Completed test suites: {self.done}")
         print(f"Passing test suites: {self.passed}")
+        print(f"Built only test suites: {self.notrun}")
         print(f"Failing test suites: {self.failed}")
         print(f"Skipped test suites: {self.skipped_configs}")
         print(f"Skipped test suites (runtime): {self.skipped_runtime}")
@@ -179,6 +184,16 @@ class ExecutionCounter(object):
     def passed(self, value):
         with self._passed.get_lock():
             self._passed.value = value
+
+    @property
+    def notrun(self):
+        with self._notrun.get_lock():
+            return self._notrun.value
+
+    @notrun.setter
+    def notrun(self, value):
+        with self._notrun.get_lock():
+            self._notrun.value = value
 
     @property
     def skipped_configs(self):
@@ -285,9 +300,11 @@ class CMake:
             msg = f"Finished building {self.source_dir} for {self.platform.name} in {duration:.2f} seconds"
             logger.debug(msg)
 
-            self.instance.status = TwisterStatus.PASS
             if not self.instance.run:
-                self.instance.add_missing_case_status(TwisterStatus.SKIP, "Test was built only")
+                self.instance.status = TwisterStatus.NOTRUN
+                self.instance.add_missing_case_status(TwisterStatus.NOTRUN, "Test was built only")
+            else:
+                self.instance.status = TwisterStatus.PASS
             ret = {"returncode": p.returncode}
 
             if out:
@@ -838,6 +855,7 @@ class ProjectBuilder(FilterBuilder):
 
         if detected_cases:
             logger.debug(f"{', '.join(detected_cases)} in {elf_file}")
+            tc_keeper = {tc.name: {'status': tc.status, 'reason': tc.reason} for tc in self.instance.testcases}
             self.instance.testcases.clear()
             self.instance.testsuite.testcases.clear()
 
@@ -846,8 +864,13 @@ class ProjectBuilder(FilterBuilder):
             # Then we can further include the new_ztest_suite info in the testcase_id.
 
             for testcase_id in detected_cases:
-                self.instance.add_testcase(name=testcase_id)
+                testcase = self.instance.add_testcase(name=testcase_id)
                 self.instance.testsuite.add_testcase(name=testcase_id)
+
+                # Keep previous statuses and reasons
+                tc_info = tc_keeper.get(testcase_id, {})
+                testcase.status = tc_info.get('status', TwisterStatus.NONE)
+                testcase.reason = tc_info.get('reason')
 
 
     def cleanup_artifacts(self, additional_keep: List[str] = []):
@@ -1083,6 +1106,12 @@ class ProjectBuilder(FilterBuilder):
                 # test cases skipped at the test case level
                 if case.status == TwisterStatus.SKIP:
                     results.skipped_cases += 1
+        elif instance.status == TwisterStatus.NOTRUN:
+            status = Fore.CYAN + "NOT RUN" + Fore.RESET
+            results.notrun += 1
+            for case in instance.testcases:
+                if case.status == TwisterStatus.SKIP:
+                    results.skipped_cases += 1
         else:
             logger.debug(f"Unknown status = {instance.status}")
             status = Fore.YELLOW + "UNKNOWN" + Fore.RESET
@@ -1125,12 +1154,13 @@ class ProjectBuilder(FilterBuilder):
             if total_to_do > 0:
                 completed_perc = int((float(results.done) / total_to_do) * 100)
 
-            sys.stdout.write("INFO    - Total complete: %s%4d/%4d%s  %2d%%  skipped: %s%4d%s, failed: %s%4d%s, error: %s%4d%s\r" % (
+            sys.stdout.write("INFO    - Total complete: %s%4d/%4d%s  %2d%%  built (not run): %4d, skipped: %s%4d%s, failed: %s%4d%s, error: %s%4d%s\r" % (
                 Fore.GREEN,
                 results.done,
                 total_to_do,
                 Fore.RESET,
                 completed_perc,
+                results.notrun,
                 Fore.YELLOW if results.skipped_configs > 0 else Fore.RESET,
                 results.skipped_configs,
                 Fore.RESET,
@@ -1391,7 +1421,7 @@ class TwisterRunner:
             if build_only:
                 instance.run = False
 
-            no_retry_statuses = [TwisterStatus.PASS, TwisterStatus.SKIP, TwisterStatus.FILTER]
+            no_retry_statuses = [TwisterStatus.PASS, TwisterStatus.SKIP, TwisterStatus.FILTER, TwisterStatus.NOTRUN]
             if not retry_build_errors:
                 no_retry_statuses.append(TwisterStatus.ERROR)
 

--- a/scripts/pylib/twister/twisterlib/statuses.py
+++ b/scripts/pylib/twister/twisterlib/statuses.py
@@ -25,6 +25,7 @@ class TwisterStatus(str, Enum):
     def get_color(status: TwisterStatus) -> str:
         status2color = {
             TwisterStatus.PASS: Fore.GREEN,
+            TwisterStatus.NOTRUN: Fore.CYAN,
             TwisterStatus.SKIP: Fore.YELLOW,
             TwisterStatus.FILTER: Fore.YELLOW,
             TwisterStatus.BLOCK: Fore.YELLOW,
@@ -42,6 +43,7 @@ class TwisterStatus(str, Enum):
     # All statuses below this comment can be used for TestSuite
     # All statuses below this comment can be used for TestInstance
     FILTER = 'filtered'
+    NOTRUN = 'not run'
 
     # All statuses below this comment can be used for Harness
     NONE = None

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -213,6 +213,7 @@ def test_executioncounter(capfd):
         f'Skipped test cases: 6\n'
         f'Completed test suites: 9\n'
         f'Passing test suites: 6\n'
+        f'Built only test suites: 0\n'
         f'Failing test suites: 1\n'
         f'Skipped test suites: 3\n'
         f'Skipped test suites (runtime): 1\n'
@@ -254,7 +255,7 @@ TESTDATA_1_1 = [
 ]
 TESTDATA_1_2 = [
     (0, False, 'dummy out',
-     True, True, TwisterStatus.PASS, None, False, True),
+     True, True, TwisterStatus.NOTRUN, None, False, True),
     (0, True, '',
      False, False, TwisterStatus.PASS, None, False, False),
     (1, True, 'ERROR: region `FLASH\' overflowed by 123 MB',
@@ -355,7 +356,7 @@ def test_cmake_run_build(
 
     if expected_add_missing:
         cmake.instance.add_missing_case_status.assert_called_once_with(
-            TwisterStatus.SKIP, 'Test was built only'
+            TwisterStatus.NOTRUN, 'Test was built only'
         )
 
 
@@ -1941,8 +1942,8 @@ TESTDATA_13 = [
         ['ERROR     dummy platform' \
          '            dummy.testsuite.name' \
          '                                FAILED : dummy reason'],
-        'INFO    - Total complete:   20/  25  80%  skipped:    3,' \
-        ' failed:    3, error:    1'
+        'INFO    - Total complete:   20/  25  80%' \
+        '  built (not run):    0, skipped:    3, failed:    3, error:    1'
     ),
     (
         TwisterStatus.SKIP, True, False, False,
@@ -1954,8 +1955,8 @@ TESTDATA_13 = [
     (
         TwisterStatus.FILTER, False, False, False,
         [],
-        'INFO    - Total complete:   20/  25  80%  skipped:    4,' \
-        ' failed:    2, error:    1'
+        'INFO    - Total complete:   20/  25  80%' \
+        '  built (not run):    0, skipped:    4, failed:    2, error:    1'
     ),
     (
         TwisterStatus.PASS, True, False, True,
@@ -1975,8 +1976,8 @@ TESTDATA_13 = [
     (
         'unknown status', False, False, False,
         ['Unknown status = unknown status'],
-        'INFO    - Total complete:   20/  25  80%  skipped:    3,' \
-        ' failed:    2, error:    1\r'
+        'INFO    - Total complete:   20/  25  80%'
+        '  built (not run):    0, skipped:    3, failed:    2, error:    1\r'
     )
 ]
 
@@ -2008,10 +2009,10 @@ def test_projectbuilder_report_out(
     instance_mock.status = status
     instance_mock.reason = 'dummy reason'
     instance_mock.testsuite.name = 'dummy.testsuite.name'
-    skip_mock_tc = mock.Mock(status=TwisterStatus.SKIP, reason='?')
-    skip_mock_tc.name = '?'
-    unknown_mock_tc = mock.Mock(status=mock.Mock(value='?'), reason='?')
-    unknown_mock_tc.name = '?'
+    skip_mock_tc = mock.Mock(status=TwisterStatus.SKIP, reason=None)
+    skip_mock_tc.name = 'mocked_testcase_to_skip'
+    unknown_mock_tc = mock.Mock(status=mock.Mock(value='dummystatus'), reason=None)
+    unknown_mock_tc.name = 'mocked_testcase_unknown'
     instance_mock.testsuite.testcases = [unknown_mock_tc for _ in range(25)]
     instance_mock.testcases = [unknown_mock_tc for _ in range(24)] + \
                               [skip_mock_tc]
@@ -2028,6 +2029,7 @@ def test_projectbuilder_report_out(
     results_mock.total = 25
     results_mock.done = 19
     results_mock.passed = 17
+    results_mock.notrun = 0
     results_mock.skipped_configs = 3
     results_mock.skipped_cases = 4
     results_mock.failed = 2
@@ -2044,6 +2046,7 @@ def test_projectbuilder_report_out(
         caplog.text
     )
     trim_actual_log = re.sub(r'twister:runner.py:\d+', '', trim_actual_log)
+
     assert all([log in trim_actual_log for log in expected_logs])
 
     if expected_out:

--- a/scripts/tests/twister_blackbox/test_coverage.py
+++ b/scripts/tests/twister_blackbox/test_coverage.py
@@ -14,6 +14,7 @@ import sys
 import json
 
 # pylint: disable=duplicate-code
+# pylint: disable=no-name-in-module
 from conftest import TEST_DATA, ZEPHYR_BASE, testsuite_filename_mock, clear_log_in_test
 from twisterlib.testplan import TestPlan
 

--- a/scripts/tests/twister_blackbox/test_platform.py
+++ b/scripts/tests/twister_blackbox/test_platform.py
@@ -14,6 +14,7 @@ import pytest
 import sys
 import json
 
+# pylint: disable=no-name-in-module
 from conftest import ZEPHYR_BASE, TEST_DATA, testsuite_filename_mock
 from twisterlib.testplan import TestPlan
 
@@ -30,10 +31,11 @@ class TestPlatform:
                 'skipped_configurations': 3,
                 'skipped_by_static_filter': 3,
                 'skipped_at_runtime': 0,
-                'passed_configurations': 6,
+                'passed_configurations': 4,
+                'built_configurations': 2,
                 'failed_configurations': 0,
                 'errored_configurations': 0,
-                'executed_test_cases': 10,
+                'executed_test_cases': 8,
                 'skipped_test_cases': 5,
                 'platform_count': 3,
                 'executed_on_platform': 4,
@@ -50,6 +52,7 @@ class TestPlatform:
                 'skipped_by_static_filter': 3,
                 'skipped_at_runtime': 0,
                 'passed_configurations': 0,
+                'built_configurations': 0,
                 'failed_configurations': 0,
                 'errored_configurations': 0,
                 'executed_test_cases': 0,
@@ -187,7 +190,7 @@ class TestPlatform:
                 os.path.join(TEST_DATA, 'tests', 'dummy', 'agnostic'),
                 ['qemu_x86', 'qemu_x86_64'],
                 {
-                    'passed_configurations': 3,
+                    'passed_configurations': 2,
                     'selected_test_instances': 6,
                     'executed_on_platform': 2,
                     'only_built': 1,
@@ -265,7 +268,8 @@ class TestPlatform:
 
         pass_regex = r'^INFO    - (?P<passed_configurations>[0-9]+) of' \
                      r' (?P<test_instances>[0-9]+) test configurations passed' \
-                     r' \([0-9]+\.[0-9]+%\), (?P<failed_configurations>[0-9]+) failed,' \
+                     r' \([0-9]+\.[0-9]+%\), (?P<built_configurations>[0-9]+) built \(not run\),' \
+                     r' (?P<failed_configurations>[0-9]+) failed,' \
                      r' (?P<errored_configurations>[0-9]+) errored,' \
                      r' (?P<skipped_configurations>[0-9]+) skipped with' \
                      r' [0-9]+ warnings in [0-9]+\.[0-9]+ seconds$'
@@ -304,6 +308,8 @@ class TestPlatform:
                expected['passed_configurations']
         assert int(pass_search.group('test_instances')) == \
                expected['selected_test_instances']
+        assert int(pass_search.group('built_configurations')) == \
+               expected['built_configurations']
         assert int(pass_search.group('failed_configurations')) == \
                expected['failed_configurations']
         assert int(pass_search.group('errored_configurations')) == \

--- a/scripts/tests/twister_blackbox/test_printouts.py
+++ b/scripts/tests/twister_blackbox/test_printouts.py
@@ -13,6 +13,7 @@ import pytest
 import sys
 import re
 
+# pylint: disable=no-name-in-module
 from conftest import (
     TEST_DATA,
     ZEPHYR_BASE,
@@ -189,6 +190,8 @@ class TestPrintOuts:
                 pytest.raises(SystemExit) as sys_exit:
             self.loader.exec_module(self.twister_module)
 
+        assert str(sys_exit.value) == '0'
+
         info_regex = r'\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} - (?:INFO|DEBUG|ERROR)'
 
         out, err = capfd.readouterr()
@@ -197,6 +200,7 @@ class TestPrintOuts:
 
         output = err.split('\n')
 
+        # Will give false positives on lines with newlines inside of them
         err_lines = []
         for line in output:
             if line.strip():
@@ -207,7 +211,6 @@ class TestPrintOuts:
 
         if err_lines:
             assert False, f'No timestamp in line {err_lines}'
-        assert str(sys_exit.value) == '0'
 
     @pytest.mark.parametrize(
         'flag',

--- a/scripts/tests/twister_blackbox/test_runner.py
+++ b/scripts/tests/twister_blackbox/test_runner.py
@@ -15,6 +15,7 @@ import re
 import sys
 import time
 
+# pylint: disable=no-name-in-module
 from conftest import TEST_DATA, ZEPHYR_BASE, testsuite_filename_mock, clear_log_in_test
 from twisterlib.testplan import TestPlan
 
@@ -50,6 +51,7 @@ class TestRunner:
                 'skipped_by_static_filter': 0,
                 'skipped_at_runtime': 0,
                 'passed_configurations': 4,
+                'built_configurations': 2,
                 'failed_configurations': 0,
                 'errored_configurations': 0,
                 'executed_test_cases': 8,
@@ -129,7 +131,7 @@ class TestRunner:
             ['dummy.agnostic.group2 SKIPPED: Command line testsuite tag filter',
              'dummy.agnostic.group1.subgroup2 SKIPPED: Command line testsuite tag filter',
              'dummy.agnostic.group1.subgroup1 SKIPPED: Command line testsuite tag filter',
-             r'0 of 4 test configurations passed \(0.00%\), 0 failed, 0 errored, 4 skipped'
+             r'0 of 4 test configurations passed \(0.00%\), 0 built \(not run\), 0 failed, 0 errored, 4 skipped'
              ]
         ),
         (
@@ -137,14 +139,14 @@ class TestRunner:
             ['qemu_x86'],
             ['subgrouped'],
             ['dummy.agnostic.group2 SKIPPED: Command line testsuite tag filter',
-             r'2 of 4 test configurations passed \(100.00%\), 0 failed, 0 errored, 2 skipped'
+             r'1 of 4 test configurations passed \(50.00%\), 1 built \(not run\), 0 failed, 0 errored, 2 skipped'
              ]
         ),
         (
             os.path.join(TEST_DATA, 'tests', 'dummy'),
             ['qemu_x86'],
             ['agnostic', 'device'],
-            [r'3 of 4 test configurations passed \(100.00%\), 0 failed, 0 errored, 1 skipped']
+            [r'2 of 4 test configurations passed \(66.67%\), 1 built \(not run\), 0 failed, 0 errored, 1 skipped']
         ),
     ]
     TESTDATA_10 = [
@@ -155,6 +157,7 @@ class TestRunner:
                 'selected_test_instances': 2,
                 'skipped_configurations': 0,
                 'passed_configurations': 0,
+                'built_configurations': 0,
                 'failed_configurations': 1,
                 'errored_configurations': 0,
             }
@@ -264,7 +267,8 @@ class TestRunner:
 
         pass_regex = r'^INFO    - (?P<passed_configurations>[0-9]+) of' \
                      r' (?P<test_instances>[0-9]+) test configurations passed' \
-                     r' \([0-9]+\.[0-9]+%\), (?P<failed_configurations>[0-9]+) failed,' \
+                     r' \([0-9]+\.[0-9]+%\), (?P<built_configurations>[0-9]+) built \(not run\),' \
+                     r' (?P<failed_configurations>[0-9]+) failed,' \
                      r' (?P<errored_configurations>[0-9]+) errored,' \
                      r' (?P<skipped_configurations>[0-9]+) skipped with' \
                      r' [0-9]+ warnings in [0-9]+\.[0-9]+ seconds$'
@@ -302,6 +306,8 @@ class TestRunner:
             expected['passed_configurations']
         assert int(pass_search.group('test_instances')) == \
             expected['selected_test_instances']
+        assert int(pass_search.group('built_configurations')) == \
+            expected['built_configurations']
         assert int(pass_search.group('failed_configurations')) == \
             expected['failed_configurations']
         assert int(pass_search.group('errored_configurations')) == \
@@ -611,7 +617,8 @@ class TestRunner:
 
         pass_regex = r'^INFO    - (?P<passed_configurations>[0-9]+) of' \
                      r' (?P<test_instances>[0-9]+) test configurations passed' \
-                     r' \([0-9]+\.[0-9]+%\), (?P<failed_configurations>[0-9]+) failed,' \
+                     r' \([0-9]+\.[0-9]+%\), (?P<built_configurations>[0-9]+) built \(not run\),' \
+                     r' (?P<failed_configurations>[0-9]+) failed,' \
                      r' (?P<errored_configurations>[0-9]+) errored,' \
                      r' (?P<skipped_configurations>[0-9]+) skipped with' \
                      r' [0-9]+ warnings in [0-9]+\.[0-9]+ seconds$'
@@ -631,6 +638,8 @@ class TestRunner:
                 expected['passed_configurations']
         assert int(pass_search.group('test_instances')) == \
                 expected['selected_test_instances']
+        assert int(pass_search.group('built_configurations')) == \
+                expected['built_configurations']
         assert int(pass_search.group('failed_configurations')) == \
                 expected['failed_configurations']
         assert int(pass_search.group('errored_configurations')) == \


### PR DESCRIPTION
Adds a new NOTRUN status, which indicates that a test was successfully built, but not run on account of being not runnable in given test instance.

New Status is applicable for both `TestCase` and `TestInstance`. It is included in statistics for the purpose of reports and summaries. 

In the XUnit report, it qualifies as a `SKIP` if `build_only_as_skip` is `True` and as a pass otherwise. This is consistent with the previous behaviour of the `PASS` status there, which already did a version of a is-build-only check.

Need for such a case was indicated e.g. in https://github.com/zephyrproject-rtos/zephyr/issues/58070. 

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/77404. It was required for proper NOTRUN status assignment. BUILT name was also proposed.

Uses a `CYAN` colour to differentiate it from the `PASS` and `SKIP`, as it can be interpreted both ways, as the XUnit case shows us.

Is not considered executed for the purposes of the end summary. Is not counted as a pass for the purposes of pass rate calculation.

