### PR TITLE
Doc: Contribute: Add instructions for GitHub profile name and email

### DIFF
--- a/doc/contribute/guidelines.rst
+++ b/doc/contribute/guidelines.rst
@@ -351,6 +351,15 @@ address is ``z.developer@example.com``:
    git config --global user.name "Zephyr Developer"
    git config --global user.email "z.developer@example.com"
 
+.. note::
+   ``user.name`` must be your full name (first and last at minimum), not a
+   pseudonym or hacker handle. The email address that you use in your Git configuration must match the email
+   address you use to sign your commits. If they don't match, the CI system will
+   fail your pull request.
+
+   If you intend to edit commits using the Github.com UI, ensure that your github profile
+   ``email address`` and profile ``name`` also match those used in your git configuration
+   (``user.name`` & ``user.email``).
 
 Pull Request Guidelines
 ***********************


### PR DESCRIPTION
Fixes #78713
Add instructions to the "Git Setup" section to ensure that the user's GitHub profile name is their full name (first and last) and that the GitHub profile name and email address match the git config user.name and user.email.

Page: contribute/guidelines
Tested with:
cd zephyr/doc/_build/html
ninja html
python3 -m http.server 8000

Signed-off-by: <Arrel Neumiller rlneumiller@gmail.com>