### PR TITLE
net: lib: http_server: fix print format for 64-bit platforms

### DIFF
--- a/subsys/net/lib/http/http_server_http1.c
+++ b/subsys/net/lib/http/http_server_http1.c
@@ -237,7 +237,7 @@ static int http1_dynamic_response(struct http_client_ctx *client, struct http_re
 
 	/* Send body data if provided */
 	if (rsp->body != NULL && rsp->body_len > 0) {
-		ret = snprintk(tmp, sizeof(tmp), "%x\r\n", rsp->body_len);
+		ret = snprintk(tmp, sizeof(tmp), "%zx\r\n", rsp->body_len);
 		ret = http_server_sendall(client, tmp, ret);
 		if (ret < 0) {
 			return ret;


### PR DESCRIPTION
The "body_len" field of "struct http_response_ctx" is 64-bit (size_t type) on 64-bit platforms. As such, using the "%x" format to print it will generate build warnings such as:

"error: format '%x' expects argument of type 'unsigned int', but argument 4 has type 'size_t' {aka 'long unsigned int'} [-Werror=format=]"

Fix this issue by switching the format to "%zx" from "%x".

To reproduce:

`west build -p -b imx8mp_evk//a53 tests/net/lib/http_server/core/`
or
`west build -p -b imx95_evk//a55 tests/net/lib/http_server/core/`

Any 64-bit platform should do the trick. The issue was encountered in https://github.com/zephyrproject-rtos/zephyr/pull/78749.