### PR TITLE
Fix NXP LPSPI native chip select when using synchronous API with DMA

### DIFF
--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -199,11 +199,6 @@ static int spi_mcux_configure(const struct device *dev,
 	uint32_t clock_freq;
 	uint32_t word_size;
 
-	if (spi_context_configured(&data->ctx, spi_cfg)) {
-		/* This configuration is already in use */
-		return 0;
-	}
-
 	if (spi_cfg->operation & SPI_HALF_DUPLEX) {
 		LOG_ERR("Half-duplex not supported");
 		return -ENOTSUP;
@@ -517,6 +512,8 @@ static int transceive_dma(const struct device *dev,
 		return ret;
 	}
 
+	base->TCR |= LPSPI_TCR_CONT_MASK;
+
 	/* DMA is fast enough watermarks are not required */
 	LPSPI_SetFifoWatermarks(base, 0U, 0U);
 
@@ -531,6 +528,11 @@ static int transceive_dma(const struct device *dev,
 			if (ret != 0) {
 				goto out;
 			}
+
+			while (!(LPSPI_GetStatusFlags(base) & kLPSPI_TxDataRequestFlag)) {
+				/* wait until previous tx finished */
+			}
+
 			/* Enable DMA Requests */
 			LPSPI_EnableDMA(base, kLPSPI_TxDmaEnable | kLPSPI_RxDmaEnable);
 
@@ -538,9 +540,6 @@ static int transceive_dma(const struct device *dev,
 			ret = wait_dma_rx_tx_done(dev);
 			if (ret != 0) {
 				goto out;
-			}
-			while ((LPSPI_GetStatusFlags(base) & kLPSPI_ModuleBusyFlag)) {
-				/* wait until module is idle */
 			}
 
 			/* Disable DMA */
@@ -551,6 +550,7 @@ static int transceive_dma(const struct device *dev,
 			spi_context_update_rx(&data->ctx, 1, dma_size);
 		}
 		spi_context_cs_control(&data->ctx, false);
+		base->TCR = 0;
 
 out:
 		spi_context_release(&data->ctx, ret);

--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -276,6 +276,10 @@ static int spi_mcux_configure(const struct device *dev,
 
 	LPSPI_MasterInit(base, &master_config, clock_freq);
 
+	if (IS_ENABLED(CONFIG_DEBUG)) {
+		base->CR |= LPSPI_CR_DBGEN_MASK;
+	}
+
 	LPSPI_MasterTransferCreateHandle(base, &data->handle,
 					 spi_mcux_master_transfer_callback,
 					 data);


### PR DESCRIPTION
This PR fixes the native CS so that it does not deassert during a transfer when using the synchronous spi_transceive API with the CONFIG_SPI_MCUX_LPSPI_DMA=y when the dma channel is set up for the peripheral.

Note that this does NOT fix the native chip select non-DMA path of the driver, it appears that would require a large driver rework as that limitation comes from using the MCUX SDK driver API which is not compatible with the zephyr use case. The DMA path does not use the SDK API and therefore it is more straightforward to fix.

This also does not work still on the asynchronous API, as the asynchronous API is known not to work at all anyways (see: #74907)

This PR will not close issue #16544 since it only fixes the DMA path of the driver.

spi_loopback test with DMA without fix:
![image](https://github.com/user-attachments/assets/97e136a5-408e-4464-b458-88e706a9ec4b)

spi_loopback test with DMA with fix: 
![image](https://github.com/user-attachments/assets/4f60f0ec-1a28-448e-8f55-e39fd5d7d560)
