### PR TITLE
Updated adxl345 sensor driver to utilze devicetree configuration

### DIFF
--- a/drivers/sensor/adi/adxl345/adxl345.c
+++ b/drivers/sensor/adi/adxl345/adxl345.c
@@ -96,6 +96,22 @@ static inline int adxl345_reg_read_byte(const struct device *dev, uint8_t addr, 
 	return adxl345_reg_read(dev, addr, buf, 1);
 }
 
+int adxl345_reg_write_mask(const struct device *dev, uint8_t reg_addr, uint32_t mask, uint8_t data)
+{
+	int ret;
+	uint8_t tmp;
+
+	ret = adxl345_reg_read_byte(dev, reg_addr, &tmp);
+	if (ret != 0) {
+		return ret;
+	}
+
+	tmp &= ~mask;
+	tmp |= data;
+
+	return adxl345_reg_write_byte(dev, reg_addr, tmp);
+}
+
 static inline bool adxl345_bus_is_ready(const struct device *dev)
 {
 	const struct adxl345_dev_config *cfg = dev->config;
@@ -106,7 +122,6 @@ static inline bool adxl345_bus_is_ready(const struct device *dev)
 static int adxl345_read_sample(const struct device *dev,
 			       struct adxl345_sample *sample)
 {
-	int16_t raw_x, raw_y, raw_z;
 	uint8_t axis_data[6];
 
 	int rc = adxl345_reg_read(dev, ADXL345_X_AXIS_DATA_0_REG, axis_data, 6);
@@ -116,25 +131,18 @@ static int adxl345_read_sample(const struct device *dev,
 		return rc;
 	}
 
-	raw_x = axis_data[0] | (axis_data[1] << 8);
-	raw_y = axis_data[2] | (axis_data[3] << 8);
-	raw_z = axis_data[4] | (axis_data[5] << 8);
-
-	sample->x = raw_x;
-	sample->y = raw_y;
-	sample->z = raw_z;
+	sample->x = axis_data[0] | (((int16_t)axis_data[1]) << 8);
+	sample->y = axis_data[2] | (((int16_t)axis_data[3]) << 8);
+	sample->z = axis_data[4] | (((int16_t)axis_data[5]) << 8);
 
 	return 0;
 }
 
-static void adxl345_accel_convert(struct sensor_value *val, int16_t sample)
+static void adxl345_accel_convert(struct sensor_value *val, int16_t sample, uint16_t scale)
 {
-	if (sample & BIT(9)) {
-		sample |= ADXL345_COMPLEMENT;
-	}
+	int64_t micro_g = (sample * scale) * 1000;
 
-	val->val1 = ((sample * SENSOR_G) / 32) / 1000000;
-	val->val2 = ((sample * SENSOR_G) / 32) % 1000000;
+	sensor_ug_to_ms2(micro_g, val);
 }
 
 static int adxl345_sample_fetch(const struct device *dev,
@@ -146,10 +154,15 @@ static int adxl345_sample_fetch(const struct device *dev,
 	int rc;
 
 	data->sample_number = 0;
-	rc = adxl345_reg_read_byte(dev, ADXL345_FIFO_STATUS_REG, &samples_count);
-	if (rc < 0) {
-		LOG_ERR("Failed to read FIFO status rc = %d\n", rc);
-		return rc;
+
+	if (data->fifo_mode == ADXL345_FIFO_BYPASS) {
+		samples_count = 1;
+	} else {
+		rc = adxl345_reg_read_byte(dev, ADXL345_FIFO_STATUS_REG, &samples_count);
+		if (rc < 0) {
+			LOG_ERR("Failed to read FIFO status rc = %d\n", rc);
+			return rc;
+		}
 	}
 
 	__ASSERT_NO_MSG(samples_count <= ARRAY_SIZE(data->bufx));
@@ -180,21 +193,21 @@ static int adxl345_channel_get(const struct device *dev,
 
 	switch (chan) {
 	case SENSOR_CHAN_ACCEL_X:
-		adxl345_accel_convert(val, data->bufx[data->sample_number]);
+		adxl345_accel_convert(val, data->bufx[data->sample_number], data->scale_factor);
 		data->sample_number++;
 		break;
 	case SENSOR_CHAN_ACCEL_Y:
-		adxl345_accel_convert(val, data->bufy[data->sample_number]);
+		adxl345_accel_convert(val, data->bufy[data->sample_number], data->scale_factor);
 		data->sample_number++;
 		break;
 	case SENSOR_CHAN_ACCEL_Z:
-		adxl345_accel_convert(val, data->bufz[data->sample_number]);
+		adxl345_accel_convert(val, data->bufz[data->sample_number], data->scale_factor);
 		data->sample_number++;
 		break;
 	case SENSOR_CHAN_ACCEL_XYZ:
-		adxl345_accel_convert(val++, data->bufx[data->sample_number]);
-		adxl345_accel_convert(val++, data->bufy[data->sample_number]);
-		adxl345_accel_convert(val,   data->bufz[data->sample_number]);
+		adxl345_accel_convert(val++, data->bufx[data->sample_number], data->scale_factor);
+		adxl345_accel_convert(val++, data->bufy[data->sample_number], data->scale_factor);
+		adxl345_accel_convert(val, data->bufz[data->sample_number], data->scale_factor);
 		data->sample_number++;
 		break;
 	default:
@@ -209,10 +222,109 @@ static const struct sensor_driver_api adxl345_api_funcs = {
 	.channel_get = adxl345_channel_get,
 };
 
+static int adxl345_set_output_rate(const struct device *dev, const enum adxl345_odr odr)
+{
+	int rc = adxl345_reg_write_mask(dev, ADXL345_BW_RATE_REG, ADXL345_BW_RATE_RATE_MSK, odr);
+
+	if (rc < 0) {
+		return -EIO;
+	}
+
+	return rc;
+}
+
+static int adxl345_set_range(const struct device *dev, const enum adxl345_range range)
+{
+	int rc;
+	struct adxl345_dev_data *data = dev->data;
+
+	rc = adxl345_reg_write_mask(dev, ADXL345_DATA_FORMAT_REG, ADXL345_DATA_FORMAT_RANGE_MSK,
+				    range);
+	if (rc < 0) {
+		return -EIO;
+	}
+
+	switch (range) {
+	case ADXL345_2G_RANGE:
+		data->scale_factor = 4;
+		break;
+	case ADXL345_4G_RANGE:
+		data->scale_factor = 8;
+		break;
+	case ADXL345_8G_RANGE:
+		data->scale_factor = 16;
+		break;
+	case ADXL345_16G_RANGE:
+	default:
+		data->scale_factor = 32;
+		break;
+	}
+
+	return rc;
+}
+
+static enum adxl345_odr adxl345_map_odr(int frequency)
+{
+	switch (frequency) {
+	case 6:
+		return ADXL345_ODR_6P25HZ;
+	case 12:
+		return ADXL345_ODR_12P5HZ;
+	case 25:
+		return ADXL345_ODR_25HZ;
+	case 50:
+		return ADXL345_ODR_50HZ;
+	case 100:
+		return ADXL345_ODR_100HZ;
+	case 200:
+		return ADXL345_ODR_200HZ;
+	case 400:
+		return ADXL345_ODR_400HZ;
+	default:
+		LOG_WRN("Invalid ADXL345 frequency received, set to 100Hz");
+		return ADXL345_ODR_100HZ;
+	}
+}
+
+static enum adxl345_range adxl345_map_range(int range)
+{
+	switch (range) {
+	case 2:
+		return ADXL345_2G_RANGE;
+	case 4:
+		return ADXL345_4G_RANGE;
+	case 8:
+		return ADXL345_8G_RANGE;
+	case 16:
+		return ADXL345_16G_RANGE;
+	default:
+		LOG_WRN("Invalid ADXL345 range received, set to 16G");
+		return ADXL345_16G_RANGE;
+	}
+}
+
+static enum adxl345_fifo adxl345_map_fifo(int fifo_mode)
+{
+	switch (fifo_mode) {
+	case 0:
+		return ADXL345_FIFO_BYPASS;
+	case 1:
+		return ADXL345_FIFO_FIFO;
+	case 2:
+		return ADXL345_FIFO_STREAM;
+	case 3:
+		return ADXL345_FIFO_TRIGGER;
+	default:
+		LOG_WRN("Invalid ADXL345 range received, set to bypass");
+		return ADXL345_FIFO_BYPASS;
+	}
+}
+
 static int adxl345_init(const struct device *dev)
 {
 	int rc;
 	struct adxl345_dev_data *data = dev->data;
+	const struct adxl345_dev_config *cfg = dev->config;
 	uint8_t dev_id;
 
 	data->sample_number = 0;
@@ -223,30 +335,33 @@ static int adxl345_init(const struct device *dev)
 	}
 
 	rc = adxl345_reg_read_byte(dev, ADXL345_DEVICE_ID_REG, &dev_id);
-	if (rc < 0 || dev_id != ADXL345_PART_ID) {
+	if (rc < 0 || dev_id != ADXL345_DEVICE_ID_VALUE) {
 		LOG_ERR("Read PART ID failed: 0x%x\n", rc);
 		return -ENODEV;
 	}
 
-	rc = adxl345_reg_write_byte(dev, ADXL345_FIFO_CTL_REG, ADXL345_FIFO_STREAM_MODE);
+	data->fifo_mode = adxl345_map_fifo(cfg->fifo_mode);
+	rc = adxl345_reg_write_byte(dev, ADXL345_FIFO_CTL_REG, data->fifo_mode);
 	if (rc < 0) {
 		LOG_ERR("FIFO enable failed\n");
 		return -EIO;
 	}
 
-	rc = adxl345_reg_write_byte(dev, ADXL345_DATA_FORMAT_REG, ADXL345_RANGE_16G);
+	data->range = adxl345_map_range(cfg->range);
+	rc = adxl345_set_range(dev, data->range);
 	if (rc < 0) {
 		LOG_ERR("Data format set failed\n");
 		return -EIO;
 	}
 
-	rc = adxl345_reg_write_byte(dev, ADXL345_RATE_REG, ADXL345_RATE_25HZ);
+	data->odr = adxl345_map_odr(cfg->frequency);
+	rc = adxl345_set_output_rate(dev, data->odr);
 	if (rc < 0) {
 		LOG_ERR("Rate setting failed\n");
 		return -EIO;
 	}
 
-	rc = adxl345_reg_write_byte(dev, ADXL345_POWER_CTL_REG, ADXL345_ENABLE_MEASURE_BIT);
+	rc = adxl345_reg_write_byte(dev, ADXL345_POWER_CTL_REG, ADXL345_POWER_CTL_REG_MEASURE_BIT);
 	if (rc < 0) {
 		LOG_ERR("Enable measure bit failed\n");
 		return -EIO;
@@ -254,6 +369,11 @@ static int adxl345_init(const struct device *dev)
 
 	return 0;
 }
+
+#define ADXL345_CONFIG(inst)                                                                       \
+	.frequency = DT_INST_PROP(inst, frequency), .range = DT_INST_PROP(inst, range),            \
+	.fifo_mode = DT_INST_PROP(inst, fifo),
+
 
 #define ADXL345_CONFIG_SPI(inst)                                       \
 	{                                                              \
@@ -265,6 +385,7 @@ static int adxl345_init(const struct device *dev)
 						    0)},               \
 		.bus_is_ready = adxl345_bus_is_ready_spi,              \
 		.reg_access = adxl345_reg_access_spi,                  \
+		ADXL345_CONFIG(inst)                                   \
 	}
 
 #define ADXL345_CONFIG_I2C(inst)			    \
@@ -272,6 +393,7 @@ static int adxl345_init(const struct device *dev)
 		.bus = {.i2c = I2C_DT_SPEC_INST_GET(inst)}, \
 		.bus_is_ready = adxl345_bus_is_ready_i2c,   \
 		.reg_access = adxl345_reg_access_i2c,	    \
+		ADXL345_CONFIG(inst)                        \
 	}
 
 #define ADXL345_DEFINE(inst)								\

--- a/drivers/sensor/adi/adxl345/adxl345.h
+++ b/drivers/sensor/adi/adxl345/adxl345.h
@@ -7,6 +7,7 @@
 #ifndef ZEPHYR_DRIVERS_SENSOR_ADX345_ADX345_H_
 #define ZEPHYR_DRIVERS_SENSOR_ADX345_ADX345_H_
 
+#include <zephyr/drivers/sensor.h>
 #include <zephyr/types.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
@@ -19,32 +20,129 @@
 #include <zephyr/sys/util.h>
 
 /* ADXL345 communication commands */
-#define ADXL345_WRITE_CMD          0x00
-#define ADXL345_READ_CMD           0x80
-#define ADXL345_MULTIBYTE_FLAG     0x40
+#define ADXL345_WRITE_CMD      0x00
+#define ADXL345_READ_CMD       0x80
+#define ADXL345_MULTIBYTE_FLAG 0x40
 
 /* Registers */
-#define ADXL345_DEVICE_ID_REG      0x00
-#define ADXL345_RATE_REG           0x2c
-#define ADXL345_POWER_CTL_REG      0x2d
-#define ADXL345_DATA_FORMAT_REG    0x31
-#define ADXL345_X_AXIS_DATA_0_REG  0x32
-#define ADXL345_FIFO_CTL_REG       0x38
-#define ADXL345_FIFO_STATUS_REG    0x39
+/* ADXL345 DEVICE_ID register */
+#define ADXL345_DEVICE_ID_REG   0x00
+#define ADXL345_DEVICE_ID_VALUE 0b11100101
 
-#define ADXL345_PART_ID            0xe5
+/* ADXL345 THRESH_TAP register */
+#define ADXL345_THRESH_TAP_REG 0x1D
 
-#define ADXL345_RANGE_2G           0x0
-#define ADXL345_RANGE_4G           0x1
-#define ADXL345_RANGE_8G           0x2
-#define ADXL345_RANGE_16G          0x3
-#define ADXL345_RATE_25HZ          0x8
-#define ADXL345_ENABLE_MEASURE_BIT (1 << 3)
-#define ADXL345_FIFO_STREAM_MODE   (1 << 7)
-#define ADXL345_FIFO_COUNT_MASK    0x3f
-#define ADXL345_COMPLEMENT         0xfc00
+/* ADXL345 DUR register */
+#define ADXL345_DUR_REG 0x21
 
-#define ADXL345_MAX_FIFO_SIZE      32
+/* ADXL345 THRESH_ACT register */
+#define ADXL345_THRESH_ACT_REG 0x24
+
+/* ADXL345 THRESH_INACT register */
+#define ADXL345_THRESH_INACT_REG 0x25
+
+/* ADXL345 TIME_INACT register */
+#define ADXL345_TIME_INACT_REG 0x26
+
+/* ADXL345 ACT_INACT_CTL register */
+#define ADXL345_ACT_INACT_CTL_REG                0x27
+#define ADXL345_ACT_INACT_CTL_ACT_DECOUPLE_MSK   BIT(7)
+#define ADXL345_ACT_INACT_CTL_ACT_AXIS_MSK       GENMASK(6, 4)
+#define ADXL345_ACT_INACT_CTL_INACT_DECOUPLE_MSK BIT(3)
+#define ADXL345_ACT_INACT_CTL_INACT_AXIS_MSK     GENMASK(2, 0)
+
+/* ADXL345 THRESH_FF register */
+#define ADXL345_THRESH_FF_REG 0x28
+/* ADXL345 TIME_FF register */
+#define ADXL345_TIME_FF_REG   0x29
+
+/* ADXL345 TAP_AXES register */
+#define ADXL345_TAP_AXES_REG          0x2A
+#define ADXL345_TAP_AXES_TAP_AXIS_MSK GENMASK(2, 0)
+
+/* ADXL345 BW_RATE register */
+#define ADXL345_BW_RATE_REG           0x2C
+#define ADXL345_BW_RATE_RATE_MSK      GENMASK(3, 0)
+#define ADXL345_BW_RATE_LOW_POWER_MSK BIT(4)
+
+/* ADXL345 POWER_CTL register */
+#define ADXL345_POWER_CTL_REG             0x2D
+#define ADXL345_POWER_CTL_REG_MEASURE_BIT BIT(3)
+#define ADXL345_POWER_CTL_LINK_BIT        BIT(5)
+
+/* ADXL345 INT_ENABLE register */
+#define ADXL345_INT_ENABLE_REG            0x2E
+#define ADXL345_INT_ENABLE_WATERMARK_BIT  BIT(1)
+#define ADXL345_INT_ENABLE_FREE_FALL_BIT  BIT(2)
+#define ADXL345_INT_ENABLE_INACTIVE_BIT   BIT(3)
+#define ADXL345_INT_ENABLE_ACTIVE_BIT     BIT(4)
+#define ADXL345_INT_ENABLE_DOUBLE_TAP_BIT BIT(5)
+#define ADXL345_INT_ENABLE_SINGLE_TAP_BIT BIT(6)
+#define ADXL345_INT_ENABLE_DATA_READY_BIT BIT(7)
+
+/* ADXL345 INT_SOURCE register */
+#define ADXL345_INT_SOURCE_REG            0x30
+#define ADXL345_INT_SOURCE_WATERMARK_BIT  BIT(1)
+#define ADXL345_INT_SOURCE_FREE_FALL_BIT  BIT(2)
+#define ADXL345_INT_SOURCE_INACTIVE_BIT   BIT(3)
+#define ADXL345_INT_SOURCE_ACTIVE_BIT     BIT(4)
+#define ADXL345_INT_SOURCE_DOUBLE_TAP_BIT BIT(5)
+#define ADXL345_INT_SOURCE_SINGLE_TAP_BIT BIT(6)
+#define ADXL345_INT_SOURCE_DATA_READY_BIT BIT(7)
+
+/* ADXL345 DATA_FORMAT register */
+#define ADXL345_DATA_FORMAT_REG       0x31
+#define ADXL345_DATA_FORMAT_RANGE_MSK GENMASK(1, 0)
+
+/* ADXL345 DATAX0, etc registers */
+#define ADXL345_X_AXIS_DATA_0_REG 0x32
+
+/* ADXL345 FIFO_CTL register */
+#define ADXL345_FIFO_CTL_REG        0x38
+#define ADXL345_FIFO_CTL_FIFO_MSK   GENMASK(7, 6)
+#define ADXL345_FIFO_CTL_SAMPLE_MSK GENMASK(4, 0)
+
+/* ADXL345 FIFO_STATUS register */
+#define ADXL345_FIFO_STATUS_REG 0x39
+
+/* Sensor properties definitions */
+/* ADXL345 FIFO size */
+#define ADXL345_MAX_FIFO_SIZE 32
+#define ADXL345_COMPLEMENT    0xfc00
+
+/* ADXL345 supported sampling frequencies */
+enum adxl345_odr {
+	ADXL345_ODR_6P25HZ = BIT(2) | BIT(1),
+	ADXL345_ODR_12P5HZ = BIT(2) | BIT(1) | BIT(0),
+	ADXL345_ODR_25HZ = BIT(3),
+	ADXL345_ODR_50HZ = BIT(3) | BIT(0),
+	ADXL345_ODR_100HZ = BIT(3) | BIT(1),
+	ADXL345_ODR_200HZ = BIT(3) | BIT(2),
+	ADXL345_ODR_400HZ = BIT(3) | BIT(2) | BIT(0),
+};
+
+/* ADXL345 supported sampling ranges */
+enum adxl345_range {
+	ADXL345_2G_RANGE = 0,
+	ADXL345_4G_RANGE = BIT(0),
+	ADXL345_8G_RANGE = BIT(1),
+	ADXL345_16G_RANGE = BIT(1) | BIT(0),
+};
+
+/* ADXL345 supported fifo modes */
+enum adxl345_fifo {
+	ADXL345_FIFO_BYPASS = 0,
+	ADXL345_FIFO_FIFO = BIT(6),
+	ADXL345_FIFO_STREAM = BIT(7),
+	ADXL345_FIFO_TRIGGER = GENMASK(7, 6),
+};
+
+/* ADXL345 sample */
+struct adxl345_sample {
+	int16_t x;
+	int16_t y;
+	int16_t z;
+};
 
 struct adxl345_dev_data {
 	unsigned int sample_number;
@@ -52,12 +150,11 @@ struct adxl345_dev_data {
 	int16_t bufx[ADXL345_MAX_FIFO_SIZE];
 	int16_t bufy[ADXL345_MAX_FIFO_SIZE];
 	int16_t bufz[ADXL345_MAX_FIFO_SIZE];
-};
 
-struct adxl345_sample {
-	int16_t x;
-	int16_t y;
-	int16_t z;
+	enum adxl345_odr odr;
+	enum adxl345_range range;
+	enum adxl345_fifo fifo_mode;
+	uint16_t scale_factor;
 };
 
 union adxl345_bus {
@@ -70,13 +167,17 @@ union adxl345_bus {
 };
 
 typedef bool (*adxl345_bus_is_ready_fn)(const union adxl345_bus *bus);
-typedef int (*adxl345_reg_access_fn)(const struct device *dev, uint8_t cmd,
-				     uint8_t reg_addr, uint8_t *data, size_t length);
+typedef int (*adxl345_reg_access_fn)(const struct device *dev, uint8_t cmd, uint8_t reg_addr,
+				     uint8_t *data, size_t length);
 
 struct adxl345_dev_config {
 	const union adxl345_bus bus;
 	adxl345_bus_is_ready_fn bus_is_ready;
 	adxl345_reg_access_fn reg_access;
+
+	uint16_t frequency;
+	uint8_t range;
+	uint8_t fifo_mode;
 };
 
 #endif /* ZEPHYR_DRIVERS_SENSOR_ADX345_ADX345_H_ */

--- a/dts/bindings/sensor/adi,adxl345-common.yaml
+++ b/dts/bindings/sensor/adi,adxl345-common.yaml
@@ -1,0 +1,49 @@
+# Copyright (c) 2024 Andreas Karner <andreaskarner@outlook.com>
+# SPDX-License-Identifier: Apache-2.0
+
+description: ADXL345 3-axis I2C accelerometer
+
+include: [sensor-device.yaml]
+
+properties:
+  frequency:
+    type: int
+    default: 100
+    description: |
+          Accelerometer sampling frequency (ODR).
+          Default is power on reset value (100 Hz).
+    enum:
+      - 6
+      - 12
+      - 25
+      - 50
+      - 100
+      - 200
+      - 400
+
+  range:
+    type: int
+    default: 2
+    description: |
+      Accelerometer sampling range in G.
+      Default is power on reset value (2 G).
+    enum:
+      - 2
+      - 4
+      - 8
+      - 16
+
+  fifo:
+    type: int
+    default: 0
+    description: |
+      Accelerometer fifo mode.
+      Default is power on reset value (0 - Bypass).
+      0 - Bypass(no FIFO mode)
+      1 - FIFO
+      2 - Stream
+      3 - Trigger (not supported yet)
+    enum:
+      - 0
+      - 1
+      - 2

--- a/dts/bindings/sensor/adi,adxl345-i2c.yaml
+++ b/dts/bindings/sensor/adi,adxl345-i2c.yaml
@@ -5,4 +5,4 @@ description: ADXL345 3-axis I2C accelerometer
 
 compatible: "adi,adxl345"
 
-include: [sensor-device.yaml, i2c-device.yaml]
+include: [i2c-device.yaml, "adi,adxl345-common.yaml"]

--- a/dts/bindings/sensor/adi,adxl345-spi.yaml
+++ b/dts/bindings/sensor/adi,adxl345-spi.yaml
@@ -5,4 +5,4 @@ description: ADXL345 3-axis accelerometer with SPI connection
 
 compatible: "adi,adxl345"
 
-include: [sensor-device.yaml, spi-device.yaml]
+include: [spi-device.yaml, "adi,adxl345-common.yaml"]


### PR DESCRIPTION
Followup PR of: https://github.com/zephyrproject-rtos/zephyr/pull/66046

Updated/rewritten adxl345 sensor code to support devicetree parameters. I have tested the code with an nrf52840-dk and a adxl345 connected via I2C.