### PR TITLE
Bluetooth: BREDR: L2CAP: Recover ident when conn is pending

### DIFF
--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -1031,6 +1031,9 @@ static void l2cap_br_conn_req(struct bt_l2cap_br *l2cap, uint8_t ident,
 		/* Disconnect link when security rules were violated */
 		if (result == BT_L2CAP_BR_ERR_SEC_BLOCK) {
 			bt_conn_disconnect(conn, BT_HCI_ERR_AUTH_FAIL);
+		} else if (result == BT_L2CAP_BR_PENDING) {
+			/* Recover the ident when conn is pending */
+			br_chan->ident = ident;
 		}
 
 		return;


### PR DESCRIPTION
The `ident` of L2CAP BR connection req will be cleared if function l2cap_br_conn_req_reply called to send L2CAP BR connection rsp with result `BT_L2CAP_BR_PENDING`.

Then the invalid `ident` (it is zero) will be filled in the L2CAP BR connection rsp after the ACL connection is encrypted.

Recover `ident` if the result of the connection rsp is `BT_L2CAP_BR_PENDING`.