### PR TITLE
[logging][dictionary]: Update dict out to send complete message to backend

### DIFF
--- a/subsys/logging/log_output_dict.c
+++ b/subsys/logging/log_output_dict.c
@@ -12,8 +12,7 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/util.h>
 
-static void buffer_write(log_output_func_t outf, uint8_t *buf, size_t len,
-			 void *ctx)
+static void buffer_write(log_output_func_t outf, uint8_t *buf, size_t len, void *ctx)
 {
 	int processed;
 
@@ -24,8 +23,32 @@ static void buffer_write(log_output_func_t outf, uint8_t *buf, size_t len,
 	} while (len != 0);
 }
 
-void log_dict_output_msg_process(const struct log_output *output,
-				 struct log_msg *msg, uint32_t flags)
+static void out_func(const struct log_output *output, uint8_t *data, size_t len)
+{
+	size_t length = 0;
+
+	do {
+		length = MIN(len, output->size - output->control_block->offset);
+
+		memcpy((void *)&output->buf[output->control_block->offset], (void *)data, length);
+
+		atomic_add(&output->control_block->offset, length);
+
+		if (output->control_block->offset == output->size) {
+			log_output_flush(output);
+		}
+
+		len -= length;
+
+		data += length;
+
+	} while (len != 0);
+
+	__ASSERT_NO_MSG(output->control_block->offset <= output->size);
+}
+
+void log_dict_output_msg_process(const struct log_output *output, struct log_msg *msg,
+				 uint32_t flags)
 {
 	struct log_dict_output_normal_msg_hdr_t output_hdr;
 	void *source = (void *)log_msg_get_source(msg);
@@ -38,25 +61,23 @@ void log_dict_output_msg_process(const struct log_output *output,
 	output_hdr.data_len = msg->hdr.desc.data_len;
 	output_hdr.timestamp = msg->hdr.timestamp;
 
-	output_hdr.source = (source != NULL) ?
-				(IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ?
-					log_dynamic_source_id(source) :
-					log_const_source_id(source)) :
-				0U;
+	output_hdr.source = (source != NULL) ? (IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING)
+							? log_dynamic_source_id(source)
+							: log_const_source_id(source))
+					     : 0U;
 
-	buffer_write(output->func, (uint8_t *)&output_hdr, sizeof(output_hdr),
-		     (void *)output->control_block->ctx);
+	out_func(output, (uint8_t *)&output_hdr, sizeof(output_hdr));
 
 	size_t len;
 	uint8_t *data = log_msg_get_package(msg, &len);
 
 	if (len > 0U) {
-		buffer_write(output->func, data, len, (void *)output->control_block->ctx);
+		out_func(output, data, len);
 	}
 
 	data = log_msg_get_data(msg, &len);
 	if (len > 0U) {
-		buffer_write(output->func, data, len, (void *)output->control_block->ctx);
+		out_func(output, data, len);
 	}
 
 	log_output_flush(output);


### PR DESCRIPTION
Updates the log_output_dict to aggregate complete message in the buffer provided by backend and send all message at once or when buffer is full. This also helps simplifies the backend implementation to expect the complete
binary message in the function registered with logging Subsystem or get notified when buffer is full similar to log_output