### PR TITLE
hostapd: fix hostap enable fail during stress test

### DIFF
--- a/modules/hostap/src/supp_main.c
+++ b/modules/hostap/src/supp_main.c
@@ -696,6 +696,14 @@ static int hostapd_disable_iface_cb(struct hostapd_iface *hapd_iface)
 	supplicant_send_wifi_mgmt_ap_status(hapd_iface,
 					    NET_EVENT_WIFI_CMD_AP_DISABLE_RESULT,
 					    WIFI_STATUS_AP_SUCCESS);
+	hostapd_config_free(hapd_iface->conf);
+	hapd_iface->conf = hapd_iface->interfaces->config_read_cb(hapd_iface->config_fname);
+	for (j = 0; j < hapd_iface->num_bss; j++) {
+		hapd = hapd_iface->bss[j];
+		hapd->iconf = hapd_iface->conf;
+		hapd->conf = hapd_iface->conf->bss[j];
+		hapd->driver = hapd_iface->conf->driver;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
1.everytime ap wpa3 sae enable command will increase the sae_passpharse list of config_bss, and sae_derive_pt will derive all sae pt in the sae_passpharse list, every sae derive pt spend 100ms. 
2.with the time going, the sae_passpharse list has more sae, and the time to derive pt for sae will become long, sae_derive_pt will held cpu and doesn't sleep.
3.hostapd task prio is 3, and imu task is 3, hostapd task run before imu task, when the imu interrupt arrive and wake up the imu task, imu task can't run,
4.hostapd task is deriving pt for every sae in the sae_passpharse list. imu task can't run and sleep rwlock can't be release, sleep rwlock timeout is 3s, when derive pt spend over 3s, wlcmgr task waiting command resp on sleep rwlock will assert and hang.