### PR TITLE
MAINTAINERS: Add kruithofa as collaborator for BT ISO

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -517,6 +517,7 @@ Bluetooth ISO:
     - Thalley
   collaborators:
     - jhedberg
+    - kruithofa
   files:
     - include/zephyr/bluetooth/iso.h
     - doc/connectivity/bluetooth/api/shell/iso.rst


### PR DESCRIPTION
Added kruithofa as a collaborator as they are familiar with ISO and we should have at least 2 collaborators to perform reviews.