### PR TITLE
boards: nxp: mimxrt1170_evk: Delete redundant Kconfig.sysbuild

### DIFF
--- a/boards/nxp/mimxrt1170_evk/Kconfig.sysbuild
+++ b/boards/nxp/mimxrt1170_evk/Kconfig.sysbuild
@@ -1,6 +1,0 @@
-# Copyright (c) 2024 Nordic Semiconductor ASA
-# SPDX-License-Identifier: Apache-2.0
-
-choice MCUBOOT_MODE
-	default MCUBOOT_MODE_SWAP_WITHOUT_SCRATCH if BOARD_MIMXRT1170_EVK_MIMXRT1176_CM7
-endchoice


### PR DESCRIPTION
Remove unnecessary Kconfig.sysbuild for mimxrt1170_evk as MCUBOOT_MODE_SWAP_WITHOUT_SCRATCH is set by default without it.