### PR TITLE
Bluetooth: BR: improve br_sufficient_key_size

### DIFF
--- a/subsys/bluetooth/host/classic/Kconfig
+++ b/subsys/bluetooth/host/classic/Kconfig
@@ -18,6 +18,15 @@ config BT_CLASSIC
 	  This option enables Bluetooth BR/EDR support
 
 if BT_CLASSIC
+config BT_BR_MIN_ENC_KEY_SIZE
+	int
+	prompt "Minimum encryption key size accepted in octets" if !BT_SMP_SC_ONLY
+	default BT_SMP_MIN_ENC_KEY_SIZE
+	range 7 16
+	help
+	  This option sets the minimum encryption key size accepted during pairing
+	  for classic.
+
 config BT_MAX_SCO_CONN
 	int "Maximum number of simultaneous SCO connections"
 	default 1

--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -141,7 +141,7 @@ static bool br_sufficient_key_size(struct bt_conn *conn)
 		return key_size == BT_HCI_ENCRYPTION_KEY_SIZE_MAX;
 	}
 
-	return key_size >= BT_HCI_ENCRYPTION_KEY_SIZE_MIN;
+	return key_size >= CONFIG_BT_BR_MIN_ENC_KEY_SIZE;
 }
 
 bool bt_br_update_sec_level(struct bt_conn *conn)


### PR DESCRIPTION
Currently, the minimum value of encryption key size is `BT_HCI_ENCRYPTION_KEY_SIZE_MIN`.

Add a new Kconfig `BT_BR_MIN_ENC_KEY_SIZE`. It is used to set the specific minimum encryption key size.
The default value is `BT_SMP_MIN_ENC_KEY_SIZE`. And it can be configured if `BT_SMP_SC_ONLY` is not enabled.

Use `CONFIG_BT_BR_MIN_ENC_KEY_SIZE` as minimum encryption key size in `br_sufficient_key_size`.
