### PR TITLE
net: l2: wifi: ensure certificates directory is created

### DIFF
--- a/subsys/net/l2/wifi/CMakeLists.txt
+++ b/subsys/net/l2/wifi/CMakeLists.txt
@@ -26,6 +26,8 @@ endif()
 # Wi-Fi Enterprise test certificates handling
 set(gen_inc_dir ${ZEPHYR_BINARY_DIR}/misc/generated)
 set(gen_dir ${gen_inc_dir}/wifi_enterprise_test_certs)
+# Create output directory for test certs
+file(MAKE_DIRECTORY ${gen_dir})
 
 # convert .pem files to array data at build time
 zephyr_include_directories(${gen_inc_dir})


### PR DESCRIPTION
Ensure that the output certificates directory is created, where generated certificates will be placed. This fixes a build error seen when using `make` to build samples/net/wifi for the rd_rw612_bga board, where the output directory for generated certificates did not exist at build time.