### PR TITLE
Bluetooth: SSP: Support security level 4

### DIFF
--- a/subsys/bluetooth/host/classic/ssp.c
+++ b/subsys/bluetooth/host/classic/ssp.c
@@ -347,10 +347,6 @@ int bt_ssp_start_security(struct bt_conn *conn)
 		return -EBUSY;
 	}
 
-	if (conn->required_sec_level > BT_SECURITY_L3) {
-		return -ENOTSUP;
-	}
-
 	if (get_io_capa() == BT_IO_NO_INPUT_OUTPUT &&
 	    conn->required_sec_level > BT_SECURITY_L2) {
 		return -EINVAL;


### PR DESCRIPTION
Currently, error code `-ENOTSUP` will be returned if start security with security level 4.

For SC supported case, level 4 for ssp should be supported.

Remove the code limitation to support security level 4.