### PR TITLE
picolibc: Add fix for module build with gcc-9

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -315,7 +315,7 @@ manifest:
         - debug
     - name: picolibc
       path: modules/lib/picolibc
-      revision: 06bde1fd7531b1f788f6e42b6f7b358c0fe4f814
+      revision: ac654d7fe5f1d504eb23d85420eb9b5d1c48984c
     - name: segger
       revision: b011c45b585e097d95d9cf93edf4f2e01588d3cd
       path: modules/debug/segger


### PR DESCRIPTION
Merge upstream picolibc fixes for cmake when detecting support for 'alias' attribute using a compiler that doesn't default to -fno-common.

Closes: #78830 