### PR TITLE
Bluetooth: SSP: No MITM if required level is less than L3

### DIFF
--- a/subsys/bluetooth/host/classic/ssp.c
+++ b/subsys/bluetooth/host/classic/ssp.c
@@ -631,6 +631,9 @@ void bt_hci_io_capa_resp(struct net_buf *buf)
 /* Clear Bonding flag */
 #define BT_HCI_SET_NO_BONDING(auth) ((auth) & 0x01)
 
+/* Clear MITM flag */
+#define BT_HCI_SET_NO_MITM(auth) ((auth) & (~0x01))
+
 void bt_hci_io_capa_req(struct net_buf *buf)
 {
 	struct bt_hci_evt_io_capa_req *evt = (void *)buf->data;
@@ -674,6 +677,11 @@ void bt_hci_io_capa_req(struct net_buf *buf)
 			} else {
 				auth = BT_HCI_DEDICATED_BONDING;
 			}
+		}
+
+		if (conn->required_sec_level < BT_SECURITY_L3) {
+			/* If security level less than L3, clear MITM flag. */
+			auth = BT_HCI_SET_NO_MITM(auth);
 		}
 	} else {
 		auth = ssp_get_auth(conn);


### PR DESCRIPTION
Regardless IO capabilities, clear MITM flag for pairing initiator if the required security level is less than BT_SECURITY_L3.