### PR TITLE
devicetree: make DT_..._REG_ADDR return unsigned

### DIFF
--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -37,6 +37,13 @@ Boards
 
 * Board ``qemu_xtensa`` is deprecated. Use ``qemu_xtensa/dc233c`` instead.
 
+Devicetree
+**********
+
+* The :c:macro:`DT_REG_ADDR` macro and its variants are now expanding into an
+  unsigned literals (i.e. with a ``U`` suffix). To use addresses as devicetree
+  indexes use the :c:macro:`DT_REG_ADDR_RAW` variants.
+
 STM32
 =====
 

--- a/drivers/w1/w1_ds2482-800_channel.c
+++ b/drivers/w1/w1_ds2482-800_channel.c
@@ -164,8 +164,8 @@ static const struct w1_driver_api ds2482_driver_api = {
 		.w1_config.slave_count = W1_INST_SLAVE_COUNT(inst),                                \
 		.parent = DEVICE_DT_GET(DT_INST_PARENT(inst)),                                     \
 		.i2c_spec = I2C_DT_SPEC_GET(DT_INST_PARENT(inst)),                                 \
-		.reg_channel = UTIL_CAT(CHSL_IO, DT_INST_REG_ADDR(inst)),                          \
-		.reg_channel_rb = UTIL_CAT(CHSL_RB_IO, DT_INST_REG_ADDR(inst)),                    \
+		.reg_channel = UTIL_CAT(CHSL_IO, DT_INST_REG_ADDR_RAW(inst)),                      \
+		.reg_channel_rb = UTIL_CAT(CHSL_RB_IO, DT_INST_REG_ADDR_RAW(inst)),                \
 		.reg_config = DT_INST_PROP(inst, active_pullup) << DEVICE_APU_pos,                 \
 	};                                                                                         \
 	static struct ds2482_data inst_##inst##_data = {0};                                        \

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -2244,13 +2244,41 @@
 	IS_ENABLED(DT_CAT4(node_id, _REG_NAME_, name, _EXISTS))
 
 /**
+ * @brief Get the base raw address of the register block at index @p idx
+ *
+ * Get the base address of the register block at index @p idx without any
+ * type suffix. This can be used to index other devicetree properties, use the
+ * non _RAW macros for assigning values in actual code.
+ *
+ * @param node_id node identifier
+ * @param idx index of the register whose address to return
+ * @return address of the idx-th register block
+ */
+#define DT_REG_ADDR_BY_IDX_RAW(node_id, idx) \
+	DT_CAT4(node_id, _REG_IDX_, idx, _VAL_ADDRESS)
+
+/**
+ * @brief Get a node's (only) register block raw address
+ *
+ * Get a node's only register block address without any type suffix. This can
+ * be used to index other devicetree properties, use the non _RAW macros for
+ * assigning values in actual code.
+ *
+ * Equivalent to DT_REG_ADDR_BY_IDX_RAW(node_id, 0).
+ * @param node_id node identifier
+ * @return node's register block address
+ */
+#define DT_REG_ADDR_RAW(node_id) \
+	DT_REG_ADDR_BY_IDX_RAW(node_id, 0)
+
+/**
  * @brief Get the base address of the register block at index @p idx
  * @param node_id node identifier
  * @param idx index of the register whose address to return
  * @return address of the idx-th register block
  */
 #define DT_REG_ADDR_BY_IDX(node_id, idx) \
-	DT_CAT4(node_id, _REG_IDX_, idx, _VAL_ADDRESS)
+	DT_U32_C(DT_REG_ADDR_BY_IDX_RAW(node_id, idx))
 
 /**
  * @brief Get the size of the register block at index @p idx
@@ -2285,7 +2313,7 @@
  * @param node_id node identifier
  * @return node's register block address
  */
-#define DT_REG_ADDR_U64(node_id) DT_U64_C(DT_REG_ADDR(node_id))
+#define DT_REG_ADDR_U64(node_id) DT_U64_C(DT_REG_ADDR_BY_IDX_RAW(node_id, 0))
 
 /**
  * @brief Get a node's (only) register block size
@@ -2303,7 +2331,7 @@
  * @return address of the register block specified by name
  */
 #define DT_REG_ADDR_BY_NAME(node_id, name) \
-	DT_CAT4(node_id, _REG_NAME_, name, _VAL_ADDRESS)
+	DT_U32_C(DT_CAT4(node_id, _REG_NAME_, name, _VAL_ADDRESS))
 
 /**
  * @brief Like DT_REG_ADDR_BY_NAME(), but with a fallback to @p default_value
@@ -2330,7 +2358,7 @@
  * @return address of the register block specified by name
  */
 #define DT_REG_ADDR_BY_NAME_U64(node_id, name) \
-	DT_U64_C(DT_REG_ADDR_BY_NAME(node_id, name))
+	DT_U64_C(DT_CAT4(node_id, _REG_NAME_, name, _VAL_ADDRESS))
 
 /**
  * @brief Get a register block's size by name
@@ -4136,6 +4164,14 @@
 #define DT_INST_REG_HAS_NAME(inst, name) DT_REG_HAS_NAME(DT_DRV_INST(inst), name)
 
 /**
+ * @brief Get a `DT_DRV_COMPAT` instance's idx-th register block's raw address
+ * @param inst instance number
+ * @param idx index of the register whose address to return
+ * @return address of the instance's idx-th register block
+ */
+#define DT_INST_REG_ADDR_BY_IDX_RAW(inst, idx) DT_REG_ADDR_BY_IDX_RAW(DT_DRV_INST(inst), idx)
+
+/**
  * @brief Get a `DT_DRV_COMPAT` instance's idx-th register block's address
  * @param inst instance number
  * @param idx index of the register whose address to return
@@ -4185,7 +4221,7 @@
  * @return address of the register block with the given @p name
  */
 #define DT_INST_REG_ADDR_BY_NAME_U64(inst, name) \
-	DT_U64_C(DT_INST_REG_ADDR_BY_NAME(inst, name))
+	DT_REG_ADDR_BY_NAME_U64(DT_DRV_INST(inst), name)
 
 /**
  * @brief Get a `DT_DRV_COMPAT`'s register block size by name
@@ -4208,6 +4244,13 @@
 	DT_REG_SIZE_BY_NAME_OR(DT_DRV_INST(inst), name, default_value)
 
 /**
+ * @brief Get a `DT_DRV_COMPAT`'s (only) register block raw address
+ * @param inst instance number
+ * @return instance's register block address
+ */
+#define DT_INST_REG_ADDR_RAW(inst) DT_INST_REG_ADDR_BY_IDX_RAW(inst, 0)
+
+/**
  * @brief Get a `DT_DRV_COMPAT`'s (only) register block address
  * @param inst instance number
  * @return instance's register block address
@@ -4225,7 +4268,7 @@
  * @param inst instance number
  * @return instance's register block address
  */
-#define DT_INST_REG_ADDR_U64(inst) DT_U64_C(DT_INST_REG_ADDR(inst))
+#define DT_INST_REG_ADDR_U64(inst) DT_REG_ADDR_U64(DT_DRV_INST(inst))
 
 /**
  * @brief Get a `DT_DRV_COMPAT`'s (only) register block size
@@ -4886,6 +4929,16 @@
  */
 #define DT_COMPAT_NODE_HAS_PROP_AND_OR(inst, compat, prop) \
 	DT_NODE_HAS_PROP(DT_INST(inst, compat), prop) ||
+
+/**
+ * @def DT_U32_C
+ * @brief Macro to add 32bit unsigned postfix to the devicetree address constants
+ */
+#if defined(_LINKER) || defined(_ASMLANGUAGE)
+#define DT_U32_C(_v) (_v)
+#else
+#define DT_U32_C(_v) UINT32_C(_v)
+#endif
 
 /**
  * @def DT_U64_C

--- a/include/zephyr/devicetree/spi.h
+++ b/include/zephyr/devicetree/spi.h
@@ -148,7 +148,7 @@ extern "C" {
  * @return node identifier for spi_dev's chip select GPIO controller
  */
 #define DT_SPI_DEV_CS_GPIOS_CTLR(spi_dev) \
-	DT_GPIO_CTLR_BY_IDX(DT_BUS(spi_dev), cs_gpios, DT_REG_ADDR(spi_dev))
+	DT_GPIO_CTLR_BY_IDX(DT_BUS(spi_dev), cs_gpios, DT_REG_ADDR_RAW(spi_dev))
 
 /**
  * @brief Get a SPI device's chip select GPIO pin number
@@ -181,7 +181,7 @@ extern "C" {
  * @return pin number of spi_dev's chip select GPIO
  */
 #define DT_SPI_DEV_CS_GPIOS_PIN(spi_dev) \
-	DT_GPIO_PIN_BY_IDX(DT_BUS(spi_dev), cs_gpios, DT_REG_ADDR(spi_dev))
+	DT_GPIO_PIN_BY_IDX(DT_BUS(spi_dev), cs_gpios, DT_REG_ADDR_RAW(spi_dev))
 
 /**
  * @brief Get a SPI device's chip select GPIO flags
@@ -209,7 +209,7 @@ extern "C" {
  *         zero if there is none
  */
 #define DT_SPI_DEV_CS_GPIOS_FLAGS(spi_dev) \
-	DT_GPIO_FLAGS_BY_IDX(DT_BUS(spi_dev), cs_gpios, DT_REG_ADDR(spi_dev))
+	DT_GPIO_FLAGS_BY_IDX(DT_BUS(spi_dev), cs_gpios, DT_REG_ADDR_RAW(spi_dev))
 
 /**
  * @brief Equivalent to DT_SPI_DEV_HAS_CS_GPIOS(DT_DRV_INST(inst)).

--- a/include/zephyr/drivers/adc.h
+++ b/include/zephyr/drivers/adc.h
@@ -321,7 +321,7 @@ struct adc_dt_spec {
 	DT_FOREACH_CHILD_VARGS(ctlr, ADC_FOREACH_INPUT, input)
 
 #define ADC_FOREACH_INPUT(node, input) \
-	IF_ENABLED(IS_EQ(DT_REG_ADDR(node), input), (node))
+	IF_ENABLED(IS_EQ(DT_REG_ADDR_RAW(node), input), (node))
 
 #define ADC_CHANNEL_CFG_FROM_DT_NODE(node_id) \
 	IF_ENABLED(DT_NODE_EXISTS(node_id), \

--- a/include/zephyr/drivers/firmware/scmi/util.h
+++ b/include/zephyr/drivers/firmware/scmi/util.h
@@ -66,7 +66,7 @@
 #define DT_SCMI_TRANSPORT_TX_CHAN_DECLARE(node_id)				\
 	COND_CODE_1(DT_SCMI_TRANSPORT_PROTO_HAS_CHAN(node_id, 0),		\
 		    (extern struct scmi_channel					\
-		     SCMI_TRANSPORT_CHAN_NAME(DT_REG_ADDR(node_id), 0);),	\
+		     SCMI_TRANSPORT_CHAN_NAME(DT_REG_ADDR_RAW(node_id), 0);),	\
 		    (extern struct scmi_channel					\
 		     SCMI_TRANSPORT_CHAN_NAME(SCMI_PROTOCOL_BASE, 0);))		\
 
@@ -110,7 +110,7 @@
  */
 #define DT_SCMI_TRANSPORT_TX_CHAN(node_id)					\
 	COND_CODE_1(DT_SCMI_TRANSPORT_PROTO_HAS_CHAN(node_id, 0),		\
-		    (&SCMI_TRANSPORT_CHAN_NAME(DT_REG_ADDR(node_id), 0)),	\
+		    (&SCMI_TRANSPORT_CHAN_NAME(DT_REG_ADDR_RAW(node_id), 0)),	\
 		    (&SCMI_TRANSPORT_CHAN_NAME(SCMI_PROTOCOL_BASE, 0)))
 
 /**
@@ -211,9 +211,9 @@
 #define DT_SCMI_PROTOCOL_DEFINE(node_id, init_fn, pm, data, config,		\
 				level, prio, api)				\
 	DT_SCMI_TRANSPORT_CHANNELS_DECLARE(node_id)				\
-	DT_SCMI_PROTOCOL_DATA_DEFINE(node_id, DT_REG_ADDR(node_id), data);	\
+	DT_SCMI_PROTOCOL_DATA_DEFINE(node_id, DT_REG_ADDR_RAW(node_id), data);	\
 	DEVICE_DT_DEFINE(node_id, init_fn, pm,					\
-			 &SCMI_PROTOCOL_NAME(DT_REG_ADDR(node_id)),		\
+			 &SCMI_PROTOCOL_NAME(DT_REG_ADDR_RAW(node_id)),		\
 					     config, level, prio, api)
 
 /**
@@ -247,7 +247,7 @@
  */
 #define DT_SCMI_PROTOCOL_DEFINE_NODEV(node_id, data)				\
 	DT_SCMI_TRANSPORT_CHANNELS_DECLARE(node_id)				\
-	DT_SCMI_PROTOCOL_DATA_DEFINE(node_id, DT_REG_ADDR(node_id), data)
+	DT_SCMI_PROTOCOL_DATA_DEFINE(node_id, DT_REG_ADDR_RAW(node_id), data)
 
 /**
  * @brief Create an SCMI message field

--- a/include/zephyr/drivers/mipi_dbi.h
+++ b/include/zephyr/drivers/mipi_dbi.h
@@ -63,7 +63,7 @@ extern "C" {
 		.cs = {							\
 			.gpio = GPIO_DT_SPEC_GET_BY_IDX_OR(DT_PHANDLE(DT_PARENT(node_id), \
 							   spi_dev), cs_gpios, \
-							   DT_REG_ADDR(node_id), \
+							   DT_REG_ADDR_RAW(node_id), \
 							   {}),		\
 			.delay = (delay_),				\
 		},							\

--- a/include/zephyr/drivers/mspi/devicetree.h
+++ b/include/zephyr/drivers/mspi/devicetree.h
@@ -212,7 +212,8 @@ extern "C" {
  * @return #gpio_dt_spec struct corresponding with mspi_dev's chip enable
  */
 #define MSPI_DEV_CE_GPIOS_DT_SPEC_GET(mspi_dev)                                                   \
-		GPIO_DT_SPEC_GET_BY_IDX_OR(DT_BUS(mspi_dev), ce_gpios, DT_REG_ADDR(mspi_dev), {})
+		GPIO_DT_SPEC_GET_BY_IDX_OR(DT_BUS(mspi_dev), ce_gpios,                            \
+					   DT_REG_ADDR_RAW(mspi_dev), {})
 
 /**
  * @brief Get a <tt>struct gpio_dt_spec</tt> for a MSPI device's chip enable pin

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -211,7 +211,7 @@ struct spi_cs_control {
  */
 #define SPI_CS_GPIOS_DT_SPEC_GET(spi_dev)			\
 	GPIO_DT_SPEC_GET_BY_IDX_OR(DT_BUS(spi_dev), cs_gpios,	\
-				   DT_REG_ADDR(spi_dev), {})
+				   DT_REG_ADDR_RAW(spi_dev), {})
 
 /**
  * @brief Get a <tt>struct gpio_dt_spec</tt> for a SPI device's chip select pin

--- a/include/zephyr/sys/device_mmio.h
+++ b/include/zephyr/sys/device_mmio.h
@@ -63,13 +63,13 @@ struct z_device_mmio_rom {
 
 #define Z_DEVICE_MMIO_ROM_INITIALIZER(node_id) \
 	{ \
-		.phys_addr = UINT32_C(DT_REG_ADDR(node_id)), \
+		.phys_addr = DT_REG_ADDR(node_id), \
 		.size = DT_REG_SIZE(node_id) \
 	}
 
 #define Z_DEVICE_MMIO_NAMED_ROM_INITIALIZER(name, node_id) \
 	{ \
-		.phys_addr = UINT32_C(DT_REG_ADDR_BY_NAME(node_id, name)), \
+		.phys_addr = DT_REG_ADDR_BY_NAME(node_id, name), \
 		.size = DT_REG_SIZE_BY_NAME(node_id, name) \
 	}
 

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -2948,7 +2948,7 @@ ZTEST(devicetree_api, test_fixed_partitions)
 	 * Test this by way of string comparison.
 	 */
 	zassert_true(!strcmp(TO_STRING(DT_FIXED_PARTITION_ADDR(TEST_PARTITION_2)),
-			     "(__REG_IDX_0_VAL_ADDRESS + 458624)"));
+			     "(__REG_IDX_0_VAL_ADDRESSU + 458624U)"));
 	zassert_equal(DT_REG_ADDR(TEST_PARTITION_2), 458624);
 
 	/* Test that all DT_FIXED_PARTITION_ID are defined and unique. */


### PR DESCRIPTION
`DT_..._REG_ADDR` macros do not always return an unsigned value. This commit adds and unsigned 32bit prefix to ensure the value is always unsigned.

More context:
- https://github.com/zephyrproject-rtos/zephyr/issues/53505
- https://github.com/zephyrproject-rtos/zephyr/pull/78419

Picking up from https://github.com/zephyrproject-rtos/zephyr/pull/70761