### PR TITLE
boards: shields: rk055hdmipi4ma0: raise MIPI DSI bit clock for RT1170

### DIFF
--- a/boards/shields/rk055hdmipi4ma0/boards/mimxrt1170_evk_mimxrt1176_cm7.overlay
+++ b/boards/shields/rk055hdmipi4ma0/boards/mimxrt1170_evk_mimxrt1176_cm7.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2024, NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&zephyr_mipi_dsi {
+	/* Raise the DSI clock frequency */
+	phy-clock = <792000000>;
+};


### PR DESCRIPTION
The RT1170 MIPI DPHY requires a faster clock frequency setting for the MIPI DPHY, or the pixel packet counts for the HFP, HBP, and HSA will be incorrect, and the DSI transfers will stall. Raise the target DPHY clock frequency to resolve this.

Fixes #78299