### PR TITLE
net: if: Check chksum offloading properly for VLAN interfaces

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -5148,7 +5148,19 @@ static bool need_calc_checksum(struct net_if *iface, enum ethernet_hw_caps caps,
 	enum ethernet_config_type config_type;
 
 	if (net_if_l2(iface) != &NET_L2_GET_NAME(ETHERNET)) {
-		return true;
+		/* For VLANs, figure out the main Ethernet interface and
+		 * get the offloading capabilities from it.
+		 */
+		if (IS_ENABLED(CONFIG_NET_VLAN) && net_eth_is_vlan_interface(iface)) {
+			iface = net_eth_get_vlan_main(iface);
+			if (iface == NULL) {
+				return true;
+			}
+
+			NET_ASSERT(net_if_l2(iface) == &NET_L2_GET_NAME(ETHERNET));
+		} else {
+			return true;
+		}
 	}
 
 	if (!(net_eth_get_hw_capabilities(iface) & caps)) {


### PR DESCRIPTION
Make sure we check the checksum offloading capabilities correctly for VLAN interfaces. Use the real Ethernet interface when doing the check.

Fixes #78724