### PR TITLE
modules: lvgl: fix multiple LVGL input nodes

### DIFF
--- a/drivers/kscan/kscan_input.c
+++ b/drivers/kscan/kscan_input.c
@@ -101,9 +101,10 @@ static const struct kscan_driver_api kscan_input_driver_api = {
 };
 
 #define KSCAN_INPUT_INIT(index) \
-	INPUT_CALLBACK_DEFINE(DEVICE_DT_GET(DT_INST_PARENT(index)),            \
-			      kscan_input_cb,                                  \
-			      (void *)DEVICE_DT_INST_GET(index));              \
+	INPUT_CALLBACK_DEFINE_NAMED(DEVICE_DT_GET(DT_INST_PARENT(index)),      \
+				    kscan_input_cb,                            \
+				    (void *)DEVICE_DT_INST_GET(index),         \
+				    kscan_input_cb_##index);                   \
 	static const struct kscan_input_config kscan_input_config_##index = {  \
 		.input_dev = DEVICE_DT_GET(DT_INST_PARENT(index)),             \
 	};                                                                     \

--- a/include/zephyr/input/input.h
+++ b/include/zephyr/input/input.h
@@ -137,7 +137,8 @@ struct input_callback {
  * same callback function.
  */
 #define INPUT_CALLBACK_DEFINE_NAMED(_dev, _callback, _user_data, name)         \
-	static const STRUCT_SECTION_ITERABLE(input_callback, name) = {         \
+	static const STRUCT_SECTION_ITERABLE(input_callback,                   \
+					     _input_callback__##name) = {      \
 		.dev = _dev,                                                   \
 		.callback = _callback,                                         \
 		.user_data = _user_data,                                       \
@@ -155,8 +156,7 @@ struct input_callback {
  * @param _user_data Pointer to user specified data.
  */
 #define INPUT_CALLBACK_DEFINE(_dev, _callback, _user_data)                     \
-	INPUT_CALLBACK_DEFINE_NAMED(_dev, _callback, _user_data,               \
-				    _input_callback__##_callback)
+	INPUT_CALLBACK_DEFINE_NAMED(_dev, _callback, _user_data, _callback)
 
 #ifdef __cplusplus
 }

--- a/modules/lvgl/include/lvgl_common_input.h
+++ b/modules/lvgl/include/lvgl_common_input.h
@@ -36,8 +36,8 @@ int lvgl_init_input_devices(void);
 #define LVGL_KEY_VALID(key)     IN_RANGE(key, 0, UINT8_MAX)
 
 #define LVGL_INPUT_DEFINE(inst, type, msgq_size, process_evt_cb)                                   \
-	INPUT_CALLBACK_DEFINE(LVGL_INPUT_DEVICE(inst), process_evt_cb,                             \
-			      (void *)DEVICE_DT_INST_GET(inst));                                   \
+	INPUT_CALLBACK_DEFINE_NAMED(LVGL_INPUT_DEVICE(inst), process_evt_cb,                       \
+				    (void *)DEVICE_DT_INST_GET(inst), process_evt_cb_##inst);      \
 	K_MSGQ_DEFINE(lvgl_input_msgq_##type##_##inst, sizeof(lv_indev_data_t), msgq_size, 4)
 
 #ifdef __cplusplus


### PR DESCRIPTION
The input callback does not use an instance specific name, so we can only every have one instance of this type. This issue was evident by a build error, e.g., when using "zephyr,lvgl-keypad-input" nodes twice:

```
  /path/to/include/zephyr/input/input.h:159:37: error: redefinition of '_input_callback__lvgl_keypad_process_event'
    159 |                                     _input_callback__##_callback)
        |                                     ^~~~~~~~~~~~~~~~~
```

Called from

```C
#define LVGL_INPUT_DEFINE(inst, type, msgq_size, process_evt_cb)                                   \
        INPUT_CALLBACK_DEFINE(LVGL_INPUT_DEVICE(inst), process_evt_cb,                             \
                              (void *)DEVICE_DT_INST_GET(inst));                                   \
        K_MSGQ_DEFINE(lvgl_input_msgq_##type##_##inst, sizeof(lv_indev_data_t), msgq_size, 4)
```