### PR TITLE
llext: Add cmake/llext-edk.cmake to LLEXT area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5311,6 +5311,7 @@ zbus:
     - lyakh
     - pillo79
   files:
+    - cmake/llext-edk.cmake
     - samples/subsys/llext/
     - include/zephyr/llext/
     - tests/subsys/llext/


### PR DESCRIPTION
This file should be assigned to LLEXT maintainers as it is LLEXT specific.