### PR TITLE
drivers: dac: dac_shell: consider buffered and internal options

### DIFF
--- a/drivers/dac/dac_shell.c
+++ b/drivers/dac/dac_shell.c
@@ -18,6 +18,7 @@ struct args_index {
 	uint8_t channel;
 	uint8_t value;
 	uint8_t resolution;
+	uint8_t options;
 };
 
 static const struct args_index args_indx = {
@@ -25,12 +26,14 @@ static const struct args_index args_indx = {
 	.channel = 2,
 	.value = 3,
 	.resolution = 3,
+	.options = 4,
 };
 
 static int cmd_setup(const struct shell *sh, size_t argc, char **argv)
 {
-	struct dac_channel_cfg cfg;
+	struct dac_channel_cfg cfg = {0};
 	const struct device *dac;
+	int argidx;
 	int err;
 
 	dac = device_get_binding(argv[args_indx.device]);
@@ -41,6 +44,21 @@ static int cmd_setup(const struct shell *sh, size_t argc, char **argv)
 
 	cfg.channel_id = strtoul(argv[args_indx.channel], NULL, 0);
 	cfg.resolution = strtoul(argv[args_indx.resolution], NULL, 0);
+
+	argidx = args_indx.options;
+	while (argidx < argc && strncmp(argv[argidx], "-", 1) == 0) {
+		if (strcmp(argv[argidx], "-b") == 0) {
+			cfg.buffered = true;
+			argidx++;
+		} else if (strcmp(argv[argidx], "-i") == 0) {
+			cfg.internal = true;
+			argidx++;
+		} else {
+			shell_error(sh, "unsupported option %s", argv[argidx]);
+			shell_help(sh);
+			return SHELL_CMD_HELP_PRINTED;
+		}
+	}
 
 	err = dac_channel_setup(dac, &cfg);
 	if (err) {
@@ -77,9 +95,15 @@ static int cmd_write_value(const struct shell *sh, size_t argc, char **argv)
 }
 
 SHELL_STATIC_SUBCMD_SET_CREATE(dac_cmds,
-	SHELL_CMD_ARG(setup, NULL, "<device> <channel> <resolution>",
-		      cmd_setup, 4, 0),
-	SHELL_CMD_ARG(write_value, NULL, "<device> <channel> <value>",
+	SHELL_CMD_ARG(setup, NULL,
+		      "Setup DAC channel\n"
+		      "Usage: setup <device> <channel> <resolution> [-b] [-i]\n"
+		      "-b Enable output buffer\n"
+		      "-i Connect internally",
+		      cmd_setup, 4, 2),
+	SHELL_CMD_ARG(write_value, NULL,
+		      "Write DAC value\n"
+		      "Usage: write <device> <channel> <value>",
 		      cmd_write_value, 4, 0),
 	SHELL_SUBCMD_SET_END
 );


### PR DESCRIPTION
The buffered and internal options were not assigned in the `channel_cfg`, so they would end up at a random state.

The `cfg` struct is now properly zero-initialized and both options can be set using optional parameters `-b` and `-i`.

Fixes #75884