### PR TITLE
manifest: Update NXP HAL to fix MCX flash driver

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -198,7 +198,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: f4e26fad2cfd8b8e8988e835a28667573ed072cf
+      revision: adfa0bbba6f5d36352d387527bdc486616c9f521
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Fix the flash driver header for MCXA and MCXN not being included correctly in the hal.

Fixes #78866
Fixes #78798