### PR TITLE
drivers: i2c: nrfx_twim: simplify PM by using pm_device_driver_init

### DIFF
--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -297,40 +297,26 @@ static const struct i2c_driver_api i2c_nrfx_twim_driver_api = {
 	.recover_bus = i2c_nrfx_twim_recover_bus,
 };
 
-#ifdef CONFIG_PM_DEVICE
 static int twim_nrfx_pm_action(const struct device *dev,
 			       enum pm_device_action action)
 {
 	const struct i2c_nrfx_twim_config *dev_config = dev->config;
-	int ret = 0;
 
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
-		ret = pinctrl_apply_state(dev_config->pcfg,
-					  PINCTRL_STATE_DEFAULT);
-		if (ret < 0) {
-			return ret;
-		}
+		(void)pinctrl_apply_state(dev_config->pcfg, PINCTRL_STATE_DEFAULT);
 		nrfx_twim_enable(&dev_config->twim);
 		break;
-
 	case PM_DEVICE_ACTION_SUSPEND:
 		nrfx_twim_disable(&dev_config->twim);
-
-		ret = pinctrl_apply_state(dev_config->pcfg,
-					  PINCTRL_STATE_SLEEP);
-		if (ret < 0) {
-			return ret;
-		}
+		(void)pinctrl_apply_state(dev_config->pcfg, PINCTRL_STATE_SLEEP);
 		break;
-
 	default:
-		ret = -ENOTSUP;
+		return -ENOTSUP;
 	}
 
-	return ret;
+	return 0;
 }
-#endif /* CONFIG_PM_DEVICE */
 
 static int i2c_nrfx_twim_init(const struct device *dev)
 {
@@ -342,13 +328,7 @@ static int i2c_nrfx_twim_init(const struct device *dev)
 	k_sem_init(&dev_data->transfer_sync, 1, 1);
 	k_sem_init(&dev_data->completion_sync, 0, 1);
 
-	int err = pinctrl_apply_state(dev_config->pcfg,
-				      COND_CODE_1(CONFIG_PM_DEVICE_RUNTIME,
-						  (PINCTRL_STATE_SLEEP),
-						  (PINCTRL_STATE_DEFAULT)));
-	if (err < 0) {
-		return err;
-	}
+	(void)pinctrl_apply_state(dev_config->pcfg, PINCTRL_STATE_SLEEP);
 
 	if (nrfx_twim_init(&dev_config->twim, &dev_config->twim_config,
 			   event_handler, dev_data) != NRFX_SUCCESS) {
@@ -356,14 +336,7 @@ static int i2c_nrfx_twim_init(const struct device *dev)
 		return -EIO;
 	}
 
-#ifdef CONFIG_PM_DEVICE_RUNTIME
-	pm_device_init_suspended(dev);
-	pm_device_runtime_enable(dev);
-#else
-	nrfx_twim_enable(&dev_config->twim);
-#endif
-
-	return 0;
+	return pm_device_driver_init(dev, twim_nrfx_pm_action);
 }
 
 #define I2C_NRFX_TWIM_INVALID_FREQUENCY  ((nrf_twim_frequency_t)-1)

--- a/dts/arm/nordic/nrf52805.dtsi
+++ b/dts/arm/nordic/nrf52805.dtsi
@@ -130,6 +130,7 @@
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <14>;
 			status = "disabled";
+			zephyr,pm-device-runtime-auto;
 		};
 
 		spi0: spi@40004000 {

--- a/dts/arm/nordic/nrf52810.dtsi
+++ b/dts/arm/nordic/nrf52810.dtsi
@@ -134,6 +134,7 @@
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <10>;
 			status = "disabled";
+			zephyr,pm-device-runtime-auto;
 		};
 
 		spi0: spi@40004000 {

--- a/dts/arm/nordic/nrf52811.dtsi
+++ b/dts/arm/nordic/nrf52811.dtsi
@@ -146,6 +146,7 @@
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <14>;
 			status = "disabled";
+			zephyr,pm-device-runtime-auto;
 		};
 
 		spi1: spi@40003000 {

--- a/dts/arm/nordic/nrf52820.dtsi
+++ b/dts/arm/nordic/nrf52820.dtsi
@@ -149,6 +149,7 @@
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <15>;
 			status = "disabled";
+			zephyr,pm-device-runtime-auto;
 		};
 
 		spi0: spi@40003000 {
@@ -185,6 +186,7 @@
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <15>;
 			status = "disabled";
+			zephyr,pm-device-runtime-auto;
 		};
 
 		spi1: spi@40004000 {

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -134,6 +134,7 @@
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <8>;
 			status = "disabled";
+			zephyr,pm-device-runtime-auto;
 		};
 
 		spi0: spi@40003000 {
@@ -170,6 +171,7 @@
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <8>;
 			status = "disabled";
+			zephyr,pm-device-runtime-auto;
 		};
 
 		spi1: spi@40004000 {

--- a/dts/arm/nordic/nrf52833.dtsi
+++ b/dts/arm/nordic/nrf52833.dtsi
@@ -148,6 +148,7 @@
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <16>;
 			status = "disabled";
+			zephyr,pm-device-runtime-auto;
 		};
 
 		spi0: spi@40003000 {
@@ -184,6 +185,7 @@
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <16>;
 			status = "disabled";
+			zephyr,pm-device-runtime-auto;
 		};
 
 		spi1: spi@40004000 {

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -136,6 +136,7 @@
 			interrupts = <3 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <16>;
 			status = "disabled";
+			zephyr,pm-device-runtime-auto;
 		};
 
 		spi0: spi@40003000 {
@@ -172,6 +173,7 @@
 			interrupts = <4 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <16>;
 			status = "disabled";
+			zephyr,pm-device-runtime-auto;
 		};
 
 		spi1: spi@40004000 {

--- a/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
@@ -119,6 +119,7 @@ i2c0: i2c@8000 {
 	interrupts = <8 NRF_DEFAULT_IRQ_PRIORITY>;
 	easydma-maxcnt-bits = <16>;
 	status = "disabled";
+	zephyr,pm-device-runtime-auto;
 };
 
 spi0: spi@8000 {
@@ -160,6 +161,7 @@ i2c1: i2c@9000 {
 	interrupts = <9 NRF_DEFAULT_IRQ_PRIORITY>;
 	easydma-maxcnt-bits = <16>;
 	status = "disabled";
+	zephyr,pm-device-runtime-auto;
 };
 
 spi1: spi@9000 {
@@ -214,6 +216,7 @@ i2c2: i2c@b000 {
 	interrupts = <11 NRF_DEFAULT_IRQ_PRIORITY>;
 	easydma-maxcnt-bits = <16>;
 	status = "disabled";
+	zephyr,pm-device-runtime-auto;
 };
 
 spi2: spi@b000 {
@@ -255,6 +258,7 @@ i2c3: i2c@c000 {
 	interrupts = <12 NRF_DEFAULT_IRQ_PRIORITY>;
 	easydma-maxcnt-bits = <16>;
 	status = "disabled";
+	zephyr,pm-device-runtime-auto;
 };
 
 spi3: spi@c000 {

--- a/dts/arm/nordic/nrf5340_cpunet.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet.dtsi
@@ -205,6 +205,7 @@
 			interrupts = <19 NRF_DEFAULT_IRQ_PRIORITY>;
 			easydma-maxcnt-bits = <16>;
 			status = "disabled";
+			zephyr,pm-device-runtime-auto;
 		};
 
 		spi0: spi@41013000 {

--- a/dts/arm/nordic/nrf91_peripherals.dtsi
+++ b/dts/arm/nordic/nrf91_peripherals.dtsi
@@ -160,6 +160,7 @@ i2c0: i2c@8000 {
 	interrupts = <8 NRF_DEFAULT_IRQ_PRIORITY>;
 	easydma-maxcnt-bits = <13>;
 	status = "disabled";
+	zephyr,pm-device-runtime-auto;
 };
 
 i2c1: i2c@9000 {
@@ -176,6 +177,7 @@ i2c1: i2c@9000 {
 	interrupts = <9 NRF_DEFAULT_IRQ_PRIORITY>;
 	easydma-maxcnt-bits = <13>;
 	status = "disabled";
+	zephyr,pm-device-runtime-auto;
 };
 
 i2c2: i2c@a000 {
@@ -192,6 +194,7 @@ i2c2: i2c@a000 {
 	interrupts = <10 NRF_DEFAULT_IRQ_PRIORITY>;
 	easydma-maxcnt-bits = <13>;
 	status = "disabled";
+	zephyr,pm-device-runtime-auto;
 };
 
 i2c3: i2c@b000 {
@@ -208,6 +211,7 @@ i2c3: i2c@b000 {
 	interrupts = <11 NRF_DEFAULT_IRQ_PRIORITY>;
 	easydma-maxcnt-bits = <13>;
 	status = "disabled";
+	zephyr,pm-device-runtime-auto;
 };
 
 spi0: spi@8000 {

--- a/dts/common/nordic/nrf54h20.dtsi
+++ b/dts/common/nordic/nrf54h20.dtsi
@@ -910,6 +910,7 @@
 				#size-cells = <0>;
 				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
 							 <NRF_FUN_TWIM_SCL>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			spi130: spi@9a5000 {
@@ -952,6 +953,7 @@
 				#size-cells = <0>;
 				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
 							 <NRF_FUN_TWIM_SCL>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			spi131: spi@9a6000 {
@@ -1031,6 +1033,7 @@
 				#size-cells = <0>;
 				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
 							 <NRF_FUN_TWIM_SCL>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			spi132: spi@9b5000 {
@@ -1073,6 +1076,7 @@
 				#size-cells = <0>;
 				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
 							 <NRF_FUN_TWIM_SCL>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			spi133: spi@9b6000 {
@@ -1152,6 +1156,7 @@
 				#size-cells = <0>;
 				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
 							 <NRF_FUN_TWIM_SCL>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			spi134: spi@9c5000 {
@@ -1194,6 +1199,7 @@
 				#size-cells = <0>;
 				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
 							 <NRF_FUN_TWIM_SCL>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			spi135: spi@9c6000 {
@@ -1273,6 +1279,7 @@
 				#size-cells = <0>;
 				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
 							 <NRF_FUN_TWIM_SCL>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			spi136: spi@9d5000 {
@@ -1315,6 +1322,7 @@
 				#size-cells = <0>;
 				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
 							 <NRF_FUN_TWIM_SCL>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			spi137: spi@9d6000 {

--- a/dts/common/nordic/nrf54l15.dtsi
+++ b/dts/common/nordic/nrf54l15.dtsi
@@ -243,6 +243,7 @@
 				interrupts = <198 NRF_DEFAULT_IRQ_PRIORITY>;
 				easydma-maxcnt-bits = <16>;
 				status = "disabled";
+				zephyr,pm-device-runtime-auto;
 			};
 
 			spi20: spi@c6000 {
@@ -282,6 +283,7 @@
 				interrupts = <199 NRF_DEFAULT_IRQ_PRIORITY>;
 				easydma-maxcnt-bits = <16>;
 				status = "disabled";
+				zephyr,pm-device-runtime-auto;
 			};
 
 			spi21: spi@c7000 {
@@ -321,6 +323,7 @@
 				interrupts = <200 NRF_DEFAULT_IRQ_PRIORITY>;
 				easydma-maxcnt-bits = <16>;
 				status = "disabled";
+				zephyr,pm-device-runtime-auto;
 			};
 
 			spi22: spi@c8000 {
@@ -531,6 +534,7 @@
 				interrupts = <260 NRF_DEFAULT_IRQ_PRIORITY>;
 				easydma-maxcnt-bits = <16>;
 				status = "disabled";
+				zephyr,pm-device-runtime-auto;
 			};
 
 			spi30: spi@104000 {

--- a/dts/common/nordic/nrf54l20.dtsi
+++ b/dts/common/nordic/nrf54l20.dtsi
@@ -193,6 +193,7 @@
 				interrupts = <198 NRF_DEFAULT_IRQ_PRIORITY>;
 				easydma-maxcnt-bits = <16>;
 				status = "disabled";
+				zephyr,pm-device-runtime-auto;
 			};
 
 			spi20: spi@c6000 {
@@ -232,6 +233,7 @@
 				interrupts = <199 NRF_DEFAULT_IRQ_PRIORITY>;
 				easydma-maxcnt-bits = <16>;
 				status = "disabled";
+				zephyr,pm-device-runtime-auto;
 			};
 
 			spi21: spi@c7000 {
@@ -271,6 +273,7 @@
 				interrupts = <200 NRF_DEFAULT_IRQ_PRIORITY>;
 				easydma-maxcnt-bits = <16>;
 				status = "disabled";
+				zephyr,pm-device-runtime-auto;
 			};
 
 			spi22: spi@c8000 {
@@ -472,6 +475,7 @@
 				interrupts = <260 NRF_DEFAULT_IRQ_PRIORITY>;
 				easydma-maxcnt-bits = <16>;
 				status = "disabled";
+				zephyr,pm-device-runtime-auto;
 			};
 
 			spi30: spi@104000 {

--- a/dts/common/nordic/nrf9280.dtsi
+++ b/dts/common/nordic/nrf9280.dtsi
@@ -821,6 +821,7 @@
 				#size-cells = <0>;
 				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
 							 <NRF_FUN_TWIM_SCL>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			spi130: spi@9a5000 {
@@ -860,6 +861,7 @@
 				#size-cells = <0>;
 				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
 							 <NRF_FUN_TWIM_SCL>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			spi131: spi@9a6000 {
@@ -933,6 +935,7 @@
 				#size-cells = <0>;
 				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
 							 <NRF_FUN_TWIM_SCL>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			spi132: spi@9b5000 {
@@ -972,6 +975,7 @@
 				#size-cells = <0>;
 				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
 							 <NRF_FUN_TWIM_SCL>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			spi133: spi@9b6000 {
@@ -1045,6 +1049,7 @@
 				#size-cells = <0>;
 				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
 							 <NRF_FUN_TWIM_SCL>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			spi134: spi@9c5000 {
@@ -1084,6 +1089,7 @@
 				#size-cells = <0>;
 				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
 							 <NRF_FUN_TWIM_SCL>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			spi135: spi@9c6000 {
@@ -1157,6 +1163,7 @@
 				#size-cells = <0>;
 				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
 							 <NRF_FUN_TWIM_SCL>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			spi136: spi@9d5000 {
@@ -1196,6 +1203,7 @@
 				#size-cells = <0>;
 				nordic,clockpin-enable = <NRF_FUN_TWIM_SDA>,
 							 <NRF_FUN_TWIM_SCL>;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			spi137: spi@9d6000 {

--- a/include/zephyr/pm/device.h
+++ b/include/zephyr/pm/device.h
@@ -625,7 +625,8 @@ bool pm_device_is_powered(const struct device *dev);
  * This helper function is intended to be called at the end of a driver
  * init function to automatically setup the device into the lowest power
  * mode. It assumes that the device has been configured as if it is in
- * @ref PM_DEVICE_STATE_OFF.
+ * @ref PM_DEVICE_STATE_OFF, or @ref PM_DEVICE_STATE_SUSPENDED if device can
+ * never be powered off.
  *
  * @param dev Device instance.
  * @param action_cb Device PM control callback function.
@@ -718,7 +719,7 @@ static inline int pm_device_driver_init(const struct device *dev, pm_device_acti
 
 	/* When power management is not enabled, all drivers should initialise to active state */
 	rc = action_cb(dev, PM_DEVICE_ACTION_TURN_ON);
-	if (rc < 0) {
+	if ((rc < 0) && (rc != -ENOTSUP)) {
 		return rc;
 	}
 

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -370,7 +370,7 @@ int pm_device_driver_init(const struct device *dev,
 
 	/* Run power-up logic */
 	rc = action_cb(dev, PM_DEVICE_ACTION_TURN_ON);
-	if (rc != 0) {
+	if ((rc < 0) && (rc != -ENOTSUP)) {
 		return rc;
 	}
 


### PR DESCRIPTION
- Driver always initializes the device in the suspended state
- If CONFIG_PM_DEVICE_RUNTIME=n, device PM callback will be called with
  RESUME action, thus setting up pins to default state and enabling the
  peripheral

NOTE: when CONFIG_PM_DEVICE=n, the pinctrl sleep state will not be
available (-ENOENT) and so never applied, thus avoiding a pin
suspended->active transition.

See the other commits in the PM subsystem:

- 2b08eaa1cf0590dcb05b559c62ed4eaf8b4568b0 makes TURN_ON action optional, as for some devices it's pointless