### PR TITLE
linker: Include the .ARM.extab section for Rust

### DIFF
--- a/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
@@ -174,7 +174,7 @@ SECTIONS
 
 	__text_region_end = .;
 
-#if defined (CONFIG_CPP)
+#if defined (CONFIG_CPP) || defined(CONFIG_RUST)
 	SECTION_PROLOGUE(.ARM.extab,,)
 	{
 	/*


### PR DESCRIPTION
This is a little complicated.  We currently just jump directly to rust's panic handler, so we don't actually need these unwind tables.  But, they would be needed if we ever really handle panic.  As of the time of this change, the tables seem to just be 24 bytes of ROM space.

In Rust, unwind tables are not used for ordinary code, but for recovery from panic.