### PR TITLE
Bluetooth: SSP: Improve BR SC only mode

### DIFF
--- a/subsys/bluetooth/host/classic/ssp.c
+++ b/subsys/bluetooth/host/classic/ssp.c
@@ -443,6 +443,23 @@ void bt_hci_link_key_notify(struct net_buf *buf)
 
 	LOG_DBG("%s, link type 0x%02x", bt_addr_str(&evt->bdaddr), evt->key_type);
 
+	if (IS_ENABLED(CONFIG_BT_SMP_SC_ONLY) && (evt->key_type != BT_LK_AUTH_COMBINATION_P256)) {
+		/*
+		 * When in Secure Connections Only mode, all services
+		 * (except those allowed to have Security Mode 4, Level 0)
+		 * available on the BR/EDR physical transport require Security
+		 * Mode 4, Level 4.
+		 * Link key type should be P-256 based Secure Simple Pairing
+		 * and Secure Authentication.
+		 */
+		LOG_WRN("For SC only mode, link key type should be %d",
+			BT_LK_AUTH_COMBINATION_P256);
+		ssp_pairing_complete(conn, bt_security_err_get(BT_HCI_ERR_AUTH_FAIL));
+		bt_conn_disconnect(conn, BT_HCI_ERR_AUTH_FAIL);
+		bt_conn_unref(conn);
+		return;
+	}
+
 	if (!conn->br.link_key) {
 		conn->br.link_key = bt_keys_get_link_key(&evt->bdaddr);
 	}


### PR DESCRIPTION
Actively disconnect the connection with error code `BT_HCI_ERR_AUTH_FAIL` when the notified link key type is not `BT_LK_AUTH_COMBINATION_P256` in BR SC only mode.