### PR TITLE
Bluetooth: GATT: Replace magic number 0 with macro for auto ccc

### DIFF
--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -1644,6 +1644,9 @@ enum {
 	BT_GATT_DISCOVER_STD_CHAR_DESC,
 };
 
+/** Handle value to denote that the CCC will be automatically discovered */
+#define BT_GATT_AUTO_DISCOVER_CCC_HANDLE 0x0000U
+
 /** @brief GATT Discover Attributes parameters */
 struct bt_gatt_discover_params {
 	/** Discover UUID type */
@@ -2049,7 +2052,7 @@ struct bt_gatt_subscribe_params {
 #if defined(CONFIG_BT_GATT_AUTO_DISCOVER_CCC) || defined(__DOXYGEN__)
 	/** Subscribe End handle (for automatic discovery) */
 	uint16_t end_handle;
-	/** Discover parameters used when ccc_handle = 0 */
+	/** Discover parameters used when ccc_handle = @ref BT_GATT_AUTO_DISCOVER_CCC_HANDLE */
 	struct bt_gatt_discover_params *disc_params;
 #endif /* defined(CONFIG_BT_GATT_AUTO_DISCOVER_CCC) || defined(__DOXYGEN__) */
 	/** Subscribe value */

--- a/samples/bluetooth/central_otc/src/main.c
+++ b/samples/bluetooth/central_otc/src/main.c
@@ -313,8 +313,7 @@ static int subscribe_func(void)
 	oacp_sub_params = &otc.oacp_sub_params;
 	oacp_sub_params->disc_params = &otc.oacp_sub_disc_params;
 	if (oacp_sub_params) {
-		/* With ccc_handle == 0 it will use auto discovery */
-		oacp_sub_params->ccc_handle = 0;
+		oacp_sub_params->ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE;
 		oacp_sub_params->end_handle = otc.end_handle;
 		oacp_sub_params->value = BT_GATT_CCC_INDICATE;
 		oacp_sub_params->value_handle = otc.oacp_handle;
@@ -330,8 +329,7 @@ static int subscribe_func(void)
 	olcp_sub_params = &otc.olcp_sub_params;
 	olcp_sub_params->disc_params = &otc.olcp_sub_disc_params;
 	if (olcp_sub_params) {
-		/* With ccc_handle == 0 it will use auto discovery */
-		olcp_sub_params->ccc_handle = 0;
+		olcp_sub_params->ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE;
 		olcp_sub_params->end_handle = otc.end_handle;
 		olcp_sub_params->value = BT_GATT_CCC_INDICATE;
 		olcp_sub_params->value_handle = otc.olcp_handle;

--- a/subsys/bluetooth/audio/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/bap_broadcast_assistant.c
@@ -701,9 +701,8 @@ static uint8_t char_discover_func(struct bt_conn *conn,
 		}
 
 		if (sub_params != NULL) {
-			/* With ccc_handle == 0 it will use auto discovery */
 			sub_params->end_handle = inst->end_handle;
-			sub_params->ccc_handle = 0;
+			sub_params->ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE;
 			sub_params->value = BT_GATT_CCC_NOTIFY;
 			sub_params->value_handle = attr->handle + 1;
 			sub_params->notify = notify_handler;

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -1656,7 +1656,7 @@ static int unicast_client_ep_subscribe(struct bt_conn *conn, struct bt_bap_ep *e
 	}
 
 	client_ep->subscribe.value_handle = client_ep->handle;
-	client_ep->subscribe.ccc_handle = 0x0000;
+	client_ep->subscribe.ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE;
 	client_ep->subscribe.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;
 	client_ep->subscribe.disc_params = &client_ep->discover;
 	client_ep->subscribe.notify = unicast_client_ep_notify;
@@ -1749,7 +1749,7 @@ static void unicast_client_ep_set_cp(struct bt_conn *conn, uint16_t handle)
 		int err;
 
 		client->cp_subscribe.value_handle = handle;
-		client->cp_subscribe.ccc_handle = 0x0000;
+		client->cp_subscribe.ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE;
 		client->cp_subscribe.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;
 		client->cp_subscribe.disc_params = &client->disc_params;
 		client->cp_subscribe.notify = unicast_client_cp_notify;
@@ -3777,7 +3777,7 @@ static uint8_t unicast_client_pacs_avail_ctx_discover_cb(struct bt_conn *conn,
 		if (sub_params->value_handle == 0) {
 			LOG_DBG("Subscribing to handle %u", value_handle);
 			sub_params->value_handle = value_handle;
-			sub_params->ccc_handle = 0x0000; /* auto discover ccc */
+			sub_params->ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE;
 			sub_params->end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;
 			sub_params->disc_params = &uni_cli_insts[index].avail_ctx_cc_disc;
 			sub_params->notify = unicast_client_pacs_avail_ctx_notify_cb;
@@ -3976,7 +3976,7 @@ static uint8_t unicast_client_pacs_location_discover_cb(struct bt_conn *conn,
 		}
 
 		sub_params->value_handle = value_handle;
-		sub_params->ccc_handle = 0x0000; /* auto discover ccc */
+		sub_params->ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE;
 		sub_params->end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;
 		sub_params->disc_params = &uni_cli_insts[index].loc_cc_disc;
 		sub_params->notify = unicast_client_pacs_location_notify_cb;

--- a/subsys/bluetooth/audio/csip_set_coordinator.c
+++ b/subsys/bluetooth/audio/csip_set_coordinator.c
@@ -764,8 +764,7 @@ static uint8_t discover_func(struct bt_conn *conn,
 			if (sub_params->value != 0) {
 				int err;
 
-				/* With ccc_handle == 0 it will use auto discovery */
-				sub_params->ccc_handle = 0;
+				sub_params->ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE;
 				sub_params->end_handle = client->cur_inst->end_handle;
 				sub_params->value_handle = chrc->value_handle;
 				sub_params->notify = notify_handler;

--- a/subsys/bluetooth/audio/has_client.c
+++ b/subsys/bluetooth/audio/has_client.c
@@ -441,7 +441,7 @@ static int active_index_subscribe(struct bt_has_client *inst, uint16_t value_han
 	inst->active_index_subscription.notify = active_preset_notify_cb;
 	inst->active_index_subscription.subscribe = active_index_subscribe_cb;
 	inst->active_index_subscription.value_handle = value_handle;
-	inst->active_index_subscription.ccc_handle = 0x0000;
+	inst->active_index_subscription.ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE;
 	inst->active_index_subscription.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;
 	inst->active_index_subscription.disc_params = &inst->params.discover;
 	inst->active_index_subscription.value = BT_GATT_CCC_NOTIFY;
@@ -543,7 +543,7 @@ static int control_point_subscribe(struct bt_has_client *inst, uint16_t value_ha
 	inst->control_point_subscription.notify = control_point_notify_cb;
 	inst->control_point_subscription.subscribe = control_point_subscribe_cb;
 	inst->control_point_subscription.value_handle = value_handle;
-	inst->control_point_subscription.ccc_handle = 0x0000;
+	inst->control_point_subscription.ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE;
 	inst->control_point_subscription.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;
 	inst->control_point_subscription.disc_params = &inst->params.discover;
 	atomic_set_bit(inst->control_point_subscription.flags, BT_GATT_SUBSCRIBE_FLAG_VOLATILE);
@@ -739,7 +739,7 @@ static int features_subscribe(struct bt_has_client *inst, uint16_t value_handle)
 	inst->features_subscription.notify = features_notify_cb;
 	inst->features_subscription.subscribe = features_subscribe_cb;
 	inst->features_subscription.value_handle = value_handle;
-	inst->features_subscription.ccc_handle = 0x0000;
+	inst->features_subscription.ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE;
 	inst->features_subscription.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;
 	inst->features_subscription.disc_params = &inst->params.discover;
 	inst->features_subscription.value = BT_GATT_CCC_NOTIFY;

--- a/subsys/bluetooth/audio/mcc.c
+++ b/subsys/bluetooth/audio/mcc.c
@@ -1439,8 +1439,7 @@ static uint8_t discover_otc_char_func(struct bt_conn *conn,
 		}
 
 		if (sub_params) {
-			/* With ccc_handle == 0 it will use auto discovery */
-			sub_params->ccc_handle = 0;
+			sub_params->ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE;
 			sub_params->end_handle = mcs_inst->otc.end_handle;
 			sub_params->value = BT_GATT_CCC_INDICATE;
 			sub_params->value_handle = chrc->value_handle;
@@ -1605,8 +1604,7 @@ static int do_subscribe(struct mcs_instance_t *mcs_inst, struct bt_conn *conn,
 			uint16_t handle,
 			struct bt_gatt_subscribe_params *sub_params)
 {
-	/* With ccc_handle == 0 it will use auto discovery */
-	sub_params->ccc_handle = 0;
+	sub_params->ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE;
 	sub_params->end_handle = mcs_inst->end_handle;
 	sub_params->value_handle = handle;
 	sub_params->notify = mcs_notify_handler;

--- a/subsys/bluetooth/audio/micp_mic_ctlr.c
+++ b/subsys/bluetooth/audio/micp_mic_ctlr.c
@@ -423,8 +423,7 @@ static uint8_t micp_discover_func(struct bt_conn *conn,
 		if (sub_params != NULL) {
 			int err;
 
-			/* With ccc_handle == 0 it will use auto discovery */
-			sub_params->ccc_handle = 0;
+			sub_params->ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE;
 			sub_params->end_handle = mic_ctlr->end_handle;
 			sub_params->value = BT_GATT_CCC_NOTIFY;
 			sub_params->value_handle = chrc->value_handle;

--- a/subsys/bluetooth/audio/tbs_client.c
+++ b/subsys/bluetooth/audio/tbs_client.c
@@ -1692,8 +1692,7 @@ static uint8_t discover_func(struct bt_conn *conn,
 			if (sub_params->value != 0) {
 				int err;
 
-				/* Setting ccc_handle = will use auto discovery feature */
-				sub_params->ccc_handle = 0;
+				sub_params->ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE;
 				sub_params->end_handle = current_inst->end_handle;
 				sub_params->notify = notify_handler;
 				atomic_set_bit(sub_params->flags, BT_GATT_SUBSCRIBE_FLAG_VOLATILE);

--- a/subsys/bluetooth/audio/vcp_vol_ctlr.c
+++ b/subsys/bluetooth/audio/vcp_vol_ctlr.c
@@ -480,7 +480,7 @@ static uint8_t vcs_discover_func(struct bt_conn *conn,
 		if (sub_params != NULL) {
 			sub_params->value = BT_GATT_CCC_NOTIFY;
 			sub_params->value_handle = chrc->value_handle;
-			sub_params->ccc_handle = 0;
+			sub_params->ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE;
 			sub_params->end_handle = vol_ctlr->end_handle;
 			sub_params->notify = vcp_vol_ctlr_notify_handler;
 			atomic_set_bit(sub_params->flags, BT_GATT_SUBSCRIBE_FLAG_VOLATILE);

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -5486,7 +5486,7 @@ int bt_gatt_subscribe(struct bt_conn *conn,
 		int err;
 
 #if defined(CONFIG_BT_GATT_AUTO_DISCOVER_CCC)
-		if (!params->ccc_handle) {
+		if (params->ccc_handle == BT_GATT_AUTO_DISCOVER_CCC_HANDLE) {
 			return gatt_ccc_discover(conn, params);
 		}
 #endif

--- a/subsys/bluetooth/host/shell/gatt.c
+++ b/subsys/bluetooth/host/shell/gatt.c
@@ -591,7 +591,7 @@ static int cmd_subscribe(const struct shell *sh, size_t argc, char *argv[])
 	SET_CHAN_OPT_ANY(subscribe_params);
 
 #if defined(CONFIG_BT_GATT_AUTO_DISCOVER_CCC)
-	if (subscribe_params.ccc_handle == 0) {
+	if (subscribe_params.ccc_handle == BT_GATT_AUTO_DISCOVER_CCC_HANDLE) {
 		static struct bt_gatt_discover_params disc_params;
 
 		subscribe_params.disc_params = &disc_params;

--- a/tests/bsim/bluetooth/host/att/eatt_notif/src/server_test.c
+++ b/tests/bsim/bluetooth/host/att/eatt_notif/src/server_test.c
@@ -159,8 +159,7 @@ static void gatt_subscribe(void)
 	subscribe_params.notify = notify_cb;
 	subscribe_params.subscribe = subscribed_cb;
 
-	/* Use the BT_GATT_AUTO_DISCOVER_CCC feature */
-	subscribe_params.ccc_handle = 0;
+	subscribe_params.ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE;
 	subscribe_params.disc_params = &disc_params,
 	subscribe_params.value = BT_GATT_CCC_NOTIFY;
 	subscribe_params.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;

--- a/tests/bsim/bluetooth/host/gatt/notify/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/gatt/notify/src/gatt_client_test.c
@@ -227,8 +227,8 @@ static struct bt_gatt_discover_params disc_params_short;
 static struct bt_gatt_subscribe_params sub_params_short = {
 	.notify = test_notify,
 	.subscribe = test_short_subscribed,
-	.ccc_handle = 0, /* Auto-discover CCC*/
-	.disc_params = &disc_params_short, /* Auto-discover CCC */
+	.ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE,
+	.disc_params = &disc_params_short,
 	.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE,
 	.value = BT_GATT_CCC_NOTIFY,
 };
@@ -236,8 +236,8 @@ static struct bt_gatt_discover_params disc_params_long;
 static struct bt_gatt_subscribe_params sub_params_long = {
 	.notify = test_notify,
 	.subscribe = test_long_subscribed,
-	.ccc_handle = 0, /* Auto-discover CCC*/
-	.disc_params = &disc_params_long, /* Auto-discover CCC */
+	.ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE,
+	.disc_params = &disc_params_long,
 	.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE,
 	.value = BT_GATT_CCC_NOTIFY,
 };

--- a/tests/bsim/bluetooth/host/gatt/notify_multiple/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/gatt/notify_multiple/src/gatt_client_test.c
@@ -230,8 +230,8 @@ static struct bt_gatt_discover_params disc_params_short;
 static struct bt_gatt_subscribe_params sub_params_short = {
 	.notify = test_notify,
 	.subscribe = test_subscribed,
-	.ccc_handle = 0, /* Auto-discover CCC*/
-	.disc_params = &disc_params_short, /* Auto-discover CCC */
+	.ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE,
+	.disc_params = &disc_params_short,
 	.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE,
 	.value = BT_GATT_CCC_NOTIFY,
 };
@@ -239,8 +239,8 @@ static struct bt_gatt_discover_params disc_params_long;
 static struct bt_gatt_subscribe_params sub_params_long = {
 	.notify = test_notify,
 	.subscribe = test_subscribed,
-	.ccc_handle = 0, /* Auto-discover CCC*/
-	.disc_params = &disc_params_long, /* Auto-discover CCC */
+	.ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE,
+	.disc_params = &disc_params_long,
 	.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE,
 	.value = BT_GATT_CCC_NOTIFY,
 };

--- a/tests/bsim/bluetooth/host/gatt/settings/src/gatt_utils.c
+++ b/tests/bsim/bluetooth/host/gatt/settings/src/gatt_utils.c
@@ -206,8 +206,7 @@ void gatt_subscribe_to_service_changed(bool subscribe)
 	subscribe_params.subscribe = sc_subscribed;
 
 	if (subscribe) {
-		/* Use the BT_GATT_AUTO_DISCOVER_CCC feature */
-		subscribe_params.ccc_handle = 0;
+		subscribe_params.ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE;
 		subscribe_params.disc_params = &disc_params,
 		subscribe_params.value = BT_GATT_CCC_INDICATE;
 		subscribe_params.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;

--- a/tests/bsim/bluetooth/host/misc/acl_tx_frag/src/peer.c
+++ b/tests/bsim/bluetooth/host/misc/acl_tx_frag/src/peer.c
@@ -109,9 +109,7 @@ static void subscribe(struct bt_conn *conn, uint16_t handle, bt_gatt_notify_func
 	sub_params.subscribe = sub_cb;
 	sub_params.value = BT_GATT_CCC_INDICATE;
 	sub_params.value_handle = handle;
-
-	/* Set-up auto-discovery of the CCC handle */
-	sub_params.ccc_handle = 0;
+	sub_params.ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE;
 	sub_params.disc_params = &ccc_disc_params;
 	sub_params.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;
 

--- a/tests/bsim/bluetooth/host/misc/sample_test/src/peer.c
+++ b/tests/bsim/bluetooth/host/misc/sample_test/src/peer.c
@@ -125,9 +125,7 @@ static void subscribe(struct bt_conn *conn,
 	sub_params.subscribe = sub_cb;
 	sub_params.value = BT_GATT_CCC_NOTIFY;
 	sub_params.value_handle = handle;
-
-	/* Set-up auto-discovery of the CCC handle */
-	sub_params.ccc_handle = 0;
+	sub_params.ccc_handle = BT_GATT_AUTO_DISCOVER_CCC_HANDLE;
 	sub_params.disc_params = &ccc_disc_params;
 	sub_params.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;
 


### PR DESCRIPTION
Replace the magic number 0 with a #defined value for the auto CCC discovery feature.