### PR TITLE
arm: cortex_a_r: rom_start relocation configuration

### DIFF
--- a/include/zephyr/arch/arm/cortex_a_r/scripts/linker.ld
+++ b/include/zephyr/arch/arm/cortex_a_r/scripts/linker.ld
@@ -26,6 +26,14 @@
 #endif
 #define RAMABLE_REGION RAM
 
+/* Region of the irq vectors and boot-vector SP/PC */
+#if defined(CONFIG_ROMSTART_RELOCATION_ROM)
+ #define ROMSTART_ADDR CONFIG_ROMSTART_REGION_ADDRESS
+ #define ROMSTART_SIZE (CONFIG_ROMSTART_REGION_SIZE * 1K)
+#else
+ #define ROMSTART_REGION ROMABLE_REGION
+#endif
+
 #if !defined(CONFIG_XIP) && (CONFIG_FLASH_SIZE == 0)
   #define ROM_ADDR RAM_ADDR
 #else
@@ -85,6 +93,9 @@ _region_min_align = 4;
 
 MEMORY
 {
+#if defined(CONFIG_ROMSTART_RELOCATION_ROM)
+    ROMSTART_REGION (rx) : ORIGIN = ROMSTART_ADDR, LENGTH = ROMSTART_SIZE
+#endif
     FLASH    (rx) : ORIGIN = ROM_ADDR, LENGTH = ROM_SIZE
     RAM      (wx) : ORIGIN = RAM_ADDR, LENGTH = RAM_SIZE
     LINKER_DT_REGIONS()
@@ -133,7 +144,7 @@ SECTIONS
  */
 #include <snippets-rom-start.ld>
 
-    } GROUP_LINK_IN(ROMABLE_REGION)
+    } GROUP_LINK_IN(ROMSTART_REGION)
 
 #ifdef CONFIG_CODE_DATA_RELOCATION
 


### PR DESCRIPTION
This commit makes the rom_start relocation introduced in commit 8ef8e8b4974 available for Cortex-A/R CPUs.