### PR TITLE
DNS statistics

### DIFF
--- a/include/zephyr/net/net_stats.h
+++ b/include/zephyr/net/net_stats.h
@@ -227,6 +227,20 @@ struct net_stats_ipv4_igmp {
 };
 
 /**
+ * @brief DNS statistics
+ */
+struct net_stats_dns {
+	/** Number of received DNS queries */
+	net_stats_t recv;
+
+	/** Number of sent DNS responses */
+	net_stats_t sent;
+
+	/** Number of dropped DNS packets */
+	net_stats_t drop;
+};
+
+/**
  * @brief Network packet transfer times for calculating average TX time
  */
 struct net_stats_tx_time {
@@ -373,6 +387,11 @@ struct net_stats {
 #if defined(CONFIG_NET_STATISTICS_IGMP)
 	/** IPv4 IGMP statistics */
 	struct net_stats_ipv4_igmp ipv4_igmp;
+#endif
+
+#if defined(CONFIG_NET_STATISTICS_DNS)
+	/** DNS statistics */
+	struct net_stats_dns dns;
 #endif
 
 #if NET_TC_COUNT > 1

--- a/subsys/net/ip/Kconfig.stats
+++ b/subsys/net/ip/Kconfig.stats
@@ -93,6 +93,13 @@ config NET_STATISTICS_IGMP
 	help
 	  Keep track of IGMP related statistics
 
+config NET_STATISTICS_DNS
+	bool "Domain Name Service (DNS) statistics"
+	depends on DNS_RESOLVER || MDNS_RESPONDER || LLMNR_RESPONDER
+	default y
+	help
+	  Keep track of DNS related statistics
+
 config NET_STATISTICS_PPP
 	bool "Point-to-point (PPP) statistics"
 	depends on NET_L2_PPP

--- a/subsys/net/ip/net_stats.h
+++ b/subsys/net/ip/net_stats.h
@@ -345,6 +345,27 @@ static inline void net_stats_update_ipv4_igmp_drop(struct net_if *iface)
 #define net_stats_update_ipv4_igmp_drop(iface)
 #endif /* CONFIG_NET_STATISTICS_IGMP */
 
+#if defined(CONFIG_NET_STATISTICS_DNS)
+static inline void net_stats_update_dns_recv(struct net_if *iface)
+{
+	UPDATE_STAT(iface, stats.dns.recv++);
+}
+
+static inline void net_stats_update_dns_sent(struct net_if *iface)
+{
+	UPDATE_STAT(iface, stats.dns.sent++);
+}
+
+static inline void net_stats_update_dns_drop(struct net_if *iface)
+{
+	UPDATE_STAT(iface, stats.dns.drop++);
+}
+#else
+#define net_stats_update_dns_recv(iface)
+#define net_stats_update_dns_sent(iface)
+#define net_stats_update_dns_drop(iface)
+#endif /* CONFIG_NET_STATISTICS_DNS */
+
 #if defined(CONFIG_NET_PKT_TXTIME_STATS) && defined(CONFIG_NET_STATISTICS)
 static inline void net_stats_update_tx_time(struct net_if *iface,
 					    uint32_t start_time,

--- a/subsys/net/lib/dns/dns_pack.c
+++ b/subsys/net/lib/dns/dns_pack.c
@@ -449,7 +449,8 @@ int mdns_unpack_query_header(struct dns_msg_t *msg, uint16_t *src_id)
 
 	qdcount = dns_unpack_header_qdcount(dns_header);
 	if (qdcount < 1) {
-		return -EINVAL;
+		/* Discard the message if query count is 0. RFC 6804 ch. 2 */
+		return -ENOENT;
 	}
 
 	if (src_id) {

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -533,7 +533,6 @@ static int dns_read(int sock,
 
 	ret = mdns_unpack_query_header(&dns_msg, NULL);
 	if (ret < 0) {
-		ret = -EINVAL;
 		goto quit;
 	}
 
@@ -670,7 +669,7 @@ static int dispatcher_cb(void *my_ctx, int sock,
 	ARG_UNUSED(my_ctx);
 
 	ret = dns_read(sock, dns_data, len, addr, addrlen);
-	if (ret < 0 && ret != -EINVAL) {
+	if (ret < 0 && ret != -EINVAL && ret != -ENOENT) {
 		NET_DBG("%s read failed (%d)", "mDNS", ret);
 	}
 

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -32,6 +32,7 @@ LOG_MODULE_REGISTER(net_mdns_responder, CONFIG_MDNS_RESPONDER_LOG_LEVEL);
 #include "dns_sd.h"
 #include "dns_pack.h"
 #include "ipv6.h"
+#include "../../ip/net_stats.h"
 
 #include "net_private.h"
 
@@ -336,6 +337,8 @@ static int send_response(int sock,
 			   (struct sockaddr *)&dst, dst_len);
 	if (ret < 0) {
 		NET_DBG("Cannot send %s reply (%d)", "mDNS", ret);
+	} else {
+		net_stats_update_dns_sent(iface);
 	}
 
 	return ret;
@@ -496,6 +499,8 @@ static void send_sd_response(int sock,
 			if (ret < 0) {
 				NET_DBG("Cannot send %s reply (%d)", "mDNS", ret);
 				continue;
+			} else {
+				net_stats_update_dns_sent(iface);
 			}
 		}
 	}

--- a/subsys/net/lib/shell/stats.c
+++ b/subsys/net/lib/shell/stats.c
@@ -537,6 +537,12 @@ static void net_shell_print_statistics(struct net_if *iface, void *user_data)
 	   GET_STAT(iface, tcp.connrst));
 	PR("TCP pkt drop   %d\n", GET_STAT(iface, tcp.drop));
 #endif
+#if defined(CONFIG_NET_STATISTICS_DNS)
+	PR("DNS recv       %d\tsent\t%d\tdrop\t%d\n",
+	   GET_STAT(iface, dns.recv),
+	   GET_STAT(iface, dns.sent),
+	   GET_STAT(iface, dns.drop));
+#endif /* CONFIG_NET_STATISTICS_DNS */
 
 	PR("Bytes received %u\n", GET_STAT(iface, bytes.received));
 	PR("Bytes sent     %u\n", GET_STAT(iface, bytes.sent));


### PR DESCRIPTION
* If DNS query count is 0, then we drop the packet already. Unfortunately we print an error in this case instead of silently discarding the message (see https://www.rfc-editor.org/rfc/rfc6804.html chapter 2).
* In order to see that we have dropped a packet, create DNS statistics to collect the information of sent/received or dropped DNS messages.

