### PR TITLE
Bluetooth: SSP: clear pairing flag if ssp pairing completed

### DIFF
--- a/subsys/bluetooth/host/classic/ssp.c
+++ b/subsys/bluetooth/host/classic/ssp.c
@@ -213,6 +213,13 @@ static int ssp_confirm_neg_reply(struct bt_conn *conn)
 
 static void ssp_pairing_complete(struct bt_conn *conn, uint8_t status)
 {
+	/* When the ssp pairing complete event notified,
+	 * clear the pairing flag.
+	 */
+	atomic_clear_bit(conn->flags, BT_CONN_BR_PAIRING);
+
+	LOG_DBG("Pairing completed status %d", status);
+
 	if (!status) {
 		bool bond = !atomic_test_bit(conn->flags, BT_CONN_BR_NOBOND);
 		struct bt_conn_auth_info_cb *listener, *next;

--- a/subsys/bluetooth/host/classic/ssp.c
+++ b/subsys/bluetooth/host/classic/ssp.c
@@ -217,6 +217,7 @@ static void ssp_pairing_complete(struct bt_conn *conn, uint8_t status)
 	 * clear the pairing flag.
 	 */
 	atomic_clear_bit(conn->flags, BT_CONN_BR_PAIRING);
+	atomic_set_bit_to(conn->flags, BT_CONN_BR_PAIRED, !status);
 
 	LOG_DBG("Pairing completed status %d", status);
 

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2579,6 +2579,7 @@ static void reset_pairing(struct bt_conn *conn)
 #if defined(CONFIG_BT_CLASSIC)
 	if (conn->type == BT_CONN_TYPE_BR) {
 		atomic_clear_bit(conn->flags, BT_CONN_BR_PAIRING);
+		atomic_clear_bit(conn->flags, BT_CONN_BR_PAIRED);
 		atomic_clear_bit(conn->flags, BT_CONN_BR_PAIRING_INITIATOR);
 		atomic_clear_bit(conn->flags, BT_CONN_BR_LEGACY_SECURE);
 	}

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -59,6 +59,7 @@ enum {
 	BT_CONN_BR_LEGACY_SECURE,             /* 16 digits legacy PIN tracker */
 	BT_CONN_USER,                         /* user I/O when pairing */
 	BT_CONN_BR_PAIRING,                   /* BR connection in pairing context */
+	BT_CONN_BR_PAIRED,                    /* BR connection pairing is done */
 	BT_CONN_BR_NOBOND,                    /* SSP no bond pairing tracker */
 	BT_CONN_BR_PAIRING_INITIATOR,         /* local host starts authentication */
 	BT_CONN_CLEANUP,                      /* Disconnected, pending cleanup */

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2176,7 +2176,7 @@ static void hci_encrypt_change(struct net_buf *buf)
 			 * Start SMP over BR/EDR if we are pairing and are
 			 * central on the link
 			 */
-			if (atomic_test_bit(conn->flags, BT_CONN_BR_PAIRING) &&
+			if (atomic_test_bit(conn->flags, BT_CONN_BR_PAIRED) &&
 			    conn->role == BT_CONN_ROLE_CENTRAL) {
 				bt_smp_br_send_pairing_req(conn);
 			}


### PR DESCRIPTION
* Bluetooth: SSP: clear pairing flag if ssp pairing completed

When the ssp pairing event is notified, clear the pairing flag.

It is used to support case that the authentication is started by peer, the link will not be encrypted after the pairing is completed without any err.
If the local device want to encrypt the link, it could call `bt_conn_set_security` to start encrypt the link after the pairing complete callback triggered.

In original implementation, the `bt_conn_set_security` cannot be called if the authentication has been started.

* Bluetooth: BR_SMP: Add a flag BT_CONN_BR_PAIRED

Due to the BT_CONN_BR_PAIRING is cleared when receiving ssp pairing complete event. The LTK key cannot be derived after the BR connection encrypted.

Add a flag BT_CONN_BR_PAIRED that the pairing has been done.

Use this flag to indicate whether the LTK derivation needs to be applied if the BR ACL connection is encrypted.

