### PR TITLE
soc: silabs: Update HAL for Series 2

### DIFF
--- a/drivers/bluetooth/hci/slz_hci.c
+++ b/drivers/bluetooth/hci/slz_hci.c
@@ -144,6 +144,10 @@ static int slz_bt_open(const struct device *dev, bt_hci_recv_t recv)
 	rail_isr_installer();
 	sl_rail_util_pa_init();
 
+	/* Disable 2M and coded PHYs, they do not work with the current configuration */
+	sl_btctrl_disable_2m_phy();
+	sl_btctrl_disable_coded_phy();
+
 	/* sl_btctrl_init_mem returns the number of memory buffers allocated */
 	ret = sl_btctrl_init_mem(SL_BT_CONTROLLER_BUFFER_MEMORY);
 	if (!ret) {
@@ -162,6 +166,7 @@ static int slz_bt_open(const struct device *dev, bt_hci_recv_t recv)
 	sl_btctrl_init_adv();
 	sl_btctrl_init_scan();
 	sl_btctrl_init_conn();
+	sl_btctrl_init_phy();
 	sl_btctrl_init_adv_ext();
 	sl_btctrl_init_scan_ext();
 

--- a/soc/silabs/common/soc.c
+++ b/soc/silabs/common/soc.c
@@ -22,9 +22,7 @@
 #ifdef CONFIG_SOC_GECKO_DEV_INIT
 #include <sl_device_init_dcdc.h>
 #include <sl_device_init_dpll.h>
-#include <sl_device_init_emu.h>
 #include <sl_device_init_hfxo.h>
-#include <sl_device_init_nvic.h>
 
 #ifdef CONFIG_PM
 #include <sl_hfxo_manager.h>
@@ -219,7 +217,6 @@ void soc_early_init_hook(void)
 	sl_device_init_dcdc();
 	sl_device_init_hfxo();
 	sl_device_init_dpll();
-	sl_device_init_emu();
 
 #ifdef CONFIG_PM
 	sl_power_manager_init();

--- a/west.yml
+++ b/west.yml
@@ -223,7 +223,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: 4c813a1f6c0bba03dec45a3878ba06cfb385565d
+      revision: bb44c61d3f8b1e00d7b3d3804cfaf8df1e905d5d
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
Update HAL for Series 2 devices to Simplicity SDK 2024.6.

This HAL deprecates sl_device_init_emu(). Equivalent functions are now performed by sl_power_manager_init().

For now, soc.c remains compatible with both the Gecko SDK based HAL for Series 0 and 1, and the Simplicity SDK based HAL for Series 2. In a future commit, soc.c will be split between the two platforms.