### PR TITLE
drivers: serial: nrfx_uarte: Remove CONFIG_UART_n_GPIO_MANAGEMENT

### DIFF
--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -236,6 +236,8 @@ Drivers and Sensors
 * Serial
 
   * LiteX: Renamed the ``compatible`` from ``litex,uart0`` to :dtcompatible:`litex,uart`.
+  * Nordic: Removed ``CONFIG_UART_n_GPIO_MANAGEMENT`` Kconfig options (where n is an instance
+    index) which had no use after pinctrl driver was introduced.
 
 * SPI
 

--- a/drivers/serial/Kconfig.nrfx_uart_instance
+++ b/drivers/serial/Kconfig.nrfx_uart_instance
@@ -119,12 +119,3 @@ config UART_$(nrfx_uart_num)_A2I_RX_BUF_COUNT
 	default 0
 	help
 	  Number of chunks into RX space is divided.
-
-config UART_$(nrfx_uart_num)_GPIO_MANAGEMENT
-	bool "GPIO management on port $(nrfx_uart_num)"
-	depends on PM_DEVICE
-	default y
-	help
-	  If enabled, the driver will configure the GPIOs used by the uart to
-	  their default configuration when device is powered down. The GPIOs
-	  will be configured back to correct state when UART is powered up.

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -1086,12 +1086,9 @@ static int uart_nrfx_pm_action(const struct device *dev,
 
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
-		if (IS_ENABLED(CONFIG_UART_0_GPIO_MANAGEMENT)) {
-			ret = pinctrl_apply_state(config->pcfg,
-						  PINCTRL_STATE_DEFAULT);
-			if (ret < 0) {
-				return ret;
-			}
+		ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+		if (ret < 0) {
+			return ret;
 		}
 
 		nrf_uart_enable(uart0_addr);
@@ -1102,13 +1099,9 @@ static int uart_nrfx_pm_action(const struct device *dev,
 		break;
 	case PM_DEVICE_ACTION_SUSPEND:
 		nrf_uart_disable(uart0_addr);
-
-		if (IS_ENABLED(CONFIG_UART_0_GPIO_MANAGEMENT)) {
-			ret = pinctrl_apply_state(config->pcfg,
-						  PINCTRL_STATE_SLEEP);
-			if (ret < 0) {
-				return ret;
-			}
+		ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_SLEEP);
+		if (ret < 0) {
+			return ret;
 		}
 		break;
 	default:


### PR DESCRIPTION
This is a leftover from pre-pinctrl era and no longer makes sense. Driver always manages gpio through pinctrl.

Support removed from uart and uarte shims.