### PR TITLE
Bluetooth: ssp: correct pairing failed callback

### DIFF
--- a/subsys/bluetooth/host/classic/ssp.c
+++ b/subsys/bluetooth/host/classic/ssp.c
@@ -228,8 +228,8 @@ static void ssp_pairing_complete(struct bt_conn *conn, uint8_t status)
 
 		SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&bt_auth_info_cbs, listener,
 						  next, node) {
-			if (listener->pairing_complete) {
-				listener->pairing_complete(conn, status);
+			if (listener->pairing_failed) {
+				listener->pairing_failed(conn, status);
 			}
 		}
 	}


### PR DESCRIPTION
Current, the callback `pairing_complete` is called when the pairing is filed. But there is a callback `pairing_failed` for pairing failed case.

Correct the callback calling if pairing failed.
Call `pairing_failed` instead of `pairing_complete` if the pairing failed.