### PR TITLE
scripts: check_compliance: add DER certificates to allowed binaries

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1361,7 +1361,7 @@ class BinaryFiles(ComplianceTest):
     def run(self):
         BINARY_ALLOW_PATHS = ("doc/", "boards/", "samples/")
         # svg files are always detected as binary, see .gitattributes
-        BINARY_ALLOW_EXT = (".jpg", ".jpeg", ".png", ".svg", ".webp")
+        BINARY_ALLOW_EXT = (".jpg", ".jpeg", ".png", ".svg", ".webp", ".der")
 
         for stat in git("diff", "--numstat", "--diff-filter=A",
                         COMMIT_RANGE).splitlines():


### PR DESCRIPTION
> There are already plenty of DER certificate files through the tree, this patch allows to commit sample certificates to samples such as network libraries.

I hope I interpreted @jukkar's comment well:
- https://github.com/zephyrproject-rtos/zephyr/pull/72804#issuecomment-2365006456

My bad for missing his former https://github.com/zephyrproject-rtos/zephyr/pull/72804#issuecomment-2286181382

Or maybe the goal is to keep the "forbidden binaries" and manually override the check...