### PR TITLE
drivers: pwm: pwm_stm32: remove capture overflow log err

### DIFF
--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -732,7 +732,6 @@ static void pwm_stm32_isr(const struct device *dev)
 	}
 
 	if (cpt->overflows) {
-		LOG_ERR("counter overflow during PWM capture");
 		status = -ERANGE;
 	}
 


### PR DESCRIPTION
The `LOG_ERR` will spam the log if the window is low e.g. 1 ms.
Also the PWM capture callback will be called with an error, which allows handling and logging the error if desired.