### PR TITLE
drivers: adc: stm32: fix stm32u5 extended calibration

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -549,7 +549,9 @@ static void adc_stm32_calibration_start(const struct device *dev)
 		if ((dev_id != 0x482UL) && (rev_id != 0x2001UL)) {
 			adc_stm32_enable(adc);
 			MODIFY_REG(adc->CR, ADC_CR_CALINDEX, 0x9UL << ADC_CR_CALINDEX_Pos);
+			__DMB();
 			MODIFY_REG(adc->CALFACT2, 0xFFFFFF00UL, 0x03021100UL);
+			__DMB();
 			SET_BIT(adc->CALFACT, ADC_CALFACT_LATCH_COEF);
 			adc_stm32_disable(adc);
 		}


### PR DESCRIPTION
Add Data Memory Barrier during the extended calibration of STM32U5, as it is done in STM32Cube HAL, to avoid sporadic errors during calibration that may result in measures that are offset from real values.

Fixes #78459