### PR TITLE
Bluetooth: Host: SSP: Correct BR bonding type

### DIFF
--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -786,6 +786,13 @@ l2cap_br_conn_security(struct bt_l2cap_chan *chan, const uint16_t psm)
 	 * since service/profile requires that.
 	 */
 	if (check == 0) {
+		/*
+		 * General Bonding refers to the process of performing bonding
+		 * during connection setup or channel establishment procedures
+		 * as a precursor to accessing a service.
+		 * For current case, it is dedicated bonding.
+		 */
+		atomic_set_bit(chan->conn->flags, BT_CONN_BR_GENERAL_BONDING);
 		return L2CAP_CONN_SECURITY_PENDING;
 	}
 

--- a/subsys/bluetooth/host/classic/rfcomm.c
+++ b/subsys/bluetooth/host/classic/rfcomm.c
@@ -829,6 +829,13 @@ static enum security_result rfcomm_dlc_security(struct bt_rfcomm_dlc *dlc)
 	}
 
 	if (!bt_conn_set_security(conn, dlc->required_sec_level)) {
+		/*
+		 * General Bonding refers to the process of performing bonding
+		 * during connection setup or channel establishment procedures
+		 * as a precursor to accessing a service.
+		 * For current case, it is dedicated bonding.
+		 */
+		atomic_set_bit(conn->flags, BT_CONN_BR_GENERAL_BONDING);
 		/* If Security elevation is initiated or in progress */
 		return RFCOMM_SECURITY_PENDING;
 	}

--- a/subsys/bluetooth/host/classic/ssp.c
+++ b/subsys/bluetooth/host/classic/ssp.c
@@ -666,9 +666,17 @@ void bt_hci_io_capa_req(struct net_buf *buf)
 	 */
 	if (atomic_test_bit(conn->flags, BT_CONN_BR_PAIRING_INITIATOR)) {
 		if (get_io_capa() != BT_IO_NO_INPUT_OUTPUT) {
-			auth = BT_HCI_DEDICATED_BONDING_MITM;
+			if (atomic_test_bit(conn->flags, BT_CONN_BR_GENERAL_BONDING)) {
+				auth = BT_HCI_GENERAL_BONDING_MITM;
+			} else {
+				auth = BT_HCI_DEDICATED_BONDING_MITM;
+			}
 		} else {
-			auth = BT_HCI_DEDICATED_BONDING;
+			if (atomic_test_bit(conn->flags, BT_CONN_BR_GENERAL_BONDING)) {
+				auth = BT_HCI_GENERAL_BONDING;
+			} else {
+				auth = BT_HCI_DEDICATED_BONDING;
+			}
 		}
 	} else {
 		auth = ssp_get_auth(conn);

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2581,6 +2581,7 @@ static void reset_pairing(struct bt_conn *conn)
 		atomic_clear_bit(conn->flags, BT_CONN_BR_PAIRING);
 		atomic_clear_bit(conn->flags, BT_CONN_BR_PAIRING_INITIATOR);
 		atomic_clear_bit(conn->flags, BT_CONN_BR_LEGACY_SECURE);
+		atomic_clear_bit(conn->flags, BT_CONN_BR_GENERAL_BONDING);
 	}
 #endif /* CONFIG_BT_CLASSIC */
 

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -60,6 +60,7 @@ enum {
 	BT_CONN_USER,                         /* user I/O when pairing */
 	BT_CONN_BR_PAIRING,                   /* BR connection in pairing context */
 	BT_CONN_BR_NOBOND,                    /* SSP no bond pairing tracker */
+	BT_CONN_BR_GENERAL_BONDING,           /* BR general bonding */
 	BT_CONN_BR_PAIRING_INITIATOR,         /* local host starts authentication */
 	BT_CONN_CLEANUP,                      /* Disconnected, pending cleanup */
 	BT_CONN_AUTO_INIT_PROCEDURES_DONE,    /* Auto-initiated procedures have run */


### PR DESCRIPTION
Currently, the bonding type of Authentication
_Requirements parameter is always `Dedicated
Bonding` if the device is pairing initiator.

But if the bonding is performed during
connection setup or channel establishment as
a precursor to accessing a service, the
bonding type should be `General bonding`.

Add a flag BT_CONN_BR_GENERAL_BONDING.
Set the flag if the bonding is performed in
the L2CAP_BR/RFCOMM channel establishment.

Set bonding type depends on the flag when
receiving IO cap request.