### PR TITLE
Enable PWM on NXP i.MX95 EVK board for M7

### DIFF
--- a/boards/nxp/imx95_evk/doc/index.rst
+++ b/boards/nxp/imx95_evk/doc/index.rst
@@ -93,6 +93,8 @@ The Zephyr ``imx95_evk/mimx9596/m7`` board target supports the following hardwar
 +-----------+------------+-------------------------------------+
 | I2C       | on-chip    | i2c                                 |
 +-----------+------------+-------------------------------------+
+| TPM       | on-chip    | tpm                                 |
++-----------+------------+-------------------------------------+
 
 The Zephyr ``imx95_evk/mimx9596/a55`` and ``imx95_evk/mimx9596/a55/smp`` board targets support
 the following hardware features:
@@ -123,6 +125,15 @@ Serial Port
 
 This board configuration uses a single serial communication channel with the
 CPU's UART1 for Cortex-A55, UART3 for Cortex-M7.
+
+TPM
+---
+
+Two channels are enabled on TPM2 for PWM for M7. Signals can be observerd with
+oscilloscope.
+Channel 2 signal routed to resistance R881.
+Channel 3 signal routed to resistance R882.
+
 
 Programming and Debugging (A55)
 *******************************

--- a/boards/nxp/imx95_evk/imx95_evk-pinctrl.dtsi
+++ b/boards/nxp/imx95_evk/imx95_evk-pinctrl.dtsi
@@ -60,4 +60,15 @@
 			drive-strength = "x4";
 		};
 	};
+
+	tpm2_default: tpm2_default {
+		group0 {
+			pinmux = <&iomuxc_i2c2_scl_tpm_ch_tpm2_ch2>,
+				<&iomuxc_i2c2_sda_tpm_ch_tpm2_ch3>;
+			drive-open-drain;
+			slew-rate = "slightly_fast";
+			drive-strength = "x4";
+			input-enable;
+		};
+	};
 };

--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.dts
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.dts
@@ -46,3 +46,9 @@
 	pinctrl-0 = <&sai3_default>;
 	pinctrl-names = "default";
 };
+
+&tpm2 {
+	pinctrl-0 = <&tpm2_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.yaml
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.yaml
@@ -17,4 +17,5 @@ toolchain:
 supported:
   - uart
   - i2c
+  - pwm
 vendor: nxp

--- a/drivers/pwm/pwm_mcux_tpm.c
+++ b/drivers/pwm/pwm_mcux_tpm.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2019 Henrik Brix Andersen <henrik@brixandersen.dk>
- * Copyright 2020 NXP
+ * Copyright 2020, 2024 NXP
  *
  * Heavily based on pwm_mcux_ftm.c, which is:
  * Copyright (c) 2017, NXP
@@ -22,7 +22,11 @@
 
 LOG_MODULE_REGISTER(pwm_mcux_tpm, CONFIG_PWM_LOG_LEVEL);
 
+#if defined(TPM0)
 #define MAX_CHANNELS ARRAY_SIZE(TPM0->CONTROLS)
+#else
+#define MAX_CHANNELS ARRAY_SIZE(TPM1->CONTROLS)
+#endif
 
 struct mcux_tpm_config {
 	TPM_Type *base;

--- a/dts/arm/nxp/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/nxp_imx95_m7.dtsi
@@ -86,6 +86,42 @@
 			status = "disabled";
 		};
 
+		tpm3: pwm@424e0000 {
+			compatible = "nxp,kinetis-tpm";
+			reg = <0x424e0000 0x88>;
+			interrupts = <73 0>;
+			clocks = <&scmi_clk IMX95_CLK_BUSWAKEUP>;
+			status = "disabled";
+			#pwm-cells = <3>;
+		};
+
+		tpm4: pwm@424f0000 {
+			compatible = "nxp,kinetis-tpm";
+			reg = <0x424f0000 0x88>;
+			interrupts = <74 0>;
+			clocks = <&scmi_clk IMX95_CLK_TPM4>;
+			status = "disabled";
+			#pwm-cells = <3>;
+		};
+
+		tpm5: pwm@42500000 {
+			compatible = "nxp,kinetis-tpm";
+			reg = <0x42500000 0x88>;
+			interrupts = <75 0>;
+			clocks = <&scmi_clk IMX95_CLK_TPM5>;
+			status = "disabled";
+			#pwm-cells = <3>;
+		};
+
+		tpm6: pwm@42510000 {
+			compatible = "nxp,kinetis-tpm";
+			reg = <0x42510000 0x88>;
+			interrupts = <76 0>;
+			clocks = <&scmi_clk IMX95_CLK_TPM6>;
+			status = "disabled";
+			#pwm-cells = <3>;
+		};
+
 		lpi2c3: i2c@42530000 {
 			compatible = "nxp,imx-lpi2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
@@ -211,6 +247,24 @@
 			interrupts = <184 0>;
 			clocks = <&scmi_clk IMX95_CLK_LPI2C8>;
 			status = "disabled";
+		};
+
+		tpm1: pwm@44310000 {
+			compatible = "nxp,kinetis-tpm";
+			reg = <0x44310000 0x88>;
+			interrupts = <29 0>;
+			clocks = <&scmi_clk IMX95_CLK_BUSAON>;
+			status = "disabled";
+			#pwm-cells = <3>;
+		};
+
+		tpm2: pwm@44320000 {
+			compatible = "nxp,kinetis-tpm";
+			reg = <0x44320000 0x88>;
+			interrupts = <30 0>;
+			clocks = <&scmi_clk IMX95_CLK_TPM2>;
+			status = "disabled";
+			#pwm-cells = <3>;
 		};
 
 		lpi2c1: i2c@44340000 {

--- a/west.yml
+++ b/west.yml
@@ -198,7 +198,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: adfa0bbba6f5d36352d387527bdc486616c9f521
+      revision: 9702923eeb6f4a9ca063ca3b200324b118d3e843
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
This PR is to enable TPM PWM on NXP i.MX95 EVK board for M7.
The function had been verified through pwm command, and expected signals were observed with oscilloscope.

Depends on one hal patch.
https://github.com/zephyrproject-rtos/hal_nxp/pull/441

Thanks.