### PR TITLE
Bluetooth: BR: SMP: Check if remote supports CID 0x0007

### DIFF
--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -85,6 +85,13 @@ struct bt_l2cap_br {
 	/* The channel this context is associated with */
 	struct bt_l2cap_br_chan	chan;
 	uint8_t			info_ident;
+	/*
+	 * 2.1 CHANNEL IDENTIFIERS in
+	 * BLUETOOTH CORE SPECIFICATION Version 5.4 | Vol 3, Part A.
+	 * The range of fixed L2CAP CID is 0x0001 ~ 0x0007 both for LE and BR.
+	 * So use one octet buffer to keep the `Fixed channels supported`
+	 * of peer device.
+	 */
 	uint8_t			info_fixed_chan;
 	uint32_t			info_feat_mask;
 };
@@ -541,6 +548,14 @@ static int l2cap_br_info_rsp(struct bt_l2cap_br *l2cap, uint8_t ident,
 			err = -EINVAL;
 			break;
 		}
+		/*
+		 * 2.1 CHANNEL IDENTIFIERS in
+		 * BLUETOOTH CORE SPECIFICATION Version 5.4 | Vol 3, Part A.
+		 * The info length of `Fixed channels supported` is 8 octets.
+		 * Then the range of fixed L2CAP CID is 0x0001 ~ 0x0007 both for LE and BR.
+		 * So use one octet buffer to keep the `Fixed channels supported`
+		 * of peer device.
+		 */
 		l2cap->info_fixed_chan = net_buf_pull_u8(buf);
 		LOG_DBG("remote fixed channel mask 0x%02x", l2cap->info_fixed_chan);
 

--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -119,6 +119,21 @@ struct bt_l2cap_chan *bt_l2cap_br_lookup_tx_cid(struct bt_conn *conn,
 	return NULL;
 }
 
+uint8_t bt_l2cap_br_get_remote_fixed_chan(struct bt_conn *conn)
+{
+	struct bt_l2cap_chan *chan_sig;
+	struct bt_l2cap_br *br_chan_sig;
+
+	chan_sig = bt_l2cap_br_lookup_rx_cid(conn, BT_L2CAP_CID_BR_SIG);
+	if (!chan_sig) {
+		return (uint8_t)0U;
+	}
+
+	br_chan_sig = CONTAINER_OF(chan_sig, struct bt_l2cap_br, chan.chan);
+
+	return br_chan_sig->info_fixed_chan;
+}
+
 static struct bt_l2cap_br_chan*
 l2cap_br_chan_alloc_cid(struct bt_conn *conn, struct bt_l2cap_chan *chan)
 {

--- a/subsys/bluetooth/host/classic/l2cap_br_interface.h
+++ b/subsys/bluetooth/host/classic/l2cap_br_interface.h
@@ -67,3 +67,6 @@ struct net_buf *l2cap_br_data_pull(struct bt_conn *conn,
 /* Find L2CAP BR channel by using specific cid on specific connection */
 struct bt_l2cap_chan *bt_l2cap_br_lookup_tx_cid(struct bt_conn *conn,
 						uint16_t cid);
+
+/* Get remote supported fixed channels */
+uint8_t bt_l2cap_br_get_remote_fixed_chan(struct bt_conn *conn);

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -1587,6 +1587,12 @@ int bt_smp_br_send_pairing_req(struct bt_conn *conn)
 	struct net_buf *req_buf;
 	uint8_t max_key_size;
 	struct bt_smp_br *smp;
+	uint8_t remote_fixed_chan;
+
+	remote_fixed_chan = bt_l2cap_br_get_remote_fixed_chan(conn);
+	if (!(remote_fixed_chan & BIT(BT_L2CAP_CID_BR_SMP))) {
+		return -ENOTSUP;
+	}
 
 	smp = smp_br_chan_get(conn);
 	if (!smp) {


### PR DESCRIPTION
Add a function bt_l2cap_br_get_remote_fixed_chan to get the remote fixed channels.

If the fixed channel CID 0x0007 is unsupported, skip the LTK derivation.