### PR TITLE
Bluetooth: L2CAP_BR: handle all configuration options

### DIFF
--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -1174,25 +1174,138 @@ static uint16_t l2cap_br_conf_opt_mtu(struct bt_l2cap_chan *chan,
 				   struct net_buf *buf, size_t len)
 {
 	uint16_t mtu, result = BT_L2CAP_CONF_SUCCESS;
+	struct bt_l2cap_conf_opt_mtu *opt_mtu;
 
 	/* Core 4.2 [Vol 3, Part A, 5.1] MTU payload length */
-	if (len != 2) {
+	if (len != sizeof(*opt_mtu)) {
 		LOG_ERR("tx MTU length %zu invalid", len);
 		result = BT_L2CAP_CONF_REJECT;
 		goto done;
 	}
 
-	/* pulling MTU value moves buf data to next option item */
-	mtu = net_buf_pull_le16(buf);
+	opt_mtu = (struct bt_l2cap_conf_opt_mtu *)buf->data;
+
+	mtu = sys_le16_to_cpu(opt_mtu->mtu);
 	if (mtu < L2CAP_BR_MIN_MTU) {
 		result = BT_L2CAP_CONF_UNACCEPT;
 		BR_CHAN(chan)->tx.mtu = L2CAP_BR_MIN_MTU;
+		opt_mtu->mtu = sys_cpu_to_le16(L2CAP_BR_MIN_MTU);
 		LOG_DBG("tx MTU %u invalid", mtu);
 		goto done;
 	}
 
 	BR_CHAN(chan)->tx.mtu = mtu;
 	LOG_DBG("tx MTU %u", mtu);
+done:
+	return result;
+}
+
+static uint16_t l2cap_br_conf_opt_flush_timeout(struct bt_l2cap_chan *chan,
+						struct net_buf *buf, size_t len)
+{
+	uint16_t result = BT_L2CAP_CONF_SUCCESS;
+	struct bt_l2cap_conf_opt_flush_timeout *opt_to;
+
+	if (len != sizeof(*opt_to)) {
+		LOG_ERR("qos frame length %zu invalid", len);
+		result = BT_L2CAP_CONF_REJECT;
+		goto done;
+	}
+
+	opt_to = (struct bt_l2cap_conf_opt_flush_timeout *)buf->data;
+
+	LOG_DBG("Flush timeout %u", opt_to->timeout);
+
+	opt_to->timeout = sys_cpu_to_le16(0xFFFF);
+	result = BT_L2CAP_CONF_UNACCEPT;
+done:
+	return result;
+}
+
+static uint16_t l2cap_br_conf_opt_qos(struct bt_l2cap_chan *chan,
+				      struct net_buf *buf, size_t len)
+{
+	uint16_t result = BT_L2CAP_CONF_SUCCESS;
+	struct bt_l2cap_conf_opt_qos *opt_qos;
+
+	if (len != sizeof(*opt_qos)) {
+		LOG_ERR("qos frame length %zu invalid", len);
+		result = BT_L2CAP_CONF_REJECT;
+		goto done;
+	}
+
+	opt_qos = (struct bt_l2cap_conf_opt_qos *)buf->data;
+
+	LOG_DBG("QOS Type %u", opt_qos->service_type);
+
+	if (opt_qos->service_type == BT_L2CAP_QOS_TYPE_GUARANTEED) {
+		/* Set to default value */
+		result = BT_L2CAP_CONF_UNACCEPT;
+		opt_qos->flags = 0x00;
+		/* do not care */
+		opt_qos->token_rate = sys_cpu_to_le32(0x00000000);
+		/* no token bucket is needed */
+		opt_qos->token_bucket_size = sys_cpu_to_le32(0x00000000);
+		/* do not care */
+		opt_qos->peak_bandwidth = sys_cpu_to_le32(0x00000000);
+		/* do not care */
+		opt_qos->latency = sys_cpu_to_le32(0xFFFFFFFF);
+		/* do not care */
+		opt_qos->delay_variation = sys_cpu_to_le32(0xFFFFFFFF);
+	}
+
+done:
+	return result;
+}
+
+static uint16_t l2cap_br_conf_opt_ret_fc(struct bt_l2cap_chan *chan,
+					 struct net_buf *buf, size_t len)
+{
+	uint16_t result = BT_L2CAP_CONF_SUCCESS;
+	struct bt_l2cap_conf_opt_ret_fc *opt_ret_fc;
+
+	if (len != sizeof(*opt_ret_fc)) {
+		LOG_ERR("ret_fc frame length %zu invalid", len);
+		result = BT_L2CAP_CONF_REJECT;
+		goto done;
+	}
+
+	opt_ret_fc = (struct bt_l2cap_conf_opt_ret_fc *)buf->data;
+
+	LOG_DBG("ret_fc mode %u", opt_ret_fc->mode);
+
+	if (opt_ret_fc->mode != BT_L2CAP_RET_FC_MODE_BASIC) {
+		/* Set to default value */
+		result = BT_L2CAP_CONF_UNACCEPT;
+		opt_ret_fc->mode = BT_L2CAP_RET_FC_MODE_BASIC;
+	}
+
+done:
+	return result;
+}
+
+static uint16_t l2cap_br_conf_opt_fcs(struct bt_l2cap_chan *chan,
+				      struct net_buf *buf, size_t len)
+{
+	uint16_t result = BT_L2CAP_CONF_SUCCESS;
+	struct bt_l2cap_conf_opt_fcs *opt_fcs;
+
+	if (len != sizeof(*opt_fcs)) {
+		LOG_ERR("fcs frame length %zu invalid", len);
+		result = BT_L2CAP_CONF_REJECT;
+		goto done;
+	}
+
+	opt_fcs = (struct bt_l2cap_conf_opt_fcs *)buf->data;
+
+	LOG_DBG("FCS type %u", opt_fcs->type);
+
+	if (opt_fcs->type != BT_L2CAP_FCS_TYPE_NO) {
+		/* Set to default value */
+		result = BT_L2CAP_CONF_UNACCEPT;
+		opt_fcs->type = BT_L2CAP_FCS_TYPE_NO;
+	}
+
 done:
 	return result;
 }
@@ -1223,9 +1336,10 @@ static void l2cap_br_conf_req(struct bt_l2cap_br *l2cap, uint8_t ident,
 	chan = bt_l2cap_br_lookup_rx_cid(conn, dcid);
 	if (!chan) {
 		LOG_ERR("rx channel mismatch!");
-		struct bt_l2cap_cmd_reject_cid_data data = {.scid = req->dcid,
-							    .dcid = 0,
-							   };
+		struct bt_l2cap_cmd_reject_cid_data data = {
+			.scid = req->dcid,
+			.dcid = 0,
+		};
 
 		l2cap_br_send_reject(conn, ident, BT_L2CAP_REJ_INVALID_CID,
 				     &data, sizeof(data));
@@ -1261,17 +1375,46 @@ static void l2cap_br_conf_req(struct bt_l2cap_br *l2cap, uint8_t ident,
 			 * way out here.
 			 */
 			goto send_rsp;
+		case BT_L2CAP_CONF_OPT_FLUSH_TIMEOUT:
+			result = l2cap_br_conf_opt_flush_timeout(chan, buf, opt->len);
+			if (result != BT_L2CAP_CONF_SUCCESS) {
+				goto send_rsp;
+			}
+			break;
+		case BT_L2CAP_CONF_OPT_QOS:
+			result = l2cap_br_conf_opt_qos(chan, buf, opt->len);
+			if (result != BT_L2CAP_CONF_SUCCESS) {
+				goto send_rsp;
+			}
+			break;
+		case BT_L2CAP_CONF_OPT_RET_FC:
+			result = l2cap_br_conf_opt_ret_fc(chan, buf, opt->len);
+			if (result != BT_L2CAP_CONF_SUCCESS) {
+				goto send_rsp;
+			}
+			break;
+		case BT_L2CAP_CONF_OPT_FCS:
+			result = l2cap_br_conf_opt_fcs(chan, buf, opt->len);
+			if (result != BT_L2CAP_CONF_SUCCESS) {
+				goto send_rsp;
+			}
+			break;
+		case BT_L2CAP_CONF_OPT_EXT_FLOW_SPEC:
+			__fallthrough;
+		case BT_L2CAP_CONF_OPT_EXT_WIN_SIZE:
+			result = BT_L2CAP_CONF_REJECT;
+			goto send_rsp;
 		default:
 			if (!hint) {
 				LOG_DBG("option %u not handled", opt->type);
 				result = BT_L2CAP_CONF_UNKNOWN_OPT;
 				goto send_rsp;
 			}
-
-			/* Update buffer to point at next option */
-			net_buf_pull(buf, opt->len);
 			break;
 		}
+
+		/* Update buffer to point at next option */
+		net_buf_pull(buf, opt->len);
 	}
 
 send_rsp:
@@ -1291,9 +1434,7 @@ send_rsp:
 	 * the options chain need to be modified and taken into account when
 	 * sending back to peer.
 	 */
-	if (result == BT_L2CAP_CONF_UNACCEPT) {
-		l2cap_br_conf_add_mtu(buf, BR_CHAN(chan)->tx.mtu);
-	} else if (result == BT_L2CAP_CONF_UNKNOWN_OPT) {
+	if ((result == BT_L2CAP_CONF_UNKNOWN_OPT) || (result == BT_L2CAP_CONF_UNACCEPT)) {
 		if (opt) {
 			l2cap_br_conf_add_opt(buf, opt);
 		}

--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -677,6 +677,13 @@ static void l2cap_br_conf_add_mtu(struct net_buf *buf, const uint16_t mtu)
 	net_buf_add_le16(buf, mtu);
 }
 
+static void l2cap_br_conf_add_opt(struct net_buf *buf, const struct bt_l2cap_conf_opt *opt)
+{
+	net_buf_add_u8(buf, opt->type & BT_L2CAP_CONF_MASK);
+	net_buf_add_u8(buf, opt->len);
+	net_buf_add_mem(buf, opt->data, opt->len);
+}
+
 static void l2cap_br_conf(struct bt_l2cap_chan *chan)
 {
 	struct bt_l2cap_sig_hdr *hdr;
@@ -1198,7 +1205,7 @@ static void l2cap_br_conf_req(struct bt_l2cap_br *l2cap, uint8_t ident,
 	struct bt_l2cap_conf_req *req;
 	struct bt_l2cap_sig_hdr *hdr;
 	struct bt_l2cap_conf_rsp *rsp;
-	struct bt_l2cap_conf_opt *opt;
+	struct bt_l2cap_conf_opt *opt = NULL;
 	uint16_t flags, dcid, opt_len, hint, result = BT_L2CAP_CONF_SUCCESS;
 
 	if (buf->len < sizeof(*req)) {
@@ -1257,6 +1264,7 @@ static void l2cap_br_conf_req(struct bt_l2cap_br *l2cap, uint8_t ident,
 		default:
 			if (!hint) {
 				LOG_DBG("option %u not handled", opt->type);
+				result = BT_L2CAP_CONF_UNKNOWN_OPT;
 				goto send_rsp;
 			}
 
@@ -1285,6 +1293,10 @@ send_rsp:
 	 */
 	if (result == BT_L2CAP_CONF_UNACCEPT) {
 		l2cap_br_conf_add_mtu(buf, BR_CHAN(chan)->tx.mtu);
+	} else if (result == BT_L2CAP_CONF_UNKNOWN_OPT) {
+		if (opt) {
+			l2cap_br_conf_add_opt(buf, opt);
+		}
 	}
 
 	hdr->len = sys_cpu_to_le16(buf->len - sizeof(*hdr));

--- a/subsys/bluetooth/host/classic/l2cap_br_internal.h
+++ b/subsys/bluetooth/host/classic/l2cap_br_internal.h
@@ -72,6 +72,9 @@ struct bt_l2cap_conn_rsp {
 #define BT_L2CAP_CONF_SUCCESS           0x0000
 #define BT_L2CAP_CONF_UNACCEPT          0x0001
 #define BT_L2CAP_CONF_REJECT            0x0002
+#define BT_L2CAP_CONF_UNKNOWN_OPT       0x0003
+#define BT_L2CAP_CONF_PENDING           0x0004
+#define BT_L2CAP_CONF_FLOW_SPEC_REJECT  0x0005
 
 #define BT_L2CAP_CONF_REQ               0x04
 struct bt_l2cap_conf_req {

--- a/subsys/bluetooth/host/classic/l2cap_br_internal.h
+++ b/subsys/bluetooth/host/classic/l2cap_br_internal.h
@@ -93,6 +93,13 @@ struct bt_l2cap_conf_rsp {
 
 /* Option type used by MTU config request data */
 #define BT_L2CAP_CONF_OPT_MTU           0x01
+#define BT_L2CAP_CONF_OPT_FLUSH_TIMEOUT 0x02
+#define BT_L2CAP_CONF_OPT_QOS           0x03
+#define BT_L2CAP_CONF_OPT_RET_FC        0x04
+#define BT_L2CAP_CONF_OPT_FCS           0x05
+#define BT_L2CAP_CONF_OPT_EXT_FLOW_SPEC 0x06
+#define BT_L2CAP_CONF_OPT_EXT_WIN_SIZE  0x07
+
 /* Options bits selecting most significant bit (hint) in type field */
 #define BT_L2CAP_CONF_HINT              0x80
 #define BT_L2CAP_CONF_MASK              0x7f
@@ -101,6 +108,47 @@ struct bt_l2cap_conf_opt {
 	uint8_t type;
 	uint8_t len;
 	uint8_t data[0];
+} __packed;
+
+struct bt_l2cap_conf_opt_mtu {
+	uint16_t mtu;
+} __packed;
+
+struct bt_l2cap_conf_opt_flush_timeout {
+	uint16_t timeout;
+} __packed;
+
+#define BT_L2CAP_QOS_TYPE_NO_TRAFFIC    0x00
+#define BT_L2CAP_QOS_TYPE_BEST_EFFORT   0x01
+#define BT_L2CAP_QOS_TYPE_GUARANTEED    0x02
+struct bt_l2cap_conf_opt_qos {
+	uint8_t flags;
+	uint8_t service_type;
+	uint32_t token_rate;
+	uint32_t token_bucket_size;
+	uint32_t peak_bandwidth;
+	uint32_t latency;
+	uint32_t delay_variation;
+} __packed;
+
+#define BT_L2CAP_RET_FC_MODE_BASIC   0x00
+#define BT_L2CAP_RET_FC_MODE_RET     0x01
+#define BT_L2CAP_RET_FC_MODE_FC      0x02
+#define BT_L2CAP_RET_FC_MODE_ENH_RET 0x03
+#define BT_L2CAP_RET_FC_MODE_STREAM  0x04
+struct bt_l2cap_conf_opt_ret_fc {
+	uint8_t mode;
+	uint8_t tx_windows_size;
+	uint8_t max_transmit;
+	uint16_t retransmission_timeout;
+	uint16_t monitor_timeout;
+	uint16_t mps;
+} __packed;
+
+#define BT_L2CAP_FCS_TYPE_NO         0x00
+#define BT_L2CAP_FCS_TYPE_16BIT      0x01
+struct bt_l2cap_conf_opt_fcs {
+	uint8_t type;
 } __packed;
 
 #define BT_L2CAP_DISCONN_REQ            0x06


### PR DESCRIPTION
* Bluetooth: L2CAP_BR: incorrect result returned if config opt unsupported

The `BT_L2CAP_CONF_SUCCESS` is returned as result for the config req with supported opt.

Result `BT_L2CAP_CONF_UNKNOWN_OPT` should be returned for this case.

* Bluetooth: L2CAP_BR: Process all defined OPTs

Currently, Only configuration opt MTU is handled.

For opt `Flush timeout`, `QOS`, `Retransmission and Flow Control`, and `FCS`, response wilt result `BT_L2CAP_CONF_UNACCEPT`.

For opt `extended flow specification` and `extended windows size`, response wilt result `BT_L2CAP_CONF_REJECT`.
