### PR TITLE
ethernet: phy: extend phy interface with MMD read and write

### DIFF
--- a/drivers/ethernet/phy/phy_adin2111.c
+++ b/drivers/ethernet/phy/phy_adin2111.c
@@ -146,7 +146,7 @@ static int phy_adin2111_c45_setup_dev_reg(const struct device *dev, uint16_t dev
 	return mdio_write(cfg->mdio, cfg->phy_addr, ADIN1100_MMD_ACCESS_CNTRL, devad | BIT(14));
 }
 
-static int phy_adin2111_c45_read(const struct device *dev, uint16_t devad,
+static int phy_adin2111_c45_read(const struct device *dev, uint8_t devad,
 				 uint16_t reg, uint16_t *val)
 {
 	const struct phy_adin2111_config *cfg = dev->config;
@@ -165,7 +165,7 @@ static int phy_adin2111_c45_read(const struct device *dev, uint16_t devad,
 	return mdio_read_c45(cfg->mdio, cfg->phy_addr, devad, reg, val);
 }
 
-static int phy_adin2111_c45_write(const struct device *dev, uint16_t devad,
+static int phy_adin2111_c45_write(const struct device *dev, uint8_t devad,
 				  uint16_t reg, uint16_t val)
 {
 	const struct phy_adin2111_config *cfg = dev->config;
@@ -208,6 +208,36 @@ static int phy_adin2111_reg_write(const struct device *dev, uint16_t reg_addr,
 	mdio_bus_enable(cfg->mdio);
 
 	ret = phy_adin2111_c22_write(dev, reg_addr, (uint16_t) data);
+
+	mdio_bus_disable(cfg->mdio);
+
+	return ret;
+}
+
+static int phy_adin2111_reg_read_mmd(const struct device *dev, uint8_t dev_addr, uint16_t reg_addr,
+				     uint32_t *data)
+{
+	const struct phy_adin2111_config *cfg = dev->config;
+	int ret;
+
+	mdio_bus_enable(cfg->mdio);
+
+	ret = phy_adin2111_c45_read(dev, dev_addr, reg_addr, (uint16_t *)data);
+
+	mdio_bus_disable(cfg->mdio);
+
+	return ret;
+}
+
+static int phy_adin2111_reg_write_mmd(const struct device *dev, uint8_t dev_addr, uint16_t reg_addr,
+				      uint32_t data)
+{
+	const struct phy_adin2111_config *cfg = dev->config;
+	int ret;
+
+	mdio_bus_enable(cfg->mdio);
+
+	ret = phy_adin2111_c45_write(dev, dev_addr, reg_addr, (uint16_t)data);
 
 	mdio_bus_disable(cfg->mdio);
 
@@ -634,6 +664,8 @@ static const struct ethphy_driver_api phy_adin2111_api = {
 	.link_cb_set = phy_adin2111_link_cb_set,
 	.read = phy_adin2111_reg_read,
 	.write = phy_adin2111_reg_write,
+	.read_mmd = phy_adin2111_reg_read_mmd,
+	.write_mmd = phy_adin2111_reg_write_mmd,
 };
 
 #define ADIN2111_PHY_INITIALIZE(n)						\

--- a/include/zephyr/net/phy.h
+++ b/include/zephyr/net/phy.h
@@ -23,6 +23,8 @@
  */
 #include <zephyr/types.h>
 #include <zephyr/device.h>
+#include <zephyr/net/mii.h>
+#include <errno.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -118,6 +120,14 @@ __subsystem struct ethphy_driver_api {
 	/** Write PHY register */
 	int (*write)(const struct device *dev, uint16_t reg_addr,
 		     uint32_t data);
+
+	/** Read PHY register on an MMD */
+	int (*read_mmd)(const struct device *dev, uint8_t dev_addr, uint16_t reg_addr,
+			uint32_t *data);
+
+	/** Write PHY register on an MMD */
+	int (*write_mmd)(const struct device *dev, uint8_t dev_addr, uint16_t reg_addr,
+			 uint32_t data);
 };
 /**
  * @endcond
@@ -232,6 +242,69 @@ static inline int phy_write(const struct device *dev, uint16_t reg_addr,
 	return api->write(dev, reg_addr, value);
 }
 
+/**
+ * @brief Read PHY registers on an MMD
+ *
+ * This routine provides a generic interface for reading a register from an MMD
+ * on a given PHY.
+ *
+ * @param[in]  dev       PHY device structure
+ * @param[in]  dev_addr  MMD address
+ * @param[in]  reg_addr  Register address
+ * @param      value     Pointer to receive read value
+ *
+ * @retval 0 If successful.
+ * @retval -EIO If communication with PHY failed.
+ * @retval -ENOSYS if the interface is not implemented.
+ * @retval -EINVAL invalid device or register address.
+ */
+static inline int phy_read_mmd(const struct device *dev, uint8_t dev_addr, uint16_t reg_addr,
+			       uint32_t *value)
+{
+	const struct ethphy_driver_api *api = (const struct ethphy_driver_api *)dev->api;
+
+	if (api->read_mmd == NULL) {
+		return -ENOSYS;
+	}
+
+	if (dev_addr > MII_MMD_ACR_DEVAD_MASK) {
+		return -EINVAL;
+	}
+
+	return api->read_mmd(dev, dev_addr, reg_addr, value);
+}
+
+/**
+ * @brief Write PHY register on an MMD
+ *
+ * This routine provides a generic interface for writing a register on an MMD
+ * on a given PHY.
+ *
+ * @param[in]  dev       PHY device structure
+ * @param[in]  dev_addr  MMD address
+ * @param[in]  reg_addr  Register address
+ * @param[in]  value     Value to write
+ *
+ * @retval 0 If successful.
+ * @retval -EIO If communication with PHY failed.
+ * @retval -ENOSYS if the interface is not implemented.
+ * @retval -EINVAL invalid device or register address.
+ */
+static inline int phy_write_mmd(const struct device *dev, uint8_t dev_addr, uint16_t reg_addr,
+				uint32_t value)
+{
+	const struct ethphy_driver_api *api = (const struct ethphy_driver_api *)dev->api;
+
+	if (api->write_mmd == NULL) {
+		return -ENOSYS;
+	}
+
+	if (dev_addr > MII_MMD_ACR_DEVAD_MASK) {
+		return -EINVAL;
+	}
+
+	return api->write_mmd(dev, dev_addr, reg_addr, value);
+}
 
 #ifdef __cplusplus
 }

--- a/tests/drivers/ethernet/phy/api/CMakeLists.txt
+++ b/tests/drivers/ethernet/phy/api/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(phy)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/ethernet/phy/api/prj.conf
+++ b/tests/drivers/ethernet/phy/api/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/drivers/ethernet/phy/api/src/main.c
+++ b/tests/drivers/ethernet/phy/api/src/main.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2024 Infineon Technologies AG
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+#include <zephyr/net/phy.h>
+
+static uint32_t written = 0xFFFFFFFF;
+
+static int test_phy_read_mmd(const struct device *dev, uint8_t dev_addr, uint16_t reg_addr,
+			     uint32_t *data)
+{
+	*data = reg_addr + 1;
+	return 0;
+}
+
+static int test_phy_write_mmd(const struct device *dev, uint8_t dev_addr, uint16_t reg_addr,
+			      uint32_t data)
+{
+	written = data;
+	return 0;
+}
+
+struct ethphy_driver_api test_phy_api = {
+	.read_mmd = test_phy_read_mmd,
+	.write_mmd = test_phy_write_mmd,
+};
+
+static struct device_state test_phy_state = {.init_res = 0, .initialized = true};
+
+static const struct device test_phy = {
+	.name = "test_phy",
+	.state = &test_phy_state,
+	.api = &test_phy_api,
+};
+
+static void test_setup(void *fixture)
+{
+	ARG_UNUSED(fixture);
+}
+
+ZTEST(eth_phy_tests, test_read_mmd)
+{
+	uint32_t value;
+	/* Normal read */
+	zassert_ok(phy_read_mmd(&test_phy, 0x0, 0x1000, &value));
+	zassert_equal(value, 0x1001);
+	/* Out of range mmd */
+	zassert_equal(phy_read_mmd(&test_phy, 0x20, 0x1000, &value), -EINVAL);
+	/* No implementaion */
+	test_phy_api.read_mmd = NULL;
+	zassert_equal(phy_read_mmd(&test_phy, 0x0, 0x1000, &value), -ENOSYS);
+}
+
+ZTEST(eth_phy_tests, test_write_mmd)
+{
+	/* Normal write */
+	written = 0;
+	zassert_ok(phy_write_mmd(&test_phy, 0x0, 0x1000, 0xAFAF));
+	zassert_equal(written, 0xAFAF);
+	/* Out of range mmd */
+	zassert_equal(phy_write_mmd(&test_phy, 0x20, 0x1000, 0xAFAF), -EINVAL);
+	/* No implementaion */
+	test_phy_api.write_mmd = NULL;
+	zassert_equal(phy_write_mmd(&test_phy, 0x0, 0x1000, 0xAFAF), -ENOSYS);
+}
+
+ZTEST_SUITE(eth_phy_tests, NULL, NULL, test_setup, NULL, NULL);

--- a/tests/drivers/ethernet/phy/api/testcase.yaml
+++ b/tests/drivers/ethernet/phy/api/testcase.yaml
@@ -1,0 +1,5 @@
+tests:
+  drivers.ethernet.phy.api:
+    tags:
+      - drivers
+      - api


### PR DESCRIPTION
Extend the phy interface to read and write MMD device registers. To be used in conjunction with clause 45 mdio requests.