### PR TITLE
drivers: Clean up NXP MCUX LPSPI driver

### DIFF
--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -548,7 +548,6 @@ static void spi_mcux_iodev_start(const struct device *dev)
 	struct rtio_sqe *sqe = &rtio_ctx->txn_curr->sqe;
 	struct spi_dt_spec *spi_dt_spec = sqe->iodev->data;
 	struct spi_config *spi_cfg = &spi_dt_spec->config;
-
 	LPSPI_Type *base = (LPSPI_Type *)DEVICE_MMIO_NAMED_GET(dev, reg_base);
 	lpspi_transfer_t transfer;
 	status_t status;
@@ -586,7 +585,7 @@ static void spi_mcux_iodev_start(const struct device *dev)
 
 	status = LPSPI_MasterTransferNonBlocking(base, &data->handle, &transfer);
 	if (status != kStatus_Success) {
-		LOG_ERR("Transfer could not start");
+		LOG_ERR("Transfer could not start on %s: %d", dev->name, status);
 		spi_mcux_iodev_complete(dev, -EIO);
 	}
 }

--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -751,20 +751,11 @@ static void spi_mcux_iodev_complete(const struct device *dev, int status)
 
 static int spi_mcux_init(const struct device *dev)
 {
-	int err;
 	const struct spi_mcux_config *config = dev->config;
 	struct spi_mcux_data *data = dev->data;
+	int err;
 
 	DEVICE_MMIO_NAMED_MAP(dev, reg_base, K_MEM_CACHE_NONE | K_MEM_DIRECT_MAP);
-
-	config->irq_config_func(dev);
-
-	err = spi_context_cs_configure_all(&data->ctx);
-	if (err < 0) {
-		return err;
-	}
-
-	spi_context_unlock_unconditionally(&data->ctx);
 
 	data->dev = dev;
 
@@ -782,15 +773,21 @@ static int spi_mcux_init(const struct device *dev)
 	}
 #endif /* CONFIG_SPI_MCUX_LPSPI_DMA */
 
-#ifdef CONFIG_SPI_RTIO
-	spi_rtio_init(data->rtio_ctx, dev);
-#endif
+	err = spi_context_cs_configure_all(&data->ctx);
+	if (err < 0) {
+		return err;
+	}
 
 	err = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
 	if (err) {
 		return err;
 	}
 
+	config->irq_config_func(dev);
+
+#ifdef CONFIG_SPI_RTIO
+	spi_rtio_init(data->rtio_ctx, dev);
+#endif
 	spi_context_unlock_unconditionally(&data->ctx);
 
 	return 0;

--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -39,6 +39,10 @@ LOG_MODULE_REGISTER(spi_mcux_lpspi, CONFIG_SPI_LOG_LEVEL);
 /* Argument to MCUX SDK IRQ handler */
 #define LPSPI_IRQ_HANDLE_ARG COND_CODE_1(CONFIG_NXP_LP_FLEXCOMM, (LPSPI_GetInstance(base)), (base))
 
+/* flag for SDK API for master transfers */
+#define LPSPI_MASTER_XFER_CFG_FLAGS(slave)                                                         \
+	kLPSPI_MasterPcsContinuous | (slave << LPSPI_MASTER_PCS_SHIFT)
+
 #ifdef CONFIG_SPI_MCUX_LPSPI_DMA
 #include <zephyr/drivers/dma.h>
 
@@ -137,8 +141,7 @@ static int spi_mcux_transfer_next_packet(const struct device *dev)
 
 	data->transfer_len = max_chunk;
 
-	transfer.configFlags =
-		kLPSPI_MasterPcsContinuous | (ctx->config->slave << LPSPI_MASTER_PCS_SHIFT);
+	transfer.configFlags = LPSPI_MASTER_XFER_CFG_FLAGS(ctx->config->slave);
 	transfer.txData = (ctx->tx_len == 0 ? NULL : ctx->tx_buf);
 	transfer.rxData = (ctx->rx_len == 0 ? NULL : ctx->rx_buf);
 	transfer.dataSize = max_chunk;
@@ -550,8 +553,7 @@ static void spi_mcux_iodev_start(const struct device *dev)
 	lpspi_transfer_t transfer;
 	status_t status;
 
-	transfer.configFlags =
-		kLPSPI_MasterPcsContinuous | (spi_cfg->slave << LPSPI_MASTER_PCS_SHIFT);
+	transfer.configFlags = LPSPI_MASTER_XFER_CFG_FLAGS(spi_cfg->slave);
 
 	switch (sqe->op) {
 	case RTIO_OP_RX:

--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -122,7 +122,6 @@ static void spi_mcux_master_callback(LPSPI_Type *base, lpspi_master_handle_t *ha
 
 static int spi_mcux_transfer_next_packet(const struct device *dev)
 {
-	/* const struct spi_mcux_config *config = dev->config; */
 	struct spi_mcux_data *data = dev->data;
 	LPSPI_Type *base = (LPSPI_Type *)DEVICE_MMIO_NAMED_GET(dev, reg_base);
 	struct spi_context *ctx = &data->ctx;
@@ -324,7 +323,6 @@ static void spi_mcux_dma_callback(const struct device *dev, void *arg, uint32_t 
 
 static int spi_mcux_dma_tx_load(const struct device *dev, const uint8_t *buf, size_t len)
 {
-	/* const struct spi_mcux_config *cfg = dev->config; */
 	struct spi_mcux_data *data = dev->data;
 	struct dma_block_config *blk_cfg;
 	LPSPI_Type *base = (LPSPI_Type *)DEVICE_MMIO_NAMED_GET(dev, reg_base);
@@ -365,7 +363,6 @@ static int spi_mcux_dma_tx_load(const struct device *dev, const uint8_t *buf, si
 
 static int spi_mcux_dma_rx_load(const struct device *dev, uint8_t *buf, size_t len)
 {
-	/*const struct spi_mcux_config *cfg = dev->config; */
 	struct spi_mcux_data *data = dev->data;
 	struct dma_block_config *blk_cfg;
 	LPSPI_Type *base = (LPSPI_Type *)DEVICE_MMIO_NAMED_GET(dev, reg_base);
@@ -462,7 +459,6 @@ static int transceive_dma(const struct device *dev, const struct spi_config *spi
 			  const struct spi_buf_set *tx_bufs, const struct spi_buf_set *rx_bufs,
 			  bool asynchronous, spi_callback_t cb, void *userdata)
 {
-	/* const struct spi_mcux_config *config = dev->config; */
 	struct spi_mcux_data *data = dev->data;
 	LPSPI_Type *base = (LPSPI_Type *)DEVICE_MMIO_NAMED_GET(dev, reg_base);
 	int ret;

--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -487,8 +487,9 @@ static int transceive_dma(const struct device *dev, const struct spi_config *spi
 	/* DMA is fast enough watermarks are not required */
 	LPSPI_SetFifoWatermarks(base, 0U, 0U);
 
+	spi_context_buffers_setup(&data->ctx, tx_bufs, rx_bufs, 1);
+
 	if (!asynchronous) {
-		spi_context_buffers_setup(&data->ctx, tx_bufs, rx_bufs, 1);
 		spi_context_cs_control(&data->ctx, true);
 
 		/* Send each spi buf via DMA, updating context as DMA completes */
@@ -710,9 +711,6 @@ static int spi_mcux_transceive(const struct device *dev, const struct spi_config
 	struct spi_mcux_data *data = dev->data;
 
 	if (lpspi_inst_has_dma(data)) {
-		if (async) {
-			spi_context_buffers_setup(&data->ctx, tx_bufs, rx_bufs, 1);
-		}
 		return transceive_dma(dev, spi_cfg, tx_bufs, rx_bufs, async, cb, userdata);
 	}
 


### PR DESCRIPTION
Driver was totally unreadable and tangled up in all sorts of conditional compilations and duplicated code, this PR addresses it, and makes the paths way more obvious to facilitate making changes much easier

No major functional changes intended by this PR.

There are a lot of commits so that one merge conflict doesnt cause a giant problem when rebasing.