### PR TITLE
dts: renesas: ra: Handle interrupt numbers generation for Renesas RA series

### DIFF
--- a/dts/arm/renesas/ra/ra2/ra2xx.dtsi
+++ b/dts/arm/renesas/ra/ra2/ra2xx.dtsi
@@ -9,6 +9,7 @@
 #include <zephyr/dt-bindings/pinctrl/renesas/pinctrl-ra.h>
 #include <zephyr/dt-bindings/clock/ra_clock.h>
 #include <freq.h>
+#include <zephyr/dt-bindings/interrupt-controller/renesas-ra-interrupt.h>
 
 / {
 	cpus {
@@ -23,6 +24,15 @@
 	};
 
 	soc {
+		interrupt-parent = <&icu>;
+		icu: interrupt-controller@40006000 {
+			compatible = "renesas,ra-interrupt-controller";
+			reg = <0x40006000 0x40>;
+			reg-names = "icu";
+			interrupt-controller;
+			#interrupt-cells = <2>;
+		};
+
 		system: system@4001e000 {
 			compatible = "renesas,ra-system";
 			reg = <0x4001e000 0x1000>;
@@ -137,7 +147,8 @@
 
 		sci0: sci@40070000 {
 			compatible = "renesas,ra-sci";
-			interrupts = <4 1>, <5 1>, <6 1>, <7 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40070000 0x20>;
 			clocks = <&pclkb MSTPB 31>;
@@ -151,7 +162,8 @@
 
 		sci1: sci@40070020 {
 			compatible = "renesas,ra-sci";
-			interrupts = <8 1>, <9 1>, <10 1>, <11 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40070020 0x20>;
 			clocks = <&pclkb MSTPB 30>;
@@ -165,7 +177,8 @@
 
 		sci2: sci@40070040 {
 			compatible = "renesas,ra-sci";
-			interrupts = <12 1>, <13 1>, <14 1>, <15 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40070040 0x20>;
 			clocks = <&pclkb MSTPB 29>;
@@ -179,7 +192,8 @@
 
 		sci3: sci@40070060 {
 			compatible = "renesas,ra-sci";
-			interrupts = <16 1>, <17 1>, <18 1>, <19 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40070060 0x20>;
 			clocks = <&pclkb MSTPB 28>;
@@ -193,7 +207,8 @@
 
 		sci9: sci@40070120 {
 			compatible = "renesas,ra-sci";
-			interrupts = <24 1>, <25 1>, <26 1>, <27 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40070120 0x20>;
 			clocks = <&pclkb MSTPB 22>;

--- a/dts/arm/renesas/ra/ra4/r7fa4m2ax.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4m2ax.dtsi
@@ -36,7 +36,8 @@
 
 		sci1: sci1@40118100 {
 			compatible = "renesas,ra-sci";
-			interrupts = <4 1>, <5 1>, <6 1>, <7 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40118100 0x100>;
 			clocks = <&pclka MSTPB 30>;
@@ -50,7 +51,8 @@
 
 		sci2: sci2@40118200 {
 			compatible = "renesas,ra-sci";
-			interrupts = <8 1>, <9 1>, <10 1>, <11 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40118200 0x100>;
 			clocks = <&pclka MSTPB 29>;
@@ -64,7 +66,8 @@
 
 		sci3: sci3@40118300 {
 			compatible = "renesas,ra-sci";
-			interrupts = <12 1>, <13 1>, <14 1>, <15 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40118300 0x100>;
 			clocks = <&pclka MSTPB 28>;
@@ -78,7 +81,8 @@
 
 		sci4: sci4@40118400 {
 			compatible = "renesas,ra-sci";
-			interrupts = <16 1>, <17 1>, <18 1>, <19 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40118400 0x100>;
 			clocks = <&pclka MSTPB 27>;

--- a/dts/arm/renesas/ra/ra4/r7fa4m3ax.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4m3ax.dtsi
@@ -46,7 +46,8 @@
 
 		sci1: sci1@40118100 {
 			compatible = "renesas,ra-sci";
-			interrupts = <4 1>, <5 1>, <6 1>, <7 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40118100 0x100>;
 			clocks = <&pclka MSTPB 30>;
@@ -60,7 +61,8 @@
 
 		sci2: sci2@40118200 {
 			compatible = "renesas,ra-sci";
-			interrupts = <8 1>, <9 1>, <10 1>, <11 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40118200 0x100>;
 			clocks = <&pclka MSTPB 29>;
@@ -74,7 +76,8 @@
 
 		sci3: sci3@40118300 {
 			compatible = "renesas,ra-sci";
-			interrupts = <12 1>, <13 1>, <14 1>, <15 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40118300 0x100>;
 			clocks = <&pclka MSTPB 28>;
@@ -88,7 +91,8 @@
 
 		sci4: sci4@40118400 {
 			compatible = "renesas,ra-sci";
-			interrupts = <16 1>, <17 1>, <18 1>, <19 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40118400 0x100>;
 			clocks = <&pclka MSTPB 27>;

--- a/dts/arm/renesas/ra/ra4/r7fa4w1ad2cng.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4w1ad2cng.dtsi
@@ -23,7 +23,8 @@
 
 		sci4: sci4@40070080  {
 			compatible = "renesas,ra-sci";
-			interrupts = <16 1>, <17 1>, <18 1>, <19 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40070080 0x20>;
 			clocks = <&pclka MSTPB 26>;

--- a/dts/arm/renesas/ra/ra4/ra4-cm33-common.dtsi
+++ b/dts/arm/renesas/ra/ra4/ra4-cm33-common.dtsi
@@ -8,6 +8,7 @@
 #include <arm/armv8-m.dtsi>
 #include <zephyr/dt-bindings/pinctrl/renesas/pinctrl-ra.h>
 #include <freq.h>
+#include <zephyr/dt-bindings/interrupt-controller/renesas-ra-interrupt.h>
 
 / {
 	cpus {
@@ -29,7 +30,14 @@
 	};
 
 	soc {
-		interrupt-parent = <&nvic>;
+		interrupt-parent = <&icu>;
+		icu: interrupt-controller@40006000 {
+			compatible = "renesas,ra-interrupt-controller";
+			reg = <0x40006000 0x40>;
+			reg-names = "icu";
+			interrupt-controller;
+			#interrupt-cells = <2>;
+		};
 
 		system: system@4001e000 {
 			compatible = "renesas,ra-system";
@@ -111,7 +119,8 @@
 
 		sci0: sci0@40118000 {
 			compatible = "renesas,ra-sci";
-			interrupts = <0 1>, <1 1>, <2 1>, <3 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40118000 0x100>;
 			clocks = <&pclka MSTPB 31>;
@@ -125,7 +134,8 @@
 
 		sci9: sci9@40118900 {
 			compatible = "renesas,ra-sci";
-			interrupts = <36 1>, <37 1>, <38 1>, <39 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40118900 0x100>;
 			clocks = <&pclka MSTPB 22>;

--- a/dts/arm/renesas/ra/ra4/ra4-cm4-common.dtsi
+++ b/dts/arm/renesas/ra/ra4/ra4-cm4-common.dtsi
@@ -8,6 +8,7 @@
 #include <arm/armv7-m.dtsi>
 #include <zephyr/dt-bindings/pinctrl/renesas/pinctrl-ra.h>
 #include <freq.h>
+#include <zephyr/dt-bindings/interrupt-controller/renesas-ra-interrupt.h>
 
 / {
 	cpus {
@@ -30,6 +31,15 @@
 	};
 
 	soc {
+		interrupt-parent = <&icu>;
+		icu: interrupt-controller@40006000 {
+			compatible = "renesas,ra-interrupt-controller";
+			reg = <0x40006000 0x40>;
+			reg-names = "icu";
+			interrupt-controller;
+			#interrupt-cells = <2>;
+		};
+
 		system: system@4001e000 {
 			compatible = "renesas,ra-system";
 			reg = <0x4001e000 0x1000>;
@@ -120,7 +130,8 @@
 
 		sci0: sci0@40070000  {
 			compatible = "renesas,ra-sci";
-			interrupts = <0 1>, <1 1>, <2 1>, <3 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40070000 0x20>;
 			clocks = <&pclka MSTPB 31>;
@@ -134,7 +145,8 @@
 
 		sci1: sci1@40070020  {
 			compatible = "renesas,ra-sci";
-			interrupts = <4 1>, <5 1>, <6 1>, <7 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40070020 0x20>;
 			clocks = <&pclka MSTPB 30>;
@@ -148,7 +160,8 @@
 
 		sci9: sci9@40070120  {
 			compatible = "renesas,ra-sci";
-			interrupts = <36 1>, <37 1>, <38 1>, <39 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40070120 0x20>;
 			clocks = <&pclka MSTPB 22>;

--- a/dts/arm/renesas/ra/ra6/r7fa6e10x.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6e10x.dtsi
@@ -36,7 +36,8 @@
 
 		sci1: sci1@40118100 {
 			compatible = "renesas,ra-sci";
-			interrupts = <4 1>, <5 1>, <6 1>, <7 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40118100 0x100>;
 			clocks = <&pclka MSTPB 30>;
@@ -50,7 +51,8 @@
 
 		sci2: sci2@40118200 {
 			compatible = "renesas,ra-sci";
-			interrupts = <8 1>, <9 1>, <10 1>, <11 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40118200 0x100>;
 			clocks = <&pclka MSTPB 29>;
@@ -64,7 +66,8 @@
 
 		sci3: sci3@40118300 {
 			compatible = "renesas,ra-sci";
-			interrupts = <12 1>, <13 1>, <14 1>, <15 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40118300 0x100>;
 			clocks = <&pclka MSTPB 28>;
@@ -78,7 +81,8 @@
 
 		sci4: sci4@40118400 {
 			compatible = "renesas,ra-sci";
-			interrupts = <16 1>, <17 1>, <18 1>, <19 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40118400 0x100>;
 			clocks = <&pclka MSTPB 27>;

--- a/dts/arm/renesas/ra/ra6/r7fa6m2af3cfb.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m2af3cfb.dtsi
@@ -13,7 +13,7 @@
 			reg = <0x407e0000 0x10000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
-			interrupts = <4 1>, <5 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "frdyi", "fiferr";
 
 			flash0: flash@0 {

--- a/dts/arm/renesas/ra/ra6/r7fa6m2ax.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m2ax.dtsi
@@ -16,7 +16,8 @@
 
 		sci5: sci5@400700a0 {
 			compatible = "renesas,ra-sci";
-			interrupts = <20 1>, <21 1>, <22 1>, <23 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x400700a0 0x20>;
 			clocks = <&pclka MSTPB 26>;
@@ -30,7 +31,8 @@
 
 		sci6: sci6@400700c0 {
 			compatible = "renesas,ra-sci";
-			interrupts = <24 1>, <25 1>, <26 1>, <27 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x400700c0 0x20>;
 			clocks = <&pclka MSTPB 25>;
@@ -44,7 +46,8 @@
 
 		sci7: sci7@400700e0 {
 			compatible = "renesas,ra-sci";
-			interrupts = <28 1>, <29 1>, <30 1>, <31 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x400700e0 0x20>;
 			clocks = <&pclka MSTPB 24>;

--- a/dts/arm/renesas/ra/ra6/r7fa6m3ax.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m3ax.dtsi
@@ -56,7 +56,8 @@
 
 		sci5: sci5@400700a0 {
 			compatible = "renesas,ra-sci";
-			interrupts = <20 1>, <21 1>, <22 1>, <23 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x400700a0 0x20>;
 			clocks = <&pclka MSTPB 26>;
@@ -70,7 +71,8 @@
 
 		sci6: sci6@400700c0 {
 			compatible = "renesas,ra-sci";
-			interrupts = <24 1>, <25 1>, <26 1>, <27 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x400700c0 0x20>;
 			clocks = <&pclka MSTPB 25>;
@@ -84,7 +86,8 @@
 
 		sci7: sci7@400700e0 {
 			compatible = "renesas,ra-sci";
-			interrupts = <28 1>, <29 1>, <30 1>, <31 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x400700e0 0x20>;
 			clocks = <&pclka MSTPB 24>;

--- a/dts/arm/renesas/ra/ra6/r7fa6m4ax.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m4ax.dtsi
@@ -16,7 +16,8 @@
 
 		sci1: sci1@40118100 {
 			compatible = "renesas,ra-sci";
-			interrupts = <4 1>, <5 1>, <6 1>, <7 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40118100 0x100>;
 			clocks = <&pclka MSTPB 30>;
@@ -30,7 +31,8 @@
 
 		sci2: sci2@40118200 {
 			compatible = "renesas,ra-sci";
-			interrupts = <8 1>, <9 1>, <10 1>, <11 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40118200 0x100>;
 			clocks = <&pclka MSTPB 29>;
@@ -44,7 +46,8 @@
 
 		sci3: sci3@40118300 {
 			compatible = "renesas,ra-sci";
-			interrupts = <12 1>, <13 1>, <14 1>, <15 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40118300 0x100>;
 			clocks = <&pclka MSTPB 28>;
@@ -58,7 +61,8 @@
 
 		sci4: sci4@40118400 {
 			compatible = "renesas,ra-sci";
-			interrupts = <16 1>, <17 1>, <18 1>, <19 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40118400 0x100>;
 			clocks = <&pclka MSTPB 27>;
@@ -72,7 +76,8 @@
 
 		sci5: sci5@40118500 {
 			compatible = "renesas,ra-sci";
-			interrupts = <20 1>, <21 1>, <22 1>, <23 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40118500 0x100>;
 			clocks = <&pclka MSTPB 26>;
@@ -86,7 +91,8 @@
 
 		sci6: sci6@40118600 {
 			compatible = "renesas,ra-sci";
-			interrupts = <24 1>, <25 1>, <26 1>, <27 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40118600 0x100>;
 			clocks = <&pclka MSTPB 25>;
@@ -100,7 +106,8 @@
 
 		sci7: sci7@40118700 {
 			compatible = "renesas,ra-sci";
-			interrupts = <28 1>, <29 1>, <30 1>, <31 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40118700 0x100>;
 			clocks = <&pclka MSTPB 24>;
@@ -114,7 +121,8 @@
 
 		sci8: sci8@40118800 {
 			compatible = "renesas,ra-sci";
-			interrupts = <32 1>, <33 1>, <34 1>, <35 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40118800 0x100>;
 			clocks = <&pclka MSTPB 23>;

--- a/dts/arm/renesas/ra/ra6/r7fa6m5xh.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m5xh.dtsi
@@ -76,7 +76,8 @@
 
 		sci1: sci1@40118100 {
 			compatible = "renesas,ra-sci";
-			interrupts = <4 1>, <5 1>, <6 1>, <7 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40118100 0x100>;
 			clocks = <&pclka MSTPB 30>;
@@ -90,7 +91,8 @@
 
 		sci2: sci2@40118200 {
 			compatible = "renesas,ra-sci";
-			interrupts = <8 1>, <9 1>, <10 1>, <11 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40118200 0x100>;
 			clocks = <&pclka MSTPB 29>;
@@ -104,7 +106,8 @@
 
 		sci3: sci3@40118300 {
 			compatible = "renesas,ra-sci";
-			interrupts = <12 1>, <13 1>, <14 1>, <15 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40118300 0x100>;
 			clocks = <&pclka MSTPB 28>;
@@ -118,7 +121,8 @@
 
 		sci4: sci4@40118400 {
 			compatible = "renesas,ra-sci";
-			interrupts = <16 1>, <17 1>, <18 1>, <19 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40118400 0x100>;
 			clocks = <&pclka MSTPB 27>;
@@ -132,7 +136,8 @@
 
 		sci5: sci5@40118500 {
 			compatible = "renesas,ra-sci";
-			interrupts = <20 1>, <21 1>, <22 1>, <23 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40118500 0x100>;
 			clocks = <&pclka MSTPB 26>;
@@ -146,7 +151,8 @@
 
 		sci6: sci6@40118600 {
 			compatible = "renesas,ra-sci";
-			interrupts = <24 1>, <25 1>, <26 1>, <27 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40118600 0x100>;
 			clocks = <&pclka MSTPB 25>;
@@ -160,7 +166,8 @@
 
 		sci7: sci7@40118700 {
 			compatible = "renesas,ra-sci";
-			interrupts = <28 1>, <29 1>, <30 1>, <31 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40118700 0x100>;
 			clocks = <&pclka MSTPB 24>;
@@ -174,7 +181,8 @@
 
 		sci8: sci8@40118800 {
 			compatible = "renesas,ra-sci";
-			interrupts = <32 1>, <33 1>, <34 1>, <35 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40118800 0x100>;
 			clocks = <&pclka MSTPB 23>;

--- a/dts/arm/renesas/ra/ra6/ra6-cm33-common.dtsi
+++ b/dts/arm/renesas/ra/ra6/ra6-cm33-common.dtsi
@@ -9,6 +9,7 @@
 #include <zephyr/dt-bindings/pinctrl/renesas/pinctrl-ra.h>
 #include <zephyr/dt-bindings/clock/ra_clock.h>
 #include <freq.h>
+#include <zephyr/dt-bindings/interrupt-controller/renesas-ra-interrupt.h>
 
 / {
 	cpus {
@@ -30,7 +31,14 @@
 	};
 
 	soc {
-		interrupt-parent = <&nvic>;
+		interrupt-parent = <&icu>;
+		icu: interrupt-controller@40006000 {
+			compatible = "renesas,ra-interrupt-controller";
+			reg = <0x40006000 0x40>;
+			reg-names = "icu";
+			interrupt-controller;
+			#interrupt-cells = <2>;
+		};
 
 		system: system@4001e000 {
 			compatible = "renesas,ra-system";
@@ -106,7 +114,8 @@
 
 		sci0: sci0@40118000 {
 			compatible = "renesas,ra-sci";
-			interrupts = <0 1>, <1 1>, <2 1>, <3 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40118000 0x100>;
 			clocks = <&pclka MSTPB 31>;
@@ -120,7 +129,8 @@
 
 		sci9: sci9@40118900 {
 			compatible = "renesas,ra-sci";
-			interrupts = <36 1>, <37 1>, <38 1>, <39 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40118900 0x100>;
 			clocks = <&pclka MSTPB 22>;

--- a/dts/arm/renesas/ra/ra6/ra6-cm4-common.dtsi
+++ b/dts/arm/renesas/ra/ra6/ra6-cm4-common.dtsi
@@ -9,6 +9,7 @@
 #include <zephyr/dt-bindings/pinctrl/renesas/pinctrl-ra.h>
 #include <zephyr/dt-bindings/clock/ra_clock.h>
 #include <freq.h>
+#include <zephyr/dt-bindings/interrupt-controller/renesas-ra-interrupt.h>
 
 / {
 	cpus {
@@ -30,6 +31,14 @@
 	};
 
 	soc {
+		interrupt-parent = <&icu>;
+		icu: interrupt-controller@40006000 {
+			compatible = "renesas,ra-interrupt-controller";
+			reg = <0x40006000 0x40>;
+			reg-names = "icu";
+			interrupt-controller;
+			#interrupt-cells = <2>;
+		};
 
 		system: system@4001e000 {
 			compatible = "renesas,ra-system";
@@ -125,7 +134,8 @@
 
 		sci0: sci0@40070000  {
 			compatible = "renesas,ra-sci";
-			interrupts = <0 1>, <1 1>, <2 1>, <3 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40070000 0x20>;
 			clocks = <&pclka MSTPB 31>;
@@ -139,7 +149,8 @@
 
 		sci1: sci1@40070020  {
 			compatible = "renesas,ra-sci";
-			interrupts = <4 1>, <5 1>, <6 1>, <7 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40070020 0x20>;
 			clocks = <&pclka MSTPB 30>;
@@ -153,7 +164,8 @@
 
 		sci2: sci2@40070040 {
 			compatible = "renesas,ra-sci";
-			interrupts = <8 1>, <9 1>, <10 1>, <11 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40070040 0x20>;
 			clocks = <&pclka MSTPB 29>;
@@ -167,7 +179,8 @@
 
 		sci3: sci3@40070060  {
 			compatible = "renesas,ra-sci";
-			interrupts = <12 1>, <13 1>, <14 1>, <15 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40070060 0x20>;
 			clocks = <&pclka MSTPB 27>;
@@ -181,7 +194,8 @@
 
 		sci4: sci4@40070080  {
 			compatible = "renesas,ra-sci";
-			interrupts = <16 1>, <17 1>, <18 1>, <19 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40070080 0x20>;
 			clocks = <&pclka MSTPB 26>;
@@ -195,7 +209,8 @@
 
 		sci8: sci8@40070100  {
 			compatible = "renesas,ra-sci";
-			interrupts = <32 1>, <33 1>, <34 1>, <35 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40070100 0x20>;
 			clocks = <&pclka MSTPB 23>;
@@ -209,7 +224,8 @@
 
 		sci9: sci9@40070120  {
 			compatible = "renesas,ra-sci";
-			interrupts = <36 1>, <37 1>, <38 1>, <39 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40070120 0x20>;
 			clocks = <&pclka MSTPB 22>;

--- a/dts/arm/renesas/ra/ra8/ra8x1.dtsi
+++ b/dts/arm/renesas/ra/ra8/ra8x1.dtsi
@@ -9,6 +9,7 @@
 #include <freq.h>
 #include <zephyr/dt-bindings/pinctrl/renesas/pinctrl-ra.h>
 #include <zephyr/dt-bindings/clock/ra_clock.h>
+#include <zephyr/dt-bindings/interrupt-controller/renesas-ra-interrupt.h>
 
 / {
 	cpus {
@@ -30,7 +31,14 @@
 	};
 
 	soc {
-		interrupt-parent = <&nvic>;
+		interrupt-parent = <&icu>;
+		icu: interrupt-controller@4000c000 {
+			compatible = "renesas,ra-interrupt-controller";
+			reg = <0x4000c000 0x40>;
+			reg-names = "icu";
+			interrupt-controller;
+			#interrupt-cells = <2>;
+		};
 
 		sram0: memory@22000000 {
 			compatible = "mmio-sram";
@@ -173,7 +181,8 @@
 		iic0: iic0@4025e000 {
 			compatible = "renesas,ra-iic";
 			channel = <0>;
-			interrupts = <87 1>, <88 1>, <89 1>, <90 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x4025E000 0x100>;
 			status = "disabled";
@@ -181,7 +190,8 @@
 		iic1: iic1@4025e100 {
 			compatible = "renesas,ra-iic";
 			channel = <1>;
-			interrupts = <91 1>, <92 1>, <93 1>, <94 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x4025E100 0x100>;
 			status = "disabled";
@@ -189,7 +199,8 @@
 
 		sci0: sci0@40358000 {
 			compatible = "renesas,ra-sci";
-			interrupts = <4 1>, <5 1>, <6 1>, <7 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40358000 0x100>;
 			clocks = <&sciclk MSTPB 31>;
@@ -203,7 +214,8 @@
 
 		sci1: sci1@40358100 {
 			compatible = "renesas,ra-sci";
-			interrupts = <8 1>, <9 1>, <10 1>, <11 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40358100 0x100>;
 			clocks = <&sciclk MSTPB 30>;
@@ -217,7 +229,8 @@
 
 		sci2: sci2@40358200 {
 			compatible = "renesas,ra-sci";
-			interrupts = <12 1>, <13 1>, <14 1>, <15 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40358200 0x100>;
 			clocks = <&sciclk MSTPB 29>;
@@ -231,7 +244,8 @@
 
 		sci3: sci3@40358300 {
 			compatible = "renesas,ra-sci";
-			interrupts = <16 1>, <17 1>, <18 1>, <19 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40358300 0x100>;
 			clocks = <&sciclk MSTPB 28>;
@@ -245,7 +259,8 @@
 
 		sci4: sci4@40358400 {
 			compatible = "renesas,ra-sci";
-			interrupts = <20 1>, <21 1>, <22 1>, <23 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40358400 0x100>;
 			clocks = <&sciclk MSTPB 27>;
@@ -259,7 +274,8 @@
 
 		sci9: sci9@40358900 {
 			compatible = "renesas,ra-sci";
-			interrupts = <24 1>, <25 1>, <26 1>, <27 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x40358900 0x100>;
 			clocks = <&sciclk MSTPB 22>;
@@ -276,13 +292,13 @@
 			reg = <0x40100000 0x20000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
-			interrupts = <38 2>, <39 2>;
+			interrupts = <RA_ICU_UNSPECIFIED 2>, <RA_ICU_UNSPECIFIED 2>;
 			interrupt-names = "frdyi", "fiferr";
 		};
 
 		adc0: adc@40332000 {
 			compatible = "renesas,ra-adc";
-			interrupts = <38 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "scanend";
 			reg = <0x40332000 0x100>;
 			#io-channel-cells = <1>;
@@ -293,7 +309,7 @@
 
 		adc1: adc@40332200 {
 			compatible = "renesas,ra-adc";
-			interrupts = <39 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "scanend";
 			reg = <0x40332200 0x100>;
 			#io-channel-cells = <1>;
@@ -313,7 +329,8 @@
 			channel = <0>;
 			clocks = <&pclka MSTPB 19>;
 			clock-names = "spiclk";
-			interrupts = <28 1>, <29 1>, <30 1>, <31 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x4035c000 0x100>;
 			status = "disabled";
@@ -326,7 +343,8 @@
 			channel = <1>;
 			clocks = <&pclka MSTPB 18>;
 			clock-names = "spiclk";
-			interrupts = <32 1>, <33 1>, <34 1>, <35 1>;
+			interrupts = <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>,
+					 <RA_ICU_UNSPECIFIED 1>, <RA_ICU_UNSPECIFIED 1>;
 			interrupt-names = "rxi", "txi", "tei", "eri";
 			reg = <0x4035c100 0x100>;
 			status = "disabled";

--- a/dts/bindings/interrupt-controller/renesas,ra-interrupt-controller.yaml
+++ b/dts/bindings/interrupt-controller/renesas,ra-interrupt-controller.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2024 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+description: Renesas RA series interrupt controller
+
+compatible: "renesas,ra-interrupt-controller"
+
+include: [interrupt-controller.yaml, base.yaml]
+
+properties:
+  reg:
+    required: true
+
+  "#interrupt-cells":
+    const: 2
+
+interrupt-cells:
+  - irq
+  - priority

--- a/include/zephyr/dt-bindings/interrupt-controller/renesas-ra-interrupt.h
+++ b/include/zephyr/dt-bindings/interrupt-controller/renesas-ra-interrupt.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DT_BINDINGS_INTERRUPT_CONTROLLER_RENESAS_RA_INTERRUPT_H_
+#define ZEPHYR_DT_BINDINGS_INTERRUPT_CONTROLLER_RENESAS_RA_INTERRUPT_H_
+
+/* When using macros in the device tree, the interrupt numbers will be
+ * automatically filled in by the script.
+ */
+#define RA_ICU_UNSPECIFIED (0xff)
+
+#endif /* ZEPHYR_DT_BINDINGS_INTERRUPT_CONTROLLER_RENESAS_RA_INTERRUPT_H_ */


### PR DESCRIPTION
This PR updates interrupt number for Renesas RA boards (for current supported boards, RA2L1 will be supported later) to avoid full of interrupt ID.
(related to PR #78579).
We will add `map_renesas_ra_irq` function in `gen_defines.py` script to intervene in the generation of the device tree during build.
Only nodes with `status = "okay";` will have their interrupt IDs generated as valid numbers in `devicetree_generated.h`. The others will be assigned interrupt IDs with the unspecified value (0xff). 
This will help conserve the interrupt IDs allocated in `isr_table.c`.