### PR TITLE
tests: mcuboot: Add other nxp boards as test targets

### DIFF
--- a/tests/boot/test_mcuboot/testcase.yaml
+++ b/tests/boot/test_mcuboot/testcase.yaml
@@ -16,6 +16,12 @@ tests:
       - frdm_k22f
       - frdm_k64f
       - frdm_k82f
+      - frdm_ke17z
+      - frdm_ke17z512
+      - rddrone_fmuk66
+      - twr_ke18f
+      - twr_kv58f220m
+      - frdm_mcxn947/mcxn947/cpu0
       - lpcxpresso55s06
       - lpcxpresso55s16
       - lpcxpresso55s28
@@ -28,9 +34,11 @@ tests:
       - mimxrt1040_evk
       - mimxrt1050_evk
       - mimxrt1060_evk
+      - mimxrt1062_fmurt6
       - mimxrt1064_evk
       - mimxrt1160_evk/mimxrt1166/cm7
       - mimxrt1170_evk/mimxrt1176/cm7
+      - vmu_rt1170/mimxrt1176/cm7
       - mimxrt595_evk/mimxrt595s/cm33
       - mimxrt685_evk/mimxrt685s/cm33
       - nrf52840dk/nrf52840


### PR DESCRIPTION
Added other nxp boards as test targets: frdm_ke17z, frdm_ke17z, frdm_ke17z512, rddrone_fmuk66, twr_ke18f, twr_kv58f220m, frdm_mcxn947/mcxn947/cpu0, mimxrt1062_fmurt6, vmu_rt1170.