### PR TITLE
drivers: led_strip: Fix formatting of log message

### DIFF
--- a/drivers/led_strip/lpd880x.c
+++ b/drivers/led_strip/lpd880x.c
@@ -78,7 +78,7 @@ static int lpd880x_update(const struct device *dev, void *data, size_t size)
 
 	rc = spi_write_dt(&config->bus, &tx);
 	if (rc) {
-		LOG_ERR("can't update strip: %d", rc);
+		LOG_ERR("can't update strip: %zu", rc);
 	}
 
 	return rc;


### PR DESCRIPTION
The previous version generated compilation warnings.

Discovered in https://github.com/zephyrproject-rtos/zephyr/pull/78483.