### PR TITLE
include: kernel: arch: sys: Use new TLS macro

### DIFF
--- a/include/zephyr/arch/riscv/syscall.h
+++ b/include/zephyr/arch/riscv/syscall.h
@@ -158,7 +158,7 @@ static inline bool arch_is_user_context(void)
 	}
 
 	/* Defined in arch/riscv/core/thread.c */
-	extern __thread uint8_t is_user_mode;
+	extern Z_THREAD_LOCAL uint8_t is_user_mode;
 
 	return is_user_mode != 0;
 }

--- a/include/zephyr/arch/xtensa/syscall.h
+++ b/include/zephyr/arch/xtensa/syscall.h
@@ -211,7 +211,7 @@ static inline bool arch_is_user_context(void)
 		: "=a" (thread)
 	);
 #ifdef CONFIG_THREAD_LOCAL_STORAGE
-	extern __thread uint32_t is_user_mode;
+	extern Z_THREAD_LOCAL uint32_t is_user_mode;
 
 	if (!thread) {
 		return false;

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -665,7 +665,7 @@ static inline k_tid_t k_current_get(void)
 #ifdef CONFIG_CURRENT_THREAD_USE_TLS
 
 	/* Thread-local cache of current thread ID, set in z_thread_entry() */
-	extern __thread k_tid_t z_tls_current;
+	extern Z_THREAD_LOCAL k_tid_t z_tls_current;
 
 	return z_tls_current;
 #else

--- a/include/zephyr/sys/errno_private.h
+++ b/include/zephyr/sys/errno_private.h
@@ -8,6 +8,7 @@
 #define ZEPHYR_INCLUDE_SYS_ERRNO_PRIVATE_H_
 
 #include <zephyr/toolchain.h>
+#include <zephyr/types.h> /* For Z_THREAD_LOCAL */
 
 #ifdef __cplusplus
 extern "C" {
@@ -26,7 +27,7 @@ static inline int *z_errno(void)
 }
 
 #elif defined(CONFIG_ERRNO_IN_TLS)
-extern __thread int z_errno_var;
+extern Z_THREAD_LOCAL int z_errno_var;
 
 static inline int *z_errno(void)
 {


### PR DESCRIPTION
PR #78645 replaced uses of the GNU keyword `__thread` with a new macro `Z_THREAD_LOCAL` which expands to correspond C/C++ standard keyword if applicable, else it falls back to `__thread`.

This PR addresses some missed replacements in headers files for #78645.

Signed-off-by: Daniel Flodin <daniel.flodin@iar.com>