### PR TITLE
net: dns: Improve interface count mismatch warning

### DIFF
--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -722,17 +722,15 @@ static int init_listener(void)
 	NET_DBG("Setting %s listener to %d interface%s", "mDNS", iface_count,
 		iface_count > 1 ? "s" : "");
 
-	if ((iface_count > MAX_IPV6_IFACE_COUNT && MAX_IPV6_IFACE_COUNT > 0) ||
-	    (iface_count > MAX_IPV4_IFACE_COUNT && MAX_IPV4_IFACE_COUNT > 0)) {
-		NET_WARN("You have %d interfaces configured but there "
-			 "are %d network interfaces in the system.",
-			 MAX(MAX_IPV4_IFACE_COUNT,
-			     MAX_IPV6_IFACE_COUNT), iface_count);
-	}
-
 #if defined(CONFIG_NET_IPV6)
 	struct sockaddr_in6 local_addr6;
 	int v6;
+
+	if ((iface_count > MAX_IPV6_IFACE_COUNT && MAX_IPV6_IFACE_COUNT > 0)) {
+		NET_WARN("You have %d %s interfaces configured but there "
+			 "are %d network interfaces in the system.",
+			 MAX_IPV6_IFACE_COUNT, "IPv6", iface_count);
+	}
 
 	setup_ipv6_addr(&local_addr6);
 
@@ -810,6 +808,12 @@ static int init_listener(void)
 #if defined(CONFIG_NET_IPV4)
 	struct sockaddr_in local_addr4;
 	int v4;
+
+	if ((iface_count > MAX_IPV4_IFACE_COUNT && MAX_IPV4_IFACE_COUNT > 0)) {
+		NET_WARN("You have %d %s interfaces configured but there "
+			 "are %d network interfaces in the system.",
+			 MAX_IPV4_IFACE_COUNT, "IPv4", iface_count);
+	}
 
 	setup_ipv4_addr(&local_addr4);
 


### PR DESCRIPTION
The current warning given by the MDNS responder when the interface count does not match the `MAX_XXX_IFACE_COUNT` can be quite confusing.

**For example:** If IPv6 is disabled and IPv4 is enabled, two interfaces are present on the system and `CONFIG_NET_IF_MAX_IPV4_COUNT` is set to 2 the following warning is printed:
`You have 2 interfaces configured but there are 2 network interfaces in the system.`

This is due to the warning being dependent on both IPv6 and IPv4. My suggestion would be to split the warning as implemented in this PR or to remove it completely.