### PR TITLE
scripts: twister: Fix trailing CR/LF at BinaryHandler logs

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -216,10 +216,9 @@ class BinaryHandler(Handler):
                 reader_t.join(this_timeout)
                 if not reader_t.is_alive() and self.line != b"":
                     line_decoded = self.line.decode('utf-8', "replace")
-                    if line_decoded.endswith(suffix):
-                        stripped_line = line_decoded[:-len(suffix)].rstrip()
-                    else:
-                        stripped_line = line_decoded.rstrip()
+                    stripped_line = line_decoded.rstrip()
+                    if stripped_line.endswith(suffix):
+                        stripped_line = stripped_line[:-len(suffix)].rstrip()
                     logger.debug("OUTPUT: %s", stripped_line)
                     log_out_fp.write(strip_ansi_sequences(line_decoded))
                     log_out_fp.flush()

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -297,17 +297,19 @@ def test_binaryhandler_try_kill_process_by_pid(mocked_instance):
 
 TESTDATA_3 = [
     (
-        [b'This\\r\\n', b'is\r', b'a short', b'file.'],
+        [b'This\\r\\n\n', b'is\r', b'some \x1B[31mANSI\x1B[39m in\n', b'a short\n', b'file.'],
         mock.Mock(status=TwisterStatus.NONE, capture_coverage=False),
         [
-            mock.call('This\\r\\n'),
+            mock.call('This\\r\\n\n'),
             mock.call('is\r'),
-            mock.call('a short'),
+            mock.call('some ANSI in\n'),
+            mock.call('a short\n'),
             mock.call('file.')
         ],
         [
             mock.call('This'),
             mock.call('is'),
+            mock.call('some \x1B[31mANSI\x1B[39m in'),
             mock.call('a short'),
             mock.call('file.')
         ],


### PR DESCRIPTION
Fix trailing `\\r\\n` (escaped CR/LF) didn't cut off because of `rstrip()` removed by #58338,
so the CR/LF suffix was never found as the actual line end was `\\r\\n\n`.

Add ANSI code sequence to `test_handlers` Twister unit test.

// AFAIK, the issue should affect only Simics simulators.