### PR TITLE
doc: get output folder from environment

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -151,7 +151,7 @@ set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${GEN_DEVICETREE_
 
 add_doc_target(
   html
-  COMMAND ${CMAKE_COMMAND} -E env ${SPHINX_ENV}
+  COMMAND ${CMAKE_COMMAND} -E env ${SPHINX_ENV} OUTPUT_DIR=${DOCS_HTML_DIR}
   ${SPHINXBUILD}
     -b html
     -c ${DOCS_CFG_DIR}
@@ -208,7 +208,7 @@ add_dependencies(html-live devicetree)
 
 add_doc_target(
   latex
-  COMMAND ${CMAKE_COMMAND} -E env ${SPHINX_ENV}
+  COMMAND ${CMAKE_COMMAND} -E env ${SPHINX_ENV} OUTPUT_DIR=${DOCS_LATEX_DIR}
   ${SPHINXBUILD}
     -b latex
     -c ${DOCS_CFG_DIR}
@@ -260,7 +260,7 @@ endif()
 
 add_doc_target(
   linkcheck
-  COMMAND ${CMAKE_COMMAND} -E env ${SPHINX_ENV}
+  COMMAND ${CMAKE_COMMAND} -E env ${SPHINX_ENV} OUTPUT_DIR=${DOCS_LINKCHECK_DIR}
   ${SPHINXBUILD}
     -b linkcheck
     -c ${DOCS_CFG_DIR}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -8,7 +8,7 @@ import re
 import textwrap
 
 ZEPHYR_BASE = Path(__file__).resolve().parents[1]
-ZEPHYR_BUILD = Path(os.environ.get("DOCS_HTML_DIR")).resolve()
+ZEPHYR_BUILD = Path(os.environ.get("OUTPUT_DIR")).resolve()
 
 # Add the '_extensions' directory to sys.path, to enable finding Sphinx
 # extensions within.


### PR DESCRIPTION
Pull the output build folder from the environment, instead of hardcoding the HTML output folder, which is wrong for the latex build.

Alternate solution to #78165