### PR TITLE
net: coap: add no-response option definition and values

### DIFF
--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -64,6 +64,7 @@ enum coap_option_num {
 	COAP_OPTION_PROXY_SCHEME = 39,   /**< Proxy-Scheme */
 	COAP_OPTION_SIZE1 = 60,          /**< Size1 */
 	COAP_OPTION_ECHO = 252,          /**< Echo (RFC 9175) */
+	COAP_OPTION_NO_RESPONSE = 258,   /**< No-Response (RFC 7967) */
 	COAP_OPTION_REQUEST_TAG = 292    /**< Request-Tag (RFC 9175) */
 };
 
@@ -220,6 +221,22 @@ enum coap_content_format {
 	COAP_CONTENT_FORMAT_APP_JSON_PATCH_JSON = 51,   /**< application/json-patch+json */
 	COAP_CONTENT_FORMAT_APP_MERGE_PATCH_JSON = 52,  /**< application/merge-patch+json */
 	COAP_CONTENT_FORMAT_APP_CBOR = 60               /**< application/cbor */
+};
+
+/**
+ * @brief Set of No-Response option values for CoAP.
+ *
+ * To be used when encoding or decoding a No-Response option defined
+ * in RFC 7967.
+ */
+enum coap_no_response {
+	COAP_NO_RESPONSE_SUPPRESS_2_XX = 0x02,
+	COAP_NO_RESPONSE_SUPPRESS_4_XX = 0x08,
+	COAP_NO_RESPONSE_SUPPRESS_5_XX = 0x10,
+
+	COAP_NO_RESPONSE_SUPPRESS_ALL = COAP_NO_RESPONSE_SUPPRESS_2_XX |
+					COAP_NO_RESPONSE_SUPPRESS_4_XX |
+					COAP_NO_RESPONSE_SUPPRESS_5_XX,
 };
 
 /** @cond INTERNAL_HIDDEN */


### PR DESCRIPTION
Constrained application can require to avoid waiting for response from a server. CoAP No-response option defined in RFC 7967 allows to do that by suppressing selected response types.