### PR TITLE
Bluetooth: SSP: Support non-bondable mode

### DIFF
--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -1746,6 +1746,17 @@ static inline const char *bt_security_err_to_str(enum bt_security_err err)
  */
 void bt_set_bondable(bool enable);
 
+/** @brief Get bonding flag.
+ *
+ *  Get current bonding flag.
+ *  The initial value of this flag depends on @kconfig{CONFIG_BT_BONDABLE} Kconfig
+ *  setting.
+ *  The Bonding flag can be updated using bt_set_bondable().
+ *
+ *  @return Current bonding flag.
+ */
+bool bt_get_bondable(void);
+
 /** @brief Set/clear the bonding flag for a given connection.
  *
  *  Set/clear the Bonding flag in the Authentication Requirements of

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -632,9 +632,13 @@ config BT_BONDABLE
 	bool "Bondable Mode"
 	default y
 	help
-	  This option enables support for Bondable Mode. In this mode,
-	  Bonding flag in AuthReq of SMP Pairing Request/Response will be set
-	  indicating the support for this mode.
+	  This option is the default value of the bonding flag for any ACL connection.
+	  If the option is true, the default bonding flag is true. Or, the default
+	  bonding flag is false.
+	  After a connection is established, the bonding flag of the connection
+	  can also be changed by calling `bt_conn_set_bondable()` if the configuration
+	  `the bonding flag per-connection` (BT_BONDABLE_PER_CONNECTION) is
+	  enabled. Please see the BT_BONDABLE_PER_CONNECTION configuration.
 
 config BT_BONDING_REQUIRED
 	bool "Always require bonding"

--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -240,6 +240,8 @@ void bt_hci_conn_complete(struct net_buf *buf)
 
 	bt_conn_set_state(conn, BT_CONN_CONNECTED);
 
+	atomic_set_bit_to(conn->flags, BT_CONN_BR_BONDABLE, bt_get_bondable());
+
 	bt_conn_connected(conn);
 
 	bt_conn_unref(conn);

--- a/subsys/bluetooth/host/classic/ssp.c
+++ b/subsys/bluetooth/host/classic/ssp.c
@@ -677,7 +677,7 @@ void bt_hci_io_capa_req(struct net_buf *buf)
 		auth = ssp_get_auth(conn);
 	}
 
-	if (!bt_get_bondable()) {
+	if (!atomic_test_bit(conn->flags, BT_CONN_BR_BONDABLE)) {
 		/* If bondable is false, clear bonding flag. */
 		auth = BT_HCI_SET_NO_BONDING(auth);
 	}

--- a/subsys/bluetooth/host/classic/ssp.c
+++ b/subsys/bluetooth/host/classic/ssp.c
@@ -471,11 +471,6 @@ void bt_hci_link_key_notify(struct net_buf *buf)
 		conn->br.link_key->flags |= BT_LINK_KEY_AUTHENTICATED;
 		__fallthrough;
 	case BT_LK_UNAUTH_COMBINATION_P192:
-		/* Mark no-bond so that link-key is removed on disconnection */
-		if (ssp_get_auth(conn) < BT_HCI_DEDICATED_BONDING) {
-			atomic_set_bit(conn->flags, BT_CONN_BR_NOBOND);
-		}
-
 		memcpy(conn->br.link_key->val, evt->link_key, 16);
 		break;
 	case BT_LK_AUTH_COMBINATION_P256:
@@ -483,11 +478,6 @@ void bt_hci_link_key_notify(struct net_buf *buf)
 		__fallthrough;
 	case BT_LK_UNAUTH_COMBINATION_P256:
 		conn->br.link_key->flags |= BT_LINK_KEY_SC;
-
-		/* Mark no-bond so that link-key is removed on disconnection */
-		if (ssp_get_auth(conn) < BT_HCI_DEDICATED_BONDING) {
-			atomic_set_bit(conn->flags, BT_CONN_BR_NOBOND);
-		}
 
 		memcpy(conn->br.link_key->val, evt->link_key, 16);
 		break;
@@ -702,6 +692,11 @@ void bt_hci_ssp_complete(struct net_buf *buf)
 	if (!conn) {
 		LOG_ERR("Can't find conn for %s", bt_addr_str(&evt->bdaddr));
 		return;
+	}
+
+	/* Mark no-bond so that link-key will be removed on disconnection */
+	if (ssp_get_auth(conn) < BT_HCI_DEDICATED_BONDING) {
+		atomic_set_bit(conn->flags, BT_CONN_BR_NOBOND);
 	}
 
 	ssp_pairing_complete(conn, bt_security_err_get(evt->status));

--- a/subsys/bluetooth/host/classic/ssp.c
+++ b/subsys/bluetooth/host/classic/ssp.c
@@ -634,6 +634,9 @@ void bt_hci_io_capa_resp(struct net_buf *buf)
 	bt_conn_unref(conn);
 }
 
+/* Clear Bonding flag */
+#define BT_HCI_SET_NO_BONDING(auth) ((auth) & 0x01)
+
 void bt_hci_io_capa_req(struct net_buf *buf)
 {
 	struct bt_hci_evt_io_capa_req *evt = (void *)buf->data;
@@ -672,6 +675,11 @@ void bt_hci_io_capa_req(struct net_buf *buf)
 		}
 	} else {
 		auth = ssp_get_auth(conn);
+	}
+
+	if (!bt_get_bondable()) {
+		/* If bondable is false, clear bonding flag. */
+		auth = BT_HCI_SET_NO_BONDING(auth);
 	}
 
 	cp = net_buf_add(resp_buf, sizeof(*cp));

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -57,6 +57,7 @@ enum {
 	 */
 	BT_CONN_AUTO_CONNECT,
 	BT_CONN_BR_LEGACY_SECURE,             /* 16 digits legacy PIN tracker */
+	BT_CONN_BR_BONDABLE,                  /* BR connection is bondable */
 	BT_CONN_USER,                         /* user I/O when pairing */
 	BT_CONN_BR_PAIRING,                   /* BR connection in pairing context */
 	BT_CONN_BR_NOBOND,                    /* SSP no bond pairing tracker */

--- a/subsys/bluetooth/host/shell/bt.c
+++ b/subsys/bluetooth/host/shell/bt.c
@@ -3902,6 +3902,35 @@ static int cmd_bondable(const struct shell *sh, size_t argc, char *argv[])
 	return 0;
 }
 
+#if defined(CONFIG_BT_BONDABLE_PER_CONNECTION)
+static int cmd_conn_bondable(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err = 0;
+	bool enable;
+
+	if (!default_conn) {
+		shell_error(sh, "Not connected");
+		return -ENOEXEC;
+	}
+
+	enable = shell_strtobool(argv[1], 0, &err);
+	if (err) {
+		shell_help(sh);
+		return SHELL_CMD_HELP_PRINTED;
+	}
+
+	shell_print(sh, "[%p] set conn bondable %s", default_conn, argv[1]);
+
+	err = bt_conn_set_bondable(default_conn, enable);
+	if (err) {
+		shell_error(sh, "Set conn bondable failed: err %d", err);
+		return -ENOEXEC;
+	}
+	shell_print(sh, "Set conn bondable done");
+	return 0;
+}
+#endif /* CONFIG_BT_BONDABLE_PER_CONNECTION */
+
 static void bond_info(const struct bt_bond_info *info, void *user_data)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
@@ -5079,6 +5108,9 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
 		      cmd_security, 1, 2),
 	SHELL_CMD_ARG(bondable, NULL, HELP_ONOFF, cmd_bondable,
 		      2, 0),
+#if defined(CONFIG_BT_BONDABLE_PER_CONNECTION)
+	SHELL_CMD_ARG(conn-bondable, NULL, HELP_ONOFF, cmd_conn_bondable, 2, 0),
+#endif /* CONFIG_BT_BONDABLE_PER_CONNECTION */
 	SHELL_CMD_ARG(bonds, NULL, HELP_NONE, cmd_bonds, 1, 0),
 	SHELL_CMD_ARG(connections, NULL, HELP_NONE, cmd_connections, 1, 0),
 	SHELL_CMD_ARG(auth, NULL,

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -2639,6 +2639,11 @@ void bt_set_bondable(bool enable)
 	bondable = enable;
 }
 
+bool bt_get_bondable(void)
+{
+	return bondable;
+}
+
 void bt_le_oob_set_sc_flag(bool enable)
 {
 	sc_oobd_present = enable;

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -5423,6 +5423,16 @@ int bt_conn_set_bondable(struct bt_conn *conn, bool enable)
 {
 	struct bt_smp *smp;
 
+	if (IS_ENABLED(CONFIG_BT_CLASSIC) && (conn->type == BT_CONN_TYPE_BR)) {
+		if (enable && atomic_test_and_set_bit(conn->flags, BT_CONN_BR_BONDABLE)) {
+			return -EALREADY;
+		}
+		if (!enable && !atomic_test_and_clear_bit(conn->flags, BT_CONN_BR_BONDABLE)) {
+			return -EALREADY;
+		}
+		return 0;
+	}
+
 	smp = smp_chan_get(conn);
 	if (!smp) {
 		return -EINVAL;


### PR DESCRIPTION
Add a function bt_get_bondable to get the bonding setting.

If the return value of function bt_get_bondable is false, clear the bonding flag when controller requiring `Authentication_Requirements`.
