### PR TITLE
Make cavstool code more shareable

### DIFF
--- a/soc/intel/intel_adsp/tools/acetool.py
+++ b/soc/intel/intel_adsp/tools/acetool.py
@@ -6,6 +6,7 @@ import asyncio
 import cavstool
 
 if __name__ == "__main__":
+    cavstool.args_parse()
     try:
         asyncio.run(cavstool.main())
     except KeyboardInterrupt:

--- a/soc/intel/intel_adsp/tools/cavstool.py
+++ b/soc/intel/intel_adsp/tools/cavstool.py
@@ -962,28 +962,30 @@ async def main():
         if not args.log_only:
             handle_ipc()
 
+def args_parse():
+    global args
+    ap = argparse.ArgumentParser(description="DSP loader/logger tool", allow_abbrev=False)
+    ap.add_argument("-q", "--quiet", action="store_true",
+                    help="No loader output, just DSP logging")
+    ap.add_argument("-v", "--verbose", action="store_true",
+                    help="More loader output, DEBUG logging level")
+    ap.add_argument("-l", "--log-only", action="store_true",
+                    help="Don't load firmware, just show log output")
+    ap.add_argument("-p", "--shell-pty", action="store_true",
+                    help="Create a Zephyr shell pty if enabled in firmware")
+    ap.add_argument("-n", "--no-history", action="store_true",
+                    help="No current log buffer at start, just new output")
+    ap.add_argument("fw_file", nargs="?", help="Firmware file")
 
-ap = argparse.ArgumentParser(description="DSP loader/logger tool", allow_abbrev=False)
-ap.add_argument("-q", "--quiet", action="store_true",
-                help="No loader output, just DSP logging")
-ap.add_argument("-v", "--verbose", action="store_true",
-                help="More loader output, DEBUG logging level")
-ap.add_argument("-l", "--log-only", action="store_true",
-                help="Don't load firmware, just show log output")
-ap.add_argument("-p", "--shell-pty", action="store_true",
-                help="Create a Zephyr shell pty if enabled in firmware")
-ap.add_argument("-n", "--no-history", action="store_true",
-                help="No current log buffer at start, just new output")
-ap.add_argument("fw_file", nargs="?", help="Firmware file")
+    args = ap.parse_args()
 
-args = ap.parse_args()
-
-if args.quiet:
-    log.setLevel(logging.WARN)
-elif args.verbose:
-    log.setLevel(logging.DEBUG)
+    if args.quiet:
+        log.setLevel(logging.WARN)
+    elif args.verbose:
+        log.setLevel(logging.DEBUG)
 
 if __name__ == "__main__":
+    args_parse()
     try:
         asyncio.run(main())
     except KeyboardInterrupt:

--- a/soc/intel/intel_adsp/tools/cavstool.py
+++ b/soc/intel/intel_adsp/tools/cavstool.py
@@ -210,7 +210,7 @@ def adsp_mem_window_config():
 
     return (base, stride)
 
-def map_regs():
+def map_regs(log_only):
     p = runx(f"grep -iEl 'PCI_CLASS=40(10|38)0' /sys/bus/pci/devices/*/uevent")
     pcidir = os.path.dirname(p)
 
@@ -226,7 +226,7 @@ def map_regs():
     if os.path.exists(f"{pcidir}/driver"):
         mod = os.path.basename(os.readlink(f"{pcidir}/driver/module"))
         found_msg = f"Existing driver \"{mod}\" found"
-        if args.log_only:
+        if log_only:
             log.info(found_msg)
         else:
             log.warning(found_msg + ", unloading module")
@@ -920,7 +920,7 @@ async def main():
     global hda, sd, dsp, hda_ostream_id, hda_streams
 
     try:
-        (hda, sd, dsp, hda_ostream_id) = map_regs()
+        (hda, sd, dsp, hda_ostream_id) = map_regs(args.log_only)
     except Exception as e:
         log.error("Could not map device in sysfs; run as root?")
         log.error(e)

--- a/soc/intel/intel_adsp/tools/cavstool.py
+++ b/soc/intel/intel_adsp/tools/cavstool.py
@@ -745,6 +745,9 @@ def debug_offset():
     ( base, stride ) = adsp_mem_window_config()
     return base + stride * 2
 
+def debug_slot_offset(num):
+    return debug_offset() + DEBUG_SLOT_SIZE * (1 + num)
+
 def shell_base_offset():
     return debug_offset() + DEBUG_SLOT_SIZE * (1 + DEBUG_SLOT_SHELL)
 


### PR DESCRIPTION
The cavstool.py has a lot of useful but complex code in it to access DSP memory, but it looks to be grown quite hard to maintain. This PR makes some critical changes there to make some of the functions in cavstool.py shareable from outside the module to avoid growing it even more or forking the code. Much more could be done to that direction, but since I do not understand too well what it is doing, I am proceeding in baby steps and doing only what I need.

The motivation to these changes is to allow debug_stream.py [1] from SOF side to access its debug window slot directly using cavstool.py functions.

[1] https://github.com/thesofproject/sof/blob/main/tools/debug_stream/debug_stream.py