### PR TITLE
soc: nxp: rt116x: Fix bus clocking

### DIFF
--- a/soc/nxp/imxrt/imxrt11xx/soc.c
+++ b/soc/nxp/imxrt/imxrt11xx/soc.c
@@ -334,9 +334,9 @@ static ALWAYS_INLINE void clock_init(void)
 	rootCfg.div = 2;
 	CLOCK_SetRootClock(kCLOCK_Root_Bus, &rootCfg);
 #elif defined(CONFIG_SOC_MIMXRT1166_CM7)
-	/* Configure root bus clock at 200M */
-	rootCfg.mux = kCLOCK_BUS_ClockRoot_MuxSysPll1Div5;
-	rootCfg.div = 1;
+	/* Configure root bus clock at 198M */
+	rootCfg.mux = kCLOCK_BUS_ClockRoot_MuxSysPll2Pfd3;
+	rootCfg.div = 2;
 	CLOCK_SetRootClock(kCLOCK_Root_Bus, &rootCfg);
 #endif
 


### PR DESCRIPTION
Fixes #78676, Reverts bus clock settings.  Follows MCUXpresso SDK clock settings, and sets to output of SysPLL2 PFD3 at 198 MHz.