### PR TITLE
soc: st: adds support for stm32u545xx

### DIFF
--- a/dts/arm/st/u5/stm32u545.dtsi
+++ b/dts/arm/st/u5/stm32u545.dtsi
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024 Opito
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <st/u5/stm32u5.dtsi>
+
+
+/ {
+	soc {
+		/* USB-C PD is not available on this part. */
+		/delete-node/ ucpd@4000dc00;
+
+		compatible = "st,stm32u545", "st,stm32u5", "simple-bus";
+
+		usb: usb@40006000 {
+			compatible = "st,stm32-usb";
+			reg = <0x40006000 0x400>;
+			interrupts = <73 0>;
+			interrupt-names = "usb";
+			num-bidir-endpoints = <8>;
+			ram-size = <1024>;
+			status = "disabled";
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x01000000>,
+				 <&rcc STM32_SRC_HSI48 ICKLK_SEL(0)>;
+			phys = <&usb_fs_phy>;
+		};
+	};
+
+	usb_fs_phy: usb_fs_phy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
+	};
+};

--- a/dts/arm/st/u5/stm32u545Xi.dtsi
+++ b/dts/arm/st/u5/stm32u545Xi.dtsi
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2024 Opito
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <mem.h>
+#include <st/u5/stm32u545.dtsi>
+
+/ {
+	sram0: memory@20000000 {
+		/* SRAM1 + SRAM2 */
+		reg = <0x20000000 DT_SIZE_K(256)>;
+	};
+
+	sram1: memory@28000000 {
+		/* SRAM4, low-power background autonomous mode */
+		reg = <0x28000000 DT_SIZE_K(16)>;
+	};
+
+	soc {
+		flash-controller@40022000 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_K(512)>;
+			};
+		};
+	};
+};

--- a/soc/st/stm32/soc.yml
+++ b/soc/st/stm32/soc.yml
@@ -190,6 +190,7 @@ family:
     socs:
     - name: stm32u5a5xx
     - name: stm32u5a9xx
+    - name: stm32u545xx
     - name: stm32u575xx
     - name: stm32u585xx
     - name: stm32u595xx

--- a/soc/st/stm32/stm32u5x/Kconfig.defconfig.stm32u545xx
+++ b/soc/st/stm32/stm32u5x/Kconfig.defconfig.stm32u545xx
@@ -1,0 +1,11 @@
+# ST Microelectronics STM32U545XX MCU
+
+# Copyright (c) 2024 Opito
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_STM32U545XX
+
+config NUM_IRQS
+	default 126
+
+endif # SOC_STM32U545XX

--- a/soc/st/stm32/stm32u5x/Kconfig.soc
+++ b/soc/st/stm32/stm32u5x/Kconfig.soc
@@ -12,6 +12,10 @@ config SOC_SERIES_STM32U5X
 config SOC_SERIES
 	default "stm32u5x" if SOC_SERIES_STM32U5X
 
+config SOC_STM32U545XX
+	bool
+	select SOC_SERIES_STM32U5X
+
 config SOC_STM32U575XX
 	bool
 	select SOC_SERIES_STM32U5X
@@ -39,6 +43,7 @@ config SOC_STM32U5A9XX
 config SOC
 	default "stm32u5a5xx" if SOC_STM32U5A5XX
 	default "stm32u5a9xx" if SOC_STM32U5A9XX
+	default "stm32u545xx" if SOC_STM32U545XX
 	default "stm32u575xx" if SOC_STM32U575XX
 	default "stm32u585xx" if SOC_STM32U585XX
 	default "stm32u595xx" if SOC_STM32U595XX

--- a/soc/st/stm32/stm32u5x/soc.c
+++ b/soc/st/stm32/stm32u5x/soc.c
@@ -40,11 +40,16 @@ void soc_early_init_hook(void)
 	/* Enable PWR */
 	LL_AHB3_GRP1_EnableClock(LL_AHB3_GRP1_PERIPH_PWR);
 
+	/* For devices with USB C PD, we can disable the dead battery
+	 * pull-down behaviour.
+	 */
+#if defined(UCPD1)
 	if (IS_ENABLED(CONFIG_DT_HAS_ST_STM32_UCPD_ENABLED) ||
 		!IS_ENABLED(CONFIG_USB_DEVICE_DRIVER)) {
 		/* Disable USB Type-C dead battery pull-down behavior */
 		LL_PWR_DisableUCPDDeadBattery();
 	}
+#endif
 
 	/* Power Configuration */
 #if defined(CONFIG_POWER_SUPPLY_DIRECT_SMPS)


### PR DESCRIPTION
We are using an stm32u545ceu6q on a custom PCB, and this PR adds the necessary SoC support to make that board work.

This has been tested using the hello_world example, along with a custom application using UART. Mostly copied from other ST SOCs and, in particular, the stm32u575xx. Of note is the exclusion of the USB-C PD periperhal - so the soc.c file needed to be modified. Also notice the USB peripheral is different - it's a simple USB FS host/device controller, rather than USB OTG FS/HS.

Please have a look over and let me know if there are any improvements needed!