### PR TITLE
Enable Display for MAX32662EVKIT

### DIFF
--- a/boards/adi/max32662evkit/Kconfig.defconfig
+++ b/boards/adi/max32662evkit/Kconfig.defconfig
@@ -1,0 +1,29 @@
+# MAX32662EVKIT boards configuration
+
+# Copyright (c) 2024 Analog Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_MAX32662EVKIT
+
+if DISPLAY
+
+config MIPI_DBI_SPI_3WIRE
+	default y
+
+if LVGL
+
+config LV_Z_BITS_PER_PIXEL
+	default 16
+
+choice LV_COLOR_DEPTH
+	default LV_COLOR_DEPTH_16  # 16 bit per pixel
+endchoice
+
+config LV_COLOR_16_SWAP
+	default y
+
+endif # LVGL
+
+endif # DISPLAY
+
+endif # BOARD_MAX32662EVKIT

--- a/boards/adi/max32662evkit/max32662evkit.dts
+++ b/boards/adi/max32662evkit/max32662evkit.dts
@@ -11,6 +11,7 @@
 #include <zephyr/dt-bindings/gpio/adi-max32-gpio.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/dma/max32662_dma.h>
+#include <zephyr/dt-bindings/mipi_dbi/mipi_dbi.h>
 
 / {
 	model = "Analog Devices MAX32662EVKIT";
@@ -21,6 +22,7 @@
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram2;
 		zephyr,flash = &flash0;
+		zephyr,display = &st7735;
 	};
 
 	leds {
@@ -46,6 +48,40 @@
 		led0 = &led1;
 		sw0 = &pb1;
 		watchdog0 = &wdt0;
+	};
+
+	mipi_dbi {
+		compatible = "zephyr,mipi-dbi-spi";
+		spi-dev = <&spi1>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		status = "okay";
+
+		st7735: st7735@0 {
+			compatible = "sitronix,st7735r";
+			mipi-max-frequency = <DT_FREQ_M(6)>;
+			mipi-mode = <MIPI_DBI_MODE_SPI_3WIRE>;
+
+			reg = <0>;
+			width = <130>;
+			height = <132>;
+			x-offset = <0>;
+			y-offset = <0>;
+			madctl = <0xc0>;
+			colmod = <0x05>;
+			vmctr1 = <0x51>;
+			pwctr1 = [02 02];
+			pwctr2 = [c5];
+			pwctr3 = [0d 00];
+			pwctr4 = [8d 1a];
+			pwctr5 = [8d ee];
+			frmctr1 = [02 35 36];
+			frmctr2 = [02 35 36];
+			frmctr3 = [02 35 36 02 35 36];
+			gamctrp1 = [0a 1c 0c 14 33 2b 24 28 27 25 2c 39 00 05 03 0d];
+			gamctrn1 = [0a 1c 0c 14 33 2b 24 28 27 25 2d 3a 00 05 03 0d];
+		};
 	};
 };
 
@@ -88,4 +124,19 @@
 	status = "okay";
 	pinctrl-0 = <&spi0a_copi_p0_3 &spi0a_cito_p0_2 &spi0a_sck_p0_4 &spi0a_ts0_p0_5>;
 	pinctrl-names = "default";
+};
+
+&spi1a_mosi_p0_8 {
+	power-source=<MAX32_VSEL_VDDIOH>;
+};
+
+&spi1a_sck_p0_17 {
+	power-source=<MAX32_VSEL_VDDIOH>;
+};
+
+&spi1 {
+	status = "okay";
+	pinctrl-0 = <&spi1a_mosi_p0_8 &spi1a_sck_p0_17>;
+	pinctrl-names = "default";
+	cs-gpios = <&gpio0 18 (GPIO_ACTIVE_LOW | MAX32_VSEL_VDDIOH)>;
 };

--- a/dts/arm/adi/max32/max32662-pinctrl.dtsi
+++ b/dts/arm/adi/max32/max32662-pinctrl.dtsi
@@ -146,6 +146,38 @@
 				pinmux = <MAX32_PINMUX(0, 6, AF5)>;
 			};
 
+			/omit-if-no-ref/ spi1a_miso_p0_7: spi1a_miso_p0_7 {
+				pinmux = <MAX32_PINMUX(0, 7, AF1)>;
+			};
+
+			/omit-if-no-ref/ uart0b_cts_p0_7: uart0b_cts_p0_7 {
+				pinmux = <MAX32_PINMUX(0, 7, AF2)>;
+			};
+
+			/omit-if-no-ref/ tmr2c_ia_p0_7: tmr2c_ia_p0_7 {
+				pinmux = <MAX32_PINMUX(0, 7, AF3)>;
+			};
+
+			/omit-if-no-ref/ uart0d_rx_p0_7: uart0d_rx_p0_7 {
+				pinmux = <MAX32_PINMUX(0, 7, AF4)>;
+			};
+
+			/omit-if-no-ref/ spi1a_mosi_p0_8: spi1a_mosi_p0_8 {
+				pinmux = <MAX32_PINMUX(0, 8, AF1)>;
+			};
+
+			/omit-if-no-ref/ uart0b_rts_p0_8: uart0b_rts_p0_8 {
+				pinmux = <MAX32_PINMUX(0, 8, AF2)>;
+			};
+
+			/omit-if-no-ref/ tmr2c_oa_p0_8: tmr2c_oa_p0_8 {
+				pinmux = <MAX32_PINMUX(0, 8, AF3)>;
+			};
+
+			/omit-if-no-ref/ uart0d_tx_p0_8: uart0d_tx_p0_8 {
+				pinmux = <MAX32_PINMUX(0, 8, AF4)>;
+			};
+
 			/omit-if-no-ref/ i2c1a_sda_p0_9: i2c1a_sda_p0_9 {
 				pinmux = <MAX32_PINMUX(0, 9, AF1)>;
 			};
@@ -232,6 +264,80 @@
 
 			/omit-if-no-ref/ ain0_p0_13: ain0_p0_13 {
 				pinmux = <MAX32_PINMUX(0, 13, AF4)>;
+			};
+
+
+
+			/omit-if-no-ref/ pt0a_p0_14: pt0a_p0_14 {
+				pinmux = <MAX32_PINMUX(0, 14, AF1)>;
+			};
+
+			/omit-if-no-ref/ pt1a_p0_15: pt1a_p0_15 {
+				pinmux = <MAX32_PINMUX(0, 15, AF1)>;
+			};
+
+			/omit-if-no-ref/ can0b_rx_p0_15: can0b_rx_p0_15 {
+				pinmux = <MAX32_PINMUX(0, 15, AF2)>;
+			};
+
+			/omit-if-no-ref/ tmr2c_ia_p0_15: tmr2c_ia_p0_15 {
+				pinmux = <MAX32_PINMUX(0, 15, AF3)>;
+			};
+
+			/omit-if-no-ref/ tmr0d_ia_p0_15: tmr0d_ia_p0_15 {
+				pinmux = <MAX32_PINMUX(0, 15, AF4)>;
+			};
+
+			/omit-if-no-ref/ pt2a_p0_16: pt2a_p0_16 {
+				pinmux = <MAX32_PINMUX(0, 16, AF1)>;
+			};
+
+			/omit-if-no-ref/ can0b_tx_p0_16: can0b_tx_p0_16 {
+				pinmux = <MAX32_PINMUX(0, 16, AF2)>;
+			};
+
+			/omit-if-no-ref/ tmr2c_oa_p0_16: tmr2c_oa_p0_16 {
+				pinmux = <MAX32_PINMUX(0, 16, AF3)>;
+			};
+
+			/omit-if-no-ref/ tmr0d_oa_p0_16: tmr0d_oa_p0_16 {
+				pinmux = <MAX32_PINMUX(0, 16, AF4)>;
+			};
+
+			/omit-if-no-ref/ spi1a_sck_p0_17: spi1a_sck_p0_17 {
+				pinmux = <MAX32_PINMUX(0, 17, AF1)>;
+			};
+
+			/omit-if-no-ref/ adc_trig_c_p0_17: adc_trig_c_p0_17 {
+				pinmux = <MAX32_PINMUX(0, 17, AF3)>;
+			};
+
+			/omit-if-no-ref/ uart0d_cts_p0_17: uart0d_cts_p0_17 {
+				pinmux = <MAX32_PINMUX(0, 17, AF4)>;
+			};
+
+			/omit-if-no-ref/ spi1a_ss0_p0_18: spi1a_ss0_p0_18 {
+				pinmux = <MAX32_PINMUX(0, 18, AF1)>;
+			};
+
+			/omit-if-no-ref/ uart0d_rts_p0_17: uart0d_rts_p0_17 {
+				pinmux = <MAX32_PINMUX(0, 18, AF4)>;
+			};
+
+			/omit-if-no-ref/ uart0a_rts_p0_19: uart0a_rts_p0_19 {
+				pinmux = <MAX32_PINMUX(0, 19, AF1)>;
+			};
+
+			/omit-if-no-ref/ tmrt1c_ia_p0_19: tmrt1c_ia_p0_19 {
+				pinmux = <MAX32_PINMUX(0, 19, AF3)>;
+			};
+
+			/omit-if-no-ref/ uart0a_cts_p0_20: uart0a_cts_p0_20 {
+				pinmux = <MAX32_PINMUX(0, 20, AF1)>;
+			};
+
+			/omit-if-no-ref/ tmrt1c_oa_p0_20: tmrt1c_oa_p0_20 {
+				pinmux = <MAX32_PINMUX(0, 20, AF3)>;
 			};
 		};
 	};

--- a/samples/subsys/display/lvgl/boards/max32662evkit.overlay
+++ b/samples/subsys/display/lvgl/boards/max32662evkit.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2024, Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,sram = &sram0;
+	};
+};
+
+/*
+ * Concatenate SRAM0(16KB), SRAM1(16KB) and SRAM2(16KB)
+ * to lvgl example work
+ */
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(48)>;
+};


### PR DESCRIPTION
This PR enables display & LVGL stack for [MAX32662EVKIT](https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/max32662evkit.html).  Content similar with https://github.com/zephyrproject-rtos/zephyr/pull/76648

Tested with [samples/subsys/display/lvgl](https://github.com/zephyrproject-rtos/zephyr/tree/main/samples/subsys/display/lvgl)

MAX32662EVKIT test output
![image](https://github.com/user-attachments/assets/dbb62edd-696b-4ae8-a7ee-10e87555e64d)

P.S: Missing pins added that requires to driver display too.
[MAX32662 Pins](https://www.analog.com/media/en/technical-documentation/data-sheets/max32662.pdf)