### PR TITLE
tests: drivers: sensor: temp_sensor: Add configs for rpi_pico die_temp

### DIFF
--- a/tests/drivers/sensor/temp_sensor/boards/rpi_pico.overlay
+++ b/tests/drivers/sensor/temp_sensor/boards/rpi_pico.overlay
@@ -1,0 +1,9 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2024 TOKITA Hiroshi
+ */
+
+temp_sensor: &die_temp {
+	status = "okay";
+};


### PR DESCRIPTION
Adds test configs for RaspberryPi Pico's die temp sensor.