### PR TITLE
doc: extensions: samples: Add "browse source code" button

### DIFF
--- a/doc/_extensions/zephyr/domain/__init__.py
+++ b/doc/_extensions/zephyr/domain/__init__.py
@@ -102,6 +102,19 @@ class ConvertCodeSampleNode(SphinxTransform):
             new_section = nodes.section(ids=[node["id"]])
             new_section += nodes.title(text=node["name"])
 
+            gh_link = gh_link_get_url(self.app, self.env.docname)
+            gh_link_button = nodes.raw(
+                "",
+                f"""
+                <a href="{gh_link}/.." class="btn btn-info fa fa-github"
+                    target="_blank" style="text-align: center;">
+                    Browse source code on GitHub
+                </a>
+                """,
+                format="html",
+            )
+            new_section += nodes.paragraph("", "", gh_link_button)
+
             # Move the sibling nodes under the new section
             new_section.extend(siblings_to_move)
 

--- a/samples/hello_world/README.rst
+++ b/samples/hello_world/README.rst
@@ -3,9 +3,6 @@
 
    Print "Hello World" to the console.
 
-Hello World
-###########
-
 Overview
 ********
 


### PR DESCRIPTION
https://builds.zephyrproject.io/zephyr/pr/78960/docs/samples/hello_world/README.html

One of the first thing one wants to do when reading about a code sample is checking the code itself. This commit adds a button to directly take the user to the code sample's source code on GitHub.

<img width="1119" alt="image" src="https://github.com/user-attachments/assets/909548c9-eeac-4957-a901-dcb316252d52">
