### PR TITLE
net: tcp: Fix net_tcp_endpoint_copy() with IPv4 disabled

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -261,7 +261,7 @@ int net_tcp_endpoint_copy(struct net_context *ctx,
 				       sizeof(struct in_addr));
 				net_sin(local)->sin_port = net_sin_ptr(&ctx->local)->sin_port;
 				net_sin(local)->sin_family = AF_INET;
-			} else if (IS_ENABLED(CONFIG_NET_IPV4) && ctx->local.family == AF_INET6) {
+			} else if (IS_ENABLED(CONFIG_NET_IPV6) && ctx->local.family == AF_INET6) {
 				memcpy(&net_sin6(local)->sin6_addr,
 				       net_sin6_ptr(&ctx->local)->sin6_addr,
 				       sizeof(struct in6_addr));


### PR DESCRIPTION
The IPv6 branch of `net_tcp_endpoint_copy()` was accidentally made conditional on `CONFIG_NET_IPV4` rather than `CONFIG_NET_IPV6`.

This bug was introduced in #71996