### PR TITLE
wifi: EAP-TLS testing fixes

### DIFF
--- a/doc/connectivity/networking/api/wifi.rst
+++ b/doc/connectivity/networking/api/wifi.rst
@@ -44,7 +44,7 @@ To initiate Wi-Fi connection, the following command can be used:
 
 .. code-block:: console
 
-    uart:~$ wifi connect -s <SSID> -k 5 -a anon -K whatever
+    uart:~$ wifi connect -s <SSID> -k 7 -a anon -K whatever
 
 Server certificate is also provided in the same directory for testing purposes.
 Any AAA server can be used for testing purposes, for example, ``FreeRADIUS`` or ``hostapd``.

--- a/doc/connectivity/networking/api/wifi.rst
+++ b/doc/connectivity/networking/api/wifi.rst
@@ -38,7 +38,15 @@ module.
     $ cp client.pem samples/net/wifi/test_certs/
     $ cp client-key.pem samples/net/wifi/test_certs/
     $ cp ca.pem samples/net/wifi/test_certs/
-    $ west build -p -b <board> samples/net/wifi
+    $ west build -p -b <board> samples/net/wifi -- -DEXTRA_CONF_FILE=overlay-enterprise.conf
+
+For using variable size network buffer, the following overlay file can be used:
+
+.. code-block:: bash
+
+    $ west build -p -b <board> samples/net/wifi -- -DEXTRA_CONF_FILE=overlay-enterprise-variable-bufs.conf
+
+
 
 To initiate Wi-Fi connection, the following command can be used:
 

--- a/modules/hostap/CMakeLists.txt
+++ b/modules/hostap/CMakeLists.txt
@@ -477,6 +477,17 @@ zephyr_library_compile_definitions_ifdef(CONFIG_EAP_FAST
   EAP_FAST
 )
 
+# Needs TLS1.3 and SESSION_TICKETS
+zephyr_library_sources_ifdef(CONFIG_EAP_FAST
+  ${HOSTAP_SRC_BASE}/eap_peer/eap_fast.c
+  ${HOSTAP_SRC_BASE}/eap_peer/eap_fast_pac.c
+  ${HOSTAP_SRC_BASE}/eap_common/eap_fast_common.c
+)
+
+zephyr_library_compile_definitions_ifdef(CONFIG_EAP_FAST
+  EAP_FAST
+)
+
 zephyr_library_compile_definitions_ifndef(CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE
 	CONFIG_NO_CONFIG_BLOBS
 )

--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -511,17 +511,7 @@ static int wpas_add_and_config_network(struct wpa_supplicant *wpa_s,
 	}
 
 	if (params->security != WIFI_SECURITY_TYPE_NONE) {
-		if (params->sae_password) {
-			if ((params->sae_password_length < WIFI_PSK_MIN_LEN) ||
-			    (params->sae_password_length > WIFI_SAE_PSWD_MAX_LEN)) {
-				wpa_printf(MSG_ERROR,
-					   "Passphrase should be in range (%d-%d) characters",
-					   WIFI_PSK_MIN_LEN, WIFI_SAE_PSWD_MAX_LEN);
-				goto out;
-			}
-			strncpy(sae_null_terminated, params->sae_password, WIFI_SAE_PSWD_MAX_LEN);
-			sae_null_terminated[params->sae_password_length] = '\0';
-		} else {
+		if (params->psk) {
 			if ((params->psk_length < WIFI_PSK_MIN_LEN) ||
 			    (params->psk_length > WIFI_PSK_MAX_LEN)) {
 				wpa_printf(MSG_ERROR,
@@ -553,6 +543,16 @@ static int wpas_add_and_config_network(struct wpa_supplicant *wpa_s,
 		    params->security == WIFI_SECURITY_TYPE_SAE_H2E ||
 		    params->security == WIFI_SECURITY_TYPE_SAE_AUTO) {
 			if (params->sae_password) {
+				if ((params->sae_password_length < WIFI_PSK_MIN_LEN) ||
+				    (params->sae_password_length > WIFI_SAE_PSWD_MAX_LEN)) {
+					wpa_printf(MSG_ERROR,
+						"Passphrase should be in range (%d-%d) characters",
+						WIFI_PSK_MIN_LEN, WIFI_SAE_PSWD_MAX_LEN);
+					goto out;
+				}
+				strncpy(sae_null_terminated, params->sae_password,
+					WIFI_SAE_PSWD_MAX_LEN);
+				sae_null_terminated[params->sae_password_length] = '\0';
 				if (!wpa_cli_cmd_v("set_network %d sae_password \"%s\"",
 						   resp.network_id, sae_null_terminated)) {
 					goto out;

--- a/samples/net/wifi/overlay-enterprise-variable-bufs.conf
+++ b/samples/net/wifi/overlay-enterprise-variable-bufs.conf
@@ -1,0 +1,9 @@
+CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE=y
+# EAP frames are ~1100 bytes, so, for efficiency, we set the data size to 1100
+CONFIG_NET_BUF_DATA_SIZE=1100
+# Use variable data size to reduce memory usage for small data packets
+CONFIG_NET_BUF_VARIABLE_DATA_SIZE=y
+# For TLS and X.509 processing MbedTLS needs large heap size and using separate heap
+# for MbedTLS gives us more control over the heap size.
+CONFIG_MBEDTLS_ENABLE_HEAP=y
+CONFIG_MBEDTLS_HEAP_SIZE=55000

--- a/samples/net/wifi/overlay-enterprise.conf
+++ b/samples/net/wifi/overlay-enterprise.conf
@@ -1,0 +1,10 @@
+CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE=y
+# EAP frames are ~1100 bytes, so, need higher packet counts as default packet size is 128
+CONFIG_NET_PKT_TX_COUNT=36
+CONFIG_NET_PKT_RX_COUNT=36
+CONFIG_NET_BUF_TX_COUNT=72
+CONFIG_NET_BUF_RX_COUNT=36
+# For TLS and X.509 processing MbedTLS needs large heap size and using separate heap
+# for MbedTLS gives us more control over the heap size.
+CONFIG_MBEDTLS_ENABLE_HEAP=y
+CONFIG_MBEDTLS_HEAP_SIZE=55000

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -32,14 +32,17 @@ LOG_MODULE_REGISTER(net_wifi_shell, LOG_LEVEL_INF);
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE
 static const char ca_cert_test[] = {
 	#include <wifi_enterprise_test_certs/ca.pem.inc>
+	'\0'
 };
 
 static const char client_cert_test[] = {
 	#include <wifi_enterprise_test_certs/client.pem.inc>
+	'\0'
 };
 
 static const char client_key_test[] = {
 	#include <wifi_enterprise_test_certs/client-key.pem.inc>
+	'\0'
 };
 #endif
 


### PR DESCRIPTION
Fixes from testing EAP-TLS, also recent SAE changes has broken the doc (enum in Wi-Fi shell), fixes that as well.