### PR TITLE
drivers: eth_xlnx_gem: Align pll divisor settings with reference manual

### DIFF
--- a/drivers/ethernet/eth_xlnx_gem.c
+++ b/drivers/ethernet/eth_xlnx_gem.c
@@ -772,9 +772,9 @@ static void eth_xlnx_gem_configure_clocks(const struct device *dev)
 	 * The frequency of the PLL to which the divisors shall be applied are
 	 * provided in the respective GEM's device tree data.
 	 */
-	for (div0 = 1; div0 < 64; div0++) {
-		for (div1 = 1; div1 < 64; div1++) {
-			tmp = ((dev_conf->pll_clock_frequency / div0) / div1);
+	for (div1 = 1; div1 < 64; div1++) {
+		for (div0 = 1; div0 < 64; div0++) {
+			tmp = ((dev_conf->pll_clock_frequency / div1) / div0);
 			if (tmp >= (target - 10) && tmp <= (target + 10)) {
 				break;
 			}


### PR DESCRIPTION
The reference manual states that for an IOPLL of 1GHz, divisor0 shall be 8 and divisor1 shall be 1. The existing implementation swaps them and make cross validation with the register setting made by the Xilinx ecosystem more difficult.

![image](https://github.com/user-attachments/assets/837cebaf-147f-471f-8675-f7471a80b98c)
