### PR TITLE
MAINTAINERS: Move Bluetooth host from jori-nordic to alwa-nordic

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -305,7 +305,6 @@ Bluetooth HCI:
   status: maintained
   maintainers:
     - jhedberg
-    - jori-nordic
   collaborators:
     - hermabe
     - alwa-nordic
@@ -359,7 +358,6 @@ Bluetooth controller:
 Bluetooth Host:
   status: maintained
   maintainers:
-    - jori-nordic
     - jhedberg
   collaborators:
     - hermabe

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -305,9 +305,9 @@ Bluetooth HCI:
   status: maintained
   maintainers:
     - jhedberg
+    - alwa-nordic
   collaborators:
     - hermabe
-    - alwa-nordic
     - Thalley
     - sjanc
     - theob-pro
@@ -359,9 +359,9 @@ Bluetooth Host:
   status: maintained
   maintainers:
     - jhedberg
+    - alwa-nordic
   collaborators:
     - hermabe
-    - alwa-nordic
     - Thalley
     - sjanc
     - theob-pro


### PR DESCRIPTION
```
MAINTAINERS: Remove myself from Bluetooth

This is my final week at Nordic. My future job will not involve me
maintaining the Bluetooth host.
```
```
MAINTAINERS: Add alwa-nordic as Bluetooth maintainer

He will be taking over my duties.
```