### PR TITLE
boards: nxp: imx95_evk: add edma and sai nodes

### DIFF
--- a/boards/nxp/imx95_evk/imx95_evk-pinctrl.dtsi
+++ b/boards/nxp/imx95_evk/imx95_evk-pinctrl.dtsi
@@ -47,4 +47,17 @@
 			drive-strength = "x4";
 		};
 	};
+
+	sai3_default: sai3_default {
+		group0 {
+			pinmux = <&iomuxc_gpio_io16_sai_tx_bclk_sai3_tx_bclk>,
+				 <&iomuxc_gpio_io17_sai_mclk_sai3_mclk>,
+				 <&iomuxc_gpio_io20_sai_rx_data_bit_sai3_rx_data_bit0>,
+				 <&iomuxc_gpio_io21_sai_tx_data_bit_sai3_tx_data_bit0>,
+				 <&iomuxc_gpio_io26_sai_tx_sync_sai3_tx_sync>;
+			bias-pull-up;
+			slew-rate = "slightly_fast";
+			drive-strength = "x4";
+		};
+	};
 };

--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.dts
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.dts
@@ -41,3 +41,8 @@
 	pinctrl-0 = <&lpuart3_default>;
 	pinctrl-names = "default";
 };
+
+&sai3 {
+	pinctrl-0 = <&sai3_default>;
+	pinctrl-names = "default";
+};

--- a/dts/arm/nxp/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/nxp_imx95_m7.dtsi
@@ -77,6 +77,15 @@
 			reg = <0x20000000 DT_SIZE_K(256)>;
 		};
 
+		edma2: dma@42000000 {
+			compatible = "nxp,edma";
+			reg = <0x42000000 (DT_SIZE_K(64) * 33)>;
+			valid-channels = <30>, <31>;
+			interrupts = <143 0>, <143 0>;
+			#dma-cells = <2>;
+			status = "disabled";
+		};
+
 		lpi2c3: i2c@42530000 {
 			compatible = "nxp,imx-lpi2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
@@ -128,6 +137,19 @@
 			reg = <0x425a0000 DT_SIZE_K(64)>;
 			interrupts = <67 3>;
 			clocks = <&scmi_clk IMX95_CLK_LPUART6>;
+			status = "disabled";
+		};
+
+		sai3: dai@42650000 {
+			compatible = "nxp,dai-sai";
+			reg = <0x42650000 DT_SIZE_K(64)>;
+			clocks = <&scmi_clk IMX95_CLK_SAI3>;
+			clock-names = "mclk1";
+			interrupts = <170 0>;
+			dai-index = <3>;
+			mclk-is-output;
+			dmas = <&edma2 30 60>, <&edma2 31 61>;
+			dma-names = "tx", "rx";
 			status = "disabled";
 		};
 


### PR DESCRIPTION
Add edma and sai nodes for the M7-based i.MX95 board.