### PR TITLE
kernel.h: Fix k_msgq_get retval doxygen

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -4577,7 +4577,7 @@ __syscall int k_msgq_put(struct k_msgq *msgq, const void *data, k_timeout_t time
  *                K_FOREVER.
  *
  * @retval 0 Message received.
- * @retval -ENOMSG Returned without waiting.
+ * @retval -ENOMSG Returned without waiting or queue purged.
  * @retval -EAGAIN Waiting period timed out.
  */
 __syscall int k_msgq_get(struct k_msgq *msgq, void *data, k_timeout_t timeout);


### PR DESCRIPTION
Added a hint about -ENOMSG being returned when the queue is purged.

This is then in-line with the `k_msgq_put` return value documentation and the "prose" documentation in chapter [Reading from a Message Queue](https://docs.zephyrproject.org/3.6.0/kernel/services/data_passing/message_queues.html#reading-from-a-message-queue)