### PR TITLE
drivers: flash: spi nor: Allow the init priority to be configurable

### DIFF
--- a/drivers/flash/Kconfig.nor
+++ b/drivers/flash/Kconfig.nor
@@ -45,7 +45,7 @@ config SPI_NOR_SFDP_RUNTIME
 endchoice
 
 config SPI_NOR_INIT_PRIORITY
-	int
+	int "Init priority"
 	default 80
 	help
 	  Device driver initialization priority.


### PR DESCRIPTION
Some applications may require the SPI NOR driver to be initialized earlier. This commit enables the user to change the default initialization priority.