### PR TITLE
Bluetooth: Controller: Add device tree dependency to selection

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -138,6 +138,7 @@ choice BT_LL_CHOICE
 
 config BT_LL_SW_SPLIT
 	bool "Software-based BLE Link Layer"
+	depends on DT_HAS_ZEPHYR_BT_HCI_LL_SW_SPLIT_ENABLED
 	help
 	  Use Zephyr software BLE Link Layer ULL LLL split implementation.
 

--- a/tests/bluetooth/controller/common/Kconfig
+++ b/tests/bluetooth/controller/common/Kconfig
@@ -1,0 +1,9 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# The link layer requires a corresponding device tree node to be enabled
+# The corresponding Kconfig entry is not generated for unit tests,
+# so we add it here.
+config DT_HAS_ZEPHYR_BT_HCI_LL_SW_SPLIT_ENABLED
+	bool
+	default y

--- a/tests/bluetooth/controller/ctrl_api/Kconfig
+++ b/tests/bluetooth/controller/ctrl_api/Kconfig
@@ -25,5 +25,7 @@ config ENTROPY_NRF_FORCE_ALT
 config ENTROPY_NRF5_RNG
 	default n
 
+source "tests/bluetooth/controller/common/Kconfig"
+
 # Include Zephyr's Kconfig
 source "Kconfig"

--- a/tests/bluetooth/controller/ctrl_chmu/Kconfig
+++ b/tests/bluetooth/controller/ctrl_chmu/Kconfig
@@ -25,5 +25,7 @@ config ENTROPY_NRF_FORCE_ALT
 config ENTROPY_NRF5_RNG
 	default n
 
+source "tests/bluetooth/controller/common/Kconfig"
+
 # Include Zephyr's Kconfig
 source "Kconfig"

--- a/tests/bluetooth/controller/ctrl_cis_create/Kconfig
+++ b/tests/bluetooth/controller/ctrl_cis_create/Kconfig
@@ -25,5 +25,7 @@ config ENTROPY_NRF_FORCE_ALT
 config ENTROPY_NRF5_RNG
 	default n
 
+source "tests/bluetooth/controller/common/Kconfig"
+
 # Include Zephyr's Kconfig
 source "Kconfig"

--- a/tests/bluetooth/controller/ctrl_cis_terminate/Kconfig
+++ b/tests/bluetooth/controller/ctrl_cis_terminate/Kconfig
@@ -25,5 +25,7 @@ config ENTROPY_NRF_FORCE_ALT
 config ENTROPY_NRF5_RNG
 	default n
 
+source "tests/bluetooth/controller/common/Kconfig"
+
 # Include Zephyr's Kconfig
 source "Kconfig"

--- a/tests/bluetooth/controller/ctrl_collision/Kconfig
+++ b/tests/bluetooth/controller/ctrl_collision/Kconfig
@@ -25,5 +25,7 @@ config ENTROPY_NRF_FORCE_ALT
 config ENTROPY_NRF5_RNG
 	default n
 
+source "tests/bluetooth/controller/common/Kconfig"
+
 # Include Zephyr's Kconfig
 source "Kconfig"

--- a/tests/bluetooth/controller/ctrl_conn_update/Kconfig
+++ b/tests/bluetooth/controller/ctrl_conn_update/Kconfig
@@ -25,5 +25,7 @@ config ENTROPY_NRF_FORCE_ALT
 config ENTROPY_NRF5_RNG
 	default n
 
+source "tests/bluetooth/controller/common/Kconfig"
+
 # Include Zephyr's Kconfig
 source "Kconfig"

--- a/tests/bluetooth/controller/ctrl_cte_req/Kconfig
+++ b/tests/bluetooth/controller/ctrl_cte_req/Kconfig
@@ -43,5 +43,7 @@ config ENTROPY_NRF_FORCE_ALT
 config ENTROPY_NRF5_RNG
 	default n
 
+source "tests/bluetooth/controller/common/Kconfig"
+
 # Include Zephyr's Kconfig
 source "Kconfig"

--- a/tests/bluetooth/controller/ctrl_data_length_update/Kconfig
+++ b/tests/bluetooth/controller/ctrl_data_length_update/Kconfig
@@ -25,5 +25,7 @@ config ENTROPY_NRF_FORCE_ALT
 config ENTROPY_NRF5_RNG
 	default n
 
+source "tests/bluetooth/controller/common/Kconfig"
+
 # Include Zephyr's Kconfig
 source "Kconfig"

--- a/tests/bluetooth/controller/ctrl_encrypt/Kconfig
+++ b/tests/bluetooth/controller/ctrl_encrypt/Kconfig
@@ -25,5 +25,7 @@ config ENTROPY_NRF_FORCE_ALT
 config ENTROPY_NRF5_RNG
 	default n
 
+source "tests/bluetooth/controller/common/Kconfig"
+
 # Include Zephyr's Kconfig
 source "Kconfig"

--- a/tests/bluetooth/controller/ctrl_feature_exchange/Kconfig
+++ b/tests/bluetooth/controller/ctrl_feature_exchange/Kconfig
@@ -25,5 +25,7 @@ config ENTROPY_NRF_FORCE_ALT
 config ENTROPY_NRF5_RNG
 	default n
 
+source "tests/bluetooth/controller/common/Kconfig"
+
 # Include Zephyr's Kconfig
 source "Kconfig"

--- a/tests/bluetooth/controller/ctrl_hci/Kconfig
+++ b/tests/bluetooth/controller/ctrl_hci/Kconfig
@@ -25,5 +25,7 @@ config ENTROPY_NRF_FORCE_ALT
 config ENTROPY_NRF5_RNG
 	default n
 
+source "tests/bluetooth/controller/common/Kconfig"
+
 # Include Zephyr's Kconfig
 source "Kconfig"

--- a/tests/bluetooth/controller/ctrl_invalid/Kconfig
+++ b/tests/bluetooth/controller/ctrl_invalid/Kconfig
@@ -25,5 +25,7 @@ config ENTROPY_NRF_FORCE_ALT
 config ENTROPY_NRF5_RNG
 	default n
 
+source "tests/bluetooth/controller/common/Kconfig"
+
 # Include Zephyr's Kconfig
 source "Kconfig"

--- a/tests/bluetooth/controller/ctrl_isoal/Kconfig
+++ b/tests/bluetooth/controller/ctrl_isoal/Kconfig
@@ -57,4 +57,6 @@ config BT_CTLR_ISOAL_SN_STRICT
 	depends on BT_CTLR_ADV_ISO || BT_CTLR_CONN_ISO
 	default y
 
+source "tests/bluetooth/controller/common/Kconfig"
+
 source "Kconfig.zephyr"

--- a/tests/bluetooth/controller/ctrl_le_ping/Kconfig
+++ b/tests/bluetooth/controller/ctrl_le_ping/Kconfig
@@ -25,5 +25,7 @@ config ENTROPY_NRF_FORCE_ALT
 config ENTROPY_NRF5_RNG
 	default n
 
+source "tests/bluetooth/controller/common/Kconfig"
+
 # Include Zephyr's Kconfig
 source "Kconfig"

--- a/tests/bluetooth/controller/ctrl_min_used_chans/Kconfig
+++ b/tests/bluetooth/controller/ctrl_min_used_chans/Kconfig
@@ -25,5 +25,7 @@ config ENTROPY_NRF_FORCE_ALT
 config ENTROPY_NRF5_RNG
 	default n
 
+source "tests/bluetooth/controller/common/Kconfig"
+
 # Include Zephyr's Kconfig
 source "Kconfig"

--- a/tests/bluetooth/controller/ctrl_phy_update/Kconfig
+++ b/tests/bluetooth/controller/ctrl_phy_update/Kconfig
@@ -25,5 +25,7 @@ config ENTROPY_NRF_FORCE_ALT
 config ENTROPY_NRF5_RNG
 	default n
 
+source "tests/bluetooth/controller/common/Kconfig"
+
 # Include Zephyr's Kconfig
 source "Kconfig"

--- a/tests/bluetooth/controller/ctrl_sca_update/Kconfig
+++ b/tests/bluetooth/controller/ctrl_sca_update/Kconfig
@@ -25,5 +25,7 @@ config ENTROPY_NRF_FORCE_ALT
 config ENTROPY_NRF5_RNG
 	default n
 
+source "tests/bluetooth/controller/common/Kconfig"
+
 # Include Zephyr's Kconfig
 source "Kconfig"

--- a/tests/bluetooth/controller/ctrl_sw_privacy/Kconfig
+++ b/tests/bluetooth/controller/ctrl_sw_privacy/Kconfig
@@ -1,0 +1,7 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+source "tests/bluetooth/controller/common/Kconfig"
+
+# Include Zephyr's Kconfig
+source "Kconfig"

--- a/tests/bluetooth/controller/ctrl_sw_privacy_unit/Kconfig
+++ b/tests/bluetooth/controller/ctrl_sw_privacy_unit/Kconfig
@@ -1,0 +1,7 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+source "tests/bluetooth/controller/common/Kconfig"
+
+# Include Zephyr's Kconfig
+source "Kconfig"

--- a/tests/bluetooth/controller/ctrl_terminate/Kconfig
+++ b/tests/bluetooth/controller/ctrl_terminate/Kconfig
@@ -25,5 +25,7 @@ config ENTROPY_NRF_FORCE_ALT
 config ENTROPY_NRF5_RNG
 	default n
 
+source "tests/bluetooth/controller/common/Kconfig"
+
 # Include Zephyr's Kconfig
 source "Kconfig"

--- a/tests/bluetooth/controller/ctrl_tx_buffer_alloc/Kconfig
+++ b/tests/bluetooth/controller/ctrl_tx_buffer_alloc/Kconfig
@@ -25,5 +25,7 @@ config ENTROPY_NRF_FORCE_ALT
 config ENTROPY_NRF5_RNG
 	default n
 
+source "tests/bluetooth/controller/common/Kconfig"
+
 # Include Zephyr's Kconfig
 source "Kconfig"

--- a/tests/bluetooth/controller/ctrl_tx_queue/Kconfig
+++ b/tests/bluetooth/controller/ctrl_tx_queue/Kconfig
@@ -25,5 +25,7 @@ config ENTROPY_NRF_FORCE_ALT
 config ENTROPY_NRF5_RNG
 	default n
 
+source "tests/bluetooth/controller/common/Kconfig"
+
 # Include Zephyr's Kconfig
 source "Kconfig"

--- a/tests/bluetooth/controller/ctrl_unsupported/Kconfig
+++ b/tests/bluetooth/controller/ctrl_unsupported/Kconfig
@@ -25,5 +25,7 @@ config ENTROPY_NRF_FORCE_ALT
 config ENTROPY_NRF5_RNG
 	default n
 
+source "tests/bluetooth/controller/common/Kconfig"
+
 # Include Zephyr's Kconfig
 source "Kconfig"

--- a/tests/bluetooth/controller/ctrl_user_ext/Kconfig
+++ b/tests/bluetooth/controller/ctrl_user_ext/Kconfig
@@ -1,0 +1,7 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+source "tests/bluetooth/controller/common/Kconfig"
+
+# Include Zephyr's Kconfig
+source "Kconfig"

--- a/tests/bluetooth/controller/ctrl_version/Kconfig
+++ b/tests/bluetooth/controller/ctrl_version/Kconfig
@@ -25,5 +25,7 @@ config ENTROPY_NRF_FORCE_ALT
 config ENTROPY_NRF5_RNG
 	default n
 
+source "tests/bluetooth/controller/common/Kconfig"
+
 # Include Zephyr's Kconfig
 source "Kconfig"

--- a/tests/bluetooth/controller/ll_settings/Kconfig
+++ b/tests/bluetooth/controller/ll_settings/Kconfig
@@ -1,0 +1,7 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+source "tests/bluetooth/controller/common/Kconfig"
+
+# Include Zephyr's Kconfig
+source "Kconfig"


### PR DESCRIPTION
This commit makes the device tree configuration decide which link layer is compiled in. We do this to avoid hard-to-understand linker errors referencing device tree nodes.

The following configuration creates a difficult to parse linker error:
* BT_LL_CHOICE contains multiple entries, BT_LL_SW_SPLIT is selected.
* Each BT_LL_CHOICE has its own unique device tree node with its own "compatible".
* Only one of the link layer device tree nodes has status "okay", but not the one corresponding to BT_LL_SW_SPLIT.

The linker error indicates that code using the HCI driver fails to link with the controller. This because the HCI driver device tree node references the link layer selected in devicetree which is not compiled in.

By adding a dependendency to the device tree node, this can no longer happen. Instead, if BT_LL_SW_SPLIT is now selected in a configuration file, a Kconfig warning will be issued:

```
warning: The choice symbol BT_LL_SW_SPLIT
(defined at subsys/bluetooth/controller/Kconfig:129) was
selected (set =y), but BT_LL_SOFTDEVICE (defined at
/home/ruge/ncs/nrf/subsys/bluetooth/controller/Kconfig:11)
ended up as the choice selection.
```

This should be easier to understand than:

```
...(hci_core.c.obj):(.data.bt_dev+0x16c):
undefined reference to `__device_dts_ord_132'
```

After this commit we should consider getting rid of link layer selection from Kconfig completely as the link layer is in practice selected through device tree.