### PR TITLE
drivers: can: nrf: add support for PM

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -304,6 +304,7 @@ zephyr_udc0: &usbhs {
 	status = "okay";
 	pinctrl-0 = <&can120_default>;
 	pinctrl-names = "default";
+	zephyr,pm-device-runtime-auto;
 };
 
 &pwm130 {


### PR DESCRIPTION
Add support for device power management. Actions taken:

- Shutdown/Resume AUXPLL clock
- Configure pins in default/sleep state
- Stop peripheral using the nRF wrapper

TODO:
- Check if there's any LP settings in the Bosch MCAN IP
- Make some power measurements
- Some changes in https://github.com/zephyrproject-rtos/zephyr/pull/78851 could simplify things a bit