### PR TITLE
Revert "arch: common: Add user can specify the nocache location"

### DIFF
--- a/arch/common/nocache.ld
+++ b/arch/common/nocache.ld
@@ -7,12 +7,6 @@
 
 /* Copied from linker.ld */
 
-#if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_nocache_ram), okay)
-#define NOCACHE_REGION LINKER_DT_NODE_REGION_NAME_TOKEN(DT_CHOSEN(zephyr_nocache_ram))
-#else
-#define NOCACHE_REGION RAMABLE_REGION
-#endif
-
 /* Non-cached region of RAM */
 SECTION_DATA_PROLOGUE(_NOCACHE_SECTION_NAME,(NOLOAD),)
 {
@@ -33,5 +27,5 @@ SECTION_DATA_PROLOGUE(_NOCACHE_SECTION_NAME,(NOLOAD),)
 	MPU_ALIGN(_nocache_ram_size);
 #endif
 	_nocache_ram_end = .;
-} GROUP_DATA_LINK_IN(NOCACHE_REGION, NOCACHE_REGION)
+} GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
 _nocache_ram_size = _nocache_ram_end - _nocache_ram_start;


### PR DESCRIPTION
This reverts PR https://github.com/zephyrproject-rtos/zephyr/pull/76998

we should not add new chosen node to zephyr, which is yet another zephyr-ism in DT, we already have the ability to generate no-cache linker region using zephyr,memory-region and zephyr,memory-attr