### PR TITLE
dts: nxp: Fix lpspi node names on mcxn

### DIFF
--- a/dts/arm/nxp/nxp_mcxn23x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn23x_common.dtsi
@@ -180,7 +180,7 @@
 			clocks = <&syscon MCUX_FLEXCOMM0_CLK>;
 			status = "disabled";
 		};
-		flexcomm0_lpspi0: lpspi@92000 {
+		flexcomm0_lpspi0: spi@92000 {
 			compatible = "nxp,imx-lpspi";
 			reg = <0x92000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM0_CLK>;
@@ -217,7 +217,7 @@
 			dma-names = "rx", "tx";
 			status = "disabled";
 		};
-		flexcomm1_lpspi1: lpspi@93000 {
+		flexcomm1_lpspi1: spi@93000 {
 			compatible = "nxp,imx-lpspi";
 			reg = <0x93000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM1_CLK>;
@@ -257,7 +257,7 @@
 			dma-names = "rx", "tx";
 			status = "disabled";
 		};
-		flexcomm2_lpspi2: lpspi@94000 {
+		flexcomm2_lpspi2: spi@94000 {
 			compatible = "nxp,imx-lpspi";
 			reg = <0x94000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM2_CLK>;
@@ -294,7 +294,7 @@
 			clocks = <&syscon MCUX_FLEXCOMM3_CLK>;
 			status = "disabled";
 		};
-		flexcomm3_lpspi3: lpspi@95000 {
+		flexcomm3_lpspi3: spi@95000 {
 			compatible = "nxp,imx-lpspi";
 			reg = <0x95000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM3_CLK>;
@@ -331,7 +331,7 @@
 			dma-names = "rx", "tx";
 			status = "disabled";
 		};
-		flexcomm4_lpspi4: lpspi@b4000 {
+		flexcomm4_lpspi4: spi@b4000 {
 			compatible = "nxp,imx-lpspi";
 			reg = <0xb4000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM4_CLK>;
@@ -368,7 +368,7 @@
 			clocks = <&syscon MCUX_FLEXCOMM5_CLK>;
 			status = "disabled";
 		};
-		flexcomm5_lpspi5: lpspi@b5000 {
+		flexcomm5_lpspi5: spi@b5000 {
 			compatible = "nxp,imx-lpspi";
 			reg = <0xb5000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM5_CLK>;
@@ -402,7 +402,7 @@
 			clocks = <&syscon MCUX_FLEXCOMM6_CLK>;
 			status = "disabled";
 		};
-		flexcomm6_lpspi6: lpspi@b6000 {
+		flexcomm6_lpspi6: spi@b6000 {
 			compatible = "nxp,imx-lpspi";
 			reg = <0xb6000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM6_CLK>;
@@ -436,7 +436,7 @@
 			clocks = <&syscon MCUX_FLEXCOMM7_CLK>;
 			status = "disabled";
 		};
-		flexcomm7_lpspi7: lpspi@b7000 {
+		flexcomm7_lpspi7: spi@b7000 {
 			compatible = "nxp,imx-lpspi";
 			reg = <0xb7000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM7_CLK>;

--- a/dts/arm/nxp/nxp_mcxn94x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn94x_common.dtsi
@@ -187,7 +187,7 @@
 			clocks = <&syscon MCUX_FLEXCOMM0_CLK>;
 			status = "disabled";
 		};
-		flexcomm0_lpspi0: lpspi@92000 {
+		flexcomm0_lpspi0: spi@92000 {
 			compatible = "nxp,imx-lpspi";
 			reg = <0x92000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM0_CLK>;
@@ -224,7 +224,7 @@
 			dma-names = "rx", "tx";
 			status = "disabled";
 		};
-		flexcomm1_lpspi1: lpspi@93000 {
+		flexcomm1_lpspi1: spi@93000 {
 			compatible = "nxp,imx-lpspi";
 			reg = <0x93000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM1_CLK>;
@@ -264,7 +264,7 @@
 			dma-names = "rx", "tx";
 			status = "disabled";
 		};
-		flexcomm2_lpspi2: lpspi@94000 {
+		flexcomm2_lpspi2: spi@94000 {
 			compatible = "nxp,imx-lpspi";
 			reg = <0x94000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM2_CLK>;
@@ -301,7 +301,7 @@
 			clocks = <&syscon MCUX_FLEXCOMM3_CLK>;
 			status = "disabled";
 		};
-		flexcomm3_lpspi3: lpspi@95000 {
+		flexcomm3_lpspi3: spi@95000 {
 			compatible = "nxp,imx-lpspi";
 			reg = <0x95000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM3_CLK>;
@@ -338,7 +338,7 @@
 			dma-names = "rx", "tx";
 			status = "disabled";
 		};
-		flexcomm4_lpspi4: lpspi@b4000 {
+		flexcomm4_lpspi4: spi@b4000 {
 			compatible = "nxp,imx-lpspi";
 			reg = <0xb4000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM4_CLK>;
@@ -375,7 +375,7 @@
 			clocks = <&syscon MCUX_FLEXCOMM5_CLK>;
 			status = "disabled";
 		};
-		flexcomm5_lpspi5: lpspi@b5000 {
+		flexcomm5_lpspi5: spi@b5000 {
 			compatible = "nxp,imx-lpspi";
 			reg = <0xb5000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM5_CLK>;
@@ -409,7 +409,7 @@
 			clocks = <&syscon MCUX_FLEXCOMM6_CLK>;
 			status = "disabled";
 		};
-		flexcomm6_lpspi6: lpspi@b6000 {
+		flexcomm6_lpspi6: spi@b6000 {
 			compatible = "nxp,imx-lpspi";
 			reg = <0xb6000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM6_CLK>;
@@ -443,7 +443,7 @@
 			clocks = <&syscon MCUX_FLEXCOMM7_CLK>;
 			status = "disabled";
 		};
-		flexcomm7_lpspi7: lpspi@b7000 {
+		flexcomm7_lpspi7: spi@b7000 {
 			compatible = "nxp,imx-lpspi";
 			reg = <0xb7000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM7_CLK>;
@@ -477,7 +477,7 @@
 			clocks = <&syscon MCUX_FLEXCOMM8_CLK>;
 			status = "disabled";
 		};
-		flexcomm8_lpspi8: lpspi@b8000 {
+		flexcomm8_lpspi8: spi@b8000 {
 			compatible = "nxp,imx-lpspi";
 			reg = <0xb8000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM8_CLK>;
@@ -511,7 +511,7 @@
 			clocks = <&syscon MCUX_FLEXCOMM9_CLK>;
 			status = "disabled";
 		};
-		flexcomm9_lpspi9: lpspi@b9000 {
+		flexcomm9_lpspi9: spi@b9000 {
 			compatible = "nxp,imx-lpspi";
 			reg = <0xb9000 0x1000>;
 			clocks = <&syscon MCUX_FLEXCOMM9_CLK>;


### PR DESCRIPTION
Spi bus controller node names should follow recommended naming convention from DT spec otherwise DTC will report a warning.