### PR TITLE
west: update hal_xtensa to latest commit

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -253,7 +253,7 @@ manifest:
       groups:
         - hal
     - name: hal_xtensa
-      revision: a2d658525b16c57bea8dd565f5bd5167e4b9f1ee
+      revision: baa56aa3e119b5aae43d16f9b2d2c8112e052871
       path: modules/hal/xtensa
       groups:
         - hal


### PR DESCRIPTION
This updates the hal_xtensa commit to latest, including:

* Adds intel_adsp_ace30_ptl SoC
* Adds sample_controller32 for MPU

Fixes https://github.com/zephyrproject-rtos/sdk-ng/issues/791