### PR TITLE
Bluetooth: Adv type sample fixes

### DIFF
--- a/samples/bluetooth/extended_adv/scanner/src/main.c
+++ b/samples/bluetooth/extended_adv/scanner/src/main.c
@@ -79,7 +79,7 @@ BT_CONN_CB_DEFINE(conn_cb) = {
 
 static void scan_recv(const struct bt_le_scan_recv_info *info, struct net_buf_simple *buf)
 {
-	if (info->adv_type & BT_GAP_ADV_TYPE_EXT_ADV &&
+	if (info->adv_type == BT_GAP_ADV_TYPE_EXT_ADV &&
 	    info->adv_props & BT_GAP_ADV_PROP_EXT_ADV &&
 	    info->adv_props & BT_GAP_ADV_PROP_CONNECTABLE) {
 		/* Attempt connection request for device with extended advertisements */

--- a/tests/bsim/bluetooth/host/adv/extended/src/ext_adv_scanner.c
+++ b/tests/bsim/bluetooth/host/adv/extended/src/ext_adv_scanner.c
@@ -87,7 +87,7 @@ static void scan_recv(const struct bt_le_scan_recv_info *info,
 	printk("Found advertisement. Adv-type: 0x%02x, Adv-prop: 0x%02x\n",
 		info->adv_type, info->adv_props);
 
-	if (info->adv_type & BT_GAP_ADV_TYPE_EXT_ADV &&
+	if (info->adv_type == BT_GAP_ADV_TYPE_EXT_ADV &&
 	    info->adv_props & BT_GAP_ADV_PROP_EXT_ADV) {
 		printk("Found extended advertisement!\n");
 		SET_FLAG(flag_ext_adv_seen);


### PR DESCRIPTION
Fixes incorrect uses of `adv_type` in scan receive callbacks where it was used a bitfield rather than a value. 