### PR TITLE
llext-edk: rework, add Python export and more optional information

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2210,6 +2210,12 @@ add_custom_command(
         -DWEST_TOPDIR=${WEST_TOPDIR}
         -DZEPHYR_BASE=${ZEPHYR_BASE}
         -DCONFIG_LLEXT_EDK_USERSPACE_ONLY=${CONFIG_LLEXT_EDK_USERSPACE_ONLY}
+        -DARCH=${ARCH}
+        -DBOARD=${NORMALIZED_BOARD_TARGET}
+        -DSOC=${SOC_NAME}
+        -DTOOLCHAIN=${ZEPHYR_TOOLCHAIN_VARIANT}
+        -DCROSS_COMPILE=${CROSS_COMPILE_TARGET}
+        -DCOMPILER=${COMPILER}
         -P ${ZEPHYR_BASE}/cmake/llext-edk.cmake
     DEPENDS ${logical_target_for_zephyr_elf}
     COMMAND_EXPAND_LISTS

--- a/cmake/llext-edk.cmake
+++ b/cmake/llext-edk.cmake
@@ -106,11 +106,9 @@ foreach(flag ${llext_edk_cflags})
         relative_dir(${parent} dest bindir)
         cmake_path(RELATIVE_PATH dest BASE_DIRECTORY ${llext_edk} OUTPUT_VARIABLE dest_rel)
         if(bindir)
-            list(APPEND imacros_gen_make "-imacros\$(${install_dir_var})/${dest_rel}/${name}")
-            list(APPEND imacros_gen_cmake "-imacros\${CMAKE_CURRENT_LIST_DIR}/${dest_rel}/${name}")
+            list(APPEND imacros_gen "@DASHIMACROS@${dest_rel}/${name}")
         else()
-            list(APPEND imacros_make "-imacros\$(${install_dir_var})/${dest_rel}/${name}")
-            list(APPEND imacros_cmake "-imacros\${CMAKE_CURRENT_LIST_DIR}/${dest_rel}/${name}")
+            list(APPEND imacros "@DASHIMACROS@${dest_rel}/${name}")
         endif()
     else()
         list(APPEND new_cflags ${flag})
@@ -118,8 +116,7 @@ foreach(flag ${llext_edk_cflags})
 endforeach()
 set(llext_edk_cflags ${new_cflags})
 
-list(APPEND base_flags_make ${llext_edk_cflags} ${imacros_make})
-list(APPEND base_flags_cmake ${llext_edk_cflags} ${imacros_cmake})
+list(APPEND base_flags ${llext_edk_cflags} ${imacros})
 
 separate_arguments(include_dirs NATIVE_COMMAND ${INTERFACE_INCLUDE_DIRECTORIES})
 file(MAKE_DIRECTORY ${llext_edk_inc})
@@ -137,18 +134,14 @@ foreach(dir ${include_dirs})
 
     cmake_path(RELATIVE_PATH dest BASE_DIRECTORY ${llext_edk} OUTPUT_VARIABLE dest_rel)
     if(bindir)
-        list(APPEND inc_gen_flags_make "-I\$(${install_dir_var})/${dest_rel}")
-        list(APPEND inc_gen_flags_cmake "-I\${CMAKE_CURRENT_LIST_DIR}/${dest_rel}")
+        list(APPEND gen_inc_flags "@DASHI@${dest_rel}")
     else()
-        list(APPEND inc_flags_make "-I\$(${install_dir_var})/${dest_rel}")
-        list(APPEND inc_flags_cmake "-I\${CMAKE_CURRENT_LIST_DIR}/${dest_rel}")
+        list(APPEND inc_flags "@DASHI@${dest_rel}")
     endif()
-    list(APPEND all_inc_flags_make "-I\$(${install_dir_var})/${dest_rel}")
-    list(APPEND all_inc_flags_cmake "-I\${CMAKE_CURRENT_LIST_DIR}/${dest_rel}")
+    list(APPEND all_inc_flags "@DASHI@${dest_rel}")
 endforeach()
 
-list(APPEND all_flags_make ${base_flags_make} ${imacros_gen_make} ${all_inc_flags_make})
-list(APPEND all_flags_cmake ${base_flags_cmake} ${imacros_gen_cmake} ${all_inc_flags_cmake})
+list(APPEND all_flags ${base_flags} ${imacros_gen} ${all_inc_flags})
 
 if(CONFIG_LLEXT_EDK_USERSPACE_ONLY)
     # Copy syscall headers from edk directory, as they were regenerated there.
@@ -160,8 +153,16 @@ endif()
 # Generate the EDK flags files
 #
 
+set(edk_targets MAKEFILE CMAKE)
 set(edk_file_MAKEFILE ${llext_edk}/Makefile.cflags)
 set(edk_file_CMAKE ${llext_edk}/cmake.cflags)
+
+# Escape problematic characters in a string
+function(edk_escape target str_in str_out)
+    string(REPLACE "\\" "\\\\" str_escaped "${str_in}")
+    string(REPLACE "\"" "\\\"" str_escaped "${str_escaped}")
+    set(${str_out} "${str_escaped}" PARENT_SCOPE)
+endfunction()
 
 # Clear the contents of the requested file
 function(edk_write_header target)
@@ -173,36 +174,39 @@ function(edk_write_var target var_name var_value)
     if(target STREQUAL "CMAKE")
         # CMake: export assignments of the form:
         #
-        #   set(var value1;value2;...)
+        #   set(var "value1;value2;...")
         #
-        file(APPEND ${edk_file_${target}} "set(${var_name} ${var_value})\n")
+        edk_escape(${target} "${exp_var_value}" exp_var_value)
+        set(DASHIMACROS "-imacros\${CMAKE_CURRENT_LIST_DIR}/")
+        set(DASHI "-I\${CMAKE_CURRENT_LIST_DIR}/")
+        string(CONFIGURE "${var_value}" exp_var_value @ONLY)
+        # The list is otherwise exported verbatim, surrounded by quotes.
+        file(APPEND ${edk_file_${target}} "set(${var_name} \"${exp_var_value}\")\n")
     elseif(target STREQUAL "MAKEFILE")
         # Makefile: export assignments of the form:
         #
-        #   var = value1 value2 ...
+        #   var = "value1" "value2" ...
         #
-        list(JOIN var_value " " var_value_str)
-        file(APPEND ${edk_file_${target}} "${var_name} = ${var_value_str}\n")
+        edk_escape(${target} "${exp_var_value}" exp_var_value)
+        set(DASHIMACROS "-imacros\$(${install_dir_var})/")
+        set(DASHI "-I\$(${install_dir_var})/")
+        string(CONFIGURE "${var_value}" exp_var_value @ONLY)
+        # Each element of the list is wrapped in quotes and is separated by a space.
+        list(JOIN exp_var_value "\" \"" exp_var_value_str)
+        file(APPEND ${edk_file_${target}} "${var_name} = \"${exp_var_value_str}\"\n")
     endif()
 endfunction()
 
-# Generate flags for Makefile
-edk_write_header(MAKEFILE)
-edk_write_var(MAKEFILE "LLEXT_CFLAGS" "${all_flags_make}")
-edk_write_var(MAKEFILE "LLEXT_ALL_INCLUDE_CFLAGS" "${all_inc_flags_make}")
-edk_write_var(MAKEFILE "LLEXT_INCLUDE_CFLAGS" "${inc_flags_make}")
-edk_write_var(MAKEFILE "LLEXT_GENERATED_INCLUDE_CFLAGS" "${gen_inc_flags_make}")
-edk_write_var(MAKEFILE "LLEXT_BASE_CFLAGS" "${base_flags_make}")
-edk_write_var(MAKEFILE "LLEXT_GENERATED_IMACROS_CFLAGS" "${imacros_gen_make}")
+foreach(target ${edk_targets})
+    edk_write_header(${target})
 
-# Generate flags for CMake
-edk_write_header(CMAKE)
-edk_write_var(CMAKE "LLEXT_CFLAGS" "${all_flags_cmake}")
-edk_write_var(CMAKE "LLEXT_ALL_INCLUDE_CFLAGS" "${all_inc_flags_cmake}")
-edk_write_var(CMAKE "LLEXT_INCLUDE_CFLAGS" "${inc_flags_cmake}")
-edk_write_var(CMAKE "LLEXT_GENERATED_INCLUDE_CFLAGS" "${gen_inc_flags_cmake}")
-edk_write_var(CMAKE "LLEXT_BASE_CFLAGS" "${base_flags_cmake}")
-edk_write_var(CMAKE "LLEXT_GENERATED_IMACROS_CFLAGS" "${imacros_gen_cmake}")
+    edk_write_var(${target} "LLEXT_CFLAGS" "${all_flags}")
+    edk_write_var(${target} "LLEXT_ALL_INCLUDE_CFLAGS" "${all_inc_flags}")
+    edk_write_var(${target} "LLEXT_INCLUDE_CFLAGS" "${inc_flags}")
+    edk_write_var(${target} "LLEXT_GENERATED_INCLUDE_CFLAGS" "${gen_inc_flags}")
+    edk_write_var(${target} "LLEXT_BASE_CFLAGS" "${base_flags}")
+    edk_write_var(${target} "LLEXT_GENERATED_IMACROS_CFLAGS" "${imacros_gen}")
+endforeach()
 
 # Generate the tarball
 file(ARCHIVE_CREATE

--- a/cmake/llext-edk.cmake
+++ b/cmake/llext-edk.cmake
@@ -147,44 +147,62 @@ foreach(dir ${include_dirs})
     list(APPEND all_inc_flags_cmake "-I\${CMAKE_CURRENT_LIST_DIR}/${dest_rel}")
 endforeach()
 
+list(APPEND all_flags_make ${base_flags_make} ${imacros_gen_make} ${all_inc_flags_make})
+list(APPEND all_flags_cmake ${base_flags_cmake} ${imacros_gen_cmake} ${all_inc_flags_cmake})
+
 if(CONFIG_LLEXT_EDK_USERSPACE_ONLY)
     # Copy syscall headers from edk directory, as they were regenerated there.
     file(COPY ${PROJECT_BINARY_DIR}/edk/include/generated/ DESTINATION ${llext_edk_inc}/zephyr/include/generated)
 endif()
 
+
+#
+# Generate the EDK flags files
+#
+
+set(edk_file_MAKEFILE ${llext_edk}/Makefile.cflags)
+set(edk_file_CMAKE ${llext_edk}/cmake.cflags)
+
+# Clear the contents of the requested file
+function(edk_write_header target)
+    file(WRITE ${edk_file_${target}} "")
+endfunction()
+
+# Define a variable in the file
+function(edk_write_var target var_name var_value)
+    if(target STREQUAL "CMAKE")
+        # CMake: export assignments of the form:
+        #
+        #   set(var value1;value2;...)
+        #
+        file(APPEND ${edk_file_${target}} "set(${var_name} ${var_value})\n")
+    elseif(target STREQUAL "MAKEFILE")
+        # Makefile: export assignments of the form:
+        #
+        #   var = value1 value2 ...
+        #
+        list(JOIN var_value " " var_value_str)
+        file(APPEND ${edk_file_${target}} "${var_name} = ${var_value_str}\n")
+    endif()
+endfunction()
+
 # Generate flags for Makefile
-list(APPEND all_flags_make ${base_flags_make} ${imacros_gen_make} ${all_inc_flags_make})
-list(JOIN all_flags_make " " all_flags_str)
-file(WRITE ${llext_edk}/Makefile.cflags "LLEXT_CFLAGS = ${all_flags_str}")
-
-list(JOIN all_inc_flags_make " " all_inc_flags_str)
-file(APPEND ${llext_edk}/Makefile.cflags "\n\nLLEXT_ALL_INCLUDE_CFLAGS = ${all_inc_flags_str}")
-
-list(JOIN inc_flags_make " " inc_flags_str)
-file(APPEND ${llext_edk}/Makefile.cflags "\n\nLLEXT_INCLUDE_CFLAGS = ${inc_flags_str}")
-
-list(JOIN inc_gen_flags_make " " inc_gen_flags_str)
-file(APPEND ${llext_edk}/Makefile.cflags "\n\nLLEXT_GENERATED_INCLUDE_CFLAGS = ${inc_gen_flags_str}")
-
-list(JOIN base_flags_make " " base_flags_str)
-file(APPEND ${llext_edk}/Makefile.cflags "\n\nLLEXT_BASE_CFLAGS = ${base_flags_str}")
-
-list(JOIN imacros_gen_make " " imacros_gen_str)
-file(APPEND ${llext_edk}/Makefile.cflags "\n\nLLEXT_GENERATED_IMACROS_CFLAGS = ${imacros_gen_str}")
+edk_write_header(MAKEFILE)
+edk_write_var(MAKEFILE "LLEXT_CFLAGS" "${all_flags_make}")
+edk_write_var(MAKEFILE "LLEXT_ALL_INCLUDE_CFLAGS" "${all_inc_flags_make}")
+edk_write_var(MAKEFILE "LLEXT_INCLUDE_CFLAGS" "${inc_flags_make}")
+edk_write_var(MAKEFILE "LLEXT_GENERATED_INCLUDE_CFLAGS" "${gen_inc_flags_make}")
+edk_write_var(MAKEFILE "LLEXT_BASE_CFLAGS" "${base_flags_make}")
+edk_write_var(MAKEFILE "LLEXT_GENERATED_IMACROS_CFLAGS" "${imacros_gen_make}")
 
 # Generate flags for CMake
-list(APPEND all_flags_cmake ${base_flags_cmake} ${imacros_gen_cmake} ${all_inc_flags_cmake})
-file(WRITE ${llext_edk}/cmake.cflags "set(LLEXT_CFLAGS ${all_flags_cmake})")
-
-file(APPEND ${llext_edk}/cmake.cflags "\n\nset(LLEXT_ALL_INCLUDE_CFLAGS ${all_inc_flags_cmake})")
-
-file(APPEND ${llext_edk}/cmake.cflags "\n\nset(LLEXT_INCLUDE_CFLAGS ${inc_flags_cmake})")
-
-file(APPEND ${llext_edk}/cmake.cflags "\n\nset(LLEXT_GENERATED_INCLUDE_CFLAGS ${inc_gen_flags_cmake})")
-
-file(APPEND ${llext_edk}/cmake.cflags "\n\nset(LLEXT_BASE_CFLAGS ${base_flags_cmake})")
-
-file(APPEND ${llext_edk}/cmake.cflags "\n\nset(LLEXT_GENERATED_IMACROS_CFLAGS ${imacros_gen_cmake})")
+edk_write_header(CMAKE)
+edk_write_var(CMAKE "LLEXT_CFLAGS" "${all_flags_cmake}")
+edk_write_var(CMAKE "LLEXT_ALL_INCLUDE_CFLAGS" "${all_inc_flags_cmake}")
+edk_write_var(CMAKE "LLEXT_INCLUDE_CFLAGS" "${inc_flags_cmake}")
+edk_write_var(CMAKE "LLEXT_GENERATED_INCLUDE_CFLAGS" "${gen_inc_flags_cmake}")
+edk_write_var(CMAKE "LLEXT_BASE_CFLAGS" "${base_flags_cmake}")
+edk_write_var(CMAKE "LLEXT_GENERATED_IMACROS_CFLAGS" "${imacros_gen_cmake}")
 
 # Generate the tarball
 file(ARCHIVE_CREATE

--- a/doc/services/llext/build.rst
+++ b/doc/services/llext/build.rst
@@ -152,15 +152,35 @@ directory. It's a tarball that contains the headers and compile flags needed
 to build extensions. The extension developer can then include the headers
 and use the compile flags in their build system to build the extension.
 
+EDK definition files
+--------------------
+
+The EDK includes several convenience files which define a set of variables that
+contain the compile flags needed by the project, as well as other build-related
+information, when enabled. The information is currently exported in the
+following formats:
+
+- ``Makefile.cflags``, for Makefile-based projects;
+- ``cmake.cflags``, for CMake-based projects;
+- ``python.cflags``, for interfacing with Python scripts.
+
+Paths to the headers and flags are prefixed by the EDK root directory. This is
+automatically obtained for CMake projects from ``CMAKE_CURRENT_LIST_DIR``;
+other formats refer to an ``LLEXT_EDK_INSTALL_DIR`` variable, which must be set
+by the user with the path where the EDK is installed before including the
+generated file.
+
+.. note::
+   The ``LLEXT_EDK`` prefix in the variable name may be changed with the
+   :kconfig:option:`CONFIG_LLEXT_EDK_NAME` option.
+
 Compile flags
 -------------
 
-The EDK includes the convenience files ``cmake.cflags`` (for CMake-based
-projects) and ``Makefile.cflags`` (for Make-based ones), which define a set of
-variables that contain the compile flags needed by the project. The full list
-of flags needed to build an extension is provided by ``LLEXT_CFLAGS``. Also
-provided is a more granular set of flags that can be used in support of
-different use cases, such as when building mocks for unit tests:
+The full list of flags needed to build an extension is provided by
+``LLEXT_CFLAGS``. Also provided is a more granular set of flags that can be
+used in support of different use cases, such as when building mocks for unit
+tests:
 
 ``LLEXT_INCLUDE_CFLAGS``
 
@@ -194,6 +214,40 @@ different use cases, such as when building mocks for unit tests:
         ``LLEXT_ALL_INCLUDE_CFLAGS``, ``LLEXT_GENERATED_IMACROS_CFLAGS`` and
         ``LLEXT_BASE_CFLAGS``.
 
+Target and build information
+----------------------------
+
+The EDK includes information that identifies the target of the current Zephyr
+build and the used toolchain. The following variables are currently defined,
+which mirror the information available in the Zephyr build system:
+
+``LLEXT_EDK_ARCH``
+    The architecture for the target used in the Zephyr build.
+
+``LLEXT_EDK_BOARD``
+    The fully normalized board target used in the Zephyr build.
+
+``LLEXT_EDK_SOC``
+    The SoC name for the target used in the Zephyr build.
+
+``LLEXT_EDK_TOOLCHAIN``
+    The toolchain variant used in the Zephyr build.
+
+``LLEXT_EDK_CROSS_COMPILE``
+    When defined by the toolchain, the cross-compile prefix for the compiler
+    used in the Zephyr build.
+
+``LLEXT_EDK_COMPILER``
+    The name of the compiler used in the Zephyr build.
+
+.. important::
+   The above variables exposie Zephyr internals. The list of variables and
+   their contents may change in future Zephyr releases.
+
+.. note::
+   The ``LLEXT_EDK`` prefix in the variable names may be changed with the
+   :kconfig:option:`CONFIG_LLEXT_EDK_NAME` option.
+
 .. _llext_kconfig_edk:
 
 LLEXT EDK Kconfig options
@@ -202,7 +256,8 @@ LLEXT EDK Kconfig options
 The LLEXT EDK can be configured using the following Kconfig options:
 
 :kconfig:option:`CONFIG_LLEXT_EDK_NAME`
-    The name of the generated EDK tarball.
+    The name of the generated EDK tarball. This is also used as the prefix for
+    several variables defined in the EDK files.
 
 :kconfig:option:`CONFIG_LLEXT_EDK_USERSPACE_ONLY`
     If set, the EDK will include headers that do not contain code to route


### PR DESCRIPTION
When building several different EDKs, there's currently no way to avoid mistaking one for another. The goal of this PR is to add metadata to a generated EDK so that the target board / SOC / CPU can be retrieved and checked by downstream projects.

An additional Python-compatible output format is provided for projects that do not use CMake or make.

To implement the above, a number of internal refactors with minimal visible effect have been implemented, with the goal of having more maintainable and extendable code:
- the EDK output commands have been refactored into generic functions that take the target file type as a parameter;
- flag processing has been made target-agnostic by using placeholders that are expanded in the output functions.

[LLEXT EDK documentation](https://builds.zephyrproject.io/zephyr/pr/78727/docs/services/llext/build.html#llext-extension-development-kit-edk) has been updated accordingly.

*EDIT:* updated after review notes. 