### PR TITLE
doxygen: fix various build warnings

### DIFF
--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -4490,6 +4490,7 @@
  * @brief Check if any device node with status `okay` has a given
  *        property.
  *
+ * @param compat lowercase-and-underscores devicetree compatible
  * @param prop lowercase-and-underscores property name
  *
  * Example devicetree overlay:

--- a/include/zephyr/drivers/firmware/scmi/util.h
+++ b/include/zephyr/drivers/firmware/scmi/util.h
@@ -221,7 +221,13 @@
  * of a `DT_DRV_COMPAT` compatible instead of a node identifier
  *
  * @param inst instance number
- * @param ... other parameters as expected by DT_SCMI_PROTOCOL_DEFINE()
+ * @param init_fn pointer to protocol's initialization function
+ * @param api pointer to protocol's subsystem API
+ * @param pm pointer to the protocol's power management resources
+ * @param data pointer to protocol's private data
+ * @param config pointer to protocol's private constant data
+ * @param level protocol initialization level
+ * @param prio protocol's priority within its initialization level
  */
 #define DT_INST_SCMI_PROTOCOL_DEFINE(inst, init_fn, pm, data, config,		\
 				     level, prio, api)				\

--- a/include/zephyr/llext/llext.h
+++ b/include/zephyr/llext/llext.h
@@ -293,7 +293,7 @@ int llext_call_fn(struct llext *ext, const char *sym_name);
  * @param[in] domain Memory domain to add partitions to
  *
  * @returns 0 on success, or a negative error code.
- * @retval -ENOSYS @kconfig{CONFIG_USERSPACE} is not enabled or supported
+ * @retval -ENOSYS Option @kconfig{CONFIG_USERSPACE} is not enabled or supported
  */
 int llext_add_domain(struct llext *ext, struct k_mem_domain *domain);
 


### PR DESCRIPTION
Fix the following doc build warning on main:
```
WARNING: /home/jordan/code/zephyr/zephyr/include/zephyr/drivers/firmware/scmi/util.h:227: The following parameters of DT_INST_SCMI_PROTOCOL_DEFINE(inst, init_fn, pm, data, config, level, prio, api) are not documented:
WARNING: /home/jordan/code/zephyr/zephyr/include/zephyr/devicetree.h:4532: The following parameter of DT_ANY_COMPAT_HAS_PROP_STATUS_OKAY(compat, prop) is not documented:
WARNING: /home/jordan/code/zephyr/zephyr/include/zephyr/llext/llext.h:296: unexpected token in comment block while parsing the argument of command retval
```

Another instance of #72605