### PR TITLE
boards: imx8mm/n/p imx93: add U-Boot requirement in document

### DIFF
--- a/boards/nxp/imx8mm_evk/doc/index.rst
+++ b/boards/nxp/imx8mm_evk/doc/index.rst
@@ -114,21 +114,32 @@ CPU's UART4. This is used for the M4 and A53 core targets.
 Programming and Debugging (A53)
 *******************************
 
+U-Boot "cpu" command is used to load and kick Zephyr to Cortex-A secondary Core, Currently
+it is supported in : `Real-Time Edge U-Boot`_ (use the branch "uboot_vxxxx.xx-y.y.y,
+xxxx.xx is uboot version and y.y.y is Real-Time Edge Software version, for example
+"uboot_v2023.04-2.9.0" branch is U-Boot v2023.04 used in Real-Time Edge Software release
+v2.9.0), and pre-build images and user guide can be found at `Real-Time Edge Software`_.
+
+.. _Real-Time Edge U-Boot:
+   https://github.com/nxp-real-time-edge-sw/real-time-edge-uboot
+.. _Real-Time Edge Software:
+   https://www.nxp.com/rtedge
+
 Copy the compiled ``zephyr.bin`` to the first FAT partition of the SD card and
 plug the SD card into the board. Power it up and stop the u-boot execution at
 prompt.
 
-Use U-Boot to load and kick zephyr.bin:
+Use U-Boot to load and kick zephyr.bin to Cortex-A53 Core0:
 
 .. code-block:: console
 
-    fatload mmc 1:1 0x93c00000 zephyr.bin; dcache flush; icache flush; dcache off; icache off; go 0x93c00000
+    fatload mmc 1:1 0x93c00000 zephyr.bin; dcache flush; icache flush; go 0x93c00000
 
-Or kick SMP zephyr.bin:
+Or kick zephyr.bin to the other Cortex-A53 Core, for example Core2:
 
 .. code-block:: console
 
-    fatload mmc 1:1 0x93c00000 zephyr.bin; dcache flush; icache flush; dcache off; icache off; cpu 2 release 0x93c00000
+    fatload mmc 1:1 0x93c00000 zephyr.bin; dcache flush; icache flush; cpu 2 release 0x93c00000
 
 
 Use this configuration to run basic Zephyr applications and kernel tests,

--- a/boards/nxp/imx8mn_evk/doc/index.rst
+++ b/boards/nxp/imx8mn_evk/doc/index.rst
@@ -84,21 +84,27 @@ CPU's UART4.
 Programming and Debugging
 *************************
 
+U-Boot "cpu" command is used to load and kick Zephyr to Cortex-A secondary Core, Currently
+it has been supported in latest U-Boot version by `patch serials`_.
+
+.. _patch serials:
+   https://patchwork.ozlabs.org/project/uboot/list/?series=417536&archive=both&state=*
+
 Copy the compiled ``zephyr.bin`` to the first FAT partition of the SD card and
 plug the SD card into the board. Power it up and stop the u-boot execution at
 prompt.
 
-Use U-Boot to load and kick zephyr.bin:
+Use U-Boot to load and kick zephyr.bin to Cortex-A53 Core0:
 
 .. code-block:: console
 
-    fatload mmc 1:1 0x93c00000 zephyr.bin; dcache flush; icache flush; dcache off; icache off; go 0x93c00000
+    fatload mmc 1:1 0x93c00000 zephyr.bin; dcache flush; icache flush; go 0x93c00000
 
-Or kick SMP zephyr.bin:
+Or kick zephyr.bin to the other Cortex-A53 Core, for example Core2:
 
 .. code-block:: console
 
-    fatload mmc 1:1 0x93c00000 zephyr.bin; dcache flush; icache flush; dcache off; icache off; cpu 2 release 0x93c00000
+    fatload mmc 1:1 0x93c00000 zephyr.bin; dcache flush; icache flush; cpu 2 release 0x93c00000
 
 
 Use this configuration to run basic Zephyr applications and kernel tests,

--- a/boards/nxp/imx8mp_evk/doc/index.rst
+++ b/boards/nxp/imx8mp_evk/doc/index.rst
@@ -102,21 +102,32 @@ CPU's UART4.
 Programming and Debugging (A53)
 *******************************
 
+U-Boot "cpu" command is used to load and kick Zephyr to Cortex-A secondary Core, Currently
+it is supported in : `Real-Time Edge U-Boot`_ (use the branch "uboot_vxxxx.xx-y.y.y,
+xxxx.xx is uboot version and y.y.y is Real-Time Edge Software version, for example
+"uboot_v2023.04-2.9.0" branch is U-Boot v2023.04 used in Real-Time Edge Software release
+v2.9.0), and pre-build images and user guide can be found at `Real-Time Edge Software`_.
+
+.. _Real-Time Edge U-Boot:
+   https://github.com/nxp-real-time-edge-sw/real-time-edge-uboot
+.. _Real-Time Edge Software:
+   https://www.nxp.com/rtedge
+
 Copy the compiled ``zephyr.bin`` to the first FAT partition of the SD card and
 plug the SD card into the board. Power it up and stop the u-boot execution at
 prompt.
 
-Use U-Boot to load and kick non-smp zephyr.bin:
+Use U-Boot to load and kick zephyr.bin to Cortex-A53 Core0:
 
 .. code-block:: console
 
-    fatload mmc 1:1 0xc0000000 zephyr.bin; dcache flush; icache flush; dcache off; icache off; go 0xc0000000
+    fatload mmc 1:1 0xc0000000 zephyr.bin; dcache flush; icache flush; go 0xc0000000
 
-Or kick SMP zephyr.bin:
+Or kick zephyr.bin to the other Cortex-A53 Core, for example Core2:
 
 .. code-block:: console
 
-    fatload mmc 1:1 0xc0000000 zephyr.bin; dcache flush; icache flush; dcache off; icache off; cpu 2 release 0xc0000000
+    fatload mmc 1:1 0xc0000000 zephyr.bin; dcache flush; icache flush; cpu 2 release 0xc0000000
 
 Use this configuration to run basic Zephyr applications and kernel tests,
 for example, with the :zephyr:code-sample:`synchronization` sample:

--- a/boards/nxp/imx93_evk/doc/index.rst
+++ b/boards/nxp/imx93_evk/doc/index.rst
@@ -143,6 +143,17 @@ the log.
 Programming and Debugging (A55)
 *******************************
 
+U-Boot "cpu" command is used to load and kick Zephyr to Cortex-A secondary Core, Currently
+it is supported in : `Real-Time Edge U-Boot`_ (use the branch "uboot_vxxxx.xx-y.y.y,
+xxxx.xx is uboot version and y.y.y is Real-Time Edge Software version, for example
+"uboot_v2023.04-2.9.0" branch is U-Boot v2023.04 used in Real-Time Edge Software release
+v2.9.0), and pre-build images and user guide can be found at `Real-Time Edge Software`_.
+
+.. _Real-Time Edge U-Boot:
+   https://github.com/nxp-real-time-edge-sw/real-time-edge-uboot
+.. _Real-Time Edge Software:
+   https://www.nxp.com/rtedge
+
 Copy the compiled ``zephyr.bin`` to the first FAT partition of the SD card and
 plug the SD card into the board. Power it up and stop the u-boot execution at
 prompt.
@@ -151,14 +162,14 @@ Use U-Boot to load and kick zephyr.bin to Cortex-A55 Core1:
 
 .. code-block:: console
 
-    fatload mmc 1:1 0xd0000000 zephyr.bin; dcache flush; icache flush; dcache off; icache off; cpu 1 release 0xd0000000
+    fatload mmc 1:1 0xd0000000 zephyr.bin; dcache flush; icache flush; cpu 1 release 0xd0000000
 
 
 Or use the following command to kick zephyr.bin to Cortex-A55 Core0:
 
 .. code-block:: console
 
-    fatload mmc 1:1 0xd0000000 zephyr.bin; dcache flush; icache flush; dcache off; icache off; go 0xd0000000
+    fatload mmc 1:1 0xd0000000 zephyr.bin; dcache flush; icache flush; go 0xd0000000
 
 
 Use this configuration to run basic Zephyr applications and kernel tests,


### PR DESCRIPTION
Currently NXP MPU depends on "cpu" command in uboot to kick Zephyr to Cortex-A Core, added U-Boot version which support "cpu" command in the board documents.

Refined boot commands.

This PR is to address [#78939](https://github.com/zephyrproject-rtos/zephyr/issues/78939)