### PR TITLE
doc: extensions: link-roles: missing module not critical

### DIFF
--- a/doc/_extensions/zephyr/link-roles.py
+++ b/doc/_extensions/zephyr/link-roles.py
@@ -9,6 +9,7 @@ from __future__ import unicode_literals
 import re
 import subprocess
 from docutils import nodes
+from sphinx.util import logging
 
 try:
     import west.manifest
@@ -19,6 +20,9 @@ try:
         west_manifest = None
 except ImportError:
     west_manifest = None
+
+
+logger = logging.getLogger(__name__)
 
 
 def get_github_rev():
@@ -88,9 +92,7 @@ def modulelink(default_module=None, format="blob"):
             )
         # Invalid module provided
         elif module != config.link_roles_manifest_project:
-            raise ModuleNotFoundError(
-                f"Module {module} not found in the west manifest\n\t{trace}"
-            )
+            logger.debug(f"Module {module} not found in the west manifest")
         # Baseurl for manifest project not set
         elif baseurl is None:
             raise ValueError(


### PR DESCRIPTION
External projects building the documentation may not clone all modules, as they have manifest filtering. Therefore, not having access to a module should not produce a fatal documentation build error. Convert the error to a debug log, so it is at least traced.