### PR TITLE
scripts: Don't fail CI if using deprecated DT prop

### DIFF
--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -60,6 +60,7 @@ def main():
                          # Suppress this warning if it's suppressed in dtc
                          warn_reg_unit_address_mismatch=
                              "-Wno-simple_bus_reg" not in args.dtc_flags,
+                         warn_deprecated=not args.edtlib_Wno_deprecated,
                          default_prop_types=True,
                          infer_binding_for_paths=["/zephyr,user"],
                          werror=args.edtlib_Werror,
@@ -208,6 +209,9 @@ def parse_args():
                         help="if set, edtlib-specific warnings become errors. "
                              "(this does not apply to warnings shared "
                              "with dtc.)")
+    parser.add_argument("--edtlib-Wno-deprecated", action="store_true",
+                        help="if set, edtlib will not warn if a property on "
+                             "a node is deprecated.")
 
     return parser.parse_args()
 

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -1981,6 +1981,7 @@ class EDT:
                  dts: Optional[str],
                  bindings_dirs: List[str],
                  warn_reg_unit_address_mismatch: bool = True,
+                 warn_deprecated: bool = True,
                  default_prop_types: bool = True,
                  support_fixed_partitions_on_any_bus: bool = True,
                  infer_binding_for_paths: Optional[Iterable[str]] = None,
@@ -2000,6 +2001,10 @@ class EDT:
           If True, a warning is logged if a node has a 'reg' property where
           the address of the first entry does not match the unit address of the
           node
+
+        warn_deprecated (default: True):
+          If True, a warning is logged if a node has a property that is marked
+          as deprecated in its binding.
 
         default_prop_types (default: True):
           If True, default property types will be used when a node has no
@@ -2045,6 +2050,7 @@ class EDT:
 
         # Saved kwarg values for internal use
         self._warn_reg_unit_address_mismatch: bool = warn_reg_unit_address_mismatch
+        self._warn_deprecated: bool = warn_deprecated
         self._default_prop_types: bool = default_prop_types
         self._fixed_partitions_no_bus: bool = support_fixed_partitions_on_any_bus
         self._infer_binding_for_paths: Set[str] = set(infer_binding_for_paths or [])
@@ -2135,6 +2141,7 @@ class EDT:
             None,
             self.bindings_dirs,
             warn_reg_unit_address_mismatch=self._warn_reg_unit_address_mismatch,
+            warn_deprecated = self._warn_deprecated,
             default_prop_types=self._default_prop_types,
             support_fixed_partitions_on_any_bus=self._fixed_partitions_no_bus,
             infer_binding_for_paths=set(self._infer_binding_for_paths),
@@ -2346,7 +2353,7 @@ class EDT:
             # they (either always or sometimes) reference other nodes, so we
             # run them separately
             node._init_props(default_prop_types=self._default_prop_types,
-                             err_on_deprecated=self._werror)
+                             err_on_deprecated=self._werror and self._warn_deprecated)
             node._init_interrupts()
             node._init_pinctrls()
 

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -335,6 +335,8 @@ class CMake:
             warnings_as_errors = 'n'
             gen_defines_args = ""
 
+        gen_defines_args = gen_defines_args + ";--edtlib-Wno-deprecated"
+
         warning_command = 'CONFIG_COMPILER_WARNINGS_AS_ERRORS'
         if self.instance.sysbuild:
             warning_command = 'SB_' + warning_command


### PR DESCRIPTION
Add parameter to EDT class init for enabling a warning if a property on a node in DT is deprecated the default is True since this is the current behavior.

Add argument to gen_defines.py to suppres warning if a DT property appearing on a node is deprecated. If this argument is not set, the current behavior (no suppression) will be used.

Set the gen_defines argument in the twister runner.py so that CI doesn't fail when using a deprecated DT property.

**The purpose of this is to allow deprecating DT properties and still using them in-tree if they have not yet been removed from a binding.**