### PR TITLE
xtensa: do not disable C++ standard includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2223,7 +2223,7 @@ add_custom_target(llext-edk DEPENDS ${llext_edk_file})
 zephyr_compile_options($<TARGET_PROPERTY:compiler,nostdinc>)
 target_include_directories(zephyr_interface SYSTEM INTERFACE $<TARGET_PROPERTY:compiler,nostdinc_include>)
 
-if(CONFIG_MINIMAL_LIBCPP)
+if(NOT CONFIG_USE_STD_CPP_HEADERS)
   zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:$<TARGET_PROPERTY:compiler-cpp,nostdincxx>>)
 endif()
 

--- a/lib/cpp/Kconfig
+++ b/lib/cpp/Kconfig
@@ -71,6 +71,11 @@ config FULL_LIBCPP_SUPPORTED
 	  complete implementation and which would be selected when
 	  REQUIRES_FULL_LIBCPP is set.
 
+config USE_STD_CPP_HEADERS
+	bool "Use toolchain C++ headers"
+	help
+	  Prevent the use of -nostdinc++.
+
 choice LIBCPP_IMPLEMENTATION
 	prompt "C++ Standard Library Implementation"
 	default EXTERNAL_LIBCPP if REQUIRES_FULL_LIBCPP && NATIVE_BUILD
@@ -81,6 +86,7 @@ choice LIBCPP_IMPLEMENTATION
 config MINIMAL_LIBCPP
 	bool "Minimal C++ Library"
 	depends on !REQUIRES_FULL_LIBCPP
+	select USE_STD_CPP_HEADERS if (XTENSA)
 	help
 	  Build with the minimal C++ library provided by Zephyr.
 


### PR DESCRIPTION
C++ examples such as `samples/cpp/cpp_synchronization` do not build on xtensa because some toolchain headers such as <limits.h> which is a C header turns out to depend on a C++ header when included in C++ mode.

This change preserves the fix for issue #36644 while selectively enabling the use of C++ standard includes.