### PR TITLE
Bluetooth: L2CAP_BR: Set flags in CFG RSP

### DIFF
--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -1279,6 +1279,16 @@ send_rsp:
 	rsp->scid = sys_cpu_to_le16(BR_CHAN(chan)->tx.cid);
 
 	/*
+	 * Core 5.4, Vol 3, Part A, section 4.5.
+	 * When used in the L2CAP_CONFIGURATION_RSP packet,
+	 * the continuation flag shall be set to one if the
+	 * flag is set to one in the Request, except for
+	 * those error conditions more appropriate for an
+	 * L2CAP_COMMAND_REJECT_RSP packet.
+	 */
+	rsp->flags = sys_cpu_to_le16(flags & BT_L2CAP_CONF_FLAGS_MASK);
+
+	/*
 	 * TODO: If options other than MTU became meaningful then processing
 	 * the options chain need to be modified and taken into account when
 	 * sending back to peer.

--- a/subsys/bluetooth/host/classic/l2cap_br_internal.h
+++ b/subsys/bluetooth/host/classic/l2cap_br_internal.h
@@ -73,6 +73,9 @@ struct bt_l2cap_conn_rsp {
 #define BT_L2CAP_CONF_UNACCEPT          0x0001
 #define BT_L2CAP_CONF_REJECT            0x0002
 
+#define BT_L2CAP_CONF_FLAGS_C           BIT(0)
+#define BT_L2CAP_CONF_FLAGS_MASK        BT_L2CAP_CONF_FLAGS_C
+
 #define BT_L2CAP_CONF_REQ               0x04
 struct bt_l2cap_conf_req {
 	uint16_t dcid;


### PR DESCRIPTION
The flags of L2CAP_CONFIGURATION_REQ are set.
But in L2CAP_CONFIGURATION_RSP, all bits of flags are cleared.

When used in the L2CAP_CONFIGURATION_RSP packet, the continuation flag shall be set to one if the flag is set to one in the Request.

Copy flags from Request to Response if it is a successful result.