### PR TITLE
bluetooth: host: set BT_BUF_EVT_RX_SIZE to 255 when CS is enabled

### DIFF
--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -100,10 +100,11 @@ config BT_BUF_ACL_RX_COUNT
 
 config BT_BUF_EVT_RX_SIZE
 	int "Maximum supported HCI Event buffer length"
-	default $(UINT8_MAX) if (BT_EXT_ADV && BT_OBSERVER) || BT_PER_ADV_SYNC || BT_DF_CONNECTION_CTE_RX || BT_CLASSIC
+	default $(UINT8_MAX) if (BT_EXT_ADV && BT_OBSERVER) || BT_PER_ADV_SYNC || BT_DF_CONNECTION_CTE_RX || BT_CLASSIC || BT_CHANNEL_SOUNDING
 	# LE Read Supported Commands command complete event.
 	default 68
 	range 68 $(UINT8_MAX)
+	range 78 $(UINT8_MAX) if BT_CHANNEL_SOUNDING
 	help
 	  Maximum supported HCI event buffer size. This value does not include
 	  the HCI Event header.


### PR DESCRIPTION
Channel sounding frequently produces very large events, so the default of 68 bytes can lead to buffer overruns / memory corruption.