### PR TITLE
dts: nordic: Add Channel Sounding support to nrf-radio

### DIFF
--- a/boards/native/nrf_bsim/nrf54l15bsim_nrf54l15_cpuapp.dts
+++ b/boards/native/nrf_bsim/nrf54l15bsim_nrf54l15_cpuapp.dts
@@ -97,8 +97,9 @@
 
 &radio {
 	status = "okay";
-	/* This feature is not yet supported by the RADIO model */
+	/* These features are not yet supported by the RADIO model */
 	/delete-property/ dfe-supported;
+	/delete-property/ cs-supported;
 };
 
 &clock {

--- a/dts/bindings/net/wireless/nordic,nrf-radio.yaml
+++ b/dts/bindings/net/wireless/nordic,nrf-radio.yaml
@@ -227,3 +227,10 @@ properties:
     description: |
       If set, indicates that the radio hardware supports high TX power
       settings.
+
+  cs-supported:
+    type: boolean
+    description: |
+      If set, the radio hardware supports the BLE Channel Sounding feature.
+      This property should be treated as read-only and should not be overridden;
+      the correct value is provided for your target's SoC already.

--- a/dts/common/nordic/nrf54h20.dtsi
+++ b/dts/common/nordic/nrf54h20.dtsi
@@ -399,6 +399,7 @@
 				status = "disabled";
 				ble-2mbps-supported;
 				ble-coded-phy-supported;
+				cs-supported;
 				dfe-supported;
 				ieee802154-supported;
 				interrupts = <44 NRF_DEFAULT_IRQ_PRIORITY>;

--- a/dts/common/nordic/nrf54l15.dtsi
+++ b/dts/common/nordic/nrf54l15.dtsi
@@ -212,6 +212,7 @@
 				ieee802154-supported;
 				ble-2mbps-supported;
 				ble-coded-phy-supported;
+				cs-supported;
 
 				ieee802154: ieee802154 {
 					compatible = "nordic,nrf-ieee802154";

--- a/soc/nordic/common/Kconfig.peripherals
+++ b/soc/nordic/common/Kconfig.peripherals
@@ -198,6 +198,9 @@ config HAS_HW_NRF_RADIO_BLE_2M
 config HAS_HW_NRF_RADIO_BLE_CODED
 	def_bool $(dt_nodelabel_bool_prop,radio,ble-coded-phy-supported)
 
+config HAS_HW_NRF_RADIO_CS
+	def_bool $(dt_nodelabel_bool_prop,radio,cs-supported)
+
 config HAS_HW_NRF_RADIO_DFE
 	def_bool $(dt_nodelabel_bool_prop,radio,dfe-supported)
 


### PR DESCRIPTION
- Added `cs-supported` property to nrf-radio devicetree
- Added `HAS_HW_NRF_RADIO_CS` Kconfig option which is set if `cs-supported` property is enabled
- Enabled `cs-supported` property for nrf54-series devices