### PR TITLE
ethernet: Add 2.5G and 5G Ethernet defines

### DIFF
--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -204,6 +204,12 @@ enum ethernet_hw_caps {
 
 	/** TX-Injection supported */
 	ETHERNET_TXINJECTION_MODE	= BIT(20),
+
+	/** 2.5 Gbits link supported */
+	ETHERNET_LINK_2500BASE_T	= BIT(21),
+
+	/** 5 Gbits link supported */
+	ETHERNET_LINK_5000BASE_T	= BIT(22),
 };
 
 /** @cond INTERNAL_HIDDEN */

--- a/include/zephyr/net/phy.h
+++ b/include/zephyr/net/phy.h
@@ -42,6 +42,10 @@ enum phy_link_speed {
 	LINK_HALF_1000BASE_T		= BIT(4),
 	/** 1000Base-T Full-Duplex */
 	LINK_FULL_1000BASE_T		= BIT(5),
+	/** 2.5GBase-T Full-Duplex */
+	LINK_FULL_2500BASE_T		= BIT(6),
+	/** 5GBase-T Full-Duplex */
+	LINK_FULL_5000BASE_T		= BIT(7),
 };
 
 /**
@@ -51,7 +55,7 @@ enum phy_link_speed {
  *
  * @return True if link is full duplex, false if not.
  */
-#define PHY_LINK_IS_FULL_DUPLEX(x)	(x & (BIT(1) | BIT(3) | BIT(5)))
+#define PHY_LINK_IS_FULL_DUPLEX(x)	(x & (BIT(1) | BIT(3) | BIT(5) | BIT(6) | BIT(7)))
 
 /**
  * @brief Check if phy link speed is 1 Gbit/sec.

--- a/subsys/net/lib/shell/iface.c
+++ b/subsys/net/lib/shell/iface.c
@@ -56,6 +56,8 @@ static struct ethernet_capabilities eth_hw_caps[] = {
 	EC(ETHERNET_HW_FILTERING,         "MAC address filtering"),
 	EC(ETHERNET_DSA_SLAVE_PORT,       "DSA slave port"),
 	EC(ETHERNET_DSA_MASTER_PORT,      "DSA master port"),
+	EC(ETHERNET_TXTIME,               "TXTIME supported"),
+	EC(ETHERNET_TXINJECTION_MODE,     "TX-Injection supported"),
 };
 
 static void print_supported_ethernet_capabilities(

--- a/subsys/net/lib/shell/iface.c
+++ b/subsys/net/lib/shell/iface.c
@@ -58,6 +58,8 @@ static struct ethernet_capabilities eth_hw_caps[] = {
 	EC(ETHERNET_DSA_MASTER_PORT,      "DSA master port"),
 	EC(ETHERNET_TXTIME,               "TXTIME supported"),
 	EC(ETHERNET_TXINJECTION_MODE,     "TX-Injection supported"),
+	EC(ETHERNET_LINK_2500BASE_T,      "2.5 Gbits"),
+	EC(ETHERNET_LINK_5000BASE_T,      "5 Gbits"),
 };
 
 static void print_supported_ethernet_capabilities(


### PR DESCRIPTION
Add required defines for 2.5G and 5G ethernet standards.

Will be used in conjunction with the xgmac driver.