### PR TITLE
Bluetooth: CSIP: Add bonding requirement for set lock/release

### DIFF
--- a/doc/releases/migration-guide-4.0.rst
+++ b/doc/releases/migration-guide-4.0.rst
@@ -278,6 +278,11 @@ Bluetooth Audio
   :c:func:`bt_bap_unicast_server_unregister` has been called.
   (:github:`76632`)
 
+* The Coordinated Set Coordinator functions :c:func:`bt_csip_set_coordinator_lock` and
+  :c:func:`bt_csip_set_coordinator_release` now require that :kconfig:option:`CONFIG_BT_BONDABLE`
+  is enabled and that all members are bonded, to comply with the requirements from the CSIP spec.
+  (:github:`78877`)
+
 Bluetooth Classic
 =================
 

--- a/include/zephyr/bluetooth/audio/csip.h
+++ b/include/zephyr/bluetooth/audio/csip.h
@@ -494,6 +494,8 @@ int bt_csip_set_coordinator_ordered_access(
  *
  * The members will be locked starting from lowest rank going up.
  *
+ * @kconfig_dep{CONFIG_BT_CSIP_SET_COORDINATOR,CONFIG_BT_BONDABLE}
+ *
  * TODO: If locking fails, the already locked members will not be unlocked.
  *
  * @param members   Array of set members to lock.
@@ -511,6 +513,8 @@ int bt_csip_set_coordinator_lock(const struct bt_csip_set_coordinator_set_member
  * @brief Release an array of set members
  *
  * The members will be released starting from highest rank going down.
+ *
+ * @kconfig_dep{CONFIG_BT_CSIP_SET_COORDINATOR,CONFIG_BT_BONDABLE}
  *
  * @param members   Array of set members to lock.
  * @param count     Number of set members in @p members.

--- a/subsys/bluetooth/audio/shell/csip_set_coordinator.c
+++ b/subsys/bluetooth/audio/shell/csip_set_coordinator.c
@@ -379,6 +379,7 @@ static int cmd_csip_set_coordinator_discover_members(const struct shell *sh,
 	return err;
 }
 
+#if defined(CONFIG_BT_BONDABLE)
 static int cmd_csip_set_coordinator_lock_set(const struct shell *sh,
 					     size_t argc, char *argv[])
 {
@@ -424,45 +425,6 @@ static int cmd_csip_set_coordinator_release_set(const struct shell *sh,
 
 	err = bt_csip_set_coordinator_release(locked_members, conn_count,
 					      &cur_inst->info);
-	if (err != 0) {
-		shell_error(sh, "Fail: %d", err);
-	}
-
-	return err;
-}
-
-static int cmd_csip_set_coordinator_ordered_access(const struct shell *sh,
-						   size_t argc, char *argv[])
-{
-	int err;
-	unsigned long member_count = (unsigned long)ARRAY_SIZE(set_members);
-	const struct bt_csip_set_coordinator_set_member *members[ARRAY_SIZE(set_members)];
-
-	if (argc > 1) {
-		member_count = shell_strtoul(argv[1], 0, &err);
-		if (err != 0) {
-			shell_error(sh, "Could not parse member_count: %d",
-				    err);
-
-			return -ENOEXEC;
-		}
-
-		if (member_count > ARRAY_SIZE(members)) {
-			shell_error(sh, "Invalid member_count: %lu",
-				    member_count);
-
-			return -ENOEXEC;
-		}
-	}
-
-	for (size_t i = 0; i < (size_t)member_count; i++) {
-		members[i] = set_members[i];
-	}
-
-	err = bt_csip_set_coordinator_ordered_access(members,
-						     ARRAY_SIZE(members),
-						     &cur_inst->info,
-						     csip_set_coordinator_oap_cb);
 	if (err != 0) {
 		shell_error(sh, "Fail: %d", err);
 	}
@@ -547,6 +509,46 @@ static int cmd_csip_set_coordinator_release(const struct shell *sh, size_t argc,
 
 	return err;
 }
+#endif /* CONFIG_BT_BONDABLE */
+
+static int cmd_csip_set_coordinator_ordered_access(const struct shell *sh,
+						   size_t argc, char *argv[])
+{
+	int err;
+	unsigned long member_count = (unsigned long)ARRAY_SIZE(set_members);
+	const struct bt_csip_set_coordinator_set_member *members[ARRAY_SIZE(set_members)];
+
+	if (argc > 1) {
+		member_count = shell_strtoul(argv[1], 0, &err);
+		if (err != 0) {
+			shell_error(sh, "Could not parse member_count: %d",
+				    err);
+
+			return -ENOEXEC;
+		}
+
+		if (member_count > ARRAY_SIZE(members)) {
+			shell_error(sh, "Invalid member_count: %lu",
+				    member_count);
+
+			return -ENOEXEC;
+		}
+	}
+
+	for (size_t i = 0; i < (size_t)member_count; i++) {
+		members[i] = set_members[i];
+	}
+
+	err = bt_csip_set_coordinator_ordered_access(members,
+						     ARRAY_SIZE(members),
+						     &cur_inst->info,
+						     csip_set_coordinator_oap_cb);
+	if (err != 0) {
+		shell_error(sh, "Fail: %d", err);
+	}
+
+	return err;
+}
 
 static int cmd_csip_set_coordinator(const struct shell *sh, size_t argc,
 				    char **argv)
@@ -568,6 +570,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(csip_set_coordinator_cmds,
 	SHELL_CMD_ARG(discover_members, NULL,
 		      "Scan for set members <set_pointer>",
 		      cmd_csip_set_coordinator_discover_members, 2, 0),
+#if defined(CONFIG_BT_BONDABLE)
 	SHELL_CMD_ARG(lock_set, NULL,
 		      "Lock set",
 		      cmd_csip_set_coordinator_lock_set, 1, 0),
@@ -580,6 +583,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(csip_set_coordinator_cmds,
 	SHELL_CMD_ARG(release, NULL,
 		      "Release specific member [member_index]",
 		      cmd_csip_set_coordinator_release, 1, 1),
+#endif /* CONFIG_BT_BONDABLE */
 	SHELL_CMD_ARG(ordered_access, NULL,
 		      "Perform dummy ordered access procedure [member_count]",
 		      cmd_csip_set_coordinator_ordered_access, 1, 1),


### PR DESCRIPTION
The CSIP spec states that the procedures shall only be done on bonded devices, so a check for that was added.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/78554