### PR TITLE
[fix] tests/net/socket/tls_configurations/ fails due to reusing ports

### DIFF
--- a/tests/net/socket/tls_configurations/testcase.yaml
+++ b/tests/net/socket/tls_configurations/testcase.yaml
@@ -4,7 +4,6 @@ common:
     - net.socket
   platform_allow:
     - native_sim
-    - native_sim/native/64
   integration_platforms:
     - native_sim
   harness: pytest


### PR DESCRIPTION
This PR fixes #78792 by removing `native_sim/native/64` from the `platform_allow` list of `zephyr/tests/net/socket/tls_configurations/testcase.yaml`.